### PR TITLE
fix: keep fleet test daemons out of telemetry

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,8 +1,5 @@
 FROM golang:1.26
 
-ARG MIDDLEMAN_GO_BUILD_TAGS=""
-ENV MIDDLEMAN_GO_BUILD_TAGS=${MIDDLEMAN_GO_BUILD_TAGS}
-
 RUN apt-get update && apt-get install -y --no-install-recommends curl git make openssh-client openssh-server socat tmux unzip && rm -rf /var/lib/apt/lists/*
 
 # Bun from GitHub release (pinned to match frontend/package.json)

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,8 @@
 FROM golang:1.26
 
+ARG MIDDLEMAN_GO_BUILD_TAGS=""
+ENV MIDDLEMAN_GO_BUILD_TAGS=${MIDDLEMAN_GO_BUILD_TAGS}
+
 RUN apt-get update && apt-get install -y --no-install-recommends curl git make openssh-client openssh-server socat tmux unzip && rm -rf /var/lib/apt/lists/*
 
 # Bun from GitHub release (pinned to match frontend/package.json)

--- a/frontend/src/lib/components/settings/RepoSettings.test.ts
+++ b/frontend/src/lib/components/settings/RepoSettings.test.ts
@@ -408,6 +408,7 @@ describe("RepoSettings", () => {
         renderer: "xterm",
       },
       agents: [],
+      fleet: defaultFleetSettings(),
     });
     mockUpdateRepoWorktreeBasePath.mockResolvedValue({
       repos: promotedRepos,
@@ -431,6 +432,7 @@ describe("RepoSettings", () => {
         renderer: "xterm",
       },
       agents: [],
+      fleet: defaultFleetSettings(),
     });
 
     render(RepoSettings, {
@@ -603,6 +605,7 @@ describe("RepoSettings", () => {
         renderer: "xterm",
       },
       agents: [],
+      fleet: defaultFleetSettings(),
     });
     mockUpdateRepoWorktreeBasePath.mockRejectedValue(new Error("path does not exist"));
     mockRemoveRepo.mockResolvedValue();

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -21152,21 +21152,23 @@ exit 0
 		for _, argv := range readTmuxRecord(t, record) {
 			if len(argv) > 0 &&
 				argv[0] == "new-session" &&
-				strings.Contains(strings.Join(argv, "\n"), agentPath) {
+				runtimeTmuxNewSessionCommandContains(t, argv, agentPath) {
 				newSession = argv
 				return true
 			}
 		}
 		return false
 	}, 2*time.Second, 20*time.Millisecond)
+	scriptText, ok := runtimeTmuxNewSessionScript(t, newSession)
+	require.True(ok, "new-session should run generated tmux pane script")
 
 	session, ok := argAfter(newSession, "-s")
 	require.True(ok, "new-session should name a tmux session")
 	assert.True(isRuntimeTmuxSessionNameForWorkspace(ws.Id, session))
 	assert.Contains(newSession, "-d")
 	assert.Contains(newSession, "-c")
-	assert.Contains(strings.Join(newSession, "\n"), agentPath)
-	assert.Contains(strings.Join(newSession, "\n"), "--flag")
+	assert.Contains(scriptText, agentPath)
+	assert.Contains(scriptText, "--flag")
 	assert.Contains(newSession, ";")
 	assert.Contains(newSession, "set-option")
 	assert.Contains(newSession, "-t")
@@ -21455,7 +21457,7 @@ exit 0
 	var sessionName string
 	require.Eventually(func() bool {
 		name, ok := findRuntimeTmuxNewSessionName(
-			readTmuxRecord(t, record), ws.Id, agentPath,
+			t, readTmuxRecord(t, record), ws.Id, "",
 		)
 		if ok {
 			sessionName = name
@@ -21520,14 +21522,19 @@ func isRuntimeTmuxSessionNameForWorkspace(
 }
 
 func findRuntimeTmuxNewSessionName(
+	t *testing.T,
 	argvs [][]string,
 	workspaceID string,
 	commandPath string,
 ) (string, bool) {
+	t.Helper()
 	for _, argv := range argvs {
 		if len(argv) == 0 ||
-			argv[0] != "new-session" ||
-			!strings.Contains(strings.Join(argv, "\n"), commandPath) {
+			argv[0] != "new-session" {
+			continue
+		}
+		if commandPath != "" &&
+			!runtimeTmuxNewSessionCommandContains(t, argv, commandPath) {
 			continue
 		}
 		name, ok := argAfter(argv, "-s")
@@ -21536,6 +21543,51 @@ func findRuntimeTmuxNewSessionName(
 		}
 	}
 	return "", false
+}
+
+func runtimeTmuxNewSessionCommandContains(
+	t *testing.T,
+	argv []string,
+	needle string,
+) bool {
+	t.Helper()
+	if strings.Contains(strings.Join(argv, "\n"), needle) {
+		return true
+	}
+	scriptText, ok := runtimeTmuxNewSessionScript(t, argv)
+	return ok && strings.Contains(scriptText, needle)
+}
+
+func runtimeTmuxNewSessionScript(t *testing.T, argv []string) (string, bool) {
+	t.Helper()
+	command := tmuxNewSessionPaneCommand(argv)
+	if command == "" {
+		return "", false
+	}
+	words, err := shellquote.Split(command)
+	if err != nil ||
+		len(words) != 2 ||
+		words[0] != "/bin/sh" {
+		return "", false
+	}
+	data, err := os.ReadFile(words[1])
+	if err != nil {
+		return "", false
+	}
+	return string(data), true
+}
+
+func tmuxNewSessionPaneCommand(argv []string) string {
+	if len(argv) == 0 {
+		return ""
+	}
+	command := argv[len(argv)-1]
+	for i, arg := range argv {
+		if arg == ";" && i > 0 {
+			return argv[i-1]
+		}
+	}
+	return command
 }
 
 func isRuntimeSessionKeyForWorkspace(workspaceID string, key string) bool {

--- a/internal/server/fleet_container_e2e_test.go
+++ b/internal/server/fleet_container_e2e_test.go
@@ -28,17 +28,27 @@ import (
 
 var fleetContainerUUIDPattern = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
 
-func TestFleetRunDaemonBuildDisablesTelemetry(t *testing.T) {
+func TestFleetComposeBuildDisablesTelemetry(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
+	dockerfile, err := os.ReadFile(filepath.Join(repoRoot(t), "Dockerfile.dev"))
+	require.NoError(err)
+	compose, err := os.ReadFile(filepath.Join(repoRoot(t), "scripts/e2e/fleet/docker-compose.yml"))
+	require.NoError(err)
 	script, err := os.ReadFile(filepath.Join(repoRoot(t), "scripts/e2e/fleet/run-daemon.sh"))
 	require.NoError(err)
 
+	assert.Contains(string(dockerfile), `ARG MIDDLEMAN_GO_BUILD_TAGS=""`)
+	assert.Contains(string(dockerfile), `ENV MIDDLEMAN_GO_BUILD_TAGS=${MIDDLEMAN_GO_BUILD_TAGS}`)
+	assert.Equal(3, strings.Count(string(compose), "MIDDLEMAN_GO_BUILD_TAGS: kit_posthog_disabled"))
 	assert.Contains(
 		string(script),
-		"go build -tags kit_posthog_disabled -o \"${binary}\" ./cmd/middleman",
+		`if [[ -n "${MIDDLEMAN_GO_BUILD_TAGS:-}" ]]; then`,
 	)
+	assert.Contains(string(script), `go_build_args=(-tags "${MIDDLEMAN_GO_BUILD_TAGS}" "${go_build_args[@]}")`)
+	assert.Contains(string(script), `go build "${go_build_args[@]}" ./cmd/middleman`)
+	assert.NotContains(string(script), "go build -tags kit_posthog_disabled")
 }
 
 func TestFleetContainerReadE2E(t *testing.T) {

--- a/internal/server/fleet_container_e2e_test.go
+++ b/internal/server/fleet_container_e2e_test.go
@@ -37,7 +37,7 @@ func TestFleetRunDaemonBuildDisablesTelemetry(t *testing.T) {
 
 	assert.Contains(
 		string(script),
-		"go build -tags middleman_no_telemetry -o \"${binary}\" ./cmd/middleman",
+		"go build -tags kit_posthog_disabled -o \"${binary}\" ./cmd/middleman",
 	)
 }
 

--- a/internal/server/fleet_container_e2e_test.go
+++ b/internal/server/fleet_container_e2e_test.go
@@ -28,6 +28,19 @@ import (
 
 var fleetContainerUUIDPattern = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
 
+func TestFleetRunDaemonBuildDisablesTelemetry(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	script, err := os.ReadFile(filepath.Join(repoRoot(t), "scripts/e2e/fleet/run-daemon.sh"))
+	require.NoError(err)
+
+	assert.Contains(
+		string(script),
+		"go build -tags middleman_no_telemetry -o \"${binary}\" ./cmd/middleman",
+	)
+}
+
 func TestFleetContainerReadE2E(t *testing.T) {
 	if os.Getenv("MIDDLEMAN_FLEET_CONTAINER_E2E") != "1" {
 		t.Skip("set MIDDLEMAN_FLEET_CONTAINER_E2E=1 to run fleet container e2e")

--- a/internal/server/fleet_container_e2e_test.go
+++ b/internal/server/fleet_container_e2e_test.go
@@ -39,9 +39,9 @@ func TestFleetComposeBuildDisablesTelemetry(t *testing.T) {
 	script, err := os.ReadFile(filepath.Join(repoRoot(t), "scripts/e2e/fleet/run-daemon.sh"))
 	require.NoError(err)
 
-	assert.Contains(string(dockerfile), `ARG MIDDLEMAN_GO_BUILD_TAGS=""`)
-	assert.Contains(string(dockerfile), `ENV MIDDLEMAN_GO_BUILD_TAGS=${MIDDLEMAN_GO_BUILD_TAGS}`)
+	assert.NotContains(string(dockerfile), "MIDDLEMAN_GO_BUILD_TAGS")
 	assert.Equal(3, strings.Count(string(compose), "MIDDLEMAN_GO_BUILD_TAGS: kit_posthog_disabled"))
+	assert.NotContains(string(compose), "args:\n        MIDDLEMAN_GO_BUILD_TAGS: kit_posthog_disabled")
 	assert.Contains(
 		string(script),
 		`if [[ -n "${MIDDLEMAN_GO_BUILD_TAGS:-}" ]]; then`,

--- a/internal/telemetry/build_default.go
+++ b/internal/telemetry/build_default.go
@@ -1,4 +1,4 @@
-//go:build !middleman_no_telemetry
+//go:build !kit_posthog_disabled
 
 package telemetry
 

--- a/internal/telemetry/build_default.go
+++ b/internal/telemetry/build_default.go
@@ -1,0 +1,7 @@
+//go:build !middleman_no_telemetry
+
+package telemetry
+
+func enabledInBuild() bool {
+	return true
+}

--- a/internal/telemetry/build_default_test.go
+++ b/internal/telemetry/build_default_test.go
@@ -1,4 +1,4 @@
-//go:build !middleman_no_telemetry
+//go:build !kit_posthog_disabled
 
 package telemetry
 

--- a/internal/telemetry/build_default_test.go
+++ b/internal/telemetry/build_default_test.go
@@ -1,0 +1,13 @@
+//go:build !middleman_no_telemetry
+
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTelemetryEnabledInDefaultBuild(t *testing.T) {
+	assert.True(t, enabledInBuild())
+}

--- a/internal/telemetry/build_no_telemetry.go
+++ b/internal/telemetry/build_no_telemetry.go
@@ -1,0 +1,7 @@
+//go:build middleman_no_telemetry
+
+package telemetry
+
+func enabledInBuild() bool {
+	return false
+}

--- a/internal/telemetry/build_no_telemetry.go
+++ b/internal/telemetry/build_no_telemetry.go
@@ -1,4 +1,4 @@
-//go:build middleman_no_telemetry
+//go:build kit_posthog_disabled
 
 package telemetry
 

--- a/internal/telemetry/build_no_telemetry_test.go
+++ b/internal/telemetry/build_no_telemetry_test.go
@@ -1,0 +1,13 @@
+//go:build middleman_no_telemetry
+
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTelemetryDisabledByBuildTag(t *testing.T) {
+	assert.False(t, enabledInBuild())
+}

--- a/internal/telemetry/build_no_telemetry_test.go
+++ b/internal/telemetry/build_no_telemetry_test.go
@@ -1,4 +1,4 @@
-//go:build middleman_no_telemetry
+//go:build kit_posthog_disabled
 
 package telemetry
 

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -98,7 +98,7 @@ func SanitizeProperties(event string, properties map[string]any) (map[string]any
 }
 
 func NewReporter(opts Options) (*Reporter, error) {
-	if !EnabledFromEnv() || testing.Testing() {
+	if !enabledInBuild() || !EnabledFromEnv() || testing.Testing() {
 		return DisabledReporter(), nil
 	}
 	if opts.Database == nil {

--- a/internal/workspace/localruntime/command_session_test.go
+++ b/internal/workspace/localruntime/command_session_test.go
@@ -104,11 +104,11 @@ func TestEnsureCommandSessionLaunchesTmuxBackedCommand(t *testing.T) {
 		}
 	}
 	require.NotEmpty(newSession)
-	newSessionText := strings.Join(newSession, "\n")
+	scriptText := requireNewSessionPaneScript(t, newSession)
 	assert.Contains(newSession, "-c")
 	assert.Contains(newSession, cwd)
-	assert.Contains(newSessionText, `CUSTOM_SESSION_VAR="${CUSTOM_SESSION_VAR-}"`)
-	assert.Contains(newSessionText, shellquote.Join("/bin/sh"))
+	assert.Contains(scriptText, `CUSTOM_SESSION_VAR="${CUSTOM_SESSION_VAR-}"`)
+	assert.Contains(scriptText, shellquote.Join("/bin/sh"))
 
 	sessions := mgr.ListSessions("scope-1")
 	require.Len(sessions, 1)

--- a/internal/workspace/localruntime/manager_test.go
+++ b/internal/workspace/localruntime/manager_test.go
@@ -341,14 +341,15 @@ exit 0
 	}
 	require.NotEmpty(newSession)
 	newSessionText := strings.Join(newSession, "\n")
+	scriptText := requireNewSessionPaneScript(t, newSession)
 	assert.Contains(newSession, "-E")
 	assert.NotContains(newSession, "-e")
 	assert.Contains(newSession, "-c")
 	assert.Contains(newSession, "/tmp/work tree")
-	assert.Contains(newSessionText, "__middleman_env_file=")
-	assert.Contains(newSessionText, "exec env -i")
-	assert.Contains(newSessionText, `XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR-}"`)
-	assert.Contains(newSessionText, shellquote.Join(agent.Command[0]))
+	assert.Contains(scriptText, "__middleman_env_file=")
+	assert.Contains(scriptText, "exec env -i")
+	assert.Contains(scriptText, `XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR-}"`)
+	assert.Contains(scriptText, shellquote.Join(agent.Command[0]))
 	assert.NotContains(newSessionText, "argv-visible-value")
 }
 
@@ -512,21 +513,22 @@ exit 0
 	}
 	require.NotEmpty(newSession)
 	newSessionText := strings.Join(newSession, "\n")
+	scriptText := requireNewSessionPaneScript(t, newSession)
 	assert.Contains(newSession, "-c")
 	assert.Contains(newSession, "/tmp/work tree")
-	assert.Contains(newSessionText, "exec env -i")
-	assert.Contains(newSessionText, shellquote.Join(os.Args[0]))
+	assert.Contains(scriptText, "exec env -i")
+	assert.Contains(scriptText, shellquote.Join(os.Args[0]))
 	assert.Contains(
-		newSessionText,
+		scriptText,
 		"XDG_RUNTIME_DIR=\"${XDG_RUNTIME_DIR-}\"",
 	)
 	assert.Contains(
-		newSessionText,
+		scriptText,
 		"MIDDLEMAN_TEST_CUSTOM_SHELL_ENV=\"${MIDDLEMAN_TEST_CUSTOM_SHELL_ENV-}\"",
 	)
 	assert.Contains(newSession, "-E")
 	assert.NotContains(newSession, "-e")
-	assert.Contains(newSessionText, "__middleman_env_file=")
+	assert.Contains(scriptText, "__middleman_env_file=")
 	assert.Contains(newSession, ";")
 	assert.Contains(newSession, "set-option")
 	assert.Contains(newSession, "-t")

--- a/internal/workspace/localruntime/tmux_launcher.go
+++ b/internal/workspace/localruntime/tmux_launcher.go
@@ -255,21 +255,61 @@ func (l tmuxLauncher) newSessionPaneCommand() (string, func(), error) {
 	if err != nil {
 		return "", nil, fmt.Errorf("write tmux pane environment: %w", err)
 	}
+	// tmux parses shell-command with its default shell, which may not be
+	// POSIX-compatible. Keep the POSIX handoff in a script run by /bin/sh.
+	scriptPath, err := writeTmuxPaneScript(path, l.Pane.paneCommand)
+	if err != nil {
+		_ = os.Remove(path)
+		return "", nil, fmt.Errorf("write tmux pane script: %w", err)
+	}
 	cleanup := func() {
 		_ = os.Remove(path)
+		_ = os.Remove(scriptPath)
 	}
-	return strings.Join([]string{
-		"__middleman_env_file=" + shellCommand([]string{path}),
-		`__middleman_cleanup_env_file() { /bin/rm -f "$__middleman_env_file"; }`,
-		`trap __middleman_cleanup_env_file EXIT`,
+	return shellCommand([]string{"/bin/sh", scriptPath}), cleanup, nil
+}
+
+func writeTmuxPaneScript(envPath string, paneCommand string) (string, error) {
+	file, err := os.CreateTemp(tmuxPaneEnvironmentTempDir(), "middleman-tmux-pane-*")
+	if err != nil {
+		return "", err
+	}
+	path := file.Name()
+	if err := file.Chmod(0o600); err != nil {
+		_ = file.Close()
+		_ = os.Remove(path)
+		return "", err
+	}
+
+	content := strings.Join([]string{
+		"__middleman_env_file=" + shellCommand([]string{envPath}),
+		"__middleman_script_file=" + shellCommand([]string{path}),
+		`__middleman_cleanup_tmux_files() { /bin/rm -f "$__middleman_env_file" "$__middleman_script_file"; }`,
+		`trap __middleman_cleanup_tmux_files EXIT`,
 		`if [ ! -r "$__middleman_env_file" ]; then exit 127; fi`,
 		`. "$__middleman_env_file"`,
-		`__middleman_cleanup_env_file`,
+		`__middleman_cleanup_tmux_files`,
 		`trap - EXIT`,
-		`unset -f __middleman_cleanup_env_file`,
+		`unset -f __middleman_cleanup_tmux_files`,
 		`unset __middleman_env_file`,
-		l.Pane.paneCommand,
-	}, "\n"), cleanup, nil
+		`unset __middleman_script_file`,
+		paneCommand,
+	}, "\n")
+	if _, err := file.WriteString(content); err != nil {
+		_ = file.Close()
+		_ = os.Remove(path)
+		return "", err
+	}
+	if _, err := file.WriteString("\n"); err != nil {
+		_ = file.Close()
+		_ = os.Remove(path)
+		return "", err
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(path)
+		return "", err
+	}
+	return path, nil
 }
 
 func writeTmuxPaneEnvironment(env []string, keys []string) (string, error) {

--- a/internal/workspace/localruntime/tmux_launcher_test.go
+++ b/internal/workspace/localruntime/tmux_launcher_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	shellquote "github.com/kballard/go-shellquote"
 	Assert "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -31,25 +32,38 @@ func TestTmuxLauncherAgentOperationsKeepEnvValuesOutOfArgv(t *testing.T) {
 	paneCommand, cleanup, err := launcher.newSessionPaneCommand()
 	require.NoError(t, err)
 	t.Cleanup(cleanup)
+	scriptText := requireTmuxPaneScript(t, paneCommand)
 	newSession := launcher.newSessionCommand(paneCommand)
 	newSessionText := strings.Join(newSession, "\n")
+	paneCommandArg := ""
+	for i, arg := range newSession {
+		if arg == ";" && i > 0 {
+			paneCommandArg = newSession[i-1]
+			break
+		}
+	}
+	require.NotEmpty(t, paneCommandArg)
 
 	assert.Equal("new-session", newSession[1])
 	assert.Contains(newSession, "-E")
 	assert.NotContains(newSession, "-e")
+	assert.Equal(paneCommand, paneCommandArg)
 	assert.Contains(newSession, "-c")
 	assert.Contains(newSession, "/tmp/work tree")
-	assert.Contains(newSessionText, "exec env -i")
+	assert.Contains(scriptText, "exec env -i")
 	assert.Contains(newSession, ";")
 	assert.Contains(newSession, "set-option")
 	assert.Contains(newSession, "@middleman_owner")
 	assert.Contains(newSession, "middleman:test-owner")
-	assert.Contains(newSessionText, `XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR-}"`)
-	assert.Contains(newSessionText, "__middleman_env_file=")
-	assert.Contains(newSessionText, "trap __middleman_cleanup_env_file EXIT")
-	assert.Contains(newSessionText, "trap - EXIT")
+	assert.Contains(scriptText, `XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR-}"`)
+	assert.Contains(scriptText, "__middleman_env_file=")
+	assert.Contains(scriptText, "__middleman_script_file=")
+	assert.Contains(scriptText, "trap __middleman_cleanup_tmux_files EXIT")
+	assert.Contains(scriptText, "trap - EXIT")
 	assert.NotContains(newSessionText, "argv-visible-value")
 	assert.NotContains(newSessionText, "secret-value")
+	assert.NotContains(scriptText, "argv-visible-value")
+	assert.NotContains(scriptText, "secret-value")
 }
 
 func TestTmuxLauncherShellPolicyPreservesCustomEnvByKey(t *testing.T) {
@@ -150,4 +164,28 @@ func readNullArgvRecord(t *testing.T, path string) [][]string {
 		i += count
 	}
 	return records
+}
+
+func requireNewSessionPaneScript(t *testing.T, newSession []string) string {
+	t.Helper()
+	require.NotEmpty(t, newSession)
+	command := newSession[len(newSession)-1]
+	for i, arg := range newSession {
+		if arg == ";" && i > 0 {
+			command = newSession[i-1]
+			break
+		}
+	}
+	return requireTmuxPaneScript(t, command)
+}
+
+func requireTmuxPaneScript(t *testing.T, command string) string {
+	t.Helper()
+	words, err := shellquote.Split(command)
+	require.NoError(t, err)
+	require.Len(t, words, 2)
+	require.Equal(t, "/bin/sh", words[0])
+	data, err := os.ReadFile(words[1])
+	require.NoError(t, err)
+	return string(data)
 }

--- a/scripts/e2e/fleet/docker-compose.yml
+++ b/scripts/e2e/fleet/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     build:
       context: ../../..
       dockerfile: Dockerfile.dev
+      args:
+        MIDDLEMAN_GO_BUILD_TAGS: kit_posthog_disabled
     command: ["./scripts/e2e/fleet/run-daemon.sh", "hub"]
     environment:
       MIDDLEMAN_GITHUB_TOKEN_UNSET_FOR_FLEET_E2E: ""
@@ -22,6 +24,8 @@ services:
     build:
       context: ../../..
       dockerfile: Dockerfile.dev
+      args:
+        MIDDLEMAN_GO_BUILD_TAGS: kit_posthog_disabled
     command: ["./scripts/e2e/fleet/run-daemon.sh", "member"]
     environment:
       MIDDLEMAN_GITHUB_TOKEN_UNSET_FOR_FLEET_E2E: ""
@@ -37,6 +41,8 @@ services:
     build:
       context: ../../..
       dockerfile: Dockerfile.dev
+      args:
+        MIDDLEMAN_GO_BUILD_TAGS: kit_posthog_disabled
     command: ["./scripts/e2e/fleet/run-daemon.sh", "member-ssh"]
     environment:
       MIDDLEMAN_GITHUB_TOKEN_UNSET_FOR_FLEET_E2E: ""

--- a/scripts/e2e/fleet/docker-compose.yml
+++ b/scripts/e2e/fleet/docker-compose.yml
@@ -3,10 +3,9 @@ services:
     build:
       context: ../../..
       dockerfile: Dockerfile.dev
-      args:
-        MIDDLEMAN_GO_BUILD_TAGS: kit_posthog_disabled
     command: ["./scripts/e2e/fleet/run-daemon.sh", "hub"]
     environment:
+      MIDDLEMAN_GO_BUILD_TAGS: kit_posthog_disabled
       MIDDLEMAN_GITHUB_TOKEN_UNSET_FOR_FLEET_E2E: ""
       MIDDLEMAN_FLEET_HOST_PORT: "${MIDDLEMAN_FLEET_HUB_PORT:-18091}"
     expose:
@@ -24,10 +23,9 @@ services:
     build:
       context: ../../..
       dockerfile: Dockerfile.dev
-      args:
-        MIDDLEMAN_GO_BUILD_TAGS: kit_posthog_disabled
     command: ["./scripts/e2e/fleet/run-daemon.sh", "member"]
     environment:
+      MIDDLEMAN_GO_BUILD_TAGS: kit_posthog_disabled
       MIDDLEMAN_GITHUB_TOKEN_UNSET_FOR_FLEET_E2E: ""
     expose:
       - "18091"
@@ -41,10 +39,9 @@ services:
     build:
       context: ../../..
       dockerfile: Dockerfile.dev
-      args:
-        MIDDLEMAN_GO_BUILD_TAGS: kit_posthog_disabled
     command: ["./scripts/e2e/fleet/run-daemon.sh", "member-ssh"]
     environment:
+      MIDDLEMAN_GO_BUILD_TAGS: kit_posthog_disabled
       MIDDLEMAN_GITHUB_TOKEN_UNSET_FOR_FLEET_E2E: ""
     expose:
       - "22"

--- a/scripts/e2e/fleet/run-daemon.sh
+++ b/scripts/e2e/fleet/run-daemon.sh
@@ -77,7 +77,7 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
-go build -o "${binary}" ./cmd/middleman
+go build -tags middleman_no_telemetry -o "${binary}" ./cmd/middleman
 
 "${binary}" serve --config "${config}" &
 middleman_pid=$!

--- a/scripts/e2e/fleet/run-daemon.sh
+++ b/scripts/e2e/fleet/run-daemon.sh
@@ -77,7 +77,7 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
-go build -tags middleman_no_telemetry -o "${binary}" ./cmd/middleman
+go build -tags kit_posthog_disabled -o "${binary}" ./cmd/middleman
 
 "${binary}" serve --config "${config}" &
 middleman_pid=$!

--- a/scripts/e2e/fleet/run-daemon.sh
+++ b/scripts/e2e/fleet/run-daemon.sh
@@ -77,7 +77,11 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
-go build -tags kit_posthog_disabled -o "${binary}" ./cmd/middleman
+go_build_args=(-o "${binary}")
+if [[ -n "${MIDDLEMAN_GO_BUILD_TAGS:-}" ]]; then
+  go_build_args=(-tags "${MIDDLEMAN_GO_BUILD_TAGS}" "${go_build_args[@]}")
+fi
+go build "${go_build_args[@]}" ./cmd/middleman
 
 "${binary}" serve --config "${config}" &
 middleman_pid=$!


### PR DESCRIPTION
Fleet federation container fixtures run real middleman daemons and were able to show up as Linux active users in PostHog. This keeps those test binaries out of production telemetry by wiring the existing `kit_posthog_disabled` tag into the fleet compose runtime environment.

The fleet daemon entrypoint builds the middleman binary when each container starts, so the tag must be present at container runtime even when Compose reuses an existing image. Each fleet service now sets `MIDDLEMAN_GO_BUILD_TAGS=kit_posthog_disabled` in its `environment` block, and the entrypoint consumes that value when running `go build`.