### PR TITLE
fix: narrow list searches by independent terms

### DIFF
--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -11,13 +11,18 @@ import (
 )
 
 // listSearchCondition returns a SQL condition and args for a free-text search.
-// The title is searched as "#{number} {title}" so substring queries can match
-// the number, the title, or both at once (e.g. "278" hits "#278 fix bug").
-// Author is matched separately. Labels are matched by name for list aliases
-// with item-label join tables. The alias is the table alias used in the
-// surrounding query (e.g. "p" for merge requests, "i" for issues).
+// Unquoted whitespace-separated terms are ANDed. Within each term, the title
+// is searched as "#{number} {title}" so substring queries can match the
+// number, the title, or both at once (e.g. "278" hits "#278 fix bug").
+// Author and repository path/name are matched separately. Labels are matched
+// by name for list aliases with item-label join tables. The alias is the table
+// alias used in the surrounding query (e.g. "p" for merge requests, "i" for
+// issues), and the repository table must be joined as alias "r".
 func listSearchCondition(alias, search string) (string, []any) {
-	like := "%" + search + "%"
+	terms := listSearchTerms(search)
+	if len(terms) == 0 {
+		return "", nil
+	}
 	labelCondition := ""
 	switch alias {
 	case "p":
@@ -41,15 +46,54 @@ func listSearchCondition(alias, search string) (string, []any) {
 			alias,
 		)
 	}
-	cond := fmt.Sprintf(
-		"(('#' || %s.number || ' ' || %s.title) LIKE ? OR %s.author LIKE ?%s)",
+	termCondition := fmt.Sprintf(
+		"(('#' || %s.number || ' ' || %s.title) LIKE ? OR %s.author LIKE ? OR r.repo_path LIKE ? OR r.owner LIKE ? OR r.name LIKE ?%s)",
 		alias, alias, alias, labelCondition,
 	)
-	args := []any{like, like}
-	if labelCondition != "" {
-		args = append(args, like)
+	conds := make([]string, 0, len(terms))
+	args := make([]any, 0, len(terms)*6)
+	for _, term := range terms {
+		conds = append(conds, termCondition)
+		like := "%" + term + "%"
+		args = append(args, like, like, like, like, like)
+		if labelCondition != "" {
+			args = append(args, like)
+		}
 	}
-	return cond, args
+	return "(" + strings.Join(conds, " AND ") + ")", args
+}
+
+func listSearchTerms(search string) []string {
+	var terms []string
+	var b strings.Builder
+	var quote rune
+
+	flush := func() {
+		term := strings.TrimSpace(b.String())
+		if term != "" {
+			terms = append(terms, term)
+		}
+		b.Reset()
+	}
+
+	for _, r := range search {
+		switch {
+		case quote != 0:
+			if r == quote {
+				quote = 0
+				continue
+			}
+			b.WriteRune(r)
+		case r == '"' || r == '\'':
+			quote = r
+		case r == ' ' || r == '\t' || r == '\n' || r == '\r':
+			flush()
+		default:
+			b.WriteRune(r)
+		}
+	}
+	flush()
+	return terms
 }
 
 func appendLimitOffset(query string, args *[]any, limit, offset int) string {
@@ -2454,8 +2498,10 @@ func (d *DB) ListMergeRequests(ctx context.Context, opts ListMergeRequestsOpts) 
 	}
 	if opts.Search != "" {
 		cond, condArgs := listSearchCondition("p", opts.Search)
-		conds = append(conds, cond)
-		args = append(args, condArgs...)
+		if cond != "" {
+			conds = append(conds, cond)
+			args = append(args, condArgs...)
+		}
 	}
 
 	where := ""
@@ -3307,8 +3353,10 @@ func (d *DB) ListIssues(
 	}
 	if opts.Search != "" {
 		cond, condArgs := listSearchCondition("i", opts.Search)
-		conds = append(conds, cond)
-		args = append(args, condArgs...)
+		if cond != "" {
+			conds = append(conds, cond)
+			args = append(args, condArgs...)
+		}
 	}
 	if opts.Assignee != "" {
 		// Query JSON array structurally to avoid LIKE wildcard injection.

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -85,7 +85,11 @@ func listSearchTerms(search string) []string {
 			}
 			b.WriteRune(r)
 		case r == '"' || r == '\'':
-			quote = r
+			if b.Len() == 0 {
+				quote = r
+				continue
+			}
+			b.WriteRune(r)
 		case r == ' ' || r == '\t' || r == '\n' || r == '\r':
 			flush()
 		default:

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -2465,6 +2465,28 @@ func TestListPullRequestsFilterBySearch(t *testing.T) {
 	assert.Equal(1, prs[0].Number)
 }
 
+func TestListPullRequestsFilterBySearchPreservesApostrophesInTerms(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	d := openTestDB(t)
+
+	repoID := insertTestRepo(t, d, "owner", "repo")
+	base := baseTime()
+
+	insertTestMR(t, d, repoID, 1, "can't reproduce", base)
+	insertTestMR(t, d, repoID, 2, "O'Reilly docs update", base.Add(time.Hour))
+
+	prs, err := d.ListMergeRequests(t.Context(), ListMergeRequestsOpts{Search: "can't"})
+	require.NoError(err)
+	require.Len(prs, 1)
+	assert.Equal(1, prs[0].Number)
+
+	prs, err = d.ListMergeRequests(t.Context(), ListMergeRequestsOpts{Search: "O'Reilly"})
+	require.NoError(err)
+	require.Len(prs, 1)
+	assert.Equal(2, prs[0].Number)
+}
+
 func TestListPullRequestsFilterBySearchRepoFragment(t *testing.T) {
 	require := require.New(t)
 	assert := Assert.New(t)

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -2443,6 +2443,8 @@ func TestPullRequestRepoScopedQueriesCanonicalizeOwnerName(t *testing.T) {
 }
 
 func TestListPullRequestsFilterBySearch(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
 	d := openTestDB(t)
 
 	repoID := insertTestRepo(t, d, "owner", "repo")
@@ -2450,11 +2452,40 @@ func TestListPullRequestsFilterBySearch(t *testing.T) {
 
 	insertTestMR(t, d, repoID, 1, "add feature", base)
 	insertTestMR(t, d, repoID, 2, "fix bug", base.Add(time.Hour))
+	insertTestMR(t, d, repoID, 3, "feature cleanup", base.Add(2*time.Hour))
 
 	prs, err := d.ListMergeRequests(t.Context(), ListMergeRequestsOpts{Search: "feature"})
-	require.NoError(t, err)
-	require.Len(t, prs, 1)
-	Assert.Equal(t, 1, prs[0].Number)
+	require.NoError(err)
+	require.Len(prs, 2)
+	assert.ElementsMatch([]int{1, 3}, []int{prs[0].Number, prs[1].Number})
+
+	prs, err = d.ListMergeRequests(t.Context(), ListMergeRequestsOpts{Search: "feature add"})
+	require.NoError(err)
+	require.Len(prs, 1)
+	assert.Equal(1, prs[0].Number)
+}
+
+func TestListPullRequestsFilterBySearchRepoFragment(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	d := openTestDB(t)
+
+	apiRepoID := insertTestRepo(t, d, "acme", "api")
+	workerRepoID := insertTestRepo(t, d, "tools", "worker")
+	base := baseTime()
+
+	insertTestMR(t, d, apiRepoID, 1, "fix bug", base)
+	insertTestMR(t, d, workerRepoID, 2, "fix bug", base.Add(time.Hour))
+
+	prs, err := d.ListMergeRequests(t.Context(), ListMergeRequestsOpts{Search: "acm"})
+	require.NoError(err)
+	require.Len(prs, 1)
+	assert.Equal(1, prs[0].Number)
+
+	prs, err = d.ListMergeRequests(t.Context(), ListMergeRequestsOpts{Search: "work bug"})
+	require.NoError(err)
+	require.Len(prs, 1)
+	assert.Equal(2, prs[0].Number)
 }
 
 func TestListPullRequestsFilterBySearchNumber(t *testing.T) {
@@ -3556,6 +3587,11 @@ func TestListIssuesFilterBySearch(t *testing.T) {
 	require.Len(issues, 1)
 	assert.Equal(278, issues[0].Number)
 
+	issues, err = d.ListIssues(t.Context(), ListIssuesOpts{Search: "filter broken"})
+	require.NoError(err)
+	require.Len(issues, 1)
+	assert.Equal(278, issues[0].Number)
+
 	issues, err = d.ListIssues(t.Context(), ListIssuesOpts{Search: "278"})
 	require.NoError(err)
 	require.Len(issues, 1)
@@ -3570,6 +3606,29 @@ func TestListIssuesFilterBySearch(t *testing.T) {
 	issues, err = d.ListIssues(t.Context(), ListIssuesOpts{Search: "2"})
 	require.NoError(err)
 	require.Len(issues, 3)
+}
+
+func TestListIssuesFilterBySearchRepoFragment(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	d := openTestDB(t)
+
+	apiRepoID := insertTestRepo(t, d, "acme", "api")
+	workerRepoID := insertTestRepo(t, d, "tools", "worker")
+	base := baseTime()
+
+	insertTestIssue(t, d, apiRepoID, 1, "fix bug", base)
+	insertTestIssue(t, d, workerRepoID, 2, "fix bug", base.Add(time.Hour))
+
+	issues, err := d.ListIssues(t.Context(), ListIssuesOpts{Search: "acm"})
+	require.NoError(err)
+	require.Len(issues, 1)
+	assert.Equal(1, issues[0].Number)
+
+	issues, err = d.ListIssues(t.Context(), ListIssuesOpts{Search: "work bug"})
+	require.NoError(err)
+	require.Len(issues, 1)
+	assert.Equal(2, issues[0].Number)
 }
 
 func TestListIssuesFilterBySearchLabel(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -7436,6 +7436,7 @@ func TestAPIListPullsSearchByNumber(t *testing.T) {
 	seedPR(t, database, "acme", "widget", 12, withSeedPRTitle("add feature"))
 	prID := seedPR(t, database, "acme", "widget", 278, withSeedPRTitle("fix bug"))
 	seedPR(t, database, "acme", "widget", 290, withSeedPRTitle("another change"))
+	seedPR(t, database, "tools", "worker", 301, withSeedPRTitle("repair bug"))
 	repo, err := database.GetRepoByOwnerName(ctx, "acme", "widget")
 	require.NoError(err)
 	require.NoError(database.ReplaceMergeRequestLabels(ctx, repo.ID, prID, []db.Label{{
@@ -7470,6 +7471,12 @@ func TestAPIListPullsSearchByNumber(t *testing.T) {
 	q = "fix"
 	assert.ElementsMatch([]int{278}, pullNumbers(&generated.ListPullsParams{Q: &q}))
 
+	q = "fix widget"
+	assert.ElementsMatch([]int{278}, pullNumbers(&generated.ListPullsParams{Q: &q}))
+
+	q = "work bug"
+	assert.ElementsMatch([]int{301}, pullNumbers(&generated.ListPullsParams{Q: &q}))
+
 	q = "needs-review"
 	assert.ElementsMatch([]int{278}, pullNumbers(&generated.ListPullsParams{Q: &q}))
 
@@ -7487,6 +7494,7 @@ func TestAPIListIssuesSearchByNumber(t *testing.T) {
 	seedIssueOnHost(t, database, "github.com", "acme", "widget", 12, "open", "report a bug")
 	issueID := seedIssueOnHost(t, database, "github.com", "acme", "widget", 278, "open", "filter broken")
 	seedIssueOnHost(t, database, "github.com", "acme", "widget", 290, "open", "another change")
+	seedIssueOnHost(t, database, "github.com", "tools", "worker", 301, "open", "triage bug")
 	repo, err := database.GetRepoByOwnerName(ctx, "acme", "widget")
 	require.NoError(err)
 	require.NoError(database.ReplaceIssueLabels(ctx, repo.ID, issueID, []db.Label{{
@@ -7520,6 +7528,12 @@ func TestAPIListIssuesSearchByNumber(t *testing.T) {
 	// Title still matches.
 	q = "broken"
 	assert.ElementsMatch([]int{278}, issueNumbers(&generated.ListIssuesParams{Q: &q}))
+
+	q = "filter widget"
+	assert.ElementsMatch([]int{278}, issueNumbers(&generated.ListIssuesParams{Q: &q}))
+
+	q = "work bug"
+	assert.ElementsMatch([]int{301}, issueNumbers(&generated.ListIssuesParams{Q: &q}))
 
 	q = "needs-triage"
 	assert.ElementsMatch([]int{278}, issueNumbers(&generated.ListIssuesParams{Q: &q}))

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -7437,6 +7437,7 @@ func TestAPIListPullsSearchByNumber(t *testing.T) {
 	prID := seedPR(t, database, "acme", "widget", 278, withSeedPRTitle("fix bug"))
 	seedPR(t, database, "acme", "widget", 290, withSeedPRTitle("another change"))
 	seedPR(t, database, "tools", "worker", 301, withSeedPRTitle("repair bug"))
+	seedPR(t, database, "docs", "reader", 302, withSeedPRTitle("can't reproduce"))
 	repo, err := database.GetRepoByOwnerName(ctx, "acme", "widget")
 	require.NoError(err)
 	require.NoError(database.ReplaceMergeRequestLabels(ctx, repo.ID, prID, []db.Label{{
@@ -7477,12 +7478,15 @@ func TestAPIListPullsSearchByNumber(t *testing.T) {
 	q = "work bug"
 	assert.ElementsMatch([]int{301}, pullNumbers(&generated.ListPullsParams{Q: &q}))
 
+	q = "can't"
+	assert.ElementsMatch([]int{302}, pullNumbers(&generated.ListPullsParams{Q: &q}))
+
 	q = "needs-review"
 	assert.ElementsMatch([]int{278}, pullNumbers(&generated.ListPullsParams{Q: &q}))
 
 	// Substring of number matches multiple.
 	q = "2"
-	assert.ElementsMatch([]int{12, 278, 290}, pullNumbers(&generated.ListPullsParams{Q: &q}))
+	assert.ElementsMatch([]int{12, 278, 290, 302}, pullNumbers(&generated.ListPullsParams{Q: &q}))
 }
 
 func TestAPIListIssuesSearchByNumber(t *testing.T) {
@@ -7495,6 +7499,7 @@ func TestAPIListIssuesSearchByNumber(t *testing.T) {
 	issueID := seedIssueOnHost(t, database, "github.com", "acme", "widget", 278, "open", "filter broken")
 	seedIssueOnHost(t, database, "github.com", "acme", "widget", 290, "open", "another change")
 	seedIssueOnHost(t, database, "github.com", "tools", "worker", 301, "open", "triage bug")
+	seedIssueOnHost(t, database, "github.com", "docs", "reader", 302, "open", "O'Reilly reference")
 	repo, err := database.GetRepoByOwnerName(ctx, "acme", "widget")
 	require.NoError(err)
 	require.NoError(database.ReplaceIssueLabels(ctx, repo.ID, issueID, []db.Label{{
@@ -7535,12 +7540,15 @@ func TestAPIListIssuesSearchByNumber(t *testing.T) {
 	q = "work bug"
 	assert.ElementsMatch([]int{301}, issueNumbers(&generated.ListIssuesParams{Q: &q}))
 
+	q = "O'Reilly"
+	assert.ElementsMatch([]int{302}, issueNumbers(&generated.ListIssuesParams{Q: &q}))
+
 	q = "needs-triage"
 	assert.ElementsMatch([]int{278}, issueNumbers(&generated.ListIssuesParams{Q: &q}))
 
 	// Substring of number matches multiple.
 	q = "2"
-	assert.ElementsMatch([]int{12, 278, 290}, issueNumbers(&generated.ListIssuesParams{Q: &q}))
+	assert.ElementsMatch([]int{12, 278, 290, 302}, issueNumbers(&generated.ListIssuesParams{Q: &q}))
 }
 
 func TestAPIListItemsHonorsLimit(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -7478,6 +7478,9 @@ func TestAPIListPullsSearchByNumber(t *testing.T) {
 	q = "work bug"
 	assert.ElementsMatch([]int{301}, pullNumbers(&generated.ListPullsParams{Q: &q}))
 
+	q = "needs-review bug"
+	assert.ElementsMatch([]int{278}, pullNumbers(&generated.ListPullsParams{Q: &q}))
+
 	q = "can't"
 	assert.ElementsMatch([]int{302}, pullNumbers(&generated.ListPullsParams{Q: &q}))
 
@@ -7539,6 +7542,9 @@ func TestAPIListIssuesSearchByNumber(t *testing.T) {
 
 	q = "work bug"
 	assert.ElementsMatch([]int{301}, issueNumbers(&generated.ListIssuesParams{Q: &q}))
+
+	q = "needs-triage filter"
+	assert.ElementsMatch([]int{278}, issueNumbers(&generated.ListIssuesParams{Q: &q}))
 
 	q = "O'Reilly"
 	assert.ElementsMatch([]int{302}, issueNumbers(&generated.ListIssuesParams{Q: &q}))


### PR DESCRIPTION
PR and issue list search was too literal: multi-word input only matched an exact phrase, and multi-repo views could not be narrowed by typing org or repository fragments.

This makes unquoted search words independent required terms, with each term able to match item fields, labels, authors, or repository identity. Searches like `bug api` now narrow to PRs or issues that match both ideas, including repo names.

<sup>generated by a clanker</sup>