### PR TITLE
Hide disabled workspace agents from launch controls

### DIFF
--- a/cmd/middleman/api_verb_e2e_test.go
+++ b/cmd/middleman/api_verb_e2e_test.go
@@ -188,7 +188,7 @@ func TestAPIVerbE2EWithBasePath(t *testing.T) {
 		return err == nil &&
 			strings.Contains(stdout.String(), `"hosts"`)
 	}
-	require.Eventually(callSnapshot, 10*time.Second, 200*time.Millisecond,
+	require.Eventually(callSnapshot, 30*time.Second, 200*time.Millisecond,
 		"api verb must reach the snapshot under the base path")
 
 	// base_path is startup-bound: editing the config while the old

--- a/frontend/src/App.workspace-launch-targets.browser.svelte.ts
+++ b/frontend/src/App.workspace-launch-targets.browser.svelte.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { page } from "vite-plus/test/browser";
+
+import { mountBrowserApp, resetKeyboardModuleState, type MountedBrowserApp } from "./test/browserAppHarness.js";
+import { jsonResponse, type MockRouteOverride } from "./test/mockApiFetch.js";
+
+const workspace = {
+  id: "ws-123",
+  platform_host: "github.com",
+  repo_owner: "acme",
+  repo_name: "widgets",
+  repo: {
+    provider: "github",
+    platform_host: "github.com",
+    owner: "acme",
+    name: "widgets",
+    repo_path: "acme/widgets",
+  },
+  item_type: "pull_request",
+  item_number: 42,
+  git_head_ref: "feature/auth",
+  worktree_path: "/tmp/worktrees/ws-123",
+  tmux_session: "middleman-ws-123",
+  tmux_pane_title: null,
+  tmux_working: false,
+  status: "ready",
+  created_at: "2026-04-10T12:00:00Z",
+  mr_title: "Add auth middleware",
+  mr_state: "open",
+  mr_is_draft: false,
+};
+
+const runtime = {
+  launch_targets: [
+    {
+      key: "codex",
+      label: "Codex",
+      kind: "agent",
+      source: "builtin",
+      command: ["codex"],
+      available: true,
+    },
+    {
+      key: "missing",
+      label: "Missing",
+      kind: "agent",
+      source: "builtin",
+      command: ["missing"],
+      available: false,
+      disabled_reason: "missing not found on PATH",
+    },
+    {
+      key: "disabled_config",
+      label: "Disabled config",
+      kind: "agent",
+      source: "config",
+      command: ["disabled"],
+      available: false,
+      disabled_reason: "disabled by config",
+    },
+    {
+      key: "plain_shell",
+      label: "Plain shell",
+      kind: "plain_shell",
+      source: "system",
+      command: ["/bin/sh"],
+      available: true,
+    },
+  ],
+  sessions: [],
+};
+
+const workspaceRoutes: MockRouteOverride = (req) => {
+  if (req.method === "GET" && req.url.pathname === "/api/v1/workspaces") {
+    return jsonResponse({ workspaces: [workspace] });
+  }
+  if (req.method === "GET" && req.url.pathname === "/api/v1/workspaces/ws-123") {
+    return jsonResponse(workspace);
+  }
+  if (req.method === "GET" && req.url.pathname === "/api/v1/workspaces/ws-123/runtime") {
+    return jsonResponse(runtime);
+  }
+  if (
+    req.method === "GET" &&
+    (req.url.pathname === "/api/v1/workspaces/ws-123/files" || req.url.pathname === "/api/v1/workspaces/ws-123/diff")
+  ) {
+    return jsonResponse({
+      stale: false,
+      whitespace_only_count: 0,
+      files: [],
+    });
+  }
+  if (req.method === "GET" && req.url.pathname === "/api/v1/workspaces/ws-123/commits") {
+    return jsonResponse({ commits: [] });
+  }
+  return null;
+};
+
+let mounted: MountedBrowserApp | null = null;
+
+describe("workspace launch targets (browser)", () => {
+  vi.setConfig({ testTimeout: 20_000 });
+
+  beforeEach(async () => {
+    mounted = null;
+    await page.viewport(1280, 900);
+  });
+
+  afterEach(async () => {
+    mounted?.unmount();
+    mounted = null;
+    localStorage.clear();
+    await resetKeyboardModuleState();
+  });
+
+  it("hides disabled configured targets from home cards and the toolbar menu", async () => {
+    mounted = await mountBrowserApp("/terminal/ws-123", {
+      overrides: [workspaceRoutes],
+    });
+
+    await vi.waitFor(
+      () => {
+        expect(page.getByRole("region", { name: "Worktree Home" }).element()).toBeTruthy();
+      },
+      { timeout: 10_000, interval: 50 },
+    );
+
+    const home = page.getByRole("region", { name: "Worktree Home" });
+    const homeEl = home.element();
+    expect(home.getByRole("button", { name: "Codex" }).element()).toBeTruthy();
+    expect(home.getByRole("button", { name: "Missing" }).element().hasAttribute("disabled")).toBe(true);
+    expect(home.getByRole("button", { name: "Shell" }).element()).toBeTruthy();
+    expect(homeEl.textContent).not.toContain("Disabled config");
+
+    await page.getByRole("button", { name: "Launch" }).click();
+
+    const menu = document.querySelector(".launch-popover");
+    expect(menu).not.toBeNull();
+    const options = Array.from(menu!.querySelectorAll("button"));
+    const optionText = (button: HTMLButtonElement) => button.textContent ?? "";
+    const missingOption = options.find((button) => optionText(button).includes("Missing"));
+    expect(options.some((button) => optionText(button).includes("Codex"))).toBe(true);
+    expect(missingOption?.hasAttribute("disabled")).toBe(true);
+    expect(options.some((button) => optionText(button).includes("Shell"))).toBe(true);
+    expect(menu!.textContent).not.toContain("Disabled config");
+  });
+});

--- a/frontend/src/lib/components/terminal/LaunchMenu.svelte
+++ b/frontend/src/lib/components/terminal/LaunchMenu.svelte
@@ -5,6 +5,7 @@
   import TerminalIcon from "@lucide/svelte/icons/terminal";
   import SparklesIcon from "@lucide/svelte/icons/sparkles";
   import BoxIcon from "@lucide/svelte/icons/box";
+  import { isVisibleLaunchTarget } from "./launchTargets";
 
   interface LaunchMenuProps {
     launchTargets: LaunchTarget[];
@@ -21,9 +22,7 @@
   let open = $state(false);
   let rootEl = $state<HTMLDivElement | null>(null);
 
-  const visibleTargets = $derived(
-    launchTargets.filter((target) => target.kind !== "shell"),
-  );
+  const visibleTargets = $derived(launchTargets.filter(isVisibleLaunchTarget));
 
   function launch(targetKey: string): void {
     open = false;

--- a/frontend/src/lib/components/terminal/LaunchMenu.test.ts
+++ b/frontend/src/lib/components/terminal/LaunchMenu.test.ts
@@ -1,0 +1,60 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+import LaunchMenu from "./LaunchMenu.svelte";
+
+describe("LaunchMenu", () => {
+  afterEach(() => cleanup());
+
+  it("hides disabled configured targets but keeps unavailable detected targets visible", async () => {
+    const onLaunch = vi.fn();
+
+    render(LaunchMenu, {
+      props: {
+        launchTargets: [
+          {
+            key: "codex",
+            label: "Codex",
+            kind: "agent",
+            source: "builtin",
+            available: true,
+          },
+          {
+            key: "missing",
+            label: "Missing",
+            kind: "agent",
+            source: "builtin",
+            available: false,
+            disabled_reason: "missing not found on PATH",
+          },
+          {
+            key: "disabled_config",
+            label: "Disabled config",
+            kind: "agent",
+            source: "config",
+            available: false,
+            disabled_reason: "disabled by config",
+          },
+          {
+            key: "plain_shell",
+            label: "Plain shell",
+            kind: "plain_shell",
+            source: "system",
+            available: true,
+          },
+        ],
+        onLaunch,
+      },
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Launch" }));
+
+    expect(screen.getByRole("button", { name: /Codex/ })).toBeTruthy();
+    expect((screen.getByRole("button", { name: /Missing/ }) as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.queryByRole("button", { name: /Disabled config/ })).toBeNull();
+    expect(screen.getByRole("button", { name: /Shell/ })).toBeTruthy();
+
+    await fireEvent.click(screen.getByRole("button", { name: /Codex/ }));
+    expect(onLaunch).toHaveBeenCalledWith("codex");
+  });
+});

--- a/frontend/src/lib/components/terminal/WorkspaceHome.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceHome.svelte
@@ -9,6 +9,7 @@
   import TerminalIcon from "@lucide/svelte/icons/terminal";
   import SparklesIcon from "@lucide/svelte/icons/sparkles";
   import BoxIcon from "@lucide/svelte/icons/box";
+  import { isVisibleLaunchTarget } from "./launchTargets";
 
   interface WorkspaceHomeWorkspace {
     id: string;
@@ -40,9 +41,7 @@
     onOpenSession,
   }: WorkspaceHomeProps = $props();
 
-  const visibleTargets = $derived(
-    launchTargets.filter((target) => target.kind !== "shell"),
-  );
+  const visibleTargets = $derived(launchTargets.filter(isVisibleLaunchTarget));
 
   function title(): string {
     return workspace.mr_title ?? workspace.git_head_ref;

--- a/frontend/src/lib/components/terminal/WorkspaceHome.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceHome.test.ts
@@ -38,6 +38,14 @@ describe("WorkspaceHome", () => {
             disabled_reason: "missing not found on PATH",
           },
           {
+            key: "disabled_config",
+            label: "Disabled config",
+            kind: "agent",
+            source: "config",
+            available: false,
+            disabled_reason: "disabled by config",
+          },
+          {
             key: "shell",
             label: "Shell",
             kind: "shell",
@@ -95,6 +103,7 @@ describe("WorkspaceHome", () => {
         }) as HTMLButtonElement
       ).disabled,
     ).toBe(true);
+    expect(screen.queryByRole("button", { name: "Disabled config" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Plain shell" })).toBeNull();
     expect(screen.queryByRole("button", { name: "shell" })).toBeNull();
 

--- a/frontend/src/lib/components/terminal/launchTargets.ts
+++ b/frontend/src/lib/components/terminal/launchTargets.ts
@@ -1,0 +1,6 @@
+import type { LaunchTarget } from "@middleman/ui/api/types";
+
+export function isVisibleLaunchTarget(target: LaunchTarget): boolean {
+  if (target.kind === "shell") return false;
+  return target.available || target.source !== "config";
+}


### PR DESCRIPTION
- Disabled configured workspace agents no longer appear in workspace launch controls.
- Unavailable detected tools still appear disabled so missing PATH diagnostics remain visible.