### PR TITLE
Block workspace controls during delete

### DIFF
--- a/frontend/src/lib/components/terminal/DockedTerminalPanel.svelte
+++ b/frontend/src/lib/components/terminal/DockedTerminalPanel.svelte
@@ -241,6 +241,7 @@
             {sessions}
             {displayLabels}
             {activeSessionKey}
+            {disabled}
             {onSelect}
             {onClose}
             {onRename}
@@ -266,7 +267,7 @@
         <div class="terminal-selector" aria-label="Terminal selector">
           {#each sessions as session (session.key)}
             <button
-              draggable="true"
+              draggable={!disabled}
               ondragstart={(event) => startSessionDrag(event, session)}
               ondragend={clearActiveTerminalDrag}
               class={[
@@ -276,7 +277,10 @@
                   visible: visibleKeys.includes(session.key),
                 },
               ]}
-              onclick={() => onSelect?.(session.key)}
+              onclick={() => {
+                if (disabled) return;
+                onSelect?.(session.key);
+              }}
               disabled={disabled}
               ondblclick={() => {
                 if (disabled) return;

--- a/frontend/src/lib/components/terminal/DockedTerminalPanel.svelte
+++ b/frontend/src/lib/components/terminal/DockedTerminalPanel.svelte
@@ -36,6 +36,7 @@
     dock: TerminalDock;
     height: number;
     loading?: boolean;
+    disabled?: boolean;
     onToggle?: (() => void) | undefined;
     onNewTerminal?: (() => void) | undefined;
     onSplit?: ((direction: SplitDirection) => void) | undefined;
@@ -69,6 +70,7 @@
     dock,
     height,
     loading = false,
+    disabled = false,
     onToggle,
     onNewTerminal,
     onSplit,
@@ -98,6 +100,7 @@
     event: DragEvent,
     session: RuntimeSession,
   ): void {
+    if (disabled) return;
     startRuntimeSessionDrag(event, {
       workspaceId: session.workspace_id,
       sessionKey: session.key,
@@ -109,6 +112,7 @@
   }
 
   function handleDragOver(event: DragEvent): void {
+    if (disabled) return;
     if (readDroppedSession(event) === null) return;
     event.preventDefault();
     if (event.dataTransfer) {
@@ -117,6 +121,7 @@
   }
 
   function handleDrop(event: DragEvent): void {
+    if (disabled) return;
     const sessionKey = readDroppedSession(event);
     if (sessionKey === null) return;
     event.preventDefault();
@@ -125,6 +130,7 @@
   }
 
   function startPanelResize(event: PointerEvent): void {
+    if (disabled) return;
     if (dock !== "bottom") return;
     event.preventDefault();
     const startY = event.clientY;
@@ -155,6 +161,7 @@
     <button
       class="panel-resizer"
       aria-label="Resize terminal panel"
+      disabled={disabled}
       onpointerdown={startPanelResize}
     ></button>
   {/if}
@@ -163,6 +170,7 @@
     <button
       class="panel-title"
       aria-label={open ? "Close terminal panel" : "Open terminal panel"}
+      disabled={disabled}
       onclick={() => onToggle?.()}
     >
       <TerminalIcon size="14" strokeWidth="2" aria-hidden="true" />
@@ -174,7 +182,7 @@
         class="panel-action"
         title="New terminal"
         aria-label="New terminal"
-        disabled={loading}
+        disabled={disabled || loading}
         onclick={() => onNewTerminal?.()}
       >
         <PlusIcon size="13" strokeWidth="2.2" aria-hidden="true" />
@@ -183,7 +191,7 @@
         class="panel-action"
         title="Split right"
         aria-label="Split terminal right"
-        disabled={!canSplit || loading}
+        disabled={disabled || !canSplit || loading}
         onclick={() => onSplit?.("horizontal")}
       >
         <Columns2Icon size="13" strokeWidth="2" aria-hidden="true" />
@@ -192,7 +200,7 @@
         class="panel-action"
         title="Split down"
         aria-label="Split terminal down"
-        disabled={!canSplit || loading}
+        disabled={disabled || !canSplit || loading}
         onclick={() => onSplit?.("vertical")}
       >
         <Rows2Icon size="13" strokeWidth="2" aria-hidden="true" />
@@ -201,6 +209,7 @@
         class="panel-action"
         title={dock === "bottom" ? "Move to workflow" : "Move to bottom"}
         aria-label={dock === "bottom" ? "Move terminal panel to workflow" : "Move terminal panel to bottom"}
+        disabled={disabled}
         onclick={() => onDock?.(dock === "bottom" ? "top" : "bottom")}
       >
         {#if dock === "bottom"}
@@ -213,6 +222,7 @@
         class="panel-action"
         title="Close panel"
         aria-label="Close terminal panel"
+        disabled={disabled}
         onclick={() => onToggle?.()}
       >
         <XIcon size="13" strokeWidth="2.2" aria-hidden="true" />
@@ -244,7 +254,7 @@
             <span>{loading ? "Starting terminal..." : "No terminals"}</span>
             <button
               class="empty-action"
-              disabled={loading}
+              disabled={disabled || loading}
               onclick={() => onNewTerminal?.()}
             >
               New terminal
@@ -267,7 +277,11 @@
                 },
               ]}
               onclick={() => onSelect?.(session.key)}
-              ondblclick={() => onRename?.(session)}
+              disabled={disabled}
+              ondblclick={() => {
+                if (disabled) return;
+                onRename?.(session);
+              }}
             >
               <span class={["selector-dot", session.status]}></span>
               <span class="selector-label">{labelFor(session)}</span>

--- a/frontend/src/lib/components/terminal/GhosttyTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/GhosttyTerminalPane.svelte
@@ -26,6 +26,7 @@
     websocketPath?: string;
     reconnectOnExit?: boolean;
     active?: boolean;
+    disabled?: boolean;
     onExit?: (code: number) => void;
     // When the session is not attachable at mount time, skip the
     // WebSocket connect — the server's attach endpoint returns 404
@@ -38,6 +39,7 @@
     websocketPath,
     reconnectOnExit = true,
     active = true,
+    disabled = false,
     onExit,
     initialStatus,
   }: TerminalPaneProps = $props();
@@ -180,6 +182,7 @@
   }
 
   function sendTerminalInput(data: TerminalInputData): void {
+    if (disabled) return;
     if (ws?.readyState !== WebSocket.OPEN) return;
 
     if (typeof data === "string") {
@@ -206,6 +209,11 @@
   }
 
   function handleTerminalPaste(event: ClipboardEvent): void {
+    if (disabled) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      return;
+    }
     if (ws?.readyState !== WebSocket.OPEN || !terminal) return;
 
     const pastedText =
@@ -363,7 +371,13 @@
     terminal.options.fontSize = terminalFontSize;
     terminal.options.scrollback = terminalScrollback;
     terminal.options.cursorBlink = terminalCursorBlink;
+    terminal.options.disableStdin = disabled;
     fitAddon?.fit();
+  });
+
+  $effect(() => {
+    if (!terminal) return;
+    terminal.options.disableStdin = disabled;
   });
 
   $effect(() => {
@@ -392,6 +406,7 @@
         fontFamily: terminalFontFamily,
         fontSize: terminalFontSize,
         scrollback: terminalScrollback,
+        disableStdin: disabled,
       });
       terminal = term;
 

--- a/frontend/src/lib/components/terminal/GhosttyTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/GhosttyTerminalPane.svelte
@@ -22,19 +22,19 @@
   import { createTmuxMouseDragFilter } from "./tmuxMouseDragFilter.js";
 
   interface TerminalPaneProps {
-    workspaceId?: string;
-    websocketPath?: string;
-    reconnectOnExit?: boolean;
-    active?: boolean;
+    workspaceId?: string | undefined;
+    websocketPath?: string | undefined;
+    reconnectOnExit?: boolean | undefined;
+    active?: boolean | undefined;
     disabled?: boolean;
-    onExit?: (code: number) => void;
+    onExit?: ((code: number) => void) | undefined;
     // When the session is not attachable at mount time, skip the
     // WebSocket connect — the server's attach endpoint returns 404
     // for non-running sessions, which would loop scheduleReconnect.
-    initialStatus?: string;
+    initialStatus?: string | undefined;
   }
 
