### PR TITLE
fix: wire workspace list actions

### DIFF
--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -7988,6 +7988,62 @@ paths:
       summary: Get workspace files on fleet host
       tags:
         - Fleet
+  /fleet/hosts/{host_key}/workspaces/{id}/pull:
+    post:
+      operationId: pull-fleet-workspace-branch
+      parameters:
+        - in: path
+          name: host_key
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Response returned by the owning fleet host.
+      summary: Pull workspace branch on fleet host
+      tags:
+        - Fleet
+  /fleet/hosts/{host_key}/workspaces/{id}/push:
+    post:
+      operationId: push-fleet-workspace-branch
+      parameters:
+        - in: path
+          name: host_key
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Response returned by the owning fleet host.
+      summary: Push workspace branch on fleet host
+      tags:
+        - Fleet
   /fleet/hosts/{host_key}/workspaces/{id}/refresh:
     post:
       operationId: refresh-fleet-workspace
@@ -8042,6 +8098,34 @@ paths:
                 $ref: "#/components/schemas/ProblemError"
           description: Response returned by the owning fleet host.
       summary: Retry workspace setup on fleet host
+      tags:
+        - Fleet
+  /fleet/hosts/{host_key}/workspaces/{id}/reveal:
+    post:
+      operationId: reveal-fleet-workspace
+      parameters:
+        - in: path
+          name: host_key
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Response returned by the owning fleet host.
+      summary: Reveal workspace folder on fleet host
       tags:
         - Fleet
   /fleet/hosts/{host_key}/workspaces/{id}/runtime:
@@ -15330,6 +15414,56 @@ paths:
       summary: Get workspace files
       tags:
         - Workspaces
+  /workspaces/{id}/pull:
+    post:
+      operationId: pull-workspace-branch
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkspaceResponse"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Error
+      summary: Pull workspace branch
+      tags:
+        - Workspaces
+  /workspaces/{id}/push:
+    post:
+      operationId: push-workspace-branch
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkspaceResponse"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Error
+      summary: Push workspace branch
+      tags:
+        - Workspaces
   /workspaces/{id}/refresh:
     post:
       operationId: refresh-workspace
@@ -15378,6 +15512,27 @@ paths:
                 $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Retry workspace
+      tags:
+        - Workspaces
+  /workspaces/{id}/reveal:
+    post:
+      operationId: reveal-workspace
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: No Content
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Error
+      summary: Reveal workspace folder
       tags:
         - Workspaces
   /workspaces/{id}/runtime:

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -115,6 +115,10 @@
     x: number;
     y: number;
   } | null>(null);
+  let workspaceAction = $state<{
+    workspaceKey: string;
+    action: "push" | "pull" | "reveal" | "delete";
+  } | null>(null);
   let contextMenuEl = $state<HTMLDivElement | null>(null);
   let contextMenuStyle = $state("");
 
@@ -657,6 +661,136 @@
     await fetchWorkspaces();
   }
 
+  function workspaceActionMatches(
+    ws: Workspace,
+    action?: "push" | "pull" | "reveal" | "delete",
+  ): boolean {
+    return (
+      workspaceAction?.workspaceKey === workspaceRowKey(ws) &&
+      (action === undefined || workspaceAction.action === action)
+    );
+  }
+
+  function workspaceBusyLabel(ws: Workspace): string {
+    if (!workspaceActionMatches(ws)) return "";
+    if (workspaceAction?.action === "push") return "Pushing branch";
+    if (workspaceAction?.action === "pull") return "Pulling branch";
+    if (workspaceAction?.action === "reveal") return "Opening folder";
+    if (workspaceAction?.action === "delete") return "Deleting workspace";
+    return "";
+  }
+
+  function startWorkspaceAction(
+    ws: Workspace,
+    action: "push" | "pull" | "reveal" | "delete",
+  ): boolean {
+    if (workspaceAction !== null) return false;
+    workspaceAction = { workspaceKey: workspaceRowKey(ws), action };
+    return true;
+  }
+
+  function finishWorkspaceAction(ws: Workspace): void {
+    if (workspaceActionMatches(ws)) {
+      workspaceAction = null;
+    }
+  }
+
+  async function syncWorkspaceBranch(
+    ws: Workspace,
+    action: "push" | "pull",
+  ): Promise<void> {
+    if (!startWorkspaceAction(ws, action)) return;
+    const label = action === "push" ? "Push branch" : "Pull remote changes";
+    try {
+      const { error, response } = ws.fleet_host_key
+        ? await client.POST(
+            action === "push"
+              ? "/fleet/hosts/{host_key}/workspaces/{id}/push"
+              : "/fleet/hosts/{host_key}/workspaces/{id}/pull",
+            {
+              params: {
+                path: { host_key: ws.fleet_host_key, id: ws.id },
+              },
+            },
+          )
+        : await client.POST(
+            action === "push" ? "/workspaces/{id}/push" : "/workspaces/{id}/pull",
+            {
+              params: { path: { id: ws.id } },
+            },
+          );
+      if (!response.ok) {
+        showFlash(apiErrorMessage(error, `${label} failed (${response.status})`));
+        return;
+      }
+      await fetchWorkspaces();
+      closeContextMenu();
+    } catch (err) {
+      showFlash(err instanceof Error ? err.message : `${label} failed.`);
+    } finally {
+      finishWorkspaceAction(ws);
+    }
+  }
+
+  async function revealWorkspacePath(ws: Workspace): Promise<void> {
+    if (!startWorkspaceAction(ws, "reveal")) return;
+    const label = revealLabel(ws);
+    try {
+      const { error, response } = ws.fleet_host_key
+        ? await client.POST("/fleet/hosts/{host_key}/workspaces/{id}/reveal", {
+            params: {
+              path: { host_key: ws.fleet_host_key, id: ws.id },
+            },
+          })
+        : await client.POST("/workspaces/{id}/reveal", {
+            params: { path: { id: ws.id } },
+          });
+      if (!response.ok) {
+        showFlash(apiErrorMessage(error, `${label} failed (${response.status})`));
+        return;
+      }
+      closeContextMenu();
+    } catch (err) {
+      showFlash(err instanceof Error ? err.message : `${label} failed.`);
+    } finally {
+      finishWorkspaceAction(ws);
+    }
+  }
+
+  async function deleteWorkspaceFromList(ws: Workspace): Promise<void> {
+    const confirmed = window.confirm(
+      `Delete workspace "${displayName(ws)}"?\n\nThis removes its managed worktree and runtime sessions.`,
+    );
+    if (!confirmed || !startWorkspaceAction(ws, "delete")) return;
+    try {
+      const { error, response } = ws.fleet_host_key
+        ? await client.DELETE("/fleet/hosts/{host_key}/workspaces/{id}", {
+            params: {
+              path: { host_key: ws.fleet_host_key, id: ws.id },
+            },
+          })
+        : await client.DELETE("/workspaces/{id}", {
+            params: { path: { id: ws.id } },
+          });
+      if (!response.ok && response.status !== 204) {
+        const fallback = response.status === 409
+          ? "Workspace has uncommitted changes. Open it to force delete."
+          : `Delete failed (${response.status})`;
+        showFlash(apiErrorMessage(error, fallback));
+        return;
+      }
+      await fetchWorkspaces();
+      closeContextMenu();
+      if (isSelectedWorkspace(ws)) {
+        navigate("/workspaces");
+      }
+    } catch (err) {
+      showFlash(err instanceof Error ? err.message : "Delete failed.");
+    } finally {
+      finishWorkspaceAction(ws);
+    }
+  }
+
   function openProviderItem(ws: Workspace): void {
     const url = providerItemURL(ws);
     closeContextMenu();
@@ -675,11 +809,6 @@
       return;
     }
     void copyMenuText(url, "Copied item URL.");
