### PR TITLE
Reuse existing workspace worktrees and fall back to PR refs

### DIFF
--- a/internal/gitclone/clone.go
+++ b/internal/gitclone/clone.go
@@ -208,8 +208,8 @@ func (m *Manager) ensureCloneNowInNamespace(
 //     branch that a workspace has checked out.
 //   - pullRefspec makes refs/pull/<N>/head available, which is how we resolve
 //     PR heads that live on forks.
-//   - gitlabMergeRequestRefspec makes refs/merge-requests/<N>/head available,
-//     which is GitLab's equivalent merge request head ref.
+//   - gitlabMergeRequestRefspec is intentionally not a default refspec. GitLab
+//     MR heads are fetched one at a time by explicit workspace operations.
 const (
 	legacyBranchRefspec       = "+refs/heads/*:refs/heads/*"
 	remoteTrackingRefspec     = "+refs/heads/*:refs/remotes/origin/*"
@@ -223,7 +223,6 @@ func defaultRefspecs() []string {
 	return []string{
 		remoteTrackingRefspec,
 		pullRefspec,
-		gitlabMergeRequestRefspec,
 	}
 }
 
@@ -256,6 +255,18 @@ func (m *Manager) ensureRefspecs(
 				"path", clonePath, "refspec", legacyBranchRefspec, "err", err)
 		} else {
 			delete(existing, legacyBranchRefspec)
+		}
+	}
+	if existing[gitlabMergeRequestRefspec] {
+		if _, err := m.git(
+			ctx, clonePath,
+			"config", "--fixed-value", "--unset-all",
+			"remote.origin.fetch", gitlabMergeRequestRefspec,
+		); err != nil {
+			slog.Warn("failed to remove unbounded GitLab MR refspec from existing clone",
+				"path", clonePath, "refspec", gitlabMergeRequestRefspec, "err", err)
+		} else {
+			delete(existing, gitlabMergeRequestRefspec)
 		}
 	}
 	for _, refspec := range defaultRefspecs() {

--- a/internal/gitclone/clone.go
+++ b/internal/gitclone/clone.go
@@ -208,16 +208,23 @@ func (m *Manager) ensureCloneNowInNamespace(
 //     branch that a workspace has checked out.
 //   - pullRefspec makes refs/pull/<N>/head available, which is how we resolve
 //     PR heads that live on forks.
+//   - gitlabMergeRequestRefspec makes refs/merge-requests/<N>/head available,
+//     which is GitLab's equivalent merge request head ref.
 const (
-	legacyBranchRefspec   = "+refs/heads/*:refs/heads/*"
-	remoteTrackingRefspec = "+refs/heads/*:refs/remotes/origin/*"
-	pullRefspec           = "+refs/pull/*/head:refs/pull/*/head"
+	legacyBranchRefspec       = "+refs/heads/*:refs/heads/*"
+	remoteTrackingRefspec     = "+refs/heads/*:refs/remotes/origin/*"
+	pullRefspec               = "+refs/pull/*/head:refs/pull/*/head"
+	gitlabMergeRequestRefspec = "+refs/merge-requests/*/head:refs/merge-requests/*/head"
 )
 
 // defaultRefspecs returns the full list of fetch refspecs every clone should
 // have. Used by both cloneBare (fresh clones) and ensureRefspecs (migration).
 func defaultRefspecs() []string {
-	return []string{remoteTrackingRefspec, pullRefspec}
+	return []string{
+		remoteTrackingRefspec,
+		pullRefspec,
+		gitlabMergeRequestRefspec,
+	}
 }
 
 // ensureRefspecs idempotently adds any missing fetch refspecs to an

--- a/internal/gitclone/clone_test.go
+++ b/internal/gitclone/clone_test.go
@@ -150,11 +150,10 @@ func TestEnsureCloneSweepsPartialClone(t *testing.T) {
 	assert.True(os.IsNotExist(err), "stray file from partial clone should be gone")
 }
 
-// TestEnsureCloneInstallsBothRefspecs verifies that a fresh clone gets both
-// the remote-tracking and pull refspecs configured. Without the remote-
-// tracking refspec, git fetch never updates origin/* and branch tips
-// drift stale in the bare clone.
-func TestEnsureCloneInstallsBothRefspecs(t *testing.T) {
+// TestEnsureCloneInstallsDefaultRefspecs verifies that a fresh clone gets every
+// ref family workspace setup needs: remote branches, GitHub-style pull refs, and
+// GitLab merge request refs.
+func TestEnsureCloneInstallsDefaultRefspecs(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -170,6 +169,7 @@ func TestEnsureCloneInstallsBothRefspecs(t *testing.T) {
 	refspecs := getFetchRefspecs(t, clonePath)
 	assert.Contains(refspecs, remoteTrackingRefspec)
 	assert.Contains(refspecs, pullRefspec)
+	assert.Contains(refspecs, gitlabMergeRequestRefspec)
 	assert.NotContains(refspecs, legacyBranchRefspec)
 }
 
@@ -198,6 +198,40 @@ func TestEnsureCloneFetchesNewBranchCommits(t *testing.T) {
 	got, err := mgr.RevParse(ctx, "github.com", "testowner", "testrepo", newSHA)
 	require.NoError(err)
 	assert.Equal(newSHA, got)
+}
+
+func TestEnsureCloneFetchesGitLabMergeRequestHeads(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	remote, work := setupTestRepo(t)
+	clonesDir := t.TempDir()
+	mgr := New(clonesDir, nil)
+
+	ctx := t.Context()
+	require.NoError(mgr.EnsureClone(
+		ctx, "gitlab.com", "testowner", "testrepo", remote))
+
+	require.NoError(os.WriteFile(
+		filepath.Join(work, "gitlab-mr.go"), []byte("package main\n"), 0o644,
+	))
+	run(t, work, "git", "add", ".")
+	run(t, work, "git", "commit", "-m", "gitlab mr head")
+	out, err := gitcmd.New().Output(t.Context(), work, "rev-parse", "HEAD")
+	require.NoError(err)
+	headSHA := strings.TrimSpace(string(out))
+	run(t, work, "git", "push", "origin", "HEAD:refs/merge-requests/17/head")
+
+	require.NoError(mgr.EnsureClone(
+		ctx, "gitlab.com", "testowner", "testrepo", remote))
+
+	clonePath, err := mgr.ClonePath("gitlab.com", "testowner", "testrepo")
+	require.NoError(err)
+	got, err := gitcmd.New().Output(
+		t.Context(), clonePath, "rev-parse", "refs/merge-requests/17/head",
+	)
+	require.NoError(err)
+	assert.Equal(headSHA, strings.TrimSpace(string(got)))
 }
 
 // TestEnsureCloneMigratesBrokenClone simulates a clone created by the
@@ -240,6 +274,7 @@ func TestEnsureCloneMigratesBrokenClone(t *testing.T) {
 	refspecs = getFetchRefspecs(t, clonePath)
 	assert.Contains(refspecs, remoteTrackingRefspec)
 	assert.Contains(refspecs, pullRefspec)
+	assert.Contains(refspecs, gitlabMergeRequestRefspec)
 	assert.NotContains(refspecs, legacyBranchRefspec)
 
 	got, err := mgr.RevParse(ctx, "github.com", "testowner", "testrepo", newSHA)
@@ -275,6 +310,7 @@ func TestEnsureCloneRemovesLegacyBranchRefspec(t *testing.T) {
 	refspecs = getFetchRefspecs(t, clonePath)
 	assert.Contains(refspecs, remoteTrackingRefspec)
 	assert.Contains(refspecs, pullRefspec)
+	assert.Contains(refspecs, gitlabMergeRequestRefspec)
 	assert.NotContains(refspecs, legacyBranchRefspec)
 }
 
@@ -315,6 +351,7 @@ func TestEnsureCloneMigratesCloneWithNoRefspec(t *testing.T) {
 	refspecs = getFetchRefspecs(t, clonePath)
 	assert.Contains(refspecs, remoteTrackingRefspec)
 	assert.Contains(refspecs, pullRefspec)
+	assert.Contains(refspecs, gitlabMergeRequestRefspec)
 	assert.NotContains(refspecs, legacyBranchRefspec)
 
 	got, err := mgr.RevParse(ctx, "github.com", "testowner", "testrepo", newSHA)

--- a/internal/gitclone/clone_test.go
+++ b/internal/gitclone/clone_test.go
@@ -150,9 +150,8 @@ func TestEnsureCloneSweepsPartialClone(t *testing.T) {
 	assert.True(os.IsNotExist(err), "stray file from partial clone should be gone")
 }
 
-// TestEnsureCloneInstallsDefaultRefspecs verifies that a fresh clone gets every
-// ref family workspace setup needs: remote branches, GitHub-style pull refs, and
-// GitLab merge request refs.
+// TestEnsureCloneInstallsDefaultRefspecs verifies that a fresh clone gets the
+// bounded ref families workspace setup needs during background refresh.
 func TestEnsureCloneInstallsDefaultRefspecs(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -169,7 +168,7 @@ func TestEnsureCloneInstallsDefaultRefspecs(t *testing.T) {
 	refspecs := getFetchRefspecs(t, clonePath)
 	assert.Contains(refspecs, remoteTrackingRefspec)
 	assert.Contains(refspecs, pullRefspec)
-	assert.Contains(refspecs, gitlabMergeRequestRefspec)
+	assert.NotContains(refspecs, gitlabMergeRequestRefspec)
 	assert.NotContains(refspecs, legacyBranchRefspec)
 }
 
@@ -200,7 +199,7 @@ func TestEnsureCloneFetchesNewBranchCommits(t *testing.T) {
 	assert.Equal(newSHA, got)
 }
 
-func TestEnsureCloneFetchesGitLabMergeRequestHeads(t *testing.T) {
+func TestEnsureCloneDoesNotFetchGitLabMergeRequestHeadsByDefault(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -230,8 +229,8 @@ func TestEnsureCloneFetchesGitLabMergeRequestHeads(t *testing.T) {
 	got, err := gitcmd.New().Output(
 		t.Context(), clonePath, "rev-parse", "refs/merge-requests/17/head",
 	)
-	require.NoError(err)
-	assert.Equal(headSHA, strings.TrimSpace(string(got)))
+	require.Error(err)
+	assert.NotContains(strings.TrimSpace(string(got)), headSHA)
 }
 
 // TestEnsureCloneMigratesBrokenClone simulates a clone created by the
@@ -274,7 +273,7 @@ func TestEnsureCloneMigratesBrokenClone(t *testing.T) {
 	refspecs = getFetchRefspecs(t, clonePath)
 	assert.Contains(refspecs, remoteTrackingRefspec)
 	assert.Contains(refspecs, pullRefspec)
-	assert.Contains(refspecs, gitlabMergeRequestRefspec)
+	assert.NotContains(refspecs, gitlabMergeRequestRefspec)
 	assert.NotContains(refspecs, legacyBranchRefspec)
 
 	got, err := mgr.RevParse(ctx, "github.com", "testowner", "testrepo", newSHA)
@@ -301,8 +300,11 @@ func TestEnsureCloneRemovesLegacyBranchRefspec(t *testing.T) {
 	require.NoError(err)
 	run(t, clonePath, "git", "config", "--add",
 		"remote.origin.fetch", legacyBranchRefspec)
+	run(t, clonePath, "git", "config", "--add",
+		"remote.origin.fetch", gitlabMergeRequestRefspec)
 	refspecs := getFetchRefspecs(t, clonePath)
 	require.Contains(refspecs, legacyBranchRefspec)
+	require.Contains(refspecs, gitlabMergeRequestRefspec)
 
 	require.NoError(mgr.EnsureClone(
 		ctx, "github.com", "testowner", "testrepo", remote))
@@ -310,7 +312,7 @@ func TestEnsureCloneRemovesLegacyBranchRefspec(t *testing.T) {
 	refspecs = getFetchRefspecs(t, clonePath)
 	assert.Contains(refspecs, remoteTrackingRefspec)
 	assert.Contains(refspecs, pullRefspec)
-	assert.Contains(refspecs, gitlabMergeRequestRefspec)
+	assert.NotContains(refspecs, gitlabMergeRequestRefspec)
 	assert.NotContains(refspecs, legacyBranchRefspec)
 }
 
@@ -351,7 +353,7 @@ func TestEnsureCloneMigratesCloneWithNoRefspec(t *testing.T) {
 	refspecs = getFetchRefspecs(t, clonePath)
 	assert.Contains(refspecs, remoteTrackingRefspec)
 	assert.Contains(refspecs, pullRefspec)
-	assert.Contains(refspecs, gitlabMergeRequestRefspec)
+	assert.NotContains(refspecs, gitlabMergeRequestRefspec)
 	assert.NotContains(refspecs, legacyBranchRefspec)
 
 	got, err := mgr.RevParse(ctx, "github.com", "testowner", "testrepo", newSHA)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -25508,6 +25508,171 @@ func TestWorkspaceCreateUsesPRBranchAndFallbackBranch(t *testing.T) {
 	)
 }
 
+func TestWorkspaceCreateWithLocalBaseUsesPullRefWhenHeadBranchDeleted(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	const prNumber = 43
+	localRepo, remote, platformHost := setupHTTPWorktreeBaseForServerTest(
+		t, "feature",
+	)
+	wantSHA := testGitSHA(t, localRepo, "refs/remotes/origin/feature")
+	runGit(
+		t, remote, "update-ref",
+		fmt.Sprintf("refs/pull/%d/head", prNumber), wantSHA,
+	)
+	runGit(t, remote, "update-ref", "-d", "refs/heads/feature")
+	runGit(t, remote, "update-server-info")
+	runGit(t, localRepo, "fetch", "--prune", "origin")
+
+	cfg := &config.Config{Repos: []config.Repo{{
+		Platform:         "github",
+		PlatformHost:     platformHost,
+		Owner:            "acme",
+		Name:             "widget",
+		WorktreeBasePath: localRepo,
+	}}}
+	fixture := setupWorkspaceServerFixture(t, cfg)
+	ctx := t.Context()
+	seedPROnHost(
+		t, fixture.database,
+		platformHost, "acme", "widget", prNumber,
+		withSeedPRHeadRepoCloneURL("https://"+platformHost+"/acme/widget.git"),
+	)
+
+	createResp, err := fixture.client.HTTP.CreateWorkspaceWithResponse(
+		ctx,
+		generated.CreateWorkspaceInputBody{
+			PlatformHost: platformHost,
+			Owner:        "acme",
+			Name:         "widget",
+			MrNumber:     prNumber,
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusAccepted, createResp.StatusCode())
+	require.NotNil(createResp.JSON202)
+
+	ready := waitForWorkspaceReady(t, ctx, fixture.client, createResp.JSON202.Id)
+	stored, err := fixture.database.GetWorkspace(ctx, ready.Id)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.Equal("ready", stored.Status)
+	assert.Equal(syntheticPRWorktreeBranchForTest(prNumber), stored.WorkspaceBranch)
+	assert.Equal(wantSHA, testGitSHA(t, ready.WorktreePath, "HEAD"))
+	assert.Equal(
+		syntheticPRWorktreeBranchForTest(prNumber),
+		gitOutput(t, ready.WorktreePath, "branch", "--show-current"),
+	)
+}
+
+func TestWorkspaceCreateReusesExistingWorktreeThroughAPI(t *testing.T) {
+	t.Parallel()
+
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	const prNumber = 44
+	localRepo, _, platformHost := setupHTTPWorktreeBaseForServerTest(
+		t, "feature",
+	)
+	cfg := &config.Config{Repos: []config.Repo{{
+		Platform:         "github",
+		PlatformHost:     platformHost,
+		Owner:            "acme",
+		Name:             "widget",
+		WorktreeBasePath: localRepo,
+	}}}
+	fixture := setupWorkspaceServerFixture(t, cfg)
+	ctx := t.Context()
+	existingBranch := syntheticPRWorktreeBranchForTest(prNumber)
+	worktreePath := filepath.Join(
+		fixture.worktrees, "github", platformHost, "acme", "widget",
+		fmt.Sprintf("pr-%d", prNumber),
+	)
+	runGit(
+		t, localRepo,
+		"worktree", "add", worktreePath, "-b", existingBranch, "main",
+	)
+	wantSHA := testGitSHA(t, worktreePath, "HEAD")
+	seedPROnHost(
+		t, fixture.database,
+		platformHost, "acme", "widget", prNumber,
+		withSeedPRHeadRepoCloneURL("https://"+platformHost+"/acme/widget.git"),
+	)
+
+	createResp, err := fixture.client.HTTP.CreateWorkspaceWithResponse(
+		ctx,
+		generated.CreateWorkspaceInputBody{
+			PlatformHost: platformHost,
+			Owner:        "acme",
+			Name:         "widget",
+			MrNumber:     prNumber,
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusAccepted, createResp.StatusCode())
+	require.NotNil(createResp.JSON202)
+
+	ready := waitForWorkspaceReady(t, ctx, fixture.client, createResp.JSON202.Id)
+	stored, err := fixture.database.GetWorkspace(ctx, ready.Id)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.Equal("ready", stored.Status)
+	assert.Equal(worktreePath, stored.WorktreePath)
+	assert.Equal(existingBranch, stored.WorkspaceBranch)
+	assert.Equal(worktreePath, ready.WorktreePath)
+	assert.Equal(wantSHA, testGitSHA(t, ready.WorktreePath, "HEAD"))
+	assert.Equal(existingBranch, gitOutput(t, ready.WorktreePath, "branch", "--show-current"))
+}
+
+func syntheticPRWorktreeBranchForTest(mrNumber int) string {
+	return fmt.Sprintf("middleman/pr-%d", mrNumber)
+}
+
+func setupHTTPWorktreeBaseForServerTest(
+	t *testing.T,
+	branch string,
+) (repo, remote, platformHost string) {
+	t.Helper()
+	root := t.TempDir()
+	remote = filepath.Join(root, "acme", "widget.git")
+	repo = filepath.Join(root, "repo")
+	require.NoError(t, os.MkdirAll(filepath.Dir(remote), 0o755))
+	runGit(t, root, "init", "--bare", "--initial-branch=main", remote)
+	server := httptest.NewServer(http.FileServer(http.Dir(root)))
+	t.Cleanup(server.Close)
+	remoteURL := server.URL + "/acme/widget.git"
+	parsed, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	platformHost = parsed.Host
+
+	runGit(t, root, "init", "--initial-branch=main", repo)
+	runGit(t, repo, "config", "user.email", "test@test.com")
+	runGit(t, repo, "config", "user.name", "Test")
+	runGit(t, repo, "remote", "add", "origin", remote)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repo, "base.txt"), []byte("base\n"), 0o644,
+	))
+	runGit(t, repo, "add", ".")
+	runGit(t, repo, "commit", "-m", "base commit")
+	runGit(t, repo, "push", "origin", "HEAD:refs/heads/main")
+	runGit(t, remote, "symbolic-ref", "HEAD", "refs/heads/main")
+	runGit(t, repo, "push", "origin", "HEAD:refs/heads/"+branch)
+	runGit(t, remote, "update-server-info")
+	runGit(t, repo, "remote", "set-url", "origin", remoteURL)
+	runGit(t, repo, "fetch", "--prune", "origin")
+	runGit(
+		t, repo, "symbolic-ref",
+		"refs/remotes/origin/HEAD", "refs/remotes/origin/main",
+	)
+	return repo, remote, platformHost
+}
+
 func TestWorkspaceCreateSameRepoHeadCloneURLTracksOriginBranchE2E(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -993,6 +993,10 @@ func withSeedPRHeadRepoCloneURL(cloneURL string) seedPROpt {
 	return func(pr *db.MergeRequest) { pr.HeadRepoCloneURL = cloneURL }
 }
 
+func withSeedPRHeadBranch(branch string) seedPROpt {
+	return func(pr *db.MergeRequest) { pr.HeadBranch = branch }
+}
+
 func withSeedPRTitle(title string) seedPROpt {
 	return func(pr *db.MergeRequest) { pr.Title = title }
 }
@@ -25570,6 +25574,79 @@ func TestWorkspaceCreateWithLocalBaseUsesPullRefWhenHeadBranchDeleted(
 	)
 }
 
+func TestWorkspaceCreateGitLabUsesSpecificMergeRequestHeadRefE2E(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	const mrNumber = 57
+	const headBranch = "contributor/gitlab-fork"
+	localRepo, remote, platformHost := setupHTTPWorktreeBaseForServerTest(
+		t, "feature",
+	)
+	runGit(t, localRepo, "checkout", "-b", headBranch, "main")
+	require.NoError(os.WriteFile(
+		filepath.Join(localRepo, "gitlab-mr.txt"),
+		[]byte("gitlab mr head\n"), 0o644,
+	))
+	runGit(t, localRepo, "add", ".")
+	runGit(t, localRepo, "commit", "-m", "gitlab mr head")
+	wantSHA := testGitSHA(t, localRepo, "HEAD")
+	runGit(
+		t, localRepo, "push", remote,
+		fmt.Sprintf("HEAD:refs/merge-requests/%d/head", mrNumber),
+	)
+	runGit(t, remote, "update-server-info")
+
+	fixture := setupWorkspaceServerFixtureWithHost(t, nil, platformHost)
+	ctx := t.Context()
+	repoID, err := fixture.database.UpsertRepo(ctx, db.RepoIdentity{
+		Platform:     string(platform.KindGitLab),
+		PlatformHost: platformHost,
+		Owner:        "acme",
+		Name:         "widget",
+	})
+	require.NoError(err)
+	require.NoError(fixture.database.UpdateRepoProviderMetadata(
+		ctx, repoID, db.RepoProviderMetadata{
+			CloneURL:      "http://" + platformHost + "/acme/widget.git",
+			DefaultBranch: "main",
+		},
+	))
+	seedPRForRepo(
+		t, fixture.database, repoID, platformHost, "acme", "widget", mrNumber,
+		withSeedPRHeadBranch(headBranch),
+		withSeedPRHeadRepoCloneURL("https://"+platformHost+"/fork/widget.git"),
+	)
+	provider := string(platform.KindGitLab)
+
+	createResp, err := fixture.client.HTTP.CreateWorkspaceWithResponse(
+		ctx,
+		generated.CreateWorkspaceInputBody{
+			Provider:     &provider,
+			PlatformHost: platformHost,
+			Owner:        "acme",
+			Name:         "widget",
+			MrNumber:     mrNumber,
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusAccepted, createResp.StatusCode())
+	require.NotNil(createResp.JSON202)
+
+	ready := waitForWorkspaceReady(t, ctx, fixture.client, createResp.JSON202.Id)
+	stored, err := fixture.database.GetWorkspace(ctx, ready.Id)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.Equal("ready", stored.Status)
+	assert.Equal(headBranch, stored.WorkspaceBranch)
+	assert.Equal(headBranch, gitOutput(t, ready.WorktreePath, "branch", "--show-current"))
+	assert.Equal(wantSHA, testGitSHA(t, ready.WorktreePath, "HEAD"))
+}
+
 func TestWorkspaceCreateReusesExistingWorktreeThroughAPI(t *testing.T) {
 	t.Parallel()
 
@@ -25628,6 +25705,90 @@ func TestWorkspaceCreateReusesExistingWorktreeThroughAPI(t *testing.T) {
 	assert.Equal(worktreePath, ready.WorktreePath)
 	assert.Equal(wantSHA, testGitSHA(t, ready.WorktreePath, "HEAD"))
 	assert.Equal(existingBranch, gitOutput(t, ready.WorktreePath, "branch", "--show-current"))
+}
+
+func TestWorkspaceRetryReusesExistingLocalHeadBranchThroughAPI(t *testing.T) {
+	t.Parallel()
+
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	const prNumber = 45
+	localRepo, _, platformHost := setupHTTPWorktreeBaseForServerTest(
+		t, "feature",
+	)
+	cfg := &config.Config{Repos: []config.Repo{{
+		Platform:         "github",
+		PlatformHost:     platformHost,
+		Owner:            "acme",
+		Name:             "widget",
+		WorktreeBasePath: localRepo,
+	}}}
+	fixture := setupWorkspaceServerFixture(t, cfg)
+	ctx := t.Context()
+	worktreePath := filepath.Join(
+		fixture.worktrees, "github", platformHost, "acme", "widget",
+		fmt.Sprintf("pr-%d", prNumber),
+	)
+	runGit(
+		t, localRepo,
+		"worktree", "add", worktreePath,
+		"-b", "feature", "refs/remotes/origin/feature",
+	)
+	wantSHA := testGitSHA(t, worktreePath, "HEAD")
+	seedPROnHost(
+		t, fixture.database,
+		platformHost, "acme", "widget", prNumber,
+		withSeedPRHeadRepoCloneURL("https://"+platformHost+"/acme/widget.git"),
+	)
+
+	createResp, err := fixture.client.HTTP.CreateWorkspaceWithResponse(
+		ctx,
+		generated.CreateWorkspaceInputBody{
+			PlatformHost: platformHost,
+			Owner:        "acme",
+			Name:         "widget",
+			MrNumber:     prNumber,
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusAccepted, createResp.StatusCode())
+	require.NotNil(createResp.JSON202)
+	ready := waitForWorkspaceReady(t, ctx, fixture.client, createResp.JSON202.Id)
+	stored, err := fixture.database.GetWorkspace(ctx, ready.Id)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.Equal("ready", stored.Status)
+	assert.Empty(stored.WorkspaceBranch)
+	assert.Equal("feature", gitOutput(t, ready.WorktreePath, "branch", "--show-current"))
+	assert.Equal(wantSHA, testGitSHA(t, ready.WorktreePath, "HEAD"))
+
+	msg := "retry existing local base worktree"
+	require.NoError(fixture.database.UpdateWorkspaceStatus(
+		ctx, ready.Id, "error", &msg,
+	))
+	retryResp, err := fixture.client.HTTP.RetryWorkspaceWithResponse(ctx, ready.Id)
+	require.NoError(err)
+	require.Equal(http.StatusAccepted, retryResp.StatusCode())
+	require.NotNil(retryResp.JSON202)
+
+	retried := waitForWorkspaceReady(t, ctx, fixture.client, ready.Id)
+	stored, err = fixture.database.GetWorkspace(ctx, ready.Id)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.Equal("ready", stored.Status)
+	assert.Empty(stored.WorkspaceBranch)
+	assert.Equal(worktreePath, stored.WorktreePath)
+	assert.Equal("feature", gitOutput(t, retried.WorktreePath, "branch", "--show-current"))
+	assert.Equal(wantSHA, testGitSHA(t, retried.WorktreePath, "HEAD"))
+
+	force := true
+	deleteResp, err := fixture.client.HTTP.DeleteWorkspaceWithResponse(
+		ctx, ready.Id, &generated.DeleteWorkspaceParams{Force: &force},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusNoContent, deleteResp.StatusCode())
+	assert.Equal(wantSHA, testGitSHA(t, localRepo, "refs/heads/feature"))
 }
 
 func syntheticPRWorktreeBranchForTest(mrNumber int) string {

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -613,18 +613,43 @@ func (m *Manager) reuseExistingWorkspaceWorktree(
 	if err != nil {
 		return "", false, err
 	}
-	return existingWorkspacePersistedBranch(ws, currentBranch), true, nil
+	branch, ok, err := existingWorkspacePersistedBranch(ctx, ws, currentBranch)
+	if err != nil {
+		return "", false, err
+	}
+	if !ok {
+		return "", false, fmt.Errorf(
+			"existing worktree branch %q does not match workspace-owned branch for %s #%d",
+			currentBranch, ws.ItemType, ws.ItemNumber,
+		)
+	}
+	return branch, true, nil
 }
 
-func existingWorkspacePersistedBranch(ws *Workspace, currentBranch string) string {
+func existingWorkspacePersistedBranch(
+	ctx context.Context,
+	ws *Workspace,
+	currentBranch string,
+) (string, bool, error) {
 	if ws.WorkspaceBranch != "" && ws.WorkspaceBranch != workspaceBranchUnknown {
-		return ws.WorkspaceBranch
+		return ws.WorkspaceBranch, currentBranch == ws.WorkspaceBranch, nil
 	}
 	if ws.ItemType == db.WorkspaceItemTypePullRequest &&
 		currentBranch == syntheticPRWorktreeBranch(ws.ItemNumber) {
-		return currentBranch
+		return currentBranch, true, nil
 	}
-	return ws.WorkspaceBranch
+	if currentBranch != "" && currentBranch == ws.GitHeadRef {
+		headSHA, ok, err := gitRefSHA(ctx, ws.WorktreePath, "HEAD")
+		if err != nil || !ok {
+			return "", false, err
+		}
+		startSHA, ok, err := gitRefSHA(ctx, ws.WorktreePath, workspaceStartRef(ws))
+		if err != nil || !ok {
+			return "", false, err
+		}
+		return currentBranch, headSHA == startSHA, nil
+	}
+	return "", false, nil
 }
 
 func worktreeCurrentBranch(ctx context.Context, path string) (string, error) {
@@ -1079,13 +1104,18 @@ func (m *Manager) addWorktreeLocked(
 		return branch, nil
 	}
 	fallbackBranch := syntheticPRWorktreeBranch(ws.ItemNumber)
+	useMergeRequestHeadRef := !localBase
 	if localBase {
 		// Providers may not retain a synthetic MR head ref. Try to populate it
-		// for deleted-head recovery, then let the existing fallback selection
-		// decide whether that ref or origin/<head> is usable.
-		_ = m.fetchWorkspaceMergeRequestHeadRef(ctx, cloneDir, ws)
+		// for deleted-head recovery, but do not trust a local stale copy when
+		// the exact refresh fails.
+		useMergeRequestHeadRef = m.fetchWorkspaceMergeRequestHeadRef(
+			ctx, cloneDir, ws,
+		) == nil
 	}
-	startRef, startRefErr := workspaceFallbackStartRef(ctx, cloneDir, ws)
+	startRef, startRefErr := workspaceFallbackStartRef(
+		ctx, cloneDir, ws, useMergeRequestHeadRef,
+	)
 	if startRefErr != nil {
 		return "", fmt.Errorf(
 			"preferred branch %q failed: %w; fallback branch %q failed: %w",
@@ -1246,9 +1276,9 @@ func workspaceStartRef(ws *Workspace) string {
 }
 
 func workspaceFallbackStartRef(
-	ctx context.Context, cloneDir string, ws *Workspace,
+	ctx context.Context, cloneDir string, ws *Workspace, useMergeRequestHeadRef bool,
 ) (string, error) {
-	if ws.ItemType == db.WorkspaceItemTypePullRequest {
+	if useMergeRequestHeadRef && ws.ItemType == db.WorkspaceItemTypePullRequest {
 		ref := workspaceMergeRequestHeadRef(ws)
 		_, exists, err := gitRefSHA(ctx, cloneDir, ref)
 		if err != nil {

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -1079,6 +1079,12 @@ func (m *Manager) addWorktreeLocked(
 		return branch, nil
 	}
 	fallbackBranch := syntheticPRWorktreeBranch(ws.ItemNumber)
+	if localBase {
+		// Providers may not retain a synthetic MR head ref. Try to populate it
+		// for deleted-head recovery, then let the existing fallback selection
+		// decide whether that ref or origin/<head> is usable.
+		_ = m.fetchWorkspaceMergeRequestHeadRef(ctx, cloneDir, ws)
+	}
 	startRef, startRefErr := workspaceFallbackStartRef(ctx, cloneDir, ws)
 	if startRefErr != nil {
 		return "", fmt.Errorf(
@@ -2735,6 +2741,41 @@ func (m *Manager) fetchWorkspaceBase(
 		}
 	}
 	return fetchWorkspaceBaseWithGit(ctx, run, dir, requireOriginHead)
+}
+
+func (m *Manager) fetchWorkspaceMergeRequestHeadRef(
+	ctx context.Context,
+	dir string,
+	ws *Workspace,
+) error {
+	run := runGitWithoutHooks
+	if m.clones != nil {
+		run = func(ctx context.Context, dir string, args ...string) error {
+			out, err := m.clones.RunGit(ctx, ws.PlatformHost, dir, args...)
+			if err != nil {
+				return fmt.Errorf(
+					"%w: %s", err, strings.TrimSpace(string(out)),
+				)
+			}
+			return nil
+		}
+	}
+	return fetchWorkspaceMergeRequestHeadRefWithGit(ctx, run, dir, ws)
+}
+
+func fetchWorkspaceMergeRequestHeadRefWithGit(
+	ctx context.Context,
+	run func(context.Context, string, ...string) error,
+	dir string,
+	ws *Workspace,
+) error {
+	ref := workspaceMergeRequestHeadRef(ws)
+	return run(
+		ctx, dir, gitArgsWithoutHooks(
+			"fetch", "--no-tags", "--recurse-submodules=no",
+			"origin", "+"+ref+":"+ref,
+		)...,
+	)
 }
 
 func fetchWorkspaceBaseWithGit(

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -609,11 +609,15 @@ func (m *Manager) reuseExistingWorkspaceWorktree(
 	if !owned {
 		return "", false, nil
 	}
+	localBase, err := m.workspaceWorktreeUsesLocalBase(ctx, commonDir, ws)
+	if err != nil {
+		return "", false, err
+	}
 	currentBranch, err := worktreeCurrentBranch(ctx, ws.WorktreePath)
 	if err != nil {
 		return "", false, err
 	}
-	branch, ok, err := existingWorkspacePersistedBranch(ctx, ws, currentBranch)
+	branch, ok, err := existingWorkspacePersistedBranch(ctx, ws, currentBranch, localBase)
 	if err != nil {
 		return "", false, err
 	}
@@ -626,10 +630,37 @@ func (m *Manager) reuseExistingWorkspaceWorktree(
 	return branch, true, nil
 }
 
+func (m *Manager) workspaceWorktreeUsesLocalBase(
+	ctx context.Context,
+	commonDir string,
+	ws *Workspace,
+) (bool, error) {
+	baseDir, ok, err := m.localWorktreeBaseDir(
+		ctx, ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
+	)
+	if err != nil || !ok {
+		return false, err
+	}
+	baseCommonDir, err := worktreeCommonGitDir(ctx, baseDir)
+	if err != nil {
+		return false, fmt.Errorf("inspect local worktree base: %w", err)
+	}
+	actualDir, err := canonicalFilesystemPath(commonDir)
+	if err != nil {
+		return false, fmt.Errorf("resolve existing worktree git dir: %w", err)
+	}
+	expectedDir, err := canonicalFilesystemPath(baseCommonDir)
+	if err != nil {
+		return false, fmt.Errorf("resolve local worktree base git dir: %w", err)
+	}
+	return actualDir == expectedDir, nil
+}
+
 func existingWorkspacePersistedBranch(
 	ctx context.Context,
 	ws *Workspace,
 	currentBranch string,
+	localBase bool,
 ) (string, bool, error) {
 	if ws.WorkspaceBranch != "" && ws.WorkspaceBranch != workspaceBranchUnknown {
 		return ws.WorkspaceBranch, currentBranch == ws.WorkspaceBranch, nil
@@ -647,7 +678,13 @@ func existingWorkspacePersistedBranch(
 		if err != nil || !ok {
 			return "", false, err
 		}
-		return currentBranch, headSHA == startSHA, nil
+		if headSHA != startSHA {
+			return "", false, nil
+		}
+		if localBase && ws.ItemType == db.WorkspaceItemTypePullRequest {
+			return "", true, nil
+		}
+		return currentBranch, true, nil
 	}
 	return "", false, nil
 }

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -609,9 +609,14 @@ func (m *Manager) reuseExistingWorkspaceWorktree(
 	if !owned {
 		return "", false, nil
 	}
-	localBase, err := m.workspaceWorktreeUsesLocalBase(ctx, commonDir, ws)
+	localBase, reusable, err := m.existingWorkspaceWorktreeProvenance(
+		ctx, commonDir, ws,
+	)
 	if err != nil {
 		return "", false, err
+	}
+	if !reusable {
+		return "", false, nil
 	}
 	var branch string
 	if err := m.withRepoLockForGitDir(ctx, commonDir, func() error {
@@ -643,6 +648,75 @@ func (m *Manager) reuseExistingWorkspaceWorktree(
 		return "", false, err
 	}
 	return branch, true, nil
+}
+
+// existingWorkspaceWorktreeProvenance decides whether the path already
+// recorded for this workspace may be refreshed and reused. The ownership
+// matrix is intentionally narrow:
+//   - expected managed clone: reusable for synthetic PR branches, persisted
+//     workspace branches, issue branches, and detached/unknown heads that later
+//     pass branch validation;
+//   - current configured local base: reusable only for same-repo workspaces
+//     after validating the actual worktree config, hooks, refspecs, and origin;
+//   - fork PR/MR: reusable only from the managed clone, never from a local base;
+//   - matching origin from any other git dir, stale local-base config, or a
+//     user-created checkout at the deterministic path: not reusable.
+//
+// If reuse fails after this point, Setup records an error and leaves the
+// worktree in place. Cleanup later deletes only branches that the persisted
+// workspace branch proves middleman owns; an empty or unknown branch marker is
+// deliberately treated as user-owned.
+func (m *Manager) existingWorkspaceWorktreeProvenance(
+	ctx context.Context,
+	commonDir string,
+	ws *Workspace,
+) (localBase bool, reusable bool, err error) {
+	if m.existingWorktreeUsesManagedClone(ctx, commonDir, ws) {
+		return false, true, nil
+	}
+	if ws.MRHeadRepo != nil {
+		return false, false, nil
+	}
+	usesLocalBase, err := m.workspaceWorktreeUsesLocalBase(ctx, commonDir, ws)
+	if err != nil || !usesLocalBase {
+		return false, false, err
+	}
+	if _, err := ValidateWorktreeBasePath(
+		ctx, ws.WorktreePath, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
+	); err != nil {
+		return false, false, err
+	}
+	return true, true, nil
+}
+
+func (m *Manager) existingWorktreeUsesManagedClone(
+	ctx context.Context,
+	commonDir string,
+	ws *Workspace,
+) bool {
+	if m.clones == nil {
+		return false
+	}
+	cloneDir, err := m.clones.ClonePathInNamespace(
+		workspaceCloneNamespace(ws.Platform),
+		ws.PlatformHost, ws.RepoOwner, ws.RepoName,
+	)
+	if err != nil {
+		return false
+	}
+	ready, err := gitCloneDirReady(cloneDir)
+	if err != nil || !ready {
+		return false
+	}
+	actualDir, err := canonicalFilesystemPath(commonDir)
+	if err != nil {
+		return false
+	}
+	expectedDir, err := canonicalFilesystemPath(cloneDir)
+	if err != nil {
+		return false
+	}
+	return actualDir == expectedDir
 }
 
 func (m *Manager) refreshExistingWorkspaceWorktree(
@@ -1169,7 +1243,8 @@ func localGitConfigKeysForScope(
 		}
 		if scope == "--worktree" &&
 			(strings.Contains(out, "extensions.worktreeConfig") ||
-				strings.Contains(out, "extension worktreeConfig")) {
+				strings.Contains(out, "extension worktreeConfig") ||
+				strings.Contains(out, "config.worktree")) {
 			return nil, nil
 		}
 		return nil, err
@@ -1215,6 +1290,13 @@ func (m *Manager) addWorktreeLocked(
 	if ws.ItemType == db.WorkspaceItemTypeIssue {
 		return m.addIssueWorktree(ctx, cloneDir, ws)
 	}
+	mergeRequestHeadRefFetched := false
+	if ws.MRHeadRepo != nil {
+		if err := m.fetchWorkspaceMergeRequestHeadRef(ctx, cloneDir, ws); err != nil {
+			return "", fmt.Errorf("fetch merge request head ref: %w", err)
+		}
+		mergeRequestHeadRefFetched = true
+	}
 	branch, err := m.addPreferredWorktree(ctx, cloneDir, localBase, ws)
 	if err == nil {
 		return branch, nil
@@ -1223,8 +1305,12 @@ func (m *Manager) addWorktreeLocked(
 	// Providers may not retain a synthetic MR head ref. Try to populate the
 	// specific ref needed for this workspace, but do not trust a local stale
 	// copy when the exact refresh fails.
-	fetchHeadErr := m.fetchWorkspaceMergeRequestHeadRef(ctx, cloneDir, ws)
-	useMergeRequestHeadRef := fetchHeadErr == nil
+	var fetchHeadErr error
+	useMergeRequestHeadRef := mergeRequestHeadRefFetched
+	if !useMergeRequestHeadRef {
+		fetchHeadErr = m.fetchWorkspaceMergeRequestHeadRef(ctx, cloneDir, ws)
+		useMergeRequestHeadRef = fetchHeadErr == nil
+	}
 	if !useMergeRequestHeadRef && ws.MRHeadRepo != nil {
 		return "", fmt.Errorf(
 			"preferred branch %q failed: %w; fallback branch %q failed: fetch merge request head ref: %w",

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -1010,7 +1010,13 @@ func (m *Manager) addWorktreeLocked(
 		return branch, nil
 	}
 	fallbackBranch := syntheticPRWorktreeBranch(ws.ItemNumber)
-	startRef := workspaceStartRef(ws)
+	startRef, startRefErr := workspaceFallbackStartRef(ctx, cloneDir, ws)
+	if startRefErr != nil {
+		return "", fmt.Errorf(
+			"preferred branch %q failed: %w; fallback branch %q failed: %w",
+			ws.GitHeadRef, err, fallbackBranch, startRefErr,
+		)
+	}
 	fallbackErr := runGitWorktreeAdd(
 		ctx, cloneDir, ws.WorktreePath,
 		"-b", fallbackBranch, startRef,
@@ -1159,9 +1165,29 @@ func workspaceStartRef(ws *Workspace) string {
 		return "origin/HEAD"
 	}
 	if ws.MRHeadRepo != nil {
-		return fmt.Sprintf("refs/pull/%d/head", ws.ItemNumber)
+		return workspaceMergeRequestHeadRef(ws)
 	}
 	return "origin/" + ws.GitHeadRef
+}
+
+func workspaceFallbackStartRef(
+	ctx context.Context, cloneDir string, ws *Workspace,
+) (string, error) {
+	if ws.ItemType == db.WorkspaceItemTypePullRequest {
+		ref := workspaceMergeRequestHeadRef(ws)
+		_, exists, err := gitRefSHA(ctx, cloneDir, ref)
+		if err != nil {
+			return "", fmt.Errorf("inspect merge request head ref %q: %w", ref, err)
+		}
+		if exists {
+			return ref, nil
+		}
+	}
+	return workspaceStartRef(ws), nil
+}
+
+func workspaceMergeRequestHeadRef(ws *Workspace) string {
+	return platform.MergeRequestHeadRef(platform.Kind(ws.Platform), ws.ItemNumber)
 }
 
 func syntheticPRWorktreeBranch(mrNumber int) string {

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -613,21 +613,56 @@ func (m *Manager) reuseExistingWorkspaceWorktree(
 	if err != nil {
 		return "", false, err
 	}
-	currentBranch, err := worktreeCurrentBranch(ctx, ws.WorktreePath)
-	if err != nil {
-		return "", false, err
-	}
-	branch, ok, err := existingWorkspacePersistedBranch(ctx, ws, currentBranch, localBase)
-	if err != nil {
-		return "", false, err
-	}
-	if !ok {
-		return "", false, fmt.Errorf(
-			"existing worktree branch %q does not match workspace-owned branch for %s #%d",
-			currentBranch, ws.ItemType, ws.ItemNumber,
+	var branch string
+	if err := m.withRepoLockForGitDir(ctx, commonDir, func() error {
+		useMergeRequestHeadRef, refreshErr := m.refreshExistingWorkspaceWorktree(
+			ctx, commonDir, ws,
 		)
+		if refreshErr != nil {
+			return refreshErr
+		}
+		currentBranch, branchErr := worktreeCurrentBranch(ctx, ws.WorktreePath)
+		if branchErr != nil {
+			return branchErr
+		}
+		var ok bool
+		branch, ok, branchErr = existingWorkspacePersistedBranch(
+			ctx, commonDir, ws, currentBranch, localBase, useMergeRequestHeadRef,
+		)
+		if branchErr != nil {
+			return branchErr
+		}
+		if !ok {
+			return fmt.Errorf(
+				"existing worktree branch %q does not match workspace-owned branch for %s #%d",
+				currentBranch, ws.ItemType, ws.ItemNumber,
+			)
+		}
+		return nil
+	}); err != nil {
+		return "", false, err
 	}
 	return branch, true, nil
+}
+
+func (m *Manager) refreshExistingWorkspaceWorktree(
+	ctx context.Context,
+	commonDir string,
+	ws *Workspace,
+) (bool, error) {
+	if err := m.fetchWorkspaceBase(ctx, commonDir, ws.PlatformHost, false); err != nil {
+		return false, err
+	}
+	if ws.ItemType != db.WorkspaceItemTypePullRequest {
+		return false, nil
+	}
+	if err := m.fetchWorkspaceMergeRequestHeadRef(ctx, commonDir, ws); err != nil {
+		if ws.MRHeadRepo != nil {
+			return false, err
+		}
+		return false, nil
+	}
+	return true, nil
 }
 
 func (m *Manager) workspaceWorktreeUsesLocalBase(
@@ -658,18 +693,35 @@ func (m *Manager) workspaceWorktreeUsesLocalBase(
 
 func existingWorkspacePersistedBranch(
 	ctx context.Context,
+	gitDir string,
 	ws *Workspace,
 	currentBranch string,
 	localBase bool,
+	useMergeRequestHeadRef bool,
 ) (string, bool, error) {
+	if ws.ItemType == db.WorkspaceItemTypePullRequest &&
+		currentBranch == syntheticPRWorktreeBranch(ws.ItemNumber) {
+		ok, err := existingWorkspaceHeadMatchesCurrentHead(
+			ctx, gitDir, ws, currentBranch, useMergeRequestHeadRef,
+		)
+		return currentBranch, ok, err
+	}
 	if ws.WorkspaceBranch != "" && ws.WorkspaceBranch != workspaceBranchUnknown {
 		return ws.WorkspaceBranch, currentBranch == ws.WorkspaceBranch, nil
 	}
-	if ws.ItemType == db.WorkspaceItemTypePullRequest &&
-		currentBranch == syntheticPRWorktreeBranch(ws.ItemNumber) {
-		return currentBranch, true, nil
-	}
 	if currentBranch != "" && currentBranch == ws.GitHeadRef {
+		if ws.ItemType == db.WorkspaceItemTypePullRequest {
+			ok, err := existingWorkspaceHeadMatchesCurrentHead(
+				ctx, gitDir, ws, currentBranch, useMergeRequestHeadRef,
+			)
+			if err != nil || !ok {
+				return "", false, err
+			}
+			if localBase {
+				return "", true, nil
+			}
+			return currentBranch, true, nil
+		}
 		headSHA, ok, err := gitRefSHA(ctx, ws.WorktreePath, "HEAD")
 		if err != nil || !ok {
 			return "", false, err
@@ -681,12 +733,39 @@ func existingWorkspacePersistedBranch(
 		if headSHA != startSHA {
 			return "", false, nil
 		}
-		if localBase && ws.ItemType == db.WorkspaceItemTypePullRequest {
-			return "", true, nil
-		}
 		return currentBranch, true, nil
 	}
 	return "", false, nil
+}
+
+func existingWorkspaceHeadMatchesCurrentHead(
+	ctx context.Context,
+	gitDir string,
+	ws *Workspace,
+	currentBranch string,
+	useMergeRequestHeadRef bool,
+) (bool, error) {
+	headSHA, ok, err := gitRefSHA(ctx, ws.WorktreePath, "HEAD")
+	if err != nil || !ok {
+		return false, err
+	}
+	expectedRef, err := workspaceFallbackStartRef(
+		ctx, gitDir, ws, useMergeRequestHeadRef,
+	)
+	if err != nil {
+		return false, err
+	}
+	expectedSHA, ok, err := gitRefSHA(ctx, gitDir, expectedRef)
+	if err != nil || !ok {
+		return false, err
+	}
+	if headSHA != expectedSHA {
+		return false, fmt.Errorf(
+			"existing worktree branch %q points at %s, not current workspace head %s",
+			currentBranch, headSHA, expectedSHA,
+		)
+	}
+	return true, nil
 }
 
 func worktreeCurrentBranch(ctx context.Context, path string) (string, error) {
@@ -1141,14 +1220,16 @@ func (m *Manager) addWorktreeLocked(
 		return branch, nil
 	}
 	fallbackBranch := syntheticPRWorktreeBranch(ws.ItemNumber)
-	useMergeRequestHeadRef := !localBase
-	if localBase {
-		// Providers may not retain a synthetic MR head ref. Try to populate it
-		// for deleted-head recovery, but do not trust a local stale copy when
-		// the exact refresh fails.
-		useMergeRequestHeadRef = m.fetchWorkspaceMergeRequestHeadRef(
-			ctx, cloneDir, ws,
-		) == nil
+	// Providers may not retain a synthetic MR head ref. Try to populate the
+	// specific ref needed for this workspace, but do not trust a local stale
+	// copy when the exact refresh fails.
+	fetchHeadErr := m.fetchWorkspaceMergeRequestHeadRef(ctx, cloneDir, ws)
+	useMergeRequestHeadRef := fetchHeadErr == nil
+	if !useMergeRequestHeadRef && ws.MRHeadRepo != nil {
+		return "", fmt.Errorf(
+			"preferred branch %q failed: %w; fallback branch %q failed: fetch merge request head ref: %w",
+			ws.GitHeadRef, err, fallbackBranch, fetchHeadErr,
+		)
 	}
 	startRef, startRefErr := workspaceFallbackStartRef(
 		ctx, cloneDir, ws, useMergeRequestHeadRef,

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -500,20 +500,29 @@ func (m *Manager) Setup(
 		ws.ID, workspaceSetupStageSetup, "started",
 		"starting workspace setup",
 	)
-	gitDir, refreshBeforeAdd, err := m.workspaceSetupGitDir(ctx, ws)
-	if err != nil {
-		return m.failSetup(
-			ctx,
-			ws.ID, workspaceSetupStageClone, err,
-		)
-	}
 
-	branch, err := m.addWorktree(ctx, gitDir, refreshBeforeAdd, ws)
+	branch, reusedWorktree, err := m.reuseExistingWorkspaceWorktree(ctx, ws)
+	var gitDir string
 	if err != nil {
-		return m.failSetup(
-			ctx,
-			ws.ID, workspaceSetupStageWorktree, err,
-		)
+		return m.failSetup(ctx, ws.ID, workspaceSetupStageWorktree, err)
+	}
+	if !reusedWorktree {
+		var refreshBeforeAdd bool
+		gitDir, refreshBeforeAdd, err = m.workspaceSetupGitDir(ctx, ws)
+		if err != nil {
+			return m.failSetup(
+				ctx,
+				ws.ID, workspaceSetupStageClone, err,
+			)
+		}
+
+		branch, err = m.addWorktree(ctx, gitDir, refreshBeforeAdd, ws)
+		if err != nil {
+			return m.failSetup(
+				ctx,
+				ws.ID, workspaceSetupStageWorktree, err,
+			)
+		}
 	}
 	persistedBranch := branch
 	if ws.ItemType == db.WorkspaceItemTypeIssue && ws.WorkspaceBranch == "" {
@@ -523,7 +532,9 @@ func (m *Manager) Setup(
 	if err := m.updateWorkspaceBranch(
 		ctx, ws.ID, persistedBranch,
 	); err != nil {
-		m.rollbackWorktree(ctx, gitDir, ws, branch)
+		if !reusedWorktree {
+			m.rollbackWorktree(ctx, gitDir, ws, branch)
+		}
 		return m.failSetup(
 			ctx,
 			ws.ID, workspaceSetupStageWorktree, err,
@@ -532,7 +543,9 @@ func (m *Manager) Setup(
 
 	err = m.newTerminalSession(ctx, ws)
 	if err != nil {
-		m.rollbackWorktree(ctx, gitDir, ws, branch)
+		if !reusedWorktree {
+			m.rollbackWorktree(ctx, gitDir, ws, branch)
+		}
 		return m.failSetup(
 			ctx,
 			ws.ID, workspaceSetupStageTmuxSession, err,
@@ -564,6 +577,62 @@ func (m *Manager) Setup(
 		)
 	}
 	return nil
+}
+
+func (m *Manager) reuseExistingWorkspaceWorktree(
+	ctx context.Context, ws *Workspace,
+) (string, bool, error) {
+	info, err := os.Stat(ws.WorktreePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("stat existing worktree: %w", err)
+	}
+	if !info.IsDir() {
+		return "", false, nil
+	}
+	commonDir, err := worktreeCommonGitDir(ctx, ws.WorktreePath)
+	if err != nil {
+		if isGitWorktreeAbsent(err) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("inspect existing worktree: %w", err)
+	}
+	if !gitDirMatchesWorkspaceRepo(ctx, commonDir, ws) {
+		return "", false, nil
+	}
+	owned, err := gitDirOwnsLinkedWorktree(ctx, commonDir, ws.WorktreePath)
+	if err != nil {
+		return "", false, err
+	}
+	if !owned {
+		return "", false, nil
+	}
+	currentBranch, err := worktreeCurrentBranch(ctx, ws.WorktreePath)
+	if err != nil {
+		return "", false, err
+	}
+	return existingWorkspacePersistedBranch(ws, currentBranch), true, nil
+}
+
+func existingWorkspacePersistedBranch(ws *Workspace, currentBranch string) string {
+	if ws.WorkspaceBranch != "" && ws.WorkspaceBranch != workspaceBranchUnknown {
+		return ws.WorkspaceBranch
+	}
+	if ws.ItemType == db.WorkspaceItemTypePullRequest &&
+		currentBranch == syntheticPRWorktreeBranch(ws.ItemNumber) {
+		return currentBranch
+	}
+	return ws.WorkspaceBranch
+}
+
+func worktreeCurrentBranch(ctx context.Context, path string) (string, error) {
+	out, err := gitCombinedOutput(ctx, path, "branch", "--show-current")
+	if err != nil {
+		return "", fmt.Errorf("inspect existing worktree branch: %w", err)
+	}
+	return strings.TrimSpace(out), nil
 }
 
 func (m *Manager) workspaceSetupGitDir(

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -581,6 +581,43 @@ func TestSetupReusesExistingWorkspaceWorktree(t *testing.T) {
 	assert.Contains(argvs[0], ws.WorktreePath)
 }
 
+func TestSetupRejectsExistingPRWorktreeOnUnexpectedBranch(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	wtDir := t.TempDir()
+
+	localRepo, _, platformHost := setupHTTPWorktreeBaseForWorkspaceGitTest(
+		t, "feature/thing",
+	)
+	repoID := seedRepo(t, d, platformHost, "acme", "widget")
+	seedMR(t, d, repoID, 42, "feature/thing")
+
+	tmuxScript, _ := writeRecorderScript(t)
+
+	mgr := NewManager(d, wtDir)
+	mgr.SetTmuxCommand([]string{tmuxScript})
+	mgr.SetWorktreeBasePathResolver(staticBaseResolver(localRepo))
+
+	ws, err := mgr.Create(t.Context(), "github", platformHost, "acme", "widget", 42)
+	require.NoError(err)
+	runWorkspaceTestGit(
+		t, localRepo,
+		"worktree", "add", ws.WorktreePath, "-b", "wrong/main", "main",
+	)
+
+	err = mgr.Setup(t.Context(), ws)
+
+	require.Error(err)
+	got, getErr := d.GetWorkspace(t.Context(), ws.ID)
+	require.NoError(getErr)
+	require.NotNil(got)
+	assert.Equal("error", got.Status)
+	require.NotNil(got.ErrorMessage)
+	assert.Contains(*got.ErrorMessage, "existing worktree branch")
+	assert.Contains(*got.ErrorMessage, "wrong/main")
+}
+
 func TestValidateWorktreeBasePathRejectsLocalRemotes(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
@@ -1819,6 +1856,54 @@ func TestAddWorktreeLocalBaseFetchesPullRefWhenHeadBranchDeleted(t *testing.T) {
 	headSHA, err := gitHeadSHA(t.Context(), ws.WorktreePath)
 	require.NoError(err)
 	assert.Equal(wantSHA, headSHA)
+}
+
+func TestAddWorktreeLocalBaseIgnoresStalePullRefWhenFetchFails(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	const branch = "feature/live"
+	const prNumber = 44
+	localRepo, _, _ := setupHTTPWorktreeBaseForWorkspaceGitTest(t, branch)
+	originSHA := strings.TrimSpace(string(runWorkspaceTestGit(
+		t, localRepo, "rev-parse", "refs/remotes/origin/"+branch,
+	)))
+	treeSHA := strings.TrimSpace(string(runWorkspaceTestGit(
+		t, localRepo, "rev-parse", "main^{tree}",
+	)))
+	staleSHA := strings.TrimSpace(string(runWorkspaceTestGit(
+		t, localRepo,
+		"commit-tree", treeSHA,
+		"-p", originSHA,
+		"-m", "stale pull head",
+	)))
+	require.NotEqual(originSHA, staleSHA)
+	runWorkspaceTestGit(
+		t, localRepo, "update-ref",
+		fmt.Sprintf("refs/pull/%d/head", prNumber), staleSHA,
+	)
+	existingWorktree := filepath.Join(t.TempDir(), "existing")
+	runWorkspaceTestGit(
+		t, localRepo, "worktree", "add", existingWorktree,
+		"-b", branch, "refs/remotes/origin/"+branch,
+	)
+	mgr := NewManager(openTestDB(t), t.TempDir())
+	ws := &Workspace{
+		Platform:     "github",
+		PlatformHost: "127.0.0.1",
+		ItemType:     db.WorkspaceItemTypePullRequest,
+		ItemNumber:   prNumber,
+		GitHeadRef:   branch,
+		WorktreePath: filepath.Join(t.TempDir(), "worktree"),
+	}
+
+	gotBranch, err := mgr.addWorktree(t.Context(), localRepo, true, ws)
+
+	require.NoError(err)
+	assert.Equal(syntheticPRWorktreeBranch(prNumber), gotBranch)
+	headSHA, err := gitHeadSHA(t.Context(), ws.WorktreePath)
+	require.NoError(err)
+	assert.Equal(originSHA, headSHA)
 }
 
 func TestLocalBaseExistingPRBranchIsNotDeletedOnCleanup(t *testing.T) {

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -581,6 +581,49 @@ func TestSetupReusesExistingWorkspaceWorktree(t *testing.T) {
 	assert.Contains(argvs[0], ws.WorktreePath)
 }
 
+func TestSetupReusesExistingLocalBasePRHeadBranchWithoutManagingIt(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	wtDir := t.TempDir()
+
+	localRepo, _, platformHost := setupHTTPWorktreeBaseForWorkspaceGitTest(
+		t, "feature/thing",
+	)
+	repoID := seedRepo(t, d, platformHost, "acme", "widget")
+	seedMR(t, d, repoID, 42, "feature/thing")
+
+	tmuxScript, _ := writeRecorderScript(t)
+
+	mgr := NewManager(d, wtDir)
+	mgr.SetTmuxCommand([]string{tmuxScript})
+	mgr.SetWorktreeBasePathResolver(staticBaseResolver(localRepo))
+
+	ws, err := mgr.Create(t.Context(), "github", platformHost, "acme", "widget", 42)
+	require.NoError(err)
+	runWorkspaceTestGit(
+		t, localRepo,
+		"branch", "feature/thing", "refs/remotes/origin/feature/thing",
+	)
+	runWorkspaceTestGit(
+		t, localRepo,
+		"worktree", "add", ws.WorktreePath, "feature/thing",
+	)
+
+	require.NoError(mgr.Setup(t.Context(), ws))
+
+	got, err := d.GetWorkspace(t.Context(), ws.ID)
+	require.NoError(err)
+	require.NotNil(got)
+	assert.Equal("ready", got.Status)
+	assert.Empty(got.WorkspaceBranch)
+
+	require.NoError(mgr.cleanupWorkspaceArtifactsForDelete(t.Context(), got))
+	exists, err := localBranchExists(t.Context(), localRepo, "feature/thing")
+	require.NoError(err)
+	assert.True(exists)
+}
+
 func TestSetupRejectsExistingPRWorktreeOnUnexpectedBranch(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -1992,6 +1992,46 @@ func TestAddWorktreeMergedSameRepoPRUsesPullRefWhenHeadBranchDeleted(
 	assert.Equal(headSHA, gotSHA)
 }
 
+func TestAddWorktreeGitLabMRUsesMergeRequestRefWhenHeadBranchDeleted(
+	t *testing.T,
+) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	cloneDir := setupBareCloneForWorkspaceGitTest(t)
+	mrNumber := 546
+	headBranch := "feature/gitlab-merged"
+	headSHA := configureGitLabMRRefs(t, cloneDir, headBranch, mrNumber)
+	runWorkspaceTestGit(
+		t, cloneDir, "update-ref", "-d",
+		"refs/remotes/origin/"+headBranch,
+	)
+
+	ws := &Workspace{
+		ID:              "ws-merged-gitlab-mr",
+		Platform:        "gitlab",
+		PlatformHost:    "gitlab.com",
+		RepoOwner:       "middleman",
+		RepoName:        "middleman",
+		ItemType:        db.WorkspaceItemTypePullRequest,
+		ItemNumber:      mrNumber,
+		GitHeadRef:      headBranch,
+		WorkspaceBranch: workspaceBranchUnknown,
+		WorktreePath:    filepath.Join(t.TempDir(), "worktree"),
+		TmuxSession:     "ws-merged-gitlab-mr",
+		Status:          "creating",
+	}
+	mgr := NewManager(openTestDB(t), t.TempDir())
+
+	branch, err := mgr.addWorktreeLocked(t.Context(), cloneDir, false, ws)
+
+	require.NoError(err)
+	assert.Equal(syntheticPRWorktreeBranch(mrNumber), branch)
+	gotSHA, err := gitHeadSHA(t.Context(), ws.WorktreePath)
+	require.NoError(err)
+	assert.Equal(headSHA, gotSHA)
+}
+
 func TestRollbackWorktreeDeletesBranchWhenContextCanceled(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
@@ -2276,6 +2316,24 @@ func configureSameRepoPRRefs(
 	runWorkspaceTestGit(
 		t, cloneDir, "update-ref",
 		fmt.Sprintf("refs/pull/%d/head", prNumber), sha,
+	)
+	return sha
+}
+
+func configureGitLabMRRefs(
+	t *testing.T, cloneDir, branch string, mrNumber int,
+) string {
+	t.Helper()
+	out, err := gitOutput(t.Context(), cloneDir, "rev-parse", "main")
+	require.NoError(t, err)
+	sha := strings.TrimSpace(out)
+	require.NotEmpty(t, sha)
+	runWorkspaceTestGit(
+		t, cloneDir, "update-ref", "refs/remotes/origin/"+branch, sha,
+	)
+	runWorkspaceTestGit(
+		t, cloneDir, "update-ref",
+		fmt.Sprintf("refs/merge-requests/%d/head", mrNumber), sha,
 	)
 	return sha
 }

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -539,6 +539,48 @@ func TestSetupUsesConfiguredWorktreeBasePath(t *testing.T) {
 	assert.Equal(sourceSHA, headSHA)
 }
 
+func TestSetupReusesExistingWorkspaceWorktree(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	wtDir := t.TempDir()
+
+	localRepo, _, platformHost := setupHTTPWorktreeBaseForWorkspaceGitTest(
+		t, "feature/thing",
+	)
+	repoID := seedRepo(t, d, platformHost, "acme", "widget")
+	seedMR(t, d, repoID, 42, "feature/thing")
+
+	tmuxScript, tmuxRecord := writeRecorderScript(t)
+
+	mgr := NewManager(d, wtDir)
+	mgr.SetTmuxCommand([]string{tmuxScript})
+	mgr.SetWorktreeBasePathResolver(staticBaseResolver(localRepo))
+
+	ws, err := mgr.Create(t.Context(), "github", platformHost, "acme", "widget", 42)
+	require.NoError(err)
+	existingBranch := syntheticPRWorktreeBranch(42)
+	runWorkspaceTestGit(
+		t, localRepo,
+		"worktree", "add", ws.WorktreePath, "-b", existingBranch, "HEAD",
+	)
+
+	require.NoError(mgr.Setup(t.Context(), ws))
+
+	got, err := d.GetWorkspace(t.Context(), ws.ID)
+	require.NoError(err)
+	require.NotNil(got)
+	assert.Equal("ready", got.Status)
+	assert.Equal(existingBranch, got.WorkspaceBranch)
+	headBranch := strings.TrimSpace(string(runWorkspaceTestGit(
+		t, ws.WorktreePath, "branch", "--show-current",
+	)))
+	assert.Equal(existingBranch, headBranch)
+	argvs := readRecorderArgv(t, tmuxRecord)
+	require.NotEmpty(argvs)
+	assert.Contains(argvs[0], ws.WorktreePath)
+}
+
 func TestValidateWorktreeBasePathRejectsLocalRemotes(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -1771,6 +1771,56 @@ func TestAddWorktreeUsesFallbackWhenLocalBasePreferredBranchCheckedOut(t *testin
 	assert.Equal(originSHA, headSHA)
 }
 
+func TestAddWorktreeLocalBaseFetchesPullRefWhenHeadBranchDeleted(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	const branch = "feature/deleted"
+	const prNumber = 43
+	localRepo, remote, platformHost := setupHTTPWorktreeBaseForWorkspaceGitTest(
+		t, branch,
+	)
+	wantSHA := strings.TrimSpace(string(runWorkspaceTestGit(
+		t, localRepo, "rev-parse", "refs/remotes/origin/"+branch,
+	)))
+	runWorkspaceTestGit(
+		t, remote, "update-ref",
+		fmt.Sprintf("refs/pull/%d/head", prNumber), wantSHA,
+	)
+	runWorkspaceTestGit(t, remote, "update-ref", "-d", "refs/heads/"+branch)
+	runWorkspaceTestGit(t, remote, "update-server-info")
+	runWorkspaceTestGit(t, localRepo, "fetch", "--prune", "origin")
+	_, exists, err := gitRefSHA(
+		t.Context(), localRepo, "refs/remotes/origin/"+branch,
+	)
+	require.NoError(err)
+	require.False(exists)
+	_, exists, err = gitRefSHA(
+		t.Context(), localRepo,
+		fmt.Sprintf("refs/pull/%d/head", prNumber),
+	)
+	require.NoError(err)
+	require.False(exists)
+
+	mgr := NewManager(openTestDB(t), t.TempDir())
+	ws := &Workspace{
+		Platform:     "github",
+		PlatformHost: platformHost,
+		ItemType:     db.WorkspaceItemTypePullRequest,
+		ItemNumber:   prNumber,
+		GitHeadRef:   branch,
+		WorktreePath: filepath.Join(t.TempDir(), "worktree"),
+	}
+
+	gotBranch, err := mgr.addWorktree(t.Context(), localRepo, true, ws)
+
+	require.NoError(err)
+	assert.Equal(syntheticPRWorktreeBranch(prNumber), gotBranch)
+	headSHA, err := gitHeadSHA(t.Context(), ws.WorktreePath)
+	require.NoError(err)
+	assert.Equal(wantSHA, headSHA)
+}
+
 func TestLocalBaseExistingPRBranchIsNotDeletedOnCleanup(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -581,6 +581,85 @@ func TestSetupReusesExistingWorkspaceWorktree(t *testing.T) {
 	assert.Contains(argvs[0], ws.WorktreePath)
 }
 
+func TestSetupDoesNotReuseUnconfiguredMatchingOriginWorktree(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	wtDir := t.TempDir()
+
+	localRepo, _, platformHost := setupHTTPWorktreeBaseForWorkspaceGitTest(
+		t, "feature/thing",
+	)
+	repoID := seedRepo(t, d, platformHost, "acme", "widget")
+	seedMR(t, d, repoID, 42, "feature/thing")
+
+	tmuxScript, _ := writeRecorderScript(t)
+
+	mgr := NewManager(d, wtDir)
+	mgr.SetTmuxCommand([]string{tmuxScript})
+
+	ws, err := mgr.Create(t.Context(), "github", platformHost, "acme", "widget", 42)
+	require.NoError(err)
+	runWorkspaceTestGit(
+		t, localRepo,
+		"worktree", "add", ws.WorktreePath,
+		"-b", syntheticPRWorktreeBranch(42), "HEAD",
+	)
+
+	err = mgr.Setup(t.Context(), ws)
+
+	require.Error(err)
+	assert.Contains(err.Error(), "clone manager not set")
+	got, getErr := d.GetWorkspace(t.Context(), ws.ID)
+	require.NoError(getErr)
+	require.NotNil(got)
+	assert.Equal("error", got.Status)
+	assert.Equal(workspaceBranchUnknown, got.WorkspaceBranch)
+}
+
+func TestSetupRejectsExistingLocalBaseWorktreeWithExecutableConfig(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	wtDir := t.TempDir()
+
+	localRepo, _, platformHost := setupHTTPWorktreeBaseForWorkspaceGitTest(
+		t, "feature/thing",
+	)
+	repoID := seedRepo(t, d, platformHost, "acme", "widget")
+	seedMR(t, d, repoID, 42, "feature/thing")
+
+	tmuxScript, _ := writeRecorderScript(t)
+
+	mgr := NewManager(d, wtDir)
+	mgr.SetTmuxCommand([]string{tmuxScript})
+	mgr.SetWorktreeBasePathResolver(staticBaseResolver(localRepo))
+
+	ws, err := mgr.Create(t.Context(), "github", platformHost, "acme", "widget", 42)
+	require.NoError(err)
+	runWorkspaceTestGit(
+		t, localRepo,
+		"worktree", "add", ws.WorktreePath,
+		"-b", syntheticPRWorktreeBranch(42), "HEAD",
+	)
+	runWorkspaceTestGit(t, localRepo, "config", "extensions.worktreeConfig", "true")
+	runWorkspaceTestGit(
+		t, ws.WorktreePath,
+		"config", "--worktree", "core.fsmonitor", "demo-fsmonitor",
+	)
+
+	err = mgr.Setup(t.Context(), ws)
+
+	require.Error(err)
+	assert.Contains(err.Error(), "local git config")
+	assert.Contains(err.Error(), "core.fsmonitor")
+	got, getErr := d.GetWorkspace(t.Context(), ws.ID)
+	require.NoError(getErr)
+	require.NotNil(got)
+	assert.Equal("error", got.Status)
+	assert.Equal(workspaceBranchUnknown, got.WorkspaceBranch)
+}
+
 func TestSetupRejectsExistingSyntheticPRWorktreeOnStaleHead(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
@@ -2184,6 +2263,51 @@ func TestAddPreferredWorktreeHeadRepoRouting(t *testing.T) {
 			assert.Equal(want.mergeRef, mergeRef)
 		})
 	}
+}
+
+func TestAddWorktreeGitLabForkMRFetchesHeadBeforePreferredBranch(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	cloneDir := setupBareCloneForWorkspaceGitTest(t)
+	mrNumber := 547
+	headBranch := "contributor/gitlab-fork"
+	treeSHA := strings.TrimSpace(string(runWorkspaceTestGit(
+		t, cloneDir, "rev-parse", "main^{tree}",
+	)))
+	headSHA := strings.TrimSpace(string(runWorkspaceTestGit(
+		t, cloneDir, "commit-tree", treeSHA, "-p", "main",
+		"-m", "remote fork mr head",
+	)))
+	runWorkspaceTestGit(
+		t, cloneDir, "push", "origin",
+		fmt.Sprintf("%s:refs/merge-requests/%d/head", headSHA, mrNumber),
+	)
+	headRepo := "https://gitlab.com/contributor/widget.git"
+	ws := &Workspace{
+		ID:              "ws-gitlab-fork-mr-preferred",
+		Platform:        "gitlab",
+		PlatformHost:    "gitlab.com",
+		RepoOwner:       "acme",
+		RepoName:        "widget",
+		ItemType:        db.WorkspaceItemTypePullRequest,
+		ItemNumber:      mrNumber,
+		GitHeadRef:      headBranch,
+		MRHeadRepo:      &headRepo,
+		WorkspaceBranch: workspaceBranchUnknown,
+		WorktreePath:    filepath.Join(t.TempDir(), "worktree"),
+		TmuxSession:     "ws-gitlab-fork-mr-preferred",
+		Status:          "creating",
+	}
+	mgr := NewManager(openTestDB(t), t.TempDir())
+
+	branch, err := mgr.addWorktreeLocked(t.Context(), cloneDir, false, ws)
+
+	require.NoError(err)
+	assert.Equal(headBranch, branch)
+	gotSHA, err := gitHeadSHA(t.Context(), ws.WorktreePath)
+	require.NoError(err)
+	assert.Equal(headSHA, gotSHA)
 }
 
 func TestAddWorktreeMergedSameRepoPRUsesPullRefWhenHeadBranchDeleted(

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -1910,6 +1910,46 @@ func TestAddPreferredWorktreeHeadRepoRouting(t *testing.T) {
 	}
 }
 
+func TestAddWorktreeMergedSameRepoPRUsesPullRefWhenHeadBranchDeleted(
+	t *testing.T,
+) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	cloneDir := setupBareCloneForWorkspaceGitTest(t)
+	prNumber := 545
+	headBranch := "codex/wildcard-promote-local-clones"
+	headSHA := configureSameRepoPRRefs(t, cloneDir, headBranch, prNumber)
+	runWorkspaceTestGit(
+		t, cloneDir, "update-ref", "-d",
+		"refs/remotes/origin/"+headBranch,
+	)
+
+	ws := &Workspace{
+		ID:              "ws-merged-same-repo-pr",
+		Platform:        "github",
+		PlatformHost:    "github.com",
+		RepoOwner:       "middleman",
+		RepoName:        "middleman",
+		ItemType:        db.WorkspaceItemTypePullRequest,
+		ItemNumber:      prNumber,
+		GitHeadRef:      headBranch,
+		WorkspaceBranch: workspaceBranchUnknown,
+		WorktreePath:    filepath.Join(t.TempDir(), "worktree"),
+		TmuxSession:     "ws-merged-same-repo-pr",
+		Status:          "creating",
+	}
+	mgr := NewManager(openTestDB(t), t.TempDir())
+
+	branch, err := mgr.addWorktreeLocked(t.Context(), cloneDir, false, ws)
+
+	require.NoError(err)
+	assert.Equal(syntheticPRWorktreeBranch(prNumber), branch)
+	gotSHA, err := gitHeadSHA(t.Context(), ws.WorktreePath)
+	require.NoError(err)
+	assert.Equal(headSHA, gotSHA)
+}
+
 func TestRollbackWorktreeDeletesBranchWhenContextCanceled(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -581,6 +581,62 @@ func TestSetupReusesExistingWorkspaceWorktree(t *testing.T) {
 	assert.Contains(argvs[0], ws.WorktreePath)
 }
 
+func TestSetupRejectsExistingSyntheticPRWorktreeOnStaleHead(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	wtDir := t.TempDir()
+
+	localRepo, remote, platformHost := setupHTTPWorktreeBaseForWorkspaceGitTest(
+		t, "feature/thing",
+	)
+	repoID := seedRepo(t, d, platformHost, "acme", "widget")
+	seedMR(t, d, repoID, 42, "feature/thing")
+
+	tmuxScript, _ := writeRecorderScript(t)
+
+	mgr := NewManager(d, wtDir)
+	mgr.SetTmuxCommand([]string{tmuxScript})
+	mgr.SetWorktreeBasePathResolver(staticBaseResolver(localRepo))
+
+	ws, err := mgr.Create(t.Context(), "github", platformHost, "acme", "widget", 42)
+	require.NoError(err)
+	existingBranch := syntheticPRWorktreeBranch(42)
+	runWorkspaceTestGit(
+		t, localRepo,
+		"worktree", "add", ws.WorktreePath, "-b", existingBranch, "HEAD",
+	)
+
+	require.NoError(os.WriteFile(
+		filepath.Join(localRepo, "new-head.txt"), []byte("new head\n"), 0o644,
+	))
+	runWorkspaceTestGit(t, localRepo, "add", ".")
+	runWorkspaceTestGit(t, localRepo, "commit", "-m", "new pr head")
+	newHead := strings.TrimSpace(string(runWorkspaceTestGit(
+		t, localRepo, "rev-parse", "HEAD",
+	)))
+	runWorkspaceTestGit(
+		t, localRepo, "push", remote,
+		"HEAD:refs/heads/feature/thing",
+	)
+	runWorkspaceTestGit(t, remote, "update-server-info")
+
+	err = mgr.Setup(t.Context(), ws)
+
+	require.Error(err)
+	assert.Contains(err.Error(), "not current workspace head")
+	got, getErr := d.GetWorkspace(t.Context(), ws.ID)
+	require.NoError(getErr)
+	require.NotNil(got)
+	assert.Equal("error", got.Status)
+	require.NotNil(got.ErrorMessage)
+	assert.Contains(*got.ErrorMessage, "not current workspace head")
+	gotHead := strings.TrimSpace(string(runWorkspaceTestGit(
+		t, localRepo, "rev-parse", "refs/remotes/origin/feature/thing",
+	)))
+	assert.Equal(newHead, gotHead)
+}
+
 func TestSetupReusesExistingLocalBasePRHeadBranchWithoutManagingIt(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
@@ -2141,6 +2197,10 @@ func TestAddWorktreeMergedSameRepoPRUsesPullRefWhenHeadBranchDeleted(
 	headBranch := "codex/wildcard-promote-local-clones"
 	headSHA := configureSameRepoPRRefs(t, cloneDir, headBranch, prNumber)
 	runWorkspaceTestGit(
+		t, cloneDir, "push", "origin",
+		fmt.Sprintf("%s:refs/pull/%d/head", headSHA, prNumber),
+	)
+	runWorkspaceTestGit(
 		t, cloneDir, "update-ref", "-d",
 		"refs/remotes/origin/"+headBranch,
 	)
@@ -2181,6 +2241,10 @@ func TestAddWorktreeGitLabMRUsesMergeRequestRefWhenHeadBranchDeleted(
 	headBranch := "feature/gitlab-merged"
 	headSHA := configureGitLabMRRefs(t, cloneDir, headBranch, mrNumber)
 	runWorkspaceTestGit(
+		t, cloneDir, "push", "origin",
+		fmt.Sprintf("%s:refs/merge-requests/%d/head", headSHA, mrNumber),
+	)
+	runWorkspaceTestGit(
 		t, cloneDir, "update-ref", "-d",
 		"refs/remotes/origin/"+headBranch,
 	)
@@ -2208,6 +2272,55 @@ func TestAddWorktreeGitLabMRUsesMergeRequestRefWhenHeadBranchDeleted(
 	gotSHA, err := gitHeadSHA(t.Context(), ws.WorktreePath)
 	require.NoError(err)
 	assert.Equal(headSHA, gotSHA)
+}
+
+func TestAddWorktreeGitLabMRFetchesSpecificMergeRequestRef(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	cloneDir := setupBareCloneForWorkspaceGitTest(t)
+	mrNumber := 546
+	headBranch := "feature/gitlab-merged"
+	treeSHA := strings.TrimSpace(string(runWorkspaceTestGit(
+		t, cloneDir, "rev-parse", "main^{tree}",
+	)))
+	headSHA := strings.TrimSpace(string(runWorkspaceTestGit(
+		t, cloneDir, "commit-tree", treeSHA, "-p", "main",
+		"-m", "remote mr head",
+	)))
+	runWorkspaceTestGit(
+		t, cloneDir, "push", "origin",
+		fmt.Sprintf("%s:refs/merge-requests/%d/head", headSHA, mrNumber),
+	)
+
+	ws := &Workspace{
+		ID:              "ws-merged-gitlab-mr-specific-fetch",
+		Platform:        "gitlab",
+		PlatformHost:    "gitlab.com",
+		RepoOwner:       "middleman",
+		RepoName:        "middleman",
+		ItemType:        db.WorkspaceItemTypePullRequest,
+		ItemNumber:      mrNumber,
+		GitHeadRef:      headBranch,
+		WorkspaceBranch: workspaceBranchUnknown,
+		WorktreePath:    filepath.Join(t.TempDir(), "worktree"),
+		TmuxSession:     "ws-merged-gitlab-mr-specific-fetch",
+		Status:          "creating",
+	}
+	mgr := NewManager(openTestDB(t), t.TempDir())
+
+	branch, err := mgr.addWorktreeLocked(t.Context(), cloneDir, false, ws)
+
+	require.NoError(err)
+	assert.Equal(syntheticPRWorktreeBranch(mrNumber), branch)
+	gotSHA, err := gitHeadSHA(t.Context(), ws.WorktreePath)
+	require.NoError(err)
+	assert.Equal(headSHA, gotSHA)
+	gotRef := strings.TrimSpace(string(runWorkspaceTestGit(
+		t, cloneDir, "rev-parse",
+		fmt.Sprintf("refs/merge-requests/%d/head", mrNumber),
+	)))
+	assert.Equal(headSHA, gotRef)
 }
 
 func TestRollbackWorktreeDeletesBranchWhenContextCanceled(t *testing.T) {


### PR DESCRIPTION
## Summary
- Reuse an already-existing workspace worktree when it matches the expected repo and branch state
- Skip unnecessary worktree cleanup when setup is reattaching to an owned existing worktree
- Fall back to provider merge-request head refs when the preferred branch ref is unavailable during worktree creation
- Cover the reuse path and the same-repo PR fallback with targeted tests

## Testing
- Added workspace setup coverage for reusing an existing worktree
- Added worktree creation coverage for same-repo PRs after the head branch ref has been deleted