### PR TITLE
Make fleet federation opt-in

### DIFF
--- a/context/ui-design-system.md
+++ b/context/ui-design-system.md
@@ -192,6 +192,7 @@ theme overrides, or Shadow DOM CSS into another component.
 Use semantic variables instead of hard-coded values whenever possible.
 
 - Surfaces and borders come from the app token set in `frontend/src/app.css`
+- Spacing uses the shared `--space-*` scale in `frontend/src/app.css` before local pixel values
 - Text uses the shared primary / secondary / muted hierarchy
 - Accent colors carry meaning, not decoration
 

--- a/context/ui-design-system.md
+++ b/context/ui-design-system.md
@@ -192,7 +192,6 @@ theme overrides, or Shadow DOM CSS into another component.
 Use semantic variables instead of hard-coded values whenever possible.
 
 - Surfaces and borders come from the app token set in `frontend/src/app.css`
-- Spacing uses the shared `--space-*` scale in `frontend/src/app.css` before local pixel values
 - Text uses the shared primary / secondary / muted hierarchy
 - Accent colors carry meaning, not decoration
 

--- a/docs/federated-fleet.md
+++ b/docs/federated-fleet.md
@@ -42,6 +42,9 @@ always hub → peer, one hop.
 
 ```toml
 [fleet]
+# Fleet federation is opt-in. Set this on hubs that should fetch and
+# proxy remote peers; leaving it false keeps remote hosts unavailable.
+enabled = true
 # This daemon's identity in the fleet. Required to be unique across
 # the fleet; empty means "anonymous member" (can be a peer, cannot
 # meaningfully host).

--- a/docs/superpowers/plans/2026-06-18-fleet-federation-settings.md
+++ b/docs/superpowers/plans/2026-06-18-fleet-federation-settings.md
@@ -1,0 +1,196 @@
+# Fleet Federation Settings Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add opt-in remote fleet federation settings without disabling local workspace behavior.
+
+**Architecture:** Add `fleet.enabled` to config and expose a focused fleet settings API shape. Gate remote peer fan-out and remote peer proxy resolution on that flag while leaving local snapshots and self routing intact. Add a Svelte settings section for federation and hide the workspace sidebar fleet indicator when the backend returns only local-host state.
+
+**Tech Stack:** Go, Huma, TOML config, generated OpenAPI clients, Svelte 5, Vite+ Vitest.
+
+---
+
+### Task 1: Backend Config And Fleet Gate
+
+**Files:**
+- Modify: `internal/config/config.go`
+- Modify: `internal/config/config_test.go`
+- Modify: `internal/server/fleet_hub.go`
+- Modify: `internal/server/fleet_proxy.go`
+- Test: `internal/server/fleet_hub_test.go`
+- Test: `internal/server/fleet_proxy_test.go`
+
+- [ ] **Step 1: Write failing config tests**
+
+Add tests in `internal/config/config_test.go` that load a config with no `fleet.enabled` and assert false, then round-trip a config with `Fleet.Enabled = true` through `Save` and `Load`.
+
+- [ ] **Step 2: Run config tests to verify failure**
+
+Run: `go test ./internal/config -run 'Test(FleetConfigParsesAndValidates|SaveRoundTripsFleet)' -shuffle=on`
+
+Expected: failure because `Fleet.Enabled` does not exist.
+
+- [ ] **Step 3: Implement config field**
+
+Add `Enabled bool 'toml:"enabled,omitempty" json:"enabled"'` to `config.Fleet`. Update default config comments to show `[fleet] enabled = false`.
+
+- [ ] **Step 4: Run config tests to verify pass**
+
+Run: `go test ./internal/config -run 'Test(FleetConfigParsesAndValidates|SaveRoundTripsFleet)' -shuffle=on`
+
+Expected: pass.
+
+- [ ] **Step 5: Write failing server gate tests**
+
+Add tests proving `buildFleetSnapshot(..., true)` does not fetch HTTP peers when `Fleet.Enabled` is false, does fetch when true, and `resolveFleetHostTarget` does not resolve configured remote peers when disabled while preserving self routing.
+
+- [ ] **Step 6: Run server gate tests to verify failure**
+
+Run: `go test ./internal/server -run 'TestBuildFleetSnapshot|TestResolveFleetHostTarget' -shuffle=on`
+
+Expected: disabled tests fail because current code always includes configured peers.
+
+- [ ] **Step 7: Implement backend gate**
+
+In `buildFleetSnapshot`, fetch HTTP and SSH peers only when `includePeers && fleetCfg.Enabled`. In `resolveFleetHostTarget`, return remote HTTP/SSH peer targets only when `cfg.Fleet.Enabled`; keep self alias behavior unchanged.
+
+- [ ] **Step 8: Run server gate tests to verify pass**
+
+Run: `go test ./internal/server -run 'TestBuildFleetSnapshot|TestResolveFleetHostTarget' -shuffle=on`
+
+Expected: pass.
+
+### Task 2: Fleet Settings API
+
+**Files:**
+- Modify: `internal/server/settings_handlers.go`
+- Modify: `internal/server/settings_routes.go`
+- Modify: `internal/server/e2etest/settings_test.go`
+- Modify: `internal/server/config_reload.go`
+- Modify: `internal/server/config_reload_test.go`
+- Generated: `packages/ui/src/api/generated/schema.ts`
+- Generated: `internal/apiclient/generated/client.gen.go`
+
+- [ ] **Step 1: Write failing settings API tests**
+
+Add e2e tests for `GET /api/v1/settings` returning `fleet`, `PUT /api/v1/settings/fleet` preserving peers while toggling disabled, and invalid peer inputs returning `400`.
+
+- [ ] **Step 2: Run settings API tests to verify failure**
+
+Run: `go test ./internal/server/e2etest -run TestSettingsAPI -shuffle=on`
+
+Expected: failure because the fleet settings route/shape does not exist.
+
+- [ ] **Step 3: Implement fleet settings shape and route**
+
+Add `fleetSettingsResponse`, `updateFleetSettingsRequest`, `getFleetSettings`, and `updateFleetSettings` using full-config validation and rollback on save errors. Include `restart_required`.
+
+- [ ] **Step 4: Update restart-required comparison**
+
+Include `Fleet.Enabled`, `Fleet.Key`, `Fleet.PeerTimeout`, and HTTP peers in hot-reload behavior while preserving restart-required for SSH peers and `Fleet.Sessions`.
+
+- [ ] **Step 5: Run settings API tests to verify pass**
+
+Run: `go test ./internal/server/e2etest -run TestSettingsAPI -shuffle=on`
+
+Expected: pass.
+
+- [ ] **Step 6: Regenerate API clients**
+
+Run: `make api-generate`
+
+Expected: generated schema/client files include fleet settings types and `/settings/fleet`.
+
+### Task 3: Frontend API And Settings Panel
+
+**Files:**
+- Modify: `packages/ui/src/api/types.ts`
+- Modify: `frontend/src/lib/api/settings.ts`
+- Modify: `frontend/src/lib/components/settings/SettingsPage.svelte`
+- Create: `frontend/src/lib/components/settings/FleetSettings.svelte`
+- Test: `frontend/src/lib/components/settings/FleetSettings.test.ts`
+
+- [ ] **Step 1: Write failing frontend settings tests**
+
+Add tests that render `FleetSettings`, show default disabled state, keep HTTP and SSH membership visible while disabled, save through `updateFleetSettings`, and surface save errors.
+
+- [ ] **Step 2: Run frontend settings tests to verify failure**
+
+Run: `cd frontend && node ../node_modules/vite-plus/bin/vp test run src/lib/components/settings/FleetSettings.test.ts`
+
+Expected: failure because `FleetSettings.svelte` and `updateFleetSettings` do not exist.
+
+- [ ] **Step 3: Implement API helper and types**
+
+Export fleet setting types from `packages/ui/src/api/types.ts`. Add `updateFleetSettings` to `frontend/src/lib/api/settings.ts` using `PUT /settings/fleet`.
+
+- [ ] **Step 4: Implement settings component**
+
+Create `FleetSettings.svelte` with integrated toggle, optional key, timeout, unmanaged session detail toggle, HTTP peer rows, SSH peer rows, save/reset controls, and restrained disabled-state/help text.
+
+- [ ] **Step 5: Wire into SettingsPage**
+
+Add a Workspace nav item and render `FleetSettings` under Workspace. Update local settings state after save.
+
+- [ ] **Step 6: Run frontend settings tests and Svelte autofixer**
+
+Run: `cd frontend && node ../node_modules/vite-plus/bin/vp test run src/lib/components/settings/FleetSettings.test.ts`
+
+Run: `node node_modules/vite-plus/bin/vp exec svelte-mcp svelte-autofixer ./frontend/src/lib/components/settings/FleetSettings.svelte`
+
+Expected: tests pass and autofixer reports no required changes.
+
+### Task 4: Workspace Sidebar Fleet Indicator
+
+**Files:**
+- Modify: `frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte`
+- Test: `frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts`
+
+- [ ] **Step 1: Write failing sidebar test**
+
+Update the current local-host-only test so it expects no `Fleet` status block when the snapshot contains only the self host.
+
+- [ ] **Step 2: Run sidebar test to verify failure**
+
+Run: `cd frontend && node ../node_modules/vite-plus/bin/vp test run src/lib/components/terminal/WorkspaceListSidebar.test.ts`
+
+Expected: failure because the component currently renders the fleet block for a single local host.
+
+- [ ] **Step 3: Implement hide condition**
+
+Change `showFleetStatus` so it renders only when there is a remote host or a fleet error related to remote status. Keep remote workspace loading based on reachable remote hosts.
+
+- [ ] **Step 4: Run sidebar tests and Svelte autofixer**
+
+Run: `cd frontend && node ../node_modules/vite-plus/bin/vp test run src/lib/components/terminal/WorkspaceListSidebar.test.ts`
+
+Run: `node node_modules/vite-plus/bin/vp exec svelte-mcp svelte-autofixer ./frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte`
+
+Expected: tests pass and autofixer reports no required changes.
+
+### Task 5: Final Verification
+
+**Files:**
+- All modified files
+
+- [ ] **Step 1: Run focused Go tests**
+
+Run: `go test ./internal/config ./internal/server ./internal/server/e2etest -run 'Test(Fleet|Settings|ConfigReload)' -shuffle=on`
+
+Expected: pass.
+
+- [ ] **Step 2: Run focused frontend tests**
+
+Run: `cd frontend && node ../node_modules/vite-plus/bin/vp test run src/lib/components/settings/FleetSettings.test.ts src/lib/components/terminal/WorkspaceListSidebar.test.ts`
+
+Expected: pass.
+
+- [ ] **Step 3: Run API generation check**
+
+Run: `make api-generate`
+
+Expected: no additional generated diff after the previous generation.
+
+- [ ] **Step 4: Review diff and commit**
+
+Run: `git status --short`, `git diff --stat`, and `git diff --check`. Stage relevant files and commit with hooks enabled.

--- a/docs/superpowers/plans/2026-06-18-fleet-federation-settings.md
+++ b/docs/superpowers/plans/2026-06-18-fleet-federation-settings.md
@@ -1,6 +1,6 @@
 # Fleet Federation Settings Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
 
 **Goal:** Add opt-in remote fleet federation settings without disabling local workspace behavior.
 
@@ -20,41 +20,41 @@
 - Test: `internal/server/fleet_hub_test.go`
 - Test: `internal/server/fleet_proxy_test.go`
 
-- [ ] **Step 1: Write failing config tests**
+- [x] **Step 1: Write failing config tests**
 
 Add tests in `internal/config/config_test.go` that load a config with no `fleet.enabled` and assert false, then round-trip a config with `Fleet.Enabled = true` through `Save` and `Load`.
 
-- [ ] **Step 2: Run config tests to verify failure**
+- [x] **Step 2: Run config tests to verify failure**
 
 Run: `go test ./internal/config -run 'Test(FleetConfigParsesAndValidates|SaveRoundTripsFleet)' -shuffle=on`
 
 Expected: failure because `Fleet.Enabled` does not exist.
 
-- [ ] **Step 3: Implement config field**
+- [x] **Step 3: Implement config field**
 
 Add `Enabled bool 'toml:"enabled,omitempty" json:"enabled"'` to `config.Fleet`. Update default config comments to show `[fleet] enabled = false`.
 
-- [ ] **Step 4: Run config tests to verify pass**
+- [x] **Step 4: Run config tests to verify pass**
 
 Run: `go test ./internal/config -run 'Test(FleetConfigParsesAndValidates|SaveRoundTripsFleet)' -shuffle=on`
 
 Expected: pass.
 
-- [ ] **Step 5: Write failing server gate tests**
+- [x] **Step 5: Write failing server gate tests**
 
-Add tests proving `buildFleetSnapshot(..., true)` does not fetch HTTP peers when `Fleet.Enabled` is false, does fetch when true, and `resolveFleetHostTarget` does not resolve configured remote peers when disabled while preserving self routing.
+Add tests proving `buildFleetSnapshot(..., true)` does not fetch HTTP peers when `Fleet.Enabled` is false, does fetch when true, and `resolveFleetHostTarget` does not resolve configured remote peers when disabled while preserving self routing. Add full-stack HTTP coverage in `internal/server/e2etest` for disabled HTTP and SSH peer membership so snapshot fan-out makes zero peer calls, remote proxy routes return `notFound`, and self-host routing remains available.
 
-- [ ] **Step 6: Run server gate tests to verify failure**
+- [x] **Step 6: Run server gate tests to verify failure**
 
 Run: `go test ./internal/server -run 'TestBuildFleetSnapshot|TestResolveFleetHostTarget' -shuffle=on`
 
 Expected: disabled tests fail because current code always includes configured peers.
 
-- [ ] **Step 7: Implement backend gate**
+- [x] **Step 7: Implement backend gate**
 
 In `buildFleetSnapshot`, fetch HTTP and SSH peers only when `includePeers && fleetCfg.Enabled`. In `resolveFleetHostTarget`, return remote HTTP/SSH peer targets only when `cfg.Fleet.Enabled`; keep self alias behavior unchanged.
 
-- [ ] **Step 8: Run server gate tests to verify pass**
+- [x] **Step 8: Run server gate tests to verify pass**
 
 Run: `go test ./internal/server -run 'TestBuildFleetSnapshot|TestResolveFleetHostTarget' -shuffle=on`
 
@@ -71,31 +71,31 @@ Expected: pass.
 - Generated: `packages/ui/src/api/generated/schema.ts`
 - Generated: `internal/apiclient/generated/client.gen.go`
 
-- [ ] **Step 1: Write failing settings API tests**
+- [x] **Step 1: Write failing settings API tests**
 
 Add e2e tests for `GET /api/v1/settings` returning `fleet`, `PUT /api/v1/settings/fleet` preserving peers while toggling disabled, and invalid peer inputs returning `400`.
 
-- [ ] **Step 2: Run settings API tests to verify failure**
+- [x] **Step 2: Run settings API tests to verify failure**
 
 Run: `go test ./internal/server/e2etest -run TestSettingsAPI -shuffle=on`
 
 Expected: failure because the fleet settings route/shape does not exist.
 
-- [ ] **Step 3: Implement fleet settings shape and route**
+- [x] **Step 3: Implement fleet settings shape and route**
 
-Add `fleetSettingsResponse`, `updateFleetSettingsRequest`, `getFleetSettings`, and `updateFleetSettings` using full-config validation and rollback on save errors. Include `restart_required`.
+Add `fleetSettingsResponse`, `updateFleetSettingsRequest`, `getFleetSettings`, and `updateFleetSettings` using full-config validation and rollback on save errors. Include `restart_required`, keep `GET /settings` bootstrapping the same fleet shape, and keep the existing `/settings/fleet/ssh-peers` route aligned with the same validation, persistence, rollback, and SSH restart-drift calculation.
 
-- [ ] **Step 4: Update restart-required comparison**
+- [x] **Step 4: Update restart-required comparison**
 
 Include `Fleet.Enabled`, `Fleet.Key`, `Fleet.PeerTimeout`, and HTTP peers in hot-reload behavior while preserving restart-required for SSH peers and `Fleet.Sessions`.
 
-- [ ] **Step 5: Run settings API tests to verify pass**
+- [x] **Step 5: Run settings API tests to verify pass**
 
 Run: `go test ./internal/server/e2etest -run TestSettingsAPI -shuffle=on`
 
 Expected: pass.
 
-- [ ] **Step 6: Regenerate API clients**
+- [x] **Step 6: Regenerate API clients**
 
 Run: `make api-generate`
 
@@ -110,29 +110,29 @@ Expected: generated schema/client files include fleet settings types and `/setti
 - Create: `frontend/src/lib/components/settings/FleetSettings.svelte`
 - Test: `frontend/src/lib/components/settings/FleetSettings.test.ts`
 
-- [ ] **Step 1: Write failing frontend settings tests**
+- [x] **Step 1: Write failing frontend settings tests**
 
 Add tests that render `FleetSettings`, show default disabled state, keep HTTP and SSH membership visible while disabled, save through `updateFleetSettings`, and surface save errors.
 
-- [ ] **Step 2: Run frontend settings tests to verify failure**
+- [x] **Step 2: Run frontend settings tests to verify failure**
 
 Run: `cd frontend && node ../node_modules/vite-plus/bin/vp test run src/lib/components/settings/FleetSettings.test.ts`
 
 Expected: failure because `FleetSettings.svelte` and `updateFleetSettings` do not exist.
 
-- [ ] **Step 3: Implement API helper and types**
+- [x] **Step 3: Implement API helper and types**
 
 Export fleet setting types from `packages/ui/src/api/types.ts`. Add `updateFleetSettings` to `frontend/src/lib/api/settings.ts` using `PUT /settings/fleet`.
 
-- [ ] **Step 4: Implement settings component**
+- [x] **Step 4: Implement settings component**
 
 Create `FleetSettings.svelte` with integrated toggle, optional key, timeout, unmanaged session detail toggle, HTTP peer rows, SSH peer rows, save/reset controls, and restrained disabled-state/help text.
 
-- [ ] **Step 5: Wire into SettingsPage**
+- [x] **Step 5: Wire into SettingsPage**
 
 Add a Workspace nav item and render `FleetSettings` under Workspace. Update local settings state after save.
 
-- [ ] **Step 6: Run frontend settings tests and Svelte autofixer**
+- [x] **Step 6: Run frontend settings tests and Svelte autofixer**
 
 Run: `cd frontend && node ../node_modules/vite-plus/bin/vp test run src/lib/components/settings/FleetSettings.test.ts`
 
@@ -146,21 +146,21 @@ Expected: tests pass and autofixer reports no required changes.
 - Modify: `frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte`
 - Test: `frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts`
 
-- [ ] **Step 1: Write failing sidebar test**
+- [x] **Step 1: Write failing sidebar test**
 
 Update the current local-host-only test so it expects no `Fleet` status block when the snapshot contains only the self host.
 
-- [ ] **Step 2: Run sidebar test to verify failure**
+- [x] **Step 2: Run sidebar test to verify failure**
 
 Run: `cd frontend && node ../node_modules/vite-plus/bin/vp test run src/lib/components/terminal/WorkspaceListSidebar.test.ts`
 
 Expected: failure because the component currently renders the fleet block for a single local host.
 
-- [ ] **Step 3: Implement hide condition**
+- [x] **Step 3: Implement hide condition**
 
-Change `showFleetStatus` so it renders only when there is a remote host or a fleet error related to remote status. Keep remote workspace loading based on reachable remote hosts.
+Change `showFleetStatus` so it renders only when there is a remote host or a fleet error related to remote status. Keep remote workspace loading based on reachable remote hosts, clear or ignore stale remote host state when snapshots contain only the local host, and make disabled federation hide remote filters, remote rows, unreachable diagnostics, route affordances, and remote operation controls.
 
-- [ ] **Step 4: Run sidebar tests and Svelte autofixer**
+- [x] **Step 4: Run sidebar tests and Svelte autofixer**
 
 Run: `cd frontend && node ../node_modules/vite-plus/bin/vp test run src/lib/components/terminal/WorkspaceListSidebar.test.ts`
 
@@ -173,24 +173,38 @@ Expected: tests pass and autofixer reports no required changes.
 **Files:**
 - All modified files
 
-- [ ] **Step 1: Run focused Go tests**
+- [x] **Step 1: Run focused Go tests**
 
-Run: `go test ./internal/config ./internal/server ./internal/server/e2etest -run 'Test(Fleet|Settings|ConfigReload)' -shuffle=on`
+Run: `go test ./internal/config ./internal/server ./internal/server/e2etest -run 'Test(Fleet|Settings|ConfigReload|SSHFleet)' -shuffle=on`
 
 Expected: pass.
 
-- [ ] **Step 2: Run focused frontend tests**
+- [x] **Step 2: Run focused frontend tests**
 
 Run: `cd frontend && node ../node_modules/vite-plus/bin/vp test run src/lib/components/settings/FleetSettings.test.ts src/lib/components/terminal/WorkspaceListSidebar.test.ts`
 
 Expected: pass.
 
-- [ ] **Step 3: Run API generation check**
+- [x] **Step 3: Run API generation check**
 
 Run: `make api-generate`
 
 Expected: no additional generated diff after the previous generation.
 
-- [ ] **Step 4: Review diff and commit**
+- [x] **Step 4: Review diff and commit**
 
 Run: `git status --short`, `git diff --stat`, and `git diff --check`. Stage relevant files and commit with hooks enabled.
+
+## Final Status
+
+Completed in commits `a5127748` and follow-up review fixes. The implementation
+adds the opt-in fleet federation config, backend gates, focused settings API,
+settings panel, workspace sidebar hiding behavior, generated API artifacts, and
+coverage for disabled/enabled HTTP and SSH fleet behavior.
+
+Final verification includes stage-attached config, backend gate, full-stack
+settings, disabled HTTP/SSH remote snapshot/proxy, frontend settings/sidebar,
+and SSH fleet tests. The full-stack settings tests exercise a real HTTP server
+and temp TOML config path; snapshot tests add SQLite-backed workspace data where
+needed. Svelte autofixer checks, API generation, frontend package checks,
+`git diff --check`, and hook-enforced commit validation complete the pass.

--- a/docs/superpowers/specs/2026-06-18-fleet-federation-settings-design.md
+++ b/docs/superpowers/specs/2026-06-18-fleet-federation-settings-design.md
@@ -77,10 +77,12 @@ Remote federation gates should be centralized in the existing fleet paths:
   `cfg.Fleet.Enabled` is true.
 - Remote proxy routes therefore become unavailable while federation is
   disabled, even if peer membership is still saved.
-- Disabled remote proxy routes return the existing `404`/`notFound` problem
-  shape with `details.hostKey` rather than a peer-unreachable or capability
-  error. This keeps disabled federation distinct from a configured but
-  unreachable enabled peer.
+- Disabled remote proxy routes return the existing unknown-host contract:
+  `404`/`notFound` with `details.hostKey`. This applies consistently to HTTP
+  proxy routes, WebSocket terminal proxy routes, filesystem routes, runtime
+  routes, and mutation routes. Disabled configured peers intentionally collapse
+  to the same client-visible behavior as unknown hosts, rather than reporting
+  peer-unreachable or capability errors.
 - Existing raw snapshot behavior remains local-only and is not affected by the
   toggle.
 - Disabled federation must avoid HTTP and SSH peer network calls entirely.
