### PR TITLE
Keep activity detail open after merge modal escape

### DIFF
--- a/frontend/tests/e2e-full/activity-drawer.spec.ts
+++ b/frontend/tests/e2e-full/activity-drawer.spec.ts
@@ -961,6 +961,24 @@ test.describe("activity split view and detail drawers", () => {
     await expect(detail.locator(".list-layout > .resize-handle")).toHaveCount(0);
   });
 
+  test("Escape from merge modal keeps activity split detail open", async ({ page }) => {
+    await page.goto("/");
+    await waitForActivityTable(page);
+
+    const detail = await openActivityPRSplit(page);
+    await detail.locator(".btn--merge").first().click();
+
+    const modal = page.locator(".modal", { hasText: "Merge Pull Request" });
+    await expect(modal).toBeVisible();
+
+    await page.keyboard.press("Escape");
+
+    await expect(modal).toHaveCount(0);
+    await expect(page.locator(".activity-shell.activity-shell--split")).toBeVisible();
+    await expect(detail).toBeVisible();
+    await expect(detail.locator(".pull-detail")).toBeVisible();
+  });
+
   test("kanban drawer Files tab renders the file/commit sidebar", async ({ page }) => {
     await mockDiffForAllPRs(page, tinyDiff);
 

--- a/packages/ui/src/components/detail/MergeModal.svelte
+++ b/packages/ui/src/components/detail/MergeModal.svelte
@@ -9,7 +9,14 @@
 
   const client = getClient();
 
-  onMount(() => pushModalFrame("merge-modal", []));
+  onMount(() => {
+    const cleanupFrame = pushModalFrame("merge-modal", []);
+    window.addEventListener("keydown", handleKeydown, { capture: true });
+    return () => {
+      window.removeEventListener("keydown", handleKeydown, { capture: true });
+      cleanupFrame();
+    };
+  });
 
   interface Props {
     owner: string;
@@ -168,6 +175,7 @@
   function handleKeydown(e: KeyboardEvent): void {
     if (e.key === "Escape") {
       e.preventDefault();
+      e.stopImmediatePropagation();
       onclose();
     }
   }


### PR DESCRIPTION
- Escape now dismisses the merge modal without also closing the Activity PR detail split.
- Adds e2e coverage for the Activity split + merge modal Escape flow.