### PR TITLE
fix: tune command palette shortcut spacing

### DIFF
--- a/frontend/src/lib/components/layout/AppHeader.test.ts
+++ b/frontend/src/lib/components/layout/AppHeader.test.ts
@@ -1,5 +1,7 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
+import { compile } from "svelte/compiler";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import headerIconButtonSource from "./HeaderIconButton.svelte?raw";
 
 const mockedContainerSize = vi.hoisted(() => ({
   value: "wide" as "narrow" | "medium" | "wide",
@@ -67,6 +69,21 @@ import { initTheme, cleanupTheme } from "../../stores/theme.svelte.js";
 import { setSidebarCollapsed } from "../../stores/sidebar.svelte.ts";
 import { navigate } from "../../stores/router.svelte.ts";
 import { isPaletteOpen, resetPaletteState } from "../../stores/keyboard/palette-state.svelte.js";
+
+function compiledStyle(source: string, selector: string): CSSStyleDeclaration {
+  const css = compile(source, { filename: "component.svelte" }).css?.code ?? "";
+  const style = document.createElement("style");
+  style.textContent = css;
+  document.head.appendChild(style);
+
+  for (const rule of Array.from(style.sheet?.cssRules ?? [])) {
+    if (!("selectorText" in rule) || !("style" in rule)) continue;
+    if (String(rule.selectorText).includes(selector)) {
+      return rule.style as CSSStyleDeclaration;
+    }
+  }
+  throw new Error(`Could not find compiled style rule for ${selector}`);
+}
 
 type MediaChangeCallback = (event: MediaQueryListEvent) => void;
 
@@ -258,6 +275,12 @@ describe("AppHeader", () => {
     expect(container.querySelector("button[title='Toggle theme'] svg")).toBeTruthy();
     expect(container.querySelector("button[title='Settings'] svg")).toBeTruthy();
     expect(container.querySelector("button[title='Select repository'] svg")).toBeTruthy();
+  });
+
+  it("spaces the command palette icon and shortcut hint", () => {
+    const buttonStyle = compiledStyle(headerIconButtonSource, "button");
+
+    expect(buttonStyle.getPropertyValue("gap")).toBe("7px");
   });
 
   it("opens the command palette from the header trigger", async () => {

--- a/frontend/src/lib/components/layout/HeaderIconButton.svelte
+++ b/frontend/src/lib/components/layout/HeaderIconButton.svelte
@@ -44,6 +44,7 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    gap: 7px;
     line-height: 0;
     transition: background 0.15s, color 0.15s, border-color 0.15s;
   }

--- a/packages/ui/src/components/keyboard/KbdBadge.svelte
+++ b/packages/ui/src/components/keyboard/KbdBadge.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { KeySpec } from "../../stores/keyboard/keyspec.js";
-  import { kbdAriaLabel, kbdGlyph } from "./useKbdLabel.js";
+  import { kbdAriaLabel, kbdGlyph, kbdGlyphJoiner } from "./useKbdLabel.js";
 
   interface Props {
     binding: KeySpec;
@@ -9,10 +9,11 @@
   let { binding }: Props = $props();
 
   const glyph = $derived(kbdGlyph(binding));
+  const joiner = $derived(kbdGlyphJoiner());
   const aria = $derived(kbdAriaLabel(binding));
 </script>
 
-<kbd class="kbd-badge" aria-label={aria}>
+<kbd class="kbd-badge" data-joiner={joiner === "" ? "compact" : "plus"} aria-label={aria}>
   {glyph}
   <span class="sr-only">{aria}</span>
 </kbd>
@@ -29,6 +30,10 @@
     color: var(--text-secondary);
     background: var(--bg-inset);
     font-family: ui-monospace, monospace;
+  }
+  .kbd-badge[data-joiner="compact"] {
+    font-family: var(--font-sans);
+    letter-spacing: 0.07em;
   }
   .sr-only {
     position: absolute;

--- a/packages/ui/src/components/keyboard/KbdBadge.test.ts
+++ b/packages/ui/src/components/keyboard/KbdBadge.test.ts
@@ -1,7 +1,28 @@
 import { cleanup, render, screen } from "@testing-library/svelte";
+import { compile } from "svelte/compiler";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import KbdBadge from "./KbdBadge.svelte";
+import componentSource from "./KbdBadge.svelte?raw";
+
+function compiledStyle(source: string, selectorParts: string[]): CSSStyleDeclaration {
+  const css = compile(source, { filename: "component.svelte" }).css?.code ?? "";
+  const style = document.createElement("style");
+  style.textContent = css;
+  document.head.appendChild(style);
+
+  for (const rule of Array.from(style.sheet?.cssRules ?? [])) {
+    if (!("selectorText" in rule) || !("style" in rule)) continue;
+    if (selectorParts.every((part) => String(rule.selectorText).includes(part))) {
+      return rule.style as CSSStyleDeclaration;
+    }
+  }
+  throw new Error(`Could not find compiled style rule for ${selectorParts.join(" ")}`);
+}
+
+function compactText(element: HTMLElement): string {
+  return element.textContent?.replace(/\s+/g, "") ?? "";
+}
 
 describe("KbdBadge", () => {
   afterEach(() => {
@@ -17,7 +38,7 @@ describe("KbdBadge", () => {
     render(KbdBadge, {
       props: { binding: { key: "k", ctrlOrMeta: true } },
     });
-    expect(screen.getByText(/⌘.*K/i)).toBeTruthy();
+    expect(compactText(screen.getByLabelText(/Command-k/i))).toMatch(/^⌘K/);
   });
 
   it("renders Ctrl glyph on Linux", () => {
@@ -29,6 +50,13 @@ describe("KbdBadge", () => {
       props: { binding: { key: "k", ctrlOrMeta: true } },
     });
     expect(screen.getByText(/Ctrl.*K/i)).toBeTruthy();
+  });
+
+  it("uses app text metrics for compact macOS shortcuts", () => {
+    const badge = compiledStyle(componentSource, [".kbd-badge", '[data-joiner="compact"]']);
+
+    expect(badge.getPropertyValue("font-family")).toBe("var(--font-sans)");
+    expect(badge.getPropertyValue("letter-spacing")).toBe("0.07em");
   });
 
   it("includes a screen-reader-only expanded label", () => {

--- a/packages/ui/src/components/keyboard/useKbdLabel.test.ts
+++ b/packages/ui/src/components/keyboard/useKbdLabel.test.ts
@@ -1,8 +1,12 @@
-import { describe, expect, it } from "vite-plus/test";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { kbdAriaLabel, kbdGlyph } from "./useKbdLabel.js";
 
 describe("kbdGlyph", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("renders the space key as 'Space'", () => {
     expect(kbdGlyph({ key: " " })).toBe("Space");
   });
@@ -13,6 +17,15 @@ describe("kbdGlyph", () => {
 
   it("passes a named key through unchanged", () => {
     expect(kbdGlyph({ key: "ArrowRight" })).toBe("ArrowRight");
+  });
+
+  it("keeps macOS modifier glyph text compact", () => {
+    vi.stubGlobal("navigator", {
+      platform: "MacIntel",
+      userAgent: "Mac",
+    });
+
+    expect(kbdGlyph({ key: "k", ctrlOrMeta: true })).toBe("⌘K");
   });
 });
 

--- a/packages/ui/src/components/keyboard/useKbdLabel.ts
+++ b/packages/ui/src/components/keyboard/useKbdLabel.ts
@@ -8,6 +8,10 @@ function isMacPlatform(): boolean {
 }
 
 export function kbdGlyph(spec: KeySpec): string {
+  return kbdGlyphParts(spec).join(kbdGlyphJoiner());
+}
+
+function kbdGlyphParts(spec: KeySpec): string[] {
   const isMac = isMacPlatform();
   const parts: string[] = [];
   if (spec.ctrlOrMeta) parts.push(isMac ? "⌘" : "Ctrl");
@@ -15,7 +19,11 @@ export function kbdGlyph(spec: KeySpec): string {
   if (spec.alt) parts.push(isMac ? "⌥" : "Alt");
   if (spec.key === " ") parts.push("Space");
   else parts.push(spec.key.length === 1 ? spec.key.toUpperCase() : spec.key);
-  return parts.join(isMac ? "" : "+");
+  return parts;
+}
+
+export function kbdGlyphJoiner(): "" | "+" {
+  return isMacPlatform() ? "" : "+";
 }
 
 export function kbdAriaLabel(spec: KeySpec): string {


### PR DESCRIPTION
## Summary

- Adjusts the command palette trigger so the search icon and shortcut hint have clearer spacing.
- Tunes macOS compact key hints so `⌘K` uses app text metrics and closer native-menu proportions while non-mac shortcuts keep the plus-joined keycap style.

## Before

<img width="79" height="38" alt="image" src="https://github.com/user-attachments/assets/1a3ba7fb-a466-4746-b13c-03e38e14de5a" />

## After

<img width="95" height="35" alt="image" src="https://github.com/user-attachments/assets/58e35147-6122-42c2-b60a-9d55274f2769" />
