### PR TITLE
fix: sync active PR detail during polling

### DIFF
--- a/packages/ui/src/stores/detail.svelte.test.ts
+++ b/packages/ui/src/stores/detail.svelte.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vite-plus/test";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import type { PullDetail } from "../api/types.js";
 import type { MiddlemanClient } from "../types.js";
@@ -40,6 +40,10 @@ function mockClient(overrides: Partial<MiddlemanClient> = {}): MiddlemanClient {
 }
 
 describe("createDetailStore", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("syncs detail and resolves after applying the refreshed head", async () => {
     const post = vi.fn().mockResolvedValue({
       data: pullDetail("fresh-head"),
@@ -61,5 +65,33 @@ describe("createDetailStore", () => {
 
     expect(store.getDetail()?.platform_head_sha).toBe("fresh-head");
     expect(pulls.loadPulls).toHaveBeenCalledTimes(1);
+  });
+
+  it("enqueues background sync when active detail polling fires", async () => {
+    vi.useFakeTimers();
+    const post = vi.fn().mockResolvedValue({ error: undefined });
+    const get = vi.fn().mockResolvedValue({ data: pullDetail("cached-head") });
+    const store = createDetailStore({
+      client: mockClient({ GET: get, POST: post }),
+    });
+
+    store.startDetailPolling("acme", "widget", 7, {
+      provider: "github",
+      platformHost: "github.com",
+      repoPath: "acme/widget",
+    });
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(post).toHaveBeenCalledWith("/pulls/{provider}/{owner}/{name}/{number}/sync/async", {
+      params: {
+        path: {
+          provider: "github",
+          owner: "acme",
+          name: "widget",
+          number: 7,
+        },
+      },
+    });
   });
 });

--- a/packages/ui/src/stores/detail.svelte.ts
+++ b/packages/ui/src/stores/detail.svelte.ts
@@ -908,7 +908,7 @@ export function createDetailStore(opts: DetailStoreOptions) {
     const ref = detailRequestRef(owner, name, number, identity);
     stopDetailPolling();
     detailPollHandle = setInterval(() => {
-      void refreshDetail(owner, name, number, syncGeneration, ref);
+      void enqueueBackgroundDetailSync(owner, name, number, syncGeneration, detail?.detail_fetched_at, ref);
     }, 60_000);
     if (syncDep) {
       unsubSyncComplete = syncDep.subscribeSyncComplete(() => {


### PR DESCRIPTION
Active PR detail panes could appear stale because the minute poll only re-read Middleman's cached detail response. Changes that existed only on the provider stayed hidden until another sync path happened to run.

This makes the open Activity or PR detail pane enqueue the existing background detail sync on each poll tick, so provider-side PR updates can appear without navigating away or waiting for a broader sync.