@@ -112,8 +114,9 @@ folding peer editing into unrelated general settings updates:
 }
 ```
 
-`GET /settings` can include this fleet shape for page bootstrap, but fleet
-updates should use a focused route such as `PUT /settings/fleet`. This keeps
+`GET /settings` must include this fleet shape for page bootstrap, and
+`GET /settings/fleet` returns the same fleet shape for clients that want to read
+only federation settings. Fleet updates use `PUT /settings/fleet`. This keeps
 fleet validation, restart-required reporting, and peer replacement semantics
 separate from activity, terminal, mode, and agent settings.
 
@@ -125,12 +128,21 @@ change if persistence fails. Concurrent saves use the same settings lock as the
 other settings routes. Success always returns the stable fleet settings shape
 above, including `restart_required`.
 
+The existing `/settings/fleet/ssh-peers` endpoint remains supported for clients
+that only edit SSH fleet peers. It is not a new compatibility alias; it is an
+existing narrower settings surface. Both endpoints validate through the full
+config, persist through the same config writer, roll back on failure, and report
+restart drift against the same live SSH transport membership. New clients should
+prefer `/settings/fleet` when they need the complete federation settings shape.
+
 ## Validation And Restart Semantics
 
 Validation should preserve existing rules and add only the enable flag:
 
 - `fleet.enabled` defaults to false.
 - `fleet.key`, if present, is trimmed and must not collide with any peer key.
+  The key `self` is reserved for local self routing and is invalid as a local,
+  HTTP peer, or SSH peer key.
 - Peer keys remain non-empty and unique across HTTP peers, SSH peers, and the
   local key when the local key is set.
 - HTTP peer `base_url` must be an absolute `http` or `https` URL.
@@ -141,8 +153,14 @@ Validation should preserve existing rules and add only the enable flag:
 
 Validation failures return the existing settings `badRequest` problem style.
 Save failures return the existing internal settings save problem style. Disabled
-remote proxy access returns `notFound`. Enabled but unreachable peers keep using
-the existing peer health and proxy error taxonomy.
+remote proxy access returns `notFound`, including WebSocket, filesystem,
+runtime, and mutation proxy routes. Enabled but unreachable peers keep using the
+existing peer health and proxy error taxonomy.
+
+`restart_required` reports fleet startup drift that cannot be applied to the
+running daemon without restart. Both `/settings/fleet` and
+`/settings/fleet/ssh-peers` use the same SSH peer drift calculation against the
+running SSH transport membership.
 
 Restart-required behavior:
 
@@ -205,6 +223,9 @@ When federation is disabled, workspace UI should read as single-host:
   hidden.
 - Remote host filters, remote host rows, unreachable-peer diagnostics, and
   remote host operations should not appear.
+- Stale remote route state should be cleared or ignored when the current
+  snapshot contains only the local host, so disabled federation cannot leave
+  remote operation controls reachable from old UI state.
 - Local workspace rows, local runtime sessions, and local create/delete/retry
   actions remain visible.
 
@@ -221,14 +242,18 @@ Backend tests:
 - `GET /snapshot?include_peers=true` excludes HTTP and SSH peers when disabled.
 - The same snapshot includes configured peers when enabled.
 - Remote fleet proxy resolution returns `404`/`notFound` for remote peers when
-  disabled, while local self routing still works.
+  disabled, while local self routing still works. This includes a representative
+  REST route and the shared WebSocket-resolution path through the same target
+  resolver.
 - `PUT /settings/fleet` validates peer collisions, HTTP URLs, SSH
   destinations, SSH remote commands, and peer timeout.
 - `restart_required` is true for SSH peer and session detail edits, but false
   for enable toggle, key, timeout, and HTTP peer edits.
-- Full-stack API tests exercise `GET /settings`, `PUT /settings/fleet`,
-  disabled snapshot behavior, enabled snapshot behavior, and disabled remote
-  proxy behavior through the real HTTP server and SQLite-backed settings path.
+- Full-stack API tests exercise `GET /settings`, `GET /settings/fleet`,
+  `PUT /settings/fleet`, disabled snapshot behavior, enabled snapshot behavior,
+  and disabled remote proxy behavior through the real HTTP server, temp TOML
+  config path, and SQLite-backed workspace data where snapshot behavior needs
+  it.
 
 Frontend tests:
 

--- a/docs/superpowers/specs/2026-06-18-fleet-federation-settings-design.md
+++ b/docs/superpowers/specs/2026-06-18-fleet-federation-settings-design.md
@@ -3,20 +3,22 @@
 ## Summary
 
 Add a fleet federation settings panel that lets users keep local workspace
-features enabled while disabling every remote fleet surface by default. The
-settings panel manages the federation toggle, optional local fleet key, peer
-timeout, session detail setting, and both HTTP and SSH peer membership.
+features enabled while disabling every remote runtime, status, and operation
+surface by default. The settings panel manages the federation toggle, optional
+local fleet key, peer timeout, session detail setting, and both HTTP and SSH
+peer membership.
 
 The toggle controls remote federation only. Local workspace snapshots,
 registered worktrees, runtime sessions, and local host operations continue to
-work when federation is disabled. Saved peer membership remains in config so a
-user can turn federation off temporarily and later re-enable the same members.
+work when federation is disabled. Saved peer membership remains visible and
+editable in settings so a user can turn federation off temporarily and later
+re-enable the same members.
 
 ## Goals
 
 - Make remote fleet federation opt-in, with a default disabled state.
-- Hide remote fleet UI when federation is disabled, including the fleet
-  indicator/status block in the workspace sidebar.
+- Hide remote runtime/status/operation fleet UI when federation is disabled,
+  including the fleet indicator/status block in the workspace sidebar.
 - Preserve current local workspace behavior when federation is disabled.
 - Let users configure both HTTP peers and SSH peers from the settings UI.
 - Preserve existing config flexibility: `fleet.key` remains optional, but the
@@ -60,6 +62,8 @@ The rest of the fleet config remains structurally the same:
 
 Membership can be edited while federation is disabled. Saving membership while
 disabled only changes persisted config; it does not make remote hosts visible.
+This means the settings page remains a configuration surface even while the
+runtime fleet surface is off.
 
 ## Backend Behavior
 
@@ -73,8 +77,13 @@ Remote federation gates should be centralized in the existing fleet paths:
   `cfg.Fleet.Enabled` is true.
 - Remote proxy routes therefore become unavailable while federation is
   disabled, even if peer membership is still saved.
+- Disabled remote proxy routes return the existing `404`/`notFound` problem
+  shape with `details.hostKey` rather than a peer-unreachable or capability
+  error. This keeps disabled federation distinct from a configured but
+  unreachable enabled peer.
 - Existing raw snapshot behavior remains local-only and is not affected by the
   toggle.
+- Disabled federation must avoid HTTP and SSH peer network calls entirely.
 
 The settings API should expose a focused fleet settings shape rather than
 folding peer editing into unrelated general settings updates:
@@ -108,6 +117,14 @@ updates should use a focused route such as `PUT /settings/fleet`. This keeps
 fleet validation, restart-required reporting, and peer replacement semantics
 separate from activity, terminal, mode, and agent settings.
 
+`PUT /settings/fleet` is a full replacement of the fleet settings object, not a
+patch. The server validates the complete candidate config before saving,
+persists it through the existing atomic config writer, updates live in-memory
+config only for successfully saved values, and rolls back any live in-memory
+change if persistence fails. Concurrent saves use the same settings lock as the
+other settings routes. Success always returns the stable fleet settings shape
+above, including `restart_required`.
+
 ## Validation And Restart Semantics
 
 Validation should preserve existing rules and add only the enable flag:
@@ -123,16 +140,25 @@ Validation should preserve existing rules and add only the enable flag:
 - `peer_timeout`, when set, must parse as a Go duration.
 
 Validation failures return the existing settings `badRequest` problem style.
-Save failures return the existing internal settings save problem style.
+Save failures return the existing internal settings save problem style. Disabled
+remote proxy access returns `notFound`. Enabled but unreachable peers keep using
+the existing peer health and proxy error taxonomy.
 
 Restart-required behavior:
 
 - Toggling `fleet.enabled` applies immediately to snapshot fan-out and remote
   proxy resolution.
-- Editing HTTP peers, `fleet.key`, or `peer_timeout` applies immediately to
-  snapshot fan-out and HTTP proxy routing.
+- Editing HTTP peers, `fleet.key`, or `peer_timeout` applies immediately to new
+  snapshot fan-out and HTTP proxy routing requests. Changing `fleet.key`
+  changes the local host key emitted by subsequent snapshots; clients should
+  refresh settings/snapshot data after save, and old explicit host-key routes
+  are not compatibility aliases. The generic self/local route behavior remains
+  available.
 - Editing SSH peers still reports `restart_required` because the SSH transport
-  is constructed at daemon startup.
+  is constructed at daemon startup. Newly saved SSH peer membership is shown in
+  settings immediately, but the live SSH transport continues to use the startup
+  peer set until restart. Enabling federation before restart exposes only the
+  live startup SSH peers, not newly persisted SSH peers.
 - Editing `fleet.sessions.include_unmanaged_details` still reports
   `restart_required` because tmux monitoring is constructed at daemon startup.
 
@@ -164,6 +190,9 @@ behavior clear without requiring the user to enter `middleman`.
 
 HTTP peer rows should include restrained warning text that HTTP federation is
 for trusted network boundaries because the hub does not forward auth to peers.
+Existing users who already have peers but no explicit `enabled` flag see the
+disabled toggle and saved memberships in this settings section; no separate
+first-run migration banner is required.
 
 ## Workspace UI
 
@@ -191,12 +220,15 @@ Backend tests:
 - Settings save preserves peer membership while toggling enabled off.
 - `GET /snapshot?include_peers=true` excludes HTTP and SSH peers when disabled.
 - The same snapshot includes configured peers when enabled.
-- Remote fleet proxy resolution returns not found or unavailable for remote
-  peers when disabled, while local self routing still works.
+- Remote fleet proxy resolution returns `404`/`notFound` for remote peers when
+  disabled, while local self routing still works.
 - `PUT /settings/fleet` validates peer collisions, HTTP URLs, SSH
   destinations, SSH remote commands, and peer timeout.
 - `restart_required` is true for SSH peer and session detail edits, but false
   for enable toggle, key, timeout, and HTTP peer edits.
+- Full-stack API tests exercise `GET /settings`, `PUT /settings/fleet`,
+  disabled snapshot behavior, enabled snapshot behavior, and disabled remote
+  proxy behavior through the real HTTP server and SQLite-backed settings path.
 
 Frontend tests:
 
@@ -211,3 +243,14 @@ Frontend tests:
 Use Vitest + jsdom for settings and workspace sidebar behavior. Browser tests
 are not required unless implementation changes layout behavior that needs real
 geometry verification.
+
+## Implementation Plan
+
+Implement the feature in reviewable stages:
+
+1. Add config model/default coverage for `fleet.enabled`.
+2. Gate backend snapshot fan-out and remote proxy resolution.
+3. Add focused settings API read/update behavior and generated client types.
+4. Add the fleet settings editor under Workspace settings.
+5. Hide workspace sidebar fleet status when only the local host is visible.
+6. Add full-stack, unit, and frontend regression coverage.

--- a/docs/superpowers/specs/2026-06-18-fleet-federation-settings-design.md
+++ b/docs/superpowers/specs/2026-06-18-fleet-federation-settings-design.md
@@ -1,0 +1,213 @@
+# Fleet Federation Settings Design
+
+## Summary
+
+Add a fleet federation settings panel that lets users keep local workspace
+features enabled while disabling every remote fleet surface by default. The
+settings panel manages the federation toggle, optional local fleet key, peer
+timeout, session detail setting, and both HTTP and SSH peer membership.
+
+The toggle controls remote federation only. Local workspace snapshots,
+registered worktrees, runtime sessions, and local host operations continue to
+work when federation is disabled. Saved peer membership remains in config so a
+user can turn federation off temporarily and later re-enable the same members.
+
+## Goals
+
+- Make remote fleet federation opt-in, with a default disabled state.
+- Hide remote fleet UI when federation is disabled, including the fleet
+  indicator/status block in the workspace sidebar.
+- Preserve current local workspace behavior when federation is disabled.
+- Let users configure both HTTP peers and SSH peers from the settings UI.
+- Preserve existing config flexibility: `fleet.key` remains optional, but the
+  UI explains why a stable key is recommended for hubs.
+- Keep HTTP peer risk visible: HTTP federation requires a trusted transport
+  boundary because the hub does not forward caller auth to peers.
+
+## Non-Goals
+
+- Do not disable the local snapshot or local workspace runtime layer.
+- Do not provision, install, or bootstrap remote middleman daemons.
+- Do not change the one-hop hub-to-peer topology.
+- Do not delete peer membership when federation is disabled.
+- Do not add compatibility aliases or legacy config paths.
+
+## Configuration Model
+
+Extend `config.Fleet` with an explicit enable flag:
+
+```toml
+[fleet]
+enabled = false
+key = "studio"
+peer_timeout = "2s"
+```
+
+`enabled` defaults to `false` when omitted. Existing configs with peer entries
+but no `enabled` flag will load with saved membership intact but remote
+federation disabled until the user opts in. This is the intended new default.
+
+The rest of the fleet config remains structurally the same:
+
+- `key`: optional local host key. If empty, runtime behavior keeps the current
+  hostname fallback. The settings UI warns that hubs should set a stable key.
+- `peer_timeout`: optional Go duration, defaulting through existing
+  `PeerTimeoutOrDefault`.
+- `sessions.include_unmanaged_details`: existing tmux detail redaction flag.
+- `[[fleet.peers]]`: HTTP members with `key`, optional `name`, and `base_url`.
+- `[[fleet.ssh_peers]]`: SSH members with `key`, optional `name`,
+  `destination`, optional `platform`, and optional `remote_command`.
+
+Membership can be edited while federation is disabled. Saving membership while
+disabled only changes persisted config; it does not make remote hosts visible.
+
+## Backend Behavior
+
+Remote federation gates should be centralized in the existing fleet paths:
+
+- `buildFleetSnapshot(ctx, includePeers)` always builds the local raw snapshot.
+  It fetches HTTP peers and SSH peers only when both `includePeers` and
+  `cfg.Fleet.Enabled` are true.
+- `resolveFleetHostTarget(hostKey)` keeps resolving the local self alias and
+  local host behavior. It resolves HTTP or SSH peer targets only when
+  `cfg.Fleet.Enabled` is true.
+- Remote proxy routes therefore become unavailable while federation is
+  disabled, even if peer membership is still saved.
+- Existing raw snapshot behavior remains local-only and is not affected by the
+  toggle.
+
+The settings API should expose a focused fleet settings shape rather than
+folding peer editing into unrelated general settings updates:
+
+```json
+{
+  "enabled": false,
+  "key": "studio",
+  "peer_timeout": "2s",
+  "sessions": {
+    "include_unmanaged_details": false
+  },
+  "peers": [
+    { "key": "mini", "name": "Mac mini", "base_url": "http://mini.tail:8091" }
+  ],
+  "ssh_peers": [
+    {
+      "key": "epyc",
+      "name": "EPYC box",
+      "destination": "wes@epyc.tail",
+      "platform": "linux",
+      "remote_command": "middleman"
+    }
+  ],
+  "restart_required": false
+}
+```
+
+`GET /settings` can include this fleet shape for page bootstrap, but fleet
+updates should use a focused route such as `PUT /settings/fleet`. This keeps
+fleet validation, restart-required reporting, and peer replacement semantics
+separate from activity, terminal, mode, and agent settings.
+
+## Validation And Restart Semantics
+
+Validation should preserve existing rules and add only the enable flag:
+
+- `fleet.enabled` defaults to false.
+- `fleet.key`, if present, is trimmed and must not collide with any peer key.
+- Peer keys remain non-empty and unique across HTTP peers, SSH peers, and the
+  local key when the local key is set.
+- HTTP peer `base_url` must be an absolute `http` or `https` URL.
+- SSH peer `destination` is required.
+- SSH peer `remote_command`, when set, must remain a bare executable name or
+  path with no flags or shell metacharacters.
+- `peer_timeout`, when set, must parse as a Go duration.
+
+Validation failures return the existing settings `badRequest` problem style.
+Save failures return the existing internal settings save problem style.
+
+Restart-required behavior:
+
+- Toggling `fleet.enabled` applies immediately to snapshot fan-out and remote
+  proxy resolution.
+- Editing HTTP peers, `fleet.key`, or `peer_timeout` applies immediately to
+  snapshot fan-out and HTTP proxy routing.
+- Editing SSH peers still reports `restart_required` because the SSH transport
+  is constructed at daemon startup.
+- Editing `fleet.sessions.include_unmanaged_details` still reports
+  `restart_required` because tmux monitoring is constructed at daemon startup.
+
+## Settings UI
+
+Add a `Fleet federation` section to the existing settings page under the
+Workspace group. Use the integrated layout:
+
+- A top-level toggle labeled around federation, not local workspaces. Suggested
+  copy: `Enable fleet federation`.
+- A short disabled-state explanation: remote hosts and remote operations are
+  unavailable while local workspaces continue to work.
+- Optional local key field with a warning or helper text that hubs should set a
+  stable key.
+- Peer timeout field.
+- Existing unmanaged tmux details setting.
+- HTTP peer membership editor.
+- SSH peer membership editor.
+- Save/reset controls consistent with current settings sections.
+
+Membership editors stay visible while disabled, but the section should make it
+clear that saved members are inactive until federation is enabled. This lets a
+user prepare membership before turning the toggle on.
+
+Both peer editors should support `key` and optional `name`. HTTP peers edit
+`base_url`. SSH peers edit `destination`, optional `platform`, and optional
+`remote_command`. The SSH editor should make the default remote command
+behavior clear without requiring the user to enter `middleman`.
+
+HTTP peer rows should include restrained warning text that HTTP federation is
+for trusted network boundaries because the hub does not forward auth to peers.
+
+## Workspace UI
+
+When federation is disabled, workspace UI should read as single-host:
+
+- `WorkspaceListSidebar` should not request peer-inclusive data for display, or
+  should receive only the local host from the backend even when it asks for
+  peers.
+- The fleet host indicator/status block in the workspace sidebar should be
+  hidden.
+- Remote host filters, remote host rows, unreachable-peer diagnostics, and
+  remote host operations should not appear.
+- Local workspace rows, local runtime sessions, and local create/delete/retry
+  actions remain visible.
+
+When federation is enabled, the current multi-host workspace sidebar behavior
+returns: host status appears, remote workspaces load from reachable peers, and
+remote operations use hub-keyed routes.
+
+## Testing
+
+Backend tests:
+
+- Config parsing defaults `fleet.enabled` to false and round-trips true/false.
+- Settings save preserves peer membership while toggling enabled off.
+- `GET /snapshot?include_peers=true` excludes HTTP and SSH peers when disabled.
+- The same snapshot includes configured peers when enabled.
+- Remote fleet proxy resolution returns not found or unavailable for remote
+  peers when disabled, while local self routing still works.
+- `PUT /settings/fleet` validates peer collisions, HTTP URLs, SSH
+  destinations, SSH remote commands, and peer timeout.
+- `restart_required` is true for SSH peer and session detail edits, but false
+  for enable toggle, key, timeout, and HTTP peer edits.
+
+Frontend tests:
+
+- Settings page shows the fleet federation section and default disabled state.
+- Saving `enabled=false` keeps configured membership visible in the editor.
+- HTTP and SSH peer validation errors surface through the existing settings
+  error UI.
+- Workspace sidebar hides the fleet status block when federation is disabled.
+- Workspace sidebar shows the fleet status block when federation is enabled
+  and multiple hosts are present.
+
+Use Vitest + jsdom for settings and workspace sidebar behavior. Browser tests
+are not required unless implementation changes layout behavior that needs real
+geometry verification.

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -1520,6 +1520,19 @@ components:
       required:
         - is_valid
       type: object
+    FleetPeer:
+      additionalProperties: false
+      properties:
+        base_url:
+          type: string
+        key:
+          type: string
+        name:
+          type: string
+      required:
+        - key
+        - base_url
+      type: object
     FleetSSHPeer:
       additionalProperties: false
       properties:
@@ -1554,6 +1567,47 @@ components:
             $ref: "#/components/schemas/FleetSSHPeer"
           type: array
       required:
+        - ssh_peers
+        - restart_required
+      type: object
+    FleetSessions:
+      additionalProperties: false
+      properties:
+        include_unmanaged_details:
+          type: boolean
+      type: object
+    FleetSettingsResponse:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /api/v1/schemas/FleetSettingsResponse.json
+          format: uri
+          readOnly: true
+          type: string
+        enabled:
+          type: boolean
+        key:
+          type: string
+        peer_timeout:
+          type: string
+        peers:
+          items:
+            $ref: "#/components/schemas/FleetPeer"
+          type: array
+        restart_required:
+          type: boolean
+        sessions:
+          $ref: "#/components/schemas/FleetSessions"
+        ssh_peers:
+          items:
+            $ref: "#/components/schemas/FleetSSHPeer"
+          type: array
+      required:
+        - enabled
+        - sessions
+        - peers
         - ssh_peers
         - restart_required
       type: object
@@ -5350,6 +5404,8 @@ components:
           items:
             $ref: "#/components/schemas/Agent"
           type: array
+        fleet:
+          $ref: "#/components/schemas/FleetSettingsResponse"
         modes:
           $ref: "#/components/schemas/ModeVisibility"
         repos:
@@ -5363,6 +5419,7 @@ components:
         - activity
         - terminal
         - agents
+        - fleet
       type: object
     Snapshot:
       additionalProperties: false
@@ -5778,6 +5835,38 @@ components:
             $ref: "#/components/schemas/FleetSSHPeer"
           type: array
       required:
+        - ssh_peers
+      type: object
+    UpdateFleetSettingsInputBody:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /api/v1/schemas/UpdateFleetSettingsInputBody.json
+          format: uri
+          readOnly: true
+          type: string
+        enabled:
+          type: boolean
+        key:
+          type: string
+        peer_timeout:
+          type: string
+        peers:
+          items:
+            $ref: "#/components/schemas/FleetPeer"
+          type: array
+        sessions:
+          $ref: "#/components/schemas/FleetSessions"
+        ssh_peers:
+          items:
+            $ref: "#/components/schemas/FleetSSHPeer"
+          type: array
+      required:
+        - enabled
+        - sessions
+        - peers
         - ssh_peers
       type: object
     UpdateSettingsRequest:
@@ -14462,6 +14551,49 @@ paths:
                 $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Update settings
+      tags:
+        - Settings
+  /settings/fleet:
+    get:
+      operationId: get-fleet-settings
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FleetSettingsResponse"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Error
+      summary: Get fleet settings
+      tags:
+        - Settings
+    put:
+      operationId: update-fleet-settings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateFleetSettingsInputBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FleetSettingsResponse"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Error
+      summary: Update fleet settings
       tags:
         - Settings
   /settings/fleet/ssh-peers:

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -45,17 +45,6 @@
   --radius-sm: 4px;
   --radius-md: 6px;
   --radius-lg: 8px;
-  --space-0: 0;
-  --space-0-5: 2px;
-  --space-1: 4px;
-  --space-1-5: 6px;
-  --space-2: 8px;
-  --space-2-5: 10px;
-  --space-3: 12px;
-  --space-3-5: 14px;
-  --space-4: 16px;
-  --space-5: 20px;
-  --space-6: 24px;
   --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
   --font-mono: "JetBrains Mono", "SF Mono", Menlo, Consolas, monospace;
 

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -45,6 +45,17 @@
   --radius-sm: 4px;
   --radius-md: 6px;
   --radius-lg: 8px;
+  --space-0: 0;
+  --space-0-5: 2px;
+  --space-1: 4px;
+  --space-1-5: 6px;
+  --space-2: 8px;
+  --space-2-5: 10px;
+  --space-3: 12px;
+  --space-3-5: 14px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
   --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
   --font-mono: "JetBrains Mono", "SF Mono", Menlo, Consolas, monospace;
 

--- a/frontend/src/lib/api/settings.ts
+++ b/frontend/src/lib/api/settings.ts
@@ -5,6 +5,7 @@ import { providerRepoPath, providerRouteParams } from "@middleman/ui/api/provide
 import { apiErrorMessage, client } from "./runtime.js";
 
 type UpdateSettingsRequest = components["schemas"]["UpdateSettingsRequest"];
+type UpdateFleetSettingsRequest = components["schemas"]["UpdateFleetSettingsInputBody"];
 export type RepoPreviewResponse = components["schemas"]["RepoPreviewResponse"];
 export type RepoPreviewRow = components["schemas"]["RepoPreviewRow"];
 
@@ -64,6 +65,16 @@ export async function updateSettings(settings: {
   });
   if (!data) {
     throw new Error(requestErrorMessage(error, `PUT /settings -> ${response.status}`));
+  }
+  return data;
+}
+
+export async function updateFleetSettings(fleet: UpdateFleetSettingsRequest): Promise<Settings["fleet"]> {
+  const { data, error, response } = await client.PUT("/settings/fleet", {
+    body: fleet,
+  });
+  if (!data) {
+    throw new Error(requestErrorMessage(error, `PUT /settings/fleet -> ${response.status}`));
   }
   return data;
 }

--- a/frontend/src/lib/components/settings/FleetSettings.svelte
+++ b/frontend/src/lib/components/settings/FleetSettings.svelte
@@ -1,0 +1,673 @@
+<script lang="ts">
+  import PlusIcon from "@lucide/svelte/icons/plus";
+  import RotateCcwIcon from "@lucide/svelte/icons/rotate-ccw";
+  import TrashIcon from "@lucide/svelte/icons/trash-2";
+  import type {
+    FleetPeer,
+    FleetSSHPeer,
+    FleetSettings as FleetSettingsType,
+    FleetSettingsUpdate,
+  } from "@middleman/ui/api/types";
+  import { updateFleetSettings } from "../../api/settings.js";
+  import { isEmbedded } from "../../stores/embed-config.svelte.js";
+
+  interface Props {
+    fleet: FleetSettingsType;
+    onUpdate: (fleet: FleetSettingsType) => void;
+  }
+
+  interface HTTPPeerDraft {
+    id: string;
+    key: string;
+    name: string;
+    baseURL: string;
+  }
+
+  interface SSHPeerDraft {
+    id: string;
+    key: string;
+    name: string;
+    destination: string;
+    platform: string;
+    remoteCommand: string;
+  }
+
+  let { fleet, onUpdate }: Props = $props();
+
+  const embedded = isEmbedded();
+  // svelte-ignore state_referenced_locally
+  let currentFleet = $state(fleet);
+  let nextID = 0;
+  let saving = $state(false);
+  let error = $state<string | null>(null);
+  // svelte-ignore state_referenced_locally
+  let enabledDraft = $state(currentFleet.enabled);
+  // svelte-ignore state_referenced_locally
+  let keyDraft = $state(currentFleet.key ?? "");
+  // svelte-ignore state_referenced_locally
+  let peerTimeoutDraft = $state(currentFleet.peer_timeout ?? "");
+  // svelte-ignore state_referenced_locally
+  let includeUnmanagedDetailsDraft = $state(
+    currentFleet.sessions.include_unmanaged_details ?? false,
+  );
+  // svelte-ignore state_referenced_locally
+  let httpPeerDrafts = $state<HTTPPeerDraft[]>(httpDraftsFromFleet(currentFleet));
+  // svelte-ignore state_referenced_locally
+  let sshPeerDrafts = $state<SSHPeerDraft[]>(sshDraftsFromFleet(currentFleet));
+
+  const pendingFleet = $derived(buildPendingFleet());
+  const savedFleet = $derived(normalizeFleetForCompare(currentFleet));
+  const isDirty = $derived(
+    JSON.stringify(pendingFleet) !== JSON.stringify(savedFleet),
+  );
+  const hasInvalidDraft = $derived(
+    httpPeerDrafts.some((peer) => peer.key.trim() === "" || peer.baseURL.trim() === "") ||
+      sshPeerDrafts.some((peer) => peer.key.trim() === "" || peer.destination.trim() === ""),
+  );
+  const canSave = $derived(!embedded && !saving && isDirty && !hasInvalidDraft);
+
+  function nextDraftID(prefix: string): string {
+    nextID += 1;
+    return `${prefix}:${nextID}`;
+  }
+
+  function httpDraftsFromFleet(value: FleetSettingsType): HTTPPeerDraft[] {
+    return value.peers.map((peer, index) => ({
+      id: `http:${peer.key || index}:${nextID++}`,
+      key: peer.key,
+      name: peer.name ?? "",
+      baseURL: peer.base_url,
+    }));
+  }
+
+  function sshDraftsFromFleet(value: FleetSettingsType): SSHPeerDraft[] {
+    return value.ssh_peers.map((peer, index) => ({
+      id: `ssh:${peer.key || index}:${nextID++}`,
+      key: peer.key,
+      name: peer.name ?? "",
+      destination: peer.destination,
+      platform: peer.platform ?? "",
+      remoteCommand: peer.remote_command ?? "",
+    }));
+  }
+
+  function compactHTTPPeer(peer: HTTPPeerDraft): FleetPeer {
+    const out: FleetPeer = {
+      key: peer.key.trim(),
+      base_url: peer.baseURL.trim(),
+    };
+    const name = peer.name.trim();
+    if (name !== "") out.name = name;
+    return out;
+  }
+
+  function compactSSHPeer(peer: SSHPeerDraft): FleetSSHPeer {
+    const out: FleetSSHPeer = {
+      key: peer.key.trim(),
+      destination: peer.destination.trim(),
+    };
+    const name = peer.name.trim();
+    const platform = peer.platform.trim();
+    const remoteCommand = peer.remoteCommand.trim();
+    if (name !== "") out.name = name;
+    if (platform !== "") out.platform = platform;
+    if (remoteCommand !== "") out.remote_command = remoteCommand;
+    return out;
+  }
+
+  function buildPendingFleet(): FleetSettingsUpdate {
+    return {
+      enabled: enabledDraft,
+      key: keyDraft.trim(),
+      peer_timeout: peerTimeoutDraft.trim(),
+      sessions: {
+        include_unmanaged_details: includeUnmanagedDetailsDraft,
+      },
+      peers: httpPeerDrafts.map(compactHTTPPeer),
+      ssh_peers: sshPeerDrafts.map(compactSSHPeer),
+    };
+  }
+
+  function normalizeFleetForCompare(value: FleetSettingsType): FleetSettingsUpdate {
+    return {
+      enabled: value.enabled,
+      key: value.key ?? "",
+      peer_timeout: value.peer_timeout ?? "",
+      sessions: {
+        include_unmanaged_details:
+          value.sessions.include_unmanaged_details ?? false,
+      },
+      peers: value.peers.map((peer) => compactHTTPPeer({
+        id: "",
+        key: peer.key,
+        name: peer.name ?? "",
+        baseURL: peer.base_url,
+      })),
+      ssh_peers: value.ssh_peers.map((peer) => compactSSHPeer({
+        id: "",
+        key: peer.key,
+        name: peer.name ?? "",
+        destination: peer.destination,
+        platform: peer.platform ?? "",
+        remoteCommand: peer.remote_command ?? "",
+      })),
+    };
+  }
+
+  function resetDraft(): void {
+    enabledDraft = currentFleet.enabled;
+    keyDraft = currentFleet.key ?? "";
+    peerTimeoutDraft = currentFleet.peer_timeout ?? "";
+    includeUnmanagedDetailsDraft =
+      currentFleet.sessions.include_unmanaged_details ?? false;
+    httpPeerDrafts = httpDraftsFromFleet(currentFleet);
+    sshPeerDrafts = sshDraftsFromFleet(currentFleet);
+    error = null;
+  }
+
+  function addHTTPPeer(): void {
+    httpPeerDrafts = [
+      ...httpPeerDrafts,
+      { id: nextDraftID("http"), key: "", name: "", baseURL: "" },
+    ];
+  }
+
+  function removeHTTPPeer(id: string): void {
+    httpPeerDrafts = httpPeerDrafts.filter((peer) => peer.id !== id);
+  }
+
+  function addSSHPeer(): void {
+    sshPeerDrafts = [
+      ...sshPeerDrafts,
+      {
+        id: nextDraftID("ssh"),
+        key: "",
+        name: "",
+        destination: "",
+        platform: "",
+        remoteCommand: "",
+      },
+    ];
+  }
+
+  function removeSSHPeer(id: string): void {
+    sshPeerDrafts = sshPeerDrafts.filter((peer) => peer.id !== id);
+  }
+
+  function peerLabel(prefix: string, key: string, index: number): string {
+    const trimmed = key.trim();
+    return trimmed === "" ? `${prefix} ${index + 1}` : trimmed;
+  }
+
+  async function save(): Promise<void> {
+    if (!canSave) return;
+    saving = true;
+    error = null;
+    try {
+      const updated = await updateFleetSettings(pendingFleet);
+      currentFleet = updated;
+      resetDraft();
+      onUpdate(updated);
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err);
+    } finally {
+      saving = false;
+    }
+  }
+</script>
+
+<div class="fleet-settings">
+  <label class="toggle-row">
+    <span>
+      <span class="field-label">Enable fleet federation</span>
+      <span class="field-help">
+        Remote hosts stay unavailable while federation is off.
+      </span>
+    </span>
+    <input
+      type="checkbox"
+      bind:checked={enabledDraft}
+      disabled={embedded || saving}
+      aria-label="Enable fleet federation"
+    />
+  </label>
+
+  {#if currentFleet.restart_required}
+    <p class="restart-banner">Restart required</p>
+  {/if}
+
+  {#if error}
+    <p class="settings-error">{error}</p>
+  {/if}
+
+  <div class="settings-grid">
+    <label class="field">
+      <span class="field-label">Local fleet key</span>
+      <input
+        value={keyDraft}
+        oninput={(event) => {
+          keyDraft = event.currentTarget instanceof HTMLInputElement
+            ? event.currentTarget.value
+            : "";
+        }}
+        placeholder="Optional stable hub key"
+        disabled={embedded || saving}
+        aria-label="Local fleet key"
+      />
+      <span class="field-help">Hubs should use a stable key; empty keeps the current hostname fallback.</span>
+    </label>
+
+    <label class="field">
+      <span class="field-label">Peer timeout</span>
+      <input
+        value={peerTimeoutDraft}
+        oninput={(event) => {
+          peerTimeoutDraft = event.currentTarget instanceof HTMLInputElement
+            ? event.currentTarget.value
+            : "";
+        }}
+        placeholder="2s"
+        disabled={embedded || saving}
+        aria-label="Peer timeout"
+      />
+    </label>
+  </div>
+
+  <label class="check-row">
+    <input
+      type="checkbox"
+      bind:checked={includeUnmanagedDetailsDraft}
+      disabled={embedded || saving}
+    />
+    <span>
+      <span class="field-label">Include unmanaged tmux details</span>
+      <span class="field-help">Changing this monitor setting applies after restart.</span>
+    </span>
+  </label>
+
+  <section class="peer-section" aria-label="HTTP fleet peers">
+    <div class="peer-section-header">
+      <div>
+        <h3>HTTP peers</h3>
+        <p>Use only on a trusted network boundary; hub credentials are not forwarded.</p>
+      </div>
+      <button
+        class="secondary-button"
+        type="button"
+        onclick={addHTTPPeer}
+        disabled={embedded || saving}
+      >
+        <PlusIcon size="14" strokeWidth="2.2" aria-hidden="true" />
+        Add HTTP peer
+      </button>
+    </div>
+
+    {#if httpPeerDrafts.length === 0}
+      <p class="empty-peers">No HTTP peers configured.</p>
+    {:else}
+      <div class="peer-list">
+        {#each httpPeerDrafts as peer, index (peer.id)}
+          {@const label = peerLabel("HTTP peer", peer.key, index)}
+          <div class="peer-row">
+            <div class="peer-fields">
+              <label class="field">
+                <span class="field-label">Key</span>
+                <input
+                  bind:value={peer.key}
+                  disabled={embedded || saving}
+                  aria-label={`HTTP peer ${label} key`}
+                />
+              </label>
+              <label class="field">
+                <span class="field-label">Name</span>
+                <input
+                  bind:value={peer.name}
+                  disabled={embedded || saving}
+                  aria-label={`HTTP peer ${label} name`}
+                />
+              </label>
+              <label class="field field-wide">
+                <span class="field-label">Base URL</span>
+                <input
+                  bind:value={peer.baseURL}
+                  disabled={embedded || saving}
+                  aria-label={`HTTP peer ${label} base URL`}
+                />
+              </label>
+            </div>
+            <button
+              class="icon-button"
+              type="button"
+              onclick={() => removeHTTPPeer(peer.id)}
+              disabled={embedded || saving}
+              aria-label={`Remove HTTP peer ${label}`}
+              title={`Remove HTTP peer ${label}`}
+            >
+              <TrashIcon size="14" strokeWidth="2.2" aria-hidden="true" />
+            </button>
+          </div>
+        {/each}
+      </div>
+    {/if}
+  </section>
+
+  <section class="peer-section" aria-label="SSH fleet peers">
+    <div class="peer-section-header">
+      <div>
+        <h3>SSH peers</h3>
+        <p>Private relay members reached by running the peer CLI remotely.</p>
+      </div>
+      <button
+        class="secondary-button"
+        type="button"
+        onclick={addSSHPeer}
+        disabled={embedded || saving}
+      >
+        <PlusIcon size="14" strokeWidth="2.2" aria-hidden="true" />
+        Add SSH peer
+      </button>
+    </div>
+
+    {#if sshPeerDrafts.length === 0}
+      <p class="empty-peers">No SSH peers configured.</p>
+    {:else}
+      <div class="peer-list">
+        {#each sshPeerDrafts as peer, index (peer.id)}
+          {@const label = peerLabel("SSH peer", peer.key, index)}
+          <div class="peer-row">
+            <div class="peer-fields ssh">
+              <label class="field">
+                <span class="field-label">Key</span>
+                <input
+                  bind:value={peer.key}
+                  disabled={embedded || saving}
+                  aria-label={`SSH peer ${label} key`}
+                />
+              </label>
+              <label class="field">
+                <span class="field-label">Name</span>
+                <input
+                  bind:value={peer.name}
+                  disabled={embedded || saving}
+                  aria-label={`SSH peer ${label} name`}
+                />
+              </label>
+              <label class="field field-wide">
+                <span class="field-label">Destination</span>
+                <input
+                  bind:value={peer.destination}
+                  disabled={embedded || saving}
+                  aria-label={`SSH peer ${label} destination`}
+                />
+              </label>
+              <label class="field">
+                <span class="field-label">Platform</span>
+                <input
+                  bind:value={peer.platform}
+                  disabled={embedded || saving}
+                  aria-label={`SSH peer ${label} platform`}
+                />
+              </label>
+              <label class="field">
+                <span class="field-label">Remote command</span>
+                <input
+                  bind:value={peer.remoteCommand}
+                  placeholder="middleman"
+                  disabled={embedded || saving}
+                  aria-label={`SSH peer ${label} remote command`}
+                />
+              </label>
+            </div>
+            <button
+              class="icon-button"
+              type="button"
+              onclick={() => removeSSHPeer(peer.id)}
+              disabled={embedded || saving}
+              aria-label={`Remove SSH peer ${label}`}
+              title={`Remove SSH peer ${label}`}
+            >
+              <TrashIcon size="14" strokeWidth="2.2" aria-hidden="true" />
+            </button>
+          </div>
+        {/each}
+      </div>
+    {/if}
+  </section>
+
+  <div class="settings-actions">
+    <button
+      class="secondary-button"
+      type="button"
+      onclick={resetDraft}
+      disabled={!isDirty || saving}
+    >
+      <RotateCcwIcon size="14" strokeWidth="2.2" aria-hidden="true" />
+      Reset
+    </button>
+    <button
+      class="primary-button"
+      type="button"
+      onclick={save}
+      disabled={!canSave}
+    >
+      Save fleet federation
+    </button>
+  </div>
+</div>
+
+<style>
+  .fleet-settings {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
+
+  .toggle-row,
+  .check-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 16px;
+  }
+
+  .check-row {
+    justify-content: flex-start;
+  }
+
+  .toggle-row input,
+  .check-row input {
+    margin-top: 2px;
+  }
+
+  .field-label {
+    display: block;
+    color: var(--text-primary);
+    font-size: var(--font-size-sm);
+    font-weight: 600;
+  }
+
+  .field-help,
+  .peer-section-header p,
+  .empty-peers {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    line-height: 1.4;
+  }
+
+  .settings-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 12px;
+  }
+
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    min-width: 0;
+  }
+
+  .field input {
+    min-height: 32px;
+    padding: 5px 8px;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    font-size: var(--font-size-sm);
+  }
+
+  .field input:disabled {
+    color: var(--text-muted);
+    background: var(--bg-inset);
+  }
+
+  .restart-banner,
+  .settings-error {
+    margin: 0;
+    padding: 8px 10px;
+    border-radius: var(--radius-sm);
+    font-size: var(--font-size-sm);
+  }
+
+  .restart-banner {
+    border: 1px solid var(--diff-stale-border);
+    background: var(--diff-stale-bg);
+    color: var(--diff-stale-text);
+  }
+
+  .settings-error {
+    border: 1px solid color-mix(in srgb, var(--accent-red) 45%, var(--border-muted));
+    background: color-mix(in srgb, var(--accent-red) 9%, var(--bg-primary));
+    color: var(--accent-red);
+  }
+
+  .peer-section {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding-top: 12px;
+    border-top: 1px solid var(--border-muted);
+  }
+
+  .peer-section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 12px;
+  }
+
+  .peer-section-header h3 {
+    margin: 0;
+    color: var(--text-primary);
+    font-size: var(--font-size-sm);
+    font-weight: 700;
+  }
+
+  .peer-section-header p {
+    margin: 3px 0 0;
+  }
+
+  .peer-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .peer-row {
+    display: flex;
+    gap: 8px;
+    align-items: flex-start;
+    padding: 10px;
+    border: 1px solid var(--border-muted);
+    border-radius: var(--radius-sm);
+  }
+
+  .peer-fields {
+    flex: 1 1 auto;
+    min-width: 0;
+    display: grid;
+    grid-template-columns: minmax(90px, 0.7fr) minmax(110px, 1fr);
+    gap: 10px;
+  }
+
+  .peer-fields.ssh {
+    grid-template-columns: minmax(90px, 0.7fr) minmax(110px, 1fr);
+  }
+
+  .field-wide {
+    grid-column: 1 / -1;
+  }
+
+  .settings-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+  }
+
+  .primary-button,
+  .secondary-button,
+  .icon-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    min-height: 30px;
+    border-radius: var(--radius-sm);
+    font-size: var(--font-size-sm);
+    font-weight: 600;
+  }
+
+  .primary-button {
+    padding: 0 12px;
+    background: var(--accent-blue);
+    color: white;
+  }
+
+  .secondary-button {
+    padding: 0 10px;
+    border: 1px solid var(--border-default);
+    background: var(--bg-primary);
+    color: var(--text-secondary);
+  }
+
+  .icon-button {
+    flex: 0 0 auto;
+    width: 30px;
+    border: 1px solid var(--border-default);
+    color: var(--text-muted);
+  }
+
+  .primary-button:disabled,
+  .secondary-button:disabled,
+  .icon-button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  @media (min-width: 760px) {
+    .settings-grid {
+      grid-template-columns: minmax(0, 1fr) minmax(160px, 0.5fr);
+    }
+
+    .peer-fields {
+      grid-template-columns:
+        minmax(90px, 0.6fr)
+        minmax(120px, 0.8fr)
+        minmax(220px, 1.4fr);
+    }
+
+    .peer-fields.ssh {
+      grid-template-columns:
+        minmax(90px, 0.6fr)
+        minmax(120px, 0.8fr)
+        minmax(190px, 1.2fr)
+        minmax(90px, 0.6fr)
+        minmax(130px, 0.8fr);
+    }
+
+    .field-wide {
+      grid-column: auto;
+    }
+  }
+</style>

--- a/frontend/src/lib/components/settings/FleetSettings.svelte
+++ b/frontend/src/lib/components/settings/FleetSettings.svelte
@@ -305,48 +305,57 @@
     {#if httpPeerDrafts.length === 0}
       <p class="empty-peers">No HTTP peers configured.</p>
     {:else}
-      <div class="peer-list">
-        {#each httpPeerDrafts as peer, index (peer.id)}
-          {@const label = peerLabel("HTTP peer", peer.key, index)}
-          <div class="peer-row">
-            <div class="peer-fields">
-              <label class="field">
-                <span class="field-label">Key</span>
-                <input
-                  bind:value={peer.key}
-                  disabled={embedded || saving}
-                  aria-label={`HTTP peer ${label} key`}
-                />
-              </label>
-              <label class="field">
-                <span class="field-label">Name</span>
-                <input
-                  bind:value={peer.name}
-                  disabled={embedded || saving}
-                  aria-label={`HTTP peer ${label} name`}
-                />
-              </label>
-              <label class="field field-wide">
-                <span class="field-label">Base URL</span>
-                <input
-                  bind:value={peer.baseURL}
-                  disabled={embedded || saving}
-                  aria-label={`HTTP peer ${label} base URL`}
-                />
-              </label>
-            </div>
-            <button
-              class="icon-button"
-              type="button"
-              onclick={() => removeHTTPPeer(peer.id)}
-              disabled={embedded || saving}
-              aria-label={`Remove HTTP peer ${label}`}
-              title={`Remove HTTP peer ${label}`}
-            >
-              <TrashIcon size="14" strokeWidth="2.2" aria-hidden="true" />
-            </button>
-          </div>
-        {/each}
+      <div class="peer-table-wrap">
+        <table class="peer-table http" aria-label="HTTP peer membership">
+          <thead>
+            <tr>
+              <th scope="col">Key</th>
+              <th scope="col">Name</th>
+              <th scope="col">Base URL</th>
+              <th scope="col" aria-label="HTTP peer actions"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each httpPeerDrafts as peer, index (peer.id)}
+              {@const label = peerLabel("HTTP peer", peer.key, index)}
+              <tr>
+                <td>
+                  <input
+                    bind:value={peer.key}
+                    disabled={embedded || saving}
+                    aria-label={`HTTP peer ${label} key`}
+                  />
+                </td>
+                <td>
+                  <input
+                    bind:value={peer.name}
+                    disabled={embedded || saving}
+                    aria-label={`HTTP peer ${label} name`}
+                  />
+                </td>
+                <td>
+                  <input
+                    bind:value={peer.baseURL}
+                    disabled={embedded || saving}
+                    aria-label={`HTTP peer ${label} base URL`}
+                  />
+                </td>
+                <td class="action-cell">
+                  <button
+                    class="icon-button"
+                    type="button"
+                    onclick={() => removeHTTPPeer(peer.id)}
+                    disabled={embedded || saving}
+                    aria-label={`Remove HTTP peer ${label}`}
+                    title={`Remove HTTP peer ${label}`}
+                  >
+                    <TrashIcon size="14" strokeWidth="2.2" aria-hidden="true" />
+                  </button>
+                </td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
       </div>
     {/if}
   </section>
@@ -371,65 +380,74 @@
     {#if sshPeerDrafts.length === 0}
       <p class="empty-peers">No SSH peers configured.</p>
     {:else}
-      <div class="peer-list">
-        {#each sshPeerDrafts as peer, index (peer.id)}
-          {@const label = peerLabel("SSH peer", peer.key, index)}
-          <div class="peer-row">
-            <div class="peer-fields ssh">
-              <label class="field">
-                <span class="field-label">Key</span>
-                <input
-                  bind:value={peer.key}
-                  disabled={embedded || saving}
-                  aria-label={`SSH peer ${label} key`}
-                />
-              </label>
-              <label class="field">
-                <span class="field-label">Name</span>
-                <input
-                  bind:value={peer.name}
-                  disabled={embedded || saving}
-                  aria-label={`SSH peer ${label} name`}
-                />
-              </label>
-              <label class="field field-wide">
-                <span class="field-label">Destination</span>
-                <input
-                  bind:value={peer.destination}
-                  disabled={embedded || saving}
-                  aria-label={`SSH peer ${label} destination`}
-                />
-              </label>
-              <label class="field">
-                <span class="field-label">Platform</span>
-                <input
-                  bind:value={peer.platform}
-                  disabled={embedded || saving}
-                  aria-label={`SSH peer ${label} platform`}
-                />
-              </label>
-              <label class="field">
-                <span class="field-label">Remote command</span>
-                <input
-                  bind:value={peer.remoteCommand}
-                  placeholder="middleman"
-                  disabled={embedded || saving}
-                  aria-label={`SSH peer ${label} remote command`}
-                />
-              </label>
-            </div>
-            <button
-              class="icon-button"
-              type="button"
-              onclick={() => removeSSHPeer(peer.id)}
-              disabled={embedded || saving}
-              aria-label={`Remove SSH peer ${label}`}
-              title={`Remove SSH peer ${label}`}
-            >
-              <TrashIcon size="14" strokeWidth="2.2" aria-hidden="true" />
-            </button>
-          </div>
-        {/each}
+      <div class="peer-table-wrap">
+        <table class="peer-table ssh" aria-label="SSH peer membership">
+          <thead>
+            <tr>
+              <th scope="col">Key</th>
+              <th scope="col">Name</th>
+              <th scope="col">Destination</th>
+              <th scope="col">Platform</th>
+              <th scope="col">Remote command</th>
+              <th scope="col" aria-label="SSH peer actions"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each sshPeerDrafts as peer, index (peer.id)}
+              {@const label = peerLabel("SSH peer", peer.key, index)}
+              <tr>
+                <td>
+                  <input
+                    bind:value={peer.key}
+                    disabled={embedded || saving}
+                    aria-label={`SSH peer ${label} key`}
+                  />
+                </td>
+                <td>
+                  <input
+                    bind:value={peer.name}
+                    disabled={embedded || saving}
+                    aria-label={`SSH peer ${label} name`}
+                  />
+                </td>
+                <td>
+                  <input
+                    bind:value={peer.destination}
+                    disabled={embedded || saving}
+                    aria-label={`SSH peer ${label} destination`}
+                  />
+                </td>
+                <td>
+                  <input
+                    bind:value={peer.platform}
+                    disabled={embedded || saving}
+                    aria-label={`SSH peer ${label} platform`}
+                  />
+                </td>
+                <td>
+                  <input
+                    bind:value={peer.remoteCommand}
+                    placeholder="middleman"
+                    disabled={embedded || saving}
+                    aria-label={`SSH peer ${label} remote command`}
+                  />
+                </td>
+                <td class="action-cell">
+                  <button
+                    class="icon-button"
+                    type="button"
+                    onclick={() => removeSSHPeer(peer.id)}
+                    disabled={embedded || saving}
+                    aria-label={`Remove SSH peer ${label}`}
+                    title={`Remove SSH peer ${label}`}
+                  >
+                    <TrashIcon size="14" strokeWidth="2.2" aria-hidden="true" />
+                  </button>
+                </td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
       </div>
     {/if}
   </section>
@@ -507,8 +525,10 @@
     min-width: 0;
   }
 
-  .field input {
-    min-height: 32px;
+  .field input,
+  .peer-table input {
+    width: 100%;
+    min-height: 30px;
     padding: 5px 8px;
     border: 1px solid var(--border-default);
     border-radius: var(--radius-sm);
@@ -517,7 +537,8 @@
     font-size: var(--font-size-sm);
   }
 
-  .field input:disabled {
+  .field input:disabled,
+  .peer-table input:disabled {
     color: var(--text-muted);
     background: var(--bg-inset);
   }
@@ -568,35 +589,75 @@
     margin: 3px 0 0;
   }
 
-  .peer-list {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-  }
-
-  .peer-row {
-    display: flex;
-    gap: 8px;
-    align-items: flex-start;
-    padding: 10px;
+  .peer-table-wrap {
+    overflow-x: auto;
     border: 1px solid var(--border-muted);
     border-radius: var(--radius-sm);
   }
 
-  .peer-fields {
-    flex: 1 1 auto;
-    min-width: 0;
-    display: grid;
-    grid-template-columns: minmax(90px, 0.7fr) minmax(110px, 1fr);
-    gap: 10px;
+  .peer-table {
+    width: 100%;
+    min-width: 620px;
+    border-collapse: collapse;
+    table-layout: fixed;
   }
 
-  .peer-fields.ssh {
-    grid-template-columns: minmax(90px, 0.7fr) minmax(110px, 1fr);
+  .peer-table.ssh {
+    min-width: 860px;
   }
 
-  .field-wide {
-    grid-column: 1 / -1;
+  .peer-table th,
+  .peer-table td {
+    padding: 7px 8px;
+    border-bottom: 1px solid var(--border-muted);
+    vertical-align: top;
+  }
+
+  .peer-table tbody tr:last-child td {
+    border-bottom: 0;
+  }
+
+  .peer-table th {
+    color: var(--text-secondary);
+    font-size: var(--font-size-xs);
+    font-weight: 700;
+    text-align: left;
+    background: var(--bg-inset);
+  }
+
+  .peer-table.http th:nth-child(1),
+  .peer-table.http td:nth-child(1) {
+    width: 20%;
+  }
+
+  .peer-table.http th:nth-child(2),
+  .peer-table.http td:nth-child(2) {
+    width: 26%;
+  }
+
+  .peer-table.ssh th:nth-child(1),
+  .peer-table.ssh td:nth-child(1) {
+    width: 14%;
+  }
+
+  .peer-table.ssh th:nth-child(2),
+  .peer-table.ssh td:nth-child(2) {
+    width: 18%;
+  }
+
+  .peer-table.ssh th:nth-child(4),
+  .peer-table.ssh td:nth-child(4) {
+    width: 13%;
+  }
+
+  .peer-table.ssh th:nth-child(5),
+  .peer-table.ssh td:nth-child(5) {
+    width: 19%;
+  }
+
+  .action-cell {
+    width: 40px;
+    text-align: right;
   }
 
   .settings-actions {
@@ -648,26 +709,6 @@
   @media (min-width: 760px) {
     .settings-grid {
       grid-template-columns: minmax(0, 1fr) minmax(160px, 0.5fr);
-    }
-
-    .peer-fields {
-      grid-template-columns:
-        minmax(90px, 0.6fr)
-        minmax(120px, 0.8fr)
-        minmax(220px, 1.4fr);
-    }
-
-    .peer-fields.ssh {
-      grid-template-columns:
-        minmax(90px, 0.6fr)
-        minmax(120px, 0.8fr)
-        minmax(190px, 1.2fr)
-        minmax(90px, 0.6fr)
-        minmax(130px, 0.8fr);
-    }
-
-    .field-wide {
-      grid-column: auto;
     }
   }
 </style>

--- a/frontend/src/lib/components/settings/FleetSettings.svelte
+++ b/frontend/src/lib/components/settings/FleetSettings.svelte
@@ -2,7 +2,8 @@
   import PlusIcon from "@lucide/svelte/icons/plus";
   import RotateCcwIcon from "@lucide/svelte/icons/rotate-ccw";
   import TrashIcon from "@lucide/svelte/icons/trash-2";
-  import { SelectDropdown } from "@middleman/ui";
+  import { ActionButton, SelectDropdown } from "@middleman/ui";
+  import type { SelectDropdownOption } from "@middleman/ui";
   import type {
     FleetPeer,
     FleetSSHPeer,
@@ -33,17 +34,10 @@
     remoteCommand: string;
   }
 
-  interface DropdownOption {
-    value: string;
-    label: string;
-    triggerLabel?: string;
-    disabled?: boolean;
-  }
-
   let { fleet, onUpdate }: Props = $props();
 
   const embedded = isEmbedded();
-  const basePlatformOptions: DropdownOption[] = [
+  const basePlatformOptions: SelectDropdownOption[] = [
     { value: "", label: "Unspecified", triggerLabel: "Unspecified" },
     { value: "darwin", label: "darwin" },
     { value: "linux", label: "linux" },
@@ -213,7 +207,7 @@
     return trimmed === "" ? `${prefix} ${index + 1}` : trimmed;
   }
 
-  function platformOptions(value: string): DropdownOption[] {
+  function platformOptions(value: string): SelectDropdownOption[] {
     const trimmed = value.trim();
     if (trimmed === "" || basePlatformOptions.some((option) => option.value === trimmed)) {
       return basePlatformOptions;
@@ -313,15 +307,15 @@
         <h3>HTTP peers</h3>
         <p>Use only on a trusted network boundary; hub credentials are not forwarded.</p>
       </div>
-      <button
-        class="secondary-button"
+      <ActionButton
+        size="sm"
         type="button"
         onclick={addHTTPPeer}
         disabled={embedded || saving}
       >
         <PlusIcon size="14" strokeWidth="2.2" aria-hidden="true" />
         Add HTTP peer
-      </button>
+      </ActionButton>
     </div>
 
     {#if httpPeerDrafts.length === 0}
@@ -369,16 +363,18 @@
                   />
                 </td>
                 <td class="action-cell">
-                  <button
-                    class="icon-button"
+                  <ActionButton
+                    size="sm"
+                    tone="danger"
+                    surface="outline"
                     type="button"
                     onclick={() => removeHTTPPeer(peer.id)}
                     disabled={embedded || saving}
-                    aria-label={`Remove HTTP peer ${label}`}
+                    ariaLabel={`Remove HTTP peer ${label}`}
                     title={`Remove HTTP peer ${label}`}
                   >
                     <TrashIcon size="14" strokeWidth="2.2" aria-hidden="true" />
-                  </button>
+                  </ActionButton>
                 </td>
               </tr>
             {/each}
@@ -394,15 +390,15 @@
         <h3>SSH peers</h3>
         <p>Private relay members reached by running the peer CLI remotely.</p>
       </div>
-      <button
-        class="secondary-button"
+      <ActionButton
+        size="sm"
         type="button"
         onclick={addSSHPeer}
         disabled={embedded || saving}
       >
         <PlusIcon size="14" strokeWidth="2.2" aria-hidden="true" />
         Add SSH peer
-      </button>
+      </ActionButton>
     </div>
 
     {#if sshPeerDrafts.length === 0}
@@ -474,16 +470,18 @@
                   />
                 </td>
                 <td class="action-cell">
-                  <button
-                    class="icon-button"
+                  <ActionButton
+                    size="sm"
+                    tone="danger"
+                    surface="outline"
                     type="button"
                     onclick={() => removeSSHPeer(peer.id)}
                     disabled={embedded || saving}
-                    aria-label={`Remove SSH peer ${label}`}
+                    ariaLabel={`Remove SSH peer ${label}`}
                     title={`Remove SSH peer ${label}`}
                   >
                     <TrashIcon size="14" strokeWidth="2.2" aria-hidden="true" />
-                  </button>
+                  </ActionButton>
                 </td>
               </tr>
             {/each}
@@ -494,23 +492,24 @@
   </section>
 
   <div class="settings-actions">
-    <button
-      class="secondary-button"
+    <ActionButton
+      size="sm"
       type="button"
       onclick={resetDraft}
       disabled={!isDirty || saving}
     >
       <RotateCcwIcon size="14" strokeWidth="2.2" aria-hidden="true" />
       Reset
-    </button>
-    <button
-      class="primary-button"
+    </ActionButton>
+    <ActionButton
+      tone="info"
+      surface="solid"
       type="button"
-      onclick={save}
+      onclick={() => void save()}
       disabled={!canSave}
     >
       Save fleet federation
-    </button>
+    </ActionButton>
   </div>
 </div>
 
@@ -518,7 +517,7 @@
   .fleet-settings {
     display: flex;
     flex-direction: column;
-    gap: var(--space-3-5);
+    gap: 14px;
   }
 
   .toggle-row,
@@ -526,7 +525,7 @@
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
-    gap: var(--space-4);
+    gap: 16px;
   }
 
   .check-row {
@@ -535,7 +534,7 @@
 
   .toggle-row input,
   .check-row input {
-    margin-top: var(--space-0-5);
+    margin-top: 2px;
   }
 
   .field-label {
@@ -556,13 +555,13 @@
   .settings-grid {
     display: grid;
     grid-template-columns: minmax(0, 1fr);
-    gap: var(--space-3);
+    gap: 12px;
   }
 
   .field {
     display: flex;
     flex-direction: column;
-    gap: var(--space-1);
+    gap: 4px;
     min-width: 0;
   }
 
@@ -571,7 +570,7 @@
   .platform-cell :global(.select-dropdown-trigger) {
     width: 100%;
     min-height: 30px;
-    padding: var(--space-1) var(--space-2);
+    padding: 4px 8px;
     border: 1px solid var(--border-default);
     border-radius: var(--radius-sm);
     background: var(--bg-primary);
@@ -600,7 +599,7 @@
   .restart-banner,
   .settings-error {
     margin: 0;
-    padding: var(--space-2) var(--space-2-5);
+    padding: 8px 10px;
     border-radius: var(--radius-sm);
     font-size: var(--font-size-sm);
   }
@@ -620,8 +619,8 @@
   .peer-section {
     display: flex;
     flex-direction: column;
-    gap: var(--space-2-5);
-    padding-top: var(--space-3);
+    gap: 10px;
+    padding-top: 12px;
     border-top: 1px solid var(--border-muted);
   }
 
@@ -629,7 +628,7 @@
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
-    gap: var(--space-3);
+    gap: 12px;
   }
 
   .peer-section-header h3 {
@@ -640,7 +639,7 @@
   }
 
   .peer-section-header p {
-    margin: var(--space-0-5) 0 0;
+    margin: 2px 0 0;
   }
 
   .peer-table-wrap {
@@ -657,12 +656,12 @@
   }
 
   .peer-table.ssh {
-    min-width: 860px;
+    min-width: 680px;
   }
 
   .peer-table th,
   .peer-table td {
-    padding: var(--space-2);
+    padding: 8px;
     border-bottom: 1px solid var(--border-muted);
     vertical-align: top;
   }
@@ -719,47 +718,7 @@
   .settings-actions {
     display: flex;
     justify-content: flex-end;
-    gap: var(--space-2);
-  }
-
-  .primary-button,
-  .secondary-button,
-  .icon-button {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: var(--space-1-5);
-    min-height: 30px;
-    border-radius: var(--radius-sm);
-    font-size: var(--font-size-sm);
-    font-weight: 600;
-  }
-
-  .primary-button {
-    padding: 0 var(--space-3);
-    background: var(--accent-blue);
-    color: white;
-  }
-
-  .secondary-button {
-    padding: 0 var(--space-2-5);
-    border: 1px solid var(--border-default);
-    background: var(--bg-primary);
-    color: var(--text-secondary);
-  }
-
-  .icon-button {
-    flex: 0 0 auto;
-    width: 30px;
-    border: 1px solid var(--border-default);
-    color: var(--text-muted);
-  }
-
-  .primary-button:disabled,
-  .secondary-button:disabled,
-  .icon-button:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
+    gap: 8px;
   }
 
   @media (min-width: 760px) {

--- a/frontend/src/lib/components/settings/FleetSettings.svelte
+++ b/frontend/src/lib/components/settings/FleetSettings.svelte
@@ -2,8 +2,7 @@
   import PlusIcon from "@lucide/svelte/icons/plus";
   import RotateCcwIcon from "@lucide/svelte/icons/rotate-ccw";
   import TrashIcon from "@lucide/svelte/icons/trash-2";
-  import { ActionButton, SelectDropdown } from "@middleman/ui";
-  import type { SelectDropdownOption } from "@middleman/ui";
+  import { ActionButton } from "@middleman/ui";
   import type {
     FleetPeer,
     FleetSSHPeer,
@@ -12,6 +11,7 @@
   } from "@middleman/ui/api/types";
   import { updateFleetSettings } from "../../api/settings.js";
   import { isEmbedded } from "../../stores/embed-config.svelte.js";
+  import TypeaheadTrigger, { type TypeaheadOption } from "../shared/TypeaheadTrigger.svelte";
 
   interface Props {
     fleet: FleetSettingsType;
@@ -37,9 +37,8 @@
   let { fleet, onUpdate }: Props = $props();
 
   const embedded = isEmbedded();
-  const basePlatformOptions: SelectDropdownOption[] = [
-    { value: "", label: "Unspecified", triggerLabel: "Unspecified" },
-    { value: "darwin", label: "darwin" },
+  const basePlatformOptions: TypeaheadOption[] = [
+    { value: "macos", label: "macOS" },
     { value: "linux", label: "linux" },
     { value: "windows", label: "windows" },
   ];
@@ -207,7 +206,7 @@
     return trimmed === "" ? `${prefix} ${index + 1}` : trimmed;
   }
 
-  function platformOptions(value: string): SelectDropdownOption[] {
+  function platformOptions(value: string): TypeaheadOption[] {
     const trimmed = value.trim();
     if (trimmed === "" || basePlatformOptions.some((option) => option.value === trimmed)) {
       return basePlatformOptions;
@@ -450,14 +449,23 @@
                   />
                 </td>
                 <td class="platform-cell">
-                  <SelectDropdown
-                    class="platform-dropdown"
-                    value={peer.platform}
+                  <TypeaheadTrigger
+                    ariaLabel={`SSH peer ${label} platform`}
+                    selected={peer.platform.trim() === "" ? null : peer.platform}
                     options={platformOptions(peer.platform)}
-                    onchange={(value) => {
-                      peer.platform = value;
+                    allowClear
+                    allowCustom
+                    clearLabel="Unspecified"
+                    placeholder="Platform..."
+                    emptyLabel="Enter a platform"
+                    placement="top"
+                    triggerAriaLabel={`SSH peer ${label} platform: ${
+                      platformOptions(peer.platform).find((option) => option.value === peer.platform)?.label ??
+                        "Unspecified"
+                    }`}
+                    onChange={(value) => {
+                      peer.platform = value ?? "";
                     }}
-                    title={`SSH peer ${label} platform`}
                     disabled={embedded || saving}
                   />
                 </td>
@@ -567,7 +575,8 @@
 
   .field input,
   .peer-table input,
-  .platform-cell :global(.select-dropdown-trigger) {
+  .platform-cell :global(.typeahead-trigger),
+  .platform-cell :global(.typeahead-input) {
     width: 100%;
     min-height: 30px;
     padding: 4px 8px;
@@ -581,19 +590,19 @@
 
   .field input:disabled,
   .peer-table input:disabled,
-  .platform-cell :global(.select-dropdown-trigger:disabled) {
+  .platform-cell :global(.typeahead-trigger:disabled) {
     color: var(--text-muted);
     background: var(--bg-inset);
   }
 
-  .platform-cell :global(.select-dropdown) {
+  .platform-cell :global(.typeahead) {
     width: 100%;
     min-width: 0;
   }
 
-  .platform-cell :global(.select-dropdown-trigger) {
+  .platform-cell :global(.typeahead-trigger),
+  .platform-cell :global(.typeahead-input) {
     height: 30px;
-    justify-content: space-between;
   }
 
   .restart-banner,
@@ -643,7 +652,7 @@
   }
 
   .peer-table-wrap {
-    overflow-x: auto;
+    overflow: visible;
     border: 1px solid var(--border-muted);
     border-radius: var(--radius-sm);
   }
@@ -724,6 +733,12 @@
   @media (min-width: 760px) {
     .settings-grid {
       grid-template-columns: minmax(0, 1fr) minmax(160px, 0.5fr);
+    }
+  }
+
+  @media (max-width: 759px) {
+    .peer-table-wrap {
+      overflow-x: auto;
     }
   }
 </style>

--- a/frontend/src/lib/components/settings/FleetSettings.svelte
+++ b/frontend/src/lib/components/settings/FleetSettings.svelte
@@ -2,6 +2,7 @@
   import PlusIcon from "@lucide/svelte/icons/plus";
   import RotateCcwIcon from "@lucide/svelte/icons/rotate-ccw";
   import TrashIcon from "@lucide/svelte/icons/trash-2";
+  import { SelectDropdown } from "@middleman/ui";
   import type {
     FleetPeer,
     FleetSSHPeer,
@@ -32,9 +33,22 @@
     remoteCommand: string;
   }
 
+  interface DropdownOption {
+    value: string;
+    label: string;
+    triggerLabel?: string;
+    disabled?: boolean;
+  }
+
   let { fleet, onUpdate }: Props = $props();
 
   const embedded = isEmbedded();
+  const basePlatformOptions: DropdownOption[] = [
+    { value: "", label: "Unspecified", triggerLabel: "Unspecified" },
+    { value: "darwin", label: "darwin" },
+    { value: "linux", label: "linux" },
+    { value: "windows", label: "windows" },
+  ];
   // svelte-ignore state_referenced_locally
   let currentFleet = $state(fleet);
   let nextID = 0;
@@ -199,6 +213,14 @@
     return trimmed === "" ? `${prefix} ${index + 1}` : trimmed;
   }
 
+  function platformOptions(value: string): DropdownOption[] {
+    const trimmed = value.trim();
+    if (trimmed === "" || basePlatformOptions.some((option) => option.value === trimmed)) {
+      return basePlatformOptions;
+    }
+    return [...basePlatformOptions, { value: trimmed, label: trimmed }];
+  }
+
   async function save(): Promise<void> {
     if (!canSave) return;
     saving = true;
@@ -307,6 +329,12 @@
     {:else}
       <div class="peer-table-wrap">
         <table class="peer-table http" aria-label="HTTP peer membership">
+          <colgroup>
+            <col class="http-key-col" />
+            <col class="http-name-col" />
+            <col class="http-url-col" />
+            <col class="peer-action-col" />
+          </colgroup>
           <thead>
             <tr>
               <th scope="col">Key</th>
@@ -382,6 +410,14 @@
     {:else}
       <div class="peer-table-wrap">
         <table class="peer-table ssh" aria-label="SSH peer membership">
+          <colgroup>
+            <col class="ssh-key-col" />
+            <col class="ssh-name-col" />
+            <col class="ssh-destination-col" />
+            <col class="ssh-platform-col" />
+            <col class="ssh-command-col" />
+            <col class="peer-action-col" />
+          </colgroup>
           <thead>
             <tr>
               <th scope="col">Key</th>
@@ -417,11 +453,16 @@
                     aria-label={`SSH peer ${label} destination`}
                   />
                 </td>
-                <td>
-                  <input
-                    bind:value={peer.platform}
+                <td class="platform-cell">
+                  <SelectDropdown
+                    class="platform-dropdown"
+                    value={peer.platform}
+                    options={platformOptions(peer.platform)}
+                    onchange={(value) => {
+                      peer.platform = value;
+                    }}
+                    title={`SSH peer ${label} platform`}
                     disabled={embedded || saving}
-                    aria-label={`SSH peer ${label} platform`}
                   />
                 </td>
                 <td>
@@ -477,7 +518,7 @@
   .fleet-settings {
     display: flex;
     flex-direction: column;
-    gap: 14px;
+    gap: var(--space-3-5);
   }
 
   .toggle-row,
@@ -485,7 +526,7 @@
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
-    gap: 16px;
+    gap: var(--space-4);
   }
 
   .check-row {
@@ -494,7 +535,7 @@
 
   .toggle-row input,
   .check-row input {
-    margin-top: 2px;
+    margin-top: var(--space-0-5);
   }
 
   .field-label {
@@ -515,38 +556,51 @@
   .settings-grid {
     display: grid;
     grid-template-columns: minmax(0, 1fr);
-    gap: 12px;
+    gap: var(--space-3);
   }
 
   .field {
     display: flex;
     flex-direction: column;
-    gap: 5px;
+    gap: var(--space-1);
     min-width: 0;
   }
 
   .field input,
-  .peer-table input {
+  .peer-table input,
+  .platform-cell :global(.select-dropdown-trigger) {
     width: 100%;
     min-height: 30px;
-    padding: 5px 8px;
+    padding: var(--space-1) var(--space-2);
     border: 1px solid var(--border-default);
     border-radius: var(--radius-sm);
     background: var(--bg-primary);
     color: var(--text-primary);
     font-size: var(--font-size-sm);
+    font-weight: 400;
   }
 
   .field input:disabled,
-  .peer-table input:disabled {
+  .peer-table input:disabled,
+  .platform-cell :global(.select-dropdown-trigger:disabled) {
     color: var(--text-muted);
     background: var(--bg-inset);
+  }
+
+  .platform-cell :global(.select-dropdown) {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .platform-cell :global(.select-dropdown-trigger) {
+    height: 30px;
+    justify-content: space-between;
   }
 
   .restart-banner,
   .settings-error {
     margin: 0;
-    padding: 8px 10px;
+    padding: var(--space-2) var(--space-2-5);
     border-radius: var(--radius-sm);
     font-size: var(--font-size-sm);
   }
@@ -566,8 +620,8 @@
   .peer-section {
     display: flex;
     flex-direction: column;
-    gap: 10px;
-    padding-top: 12px;
+    gap: var(--space-2-5);
+    padding-top: var(--space-3);
     border-top: 1px solid var(--border-muted);
   }
 
@@ -575,7 +629,7 @@
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
-    gap: 12px;
+    gap: var(--space-3);
   }
 
   .peer-section-header h3 {
@@ -586,7 +640,7 @@
   }
 
   .peer-section-header p {
-    margin: 3px 0 0;
+    margin: var(--space-0-5) 0 0;
   }
 
   .peer-table-wrap {
@@ -608,7 +662,7 @@
 
   .peer-table th,
   .peer-table td {
-    padding: 7px 8px;
+    padding: var(--space-2);
     border-bottom: 1px solid var(--border-muted);
     vertical-align: top;
   }
@@ -625,45 +679,47 @@
     background: var(--bg-inset);
   }
 
-  .peer-table.http th:nth-child(1),
-  .peer-table.http td:nth-child(1) {
+  .http-key-col {
     width: 20%;
   }
 
-  .peer-table.http th:nth-child(2),
-  .peer-table.http td:nth-child(2) {
+  .http-name-col {
     width: 26%;
   }
 
-  .peer-table.ssh th:nth-child(1),
-  .peer-table.ssh td:nth-child(1) {
+  .http-url-col,
+  .ssh-command-col {
+    width: auto;
+  }
+
+  .ssh-key-col {
     width: 14%;
   }
 
-  .peer-table.ssh th:nth-child(2),
-  .peer-table.ssh td:nth-child(2) {
+  .ssh-name-col {
     width: 18%;
   }
 
-  .peer-table.ssh th:nth-child(4),
-  .peer-table.ssh td:nth-child(4) {
-    width: 13%;
+  .ssh-destination-col {
+    width: 24%;
   }
 
-  .peer-table.ssh th:nth-child(5),
-  .peer-table.ssh td:nth-child(5) {
-    width: 19%;
+  .ssh-platform-col {
+    width: 15%;
+  }
+
+  .peer-action-col {
+    width: 46px;
   }
 
   .action-cell {
-    width: 40px;
     text-align: right;
   }
 
   .settings-actions {
     display: flex;
     justify-content: flex-end;
-    gap: 8px;
+    gap: var(--space-2);
   }
 
   .primary-button,
@@ -672,7 +728,7 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    gap: 6px;
+    gap: var(--space-1-5);
     min-height: 30px;
     border-radius: var(--radius-sm);
     font-size: var(--font-size-sm);
@@ -680,13 +736,13 @@
   }
 
   .primary-button {
-    padding: 0 12px;
+    padding: 0 var(--space-3);
     background: var(--accent-blue);
     color: white;
   }
 
   .secondary-button {
-    padding: 0 10px;
+    padding: 0 var(--space-2-5);
     border: 1px solid var(--border-default);
     background: var(--bg-primary);
     color: var(--text-secondary);

--- a/frontend/src/lib/components/settings/FleetSettings.test.ts
+++ b/frontend/src/lib/components/settings/FleetSettings.test.ts
@@ -68,6 +68,7 @@ describe("FleetSettings", () => {
     expect(screen.getByLabelText("HTTP peer mini base URL")).toBeTruthy();
     expect(screen.getByLabelText("SSH peer epyc key")).toBeTruthy();
     expect(screen.getByLabelText("SSH peer epyc destination")).toBeTruthy();
+    expect(screen.getByRole("combobox", { name: "SSH peer epyc platform: linux" })).toBeTruthy();
   });
 
   it("saves edited federation settings", async () => {
@@ -100,6 +101,8 @@ describe("FleetSettings", () => {
     await fireEvent.input(screen.getByLabelText("SSH peer epyc remote command"), {
       target: { value: "middleman" },
     });
+    await fireEvent.click(screen.getByRole("combobox", { name: "SSH peer epyc platform: linux" }));
+    await fireEvent.click(screen.getByRole("option", { name: "darwin" }));
     await fireEvent.click(screen.getByRole("button", { name: "Save fleet federation" }));
 
     await waitFor(() => {
@@ -120,7 +123,7 @@ describe("FleetSettings", () => {
             key: "epyc",
             name: "EPYC",
             destination: "wes@epyc.tail",
-            platform: "linux",
+            platform: "darwin",
             remote_command: "middleman",
           },
         ],

--- a/frontend/src/lib/components/settings/FleetSettings.test.ts
+++ b/frontend/src/lib/components/settings/FleetSettings.test.ts
@@ -62,6 +62,8 @@ describe("FleetSettings", () => {
     }) as HTMLInputElement;
     expect(toggle.checked).toBe(false);
     expect(screen.getByText("Remote hosts stay unavailable while federation is off.")).toBeTruthy();
+    expect(screen.getByRole("table", { name: "HTTP peer membership" })).toBeTruthy();
+    expect(screen.getByRole("table", { name: "SSH peer membership" })).toBeTruthy();
     expect(screen.getByLabelText("HTTP peer mini key")).toBeTruthy();
     expect(screen.getByLabelText("HTTP peer mini base URL")).toBeTruthy();
     expect(screen.getByLabelText("SSH peer epyc key")).toBeTruthy();

--- a/frontend/src/lib/components/settings/FleetSettings.test.ts
+++ b/frontend/src/lib/components/settings/FleetSettings.test.ts
@@ -68,7 +68,7 @@ describe("FleetSettings", () => {
     expect(screen.getByLabelText("HTTP peer mini base URL")).toBeTruthy();
     expect(screen.getByLabelText("SSH peer epyc key")).toBeTruthy();
     expect(screen.getByLabelText("SSH peer epyc destination")).toBeTruthy();
-    expect(screen.getByRole("combobox", { name: "SSH peer epyc platform: linux" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "SSH peer epyc platform: linux" })).toBeTruthy();
   });
 
   it("saves edited federation settings", async () => {
@@ -101,8 +101,10 @@ describe("FleetSettings", () => {
     await fireEvent.input(screen.getByLabelText("SSH peer epyc remote command"), {
       target: { value: "middleman" },
     });
-    await fireEvent.click(screen.getByRole("combobox", { name: "SSH peer epyc platform: linux" }));
-    await fireEvent.click(screen.getByRole("option", { name: "darwin" }));
+    await fireEvent.click(screen.getByRole("button", { name: "SSH peer epyc platform: linux" }));
+    const platformInput = screen.getByRole("combobox", { name: "SSH peer epyc platform" });
+    await fireEvent.input(platformInput, { target: { value: "mac" } });
+    await fireEvent.keyDown(platformInput, { key: "Enter" });
     await fireEvent.click(screen.getByRole("button", { name: "Save fleet federation" }));
 
     await waitFor(() => {
@@ -123,7 +125,7 @@ describe("FleetSettings", () => {
             key: "epyc",
             name: "EPYC",
             destination: "wes@epyc.tail",
-            platform: "darwin",
+            platform: "macos",
             remote_command: "middleman",
           },
         ],
@@ -131,6 +133,44 @@ describe("FleetSettings", () => {
     });
     expect(onUpdate).toHaveBeenCalledWith(saved);
     expect(screen.getByText("Restart required")).toBeTruthy();
+  });
+
+  it("keeps SSH platform custom values editable", async () => {
+    mockUpdateFleetSettings.mockResolvedValue(fleetSettings());
+
+    render(FleetSettings, {
+      props: {
+        fleet: fleetSettings({
+          ssh_peers: [
+            {
+              key: "epyc",
+              name: "EPYC",
+              destination: "wes@epyc.tail",
+              platform: "plan9",
+            },
+          ],
+        }),
+        onUpdate: vi.fn(),
+      },
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: "SSH peer epyc platform: plan9" }));
+    const platformInput = screen.getByRole("combobox", { name: "SSH peer epyc platform" });
+    await fireEvent.input(platformInput, { target: { value: "freebsd" } });
+    await fireEvent.keyDown(platformInput, { key: "Enter" });
+    await fireEvent.click(screen.getByRole("button", { name: "Save fleet federation" }));
+
+    await waitFor(() => {
+      expect(mockUpdateFleetSettings).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ssh_peers: [
+            expect.objectContaining({
+              platform: "freebsd",
+            }),
+          ],
+        }),
+      );
+    });
   });
 
   it("surfaces save errors without discarding the draft", async () => {

--- a/frontend/src/lib/components/settings/FleetSettings.test.ts
+++ b/frontend/src/lib/components/settings/FleetSettings.test.ts
@@ -1,0 +1,149 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/svelte";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+import type { FleetSettings as FleetSettingsType } from "@middleman/ui/api/types";
+
+const { mockUpdateFleetSettings } = vi.hoisted(() => ({
+  mockUpdateFleetSettings: vi.fn(),
+}));
+
+vi.mock("../../api/settings.js", () => ({
+  updateFleetSettings: mockUpdateFleetSettings,
+}));
+
+vi.mock("../../stores/embed-config.svelte.js", () => ({
+  isEmbedded: () => false,
+}));
+
+import FleetSettings from "./FleetSettings.svelte";
+
+function fleetSettings(overrides: Partial<FleetSettingsType> = {}): FleetSettingsType {
+  return {
+    enabled: false,
+    key: "studio",
+    peer_timeout: "2s",
+    sessions: { include_unmanaged_details: false },
+    peers: [
+      {
+        key: "mini",
+        name: "Mac mini",
+        base_url: "http://mini.tail:8091",
+      },
+    ],
+    ssh_peers: [
+      {
+        key: "epyc",
+        name: "EPYC",
+        destination: "wes@epyc.tail",
+        platform: "linux",
+      },
+    ],
+    restart_required: false,
+    ...overrides,
+  };
+}
+
+describe("FleetSettings", () => {
+  afterEach(() => {
+    cleanup();
+    mockUpdateFleetSettings.mockReset();
+  });
+
+  it("shows disabled federation while keeping saved membership editable", () => {
+    render(FleetSettings, {
+      props: {
+        fleet: fleetSettings(),
+        onUpdate: vi.fn(),
+      },
+    });
+
+    const toggle = screen.getByRole("checkbox", {
+      name: "Enable fleet federation",
+    }) as HTMLInputElement;
+    expect(toggle.checked).toBe(false);
+    expect(screen.getByText("Remote hosts stay unavailable while federation is off.")).toBeTruthy();
+    expect(screen.getByLabelText("HTTP peer mini key")).toBeTruthy();
+    expect(screen.getByLabelText("HTTP peer mini base URL")).toBeTruthy();
+    expect(screen.getByLabelText("SSH peer epyc key")).toBeTruthy();
+    expect(screen.getByLabelText("SSH peer epyc destination")).toBeTruthy();
+  });
+
+  it("saves edited federation settings", async () => {
+    const onUpdate = vi.fn();
+    const saved = fleetSettings({
+      enabled: true,
+      key: "hub",
+      peer_timeout: "4s",
+      restart_required: true,
+    });
+    mockUpdateFleetSettings.mockResolvedValue(saved);
+
+    render(FleetSettings, {
+      props: {
+        fleet: fleetSettings(),
+        onUpdate,
+      },
+    });
+
+    await fireEvent.click(screen.getByRole("checkbox", { name: "Enable fleet federation" }));
+    await fireEvent.input(screen.getByLabelText("Local fleet key"), {
+      target: { value: "hub" },
+    });
+    await fireEvent.input(screen.getByLabelText("Peer timeout"), {
+      target: { value: "4s" },
+    });
+    await fireEvent.input(screen.getByLabelText("HTTP peer mini name"), {
+      target: { value: "Mini" },
+    });
+    await fireEvent.input(screen.getByLabelText("SSH peer epyc remote command"), {
+      target: { value: "middleman" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Save fleet federation" }));
+
+    await waitFor(() => {
+      expect(mockUpdateFleetSettings).toHaveBeenCalledWith({
+        enabled: true,
+        key: "hub",
+        peer_timeout: "4s",
+        sessions: { include_unmanaged_details: false },
+        peers: [
+          {
+            key: "mini",
+            name: "Mini",
+            base_url: "http://mini.tail:8091",
+          },
+        ],
+        ssh_peers: [
+          {
+            key: "epyc",
+            name: "EPYC",
+            destination: "wes@epyc.tail",
+            platform: "linux",
+            remote_command: "middleman",
+          },
+        ],
+      });
+    });
+    expect(onUpdate).toHaveBeenCalledWith(saved);
+    expect(screen.getByText("Restart required")).toBeTruthy();
+  });
+
+  it("surfaces save errors without discarding the draft", async () => {
+    mockUpdateFleetSettings.mockRejectedValue(new Error("fleet.peers[0]: base_url is required"));
+
+    render(FleetSettings, {
+      props: {
+        fleet: fleetSettings(),
+        onUpdate: vi.fn(),
+      },
+    });
+
+    await fireEvent.input(screen.getByLabelText("HTTP peer mini name"), {
+      target: { value: "Mini" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Save fleet federation" }));
+
+    expect(await screen.findByText("fleet.peers[0]: base_url is required")).toBeTruthy();
+    expect((screen.getByLabelText("HTTP peer mini name") as HTMLInputElement).value).toBe("Mini");
+  });
+});

--- a/frontend/src/lib/components/settings/RepoImportModal.test.ts
+++ b/frontend/src/lib/components/settings/RepoImportModal.test.ts
@@ -12,6 +12,16 @@ vi.mock("../../api/settings.js", () => ({
 const preview = previewRepos as MockedFunction<typeof previewRepos>;
 const bulk = bulkAddRepos as MockedFunction<typeof bulkAddRepos>;
 
+function defaultFleetSettings() {
+  return {
+    enabled: false,
+    sessions: {},
+    peers: [],
+    ssh_peers: [],
+    restart_required: false,
+  };
+}
+
 const rows = [
   {
     provider: "github",
@@ -130,6 +140,7 @@ describe("RepoImportModal", () => {
         renderer: "xterm",
       },
       agents: [],
+      fleet: defaultFleetSettings(),
     });
     render(RepoImportModal, {
       props: { open: true, onClose: vi.fn(), onImported },
@@ -201,6 +212,7 @@ describe("RepoImportModal", () => {
         renderer: "xterm",
       },
       agents: [],
+      fleet: defaultFleetSettings(),
     });
     render(RepoImportModal, {
       props: { open: true, onClose: vi.fn(), onImported: vi.fn() },

--- a/frontend/src/lib/components/settings/RepoSettings.test.ts
+++ b/frontend/src/lib/components/settings/RepoSettings.test.ts
@@ -30,6 +30,16 @@ const mockUpdateRepoWorktreeBasePath = vi.mocked(updateRepoWorktreeBasePath);
 const mockPreviewRepos = vi.mocked(previewRepos);
 const mockBulkAddRepos = vi.mocked(bulkAddRepos);
 
+function defaultFleetSettings() {
+  return {
+    enabled: false,
+    sessions: {},
+    peers: [],
+    ssh_peers: [],
+    restart_required: false,
+  };
+}
+
 describe("RepoSettings", () => {
   afterEach(() => {
     cleanup();
@@ -180,6 +190,7 @@ describe("RepoSettings", () => {
         renderer: "xterm",
       },
       agents: [],
+      fleet: defaultFleetSettings(),
     });
     mockRefreshRepo.mockResolvedValue({
       repos: [],
@@ -203,6 +214,7 @@ describe("RepoSettings", () => {
         renderer: "xterm",
       },
       agents: [],
+      fleet: defaultFleetSettings(),
     });
 
     render(RepoSettings, {
@@ -274,6 +286,7 @@ describe("RepoSettings", () => {
         renderer: "xterm",
       },
       agents: [],
+      fleet: defaultFleetSettings(),
     });
 
     render(RepoSettings, {
@@ -368,6 +381,7 @@ describe("RepoSettings", () => {
         renderer: "xterm",
       },
       agents: [],
+      fleet: defaultFleetSettings(),
     });
     render(RepoSettings, {
       props: {

--- a/frontend/src/lib/components/settings/SettingsPage.svelte
+++ b/frontend/src/lib/components/settings/SettingsPage.svelte
@@ -12,6 +12,7 @@
   import TerminalSettings from "./TerminalSettings.svelte";
   import ModeVisibilitySettings from "./ModeVisibilitySettings.svelte";
   import AgentSettings from "./AgentSettings.svelte";
+  import FleetSettings from "./FleetSettings.svelte";
 
   interface SettingsNavItem {
     id: string;
@@ -58,6 +59,13 @@
       group: "Workspace",
       summary: "Agent commands available in workspaces",
       keywords: "workspace agents codex claude gemini opencode aider binary arguments",
+    },
+    {
+      id: "settings-fleet",
+      title: "Fleet federation",
+      group: "Workspace",
+      summary: "Remote hosts and fleet membership",
+      keywords: "fleet federation remote hosts peers ssh http membership",
     },
   ];
 
@@ -223,6 +231,15 @@
             agents={settings.agents}
             onUpdate={(agents) => {
               settings = { ...settings!, agents };
+            }}
+          />
+        </SettingsSection>
+
+        <SettingsSection title="Fleet federation" sectionId="settings-fleet">
+          <FleetSettings
+            fleet={settings.fleet}
+            onUpdate={(fleet) => {
+              settings = { ...settings!, fleet };
             }}
           />
         </SettingsSection>

--- a/frontend/src/lib/components/shared/TypeaheadTrigger.svelte
+++ b/frontend/src/lib/components/shared/TypeaheadTrigger.svelte
@@ -18,6 +18,8 @@
     emptyLabel?: string;
     allowClear?: boolean;
     allowCustom?: boolean;
+    disabled?: boolean;
+    placement?: "bottom" | "top";
     clearLabel?: string;
     triggerPrefix?: string;
     triggerAriaLabel?: string;
@@ -32,6 +34,8 @@
     emptyLabel = "No matches",
     allowClear = false,
     allowCustom = false,
+    disabled = false,
+    placement = "bottom",
     clearLabel = "None",
     triggerPrefix = "",
     triggerAriaLabel = undefined,
@@ -58,6 +62,7 @@
   let optionCount = $derived(filtered.length + optionOffset);
 
   async function openDropdown() {
+    if (disabled) return;
     query = "";
     open = true;
     highlightIndex = allowClear && options.length > 0 ? 1 : 0;
@@ -160,6 +165,7 @@
     <ul
       id={listboxID}
       class="typeahead-list"
+      class:typeahead-list--top={placement === "top"}
       data-surface="solid"
       role="listbox"
       aria-label={`${ariaLabel} options`}
@@ -203,6 +209,7 @@
       type="button"
       aria-label={triggerAriaLabel ?? `${ariaLabel}: ${displayValue}`}
       aria-haspopup="listbox"
+      {disabled}
       onclick={openDropdown}
     >
       <span class="typeahead-value">
@@ -248,6 +255,12 @@
     border-color: var(--border-default);
   }
 
+  .typeahead-trigger:disabled {
+    color: var(--text-muted);
+    background: var(--bg-inset);
+    cursor: default;
+  }
+
   .typeahead-value {
     min-width: 0;
     display: inline-flex;
@@ -286,6 +299,11 @@
     border: 1px solid var(--border-default);
     border-radius: var(--radius-sm);
     box-shadow: var(--shadow-lg);
+  }
+
+  .typeahead-list--top {
+    top: auto;
+    bottom: calc(100% + 3px);
   }
 
   .typeahead-option {

--- a/frontend/src/lib/components/shared/TypeaheadTrigger.test.ts
+++ b/frontend/src/lib/components/shared/TypeaheadTrigger.test.ts
@@ -70,4 +70,34 @@ describe("TypeaheadTrigger", () => {
     expect(list).toBeTruthy();
     expect(list!.getAttribute("data-surface")).toBe("solid");
   });
+
+  it("can place the option list above the trigger", async () => {
+    const { container } = render(TypeaheadTrigger, {
+      props: {
+        ariaLabel: "Platform",
+        options: [{ value: "macos", label: "macOS" }],
+        placement: "top",
+        onChange: vi.fn(),
+      },
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Platform: None" }));
+
+    expect(container.querySelector(".typeahead-list--top")).toBeTruthy();
+  });
+
+  it("does not open when disabled", async () => {
+    render(TypeaheadTrigger, {
+      props: {
+        ariaLabel: "Owner",
+        options: [{ value: "agent:planner", label: "agent:planner" }],
+        disabled: true,
+        onChange: vi.fn(),
+      },
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Owner: None" }));
+
+    expect(screen.queryByRole("combobox", { name: "Owner" })).toBeNull();
+  });
 });

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -215,7 +215,7 @@
   );
 
   const hasRemoteFleetHosts = $derived(
-    fleetHosts.some((host) => host.kind !== "self"),
+    hasNonSelfFleetHost(fleetHosts),
   );
 
   const showFleetStatus = $derived(
@@ -260,6 +260,14 @@
     return Number.isNaN(ms) ? 0 : ms;
   }
 
+  function hasNonSelfFleetHost(hosts: HostSummary[]): boolean {
+    return hosts.some((host) => host.kind !== "self");
+  }
+
+  function localWorkspacesOnly(items: Workspace[]): Workspace[] {
+    return items.filter((ws) => !ws.fleet_host_key);
+  }
+
   const repoLabelFormatter = $derived.by(() =>
     createRepoLabelFormatter(
       workspaces.map(workspaceRepoIdentity),
@@ -296,10 +304,13 @@
         return;
       }
       const local = (data.workspaces ?? []) as Workspace[];
-      const remote = fleetLoaded && !fleetError
+      const remote = fleetLoaded && !fleetError && hasRemoteFleetHosts
         ? await fetchPeerWorkspaces(abortController.signal)
         : [];
-      workspaces = [...local, ...remote];
+      workspaces = [
+        ...local,
+        ...(hasRemoteFleetHosts ? remote : []),
+      ];
       workspaceListStatus = "loaded";
     } catch {
       // Network error; keep stale list.
@@ -354,9 +365,13 @@
         fleetLoaded = true;
         return;
       }
-      fleetHosts = (data?.hosts ?? []) as HostSummary[];
+      const nextHosts = (data?.hosts ?? []) as HostSummary[];
+      fleetHosts = nextHosts;
       fleetError = null;
       fleetLoaded = true;
+      if (!hasNonSelfFleetHost(nextHosts)) {
+        workspaces = localWorkspacesOnly(workspaces);
+      }
       void fetchWorkspaces();
     } catch {
       fleetError = "Fleet unavailable";

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -214,8 +214,12 @@
     fleetHosts.filter((host) => host.reachable).length,
   );
 
+  const hasRemoteFleetHosts = $derived(
+    fleetHosts.some((host) => host.kind !== "self"),
+  );
+
   const showFleetStatus = $derived(
-    fleetError !== null || (fleetLoaded && fleetHosts.length > 0),
+    fleetError !== null || (fleetLoaded && hasRemoteFleetHosts),
   );
 
   // Flat ordering for timestamp sorts. The org/repo mode keeps

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
@@ -193,7 +193,7 @@ describe("WorkspaceListSidebar", () => {
     expect(screen.getByText("http")).toBeTruthy();
   });
 
-  it("shows the local fleet host even without peers", async () => {
+  it("hides the fleet status block when only the local host is present", async () => {
     mockGet.mockImplementation((path: string) => {
       if (path === "/snapshot") {
         return Promise.resolve({
@@ -222,11 +222,19 @@ describe("WorkspaceListSidebar", () => {
       props: { selectedId: "" },
     });
 
-    await screen.findByText("Fleet");
-    expect(screen.getByText("1/1")).toBeTruthy();
-    expect(screen.getByText("member")).toBeTruthy();
-    expect(screen.getByText("self")).toBeTruthy();
-    expect(screen.getByText("local")).toBeTruthy();
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledWith(
+        "/snapshot",
+        expect.objectContaining({
+          params: { query: { include_peers: true } },
+        }),
+      );
+    });
+    expect(screen.queryByText("Fleet")).toBeNull();
+    expect(screen.queryByText("1/1")).toBeNull();
+    expect(screen.queryByText("member")).toBeNull();
+    expect(screen.queryByText("self")).toBeNull();
+    expect(screen.queryByText("local")).toBeNull();
   });
 
   it("loads workspaces from reachable ssh fleet hosts", async () => {

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
@@ -128,6 +128,16 @@ function rowTitles(container: HTMLElement): string[] {
   return Array.from(container.querySelectorAll(".ws-name")).map((el) => el.textContent?.trim() ?? "");
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, reject, resolve };
+}
+
 describe("WorkspaceListSidebar", () => {
   beforeEach(() => {
     mockGet.mockReset();
@@ -305,6 +315,120 @@ describe("WorkspaceListSidebar", () => {
       );
     });
     expect(await screen.findByText("Remote SSH workspace")).toBeTruthy();
+  });
+
+  it("removes remote workspaces when the fleet snapshot becomes local-only", async () => {
+    vi.useFakeTimers();
+    const stalledLocalRefresh = deferred<{ data: { workspaces: unknown[] } }>();
+    let localWorkspaceCalls = 0;
+    let snapshotCalls = 0;
+
+    mockGet.mockImplementation((path: string, options?: { params?: { path?: { host_key?: string } } }) => {
+      if (path === "/snapshot") {
+        snapshotCalls += 1;
+        return Promise.resolve({
+          data: {
+            hosts:
+              snapshotCalls === 1
+                ? [
+                    {
+                      configKey: "hub",
+                      diagnostics: [],
+                      id: "hub",
+                      kind: "self",
+                      name: "hub",
+                      operationAvailability: {},
+                      platform: "darwin",
+                      preferredTransport: "local",
+                      reachable: true,
+                      tmuxSessions: [],
+                    },
+                    {
+                      configKey: "epyc",
+                      diagnostics: [],
+                      id: "epyc",
+                      kind: "remote",
+                      name: "epyc",
+                      operationAvailability: {},
+                      platform: "linux",
+                      preferredTransport: "ssh",
+                      reachable: true,
+                      tmuxSessions: [],
+                    },
+                  ]
+                : [
+                    {
+                      configKey: "hub",
+                      diagnostics: [],
+                      id: "hub",
+                      kind: "self",
+                      name: "hub",
+                      operationAvailability: {},
+                      platform: "darwin",
+                      preferredTransport: "local",
+                      reachable: true,
+                      tmuxSessions: [],
+                    },
+                  ],
+          },
+        });
+      }
+      if (path === "/fleet/hosts/{host_key}/workspaces") {
+        expect(options?.params?.path?.host_key).toBe("epyc");
+        return Promise.resolve({
+          data: {
+            workspaces: [
+              workspaceFixture({
+                id: "remote-ws",
+                provider: "github",
+                platformHost: "github.com",
+                owner: "remote",
+                name: "service",
+                number: 12,
+                title: "Remote SSH workspace",
+              }),
+            ],
+          },
+        });
+      }
+      if (path === "/workspaces") {
+        localWorkspaceCalls += 1;
+        if (localWorkspaceCalls >= 3) {
+          return stalledLocalRefresh.promise;
+        }
+        return Promise.resolve({
+          data: {
+            workspaces: [
+              workspaceFixture({
+                id: "local-ws",
+                provider: "github",
+                platformHost: "github.com",
+                owner: "local",
+                name: "service",
+                number: 1,
+                title: "Local workspace",
+              }),
+            ],
+          },
+        });
+      }
+      return Promise.resolve({ data: { workspaces: [] } });
+    });
+
+    render(WorkspaceListSidebar, {
+      props: { selectedId: "" },
+    });
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(await screen.findByText("Remote SSH workspace")).toBeTruthy();
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    await tick();
+
+    await waitFor(() => {
+      expect(screen.queryByText("Remote SSH workspace")).toBeNull();
+    });
+    expect(screen.getByText("Local workspace")).toBeTruthy();
   });
 
   it("shows provider icons in repo groups when multiple providers are present", async () => {

--- a/frontend/src/lib/utils/appStartup.test.ts
+++ b/frontend/src/lib/utils/appStartup.test.ts
@@ -37,6 +37,13 @@ function makeStores(): StoreInstances {
 function makeSettings(): Settings {
   return {
     repos: [],
+    fleet: {
+      enabled: false,
+      sessions: {},
+      peers: [],
+      ssh_peers: [],
+      restart_required: false,
+    },
     activity: {
       view_mode: "threaded",
       time_range: "7d",

--- a/frontend/src/test/mockApiFetch.ts
+++ b/frontend/src/test/mockApiFetch.ts
@@ -286,6 +286,17 @@ const settings = {
     renderer: "xterm",
   },
   agents: [],
+  fleet: {
+    enabled: false,
+    key: "",
+    peer_timeout: "2s",
+    sessions: {
+      include_unmanaged_details: false,
+    },
+    peers: [],
+    ssh_peers: [],
+    restart_required: false,
+  },
 };
 
 export function makeRateLimits() {

--- a/frontend/tests/e2e/viewport-fit.spec.ts
+++ b/frontend/tests/e2e/viewport-fit.spec.ts
@@ -78,8 +78,8 @@ test("settings sidebar order matches rendered section order", async ({ page }) =
       return { navOrder, sectionOrder, orderMatches: navOrder.join("\n") === sectionOrder.join("\n") };
     }),
   ).resolves.toEqual({
-    navOrder: ["Repositories", "Activity", "Terminal", "Workspace agents", "Visible modes"],
-    sectionOrder: ["Repositories", "Activity", "Terminal", "Workspace agents", "Visible modes"],
+    navOrder: ["Repositories", "Activity", "Terminal", "Workspace agents", "Fleet federation", "Visible modes"],
+    sectionOrder: ["Repositories", "Activity", "Terminal", "Workspace agents", "Fleet federation", "Visible modes"],
     orderMatches: true,
   });
 });

--- a/frontend/tests/e2e/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar.spec.ts
@@ -2860,7 +2860,7 @@ test.describe("workspace list fleet inventory", () => {
     await expect(page.locator(".workspace-home")).toContainText("Member workspace");
   });
 
-  test("shows singleton self fleet host status", async ({ page }) => {
+  test("hides singleton self fleet host status", async ({ page }) => {
     await page.route("**/api/v1/workspaces", async (route) => {
       await route.fulfill({
         status: 200,
@@ -2897,11 +2897,10 @@ test.describe("workspace list fleet inventory", () => {
     await page.goto("/workspaces");
 
     const sidebar = page.locator(".workspace-list-sidebar");
-    await expect(sidebar).toContainText("Fleet");
-    await expect(sidebar).toContainText("1/1");
-    await expect(sidebar).toContainText("member");
-    await expect(sidebar).toContainText("self");
-    await expect(sidebar).toContainText("local");
+    await expect(sidebar).toBeVisible();
+    await expect(sidebar).not.toContainText("Fleet");
+    await expect(sidebar).not.toContainText("1/1");
+    await expect(sidebar).not.toContainText("member");
   });
 
   test("a hung fleet peer does not freeze local workspace updates", async ({ page }) => {

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -1056,6 +1056,13 @@ type FilesystemValidateRepoOutputBody struct {
 	RootPath *string `json:"root_path,omitempty"`
 }
 
+// FleetPeer defines model for FleetPeer.
+type FleetPeer struct {
+	BaseUrl string  `json:"base_url"`
+	Key     string  `json:"key"`
+	Name    *string `json:"name,omitempty"`
+}
+
 // FleetSSHPeer defines model for FleetSSHPeer.
 type FleetSSHPeer struct {
 	Destination   string  `json:"destination"`
@@ -1070,6 +1077,24 @@ type FleetSSHPeersBody struct {
 	// Schema A URL to the JSON Schema for this object.
 	Schema          *string        `json:"$schema,omitempty"`
 	RestartRequired bool           `json:"restart_required"`
+	SshPeers        []FleetSSHPeer `json:"ssh_peers"`
+}
+
+// FleetSessions defines model for FleetSessions.
+type FleetSessions struct {
+	IncludeUnmanagedDetails *bool `json:"include_unmanaged_details,omitempty"`
+}
+
+// FleetSettingsResponse defines model for FleetSettingsResponse.
+type FleetSettingsResponse struct {
+	// Schema A URL to the JSON Schema for this object.
+	Schema          *string        `json:"$schema,omitempty"`
+	Enabled         bool           `json:"enabled"`
+	Key             *string        `json:"key,omitempty"`
+	PeerTimeout     *string        `json:"peer_timeout,omitempty"`
+	Peers           []FleetPeer    `json:"peers"`
+	RestartRequired bool           `json:"restart_required"`
+	Sessions        FleetSessions  `json:"sessions"`
 	SshPeers        []FleetSSHPeer `json:"ssh_peers"`
 }
 
@@ -2507,6 +2532,7 @@ type SettingsResponse struct {
 	Schema   *string                `json:"$schema,omitempty"`
 	Activity Activity               `json:"activity"`
 	Agents   []Agent                `json:"agents"`
+	Fleet    FleetSettingsResponse  `json:"fleet"`
 	Modes    *ModeVisibility        `json:"modes,omitempty"`
 	Repos    []ConfiguredRepoStatus `json:"repos"`
 	Terminal Terminal               `json:"terminal"`
@@ -2675,6 +2701,18 @@ type UpdateFleetSSHPeersInputBody struct {
 	// Schema A URL to the JSON Schema for this object.
 	Schema   *string        `json:"$schema,omitempty"`
 	SshPeers []FleetSSHPeer `json:"ssh_peers"`
+}
+
+// UpdateFleetSettingsInputBody defines model for UpdateFleetSettingsInputBody.
+type UpdateFleetSettingsInputBody struct {
+	// Schema A URL to the JSON Schema for this object.
+	Schema      *string        `json:"$schema,omitempty"`
+	Enabled     bool           `json:"enabled"`
+	Key         *string        `json:"key,omitempty"`
+	PeerTimeout *string        `json:"peer_timeout,omitempty"`
+	Peers       []FleetPeer    `json:"peers"`
+	Sessions    FleetSessions  `json:"sessions"`
+	SshPeers    []FleetSSHPeer `json:"ssh_peers"`
 }
 
 // UpdateSettingsRequest defines model for UpdateSettingsRequest.
@@ -3536,6 +3574,9 @@ type LaunchHostRuntimeSessionJSONRequestBody = LaunchHostRuntimeSessionInputBody
 
 // UpdateSettingsJSONRequestBody defines body for UpdateSettings for application/json ContentType.
 type UpdateSettingsJSONRequestBody = UpdateSettingsRequest
+
+// UpdateFleetSettingsJSONRequestBody defines body for UpdateFleetSettings for application/json ContentType.
+type UpdateFleetSettingsJSONRequestBody = UpdateFleetSettingsInputBody
 
 // UpdateFleetSshPeersJSONRequestBody defines body for UpdateFleetSshPeers for application/json ContentType.
 type UpdateFleetSshPeersJSONRequestBody = UpdateFleetSSHPeersInputBody
@@ -4434,6 +4475,14 @@ type ClientInterface interface {
 	UpdateSettingsWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	UpdateSettings(ctx context.Context, body UpdateSettingsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetFleetSettings request
+	GetFleetSettings(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateFleetSettingsWithBody request with any body
+	UpdateFleetSettingsWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateFleetSettings(ctx context.Context, body UpdateFleetSettingsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetFleetSshPeers request
 	GetFleetSshPeers(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -8062,6 +8111,42 @@ func (c *Client) UpdateSettingsWithBody(ctx context.Context, contentType string,
 
 func (c *Client) UpdateSettings(ctx context.Context, body UpdateSettingsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewUpdateSettingsRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetFleetSettings(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetFleetSettingsRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateFleetSettingsWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateFleetSettingsRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateFleetSettings(ctx context.Context, body UpdateFleetSettingsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateFleetSettingsRequest(c.Server, body)
 	if err != nil {
 		return nil, err
 	}
@@ -21179,6 +21264,73 @@ func NewUpdateSettingsRequestWithBody(server string, contentType string, body io
 	return req, nil
 }
 
+// NewGetFleetSettingsRequest generates requests for GetFleetSettings
+func NewGetFleetSettingsRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/settings/fleet")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdateFleetSettingsRequest calls the generic UpdateFleetSettings builder with application/json body
+func NewUpdateFleetSettingsRequest(server string, body UpdateFleetSettingsJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateFleetSettingsRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewUpdateFleetSettingsRequestWithBody generates requests for UpdateFleetSettings with any type of body
+func NewUpdateFleetSettingsRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/settings/fleet")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPut, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewGetFleetSshPeersRequest generates requests for GetFleetSshPeers
 func NewGetFleetSshPeersRequest(server string) (*http.Request, error) {
 	var err error
@@ -23424,6 +23576,14 @@ type ClientWithResponsesInterface interface {
 	UpdateSettingsWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateSettingsResponse, error)
 
 	UpdateSettingsWithResponse(ctx context.Context, body UpdateSettingsJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateSettingsResponse, error)
+
+	// GetFleetSettingsWithResponse request
+	GetFleetSettingsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetFleetSettingsResponse, error)
+
+	// UpdateFleetSettingsWithBodyWithResponse request with any body
+	UpdateFleetSettingsWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateFleetSettingsResponse, error)
+
+	UpdateFleetSettingsWithResponse(ctx context.Context, body UpdateFleetSettingsJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateFleetSettingsResponse, error)
 
 	// GetFleetSshPeersWithResponse request
 	GetFleetSshPeersWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetFleetSshPeersResponse, error)
@@ -28313,6 +28473,52 @@ func (r UpdateSettingsResponse) StatusCode() int {
 	return 0
 }
 
+type GetFleetSettingsResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *FleetSettingsResponse
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r GetFleetSettingsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetFleetSettingsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UpdateFleetSettingsResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *FleetSettingsResponse
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateFleetSettingsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateFleetSettingsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type GetFleetSshPeersResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
@@ -31548,6 +31754,32 @@ func (c *ClientWithResponses) UpdateSettingsWithResponse(ctx context.Context, bo
 		return nil, err
 	}
 	return ParseUpdateSettingsResponse(rsp)
+}
+
+// GetFleetSettingsWithResponse request returning *GetFleetSettingsResponse
+func (c *ClientWithResponses) GetFleetSettingsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetFleetSettingsResponse, error) {
+	rsp, err := c.GetFleetSettings(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetFleetSettingsResponse(rsp)
+}
+
+// UpdateFleetSettingsWithBodyWithResponse request with arbitrary body returning *UpdateFleetSettingsResponse
+func (c *ClientWithResponses) UpdateFleetSettingsWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateFleetSettingsResponse, error) {
+	rsp, err := c.UpdateFleetSettingsWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateFleetSettingsResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateFleetSettingsWithResponse(ctx context.Context, body UpdateFleetSettingsJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateFleetSettingsResponse, error) {
+	rsp, err := c.UpdateFleetSettings(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateFleetSettingsResponse(rsp)
 }
 
 // GetFleetSshPeersWithResponse request returning *GetFleetSshPeersResponse
@@ -38576,6 +38808,72 @@ func ParseUpdateSettingsResponse(rsp *http.Response) (*UpdateSettingsResponse, e
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest SettingsResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetFleetSettingsResponse parses an HTTP response from a GetFleetSettingsWithResponse call
+func ParseGetFleetSettingsResponse(rsp *http.Response) (*GetFleetSettingsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetFleetSettingsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest FleetSettingsResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateFleetSettingsResponse parses an HTTP response from a UpdateFleetSettingsWithResponse call
+func ParseUpdateFleetSettingsResponse(rsp *http.Response) (*UpdateFleetSettingsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateFleetSettingsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest FleetSettingsResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -809,8 +809,8 @@ func isBareExecutable(s string) bool {
 
 // validateFleetSSHPeers rejects ssh peers that would later produce
 // unroutable hosts or merge collisions: empty keys/destinations,
-// duplicate keys, and keys colliding with HTTP peers or the local
-// fleet key.
+// duplicate keys, the reserved self alias, and keys colliding with
+// HTTP peers or the local fleet key.
 func (c *Config) validateFleetSSHPeers() error {
 	seen := make(map[string]string, len(c.Fleet.Peers))
 	for _, p := range c.Fleet.Peers {
@@ -821,6 +821,12 @@ func (c *Config) validateFleetSSHPeers() error {
 		if key == "" {
 			return fmt.Errorf(
 				"config: fleet.ssh_peers[%d]: key is required", i,
+			)
+		}
+		if key == "self" {
+			return fmt.Errorf(
+				"config: fleet.ssh_peers[%d]: key %q is reserved for local self routing",
+				i, key,
 			)
 		}
 		// Destination is passed to ssh(1) as a single positional
@@ -1496,14 +1502,22 @@ func (c *Config) validate(skipAppCoverage bool) error {
 }
 
 // Validate checks the fleet section: peer keys must be unique, non-empty,
-// and distinct from the local fleet key; base URLs must be absolute
-// http(s); peer_timeout must parse when set. Embedders that supply peers
-// through Options share this validation with the config-file path.
+// distinct from the local fleet key, and not shadow the reserved self alias;
+// base URLs must be absolute http(s); peer_timeout must parse when set.
+// Embedders that supply peers through Options share this validation with the
+// config-file path.
 func (f Fleet) Validate() error {
+	const reservedSelfKey = "self"
+	if strings.TrimSpace(f.Key) == reservedSelfKey {
+		return fmt.Errorf("fleet.key %q is reserved for local self routing", reservedSelfKey)
+	}
 	seenFleetPeers := map[string]bool{}
 	for i, p := range f.Peers {
 		if p.Key == "" {
 			return fmt.Errorf("fleet.peers[%d]: key is required", i)
+		}
+		if strings.TrimSpace(p.Key) == reservedSelfKey {
+			return fmt.Errorf("fleet.peers[%d]: key %q is reserved for local self routing", i, reservedSelfKey)
 		}
 		if seenFleetPeers[p.Key] {
 			return fmt.Errorf("fleet.peers: duplicate key %q", p.Key)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1227,6 +1227,9 @@ func (c *Config) Validate() error {
 // GitHub App installation coverage check for the CLI's repair path.
 func (c *Config) validate(skipAppCoverage bool) error {
 	var err error
+	if err := c.Fleet.Validate(); err != nil {
+		return err
+	}
 	if err := c.validateFleetSSHPeers(); err != nil {
 		return err
 	}
@@ -1494,21 +1497,24 @@ func (c *Config) validate(skipAppCoverage bool) error {
 		)
 	}
 
-	if err := c.Fleet.Validate(); err != nil {
-		return err
-	}
-
 	return nil
 }
 
-// Validate checks the fleet section: peer keys must be unique, non-empty,
-// distinct from the local fleet key, and not shadow the reserved self alias;
-// base URLs must be absolute http(s); peer_timeout must parse when set.
-// Embedders that supply peers through Options share this validation with the
-// config-file path.
-func (f Fleet) Validate() error {
+// Validate checks and canonicalizes the fleet section: peer keys must be
+// unique, non-empty, distinct from the local fleet key, and not shadow the
+// reserved self alias; base URLs must be absolute http(s); peer_timeout must
+// parse when set. Embedders that supply peers through Options share this
+// validation with the config-file path.
+func (f *Fleet) Validate() error {
 	const reservedSelfKey = "self"
-	if strings.TrimSpace(f.Key) == reservedSelfKey {
+	f.Key = strings.TrimSpace(f.Key)
+	for i := range f.Peers {
+		f.Peers[i].Key = strings.TrimSpace(f.Peers[i].Key)
+	}
+	for i := range f.SSHPeers {
+		f.SSHPeers[i].Key = strings.TrimSpace(f.SSHPeers[i].Key)
+	}
+	if f.Key == reservedSelfKey {
 		return fmt.Errorf("fleet.key %q is reserved for local self routing", reservedSelfKey)
 	}
 	seenFleetPeers := map[string]bool{}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -703,6 +703,7 @@ func (p FleetSSHPeer) RemoteCommandOrDefault() string {
 // Fleet configures this daemon's federation: an optional local host key
 // and the peers whose snapshots the hub fans out to.
 type Fleet struct {
+	Enabled     bool           `toml:"enabled,omitempty" json:"enabled"`
 	Key         string         `toml:"key,omitempty" json:"key,omitempty"`
 	PeerTimeout string         `toml:"peer_timeout,omitempty" json:"peer_timeout,omitempty"`
 	Sessions    FleetSessions  `toml:"sessions" json:"sessions"`
@@ -992,6 +993,7 @@ port = 8091
 # A peer that does not answer in time degrades (reachable=false)
 # instead of stalling the snapshot.
 # [fleet]
+# enabled = false
 # peer_timeout = "2s"
 
 # Federate with fleet peers reached over SSH: the daemon holds a

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2955,6 +2955,7 @@ func TestSaveRoundTripsFleet(t *testing.T) {
 		DataDir:        dir,
 		Activity:       Activity{ViewMode: "threaded", TimeRange: "7d"},
 		Fleet: Fleet{
+			Enabled:     true,
 			Key:         "studio",
 			PeerTimeout: "3s",
 			Sessions:    FleetSessions{IncludeUnmanagedDetails: true},
@@ -2968,6 +2969,7 @@ func TestSaveRoundTripsFleet(t *testing.T) {
 
 	reloaded, err := Load(path)
 	require.NoError(t, err)
+	assert.True(reloaded.Fleet.Enabled)
 	assert.Equal("studio", reloaded.Fleet.Key)
 	assert.Equal("3s", reloaded.Fleet.PeerTimeout)
 	assert.True(reloaded.Fleet.Sessions.IncludeUnmanagedDetails)
@@ -3545,6 +3547,7 @@ func TestFleetConfigParsesAndValidates(t *testing.T) {
 	require := require.New(t)
 	path := writeConfig(t, `
 [fleet]
