### PR TITLE
Fix trailing inline composers and dev-ephemeral API loading

### DIFF
--- a/frontend/tests/e2e/inline-review.spec.ts
+++ b/frontend/tests/e2e/inline-review.spec.ts
@@ -252,6 +252,87 @@ const splitComposerDiffResponse = {
   ],
 };
 
+const trailingAddedFileDiffResponse = {
+  stale: false,
+  whitespace_only_count: 0,
+  files: [
+    {
+      path: ".github/ISSUE_TEMPLATE/config.yml",
+      old_path: ".github/ISSUE_TEMPLATE/config.yml",
+      status: "added",
+      additions: 4,
+      deletions: 0,
+      is_binary: false,
+      hunks: [
+        {
+          old_start: 0,
+          old_count: 0,
+          new_start: 1,
+          new_count: 4,
+          section: "",
+          lines: [
+            {
+              type: "add",
+              old_num: null,
+              new_num: 1,
+              content: "# Route every new issue through one of the templates above.",
+            },
+            {
+              type: "add",
+              old_num: null,
+              new_num: 2,
+              content: "# Discussions is enabled for this repo, add a contact_links entry pointing",
+            },
+            {
+              type: "add",
+              old_num: null,
+              new_num: 3,
+              content: '# usage/"how do I" questions there instead of the issue tracker.',
+            },
+            {
+              type: "add",
+              old_num: null,
+              new_num: 4,
+              content: "blank_issues_enabled: false",
+            },
+          ],
+        },
+      ],
+    },
+    {
+      path: ".github/ISSUE_TEMPLATE/feature_request.yml",
+      old_path: ".github/ISSUE_TEMPLATE/feature_request.yml",
+      status: "added",
+      additions: 2,
+      deletions: 0,
+      is_binary: false,
+      hunks: [
+        {
+          old_start: 0,
+          old_count: 0,
+          new_start: 1,
+          new_count: 2,
+          section: "",
+          lines: [
+            {
+              type: "add",
+              old_num: null,
+              new_num: 1,
+              content: "name: Feature request",
+            },
+            {
+              type: "add",
+              old_num: null,
+              new_num: 2,
+              content: "description: Suggest a new feature or improvement",
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
 const multiHunkDiffResponse = {
   stale: false,
   whitespace_only_count: 0,
@@ -650,19 +731,35 @@ test("keeps split-mode inline composers on trailing right-side hunk lines", asyn
     const button = page.getByRole("button", { name: `Comment on new line ${line}` });
     await expect(button).toBeVisible();
     await expect(
-      button.evaluate((element) => {
-        const code = element.closest("code");
-        const pre = code?.parentElement;
-        if (!code || !pre) return null;
-        if (code.hasAttribute("data-additions")) return "additions";
-        if (code.hasAttribute("data-deletions")) return "deletions";
-        const index = Array.from(pre.children)
-          .filter((child) => child.tagName.toLowerCase() === "code")
-          .indexOf(code);
-        if (index === 0) return "deletions";
-        if (index === 1) return "additions";
-        return null;
-      }),
+      page
+        .locator(".pierre-diff")
+        .first()
+        .evaluate((host, lineNumber) => {
+          const root = host.shadowRoot;
+          const button = Array.from(
+            root?.querySelectorAll<HTMLButtonElement>("[data-middleman-line-comment-button]") ?? [],
+          ).find((candidate) => candidate.getAttribute("aria-label") === `Comment on new line ${lineNumber}`);
+          return button ? pierreCodeSide(root, button) : null;
+
+          function pierreCodeSide(
+            root: ShadowRoot | null | undefined,
+            element: Element,
+          ): "deletions" | "additions" | null {
+            const code = Array.from(root?.querySelectorAll<HTMLElement>("code") ?? []).find((candidate) =>
+              candidate.contains(element),
+            );
+            const pre = code?.parentElement;
+            if (!code || !pre) return null;
+            if (code.hasAttribute("data-additions")) return "additions";
+            if (code.hasAttribute("data-deletions")) return "deletions";
+            const index = Array.from(pre.children)
+              .filter((child) => child.tagName.toLowerCase() === "code")
+              .indexOf(code);
+            if (index === 0) return "deletions";
+            if (index === 1) return "additions";
+            return null;
+          }
+        }, line),
     ).resolves.toBe("additions");
 
     await button.click();
@@ -672,18 +769,28 @@ test("keeps split-mode inline composers on trailing right-side hunk lines", asyn
         .locator(".pierre-diff")
         .first()
         .evaluate((host, lineNumber) => {
-          const slot = host.shadowRoot?.querySelector(`slot[name="annotation-additions-${lineNumber}"]`);
-          const code = slot?.closest("code");
-          const pre = code?.parentElement;
-          if (!code || !pre) return null;
-          if (code.hasAttribute("data-additions")) return "additions";
-          if (code.hasAttribute("data-deletions")) return "deletions";
-          const index = Array.from(pre.children)
-            .filter((child) => child.tagName.toLowerCase() === "code")
-            .indexOf(code);
-          if (index === 0) return "deletions";
-          if (index === 1) return "additions";
-          return null;
+          const root = host.shadowRoot;
+          const slot = root?.querySelector(`slot[name="annotation-additions-${lineNumber}"]`);
+          return slot ? pierreCodeSide(root, slot) : null;
+
+          function pierreCodeSide(
+            root: ShadowRoot | null | undefined,
+            element: Element,
+          ): "deletions" | "additions" | null {
+            const code = Array.from(root?.querySelectorAll<HTMLElement>("code") ?? []).find((candidate) =>
+              candidate.contains(element),
+            );
+            const pre = code?.parentElement;
+            if (!code || !pre) return null;
+            if (code.hasAttribute("data-additions")) return "additions";
+            if (code.hasAttribute("data-deletions")) return "deletions";
+            const index = Array.from(pre.children)
+              .filter((child) => child.tagName.toLowerCase() === "code")
+              .indexOf(code);
+            if (index === 0) return "deletions";
+            if (index === 1) return "additions";
+            return null;
+          }
         }, line),
     ).resolves.toBe("additions");
     await page.getByRole("button", { name: "Cancel" }).click();
@@ -692,6 +799,67 @@ test("keeps split-mode inline composers on trailing right-side hunk lines", asyn
 
   await assertRightSideComposer(2);
   await assertRightSideComposer(3);
+});
+
+test("keeps final added-file line visible when opening an inline composer", async ({ page }) => {
+  await mockInlineReviewAPI(page, baseCapabilities, "github", "github.com", trailingAddedFileDiffResponse, undefined, {
+    detailEvents: [],
+  });
+
+  await page.goto("/pulls/github/acme/widgets/42/files");
+  await expect(page.getByText("blank_issues_enabled: false")).toBeVisible();
+
+  async function assertComposerLayout(lineNumber: number, lineText: string, followingText?: string): Promise<void> {
+    await page.getByRole("button", { name: `Comment on new line ${lineNumber}` }).click();
+    await expect(page.getByPlaceholder("Leave a comment")).toBeVisible();
+    await expect(page.getByText(lineText)).toBeVisible();
+
+    const layout = await page
+      .locator(".pierre-diff")
+      .first()
+      .evaluate(
+        (host, { lineNumber, lineText, followingText }) => {
+          const root = host.shadowRoot;
+          const line = Array.from(
+            root?.querySelectorAll<HTMLElement>(`[data-diff-new-line="${lineNumber}"]`) ?? [],
+          ).find((node) => node.textContent?.includes(lineText));
+          const following = followingText
+            ? Array.from(root?.querySelectorAll<HTMLElement>("[data-diff-new-line]") ?? []).find((node) =>
+                node.textContent?.includes(followingText),
+              )
+            : host.closest(".diff-file")?.nextElementSibling?.querySelector(".file-header");
+          const slot = root?.querySelector<HTMLSlotElement>(`slot[name="annotation-additions-${lineNumber}"]`);
+          const composer = host.querySelector<HTMLElement>(".inline-composer");
+          if (!line || !slot || !composer || !(following instanceof HTMLElement)) return null;
+          const lineRect = line.getBoundingClientRect();
+          const composerRect = composer.getBoundingClientRect();
+          const followingRect = following.getBoundingClientRect();
+          return {
+            assignedCount: slot.assignedElements({ flatten: true }).length,
+            composerBottom: Math.round(composerRect.bottom),
+            composerTop: Math.round(composerRect.top),
+            followingTop: Math.round(followingRect.top),
+            lineBottom: Math.round(lineRect.bottom),
+            slotInsideLine: slot.closest(`[data-diff-new-line="${lineNumber}"]`) !== null,
+          };
+        },
+        { lineNumber, lineText, followingText },
+      );
+    expect(layout).not.toBeNull();
+    expect(layout!.assignedCount).toBeGreaterThan(0);
+    expect(layout!.slotInsideLine).toBe(false);
+    expect(layout!.composerTop).toBeGreaterThanOrEqual(layout!.lineBottom);
+    expect(layout!.followingTop).toBeGreaterThanOrEqual(layout!.composerBottom);
+    await page.getByRole("button", { name: "Cancel" }).click();
+    await expect(page.getByPlaceholder("Leave a comment")).toHaveCount(0);
+  }
+
+  await assertComposerLayout(
+    3,
+    '# usage/"how do I" questions there instead of the issue tracker.',
+    "blank_issues_enabled: false",
+  );
+  await assertComposerLayout(4, "blank_issues_enabled: false");
 });
 
 test("shows a visible composer focus indicator without focus flicker", async ({ page }) => {

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -170,6 +170,47 @@ function makeTwoAdditionFile(): DiffFileType {
   });
 }
 
+function makeAddedConfigFile(): DiffFileType {
+  return makeFile({
+    path: ".github/ISSUE_TEMPLATE/config.yml",
+    old_path: ".github/ISSUE_TEMPLATE/config.yml",
+    status: "added",
+    additions: 4,
+    deletions: 0,
+    patch: `diff --git a/.github/ISSUE_TEMPLATE/config.yml b/.github/ISSUE_TEMPLATE/config.yml
+--- /dev/null
++++ b/.github/ISSUE_TEMPLATE/config.yml
+@@ -0,0 +1,4 @@
++# Route every new issue through one of the templates above.
++# Discussions is enabled for this repo, add a contact_links entry pointing
++# usage/"how do I" questions there instead of the issue tracker.
++blank_issues_enabled: false
+`,
+    hunks: [
+      {
+        old_start: 0,
+        old_count: 0,
+        new_start: 1,
+        new_count: 4,
+        lines: [
+          { type: "add", content: "# Route every new issue through one of the templates above.", new_num: 1 },
+          {
+            type: "add",
+            content: "# Discussions is enabled for this repo, add a contact_links entry pointing",
+            new_num: 2,
+          },
+          {
+            type: "add",
+            content: '# usage/"how do I" questions there instead of the issue tracker.',
+            new_num: 3,
+          },
+          { type: "add", content: "blank_issues_enabled: false", new_num: 4 },
+        ],
+      },
+    ],
+  });
+}
+
 function makeReviewThread(overrides: Partial<ReviewThread> = {}): ReviewThread {
   return {
     id: "thread-1",
@@ -551,6 +592,26 @@ describe("DiffFile", () => {
 
     expect(screen.queryByPlaceholderText("Leave a comment")).toBeNull();
     expect(selectedPierreLines()).toHaveLength(0);
+  });
+
+  it("keeps the final line visible when opening an inline composer", async () => {
+    renderDiffFile(makeAddedConfigFile(), {
+      reviewEnabled: true,
+      diffHeadSHA: "diff-head",
+    });
+
+    await clickLineCommentButton(4, "right");
+    await waitFor(() => expect(screen.getByPlaceholderText("Leave a comment")).toBeTruthy());
+
+    const root = document.querySelector(".pierre-diff")?.shadowRoot;
+    const lineTargets = Array.from(root?.querySelectorAll<HTMLElement>('[data-diff-new-line="4"]') ?? []);
+    expect(lineTargets.some((line) => line.textContent?.includes("blank_issues_enabled: false"))).toBe(true);
+
+    await waitFor(() => {
+      const slot = root?.querySelector<HTMLSlotElement>('slot[name="annotation-additions-4"]');
+      expect(slot).toBeTruthy();
+      expect(slot?.closest('[data-diff-new-line="4"]')).toBeNull();
+    });
   });
 
   it("keeps right-side inline composers in the additions column in split mode", async () => {

--- a/packages/ui/src/components/diff/PierreFileDiff.svelte
+++ b/packages/ui/src/components/diff/PierreFileDiff.svelte
@@ -51,9 +51,14 @@
     gutter: HTMLElement;
     side: PierreSide | undefined;
   };
+  type TransientInsertedAnnotationRow = {
+    content: HTMLElement;
+    gutter: HTMLElement;
+  };
   type TransientAnnotationRow = {
     content?: HTMLElement;
     gutter?: HTMLElement;
+    insertedRows?: TransientInsertedAnnotationRow[];
     key: string;
     wrapper: HTMLElement;
   };
@@ -1165,9 +1170,19 @@
   }
 
   function clearTransientLineAnnotation(): void {
-    transientAnnotationRow?.wrapper.remove();
-    transientAnnotationRow?.content?.remove();
-    transientAnnotationRow?.gutter?.remove();
+    const row = transientAnnotationRow;
+    row?.wrapper.remove();
+    const insertedRows = row?.insertedRows ?? (
+      row?.content && row.gutter ? [{ content: row.content, gutter: row.gutter }] : []
+    );
+    const adjustedColumns = new Map<HTMLElement, number>();
+    for (const insertedRow of insertedRows) {
+      queueColumnSpanAdjustment(adjustedColumns, insertedRow.content.parentElement, -1);
+      queueColumnSpanAdjustment(adjustedColumns, insertedRow.gutter.parentElement, -1);
+      insertedRow.content.remove();
+      insertedRow.gutter.remove();
+    }
+    applyColumnSpanAdjustments(adjustedColumns);
     transientAnnotationRow = undefined;
   }
 
@@ -1221,7 +1236,7 @@
 
   function insertTransientAnnotationRow(
     annotation: DiffLineAnnotation<unknown>,
-  ): { content: HTMLElement; gutter: HTMLElement } | undefined {
+  ): { content: HTMLElement; gutter: HTMLElement; insertedRows: TransientInsertedAnnotationRow[] } | undefined {
     const root = host?.shadowRoot;
     const pre = renderedDiffPre(root);
     if (!pre || !pierreDiff) return undefined;
@@ -1237,23 +1252,107 @@
     const target = renderedLinePair(pre, lineIndex, split, annotation.side as PierreSide);
     if (!target) return undefined;
 
+    const insertedRows: TransientInsertedAnnotationRow[] = [];
+    const adjustedColumns = new Map<HTMLElement, number>();
+    const targets = transientAnnotationInsertionTargets(pre, target, split);
+    const annotationLine = `0,${lineIndex}`;
+    const slotName = annotationSlotName(annotation);
+    let primaryRow: TransientInsertedAnnotationRow | undefined;
+    for (const insertionTarget of targets) {
+      const insertedRow = insertAnnotationRowAfter(
+        insertionTarget,
+        annotationLine,
+        insertionTarget.content === target.content ? slotName : undefined,
+      );
+      if (!insertedRow) continue;
+      insertedRows.push(insertedRow);
+      if (insertionTarget.content === target.content) {
+        primaryRow = insertedRow;
+      }
+      queueColumnSpanAdjustment(adjustedColumns, insertedRow.content.parentElement, 1);
+      queueColumnSpanAdjustment(adjustedColumns, insertedRow.gutter.parentElement, 1);
+    }
+    applyColumnSpanAdjustments(adjustedColumns);
+    primaryRow ??= insertedRows[0];
+    if (!primaryRow) return undefined;
+    return { ...primaryRow, insertedRows };
+  }
+
+  function transientAnnotationInsertionTargets(
+    pre: HTMLPreElement,
+    target: RenderedLinePair,
+    split: boolean,
+  ): RenderedLinePair[] {
+    if (!split) return [target];
+    const targetContentColumn = target.content.parentElement;
+    if (!targetContentColumn) return [target];
+    const rowIndex = Array.prototype.indexOf.call(targetContentColumn.children, target.content);
+    if (rowIndex < 0) return [target];
+
+    const targets: RenderedLinePair[] = [];
+    for (const code of renderedCodeColumns(pre)) {
+      const [gutter, content] = Array.from(code.children);
+      if (!(gutter instanceof HTMLElement) || !(content instanceof HTMLElement)) continue;
+      const contentElement = content.children[rowIndex];
+      const gutterElement = gutter.children[rowIndex];
+      if (!(contentElement instanceof HTMLElement) || !(gutterElement instanceof HTMLElement)) continue;
+      targets.push({
+        content: contentElement,
+        gutter: gutterElement,
+        side: renderedPierreCodeSide(code),
+      });
+    }
+    return targets.length > 0 ? targets : [target];
+  }
+
+  function insertAnnotationRowAfter(
+    target: RenderedLinePair,
+    annotationLine: string,
+    slotName: string | undefined,
+  ): TransientInsertedAnnotationRow | undefined {
+    if (!target.content.parentElement || !target.gutter.parentElement) return undefined;
     const gutter = document.createElement("div");
     gutter.setAttribute("data-gutter-buffer", "annotation");
     gutter.setAttribute("data-buffer-size", "1");
     gutter.style.gridRow = "span 1";
 
     const content = document.createElement("div");
-    content.setAttribute("data-line-annotation", `0,${lineIndex}`);
+    content.setAttribute("data-line-annotation", annotationLine);
     const annotationContent = document.createElement("div");
     annotationContent.setAttribute("data-annotation-content", "");
-    const slot = document.createElement("slot");
-    slot.name = annotationSlotName(annotation);
-    annotationContent.appendChild(slot);
+    if (slotName) {
+      const slot = document.createElement("slot");
+      slot.name = slotName;
+      annotationContent.appendChild(slot);
+    }
     content.appendChild(annotationContent);
 
     target.gutter.after(gutter);
     target.content.after(content);
     return { content, gutter };
+  }
+
+  function queueColumnSpanAdjustment(
+    adjustments: Map<HTMLElement, number>,
+    column: Element | null,
+    delta: number,
+  ): void {
+    if (!(column instanceof HTMLElement)) return;
+    adjustments.set(column, (adjustments.get(column) ?? 0) + delta);
+  }
+
+  function applyColumnSpanAdjustments(adjustments: Map<HTMLElement, number>): void {
+    for (const [column, delta] of adjustments) {
+      const nextSpan = Math.max(1, currentGridRowSpan(column) + delta);
+      column.style.setProperty("grid-row", `span ${nextSpan}`);
+    }
+  }
+
+  function currentGridRowSpan(column: HTMLElement): number {
+    const span = /^span\s+(\d+)/.exec(column.style.getPropertyValue("grid-row").trim());
+    const rowSpan = span?.[1];
+    if (rowSpan) return Number.parseInt(rowSpan, 10);
+    return Math.max(1, column.children.length);
   }
 
   function annotationSlotName(annotation: DiffLineAnnotation<unknown>): string {

--- a/tools/devephemeral/main.go
+++ b/tools/devephemeral/main.go
@@ -280,6 +280,7 @@ func prepareEphemeralConfig(opts ephemeralOptions) (ephemeralRun, error) {
 	cfg.Host = "127.0.0.1"
 	cfg.Port = opts.backendPort
 	cfg.DataDir = dataDir
+	cfg.TrustReverseProxy = false
 
 	configPath := filepath.Join(opts.workDir, "config.toml")
 	if err := cfg.Save(configPath); err != nil {

--- a/tools/devephemeral/main_test.go
+++ b/tools/devephemeral/main_test.go
@@ -90,6 +90,39 @@ func TestPrepareEphemeralConfigForcesBackendToLoopback(t *testing.T) {
 	assert.Equal("::1", source.Host)
 }
 
+func TestPrepareEphemeralConfigDisablesReverseProxyTrustForDirectBackend(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.toml")
+
+	source := config.Config{
+		SyncInterval:        "5m",
+		GitHubTokenEnv:      "MIDDLEMAN_GITHUB_TOKEN",
+		DefaultPlatformHost: "github.com",
+		Host:                "127.0.0.1",
+		Port:                8091,
+		DataDir:             filepath.Join(dir, "source-data"),
+		AllowedHosts:        []string{"middleman.example.test"},
+		TrustReverseProxy:   true,
+		Activity:            config.Activity{ViewMode: "threaded", TimeRange: "7d"},
+	}
+	require.NoError(source.Save(sourcePath))
+
+	prepared, err := prepareEphemeralConfig(ephemeralOptions{
+		sourceConfigPath: sourcePath,
+		workDir:          filepath.Join(dir, "run"),
+		backendPort:      39141,
+		frontendPort:     39142,
+	})
+	require.NoError(err)
+
+	reloaded, err := config.Load(prepared.configPath)
+	require.NoError(err)
+	assert.False(reloaded.TrustReverseProxy)
+	assert.True(source.TrustReverseProxy)
+}
+
 func TestPrepareEphemeralConfigCopiesSourceDatabaseByDefault(t *testing.T) {
 	require := require.New(t)
 	dir := t.TempDir()

--- a/tools/devephemeral/main_test.go
+++ b/tools/devephemeral/main_test.go
@@ -8,6 +8,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -17,6 +19,8 @@ import (
 	Assert "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/middleman/internal/config"
+	"go.kenn.io/middleman/internal/server"
+	"go.kenn.io/middleman/internal/testutil/dbtest"
 	_ "modernc.org/sqlite"
 )
 
@@ -121,6 +125,15 @@ func TestPrepareEphemeralConfigDisablesReverseProxyTrustForDirectBackend(t *test
 	require.NoError(err)
 	assert.False(reloaded.TrustReverseProxy)
 	assert.True(source.TrustReverseProxy)
+
+	srv := server.NewWithConfig(
+		dbtest.Open(t), nil, nil, nil, reloaded, prepared.configPath, server.ServerOptions{},
+	)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/version", nil)
+	req.Host = "127.0.0.1:39141"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
 }
 
 func TestPrepareEphemeralConfigCopiesSourceDatabaseByDefault(t *testing.T) {


### PR DESCRIPTION
- Keeps inline review composers from covering trailing added lines in Pierre-rendered diffs, including second-to-last and final-line comment targets in added-file chunks.
- Makes `dev-ephemeral` generate a direct loopback backend config even when the normal middleman config is set up for reverse-proxy host validation.

The ephemeral change leaves the source config untouched; it only clears reverse-proxy trust in the generated temporary config so Vite's local proxy can load API data.
