### PR TITLE
fix: stop misreading GitLab fork-head transient errors as 404/403

### DIFF
--- a/internal/platform/gitlab/client.go
+++ b/internal/platform/gitlab/client.go
@@ -275,7 +275,7 @@ func (c *Client) PreviewNamespace(
 	if err == nil {
 		return result.finish(), nil
 	}
-	if !isGitLabStatus(err, http.StatusNotFound) {
+	if !isGitLabNotFound(err) {
 		return PreviewResult{}, mapGitLabError("preview_group", err)
 	}
 	if err := ctx.Err(); err != nil {
@@ -882,12 +882,27 @@ func mapGitLabErrorForHost(platformHost, capability string, err error) error {
 	}
 }
 
+// isGitLabStatus reports whether err carries a typed GitLab response with the
+// given status. It matches only on the typed *gitlab.ErrorResponse (errors.As
+// unwraps platform.Error). It deliberately does NOT fall back to substring
+// matching on err.Error(): that string embeds the request URL, so an unrelated
+// host:port (for example an ephemeral httptest port like 127.0.0.1:40404, or a
+// project ID) could contain "404"/"403" and misclassify a transient 429/5xx as
+// a not-found/forbidden error that callers then silently swallow.
+//
+// Note: go-gitlab does not return a typed *gitlab.ErrorResponse for 404s; it
+// returns the sentinel gitlab.ErrNotFound. Use isGitLabNotFound for those.
 func isGitLabStatus(err error, status int) bool {
 	var gitlabErr *gitlab.ErrorResponse
-	if errors.As(err, &gitlabErr) && gitlabErr.HasStatusCode(status) {
-		return true
-	}
-	return strings.Contains(err.Error(), strconv.Itoa(status))
+	return errors.As(err, &gitlabErr) && gitlabErr.HasStatusCode(status)
+}
+
+// isGitLabNotFound reports whether err is a GitLab 404. go-gitlab's
+// CheckResponse returns the sentinel gitlab.ErrNotFound (a plain error, not a
+// *gitlab.ErrorResponse) for every 404, so errors.Is is the only reliable
+// detection. errors.Is unwraps platform.Error, so wrapped errors match too.
+func isGitLabNotFound(err error) bool {
+	return errors.Is(err, gitlab.ErrNotFound)
 }
 
 func isUnavailableSourceProjectError(err error) bool {
@@ -898,8 +913,7 @@ func isUnavailableSourceProjectError(err error) bool {
 			return true
 		}
 	}
-	return isGitLabStatus(err, http.StatusForbidden) ||
-		isGitLabStatus(err, http.StatusNotFound)
+	return isGitLabNotFound(err) || isGitLabStatus(err, http.StatusForbidden)
 }
 
 func partialError(namespace string, page int64, err error) PartialError {

--- a/internal/platform/gitlab/status_classification_test.go
+++ b/internal/platform/gitlab/status_classification_test.go
@@ -1,0 +1,64 @@
+package gitlab
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	gitlab "gitlab.com/gitlab-org/api/client-go"
+)
+
+// gitlabStatusError builds a *gitlab.ErrorResponse whose embedded request URL
+// uses the given host. go-gitlab renders such errors as
+// "GET <scheme>://<host><path>: <status> <message>", so host is where an
+// ephemeral httptest port (or any digits) can leak into err.Error(). go-gitlab
+// returns this typed shape for every error status except 404, which comes back
+// as the gitlab.ErrNotFound sentinel instead.
+func gitlabStatusError(host string, status int) *gitlab.ErrorResponse {
+	return &gitlab.ErrorResponse{
+		Message: "boom",
+		Response: &http.Response{
+			StatusCode: status,
+			Request: &http.Request{
+				Method: http.MethodGet,
+				URL:    &url.URL{Scheme: "http", Host: host, Path: "/api/v4/projects/77"},
+			},
+		},
+	}
+}
+
+// Regression: a transient fork-head lookup failure must never be classified as a
+// downgradeable (not-found/forbidden) error just because the request URL's
+// host:port happens to contain "403"/"404". Before the fix, isGitLabStatus fell
+// back to strings.Contains(err.Error(), "404"), so an ephemeral httptest port
+// like 127.0.0.1:40404 turned a 429 into a silently-swallowed lookup, flaking
+// TestClientListOpenMergeRequestsPropagatesTransientForkHeadRepoLookupFailures.
+func TestUnavailableSourceProjectIgnoresStatusDigitsInErrorURL(t *testing.T) {
+	assert := assert.New(t)
+	cases := []struct {
+		name          string
+		err           error
+		wantDowngrade bool
+	}{
+		// Transient failures must propagate even when the request URL's host:port
+		// contains the digits "404"/"403" (e.g. an ephemeral httptest port).
+		{"rate limited on 404-bearing port", gitlabStatusError("127.0.0.1:40404", http.StatusTooManyRequests), false},
+		{"rate limited on 403-bearing port", gitlabStatusError("127.0.0.1:54033", http.StatusTooManyRequests), false},
+		{"bad gateway on 404-bearing port", gitlabStatusError("127.0.0.1:40404", http.StatusBadGateway), false},
+		{"server error on 403-bearing port", gitlabStatusError("127.0.0.1:40430", http.StatusInternalServerError), false},
+		// Genuine not-found/forbidden still downgrade (fork identity is dropped).
+		// 404 arrives as go-gitlab's sentinel, 403 as a typed *gitlab.ErrorResponse.
+		{"genuine not found (sentinel)", gitlab.ErrNotFound, true},
+		{"genuine forbidden", gitlabStatusError("127.0.0.1:51234", http.StatusForbidden), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Mirror the real call path: projectCloneURL wraps the SDK error
+			// via mapGitLabError before it reaches isUnavailableSourceProjectError.
+			wrapped := mapGitLabError("get_source_project", tc.err)
+			assert.Equal(tc.wantDowngrade, isUnavailableSourceProjectError(wrapped),
+				"raw err: %q", tc.err.Error())
+		})
+	}
+}


### PR DESCRIPTION
GitLab fork merge requests look up the source project to resolve the head clone URL. Transient failures there (429, 5xx) must propagate so a fork's identity isn't silently downgraded; only genuine 404/403 should drop the fork head.

The classifier fell back to substring-matching the error string for "404"/"403". go-gitlab includes the full request URL (host:port) in that string, so an ephemeral httptest port like `127.0.0.1:40404` made a 429 look like a not-found and the error was swallowed. This flaked `go test -race` (`TestClientListOpenMergeRequestsPropagatesTransientForkHeadRepoLookupFailures`) and could mis-downgrade fork identity in production whenever a transient error's text contained those digits.

- Match status only on the typed `*gitlab.ErrorResponse`; never substring-match the error text.
- Detect 404 via `errors.Is(err, gitlab.ErrNotFound)`, since go-gitlab returns that sentinel (not a typed response) for every 404.
- Apply the same sentinel check to the `PreviewNamespace` group-not-found fallback, which relied on the same substring path.
- Add a deterministic regression test that pins transient-vs-downgradeable classification regardless of digits in the error URL.