+enabled = true
 key = "studio"
 peer_timeout = "2s"
 [fleet.sessions]
@@ -3556,12 +3559,28 @@ base_url = "http://mbp:8091"
 `)
 	cfg, err := Load(path)
 	require.NoError(err)
+	require.True(cfg.Fleet.Enabled)
 	require.Equal("studio", cfg.Fleet.Key)
 	require.Len(cfg.Fleet.Peers, 1)
 	require.Equal("mbp", cfg.Fleet.Peers[0].Key)
 	require.Equal("http://mbp:8091", cfg.Fleet.Peers[0].BaseURL)
 	require.Equal("2s", cfg.Fleet.PeerTimeoutOrDefault().String())
 	require.True(cfg.Fleet.Sessions.IncludeUnmanagedDetails)
+}
+
+func TestFleetConfigDefaultsToDisabledFederation(t *testing.T) {
+	require := require.New(t)
+	path := writeConfig(t, `
+[fleet]
+key = "studio"
+[[fleet.peers]]
+key = "mbp"
+base_url = "http://mbp:8091"
+`)
+	cfg, err := Load(path)
+	require.NoError(err)
+	require.False(cfg.Fleet.Enabled)
+	require.Len(cfg.Fleet.Peers, 1)
 }
 
 func TestFleetSessionsConfigDefaultsToRedactedUnmanagedDetails(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3606,6 +3606,51 @@ base_url = "http://b:8091"
 	require.Error(t, err, "expected duplicate peer key to fail validation")
 }
 
+func TestFleetRejectsReservedSelfKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name: "local key",
+			content: `
+[fleet]
+key = "self"
+`,
+			want: "fleet.key",
+		},
+		{
+			name: "http peer",
+			content: `
+[[fleet.peers]]
+key = "self"
+base_url = "http://middleman.local:8091"
+`,
+			want: "fleet.peers[0]",
+		},
+		{
+			name: "ssh peer",
+			content: `
+[[fleet.ssh_peers]]
+key = "self"
+destination = "dev@middleman.local"
+`,
+			want: "fleet.ssh_peers[0]",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeConfig(t, tc.content)
+			_, err := Load(path)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.want)
+			require.Contains(t, err.Error(), "reserved")
+		})
+	}
+}
+
 func TestFleetRejectsSchemelessBaseURL(t *testing.T) {
 	path := writeConfig(t, "[[fleet.peers]]\nkey = \"p\"\nbase_url = \"localhost:8091\"\n")
 	_, err := Load(path)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3568,6 +3568,89 @@ base_url = "http://mbp:8091"
 	require.True(cfg.Fleet.Sessions.IncludeUnmanagedDetails)
 }
 
+func TestFleetConfigNormalizesHostKeys(t *testing.T) {
+	assert := Assert.New(t)
+	path := writeConfig(t, `
+[fleet]
+key = " studio "
+[[fleet.peers]]
+key = " mbp "
+name = "MacBook"
+base_url = "http://mbp:8091"
+[[fleet.ssh_peers]]
+key = " epyc "
+destination = "dev@epyc.tail"
+`)
+	cfg, err := Load(path)
+	require.NoError(t, err)
+
+	assert.Equal("studio", cfg.Fleet.Key)
+	require.Len(t, cfg.Fleet.Peers, 1)
+	assert.Equal("mbp", cfg.Fleet.Peers[0].Key)
+	require.Len(t, cfg.Fleet.SSHPeers, 1)
+	assert.Equal("epyc", cfg.Fleet.SSHPeers[0].Key)
+}
+
+func TestFleetRejectsTrimmedEmptyAndDuplicatePeerKeys(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name: "empty http peer",
+			content: `
+[[fleet.peers]]
+key = "   "
+base_url = "http://empty:8091"
+`,
+			want: "key is required",
+		},
+		{
+			name: "duplicate http peers",
+			content: `
+[[fleet.peers]]
+key = "mini"
+base_url = "http://mini:8091"
+[[fleet.peers]]
+key = " mini "
+base_url = "http://mini2:8091"
+`,
+			want: "duplicate key",
+		},
+		{
+			name: "http peer collides with local key",
+			content: `
+[fleet]
+key = " hub "
+[[fleet.peers]]
+key = "hub"
+base_url = "http://hub:8091"
+`,
+			want: "collides with fleet.key",
+		},
+		{
+			name: "ssh peer collides with trimmed http peer",
+			content: `
+[[fleet.peers]]
+key = " mini "
+base_url = "http://mini:8091"
+[[fleet.ssh_peers]]
+key = "mini"
+destination = "dev@mini"
+`,
+			want: "collides with fleet.peers",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Load(writeConfig(t, tc.content))
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.want)
+		})
+	}
+}
+
 func TestFleetConfigDefaultsToDisabledFederation(t *testing.T) {
 	require := require.New(t)
 	path := writeConfig(t, `

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -2925,21 +2925,7 @@ func TestSyncStatusUpdated(t *testing.T) {
 	assert.Empty(status.LastError)
 }
 
