### PR TITLE
Let wildcard repos promote to local clones

### DIFF
--- a/frontend/src/lib/components/settings/RepoPromoteModal.svelte
+++ b/frontend/src/lib/components/settings/RepoPromoteModal.svelte
@@ -52,6 +52,7 @@
   const selectedPath = $derived(
     selectedKey ? (pathDrafts[selectedKey] ?? "") : "",
   );
+  const availableCount = $derived(rows.filter((row) => !row.already_configured).length);
 
   $effect(() => {
     const target = repo;
@@ -215,7 +216,7 @@
       {#if loading}
         <div class="empty-state">Loading matches...</div>
       {:else if filteredRows.length > 0}
-        <div class="match-list" role="listbox" aria-label="Wildcard matches">
+        <div class="match-list" role="radiogroup" aria-label="Wildcard matches">
           {#each filteredRows as row (promoteRowKey(row))}
             {@const key = promoteRowKey(row)}
             <label class={["match-row", selectedKey === key && "match-row--selected", row.already_configured && "match-row--disabled"]}>
@@ -244,7 +245,7 @@
 
       {#if selectedRow}
         <label class="path-field">
-          <span>Local clone path</span>
+          <span>Local clone path for {selectedRow.repo_path}</span>
           <input
             type="text"
             placeholder="/path/to/existing/clone"
@@ -269,7 +270,7 @@
       {/if}
 
       <footer class="modal-footer">
-        <span>{rows.length} matches</span>
+        <span>{availableCount} available of {rows.length} matches</span>
         <div class="footer-actions">
           <button class="secondary-btn" type="button" onclick={closeIfAllowed} disabled={submitting}>Cancel</button>
           <button

--- a/frontend/src/lib/components/settings/RepoPromoteModal.svelte
+++ b/frontend/src/lib/components/settings/RepoPromoteModal.svelte
@@ -204,7 +204,7 @@
           bind:this={searchInput}
           value={filterText}
           placeholder="Filter repositories..."
-          disabled={loading || submitting}
+          disabled={submitting}
           oninput={(event) => { filterText = event.currentTarget.value; }}
         />
       </label>

--- a/frontend/src/lib/components/settings/RepoPromoteModal.svelte
+++ b/frontend/src/lib/components/settings/RepoPromoteModal.svelte
@@ -1,0 +1,447 @@
+<script lang="ts">
+  import { tick, untrack } from "svelte";
+  import type { ConfigRepo, Settings } from "@middleman/ui/api/types";
+  import { pushModalFrame } from "@middleman/ui/stores/keyboard/modal-stack";
+  import {
+    bulkAddRepos,
+    previewRepos,
+    updateRepoWorktreeBasePath,
+    type RepoPreviewRow,
+  } from "../../api/settings.js";
+
+  interface Props {
+    open: boolean;
+    repo: ConfigRepo | null;
+    onClose: () => void;
+    onPromoted: (settings: Settings) => void;
+  }
+
+  let { open, repo, onClose, onPromoted }: Props = $props();
+
+  let rows = $state.raw<RepoPreviewRow[]>([]);
+  let selectedKey = $state<string | null>(null);
+  let pathDrafts = $state<Record<string, string>>({});
+  let addedExactKeys = $state<Record<string, boolean>>({});
+  let filterText = $state("");
+  let loading = $state(false);
+  let submitting = $state(false);
+  let error = $state<string | null>(null);
+  let requestToken = 0;
+  let loadedRepoKey: string | null = null;
+  let searchInput = $state<HTMLInputElement | null>(null);
+
+  const filteredRows = $derived.by(() => {
+    const query = filterText.trim().toLowerCase();
+    if (query === "") return rows;
+    return rows.filter((row) => {
+      const haystack = [
+        row.repo_path,
+        row.owner,
+        row.name,
+        row.description ?? "",
+      ].join(" ").toLowerCase();
+      return haystack.includes(query);
+    });
+  });
+
+  const selectedRow = $derived.by(() => {
+    if (!selectedKey) return null;
+    return rows.find((row) => promoteRowKey(row) === selectedKey) ?? null;
+  });
+
+  const selectedPath = $derived(
+    selectedKey ? (pathDrafts[selectedKey] ?? "") : "",
+  );
+
+  $effect(() => {
+    const target = repo;
+    if (!open || !target) {
+      loadedRepoKey = null;
+      untrack(resetAll);
+      return;
+    }
+    const key = configRepoKey(target);
+    if (loadedRepoKey === key) return;
+    loadedRepoKey = key;
+    void tick().then(() => searchInput?.focus());
+    untrack(() => { void loadMatches(target); });
+  });
+
+  $effect(() => {
+    if (!open) return;
+    return untrack(() => pushModalFrame("repo-promote-modal", []));
+  });
+
+  function promoteRowKey(row: RepoPreviewRow): string {
+    return `${row.provider}/${row.platform_host}/${row.repo_path}`.toLowerCase();
+  }
+
+  function configRepoKey(target: ConfigRepo): string {
+    return `${target.provider}/${target.platform_host}/${target.repo_path || `${target.owner}/${target.name}`}`.toLowerCase();
+  }
+
+  function resetAll(): void {
+    rows = [];
+    selectedKey = null;
+    pathDrafts = {};
+    addedExactKeys = {};
+    filterText = "";
+    loading = false;
+    submitting = false;
+    error = null;
+    requestToken += 1;
+  }
+
+  async function loadMatches(target: ConfigRepo): Promise<void> {
+    const token = ++requestToken;
+    rows = [];
+    selectedKey = null;
+    pathDrafts = {};
+    addedExactKeys = {};
+    loading = true;
+    error = null;
+    try {
+      const resp = await previewRepos(target.owner, target.name, {
+        provider: target.provider,
+        host: target.platform_host,
+      });
+      if (token !== requestToken) return;
+      rows = resp.repos;
+      const firstAvailable = resp.repos.find((row) => !row.already_configured);
+      selectedKey = firstAvailable ? promoteRowKey(firstAvailable) : null;
+    } catch (err) {
+      if (token !== requestToken) return;
+      error = err instanceof Error ? err.message : String(err);
+    } finally {
+      if (token === requestToken) loading = false;
+    }
+  }
+
+  async function handlePromote(): Promise<void> {
+    if (!selectedRow || !selectedKey || selectedRow.already_configured) return;
+    const worktreeBasePath = selectedPath.trim();
+    if (worktreeBasePath === "") return;
+    submitting = true;
+    error = null;
+    try {
+      if (!addedExactKeys[selectedKey]) {
+        await bulkAddRepos([
+          {
+            provider: selectedRow.provider,
+            host: selectedRow.platform_host,
+            owner: selectedRow.owner,
+            name: selectedRow.name,
+            repo_path: selectedRow.repo_path,
+          },
+        ]);
+        addedExactKeys = { ...addedExactKeys, [selectedKey]: true };
+      }
+      const settings = await updateRepoWorktreeBasePath(
+        selectedRow.owner,
+        selectedRow.name,
+        {
+          provider: selectedRow.provider,
+          host: selectedRow.platform_host,
+        },
+        worktreeBasePath,
+      );
+      onPromoted(settings);
+      onClose();
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err);
+    } finally {
+      submitting = false;
+    }
+  }
+
+  function closeIfAllowed(): void {
+    if (!submitting) onClose();
+  }
+
+  function handleKeydown(event: KeyboardEvent): void {
+    if (event.key === "Escape") {
+      closeIfAllowed();
+      return;
+    }
+    if (event.key !== "Tab") return;
+    const container = event.currentTarget;
+    if (!(container instanceof HTMLElement)) return;
+    const modal = container.querySelector("[role='dialog']");
+    if (!(modal instanceof HTMLElement)) return;
+    const focusable = Array.from(
+      modal.querySelectorAll<HTMLElement>(
+        "button:not(:disabled), input:not(:disabled), [tabindex]:not([tabindex='-1'])",
+      ),
+    );
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (!first || !last) return;
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+</script>
+
+{#if open && repo}
+  <div class="modal-backdrop" role="presentation" onkeydown={handleKeydown}>
+    <div class="modal" role="dialog" aria-modal="true" aria-labelledby="repo-promote-title">
+      <header class="modal-header">
+        <div>
+          <h2 id="repo-promote-title">Promote wildcard repository</h2>
+          <p>{repo.repo_path || `${repo.owner}/${repo.name}`}</p>
+        </div>
+        <button type="button" class="close-btn" aria-label="Close" onclick={closeIfAllowed}>×</button>
+      </header>
+
+      <label class="search-field">
+        <span>Search matches</span>
+        <input
+          bind:this={searchInput}
+          value={filterText}
+          placeholder="Filter repositories..."
+          disabled={loading || submitting}
+          oninput={(event) => { filterText = event.currentTarget.value; }}
+        />
+      </label>
+
+      {#if error}
+        <div class="error-msg" role="alert">{error}</div>
+      {/if}
+
+      {#if loading}
+        <div class="empty-state">Loading matches...</div>
+      {:else if filteredRows.length > 0}
+        <div class="match-list" role="listbox" aria-label="Wildcard matches">
+          {#each filteredRows as row (promoteRowKey(row))}
+            {@const key = promoteRowKey(row)}
+            <label class={["match-row", selectedKey === key && "match-row--selected", row.already_configured && "match-row--disabled"]}>
+              <input
+                type="radio"
+                name="promote-repo"
+                checked={selectedKey === key}
+                disabled={row.already_configured || submitting}
+                onchange={() => { selectedKey = key; }}
+              />
+              <span class="match-main">
+                <span class="match-name">{row.repo_path}</span>
+                {#if row.description}
+                  <span class="match-description">{row.description}</span>
+                {/if}
+              </span>
+              {#if row.already_configured}
+                <span class="match-status">Configured</span>
+              {/if}
+            </label>
+          {/each}
+        </div>
+      {:else}
+        <div class="empty-state">No matching repositories.</div>
+      {/if}
+
+      {#if selectedRow}
+        <label class="path-field">
+          <span>Local clone path</span>
+          <input
+            type="text"
+            placeholder="/path/to/existing/clone"
+            aria-label={`Local clone path for ${selectedRow.repo_path}`}
+            value={selectedKey ? (pathDrafts[selectedKey] ?? "") : ""}
+            disabled={submitting || selectedRow.already_configured}
+            oninput={(event) => {
+              if (!selectedKey) return;
+              pathDrafts = {
+                ...pathDrafts,
+                [selectedKey]: event.currentTarget.value,
+              };
+            }}
+            onkeydown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault();
+                void handlePromote();
+              }
+            }}
+          />
+        </label>
+      {/if}
+
+      <footer class="modal-footer">
+        <span>{rows.length} matches</span>
+        <div class="footer-actions">
+          <button class="secondary-btn" type="button" onclick={closeIfAllowed} disabled={submitting}>Cancel</button>
+          <button
+            class="submit-btn"
+            type="button"
+            onclick={() => void handlePromote()}
+            disabled={submitting || !selectedRow || selectedRow.already_configured || selectedPath.trim() === ""}
+          >
+            {submitting ? "Promoting..." : "Promote repository"}
+          </button>
+        </div>
+      </footer>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .modal-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 40;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    background: color-mix(in srgb, black 38%, transparent);
+  }
+  .modal {
+    width: min(760px, 100%);
+    max-height: min(720px, 92vh);
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    padding: 18px;
+    color: var(--text-primary);
+    background: var(--bg-surface);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-lg);
+    box-shadow: 0 24px 80px rgb(0 0 0 / 35%);
+  }
+  .modal-header,
+  .modal-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+  }
+  h2 {
+    margin: 0;
+    font-size: var(--font-size-lg);
+  }
+  p {
+    margin: 4px 0 0;
+    color: var(--text-muted);
+    font-size: var(--font-size-sm);
+  }
+  .close-btn {
+    color: var(--text-muted);
+    font-size: var(--font-size-xl);
+  }
+  .search-field,
+  .path-field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+  }
+  input[type="text"],
+  .search-field input {
+    min-width: 0;
+    padding: 7px 10px;
+    color: var(--text-primary);
+    background: var(--bg-inset);
+    border: 1px solid var(--border-muted);
+    border-radius: var(--radius-sm);
+    font-size: var(--font-size-md);
+  }
+  input:focus {
+    border-color: var(--accent-blue);
+    outline: none;
+  }
+  .match-list {
+    min-height: 0;
+    overflow: auto;
+    border: 1px solid var(--border-muted);
+    border-radius: var(--radius-md);
+  }
+  .match-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-height: 48px;
+    padding: 8px 10px;
+    border-bottom: 1px solid var(--border-muted);
+    cursor: pointer;
+  }
+  .match-row:last-child {
+    border-bottom: 0;
+  }
+  .match-row:hover {
+    background: var(--bg-surface-hover);
+  }
+  .match-row--selected {
+    background: color-mix(in srgb, var(--accent-blue) 8%, transparent);
+  }
+  .match-row--disabled {
+    cursor: not-allowed;
+    opacity: 0.62;
+  }
+  .match-main {
+    display: flex;
+    min-width: 0;
+    flex: 1;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .match-name {
+    overflow: hidden;
+    color: var(--text-primary);
+    font-size: var(--font-size-sm);
+    font-weight: 600;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .match-description {
+    overflow: hidden;
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .match-status {
+    flex-shrink: 0;
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+  }
+  .empty-state {
+    border: 1px dashed var(--border-muted);
+    border-radius: var(--radius-md);
+    padding: 24px;
+    color: var(--text-muted);
+    text-align: center;
+    font-size: var(--font-size-sm);
+  }
+  .secondary-btn,
+  .submit-btn {
+    padding: 7px 14px;
+    border-radius: var(--radius-sm);
+    font-size: var(--font-size-md);
+    font-weight: 600;
+  }
+  .secondary-btn {
+    color: var(--text-secondary);
+    background: var(--bg-inset);
+    border: 1px solid var(--border-muted);
+  }
+  .submit-btn {
+    color: white;
+    background: var(--accent-blue);
+  }
+  button:disabled,
+  input:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+  .error-msg {
+    color: var(--accent-red);
+    font-size: var(--font-size-sm);
+  }
+  .footer-actions {
+    display: flex;
+    gap: 8px;
+  }
+</style>

--- a/frontend/src/lib/components/settings/RepoPromoteModal.svelte
+++ b/frontend/src/lib/components/settings/RepoPromoteModal.svelte
@@ -5,6 +5,7 @@
   import {
     bulkAddRepos,
     previewRepos,
+    removeRepo,
     updateRepoWorktreeBasePath,
     type RepoPreviewRow,
   } from "../../api/settings.js";
@@ -119,37 +120,55 @@
   }
 
   async function handlePromote(): Promise<void> {
-    if (!selectedRow || !selectedKey || selectedRow.already_configured) return;
+    const row = selectedRow;
+    const key = selectedKey;
+    if (!row || !key || row.already_configured) return;
     const worktreeBasePath = selectedPath.trim();
     if (worktreeBasePath === "") return;
+    let addedThisAttempt = false;
     submitting = true;
     error = null;
     try {
-      if (!addedExactKeys[selectedKey]) {
+      if (!addedExactKeys[key]) {
         await bulkAddRepos([
           {
-            provider: selectedRow.provider,
-            host: selectedRow.platform_host,
-            owner: selectedRow.owner,
-            name: selectedRow.name,
-            repo_path: selectedRow.repo_path,
+            provider: row.provider,
+            host: row.platform_host,
+            owner: row.owner,
+            name: row.name,
+            repo_path: row.repo_path,
           },
         ]);
-        addedExactKeys = { ...addedExactKeys, [selectedKey]: true };
+        addedThisAttempt = true;
+        addedExactKeys = { ...addedExactKeys, [key]: true };
       }
       const settings = await updateRepoWorktreeBasePath(
-        selectedRow.owner,
-        selectedRow.name,
+        row.owner,
+        row.name,
         {
-          provider: selectedRow.provider,
-          host: selectedRow.platform_host,
+          provider: row.provider,
+          host: row.platform_host,
         },
         worktreeBasePath,
       );
       onPromoted(settings);
       onClose();
     } catch (err) {
-      error = err instanceof Error ? err.message : String(err);
+      const message = err instanceof Error ? err.message : String(err);
+      if (addedThisAttempt) {
+        try {
+          await removeRepo(row.owner, row.name, {
+            provider: row.provider,
+            host: row.platform_host,
+          });
+          addedExactKeys = { ...addedExactKeys, [key]: false };
+        } catch (rollbackErr) {
+          const rollbackMessage = rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr);
+          error = `${message}; rollback failed: ${rollbackMessage}`;
+          return;
+        }
+      }
+      error = message;
     } finally {
       submitting = false;
     }

--- a/frontend/src/lib/components/settings/RepoSettings.svelte
+++ b/frontend/src/lib/components/settings/RepoSettings.svelte
@@ -12,6 +12,7 @@
   import SettingsIcon from "@lucide/svelte/icons/settings";
   import ProviderIcon from "../provider/ProviderIcon.svelte";
   import RepoImportModal from "./RepoImportModal.svelte";
+  import RepoPromoteModal from "./RepoPromoteModal.svelte";
 
   const { sync } = getStores();
 
@@ -38,6 +39,7 @@
   let savingWorktreeBaseByKey = $state<Record<string, boolean>>({});
   let worktreeBaseErrors = $state<Record<string, string>>({});
   let cloneEditorOpen = $state<Record<string, boolean>>({});
+  let promoteRepo = $state<ConfigRepo | null>(null);
 
   const showProviderIcons = $derived.by(() => {
     const providers = new Set(
@@ -194,6 +196,16 @@
   }}
 />
 
+<RepoPromoteModal
+  open={Boolean(promoteRepo)}
+  repo={promoteRepo}
+  onClose={() => { promoteRepo = null; }}
+  onPromoted={(settings) => {
+    onUpdate(settings.repos);
+    void sync.refreshSyncStatus();
+  }}
+/>
+
 <div class="repo-list">
   {#each repos as repo (repoKey(repo))}
     {@const key = repoKey(repo)}
@@ -214,6 +226,14 @@
         {:else}
           <div class="repo-actions">
             {#if repo.is_glob}
+              <button
+                class="promote-btn"
+                onclick={() => { promoteRepo = repo; }}
+                disabled={embedded}
+                aria-label={`Promote glob repository ${repoLabel(repo)}`}
+              >
+                Promote
+              </button>
               <button
                 class="refresh-btn"
                 onclick={() => void handleRefresh(repo)}
@@ -364,6 +384,17 @@
     color: var(--accent-blue); border: 1px solid color-mix(in srgb, var(--accent-blue) 35%, var(--border-muted));
     border-radius: var(--radius-sm); transition: background 0.12s, opacity 0.12s;
   }
+  .promote-btn {
+    padding: 4px 10px; font-size: var(--font-size-sm); font-weight: 600;
+    color: var(--text-primary); background: var(--bg-inset);
+    border: 1px solid var(--border-muted); border-radius: var(--radius-sm);
+    transition: background 0.12s, border-color 0.12s, opacity 0.12s;
+  }
+  .promote-btn:hover:not(:disabled) {
+    border-color: color-mix(in srgb, var(--accent-blue) 35%, var(--border-muted));
+    background: color-mix(in srgb, var(--accent-blue) 8%, var(--bg-inset));
+  }
+  .promote-btn:disabled { opacity: 0.5; cursor: not-allowed; }
   .refresh-btn:hover:not(:disabled) {
     background: color-mix(in srgb, var(--accent-blue) 10%, transparent);
   }

--- a/frontend/src/lib/components/settings/RepoSettings.test.ts
+++ b/frontend/src/lib/components/settings/RepoSettings.test.ts
@@ -313,6 +313,155 @@ describe("RepoSettings", () => {
     await waitFor(() => expect(onUpdate).toHaveBeenCalledWith(updatedRepos));
   });
 
+  it("promotes a glob match to an exact repository with a local clone path", async () => {
+    const onUpdate = vi.fn();
+    const addedRepos = [
+      {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "acme",
+        name: "*",
+        repo_path: "acme/*",
+        is_glob: true,
+        matched_repo_count: 1,
+      },
+      {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "acme",
+        name: "api",
+        repo_path: "acme/api",
+        is_glob: false,
+        matched_repo_count: 1,
+      },
+    ];
+    const promotedRepos = [
+      {
+        ...addedRepos[0]!,
+      },
+      {
+        ...addedRepos[1]!,
+        worktree_base_path: "/Users/acme/api",
+      },
+    ];
+    mockPreviewRepos.mockResolvedValue({
+      provider: "github",
+      platform_host: "github.com",
+      owner: "acme",
+      pattern: "*",
+      repos: [
+        {
+          provider: "github",
+          platform_host: "github.com",
+          owner: "acme",
+          name: "api",
+          repo_path: "acme/api",
+          description: "HTTP API",
+          private: false,
+          fork: false,
+          pushed_at: null,
+          already_configured: false,
+        },
+      ],
+    });
+    mockBulkAddRepos.mockResolvedValue({
+      repos: addedRepos,
+      activity: {
+        view_mode: "threaded",
+        time_range: "7d",
+        hide_closed: false,
+        hide_bots: false,
+        collapse_threads: false,
+        default_branch_retention_days: 90,
+        default_branch_max_commits: 5000,
+      },
+      terminal: {
+        font_family: "",
+        font_size: 14,
+        scrollback: 1000,
+        line_height: 1,
+        letter_spacing: 0,
+        cursor_blink: true,
+        font_ligatures: false,
+        renderer: "xterm",
+      },
+      agents: [],
+    });
+    mockUpdateRepoWorktreeBasePath.mockResolvedValue({
+      repos: promotedRepos,
+      activity: {
+        view_mode: "threaded",
+        time_range: "7d",
+        hide_closed: false,
+        hide_bots: false,
+        collapse_threads: false,
+        default_branch_retention_days: 90,
+        default_branch_max_commits: 5000,
+      },
+      terminal: {
+        font_family: "",
+        font_size: 14,
+        scrollback: 1000,
+        line_height: 1,
+        letter_spacing: 0,
+        cursor_blink: true,
+        font_ligatures: false,
+        renderer: "xterm",
+      },
+      agents: [],
+    });
+
+    render(RepoSettings, {
+      props: {
+        repos: [
+          {
+            provider: "github",
+            platform_host: "github.com",
+            owner: "acme",
+            name: "*",
+            repo_path: "acme/*",
+            is_glob: true,
+            matched_repo_count: 1,
+          },
+        ],
+        onUpdate,
+      },
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Promote glob repository acme/*" }));
+    await screen.findByRole("dialog", { name: "Promote wildcard repository" });
+    await screen.findByText("acme/api");
+    await fireEvent.input(screen.getByLabelText("Local clone path for acme/api"), {
+      target: { value: "/Users/acme/api" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Promote repository" }));
+
+    expect(mockPreviewRepos).toHaveBeenCalledWith("acme", "*", {
+      provider: "github",
+      host: "github.com",
+    });
+    expect(mockBulkAddRepos).toHaveBeenCalledWith([
+      {
+        provider: "github",
+        host: "github.com",
+        owner: "acme",
+        name: "api",
+        repo_path: "acme/api",
+      },
+    ]);
+    expect(mockUpdateRepoWorktreeBasePath).toHaveBeenCalledWith(
+      "acme",
+      "api",
+      {
+        provider: "github",
+        host: "github.com",
+      },
+      "/Users/acme/api",
+    );
+    await waitFor(() => expect(onUpdate).toHaveBeenCalledWith(promotedRepos));
+    expect(mockRefreshSyncStatus).toHaveBeenCalled();
+  });
+
   it("updates repos and refreshes sync status after import", async () => {
     const importedRepos = [
       {

--- a/frontend/src/lib/components/settings/RepoSettings.test.ts
+++ b/frontend/src/lib/components/settings/RepoSettings.test.ts
@@ -463,6 +463,60 @@ describe("RepoSettings", () => {
     expect(mockRefreshSyncStatus).toHaveBeenCalled();
   });
 
+  it("focuses the promote search while wildcard matches are loading", async () => {
+    let resolvePreview: ((value: Awaited<ReturnType<typeof previewRepos>>) => void) | undefined;
+    mockPreviewRepos.mockReturnValue(
+      new Promise((resolve) => {
+        resolvePreview = resolve;
+      }),
+    );
+
+    render(RepoSettings, {
+      props: {
+        repos: [
+          {
+            provider: "github",
+            platform_host: "github.com",
+            owner: "acme",
+            name: "*",
+            repo_path: "acme/*",
+            is_glob: true,
+            matched_repo_count: 1,
+          },
+        ],
+        onUpdate: vi.fn(),
+      },
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Promote glob repository acme/*" }));
+    await screen.findByRole("dialog", { name: "Promote wildcard repository" });
+    const searchInput = screen.getByPlaceholderText("Filter repositories...");
+
+    await waitFor(() => expect(document.activeElement).toBe(searchInput));
+
+    resolvePreview?.({
+      provider: "github",
+      platform_host: "github.com",
+      owner: "acme",
+      pattern: "*",
+      repos: [
+        {
+          provider: "github",
+          platform_host: "github.com",
+          owner: "acme",
+          name: "api",
+          repo_path: "acme/api",
+          description: "HTTP API",
+          private: false,
+          fork: false,
+          pushed_at: null,
+          already_configured: false,
+        },
+      ],
+    });
+    await screen.findByText("acme/api");
+  });
+
   it("updates repos and refreshes sync status after import", async () => {
     const importedRepos = [
       {

--- a/frontend/src/lib/components/settings/RepoSettings.test.ts
+++ b/frontend/src/lib/components/settings/RepoSettings.test.ts
@@ -430,6 +430,7 @@ describe("RepoSettings", () => {
 
     await fireEvent.click(screen.getByRole("button", { name: "Promote glob repository acme/*" }));
     await screen.findByRole("dialog", { name: "Promote wildcard repository" });
+    expect(screen.getByRole("radiogroup", { name: "Wildcard matches" })).toBeTruthy();
     await screen.findByText("acme/api");
     await fireEvent.input(screen.getByLabelText("Local clone path for acme/api"), {
       target: { value: "/Users/acme/api" },

--- a/frontend/src/lib/components/settings/RepoSettings.test.ts
+++ b/frontend/src/lib/components/settings/RepoSettings.test.ts
@@ -21,7 +21,14 @@ vi.mock("../../api/settings.js", () => ({
   bulkAddRepos: vi.fn(),
 }));
 
-import { addRepo, bulkAddRepos, previewRepos, refreshRepo, updateRepoWorktreeBasePath } from "../../api/settings.js";
+import {
+  addRepo,
+  bulkAddRepos,
+  previewRepos,
+  refreshRepo,
+  removeRepo,
+  updateRepoWorktreeBasePath,
+} from "../../api/settings.js";
 import RepoSettings from "./RepoSettings.svelte";
 
 const mockAddRepo = vi.mocked(addRepo);
@@ -29,6 +36,7 @@ const mockRefreshRepo = vi.mocked(refreshRepo);
 const mockUpdateRepoWorktreeBasePath = vi.mocked(updateRepoWorktreeBasePath);
 const mockPreviewRepos = vi.mocked(previewRepos);
 const mockBulkAddRepos = vi.mocked(bulkAddRepos);
+const mockRemoveRepo = vi.mocked(removeRepo);
 
 describe("RepoSettings", () => {
   afterEach(() => {
@@ -39,6 +47,7 @@ describe("RepoSettings", () => {
     mockUpdateRepoWorktreeBasePath.mockReset();
     mockPreviewRepos.mockReset();
     mockBulkAddRepos.mockReset();
+    mockRemoveRepo.mockReset();
   });
 
   it("renders the glob count and refresh action", () => {
@@ -515,6 +524,109 @@ describe("RepoSettings", () => {
       ],
     });
     await screen.findByText("acme/api");
+  });
+
+  it("rolls back a promoted exact repository when saving the local clone path fails", async () => {
+    const onUpdate = vi.fn();
+    const addedRepos = [
+      {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "acme",
+        name: "*",
+        repo_path: "acme/*",
+        is_glob: true,
+        matched_repo_count: 1,
+      },
+      {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "acme",
+        name: "api",
+        repo_path: "acme/api",
+        is_glob: false,
+        matched_repo_count: 1,
+      },
+    ];
+    mockPreviewRepos.mockResolvedValue({
+      provider: "github",
+      platform_host: "github.com",
+      owner: "acme",
+      pattern: "*",
+      repos: [
+        {
+          provider: "github",
+          platform_host: "github.com",
+          owner: "acme",
+          name: "api",
+          repo_path: "acme/api",
+          description: "HTTP API",
+          private: false,
+          fork: false,
+          pushed_at: null,
+          already_configured: false,
+        },
+      ],
+    });
+    mockBulkAddRepos.mockResolvedValue({
+      repos: addedRepos,
+      activity: {
+        view_mode: "threaded",
+        time_range: "7d",
+        hide_closed: false,
+        hide_bots: false,
+        collapse_threads: false,
+        default_branch_retention_days: 90,
+        default_branch_max_commits: 5000,
+      },
+      terminal: {
+        font_family: "",
+        font_size: 14,
+        scrollback: 1000,
+        line_height: 1,
+        letter_spacing: 0,
+        cursor_blink: true,
+        font_ligatures: false,
+        renderer: "xterm",
+      },
+      agents: [],
+    });
+    mockUpdateRepoWorktreeBasePath.mockRejectedValue(new Error("path does not exist"));
+    mockRemoveRepo.mockResolvedValue();
+
+    render(RepoSettings, {
+      props: {
+        repos: [
+          {
+            provider: "github",
+            platform_host: "github.com",
+            owner: "acme",
+            name: "*",
+            repo_path: "acme/*",
+            is_glob: true,
+            matched_repo_count: 1,
+          },
+        ],
+        onUpdate,
+      },
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Promote glob repository acme/*" }));
+    await screen.findByText("acme/api");
+    await fireEvent.input(screen.getByLabelText("Local clone path for acme/api"), {
+      target: { value: "/missing/api" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Promote repository" }));
+
+    await waitFor(() =>
+      expect(mockRemoveRepo).toHaveBeenCalledWith("acme", "api", {
+        provider: "github",
+        host: "github.com",
+      }),
+    );
+    await waitFor(() => expect(screen.getByRole("alert").textContent).toContain("path does not exist"));
+    expect(onUpdate).not.toHaveBeenCalled();
+    expect(mockRefreshSyncStatus).not.toHaveBeenCalled();
   });
 
   it("updates repos and refreshes sync status after import", async () => {

--- a/frontend/tests/e2e-full/settings-globs.spec.ts
+++ b/frontend/tests/e2e-full/settings-globs.spec.ts
@@ -237,6 +237,59 @@ test("settings promotes a glob match to a persisted exact repo with a local clon
   );
 });
 
+test("settings rolls back a promoted glob match when the local clone path is invalid", async ({ page }) => {
+  await page.goto(`${isolatedServer!.info.base_url}/settings`);
+  await page.locator(".settings-page").waitFor({ state: "visible", timeout: 10_000 });
+
+  const globRow = page.locator(".repo-row", { hasText: "roborev-dev/*" });
+  await globRow.getByRole("button", { name: "Promote glob repository roborev-dev/*" }).click();
+  const dialog = page.getByRole("dialog", { name: "Promote wildcard repository" });
+  await expect(dialog.getByRole("radio", { name: /roborev-dev\/middleman/ })).toBeChecked();
+
+  const addResponsePromise = page.waitForResponse(
+    (response) => response.url().endsWith("/api/v1/repos/bulk") && response.request().method() === "POST",
+  );
+  const saveResponsePromise = page.waitForResponse(
+    (response) =>
+      response.url().endsWith("/api/v1/repo/github/roborev-dev/middleman/worktree-base") &&
+      response.request().method() === "PUT",
+  );
+  const rollbackResponsePromise = page.waitForResponse(
+    (response) =>
+      response.url().endsWith("/api/v1/repo/github/roborev-dev/middleman") && response.request().method() === "DELETE",
+  );
+
+  await dialog
+    .getByLabel("Local clone path for roborev-dev/middleman", { exact: true })
+    .fill("/missing/promoted/clone");
+  await dialog.getByRole("button", { name: "Promote repository" }).click();
+  const addResponse = await addResponsePromise;
+  const saveResponse = await saveResponsePromise;
+  const rollbackResponse = await rollbackResponsePromise;
+  expect(addResponse.status(), `POST repos/bulk failed: ${await addResponse.text()}`).toBe(201);
+  expect(saveResponse.status(), "invalid worktree path should fail validation").not.toBe(200);
+  expect(rollbackResponse.ok(), `DELETE promoted repo returned ${rollbackResponse.status()}`).toBe(true);
+
+  await expect(dialog.getByRole("alert")).toContainText("path does not exist");
+
+  if (!api) throw new Error("settings-globs API context not initialized");
+  await expect
+    .poll(async () => {
+      const settingsResponse = await api!.get("/api/v1/settings");
+      expect(settingsResponse.ok()).toBe(true);
+      const settings = (await settingsResponse.json()) as {
+        repos: Array<{
+          owner: string;
+          name: string;
+          repo_path: string;
+          is_glob: boolean;
+        }>;
+      };
+      return settings.repos.some((repo) => repo.owner === "roborev-dev" && repo.name === "middleman" && !repo.is_glob);
+    })
+    .toBe(false);
+});
+
 test("repository import can hide forks and private repositories before adding", async ({ page }) => {
   let bulkRepos:
     | Array<{

--- a/frontend/tests/e2e-full/settings-globs.spec.ts
+++ b/frontend/tests/e2e-full/settings-globs.spec.ts
@@ -1,3 +1,7 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { expect, request as playwrightRequest, test, type APIRequestContext } from "@playwright/test";
 import { startIsolatedE2EServer, type IsolatedE2EServer } from "./support/e2eServer";
 
@@ -10,6 +14,11 @@ type RepoSummary = {
 
 let isolatedServer: IsolatedE2EServer | undefined;
 let api: APIRequestContext | undefined;
+let localRepo: string | undefined;
+
+function git(dir: string, ...args: string[]): void {
+  execFileSync("git", args, { cwd: dir, stdio: "ignore" });
+}
 
 test.beforeEach(async () => {
   isolatedServer = await startIsolatedE2EServer();
@@ -23,6 +32,10 @@ test.afterEach(async () => {
   await isolatedServer?.stop();
   api = undefined;
   isolatedServer = undefined;
+  if (localRepo) {
+    rmSync(localRepo, { recursive: true, force: true });
+    localRepo = undefined;
+  }
 });
 
 test("settings shows glob match counts and refresh updates tracked repos", async ({ page }) => {
@@ -165,6 +178,63 @@ test("settings imports a selected subset from a repository glob", async ({ page 
 
   await page.goto(`${isolatedServer!.info.base_url}/pulls`);
   await expect(page.getByTitle("Select repository")).toContainText("All repos");
+});
+
+test("settings promotes a glob match to a persisted exact repo with a local clone", async ({ page }) => {
+  localRepo = realpathSync(mkdtempSync(path.join(os.tmpdir(), "mm-promote-clone-")));
+  git(localRepo, "init");
+  git(localRepo, "remote", "add", "origin", "https://github.com/roborev-dev/middleman.git");
+
+  await page.goto(`${isolatedServer!.info.base_url}/settings`);
+  await page.locator(".settings-page").waitFor({ state: "visible", timeout: 10_000 });
+
+  const globRow = page.locator(".repo-row", { hasText: "roborev-dev/*" });
+  await globRow.getByRole("button", { name: "Promote glob repository roborev-dev/*" }).click();
+  const dialog = page.getByRole("dialog", { name: "Promote wildcard repository" });
+  await expect(dialog.getByLabel("Search matches")).toBeFocused();
+  await expect(dialog.getByRole("radio", { name: /roborev-dev\/middleman/ })).toBeChecked();
+
+  const saveResponsePromise = page.waitForResponse(
+    (response) =>
+      response.url().endsWith("/api/v1/repo/github/roborev-dev/middleman/worktree-base") &&
+      response.request().method() === "PUT",
+  );
+  await dialog.getByLabel("Local clone path for roborev-dev/middleman", { exact: true }).fill(localRepo);
+  await dialog.getByRole("button", { name: "Promote repository" }).click();
+  const saveResponse = await saveResponsePromise;
+  const saveBody = await saveResponse.text();
+  expect(saveResponse.status(), `PUT worktree-base failed: ${saveBody}`).toBe(200);
+
+  await expect(dialog).toHaveCount(0);
+  const exactRow = page.locator(".repo-row", { hasText: "roborev-dev/middleman" });
+  await expect(exactRow).toBeVisible();
+  await expect(exactRow.getByRole("button", { name: "Local clone for roborev-dev/middleman" })).toHaveAttribute(
+    "title",
+    `Local clone: ${localRepo}`,
+  );
+
+  if (!api) throw new Error("settings-globs API context not initialized");
+  const settingsResponse = await api.get("/api/v1/settings");
+  const settingsBody = await settingsResponse.text();
+  expect(settingsResponse.status(), `GET settings failed: ${settingsBody}`).toBe(200);
+  const settings = JSON.parse(settingsBody) as {
+    repos: Array<{
+      owner: string;
+      name: string;
+      repo_path: string;
+      is_glob: boolean;
+      worktree_base_path?: string;
+    }>;
+  };
+  expect(settings.repos).toContainEqual(
+    expect.objectContaining({
+      owner: "roborev-dev",
+      name: "middleman",
+      repo_path: "roborev-dev/middleman",
+      is_glob: false,
+      worktree_base_path: localRepo,
+    }),
+  );
 });
 
 test("repository import can hide forks and private repositories before adding", async ({ page }) => {

--- a/internal/server/fleet_ssh_test.go
+++ b/internal/server/fleet_ssh_test.go
@@ -310,10 +310,13 @@ func TestSSHFleetSnapshotDegradesColdPeerFast(t *testing.T) {
 	raw := `{"schemaVersion":2,"host":{"hostname":"epyc","platform":"linux"}}`
 	release := make(chan struct{})
 	var fetches atomic.Int32
+	started := make(chan struct{})
+	var startedOnce sync.Once
 	exec := func(
 		_ context.Context, argv []string, _ []byte,
 	) ([]byte, []byte, int, error) {
 		fetches.Add(1)
+		startedOnce.Do(func() { close(started) })
 		<-release
 		return []byte(framedJSON(200, raw)), nil, 0, nil
 	}
@@ -387,6 +390,12 @@ func TestSSHFleetSnapshotDegradesColdPeerFast(t *testing.T) {
 	assert.False(epyc.Reachable)
 	require.NotNil(epyc.Error)
 	assert.Contains(*epyc.Error, "warming")
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		require.Fail("cold snapshot fetch did not start")
+	}
 
 	// A second read while the fetch is still blocked must not start
 	// another fetch.

--- a/internal/server/msgvault_routes_test.go
+++ b/internal/server/msgvault_routes_test.go
@@ -1577,12 +1577,21 @@ func TestMsgvaultConfigureConcurrentSavesKeepDiskAndMemoryAligned(t *testing.T) 
 	for i, status := range statuses {
 		Assert.Equalf(t, http.StatusOK, status, "worker %d", i)
 	}
-	reloaded, err := config.Load(cfgPath)
-	require.NoError(err)
-	require.NotNil(reloaded.Msgvault)
-	health := doMsgvaultJSON(t, srv, http.MethodGet, "/api/v1/msgvault/health", nil)
-	require.Equal(http.StatusOK, health.Code, health.Body.String())
-	Assert.Equal(t, reloaded.Msgvault.URL, decodeMsgvaultHealth(t, health).URL)
+	var diskURL, healthURL string
+	require.Eventually(func() bool {
+		reloaded, err := config.Load(cfgPath)
+		if err != nil || reloaded.Msgvault == nil {
+			return false
+		}
+		health := doMsgvaultJSON(t, srv, http.MethodGet, "/api/v1/msgvault/health", nil)
+		if health.Code != http.StatusOK {
+			return false
+		}
+		diskURL = reloaded.Msgvault.URL
+		healthURL = decodeMsgvaultHealth(t, health).URL
+		return diskURL == healthURL
+	}, time.Second, 10*time.Millisecond,
+		"disk URL %q and health URL %q should align", diskURL, healthURL)
 }
 
 func TestMsgvaultConfigureResponseEchoesOwnSavedConfig(t *testing.T) {


### PR DESCRIPTION
- Adds a Promote flow on wildcard repository settings rows for choosing a matched exact repository.
- Lets the promoted exact repo save a local clone path while the wildcard remains configured for future matches.

Screenshots:

![wildcard-promote-repositories-section.png](https://github.com/user-attachments/assets/c42ffd9b-e17c-4658-b664-64b8c1c23640)

![wildcard-promote-dialog.png](https://github.com/user-attachments/assets/0bdb8c79-644b-41ad-8c7e-2e645b9ab9aa)
