### PR TITLE
fix: keep filtered diff scrolling local

### DIFF
--- a/frontend/src/lib/components/settings/RepoSettings.test.ts
+++ b/frontend/src/lib/components/settings/RepoSettings.test.ts
@@ -408,6 +408,7 @@ describe("RepoSettings", () => {
         renderer: "xterm",
       },
       agents: [],
+      fleet: defaultFleetSettings(),
     });
     mockUpdateRepoWorktreeBasePath.mockResolvedValue({
       repos: promotedRepos,
@@ -431,6 +432,7 @@ describe("RepoSettings", () => {
         renderer: "xterm",
       },
       agents: [],
+      fleet: defaultFleetSettings(),
     });
 
     render(RepoSettings, {
@@ -603,6 +605,7 @@ describe("RepoSettings", () => {
         renderer: "xterm",
       },
       agents: [],
+      fleet: defaultFleetSettings(),
     });
     mockUpdateRepoWorktreeBasePath.mockRejectedValue(new Error("path does not exist"));
     mockRemoveRepo.mockResolvedValue();

--- a/frontend/src/lib/stores/diff.svelte.test.ts
+++ b/frontend/src/lib/stores/diff.svelte.test.ts
@@ -835,6 +835,27 @@ describe("createDiffStore loadDiff", () => {
     ]);
   });
 