-func setTestLocalEDT(t *testing.T) {
-	t.Helper()
-	//nolint:forbidigo // Tests intentionally override the process local zone to verify UTC normalization.
-	oldLocal := time.Local
-	//nolint:forbidigo // Tests intentionally override the process local zone to verify UTC normalization.
-	time.Local = time.FixedZone("EDT", -4*60*60)
-	t.Cleanup(func() {
-		//nolint:forbidigo // Tests intentionally restore the overridden process local zone.
-		time.Local = oldLocal
-	})
-}
-
 func TestSyncStatusUpdatedUsesUTC(t *testing.T) {
-	setTestLocalEDT(t)
-
 	d := openTestDB(t)
 	mc := &mockClient{
 		openPRs:  []*gh.PullRequest{},
@@ -7365,7 +7351,6 @@ func TestRunBackfillDiscoveryUsesProviderQualifiedRepo(t *testing.T) {
 
 func TestBackfillRepoStoresCompletionTimestampsInUTC(t *testing.T) {
 	require := require.New(t)
-	setTestLocalEDT(t)
 
 	ctx := t.Context()
 	d := openTestDB(t)

--- a/internal/server/config_reload_test.go
+++ b/internal/server/config_reload_test.go
@@ -1613,6 +1613,28 @@ func TestRestartRequiredForAuthFleetSessionsAndSSHPeers(t *testing.T) {
 	require.False(snap.restartRequiredFor(base()),
 		"identical config must not demand a restart")
 
+	enabledFlipped := base()
+	enabledFlipped.Fleet.Enabled = true
+	require.False(snap.restartRequiredFor(enabledFlipped),
+		"fleet.enabled changes apply without restart")
+
+	keyChanged := base()
+	keyChanged.Fleet.Key = "studio"
+	require.False(snap.restartRequiredFor(keyChanged),
+		"fleet.key changes apply without restart")
+
+	timeoutChanged := base()
+	timeoutChanged.Fleet.PeerTimeout = "4s"
+	require.False(snap.restartRequiredFor(timeoutChanged),
+		"fleet.peer_timeout changes apply without restart")
+
+	httpPeerAdded := base()
+	httpPeerAdded.Fleet.Peers = []config.FleetPeer{
+		{Key: "mini", BaseURL: "http://mini.local:8091"},
+	}
+	require.False(snap.restartRequiredFor(httpPeerAdded),
+		"HTTP fleet peer changes apply without restart")
+
 	authFlipped := base()
 	authFlipped.API.RequireAuth = true
 	require.True(snap.restartRequiredFor(authFlipped))

--- a/internal/server/e2etest/fleet_snapshot_test.go
+++ b/internal/server/e2etest/fleet_snapshot_test.go
@@ -274,6 +274,79 @@ func TestFleetSnapshotFanOutE2E(t *testing.T) {
 	require.True(sawPeer, "peer worktree merged with distinct host id")
 }
 
+func TestFleetDisabledBlocksRemoteSnapshotAndProxyE2E(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := context.Background()
+
+	var peerCalls int
+	var peerCallsMu sync.Mutex
+	peerTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		peerCallsMu.Lock()
+		peerCalls++
+		peerCallsMu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(
+			`{"schemaVersion":2,"host":{"configKey":"peer","hostname":"peer","platform":"linux"}}`,
+		))
+	}))
+	t.Cleanup(peerTS.Close)
+
+	hubCfg := &config.Config{
+		BasePath: "/",
+		Fleet: config.Fleet{
+			Enabled: false,
+			Key:     "hub",
+			Peers: []config.FleetPeer{
+				{Key: "peer", Name: "peer", BaseURL: peerTS.URL},
+			},
+			SSHPeers: []config.FleetSSHPeer{
+				{Key: "ssh-peer", Name: "ssh peer", Destination: "dev@ssh.local"},
+			},
+		},
+	}
+	hubTS, hubDB := bootFleetServer(t, hubCfg)
+	_, err := hubDB.CreateProject(ctx, dbpkg.CreateProjectInput{
+		DisplayName: "hubapp", LocalPath: t.TempDir() + "/hubapp", DefaultBranch: "main",
+	})
+	require.NoError(err)
+
+	var snap fleet.Snapshot
+	getJSON(t, hubTS, "/api/v1/snapshot?include_peers=true", &snap)
+	require.NotNil(findHost(snap.Hosts, "hub"), "self host remains visible")
+	assert.Nil(findHost(snap.Hosts, "peer"), "disabled federation hides configured peer")
+	assert.Nil(findHost(snap.Hosts, "ssh-peer"), "disabled federation hides configured ssh peer")
+	peerCallsMu.Lock()
+	assert.Equal(0, peerCalls, "disabled federation must not fan out to peers")
+	peerCallsMu.Unlock()
+
+	status, body := getRaw(
+		t, hubTS.Client(),
+		hubTS.URL+"/api/v1/fleet/hosts/peer/workspaces",
+	)
+	assert.Equal(http.StatusNotFound, status)
+	assert.Contains(body, `"code":"notFound"`)
+	assert.Contains(body, `"hostKey":"peer"`)
+	peerCallsMu.Lock()
+	assert.Equal(0, peerCalls, "disabled remote proxy must not call peers")
+	peerCallsMu.Unlock()
+
+	status, body = getRaw(
+		t, hubTS.Client(),
+		hubTS.URL+"/api/v1/fleet/hosts/ssh-peer/workspaces",
+	)
+	assert.Equal(http.StatusNotFound, status)
+	assert.Contains(body, `"code":"notFound"`)
+	assert.Contains(body, `"hostKey":"ssh-peer"`)
+
+	status, body = getRaw(
+		t, hubTS.Client(),
+		hubTS.URL+"/api/v1/fleet/hosts/hub/workspaces",
+	)
+	assert.Equal(http.StatusOK, status)
+	assert.NotContains(body, "fleet host not found")
+}
+
 func TestFleetSnapshotLiveTmuxEnrichmentE2E(t *testing.T) {
 	require := require.New(t)
 	fakeTmux := writeFleetSnapshotFakeTmux(t)

--- a/internal/server/e2etest/fleet_snapshot_test.go
+++ b/internal/server/e2etest/fleet_snapshot_test.go
@@ -294,9 +294,11 @@ func TestFleetDisabledBlocksRemoteSnapshotAndProxyE2E(t *testing.T) {
 
 	hubCfg := &config.Config{
 		BasePath: "/",
+		DataDir:  t.TempDir(),
 		Fleet: config.Fleet{
-			Enabled: false,
-			Key:     "hub",
+			Enabled:     false,
+			Key:         "hub",
+			PeerTimeout: "10ms",
 			Peers: []config.FleetPeer{
 				{Key: "peer", Name: "peer", BaseURL: peerTS.URL},
 			},

--- a/internal/server/e2etest/fleet_snapshot_test.go
+++ b/internal/server/e2etest/fleet_snapshot_test.go
@@ -46,6 +46,7 @@ func bootFleetServer(t *testing.T, cfg *config.Config) (*httptest.Server, *dbpkg
 			AllowLoopbackAnyPort: true,
 		},
 	})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
 	ts := httptest.NewServer(srv)
 	t.Cleanup(ts.Close)
 	return ts, database

--- a/internal/server/e2etest/fleet_snapshot_test.go
+++ b/internal/server/e2etest/fleet_snapshot_test.go
@@ -229,6 +229,7 @@ func TestFleetSnapshotFanOutE2E(t *testing.T) {
 	hubCfg := &config.Config{
 		BasePath: "/",
 		Fleet: config.Fleet{
+			Enabled:     true,
 			Key:         "hub",
 			PeerTimeout: "1s",
 			Peers: []config.FleetPeer{
@@ -709,7 +710,8 @@ func TestFleetOperationProxyRoutesMutationsToPeerE2E(t *testing.T) {
 	hubCfg := &config.Config{
 		BasePath: "/",
 		Fleet: config.Fleet{
-			Key: "hub",
+			Enabled: true,
+			Key:     "hub",
 			// PeerTimeout is the read fan-out budget. Drive mutations
 			// deliberately forward the caller's request context instead
 			// of reusing this short read timeout.
@@ -823,7 +825,8 @@ func TestFleetOperationProxyUnknownHostE2E(t *testing.T) {
 	hubCfg := &config.Config{
 		BasePath: "/",
 		Fleet: config.Fleet{
-			Key: "hub",
+			Enabled: true,
+			Key:     "hub",
 		},
 	}
 	hubTS, _ := bootFleetServer(t, hubCfg)
@@ -843,7 +846,8 @@ func TestFleetOperationProxyPeerDispatchFailureE2E(t *testing.T) {
 	hubCfg := &config.Config{
 		BasePath: "/",
 		Fleet: config.Fleet{
-			Key: "hub",
+			Enabled: true,
+			Key:     "hub",
 			Peers: []config.FleetPeer{
 				{Key: "peer", Name: "peer", BaseURL: peerURL},
 			},
@@ -871,7 +875,8 @@ func TestFleetOperationProxyRoutesSelfNestedOwnerE2E(t *testing.T) {
 	hubCfg := &config.Config{
 		BasePath: "/",
 		Fleet: config.Fleet{
-			Key: "hub",
+			Enabled: true,
+			Key:     "hub",
 		},
 	}
 	hubTS, database := bootFleetServer(t, hubCfg)
@@ -964,7 +969,8 @@ func TestFleetTerminalWebSocketProxyE2E(t *testing.T) {
 	hubCfg := &config.Config{
 		BasePath: "/",
 		Fleet: config.Fleet{
-			Key: "hub",
+			Enabled: true,
+			Key:     "hub",
 			Peers: []config.FleetPeer{
 				{Key: "peer", Name: "peer", BaseURL: peerTS.URL},
 			},
@@ -1003,7 +1009,8 @@ func TestFleetTerminalWebSocketProxyPeerDialFailureE2E(t *testing.T) {
 	hubCfg := &config.Config{
 		BasePath: "/",
 		Fleet: config.Fleet{
-			Key: "hub",
+			Enabled: true,
+			Key:     "hub",
 			Peers: []config.FleetPeer{
 				{Key: "peer", Name: "peer", BaseURL: peerTS.URL},
 			},
@@ -1271,6 +1278,7 @@ func TestFleetSnapshotPeerRichFieldsE2E(t *testing.T) {
 	hubCfg := &config.Config{
 		BasePath: "/",
 		Fleet: config.Fleet{
+			Enabled:     true,
 			Key:         "hub",
 			PeerTimeout: "5s",
 			Peers: []config.FleetPeer{

--- a/internal/server/e2etest/settings_test.go
+++ b/internal/server/e2etest/settings_test.go
@@ -333,6 +333,45 @@ platform = "linux"
 	assert.Equal("epyc", settings.Fleet.SSHPeers[0].Key)
 	assert.False(settings.Fleet.RestartRequired)
 
+	fleetGetResp := doServerJSON(
+		t, ts.Client(), http.MethodGet,
+		ts.URL+"/api/v1/settings/fleet", nil,
+	)
+	defer fleetGetResp.Body.Close()
+	require.Equal(http.StatusOK, fleetGetResp.StatusCode)
+
+	var fleetSettings struct {
+		Enabled     bool   `json:"enabled"`
+		Key         string `json:"key"`
+		PeerTimeout string `json:"peer_timeout"`
+		Peers       []struct {
+			Key     string `json:"key"`
+			Name    string `json:"name"`
+			BaseURL string `json:"base_url"`
+		} `json:"peers"`
+		SSHPeers []struct {
+			Key         string `json:"key"`
+			Name        string `json:"name"`
+			Destination string `json:"destination"`
+			Platform    string `json:"platform"`
+		} `json:"ssh_peers"`
+		RestartRequired bool `json:"restart_required"`
+	}
+	require.NoError(json.NewDecoder(fleetGetResp.Body).Decode(&fleetSettings))
+	assert.False(fleetSettings.Enabled)
+	assert.Equal("studio", fleetSettings.Key)
+	assert.Equal("3s", fleetSettings.PeerTimeout)
+	require.Len(fleetSettings.Peers, 1)
+	assert.Equal("mini", fleetSettings.Peers[0].Key)
+	assert.Equal("Mac mini", fleetSettings.Peers[0].Name)
+	assert.Equal("http://mini.tail:8091", fleetSettings.Peers[0].BaseURL)
+	require.Len(fleetSettings.SSHPeers, 1)
+	assert.Equal("epyc", fleetSettings.SSHPeers[0].Key)
+	assert.Equal("EPYC", fleetSettings.SSHPeers[0].Name)
+	assert.Equal("wes@epyc.tail", fleetSettings.SSHPeers[0].Destination)
+	assert.Equal("linux", fleetSettings.SSHPeers[0].Platform)
+	assert.False(fleetSettings.RestartRequired)
+
 	updateResp := doServerJSON(
 		t, ts.Client(), http.MethodPut,
 		ts.URL+"/api/v1/settings/fleet",

--- a/internal/server/e2etest/settings_test.go
+++ b/internal/server/e2etest/settings_test.go
@@ -337,7 +337,7 @@ platform = "linux"
 		t, ts.Client(), http.MethodPut,
 		ts.URL+"/api/v1/settings/fleet",
 		map[string]any{
-			"enabled":      false,
+			"enabled":      true,
 			"key":          "hub",
 			"peer_timeout": "4s",
 			"sessions": map[string]any{
@@ -368,12 +368,14 @@ platform = "linux"
 	require.Equal(http.StatusOK, updateResp.StatusCode)
 
 	var updatedSettings struct {
+		Enabled  bool `json:"enabled"`
 		SSHPeers []struct {
 			Key      string `json:"key"`
 			Platform string `json:"platform"`
 		} `json:"ssh_peers"`
 	}
 	require.NoError(json.NewDecoder(updateResp.Body).Decode(&updatedSettings))
+	assert.True(updatedSettings.Enabled)
 	require.Len(updatedSettings.SSHPeers, 2)
 	assert.Equal("studio-mac", updatedSettings.SSHPeers[0].Key)
 	assert.Equal("macos", updatedSettings.SSHPeers[0].Platform)
@@ -382,7 +384,7 @@ platform = "linux"
 
 	cfgAfterUpdate, err := config.Load(cfgPath)
 	require.NoError(err)
-	assert.False(cfgAfterUpdate.Fleet.Enabled)
+	assert.True(cfgAfterUpdate.Fleet.Enabled)
 	assert.Equal("hub", cfgAfterUpdate.Fleet.Key)
 	assert.Equal("4s", cfgAfterUpdate.Fleet.PeerTimeout)
 	require.Len(cfgAfterUpdate.Fleet.Peers, 1)

--- a/internal/server/e2etest/settings_test.go
+++ b/internal/server/e2etest/settings_test.go
@@ -377,25 +377,25 @@ platform = "linux"
 		ts.URL+"/api/v1/settings/fleet",
 		map[string]any{
 			"enabled":      true,
-			"key":          "hub",
+			"key":          " hub ",
 			"peer_timeout": "4s",
 			"sessions": map[string]any{
 				"include_unmanaged_details": false,
 			},
 			"peers": []map[string]any{{
-				"key":      "mini",
+				"key":      " mini ",
 				"name":     "Mac mini",
 				"base_url": "http://mini.tail:8091",
 			}},
 			"ssh_peers": []map[string]any{
 				{
-					"key":         "studio-mac",
+					"key":         " studio-mac ",
 					"name":        "Studio Mac",
 					"destination": "dev@studio.local",
 					"platform":    "macos",
 				},
 				{
-					"key":         "freebsd-box",
+					"key":         " freebsd-box ",
 					"name":        "FreeBSD box",
 					"destination": "dev@freebsd.local",
 					"platform":    "freebsd",

--- a/internal/server/e2etest/settings_test.go
+++ b/internal/server/e2etest/settings_test.go
@@ -270,6 +270,126 @@ command = ["systemd-run", "--user", "--scope", "--pty", "bash"]
 	assert.Equal("30d", cfgAfterUpdate.Activity.TimeRange)
 }
 
+func TestSettingsAPIE2EFleetReadUpdateAndValidation(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	srv, _, cfgPath := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[fleet]
+key = "studio"
+peer_timeout = "3s"
+
+[[fleet.peers]]
+key = "mini"
+name = "Mac mini"
+base_url = "http://mini.tail:8091"
+
+[[fleet.ssh_peers]]
+key = "epyc"
+name = "EPYC"
+destination = "wes@epyc.tail"
+platform = "linux"
+`, &mockGH{})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	getResp := doServerJSON(
+		t, ts.Client(), http.MethodGet,
+		ts.URL+"/api/v1/settings", nil,
+	)
+	defer getResp.Body.Close()
+	require.Equal(http.StatusOK, getResp.StatusCode)
+
+	var settings struct {
+		Fleet struct {
+			Enabled     bool   `json:"enabled"`
+			Key         string `json:"key"`
+			PeerTimeout string `json:"peer_timeout"`
+			Peers       []struct {
+				Key     string `json:"key"`
+				Name    string `json:"name"`
+				BaseURL string `json:"base_url"`
+			} `json:"peers"`
+			SSHPeers []struct {
+				Key         string `json:"key"`
+				Name        string `json:"name"`
+				Destination string `json:"destination"`
+				Platform    string `json:"platform"`
+			} `json:"ssh_peers"`
+			RestartRequired bool `json:"restart_required"`
+		} `json:"fleet"`
+	}
+	require.NoError(json.NewDecoder(getResp.Body).Decode(&settings))
+	assert.False(settings.Fleet.Enabled)
+	assert.Equal("studio", settings.Fleet.Key)
+	assert.Equal("3s", settings.Fleet.PeerTimeout)
+	require.Len(settings.Fleet.Peers, 1)
+	assert.Equal("mini", settings.Fleet.Peers[0].Key)
+	require.Len(settings.Fleet.SSHPeers, 1)
+	assert.Equal("epyc", settings.Fleet.SSHPeers[0].Key)
+	assert.False(settings.Fleet.RestartRequired)
+
+	updateResp := doServerJSON(
+		t, ts.Client(), http.MethodPut,
+		ts.URL+"/api/v1/settings/fleet",
+		map[string]any{
+			"enabled":      false,
+			"key":          "hub",
+			"peer_timeout": "4s",
+			"sessions": map[string]any{
+				"include_unmanaged_details": false,
+			},
+			"peers": []map[string]any{{
+				"key":      "mini",
+				"name":     "Mac mini",
+				"base_url": "http://mini.tail:8091",
+			}},
+			"ssh_peers": []map[string]any{{
+				"key":         "epyc",
+				"name":        "EPYC",
+				"destination": "wes@epyc.tail",
+				"platform":    "linux",
+			}},
+		},
+	)
+	defer updateResp.Body.Close()
+	require.Equal(http.StatusOK, updateResp.StatusCode)
+
+	cfgAfterUpdate, err := config.Load(cfgPath)
+	require.NoError(err)
+	assert.False(cfgAfterUpdate.Fleet.Enabled)
+	assert.Equal("hub", cfgAfterUpdate.Fleet.Key)
+	assert.Equal("4s", cfgAfterUpdate.Fleet.PeerTimeout)
+	require.Len(cfgAfterUpdate.Fleet.Peers, 1)
+	assert.Equal("mini", cfgAfterUpdate.Fleet.Peers[0].Key)
+	require.Len(cfgAfterUpdate.Fleet.SSHPeers, 1)
+	assert.Equal("epyc", cfgAfterUpdate.Fleet.SSHPeers[0].Key)
+
+	invalidResp := doServerJSON(
+		t, ts.Client(), http.MethodPut,
+		ts.URL+"/api/v1/settings/fleet",
+		map[string]any{
+			"enabled":      true,
+			"key":          "mini",
+			"peer_timeout": "2s",
+			"sessions": map[string]any{
+				"include_unmanaged_details": false,
+			},
+			"peers": []map[string]any{{
+				"key":      "mini",
+				"base_url": "mini.tail:8091",
+			}},
+			"ssh_peers": []map[string]any{},
+		},
+	)
+	defer invalidResp.Body.Close()
+	require.Equal(http.StatusBadRequest, invalidResp.StatusCode)
+}
+
 func TestRepoConfigAPIE2EAddDeleteAndErrors(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)

--- a/internal/server/e2etest/settings_test.go
+++ b/internal/server/e2etest/settings_test.go
@@ -348,16 +348,37 @@ platform = "linux"
 				"name":     "Mac mini",
 				"base_url": "http://mini.tail:8091",
 			}},
-			"ssh_peers": []map[string]any{{
-				"key":         "epyc",
-				"name":        "EPYC",
-				"destination": "wes@epyc.tail",
-				"platform":    "linux",
-			}},
+			"ssh_peers": []map[string]any{
+				{
+					"key":         "studio-mac",
+					"name":        "Studio Mac",
+					"destination": "dev@studio.local",
+					"platform":    "macos",
+				},
+				{
+					"key":         "freebsd-box",
+					"name":        "FreeBSD box",
+					"destination": "dev@freebsd.local",
+					"platform":    "freebsd",
+				},
+			},
 		},
 	)
 	defer updateResp.Body.Close()
 	require.Equal(http.StatusOK, updateResp.StatusCode)
+
+	var updatedSettings struct {
+		SSHPeers []struct {
+			Key      string `json:"key"`
+			Platform string `json:"platform"`
+		} `json:"ssh_peers"`
+	}
+	require.NoError(json.NewDecoder(updateResp.Body).Decode(&updatedSettings))
+	require.Len(updatedSettings.SSHPeers, 2)
+	assert.Equal("studio-mac", updatedSettings.SSHPeers[0].Key)
+	assert.Equal("macos", updatedSettings.SSHPeers[0].Platform)
+	assert.Equal("freebsd-box", updatedSettings.SSHPeers[1].Key)
+	assert.Equal("freebsd", updatedSettings.SSHPeers[1].Platform)
 
 	cfgAfterUpdate, err := config.Load(cfgPath)
 	require.NoError(err)
@@ -366,8 +387,11 @@ platform = "linux"
 	assert.Equal("4s", cfgAfterUpdate.Fleet.PeerTimeout)
 	require.Len(cfgAfterUpdate.Fleet.Peers, 1)
 	assert.Equal("mini", cfgAfterUpdate.Fleet.Peers[0].Key)
-	require.Len(cfgAfterUpdate.Fleet.SSHPeers, 1)
-	assert.Equal("epyc", cfgAfterUpdate.Fleet.SSHPeers[0].Key)
+	require.Len(cfgAfterUpdate.Fleet.SSHPeers, 2)
+	assert.Equal("studio-mac", cfgAfterUpdate.Fleet.SSHPeers[0].Key)
+	assert.Equal("macos", cfgAfterUpdate.Fleet.SSHPeers[0].Platform)
+	assert.Equal("freebsd-box", cfgAfterUpdate.Fleet.SSHPeers[1].Key)
+	assert.Equal("freebsd", cfgAfterUpdate.Fleet.SSHPeers[1].Platform)
 
 	invalidResp := doServerJSON(
 		t, ts.Client(), http.MethodPut,

--- a/internal/server/fleet_host_runtime_proxy_test.go
+++ b/internal/server/fleet_host_runtime_proxy_test.go
@@ -42,7 +42,8 @@ func TestFleetHostRuntimeSessionProxiesToPeer(t *testing.T) {
 
 	s := &Server{cfg: &config.Config{
 		Fleet: config.Fleet{
-			Key: "hub",
+			Enabled: true,
+			Key:     "hub",
 			Peers: []config.FleetPeer{
 				{Key: "member", BaseURL: peer.URL},
 			},
@@ -141,7 +142,8 @@ func TestFleetFilesystemProxiesToPeer(t *testing.T) {
 
 	s := &Server{cfg: &config.Config{
 		Fleet: config.Fleet{
-			Key: "hub",
+			Enabled: true,
+			Key:     "hub",
 			Peers: []config.FleetPeer{
 				{Key: "member", BaseURL: peer.URL},
 			},

--- a/internal/server/fleet_hub.go
+++ b/internal/server/fleet_hub.go
@@ -31,10 +31,10 @@ func (s *Server) buildFleetSnapshot(ctx context.Context, includePeers bool) (fle
 	selfKey := s.fleetSelfKey(local.Host.Hostname)
 
 	var results []fleet.PeerResult
-	if includePeers && len(fleetCfg.Peers) > 0 {
+	if includePeers && fleetCfg.Enabled && len(fleetCfg.Peers) > 0 {
 		results = append(results, s.fetchPeerResults(ctx, fleetCfg)...)
 	}
-	if includePeers {
+	if includePeers && fleetCfg.Enabled {
 		results = append(results, s.fetchSSHPeerResults(ctx)...)
 	}
 

--- a/internal/server/fleet_hub_test.go
+++ b/internal/server/fleet_hub_test.go
@@ -27,7 +27,8 @@ func TestBuildFleetSnapshotMergesPeerAndDegrades(t *testing.T) {
 
 	srv := &Server{db: dbtest.Open(t), cfg: &config.Config{}}
 	srv.cfg.Fleet = config.Fleet{
-		Key: "studio",
+		Enabled: true,
+		Key:     "studio",
 		Peers: []config.FleetPeer{
 			{Key: "mbp", Name: "mbp", BaseURL: peer.URL},
 			{Key: "epyc", Name: "epyc", BaseURL: "http://127.0.0.1:0"}, // unreachable
@@ -46,6 +47,29 @@ func TestBuildFleetSnapshotMergesPeerAndDegrades(t *testing.T) {
 	}
 	assert.GreaterOrEqual(t, reachable, 2, "want self+mbp reachable, hosts=%+v", snap.Hosts)
 	assert.Equal(t, 1, down, "want 1 unreachable (epyc)")
+}
+
+func TestBuildFleetSnapshotSkipsPeersWhenFederationDisabled(t *testing.T) {
+	peerRequests := 0
+	peer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		peerRequests++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"schemaVersion":2,"host":{"hostname":"mbp","platform":"macos"}}`))
+	}))
+	defer peer.Close()
+
+	srv := &Server{db: dbtest.Open(t), cfg: &config.Config{}}
+	srv.cfg.Fleet = config.Fleet{
+		Key: "studio",
+		Peers: []config.FleetPeer{
+			{Key: "mbp", Name: "mbp", BaseURL: peer.URL},
+		},
+	}
+
+	snap, err := srv.buildFleetSnapshot(context.Background(), true)
+	require.NoError(t, err)
+	require.Len(t, snap.Hosts, 1, "disabled federation must return local host only")
+	assert.Equal(t, 0, peerRequests, "disabled federation must not fetch HTTP peers")
 }
 
 func TestBuildFleetSnapshotLocalOnly(t *testing.T) {
@@ -83,7 +107,8 @@ func TestHubRoutabilityPolicySuppressesUnroutableHosts(t *testing.T) {
 
 	srv := &Server{db: dbtest.Open(t), cfg: &config.Config{}}
 	srv.cfg.Fleet = config.Fleet{
-		Key: "studio",
+		Enabled: true,
+		Key:     "studio",
 		Peers: []config.FleetPeer{
 			{Key: "mbp", BaseURL: "http://peer.invalid"},
 		},

--- a/internal/server/fleet_proxy.go
+++ b/internal/server/fleet_proxy.go
@@ -1103,8 +1103,8 @@ func proxyWebSocketMessages(
 // addresses the local host: a daemon with no fleet.key (anonymous,
 // hostname-derived self key) cannot put an empty key in a
 // /fleet/hosts/{host_key}/... path, so clients route local operations
-// through this alias instead. A configured peer key takes precedence
-// over the alias.
+// through this alias instead. Config validation reserves this key so
+// configured peers cannot shadow local self routing.
 const fleetSelfHostAlias = "self"
 
 func (s *Server) resolveFleetHostTarget(hostKey string) (fleetHostTarget, bool) {

--- a/internal/server/fleet_proxy.go
+++ b/internal/server/fleet_proxy.go
@@ -1115,14 +1115,15 @@ func (s *Server) resolveFleetHostTarget(hostKey string) (fleetHostTarget, bool) 
 	if hostKey == s.fleetSelfKey("") {
 		return fleetHostTarget{self: true}, true
 	}
-	if s.cfg != nil {
+	federationEnabled := s.cfg != nil && s.cfg.Fleet.Enabled
+	if federationEnabled {
 		for _, peer := range s.cfg.Fleet.Peers {
 			if peer.Key == hostKey {
 				return fleetHostTarget{peer: peer}, true
 			}
 		}
 	}
-	if s.sshFleet != nil {
+	if federationEnabled && s.sshFleet != nil {
 		if peer, ok := s.sshFleet.peer(hostKey); ok {
 			return fleetHostTarget{sshPeer: &peer}, true
 		}

--- a/internal/server/fleet_proxy_test.go
+++ b/internal/server/fleet_proxy_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/middleman/internal/config"
 )
 
 // TestCopyProxyRequestHeadersStripsBrowserHeaders verifies the hub does not
@@ -107,4 +110,44 @@ func TestIsPeerProxyCredentialHeader(t *testing.T) {
 	} {
 		assert.Equal(t, tc.want, isPeerProxyCredentialHeader(tc.key), "header %q", tc.key)
 	}
+}
+
+func TestResolveFleetHostTargetSkipsRemotePeersWhenFederationDisabled(t *testing.T) {
+	assert := assert.New(t)
+	srv := &Server{
+		cfg: &config.Config{
+			Fleet: config.Fleet{
+				Key: "hub",
+				Peers: []config.FleetPeer{
+					{Key: "member", BaseURL: "http://member.test"},
+				},
+			},
+		},
+	}
+
+	_, ok := srv.resolveFleetHostTarget("member")
+	assert.False(ok, "disabled federation must not resolve remote HTTP peers")
+
+	self, ok := srv.resolveFleetHostTarget(fleetSelfHostAlias)
+	require.True(t, ok, "disabled federation must preserve self routing")
+	assert.True(self.self)
+}
+
+func TestResolveFleetHostTargetUsesRemotePeersWhenFederationEnabled(t *testing.T) {
+	assert := assert.New(t)
+	srv := &Server{
+		cfg: &config.Config{
+			Fleet: config.Fleet{
+				Enabled: true,
+				Key:     "hub",
+				Peers: []config.FleetPeer{
+					{Key: "member", BaseURL: "http://member.test"},
+				},
+			},
+		},
+	}
+
+	target, ok := srv.resolveFleetHostTarget("member")
+	require.True(t, ok)
+	assert.Equal("member", target.peer.Key)
 }

--- a/internal/server/fleet_ssh_test.go
+++ b/internal/server/fleet_ssh_test.go
@@ -116,6 +116,7 @@ func TestFleetSnapshotIncludesSSHPeers(t *testing.T) {
 
 	srv, _ := setupTestServer(t)
 	setTestFleetConfig(srv, func(cfg *config.Config) {
+		cfg.Fleet.Enabled = true
 		cfg.Fleet.Key = "studio"
 	})
 	srv.sshFleet = newSSHTestTransport(t, fake, config.FleetSSHPeer{
@@ -182,6 +183,9 @@ func TestSSHFleetProxyRelaysWrites(t *testing.T) {
 		),
 	}}
 	srv, _ := setupTestServer(t)
+	setTestFleetConfig(srv, func(cfg *config.Config) {
+		cfg.Fleet.Enabled = true
+	})
 	srv.sshFleet = newSSHTestTransport(t, fake, config.FleetSSHPeer{
 		Key: "epyc", Destination: "wes@epyc.local",
 	})
@@ -226,6 +230,9 @@ func TestSSHFleetProxyRelaysWorkspaceDiffReads(t *testing.T) {
 		),
 	}}
 	srv, _ := setupTestServer(t)
+	setTestFleetConfig(srv, func(cfg *config.Config) {
+		cfg.Fleet.Enabled = true
+	})
 	srv.sshFleet = newSSHTestTransport(t, fake, config.FleetSSHPeer{
 		Key: "epyc", Destination: "wes@epyc.local",
 	})
@@ -269,6 +276,9 @@ func TestSSHFleetAttachSpecWrapped(t *testing.T) {
 		"GET /api/v1/runtime/sessions/s1/attach-spec": framedJSON(200, remoteSpec),
 	}}
 	srv, _ := setupTestServer(t)
+	setTestFleetConfig(srv, func(cfg *config.Config) {
+		cfg.Fleet.Enabled = true
+	})
 	srv.sshFleet = newSSHTestTransport(t, fake, config.FleetSSHPeer{
 		Key: "epyc", Destination: "wes@epyc.local",
 	})
@@ -333,6 +343,7 @@ func TestSSHFleetSnapshotDegradesColdPeerFast(t *testing.T) {
 	})
 	srv, _ := setupTestServer(t)
 	setTestFleetConfig(srv, func(cfg *config.Config) {
+		cfg.Fleet.Enabled = true
 		cfg.Fleet.Key = "studio"
 		cfg.Fleet.PeerTimeout = "150ms"
 	})
@@ -460,6 +471,7 @@ func TestSSHFleetRelayAutoStartsRemoteDaemon(t *testing.T) {
 	transport.runner = sshfleet.NewRunnerWithExec(transport.conns, exec)
 	srv, _ := setupTestServer(t)
 	setTestFleetConfig(srv, func(cfg *config.Config) {
+		cfg.Fleet.Enabled = true
 		cfg.Fleet.Key = "studio"
 	})
 	srv.sshFleet = transport
@@ -485,6 +497,9 @@ func TestSSHFleetWebSocketTerminalUsesAttachSpecCommand(t *testing.T) {
 	require := require.New(t)
 
 	fixture := setupWorkspaceServerFixture(t, nil)
+	setTestFleetConfig(fixture.server, func(cfg *config.Config) {
+		cfg.Fleet.Enabled = true
+	})
 	writeFakeSSHForAttach(t)
 	remoteSpec := runtimeAttachSpecResponse{
 		Version:           1,
@@ -527,6 +542,9 @@ func TestSSHFleetWebSocketTerminalHonorsResizeActive(t *testing.T) {
 	require := require.New(t)
 
 	fixture := setupWorkspaceServerFixture(t, nil)
+	setTestFleetConfig(fixture.server, func(cfg *config.Config) {
+		cfg.Fleet.Enabled = true
+	})
 	writeFakeSSHForAttach(t)
 	remoteSpec := runtimeAttachSpecResponse{
 		Version:     1,

--- a/internal/server/fleet_worktree_proxy_test.go
+++ b/internal/server/fleet_worktree_proxy_test.go
@@ -41,7 +41,8 @@ func TestFleetWorktreeLifecycleProxiesToPeer(t *testing.T) {
 
 	s := &Server{cfg: &config.Config{
 		Fleet: config.Fleet{
-			Key: "hub",
+			Enabled: true,
+			Key:     "hub",
 			Peers: []config.FleetPeer{
 				{Key: "member", BaseURL: peer.URL},
 			},

--- a/internal/server/settings_handlers.go
+++ b/internal/server/settings_handlers.go
@@ -23,6 +23,7 @@ type settingsResponse struct {
 	Terminal config.Terminal                 `json:"terminal"`
 	Modes    config.ModeVisibility           `json:"modes,omitzero"`
 	Agents   []config.Agent                  `json:"agents" nullable:"false"`
+	Fleet    fleetSettingsResponse           `json:"fleet"`
 }
 
 type updateSettingsRequest struct {
@@ -59,6 +60,7 @@ func (s *Server) buildLocalSettingsResponse() settingsResponse {
 	terminal := s.cfg.Terminal
 	modes := cloneModeVisibility(s.cfg.Modes).WithDefaults()
 	agents := cloneConfigAgents(s.cfg.Agents)
+	fleetSettings := s.buildFleetSettingsResponseLocked()
 	s.cfgMu.Unlock()
 
 	tracked := s.syncer.TrackedRepos()
@@ -83,6 +85,7 @@ func (s *Server) buildLocalSettingsResponse() settingsResponse {
 		Terminal: terminal,
 		Modes:    modes,
 		Agents:   agents,
+		Fleet:    fleetSettings,
 	}
 }
 
@@ -479,6 +482,20 @@ func cloneConfigAgents(agents []config.Agent) []config.Agent {
 		cloned[i].Command = slices.Clone(agent.Command)
 	}
 	return cloned
+}
+
+func cloneFleetPeers(peers []config.FleetPeer) []config.FleetPeer {
+	if peers == nil {
+		return []config.FleetPeer{}
+	}
+	return slices.Clone(peers)
+}
+
+func cloneFleetSSHPeers(peers []config.FleetSSHPeer) []config.FleetSSHPeer {
+	if peers == nil {
+		return []config.FleetSSHPeer{}
+	}
+	return slices.Clone(peers)
 }
 
 func (s *Server) refreshRuntimeTargetsLocked() {

--- a/internal/server/settings_routes.go
+++ b/internal/server/settings_routes.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"net/http"
+	"slices"
 
 	"go.kenn.io/middleman/internal/config"
 
@@ -91,10 +92,105 @@ type fleetSSHPeersBody struct {
 
 type fleetSSHPeersOutput = bodyOutput[fleetSSHPeersBody]
 
+type fleetSettingsResponse struct {
+	Enabled         bool                  `json:"enabled"`
+	Key             string                `json:"key,omitempty"`
+	PeerTimeout     string                `json:"peer_timeout,omitempty"`
+	Sessions        config.FleetSessions  `json:"sessions"`
+	Peers           []config.FleetPeer    `json:"peers" nullable:"false"`
+	SSHPeers        []config.FleetSSHPeer `json:"ssh_peers" nullable:"false"`
+	RestartRequired bool                  `json:"restart_required"`
+}
+
+type getFleetSettingsOutput = bodyOutput[fleetSettingsResponse]
+
+type updateFleetSettingsInput struct {
+	Body struct {
+		Enabled     bool                  `json:"enabled"`
+		Key         string                `json:"key,omitempty"`
+		PeerTimeout string                `json:"peer_timeout,omitempty"`
+		Sessions    config.FleetSessions  `json:"sessions"`
+		Peers       []config.FleetPeer    `json:"peers" nullable:"false"`
+		SSHPeers    []config.FleetSSHPeer `json:"ssh_peers" nullable:"false"`
+	}
+}
+
 type updateFleetSSHPeersInput struct {
 	Body struct {
 		SSHPeers []config.FleetSSHPeer `json:"ssh_peers" nullable:"false"`
 	}
+}
+
+func (s *Server) buildFleetSettingsResponseLocked() fleetSettingsResponse {
+	fleet := s.cfg.Fleet
+	return fleetSettingsResponse{
+		Enabled:         fleet.Enabled,
+		Key:             fleet.Key,
+		PeerTimeout:     fleet.PeerTimeout,
+		Sessions:        fleet.Sessions,
+		Peers:           cloneFleetPeers(fleet.Peers),
+		SSHPeers:        cloneFleetSSHPeers(fleet.SSHPeers),
+		RestartRequired: s.fleetSettingsRestartRequiredLocked(fleet),
+	}
+}
+
+func (s *Server) fleetSettingsRestartRequiredLocked(fleet config.Fleet) bool {
+	return fleet.Sessions != s.bootCfgSnapshot.FleetSessions ||
+		!slices.Equal(fleet.SSHPeers, s.bootCfgSnapshot.SSHPeers)
+}
+
+// getFleetSettings returns the complete fleet federation settings shape.
+func (s *Server) getFleetSettings(
+	_ context.Context, _ *struct{},
+) (*getFleetSettingsOutput, error) {
+	if s.cfgPath == "" {
+		return nil, problemNotFound(
+			CodeSettingsUnavailable, "settings not available", nil,
+		)
+	}
+	s.cfgMu.Lock()
+	out := s.buildFleetSettingsResponseLocked()
+	s.cfgMu.Unlock()
+	return &getFleetSettingsOutput{Body: out}, nil
+}
+
+// updateFleetSettings replaces the complete fleet federation settings shape.
+// Validation happens against the whole config so key collisions across local,
+// HTTP, and SSH membership stay consistent with file loading.
+func (s *Server) updateFleetSettings(
+	_ context.Context, input *updateFleetSettingsInput,
+) (*getFleetSettingsOutput, error) {
+	if s.cfgPath == "" {
+		return nil, problemNotFound(
+			CodeSettingsUnavailable, "settings not available", nil,
+		)
+	}
+
+	next := config.Fleet{
+		Enabled:     input.Body.Enabled,
+		Key:         input.Body.Key,
+		PeerTimeout: input.Body.PeerTimeout,
+		Sessions:    input.Body.Sessions,
+		Peers:       cloneFleetPeers(input.Body.Peers),
+		SSHPeers:    cloneFleetSSHPeers(input.Body.SSHPeers),
+	}
+
+	s.cfgMu.Lock()
+	prev := s.cfg.Fleet
+	s.cfg.Fleet = next
+	if err := s.cfg.Validate(); err != nil {
+		s.cfg.Fleet = prev
+		s.cfgMu.Unlock()
+		return nil, problemBadRequest(CodeBadRequest, err.Error(), nil)
+	}
+	if err := s.cfg.Save(s.cfgPath); err != nil {
+		s.cfg.Fleet = prev
+		s.cfgMu.Unlock()
+		return nil, problemInternal("save config: " + err.Error())
+	}
+	out := s.buildFleetSettingsResponseLocked()
+	s.cfgMu.Unlock()
+	return &getFleetSettingsOutput{Body: out}, nil
 }
 
 // getFleetSSHPeers lists the configured ssh fleet peers.
@@ -173,6 +269,20 @@ func (s *Server) fleetSSHPeersRestartRequired(
 }
 
 func (s *Server) registerSettingsAPI(api huma.API) {
+	huma.Register(api, huma.Operation{
+		OperationID: "get-fleet-settings",
+		Method:      http.MethodGet,
+		Path:        "/settings/fleet",
+		Summary:     "Get fleet settings",
+		Tags:        []string{"Settings"},
+	}, s.getFleetSettings)
+	huma.Register(api, huma.Operation{
+		OperationID: "update-fleet-settings",
+		Method:      http.MethodPut,
+		Path:        "/settings/fleet",
+		Summary:     "Update fleet settings",
+		Tags:        []string{"Settings"},
+	}, s.updateFleetSettings)
 	huma.Register(api, huma.Operation{
 		OperationID: "get-fleet-ssh-peers",
 		Method:      http.MethodGet,

--- a/internal/server/settings_routes.go
+++ b/internal/server/settings_routes.go
@@ -175,18 +175,17 @@ func (s *Server) updateFleetSettings(
 	}
 
 	s.cfgMu.Lock()
-	prev := s.cfg.Fleet
-	s.cfg.Fleet = next
-	if err := s.cfg.Validate(); err != nil {
-		s.cfg.Fleet = prev
+	candidate := cloneReloadedConfig(s.cfg)
+	candidate.Fleet = next
+	if err := candidate.Validate(); err != nil {
 		s.cfgMu.Unlock()
 		return nil, problemBadRequest(CodeBadRequest, err.Error(), nil)
 	}
-	if err := s.cfg.Save(s.cfgPath); err != nil {
-		s.cfg.Fleet = prev
+	if err := candidate.Save(s.cfgPath); err != nil {
 		s.cfgMu.Unlock()
 		return nil, problemInternal("save config: " + err.Error())
 	}
+	s.cfg.Fleet = candidate.Fleet
 	out := s.buildFleetSettingsResponseLocked()
 	s.cfgMu.Unlock()
 	return &getFleetSettingsOutput{Body: out}, nil
@@ -213,8 +212,7 @@ func (s *Server) getFleetSSHPeers(
 }
 
 // updateFleetSSHPeers replaces the configured ssh peer set. The set
-// is validated as a whole and persisted; a failed validation or save
-// rolls the in-memory config back.
+// is validated as a whole and persisted before updating live config.
 func (s *Server) updateFleetSSHPeers(
 	_ context.Context, input *updateFleetSSHPeersInput,
 ) (*fleetSSHPeersOutput, error) {
@@ -227,19 +225,18 @@ func (s *Server) updateFleetSSHPeers(
 		[]config.FleetSSHPeer(nil), input.Body.SSHPeers...,
 	)
 	s.cfgMu.Lock()
-	prev := s.cfg.Fleet.SSHPeers
-	s.cfg.Fleet.SSHPeers = next
-	if err := s.cfg.Validate(); err != nil {
-		s.cfg.Fleet.SSHPeers = prev
+	candidate := cloneReloadedConfig(s.cfg)
+	candidate.Fleet.SSHPeers = next
+	if err := candidate.Validate(); err != nil {
 		s.cfgMu.Unlock()
 		return nil, problemBadRequest(CodeBadRequest, err.Error(), nil)
 	}
-	if err := s.cfg.Save(s.cfgPath); err != nil {
-		s.cfg.Fleet.SSHPeers = prev
+	if err := candidate.Save(s.cfgPath); err != nil {
 		s.cfgMu.Unlock()
 		return nil, problemInternal("save config: " + err.Error())
 	}
-	persisted := append([]config.FleetSSHPeer(nil), s.cfg.Fleet.SSHPeers...)
+	s.cfg.Fleet.SSHPeers = candidate.Fleet.SSHPeers
+	persisted := append([]config.FleetSSHPeer(nil), candidate.Fleet.SSHPeers...)
 	s.cfgMu.Unlock()
 	return &fleetSSHPeersOutput{Body: fleetSSHPeersBody{
 		SSHPeers:        persisted,

--- a/internal/server/settings_routes.go
+++ b/internal/server/settings_routes.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"net/http"
-	"slices"
 
 	"go.kenn.io/middleman/internal/config"
 
@@ -136,7 +135,7 @@ func (s *Server) buildFleetSettingsResponseLocked() fleetSettingsResponse {
 
 func (s *Server) fleetSettingsRestartRequiredLocked(fleet config.Fleet) bool {
 	return fleet.Sessions != s.bootCfgSnapshot.FleetSessions ||
-		!slices.Equal(fleet.SSHPeers, s.bootCfgSnapshot.SSHPeers)
+		s.fleetSSHPeersRestartRequired(fleet.SSHPeers)
 }
 
 // getFleetSettings returns the complete fleet federation settings shape.

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -3174,6 +3174,24 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/settings/fleet": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get fleet settings */
+        get: operations["get-fleet-settings"];
+        /** Update fleet settings */
+        put: operations["update-fleet-settings"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/settings/fleet/ssh-peers": {
         parameters: {
             query?: never;
@@ -4356,6 +4374,11 @@ export interface components {
             message?: string;
             root_path?: string;
         };
+        FleetPeer: {
+            base_url: string;
+            key: string;
+            name?: string;
+        };
         FleetSSHPeer: {
             destination: string;
             key: string;
@@ -4371,6 +4394,24 @@ export interface components {
              */
             readonly $schema?: string;
             restart_required: boolean;
+            ssh_peers: components["schemas"]["FleetSSHPeer"][];
+        };
+        FleetSessions: {
+            include_unmanaged_details?: boolean;
+        };
+        FleetSettingsResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example /api/v1/schemas/FleetSettingsResponse.json
+             */
+            readonly $schema?: string;
+            enabled: boolean;
+            key?: string;
+            peer_timeout?: string;
+            peers: components["schemas"]["FleetPeer"][];
+            restart_required: boolean;
+            sessions: components["schemas"]["FleetSessions"];
             ssh_peers: components["schemas"]["FleetSSHPeer"][];
         };
         GitChangesResponse: {
@@ -6039,6 +6080,7 @@ export interface components {
             readonly $schema?: string;
             activity: components["schemas"]["Activity"];
             agents: components["schemas"]["Agent"][];
+            fleet: components["schemas"]["FleetSettingsResponse"];
             modes?: components["schemas"]["ModeVisibility"];
             repos: components["schemas"]["ConfiguredRepoStatus"][];
             terminal: components["schemas"]["Terminal"];
@@ -6229,6 +6271,20 @@ export interface components {
              * @example /api/v1/schemas/UpdateFleetSSHPeersInputBody.json
              */
             readonly $schema?: string;
+            ssh_peers: components["schemas"]["FleetSSHPeer"][];
+        };
+        UpdateFleetSettingsInputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example /api/v1/schemas/UpdateFleetSettingsInputBody.json
+             */
+            readonly $schema?: string;
+            enabled: boolean;
+            key?: string;
+            peer_timeout?: string;
+            peers: components["schemas"]["FleetPeer"][];
+            sessions: components["schemas"]["FleetSessions"];
             ssh_peers: components["schemas"]["FleetSSHPeer"][];
         };
         UpdateSettingsRequest: {
@@ -13562,6 +13618,68 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SettingsResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
+    "get-fleet-settings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FleetSettingsResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
+    "update-fleet-settings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateFleetSettingsInputBody"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FleetSettingsResponse"];
                 };
             };
             /** @description Error */

--- a/packages/ui/src/api/types.ts
+++ b/packages/ui/src/api/types.ts
@@ -82,6 +82,10 @@ export const DEFAULT_MODE_VISIBILITY: ModeVisibility = {
 export type AgentSettings = components["schemas"]["Agent"];
 export type ConfigRepo = components["schemas"]["ConfiguredRepoStatus"];
 export type Settings = components["schemas"]["SettingsResponse"];
+export type FleetSettings = components["schemas"]["FleetSettingsResponse"];
+export type FleetSettingsUpdate = components["schemas"]["UpdateFleetSettingsInputBody"];
+export type FleetPeer = components["schemas"]["FleetPeer"];
+export type FleetSSHPeer = components["schemas"]["FleetSSHPeer"];
 
 export interface DiffResult {
   stale: boolean;

--- a/packages/ui/src/components/shared/ActionButton.svelte
+++ b/packages/ui/src/components/shared/ActionButton.svelte
@@ -180,6 +180,25 @@
     border-color: #145c27;
   }
 
+  /* Info solid — primary submit / save */
+  .action-button--solid.action-button--info {
+    background: var(--accent-blue);
+    color: #fff;
+    border: 1px solid var(--accent-blue);
+  }
+  .action-button--solid.action-button--info:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--accent-blue) 88%, #000);
+    border-color: color-mix(in srgb, var(--accent-blue) 88%, #000);
+  }
+  .action-button--solid.action-button--info:focus-visible {
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-blue) 42%, transparent);
+  }
+  .action-button--solid.action-button--info:active:not(:disabled),
+  .action-button--solid.action-button--info[aria-expanded="true"] {
+    background: color-mix(in srgb, var(--accent-blue) 78%, #000);
+    border-color: color-mix(in srgb, var(--accent-blue) 78%, #000);
+  }
+
   /* Success soft — approve */
   .action-button--soft.action-button--success {
     background: color-mix(in srgb, var(--accent-green) 12%, transparent);

--- a/packages/ui/src/components/shared/SelectDropdown.svelte
+++ b/packages/ui/src/components/shared/SelectDropdown.svelte
@@ -10,13 +10,7 @@
 <script lang="ts">
   import CheckIcon from "@lucide/svelte/icons/check";
   import ChevronDownIcon from "@lucide/svelte/icons/chevron-down";
-
-  export interface SelectDropdownOption {
-    value: string;
-    label: string;
-    triggerLabel?: string;
-    disabled?: boolean;
-  }
+  import type { SelectDropdownOption } from "./select-dropdown.js";
 
   interface Props {
     value: string;

--- a/packages/ui/src/components/shared/select-dropdown.ts
+++ b/packages/ui/src/components/shared/select-dropdown.ts
@@ -1,0 +1,6 @@
+export interface SelectDropdownOption {
+  value: string;
+  label: string;
+  triggerLabel?: string;
+  disabled?: boolean;
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -115,6 +115,7 @@ export { default as LeftSidebarToggle } from "./components/shared/LeftSidebarTog
 export { default as DiffStats } from "./components/shared/DiffStats.svelte";
 export { default as FilterDropdown } from "./components/shared/FilterDropdown.svelte";
 export { default as SelectDropdown } from "./components/shared/SelectDropdown.svelte";
+export type { SelectDropdownOption } from "./components/shared/select-dropdown.js";
 export { default as SplitResizeHandle } from "./components/shared/SplitResizeHandle.svelte";
 export type { SplitResizeEvent } from "./components/shared/split-resize.js";
 export { default as TabbedPanelTree } from "./components/shared/TabbedPanelTree.svelte";

--- a/scripts/e2e/fleet/hub.toml
+++ b/scripts/e2e/fleet/hub.toml
@@ -12,6 +12,7 @@ time_range = "7d"
 renderer = "xterm"
 
 [fleet]
+enabled = true
 key = "hub"
 peer_timeout = "1s"
 


### PR DESCRIPTION
Fleet federation should not expose remote hosts or proxy routes unless the user has explicitly opted in. This keeps local workspace inventory available by default while making remote federation membership a deliberate settings choice.

Summary:
- Add fleet federation settings for enablement, local key, timeouts, HTTP peers, and SSH peers.
- Hide remote fleet UI/status when only local workspaces are available.
- Gate remote snapshot fan-out and remote proxy routing behind `fleet.enabled`.
- Preserve saved membership while federation is disabled.

Screenshot captured locally from mocked data: `tmp/fleet-settings-pr.png`.