-  const {
+  let {
     workspaceId,
     websocketPath,
     reconnectOnExit = true,

--- a/frontend/src/lib/components/terminal/LaunchMenu.svelte
+++ b/frontend/src/lib/components/terminal/LaunchMenu.svelte
@@ -10,12 +10,14 @@
   interface LaunchMenuProps {
     launchTargets: LaunchTarget[];
     launchingKey?: string | null;
+    disabled?: boolean;
     onLaunch?: (targetKey: string) => void;
   }
 
   const {
     launchTargets,
     launchingKey = null,
+    disabled = false,
     onLaunch,
   }: LaunchMenuProps = $props();
 
@@ -24,7 +26,12 @@
 
   const visibleTargets = $derived(launchTargets.filter(isVisibleLaunchTarget));
 
+  $effect(() => {
+    if (disabled) open = false;
+  });
+
   function launch(targetKey: string): void {
+    if (disabled) return;
     open = false;
     onLaunch?.(targetKey);
   }
@@ -68,7 +75,9 @@
     aria-label="Launch"
     aria-haspopup="true"
     aria-expanded={open}
+    disabled={disabled}
     onclick={() => {
+      if (disabled) return;
       open = !open;
     }}
   >
@@ -94,7 +103,7 @@
         {@const isAgent = target.kind === "agent"}
         <button
           class="launch-option"
-          disabled={!target.available || launchingKey === target.key}
+          disabled={disabled || !target.available || launchingKey === target.key}
           title={target.disabled_reason ?? targetLabel(target)}
           onclick={() => launch(target.key)}
         >

--- a/frontend/src/lib/components/terminal/TerminalOptionsMenu.svelte
+++ b/frontend/src/lib/components/terminal/TerminalOptionsMenu.svelte
@@ -4,6 +4,11 @@
   import type { TerminalSettings as TerminalSettingsType } from "@middleman/ui/api/types";
   import TerminalSettings from "../settings/TerminalSettings.svelte";
 
+  interface Props {
+    disabled?: boolean;
+  }
+
+  const { disabled = false }: Props = $props();
   const { settings: settingsStore } = getStores();
 
   let open = $state(false);
@@ -13,7 +18,12 @@
   );
   let childSaving = $state(false);
 
+  $effect(() => {
+    if (disabled) open = false;
+  });
+
   function toggleOpen(): void {
+    if (disabled) return;
     if (childSaving) return;
     if (!open) {
       terminal = settingsStore.getTerminalSettings();
@@ -55,6 +65,7 @@
     aria-haspopup="true"
     aria-expanded={open}
     title="Terminal options"
+    disabled={disabled}
     onclick={toggleOpen}
   >
     <SettingsIcon size="13" strokeWidth="2" aria-hidden="true" />

--- a/frontend/src/lib/components/terminal/TerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/TerminalPane.svelte
@@ -9,6 +9,7 @@
     websocketPath?: string;
     reconnectOnExit?: boolean;
     active?: boolean;
+    disabled?: boolean;
     onExit?: (code: number) => void;
     // When the session is already exited at mount time, skip the
     // WebSocket connect — the server's attach endpoint returns 404

--- a/frontend/src/lib/components/terminal/TerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/TerminalPane.svelte
@@ -5,19 +5,27 @@
   import XtermTerminalPane from "./XtermTerminalPane.svelte";
 
   interface TerminalPaneProps {
-    workspaceId?: string;
-    websocketPath?: string;
-    reconnectOnExit?: boolean;
-    active?: boolean;
+    workspaceId?: string | undefined;
+    websocketPath?: string | undefined;
+    reconnectOnExit?: boolean | undefined;
+    active?: boolean | undefined;
     disabled?: boolean;
-    onExit?: (code: number) => void;
+    onExit?: ((code: number) => void) | undefined;
     // When the session is already exited at mount time, skip the
     // WebSocket connect — the server's attach endpoint returns 404
     // for non-running sessions, which would loop scheduleReconnect.
-    initialStatus?: string;
+    initialStatus?: string | undefined;
   }
 
-  const props: TerminalPaneProps = $props();
+  let {
+    workspaceId = undefined,
+    websocketPath = undefined,
+    reconnectOnExit = undefined,
+    active = undefined,
+    disabled = false,
+    onExit = undefined,
+    initialStatus = undefined,
+  }: TerminalPaneProps = $props();
   const { settings: settingsStore } = getStores();
 
   function normalizeRenderer(renderer: string | null | undefined): TerminalRenderer {
@@ -30,7 +38,23 @@
 </script>
 
 {#if terminalRenderer === "ghostty-web"}
-  <GhosttyTerminalPane {...props} />
+  <GhosttyTerminalPane
+    {workspaceId}
+    {websocketPath}
+    {reconnectOnExit}
+    {active}
+    {disabled}
+    {onExit}
+    {initialStatus}
+  />
 {:else}
-  <XtermTerminalPane {...props} />
+  <XtermTerminalPane
+    {workspaceId}
+    {websocketPath}
+    {reconnectOnExit}
+    {active}
+    {disabled}
+    {onExit}
+    {initialStatus}
+  />
 {/if}

--- a/frontend/src/lib/components/terminal/TerminalSplitTree.svelte
+++ b/frontend/src/lib/components/terminal/TerminalSplitTree.svelte
@@ -37,6 +37,7 @@
     displayLabels: Record<string, string>;
     activeSessionKey: string | null;
     borderTrim?: BorderTrim | undefined;
+    disabled?: boolean;
     onSelect?: ((sessionKey: string) => void) | undefined;
     onClose?: ((session: RuntimeSession) => void) | undefined;
     onRename?: ((session: RuntimeSession) => void) | undefined;
@@ -61,6 +62,7 @@
     displayLabels,
     activeSessionKey,
     borderTrim = {},
+    disabled = false,
     onSelect,
     onClose,
     onRename,
@@ -86,6 +88,7 @@
     event: DragEvent,
     session: RuntimeSession,
   ): void {
+    if (disabled) return;
     startRuntimeSessionDrag(event, {
       workspaceId: session.workspace_id,
       sessionKey: session.key,
@@ -93,6 +96,7 @@
   }
 
   function readDroppedSession(event: DragEvent): string | null {
+    if (disabled) return null;
     const sessionKey = readRuntimeSessionDrag(event, workspaceId);
     if (
       sessionKey === null ||
@@ -112,6 +116,7 @@
   }
 
   function handleDragOver(event: DragEvent): void {
+    if (disabled) return;
     if (node.type !== "leaf" || readDroppedSession(event) === null) return;
     event.preventDefault();
     event.stopPropagation();
@@ -128,6 +133,7 @@
   }
 
   function handleDragLeave(event: DragEvent): void {
+    if (disabled) return;
     const current = event.currentTarget;
     const next = event.relatedTarget;
     if (
@@ -141,6 +147,7 @@
   }
 
   function dropSplit(event: DragEvent): void {
+    if (disabled) return;
     if (node.type !== "leaf") return;
     const sessionKey = readDroppedSession(event);
     const edge = splitEdgeFromEvent(event);
@@ -154,6 +161,7 @@
   }
 
   function startResize(event: PointerEvent): void {
+    if (disabled) return;
     if (node.type !== "split" || !splitEl) return;
     event.preventDefault();
     const rect = splitEl.getBoundingClientRect();
@@ -246,17 +254,21 @@
           class="leaf-header"
           role="group"
           aria-label={`${labelFor(session)} terminal pane`}
-          draggable="true"
+          draggable={!disabled}
           ondragstart={(event) => startSessionDrag(event, session)}
           ondragend={clearActiveTerminalDrag}
         >
           <button
             class="leaf-title"
-            draggable="true"
+            draggable={!disabled}
             ondragstart={(event) => startSessionDrag(event, session)}
             ondragend={clearActiveTerminalDrag}
-            onclick={() => onSelect?.(session.key)}
+            onclick={() => {
+              if (disabled) return;
+              onSelect?.(session.key);
+            }}
             aria-label={`Focus ${labelFor(session)}`}
+            disabled={disabled}
           >
             <span class="leaf-icon" aria-hidden="true">
               {#if session.kind === "plain_shell"}
@@ -273,7 +285,11 @@
               class="leaf-action"
               title="Rename"
               aria-label={`Rename ${labelFor(session)}`}
-              onclick={() => onRename?.(session)}
+              disabled={disabled}
+              onclick={() => {
+                if (disabled) return;
+                onRename?.(session);
+              }}
             >
               <PencilIcon size="12" strokeWidth="2" aria-hidden="true" />
             </button>
@@ -281,7 +297,11 @@
               class="leaf-action"
               title="Move to workflow"
               aria-label={`Move ${labelFor(session)} to workflow`}
-              onclick={() => onMoveToWorkflow?.(session.key)}
+              disabled={disabled}
+              onclick={() => {
+                if (disabled) return;
+                onMoveToWorkflow?.(session.key);
+              }}
             >
               <MoveIcon size="12" strokeWidth="2" aria-hidden="true" />
             </button>
@@ -289,7 +309,11 @@
               class="leaf-action"
               title="Close"
               aria-label={`Close ${labelFor(session)}`}
-              onclick={() => onClose?.(session)}
+              disabled={disabled}
+              onclick={() => {
+                if (disabled) return;
+                onClose?.(session);
+              }}
             >
               <XIcon size="12" strokeWidth="2.2" aria-hidden="true" />
             </button>
@@ -304,8 +328,14 @@
           ]}
           role="group"
           aria-label={`${labelFor(session)} split drop targets`}
-          onpointerdown={() => onSelect?.(session.key)}
-          onfocusin={() => onSelect?.(session.key)}
+          onpointerdown={() => {
+            if (disabled) return;
+            onSelect?.(session.key);
+          }}
+          onfocusin={() => {
+            if (disabled) return;
+            onSelect?.(session.key);
+          }}
           ondragover={handleDragOver}
           ondragleave={handleDragLeave}
           ondrop={dropSplit}
@@ -349,6 +379,7 @@
         {sessions}
         {displayLabels}
         {activeSessionKey}
+        {disabled}
         borderTrim={firstChildTrim(node.direction)}
         {onSelect}
         {onClose}
@@ -362,6 +393,7 @@
     <button
       class="split-divider"
       aria-label="Resize split"
+      disabled={disabled}
       onpointerdown={startResize}
     ></button>
     <div class="split-child second">
@@ -372,6 +404,7 @@
         {sessions}
         {displayLabels}
         {activeSessionKey}
+        {disabled}
         borderTrim={secondChildTrim(node.direction)}
         {onSelect}
         {onClose}
@@ -496,6 +529,12 @@
     cursor: grab;
   }
 
+  .leaf-title:disabled {
+    color: var(--text-muted);
+    cursor: default;
+    opacity: 0.65;
+  }
+
   .terminal-leaf.active .leaf-title {
     color: var(--text-primary);
   }
@@ -560,6 +599,17 @@
     background: var(--bg-surface-hover);
     color: var(--text-primary);
     outline: none;
+  }
+
+  .leaf-action:disabled {
+    cursor: default;
+    opacity: 0.55;
+  }
+
+  .leaf-action:disabled:hover,
+  .leaf-action:disabled:focus-visible {
+    background: transparent;
+    color: var(--text-muted);
   }
 
   .missing-session {

--- a/frontend/src/lib/components/terminal/TerminalSplitTree.svelte
+++ b/frontend/src/lib/components/terminal/TerminalSplitTree.svelte
@@ -348,6 +348,7 @@
             )}
             reconnectOnExit={false}
             active={activeSessionKey === session.key}
+            {disabled}
             onExit={() => onExit?.(session)}
             initialStatus={session.status}
           />

--- a/frontend/src/lib/components/terminal/WorkflowPresetMenu.svelte
+++ b/frontend/src/lib/components/terminal/WorkflowPresetMenu.svelte
@@ -9,6 +9,7 @@
     presets: WorkflowPreset[];
     selectedPresetId?: string | null;
     applying?: boolean;
+    disabled?: boolean;
     onSaveNew?: (() => void) | undefined;
     onUpdate?: ((presetId: string) => void) | undefined;
     onApply?: ((presetId: string) => void) | undefined;
@@ -19,6 +20,7 @@
     presets,
     selectedPresetId = null,
     applying = false,
+    disabled = false,
     onSaveNew,
     onUpdate,
     onApply,
@@ -31,6 +33,10 @@
   const selectedPreset = $derived(
     presets.find((preset) => preset.id === selectedPresetId) ?? null,
   );
+
+  $effect(() => {
+    if (disabled) open = false;
+  });
 
   $effect(() => {
     if (!open) return;
@@ -64,8 +70,9 @@
     aria-label="Workflow presets"
     aria-haspopup="true"
     aria-expanded={open}
-    disabled={applying}
+    disabled={disabled || applying}
     onclick={() => {
+      if (disabled) return;
       open = !open;
     }}
   >
@@ -79,7 +86,9 @@
       <button
         class="preset-command"
         type="button"
+        disabled={disabled}
         onclick={() => {
+          if (disabled) return;
           open = false;
           onSaveNew?.();
         }}
@@ -90,8 +99,9 @@
       <button
         class="preset-command"
         type="button"
-        disabled={!selectedPreset}
+        disabled={disabled || !selectedPreset}
         onclick={() => {
+          if (disabled) return;
           if (!selectedPreset) return;
           open = false;
           onUpdate?.(selectedPreset.id);
@@ -109,8 +119,9 @@
               <button
                 class="preset-apply"
                 type="button"
-                disabled={applying}
+                disabled={disabled || applying}
                 onclick={() => {
+                  if (disabled) return;
                   open = false;
                   onApply?.(preset.id);
                 }}
@@ -122,7 +133,11 @@
                 class="preset-delete"
                 type="button"
                 aria-label={`Delete ${preset.name}`}
-                onclick={() => onDelete?.(preset.id)}
+                disabled={disabled}
+                onclick={() => {
+                  if (disabled) return;
+                  onDelete?.(preset.id);
+                }}
               >
                 <TrashIcon size="12" strokeWidth="2.2" aria-hidden="true" />
               </button>

--- a/frontend/src/lib/components/terminal/WorkflowSplitTree.svelte
+++ b/frontend/src/lib/components/terminal/WorkflowSplitTree.svelte
@@ -28,6 +28,7 @@
     tabs: WorkflowTabDescriptor[];
     activeTabKey: WorkflowTabKey;
     renderTab: Snippet<[WorkflowTabKey, boolean]>;
+    disabled?: boolean;
     onSelectTab?: ((tabKey: WorkflowTabKey) => void) | undefined;
     onMoveTabBefore?:
       | ((sourceTabKey: WorkflowTabKey, targetTabKey: WorkflowTabKey) => void)
@@ -53,6 +54,7 @@
     tabs,
     activeTabKey,
     renderTab: renderWorkflowTab,
+    disabled = false,
     onSelectTab,
     onMoveTabBefore,
     onAppendTabToLeaf,
@@ -97,20 +99,26 @@
   leafLabel="Workflow group"
   dropTargetsLabel="Workflow group drop targets"
   resizeLabel="Resize workflow split"
-  onSelectTab={(tabKey) => onSelectTab?.(workflowTabFrom(tabKey))}
+  onSelectTab={(tabKey) => {
+    if (disabled) return;
+    onSelectTab?.(workflowTabFrom(tabKey));
+  }}
   onMoveTabBefore={(source, target) =>
-    onMoveTabBefore?.(workflowTabFrom(source), workflowTabFrom(target))}
-  onAppendTabToLeaf={(source, leafID) => onAppendTabToLeaf?.(workflowTabFrom(source), leafID)}
+    !disabled && onMoveTabBefore?.(workflowTabFrom(source), workflowTabFrom(target))}
+  onAppendTabToLeaf={(source, leafID) => !disabled && onAppendTabToLeaf?.(workflowTabFrom(source), leafID)}
   onSplitTab={(source, leafID, direction, placement) =>
-    onSplitTab?.(workflowTabFrom(source), leafID, splitDirectionFrom(direction), placement)}
-  onTabDoubleClick={(tabKey) => onRenameTab?.(workflowTabFrom(tabKey))}
+    !disabled && onSplitTab?.(workflowTabFrom(source), leafID, splitDirectionFrom(direction), placement)}
+  onTabDoubleClick={(tabKey) => {
+    if (disabled) return;
+    onRenameTab?.(workflowTabFrom(tabKey));
+  }}
   {onRatioChange}
   onStartTabDrag={(event, tab) =>
-    startWorkflowTabDrag(event, {
+    !disabled && startWorkflowTabDrag(event, {
       workspaceId,
       tabKey: workflowTabFrom(tab.key),
     })}
-  onReadDraggedTab={(event) => readWorkflowTabDrag(event, workspaceId)}
+  onReadDraggedTab={(event) => disabled ? null : readWorkflowTabDrag(event, workspaceId)}
   onClearDrag={clearActiveTerminalDrag}
 >
   {#snippet renderTab(tabKey, active)}
@@ -134,7 +142,11 @@
         class="tabbed-panel-tab-tool"
         title="Rename"
         aria-label={`Rename ${tab.label}`}
-        onclick={() => onRenameTab?.(tabKey)}
+        disabled={disabled}
+        onclick={() => {
+          if (disabled) return;
+          onRenameTab?.(tabKey);
+        }}
       >
         <PencilIcon size="11" strokeWidth="2.2" aria-hidden="true" />
       </button>
@@ -144,7 +156,11 @@
         class="tabbed-panel-tab-tool"
         title="Move to terminal"
         aria-label={`Move ${tab.label} to terminal`}
-        onclick={() => onMoveTabToTerminal?.(tabKey)}
+        disabled={disabled}
+        onclick={() => {
+          if (disabled) return;
+          onMoveTabToTerminal?.(tabKey);
+        }}
       >
         <MoveIcon size="11" strokeWidth="2.2" aria-hidden="true" />
       </button>
@@ -154,7 +170,11 @@
         class="tabbed-panel-tab-tool"
         title="Close"
         aria-label={`Close ${tab.label}`}
-        onclick={() => onCloseTab?.(tabKey)}
+        disabled={disabled}
+        onclick={() => {
+          if (disabled) return;
+          onCloseTab?.(tabKey);
+        }}
       >
         <XIcon size="11" strokeWidth="2.3" aria-hidden="true" />
       </button>

--- a/frontend/src/lib/components/terminal/WorkflowSplitTree.svelte
+++ b/frontend/src/lib/components/terminal/WorkflowSplitTree.svelte
@@ -95,6 +95,7 @@
   {node}
   {tabs}
   {activeTabKey}
+  {disabled}
   tablistLabel="Workflow group tabs"
   leafLabel="Workflow group"
   dropTargetsLabel="Workflow group drop targets"

--- a/frontend/src/lib/components/terminal/WorkflowSplitTree.svelte
+++ b/frontend/src/lib/components/terminal/WorkflowSplitTree.svelte
@@ -112,7 +112,10 @@
     if (disabled) return;
     onRenameTab?.(workflowTabFrom(tabKey));
   }}
-  {onRatioChange}
+  onRatioChange={(splitID, ratio) => {
+    if (disabled) return;
+    onRatioChange?.(splitID, ratio);
+  }}
   onStartTabDrag={(event, tab) =>
     !disabled && startWorkflowTabDrag(event, {
       workspaceId,

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -93,6 +93,11 @@
       workspaceId: string,
       hostKey?: string,
     ) => boolean;
+    onWorkspaceDeletePendingChange?: (
+      workspaceId: string,
+      hostKey: string | undefined,
+      pending: boolean,
+    ) => void;
     isSidebarToggleEnabled?: boolean;
     onCollapseSidebar?: (() => void) | undefined;
   }
@@ -103,6 +108,7 @@
     onOpenItemSidebar,
     onWorkspaceListStateChange,
     isWorkspaceActionDisabled,
+    onWorkspaceDeletePendingChange,
     isSidebarToggleEnabled = false,
     onCollapseSidebar,
   }: Props = $props();
@@ -798,6 +804,7 @@
   async function confirmDeleteWorkspaceFromList(): Promise<void> {
     const ws = deleteConfirmWorkspace;
     if (!ws || workspaceActionsDisabled(ws) || !startWorkspaceAction(ws, "delete")) return;
+    onWorkspaceDeletePendingChange?.(ws.id, ws.fleet_host_key, true);
     try {
       const { error, response } = ws.fleet_host_key
         ? await client.DELETE("/fleet/hosts/{host_key}/workspaces/{id}", {
@@ -823,6 +830,7 @@
     } catch (err) {
       showFlash(err instanceof Error ? err.message : "Delete failed.");
     } finally {
+      onWorkspaceDeletePendingChange?.(ws.id, ws.fleet_host_key, false);
       finishWorkspaceAction(ws);
       deleteConfirmWorkspace = null;
     }

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -89,6 +89,10 @@
     onWorkspaceListStateChange?: (
       state: { status: "loading" | "retrying" | "loaded"; total: number },
     ) => void;
+    isWorkspaceActionDisabled?: (
+      workspaceId: string,
+      hostKey?: string,
+    ) => boolean;
     isSidebarToggleEnabled?: boolean;
     onCollapseSidebar?: (() => void) | undefined;
   }
@@ -98,6 +102,7 @@
     selectedHostKey = undefined,
     onOpenItemSidebar,
     onWorkspaceListStateChange,
+    isWorkspaceActionDisabled,
     isSidebarToggleEnabled = false,
     onCollapseSidebar,
   }: Props = $props();
@@ -661,6 +666,7 @@
   }
 
   async function refreshWorkspaceStatus(ws: Workspace): Promise<void> {
+    if (workspaceActionsDisabled(ws)) return;
     closeContextMenu();
     const { error, response } = ws.fleet_host_key
       ? await client.POST("/fleet/hosts/{host_key}/workspaces/{id}/refresh", {
@@ -688,7 +694,12 @@
     );
   }
 
+  function workspaceActionsDisabled(ws: Workspace): boolean {
+    return isWorkspaceActionDisabled?.(ws.id, ws.fleet_host_key) ?? false;
+  }
+
   function workspaceBusyLabel(ws: Workspace): string {
+    if (workspaceActionsDisabled(ws)) return "Deleting workspace";
     if (!workspaceActionMatches(ws)) return "";
     if (workspaceAction?.action === "push") return "Pushing branch";
     if (workspaceAction?.action === "pull") return "Pulling branch";
@@ -701,7 +712,7 @@
     ws: Workspace,
     action: "push" | "pull" | "reveal" | "delete",
   ): boolean {
-    if (workspaceAction !== null) return false;
+    if (workspaceAction !== null || workspaceActionsDisabled(ws)) return false;
     workspaceAction = { workspaceKey: workspaceRowKey(ws), action };
     return true;
   }
@@ -786,7 +797,7 @@
 
   async function confirmDeleteWorkspaceFromList(): Promise<void> {
     const ws = deleteConfirmWorkspace;
-    if (!ws || !startWorkspaceAction(ws, "delete")) return;
+    if (!ws || workspaceActionsDisabled(ws) || !startWorkspaceAction(ws, "delete")) return;
     try {
       const { error, response } = ws.fleet_host_key
         ? await client.DELETE("/fleet/hosts/{host_key}/workspaces/{id}", {
@@ -1063,7 +1074,7 @@
                     title={workingTitle(ws)}
                     aria-label={workingTitle(ws)}
                   ></span>
-                {:else if workspaceActionMatches(ws)}
+                {:else if workspaceActionMatches(ws) || workspaceActionsDisabled(ws)}
                   <span
                     class="working-pulse"
                     title={workspaceBusyLabel(ws)}
@@ -1179,6 +1190,7 @@
   {@const localWorkspace = !isRemoteWorkspace(menuWorkspace)}
   {@const itemURL = providerItemURL(menuWorkspace)}
   {@const actionBusy = workspaceAction !== null}
+  {@const actionDisabled = actionBusy || workspaceActionsDisabled(menuWorkspace)}
   <div
     class="workspace-context-menu filter-dropdown"
     bind:this={contextMenuEl}
@@ -1203,7 +1215,7 @@
         class="filter-item active"
         role="menuitem"
         type="button"
-        disabled={actionBusy}
+        disabled={actionDisabled}
         onclick={() => {
           void syncWorkspaceBranch(menuWorkspace, "push");
         }}
@@ -1217,7 +1229,7 @@
         class="filter-item active"
         role="menuitem"
         type="button"
-        disabled={actionBusy}
+        disabled={actionDisabled}
         onclick={() => {
           void syncWorkspaceBranch(menuWorkspace, "pull");
         }}
@@ -1231,7 +1243,7 @@
       class="filter-item active"
       role="menuitem"
       type="button"
-      disabled={actionBusy}
+      disabled={actionDisabled}
       onclick={() => {
         void refreshWorkspaceStatus(menuWorkspace);
       }}
@@ -1276,7 +1288,7 @@
         class="filter-item active"
         role="menuitem"
         type="button"
-        disabled={actionBusy}
+        disabled={actionDisabled}
         onclick={() => {
           void revealWorkspacePath(menuWorkspace);
         }}
@@ -1315,7 +1327,7 @@
       class="filter-item active workspace-context-danger"
       role="menuitem"
       type="button"
-      disabled={actionBusy}
+      disabled={actionDisabled}
       onclick={() => {
         openDeleteWorkspaceDialog(menuWorkspace);
       }}

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -2814,6 +2814,7 @@
                                   workspaceHostKey,
                                 )}
                                 reconnectOnExit={false}
+                                disabled={actionsBlocked}
                                 {active}
                                 onExit={() => handleSessionExit(session)}
                                 initialStatus={session.status}

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -170,10 +170,11 @@
   let actionError = $state<string | null>(null);
   let retryingSetup = $state(false);
   let refreshingWorkspace = $state(false);
-  let deletingWorkspaceTarget = $state<{
+  type DeletingWorkspaceTarget = {
     id: string;
     hostKey: string | undefined;
-  } | null>(null);
+  };
+  let deletingWorkspaceTargets = $state<DeletingWorkspaceTarget[]>([]);
   let sidebarRefreshToken = $state(0);
   let forcePromptMessage = $state<string | null>(null);
   let forcePromptForId = $state<string | null>(null);
@@ -447,9 +448,9 @@
         workspaceHostKey !== selectedWorkspaceHostKey(workspace)),
   );
   const deletingSelectedWorkspace = $derived(
-    deletingWorkspaceTarget !== null &&
-      deletingWorkspaceTarget.id === workspaceId &&
-      deletingWorkspaceTarget.hostKey === workspaceHostKey,
+    deletingWorkspaceTargets.some((target) =>
+      isDeletingWorkspaceTarget(target, workspaceId, workspaceHostKey),
+    ),
   );
   const actionsBlocked = $derived(transitioning || deletingSelectedWorkspace || forceDeleting);
   const modalOpen = $derived(
@@ -2160,7 +2161,7 @@
       document.activeElement instanceof HTMLElement
         ? document.activeElement
         : null;
-    deletingWorkspaceTarget = { id: targetId, hostKey: targetHostKey };
+    addDeletingWorkspaceTarget(targetId, targetHostKey);
     try {
       const { error, response } = targetHostKey
         ? await client.DELETE("/fleet/hosts/{host_key}/workspaces/{id}", {
@@ -2195,13 +2196,39 @@
       if (!isCurrentTerminalRoute(targetId)) return;
       navigate("/workspaces");
     } finally {
-      if (
-        deletingWorkspaceTarget?.id === targetId &&
-        deletingWorkspaceTarget.hostKey === targetHostKey
-      ) {
-        deletingWorkspaceTarget = null;
-      }
+      removeDeletingWorkspaceTarget(targetId, targetHostKey);
     }
+  }
+
+  function isDeletingWorkspaceTarget(
+    target: DeletingWorkspaceTarget,
+    id: string,
+    hostKey: string | undefined,
+  ): boolean {
+    return target.id === id && target.hostKey === hostKey;
+  }
+
+  function addDeletingWorkspaceTarget(
+    id: string,
+    hostKey: string | undefined,
+  ): void {
+    if (
+      deletingWorkspaceTargets.some((target) =>
+        isDeletingWorkspaceTarget(target, id, hostKey),
+      )
+    ) {
+      return;
+    }
+    deletingWorkspaceTargets = [...deletingWorkspaceTargets, { id, hostKey }];
+  }
+
+  function removeDeletingWorkspaceTarget(
+    id: string,
+    hostKey: string | undefined,
+  ): void {
+    deletingWorkspaceTargets = deletingWorkspaceTargets.filter(
+      (target) => !isDeletingWorkspaceTarget(target, id, hostKey),
+    );
   }
 
   function isCurrentTerminalRoute(targetId: string): boolean {

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -2600,13 +2600,14 @@
           </span>
           <button
             class="retry-btn"
-            disabled={retryingSetup}
+            disabled={actionsBlocked || retryingSetup}
             onclick={() => void handleRetrySetup()}
           >
             Retry
           </button>
           <button
             class="retry-btn danger"
+            disabled={actionsBlocked}
             onclick={(event) =>
               void handleDelete(event.currentTarget)}
           >

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -2952,6 +2952,13 @@
             deletingWorkspaceTargets.some((target) =>
               isDeletingWorkspaceTarget(target, id, hostKey),
             )}
+          onWorkspaceDeletePendingChange={(id, hostKey, pending) => {
+            if (pending) {
+              addDeletingWorkspaceTarget(id, hostKey);
+            } else {
+              removeDeletingWorkspaceTarget(id, hostKey);
+            }
+          }}
         />
       {/snippet}
       {@render terminalMainContent()}

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -170,6 +170,7 @@
   let actionError = $state<string | null>(null);
   let retryingSetup = $state(false);
   let refreshingWorkspace = $state(false);
+  let deletingWorkspace = $state(false);
   let sidebarRefreshToken = $state(0);
   let forcePromptMessage = $state<string | null>(null);
   let forcePromptForId = $state<string | null>(null);
@@ -443,7 +444,7 @@
       (workspace.id !== workspaceId ||
         workspaceHostKey !== selectedWorkspaceHostKey(workspace)),
   );
-  const actionsBlocked = $derived(transitioning);
+  const actionsBlocked = $derived(transitioning || deletingWorkspace || forceDeleting);
   const modalOpen = $derived(
     forcePromptMessage !== null ||
       stopPromptSession !== null ||
@@ -2136,44 +2137,51 @@
       document.activeElement instanceof HTMLElement
         ? document.activeElement
         : null;
-    const { error, response } = targetHostKey
-      ? await client.DELETE("/fleet/hosts/{host_key}/workspaces/{id}", {
-          params: { path: { host_key: targetHostKey, id: targetId } },
-        })
-      : await client.DELETE("/workspaces/{id}", {
-          params: { path: { id: targetId } },
-        });
-    // Different workspace now: the user has moved on and nothing
-    // about this response applies.
-    if (!isCurrentWorkspace(targetId, targetHostKey)) return;
-    if (response.status === 409) {
-      // A 409 that lands after the user briefly left and returned
-      // to the same workspace would feel like an unrequested
-      // prompt; suppress it on a generation mismatch and let the
-      // user retry if they want.
-      if (targetGen !== workspaceGen) return;
-      previouslyFocusedEl = triggerEl;
-      forcePromptForId = targetId;
-      forcePromptMessage = apiErrorMessage(
-        error,
-        "Workspace has uncommitted changes.",
-      );
-      return;
+    deletingWorkspace = true;
+    try {
+      const { error, response } = targetHostKey
+        ? await client.DELETE("/fleet/hosts/{host_key}/workspaces/{id}", {
+            params: { path: { host_key: targetHostKey, id: targetId } },
+          })
+        : await client.DELETE("/workspaces/{id}", {
+            params: { path: { id: targetId } },
+          });
+      // Different workspace now: the user has moved on and nothing
+      // about this response applies.
+      if (!isCurrentWorkspace(targetId, targetHostKey)) return;
+      if (response.status === 409) {
+        // A 409 that lands after the user briefly left and returned
+        // to the same workspace would feel like an unrequested
+        // prompt; suppress it on a generation mismatch and let the
+        // user retry if they want.
+        if (targetGen !== workspaceGen) return;
+        previouslyFocusedEl = triggerEl;
+        forcePromptForId = targetId;
+        forcePromptMessage = apiErrorMessage(
+          error,
+          "Workspace has uncommitted changes.",
+        );
+        return;
+      }
+      if (!response.ok && response.status !== 204) {
+        if (targetGen !== workspaceGen) return;
+        actionError = apiErrorMessage(
+          error,
+          `Delete failed (${response.status})`,
+        );
+        return;
+      }
+      // Successful delete: the server destroyed this workspace and
+      // the user is still looking at it. Navigate away even after
+      // an A→B→A round trip — otherwise they'd be staring at a
+      // workspace that no longer exists.
+      if (!isCurrentTerminalRoute(targetId)) return;
+      navigate("/workspaces");
+    } finally {
+      if (isCurrentWorkspace(targetId, targetHostKey)) {
+        deletingWorkspace = false;
+      }
     }
-    if (!response.ok && response.status !== 204) {
-      if (targetGen !== workspaceGen) return;
-      actionError = apiErrorMessage(
-        error,
-        `Delete failed (${response.status})`,
-      );
-      return;
-    }
-    // Successful delete: the server destroyed this workspace and
-    // the user is still looking at it. Navigate away even after
-    // an A→B→A round trip — otherwise they'd be staring at a
-    // workspace that no longer exists.
-    if (!isCurrentTerminalRoute(targetId)) return;
-    navigate("/workspaces");
   }
 
   function isCurrentTerminalRoute(targetId: string): boolean {
@@ -2306,6 +2314,7 @@
     // leave these flags stuck true on the next workspace.
     retryingSetup = false;
     refreshingWorkspace = false;
+    deletingWorkspace = false;
 
     // Errors/transient flags from the prior workspace should not
     // bleed across — clear them but don't touch workspace/runtime.
@@ -2655,11 +2664,13 @@
                     onUpdate={updateWorkflowPreset}
                     onApply={(presetId) => void applyWorkflowPreset(presetId)}
                     onDelete={deleteWorkflowPreset}
+                    disabled={actionsBlocked}
                   />
-                  <TerminalOptionsMenu />
+                  <TerminalOptionsMenu disabled={actionsBlocked} />
                   <LaunchMenu
                     launchTargets={launchTargets}
                     {launchingKey}
+                    disabled={actionsBlocked}
                     onLaunch={(key) => void handleLaunch(key)}
                   />
                 </div>
@@ -2691,6 +2702,7 @@
                       node={terminalLayout.workflowTree}
                       tabs={workflowTabDescriptors}
                       {activeTabKey}
+                      disabled={actionsBlocked}
                       onSelectTab={(tabKey) => {
                         if (tabKey === "terminal") {
                           terminalLayout = { ...terminalLayout, open: true };
@@ -2725,6 +2737,7 @@
                               sessions={runtimeSessions}
                               displayLabels={sessionDisplayLabels}
                               {launchingKey}
+                              readonly={actionsBlocked}
                               onLaunch={(key) => void handleLaunch(key)}
                               onOpenSession={openSession}
                             />
@@ -2741,6 +2754,7 @@
                             dock={terminalLayout.dock}
                             height={terminalLayout.height}
                             loading={terminalLaunching}
+                            disabled={actionsBlocked}
                             onToggle={() => void toggleTerminalPanel()}
                             onNewTerminal={() => void launchTerminalSession()}
                             onSplit={(direction) => void splitTerminal(direction)}
@@ -2801,6 +2815,7 @@
                   dock={terminalLayout.dock}
                   height={terminalLayout.height}
                   loading={terminalLaunching}
+                  disabled={actionsBlocked}
                   onToggle={() => void toggleTerminalPanel()}
                   onNewTerminal={() => void launchTerminalSession()}
                   onSplit={(direction) => void splitTerminal(direction)}
@@ -2852,6 +2867,7 @@
                 branch={workspace.git_head_ref}
                 roborevBaseUrl={basePath + "/api/roborev"}
                 refreshToken={sidebarRefreshToken}
+                disabled={actionsBlocked}
               />
             </div>
           {/if}

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -487,6 +487,7 @@
   });
 
   function handleSegmentClick(tab: SidebarTab): void {
+    if (actionsBlocked) return;
     if (sidebarOpen && sidebarTab === tab) {
       sidebarOpen = false;
     } else {
@@ -2584,6 +2585,7 @@
                 <button
                   class="seg-btn"
                   class:active={sidebarOpen && sidebarTab === "diff"}
+                  disabled={actionsBlocked}
                   onclick={() => handleSegmentClick("diff")}
                 >
                   Diff
@@ -2592,6 +2594,7 @@
                   <button
                     class="seg-btn"
                     class:active={sidebarOpen && sidebarTab === "issue"}
+                    disabled={actionsBlocked}
                     onclick={() => handleSegmentClick("issue")}
                   >
                     Issue
@@ -2601,6 +2604,7 @@
                   <button
                     class="seg-btn"
                     class:active={sidebarOpen && sidebarTab === "pr"}
+                    disabled={actionsBlocked}
                     onclick={() => handleSegmentClick("pr")}
                   >
                     PR
@@ -2610,6 +2614,7 @@
                   <button
                     class="seg-btn"
                     class:active={sidebarOpen && sidebarTab === "reviews"}
+                    disabled={actionsBlocked}
                     onclick={() => handleSegmentClick("reviews")}
                   >
                     Reviews
@@ -3377,15 +3382,29 @@
     border-left: 1px solid var(--border-default);
   }
 
-  .seg-btn:hover:not(.active) {
+  .seg-btn:hover:not(.active):not(:disabled) {
     color: var(--text-primary);
     background: var(--bg-surface-hover);
   }
 
-  .seg-btn.active {
+  .seg-btn.active:not(:disabled) {
     background: var(--accent-blue);
     color: #fff;
     font-weight: 600;
+  }
+
+  .seg-btn:disabled {
+    cursor: not-allowed;
+    color: color-mix(in srgb, var(--text-muted) 75%, var(--bg-surface));
+    background: var(--bg-surface);
+    opacity: 1;
+  }
+
+  .seg-control .seg-btn.active:disabled {
+    background: color-mix(in srgb, rgb(128 128 128) 28%, var(--bg-surface)) !important;
+    color: color-mix(in srgb, rgb(115 115 115) 80%, var(--text-primary)) !important;
+    box-shadow: inset 0 0 0 1px
+      color-mix(in srgb, rgb(128 128 128) 35%, var(--border-muted));
   }
 
   .terminal-and-sidebar {

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -170,7 +170,10 @@
   let actionError = $state<string | null>(null);
   let retryingSetup = $state(false);
   let refreshingWorkspace = $state(false);
-  let deletingWorkspace = $state(false);
+  let deletingWorkspaceTarget = $state<{
+    id: string;
+    hostKey: string | undefined;
+  } | null>(null);
   let sidebarRefreshToken = $state(0);
   let forcePromptMessage = $state<string | null>(null);
   let forcePromptForId = $state<string | null>(null);
@@ -184,11 +187,10 @@
   let renameInputValue = $state("");
   let renameSaving = $state(false);
   let renameInputEl = $state<HTMLInputElement | null>(null);
-  // Bumps on every workspace route change. Async delete callbacks
-  // capture this at request time and bail out if it has moved on,
-  // covering the case where the user leaves and returns to the same
-  // workspace before an in-flight response settles — an id check
-  // alone would let a stale 409 reopen the prompt.
+  // Bumps on every workspace route change so non-delete async
+  // callbacks can detect stale responses for the previous route.
+  // Delete requests track their own target separately because the
+  // same workspace must stay blocked across A -> B -> A navigation.
   let workspaceGen = 0;
   let runtimeError = $state<string | null>(null);
   let pollTimer = $state<ReturnType<
@@ -444,7 +446,12 @@
       (workspace.id !== workspaceId ||
         workspaceHostKey !== selectedWorkspaceHostKey(workspace)),
   );
-  const actionsBlocked = $derived(transitioning || deletingWorkspace || forceDeleting);
+  const deletingSelectedWorkspace = $derived(
+    deletingWorkspaceTarget !== null &&
+      deletingWorkspaceTarget.id === workspaceId &&
+      deletingWorkspaceTarget.hostKey === workspaceHostKey,
+  );
+  const actionsBlocked = $derived(transitioning || deletingSelectedWorkspace || forceDeleting);
   const modalOpen = $derived(
     forcePromptMessage !== null ||
       stopPromptSession !== null ||
@@ -2144,7 +2151,6 @@
     actionError = null;
     const targetId = workspaceId;
     const targetHostKey = workspaceHostKey;
-    const targetGen = workspaceGen;
     // Capture the trigger synchronously: the click handler runs
     // before `inert` is applied to .terminal-view, so this is the
     // last point we can read the originating focused element. By
@@ -2154,7 +2160,7 @@
       document.activeElement instanceof HTMLElement
         ? document.activeElement
         : null;
-    deletingWorkspace = true;
+    deletingWorkspaceTarget = { id: targetId, hostKey: targetHostKey };
     try {
       const { error, response } = targetHostKey
         ? await client.DELETE("/fleet/hosts/{host_key}/workspaces/{id}", {
@@ -2167,11 +2173,6 @@
       // about this response applies.
       if (!isCurrentWorkspace(targetId, targetHostKey)) return;
       if (response.status === 409) {
-        // A 409 that lands after the user briefly left and returned
-        // to the same workspace would feel like an unrequested
-        // prompt; suppress it on a generation mismatch and let the
-        // user retry if they want.
-        if (targetGen !== workspaceGen) return;
         previouslyFocusedEl = triggerEl;
         forcePromptForId = targetId;
         forcePromptMessage = apiErrorMessage(
@@ -2181,7 +2182,6 @@
         return;
       }
       if (!response.ok && response.status !== 204) {
-        if (targetGen !== workspaceGen) return;
         actionError = apiErrorMessage(
           error,
           `Delete failed (${response.status})`,
@@ -2195,8 +2195,11 @@
       if (!isCurrentTerminalRoute(targetId)) return;
       navigate("/workspaces");
     } finally {
-      if (isCurrentWorkspace(targetId, targetHostKey)) {
-        deletingWorkspace = false;
+      if (
+        deletingWorkspaceTarget?.id === targetId &&
+        deletingWorkspaceTarget.hostKey === targetHostKey
+      ) {
+        deletingWorkspaceTarget = null;
       }
     }
   }
@@ -2331,7 +2334,6 @@
     // leave these flags stuck true on the next workspace.
     retryingSetup = false;
     refreshingWorkspace = false;
-    deletingWorkspace = false;
 
     // Errors/transient flags from the prior workspace should not
     // bleed across — clear them but don't touch workspace/runtime.

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -2948,6 +2948,10 @@
           onCollapseSidebar={onToggleSidebar}
           onOpenItemSidebar={openItemSidebar}
           onWorkspaceListStateChange={updateWorkspaceListState}
+          isWorkspaceActionDisabled={(id, hostKey) =>
+            deletingWorkspaceTargets.some((target) =>
+              isDeletingWorkspaceTarget(target, id, hostKey),
+            )}
         />
       {/snippet}
       {@render terminalMainContent()}

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -2242,6 +2242,7 @@
     const targetHostKey = workspaceHostKey;
     const targetGen = workspaceGen;
     forceDeleting = true;
+    addDeletingWorkspaceTarget(targetId, targetHostKey);
     actionError = null;
     try {
       const { error, response } = targetHostKey
@@ -2281,6 +2282,7 @@
       if (!isCurrentTerminalRoute(targetId)) return;
       navigate("/workspaces");
     } finally {
+      removeDeletingWorkspaceTarget(targetId, targetHostKey);
       forceDeleting = false;
     }
   }

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -1319,6 +1319,7 @@
   }
 
   async function toggleTerminalPanel(): Promise<void> {
+    if (actionsBlocked) return;
     if (terminalLayout.open) {
       terminalLayout = normalizeLayoutForSessions(runtimeSessions, {
         ...terminalLayout,
@@ -1338,6 +1339,7 @@
   }
 
   function selectTerminalSession(sessionKey: string): void {
+    if (actionsBlocked) return;
     const group = terminalGroupForSession(terminalLayout.terminalGroups, sessionKey);
     const groups = terminalLayout.terminalGroups.map((candidate) =>
       candidate.id === group?.id
@@ -1361,6 +1363,7 @@
   }
 
   function selectTerminalGroup(groupID: string): void {
+    if (actionsBlocked) return;
     terminalLayout = normalizeLayoutForSessions(
       runtimeSessions,
       layoutWithTerminalGroups(
@@ -1375,6 +1378,7 @@
   }
 
   function moveSessionToTerminal(sessionKey: string): void {
+    if (actionsBlocked) return;
     const session = runtimeSessions.find((s) => s.key === sessionKey);
     if (!session) return;
     const groups = addTerminalGroup(terminalLayout.terminalGroups, sessionKey);
@@ -1400,6 +1404,7 @@
   }
 
   function moveSessionToWorkflow(sessionKey: string): void {
+    if (actionsBlocked) return;
     const terminalGroups = closeSessionInTerminalGroups(
       terminalLayout.terminalGroups,
       sessionKey,
@@ -1456,6 +1461,7 @@
     sourceTabKey: WorkflowTabKey,
     targetTabKey: WorkflowTabKey,
   ): void {
+    if (actionsBlocked) return;
     if (sourceTabKey === targetTabKey) return;
     const prepared = normalizeLayoutForSessions(
       runtimeSessions,
@@ -1476,6 +1482,7 @@
     sourceTabKey: WorkflowTabKey,
     leafID: string,
   ): void {
+    if (actionsBlocked) return;
     const prepared = normalizeLayoutForSessions(
       runtimeSessions,
       layoutWithWorkflowTab(sourceTabKey, terminalLayout),
@@ -1497,6 +1504,7 @@
     direction: SplitDirection,
     placement: "before" | "after",
   ): void {
+    if (actionsBlocked) return;
     const prepared = normalizeLayoutForSessions(
       runtimeSessions,
       layoutWithWorkflowTab(sourceTabKey, terminalLayout),
@@ -1515,6 +1523,7 @@
   }
 
   function closeWorkflowTab(tabKey: WorkflowTabKey): void {
+    if (actionsBlocked) return;
     if (tabKey === "terminal") {
       terminalLayout = normalizeLayoutForSessions(runtimeSessions, {
         ...terminalLayout,
@@ -1534,6 +1543,7 @@
   }
 
   function moveWorkflowTabToTerminal(tabKey: WorkflowTabKey): void {
+    if (actionsBlocked) return;
     const sessionKey = sessionKeyFromWorkflowTab(tabKey);
     if (sessionKey !== null) {
       moveSessionToTerminal(sessionKey);
@@ -1541,6 +1551,7 @@
   }
 
   function renameWorkflowTab(tabKey: WorkflowTabKey): void {
+    if (actionsBlocked) return;
     const sessionKey = sessionKeyFromWorkflowTab(tabKey);
     if (sessionKey === null) return;
     const session = runtimeSessions.find((s) => s.key === sessionKey);
@@ -1912,6 +1923,7 @@
   }
 
   function dockTerminalPanel(dock: TerminalDock): void {
+    if (actionsBlocked) return;
     terminalLayout = normalizeLayoutForSessions(runtimeSessions, {
       ...terminalLayout,
       dock,
@@ -1925,6 +1937,7 @@
   }
 
   function resizeTerminalPanel(height: number): void {
+    if (actionsBlocked) return;
     terminalLayout = {
       ...terminalLayout,
       height: clampTerminalHeight(height),
@@ -1932,6 +1945,7 @@
   }
 
   function updateActiveTerminalTree(tree: PaneNode | null): void {
+    if (actionsBlocked) return;
     const activeGroupID = terminalLayout.activeTerminalGroupID;
     terminalLayout = {
       ...terminalLayout,
@@ -1951,6 +1965,7 @@
   }
 
   function handleWorkflowDragOver(event: DragEvent): void {
+    if (actionsBlocked) return;
     if (readDroppedSession(event) === null) return;
     event.preventDefault();
     if (event.dataTransfer) {
@@ -1959,6 +1974,7 @@
   }
 
   function handleWorkflowDrop(event: DragEvent): void {
+    if (actionsBlocked) return;
     const sessionKey = readDroppedSession(event);
     if (sessionKey === null) return;
     event.preventDefault();

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -1156,6 +1156,7 @@ describe("WorkspaceTerminalView", () => {
     localStorage.setItem("middleman-workspace-active-tab:ws-1", "home");
     mocks.getWorkspaceRuntime.mockResolvedValue(runtimeWithTwoTerminalSessions());
     const deleteRequest = deferred<Response>();
+    const otherDeleteRequest = deferred<Response>();
     const otherWorkspaceResponse = {
       ...workspaceResponse,
       id: "ws-2",
@@ -1168,6 +1169,9 @@ describe("WorkspaceTerminalView", () => {
       const { pathname } = new URL(url, "http://localhost");
       if (method === "DELETE" && pathname.endsWith("/workspaces/ws-1")) {
         return deleteRequest.promise;
+      }
+      if (method === "DELETE" && pathname.endsWith("/workspaces/ws-2")) {
+        return otherDeleteRequest.promise;
       }
       if (pathname.endsWith("/workspaces/ws-1")) {
         return Promise.resolve(Response.json(workspaceResponse));
@@ -1246,6 +1250,17 @@ describe("WorkspaceTerminalView", () => {
         }),
       ).toBe(true);
     });
+    await fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(([input]) => {
+          if (!(input instanceof Request)) return false;
+          const { pathname } = new URL(input.url);
+          return input.method === "DELETE" && pathname === "/api/v1/workspaces/ws-2";
+        }),
+      ).toBe(true);
+    });
+    expect(screen.getByRole("button", { name: "Delete" }).hasAttribute("disabled")).toBe(true);
 
     window.history.pushState({}, "", "/terminal/ws-1");
     await view.rerender({ workspaceId: "ws-1" });
@@ -1257,6 +1272,7 @@ describe("WorkspaceTerminalView", () => {
     expect(screen.getByRole("button", { name: "Move Shell to workflow" }).hasAttribute("disabled")).toBe(true);
     expect(screen.getByRole("button", { name: "Close Shell" }).hasAttribute("disabled")).toBe(true);
 
+    otherDeleteRequest.resolve(new Response(null, { status: 204 }));
     deleteRequest.resolve(new Response(null, { status: 204 }));
     await waitFor(() => expect(window.location.pathname).toBe("/workspaces"));
   });

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -193,6 +193,13 @@ const workspaceResponse = {
   platform_host: "github.com",
   repo_owner: "acme",
   repo_name: "widget",
+  repo: {
+    provider: "github",
+    platform_host: "github.com",
+    owner: "acme",
+    name: "widget",
+    repo_path: "acme/widget",
+  },
   item_type: "pull_request",
   item_number: 7,
   git_head_ref: "feature/session-exit",
@@ -216,7 +223,15 @@ function runtimeWithSession(createdAt: string) {
 
 function runtimeWithStaleSession() {
   return {
-    launch_targets: [],
+    launch_targets: [
+      {
+        key: "helper",
+        label: "Helper",
+        kind: "agent",
+        source: "config",
+        available: true,
+      },
+    ],
     sessions: [runningSession],
   };
 }
@@ -1129,5 +1144,64 @@ describe("WorkspaceTerminalView", () => {
     await fireEvent.click(collapseButton);
 
     expect(onToggleSidebar).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables middle-pane workspace controls while the selected workspace is deleting", async () => {
+    localStorage.setItem("middleman-workspace-active-tab:ws-1", "home");
+    const deleteRequest = deferred<Response>();
+    const fetchMock = vi.fn().mockImplementation((input: Request | URL | string, init?: RequestInit) => {
+      const url = input instanceof Request ? input.url : String(input);
+      const method = init?.method ?? (input instanceof Request ? input.method : "GET");
+      const { pathname } = new URL(url, "http://localhost");
+      if (method === "DELETE" && pathname.endsWith("/workspaces/ws-1")) {
+        return deleteRequest.promise;
+      }
+      if (pathname.endsWith("/workspaces/ws-1")) {
+        return Promise.resolve(Response.json(workspaceResponse));
+      }
+      if (pathname.endsWith("/api/v1/workspaces")) {
+        return Promise.resolve(Response.json({ workspaces: [workspaceResponse] }));
+      }
+      if (pathname.endsWith("/workspaces/ws-1/files")) {
+        return Promise.resolve(Response.json({ stale: false, whitespace_only_count: 0, files: [] }));
+      }
+      if (pathname.endsWith("/workspaces/ws-1/diff")) {
+        return Promise.resolve(Response.json({ stale: false, whitespace_only_count: 0, files: [] }));
+      }
+      return Promise.resolve(Response.json({}));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal(
+      "confirm",
+      vi.fn(() => true),
+    );
+    window.history.pushState({}, "", "/terminal/ws-1");
+
+    render(WorkspaceTerminalView, {
+      props: {
+        workspaceId: "ws-1",
+      },
+    });
+
+    await screen.findByRole("button", { name: "Launch" });
+    await fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(([input]) => {
+          if (!(input instanceof Request)) return false;
+          const { pathname } = new URL(input.url);
+          return input.method === "DELETE" && pathname === "/api/v1/workspaces/ws-1";
+        }),
+      ).toBe(true);
+    });
+
+    expect(screen.getAllByRole("button", { name: "Launch" }).every((button) => button.hasAttribute("disabled"))).toBe(
+      true,
+    );
+    expect(screen.getByRole("button", { name: "Delete" }).hasAttribute("disabled")).toBe(true);
+    expect(screen.getByRole("button", { name: "Terminal options" }).hasAttribute("disabled")).toBe(true);
+
+    deleteRequest.resolve(new Response(null, { status: 204 }));
+    await waitFor(() => expect(window.location.pathname).toBe("/workspaces"));
   });
 });

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -1150,6 +1150,12 @@ describe("WorkspaceTerminalView", () => {
     localStorage.setItem("middleman-workspace-active-tab:ws-1", "home");
     mocks.getWorkspaceRuntime.mockResolvedValue(runtimeWithTwoTerminalSessions());
     const deleteRequest = deferred<Response>();
+    const otherWorkspaceResponse = {
+      ...workspaceResponse,
+      id: "ws-2",
+      item_number: 8,
+      worktree_path: "/tmp/worktree-2",
+    };
     const fetchMock = vi.fn().mockImplementation((input: Request | URL | string, init?: RequestInit) => {
       const url = input instanceof Request ? input.url : String(input);
       const method = init?.method ?? (input instanceof Request ? input.method : "GET");
@@ -1160,13 +1166,16 @@ describe("WorkspaceTerminalView", () => {
       if (pathname.endsWith("/workspaces/ws-1")) {
         return Promise.resolve(Response.json(workspaceResponse));
       }
-      if (pathname.endsWith("/api/v1/workspaces")) {
-        return Promise.resolve(Response.json({ workspaces: [workspaceResponse] }));
+      if (pathname.endsWith("/workspaces/ws-2")) {
+        return Promise.resolve(Response.json(otherWorkspaceResponse));
       }
-      if (pathname.endsWith("/workspaces/ws-1/files")) {
+      if (pathname.endsWith("/api/v1/workspaces")) {
+        return Promise.resolve(Response.json({ workspaces: [workspaceResponse, otherWorkspaceResponse] }));
+      }
+      if (pathname.endsWith("/workspaces/ws-1/files") || pathname.endsWith("/workspaces/ws-2/files")) {
         return Promise.resolve(Response.json({ stale: false, whitespace_only_count: 0, files: [] }));
       }
-      if (pathname.endsWith("/workspaces/ws-1/diff")) {
+      if (pathname.endsWith("/workspaces/ws-1/diff") || pathname.endsWith("/workspaces/ws-2/diff")) {
         return Promise.resolve(Response.json({ stale: false, whitespace_only_count: 0, files: [] }));
       }
       return Promise.resolve(Response.json({}));
@@ -1178,7 +1187,7 @@ describe("WorkspaceTerminalView", () => {
     );
     window.history.pushState({}, "", "/terminal/ws-1");
 
-    render(WorkspaceTerminalView, {
+    const view = render(WorkspaceTerminalView, {
       props: {
         workspaceId: "ws-1",
       },
@@ -1219,6 +1228,28 @@ describe("WorkspaceTerminalView", () => {
     expect(
       screen.getAllByRole("button", { name: "Shell" }).every((button) => button.getAttribute("draggable") === "false"),
     ).toBe(true);
+
+    window.history.pushState({}, "", "/terminal/ws-2");
+    await view.rerender({ workspaceId: "ws-2" });
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(([input]) => {
+          if (!(input instanceof Request)) return false;
+          const { pathname } = new URL(input.url);
+          return pathname === "/api/v1/workspaces/ws-2";
+        }),
+      ).toBe(true);
+    });
+
+    window.history.pushState({}, "", "/terminal/ws-1");
+    await view.rerender({ workspaceId: "ws-1" });
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Focus Shell" }).hasAttribute("disabled")).toBe(true);
+    });
+    expect(screen.getByRole("button", { name: "Focus Shell" }).getAttribute("draggable")).toBe("false");
+    expect(screen.getByRole("button", { name: "Rename Shell" }).hasAttribute("disabled")).toBe(true);
+    expect(screen.getByRole("button", { name: "Move Shell to workflow" }).hasAttribute("disabled")).toBe(true);
+    expect(screen.getByRole("button", { name: "Close Shell" }).hasAttribute("disabled")).toBe(true);
 
     deleteRequest.resolve(new Response(null, { status: 204 }));
     await waitFor(() => expect(window.location.pathname).toBe("/workspaces"));

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   mockLoadAddon: vi.fn(),
   mockOnData: vi.fn(),
   mockOpen: vi.fn(),
+  mockTerminalInstances: [] as Array<{ options: Record<string, unknown> }>,
   renameWorkspaceSession: vi.fn(),
   stopWorkspaceSession: vi.fn(),
   terminalWrite: vi.fn(),
@@ -29,13 +30,13 @@ class MockWebSocket {
     sockets.push(this);
   }
 
-  send(): void {}
-  close(): void {}
+  send = vi.fn();
+  close = vi.fn();
 }
 
 vi.mock("@xterm/xterm", () => ({
   Terminal: vi.fn().mockImplementation(function (options) {
-    return {
+    const terminal = {
       cols: 80,
       rows: 24,
       clearTextureAtlas: vi.fn(),
@@ -48,6 +49,8 @@ vi.mock("@xterm/xterm", () => ({
       write: mocks.terminalWrite,
       options: { ...options },
     };
+    mocks.mockTerminalInstances.push(terminal);
+    return terminal;
   }),
 }));
 
@@ -78,7 +81,7 @@ vi.mock("ghostty-web", () => ({
     };
   }),
   Terminal: vi.fn().mockImplementation(function (options) {
-    return {
+    const terminal = {
       cols: 80,
       rows: 24,
       open: mocks.mockOpen,
@@ -88,6 +91,8 @@ vi.mock("ghostty-web", () => ({
       write: mocks.terminalWrite,
       options: { ...options },
     };
+    mocks.mockTerminalInstances.push(terminal);
+    return terminal;
   }),
 }));
 
@@ -325,6 +330,7 @@ describe("WorkspaceTerminalView", () => {
     );
     mocks.stopWorkspaceSession.mockReset();
     mocks.terminalWrite.mockReset();
+    mocks.mockTerminalInstances.length = 0;
 
     vi.stubGlobal(
       "fetch",
@@ -1250,6 +1256,63 @@ describe("WorkspaceTerminalView", () => {
     expect(screen.getByRole("button", { name: "Rename Shell" }).hasAttribute("disabled")).toBe(true);
     expect(screen.getByRole("button", { name: "Move Shell to workflow" }).hasAttribute("disabled")).toBe(true);
     expect(screen.getByRole("button", { name: "Close Shell" }).hasAttribute("disabled")).toBe(true);
+
+    deleteRequest.resolve(new Response(null, { status: 204 }));
+    await waitFor(() => expect(window.location.pathname).toBe("/workspaces"));
+  });
+
+  it("disables active workflow terminal input while the selected workspace is deleting", async () => {
+    const deleteRequest = deferred<Response>();
+    const fetchMock = vi.fn().mockImplementation((input: Request | URL | string, init?: RequestInit) => {
+      const url = input instanceof Request ? input.url : String(input);
+      const method = init?.method ?? (input instanceof Request ? input.method : "GET");
+      const { pathname } = new URL(url, "http://localhost");
+      if (method === "DELETE" && pathname.endsWith("/workspaces/ws-1")) {
+        return deleteRequest.promise;
+      }
+      if (pathname.endsWith("/workspaces/ws-1")) {
+        return Promise.resolve(Response.json(workspaceResponse));
+      }
+      if (pathname.endsWith("/api/v1/workspaces")) {
+        return Promise.resolve(Response.json({ workspaces: [workspaceResponse] }));
+      }
+      return Promise.resolve(Response.json({}));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal(
+      "confirm",
+      vi.fn(() => true),
+    );
+    window.history.pushState({}, "", "/terminal/ws-1");
+
+    render(WorkspaceTerminalView, {
+      props: {
+        workspaceId: "ws-1",
+      },
+    });
+
+    await screen.findByRole("tab", { name: /Helper/ });
+    await waitFor(() => expect(mocks.mockTerminalInstances.length).toBeGreaterThanOrEqual(1));
+    expect(mocks.mockTerminalInstances.some((terminal) => terminal.options.disableStdin === true)).toBe(false);
+    const terminalDataHandler = mocks.mockOnData.mock.calls.at(-1)?.[0] as ((data: string) => void) | undefined;
+    expect(terminalDataHandler).toBeTypeOf("function");
+
+    await fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(([input]) => {
+          if (!(input instanceof Request)) return false;
+          const { pathname } = new URL(input.url);
+          return input.method === "DELETE" && pathname === "/api/v1/workspaces/ws-1";
+        }),
+      ).toBe(true);
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Delete" }).hasAttribute("disabled")).toBe(true);
+    });
+    sockets.forEach((socket) => socket.send.mockClear());
+    terminalDataHandler?.("echo blocked");
+    expect(sockets.every((socket) => socket.send.mock.calls.length === 0)).toBe(true);
 
     deleteRequest.resolve(new Response(null, { status: 204 }));
     await waitFor(() => expect(window.location.pathname).toBe("/workspaces"));

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -1148,6 +1148,7 @@ describe("WorkspaceTerminalView", () => {
 
   it("disables middle-pane workspace controls while the selected workspace is deleting", async () => {
     localStorage.setItem("middleman-workspace-active-tab:ws-1", "home");
+    mocks.getWorkspaceRuntime.mockResolvedValue(runtimeWithTwoTerminalSessions());
     const deleteRequest = deferred<Response>();
     const fetchMock = vi.fn().mockImplementation((input: Request | URL | string, init?: RequestInit) => {
       const url = input instanceof Request ? input.url : String(input);
@@ -1184,6 +1185,10 @@ describe("WorkspaceTerminalView", () => {
     });
 
     await screen.findByRole("button", { name: "Launch" });
+    await fireEvent.click(screen.getByRole("button", { name: "Open terminal panel" }));
+    const shellPaneButton = await screen.findByRole("button", { name: "Focus Shell" });
+    expect(shellPaneButton.getAttribute("draggable")).toBe("true");
+
     await fireEvent.click(screen.getByRole("button", { name: "Delete" }));
     await waitFor(() => {
       expect(
@@ -1203,6 +1208,17 @@ describe("WorkspaceTerminalView", () => {
     expect(screen.getByRole("button", { name: "Reviews" }).hasAttribute("disabled")).toBe(true);
     expect(screen.getByRole("button", { name: "Delete" }).hasAttribute("disabled")).toBe(true);
     expect(screen.getByRole("button", { name: "Terminal options" }).hasAttribute("disabled")).toBe(true);
+    expect(screen.getByRole("button", { name: "Focus Shell" }).hasAttribute("disabled")).toBe(true);
+    expect(screen.getByRole("button", { name: "Focus Shell" }).getAttribute("draggable")).toBe("false");
+    expect(screen.getByRole("button", { name: "Rename Shell" }).hasAttribute("disabled")).toBe(true);
+    expect(screen.getByRole("button", { name: "Move Shell to workflow" }).hasAttribute("disabled")).toBe(true);
+    expect(screen.getByRole("button", { name: "Close Shell" }).hasAttribute("disabled")).toBe(true);
+    expect(screen.getAllByRole("button", { name: "Shell" }).every((button) => button.hasAttribute("disabled"))).toBe(
+      true,
+    );
+    expect(
+      screen.getAllByRole("button", { name: "Shell" }).every((button) => button.getAttribute("draggable") === "false"),
+    ).toBe(true);
 
     deleteRequest.resolve(new Response(null, { status: 204 }));
     await waitFor(() => expect(window.location.pathname).toBe("/workspaces"));

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -1198,6 +1198,9 @@ describe("WorkspaceTerminalView", () => {
     expect(screen.getAllByRole("button", { name: "Launch" }).every((button) => button.hasAttribute("disabled"))).toBe(
       true,
     );
+    expect(screen.getByRole("button", { name: "Diff" }).hasAttribute("disabled")).toBe(true);
+    expect(screen.getByRole("button", { name: "PR" }).hasAttribute("disabled")).toBe(true);
+    expect(screen.getByRole("button", { name: "Reviews" }).hasAttribute("disabled")).toBe(true);
     expect(screen.getByRole("button", { name: "Delete" }).hasAttribute("disabled")).toBe(true);
     expect(screen.getByRole("button", { name: "Terminal options" }).hasAttribute("disabled")).toBe(true);
 

--- a/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
@@ -15,19 +15,19 @@
   import { createTmuxMouseDragFilter } from "./tmuxMouseDragFilter.js";
 
   interface TerminalPaneProps {
-    workspaceId?: string;
-    websocketPath?: string;
-    reconnectOnExit?: boolean;
-    active?: boolean;
+    workspaceId?: string | undefined;
+    websocketPath?: string | undefined;
+    reconnectOnExit?: boolean | undefined;
+    active?: boolean | undefined;
     disabled?: boolean;
-    onExit?: (code: number) => void;
+    onExit?: ((code: number) => void) | undefined;
     // When the session is not attachable at mount time, skip the
     // WebSocket connect — the server's attach endpoint returns 404
     // for non-running sessions, which would loop scheduleReconnect.
-    initialStatus?: string;
+    initialStatus?: string | undefined;
   }
 
-  const {
+  let {
     workspaceId,
     websocketPath,
     reconnectOnExit = true,

--- a/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
@@ -19,6 +19,7 @@
     websocketPath?: string;
     reconnectOnExit?: boolean;
     active?: boolean;
+    disabled?: boolean;
     onExit?: (code: number) => void;
     // When the session is not attachable at mount time, skip the
     // WebSocket connect — the server's attach endpoint returns 404
@@ -31,6 +32,7 @@
     websocketPath,
     reconnectOnExit = true,
     active = true,
+    disabled = false,
     onExit,
     initialStatus,
   }: TerminalPaneProps = $props();
@@ -271,6 +273,11 @@
   }
 
   function handleTerminalPaste(event: ClipboardEvent): void {
+    if (disabled) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      return;
+    }
     if (ws?.readyState !== WebSocket.OPEN) return;
 
     const pastedText =
@@ -445,11 +452,17 @@
     terminal.options.lineHeight = terminalLineHeight;
     terminal.options.letterSpacing = terminalLetterSpacing;
     terminal.options.cursorBlink = terminalCursorBlink;
+    terminal.options.disableStdin = disabled;
     if (ligaturesChanged) {
       syncLigaturesAddon();
     }
     redrawTerminalTextureAtlas();
     fitAddon?.fit();
+  });
+
+  $effect(() => {
+    if (!terminal) return;
+    terminal.options.disableStdin = disabled;
   });
 
   $effect(() => {
@@ -488,6 +501,7 @@
         rescaleOverlappingGlyphs: true,
         scrollOnEraseInDisplay: true,
         smoothScrollDuration: TERMINAL_SMOOTH_SCROLL_DURATION,
+        disableStdin: disabled,
       });
       terminal = term;
 
@@ -514,6 +528,7 @@
       fit.fit();
 
       term.onData((data: string) => {
+        if (disabled) return;
         if (ws?.readyState !== WebSocket.OPEN) return;
 
         const filteredData = tmuxMouseDragFilter.filter(data);
@@ -523,6 +538,7 @@
       });
 
       term.onBinary((data: string) => {
+        if (disabled) return;
         if (ws?.readyState === WebSocket.OPEN) {
           const buf = new Uint8Array(data.length);
           for (let i = 0; i < data.length; i++) {

--- a/frontend/tests/e2e-full/00-workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e-full/00-workspace-sidebar.spec.ts
@@ -591,11 +591,7 @@ test.describe("workspace sidebar full-stack", () => {
       await page.goto(`${isolatedServer.info.base_url}/terminal/${deletingWorkspace.id}`);
       await expect(page.locator(".workspace-list-sidebar .ws-row")).toHaveCount(2);
 
-      await page.locator(".workspace-list-sidebar .ws-row.selected").click({ button: "right" });
-      page.once("dialog", (dialog) => {
-        void dialog.accept();
-      });
-      await page.getByRole("menuitem", { name: /Delete workspace/ }).click();
+      await page.locator(".header-bar").getByRole("button", { name: "Delete" }).click();
       await deleteStarted;
 
       const deleteButton = page.locator(".header-bar").getByRole("button", { name: "Delete" });
@@ -606,9 +602,6 @@ test.describe("workspace sidebar full-stack", () => {
       await expect(page).not.toHaveURL(new RegExp(`/terminal/${deletingWorkspace.id}$`));
       await expect(page).toHaveURL(new RegExp(`/terminal/${otherWorkspace.id}$`));
 
-      page.once("dialog", (dialog) => {
-        void dialog.accept();
-      });
       await page.locator(".header-bar").getByRole("button", { name: "Delete" }).click();
       await otherDeleteStarted;
       await expect(page.locator(".header-bar").getByRole("button", { name: "Delete" })).toBeDisabled();

--- a/frontend/tests/e2e-full/00-workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e-full/00-workspace-sidebar.spec.ts
@@ -540,6 +540,64 @@ test.describe("workspace sidebar full-stack", () => {
     }
   });
 
+  test("pending workspace delete stays locked after navigating away and back", async ({ page }) => {
+    let isolatedServer: IsolatedE2EServer | null = null;
+    let api: APIRequestContext | null = null;
+    try {
+      isolatedServer = await startIsolatedWorkspaceE2EServer();
+      api = await playwrightRequest.newContext({
+        baseURL: isolatedServer.info.base_url,
+      });
+
+      const deletingWorkspace = await createIssueWorkspace(api, 10);
+      await createIssueWorkspace(api, 13);
+
+      let releaseDelete!: () => void;
+      const deleteMayContinue = new Promise<void>((resolve) => {
+        releaseDelete = resolve;
+      });
+      let markDeleteStarted!: () => void;
+      const deleteStarted = new Promise<void>((resolve) => {
+        markDeleteStarted = resolve;
+      });
+
+      await page.route(`**/api/v1/workspaces/${deletingWorkspace.id}`, async (route) => {
+        if (route.request().method() !== "DELETE") {
+          await route.continue();
+          return;
+        }
+        markDeleteStarted();
+        await deleteMayContinue;
+        await route.continue();
+      });
+
+      await page.goto(`${isolatedServer.info.base_url}/terminal/${deletingWorkspace.id}`);
+      await expect(page.locator(".workspace-list-sidebar .ws-row")).toHaveCount(2);
+
+      page.once("dialog", (dialog) => {
+        void dialog.accept();
+      });
+      await page.locator(".header-bar").getByRole("button", { name: "Delete" }).click();
+      await deleteStarted;
+
+      const deleteButton = page.locator(".header-bar").getByRole("button", { name: "Delete" });
+      await expect(deleteButton).toBeDisabled();
+
+      await page.locator(".workspace-list-sidebar .ws-row:not(.selected)").click();
+      await expect(page).not.toHaveURL(new RegExp(`/terminal/${deletingWorkspace.id}$`));
+
+      await page.locator(".workspace-list-sidebar .ws-row:not(.selected)").click();
+      await expect(page).toHaveURL(new RegExp(`/terminal/${deletingWorkspace.id}$`));
+      await expect(deleteButton).toBeDisabled();
+
+      releaseDelete();
+      await expect(page).toHaveURL(/\/workspaces$/);
+    } finally {
+      await api?.dispose();
+      await isolatedServer?.stop();
+    }
+  });
+
   test("ghostty shell terminal paints output and accepts browser keyboard input", async ({ page }) => {
     let isolatedServer: IsolatedE2EServer | null = null;
     let api: APIRequestContext | null = null;

--- a/frontend/tests/e2e-full/00-workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e-full/00-workspace-sidebar.spec.ts
@@ -591,14 +591,16 @@ test.describe("workspace sidebar full-stack", () => {
       await page.goto(`${isolatedServer.info.base_url}/terminal/${deletingWorkspace.id}`);
       await expect(page.locator(".workspace-list-sidebar .ws-row")).toHaveCount(2);
 
+      await page.locator(".workspace-list-sidebar .ws-row.selected").click({ button: "right" });
       page.once("dialog", (dialog) => {
         void dialog.accept();
       });
-      await page.locator(".header-bar").getByRole("button", { name: "Delete" }).click();
+      await page.getByRole("menuitem", { name: /Delete workspace/ }).click();
       await deleteStarted;
 
       const deleteButton = page.locator(".header-bar").getByRole("button", { name: "Delete" });
       await expect(deleteButton).toBeDisabled();
+      await page.keyboard.press("Escape");
 
       await page.locator(".workspace-list-sidebar .ws-row:not(.selected)").click();
       await expect(page).not.toHaveURL(new RegExp(`/terminal/${deletingWorkspace.id}$`));
@@ -612,7 +614,7 @@ test.describe("workspace sidebar full-stack", () => {
       await expect(page.locator(".header-bar").getByRole("button", { name: "Delete" })).toBeDisabled();
 
       await page.locator(".workspace-list-sidebar .ws-row.selected").click({ button: "right" });
-      await expect(page.getByRole("menuitem", { name: /Delete workspace/ })).toBeDisabled();
+      await expect(page.getByRole("menuitem", { name: /Delete workspace|Deleting/ })).toBeDisabled();
       await page.keyboard.press("Escape");
 
       await page.locator(".workspace-list-sidebar .ws-row:not(.selected)").click();
@@ -620,7 +622,7 @@ test.describe("workspace sidebar full-stack", () => {
       await expect(deleteButton).toBeDisabled();
 
       await page.locator(".workspace-list-sidebar .ws-row.selected").click({ button: "right" });
-      await expect(page.getByRole("menuitem", { name: /Delete workspace/ })).toBeDisabled();
+      await expect(page.getByRole("menuitem", { name: /Delete workspace|Deleting/ })).toBeDisabled();
       await page.keyboard.press("Escape");
 
       releaseOtherDelete();

--- a/frontend/tests/e2e-full/00-workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e-full/00-workspace-sidebar.spec.ts
@@ -550,7 +550,7 @@ test.describe("workspace sidebar full-stack", () => {
       });
 
       const deletingWorkspace = await createIssueWorkspace(api, 10);
-      await createIssueWorkspace(api, 13);
+      const otherWorkspace = await createIssueWorkspace(api, 13);
 
       let releaseDelete!: () => void;
       const deleteMayContinue = new Promise<void>((resolve) => {
@@ -560,6 +560,14 @@ test.describe("workspace sidebar full-stack", () => {
       const deleteStarted = new Promise<void>((resolve) => {
         markDeleteStarted = resolve;
       });
+      let releaseOtherDelete!: () => void;
+      const otherDeleteMayContinue = new Promise<void>((resolve) => {
+        releaseOtherDelete = resolve;
+      });
+      let markOtherDeleteStarted!: () => void;
+      const otherDeleteStarted = new Promise<void>((resolve) => {
+        markOtherDeleteStarted = resolve;
+      });
 
       await page.route(`**/api/v1/workspaces/${deletingWorkspace.id}`, async (route) => {
         if (route.request().method() !== "DELETE") {
@@ -568,6 +576,15 @@ test.describe("workspace sidebar full-stack", () => {
         }
         markDeleteStarted();
         await deleteMayContinue;
+        await route.continue();
+      });
+      await page.route(`**/api/v1/workspaces/${otherWorkspace.id}`, async (route) => {
+        if (route.request().method() !== "DELETE") {
+          await route.continue();
+          return;
+        }
+        markOtherDeleteStarted();
+        await otherDeleteMayContinue;
         await route.continue();
       });
 
@@ -585,11 +602,28 @@ test.describe("workspace sidebar full-stack", () => {
 
       await page.locator(".workspace-list-sidebar .ws-row:not(.selected)").click();
       await expect(page).not.toHaveURL(new RegExp(`/terminal/${deletingWorkspace.id}$`));
+      await expect(page).toHaveURL(new RegExp(`/terminal/${otherWorkspace.id}$`));
+
+      page.once("dialog", (dialog) => {
+        void dialog.accept();
+      });
+      await page.locator(".header-bar").getByRole("button", { name: "Delete" }).click();
+      await otherDeleteStarted;
+      await expect(page.locator(".header-bar").getByRole("button", { name: "Delete" })).toBeDisabled();
+
+      await page.locator(".workspace-list-sidebar .ws-row.selected").click({ button: "right" });
+      await expect(page.getByRole("menuitem", { name: /Delete workspace/ })).toBeDisabled();
+      await page.keyboard.press("Escape");
 
       await page.locator(".workspace-list-sidebar .ws-row:not(.selected)").click();
       await expect(page).toHaveURL(new RegExp(`/terminal/${deletingWorkspace.id}$`));
       await expect(deleteButton).toBeDisabled();
 
+      await page.locator(".workspace-list-sidebar .ws-row.selected").click({ button: "right" });
+      await expect(page.getByRole("menuitem", { name: /Delete workspace/ })).toBeDisabled();
+      await page.keyboard.press("Escape");
+
+      releaseOtherDelete();
       releaseDelete();
       await expect(page).toHaveURL(/\/workspaces$/);
     } finally {

--- a/packages/ui/src/components/diff/DiffScopePicker.svelte
+++ b/packages/ui/src/components/diff/DiffScopePicker.svelte
@@ -7,9 +7,10 @@
 
   interface Props {
     compact?: boolean;
+    disabled?: boolean;
   }
 
-  const { compact = false }: Props = $props();
+  const { compact = false, disabled = false }: Props = $props();
   const { diff: diffStore } = getStores();
 
   let open = $state(false);
@@ -21,7 +22,12 @@
   const scope = $derived(diffStore.getScope());
   const scopeLabel = $derived(formatDiffScopeLabel(scope));
 
+  $effect(() => {
+    if (disabled) open = false;
+  });
+
   function toggle(): void {
+    if (disabled) return;
     open = !open;
     if (open) {
       void diffStore.loadCommits();
@@ -43,6 +49,7 @@
   }
 
   function handleCommitClick(sha: string, shiftKey: boolean): void {
+    if (disabled) return;
     if (shiftKey && scope.kind === "commit") {
       diffStore.selectRange(scope.sha, sha);
     } else {
@@ -75,6 +82,7 @@
       aria-label={`Select commit range: ${scopeLabel}`}
       aria-expanded={open}
       title="Commits"
+      disabled={disabled}
       onclick={toggle}
     >
       {#if compact}
@@ -95,6 +103,7 @@
           <button
             class="diff-scope-picker__reset"
             type="button"
+            disabled={disabled}
             onclick={diffStore.resetToHead}
           >
             Clear

--- a/packages/ui/src/components/diff/DiffToolbar.svelte
+++ b/packages/ui/src/components/diff/DiffToolbar.svelte
@@ -15,6 +15,7 @@
     showRichPreview?: boolean;
     showScopePicker?: boolean;
     showFileJump?: boolean;
+    disabled?: boolean;
   }
 
   let {
@@ -24,6 +25,7 @@
     showRichPreview = true,
     showScopePicker = true,
     showFileJump = false,
+    disabled = false,
   }: Props = $props();
 
   const { diff } = getStores();
@@ -45,7 +47,12 @@
   let menuOpen = $state(false);
   let compactMenuRef = $state<HTMLDivElement>();
 
+  $effect(() => {
+    if (disabled) menuOpen = false;
+  });
+
   function setFileCategoryFilter(value: DiffFileCategoryFilter): void {
+    if (disabled) return;
     diff.setFileCategoryFilter(value);
   }
 
@@ -76,6 +83,7 @@
             class:compact-menu-item--active={activeCategory === option.value}
             aria-pressed={activeCategory === option.value}
             type="button"
+            disabled={disabled}
             onclick={() => setFileCategoryFilter(option.value)}
           >
             <span>{option.label}</span>
@@ -89,6 +97,7 @@
     <button
       class="compact-menu-action"
       type="button"
+      disabled={disabled}
       onclick={() => diff.setAllVisibleFilesCollapsed(!allVisibleFilesCollapsed)}
     >
       {collapseAllLabel}
@@ -103,6 +112,7 @@
           class:compact-menu-item--active={diff.getTabWidth() === opt}
           aria-pressed={diff.getTabWidth() === opt}
           type="button"
+          disabled={disabled}
           onclick={() => diff.setTabWidth(opt)}
         >
           {opt}
@@ -118,6 +128,7 @@
         role="switch"
         aria-label="File list"
         aria-checked={!fileListHidden}
+        disabled={disabled}
         onclick={onToggleFileList}
       >
         <span>File list</span>
@@ -136,6 +147,7 @@
       role="switch"
       aria-label="Hide whitespace changes"
       aria-checked={diff.getHideWhitespace()}
+      disabled={disabled}
       onclick={() => diff.setHideWhitespace(!diff.getHideWhitespace())}
     >
       <span>Hide whitespace</span>
@@ -153,6 +165,7 @@
       role="switch"
       aria-label="Side-by-side diffs"
       aria-checked={diff.getViewMode() === "split"}
+      disabled={disabled}
       onclick={() => diff.setViewMode(diff.getViewMode() === "split" ? "unified" : "split")}
     >
       <span>Side-by-side</span>
@@ -169,6 +182,7 @@
       type="button"
       role="switch"
       aria-checked={diff.getWordWrap()}
+      disabled={disabled}
       onclick={() => diff.setWordWrap(!diff.getWordWrap())}
     >
       <span>Word wrap</span>
@@ -186,6 +200,7 @@
         type="button"
         role="switch"
         aria-checked={diff.getRichPreview()}
+        disabled={disabled}
         onclick={() => diff.setRichPreview(!diff.getRichPreview())}
       >
         <span>Rich preview</span>
@@ -222,6 +237,7 @@
             class="category-btn"
             class:category-btn--active={activeCategory === option.value}
             aria-pressed={activeCategory === option.value}
+            disabled={disabled}
             onclick={() => setFileCategoryFilter(option.value)}
           >
             <span>{option.label}</span> <span class="category-count">({categoryCounts[option.value]})</span>
@@ -231,11 +247,11 @@
     </div>
   {/if}
   {#if showScopePicker}
-    <DiffScopePicker />
+    <DiffScopePicker {disabled} />
   {/if}
   <div class="toolbar-actions">
     {#if shouldShowFileJump}
-      <FileJumpPicker />
+      <FileJumpPicker {disabled} />
     {/if}
     <div class="compact-menu-wrap" bind:this={compactMenuRef}>
       <button
@@ -245,7 +261,9 @@
         aria-label="More diff filters"
         aria-expanded={menuOpen}
         title="More diff filters"
+        disabled={disabled}
         onclick={() => {
+          if (disabled) return;
           menuOpen = !menuOpen;
         }}
       >

--- a/packages/ui/src/components/diff/FileJumpPicker.svelte
+++ b/packages/ui/src/components/diff/FileJumpPicker.svelte
@@ -6,6 +6,11 @@
   import { getStores } from "../../context.js";
   import { floatingPopoverStyle } from "../shared/floatingPosition.js";
 
+  interface Props {
+    disabled?: boolean;
+  }
+
+  const { disabled = false }: Props = $props();
   const { diff } = getStores();
 
   let open = $state(false);
@@ -29,6 +34,10 @@
     if (highlightIndex > filteredFiles.length - 1) {
       highlightIndex = Math.max(filteredFiles.length - 1, 0);
     }
+  });
+
+  $effect(() => {
+    if (disabled) close();
   });
 
   $effect(() => {
@@ -72,6 +81,7 @@
   }
 
   async function toggle(): Promise<void> {
+    if (disabled) return;
     if (open) {
       close();
       return;
@@ -113,6 +123,7 @@
   }
 
   function selectFile(file: DiffFile): void {
+    if (disabled) return;
     diff.requestScrollToFile(file.path);
     close();
   }
@@ -145,7 +156,7 @@
     aria-label="Jump to file"
     aria-expanded={open}
     title="Jump to file"
-    disabled={files.length === 0}
+    disabled={disabled || files.length === 0}
     onclick={toggle}
   >
     <FileSearchIcon size={16} strokeWidth={1.9} aria-hidden="true" />
@@ -176,6 +187,7 @@
             type="button"
             role="option"
             aria-selected={file.path === activeFile}
+            disabled={disabled}
             onmouseenter={() => {
               highlightIndex = index;
             }}

--- a/packages/ui/src/components/shared/TabbedPanelTree.svelte
+++ b/packages/ui/src/components/shared/TabbedPanelTree.svelte
@@ -27,6 +27,7 @@
     tabIcon?: Snippet<[TabbedPanelDescriptor]> | undefined;
     tabActions?: Snippet<[TabbedPanelDescriptor]> | undefined;
     scrollPanels?: boolean;
+    disabled?: boolean;
     tablistLabel?: string;
     leafLabel?: string;
     resizeLabel?: string;
@@ -58,6 +59,7 @@
     tabIcon = undefined,
     tabActions = undefined,
     scrollPanels = false,
+    disabled = false,
     tablistLabel = "Panel group tabs",
     leafLabel = "Panel group",
     resizeLabel = "Resize panel split",
@@ -88,6 +90,7 @@
   }
 
   function startTabDrag(event: DragEvent, tab: TabbedPanelDescriptor): void {
+    if (disabled) return;
     if (!tabDragEnabled()) return;
     if (onStartTabDrag) {
       onStartTabDrag(event, tab);
@@ -104,6 +107,7 @@
   }
 
   function readDraggedTab(event: DragEvent): string | null {
+    if (disabled) return null;
     return onReadDraggedTab ? onReadDraggedTab(event) : readTabbedPanelTabDrag(event, dragScope);
   }
 
@@ -122,6 +126,7 @@
   }
 
   function handleTabDragOver(event: DragEvent, targetTabKey: string): void {
+    if (disabled) return;
     if (!canSortTabs()) return;
     const sourceTabKey = readDraggedTab(event);
     if (sourceTabKey === null) return;
@@ -142,6 +147,7 @@
   }
 
   function handleTabStripDragOver(event: DragEvent): void {
+    if (disabled) return;
     const sourceTabKey = readDraggedTab(event);
     if (sourceTabKey === null) return;
     const target = event.target;
@@ -164,6 +170,7 @@
   }
 
   function handleSplitDragOver(event: DragEvent): void {
+    if (disabled) return;
     const sourceTabKey = readDraggedTab(event);
     if (sourceTabKey === null) return;
     const edge = splitEdgeFromEvent(event);
@@ -284,6 +291,7 @@
   }
 
   function dropOnTab(event: DragEvent, targetTabKey: string): void {
+    if (disabled) return;
     if (!canSortTabs()) return;
     const sourceTabKey = readDraggedTab(event);
     if (sourceTabKey === null || sourceTabKey === targetTabKey) return;
@@ -298,6 +306,7 @@
   }
 
   function dropIntoLeaf(event: DragEvent, leafID: string): void {
+    if (disabled) return;
     const sourceTabKey = readDraggedTab(event);
     if (sourceTabKey === null) return;
     if (tabSortPreview && canSortTabs()) {
@@ -312,6 +321,7 @@
   }
 
   function dropSplit(event: DragEvent, leafID: string): void {
+    if (disabled) return;
     const sourceTabKey = readDraggedTab(event);
     const edge = splitEdgeFromEvent(event);
     if (sourceTabKey === null) return;
@@ -380,6 +390,7 @@
   }
 
   function startResize(event: PointerEvent): void {
+    if (disabled) return;
     if (node.type !== "split" || !splitEl) return;
     event.preventDefault();
     const rect = splitEl.getBoundingClientRect();
@@ -411,11 +422,11 @@
   }
 
   function tabDragEnabled(): boolean {
-    return Boolean(onStartTabDrag || onMoveTabBefore || onAppendTabToLeaf || onSplitTab);
+    return !disabled && Boolean(onStartTabDrag || onMoveTabBefore || onAppendTabToLeaf || onSplitTab);
   }
 
   function canSortTabs(): boolean {
-    return Boolean(onMoveTabBefore);
+    return !disabled && Boolean(onMoveTabBefore);
   }
 </script>
 
@@ -459,6 +470,7 @@
             <button
               class="tabbed-panel-tab-button"
               draggable={tabDragEnabled()}
+              disabled={disabled}
               ondragstart={(event) => startTabDrag(event, tab)}
               ondragend={finishTabDrag}
               ondblclick={() => onTabDoubleClick?.(tab.key)}
@@ -541,6 +553,7 @@
         {tabIcon}
         {tabActions}
         {scrollPanels}
+        {disabled}
         {tablistLabel}
         {leafLabel}
         {resizeLabel}
@@ -559,6 +572,7 @@
     <button
       class="tabbed-panel-split-divider"
       aria-label={resizeLabel}
+      disabled={disabled}
       onpointerdown={startResize}
     ></button>
     <div class="tabbed-panel-split-child second">
@@ -571,6 +585,7 @@
         {tabIcon}
         {tabActions}
         {scrollPanels}
+        {disabled}
         {tablistLabel}
         {leafLabel}
         {resizeLabel}
@@ -642,6 +657,16 @@
   .tabbed-panel-split-divider:focus-visible {
     background: var(--accent-blue);
     outline: none;
+  }
+
+  .tabbed-panel-split-divider:disabled {
+    cursor: default;
+    opacity: 0.62;
+  }
+
+  .tabbed-panel-split-divider:disabled:hover,
+  .tabbed-panel-split-divider:disabled:focus-visible {
+    background: var(--border-muted);
   }
 
   :global(.tabbed-panel-split.horizontal
@@ -767,12 +792,17 @@
     cursor: grab;
   }
 
+  .tabbed-panel-tab-button:disabled {
+    cursor: default;
+    color: inherit;
+  }
+
   .tabbed-panel-tabs.drag-sorting .tabbed-panel-tab-button {
     cursor: grabbing;
   }
 
-  .tabbed-panel-tab-button:hover,
-  .tabbed-panel-tab-button:focus-visible {
+  .tabbed-panel-tab-button:hover:not(:disabled),
+  .tabbed-panel-tab-button:focus-visible:not(:disabled) {
     color: var(--text-primary);
     outline: none;
   }

--- a/packages/ui/src/components/shared/TabbedPanelTree.test.ts
+++ b/packages/ui/src/components/shared/TabbedPanelTree.test.ts
@@ -239,4 +239,52 @@ describe("TabbedPanelTree", () => {
 
     expect(onRatioChange).toHaveBeenCalledWith("split-1", 0.7);
   });
+
+  it("disables tab movement and split resizing", async () => {
+    const onMoveTabBefore = vi.fn();
+    const onAppendTabToLeaf = vi.fn();
+    const onSplitTab = vi.fn();
+    const onRatioChange = vi.fn();
+    render(TabbedPanelTreeTestHarness, {
+      props: {
+        node: splitNode(),
+        disabled: true,
+        onMoveTabBefore,
+        onAppendTabToLeaf,
+        onSplitTab,
+        onRatioChange,
+      },
+    });
+    const dataTransfer = fakeDataTransfer();
+    const filesTab = screen.getByRole("tab", { name: /Files/ });
+    const feedHost = screen.getByRole("tab", { name: /Feed/ }).closest(".tabbed-panel-tab");
+    expect(feedHost).toBeTruthy();
+
+    expect(filesTab.hasAttribute("disabled")).toBe(true);
+    expect(filesTab.getAttribute("draggable")).toBe("false");
+
+    await fireEvent.dragStart(filesTab, { dataTransfer });
+    await fireEvent.dragOver(feedHost!, {
+      clientX: 210,
+      dataTransfer,
+    });
+    await fireEvent.drop(feedHost!, {
+      clientX: 210,
+      dataTransfer,
+    });
+
+    expect(screen.queryByTestId("tabbed-panel-tab-drop-placeholder")).toBeNull();
+    expect(onMoveTabBefore).not.toHaveBeenCalled();
+    expect(onAppendTabToLeaf).not.toHaveBeenCalled();
+    expect(onSplitTab).not.toHaveBeenCalled();
+
+    const divider = screen.getByRole("button", {
+      name: "Resize test split",
+    });
+    expect(divider.hasAttribute("disabled")).toBe(true);
+    await fireEvent.pointerDown(divider, { clientX: 400, pointerId: 1 });
+    window.dispatchEvent(new MouseEvent("pointermove", { clientX: 700, bubbles: true }));
+
+    expect(onRatioChange).not.toHaveBeenCalled();
+  });
 });

--- a/packages/ui/src/components/shared/TabbedPanelTreeTestHarness.svelte
+++ b/packages/ui/src/components/shared/TabbedPanelTreeTestHarness.svelte
@@ -20,6 +20,7 @@
         ) => void)
       | undefined;
     onRatioChange?: ((splitID: string, ratio: number) => void) | undefined;
+    disabled?: boolean;
   }
 
   const {
@@ -29,6 +30,7 @@
     onAppendTabToLeaf,
     onSplitTab,
     onRatioChange,
+    disabled = false,
   }: Props = $props();
 
   const tabs: TabbedPanelDescriptor[] = [
@@ -47,6 +49,7 @@
   leafLabel="Test panel group"
   dropTargetsLabel="Test panel drop targets"
   resizeLabel="Resize test split"
+  {disabled}
   {onMoveTabBefore}
   {onAppendTabToLeaf}
   {onSplitTab}

--- a/packages/ui/src/components/workspace/WorkspaceDiffPanel.svelte
+++ b/packages/ui/src/components/workspace/WorkspaceDiffPanel.svelte
@@ -185,17 +185,31 @@
     white-space: nowrap;
   }
 
-  .scope-btn:hover {
+  .scope-btn:hover:not(:disabled) {
     color: var(--text-primary);
   }
 
-  .scope-btn--active {
+  .scope-btn--active:not(:disabled) {
     background: var(--accent-blue);
     color: #fff;
   }
 
-  .scope-btn--active:hover {
+  .scope-btn--active:hover:not(:disabled) {
     color: #fff;
+  }
+
+  .scope-btn:disabled {
+    cursor: not-allowed;
+    color: color-mix(in srgb, var(--text-muted) 75%, var(--bg-surface));
+    background: var(--bg-surface);
+    opacity: 1;
+  }
+
+  .scope-btn--active:disabled {
+    background: color-mix(in srgb, rgb(128 128 128) 28%, var(--bg-surface));
+    color: color-mix(in srgb, rgb(115 115 115) 80%, var(--text-primary));
+    box-shadow: inset 0 0 0 1px
+      color-mix(in srgb, rgb(128 128 128) 35%, var(--border-muted));
   }
 
   .workspace-diff-layout {

--- a/packages/ui/src/components/workspace/WorkspaceDiffPanel.svelte
+++ b/packages/ui/src/components/workspace/WorkspaceDiffPanel.svelte
@@ -16,6 +16,7 @@
     itemNumber: number;
     active?: boolean;
     refreshToken?: number;
+    disabled?: boolean;
   }
 
   const {
@@ -29,6 +30,7 @@
     itemNumber,
     active = false,
     refreshToken = 0,
+    disabled = false,
   }: Props = $props();
   const { diff } = getStores();
 
@@ -47,6 +49,7 @@
   });
 
   function selectBase(nextBase: WorkspaceDiffBase): void {
+    if (disabled) return;
     base = nextBase;
   }
 </script>
@@ -61,6 +64,7 @@
         aria-pressed={base === "head"}
         aria-label="Compare with HEAD"
         title="HEAD"
+        disabled={disabled}
         onclick={() => selectBase("head")}
       >
         HEAD
@@ -71,6 +75,7 @@
         aria-pressed={base === "pushed"}
         aria-label="Compare with pushed branch"
         title="Pushed branch"
+        disabled={disabled}
         onclick={() => selectBase("pushed")}
       >
         Branch
@@ -81,18 +86,20 @@
         aria-pressed={base === "merge-target"}
         aria-label="Compare with merge target"
         title="Merge target"
+        disabled={disabled}
         onclick={() => selectBase("merge-target")}
       >
         Target
       </button>
     </div>
-    <DiffScopePicker compact />
+    <DiffScopePicker compact {disabled} />
   </div>
   <DiffToolbar
     compact
     showRichPreview={false}
     showFileJump
     showScopePicker={false}
+    {disabled}
   />
   <div class="workspace-diff-layout">
     <div class="workspace-diff-main">

--- a/packages/ui/src/components/workspace/WorkspaceRightSidebar.svelte
+++ b/packages/ui/src/components/workspace/WorkspaceRightSidebar.svelte
@@ -302,7 +302,7 @@
   {:else if activeTab === "pr"}
     {#if hasPR}
       {#key `pr:${provider}:${platformHost ?? ""}:${repoPath}:${associatedPRNumber ?? 0}:${refreshToken}`}
-        <div class="pr-scroll">
+        <div class="pr-scroll" inert={disabled}>
           <PullDetail
             {provider}
             {platformHost}
@@ -321,7 +321,7 @@
   {:else if activeTab === "issue"}
     {#if hasIssue}
       {#key `issue:${provider}:${platformHost ?? ""}:${repoPath}:${ownerItemNumber}:${refreshToken}`}
-        <div class="pr-scroll">
+        <div class="pr-scroll" inert={disabled}>
           <IssueDetail
             {provider}
             {platformHost}
@@ -354,9 +354,9 @@
       </div>
     {:else}
       <SidebarStoreScope stores={sidebarStores}>
-        <div class="sidebar-reviews">
+        <div class="sidebar-reviews" inert={disabled}>
           <div class="sidebar-reviews-header">
-            <FilterBar disabled={!parentStores.roborevDaemon?.isAvailable()} />
+            <FilterBar disabled={disabled || !parentStores.roborevDaemon?.isAvailable()} />
             <DaemonStatus />
           </div>
           <div class="sidebar-reviews-body">

--- a/packages/ui/src/components/workspace/WorkspaceRightSidebar.svelte
+++ b/packages/ui/src/components/workspace/WorkspaceRightSidebar.svelte
@@ -52,6 +52,7 @@
     branch: string;
     roborevBaseUrl: string;
     refreshToken?: number;
+    disabled?: boolean;
   }
 
   let {
@@ -69,6 +70,7 @@
     branch,
     roborevBaseUrl,
     refreshToken = 0,
+    disabled = false,
   }: Props = $props();
 
   const parentStores = getStores();
@@ -294,6 +296,7 @@
         itemNumber={ownerItemNumber}
         active={activeTab === "diff"}
         {refreshToken}
+        {disabled}
       />
     {/key}
   {:else if activeTab === "pr"}

--- a/packages/ui/src/components/workspace/WorkspaceRightSidebar.test.ts
+++ b/packages/ui/src/components/workspace/WorkspaceRightSidebar.test.ts
@@ -35,6 +35,27 @@ function renderSidebar(refreshToken = 0) {
   });
 }
 
+function renderDisabledSidebar() {
+  return render(WorkspaceRightSidebar, {
+    props: {
+      activeTab: "diff",
+      workspaceID: "ws-1",
+      provider: "github",
+      platformHost: "github.com",
+      repoOwner: "acme",
+      repoName: "widgets",
+      repoPath: "acme/widgets",
+      ownerItemType: "pull_request",
+      ownerItemNumber: 7,
+      associatedPRNumber: 7,
+      branch: "feature/widgets",
+      roborevBaseUrl: "http://localhost/api/roborev",
+      disabled: true,
+    },
+    context: new Map([[STORES_KEY, makeStores()]]),
+  });
+}
+
 describe("WorkspaceRightSidebar", () => {
   afterEach(() => {
     cleanup();
@@ -115,5 +136,38 @@ describe("WorkspaceRightSidebar", () => {
     expect(calls.some((url) => url.endsWith("/api/v1/workspaces/ws-1/commits"))).toBe(true);
     expect(screen.getByRole("button", { name: "Compare with merge target" }).getAttribute("aria-pressed")).toBe("true");
     expect(calls.some((url) => url.endsWith("/api/v1/workspaces/ws-1/diff?base=head"))).toBe(false);
+  });
+
+  it("disables diff controls while the workspace is deleting", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+
+      if (url.includes("/api/roborev/api/repos")) {
+        return Response.json({ repos: [] });
+      }
+      if (url.includes("/api/v1/workspaces/ws-1/files")) {
+        return Response.json({
+          stale: false,
+          whitespace_only_count: 0,
+          files: [],
+        });
+      }
+      if (url.includes("/api/v1/workspaces/ws-1/diff")) {
+        return Response.json({
+          stale: false,
+          whitespace_only_count: 0,
+          files: [],
+        });
+      }
+      return Response.json({}, { status: 404 });
+    });
+
+    renderDisabledSidebar();
+
+    expect(screen.getByRole("button", { name: "Compare with HEAD" }).hasAttribute("disabled")).toBe(true);
+    expect(screen.getByRole("button", { name: "Compare with pushed branch" }).hasAttribute("disabled")).toBe(true);
+    expect(screen.getByRole("button", { name: "Compare with merge target" }).hasAttribute("disabled")).toBe(true);
+    expect(screen.getByRole("button", { name: /Select commit range/ }).hasAttribute("disabled")).toBe(true);
+    expect(screen.getByRole("button", { name: "More diff filters" }).hasAttribute("disabled")).toBe(true);
   });
 });


### PR DESCRIPTION
Deleting a workspace can race with launch, terminal, and diff-sidebar actions that still address the same PR workspace. The previous UI left those controls active while the destructive DELETE was in flight, which made it possible to send follow-up mutations against a workspace that might already be gone.

This keeps the visible workspace surface read-only during the delete request and releases it only when the route changes or the request completes, so unrelated workspaces are not blocked.

Validation: targeted terminal/sidebar unit tests, package type checks, git diff --check, commit hooks, and a local Playwright screenshot capture at tmp/workspace-delete-disabled.png.