+  it("reveals active files only for explicit diff navigation", async () => {
+    const store = createDiffStore({ client: testClient() });
+
+    expect(store.getActiveFileRevealKey()).toBe(0);
+
+    store.setActiveFile("a.ts");
+
+    expect(store.getActiveFile()).toBe("a.ts");
+    expect(store.getActiveFileRevealKey()).toBe(0);
+
+    store.requestScrollToFile("b.ts");
+
+    expect(store.getActiveFile()).toBe("b.ts");
+    expect(store.getActiveFileRevealKey()).toBe(1);
+
+    store.requestScrollToLine("c.ts", 12);
+
+    expect(store.getActiveFile()).toBe("c.ts");
+    expect(store.getActiveFileRevealKey()).toBe(2);
+  });
+
   it("uses the workspace diff whitespace count", async () => {
     const files = makeFilesResult(["a.ts", "whitespace.ts"], {
       whitespace_only_count: 7,

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -622,6 +622,28 @@ async function clickTreeFileItem(pageOrLocator: Page | ReturnType<Page["locator"
   await expect(item).toHaveAttribute("aria-selected", "true");
 }
 
+async function jumpToFile(page: Page, path: string): Promise<void> {
+  await page.getByRole("button", { name: "Jump to file" }).click();
+  const menu = page.locator(".file-jump-menu");
+  await expect(menu).toBeVisible();
+  await menu.getByRole("searchbox", { name: "Jump to file" }).fill(path);
+  await menu.locator(".file-jump-option").first().click();
+  await expect(menu).toBeHidden();
+}
+
+async function scrollFileTreeToTop(page: Page): Promise<void> {
+  await page.locator(".diff-file-tree").evaluate((host) => {
+    host.scrollTop = 0;
+    const root = host.shadowRoot;
+    if (!root) return;
+    for (const element of root.querySelectorAll<HTMLElement>("*")) {
+      if (element.scrollHeight > element.clientHeight) {
+        element.scrollTop = 0;
+      }
+    }
+  });
+}
+
 const diffAdditionsSelector = '[data-content] [data-line-type="change-addition"]';
 const diffDeletionsSelector = '[data-content] [data-line-type="change-deletion"]';
 const diffContextSelector = '[data-content] [data-line-type="context"]';
@@ -1634,6 +1656,64 @@ test.describe("diff view", () => {
     await expect.poll(() => mainArea.evaluate((el) => Math.round(el.scrollTop))).toBe(0);
   });
 
+  test("diff pane boundary wheel events do not scroll the outer detail frame", async ({ page }) => {
+    await mockDiffApi(page, largeDiff);
+    await navigateToDiff(page);
+    await waitForDiffLoaded(page);
+    await waitForSidebarFilesLoaded(page);
+
+    const mainArea = page.locator(".main-area");
+    const diffArea = page.locator(".diff-area");
+    await page.evaluate(() => {
+      document.documentElement.style.overflow = "hidden";
+      document.body.style.overflow = "hidden";
+    });
+    await mainArea.evaluate((area) => {
+      area.style.overflowY = "auto";
+      area.style.overflowAnchor = "none";
+      const filesView = area.firstElementChild;
+      if (!(filesView instanceof HTMLElement)) throw new Error("missing files view");
+      const frameHeight = Math.round(area.getBoundingClientRect().height);
+      filesView.style.flex = `0 0 ${frameHeight}px`;
+      filesView.style.minHeight = `${frameHeight}px`;
+      const topSpacer = document.createElement("div");
+      topSpacer.dataset.testid = "overscroll-top-spacer";
+      topSpacer.setAttribute("aria-hidden", "true");
+      topSpacer.style.flexShrink = "0";
+      topSpacer.style.height = "180px";
+      area.insertBefore(topSpacer, area.firstElementChild);
+      const bottomSpacer = document.createElement("div");
+      bottomSpacer.dataset.testid = "overscroll-bottom-spacer";
+      bottomSpacer.setAttribute("aria-hidden", "true");
+      bottomSpacer.style.flexShrink = "0";
+      bottomSpacer.style.height = "1200px";
+      area.appendChild(bottomSpacer);
+    });
+    await expect.poll(async () => mainArea.evaluate((area) => area.scrollHeight > area.clientHeight)).toBe(true);
+    const pinnedFrameScrollTop = await mainArea.evaluate((area) => {
+      area.scrollTop = 180;
+      return Math.round(area.scrollTop);
+    });
+    expect(pinnedFrameScrollTop).toBeGreaterThan(0);
+    await expect(diffArea).toBeVisible();
+
+    await diffArea.evaluate((area) => {
+      area.scrollTop = 0;
+    });
+    await diffArea.hover();
+    await page.mouse.wheel(0, -900);
+    await expect.poll(async () => mainArea.evaluate((area) => Math.round(area.scrollTop))).toBe(pinnedFrameScrollTop);
+
+    const bottomScrollTop = await diffArea.evaluate((area) => {
+      area.scrollTop = area.scrollHeight - area.clientHeight;
+      return Math.round(area.scrollTop);
+    });
+    expect(bottomScrollTop).toBeGreaterThan(0);
+    await diffArea.hover();
+    await page.mouse.wheel(0, 900);
+    await expect.poll(async () => mainArea.evaluate((area) => Math.round(area.scrollTop))).toBe(pinnedFrameScrollTop);
+  });
+
   test("sidebar jump to the last file preserves expanded body space above it", async ({ page }) => {
     await mockDiffApi(page, largeDiff);
     await navigateToDiff(page);
@@ -2589,6 +2669,40 @@ test.describe("diff view", () => {
     // Clearing filter restores full list.
     await filterInput.fill("");
     await expect(treeFileItems(page)).toHaveCount(50);
+  });
+
+  test("filtered file tree consumes hidden explicit file jumps without revealing stale rows", async ({ page }) => {
+    const targetPath = "src/pkg8/file_40.go";
+    await mockDiffApi(page, largeDiff);
+    await navigateToDiff(page);
+    await waitForDiffLoaded(page);
+    await waitForSidebarFilesLoaded(page);
+
+    const filterInput = page.locator(".diff-files-filter__input").first();
+    await filterInput.fill("file_1");
+    await expect(treeFileItems(page)).toHaveCount(11);
+    await expect(treeFileItem(page, targetPath)).toHaveCount(0);
+
+    await jumpToFile(page, targetPath);
+    await expect(page.locator(`[data-file-path="${targetPath}"]`)).toBeVisible();
+    await expect(treeFileItem(page, targetPath)).toHaveCount(0);
+    await expect(page.locator(".diff-file-tree [data-item-type='file'][aria-selected='true']")).toHaveCount(0);
+
+    await filterInput.fill("");
+    await expect(treeFileItems(page)).toHaveCount(50);
+    const targetTreeItem = treeFileItem(page, targetPath);
+    await expect(targetTreeItem).toHaveAttribute("aria-selected", "true");
+    await scrollFileTreeToTop(page);
+    expect(
+      await targetTreeItem.evaluate((item) => {
+        const rect = item.getBoundingClientRect();
+        return rect.bottom > 0 && rect.top < window.innerHeight;
+      }),
+    ).toBe(false);
+
+    await jumpToFile(page, targetPath);
+    await expect(targetTreeItem).toHaveAttribute("aria-selected", "true");
+    await expect(targetTreeItem).toBeInViewport();
   });
 
   test("inline file filter is hidden for small diffs", async ({ page }) => {

--- a/internal/server/e2etest/sync_cooldown_test.go
+++ b/internal/server/e2etest/sync_cooldown_test.go
@@ -563,7 +563,7 @@ func waitForRepoSynced(
 		}
 		repo = got
 		return true
-	}, 2*time.Second, 10*time.Millisecond)
+	}, 5*time.Second, 10*time.Millisecond)
 
 	return repo
 }

--- a/packages/ui/src/components/diff/DiffSidebar.svelte
+++ b/packages/ui/src/components/diff/DiffSidebar.svelte
@@ -49,6 +49,7 @@
   });
   const filteredDiffFiles = $derived(filteredFileList?.files ?? null);
   const activeFile = $derived(diff.getActiveFile());
+  const activeFileRevealKey = $derived(diff.getActiveFileRevealKey());
 </script>
 
 {#if showCommits}
@@ -71,6 +72,7 @@
     <PierreFileTree
       files={filteredDiffFiles}
       selectedPath={activeFile}
+      selectedPathRevealKey={activeFileRevealKey}
       onSelect={handleTreeSelection}
     />
   {/if}

--- a/packages/ui/src/components/diff/DiffSidebar.test.ts
+++ b/packages/ui/src/components/diff/DiffSidebar.test.ts
@@ -195,6 +195,32 @@ describe("DiffSidebar", () => {
     }
   });
 
+  it("scrolls the selected file tree row into view when mounted with a pending reveal key", async () => {
+    const files = Array.from({ length: 12 }, (_, i) => makeFile(`src/file-${i}.ts`));
+    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+    const scrolledPaths: string[] = [];
+    HTMLElement.prototype.scrollIntoView = function scrollIntoView() {
+      scrolledPaths.push(this.dataset.itemPath ?? "");
+    };
+
+    try {
+      render(PierreFileTree, {
+        props: {
+          files,
+          selectedPath: "src/file-8.ts",
+          selectedPathRevealKey: 1,
+        },
+      });
+
+      await findTreeItem("src/file-8.ts");
+      await waitFor(() => {
+        expect(scrolledPaths).toContain("src/file-8.ts");
+      });
+    } finally {
+      HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+    }
+  });
+
   it("does not reuse a stale reveal key after the selected path was filtered out", async () => {
     const files = [makeFile("src/file-0.ts"), makeFile("src/file-8.ts")];
     const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;

--- a/packages/ui/src/components/diff/DiffSidebar.test.ts
+++ b/packages/ui/src/components/diff/DiffSidebar.test.ts
@@ -194,4 +194,50 @@ describe("DiffSidebar", () => {
       HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
     }
   });
+
+  it("does not reuse a stale reveal key after the selected path was filtered out", async () => {
+    const files = [makeFile("src/file-0.ts"), makeFile("src/file-8.ts")];
+    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+    const scrolledPaths: string[] = [];
+    HTMLElement.prototype.scrollIntoView = function scrollIntoView() {
+      scrolledPaths.push(this.dataset.itemPath ?? "");
+    };
+
+    try {
+      const { rerender } = render(PierreFileTree, {
+        props: {
+          files,
+          selectedPath: "src/file-0.ts",
+          selectedPathRevealKey: 0,
+        },
+      });
+
+      await findTreeItem("src/file-0.ts");
+      expect(scrolledPaths).toEqual([]);
+
+      await rerender({
+        files,
+        selectedPath: "src/hidden.ts",
+        selectedPathRevealKey: 1,
+      });
+
+      expect(treeRoot()?.querySelector('[data-item-path="src/hidden.ts"]')).toBeNull();
+      expect(scrolledPaths).toEqual([]);
+
+      await rerender({
+        files,
+        selectedPath: "src/file-8.ts",
+        selectedPathRevealKey: 1,
+      });
+
+      await waitFor(() => {
+        expect(treeRoot()?.querySelector('[data-item-path="src/file-8.ts"]')?.getAttribute("aria-selected")).toBe(
+          "true",
+        );
+      });
+      expect(scrolledPaths).toEqual([]);
+    } finally {
+      HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+    }
+  });
 });

--- a/packages/ui/src/components/diff/DiffSidebar.test.ts
+++ b/packages/ui/src/components/diff/DiffSidebar.test.ts
@@ -39,6 +39,7 @@ function makeDiffStore(files: DiffFile[], overrides: Partial<DiffStore> = {}): D
     getFileList: () => fileList,
     isFileListLoading: () => false,
     getActiveFile: () => files[0]?.path ?? null,
+    getActiveFileRevealKey: () => 0,
     requestScrollToFile: vi.fn(),
     ...overrides,
   } as unknown as DiffStore;
