### PR TITLE
fix: complete fleet field in RepoSettings settings mocks

### DIFF
--- a/frontend/src/lib/components/settings/RepoSettings.test.ts
+++ b/frontend/src/lib/components/settings/RepoSettings.test.ts
@@ -408,6 +408,7 @@ describe("RepoSettings", () => {
         renderer: "xterm",
       },
       agents: [],
+      fleet: defaultFleetSettings(),
     });
     mockUpdateRepoWorktreeBasePath.mockResolvedValue({
       repos: promotedRepos,
@@ -431,6 +432,7 @@ describe("RepoSettings", () => {
         renderer: "xterm",
       },
       agents: [],
+      fleet: defaultFleetSettings(),
     });
 
     render(RepoSettings, {
@@ -603,6 +605,7 @@ describe("RepoSettings", () => {
         renderer: "xterm",
       },
       agents: [],
+      fleet: defaultFleetSettings(),
     });
     mockUpdateRepoWorktreeBasePath.mockRejectedValue(new Error("path does not exist"));
     mockRemoveRepo.mockResolvedValue();


### PR DESCRIPTION
Three `Settings`-returning mocks in `RepoSettings.test.ts` (the `bulkAddRepos` and `updateRepoWorktreeBasePath` `mockResolvedValue` calls) were missing the `fleet` field that became required on the generated `Settings` type in #543. The four sibling mocks in the same file were updated then; these three were missed, so `svelte-check --fail-on-warnings` reports three "Property fleet is missing" type errors on the committed tree.

- Add `fleet: defaultFleetSettings()` to the three affected mocks, matching the existing pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)