-  }
-
-  function unavailableSyncAction(label: string): void {
-    closeContextMenu();
-    showFlash(`${label} is not available from the workspace list yet.`);
   }
 
   function workspaceRoute(ws: Workspace): string {
@@ -908,6 +1037,12 @@
                     title={workingTitle(ws)}
                     aria-label={workingTitle(ws)}
                   ></span>
+                {:else if workspaceActionMatches(ws)}
+                  <span
+                    class="working-pulse"
+                    title={workspaceBusyLabel(ws)}
+                    aria-label={workspaceBusyLabel(ws)}
+                  ></span>
                 {/if}
               </div>
               <div class="ws-row-meta">
@@ -1017,6 +1152,7 @@
   {@const menuWorkspace = contextMenu.ws}
   {@const localWorkspace = !isRemoteWorkspace(menuWorkspace)}
   {@const itemURL = providerItemURL(menuWorkspace)}
+  {@const actionBusy = workspaceAction !== null}
   <div
     class="workspace-context-menu filter-dropdown"
     bind:this={contextMenuEl}
@@ -1041,10 +1177,13 @@
         class="filter-item active"
         role="menuitem"
         type="button"
-        onclick={() => unavailableSyncAction("Push branch")}
+        disabled={actionBusy}
+        onclick={() => {
+          void syncWorkspaceBranch(menuWorkspace, "push");
+        }}
       >
         <span class="filter-dot filter-dot--success"></span>
-        <span class="filter-label">Push branch</span>
+        <span class="filter-label">{workspaceActionMatches(menuWorkspace, "push") ? "Pushing..." : "Push branch"}</span>
         <span class="workspace-context-detail">{syncActionDetail(menuWorkspace)}</span>
       </button>
     {:else if canPull(menuWorkspace)}
@@ -1052,10 +1191,13 @@
         class="filter-item active"
         role="menuitem"
         type="button"
-        onclick={() => unavailableSyncAction("Pull remote changes")}
+        disabled={actionBusy}
+        onclick={() => {
+          void syncWorkspaceBranch(menuWorkspace, "pull");
+        }}
       >
         <span class="filter-dot filter-dot--warning"></span>
-        <span class="filter-label">Pull remote changes</span>
+        <span class="filter-label">{workspaceActionMatches(menuWorkspace, "pull") ? "Pulling..." : "Pull remote changes"}</span>
         <span class="workspace-context-detail">{syncActionDetail(menuWorkspace)}</span>
       </button>
     {/if}
@@ -1063,6 +1205,7 @@
       class="filter-item active"
       role="menuitem"
       type="button"
+      disabled={actionBusy}
       onclick={() => {
         void refreshWorkspaceStatus(menuWorkspace);
       }}
@@ -1076,6 +1219,7 @@
       class="filter-item active"
       role="menuitem"
       type="button"
+      disabled={actionBusy}
       onclick={() => {
         void copyMenuText(
           shortBranch(menuWorkspace.git_head_ref),
@@ -1091,6 +1235,7 @@
         class="filter-item active"
         role="menuitem"
         type="button"
+        disabled={actionBusy}
         onclick={() => {
           void copyMenuText(
             menuWorkspace.worktree_path,
@@ -1105,10 +1250,13 @@
         class="filter-item active"
         role="menuitem"
         type="button"
-        onclick={() => unavailableSyncAction(revealLabel(menuWorkspace))}
+        disabled={actionBusy}
+        onclick={() => {
+          void revealWorkspacePath(menuWorkspace);
+        }}
       >
         <span class="filter-dot"></span>
-        <span class="filter-label">{revealLabel(menuWorkspace)}</span>
+        <span class="filter-label">{workspaceActionMatches(menuWorkspace, "reveal") ? "Opening..." : revealLabel(menuWorkspace)}</span>
       </button>
     {/if}
 
@@ -1118,6 +1266,7 @@
         class="filter-item active"
         role="menuitem"
         type="button"
+        disabled={actionBusy}
         onclick={() => openProviderItem(menuWorkspace)}
       >
         <span class="filter-dot"></span>
@@ -1127,6 +1276,7 @@
         class="filter-item active"
         role="menuitem"
         type="button"
+        disabled={actionBusy}
         onclick={() => copyProviderItemURL(menuWorkspace)}
       >
         <span class="filter-dot"></span>
@@ -1139,10 +1289,13 @@
       class="filter-item active workspace-context-danger"
       role="menuitem"
       type="button"
-      onclick={() => unavailableSyncAction("Delete workspace")}
+      disabled={actionBusy}
+      onclick={() => {
+        void deleteWorkspaceFromList(menuWorkspace);
+      }}
     >
       <span class="filter-dot filter-dot--danger"></span>
-      <span class="filter-label">Delete workspace...</span>
+      <span class="filter-label">{workspaceActionMatches(menuWorkspace, "delete") ? "Deleting..." : "Delete workspace..."}</span>
     </button>
   </div>
 {/if}

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
@@ -6,10 +6,12 @@ import WorkspaceListSidebar from "./WorkspaceListSidebar.svelte";
 
 const mockGet = vi.fn();
 const mockPost = vi.fn();
+const mockDelete = vi.fn();
 const mockNavigate = vi.fn();
 
 vi.mock("../../api/runtime.js", () => ({
   client: {
+    DELETE: (...args: unknown[]) => mockDelete(...args),
     GET: (...args: unknown[]) => mockGet(...args),
     POST: (...args: unknown[]) => mockPost(...args),
   },
@@ -150,6 +152,7 @@ describe("WorkspaceListSidebar", () => {
   beforeEach(() => {
     mockGet.mockReset();
     mockPost.mockReset();
+    mockDelete.mockReset();
     mockNavigate.mockReset();
     localStorage.clear();
     vi.stubGlobal("EventSource", MockEventSource);
@@ -1095,6 +1098,252 @@ describe("WorkspaceListSidebar", () => {
     expect(screen.getByRole("menuitem", { name: "Copy worktree path" })).toBeTruthy();
     expect(screen.getByRole("menuitem", { name: "Reveal in Finder" })).toBeTruthy();
     expect(screen.getByRole("menuitem", { name: "Refresh git status" })).toBeTruthy();
+  });
+
+  it("pushes an ahead workspace branch and shows a busy state while pending", async () => {
+    const push = deferred<{
+      error?: unknown;
+      response: { ok: boolean; status: number };
+    }>();
+    mockGet.mockResolvedValue({
+      data: {
+        workspaces: [
+          workspaceFixture({
+            id: "ws-ahead",
+            provider: "github",
+            platformHost: "github.com",
+            owner: "kenn-io",
+            name: "middleman",
+            number: 9,
+            title: "Ahead workspace",
+            commitsAhead: 2,
+          }),
+        ],
+      },
+    });
+    mockPost.mockImplementation((path: string) => {
+      if (path === "/workspaces/{id}/push") return push.promise;
+      return Promise.resolve({ data: {}, response: { ok: true, status: 200 } });
+    });
+
+    const { container } = render(WorkspaceListSidebar, {
+      props: { selectedId: "ws-ahead" },
+    });
+    await screen.findByText("Ahead workspace");
+
+    await fireEvent.contextMenu(container.querySelector(".ws-row")!);
+
+    await fireEvent.click(screen.getByRole("menuitem", { name: /Push branch/ }));
+
+    expect(mockPost).toHaveBeenCalledWith("/workspaces/{id}/push", {
+      params: { path: { id: "ws-ahead" } },
+    });
+    expect((screen.getByRole("menuitem", { name: /Pushing\.\.\./ }) as HTMLButtonElement).disabled).toBe(true);
+
+    push.resolve({ response: { ok: true, status: 200 } });
+    await waitFor(() => {
+      expect(screen.queryByRole("menuitem", { name: /Pushing\.\.\./ })).toBeNull();
+    });
+  });
+
+  it("pulls a behind workspace branch and shows a busy state while pending", async () => {
+    const pull = deferred<{
+      error?: unknown;
+      response: { ok: boolean; status: number };
+    }>();
+    mockGet.mockResolvedValue({
+      data: {
+        workspaces: [
+          workspaceFixture({
+            id: "ws-behind",
+            provider: "github",
+            platformHost: "github.com",
+            owner: "kenn-io",
+            name: "middleman",
+            number: 9,
+            title: "Behind workspace",
+            commitsBehind: 1,
+          }),
+        ],
+      },
+    });
+    mockPost.mockImplementation((path: string) => {
+      if (path === "/workspaces/{id}/pull") return pull.promise;
+      return Promise.resolve({ data: {}, response: { ok: true, status: 200 } });
+    });
+
+    const { container } = render(WorkspaceListSidebar, {
+      props: { selectedId: "ws-behind" },
+    });
+    await screen.findByText("Behind workspace");
+
+    await fireEvent.contextMenu(container.querySelector(".ws-row")!);
+    await fireEvent.click(screen.getByRole("menuitem", { name: /Pull remote changes/ }));
+
+    expect(mockPost).toHaveBeenCalledWith("/workspaces/{id}/pull", {
+      params: { path: { id: "ws-behind" } },
+    });
+    expect((screen.getByRole("menuitem", { name: /Pulling\.\.\./ }) as HTMLButtonElement).disabled).toBe(true);
+
+    pull.resolve({ response: { ok: true, status: 200 } });
+    await waitFor(() => {
+      expect(screen.queryByRole("menuitem", { name: /Pulling\.\.\./ })).toBeNull();
+    });
+  });
+
+  it("opens a local workspace path from the context menu", async () => {
+    mockGet.mockImplementation((path: string) => {
+      if (path === "/snapshot") {
+        return Promise.resolve({
+          data: {
+            hosts: [
+              {
+                configKey: "hub",
+                diagnostics: [],
+                id: "hub",
+                kind: "self",
+                name: "hub",
+                operationAvailability: {},
+                platform: "darwin",
+                preferredTransport: "local",
+                reachable: true,
+                tmuxSessions: [],
+              },
+            ],
+          },
+        });
+      }
+      return Promise.resolve({
+        data: {
+          workspaces: [
+            workspaceFixture({
+              id: "ws-reveal",
+              provider: "github",
+              platformHost: "github.com",
+              owner: "kenn-io",
+              name: "middleman",
+              number: 12,
+              title: "Reveal me",
+            }),
+          ],
+        },
+      });
+    });
+    mockPost.mockResolvedValue({
+      error: undefined,
+      response: { ok: true, status: 204 },
+    });
+
+    const { container } = render(WorkspaceListSidebar, {
+      props: { selectedId: "ws-reveal" },
+    });
+    await screen.findByText("Reveal me");
+
+    await fireEvent.contextMenu(container.querySelector(".ws-row")!);
+    await fireEvent.click(screen.getByRole("menuitem", { name: "Reveal in Finder" }));
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith("/workspaces/{id}/reveal", {
+        params: { path: { id: "ws-reveal" } },
+      });
+    });
+  });
+
+  it("deletes a workspace from the context menu after confirmation", async () => {
+    vi.stubGlobal(
+      "confirm",
+      vi.fn(() => true),
+    );
+    mockGet.mockImplementation((path: string) => {
+      if (path === "/snapshot") {
+        return Promise.resolve({
+          data: {
+            hosts: [
+              {
+                configKey: "hub",
+                diagnostics: [],
+                id: "hub",
+                kind: "self",
+                name: "hub",
+                operationAvailability: {},
+                platform: "darwin",
+                preferredTransport: "local",
+                reachable: true,
+                tmuxSessions: [],
+              },
+            ],
+          },
+        });
+      }
+      return Promise.resolve({
+        data: {
+          workspaces: [
+            workspaceFixture({
+              id: "ws-delete",
+              provider: "github",
+              platformHost: "github.com",
+              owner: "kenn-io",
+              name: "middleman",
+              number: 10,
+              title: "Delete me",
+            }),
+          ],
+        },
+      });
+    });
+    mockDelete.mockResolvedValue({
+      error: undefined,
+      response: { ok: true, status: 204 },
+    });
+
+    const { container } = render(WorkspaceListSidebar, {
+      props: { selectedId: "ws-delete" },
+    });
+    await screen.findByText("Delete me");
+
+    await fireEvent.contextMenu(container.querySelector(".ws-row")!);
+    await fireEvent.click(screen.getByRole("menuitem", { name: "Delete workspace..." }));
+
+    await waitFor(() => {
+      expect(window.confirm).toHaveBeenCalledWith(expect.stringContaining('Delete workspace "Delete me"?'));
+      expect(mockDelete).toHaveBeenCalledWith("/workspaces/{id}", {
+        params: { path: { id: "ws-delete" } },
+      });
+    });
+    expect(mockNavigate).toHaveBeenCalledWith("/workspaces");
+  });
+
+  it("keeps a workspace when context menu deletion is cancelled", async () => {
+    vi.stubGlobal(
+      "confirm",
+      vi.fn(() => false),
+    );
+    mockGet.mockResolvedValue({
+      data: {
+        workspaces: [
+          workspaceFixture({
+            id: "ws-keep",
+            provider: "github",
+            platformHost: "github.com",
+            owner: "kenn-io",
+            name: "middleman",
+            number: 11,
+            title: "Keep me",
+          }),
+        ],
+      },
+    });
+
+    const { container } = render(WorkspaceListSidebar, {
+      props: { selectedId: "ws-keep" },
+    });
+    await screen.findByText("Keep me");
+
+    await fireEvent.contextMenu(container.querySelector(".ws-row")!);
+    await fireEvent.click(screen.getByRole("menuitem", { name: "Delete workspace..." }));
+
+    expect(mockDelete).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 
   it("omits local filesystem actions for remote workspace context menus", async () => {

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -3875,11 +3875,20 @@ type ClientInterface interface {
 	// GetFleetWorkspaceFiles request
 	GetFleetWorkspaceFiles(ctx context.Context, hostKey string, id string, params *GetFleetWorkspaceFilesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// PullFleetWorkspaceBranch request
+	PullFleetWorkspaceBranch(ctx context.Context, hostKey string, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PushFleetWorkspaceBranch request
+	PushFleetWorkspaceBranch(ctx context.Context, hostKey string, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// RefreshFleetWorkspace request
 	RefreshFleetWorkspace(ctx context.Context, hostKey string, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// RetryFleetWorkspace request
 	RetryFleetWorkspace(ctx context.Context, hostKey string, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// RevealFleetWorkspace request
+	RevealFleetWorkspace(ctx context.Context, hostKey string, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetFleetWorkspaceRuntime request
 	GetFleetWorkspaceRuntime(ctx context.Context, hostKey string, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -4577,11 +4586,20 @@ type ClientInterface interface {
 	// GetWorkspaceFiles request
 	GetWorkspaceFiles(ctx context.Context, id string, params *GetWorkspaceFilesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// PullWorkspaceBranch request
+	PullWorkspaceBranch(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PushWorkspaceBranch request
+	PushWorkspaceBranch(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// RefreshWorkspace request
 	RefreshWorkspace(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// RetryWorkspace request
 	RetryWorkspace(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// RevealWorkspace request
+	RevealWorkspace(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetWorkspaceRuntime request
 	GetWorkspaceRuntime(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -5448,6 +5466,30 @@ func (c *Client) GetFleetWorkspaceFiles(ctx context.Context, hostKey string, id 
 	return c.Client.Do(req)
 }
 
+func (c *Client) PullFleetWorkspaceBranch(ctx context.Context, hostKey string, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPullFleetWorkspaceBranchRequest(c.Server, hostKey, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PushFleetWorkspaceBranch(ctx context.Context, hostKey string, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPushFleetWorkspaceBranchRequest(c.Server, hostKey, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) RefreshFleetWorkspace(ctx context.Context, hostKey string, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewRefreshFleetWorkspaceRequest(c.Server, hostKey, id)
 	if err != nil {
@@ -5462,6 +5504,18 @@ func (c *Client) RefreshFleetWorkspace(ctx context.Context, hostKey string, id s
 
 func (c *Client) RetryFleetWorkspace(ctx context.Context, hostKey string, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewRetryFleetWorkspaceRequest(c.Server, hostKey, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RevealFleetWorkspace(ctx context.Context, hostKey string, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRevealFleetWorkspaceRequest(c.Server, hostKey, id)
 	if err != nil {
 		return nil, err
 	}
@@ -8556,6 +8610,30 @@ func (c *Client) GetWorkspaceFiles(ctx context.Context, id string, params *GetWo
 	return c.Client.Do(req)
 }
 
+func (c *Client) PullWorkspaceBranch(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPullWorkspaceBranchRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PushWorkspaceBranch(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPushWorkspaceBranchRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) RefreshWorkspace(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewRefreshWorkspaceRequest(c.Server, id)
 	if err != nil {
@@ -8570,6 +8648,18 @@ func (c *Client) RefreshWorkspace(ctx context.Context, id string, reqEditors ...
 
 func (c *Client) RetryWorkspace(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewRetryWorkspaceRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RevealWorkspace(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRevealWorkspaceRequest(c.Server, id)
 	if err != nil {
 		return nil, err
 	}
@@ -11618,6 +11708,88 @@ func NewGetFleetWorkspaceFilesRequest(server string, hostKey string, id string, 
 	return req, nil
 }
 
+// NewPullFleetWorkspaceBranchRequest generates requests for PullFleetWorkspaceBranch
+func NewPullFleetWorkspaceBranchRequest(server string, hostKey string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "host_key", hostKey, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/fleet/hosts/%s/workspaces/%s/pull", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewPushFleetWorkspaceBranchRequest generates requests for PushFleetWorkspaceBranch
+func NewPushFleetWorkspaceBranchRequest(server string, hostKey string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "host_key", hostKey, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/fleet/hosts/%s/workspaces/%s/push", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewRefreshFleetWorkspaceRequest generates requests for RefreshFleetWorkspace
 func NewRefreshFleetWorkspaceRequest(server string, hostKey string, id string) (*http.Request, error) {
 	var err error
@@ -11683,6 +11855,47 @@ func NewRetryFleetWorkspaceRequest(server string, hostKey string, id string) (*h
 	}
 
 	operationPath := fmt.Sprintf("/fleet/hosts/%s/workspaces/%s/retry", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewRevealFleetWorkspaceRequest generates requests for RevealFleetWorkspace
+func NewRevealFleetWorkspaceRequest(server string, hostKey string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "host_key", hostKey, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/fleet/hosts/%s/workspaces/%s/reveal", pathParam0, pathParam1)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -22620,6 +22833,74 @@ func NewGetWorkspaceFilesRequest(server string, id string, params *GetWorkspaceF
 	return req, nil
 }
 
+// NewPullWorkspaceBranchRequest generates requests for PullWorkspaceBranch
+func NewPullWorkspaceBranchRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/workspaces/%s/pull", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewPushWorkspaceBranchRequest generates requests for PushWorkspaceBranch
+func NewPushWorkspaceBranchRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/workspaces/%s/push", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewRefreshWorkspaceRequest generates requests for RefreshWorkspace
 func NewRefreshWorkspaceRequest(server string, id string) (*http.Request, error) {
 	var err error
@@ -22671,6 +22952,40 @@ func NewRetryWorkspaceRequest(server string, id string) (*http.Request, error) {
 	}
 
 	operationPath := fmt.Sprintf("/workspaces/%s/retry", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewRevealWorkspaceRequest generates requests for RevealWorkspace
+func NewRevealWorkspaceRequest(server string, id string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/workspaces/%s/reveal", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -23177,11 +23492,20 @@ type ClientWithResponsesInterface interface {
 	// GetFleetWorkspaceFilesWithResponse request
 	GetFleetWorkspaceFilesWithResponse(ctx context.Context, hostKey string, id string, params *GetFleetWorkspaceFilesParams, reqEditors ...RequestEditorFn) (*GetFleetWorkspaceFilesResponse, error)
 
+	// PullFleetWorkspaceBranchWithResponse request
+	PullFleetWorkspaceBranchWithResponse(ctx context.Context, hostKey string, id string, reqEditors ...RequestEditorFn) (*PullFleetWorkspaceBranchResponse, error)
+
+	// PushFleetWorkspaceBranchWithResponse request
+	PushFleetWorkspaceBranchWithResponse(ctx context.Context, hostKey string, id string, reqEditors ...RequestEditorFn) (*PushFleetWorkspaceBranchResponse, error)
+
 	// RefreshFleetWorkspaceWithResponse request
 	RefreshFleetWorkspaceWithResponse(ctx context.Context, hostKey string, id string, reqEditors ...RequestEditorFn) (*RefreshFleetWorkspaceResponse, error)
 
 	// RetryFleetWorkspaceWithResponse request
 	RetryFleetWorkspaceWithResponse(ctx context.Context, hostKey string, id string, reqEditors ...RequestEditorFn) (*RetryFleetWorkspaceResponse, error)
+
+	// RevealFleetWorkspaceWithResponse request
+	RevealFleetWorkspaceWithResponse(ctx context.Context, hostKey string, id string, reqEditors ...RequestEditorFn) (*RevealFleetWorkspaceResponse, error)
 
 	// GetFleetWorkspaceRuntimeWithResponse request
 	GetFleetWorkspaceRuntimeWithResponse(ctx context.Context, hostKey string, id string, reqEditors ...RequestEditorFn) (*GetFleetWorkspaceRuntimeResponse, error)
@@ -23879,11 +24203,20 @@ type ClientWithResponsesInterface interface {
 	// GetWorkspaceFilesWithResponse request
 	GetWorkspaceFilesWithResponse(ctx context.Context, id string, params *GetWorkspaceFilesParams, reqEditors ...RequestEditorFn) (*GetWorkspaceFilesResponse, error)
 
+	// PullWorkspaceBranchWithResponse request
+	PullWorkspaceBranchWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*PullWorkspaceBranchResponse, error)
+
+	// PushWorkspaceBranchWithResponse request
+	PushWorkspaceBranchWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*PushWorkspaceBranchResponse, error)
+
 	// RefreshWorkspaceWithResponse request
 	RefreshWorkspaceWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*RefreshWorkspaceResponse, error)
 
 	// RetryWorkspaceWithResponse request
 	RetryWorkspaceWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*RetryWorkspaceResponse, error)
+
+	// RevealWorkspaceWithResponse request
+	RevealWorkspaceWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*RevealWorkspaceResponse, error)
 
 	// GetWorkspaceRuntimeWithResponse request
 	GetWorkspaceRuntimeWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*GetWorkspaceRuntimeResponse, error)
@@ -25080,6 +25413,52 @@ func (r GetFleetWorkspaceFilesResponse) StatusCode() int {
 	return 0
 }
 
+type PullFleetWorkspaceBranchResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSONDefault                   *map[string]interface{}
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r PullFleetWorkspaceBranchResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PullFleetWorkspaceBranchResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PushFleetWorkspaceBranchResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSONDefault                   *map[string]interface{}
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r PushFleetWorkspaceBranchResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PushFleetWorkspaceBranchResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type RefreshFleetWorkspaceResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
@@ -25120,6 +25499,29 @@ func (r RetryFleetWorkspaceResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r RetryFleetWorkspaceResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type RevealFleetWorkspaceResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSONDefault                   *map[string]interface{}
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r RevealFleetWorkspaceResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RevealFleetWorkspaceResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -29282,6 +29684,52 @@ func (r GetWorkspaceFilesResponse) StatusCode() int {
 	return 0
 }
 
+type PullWorkspaceBranchResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *WorkspaceResponse
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r PullWorkspaceBranchResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PullWorkspaceBranchResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PushWorkspaceBranchResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *WorkspaceResponse
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r PushWorkspaceBranchResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PushWorkspaceBranchResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type RefreshWorkspaceResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
@@ -29322,6 +29770,28 @@ func (r RetryWorkspaceResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r RetryWorkspaceResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type RevealWorkspaceResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r RevealWorkspaceResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RevealWorkspaceResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -30068,6 +30538,24 @@ func (c *ClientWithResponses) GetFleetWorkspaceFilesWithResponse(ctx context.Con
 	return ParseGetFleetWorkspaceFilesResponse(rsp)
 }
 
+// PullFleetWorkspaceBranchWithResponse request returning *PullFleetWorkspaceBranchResponse
+func (c *ClientWithResponses) PullFleetWorkspaceBranchWithResponse(ctx context.Context, hostKey string, id string, reqEditors ...RequestEditorFn) (*PullFleetWorkspaceBranchResponse, error) {
+	rsp, err := c.PullFleetWorkspaceBranch(ctx, hostKey, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePullFleetWorkspaceBranchResponse(rsp)
+}
+
+// PushFleetWorkspaceBranchWithResponse request returning *PushFleetWorkspaceBranchResponse
+func (c *ClientWithResponses) PushFleetWorkspaceBranchWithResponse(ctx context.Context, hostKey string, id string, reqEditors ...RequestEditorFn) (*PushFleetWorkspaceBranchResponse, error) {
+	rsp, err := c.PushFleetWorkspaceBranch(ctx, hostKey, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePushFleetWorkspaceBranchResponse(rsp)
+}
+
 // RefreshFleetWorkspaceWithResponse request returning *RefreshFleetWorkspaceResponse
 func (c *ClientWithResponses) RefreshFleetWorkspaceWithResponse(ctx context.Context, hostKey string, id string, reqEditors ...RequestEditorFn) (*RefreshFleetWorkspaceResponse, error) {
 	rsp, err := c.RefreshFleetWorkspace(ctx, hostKey, id, reqEditors...)
@@ -30084,6 +30572,15 @@ func (c *ClientWithResponses) RetryFleetWorkspaceWithResponse(ctx context.Contex
 		return nil, err
 	}
 	return ParseRetryFleetWorkspaceResponse(rsp)
+}
+
+// RevealFleetWorkspaceWithResponse request returning *RevealFleetWorkspaceResponse
+func (c *ClientWithResponses) RevealFleetWorkspaceWithResponse(ctx context.Context, hostKey string, id string, reqEditors ...RequestEditorFn) (*RevealFleetWorkspaceResponse, error) {
+	rsp, err := c.RevealFleetWorkspace(ctx, hostKey, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRevealFleetWorkspaceResponse(rsp)
 }
 
 // GetFleetWorkspaceRuntimeWithResponse request returning *GetFleetWorkspaceRuntimeResponse
@@ -32324,6 +32821,24 @@ func (c *ClientWithResponses) GetWorkspaceFilesWithResponse(ctx context.Context,
 	return ParseGetWorkspaceFilesResponse(rsp)
 }
 
+// PullWorkspaceBranchWithResponse request returning *PullWorkspaceBranchResponse
+func (c *ClientWithResponses) PullWorkspaceBranchWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*PullWorkspaceBranchResponse, error) {
+	rsp, err := c.PullWorkspaceBranch(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePullWorkspaceBranchResponse(rsp)
+}
+
+// PushWorkspaceBranchWithResponse request returning *PushWorkspaceBranchResponse
+func (c *ClientWithResponses) PushWorkspaceBranchWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*PushWorkspaceBranchResponse, error) {
+	rsp, err := c.PushWorkspaceBranch(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePushWorkspaceBranchResponse(rsp)
+}
+
 // RefreshWorkspaceWithResponse request returning *RefreshWorkspaceResponse
 func (c *ClientWithResponses) RefreshWorkspaceWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*RefreshWorkspaceResponse, error) {
 	rsp, err := c.RefreshWorkspace(ctx, id, reqEditors...)
@@ -32340,6 +32855,15 @@ func (c *ClientWithResponses) RetryWorkspaceWithResponse(ctx context.Context, id
 		return nil, err
 	}
 	return ParseRetryWorkspaceResponse(rsp)
+}
+
+// RevealWorkspaceWithResponse request returning *RevealWorkspaceResponse
+func (c *ClientWithResponses) RevealWorkspaceWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*RevealWorkspaceResponse, error) {
+	rsp, err := c.RevealWorkspace(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRevealWorkspaceResponse(rsp)
 }
 
 // GetWorkspaceRuntimeWithResponse request returning *GetWorkspaceRuntimeResponse
@@ -34082,6 +34606,72 @@ func ParseGetFleetWorkspaceFilesResponse(rsp *http.Response) (*GetFleetWorkspace
 	return response, nil
 }
 
+// ParsePullFleetWorkspaceBranchResponse parses an HTTP response from a PullFleetWorkspaceBranchWithResponse call
+func ParsePullFleetWorkspaceBranchResponse(rsp *http.Response) (*PullFleetWorkspaceBranchResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PullFleetWorkspaceBranchResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case rsp.Header.Get("Content-Type") == "application/json" && true:
+		var dest map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	case rsp.Header.Get("Content-Type") == "application/problem+json" && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePushFleetWorkspaceBranchResponse parses an HTTP response from a PushFleetWorkspaceBranchWithResponse call
+func ParsePushFleetWorkspaceBranchResponse(rsp *http.Response) (*PushFleetWorkspaceBranchResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PushFleetWorkspaceBranchResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case rsp.Header.Get("Content-Type") == "application/json" && true:
+		var dest map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	case rsp.Header.Get("Content-Type") == "application/problem+json" && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseRefreshFleetWorkspaceResponse parses an HTTP response from a RefreshFleetWorkspaceWithResponse call
 func ParseRefreshFleetWorkspaceResponse(rsp *http.Response) (*RefreshFleetWorkspaceResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -34124,6 +34714,39 @@ func ParseRetryFleetWorkspaceResponse(rsp *http.Response) (*RetryFleetWorkspaceR
 	}
 
 	response := &RetryFleetWorkspaceResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case rsp.Header.Get("Content-Type") == "application/json" && true:
+		var dest map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	case rsp.Header.Get("Content-Type") == "application/problem+json" && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseRevealFleetWorkspaceResponse parses an HTTP response from a RevealFleetWorkspaceWithResponse call
+func ParseRevealFleetWorkspaceResponse(rsp *http.Response) (*RevealFleetWorkspaceResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RevealFleetWorkspaceResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -39944,6 +40567,72 @@ func ParseGetWorkspaceFilesResponse(rsp *http.Response) (*GetWorkspaceFilesRespo
 	return response, nil
 }
 
+// ParsePullWorkspaceBranchResponse parses an HTTP response from a PullWorkspaceBranchWithResponse call
+func ParsePullWorkspaceBranchResponse(rsp *http.Response) (*PullWorkspaceBranchResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PullWorkspaceBranchResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest WorkspaceResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePushWorkspaceBranchResponse parses an HTTP response from a PushWorkspaceBranchWithResponse call
+func ParsePushWorkspaceBranchResponse(rsp *http.Response) (*PushWorkspaceBranchResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PushWorkspaceBranchResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest WorkspaceResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseRefreshWorkspaceResponse parses an HTTP response from a RefreshWorkspaceWithResponse call
 func ParseRefreshWorkspaceResponse(rsp *http.Response) (*RefreshWorkspaceResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -39998,6 +40687,32 @@ func ParseRetryWorkspaceResponse(rsp *http.Response) (*RetryWorkspaceResponse, e
 		}
 		response.JSON202 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseRevealWorkspaceResponse parses an HTTP response from a RevealWorkspaceWithResponse call
+func ParseRevealWorkspaceResponse(rsp *http.Response) (*RevealWorkspaceResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RevealWorkspaceResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
 		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {

--- a/internal/server/fleet_proxy.go
+++ b/internal/server/fleet_proxy.go
@@ -124,6 +124,36 @@ func (s *Server) registerFleetOperationRoutes(api huma.API) {
 			},
 		},
 		{
+			operationID: "push-fleet-workspace-branch",
+			method:      http.MethodPost,
+			path:        "/fleet/hosts/{host_key}/workspaces/{id}/push",
+			summary:     "Push workspace branch on fleet host",
+			pathParams:  []string{"host_key", "id"},
+			targetPath: func(r *http.Request) string {
+				return "/api/v1/workspaces/" + escapePath(r.PathValue("id")) + "/push"
+			},
+		},
+		{
+			operationID: "pull-fleet-workspace-branch",
+			method:      http.MethodPost,
+			path:        "/fleet/hosts/{host_key}/workspaces/{id}/pull",
+			summary:     "Pull workspace branch on fleet host",
+			pathParams:  []string{"host_key", "id"},
+			targetPath: func(r *http.Request) string {
+				return "/api/v1/workspaces/" + escapePath(r.PathValue("id")) + "/pull"
+			},
+		},
+		{
+			operationID: "reveal-fleet-workspace",
+			method:      http.MethodPost,
+			path:        "/fleet/hosts/{host_key}/workspaces/{id}/reveal",
+			summary:     "Reveal workspace folder on fleet host",
+			pathParams:  []string{"host_key", "id"},
+			targetPath: func(r *http.Request) string {
+				return "/api/v1/workspaces/" + escapePath(r.PathValue("id")) + "/reveal"
+			},
+		},
+		{
 			operationID: "get-fleet-workspace-runtime",
 			method:      http.MethodGet,
 			path:        "/fleet/hosts/{host_key}/workspaces/{id}/runtime",

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -787,6 +787,28 @@ func (s *Server) registerAPI(api huma.API) {
 		Tags:        []string{"Workspaces"},
 	}, s.refreshWorkspace)
 	huma.Register(api, huma.Operation{
+		OperationID: "push-workspace-branch",
+		Method:      http.MethodPost,
+		Path:        "/workspaces/{id}/push",
+		Summary:     "Push workspace branch",
+		Tags:        []string{"Workspaces"},
+	}, s.pushWorkspaceBranch)
+	huma.Register(api, huma.Operation{
+		OperationID: "pull-workspace-branch",
+		Method:      http.MethodPost,
+		Path:        "/workspaces/{id}/pull",
+		Summary:     "Pull workspace branch",
+		Tags:        []string{"Workspaces"},
+	}, s.pullWorkspaceBranch)
+	huma.Register(api, huma.Operation{
+		OperationID:   "reveal-workspace",
+		Method:        http.MethodPost,
+		Path:          "/workspaces/{id}/reveal",
+		DefaultStatus: http.StatusNoContent,
+		Summary:       "Reveal workspace folder",
+		Tags:          []string{"Workspaces"},
+	}, s.revealWorkspace)
+	huma.Register(api, huma.Operation{
 		OperationID: "get-workspace-runtime",
 		Method:      http.MethodGet,
 		Path:        "/workspaces/{id}/runtime",

--- a/internal/server/workspace_branch_actions.go
+++ b/internal/server/workspace_branch_actions.go
@@ -24,14 +24,14 @@ func (s *Server) pushWorkspaceBranch(
 	ctx context.Context,
 	input *workspaceBranchActionInput,
 ) (*workspaceBranchActionOutput, error) {
-	return s.runWorkspaceBranchAction(ctx, input.ID, workspace.PushWorktreeBranch)
+	return s.runWorkspaceBranchAction(ctx, input.ID, s.workspaces.PushWorktreeBranch)
 }
 
 func (s *Server) pullWorkspaceBranch(
 	ctx context.Context,
 	input *workspaceBranchActionInput,
 ) (*workspaceBranchActionOutput, error) {
-	return s.runWorkspaceBranchAction(ctx, input.ID, workspace.PullWorktreeBranch)
+	return s.runWorkspaceBranchAction(ctx, input.ID, s.workspaces.PullWorktreeBranch)
 }
 
 func (s *Server) revealWorkspace(
@@ -54,13 +54,13 @@ func (s *Server) revealWorkspace(
 func (s *Server) runWorkspaceBranchAction(
 	ctx context.Context,
 	id string,
-	action func(context.Context, string) error,
+	action func(ctx context.Context, platformHost, dir string) error,
 ) (*workspaceBranchActionOutput, error) {
 	summary, err := s.getWorkspaceActionSummary(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-	if err := action(ctx, summary.WorktreePath); err != nil {
+	if err := action(ctx, summary.PlatformHost, summary.WorktreePath); err != nil {
 		return nil, workspaceBranchActionProblem(err)
 	}
 	refreshed, err := s.workspaces.GetSummary(ctx, id)

--- a/internal/server/workspace_branch_actions.go
+++ b/internal/server/workspace_branch_actions.go
@@ -1,0 +1,106 @@
+package server
+
+import (
+	"context"
+	"errors"
+
+	"go.kenn.io/middleman/internal/db"
+	"go.kenn.io/middleman/internal/workspace"
+)
+
+type workspaceBranchActionInput struct {
+	ID string `path:"id"`
+}
+
+type revealWorkspaceInput struct {
+	ID string `path:"id"`
+}
+
+type workspaceBranchActionOutput = bodyOutput[workspaceResponse]
+
+var revealWorkspacePath = workspace.RevealWorktreePath
+
+func (s *Server) pushWorkspaceBranch(
+	ctx context.Context,
+	input *workspaceBranchActionInput,
+) (*workspaceBranchActionOutput, error) {
+	return s.runWorkspaceBranchAction(ctx, input.ID, workspace.PushWorktreeBranch)
+}
+
+func (s *Server) pullWorkspaceBranch(
+	ctx context.Context,
+	input *workspaceBranchActionInput,
+) (*workspaceBranchActionOutput, error) {
+	return s.runWorkspaceBranchAction(ctx, input.ID, workspace.PullWorktreeBranch)
+}
+
+func (s *Server) revealWorkspace(
+	ctx context.Context,
+	input *revealWorkspaceInput,
+) (*struct{}, error) {
+	summary, err := s.getWorkspaceActionSummary(ctx, input.ID)
+	if err != nil {
+		return nil, err
+	}
+	if err := revealWorkspacePath(ctx, summary.WorktreePath); err != nil {
+		if errors.Is(err, workspace.ErrRevealUnsupported) {
+			return nil, problemBadRequest(CodeUnsupportedCapability, err.Error(), nil)
+		}
+		return nil, problemConflict(CodeConflict, err.Error(), nil)
+	}
+	return nil, nil
+}
+
+func (s *Server) runWorkspaceBranchAction(
+	ctx context.Context,
+	id string,
+	action func(context.Context, string) error,
+) (*workspaceBranchActionOutput, error) {
+	summary, err := s.getWorkspaceActionSummary(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if err := action(ctx, summary.WorktreePath); err != nil {
+		return nil, workspaceBranchActionProblem(err)
+	}
+	refreshed, err := s.workspaces.GetSummary(ctx, id)
+	if err != nil {
+		return nil, problemInternal("get workspace summary: " + err.Error())
+	}
+	if refreshed == nil {
+		return nil, problemNotFound(CodeWorkspaceNotFound, "workspace not found", nil)
+	}
+	resp := s.toWorkspaceResponse(ctx, refreshed)
+	return &workspaceBranchActionOutput{Body: resp}, nil
+}
+
+func (s *Server) getWorkspaceActionSummary(
+	ctx context.Context,
+	id string,
+) (*db.WorkspaceSummary, error) {
+	if s.workspaces == nil {
+		return nil, problemServiceUnavailable("workspace manager not configured")
+	}
+	summary, err := s.workspaces.GetSummary(ctx, id)
+	if err != nil {
+		return nil, problemInternal("get workspace summary: " + err.Error())
+	}
+	if summary == nil {
+		return nil, problemNotFound(CodeWorkspaceNotFound, "workspace not found", nil)
+	}
+	return summary, nil
+}
+
+func workspaceBranchActionProblem(err error) error {
+	switch {
+	case errors.Is(err, workspace.ErrWorktreeDirty):
+		return problemConflict(CodeWorktreeDirty, err.Error(), nil)
+	case errors.Is(err, workspace.ErrWorktreeDiverged):
+		return problemConflict(CodeBranchConflict, err.Error(), nil)
+	case errors.Is(err, workspace.ErrWorktreeNoUpstream),
+		errors.Is(err, workspace.ErrWorktreeInSync):
+		return problemConflict(CodeConflict, err.Error(), nil)
+	default:
+		return problemConflict(CodeConflict, err.Error(), nil)
+	}
+}

--- a/internal/server/workspace_branch_actions_test.go
+++ b/internal/server/workspace_branch_actions_test.go
@@ -44,7 +44,7 @@ func TestWorkspacePullBranchRouteFastForwardsBehindBranch(t *testing.T) {
 	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, nil)
 	ctx := context.Background()
 	ws := createReadyWorkspace(t, ctx, client)
-	err := workspace.PushWorktreeBranch(ctx, ws.WorktreePath)
+	err := srv.workspaces.PushWorktreeBranch(ctx, ws.PlatformHost, ws.WorktreePath)
 	if err != nil && !errors.Is(err, workspace.ErrWorktreeInSync) {
 		require.NoError(err)
 	}

--- a/internal/server/workspace_branch_actions_test.go
+++ b/internal/server/workspace_branch_actions_test.go
@@ -1,0 +1,119 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/middleman/internal/workspace"
+)
+
+func TestWorkspacePushBranchRoutePushesAheadBranch(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, nil)
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+	runGit(t, ws.WorktreePath, "config", "user.email", "test@test.com")
+	runGit(t, ws.WorktreePath, "config", "user.name", "Test")
+	require.NoError(os.WriteFile(
+		filepath.Join(ws.WorktreePath, "ahead.txt"), []byte("ahead\n"), 0o644,
+	))
+	runGit(t, ws.WorktreePath, "add", ".")
+	runGit(t, ws.WorktreePath, "commit", "-m", "ahead")
+
+	rr := doJSON(t, srv, http.MethodPost, "/api/v1/workspaces/"+ws.Id+"/push", nil)
+
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+	div, ok, err := workspace.WorktreeDivergence(ctx, ws.WorktreePath)
+	require.NoError(err)
+	require.True(ok)
+	assert.Equal(workspace.Divergence{}, div)
+}
+
+func TestWorkspacePullBranchRouteFastForwardsBehindBranch(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, nil)
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+	err := workspace.PushWorktreeBranch(ctx, ws.WorktreePath)
+	if err != nil && !errors.Is(err, workspace.ErrWorktreeInSync) {
+		require.NoError(err)
+	}
+	div, ok, err := workspace.WorktreeDivergence(ctx, ws.WorktreePath)
+	require.NoError(err)
+	require.True(ok)
+	require.Equal(workspace.Divergence{}, div)
+	upstreamRef := gitOutput(
+		t, ws.WorktreePath,
+		"rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}",
+	)
+	upstreamBranch := strings.TrimPrefix(upstreamRef, "origin/")
+
+	other := filepath.Join(t.TempDir(), "other")
+	originURL := gitOutput(t, ws.WorktreePath, "remote", "get-url", "origin")
+	runGit(t, t.TempDir(), "clone", originURL, other)
+	runGit(t, other, "config", "user.email", "test@test.com")
+	runGit(t, other, "config", "user.name", "Test")
+	runGit(t, other, "checkout", "-b", upstreamBranch, upstreamRef)
+	require.NoError(os.WriteFile(
+		filepath.Join(other, "remote.txt"), []byte("remote\n"), 0o644,
+	))
+	runGit(t, other, "add", ".")
+	runGit(t, other, "commit", "-m", "remote")
+	runGit(t, other, "push", "origin", upstreamBranch)
+
+	rr := doJSON(t, srv, http.MethodPost, "/api/v1/workspaces/"+ws.Id+"/pull", nil)
+
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+	contents, err := os.ReadFile(filepath.Join(ws.WorktreePath, "remote.txt"))
+	require.NoError(err)
+	assert.Equal("remote\n", string(contents))
+}
+
+func TestWorkspacePullBranchRouteRejectsDirtyWorktree(t *testing.T) {
+	require := require.New(t)
+	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, nil)
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+	require.NoError(os.WriteFile(
+		filepath.Join(ws.WorktreePath, "dirty.txt"), []byte("dirty\n"), 0o644,
+	))
+
+	rr := doJSON(t, srv, http.MethodPost, "/api/v1/workspaces/"+ws.Id+"/pull", nil)
+
+	require.Equal(http.StatusConflict, rr.Code, rr.Body.String())
+	var problem rawProblemDetail
+	require.NoError(json.NewDecoder(rr.Body).Decode(&problem))
+	Assert.New(t).Equal(string(CodeWorktreeDirty), problem.Code)
+}
+
+func TestWorkspaceRevealRouteOpensWorkspacePath(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, nil)
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+	previous := revealWorkspacePath
+	var opened string
+	revealWorkspacePath = func(_ context.Context, path string) error {
+		opened = path
+		return nil
+	}
+	t.Cleanup(func() {
+		revealWorkspacePath = previous
+	})
+
+	rr := doJSON(t, srv, http.MethodPost, "/api/v1/workspaces/"+ws.Id+"/reveal", nil)
+
+	require.Equal(http.StatusNoContent, rr.Code, rr.Body.String())
+	assert.Equal(ws.WorktreePath, opened)
+}

--- a/internal/workspace/branch_sync.go
+++ b/internal/workspace/branch_sync.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+
+	"go.kenn.io/middleman/internal/tokenauth"
 )
 
 var (
@@ -19,10 +21,56 @@ type branchUpstream struct {
 	branch string
 }
 
+// networkedBranchGit runs a branch-sync git command that contacts the remote
+// (fetch or push) in the worktree dir. It returns only an error because branch
+// sync never needs the command's stdout, and the managed implementation
+// deliberately discards git's raw output so credential material in a remote
+// error string cannot leak back through the API.
+type networkedBranchGit func(ctx context.Context, dir string, args ...string) error
+
+// branchSyncGit returns the runner used for the networked steps of branch
+// push/pull. With clone management configured it routes fetch and push through
+// the authenticated gitclone runner so the provider host's PAT or GitHub App
+// credential is injected, expired tokens are re-resolved on auth failure, and
+// raw git remote output is redacted out of returned errors. Without clone
+// management (unmanaged local checkouts and unit tests) it falls back to plain
+// git, which carries no injected credential.
+func (m *Manager) branchSyncGit(platformHost string) networkedBranchGit {
+	if m.clones == nil {
+		return func(ctx context.Context, dir string, args ...string) error {
+			_, err := gitCombinedOutput(ctx, dir, args...)
+			return err
+		}
+	}
+	return func(ctx context.Context, dir string, args ...string) error {
+		if _, err := m.clones.RunGit(ctx, platformHost, dir, args...); err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
 // PushWorktreeBranch pushes the current branch to its configured upstream.
 // This is a user-triggered git operation, so it intentionally uses normal git
-// hook behavior instead of the internal no-hooks mutation helper.
-func PushWorktreeBranch(ctx context.Context, dir string) error {
+// hook behavior instead of the internal no-hooks mutation helper. The fetch
+// and push are networked: they run through the host's authenticated git runner
+// so managed HTTPS workspaces inject the provider credential, and the push is
+// marked as a mutation so it stays on the user's own PAT chain rather than a
+// GitHub App installation token.
+func (m *Manager) PushWorktreeBranch(ctx context.Context, platformHost, dir string) error {
+	return pushWorktreeBranch(ctx, m.branchSyncGit(platformHost), dir)
+}
+
+// PullWorktreeBranch fast-forwards the current branch from its configured
+// upstream. It rejects dirty or diverged worktrees so the UI action cannot
+// silently merge, rebase, or overwrite local work. The upstream refresh is
+// networked and runs through the host's authenticated git runner; the merge
+// itself is local against the already-fetched tracking ref.
+func (m *Manager) PullWorktreeBranch(ctx context.Context, platformHost, dir string) error {
+	return pullWorktreeBranch(ctx, m.branchSyncGit(platformHost), dir)
+}
+
+func pushWorktreeBranch(ctx context.Context, run networkedBranchGit, dir string) error {
 	if err := ensureBranchSyncClean(ctx, dir); err != nil {
 		return err
 	}
@@ -30,7 +78,7 @@ func PushWorktreeBranch(ctx context.Context, dir string) error {
 	if err != nil {
 		return err
 	}
-	if err := refreshBranchUpstream(ctx, dir, upstream); err != nil {
+	if err := refreshBranchUpstream(ctx, run, dir, upstream); err != nil {
 		return err
 	}
 	div, err := branchSyncDivergence(ctx, dir)
@@ -43,19 +91,21 @@ func PushWorktreeBranch(ctx context.Context, dir string) error {
 	if div.Ahead == 0 {
 		return ErrWorktreeInSync
 	}
-	if _, err := gitCombinedOutput(ctx, dir, "push", upstream.remote, "HEAD:"+upstream.branch); err != nil {
+	// Writes stay on the user's own credential chain so the pushed commits
+	// are attributed to the user instead of a GitHub App bot.
+	if err := run(
+		tokenauth.WithMutationAuth(ctx), dir,
+		"push", upstream.remote, "HEAD:"+upstream.branch,
+	); err != nil {
 		return fmt.Errorf("git push: %w", err)
 	}
-	if err := refreshBranchUpstream(ctx, dir, upstream); err != nil {
+	if err := refreshBranchUpstream(ctx, run, dir, upstream); err != nil {
 		return fmt.Errorf("refresh after push: %w", err)
 	}
 	return nil
 }
 
-// PullWorktreeBranch fast-forwards the current branch from its configured
-// upstream. It rejects dirty or diverged worktrees so the UI action cannot
-// silently merge, rebase, or overwrite local work.
-func PullWorktreeBranch(ctx context.Context, dir string) error {
+func pullWorktreeBranch(ctx context.Context, run networkedBranchGit, dir string) error {
 	if err := ensureBranchSyncClean(ctx, dir); err != nil {
 		return err
 	}
@@ -63,7 +113,7 @@ func PullWorktreeBranch(ctx context.Context, dir string) error {
 	if err != nil {
 		return err
 	}
-	if err := refreshBranchUpstream(ctx, dir, upstream); err != nil {
+	if err := refreshBranchUpstream(ctx, run, dir, upstream); err != nil {
 		return err
 	}
 	div, err := branchSyncDivergence(ctx, dir)
@@ -121,9 +171,11 @@ func currentBranchUpstream(ctx context.Context, dir string) (branchUpstream, err
 	return upstream, nil
 }
 
-func refreshBranchUpstream(ctx context.Context, dir string, upstream branchUpstream) error {
+func refreshBranchUpstream(
+	ctx context.Context, run networkedBranchGit, dir string, upstream branchUpstream,
+) error {
 	refspec := "+refs/heads/" + upstream.branch + ":refs/remotes/" + upstream.remote + "/" + upstream.branch
-	if _, err := gitCombinedOutput(ctx, dir, "fetch", "--prune", upstream.remote, refspec); err != nil {
+	if err := run(ctx, dir, "fetch", "--prune", upstream.remote, refspec); err != nil {
 		return fmt.Errorf("git fetch %s %s: %w", upstream.remote, upstream.branch, err)
 	}
 	return nil

--- a/internal/workspace/branch_sync.go
+++ b/internal/workspace/branch_sync.go
@@ -1,0 +1,141 @@
+package workspace
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var (
+	ErrWorktreeDirty      = errors.New("worktree has uncommitted changes")
+	ErrWorktreeDiverged   = errors.New("worktree branch diverged from upstream")
+	ErrWorktreeNoUpstream = errors.New("worktree branch has no upstream")
+	ErrWorktreeInSync     = errors.New("worktree branch is already in sync")
+)
+
+type branchUpstream struct {
+	remote string
+	branch string
+}
+
+// PushWorktreeBranch pushes the current branch to its configured upstream.
+// This is a user-triggered git operation, so it intentionally uses normal git
+// hook behavior instead of the internal no-hooks mutation helper.
+func PushWorktreeBranch(ctx context.Context, dir string) error {
+	if err := ensureBranchSyncClean(ctx, dir); err != nil {
+		return err
+	}
+	upstream, err := currentBranchUpstream(ctx, dir)
+	if err != nil {
+		return err
+	}
+	if err := refreshBranchUpstream(ctx, dir, upstream); err != nil {
+		return err
+	}
+	div, err := branchSyncDivergence(ctx, dir)
+	if err != nil {
+		return err
+	}
+	if div.Behind > 0 {
+		return fmt.Errorf("%w: %d ahead, %d behind", ErrWorktreeDiverged, div.Ahead, div.Behind)
+	}
+	if div.Ahead == 0 {
+		return ErrWorktreeInSync
+	}
+	if _, err := gitCombinedOutput(ctx, dir, "push", upstream.remote, "HEAD:"+upstream.branch); err != nil {
+		return fmt.Errorf("git push: %w", err)
+	}
+	if err := refreshBranchUpstream(ctx, dir, upstream); err != nil {
+		return fmt.Errorf("refresh after push: %w", err)
+	}
+	return nil
+}
+
+// PullWorktreeBranch fast-forwards the current branch from its configured
+// upstream. It rejects dirty or diverged worktrees so the UI action cannot
+// silently merge, rebase, or overwrite local work.
+func PullWorktreeBranch(ctx context.Context, dir string) error {
+	if err := ensureBranchSyncClean(ctx, dir); err != nil {
+		return err
+	}
+	upstream, err := currentBranchUpstream(ctx, dir)
+	if err != nil {
+		return err
+	}
+	if err := refreshBranchUpstream(ctx, dir, upstream); err != nil {
+		return err
+	}
+	div, err := branchSyncDivergence(ctx, dir)
+	if err != nil {
+		return err
+	}
+	if div.Ahead > 0 {
+		return fmt.Errorf("%w: %d ahead, %d behind", ErrWorktreeDiverged, div.Ahead, div.Behind)
+	}
+	if div.Behind == 0 {
+		return ErrWorktreeInSync
+	}
+	if _, err := gitCombinedOutput(ctx, dir, "merge", "--ff-only", "@{upstream}"); err != nil {
+		return fmt.Errorf("git merge --ff-only upstream: %w", err)
+	}
+	return nil
+}
+
+func ensureBranchSyncClean(ctx context.Context, dir string) error {
+	dirty, err := dirtyFiles(ctx, dir)
+	if err != nil {
+		return fmt.Errorf("check worktree dirty state: %w", err)
+	}
+	if len(dirty) > 0 {
+		return fmt.Errorf("%w: %s", ErrWorktreeDirty, strings.Join(dirty, ", "))
+	}
+	return nil
+}
+
+func currentBranchUpstream(ctx context.Context, dir string) (branchUpstream, error) {
+	out, err := gitCombinedOutput(ctx, dir, "branch", "--show-current")
+	if err != nil {
+		return branchUpstream{}, fmt.Errorf("git branch --show-current: %w", err)
+	}
+	branch := strings.TrimSpace(out)
+	if branch == "" {
+		return branchUpstream{}, ErrWorktreeNoUpstream
+	}
+
+	remote, err := gitCombinedOutput(ctx, dir, "config", "--get", "branch."+branch+".remote")
+	if err != nil {
+		return branchUpstream{}, fmt.Errorf("%w: branch %s", ErrWorktreeNoUpstream, branch)
+	}
+	mergeRef, err := gitCombinedOutput(ctx, dir, "config", "--get", "branch."+branch+".merge")
+	if err != nil {
+		return branchUpstream{}, fmt.Errorf("%w: branch %s", ErrWorktreeNoUpstream, branch)
+	}
+	upstream := branchUpstream{
+		remote: strings.TrimSpace(remote),
+		branch: strings.TrimPrefix(strings.TrimSpace(mergeRef), "refs/heads/"),
+	}
+	if upstream.remote == "" || upstream.branch == "" {
+		return branchUpstream{}, fmt.Errorf("%w: branch %s", ErrWorktreeNoUpstream, branch)
+	}
+	return upstream, nil
+}
+
+func refreshBranchUpstream(ctx context.Context, dir string, upstream branchUpstream) error {
+	refspec := "+refs/heads/" + upstream.branch + ":refs/remotes/" + upstream.remote + "/" + upstream.branch
+	if _, err := gitCombinedOutput(ctx, dir, "fetch", "--prune", upstream.remote, refspec); err != nil {
+		return fmt.Errorf("git fetch %s %s: %w", upstream.remote, upstream.branch, err)
+	}
+	return nil
+}
+
+func branchSyncDivergence(ctx context.Context, dir string) (Divergence, error) {
+	div, ok, err := WorktreeDivergence(ctx, dir)
+	if err != nil {
+		return Divergence{}, err
+	}
+	if !ok {
+		return Divergence{}, ErrWorktreeNoUpstream
+	}
+	return div, nil
+}

--- a/internal/workspace/branch_sync_test.go
+++ b/internal/workspace/branch_sync_test.go
@@ -1,0 +1,105 @@
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	Assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPushWorktreeBranchPushesAheadCommitsAndRunsHooks(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	work := setupDivergenceWorktree(t)
+	marker := filepath.Join(filepath.Dir(work), "pre-push-ran")
+	hook := filepath.Join(work, ".git", "hooks", "pre-push")
+	require.NoError(os.WriteFile(
+		hook,
+		[]byte("#!/bin/sh\nprintf ran > "+marker+"\n"),
+		0o755,
+	))
+	require.NoError(os.WriteFile(
+		filepath.Join(work, "f.txt"), []byte("ahead\n"), 0o644,
+	))
+	runWorkspaceTestGit(t, work, "add", ".")
+	runWorkspaceTestGit(t, work, "commit", "-m", "ahead")
+
+	require.NoError(PushWorktreeBranch(t.Context(), work))
+
+	div, ok, err := WorktreeDivergence(t.Context(), work)
+	require.NoError(err)
+	require.True(ok)
+	assert.Equal(Divergence{}, div)
+	assert.FileExists(marker)
+}
+
+func TestPullWorktreeBranchFastForwardsBehindBranch(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	work := setupDivergenceWorktree(t)
+	other := filepath.Join(filepath.Dir(work), "other")
+	remote := filepath.Join(filepath.Dir(work), "remote.git")
+	runWorkspaceTestGit(t, filepath.Dir(work), "clone", remote, other)
+	runWorkspaceTestGit(t, other, "config", "user.email", "o@test.com")
+	runWorkspaceTestGit(t, other, "config", "user.name", "Other")
+	runWorkspaceTestGit(t, other, "checkout", "-b", "feature", "origin/feature")
+	require.NoError(os.WriteFile(
+		filepath.Join(other, "f.txt"), []byte("remote-extra\n"), 0o644,
+	))
+	runWorkspaceTestGit(t, other, "add", ".")
+	runWorkspaceTestGit(t, other, "commit", "-m", "remote extra")
+	runWorkspaceTestGit(t, other, "push", "origin", "feature")
+
+	require.NoError(PullWorktreeBranch(t.Context(), work))
+
+	contents, err := os.ReadFile(filepath.Join(work, "f.txt"))
+	require.NoError(err)
+	assert.Equal("remote-extra\n", string(contents))
+	div, ok, err := WorktreeDivergence(t.Context(), work)
+	require.NoError(err)
+	require.True(ok)
+	assert.Equal(Divergence{}, div)
+}
+
+func TestPushWorktreeBranchRejectsDivergedBranch(t *testing.T) {
+	require := require.New(t)
+	work := setupDivergenceWorktree(t)
+	require.NoError(os.WriteFile(
+		filepath.Join(work, "f.txt"), []byte("local\n"), 0o644,
+	))
+	runWorkspaceTestGit(t, work, "add", ".")
+	runWorkspaceTestGit(t, work, "commit", "-m", "local")
+
+	other := filepath.Join(filepath.Dir(work), "other")
+	remote := filepath.Join(filepath.Dir(work), "remote.git")
+	runWorkspaceTestGit(t, filepath.Dir(work), "clone", remote, other)
+	runWorkspaceTestGit(t, other, "config", "user.email", "o@test.com")
+	runWorkspaceTestGit(t, other, "config", "user.name", "Other")
+	runWorkspaceTestGit(t, other, "checkout", "-b", "feature", "origin/feature")
+	require.NoError(os.WriteFile(
+		filepath.Join(other, "f.txt"), []byte("remote\n"), 0o644,
+	))
+	runWorkspaceTestGit(t, other, "add", ".")
+	runWorkspaceTestGit(t, other, "commit", "-m", "remote")
+	runWorkspaceTestGit(t, other, "push", "origin", "feature")
+
+	err := PushWorktreeBranch(t.Context(), work)
+
+	require.Error(err)
+	Assert.New(t).ErrorIs(err, ErrWorktreeDiverged)
+}
+
+func TestPullWorktreeBranchRejectsDirtyWorktree(t *testing.T) {
+	require := require.New(t)
+	work := setupDivergenceWorktree(t)
+	require.NoError(os.WriteFile(
+		filepath.Join(work, "dirty.txt"), []byte("dirty\n"), 0o644,
+	))
+
+	err := PullWorktreeBranch(t.Context(), work)
+
+	require.Error(err)
+	Assert.New(t).ErrorIs(err, ErrWorktreeDirty)
+}

--- a/internal/workspace/branch_sync_test.go
+++ b/internal/workspace/branch_sync_test.go
@@ -1,13 +1,28 @@
 package workspace
 
 import (
+	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	Assert "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/middleman/internal/gitclone"
+	"go.kenn.io/middleman/internal/tokenauth"
 )
+
+// branchSyncTestManager builds a Manager with no clone manager configured, so
+// PushWorktreeBranch and PullWorktreeBranch fall back to plain git against the
+// worktree's existing remote. The networked-runner path is exercised
+// separately by TestPushWorktreeBranchUsesAuthenticatedRunnerAndMutationAuth.
+func branchSyncTestManager(t *testing.T) *Manager {
+	t.Helper()
+	return NewManager(nil, t.TempDir())
+}
 
 func TestPushWorktreeBranchPushesAheadCommitsAndRunsHooks(t *testing.T) {
 	require := require.New(t)
@@ -26,7 +41,7 @@ func TestPushWorktreeBranchPushesAheadCommitsAndRunsHooks(t *testing.T) {
 	runWorkspaceTestGit(t, work, "add", ".")
 	runWorkspaceTestGit(t, work, "commit", "-m", "ahead")
 
-	require.NoError(PushWorktreeBranch(t.Context(), work))
+	require.NoError(branchSyncTestManager(t).PushWorktreeBranch(t.Context(), "", work))
 
 	div, ok, err := WorktreeDivergence(t.Context(), work)
 	require.NoError(err)
@@ -52,7 +67,7 @@ func TestPullWorktreeBranchFastForwardsBehindBranch(t *testing.T) {
 	runWorkspaceTestGit(t, other, "commit", "-m", "remote extra")
 	runWorkspaceTestGit(t, other, "push", "origin", "feature")
 
-	require.NoError(PullWorktreeBranch(t.Context(), work))
+	require.NoError(branchSyncTestManager(t).PullWorktreeBranch(t.Context(), "", work))
 
 	contents, err := os.ReadFile(filepath.Join(work, "f.txt"))
 	require.NoError(err)
@@ -85,7 +100,7 @@ func TestPushWorktreeBranchRejectsDivergedBranch(t *testing.T) {
 	runWorkspaceTestGit(t, other, "commit", "-m", "remote")
 	runWorkspaceTestGit(t, other, "push", "origin", "feature")
 
-	err := PushWorktreeBranch(t.Context(), work)
+	err := branchSyncTestManager(t).PushWorktreeBranch(t.Context(), "", work)
 
 	require.Error(err)
 	Assert.New(t).ErrorIs(err, ErrWorktreeDiverged)
@@ -98,8 +113,111 @@ func TestPullWorktreeBranchRejectsDirtyWorktree(t *testing.T) {
 		filepath.Join(work, "dirty.txt"), []byte("dirty\n"), 0o644,
 	))
 
-	err := PullWorktreeBranch(t.Context(), work)
+	err := branchSyncTestManager(t).PullWorktreeBranch(t.Context(), "", work)
 
 	require.Error(err)
 	Assert.New(t).ErrorIs(err, ErrWorktreeDirty)
+}
+
+// TestPushWorktreeBranchUsesAuthenticatedRunnerAndMutationAuth proves that
+// when clone management is configured the networked branch-sync steps route
+// through the host's authenticated git runner so a provider credential is
+// always injected, and that the push specifically resolves the user's own PAT
+// chain (mutation auth) while the fetches resolve the read-preferred GitHub App
+// installation token. A fake git on PATH stands in for an authenticated
+// remote: it rejects any push or fetch that arrives without a credential and
+// records which token each networked operation carried.
+func TestPushWorktreeBranchUsesAuthenticatedRunnerAndMutationAuth(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+	work := setupDivergenceWorktree(t)
+	require.NoError(os.WriteFile(
+		filepath.Join(work, "f.txt"), []byte("ahead\n"), 0o644,
+	))
+	runWorkspaceTestGit(t, work, "add", ".")
+	runWorkspaceTestGit(t, work, "commit", "-m", "ahead")
+
+	realGit, err := exec.LookPath("git")
+	require.NoError(err)
+	fakeDir := t.TempDir()
+	capturePath := filepath.Join(fakeDir, "credentials.txt")
+	require.NoError(os.WriteFile(filepath.Join(fakeDir, "git"), []byte(`#!/bin/sh
+set -eu
+real="${MIDDLEMAN_TEST_REAL_GIT:?}"
+capture="${MIDDLEMAN_TEST_GIT_CAPTURE:?}"
+op="${1:-}"
+case "$op" in
+push|fetch)
+	helper=""
+	i=0
+	count="${GIT_CONFIG_COUNT:-0}"
+	while [ "$i" -lt "$count" ]; do
+		eval "key=\${GIT_CONFIG_KEY_$i:-}"
+		eval "value=\${GIT_CONFIG_VALUE_$i:-}"
+		if [ "$key" = "credential.helper" ]; then
+			helper="$value"
+		fi
+		i=$((i + 1))
+	done
+	if [ -z "$helper" ]; then
+		echo "fatal: Authentication failed: no credential helper" >&2
+		exit 128
+	fi
+	password="$("$helper" get | sed -n 's/^password=//p')"
+	if [ -z "$password" ]; then
+		echo "fatal: Authentication failed: empty credential" >&2
+		exit 128
+	fi
+	printf '%s:%s\n' "$op" "$password" >> "$capture"
+	;;
+esac
+exec "$real" "$@"
+`), 0o755))
+	t.Setenv("MIDDLEMAN_TEST_REAL_GIT", realGit)
+	t.Setenv("MIDDLEMAN_TEST_GIT_CAPTURE", capturePath)
+	t.Setenv("PATH", fakeDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	const patEnv = "MIDDLEMAN_TEST_BRANCH_SYNC_PAT"
+	t.Setenv(patEnv, "pat-token")
+	source := tokenauth.NewManagedSource(
+		tokenauth.Descriptor{
+			Key: tokenauth.Key{Platform: "github", Host: "github.com"},
+			Candidates: []tokenauth.Candidate{
+				{
+					Kind:           tokenauth.SourceKindGitHubApp,
+					Host:           "github.com",
+					AppID:          1,
+					InstallationID: 123,
+				},
+				{Kind: tokenauth.SourceKindEnv, EnvName: patEnv},
+			},
+		},
+		tokenauth.Options{
+			GitHubApp: func(context.Context, tokenauth.Candidate) (string, time.Time, error) {
+				return "app-token", time.Now().Add(time.Hour), nil
+			},
+		},
+	)
+	mgr := NewManager(nil, t.TempDir())
+	mgr.SetClones(gitclone.New(
+		t.TempDir(), map[string]tokenauth.Source{"github.com": source},
+	))
+
+	require.NoError(mgr.PushWorktreeBranch(t.Context(), "github.com", work))
+
+	data, err := os.ReadFile(capturePath)
+	require.NoError(err)
+	ops := strings.Split(strings.TrimSpace(string(data)), "\n")
+	// The push must carry the user's PAT, never the app installation token,
+	// so the pushed commits stay attributed to the user rather than the bot.
+	assert.Contains(ops, "push:pat-token")
+	assert.NotContains(ops, "push:app-token")
+	// Reads (the upstream refresh fetches) prefer the app installation token.
+	assert.Contains(ops, "fetch:app-token")
+	assert.NotContains(ops, "fetch:pat-token")
+
+	div, ok, err := WorktreeDivergence(t.Context(), work)
+	require.NoError(err)
+	require.True(ok)
+	assert.Equal(Divergence{}, div)
 }

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -2632,10 +2632,10 @@ func shellFromPasswdLine(line string) string {
 }
 
 // runGitWithoutHooks executes a git mutation in dir and returns combined
-// output on error. It is the only git mutation runner in this package:
-// workspace git dirs may be user-owned local worktree bases whose repo-local
-// hooks middleman must never run, so there is deliberately no hook-executing
-// variant.
+// output on error. Internal workspace setup and cleanup paths must not run
+// repo-local hooks from user-owned worktree bases; user-triggered foreground
+// actions such as branch push/pull may call gitCombinedOutput directly when
+// hooks are expected to run.
 func runGitWithoutHooks(ctx context.Context, dir string, args ...string) error {
 	_, err := gitCombinedOutput(ctx, dir, gitArgsWithoutHooks(args...)...)
 	return err

--- a/internal/workspace/reveal.go
+++ b/internal/workspace/reveal.go
@@ -1,0 +1,47 @@
+package workspace
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+
+	"go.kenn.io/middleman/internal/procutil"
+)
+
+var ErrRevealUnsupported = errors.New("open workspace folder is not supported on this platform")
+
+// RevealWorktreePath asks the host OS to reveal or open the workspace folder.
+// It is intended for local workspaces only; fleet callers proxy to the remote
+// daemon only when opening the folder on that remote host is explicitly desired.
+func RevealWorktreePath(ctx context.Context, path string) error {
+	if path == "" {
+		return errors.New("empty workspace path")
+	}
+	if _, err := os.Stat(path); err != nil {
+		return fmt.Errorf("stat workspace path: %w", err)
+	}
+	name, args, ok := revealCommandForPlatform(runtime.GOOS, path)
+	if !ok {
+		return ErrRevealUnsupported
+	}
+	cmd := procutil.CommandContext(ctx, name, args...)
+	if err := procutil.Run(ctx, cmd, "workspace reveal command"); err != nil {
+		return fmt.Errorf("open workspace path: %w", err)
+	}
+	return nil
+}
+
+func revealCommandForPlatform(goos, path string) (string, []string, bool) {
+	switch goos {
+	case "darwin":
+		return "open", []string{"-R", path}, true
+	case "windows":
+		return "explorer.exe", []string{"/select," + path}, true
+	case "linux", "freebsd", "openbsd", "netbsd":
+		return "xdg-open", []string{path}, true
+	default:
+		return "", nil, false
+	}
+}

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -776,6 +776,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/fleet/hosts/{host_key}/workspaces/{id}/pull": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Pull workspace branch on fleet host */
+        post: operations["pull-fleet-workspace-branch"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/fleet/hosts/{host_key}/workspaces/{id}/push": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Push workspace branch on fleet host */
+        post: operations["push-fleet-workspace-branch"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/fleet/hosts/{host_key}/workspaces/{id}/refresh": {
         parameters: {
             query?: never;
@@ -804,6 +838,23 @@ export interface paths {
         put?: never;
         /** Retry workspace setup on fleet host */
         post: operations["retry-fleet-workspace"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/fleet/hosts/{host_key}/workspaces/{id}/reveal": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Reveal workspace folder on fleet host */
+        post: operations["reveal-fleet-workspace"];
         delete?: never;
         options?: never;
         head?: never;
@@ -3536,6 +3587,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/workspaces/{id}/pull": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Pull workspace branch */
+        post: operations["pull-workspace-branch"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/workspaces/{id}/push": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Push workspace branch */
+        post: operations["push-workspace-branch"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/workspaces/{id}/refresh": {
         parameters: {
             query?: never;
@@ -3564,6 +3649,23 @@ export interface paths {
         put?: never;
         /** Retry workspace */
         post: operations["retry-workspace"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/workspaces/{id}/reveal": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Reveal workspace folder */
+        post: operations["reveal-workspace"];
         delete?: never;
         options?: never;
         head?: never;
@@ -8131,6 +8233,58 @@ export interface operations {
             };
         };
     };
+    "pull-fleet-workspace-branch": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                host_key: string;
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Response returned by the owning fleet host. */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
+    "push-fleet-workspace-branch": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                host_key: string;
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Response returned by the owning fleet host. */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
     "refresh-fleet-workspace": {
         parameters: {
             query?: never;
@@ -8158,6 +8312,32 @@ export interface operations {
         };
     };
     "retry-fleet-workspace": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                host_key: string;
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Response returned by the owning fleet host. */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
+    "reveal-fleet-workspace": {
         parameters: {
             query?: never;
             header?: never;
@@ -14517,6 +14697,68 @@ export interface operations {
             };
         };
     };
+    "pull-workspace-branch": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkspaceResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
+    "push-workspace-branch": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkspaceResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
     "refresh-workspace": {
         parameters: {
             query?: never;
@@ -14567,6 +14809,35 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["WorkspaceResponse"];
                 };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
+    "reveal-workspace": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description No Content */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Error */
             default: {


### PR DESCRIPTION
Workspace context menus were exposing actions that looked available but did not actually run. That is a bad failure mode for a maintainer console because users need to trust that visible workspace actions either execute or report a real failure.

This wires push, pull, reveal, and delete from the workspace list, keeps foreground push/pull behavior conservative around dirty or diverged worktrees, and shows pending/failure feedback while long-running git operations are active.

Screenshot:

![workspace-actions-context-menu.png](https://github.com/user-attachments/assets/bb54958c-fd9a-43c3-9b51-0cb30bb2e020)

Validated locally with the focused workspace/server Go tests, the workspace sidebar unit tests, frontend typecheck, and the repository commit hooks.

<sup>generated by a clanker</sup>