@@ -124,7 +125,7 @@ describe("DiffSidebar", () => {
     });
   });
 
-  it("scrolls the selected file tree row into view when active path changes", async () => {
+  it("selects active path changes without scrolling the file tree", async () => {
     const files = Array.from({ length: 12 }, (_, i) => makeFile(`src/file-${i}.ts`));
     const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
     const scrolledPaths: string[] = [];
@@ -141,14 +142,48 @@ describe("DiffSidebar", () => {
       });
 
       await findTreeItem("src/file-0.ts");
-      await waitFor(() => {
-        expect(scrolledPaths).toContain("src/file-0.ts");
-      });
-      scrolledPaths.length = 0;
+      expect(scrolledPaths).toEqual([]);
 
       await rerender({
         files,
         selectedPath: "src/file-8.ts",
+      });
+
+      await waitFor(() => {
+        expect(treeRoot()?.querySelector('[data-item-path="src/file-8.ts"]')?.getAttribute("aria-selected")).toBe(
+          "true",
+        );
+      });
+      expect(scrolledPaths).toEqual([]);
+    } finally {
+      HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+    }
+  });
+
+  it("scrolls the selected file tree row into view when reveal key changes", async () => {
+    const files = Array.from({ length: 12 }, (_, i) => makeFile(`src/file-${i}.ts`));
+    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+    const scrolledPaths: string[] = [];
+    HTMLElement.prototype.scrollIntoView = function scrollIntoView() {
+      scrolledPaths.push(this.dataset.itemPath ?? "");
+    };
+
+    try {
+      const { rerender } = render(PierreFileTree, {
+        props: {
+          files,
+          selectedPath: "src/file-0.ts",
+          selectedPathRevealKey: 0,
+        },
+      });
+
+      await findTreeItem("src/file-0.ts");
+      expect(scrolledPaths).toEqual([]);
+
+      await rerender({
+        files,
+        selectedPath: "src/file-8.ts",
+        selectedPathRevealKey: 1,
       });
 
       await findTreeItem("src/file-8.ts");

--- a/packages/ui/src/components/diff/DiffView.svelte
+++ b/packages/ui/src/components/diff/DiffView.svelte
@@ -483,8 +483,27 @@
     onScrollTopChange?.(area.scrollTop);
   }
 
-  function onDiffUserScrollIntent(): void {
+  function shouldContainWheelAtDiffBoundary(
+    event: WheelEvent,
+    area: HTMLElement,
+  ): boolean {
+    if (event.deltaY === 0) return false;
+
+    const maxScrollTop = Math.max(0, area.scrollHeight - area.clientHeight);
+    if (maxScrollTop === 0) return true;
+    if (event.deltaY < 0) return area.scrollTop <= 0;
+    return area.scrollTop >= maxScrollTop - 1;
+  }
+
+  function onDiffUserScrollIntent(event: Event): void {
     cancelProgrammaticScrollIfUserOverrides();
+    if (!(event instanceof WheelEvent)) return;
+
+    const area = event.currentTarget instanceof HTMLElement
+      ? event.currentTarget
+      : diffArea;
+    if (!area || !shouldContainWheelAtDiffBoundary(event, area)) return;
+    event.preventDefault();
   }
 
   function handlePageKeydown(e: KeyboardEvent): boolean {
@@ -546,7 +565,7 @@
     if (!area) return;
 
     area.tabIndex = -1;
-    area.addEventListener("wheel", onDiffUserScrollIntent);
+    area.addEventListener("wheel", onDiffUserScrollIntent, { passive: false });
     area.addEventListener("touchstart", onDiffUserScrollIntent);
     area.addEventListener("pointerdown", onDiffUserScrollIntent);
     area.addEventListener("keydown", handleDiffAreaKeydown);

--- a/packages/ui/src/components/diff/DiffView.svelte
+++ b/packages/ui/src/components/diff/DiffView.svelte
@@ -590,6 +590,7 @@
           role="region"
           aria-label="Changed file diffs"
           style:tab-size={tabWidth}
+          style:overscroll-behavior="contain"
         >
           <div class="diff-content" bind:this={diffContent}>
             {#if visibleFiles.length === 0}

--- a/packages/ui/src/components/diff/DiffView.test.ts
+++ b/packages/ui/src/components/diff/DiffView.test.ts
@@ -218,6 +218,14 @@ describe("DiffView", () => {
     expect(clearScrolling).toHaveBeenCalledOnce();
   });
 
+  it("contains wheel overscroll at diff pane boundaries", () => {
+    const diff = makeDiffStore();
+    const { container } = renderDiffView(diff);
+    const diffArea = container.querySelector(".diff-area") as HTMLDivElement;
+
+    expect(diffArea.style.overscrollBehavior).toBe("contain");
+  });
+
   it("keeps a scroll target pending until the file is rendered", async () => {
     const consumeScrollTarget = vi.fn();
     const diff = makeDiffStore({

--- a/packages/ui/src/components/diff/DiffView.test.ts
+++ b/packages/ui/src/components/diff/DiffView.test.ts
@@ -218,12 +218,36 @@ describe("DiffView", () => {
     expect(clearScrolling).toHaveBeenCalledOnce();
   });
 
-  it("contains wheel overscroll at diff pane boundaries", () => {
+  it("contains wheel overscroll at diff pane boundaries", async () => {
     const diff = makeDiffStore();
     const { container } = renderDiffView(diff);
     const diffArea = container.querySelector(".diff-area") as HTMLDivElement;
+    Object.defineProperty(diffArea, "clientHeight", {
+      configurable: true,
+      value: 400,
+    });
+    Object.defineProperty(diffArea, "scrollHeight", {
+      configurable: true,
+      value: 2_000,
+    });
+    await Promise.resolve();
 
     expect(diffArea.style.overscrollBehavior).toBe("contain");
+
+    diffArea.scrollTop = 0;
+    const topEvent = new WheelEvent("wheel", { deltaY: -120, cancelable: true });
+    diffArea.dispatchEvent(topEvent);
+    expect(topEvent.defaultPrevented).toBe(true);
+
+    diffArea.scrollTop = 400;
+    const middleEvent = new WheelEvent("wheel", { deltaY: 120, cancelable: true });
+    diffArea.dispatchEvent(middleEvent);
+    expect(middleEvent.defaultPrevented).toBe(false);
+
+    diffArea.scrollTop = 1_600;
+    const bottomEvent = new WheelEvent("wheel", { deltaY: 120, cancelable: true });
+    diffArea.dispatchEvent(bottomEvent);
+    expect(bottomEvent.defaultPrevented).toBe(true);
   });
 
   it("keeps a scroll target pending until the file is rendered", async () => {

--- a/packages/ui/src/components/diff/PierreFileTree.svelte
+++ b/packages/ui/src/components/diff/PierreFileTree.svelte
@@ -124,20 +124,22 @@
         tree.getItem(selected)?.deselect();
       }
     }
-    if (selectedPath && tree.getItem(selectedPath)) {
-      tree.getItem(selectedPath)?.select();
-      revealSelectedPathIfRequested(selectedPath);
+    const selectedItem = selectedPath ? tree.getItem(selectedPath) : undefined;
+    if (selectedItem) {
+      selectedItem.select();
     }
+    revealSelectedPathIfRequested(selectedPath, !!selectedItem);
     syncingSelection = false;
   }
 
-  function revealSelectedPathIfRequested(path: string): void {
+  function revealSelectedPathIfRequested(path: string | null, canRevealPath: boolean): void {
     if (lastSelectedPathRevealKey === null) {
       lastSelectedPathRevealKey = selectedPathRevealKey;
       return;
     }
     if (selectedPathRevealKey === lastSelectedPathRevealKey) return;
     lastSelectedPathRevealKey = selectedPathRevealKey;
+    if (!path || !canRevealPath) return;
     tree?.focusNearestPath(path);
     scheduleSelectedPathIntoView(path);
   }

--- a/packages/ui/src/components/diff/PierreFileTree.svelte
+++ b/packages/ui/src/components/diff/PierreFileTree.svelte
@@ -9,6 +9,7 @@
   interface Props {
     files: readonly DiffFile[] | null | undefined;
     selectedPath?: string | null;
+    selectedPathRevealKey?: number;
     ariaLabel?: string;
     onSelect?: (path: string) => void;
   }
@@ -16,6 +17,7 @@
   const {
     files,
     selectedPath = null,
+    selectedPathRevealKey = 0,
     ariaLabel = "Changed files",
     onSelect,
   }: Props = $props();
@@ -25,6 +27,7 @@
   let renderedTreeKey = "";
   let syncingSelection = false;
   let selectedPathScrollFrame = 0;
+  let lastSelectedPathRevealKey: number | null = null;
 
   const safeFiles = $derived(files ?? []);
   const treePaths = $derived(safeFiles.map((file) => file.path));
@@ -123,10 +126,20 @@
     }
     if (selectedPath && tree.getItem(selectedPath)) {
       tree.getItem(selectedPath)?.select();
-      tree.focusNearestPath(selectedPath);
-      scheduleSelectedPathIntoView(selectedPath);
+      revealSelectedPathIfRequested(selectedPath);
     }
     syncingSelection = false;
+  }
+
+  function revealSelectedPathIfRequested(path: string): void {
+    if (lastSelectedPathRevealKey === null) {
+      lastSelectedPathRevealKey = selectedPathRevealKey;
+      return;
+    }
+    if (selectedPathRevealKey === lastSelectedPathRevealKey) return;
+    lastSelectedPathRevealKey = selectedPathRevealKey;
+    tree?.focusNearestPath(path);
+    scheduleSelectedPathIntoView(path);
   }
 
   function scheduleSelectedPathIntoView(path: string): void {

--- a/packages/ui/src/components/diff/PierreFileTree.svelte
+++ b/packages/ui/src/components/diff/PierreFileTree.svelte
@@ -133,12 +133,10 @@
   }
 
   function revealSelectedPathIfRequested(path: string | null, canRevealPath: boolean): void {
-    if (lastSelectedPathRevealKey === null) {
-      lastSelectedPathRevealKey = selectedPathRevealKey;
-      return;
-    }
-    if (selectedPathRevealKey === lastSelectedPathRevealKey) return;
+    const isInitialSync = lastSelectedPathRevealKey === null;
+    if (!isInitialSync && selectedPathRevealKey === lastSelectedPathRevealKey) return;
     lastSelectedPathRevealKey = selectedPathRevealKey;
+    if (selectedPathRevealKey === 0) return;
     if (!path || !canRevealPath) return;
     tree?.focusNearestPath(path);
     scheduleSelectedPathIntoView(path);

--- a/packages/ui/src/stores/diff.svelte.ts
+++ b/packages/ui/src/stores/diff.svelte.ts
@@ -154,6 +154,7 @@ export function createDiffStore(opts?: DiffStoreOptions) {
   let viewMode = $state<DiffViewMode>(loadDiffViewMode());
   let collapsedFiles = $state<Record<string, string[]>>(loadCollapsedFiles());
   let activeFile = $state<string | null>(null);
+  let activeFileRevealKey = $state(0);
   let scrollTarget = $state<DiffScrollTarget | null>(null);
   let scrolling = $state(false);
   let fileCategoryFilter = $state<DiffFileCategoryFilter>("all");
@@ -268,6 +269,9 @@ export function createDiffStore(opts?: DiffStoreOptions) {
   function getActiveFile(): string | null {
     return activeFile;
   }
+  function getActiveFileRevealKey(): number {
+    return activeFileRevealKey;
+  }
   function isScrolling(): boolean {
     return scrolling;
   }
@@ -325,12 +329,14 @@ export function createDiffStore(opts?: DiffStoreOptions) {
 
   function requestScrollToFile(path: string): void {
     activeFile = path;
+    activeFileRevealKey += 1;
     scrolling = true;
     scrollTarget = { path };
   }
 
   function requestScrollToLine(path: string, line: number, side: "left" | "right" = "right"): void {
     activeFile = path;
+    activeFileRevealKey += 1;
     scrolling = true;
     scrollTarget = { path, line, side };
   }
@@ -1138,6 +1144,7 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     getViewMode,
     getFileCategoryFilter,
     getActiveFile,
+    getActiveFileRevealKey,
     setActiveFile,
     setFileCategoryFilter,
     isScrolling,


### PR DESCRIPTION
Passive scrolling in the PR diff should update the current-file highlight without treating that highlight update as a command to reveal and focus rows in the file tree. Under file-category filters like Code, that coupling made normal wheel scrolling look like the diff was reloading or remounting even though no new diff data was needed.

This keeps the diff pane scrollable, keeps the filtered tree and diff body aligned, and reserves file-tree reveal behavior for explicit navigation such as sidebar selection, keyboard file jumps, or line jumps.

Validation: full frontend unit suite, UI package check, Svelte analyzer on touched files, and live Chrome verification of Code-filter wheel scrolling with no extra diff/files requests, route changes, remounts, or file-tree reveal calls.

Visual capture was kept local because the available reproduction uses live middleman data and the screenshot upload policy requires explicit approval before attaching live captures.