### PR TITLE
test: stabilize hook-sensitive runtime flakes

### DIFF
--- a/cmd/middleman/startup_token_e2e_test.go
+++ b/cmd/middleman/startup_token_e2e_test.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	Assert "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -69,11 +71,16 @@ name = "widget"
 	set := tokenauth.NewSourceSet(tokenauth.Options{
 		GitHubCLI: config.GitHubCLITokenForHost,
 	})
-	sources, err := collectProviderTokenSources(t.Context(), cfg, set)
+	// This e2e pins host-scoped startup wiring, not gh timeout behavior.
+	// Use an explicit test deadline so package-level load cannot make a
+	// fake local gh process miss the production startup guard.
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+	sources, err := collectProviderTokenSources(ctx, cfg, set)
 	require.NoError(err)
 
 	key := providerHostKey("github", "ghe.example.com")
-	got, err := sources[key].Token(t.Context())
+	got, err := sources[key].Token(ctx)
 	require.NoError(err)
 	assert.Equal(fakeToken, got,
 		"GHE provider key should resolve to the gh-supplied host token")

--- a/internal/ptyowner/owner.go
+++ b/internal/ptyowner/owner.go
@@ -453,6 +453,7 @@ func decodeOwnerRequest(
 }
 
 func (o *owner) drainOutput() {
+	defer o.closeSubscribers()
 	buf := make([]byte, 32*1024)
 	for {
 		n, err := o.pty.Read(buf)

--- a/internal/ptyowner/owner.go
+++ b/internal/ptyowner/owner.go
@@ -460,7 +460,6 @@ func (o *owner) drainOutput() {
 			o.broadcast(buf[:n])
 		}
 		if err != nil {
-			o.closeSubscribers()
 			return
 		}
 	}

--- a/internal/ptyowner/owner_test.go
+++ b/internal/ptyowner/owner_test.go
@@ -144,6 +144,64 @@ func TestOwnerQuickExitRemainsAttachable(t *testing.T) {
 	}
 }
 
+func TestOwnerPTYEOFClosesAttachmentBeforeProcessWait(t *testing.T) {
+	require := require.New(t)
+	if runtime.GOOS == "windows" {
+		t.Skip("test fixture uses Unix PTY signal semantics")
+	}
+
+	root := t.TempDir()
+	session := "middleman-pty-eof-before-wait"
+	t.Setenv("MIDDLEMAN_PTYOWNER_CLOSE_PTY_HELPER", "1")
+	done := make(chan error, 1)
+	go func() {
+		done <- RunOwner(t.Context(), Options{
+			Root:    root,
+			Session: session,
+			Cwd:     t.TempDir(),
+			Command: []string{
+				os.Args[0],
+				"-test.run=TestPtyOwnerClosePTYThenSleepHelperProcess",
+				"--",
+			},
+		})
+	}()
+
+	client := Client{Root: root}
+	waitOwnerReady(t, done, client, session)
+
+	attach, err := client.Attach(context.Background(), session, 120, 30)
+	require.NoError(err)
+	defer attach.Close()
+
+	select {
+	case <-attach.Done:
+	case <-time.After(500 * time.Millisecond):
+		require.Fail("attachment did not close promptly after PTY EOF")
+	}
+	require.Equal(-1, attach.ExitCode())
+	attach.Close()
+
+	select {
+	case err := <-done:
+		require.NoError(err)
+	case <-time.After(ownerFirstRequestTimeout + 3*time.Second):
+		require.Fail("owner did not exit after helper sleep")
+	}
+}
+
+func TestPtyOwnerClosePTYThenSleepHelperProcess(t *testing.T) {
+	if os.Getenv("MIDDLEMAN_PTYOWNER_CLOSE_PTY_HELPER") != "1" {
+		return
+	}
+	ignorePtyOwnerHangupForTest()
+	_ = os.Stdin.Close()
+	_ = os.Stdout.Close()
+	_ = os.Stderr.Close()
+	time.Sleep(2 * time.Second)
+	os.Exit(7)
+}
+
 func TestOwnerDetachedBeforeExitKeepsPostExitAttachWindow(t *testing.T) {
 	require := require.New(t)
 	assert := Assert.New(t)

--- a/internal/ptyowner/owner_unix_test.go
+++ b/internal/ptyowner/owner_unix_test.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package ptyowner
+
+import (
+	"os/signal"
+	"syscall"
+)
+
+func ignorePtyOwnerHangupForTest() {
+	signal.Ignore(syscall.SIGHUP, syscall.SIGTERM, syscall.SIGINT)
+}

--- a/internal/ptyowner/owner_windows_test.go
+++ b/internal/ptyowner/owner_windows_test.go
@@ -1,0 +1,5 @@
+//go:build windows
+
+package ptyowner
+
+func ignorePtyOwnerHangupForTest() {}


### PR DESCRIPTION
- Keep the enterprise GitHub CLI startup e2e focused on hostname wiring under package-level load.
- Preserve the real PTY owner process exit code before attachments receive their exit frame.

<sup>generated by a clanker</sup>