### PR TITLE
Fix rich preview review card placement

### DIFF
--- a/docs/superpowers/plans/2026-06-18-rich-preview-review-card-anchoring.md
+++ b/docs/superpowers/plans/2026-06-18-rich-preview-review-card-anchoring.md
@@ -5,7 +5,7 @@
 
 **Goal:** Replace fragment-rendered Markdown rich preview with a source-line-aware render model that preserves Markdown semantics and anchors review cards in unified and split modes.
 
-**Architecture:** Add a pure Markdown rich-preview model under `packages/ui/src/utils/` that builds old/new Markdown documents from diff hunks, maps generated Markdown lines back to source diff lines, renders top-level Markdown tokens through the canonical renderer, and produces unified/split block HTML. `DiffRichPreview.svelte` consumes that model and only assigns/render review cards against explicit block ranges. Structured Markdown containers anchor at the top-level token boundary so cards do not become invalid list/table/blockquote children. Synthetic hunk separators are parser-only, have no source mapping, are stripped from spanning tokens before rendering, and are not rendered or aligned as preview blocks. User-authored `---` lines keep their source mapping and render normally. The model uses a bounded block comparison strategy for large Markdown diffs.
+**Architecture:** Add a pure Markdown rich-preview model under `packages/ui/src/utils/` that builds old/new Markdown documents from diff hunks, maps generated Markdown lines back to source diff lines, renders top-level Markdown tokens through the canonical renderer, and produces unified/split block HTML. `DiffRichPreview.svelte` consumes that model and only assigns/render review cards against exact mapped source-line sets; start/end ranges are display metadata and do not imply that hidden hunk-gap lines are contained. Structured Markdown containers anchor at the top-level token boundary so cards do not become invalid list/table/blockquote children. Synthetic hunk separators are parser-only, have no source mapping, are stripped from spanning tokens before rendering, and are not rendered or aligned as preview blocks. Stripped spanning-token renders carry in-document reference definitions as parser context. User-authored `---` lines keep their source mapping and render normally. The model uses a bounded block comparison strategy for large Markdown diffs.
 
 **Tech Stack:** Svelte 5, TypeScript, Marked, DOMPurify, existing `renderMarkdownDiff` and `renderMarkdownSplitDiff`, Vite+/Vitest, Playwright.
 
@@ -111,8 +111,10 @@ export interface MarkdownRichPreviewBlock {
   key: string;
   oldStart?: number | undefined;
   oldEnd?: number | undefined;
+  oldLines?: number[] | undefined;
   newStart?: number | undefined;
   newEnd?: number | undefined;
+  newLines?: number[] | undefined;
   unifiedHtml: string;
   beforeHtml?: string | undefined;
   afterHtml?: string | undefined;
@@ -159,7 +161,7 @@ Unified mode renders each block's `unifiedHtml` followed by assigned review card
 
 - [x] **Step 1: Add component tests**
 
-Add tests proving Markdown semantics survive anchored cards, split mode does not dump line comments at the top, synthetic separators stay hidden for standalone and spanning-token cases, and user-authored thematic breaks remain visible.
+Add tests proving Markdown semantics survive anchored cards, split mode does not dump line comments at the top, synthetic separators stay hidden for standalone fenced-code, HTML-block, blockquote, and list-continuation cases, user-authored thematic breaks remain visible, and review threads targeting hidden hunk gaps fall back instead of anchoring to a spanning block's display range.
 
 - [x] **Step 2: Run component tests and verify RED before production wiring if not already red**
 

--- a/docs/superpowers/plans/2026-06-18-rich-preview-review-card-anchoring.md
+++ b/docs/superpowers/plans/2026-06-18-rich-preview-review-card-anchoring.md
@@ -1,10 +1,11 @@
 # Rich Preview Review Card Anchoring Implementation Plan
 
 > **Status:** Implemented on the rich-preview review-card branch. This plan is kept as historical implementation context; completed checkboxes describe work already done, not new pending tasks.
+> RED/GREEN notes below describe the original implementation workflow at the time each step was executed. They are not predictions about the current repository state.
 
 **Goal:** Replace fragment-rendered Markdown rich preview with a source-line-aware render model that preserves Markdown semantics and anchors review cards in unified and split modes.
 
-**Architecture:** Add a pure Markdown rich-preview model under `packages/ui/src/utils/` that builds old/new Markdown documents from diff hunks, maps generated Markdown lines back to source diff lines, renders top-level Markdown tokens through the canonical renderer, and produces unified/split block HTML. `DiffRichPreview.svelte` consumes that model and only assigns/render review cards against explicit block ranges. Structured Markdown containers anchor at the top-level token boundary so cards do not become invalid list/table/blockquote children. The model uses a bounded block comparison strategy for large Markdown diffs.
+**Architecture:** Add a pure Markdown rich-preview model under `packages/ui/src/utils/` that builds old/new Markdown documents from diff hunks, maps generated Markdown lines back to source diff lines, renders top-level Markdown tokens through the canonical renderer, and produces unified/split block HTML. `DiffRichPreview.svelte` consumes that model and only assigns/render review cards against explicit block ranges. Structured Markdown containers anchor at the top-level token boundary so cards do not become invalid list/table/blockquote children. Synthetic hunk separators are parser-only, have no source mapping, and are not rendered or aligned as preview blocks. The model uses a bounded block comparison strategy for large Markdown diffs.
 
 **Tech Stack:** Svelte 5, TypeScript, Marked, DOMPurify, existing `renderMarkdownDiff` and `renderMarkdownSplitDiff`, Vite+/Vitest, Playwright.
 

--- a/docs/superpowers/plans/2026-06-18-rich-preview-review-card-anchoring.md
+++ b/docs/superpowers/plans/2026-06-18-rich-preview-review-card-anchoring.md
@@ -5,7 +5,7 @@
 
 **Goal:** Replace fragment-rendered Markdown rich preview with a source-line-aware render model that preserves Markdown semantics and anchors review cards in unified and split modes.
 
-**Architecture:** Add a pure Markdown rich-preview model under `packages/ui/src/utils/` that builds old/new Markdown documents from diff hunks, maps generated Markdown lines back to source diff lines, renders top-level Markdown tokens through the canonical renderer, and produces unified/split block HTML. `DiffRichPreview.svelte` consumes that model and only assigns/render review cards against explicit block ranges. Structured Markdown containers anchor at the top-level token boundary so cards do not become invalid list/table/blockquote children. Synthetic hunk separators are parser-only, have no source mapping, and are not rendered or aligned as preview blocks. The model uses a bounded block comparison strategy for large Markdown diffs.
+**Architecture:** Add a pure Markdown rich-preview model under `packages/ui/src/utils/` that builds old/new Markdown documents from diff hunks, maps generated Markdown lines back to source diff lines, renders top-level Markdown tokens through the canonical renderer, and produces unified/split block HTML. `DiffRichPreview.svelte` consumes that model and only assigns/render review cards against explicit block ranges. Structured Markdown containers anchor at the top-level token boundary so cards do not become invalid list/table/blockquote children. Synthetic hunk separators are parser-only, have no source mapping, are stripped from spanning tokens before rendering, and are not rendered or aligned as preview blocks. User-authored `---` lines keep their source mapping and render normally. The model uses a bounded block comparison strategy for large Markdown diffs.
 
 **Tech Stack:** Svelte 5, TypeScript, Marked, DOMPurify, existing `renderMarkdownDiff` and `renderMarkdownSplitDiff`, Vite+/Vitest, Playwright.
 
@@ -159,7 +159,7 @@ Unified mode renders each block's `unifiedHtml` followed by assigned review card
 
 - [x] **Step 1: Add component tests**
 
-Add tests proving Markdown semantics survive anchored cards and split mode does not dump line comments at the top.
+Add tests proving Markdown semantics survive anchored cards, split mode does not dump line comments at the top, synthetic separators stay hidden for standalone and spanning-token cases, and user-authored thematic breaks remain visible.
 
 - [x] **Step 2: Run component tests and verify RED before production wiring if not already red**
 

--- a/docs/superpowers/plans/2026-06-18-rich-preview-review-card-anchoring.md
+++ b/docs/superpowers/plans/2026-06-18-rich-preview-review-card-anchoring.md
@@ -162,11 +162,11 @@ Unified mode renders each block's `unifiedHtml` followed by assigned review card
 
 - [x] **Step 1: Add model tests**
 
-Add tests proving synthetic separators stay hidden for standalone fenced-code, HTML-block, blockquote, list, and table cases, stripped spanning-token renders keep in-document reference definitions available through the approved parser-context API, user-authored thematic breaks remain visible, list items expose separate rich-preview anchor blocks when review cards target individual source items, and review threads targeting hidden hunk gaps fall back instead of anchoring to a spanning block's display range.
+Add tests proving synthetic separators stay hidden for standalone fenced-code, HTML-block, blockquote, list, and table cases, stripped spanning-token renders keep in-document reference definitions available through the approved parser-context API, user-authored thematic breaks remain visible, untargeted lists remain whole rendered lists, split-line inputs expose separate rich-preview anchor blocks for targeted list items, and review threads targeting hidden hunk gaps fall back instead of anchoring to a spanning block's display range.
 
 - [x] **Step 2: Add component tests**
 
-Add tests proving split mode does not dump line comments at the top, comments preserve source order, and list-item review cards render after the matching item rather than after the whole list.
+Add tests proving split mode does not dump line comments at the top, comments preserve source order, list-item review cards render after the matching item rather than after the whole list, and added/deleted list-item review cards keep unchanged sibling items aligned.
 
 - [x] **Step 3: Run component tests and verify RED before production wiring if not already red**
 
@@ -183,7 +183,7 @@ Extend the existing rich-preview review-card e2e case to assert the card has a r
 - [x] **Step 6: Add multi-card and hidden-gap fallback e2e coverage**
 
 Add a diff-view e2e case with a multi-hunk Markdown block and a review thread targeting a hidden source gap, proving the card remains a file-level fallback instead of rendering inside `.markdown-rich-diff--unified`.
-Add another diff-view e2e case with multiple list-item review threads returned out of source order, proving rich preview renders the cards in source order and anchors each card after the matching rendered item.
+Add another diff-view e2e case with multiple list-item review threads returned out of source order, proving rich preview renders the cards in source order, anchors each card after the matching rendered item, and does not add synthetic split-list margins.
 
 ### Task 5: Styling, Validation, And Commit
 
@@ -209,6 +209,8 @@ Run:
 node node_modules/vite-plus/bin/vp run ui-package-check
 (cd frontend && node node_modules/.bin/playwright test --config=playwright-e2e.config.ts tests/e2e-full/diff-view.spec.ts -g "rich preview shows review thread cards")
 (cd frontend && node node_modules/.bin/playwright test --config=playwright-e2e.config.ts tests/e2e-full/diff-view.spec.ts -g "rich preview anchors multiple list review cards")
+(cd frontend && node node_modules/.bin/playwright test --config=playwright-e2e.config.ts tests/e2e-full/diff-view.spec.ts -g "rich preview keeps untargeted lists intact")
+(cd frontend && node node_modules/.bin/playwright test --config=playwright-e2e.config.ts tests/e2e-full/diff-view.spec.ts -g "rich preview keeps unchanged list siblings aligned")
 (cd frontend && node node_modules/.bin/playwright test --config=playwright-e2e.config.ts tests/e2e-full/diff-view.spec.ts -g "rich preview keeps hidden hunk-gap review threads")
 git diff --check
 ```

--- a/docs/superpowers/plans/2026-06-18-rich-preview-review-card-anchoring.md
+++ b/docs/superpowers/plans/2026-06-18-rich-preview-review-card-anchoring.md
@@ -156,28 +156,34 @@ Unified mode renders each block's `unifiedHtml` followed by assigned review card
 
 **Files:**
 
+- Modify: `packages/ui/src/utils/markdown-rich-preview.test.ts`
 - Modify: `packages/ui/src/components/diff/DiffFile.test.ts`
 - Modify: `frontend/tests/e2e-full/diff-view.spec.ts`
 
-- [x] **Step 1: Add component tests**
+- [x] **Step 1: Add model tests**
 
-Add tests proving Markdown semantics survive anchored cards, split mode does not dump line comments at the top, synthetic separators stay hidden for standalone fenced-code, HTML-block, blockquote, list, and table cases, stripped spanning-token renders keep in-document reference definitions available through the approved parser-context API, user-authored thematic breaks remain visible, and review threads targeting hidden hunk gaps fall back instead of anchoring to a spanning block's display range.
+Add tests proving synthetic separators stay hidden for standalone fenced-code, HTML-block, blockquote, list, and table cases, stripped spanning-token renders keep in-document reference definitions available through the approved parser-context API, user-authored thematic breaks remain visible, list items expose separate rich-preview anchor blocks when review cards target individual source items, and review threads targeting hidden hunk gaps fall back instead of anchoring to a spanning block's display range.
 
-- [x] **Step 2: Run component tests and verify RED before production wiring if not already red**
+- [x] **Step 2: Add component tests**
+
+Add tests proving split mode does not dump line comments at the top, comments preserve source order, and list-item review cards render after the matching item rather than after the whole list.
+
+- [x] **Step 3: Run component tests and verify RED before production wiring if not already red**
 
 Run focused tests with `cd frontend && node ../node_modules/vite-plus/bin/vp test run ../packages/ui/src/components/diff/DiffFile.test.ts -t "markdown rich preview"`
 
-- [x] **Step 3: Run component tests and verify GREEN**
+- [x] **Step 4: Run component tests and verify GREEN**
 
 Run: `cd frontend && node ../node_modules/vite-plus/bin/vp test run ../packages/ui/src/components/diff/DiffFile.test.ts`
 
-- [x] **Step 4: Update Playwright assertion**
+- [x] **Step 5: Update Playwright assertion**
 
 Extend the existing rich-preview review-card e2e case to assert the card has a rendered Markdown block immediately before it and is not the first child of the preview.
 
-- [x] **Step 5: Add hidden-gap fallback e2e coverage**
+- [x] **Step 6: Add multi-card and hidden-gap fallback e2e coverage**
 
 Add a diff-view e2e case with a multi-hunk Markdown block and a review thread targeting a hidden source gap, proving the card remains a file-level fallback instead of rendering inside `.markdown-rich-diff--unified`.
+Add another diff-view e2e case with multiple list-item review threads returned out of source order, proving rich preview renders the cards in source order and anchors each card after the matching rendered item.
 
 ### Task 5: Styling, Validation, And Commit
 
@@ -202,6 +208,8 @@ Run:
 (cd frontend && node ../node_modules/vite-plus/bin/vp test run ../packages/ui/src/components/diff/DiffFile.test.ts)
 node node_modules/vite-plus/bin/vp run ui-package-check
 (cd frontend && node node_modules/.bin/playwright test --config=playwright-e2e.config.ts tests/e2e-full/diff-view.spec.ts -g "rich preview shows review thread cards")
+(cd frontend && node node_modules/.bin/playwright test --config=playwright-e2e.config.ts tests/e2e-full/diff-view.spec.ts -g "rich preview anchors multiple list review cards")
+(cd frontend && node node_modules/.bin/playwright test --config=playwright-e2e.config.ts tests/e2e-full/diff-view.spec.ts -g "rich preview keeps hidden hunk-gap review threads")
 git diff --check
 ```
 

--- a/docs/superpowers/plans/2026-06-18-rich-preview-review-card-anchoring.md
+++ b/docs/superpowers/plans/2026-06-18-rich-preview-review-card-anchoring.md
@@ -161,7 +161,7 @@ Unified mode renders each block's `unifiedHtml` followed by assigned review card
 
 - [x] **Step 1: Add component tests**
 
-Add tests proving Markdown semantics survive anchored cards, split mode does not dump line comments at the top, synthetic separators stay hidden for standalone fenced-code, HTML-block, blockquote, and list-continuation cases, user-authored thematic breaks remain visible, and review threads targeting hidden hunk gaps fall back instead of anchoring to a spanning block's display range.
+Add tests proving Markdown semantics survive anchored cards, split mode does not dump line comments at the top, synthetic separators stay hidden for standalone fenced-code, HTML-block, blockquote, list, and table cases, stripped spanning-token renders keep in-document reference definitions available through the approved parser-context API, user-authored thematic breaks remain visible, and review threads targeting hidden hunk gaps fall back instead of anchoring to a spanning block's display range.
 
 - [x] **Step 2: Run component tests and verify RED before production wiring if not already red**
 
@@ -174,6 +174,10 @@ Run: `cd frontend && node ../node_modules/vite-plus/bin/vp test run ../packages/
 - [x] **Step 4: Update Playwright assertion**
 
 Extend the existing rich-preview review-card e2e case to assert the card has a rendered Markdown block immediately before it and is not the first child of the preview.
+
+- [x] **Step 5: Add hidden-gap fallback e2e coverage**
+
+Add a diff-view e2e case with a multi-hunk Markdown block and a review thread targeting a hidden source gap, proving the card remains a file-level fallback instead of rendering inside `.markdown-rich-diff--unified`.
 
 ### Task 5: Styling, Validation, And Commit
 

--- a/docs/superpowers/plans/2026-06-18-rich-preview-review-card-anchoring.md
+++ b/docs/superpowers/plans/2026-06-18-rich-preview-review-card-anchoring.md
@@ -166,7 +166,7 @@ Add tests proving synthetic separators stay hidden for standalone fenced-code, H
 
 - [x] **Step 2: Add component tests**
 
-Add tests proving split mode does not dump line comments at the top, comments preserve source order, list-item review cards render after the matching item rather than after the whole list, and added/deleted list-item review cards keep unchanged sibling items aligned.
+Add tests proving split mode does not dump line comments at the top, comments preserve source order, list-item review cards render after the matching item rather than after the whole list, and added/deleted list-item review cards keep unchanged sibling items aligned at middle and edge positions.
 
 - [x] **Step 3: Run component tests and verify RED before production wiring if not already red**
 
@@ -184,6 +184,7 @@ Extend the existing rich-preview review-card e2e case to assert the card has a r
 
 Add a diff-view e2e case with a multi-hunk Markdown block and a review thread targeting a hidden source gap, proving the card remains a file-level fallback instead of rendering inside `.markdown-rich-diff--unified`.
 Add another diff-view e2e case with multiple list-item review threads returned out of source order, proving rich preview renders the cards in source order, anchors each card after the matching rendered item, and does not add synthetic split-list margins.
+Add browser coverage proving rich preview side-by-side panes render changed text without native `<ins>`/`<del>` underlines or strike-through styling.
 
 ### Task 5: Styling, Validation, And Commit
 
@@ -211,6 +212,7 @@ node node_modules/vite-plus/bin/vp run ui-package-check
 (cd frontend && node node_modules/.bin/playwright test --config=playwright-e2e.config.ts tests/e2e-full/diff-view.spec.ts -g "rich preview anchors multiple list review cards")
 (cd frontend && node node_modules/.bin/playwright test --config=playwright-e2e.config.ts tests/e2e-full/diff-view.spec.ts -g "rich preview keeps untargeted lists intact")
 (cd frontend && node node_modules/.bin/playwright test --config=playwright-e2e.config.ts tests/e2e-full/diff-view.spec.ts -g "rich preview keeps unchanged list siblings aligned")
+(cd frontend && node node_modules/.bin/playwright test --config=playwright-e2e.config.ts tests/e2e-full/diff-view.spec.ts -g "rich preview side-by-side panes do not underline")
 (cd frontend && node node_modules/.bin/playwright test --config=playwright-e2e.config.ts tests/e2e-full/diff-view.spec.ts -g "rich preview keeps hidden hunk-gap review threads")
 git diff --check
 ```

--- a/docs/superpowers/plans/2026-06-18-rich-preview-review-card-anchoring.md
+++ b/docs/superpowers/plans/2026-06-18-rich-preview-review-card-anchoring.md
@@ -1,10 +1,10 @@
 # Rich Preview Review Card Anchoring Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **Status:** Implemented on the rich-preview review-card branch. This plan is kept as historical implementation context; completed checkboxes describe work already done, not new pending tasks.
 
 **Goal:** Replace fragment-rendered Markdown rich preview with a source-line-aware render model that preserves Markdown semantics and anchors review cards in unified and split modes.
 
-**Architecture:** Add a pure Markdown rich-preview model under `packages/ui/src/utils/` that builds old/new Markdown documents from diff hunks, maps generated Markdown lines back to source diff lines, renders top-level Markdown tokens through the canonical renderer, and produces unified/split block HTML. `DiffRichPreview.svelte` consumes that model and only assigns/render review cards against explicit block ranges.
+**Architecture:** Add a pure Markdown rich-preview model under `packages/ui/src/utils/` that builds old/new Markdown documents from diff hunks, maps generated Markdown lines back to source diff lines, renders top-level Markdown tokens through the canonical renderer, and produces unified/split block HTML. `DiffRichPreview.svelte` consumes that model and only assigns/render review cards against explicit block ranges. Structured Markdown containers anchor at the top-level token boundary so cards do not become invalid list/table/blockquote children. The model uses a bounded block comparison strategy for large Markdown diffs.
 
 **Tech Stack:** Svelte 5, TypeScript, Marked, DOMPurify, existing `renderMarkdownDiff` and `renderMarkdownSplitDiff`, Vite+/Vitest, Playwright.
 
@@ -13,9 +13,10 @@
 ### Task 1: Add Failing Model Tests
 
 **Files:**
+
 - Create: `packages/ui/src/utils/markdown-rich-preview.test.ts`
 
-- [ ] **Step 1: Write failing tests**
+- [x] **Step 1: Write failing tests**
 
 Add tests for the wished-for API:
 
@@ -44,15 +45,18 @@ describe("buildMarkdownRichPreview", () => {
   const repo = { provider: "github", owner: "acme", name: "widgets", repoPath: "acme/widgets" };
 
   it("preserves whole-document Markdown semantics while exposing block ranges", () => {
-    const preview = buildMarkdownRichPreview(markdownFile([
-      { type: "context", content: "- first", old_num: 1, new_num: 1 },
-      { type: "context", content: "", old_num: 2, new_num: 2 },
-      { type: "context", content: "- second", old_num: 3, new_num: 3 },
-      { type: "context", content: "", old_num: 4, new_num: 4 },
-      { type: "context", content: "[ref]: https://example.com", old_num: 5, new_num: 5 },
-      { type: "context", content: "", old_num: 6, new_num: 6 },
-      { type: "add", content: "See [the ref][ref]", new_num: 7 },
-    ]), repo);
+    const preview = buildMarkdownRichPreview(
+      markdownFile([
+        { type: "context", content: "- first", old_num: 1, new_num: 1 },
+        { type: "context", content: "", old_num: 2, new_num: 2 },
+        { type: "context", content: "- second", old_num: 3, new_num: 3 },
+        { type: "context", content: "", old_num: 4, new_num: 4 },
+        { type: "context", content: "[ref]: https://example.com", old_num: 5, new_num: 5 },
+        { type: "context", content: "", old_num: 6, new_num: 6 },
+        { type: "add", content: "See [the ref][ref]", new_num: 7 },
+      ]),
+      repo,
+    );
 
     const html = preview.blocks.map((block) => block.unifiedHtml).join("");
     expect(html).toContain("<ul>");
@@ -62,11 +66,14 @@ describe("buildMarkdownRichPreview", () => {
   });
 
   it("projects split block additions without inline underline markup on every word", () => {
-    const preview = buildMarkdownRichPreview(markdownFile([
-      { type: "context", content: "## Title", old_num: 1, new_num: 1 },
-      { type: "context", content: "", old_num: 2, new_num: 2 },
-      { type: "add", content: "Added paragraph with several words", new_num: 3 },
-    ]), repo);
+    const preview = buildMarkdownRichPreview(
+      markdownFile([
+        { type: "context", content: "## Title", old_num: 1, new_num: 1 },
+        { type: "context", content: "", old_num: 2, new_num: 2 },
+        { type: "add", content: "Added paragraph with several words", new_num: 3 },
+      ]),
+      repo,
+    );
 
     const added = preview.blocks.find((block) => block.newStart === 3);
     expect(added?.unifiedHtml).toContain('class="markdown-diff__block"');
@@ -77,7 +84,7 @@ describe("buildMarkdownRichPreview", () => {
 });
 ```
 
-- [ ] **Step 2: Run tests and verify RED**
+- [x] **Step 2: Run tests and verify RED**
 
 Run: `cd frontend && node ../node_modules/vite-plus/bin/vp test run ../packages/ui/src/utils/markdown-rich-preview.test.ts`
 
@@ -86,14 +93,15 @@ Expected: FAIL because `./markdown-rich-preview.js` does not exist.
 ### Task 2: Implement The Pure Rich Preview Model
 
 **Files:**
+
 - Create: `packages/ui/src/utils/markdown-rich-preview.ts`
 - Modify: `packages/ui/src/utils/markdown.ts`
 
-- [ ] **Step 1: Expose canonical block rendering from Markdown utilities**
+- [x] **Step 1: Expose canonical block rendering from Markdown utilities**
 
-Add an exported `renderMarkdownBlocks(raw, repo)` helper in `markdown.ts`. It should use the existing `getMarked(repo)` instance, lexer, renderer state, and DOMPurify attributes. It returns visible top-level token blocks with generated Markdown line ranges and sanitized HTML.
+Add an exported `renderMarkdownBlocks(raw, repo)` helper in `markdown.ts`. It should use the existing `getMarked(repo)` instance, lexer, renderer state, and DOMPurify attributes. It returns visible top-level token blocks with generated Markdown line ranges and sanitized HTML. Reference definitions inside the reconstructed hunk document must keep resolving through this helper.
 
-- [ ] **Step 2: Build `buildMarkdownRichPreview`**
+- [x] **Step 2: Build `buildMarkdownRichPreview`**
 
 Create `markdown-rich-preview.ts` with:
 
@@ -114,9 +122,9 @@ export interface MarkdownRichPreview {
 }
 ```
 
-The function builds old/new side documents from diff hunk lines, renders canonical token blocks, aligns equal blocks with an LCS pass, pairs adjacent delete/insert runs by order, and uses `renderMarkdownDiff` plus `renderMarkdownSplitDiff` for each output block.
+The function builds old/new side documents from diff hunk lines, renders canonical token blocks, aligns equal blocks with an LCS pass below a block-product threshold, falls back to coarse delete/insert projection above that threshold, pairs adjacent delete/insert runs by order, and uses `renderMarkdownDiff` plus `renderMarkdownSplitDiff` for each output block.
 
-- [ ] **Step 3: Run model tests and verify GREEN**
+- [x] **Step 3: Run model tests and verify GREEN**
 
 Run: `cd frontend && node ../node_modules/vite-plus/bin/vp test run ../packages/ui/src/utils/markdown-rich-preview.test.ts`
 
@@ -125,68 +133,71 @@ Expected: PASS.
 ### Task 3: Wire The Model Into DiffRichPreview
 
 **Files:**
+
 - Modify: `packages/ui/src/components/diff/DiffRichPreview.svelte`
 - Modify: `packages/ui/src/components/diff/DiffFile.svelte`
 
-- [ ] **Step 1: Remove fragment-rendering helpers**
+- [x] **Step 1: Remove fragment-rendering helpers**
 
 Delete `markdownLineBlocks`, `pushMarkdownLineBlock`, `isFenceLine`, and block-local rendering from `DiffRichPreview.svelte`.
 
-- [ ] **Step 2: Consume `buildMarkdownRichPreview`**
+- [x] **Step 2: Consume `buildMarkdownRichPreview`**
 
-Add a `$derived.by` value that calls `buildMarkdownRichPreview(file, { provider, platformHost, owner, name, repoPath })` for Markdown files. Assign review threads to model blocks by `reviewThreadTargetSide()` and `reviewThreadTargetLine()`. Treat file-level, stale-head, and unassigned threads as fallback.
+Add a `$derived.by` value that calls `buildMarkdownRichPreview(file, { provider, platformHost, owner, name, repoPath })` for Markdown files. Assign review threads to model blocks by `reviewThreadTargetSide()` and `reviewThreadTargetLine()`. Treat file-level, stale-head, and unassigned threads as fallback file-level cards.
 
-- [ ] **Step 3: Render unified and split block streams**
+- [x] **Step 3: Render unified and split block streams**
 
 Unified mode renders each block's `unifiedHtml` followed by assigned review cards. Split mode renders rows with before/after HTML and places cards in the side pane matching the review target side. Fallback cards render in a separated stack before the block stream.
 
 ### Task 4: Add Failing Component And E2E Coverage, Then Make It Green
 
 **Files:**
+
 - Modify: `packages/ui/src/components/diff/DiffFile.test.ts`
 - Modify: `frontend/tests/e2e-full/diff-view.spec.ts`
 
-- [ ] **Step 1: Add component tests**
+- [x] **Step 1: Add component tests**
 
 Add tests proving Markdown semantics survive anchored cards and split mode does not dump line comments at the top.
 
-- [ ] **Step 2: Run component tests and verify RED before production wiring if not already red**
+- [x] **Step 2: Run component tests and verify RED before production wiring if not already red**
 
 Run focused tests with `cd frontend && node ../node_modules/vite-plus/bin/vp test run ../packages/ui/src/components/diff/DiffFile.test.ts -t "markdown rich preview"`
 
-- [ ] **Step 3: Run component tests and verify GREEN**
+- [x] **Step 3: Run component tests and verify GREEN**
 
 Run: `cd frontend && node ../node_modules/vite-plus/bin/vp test run ../packages/ui/src/components/diff/DiffFile.test.ts`
 
-- [ ] **Step 4: Update Playwright assertion**
+- [x] **Step 4: Update Playwright assertion**
 
 Extend the existing rich-preview review-card e2e case to assert the card has a rendered Markdown block immediately before it and is not the first child of the preview.
 
 ### Task 5: Styling, Validation, And Commit
 
 **Files:**
+
 - Modify: `packages/ui/src/components/diff/DiffRichPreview.svelte`
 
-- [ ] **Step 1: Quiet block-level diff styling**
+- [x] **Step 1: Quiet block-level diff styling**
 
 Change rich-preview CSS so `ins.markdown-diff__block` and `del.markdown-diff__block` use block background/border without text underline. Keep inline `ins`/`del` styling for non-block changes.
 
-- [ ] **Step 2: Run Svelte validation**
+- [x] **Step 2: Run Svelte validation**
 
 Run `vp exec svelte-mcp svelte-autofixer packages/ui/src/components/diff/DiffRichPreview.svelte --svelte-version 5` and the same for `DiffFile.svelte`. If the helper exits silently, run `node node_modules/vite-plus/bin/vp run ui-package-check`.
 
-- [ ] **Step 3: Run verification**
+- [x] **Step 3: Run verification**
 
 Run:
 
 ```bash
-cd frontend && node ../node_modules/vite-plus/bin/vp test run ../packages/ui/src/utils/markdown-rich-preview.test.ts
-cd frontend && node ../node_modules/vite-plus/bin/vp test run ../packages/ui/src/components/diff/DiffFile.test.ts
+(cd frontend && node ../node_modules/vite-plus/bin/vp test run ../packages/ui/src/utils/markdown-rich-preview.test.ts)
+(cd frontend && node ../node_modules/vite-plus/bin/vp test run ../packages/ui/src/components/diff/DiffFile.test.ts)
 node node_modules/vite-plus/bin/vp run ui-package-check
-cd frontend && node node_modules/.bin/playwright test --config=playwright-e2e.config.ts tests/e2e-full/diff-view.spec.ts -g "rich preview shows review thread cards"
+(cd frontend && node node_modules/.bin/playwright test --config=playwright-e2e.config.ts tests/e2e-full/diff-view.spec.ts -g "rich preview shows review thread cards")
 git diff --check
 ```
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 Commit the implementation with a rationale-first conventional message, then push the existing PR branch.

--- a/docs/superpowers/plans/2026-06-18-rich-preview-review-card-anchoring.md
+++ b/docs/superpowers/plans/2026-06-18-rich-preview-review-card-anchoring.md
@@ -166,7 +166,7 @@ Add tests proving synthetic separators stay hidden for standalone fenced-code, H
 
 - [x] **Step 2: Add component tests**
 
-Add tests proving split mode does not dump line comments at the top, comments preserve source order, list-item review cards render after the matching item rather than after the whole list, and added/deleted list-item review cards keep unchanged sibling items aligned at middle and edge positions, including multiline changed items.
+Add tests proving split mode does not dump line comments at the top, comments preserve source order, list-item review cards render after the matching item rather than after the whole list, and added/deleted list-item review cards keep unchanged sibling items aligned at middle and edge positions, including lazy multiline changed items.
 
 - [x] **Step 3: Run component tests and verify RED before production wiring if not already red**
 
@@ -184,7 +184,7 @@ Extend the existing rich-preview review-card e2e case to assert the card has a r
 
 Add a diff-view e2e case with a multi-hunk Markdown block and a review thread targeting a hidden source gap, proving the card remains a file-level fallback instead of rendering inside `.markdown-rich-diff--unified`.
 Add another diff-view e2e case with multiple list-item review threads returned out of source order, proving rich preview renders the cards in source order, anchors each card after the matching rendered item, and does not add synthetic split-list margins.
-Add browser coverage proving rich preview side-by-side panes render changed text without native `<ins>`/`<del>` underlines or strike-through styling while keeping an inline background cue for word-level changes.
+Add browser coverage proving rich preview side-by-side panes render changed text without native `<ins>`/`<del>` underlines or strike-through styling while keeping an inline background cue for word-level changes, and that split rich preview uses wide file-pane space rather than the unified prose-width cap.
 
 ### Task 5: Styling, Validation, And Commit
 
@@ -194,7 +194,7 @@ Add browser coverage proving rich preview side-by-side panes render changed text
 
 - [x] **Step 1: Quiet block-level diff styling**
 
-Change rich-preview CSS so `ins.markdown-diff__block` and `del.markdown-diff__block` use block background/border without text underline. Keep inline `ins`/`del` background styling for non-block changes in unified and split modes.
+Change rich-preview CSS so `ins.markdown-diff__block` and `del.markdown-diff__block` use block background/border without text underline. Keep inline `ins`/`del` background styling for non-block changes in unified and split modes, and let split mode expand to the available file width.
 
 - [x] **Step 2: Run Svelte validation**
 

--- a/docs/superpowers/plans/2026-06-18-rich-preview-review-card-anchoring.md
+++ b/docs/superpowers/plans/2026-06-18-rich-preview-review-card-anchoring.md
@@ -1,0 +1,192 @@
+# Rich Preview Review Card Anchoring Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace fragment-rendered Markdown rich preview with a source-line-aware render model that preserves Markdown semantics and anchors review cards in unified and split modes.
+
+**Architecture:** Add a pure Markdown rich-preview model under `packages/ui/src/utils/` that builds old/new Markdown documents from diff hunks, maps generated Markdown lines back to source diff lines, renders top-level Markdown tokens through the canonical renderer, and produces unified/split block HTML. `DiffRichPreview.svelte` consumes that model and only assigns/render review cards against explicit block ranges.
+
+**Tech Stack:** Svelte 5, TypeScript, Marked, DOMPurify, existing `renderMarkdownDiff` and `renderMarkdownSplitDiff`, Vite+/Vitest, Playwright.
+
+---
+
+### Task 1: Add Failing Model Tests
+
+**Files:**
+- Create: `packages/ui/src/utils/markdown-rich-preview.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Add tests for the wished-for API:
+
+```ts
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vite-plus/test";
+import type { DiffFile } from "../api/types.js";
+import { buildMarkdownRichPreview } from "./markdown-rich-preview.js";
+
+function markdownFile(lines: DiffFile["hunks"][number]["lines"]): DiffFile {
+  return {
+    path: "README.md",
+    old_path: "README.md",
+    status: "modified",
+    is_binary: false,
+    is_whitespace_only: false,
+    additions: lines.filter((line) => line.type === "add").length,
+    deletions: lines.filter((line) => line.type === "delete").length,
+    patch: "",
+    hunks: [{ old_start: 1, old_count: 20, new_start: 1, new_count: 20, lines }],
+  };
+}
+
+describe("buildMarkdownRichPreview", () => {
+  const repo = { provider: "github", owner: "acme", name: "widgets", repoPath: "acme/widgets" };
+
+  it("preserves whole-document Markdown semantics while exposing block ranges", () => {
+    const preview = buildMarkdownRichPreview(markdownFile([
+      { type: "context", content: "- first", old_num: 1, new_num: 1 },
+      { type: "context", content: "", old_num: 2, new_num: 2 },
+      { type: "context", content: "- second", old_num: 3, new_num: 3 },
+      { type: "context", content: "", old_num: 4, new_num: 4 },
+      { type: "context", content: "[ref]: https://example.com", old_num: 5, new_num: 5 },
+      { type: "context", content: "", old_num: 6, new_num: 6 },
+      { type: "add", content: "See [the ref][ref]", new_num: 7 },
+    ]), repo);
+
+    const html = preview.blocks.map((block) => block.unifiedHtml).join("");
+    expect(html).toContain("<ul>");
+    expect(html.match(/<ul>/g)).toHaveLength(1);
+    expect(html).toContain('<a href="https://example.com">the ref</a>');
+    expect(preview.blocks.some((block) => block.newStart === 7 && block.newEnd === 7)).toBe(true);
+  });
+
+  it("projects split block additions without inline underline markup on every word", () => {
+    const preview = buildMarkdownRichPreview(markdownFile([
+      { type: "context", content: "## Title", old_num: 1, new_num: 1 },
+      { type: "context", content: "", old_num: 2, new_num: 2 },
+      { type: "add", content: "Added paragraph with several words", new_num: 3 },
+    ]), repo);
+
+    const added = preview.blocks.find((block) => block.newStart === 3);
+    expect(added?.unifiedHtml).toContain('class="markdown-diff__block"');
+    expect(added?.unifiedHtml).not.toContain("<ins>Added</ins>");
+    expect(added?.beforeHtml).toContain("markdown-diff__placeholder");
+    expect(added?.afterHtml).toContain("Added paragraph with several words");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run: `cd frontend && node ../node_modules/vite-plus/bin/vp test run ../packages/ui/src/utils/markdown-rich-preview.test.ts`
+
+Expected: FAIL because `./markdown-rich-preview.js` does not exist.
+
+### Task 2: Implement The Pure Rich Preview Model
+
+**Files:**
+- Create: `packages/ui/src/utils/markdown-rich-preview.ts`
+- Modify: `packages/ui/src/utils/markdown.ts`
+
+- [ ] **Step 1: Expose canonical block rendering from Markdown utilities**
+
+Add an exported `renderMarkdownBlocks(raw, repo)` helper in `markdown.ts`. It should use the existing `getMarked(repo)` instance, lexer, renderer state, and DOMPurify attributes. It returns visible top-level token blocks with generated Markdown line ranges and sanitized HTML.
+
+- [ ] **Step 2: Build `buildMarkdownRichPreview`**
+
+Create `markdown-rich-preview.ts` with:
+
+```ts
+export interface MarkdownRichPreviewBlock {
+  key: string;
+  oldStart?: number | undefined;
+  oldEnd?: number | undefined;
+  newStart?: number | undefined;
+  newEnd?: number | undefined;
+  unifiedHtml: string;
+  beforeHtml?: string | undefined;
+  afterHtml?: string | undefined;
+}
+
+export interface MarkdownRichPreview {
+  blocks: MarkdownRichPreviewBlock[];
+}
+```
+
+The function builds old/new side documents from diff hunk lines, renders canonical token blocks, aligns equal blocks with an LCS pass, pairs adjacent delete/insert runs by order, and uses `renderMarkdownDiff` plus `renderMarkdownSplitDiff` for each output block.
+
+- [ ] **Step 3: Run model tests and verify GREEN**
+
+Run: `cd frontend && node ../node_modules/vite-plus/bin/vp test run ../packages/ui/src/utils/markdown-rich-preview.test.ts`
+
+Expected: PASS.
+
+### Task 3: Wire The Model Into DiffRichPreview
+
+**Files:**
+- Modify: `packages/ui/src/components/diff/DiffRichPreview.svelte`
+- Modify: `packages/ui/src/components/diff/DiffFile.svelte`
+
+- [ ] **Step 1: Remove fragment-rendering helpers**
+
+Delete `markdownLineBlocks`, `pushMarkdownLineBlock`, `isFenceLine`, and block-local rendering from `DiffRichPreview.svelte`.
+
+- [ ] **Step 2: Consume `buildMarkdownRichPreview`**
+
+Add a `$derived.by` value that calls `buildMarkdownRichPreview(file, { provider, platformHost, owner, name, repoPath })` for Markdown files. Assign review threads to model blocks by `reviewThreadTargetSide()` and `reviewThreadTargetLine()`. Treat file-level, stale-head, and unassigned threads as fallback.
+
+- [ ] **Step 3: Render unified and split block streams**
+
+Unified mode renders each block's `unifiedHtml` followed by assigned review cards. Split mode renders rows with before/after HTML and places cards in the side pane matching the review target side. Fallback cards render in a separated stack before the block stream.
+
+### Task 4: Add Failing Component And E2E Coverage, Then Make It Green
+
+**Files:**
+- Modify: `packages/ui/src/components/diff/DiffFile.test.ts`
+- Modify: `frontend/tests/e2e-full/diff-view.spec.ts`
+
+- [ ] **Step 1: Add component tests**
+
+Add tests proving Markdown semantics survive anchored cards and split mode does not dump line comments at the top.
+
+- [ ] **Step 2: Run component tests and verify RED before production wiring if not already red**
+
+Run focused tests with `cd frontend && node ../node_modules/vite-plus/bin/vp test run ../packages/ui/src/components/diff/DiffFile.test.ts -t "markdown rich preview"`
+
+- [ ] **Step 3: Run component tests and verify GREEN**
+
+Run: `cd frontend && node ../node_modules/vite-plus/bin/vp test run ../packages/ui/src/components/diff/DiffFile.test.ts`
+
+- [ ] **Step 4: Update Playwright assertion**
+
+Extend the existing rich-preview review-card e2e case to assert the card has a rendered Markdown block immediately before it and is not the first child of the preview.
+
+### Task 5: Styling, Validation, And Commit
+
+**Files:**
+- Modify: `packages/ui/src/components/diff/DiffRichPreview.svelte`
+
+- [ ] **Step 1: Quiet block-level diff styling**
+
+Change rich-preview CSS so `ins.markdown-diff__block` and `del.markdown-diff__block` use block background/border without text underline. Keep inline `ins`/`del` styling for non-block changes.
+
+- [ ] **Step 2: Run Svelte validation**
+
+Run `vp exec svelte-mcp svelte-autofixer packages/ui/src/components/diff/DiffRichPreview.svelte --svelte-version 5` and the same for `DiffFile.svelte`. If the helper exits silently, run `node node_modules/vite-plus/bin/vp run ui-package-check`.
+
+- [ ] **Step 3: Run verification**
+
+Run:
+
+```bash
+cd frontend && node ../node_modules/vite-plus/bin/vp test run ../packages/ui/src/utils/markdown-rich-preview.test.ts
+cd frontend && node ../node_modules/vite-plus/bin/vp test run ../packages/ui/src/components/diff/DiffFile.test.ts
+node node_modules/vite-plus/bin/vp run ui-package-check
+cd frontend && node node_modules/.bin/playwright test --config=playwright-e2e.config.ts tests/e2e-full/diff-view.spec.ts -g "rich preview shows review thread cards"
+git diff --check
+```
+
+- [ ] **Step 4: Commit**
+
+Commit the implementation with a rationale-first conventional message, then push the existing PR branch.

--- a/docs/superpowers/plans/2026-06-18-rich-preview-review-card-anchoring.md
+++ b/docs/superpowers/plans/2026-06-18-rich-preview-review-card-anchoring.md
@@ -162,11 +162,11 @@ Unified mode renders each block's `unifiedHtml` followed by assigned review card
 
 - [x] **Step 1: Add model tests**
 
-Add tests proving synthetic separators stay hidden for standalone fenced-code, HTML-block, blockquote, list, and table cases, stripped spanning-token renders keep in-document reference definitions available through the approved parser-context API, user-authored thematic breaks remain visible, untargeted lists remain whole rendered lists, split-line inputs expose separate rich-preview anchor blocks for targeted list items, and review threads targeting hidden hunk gaps fall back instead of anchoring to a spanning block's display range.
+Add tests proving synthetic separators stay hidden for standalone fenced-code, HTML-block, blockquote, list, and table cases, stripped spanning-token renders keep in-document reference definitions available through the approved parser-context API, user-authored thematic breaks remain visible, untargeted lists remain whole rendered lists, split-line inputs expose separate rich-preview anchor blocks for targeted list items, targeted loose lists preserve paragraph-wrapped item subtrees, and review threads targeting hidden hunk gaps fall back instead of anchoring to a spanning block's display range.
 
 - [x] **Step 2: Add component tests**
 
-Add tests proving split mode does not dump line comments at the top, comments preserve source order, list-item review cards render after the matching item rather than after the whole list, and added/deleted list-item review cards keep unchanged sibling items aligned at middle and edge positions.
+Add tests proving split mode does not dump line comments at the top, comments preserve source order, list-item review cards render after the matching item rather than after the whole list, and added/deleted list-item review cards keep unchanged sibling items aligned at middle and edge positions, including multiline changed items.
 
 - [x] **Step 3: Run component tests and verify RED before production wiring if not already red**
 
@@ -184,7 +184,7 @@ Extend the existing rich-preview review-card e2e case to assert the card has a r
 
 Add a diff-view e2e case with a multi-hunk Markdown block and a review thread targeting a hidden source gap, proving the card remains a file-level fallback instead of rendering inside `.markdown-rich-diff--unified`.
 Add another diff-view e2e case with multiple list-item review threads returned out of source order, proving rich preview renders the cards in source order, anchors each card after the matching rendered item, and does not add synthetic split-list margins.
-Add browser coverage proving rich preview side-by-side panes render changed text without native `<ins>`/`<del>` underlines or strike-through styling.
+Add browser coverage proving rich preview side-by-side panes render changed text without native `<ins>`/`<del>` underlines or strike-through styling while keeping an inline background cue for word-level changes.
 
 ### Task 5: Styling, Validation, And Commit
 
@@ -194,7 +194,7 @@ Add browser coverage proving rich preview side-by-side panes render changed text
 
 - [x] **Step 1: Quiet block-level diff styling**
 
-Change rich-preview CSS so `ins.markdown-diff__block` and `del.markdown-diff__block` use block background/border without text underline. Keep inline `ins`/`del` styling for non-block changes.
+Change rich-preview CSS so `ins.markdown-diff__block` and `del.markdown-diff__block` use block background/border without text underline. Keep inline `ins`/`del` background styling for non-block changes in unified and split modes.
 
 - [x] **Step 2: Run Svelte validation**
 

--- a/docs/superpowers/specs/2026-06-18-rich-preview-review-card-anchoring-design.md
+++ b/docs/superpowers/specs/2026-06-18-rich-preview-review-card-anchoring-design.md
@@ -19,6 +19,7 @@ The fix should preserve rendered Markdown behavior first, then layer review-card
 - Do not build a custom Markdown parser.
 - Do not make non-Markdown binary, image, PDF, or plain text previews line-anchor review cards.
 - Do not change the source-diff review annotation behavior.
+- Do not promise whole-file Markdown semantics when the diff view only has hunk lines. Rich preview preserves whole-document semantics for the reconstructed hunk document it renders.
 
 ## Architecture
 
@@ -47,18 +48,26 @@ type MarkdownPreviewBlock = {
 - split mode: `block.beforeHtml` and `block.afterHtml`, followed by review cards assigned to the matching old or new side;
 - fallback review threads in a separated stack before the block stream, not as fake inline anchors.
 
+The render block is the top-level Markdown token/container produced by the parser. This keeps lists, tables, blockquotes, HTML blocks, and other structured containers valid. A comment on a list item, table row, or nested blockquote child anchors after the containing top-level rendered block rather than inserting a review card inside invalid list/table markup. The review card header keeps the exact file line reference so the line-level target remains visible even when the valid DOM insertion point is the container boundary.
+
+This is intentional: preserving valid rendered Markdown takes priority over placing cards inside structured containers.
+
 ## Data Flow
 
 1. Build old and new Markdown documents from diff hunk lines.
 2. While building those documents, keep a generated-line to source-line map for old and new sides.
-3. Parse old and new Markdown as whole documents through the canonical Markdown parser path.
-4. Derive top-level token or rendered-block source spans from parser metadata and the generated-line maps.
+3. Parse old and new Markdown as whole hunk documents through the canonical Markdown parser path.
+4. Use Marked's lexer token stream and a deterministic generated-line cursor to derive top-level token source spans. For each token, use `token.raw` line counts to advance the cursor; ignore non-rendered `space` and `def` tokens as visible blocks while still counting their lines. Map generated lines back to source old/new line numbers through the side-specific line maps.
 5. Render blocks using the canonical renderer while preserving the same Markdown semantics as whole-document rendering. If that cannot be guaranteed for a construct, do not decompose that construct into independently rendered fragments.
 6. Diff corresponding old/new rendered blocks for unified HTML.
 7. Project the same diff into before/after HTML for split mode.
 8. Assign each review thread to the block whose old or new source range contains the target line.
 
 If a block cannot be mapped confidently, keep the rendered Markdown correct and leave related review threads in the fallback area. Correct rendering is more important than guessed inline placement.
+
+Repeated paragraphs, headings, or list items are resolved by source order, not rendered text identity alone. The generated-line cursor makes identical text in different source locations produce distinct ranges.
+
+Definitions outside the loaded diff hunks are outside this feature's available input. They may not resolve until the preview is backed by full-file content. Definitions inside the reconstructed hunk document must keep working.
 
 ## Visual Behavior
 
@@ -67,6 +76,20 @@ Rich preview should read like rendered Markdown first.
 For added or removed block-level content, use quiet block background and border styling. Avoid underlining every word in newly inserted paragraphs, headings, or list items. Inline `ins` and `del` styling should be reserved for small text changes inside otherwise matching blocks.
 
 Review cards should sit between rendered blocks without introducing artificial paragraph breaks, isolated list fragments, or source-diff-style clutter.
+
+For structured containers, the card sits after the whole top-level container. It must not become a child of `<ul>`, `<ol>`, `<table>`, `<tbody>`, `<tr>`, `<blockquote>`, or similar elements unless the implementation has a valid, tested container-specific insertion model.
+
+## Acceptance Criteria
+
+- Rich preview does not render arbitrary raw Markdown fragments independently.
+- Reference-style links defined inside the rendered hunk document still resolve.
+- Loose lists that Marked treats as one list remain one rendered list.
+- Review cards on repeated text blocks map by source line order.
+- Review cards on structured container children remain near the valid top-level container boundary and keep the exact line reference in the card header.
+- File-level, stale-head, and unmapped review threads remain visible in a separated fallback stack.
+- Split rich preview anchors cards to the matching old or new side rather than dumping all cards above the preview.
+- Block-level additions and deletions use block diff styling without per-word underline decoration.
+- The rendered DOM remains valid for lists, tables, and blockquotes.
 
 ## Testing
 
@@ -84,6 +107,15 @@ Keep component coverage for:
 - source diff review annotations remain unchanged.
 
 Keep browser e2e coverage for the PR files page rich preview toggle, including a review-card case that proves cards are not at the top of the file.
+
+## Implementation Staging
+
+1. Add pure model tests and a `markdown-rich-preview` utility.
+2. Implement generated-line to source-line mapping from Marked tokens.
+3. Wire unified rich preview to the model.
+4. Wire split rich preview to the same model.
+5. Adjust block-level diff styling.
+6. Add component and Playwright coverage.
 
 ## Implementation Boundaries
 

--- a/docs/superpowers/specs/2026-06-18-rich-preview-review-card-anchoring-design.md
+++ b/docs/superpowers/specs/2026-06-18-rich-preview-review-card-anchoring-design.md
@@ -86,7 +86,7 @@ Rich preview should read like rendered Markdown first.
 
 For added or removed block-level content, use quiet block background and border styling. Avoid underlining every word in newly inserted paragraphs, headings, or list items. Inline `ins` and `del` styling should be reserved for small text changes inside otherwise matching blocks.
 
-Split mode uses the before/after pane and block background as the primary block-level add/delete cue. Inline `ins` and `del` nodes inside otherwise matching split-pane blocks keep a subtle add/delete background cue, but never use native underline or strike-through text decoration.
+Split mode uses the before/after pane and block background as the primary block-level add/delete cue. Inline `ins` and `del` nodes inside otherwise matching split-pane blocks keep a subtle add/delete background cue, but never use native underline or strike-through text decoration. This no-decoration rule applies to block-level diff wrappers and their descendants; block fill and pane placement carry the add/delete signal for full-block changes.
 
 Review cards should sit between rendered blocks without introducing artificial paragraph breaks, isolated list fragments, or source-diff-style clutter.
 
@@ -94,7 +94,9 @@ For structured containers, the card sits after the whole top-level container. It
 
 List-item anchoring is the only container-specific exception in this milestone. The pure rich-preview builder accepts explicit old-side and new-side source-line sets that need internal anchors. It keeps normal lists as one rendered list unless one of those target lines falls inside the list. When a review targets a context list item, the component uses that target line as the anchor boundary. When a review targets an added or deleted list item, it also adds a same-indent comparable context list item as an alignment boundary so unchanged sibling items do not render as false additions or deletions. Boundary selection prefers the nearest preceding comparable item, then the nearest following comparable item; if neither exists, the changed side can still split for card placement and the opposite side remains absent or whole.
 
-Split list blocks are a placement device, not new Markdown paragraph breaks. They render only the minimum number of `<ul>` or `<ol>` chunks needed to put review cards after their target items; untargeted consecutive items stay grouped in the same chunk. Split chunks must preserve numbering for ordered lists, keep nested lists and multiline item content inside the owning item, abandon splitting when rendered `<li>` counts do not match source markers, and use styling that removes only synthetic wrapper margins. Untargeted lists, loose lists outside targeted regions, tables, and blockquotes remain whole top-level blocks. Targeted loose lists use the same source-marker grouping, preserving each rendered `<li>` subtree; if the renderer/source marker count no longer matches, the card anchors after the whole list container instead of guessing.
+Split list blocks are a placement device, not new Markdown paragraph breaks. They render only the minimum number of `<ul>` or `<ol>` chunks needed to put review cards after their target items; untargeted consecutive items stay grouped in the same chunk. Split chunks must preserve numbering for ordered lists, keep nested lists and multiline item content inside the owning item, abandon splitting when rendered `<li>` counts do not match source markers, and use styling that removes only synthetic wrapper margins. Untargeted lists, loose lists outside targeted regions, tables, and blockquotes remain whole top-level blocks. Targeted loose lists use the same source-marker grouping, preserving each rendered `<li>` subtree; if the renderer/source marker count no longer matches, the card anchors after the whole list container instead of guessing. Added/deleted list boundary scans treat indented continuation lines and pre-blank lazy continuation lines as part of the current list item; they stop at lower-indented content, lower-indented markers, or same-indent non-list text after a blank line so unrelated blocks are not selected as alignment context.
+
+Side-by-side rich preview is a comparison surface, not a single prose column. It should use the available file width for its two panes, while unified rich preview keeps the narrower readable Markdown measure.
 
 Wrapper elements around rendered blocks are acceptable only when they preserve the readable Markdown layout. They must not force one-off margin, table, list, or heading behavior that differs materially from the normal rich preview. Layout regressions for lists, headings, paragraphs, and tables should be covered by component or browser assertions when wrappers change.
 
@@ -115,6 +117,7 @@ Markdown rich preview should avoid unbounded quadratic work. Block alignment may
 - Split rich preview anchors cards to the matching old or new side rather than dumping all cards above the preview.
 - Block-level additions and deletions use block diff styling without per-word underline decoration.
 - Split-pane inline text changes retain a visible add/delete background cue without underline or strike-through decoration.
+- Split-pane rich preview uses the available file width instead of the unified preview's prose-width cap.
 - The rendered DOM remains valid for lists, tables, and blockquotes.
 - Large Markdown diffs do not allocate an unbounded block comparison matrix.
 - The block-rendering path preserves centralized Markdown sanitization and the allowed attribute policy.

--- a/docs/superpowers/specs/2026-06-18-rich-preview-review-card-anchoring-design.md
+++ b/docs/superpowers/specs/2026-06-18-rich-preview-review-card-anchoring-design.md
@@ -86,6 +86,8 @@ Rich preview should read like rendered Markdown first.
 
 For added or removed block-level content, use quiet block background and border styling. Avoid underlining every word in newly inserted paragraphs, headings, or list items. Inline `ins` and `del` styling should be reserved for small text changes inside otherwise matching blocks.
 
+Split mode uses the before/after pane and block background as the primary block-level add/delete cue. Inline `ins` and `del` nodes inside otherwise matching split-pane blocks keep a subtle add/delete background cue, but never use native underline or strike-through text decoration.
+
 Review cards should sit between rendered blocks without introducing artificial paragraph breaks, isolated list fragments, or source-diff-style clutter.
 
 For structured containers, the card sits after the whole top-level container. It must not become a child of `<ul>`, `<ol>`, `<table>`, `<tbody>`, `<tr>`, `<blockquote>`, or similar elements unless the implementation has a valid, tested container-specific insertion model.
@@ -112,6 +114,7 @@ Markdown rich preview should avoid unbounded quadratic work. Block alignment may
 - File-level, stale-head, and unmapped review threads remain visible in a separated fallback stack.
 - Split rich preview anchors cards to the matching old or new side rather than dumping all cards above the preview.
 - Block-level additions and deletions use block diff styling without per-word underline decoration.
+- Split-pane inline text changes retain a visible add/delete background cue without underline or strike-through decoration.
 - The rendered DOM remains valid for lists, tables, and blockquotes.
 - Large Markdown diffs do not allocate an unbounded block comparison matrix.
 - The block-rendering path preserves centralized Markdown sanitization and the allowed attribute policy.
@@ -126,7 +129,7 @@ Add unit coverage for the rich-preview model:
 - reference-style links still resolve when review cards are anchored;
 - untargeted lists remain whole rendered lists;
 - list items expose separate rich-preview anchor blocks when split-line inputs target individual source items;
-- ordered-list numbering, nested lists, multiline items, and mismatched source/rendered item counts have focused coverage;
+- ordered-list numbering, nested lists, multiline items, targeted loose lists, and mismatched source/rendered item counts have focused coverage;
 - multi-hunk fenced code, HTML blocks, blockquotes, lists, and tables do not expose synthetic separator lines and keep the expected top-level structure;
 - stripped spanning-token re-renders keep in-document reference definitions available through the approved parser-context API;
 - user-authored thematic breaks inside hunks still render;

--- a/docs/superpowers/specs/2026-06-18-rich-preview-review-card-anchoring-design.md
+++ b/docs/superpowers/specs/2026-06-18-rich-preview-review-card-anchoring-design.md
@@ -66,19 +66,19 @@ This is intentional: preserving valid rendered Markdown takes priority over plac
 5. Render blocks using the canonical renderer while preserving the same Markdown semantics as whole-document rendering. If that cannot be guaranteed for a construct, do not decompose that construct into independently rendered fragments.
 6. Diff corresponding old/new rendered blocks for unified HTML.
 7. Project the same diff into before/after HTML for split mode.
-8. Assign each review thread to the block whose old or new source range contains the target line.
+8. Assign each review thread to the block whose exact old or new mapped source-line set contains the target line. Start/end ranges are display metadata only; they are not enough for anchoring when a block spans multiple hunks with hidden source gaps.
 
 If a block cannot be mapped confidently, keep the rendered Markdown correct and leave related review threads in the fallback area. Correct rendering is more important than guessed inline placement.
 
 `renderMarkdownBlocks(raw, repo)` is the only block-rendering API this feature should use. It must parse once with the configured Marked instance, keep document-level Marked behavior such as in-document reference definitions intact for the visible block output, render only visible top-level tokens as blocks, and sanitize every block through the same DOMPurify allow-list used by `renderMarkdown()`. Reference-link resolution inside the reconstructed hunk document is a required regression test for this API boundary.
 
-Multiple hunks are joined in backend hunk order with an explicit parser-only separator: blank line, thematic break line `---`, blank line. The separator prevents accidental list/table merging across unrelated hunks and can influence Markdown parsing the same way a thematic break does, but it is hidden from rendered preview output. Synthetic separator tokens have no old/new source-line mapping, are excluded from source-line range calculations, do not participate in block alignment, and cannot receive review cards. If Marked absorbs synthetic separator lines into a mapped multi-line token, such as a fenced code block or HTML block spanning hunks, the rendered block is rebuilt from mapped source lines only so the synthetic lines are stripped before sanitization and diffing. User-authored `---` lines inside a hunk keep their source mapping and render normally. Definitions inside the reconstructed hunk document may resolve across that separator; definitions outside loaded hunks remain unavailable.
+Multiple hunks are joined in backend hunk order with an explicit parser-only separator: blank line, thematic break line `---`, blank line. The separator prevents accidental list/table merging across unrelated hunks and can influence Markdown parsing the same way a thematic break does, but it is hidden from rendered preview output. Synthetic separator tokens have no old/new source-line mapping, are excluded from mapped source-line sets and display range calculations, do not participate in block alignment, and cannot receive review cards. If Marked absorbs synthetic separator lines into a mapped multi-line token, such as a fenced code block spanning hunks, the rendered block is rebuilt from mapped source lines only so the synthetic lines are stripped before sanitization and diffing. That stripped re-render must include in-document reference definitions from the reconstructed hunk document as parser context; if a future token type cannot be stripped without preserving document-level semantics, keep the correct rendered output and move related cards to fallback instead of guessing. User-authored `---` lines inside a hunk keep their source mapping and render normally. Definitions inside the reconstructed hunk document may resolve across that separator; definitions outside loaded hunks remain unavailable.
 
 Repeated paragraphs, headings, or list items are resolved by source order, not rendered text identity alone. The generated-line cursor makes identical text in different source locations produce distinct ranges.
 
 Definitions outside the loaded diff hunks are outside this feature's available input. They may not resolve until the preview is backed by full-file content. Definitions inside the reconstructed hunk document must keep working.
 
-Deleted-only comments anchor against old-side block ranges. Added/current comments anchor against new-side block ranges. Multi-line review ranges use the same target side and line that the source diff uses for card placement; if the target range crosses multiple top-level Markdown containers, the card anchors to the first containing top-level block for that target line. If no containing block exists, the card becomes a file-level fallback card rather than guessing.
+Deleted-only comments anchor against old-side mapped line sets. Added/current comments anchor against new-side mapped line sets. Multi-line review ranges use the same target side and line that the source diff uses for card placement; if the target range crosses multiple top-level Markdown containers, the card anchors to the first containing top-level block for that target line. If no containing block exists, or if the target line falls inside a hidden hunk gap within a block's display start/end range, the card becomes a file-level fallback card rather than guessing.
 
 ## Visual Behavior
 
@@ -111,6 +111,7 @@ Markdown rich preview should avoid unbounded quadratic work. Block alignment may
 - The block-rendering path preserves centralized Markdown sanitization and the allowed attribute policy.
 - Multi-hunk previews do not show artificial `<hr>` or separator content that was not part of the reviewed file.
 - Synthetic separator lines are hidden even when a Markdown token spans hunks, while user-authored thematic breaks remain visible.
+- Review cards do not anchor to hidden source gaps between hunks, even when one rendered block spans both hunks.
 
 ## Testing
 
@@ -120,6 +121,7 @@ Add unit coverage for the rich-preview model:
 - loose lists render as a single list where Markdown defines one;
 - multi-hunk fenced code, HTML blocks, blockquotes, and list continuations do not expose synthetic separator lines;
 - user-authored thematic breaks inside hunks still render;
+- mapped source-line sets exclude synthetic separator lines and hidden hunk gaps;
 - review threads assign to old-side and new-side blocks;
 - uncertain or file-level threads fall back visibly.
 
@@ -127,6 +129,7 @@ Keep component coverage for:
 
 - unified rich preview renders review cards inside the preview after their target block;
 - split rich preview renders review cards near the matching side block;
+- review threads targeting hidden hunk gaps remain file-level fallback cards;
 - source diff review annotations remain unchanged.
 
 Keep browser e2e coverage for the PR files page rich preview toggle, including a review-card case that proves cards are not at the top of the file.

--- a/docs/superpowers/specs/2026-06-18-rich-preview-review-card-anchoring-design.md
+++ b/docs/superpowers/specs/2026-06-18-rich-preview-review-card-anchoring-design.md
@@ -90,9 +90,9 @@ Review cards should sit between rendered blocks without introducing artificial p
 
 For structured containers, the card sits after the whole top-level container. It must not become a child of `<ul>`, `<ol>`, `<table>`, `<tbody>`, `<tr>`, `<blockquote>`, or similar elements unless the implementation has a valid, tested container-specific insertion model.
 
-List-item anchoring is the only container-specific exception in this milestone. The pure rich-preview builder accepts explicit old-side and new-side source-line sets that need internal anchors. It keeps normal lists as one rendered list unless one of those target lines falls inside the list. When a review targets a context list item, the component uses that target line as the anchor boundary. When a review targets an added or deleted list item, it also adds the previous comparable list-item boundary where one exists so unchanged sibling items can still align with the opposite side instead of being rendered as false additions or deletions.
+List-item anchoring is the only container-specific exception in this milestone. The pure rich-preview builder accepts explicit old-side and new-side source-line sets that need internal anchors. It keeps normal lists as one rendered list unless one of those target lines falls inside the list. When a review targets a context list item, the component uses that target line as the anchor boundary. When a review targets an added or deleted list item, it also adds a same-indent comparable context list item as an alignment boundary so unchanged sibling items do not render as false additions or deletions. Boundary selection prefers the nearest preceding comparable item, then the nearest following comparable item; if neither exists, the changed side can still split for card placement and the opposite side remains absent or whole.
 
-Split list blocks are a placement device, not new Markdown paragraph breaks. They render only the minimum number of `<ul>` or `<ol>` chunks needed to put review cards after their target items; untargeted consecutive items stay grouped in the same chunk. Split chunks must preserve numbering for ordered lists, keep nested lists inside the owning item, abandon splitting when rendered `<li>` counts do not match source markers, and use styling that removes synthetic wrapper margins. Untargeted lists, loose lists outside targeted regions, tables, and blockquotes remain whole top-level blocks.
+Split list blocks are a placement device, not new Markdown paragraph breaks. They render only the minimum number of `<ul>` or `<ol>` chunks needed to put review cards after their target items; untargeted consecutive items stay grouped in the same chunk. Split chunks must preserve numbering for ordered lists, keep nested lists and multiline item content inside the owning item, abandon splitting when rendered `<li>` counts do not match source markers, and use styling that removes only synthetic wrapper margins. Untargeted lists, loose lists outside targeted regions, tables, and blockquotes remain whole top-level blocks. Targeted loose lists use the same source-marker grouping, preserving each rendered `<li>` subtree; if the renderer/source marker count no longer matches, the card anchors after the whole list container instead of guessing.
 
 Wrapper elements around rendered blocks are acceptable only when they preserve the readable Markdown layout. They must not force one-off margin, table, list, or heading behavior that differs materially from the normal rich preview. Layout regressions for lists, headings, paragraphs, and tables should be covered by component or browser assertions when wrappers change.
 
@@ -126,7 +126,7 @@ Add unit coverage for the rich-preview model:
 - reference-style links still resolve when review cards are anchored;
 - untargeted lists remain whole rendered lists;
 - list items expose separate rich-preview anchor blocks when split-line inputs target individual source items;
-- ordered-list numbering, nested lists, multiline items, and mismatched source/rendered item counts have focused coverage or an explicit fallback expectation;
+- ordered-list numbering, nested lists, multiline items, and mismatched source/rendered item counts have focused coverage;
 - multi-hunk fenced code, HTML blocks, blockquotes, lists, and tables do not expose synthetic separator lines and keep the expected top-level structure;
 - stripped spanning-token re-renders keep in-document reference definitions available through the approved parser-context API;
 - user-authored thematic breaks inside hunks still render;
@@ -139,6 +139,7 @@ Keep component coverage for:
 - unified rich preview renders review cards inside the preview after their target block;
 - split rich preview renders review cards near the matching side block;
 - added and deleted list-item review cards keep unchanged sibling items aligned rather than rendering them as false additions or deletions;
+- added and deleted list-item review cards at the first and last list item keep unchanged sibling items aligned;
 - review threads targeting hidden hunk gaps remain file-level fallback cards;
 - source diff review annotations remain unchanged.
 

--- a/docs/superpowers/specs/2026-06-18-rich-preview-review-card-anchoring-design.md
+++ b/docs/superpowers/specs/2026-06-18-rich-preview-review-card-anchoring-design.md
@@ -72,7 +72,7 @@ If a block cannot be mapped confidently, keep the rendered Markdown correct and 
 
 `renderMarkdownBlocks(raw, repo)` is the only block-rendering API this feature should use. It must parse once with the configured Marked instance, keep document-level Marked behavior such as in-document reference definitions intact for the visible block output, render only visible top-level tokens as blocks, and sanitize every block through the same DOMPurify allow-list used by `renderMarkdown()`. Reference-link resolution inside the reconstructed hunk document is a required regression test for this API boundary.
 
-Multiple hunks are joined in backend hunk order with an explicit parser-only separator: blank line, thematic break line `---`, blank line. The separator prevents accidental list/table merging across unrelated hunks and can influence Markdown parsing the same way a thematic break does, but it is hidden from rendered preview output. Synthetic separator tokens have no old/new source-line mapping, are excluded from source-line range calculations, do not participate in block alignment, and cannot receive review cards. Definitions inside the reconstructed hunk document may resolve across that separator; definitions outside loaded hunks remain unavailable.
+Multiple hunks are joined in backend hunk order with an explicit parser-only separator: blank line, thematic break line `---`, blank line. The separator prevents accidental list/table merging across unrelated hunks and can influence Markdown parsing the same way a thematic break does, but it is hidden from rendered preview output. Synthetic separator tokens have no old/new source-line mapping, are excluded from source-line range calculations, do not participate in block alignment, and cannot receive review cards. If Marked absorbs synthetic separator lines into a mapped multi-line token, such as a fenced code block or HTML block spanning hunks, the rendered block is rebuilt from mapped source lines only so the synthetic lines are stripped before sanitization and diffing. User-authored `---` lines inside a hunk keep their source mapping and render normally. Definitions inside the reconstructed hunk document may resolve across that separator; definitions outside loaded hunks remain unavailable.
 
 Repeated paragraphs, headings, or list items are resolved by source order, not rendered text identity alone. The generated-line cursor makes identical text in different source locations produce distinct ranges.
 
@@ -110,6 +110,7 @@ Markdown rich preview should avoid unbounded quadratic work. Block alignment may
 - Large Markdown diffs do not allocate an unbounded block comparison matrix.
 - The block-rendering path preserves centralized Markdown sanitization and the allowed attribute policy.
 - Multi-hunk previews do not show artificial `<hr>` or separator content that was not part of the reviewed file.
+- Synthetic separator lines are hidden even when a Markdown token spans hunks, while user-authored thematic breaks remain visible.
 
 ## Testing
 
@@ -117,6 +118,8 @@ Add unit coverage for the rich-preview model:
 
 - reference-style links still resolve when review cards are anchored;
 - loose lists render as a single list where Markdown defines one;
+- multi-hunk fenced code, HTML blocks, blockquotes, and list continuations do not expose synthetic separator lines;
+- user-authored thematic breaks inside hunks still render;
 - review threads assign to old-side and new-side blocks;
 - uncertain or file-level threads fall back visibly.
 

--- a/docs/superpowers/specs/2026-06-18-rich-preview-review-card-anchoring-design.md
+++ b/docs/superpowers/specs/2026-06-18-rich-preview-review-card-anchoring-design.md
@@ -100,7 +100,7 @@ Markdown rich preview should avoid unbounded quadratic work. Block alignment may
 
 - Rich preview does not render arbitrary raw Markdown fragments independently.
 - Reference-style links defined inside the rendered hunk document still resolve.
-- Loose lists that Marked treats as one list remain one rendered list.
+- List items can be emitted as separate rich-preview anchor blocks when needed to place review cards after the matching source item.
 - Separate lists and tables on opposite sides of a hidden hunk separator stay separate top-level blocks.
 - Review cards on repeated text blocks map by source line order.
 - Review cards on structured container children remain near the valid top-level container boundary and keep the exact line reference in the card header.
@@ -119,7 +119,7 @@ Markdown rich preview should avoid unbounded quadratic work. Block alignment may
 Add unit coverage for the rich-preview model:
 
 - reference-style links still resolve when review cards are anchored;
-- loose lists render as a single list where Markdown defines one;
+- list items expose separate rich-preview anchor blocks when review cards target individual source items;
 - multi-hunk fenced code, HTML blocks, blockquotes, lists, and tables do not expose synthetic separator lines and keep the expected top-level structure;
 - stripped spanning-token re-renders keep in-document reference definitions available through the approved parser-context API;
 - user-authored thematic breaks inside hunks still render;
@@ -134,7 +134,7 @@ Keep component coverage for:
 - review threads targeting hidden hunk gaps remain file-level fallback cards;
 - source diff review annotations remain unchanged.
 
-Keep browser e2e coverage for the PR files page rich preview toggle, including a review-card case that proves cards are not at the top of the file.
+Keep browser e2e coverage for the PR files page rich preview toggle, including review-card cases that prove cards are not at the top of the file, multiple cards render in source order, list-item cards attach after the matching rendered item, and hidden-gap review threads remain file-level fallback cards.
 
 ## Implementation Staging
 

--- a/docs/superpowers/specs/2026-06-18-rich-preview-review-card-anchoring-design.md
+++ b/docs/superpowers/specs/2026-06-18-rich-preview-review-card-anchoring-design.md
@@ -70,9 +70,9 @@ This is intentional: preserving valid rendered Markdown takes priority over plac
 
 If a block cannot be mapped confidently, keep the rendered Markdown correct and leave related review threads in the fallback area. Correct rendering is more important than guessed inline placement.
 
-`renderMarkdownBlocks(raw, repo)` is the only block-rendering API this feature should use. It must parse once with the configured Marked instance, keep document-level Marked behavior such as in-document reference definitions intact for the visible block output, render only visible top-level tokens as blocks, and sanitize every block through the same DOMPurify allow-list used by `renderMarkdown()`. Reference-link resolution inside the reconstructed hunk document is a required regression test for this API boundary.
+`renderMarkdownBlocks(raw, repo)` is the only visible block-rendering API this feature should use. It must parse with the configured Marked instance, keep document-level Marked behavior such as in-document reference definitions intact for the visible block output, render only visible top-level tokens as blocks, and sanitize every block through the same DOMPurify allow-list used by `renderMarkdown()`. `extractMarkdownDefinitionLines(raw, repo)` is an approved companion parser-context API for the synthetic-separator stripping path; no other rich-preview code should create an ad hoc definition scanner or alternate sanitizer. Reference-link resolution inside the reconstructed hunk document is a required regression test for this API boundary.
 
-Multiple hunks are joined in backend hunk order with an explicit parser-only separator: blank line, thematic break line `---`, blank line. The separator prevents accidental list/table merging across unrelated hunks and can influence Markdown parsing the same way a thematic break does, but it is hidden from rendered preview output. Synthetic separator tokens have no old/new source-line mapping, are excluded from mapped source-line sets and display range calculations, do not participate in block alignment, and cannot receive review cards. If Marked absorbs synthetic separator lines into a mapped multi-line token, such as a fenced code block spanning hunks, the rendered block is rebuilt from mapped source lines only so the synthetic lines are stripped before sanitization and diffing. That stripped re-render must include in-document reference definitions from the reconstructed hunk document as parser context; if a future token type cannot be stripped without preserving document-level semantics, keep the correct rendered output and move related cards to fallback instead of guessing. User-authored `---` lines inside a hunk keep their source mapping and render normally. Definitions inside the reconstructed hunk document may resolve across that separator; definitions outside loaded hunks remain unavailable.
+Multiple hunks are joined in backend hunk order with an explicit parser-only separator: blank line, thematic break line `---`, blank line. The separator prevents accidental list/table merging across unrelated hunks and can influence Markdown parsing the same way a thematic break does, but it is hidden from rendered preview output. Synthetic separator tokens have no old/new source-line mapping, are excluded from mapped source-line sets and display range calculations, do not participate in block alignment, and cannot receive review cards. Hunk boundaries are not source continuity hints: when Marked emits separate list, blockquote, table, or paragraph tokens on either side of the hidden separator, render those as separate top-level blocks and do not merge them by text shape. If Marked absorbs synthetic separator lines into a mapped multi-line token, such as a fenced code block spanning hunks, the rendered block is rebuilt from mapped source lines only so the synthetic lines are stripped before sanitization and diffing. That stripped re-render must include in-document reference definitions from the reconstructed hunk document as parser context; if a future token type cannot be stripped without preserving document-level semantics, keep the correct rendered output and move the uncertain block's related cards to fallback instead of guessing. User-authored `---` lines inside a hunk keep their source mapping and render normally. Definitions inside the reconstructed hunk document may resolve across that separator; definitions outside loaded hunks remain unavailable.
 
 Repeated paragraphs, headings, or list items are resolved by source order, not rendered text identity alone. The generated-line cursor makes identical text in different source locations produce distinct ranges.
 
@@ -94,13 +94,14 @@ Wrapper elements around rendered blocks are acceptable only when they preserve t
 
 ## Performance
 
-Markdown rich preview should avoid unbounded quadratic work. Block alignment may use an LCS only below a fixed block-product threshold; above that threshold it must fall back to a coarse delete/insert projection or another bounded strategy. Parsing, token mapping, sanitization, and block diffing should be derived from stable inputs so Svelte recomputation only happens when the file, repository context, or relevant review-thread inputs change.
+Markdown rich preview should avoid unbounded quadratic work. Block alignment may use an LCS only below a fixed block-product threshold; above that threshold it must fall back to a coarse delete/insert projection or another bounded strategy. Parsing, token mapping, sanitization, exact-line membership checks, and block diffing should be derived from stable inputs so Svelte recomputation only happens when the file, repository context, or relevant review-thread inputs change. If review-thread placement becomes a hot path for large blocks, precompute per-block line sets rather than scanning large arrays repeatedly.
 
 ## Acceptance Criteria
 
 - Rich preview does not render arbitrary raw Markdown fragments independently.
 - Reference-style links defined inside the rendered hunk document still resolve.
 - Loose lists that Marked treats as one list remain one rendered list.
+- Separate lists and tables on opposite sides of a hidden hunk separator stay separate top-level blocks.
 - Review cards on repeated text blocks map by source line order.
 - Review cards on structured container children remain near the valid top-level container boundary and keep the exact line reference in the card header.
 - File-level, stale-head, and unmapped review threads remain visible in a separated fallback stack.
@@ -119,7 +120,8 @@ Add unit coverage for the rich-preview model:
 
 - reference-style links still resolve when review cards are anchored;
 - loose lists render as a single list where Markdown defines one;
-- multi-hunk fenced code, HTML blocks, blockquotes, and list continuations do not expose synthetic separator lines;
+- multi-hunk fenced code, HTML blocks, blockquotes, lists, and tables do not expose synthetic separator lines and keep the expected top-level structure;
+- stripped spanning-token re-renders keep in-document reference definitions available through the approved parser-context API;
 - user-authored thematic breaks inside hunks still render;
 - mapped source-line sets exclude synthetic separator lines and hidden hunk gaps;
 - review threads assign to old-side and new-side blocks;

--- a/docs/superpowers/specs/2026-06-18-rich-preview-review-card-anchoring-design.md
+++ b/docs/superpowers/specs/2026-06-18-rich-preview-review-card-anchoring-design.md
@@ -1,0 +1,93 @@
+# Rich Preview Review Card Anchoring Design
+
+## Context
+
+Markdown rich preview needs to show review cards in the rendered document, not only in the raw source diff. The first implementation made cards visible, but it anchored them by splitting Markdown into raw line fragments and rendering each fragment independently. That breaks normal Markdown semantics for constructs that depend on whole-document context, such as loose lists, reference links, and future parser extensions.
+
+The fix should preserve rendered Markdown behavior first, then layer review-card placement and diff cues on top.
+
+## Goals
+
+- Show inline review cards inside Markdown rich preview for unified and split diff modes.
+- Preserve whole-document Markdown parsing semantics.
+- Keep review placement logic out of `DiffRichPreview.svelte` except for rendering an explicit model.
+- Avoid per-word green underlines for newly added block content.
+- Keep unanchored, file-level, stale-head, or uncertain review threads visible in a clearly separated fallback area.
+
+## Non-Goals
+
+- Do not build a custom Markdown parser.
+- Do not make non-Markdown binary, image, PDF, or plain text previews line-anchor review cards.
+- Do not change the source-diff review annotation behavior.
+
+## Architecture
+
+Introduce a small Markdown rich-preview model layer near the existing Markdown utilities. The model owns source-line mapping, Markdown rendering, block diffing, and review placement inputs. `DiffRichPreview.svelte` consumes the model and renders it.
+
+The component should no longer split raw Markdown by blank lines or code fences. It should not call `renderMarkdown()` on arbitrary fragments as a placement strategy.
+
+The model should expose block records with this minimum shape:
+
+```ts
+type MarkdownPreviewBlock = {
+  key: string;
+  oldStart?: number;
+  oldEnd?: number;
+  newStart?: number;
+  newEnd?: number;
+  unifiedHtml: string;
+  beforeHtml?: string;
+  afterHtml?: string;
+};
+```
+
+`DiffRichPreview.svelte` renders:
+
+- unified mode: `block.unifiedHtml`, followed by review cards assigned to that block;
+- split mode: `block.beforeHtml` and `block.afterHtml`, followed by review cards assigned to the matching old or new side;
+- fallback review threads in a separated stack before the block stream, not as fake inline anchors.
+
+## Data Flow
+
+1. Build old and new Markdown documents from diff hunk lines.
+2. While building those documents, keep a generated-line to source-line map for old and new sides.
+3. Parse old and new Markdown as whole documents through the canonical Markdown parser path.
+4. Derive top-level token or rendered-block source spans from parser metadata and the generated-line maps.
+5. Render blocks using the canonical renderer while preserving the same Markdown semantics as whole-document rendering. If that cannot be guaranteed for a construct, do not decompose that construct into independently rendered fragments.
+6. Diff corresponding old/new rendered blocks for unified HTML.
+7. Project the same diff into before/after HTML for split mode.
+8. Assign each review thread to the block whose old or new source range contains the target line.
+
+If a block cannot be mapped confidently, keep the rendered Markdown correct and leave related review threads in the fallback area. Correct rendering is more important than guessed inline placement.
+
+## Visual Behavior
+
+Rich preview should read like rendered Markdown first.
+
+For added or removed block-level content, use quiet block background and border styling. Avoid underlining every word in newly inserted paragraphs, headings, or list items. Inline `ins` and `del` styling should be reserved for small text changes inside otherwise matching blocks.
+
+Review cards should sit between rendered blocks without introducing artificial paragraph breaks, isolated list fragments, or source-diff-style clutter.
+
+## Testing
+
+Add unit coverage for the rich-preview model:
+
+- reference-style links still resolve when review cards are anchored;
+- loose lists render as a single list where Markdown defines one;
+- review threads assign to old-side and new-side blocks;
+- uncertain or file-level threads fall back visibly.
+
+Keep component coverage for:
+
+- unified rich preview renders review cards inside the preview after their target block;
+- split rich preview renders review cards near the matching side block;
+- source diff review annotations remain unchanged.
+
+Keep browser e2e coverage for the PR files page rich preview toggle, including a review-card case that proves cards are not at the top of the file.
+
+## Implementation Boundaries
+
+- The first implementation should replace the fragment-rendering path, not polish it.
+- The Markdown rich-preview model should be pure enough to test without Svelte.
+- The component should receive a simple render model and avoid knowing parser details.
+- Any fallback should be explicit and tested, not silent semantic drift.

--- a/docs/superpowers/specs/2026-06-18-rich-preview-review-card-anchoring-design.md
+++ b/docs/superpowers/specs/2026-06-18-rich-preview-review-card-anchoring-design.md
@@ -27,6 +27,11 @@ Introduce a small Markdown rich-preview model layer near the existing Markdown u
 
 The component should no longer split raw Markdown by blank lines or code fences. It should not call `renderMarkdown()` on arbitrary fragments as a placement strategy.
 
+The model has two explicit boundaries:
+
+- The reconstructed hunk document is the complete Markdown input available to rich preview. It is made from the diff hunk lines that belong to each side.
+- The render block is a top-level Marked token/container derived from that hunk document. Blocks are display and anchoring units; they are not separate Markdown documents with independent parser semantics.
+
 The model should expose block records with this minimum shape:
 
 ```ts
@@ -65,9 +70,15 @@ This is intentional: preserving valid rendered Markdown takes priority over plac
 
 If a block cannot be mapped confidently, keep the rendered Markdown correct and leave related review threads in the fallback area. Correct rendering is more important than guessed inline placement.
 
+`renderMarkdownBlocks(raw, repo)` is the only block-rendering API this feature should use. It must parse once with the configured Marked instance, keep document-level Marked behavior such as in-document reference definitions intact for the visible block output, render only visible top-level tokens as blocks, and sanitize every block through the same DOMPurify allow-list used by `renderMarkdown()`. Reference-link resolution inside the reconstructed hunk document is a required regression test for this API boundary.
+
+Multiple hunks are joined in backend hunk order with an explicit anchorless separator: blank line, thematic break line `---`, blank line. The separator prevents accidental list/table merging across unrelated hunks, can influence Markdown parsing the same way a visible thematic break does, has no old/new source-line mapping, and cannot receive review cards. Definitions inside the reconstructed hunk document may resolve across that separator; definitions outside loaded hunks remain unavailable.
+
 Repeated paragraphs, headings, or list items are resolved by source order, not rendered text identity alone. The generated-line cursor makes identical text in different source locations produce distinct ranges.
 
 Definitions outside the loaded diff hunks are outside this feature's available input. They may not resolve until the preview is backed by full-file content. Definitions inside the reconstructed hunk document must keep working.
+
+Deleted-only comments anchor against old-side block ranges. Added/current comments anchor against new-side block ranges. Multi-line review ranges use the same target side and line that the source diff uses for card placement; if the target range crosses multiple top-level Markdown containers, the card anchors to the first containing top-level block for that target line. If no containing block exists, the card becomes a file-level fallback card rather than guessing.
 
 ## Visual Behavior
 
@@ -78,6 +89,12 @@ For added or removed block-level content, use quiet block background and border 
 Review cards should sit between rendered blocks without introducing artificial paragraph breaks, isolated list fragments, or source-diff-style clutter.
 
 For structured containers, the card sits after the whole top-level container. It must not become a child of `<ul>`, `<ol>`, `<table>`, `<tbody>`, `<tr>`, `<blockquote>`, or similar elements unless the implementation has a valid, tested container-specific insertion model.
+
+Wrapper elements around rendered blocks are acceptable only when they preserve the readable Markdown layout. They must not force one-off margin, table, list, or heading behavior that differs materially from the normal rich preview. Layout regressions for lists, headings, paragraphs, and tables should be covered by component or browser assertions when wrappers change.
+
+## Performance
+
+Markdown rich preview should avoid unbounded quadratic work. Block alignment may use an LCS only below a fixed block-product threshold; above that threshold it must fall back to a coarse delete/insert projection or another bounded strategy. Parsing, token mapping, sanitization, and block diffing should be derived from stable inputs so Svelte recomputation only happens when the file, repository context, or relevant review-thread inputs change.
 
 ## Acceptance Criteria
 
@@ -90,6 +107,8 @@ For structured containers, the card sits after the whole top-level container. It
 - Split rich preview anchors cards to the matching old or new side rather than dumping all cards above the preview.
 - Block-level additions and deletions use block diff styling without per-word underline decoration.
 - The rendered DOM remains valid for lists, tables, and blockquotes.
+- Large Markdown diffs do not allocate an unbounded block comparison matrix.
+- The block-rendering path preserves centralized Markdown sanitization and the allowed attribute policy.
 
 ## Testing
 
@@ -110,12 +129,13 @@ Keep browser e2e coverage for the PR files page rich preview toggle, including a
 
 ## Implementation Staging
 
-1. Add pure model tests and a `markdown-rich-preview` utility.
-2. Implement generated-line to source-line mapping from Marked tokens.
-3. Wire unified rich preview to the model.
-4. Wire split rich preview to the same model.
-5. Adjust block-level diff styling.
-6. Add component and Playwright coverage.
+1. Define the pure rich-preview model contract and fixtures.
+2. Add failing model tests for reference definitions, loose lists, block ranges, structured container anchoring, and large-block fallback.
+3. Implement generated-line to source-line mapping from Marked tokens through the shared block-rendering API.
+4. Wire unified rich preview to the model with component coverage.
+5. Wire split rich preview to the same model with component coverage.
+6. Adjust block-level diff styling.
+7. Add full PR files Playwright coverage before finalizing the branch.
 
 ## Implementation Boundaries
 
@@ -123,3 +143,4 @@ Keep browser e2e coverage for the PR files page rich preview toggle, including a
 - The Markdown rich-preview model should be pure enough to test without Svelte.
 - The component should receive a simple render model and avoid knowing parser details.
 - Any fallback should be explicit and tested, not silent semantic drift.
+- Sanitization must stay centralized through the existing Markdown utility policy; no new unsanitized token/block HTML path is allowed.

--- a/docs/superpowers/specs/2026-06-18-rich-preview-review-card-anchoring-design.md
+++ b/docs/superpowers/specs/2026-06-18-rich-preview-review-card-anchoring-design.md
@@ -72,7 +72,7 @@ If a block cannot be mapped confidently, keep the rendered Markdown correct and 
 
 `renderMarkdownBlocks(raw, repo)` is the only block-rendering API this feature should use. It must parse once with the configured Marked instance, keep document-level Marked behavior such as in-document reference definitions intact for the visible block output, render only visible top-level tokens as blocks, and sanitize every block through the same DOMPurify allow-list used by `renderMarkdown()`. Reference-link resolution inside the reconstructed hunk document is a required regression test for this API boundary.
 
-Multiple hunks are joined in backend hunk order with an explicit anchorless separator: blank line, thematic break line `---`, blank line. The separator prevents accidental list/table merging across unrelated hunks, can influence Markdown parsing the same way a visible thematic break does, has no old/new source-line mapping, and cannot receive review cards. Definitions inside the reconstructed hunk document may resolve across that separator; definitions outside loaded hunks remain unavailable.
+Multiple hunks are joined in backend hunk order with an explicit parser-only separator: blank line, thematic break line `---`, blank line. The separator prevents accidental list/table merging across unrelated hunks and can influence Markdown parsing the same way a thematic break does, but it is hidden from rendered preview output. Synthetic separator tokens have no old/new source-line mapping, are excluded from source-line range calculations, do not participate in block alignment, and cannot receive review cards. Definitions inside the reconstructed hunk document may resolve across that separator; definitions outside loaded hunks remain unavailable.
 
 Repeated paragraphs, headings, or list items are resolved by source order, not rendered text identity alone. The generated-line cursor makes identical text in different source locations produce distinct ranges.
 
@@ -109,6 +109,7 @@ Markdown rich preview should avoid unbounded quadratic work. Block alignment may
 - The rendered DOM remains valid for lists, tables, and blockquotes.
 - Large Markdown diffs do not allocate an unbounded block comparison matrix.
 - The block-rendering path preserves centralized Markdown sanitization and the allowed attribute policy.
+- Multi-hunk previews do not show artificial `<hr>` or separator content that was not part of the reviewed file.
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-06-18-rich-preview-review-card-anchoring-design.md
+++ b/docs/superpowers/specs/2026-06-18-rich-preview-review-card-anchoring-design.md
@@ -90,6 +90,10 @@ Review cards should sit between rendered blocks without introducing artificial p
 
 For structured containers, the card sits after the whole top-level container. It must not become a child of `<ul>`, `<ol>`, `<table>`, `<tbody>`, `<tr>`, `<blockquote>`, or similar elements unless the implementation has a valid, tested container-specific insertion model.
 
+List-item anchoring is the only container-specific exception in this milestone. The pure rich-preview builder accepts explicit old-side and new-side source-line sets that need internal anchors. It keeps normal lists as one rendered list unless one of those target lines falls inside the list. When a review targets a context list item, the component uses that target line as the anchor boundary. When a review targets an added or deleted list item, it also adds the previous comparable list-item boundary where one exists so unchanged sibling items can still align with the opposite side instead of being rendered as false additions or deletions.
+
+Split list blocks are a placement device, not new Markdown paragraph breaks. They render only the minimum number of `<ul>` or `<ol>` chunks needed to put review cards after their target items; untargeted consecutive items stay grouped in the same chunk. Split chunks must preserve numbering for ordered lists, keep nested lists inside the owning item, abandon splitting when rendered `<li>` counts do not match source markers, and use styling that removes synthetic wrapper margins. Untargeted lists, loose lists outside targeted regions, tables, and blockquotes remain whole top-level blocks.
+
 Wrapper elements around rendered blocks are acceptable only when they preserve the readable Markdown layout. They must not force one-off margin, table, list, or heading behavior that differs materially from the normal rich preview. Layout regressions for lists, headings, paragraphs, and tables should be covered by component or browser assertions when wrappers change.
 
 ## Performance
@@ -100,7 +104,8 @@ Markdown rich preview should avoid unbounded quadratic work. Block alignment may
 
 - Rich preview does not render arbitrary raw Markdown fragments independently.
 - Reference-style links defined inside the rendered hunk document still resolve.
-- List items can be emitted as separate rich-preview anchor blocks when needed to place review cards after the matching source item.
+- List items emit separate rich-preview anchor blocks only when explicit review target lines require item-level placement, and untargeted consecutive items stay grouped instead of splitting into artificial one-line lists.
+- Split list anchors do not introduce synthetic vertical margins or blank lines beyond the review card itself.
 - Separate lists and tables on opposite sides of a hidden hunk separator stay separate top-level blocks.
 - Review cards on repeated text blocks map by source line order.
 - Review cards on structured container children remain near the valid top-level container boundary and keep the exact line reference in the card header.
@@ -119,7 +124,9 @@ Markdown rich preview should avoid unbounded quadratic work. Block alignment may
 Add unit coverage for the rich-preview model:
 
 - reference-style links still resolve when review cards are anchored;
-- list items expose separate rich-preview anchor blocks when review cards target individual source items;
+- untargeted lists remain whole rendered lists;
+- list items expose separate rich-preview anchor blocks when split-line inputs target individual source items;
+- ordered-list numbering, nested lists, multiline items, and mismatched source/rendered item counts have focused coverage or an explicit fallback expectation;
 - multi-hunk fenced code, HTML blocks, blockquotes, lists, and tables do not expose synthetic separator lines and keep the expected top-level structure;
 - stripped spanning-token re-renders keep in-document reference definitions available through the approved parser-context API;
 - user-authored thematic breaks inside hunks still render;
@@ -131,10 +138,11 @@ Keep component coverage for:
 
 - unified rich preview renders review cards inside the preview after their target block;
 - split rich preview renders review cards near the matching side block;
+- added and deleted list-item review cards keep unchanged sibling items aligned rather than rendering them as false additions or deletions;
 - review threads targeting hidden hunk gaps remain file-level fallback cards;
 - source diff review annotations remain unchanged.
 
-Keep browser e2e coverage for the PR files page rich preview toggle, including review-card cases that prove cards are not at the top of the file, multiple cards render in source order, list-item cards attach after the matching rendered item, and hidden-gap review threads remain file-level fallback cards.
+Keep browser e2e coverage for the PR files page rich preview toggle, including review-card cases that prove cards are not at the top of the file, multiple cards render in source order, list-item cards attach after the matching rendered item, split-list anchors do not add synthetic list margins, and hidden-gap review threads remain file-level fallback cards.
 
 ## Implementation Staging
 

--- a/frontend/src/lib/components/settings/RepoSettings.test.ts
+++ b/frontend/src/lib/components/settings/RepoSettings.test.ts
@@ -408,6 +408,7 @@ describe("RepoSettings", () => {
         renderer: "xterm",
       },
       agents: [],
+      fleet: defaultFleetSettings(),
     });
     mockUpdateRepoWorktreeBasePath.mockResolvedValue({
       repos: promotedRepos,
@@ -431,6 +432,7 @@ describe("RepoSettings", () => {
         renderer: "xterm",
       },
       agents: [],
+      fleet: defaultFleetSettings(),
     });
 
     render(RepoSettings, {
@@ -603,6 +605,7 @@ describe("RepoSettings", () => {
         renderer: "xterm",
       },
       agents: [],
+      fleet: defaultFleetSettings(),
     });
     mockUpdateRepoWorktreeBasePath.mockRejectedValue(new Error("path does not exist"));
     mockRemoveRepo.mockResolvedValue();

--- a/frontend/src/lib/dev/healthcheckPlugin.test.ts
+++ b/frontend/src/lib/dev/healthcheckPlugin.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import type { AddressInfo } from "node:net";
+import { createServer as createNetServer, type AddressInfo } from "node:net";
 import { createServer, mergeConfig, type ViteDevServer } from "vite";
 import { afterEach, describe, expect, it } from "vite-plus/test";
 import config from "../../../vite.config";
@@ -16,6 +16,8 @@ describe("healthcheckPlugin", () => {
   });
 
   async function startServer() {
+    const port = await reserveLoopbackPort();
+
     server = await createServer({
       ...mergeConfig(config, {
         appType: "custom",
@@ -24,7 +26,7 @@ describe("healthcheckPlugin", () => {
         logLevel: "error",
         server: {
           host: "127.0.0.1",
-          port: 0,
+          port,
         },
       }),
     });
@@ -37,6 +39,37 @@ describe("healthcheckPlugin", () => {
     }
 
     return `http://127.0.0.1:${address.port}`;
+  }
+
+  async function reserveLoopbackPort(): Promise<number> {
+    const probe = createNetServer();
+    await new Promise<void>((resolve, reject) => {
+      probe.once("error", reject);
+      probe.listen(0, "127.0.0.1", () => {
+        probe.off("error", reject);
+        resolve();
+      });
+    });
+
+    const address = probe.address() as AddressInfo | null;
+    if (!address) {
+      await new Promise<void>((resolve) => probe.close(() => resolve()));
+      throw new Error("expected loopback port probe to listen on a TCP address");
+    }
+
+    const port = address.port;
+    await new Promise<void>((resolve, reject) => {
+      probe.once("error", reject);
+      probe.close((error) => {
+        probe.off("error", reject);
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+    return port;
   }
 
   it.each(["/healthz", "/livez"])("serves %s", async (path) => {

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -570,18 +570,19 @@ const listReviewPreviewDiff: DiffResult = withServerDiffData({
       status: "modified",
       is_binary: false,
       is_whitespace_only: false,
-      additions: 3,
+      additions: 4,
       deletions: 0,
       hunks: [
         {
           old_start: 1,
           old_count: 0,
           new_start: 1,
-          new_count: 3,
+          new_count: 4,
           lines: [
             { type: "add", content: "- Issues", new_num: 1 },
             { type: "add", content: "- Actions", new_num: 2 },
             { type: "add", content: "- Statuses", new_num: 3 },
+            { type: "add", content: "- Members", new_num: 4 },
           ],
         },
       ],
@@ -614,6 +615,36 @@ const untargetedListReviewPreviewDiff: DiffResult = withServerDiffData({
             { type: "context", content: "- Statuses", old_num: 3, new_num: 3 },
             { type: "context", content: "", old_num: 4, new_num: 4 },
             { type: "add", content: "Paragraph with review note.", new_num: 5 },
+          ],
+        },
+      ],
+    },
+    ...smallDiff.files,
+  ],
+});
+
+const changedListReviewPreviewDiff: DiffResult = withServerDiffData({
+  stale: false,
+  whitespace_only_count: 0,
+  files: [
+    {
+      path: "docs/changed-list-review.md",
+      old_path: "docs/changed-list-review.md",
+      status: "modified",
+      is_binary: false,
+      is_whitespace_only: false,
+      additions: 1,
+      deletions: 0,
+      hunks: [
+        {
+          old_start: 1,
+          old_count: 2,
+          new_start: 1,
+          new_count: 3,
+          lines: [
+            { type: "context", content: "- Issues", old_num: 1, new_num: 1 },
+            { type: "add", content: "- Actions", new_num: 2 },
+            { type: "context", content: "- Statuses", old_num: 2, new_num: 3 },
           ],
         },
       ],
@@ -2172,6 +2203,43 @@ test.describe("diff view", () => {
 
     const markdownFile = page.locator('[data-file-path="docs/list-review.md"]');
     await expect(markdownFile.locator(".markdown-rich-diff--unified")).toBeVisible();
+    await expect(markdownFile.locator(".markdown-rich-diff__split-list")).toHaveCount(3);
+    await expect
+      .poll(() =>
+        markdownFile.locator(".markdown-rich-diff__split-list").evaluateAll((lists) =>
+          lists.every((list) => {
+            const style = getComputedStyle(list);
+            return style.marginTop === "0px" && style.marginBottom === "0px";
+          }),
+        ),
+      )
+      .toBe(true);
+    await expect
+      .poll(() =>
+        markdownFile
+          .locator(".markdown-diff__block")
+          .evaluateAll(
+            (blocks) => blocks.filter((block) => block.querySelector(".markdown-rich-diff__split-list")).length,
+          ),
+      )
+      .toBeGreaterThan(0);
+    await expect
+      .poll(() =>
+        markdownFile.locator(".markdown-diff__block").evaluateAll((blocks) =>
+          blocks
+            .filter((block) => block.querySelector(".markdown-rich-diff__split-list"))
+            .every((block) => {
+              const style = getComputedStyle(block);
+              return (
+                style.marginTop === "0px" &&
+                style.marginBottom === "0px" &&
+                style.paddingTop === "0px" &&
+                style.paddingBottom === "0px"
+              );
+            }),
+        ),
+      )
+      .toBe(true);
     await expect
       .poll(() => markdownFile.locator(".markdown-rich-diff--unified .review-thread-body").allTextContents())
       .toEqual(["Issues review note", "Actions review note"]);
@@ -2188,6 +2256,12 @@ test.describe("diff view", () => {
     await expect
       .poll(() => actionsCard.evaluate((element) => element.previousElementSibling?.textContent?.trim() ?? ""))
       .toContain("Actions");
+    await expect
+      .poll(() => markdownFile.locator(".markdown-rich-diff__split-list").last().textContent())
+      .toContain("Statuses");
+    await expect
+      .poll(() => markdownFile.locator(".markdown-rich-diff__split-list").last().textContent())
+      .toContain("Members");
   });
 
   test("rich preview keeps untargeted lists intact when a later block has a review card", async ({ page }) => {
@@ -2213,6 +2287,30 @@ test.describe("diff view", () => {
     await expect
       .poll(() => reviewCard.evaluate((element) => element.previousElementSibling?.textContent?.trim() ?? ""))
       .toContain("Paragraph with review note.");
+  });
+
+  test("rich preview keeps unchanged list siblings aligned around an added item review card", async ({ page }) => {
+    const reviewBody = "Added list item review note";
+    await mockDiffApi(page, changedListReviewPreviewDiff);
+    await mockReviewThreadOnPreviewMarkdown(page, reviewBody, 2, "docs/changed-list-review.md");
+    await navigateToDiff(page);
+    await waitForDiffLoaded(page);
+    await waitForSidebarFilesLoaded(page);
+
+    await openDiffFilterMenu(page);
+    await page.getByRole("switch", { name: "Rich preview" }).click();
+
+    const markdownPreview = page.locator('[data-file-path="docs/changed-list-review.md"] .markdown-rich-diff--unified');
+    await expect(markdownPreview).toBeVisible();
+    await expect(markdownPreview.locator("ins", { hasText: "Actions" })).toBeVisible();
+    await expect(markdownPreview.locator("ins", { hasText: "Issues" })).toHaveCount(0);
+    await expect(markdownPreview.locator("del", { hasText: "Statuses" })).toHaveCount(0);
+
+    const reviewCard = markdownPreview.locator(".inline-review-thread").filter({ hasText: reviewBody });
+    await expect(reviewCard).toBeVisible();
+    await expect
+      .poll(() => reviewCard.evaluate((element) => element.previousElementSibling?.textContent?.trim() ?? ""))
+      .toContain("Actions");
   });
 
   test("rich preview keeps unmapped review thread cards visible as file-level fallback", async ({ page }) => {

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -1173,64 +1173,6 @@ async function mockFilePreviewApi(page: Page): Promise<void> {
   });
 }
 
-type MergeRequestDetailForRoute = {
-  diff_head_sha?: string;
-  events?: unknown[] | null;
-  merge_request?: {
-    ID?: number;
-  };
-};
-
-async function mockReviewThreadOnPreviewMarkdown(page: Page, body: string): Promise<void> {
-  await page.route("**/api/v1/pulls/github/acme/widgets/1", async (route) => {
-    const response = await route.fetch();
-    const detail = (await response.json()) as MergeRequestDetailForRoute;
-    const timestamp = "2026-06-17T15:00:00Z";
-    await route.fulfill({
-      response,
-      json: {
-        ...detail,
-        events: [
-          ...(detail.events ?? []),
-          {
-            Author: "reviewer",
-            Body: body,
-            CreatedAt: timestamp,
-            DedupeKey: "review_comment:e2e-rich-preview",
-            DirectURL: "",
-            EventType: "review_comment",
-            ID: 900_001,
-            MergeRequestID: detail.merge_request?.ID ?? 1,
-            MetadataJSON: "{}",
-            PlatformExternalID: "e2e-rich-preview",
-            PlatformID: 900_001,
-            Resolvable: false,
-            Resolved: false,
-            Summary: body,
-            ThreadID: "thread-rich-preview",
-            diff_thread: {
-              author_login: "reviewer",
-              body,
-              can_resolve: false,
-              created_at: timestamp,
-              diff_head_sha: detail.diff_head_sha,
-              id: "thread-rich-preview",
-              line: 99,
-              line_type: "add",
-              new_line: 99,
-              path: "docs/preview.md",
-              provider_comment_id: "e2e-rich-preview",
-              resolved: false,
-              side: "right",
-              updated_at: timestamp,
-            },
-          },
-        ],
-      },
-    });
-  });
-}
-
 async function mockDiffApiError(page: Page, status: number, detail: string): Promise<void> {
   await page.route("**/api/v1/pulls/github/acme/widgets/1/files", async (route) => {
     await route.fulfill({
@@ -1924,28 +1866,6 @@ test.describe("diff view", () => {
 
     await clickTreeFileItem(page, "assets/logo.png");
     await expect(page.locator(".diff-image-preview img[alt='assets/logo.png']")).toBeVisible();
-  });
-
-  test("rich preview hides review thread cards until source diff mode", async ({ page }) => {
-    const reviewBody = "Review note should stay out of rich preview";
-    await mockDiffApi(page, previewDiff);
-    await mockReviewThreadOnPreviewMarkdown(page, reviewBody);
-    await navigateToDiff(page);
-    await waitForDiffLoaded(page);
-    await waitForSidebarFilesLoaded(page);
-
-    await openDiffFilterMenu(page);
-    const previewToggle = page.getByRole("switch", {
-      name: "Rich preview",
-    });
-
-    await previewToggle.click();
-    const markdownFile = page.locator('[data-file-path="docs/preview.md"]');
-    await expect(markdownFile.locator(".markdown-rich-diff--unified")).toBeVisible();
-    await expect(markdownFile.getByText(reviewBody)).toHaveCount(0);
-
-    await previewToggle.click();
-    await expect(markdownFile.locator(".inline-review-thread").filter({ hasText: reviewBody }).first()).toBeVisible();
   });
 
   test("rich preview refetches blob content after a same-PR diff reload", async ({ page }) => {

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -673,7 +673,7 @@ const edgeListReviewPreviewDiff: DiffResult = withServerDiffData({
           new_count: 5,
           lines: [
             { type: "add", content: "- Prepended", new_num: 1 },
-            { type: "add", content: "  prepended details", new_num: 2 },
+            { type: "add", content: "prepended details", new_num: 2 },
             { type: "context", content: "- Issues", old_num: 1, new_num: 3 },
             { type: "context", content: "- Statuses", old_num: 2, new_num: 4 },
             { type: "add", content: "- Appended", new_num: 5 },
@@ -697,7 +697,7 @@ const edgeListReviewPreviewDiff: DiffResult = withServerDiffData({
           new_count: 2,
           lines: [
             { type: "delete", content: "- Removed first", old_num: 1 },
-            { type: "delete", content: "  removed first details", old_num: 2 },
+            { type: "delete", content: "removed first details", old_num: 2 },
             { type: "context", content: "- Issues", old_num: 3, new_num: 1 },
             { type: "context", content: "- Statuses", old_num: 4, new_num: 2 },
             { type: "delete", content: "- Removed last", old_num: 5 },
@@ -787,6 +787,12 @@ const blockFillMarkdownDiff: DiffResult = withServerDiffData({
       ],
     },
   ],
+});
+
+const splitRichPreviewDiff: DiffResult = withServerDiffData({
+  stale: false,
+  whitespace_only_count: 0,
+  files: [previewDiff.files[0]!, blockFillMarkdownDiff.files[0]!, ...smallDiff.files],
 });
 
 // --- Helpers ---
@@ -2193,7 +2199,8 @@ test.describe("diff view", () => {
   });
 
   test("rich preview side-by-side panes do not underline changed text", async ({ page }) => {
-    await mockDiffApi(page, previewDiff);
+    await page.setViewportSize({ width: 2200, height: 1000 });
+    await mockDiffApi(page, splitRichPreviewDiff);
     await navigateToDiff(page);
     await waitForDiffLoaded(page);
 
@@ -2219,6 +2226,21 @@ test.describe("diff view", () => {
     await expect
       .poll(() => afterChange.evaluate((element) => getComputedStyle(element).textDecorationLine))
       .toBe("none");
+    const blockFillPreview = page.locator('[data-file-path="docs/block-fill.md"] .markdown-rich-diff--split');
+    await expect(blockFillPreview).toBeVisible();
+    const deletedBlock = blockFillPreview
+      .locator('[aria-label="Before markdown preview"] del.markdown-diff__block')
+      .filter({ hasText: "Removed standalone block" })
+      .first();
+    await expect(deletedBlock).toBeVisible();
+    await expect
+      .poll(() =>
+        deletedBlock.evaluate((element) => {
+          const textElement = element.querySelector("*") ?? element;
+          return getComputedStyle(textElement).textDecorationLine;
+        }),
+      )
+      .toBe("none");
     const inlineBeforeChange = markdownPreview
       .locator('[aria-label="Before markdown preview"] strong del')
       .filter({ hasText: "beta" })
@@ -2235,6 +2257,9 @@ test.describe("diff view", () => {
     await expect
       .poll(() => inlineAfterChange.evaluate((element) => getComputedStyle(element).backgroundColor))
       .not.toBe("rgba(0, 0, 0, 0)");
+    await expect
+      .poll(() => markdownPreview.evaluate((element) => element.getBoundingClientRect().width))
+      .toBeGreaterThan(1300);
   });
 
   test("rich preview gives standalone block additions and deletions visible fills", async ({ page }) => {

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -1178,11 +1178,13 @@ async function mockFilePreviewApi(page: Page): Promise<void> {
   });
 }
 
-async function mockReviewThreadOnPreviewMarkdown(page: Page, body: string): Promise<void> {
+async function mockReviewThreadOnPreviewMarkdown(page: Page, body: string, line = 3): Promise<void> {
   await page.route("**/api/v1/pulls/github/acme/widgets/1", async (route) => {
     const response = await route.fetch();
     const detail = (await response.json()) as MergeRequestDetailForRoute;
     const timestamp = "2026-06-17T15:00:00Z";
+    const externalID = `e2e-rich-preview-${line}`;
+    const threadID = `thread-rich-preview-${line}`;
 
     await route.fulfill({
       response,
@@ -1194,30 +1196,30 @@ async function mockReviewThreadOnPreviewMarkdown(page: Page, body: string): Prom
             Author: "reviewer",
             Body: body,
             CreatedAt: timestamp,
-            DedupeKey: "review_comment:e2e-rich-preview",
+            DedupeKey: `review_comment:${externalID}`,
             DirectURL: "",
             EventType: "review_comment",
             ID: 900_001,
             MergeRequestID: detail.merge_request?.ID ?? 1,
             MetadataJSON: "{}",
-            PlatformExternalID: "e2e-rich-preview",
+            PlatformExternalID: externalID,
             PlatformID: 900_001,
             Resolvable: false,
             Resolved: false,
             Summary: body,
-            ThreadID: "thread-rich-preview",
+            ThreadID: threadID,
             diff_thread: {
               author_login: "reviewer",
               body,
               can_resolve: false,
               created_at: timestamp,
               diff_head_sha: detail.diff_head_sha,
-              id: "thread-rich-preview",
-              line: 3,
+              id: threadID,
+              line,
               line_type: "add",
-              new_line: 3,
+              new_line: line,
               path: "docs/preview.md",
-              provider_comment_id: "e2e-rich-preview",
+              provider_comment_id: externalID,
               resolved: false,
               side: "right",
               updated_at: timestamp,
@@ -1950,6 +1952,31 @@ test.describe("diff view", () => {
         ),
       )
       .toBe(true);
+  });
+
+  test("rich preview keeps unmapped review thread cards visible as file-level fallback", async ({ page }) => {
+    const reviewBody = "Unmapped rich preview note should stay visible";
+    await mockDiffApi(page, previewDiff);
+    await mockFilePreviewApi(page);
+    await mockReviewThreadOnPreviewMarkdown(page, reviewBody, 99);
+    await navigateToDiff(page);
+    await waitForDiffLoaded(page);
+    await waitForSidebarFilesLoaded(page);
+
+    await openDiffFilterMenu(page);
+    await page.getByRole("switch", { name: "Rich preview" }).click();
+
+    const markdownFile = page.locator('[data-file-path="docs/preview.md"]');
+    await expect(markdownFile.locator(".markdown-rich-diff--unified")).toBeVisible();
+    const fallbackCard = markdownFile.locator(".preview-shell > .inline-review-thread").filter({
+      hasText: reviewBody,
+    });
+    await expect(fallbackCard).toBeVisible();
+    await expect(fallbackCard).toHaveClass(/inline-review-thread--file-level/);
+    await expect(fallbackCard).toContainText("File");
+    await expect(
+      markdownFile.locator(".markdown-rich-diff--unified .inline-review-thread").filter({ hasText: reviewBody }),
+    ).toHaveCount(0);
   });
 
   test("rich preview refetches blob content after a same-PR diff reload", async ({ page }) => {

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -590,6 +590,38 @@ const listReviewPreviewDiff: DiffResult = withServerDiffData({
   ],
 });
 
+const untargetedListReviewPreviewDiff: DiffResult = withServerDiffData({
+  stale: false,
+  whitespace_only_count: 0,
+  files: [
+    {
+      path: "docs/untargeted-list-review.md",
+      old_path: "docs/untargeted-list-review.md",
+      status: "modified",
+      is_binary: false,
+      is_whitespace_only: false,
+      additions: 1,
+      deletions: 0,
+      hunks: [
+        {
+          old_start: 1,
+          old_count: 4,
+          new_start: 1,
+          new_count: 5,
+          lines: [
+            { type: "context", content: "- Issues", old_num: 1, new_num: 1 },
+            { type: "context", content: "- Actions", old_num: 2, new_num: 2 },
+            { type: "context", content: "- Statuses", old_num: 3, new_num: 3 },
+            { type: "context", content: "", old_num: 4, new_num: 4 },
+            { type: "add", content: "Paragraph with review note.", new_num: 5 },
+          ],
+        },
+      ],
+    },
+    ...smallDiff.files,
+  ],
+});
+
 const multiHunkMarkdownDiff: DiffResult = withServerDiffData({
   stale: false,
   whitespace_only_count: 0,
@@ -2156,6 +2188,31 @@ test.describe("diff view", () => {
     await expect
       .poll(() => actionsCard.evaluate((element) => element.previousElementSibling?.textContent?.trim() ?? ""))
       .toContain("Actions");
+  });
+
+  test("rich preview keeps untargeted lists intact when a later block has a review card", async ({ page }) => {
+    const reviewBody = "Paragraph review note";
+    await mockDiffApi(page, untargetedListReviewPreviewDiff);
+    await mockReviewThreadOnPreviewMarkdown(page, reviewBody, 5, "docs/untargeted-list-review.md");
+    await navigateToDiff(page);
+    await waitForDiffLoaded(page);
+    await waitForSidebarFilesLoaded(page);
+
+    await openDiffFilterMenu(page);
+    await page.getByRole("switch", { name: "Rich preview" }).click();
+
+    const markdownPreview = page.locator(
+      '[data-file-path="docs/untargeted-list-review.md"] .markdown-rich-diff--unified',
+    );
+    await expect(markdownPreview).toBeVisible();
+    await expect(markdownPreview.locator("ul")).toHaveCount(1);
+    await expect(markdownPreview.locator("ul.markdown-rich-diff__split-list")).toHaveCount(0);
+
+    const reviewCard = markdownPreview.locator(".inline-review-thread").filter({ hasText: reviewBody });
+    await expect(reviewCard).toBeVisible();
+    await expect
+      .poll(() => reviewCard.evaluate((element) => element.previousElementSibling?.textContent?.trim() ?? ""))
+      .toContain("Paragraph with review note.");
   });
 
   test("rich preview keeps unmapped review thread cards visible as file-level fallback", async ({ page }) => {

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -653,6 +653,60 @@ const changedListReviewPreviewDiff: DiffResult = withServerDiffData({
   ],
 });
 
+const edgeListReviewPreviewDiff: DiffResult = withServerDiffData({
+  stale: false,
+  whitespace_only_count: 0,
+  files: [
+    {
+      path: "docs/edge-added-list-review.md",
+      old_path: "docs/edge-added-list-review.md",
+      status: "modified",
+      is_binary: false,
+      is_whitespace_only: false,
+      additions: 2,
+      deletions: 0,
+      hunks: [
+        {
+          old_start: 1,
+          old_count: 2,
+          new_start: 1,
+          new_count: 4,
+          lines: [
+            { type: "add", content: "- Prepended", new_num: 1 },
+            { type: "context", content: "- Issues", old_num: 1, new_num: 2 },
+            { type: "context", content: "- Statuses", old_num: 2, new_num: 3 },
+            { type: "add", content: "- Appended", new_num: 4 },
+          ],
+        },
+      ],
+    },
+    {
+      path: "docs/edge-deleted-list-review.md",
+      old_path: "docs/edge-deleted-list-review.md",
+      status: "modified",
+      is_binary: false,
+      is_whitespace_only: false,
+      additions: 0,
+      deletions: 2,
+      hunks: [
+        {
+          old_start: 1,
+          old_count: 4,
+          new_start: 1,
+          new_count: 2,
+          lines: [
+            { type: "delete", content: "- Removed first", old_num: 1 },
+            { type: "context", content: "- Issues", old_num: 2, new_num: 1 },
+            { type: "context", content: "- Statuses", old_num: 3, new_num: 2 },
+            { type: "delete", content: "- Removed last", old_num: 4 },
+          ],
+        },
+      ],
+    },
+    ...smallDiff.files,
+  ],
+});
+
 const multiHunkMarkdownDiff: DiffResult = withServerDiffData({
   stale: false,
   whitespace_only_count: 0,
@@ -1372,7 +1426,11 @@ async function mockReviewThreadOnPreviewMarkdown(
 interface PreviewMarkdownReviewThread {
   body: string;
   line?: number;
+  lineType?: "add" | "delete";
+  newLine?: number;
+  oldLine?: number;
   path?: string;
+  side?: "left" | "right";
 }
 
 async function mockReviewThreadsOnPreviewMarkdown(page: Page, threads: PreviewMarkdownReviewThread[]): Promise<void> {
@@ -1390,8 +1448,12 @@ async function mockReviewThreadsOnPreviewMarkdown(page: Page, threads: PreviewMa
           ...threads.map((thread, index) => {
             const line = thread.line ?? 3;
             const path = thread.path ?? "docs/preview.md";
-            const externalID = `e2e-rich-preview-${path}-${line}-${index}`;
-            const threadID = `thread-rich-preview-${path}-${line}-${index}`;
+            const side = thread.side ?? "right";
+            const lineType = thread.lineType ?? (side === "left" ? "delete" : "add");
+            const newLine = thread.newLine ?? (side === "right" ? line : undefined);
+            const oldLine = thread.oldLine ?? (side === "left" ? line : undefined);
+            const externalID = `e2e-rich-preview-${path}-${side}-${line}-${index}`;
+            const threadID = `thread-rich-preview-${path}-${side}-${line}-${index}`;
             return {
               Author: "reviewer",
               Body: thread.body,
@@ -1416,12 +1478,13 @@ async function mockReviewThreadsOnPreviewMarkdown(page: Page, threads: PreviewMa
                 diff_head_sha: detail.diff_head_sha,
                 id: threadID,
                 line,
-                line_type: "add",
-                new_line: line,
+                line_type: lineType,
+                new_line: newLine,
+                old_line: oldLine,
                 path,
                 provider_comment_id: externalID,
                 resolved: false,
-                side: "right",
+                side,
                 updated_at: timestamp,
               },
             };
@@ -2127,6 +2190,35 @@ test.describe("diff view", () => {
     await expect(page.locator(".diff-image-preview img[alt='assets/logo.png']")).toBeVisible();
   });
 
+  test("rich preview side-by-side panes do not underline changed text", async ({ page }) => {
+    await mockDiffApi(page, previewDiff);
+    await navigateToDiff(page);
+    await waitForDiffLoaded(page);
+
+    await openDiffFilterMenu(page);
+    await page.getByRole("switch", { name: "Rich preview" }).click();
+    await page.getByRole("switch", { name: "Side-by-side diffs" }).click();
+
+    const markdownPreview = page.locator('[data-file-path="docs/preview.md"] .markdown-rich-diff--split');
+    await expect(markdownPreview).toBeVisible();
+    const beforeChange = markdownPreview
+      .locator('[aria-label="Before markdown preview"] del')
+      .filter({ hasText: "Old" })
+      .first();
+    const afterChange = markdownPreview
+      .locator('[aria-label="After markdown preview"] ins')
+      .filter({ hasText: "New" })
+      .first();
+    await expect(beforeChange).toBeVisible();
+    await expect(afterChange).toBeVisible();
+    await expect
+      .poll(() => beforeChange.evaluate((element) => getComputedStyle(element).textDecorationLine))
+      .toBe("none");
+    await expect
+      .poll(() => afterChange.evaluate((element) => getComputedStyle(element).textDecorationLine))
+      .toBe("none");
+  });
+
   test("rich preview gives standalone block additions and deletions visible fills", async ({ page }) => {
     await mockDiffApi(page, blockFillMarkdownDiff);
     await navigateToDiff(page);
@@ -2311,6 +2403,68 @@ test.describe("diff view", () => {
     await expect
       .poll(() => reviewCard.evaluate((element) => element.previousElementSibling?.textContent?.trim() ?? ""))
       .toContain("Actions");
+  });
+
+  test("rich preview keeps unchanged list siblings aligned for edge added and deleted item comments", async ({
+    page,
+  }) => {
+    await mockDiffApi(page, edgeListReviewPreviewDiff);
+    await mockReviewThreadsOnPreviewMarkdown(page, [
+      {
+        body: "Prepended item review note",
+        line: 1,
+        path: "docs/edge-added-list-review.md",
+      },
+      {
+        body: "Appended item review note",
+        line: 4,
+        path: "docs/edge-added-list-review.md",
+      },
+      {
+        body: "Deleted first item review note",
+        line: 1,
+        oldLine: 1,
+        path: "docs/edge-deleted-list-review.md",
+        side: "left",
+      },
+      {
+        body: "Deleted last item review note",
+        line: 4,
+        oldLine: 4,
+        path: "docs/edge-deleted-list-review.md",
+        side: "left",
+      },
+    ]);
+    await navigateToDiff(page);
+    await waitForDiffLoaded(page);
+    await waitForSidebarFilesLoaded(page);
+
+    await openDiffFilterMenu(page);
+    await page.getByRole("switch", { name: "Rich preview" }).click();
+
+    const addedPreview = page.locator('[data-file-path="docs/edge-added-list-review.md"] .markdown-rich-diff--unified');
+    await expect(addedPreview).toBeVisible();
+    await expect(addedPreview.locator("ins", { hasText: "Prepended" })).toBeVisible();
+    await expect(addedPreview.locator("ins", { hasText: "Appended" })).toBeVisible();
+    await expect(addedPreview.locator("ins", { hasText: "Issues" })).toHaveCount(0);
+    await expect(addedPreview.locator("ins", { hasText: "Statuses" })).toHaveCount(0);
+    await expect(addedPreview.locator("del", { hasText: "Issues" })).toHaveCount(0);
+    await expect(addedPreview.locator("del", { hasText: "Statuses" })).toHaveCount(0);
+    await expect(addedPreview.locator(".inline-review-thread").filter({ hasText: "Prepended item" })).toBeVisible();
+    await expect(addedPreview.locator(".inline-review-thread").filter({ hasText: "Appended item" })).toBeVisible();
+
+    const deletedPreview = page.locator(
+      '[data-file-path="docs/edge-deleted-list-review.md"] .markdown-rich-diff--unified',
+    );
+    await expect(deletedPreview).toBeVisible();
+    await expect(deletedPreview.locator("del", { hasText: "Removed first" })).toBeVisible();
+    await expect(deletedPreview.locator("del", { hasText: "Removed last" })).toBeVisible();
+    await expect(deletedPreview.locator("del", { hasText: "Issues" })).toHaveCount(0);
+    await expect(deletedPreview.locator("del", { hasText: "Statuses" })).toHaveCount(0);
+    await expect(deletedPreview.locator("ins", { hasText: "Issues" })).toHaveCount(0);
+    await expect(deletedPreview.locator("ins", { hasText: "Statuses" })).toHaveCount(0);
+    await expect(deletedPreview.locator(".inline-review-thread").filter({ hasText: "Deleted first" })).toBeVisible();
+    await expect(deletedPreview.locator(".inline-review-thread").filter({ hasText: "Deleted last" })).toBeVisible();
   });
 
   test("rich preview keeps unmapped review thread cards visible as file-level fallback", async ({ page }) => {

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -599,10 +599,60 @@ const multiHunkMarkdownDiff: DiffResult = withServerDiffData({
   ],
 });
 
+const blockFillMarkdownDiff: DiffResult = withServerDiffData({
+  stale: false,
+  whitespace_only_count: 0,
+  files: [
+    {
+      path: "docs/block-fill.md",
+      old_path: "docs/block-fill.md",
+      status: "modified",
+      is_binary: false,
+      is_whitespace_only: false,
+      additions: 1,
+      deletions: 1,
+      hunks: [
+        {
+          old_start: 1,
+          old_count: 6,
+          new_start: 1,
+          new_count: 6,
+          lines: [
+            { type: "context", content: "# Block fills", old_num: 1, new_num: 1 },
+            { type: "context", content: "", old_num: 2, new_num: 2 },
+            {
+              type: "delete",
+              content: "Removed standalone block that should have a filled background.",
+              old_num: 3,
+            },
+            { type: "context", content: "", old_num: 4, new_num: 3 },
+            { type: "context", content: "Shared stable block", old_num: 5, new_num: 4 },
+            { type: "context", content: "", old_num: 6, new_num: 5 },
+            {
+              type: "add",
+              content: "Added standalone block that should have a filled background.",
+              new_num: 6,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+});
+
 // --- Helpers ---
 
 function cssString(value: string): string {
   return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+async function expectNonTransparentBackground(locator: Locator) {
+  await expect
+    .poll(async () => {
+      const background = await locator.evaluate((element) => getComputedStyle(element).backgroundColor);
+      return background !== "rgba(0, 0, 0, 0)" && background !== "transparent";
+    })
+    .toBe(true);
 }
 
 function treeFileItems(pageOrLocator: Page | ReturnType<Page["locator"]>) {
@@ -1963,6 +2013,28 @@ test.describe("diff view", () => {
 
     await clickTreeFileItem(page, "assets/logo.png");
     await expect(page.locator(".diff-image-preview img[alt='assets/logo.png']")).toBeVisible();
+  });
+
+  test("rich preview gives standalone block additions and deletions visible fills", async ({ page }) => {
+    await mockDiffApi(page, blockFillMarkdownDiff);
+    await navigateToDiff(page);
+    await waitForDiffLoaded(page);
+
+    await openDiffFilterMenu(page);
+    await page.getByRole("switch", { name: "Rich preview" }).click();
+
+    const markdownPreview = page.locator('[data-file-path="docs/block-fill.md"] .markdown-rich-diff--unified');
+    await expect(markdownPreview).toBeVisible();
+    await expectNonTransparentBackground(
+      markdownPreview.locator("del.markdown-diff__block").filter({
+        hasText: "Removed standalone block that should have a filled background.",
+      }),
+    );
+    await expectNonTransparentBackground(
+      markdownPreview.locator("ins.markdown-diff__block").filter({
+        hasText: "Added standalone block that should have a filled background.",
+      }),
+    );
   });
 
   test("rich preview shows review thread cards", async ({ page }) => {

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -560,6 +560,45 @@ const previewDiff: DiffResult = withServerDiffData({
   ],
 });
 
+const multiHunkMarkdownDiff: DiffResult = withServerDiffData({
+  stale: false,
+  whitespace_only_count: 0,
+  files: [
+    {
+      path: "docs/multihunk.md",
+      old_path: "docs/multihunk.md",
+      status: "modified",
+      is_binary: false,
+      is_whitespace_only: false,
+      additions: 1,
+      deletions: 0,
+      hunks: [
+        {
+          old_start: 1,
+          old_count: 2,
+          new_start: 1,
+          new_count: 2,
+          lines: [
+            { type: "context", content: "```text", old_num: 1, new_num: 1 },
+            { type: "context", content: "first hunk code", old_num: 2, new_num: 2 },
+          ],
+        },
+        {
+          old_start: 10,
+          old_count: 2,
+          new_start: 10,
+          new_count: 3,
+          lines: [
+            { type: "context", content: "second hunk code", old_num: 10, new_num: 10 },
+            { type: "add", content: "added hunk code", new_num: 11 },
+            { type: "context", content: "```", old_num: 11, new_num: 12 },
+          ],
+        },
+      ],
+    },
+  ],
+});
+
 // --- Helpers ---
 
 function cssString(value: string): string {
@@ -1977,6 +2016,25 @@ test.describe("diff view", () => {
     await expect(
       markdownFile.locator(".markdown-rich-diff--unified .inline-review-thread").filter({ hasText: reviewBody }),
     ).toHaveCount(0);
+  });
+
+  test("rich preview hides synthetic hunk separators inside spanning markdown blocks", async ({ page }) => {
+    await mockDiffApi(page, multiHunkMarkdownDiff);
+    await navigateToDiff(page);
+    await waitForDiffLoaded(page);
+
+    await openDiffFilterMenu(page);
+    await page.getByRole("switch", { name: "Rich preview" }).click();
+
+    const markdownFile = page.locator('[data-file-path="docs/multihunk.md"]');
+    const markdownPreview = markdownFile.locator(".markdown-rich-diff--unified");
+    await expect(markdownPreview).toBeVisible();
+    const codeBlock = markdownPreview.locator("code").filter({ hasText: "first hunk code" });
+    await expect(codeBlock).toBeVisible();
+    await expect(codeBlock).toContainText("second hunk code");
+    await expect(codeBlock).toContainText("added hunk code");
+    await expect(codeBlock).not.toContainText("---");
+    await expect(markdownPreview.locator("hr")).toHaveCount(0);
   });
 
   test("rich preview refetches blob content after a same-PR diff reload", async ({ page }) => {

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -1938,7 +1938,9 @@ test.describe("diff view", () => {
 
     const markdownFile = page.locator('[data-file-path="docs/preview.md"]');
     await expect(markdownFile.locator(".markdown-rich-diff--unified")).toBeVisible();
-    await expect(markdownFile.locator(".inline-review-thread").filter({ hasText: reviewBody })).toBeVisible();
+    await expect(
+      markdownFile.locator(".markdown-rich-diff--unified .inline-review-thread").filter({ hasText: reviewBody }),
+    ).toBeVisible();
   });
 
   test("rich preview refetches blob content after a same-PR diff reload", async ({ page }) => {

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -1173,6 +1173,64 @@ async function mockFilePreviewApi(page: Page): Promise<void> {
   });
 }
 
+type MergeRequestDetailForRoute = {
+  diff_head_sha?: string;
+  events?: unknown[] | null;
+  merge_request?: {
+    ID?: number;
+  };
+};
+
+async function mockReviewThreadOnPreviewMarkdown(page: Page, body: string): Promise<void> {
+  await page.route("**/api/v1/pulls/github/acme/widgets/1", async (route) => {
+    const response = await route.fetch();
+    const detail = (await response.json()) as MergeRequestDetailForRoute;
+    const timestamp = "2026-06-17T15:00:00Z";
+    await route.fulfill({
+      response,
+      json: {
+        ...detail,
+        events: [
+          ...(detail.events ?? []),
+          {
+            Author: "reviewer",
+            Body: body,
+            CreatedAt: timestamp,
+            DedupeKey: "review_comment:e2e-rich-preview",
+            DirectURL: "",
+            EventType: "review_comment",
+            ID: 900_001,
+            MergeRequestID: detail.merge_request?.ID ?? 1,
+            MetadataJSON: "{}",
+            PlatformExternalID: "e2e-rich-preview",
+            PlatformID: 900_001,
+            Resolvable: false,
+            Resolved: false,
+            Summary: body,
+            ThreadID: "thread-rich-preview",
+            diff_thread: {
+              author_login: "reviewer",
+              body,
+              can_resolve: false,
+              created_at: timestamp,
+              diff_head_sha: detail.diff_head_sha,
+              id: "thread-rich-preview",
+              line: 99,
+              line_type: "add",
+              new_line: 99,
+              path: "docs/preview.md",
+              provider_comment_id: "e2e-rich-preview",
+              resolved: false,
+              side: "right",
+              updated_at: timestamp,
+            },
+          },
+        ],
+      },
+    });
+  });
+}
+
 async function mockDiffApiError(page: Page, status: number, detail: string): Promise<void> {
   await page.route("**/api/v1/pulls/github/acme/widgets/1/files", async (route) => {
     await route.fulfill({
@@ -1866,6 +1924,28 @@ test.describe("diff view", () => {
 
     await clickTreeFileItem(page, "assets/logo.png");
     await expect(page.locator(".diff-image-preview img[alt='assets/logo.png']")).toBeVisible();
+  });
+
+  test("rich preview hides review thread cards until source diff mode", async ({ page }) => {
+    const reviewBody = "Review note should stay out of rich preview";
+    await mockDiffApi(page, previewDiff);
+    await mockReviewThreadOnPreviewMarkdown(page, reviewBody);
+    await navigateToDiff(page);
+    await waitForDiffLoaded(page);
+    await waitForSidebarFilesLoaded(page);
+
+    await openDiffFilterMenu(page);
+    const previewToggle = page.getByRole("switch", {
+      name: "Rich preview",
+    });
+
+    await previewToggle.click();
+    const markdownFile = page.locator('[data-file-path="docs/preview.md"]');
+    await expect(markdownFile.locator(".markdown-rich-diff--unified")).toBeVisible();
+    await expect(markdownFile.getByText(reviewBody)).toHaveCount(0);
+
+    await previewToggle.click();
+    await expect(markdownFile.locator(".inline-review-thread").filter({ hasText: reviewBody }).first()).toBeVisible();
   });
 
   test("rich preview refetches blob content after a same-PR diff reload", async ({ page }) => {

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -2068,6 +2068,17 @@ test.describe("diff view", () => {
         ),
       )
       .toBe(true);
+    await expect
+      .poll(() =>
+        reviewCard.evaluate((element) => {
+          const preview = element.closest(".markdown-rich-diff--unified");
+          if (!preview) return false;
+          const cardRect = element.getBoundingClientRect();
+          const previewRect = preview.getBoundingClientRect();
+          return cardRect.right <= previewRect.right + 1;
+        }),
+      )
+      .toBe(true);
   });
 
   test("rich preview keeps unmapped review thread cards visible as file-level fallback", async ({ page }) => {

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -663,19 +663,20 @@ const edgeListReviewPreviewDiff: DiffResult = withServerDiffData({
       status: "modified",
       is_binary: false,
       is_whitespace_only: false,
-      additions: 2,
+      additions: 3,
       deletions: 0,
       hunks: [
         {
           old_start: 1,
           old_count: 2,
           new_start: 1,
-          new_count: 4,
+          new_count: 5,
           lines: [
             { type: "add", content: "- Prepended", new_num: 1 },
-            { type: "context", content: "- Issues", old_num: 1, new_num: 2 },
-            { type: "context", content: "- Statuses", old_num: 2, new_num: 3 },
-            { type: "add", content: "- Appended", new_num: 4 },
+            { type: "add", content: "  prepended details", new_num: 2 },
+            { type: "context", content: "- Issues", old_num: 1, new_num: 3 },
+            { type: "context", content: "- Statuses", old_num: 2, new_num: 4 },
+            { type: "add", content: "- Appended", new_num: 5 },
           ],
         },
       ],
@@ -687,18 +688,19 @@ const edgeListReviewPreviewDiff: DiffResult = withServerDiffData({
       is_binary: false,
       is_whitespace_only: false,
       additions: 0,
-      deletions: 2,
+      deletions: 3,
       hunks: [
         {
           old_start: 1,
-          old_count: 4,
+          old_count: 5,
           new_start: 1,
           new_count: 2,
           lines: [
             { type: "delete", content: "- Removed first", old_num: 1 },
-            { type: "context", content: "- Issues", old_num: 2, new_num: 1 },
-            { type: "context", content: "- Statuses", old_num: 3, new_num: 2 },
-            { type: "delete", content: "- Removed last", old_num: 4 },
+            { type: "delete", content: "  removed first details", old_num: 2 },
+            { type: "context", content: "- Issues", old_num: 3, new_num: 1 },
+            { type: "context", content: "- Statuses", old_num: 4, new_num: 2 },
+            { type: "delete", content: "- Removed last", old_num: 5 },
           ],
         },
       ],
@@ -2217,6 +2219,22 @@ test.describe("diff view", () => {
     await expect
       .poll(() => afterChange.evaluate((element) => getComputedStyle(element).textDecorationLine))
       .toBe("none");
+    const inlineBeforeChange = markdownPreview
+      .locator('[aria-label="Before markdown preview"] strong del')
+      .filter({ hasText: "beta" })
+      .first();
+    const inlineAfterChange = markdownPreview
+      .locator('[aria-label="After markdown preview"] strong ins')
+      .filter({ hasText: "two" })
+      .first();
+    await expect(inlineBeforeChange).toBeVisible();
+    await expect(inlineAfterChange).toBeVisible();
+    await expect
+      .poll(() => inlineBeforeChange.evaluate((element) => getComputedStyle(element).backgroundColor))
+      .not.toBe("rgba(0, 0, 0, 0)");
+    await expect
+      .poll(() => inlineAfterChange.evaluate((element) => getComputedStyle(element).backgroundColor))
+      .not.toBe("rgba(0, 0, 0, 0)");
   });
 
   test("rich preview gives standalone block additions and deletions visible fills", async ({ page }) => {
@@ -2417,7 +2435,7 @@ test.describe("diff view", () => {
       },
       {
         body: "Appended item review note",
-        line: 4,
+        line: 5,
         path: "docs/edge-added-list-review.md",
       },
       {
@@ -2429,8 +2447,8 @@ test.describe("diff view", () => {
       },
       {
         body: "Deleted last item review note",
-        line: 4,
-        oldLine: 4,
+        line: 5,
+        oldLine: 5,
         path: "docs/edge-deleted-list-review.md",
         side: "left",
       },

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -9,6 +9,11 @@ type DiffFixtureFile = Omit<DiffFile, "patch"> & {
 type DiffFixture = Omit<DiffResult, "files"> & {
   files: DiffFixtureFile[];
 };
+type MergeRequestDetailForRoute = {
+  diff_head_sha?: string;
+  events?: unknown[] | null;
+  merge_request?: { ID?: number };
+};
 
 const gitBackedDiffTestTimeoutMs = 120_000;
 
@@ -1173,6 +1178,57 @@ async function mockFilePreviewApi(page: Page): Promise<void> {
   });
 }
 
+async function mockReviewThreadOnPreviewMarkdown(page: Page, body: string): Promise<void> {
+  await page.route("**/api/v1/pulls/github/acme/widgets/1", async (route) => {
+    const response = await route.fetch();
+    const detail = (await response.json()) as MergeRequestDetailForRoute;
+    const timestamp = "2026-06-17T15:00:00Z";
+
+    await route.fulfill({
+      response,
+      json: {
+        ...detail,
+        events: [
+          ...(detail.events ?? []),
+          {
+            Author: "reviewer",
+            Body: body,
+            CreatedAt: timestamp,
+            DedupeKey: "review_comment:e2e-rich-preview",
+            DirectURL: "",
+            EventType: "review_comment",
+            ID: 900_001,
+            MergeRequestID: detail.merge_request?.ID ?? 1,
+            MetadataJSON: "{}",
+            PlatformExternalID: "e2e-rich-preview",
+            PlatformID: 900_001,
+            Resolvable: false,
+            Resolved: false,
+            Summary: body,
+            ThreadID: "thread-rich-preview",
+            diff_thread: {
+              author_login: "reviewer",
+              body,
+              can_resolve: false,
+              created_at: timestamp,
+              diff_head_sha: detail.diff_head_sha,
+              id: "thread-rich-preview",
+              line: 3,
+              line_type: "add",
+              new_line: 3,
+              path: "docs/preview.md",
+              provider_comment_id: "e2e-rich-preview",
+              resolved: false,
+              side: "right",
+              updated_at: timestamp,
+            },
+          },
+        ],
+      },
+    });
+  });
+}
+
 async function mockDiffApiError(page: Page, status: number, detail: string): Promise<void> {
   await page.route("**/api/v1/pulls/github/acme/widgets/1/files", async (route) => {
     await route.fulfill({
@@ -1866,6 +1922,23 @@ test.describe("diff view", () => {
 
     await clickTreeFileItem(page, "assets/logo.png");
     await expect(page.locator(".diff-image-preview img[alt='assets/logo.png']")).toBeVisible();
+  });
+
+  test("rich preview shows review thread cards", async ({ page }) => {
+    const reviewBody = "Review note should show in rich preview";
+    await mockDiffApi(page, previewDiff);
+    await mockFilePreviewApi(page);
+    await mockReviewThreadOnPreviewMarkdown(page, reviewBody);
+    await navigateToDiff(page);
+    await waitForDiffLoaded(page);
+    await waitForSidebarFilesLoaded(page);
+
+    await openDiffFilterMenu(page);
+    await page.getByRole("switch", { name: "Rich preview" }).click();
+
+    const markdownFile = page.locator('[data-file-path="docs/preview.md"]');
+    await expect(markdownFile.locator(".markdown-rich-diff--unified")).toBeVisible();
+    await expect(markdownFile.locator(".inline-review-thread").filter({ hasText: reviewBody })).toBeVisible();
   });
 
   test("rich preview refetches blob content after a same-PR diff reload", async ({ page }) => {

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -560,6 +560,36 @@ const previewDiff: DiffResult = withServerDiffData({
   ],
 });
 
+const listReviewPreviewDiff: DiffResult = withServerDiffData({
+  stale: false,
+  whitespace_only_count: 0,
+  files: [
+    {
+      path: "docs/list-review.md",
+      old_path: "docs/list-review.md",
+      status: "modified",
+      is_binary: false,
+      is_whitespace_only: false,
+      additions: 3,
+      deletions: 0,
+      hunks: [
+        {
+          old_start: 1,
+          old_count: 0,
+          new_start: 1,
+          new_count: 3,
+          lines: [
+            { type: "add", content: "- Issues", new_num: 1 },
+            { type: "add", content: "- Actions", new_num: 2 },
+            { type: "add", content: "- Statuses", new_num: 3 },
+          ],
+        },
+      ],
+    },
+    ...smallDiff.files,
+  ],
+});
+
 const multiHunkMarkdownDiff: DiffResult = withServerDiffData({
   stale: false,
   whitespace_only_count: 0,
@@ -1273,12 +1303,20 @@ async function mockReviewThreadOnPreviewMarkdown(
   line = 3,
   path = "docs/preview.md",
 ): Promise<void> {
+  await mockReviewThreadsOnPreviewMarkdown(page, [{ body, line, path }]);
+}
+
+interface PreviewMarkdownReviewThread {
+  body: string;
+  line?: number;
+  path?: string;
+}
+
+async function mockReviewThreadsOnPreviewMarkdown(page: Page, threads: PreviewMarkdownReviewThread[]): Promise<void> {
   await page.route("**/api/v1/pulls/github/acme/widgets/1", async (route) => {
     const response = await route.fetch();
     const detail = (await response.json()) as MergeRequestDetailForRoute;
     const timestamp = "2026-06-17T15:00:00Z";
-    const externalID = `e2e-rich-preview-${line}`;
-    const threadID = `thread-rich-preview-${line}`;
 
     await route.fulfill({
       response,
@@ -1286,39 +1324,45 @@ async function mockReviewThreadOnPreviewMarkdown(
         ...detail,
         events: [
           ...(detail.events ?? []),
-          {
-            Author: "reviewer",
-            Body: body,
-            CreatedAt: timestamp,
-            DedupeKey: `review_comment:${externalID}`,
-            DirectURL: "",
-            EventType: "review_comment",
-            ID: 900_001,
-            MergeRequestID: detail.merge_request?.ID ?? 1,
-            MetadataJSON: "{}",
-            PlatformExternalID: externalID,
-            PlatformID: 900_001,
-            Resolvable: false,
-            Resolved: false,
-            Summary: body,
-            ThreadID: threadID,
-            diff_thread: {
-              author_login: "reviewer",
-              body,
-              can_resolve: false,
-              created_at: timestamp,
-              diff_head_sha: detail.diff_head_sha,
-              id: threadID,
-              line,
-              line_type: "add",
-              new_line: line,
-              path,
-              provider_comment_id: externalID,
-              resolved: false,
-              side: "right",
-              updated_at: timestamp,
-            },
-          },
+          ...threads.map((thread, index) => {
+            const line = thread.line ?? 3;
+            const path = thread.path ?? "docs/preview.md";
+            const externalID = `e2e-rich-preview-${path}-${line}-${index}`;
+            const threadID = `thread-rich-preview-${path}-${line}-${index}`;
+            return {
+              Author: "reviewer",
+              Body: thread.body,
+              CreatedAt: timestamp,
+              DedupeKey: `review_comment:${externalID}`,
+              DirectURL: "",
+              EventType: "review_comment",
+              ID: 900_001 + index,
+              MergeRequestID: detail.merge_request?.ID ?? 1,
+              MetadataJSON: "{}",
+              PlatformExternalID: externalID,
+              PlatformID: 900_001 + index,
+              Resolvable: false,
+              Resolved: false,
+              Summary: thread.body,
+              ThreadID: threadID,
+              diff_thread: {
+                author_login: "reviewer",
+                body: thread.body,
+                can_resolve: false,
+                created_at: timestamp,
+                diff_head_sha: detail.diff_head_sha,
+                id: threadID,
+                line,
+                line_type: "add",
+                new_line: line,
+                path,
+                provider_comment_id: externalID,
+                resolved: false,
+                side: "right",
+                updated_at: timestamp,
+              },
+            };
+          }),
         ],
       },
     });
@@ -2079,6 +2123,39 @@ test.describe("diff view", () => {
         }),
       )
       .toBe(true);
+  });
+
+  test("rich preview anchors multiple list review cards to their source items", async ({ page }) => {
+    await mockDiffApi(page, listReviewPreviewDiff);
+    await mockReviewThreadsOnPreviewMarkdown(page, [
+      { body: "Actions review note", line: 2, path: "docs/list-review.md" },
+      { body: "Issues review note", line: 1, path: "docs/list-review.md" },
+    ]);
+    await navigateToDiff(page);
+    await waitForDiffLoaded(page);
+    await waitForSidebarFilesLoaded(page);
+
+    await openDiffFilterMenu(page);
+    await page.getByRole("switch", { name: "Rich preview" }).click();
+
+    const markdownFile = page.locator('[data-file-path="docs/list-review.md"]');
+    await expect(markdownFile.locator(".markdown-rich-diff--unified")).toBeVisible();
+    await expect
+      .poll(() => markdownFile.locator(".markdown-rich-diff--unified .review-thread-body").allTextContents())
+      .toEqual(["Issues review note", "Actions review note"]);
+
+    const issuesCard = markdownFile
+      .locator(".markdown-rich-diff--unified .inline-review-thread")
+      .filter({ hasText: "Issues review note" });
+    const actionsCard = markdownFile
+      .locator(".markdown-rich-diff--unified .inline-review-thread")
+      .filter({ hasText: "Actions review note" });
+    await expect
+      .poll(() => issuesCard.evaluate((element) => element.previousElementSibling?.textContent?.trim() ?? ""))
+      .toContain("Issues");
+    await expect
+      .poll(() => actionsCard.evaluate((element) => element.previousElementSibling?.textContent?.trim() ?? ""))
+      .toContain("Actions");
   });
 
   test("rich preview keeps unmapped review thread cards visible as file-level fallback", async ({ page }) => {

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -1938,9 +1938,18 @@ test.describe("diff view", () => {
 
     const markdownFile = page.locator('[data-file-path="docs/preview.md"]');
     await expect(markdownFile.locator(".markdown-rich-diff--unified")).toBeVisible();
-    await expect(
-      markdownFile.locator(".markdown-rich-diff--unified .inline-review-thread").filter({ hasText: reviewBody }),
-    ).toBeVisible();
+    const reviewCard = markdownFile
+      .locator(".markdown-rich-diff--unified .inline-review-thread")
+      .filter({ hasText: reviewBody });
+    await expect(reviewCard).toBeVisible();
+    await expect
+      .poll(() =>
+        reviewCard.evaluate(
+          (element) =>
+            element.previousElementSibling?.classList.contains("markdown-rich-diff__anchored-block") ?? false,
+        ),
+      )
+      .toBe(true);
   });
 
   test("rich preview refetches blob content after a same-PR diff reload", async ({ page }) => {

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -1267,7 +1267,12 @@ async function mockFilePreviewApi(page: Page): Promise<void> {
   });
 }
 
-async function mockReviewThreadOnPreviewMarkdown(page: Page, body: string, line = 3): Promise<void> {
+async function mockReviewThreadOnPreviewMarkdown(
+  page: Page,
+  body: string,
+  line = 3,
+  path = "docs/preview.md",
+): Promise<void> {
   await page.route("**/api/v1/pulls/github/acme/widgets/1", async (route) => {
     const response = await route.fetch();
     const detail = (await response.json()) as MergeRequestDetailForRoute;
@@ -1307,7 +1312,7 @@ async function mockReviewThreadOnPreviewMarkdown(page: Page, body: string, line 
               line,
               line_type: "add",
               new_line: line,
-              path: "docs/preview.md",
+              path,
               provider_comment_id: externalID,
               resolved: false,
               side: "right",
@@ -2107,6 +2112,28 @@ test.describe("diff view", () => {
     await expect(codeBlock).toContainText("added hunk code");
     await expect(codeBlock).not.toContainText("---");
     await expect(markdownPreview.locator("hr")).toHaveCount(0);
+  });
+
+  test("rich preview keeps hidden hunk-gap review threads as file-level fallback", async ({ page }) => {
+    const reviewBody = "Hidden hunk gap review note should stay fallback";
+    await mockDiffApi(page, multiHunkMarkdownDiff);
+    await mockReviewThreadOnPreviewMarkdown(page, reviewBody, 6, "docs/multihunk.md");
+    await navigateToDiff(page);
+    await waitForDiffLoaded(page);
+    await waitForSidebarFilesLoaded(page);
+
+    await openDiffFilterMenu(page);
+    await page.getByRole("switch", { name: "Rich preview" }).click();
+
+    const markdownFile = page.locator('[data-file-path="docs/multihunk.md"]');
+    const fallbackCard = markdownFile.locator(".preview-shell > .inline-review-thread").filter({
+      hasText: reviewBody,
+    });
+    await expect(fallbackCard).toBeVisible();
+    await expect(fallbackCard).toHaveClass(/inline-review-thread--file-level/);
+    await expect(
+      markdownFile.locator(".markdown-rich-diff--unified .inline-review-thread").filter({ hasText: reviewBody }),
+    ).toHaveCount(0);
   });
 
   test("rich preview refetches blob content after a same-PR diff reload", async ({ page }) => {

--- a/packages/ui/src/components/diff/DiffFile.svelte
+++ b/packages/ui/src/components/diff/DiffFile.svelte
@@ -532,14 +532,6 @@
   {#if !collapsed}
     <div class="file-content">
       {#if showRichPreview}
-        {#each fileReviewThreads as thread (thread.id)}
-          <DiffReviewThreadInlineComment
-            {thread}
-            fileLevel={reviewThreadIsFileLevelCard(thread)}
-            canReply={canReplyToThreads}
-            onreply={replyToThread}
-          />
-        {/each}
         {#key richPreviewKey}
           <DiffRichPreview
             {file}
@@ -551,6 +543,10 @@
             {number}
             active={inViewport}
             {viewMode}
+            reviewThreads={fileReviewThreads}
+            {canReplyToThreads}
+            {reviewThreadIsFileLevelCard}
+            onreply={replyToThread}
           />
         {/key}
       {:else}

--- a/packages/ui/src/components/diff/DiffFile.svelte
+++ b/packages/ui/src/components/diff/DiffFile.svelte
@@ -255,8 +255,14 @@
     );
   }
 
+  function reviewThreadIsFileLevelCard(thread: ReviewThread): boolean {
+    return thread.line_type === "file" ||
+      !threadMatchesCurrentDiff(thread) ||
+      !hasRenderedReviewThread(thread);
+  }
+
   const fileLevelReviewThreads = $derived(
-    fileReviewThreads.filter((thread) => !hasRenderedReviewThread(thread)),
+    fileReviewThreads.filter((thread) => reviewThreadIsFileLevelCard(thread)),
   );
 
   function lineRef(
@@ -525,10 +531,15 @@
   </button>
   {#if !collapsed}
     <div class="file-content">
-      {#each fileLevelReviewThreads as thread (thread.id)}
-        <DiffReviewThreadInlineComment {thread} fileLevel={true} />
-      {/each}
       {#if showRichPreview}
+        {#each fileReviewThreads as thread (thread.id)}
+          <DiffReviewThreadInlineComment
+            {thread}
+            fileLevel={reviewThreadIsFileLevelCard(thread)}
+            canReply={canReplyToThreads}
+            onreply={replyToThread}
+          />
+        {/each}
         {#key richPreviewKey}
           <DiffRichPreview
             {file}
@@ -542,27 +553,32 @@
             {viewMode}
           />
         {/key}
-      {:else if file.is_binary}
-        <div class="binary-notice">Binary file changed</div>
       {:else}
-        {#key textDiffKey}
-          <PierreFileDiff
-            {file}
-            active={inViewport}
-            {viewMode}
-            {wordWrap}
-            {tabWidth}
-            loadFileText={contextExpansionEnabled ? loadDiffText : undefined}
-            lineAnnotations={pierreLineAnnotations}
-            transientLineAnnotation={pierreComposerAnnotation}
-            selectedRange={selectedRange}
-            selectedRanges={draftSelectedRanges}
-            enableLineSelection={reviewEnabled && !!diffHeadSHA}
-            onLineSelected={handlePierreSelection}
-            renderAnnotation={renderUnknownAnnotation}
-            {virtualizer}
-          />
-        {/key}
+        {#each fileLevelReviewThreads as thread (thread.id)}
+          <DiffReviewThreadInlineComment {thread} fileLevel={true} />
+        {/each}
+        {#if file.is_binary}
+          <div class="binary-notice">Binary file changed</div>
+        {:else}
+          {#key textDiffKey}
+            <PierreFileDiff
+              {file}
+              active={inViewport}
+              {viewMode}
+              {wordWrap}
+              {tabWidth}
+              loadFileText={contextExpansionEnabled ? loadDiffText : undefined}
+              lineAnnotations={pierreLineAnnotations}
+              transientLineAnnotation={pierreComposerAnnotation}
+              selectedRange={selectedRange}
+              selectedRanges={draftSelectedRanges}
+              enableLineSelection={reviewEnabled && !!diffHeadSHA}
+              onLineSelected={handlePierreSelection}
+              renderAnnotation={renderUnknownAnnotation}
+              {virtualizer}
+            />
+          {/key}
+        {/if}
       {/if}
     </div>
   {/if}

--- a/packages/ui/src/components/diff/DiffFile.svelte
+++ b/packages/ui/src/components/diff/DiffFile.svelte
@@ -258,9 +258,6 @@
   const fileLevelReviewThreads = $derived(
     fileReviewThreads.filter((thread) => !hasRenderedReviewThread(thread)),
   );
-  const visibleFileLevelReviewThreads = $derived(
-    showRichPreview ? [] : fileLevelReviewThreads,
-  );
 
   function lineRef(
     line: DiffFileType["hunks"][number]["lines"][number],
@@ -528,7 +525,7 @@
   </button>
   {#if !collapsed}
     <div class="file-content">
-      {#each visibleFileLevelReviewThreads as thread (thread.id)}
+      {#each fileLevelReviewThreads as thread (thread.id)}
         <DiffReviewThreadInlineComment {thread} fileLevel={true} />
       {/each}
       {#if showRichPreview}

--- a/packages/ui/src/components/diff/DiffFile.svelte
+++ b/packages/ui/src/components/diff/DiffFile.svelte
@@ -545,7 +545,7 @@
             {viewMode}
             reviewThreads={fileReviewThreads}
             {canReplyToThreads}
-            {reviewThreadIsFileLevelCard}
+            {diffHeadSHA}
             onreply={replyToThread}
           />
         {/key}

--- a/packages/ui/src/components/diff/DiffFile.svelte
+++ b/packages/ui/src/components/diff/DiffFile.svelte
@@ -258,6 +258,9 @@
   const fileLevelReviewThreads = $derived(
     fileReviewThreads.filter((thread) => !hasRenderedReviewThread(thread)),
   );
+  const visibleFileLevelReviewThreads = $derived(
+    showRichPreview ? [] : fileLevelReviewThreads,
+  );
 
   function lineRef(
     line: DiffFileType["hunks"][number]["lines"][number],
@@ -525,7 +528,7 @@
   </button>
   {#if !collapsed}
     <div class="file-content">
-      {#each fileLevelReviewThreads as thread (thread.id)}
+      {#each visibleFileLevelReviewThreads as thread (thread.id)}
         <DiffReviewThreadInlineComment {thread} fileLevel={true} />
       {/each}
       {#if showRichPreview}

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -1018,6 +1018,74 @@ describe("DiffFile", () => {
     expect(actionsComment?.previousElementSibling?.textContent).not.toContain("Statuses");
   });
 
+  it("keeps unchanged list siblings aligned when added list item review targets an edge", async () => {
+    for (const scenario of [
+      {
+        name: "prepended",
+        targetLine: 1,
+        lines: [
+          { type: "add" as const, content: "- Actions", new_num: 1 },
+          { type: "context" as const, content: "- Issues", old_num: 1, new_num: 2 },
+          { type: "context" as const, content: "- Statuses", old_num: 2, new_num: 3 },
+        ],
+      },
+      {
+        name: "appended",
+        targetLine: 3,
+        lines: [
+          { type: "context" as const, content: "- Issues", old_num: 1, new_num: 1 },
+          { type: "context" as const, content: "- Statuses", old_num: 2, new_num: 2 },
+          { type: "add" as const, content: "- Actions", new_num: 3 },
+        ],
+      },
+    ]) {
+      cleanup();
+      renderDiffFile(
+        makeFile({
+          path: "README.md",
+          old_path: "README.md",
+          hunks: [
+            {
+              old_start: 1,
+              old_count: 2,
+              new_start: 1,
+              new_count: 3,
+              lines: scenario.lines,
+            },
+          ],
+        }),
+        {
+          richPreview: true,
+          diffHeadSHA: "diff-head",
+          reviewThreads: [
+            makeReviewThread({
+              id: `thread-actions-${scenario.name}`,
+              provider_comment_id: `comment-actions-${scenario.name}`,
+              path: "README.md",
+              old_path: "README.md",
+              line: scenario.targetLine,
+              new_line: scenario.targetLine,
+              body: `Actions ${scenario.name} review note`,
+              diff_head_sha: "diff-head",
+            }),
+          ],
+        },
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText(`Actions ${scenario.name} review note`)).toBeTruthy();
+      });
+      const preview = document.querySelector(".markdown-rich-diff--unified");
+      expect(preview?.querySelector("ins")?.textContent).toContain("Actions");
+      expect(preview?.querySelector("ins")?.textContent ?? "").not.toContain("Issues");
+      expect(preview?.querySelector("ins")?.textContent ?? "").not.toContain("Statuses");
+      expect(preview?.querySelector("del")?.textContent ?? "").not.toContain("Issues");
+      expect(preview?.querySelector("del")?.textContent ?? "").not.toContain("Statuses");
+      const actionsComment = document.querySelector(`[data-review-thread-id='thread-actions-${scenario.name}']`);
+      expect(actionsComment?.previousElementSibling?.textContent).toContain("Actions");
+    }
+  });
+
   it("keeps unchanged list siblings aligned when a review targets a deleted list item", async () => {
     renderDiffFile(
       makeFile({
@@ -1068,6 +1136,77 @@ describe("DiffFile", () => {
     const actionsComment = document.querySelector("[data-review-thread-id='thread-actions']");
     expect(actionsComment?.previousElementSibling?.textContent).toContain("Actions");
     expect(actionsComment?.previousElementSibling?.textContent).not.toContain("Statuses");
+  });
+
+  it("keeps unchanged list siblings aligned when deleted list item review targets an edge", async () => {
+    for (const scenario of [
+      {
+        name: "first",
+        targetLine: 1,
+        lines: [
+          { type: "delete" as const, content: "- Actions", old_num: 1 },
+          { type: "context" as const, content: "- Issues", old_num: 2, new_num: 1 },
+          { type: "context" as const, content: "- Statuses", old_num: 3, new_num: 2 },
+        ],
+      },
+      {
+        name: "last",
+        targetLine: 3,
+        lines: [
+          { type: "context" as const, content: "- Issues", old_num: 1, new_num: 1 },
+          { type: "context" as const, content: "- Statuses", old_num: 2, new_num: 2 },
+          { type: "delete" as const, content: "- Actions", old_num: 3 },
+        ],
+      },
+    ]) {
+      cleanup();
+      renderDiffFile(
+        makeFile({
+          path: "README.md",
+          old_path: "README.md",
+          hunks: [
+            {
+              old_start: 1,
+              old_count: 3,
+              new_start: 1,
+              new_count: 2,
+              lines: scenario.lines,
+            },
+          ],
+        }),
+        {
+          richPreview: true,
+          diffHeadSHA: "diff-head",
+          reviewThreads: [
+            makeReviewThread({
+              id: `thread-actions-${scenario.name}`,
+              provider_comment_id: `comment-actions-${scenario.name}`,
+              path: "README.md",
+              old_path: "README.md",
+              side: "left",
+              line: scenario.targetLine,
+              old_line: scenario.targetLine,
+              new_line: undefined,
+              line_type: "delete",
+              body: `Actions ${scenario.name} review note`,
+              diff_head_sha: "diff-head",
+            }),
+          ],
+        },
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText(`Actions ${scenario.name} review note`)).toBeTruthy();
+      });
+      const preview = document.querySelector(".markdown-rich-diff--unified");
+      expect(preview?.querySelector("del")?.textContent).toContain("Actions");
+      expect(preview?.querySelector("del")?.textContent ?? "").not.toContain("Issues");
+      expect(preview?.querySelector("del")?.textContent ?? "").not.toContain("Statuses");
+      expect(preview?.querySelector("ins")?.textContent ?? "").not.toContain("Issues");
+      expect(preview?.querySelector("ins")?.textContent ?? "").not.toContain("Statuses");
+      const actionsComment = document.querySelector(`[data-review-thread-id='thread-actions-${scenario.name}']`);
+      expect(actionsComment?.previousElementSibling?.textContent).toContain("Actions");
+    }
   });
 
   it("keeps markdown document semantics when review cards are anchored in rich preview", async () => {

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -996,6 +996,37 @@ describe("DiffFile", () => {
     expect(document.querySelector(".preview-shell > .inline-review-thread")).toBeNull();
   });
 
+  it("keeps unmapped markdown rich preview threads in file-level fallback cards", async () => {
+    renderDiffFile(
+      makeFile({
+        path: "README.md",
+        old_path: "README.md",
+      }),
+      {
+        richPreview: true,
+        diffHeadSHA: "diff-head",
+        reviewThreads: [
+          makeReviewThread({
+            path: "README.md",
+            old_path: "README.md",
+            line: 99,
+            new_line: 99,
+            body: "Unmapped rich preview note",
+            diff_head_sha: "diff-head",
+          }),
+        ],
+      },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Unmapped rich preview note")).toBeTruthy();
+    });
+    const comment = document.querySelector("[data-review-thread-id='thread-1']");
+    expect(comment?.closest(".markdown-rich-diff--unified")).toBeNull();
+    expect(comment?.classList.contains("inline-review-thread--file-level")).toBe(true);
+    expect(comment?.textContent).toContain("File");
+  });
+
   it("lets published inline review threads be replied to", async () => {
     const replyToDiscussion = vi.fn().mockResolvedValue(true);
     renderDiffFile(makeFile(), {

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -89,6 +89,7 @@ afterAll(() => {
 });
 
 import DiffFile from "./DiffFile.svelte";
+import diffRichPreviewSource from "./DiffRichPreview.svelte?raw";
 import type { DiffFile as DiffFileType, FilePreview } from "../../api/types.js";
 import { STORES_KEY } from "../../context.js";
 import type { DiffReviewDraftComment, DiffReviewLineRange } from "../../stores/diff-review-draft.svelte.js";
@@ -447,6 +448,45 @@ describe("DiffFile", () => {
       expect(document.querySelector(".markdown-rich-diff--unified del")?.textContent).toBe("old");
       expect(document.querySelector(".markdown-rich-diff--unified ins")?.textContent).toBe("new");
     });
+  });
+
+  it("keeps structural markdown rich preview changes visibly highlighted", async () => {
+    renderDiffFile(
+      makeFile({
+        path: "README.md",
+        old_path: "README.md",
+        hunks: [
+          {
+            old_start: 1,
+            old_count: 2,
+            new_start: 1,
+            new_count: 2,
+            lines: [
+              { type: "delete", content: "- Removed", old_num: 1 },
+              { type: "context", content: "- Keep", old_num: 2, new_num: 1 },
+              { type: "add", content: "- Added", new_num: 2 },
+            ],
+          },
+        ],
+      }),
+      { richPreview: true },
+    );
+
+    await waitFor(() => {
+      const preview = document.querySelector(".markdown-rich-diff--unified");
+      expect(preview?.querySelector('li.markdown-diff__structural[data-diff-kind="delete"] > del')?.textContent).toBe(
+        "Removed",
+      );
+      expect(preview?.querySelector('li.markdown-diff__structural[data-diff-kind="insert"] > ins')?.textContent).toBe(
+        "Added",
+      );
+    });
+    expect(diffRichPreviewSource).toMatch(
+      /\.markdown-diff__structural\[data-diff-kind="delete"\][\s\S]*background: var\(--diff-del-bg\);/,
+    );
+    expect(diffRichPreviewSource).toMatch(
+      /\.markdown-diff__structural\[data-diff-kind="insert"\][\s\S]*background: var\(--diff-add-bg\);/,
+    );
   });
 
   it("keeps markdown rich preview side by side when split diff mode is enabled", async () => {
@@ -960,6 +1000,48 @@ describe("DiffFile", () => {
     const comment = document.querySelector("[data-review-thread-id='thread-1']");
     expect(comment?.closest("[slot^='annotation-']")).toBeNull();
     expect(comment?.closest(".markdown-rich-diff--unified")).toBeTruthy();
+  });
+
+  it("keeps markdown rich preview review threads visible when hunk lines are null", async () => {
+    renderDiffFile(
+      makeFile({
+        path: "README.md",
+        old_path: "README.md",
+        additions: 0,
+        deletions: 0,
+        patch: "",
+        hunks: [
+          {
+            old_start: 1,
+            old_count: 0,
+            new_start: 1,
+            new_count: 0,
+            lines: null as unknown as DiffFileType["hunks"][number]["lines"],
+          },
+        ],
+      }),
+      {
+        richPreview: true,
+        diffHeadSHA: "diff-head",
+        reviewThreads: [
+          makeReviewThread({
+            path: "README.md",
+            old_path: "README.md",
+            line: 1,
+            new_line: 1,
+            body: "Nullable rich preview note",
+            diff_head_sha: "diff-head",
+          }),
+        ],
+      },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Nullable rich preview note")).toBeTruthy();
+    });
+    const comment = document.querySelector("[data-review-thread-id='thread-1']");
+    expect(comment?.closest(".markdown-rich-diff--unified")).toBeNull();
+    expect(comment?.classList.contains("inline-review-thread--file-level")).toBe(true);
   });
 
   it("orders markdown rich preview review cards by their target source line", async () => {

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -1420,6 +1420,62 @@ describe("DiffFile", () => {
     expect(detailsComment?.previousElementSibling?.textContent).toContain("updated details");
   });
 
+  it("keeps context-owned list items aligned when a review targets a changed detail line", async () => {
+    renderDiffFile(
+      makeFile({
+        path: "README.md",
+        old_path: "README.md",
+        hunks: [
+          {
+            old_start: 1,
+            old_count: 3,
+            new_start: 1,
+            new_count: 3,
+            lines: [
+              { type: "context", content: "- Action", old_num: 1, new_num: 1 },
+              { type: "delete", content: "legacy details", old_num: 2 },
+              { type: "add", content: "updated details", new_num: 2 },
+              { type: "context", content: "- Statuses", old_num: 3, new_num: 3 },
+            ],
+          },
+        ],
+      }),
+      {
+        richPreview: true,
+        diffHeadSHA: "diff-head",
+        reviewThreads: [
+          makeReviewThread({
+            id: "thread-context-details",
+            provider_comment_id: "comment-context-details",
+            path: "README.md",
+            old_path: "README.md",
+            line: 2,
+            new_line: 2,
+            body: "Context-owned details review note",
+            diff_head_sha: "diff-head",
+          }),
+        ],
+      },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Context-owned details review note")).toBeTruthy();
+    });
+    const preview = document.querySelector(".markdown-rich-diff--unified");
+    const deletedText = Array.from(preview?.querySelectorAll("del") ?? [])
+      .map((element) => element.textContent ?? "")
+      .join("\n");
+    const insertedText = Array.from(preview?.querySelectorAll("ins") ?? [])
+      .map((element) => element.textContent ?? "")
+      .join("\n");
+    expect(deletedText).toContain("legacy");
+    expect(deletedText).not.toContain("Statuses");
+    expect(insertedText).toContain("updated");
+    expect(insertedText).not.toContain("Statuses");
+    const detailsComment = document.querySelector("[data-review-thread-id='thread-context-details']");
+    expect(detailsComment?.previousElementSibling?.textContent).toContain("updated details");
+  });
+
   it("keeps markdown document semantics when review cards are anchored in rich preview", async () => {
     renderDiffFile(
       makeFile({

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -1007,7 +1007,8 @@ describe("DiffFile", () => {
       expect(screen.getByText("Anchored semantic note")).toBeTruthy();
     });
     const preview = document.querySelector(".markdown-rich-diff--unified");
-    expect(preview?.querySelectorAll("ul.markdown-rich-diff__split-list")).toHaveLength(2);
+    expect(preview?.querySelectorAll("ul")).toHaveLength(1);
+    expect(preview?.querySelectorAll("ul.markdown-rich-diff__split-list")).toHaveLength(0);
     expect(preview?.querySelector('a[href="https://example.com"]')?.textContent).toBe("the ref");
     const comment = document.querySelector("[data-review-thread-id='thread-1']");
     expect(comment?.previousElementSibling?.classList.contains("markdown-rich-diff__anchored-block")).toBe(true);

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -1027,6 +1027,58 @@ describe("DiffFile", () => {
     expect(comment?.textContent).toContain("File");
   });
 
+  it("does not anchor markdown rich preview threads to hidden source gaps inside spanning blocks", async () => {
+    renderDiffFile(
+      makeFile({
+        path: "README.md",
+        old_path: "README.md",
+        hunks: [
+          {
+            old_start: 1,
+            old_count: 2,
+            new_start: 1,
+            new_count: 2,
+            lines: [
+              { type: "context", content: "```text", old_num: 1, new_num: 1 },
+              { type: "context", content: "first hunk code", old_num: 2, new_num: 2 },
+            ],
+          },
+          {
+            old_start: 10,
+            old_count: 2,
+            new_start: 10,
+            new_count: 2,
+            lines: [
+              { type: "context", content: "second hunk code", old_num: 10, new_num: 10 },
+              { type: "context", content: "```", old_num: 11, new_num: 11 },
+            ],
+          },
+        ],
+      }),
+      {
+        richPreview: true,
+        diffHeadSHA: "diff-head",
+        reviewThreads: [
+          makeReviewThread({
+            path: "README.md",
+            old_path: "README.md",
+            line: 6,
+            new_line: 6,
+            body: "Gap line review note",
+            diff_head_sha: "diff-head",
+          }),
+        ],
+      },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Gap line review note")).toBeTruthy();
+    });
+    const comment = document.querySelector("[data-review-thread-id='thread-1']");
+    expect(comment?.closest(".markdown-rich-diff--unified")).toBeNull();
+    expect(comment?.classList.contains("inline-review-thread--file-level")).toBe(true);
+  });
+
   it("lets published inline review threads be replied to", async () => {
     const replyToDiscussion = vi.fn().mockResolvedValue(true);
     renderDiffFile(makeFile(), {

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -956,6 +956,12 @@ describe("DiffFile", () => {
       document.querySelectorAll<HTMLElement>(".markdown-rich-diff--unified .review-thread-body"),
     ).map((element) => element.textContent?.trim());
     expect(reviewBodies).toEqual(["Issues review note", "Actions review note"]);
+    const issuesComment = document.querySelector("[data-review-thread-id='thread-issues']");
+    const actionsComment = document.querySelector("[data-review-thread-id='thread-actions']");
+    expect(issuesComment?.previousElementSibling?.textContent).toContain("Issues");
+    expect(issuesComment?.previousElementSibling?.textContent).not.toContain("Actions");
+    expect(actionsComment?.previousElementSibling?.textContent).toContain("Actions");
+    expect(actionsComment?.previousElementSibling?.textContent).not.toContain("Statuses");
   });
 
   it("keeps markdown document semantics when review cards are anchored in rich preview", async () => {
@@ -1001,7 +1007,7 @@ describe("DiffFile", () => {
       expect(screen.getByText("Anchored semantic note")).toBeTruthy();
     });
     const preview = document.querySelector(".markdown-rich-diff--unified");
-    expect(preview?.querySelectorAll("ul")).toHaveLength(1);
+    expect(preview?.querySelectorAll("ul.markdown-rich-diff__split-list")).toHaveLength(2);
     expect(preview?.querySelector('a[href="https://example.com"]')?.textContent).toBe("the ref");
     const comment = document.querySelector("[data-review-thread-id='thread-1']");
     expect(comment?.previousElementSibling?.classList.contains("markdown-rich-diff__anchored-block")).toBe(true);

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -901,6 +901,63 @@ describe("DiffFile", () => {
     expect(comment?.closest(".markdown-rich-diff--unified")).toBeTruthy();
   });
 
+  it("orders markdown rich preview review cards by their target source line", async () => {
+    renderDiffFile(
+      makeFile({
+        path: "README.md",
+        old_path: "README.md",
+        hunks: [
+          {
+            old_start: 1,
+            old_count: 3,
+            new_start: 1,
+            new_count: 3,
+            lines: [
+              { type: "context", content: "- Issues", old_num: 1, new_num: 1 },
+              { type: "context", content: "- Actions", old_num: 2, new_num: 2 },
+              { type: "context", content: "- Statuses", old_num: 3, new_num: 3 },
+            ],
+          },
+        ],
+      }),
+      {
+        richPreview: true,
+        diffHeadSHA: "diff-head",
+        reviewThreads: [
+          makeReviewThread({
+            id: "thread-actions",
+            provider_comment_id: "comment-actions",
+            path: "README.md",
+            old_path: "README.md",
+            line: 2,
+            new_line: 2,
+            body: "Actions review note",
+            diff_head_sha: "diff-head",
+          }),
+          makeReviewThread({
+            id: "thread-issues",
+            provider_comment_id: "comment-issues",
+            path: "README.md",
+            old_path: "README.md",
+            line: 1,
+            new_line: 1,
+            body: "Issues review note",
+            diff_head_sha: "diff-head",
+          }),
+        ],
+      },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Actions review note")).toBeTruthy();
+      expect(screen.getByText("Issues review note")).toBeTruthy();
+    });
+    const reviewBodies = Array.from(
+      document.querySelectorAll<HTMLElement>(".markdown-rich-diff--unified .review-thread-body"),
+    ).map((element) => element.textContent?.trim());
+    expect(reviewBodies).toEqual(["Issues review note", "Actions review note"]);
+  });
+
   it("keeps markdown document semantics when review cards are anchored in rich preview", async () => {
     renderDiffFile(
       makeFile({

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -1032,13 +1032,13 @@ describe("DiffFile", () => {
         ],
       },
       {
-        name: "prepended multiline",
+        name: "prepended lazy multiline",
         targetLine: 1,
         oldCount: 2,
         newCount: 4,
         lines: [
           { type: "add" as const, content: "- Actions", new_num: 1 },
-          { type: "add" as const, content: "  still needs details", new_num: 2 },
+          { type: "add" as const, content: "still needs details", new_num: 2 },
           { type: "context" as const, content: "- Issues", old_num: 1, new_num: 3 },
           { type: "context" as const, content: "- Statuses", old_num: 2, new_num: 4 },
         ],
@@ -1168,13 +1168,13 @@ describe("DiffFile", () => {
         ],
       },
       {
-        name: "first multiline",
+        name: "first lazy multiline",
         targetLine: 1,
         oldCount: 4,
         newCount: 2,
         lines: [
           { type: "delete" as const, content: "- Actions", old_num: 1 },
-          { type: "delete" as const, content: "  still needs details", old_num: 2 },
+          { type: "delete" as const, content: "still needs details", old_num: 2 },
           { type: "context" as const, content: "- Issues", old_num: 3, new_num: 1 },
           { type: "context" as const, content: "- Statuses", old_num: 4, new_num: 2 },
         ],

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -1302,6 +1302,124 @@ describe("DiffFile", () => {
     }
   });
 
+  it("keeps modified list item pairs aligned when a review targets the added item", async () => {
+    renderDiffFile(
+      makeFile({
+        path: "README.md",
+        old_path: "README.md",
+        hunks: [
+          {
+            old_start: 1,
+            old_count: 3,
+            new_start: 1,
+            new_count: 3,
+            lines: [
+              { type: "context", content: "- Issues", old_num: 1, new_num: 1 },
+              { type: "delete", content: "- Legacy action", old_num: 2 },
+              { type: "add", content: "- Updated action", new_num: 2 },
+              { type: "context", content: "- Statuses", old_num: 3, new_num: 3 },
+            ],
+          },
+        ],
+      }),
+      {
+        richPreview: true,
+        diffHeadSHA: "diff-head",
+        reviewThreads: [
+          makeReviewThread({
+            id: "thread-new-action",
+            provider_comment_id: "comment-new-action",
+            path: "README.md",
+            old_path: "README.md",
+            line: 2,
+            new_line: 2,
+            body: "Updated action review note",
+            diff_head_sha: "diff-head",
+          }),
+        ],
+      },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Updated action review note")).toBeTruthy();
+    });
+    const preview = document.querySelector(".markdown-rich-diff--unified");
+    const deletedText = Array.from(preview?.querySelectorAll("del") ?? [])
+      .map((element) => element.textContent ?? "")
+      .join("\n");
+    const insertedText = Array.from(preview?.querySelectorAll("ins") ?? [])
+      .map((element) => element.textContent ?? "")
+      .join("\n");
+    expect(deletedText).toContain("Legacy");
+    expect(deletedText).not.toContain("Issues");
+    expect(deletedText).not.toContain("Statuses");
+    expect(insertedText).toContain("Updated");
+    expect(insertedText).not.toContain("Issues");
+    expect(insertedText).not.toContain("Statuses");
+    const actionComment = document.querySelector("[data-review-thread-id='thread-new-action']");
+    expect(actionComment?.previousElementSibling?.textContent).toContain("Updated action");
+  });
+
+  it("keeps modified list item pairs aligned when a review targets an added continuation", async () => {
+    renderDiffFile(
+      makeFile({
+        path: "README.md",
+        old_path: "README.md",
+        hunks: [
+          {
+            old_start: 1,
+            old_count: 4,
+            new_start: 1,
+            new_count: 4,
+            lines: [
+              { type: "context", content: "- Issues", old_num: 1, new_num: 1 },
+              { type: "delete", content: "- Action", old_num: 2 },
+              { type: "delete", content: "legacy details", old_num: 3 },
+              { type: "add", content: "- Action", new_num: 2 },
+              { type: "add", content: "updated details", new_num: 3 },
+              { type: "context", content: "- Statuses", old_num: 4, new_num: 4 },
+            ],
+          },
+        ],
+      }),
+      {
+        richPreview: true,
+        diffHeadSHA: "diff-head",
+        reviewThreads: [
+          makeReviewThread({
+            id: "thread-new-details",
+            provider_comment_id: "comment-new-details",
+            path: "README.md",
+            old_path: "README.md",
+            line: 3,
+            new_line: 3,
+            body: "Updated details review note",
+            diff_head_sha: "diff-head",
+          }),
+        ],
+      },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Updated details review note")).toBeTruthy();
+    });
+    const preview = document.querySelector(".markdown-rich-diff--unified");
+    const deletedText = Array.from(preview?.querySelectorAll("del") ?? [])
+      .map((element) => element.textContent ?? "")
+      .join("\n");
+    const insertedText = Array.from(preview?.querySelectorAll("ins") ?? [])
+      .map((element) => element.textContent ?? "")
+      .join("\n");
+    expect(deletedText).toContain("legacy");
+    expect(deletedText).not.toContain("Issues");
+    expect(deletedText).not.toContain("Statuses");
+    expect(insertedText).toContain("updated");
+    expect(insertedText).not.toContain("Issues");
+    expect(insertedText).not.toContain("Statuses");
+    const detailsComment = document.querySelector("[data-review-thread-id='thread-new-details']");
+    expect(detailsComment?.previousElementSibling?.textContent).toContain("updated details");
+  });
+
   it("keeps markdown document semantics when review cards are anchored in rich preview", async () => {
     renderDiffFile(
       makeFile({

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -496,13 +496,13 @@ describe("DiffFile", () => {
     });
 
     await waitFor(() => {
-      const beforePreview = screen.getByLabelText("Before markdown preview");
-      const afterPreview = screen.getByLabelText("After markdown preview");
+      const beforePreview = document.querySelector('[data-markdown-rich-side="before"]');
+      const afterPreview = document.querySelector('[data-markdown-rich-side="after"]');
 
-      expect(beforePreview.querySelector("del")?.textContent).toBe("old");
-      expect(beforePreview.querySelector("ins")).toBeNull();
-      expect(afterPreview.querySelector("del")).toBeNull();
-      expect(afterPreview.querySelector("ins")?.textContent).toBe("new");
+      expect(beforePreview?.querySelector("del")?.textContent).toBe("old");
+      expect(beforePreview?.querySelector("ins")).toBeNull();
+      expect(afterPreview?.querySelector("del")).toBeNull();
+      expect(afterPreview?.querySelector("ins")?.textContent).toBe("new");
     });
   });
 
@@ -1681,10 +1681,69 @@ describe("DiffFile", () => {
       expect(screen.getByText("Split pane review note")).toBeTruthy();
     });
     const comment = document.querySelector("[data-review-thread-id='thread-1']");
-    expect(comment?.closest('[aria-label="Before markdown preview"]')).toBeNull();
-    expect(comment?.closest('[aria-label="After markdown preview"]')).toBeTruthy();
+    expect(comment?.closest('[data-markdown-rich-side="before"]')).toBeNull();
+    expect(comment?.closest('[data-markdown-rich-side="after"]')).toBeTruthy();
     expect(comment?.previousElementSibling?.classList.contains("markdown-rich-diff__anchored-block")).toBe(true);
     expect(document.querySelector(".preview-shell > .inline-review-thread")).toBeNull();
+  });
+
+  it("keeps split rich preview blocks paired after a side-specific review card", async () => {
+    renderDiffFile(
+      makeFile({
+        path: "README.md",
+        old_path: "README.md",
+        hunks: [
+          {
+            old_start: 1,
+            old_count: 3,
+            new_start: 1,
+            new_count: 5,
+            lines: [
+              { type: "context", content: "Opening paragraph", old_num: 1, new_num: 1 },
+              { type: "context", content: "", old_num: 2, new_num: 2 },
+              { type: "add", content: "Added reviewed paragraph", new_num: 3 },
+              { type: "context", content: "", old_num: 3, new_num: 4 },
+              { type: "context", content: "Following paragraph", old_num: 4, new_num: 5 },
+            ],
+          },
+        ],
+      }),
+      {
+        richPreview: true,
+        viewMode: "split",
+        diffHeadSHA: "diff-head",
+        reviewThreads: [
+          makeReviewThread({
+            path: "README.md",
+            old_path: "README.md",
+            line: 3,
+            new_line: 3,
+            body: "Split row review note",
+            diff_head_sha: "diff-head",
+          }),
+        ],
+      },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Split row review note")).toBeTruthy();
+    });
+    const comment = document.querySelector("[data-review-thread-id='thread-1']");
+    const commentRow = comment?.closest(".markdown-rich-diff__split-row");
+    expect(commentRow).toBeTruthy();
+    expect(commentRow?.querySelector('[data-markdown-rich-side="before"]')).toBeTruthy();
+    expect(commentRow?.querySelector('[data-markdown-rich-side="after"]')?.textContent).toContain(
+      "Added reviewed paragraph",
+    );
+    const followingRow = Array.from(document.querySelectorAll(".markdown-rich-diff__split-row")).find((row) =>
+      row.textContent?.includes("Following paragraph"),
+    );
+    expect(followingRow?.querySelector('[data-markdown-rich-side="before"]')?.textContent).toContain(
+      "Following paragraph",
+    );
+    expect(followingRow?.querySelector('[data-markdown-rich-side="after"]')?.textContent).toContain(
+      "Following paragraph",
+    );
   });
 
   it("keeps unmapped markdown rich preview threads in file-level fallback cards", async () => {

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -504,6 +504,9 @@ describe("DiffFile", () => {
       expect(afterPreview?.querySelector("del")).toBeNull();
       expect(afterPreview?.querySelector("ins")?.textContent).toBe("new");
     });
+    expect(diffRichPreviewSource).toMatch(
+      /@media \(max-width: 760px\)[\s\S]*\.markdown-rich-diff__split-header,\s*\.markdown-rich-diff__split-row[\s\S]*grid-template-columns: minmax\(0, 1fr\);/,
+    );
   });
 
   it("keeps non-Markdown rich preview review cards visible while loading", async () => {

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -909,13 +909,14 @@ describe("DiffFile", () => {
         hunks: [
           {
             old_start: 1,
-            old_count: 3,
+            old_count: 4,
             new_start: 1,
-            new_count: 3,
+            new_count: 4,
             lines: [
               { type: "context", content: "- Issues", old_num: 1, new_num: 1 },
               { type: "context", content: "- Actions", old_num: 2, new_num: 2 },
               { type: "context", content: "- Statuses", old_num: 3, new_num: 3 },
+              { type: "context", content: "- Members", old_num: 4, new_num: 4 },
             ],
           },
         ],
@@ -958,8 +959,113 @@ describe("DiffFile", () => {
     expect(reviewBodies).toEqual(["Issues review note", "Actions review note"]);
     const issuesComment = document.querySelector("[data-review-thread-id='thread-issues']");
     const actionsComment = document.querySelector("[data-review-thread-id='thread-actions']");
+    const splitLists = Array.from(document.querySelectorAll<HTMLElement>("ul.markdown-rich-diff__split-list"));
+    expect(splitLists).toHaveLength(3);
+    expect(splitLists.at(-1)?.textContent).toContain("Statuses");
+    expect(splitLists.at(-1)?.textContent).toContain("Members");
     expect(issuesComment?.previousElementSibling?.textContent).toContain("Issues");
     expect(issuesComment?.previousElementSibling?.textContent).not.toContain("Actions");
+    expect(actionsComment?.previousElementSibling?.textContent).toContain("Actions");
+    expect(actionsComment?.previousElementSibling?.textContent).not.toContain("Statuses");
+  });
+
+  it("keeps unchanged list siblings aligned when a review targets an added list item", async () => {
+    renderDiffFile(
+      makeFile({
+        path: "README.md",
+        old_path: "README.md",
+        hunks: [
+          {
+            old_start: 1,
+            old_count: 2,
+            new_start: 1,
+            new_count: 3,
+            lines: [
+              { type: "context", content: "- Issues", old_num: 1, new_num: 1 },
+              { type: "add", content: "- Actions", new_num: 2 },
+              { type: "context", content: "- Statuses", old_num: 2, new_num: 3 },
+            ],
+          },
+        ],
+      }),
+      {
+        richPreview: true,
+        diffHeadSHA: "diff-head",
+        reviewThreads: [
+          makeReviewThread({
+            id: "thread-actions",
+            provider_comment_id: "comment-actions",
+            path: "README.md",
+            old_path: "README.md",
+            line: 2,
+            new_line: 2,
+            body: "Actions review note",
+            diff_head_sha: "diff-head",
+          }),
+        ],
+      },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Actions review note")).toBeTruthy();
+    });
+    const preview = document.querySelector(".markdown-rich-diff--unified");
+    expect(preview?.querySelector("ins")?.textContent).toContain("Actions");
+    expect(preview?.querySelector("del")?.textContent ?? "").not.toContain("Statuses");
+    expect(preview?.querySelector("ins")?.textContent ?? "").not.toContain("Issues");
+    const actionsComment = document.querySelector("[data-review-thread-id='thread-actions']");
+    expect(actionsComment?.previousElementSibling?.textContent).toContain("Actions");
+    expect(actionsComment?.previousElementSibling?.textContent).not.toContain("Statuses");
+  });
+
+  it("keeps unchanged list siblings aligned when a review targets a deleted list item", async () => {
+    renderDiffFile(
+      makeFile({
+        path: "README.md",
+        old_path: "README.md",
+        hunks: [
+          {
+            old_start: 1,
+            old_count: 3,
+            new_start: 1,
+            new_count: 2,
+            lines: [
+              { type: "context", content: "- Issues", old_num: 1, new_num: 1 },
+              { type: "delete", content: "- Actions", old_num: 2 },
+              { type: "context", content: "- Statuses", old_num: 3, new_num: 2 },
+            ],
+          },
+        ],
+      }),
+      {
+        richPreview: true,
+        diffHeadSHA: "diff-head",
+        reviewThreads: [
+          makeReviewThread({
+            id: "thread-actions",
+            provider_comment_id: "comment-actions",
+            path: "README.md",
+            old_path: "README.md",
+            side: "left",
+            line: 2,
+            old_line: 2,
+            new_line: undefined,
+            line_type: "delete",
+            body: "Actions review note",
+            diff_head_sha: "diff-head",
+          }),
+        ],
+      },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Actions review note")).toBeTruthy();
+    });
+    const preview = document.querySelector(".markdown-rich-diff--unified");
+    expect(preview?.querySelector("del")?.textContent).toContain("Actions");
+    expect(preview?.querySelector("del")?.textContent ?? "").not.toContain("Statuses");
+    expect(preview?.querySelector("ins")?.textContent ?? "").not.toContain("Issues");
+    const actionsComment = document.querySelector("[data-review-thread-id='thread-actions']");
     expect(actionsComment?.previousElementSibling?.textContent).toContain("Actions");
     expect(actionsComment?.previousElementSibling?.textContent).not.toContain("Statuses");
   });

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -977,6 +977,41 @@ describe("DiffFile", () => {
     expect(comment?.parentElement?.classList.contains("file-content")).toBe(true);
   });
 
+  it("hides review thread cards while markdown rich preview is active", async () => {
+    const file = makeFile({
+      path: "README.md",
+      old_path: "README.md",
+    });
+    const thread = makeReviewThread({
+      id: "thread-preview-hidden",
+      path: "README.md",
+      line: 99,
+      new_line: 99,
+      body: "Review note should stay out of rich preview",
+    });
+
+    const { unmount } = renderDiffFile(file, {
+      richPreview: true,
+      reviewThreads: [thread],
+    });
+
+    await waitFor(() => {
+      expect(document.querySelector(".markdown-rich-diff--unified")).toBeTruthy();
+    });
+    expect(screen.queryByText("Review note should stay out of rich preview")).toBeNull();
+
+    unmount();
+    renderDiffFile(file, {
+      richPreview: true,
+      richPreviewEnabled: false,
+      reviewThreads: [thread],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Review note should stay out of rich preview")).toBeTruthy();
+    });
+  });
+
   it("clears an open inline composer when review context changes", async () => {
     const file = makeFile();
     const owner = uniqueOwner();

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -898,6 +898,7 @@ describe("DiffFile", () => {
     expect(screen.getByText("Published review note in rich preview")).toBeTruthy();
     const comment = document.querySelector("[data-review-thread-id='thread-1']");
     expect(comment?.closest("[slot^='annotation-']")).toBeNull();
+    expect(comment?.closest(".markdown-rich-diff--unified")).toBeTruthy();
   });
 
   it("lets published inline review threads be replied to", async () => {

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -96,6 +96,14 @@ import { createDiffStore } from "../../stores/diff.svelte.js";
 import { renderedCodeSide } from "./pierre-dom.js";
 import type { ReviewThread } from "./review-thread-context.js";
 
+type LoadFilePreview = (
+  owner: string,
+  name: string,
+  number: number,
+  path: string,
+  side?: "old" | "new",
+) => Promise<FilePreview>;
+
 function makeFile(overrides: Partial<DiffFileType> = {}): DiffFileType {
   return {
     path: "src/foo.ts",
@@ -251,6 +259,7 @@ function renderDiffFile(
     createComment?: (body: string, range: DiffReviewLineRange) => Promise<boolean>;
     canReplyToThreads?: boolean;
     viewMode?: "unified" | "split";
+    loadFilePreview?: LoadFilePreview;
     replyToDiscussion?: (
       owner: string,
       name: string,
@@ -263,6 +272,7 @@ function renderDiffFile(
   const diff = createDiffStore();
   if (options.richPreview) diff.setRichPreview(true);
   if (options.viewMode) diff.setViewMode(options.viewMode);
+  if (options.loadFilePreview) vi.spyOn(diff, "loadFilePreview").mockImplementation(options.loadFilePreview);
   const diffReviewDraft = {
     getComments: () => options.draftComments ?? [],
     isSubmitting: () => false,
@@ -454,6 +464,57 @@ describe("DiffFile", () => {
       expect(afterPreview.querySelector("del")).toBeNull();
       expect(afterPreview.querySelector("ins")?.textContent).toBe("new");
     });
+  });
+
+  it("keeps non-Markdown rich preview review cards visible while loading", async () => {
+    let resolvePreview: (preview: FilePreview) => void = () => {};
+    renderDiffFile(makeFile({ path: "assets/chart.png", old_path: "assets/chart.png" }), {
+      richPreview: true,
+      diffHeadSHA: "diff-head",
+      loadFilePreview: () =>
+        new Promise<FilePreview>((resolve) => {
+          resolvePreview = resolve;
+        }),
+      reviewThreads: [
+        makeReviewThread({
+          path: "assets/chart.png",
+          old_path: "assets/chart.png",
+          body: "Loading non-markdown review note",
+          diff_head_sha: "diff-head",
+        }),
+      ],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Loading preview")).toBeTruthy();
+    });
+    expect(screen.getByText("Loading non-markdown review note")).toBeTruthy();
+
+    resolvePreview(textPreview("assets/chart.png", "preview content"));
+    await waitFor(() => {
+      expect(screen.getByText("preview content")).toBeTruthy();
+    });
+  });
+
+  it("keeps non-Markdown rich preview review cards visible after preview errors", async () => {
+    renderDiffFile(makeFile({ path: "assets/chart.png", old_path: "assets/chart.png" }), {
+      richPreview: true,
+      diffHeadSHA: "diff-head",
+      loadFilePreview: () => Promise.reject(new Error("preview failed")),
+      reviewThreads: [
+        makeReviewThread({
+          path: "assets/chart.png",
+          old_path: "assets/chart.png",
+          body: "Error non-markdown review note",
+          diff_head_sha: "diff-head",
+        }),
+      ],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("preview failed")).toBeTruthy();
+    });
+    expect(screen.getByText("Error non-markdown review note")).toBeTruthy();
   });
 
   it("hides content after clicking the header to collapse", async () => {
@@ -1032,8 +1093,8 @@ describe("DiffFile", () => {
         ],
       },
       {
-        name: "prepended lazy multiline",
-        targetLine: 1,
+        name: "prepended continuation",
+        targetLine: 2,
         oldCount: 2,
         newCount: 4,
         lines: [
@@ -1168,8 +1229,8 @@ describe("DiffFile", () => {
         ],
       },
       {
-        name: "first lazy multiline",
-        targetLine: 1,
+        name: "first continuation",
+        targetLine: 2,
         oldCount: 4,
         newCount: 2,
         lines: [

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -871,6 +871,35 @@ describe("DiffFile", () => {
     expect(host).toBeTruthy();
   });
 
+  it("renders published review thread cards in markdown rich preview", async () => {
+    renderDiffFile(
+      makeFile({
+        path: "README.md",
+        old_path: "README.md",
+      }),
+      {
+        richPreview: true,
+        diffHeadSHA: "diff-head",
+        canReplyToThreads: true,
+        reviewThreads: [
+          makeReviewThread({
+            path: "README.md",
+            old_path: "README.md",
+            body: "Published review note in rich preview",
+            diff_head_sha: "diff-head",
+          }),
+        ],
+      },
+    );
+
+    await waitFor(() => {
+      expect(document.querySelector(".markdown-rich-diff--unified")).toBeTruthy();
+    });
+    expect(screen.getByText("Published review note in rich preview")).toBeTruthy();
+    const comment = document.querySelector("[data-review-thread-id='thread-1']");
+    expect(comment?.closest("[slot^='annotation-']")).toBeNull();
+  });
+
   it("lets published inline review threads be replied to", async () => {
     const replyToDiscussion = vi.fn().mockResolvedValue(true);
     renderDiffFile(makeFile(), {

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -1023,6 +1023,8 @@ describe("DiffFile", () => {
       {
         name: "prepended",
         targetLine: 1,
+        oldCount: 2,
+        newCount: 3,
         lines: [
           { type: "add" as const, content: "- Actions", new_num: 1 },
           { type: "context" as const, content: "- Issues", old_num: 1, new_num: 2 },
@@ -1030,8 +1032,22 @@ describe("DiffFile", () => {
         ],
       },
       {
+        name: "prepended multiline",
+        targetLine: 1,
+        oldCount: 2,
+        newCount: 4,
+        lines: [
+          { type: "add" as const, content: "- Actions", new_num: 1 },
+          { type: "add" as const, content: "  still needs details", new_num: 2 },
+          { type: "context" as const, content: "- Issues", old_num: 1, new_num: 3 },
+          { type: "context" as const, content: "- Statuses", old_num: 2, new_num: 4 },
+        ],
+      },
+      {
         name: "appended",
         targetLine: 3,
+        oldCount: 2,
+        newCount: 3,
         lines: [
           { type: "context" as const, content: "- Issues", old_num: 1, new_num: 1 },
           { type: "context" as const, content: "- Statuses", old_num: 2, new_num: 2 },
@@ -1047,9 +1063,9 @@ describe("DiffFile", () => {
           hunks: [
             {
               old_start: 1,
-              old_count: 2,
+              old_count: scenario.oldCount,
               new_start: 1,
-              new_count: 3,
+              new_count: scenario.newCount,
               lines: scenario.lines,
             },
           ],
@@ -1143,6 +1159,8 @@ describe("DiffFile", () => {
       {
         name: "first",
         targetLine: 1,
+        oldCount: 3,
+        newCount: 2,
         lines: [
           { type: "delete" as const, content: "- Actions", old_num: 1 },
           { type: "context" as const, content: "- Issues", old_num: 2, new_num: 1 },
@@ -1150,8 +1168,22 @@ describe("DiffFile", () => {
         ],
       },
       {
+        name: "first multiline",
+        targetLine: 1,
+        oldCount: 4,
+        newCount: 2,
+        lines: [
+          { type: "delete" as const, content: "- Actions", old_num: 1 },
+          { type: "delete" as const, content: "  still needs details", old_num: 2 },
+          { type: "context" as const, content: "- Issues", old_num: 3, new_num: 1 },
+          { type: "context" as const, content: "- Statuses", old_num: 4, new_num: 2 },
+        ],
+      },
+      {
         name: "last",
         targetLine: 3,
+        oldCount: 3,
+        newCount: 2,
         lines: [
           { type: "context" as const, content: "- Issues", old_num: 1, new_num: 1 },
           { type: "context" as const, content: "- Statuses", old_num: 2, new_num: 2 },
@@ -1167,9 +1199,9 @@ describe("DiffFile", () => {
           hunks: [
             {
               old_start: 1,
-              old_count: 3,
+              old_count: scenario.oldCount,
               new_start: 1,
-              new_count: 2,
+              new_count: scenario.newCount,
               lines: scenario.lines,
             },
           ],

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -1476,6 +1476,39 @@ describe("DiffFile", () => {
     expect(detailsComment?.previousElementSibling?.textContent).toContain("updated details");
   });
 
+  it("preserves spacing between consecutive markdown rich preview paragraph blocks", async () => {
+    renderDiffFile(
+      makeFile({
+        path: "README.md",
+        old_path: "README.md",
+        hunks: [
+          {
+            old_start: 1,
+            old_count: 3,
+            new_start: 1,
+            new_count: 3,
+            lines: [
+              { type: "context", content: "First paragraph", old_num: 1, new_num: 1 },
+              { type: "context", content: "", old_num: 2, new_num: 2 },
+              { type: "context", content: "Second paragraph", old_num: 3, new_num: 3 },
+            ],
+          },
+        ],
+      }),
+      {
+        richPreview: true,
+        diffHeadSHA: "diff-head",
+      },
+    );
+
+    await waitFor(() => {
+      expect(document.querySelector(".markdown-rich-diff--unified")).toBeTruthy();
+    });
+    const blocks = Array.from(document.querySelectorAll<HTMLElement>(".markdown-rich-diff__anchored-block"));
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]!.classList.contains("markdown-rich-diff__anchored-block--spaced")).toBe(true);
+  });
+
   it("keeps markdown document semantics when review cards are anchored in rich preview", async () => {
     renderDiffFile(
       makeFile({

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -901,6 +901,101 @@ describe("DiffFile", () => {
     expect(comment?.closest(".markdown-rich-diff--unified")).toBeTruthy();
   });
 
+  it("keeps markdown document semantics when review cards are anchored in rich preview", async () => {
+    renderDiffFile(
+      makeFile({
+        path: "README.md",
+        old_path: "README.md",
+        hunks: [
+          {
+            old_start: 1,
+            old_count: 6,
+            new_start: 1,
+            new_count: 7,
+            lines: [
+              { type: "context", content: "- first", old_num: 1, new_num: 1 },
+              { type: "context", content: "", old_num: 2, new_num: 2 },
+              { type: "context", content: "- second", old_num: 3, new_num: 3 },
+              { type: "context", content: "", old_num: 4, new_num: 4 },
+              { type: "context", content: "[ref]: https://example.com", old_num: 5, new_num: 5 },
+              { type: "context", content: "", old_num: 6, new_num: 6 },
+              { type: "add", content: "See [the ref][ref]", new_num: 7 },
+            ],
+          },
+        ],
+      }),
+      {
+        richPreview: true,
+        diffHeadSHA: "diff-head",
+        reviewThreads: [
+          makeReviewThread({
+            path: "README.md",
+            old_path: "README.md",
+            line: 7,
+            new_line: 7,
+            body: "Anchored semantic note",
+            diff_head_sha: "diff-head",
+          }),
+        ],
+      },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Anchored semantic note")).toBeTruthy();
+    });
+    const preview = document.querySelector(".markdown-rich-diff--unified");
+    expect(preview?.querySelectorAll("ul")).toHaveLength(1);
+    expect(preview?.querySelector('a[href="https://example.com"]')?.textContent).toBe("the ref");
+    const comment = document.querySelector("[data-review-thread-id='thread-1']");
+    expect(comment?.previousElementSibling?.classList.contains("markdown-rich-diff__anchored-block")).toBe(true);
+  });
+
+  it("anchors markdown rich preview review cards in the matching split pane", async () => {
+    renderDiffFile(
+      makeFile({
+        path: "README.md",
+        old_path: "README.md",
+        hunks: [
+          {
+            old_start: 1,
+            old_count: 2,
+            new_start: 1,
+            new_count: 3,
+            lines: [
+              { type: "context", content: "## Title", old_num: 1, new_num: 1 },
+              { type: "context", content: "", old_num: 2, new_num: 2 },
+              { type: "add", content: "Added split-pane paragraph", new_num: 3 },
+            ],
+          },
+        ],
+      }),
+      {
+        richPreview: true,
+        viewMode: "split",
+        diffHeadSHA: "diff-head",
+        reviewThreads: [
+          makeReviewThread({
+            path: "README.md",
+            old_path: "README.md",
+            line: 3,
+            new_line: 3,
+            body: "Split pane review note",
+            diff_head_sha: "diff-head",
+          }),
+        ],
+      },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Split pane review note")).toBeTruthy();
+    });
+    const comment = document.querySelector("[data-review-thread-id='thread-1']");
+    expect(comment?.closest('[aria-label="Before markdown preview"]')).toBeNull();
+    expect(comment?.closest('[aria-label="After markdown preview"]')).toBeTruthy();
+    expect(comment?.previousElementSibling?.classList.contains("markdown-rich-diff__anchored-block")).toBe(true);
+    expect(document.querySelector(".preview-shell > .inline-review-thread")).toBeNull();
+  });
+
   it("lets published inline review threads be replied to", async () => {
     const replyToDiscussion = vi.fn().mockResolvedValue(true);
     renderDiffFile(makeFile(), {

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -977,41 +977,6 @@ describe("DiffFile", () => {
     expect(comment?.parentElement?.classList.contains("file-content")).toBe(true);
   });
 
-  it("hides review thread cards while markdown rich preview is active", async () => {
-    const file = makeFile({
-      path: "README.md",
-      old_path: "README.md",
-    });
-    const thread = makeReviewThread({
-      id: "thread-preview-hidden",
-      path: "README.md",
-      line: 99,
-      new_line: 99,
-      body: "Review note should stay out of rich preview",
-    });
-
-    const { unmount } = renderDiffFile(file, {
-      richPreview: true,
-      reviewThreads: [thread],
-    });
-
-    await waitFor(() => {
-      expect(document.querySelector(".markdown-rich-diff--unified")).toBeTruthy();
-    });
-    expect(screen.queryByText("Review note should stay out of rich preview")).toBeNull();
-
-    unmount();
-    renderDiffFile(file, {
-      richPreview: true,
-      richPreviewEnabled: false,
-      reviewThreads: [thread],
-    });
-
-    await waitFor(() => {
-      expect(screen.getByText("Review note should stay out of rich preview")).toBeTruthy();
-    });
-  });
-
   it("clears an open inline composer when review context changes", async () => {
     const file = makeFile();
     const owner = uniqueOwner();

--- a/packages/ui/src/components/diff/DiffReviewThreadInlineComment.svelte
+++ b/packages/ui/src/components/diff/DiffReviewThreadInlineComment.svelte
@@ -74,9 +74,19 @@
   function layoutContainer(element: HTMLElement): HTMLElement | null {
     const root = element.getRootNode();
     if (root instanceof ShadowRoot && root.host instanceof HTMLElement) {
-      return root.host.closest(".file-content") ?? root.host.closest(".diff-area");
+      return closestLayoutContainer(root.host);
     }
-    return element.closest(".file-content") ?? element.closest(".diff-area");
+    return closestLayoutContainer(element);
+  }
+
+  function closestLayoutContainer(element: HTMLElement): HTMLElement | null {
+    return (
+      element.closest(".markdown-rich-diff__pane") ??
+      element.closest(".diff-rich-preview") ??
+      element.closest(".preview-shell") ??
+      element.closest(".file-content") ??
+      element.closest(".diff-area")
+    );
   }
 
   function startReply(): void {

--- a/packages/ui/src/components/diff/DiffReviewThreadInlineComment.test.ts
+++ b/packages/ui/src/components/diff/DiffReviewThreadInlineComment.test.ts
@@ -1,0 +1,81 @@
+import { cleanup, render, waitFor } from "@testing-library/svelte";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import DiffReviewThreadInlineComment from "./DiffReviewThreadInlineComment.svelte";
+import type { ReviewThread } from "./review-thread-context.js";
+
+type GlobalWithResizeObserver = { ResizeObserver?: unknown };
+
+const originalResizeObserver = (globalThis as GlobalWithResizeObserver).ResizeObserver;
+
+class ResizeObserverStub {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+function makeReviewThread(overrides: Partial<ReviewThread> = {}): ReviewThread {
+  return {
+    id: "thread-1",
+    provider_comment_id: "comment-1",
+    path: "README.md",
+    side: "right",
+    line: 2,
+    new_line: 2,
+    line_type: "add",
+    body: "Published review note",
+    author_login: "reviewer",
+    resolved: false,
+    can_resolve: false,
+    created_at: "2026-03-30T14:01:00Z",
+    updated_at: "2026-03-30T14:01:00Z",
+    ...overrides,
+  };
+}
+
+describe("DiffReviewThreadInlineComment", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    if (originalResizeObserver === undefined) {
+      delete (globalThis as GlobalWithResizeObserver).ResizeObserver;
+    } else {
+      (globalThis as GlobalWithResizeObserver).ResizeObserver = originalResizeObserver;
+    }
+  });
+
+  it("sizes rich preview cards to the preview column instead of the whole file content", async () => {
+    (globalThis as GlobalWithResizeObserver).ResizeObserver = ResizeObserverStub;
+    document.body.innerHTML = `
+      <div class="file-content">
+        <div class="diff-rich-preview markdown-rich-diff--unified"></div>
+      </div>
+    `;
+    const preview = document.querySelector<HTMLElement>(".diff-rich-preview");
+    expect(preview).toBeTruthy();
+
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function getBoundingClientRect() {
+      if (this.classList.contains("file-content")) {
+        return { left: 0, right: 1000, width: 1000 } as DOMRect;
+      }
+      if (this.classList.contains("diff-rich-preview")) {
+        return { left: 100, right: 500, width: 400 } as DOMRect;
+      }
+      if (this.classList.contains("inline-review-thread")) {
+        return { left: 112, right: 500, width: 388 } as DOMRect;
+      }
+      return { left: 0, right: 0, width: 0 } as DOMRect;
+    });
+
+    render(DiffReviewThreadInlineComment, {
+      target: preview!,
+      props: {
+        thread: makeReviewThread(),
+      },
+    });
+
+    const card = document.querySelector<HTMLElement>(".inline-review-thread");
+    await waitFor(() => {
+      expect(card?.style.getPropertyValue("--inline-review-thread-width")).toBe("376px");
+    });
+  });
+});

--- a/packages/ui/src/components/diff/DiffRichPreview.svelte
+++ b/packages/ui/src/components/diff/DiffRichPreview.svelte
@@ -51,6 +51,8 @@
     thread: ReviewThread;
     fileLevel: boolean;
   };
+  type DiffHunk = DiffFile["hunks"][number];
+  type DiffHunkLine = DiffHunk["lines"][number];
   type AnchoredMarkdownBlock = MarkdownRichPreviewBlock & {
     leftReviewThreads: ReviewThreadPlacement[];
     rightReviewThreads: ReviewThreadPlacement[];
@@ -203,14 +205,16 @@
       if (threadLineIsFileLevelCard(thread)) continue;
       const side = reviewThreadTargetSide(thread);
       const targetLine = reviewThreadTargetLine(thread);
-      const diffLine = findReviewThreadDiffLine(source, side, targetLine);
-      if (diffLine?.old_num != null) addUniqueLine(splitOldLines, diffLine.old_num);
-      if (diffLine?.new_num != null) addUniqueLine(splitNewLines, diffLine.new_num);
-      if (!diffLine && side === "left") {
+      const match = findReviewThreadDiffLine(source, side, targetLine);
+      if (!match && side === "left") {
         addUniqueLine(splitOldLines, targetLine);
-      } else if (!diffLine) {
+        continue;
+      } else if (!match) {
         addUniqueLine(splitNewLines, targetLine);
+        continue;
       }
+      addDiffLineNumbers(splitOldLines, splitNewLines, match.hunk.lines[match.index]!);
+      addPreviousListBoundaryForChangedLine(splitOldLines, splitNewLines, match.hunk.lines, match.index);
     }
     return {
       splitOldLines,
@@ -226,15 +230,56 @@
     source: DiffFile,
     side: "left" | "right",
     targetLine: number,
-  ): DiffFile["hunks"][number]["lines"][number] | undefined {
+  ): { hunk: DiffHunk; index: number } | undefined {
     for (const hunk of source.hunks ?? []) {
-      const line = hunk.lines.find((candidate) => {
+      const index = hunk.lines.findIndex((candidate) => {
         const lineNumber = side === "left" ? candidate.old_num : candidate.new_num;
         return lineNumber === targetLine;
       });
-      if (line) return line;
+      if (index >= 0) return { hunk, index };
     }
     return undefined;
+  }
+
+  function addDiffLineNumbers(oldLines: number[], newLines: number[], line: DiffHunkLine): void {
+    if (line.old_num != null) addUniqueLine(oldLines, line.old_num);
+    if (line.new_num != null) addUniqueLine(newLines, line.new_num);
+  }
+
+  function addPreviousListBoundaryForChangedLine(
+    oldLines: number[],
+    newLines: number[],
+    lines: DiffHunk["lines"],
+    targetIndex: number,
+  ): void {
+    const target = lines[targetIndex]!;
+    if (target.type !== "add" && target.type !== "delete") return;
+    const targetIndent = listMarkerIndent(target.content);
+    if (targetIndent == null) return;
+
+    const previous = previousListMarkerLine(lines, targetIndex, targetIndent);
+    if (previous) addDiffLineNumbers(oldLines, newLines, previous);
+  }
+
+  function previousListMarkerLine(
+    lines: DiffHunk["lines"],
+    targetIndex: number,
+    targetIndent: number,
+  ): DiffHunkLine | undefined {
+    for (let index = targetIndex - 1; index >= 0; index--) {
+      const line = lines[index]!;
+      if (line.content.trim() === "") continue;
+      const lineIndent = listMarkerIndent(line.content);
+      if (lineIndent == null || lineIndent < targetIndent) return undefined;
+      if (lineIndent === targetIndent) return line;
+    }
+    return undefined;
+  }
+
+  function listMarkerIndent(line: string): number | null {
+    const match = line.match(/^(\s{0,12})(?:[-+*]|\d+[.)])\s+/);
+    if (!match) return null;
+    return Array.from(match[1]!).reduce((width, char) => width + (char === "\t" ? 4 : 1), 0);
   }
 
   function sortReviewThreadPlacements(placements: ReviewThreadPlacement[]): void {
@@ -529,6 +574,19 @@
   }
 
   .markdown-rich-diff :global(.markdown-rich-diff__split-list) {
+    margin: 0;
+  }
+
+  .markdown-rich-diff__anchored-block:has(:global(.markdown-rich-diff__split-list)) {
+    margin: 0;
+  }
+
+  .markdown-rich-diff--unified :global(.markdown-diff__block:has(.markdown-rich-diff__split-list)) {
+    margin: 0;
+    padding-block: 0;
+  }
+
+  .markdown-rich-diff :global(.markdown-rich-diff__split-list > li) {
     margin-block: 0;
   }
 

--- a/packages/ui/src/components/diff/DiffRichPreview.svelte
+++ b/packages/ui/src/components/diff/DiffRichPreview.svelte
@@ -543,7 +543,7 @@
             <div class="markdown-rich-diff__label">Before</div>
             <div class="markdown-body">
               {#each markdownPreview.blocks as block (block.key)}
-                <div class="markdown-rich-diff__anchored-block">
+                <div class="markdown-rich-diff__anchored-block markdown-rich-diff__anchored-block--spaced">
                   {@html block.beforeHtml ?? ""}
                 </div>
                 {#each block.leftReviewThreads as placement (placement.thread.id)}
@@ -564,7 +564,7 @@
             <div class="markdown-rich-diff__label">After</div>
             <div class="markdown-body">
               {#each markdownPreview.blocks as block (block.key)}
-                <div class="markdown-rich-diff__anchored-block">
+                <div class="markdown-rich-diff__anchored-block markdown-rich-diff__anchored-block--spaced">
                   {@html block.afterHtml ?? ""}
                 </div>
                 {#each block.rightReviewThreads as placement (placement.thread.id)}
@@ -582,7 +582,7 @@
       {:else}
         <div class="diff-rich-preview markdown-rich-diff markdown-rich-diff--unified markdown-body">
           {#each markdownPreview.blocks as block (block.key)}
-            <div class="markdown-rich-diff__anchored-block">
+            <div class="markdown-rich-diff__anchored-block markdown-rich-diff__anchored-block--spaced">
               {@html block.unifiedHtml}
             </div>
             {#each block.reviewThreads as placement (placement.thread.id)}
@@ -801,7 +801,15 @@
     margin: 0;
   }
 
-  .markdown-rich-diff__anchored-block:has(:global(.markdown-rich-diff__split-list)) {
+  .markdown-rich-diff__anchored-block--spaced {
+    margin-bottom: 1rem;
+  }
+
+  .markdown-rich-diff__anchored-block--spaced:last-child {
+    margin-bottom: 0;
+  }
+
+  .markdown-rich-diff__anchored-block--spaced:has(:global(.markdown-rich-diff__split-list)) {
     margin: 0;
   }
 

--- a/packages/ui/src/components/diff/DiffRichPreview.svelte
+++ b/packages/ui/src/components/diff/DiffRichPreview.svelte
@@ -217,8 +217,8 @@
         addUniqueLine(splitNewLines, targetLine);
         continue;
       }
-      addDiffLineNumbers(splitOldLines, splitNewLines, match.hunk.lines[match.index]!);
-      addListSplitLinesForChangedLine(splitOldLines, splitNewLines, match.hunk.lines, match.index);
+      addDiffLineNumbers(splitOldLines, splitNewLines, match.lines[match.index]!);
+      addListSplitLinesForChangedLine(splitOldLines, splitNewLines, match.lines, match.index);
     }
     return {
       splitOldLines,
@@ -234,13 +234,14 @@
     source: DiffFile,
     side: "left" | "right",
     targetLine: number,
-  ): { hunk: DiffHunk; index: number } | undefined {
+  ): { lines: DiffHunk["lines"]; index: number } | undefined {
     for (const hunk of source.hunks ?? []) {
-      const index = hunk.lines.findIndex((candidate) => {
+      const lines = hunk.lines ?? [];
+      const index = lines.findIndex((candidate) => {
         const lineNumber = side === "left" ? candidate.old_num : candidate.new_num;
         return lineNumber === targetLine;
       });
-      if (index >= 0) return { hunk, index };
+      if (index >= 0) return { lines, index };
     }
     return undefined;
   }
@@ -788,6 +789,14 @@
   .markdown-rich-diff--unified :global(del.markdown-diff__block) {
     background: var(--diff-del-bg);
     border-color: color-mix(in srgb, var(--diff-del-text) 36%, transparent);
+  }
+
+  .markdown-rich-diff--unified :global(.markdown-diff__structural[data-diff-kind="insert"]) {
+    background: var(--diff-add-bg);
+  }
+
+  .markdown-rich-diff--unified :global(.markdown-diff__structural[data-diff-kind="delete"]) {
+    background: var(--diff-del-bg);
   }
 
   .markdown-rich-diff :global(.markdown-diff__structural > ins:not(.markdown-diff__block)),

--- a/packages/ui/src/components/diff/DiffRichPreview.svelte
+++ b/packages/ui/src/components/diff/DiffRichPreview.svelte
@@ -4,6 +4,12 @@
   import type { DiffViewMode } from "../../stores/diff.svelte.js";
   import { renderMarkdownDiff, renderMarkdownSplitDiff } from "../../utils/markdown-diff.js";
   import { renderMarkdown } from "../../utils/markdown.js";
+  import DiffReviewThreadInlineComment from "./DiffReviewThreadInlineComment.svelte";
+  import {
+    reviewThreadTargetLine,
+    reviewThreadTargetSide,
+    type ReviewThread,
+  } from "./review-thread-context.js";
 
   interface Props {
     file: DiffFile;
@@ -15,15 +21,50 @@
     number: number;
     active: boolean;
     viewMode?: DiffViewMode;
+    reviewThreads?: ReviewThread[];
+    canReplyToThreads?: boolean;
+    reviewThreadIsFileLevelCard?: ((thread: ReviewThread) => boolean) | undefined;
+    onreply?: ((thread: ReviewThread, body: string) => Promise<boolean>) | undefined;
   }
 
-  const { file, provider, platformHost, owner, name, repoPath, number, active, viewMode = "unified" }: Props = $props();
+  const {
+    file,
+    provider,
+    platformHost,
+    owner,
+    name,
+    repoPath,
+    number,
+    active,
+    viewMode = "unified",
+    reviewThreads = [],
+    canReplyToThreads = false,
+    reviewThreadIsFileLevelCard,
+    onreply,
+  }: Props = $props();
   const { diff: diffStore } = getStores();
 
   interface MarkdownComparison {
     diffHtml?: string;
     oldHtml: string;
     newHtml: string;
+  }
+  type SourceLine = DiffFile["hunks"][number]["lines"][number];
+  type MarkdownLineBlock = {
+    key: string;
+    lines: SourceLine[];
+    oldStart?: number | undefined;
+    oldEnd?: number | undefined;
+    newStart?: number | undefined;
+    newEnd?: number | undefined;
+  };
+  type MarkdownRenderedBlock = MarkdownLineBlock & {
+    diffHtml: string;
+    reviewThreads: ReviewThread[];
+  };
+  interface AnchoredMarkdownComparison {
+    blocks: MarkdownRenderedBlock[];
+    unanchoredReviewThreads: ReviewThread[];
   }
 
   let loading = $state(false);
@@ -35,10 +76,18 @@
   const markdownComparison = $derived.by(() =>
     active && isMarkdownFile ? buildMarkdownComparison(file, viewMode) : null,
   );
+  const anchoredMarkdownComparison = $derived.by(() =>
+    active && isMarkdownFile && viewMode !== "split"
+      ? buildAnchoredMarkdownComparison(file, reviewThreads)
+      : null,
+  );
   const text = $derived(preview ? decodeText(preview.content) : "");
   const dataURL = $derived(preview ? `data:${preview.media_type};base64,${preview.content}` : "");
   const kind = $derived(previewKind(file.path, preview?.media_type ?? ""));
   const displayText = $derived(formatText(file.path, text));
+  const fallbackReviewThreads = $derived(
+    anchoredMarkdownComparison?.unanchoredReviewThreads ?? reviewThreads,
+  );
 
   $effect(() => {
     const sourceFile = file;
@@ -132,12 +181,114 @@
       newHtml: splitHtml?.afterHtml ?? newHtml,
     };
   }
+
+  function buildAnchoredMarkdownComparison(
+    source: DiffFile,
+    threads: ReviewThread[],
+  ): AnchoredMarkdownComparison {
+    const blocks: MarkdownRenderedBlock[] = markdownLineBlocks(source).map((block): MarkdownRenderedBlock => {
+      const oldMarkdown = block.lines
+        .filter((line) => line.type !== "add")
+        .map((line) => line.content)
+        .join("\n");
+      const newMarkdown = block.lines
+        .filter((line) => line.type !== "delete")
+        .map((line) => line.content)
+        .join("\n");
+      const repo = { provider, platformHost, owner, name, repoPath };
+      const oldHtml = renderMarkdown(`${oldMarkdown}\n`, repo);
+      const newHtml = renderMarkdown(`${newMarkdown}\n`, repo);
+      return {
+        ...block,
+        diffHtml: renderMarkdownDiff(oldHtml, newHtml),
+        reviewThreads: [],
+      };
+    });
+    const unanchoredReviewThreads: ReviewThread[] = [];
+    for (const thread of threads) {
+      const block = blocks.find((candidate) => blockContainsReviewThread(candidate, thread));
+      if (block) block.reviewThreads.push(thread);
+      else unanchoredReviewThreads.push(thread);
+    }
+    return { blocks, unanchoredReviewThreads };
+  }
+
+  function markdownLineBlocks(source: DiffFile): MarkdownLineBlock[] {
+    const blocks: MarkdownLineBlock[] = [];
+    let current: SourceLine[] = [];
+    let inFence = false;
+    for (const hunk of source.hunks) {
+      if (current.length > 0) {
+        pushMarkdownLineBlock(blocks, current);
+        current = [];
+      }
+      for (const line of hunk.lines) {
+        current.push(line);
+        if (isFenceLine(line.content)) {
+          inFence = !inFence;
+          continue;
+        }
+        if (!inFence && line.content.trim() === "") {
+          pushMarkdownLineBlock(blocks, current);
+          current = [];
+        }
+      }
+    }
+    pushMarkdownLineBlock(blocks, current);
+    return blocks;
+  }
+
+  function isFenceLine(content: string): boolean {
+    return /^\s*(```|~~~)/.test(content);
+  }
+
+  function pushMarkdownLineBlock(blocks: MarkdownLineBlock[], lines: SourceLine[]): void {
+    if (lines.length === 0) return;
+    const oldNumbers = lines.map((line) => line.old_num).filter((line): line is number => line != null);
+    const newNumbers = lines.map((line) => line.new_num).filter((line): line is number => line != null);
+    blocks.push({
+      key: `${blocks.length}:${oldNumbers[0] ?? ""}:${newNumbers[0] ?? ""}`,
+      lines,
+      oldStart: oldNumbers[0],
+      oldEnd: oldNumbers.at(-1),
+      newStart: newNumbers[0],
+      newEnd: newNumbers.at(-1),
+    });
+  }
+
+  function blockContainsReviewThread(block: MarkdownLineBlock, thread: ReviewThread): boolean {
+    if (threadLineIsFileLevelCard(thread)) return false;
+    const line = reviewThreadTargetLine(thread);
+    return reviewThreadTargetSide(thread) === "left"
+      ? lineInRange(line, block.oldStart, block.oldEnd)
+      : lineInRange(line, block.newStart, block.newEnd);
+  }
+
+  function lineInRange(
+    line: number,
+    start: number | undefined,
+    end: number | undefined,
+  ): boolean {
+    return start != null && end != null && line >= start && line <= end;
+  }
+
+  function threadLineIsFileLevelCard(thread: ReviewThread): boolean {
+    return reviewThreadIsFileLevelCard?.(thread) ?? thread.line_type === "file";
+  }
 </script>
 
 <div class="preview-shell">
   {#if isMarkdownFile}
     {#if markdownComparison}
       {#if viewMode === "split"}
+        {#each fallbackReviewThreads as thread (thread.id)}
+          <DiffReviewThreadInlineComment
+            {thread}
+            fileLevel={threadLineIsFileLevelCard(thread)}
+            canReply={canReplyToThreads}
+            {onreply}
+          />
+        {/each}
         <div class="diff-rich-preview markdown-rich-diff markdown-rich-diff--split">
           <div
             class="markdown-rich-diff__pane markdown-rich-diff__block--delete"
@@ -160,7 +311,31 @@
         </div>
       {:else}
         <div class="diff-rich-preview markdown-rich-diff markdown-rich-diff--unified markdown-body">
-          {@html markdownComparison.diffHtml ?? markdownComparison.newHtml}
+          {#if anchoredMarkdownComparison}
+            {#each anchoredMarkdownComparison.unanchoredReviewThreads as thread (thread.id)}
+              <DiffReviewThreadInlineComment
+                {thread}
+                fileLevel={threadLineIsFileLevelCard(thread)}
+                canReply={canReplyToThreads}
+                {onreply}
+              />
+            {/each}
+            {#each anchoredMarkdownComparison.blocks as block (block.key)}
+              <div class="markdown-rich-diff__anchored-block">
+                {@html block.diffHtml}
+              </div>
+              {#each block.reviewThreads as thread (thread.id)}
+                <DiffReviewThreadInlineComment
+                  {thread}
+                  fileLevel={threadLineIsFileLevelCard(thread)}
+                  canReply={canReplyToThreads}
+                  {onreply}
+                />
+              {/each}
+            {/each}
+          {:else}
+            {@html markdownComparison.diffHtml ?? markdownComparison.newHtml}
+          {/if}
         </div>
       {/if}
     {:else}
@@ -171,6 +346,14 @@
   {:else if error}
     <div class="preview-state preview-state--error">{error}</div>
   {:else if preview}
+    {#each fallbackReviewThreads as thread (thread.id)}
+      <DiffReviewThreadInlineComment
+        {thread}
+        fileLevel={threadLineIsFileLevelCard(thread)}
+        canReply={canReplyToThreads}
+        {onreply}
+      />
+    {/each}
     {#if kind === "markdown"}
       <div class="diff-rich-preview markdown-body">
         {@html renderMarkdown(text, { provider, platformHost, owner, name, repoPath })}

--- a/packages/ui/src/components/diff/DiffRichPreview.svelte
+++ b/packages/ui/src/components/diff/DiffRichPreview.svelte
@@ -53,6 +53,10 @@
   };
   type DiffHunk = DiffFile["hunks"][number];
   type DiffHunkLine = DiffHunk["lines"][number];
+  type ChangedListMarker = {
+    index: number;
+    indent: number;
+  };
   type AnchoredMarkdownBlock = MarkdownRichPreviewBlock & {
     leftReviewThreads: ReviewThreadPlacement[];
     rightReviewThreads: ReviewThreadPlacement[];
@@ -214,7 +218,7 @@
         continue;
       }
       addDiffLineNumbers(splitOldLines, splitNewLines, match.hunk.lines[match.index]!);
-      addPreviousListBoundaryForChangedLine(splitOldLines, splitNewLines, match.hunk.lines, match.index);
+      addListSplitLinesForChangedLine(splitOldLines, splitNewLines, match.hunk.lines, match.index);
     }
     return {
       splitOldLines,
@@ -246,7 +250,7 @@
     if (line.new_num != null) addUniqueLine(newLines, line.new_num);
   }
 
-  function addPreviousListBoundaryForChangedLine(
+  function addListSplitLinesForChangedLine(
     oldLines: number[],
     newLines: number[],
     lines: DiffHunk["lines"],
@@ -254,17 +258,20 @@
   ): void {
     const target = lines[targetIndex]!;
     if (target.type !== "add" && target.type !== "delete") return;
-    const targetIndent = changedListMarkerIndent(lines, targetIndex);
-    if (targetIndent == null) return;
+    const marker = changedListMarker(lines, targetIndex);
+    if (!marker) return;
 
-    const boundary = comparableListMarkerLine(lines, targetIndex, targetIndent);
+    const adjacent = adjacentOppositeChangedListMarker(lines, marker);
+    if (adjacent) addDiffLineNumbers(oldLines, newLines, adjacent);
+
+    const boundary = comparableListMarkerLine(lines, targetIndex, marker.indent);
     if (boundary) addDiffLineNumbers(oldLines, newLines, boundary);
   }
 
-  function changedListMarkerIndent(lines: DiffHunk["lines"], targetIndex: number): number | null {
+  function changedListMarker(lines: DiffHunk["lines"], targetIndex: number): ChangedListMarker | null {
     const target = lines[targetIndex]!;
     const targetIndent = listMarkerIndent(target.content);
-    if (targetIndent != null) return targetIndent;
+    if (targetIndent != null) return { index: targetIndex, indent: targetIndent };
 
     let crossedBlank = false;
     for (let index = targetIndex - 1; index >= 0; index--) {
@@ -276,9 +283,110 @@
       }
       const lineIndent = listMarkerIndent(line.content);
       if (lineIndent == null) continue;
-      return isListContinuation(target.content, lineIndent, crossedBlank) ? lineIndent : null;
+      return isListContinuation(target.content, lineIndent, crossedBlank)
+        ? { index, indent: lineIndent }
+        : null;
     }
     return null;
+  }
+
+  function adjacentOppositeChangedListMarker(
+    lines: DiffHunk["lines"],
+    marker: ChangedListMarker,
+  ): DiffHunkLine | undefined {
+    const target = lines[marker.index]!;
+    const oppositeType = target.type === "add" ? "delete" : "add";
+    return (
+      previousAdjacentOppositeChangedListMarker(lines, marker.index, marker.indent, oppositeType) ??
+      nextAdjacentOppositeChangedListMarker(
+        lines,
+        changedListItemEndIndex(lines, marker.index, marker.indent),
+        marker.indent,
+        oppositeType,
+      )
+    );
+  }
+
+  function previousAdjacentOppositeChangedListMarker(
+    lines: DiffHunk["lines"],
+    startIndex: number,
+    targetIndent: number,
+    oppositeType: DiffHunkLine["type"],
+  ): DiffHunkLine | undefined {
+    let crossedBlank = false;
+    for (let index = startIndex - 1; index >= 0; index--) {
+      const line = lines[index]!;
+      if (line.content.trim() === "") {
+        crossedBlank = true;
+        continue;
+      }
+      if (line.type !== oppositeType) return undefined;
+      const lineIndent = listMarkerIndent(line.content);
+      if (lineIndent == null) {
+        if (isListContinuation(line.content, targetIndent, crossedBlank)) continue;
+        return undefined;
+      }
+      if (lineIndent < targetIndent) return undefined;
+      if (lineIndent === targetIndent) return line;
+      crossedBlank = false;
+    }
+    return undefined;
+  }
+
+  function nextAdjacentOppositeChangedListMarker(
+    lines: DiffHunk["lines"],
+    startIndex: number,
+    targetIndent: number,
+    oppositeType: DiffHunkLine["type"],
+  ): DiffHunkLine | undefined {
+    let crossedBlank = false;
+    for (let index = startIndex + 1; index < lines.length; index++) {
+      const line = lines[index]!;
+      if (line.content.trim() === "") {
+        crossedBlank = true;
+        continue;
+      }
+      if (line.type !== oppositeType) return undefined;
+      const lineIndent = listMarkerIndent(line.content);
+      if (lineIndent == null) {
+        if (isListContinuation(line.content, targetIndent, crossedBlank)) continue;
+        return undefined;
+      }
+      if (lineIndent < targetIndent) return undefined;
+      if (lineIndent === targetIndent) return line;
+      crossedBlank = false;
+    }
+    return undefined;
+  }
+
+  function changedListItemEndIndex(
+    lines: DiffHunk["lines"],
+    markerIndex: number,
+    targetIndent: number,
+  ): number {
+    const target = lines[markerIndex]!;
+    let endIndex = markerIndex;
+    let crossedBlank = false;
+    for (let index = markerIndex + 1; index < lines.length; index++) {
+      const line = lines[index]!;
+      if (line.type !== target.type) return endIndex;
+      if (line.content.trim() === "") {
+        endIndex = index;
+        crossedBlank = true;
+        continue;
+      }
+      const lineIndent = listMarkerIndent(line.content);
+      if (lineIndent != null) {
+        if (lineIndent <= targetIndent) return endIndex;
+        endIndex = index;
+        crossedBlank = false;
+        continue;
+      }
+      if (!isListContinuation(line.content, targetIndent, crossedBlank)) return endIndex;
+      endIndex = index;
+      crossedBlank = false;
+    }
+    return endIndex;
   }
 
   function comparableListMarkerLine(

--- a/packages/ui/src/components/diff/DiffRichPreview.svelte
+++ b/packages/ui/src/components/diff/DiffRichPreview.svelte
@@ -537,47 +537,51 @@
       {/each}
       {#if viewMode === "split"}
         <div class="diff-rich-preview markdown-rich-diff markdown-rich-diff--split">
-          <div
-            class="markdown-rich-diff__pane markdown-rich-diff__block--delete"
-            aria-label="Before markdown preview"
-          >
-            <div class="markdown-rich-diff__label">Before</div>
-            <div class="markdown-body">
-              {#each markdownPreview.blocks as block (block.key)}
-                <div class="markdown-rich-diff__anchored-block markdown-rich-diff__anchored-block--spaced">
-                  {@html block.beforeHtml ?? ""}
-                </div>
-                {#each block.leftReviewThreads as placement (placement.thread.id)}
-                  <DiffReviewThreadInlineComment
-                    thread={placement.thread}
-                    fileLevel={placement.fileLevel}
-                    canReply={canReplyToThreads}
-                    {onreply}
-                  />
-                {/each}
-              {/each}
+          <div class="markdown-rich-diff__split-header" aria-hidden="true">
+            <div class="markdown-rich-diff__split-label markdown-rich-diff__label markdown-rich-diff__block--delete">
+              Before
+            </div>
+            <div class="markdown-rich-diff__split-label markdown-rich-diff__label markdown-rich-diff__block--add">
+              After
             </div>
           </div>
-          <div
-            class="markdown-rich-diff__pane markdown-rich-diff__block--add"
-            aria-label="After markdown preview"
-          >
-            <div class="markdown-rich-diff__label">After</div>
-            <div class="markdown-body">
-              {#each markdownPreview.blocks as block (block.key)}
-                <div class="markdown-rich-diff__anchored-block markdown-rich-diff__anchored-block--spaced">
-                  {@html block.afterHtml ?? ""}
+          <div class="markdown-rich-diff__split-rows">
+            {#each markdownPreview.blocks as block (block.key)}
+              <div class="markdown-rich-diff__split-row">
+                <div
+                  class="markdown-rich-diff__pane markdown-rich-diff__block--delete markdown-body"
+                  data-markdown-rich-side="before"
+                >
+                  <div class="markdown-rich-diff__anchored-block markdown-rich-diff__anchored-block--spaced">
+                    {@html block.beforeHtml ?? ""}
+                  </div>
+                  {#each block.leftReviewThreads as placement (placement.thread.id)}
+                    <DiffReviewThreadInlineComment
+                      thread={placement.thread}
+                      fileLevel={placement.fileLevel}
+                      canReply={canReplyToThreads}
+                      {onreply}
+                    />
+                  {/each}
                 </div>
-                {#each block.rightReviewThreads as placement (placement.thread.id)}
-                  <DiffReviewThreadInlineComment
-                    thread={placement.thread}
-                    fileLevel={placement.fileLevel}
-                    canReply={canReplyToThreads}
-                    {onreply}
-                  />
-                {/each}
-              {/each}
-            </div>
+                <div
+                  class="markdown-rich-diff__pane markdown-rich-diff__block--add markdown-body"
+                  data-markdown-rich-side="after"
+                >
+                  <div class="markdown-rich-diff__anchored-block markdown-rich-diff__anchored-block--spaced">
+                    {@html block.afterHtml ?? ""}
+                  </div>
+                  {#each block.rightReviewThreads as placement (placement.thread.id)}
+                    <DiffReviewThreadInlineComment
+                      thread={placement.thread}
+                      fileLevel={placement.fileLevel}
+                      canReply={canReplyToThreads}
+                      {onreply}
+                    />
+                  {/each}
+                </div>
+              </div>
+            {/each}
           </div>
         </div>
       {:else}
@@ -670,11 +674,24 @@
   }
 
   .markdown-rich-diff--split {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    display: flex;
+    flex-direction: column;
     gap: 12px;
     width: 100%;
     max-width: none;
+  }
+
+  .markdown-rich-diff__split-header,
+  .markdown-rich-diff__split-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    gap: 12px;
+  }
+
+  .markdown-rich-diff__split-rows {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
   }
 
   .markdown-rich-diff__pane {
@@ -690,6 +707,13 @@
     font-size: var(--font-size-xs);
     font-weight: 600;
     text-transform: uppercase;
+  }
+
+  .markdown-rich-diff__split-label {
+    margin: 0;
+    padding: 10px 14px;
+    border: 1px solid var(--diff-border);
+    border-radius: 6px;
   }
 
   .markdown-rich-diff__block--add {

--- a/packages/ui/src/components/diff/DiffRichPreview.svelte
+++ b/packages/ui/src/components/diff/DiffRichPreview.svelte
@@ -184,7 +184,34 @@
         block.rightReviewThreads.push(placement);
       }
     }
+    sortReviewThreadPlacements(fallbackReviewThreads);
+    for (const block of blocks) {
+      sortReviewThreadPlacements(block.reviewThreads);
+      sortReviewThreadPlacements(block.leftReviewThreads);
+      sortReviewThreadPlacements(block.rightReviewThreads);
+    }
     return { blocks, fallbackReviewThreads };
+  }
+
+  function sortReviewThreadPlacements(placements: ReviewThreadPlacement[]): void {
+    placements.sort(compareReviewThreadPlacements);
+  }
+
+  function compareReviewThreadPlacements(
+    left: ReviewThreadPlacement,
+    right: ReviewThreadPlacement,
+  ): number {
+    const lineDelta = reviewThreadTargetLine(left.thread) - reviewThreadTargetLine(right.thread);
+    if (lineDelta !== 0) return lineDelta;
+    const sideDelta = sideSortValue(left.thread) - sideSortValue(right.thread);
+    if (sideDelta !== 0) return sideDelta;
+    const createdAtDelta = Date.parse(left.thread.created_at) - Date.parse(right.thread.created_at);
+    if (!Number.isNaN(createdAtDelta) && createdAtDelta !== 0) return createdAtDelta;
+    return left.thread.id.localeCompare(right.thread.id);
+  }
+
+  function sideSortValue(thread: ReviewThread): number {
+    return reviewThreadTargetSide(thread) === "left" ? 0 : 1;
   }
 
   function blockContainsReviewThread(block: MarkdownRichPreviewBlock, thread: ReviewThread): boolean {

--- a/packages/ui/src/components/diff/DiffRichPreview.svelte
+++ b/packages/ui/src/components/diff/DiffRichPreview.svelte
@@ -858,7 +858,8 @@
   }
 
   @media (max-width: 760px) {
-    .markdown-rich-diff--split {
+    .markdown-rich-diff__split-header,
+    .markdown-rich-diff__split-row {
       grid-template-columns: minmax(0, 1fr);
     }
   }

--- a/packages/ui/src/components/diff/DiffRichPreview.svelte
+++ b/packages/ui/src/components/diff/DiffRichPreview.svelte
@@ -281,7 +281,11 @@
       const line = lines[index]!;
       if (line.content.trim() === "") continue;
       const lineIndent = listMarkerIndent(line.content);
-      if (lineIndent == null || lineIndent < targetIndent) return undefined;
+      if (lineIndent == null) {
+        if (isIndentedListContinuation(line.content, targetIndent)) continue;
+        return undefined;
+      }
+      if (lineIndent < targetIndent) return undefined;
       if (lineIndent === targetIndent && line.old_num != null && line.new_num != null) return line;
     }
     return undefined;
@@ -296,16 +300,29 @@
       const line = lines[index]!;
       if (line.content.trim() === "") continue;
       const lineIndent = listMarkerIndent(line.content);
-      if (lineIndent == null || lineIndent < targetIndent) return undefined;
+      if (lineIndent == null) {
+        if (isIndentedListContinuation(line.content, targetIndent)) continue;
+        return undefined;
+      }
+      if (lineIndent < targetIndent) return undefined;
       if (lineIndent === targetIndent && line.old_num != null && line.new_num != null) return line;
     }
     return undefined;
   }
 
+  function isIndentedListContinuation(line: string, targetIndent: number): boolean {
+    const match = line.match(/^(\s*)/);
+    return indentationWidth(match?.[1] ?? "") > targetIndent;
+  }
+
   function listMarkerIndent(line: string): number | null {
     const match = line.match(/^(\s{0,12})(?:[-+*]|\d+[.)])\s+/);
     if (!match) return null;
-    return Array.from(match[1]!).reduce((width, char) => width + (char === "\t" ? 4 : 1), 0);
+    return indentationWidth(match[1]!);
+  }
+
+  function indentationWidth(value: string): number {
+    return Array.from(value).reduce((width, char) => width + (char === "\t" ? 4 : 1), 0);
   }
 
   function sortReviewThreadPlacements(placements: ReviewThreadPlacement[]): void {
@@ -552,13 +569,31 @@
 
   .markdown-rich-diff--split :global(ins),
   .markdown-rich-diff--split :global(del) {
-    color: inherit;
-    background: transparent;
+    color: var(--text-primary);
     text-decoration: none;
   }
 
   .markdown-rich-diff--split :global(.markdown-diff__block) {
     display: block;
+  }
+
+  .markdown-rich-diff--split :global(ins:not(.markdown-diff__block)),
+  .markdown-rich-diff--split :global(del:not(.markdown-diff__block)) {
+    padding: 0 0.16em;
+    border-radius: 3px;
+  }
+
+  .markdown-rich-diff--split :global(ins:not(.markdown-diff__block)) {
+    background: color-mix(in srgb, var(--diff-add-bg) 78%, transparent);
+  }
+
+  .markdown-rich-diff--split :global(del:not(.markdown-diff__block)) {
+    background: color-mix(in srgb, var(--diff-del-bg) 80%, transparent);
+  }
+
+  .markdown-rich-diff--split :global(ins.markdown-diff__block),
+  .markdown-rich-diff--split :global(del.markdown-diff__block) {
+    background: transparent;
   }
 
   .markdown-rich-diff--unified {

--- a/packages/ui/src/components/diff/DiffRichPreview.svelte
+++ b/packages/ui/src/components/diff/DiffRichPreview.svelte
@@ -2,8 +2,11 @@
   import type { DiffFile, FilePreview } from "../../api/types.js";
   import { getStores } from "../../context.js";
   import type { DiffViewMode } from "../../stores/diff.svelte.js";
-  import { renderMarkdownDiff, renderMarkdownSplitDiff } from "../../utils/markdown-diff.js";
   import { renderMarkdown } from "../../utils/markdown.js";
+  import {
+    buildMarkdownRichPreview,
+    type MarkdownRichPreviewBlock,
+  } from "../../utils/markdown-rich-preview.js";
   import DiffReviewThreadInlineComment from "./DiffReviewThreadInlineComment.svelte";
   import {
     reviewThreadTargetLine,
@@ -23,7 +26,7 @@
     viewMode?: DiffViewMode;
     reviewThreads?: ReviewThread[];
     canReplyToThreads?: boolean;
-    reviewThreadIsFileLevelCard?: ((thread: ReviewThread) => boolean) | undefined;
+    diffHeadSHA?: string | undefined;
     onreply?: ((thread: ReviewThread, body: string) => Promise<boolean>) | undefined;
   }
 
@@ -39,32 +42,23 @@
     viewMode = "unified",
     reviewThreads = [],
     canReplyToThreads = false,
-    reviewThreadIsFileLevelCard,
+    diffHeadSHA,
     onreply,
   }: Props = $props();
   const { diff: diffStore } = getStores();
 
-  interface MarkdownComparison {
-    diffHtml?: string;
-    oldHtml: string;
-    newHtml: string;
-  }
-  type SourceLine = DiffFile["hunks"][number]["lines"][number];
-  type MarkdownLineBlock = {
-    key: string;
-    lines: SourceLine[];
-    oldStart?: number | undefined;
-    oldEnd?: number | undefined;
-    newStart?: number | undefined;
-    newEnd?: number | undefined;
+  type ReviewThreadPlacement = {
+    thread: ReviewThread;
+    fileLevel: boolean;
   };
-  type MarkdownRenderedBlock = MarkdownLineBlock & {
-    diffHtml: string;
-    reviewThreads: ReviewThread[];
+  type AnchoredMarkdownBlock = MarkdownRichPreviewBlock & {
+    leftReviewThreads: ReviewThreadPlacement[];
+    rightReviewThreads: ReviewThreadPlacement[];
+    reviewThreads: ReviewThreadPlacement[];
   };
-  interface AnchoredMarkdownComparison {
-    blocks: MarkdownRenderedBlock[];
-    unanchoredReviewThreads: ReviewThread[];
+  interface AnchoredMarkdownPreview {
+    blocks: AnchoredMarkdownBlock[];
+    fallbackReviewThreads: ReviewThreadPlacement[];
   }
 
   let loading = $state(false);
@@ -73,20 +67,16 @@
   let requestVersion = 0;
 
   const isMarkdownFile = $derived(isMarkdownPath(file.path));
-  const markdownComparison = $derived.by(() =>
-    active && isMarkdownFile ? buildMarkdownComparison(file, viewMode) : null,
-  );
-  const anchoredMarkdownComparison = $derived.by(() =>
-    active && isMarkdownFile && viewMode !== "split"
-      ? buildAnchoredMarkdownComparison(file, reviewThreads)
-      : null,
+  const markdownPreview = $derived.by(() =>
+    active && isMarkdownFile ? buildAnchoredMarkdownPreview(file, reviewThreads) : null,
   );
   const text = $derived(preview ? decodeText(preview.content) : "");
   const dataURL = $derived(preview ? `data:${preview.media_type};base64,${preview.content}` : "");
   const kind = $derived(previewKind(file.path, preview?.media_type ?? ""));
   const displayText = $derived(formatText(file.path, text));
-  const fallbackReviewThreads = $derived(
-    anchoredMarkdownComparison?.unanchoredReviewThreads ?? reviewThreads,
+  const fallbackReviewThreads = $derived<ReviewThreadPlacement[]>(
+    markdownPreview?.fallbackReviewThreads ??
+      reviewThreads.map((thread) => ({ thread, fileLevel: threadLineIsFileLevelCard(thread) })),
   );
 
   $effect(() => {
@@ -158,105 +148,46 @@
     }
   }
 
-  function buildMarkdownComparison(source: DiffFile, mode: DiffViewMode): MarkdownComparison {
-    const oldLines: string[] = [];
-    const newLines: string[] = [];
-    for (const hunk of source.hunks) {
-      if (oldLines.length > 0 || newLines.length > 0) {
-        oldLines.push("", "---", "");
-        newLines.push("", "---", "");
-      }
-      for (const line of hunk.lines) {
-        if (line.type !== "add") oldLines.push(line.content);
-        if (line.type !== "delete") newLines.push(line.content);
-      }
-    }
-    const repo = { provider, platformHost, owner, name, repoPath };
-    const oldHtml = renderMarkdown(`${oldLines.join("\n")}\n`, repo);
-    const newHtml = renderMarkdown(`${newLines.join("\n")}\n`, repo);
-    const splitHtml = mode === "split" ? renderMarkdownSplitDiff(oldHtml, newHtml) : null;
-    return {
-      ...(mode === "split" ? {} : { diffHtml: renderMarkdownDiff(oldHtml, newHtml) }),
-      oldHtml: splitHtml?.beforeHtml ?? oldHtml,
-      newHtml: splitHtml?.afterHtml ?? newHtml,
-    };
-  }
-
-  function buildAnchoredMarkdownComparison(
+  function buildAnchoredMarkdownPreview(
     source: DiffFile,
     threads: ReviewThread[],
-  ): AnchoredMarkdownComparison {
-    const blocks: MarkdownRenderedBlock[] = markdownLineBlocks(source).map((block): MarkdownRenderedBlock => {
-      const oldMarkdown = block.lines
-        .filter((line) => line.type !== "add")
-        .map((line) => line.content)
-        .join("\n");
-      const newMarkdown = block.lines
-        .filter((line) => line.type !== "delete")
-        .map((line) => line.content)
-        .join("\n");
-      const repo = { provider, platformHost, owner, name, repoPath };
-      const oldHtml = renderMarkdown(`${oldMarkdown}\n`, repo);
-      const newHtml = renderMarkdown(`${newMarkdown}\n`, repo);
-      return {
-        ...block,
-        diffHtml: renderMarkdownDiff(oldHtml, newHtml),
-        reviewThreads: [],
-      };
-    });
-    const unanchoredReviewThreads: ReviewThread[] = [];
+  ): AnchoredMarkdownPreview {
+    const blocks: AnchoredMarkdownBlock[] = buildMarkdownRichPreview(source, {
+      provider,
+      platformHost,
+      owner,
+      name,
+      repoPath,
+    }).blocks.map((block) => ({
+      ...block,
+      leftReviewThreads: [],
+      rightReviewThreads: [],
+      reviewThreads: [],
+    }));
+    const fallbackReviewThreads: ReviewThreadPlacement[] = [];
     for (const thread of threads) {
+      const fileLevel = threadLineIsFileLevelCard(thread);
+      if (fileLevel) {
+        fallbackReviewThreads.push({ thread, fileLevel });
+        continue;
+      }
       const block = blocks.find((candidate) => blockContainsReviewThread(candidate, thread));
-      if (block) block.reviewThreads.push(thread);
-      else unanchoredReviewThreads.push(thread);
-    }
-    return { blocks, unanchoredReviewThreads };
-  }
-
-  function markdownLineBlocks(source: DiffFile): MarkdownLineBlock[] {
-    const blocks: MarkdownLineBlock[] = [];
-    let current: SourceLine[] = [];
-    let inFence = false;
-    for (const hunk of source.hunks) {
-      if (current.length > 0) {
-        pushMarkdownLineBlock(blocks, current);
-        current = [];
+      if (!block) {
+        fallbackReviewThreads.push({ thread, fileLevel });
+        continue;
       }
-      for (const line of hunk.lines) {
-        current.push(line);
-        if (isFenceLine(line.content)) {
-          inFence = !inFence;
-          continue;
-        }
-        if (!inFence && line.content.trim() === "") {
-          pushMarkdownLineBlock(blocks, current);
-          current = [];
-        }
+      const placement = { thread, fileLevel };
+      block.reviewThreads.push(placement);
+      if (reviewThreadTargetSide(thread) === "left") {
+        block.leftReviewThreads.push(placement);
+      } else {
+        block.rightReviewThreads.push(placement);
       }
     }
-    pushMarkdownLineBlock(blocks, current);
-    return blocks;
+    return { blocks, fallbackReviewThreads };
   }
 
-  function isFenceLine(content: string): boolean {
-    return /^\s*(```|~~~)/.test(content);
-  }
-
-  function pushMarkdownLineBlock(blocks: MarkdownLineBlock[], lines: SourceLine[]): void {
-    if (lines.length === 0) return;
-    const oldNumbers = lines.map((line) => line.old_num).filter((line): line is number => line != null);
-    const newNumbers = lines.map((line) => line.new_num).filter((line): line is number => line != null);
-    blocks.push({
-      key: `${blocks.length}:${oldNumbers[0] ?? ""}:${newNumbers[0] ?? ""}`,
-      lines,
-      oldStart: oldNumbers[0],
-      oldEnd: oldNumbers.at(-1),
-      newStart: newNumbers[0],
-      newEnd: newNumbers.at(-1),
-    });
-  }
-
-  function blockContainsReviewThread(block: MarkdownLineBlock, thread: ReviewThread): boolean {
+  function blockContainsReviewThread(block: MarkdownRichPreviewBlock, thread: ReviewThread): boolean {
     if (threadLineIsFileLevelCard(thread)) return false;
     const line = reviewThreadTargetLine(thread);
     return reviewThreadTargetSide(thread) === "left"
@@ -273,22 +204,26 @@
   }
 
   function threadLineIsFileLevelCard(thread: ReviewThread): boolean {
-    return reviewThreadIsFileLevelCard?.(thread) ?? thread.line_type === "file";
+    return thread.line_type === "file" || !threadMatchesCurrentDiff(thread);
+  }
+
+  function threadMatchesCurrentDiff(thread: ReviewThread): boolean {
+    return !thread.diff_head_sha || !diffHeadSHA || thread.diff_head_sha === diffHeadSHA;
   }
 </script>
 
 <div class="preview-shell">
   {#if isMarkdownFile}
-    {#if markdownComparison}
+    {#if markdownPreview}
+      {#each fallbackReviewThreads as placement (placement.thread.id)}
+        <DiffReviewThreadInlineComment
+          thread={placement.thread}
+          fileLevel={placement.fileLevel}
+          canReply={canReplyToThreads}
+          {onreply}
+        />
+      {/each}
       {#if viewMode === "split"}
-        {#each fallbackReviewThreads as thread (thread.id)}
-          <DiffReviewThreadInlineComment
-            {thread}
-            fileLevel={threadLineIsFileLevelCard(thread)}
-            canReply={canReplyToThreads}
-            {onreply}
-          />
-        {/each}
         <div class="diff-rich-preview markdown-rich-diff markdown-rich-diff--split">
           <div
             class="markdown-rich-diff__pane markdown-rich-diff__block--delete"
@@ -296,7 +231,19 @@
           >
             <div class="markdown-rich-diff__label">Before</div>
             <div class="markdown-body">
-              {@html markdownComparison.oldHtml}
+              {#each markdownPreview.blocks as block (block.key)}
+                <div class="markdown-rich-diff__anchored-block">
+                  {@html block.beforeHtml ?? ""}
+                </div>
+                {#each block.leftReviewThreads as placement (placement.thread.id)}
+                  <DiffReviewThreadInlineComment
+                    thread={placement.thread}
+                    fileLevel={placement.fileLevel}
+                    canReply={canReplyToThreads}
+                    {onreply}
+                  />
+                {/each}
+              {/each}
             </div>
           </div>
           <div
@@ -305,37 +252,37 @@
           >
             <div class="markdown-rich-diff__label">After</div>
             <div class="markdown-body">
-              {@html markdownComparison.newHtml}
+              {#each markdownPreview.blocks as block (block.key)}
+                <div class="markdown-rich-diff__anchored-block">
+                  {@html block.afterHtml ?? ""}
+                </div>
+                {#each block.rightReviewThreads as placement (placement.thread.id)}
+                  <DiffReviewThreadInlineComment
+                    thread={placement.thread}
+                    fileLevel={placement.fileLevel}
+                    canReply={canReplyToThreads}
+                    {onreply}
+                  />
+                {/each}
+              {/each}
             </div>
           </div>
         </div>
       {:else}
         <div class="diff-rich-preview markdown-rich-diff markdown-rich-diff--unified markdown-body">
-          {#if anchoredMarkdownComparison}
-            {#each anchoredMarkdownComparison.unanchoredReviewThreads as thread (thread.id)}
+          {#each markdownPreview.blocks as block (block.key)}
+            <div class="markdown-rich-diff__anchored-block">
+              {@html block.unifiedHtml}
+            </div>
+            {#each block.reviewThreads as placement (placement.thread.id)}
               <DiffReviewThreadInlineComment
-                {thread}
-                fileLevel={threadLineIsFileLevelCard(thread)}
+                thread={placement.thread}
+                fileLevel={placement.fileLevel}
                 canReply={canReplyToThreads}
                 {onreply}
               />
             {/each}
-            {#each anchoredMarkdownComparison.blocks as block (block.key)}
-              <div class="markdown-rich-diff__anchored-block">
-                {@html block.diffHtml}
-              </div>
-              {#each block.reviewThreads as thread (thread.id)}
-                <DiffReviewThreadInlineComment
-                  {thread}
-                  fileLevel={threadLineIsFileLevelCard(thread)}
-                  canReply={canReplyToThreads}
-                  {onreply}
-                />
-              {/each}
-            {/each}
-          {:else}
-            {@html markdownComparison.diffHtml ?? markdownComparison.newHtml}
-          {/if}
+          {/each}
         </div>
       {/if}
     {:else}
@@ -346,10 +293,10 @@
   {:else if error}
     <div class="preview-state preview-state--error">{error}</div>
   {:else if preview}
-    {#each fallbackReviewThreads as thread (thread.id)}
+    {#each fallbackReviewThreads as placement (placement.thread.id)}
       <DiffReviewThreadInlineComment
-        {thread}
-        fileLevel={threadLineIsFileLevelCard(thread)}
+        thread={placement.thread}
+        fileLevel={placement.fileLevel}
         canReply={canReplyToThreads}
         {onreply}
       />
@@ -450,37 +397,25 @@
     pointer-events: none;
   }
 
-  .markdown-rich-diff__block--delete :global(p),
-  .markdown-rich-diff__block--delete :global(li),
-  .markdown-rich-diff__block--delete :global(h1),
-  .markdown-rich-diff__block--delete :global(h2),
-  .markdown-rich-diff__block--delete :global(h3),
-  .markdown-rich-diff__block--delete :global(h4),
-  .markdown-rich-diff__block--delete :global(h5),
-  .markdown-rich-diff__block--delete :global(h6) {
-    text-decoration: line-through;
-    text-decoration-color: color-mix(in srgb, var(--diff-del-text) 70%, transparent);
-  }
-
   .markdown-rich-diff--unified {
     max-width: 920px;
   }
 
-  .markdown-rich-diff--unified :global(ins),
-  .markdown-rich-diff--unified :global(del) {
+  .markdown-rich-diff--unified :global(ins:not(.markdown-diff__block)),
+  .markdown-rich-diff--unified :global(del:not(.markdown-diff__block)) {
     padding: 0 0.16em;
     border-radius: 3px;
     text-decoration-thickness: 1px;
     text-underline-offset: 0.12em;
   }
 
-  .markdown-rich-diff--unified :global(ins) {
+  .markdown-rich-diff--unified :global(ins:not(.markdown-diff__block)) {
     color: var(--text-primary);
     background: color-mix(in srgb, var(--diff-add-bg) 80%, transparent);
     text-decoration-color: color-mix(in srgb, var(--diff-add-text) 65%, transparent);
   }
 
-  .markdown-rich-diff--unified :global(del) {
+  .markdown-rich-diff--unified :global(del:not(.markdown-diff__block)) {
     color: var(--text-primary);
     background: color-mix(in srgb, var(--diff-del-bg) 82%, transparent);
     text-decoration-color: color-mix(in srgb, var(--diff-del-text) 70%, transparent);
@@ -491,6 +426,7 @@
     margin: 0.55rem 0;
     padding: 0.45rem 0.6rem;
     border: 1px solid transparent;
+    text-decoration: none;
   }
 
   .markdown-rich-diff--unified :global(ins.markdown-diff__block) {
@@ -499,6 +435,13 @@
 
   .markdown-rich-diff--unified :global(del.markdown-diff__block) {
     border-color: color-mix(in srgb, var(--diff-del-text) 36%, transparent);
+  }
+
+  .markdown-rich-diff :global(.markdown-diff__structural > ins),
+  .markdown-rich-diff :global(.markdown-diff__structural > del) {
+    padding: 0;
+    background: transparent;
+    text-decoration: none;
   }
 
   @media (max-width: 760px) {

--- a/packages/ui/src/components/diff/DiffRichPreview.svelte
+++ b/packages/ui/src/components/diff/DiffRichPreview.svelte
@@ -190,9 +190,20 @@
   function blockContainsReviewThread(block: MarkdownRichPreviewBlock, thread: ReviewThread): boolean {
     if (threadLineIsFileLevelCard(thread)) return false;
     const line = reviewThreadTargetLine(thread);
-    return reviewThreadTargetSide(thread) === "left"
-      ? lineInRange(line, block.oldStart, block.oldEnd)
-      : lineInRange(line, block.newStart, block.newEnd);
+    if (reviewThreadTargetSide(thread) === "left") {
+      return lineInMappedBlock(line, block.oldLines, block.oldStart, block.oldEnd);
+    }
+    return lineInMappedBlock(line, block.newLines, block.newStart, block.newEnd);
+  }
+
+  function lineInMappedBlock(
+    line: number,
+    mappedLines: number[] | undefined,
+    start: number | undefined,
+    end: number | undefined,
+  ): boolean {
+    if (mappedLines?.length) return mappedLines.includes(line);
+    return lineInRange(line, start, end);
   }
 
   function lineInRange(
@@ -430,15 +441,17 @@
   }
 
   .markdown-rich-diff--unified :global(ins.markdown-diff__block) {
+    background: var(--diff-add-bg);
     border-color: color-mix(in srgb, var(--diff-add-text) 32%, transparent);
   }
 
   .markdown-rich-diff--unified :global(del.markdown-diff__block) {
+    background: var(--diff-del-bg);
     border-color: color-mix(in srgb, var(--diff-del-text) 36%, transparent);
   }
 
-  .markdown-rich-diff :global(.markdown-diff__structural > ins),
-  .markdown-rich-diff :global(.markdown-diff__structural > del) {
+  .markdown-rich-diff :global(.markdown-diff__structural > ins:not(.markdown-diff__block)),
+  .markdown-rich-diff :global(.markdown-diff__structural > del:not(.markdown-diff__block)) {
     padding: 0;
     background: transparent;
     text-decoration: none;

--- a/packages/ui/src/components/diff/DiffRichPreview.svelte
+++ b/packages/ui/src/components/diff/DiffRichPreview.svelte
@@ -550,6 +550,7 @@
               <div class="markdown-rich-diff__split-row">
                 <div
                   class="markdown-rich-diff__pane markdown-rich-diff__block--delete markdown-body"
+                  aria-label="Before markdown preview"
                   data-markdown-rich-side="before"
                 >
                   <div class="markdown-rich-diff__anchored-block markdown-rich-diff__anchored-block--spaced">
@@ -566,6 +567,7 @@
                 </div>
                 <div
                   class="markdown-rich-diff__pane markdown-rich-diff__block--add markdown-body"
+                  aria-label="After markdown preview"
                   data-markdown-rich-side="after"
                 >
                   <div class="markdown-rich-diff__anchored-block markdown-rich-diff__anchored-block--spaced">

--- a/packages/ui/src/components/diff/DiffRichPreview.svelte
+++ b/packages/ui/src/components/diff/DiffRichPreview.svelte
@@ -254,11 +254,31 @@
   ): void {
     const target = lines[targetIndex]!;
     if (target.type !== "add" && target.type !== "delete") return;
-    const targetIndent = listMarkerIndent(target.content);
+    const targetIndent = changedListMarkerIndent(lines, targetIndex);
     if (targetIndent == null) return;
 
     const boundary = comparableListMarkerLine(lines, targetIndex, targetIndent);
     if (boundary) addDiffLineNumbers(oldLines, newLines, boundary);
+  }
+
+  function changedListMarkerIndent(lines: DiffHunk["lines"], targetIndex: number): number | null {
+    const target = lines[targetIndex]!;
+    const targetIndent = listMarkerIndent(target.content);
+    if (targetIndent != null) return targetIndent;
+
+    let crossedBlank = false;
+    for (let index = targetIndex - 1; index >= 0; index--) {
+      const line = lines[index]!;
+      if (line.type !== target.type) return null;
+      if (line.content.trim() === "") {
+        crossedBlank = true;
+        continue;
+      }
+      const lineIndent = listMarkerIndent(line.content);
+      if (lineIndent == null) continue;
+      return isListContinuation(target.content, lineIndent, crossedBlank) ? lineIndent : null;
+    }
+    return null;
   }
 
   function comparableListMarkerLine(
@@ -469,11 +489,7 @@
     {:else}
       <div class="preview-state">Loading preview</div>
     {/if}
-  {:else if loading}
-    <div class="preview-state">Loading preview</div>
-  {:else if error}
-    <div class="preview-state preview-state--error">{error}</div>
-  {:else if preview}
+  {:else}
     {#each fallbackReviewThreads as placement (placement.thread.id)}
       <DiffReviewThreadInlineComment
         thread={placement.thread}
@@ -482,27 +498,35 @@
         {onreply}
       />
     {/each}
-    {#if kind === "markdown"}
-      <div class="diff-rich-preview markdown-body">
-        {@html renderMarkdown(text, { provider, platformHost, owner, name, repoPath })}
-      </div>
-    {:else if kind === "image"}
-      <div class="diff-image-preview">
-        <img src={dataURL} alt={file.path} />
-      </div>
-    {:else if kind === "pdf"}
-      <object
-        class="diff-object-preview"
-        data={dataURL}
-        type={preview.media_type}
-        aria-label={`${file.path} preview`}
-      >
-        <a href={dataURL}>Open PDF preview</a>
-      </object>
-    {:else if kind === "text"}
-      <pre class="diff-text-preview">{displayText}</pre>
+    {#if loading}
+      <div class="preview-state">Loading preview</div>
+    {:else if error}
+      <div class="preview-state preview-state--error">{error}</div>
+    {:else if preview}
+      {#if kind === "markdown"}
+        <div class="diff-rich-preview markdown-body">
+          {@html renderMarkdown(text, { provider, platformHost, owner, name, repoPath })}
+        </div>
+      {:else if kind === "image"}
+        <div class="diff-image-preview">
+          <img src={dataURL} alt={file.path} />
+        </div>
+      {:else if kind === "pdf"}
+        <object
+          class="diff-object-preview"
+          data={dataURL}
+          type={preview.media_type}
+          aria-label={`${file.path} preview`}
+        >
+          <a href={dataURL}>Open PDF preview</a>
+        </object>
+      {:else if kind === "text"}
+        <pre class="diff-text-preview">{displayText}</pre>
+      {:else}
+        <div class="preview-state">No rich preview for {preview.media_type}</div>
+      {/if}
     {:else}
-      <div class="preview-state">No rich preview for {preview.media_type}</div>
+      <div class="preview-state">Loading preview</div>
     {/if}
   {/if}
 </div>

--- a/packages/ui/src/components/diff/DiffRichPreview.svelte
+++ b/packages/ui/src/components/diff/DiffRichPreview.svelte
@@ -257,11 +257,22 @@
     const targetIndent = listMarkerIndent(target.content);
     if (targetIndent == null) return;
 
-    const previous = previousListMarkerLine(lines, targetIndex, targetIndent);
-    if (previous) addDiffLineNumbers(oldLines, newLines, previous);
+    const boundary = comparableListMarkerLine(lines, targetIndex, targetIndent);
+    if (boundary) addDiffLineNumbers(oldLines, newLines, boundary);
   }
 
-  function previousListMarkerLine(
+  function comparableListMarkerLine(
+    lines: DiffHunk["lines"],
+    targetIndex: number,
+    targetIndent: number,
+  ): DiffHunkLine | undefined {
+    return (
+      previousComparableListMarkerLine(lines, targetIndex, targetIndent) ??
+      nextComparableListMarkerLine(lines, targetIndex, targetIndent)
+    );
+  }
+
+  function previousComparableListMarkerLine(
     lines: DiffHunk["lines"],
     targetIndex: number,
     targetIndent: number,
@@ -271,7 +282,22 @@
       if (line.content.trim() === "") continue;
       const lineIndent = listMarkerIndent(line.content);
       if (lineIndent == null || lineIndent < targetIndent) return undefined;
-      if (lineIndent === targetIndent) return line;
+      if (lineIndent === targetIndent && line.old_num != null && line.new_num != null) return line;
+    }
+    return undefined;
+  }
+
+  function nextComparableListMarkerLine(
+    lines: DiffHunk["lines"],
+    targetIndex: number,
+    targetIndent: number,
+  ): DiffHunkLine | undefined {
+    for (let index = targetIndex + 1; index < lines.length; index++) {
+      const line = lines[index]!;
+      if (line.content.trim() === "") continue;
+      const lineIndent = listMarkerIndent(line.content);
+      if (lineIndent == null || lineIndent < targetIndent) return undefined;
+      if (lineIndent === targetIndent && line.old_num != null && line.new_num != null) return line;
     }
     return undefined;
   }
@@ -522,6 +548,17 @@
   .markdown-rich-diff--split :global(.markdown-diff__placeholder) {
     visibility: hidden;
     pointer-events: none;
+  }
+
+  .markdown-rich-diff--split :global(ins),
+  .markdown-rich-diff--split :global(del) {
+    color: inherit;
+    background: transparent;
+    text-decoration: none;
+  }
+
+  .markdown-rich-diff--split :global(.markdown-diff__block) {
+    display: block;
   }
 
   .markdown-rich-diff--unified {

--- a/packages/ui/src/components/diff/DiffRichPreview.svelte
+++ b/packages/ui/src/components/diff/DiffRichPreview.svelte
@@ -277,16 +277,21 @@
     targetIndex: number,
     targetIndent: number,
   ): DiffHunkLine | undefined {
+    let crossedBlank = false;
     for (let index = targetIndex - 1; index >= 0; index--) {
       const line = lines[index]!;
-      if (line.content.trim() === "") continue;
+      if (line.content.trim() === "") {
+        crossedBlank = true;
+        continue;
+      }
       const lineIndent = listMarkerIndent(line.content);
       if (lineIndent == null) {
-        if (isIndentedListContinuation(line.content, targetIndent)) continue;
+        if (isListContinuation(line.content, targetIndent, crossedBlank)) continue;
         return undefined;
       }
       if (lineIndent < targetIndent) return undefined;
       if (lineIndent === targetIndent && line.old_num != null && line.new_num != null) return line;
+      crossedBlank = false;
     }
     return undefined;
   }
@@ -296,23 +301,29 @@
     targetIndex: number,
     targetIndent: number,
   ): DiffHunkLine | undefined {
+    let crossedBlank = false;
     for (let index = targetIndex + 1; index < lines.length; index++) {
       const line = lines[index]!;
-      if (line.content.trim() === "") continue;
+      if (line.content.trim() === "") {
+        crossedBlank = true;
+        continue;
+      }
       const lineIndent = listMarkerIndent(line.content);
       if (lineIndent == null) {
-        if (isIndentedListContinuation(line.content, targetIndent)) continue;
+        if (isListContinuation(line.content, targetIndent, crossedBlank)) continue;
         return undefined;
       }
       if (lineIndent < targetIndent) return undefined;
       if (lineIndent === targetIndent && line.old_num != null && line.new_num != null) return line;
+      crossedBlank = false;
     }
     return undefined;
   }
 
-  function isIndentedListContinuation(line: string, targetIndent: number): boolean {
+  function isListContinuation(line: string, targetIndent: number, crossedBlank: boolean): boolean {
     const match = line.match(/^(\s*)/);
-    return indentationWidth(match?.[1] ?? "") > targetIndent;
+    const lineIndent = indentationWidth(match?.[1] ?? "");
+    return lineIndent > targetIndent || (!crossedBlank && lineIndent === targetIndent);
   }
 
   function listMarkerIndent(line: string): number | null {
@@ -517,6 +528,7 @@
   }
 
   .diff-rich-preview {
+    box-sizing: border-box;
     max-width: 920px;
     padding: 24px 32px 36px;
     color: var(--text-primary);
@@ -526,7 +538,8 @@
     display: grid;
     grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
     gap: 12px;
-    max-width: 1180px;
+    width: 100%;
+    max-width: none;
   }
 
   .markdown-rich-diff__pane {
@@ -575,6 +588,11 @@
 
   .markdown-rich-diff--split :global(.markdown-diff__block) {
     display: block;
+  }
+
+  .markdown-rich-diff--split :global(.markdown-diff__block),
+  .markdown-rich-diff--split :global(.markdown-diff__block *) {
+    text-decoration: none;
   }
 
   .markdown-rich-diff--split :global(ins:not(.markdown-diff__block)),

--- a/packages/ui/src/components/diff/DiffRichPreview.svelte
+++ b/packages/ui/src/components/diff/DiffRichPreview.svelte
@@ -173,7 +173,7 @@
       }
       const block = blocks.find((candidate) => blockContainsReviewThread(candidate, thread));
       if (!block) {
-        fallbackReviewThreads.push({ thread, fileLevel });
+        fallbackReviewThreads.push({ thread, fileLevel: true });
         continue;
       }
       const placement = { thread, fileLevel };

--- a/packages/ui/src/components/diff/DiffRichPreview.svelte
+++ b/packages/ui/src/components/diff/DiffRichPreview.svelte
@@ -261,6 +261,8 @@
     const marker = changedListMarker(lines, targetIndex);
     if (!marker) return;
 
+    if (marker.index !== targetIndex) addDiffLineNumbers(oldLines, newLines, lines[marker.index]!);
+
     const adjacent = adjacentOppositeChangedListMarker(lines, marker);
     if (adjacent) addDiffLineNumbers(oldLines, newLines, adjacent);
 
@@ -276,7 +278,6 @@
     let crossedBlank = false;
     for (let index = targetIndex - 1; index >= 0; index--) {
       const line = lines[index]!;
-      if (line.type !== target.type) return null;
       if (line.content.trim() === "") {
         crossedBlank = true;
         continue;
@@ -295,6 +296,7 @@
     marker: ChangedListMarker,
   ): DiffHunkLine | undefined {
     const target = lines[marker.index]!;
+    if (target.type !== "add" && target.type !== "delete") return undefined;
     const oppositeType = target.type === "add" ? "delete" : "add";
     return (
       previousAdjacentOppositeChangedListMarker(lines, marker.index, marker.indent, oppositeType) ??

--- a/packages/ui/src/components/diff/DiffRichPreview.svelte
+++ b/packages/ui/src/components/diff/DiffRichPreview.svelte
@@ -158,7 +158,7 @@
       owner,
       name,
       repoPath,
-    }).blocks.map((block) => ({
+    }, reviewThreadSplitLines(source, threads)).blocks.map((block) => ({
       ...block,
       leftReviewThreads: [],
       rightReviewThreads: [],
@@ -191,6 +191,50 @@
       sortReviewThreadPlacements(block.rightReviewThreads);
     }
     return { blocks, fallbackReviewThreads };
+  }
+
+  function reviewThreadSplitLines(source: DiffFile, threads: ReviewThread[]): {
+    splitOldLines: number[];
+    splitNewLines: number[];
+  } {
+    const splitOldLines: number[] = [];
+    const splitNewLines: number[] = [];
+    for (const thread of threads) {
+      if (threadLineIsFileLevelCard(thread)) continue;
+      const side = reviewThreadTargetSide(thread);
+      const targetLine = reviewThreadTargetLine(thread);
+      const diffLine = findReviewThreadDiffLine(source, side, targetLine);
+      if (diffLine?.old_num != null) addUniqueLine(splitOldLines, diffLine.old_num);
+      if (diffLine?.new_num != null) addUniqueLine(splitNewLines, diffLine.new_num);
+      if (!diffLine && side === "left") {
+        addUniqueLine(splitOldLines, targetLine);
+      } else if (!diffLine) {
+        addUniqueLine(splitNewLines, targetLine);
+      }
+    }
+    return {
+      splitOldLines,
+      splitNewLines,
+    };
+  }
+
+  function addUniqueLine(lines: number[], line: number): void {
+    if (!lines.includes(line)) lines.push(line);
+  }
+
+  function findReviewThreadDiffLine(
+    source: DiffFile,
+    side: "left" | "right",
+    targetLine: number,
+  ): DiffFile["hunks"][number]["lines"][number] | undefined {
+    for (const hunk of source.hunks ?? []) {
+      const line = hunk.lines.find((candidate) => {
+        const lineNumber = side === "left" ? candidate.old_num : candidate.new_num;
+        return lineNumber === targetLine;
+      });
+      if (line) return line;
+    }
+    return undefined;
   }
 
   function sortReviewThreadPlacements(placements: ReviewThreadPlacement[]): void {

--- a/packages/ui/src/components/diff/DiffRichPreview.svelte
+++ b/packages/ui/src/components/diff/DiffRichPreview.svelte
@@ -484,6 +484,10 @@
     text-decoration: none;
   }
 
+  .markdown-rich-diff :global(.markdown-rich-diff__split-list) {
+    margin-block: 0;
+  }
+
   @media (max-width: 760px) {
     .markdown-rich-diff--split {
       grid-template-columns: minmax(0, 1fr);

--- a/packages/ui/src/utils/markdown-rich-preview.test.ts
+++ b/packages/ui/src/utils/markdown-rich-preview.test.ts
@@ -21,6 +21,32 @@ function markdownFile(lines: DiffFile["hunks"][number]["lines"]): DiffFile {
 describe("buildMarkdownRichPreview", () => {
   const repo = { provider: "github", owner: "acme", name: "widgets", repoPath: "acme/widgets" };
 
+  it("renders an empty preview when the API returns null hunks", () => {
+    const preview = buildMarkdownRichPreview({ ...markdownFile([]), hunks: null } as unknown as DiffFile, repo);
+
+    expect(preview.blocks).toEqual([]);
+  });
+
+  it("skips hunks whose API line payload is null", () => {
+    const preview = buildMarkdownRichPreview(
+      {
+        ...markdownFile([]),
+        hunks: [
+          {
+            old_start: 1,
+            old_count: 0,
+            new_start: 1,
+            new_count: 0,
+            lines: null,
+          },
+        ],
+      } as unknown as DiffFile,
+      repo,
+    );
+
+    expect(preview.blocks).toEqual([]);
+  });
+
   it("preserves reference context without splitting untargeted list blocks", () => {
     const preview = buildMarkdownRichPreview(
       markdownFile([

--- a/packages/ui/src/utils/markdown-rich-preview.test.ts
+++ b/packages/ui/src/utils/markdown-rich-preview.test.ts
@@ -114,4 +114,56 @@ describe("buildMarkdownRichPreview", () => {
     expect(html).not.toContain("<hr");
     expect(preview.blocks.every((block) => block.oldStart != null || block.newStart != null)).toBe(true);
   });
+
+  it("strips synthetic hunk separator lines from blocks spanning hunks", () => {
+    const file = {
+      ...markdownFile([]),
+      hunks: [
+        {
+          old_start: 1,
+          old_count: 2,
+          new_start: 1,
+          new_count: 2,
+          lines: [
+            { type: "context", content: "```text", old_num: 1, new_num: 1 },
+            { type: "context", content: "first hunk code", old_num: 2, new_num: 2 },
+          ],
+        },
+        {
+          old_start: 10,
+          old_count: 2,
+          new_start: 10,
+          new_count: 2,
+          lines: [
+            { type: "context", content: "second hunk code", old_num: 10, new_num: 10 },
+            { type: "context", content: "```", old_num: 11, new_num: 11 },
+          ],
+        },
+      ],
+    } satisfies DiffFile;
+
+    const preview = buildMarkdownRichPreview(file, repo);
+    const html = preview.blocks.map((block) => block.unifiedHtml).join("");
+
+    expect(html).toContain("first hunk code");
+    expect(html).toContain("second hunk code");
+    expect(html).not.toContain("---");
+  });
+
+  it("keeps user-authored thematic breaks from source lines", () => {
+    const preview = buildMarkdownRichPreview(
+      markdownFile([
+        { type: "context", content: "Before", old_num: 1, new_num: 1 },
+        { type: "context", content: "", old_num: 2, new_num: 2 },
+        { type: "context", content: "---", old_num: 3, new_num: 3 },
+        { type: "context", content: "", old_num: 4, new_num: 4 },
+        { type: "context", content: "After", old_num: 5, new_num: 5 },
+      ]),
+      repo,
+    );
+
+    const html = preview.blocks.map((block) => block.unifiedHtml).join("");
+
+    expect(html).toContain("<hr");
+  });
 });

--- a/packages/ui/src/utils/markdown-rich-preview.test.ts
+++ b/packages/ui/src/utils/markdown-rich-preview.test.ts
@@ -21,7 +21,7 @@ function markdownFile(lines: DiffFile["hunks"][number]["lines"]): DiffFile {
 describe("buildMarkdownRichPreview", () => {
   const repo = { provider: "github", owner: "acme", name: "widgets", repoPath: "acme/widgets" };
 
-  it("preserves whole-document Markdown semantics while exposing block ranges", () => {
+  it("preserves reference context while exposing list item block ranges", () => {
     const preview = buildMarkdownRichPreview(
       markdownFile([
         { type: "context", content: "- first", old_num: 1, new_num: 1 },
@@ -36,9 +36,12 @@ describe("buildMarkdownRichPreview", () => {
     );
 
     const html = preview.blocks.map((block) => block.unifiedHtml).join("");
-    expect(html).toContain("<ul>");
-    expect(html.match(/<ul>/g)).toHaveLength(1);
+    expect(html).toContain("markdown-rich-diff__split-list");
+    expect(html.match(/<ul/g)).toHaveLength(2);
     expect(html).toContain('<a href="https://example.com">the ref</a>');
+    expect(preview.blocks.filter((block) => block.unifiedHtml.includes("<li>")).map((block) => block.newLines)).toEqual(
+      [[1, 2], [3]],
+    );
     expect(preview.blocks.some((block) => block.newStart === 7 && block.newEnd === 7)).toBe(true);
   });
 

--- a/packages/ui/src/utils/markdown-rich-preview.test.ts
+++ b/packages/ui/src/utils/markdown-rich-preview.test.ts
@@ -84,4 +84,34 @@ describe("buildMarkdownRichPreview", () => {
     expect(preview.blocks.some((block) => block.oldStart != null)).toBe(true);
     expect(preview.blocks.some((block) => block.newStart != null)).toBe(true);
   });
+
+  it("does not render synthetic hunk separators as preview content", () => {
+    const file = {
+      ...markdownFile([]),
+      hunks: [
+        {
+          old_start: 1,
+          old_count: 1,
+          new_start: 1,
+          new_count: 1,
+          lines: [{ type: "context", content: "# First hunk", old_num: 1, new_num: 1 }],
+        },
+        {
+          old_start: 20,
+          old_count: 1,
+          new_start: 20,
+          new_count: 1,
+          lines: [{ type: "context", content: "Second hunk paragraph", old_num: 20, new_num: 20 }],
+        },
+      ],
+    } satisfies DiffFile;
+
+    const preview = buildMarkdownRichPreview(file, repo);
+    const html = preview.blocks.map((block) => block.unifiedHtml).join("");
+
+    expect(html).toContain("First hunk");
+    expect(html).toContain("Second hunk paragraph");
+    expect(html).not.toContain("<hr");
+    expect(preview.blocks.every((block) => block.oldStart != null || block.newStart != null)).toBe(true);
+  });
 });

--- a/packages/ui/src/utils/markdown-rich-preview.test.ts
+++ b/packages/ui/src/utils/markdown-rich-preview.test.ts
@@ -46,11 +46,11 @@ describe("buildMarkdownRichPreview", () => {
     const preview = buildMarkdownRichPreview(
       markdownFile([
         { type: "context", content: "- first", old_num: 1, new_num: 1 },
-        { type: "context", content: "", old_num: 2, new_num: 2 },
-        { type: "context", content: "- second", old_num: 3, new_num: 3 },
+        { type: "context", content: "- second", old_num: 2, new_num: 2 },
+        { type: "context", content: "- third", old_num: 3, new_num: 3 },
       ]),
       repo,
-      { splitOldLines: [3], splitNewLines: [3] },
+      { splitOldLines: [2], splitNewLines: [2] },
     );
 
     const html = preview.blocks.map((block) => block.unifiedHtml).join("");
@@ -59,6 +59,63 @@ describe("buildMarkdownRichPreview", () => {
     expect(preview.blocks.filter((block) => block.unifiedHtml.includes("<li>")).map((block) => block.newLines)).toEqual(
       [[1, 2], [3]],
     );
+  });
+
+  it("keeps untargeted trailing list items in one segment", () => {
+    const preview = buildMarkdownRichPreview(
+      markdownFile([
+        { type: "context", content: "- first", old_num: 1, new_num: 1 },
+        { type: "context", content: "- second", old_num: 2, new_num: 2 },
+        { type: "context", content: "- third", old_num: 3, new_num: 3 },
+        { type: "context", content: "- fourth", old_num: 4, new_num: 4 },
+      ]),
+      repo,
+      { splitOldLines: [2], splitNewLines: [2] },
+    );
+
+    const listBlocks = preview.blocks.filter((block) => block.unifiedHtml.includes("markdown-rich-diff__split-list"));
+    expect(listBlocks.map((block) => block.newLines)).toEqual([
+      [1, 2],
+      [3, 4],
+    ]);
+    expect(listBlocks).toHaveLength(2);
+  });
+
+  it("preserves ordered list numbering when list item anchors split a list", () => {
+    const preview = buildMarkdownRichPreview(
+      markdownFile([
+        { type: "context", content: "3. first", old_num: 1, new_num: 1 },
+        { type: "context", content: "4. second", old_num: 2, new_num: 2 },
+        { type: "context", content: "5. third", old_num: 3, new_num: 3 },
+      ]),
+      repo,
+      { splitOldLines: [2], splitNewLines: [2] },
+    );
+
+    const orderedLists = preview.blocks
+      .map((block) => block.unifiedHtml)
+      .filter((html) => html.includes("markdown-rich-diff__split-list"));
+    expect(orderedLists).toHaveLength(2);
+    expect(orderedLists[0]).toContain('start="3"');
+    expect(orderedLists[1]).toContain('start="5"');
+  });
+
+  it("keeps nested lists inside the owning top-level split item", () => {
+    const preview = buildMarkdownRichPreview(
+      markdownFile([
+        { type: "context", content: "- parent", old_num: 1, new_num: 1 },
+        { type: "context", content: "  - child", old_num: 2, new_num: 2 },
+        { type: "context", content: "- sibling", old_num: 3, new_num: 3 },
+        { type: "context", content: "- tail", old_num: 4, new_num: 4 },
+      ]),
+      repo,
+      { splitOldLines: [3], splitNewLines: [3] },
+    );
+
+    const listBlocks = preview.blocks.filter((block) => block.unifiedHtml.includes("markdown-rich-diff__split-list"));
+    expect(listBlocks.map((block) => block.newLines)).toEqual([[1, 2, 3], [4]]);
+    expect(listBlocks[0]?.unifiedHtml).toContain("child");
+    expect(listBlocks[1]?.unifiedHtml).not.toContain("child");
   });
 
   it("projects split block additions without inline underline markup on every word", () => {

--- a/packages/ui/src/utils/markdown-rich-preview.test.ts
+++ b/packages/ui/src/utils/markdown-rich-preview.test.ts
@@ -251,6 +251,45 @@ describe("buildMarkdownRichPreview", () => {
     expect(html).not.toContain("<hr");
   });
 
+  it("hides synthetic separators around multi-hunk tables without merging unrelated table blocks", () => {
+    const file = {
+      ...markdownFile([]),
+      hunks: [
+        {
+          old_start: 1,
+          old_count: 3,
+          new_start: 1,
+          new_count: 3,
+          lines: [
+            { type: "context", content: "| Name |", old_num: 1, new_num: 1 },
+            { type: "context", content: "| --- |", old_num: 2, new_num: 2 },
+            { type: "context", content: "| first hunk row |", old_num: 3, new_num: 3 },
+          ],
+        },
+        {
+          old_start: 10,
+          old_count: 3,
+          new_start: 10,
+          new_count: 3,
+          lines: [
+            { type: "context", content: "| Name |", old_num: 10, new_num: 10 },
+            { type: "context", content: "| --- |", old_num: 11, new_num: 11 },
+            { type: "context", content: "| second hunk row |", old_num: 12, new_num: 12 },
+          ],
+        },
+      ],
+    } satisfies DiffFile;
+
+    const preview = buildMarkdownRichPreview(file, repo);
+    const html = preview.blocks.map((block) => block.unifiedHtml).join("");
+
+    expect(html.match(/<table>/g)).toHaveLength(2);
+    expect(html).toContain("first hunk row");
+    expect(html).toContain("second hunk row");
+    expect(html).not.toContain("---");
+    expect(html).not.toContain("<hr");
+  });
+
   it("keeps user-authored thematic breaks from source lines", () => {
     const preview = buildMarkdownRichPreview(
       markdownFile([

--- a/packages/ui/src/utils/markdown-rich-preview.test.ts
+++ b/packages/ui/src/utils/markdown-rich-preview.test.ts
@@ -148,6 +148,107 @@ describe("buildMarkdownRichPreview", () => {
     expect(html).toContain("first hunk code");
     expect(html).toContain("second hunk code");
     expect(html).not.toContain("---");
+    expect(preview.blocks.find((block) => block.unifiedHtml.includes("first hunk code"))?.newLines).toEqual([
+      1, 2, 10, 11,
+    ]);
+  });
+
+  it("hides synthetic separators around multi-hunk HTML blocks", () => {
+    const file = {
+      ...markdownFile([]),
+      hunks: [
+        {
+          old_start: 1,
+          old_count: 2,
+          new_start: 1,
+          new_count: 2,
+          lines: [
+            { type: "context", content: "<div>", old_num: 1, new_num: 1 },
+            { type: "context", content: "first hunk html", old_num: 2, new_num: 2 },
+          ],
+        },
+        {
+          old_start: 10,
+          old_count: 2,
+          new_start: 10,
+          new_count: 2,
+          lines: [
+            { type: "context", content: "second hunk html", old_num: 10, new_num: 10 },
+            { type: "context", content: "</div>", old_num: 11, new_num: 11 },
+          ],
+        },
+      ],
+    } satisfies DiffFile;
+
+    const preview = buildMarkdownRichPreview(file, repo);
+    const html = preview.blocks.map((block) => block.unifiedHtml).join("");
+
+    expect(html).toContain("first hunk html");
+    expect(html).toContain("second hunk html");
+    expect(html).not.toContain("---");
+    expect(html).not.toContain("<hr");
+  });
+
+  it("hides synthetic separators around multi-hunk blockquotes", () => {
+    const file = {
+      ...markdownFile([]),
+      hunks: [
+        {
+          old_start: 1,
+          old_count: 1,
+          new_start: 1,
+          new_count: 1,
+          lines: [{ type: "context", content: "> first hunk quote", old_num: 1, new_num: 1 }],
+        },
+        {
+          old_start: 10,
+          old_count: 1,
+          new_start: 10,
+          new_count: 1,
+          lines: [{ type: "context", content: "> second hunk quote", old_num: 10, new_num: 10 }],
+        },
+      ],
+    } satisfies DiffFile;
+
+    const preview = buildMarkdownRichPreview(file, repo);
+    const html = preview.blocks.map((block) => block.unifiedHtml).join("");
+
+    expect(html).toContain("<blockquote>");
+    expect(html).toContain("first hunk quote");
+    expect(html).toContain("second hunk quote");
+    expect(html).not.toContain("---");
+    expect(html).not.toContain("<hr");
+  });
+
+  it("hides synthetic separators around multi-hunk list continuations", () => {
+    const file = {
+      ...markdownFile([]),
+      hunks: [
+        {
+          old_start: 1,
+          old_count: 1,
+          new_start: 1,
+          new_count: 1,
+          lines: [{ type: "context", content: "- first hunk item", old_num: 1, new_num: 1 }],
+        },
+        {
+          old_start: 10,
+          old_count: 1,
+          new_start: 10,
+          new_count: 1,
+          lines: [{ type: "context", content: "- second hunk item", old_num: 10, new_num: 10 }],
+        },
+      ],
+    } satisfies DiffFile;
+
+    const preview = buildMarkdownRichPreview(file, repo);
+    const html = preview.blocks.map((block) => block.unifiedHtml).join("");
+
+    expect(html).toContain("<ul>");
+    expect(html).toContain("first hunk item");
+    expect(html).toContain("second hunk item");
+    expect(html).not.toContain("---");
+    expect(html).not.toContain("<hr");
   });
 
   it("keeps user-authored thematic breaks from source lines", () => {

--- a/packages/ui/src/utils/markdown-rich-preview.test.ts
+++ b/packages/ui/src/utils/markdown-rich-preview.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vite-plus/test";
+import type { DiffFile } from "../api/types.js";
+import { buildMarkdownRichPreview } from "./markdown-rich-preview.js";
+
+function markdownFile(lines: DiffFile["hunks"][number]["lines"]): DiffFile {
+  return {
+    path: "README.md",
+    old_path: "README.md",
+    status: "modified",
+    is_binary: false,
+    is_whitespace_only: false,
+    additions: lines.filter((line) => line.type === "add").length,
+    deletions: lines.filter((line) => line.type === "delete").length,
+    patch: "",
+    hunks: [{ old_start: 1, old_count: 20, new_start: 1, new_count: 20, lines }],
+  };
+}
+
+describe("buildMarkdownRichPreview", () => {
+  const repo = { provider: "github", owner: "acme", name: "widgets", repoPath: "acme/widgets" };
+
+  it("preserves whole-document Markdown semantics while exposing block ranges", () => {
+    const preview = buildMarkdownRichPreview(
+      markdownFile([
+        { type: "context", content: "- first", old_num: 1, new_num: 1 },
+        { type: "context", content: "", old_num: 2, new_num: 2 },
+        { type: "context", content: "- second", old_num: 3, new_num: 3 },
+        { type: "context", content: "", old_num: 4, new_num: 4 },
+        { type: "context", content: "[ref]: https://example.com", old_num: 5, new_num: 5 },
+        { type: "context", content: "", old_num: 6, new_num: 6 },
+        { type: "add", content: "See [the ref][ref]", new_num: 7 },
+      ]),
+      repo,
+    );
+
+    const html = preview.blocks.map((block) => block.unifiedHtml).join("");
+    expect(html).toContain("<ul>");
+    expect(html.match(/<ul>/g)).toHaveLength(1);
+    expect(html).toContain('<a href="https://example.com">the ref</a>');
+    expect(preview.blocks.some((block) => block.newStart === 7 && block.newEnd === 7)).toBe(true);
+  });
+
+  it("projects split block additions without inline underline markup on every word", () => {
+    const preview = buildMarkdownRichPreview(
+      markdownFile([
+        { type: "context", content: "## Title", old_num: 1, new_num: 1 },
+        { type: "context", content: "", old_num: 2, new_num: 2 },
+        { type: "add", content: "Added paragraph with several words", new_num: 3 },
+      ]),
+      repo,
+    );
+
+    const added = preview.blocks.find((block) => block.newStart === 3);
+    expect(added?.unifiedHtml).toContain('class="markdown-diff__block"');
+    expect(added?.unifiedHtml).not.toContain("<ins>Added</ins>");
+    expect(added?.beforeHtml).toContain("markdown-diff__placeholder");
+    expect(added?.afterHtml).toContain("Added paragraph with several words");
+  });
+});

--- a/packages/ui/src/utils/markdown-rich-preview.test.ts
+++ b/packages/ui/src/utils/markdown-rich-preview.test.ts
@@ -133,6 +133,12 @@ describe("buildMarkdownRichPreview", () => {
     expect(trailing!.unifiedHtml).toContain('start="3"');
     expect(trailing!.unifiedHtml).not.toContain("<del");
     expect(trailing!.unifiedHtml).not.toContain("<ins");
+    expect(trailing!.beforeHtml).toContain('start="2"');
+    expect(trailing!.beforeHtml).not.toContain("<del");
+    expect(trailing!.beforeHtml).not.toContain("<ins");
+    expect(trailing!.afterHtml).toContain('start="3"');
+    expect(trailing!.afterHtml).not.toContain("<del");
+    expect(trailing!.afterHtml).not.toContain("<ins");
   });
 
   it("keeps nested lists inside the owning top-level split item", () => {

--- a/packages/ui/src/utils/markdown-rich-preview.test.ts
+++ b/packages/ui/src/utils/markdown-rich-preview.test.ts
@@ -21,7 +21,7 @@ function markdownFile(lines: DiffFile["hunks"][number]["lines"]): DiffFile {
 describe("buildMarkdownRichPreview", () => {
   const repo = { provider: "github", owner: "acme", name: "widgets", repoPath: "acme/widgets" };
 
-  it("preserves reference context while exposing list item block ranges", () => {
+  it("preserves reference context without splitting untargeted list blocks", () => {
     const preview = buildMarkdownRichPreview(
       markdownFile([
         { type: "context", content: "- first", old_num: 1, new_num: 1 },
@@ -36,13 +36,29 @@ describe("buildMarkdownRichPreview", () => {
     );
 
     const html = preview.blocks.map((block) => block.unifiedHtml).join("");
+    expect(html).not.toContain("markdown-rich-diff__split-list");
+    expect(html.match(/<ul/g)).toHaveLength(1);
+    expect(html).toContain('<a href="https://example.com">the ref</a>');
+    expect(preview.blocks.some((block) => block.newStart === 7 && block.newEnd === 7)).toBe(true);
+  });
+
+  it("exposes list item block ranges when a target line needs an internal anchor", () => {
+    const preview = buildMarkdownRichPreview(
+      markdownFile([
+        { type: "context", content: "- first", old_num: 1, new_num: 1 },
+        { type: "context", content: "", old_num: 2, new_num: 2 },
+        { type: "context", content: "- second", old_num: 3, new_num: 3 },
+      ]),
+      repo,
+      { splitOldLines: [3], splitNewLines: [3] },
+    );
+
+    const html = preview.blocks.map((block) => block.unifiedHtml).join("");
     expect(html).toContain("markdown-rich-diff__split-list");
     expect(html.match(/<ul/g)).toHaveLength(2);
-    expect(html).toContain('<a href="https://example.com">the ref</a>');
     expect(preview.blocks.filter((block) => block.unifiedHtml.includes("<li>")).map((block) => block.newLines)).toEqual(
       [[1, 2], [3]],
     );
-    expect(preview.blocks.some((block) => block.newStart === 7 && block.newEnd === 7)).toBe(true);
   });
 
   it("projects split block additions without inline underline markup on every word", () => {

--- a/packages/ui/src/utils/markdown-rich-preview.test.ts
+++ b/packages/ui/src/utils/markdown-rich-preview.test.ts
@@ -58,4 +58,30 @@ describe("buildMarkdownRichPreview", () => {
     expect(added?.beforeHtml).toContain("markdown-diff__placeholder");
     expect(added?.afterHtml).toContain("Added paragraph with several words");
   });
+
+  it("uses a coarse fallback for large block comparisons", () => {
+    const lines: DiffFile["hunks"][number]["lines"] = [];
+    for (let index = 0; index < 160; index++) {
+      lines.push({
+        type: "delete",
+        content: index % 20 === 0 ? "Shared paragraph" : `Old paragraph ${index}`,
+        old_num: index * 2 + 1,
+      });
+      lines.push({ type: "delete", content: "", old_num: index * 2 + 2 });
+    }
+    for (let index = 0; index < 160; index++) {
+      lines.push({
+        type: "add",
+        content: index % 20 === 0 ? "Shared paragraph" : `New paragraph ${index}`,
+        new_num: index * 2 + 1,
+      });
+      lines.push({ type: "add", content: "", new_num: index * 2 + 2 });
+    }
+
+    const preview = buildMarkdownRichPreview(markdownFile(lines), repo);
+
+    expect(preview.blocks.some((block) => block.oldStart != null && block.newStart != null)).toBe(false);
+    expect(preview.blocks.some((block) => block.oldStart != null)).toBe(true);
+    expect(preview.blocks.some((block) => block.newStart != null)).toBe(true);
+  });
 });

--- a/packages/ui/src/utils/markdown-rich-preview.test.ts
+++ b/packages/ui/src/utils/markdown-rich-preview.test.ts
@@ -81,6 +81,21 @@ describe("buildMarkdownRichPreview", () => {
     expect(listBlocks).toHaveLength(2);
   });
 
+  it("keeps a split wrapper when a requested list anchor produces one segment", () => {
+    const preview = buildMarkdownRichPreview(
+      markdownFile([
+        { type: "context", content: "- first", old_num: 1, new_num: 1 },
+        { type: "context", content: "- second", old_num: 2, new_num: 2 },
+      ]),
+      repo,
+      { splitOldLines: [2], splitNewLines: [2] },
+    );
+
+    const listBlocks = preview.blocks.filter((block) => block.unifiedHtml.includes("markdown-rich-diff__split-list"));
+    expect(listBlocks).toHaveLength(1);
+    expect(listBlocks[0]?.newLines).toEqual([1, 2]);
+  });
+
   it("preserves ordered list numbering when list item anchors split a list", () => {
     const preview = buildMarkdownRichPreview(
       markdownFile([

--- a/packages/ui/src/utils/markdown-rich-preview.test.ts
+++ b/packages/ui/src/utils/markdown-rich-preview.test.ts
@@ -115,6 +115,26 @@ describe("buildMarkdownRichPreview", () => {
     expect(orderedLists[1]).toContain('start="5"');
   });
 
+  it("aligns unchanged ordered list chunks when synthetic split starts differ", () => {
+    const preview = buildMarkdownRichPreview(
+      markdownFile([
+        { type: "context", content: "1. Alpha", old_num: 1, new_num: 1 },
+        { type: "add", content: "2. Inserted", new_num: 2 },
+        { type: "context", content: "3. Beta", old_num: 2, new_num: 3 },
+        { type: "context", content: "4. Gamma", old_num: 3, new_num: 4 },
+      ]),
+      repo,
+      { splitOldLines: [1], splitNewLines: [1, 2] },
+    );
+
+    const trailing = preview.blocks.find((block) => block.oldLines?.includes(2) && block.newLines?.includes(3));
+    expect(trailing).toBeTruthy();
+    expect(trailing!.unifiedHtml).toContain("Beta");
+    expect(trailing!.unifiedHtml).toContain('start="3"');
+    expect(trailing!.unifiedHtml).not.toContain("<del");
+    expect(trailing!.unifiedHtml).not.toContain("<ins");
+  });
+
   it("keeps nested lists inside the owning top-level split item", () => {
     const preview = buildMarkdownRichPreview(
       markdownFile([

--- a/packages/ui/src/utils/markdown-rich-preview.test.ts
+++ b/packages/ui/src/utils/markdown-rich-preview.test.ts
@@ -133,6 +133,28 @@ describe("buildMarkdownRichPreview", () => {
     expect(listBlocks[1]?.unifiedHtml).not.toContain("child");
   });
 
+  it("preserves paragraph-wrapped loose list items when a target line splits the list", () => {
+    const preview = buildMarkdownRichPreview(
+      markdownFile([
+        { type: "context", content: "- first", old_num: 1, new_num: 1 },
+        { type: "context", content: "", old_num: 2, new_num: 2 },
+        { type: "context", content: "  first detail", old_num: 3, new_num: 3 },
+        { type: "context", content: "- second", old_num: 4, new_num: 4 },
+        { type: "context", content: "", old_num: 5, new_num: 5 },
+        { type: "context", content: "  second detail", old_num: 6, new_num: 6 },
+        { type: "context", content: "- third", old_num: 7, new_num: 7 },
+      ]),
+      repo,
+      { splitOldLines: [4], splitNewLines: [4] },
+    );
+
+    const listBlocks = preview.blocks.filter((block) => block.unifiedHtml.includes("markdown-rich-diff__split-list"));
+    expect(listBlocks.map((block) => block.newLines)).toEqual([[1, 2, 3, 4, 5, 6], [7]]);
+    expect(listBlocks[0]?.unifiedHtml).toContain("<p>second</p>");
+    expect(listBlocks[0]?.unifiedHtml).toContain("<p>second detail</p>");
+    expect(listBlocks[1]?.unifiedHtml).not.toContain("second detail");
+  });
+
   it("projects split block additions without inline underline markup on every word", () => {
     const preview = buildMarkdownRichPreview(
       markdownFile([

--- a/packages/ui/src/utils/markdown-rich-preview.ts
+++ b/packages/ui/src/utils/markdown-rich-preview.ts
@@ -1,5 +1,10 @@
 import type { DiffFile } from "../api/types.js";
-import { renderMarkdownBlocks, type RenderedMarkdownBlock, type RepoContext } from "./markdown.js";
+import {
+  extractMarkdownDefinitionLines,
+  renderMarkdownBlocks,
+  type RenderedMarkdownBlock,
+  type RepoContext,
+} from "./markdown.js";
 import { renderMarkdownDiff, renderMarkdownSplitDiff } from "./markdown-diff.js";
 
 type SourceLine = DiffFile["hunks"][number]["lines"][number];
@@ -19,14 +24,17 @@ interface MarkdownSideDocument {
 interface MarkdownSideBlock extends RenderedMarkdownBlock {
   sourceStart?: number | undefined;
   sourceEnd?: number | undefined;
+  sourceLines: number[];
 }
 
 export interface MarkdownRichPreviewBlock {
   key: string;
   oldStart?: number | undefined;
   oldEnd?: number | undefined;
+  oldLines?: number[] | undefined;
   newStart?: number | undefined;
   newEnd?: number | undefined;
+  newLines?: number[] | undefined;
   unifiedHtml: string;
   beforeHtml?: string | undefined;
   afterHtml?: string | undefined;
@@ -65,13 +73,17 @@ function sideIncludesLine(side: "old" | "new", line: SourceLine): boolean {
 }
 
 function buildSideBlocks(document: MarkdownSideDocument, repo: RepoContext): MarkdownSideBlock[] {
-  return renderMarkdownBlocks(document.text, repo).flatMap((block) => renderedSideBlocks(block, document, repo));
+  const definitionLines = extractMarkdownDefinitionLines(document.text, repo);
+  return renderMarkdownBlocks(document.text, repo).flatMap((block) =>
+    renderedSideBlocks(block, document, repo, definitionLines),
+  );
 }
 
 function renderedSideBlocks(
   block: RenderedMarkdownBlock,
   document: MarkdownSideDocument,
   repo: RepoContext,
+  definitionLines: string[],
 ): MarkdownSideBlock[] {
   const blockLineMap = document.lineMap.slice(block.startLine - 1, block.endLine);
   if (blockLineMap.every((line) => line != null)) return [sideBlockForRenderedBlock(block, document.lineMap)];
@@ -82,37 +94,40 @@ function renderedSideBlocks(
     .filter((line): line is { content: string; sourceLine: number } => line.sourceLine != null);
   if (lines.length === 0) return [];
 
-  const visibleDocument: MarkdownSideDocument = {
-    text: `${lines.map((line) => line.content).join("\n")}\n`,
-    lines: lines.map((line) => line.content),
-    lineMap: lines.map((line) => line.sourceLine),
-  };
+  const visibleDocument = buildVisibleDocument(lines, definitionLines);
   return renderMarkdownBlocks(visibleDocument.text, repo).map((visibleBlock) =>
     sideBlockForRenderedBlock({ ...visibleBlock, key: `${block.key}:${visibleBlock.key}` }, visibleDocument.lineMap),
   );
+}
+
+function buildVisibleDocument(
+  lines: Array<{ content: string; sourceLine: number }>,
+  definitionLines: string[],
+): MarkdownSideDocument {
+  const sourceLines = lines.map((line) => line.content);
+  const parserContextLines = definitionLines.length > 0 ? ["", ...definitionLines] : [];
+  return {
+    text: `${[...sourceLines, ...parserContextLines].join("\n")}\n`,
+    lines: [...sourceLines, ...parserContextLines],
+    lineMap: [...lines.map((line) => line.sourceLine), ...parserContextLines.map(() => undefined)],
+  };
 }
 
 function sideBlockForRenderedBlock(
   block: RenderedMarkdownBlock,
   lineMap: Array<number | undefined>,
 ): MarkdownSideBlock {
-  const range = sourceRangeForBlock(block, lineMap);
+  const sourceLines = sourceLinesForBlock(block, lineMap);
   return {
     ...block,
-    sourceStart: range.start,
-    sourceEnd: range.end,
+    sourceLines,
+    sourceStart: sourceLines[0],
+    sourceEnd: sourceLines.at(-1),
   };
 }
 
-function sourceRangeForBlock(
-  block: RenderedMarkdownBlock,
-  lineMap: Array<number | undefined>,
-): { start?: number | undefined; end?: number | undefined } {
-  const sourceLines = lineMap.slice(block.startLine - 1, block.endLine).filter((line): line is number => line != null);
-  return {
-    start: sourceLines[0],
-    end: sourceLines.at(-1),
-  };
+function sourceLinesForBlock(block: RenderedMarkdownBlock, lineMap: Array<number | undefined>): number[] {
+  return lineMap.slice(block.startLine - 1, block.endLine).filter((line): line is number => line != null);
 }
 
 function alignBlocks(oldBlocks: MarkdownSideBlock[], newBlocks: MarkdownSideBlock[]): MarkdownRichPreviewBlock[] {
@@ -185,8 +200,10 @@ function renderBlock(
     key: `${index}:${oldBlock?.key ?? ""}:${newBlock?.key ?? ""}`,
     oldStart: oldBlock?.sourceStart,
     oldEnd: oldBlock?.sourceEnd,
+    oldLines: oldBlock?.sourceLines,
     newStart: newBlock?.sourceStart,
     newEnd: newBlock?.sourceEnd,
+    newLines: newBlock?.sourceLines,
     unifiedHtml: renderMarkdownDiff(oldHtml, newHtml),
     beforeHtml: split.beforeHtml,
     afterHtml: split.afterHtml,

--- a/packages/ui/src/utils/markdown-rich-preview.ts
+++ b/packages/ui/src/utils/markdown-rich-preview.ts
@@ -86,7 +86,7 @@ function renderedSideBlocks(
   definitionLines: string[],
 ): MarkdownSideBlock[] {
   const blockLineMap = document.lineMap.slice(block.startLine - 1, block.endLine);
-  if (blockLineMap.every((line) => line != null)) return [sideBlockForRenderedBlock(block, document.lineMap)];
+  if (blockLineMap.every((line) => line != null)) return sideBlocksForRenderedBlock(block, document);
 
   const lines = document.lines
     .slice(block.startLine - 1, block.endLine)
@@ -95,9 +95,100 @@ function renderedSideBlocks(
   if (lines.length === 0) return [];
 
   const visibleDocument = buildVisibleDocument(lines, definitionLines);
-  return renderMarkdownBlocks(visibleDocument.text, repo).map((visibleBlock) =>
-    sideBlockForRenderedBlock({ ...visibleBlock, key: `${block.key}:${visibleBlock.key}` }, visibleDocument.lineMap),
-  );
+  return renderMarkdownBlocks(visibleDocument.text, repo)
+    .map((visibleBlock) =>
+      sideBlocksForRenderedBlock({ ...visibleBlock, key: `${block.key}:${visibleBlock.key}` }, visibleDocument),
+    )
+    .flat();
+}
+
+function sideBlocksForRenderedBlock(block: RenderedMarkdownBlock, document: MarkdownSideDocument): MarkdownSideBlock[] {
+  return splitListBlock(block, document) ?? [sideBlockForRenderedBlock(block, document.lineMap)];
+}
+
+interface ListItemLineGroup {
+  startLine: number;
+  endLine: number;
+  sourceLines: number[];
+}
+
+function splitListBlock(block: RenderedMarkdownBlock, document: MarkdownSideDocument): MarkdownSideBlock[] | null {
+  if (typeof globalThis.document === "undefined") return null;
+  const template = globalThis.document.createElement("template");
+  template.innerHTML = block.html;
+  const rootElements = Array.from(template.content.children);
+  if (rootElements.length !== 1) return null;
+
+  const list = rootElements[0]!;
+  if (list.tagName !== "UL" && list.tagName !== "OL") return null;
+  const items = Array.from(list.children).filter((child) => child.tagName === "LI");
+  if (items.length < 2 || items.length !== list.children.length) return null;
+
+  const groups = listItemLineGroups(block, document);
+  if (groups.length !== items.length) return null;
+
+  return groups.map((group, index) => {
+    const html = listItemHtml(list, items[index]!, index);
+    return {
+      ...block,
+      key: `${block.key}:item:${index}`,
+      startLine: group.startLine,
+      endLine: group.endLine,
+      html,
+      sourceLines: group.sourceLines,
+      sourceStart: group.sourceLines[0],
+      sourceEnd: group.sourceLines.at(-1),
+    };
+  });
+}
+
+function listItemLineGroups(block: RenderedMarkdownBlock, document: MarkdownSideDocument): ListItemLineGroup[] {
+  const startIndex = block.startLine - 1;
+  const endIndex = block.endLine - 1;
+  const markerLines: Array<{ index: number; indent: number }> = [];
+  for (let index = startIndex; index <= endIndex; index++) {
+    const marker = listMarkerIndent(document.lines[index] ?? "");
+    if (marker == null) continue;
+    markerLines.push({ index, indent: marker });
+  }
+  if (markerLines.length < 2) return [];
+
+  const topLevelIndent = Math.min(...markerLines.map((line) => line.indent));
+  const topLevelMarkers = markerLines.filter((line) => line.indent === topLevelIndent);
+  return topLevelMarkers.map((line, index) => {
+    const next = topLevelMarkers[index + 1];
+    const groupStart = line.index;
+    const groupEnd = (next?.index ?? endIndex + 1) - 1;
+    const sourceLines = document.lineMap
+      .slice(groupStart, groupEnd + 1)
+      .filter((sourceLine): sourceLine is number => sourceLine != null);
+    return {
+      startLine: groupStart + 1,
+      endLine: groupEnd + 1,
+      sourceLines,
+    };
+  });
+}
+
+function listMarkerIndent(line: string): number | null {
+  const match = line.match(/^(\s{0,12})(?:[-+*]|\d+[.)])\s+/);
+  if (!match) return null;
+  return indentationWidth(match[1]!);
+}
+
+function indentationWidth(value: string): number {
+  return Array.from(value).reduce((width, char) => width + (char === "\t" ? 4 : 1), 0);
+}
+
+function listItemHtml(list: Element, item: Element, index: number): string {
+  const wrapper = list.cloneNode(false) as Element;
+  wrapper.classList.add("markdown-rich-diff__split-list");
+  if (wrapper.tagName === "OL") {
+    const start = parseInt(list.getAttribute("start") ?? "1", 10);
+    if (!Number.isNaN(start)) wrapper.setAttribute("start", String(start + index));
+  }
+  wrapper.append(item.cloneNode(true));
+  return wrapper.outerHTML;
 }
 
 function buildVisibleDocument(

--- a/packages/ui/src/utils/markdown-rich-preview.ts
+++ b/packages/ui/src/utils/markdown-rich-preview.ts
@@ -63,14 +63,16 @@ function sideIncludesLine(side: "old" | "new", line: SourceLine): boolean {
 }
 
 function buildSideBlocks(document: MarkdownSideDocument, repo: RepoContext): MarkdownSideBlock[] {
-  return renderMarkdownBlocks(document.text, repo).map((block) => {
-    const range = sourceRangeForBlock(block, document.lineMap);
-    return {
-      ...block,
-      sourceStart: range.start,
-      sourceEnd: range.end,
-    };
-  });
+  return renderMarkdownBlocks(document.text, repo)
+    .map((block) => {
+      const range = sourceRangeForBlock(block, document.lineMap);
+      return {
+        ...block,
+        sourceStart: range.start,
+        sourceEnd: range.end,
+      };
+    })
+    .filter((block) => block.sourceStart != null || block.sourceEnd != null);
 }
 
 function sourceRangeForBlock(

--- a/packages/ui/src/utils/markdown-rich-preview.ts
+++ b/packages/ui/src/utils/markdown-rich-preview.ts
@@ -8,6 +8,8 @@ type DiffOp<T> =
   | { kind: "delete"; oldItem: T }
   | { kind: "insert"; newItem: T };
 
+const MAX_BLOCK_COMPARISON_SIZE = 20_000;
+
 interface MarkdownSideDocument {
   text: string;
   lineMap: Array<number | undefined>;
@@ -83,6 +85,9 @@ function sourceRangeForBlock(
 }
 
 function alignBlocks(oldBlocks: MarkdownSideBlock[], newBlocks: MarkdownSideBlock[]): MarkdownRichPreviewBlock[] {
+  if (oldBlocks.length * newBlocks.length > MAX_BLOCK_COMPARISON_SIZE) {
+    return renderCoarseBlocks(oldBlocks, newBlocks);
+  }
   const ops = diffSequence(oldBlocks, newBlocks, (oldBlock, newBlock) => oldBlock.html === newBlock.html);
   const blocks: MarkdownRichPreviewBlock[] = [];
   for (let i = 0; i < ops.length; i++) {
@@ -119,6 +124,20 @@ function alignBlocks(oldBlocks: MarkdownSideBlock[], newBlocks: MarkdownSideBloc
     for (let index = pairs; index < insertRun.length; index++) {
       blocks.push(renderBlock(blocks.length, undefined, insertRun[index]));
     }
+  }
+  return blocks;
+}
+
+function renderCoarseBlocks(
+  oldBlocks: MarkdownSideBlock[],
+  newBlocks: MarkdownSideBlock[],
+): MarkdownRichPreviewBlock[] {
+  const blocks: MarkdownRichPreviewBlock[] = [];
+  for (const oldBlock of oldBlocks) {
+    blocks.push(renderBlock(blocks.length, oldBlock, undefined));
+  }
+  for (const newBlock of newBlocks) {
+    blocks.push(renderBlock(blocks.length, undefined, newBlock));
   }
   return blocks;
 }

--- a/packages/ui/src/utils/markdown-rich-preview.ts
+++ b/packages/ui/src/utils/markdown-rich-preview.ts
@@ -354,7 +354,8 @@ function renderBlock(
 ): MarkdownRichPreviewBlock {
   const oldHtml = oldBlock?.html ?? "";
   const newHtml = newBlock?.html ?? "";
-  const split = renderMarkdownSplitDiff(oldHtml, newHtml);
+  const aligned = oldBlock && newBlock && blocksAlign(oldBlock, newBlock);
+  const split = aligned ? { beforeHtml: oldHtml, afterHtml: newHtml } : renderMarkdownSplitDiff(oldHtml, newHtml);
   return {
     key: `${index}:${oldBlock?.key ?? ""}:${newBlock?.key ?? ""}`,
     oldStart: oldBlock?.sourceStart,
@@ -363,8 +364,7 @@ function renderBlock(
     newStart: newBlock?.sourceStart,
     newEnd: newBlock?.sourceEnd,
     newLines: newBlock?.sourceLines,
-    unifiedHtml:
-      oldBlock && newBlock && blocksAlign(oldBlock, newBlock) ? newHtml : renderMarkdownDiff(oldHtml, newHtml),
+    unifiedHtml: aligned ? newHtml : renderMarkdownDiff(oldHtml, newHtml),
     beforeHtml: split.beforeHtml,
     afterHtml: split.afterHtml,
   };

--- a/packages/ui/src/utils/markdown-rich-preview.ts
+++ b/packages/ui/src/utils/markdown-rich-preview.ts
@@ -12,6 +12,7 @@ const MAX_BLOCK_COMPARISON_SIZE = 20_000;
 
 interface MarkdownSideDocument {
   text: string;
+  lines: string[];
   lineMap: Array<number | undefined>;
 }
 
@@ -54,6 +55,7 @@ function buildSideDocument(source: DiffFile, side: "old" | "new"): MarkdownSideD
   }
   return {
     text: `${lines.map((line) => line.content).join("\n")}\n`,
+    lines: lines.map((line) => line.content),
     lineMap: lines.map((line) => line.sourceLine),
   };
 }
@@ -63,16 +65,43 @@ function sideIncludesLine(side: "old" | "new", line: SourceLine): boolean {
 }
 
 function buildSideBlocks(document: MarkdownSideDocument, repo: RepoContext): MarkdownSideBlock[] {
-  return renderMarkdownBlocks(document.text, repo)
-    .map((block) => {
-      const range = sourceRangeForBlock(block, document.lineMap);
-      return {
-        ...block,
-        sourceStart: range.start,
-        sourceEnd: range.end,
-      };
-    })
-    .filter((block) => block.sourceStart != null || block.sourceEnd != null);
+  return renderMarkdownBlocks(document.text, repo).flatMap((block) => renderedSideBlocks(block, document, repo));
+}
+
+function renderedSideBlocks(
+  block: RenderedMarkdownBlock,
+  document: MarkdownSideDocument,
+  repo: RepoContext,
+): MarkdownSideBlock[] {
+  const blockLineMap = document.lineMap.slice(block.startLine - 1, block.endLine);
+  if (blockLineMap.every((line) => line != null)) return [sideBlockForRenderedBlock(block, document.lineMap)];
+
+  const lines = document.lines
+    .slice(block.startLine - 1, block.endLine)
+    .map((content, index) => ({ content, sourceLine: blockLineMap[index] }))
+    .filter((line): line is { content: string; sourceLine: number } => line.sourceLine != null);
+  if (lines.length === 0) return [];
+
+  const visibleDocument: MarkdownSideDocument = {
+    text: `${lines.map((line) => line.content).join("\n")}\n`,
+    lines: lines.map((line) => line.content),
+    lineMap: lines.map((line) => line.sourceLine),
+  };
+  return renderMarkdownBlocks(visibleDocument.text, repo).map((visibleBlock) =>
+    sideBlockForRenderedBlock({ ...visibleBlock, key: `${block.key}:${visibleBlock.key}` }, visibleDocument.lineMap),
+  );
+}
+
+function sideBlockForRenderedBlock(
+  block: RenderedMarkdownBlock,
+  lineMap: Array<number | undefined>,
+): MarkdownSideBlock {
+  const range = sourceRangeForBlock(block, lineMap);
+  return {
+    ...block,
+    sourceStart: range.start,
+    sourceEnd: range.end,
+  };
 }
 
 function sourceRangeForBlock(

--- a/packages/ui/src/utils/markdown-rich-preview.ts
+++ b/packages/ui/src/utils/markdown-rich-preview.ts
@@ -180,7 +180,6 @@ function splitListBlock(
       groups: groups.slice(startIndex),
     });
   }
-  if (segments.length < 2) return null;
 
   return segments.map((segment) => {
     const sourceLines = segment.groups.flatMap((group) => group.sourceLines);

--- a/packages/ui/src/utils/markdown-rich-preview.ts
+++ b/packages/ui/src/utils/markdown-rich-preview.ts
@@ -61,11 +61,11 @@ export function buildMarkdownRichPreview(
 
 function buildSideDocument(source: DiffFile, side: "old" | "new"): MarkdownSideDocument {
   const lines: Array<{ content: string; sourceLine?: number | undefined }> = [];
-  for (const hunk of source.hunks) {
+  for (const hunk of source.hunks ?? []) {
     if (lines.length > 0) {
       lines.push({ content: "" }, { content: "---" }, { content: "" });
     }
-    for (const line of hunk.lines) {
+    for (const line of hunk.lines ?? []) {
       const sourceLine = side === "old" ? line.old_num : line.new_num;
       if (sideIncludesLine(side, line)) lines.push({ content: line.content, sourceLine });
     }

--- a/packages/ui/src/utils/markdown-rich-preview.ts
+++ b/packages/ui/src/utils/markdown-rich-preview.ts
@@ -127,7 +127,7 @@ function sideBlocksForRenderedBlock(
 ): MarkdownSideBlock[] {
   const sourceLines = sourceLinesForBlock(block, document.lineMap);
   if (sourceLines.some((line) => splitLines.has(line))) {
-    return splitListBlock(block, document) ?? [sideBlockForRenderedBlock(block, document.lineMap)];
+    return splitListBlock(block, document, splitLines) ?? [sideBlockForRenderedBlock(block, document.lineMap)];
   }
   return [sideBlockForRenderedBlock(block, document.lineMap)];
 }
@@ -138,7 +138,11 @@ interface ListItemLineGroup {
   sourceLines: number[];
 }
 
-function splitListBlock(block: RenderedMarkdownBlock, document: MarkdownSideDocument): MarkdownSideBlock[] | null {
+function splitListBlock(
+  block: RenderedMarkdownBlock,
+  document: MarkdownSideDocument,
+  splitLines: ReadonlySet<number>,
+): MarkdownSideBlock[] | null {
   if (typeof globalThis.document === "undefined") return null;
   const template = globalThis.document.createElement("template");
   template.innerHTML = block.html;
@@ -153,17 +157,43 @@ function splitListBlock(block: RenderedMarkdownBlock, document: MarkdownSideDocu
   const groups = listItemLineGroups(block, document);
   if (groups.length !== items.length) return null;
 
-  return groups.map((group, index) => {
-    const html = listItemHtml(list, items[index]!, index);
+  const breakAfterIndexes = groups
+    .map((group, index) => ({ group, index }))
+    .filter(({ group }) => group.sourceLines.some((line) => splitLines.has(line)))
+    .map(({ index }) => index);
+  if (breakAfterIndexes.length === 0) return null;
+
+  const segments: Array<{ startIndex: number; endIndex: number; groups: ListItemLineGroup[] }> = [];
+  let startIndex = 0;
+  for (const breakAfterIndex of breakAfterIndexes) {
+    segments.push({
+      startIndex,
+      endIndex: breakAfterIndex,
+      groups: groups.slice(startIndex, breakAfterIndex + 1),
+    });
+    startIndex = breakAfterIndex + 1;
+  }
+  if (startIndex < groups.length) {
+    segments.push({
+      startIndex,
+      endIndex: groups.length - 1,
+      groups: groups.slice(startIndex),
+    });
+  }
+  if (segments.length < 2) return null;
+
+  return segments.map((segment) => {
+    const sourceLines = segment.groups.flatMap((group) => group.sourceLines);
+    const html = listSegmentHtml(list, items, segment.startIndex, segment.endIndex);
     return {
       ...block,
-      key: `${block.key}:item:${index}`,
-      startLine: group.startLine,
-      endLine: group.endLine,
+      key: `${block.key}:items:${segment.startIndex}-${segment.endIndex}`,
+      startLine: segment.groups[0]!.startLine,
+      endLine: segment.groups.at(-1)!.endLine,
       html,
-      sourceLines: group.sourceLines,
-      sourceStart: group.sourceLines[0],
-      sourceEnd: group.sourceLines.at(-1),
+      sourceLines,
+      sourceStart: sourceLines[0],
+      sourceEnd: sourceLines.at(-1),
     };
   });
 }
@@ -206,14 +236,16 @@ function indentationWidth(value: string): number {
   return Array.from(value).reduce((width, char) => width + (char === "\t" ? 4 : 1), 0);
 }
 
-function listItemHtml(list: Element, item: Element, index: number): string {
+function listSegmentHtml(list: Element, items: Element[], startIndex: number, endIndex: number): string {
   const wrapper = list.cloneNode(false) as Element;
   wrapper.classList.add("markdown-rich-diff__split-list");
   if (wrapper.tagName === "OL") {
     const start = parseInt(list.getAttribute("start") ?? "1", 10);
-    if (!Number.isNaN(start)) wrapper.setAttribute("start", String(start + index));
+    if (!Number.isNaN(start)) wrapper.setAttribute("start", String(start + startIndex));
   }
-  wrapper.append(item.cloneNode(true));
+  for (let index = startIndex; index <= endIndex; index++) {
+    wrapper.append(items[index]!.cloneNode(true));
+  }
   return wrapper.outerHTML;
 }
 

--- a/packages/ui/src/utils/markdown-rich-preview.ts
+++ b/packages/ui/src/utils/markdown-rich-preview.ts
@@ -1,0 +1,187 @@
+import type { DiffFile } from "../api/types.js";
+import { renderMarkdownBlocks, type RenderedMarkdownBlock, type RepoContext } from "./markdown.js";
+import { renderMarkdownDiff, renderMarkdownSplitDiff } from "./markdown-diff.js";
+
+type SourceLine = DiffFile["hunks"][number]["lines"][number];
+type DiffOp<T> =
+  | { kind: "equal"; oldItem: T; newItem: T }
+  | { kind: "delete"; oldItem: T }
+  | { kind: "insert"; newItem: T };
+
+interface MarkdownSideDocument {
+  text: string;
+  lineMap: Array<number | undefined>;
+}
+
+interface MarkdownSideBlock extends RenderedMarkdownBlock {
+  sourceStart?: number | undefined;
+  sourceEnd?: number | undefined;
+}
+
+export interface MarkdownRichPreviewBlock {
+  key: string;
+  oldStart?: number | undefined;
+  oldEnd?: number | undefined;
+  newStart?: number | undefined;
+  newEnd?: number | undefined;
+  unifiedHtml: string;
+  beforeHtml?: string | undefined;
+  afterHtml?: string | undefined;
+}
+
+export interface MarkdownRichPreview {
+  blocks: MarkdownRichPreviewBlock[];
+}
+
+export function buildMarkdownRichPreview(source: DiffFile, repo: RepoContext): MarkdownRichPreview {
+  const oldBlocks = buildSideBlocks(buildSideDocument(source, "old"), repo);
+  const newBlocks = buildSideBlocks(buildSideDocument(source, "new"), repo);
+  return { blocks: alignBlocks(oldBlocks, newBlocks) };
+}
+
+function buildSideDocument(source: DiffFile, side: "old" | "new"): MarkdownSideDocument {
+  const lines: Array<{ content: string; sourceLine?: number | undefined }> = [];
+  for (const hunk of source.hunks) {
+    if (lines.length > 0) {
+      lines.push({ content: "" }, { content: "---" }, { content: "" });
+    }
+    for (const line of hunk.lines) {
+      const sourceLine = side === "old" ? line.old_num : line.new_num;
+      if (sideIncludesLine(side, line)) lines.push({ content: line.content, sourceLine });
+    }
+  }
+  return {
+    text: `${lines.map((line) => line.content).join("\n")}\n`,
+    lineMap: lines.map((line) => line.sourceLine),
+  };
+}
+
+function sideIncludesLine(side: "old" | "new", line: SourceLine): boolean {
+  return side === "old" ? line.type !== "add" : line.type !== "delete";
+}
+
+function buildSideBlocks(document: MarkdownSideDocument, repo: RepoContext): MarkdownSideBlock[] {
+  return renderMarkdownBlocks(document.text, repo).map((block) => {
+    const range = sourceRangeForBlock(block, document.lineMap);
+    return {
+      ...block,
+      sourceStart: range.start,
+      sourceEnd: range.end,
+    };
+  });
+}
+
+function sourceRangeForBlock(
+  block: RenderedMarkdownBlock,
+  lineMap: Array<number | undefined>,
+): { start?: number | undefined; end?: number | undefined } {
+  const sourceLines = lineMap.slice(block.startLine - 1, block.endLine).filter((line): line is number => line != null);
+  return {
+    start: sourceLines[0],
+    end: sourceLines.at(-1),
+  };
+}
+
+function alignBlocks(oldBlocks: MarkdownSideBlock[], newBlocks: MarkdownSideBlock[]): MarkdownRichPreviewBlock[] {
+  const ops = diffSequence(oldBlocks, newBlocks, (oldBlock, newBlock) => oldBlock.html === newBlock.html);
+  const blocks: MarkdownRichPreviewBlock[] = [];
+  for (let i = 0; i < ops.length; i++) {
+    const op = ops[i]!;
+    if (op.kind === "equal") {
+      blocks.push(renderBlock(blocks.length, op.oldItem, op.newItem));
+      continue;
+    }
+    if (op.kind === "insert") {
+      blocks.push(renderBlock(blocks.length, undefined, op.newItem));
+      continue;
+    }
+
+    const deleteRun: MarkdownSideBlock[] = [];
+    while (ops[i]?.kind === "delete") {
+      deleteRun.push((ops[i] as Extract<DiffOp<MarkdownSideBlock>, { kind: "delete" }>).oldItem);
+      i++;
+    }
+
+    const insertRun: MarkdownSideBlock[] = [];
+    while (ops[i]?.kind === "insert") {
+      insertRun.push((ops[i] as Extract<DiffOp<MarkdownSideBlock>, { kind: "insert" }>).newItem);
+      i++;
+    }
+    i--;
+
+    const pairs = Math.min(deleteRun.length, insertRun.length);
+    for (let pair = 0; pair < pairs; pair++) {
+      blocks.push(renderBlock(blocks.length, deleteRun[pair], insertRun[pair]));
+    }
+    for (let index = pairs; index < deleteRun.length; index++) {
+      blocks.push(renderBlock(blocks.length, deleteRun[index], undefined));
+    }
+    for (let index = pairs; index < insertRun.length; index++) {
+      blocks.push(renderBlock(blocks.length, undefined, insertRun[index]));
+    }
+  }
+  return blocks;
+}
+
+function renderBlock(
+  index: number,
+  oldBlock: MarkdownSideBlock | undefined,
+  newBlock: MarkdownSideBlock | undefined,
+): MarkdownRichPreviewBlock {
+  const oldHtml = oldBlock?.html ?? "";
+  const newHtml = newBlock?.html ?? "";
+  const split = renderMarkdownSplitDiff(oldHtml, newHtml);
+  return {
+    key: `${index}:${oldBlock?.key ?? ""}:${newBlock?.key ?? ""}`,
+    oldStart: oldBlock?.sourceStart,
+    oldEnd: oldBlock?.sourceEnd,
+    newStart: newBlock?.sourceStart,
+    newEnd: newBlock?.sourceEnd,
+    unifiedHtml: renderMarkdownDiff(oldHtml, newHtml),
+    beforeHtml: split.beforeHtml,
+    afterHtml: split.afterHtml,
+  };
+}
+
+function diffSequence<T>(
+  oldItems: readonly T[],
+  newItems: readonly T[],
+  equal: (left: T, right: T) => boolean,
+): DiffOp<T>[] {
+  const rows = oldItems.length + 1;
+  const cols = newItems.length + 1;
+  const lengths = Array.from({ length: rows }, () => Array<number>(cols).fill(0));
+  for (let i = oldItems.length - 1; i >= 0; i--) {
+    for (let j = newItems.length - 1; j >= 0; j--) {
+      lengths[i]![j] = equal(oldItems[i]!, newItems[j]!)
+        ? lengths[i + 1]![j + 1]! + 1
+        : Math.max(lengths[i + 1]![j]!, lengths[i]![j + 1]!);
+    }
+  }
+
+  const ops: DiffOp<T>[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < oldItems.length && j < newItems.length) {
+    if (equal(oldItems[i]!, newItems[j]!)) {
+      ops.push({ kind: "equal", oldItem: oldItems[i]!, newItem: newItems[j]! });
+      i++;
+      j++;
+    } else if (lengths[i + 1]![j]! >= lengths[i]![j + 1]!) {
+      ops.push({ kind: "delete", oldItem: oldItems[i]! });
+      i++;
+    } else {
+      ops.push({ kind: "insert", newItem: newItems[j]! });
+      j++;
+    }
+  }
+  while (i < oldItems.length) {
+    ops.push({ kind: "delete", oldItem: oldItems[i]! });
+    i++;
+  }
+  while (j < newItems.length) {
+    ops.push({ kind: "insert", newItem: newItems[j]! });
+    j++;
+  }
+  return ops;
+}

--- a/packages/ui/src/utils/markdown-rich-preview.ts
+++ b/packages/ui/src/utils/markdown-rich-preview.ts
@@ -282,7 +282,7 @@ function alignBlocks(oldBlocks: MarkdownSideBlock[], newBlocks: MarkdownSideBloc
   if (oldBlocks.length * newBlocks.length > MAX_BLOCK_COMPARISON_SIZE) {
     return renderCoarseBlocks(oldBlocks, newBlocks);
   }
-  const ops = diffSequence(oldBlocks, newBlocks, (oldBlock, newBlock) => oldBlock.html === newBlock.html);
+  const ops = diffSequence(oldBlocks, newBlocks, blocksAlign);
   const blocks: MarkdownRichPreviewBlock[] = [];
   for (let i = 0; i < ops.length; i++) {
     const op = ops[i]!;
@@ -322,6 +322,17 @@ function alignBlocks(oldBlocks: MarkdownSideBlock[], newBlocks: MarkdownSideBloc
   return blocks;
 }
 
+function blocksAlign(oldBlock: MarkdownSideBlock, newBlock: MarkdownSideBlock): boolean {
+  return alignmentHtml(oldBlock.html) === alignmentHtml(newBlock.html);
+}
+
+function alignmentHtml(html: string): string {
+  return html.replace(/<ol\b([^>]*)>/g, (tag: string, attributes: string) => {
+    if (!attributes.includes("markdown-rich-diff__split-list")) return tag;
+    return `<ol${attributes.replace(/\sstart="\d+"/, "")}>`;
+  });
+}
+
 function renderCoarseBlocks(
   oldBlocks: MarkdownSideBlock[],
   newBlocks: MarkdownSideBlock[],
@@ -352,7 +363,8 @@ function renderBlock(
     newStart: newBlock?.sourceStart,
     newEnd: newBlock?.sourceEnd,
     newLines: newBlock?.sourceLines,
-    unifiedHtml: renderMarkdownDiff(oldHtml, newHtml),
+    unifiedHtml:
+      oldBlock && newBlock && blocksAlign(oldBlock, newBlock) ? newHtml : renderMarkdownDiff(oldHtml, newHtml),
     beforeHtml: split.beforeHtml,
     afterHtml: split.afterHtml,
   };

--- a/packages/ui/src/utils/markdown-rich-preview.ts
+++ b/packages/ui/src/utils/markdown-rich-preview.ts
@@ -44,9 +44,18 @@ export interface MarkdownRichPreview {
   blocks: MarkdownRichPreviewBlock[];
 }
 
-export function buildMarkdownRichPreview(source: DiffFile, repo: RepoContext): MarkdownRichPreview {
-  const oldBlocks = buildSideBlocks(buildSideDocument(source, "old"), repo);
-  const newBlocks = buildSideBlocks(buildSideDocument(source, "new"), repo);
+export interface MarkdownRichPreviewOptions {
+  splitOldLines?: readonly number[] | undefined;
+  splitNewLines?: readonly number[] | undefined;
+}
+
+export function buildMarkdownRichPreview(
+  source: DiffFile,
+  repo: RepoContext,
+  options: MarkdownRichPreviewOptions = {},
+): MarkdownRichPreview {
+  const oldBlocks = buildSideBlocks(buildSideDocument(source, "old"), repo, new Set(options.splitOldLines ?? []));
+  const newBlocks = buildSideBlocks(buildSideDocument(source, "new"), repo, new Set(options.splitNewLines ?? []));
   return { blocks: alignBlocks(oldBlocks, newBlocks) };
 }
 
@@ -72,10 +81,14 @@ function sideIncludesLine(side: "old" | "new", line: SourceLine): boolean {
   return side === "old" ? line.type !== "add" : line.type !== "delete";
 }
 
-function buildSideBlocks(document: MarkdownSideDocument, repo: RepoContext): MarkdownSideBlock[] {
+function buildSideBlocks(
+  document: MarkdownSideDocument,
+  repo: RepoContext,
+  splitLines: ReadonlySet<number>,
+): MarkdownSideBlock[] {
   const definitionLines = extractMarkdownDefinitionLines(document.text, repo);
   return renderMarkdownBlocks(document.text, repo).flatMap((block) =>
-    renderedSideBlocks(block, document, repo, definitionLines),
+    renderedSideBlocks(block, document, repo, definitionLines, splitLines),
   );
 }
 
@@ -84,9 +97,10 @@ function renderedSideBlocks(
   document: MarkdownSideDocument,
   repo: RepoContext,
   definitionLines: string[],
+  splitLines: ReadonlySet<number>,
 ): MarkdownSideBlock[] {
   const blockLineMap = document.lineMap.slice(block.startLine - 1, block.endLine);
-  if (blockLineMap.every((line) => line != null)) return sideBlocksForRenderedBlock(block, document);
+  if (blockLineMap.every((line) => line != null)) return sideBlocksForRenderedBlock(block, document, splitLines);
 
   const lines = document.lines
     .slice(block.startLine - 1, block.endLine)
@@ -97,13 +111,25 @@ function renderedSideBlocks(
   const visibleDocument = buildVisibleDocument(lines, definitionLines);
   return renderMarkdownBlocks(visibleDocument.text, repo)
     .map((visibleBlock) =>
-      sideBlocksForRenderedBlock({ ...visibleBlock, key: `${block.key}:${visibleBlock.key}` }, visibleDocument),
+      sideBlocksForRenderedBlock(
+        { ...visibleBlock, key: `${block.key}:${visibleBlock.key}` },
+        visibleDocument,
+        splitLines,
+      ),
     )
     .flat();
 }
 
-function sideBlocksForRenderedBlock(block: RenderedMarkdownBlock, document: MarkdownSideDocument): MarkdownSideBlock[] {
-  return splitListBlock(block, document) ?? [sideBlockForRenderedBlock(block, document.lineMap)];
+function sideBlocksForRenderedBlock(
+  block: RenderedMarkdownBlock,
+  document: MarkdownSideDocument,
+  splitLines: ReadonlySet<number>,
+): MarkdownSideBlock[] {
+  const sourceLines = sourceLinesForBlock(block, document.lineMap);
+  if (sourceLines.some((line) => splitLines.has(line))) {
+    return splitListBlock(block, document) ?? [sideBlockForRenderedBlock(block, document.lineMap)];
+  }
+  return [sideBlockForRenderedBlock(block, document.lineMap)];
 }
 
 interface ListItemLineGroup {

--- a/packages/ui/src/utils/markdown.ts
+++ b/packages/ui/src/utils/markdown.ts
@@ -5,7 +5,7 @@ import { canonicalProvider } from "../api/provider-routes.js";
 import { itemReferenceAnchorAttributes } from "./item-reference.js";
 import type { ItemReferenceType } from "./item-reference.js";
 
-interface RepoContext {
+export interface RepoContext {
   provider: string;
   platformHost?: string | undefined;
   owner: string;
@@ -167,6 +167,19 @@ let renderState: {
 
 const htmlCache = new Map<string, string>();
 const markedCache = new Map<string, Marked>();
+const MARKDOWN_ALLOWED_ATTRS = [
+  "target",
+  "data-provider",
+  "data-platform-host",
+  "data-owner",
+  "data-name",
+  "data-repo-path",
+  "data-number",
+  "data-item-type",
+  "data-external-url",
+  "data-task-index",
+  "draggable",
+];
 
 // Six-dot drag handle SVG used to grab a task-list item. Inlined so
 // the rendered markdown is self-contained and no extra fetch is needed.
@@ -263,6 +276,70 @@ function getMarked(repo?: RepoContext): Marked {
   return instance;
 }
 
+export interface RenderedMarkdownBlock {
+  key: string;
+  startLine: number;
+  endLine: number;
+  html: string;
+}
+
+function resetRenderState(opts: RenderMarkdownOpts): void {
+  renderState = {
+    taskIndex: 0,
+    interactiveTasks: !!opts.interactiveTasks,
+    itemStack: [],
+    blockquoteDepth: 0,
+  };
+}
+
+function sanitizeMarkdownHtml(html: string): string {
+  return DOMPurify.sanitize(html, {
+    ADD_ATTR: MARKDOWN_ALLOWED_ATTRS,
+  });
+}
+
+function visibleTokenLineCount(raw: string): number {
+  if (!raw) return 0;
+  const visibleRaw = raw.endsWith("\n") ? raw.slice(0, -1) : raw;
+  if (!visibleRaw) return 0;
+  return visibleRaw.split("\n").length;
+}
+
+function tokenLineBreakCount(raw: string): number {
+  return raw.match(/\n/g)?.length ?? 0;
+}
+
+function tokenRendersVisibleBlock(token: Tokens.Generic): boolean {
+  return token.type !== "space" && token.type !== "def";
+}
+
+export function renderMarkdownBlocks(
+  raw: string,
+  repo?: RepoContext,
+  opts: RenderMarkdownOpts = {},
+): RenderedMarkdownBlock[] {
+  if (!raw) return [];
+  const marked = getMarked(repo);
+  const tokens = marked.lexer(raw) as Tokens.Generic[];
+  resetRenderState(opts);
+  const blocks: RenderedMarkdownBlock[] = [];
+  let line = 1;
+  for (const token of tokens) {
+    const startLine = line;
+    const lineCount = visibleTokenLineCount(token.raw);
+    if (tokenRendersVisibleBlock(token) && lineCount > 0) {
+      blocks.push({
+        key: `${blocks.length}:${token.type}:${startLine}`,
+        startLine,
+        endLine: startLine + lineCount - 1,
+        html: sanitizeMarkdownHtml(marked.parser([token]) as string),
+      });
+    }
+    line += tokenLineBreakCount(token.raw);
+  }
+  return blocks;
+}
+
 export function renderMarkdown(raw: string, repo?: RepoContext, opts: RenderMarkdownOpts = {}): string {
   if (!raw) return "";
   const interactiveTasks = !!opts.interactiveTasks;
@@ -271,27 +348,8 @@ export function renderMarkdown(raw: string, repo?: RepoContext, opts: RenderMark
   const cached = htmlCache.get(key);
   if (cached !== undefined) return cached;
 
-  renderState = {
-    taskIndex: 0,
-    interactiveTasks,
-    itemStack: [],
-    blockquoteDepth: 0,
-  };
-  const html = DOMPurify.sanitize(getMarked(repo).parse(raw) as string, {
-    ADD_ATTR: [
-      "target",
-      "data-provider",
-      "data-platform-host",
-      "data-owner",
-      "data-name",
-      "data-repo-path",
-      "data-number",
-      "data-item-type",
-      "data-external-url",
-      "data-task-index",
-      "draggable",
-    ],
-  });
+  resetRenderState(opts);
+  const html = sanitizeMarkdownHtml(getMarked(repo).parse(raw) as string);
   if (htmlCache.size > 500) htmlCache.clear();
   htmlCache.set(key, html);
   return html;

--- a/packages/ui/src/utils/markdown.ts
+++ b/packages/ui/src/utils/markdown.ts
@@ -340,6 +340,19 @@ export function renderMarkdownBlocks(
   return blocks;
 }
 
+export function extractMarkdownDefinitionLines(raw: string, repo?: RepoContext): string[] {
+  if (!raw) return [];
+  const marked = getMarked(repo);
+  const tokens = marked.lexer(raw) as Tokens.Generic[];
+  const lines: string[] = [];
+  for (const token of tokens) {
+    if (token.type !== "def" || !token.raw) continue;
+    const raw = token.raw.endsWith("\n") ? token.raw.slice(0, -1) : token.raw;
+    if (raw) lines.push(...raw.split("\n"));
+  }
+  return lines;
+}
+
 export function renderMarkdown(raw: string, repo?: RepoContext, opts: RenderMarkdownOpts = {}): string {
   if (!raw) return "";
   const interactiveTasks = !!opts.interactiveTasks;


### PR DESCRIPTION
Rich Markdown preview should preserve the location context of line review comments. The previous behavior made cards visible but placed them before the rendered file, which disconnected comments from the section they discuss and made the preview worse than the source diff for review workflows.

This anchors review cards to the rendered Markdown block that contains the target line while keeping unanchored and file-level review threads as preview-level fallback.

Validation: component diff tests, ui-package-check, focused and existing diff-view Playwright e2e, formatter checks, git diff --check, and live browser DOM verification on the ephemeral dev server.

Visual capture was checked locally from the live middleman app but not uploaded because it contains live app data.