### PR TITLE
fix: show pending deferred merge scheduling

### DIFF
--- a/packages/ui/src/components/detail/MergeModal.svelte
+++ b/packages/ui/src/components/detail/MergeModal.svelte
@@ -188,7 +188,7 @@
   }
 
   function primaryButtonLabel(): string {
-    if (merging) return "Merging...";
+    if (merging) return deferUntilChecksPass ? "Merge scheduled..." : "Merging...";
     return deferUntilChecksPass ? "Merge after CI is complete" : methodLabel();
   }
 </script>

--- a/packages/ui/src/components/detail/MergeModal.svelte.test.ts
+++ b/packages/ui/src/components/detail/MergeModal.svelte.test.ts
@@ -74,6 +74,14 @@ describe("MergeModal head pinning", () => {
     });
   }
 
+  function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((res) => {
+      resolve = res;
+    });
+    return { promise, resolve };
+  }
+
   async function confirmMerge(): Promise<void> {
     await fireEvent.click(screen.getByText("Squash and merge", { selector: ".modal-footer button" }));
   }
@@ -165,6 +173,22 @@ describe("MergeModal head pinning", () => {
     expect(path).toBe("/pulls/{provider}/{owner}/{name}/{number}/merge/deferred");
     expect(init.body.method).toBe("squash");
     expect(onclose).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the deferred merge action while scheduling the merge", async () => {
+    const scheduled = deferred<{ data: Record<string, never>; error: undefined; response: Response }>();
+    const post = vi.fn().mockReturnValue(scheduled.promise);
+    renderModal(post, {
+      deferUntilChecksPass: true,
+    });
+
+    await fireEvent.click(screen.getByText("Merge after CI is complete", { selector: ".modal-footer button" }));
+
+    const pendingButton = screen.getByRole<HTMLButtonElement>("button", { name: "Merge scheduled..." });
+    expect(pendingButton.disabled).toBe(true);
+    expect(post).toHaveBeenCalledTimes(1);
+
+    scheduled.resolve({ data: {}, error: undefined, response: new Response("{}") });
   });
 
   it("enqueues a deferred merge when requested without granular pending checks", async () => {


### PR DESCRIPTION
Deferred merge scheduling can take long enough that the UI looks idle after the user chooses merge-after-CI. That leaves users uncertain whether the click registered and makes repeat clicks possible while the scheduling request is still in flight.

This keeps the primary action disabled during scheduling and changes its pending copy to `Merge scheduled...`, while preserving the normal `Merging...` copy for immediate merges.

Validation: targeted MergeModal unit test, UI package check, and a local Playwright screenshot capture saved at `tmp/deferred-merge-scheduled.png`. Screenshot upload was not performed because the capture workflow requires explicit upload approval for a specific PR target.

<sup>generated by a clanker</sup>