### PR TITLE
Clarify workspace onboarding and launch targets

### DIFF
--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -5641,6 +5641,12 @@ components:
           type: array
         fleet:
           $ref: "#/components/schemas/FleetSettingsResponse"
+        launch_targets:
+          items:
+            $ref: "#/components/schemas/LaunchTarget"
+          type:
+            - array
+            - "null"
         modes:
           $ref: "#/components/schemas/ModeVisibility"
         notifications:

--- a/frontend/src/lib/components/terminal/WorkspaceHome.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceHome.svelte
@@ -22,11 +22,13 @@
   }
 
   interface WorkspaceHomeProps {
-    workspace: WorkspaceHomeWorkspace;
+    workspace?: WorkspaceHomeWorkspace;
     launchTargets: LaunchTarget[];
     sessions: RuntimeSession[];
     displayLabels?: Record<string, string>;
     launchingKey?: string | null;
+    readonly?: boolean;
+    showHeader?: boolean;
     onLaunch?: (targetKey: string) => void;
     onOpenSession?: (sessionKey: string) => void;
   }
@@ -37,6 +39,8 @@
     sessions,
     displayLabels = {},
     launchingKey = null,
+    readonly = false,
+    showHeader = true,
     onLaunch,
     onOpenSession,
   }: WorkspaceHomeProps = $props();
@@ -44,7 +48,7 @@
   const visibleTargets = $derived(launchTargets.filter(isVisibleLaunchTarget));
 
   function title(): string {
-    return workspace.mr_title ?? workspace.git_head_ref;
+    return workspace?.mr_title ?? workspace?.git_head_ref ?? "Workspace";
   }
 
   function sourceLabel(target: LaunchTarget): string {
@@ -69,24 +73,26 @@
   }
 </script>
 
-<section class="workspace-home" aria-label="Worktree Home">
-  <header class="home-header">
-    <h2 class="home-title">{title()}</h2>
-    <div class="home-meta">
-      <span class="meta-chip">
-        {workspace.repo_owner}/{workspace.repo_name}
-        <span class="meta-chip-num">#{workspace.item_number}</span>
-      </span>
-      <span class="meta-chip mono">
-        <GitBranchIcon size="11" strokeWidth="2" aria-hidden="true" />
-        {workspace.git_head_ref}
-      </span>
-      <span class="meta-chip mono path" title={workspace.worktree_path}>
-        <FolderIcon size="11" strokeWidth="2" aria-hidden="true" />
-        {workspace.worktree_path}
-      </span>
-    </div>
-  </header>
+<section class={["workspace-home", readonly && "readonly"]} aria-label="Worktree Home">
+  {#if showHeader && workspace}
+    <header class="home-header">
+      <h2 class="home-title">{title()}</h2>
+      <div class="home-meta">
+        <span class="meta-chip">
+          {workspace.repo_owner}/{workspace.repo_name}
+          <span class="meta-chip-num">#{workspace.item_number}</span>
+        </span>
+        <span class="meta-chip mono">
+          <GitBranchIcon size="11" strokeWidth="2" aria-hidden="true" />
+          {workspace.git_head_ref}
+        </span>
+        <span class="meta-chip mono path" title={workspace.worktree_path}>
+          <FolderIcon size="11" strokeWidth="2" aria-hidden="true" />
+          {workspace.worktree_path}
+        </span>
+      </div>
+    </header>
+  {/if}
 
   <div class="home-section">
     <div class="section-bar">
@@ -106,7 +112,7 @@
         {@const isLaunching = launchingKey === target.key}
         <button
           class="launch-card"
-          disabled={!target.available || isLaunching}
+          disabled={readonly || !target.available || isLaunching}
           title={target.disabled_reason ?? targetLabel(target)}
           aria-label={targetLabel(target)}
           onclick={() => onLaunch?.(target.key)}
@@ -140,6 +146,7 @@
         {#each sessions as session (session.key)}
           <button
             class="session-row"
+            disabled={readonly}
             onclick={() => onOpenSession?.(session.key)}
           >
             <span
@@ -166,6 +173,10 @@
     overflow: auto;
     background: var(--bg-primary);
     color: var(--text-primary);
+  }
+
+  .workspace-home.readonly {
+    pointer-events: none;
   }
 
   .home-header {

--- a/frontend/src/lib/components/terminal/WorkspaceHome.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceHome.svelte
@@ -256,6 +256,10 @@
     color: var(--accent-green);
   }
 
+  .workspace-home.readonly :global(.section-icon) {
+    color: var(--text-muted);
+  }
+
   .section-title {
     font-size: var(--font-size-xs);
     font-weight: 700;

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -85,6 +85,9 @@
       tab: "pr" | "issue",
       hostKey?: string,
     ) => void;
+    onWorkspaceListStateChange?: (
+      state: { status: "loading" | "retrying" | "loaded"; total: number },
+    ) => void;
     isSidebarToggleEnabled?: boolean;
     onCollapseSidebar?: (() => void) | undefined;
   }
@@ -93,6 +96,7 @@
     selectedId,
     selectedHostKey = undefined,
     onOpenItemSidebar,
+    onWorkspaceListStateChange,
     isSidebarToggleEnabled = false,
     onCollapseSidebar,
   }: Props = $props();
@@ -298,6 +302,13 @@
       window.removeEventListener("resize", reposition);
       window.removeEventListener("scroll", closeContextMenu, true);
     };
