### PR TITLE
fix: honor local Kata daemon auth

### DIFF
--- a/internal/kata/auth.go
+++ b/internal/kata/auth.go
@@ -1,0 +1,47 @@
+package kata
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+const authTokenEnv = "KATA_AUTH_TOKEN"
+
+type authFile struct {
+	Auth authConfig `toml:"auth"`
+}
+
+type authConfig struct {
+	Token string `toml:"token"`
+}
+
+// ResolveLocalAuthToken mirrors Kata's local daemon auth source. Local daemon
+// entries stay tokenless in the daemon catalog; the local process auth token is
+// configured globally for the Kata home.
+func ResolveLocalAuthToken() (string, error) {
+	if token := strings.TrimSpace(os.Getenv(authTokenEnv)); token != "" {
+		return token, nil
+	}
+
+	path, err := CatalogPath()
+	if err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(path) //nolint:gosec // path derives from KATA_HOME, not request input.
+	if errors.Is(err, os.ErrNotExist) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("read kata config %s: %w", path, err)
+	}
+
+	var cfg authFile
+	if _, err := toml.Decode(string(data), &cfg); err != nil {
+		return "", fmt.Errorf("parse kata config %s: %w", path, err)
+	}
+	return strings.TrimSpace(cfg.Auth.Token), nil
+}

--- a/internal/kata/catalog.go
+++ b/internal/kata/catalog.go
@@ -27,8 +27,9 @@ type catalogEntry struct {
 	AllowInsecure bool   `toml:"allow_insecure"`
 }
 
