### PR TITLE
fix: start notification loops immediately

### DIFF
--- a/cmd/middleman/notifications.go
+++ b/cmd/middleman/notifications.go
@@ -58,6 +58,19 @@ func newNotificationLoopHandle(parent context.Context) *notificationLoopHandle {
 func (h *notificationLoopHandle) startTicker(name string, interval time.Duration, run func(context.Context) error) {
 	h.wg.Go(func() {
 		ctx := h.ctx
+		runOnce := func() {
+			if err := run(ctx); err != nil && ctx.Err() == nil {
+				slog.Warn(name+" failed", "err", err)
+			}
+		}
+		if ctx.Err() != nil {
+			return
+		}
+		runOnce()
+		if ctx.Err() != nil {
+			return
+		}
+
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 		for {
@@ -65,9 +78,7 @@ func (h *notificationLoopHandle) startTicker(name string, interval time.Duration
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				if err := run(ctx); err != nil && ctx.Err() == nil {
-					slog.Warn(name+" failed", "err", err)
-				}
+				runOnce()
 			}
 		}
 	})

--- a/cmd/middleman/notifications_test.go
+++ b/cmd/middleman/notifications_test.go
@@ -58,6 +58,29 @@ func TestNotificationLoopStopWaitsForInFlightRun(t *testing.T) {
 	}
 }
 
+func TestNotificationLoopRunsBeforeFirstTickerInterval(t *testing.T) {
+	parent, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	handle := newNotificationLoopHandle(parent)
+	defer handle.Stop()
+
+	started := make(chan struct{})
+	var startedOnce sync.Once
+	handle.startTicker("test notification", time.Hour, func(runCtx context.Context) error {
+		startedOnce.Do(func() { close(started) })
+		return nil
+	})
+
+	require.Eventually(t, func() bool {
+		select {
+		case <-started:
+			return true
+		default:
+			return false
+		}
+	}, 200*time.Millisecond, 10*time.Millisecond, "notification loop should run before first ticker interval")
+}
+
 func TestNotificationLoopSettingsSnapshotConfig(t *testing.T) {
 	require := require.New(t)
 	cfg := &config.Config{}

--- a/tools/devephemeral/main.go
+++ b/tools/devephemeral/main.go
@@ -35,6 +35,8 @@ const (
 	stopWaitGrace      = 500 * time.Millisecond
 )
 
+var errEphemeralWorkDirLocked = errors.New("ephemeral work directory is locked")
+
 type ephemeralOptions struct {
 	sourceConfigPath string
 	workDir          string
@@ -145,6 +147,18 @@ func run(ctx context.Context, args []string) error {
 
 	releaseLock, err := lockEphemeralWorkDir(resolvedWorkDir)
 	if err != nil {
+		if errors.Is(err, errEphemeralWorkDirLocked) {
+			existingStatusPath := statusPathForWorkDir(resolvedWorkDir)
+			existingStatus, running, statusErr := readLiveEphemeralStatus(existingStatusPath)
+			if statusErr != nil {
+				return errors.Join(err, statusErr)
+			}
+			if running {
+				fmt.Printf("ephemeral dev stack already running\n")
+				printStatus(existingStatus, existingStatusPath)
+				return nil
+			}
+		}
 		return err
 	}
 	locked := true
@@ -416,7 +430,7 @@ func lockEphemeralWorkDir(workDir string) (func() error, error) {
 	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
 		_ = file.Close()
 		if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
-			return nil, fmt.Errorf("ephemeral work directory is locked: %s", workDir)
+			return nil, fmt.Errorf("%w: %s", errEphemeralWorkDirLocked, workDir)
 		}
 		return nil, fmt.Errorf("lock ephemeral work directory: %w", err)
 	}
@@ -453,6 +467,37 @@ func stopEphemeralStack(statusPath string) error {
 }
 
 func readRunningEphemeralStatus(statusPath string) (ephemeralStatus, bool, error) {
+	status, running, err := readLiveEphemeralStatus(statusPath)
+	if err != nil {
+		return ephemeralStatus{}, false, err
+	}
+	if running {
+		return status, true, nil
+	}
+
+	content, err := os.ReadFile(statusPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return ephemeralStatus{}, false, nil
+		}
+		return ephemeralStatus{}, false, fmt.Errorf("read status file: %w", err)
+	}
+	var staleStatus ephemeralStatus
+	if err := json.Unmarshal(content, &staleStatus); err != nil {
+		return ephemeralStatus{}, false, fmt.Errorf("decode status file: %w", err)
+	}
+	refs, identityErrs := verifiedProcessRefs(statusProcessRefs(staleStatus))
+	stopErrs := append(identityErrs, stopEphemeralProcesses(refs)...)
+	if len(stopErrs) > 0 {
+		return ephemeralStatus{}, false, errors.Join(stopErrs...)
+	}
+	if err := os.Remove(statusPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return ephemeralStatus{}, false, fmt.Errorf("remove stale status file: %w", err)
+	}
+	return ephemeralStatus{}, false, nil
+}
+
+func readLiveEphemeralStatus(statusPath string) (ephemeralStatus, bool, error) {
 	content, err := os.ReadFile(statusPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -470,14 +515,6 @@ func readRunningEphemeralStatus(statusPath string) (ephemeralStatus, bool, error
 	}
 	if running {
 		return status, true, nil
-	}
-	refs, identityErrs := verifiedProcessRefs(statusProcessRefs(status))
-	stopErrs := append(identityErrs, stopEphemeralProcesses(refs)...)
-	if len(stopErrs) > 0 {
-		return ephemeralStatus{}, false, errors.Join(stopErrs...)
-	}
-	if err := os.Remove(statusPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return ephemeralStatus{}, false, fmt.Errorf("remove stale status file: %w", err)
 	}
 	return ephemeralStatus{}, false, nil
 }

--- a/tools/devephemeral/main.go
+++ b/tools/devephemeral/main.go
@@ -147,19 +147,13 @@ func run(ctx context.Context, args []string) error {
 
 	releaseLock, err := lockEphemeralWorkDir(resolvedWorkDir)
 	if err != nil {
-		if errors.Is(err, errEphemeralWorkDirLocked) {
-			existingStatusPath := statusPathForWorkDir(resolvedWorkDir)
-			existingStatus, running, statusErr := readLiveEphemeralStatus(existingStatusPath)
-			if statusErr != nil {
-				return errors.Join(err, statusErr)
-			}
-			if running {
-				fmt.Printf("ephemeral dev stack already running\n")
-				printStatus(existingStatus, existingStatusPath)
-				return nil
-			}
+		if !errors.Is(err, errEphemeralWorkDirLocked) {
+			return err
 		}
-		return err
+		releaseLock, err = waitForEphemeralWorkDirLock(ctx, resolvedWorkDir)
+		if err != nil {
+			return err
+		}
 	}
 	locked := true
 	defer func() {
@@ -391,9 +385,33 @@ func writeStatusFile(path string, status ephemeralStatus) error {
 		return fmt.Errorf("encode status: %w", err)
 	}
 	content = append(content, '\n')
-	if err := os.WriteFile(path, content, 0o644); err != nil {
+
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".dev-ephemeral-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temporary status file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	removeTmp := true
+	defer func() {
+		if removeTmp {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if _, err := tmp.Write(content); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temporary status file: %w", err)
+	}
+	if err := tmp.Chmod(0o644); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod temporary status file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temporary status file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
 		return fmt.Errorf("write status file: %w", err)
 	}
+	removeTmp = false
 	return nil
 }
 
@@ -439,6 +457,30 @@ func lockEphemeralWorkDir(workDir string) (func() error, error) {
 		closeErr := file.Close()
 		return errors.Join(unlockErr, closeErr)
 	}, nil
+}
+
+func waitForEphemeralWorkDirLock(ctx context.Context, workDir string) (func() error, error) {
+	for {
+		release, err := lockEphemeralWorkDir(workDir)
+		if err == nil {
+			return release, nil
+		}
+		if !errors.Is(err, errEphemeralWorkDirLocked) {
+			return nil, err
+		}
+		timer := time.NewTimer(stopPollInterval)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
 }
 
 func stopEphemeralStack(statusPath string) error {

--- a/tools/devephemeral/main_test.go
+++ b/tools/devephemeral/main_test.go
@@ -389,7 +389,7 @@ func TestLockEphemeralWorkDirRejectsConcurrentLock(t *testing.T) {
 	require.NoError(release())
 }
 
-func TestRunReusesLiveStatusWhenStartupLockIsStillHeld(t *testing.T) {
+func TestRunWaitsForWorkDirLockBeforeReusingLiveStatus(t *testing.T) {
 	require := require.New(t)
 	dir := t.TempDir()
 	statusPath := filepath.Join(dir, "dev-ephemeral.json")
@@ -405,7 +405,12 @@ func TestRunReusesLiveStatusWhenStartupLockIsStillHeld(t *testing.T) {
 	require.NoError(err)
 	release, err := lockEphemeralWorkDir(dir)
 	require.NoError(err)
-	t.Cleanup(func() { require.NoError(release()) })
+	lockReleased := false
+	t.Cleanup(func() {
+		if !lockReleased {
+			require.NoError(release())
+		}
+	})
 	require.NoError(writeStatusFile(statusPath, ephemeralStatus{
 		PID:               os.Getpid(),
 		PIDStartedAt:      launcherStartedAt,
@@ -417,8 +422,123 @@ func TestRunReusesLiveStatusWhenStartupLockIsStillHeld(t *testing.T) {
 		FrontendURL:       "http://127.0.0.1:39412",
 	}))
 
-	err = run(context.Background(), []string{"-work-dir", dir})
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- run(context.Background(), []string{"-work-dir", dir})
+	}()
+	select {
+	case err := <-errCh:
+		require.Failf("run returned while the workdir lock was held", "err: %v", err)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	require.NoError(release())
+	lockReleased = true
+	select {
+	case err := <-errCh:
+		require.NoError(err)
+	case <-time.After(5 * time.Second):
+		require.Fail("timed out waiting for run to reuse live status after lock release")
+	}
+}
+
+func TestRunWaitsForStopLockBeforeStartingReplacementStack(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.toml")
+	sourceDataDir := filepath.Join(dir, "source-data")
+	workDir := filepath.Join(dir, "run")
+	statusPath := filepath.Join(workDir, "dev-ephemeral.json")
+
+	source := config.Config{
+		SyncInterval:        "5m",
+		GitHubTokenEnv:      "MIDDLEMAN_GITHUB_TOKEN",
+		DefaultPlatformHost: "github.com",
+		Host:                "127.0.0.1",
+		Port:                8091,
+		DataDir:             sourceDataDir,
+		Activity:            config.Activity{ViewMode: "threaded", TimeRange: "7d"},
+	}
+	require.NoError(os.MkdirAll(sourceDataDir, 0o700))
+	require.NoError(source.Save(sourcePath))
+
+	commandDir := filepath.Join(dir, "commands")
+	writeBlockingScript(t, filepath.Join(commandDir, "scripts", "dev-stack-backend.sh"))
+	writeBlockingScript(t, filepath.Join(commandDir, "scripts", "frontend-dev.sh"))
+
+	oldScriptPath := filepath.Join(dir, "old-stack.sh")
+	writeBlockingScript(t, oldScriptPath)
+	oldLauncher, _ := startTestCommand(t, commandSpec{name: oldScriptPath})
+	oldBackend, _ := startTestCommand(t, commandSpec{name: oldScriptPath})
+	oldFrontend, _ := startTestCommand(t, commandSpec{name: oldScriptPath})
+	oldLauncherStartedAt, err := processStartTime(oldLauncher.Process.Pid)
 	require.NoError(err)
+	oldBackendStartedAt, err := processStartTime(oldBackend.Process.Pid)
+	require.NoError(err)
+	oldFrontendStartedAt, err := processStartTime(oldFrontend.Process.Pid)
+	require.NoError(err)
+	require.NoError(writeStatusFile(statusPath, ephemeralStatus{
+		PID:               oldLauncher.Process.Pid,
+		PIDStartedAt:      oldLauncherStartedAt,
+		BackendPID:        oldBackend.Process.Pid,
+		BackendStartedAt:  oldBackendStartedAt,
+		FrontendPID:       oldFrontend.Process.Pid,
+		FrontendStartedAt: oldFrontendStartedAt,
+		BackendURL:        "http://127.0.0.1:39411",
+		FrontendURL:       "http://127.0.0.1:39412",
+	}))
+
+	release, err := lockEphemeralWorkDir(workDir)
+	require.NoError(err)
+	lockReleased := false
+	t.Cleanup(func() {
+		if !lockReleased {
+			require.NoError(release())
+		}
+	})
+
+	oldDir, err := os.Getwd()
+	require.NoError(err)
+	require.NoError(os.Chdir(commandDir))
+	t.Cleanup(func() {
+		require.NoError(os.Chdir(oldDir))
+	})
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- run(context.Background(), []string{
+			"-config", sourcePath,
+			"-work-dir", workDir,
+			"-backend-port", "39511",
+			"-frontend-port", "39512",
+		})
+	}()
+	select {
+	case err := <-errCh:
+		require.Failf("run returned while stop held the workdir lock", "err: %v", err)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	require.NoError(stopEphemeralStack(statusPath))
+	require.NoError(release())
+	lockReleased = true
+
+	status := waitForStatusFile(t, statusPath)
+	assert.NotEqual(oldBackend.Process.Pid, status.BackendPID)
+	assert.NotEqual(oldFrontend.Process.Pid, status.FrontendPID)
+	assert.Equal("http://127.0.0.1:39511", status.BackendURL)
+	assert.Equal("http://127.0.0.1:39512", status.FrontendURL)
+
+	status.PID = 0
+	require.NoError(writeStatusFile(statusPath, status))
+	require.NoError(stopEphemeralStack(statusPath))
+	select {
+	case err := <-errCh:
+		require.NoError(err)
+	case <-time.After(5 * time.Second):
+		require.Fail("timed out waiting for replacement dev-ephemeral run to stop")
+	}
 }
 
 func TestReadRunningEphemeralStatusReturnsLiveStatus(t *testing.T) {

--- a/tools/devephemeral/main_test.go
+++ b/tools/devephemeral/main_test.go
@@ -389,6 +389,38 @@ func TestLockEphemeralWorkDirRejectsConcurrentLock(t *testing.T) {
 	require.NoError(release())
 }
 
+func TestRunReusesLiveStatusWhenStartupLockIsStillHeld(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+	statusPath := filepath.Join(dir, "dev-ephemeral.json")
+	scriptPath := filepath.Join(dir, "blocking.sh")
+	writeBlockingScript(t, scriptPath)
+	backend, _ := startTestCommand(t, commandSpec{name: scriptPath})
+	frontend, _ := startTestCommand(t, commandSpec{name: scriptPath})
+	launcherStartedAt, err := processStartTime(os.Getpid())
+	require.NoError(err)
+	backendStartedAt, err := processStartTime(backend.Process.Pid)
+	require.NoError(err)
+	frontendStartedAt, err := processStartTime(frontend.Process.Pid)
+	require.NoError(err)
+	release, err := lockEphemeralWorkDir(dir)
+	require.NoError(err)
+	t.Cleanup(func() { require.NoError(release()) })
+	require.NoError(writeStatusFile(statusPath, ephemeralStatus{
+		PID:               os.Getpid(),
+		PIDStartedAt:      launcherStartedAt,
+		BackendPID:        backend.Process.Pid,
+		BackendStartedAt:  backendStartedAt,
+		FrontendPID:       frontend.Process.Pid,
+		FrontendStartedAt: frontendStartedAt,
+		BackendURL:        "http://127.0.0.1:39411",
+		FrontendURL:       "http://127.0.0.1:39412",
+	}))
+
+	err = run(context.Background(), []string{"-work-dir", dir})
+	require.NoError(err)
+}
+
 func TestReadRunningEphemeralStatusReturnsLiveStatus(t *testing.T) {
 	require := require.New(t)
 	dir := t.TempDir()


### PR DESCRIPTION
Notification sync and read propagation now run once when the server starts before settling into their configured intervals. This prevents notification activity from staying stale until the first polling tick after launch.

<sup>generated by a clanker</sup>