### PR TITLE
fix: clarify eager refresh budget display

### DIFF
--- a/frontend/src/lib/components/layout/BudgetBars.svelte
+++ b/frontend/src/lib/components/layout/BudgetBars.svelte
@@ -95,7 +95,7 @@
 
   {#if b.hasAny}
     <span class="budget-count" style:color={syncBudgetColor(b.spent, b.limit)}>
-      {formatCompact(b.spent)} / {formatCompact(b.limit)} sync req/hr
+      Eager {formatCompact(b.spent)} / {formatCompact(b.limit)}
     </span>
   {/if}
 </button>

--- a/frontend/src/lib/components/layout/BudgetBars.svelte
+++ b/frontend/src/lib/components/layout/BudgetBars.svelte
@@ -95,7 +95,7 @@
 
   {#if b.hasAny}
     <span class="budget-count" style:color={syncBudgetColor(b.spent, b.limit)}>
-      Eager {formatCompact(b.spent)} / {formatCompact(b.limit)}
+      Refresh {formatCompact(b.spent)} / {formatCompact(b.limit)}
     </span>
   {/if}
 </button>

--- a/frontend/src/lib/components/layout/BudgetBars.svelte
+++ b/frontend/src/lib/components/layout/BudgetBars.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { RateLimitHostStatus } from "@middleman/ui/api/types";
-  import { budgetColor, worstCaseRatio, aggregateBudget } from "./budget-utils";
+  import { aggregateBudget, budgetColor, formatCompact, syncBudgetColor, worstCaseRatio } from "./budget-utils";
 
   interface Props {
     hosts: Record<string, RateLimitHostStatus>;
@@ -94,7 +94,9 @@
   </span>
 
   {#if b.hasAny}
-    <span class="budget-count">{b.spent} req/hr</span>
+    <span class="budget-count" style:color={syncBudgetColor(b.spent, b.limit)}>
+      {formatCompact(b.spent)} / {formatCompact(b.limit)} sync req/hr
+    </span>
   {/if}
 </button>
 

--- a/frontend/src/lib/components/layout/BudgetBars.svelte
+++ b/frontend/src/lib/components/layout/BudgetBars.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { RateLimitHostStatus } from "@middleman/ui/api/types";
-  import { aggregateBudget, budgetColor, formatCompact, syncBudgetColor, worstCaseRatio } from "./budget-utils";
+  import { budgetColor, worstCaseRatio } from "./budget-utils";
 
   interface Props {
     hosts: Record<string, RateLimitHostStatus>;
@@ -43,13 +43,8 @@
     return budgetColor(ratio);
   }
 
-  function budget() {
-    return aggregateBudget(Object.values(hosts));
-  }
-
   const rr = $derived(restRatio());
   const gr = $derived(gqlRatio());
-  const b = $derived(budget());
   const paused = $derived(anyPaused());
 </script>
 
@@ -92,12 +87,6 @@
       {/if}
     </span>
   </span>
-
-  {#if b.hasAny}
-    <span class="budget-count" style:color={syncBudgetColor(b.spent, b.limit)}>
-      Refresh {formatCompact(b.spent)} / {formatCompact(b.limit)}
-    </span>
-  {/if}
 </button>
 
 <style>
@@ -147,9 +136,5 @@
     height: 100%;
     border-radius: 2px;
     transition: width 0.5s ease;
-  }
-  .budget-count {
-    color: var(--budget-blue);
-    font-size: var(--font-size-2xs);
   }
 </style>

--- a/frontend/src/lib/components/layout/BudgetPopover.svelte
+++ b/frontend/src/lib/components/layout/BudgetPopover.svelte
@@ -157,9 +157,14 @@
               class:budget-spent--over={h.budget_spent > h.budget_limit}
               style:color={syncBudgetColor(h.budget_spent, h.budget_limit)}
             >{formatCompact(h.budget_spent)}</span> / {formatCompact(h.budget_limit)} <span class="row-unit">budgeted req/hr</span>
-            {#if h.budget_spent > h.budget_limit}<span class="row-reset"> · eager refresh deferred</span>{/if}
           </span>
-          <span class="row-note">Optional detail, comment, and backfill refreshes pause when spent.</span>
+          <span class="row-note">
+            {#if h.budget_spent > h.budget_limit}
+              Details, comments, and backfills are paused.
+            {:else}
+              Details, comments, and backfills pause when spent.
+            {/if}
+          </span>
         </div>
       {/if}
 
@@ -261,10 +266,10 @@
   .row-note {
     display: block;
     grid-column: 3;
-    margin-top: 2px;
+    margin-top: 1px;
     color: var(--text-muted);
     font-size: 0.9em;
-    line-height: 1.25;
+    line-height: 1.2;
   }
   .row-unknown {
     color: var(--text-muted);

--- a/frontend/src/lib/components/layout/BudgetPopover.svelte
+++ b/frontend/src/lib/components/layout/BudgetPopover.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { RateLimitHostStatus } from "@middleman/ui/api/types";
-  import { budgetColor, formatCompact } from "./budget-utils";
+  import { budgetColor, formatCompact, syncBudgetColor } from "./budget-utils";
 
   interface Props {
     hosts: Record<string, RateLimitHostStatus>;
@@ -81,7 +81,7 @@
 >
   <div class="popover-header">API Budget</div>
 
-  {#each hostEntries() as [hostname, h], i}
+  {#each hostEntries() as [hostname, h], i (hostname)}
     {#if i > 0}
       <div class="popover-divider"></div>
     {/if}
@@ -149,10 +149,15 @@
       <!-- Middleman Budget -->
       {#if h.budget_limit > 0}
         <div class="budget-row">
-          <span class="row-label">Middleman</span>
+          <span class="row-label">Sync budget</span>
           <span class="row-bar-cell"></span>
           <span class="row-value">
-            <span class="budget-spent">{formatCompact(h.budget_spent)}</span> / {formatCompact(h.budget_limit)} <span class="row-unit">req/hr</span>
+            <span
+              class="budget-spent"
+              class:budget-spent--over={h.budget_spent > h.budget_limit}
+              style:color={syncBudgetColor(h.budget_spent, h.budget_limit)}
+            >{formatCompact(h.budget_spent)}</span> / {formatCompact(h.budget_limit)} <span class="row-unit">sync req/hr</span>
+            {#if h.budget_spent > h.budget_limit}<span class="row-reset"> · over budget</span>{/if}
           </span>
         </div>
       {/if}
@@ -211,7 +216,7 @@
   .budget-row {
     /* label | bar | value (with inline reset) */
     display: grid;
-    grid-template-columns: 60px 60px 1fr;
+    grid-template-columns: 72px 48px 1fr;
     align-items: center;
     column-gap: 8px;
     margin-bottom: 6px;
@@ -257,6 +262,9 @@
   .budget-spent {
     color: var(--budget-blue);
     font-weight: 600;
+  }
+  .budget-spent--over {
+    font-weight: 700;
   }
   .throttle-indicator {
     font-size: var(--font-size-2xs);

--- a/frontend/src/lib/components/layout/BudgetPopover.svelte
+++ b/frontend/src/lib/components/layout/BudgetPopover.svelte
@@ -148,7 +148,7 @@
 
       <!-- Eager refresh budget -->
       {#if h.budget_limit > 0}
-        <div class="budget-row">
+        <div class="budget-row budget-row--eager">
           <span class="row-label">Eager refresh</span>
           <span class="row-bar-cell"></span>
           <span class="row-value">
@@ -158,8 +158,8 @@
               style:color={syncBudgetColor(h.budget_spent, h.budget_limit)}
             >{formatCompact(h.budget_spent)}</span> / {formatCompact(h.budget_limit)} <span class="row-unit">budgeted req/hr</span>
             {#if h.budget_spent > h.budget_limit}<span class="row-reset"> · eager refresh deferred</span>{/if}
-            <span class="row-note">Optional detail, comment, and backfill refreshes pause when spent.</span>
           </span>
+          <span class="row-note">Optional detail, comment, and backfill refreshes pause when spent.</span>
         </div>
       {/if}
 
@@ -222,6 +222,9 @@
     column-gap: 8px;
     margin-bottom: 6px;
   }
+  .budget-row--eager {
+    align-items: start;
+  }
   .row-label {
     color: var(--text-muted);
     font-size: var(--font-size-2xs);
@@ -257,6 +260,7 @@
   }
   .row-note {
     display: block;
+    grid-column: 3;
     margin-top: 2px;
     color: var(--text-muted);
     font-size: 0.9em;

--- a/frontend/src/lib/components/layout/BudgetPopover.svelte
+++ b/frontend/src/lib/components/layout/BudgetPopover.svelte
@@ -146,18 +146,19 @@
         {/if}
       </div>
 
-      <!-- Middleman Budget -->
+      <!-- Eager refresh budget -->
       {#if h.budget_limit > 0}
         <div class="budget-row">
-          <span class="row-label">Sync budget</span>
+          <span class="row-label">Eager refresh</span>
           <span class="row-bar-cell"></span>
           <span class="row-value">
             <span
               class="budget-spent"
               class:budget-spent--over={h.budget_spent > h.budget_limit}
               style:color={syncBudgetColor(h.budget_spent, h.budget_limit)}
-            >{formatCompact(h.budget_spent)}</span> / {formatCompact(h.budget_limit)} <span class="row-unit">sync req/hr</span>
-            {#if h.budget_spent > h.budget_limit}<span class="row-reset"> · over budget</span>{/if}
+            >{formatCompact(h.budget_spent)}</span> / {formatCompact(h.budget_limit)} <span class="row-unit">budgeted req/hr</span>
+            {#if h.budget_spent > h.budget_limit}<span class="row-reset"> · eager refresh deferred</span>{/if}
+            <span class="row-note">Optional detail, comment, and backfill refreshes pause when spent.</span>
           </span>
         </div>
       {/if}
@@ -216,7 +217,7 @@
   .budget-row {
     /* label | bar | value (with inline reset) */
     display: grid;
-    grid-template-columns: 72px 48px 1fr;
+    grid-template-columns: 78px 42px 1fr;
     align-items: center;
     column-gap: 8px;
     margin-bottom: 6px;
@@ -253,6 +254,13 @@
     color: var(--text-muted);
     font-size: 0.9em;
     opacity: 0.7;
+  }
+  .row-note {
+    display: block;
+    margin-top: 2px;
+    color: var(--text-muted);
+    font-size: 0.9em;
+    line-height: 1.25;
   }
   .row-unknown {
     color: var(--text-muted);

--- a/frontend/src/lib/components/layout/StatusBar.budget.browser.svelte.ts
+++ b/frontend/src/lib/components/layout/StatusBar.budget.browser.svelte.ts
@@ -157,7 +157,8 @@ describe("budget display", () => {
     expect(units).toContain("pts");
     expect(popover.textContent).toContain("Eager refresh");
     expect(popover.textContent).toContain("42 / 500 budgeted req/hr");
-    expect(popover.textContent).toContain("Optional detail, comment, and backfill refreshes pause when spent.");
+    expect(popover.textContent).toContain("Details, comments, and backfills pause when spent.");
+    expect(popover.textContent).not.toContain("Optional");
     expect(popover.querySelector(".budget-spent")?.textContent).toBe("42");
 
     const eagerLabel = popover.querySelector<HTMLElement>(".budget-row--eager .row-label");
@@ -187,7 +188,8 @@ describe("budget display", () => {
     const spent = popover.querySelector<HTMLElement>(".budget-spent");
     expect(spent?.textContent).toBe("1.3k");
     expect(spent?.classList.contains("budget-spent--over")).toBe(true);
-    expect(popover.textContent).toContain("eager refresh deferred");
+    expect(popover.textContent).toContain("Details, comments, and backfills are paused.");
+    expect(popover.textContent).not.toContain("eager refresh deferred");
   });
 
   it("popover dismisses on Escape", async () => {

--- a/frontend/src/lib/components/layout/StatusBar.budget.browser.svelte.ts
+++ b/frontend/src/lib/components/layout/StatusBar.budget.browser.svelte.ts
@@ -142,7 +142,7 @@ describe("budget display", () => {
 
   it("budget bars show middleman count when budget enabled", async () => {
     const bars = await mountStatusBar();
-    expect(bars.textContent).toContain("Eager 42 / 500");
+    expect(bars.textContent).toContain("Refresh 42 / 500");
   });
 
   // The popover dialog exposes REST req, GraphQL pts, and the eager
@@ -157,6 +157,12 @@ describe("budget display", () => {
     expect(popover.textContent).toContain("42 / 500 budgeted req/hr");
     expect(popover.textContent).toContain("Optional detail, comment, and backfill refreshes pause when spent.");
     expect(popover.querySelector(".budget-spent")?.textContent).toBe("42");
+
+    const eagerLabel = popover.querySelector<HTMLElement>(".budget-row--eager .row-label");
+    const eagerValue = popover.querySelector<HTMLElement>(".budget-row--eager .row-value");
+    expect(eagerLabel).not.toBeNull();
+    expect(eagerValue).not.toBeNull();
+    expect(Math.abs(eagerLabel!.getBoundingClientRect().top - eagerValue!.getBoundingClientRect().top)).toBeLessThan(2);
   });
 
   it("marks sync budget spend that exceeds the configured limit", async () => {
@@ -171,7 +177,7 @@ describe("budget display", () => {
       }),
     ]);
 
-    expect(bars.textContent).toContain("Eager 1.3k / 500");
+    expect(bars.textContent).toContain("Refresh 1.3k / 500");
     const compactBudget = bars.querySelector<HTMLElement>(".budget-count");
     expect(compactBudget?.style.color).toBe("var(--budget-red)");
 
@@ -322,7 +328,7 @@ describe("budget display", () => {
     expect(bars.textContent).not.toContain("REST");
     expect(bars.textContent).toContain("--");
     // Budget count visible — budget is independent of REST rate observation
-    expect(bars.textContent).toContain("Eager 10 / 500");
+    expect(bars.textContent).toContain("Refresh 10 / 500");
   });
 
   it("stale host excluded from compact bars, fresh host drives ratio", async () => {

--- a/frontend/src/lib/components/layout/StatusBar.budget.browser.svelte.ts
+++ b/frontend/src/lib/components/layout/StatusBar.budget.browser.svelte.ts
@@ -142,19 +142,20 @@ describe("budget display", () => {
 
   it("budget bars show middleman count when budget enabled", async () => {
     const bars = await mountStatusBar();
-    expect(bars.textContent).toContain("42 / 500 sync req/hr");
+    expect(bars.textContent).toContain("Eager 42 / 500");
   });
 
-  // The popover dialog exposes REST req, GraphQL pts, and the middleman
-  // budget spend from the same payload.
+  // The popover dialog exposes REST req, GraphQL pts, and the eager
+  // refresh budget spend from the same payload.
   it("clicking budget area opens popover with per-host breakdown", async () => {
     const bars = await mountStatusBar();
     const popover = await openPopover(bars);
     const units = Array.from(popover.querySelectorAll(".row-unit")).map((el) => el.textContent?.trim());
     expect(units).toContain("req");
     expect(units).toContain("pts");
-    expect(popover.textContent).toContain("Sync budget");
-    expect(popover.textContent).toContain("42 / 500 sync req/hr");
+    expect(popover.textContent).toContain("Eager refresh");
+    expect(popover.textContent).toContain("42 / 500 budgeted req/hr");
+    expect(popover.textContent).toContain("Optional detail, comment, and backfill refreshes pause when spent.");
     expect(popover.querySelector(".budget-spent")?.textContent).toBe("42");
   });
 
@@ -170,7 +171,7 @@ describe("budget display", () => {
       }),
     ]);
 
-    expect(bars.textContent).toContain("1.3k / 500 sync req/hr");
+    expect(bars.textContent).toContain("Eager 1.3k / 500");
     const compactBudget = bars.querySelector<HTMLElement>(".budget-count");
     expect(compactBudget?.style.color).toBe("var(--budget-red)");
 
@@ -178,7 +179,7 @@ describe("budget display", () => {
     const spent = popover.querySelector<HTMLElement>(".budget-spent");
     expect(spent?.textContent).toBe("1.3k");
     expect(spent?.classList.contains("budget-spent--over")).toBe(true);
-    expect(popover.textContent).toContain("over budget");
+    expect(popover.textContent).toContain("eager refresh deferred");
   });
 
   it("popover dismisses on Escape", async () => {
@@ -321,7 +322,7 @@ describe("budget display", () => {
     expect(bars.textContent).not.toContain("REST");
     expect(bars.textContent).toContain("--");
     // Budget count visible — budget is independent of REST rate observation
-    expect(bars.textContent).toContain("10 / 500 sync req/hr");
+    expect(bars.textContent).toContain("Eager 10 / 500");
   });
 
   it("stale host excluded from compact bars, fresh host drives ratio", async () => {

--- a/frontend/src/lib/components/layout/StatusBar.budget.browser.svelte.ts
+++ b/frontend/src/lib/components/layout/StatusBar.budget.browser.svelte.ts
@@ -142,7 +142,7 @@ describe("budget display", () => {
 
   it("budget bars show middleman count when budget enabled", async () => {
     const bars = await mountStatusBar();
-    expect(bars.textContent).toContain("42 req/hr");
+    expect(bars.textContent).toContain("42 / 500 sync req/hr");
   });
 
   // The popover dialog exposes REST req, GraphQL pts, and the middleman
@@ -153,7 +153,32 @@ describe("budget display", () => {
     const units = Array.from(popover.querySelectorAll(".row-unit")).map((el) => el.textContent?.trim());
     expect(units).toContain("req");
     expect(units).toContain("pts");
+    expect(popover.textContent).toContain("Sync budget");
+    expect(popover.textContent).toContain("42 / 500 sync req/hr");
     expect(popover.querySelector(".budget-spent")?.textContent).toBe("42");
+  });
+
+  it("marks sync budget spend that exceeds the configured limit", async () => {
+    const bars = await mountStatusBar([
+      rateLimits({
+        "github.com": {
+          ...knownHost,
+          budget_limit: 500,
+          budget_spent: 1300,
+          budget_remaining: -800,
+        },
+      }),
+    ]);
+
+    expect(bars.textContent).toContain("1.3k / 500 sync req/hr");
+    const compactBudget = bars.querySelector<HTMLElement>(".budget-count");
+    expect(compactBudget?.style.color).toBe("var(--budget-red)");
+
+    const popover = await openPopover(bars);
+    const spent = popover.querySelector<HTMLElement>(".budget-spent");
+    expect(spent?.textContent).toBe("1.3k");
+    expect(spent?.classList.contains("budget-spent--over")).toBe(true);
+    expect(popover.textContent).toContain("over budget");
   });
 
   it("popover dismisses on Escape", async () => {
@@ -296,7 +321,7 @@ describe("budget display", () => {
     expect(bars.textContent).not.toContain("REST");
     expect(bars.textContent).toContain("--");
     // Budget count visible — budget is independent of REST rate observation
-    expect(bars.textContent).toContain("10 req/hr");
+    expect(bars.textContent).toContain("10 / 500 sync req/hr");
   });
 
   it("stale host excluded from compact bars, fresh host drives ratio", async () => {

--- a/frontend/src/lib/components/layout/StatusBar.budget.browser.svelte.ts
+++ b/frontend/src/lib/components/layout/StatusBar.budget.browser.svelte.ts
@@ -140,9 +140,11 @@ describe("budget display", () => {
     expect(bars.textContent).toContain("GQL");
   });
 
-  it("budget bars show middleman count when budget enabled", async () => {
+  it("budget bars keep eager refresh budget out of the compact status", async () => {
     const bars = await mountStatusBar();
-    expect(bars.textContent).toContain("Refresh 42 / 500");
+    expect(bars.textContent).not.toContain("Refresh");
+    expect(bars.textContent).not.toContain("42 / 500");
+    expect(bars.querySelector(".budget-count")).toBeNull();
   });
 
   // The popover dialog exposes REST req, GraphQL pts, and the eager
@@ -177,9 +179,9 @@ describe("budget display", () => {
       }),
     ]);
 
-    expect(bars.textContent).toContain("Refresh 1.3k / 500");
-    const compactBudget = bars.querySelector<HTMLElement>(".budget-count");
-    expect(compactBudget?.style.color).toBe("var(--budget-red)");
+    expect(bars.textContent).not.toContain("Refresh");
+    expect(bars.textContent).not.toContain("1.3k / 500");
+    expect(bars.querySelector(".budget-count")).toBeNull();
 
     const popover = await openPopover(bars);
     const spent = popover.querySelector<HTMLElement>(".budget-spent");
@@ -307,7 +309,7 @@ describe("budget display", () => {
     expect(healthDot(popover, "github.com").style.background).toBe("var(--budget-red)");
   });
 
-  it("GQL known but REST unknown still shows budget count", async () => {
+  it("GQL known but REST unknown still hides eager refresh budget from compact status", async () => {
     const bars = await mountStatusBar([
       rateLimits({
         "github.com": {
@@ -327,8 +329,14 @@ describe("budget display", () => {
     expect(bars.textContent).toContain("GQL");
     expect(bars.textContent).not.toContain("REST");
     expect(bars.textContent).toContain("--");
-    // Budget count visible — budget is independent of REST rate observation
-    expect(bars.textContent).toContain("Refresh 10 / 500");
+    // Eager refresh budget remains available in the popover, not the compact status.
+    expect(bars.textContent).not.toContain("Refresh");
+    expect(bars.textContent).not.toContain("10 / 500");
+    expect(bars.querySelector(".budget-count")).toBeNull();
+
+    const popover = await openPopover(bars);
+    expect(popover.textContent).toContain("Eager refresh");
+    expect(popover.textContent).toContain("10 / 500 budgeted req/hr");
   });
 
   it("stale host excluded from compact bars, fresh host drives ratio", async () => {

--- a/frontend/src/lib/components/layout/budget-utils.ts
+++ b/frontend/src/lib/components/layout/budget-utils.ts
@@ -10,6 +10,11 @@ export function budgetColor(ratio: number): string {
   return "var(--budget-red)";
 }
 
+export function syncBudgetColor(spent: number, limit: number): string {
+  if (limit <= 0) return "var(--text-muted)";
+  return budgetColor(Math.max((limit - spent) / limit, 0));
+}
+
 /**
  * Returns the lowest remaining/limit ratio across known hosts.
  * Returns -1 if no hosts have known data.

--- a/internal/github/budget_transport.go
+++ b/internal/github/budget_transport.go
@@ -23,8 +23,9 @@ func IsSyncBudgetContext(ctx context.Context) bool {
 // budgetTransport wraps an http.RoundTripper and increments a
 // SyncBudget for every RoundTrip invocation whose request
 // context carries the sync-budget key. This captures paginated
-// pages, 304 responses, and GraphQL calls made during background
-// sync without counting user-initiated server actions.
+// pages and GraphQL calls made during background sync without
+// counting user-initiated server actions or GitHub REST 304
+// responses that do not spend primary provider quota.
 //
 // Transparent retries inside net/http.Transport are not visible
 // to RoundTripper wrappers and are not counted.
@@ -36,8 +37,10 @@ type budgetTransport struct {
 func (t *budgetTransport) RoundTrip(
 	req *http.Request,
 ) (*http.Response, error) {
-	if IsSyncBudgetContext(req.Context()) {
+	resp, err := t.base.RoundTrip(req)
+	if IsSyncBudgetContext(req.Context()) &&
+		(resp == nil || resp.StatusCode != http.StatusNotModified) {
 		t.budget.Spend(1)
 	}
-	return t.base.RoundTrip(req)
+	return resp, err
 }

--- a/internal/github/budget_transport_test.go
+++ b/internal/github/budget_transport_test.go
@@ -31,6 +31,30 @@ func TestBudgetTransport_CountsSyncContext(t *testing.T) {
 	assert.Equal(1, budget.Spent())
 }
 
+func TestBudgetTransport_SkipsNotModifiedResponses(t *testing.T) {
+	assert := assert.New(t)
+
+	budget := NewSyncBudget(100)
+	bt := &budgetTransport{
+		base: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+			rec := httptest.NewRecorder()
+			rec.WriteHeader(http.StatusNotModified)
+			return rec.Result(), nil
+		}),
+		budget: budget,
+	}
+
+	ctx := WithSyncBudget(t.Context())
+	req, _ := http.NewRequestWithContext(
+		ctx, "GET", "https://api.github.com/repos/o/n/pulls", nil,
+	)
+	_, err := bt.RoundTrip(req)
+	require.NoError(t, err)
+
+	assert.Equal(0, budget.Spent(),
+		"304 responses should not spend sync budget")
+}
+
 func TestBudgetTransport_SkipsNonSyncContext(t *testing.T) {
 	assert := assert.New(t)
 

--- a/internal/server/e2etest/sync_routes_test.go
+++ b/internal/server/e2etest/sync_routes_test.go
@@ -2,14 +2,20 @@ package e2etest
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	Assert "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/middleman/internal/apiclient"
 	"go.kenn.io/middleman/internal/apiclient/generated"
+	ghclient "go.kenn.io/middleman/internal/github"
+	"go.kenn.io/middleman/internal/platform"
+	platformgithub "go.kenn.io/middleman/internal/platform/github"
 	"go.kenn.io/middleman/internal/server"
 	"go.kenn.io/middleman/internal/testutil/dbtest"
 )
@@ -56,4 +62,223 @@ func TestSyncRoutesWithoutProviderSyncerE2E(t *testing.T) {
 	assert.Equal(generated.ServiceUnavailable, trigger.ApplicationproblemJSONDefault.Code)
 	require.NotNil(trigger.ApplicationproblemJSONDefault.Detail)
 	assert.Equal("syncer not configured", *trigger.ApplicationproblemJSONDefault.Detail)
+}
+
+func TestSyncListNotModifiedDoesNotChangeRateLimitBudgetE2E(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	var pulls304 atomic.Int32
+	var issues304 atomic.Int32
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v3/repos/acme/widget/pulls", func(w http.ResponseWriter, r *http.Request) {
+		writeGitHubListResponse(w, r, `"pulls-v1"`, &pulls304)
+	})
+	mux.HandleFunc("/api/v3/repos/acme/widget/issues", func(w http.ResponseWriter, r *http.Request) {
+		writeGitHubListResponse(w, r, `"issues-v1"`, &issues304)
+	})
+	githubAPI := httptest.NewServer(mux)
+	defer githubAPI.Close()
+
+	database := dbtest.Open(t)
+	restTracker := ghclient.NewRateTracker(database, "github.com", "rest")
+	budget := ghclient.NewSyncBudget(2)
+	client, err := ghclient.NewClient(
+		staticTokenSource("token"),
+		"github.com",
+		restTracker,
+		budget,
+		ghclient.WithBaseURLForTesting(githubAPI.URL),
+	)
+	require.NoError(err)
+
+	registry, err := platform.NewRegistry(gitHubIndexListProvider{
+		host:   "github.com",
+		client: client,
+	})
+	require.NoError(err)
+	syncer := ghclient.NewSyncerWithRegistry(
+		registry,
+		database,
+		nil,
+		[]ghclient.RepoRef{{
+			Owner: "acme", Name: "widget",
+			PlatformHost:       "github.com",
+			PlatformRepoID:     101,
+			PlatformExternalID: "R_101",
+		}},
+		time.Minute,
+		map[string]*ghclient.RateTracker{"github.com": restTracker},
+		map[string]*ghclient.SyncBudget{"github.com": budget},
+	)
+	t.Cleanup(syncer.Stop)
+
+	srv := server.New(database, syncer, nil, "/", nil, server.ServerOptions{
+		HostCheckAllowLoopbackAnyPort: true,
+	})
+	middleman := httptest.NewServer(srv)
+	defer middleman.Close()
+
+	api, err := apiclient.NewWithHTTPClient(middleman.URL, middleman.Client())
+	require.NoError(err)
+
+	triggerSync := func() {
+		t.Helper()
+		resp, err := api.HTTP.TriggerSyncWithResponse(
+			t.Context(),
+			nil,
+			func(_ context.Context, req *http.Request) error {
+				req.Header.Set("Content-Type", "application/json")
+				return nil
+			},
+		)
+		require.NoError(err)
+		require.Equal(http.StatusAccepted, resp.StatusCode(), string(resp.Body))
+		waitForSyncIdle(t, middleman.Client(), middleman.URL)
+	}
+	budgetSpent := func() int64 {
+		t.Helper()
+		resp, err := api.HTTP.GetRateLimitsWithResponse(t.Context())
+		require.NoError(err)
+		require.Equal(http.StatusOK, resp.StatusCode(), string(resp.Body))
+		require.NotNil(resp.JSON200)
+		host, ok := resp.JSON200.Hosts["github.com"]
+		require.True(ok)
+		return host.BudgetSpent
+	}
+
+	triggerSync()
+	firstSpent := budgetSpent()
+	require.Equal(int64(2), firstSpent)
+
+	triggerSync()
+	assert.Equal(int32(1), pulls304.Load())
+	assert.Equal(int32(1), issues304.Load())
+	assert.Equal(firstSpent, budgetSpent())
+}
+
+type gitHubIndexListProvider struct {
+	host   string
+	client ghclient.Client
+}
+
+func (p gitHubIndexListProvider) Platform() platform.Kind {
+	return platform.KindGitHub
+}
+
+func (p gitHubIndexListProvider) Host() string {
+	return p.host
+}
+
+func (p gitHubIndexListProvider) Capabilities() platform.Capabilities {
+	return platform.Capabilities{
+		ReadMergeRequests: true,
+		ReadIssues:        true,
+	}
+}
+
+func (p gitHubIndexListProvider) ListOpenMergeRequests(
+	ctx context.Context,
+	ref platform.RepoRef,
+) ([]platform.MergeRequest, error) {
+	pulls, err := p.client.ListOpenPullRequests(ctx, ref.Owner, ref.Name)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]platform.MergeRequest, 0, len(pulls))
+	for _, pull := range pulls {
+		normalized, err := platformgithub.NormalizePullRequest(ref, pull)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, normalized)
+	}
+	return out, nil
+}
+
+func (p gitHubIndexListProvider) GetMergeRequest(
+	context.Context,
+	platform.RepoRef,
+	int,
+) (platform.MergeRequest, error) {
+	return platform.MergeRequest{}, platform.UnsupportedCapability(
+		platform.KindGitHub,
+		p.host,
+		"read_merge_request_detail",
+	)
+}
+
+func (p gitHubIndexListProvider) ListMergeRequestEvents(
+	context.Context,
+	platform.RepoRef,
+	int,
+) ([]platform.MergeRequestEvent, error) {
+	return nil, platform.UnsupportedCapability(
+		platform.KindGitHub,
+		p.host,
+		"read_merge_request_events",
+	)
+}
+
+func (p gitHubIndexListProvider) ListOpenIssues(
+	ctx context.Context,
+	ref platform.RepoRef,
+) ([]platform.Issue, error) {
+	issues, err := p.client.ListOpenIssues(ctx, ref.Owner, ref.Name)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]platform.Issue, 0, len(issues))
+	for _, issue := range issues {
+		normalized, err := platformgithub.NormalizeIssue(ref, issue)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, normalized)
+	}
+	return out, nil
+}
+
+func (p gitHubIndexListProvider) GetIssue(
+	context.Context,
+	platform.RepoRef,
+	int,
+) (platform.Issue, error) {
+	return platform.Issue{}, platform.UnsupportedCapability(
+		platform.KindGitHub,
+		p.host,
+		"read_issue_detail",
+	)
+}
+
+func (p gitHubIndexListProvider) ListIssueEvents(
+	context.Context,
+	platform.RepoRef,
+	int,
+) ([]platform.IssueEvent, error) {
+	return nil, platform.UnsupportedCapability(
+		platform.KindGitHub,
+		p.host,
+		"read_issue_events",
+	)
+}
+
+func writeGitHubListResponse(
+	w http.ResponseWriter,
+	r *http.Request,
+	etag string,
+	notModified *atomic.Int32,
+) {
+	w.Header().Set("X-RateLimit-Limit", "5000")
+	w.Header().Set("X-RateLimit-Remaining", "4990")
+	w.Header().Set("X-RateLimit-Reset", fmt.Sprint(time.Now().Add(time.Hour).Unix()))
+	if r.Header.Get("If-None-Match") == etag {
+		notModified.Add(1)
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("ETag", etag)
+	_, _ = w.Write([]byte(`[]`))
 }

--- a/internal/server/e2etest/sync_routes_test.go
+++ b/internal/server/e2etest/sync_routes_test.go
@@ -123,8 +123,17 @@ func TestSyncListNotModifiedDoesNotChangeRateLimitBudgetE2E(t *testing.T) {
 	api, err := apiclient.NewWithHTTPClient(middleman.URL, middleman.Client())
 	require.NoError(err)
 
+	syncLastRunAt := func() *time.Time {
+		t.Helper()
+		resp, err := api.HTTP.GetSyncStatusWithResponse(t.Context())
+		require.NoError(err)
+		require.Equal(http.StatusOK, resp.StatusCode(), string(resp.Body))
+		require.NotNil(resp.JSON200)
+		return resp.JSON200.LastRunAt
+	}
 	triggerSync := func() {
 		t.Helper()
+		before := syncLastRunAt()
 		resp, err := api.HTTP.TriggerSyncWithResponse(
 			t.Context(),
 			nil,
@@ -135,7 +144,16 @@ func TestSyncListNotModifiedDoesNotChangeRateLimitBudgetE2E(t *testing.T) {
 		)
 		require.NoError(err)
 		require.Equal(http.StatusAccepted, resp.StatusCode(), string(resp.Body))
-		waitForSyncIdle(t, middleman.Client(), middleman.URL)
+		require.Eventually(func() bool {
+			resp, err := api.HTTP.GetSyncStatusWithResponse(t.Context())
+			if err != nil || resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
+				return false
+			}
+			if resp.JSON200.Running || resp.JSON200.LastRunAt == nil {
+				return false
+			}
+			return before == nil || resp.JSON200.LastRunAt.After(*before)
+		}, 5*time.Second, 10*time.Millisecond)
 	}
 	budgetSpent := func() int64 {
 		t.Helper()


### PR DESCRIPTION
## Summary

- Clarifies the eager refresh budget as budgeted sync work for details, comments, and backfills, and stops counting GitHub 304 responses against that budget.
- Keeps the bottom status bar focused on REST and GraphQL pressure while leaving eager refresh budget detail in the API Budget popover.
- Tightens the over-budget popover copy so it explains the paused work without an extra deferred fragment.

## Screenshot

![codex-clipboard-YDg9jN.png](https://github.com/user-attachments/assets/5070a23c-837e-414f-963d-53a36db0901e)
