### PR TITLE
Improve settings navigation layout

### DIFF
--- a/frontend/src/lib/components/settings/SettingsPage.svelte
+++ b/frontend/src/lib/components/settings/SettingsPage.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
+  import ArrowLeftIcon from "@lucide/svelte/icons/arrow-left";
+  import SearchIcon from "@lucide/svelte/icons/search";
   import { onMount } from "svelte";
   import { getStores } from "@middleman/ui";
   import type { Settings } from "@middleman/ui/api/types";
   import { getSettings } from "../../api/settings.js";
+  import { navigate } from "../../stores/router.svelte.js";
   import SettingsSection from "./SettingsSection.svelte";
   import RepoSettings from "./RepoSettings.svelte";
   import ActivitySettings from "./ActivitySettings.svelte";
@@ -10,11 +13,82 @@
   import ModeVisibilitySettings from "./ModeVisibilitySettings.svelte";
   import AgentSettings from "./AgentSettings.svelte";
 
+  interface SettingsNavItem {
+    id: string;
+    title: string;
+    group: string;
+    summary: string;
+    keywords: string;
+  }
+
   const { settings: settingsStore } = getStores();
+
+  const navItems: SettingsNavItem[] = [
+    {
+      id: "settings-repositories",
+      title: "Repositories",
+      group: "Providers",
+      summary: "Tracked repositories and import tools",
+      keywords: "repos repositories providers github gitlab forgejo gitea import glob",
+    },
+    {
+      id: "settings-activity",
+      title: "Activity",
+      group: "Workflow",
+      summary: "Default activity feed filters",
+      keywords: "activity feed defaults filters time range closed bots",
+    },
+    {
+      id: "settings-terminal",
+      title: "Terminal",
+      group: "Workspace",
+      summary: "Workspace terminal rendering and behavior",
+      keywords: "workspace terminal font renderer cursor scrollback ligatures",
+    },
+    {
+      id: "settings-modes",
+      title: "Visible modes",
+      group: "Navigation",
+      summary: "Modes shown in the app header",
+      keywords: "visible modes navigation tabs prs issues board reviews docs messages kata",
+    },
+    {
+      id: "settings-agents",
+      title: "Workspace agents",
+      group: "Workspace",
+      summary: "Agent commands available in workspaces",
+      keywords: "workspace agents codex claude gemini opencode aider binary arguments",
+    },
+  ];
 
   let settings = $state<Settings | null>(null);
   let loading = $state(true);
   let error = $state<string | null>(null);
+  let searchQuery = $state("");
+  let activeSection = $state(navItems[0]!.id);
+
+  const filteredNavItems = $derived.by(() => {
+    const query = searchQuery.trim().toLowerCase();
+    if (query === "") return navItems;
+    return navItems.filter((item) =>
+      `${item.title} ${item.group} ${item.summary} ${item.keywords}`
+        .toLowerCase()
+        .includes(query),
+    );
+  });
+
+  const groupedNavItems = $derived.by(() => {
+    const groups: { group: string; items: SettingsNavItem[] }[] = [];
+    for (const item of filteredNavItems) {
+      const group = groups.find((candidate) => candidate.group === item.group);
+      if (group) {
+        group.items.push(item);
+      } else {
+        groups.push({ group: item.group, items: [item] });
+      }
+    }
+    return groups;
+  });
 
   onMount(() => { void loadSettings(); });
 
@@ -32,59 +106,272 @@
       loading = false;
     }
   }
+
+  function backToApp(): void {
+    if (window.history.length > 1) {
+      window.history.back();
+      return;
+    }
+    navigate("/");
+  }
+
+  function scrollToSection(id: string): void {
+    activeSection = id;
+    document.getElementById(id)?.scrollIntoView({
+      block: "start",
+      behavior: "smooth",
+    });
+  }
+
+  function handleContentScroll(event: Event): void {
+    const scrollPane = event.currentTarget;
+    if (!(scrollPane instanceof HTMLElement)) return;
+    const paneTop = scrollPane.getBoundingClientRect().top;
+    let nextActive = activeSection;
+    let closestDistance = Number.POSITIVE_INFINITY;
+
+    for (const item of navItems) {
+      const section = document.getElementById(item.id);
+      if (!section) continue;
+      const distance = Math.abs(section.getBoundingClientRect().top - paneTop - 24);
+      if (distance < closestDistance) {
+        closestDistance = distance;
+        nextActive = item.id;
+      }
+    }
+
+    activeSection = nextActive;
+  }
 </script>
 
