### PR TITLE
Add workspace sidebar view options

### DIFF
--- a/cmd/e2e-server/main.go
+++ b/cmd/e2e-server/main.go
@@ -63,6 +63,11 @@ func main() {
 		"visible-imported-modes", false,
 		"show imported app modes in the seeded config",
 	)
+	providerCollision := flag.Bool(
+		"provider-collision",
+		false,
+		"seed same host/repo_path under multiple providers",
+	)
 	serverInfoFile := flag.String(
 		"server-info-file", "",
 		"path to write discovered server port info as JSON",
@@ -83,6 +88,7 @@ func main() {
 		*serverInfoFile,
 		*defaultPlatformHost,
 		*visibleImportedModes,
+		*providerCollision,
 	); err != nil {
 		slog.Error("fatal", "err", err)
 		os.Exit(1)
@@ -478,6 +484,72 @@ func seedGitLabReadOnlyCapabilityFixture(
 	return nil
 }
 
+func giteaProviderCollisionIssue(now time.Time) platform.Issue {
+	return platform.Issue{
+		Repo: platform.RepoRef{
+			Platform:           platform.KindGitea,
+			Host:               "github.com",
+			Owner:              "acme",
+			Name:               "widgets",
+			RepoPath:           "acme/widgets",
+			PlatformID:         9100,
+			PlatformExternalID: "gitea-acme-widgets",
+			WebURL:             "https://github.com/acme/widgets",
+			CloneURL:           "https://github.com/acme/widgets.git",
+			DefaultBranch:      "main",
+		},
+		PlatformID:         9101,
+		PlatformExternalID: "gitea-acme-widgets-901",
+		Number:             901,
+		URL:                "https://github.com/acme/widgets/issues/901",
+		Title:              "Gitea provider collision issue",
+		Author:             "gina",
+		State:              "open",
+		Body:               "Synthetic provider-collision issue for e2e filtering.",
+		CommentCount:       0,
+		CreatedAt:          now.Add(-2 * time.Hour),
+		UpdatedAt:          now,
+		LastActivityAt:     now,
+	}
+}
+
+func seedGiteaProviderCollisionFixture(
+	ctx context.Context,
+	database *db.DB,
+	issue platform.Issue,
+) error {
+	repoID, err := database.UpsertRepo(ctx, db.RepoIdentity{
+		Platform:       string(issue.Repo.Platform),
+		PlatformHost:   issue.Repo.Host,
+		PlatformRepoID: issue.Repo.PlatformExternalID,
+		Owner:          issue.Repo.Owner,
+		Name:           issue.Repo.Name,
+		RepoPath:       issue.Repo.RepoPath,
+	})
+	if err != nil {
+		return fmt.Errorf("upsert gitea collision repo: %w", err)
+	}
+	if _, err := database.UpsertIssue(ctx, &db.Issue{
+		RepoID:             repoID,
+		PlatformID:         issue.PlatformID,
+		PlatformExternalID: issue.PlatformExternalID,
+		Number:             issue.Number,
+		URL:                issue.URL,
+		Title:              issue.Title,
+		Author:             issue.Author,
+		State:              issue.State,
+		Body:               issue.Body,
+		CommentCount:       issue.CommentCount,
+		CreatedAt:          issue.CreatedAt,
+		UpdatedAt:          issue.UpdatedAt,
+		LastActivityAt:     issue.LastActivityAt,
+		DetailFetchedAt:    &issue.UpdatedAt,
+	}); err != nil {
+		return fmt.Errorf("upsert gitea collision issue: %w", err)
+	}
+	return nil
+}
+
 // ciFixtureOptions controls the per-fixture choices that the
 // pr-ci-state/* endpoints feed into setPR1CIState. Centralising the
 // options struct keeps the divergent fields visible and forces every
@@ -600,6 +672,7 @@ type appOptions struct {
 	roborevEndpoint      string
 	defaultPlatformHost  string
 	visibleImportedModes bool
+	providerCollision    bool
 }
 
 // appState bundles everything one logical e2e server instance owns:
@@ -823,6 +896,15 @@ func buildAppState(
 			},
 		}
 	}
+	if opts.providerCollision {
+		repos = append(repos, config.Repo{
+			Owner:        "acme",
+			Name:         "widgets",
+			Platform:     "gitea",
+			PlatformHost: "github.com",
+			RepoPath:     "acme/widgets",
+		})
+	}
 	cfg := &config.Config{
 		SyncInterval:        "5m",
 		GitHubTokenEnv:      "MIDDLEMAN_GITHUB_TOKEN",
@@ -1022,10 +1104,12 @@ func buildAppState(
 		time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC),
 		gitLabCloneURL,
 	)
+	giteaCollisionIssue := giteaProviderCollisionIssue(
+		time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC),
+	)
 	forgeUpdated := time.Date(2026, 4, 25, 10, 0, 0, 0, time.UTC)
 	giteaUpdated := time.Date(2026, 4, 26, 10, 0, 0, 0, time.UTC)