+  });
+
+  $effect(() => {
+    onWorkspaceListStateChange?.({
+      status: workspaceListStatus,
+      total: workspaces.length,
+    });
   });
 
   function timeValue(value: string | null | undefined): number {

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
@@ -263,6 +263,45 @@ describe("WorkspaceListSidebar", () => {
     expect(screen.queryByText("local")).toBeNull();
   });
 
+  it("reports when no workspaces exist", async () => {
+    const onWorkspaceListStateChange = vi.fn();
+    mockGet.mockImplementation((path: string) => {
+      if (path === "/snapshot") {
+        return Promise.resolve({
+          data: {
+            hosts: [
+              {
+                configKey: "member",
+                diagnostics: [],
+                id: "member",
+                kind: "self",
+                name: "member",
+                operationAvailability: {},
+                platform: "linux",
+                preferredTransport: "local",
+                reachable: true,
+                tmuxSessions: [],
+              },
+            ],
+          },
+        });
+      }
+      return Promise.resolve({ data: { workspaces: [] } });
+    });
+
+    render(WorkspaceListSidebar, {
+      props: { selectedId: "", onWorkspaceListStateChange },
+    });
+
+    expect(await screen.findByText("No workspaces yet.")).toBeTruthy();
+    await waitFor(() => {
+      expect(onWorkspaceListStateChange).toHaveBeenLastCalledWith({
+        status: "loaded",
+        total: 0,
+      });
+    });
+  });
+
   it("loads workspaces from reachable ssh fleet hosts", async () => {
     mockGet.mockImplementation((path: string, options?: { params?: { path?: { host_key?: string } } }) => {
       if (path === "/snapshot") {

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -222,9 +222,9 @@
     "middleman-workspace-terminal-layout:";
   const WORKFLOW_PRESETS_KEY = "middleman-workspace-layout-presets";
   const PLAIN_SHELL_TARGET = "plain_shell";
+  type EmptyLaunchTargetsState = "idle" | "loading" | "loaded" | "error";
   let emptyLaunchTargets = $state.raw<LaunchTarget[]>([]);
-  let emptyLaunchTargetsLoaded = $state(false);
-  let emptyLaunchTargetsLoading = $state(false);
+  let emptyLaunchTargetsState = $state<EmptyLaunchTargetsState>("idle");
 
   let workflowPresets = $state<WorkflowPreset[]>(loadWorkflowPresets());
   let selectedWorkflowPresetId = $state<string | null>(null);
@@ -255,17 +255,20 @@
   }
 
   async function loadEmptyLaunchTargets(): Promise<void> {
-    if (emptyLaunchTargetsLoaded || emptyLaunchTargetsLoading) return;
-    emptyLaunchTargetsLoading = true;
+    if (
+      emptyLaunchTargetsState === "loaded" ||
+      emptyLaunchTargetsState === "loading"
+    ) {
+      return;
+    }
+    emptyLaunchTargetsState = "loading";
     try {
       const { data } = await client.GET("/settings");
       emptyLaunchTargets = data?.launch_targets ?? [];
-      emptyLaunchTargetsLoaded = true;
+      emptyLaunchTargetsState = "loaded";
     } catch {
       emptyLaunchTargets = [];
-      emptyLaunchTargetsLoaded = true;
-    } finally {
-      emptyLaunchTargetsLoading = false;
+      emptyLaunchTargetsState = "error";
     }
   }
 
@@ -2485,10 +2488,13 @@
           <section class="workspace-zero-state" aria-label="Workspaces empty state">
             <div class="workspace-zero-copy">
               <p class="workspace-zero-eyebrow">Workspaces</p>
-              <h2>Create a workspace to run agents on a PR head</h2>
+              <h2>Create a workspace to run agents from a PR or issue</h2>
               <p>
                 Workspaces are git worktrees created from PR or issue
-                heads. From a PR or issue, use this button
+                heads.
+              </p>
+              <p>
+                From a PR or issue, use the
                 <span
                   class="workspace-zero-inline-action"
                   aria-label="Create Workspace example"
@@ -2510,7 +2516,7 @@
                     />
                   </ActionButton>
                 </span>
-                to launch a workspace.
+                button to launch a workspace.
               </p>
               <p>
                 Once it exists, this pane can start agents, local review
@@ -2518,9 +2524,10 @@
               </p>
             </div>
             <div class="workspace-zero-example-card" aria-label="Workspace workflow example">
-              <div class="workspace-zero-example-heading">Example workflow</div>
               <div class="workspace-zero-example" aria-label="Launch surface example">
-                <span class="workspace-zero-example-label">Then run agents here</span>
+                <span class="workspace-zero-example-label">
+                  You can then launch configured agents via the buttons provided
+                </span>
                 {#if emptyLaunchTargets.length > 0}
                   <WorkspaceHome
                     launchTargets={emptyLaunchTargets}
@@ -2528,10 +2535,18 @@
                     readonly
                     showHeader={false}
                   />
-                {:else}
+                {:else if emptyLaunchTargetsState === "error"}
+                  <p class="workspace-zero-example-empty">
+                    Launch targets could not be loaded.
+                  </p>
+                {:else if emptyLaunchTargetsState === "loaded"}
                   <p class="workspace-zero-example-empty">
                     Launch targets appear here after agent tools are configured
                     or detected.
+                  </p>
+                {:else}
+                  <p class="workspace-zero-example-empty">
+                    Loading launch targets...
                   </p>
                 {/if}
               </div>
@@ -3201,14 +3216,6 @@
     box-shadow:
       0 1px 2px rgba(0, 0, 0, 0.04),
       0 4px 14px rgba(0, 0, 0, 0.08);
-  }
-
-  .workspace-zero-example-heading {
-    color: var(--text-muted);
-    font-size: var(--font-size-xs);
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
   }
 
   .workspace-zero-example {

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
   import { tick, untrack } from "svelte";
   import { pushModalFrame } from "@middleman/ui/stores/keyboard/modal-stack";
-  import SparklesIcon from "@lucide/svelte/icons/sparkles";
-  import TerminalIcon from "@lucide/svelte/icons/terminal";
   import { navigate } from "../../stores/router.svelte.ts";
   import WorkspaceListSidebar from "./WorkspaceListSidebar.svelte";
   import TerminalPane from "./TerminalPane.svelte";
@@ -14,7 +12,11 @@
     type WorkflowTabDescriptor,
   } from "./WorkflowSplitTree.svelte";
   import WorkflowPresetMenu from "./WorkflowPresetMenu.svelte";
-  import type { RuntimeSession } from "@middleman/ui/api/types";
+  import PackagePlusIcon from "@lucide/svelte/icons/package-plus";
+  import type {
+    LaunchTarget,
+    RuntimeSession,
+  } from "@middleman/ui/api/types";
   import {
     getWorkspaceRuntime,
     launchWorkspaceSession,
@@ -64,6 +66,7 @@
     readRuntimeSessionDrag,
   } from "./terminal-drag";
   import {
+    ActionButton,
     CollapsibleResizableSidebar,
     SplitResizeHandle,
     WorkspaceRightSidebar,
@@ -219,6 +222,9 @@
     "middleman-workspace-terminal-layout:";
   const WORKFLOW_PRESETS_KEY = "middleman-workspace-layout-presets";
   const PLAIN_SHELL_TARGET = "plain_shell";
+  let emptyLaunchTargets = $state.raw<LaunchTarget[]>([]);
+  let emptyLaunchTargetsLoaded = $state(false);
+  let emptyLaunchTargetsLoading = $state(false);
 
   let workflowPresets = $state<WorkflowPreset[]>(loadWorkflowPresets());
   let selectedWorkflowPresetId = $state<string | null>(null);
@@ -246,6 +252,21 @@
     state: { status: "loading" | "retrying" | "loaded"; total: number },
   ): void {
     workspaceListState = state;
+  }
+
+  async function loadEmptyLaunchTargets(): Promise<void> {
+    if (emptyLaunchTargetsLoaded || emptyLaunchTargetsLoading) return;
+    emptyLaunchTargetsLoading = true;
+    try {
+      const { data } = await client.GET("/settings");
+      emptyLaunchTargets = data?.launch_targets ?? [];
+      emptyLaunchTargetsLoaded = true;
+    } catch {
+      emptyLaunchTargets = [];
+      emptyLaunchTargetsLoaded = true;
+    } finally {
+      emptyLaunchTargetsLoading = false;
+    }
   }
 
   function readLocalStorage(key: string): string | null {
@@ -2443,6 +2464,17 @@
       }
     };
   });
+
+  $effect(() => {
+    if (
+      workspaceId ||
+      workspaceListState.status !== "loaded" ||
+      workspaceListState.total !== 0
+    ) {
+      return;
+    }
+    void loadEmptyLaunchTargets();
+  });
 </script>
 
 <div class="terminal-view" inert={modalOpen}>
@@ -2456,35 +2488,52 @@
               <h2>Create a workspace to run agents on a PR head</h2>
               <p>
                 Workspaces are git worktrees created from PR or issue
-                heads. Open a PR or issue and choose Create Workspace to
-                check out an isolated branch here.
+                heads. From a PR or issue, use this button
+                <span
+                  class="workspace-zero-inline-action"
+                  aria-label="Create Workspace example"
+                >
+                  <ActionButton
+                    class="workspace-zero-create-button"
+                    disabled
+                    tone="info"
+                    surface="soft"
+                    size="sm"
+                    title="Create a PR or issue worktree, then open Workspaces to launch agents, shells, or local review sessions on that branch."
+                    label="Create Workspace"
+                    shortLabel="Create Workspace"
+                  >
+                    <PackagePlusIcon
+                      size="14"
+                      strokeWidth="2.2"
+                      aria-hidden="true"
+                    />
+                  </ActionButton>
+                </span>
+                to launch a workspace.
               </p>
               <p>
                 Once it exists, this pane can start agents, local review
                 sessions, or a shell inside that worktree.
               </p>
             </div>
-            <div class="disabled-session-preview" aria-label="New session preview">
-              <div class="disabled-session-toolbar">
-                <button type="button" disabled>New session</button>
-              </div>
-              <div class="disabled-session-menu" aria-label="Disabled run configurations">
-                <div class="disabled-session-heading">Run configurations</div>
-                <button type="button" disabled>
-                  <SparklesIcon size="13" strokeWidth="2" aria-hidden="true" />
-                  <span>Codex review agent</span>
-                  <span>agent</span>
-                </button>
-                <button type="button" disabled>
-                  <SparklesIcon size="13" strokeWidth="2" aria-hidden="true" />
-                  <span>Claude review agent</span>
-                  <span>agent</span>
-                </button>
-                <button type="button" disabled>
-                  <TerminalIcon size="13" strokeWidth="2" aria-hidden="true" />
-                  <span>Shell</span>
-                  <span>shell</span>
-                </button>
+            <div class="workspace-zero-example-card" aria-label="Workspace workflow example">
+              <div class="workspace-zero-example-heading">Example workflow</div>
+              <div class="workspace-zero-example" aria-label="Launch surface example">
+                <span class="workspace-zero-example-label">Then run agents here</span>
+                {#if emptyLaunchTargets.length > 0}
+                  <WorkspaceHome
+                    launchTargets={emptyLaunchTargets}
+                    sessions={[]}
+                    readonly
+                    showHeader={false}
+                  />
+                {:else}
+                  <p class="workspace-zero-example-empty">
+                    Launch targets appear here after agent tools are configured
+                    or detected.
+                  </p>
+                {/if}
               </div>
             </div>
           </section>
@@ -3084,17 +3133,19 @@
   }
 
   .workspace-zero-state {
-    display: grid;
-    grid-template-columns: minmax(260px, 460px) minmax(220px, 320px);
-    align-items: start;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
     justify-content: center;
-    gap: 28px;
+    gap: 18px;
     flex: 1;
     min-width: 0;
     overflow: auto;
     padding: 56px 28px;
     color: var(--text-primary);
     background: var(--bg-primary);
+    max-width: 560px;
+    margin: 0 auto;
   }
 
   .workspace-zero-copy {
@@ -3128,83 +3179,83 @@
     line-height: 1.5;
   }
 
-  .disabled-session-preview {
-    min-width: 0;
+  .workspace-zero-inline-action {
+    display: inline-flex;
+    vertical-align: middle;
+    margin-left: 5px;
+    transform: translateY(-1px);
+  }
+
+  .workspace-zero-example-card {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+    align-self: flex-start;
+    min-width: 280px;
+    width: min(620px, 100%);
+    padding: 12px;
     border: 1px solid var(--border-default);
     border-radius: 6px;
     background: var(--bg-surface);
     box-shadow:
       0 1px 2px rgba(0, 0, 0, 0.04),
-      0 4px 16px rgba(0, 0, 0, 0.1);
-    opacity: 0.72;
+      0 4px 14px rgba(0, 0, 0, 0.08);
   }
 
-  .disabled-session-toolbar {
-    display: flex;
-    justify-content: flex-end;
-    padding: 6px;
-    border-bottom: 1px solid var(--border-muted);
-    background: var(--bg-inset);
-  }
-
-  .disabled-session-toolbar button {
-    height: 22px;
-    padding: 0 8px;
-    border: 1px solid var(--border-default);
-    border-radius: 3px;
-    background: var(--bg-surface);
-    color: var(--text-primary);
-    font: inherit;
-    font-size: var(--font-size-sm);
-    font-weight: 600;
-  }
-
-  .disabled-session-menu {
-    display: flex;
-    flex-direction: column;
-    gap: 1px;
-    padding: 4px;
-  }
-
-  .disabled-session-heading {
-    margin-bottom: 3px;
-    padding: 4px 8px 6px;
-    border-bottom: 1px solid var(--border-muted);
+  .workspace-zero-example-heading {
     color: var(--text-muted);
     font-size: var(--font-size-xs);
-    font-weight: 600;
+    font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.06em;
   }
 
-  .disabled-session-menu button {
-    display: grid;
-    grid-template-columns: 16px 1fr auto;
+  .workspace-zero-example {
+    display: flex;
+    flex-direction: column;
     align-items: center;
-    gap: 8px;
-    width: 100%;
-    height: 26px;
-    padding: 0 8px;
-    border: 0;
-    border-radius: 3px;
-    background: transparent;
+    gap: 7px;
     color: var(--text-secondary);
-    font: inherit;
-    font-size: var(--font-size-sm);
-    text-align: left;
+    font-size: var(--font-size-md);
+    line-height: 1.5;
   }
 
-  .disabled-session-menu button span:last-child {
+  .workspace-zero-example-label {
+    align-self: flex-start;
     color: var(--text-muted);
-    font-family: var(--font-mono);
-    font-size: var(--font-size-xs);
-    text-transform: lowercase;
+    font-size: var(--font-size-sm);
+  }
+
+  .workspace-zero-inline-action :global(.workspace-zero-create-button:disabled) {
+    cursor: default;
+    opacity: 0.72;
+  }
+
+  .workspace-zero-example-empty {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+    line-height: 1.45;
+  }
+
+  .workspace-zero-example :global(.workspace-home) {
+    width: 100%;
+    height: auto;
+    padding: 0;
+    overflow: visible;
+    background: transparent;
   }
 
   @media (max-width: 760px) {
     .workspace-zero-state {
-      grid-template-columns: 1fr;
       padding: 28px 18px;
+      max-width: none;
+    }
+
+    .workspace-zero-example-card {
+      min-width: 0;
+      width: 100%;
     }
   }
 

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { tick, untrack } from "svelte";
   import { pushModalFrame } from "@middleman/ui/stores/keyboard/modal-stack";
+  import SparklesIcon from "@lucide/svelte/icons/sparkles";
+  import TerminalIcon from "@lucide/svelte/icons/terminal";
   import { navigate } from "../../stores/router.svelte.ts";
   import WorkspaceListSidebar from "./WorkspaceListSidebar.svelte";
   import TerminalPane from "./TerminalPane.svelte";
@@ -201,6 +203,10 @@
   );
   let terminalLayoutWorkspaceId = $state("");
   let terminalLaunching = $state(false);
+  let workspaceListState = $state<{
+    status: "loading" | "retrying" | "loaded";
+    total: number;
+  }>({ status: "loading", total: 0 });
 
   const SIDEBAR_TAB_KEY = "middleman-workspace-sidebar-tab";
   const SIDEBAR_OPEN_KEY = "middleman-workspace-sidebar-open";
@@ -234,6 +240,12 @@
         Math.round(value),
       ),
     );
+  }
+
+  function updateWorkspaceListState(
+    state: { status: "loading" | "retrying" | "loaded"; total: number },
+  ): void {
+    workspaceListState = state;
   }
 
   function readLocalStorage(key: string): string | null {
@@ -2437,9 +2449,50 @@
   {#snippet terminalMainContent()}
     <div class="terminal-main">
       {#if !workspaceId}
-        <div class="state-message">
-          Select a workspace from the sidebar
-        </div>
+        {#if workspaceListState.status === "loaded" && workspaceListState.total === 0}
+          <section class="workspace-zero-state" aria-label="Workspaces empty state">
+            <div class="workspace-zero-copy">
+              <p class="workspace-zero-eyebrow">Workspaces</p>
+              <h2>Create a workspace to run agents on a PR head</h2>
+              <p>
+                Workspaces are git worktrees created from PR or issue
+                heads. Open a PR or issue and choose Create Workspace to
+                check out an isolated branch here.
+              </p>
+              <p>
+                Once it exists, this pane can start agents, local review
+                sessions, or a shell inside that worktree.
+              </p>
+            </div>
+            <div class="disabled-session-preview" aria-label="New session preview">
+              <div class="disabled-session-toolbar">
+                <button type="button" disabled>New session</button>
+              </div>
+              <div class="disabled-session-menu" aria-label="Disabled run configurations">
+                <div class="disabled-session-heading">Run configurations</div>
+                <button type="button" disabled>
+                  <SparklesIcon size="13" strokeWidth="2" aria-hidden="true" />
+                  <span>Codex review agent</span>
+                  <span>agent</span>
+                </button>
+                <button type="button" disabled>
+                  <SparklesIcon size="13" strokeWidth="2" aria-hidden="true" />
+                  <span>Claude review agent</span>
+                  <span>agent</span>
+                </button>
+                <button type="button" disabled>
+                  <TerminalIcon size="13" strokeWidth="2" aria-hidden="true" />
+                  <span>Shell</span>
+                  <span>shell</span>
+                </button>
+              </div>
+            </div>
+          </section>
+        {:else}
+          <div class="state-message">
+            Select a workspace from the sidebar
+          </div>
+        {/if}
       {:else if loadError && !workspace}
         <div class="state-message error">
           <span
@@ -2832,6 +2885,7 @@
           {isSidebarToggleEnabled}
           onCollapseSidebar={onToggleSidebar}
           onOpenItemSidebar={openItemSidebar}
+          onWorkspaceListStateChange={updateWorkspaceListState}
         />
       {/snippet}
       {@render terminalMainContent()}
@@ -3027,6 +3081,131 @@
 
   .state-message.error {
     color: var(--accent-red);
+  }
+
+  .workspace-zero-state {
+    display: grid;
+    grid-template-columns: minmax(260px, 460px) minmax(220px, 320px);
+    align-items: start;
+    justify-content: center;
+    gap: 28px;
+    flex: 1;
+    min-width: 0;
+    overflow: auto;
+    padding: 56px 28px;
+    color: var(--text-primary);
+    background: var(--bg-primary);
+  }
+
+  .workspace-zero-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    min-width: 0;
+  }
+
+  .workspace-zero-eyebrow {
+    margin: 0;
+    color: var(--accent-green);
+    font-size: var(--font-size-xs);
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  .workspace-zero-copy h2 {
+    margin: 0;
+    color: var(--text-primary);
+    font-size: var(--font-size-xl);
+    font-weight: 650;
+    line-height: 1.25;
+  }
+
+  .workspace-zero-copy p {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: var(--font-size-md);
+    line-height: 1.5;
+  }
+
+  .disabled-session-preview {
+    min-width: 0;
+    border: 1px solid var(--border-default);
+    border-radius: 6px;
+    background: var(--bg-surface);
+    box-shadow:
+      0 1px 2px rgba(0, 0, 0, 0.04),
+      0 4px 16px rgba(0, 0, 0, 0.1);
+    opacity: 0.72;
+  }
+
+  .disabled-session-toolbar {
+    display: flex;
+    justify-content: flex-end;
+    padding: 6px;
+    border-bottom: 1px solid var(--border-muted);
+    background: var(--bg-inset);
+  }
+
+  .disabled-session-toolbar button {
+    height: 22px;
+    padding: 0 8px;
+    border: 1px solid var(--border-default);
+    border-radius: 3px;
+    background: var(--bg-surface);
+    color: var(--text-primary);
+    font: inherit;
+    font-size: var(--font-size-sm);
+    font-weight: 600;
+  }
+
+  .disabled-session-menu {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    padding: 4px;
+  }
+
+  .disabled-session-heading {
+    margin-bottom: 3px;
+    padding: 4px 8px 6px;
+    border-bottom: 1px solid var(--border-muted);
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  .disabled-session-menu button {
+    display: grid;
+    grid-template-columns: 16px 1fr auto;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    height: 26px;
+    padding: 0 8px;
+    border: 0;
+    border-radius: 3px;
+    background: transparent;
+    color: var(--text-secondary);
+    font: inherit;
+    font-size: var(--font-size-sm);
+    text-align: left;
+  }
+
+  .disabled-session-menu button span:last-child {
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    font-size: var(--font-size-xs);
+    text-transform: lowercase;
+  }
+
+  @media (max-width: 760px) {
+    .workspace-zero-state {
+      grid-template-columns: 1fr;
+      padding: 28px 18px;
+    }
   }
 
   .error-icon-badge {

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -358,6 +358,55 @@ describe("WorkspaceTerminalView", () => {
     vi.unstubAllGlobals();
   });
 
+  it("explains workspace creation in the main pane when no workspaces exist", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((input: Request | URL | string) => {
+        const url = input instanceof Request ? input.url : String(input);
+        const { pathname } = new URL(url, "http://localhost");
+        if (pathname.endsWith("/api/v1/workspaces")) {
+          return Promise.resolve(Response.json({ workspaces: [] }));
+        }
+        if (pathname.endsWith("/api/v1/snapshot")) {
+          return Promise.resolve(
+            Response.json({
+              hosts: [
+                {
+                  configKey: "local",
+                  diagnostics: [],
+                  id: "local",
+                  kind: "self",
+                  name: "local",
+                  operationAvailability: {},
+                  platform: "darwin",
+                  preferredTransport: "local",
+                  reachable: true,
+                  tmuxSessions: [],
+                },
+              ],
+            }),
+          );
+        }
+        return Promise.resolve(Response.json({}));
+      }),
+    );
+
+    render(WorkspaceTerminalView, {
+      props: {
+        workspaceId: "",
+      },
+    });
+
+    expect(await screen.findByText("Create a workspace to run agents on a PR head")).toBeTruthy();
+    expect(screen.getByText(/choose Create Workspace/i)).toBeTruthy();
+    expect(screen.getByText(/start agents, local review sessions, or a shell/i)).toBeTruthy();
+    expect(screen.getByText("New session")).toBeTruthy();
+    expect(screen.getByText("Run configurations")).toBeTruthy();
+    expect((screen.getByRole("button", { name: /Codex review agent/i }) as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByRole("button", { name: /Claude review agent/i }) as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByRole("button", { name: /Shell/i }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
   it("closes an agent tab immediately when its terminal exits", async () => {
     render(WorkspaceTerminalView, {
       props: {

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -387,6 +387,28 @@ describe("WorkspaceTerminalView", () => {
             }),
           );
         }
+        if (pathname.endsWith("/api/v1/settings")) {
+          return Promise.resolve(
+            Response.json({
+              launch_targets: [
+                {
+                  key: "configured-agent",
+                  label: "Configured Agent",
+                  kind: "agent",
+                  source: "config",
+                  available: true,
+                },
+                {
+                  key: "plain_shell",
+                  label: "Shell",
+                  kind: "plain_shell",
+                  source: "system",
+                  available: true,
+                },
+              ],
+            }),
+          );
+        }
         return Promise.resolve(Response.json({}));
       }),
     );
@@ -398,12 +420,22 @@ describe("WorkspaceTerminalView", () => {
     });
 
     expect(await screen.findByText("Create a workspace to run agents on a PR head")).toBeTruthy();
-    expect(screen.getByText(/choose Create Workspace/i)).toBeTruthy();
-    expect(screen.getByText(/start agents, local review sessions, or a shell/i)).toBeTruthy();
-    expect(screen.getByText("New session")).toBeTruthy();
-    expect(screen.getByText("Run configurations")).toBeTruthy();
-    expect((screen.getByRole("button", { name: /Codex review agent/i }) as HTMLButtonElement).disabled).toBe(true);
-    expect((screen.getByRole("button", { name: /Claude review agent/i }) as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.getByText(/From a PR or issue, use this button/i)).toBeTruthy();
+    const exampleCard = screen.getByLabelText("Workspace workflow example");
+    expect(exampleCard).toBeTruthy();
+    expect(screen.getByText("Example workflow")).toBeTruthy();
+    const createWorkspaceButton = screen.getByRole("button", {
+      name: "Create Workspace",
+    }) as HTMLButtonElement;
+    expect(createWorkspaceButton.disabled).toBe(true);
+    expect(createWorkspaceButton.getAttribute("title")).toContain("launch agents");
+    const capabilityCopy = screen.getByText(/start agents, local review sessions, or a shell/i);
+    const exampleHeading = await screen.findByText("Launch");
+    expect(capabilityCopy.compareDocumentPosition(exampleHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(screen.queryByText("New session")).toBeNull();
+    expect(screen.queryByRole("button", { name: /Codex review agent/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Claude review agent/i })).toBeNull();
+    expect((screen.getByRole("button", { name: /Configured Agent/i }) as HTMLButtonElement).disabled).toBe(true);
     expect((screen.getByRole("button", { name: /Shell/i }) as HTMLButtonElement).disabled).toBe(true);
   });
 

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -419,17 +419,19 @@ describe("WorkspaceTerminalView", () => {
       },
     });
 
-    expect(await screen.findByText("Create a workspace to run agents on a PR head")).toBeTruthy();
-    expect(screen.getByText(/From a PR or issue, use this button/i)).toBeTruthy();
+    expect(await screen.findByText("Create a workspace to run agents from a PR or issue")).toBeTruthy();
+    expect(screen.getByText(/Workspaces are git worktrees created from PR or issue heads\./i)).toBeTruthy();
+    expect(screen.getByText(/From a PR or issue, use the/i)).toBeTruthy();
     const exampleCard = screen.getByLabelText("Workspace workflow example");
     expect(exampleCard).toBeTruthy();
-    expect(screen.getByText("Example workflow")).toBeTruthy();
+    expect(screen.queryByText("Example workflow")).toBeNull();
     const createWorkspaceButton = screen.getByRole("button", {
       name: "Create Workspace",
     }) as HTMLButtonElement;
     expect(createWorkspaceButton.disabled).toBe(true);
     expect(createWorkspaceButton.getAttribute("title")).toContain("launch agents");
     const capabilityCopy = screen.getByText(/start agents, local review sessions, or a shell/i);
+    expect(screen.getByText("You can then launch configured agents via the buttons provided")).toBeTruthy();
     const exampleHeading = await screen.findByText("Launch");
     expect(capabilityCopy.compareDocumentPosition(exampleHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(screen.queryByText("New session")).toBeNull();

--- a/frontend/tests/e2e-full/00-workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e-full/00-workspace-sidebar.spec.ts
@@ -121,6 +121,59 @@ test.describe("workspace sidebar full-stack", () => {
     }
   });
 
+  test("empty Workspaces pane explains creation and renders launch targets from settings", async ({ page }) => {
+    let isolatedServer: IsolatedE2EServer | null = null;
+    let api: APIRequestContext | null = null;
+    try {
+      isolatedServer = await startIsolatedWorkspaceE2EServer();
+      api = await playwrightRequest.newContext({
+        baseURL: isolatedServer.info.base_url,
+      });
+
+      const seedResponse = await api.put("/api/v1/settings", {
+        data: {
+          agents: [
+            {
+              key: "e2e-agent",
+              label: "E2E Agent",
+              command: ["/bin/sh", "-lc", "true"],
+              enabled: true,
+            },
+          ],
+        },
+      });
+      const seedBody = await seedResponse.text();
+      expect(seedResponse.status(), `PUT /api/v1/settings failed: ${seedBody}`).toBe(200);
+
+      await page.goto(`${isolatedServer.info.base_url}/workspaces`);
+
+      await expect(
+        page.getByRole("heading", {
+          name: "Create a workspace to run agents from a PR or issue",
+        }),
+      ).toBeVisible();
+      await expect(page.getByText("Workspaces are git worktrees created from PR or issue heads.")).toBeVisible();
+      await expect(page.getByText(/From a PR or issue, use the/)).toBeVisible();
+      await expect(page.getByRole("button", { name: "Create Workspace" })).toBeDisabled();
+      await expect(page.getByText("No workspaces yet.")).toBeVisible();
+
+      const launchSurface = page.getByLabel("Launch surface example");
+      await expect(
+        launchSurface.getByText("You can then launch configured agents via the buttons provided"),
+      ).toBeVisible();
+      await expect(launchSurface.getByText("Launch", { exact: true })).toBeVisible();
+      await expect(launchSurface.getByRole("button", { name: "E2E Agent" })).toBeDisabled();
+      await expect(launchSurface.getByRole("button", { name: "Shell" })).toBeDisabled();
+
+      const iconColor = await launchSurface.locator(".section-icon").evaluate((node) => getComputedStyle(node).color);
+      const sectionColor = await launchSurface.locator(".section-bar").evaluate((node) => getComputedStyle(node).color);
+      expect(iconColor).toBe(sectionColor);
+    } finally {
+      await api?.dispose();
+      await isolatedServer?.stop();
+    }
+  });
+
   test("shows provider icons in group headers when workspaces span multiple providers", async ({ page }) => {
     let isolatedServer: IsolatedE2EServer | null = null;
     let api: APIRequestContext | null = null;

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -2620,6 +2620,7 @@ type SettingsResponse struct {
 	Activity      Activity                      `json:"activity"`
 	Agents        []Agent                       `json:"agents"`
 	Fleet         FleetSettingsResponse         `json:"fleet"`
+	LaunchTargets *[]LaunchTarget               `json:"launch_targets,omitempty"`
 	Modes         *ModeVisibility               `json:"modes,omitempty"`
 	Notifications NotificationsSettingsResponse `json:"notifications"`
 	Repos         []ConfiguredRepoStatus        `json:"repos"`

--- a/internal/server/e2etest/settings_test.go
+++ b/internal/server/e2etest/settings_test.go
@@ -73,6 +73,15 @@ func TestSettingsAPIE2EReadUpdateAndValidation(t *testing.T) {
 	assert.Equal("acme", settings.Repos[0].Owner)
 	assert.Equal(generated.Threaded, settings.Activity.ViewMode)
 	assert.True(settings.Activity.CollapseThreads)
+	require.NotNil(settings.LaunchTargets)
+	assert.NotEmpty(*settings.LaunchTargets)
+	plainShellTarget := findSettingsLaunchTarget(
+		t, *settings.LaunchTargets, "plain_shell",
+	)
+	assert.Equal("Shell", plainShellTarget.Label)
+	assert.Equal("plain_shell", plainShellTarget.Kind)
+	assert.Equal("system", plainShellTarget.Source)
+	assert.True(plainShellTarget.Available)
 
 	invalidResp := doServerJSON(
 		t, ts.Client(), http.MethodPut,
@@ -148,6 +157,21 @@ func TestSettingsAPIE2EReadUpdateAndValidation(t *testing.T) {
 	require.NoError(json.NewDecoder(reGetResp.Body).Decode(&reGet))
 	assert.True(reGet.Activity.CollapseThreads)
 	assert.True(reGet.Terminal.HideTmuxStatus)
+}
+
+func findSettingsLaunchTarget(
+	t *testing.T,
+	targets []generated.LaunchTarget,
+	key string,
+) generated.LaunchTarget {
+	t.Helper()
+	for _, target := range targets {
+		if target.Key == key {
+			return target
+		}
+	}
+	require.Failf(t, "target not found", "key %q", key)
+	return generated.LaunchTarget{}
 }
 
 func TestSettingsAPIE2EHideTmuxStatusUpdateAffectsRuntimeSessions(t *testing.T) {

--- a/internal/server/settings_handlers.go
+++ b/internal/server/settings_handlers.go
@@ -24,6 +24,7 @@ type settingsResponse struct {
 	Terminal      config.Terminal                 `json:"terminal"`
 	Modes         config.ModeVisibility           `json:"modes,omitzero"`
 	Agents        []config.Agent                  `json:"agents" nullable:"false"`
+	LaunchTargets []localruntime.LaunchTarget     `json:"launch_targets,omitempty"`
 	Fleet         fleetSettingsResponse           `json:"fleet"`
 }
 
@@ -65,8 +66,13 @@ func (s *Server) buildLocalSettingsResponse() settingsResponse {
 	terminal := s.cfg.Terminal
 	modes := cloneModeVisibility(s.cfg.Modes).WithDefaults()
 	agents := cloneConfigAgents(s.cfg.Agents)
+	tmuxCommand := s.cfg.TmuxCommand()
 	fleetSettings := s.buildFleetSettingsResponseLocked()
 	s.cfgMu.Unlock()
+	launchTargets := localruntime.ResolveLaunchTargets(agents, tmuxCommand, nil)
+	if launchTargets == nil {
+		launchTargets = []localruntime.LaunchTarget{}
+	}
 
 	tracked := s.syncer.TrackedRepos()
 	configured := make(
@@ -85,14 +91,15 @@ func (s *Server) buildLocalSettingsResponse() settingsResponse {
 		}
 	}
 	return settingsResponse{
-		Repos:         configured,
-		Activity:      activity,
+		Repos:    configured,
+		Activity: activity,
 		// Notifications are a built-in capability with no enable/disable
 		// setting; report them as always available.
 		Notifications: notificationsSettingsResponse{Enabled: true},
 		Terminal:      terminal,
 		Modes:         modes,
 		Agents:        agents,
+		LaunchTargets: launchTargets,
 		Fleet:         fleetSettings,
 	}
 }

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -6397,6 +6397,7 @@ export interface components {
             activity: components["schemas"]["Activity"];
             agents: components["schemas"]["Agent"][];
             fleet: components["schemas"]["FleetSettingsResponse"];
+            launch_targets?: components["schemas"]["LaunchTarget"][] | null;
             modes?: components["schemas"]["ModeVisibility"];
             notifications: components["schemas"]["NotificationsSettingsResponse"];
             repos: components["schemas"]["ConfiguredRepoStatus"][];

--- a/packages/ui/src/components/detail/IssueDetail.svelte
+++ b/packages/ui/src/components/detail/IssueDetail.svelte
@@ -451,6 +451,8 @@
   let workspaceError = $state<string | null>(null);
   const createWorkspaceTitle =
     "Create an issue worktree, then open Workspaces to launch agents or shells on that branch.";
+  const createWorkspaceDescriptionId =
+    "issue-create-workspace-description";
   const ISSUE_WORKSPACE_BRANCH_CONFLICT_TYPE =
     "urn:middleman:error:issue-workspace-branch-conflict";
 
@@ -1053,11 +1055,19 @@
             title={staleIssue
               ? "Refresh details before creating a workspace."
               : createWorkspaceTitle}
+            ariaDescribedby={createWorkspaceDescriptionId}
             label={workspaceCreating ? "Creating..." : "Create Workspace"}
             shortLabel={workspaceCreating ? "Creating..." : "Create Workspace"}
           >
             <PackagePlusIcon size="14" strokeWidth="2.2" aria-hidden="true" />
           </ActionButton>
+        {/if}
+        {#if !workspace}
+          <span id={createWorkspaceDescriptionId} class="sr-only">
+            {staleIssue
+              ? "Refresh details before creating a workspace."
+              : createWorkspaceTitle}
+          </span>
         {/if}
         {#if issue.State === "open" && capabilities.state_mutation}
           {@const closeGate = operationGate(repoOperations?.close_issue)}
@@ -1320,6 +1330,18 @@
 
   .state-msg--error {
     color: var(--accent-red);
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 
   .issue-detail {

--- a/packages/ui/src/components/detail/IssueDetail.svelte
+++ b/packages/ui/src/components/detail/IssueDetail.svelte
@@ -449,6 +449,8 @@
 
   let workspaceCreating = $state(false);
   let workspaceError = $state<string | null>(null);
+  const createWorkspaceTitle =
+    "Create an issue worktree, then open Workspaces to launch agents or shells on that branch.";
   const ISSUE_WORKSPACE_BRANCH_CONFLICT_TYPE =
     "urn:middleman:error:issue-workspace-branch-conflict";
 
@@ -1048,6 +1050,9 @@
             tone="info"
             surface="soft"
             size="sm"
+            title={staleIssue
+              ? "Refresh details before creating a workspace."
+              : createWorkspaceTitle}
             label={workspaceCreating ? "Creating..." : "Create Workspace"}
             shortLabel={workspaceCreating ? "Creating..." : "Create Workspace"}
           >

--- a/packages/ui/src/components/detail/IssueDetail.test.ts
+++ b/packages/ui/src/components/detail/IssueDetail.test.ts
@@ -193,5 +193,8 @@ describe("IssueDetail activity view", () => {
     expect(button.getAttribute("title")).toContain("issue worktree");
     expect(button.getAttribute("title")).toContain("launch agents");
     expect(button.getAttribute("title")).toContain("shells");
+    const descriptionId = button.getAttribute("aria-describedby");
+    expect(descriptionId).toBeTruthy();
+    expect(document.getElementById(descriptionId ?? "")?.textContent).toContain(button.getAttribute("title"));
   });
 });

--- a/packages/ui/src/components/detail/IssueDetail.test.ts
+++ b/packages/ui/src/components/detail/IssueDetail.test.ts
@@ -185,4 +185,13 @@ describe("IssueDetail activity view", () => {
     expect(container.querySelectorAll(".event-card--compact-row")).toHaveLength(1);
     expect(container.textContent).toContain("Issue activity preview");
   });
+
+  it("explains that creating a workspace enables agent sessions", () => {
+    renderIssueDetail(issueDetail());
+
+    const button = screen.getByRole("button", { name: "Create Workspace" });
+    expect(button.getAttribute("title")).toContain("issue worktree");
+    expect(button.getAttribute("title")).toContain("launch agents");
+    expect(button.getAttribute("title")).toContain("shells");
+  });
 });

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -885,6 +885,8 @@
   let wsError = $state<string | null>(null);
   const createWorkspaceTitle =
     "Create a PR head worktree, then open Workspaces to launch agents, shells, or local review sessions on that branch.";
+  const createWorkspaceDescriptionId =
+    "pull-create-workspace-description";
   let actionMenuOpen = $state(false);
   let actionMenuWrapEl = $state<HTMLDivElement>();
   let stateMenuOpen = $state(false);
@@ -1988,6 +1990,7 @@
             title={stalePR
               ? "Refresh details before creating a workspace."
               : createWorkspaceTitle}
+            ariaDescribedby={createWorkspaceDescriptionId}
             label={wsCreating ? "Creating..." : "Create Workspace"}
             shortLabel={wsCreating ? "Creating..." : "Create Workspace"}
           >
@@ -1997,6 +2000,11 @@
       {/snippet}
 
       <!-- Approve / Merge / Close / Reopen actions -->
+      {#if !workspace}
+        <span id={createWorkspaceDescriptionId} class="sr-only">
+          {stalePR ? "Refresh details before creating a workspace." : createWorkspaceTitle}
+        </span>
+      {/if}
       {#if pr.State !== "merged" && !stalePR}
         <div class="primary-actions-wrap">
           <div class="actions-row actions-row--primary">
@@ -2906,6 +2914,18 @@
   .action-error--workspace-compact {
     display: block;
     margin-top: 6px;
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 
   .section {

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -883,6 +883,8 @@
   const workspace = $derived(detailStore.getDetail()?.workspace);
   let wsCreating = $state(false);
   let wsError = $state<string | null>(null);
+  const createWorkspaceTitle =
+    "Create a PR head worktree, then open Workspaces to launch agents, shells, or local review sessions on that branch.";
   let actionMenuOpen = $state(false);
   let actionMenuWrapEl = $state<HTMLDivElement>();
   let stateMenuOpen = $state(false);
@@ -1983,6 +1985,9 @@
             tone="info"
             surface="soft"
             size="sm"
+            title={stalePR
+              ? "Refresh details before creating a workspace."
+              : createWorkspaceTitle}
             label={wsCreating ? "Creating..." : "Create Workspace"}
             shortLabel={wsCreating ? "Creating..." : "Create Workspace"}
           >

--- a/packages/ui/src/components/detail/PullDetail.test.ts
+++ b/packages/ui/src/components/detail/PullDetail.test.ts
@@ -231,6 +231,9 @@ describe("PullDetail approvals", () => {
       expect(button.getAttribute("title")).toContain("PR head worktree");
       expect(button.getAttribute("title")).toContain("launch agents");
       expect(button.getAttribute("title")).toContain("local review sessions");
+      const descriptionId = button.getAttribute("aria-describedby");
+      expect(descriptionId).toBeTruthy();
+      expect(document.getElementById(descriptionId ?? "")?.textContent).toContain(button.getAttribute("title"));
     }
   });
 

--- a/packages/ui/src/components/detail/PullDetail.test.ts
+++ b/packages/ui/src/components/detail/PullDetail.test.ts
@@ -137,6 +137,9 @@ function renderPullDetail(
       data: {},
     })),
   },
+  options = {
+    hideWorkspaceAction: true,
+  },
 ) {
   const detailStore = {
     loadDetail: vi.fn(async () => undefined),
@@ -163,7 +166,7 @@ function renderPullDetail(
       provider: "github",
       platformHost: "github.com",
       repoPath: "acme/widget",
-      hideWorkspaceAction: true,
+      hideWorkspaceAction: options.hideWorkspaceAction,
     },
     context: new Map<symbol, unknown>([
       [API_CLIENT_KEY, apiClient],
@@ -217,6 +220,18 @@ describe("PullDetail approvals", () => {
     await fireEvent.mouseDown(document.body);
 
     expect(document.querySelector(".approval-popup")).toBeNull();
+  });
+
+  it("explains that creating a workspace enables agent sessions", () => {
+    renderPullDetail(pullDetail(), undefined, undefined, { hideWorkspaceAction: false });
+
+    const buttons = screen.getAllByRole("button", { name: "Create Workspace" });
+    expect(buttons.length).toBeGreaterThan(0);
+    for (const button of buttons) {
+      expect(button.getAttribute("title")).toContain("PR head worktree");
+      expect(button.getAttribute("title")).toContain("launch agents");
+      expect(button.getAttribute("title")).toContain("local review sessions");
+    }
   });
 
   it("normalizes backend review decision casing before enabling approver popup", async () => {

--- a/packages/ui/src/components/shared/ActionButton.svelte
+++ b/packages/ui/src/components/shared/ActionButton.svelte
@@ -13,6 +13,7 @@
     disabled?: boolean;
     title?: string | undefined;
     ariaLabel?: string | undefined;
+    ariaDescribedby?: string | undefined;
     label?: string;
     shortLabel?: string;
     ariaExpanded?: boolean;
@@ -30,6 +31,7 @@
     disabled = false,
     title = undefined,
     ariaLabel = undefined,
+    ariaDescribedby = undefined,
     label = undefined,
     shortLabel = undefined,
     ariaExpanded = undefined,
@@ -57,6 +59,7 @@
   {title}
   aria-expanded={ariaExpanded}
   aria-label={ariaLabel ?? (label && shortLabel ? label : undefined)}
+  aria-describedby={ariaDescribedby}
   onclick={onclick}
 >
   {#if children}

--- a/scripts/context-sync
+++ b/scripts/context-sync
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+usage: scripts/context-sync --check
+
+Run the repo-local context-sync preflight used by stop hooks. The automated
+check validates that routed context docs referenced by CLAUDE.md still exist
+and that AGENTS.md resolves to CLAUDE.md.
+USAGE
+}
+
+root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+mode="${1:-}"
+
+if [ "$mode" != "--check" ]; then
+  usage
+  exit 64
+fi
+
+status=0
+
+require_file() {
+  local path="$1"
+  if [ ! -f "$root/$path" ]; then
+    printf 'context-sync: missing required file: %s\n' "$path" >&2
+    status=1
+  fi
+}
+
+require_file "CLAUDE.md"
+require_file "AGENTS.md"
+require_file "skills/context-sync/SKILL.md"
+
+if [ -e "$root/AGENTS.md" ] && [ "$(cd "$root" && realpath AGENTS.md)" != "$(cd "$root" && realpath CLAUDE.md)" ]; then
+  printf 'context-sync: AGENTS.md does not resolve to CLAUDE.md\n' >&2
+  status=1
+fi
+
+if [ -f "$root/CLAUDE.md" ]; then
+  while IFS= read -r ref; do
+    [ -n "$ref" ] || continue
+    if [ ! -f "$root/$ref" ]; then
+      printf 'context-sync: CLAUDE.md references missing context file: %s\n' "$ref" >&2
+      status=1
+    fi
+  done < <(
+    grep -Eo '(context|docs)/[A-Za-z0-9._/-]+\.md' "$root/CLAUDE.md" |
+      sort -u
+  )
+fi
+
+if [ "$status" -eq 0 ]; then
+  echo "context-sync: check passed"
+else
+  echo "context-sync: check failed" >&2
+fi
+
+exit "$status"

--- a/scripts/hooks/context-sync-stop.sh
+++ b/scripts/hooks/context-sync-stop.sh
@@ -6,7 +6,7 @@ usage() {
 usage: context-sync-stop.sh stop|mark|status
 
 stop    Enforce that context-sync has checked the current worktree state.
-mark    Record the current worktree state after context-sync --check or sync.
+mark    Record the current worktree state after scripts/context-sync --check or sync.
 status  Print whether the current worktree state is marked.
 USAGE
 }
@@ -76,7 +76,7 @@ require_marked() {
 middleman context-sync is required before this turn can complete.
 
 Run:
-  context-sync --check
+  scripts/context-sync --check
   scripts/hooks/context-sync-stop.sh mark
 
 If context-sync reports drift, address it or report the findings before marking.

--- a/skills/context-sync/SKILL.md
+++ b/skills/context-sync/SKILL.md
@@ -23,11 +23,11 @@ single-surface context layout: root `CLAUDE.md` routes to flat `context/*.md` to
 
 This repo installs Claude Code and Codex `Stop` hooks that require context-sync to check
 the current worktree state before a turn completes. When a Stop hook asks for context
-sync, run `context-sync --check` first. If it reports drift, address the drift or report
-the findings before marking the state as checked.
+sync, run `scripts/context-sync --check` first. If it reports drift, address the drift
+or report the findings before marking the state as checked.
 
-After any successful `context-sync --check` or full context-sync run, mark the current
-worktree state:
+After any successful `scripts/context-sync --check` or full context-sync run, mark the
+current worktree state:
 
 ```bash
 scripts/hooks/context-sync-stop.sh mark


### PR DESCRIPTION
The empty Workspaces view should teach the actual create-then-launch workflow instead of showing generic selection copy or fabricated launch controls. This PR makes the main pane explain that workspaces are PR or issue worktrees, shows the real disabled launch surface populated from configured/detected targets, and keeps the Create Workspace action inline with the prose users will see before they have any workspaces.

It also makes the Create Workspace hover guidance available through accessible descriptions in PR and issue detail views, and adds a repo-local context-sync entry point so the stop hook no longer depends on a missing global command.

Validated locally with targeted frontend unit coverage, settings server e2e coverage, the full-stack empty Workspaces Playwright case, frontend package checks, roborev fix closure, and the repo-local context-sync check.

Screenshot:

![workspaces-empty-onboarding-pr575.png](https://github.com/user-attachments/assets/4b0e2b52-b831-4f1b-b36e-cf29919c92df)

<sup>generated by a clanker</sup>