-// LoadCatalog reads Kata's shared daemon catalog. Auth fields are retained
-// only for remote daemons; local entries are tokenless at the catalog boundary.
+// LoadCatalog reads Kata's shared daemon catalog. Per-daemon auth fields are
+// retained only for remote daemons; local entries are tokenless at the catalog
+// boundary and pick up Kata's global local auth during resolution.
 func LoadCatalog() (Catalog, error) {
 	path, err := CatalogPath()
 	if err != nil {

--- a/internal/kata/validation.go
+++ b/internal/kata/validation.go
@@ -77,11 +77,15 @@ func ValidateLocalTarget(d Daemon) error {
 	return nil
 }
 
-// ResolveDaemon resolves TokenEnv for remote daemons and validates the daemon target.
+// ResolveDaemon resolves auth material and validates the daemon target.
 func ResolveDaemon(d Daemon) (Daemon, error) {
 	if d.Local {
-		d.Token = ""
 		d.TokenEnv = ""
+		token, err := ResolveLocalAuthToken()
+		if err != nil {
+			return d, err
+		}
+		d.Token = token
 		return d, ValidateLocalTarget(d)
 	}
 	if d.TokenEnv != "" {

--- a/internal/kata/validation_test.go
+++ b/internal/kata/validation_test.go
@@ -108,6 +108,7 @@ func TestResolveDaemonLocalIgnoresTokenFields(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
 
+	t.Setenv("KATA_AUTH_TOKEN", "")
 	t.Setenv("KATA_TEST_TOKEN", "")
 
 	daemon, err := ResolveDaemon(Daemon{
@@ -120,6 +121,42 @@ func TestResolveDaemonLocalIgnoresTokenFields(t *testing.T) {
 	require.NoError(err)
 	assert.True(daemon.Local)
 	assert.Empty(daemon.Token)
+	assert.Empty(daemon.TokenEnv)
+}
+
+func TestResolveDaemonLocalUsesKataAuthTokenEnv(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	t.Setenv("KATA_AUTH_TOKEN", "local-secret")
+
+	daemon, err := ResolveDaemon(Daemon{ID: "local", Local: true})
+	require.NoError(err)
+
+	assert.Equal("local-secret", daemon.Token)
+	assert.Empty(daemon.TokenEnv)
+}
+
+func TestResolveDaemonLocalUsesKataAuthConfig(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_AUTH_TOKEN", "")
+	writeCatalog(t, home, `
+[auth]
+token = "local-config-secret"
+
+[[daemon]]
+name = "local"
+local = true
+`)
+
+	daemon, err := ResolveDaemon(Daemon{ID: "local", Local: true})
+	require.NoError(err)
+
+	assert.Equal("local-config-secret", daemon.Token)
 	assert.Empty(daemon.TokenEnv)
 }
 
@@ -144,6 +181,8 @@ func TestResolveDaemonInlineTokenPreserved(t *testing.T) {
 func TestResolveDaemonAllowsDynamicLocalEntry(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
+
+	t.Setenv("KATA_AUTH_TOKEN", "")
 
 	daemon, err := ResolveDaemon(Daemon{ID: "local", Local: true})
 	require.NoError(err)

--- a/internal/server/e2etest/kata_daemon_test.go
+++ b/internal/server/e2etest/kata_daemon_test.go
@@ -38,6 +38,7 @@ func TestKataLocalDaemonChallengeIsDownAndProxyUpstreamErrorE2E(t *testing.T) {
 
 	home := t.TempDir()
 	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_AUTH_TOKEN", "")
 	t.Setenv("KATA_DB", "")
 	writeKataE2ECatalog(t, home, `
 active_daemon = "local"
@@ -107,6 +108,7 @@ func TestKataLocalDaemonTokenEnvIsNotUsedForRosterOrProxyE2E(t *testing.T) {
 
 	home := t.TempDir()
 	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_AUTH_TOKEN", "")
 	t.Setenv("KATA_DB", "")
 	t.Setenv("MIDDLEMAN_KATA_MISSING_TOKEN", "")
 	writeKataE2ECatalog(t, home, `

--- a/internal/server/kata_proxy.go
+++ b/internal/server/kata_proxy.go
@@ -199,6 +199,9 @@ func newKataDaemonProxyEntry(d kata.Daemon) (kataProxyCacheEntry, error) {
 			pr.Out.Header.Del(kataDaemonHeaderName)
 			if d.Local {
 				pr.Out.Header.Del("Authorization")
+				if token := kataDaemonForwardToken(d); token != "" {
+					pr.Out.Header.Set("Authorization", "Bearer "+token)
+				}
 				return
 			}
 			if token := kataDaemonForwardToken(d); token != "" && pr.Out.Header.Get("Authorization") == "" {

--- a/internal/server/kata_proxy_test.go
+++ b/internal/server/kata_proxy_test.go
@@ -483,6 +483,7 @@ func TestKataProxyLocalDaemonResolvesRuntimeAfterServerStart(t *testing.T) {
 
 	home := t.TempDir()
 	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_AUTH_TOKEN", "")
 	t.Setenv("KATA_DB", "")
 	writeKataProxyCatalog(t, home, `
 active_daemon = "local"
@@ -533,6 +534,7 @@ func TestKataProxyLocalNoAuthDoesNotForwardAuthChallenge(t *testing.T) {
 
 	home := t.TempDir()
 	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_AUTH_TOKEN", "")
 	t.Setenv("KATA_DB", "")
 	writeKataProxyCatalog(t, home, `
 active_daemon = "local"
@@ -568,6 +570,7 @@ func TestKataProxyLocalDaemonStripsAuthorization(t *testing.T) {
 
 	home := t.TempDir()
 	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_AUTH_TOKEN", "")
 	t.Setenv("KATA_DB", "")
 	writeKataProxyCatalog(t, home, `
 active_daemon = "local"
@@ -594,6 +597,42 @@ token = "local-secret"
 	assert.Equal([]string{"", ""}, authorizations)
 }
 
+func TestKataProxyLocalDaemonUsesKataAuthTokenEnv(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	var receivedAuthorization string
+	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuthorization = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"instance":"local"}`))
+	}))
+	defer daemon.Close()
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_AUTH_TOKEN", "local-secret")
+	t.Setenv("KATA_DB", "")
+	writeKataProxyCatalog(t, home, `
+active_daemon = "local"
+
+[[daemon]]
+name = "local"
+local = true
+`)
+	writeKataProxyRuntimeRecord(t, daemon.URL)
+	srv, _ := setupTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/kata/proxy/api/v1/instance", nil)
+	req.Header.Set("Authorization", "Bearer caller-secret")
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+	assert.JSONEq(`{"instance":"local"}`, rr.Body.String())
+	assert.Equal("Bearer local-secret", receivedAuthorization)
+}
+
 func TestKataProxyCacheSeparatesLocalAndRemoteDaemonMode(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
@@ -610,6 +649,7 @@ func TestKataProxyCacheSeparatesLocalAndRemoteDaemonMode(t *testing.T) {
 
 	home := t.TempDir()
 	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_AUTH_TOKEN", "")
 	t.Setenv("KATA_DB", "")
 	writeKataProxyCatalog(t, home, `
 active_daemon = "home"
@@ -657,6 +697,7 @@ func TestKataProxyLocalDaemonIgnoresTokenEnv(t *testing.T) {
 
 	home := t.TempDir()
 	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_AUTH_TOKEN", "")
 	t.Setenv("KATA_DB", "")
 	t.Setenv("MIDDLEMAN_KATA_MISSING_TOKEN", "")
 	writeKataProxyCatalog(t, home, `

--- a/internal/server/kata_routes.go
+++ b/internal/server/kata_routes.go
@@ -91,7 +91,7 @@ func (s *Server) listKataDaemons(context.Context, *struct{}) (*listKataDaemonsOu
 	for i, configured := range catalog.Daemons {
 		d := resolved[i]
 		auth := "none"
-		if !d.Local && kataDaemonForwardToken(d) != "" {
+		if kataDaemonForwardToken(d) != "" {
 			auth = "token"
 		}
 		hint := ""
@@ -168,10 +168,11 @@ func (s *Server) kataDaemonHealth(id string, d kata.Daemon) string {
 }
 
 func kataDaemonHealthCacheKey(id string, d kata.Daemon) string {
+	mode := "remote"
 	if d.Local {
-		return strings.Join([]string{id, d.URL, "local", ""}, kataDaemonCacheKeyDelim)
+		mode = "local"
 	}
-	return strings.Join([]string{id, d.URL, "remote", kataDaemonForwardToken(d)}, kataDaemonCacheKeyDelim)
+	return strings.Join([]string{id, d.URL, mode, kataDaemonForwardToken(d)}, kataDaemonCacheKeyDelim)
 }
 
 func probeKataDaemon(id string, d kata.Daemon) string {
@@ -192,10 +193,8 @@ func probeKataDaemon(id string, d kata.Daemon) string {
 	if err != nil {
 		return "down"
 	}
-	if !d.Local {
-		if token := kataDaemonForwardToken(d); token != "" {
-			req.Header.Set("Authorization", "Bearer "+token)
-		}
+	if token := kataDaemonForwardToken(d); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
 	}
 
 	client := &http.Client{
@@ -231,13 +230,12 @@ func probeKataDaemon(id string, d kata.Daemon) string {
 }
 
 func isKataLocalDaemonChallenge(d kata.Daemon, statusCode int) bool {
-	return d.Local && (statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden)
+	return d.Local &&
+		kataDaemonForwardToken(d) == "" &&
+		(statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden)
 }
 
 func kataDaemonForwardToken(d kata.Daemon) string {
-	if d.Local {
-		return ""
-	}
 	return d.Token
 }
 

--- a/internal/server/kata_routes_test.go
+++ b/internal/server/kata_routes_test.go
@@ -202,6 +202,7 @@ func TestKataDaemonsEndpointReportsDownLocalWithHint(t *testing.T) {
 
 	home := t.TempDir()
 	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_AUTH_TOKEN", "")
 	t.Setenv("KATA_DB", "")
 	writeKataServerCatalog(t, home, `
 [[daemon]]
@@ -231,6 +232,7 @@ func TestKataDaemonsEndpointDoesNotReportAuthRequiredForLocalNoAuthDaemon(t *tes
 
 	home := t.TempDir()
 	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_AUTH_TOKEN", "")
 	t.Setenv("KATA_DB", "")
 	writeKataServerCatalog(t, home, `
 [[daemon]]
@@ -257,6 +259,7 @@ func TestKataDaemonsEndpointLocalDaemonDoesNotUseTokenAuth(t *testing.T) {
 
 	home := t.TempDir()
 	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_AUTH_TOKEN", "")
 	t.Setenv("KATA_DB", "")
 	writeKataServerCatalog(t, home, `
 [[daemon]]
@@ -273,6 +276,39 @@ token = "local-secret"
 	assert.Equal("connected", got["local"].Health)
 }
 
+func TestKataDaemonsEndpointLocalDaemonUsesKataAuthTokenEnv(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("Bearer local-secret", r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer daemon.Close()
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_AUTH_TOKEN", "local-secret")
+	t.Setenv("KATA_DB", "")
+	writeKataServerCatalog(t, home, `
+[[daemon]]
+name = "local"
+local = true
+`)
+	writeKataProxyRuntimeRecord(t, daemon.URL)
+	srv, _ := setupTestServer(t)
+
+	rr := doJSON(t, srv, http.MethodGet, "/api/v1/kata/daemons", nil)
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+	assert.NotContains(rr.Body.String(), "local-secret")
+
+	var body kataDaemonRosterWire
+	require.NoError(json.NewDecoder(rr.Body).Decode(&body))
+	require.Len(body.Daemons, 1)
+	assert.Equal("token", body.Daemons[0].Auth)
+	assert.Equal("connected", body.Daemons[0].Health)
+}
+
 func TestKataDaemonsEndpointLocalDaemonIgnoresTokenEnv(t *testing.T) {
 	assert := Assert.New(t)
 
@@ -284,6 +320,7 @@ func TestKataDaemonsEndpointLocalDaemonIgnoresTokenEnv(t *testing.T) {
 
 	home := t.TempDir()
 	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_AUTH_TOKEN", "")
 	t.Setenv("KATA_DB", "")
 	t.Setenv("MIDDLEMAN_KATA_MISSING_TOKEN", "")
 	writeKataServerCatalog(t, home, `
@@ -452,6 +489,7 @@ func TestKataDaemonsEndpointHealthCacheSeparatesLocalAndRemoteMode(t *testing.T)
 
 	home := t.TempDir()
 	t.Setenv("KATA_HOME", home)
+	t.Setenv("KATA_AUTH_TOKEN", "")
 	t.Setenv("KATA_DB", "")
 	writeKataServerCatalog(t, home, `
 [[daemon]]


### PR DESCRIPTION
Local Kata daemons can be token-protected through Kata's global auth settings, even when the catalog entry is `local = true` and has no per-daemon token. Middleman previously assumed local daemons were always unauthenticated, so a daemon started with `KATA_AUTH_TOKEN` looked reachable to the Kata CLI but failed middleman health/proxy requests as an upstream error.

This PR makes middleman resolve local daemon auth from Kata's local sources while preserving the catalog rule that local `[[daemon]]` token fields are ignored. Local proxy requests still discard caller-provided `Authorization` and substitute only the resolved Kata token.

Validation: `go test ./internal/kata ./internal/server ./internal/server/e2etest -run 'TestKata|TestResolveDaemon|TestLoadCatalog' -shuffle=on`; `go test ./internal/kata ./internal/server ./internal/server/e2etest -shuffle=on`; `git diff --check`.