-	registry, err := ghclient.NewProviderRegistry(
-		fixtureClients,
+	staticProviders := []platform.Provider{
 		e2eStaticProvider{
 			kind:        platform.KindGitLab,
 			host:        "gitlab.example.com",
@@ -1036,86 +1120,121 @@ func buildAppState(
 				ReadComments: true,
 			},
 		},
-		e2eStaticProvider{
-			kind: platform.KindForgejo,
-			host: "codeberg.org",
+	}
+	if opts.providerCollision {
+		staticProviders = append(staticProviders, e2eStaticProvider{
+			kind:  platform.KindGitea,
+			host:  "github.com",
+			issue: giteaCollisionIssue,
 			caps: platform.Capabilities{
 				ReadRepositories: true,
+				ReadIssues:       true,
 			},
-			repos: []platform.Repository{
-				{
-					Ref: platform.RepoRef{
-						Platform: platform.KindForgejo,
-						Host:     "codeberg.org",
-						Owner:    "forge-lab",
-						Name:     "service",
-						RepoPath: "forge-lab/service",
-					},
-					Description:   "Forgejo service",
-					Private:       false,
-					UpdatedAt:     forgeUpdated,
-					DefaultBranch: "main",
-					WebURL:        "https://codeberg.org/forge-lab/service",
-					CloneURL:      "https://codeberg.org/forge-lab/service.git",
+			repos: []platform.Repository{{
+				Ref: platform.RepoRef{
+					Platform: platform.KindGitea,
+					Host:     "github.com",
+					Owner:    "acme",
+					Name:     "widgets",
+					RepoPath: "acme/widgets",
 				},
-				{
-					Ref: platform.RepoRef{
-						Platform: platform.KindForgejo,
-						Host:     "codeberg.org",
-						Owner:    "forge-lab",
-						Name:     "archived",
-						RepoPath: "forge-lab/archived",
-					},
-					Archived: true,
+				PlatformID:    9100,
+				Description:   "Gitea provider collision repo",
+				Private:       false,
+				UpdatedAt:     giteaCollisionIssue.UpdatedAt,
+				DefaultBranch: "main",
+				WebURL:        "https://github.com/acme/widgets",
+				CloneURL:      "https://github.com/acme/widgets.git",
+			}},
+		})
+		if err := seedGiteaProviderCollisionFixture(ctx, database, giteaCollisionIssue); err != nil {
+			return nil, fmt.Errorf("seed gitea provider collision fixture: %w", err)
+		}
+	}
+	registry, err := ghclient.NewProviderRegistry(
+		fixtureClients,
+		append(staticProviders,
+			e2eStaticProvider{
+				kind: platform.KindForgejo,
+				host: "codeberg.org",
+				caps: platform.Capabilities{
+					ReadRepositories: true,
 				},
-			},
-		},
-		e2eStaticProvider{
-			kind: platform.KindGitea,
-			host: "gitea.com",
-			caps: platform.Capabilities{
-				ReadRepositories: true,
-			},
-			repos: []platform.Repository{
-				{
-					Ref: platform.RepoRef{
-						Platform: platform.KindGitea,
-						Host:     "gitea.com",
-						Owner:    "gitea-team",
-						Name:     "service",
-						RepoPath: "gitea-team/service",
+				repos: []platform.Repository{
+					{
+						Ref: platform.RepoRef{
+							Platform: platform.KindForgejo,
+							Host:     "codeberg.org",
+							Owner:    "forge-lab",
+							Name:     "service",
+							RepoPath: "forge-lab/service",
+						},
+						Description:   "Forgejo service",
+						Private:       false,
+						UpdatedAt:     forgeUpdated,
+						DefaultBranch: "main",
+						WebURL:        "https://codeberg.org/forge-lab/service",
+						CloneURL:      "https://codeberg.org/forge-lab/service.git",
 					},
-					Description:   "Gitea service",
-					Private:       false,
-					UpdatedAt:     giteaUpdated,
-					DefaultBranch: "main",
-					WebURL:        "https://gitea.com/gitea-team/service",
-					CloneURL:      "https://gitea.com/gitea-team/service.git",
-				},
-				{
-					Ref: platform.RepoRef{
-						Platform: platform.KindGitea,
-						Host:     "gitea.com",
-						Owner:    "gitea-team",
-						Name:     "private-service",
-						RepoPath: "gitea-team/private-service",
+					{
+						Ref: platform.RepoRef{
+							Platform: platform.KindForgejo,
+							Host:     "codeberg.org",
+							Owner:    "forge-lab",
+							Name:     "archived",
+							RepoPath: "forge-lab/archived",
+						},
+						Archived: true,
 					},
-					Description: "Private Gitea service",
-					Private:     true,
-					UpdatedAt:   giteaUpdated.Add(-time.Hour),
-				},
-				{
-					Ref: platform.RepoRef{
-						Platform: platform.KindGitea,
-						Host:     "gitea.com",
-						Owner:    "gitea-team",
-						Name:     "archived",
-						RepoPath: "gitea-team/archived",
-					},
-					Archived: true,
 				},
 			},
-		},
+			e2eStaticProvider{
+				kind: platform.KindGitea,
+				host: "gitea.com",
+				caps: platform.Capabilities{
+					ReadRepositories: true,
+				},
+				repos: []platform.Repository{
+					{
+						Ref: platform.RepoRef{
+							Platform: platform.KindGitea,
+							Host:     "gitea.com",
+							Owner:    "gitea-team",
+							Name:     "service",
+							RepoPath: "gitea-team/service",
+						},
+						Description:   "Gitea service",
+						Private:       false,
+						UpdatedAt:     giteaUpdated,
+						DefaultBranch: "main",
+						WebURL:        "https://gitea.com/gitea-team/service",
+						CloneURL:      "https://gitea.com/gitea-team/service.git",
+					},
+					{
+						Ref: platform.RepoRef{
+							Platform: platform.KindGitea,
+							Host:     "gitea.com",
+							Owner:    "gitea-team",
+							Name:     "private-service",
+							RepoPath: "gitea-team/private-service",
+						},
+						Description: "Private Gitea service",
+						Private:     true,
+						UpdatedAt:   giteaUpdated.Add(-time.Hour),
+					},
+					{
+						Ref: platform.RepoRef{
+							Platform: platform.KindGitea,
+							Host:     "gitea.com",
+							Owner:    "gitea-team",
+							Name:     "archived",
+							RepoPath: "gitea-team/archived",
+						},
+						Archived: true,
+					},
+				},
+			},
+		)...,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("create e2e provider registry: %w", err)
@@ -1133,6 +1252,18 @@ func buildAppState(
 			DefaultBranch: gitLabIssue.Repo.DefaultBranch,
 		},
 	)
+	if opts.providerCollision {
+		trackedRepos = append(trackedRepos, ghclient.RepoRef{
+			Platform:      platform.KindGitea,
+			PlatformHost:  "github.com",
+			Owner:         "acme",
+			Name:          "widgets",
+			RepoPath:      "acme/widgets",
+			WebURL:        "https://github.com/acme/widgets",
+			CloneURL:      "https://github.com/acme/widgets.git",
+			DefaultBranch: "main",
+		})
+	}
 	syncer := ghclient.NewSyncerWithRegistry(
 		registry,
 		database, diffRepo.Manager, trackedRepos, time.Hour,
@@ -1586,6 +1717,7 @@ func run(
 	port int,
 	roborevEndpoint, serverInfoFile, defaultPlatformHost string,
 	visibleImportedModes bool,
+	providerCollision bool,
 ) error {
 	assets, err := web.Assets()
 	if err != nil {
@@ -1596,6 +1728,7 @@ func run(
 		roborevEndpoint:      roborevEndpoint,
 		defaultPlatformHost:  defaultPlatformHost,
 		visibleImportedModes: visibleImportedModes,
+		providerCollision:    providerCollision,
 	}
 
 	state, err := buildAppState(ctx, assets, baseOpts)
@@ -1654,6 +1787,7 @@ func run(
 			var req struct {
 				DefaultPlatformHost  string `json:"default_platform_host"`
 				VisibleImportedModes *bool  `json:"visible_imported_modes"`
+				ProviderCollision    *bool  `json:"provider_collision"`
 			}
 			// An empty body resets to the startup options; a
 			// non-empty body must be valid JSON so option typos
@@ -1678,6 +1812,9 @@ func run(
 			}
 			if req.VisibleImportedModes != nil {
 				opts.visibleImportedModes = *req.VisibleImportedModes
+			}
+			if req.ProviderCollision != nil {
+				opts.providerCollision = *req.ProviderCollision
 			}
 
 			// Build against the process ctx, not r.Context(): a

--- a/cmd/e2e-server/main_test.go
+++ b/cmd/e2e-server/main_test.go
@@ -255,7 +255,7 @@ func TestRunDefaultRoborevFailsClosedThroughProxy(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- run(ctx, 0, defaultRoborevEndpoint, serverInfoFile, "github.com", false)
+		done <- run(ctx, 0, defaultRoborevEndpoint, serverInfoFile, "github.com", false, false)
 	}()
 
 	baseURL := waitForServerInfoBaseURL(t, serverInfoFile, done)
@@ -332,7 +332,7 @@ func TestResetSwapsFixtureState(t *testing.T) {
 	serverInfoFile := filepath.Join(t.TempDir(), "server-info.json")
 	done := make(chan error, 1)
 	go func() {
-		done <- run(ctx, 0, defaultRoborevEndpoint, serverInfoFile, "github.com", false)
+		done <- run(ctx, 0, defaultRoborevEndpoint, serverInfoFile, "github.com", false, false)
 	}()
 	baseURL := waitForServerInfoBaseURL(t, serverInfoFile, done)
 

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -6171,10 +6171,12 @@ paths:
     get:
       operationId: list-activity
       parameters:
-        - explode: false
+        - description: Repository filter. Accepts owner/name, platform_host/repo_path, comma-separated values, or provider|platform_host/repo_path for provider-qualified matches.
+          explode: false
           in: query
           name: repo
           schema:
+            description: Repository filter. Accepts owner/name, platform_host/repo_path, comma-separated values, or provider|platform_host/repo_path for provider-qualified matches.
             type: string
         - explode: false
           in: query
@@ -10671,10 +10673,12 @@ paths:
     get:
       operationId: list-issues
       parameters:
-        - explode: false
+        - description: Repository filter. Accepts owner/name, platform_host/repo_path, comma-separated values, or provider|platform_host/repo_path for provider-qualified matches.
+          explode: false
           in: query
           name: repo
           schema:
+            description: Repository filter. Accepts owner/name, platform_host/repo_path, comma-separated values, or provider|platform_host/repo_path for provider-qualified matches.
             type: string
         - explode: false
           in: query
@@ -12317,10 +12321,12 @@ paths:
     get:
       operationId: list-pulls
       parameters:
-        - explode: false
+        - description: Repository filter. Accepts owner/name, platform_host/repo_path, comma-separated values, or provider|platform_host/repo_path for provider-qualified matches.
+          explode: false
           in: query
           name: repo
           schema:
+            description: Repository filter. Accepts owner/name, platform_host/repo_path, comma-separated values, or provider|platform_host/repo_path for provider-qualified matches.
             type: string
         - explode: false
           in: query

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -14646,12 +14646,12 @@ paths:
     post:
       operationId: trigger-sync
       parameters:
-        - description: Optional repository filters to sync first. Accepts repeated values or comma-separated values. Each value may be host-qualified as platform_host/owner/name or bare as owner/name; bare values match the first tracked repo with that repo path.
+        - description: Optional repository filters to sync first. Accepts repeated values or comma-separated values. Each value may be provider-qualified as provider|platform_host/owner/name, host-qualified as platform_host/owner/name, or bare as owner/name; bare values match the first tracked repo with that repo path.
           explode: false
           in: query
           name: priority_repo
           schema:
-            description: Optional repository filters to sync first. Accepts repeated values or comma-separated values. Each value may be host-qualified as platform_host/owner/name or bare as owner/name; bare values match the first tracked repo with that repo path.
+            description: Optional repository filters to sync first. Accepts repeated values or comma-separated values. Each value may be provider-qualified as provider|platform_host/owner/name, host-qualified as platform_host/owner/name, or bare as owner/name; bare values match the first tracked repo with that repo path.
             items:
               type: string
             type:

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -9,6 +9,7 @@
     KanbanBoardView,
     ReviewsView,
     FocusListView,
+    normalizeMobileActivityRepoSelection,
   } from "@middleman/ui";
   import type { StoreInstances } from "@middleman/ui";
   import type { ActivityItem, ModeVisibility } from "@middleman/ui/api/types";
@@ -532,13 +533,25 @@
     replaceUrl(`${desktopPathForMobileRoute()}${searchWithDesktopOptOut()}`);
   }
 
+  function getNormalizedGlobalRepo(repo: string | undefined = getGlobalRepo()): string | undefined {
+    const normalized = normalizeMobileActivityRepoSelection(
+      repo,
+      stores?.settings.getConfiguredRepos() ?? [],
+    );
+    return normalized || undefined;
+  }
+
   onDestroy(() => {
     stopFullAppShell();
     stores?.events.disconnect();
   });
 
   $effect(() => {
-    const repo = getGlobalRepo();
+    const repo = getNormalizedGlobalRepo();
+    if (repo !== getGlobalRepo()) {
+      setGlobalRepo(repo);
+      return;
+    }
     if (!appReady || !stores) {
       lastRepo = repo;
       return;
@@ -896,7 +909,7 @@
       })),
     }}
     hostState={{
-      getGlobalRepo,
+      getGlobalRepo: getNormalizedGlobalRepo,
       getGroupByRepo: () => stores?.grouping.getGroupByRepo() ?? true,
       getView,
       getActiveWorktreeKey,
@@ -1054,7 +1067,7 @@
           <FocusListView listType="issues" />
         {:else}
           <MobileActivityView
-            selectedRepo={getGlobalRepo()}
+            selectedRepo={getNormalizedGlobalRepo()}
             onRepoChange={setGlobalRepo}
             onSelectItem={handleActivitySelect}
           />

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -9,7 +9,7 @@
     KanbanBoardView,
     ReviewsView,
     FocusListView,
-    normalizeMobileActivityRepoSelection,
+    normalizeRepoFilterSelection,
   } from "@middleman/ui";
   import type { StoreInstances } from "@middleman/ui";
   import type { ActivityItem, ModeVisibility } from "@middleman/ui/api/types";
@@ -534,11 +534,15 @@
   }
 
   function getNormalizedGlobalRepo(repo: string | undefined = getGlobalRepo()): string | undefined {
-    const normalized = normalizeMobileActivityRepoSelection(
+    return normalizeRepoFilterSelection(
       repo,
-      stores?.settings.getConfiguredRepos() ?? [],
+      (stores?.settings.getConfiguredRepos?.() ?? []).map((configuredRepo) => ({
+        provider: configuredRepo.provider,
+        platformHost: configuredRepo.platform_host,
+        repoPath: configuredRepo.repo_path,
+        isGlob: configuredRepo.is_glob,
+      })),
     );
-    return normalized || undefined;
   }
 
   onDestroy(() => {

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -29,6 +29,7 @@ vi.mock("@middleman/ui", async () => {
     KanbanBoardView: Stub,
     ReviewsView: Stub,
     FocusListView: Stub,
+    normalizeRepoFilterSelection: (repo: string | undefined) => repo,
   };
 });
 

--- a/frontend/src/lib/components/RepoTypeahead.svelte
+++ b/frontend/src/lib/components/RepoTypeahead.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
   import { onMount, tick } from "svelte";
-  import { getStores } from "@middleman/ui";
+  import {
+    canonicalRepoFilterValue,
+    displayRepoFilterValue,
+    getStores,
+    normalizeRepoFilterSelection,
+  } from "@middleman/ui";
   import { client } from "../api/runtime.js";
   import type { ConfigRepo, Repo } from "@middleman/ui/api/types";
   import { canonicalProvider } from "@middleman/ui/api/provider-routes";
@@ -73,7 +78,7 @@
   let repoFetchVersion = 0;
   let latestRepoFetchKey = "";
 
-  type RepoOption = RepoTreeOption;
+  type RepoOption = RepoTreeOption & { repoPath: string };
 
   $effect(() => {
     const configuredRepoKey = configuredRepos
@@ -101,23 +106,28 @@
   );
 
   function optionFromRepo(repo: Repo): RepoOption {
+    const repoPath = `${repo.Owner}/${repo.Name}`;
     return {
-      value: `${repo.PlatformHost}/${repo.Owner}/${repo.Name}`,
+      value: `${repo.PlatformHost}/${repoPath}`,
       owner: repo.Owner,
       name: repo.Name,
       provider: canonicalProvider(repo.Platform),
       platformHost: repo.PlatformHost,
+      repoPath,
     };
   }
 
-  function optionFromConfigRepo(repo: ConfigRepo): RepoOption {
+  function optionFromConfigRepo(repo: ConfigRepo): RepoOption | null {
+    if (repo.is_glob) return null;
     const path = repo.repo_path || `${repo.owner}/${repo.name}`;
+    if (!repo.platform_host || !path) return null;
     return {
       value: `${repo.platform_host}/${path}`,
       owner: repo.owner,
       name: repo.name,
       provider: canonicalProvider(repo.provider),
       platformHost: repo.platform_host,
+      repoPath: path,
     };
   }
 
@@ -128,20 +138,31 @@
     const merged: RepoOption[] = [];
     const seen: string[] = [];
     const addOption = (option: RepoOption) => {
-      if (seen.includes(option.value)) return;
-      seen.push(option.value);
+      const identity = `${option.provider}|${option.platformHost}/${option.repoPath}`;
+      if (seen.includes(identity)) return;
+      seen.push(identity);
       merged.push(option);
     };
 
-    for (const repo of configured.filter((entry) => !entry.is_glob)) {
-      addOption(optionFromConfigRepo(repo));
+    for (const repo of configured) {
+      const option = optionFromConfigRepo(repo);
+      if (option) addOption(option);
     }
 
     for (const repo of fetched) {
       addOption(optionFromRepo(repo));
     }
 
-    return merged;
+    const identities = merged.map((option) => ({
+      provider: option.provider,
+      platformHost: option.platformHost,
+      repoPath: option.repoPath,
+      isGlob: false,
+    }));
+    return merged.map((option, index) => ({
+      ...option,
+      value: canonicalRepoFilterValue(identities[index]!, identities) ?? option.value,
+    }));
   }
 
   const options = $derived.by(() => {
@@ -155,7 +176,7 @@
   const selectedSet = $derived(new Set(selectedValues));
   const displayValue = $derived.by(() => {
     if (selectedValues.length === 0) return "All repos";
-    if (selectedValues.length === 1) return selectedValues[0];
+    if (selectedValues.length === 1) return displayRepoFilterValue(selectedValues[0]!);
     return `${selectedValues.length} repos`;
   });
 
@@ -168,7 +189,7 @@
   );
 
   function rowAriaLabel(row: VisibleRow): string {
-    return row.node.kind === "host" ? row.node.platformHost : row.node.id;
+    return row.node.kind === "host" ? row.node.platformHost : displayRepoFilterValue(row.node.id);
   }
 
   function toggleRowSelect(row: VisibleRow) {
@@ -181,6 +202,19 @@
 
   $effect(() => {
     if (selectedValues.length === 0 || reposLoading) return;
+    const normalized = normalizeRepoFilterSelection(
+      selected,
+      options.map((option) => ({
+        provider: option.provider,
+        platformHost: option.platformHost,
+        repoPath: option.repoPath,
+        isGlob: false,
+      })),
+    );
+    if (normalized !== selected) {
+      onchange(normalized);
+      return;
+    }
     const validValues = new Set(options.map((option) => option.value));
     const next = selectedValues.filter((value) => validValues.has(value));
     if (next.length === selectedValues.length) return;

--- a/frontend/src/lib/components/RepoTypeahead.test.ts
+++ b/frontend/src/lib/components/RepoTypeahead.test.ts
@@ -552,17 +552,14 @@ describe("RepoTypeahead", () => {
     render(RepoTypeahead, { props: { selected: undefined, onchange } });
 
     await fireEvent.click(screen.getByRole("button", { name: /all repos/i }));
+    await fireEvent.input(screen.getByPlaceholderText("Filter repos..."), {
+      target: { value: "gitea/widgets" },
+    });
     const giteaRow = screen.getByRole("option", {
       name: "gitea/github.com/acme/widgets",
     });
     expect(giteaRow.querySelector(".repo-tree-label")?.textContent).toBe("gitea/widgets");
-    expect(
-      screen
-        .getByRole("option", {
-          name: "github/github.com/acme/widgets",
-        })
-        .querySelector(".repo-tree-label")?.textContent,
-    ).toBe("github/widgets");
+    expect(screen.queryByRole("option", { name: "github/github.com/acme/widgets" })).toBeNull();
     await fireEvent.mouseDown(
       screen.getByRole("option", {
         name: "gitea/github.com/acme/widgets",

--- a/frontend/src/lib/components/RepoTypeahead.test.ts
+++ b/frontend/src/lib/components/RepoTypeahead.test.ts
@@ -8,11 +8,15 @@ import RepoTypeahead from "./RepoTypeahead.svelte";
 
 let settingsStore: ReturnType<typeof createSettingsStore>;
 
-vi.mock("@middleman/ui", () => ({
-  getStores: () => ({
-    settings: settingsStore,
-  }),
-}));
+vi.mock("@middleman/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@middleman/ui")>();
+  return {
+    ...actual,
+    getStores: () => ({
+      settings: settingsStore,
+    }),
+  };
+});
 
 vi.mock("../api/runtime.js", () => ({
   client: {
@@ -520,5 +524,102 @@ describe("RepoTypeahead", () => {
     await fireEvent.keyDown(input, { key: " " });
 
     expect(onchange).toHaveBeenLastCalledWith("github.com/import-lab/api,github.com/import-lab/web");
+  });
+
+  it("uses provider-qualified values when configured repos collide by host and path", async () => {
+    const onchange = vi.fn();
+    settingsStore.setConfiguredRepos([
+      {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "acme",
+        name: "widgets",
+        repo_path: "acme/widgets",
+        is_glob: false,
+        matched_repo_count: 1,
+      },
+      {
+        provider: "gitea",
+        platform_host: "github.com",
+        owner: "acme",
+        name: "widgets",
+        repo_path: "acme/widgets",
+        is_glob: false,
+        matched_repo_count: 1,
+      },
+    ]);
+
+    render(RepoTypeahead, { props: { selected: undefined, onchange } });
+
+    await fireEvent.click(screen.getByRole("button", { name: /all repos/i }));
+    await fireEvent.mouseDown(
+      screen.getByRole("option", {
+        name: "gitea/github.com/acme/widgets",
+      }),
+    );
+
+    expect(onchange).toHaveBeenLastCalledWith("gitea|github.com/acme/widgets");
+  });
+
+  it("keeps provider-qualified selected values valid in desktop validation", async () => {
+    const onchange = vi.fn();
+    settingsStore.setConfiguredRepos([
+      {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "acme",
+        name: "widgets",
+        repo_path: "acme/widgets",
+        is_glob: false,
+        matched_repo_count: 1,
+      },
+      {
+        provider: "gitea",
+        platform_host: "github.com",
+        owner: "acme",
+        name: "widgets",
+        repo_path: "acme/widgets",
+        is_glob: false,
+        matched_repo_count: 1,
+      },
+    ]);
+
+    render(RepoTypeahead, {
+      props: {
+        selected: "gitea|github.com/acme/widgets",
+        onchange,
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "gitea/github.com/acme/widgets" })).toBeTruthy();
+    });
+    expect(onchange).not.toHaveBeenCalled();
+  });
+
+  it("normalizes stale provider slash values before desktop validation removes missing repos", async () => {
+    const onchange = vi.fn();
+    settingsStore.setConfiguredRepos([
+      {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "acme",
+        name: "widgets",
+        repo_path: "acme/widgets",
+        is_glob: false,
+        matched_repo_count: 1,
+      },
+    ]);
+
+    render(RepoTypeahead, {
+      props: {
+        selected: "github/github.com/acme/widgets,github.com/acme/missing",
+        onchange,
+      },
+    });
+
+    await waitFor(() => {
+      expect(onchange).toHaveBeenCalledWith("github.com/acme/widgets,github.com/acme/missing");
+    });
   });
 });

--- a/frontend/src/lib/components/RepoTypeahead.test.ts
+++ b/frontend/src/lib/components/RepoTypeahead.test.ts
@@ -552,6 +552,17 @@ describe("RepoTypeahead", () => {
     render(RepoTypeahead, { props: { selected: undefined, onchange } });
 
     await fireEvent.click(screen.getByRole("button", { name: /all repos/i }));
+    const giteaRow = screen.getByRole("option", {
+      name: "gitea/github.com/acme/widgets",
+    });
+    expect(giteaRow.querySelector(".repo-tree-label")?.textContent).toBe("gitea/widgets");
+    expect(
+      screen
+        .getByRole("option", {
+          name: "github/github.com/acme/widgets",
+        })
+        .querySelector(".repo-tree-label")?.textContent,
+    ).toBe("github/widgets");
     await fireEvent.mouseDown(
       screen.getByRole("option", {
         name: "gitea/github.com/acme/widgets",

--- a/frontend/src/lib/components/repoTree.test.ts
+++ b/frontend/src/lib/components/repoTree.test.ts
@@ -173,6 +173,31 @@ describe("visibleRows", () => {
     expect(labels).not.toContain("api");
   });
 
+  it("matches provider-qualified leaves by visible and slash display labels", () => {
+    const tree = buildRepoTree([
+      {
+        ...opt("github.com", "acme/widgets", "github"),
+        value: "github|github.com/acme/widgets",
+      },
+      {
+        ...opt("github.com", "acme/widgets", "gitea"),
+        value: "gitea|github.com/acme/widgets",
+      },
+    ]);
+
+    const visibleLabelRows = visibleRows(tree, {
+      isCollapsed: () => true,
+      query: "gitea/widgets",
+    });
+    expect(visibleLabelRows.map((row) => row.displayLabel ?? row.node.label)).toEqual(["acme", "gitea/widgets"]);
+
+    const slashValueRows = visibleRows(tree, {
+      isCollapsed: () => true,
+      query: "gitea/github.com/acme/widgets",
+    });
+    expect(slashValueRows.map((row) => row.displayLabel ?? row.node.label)).toEqual(["acme", "gitea/widgets"]);
+  });
+
   it("keeps a multi-repo owner as an owner row when a filter matches only one repo", () => {
     // acme genuinely has 3 repos; the query matches only "api". The owner must
     // stay a visible owner row (not collapse into a lone leaf), so its context

--- a/frontend/src/lib/components/repoTree.test.ts
+++ b/frontend/src/lib/components/repoTree.test.ts
@@ -61,9 +61,25 @@ describe("buildRepoTree", () => {
     expect(tree.map((h) => h.label)).toEqual(["github.com", "gitlab.com"]);
   });
 
-  it("uses the first option's provider when a host's providers disagree", () => {
+  it("omits the host provider when a host's providers disagree", () => {
     const tree = buildRepoTree([opt("ghe.example.com", "a/x", "github"), opt("ghe.example.com", "b/y", "gitlab")]);
-    expect(tree[0]!.provider).toBe("github");
+    expect(tree[0]!.provider).toBe("");
+  });
+
+  it("gives provider-qualified leaves visible provider labels", () => {
+    const tree = buildRepoTree([
+      {
+        ...opt("github.com", "acme/widgets", "github"),
+        value: "github|github.com/acme/widgets",
+      },
+      {
+        ...opt("github.com", "acme/widgets", "gitea"),
+        value: "gitea|github.com/acme/widgets",
+      },
+    ]);
+
+    const acme = tree[0]!.children[0]!;
+    expect(acme.children.map((repo) => repo.displayLabel)).toEqual(["gitea/widgets", "github/widgets"]);
   });
 
   it("returns an empty array for no options", () => {

--- a/frontend/src/lib/components/repoTree.ts
+++ b/frontend/src/lib/components/repoTree.ts
@@ -1,5 +1,5 @@
 export interface RepoTreeOption {
-  value: string; // `${platformHost}/${repoPath}`
+  value: string; // `${platformHost}/${repoPath}` or `${provider}|${platformHost}/${repoPath}`
   owner: string;
   name: string;
   provider: string; // canonical, lowercase
@@ -32,10 +32,12 @@ export interface HostNode {
 export type RepoTreeNodeData = HostNode | OwnerNode | RepoLeaf;
 
 function stripHostPrefix(value: string, platformHost: string): string {
+  const providerSeparator = value.indexOf("|");
+  const concreteValue = providerSeparator === -1 ? value : value.slice(providerSeparator + 1);
   const prefix = `${platformHost}/`;
-  if (value.startsWith(prefix)) return value.slice(prefix.length);
+  if (concreteValue.startsWith(prefix)) return concreteValue.slice(prefix.length);
   // Defensive fallback: drop everything up to and including the first slash.
-  return value.replace(/^[^/]+\//, "");
+  return concreteValue.replace(/^[^/]+\//, "");
 }
 
 export function buildRepoTree(options: readonly RepoTreeOption[]): HostNode[] {

--- a/frontend/src/lib/components/repoTree.ts
+++ b/frontend/src/lib/components/repoTree.ts
@@ -10,6 +10,7 @@ export interface RepoLeaf {
   kind: "repo";
   id: string;
   label: string;
+  displayLabel?: string;
   value: string;
 }
 
@@ -40,6 +41,10 @@ function stripHostPrefix(value: string, platformHost: string): string {
   return concreteValue.replace(/^[^/]+\//, "");
 }
 
+function providerQualifiedLeafLabel(option: RepoTreeOption, name: string): string | undefined {
+  return option.value.includes("|") ? `${option.provider}/${name}` : undefined;
+}
+
 export function buildRepoTree(options: readonly RepoTreeOption[]): HostNode[] {
   const hosts = new Map<string, HostNode>();
 
@@ -61,6 +66,8 @@ export function buildRepoTree(options: readonly RepoTreeOption[]): HostNode[] {
         children: [],
       };
       hosts.set(option.platformHost, host);
+    } else if (host.provider !== option.provider) {
+      host.provider = "";
     }
 
     let owner = host.children.find((node) => node.label === ownerPath);
@@ -74,10 +81,12 @@ export function buildRepoTree(options: readonly RepoTreeOption[]): HostNode[] {
       host.children.push(owner);
     }
 
+    const displayLabel = providerQualifiedLeafLabel(option, name);
     owner.children.push({
       kind: "repo",
       id: option.value,
       label: name,
+      ...(displayLabel ? { displayLabel } : {}),
       value: option.value,
     });
   }
@@ -86,7 +95,7 @@ export function buildRepoTree(options: readonly RepoTreeOption[]): HostNode[] {
   for (const host of sorted) {
     host.children.sort((a, b) => a.label.localeCompare(b.label));
     for (const owner of host.children) {
-      owner.children.sort((a, b) => a.label.localeCompare(b.label));
+      owner.children.sort((a, b) => (a.displayLabel ?? a.label).localeCompare(b.displayLabel ?? b.label));
     }
   }
   return sorted;
@@ -160,7 +169,7 @@ export function visibleRows(tree: readonly HostNode[], { isCollapsed, query }: V
           depth: ownerDepth,
           hasChildren: false,
           expanded: false,
-          displayLabel: `${owner.original.label}/${leaf.label}`,
+          displayLabel: `${owner.original.label}/${leaf.displayLabel ?? leaf.label}`,
         });
         continue;
       }
@@ -178,6 +187,7 @@ export function visibleRows(tree: readonly HostNode[], { isCollapsed, query }: V
           depth: ownerDepth + 1,
           hasChildren: false,
           expanded: false,
+          ...(leaf.displayLabel ? { displayLabel: leaf.displayLabel } : {}),
         });
       }
     }

--- a/frontend/src/lib/components/repoTree.ts
+++ b/frontend/src/lib/components/repoTree.ts
@@ -45,6 +45,24 @@ function providerQualifiedLeafLabel(option: RepoTreeOption, name: string): strin
   return option.value.includes("|") ? `${option.provider}/${name}` : undefined;
 }
 
+function slashDisplayValue(value: string): string {
+  const providerSeparator = value.indexOf("|");
+  if (providerSeparator === -1) return value;
+  return `${value.slice(0, providerSeparator)}/${value.slice(providerSeparator + 1)}`;
+}
+
+function leafMatches(leaf: RepoLeaf, ownerLabel: string, query: string): boolean {
+  if (query === "") return true;
+  const visibleLabel = leaf.displayLabel ?? leaf.label;
+  return [
+    leaf.value,
+    slashDisplayValue(leaf.value),
+    visibleLabel,
+    `${ownerLabel}/${visibleLabel}`,
+    `${ownerLabel}/${leaf.label}`,
+  ].some((label) => label.toLowerCase().includes(query));
+}
+
 export function buildRepoTree(options: readonly RepoTreeOption[]): HostNode[] {
   const hosts = new Map<string, HostNode>();
 
@@ -123,7 +141,6 @@ export interface VisibleRowsOptions {
 export function visibleRows(tree: readonly HostNode[], { isCollapsed, query }: VisibleRowsOptions): VisibleRow[] {
   const q = query?.trim().toLowerCase() ?? "";
   const filtering = q !== "";
-  const matches = (leaf: RepoLeaf) => !filtering || leaf.value.toLowerCase().includes(q);
 
   // Prune to the owners/hosts that still have a matching leaf, but keep a
   // reference to the ORIGINAL (unpruned) node alongside the matching leaves.
@@ -136,7 +153,7 @@ export function visibleRows(tree: readonly HostNode[], { isCollapsed, query }: V
       owners: host.children
         .map((owner) => ({
           original: owner,
-          matchingLeaves: owner.children.filter(matches),
+          matchingLeaves: owner.children.filter((leaf) => leafMatches(leaf, owner.label, q)),
         }))
         .filter((owner) => owner.matchingLeaves.length > 0),
     }))

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -438,6 +438,7 @@
 
   function workspaceRepoIdentity(ws: Workspace): RepoLabelIdentity {
     return {
+      provider: ws.repo?.provider ?? "",
       platformHost: ws.platform_host,
       owner: ws.repo_owner,
       name: ws.repo_name,

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -453,11 +453,17 @@
   }
 
   function workspaceGroupKey(ws: Workspace): string {
-    // Group on the full provider ref, not just host/owner/name. Two
-    // providers can share a platform host and repo path.
+    // Group on the full provider ref, not just host/owner/name, reusing
+    // the same provider-aware identity that drives the label. Two
+    // providers can share a platform host and repo path (for example a
+    // Gitea and a Forgejo instance on one domain); without the provider
+    // segment their workspaces collapse into a single group whose label
+    // and provider icon are taken from only the first item. The NUL
+    // joiner keeps GitLab's slash-bearing subgroup owners from colliding
+    // across segments.
     const identity = workspaceRepoIdentity(ws);
     return [
-      workspaceProvider(ws) ?? "",
+      identity.provider,
       identity.platformHost,
       identity.owner,
       identity.name,

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -653,9 +653,6 @@
     {#snippet workspaceRow(ws: Workspace, showRepo: boolean)}
           {@const adds = ws.mr_additions}
           {@const dels = ws.mr_deletions}
-          {@const showDiff =
-            ws.item_type === "pull_request" &&
-            ((adds ?? 0) > 0 || (dels ?? 0) > 0)}
           {@const ahead = ws.commits_ahead ?? 0}
           {@const behind = ws.commits_behind ?? 0}
           {@const showPush = ahead > 0 || behind > 0}
@@ -763,7 +760,9 @@
                     {/if}
                   </span>
                 {/if}
-                {#if displayOptions.showDiffStats && showDiff}
+                {#if displayOptions.showDiffStats &&
+                  ws.item_type === "pull_request" &&
+                  ((adds ?? 0) > 0 || (dels ?? 0) > 0)}
                   <span class="workspace-diff-stats">
                     <DiffStats
                       additions={adds ?? 0}

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -13,6 +13,10 @@
     FilterDropdown,
     LeftSidebarToggle,
   } from "@middleman/ui";
+  import {
+    createRepoLabelFormatter,
+    type RepoLabelIdentity,
+  } from "@middleman/ui/utils/repo-label";
   import ProviderIcon from "../provider/ProviderIcon.svelte";
   import {
     defaultWorkspaceListDisplayOptions,
@@ -253,38 +257,12 @@
     return Number.isNaN(ms) ? 0 : ms;
   }
 
-  // Owner/name pairs that exist on more than one platform host.
-  // Flat rows prefix the host for these so identical repo names on
-  // different hosts stay distinguishable; repo identity is always
-  // (platform, host, owner, name), never owner/name alone.
-  const ambiguousFlatRepos = $derived.by(() => {
-    const hostByRepo: Record<string, string> = {};
-    const ambiguous: string[] = [];
-    for (const ws of workspaces) {
-      const key = `${ws.repo_owner}/${ws.repo_name}`;
-      const seen = hostByRepo[key];
-      if (seen === undefined) {
-        hostByRepo[key] = ws.platform_host;
-      } else if (seen !== ws.platform_host && !ambiguous.includes(key)) {
-        ambiguous.push(key);
-      }
-    }
-    return ambiguous;
-  });
-
-  function flatRepoLabel(ws: Workspace): string {
-    if (!displayOptions.showOrgNames) {
-      const key = `${ws.repo_owner}/${ws.repo_name}`;
-      return ambiguousFlatRepos.has(key)
-        ? `${ws.platform_host}/${ws.repo_name}`
-        : ws.repo_name;
-    }
-
-    const key = `${ws.repo_owner}/${ws.repo_name}`;
-    return ambiguousFlatRepos.includes(key)
-      ? `${ws.platform_host}/${key}`
-      : key;
-  }
+  const repoLabelFormatter = $derived.by(() =>
+    createRepoLabelFormatter(
+      workspaces.map(workspaceRepoIdentity),
+      { showOrgNames: displayOptions.showOrgNames },
+    ),
+  );
 
   const showProviderIcons = $derived.by(() => {
     const providers: string[] = [];
@@ -458,17 +436,17 @@
     return ref.replace(/^refs\/heads\//, "");
   }
 
-  function shortRepo(repoKey: string): string {
-    // platform/owner/name → owner/name (the platform host crowds
-    // the rail and is rarely useful at a glance).
-    const parts = repoKey.split("/");
-    if (!displayOptions.showOrgNames && parts.length >= 3) {
-      return parts[parts.length - 1] ?? repoKey;
-    }
-    if (parts.length >= 3) {
-      return parts.slice(-2).join("/");
-    }
-    return repoKey;
+  function workspaceRepoIdentity(ws: Workspace): RepoLabelIdentity {
+    return {
+      platformHost: ws.platform_host,
+      owner: ws.repo_owner,
+      name: ws.repo_name,
+      repoPath: ws.repo?.repo_path,
+    };
+  }
+
+  function repoLabel(ws: Workspace): string {
+    return repoLabelFormatter.format(workspaceRepoIdentity(ws));
   }
 
   function workspaceProvider(ws: Workspace): string | undefined {
@@ -635,7 +613,7 @@
             class="group-provider-icon"
           />
         {/if}
-        <span class="group-label">{shortRepo(repoKey)}</span>
+        <span class="group-label">{repoLabel(items[0]!)}</span>
         <span class="group-count">{items.length}</span>
       </button>
       {#if !collapsed}
@@ -721,7 +699,7 @@
                         class="repo-context-icon"
                       />
                     {/if}
-                    <span class="repo-context-name">{flatRepoLabel(ws)}</span>
+                    <span class="repo-context-name">{repoLabel(ws)}</span>
                   </span>
                 {/if}
                 <span class="branch-chip" title={ws.git_head_ref}>

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -15,9 +15,14 @@
   } from "@middleman/ui";
   import ProviderIcon from "../provider/ProviderIcon.svelte";
   import {
+    defaultWorkspaceListDisplayOptions,
+    defaultWorkspaceListSort,
+    loadWorkspaceListDisplayOptions,
     loadWorkspaceListSort,
+    saveWorkspaceListDisplayOptions,
     saveWorkspaceListSort,
     workspaceListSortOptions,
+    type WorkspaceListDisplayOptions,
     type WorkspaceListSort,
   } from "./workspaceListSort.ts";
 
@@ -101,6 +106,9 @@
   let fetchInFlight = false;
 
   const workspaceListLoadTimeoutMs = 10_000;
+  let displayOptions = $state<WorkspaceListDisplayOptions>(
+    loadWorkspaceListDisplayOptions(),
+  );
 
   type WorkspaceGroup = {
     key: string;
@@ -146,8 +154,21 @@
     )?.label ?? "Org / repo",
   );
 
-  const sortSections = $derived.by(() => [
+  const viewBadgeCount = $derived(
+    Number(sortMode !== defaultWorkspaceListSort) +
+      Number(
+        displayOptions.showOrgNames !==
+          defaultWorkspaceListDisplayOptions.showOrgNames,
+      ) +
+      Number(
+        displayOptions.showDiffStats !==
+          defaultWorkspaceListDisplayOptions.showDiffStats,
+      ),
+  );
+
+  const viewSections = $derived.by(() => [
     {
+      title: "Sorting",
       items: workspaceListSortOptions.map((option) => ({
         id: option.value,
         label: option.label,
@@ -156,6 +177,33 @@
         closeOnSelect: true,
         onSelect: () => setSort(option.value),
       })),
+    },
+    {
+      title: "Visibility",
+      items: [
+        {
+          id: "show-org-names",
+          label: "Show org names",
+          description: "Include owner or organization names in workspace repo labels.",
+          active: displayOptions.showOrgNames,
+          onSelect: () =>
+            setDisplayOption(
+              "showOrgNames",
+              !displayOptions.showOrgNames,
+            ),
+        },
+        {
+          id: "show-diff-stats",
+          label: "Show PR diff stats",
+          description: "Show additions and deletions for linked pull request workspaces.",
+          active: displayOptions.showDiffStats,
+          onSelect: () =>
+            setDisplayOption(
+              "showDiffStats",
+              !displayOptions.showDiffStats,
+            ),
+        },
+      ],
     },
   ]);
 
@@ -191,6 +239,14 @@
     saveWorkspaceListSort(sort);
   }
 
+  function setDisplayOption(
+    key: keyof WorkspaceListDisplayOptions,
+    value: boolean,
+  ): void {
+    displayOptions = { ...displayOptions, [key]: value };
+    saveWorkspaceListDisplayOptions(displayOptions);
+  }
+
   function timeValue(value: string | null | undefined): number {
     if (!value) return 0;
     const ms = Date.parse(value);
@@ -217,6 +273,13 @@
   });
 
   function flatRepoLabel(ws: Workspace): string {
+    if (!displayOptions.showOrgNames) {
+      const key = `${ws.repo_owner}/${ws.repo_name}`;
+      return ambiguousFlatRepos.has(key)
+        ? `${ws.platform_host}/${ws.repo_name}`
+        : ws.repo_name;
+    }
+
     const key = `${ws.repo_owner}/${ws.repo_name}`;
     return ambiguousFlatRepos.includes(key)
       ? `${ws.platform_host}/${key}`
@@ -399,6 +462,9 @@
     // platform/owner/name → owner/name (the platform host crowds
     // the rail and is rarely useful at a glance).
     const parts = repoKey.split("/");
+    if (!displayOptions.showOrgNames && parts.length >= 3) {
+      return parts[parts.length - 1] ?? repoKey;
+    }
     if (parts.length >= 3) {
       return parts.slice(-2).join("/");
     }
@@ -475,12 +541,14 @@
     <span class="sidebar-header-count">{sidebarCountLabel}</span>
     <div class="workspace-sort">
       <FilterDropdown
-        label={sortLabel}
-        showBadge={false}
-        sections={sortSections}
-        title="Sort workspaces"
-        minWidth="170px"
-        icon="sort"
+        label="View"
+        detail={sortLabel}
+        active={viewBadgeCount > 0}
+        badgeCount={viewBadgeCount}
+        sections={viewSections}
+        title="View workspace options"
+        minWidth="220px"
+        align="end"
       />
     </div>
     {#if isSidebarToggleEnabled && onCollapseSidebar}
@@ -695,7 +763,7 @@
                     {/if}
                   </span>
                 {/if}
-                {#if showDiff}
+                {#if displayOptions.showDiffStats && showDiff}
                   <span class="workspace-diff-stats">
                     <DiffStats
                       additions={adds ?? 0}

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -139,9 +139,7 @@
   const grouped = $derived.by<WorkspaceGroup[]>(() => {
     const groups: WorkspaceGroup[] = [];
     for (const ws of visibleWorkspaces) {
-      const key =
-        `${ws.platform_host}/${ws.repo_owner}` +
-        `/${ws.repo_name}`;
+      const key = workspaceGroupKey(ws);
       const group = groups.find((candidate) => candidate.key === key);
       if (group) {
         group.items.push(ws);
@@ -452,6 +450,18 @@
 
   function workspaceProvider(ws: Workspace): string | undefined {
     return ws.repo?.provider;
+  }
+
+  function workspaceGroupKey(ws: Workspace): string {
+    // Group on the full provider ref, not just host/owner/name. Two
+    // providers can share a platform host and repo path.
+    const identity = workspaceRepoIdentity(ws);
+    return [
+      workspaceProvider(ws) ?? "",
+      identity.platformHost,
+      identity.owner,
+      identity.name,
+    ].join("\0");
   }
 
   function workspaceRoute(ws: Workspace): string {

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -15,6 +15,7 @@
   } from "@middleman/ui";
   import {
     createRepoLabelFormatter,
+    repoIdentityKey,
     type RepoLabelIdentity,
   } from "@middleman/ui/utils/repo-label";
   import ProviderIcon from "../provider/ProviderIcon.svelte";
@@ -139,7 +140,7 @@
   const grouped = $derived.by<WorkspaceGroup[]>(() => {
     const groups: WorkspaceGroup[] = [];
     for (const ws of visibleWorkspaces) {
-      const key = workspaceGroupKey(ws);
+      const key = repoIdentityKey(workspaceRepoIdentity(ws));
       const group = groups.find((candidate) => candidate.key === key);
       if (group) {
         group.items.push(ws);
@@ -450,24 +451,6 @@
 
   function workspaceProvider(ws: Workspace): string | undefined {
     return ws.repo?.provider;
-  }
-
-  function workspaceGroupKey(ws: Workspace): string {
-    // Group on the full provider ref, not just host/owner/name, reusing
-    // the same provider-aware identity that drives the label. Two
-    // providers can share a platform host and repo path (for example a
-    // Gitea and a Forgejo instance on one domain); without the provider
-    // segment their workspaces collapse into a single group whose label
-    // and provider icon are taken from only the first item. The NUL
-    // joiner keeps GitLab's slash-bearing subgroup owners from colliding
-    // across segments.
-    const identity = workspaceRepoIdentity(ws);
-    return [
-      identity.provider,
-      identity.platformHost,
-      identity.owner,
-      identity.name,
-    ].join("\0");
   }
 
   function workspaceRoute(ws: Workspace): string {

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
@@ -399,6 +399,45 @@ describe("WorkspaceListSidebar", () => {
     expect(screen.queryByRole("img", { name: "GitHub" })).toBeNull();
   });
 
+  it("keeps same-host repos from different providers in separate groups", async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        workspaces: [
+          workspaceFixture({
+            id: "ws-gitea",
+            provider: "gitea",
+            platformHost: "code.example.com",
+            owner: "acme",
+            name: "widgets",
+            number: 1,
+            title: "Gitea widgets",
+          }),
+          workspaceFixture({
+            id: "ws-forgejo",
+            provider: "forgejo",
+            platformHost: "code.example.com",
+            owner: "acme",
+            name: "widgets",
+            number: 2,
+            title: "Forgejo widgets",
+          }),
+        ],
+      },
+    });
+
+    const { container } = render(WorkspaceListSidebar, {
+      props: { selectedId: "ws-gitea" },
+    });
+    await screen.findByText("Gitea widgets");
+
+    // Identical host and repo path, different providers: the rows must
+    // not collapse into a single group whose label and icon come from
+    // only the first item. Each provider keeps its own group + icon.
+    expect(container.querySelectorAll(".group-header")).toHaveLength(2);
+    expect(screen.getByRole("img", { name: "Gitea" })).toBeTruthy();
+    expect(screen.getByRole("img", { name: "Forgejo" })).toBeTruthy();
+  });
+
   it("filters workspaces by title, repo, and item number", async () => {
     mockGet.mockResolvedValue({
       data: {

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
@@ -724,6 +724,67 @@ describe("WorkspaceListSidebar", () => {
     expect(container.querySelectorAll(".repo-context-name")[1]?.textContent?.trim()).toBe("agentsview");
   });
 
+  it("keeps hidden-org workspace repo labels distinguishable", async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        workspaces: [
+          workspaceFixture({
+            id: "ws-github-acme",
+            provider: "github",
+            platformHost: "github.com",
+            owner: "acme",
+            name: "widgets",
+            number: 1,
+            title: "GitHub acme widgets",
+            createdAt: "2026-05-12T12:00:00Z",
+          }),
+          workspaceFixture({
+            id: "ws-ghe-acme",
+            provider: "github",
+            platformHost: "ghe.example.com",
+            owner: "acme",
+            name: "widgets",
+            number: 2,
+            title: "GHE acme widgets",
+            createdAt: "2026-05-11T12:00:00Z",
+          }),
+          workspaceFixture({
+            id: "ws-platform",
+            provider: "gitlab",
+            platformHost: "gitlab.example.com",
+            owner: "platform",
+            name: "widgets",
+            number: 3,
+            title: "Platform widgets",
+            createdAt: "2026-05-10T12:00:00Z",
+          }),
+        ],
+      },
+    });
+
+    const { container } = render(WorkspaceListSidebar, {
+      props: { selectedId: "ws-github-acme" },
+    });
+    await screen.findByText("GitHub acme widgets");
+
+    await fireEvent.click(screen.getByRole("button", { name: "View" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Show org names" }));
+
+    expect(Array.from(container.querySelectorAll(".group-label")).map((el) => el.textContent?.trim())).toEqual([
+      "github.com/acme/widgets",
+      "ghe.example.com/acme/widgets",
+      "platform/widgets",
+    ]);
+
+    await fireEvent.click(screen.getByRole("button", { name: "Created" }));
+
+    expect(Array.from(container.querySelectorAll(".repo-context-name")).map((el) => el.textContent?.trim())).toEqual([
+      "github.com/acme/widgets",
+      "ghe.example.com/acme/widgets",
+      "platform/widgets",
+    ]);
+  });
+
   it("can hide PR diff stats while keeping branch metadata visible", async () => {
     mockGet.mockResolvedValue({
       data: {

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
@@ -824,6 +824,47 @@ describe("WorkspaceListSidebar", () => {
     ]);
   });
 
+  it("keeps same-host different-provider repo groups separate", async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        workspaces: [
+          workspaceFixture({
+            id: "ws-github-acme",
+            provider: "github",
+            platformHost: "github.com",
+            owner: "acme",
+            name: "widgets",
+            number: 1,
+            title: "GitHub acme widgets",
+          }),
+          workspaceFixture({
+            id: "ws-gitea-acme",
+            provider: "gitea",
+            platformHost: "github.com",
+            owner: "acme",
+            name: "widgets",
+            number: 2,
+            title: "Gitea acme widgets",
+          }),
+        ],
+      },
+    });
+
+    const { container } = render(WorkspaceListSidebar, {
+      props: { selectedId: "ws-github-acme" },
+    });
+    await screen.findByText("GitHub acme widgets");
+
+    expect(Array.from(container.querySelectorAll(".group-label")).map((el) => el.textContent?.trim())).toEqual([
+      "github/github.com/acme/widgets",
+      "gitea/github.com/acme/widgets",
+    ]);
+    expect(Array.from(container.querySelectorAll(".group-count")).map((el) => el.textContent?.trim())).toEqual([
+      "1",
+      "1",
+    ]);
+  });
+
   it("can hide PR diff stats while keeping branch metadata visible", async () => {
     mockGet.mockResolvedValue({
       data: {

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
@@ -37,6 +37,8 @@ interface WorkspaceFixtureOptions {
   createdAt?: string;
   tmuxLastOutputAt?: string | null;
   itemLastActivityAt?: string | null;
+  additions?: number | null;
+  deletions?: number | null;
 }
 
 function workspaceFixture({
@@ -52,6 +54,8 @@ function workspaceFixture({
   createdAt = "2026-05-12T12:00:00Z",
   tmuxLastOutputAt = null,
   itemLastActivityAt = null,
+  additions = null,
+  deletions = null,
 }: WorkspaceFixtureOptions) {
   return {
     id,
@@ -76,6 +80,8 @@ function workspaceFixture({
     item_last_activity_at: itemLastActivityAt,
     mr_title: title,
     mr_state: "open",
+    mr_additions: additions,
+    mr_deletions: deletions,
   };
 }
 
@@ -510,7 +516,7 @@ describe("WorkspaceListSidebar", () => {
     expect(screen.getByText("kenn-io/middleman")).toBeTruthy();
     expect(container.querySelectorAll(".repo-context")).toHaveLength(0);
 
-    await fireEvent.click(screen.getByTitle("Sort workspaces"));
+    await fireEvent.click(screen.getByTitle("View workspace options"));
     await fireEvent.click(screen.getByRole("button", { name: "Created" }));
 
     expect(rowTitles(container)).toEqual(["Newest created", "Most recently active", "Oldest without activity"]);
@@ -562,7 +568,7 @@ describe("WorkspaceListSidebar", () => {
     });
     await screen.findByText("GitHub workspace");
 
-    await fireEvent.click(screen.getByTitle("Sort workspaces"));
+    await fireEvent.click(screen.getByTitle("View workspace options"));
     await fireEvent.click(screen.getByRole("button", { name: "Created" }));
 
     // Provider icons survive the loss of group headers.
@@ -588,7 +594,7 @@ describe("WorkspaceListSidebar", () => {
     });
     await screen.findByText("Newest created");
 
-    await fireEvent.click(screen.getByTitle("Sort workspaces"));
+    await fireEvent.click(screen.getByTitle("View workspace options"));
     await fireEvent.click(screen.getByRole("button", { name: "Activity" }));
 
     // ws-old has no tmux output, so it sorts by its creation time.
@@ -641,7 +647,7 @@ describe("WorkspaceListSidebar", () => {
     });
     await screen.findByText("Newest created fallback");
 
-    await fireEvent.click(screen.getByTitle("Sort workspaces"));
+    await fireEvent.click(screen.getByTitle("View workspace options"));
     const itemActivitySort = screen.getByRole("button", { name: "Item activity" });
     expect(itemActivitySort.getAttribute("title")).toBe(
       "Sort by latest linked PR or issue activity, falling back to workspace creation.",
@@ -662,7 +668,7 @@ describe("WorkspaceListSidebar", () => {
     });
     await screen.findByText("Newest created");
 
-    await fireEvent.click(screen.getByTitle("Sort workspaces"));
+    await fireEvent.click(screen.getByTitle("View workspace options"));
     await fireEvent.click(screen.getByRole("button", { name: "Activity" }));
     first.unmount();
 
@@ -673,5 +679,81 @@ describe("WorkspaceListSidebar", () => {
 
     expect(rowTitles(container)).toEqual(["Most recently active", "Newest created", "Oldest without activity"]);
     expect(container.querySelectorAll(".group-header")).toHaveLength(0);
+  });
+
+  it("folds sort choices into the workspace view menu", async () => {
+    mockGet.mockResolvedValue({
+      data: { workspaces: sortFixtures() },
+    });
+
+    render(WorkspaceListSidebar, {
+      props: { selectedId: "ws-new" },
+    });
+    await screen.findByText("Newest created");
+
+    await fireEvent.click(screen.getByRole("button", { name: "View" }));
+
+    expect(screen.getByText("Sorting")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Org / repo" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Created" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Activity" })).toBeTruthy();
+    expect(screen.getByText("Visibility")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Show org names" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Show PR diff stats" })).toBeTruthy();
+  });
+
+  it("can hide org names in grouped and flat workspace labels", async () => {
+    mockGet.mockResolvedValue({
+      data: { workspaces: sortFixtures() },
+    });
+
+    const { container } = render(WorkspaceListSidebar, {
+      props: { selectedId: "ws-new" },
+    });
+    await screen.findByText("kenn-io/middleman");
+
+    await fireEvent.click(screen.getByRole("button", { name: "View" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Show org names" }));
+
+    expect(screen.queryByText("kenn-io/middleman")).toBeNull();
+    expect(screen.getByText("middleman")).toBeTruthy();
+
+    await fireEvent.click(screen.getByRole("button", { name: "Created" }));
+
+    expect(container.querySelectorAll(".repo-context-name")[0]?.textContent?.trim()).toBe("middleman");
+    expect(container.querySelectorAll(".repo-context-name")[1]?.textContent?.trim()).toBe("agentsview");
+  });
+
+  it("can hide PR diff stats while keeping branch metadata visible", async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        workspaces: [
+          workspaceFixture({
+            id: "ws-diff",
+            provider: "github",
+            platformHost: "github.com",
+            owner: "kenn-io",
+            name: "middleman",
+            number: 9,
+            title: "Diff-heavy workspace",
+            additions: 42,
+            deletions: 7,
+          }),
+        ],
+      },
+    });
+
+    const { container } = render(WorkspaceListSidebar, {
+      props: { selectedId: "ws-diff" },
+    });
+    await screen.findByText("Diff-heavy workspace");
+
+    expect(container.querySelector(".workspace-diff-stats")).toBeTruthy();
+
+    await fireEvent.click(screen.getByRole("button", { name: "View" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Show PR diff stats" }));
+
+    expect(container.querySelector(".workspace-diff-stats")).toBeNull();
+    expect(container.querySelector(".branch-chip")).toBeTruthy();
   });
 });

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -236,9 +236,25 @@
     );
   }
 
+  function readLocalStorage(key: string): string | null {
+    try {
+      return localStorage.getItem(key);
+    } catch {
+      return null;
+    }
+  }
+
+  function writeLocalStorage(key: string, value: string): void {
+    try {
+      localStorage.setItem(key, value);
+    } catch {
+      // Best-effort UI preference persistence; keep the in-memory state.
+    }
+  }
+
   function loadWorkspaceListWidth(): number {
     const value = parseInt(
-      localStorage.getItem(WORKSPACE_LIST_WIDTH_KEY) ?? "",
+      readLocalStorage(WORKSPACE_LIST_WIDTH_KEY) ?? "",
       10,
     );
     return Number.isFinite(value)
@@ -247,7 +263,7 @@
   }
 
   function loadSidebarTab(): SidebarTab {
-    const v = localStorage.getItem(SIDEBAR_TAB_KEY);
+    const v = readLocalStorage(SIDEBAR_TAB_KEY);
     if (v === "diff") return "diff";
     if (v === "pr") return "pr";
     if (v === "issue") return "issue";
@@ -256,7 +272,7 @@
   }
 
   function loadSidebarOpen(): boolean {
-    return localStorage.getItem(SIDEBAR_OPEN_KEY) === "true";
+    return readLocalStorage(SIDEBAR_OPEN_KEY) === "true";
   }
 
   const MIN_SIDEBAR_WIDTH = 280;
@@ -266,7 +282,7 @@
 
   function loadSidebarWidth(): number {
     const v = parseInt(
-      localStorage.getItem(SIDEBAR_WIDTH_KEY) ?? "",
+      readLocalStorage(SIDEBAR_WIDTH_KEY) ?? "",
       10,
     );
     return Number.isFinite(v)
@@ -399,23 +415,23 @@
   );
 
   $effect(() => {
-    localStorage.setItem(SIDEBAR_TAB_KEY, sidebarTab);
+    writeLocalStorage(SIDEBAR_TAB_KEY, sidebarTab);
   });
   $effect(() => {
-    localStorage.setItem(
+    writeLocalStorage(
       SIDEBAR_OPEN_KEY,
       String(sidebarOpen),
     );
   });
   $effect(() => {
-    localStorage.setItem(
+    writeLocalStorage(
       SIDEBAR_WIDTH_KEY,
       String(sidebarWidth),
     );
   });
   $effect(() => {
     if (externalWorkspaceListWidth !== undefined) return;
-    localStorage.setItem(
+    writeLocalStorage(
       WORKSPACE_LIST_WIDTH_KEY,
       String(workspaceListWidth),
     );
@@ -424,13 +440,13 @@
     if (!workspaceId) return;
     const storageId = workspaceStorageId(workspaceId, workspaceHostKey);
     if (terminalLayoutWorkspaceId !== storageId) return;
-    localStorage.setItem(
+    writeLocalStorage(
       terminalLayoutStorageKey(storageId),
       JSON.stringify(terminalLayout),
     );
   });
   $effect(() => {
-    localStorage.setItem(WORKFLOW_PRESETS_KEY, JSON.stringify(workflowPresets));
+    writeLocalStorage(WORKFLOW_PRESETS_KEY, JSON.stringify(workflowPresets));
   });
 
   function handleSegmentClick(tab: SidebarTab): void {
@@ -664,11 +680,13 @@
   }
 
   function loadTerminalLayout(storageId: string): TerminalLayoutState {
-    return parseTerminalLayout(localStorage.getItem(terminalLayoutStorageKey(storageId)));
+    return parseTerminalLayout(
+      readLocalStorage(terminalLayoutStorageKey(storageId)),
+    );
   }
 
   function loadWorkflowPresets(): WorkflowPreset[] {
-    const raw = localStorage.getItem(WORKFLOW_PRESETS_KEY);
+    const raw = readLocalStorage(WORKFLOW_PRESETS_KEY);
     if (!raw) return [];
     try {
       const parsed = JSON.parse(raw) as unknown;
@@ -849,7 +867,7 @@
 
   function rememberActiveTab(key: WorkflowTabKey): void {
     if (!workspaceId) return;
-    localStorage.setItem(
+    writeLocalStorage(
       `${ACTIVE_WORKSPACE_TAB_KEY_PREFIX}${workspaceStorageId(workspaceId)}`,
       key,
     );
@@ -873,7 +891,7 @@
   }
 
   function restoreWorkspaceTab(storageId: string): WorkflowTabKey {
-    const remembered = localStorage.getItem(
+    const remembered = readLocalStorage(
       `${ACTIVE_WORKSPACE_TAB_KEY_PREFIX}${storageId}`,
     );
     if (remembered === "diff") return "home";

--- a/frontend/src/lib/components/terminal/workspaceListSort.ts
+++ b/frontend/src/lib/components/terminal/workspaceListSort.ts
@@ -1,5 +1,10 @@
 export type WorkspaceListSort = "repo" | "created" | "activity" | "item-activity";
 
+export interface WorkspaceListDisplayOptions {
+  showOrgNames: boolean;
+  showDiffStats: boolean;
+}
+
 export const workspaceListSortOptions: {
   value: WorkspaceListSort;
   label: string;
@@ -29,7 +34,13 @@ export const workspaceListSortOptions: {
 
 export const defaultWorkspaceListSort: WorkspaceListSort = "repo";
 
-const storageKey = "middleman:workspaceListSort";
+export const defaultWorkspaceListDisplayOptions: WorkspaceListDisplayOptions = {
+  showOrgNames: true,
+  showDiffStats: true,
+};
+
+const sortStorageKey = "middleman:workspaceListSort";
+const displayStorageKey = "middleman:workspaceListDisplayOptions";
 
 const validSorts = new Set<WorkspaceListSort>(workspaceListSortOptions.map((option) => option.value));
 
@@ -46,7 +57,7 @@ export function loadWorkspaceListSort(): WorkspaceListSort {
   if (!storage) return defaultWorkspaceListSort;
 
   try {
-    const value = storage.getItem(storageKey) as WorkspaceListSort | null;
+    const value = storage.getItem(sortStorageKey) as WorkspaceListSort | null;
     return value && validSorts.has(value) ? value : defaultWorkspaceListSort;
   } catch {
     return defaultWorkspaceListSort;
@@ -58,8 +69,41 @@ export function saveWorkspaceListSort(sort: WorkspaceListSort): void {
   if (!storage) return;
 
   try {
-    storage.setItem(storageKey, sort);
+    storage.setItem(sortStorageKey, sort);
   } catch {
     // Storage blocked - the sort still applies for the current page instance.
+  }
+}
+
+export function loadWorkspaceListDisplayOptions(): WorkspaceListDisplayOptions {
+  const storage = getStorage();
+  if (!storage) return { ...defaultWorkspaceListDisplayOptions };
+
+  try {
+    const raw = storage.getItem(displayStorageKey);
+    if (!raw) return { ...defaultWorkspaceListDisplayOptions };
+
+    const value = JSON.parse(raw) as Partial<WorkspaceListDisplayOptions>;
+    return {
+      showOrgNames:
+        typeof value.showOrgNames === "boolean" ? value.showOrgNames : defaultWorkspaceListDisplayOptions.showOrgNames,
+      showDiffStats:
+        typeof value.showDiffStats === "boolean"
+          ? value.showDiffStats
+          : defaultWorkspaceListDisplayOptions.showDiffStats,
+    };
+  } catch {
+    return { ...defaultWorkspaceListDisplayOptions };
+  }
+}
+
+export function saveWorkspaceListDisplayOptions(options: WorkspaceListDisplayOptions): void {
+  const storage = getStorage();
+  if (!storage) return;
+
+  try {
+    storage.setItem(displayStorageKey, JSON.stringify(options));
+  } catch {
+    // Storage blocked - the display options still apply for this page instance.
   }
 }

--- a/frontend/src/lib/dev/viteConfig.test.ts
+++ b/frontend/src/lib/dev/viteConfig.test.ts
@@ -17,9 +17,13 @@ describe("vite config", () => {
     const uiSubpathAlias = aliases.find(
       (alias) => alias.find instanceof RegExp && alias.find.source === "^@middleman\\/ui\\/api\\/client$",
     );
+    const repoLabelAlias = aliases.find(
+      (alias) => alias.find instanceof RegExp && alias.find.source === "^@middleman\\/ui\\/utils\\/repo-label$",
+    );
 
     expect(uiRootAlias?.replacement).toBe(path.resolve(process.cwd(), "../packages/ui/src/index.ts"));
     expect(uiSubpathAlias?.replacement).toBe(path.resolve(process.cwd(), "../packages/ui/src/api/generated/client.ts"));
+    expect(repoLabelAlias?.replacement).toBe(path.resolve(process.cwd(), "../packages/ui/src/utils/repo-label.ts"));
   });
 
   it("pins the dev server host to IPv4 loopback", () => {

--- a/frontend/src/lib/utils/repoSelectionSync.test.ts
+++ b/frontend/src/lib/utils/repoSelectionSync.test.ts
@@ -21,24 +21,24 @@ const issueSelected = {
 };
 
 describe("globalRepoForSelectedRoute", () => {
-  it("returns platformHost/repoPath for a pulls route with a selected PR", () => {
+  it("returns provider|platformHost/repoPath for a pulls route with a selected PR", () => {
     const route: Route = {
       page: "pulls",
       view: "list",
       selected: prSelected,
     };
-    expect(globalRepoForSelectedRoute(route)).toBe("github.com/acme/tools");
+    expect(globalRepoForSelectedRoute(route)).toBe("github|github.com/acme/tools");
   });
 
-  it("returns platformHost/repoPath for an issues route with a selected issue", () => {
+  it("returns provider|platformHost/repoPath for an issues route with a selected issue", () => {
     const route: Route = {
       page: "issues",
       selected: issueSelected,
     };
-    expect(globalRepoForSelectedRoute(route)).toBe("gitlab.example.com/team/infra");
+    expect(globalRepoForSelectedRoute(route)).toBe("gitlab|gitlab.example.com/team/infra");
   });
 
-  it("returns platformHost/repoPath for a focus PR route", () => {
+  it("returns provider|platformHost/repoPath for a focus PR route", () => {
     const route: Route = {
       page: "focus",
       itemType: "pr",
@@ -49,10 +49,10 @@ describe("globalRepoForSelectedRoute", () => {
       repoPath: "acme/tools",
       number: 42,
     };
-    expect(globalRepoForSelectedRoute(route)).toBe("github.com/acme/tools");
+    expect(globalRepoForSelectedRoute(route)).toBe("github|github.com/acme/tools");
   });
 
-  it("returns platformHost/repoPath for a focus issue route", () => {
+  it("returns provider|platformHost/repoPath for a focus issue route", () => {
     const route: Route = {
       page: "focus",
       itemType: "issue",
@@ -63,7 +63,7 @@ describe("globalRepoForSelectedRoute", () => {
       repoPath: "team/infra",
       number: 7,
     };
-    expect(globalRepoForSelectedRoute(route)).toBe("gitlab.example.com/team/infra");
+    expect(globalRepoForSelectedRoute(route)).toBe("gitlab|gitlab.example.com/team/infra");
   });
 
   it("keeps nested repo paths intact", () => {
@@ -78,7 +78,35 @@ describe("globalRepoForSelectedRoute", () => {
         number: 17,
       },
     };
-    expect(globalRepoForSelectedRoute(route)).toBe("gitlab.example.com/Group/SubGroup/Project.Special");
+    expect(globalRepoForSelectedRoute(route)).toBe("gitlab|gitlab.example.com/Group/SubGroup/Project.Special");
+  });
+
+  it("keeps same-host same-path provider collisions distinct", () => {
+    const githubRoute: Route = {
+      page: "issues",
+      selected: {
+        provider: "github",
+        platformHost: "github.com",
+        owner: "acme",
+        name: "widgets",
+        repoPath: "acme/widgets",
+        number: 101,
+      },
+    };
+    const giteaRoute: Route = {
+      page: "issues",
+      selected: {
+        provider: "gitea",
+        platformHost: "github.com",
+        owner: "acme",
+        name: "widgets",
+        repoPath: "acme/widgets",
+        number: 901,
+      },
+    };
+
+    expect(globalRepoForSelectedRoute(githubRoute)).toBe("github|github.com/acme/widgets");
+    expect(globalRepoForSelectedRoute(giteaRoute)).toBe("gitea|github.com/acme/widgets");
   });
 
   it("returns undefined for a pulls list route without a selection", () => {
@@ -119,7 +147,7 @@ describe("globalRepoForSelectedRoute", () => {
     ).toBeUndefined();
   });
 
-  it("returns undefined when platformHost is missing on the selected item", () => {
+  it("throws when platformHost is missing on the selected item", () => {
     const route: Route = {
       page: "pulls",
       view: "list",
@@ -131,6 +159,21 @@ describe("globalRepoForSelectedRoute", () => {
         number: 42,
       },
     };
-    expect(globalRepoForSelectedRoute(route)).toBeUndefined();
+    expect(() => globalRepoForSelectedRoute(route)).toThrow("selected route is missing platformHost");
+  });
+
+  it("throws when provider is missing on the selected item", () => {
+    const route = {
+      page: "pulls",
+      view: "list",
+      selected: {
+        platformHost: "github.com",
+        owner: "acme",
+        name: "tools",
+        repoPath: "acme/tools",
+        number: 42,
+      },
+    } as unknown as Route;
+    expect(() => globalRepoForSelectedRoute(route)).toThrow("selected route is missing provider");
   });
 });

--- a/frontend/src/lib/utils/repoSelectionSync.ts
+++ b/frontend/src/lib/utils/repoSelectionSync.ts
@@ -1,22 +1,36 @@
 import type { Route } from "../stores/router.svelte.ts";
 
+type SelectedRouteRepo = {
+  provider: string;
+  platformHost?: string | undefined;
+  repoPath: string;
+};
+
+function requireSelectedRouteRepoValue(value: string | undefined, field: string): string {
+  if (!value) {
+    throw new Error(`selected route is missing ${field}`);
+  }
+  return value;
+}
+
 // When the URL points at a specific PR or issue, returns the repo key
-// (`platformHost/repoPath`) that the global repo filter and dropdown should
-// follow. Returns undefined for routes that don't nail down a single item, or
-// when the selected item has no platformHost (which leaves the dropdown
-// without a stable match).
+// (`provider|platformHost/repoPath`) that the global repo filter and dropdown
+// should follow. Returns undefined for routes that don't nail down a single
+// item. Selected item routes must carry the static provider and host identity
+// from the route; missing values are route construction bugs.
 export function globalRepoForSelectedRoute(route: Route): string | undefined {
-  let selected: { platformHost?: string | undefined; repoPath: string } | undefined;
+  let selected: SelectedRouteRepo | undefined;
   if (route.page === "pulls" && "selected" in route && route.selected) {
     selected = route.selected;
   } else if (route.page === "issues" && route.selected) {
     selected = route.selected;
   } else if (route.page === "focus" && (route.itemType === "pr" || route.itemType === "issue")) {
-    selected = {
-      platformHost: route.platformHost,
-      repoPath: route.repoPath,
-    };
+    selected = route;
   }
-  if (!selected || !selected.platformHost) return undefined;
-  return `${selected.platformHost}/${selected.repoPath}`;
+  if (!selected) return undefined;
+
+  const provider = requireSelectedRouteRepoValue(selected.provider, "provider");
+  const platformHost = requireSelectedRouteRepoValue(selected.platformHost, "platformHost");
+  const repoPath = requireSelectedRouteRepoValue(selected.repoPath, "repoPath");
+  return `${provider}|${platformHost}/${repoPath}`;
 }

--- a/frontend/tests/e2e-full/00-workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e-full/00-workspace-sidebar.spec.ts
@@ -271,6 +271,85 @@ test.describe("workspace sidebar full-stack", () => {
     }
   });
 
+  test("view menu hides org names and PR diff stats against the real backend and persists", async ({ page }) => {
+    let isolatedServer: IsolatedE2EServer | null = null;
+    let api: APIRequestContext | null = null;
+    try {
+      isolatedServer = await startIsolatedWorkspaceE2EServer();
+      api = await playwrightRequest.newContext({
+        baseURL: isolatedServer.info.base_url,
+      });
+
+      // acme/widgets PR #1 ships real +240/-30 diff stats in the seeded
+      // fixture, so the rail renders its diff-stats chip from backend
+      // data rather than a route mock.
+      const createResponse = await api.post("/api/v1/workspaces", {
+        data: {
+          platform_host: "github.com",
+          owner: "acme",
+          name: "widgets",
+          mr_number: 1,
+        },
+      });
+      expect(createResponse.status()).toBe(202);
+      const workspace = (await createResponse.json()) as WorkspaceStatusResponse;
+      await waitForWorkspaceReady(api, workspace.id);
+
+      const workspacesResponse = await api.get("/api/v1/workspaces");
+      expect(workspacesResponse.ok()).toBe(true);
+      const workspacesPayload = (await workspacesResponse.json()) as {
+        workspaces: Array<{ id: string; mr_additions?: number | null; mr_deletions?: number | null }>;
+      };
+      const seeded = workspacesPayload.workspaces.find((entry) => entry.id === workspace.id);
+      expect(seeded?.mr_additions).toBe(240);
+      expect(seeded?.mr_deletions).toBe(30);
+
+      // The terminal route derives the rail width from the global
+      // sidebar width (clamped to 420px). Pin it wide so the 260px
+      // container query that hides diff stats can never fire and mask
+      // the toggle's effect.
+      await page.addInitScript(() => {
+        window.localStorage.setItem("middleman-sidebar-width", "420");
+      });
+
+      await page.goto(`${isolatedServer.info.base_url}/terminal/${workspace.id}`);
+
+      const groupLabel = page.locator(".workspace-list-sidebar .group-header .group-label");
+      const diffStats = page.locator(".workspace-list-sidebar .workspace-diff-stats");
+      const viewTrigger = page.getByTitle("View workspace options");
+      const viewBadge = viewTrigger.locator(".filter-badge");
+
+      // Defaults: org name shown in the repo label, diff stats visible.
+      await expect(groupLabel).toHaveText("acme/widgets");
+      await expect(diffStats).toBeVisible();
+      await expect(page.getByLabel("240 additions, 30 deletions")).toBeVisible();
+      await expect(viewBadge).toHaveCount(0);
+
+      // Visibility toggles do not close the menu, so both can be flipped
+      // in a single pass before dismissing it.
+      await viewTrigger.click();
+      await page.locator(".filter-dropdown .filter-item", { hasText: "Show org names" }).click();
+      await page.locator(".filter-dropdown .filter-item", { hasText: "Show PR diff stats" }).click();
+      await page.keyboard.press("Escape");
+
+      await expect(groupLabel).toHaveText("widgets");
+      await expect(diffStats).toHaveCount(0);
+      // Branch metadata survives hiding the diff stats.
+      await expect(page.locator(".workspace-list-sidebar .ws-row .branch-chip")).toBeVisible();
+      // Both deviations from default register on the trigger badge.
+      await expect(viewBadge).toHaveText("2");
+
+      // Both choices persist against the real backend across a reload.
+      await page.reload();
+      await expect(groupLabel).toHaveText("widgets");
+      await expect(diffStats).toHaveCount(0);
+      await expect(viewBadge).toHaveText("2");
+    } finally {
+      await api?.dispose();
+      await isolatedServer?.stop();
+    }
+  });
+
   test("filters real workspace API results and expands collapsed matches during search", async ({ page }) => {
     let isolatedServer: IsolatedE2EServer | null = null;
     let api: APIRequestContext | null = null;

--- a/frontend/tests/e2e-full/00-workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e-full/00-workspace-sidebar.spec.ts
@@ -231,7 +231,7 @@ test.describe("workspace sidebar full-stack", () => {
       await expect(rows).toHaveCount(2);
       await expect(headers).toHaveCount(2);
 
-      await page.getByTitle("Sort workspaces").click();
+      await page.getByTitle("View workspace options").click();
       await page.locator(".filter-dropdown .filter-item", { hasText: "Created" }).click();
 
       // Flat list ordered by the real created_at column: the
@@ -251,7 +251,7 @@ test.describe("workspace sidebar full-stack", () => {
       await expect(headers).toHaveCount(0);
       await expect(rows.first().locator(".repo-context")).toContainText("group/project");
 
-      await page.getByTitle("Sort workspaces").click();
+      await page.getByTitle("View workspace options").click();
       await page.locator(".filter-dropdown .filter-item", { hasText: "Item activity" }).click();
 
       await expect(headers).toHaveCount(0);

--- a/frontend/tests/e2e-full/mobile-routes.spec.ts
+++ b/frontend/tests/e2e-full/mobile-routes.spec.ts
@@ -352,13 +352,13 @@ test.describe("phone routes", () => {
       name: "Hide org",
     });
     await expect(hideOrgToggle).toHaveAttribute("aria-pressed", "false");
-    await expect(repoLabel).toHaveText("github.com/acme/widgets");
+    await expect(repoLabel).toHaveText("acme/widgets");
 
     await hideOrgToggle.click();
 
     await expect(hideOrgToggle).toHaveAttribute("aria-pressed", "true");
     await expect(repoLabel).toHaveText("widgets");
-    await expect(repoLabel).not.toHaveText("github.com/acme/widgets");
+    await expect(repoLabel).not.toHaveText("acme/widgets");
 
     await page.reload();
 

--- a/frontend/tests/e2e-full/repo-filter-multiselect.spec.ts
+++ b/frontend/tests/e2e-full/repo-filter-multiselect.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test, type Page } from "@playwright/test";
 
+import { startIsolatedE2EServerWithOptions } from "./support/e2eServer.js";
+
 async function waitForIssueList(page: Page): Promise<void> {
   await page.locator(".issue-item").first().waitFor({ state: "visible", timeout: 10_000 });
 }
@@ -52,6 +54,41 @@ test("repository selector normalizes stale provider-qualified persisted multi-se
   await expect(page.getByText("Widget rendering broken on Safari")).toBeVisible();
   await expect(page.getByText("Support config file loading")).toBeVisible();
   await expect(page.getByText("GitLab read-only issue")).toHaveCount(0);
+});
+
+test("repository selector persists provider-qualified filters for provider collisions", async ({ browser }) => {
+  const server = await startIsolatedE2EServerWithOptions({ providerCollision: true });
+  const page = await browser.newPage();
+  try {
+    await page.goto(`${server.info.base_url}/issues`);
+    await waitForIssueList(page);
+
+    const selector = page.getByTitle("Select repository");
+    await selector.click();
+
+    const input = page.getByPlaceholder("Filter repos...");
+    await input.fill("gitea/widgets");
+
+    const giteaRow = page.getByRole("option", {
+      name: "gitea/github.com/acme/widgets",
+      exact: true,
+    });
+    await expect(giteaRow).toBeVisible();
+    await expect(giteaRow.locator(".repo-tree-label")).toHaveText("gitea/widgets");
+    await expect(page.getByRole("option", { name: "github/github.com/acme/widgets", exact: true })).toHaveCount(0);
+
+    await giteaRow.click();
+    await page.keyboard.press("Escape");
+
+    await expect
+      .poll(() => page.evaluate(() => localStorage.getItem("middleman-filter-repo")))
+      .toBe("gitea|github.com/acme/widgets");
+    await expect(page.getByText("Gitea provider collision issue")).toBeVisible();
+    await expect(page.getByText("Widget rendering broken on Safari")).toHaveCount(0);
+  } finally {
+    await page.close();
+    await server.stop();
+  }
 });
 
 test("keyboard navigation survives a real checkbox click", async ({ page }) => {

--- a/frontend/tests/e2e-full/repo-filter-multiselect.spec.ts
+++ b/frontend/tests/e2e-full/repo-filter-multiselect.spec.ts
@@ -36,6 +36,24 @@ test("repository selector filters dashboard lists by multiple selected repos", a
   );
 });
 
+test("repository selector normalizes stale provider-qualified persisted multi-select values", async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem("middleman-filter-repo", "github/github.com/acme/widgets,github.com/acme/tools");
+  });
+
+  await page.goto("/issues");
+  await waitForIssueList(page);
+
+  await expect
+    .poll(() => page.evaluate(() => localStorage.getItem("middleman-filter-repo")))
+    .toBe("github.com/acme/widgets,github.com/acme/tools");
+  await expect(page.getByTitle("Select repository").locator(".typeahead-value")).toHaveText("2 repos");
+
+  await expect(page.getByText("Widget rendering broken on Safari")).toBeVisible();
+  await expect(page.getByText("Support config file loading")).toBeVisible();
+  await expect(page.getByText("GitLab read-only issue")).toHaveCount(0);
+});
+
 test("keyboard navigation survives a real checkbox click", async ({ page }) => {
   // A real click (not just mousedown) on a row checkbox must not steal focus
   // from the filter input. The checkbox is a focusable native input and its

--- a/frontend/tests/e2e-full/support/e2eServer.ts
+++ b/frontend/tests/e2e-full/support/e2eServer.ts
@@ -24,6 +24,7 @@ export type IsolatedE2EServer = {
 export type IsolatedE2EServerOptions = {
   defaultPlatformHost?: string;
   visibleImportedModes?: boolean;
+  providerCollision?: boolean;
   // Spawn a dedicated server process and kill it on stop() instead of
   // leasing from the per-worker pool. Required when the test depends
   // on process environment the server must inherit at spawn time
@@ -295,6 +296,9 @@ async function spawnServer(
   if (options.visibleImportedModes) {
     args.push("-visible-imported-modes");
   }
+  if (options.providerCollision) {
+    args.push("-provider-collision");
+  }
   if (process.env.ROBOREV_ENDPOINT) {
     args.push("-roborev", process.env.ROBOREV_ENDPOINT);
   }
@@ -383,6 +387,7 @@ export async function ensureE2EServer(): Promise<E2EServerInfo> {
       const server = await spawnPooledServer({
         host: defaultPlatformHost,
         visibleImportedModes: true,
+        providerCollision: false,
       });
       // Permanently leased: this is the worker's shared server; the
       // isolated-server pool must never hand it out or reset it.
@@ -453,6 +458,7 @@ export async function stopE2EServer(): Promise<void> {
 type PooledServerOptions = {
   host: string;
   visibleImportedModes: boolean;
+  providerCollision: boolean;
 };
 
 type PooledServer = {
@@ -468,6 +474,7 @@ type PooledServer = {
 const defaultPooledOptions: PooledServerOptions = {
   host: defaultPlatformHost,
   visibleImportedModes: false,
+  providerCollision: false,
 };
 
 // Env vars that steer a spawned e2e server's behavior. A pooled
@@ -497,11 +504,16 @@ function normalizedPooledOptions(options: IsolatedE2EServerOptions): PooledServe
   return {
     host: options.defaultPlatformHost ?? defaultPlatformHost,
     visibleImportedModes: options.visibleImportedModes ?? false,
+    providerCollision: options.providerCollision ?? false,
   };
 }
 
 function samePooledOptions(a: PooledServerOptions, b: PooledServerOptions): boolean {
-  return a.host === b.host && a.visibleImportedModes === b.visibleImportedModes;
+  return (
+    a.host === b.host &&
+    a.visibleImportedModes === b.visibleImportedModes &&
+    a.providerCollision === b.providerCollision
+  );
 }
 
 const isolatedPool: PooledServer[] = [];
@@ -566,6 +578,7 @@ async function postReset(baseURL: string, options: PooledServerOptions): Promise
       JSON.stringify({
         default_platform_host: options.host,
         visible_imported_modes: options.visibleImportedModes,
+        provider_collision: options.providerCollision,
       }),
     );
   });
@@ -604,6 +617,7 @@ async function spawnPooledServer(options: PooledServerOptions): Promise<PooledSe
   const started = await spawnServer(infoFile, {
     ...(options.host === defaultPlatformHost ? {} : { defaultPlatformHost: options.host }),
     ...(options.visibleImportedModes ? { visibleImportedModes: true } : {}),
+    ...(options.providerCollision ? { providerCollision: true } : {}),
   });
   // The info is in memory now; the temp dir is no longer needed.
   await rm(infoDir, { force: true, recursive: true });

--- a/frontend/tests/e2e/mobile-activity-repos.spec.ts
+++ b/frontend/tests/e2e/mobile-activity-repos.spec.ts
@@ -110,7 +110,7 @@ test.describe("mobile activity repository selector", () => {
     await expect(page.getByRole("combobox", { name: "Repository: gitea/github.com/acme/widgets" })).toHaveText(
       "gitea/github.com/acme/widgets",
     );
-    await expect.poll(() => activityRepos).toContain("gitea/github.com/acme/widgets");
+    await expect.poll(() => activityRepos).toContain("gitea|github.com/acme/widgets");
   });
 
   test("groups and labels activity from nested repo identity", async ({ page }) => {

--- a/frontend/tests/e2e/mobile-activity-repos.spec.ts
+++ b/frontend/tests/e2e/mobile-activity-repos.spec.ts
@@ -31,6 +31,15 @@ async function mockMobileRepoSettings(page: Page): Promise<string[]> {
             matched_repo_count: 1,
           },
           {
+            provider: "gitea",
+            platform_host: "github.com",
+            owner: "acme",
+            name: "widgets",
+            repo_path: "acme/widgets",
+            is_glob: false,
+            matched_repo_count: 1,
+          },
+          {
             provider: "github",
             platform_host: "github.com",
             owner: "acme",
@@ -88,7 +97,8 @@ test.describe("mobile activity repository selector", () => {
 
     await repoSelect.click();
     await expect(page.getByRole("option", { name: "All repos" })).toBeVisible();
-    await expect(page.getByRole("option", { name: "github.com/acme/widgets" })).toBeVisible();
+    await expect(page.getByRole("option", { name: "github/github.com/acme/widgets" })).toBeVisible();
+    await expect(page.getByRole("option", { name: "gitea/github.com/acme/widgets" })).toBeVisible();
     await expect(
       page.getByRole("option", {
         name: "ghe.example.com/acme/widgets",
@@ -96,11 +106,11 @@ test.describe("mobile activity repository selector", () => {
     ).toBeVisible();
     await expect(page.getByRole("option", { name: "acme/*" })).toHaveCount(0);
 
-    await page.getByRole("option", { name: "ghe.example.com/acme/widgets" }).click();
-    await expect(page.getByRole("combobox", { name: "Repository: ghe.example.com/acme/widgets" })).toHaveText(
-      "ghe.example.com/acme/widgets",
+    await page.getByRole("option", { name: "gitea/github.com/acme/widgets" }).click();
+    await expect(page.getByRole("combobox", { name: "Repository: gitea/github.com/acme/widgets" })).toHaveText(
+      "gitea/github.com/acme/widgets",
     );
-    await expect.poll(() => activityRepos).toContain("ghe.example.com/acme/widgets");
+    await expect.poll(() => activityRepos).toContain("gitea/github.com/acme/widgets");
   });
 
   test("groups and labels activity from nested repo identity", async ({ page }) => {

--- a/frontend/tests/e2e/mobile-activity-repos.spec.ts
+++ b/frontend/tests/e2e/mobile-activity-repos.spec.ts
@@ -154,6 +154,27 @@ test.describe("mobile activity repository selector", () => {
                 capabilities: {},
               },
             },
+            {
+              id: "c1",
+              cursor: "c1",
+              activity_type: "comment",
+              author: "sam",
+              body_preview: "Same host, different provider",
+              created_at: "2026-03-30T12:00:00Z",
+              item_number: 42,
+              item_state: "open",
+              item_title: "Add browser regression coverage",
+              item_type: "pr",
+              item_url: "https://github.com/acme/widgets/pull/42",
+              repo: {
+                provider: "gitea",
+                platform_host: "github.com",
+                owner: "acme",
+                name: "widgets",
+                repo_path: "acme/widgets",
+                capabilities: {},
+              },
+            },
           ],
         }),
       });
@@ -161,10 +182,15 @@ test.describe("mobile activity repository selector", () => {
 
     await page.goto("/m?range=30d&view=threaded");
 
-    await expect(page.locator(".mobile-activity-card")).toHaveCount(2);
+    await expect(page.locator(".mobile-activity-card")).toHaveCount(3);
     await expect(
       page.locator(".mobile-activity-card__meta", {
-        hasText: "github.com/acme/widgets",
+        hasText: "github/github.com/acme/widgets",
+      }),
+    ).toBeVisible();
+    await expect(
+      page.locator(".mobile-activity-card__meta", {
+        hasText: "gitea/github.com/acme/widgets",
       }),
     ).toBeVisible();
     await expect(

--- a/frontend/tests/e2e/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar.spec.ts
@@ -3564,7 +3564,7 @@ test.describe("workspace list sorting", () => {
     await expect(names).toHaveText(["Newest created", "Oldest without activity", "Most recently active"]);
     await expect(headers).toHaveCount(2);
 
-    const sortTrigger = page.getByTitle("Sort workspaces");
+    const sortTrigger = page.getByTitle("View workspace options");
     await sortTrigger.click();
     await page.locator(".filter-dropdown").getByRole("button", { name: "Created" }).click();
 
@@ -3591,10 +3591,10 @@ test.describe("workspace list sorting", () => {
     await expect(names).toHaveText(["Newest created", "Oldest without activity", "Most recently active"]);
   });
 
-  test("sort trigger hugs the collapse toggle and the dropdown opens left-aligned", async ({ page }) => {
+  test("view trigger hugs the collapse toggle and the dropdown opens end-aligned", async ({ page }) => {
     await page.goto("/workspaces");
 
-    const trigger = page.getByTitle("Sort workspaces");
+    const trigger = page.getByTitle("View workspace options");
     const toggle = page.getByRole("button", { name: "Collapse Workspaces sidebar" });
     await expect(trigger).toBeVisible();
     await expect(toggle).toBeVisible();
@@ -3618,9 +3618,11 @@ test.describe("workspace list sorting", () => {
     const dropdownBox = await dropdown.boundingBox();
     expect(dropdownBox).not.toBeNull();
 
-    // Regression: align="end" used to hang the panel out to the
-    // left over the filter input. Left edges must align instead.
-    expect(Math.abs(dropdownBox!.x - triggerBox!.x)).toBeLessThanOrEqual(1.5);
+    // The wider View menu is end-aligned so it stays inside the
+    // rail while the trigger remains beside the collapse toggle.
+    expect(Math.abs(dropdownBox!.x + dropdownBox!.width - (triggerBox!.x + triggerBox!.width))).toBeLessThanOrEqual(
+      1.5,
+    );
   });
 });
 

--- a/frontend/tests/e2e/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar.spec.ts
@@ -2,9 +2,9 @@ import { expect, test } from "@playwright/test";
 
 import { mockApi } from "./support/mockApi";
 
-function workspaceRepoRef(owner = "acme", name = "widgets", host = "github.com") {
+function workspaceRepoRef(owner = "acme", name = "widgets", host = "github.com", provider = "github") {
   return {
-    provider: "github",
+    provider,
     platform_host: host,
     owner,
     name,
@@ -3589,6 +3589,81 @@ test.describe("workspace list sorting", () => {
 
     await expect(headers).toHaveCount(2);
     await expect(names).toHaveText(["Newest created", "Oldest without activity", "Most recently active"]);
+  });
+
+  test("toggles visibility options and persists provider-aware labels", async ({ page }) => {
+    const wsGithub = {
+      ...testWorkspace,
+      id: "ws-github-provider",
+      item_number: 10,
+      mr_title: "GitHub provider workspace",
+      mr_additions: 8,
+      mr_deletions: 3,
+    };
+    const wsGitea = {
+      ...testWorkspace,
+      id: "ws-gitea-provider",
+      repo: workspaceRepoRef("acme", "widgets", "github.com", "gitea"),
+      item_number: 11,
+      mr_title: "Gitea provider workspace",
+      mr_additions: 5,
+      mr_deletions: 1,
+    };
+    const wsMiddleman = {
+      ...testWorkspace,
+      id: "ws-middleman",
+      repo_owner: "kenn-io",
+      repo_name: "middleman",
+      repo: workspaceRepoRef("kenn-io", "middleman"),
+      item_number: 12,
+      mr_title: "Middleman workspace",
+      mr_additions: 13,
+      mr_deletions: 2,
+    };
+
+    await page.route("**/api/v1/workspaces", async (route) => {
+      if (route.request().method() === "GET") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ workspaces: [wsGithub, wsGitea, wsMiddleman] }),
+        });
+        return;
+      }
+      await route.fulfill({ status: 200 });
+    });
+
+    await page.goto("/workspaces");
+
+    const groupLabels = page.locator(".workspace-list-sidebar .group-label");
+    await expect(groupLabels).toHaveText([
+      "github/github.com/acme/widgets",
+      "gitea/github.com/acme/widgets",
+      "kenn-io/middleman",
+    ]);
+    await expect(page.locator(".workspace-list-sidebar .workspace-diff-stats")).toHaveCount(3);
+
+    const viewTrigger = page.getByTitle("View workspace options");
+    await viewTrigger.click();
+    await page.locator(".filter-dropdown").getByRole("button", { name: "Show org names" }).click();
+
+    await expect(groupLabels).toHaveText([
+      "github/github.com/acme/widgets",
+      "gitea/github.com/acme/widgets",
+      "middleman",
+    ]);
+
+    await page.locator(".filter-dropdown").getByRole("button", { name: "Show PR diff stats" }).click();
+    await expect(page.locator(".workspace-list-sidebar .workspace-diff-stats")).toHaveCount(0);
+
+    await page.reload();
+
+    await expect(groupLabels).toHaveText([
+      "github/github.com/acme/widgets",
+      "gitea/github.com/acme/widgets",
+      "middleman",
+    ]);
+    await expect(page.locator(".workspace-list-sidebar .workspace-diff-stats")).toHaveCount(0);
   });
 
   test("view trigger hugs the collapse toggle and the dropdown opens end-aligned", async ({ page }) => {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -25,6 +25,7 @@ const uiGeneratedSchema = path.resolve(process.cwd(), "../packages/ui/src/api/ge
 const uiApiTypes = path.resolve(process.cwd(), "../packages/ui/src/api/types.ts");
 const uiApiCsrf = path.resolve(process.cwd(), "../packages/ui/src/api/csrf.ts");
 const uiRoutes = path.resolve(process.cwd(), "../packages/ui/src/routes.ts");
+const uiRepoLabel = path.resolve(process.cwd(), "../packages/ui/src/utils/repo-label.ts");
 const uiStoreDetail = path.resolve(process.cwd(), "../packages/ui/src/stores/detail.svelte.ts");
 const uiStoreEvents = path.resolve(process.cwd(), "../packages/ui/src/stores/events.svelte.ts");
 const uiStorePulls = path.resolve(process.cwd(), "../packages/ui/src/stores/pulls.svelte.ts");
@@ -252,6 +253,10 @@ const config = {
       {
         find: /^@middleman\/ui\/routes$/,
         replacement: uiRoutes,
+      },
+      {
+        find: /^@middleman\/ui\/utils\/repo-label$/,
+        replacement: uiRepoLabel,
       },
       {
         find: /^@middleman\/ui\/stores\/detail$/,

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -3204,7 +3204,7 @@ type ListStacksParams struct {
 
 // TriggerSyncParams defines parameters for TriggerSync.
 type TriggerSyncParams struct {
-	// PriorityRepo Optional repository filters to sync first. Accepts repeated values or comma-separated values. Each value may be host-qualified as platform_host/owner/name or bare as owner/name; bare values match the first tracked repo with that repo path.
+	// PriorityRepo Optional repository filters to sync first. Accepts repeated values or comma-separated values. Each value may be provider-qualified as provider|platform_host/owner/name, host-qualified as platform_host/owner/name, or bare as owner/name; bare values match the first tracked repo with that repo path.
 	PriorityRepo *[]string `form:"priority_repo,omitempty" json:"priority_repo,omitempty"`
 }
 

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -2827,6 +2827,7 @@ type WorktreeSummary struct {
 
 // ListActivityParams defines parameters for ListActivity.
 type ListActivityParams struct {
+	// Repo Repository filter. Accepts owner/name, platform_host/repo_path, comma-separated values, or provider|platform_host/repo_path for provider-qualified matches.
 	Repo   *string   `form:"repo,omitempty" json:"repo,omitempty"`
 	Types  *[]string `form:"types,omitempty" json:"types,omitempty"`
 	Search *string   `form:"search,omitempty" json:"search,omitempty"`
@@ -3064,6 +3065,7 @@ type ResolveRepoItemOnHostParamsItemType string
 
 // ListIssuesParams defines parameters for ListIssues.
 type ListIssuesParams struct {
+	// Repo Repository filter. Accepts owner/name, platform_host/repo_path, comma-separated values, or provider|platform_host/repo_path for provider-qualified matches.
 	Repo     *string `form:"repo,omitempty" json:"repo,omitempty"`
 	State    *string `form:"state,omitempty" json:"state,omitempty"`
 	Starred  *bool   `form:"starred,omitempty" json:"starred,omitempty"`
@@ -3123,6 +3125,7 @@ type ListUserRepositoriesParams struct {
 
 // ListPullsParams defines parameters for ListPulls.
 type ListPullsParams struct {
+	// Repo Repository filter. Accepts owner/name, platform_host/repo_path, comma-separated values, or provider|platform_host/repo_path for provider-qualified matches.
 	Repo    *string `form:"repo,omitempty" json:"repo,omitempty"`
 	State   *string `form:"state,omitempty" json:"state,omitempty"`
 	Kanban  *string `form:"kanban,omitempty" json:"kanban,omitempty"`

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -122,6 +122,10 @@ func repoListFilterCondition(repoAlias string, filters []RepoFilter, args *[]any
 	for _, filter := range filters {
 		var clauses []string
 		if filter.RepoPath != "" {
+			if filter.Platform != "" {
+				clauses = append(clauses, repoAlias+".platform = ?")
+				*args = append(*args, strings.ToLower(strings.TrimSpace(filter.Platform)))
+			}
 			if filter.PlatformHost != "" {
 				host, _, _ := canonicalRepoLookupIdentifier(filter.PlatformHost, "", "")
 				clauses = append(clauses, repoAlias+".platform_host = ?")
@@ -133,6 +137,10 @@ func repoListFilterCondition(repoAlias string, filters []RepoFilter, args *[]any
 			_, owner, name := canonicalRepoLookupIdentifier(
 				"", filter.RepoOwner, filter.RepoName,
 			)
+			if filter.Platform != "" {
+				clauses = append(clauses, repoAlias+".platform = ?")
+				*args = append(*args, strings.ToLower(strings.TrimSpace(filter.Platform)))
+			}
 			if filter.PlatformHost != "" {
 				host, _, _ := canonicalRepoLookupIdentifier(filter.PlatformHost, "", "")
 				clauses = append(clauses, repoAlias+".platform_host = ?")

--- a/internal/db/queries_activity.go
+++ b/internal/db/queries_activity.go
@@ -272,6 +272,10 @@ func activityRepoFilterCondition(filters []RepoFilter, args *[]any) string {
 			if pathKey == "" {
 				continue
 			}
+			if filter.Platform != "" {
+				clauses = append(clauses, "platform = ?")
+				*args = append(*args, strings.ToLower(strings.TrimSpace(filter.Platform)))
+			}
 			if filter.PlatformHost != "" {
 				host, _, _ := canonicalRepoLookupIdentifier(filter.PlatformHost, "", "")
 				clauses = append(clauses, "platform_host = ?")
@@ -280,6 +284,10 @@ func activityRepoFilterCondition(filters []RepoFilter, args *[]any) string {
 			clauses = append(clauses, "repo_path_key = ?")
 			*args = append(*args, pathKey)
 		} else if filter.RepoOwner != "" && filter.RepoName != "" {
+			if filter.Platform != "" {
+				clauses = append(clauses, "platform = ?")
+				*args = append(*args, strings.ToLower(strings.TrimSpace(filter.Platform)))
+			}
 			if filter.PlatformHost != "" {
 				host, _, _ := canonicalRepoLookupIdentifier(filter.PlatformHost, "", "")
 				clauses = append(clauses, "platform_host = ?")

--- a/internal/db/queries_activity_test.go
+++ b/internal/db/queries_activity_test.go
@@ -123,6 +123,46 @@ func TestListActivity(t *testing.T) {
 		})
 	})
 
+	t.Run("provider qualified repo filter", func(t *testing.T) {
+		assert := Assert.New(t)
+		require := require.New(t)
+		d := openTestDB(t)
+		ctx := t.Context()
+		base := baseTime()
+
+		githubRepo, err := d.UpsertRepo(ctx, RepoIdentity{
+			Platform:     "github",
+			PlatformHost: "github.com",
+			Owner:        "acme",
+			Name:         "widgets",
+		})
+		require.NoError(err)
+		giteaRepo, err := d.UpsertRepo(ctx, RepoIdentity{
+			Platform:     "gitea",
+			PlatformHost: "github.com",
+			Owner:        "acme",
+			Name:         "widgets",
+		})
+		require.NoError(err)
+		insertTestMR(t, d, githubRepo, 1, "github provider", base)
+		insertTestMR(t, d, giteaRepo, 2, "gitea provider", base.Add(time.Hour))
+
+		items, err := d.ListActivity(ctx, ListActivityOpts{
+			Repo: "gitea/github.com/acme/widgets",
+			RepoFilters: []RepoFilter{{
+				Platform:     "gitea",
+				PlatformHost: "github.com",
+				RepoPath:     "acme/widgets",
+			}},
+			Limit: 50,
+		})
+		require.NoError(err)
+		require.Len(items, 1)
+		assert.Equal("gitea", items[0].Platform)
+		assert.Equal("github.com", items[0].PlatformHost)
+		assert.Equal(2, items[0].ItemNumber)
+	})
+
 	t.Run("type filter", func(t *testing.T) {
 		assert := Assert.New(t)
 		items, err := d.ListActivity(ctx, ListActivityOpts{

--- a/internal/db/queries_activity_test.go
+++ b/internal/db/queries_activity_test.go
@@ -148,7 +148,7 @@ func TestListActivity(t *testing.T) {
 		insertTestMR(t, d, giteaRepo, 2, "gitea provider", base.Add(time.Hour))
 
 		items, err := d.ListActivity(ctx, ListActivityOpts{
-			Repo: "gitea/github.com/acme/widgets",
+			Repo: "gitea|github.com/acme/widgets",
 			RepoFilters: []RepoFilter{{
 				Platform:     "gitea",
 				PlatformHost: "github.com",

--- a/internal/db/types.go
+++ b/internal/db/types.go
@@ -365,6 +365,7 @@ type ListMergeRequestsOpts struct {
 }
 
 type RepoFilter struct {
+	Platform     string
 	PlatformHost string
 	RepoOwner    string
 	RepoName     string

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -3130,6 +3130,20 @@ type dedupGetUserClient struct {
 	mockClient
 	getUserCount atomic.Int32
 	block        chan struct{}
+	author       string
+	now          time.Time
+}
+
+func (c *dedupGetUserClient) ListOpenPullRequests(
+	_ context.Context, _, repo string,
+) ([]*gh.PullRequest, error) {
+	number := 1
+	if repo == "r2" {
+		number = 2
+	}
+	pr := buildOpenPR(number, c.now)
+	pr.User = &gh.User{Login: &c.author}
+	return []*gh.PullRequest{pr}, nil
 }
 
 func (c *dedupGetUserClient) GetUser(
@@ -3149,17 +3163,10 @@ func TestResolveDisplayNameDedupsConcurrentLookups(t *testing.T) {
 	author := "alice"
 	now := time.Date(2026, 4, 8, 12, 0, 0, 0, time.UTC)
 
-	// Build two PRs in two repos, both authored by "alice".
-	buildAuthoredPR := func(num int) *gh.PullRequest {
-		pr := buildOpenPR(num, now)
-		pr.User = &gh.User{Login: &author}
-		return pr
-	}
-
-	mc := &dedupGetUserClient{block: make(chan struct{})}
-	mc.openPRs = []*gh.PullRequest{
-		buildAuthoredPR(1),
-		buildAuthoredPR(2),
+	mc := &dedupGetUserClient{
+		block:  make(chan struct{}),
+		author: author,
+		now:    now,
 	}
 
 	syncer := NewSyncer(

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -6534,6 +6534,17 @@ func seedIssueOnHost(
 	repoID, err := database.UpsertRepo(ctx, db.GitHubRepoIdentity(host, owner, name))
 	require.NoError(t, err)
 
+	return seedIssueForRepo(t, database, repoID, host, owner, name, number, state, title)
+}
+
+func seedIssueForRepo(
+	t *testing.T, database *db.DB,
+	repoID int64, host, owner, name string, number int,
+	state, title string,
+) int64 {
+	t.Helper()
+	ctx := t.Context()
+
 	now := time.Now().UTC().Truncate(time.Second)
 	issue := &db.Issue{
 		RepoID:         repoID,
@@ -7627,6 +7638,43 @@ func TestAPIListPullsFiltersHostedNestedRepoPath(t *testing.T) {
 	assert.Equal("project.special", (*resp.JSON200)[0].RepoName)
 }
 
+func TestAPIListPullsAcceptsProviderQualifiedRepoFilter(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	srv, database := setupTestServer(t)
+	client := setupTestClient(t, srv)
+	ctx := t.Context()
+
+	githubRepo, err := database.UpsertRepo(ctx, db.RepoIdentity{
+		Platform:     "github",
+		PlatformHost: "github.com",
+		Owner:        "acme",
+		Name:         "widget",
+	})
+	require.NoError(err)
+	giteaRepo, err := database.UpsertRepo(ctx, db.RepoIdentity{
+		Platform:     "gitea",
+		PlatformHost: "github.com",
+		Owner:        "acme",
+		Name:         "widget",
+	})
+	require.NoError(err)
+	seedPRForRepo(t, database, githubRepo, "github.com", "acme", "widget", 1)
+	seedPRForRepo(t, database, giteaRepo, "github.com", "acme", "widget", 2)
+
+	repo := "gitea|github.com/acme/widget"
+	resp, err := client.HTTP.ListPullsWithResponse(ctx, &generated.ListPullsParams{Repo: &repo})
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode())
+	require.NotNil(resp.JSON200)
+	require.Len(*resp.JSON200, 1)
+	assert.Equal("gitea", (*resp.JSON200)[0].Repo.Provider)
+	assert.Equal("github.com", (*resp.JSON200)[0].PlatformHost)
+	assert.Equal("acme", (*resp.JSON200)[0].RepoOwner)
+	assert.Equal("widget", (*resp.JSON200)[0].RepoName)
+	assert.EqualValues(2, (*resp.JSON200)[0].Number)
+}
+
 func TestAPIListIssuesIncludesLabels(t *testing.T) {
 	require := require.New(t)
 	srv, database := setupTestServer(t)
@@ -7739,6 +7787,43 @@ func TestAPIListIssuesFiltersHostedNestedRepoPath(t *testing.T) {
 	assert.Equal("group/subgroup", (*resp.JSON200)[0].RepoOwner)
 	assert.Equal("project.special", (*resp.JSON200)[0].RepoName)
 	assert.EqualValues(1, (*resp.JSON200)[0].Number)
+}
+
+func TestAPIListIssuesAcceptsProviderQualifiedRepoFilter(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	srv, database := setupTestServer(t)
+	client := setupTestClient(t, srv)
+	ctx := t.Context()
+
+	githubRepo, err := database.UpsertRepo(ctx, db.RepoIdentity{
+		Platform:     "github",
+		PlatformHost: "github.com",
+		Owner:        "acme",
+		Name:         "widget",
+	})
+	require.NoError(err)
+	giteaRepo, err := database.UpsertRepo(ctx, db.RepoIdentity{
+		Platform:     "gitea",
+		PlatformHost: "github.com",
+		Owner:        "acme",
+		Name:         "widget",
+	})
+	require.NoError(err)
+	seedIssueForRepo(t, database, githubRepo, "github.com", "acme", "widget", 1, "open", "GitHub issue")
+	seedIssueForRepo(t, database, giteaRepo, "github.com", "acme", "widget", 2, "open", "Gitea issue")
+
+	repo := "gitea|github.com/acme/widget"
+	resp, err := client.HTTP.ListIssuesWithResponse(ctx, &generated.ListIssuesParams{Repo: &repo})
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode())
+	require.NotNil(resp.JSON200)
+	require.Len(*resp.JSON200, 1)
+	assert.Equal("gitea", (*resp.JSON200)[0].Repo.Provider)
+	assert.Equal("github.com", (*resp.JSON200)[0].PlatformHost)
+	assert.Equal("acme", (*resp.JSON200)[0].RepoOwner)
+	assert.Equal("widget", (*resp.JSON200)[0].RepoName)
+	assert.EqualValues(2, (*resp.JSON200)[0].Number)
 }
 
 func TestAPIGetIssueUsesPlatformHostQuery(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -18168,6 +18168,83 @@ func TestAPIListActivityAcceptsHostQualifiedRepoFilter(t *testing.T) {
 	}
 }
 
+func TestAPIListActivityAcceptsProviderQualifiedRepoFilter(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	srv, database := setupTestServer(t)
+	client := setupTestClient(t, srv)
+	ctx := t.Context()
+
+	githubRepo, err := database.UpsertRepo(ctx, db.RepoIdentity{
+		Platform:     "github",
+		PlatformHost: "github.com",
+		Owner:        "acme",
+		Name:         "widget",
+	})
+	require.NoError(err)
+	giteaRepo, err := database.UpsertRepo(ctx, db.RepoIdentity{
+		Platform:     "gitea",
+		PlatformHost: "github.com",
+		Owner:        "acme",
+		Name:         "widget",
+	})
+	require.NoError(err)
+	seedPRForRepo(t, database, githubRepo, "github.com", "acme", "widget", 1)
+	seedPRForRepo(t, database, giteaRepo, "github.com", "acme", "widget", 2)
+
+	since := time.Now().UTC().AddDate(0, 0, -7).Format(time.RFC3339)
+	repo := "gitea|github.com/acme/widget"
+	resp, err := client.HTTP.ListActivityWithResponse(
+		ctx, &generated.ListActivityParams{Since: &since, Repo: &repo},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode())
+	require.NotNil(resp.JSON200)
+	require.NotNil(resp.JSON200.Items)
+	require.NotEmpty(*resp.JSON200.Items)
+	for _, item := range *resp.JSON200.Items {
+		assert.Equal("gitea", item.Repo.Provider)
+		assert.Equal("github.com", item.PlatformHost)
+		assert.Equal("acme", item.RepoOwner)
+		assert.Equal("widget", item.RepoName)
+	}
+}
+
+func TestAPIListActivityKeepsProviderNamedHostsHostQualified(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	srv, database := setupTestServer(t)
+	client := setupTestClient(t, srv)
+	ctx := t.Context()
+
+	repoID, err := database.UpsertRepo(ctx, db.RepoIdentity{
+		Platform:     "github",
+		PlatformHost: "gitea",
+		Owner:        "acme/team",
+		Name:         "widget",
+	})
+	require.NoError(err)
+	seedPRForRepo(t, database, repoID, "gitea", "acme/team", "widget", 1)
+	seedPROnHost(t, database, "github.com", "acme", "widget", 2)
+
+	since := time.Now().UTC().AddDate(0, 0, -7).Format(time.RFC3339)
+	repo := "gitea/acme/team/widget"
+	resp, err := client.HTTP.ListActivityWithResponse(
+		ctx, &generated.ListActivityParams{Since: &since, Repo: &repo},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode())
+	require.NotNil(resp.JSON200)
+	require.NotNil(resp.JSON200.Items)
+	require.NotEmpty(*resp.JSON200.Items)
+	for _, item := range *resp.JSON200.Items {
+		assert.Equal("github", item.Repo.Provider)
+		assert.Equal("gitea", item.PlatformHost)
+		assert.Equal("acme/team", item.RepoOwner)
+		assert.Equal("widget", item.RepoName)
+	}
+}
+
 func TestAPIListActivityFiltersConfiguredReposByHost(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
@@ -25855,6 +25932,16 @@ func seedPROnHost(
 	repoID, err := database.UpsertRepo(ctx, db.GitHubRepoIdentity(host, owner, name))
 	require.NoError(t, err)
 
+	return seedPRForRepo(t, database, repoID, host, owner, name, number, opts...)
+}
+
+func seedPRForRepo(
+	t *testing.T, database *db.DB,
+	repoID int64, host, owner, name string, number int,
+	opts ...seedPROpt,
+) int64 {
+	t.Helper()
+	ctx := t.Context()
 	now := time.Now().UTC().Truncate(time.Second)
 	pr := &db.MergeRequest{
 		RepoID:         repoID,

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -6342,7 +6342,7 @@ func TestMatchPriorityRepoSupportsNestedBareRepoPaths(t *testing.T) {
 		},
 		{
 			Platform:     platform.KindGitea,
-			PlatformHost: "gitea",
+			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",
 			RepoPath:     "acme/widget",
@@ -6359,10 +6359,16 @@ func TestMatchPriorityRepoSupportsNestedBareRepoPaths(t *testing.T) {
 	assert.Equal(platform.KindGitHub, repo.Platform)
 	assert.Equal("acme/widget", repo.RepoPath)
 
-	repo, ok = matchPriorityRepo("gitea/acme/widget", tracked)
+	repo, ok = matchPriorityRepo("gitea|github.com/acme/widget", tracked)
 	assert.True(ok)
 	assert.Equal(platform.KindGitea, repo.Platform)
-	assert.Equal("gitea", repo.PlatformHost)
+	assert.Equal("github.com", repo.PlatformHost)
+	assert.Equal("acme/widget", repo.RepoPath)
+
+	repo, ok = matchPriorityRepo("github|github.com/acme/widget", tracked)
+	assert.True(ok)
+	assert.Equal(platform.KindGitHub, repo.Platform)
+	assert.Equal("github.com", repo.PlatformHost)
 	assert.Equal("acme/widget", repo.RepoPath)
 }
 

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -3430,6 +3430,58 @@ func TestAPIListRepos(t *testing.T) {
 	require.Equal("widget", (*resp.JSON200)[0].Name)
 }
 
+func TestAPIConfiguredRepoFiltersUseProviderIdentity(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	ctx := t.Context()
+	srv, database, _ := setupTestServerWithConfig(t)
+	client := setupTestClientWithBaseURL(t, srv, "http://127.0.0.1:8091")
+
+	_, err := database.UpsertRepo(ctx, db.RepoIdentity{
+		Platform:     "github",
+		PlatformHost: "github.com",
+		Owner:        "acme",
+		Name:         "widget",
+		RepoPath:     "acme/widget",
+	})
+	require.NoError(err)
+	_, err = database.UpsertRepo(ctx, db.RepoIdentity{
+		Platform:     "gitea",
+		PlatformHost: "github.com",
+		Owner:        "acme",
+		Name:         "widget",
+		RepoPath:     "acme/widget",
+	})
+	require.NoError(err)
+	srv.syncer.SetRepos([]ghclient.RepoRef{{
+		Platform:     platform.KindGitHub,
+		PlatformHost: "github.com",
+		Owner:        "acme",
+		Name:         "widget",
+		RepoPath:     "acme/widget",
+	}})
+
+	reposResp, err := client.HTTP.ListReposWithResponse(ctx)
+	require.NoError(err)
+	require.Equal(http.StatusOK, reposResp.StatusCode())
+	require.NotNil(reposResp.JSON200)
+	require.Len(*reposResp.JSON200, 1)
+	assert.Equal("github", (*reposResp.JSON200)[0].Platform)
+	assert.Equal("github.com", (*reposResp.JSON200)[0].PlatformHost)
+	assert.Equal("acme", (*reposResp.JSON200)[0].Owner)
+	assert.Equal("widget", (*reposResp.JSON200)[0].Name)
+
+	summariesResp, err := client.HTTP.ListRepoSummariesWithResponse(ctx)
+	require.NoError(err)
+	require.Equal(http.StatusOK, summariesResp.StatusCode())
+	require.NotNil(summariesResp.JSON200)
+	require.Len(*summariesResp.JSON200, 1)
+	assert.Equal("github", (*summariesResp.JSON200)[0].Repo.Provider)
+	assert.Equal("github.com", (*summariesResp.JSON200)[0].PlatformHost)
+	assert.Equal("acme", (*summariesResp.JSON200)[0].Owner)
+	assert.Equal("widget", (*summariesResp.JSON200)[0].Name)
+}
+
 func TestAPIGitLabConfiguredRepoSyncThroughProviderRegistry(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)

--- a/internal/server/e2etest/gitlab_mutations_test.go
+++ b/internal/server/e2etest/gitlab_mutations_test.go
@@ -358,6 +358,7 @@ func setupGitLabMutationServer(
 	t.Cleanup(syncer.Stop)
 
 	srv := server.New(database, syncer, nil, "/", nil, server.ServerOptions{})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
 	return srv, database, recorder, repoID
 }
 

--- a/internal/server/e2etest/sync_cooldown_test.go
+++ b/internal/server/e2etest/sync_cooldown_test.go
@@ -19,6 +19,7 @@ import (
 	"go.kenn.io/middleman/internal/config"
 	"go.kenn.io/middleman/internal/db"
 	ghclient "go.kenn.io/middleman/internal/github"
+	"go.kenn.io/middleman/internal/platform"
 	"go.kenn.io/middleman/internal/server"
 	"go.kenn.io/middleman/internal/testutil/dbtest"
 )
@@ -252,6 +253,84 @@ platform_host = "gitea"
 	require.Equal([]string{
 		"acme/second",
 		"acme/first",
+		"acme/third",
+	}, got)
+}
+
+func TestTriggerSyncE2EPrioritizesProviderQualifiedFilter(t *testing.T) {
+	require := require.New(t)
+
+	var mu sync.Mutex
+	var calls []string
+	done := make(chan struct{})
+	var doneClosed atomic.Bool
+	mock := &mockGH{
+		listOpenPullRequestsFn: func(
+			_ context.Context, owner, repo string,
+		) ([]*gh.PullRequest, error) {
+			mu.Lock()
+			calls = append(calls, owner+"/"+repo)
+			callCount := len(calls)
+			mu.Unlock()
+			if callCount == 2 && doneClosed.CompareAndSwap(false, true) {
+				close(done)
+			}
+			return nil, nil
+		},
+	}
+	baseURL, client, _, syncer := startSyncCooldownE2EServerWithSyncer(t, `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "third"
+`, mock)
+	syncer.SetParallelism(1)
+	syncer.SetRepos([]ghclient.RepoRef{
+		{
+			Platform:     platform.KindGitHub,
+			PlatformHost: "github.com",
+			Owner:        "acme",
+			Name:         "third",
+			RepoPath:     "acme/third",
+		},
+		{
+			Platform:     platform.KindGitea,
+			PlatformHost: "github.com",
+			Owner:        "acme",
+			Name:         "widget",
+			RepoPath:     "acme/widget",
+		},
+		{
+			Platform:     platform.KindGitHub,
+			PlatformHost: "github.com",
+			Owner:        "acme",
+			Name:         "widget",
+			RepoPath:     "acme/widget",
+		},
+	})
+
+	status, body := postJSON(
+		t, client,
+		baseURL+"/api/v1/sync?priority_repo=github|github.com/acme/widget",
+		nil,
+	)
+	require.Equal(http.StatusAccepted, status, body)
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		require.Fail("explicit sync did not process all repos")
+	}
+
+	mu.Lock()
+	got := append([]string(nil), calls...)
+	mu.Unlock()
+	require.Equal([]string{
+		"acme/widget",
 		"acme/third",
 	}, got)
 }

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"go.kenn.io/middleman/internal/db"
+	ghclient "go.kenn.io/middleman/internal/github"
 	"go.kenn.io/middleman/internal/platform"
 )
 
@@ -140,9 +141,10 @@ func (s *Server) lookupRepoMap(ctx context.Context) (map[int64]db.Repo, error) {
 
 // filterConfiguredRepos returns only repos that are currently tracked.
 func (s *Server) filterConfiguredRepos(repos []db.Repo) []db.Repo {
+	tracked := s.trackedConfiguredRepoSet()
 	filtered := make([]db.Repo, 0, len(repos))
 	for _, r := range repos {
-		if s.syncer.IsTrackedRepoOnHost(r.Owner, r.Name, r.PlatformHost) {
+		if _, ok := tracked[configuredDBRepoKey(r)]; ok {
 			filtered = append(filtered, r)
 		}
 	}
@@ -177,14 +179,39 @@ func (s *Server) lookupRepo(
 func (s *Server) filterConfiguredRepoSummaries(
 	summaries []db.RepoSummary,
 ) []db.RepoSummary {
+	tracked := s.trackedConfiguredRepoSet()
 	filtered := make([]db.RepoSummary, 0, len(summaries))
 	for _, summary := range summaries {
 		repo := summary.Repo
-		if s.syncer.IsTrackedRepoOnHost(repo.Owner, repo.Name, repo.PlatformHost) {
+		if _, ok := tracked[configuredDBRepoKey(repo)]; ok {
 			filtered = append(filtered, summary)
 		}
 	}
 	return filtered
+}
+
+func (s *Server) trackedConfiguredRepoSet() map[string]struct{} {
+	trackedRepos := s.syncer.TrackedRepos()
+	tracked := make(map[string]struct{}, len(trackedRepos))
+	for _, repo := range trackedRepos {
+		tracked[trackedRepoKey(repo)] = struct{}{}
+	}
+	return tracked
+}
+
+func configuredDBRepoKey(repo db.Repo) string {
+	return trackedRepoKey(ghclient.RepoRef{
+		Platform:     repoProviderKind(repo),
+		PlatformHost: repoProviderHost(repo),
+		Owner:        repo.Owner,
+		Name:         repo.Name,
+		RepoPath:     repo.RepoPath,
+	})
+}
+
+func (s *Server) isConfiguredRepoTracked(repo db.Repo) bool {
+	_, ok := s.trackedConfiguredRepoSet()[configuredDBRepoKey(repo)]
+	return ok
 }
 
 // lookupRepoID resolves a repository from owner/name inputs and returns a

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -261,20 +261,24 @@ func (s *Server) lookupIssueID(ctx context.Context, ref repoNumberPathRef) (int6
 	return issue.ID, nil
 }
 
-// parseRepoFilter splits the repo query parameter when it is in owner/name or
-// platform_host/repo_path form and otherwise returns empty parts so callers can
-// ignore invalid input. Repo paths can contain slashes, so hosted filters keep
-// everything after the host together as repoPath.
-func parseRepoFilter(repo string) (platformHost, owner, name, repoPath string) {
+// parseRepoFilter splits the repo query parameter when it is in owner/name,
+// platform_host/repo_path, or provider/platform_host/repo_path form and otherwise
+// returns empty parts so callers can ignore invalid input. Repo paths can contain
+// slashes, so hosted filters keep everything after the host together as repoPath.
+func parseRepoFilter(repo string) (provider, platformHost, owner, name, repoPath string) {
 	parts := strings.Split(strings.Trim(repo, "/ "), "/")
 	switch len(parts) {
 	case 2:
-		return "", parts[0], parts[1], ""
+		return "", "", parts[0], parts[1], ""
 	default:
 		if len(parts) >= 3 {
-			return parts[0], "", "", strings.Join(parts[1:], "/")
+			provider := strings.ToLower(strings.TrimSpace(parts[0]))
+			if _, ok := platform.MetadataFor(platform.Kind(provider)); ok && len(parts) >= 4 {
+				return provider, parts[1], "", "", strings.Join(parts[2:], "/")
+			}
+			return "", parts[0], "", "", strings.Join(parts[1:], "/")
 		}
-		return "", "", "", ""
+		return "", "", "", "", ""
 	}
 }
 
@@ -282,14 +286,16 @@ func parseRepoFilters(repo string) []db.RepoFilter {
 	parts := strings.Split(repo, ",")
 	filters := make([]db.RepoFilter, 0, len(parts))
 	for _, part := range parts {
-		platformHost, owner, name, repoPath := parseRepoFilter(part)
+		provider, platformHost, owner, name, repoPath := parseRepoFilter(part)
 		if repoPath != "" {
 			filters = append(filters, db.RepoFilter{
+				Platform:     provider,
 				PlatformHost: platformHost,
 				RepoPath:     repoPath,
 			})
 		} else if owner != "" {
 			filters = append(filters, db.RepoFilter{
+				Platform:     provider,
 				PlatformHost: platformHost,
 				RepoOwner:    owner,
 				RepoName:     name,

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -261,10 +261,13 @@ func (s *Server) lookupIssueID(ctx context.Context, ref repoNumberPathRef) (int6
 	return issue.ID, nil
 }
 
-// parseRepoFilter splits the repo query parameter when it is in owner/name,
-// platform_host/repo_path, or provider|platform_host/repo_path form and otherwise
-// returns empty parts so callers can ignore invalid input. Repo paths can contain
-// slashes, so hosted filters keep everything after the host together as repoPath.
+// parseRepoFilter splits the shared repo query parameter used by pull, issue,
+// and activity list endpoints. The accepted wire forms are owner/name,
+// platform_host/repo_path, and provider|platform_host/repo_path. Slash-qualified
+// provider labels such as provider/platform_host/repo_path are display-only and
+// intentionally parse as host-qualified values to keep nested repo paths
+// unambiguous. Repo paths can contain slashes, so hosted filters keep everything
+// after the host together as repoPath.
 func parseRepoFilter(repo string) (provider, platformHost, owner, name, repoPath string) {
 	repo = strings.Trim(repo, "/ ")
 	if providerPart, hostedPath, ok := strings.Cut(repo, "|"); ok {

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -262,20 +262,29 @@ func (s *Server) lookupIssueID(ctx context.Context, ref repoNumberPathRef) (int6
 }
 
 // parseRepoFilter splits the repo query parameter when it is in owner/name,
-// platform_host/repo_path, or provider/platform_host/repo_path form and otherwise
+// platform_host/repo_path, or provider|platform_host/repo_path form and otherwise
 // returns empty parts so callers can ignore invalid input. Repo paths can contain
 // slashes, so hosted filters keep everything after the host together as repoPath.
 func parseRepoFilter(repo string) (provider, platformHost, owner, name, repoPath string) {
-	parts := strings.Split(strings.Trim(repo, "/ "), "/")
+	repo = strings.Trim(repo, "/ ")
+	if providerPart, hostedPath, ok := strings.Cut(repo, "|"); ok {
+		provider := strings.ToLower(strings.TrimSpace(providerPart))
+		if _, ok := platform.MetadataFor(platform.Kind(provider)); !ok {
+			return "", "", "", "", ""
+		}
+		parts := strings.Split(strings.Trim(hostedPath, "/ "), "/")
+		if len(parts) < 2 {
+			return "", "", "", "", ""
+		}
+		return provider, parts[0], "", "", strings.Join(parts[1:], "/")
+	}
+
+	parts := strings.Split(repo, "/")
 	switch len(parts) {
 	case 2:
 		return "", "", parts[0], parts[1], ""
 	default:
 		if len(parts) >= 3 {
-			provider := strings.ToLower(strings.TrimSpace(parts[0]))
-			if _, ok := platform.MetadataFor(platform.Kind(provider)); ok && len(parts) >= 4 {
-				return provider, parts[1], "", "", strings.Join(parts[2:], "/")
-			}
 			return "", parts[0], "", "", strings.Join(parts[1:], "/")
 		}
 		return "", "", "", "", ""

--- a/internal/server/helpers_test.go
+++ b/internal/server/helpers_test.go
@@ -1,0 +1,17 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.kenn.io/middleman/internal/db"
+)
+
+func TestParseRepoFiltersAcceptsProviderQualifiedRepoPath(t *testing.T) {
+	assert.Equal(t, []db.RepoFilter{{
+		Platform:     "gitea",
+		PlatformHost: "github.com",
+		RepoPath:     "acme/widgets",
+	}}, parseRepoFilters("Gitea/github.com/acme/widgets"))
+}

--- a/internal/server/helpers_test.go
+++ b/internal/server/helpers_test.go
@@ -13,5 +13,12 @@ func TestParseRepoFiltersAcceptsProviderQualifiedRepoPath(t *testing.T) {
 		Platform:     "gitea",
 		PlatformHost: "github.com",
 		RepoPath:     "acme/widgets",
-	}}, parseRepoFilters("Gitea/github.com/acme/widgets"))
+	}}, parseRepoFilters("Gitea|github.com/acme/widgets"))
+}
+
+func TestParseRepoFiltersKeepsProviderNamedHostsHostQualified(t *testing.T) {
+	assert.Equal(t, []db.RepoFilter{{
+		PlatformHost: "gitea",
+		RepoPath:     "acme/team/widgets",
+	}}, parseRepoFilters("gitea/acme/team/widgets"))
 }

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -1230,7 +1230,7 @@ func (s *Server) listPulls(ctx context.Context, input *listPullsInput) (*listPul
 		RepoFilters: parseRepoFilters(input.Repo),
 	}
 	if len(opts.RepoFilters) == 0 {
-		if platformHost, owner, name, repoPath := parseRepoFilter(input.Repo); repoPath != "" {
+		if _, platformHost, owner, name, repoPath := parseRepoFilter(input.Repo); repoPath != "" {
 			opts.PlatformHost = platformHost
 			opts.RepoPath = repoPath
 		} else if owner != "" {
@@ -2186,7 +2186,7 @@ func (s *Server) listIssues(ctx context.Context, input *listIssuesInput) (*listI
 		RepoFilters: parseRepoFilters(input.Repo),
 	}
 	if len(opts.RepoFilters) == 0 {
-		if platformHost, owner, name, repoPath := parseRepoFilter(input.Repo); repoPath != "" {
+		if _, platformHost, owner, name, repoPath := parseRepoFilter(input.Repo); repoPath != "" {
 			opts.PlatformHost = platformHost
 			opts.RepoPath = repoPath
 		} else if owner != "" {

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -4006,7 +4006,7 @@ func (s *Server) resolveItem(
 	if providerKind != platform.KindGitLab {
 		itemTypeHint = ""
 	}
-	if !s.syncer.IsTrackedRepoOnHost(repo.Owner, repo.Name, repoProviderHost(*repo)) {
+	if !s.isConfiguredRepoTracked(*repo) {
 		return &resolveItemOutput{
 			Body: resolveItemResponse{
 				Number:      number,

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -590,7 +590,7 @@ type listActivityInput struct {
 }
 
 type triggerSyncInput struct {
-	PriorityRepos []string `query:"priority_repo" doc:"Optional repository filters to sync first. Accepts repeated values or comma-separated values. Each value may be host-qualified as platform_host/owner/name or bare as owner/name; bare values match the first tracked repo with that repo path."`
+	PriorityRepos []string `query:"priority_repo" doc:"Optional repository filters to sync first. Accepts repeated values or comma-separated values. Each value may be provider-qualified as provider|platform_host/owner/name, host-qualified as platform_host/owner/name, or bare as owner/name; bare values match the first tracked repo with that repo path."`
 }
 
 type listActivityOutput = bodyOutput[activityResponse]
@@ -3459,6 +3459,26 @@ func matchPriorityRepo(
 	filter string,
 	tracked []ghclient.RepoRef,
 ) (ghclient.RepoRef, bool) {
+	if provider, value, ok := strings.Cut(filter, "|"); ok {
+		provider = strings.TrimSpace(provider)
+		value = strings.Trim(value, "/ ")
+		parts := strings.Split(value, "/")
+		if provider == "" || len(parts) < 3 {
+			return ghclient.RepoRef{}, false
+		}
+
+		host := parts[0]
+		path := strings.Join(parts[1:], "/")
+		for _, repo := range tracked {
+			if strings.EqualFold(string(repoPlatformForPriority(repo)), provider) &&
+				strings.EqualFold(repoHostForPriority(repo), host) &&
+				strings.EqualFold(repoPathForPriority(repo), path) {
+				return repo, true
+			}
+		}
+		return ghclient.RepoRef{}, false
+	}
+
 	for _, repo := range tracked {
 		if strings.EqualFold(repoPathForPriority(repo), filter) {
 			return repo, true

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -32,7 +32,7 @@ import (
 )
 
 type listPullsInput struct {
-	Repo    string `query:"repo"`
+	Repo    string `query:"repo" doc:"Repository filter. Accepts owner/name, platform_host/repo_path, comma-separated values, or provider|platform_host/repo_path for provider-qualified matches."`
 	State   string `query:"state"`
 	Kanban  string `query:"kanban"`
 	Starred bool   `query:"starred"`
@@ -173,7 +173,7 @@ type resolveDiffReviewThreadInput struct {
 }
 
 type listIssuesInput struct {
-	Repo     string `query:"repo"`
+	Repo     string `query:"repo" doc:"Repository filter. Accepts owner/name, platform_host/repo_path, comma-separated values, or provider|platform_host/repo_path for provider-qualified matches."`
 	State    string `query:"state"`
 	Starred  bool   `query:"starred"`
 	Q        string `query:"q"`
@@ -582,7 +582,7 @@ type workspaceDiffRequest struct {
 }
 
 type listActivityInput struct {
-	Repo   string   `query:"repo"`
+	Repo   string   `query:"repo" doc:"Repository filter. Accepts owner/name, platform_host/repo_path, comma-separated values, or provider|platform_host/repo_path for provider-qualified matches."`
 	Types  []string `query:"types"`
 	Search string   `query:"search"`
 	After  string   `query:"after"`

--- a/internal/server/settings_handlers.go
+++ b/internal/server/settings_handlers.go
@@ -280,11 +280,21 @@ func repoProvider(repo ghclient.RepoRef) string {
 	return strings.ToLower(provider)
 }
 
+func trackedRepoHost(repo ghclient.RepoRef) string {
+	host := strings.TrimSpace(repo.PlatformHost)
+	if host != "" {
+		return strings.ToLower(host)
+	}
+	if defaultHost, ok := platform.DefaultHost(platform.Kind(repoProvider(repo))); ok {
+		return defaultHost
+	}
+	return ""
+}
+
 func trackedRepoKey(repo ghclient.RepoRef) string {
 	return repoProvider(repo) + "\x00" +
-		strings.ToLower(repo.PlatformHost) + "\x00" +
-		strings.ToLower(repo.Owner) + "\x00" +
-		strings.ToLower(repo.Name)
+		trackedRepoHost(repo) + "\x00" +
+		strings.ToLower(strings.Trim(trackedRepoPath(repo), "/ "))
 }
 
 func (s *Server) persistResolvedRepos(

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -41,6 +41,9 @@
     "./utils/repo-color": {
       "default": "./src/utils/repo-color.ts"
     },
+    "./utils/repo-label": {
+      "default": "./src/utils/repo-label.ts"
+    },
     "./routes": {
       "default": "./src/routes.ts"
     },

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -13823,7 +13823,7 @@ export interface operations {
     "trigger-sync": {
         parameters: {
             query?: {
-                /** @description Optional repository filters to sync first. Accepts repeated values or comma-separated values. Each value may be host-qualified as platform_host/owner/name or bare as owner/name; bare values match the first tracked repo with that repo path. */
+                /** @description Optional repository filters to sync first. Accepts repeated values or comma-separated values. Each value may be provider-qualified as provider|platform_host/owner/name, host-qualified as platform_host/owner/name, or bare as owner/name; bare values match the first tracked repo with that repo path. */
                 priority_repo?: string[] | null;
             };
             header?: never;

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -6409,6 +6409,7 @@ export interface operations {
     "list-activity": {
         parameters: {
             query?: {
+                /** @description Repository filter. Accepts owner/name, platform_host/repo_path, comma-separated values, or provider|platform_host/repo_path for provider-qualified matches. */
                 repo?: string;
                 types?: string[] | null;
                 search?: string;
@@ -10134,6 +10135,7 @@ export interface operations {
     "list-issues": {
         parameters: {
             query?: {
+                /** @description Repository filter. Accepts owner/name, platform_host/repo_path, comma-separated values, or provider|platform_host/repo_path for provider-qualified matches. */
                 repo?: string;
                 state?: string;
                 starred?: boolean;
@@ -11702,6 +11704,7 @@ export interface operations {
     "list-pulls": {
         parameters: {
             query?: {
+                /** @description Repository filter. Accepts owner/name, platform_host/repo_path, comma-separated values, or provider|platform_host/repo_path for provider-qualified matches. */
                 repo?: string;
                 state?: string;
                 kanban?: string;

--- a/packages/ui/src/components/ActivityFeed.svelte
+++ b/packages/ui/src/components/ActivityFeed.svelte
@@ -270,6 +270,7 @@
 
   function activityRepoIdentity(item: ActivityItem): RepoLabelIdentity {
     return {
+      provider: item.repo?.provider ?? "",
       platformHost: item.repo?.platform_host ?? item.platform_host,
       owner: item.repo?.owner ?? item.repo_owner,
       name: item.repo?.name ?? item.repo_name,

--- a/packages/ui/src/components/ActivityFeed.svelte
+++ b/packages/ui/src/components/ActivityFeed.svelte
@@ -22,6 +22,10 @@
     localDateLabel,
     parseAPITimestamp,
   } from "../utils/time.js";
+  import {
+    createRepoLabelFormatter,
+    type RepoLabelIdentity,
+  } from "../utils/repo-label.js";
   import { repoColor } from "../utils/repo-color.js";
   import Chip from "./shared/Chip.svelte";
   import ItemKindChip from "./shared/ItemKindChip.svelte";
@@ -226,10 +230,6 @@
     return item.activity_url || item.item_url;
   }
 
-  function repoLabel(owner: string, name: string): string {
-    return grouping.getHideOrgName() ? name : `${owner}/${name}`;
-  }
-
   function handleLinkClick(e: Event, url: string): void {
     e.stopPropagation();
     if (url) window.open(url, "_blank", "noopener");
@@ -260,6 +260,26 @@
     rollUpCommits: activity.getRollUpCommits(),
     rollUpNonCommitActivity: false,
   }));
+
+  const repoLabelFormatter = $derived.by(() =>
+    createRepoLabelFormatter(
+      displayItems.map(activityRepoIdentity),
+      { showOrgNames: !grouping.getHideOrgName() },
+    ),
+  );
+
+  function activityRepoIdentity(item: ActivityItem): RepoLabelIdentity {
+    return {
+      platformHost: item.repo?.platform_host ?? item.platform_host,
+      owner: item.repo?.owner ?? item.repo_owner,
+      name: item.repo?.name ?? item.repo_name,
+      repoPath: item.repo?.repo_path,
+    };
+  }
+
+  function repoLabel(item: ActivityItem): string {
+    return repoLabelFormatter.format(activityRepoIdentity(item));
+  }
 
   function resetFilters(): void {
     activity.setEnabledEvents(new Set(EVENT_TYPES));
@@ -603,7 +623,7 @@
                   {/if}
                 </span>
                 <span class="compact-meta">
-                  <span>{repoLabel(row.representative.repo_owner, row.representative.repo_name)}</span>
+                  <span>{repoLabel(row.representative)}</span>
                   <Chip
                     size="sm"
                     uppercase={false}
@@ -639,7 +659,7 @@
                   {isDefaultBranchActivity(row) ? branchActivityTitle(row) : row.item_title}
                 </span>
                 <span class="compact-meta">
-                  <span>{repoLabel(row.repo_owner, row.repo_name)}</span>
+                  <span>{repoLabel(row)}</span>
                   {#if isDefaultBranchActivity(row) && branchActivityDetail(row)}
                     <span class="sha">{branchActivityDetail(row)}</span>
                   {/if}
@@ -701,7 +721,7 @@
                     style={repoStyle}
                   >
                     <span class="repo-chip__label"
-                      >{repoLabel(row.representative.repo_owner, row.representative.repo_name)}</span>
+                      >{repoLabel(row.representative)}</span>
                   </Chip>
                 </span>
                 <span class="cell cell--author col-author">{row.author}</span>
@@ -756,7 +776,7 @@
                     style={repoStyle}
                   >
                     <span class="repo-chip__label"
-                      >{repoLabel(row.repo_owner, row.repo_name)}</span>
+                      >{repoLabel(row)}</span>
                   </Chip>
                 </span>
                 <span class="cell cell--author col-author">{activityAuthor(row)}</span>

--- a/packages/ui/src/components/ActivityFeed.test.ts
+++ b/packages/ui/src/components/ActivityFeed.test.ts
@@ -197,6 +197,35 @@ describe("ActivityFeed compact mode", () => {
     expect(container.textContent).not.toContain("acme/widgets");
   });
 
+  it("keeps hidden-org flat activity repo labels distinguishable", () => {
+    hideOrgName.value = true;
+    items.value = [
+      activityItem("acme-widgets"),
+      activityItem("platform-widgets", {
+        id: "platform-widgets",
+        item_number: 2,
+        repo_owner: "platform",
+        repo_name: "widgets",
+        repo: {
+          provider: "gitlab",
+          platform_host: "gitlab.example.com",
+          owner: "platform",
+          name: "widgets",
+          repo_path: "platform/widgets",
+        },
+      }),
+    ];
+
+    const { container } = render(ActivityFeed, {
+      props: { compact: false },
+    });
+
+    const repoCells = Array.from(container.querySelectorAll(".activity-row .col-repo")).map((el) =>
+      el.textContent?.trim(),
+    );
+    expect(repoCells).toEqual(["acme/widgets", "platform/widgets"]);
+  });
+
   it("highlights all compact rows for the selected item", () => {
     items.value = [
       activityItem("comment", { activity_type: "comment" }),

--- a/packages/ui/src/components/ActivityThreaded.svelte
+++ b/packages/ui/src/components/ActivityThreaded.svelte
@@ -16,6 +16,10 @@
     localDateLabel,
     parseAPITimestamp,
   } from "../utils/time.js";
+  import {
+    createRepoLabelFormatter,
+    type RepoLabelIdentity,
+  } from "../utils/repo-label.js";
   import Chip from "./shared/Chip.svelte";
   import ItemKindChip from "./shared/ItemKindChip.svelte";
   import ItemStateChip from "./shared/ItemStateChip.svelte";
@@ -113,6 +117,13 @@
     latestTime: string;
     items: ThreadedEntry[];
   }
+
+  const repoLabelFormatter = $derived.by(() =>
+    createRepoLabelFormatter(
+      items.map(activityRepoIdentity),
+      { showOrgNames: !grouping.getHideOrgName() },
+    ),
+  );
 
   const grouped = $derived.by(() => {
     const byRepo = grouping.getGroupByRepo();
@@ -216,7 +227,7 @@
         owner: entryRepoOwner(entry),
         name: entryRepoName(entry),
       });
-      repoLabels.set(repoKey, repoLabel(entryRepoOwner(entry), entryRepoName(entry)));
+      repoLabels.set(repoKey, repoLabel(entryRepoIdentity(entry)));
       let bucket = repoMap.get(repoKey);
       if (!bucket) {
         bucket = [];
@@ -442,8 +453,30 @@
     return event.item_author || eventAuthor(event);
   }
 
-  function repoLabel(owner: string, name: string): string {
-    return grouping.getHideOrgName() ? name : `${owner}/${name}`;
+  function activityRepoIdentity(item: ActivityItem): RepoLabelIdentity {
+    return {
+      platformHost: item.repo?.platform_host ?? item.platform_host,
+      owner: item.repo?.owner ?? item.repo_owner,
+      name: item.repo?.name ?? item.repo_name,
+      repoPath: item.repo?.repo_path,
+    };
+  }
+
+  function entryRepoIdentity(entry: ThreadedEntry): RepoLabelIdentity {
+    return {
+      platformHost: entryPlatformHost(entry),
+      owner: entryRepoOwner(entry),
+      name: entryRepoName(entry),
+      repoPath: entryRepoPath(entry),
+    };
+  }
+
+  function entryRepoPath(entry: ThreadedEntry): string {
+    return entry.kind === "item" ? entry.group.repoPath : entry.repoPath;
+  }
+
+  function repoLabel(repo: RepoLabelIdentity): string {
+    return repoLabelFormatter.format(repo);
   }
 
   function branchRowAuthor(row: ActivityRow): string {
@@ -554,7 +587,7 @@
                   class="repo-chip repo-tag"
                   style="color: {repoColor(`${entry.repoOwner}/${entry.repoName}`)}; background: color-mix(in srgb, {repoColor(`${entry.repoOwner}/${entry.repoName}`)} 15%, transparent);"
                 >
-                  <span class="repo-chip__label">{repoLabel(entry.repoOwner, entry.repoName)}</span>
+                  <span class="repo-chip__label">{repoLabel(entryRepoIdentity(entry))}</span>
                 </Chip>
               </span>
             {/if}
@@ -619,7 +652,7 @@
                 class="repo-chip repo-tag"
                 style="color: {repoColor(`${itemGroup.repoOwner}/${itemGroup.repoName}`)}; background: color-mix(in srgb, {repoColor(`${itemGroup.repoOwner}/${itemGroup.repoName}`)} 15%, transparent);"
               >
-                <span class="repo-chip__label">{repoLabel(itemGroup.repoOwner, itemGroup.repoName)}</span>
+                <span class="repo-chip__label">{repoLabel(entryRepoIdentity(entry))}</span>
               </Chip>
             </span>
           {/if}

--- a/packages/ui/src/components/ActivityThreaded.svelte
+++ b/packages/ui/src/components/ActivityThreaded.svelte
@@ -455,6 +455,7 @@
 
   function activityRepoIdentity(item: ActivityItem): RepoLabelIdentity {
     return {
+      provider: item.repo?.provider ?? "",
       platformHost: item.repo?.platform_host ?? item.platform_host,
       owner: item.repo?.owner ?? item.repo_owner,
       name: item.repo?.name ?? item.repo_name,
@@ -464,6 +465,7 @@
 
   function entryRepoIdentity(entry: ThreadedEntry): RepoLabelIdentity {
     return {
+      provider: entry.kind === "item" ? entry.group.provider : entry.provider,
       platformHost: entryPlatformHost(entry),
       owner: entryRepoOwner(entry),
       name: entryRepoName(entry),

--- a/packages/ui/src/components/ActivityThreaded.test.ts
+++ b/packages/ui/src/components/ActivityThreaded.test.ts
@@ -337,6 +337,38 @@ describe("ActivityThreaded collapse", () => {
     expect(container.textContent).not.toContain("acme/widgets");
   });
 
+  it("keeps hidden-org grouped activity headers distinguishable", () => {
+    groupByRepo.value = true;
+    hideOrgName.value = true;
+
+    const { container } = render(ActivityThreaded, {
+      props: {
+        items: [
+          activityItem("acme-widgets"),
+          activityItem("platform-widgets", {
+            id: "platform-widgets",
+            item_number: 2,
+            repo_owner: "platform",
+            repo_name: "widgets",
+            repo: {
+              provider: "gitlab",
+              platform_host: "gitlab.example.com",
+              owner: "platform",
+              name: "widgets",
+              repo_path: "platform/widgets",
+            },
+          }),
+        ],
+        onSelectItem: undefined,
+      },
+    });
+
+    const repoNames = Array.from(container.querySelectorAll(".repo-header .repo-name")).map((el) =>
+      el.textContent?.trim(),
+    );
+    expect(repoNames).toEqual(["acme/widgets", "platform/widgets"]);
+  });
+
   it("keeps force-push rows as provider compare links", async () => {
     const onSelectBranchCommit = vi.fn();
     const open = vi.spyOn(window, "open").mockImplementation(() => null);

--- a/packages/ui/src/components/activityRows.test.ts
+++ b/packages/ui/src/components/activityRows.test.ts
@@ -41,6 +41,20 @@ function branchItem(id: string, activity_type: string, author: string, branchNam
   } as ActivityItem;
 }
 
+function providerItem(id: string, provider: string): ActivityItem {
+  return {
+    ...item(id, "commit", "alice"),
+    platform_host: "github.com",
+    repo: {
+      provider,
+      platform_host: "github.com",
+      owner: "acme",
+      name: "widgets",
+      repo_path: "acme/widgets",
+    },
+  } as ActivityItem;
+}
+
 describe("collapseActivityRuns", () => {
   it("collapses three consecutive commits from the same author", () => {
     const rows = collapseActivityRuns(
@@ -191,6 +205,24 @@ describe("collapseActivityRuns", () => {
         branchItem("6", "default_branch_commit", "alice", "release"),
         branchItem("5", "default_branch_commit", "alice", "release"),
         branchItem("4", "default_branch_commit", "alice", "release"),
+      ],
+      { rollUpCommits: true },
+    );
+
+    expect(rows).toHaveLength(2);
+    expect(isCollapsedActivityRow(rows[0]!)).toBe(true);
+    expect(isCollapsedActivityRow(rows[1]!)).toBe(true);
+  });
+
+  it("does not collapse commit runs across providers with the same host and repo path", () => {
+    const rows = collapseActivityRuns(
+      [
+        providerItem("9", "github"),
+        providerItem("8", "github"),
+        providerItem("7", "github"),
+        providerItem("6", "gitea"),
+        providerItem("5", "gitea"),
+        providerItem("4", "gitea"),
       ],
       { rollUpCommits: true },
     );

--- a/packages/ui/src/components/activityRows.ts
+++ b/packages/ui/src/components/activityRows.ts
@@ -1,4 +1,6 @@
 import type { ActivityItem } from "../api/types.js";
+import { repoIdentityKey } from "../utils/repo-label.js";
+import type { RepoLabelIdentity } from "../utils/repo-label.js";
 
 export interface CollapsedActivityRun {
   kind: "collapsed";
@@ -119,15 +121,10 @@ export function collapseActivityRuns(items: ActivityItem[], options: CollapseAct
   return result;
 }
 
-export interface ActivityRepoKeyRef {
-  provider: string;
-  platformHost: string;
-  owner: string;
-  name: string;
-}
+export type ActivityRepoKeyRef = RepoLabelIdentity;
 
 export function activityRepoKey(ref: ActivityRepoKeyRef): string {
-  return `${ref.provider}|${ref.platformHost}|${ref.owner}/${ref.name}`;
+  return repoIdentityKey(ref);
 }
 
 export function activityItemKey(ref: ActivityRepoKeyRef & { itemType: string; itemNumber: number }): string {

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -92,7 +92,16 @@ export { default as PRListView } from "./views/PRListView.svelte";
 export { default as IssueListView } from "./views/IssueListView.svelte";
 export { default as ActivityFeedView } from "./views/ActivityFeedView.svelte";
 export { default as MobileActivityView } from "./views/MobileActivityView.svelte";
-export { normalizeMobileActivityRepoSelection } from "./views/mobileActivityRepoOptions.js";
+export {
+  canonicalRepoFilterValue,
+  concreteRepoFilterValue,
+  displayRepoFilterValue,
+  normalizeRepoFilterSelection,
+  normalizeRepoFilterValue,
+  providerQualifiedRepoFilterLabel,
+  providerQualifiedRepoFilterValue,
+  repoFilterValueNeedsProvider,
+} from "./utils/repo-filter-values.js";
 export { default as KanbanBoardView } from "./views/KanbanBoardView.svelte";
 export { default as ReviewsView } from "./views/ReviewsView.svelte";
 export { default as FocusListView } from "./views/FocusListView.svelte";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -92,6 +92,7 @@ export { default as PRListView } from "./views/PRListView.svelte";
 export { default as IssueListView } from "./views/IssueListView.svelte";
 export { default as ActivityFeedView } from "./views/ActivityFeedView.svelte";
 export { default as MobileActivityView } from "./views/MobileActivityView.svelte";
+export { normalizeMobileActivityRepoSelection } from "./views/mobileActivityRepoOptions.js";
 export { default as KanbanBoardView } from "./views/KanbanBoardView.svelte";
 export { default as ReviewsView } from "./views/ReviewsView.svelte";
 export { default as FocusListView } from "./views/FocusListView.svelte";

--- a/packages/ui/src/utils/repo-filter-values.test.ts
+++ b/packages/ui/src/utils/repo-filter-values.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  canonicalRepoFilterValue,
+  displayRepoFilterValue,
+  normalizeRepoFilterSelection,
+  normalizeRepoFilterValue,
+  type RepoFilterIdentity,
+} from "./repo-filter-values.js";
+
+const widgets = {
+  provider: "github",
+  platformHost: "github.com",
+  repoPath: "acme/widgets",
+  isGlob: false,
+};
+
+describe("repo filter values", () => {
+  it("uses provider-qualified canonical values when provider identities collide", () => {
+    const repos: RepoFilterIdentity[] = [widgets, { ...widgets, provider: "gitea" }];
+
+    expect(canonicalRepoFilterValue(repos[0]!, repos)).toBe("github|github.com/acme/widgets");
+    expect(canonicalRepoFilterValue(repos[1]!, repos)).toBe("gitea|github.com/acme/widgets");
+  });
+
+  it("uses host-qualified canonical values when provider identities no longer collide", () => {
+    expect(canonicalRepoFilterValue(widgets, [widgets])).toBe("github.com/acme/widgets");
+  });
+
+  it("normalizes stale slash-qualified provider values to pipe values while a collision exists", () => {
+    const repos: RepoFilterIdentity[] = [widgets, { ...widgets, provider: "gitea" }];
+
+    expect(normalizeRepoFilterValue("gitea/github.com/acme/widgets", repos)).toBe("gitea|github.com/acme/widgets");
+  });
+
+  it("normalizes stale slash-qualified provider values back to host-qualified values after a collision is removed", () => {
+    expect(normalizeRepoFilterValue("github/github.com/acme/widgets", [widgets])).toBe("github.com/acme/widgets");
+  });
+
+  it("normalizes stale pipe-qualified provider values back to host-qualified values after a collision is removed", () => {
+    expect(normalizeRepoFilterValue("github|github.com/acme/widgets", [widgets])).toBe("github.com/acme/widgets");
+  });
+
+  it("normalizes each value in a comma-separated filter independently", () => {
+    const repos: RepoFilterIdentity[] = [
+      widgets,
+      { ...widgets, provider: "gitea" },
+      {
+        provider: "github",
+        platformHost: "github.com",
+        repoPath: "acme/api",
+      },
+    ];
+
+    expect(
+      normalizeRepoFilterSelection(
+        "gitea/github.com/acme/widgets,github/github.com/acme/widgets,github.com/acme/api",
+        repos,
+      ),
+    ).toBe("gitea|github.com/acme/widgets,github|github.com/acme/widgets,github.com/acme/api");
+  });
+
+  it("keeps slash-qualified selections when they match a current host-qualified option", () => {
+    const repos = [
+      {
+        provider: "github",
+        platformHost: "gitea",
+        repoPath: "github.com/acme/widgets",
+      },
+    ];
+
+    expect(normalizeRepoFilterValue("gitea/github.com/acme/widgets", repos)).toBe("gitea/github.com/acme/widgets");
+  });
+
+  it("displays pipe-qualified values as slash-qualified labels", () => {
+    expect(displayRepoFilterValue("gitea|github.com/acme/widgets")).toBe("gitea/github.com/acme/widgets");
+  });
+});

--- a/packages/ui/src/utils/repo-filter-values.ts
+++ b/packages/ui/src/utils/repo-filter-values.ts
@@ -1,0 +1,139 @@
+import { canonicalProvider } from "../api/provider-routes.js";
+
+export interface RepoFilterIdentity {
+  provider?: string | null;
+  platformHost?: string | null;
+  repoPath?: string | null;
+  isGlob?: boolean | null;
+}
+
+function normalizeProvider(provider: string | null | undefined): string {
+  const trimmed = provider?.trim() ?? "";
+  return trimmed ? canonicalProvider(trimmed) : "";
+}
+
+function concreteIdentities(repos: readonly RepoFilterIdentity[]) {
+  return repos
+    .map((repo) => {
+      const concreteValue = concreteRepoFilterValue(repo);
+      if (!concreteValue) return null;
+      return {
+        repo,
+        concreteValue,
+        provider: normalizeProvider(repo.provider),
+      };
+    })
+    .filter((entry): entry is NonNullable<typeof entry> => entry !== null);
+}
+
+function providerCountsByConcreteValue(repos: readonly RepoFilterIdentity[]): Map<string, Set<string>> {
+  const providers = new Map<string, Set<string>>();
+  for (const identity of concreteIdentities(repos)) {
+    if (!identity.provider) continue;
+    let values = providers.get(identity.concreteValue);
+    if (!values) {
+      values = new Set<string>();
+      providers.set(identity.concreteValue, values);
+    }
+    values.add(identity.provider);
+  }
+  return providers;
+}
+
+export function concreteRepoFilterValue(repo: RepoFilterIdentity): string | null {
+  const repoPath = repo.repoPath?.trim();
+  const platformHost = repo.platformHost?.trim();
+  if (!repoPath || !platformHost || repo.isGlob) return null;
+  return `${platformHost}/${repoPath}`;
+}
+
+export function providerQualifiedRepoFilterValue(repo: RepoFilterIdentity): string | null {
+  const provider = normalizeProvider(repo.provider);
+  const concreteValue = concreteRepoFilterValue(repo);
+  return provider && concreteValue ? `${provider}|${concreteValue}` : concreteValue;
+}
+
+export function providerQualifiedRepoFilterLabel(repo: RepoFilterIdentity): string | null {
+  const provider = normalizeProvider(repo.provider);
+  const concreteValue = concreteRepoFilterValue(repo);
+  return provider && concreteValue ? `${provider}/${concreteValue}` : concreteValue;
+}
+
+export function repoFilterValueNeedsProvider(repo: RepoFilterIdentity, repos: readonly RepoFilterIdentity[]): boolean {
+  const concreteValue = concreteRepoFilterValue(repo);
+  if (!concreteValue) return false;
+  return (providerCountsByConcreteValue(repos).get(concreteValue)?.size ?? 0) > 1;
+}
+
+export function canonicalRepoFilterValue(
+  repo: RepoFilterIdentity,
+  repos: readonly RepoFilterIdentity[],
+): string | null {
+  if (repoFilterValueNeedsProvider(repo, repos)) {
+    return providerQualifiedRepoFilterValue(repo);
+  }
+  return concreteRepoFilterValue(repo);
+}
+
+export function displayRepoFilterValue(value: string): string {
+  const separator = value.indexOf("|");
+  if (separator === -1) return value;
+  return `${value.slice(0, separator)}/${value.slice(separator + 1)}`;
+}
+
+function currentCanonicalValues(repos: readonly RepoFilterIdentity[]): Set<string> {
+  const values = new Set<string>();
+  for (const repo of repos) {
+    const value = canonicalRepoFilterValue(repo, repos);
+    if (value) values.add(value);
+  }
+  return values;
+}
+
+export function normalizeRepoFilterValue(selected: string, repos: readonly RepoFilterIdentity[]): string {
+  const value = selected.trim();
+  if (!value) return "";
+
+  if (currentCanonicalValues(repos).has(value)) return value;
+
+  const pipeSeparator = value.indexOf("|");
+  if (pipeSeparator !== -1) {
+    const provider = normalizeProvider(value.slice(0, pipeSeparator));
+    const concreteValue = value.slice(pipeSeparator + 1);
+    for (const identity of concreteIdentities(repos)) {
+      if (identity.provider !== provider || identity.concreteValue !== concreteValue) continue;
+      return canonicalRepoFilterValue(identity.repo, repos) ?? value;
+    }
+    return value;
+  }
+
+  for (const identity of concreteIdentities(repos)) {
+    if (!identity.provider) continue;
+    const legacyValue = `${identity.provider}/${identity.concreteValue}`;
+    if (legacyValue === value) {
+      return canonicalRepoFilterValue(identity.repo, repos) ?? value;
+    }
+  }
+  return value;
+}
+
+export function parseRepoFilterSelection(selected: string | undefined): string[] {
+  return (selected ?? "")
+    .split(",")
+    .map((part) => part.trim())
+    .filter((part) => part !== "");
+}
+
+export function serializeRepoFilterSelection(values: readonly string[]): string | undefined {
+  const unique = Array.from(new Set(values.map((value) => value.trim()).filter((value) => value !== "")));
+  return unique.length > 0 ? unique.join(",") : undefined;
+}
+
+export function normalizeRepoFilterSelection(
+  selected: string | undefined,
+  repos: readonly RepoFilterIdentity[],
+): string | undefined {
+  return serializeRepoFilterSelection(
+    parseRepoFilterSelection(selected).map((value) => normalizeRepoFilterValue(value, repos)),
+  );
+}

--- a/packages/ui/src/utils/repo-label.test.ts
+++ b/packages/ui/src/utils/repo-label.test.ts
@@ -3,24 +3,28 @@ import { createRepoLabelFormatter } from "./repo-label.js";
 
 const repos = [
   {
+    provider: "github",
     platformHost: "github.com",
     owner: "acme",
     name: "widgets",
     repoPath: "acme/widgets",
   },
   {
+    provider: "gitlab",
     platformHost: "gitlab.example.com",
     owner: "platform",
     name: "widgets",
     repoPath: "platform/widgets",
   },
   {
+    provider: "github",
     platformHost: "ghe.example.com",
     owner: "acme",
     name: "widgets",
     repoPath: "acme/widgets",
   },
   {
+    provider: "github",
     platformHost: "github.com",
     owner: "acme",
     name: "api",
@@ -74,5 +78,37 @@ describe("repo labels", () => {
 
     expect(formatter.format(samePathOnDifferentHosts[0]!)).toBe("github.com/acme/widgets");
     expect(formatter.format(samePathOnDifferentHosts[1]!)).toBe("ghe.example.com/acme/widgets");
+  });
+
+  it("keeps same host owner/name repos on different providers distinguishable", () => {
+    const sameHostOnDifferentProviders = [
+      repos[0]!,
+      {
+        ...repos[0]!,
+        provider: "gitea",
+      },
+    ];
+    const formatter = createRepoLabelFormatter(sameHostOnDifferentProviders, {
+      showOrgNames: true,
+    });
+
+    expect(formatter.format(sameHostOnDifferentProviders[0]!)).toBe("github/github.com/acme/widgets");
+    expect(formatter.format(sameHostOnDifferentProviders[1]!)).toBe("gitea/github.com/acme/widgets");
+  });
+
+  it("keeps same host owner/name repos on different providers distinguishable when hiding orgs", () => {
+    const sameHostOnDifferentProviders = [
+      repos[0]!,
+      {
+        ...repos[0]!,
+        provider: "gitea",
+      },
+    ];
+    const formatter = createRepoLabelFormatter(sameHostOnDifferentProviders, {
+      showOrgNames: false,
+    });
+
+    expect(formatter.format(sameHostOnDifferentProviders[0]!)).toBe("github/github.com/acme/widgets");
+    expect(formatter.format(sameHostOnDifferentProviders[1]!)).toBe("gitea/github.com/acme/widgets");
   });
 });

--- a/packages/ui/src/utils/repo-label.test.ts
+++ b/packages/ui/src/utils/repo-label.test.ts
@@ -112,7 +112,7 @@ describe("repo labels", () => {
     expect(formatter.format(sameHostOnDifferentProviders[1]!)).toBe("gitea/github.com/acme/widgets");
   });
 
-  it("does not treat missing provider metadata as a provider collision", () => {
+  it("keeps missing provider metadata distinguishable from a known provider", () => {
     const sameRepoWithMissingProvider = [
       repos[0]!,
       {
@@ -124,8 +124,8 @@ describe("repo labels", () => {
       showOrgNames: false,
     });
 
-    expect(formatter.format(sameRepoWithMissingProvider[0]!)).toBe("widgets");
-    expect(formatter.format(sameRepoWithMissingProvider[1]!)).toBe("widgets");
+    expect(formatter.format(sameRepoWithMissingProvider[0]!)).toBe("github/github.com/acme/widgets");
+    expect(formatter.format(sameRepoWithMissingProvider[1]!)).toBe("github.com/acme/widgets");
   });
 
   it("uses the same provider-aware identity for shared grouping keys", () => {

--- a/packages/ui/src/utils/repo-label.test.ts
+++ b/packages/ui/src/utils/repo-label.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vite-plus/test";
+import { createRepoLabelFormatter } from "./repo-label.js";
+
+const repos = [
+  {
+    platformHost: "github.com",
+    owner: "acme",
+    name: "widgets",
+    repoPath: "acme/widgets",
+  },
+  {
+    platformHost: "gitlab.example.com",
+    owner: "platform",
+    name: "widgets",
+    repoPath: "platform/widgets",
+  },
+  {
+    platformHost: "ghe.example.com",
+    owner: "acme",
+    name: "widgets",
+    repoPath: "acme/widgets",
+  },
+  {
+    platformHost: "github.com",
+    owner: "acme",
+    name: "api",
+    repoPath: "acme/api",
+  },
+];
+
+describe("repo labels", () => {
+  it("uses owner/name by default and prefixes host only for host collisions", () => {
+    const formatter = createRepoLabelFormatter(repos, {
+      showOrgNames: true,
+    });
+
+    expect(formatter.format(repos[0]!)).toBe("github.com/acme/widgets");
+    expect(formatter.format(repos[1]!)).toBe("platform/widgets");
+    expect(formatter.format(repos[2]!)).toBe("ghe.example.com/acme/widgets");
+    expect(formatter.format(repos[3]!)).toBe("acme/api");
+  });
+
+  it("hides org names only while repo names stay unambiguous", () => {
+    const formatter = createRepoLabelFormatter(repos, {
+      showOrgNames: false,
+    });
+
+    expect(formatter.format(repos[0]!)).toBe("github.com/acme/widgets");
+    expect(formatter.format(repos[1]!)).toBe("platform/widgets");
+    expect(formatter.format(repos[2]!)).toBe("ghe.example.com/acme/widgets");
+    expect(formatter.format(repos[3]!)).toBe("api");
+  });
+
+  it("keeps repeated rows for the same repo collapsed to the repo name", () => {
+    const sameRepo = [
+      repos[0]!,
+      {
+        ...repos[0]!,
+      },
+    ];
+    const formatter = createRepoLabelFormatter(sameRepo, {
+      showOrgNames: false,
+    });
+
+    expect(formatter.format(sameRepo[0]!)).toBe("widgets");
+    expect(formatter.format(sameRepo[1]!)).toBe("widgets");
+  });
+});

--- a/packages/ui/src/utils/repo-label.test.ts
+++ b/packages/ui/src/utils/repo-label.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
-import { createRepoLabelFormatter } from "./repo-label.js";
+import { createRepoLabelFormatter, repoIdentityKey } from "./repo-label.js";
 
 const repos = [
   {
@@ -110,5 +110,27 @@ describe("repo labels", () => {
 
     expect(formatter.format(sameHostOnDifferentProviders[0]!)).toBe("github/github.com/acme/widgets");
     expect(formatter.format(sameHostOnDifferentProviders[1]!)).toBe("gitea/github.com/acme/widgets");
+  });
+
+  it("does not treat missing provider metadata as a provider collision", () => {
+    const sameRepoWithMissingProvider = [
+      repos[0]!,
+      {
+        ...repos[0]!,
+        provider: "",
+      },
+    ];
+    const formatter = createRepoLabelFormatter(sameRepoWithMissingProvider, {
+      showOrgNames: false,
+    });
+
+    expect(formatter.format(sameRepoWithMissingProvider[0]!)).toBe("widgets");
+    expect(formatter.format(sameRepoWithMissingProvider[1]!)).toBe("widgets");
+  });
+
+  it("uses the same provider-aware identity for shared grouping keys", () => {
+    expect(repoIdentityKey(repos[0]!)).not.toBe(repoIdentityKey({ ...repos[0]!, provider: "gitea" }));
+    expect(repoIdentityKey(repos[0]!)).not.toBe(repoIdentityKey(repos[2]!));
+    expect(repoIdentityKey(repos[0]!)).toBe(repoIdentityKey({ ...repos[0]! }));
   });
 });

--- a/packages/ui/src/utils/repo-label.test.ts
+++ b/packages/ui/src/utils/repo-label.test.ts
@@ -65,4 +65,14 @@ describe("repo labels", () => {
     expect(formatter.format(sameRepo[0]!)).toBe("widgets");
     expect(formatter.format(sameRepo[1]!)).toBe("widgets");
   });
+
+  it("keeps same owner/name repos on different hosts distinguishable when hiding orgs", () => {
+    const samePathOnDifferentHosts = [repos[0]!, repos[2]!];
+    const formatter = createRepoLabelFormatter(samePathOnDifferentHosts, {
+      showOrgNames: false,
+    });
+
+    expect(formatter.format(samePathOnDifferentHosts[0]!)).toBe("github.com/acme/widgets");
+    expect(formatter.format(samePathOnDifferentHosts[1]!)).toBe("ghe.example.com/acme/widgets");
+  });
 });

--- a/packages/ui/src/utils/repo-label.ts
+++ b/packages/ui/src/utils/repo-label.ts
@@ -48,10 +48,11 @@ export function createRepoLabelFormatter(
       const host = repo.platformHost.trim();
 
       if (!options.showOrgNames) {
+        if (hostNeeded(hostsByRepoPath, path) && host) return `${host}/${path}`;
         if ((repoPathsByName.get(name)?.size ?? 0) <= 1) {
           return name || path || host;
         }
-        return hostNeeded(hostsByRepoPath, path) && host ? `${host}/${path}` : path || name;
+        return path || name;
       }
 
       return hostNeeded(hostsByRepoPath, path) && host ? `${host}/${path}` : path || name;

--- a/packages/ui/src/utils/repo-label.ts
+++ b/packages/ui/src/utils/repo-label.ts
@@ -1,0 +1,73 @@
+export interface RepoLabelIdentity {
+  platformHost: string;
+  owner: string;
+  name: string;
+  repoPath?: string | undefined;
+}
+
+export interface RepoLabelOptions {
+  showOrgNames: boolean;
+}
+
+export interface RepoLabelFormatter {
+  format(repo: RepoLabelIdentity): string;
+}
+
+export function createRepoLabelFormatter(
+  repos: Iterable<RepoLabelIdentity>,
+  options: RepoLabelOptions,
+): RepoLabelFormatter {
+  const repoPathsByName = new Map<string, Set<string>>();
+  const hostsByRepoPath = new Map<string, Set<string>>();
+
+  for (const repo of repos) {
+    const name = repo.name.trim();
+    const path = repoPath(repo);
+    const host = repo.platformHost.trim();
+    if (!name || !path) continue;
+
+    let paths = repoPathsByName.get(name);
+    if (!paths) {
+      paths = new Set();
+      repoPathsByName.set(name, paths);
+    }
+    paths.add(path);
+
+    let hosts = hostsByRepoPath.get(path);
+    if (!hosts) {
+      hosts = new Set();
+      hostsByRepoPath.set(path, hosts);
+    }
+    hosts.add(host);
+  }
+
+  return {
+    format(repo: RepoLabelIdentity): string {
+      const name = repo.name.trim();
+      const path = repoPath(repo);
+      const host = repo.platformHost.trim();
+
+      if (!options.showOrgNames) {
+        if ((repoPathsByName.get(name)?.size ?? 0) <= 1) {
+          return name || path || host;
+        }
+        return hostNeeded(hostsByRepoPath, path) && host ? `${host}/${path}` : path || name;
+      }
+
+      return hostNeeded(hostsByRepoPath, path) && host ? `${host}/${path}` : path || name;
+    },
+  };
+}
+
+export function repoPath(repo: RepoLabelIdentity): string {
+  const explicit = repo.repoPath?.trim();
+  if (explicit) return explicit;
+  const owner = repo.owner.trim();
+  const name = repo.name.trim();
+  if (owner && name) return `${owner}/${name}`;
+  return name;
+}
+
+function hostNeeded(hostsByRepoPath: ReadonlyMap<string, ReadonlySet<string>>, path: string): boolean {
+  return (hostsByRepoPath.get(path)?.size ?? 0) > 1;
+}

--- a/packages/ui/src/utils/repo-label.ts
+++ b/packages/ui/src/utils/repo-label.ts
@@ -43,15 +43,13 @@ export function createRepoLabelFormatter(
     }
     hosts.add(host);
 
-    if (provider) {
-      const hostRepoPath = hostRepoPathKey(host, path);
-      let providers = providersByHostRepoPath.get(hostRepoPath);
-      if (!providers) {
-        providers = new Set();
-        providersByHostRepoPath.set(hostRepoPath, providers);
-      }
-      providers.add(provider);
+    const hostRepoPath = hostRepoPathKey(host, path);
+    let providers = providersByHostRepoPath.get(hostRepoPath);
+    if (!providers) {
+      providers = new Set();
+      providersByHostRepoPath.set(hostRepoPath, providers);
     }
+    providers.add(provider);
   }
 
   return {

--- a/packages/ui/src/utils/repo-label.ts
+++ b/packages/ui/src/utils/repo-label.ts
@@ -43,13 +43,15 @@ export function createRepoLabelFormatter(
     }
     hosts.add(host);
 
-    const hostRepoPath = hostRepoPathKey(host, path);
-    let providers = providersByHostRepoPath.get(hostRepoPath);
-    if (!providers) {
-      providers = new Set();
-      providersByHostRepoPath.set(hostRepoPath, providers);
+    if (provider) {
+      const hostRepoPath = hostRepoPathKey(host, path);
+      let providers = providersByHostRepoPath.get(hostRepoPath);
+      if (!providers) {
+        providers = new Set();
+        providersByHostRepoPath.set(hostRepoPath, providers);
+      }
+      providers.add(provider);
     }
-    providers.add(provider);
   }
 
   return {
@@ -60,8 +62,8 @@ export function createRepoLabelFormatter(
       const host = repo.platformHost.trim();
 
       if (!options.showOrgNames) {
-        if (providerNeeded(providersByHostRepoPath, host, path) && provider) {
-          return providerHostRepoPathLabel(provider, host, path);
+        if (providerNeeded(providersByHostRepoPath, host, path)) {
+          return provider ? providerHostRepoPathLabel(provider, host, path) : hostQualifiedRepoPathLabel(host, path);
         }
         if (hostNeeded(hostsByRepoPath, path) && host) return `${host}/${path}`;
         if ((repoPathsByName.get(name)?.size ?? 0) <= 1) {
@@ -70,8 +72,8 @@ export function createRepoLabelFormatter(
         return path || name;
       }
 
-      if (providerNeeded(providersByHostRepoPath, host, path) && provider) {
-        return providerHostRepoPathLabel(provider, host, path);
+      if (providerNeeded(providersByHostRepoPath, host, path)) {
+        return provider ? providerHostRepoPathLabel(provider, host, path) : hostQualifiedRepoPathLabel(host, path);
       }
       return hostNeeded(hostsByRepoPath, path) && host ? `${host}/${path}` : path || name;
     },
@@ -85,6 +87,10 @@ export function repoPath(repo: RepoLabelIdentity): string {
   const name = repo.name.trim();
   if (owner && name) return `${owner}/${name}`;
   return name;
+}
+
+export function repoIdentityKey(repo: RepoLabelIdentity): string {
+  return [repo.provider.trim(), repo.platformHost.trim(), repoPath(repo)].join("\0");
 }
 
 function hostNeeded(hostsByRepoPath: ReadonlyMap<string, ReadonlySet<string>>, path: string): boolean {
@@ -105,4 +111,8 @@ function hostRepoPathKey(host: string, path: string): string {
 
 function providerHostRepoPathLabel(provider: string, host: string, path: string): string {
   return host ? `${provider}/${host}/${path}` : `${provider}/${path}`;
+}
+
+function hostQualifiedRepoPathLabel(host: string, path: string): string {
+  return host ? `${host}/${path}` : path;
 }

--- a/packages/ui/src/utils/repo-label.ts
+++ b/packages/ui/src/utils/repo-label.ts
@@ -1,4 +1,5 @@
 export interface RepoLabelIdentity {
+  provider: string;
   platformHost: string;
   owner: string;
   name: string;
@@ -19,8 +20,10 @@ export function createRepoLabelFormatter(
 ): RepoLabelFormatter {
   const repoPathsByName = new Map<string, Set<string>>();
   const hostsByRepoPath = new Map<string, Set<string>>();
+  const providersByHostRepoPath = new Map<string, Set<string>>();
 
   for (const repo of repos) {
+    const provider = repo.provider.trim();
     const name = repo.name.trim();
     const path = repoPath(repo);
     const host = repo.platformHost.trim();
@@ -39,22 +42,37 @@ export function createRepoLabelFormatter(
       hostsByRepoPath.set(path, hosts);
     }
     hosts.add(host);
+
+    const hostRepoPath = hostRepoPathKey(host, path);
+    let providers = providersByHostRepoPath.get(hostRepoPath);
+    if (!providers) {
+      providers = new Set();
+      providersByHostRepoPath.set(hostRepoPath, providers);
+    }
+    providers.add(provider);
   }
 
   return {
     format(repo: RepoLabelIdentity): string {
+      const provider = repo.provider.trim();
       const name = repo.name.trim();
       const path = repoPath(repo);
       const host = repo.platformHost.trim();
 
       if (!options.showOrgNames) {
+        if (providerNeeded(providersByHostRepoPath, host, path) && provider) {
+          return providerHostRepoPathLabel(provider, host, path);
+        }
         if (hostNeeded(hostsByRepoPath, path) && host) return `${host}/${path}`;
         if ((repoPathsByName.get(name)?.size ?? 0) <= 1) {
-          return name || path || host;
+          return name || path || host || provider;
         }
         return path || name;
       }
 
+      if (providerNeeded(providersByHostRepoPath, host, path) && provider) {
+        return providerHostRepoPathLabel(provider, host, path);
+      }
       return hostNeeded(hostsByRepoPath, path) && host ? `${host}/${path}` : path || name;
     },
   };
@@ -71,4 +89,20 @@ export function repoPath(repo: RepoLabelIdentity): string {
 
 function hostNeeded(hostsByRepoPath: ReadonlyMap<string, ReadonlySet<string>>, path: string): boolean {
   return (hostsByRepoPath.get(path)?.size ?? 0) > 1;
+}
+
+function providerNeeded(
+  providersByHostRepoPath: ReadonlyMap<string, ReadonlySet<string>>,
+  host: string,
+  path: string,
+): boolean {
+  return (providersByHostRepoPath.get(hostRepoPathKey(host, path))?.size ?? 0) > 1;
+}
+
+function hostRepoPathKey(host: string, path: string): string {
+  return `${host}\0${path}`;
+}
+
+function providerHostRepoPathLabel(provider: string, host: string, path: string): string {
+  return host ? `${provider}/${host}/${path}` : `${provider}/${path}`;
 }

--- a/packages/ui/src/utils/repo-label.ts
+++ b/packages/ui/src/utils/repo-label.ts
@@ -88,7 +88,12 @@ export function repoPath(repo: RepoLabelIdentity): string {
 }
 
 export function repoIdentityKey(repo: RepoLabelIdentity): string {
-  return [repo.provider.trim(), repo.platformHost.trim(), repoPath(repo)].join("\0");
+  // The "|" delimiter is the established thread/grouping key format
+  // (provider|host|owner/name); activity item and branch keys append
+  // ":type:number" to it and ActivityThreaded relies on that shape.
+  // None of provider, host, or repo path contains "|", so segments
+  // stay unambiguous.
+  return [repo.provider.trim(), repo.platformHost.trim(), repoPath(repo)].join("|");
 }
 
 function hostNeeded(hostsByRepoPath: ReadonlyMap<string, ReadonlySet<string>>, path: string): boolean {

--- a/packages/ui/src/views/MobileActivityView.svelte
+++ b/packages/ui/src/views/MobileActivityView.svelte
@@ -298,6 +298,7 @@
 
   function activityRepoIdentity(item: ActivityItem): RepoLabelIdentity {
     return {
+      provider: item.repo.provider,
       platformHost: item.repo.platform_host,
       owner: item.repo.owner,
       name: item.repo.name,

--- a/packages/ui/src/views/MobileActivityView.svelte
+++ b/packages/ui/src/views/MobileActivityView.svelte
@@ -22,6 +22,7 @@
   } from "../components/activityRows.js";
   import {
     buildMobileActivityRepoOptions,
+    normalizeMobileActivityRepoSelection,
   } from "./mobileActivityRepoOptions.js";
   import {
     createRepoLabelFormatter,
@@ -67,6 +68,14 @@
       ...buildMobileActivityRepoOptions(settings.getConfiguredRepos()),
     ],
   );
+  const normalizedSelectedRepo = $derived(
+    normalizeMobileActivityRepoSelection(selectedRepo, settings.getConfiguredRepos()),
+  );
+
+  $effect(() => {
+    if ((selectedRepo ?? "") === normalizedSelectedRepo) return;
+    onRepoChange?.(normalizedSelectedRepo || undefined);
+  });
 
   onMount(() => {
     activity.initializeFromMount();
@@ -390,7 +399,7 @@
         <SelectDropdown
           class="mobile-filter-dropdown"
           title="Repository"
-          value={selectedRepo ?? ""}
+          value={normalizedSelectedRepo}
           options={repoOptions}
           onchange={handleRepoChange}
         />

--- a/packages/ui/src/views/MobileActivityView.svelte
+++ b/packages/ui/src/views/MobileActivityView.svelte
@@ -15,6 +15,7 @@
   import WorkspaceIndicator from "../components/shared/WorkspaceIndicator.svelte";
   import {
     activityBranchKey,
+    activityItemKey,
     isDefaultBranchActivity,
     isDefaultBranchForcePushActivity,
     shortSha,
@@ -123,9 +124,18 @@
             platformHost: item.repo.platform_host,
             owner: item.repo.owner,
             name: item.repo.name,
+            repoPath: item.repo.repo_path,
             branchName: item.branch_name || "default branch",
           })
-        : `${item.repo.platform_host}|${item.repo.repo_path}:${item.item_type}:${item.item_number}`;
+        : activityItemKey({
+            provider: item.repo.provider,
+            platformHost: item.repo.platform_host,
+            owner: item.repo.owner,
+            name: item.repo.name,
+            repoPath: item.repo.repo_path,
+            itemType: item.item_type,
+            itemNumber: item.item_number,
+          });
       const bucket = map.get(key);
       if (bucket) bucket.push(item);
       else map.set(key, [item]);

--- a/packages/ui/src/views/MobileActivityView.svelte
+++ b/packages/ui/src/views/MobileActivityView.svelte
@@ -22,6 +22,10 @@
   import {
     buildMobileActivityRepoOptions,
   } from "./mobileActivityRepoOptions.js";
+  import {
+    createRepoLabelFormatter,
+    type RepoLabelIdentity,
+  } from "../utils/repo-label.js";
 
   const { activity, settings, sync, grouping } = getStores();
 
@@ -155,6 +159,13 @@
 
   const visibleGroups = $derived(groups.slice(0, 30));
 
+  const repoLabelFormatter = $derived.by(() =>
+    createRepoLabelFormatter(
+      displayItems.map(activityRepoIdentity),
+      { showOrgNames: !grouping.getHideOrgName() },
+    ),
+  );
+
   function applyFilters(): void {
     activity.setActivityFilterTypes(buildActivityFilterTypes(
       activity.getItemFilter(),
@@ -285,9 +296,17 @@
     return group.events.slice(0, 2);
   }
 
+  function activityRepoIdentity(item: ActivityItem): RepoLabelIdentity {
+    return {
+      platformHost: item.repo.platform_host,
+      owner: item.repo.owner,
+      name: item.repo.name,
+      repoPath: item.repo.repo_path,
+    };
+  }
+
   function repoLabel(item: ActivityItem): string {
-    if (grouping.getHideOrgName()) return item.repo.name;
-    return `${item.repo.platform_host}/${item.repo.repo_path}`;
+    return repoLabelFormatter.format(activityRepoIdentity(item));
   }
 
   function branchName(item: ActivityItem): string {

--- a/packages/ui/src/views/MobileActivityView.svelte
+++ b/packages/ui/src/views/MobileActivityView.svelte
@@ -22,7 +22,6 @@
   } from "../components/activityRows.js";
   import {
     buildMobileActivityRepoOptions,
-    normalizeMobileActivityRepoSelection,
   } from "./mobileActivityRepoOptions.js";
   import {
     createRepoLabelFormatter,
@@ -68,15 +67,6 @@
       ...buildMobileActivityRepoOptions(settings.getConfiguredRepos()),
     ],
   );
-  const normalizedSelectedRepo = $derived(
-    normalizeMobileActivityRepoSelection(selectedRepo, settings.getConfiguredRepos()),
-  );
-
-  $effect(() => {
-    if ((selectedRepo ?? "") === normalizedSelectedRepo) return;
-    onRepoChange?.(normalizedSelectedRepo || undefined);
-  });
-
   onMount(() => {
     activity.initializeFromMount();
     searchInput = activity.getActivitySearch() ?? "";
@@ -399,7 +389,7 @@
         <SelectDropdown
           class="mobile-filter-dropdown"
           title="Repository"
-          value={normalizedSelectedRepo}
+          value={selectedRepo ?? ""}
           options={repoOptions}
           onchange={handleRepoChange}
         />

--- a/packages/ui/src/views/MobileActivityView.test.ts
+++ b/packages/ui/src/views/MobileActivityView.test.ts
@@ -111,13 +111,13 @@ describe("MobileActivityView branch activity", () => {
     expect(card?.querySelector(".chip--kind-issue")).toBeNull();
   });
 
-  it("uses the full hosted repo path by default", () => {
+  it("uses the shared repo path by default", () => {
     const { container } = render(MobileActivityView, {
       props: { onSelectItem },
     });
 
     const repoLabel = container.querySelector(".mobile-activity-card__meta span");
-    expect(repoLabel?.textContent).toBe("github.com/acme/widgets");
+    expect(repoLabel?.textContent).toBe("acme/widgets");
   });
 
   it("respects hide org name in mobile activity cards", () => {
@@ -129,7 +129,35 @@ describe("MobileActivityView branch activity", () => {
 
     const repoLabel = container.querySelector(".mobile-activity-card__meta span");
     expect(repoLabel?.textContent).toBe("widgets");
-    expect(container.textContent).not.toContain("github.com/acme/widgets");
+    expect(container.textContent).not.toContain("acme/widgets");
+  });
+
+  it("keeps hidden-org mobile activity repo labels distinguishable", () => {
+    hideOrgName.value = true;
+    items.value = [
+      branchActivityItem("acme-widgets"),
+      branchActivityItem("platform-widgets", {
+        id: "platform-widgets",
+        repo_owner: "platform",
+        repo_name: "widgets",
+        repo: {
+          provider: "gitlab",
+          platform_host: "gitlab.example.com",
+          owner: "platform",
+          name: "widgets",
+          repo_path: "platform/widgets",
+        },
+      }),
+    ];
+
+    const { container } = render(MobileActivityView, {
+      props: { onSelectItem },
+    });
+
+    const repoLabels = Array.from(container.querySelectorAll(".mobile-activity-card__meta span:first-child")).map(
+      (el) => el.textContent?.trim(),
+    );
+    expect(repoLabels).toEqual(["acme/widgets", "platform/widgets"]);
   });
 
   it("exposes a mobile hide org toggle", async () => {

--- a/packages/ui/src/views/mobileActivityRepoOptions.test.ts
+++ b/packages/ui/src/views/mobileActivityRepoOptions.test.ts
@@ -40,12 +40,12 @@ describe("buildMobileActivityRepoOptions", () => {
 
     expect(options).toEqual([
       {
-        value: "gitea/github.com/acme/widgets",
+        value: "gitea|github.com/acme/widgets",
         label: "gitea/github.com/acme/widgets",
         triggerLabel: "gitea/github.com/acme/widgets",
       },
       {
-        value: "github/github.com/acme/widgets",
+        value: "github|github.com/acme/widgets",
         label: "github/github.com/acme/widgets",
         triggerLabel: "github/github.com/acme/widgets",
       },

--- a/packages/ui/src/views/mobileActivityRepoOptions.test.ts
+++ b/packages/ui/src/views/mobileActivityRepoOptions.test.ts
@@ -32,6 +32,26 @@ describe("buildMobileActivityRepoOptions", () => {
     ]);
   });
 
+  it("uses provider-qualified values when the same host and repo path exist on different providers", () => {
+    const options = buildMobileActivityRepoOptions([
+      { ...baseRepo, provider: "github", platform_host: "github.com" },
+      { ...baseRepo, provider: "gitea", platform_host: "github.com" },
+    ]);
+
+    expect(options).toEqual([
+      {
+        value: "gitea/github.com/acme/widgets",
+        label: "gitea/github.com/acme/widgets",
+        triggerLabel: "gitea/github.com/acme/widgets",
+      },
+      {
+        value: "github/github.com/acme/widgets",
+        label: "github/github.com/acme/widgets",
+        triggerLabel: "github/github.com/acme/widgets",
+      },
+    ]);
+  });
+
   it("shortens trigger labels when repo paths are unique", () => {
     const options = buildMobileActivityRepoOptions([
       {

--- a/packages/ui/src/views/mobileActivityRepoOptions.test.ts
+++ b/packages/ui/src/views/mobileActivityRepoOptions.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { buildMobileActivityRepoOptions } from "./mobileActivityRepoOptions.js";
+import { buildMobileActivityRepoOptions, normalizeMobileActivityRepoSelection } from "./mobileActivityRepoOptions.js";
 
 const baseRepo = {
   provider: "github",
@@ -128,5 +128,31 @@ describe("buildMobileActivityRepoOptions", () => {
         triggerLabel: "acme/widgets",
       },
     ]);
+  });
+
+  it("normalizes stale slash-qualified provider selections to the pipe wire value", () => {
+    const repos = [
+      { ...baseRepo, provider: "github", platform_host: "github.com" },
+      { ...baseRepo, provider: "gitea", platform_host: "github.com" },
+    ];
+
+    expect(normalizeMobileActivityRepoSelection("gitea/github.com/acme/widgets", repos)).toBe(
+      "gitea|github.com/acme/widgets",
+    );
+  });
+
+  it("keeps slash-qualified selections when they match a current host-qualified option", () => {
+    const repos = [
+      {
+        ...baseRepo,
+        provider: "github",
+        platform_host: "gitea",
+        repo_path: "github.com/acme/widgets",
+      },
+    ];
+
+    expect(normalizeMobileActivityRepoSelection("gitea/github.com/acme/widgets", repos)).toBe(
+      "gitea/github.com/acme/widgets",
+    );
   });
 });

--- a/packages/ui/src/views/mobileActivityRepoOptions.test.ts
+++ b/packages/ui/src/views/mobileActivityRepoOptions.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { buildMobileActivityRepoOptions, normalizeMobileActivityRepoSelection } from "./mobileActivityRepoOptions.js";
+import { buildMobileActivityRepoOptions } from "./mobileActivityRepoOptions.js";
 
 const baseRepo = {
   provider: "github",
@@ -128,31 +128,5 @@ describe("buildMobileActivityRepoOptions", () => {
         triggerLabel: "acme/widgets",
       },
     ]);
-  });
-
-  it("normalizes stale slash-qualified provider selections to the pipe wire value", () => {
-    const repos = [
-      { ...baseRepo, provider: "github", platform_host: "github.com" },
-      { ...baseRepo, provider: "gitea", platform_host: "github.com" },
-    ];
-
-    expect(normalizeMobileActivityRepoSelection("gitea/github.com/acme/widgets", repos)).toBe(
-      "gitea|github.com/acme/widgets",
-    );
-  });
-
-  it("keeps slash-qualified selections when they match a current host-qualified option", () => {
-    const repos = [
-      {
-        ...baseRepo,
-        provider: "github",
-        platform_host: "gitea",
-        repo_path: "github.com/acme/widgets",
-      },
-    ];
-
-    expect(normalizeMobileActivityRepoSelection("gitea/github.com/acme/widgets", repos)).toBe(
-      "gitea/github.com/acme/widgets",
-    );
   });
 });

--- a/packages/ui/src/views/mobileActivityRepoOptions.ts
+++ b/packages/ui/src/views/mobileActivityRepoOptions.ts
@@ -16,6 +16,12 @@ function concreteRepoSelectorValue(repo: ConfigRepo): string | null {
 function providerRepoSelectorValue(repo: ConfigRepo): string | null {
   const provider = repo.provider?.trim();
   const concreteValue = concreteRepoSelectorValue(repo);
+  return provider && concreteValue ? `${provider}|${concreteValue}` : concreteValue;
+}
+
+function providerRepoSelectorLabel(repo: ConfigRepo): string | null {
+  const provider = repo.provider?.trim();
+  const concreteValue = concreteRepoSelectorValue(repo);
   return provider && concreteValue ? `${provider}/${concreteValue}` : concreteValue;
 }
 
@@ -51,8 +57,10 @@ export function buildMobileActivityRepoOptions(repos: ConfigRepo[]): MobileActiv
     if (!value || seen.has(value)) continue;
     seen.add(value);
     const repoPath = repo.repo_path.trim();
-    const triggerLabel = providerCollision || (valuesByRepoPath.get(repoPath)?.size ?? 0) > 1 ? value : repoPath;
-    options.push({ value, label: value, triggerLabel });
+    const label = providerCollision ? providerRepoSelectorLabel(repo) : value;
+    if (!label) continue;
+    const triggerLabel = providerCollision || (valuesByRepoPath.get(repoPath)?.size ?? 0) > 1 ? label : repoPath;
+    options.push({ value, label, triggerLabel });
   }
   return options.sort((left, right) =>
     left.label.localeCompare(right.label, undefined, {

--- a/packages/ui/src/views/mobileActivityRepoOptions.ts
+++ b/packages/ui/src/views/mobileActivityRepoOptions.ts
@@ -13,8 +13,15 @@ function concreteRepoSelectorValue(repo: ConfigRepo): string | null {
   return `${platformHost}/${repoPath}`;
 }
 
+function providerRepoSelectorValue(repo: ConfigRepo): string | null {
+  const provider = repo.provider?.trim();
+  const concreteValue = concreteRepoSelectorValue(repo);
+  return provider && concreteValue ? `${provider}/${concreteValue}` : concreteValue;
+}
+
 export function buildMobileActivityRepoOptions(repos: ConfigRepo[]): MobileActivityRepoOption[] {
   const valuesByRepoPath = new Map<string, Set<string>>();
+  const providersByConcreteValue = new Map<string, Set<string>>();
   for (const repo of repos) {
     const value = concreteRepoSelectorValue(repo);
     if (!value) continue;
@@ -25,16 +32,26 @@ export function buildMobileActivityRepoOptions(repos: ConfigRepo[]): MobileActiv
       valuesByRepoPath.set(repoPath, values);
     }
     values.add(value);
+
+    let providers = providersByConcreteValue.get(value);
+    if (!providers) {
+      providers = new Set<string>();
+      providersByConcreteValue.set(value, providers);
+    }
+    providers.add(repo.provider.trim());
   }
 
   const seen = new Set<string>();
   const options: MobileActivityRepoOption[] = [];
   for (const repo of repos) {
-    const value = concreteRepoSelectorValue(repo);
+    const concreteValue = concreteRepoSelectorValue(repo);
+    if (!concreteValue) continue;
+    const providerCollision = (providersByConcreteValue.get(concreteValue)?.size ?? 0) > 1;
+    const value = providerCollision ? providerRepoSelectorValue(repo) : concreteValue;
     if (!value || seen.has(value)) continue;
     seen.add(value);
     const repoPath = repo.repo_path.trim();
-    const triggerLabel = (valuesByRepoPath.get(repoPath)?.size ?? 0) > 1 ? value : repoPath;
+    const triggerLabel = providerCollision || (valuesByRepoPath.get(repoPath)?.size ?? 0) > 1 ? value : repoPath;
     options.push({ value, label: value, triggerLabel });
   }
   return options.sort((left, right) =>

--- a/packages/ui/src/views/mobileActivityRepoOptions.ts
+++ b/packages/ui/src/views/mobileActivityRepoOptions.ts
@@ -69,3 +69,20 @@ export function buildMobileActivityRepoOptions(repos: ConfigRepo[]): MobileActiv
     }),
   );
 }
+
+export function normalizeMobileActivityRepoSelection(selected: string | undefined, repos: ConfigRepo[]): string {
+  const value = selected?.trim() ?? "";
+  if (!value) return "";
+
+  const options = buildMobileActivityRepoOptions(repos);
+  if (options.some((option) => option.value === value)) return value;
+
+  const optionValues = new Set(options.map((option) => option.value));
+  for (const repo of repos) {
+    const legacyValue = providerRepoSelectorLabel(repo);
+    const nextValue = providerRepoSelectorValue(repo);
+    if (!legacyValue || !nextValue || !nextValue.includes("|")) continue;
+    if (legacyValue === value && optionValues.has(nextValue)) return nextValue;
+  }
+  return value;
+}

--- a/packages/ui/src/views/mobileActivityRepoOptions.ts
+++ b/packages/ui/src/views/mobileActivityRepoOptions.ts
@@ -1,4 +1,10 @@
 import type { ConfigRepo } from "../api/types.js";
+import {
+  canonicalRepoFilterValue,
+  concreteRepoFilterValue,
+  providerQualifiedRepoFilterLabel,
+  repoFilterValueNeedsProvider,
+} from "../utils/repo-filter-values.js";
 
 export interface MobileActivityRepoOption {
   value: string;
@@ -6,30 +12,19 @@ export interface MobileActivityRepoOption {
   triggerLabel?: string;
 }
 
-function concreteRepoSelectorValue(repo: ConfigRepo): string | null {
-  const repoPath = repo.repo_path?.trim();
-  const platformHost = repo.platform_host?.trim();
-  if (!repoPath || !platformHost || repo.is_glob) return null;
-  return `${platformHost}/${repoPath}`;
-}
-
-function providerRepoSelectorValue(repo: ConfigRepo): string | null {
-  const provider = repo.provider?.trim();
-  const concreteValue = concreteRepoSelectorValue(repo);
-  return provider && concreteValue ? `${provider}|${concreteValue}` : concreteValue;
-}
-
-function providerRepoSelectorLabel(repo: ConfigRepo): string | null {
-  const provider = repo.provider?.trim();
-  const concreteValue = concreteRepoSelectorValue(repo);
-  return provider && concreteValue ? `${provider}/${concreteValue}` : concreteValue;
+function repoFilterIdentity(repo: ConfigRepo) {
+  return {
+    provider: repo.provider,
+    platformHost: repo.platform_host,
+    repoPath: repo.repo_path,
+    isGlob: repo.is_glob,
+  };
 }
 
 export function buildMobileActivityRepoOptions(repos: ConfigRepo[]): MobileActivityRepoOption[] {
   const valuesByRepoPath = new Map<string, Set<string>>();
-  const providersByConcreteValue = new Map<string, Set<string>>();
   for (const repo of repos) {
-    const value = concreteRepoSelectorValue(repo);
+    const value = concreteRepoFilterValue(repoFilterIdentity(repo));
     if (!value) continue;
     const repoPath = repo.repo_path.trim();
     let values = valuesByRepoPath.get(repoPath);
@@ -38,26 +33,21 @@ export function buildMobileActivityRepoOptions(repos: ConfigRepo[]): MobileActiv
       valuesByRepoPath.set(repoPath, values);
     }
     values.add(value);
-
-    let providers = providersByConcreteValue.get(value);
-    if (!providers) {
-      providers = new Set<string>();
-      providersByConcreteValue.set(value, providers);
-    }
-    providers.add(repo.provider.trim());
   }
 
+  const identities = repos.map(repoFilterIdentity);
   const seen = new Set<string>();
   const options: MobileActivityRepoOption[] = [];
   for (const repo of repos) {
-    const concreteValue = concreteRepoSelectorValue(repo);
+    const identity = repoFilterIdentity(repo);
+    const concreteValue = concreteRepoFilterValue(identity);
     if (!concreteValue) continue;
-    const providerCollision = (providersByConcreteValue.get(concreteValue)?.size ?? 0) > 1;
-    const value = providerCollision ? providerRepoSelectorValue(repo) : concreteValue;
+    const providerCollision = repoFilterValueNeedsProvider(identity, identities);
+    const value = canonicalRepoFilterValue(identity, identities);
     if (!value || seen.has(value)) continue;
     seen.add(value);
     const repoPath = repo.repo_path.trim();
-    const label = providerCollision ? providerRepoSelectorLabel(repo) : value;
+    const label = providerCollision ? providerQualifiedRepoFilterLabel(identity) : value;
     if (!label) continue;
     const triggerLabel = providerCollision || (valuesByRepoPath.get(repoPath)?.size ?? 0) > 1 ? label : repoPath;
     options.push({ value, label, triggerLabel });
@@ -68,21 +58,4 @@ export function buildMobileActivityRepoOptions(repos: ConfigRepo[]): MobileActiv
       numeric: true,
     }),
   );
-}
-
-export function normalizeMobileActivityRepoSelection(selected: string | undefined, repos: ConfigRepo[]): string {
-  const value = selected?.trim() ?? "";
-  if (!value) return "";
-
-  const options = buildMobileActivityRepoOptions(repos);
-  if (options.some((option) => option.value === value)) return value;
-
-  const optionValues = new Set(options.map((option) => option.value));
-  for (const repo of repos) {
-    const legacyValue = providerRepoSelectorLabel(repo);
-    const nextValue = providerRepoSelectorValue(repo);
-    if (!legacyValue || !nextValue || !nextValue.includes("|")) continue;
-    if (legacyValue === value && optionValues.has(nextValue)) return nextValue;
-  }
-  return value;
 }


### PR DESCRIPTION
Workspace sidebar scanning now uses one View menu instead of separate sort controls.

- Move workspace sorting into the View menu.
- Add browser-local toggles for org names and PR diff stats.
- Keep browser coverage aligned with the new View trigger and menu placement.