### PR TITLE
Fix fork-aware stack detection

### DIFF
--- a/internal/db/queries_stacks.go
+++ b/internal/db/queries_stacks.go
@@ -11,7 +11,8 @@ import (
 // ListPRsForStackDetection returns non-closed PRs for a repo (open + merged).
 func (d *DB) ListPRsForStackDetection(ctx context.Context, repoID int64) ([]MergeRequest, error) {
 	rows, err := d.ro.QueryContext(ctx, `
-		SELECT id, number, title, head_branch, base_branch, state, ci_status, review_decision
+		SELECT id, number, title, head_branch, base_branch, state, ci_status, review_decision,
+		       head_repo_clone_url
 		FROM middleman_merge_requests
 		WHERE repo_id = ? AND state IN ('open', 'merged')
 		ORDER BY number`,
@@ -29,6 +30,7 @@ func (d *DB) ListPRsForStackDetection(ctx context.Context, repoID int64) ([]Merg
 		if err := rows.Scan(
 			&mr.ID, &mr.Number, &mr.Title, &mr.HeadBranch, &mr.BaseBranch,
 			&mr.State, &mr.CIStatus, &mr.ReviewDecision,
+			&mr.HeadRepoCloneURL,
 		); err != nil {
 			return nil, fmt.Errorf("scan pr for stack detection: %w", err)
 		}

--- a/internal/platform/gitlab/client.go
+++ b/internal/platform/gitlab/client.go
@@ -363,7 +363,10 @@ func (c *Client) optionalHeadRepoCloneURL(
 	if ctxErr := ctx.Err(); ctxErr != nil {
 		return "", ctxErr
 	}
-	return "", nil
+	if isUnavailableSourceProjectError(err) {
+		return "", nil
+	}
+	return "", err
 }
 
 func (c *Client) headRepoCloneURL(
@@ -885,6 +888,18 @@ func isGitLabStatus(err error, status int) bool {
 		return true
 	}
 	return strings.Contains(err.Error(), strconv.Itoa(status))
+}
+
+func isUnavailableSourceProjectError(err error) bool {
+	var platformErr *platform.Error
+	if errors.As(err, &platformErr) {
+		if platformErr.Code == platform.ErrCodePermissionDenied ||
+			platformErr.Code == platform.ErrCodeNotFound {
+			return true
+		}
+	}
+	return isGitLabStatus(err, http.StatusForbidden) ||
+		isGitLabStatus(err, http.StatusNotFound)
 }
 
 func partialError(namespace string, page int64, err error) PartialError {

--- a/internal/platform/gitlab/client.go
+++ b/internal/platform/gitlab/client.go
@@ -42,6 +42,9 @@ type Client struct {
 	// client lifetime (user IDs are immutable).
 	userIDMu sync.Mutex
 	userIDs  map[string]int64
+
+	projectCloneURLMu sync.Mutex
+	projectCloneURLs  map[int64]string
 }
 
 type PreviewOptions struct {
@@ -119,6 +122,7 @@ func NewClient(host string, source tokenauth.Source, options ...ClientOption) (*
 		api:               api,
 		foregroundTimeout: opts.foregroundTimeout,
 		userIDs:           make(map[string]int64),
+		projectCloneURLs:  make(map[int64]string),
 	}, nil
 }
 
@@ -311,7 +315,9 @@ func (c *Client) ListOpenMergeRequests(
 			return nil, mapGitLabError("list_merge_requests", err)
 		}
 		for _, mr := range mrs {
-			out = append(out, NormalizeMergeRequest(normalizedRef, mr, nil))
+			normalized := NormalizeMergeRequest(normalizedRef, mr, nil)
+			normalized.HeadRepoCloneURL = c.headRepoCloneURL(ctx, normalizedRef, mr.ProjectID, mr.SourceProjectID)
+			out = append(out, normalized)
 		}
 		if resp == nil || resp.NextPage == 0 {
 			return out, nil
@@ -333,7 +339,40 @@ func (c *Client) GetMergeRequest(
 	if err != nil {
 		return platform.MergeRequest{}, mapGitLabError("get_merge_request", err)
 	}
-	return NormalizeDetailedMergeRequest(normalizedRef, mr), nil
+	normalized := NormalizeDetailedMergeRequest(normalizedRef, mr)
+	normalized.HeadRepoCloneURL = c.headRepoCloneURL(ctx, normalizedRef, mr.ProjectID, mr.SourceProjectID)
+	return normalized, nil
+}
+
+func (c *Client) headRepoCloneURL(
+	ctx context.Context,
+	ref platform.RepoRef,
+	targetProjectID int64,
+	sourceProjectID int64,
+) string {
+	if sourceProjectID == 0 || sourceProjectID == targetProjectID || sourceProjectID == ref.PlatformID {
+		return ref.CloneURL
+	}
+	return c.projectCloneURL(ctx, sourceProjectID)
+}
+
+func (c *Client) projectCloneURL(ctx context.Context, projectID int64) string {
+	c.projectCloneURLMu.Lock()
+	cached, ok := c.projectCloneURLs[projectID]
+	c.projectCloneURLMu.Unlock()
+	if ok {
+		return cached
+	}
+
+	project, _, err := c.api.Projects.GetProject(projectID, nil, gitlab.WithContext(ctx))
+	if err != nil || project == nil {
+		return ""
+	}
+	cloneURL := strings.TrimSpace(project.HTTPURLToRepo)
+	c.projectCloneURLMu.Lock()
+	c.projectCloneURLs[projectID] = cloneURL
+	c.projectCloneURLMu.Unlock()
+	return cloneURL
 }
 
 func (c *Client) ListMergeRequestEvents(

--- a/internal/platform/gitlab/client.go
+++ b/internal/platform/gitlab/client.go
@@ -316,7 +316,7 @@ func (c *Client) ListOpenMergeRequests(
 		}
 		for _, mr := range mrs {
 			normalized := NormalizeMergeRequest(normalizedRef, mr, nil)
-			normalized.HeadRepoCloneURL, err = c.headRepoCloneURL(ctx, normalizedRef, mr.ProjectID, mr.SourceProjectID)
+			normalized.HeadRepoCloneURL, err = c.optionalHeadRepoCloneURL(ctx, normalizedRef, mr.ProjectID, mr.SourceProjectID)
 			if err != nil {
 				return nil, err
 			}
@@ -343,11 +343,27 @@ func (c *Client) GetMergeRequest(
 		return platform.MergeRequest{}, mapGitLabError("get_merge_request", err)
 	}
 	normalized := NormalizeDetailedMergeRequest(normalizedRef, mr)
-	normalized.HeadRepoCloneURL, err = c.headRepoCloneURL(ctx, normalizedRef, mr.ProjectID, mr.SourceProjectID)
+	normalized.HeadRepoCloneURL, err = c.optionalHeadRepoCloneURL(ctx, normalizedRef, mr.ProjectID, mr.SourceProjectID)
 	if err != nil {
 		return platform.MergeRequest{}, err
 	}
 	return normalized, nil
+}
+
+func (c *Client) optionalHeadRepoCloneURL(
+	ctx context.Context,
+	ref platform.RepoRef,
+	targetProjectID int64,
+	sourceProjectID int64,
+) (string, error) {
+	cloneURL, err := c.headRepoCloneURL(ctx, ref, targetProjectID, sourceProjectID)
+	if err == nil {
+		return cloneURL, nil
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return "", ctxErr
+	}
+	return "", nil
 }
 
 func (c *Client) headRepoCloneURL(

--- a/internal/platform/gitlab/client.go
+++ b/internal/platform/gitlab/client.go
@@ -316,7 +316,10 @@ func (c *Client) ListOpenMergeRequests(
 		}
 		for _, mr := range mrs {
 			normalized := NormalizeMergeRequest(normalizedRef, mr, nil)
-			normalized.HeadRepoCloneURL = c.headRepoCloneURL(ctx, normalizedRef, mr.ProjectID, mr.SourceProjectID)
+			normalized.HeadRepoCloneURL, err = c.headRepoCloneURL(ctx, normalizedRef, mr.ProjectID, mr.SourceProjectID)
+			if err != nil {
+				return nil, err
+			}
 			out = append(out, normalized)
 		}
 		if resp == nil || resp.NextPage == 0 {
@@ -340,7 +343,10 @@ func (c *Client) GetMergeRequest(
 		return platform.MergeRequest{}, mapGitLabError("get_merge_request", err)
 	}
 	normalized := NormalizeDetailedMergeRequest(normalizedRef, mr)
-	normalized.HeadRepoCloneURL = c.headRepoCloneURL(ctx, normalizedRef, mr.ProjectID, mr.SourceProjectID)
+	normalized.HeadRepoCloneURL, err = c.headRepoCloneURL(ctx, normalizedRef, mr.ProjectID, mr.SourceProjectID)
+	if err != nil {
+		return platform.MergeRequest{}, err
+	}
 	return normalized, nil
 }
 
@@ -349,30 +355,33 @@ func (c *Client) headRepoCloneURL(
 	ref platform.RepoRef,
 	targetProjectID int64,
 	sourceProjectID int64,
-) string {
+) (string, error) {
 	if sourceProjectID == 0 || sourceProjectID == targetProjectID || sourceProjectID == ref.PlatformID {
-		return ref.CloneURL
+		return ref.CloneURL, nil
 	}
 	return c.projectCloneURL(ctx, sourceProjectID)
 }
 
-func (c *Client) projectCloneURL(ctx context.Context, projectID int64) string {
+func (c *Client) projectCloneURL(ctx context.Context, projectID int64) (string, error) {
 	c.projectCloneURLMu.Lock()
 	cached, ok := c.projectCloneURLs[projectID]
 	c.projectCloneURLMu.Unlock()
 	if ok {
-		return cached
+		return cached, nil
 	}
 
 	project, _, err := c.api.Projects.GetProject(projectID, nil, gitlab.WithContext(ctx))
 	if err != nil || project == nil {
-		return ""
+		if err == nil {
+			err = errors.New("source project response was empty")
+		}
+		return "", mapGitLabError("get_source_project", err)
 	}
 	cloneURL := strings.TrimSpace(project.HTTPURLToRepo)
 	c.projectCloneURLMu.Lock()
 	c.projectCloneURLs[projectID] = cloneURL
 	c.projectCloneURLMu.Unlock()
-	return cloneURL
+	return cloneURL, nil
 }
 
 func (c *Client) ListMergeRequestEvents(

--- a/internal/platform/gitlab/client_test.go
+++ b/internal/platform/gitlab/client_test.go
@@ -114,6 +114,43 @@ func TestClientListOpenMergeRequestsPopulatesForkHeadRepoCloneURL(t *testing.T) 
 }
 
 func TestClientListOpenMergeRequestsContinuesWhenForkHeadRepoLookupFails(t *testing.T) {
+	for _, status := range []int{http.StatusForbidden, http.StatusNotFound} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.EscapedPath() {
+				case "/api/v4/projects/42/merge_requests":
+					writeJSON(w, `[
+						{"id": 1001, "iid": 7, "project_id": 42, "source_project_id": 77, "target_project_id": 42, "source_branch": "feature/auth", "target_branch": "main", "title": "Fork base", "state": "opened"}
+					]`)
+				case "/api/v4/projects/77":
+					http.Error(w, http.StatusText(status), status)
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer server.Close()
+
+			client := newTestClient(t, server.URL)
+			ref := platform.RepoRef{
+				Platform:   platform.KindGitLab,
+				Host:       "gitlab.example.com",
+				RepoPath:   "group/project",
+				PlatformID: 42,
+				CloneURL:   "https://gitlab.example.com/group/project.git",
+			}
+
+			mrs, err := client.ListOpenMergeRequests(context.Background(), ref)
+			require.NoError(err)
+			require.Len(mrs, 1)
+			assert.Equal(7, mrs[0].Number)
+			assert.Empty(mrs[0].HeadRepoCloneURL)
+		})
+	}
+}
+
+func TestClientListOpenMergeRequestsPropagatesTransientForkHeadRepoLookupFailures(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -123,7 +160,7 @@ func TestClientListOpenMergeRequestsContinuesWhenForkHeadRepoLookupFails(t *test
 				{"id": 1001, "iid": 7, "project_id": 42, "source_project_id": 77, "target_project_id": 42, "source_branch": "feature/auth", "target_branch": "main", "title": "Fork base", "state": "opened"}
 			]`)
 		case "/api/v4/projects/77":
-			http.NotFound(w, r)
+			http.Error(w, "rate limited", http.StatusTooManyRequests)
 		default:
 			http.NotFound(w, r)
 		}
@@ -139,11 +176,12 @@ func TestClientListOpenMergeRequestsContinuesWhenForkHeadRepoLookupFails(t *test
 		CloneURL:   "https://gitlab.example.com/group/project.git",
 	}
 
-	mrs, err := client.ListOpenMergeRequests(context.Background(), ref)
-	require.NoError(err)
-	require.Len(mrs, 1)
-	assert.Equal(7, mrs[0].Number)
-	assert.Empty(mrs[0].HeadRepoCloneURL)
+	_, err := client.ListOpenMergeRequests(context.Background(), ref)
+	require.Error(err)
+	var platformErr *platform.Error
+	require.ErrorAs(err, &platformErr)
+	assert.Equal(platform.ErrCodeRateLimited, platformErr.Code)
+	assert.Equal("get_source_project", platformErr.Capability)
 }
 
 func TestClientGetMergeRequestContinuesWhenForkHeadRepoLookupFails(t *testing.T) {
@@ -184,6 +222,48 @@ func TestClientGetMergeRequestContinuesWhenForkHeadRepoLookupFails(t *testing.T)
 	require.NoError(err)
 	assert.Equal(7, mr.Number)
 	assert.Empty(mr.HeadRepoCloneURL)
+}
+
+func TestClientGetMergeRequestPropagatesTransientForkHeadRepoLookupFailures(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.EscapedPath() {
+		case "/api/v4/projects/42/merge_requests/7":
+			writeJSON(w, `{
+				"id": 1001,
+				"iid": 7,
+				"project_id": 42,
+				"source_project_id": 77,
+				"target_project_id": 42,
+				"source_branch": "feature/auth",
+				"target_branch": "main",
+				"title": "Fork base",
+				"state": "opened"
+			}`)
+		case "/api/v4/projects/77":
+			http.Error(w, "temporary failure", http.StatusBadGateway)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	ref := platform.RepoRef{
+		Platform:   platform.KindGitLab,
+		Host:       "gitlab.example.com",
+		RepoPath:   "group/project",
+		PlatformID: 42,
+		CloneURL:   "https://gitlab.example.com/group/project.git",
+	}
+
+	_, err := client.GetMergeRequest(context.Background(), ref, 7)
+	require.Error(err)
+	var platformErr *platform.Error
+	require.ErrorAs(err, &platformErr)
+	assert.Equal(platform.ErrCodeInvalidRepoRef, platformErr.Code)
+	assert.Equal("get_source_project", platformErr.Capability)
 }
 
 func TestClientRecordsRateLimitRequests(t *testing.T) {

--- a/internal/platform/gitlab/client_test.go
+++ b/internal/platform/gitlab/client_test.go
@@ -113,7 +113,7 @@ func TestClientListOpenMergeRequestsPopulatesForkHeadRepoCloneURL(t *testing.T) 
 	}, paths)
 }
 
-func TestClientListOpenMergeRequestsFailsWhenForkHeadRepoLookupFails(t *testing.T) {
+func TestClientListOpenMergeRequestsContinuesWhenForkHeadRepoLookupFails(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -140,9 +140,50 @@ func TestClientListOpenMergeRequestsFailsWhenForkHeadRepoLookupFails(t *testing.
 	}
 
 	mrs, err := client.ListOpenMergeRequests(context.Background(), ref)
-	require.Error(err)
-	assert.Nil(mrs)
-	assert.Contains(err.Error(), "get_source_project")
+	require.NoError(err)
+	require.Len(mrs, 1)
+	assert.Equal(7, mrs[0].Number)
+	assert.Empty(mrs[0].HeadRepoCloneURL)
+}
+
+func TestClientGetMergeRequestContinuesWhenForkHeadRepoLookupFails(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.EscapedPath() {
+		case "/api/v4/projects/42/merge_requests/7":
+			writeJSON(w, `{
+				"id": 1001,
+				"iid": 7,
+				"project_id": 42,
+				"source_project_id": 77,
+				"target_project_id": 42,
+				"source_branch": "feature/auth",
+				"target_branch": "main",
+				"title": "Fork base",
+				"state": "opened"
+			}`)
+		case "/api/v4/projects/77":
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	ref := platform.RepoRef{
+		Platform:   platform.KindGitLab,
+		Host:       "gitlab.example.com",
+		RepoPath:   "group/project",
+		PlatformID: 42,
+		CloneURL:   "https://gitlab.example.com/group/project.git",
+	}
+
+	mr, err := client.GetMergeRequest(context.Background(), ref, 7)
+	require.NoError(err)
+	assert.Equal(7, mr.Number)
+	assert.Empty(mr.HeadRepoCloneURL)
 }
 
 func TestClientRecordsRateLimitRequests(t *testing.T) {

--- a/internal/platform/gitlab/client_test.go
+++ b/internal/platform/gitlab/client_test.go
@@ -113,6 +113,38 @@ func TestClientListOpenMergeRequestsPopulatesForkHeadRepoCloneURL(t *testing.T) 
 	}, paths)
 }
 
+func TestClientListOpenMergeRequestsFailsWhenForkHeadRepoLookupFails(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.EscapedPath() {
+		case "/api/v4/projects/42/merge_requests":
+			writeJSON(w, `[
+				{"id": 1001, "iid": 7, "project_id": 42, "source_project_id": 77, "target_project_id": 42, "source_branch": "feature/auth", "target_branch": "main", "title": "Fork base", "state": "opened"}
+			]`)
+		case "/api/v4/projects/77":
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	ref := platform.RepoRef{
+		Platform:   platform.KindGitLab,
+		Host:       "gitlab.example.com",
+		RepoPath:   "group/project",
+		PlatformID: 42,
+		CloneURL:   "https://gitlab.example.com/group/project.git",
+	}
+
+	mrs, err := client.ListOpenMergeRequests(context.Background(), ref)
+	require.Error(err)
+	assert.Nil(mrs)
+	assert.Contains(err.Error(), "get_source_project")
+}
+
 func TestClientRecordsRateLimitRequests(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/platform/gitlab/client_test.go
+++ b/internal/platform/gitlab/client_test.go
@@ -66,6 +66,53 @@ func TestClientLooksUpProjectByRawPathAndUsesNumericIDAfterLookup(t *testing.T) 
 	}, paths)
 }
 
+func TestClientListOpenMergeRequestsPopulatesForkHeadRepoCloneURL(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	var paths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.EscapedPath())
+		switch r.URL.EscapedPath() {
+		case "/api/v4/projects/42/merge_requests":
+			writeJSON(w, `[
+				{"id": 1001, "iid": 7, "project_id": 42, "source_project_id": 77, "target_project_id": 42, "source_branch": "feature/auth", "target_branch": "main", "title": "Fork base", "state": "opened"},
+				{"id": 1002, "iid": 8, "project_id": 42, "source_project_id": 77, "target_project_id": 42, "source_branch": "feature/auth-ui", "target_branch": "feature/auth", "title": "Fork tip", "state": "opened"},
+				{"id": 1003, "iid": 9, "project_id": 42, "source_project_id": 42, "target_project_id": 42, "source_branch": "feature/local", "target_branch": "main", "title": "Local", "state": "opened"}
+			]`)
+		case "/api/v4/projects/77":
+			writeJSON(w, `{
+				"id": 77,
+				"path": "project",
+				"path_with_namespace": "fork/project",
+				"http_url_to_repo": "https://gitlab.example.com/fork/project.git"
+			}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	ref := platform.RepoRef{
+		Platform:   platform.KindGitLab,
+		Host:       "gitlab.example.com",
+		RepoPath:   "group/project",
+		PlatformID: 42,
+		CloneURL:   "https://gitlab.example.com/group/project.git",
+	}
+
+	mrs, err := client.ListOpenMergeRequests(context.Background(), ref)
+	require.NoError(err)
+	require.Len(mrs, 3)
+	assert.Equal("https://gitlab.example.com/fork/project.git", mrs[0].HeadRepoCloneURL)
+	assert.Equal("https://gitlab.example.com/fork/project.git", mrs[1].HeadRepoCloneURL)
+	assert.Equal("https://gitlab.example.com/group/project.git", mrs[2].HeadRepoCloneURL)
+	assert.Equal([]string{
+		"/api/v4/projects/42/merge_requests",
+		"/api/v4/projects/77",
+	}, paths)
+}
+
 func TestClientRecordsRateLimitRequests(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -846,7 +846,12 @@ func setupTestServerWithMock(t *testing.T, mock *mockGH) (*Server, *db.DB) {
 }
 
 var defaultTestRepos = []ghclient.RepoRef{
-	{Owner: "acme", Name: "widget", PlatformHost: "github.com"},
+	{
+		Owner:        "acme",
+		Name:         "widget",
+		PlatformHost: "github.com",
+		CloneURL:     "https://github.com/acme/widget.git",
+	},
 }
 
 func setupTestServerWithRepos(
@@ -18447,23 +18452,29 @@ func seedStackedPRState(
 	ctx := t.Context()
 	repoID, err := database.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", owner, name))
 	require.NoError(t, err)
+	cloneURL := fmt.Sprintf("https://github.com/%s/%s.git", owner, name)
+	require.NoError(t, database.UpdateRepoProviderMetadata(ctx, repoID, db.RepoProviderMetadata{
+		CloneURL:      cloneURL,
+		DefaultBranch: "main",
+	}))
 	now := time.Now().UTC().Truncate(time.Second)
 	pr := &db.MergeRequest{
-		RepoID:         repoID,
-		PlatformID:     int64(number) * 1000,
-		Number:         number,
-		Title:          fmt.Sprintf("PR #%d: %s", number, head),
-		Author:         "testuser",
-		State:          state,
-		IsDraft:        isDraft,
-		HeadBranch:     head,
-		BaseBranch:     base,
-		CIStatus:       ci,
-		ReviewDecision: review,
-		MergeableState: mergeableState,
-		CreatedAt:      now,
-		UpdatedAt:      now,
-		LastActivityAt: now,
+		RepoID:           repoID,
+		PlatformID:       int64(number) * 1000,
+		Number:           number,
+		Title:            fmt.Sprintf("PR #%d: %s", number, head),
+		Author:           "testuser",
+		State:            state,
+		IsDraft:          isDraft,
+		HeadBranch:       head,
+		BaseBranch:       base,
+		HeadRepoCloneURL: cloneURL,
+		CIStatus:         ci,
+		ReviewDecision:   review,
+		MergeableState:   mergeableState,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+		LastActivityAt:   now,
 	}
 	prID, err := database.UpsertMergeRequest(ctx, pr)
 	require.NoError(t, err)
@@ -18702,6 +18713,7 @@ func TestAPIStacks_DetectionViaSyncHook(t *testing.T) {
 	// into DB as open PRs forming a linear chain.
 	now := time.Now().UTC().Truncate(time.Second)
 	stringPtr := func(s string) *string { return &s }
+	repoCloneURL := "https://github.com/acme/widget.git"
 	makeGHPR := func(id int64, number int, head, base string) *gh.PullRequest {
 		sha := fmt.Sprintf("sha%d", number)
 		title := fmt.Sprintf("PR #%d: %s", number, head)
@@ -18714,11 +18726,25 @@ func TestAPIStacks_DetectionViaSyncHook(t *testing.T) {
 			User:      &gh.User{Login: stringPtr("testuser")},
 			CreatedAt: &gh.Timestamp{Time: now},
 			UpdatedAt: &gh.Timestamp{Time: now},
-			Head:      &gh.PullRequestBranch{Ref: &head, SHA: &sha},
-			Base:      &gh.PullRequestBranch{Ref: &base, SHA: stringPtr("basesha")},
+			Head: &gh.PullRequestBranch{
+				Ref:  &head,
+				SHA:  &sha,
+				Repo: &gh.Repository{CloneURL: &repoCloneURL},
+			},
+			Base: &gh.PullRequestBranch{Ref: &base, SHA: stringPtr("basesha")},
 		}
 	}
 	mock := &mockGH{
+		getRepositoryFn: func(_ context.Context, owner, repo string) (*gh.Repository, error) {
+			nodeID := "repo-" + owner + "-" + repo
+			return &gh.Repository{
+				Name:     &repo,
+				NodeID:   &nodeID,
+				Owner:    &gh.User{Login: &owner},
+				CloneURL: &repoCloneURL,
+				Archived: new(false),
+			}, nil
+		},
 		listOpenPullRequestsFn: func(_ context.Context, _, _ string) ([]*gh.PullRequest, error) {
 			return []*gh.PullRequest{
 				makeGHPR(1001, 10, "feat/hook-base", "main"),

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -18851,6 +18851,116 @@ func TestAPIStacks_DetectionViaSyncHookIgnoresForkHeadBranchCollision(t *testing
 	assert.Nil(forkResp.JSON200.Stack)
 }
 
+func TestAPIStacks_GitLabUnknownForkHeadSyncsButSkipsStackEdges(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	repoRef := platform.RepoRef{
+		Platform:           platform.KindGitLab,
+		Host:               "gitlab.example.com",
+		Owner:              "group",
+		Name:               "project",
+		RepoPath:           "group/project",
+		PlatformID:         4242,
+		PlatformExternalID: "gid://gitlab/Project/4242",
+		WebURL:             "https://gitlab.example.com/group/project",
+		CloneURL:           "https://gitlab.example.com/group/project.git",
+		DefaultBranch:      "main",
+	}
+	makeMR := func(platformID int64, number int, head, base, headRepoCloneURL string) platform.MergeRequest {
+		return platform.MergeRequest{
+			Repo:               repoRef,
+			PlatformID:         platformID,
+			PlatformExternalID: fmt.Sprintf("gid://gitlab/MergeRequest/%d", platformID),
+			Number:             number,
+			URL:                fmt.Sprintf("https://gitlab.example.com/group/project/-/merge_requests/%d", number),
+			Title:              fmt.Sprintf("MR !%d: %s", number, head),
+			Author:             "ada",
+			State:              "open",
+			HeadBranch:         head,
+			BaseBranch:         base,
+			HeadSHA:            fmt.Sprintf("sha%d", number),
+			BaseSHA:            "basesha",
+			HeadRepoCloneURL:   headRepoCloneURL,
+			CreatedAt:          now,
+			UpdatedAt:          now,
+			LastActivityAt:     now,
+		}
+	}
+	provider := &apiTestGitLabProvider{
+		ref: repoRef,
+		mergeRequests: []platform.MergeRequest{
+			makeMR(9001, 90, "feature/fork-ui", "feature/auth", ""),
+			makeMR(1001, 100, "feature/auth", "main", repoRef.CloneURL),
+			makeMR(1011, 101, "feature/auth-ui", "feature/auth", repoRef.CloneURL),
+		},
+	}
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+
+	database := dbtest.Open(t)
+	syncer := ghclient.NewSyncerWithRegistry(
+		registry, database, nil, []ghclient.RepoRef{{
+			Platform:           platform.KindGitLab,
+			Owner:              "group",
+			Name:               "project",
+			PlatformHost:       "gitlab.example.com",
+			RepoPath:           "group/project",
+			PlatformRepoID:     4242,
+			PlatformExternalID: "gid://gitlab/Project/4242",
+			WebURL:             "https://gitlab.example.com/group/project",
+			CloneURL:           repoRef.CloneURL,
+			DefaultBranch:      "main",
+		}}, time.Minute, nil, nil,
+	)
+	t.Cleanup(syncer.Stop)
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	client := setupTestClient(t, srv)
+
+	syncer.SetOnSyncCompleted(stacks.SyncCompletedHook(ctx, database, nil))
+	syncer.RunOnce(ctx)
+
+	pullsResp, err := client.HTTP.ListPullsWithResponse(ctx, &generated.ListPullsParams{})
+	require.NoError(err)
+	require.Equal(http.StatusOK, pullsResp.StatusCode(), string(pullsResp.Body))
+	require.NotNil(pullsResp.JSON200)
+	pullNumbers := make([]int64, 0, len(*pullsResp.JSON200))
+	for _, pull := range *pullsResp.JSON200 {
+		pullNumbers = append(pullNumbers, pull.Number)
+	}
+	assert.ElementsMatch([]int64{90, 100, 101}, pullNumbers)
+
+	forkResp, err := client.HTTP.GetPullOnHostWithResponse(ctx, "gitlab.example.com", "gl", "group", "project", 90)
+	require.NoError(err)
+	require.Equal(http.StatusOK, forkResp.StatusCode(), string(forkResp.Body))
+	require.NotNil(forkResp.JSON200)
+	assert.Empty(forkResp.JSON200.MergeRequest.HeadRepoCloneURL)
+	assert.Nil(forkResp.JSON200.Stack)
+
+	forkStackResp, err := client.HTTP.GetPullStackOnHostWithResponse(ctx, "gitlab.example.com", "gl", "group", "project", 90)
+	require.NoError(err)
+	assert.Equal(http.StatusNotFound, forkStackResp.StatusCode(), string(forkStackResp.Body))
+
+	tipStackResp, err := client.HTTP.GetPullStackOnHostWithResponse(ctx, "gitlab.example.com", "gl", "group", "project", 101)
+	require.NoError(err)
+	require.Equal(http.StatusOK, tipStackResp.StatusCode(), string(tipStackResp.Body))
+	require.NotNil(tipStackResp.JSON200)
+	require.NotNil(tipStackResp.JSON200.Members)
+	assert.Equal(int64(2), tipStackResp.JSON200.Size)
+	assert.Equal([]int64{100, 101}, stackMemberNumbers(*tipStackResp.JSON200.Members))
+
+	stacksResp, err := client.HTTP.ListStacksWithResponse(ctx, &generated.ListStacksParams{})
+	require.NoError(err)
+	require.Equal(http.StatusOK, stacksResp.StatusCode(), string(stacksResp.Body))
+	require.NotNil(stacksResp.JSON200)
+	require.Len(*stacksResp.JSON200, 1)
+	require.NotNil((*stacksResp.JSON200)[0].Members)
+	assert.Equal([]int64{100, 101}, stackMemberNumbers(*(*stacksResp.JSON200)[0].Members))
+}
+
 func TestAPIStacks_DetectionViaSyncHookIgnoresSameRepoSelfEdge(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -18825,6 +18825,78 @@ func TestAPIStacks_DetectionViaSyncHookIgnoresForkHeadBranchCollision(t *testing
 	assert.Nil(forkResp.JSON200.Stack)
 }
 
+func TestAPIStacks_DetectionViaSyncHookIgnoresSameRepoSelfEdge(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	stringPtr := func(s string) *string { return &s }
+	repoCloneURL := "https://github.com/acme/widget.git"
+	makeGHPR := func(id int64, number int, head, base string) *gh.PullRequest {
+		sha := fmt.Sprintf("sha%d", number)
+		title := fmt.Sprintf("PR #%d: %s", number, head)
+		return &gh.PullRequest{
+			ID:        &id,
+			Number:    &number,
+			State:     stringPtr("open"),
+			Title:     &title,
+			Body:      stringPtr(""),
+			User:      &gh.User{Login: stringPtr("testuser")},
+			CreatedAt: &gh.Timestamp{Time: now},
+			UpdatedAt: &gh.Timestamp{Time: now},
+			Head: &gh.PullRequestBranch{
+				Ref:  &head,
+				SHA:  &sha,
+				Repo: &gh.Repository{CloneURL: &repoCloneURL},
+			},
+			Base: &gh.PullRequestBranch{Ref: &base, SHA: stringPtr("basesha")},
+		}
+	}
+	mock := &mockGH{
+		getRepositoryFn: func(_ context.Context, owner, repo string) (*gh.Repository, error) {
+			nodeID := "repo-" + owner + "-" + repo
+			return &gh.Repository{
+				Name:     &repo,
+				NodeID:   &nodeID,
+				Owner:    &gh.User{Login: &owner},
+				CloneURL: &repoCloneURL,
+				Archived: new(false),
+			}, nil
+		},
+		listOpenPullRequestsFn: func(_ context.Context, _, _ string) ([]*gh.PullRequest, error) {
+			return []*gh.PullRequest{
+				makeGHPR(4491, 449, "legacy-parser-base", "legacy-parser-base"),
+				makeGHPR(7481, 748, "locate-parser-interface", "legacy-parser-base"),
+				makeGHPR(7511, 751, "provider-facade-core", "locate-parser-interface"),
+			}, nil
+		},
+	}
+	srv, database := setupTestServerWithRepos(t, mock, []ghclient.RepoRef{{
+		Owner:        "acme",
+		Name:         "widget",
+		PlatformHost: "github.com",
+		CloneURL:     repoCloneURL,
+	}})
+	client := setupTestClient(t, srv)
+
+	srv.syncer.SetOnSyncCompleted(stacks.SyncCompletedHook(ctx, database, nil))
+	srv.syncer.RunOnce(ctx)
+
+	ctxResp, err := client.HTTP.GetPullStackWithResponse(ctx, "gh", "acme", "widget", 751)
+	require.NoError(err)
+	require.Equal(http.StatusOK, ctxResp.StatusCode(), string(ctxResp.Body))
+	require.NotNil(ctxResp.JSON200)
+	require.NotNil(ctxResp.JSON200.Members)
+	assert.Equal([]int64{748, 751}, stackMemberNumbers(*ctxResp.JSON200.Members))
+
+	selfEdgeResp, err := client.HTTP.GetPullWithResponse(ctx, "gh", "acme", "widget", 449)
+	require.NoError(err)
+	require.Equal(http.StatusOK, selfEdgeResp.StatusCode(), string(selfEdgeResp.Body))
+	require.NotNil(selfEdgeResp.JSON200)
+	assert.Nil(selfEdgeResp.JSON200.Stack)
+}
+
 func stackMemberNumbers(members []generated.StackMemberResponse) []int64 {
 	numbers := make([]int64, len(members))
 	for i, member := range members {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -18752,6 +18752,87 @@ func TestAPIStacks_DetectionViaSyncHook(t *testing.T) {
 	assert.Equal(int64(2), ctxResp.JSON200.Size)
 }
 
+func TestAPIStacks_DetectionViaSyncHookIgnoresForkHeadBranchCollision(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	stringPtr := func(s string) *string { return &s }
+	repoCloneURL := "https://github.com/acme/widget.git"
+	forkCloneURL := "https://github.com/fork/widget.git"
+	makeGHPR := func(id int64, number int, head, base, headRepoCloneURL string) *gh.PullRequest {
+		sha := fmt.Sprintf("sha%d", number)
+		title := fmt.Sprintf("PR #%d: %s", number, head)
+		return &gh.PullRequest{
+			ID:        &id,
+			Number:    &number,
+			State:     stringPtr("open"),
+			Title:     &title,
+			Body:      stringPtr(""),
+			User:      &gh.User{Login: stringPtr("testuser")},
+			CreatedAt: &gh.Timestamp{Time: now},
+			UpdatedAt: &gh.Timestamp{Time: now},
+			Head: &gh.PullRequestBranch{
+				Ref:  &head,
+				SHA:  &sha,
+				Repo: &gh.Repository{CloneURL: &headRepoCloneURL},
+			},
+			Base: &gh.PullRequestBranch{Ref: &base, SHA: stringPtr("basesha")},
+		}
+	}
+	mock := &mockGH{
+		getRepositoryFn: func(_ context.Context, owner, repo string) (*gh.Repository, error) {
+			nodeID := "repo-" + owner + "-" + repo
+			return &gh.Repository{
+				Name:     &repo,
+				NodeID:   &nodeID,
+				Owner:    &gh.User{Login: &owner},
+				CloneURL: &repoCloneURL,
+				Archived: new(false),
+			}, nil
+		},
+		listOpenPullRequestsFn: func(_ context.Context, _, _ string) ([]*gh.PullRequest, error) {
+			return []*gh.PullRequest{
+				makeGHPR(9001, 90, "feature/auth", "main", forkCloneURL),
+				makeGHPR(1001, 100, "feature/auth", "main", repoCloneURL),
+				makeGHPR(1011, 101, "feature/auth-ui", "feature/auth", repoCloneURL),
+			}, nil
+		},
+	}
+	srv, database := setupTestServerWithRepos(t, mock, []ghclient.RepoRef{{
+		Owner:        "acme",
+		Name:         "widget",
+		PlatformHost: "github.com",
+		CloneURL:     repoCloneURL,
+	}})
+	client := setupTestClient(t, srv)
+
+	srv.syncer.SetOnSyncCompleted(stacks.SyncCompletedHook(ctx, database, nil))
+	srv.syncer.RunOnce(ctx)
+
+	ctxResp, err := client.HTTP.GetPullStackWithResponse(ctx, "gh", "acme", "widget", 101)
+	require.NoError(err)
+	require.Equal(http.StatusOK, ctxResp.StatusCode(), string(ctxResp.Body))
+	require.NotNil(ctxResp.JSON200)
+	require.NotNil(ctxResp.JSON200.Members)
+	assert.Equal([]int64{100, 101}, stackMemberNumbers(*ctxResp.JSON200.Members))
+
+	forkResp, err := client.HTTP.GetPullWithResponse(ctx, "gh", "acme", "widget", 90)
+	require.NoError(err)
+	require.Equal(http.StatusOK, forkResp.StatusCode(), string(forkResp.Body))
+	require.NotNil(forkResp.JSON200)
+	assert.Nil(forkResp.JSON200.Stack)
+}
+
+func stackMemberNumbers(members []generated.StackMemberResponse) []int64 {
+	numbers := make([]int64, len(members))
+	for i, member := range members {
+		numbers[i] = member.Number
+	}
+	return numbers
+}
+
 func TestAPIGetStackForPR_SingleFailingIsInProgress(t *testing.T) {
 	assert := Assert.New(t)
 	srv, database := setupTestServer(t)

--- a/internal/stacks/detect.go
+++ b/internal/stacks/detect.go
@@ -2,6 +2,7 @@ package stacks
 
 import (
 	"context"
+	"net/url"
 	"slices"
 	"strings"
 
@@ -28,10 +29,10 @@ func DetectChains(prs []db.MergeRequest, repoCloneURL string) [][]db.MergeReques
 		if repo == "" {
 			repo = repoCloneURL
 		}
-		return branchKey{repo: repo, branch: pr.HeadBranch}
+		return branchKey{repo: normalizeRepoKey(repo), branch: pr.HeadBranch}
 	}
 	baseKey := func(pr db.MergeRequest) branchKey {
-		return branchKey{repo: repoCloneURL, branch: pr.BaseBranch}
+		return branchKey{repo: normalizeRepoKey(repoCloneURL), branch: pr.BaseBranch}
 	}
 
 	// A same-repo PR from a branch to itself cannot be a stack edge. If it is
@@ -87,6 +88,23 @@ func DetectChains(prs []db.MergeRequest, repoCloneURL string) [][]db.MergeReques
 	}
 
 	return chains
+}
+
+func normalizeRepoKey(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	parsed, err := url.Parse(raw)
+	if err == nil && parsed.Scheme != "" && parsed.Host != "" {
+		parsed.Scheme = strings.ToLower(parsed.Scheme)
+		parsed.Host = strings.ToLower(parsed.Host)
+		parsed.Path = strings.TrimSuffix(strings.TrimRight(parsed.Path, "/"), ".git")
+		parsed.RawQuery = ""
+		parsed.Fragment = ""
+		return strings.TrimRight(parsed.String(), "/")
+	}
+	return strings.TrimSuffix(strings.TrimRight(raw, "/"), ".git")
 }
 
 func walkChain(

--- a/internal/stacks/detect.go
+++ b/internal/stacks/detect.go
@@ -14,9 +14,9 @@ func DetectChains(prs []db.MergeRequest) [][]db.MergeRequest {
 	// Sort by number for deterministic tie-breaking.
 	sorted := slices.Clone(prs)
 	slices.SortFunc(sorted, db.MergeRequest.Compare)
-	// An unrelated self-targeting row such as main -> main would put
-	// "main" in headMap below. Then a real stack root whose base is main
-	// would no longer look like a root, so the whole stack disappears.
+	// A row whose head branch equals its base branch cannot describe a
+	// parent -> child edge. If it reaches headMap below, real PRs targeting
+	// that branch stop looking like stack roots and their chains disappear.
 	sorted = slices.DeleteFunc(sorted, func(pr db.MergeRequest) bool {
 		return pr.HeadBranch == pr.BaseBranch
 	})

--- a/internal/stacks/detect.go
+++ b/internal/stacks/detect.go
@@ -14,6 +14,9 @@ func DetectChains(prs []db.MergeRequest) [][]db.MergeRequest {
 	// Sort by number for deterministic tie-breaking.
 	sorted := slices.Clone(prs)
 	slices.SortFunc(sorted, db.MergeRequest.Compare)
+	// Historical provider rows can contain self-targeting PRs such as
+	// main -> main. They do not describe a stack edge, and treating their
+	// head as a real PR branch hides valid stacks rooted on that branch.
 	sorted = slices.DeleteFunc(sorted, func(pr db.MergeRequest) bool {
 		return pr.HeadBranch == pr.BaseBranch
 	})

--- a/internal/stacks/detect.go
+++ b/internal/stacks/detect.go
@@ -14,9 +14,9 @@ func DetectChains(prs []db.MergeRequest) [][]db.MergeRequest {
 	// Sort by number for deterministic tie-breaking.
 	sorted := slices.Clone(prs)
 	slices.SortFunc(sorted, db.MergeRequest.Compare)
-	// Historical provider rows can contain self-targeting PRs such as
-	// main -> main. They do not describe a stack edge, and treating their
-	// head as a real PR branch hides valid stacks rooted on that branch.
+	// An unrelated self-targeting row such as main -> main would put
+	// "main" in headMap below. Then a real stack root whose base is main
+	// would no longer look like a root, so the whole stack disappears.
 	sorted = slices.DeleteFunc(sorted, func(pr db.MergeRequest) bool {
 		return pr.HeadBranch == pr.BaseBranch
 	})

--- a/internal/stacks/detect.go
+++ b/internal/stacks/detect.go
@@ -8,48 +8,63 @@ import (
 	"go.kenn.io/middleman/internal/db"
 )
 
+type branchKey struct {
+	repo   string
+	branch string
+}
+
 // DetectChains finds linear PR chains from branch metadata.
 // Returns chains of length >= 2, ordered base-to-tip.
-func DetectChains(prs []db.MergeRequest) [][]db.MergeRequest {
+func DetectChains(prs []db.MergeRequest, repoCloneURL string) [][]db.MergeRequest {
 	// Sort by number for deterministic tie-breaking.
 	sorted := slices.Clone(prs)
 	slices.SortFunc(sorted, db.MergeRequest.Compare)
-	// A row whose head branch equals its base branch cannot describe a
-	// parent -> child edge. If it reaches headMap below, real PRs targeting
-	// that branch stop looking like stack roots and their chains disappear.
-	sorted = slices.DeleteFunc(sorted, func(pr db.MergeRequest) bool {
-		return pr.HeadBranch == pr.BaseBranch
-	})
 
-	// head_branch -> PR. Prefer open over merged; within same state, lowest number wins.
-	headMap := make(map[string]db.MergeRequest, len(sorted))
+	// Head and base branches only form a stack edge when they are in the same
+	// repository. Forks can reuse upstream branch names, so branch-only keys
+	// would let a fork's head shadow a real upstream stack root.
+	headKey := func(pr db.MergeRequest) branchKey {
+		repo := pr.HeadRepoCloneURL
+		if repo == "" {
+			repo = repoCloneURL
+		}
+		return branchKey{repo: repo, branch: pr.HeadBranch}
+	}
+	baseKey := func(pr db.MergeRequest) branchKey {
+		return branchKey{repo: repoCloneURL, branch: pr.BaseBranch}
+	}
+
+	// head repo+branch -> PR. Prefer open over merged; within same state, lowest number wins.
+	headMap := make(map[branchKey]db.MergeRequest, len(sorted))
 	for _, pr := range sorted {
-		existing, exists := headMap[pr.HeadBranch]
+		key := headKey(pr)
+		existing, exists := headMap[key]
 		if !exists {
-			headMap[pr.HeadBranch] = pr
+			headMap[key] = pr
 		} else if existing.State == "merged" && pr.State == "open" {
-			headMap[pr.HeadBranch] = pr
+			headMap[key] = pr
 		}
 	}
 
-	// Keep only preferred PR per head_branch to avoid ambiguous chains.
+	// Keep only preferred PR per head repo+branch to avoid ambiguous chains.
 	preferred := make([]db.MergeRequest, 0, len(headMap))
 	for _, pr := range sorted {
-		if p, ok := headMap[pr.HeadBranch]; ok && p.ID == pr.ID {
+		if p, ok := headMap[headKey(pr)]; ok && p.ID == pr.ID {
 			preferred = append(preferred, pr)
 		}
 	}
 
-	// base_branch -> []PR (children targeting that base).
-	childMap := make(map[string][]db.MergeRequest)
+	// base repo+branch -> []PR (children targeting that base).
+	childMap := make(map[branchKey][]db.MergeRequest)
 	for _, pr := range preferred {
-		childMap[pr.BaseBranch] = append(childMap[pr.BaseBranch], pr)
+		key := baseKey(pr)
+		childMap[key] = append(childMap[key], pr)
 	}
 
 	// Find bases: PRs whose base_branch is NOT in headMap.
 	var bases []db.MergeRequest
 	for _, pr := range preferred {
-		if _, isHead := headMap[pr.BaseBranch]; !isHead {
+		if _, isHead := headMap[baseKey(pr)]; !isHead {
 			bases = append(bases, pr)
 		}
 	}
@@ -57,7 +72,7 @@ func DetectChains(prs []db.MergeRequest) [][]db.MergeRequest {
 	// Walk chains from each base.
 	var chains [][]db.MergeRequest
 	for _, base := range bases {
-		chain := walkChain(base, childMap)
+		chain := walkChain(base, childMap, headKey)
 		if len(chain) >= 2 {
 			chains = append(chains, chain)
 		}
@@ -68,20 +83,22 @@ func DetectChains(prs []db.MergeRequest) [][]db.MergeRequest {
 
 func walkChain(
 	start db.MergeRequest,
-	childMap map[string][]db.MergeRequest,
+	childMap map[branchKey][]db.MergeRequest,
+	headKey func(db.MergeRequest) branchKey,
 ) []db.MergeRequest {
-	visited := make(map[string]bool)
+	visited := make(map[branchKey]bool)
 	var chain []db.MergeRequest
 	current := start
 
 	for {
-		if visited[current.HeadBranch] {
+		key := headKey(current)
+		if visited[key] {
 			return nil // cycle
 		}
-		visited[current.HeadBranch] = true
+		visited[key] = true
 		chain = append(chain, current)
 
-		children := childMap[current.HeadBranch]
+		children := childMap[key]
 		if len(children) == 0 {
 			break
 		}
@@ -177,12 +194,20 @@ func commonPrefix(a, b string) string {
 
 // RunDetection detects stacks for a single repo and persists results.
 func RunDetection(ctx context.Context, database *db.DB, repoID int64) error {
+	repo, err := database.GetRepoByID(ctx, repoID)
+	if err != nil {
+		return err
+	}
+	if repo == nil {
+		return nil
+	}
+
 	prs, err := database.ListPRsForStackDetection(ctx, repoID)
 	if err != nil {
 		return err
 	}
 
-	chains := DetectChains(prs)
+	chains := DetectChains(prs, repo.CloneURL)
 
 	var activeIDs []int64
 	for _, chain := range chains {

--- a/internal/stacks/detect.go
+++ b/internal/stacks/detect.go
@@ -14,6 +14,9 @@ func DetectChains(prs []db.MergeRequest) [][]db.MergeRequest {
 	// Sort by number for deterministic tie-breaking.
 	sorted := slices.Clone(prs)
 	slices.SortFunc(sorted, db.MergeRequest.Compare)
+	sorted = slices.DeleteFunc(sorted, func(pr db.MergeRequest) bool {
+		return pr.HeadBranch == pr.BaseBranch
+	})
 
 	// head_branch -> PR. Prefer open over merged; within same state, lowest number wins.
 	headMap := make(map[string]db.MergeRequest, len(sorted))

--- a/internal/stacks/detect.go
+++ b/internal/stacks/detect.go
@@ -21,18 +21,18 @@ func DetectChains(prs []db.MergeRequest, repoCloneURL string) [][]db.MergeReques
 	sorted := slices.Clone(prs)
 	slices.SortFunc(sorted, db.MergeRequest.Compare)
 
+	// Stack edges require a known head repository identity. When providers can
+	// list a fork MR but cannot read the fork project metadata, keeping the MR
+	// with an empty head repo would make it look like a target-repo branch.
+	sorted = slices.DeleteFunc(sorted, func(pr db.MergeRequest) bool {
+		return strings.TrimSpace(pr.HeadRepoCloneURL) == ""
+	})
+
 	// Head and base branches only form a stack edge when they are in the same
 	// repository. Forks can reuse upstream branch names, so branch-only keys
 	// would let a fork's head shadow a real upstream stack root.
 	headKey := func(pr db.MergeRequest) branchKey {
-		repo := pr.HeadRepoCloneURL
-		if repo == "" {
-			repo = repoCloneURL
-		}
-		return branchKey{repo: normalizeRepoKey(repo), branch: pr.HeadBranch}
-	}
-	hasHeadRepo := func(pr db.MergeRequest) bool {
-		return strings.TrimSpace(pr.HeadRepoCloneURL) != ""
+		return branchKey{repo: normalizeRepoKey(pr.HeadRepoCloneURL), branch: pr.HeadBranch}
 	}
 	baseKey := func(pr db.MergeRequest) branchKey {
 		return branchKey{repo: normalizeRepoKey(repoCloneURL), branch: pr.BaseBranch}
@@ -55,11 +55,7 @@ func DetectChains(prs []db.MergeRequest, repoCloneURL string) [][]db.MergeReques
 			headMap[key] = pr
 			continue
 		}
-		existingHasHeadRepo := hasHeadRepo(existing)
-		prHasHeadRepo := hasHeadRepo(pr)
-		if !existingHasHeadRepo && prHasHeadRepo {
-			headMap[key] = pr
-		} else if existingHasHeadRepo == prHasHeadRepo && existing.State == "merged" && pr.State == "open" {
+		if existing.State == "merged" && pr.State == "open" {
 			headMap[key] = pr
 		}
 	}

--- a/internal/stacks/detect.go
+++ b/internal/stacks/detect.go
@@ -31,6 +31,9 @@ func DetectChains(prs []db.MergeRequest, repoCloneURL string) [][]db.MergeReques
 		}
 		return branchKey{repo: normalizeRepoKey(repo), branch: pr.HeadBranch}
 	}
+	hasHeadRepo := func(pr db.MergeRequest) bool {
+		return strings.TrimSpace(pr.HeadRepoCloneURL) != ""
+	}
 	baseKey := func(pr db.MergeRequest) branchKey {
 		return branchKey{repo: normalizeRepoKey(repoCloneURL), branch: pr.BaseBranch}
 	}
@@ -50,7 +53,13 @@ func DetectChains(prs []db.MergeRequest, repoCloneURL string) [][]db.MergeReques
 		existing, exists := headMap[key]
 		if !exists {
 			headMap[key] = pr
-		} else if existing.State == "merged" && pr.State == "open" {
+			continue
+		}
+		existingHasHeadRepo := hasHeadRepo(existing)
+		prHasHeadRepo := hasHeadRepo(pr)
+		if !existingHasHeadRepo && prHasHeadRepo {
+			headMap[key] = pr
+		} else if existingHasHeadRepo == prHasHeadRepo && existing.State == "merged" && pr.State == "open" {
 			headMap[key] = pr
 		}
 	}

--- a/internal/stacks/detect.go
+++ b/internal/stacks/detect.go
@@ -34,6 +34,14 @@ func DetectChains(prs []db.MergeRequest, repoCloneURL string) [][]db.MergeReques
 		return branchKey{repo: repoCloneURL, branch: pr.BaseBranch}
 	}
 
+	// A same-repo PR from a branch to itself cannot be a stack edge. If it is
+	// allowed into headMap, real PRs targeting that branch stop looking like
+	// stack roots. Fork PRs such as fork:main -> upstream:main are kept because
+	// their repo-aware head and base keys differ.
+	sorted = slices.DeleteFunc(sorted, func(pr db.MergeRequest) bool {
+		return headKey(pr) == baseKey(pr)
+	})
+
 	// head repo+branch -> PR. Prefer open over merged; within same state, lowest number wins.
 	headMap := make(map[branchKey]db.MergeRequest, len(sorted))
 	for _, pr := range sorted {

--- a/internal/stacks/detect_test.go
+++ b/internal/stacks/detect_test.go
@@ -140,6 +140,20 @@ func TestDetectChains_ForkBranchNameDoesNotShadowUpstreamStackBranch(t *testing.
 	assert.Equal([]int{100, 101}, stackNumbers(chains[0]))
 }
 
+func TestDetectChains_UnknownHeadRepoDoesNotShadowKnownUpstreamStackBranch(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	prs := []realdb.MergeRequest{
+		makePRWithHeadRepo(1, 100, "feature/auth", "main", testRepoCloneURL, prOpen),
+		makePRWithHeadRepo(2, 101, "feature/auth-ui", "feature/auth", testRepoCloneURL, prOpen),
+		makePR(3, 90, "feature/auth", "main", prOpen),
+	}
+
+	chains := DetectChains(prs, testRepoCloneURL)
+	require.Len(chains, 1)
+	assert.Equal([]int{100, 101}, stackNumbers(chains[0]))
+}
+
 func TestDetectChains_NormalizesRepoCloneURLs(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)

--- a/internal/stacks/detect_test.go
+++ b/internal/stacks/detect_test.go
@@ -87,6 +87,21 @@ func TestDetectChains_PartialMerge(t *testing.T) {
 	assert.Len(chains[0], 2)
 }
 
+func TestDetectChains_SelfTargetingDefaultBranchPRDoesNotHideRoot(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	prs := []realdb.MergeRequest{
+		makePR(1, 449, "main", "main", prMerged),
+		makePR(2, 748, "locate-parser-interface", "main", prOpen),
+		makePR(3, 751, "provider-facade-core", "locate-parser-interface", prOpen),
+		makePR(4, 752, "provider-jsonl-source-set", "provider-facade-core", prOpen),
+	}
+
+	chains := DetectChains(prs)
+	require.Len(chains, 1)
+	assert.Equal([]int{748, 751, 752}, stackNumbers(chains[0]))
+}
+
 func TestDetectChains_DuplicateHeadPrefersOpen(t *testing.T) {
 	assert := Assert.New(t)
 	// Merged PR and open PR share same head branch.
@@ -154,6 +169,14 @@ func TestDeriveStackName(t *testing.T) {
 		makePR(1, 1, "feature/authorization", "main", prOpen),
 		makePR(2, 2, "feature/authorizer", "feature/authorization", prOpen),
 	}))
+}
+
+func stackNumbers(chain []realdb.MergeRequest) []int {
+	numbers := make([]int, len(chain))
+	for i, pr := range chain {
+		numbers[i] = pr.Number
+	}
+	return numbers
 }
 
 func openTestDB(t *testing.T) *realdb.DB {

--- a/internal/stacks/detect_test.go
+++ b/internal/stacks/detect_test.go
@@ -140,6 +140,19 @@ func TestDetectChains_ForkBranchNameDoesNotShadowUpstreamStackBranch(t *testing.
 	assert.Equal([]int{100, 101}, stackNumbers(chains[0]))
 }
 
+func TestDetectChains_NormalizesRepoCloneURLs(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	prs := []realdb.MergeRequest{
+		makePRWithHeadRepo(1, 100, "feature/auth", "main", "HTTPS://GITHUB.COM/acme/widget.git/", prOpen),
+		makePRWithHeadRepo(2, 101, "feature/auth-ui", "feature/auth", "https://github.com/acme/widget", prOpen),
+	}
+
+	chains := DetectChains(prs, "https://github.com/acme/widget.git?ignored=true#fragment")
+	require.Len(chains, 1)
+	assert.Equal([]int{100, 101}, stackNumbers(chains[0]))
+}
+
 func TestDetectChains_DuplicateHeadPrefersOpen(t *testing.T) {
 	assert := Assert.New(t)
 	// Merged PR and open PR share same head branch.

--- a/internal/stacks/detect_test.go
+++ b/internal/stacks/detect_test.go
@@ -11,8 +11,9 @@ import (
 )
 
 const (
-	prOpen   = realdb.MergeRequestStateOpen
-	prMerged = realdb.MergeRequestStateMerged
+	prOpen           = realdb.MergeRequestStateOpen
+	prMerged         = realdb.MergeRequestStateMerged
+	testRepoCloneURL = "https://github.com/acme/widget.git"
 )
 
 func makePR(id int64, number int, head, base string, state realdb.MergeRequestState) realdb.MergeRequest {
@@ -26,6 +27,12 @@ func makePR(id int64, number int, head, base string, state realdb.MergeRequestSt
 	}
 }
 
+func makePRWithHeadRepo(id int64, number int, head, base, headRepo string, state realdb.MergeRequestState) realdb.MergeRequest {
+	pr := makePR(id, number, head, base, state)
+	pr.HeadRepoCloneURL = headRepo
+	return pr
+}
+
 func TestDetectChains_LinearStack(t *testing.T) {
 	assert := Assert.New(t)
 	prs := []realdb.MergeRequest{
@@ -34,7 +41,7 @@ func TestDetectChains_LinearStack(t *testing.T) {
 		makePR(3, 102, "feature/auth-ui", "feature/auth-retry", prOpen),
 	}
 
-	chains := DetectChains(prs)
+	chains := DetectChains(prs, testRepoCloneURL)
 	assert.Len(chains, 1)
 	assert.Len(chains[0], 3)
 	assert.Equal(100, chains[0][0].Number) // base
@@ -47,7 +54,7 @@ func TestDetectChains_SinglePRNotAStack(t *testing.T) {
 	prs := []realdb.MergeRequest{
 		makePR(1, 100, "feature/solo", "main", prOpen),
 	}
-	chains := DetectChains(prs)
+	chains := DetectChains(prs, testRepoCloneURL)
 	assert.Empty(chains)
 }
 
@@ -59,7 +66,7 @@ func TestDetectChains_ForkPicksLowestNumber(t *testing.T) {
 		makePR(3, 101, "feature/child-a", "feature/base", prOpen),
 	}
 
-	chains := DetectChains(prs)
+	chains := DetectChains(prs, testRepoCloneURL)
 	assert.Len(chains, 1)
 	assert.Len(chains[0], 2)
 	assert.Equal(100, chains[0][0].Number)
@@ -72,7 +79,7 @@ func TestDetectChains_CycleSkipped(t *testing.T) {
 		makePR(1, 100, "branch-a", "branch-b", prOpen),
 		makePR(2, 101, "branch-b", "branch-a", prOpen),
 	}
-	chains := DetectChains(prs)
+	chains := DetectChains(prs, testRepoCloneURL)
 	assert.Empty(chains)
 }
 
@@ -82,24 +89,40 @@ func TestDetectChains_PartialMerge(t *testing.T) {
 		makePR(1, 100, "feature/a", "main", prMerged),
 		makePR(2, 101, "feature/b", "feature/a", prOpen),
 	}
-	chains := DetectChains(prs)
+	chains := DetectChains(prs, testRepoCloneURL)
 	assert.Len(chains, 1)
 	assert.Len(chains[0], 2)
 }
 
-func TestDetectChains_MalformedSameBranchPRDoesNotHideRoot(t *testing.T) {
+func TestDetectChains_ForkDefaultBranchPRDoesNotHideRoot(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
+	const fork = "https://github.com/mjacobs/widget.git"
 	prs := []realdb.MergeRequest{
-		makePR(1, 449, "legacy-parser-base", "legacy-parser-base", prMerged),
-		makePR(2, 748, "locate-parser-interface", "legacy-parser-base", prOpen),
+		makePRWithHeadRepo(1, 449, "main", "main", fork, prMerged),
+		makePR(2, 748, "locate-parser-interface", "main", prOpen),
 		makePR(3, 751, "provider-facade-core", "locate-parser-interface", prOpen),
 		makePR(4, 752, "provider-jsonl-source-set", "provider-facade-core", prOpen),
 	}
 
-	chains := DetectChains(prs)
+	chains := DetectChains(prs, testRepoCloneURL)
 	require.Len(chains, 1)
 	assert.Equal([]int{748, 751, 752}, stackNumbers(chains[0]))
+}
+
+func TestDetectChains_ForkBranchNameDoesNotShadowUpstreamStackBranch(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	const fork = "https://github.com/fork/widget.git"
+	prs := []realdb.MergeRequest{
+		makePRWithHeadRepo(1, 100, "feature/auth", "main", testRepoCloneURL, prOpen),
+		makePRWithHeadRepo(2, 101, "feature/auth-ui", "feature/auth", testRepoCloneURL, prOpen),
+		makePRWithHeadRepo(3, 90, "feature/auth", "main", fork, prOpen),
+	}
+
+	chains := DetectChains(prs, testRepoCloneURL)
+	require.Len(chains, 1)
+	assert.Equal([]int{100, 101}, stackNumbers(chains[0]))
 }
 
 func TestDetectChains_DuplicateHeadPrefersOpen(t *testing.T) {
@@ -112,7 +135,7 @@ func TestDetectChains_DuplicateHeadPrefersOpen(t *testing.T) {
 		makePR(3, 200, "feature/auth", "main", prOpen),
 	}
 
-	chains := DetectChains(prs)
+	chains := DetectChains(prs, testRepoCloneURL)
 	assert.Len(chains, 1)
 	assert.Len(chains[0], 2)
 	// Open PR #200 should be base, not merged #100.
@@ -130,7 +153,7 @@ func TestDetectChains_ForkPrefersOpenOverMerged(t *testing.T) {
 		makePR(3, 102, "feature/child-open", "feature/base", prOpen),
 	}
 
-	chains := DetectChains(prs)
+	chains := DetectChains(prs, testRepoCloneURL)
 	assert.Len(chains, 1)
 	assert.Len(chains[0], 2)
 	assert.Equal(100, chains[0][0].Number)
@@ -144,7 +167,7 @@ func TestDetectChains_FullyMergedNotAStack(t *testing.T) {
 		makePR(1, 100, "feature/a", "main", prMerged),
 		makePR(2, 101, "feature/b", "feature/a", prMerged),
 	}
-	chains := DetectChains(prs)
+	chains := DetectChains(prs, testRepoCloneURL)
 	// Chain exists but all merged — RunDetection filters these out.
 	assert.Len(chains, 1)
 }
@@ -175,6 +198,14 @@ func stackNumbers(chain []realdb.MergeRequest) []int {
 	numbers := make([]int, len(chain))
 	for i, pr := range chain {
 		numbers[i] = pr.Number
+	}
+	return numbers
+}
+
+func stackNumbersFromMembers(members []realdb.StackMemberWithPR) []int {
+	numbers := make([]int, len(members))
+	for i, member := range members {
+		numbers[i] = member.Number
 	}
 	return numbers
 }
@@ -222,6 +253,57 @@ func TestRunDetection(t *testing.T) {
 	assert.Len(members, 3)
 	assert.Equal(1, members[0].Position)
 	assert.Equal(100, members[0].Number)
+}
+
+func TestRunDetection_ForkBranchNameDoesNotShadowUpstreamStackBranch(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+
+	repoID, err := d.UpsertRepo(ctx, realdb.GitHubRepoIdentity("", "org", "repo"))
+	require.NoError(err)
+	require.NoError(d.UpdateRepoProviderMetadata(ctx, repoID, realdb.RepoProviderMetadata{
+		CloneURL:      testRepoCloneURL,
+		DefaultBranch: "main",
+	}))
+
+	now := time.Now()
+	prs := []realdb.MergeRequest{
+		{
+			RepoID: repoID, PlatformID: 1, Number: 100,
+			Title: "PR feature/auth", Author: "a", State: prOpen,
+			HeadBranch: "feature/auth", BaseBranch: "main",
+			HeadRepoCloneURL: testRepoCloneURL,
+			CreatedAt:        now, UpdatedAt: now, LastActivityAt: now,
+		},
+		{
+			RepoID: repoID, PlatformID: 2, Number: 101,
+			Title: "PR feature/auth-ui", Author: "a", State: prOpen,
+			HeadBranch: "feature/auth-ui", BaseBranch: "feature/auth",
+			HeadRepoCloneURL: testRepoCloneURL,
+			CreatedAt:        now, UpdatedAt: now, LastActivityAt: now,
+		},
+		{
+			RepoID: repoID, PlatformID: 3, Number: 90,
+			Title: "Fork PR feature/auth", Author: "fork", State: prOpen,
+			HeadBranch: "feature/auth", BaseBranch: "main",
+			HeadRepoCloneURL: "https://github.com/fork/repo.git",
+			CreatedAt:        now, UpdatedAt: now, LastActivityAt: now,
+		},
+	}
+	for i := range prs {
+		_, err := d.UpsertMergeRequest(ctx, &prs[i])
+		require.NoError(err)
+	}
+
+	require.NoError(RunDetection(ctx, d, repoID))
+
+	stack, members, err := d.GetStackForPR(ctx, "org", "repo", 101)
+	require.NoError(err)
+	require.NotNil(stack)
+	assert.Equal("auth", stack.Name)
+	assert.Equal([]int{100, 101}, stackNumbersFromMembers(members))
 }
 
 func TestRunDetection_FullyMergedStackDeleted(t *testing.T) {

--- a/internal/stacks/detect_test.go
+++ b/internal/stacks/detect_test.go
@@ -110,6 +110,21 @@ func TestDetectChains_ForkDefaultBranchPRDoesNotHideRoot(t *testing.T) {
 	assert.Equal([]int{748, 751, 752}, stackNumbers(chains[0]))
 }
 
+func TestDetectChains_SameRepoSelfEdgeDoesNotHideRoot(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	prs := []realdb.MergeRequest{
+		makePR(1, 449, "legacy-parser-base", "legacy-parser-base", prMerged),
+		makePR(2, 748, "locate-parser-interface", "legacy-parser-base", prOpen),
+		makePR(3, 751, "provider-facade-core", "locate-parser-interface", prOpen),
+		makePR(4, 752, "provider-jsonl-source-set", "provider-facade-core", prOpen),
+	}
+
+	chains := DetectChains(prs, testRepoCloneURL)
+	require.Len(chains, 1)
+	assert.Equal([]int{748, 751, 752}, stackNumbers(chains[0]))
+}
+
 func TestDetectChains_ForkBranchNameDoesNotShadowUpstreamStackBranch(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)

--- a/internal/stacks/detect_test.go
+++ b/internal/stacks/detect_test.go
@@ -87,12 +87,12 @@ func TestDetectChains_PartialMerge(t *testing.T) {
 	assert.Len(chains[0], 2)
 }
 
-func TestDetectChains_SelfTargetingDefaultBranchPRDoesNotHideRoot(t *testing.T) {
+func TestDetectChains_MalformedSameBranchPRDoesNotHideRoot(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
 	prs := []realdb.MergeRequest{
-		makePR(1, 449, "main", "main", prMerged),
-		makePR(2, 748, "locate-parser-interface", "main", prOpen),
+		makePR(1, 449, "legacy-parser-base", "legacy-parser-base", prMerged),
+		makePR(2, 748, "locate-parser-interface", "legacy-parser-base", prOpen),
 		makePR(3, 751, "provider-facade-core", "locate-parser-interface", prOpen),
 		makePR(4, 752, "provider-jsonl-source-set", "provider-facade-core", prOpen),
 	}

--- a/internal/stacks/detect_test.go
+++ b/internal/stacks/detect_test.go
@@ -18,12 +18,13 @@ const (
 
 func makePR(id int64, number int, head, base string, state realdb.MergeRequestState) realdb.MergeRequest {
 	return realdb.MergeRequest{
-		ID:         id,
-		Number:     number,
-		Title:      "PR " + head,
-		HeadBranch: head,
-		BaseBranch: base,
-		State:      state,
+		ID:               id,
+		Number:           number,
+		Title:            "PR " + head,
+		HeadBranch:       head,
+		BaseBranch:       base,
+		HeadRepoCloneURL: testRepoCloneURL,
+		State:            state,
 	}
 }
 
@@ -146,7 +147,21 @@ func TestDetectChains_UnknownHeadRepoDoesNotShadowKnownUpstreamStackBranch(t *te
 	prs := []realdb.MergeRequest{
 		makePRWithHeadRepo(1, 100, "feature/auth", "main", testRepoCloneURL, prOpen),
 		makePRWithHeadRepo(2, 101, "feature/auth-ui", "feature/auth", testRepoCloneURL, prOpen),
-		makePR(3, 90, "feature/auth", "main", prOpen),
+		makePRWithHeadRepo(3, 90, "feature/auth", "main", "", prOpen),
+	}
+
+	chains := DetectChains(prs, testRepoCloneURL)
+	require.Len(chains, 1)
+	assert.Equal([]int{100, 101}, stackNumbers(chains[0]))
+}
+
+func TestDetectChains_UnknownHeadRepoDoesNotChainWithKnownUpstreamStackBranch(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	prs := []realdb.MergeRequest{
+		makePRWithHeadRepo(1, 100, "feature/auth", "main", testRepoCloneURL, prOpen),
+		makePRWithHeadRepo(2, 101, "feature/auth-ui", "feature/auth", testRepoCloneURL, prOpen),
+		makePRWithHeadRepo(3, 90, "feature/fork-ui", "feature/auth", "", prOpen),
 	}
 
 	chains := DetectChains(prs, testRepoCloneURL)
@@ -265,6 +280,10 @@ func TestRunDetection(t *testing.T) {
 
 	repoID, err := d.UpsertRepo(ctx, realdb.GitHubRepoIdentity("", "org", "repo"))
 	require.NoError(err)
+	require.NoError(d.UpdateRepoProviderMetadata(ctx, repoID, realdb.RepoProviderMetadata{
+		CloneURL:      testRepoCloneURL,
+		DefaultBranch: "main",
+	}))
 
 	// Create a 3-PR chain.
 	now := time.Now()
@@ -279,7 +298,7 @@ func TestRunDetection(t *testing.T) {
 		_, err := d.UpsertMergeRequest(ctx, &realdb.MergeRequest{
 			RepoID: repoID, PlatformID: int64(i + 1), Number: pr.num,
 			Title: "PR " + pr.head, Author: "a", State: "open",
-			HeadBranch: pr.head, BaseBranch: pr.base,
+			HeadBranch: pr.head, BaseBranch: pr.base, HeadRepoCloneURL: testRepoCloneURL,
 			CreatedAt: now, UpdatedAt: now, LastActivityAt: now,
 		})
 		require.NoError(err)
@@ -356,6 +375,10 @@ func TestRunDetection_FullyMergedStackDeleted(t *testing.T) {
 
 	repoID, err := d.UpsertRepo(ctx, realdb.GitHubRepoIdentity("", "org", "repo"))
 	require.NoError(err)
+	require.NoError(d.UpdateRepoProviderMetadata(ctx, repoID, realdb.RepoProviderMetadata{
+		CloneURL:      testRepoCloneURL,
+		DefaultBranch: "main",
+	}))
 
 	now := time.Now()
 	// Start with an open chain.
@@ -369,7 +392,7 @@ func TestRunDetection_FullyMergedStackDeleted(t *testing.T) {
 		_, err := d.UpsertMergeRequest(ctx, &realdb.MergeRequest{
 			RepoID: repoID, PlatformID: int64(i + 1), Number: pr.num,
 			Title: "PR " + pr.head, Author: "a", State: "open",
-			HeadBranch: pr.head, BaseBranch: pr.base,
+			HeadBranch: pr.head, BaseBranch: pr.base, HeadRepoCloneURL: testRepoCloneURL,
 			CreatedAt: now, UpdatedAt: now, LastActivityAt: now,
 		})
 		require.NoError(err)
@@ -386,7 +409,8 @@ func TestRunDetection_FullyMergedStackDeleted(t *testing.T) {
 		_, err := d.UpsertMergeRequest(ctx, &realdb.MergeRequest{
 			RepoID: repoID, PlatformID: int64(num - 99), Number: num,
 			Title: "PR merged", Author: "a", State: "merged",
-			HeadBranch: "feature/" + string(rune('a'+num-100)),
+			HeadRepoCloneURL: testRepoCloneURL,
+			HeadBranch:       "feature/" + string(rune('a'+num-100)),
 			BaseBranch: func() string {
 				if num == 100 {
 					return "main"

--- a/internal/stacks/hook_test.go
+++ b/internal/stacks/hook_test.go
@@ -31,6 +31,10 @@ func TestSyncCompletedHookUsesProviderQualifiedRepoIdentity(t *testing.T) {
 		Name:         "repo",
 	})
 	require.NoError(err)
+	require.NoError(d.UpdateRepoProviderMetadata(ctx, gitlabRepoID, realdb.RepoProviderMetadata{
+		CloneURL:      "https://code.example.com/org/repo.git",
+		DefaultBranch: "main",
+	}))
 
 	now := time.Now().UTC()
 	for i, pr := range []struct {
@@ -44,7 +48,8 @@ func TestSyncCompletedHookUsesProviderQualifiedRepoIdentity(t *testing.T) {
 			RepoID: gitlabRepoID, PlatformID: int64(i + 1),
 			Number: pr.number, Title: "MR", Author: "a", State: "open",
 			HeadBranch: pr.head, BaseBranch: pr.base,
-			CreatedAt: now, UpdatedAt: now, LastActivityAt: now,
+			HeadRepoCloneURL: "https://code.example.com/org/repo.git",
+			CreatedAt:        now, UpdatedAt: now, LastActivityAt: now,
 		})
 		require.NoError(err)
 	}

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -34,6 +34,14 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 	if err != nil {
 		return nil, fmt.Errorf("upsert acme/tools: %w", err)
 	}
+	const toolsCloneURL = "https://github.com/acme/tools.git"
+	if err := d.UpdateRepoProviderMetadata(ctx, toolsID, db.RepoProviderMetadata{
+		WebURL:        "https://github.com/acme/tools",
+		CloneURL:      toolsCloneURL,
+		DefaultBranch: "main",
+	}); err != nil {
+		return nil, fmt.Errorf("update acme/tools metadata: %w", err)
+	}
 	_, err = d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "acme", "archived"))
 	if err != nil {
 		return nil, fmt.Errorf("upsert acme/archived: %w", err)
@@ -413,6 +421,7 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 			State:             "open",
 			HeadBranch:        pr.head,
 			BaseBranch:        pr.base,
+			HeadRepoCloneURL:  toolsCloneURL,
 			CIStatus:          pr.ci,
 			ReviewDecision:    pr.review,
 			MergeableState:    pr.mergeableState,


### PR DESCRIPTION
Stack detection was using branch names as identity, which lets fork PRs that reuse upstream branch names hide real same-repo stacks. This updates detection to use repo-aware branch keys, keeps true same-repo self-edges from poisoning stack roots, and makes GitLab fork identity explicit instead of silently collapsing unresolved fork sources to the target repo.

Validation: focused stack, GitLab, and server sync/API tests passed; `make test-short` passed.