### PR TITLE
Clarify frontend test lane selection in project guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,10 +119,12 @@ make vet        # go vet
 
 ### End-to-End Tests
 
-Coverage of real behavior is non-negotiable; the lane is chosen to avoid the one expensive cost — the **browser**, not the Go backend. Two independent axes:
+Coverage of real behavior is non-negotiable; the lane is chosen by the behavior under test, not by a blanket "must have e2e" rule. Avoid the expensive lanes unless they add distinct confidence. Four independent axes:
 
-- **Browser only when you must.** Reserve Playwright for real rendering/layout: screenshots/video, `getBoundingClientRect`, scroll/sticky/overflow geometry, container queries, pointer drag, viewport emulation, canvas/xterm, computed CSS pixels. Everything else runs in **Vitest + jsdom** (`vp test`) — mount the real `App.svelte` via `frontend/src/test/appHarness.ts`. Mounting the whole app or using routing is not a reason to stay in Playwright.
-- **Real Go backend by default; mocking is the exception.** Backend-dependent behavior (sync, persistence, capabilities, normalization, wire shape) must hit real Go (`frontend/tests/e2e-full/` or `internal/server/` Go tests) — don't assert backend-computed values through a hand-written fixture. Mock the API (`frontend/src/test/mockApiFetch.ts`, never fork the Playwright copy) only for the rare scenario the seeded server can't produce.
+- **Component or app harness first.** UI-owned behavior such as filtering, sorting, hidden/disabled states, menu contents, route-derived view state, and store/component data flow should usually be covered in Vitest. Use **Vitest + jsdom** (`vp test`) when layout/browser primitives are not material; mount the real `App.svelte` via `frontend/src/test/appHarness.ts` when routing matters.
+- **Vitest browser before Playwright for real DOM needs.** Use `*.browser.svelte.ts` / `vitest-browser-svelte` (`vp test --project browser`) when the behavior needs a real browser DOM, native focus/keyboard semantics, localStorage/matchMedia, computed styles, or layout, but does not need an external HTTP server or multi-page Playwright workflow.
+- **Playwright/full-stack only for boundaries they uniquely prove.** Reserve Playwright for screenshots/video, `getBoundingClientRect`, scroll/sticky/overflow geometry, container queries, pointer drag, viewport emulation, canvas/xterm, computed CSS pixels, or workflows that must exercise browser navigation against a running app. Use `frontend/tests/e2e-full/` or `internal/server/` Go tests when the behavior depends on backend persistence, sync, capabilities, normalization, wire shape, or middleware. If a real-backend API/server test already proves the runtime path and a component/browser test proves the UI presentation, do not require duplicate full-stack e2e just to click through the same data.
+- **Mocking is the exception.** Do not assert backend-computed values through a hand-written fixture. Mock the API (`frontend/src/test/mockApiFetch.ts`, never fork the Playwright copy) only when the behavior is owned by the frontend or the seeded server cannot produce the state.
 
 ### Test Guidelines
 

--- a/context/testing.md
+++ b/context/testing.md
@@ -32,6 +32,31 @@ notice the regression:
 Regenerate OpenAPI and generated clients with `make api-generate` after Huma
 route or API type changes.
 
+## Frontend test lane selection
+
+Do not treat Playwright or full-stack e2e as a universal "must have" for every
+visible frontend fix. Pick the narrowest lane that observes the behavior's real
+owner:
+
+- Use Vitest component/store tests for UI-owned data flow, filtering, sorting,
+  hidden/disabled states, menu contents, route-derived view state, and app-shell
+  behavior that does not depend on real browser layout.
+- Use Vitest browser tests (`*.browser.svelte.ts` with `vitest-browser-svelte`)
+  when the behavior needs a real browser DOM, native focus or keyboard behavior,
+  computed styles, layout, localStorage, matchMedia, or other browser primitives,
+  but does not need an external server or Playwright navigation flow.
+- Use Playwright mock e2e when the regression is specifically about a
+  multi-step browser workflow, viewport behavior, screenshots/video, drag,
+  scroll/sticky/overflow geometry, canvas/xterm rendering, or browser navigation.
+- Use full-stack e2e or server/API tests when the disputed fact is produced by
+  backend persistence, sync, capabilities, normalization, route middleware, or
+  wire serialization.
+
+A UI regression can be sufficiently covered by a backend/server test for the
+real runtime path plus a component or Vitest browser test for presentation. Do
+not require a duplicate full-stack browser test when it would only replay data
+that is already proven at those two boundaries.
+
 ## Huma API Contract
 
 Every public operation in `/api/v1/openapi.json` must have explicit OpenAPI


### PR DESCRIPTION
## Summary
- Clarify that Playwright and full-stack e2e are not mandatory for every visible frontend change.
- Add explicit lane guidance for Vitest component tests, Vitest browser tests, Playwright, and backend/server tests.
- Note that a real backend test plus a component or browser test can be enough when they cover the runtime path and presentation separately.

## Testing
- Not run (not requested)