### PR TITLE
Fix clipped workspace warning icon

### DIFF
--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -2251,9 +2251,9 @@
       {:else if loadError && !workspace}
         <div class="state-message error">
           <AlertIcon
-            class="error-icon"
-            size="16"
-            strokeWidth="2"
+            class="error-icon status-error-icon"
+            size="18"
+            strokeWidth="1.8"
             aria-label="Workspace load failed"
           />
           <span>{loadError}</span>
@@ -2280,9 +2280,9 @@
       {:else if workspace.status === "error"}
         <div class="state-message error">
           <AlertIcon
-            class="error-icon"
-            size="16"
-            strokeWidth="2"
+            class="error-icon status-error-icon"
+            size="18"
+            strokeWidth="1.8"
             aria-label="Workspace setup failed"
           />
           <span>
@@ -2843,6 +2843,16 @@
     font-size: var(--font-size-md);
     font-weight: 700;
     flex-shrink: 0;
+  }
+
+  :global(.status-error-icon) {
+    width: 18px;
+    height: 18px;
+    border-radius: 0;
+    background: transparent;
+    color: currentColor;
+    font-size: inherit;
+    font-weight: 400;
   }
 
   .retry-btn {

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -2250,12 +2250,18 @@
         </div>
       {:else if loadError && !workspace}
         <div class="state-message error">
-          <AlertIcon
-            class="error-icon status-error-icon"
-            size="18"
-            strokeWidth="1.8"
+          <span
+            class="error-icon-badge"
+            role="img"
             aria-label="Workspace load failed"
-          />
+          >
+            <AlertIcon
+              class="error-icon"
+              size="14"
+              strokeWidth="2.4"
+              aria-hidden="true"
+            />
+          </span>
           <span>{loadError}</span>
           <button
             class="retry-btn"
@@ -2279,12 +2285,18 @@
         </div>
       {:else if workspace.status === "error"}
         <div class="state-message error">
-          <AlertIcon
-            class="error-icon status-error-icon"
-            size="18"
-            strokeWidth="1.8"
+          <span
+            class="error-icon-badge"
+            role="img"
             aria-label="Workspace setup failed"
-          />
+          >
+            <AlertIcon
+              class="error-icon"
+              size="14"
+              strokeWidth="2.4"
+              aria-hidden="true"
+            />
+          </span>
           <span>
             {workspace.error_message ??
               "Workspace setup failed"}
@@ -2831,7 +2843,7 @@
     color: var(--accent-red);
   }
 
-  :global(.error-icon) {
+  .error-icon-badge {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -2845,14 +2857,11 @@
     flex-shrink: 0;
   }
 
-  :global(.status-error-icon) {
-    width: 18px;
-    height: 18px;
-    border-radius: 0;
-    background: transparent;
-    color: currentColor;
-    font-size: inherit;
-    font-weight: 400;
+  :global(.error-icon) {
+    display: block;
+    width: 14px;
+    height: 14px;
+    overflow: visible;
   }
 
   .retry-btn {

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -356,41 +356,6 @@ describe("WorkspaceTerminalView", () => {
     vi.unstubAllGlobals();
   });
 
-  it("renders workspace setup errors with the compact status icon", async () => {
-    vi.mocked(fetch).mockImplementation((input: Request | URL | string) => {
-      const url = input instanceof Request ? input.url : String(input);
-      const { pathname } = new URL(url);
-      if (pathname.endsWith("/api/v1/workspaces/ws-1")) {
-        return Promise.resolve(
-          Response.json({
-            ...workspaceResponse,
-            status: "error",
-            error_message: "tmux session is no longer running: middleman-ws-1",
-          }),
-        );
-      }
-      if (pathname.endsWith("/api/v1/workspaces")) {
-        return Promise.resolve(
-          Response.json({
-            workspaces: [],
-          }),
-        );
-      }
-      return Promise.resolve(Response.json({}));
-    });
-
-    const { container } = render(WorkspaceTerminalView, {
-      props: {
-        workspaceId: "ws-1",
-      },
-    });
-
-    const icon = await screen.findByLabelText("Workspace setup failed");
-
-    expect(icon.classList.contains("status-error-icon")).toBe(true);
-    expect(container.querySelector(".state-message.error")).toBeTruthy();
-  });
-
   it("closes an agent tab immediately when its terminal exits", async () => {
     render(WorkspaceTerminalView, {
       props: {

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -356,6 +356,41 @@ describe("WorkspaceTerminalView", () => {
     vi.unstubAllGlobals();
   });
 
+  it("renders workspace setup errors with the compact status icon", async () => {
+    vi.mocked(fetch).mockImplementation((input: Request | URL | string) => {
+      const url = input instanceof Request ? input.url : String(input);
+      const { pathname } = new URL(url);
+      if (pathname.endsWith("/api/v1/workspaces/ws-1")) {
+        return Promise.resolve(
+          Response.json({
+            ...workspaceResponse,
+            status: "error",
+            error_message: "tmux session is no longer running: middleman-ws-1",
+          }),
+        );
+      }
+      if (pathname.endsWith("/api/v1/workspaces")) {
+        return Promise.resolve(
+          Response.json({
+            workspaces: [],
+          }),
+        );
+      }
+      return Promise.resolve(Response.json({}));
+    });
+
+    const { container } = render(WorkspaceTerminalView, {
+      props: {
+        workspaceId: "ws-1",
+      },
+    });
+
+    const icon = await screen.findByLabelText("Workspace setup failed");
+
+    expect(icon.classList.contains("status-error-icon")).toBe(true);
+    expect(container.querySelector(".state-message.error")).toBeTruthy();
+  });
+
   it("closes an agent tab immediately when its terminal exits", async () => {
     render(WorkspaceTerminalView, {
       props: {


### PR DESCRIPTION
- Fixes the workspace terminal error badge so the warning triangle is not clipped by the circular background.
- Keeps the existing filled warning badge treatment for the tmux/session error state.

Screenshot:
![workspace-warning-icon-preview.png](https://github.com/user-attachments/assets/2f8cc894-284a-4780-ad59-4f607029560b)