### PR TITLE
Lower PR split view threshold

### DIFF
--- a/frontend/tests/e2e/pr-split-view.spec.ts
+++ b/frontend/tests/e2e/pr-split-view.spec.ts
@@ -149,8 +149,12 @@ test.beforeEach(async ({ page }) => {
   await mockSplitViewPR(page);
 });
 
+async function detailHostWidth(page: Page): Promise<number> {
+  return Math.round(await page.locator(".detail-host").evaluate((el) => el.getBoundingClientRect().width));
+}
+
 test("lets wide PR detail panes opt into split conversation and files", async ({ page }) => {
-  await page.setViewportSize({ width: 2200, height: 1000 });
+  await page.setViewportSize({ width: 1600, height: 1000 });
   await page.goto("/pulls/github/acme/widgets/42");
 
   await expect(page.locator(".detail-title")).toContainText("Add browser regression coverage");
@@ -160,6 +164,12 @@ test("lets wide PR detail panes opt into split conversation and files", async ({
     name: "Split view",
     exact: true,
   });
+  await expect.poll(async () => detailHostWidth(page)).toBeLessThan(1280);
+  await expect(splitToggle).toHaveCount(0);
+
+  await page.setViewportSize({ width: 1680, height: 1000 });
+  await expect.poll(async () => detailHostWidth(page)).toBeGreaterThanOrEqual(1280);
+  await expect.poll(async () => detailHostWidth(page)).toBeLessThan(1696);
   await expect(splitToggle).toBeVisible();
   await expect(splitToggle).toHaveAttribute("aria-pressed", "false");
 

--- a/packages/ui/src/views/PRListView.svelte
+++ b/packages/ui/src/views/PRListView.svelte
@@ -34,8 +34,7 @@
   const { detail: detailStore } = getStores();
   const splitViewStorageKey = "pr-detail-split-view";
   const splitViewRatioStorageKey = "pr-detail-split-ratio";
-  const regularConversationPanelWidth = 800 + 24 + 24;
-  const minSplitViewWidth = regularConversationPanelWidth * 2;
+  const minSplitViewWidth = 1280;
   const minSplitPaneWidth = 480;
   const splitResizeHandleWidth = 4;
 

--- a/packages/ui/src/views/PRListView.test.ts
+++ b/packages/ui/src/views/PRListView.test.ts
@@ -20,7 +20,7 @@ vi.mock("../components/diff/DiffFilesLayout.svelte", async () => ({
 
 import PRListView from "./PRListView.svelte";
 
-const minSplitViewWidth = (800 + 24 + 24) * 2;
+const minSplitViewWidth = 1280;
 
 const selectedPR: PullRequestRouteRef = {
   provider: "github",
@@ -105,7 +105,7 @@ describe("PRListView split view", () => {
     vi.unstubAllGlobals();
   });
 
-  it("does not expose split view below twice the regular conversation width", async () => {
+  it("does not expose split view below the xl detail-pane width", async () => {
     observedWidth.value = minSplitViewWidth - 1;
 
     renderPRListView();


### PR DESCRIPTION
- Lower the PR conversation/files split view gate to a 1280px detail-pane width.
- Keep regression coverage for the toggle appearing at the new threshold.

![pr-split-view-1280.png](https://github.com/user-attachments/assets/9077fcde-fdb2-484e-88e5-cedad7e7e017)