-<div class="settings-scroll-pane">
-  <div class="settings-page">
-    {#if loading}
-      <p class="state-msg">Loading settings...</p>
-    {:else if error}
-      <p class="state-msg state-error">Error: {error}</p>
-    {:else if settings}
-      <h1 class="page-title">Settings</h1>
+<div class="settings-shell">
+  <aside class="settings-sidebar" aria-label="Settings navigation">
+    <button class="back-button" type="button" onclick={backToApp}>
+      <ArrowLeftIcon size="15" strokeWidth="2" aria-hidden="true" />
+      <span>Back to app</span>
+    </button>
 
-      <SettingsSection title="Repositories">
-        <RepoSettings repos={settings.repos} onUpdate={(repos) => { settings = { ...settings!, repos }; settingsStore.setConfiguredRepos(repos); }} />
-      </SettingsSection>
+    <label class="settings-search">
+      <SearchIcon size="15" strokeWidth="2" aria-hidden="true" />
+      <input
+        type="search"
+        bind:value={searchQuery}
+        placeholder="Search settings..."
+        aria-label="Search settings"
+      />
+    </label>
 
-      <SettingsSection title="Activity feed defaults">
-        <ActivitySettings activity={settings.activity} onUpdate={(activity) => { settings = { ...settings!, activity }; }} />
-      </SettingsSection>
+    <nav class="settings-nav" aria-label="Settings sections">
+      {#if groupedNavItems.length === 0}
+        <p class="empty-nav">No matching settings</p>
+      {:else}
+        <div class="settings-nav-groups">
+          {#each groupedNavItems as group (group.group)}
+            <div class="settings-nav-group">
+              <div class="settings-nav-group-title">{group.group}</div>
+              <div class="settings-nav-items">
+                {#each group.items as item (item.id)}
+                  <button
+                    class={["settings-nav-item", activeSection === item.id && "settings-nav-item--active"]}
+                    type="button"
+                    onclick={() => scrollToSection(item.id)}
+                  >
+                    <span>{item.title}</span>
+                    <small>{item.summary}</small>
+                  </button>
+                {/each}
+              </div>
+            </div>
+          {/each}
+        </div>
+      {/if}
+    </nav>
+  </aside>
 
-      <SettingsSection title="Workspace terminal">
-        <TerminalSettings
-          terminal={settings.terminal}
-          onUpdate={(terminal) => {
-            settings = { ...settings!, terminal };
-            settingsStore.setTerminalSettings(terminal);
-          }}
-        />
-      </SettingsSection>
+  <div class="settings-scroll-pane" onscroll={handleContentScroll}>
+    <div class="settings-page">
+      {#if loading}
+        <p class="state-msg">Loading settings...</p>
+      {:else if error}
+        <p class="state-msg state-error">Error: {error}</p>
+      {:else if settings}
+        <header class="settings-page-header">
+          <h1 class="page-title">Settings</h1>
+          <p>Configure the local maintainer console without leaving the current workspace.</p>
+        </header>
 
-      <SettingsSection title="Visible modes">
-        <ModeVisibilitySettings
-          modes={settings.modes}
-          saveLabel="Save visible modes"
-          onUpdate={(modes) => {
-            settings = { ...settings!, modes };
-            settingsStore.setModeVisibility(modes);
-          }}
-        />
-      </SettingsSection>
+        <SettingsSection title="Repositories" sectionId="settings-repositories">
+          <RepoSettings repos={settings.repos} onUpdate={(repos) => { settings = { ...settings!, repos }; settingsStore.setConfiguredRepos(repos); }} />
+        </SettingsSection>
 
-      <SettingsSection title="Workspace agents">
-        <AgentSettings
-          agents={settings.agents}
-          onUpdate={(agents) => {
-            settings = { ...settings!, agents };
-          }}
-        />
-      </SettingsSection>
-    {/if}
+        <SettingsSection title="Activity feed defaults" sectionId="settings-activity">
+          <ActivitySettings activity={settings.activity} onUpdate={(activity) => { settings = { ...settings!, activity }; }} />
+        </SettingsSection>
+
+        <SettingsSection title="Workspace terminal" sectionId="settings-terminal">
+          <TerminalSettings
+            terminal={settings.terminal}
+            onUpdate={(terminal) => {
+              settings = { ...settings!, terminal };
+              settingsStore.setTerminalSettings(terminal);
+            }}
+          />
+        </SettingsSection>
+
+        <SettingsSection title="Visible modes" sectionId="settings-modes">
+          <ModeVisibilitySettings
+            modes={settings.modes}
+            saveLabel="Save visible modes"
+            onUpdate={(modes) => {
+              settings = { ...settings!, modes };
+              settingsStore.setModeVisibility(modes);
+            }}
+          />
+        </SettingsSection>
+
+        <SettingsSection title="Workspace agents" sectionId="settings-agents">
+          <AgentSettings
+            agents={settings.agents}
+            onUpdate={(agents) => {
+              settings = { ...settings!, agents };
+            }}
+          />
+        </SettingsSection>
+      {/if}
+    </div>
   </div>
 </div>
 
 <style>
+  .settings-shell {
+    flex: 1 1 auto;
+    min-height: 0;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    background: var(--bg-primary);
+  }
+
+  .settings-sidebar {
+    flex: 0 0 auto;
+    min-width: 0;
+    padding: 10px 12px;
+    border-bottom: 1px solid var(--border-default);
+    background: var(--bg-surface);
+  }
+
+  .back-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    min-height: 30px;
+    margin-bottom: 10px;
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+    font-weight: 600;
+  }
+
+  .back-button:hover {
+    color: var(--text-primary);
+  }
+
+  .settings-search {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 34px;
+    padding: 0 10px;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md);
+    color: var(--text-muted);
+    background: var(--bg-inset);
+  }
+
+  .settings-search input {
+    min-width: 0;
+    width: 100%;
+    border: 0;
+    outline: 0;
+    color: var(--text-primary);
+    background: transparent;
+    font-size: var(--font-size-sm);
+  }
+
+  .settings-search input::placeholder {
+    color: var(--text-muted);
+  }
+
+  .settings-nav {
+    margin-top: 12px;
+  }
+
+  .settings-nav-groups {
+    display: flex;
+    gap: 10px;
+    overflow-x: auto;
+    padding-bottom: 2px;
+  }
+
+  .settings-nav-group {
+    flex: 0 0 min(250px, 76vw);
+  }
+
+  .settings-nav-group-title {
+    margin: 0 0 6px;
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    font-weight: 650;
+    text-transform: uppercase;
+  }
+
+  .settings-nav-items {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .settings-nav-item {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    width: 100%;
+    min-height: 46px;
+    padding: 8px 10px;
+    border-radius: var(--radius-md);
+    color: var(--text-secondary);
+    text-align: left;
+  }
+
+  .settings-nav-item span {
+    color: var(--text-primary);
+    font-size: var(--font-size-sm);
+    font-weight: 650;
+  }
+
+  .settings-nav-item small {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    line-height: 1.25;
+  }
+
+  .settings-nav-item:hover {
+    background: var(--bg-surface-hover);
+  }
+
+  .settings-nav-item--active {
+    background: var(--bg-inset);
+  }
+
+  .settings-nav-item--active span {
+    color: var(--accent-blue);
+  }
+
+  .empty-nav {
+    margin: 0;
+    color: var(--text-muted);
+    font-size: var(--font-size-sm);
+  }
+
   .settings-scroll-pane {
     flex: 1 1 auto;
     min-height: 0;
@@ -93,10 +380,104 @@
   }
 
   .settings-page {
-    max-width: 640px; margin: 0 auto; padding: 24px 16px;
+    max-width: 760px; margin: 0 auto; padding: 22px 14px 28px;
     display: flex; flex-direction: column; gap: 16px;
   }
-  .page-title { font-size: var(--font-size-xl); font-weight: 600; color: var(--text-primary); margin: 0; }
+
+  .settings-page-header {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .page-title { font-size: var(--font-size-xl); font-weight: 650; color: var(--text-primary); margin: 0; }
+
+  .settings-page-header p {
+    margin: 0;
+    color: var(--text-muted);
+    font-size: var(--font-size-sm);
+    line-height: 1.45;
+  }
+
   .state-msg { padding: 40px; text-align: center; color: var(--text-muted); font-size: var(--font-size-md); }
   .state-error { color: var(--accent-red); }
+
+  @media (max-width: 47.999rem) {
+    .settings-nav-groups {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      overflow-x: visible;
+      gap: 12px;
+    }
+
+    .settings-nav-group {
+      min-width: 0;
+      flex-basis: auto;
+    }
+
+    .settings-nav-group-title {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .settings-nav-item {
+      min-height: 34px;
+      padding: 7px 9px;
+    }
+
+    .settings-nav-item small {
+      display: none;
+    }
+  }
+
+  @media (min-width: 48rem) {
+    .settings-sidebar {
+      padding: 12px 16px;
+    }
+
+    .settings-page {
+      padding: 26px 20px 34px;
+    }
+  }
+
+  @media (min-width: 64rem) {
+    .settings-shell {
+      flex-direction: row;
+    }
+
+    .settings-sidebar {
+      width: 288px;
+      height: 100%;
+      padding: 14px 12px;
+      overflow-y: auto;
+      border-right: 1px solid var(--border-default);
+      border-bottom: 0;
+    }
+
+    .settings-nav-groups {
+      flex-direction: column;
+      overflow-x: visible;
+      padding-bottom: 0;
+    }
+
+    .settings-nav-group {
+      flex-basis: auto;
+    }
+
+    .settings-page {
+      padding: 30px 24px 40px;
+    }
+  }
+
+  @media (min-width: 80rem) {
+    .settings-sidebar {
+      width: 320px;
+      padding: 16px;
+    }
+
+    .settings-page {
+      max-width: 820px;
+    }
+  }
 </style>

--- a/frontend/src/lib/components/settings/SettingsPage.svelte
+++ b/frontend/src/lib/components/settings/SettingsPage.svelte
@@ -34,59 +34,67 @@
   }
 </script>
 
-<div class="settings-page">
-  {#if loading}
-    <p class="state-msg">Loading settings...</p>
-  {:else if error}
-    <p class="state-msg state-error">Error: {error}</p>
-  {:else if settings}
-    <h1 class="page-title">Settings</h1>
+<div class="settings-scroll-pane">
+  <div class="settings-page">
+    {#if loading}
+      <p class="state-msg">Loading settings...</p>
+    {:else if error}
+      <p class="state-msg state-error">Error: {error}</p>
+    {:else if settings}
+      <h1 class="page-title">Settings</h1>
 
-    <SettingsSection title="Repositories">
-      <RepoSettings repos={settings.repos} onUpdate={(repos) => { settings = { ...settings!, repos }; settingsStore.setConfiguredRepos(repos); }} />
-    </SettingsSection>
+      <SettingsSection title="Repositories">
+        <RepoSettings repos={settings.repos} onUpdate={(repos) => { settings = { ...settings!, repos }; settingsStore.setConfiguredRepos(repos); }} />
+      </SettingsSection>
 
-    <SettingsSection title="Activity feed defaults">
-      <ActivitySettings activity={settings.activity} onUpdate={(activity) => { settings = { ...settings!, activity }; }} />
-    </SettingsSection>
+      <SettingsSection title="Activity feed defaults">
+        <ActivitySettings activity={settings.activity} onUpdate={(activity) => { settings = { ...settings!, activity }; }} />
+      </SettingsSection>
 
-    <SettingsSection title="Workspace terminal">
-      <TerminalSettings
-        terminal={settings.terminal}
-        onUpdate={(terminal) => {
-          settings = { ...settings!, terminal };
-          settingsStore.setTerminalSettings(terminal);
-        }}
-      />
-    </SettingsSection>
+      <SettingsSection title="Workspace terminal">
+        <TerminalSettings
+          terminal={settings.terminal}
+          onUpdate={(terminal) => {
+            settings = { ...settings!, terminal };
+            settingsStore.setTerminalSettings(terminal);
+          }}
+        />
+      </SettingsSection>
 
-    <SettingsSection title="Visible modes">
-      <ModeVisibilitySettings
-        modes={settings.modes}
-        saveLabel="Save visible modes"
-        onUpdate={(modes) => {
-          settings = { ...settings!, modes };
-          settingsStore.setModeVisibility(modes);
-        }}
-      />
-    </SettingsSection>
+      <SettingsSection title="Visible modes">
+        <ModeVisibilitySettings
+          modes={settings.modes}
+          saveLabel="Save visible modes"
+          onUpdate={(modes) => {
+            settings = { ...settings!, modes };
+            settingsStore.setModeVisibility(modes);
+          }}
+        />
+      </SettingsSection>
 
-    <SettingsSection title="Workspace agents">
-      <AgentSettings
-        agents={settings.agents}
-        onUpdate={(agents) => {
-          settings = { ...settings!, agents };
-        }}
-      />
-    </SettingsSection>
-  {/if}
+      <SettingsSection title="Workspace agents">
+        <AgentSettings
+          agents={settings.agents}
+          onUpdate={(agents) => {
+            settings = { ...settings!, agents };
+          }}
+        />
+      </SettingsSection>
+    {/if}
+  </div>
 </div>
 
 <style>
+  .settings-scroll-pane {
+    flex: 1 1 auto;
+    min-height: 0;
+    width: 100%;
+    overflow-y: auto;
+  }
+
   .settings-page {
     max-width: 640px; margin: 0 auto; padding: 24px 16px;
     display: flex; flex-direction: column; gap: 16px;
-    overflow-y: auto; height: 100%;
   }
   .page-title { font-size: var(--font-size-xl); font-weight: 600; color: var(--text-primary); margin: 0; }
   .state-msg { padding: 40px; text-align: center; color: var(--text-muted); font-size: var(--font-size-md); }

--- a/frontend/src/lib/components/settings/SettingsPage.svelte
+++ b/frontend/src/lib/components/settings/SettingsPage.svelte
@@ -218,6 +218,15 @@
           />
         </SettingsSection>
 
+        <SettingsSection title="Workspace agents" sectionId="settings-agents">
+          <AgentSettings
+            agents={settings.agents}
+            onUpdate={(agents) => {
+              settings = { ...settings!, agents };
+            }}
+          />
+        </SettingsSection>
+
         <SettingsSection title="Visible modes" sectionId="settings-modes">
           <ModeVisibilitySettings
             modes={settings.modes}
@@ -225,15 +234,6 @@
             onUpdate={(modes) => {
               settings = { ...settings!, modes };
               settingsStore.setModeVisibility(modes);
-            }}
-          />
-        </SettingsSection>
-
-        <SettingsSection title="Workspace agents" sectionId="settings-agents">
-          <AgentSettings
-            agents={settings.agents}
-            onUpdate={(agents) => {
-              settings = { ...settings!, agents };
             }}
           />
         </SettingsSection>

--- a/frontend/src/lib/components/settings/SettingsSection.svelte
+++ b/frontend/src/lib/components/settings/SettingsSection.svelte
@@ -3,13 +3,14 @@
 
   interface Props {
     title: string;
+    sectionId?: string;
     children: Snippet;
   }
 
-  let { title, children }: Props = $props();
+  let { title, sectionId, children }: Props = $props();
 </script>
 
-<section class="settings-section">
+<section class="settings-section" id={sectionId}>
   <h2 class="section-title">{title}</h2>
   <div class="section-body">
     {@render children()}

--- a/frontend/src/lib/components/settings/TerminalSettings.svelte
+++ b/frontend/src/lib/components/settings/TerminalSettings.svelte
@@ -586,15 +586,6 @@
     min-width: 0;
   }
 
-  .renderer-field :global(.select-dropdown-trigger) {
-    height: 28px;
-    background: var(--bg-primary);
-    border-color: var(--border-default);
-    color: var(--text-primary);
-    font-size: var(--font-size-sm);
-    font-weight: 400;
-  }
-
   .toggle-field {
     display: inline-flex;
     align-items: center;

--- a/frontend/src/lib/components/settings/TerminalSettings.svelte
+++ b/frontend/src/lib/components/settings/TerminalSettings.svelte
@@ -3,6 +3,7 @@
   import {
     DEFAULT_TERMINAL_SETTINGS,
     getStores,
+    SelectDropdown,
   } from "@middleman/ui";
   import XIcon from "@lucide/svelte/icons/x";
   import type { TerminalSettings as TerminalSettingsType } from "@middleman/ui/api/types";
@@ -46,6 +47,10 @@
     "Monaco",
     "Consolas",
     "Courier New",
+  ];
+  const rendererOptions = [
+    { value: "xterm", label: "xterm.js" },
+    { value: "ghostty-web", label: "ghostty-web" },
   ];
 
   let draftReady = $state(false);
@@ -375,18 +380,19 @@
       />
     </label>
 
-    <label class="renderer-field" for="terminal-renderer">
+    <div class="renderer-field">
       <span class="setting-label">Terminal renderer</span>
-      <select
-        id="terminal-renderer"
-        class="renderer-select"
-        bind:value={rendererDraft}
+      <SelectDropdown
+        class="renderer-dropdown"
+        value={rendererDraft}
+        options={rendererOptions}
+        onchange={(value) => {
+          rendererDraft = value as TerminalSettingsType["renderer"];
+        }}
+        title="Terminal renderer"
         disabled={saving}
-      >
-        <option value="xterm">xterm.js</option>
-        <option value="ghostty-web">ghostty-web</option>
-      </select>
-    </label>
+      />
+    </div>
   </div>
 
   <label class="toggle-field">
@@ -559,8 +565,7 @@
   }
 
   .font-input,
-  .number-input,
-  .renderer-select {
+  .number-input {
     width: 100%;
     height: 28px;
     border: 1px solid var(--border-default);
@@ -574,6 +579,20 @@
 
   .font-input {
     font-family: var(--font-mono);
+  }
+
+  .renderer-field :global(.renderer-dropdown) {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .renderer-field :global(.select-dropdown-trigger) {
+    height: 28px;
+    background: var(--bg-primary);
+    border-color: var(--border-default);
+    color: var(--text-primary);
+    font-size: var(--font-size-sm);
+    font-weight: 400;
   }
 
   .toggle-field {

--- a/frontend/src/lib/components/settings/TerminalSettings.test.ts
+++ b/frontend/src/lib/components/settings/TerminalSettings.test.ts
@@ -6,23 +6,27 @@ const { mockSetTerminalSettings, mockUpdateSettings } = vi.hoisted(() => ({
   mockUpdateSettings: vi.fn(),
 }));
 
-vi.mock("@middleman/ui", () => ({
-  DEFAULT_TERMINAL_SETTINGS: {
-    font_family: "",
-    font_size: 14,
-    scrollback: 1000,
-    line_height: 1,
-    letter_spacing: 0,
-    cursor_blink: true,
-    font_ligatures: false,
-    renderer: "xterm",
-  },
-  getStores: () => ({
-    settings: {
-      setTerminalSettings: mockSetTerminalSettings,
+vi.mock("@middleman/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@middleman/ui")>();
+  return {
+    ...actual,
+    DEFAULT_TERMINAL_SETTINGS: {
+      font_family: "",
+      font_size: 14,
+      scrollback: 1000,
+      line_height: 1,
+      letter_spacing: 0,
+      cursor_blink: true,
+      font_ligatures: false,
+      renderer: "xterm",
     },
-  }),
-}));
+    getStores: () => ({
+      settings: {
+        setTerminalSettings: mockSetTerminalSettings,
+      },
+    }),
+  };
+});
 
 vi.mock("../../api/settings.js", () => ({
   updateSettings: mockUpdateSettings,
@@ -152,9 +156,12 @@ describe("TerminalSettings", () => {
       },
     });
 
-    await fireEvent.change(screen.getByLabelText("Terminal renderer"), {
-      target: { value: "ghostty-web" },
+    expect(document.querySelector("select#terminal-renderer")).toBeNull();
+    const rendererDropdown = screen.getByRole("combobox", {
+      name: "Terminal renderer: xterm.js",
     });
+    await fireEvent.click(rendererDropdown);
+    await fireEvent.click(screen.getByRole("option", { name: "ghostty-web" }));
     await fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => {

--- a/frontend/src/lib/components/terminal/TerminalOptionsMenu.test.ts
+++ b/frontend/src/lib/components/terminal/TerminalOptionsMenu.test.ts
@@ -71,38 +71,42 @@ const {
   };
 });
 
-vi.mock("@middleman/ui", () => ({
-  DEFAULT_MODE_VISIBILITY: {
-    activity: true,
-    repos: true,
-    kata: false,
-    docs: false,
-    messages: false,
-    pulls: true,
-    issues: true,
-    board: true,
-    reviews: true,
-    workspaces: true,
-  },
-  DEFAULT_TERMINAL_SETTINGS: {
-    font_family: "",
-    font_size: 14,
-    scrollback: 1000,
-    line_height: 1,
-    letter_spacing: 0,
-    cursor_blink: true,
-    font_ligatures: false,
-    renderer: "xterm",
-  },
-  getStores: () => ({
-    settings: {
-      getTerminalSettings: () => currentTerminal.value,
-      getModeVisibility: () => currentModes.value,
-      setModeVisibility: mockSetModeVisibility,
-      setTerminalSettings: mockSetTerminalSettings,
+vi.mock("@middleman/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@middleman/ui")>();
+  return {
+    ...actual,
+    DEFAULT_MODE_VISIBILITY: {
+      activity: true,
+      repos: true,
+      kata: false,
+      docs: false,
+      messages: false,
+      pulls: true,
+      issues: true,
+      board: true,
+      reviews: true,
+      workspaces: true,
     },
-  }),
-}));
+    DEFAULT_TERMINAL_SETTINGS: {
+      font_family: "",
+      font_size: 14,
+      scrollback: 1000,
+      line_height: 1,
+      letter_spacing: 0,
+      cursor_blink: true,
+      font_ligatures: false,
+      renderer: "xterm",
+    },
+    getStores: () => ({
+      settings: {
+        getTerminalSettings: () => currentTerminal.value,
+        getModeVisibility: () => currentModes.value,
+        setModeVisibility: mockSetModeVisibility,
+        setTerminalSettings: mockSetTerminalSettings,
+      },
+    }),
+  };
+});
 
 vi.mock("../../api/settings.js", () => ({
   updateSettings: mockUpdateSettings,

--- a/frontend/tests/e2e-full/00-settings-terminal-font.spec.ts
+++ b/frontend/tests/e2e-full/00-settings-terminal-font.spec.ts
@@ -77,7 +77,9 @@ test("settings saves and reloads workspace terminal options", async ({ page }) =
   const lineHeight = page.getByLabel("Line height");
   const letterSpacing = page.getByLabel("Letter spacing");
   const cursorBlink = page.getByLabel("Cursor blink");
-  const renderer = page.getByLabel("Terminal renderer");
+  const renderer = page.getByRole("combobox", {
+    name: "Terminal renderer: xterm.js",
+  });
   const saveButton = page.getByRole("button", {
     name: "Save",
     exact: true,
@@ -88,13 +90,15 @@ test("settings saves and reloads workspace terminal options", async ({ page }) =
   await expect(lineHeight).toHaveValue("1");
   await expect(letterSpacing).toHaveValue("0");
   await expect(cursorBlink).toBeChecked();
-  await expect(renderer).toHaveValue("xterm");
+  await expect(page.locator("select#terminal-renderer")).toHaveCount(0);
+  await expect(renderer).toHaveText("xterm.js");
 
   await fontSize.fill("18");
   await scrollback.fill("5000");
   await lineHeight.fill("1.15");
   await letterSpacing.fill("1");
-  await renderer.selectOption("ghostty-web");
+  await renderer.click();
+  await page.getByRole("option", { name: "ghostty-web" }).click();
   await cursorBlink.uncheck();
   await input.click();
   await input.pressSequentially('"Iosevka Term", monospace');
@@ -146,7 +150,11 @@ test("settings saves and reloads workspace terminal options", async ({ page }) =
   await expect(page.getByLabel("Line height")).toHaveValue("1.15");
   await expect(page.getByLabel("Letter spacing")).toHaveValue("1");
   await expect(page.getByLabel("Cursor blink")).not.toBeChecked();
-  await expect(page.getByLabel("Terminal renderer")).toHaveValue("ghostty-web");
+  await expect(
+    page.getByRole("combobox", {
+      name: "Terminal renderer: ghostty-web",
+    }),
+  ).toHaveText("ghostty-web");
 });
 
 test("settings saves visible modes and hides disabled nav entries", async ({ page }) => {

--- a/frontend/tests/e2e/viewport-fit.spec.ts
+++ b/frontend/tests/e2e/viewport-fit.spec.ts
@@ -6,18 +6,54 @@ test.beforeEach(async ({ page }) => {
   await mockApi(page);
 });
 
+test("settings page scrolls from the full-width main pane", async ({ page }) => {
+  await page.goto("/settings");
+
+  await expect(page.locator(".settings-page")).toBeVisible();
+  await expect(
+    page.evaluate(() => {
+      const main = document.querySelector<HTMLElement>(".app-main");
+      const pane = document.querySelector<HTMLElement>(".settings-scroll-pane");
+      const content = document.querySelector<HTMLElement>(".settings-page");
+      if (!main || !pane || !content) return null;
+
+      const mainRect = main.getBoundingClientRect();
+      const paneRect = pane.getBoundingClientRect();
+      const contentRect = content.getBoundingClientRect();
+      const beforeTop = contentRect.top;
+      pane.scrollTop = 120;
+      const afterTop = content.getBoundingClientRect().top;
+
+      return {
+        paneFillsMain:
+          Math.round(paneRect.left) === Math.round(mainRect.left) &&
+          Math.round(paneRect.right) === Math.round(mainRect.right),
+        contentIsCentered:
+          Math.abs(contentRect.left + contentRect.width / 2 - (mainRect.left + mainRect.width / 2)) < 1,
+        paneCanScroll: pane.scrollHeight > pane.clientHeight,
+        contentMovesWithPane: afterTop < beforeTop,
+      };
+    }),
+  ).resolves.toEqual({
+    paneFillsMain: true,
+    contentIsCentered: true,
+    paneCanScroll: true,
+    contentMovesWithPane: true,
+  });
+});
+
 test("Firefox receives compact scrollbar styling for app scroll panes", async ({ page, browserName }) => {
   test.skip(browserName !== "firefox", "Firefox-specific scrollbar regression");
 
   await page.goto("/settings");
 
-  await expect(page.locator(".settings-page")).toBeVisible();
-  await expect(page.locator(".settings-page").evaluate((pane) => pane.scrollHeight > pane.clientHeight)).resolves.toBe(
-    true,
-  );
+  await expect(page.locator(".settings-scroll-pane")).toBeVisible();
+  await expect(
+    page.locator(".settings-scroll-pane").evaluate((pane) => pane.scrollHeight > pane.clientHeight),
+  ).resolves.toBe(true);
   await expect(
     page.evaluate(() => {
-      const settingsPane = document.querySelector(".settings-page");
+      const settingsPane = document.querySelector(".settings-scroll-pane");
       const appRules = Array.from(document.styleSheets)
         .flatMap((sheet) => {
           try {

--- a/frontend/tests/e2e/viewport-fit.spec.ts
+++ b/frontend/tests/e2e/viewport-fit.spec.ts
@@ -6,18 +6,24 @@ test.beforeEach(async ({ page }) => {
   await mockApi(page);
 });
 
-test("settings page scrolls from the full-width main pane", async ({ page }) => {
+test("settings page uses a sidebar and scrollable content pane", async ({ page }) => {
   await page.goto("/settings");
 
   await expect(page.locator(".settings-page")).toBeVisible();
+  await expect(page.getByRole("navigation", { name: "Settings sections" })).toBeVisible();
+  await expect(page.getByPlaceholder("Search settings...")).toBeVisible();
   await expect(
     page.evaluate(() => {
       const main = document.querySelector<HTMLElement>(".app-main");
+      const shell = document.querySelector<HTMLElement>(".settings-shell");
+      const sidebar = document.querySelector<HTMLElement>(".settings-sidebar");
       const pane = document.querySelector<HTMLElement>(".settings-scroll-pane");
       const content = document.querySelector<HTMLElement>(".settings-page");
-      if (!main || !pane || !content) return null;
+      if (!main || !shell || !sidebar || !pane || !content) return null;
 
       const mainRect = main.getBoundingClientRect();
+      const shellRect = shell.getBoundingClientRect();
+      const sidebarRect = sidebar.getBoundingClientRect();
       const paneRect = pane.getBoundingClientRect();
       const contentRect = content.getBoundingClientRect();
       const beforeTop = contentRect.top;
@@ -25,20 +31,63 @@ test("settings page scrolls from the full-width main pane", async ({ page }) => 
       const afterTop = content.getBoundingClientRect().top;
 
       return {
-        paneFillsMain:
-          Math.round(paneRect.left) === Math.round(mainRect.left) &&
+        shellFillsMain:
+          Math.round(shellRect.left) === Math.round(mainRect.left) &&
+          Math.round(shellRect.right) === Math.round(mainRect.right),
+        sidebarStartsAtMainEdge: Math.round(sidebarRect.left) === Math.round(mainRect.left),
+        paneFillsRemainingWidth:
+          Math.round(paneRect.left) >= Math.round(sidebarRect.right) &&
           Math.round(paneRect.right) === Math.round(mainRect.right),
         contentIsCentered:
-          Math.abs(contentRect.left + contentRect.width / 2 - (mainRect.left + mainRect.width / 2)) < 1,
+          Math.abs(contentRect.left + contentRect.width / 2 - (paneRect.left + paneRect.width / 2)) < 1,
         paneCanScroll: pane.scrollHeight > pane.clientHeight,
         contentMovesWithPane: afterTop < beforeTop,
       };
     }),
   ).resolves.toEqual({
-    paneFillsMain: true,
+    shellFillsMain: true,
+    sidebarStartsAtMainEdge: true,
+    paneFillsRemainingWidth: true,
     contentIsCentered: true,
     paneCanScroll: true,
     contentMovesWithPane: true,
+  });
+
+  await page
+    .getByRole("navigation", { name: "Settings sections" })
+    .getByRole("button", { name: "Workspace agents" })
+    .click();
+  await expect(page.locator("#settings-agents")).toBeInViewport();
+});
+
+test("settings navigation stacks below Tailwind lg breakpoint", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 800 });
+  await page.goto("/settings");
+
+  await expect(page.locator(".settings-page")).toBeVisible();
+  await expect(
+    page.evaluate(() => {
+      const shell = document.querySelector<HTMLElement>(".settings-shell");
+      const sidebar = document.querySelector<HTMLElement>(".settings-sidebar");
+      const pane = document.querySelector<HTMLElement>(".settings-scroll-pane");
+      if (!shell || !sidebar || !pane) return null;
+
+      const shellRect = shell.getBoundingClientRect();
+      const sidebarRect = sidebar.getBoundingClientRect();
+      const paneRect = pane.getBoundingClientRect();
+
+      return {
+        navStacksAboveContent: Math.round(sidebarRect.bottom) <= Math.round(paneRect.top),
+        navFitsViewport: Math.round(sidebarRect.left) >= 0 && Math.round(sidebarRect.right) <= window.innerWidth,
+        contentFitsViewport: document.documentElement.scrollWidth <= window.innerWidth,
+        shellFillsViewport: Math.round(shellRect.width) === window.innerWidth,
+      };
+    }),
+  ).resolves.toEqual({
+    navStacksAboveContent: true,
+    navFitsViewport: true,
+    contentFitsViewport: true,
+    shellFillsViewport: true,
   });
 });
 

--- a/frontend/tests/e2e/viewport-fit.spec.ts
+++ b/frontend/tests/e2e/viewport-fit.spec.ts
@@ -60,6 +60,30 @@ test("settings page uses a sidebar and scrollable content pane", async ({ page }
   await expect(page.locator("#settings-agents")).toBeInViewport();
 });
 
+test("settings sidebar order matches rendered section order", async ({ page }) => {
+  await page.goto("/settings");
+
+  await expect(page.locator(".settings-page")).toBeVisible();
+  await expect(
+    page.evaluate(() => {
+      const navLabel = (label: string) =>
+        label.replace("Activity feed defaults", "Activity").replace("Workspace terminal", "Terminal");
+      const navOrder = Array.from(document.querySelectorAll<HTMLElement>(".settings-nav-item span")).map(
+        (item) => item.textContent?.trim() ?? "",
+      );
+      const sectionOrder = Array.from(document.querySelectorAll<HTMLElement>(".settings-section > h2")).map((section) =>
+        navLabel(section.textContent?.trim() ?? ""),
+      );
+
+      return { navOrder, sectionOrder, orderMatches: navOrder.join("\n") === sectionOrder.join("\n") };
+    }),
+  ).resolves.toEqual({
+    navOrder: ["Repositories", "Activity", "Terminal", "Workspace agents", "Visible modes"],
+    sectionOrder: ["Repositories", "Activity", "Terminal", "Workspace agents", "Visible modes"],
+    orderMatches: true,
+  });
+});
+
 test("settings navigation stacks below Tailwind lg breakpoint", async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 800 });
   await page.goto("/settings");


### PR DESCRIPTION
Settings had grown enough that a single scrolling column made it hard to move between related controls and easy for the visible scrollbar to feel detached from the usable page.

- Adds searchable grouped settings navigation with a persistent desktop sidebar and stacked mobile layout
- Keeps the settings content pane responsible for scrolling across desktop and mobile breakpoints
- Aligns Workspace agents and Visible modes ordering between the sidebar and rendered sections
- Uses the shared dropdown control for the terminal renderer setting

Screenshot:
![settings-wide-pr.png](https://github.com/user-attachments/assets/74868134-2cea-4424-8bdd-fb7c1524315c)
