### PR TITLE
Require context decisions in context-sync stop hook

### DIFF
--- a/scripts/context-sync
+++ b/scripts/context-sync
@@ -5,9 +5,11 @@ usage() {
   cat >&2 <<'USAGE'
 usage: scripts/context-sync --check
 
-Run the repo-local context-sync preflight used by stop hooks. The automated
-check validates that routed context docs referenced by CLAUDE.md still exist
-and that AGENTS.md resolves to CLAUDE.md.
+Run the repo-local context-sync preflight used by Stop hooks. This is not a
+full context-sync review and does not propose or apply documentation updates.
+
+The automated preflight validates that routed context docs referenced by
+CLAUDE.md still exist and that AGENTS.md resolves to CLAUDE.md.
 USAGE
 }
 
@@ -52,9 +54,9 @@ if [ -f "$root/CLAUDE.md" ]; then
 fi
 
 if [ "$status" -eq 0 ]; then
-  echo "context-sync: check passed"
+  echo "context-sync: preflight passed"
 else
-  echo "context-sync: check failed" >&2
+  echo "context-sync: preflight failed" >&2
 fi
 
 exit "$status"

--- a/scripts/context-sync
+++ b/scripts/context-sync
@@ -5,8 +5,9 @@ usage() {
   cat >&2 <<'USAGE'
 usage: scripts/context-sync --check
 
-Run the repo-local context-sync preflight used by Stop hooks. This is not a
-full context-sync review and does not propose or apply documentation updates.
+Run the repo-local context-sync preflight used by Stop hooks. This command is
+only the first step: agents must still decide whether the current turn taught
+or changed durable context, then update/propose context docs or record why not.
 
 The automated preflight validates that routed context docs referenced by
 CLAUDE.md still exist and that AGENTS.md resolves to CLAUDE.md.
@@ -55,6 +56,12 @@ fi
 
 if [ "$status" -eq 0 ]; then
   echo "context-sync: preflight passed"
+  cat <<'MESSAGE'
+context-sync: before marking, make a context decision:
+  - update or propose docs for new durable behavior, design decisions, invariants, or gotchas
+  - otherwise mark with a concrete no-update reason
+context-sync: do not mark solely because this preflight passed
+MESSAGE
 else
   echo "context-sync: preflight failed" >&2
 fi

--- a/scripts/hooks/context-sync-stop.sh
+++ b/scripts/hooks/context-sync-stop.sh
@@ -5,8 +5,8 @@ usage() {
   cat >&2 <<'USAGE'
 usage: context-sync-stop.sh stop|mark|status
 
-stop    Enforce that context-sync has checked the current worktree state.
-mark    Record the current worktree state after scripts/context-sync --check or sync.
+stop    Enforce that the context-sync Stop-hook preflight has checked the current worktree state.
+mark    Record the current worktree state after the preflight or a full context-sync run.
 status  Print whether the current worktree state is marked.
 USAGE
 }
@@ -73,13 +73,15 @@ require_marked() {
   fi
 
   cat >&2 <<'MESSAGE'
-middleman context-sync is required before this turn can complete.
+middleman context-sync Stop-hook preflight is required before this turn can complete.
 
 Run:
   scripts/context-sync --check
   scripts/hooks/context-sync-stop.sh mark
 
 If context-sync reports drift, address it or report the findings before marking.
+For user-requested context documentation updates, run the full context-sync skill
+workflow; this preflight only checks hook-critical routing.
 MESSAGE
   exit 2
 }

--- a/scripts/hooks/context-sync-stop.sh
+++ b/scripts/hooks/context-sync-stop.sh
@@ -3,11 +3,11 @@ set -euo pipefail
 
 usage() {
   cat >&2 <<'USAGE'
-usage: context-sync-stop.sh stop|mark|status
+usage: context-sync-stop.sh stop|mark <context-decision>|status
 
-stop    Enforce that the context-sync Stop-hook preflight has checked the current worktree state.
-mark    Record the current worktree state after the preflight or a full context-sync run.
-status  Print whether the current worktree state is marked.
+stop    Enforce that the context-sync Stop-hook gate has checked the current worktree state.
+mark    Record the current worktree state after a preflight and explicit context decision.
+status  Print whether the current worktree state is marked, with the recorded decision.
 USAGE
 }
 
@@ -45,13 +45,14 @@ fingerprint() {
 
 mark_current() {
   local root="$1"
+  local decision="$2"
   local file
   local fp
 
   file="$(state_file "$root")" || return 1
   fp="$(fingerprint "$root")" || return 1
   mkdir -p "$(dirname "$file")"
-  printf '%s\n' "$fp" >"$file"
+  printf '%s\n%s\n' "$fp" "$decision" >"$file"
 }
 
 current_is_marked() {
@@ -62,7 +63,7 @@ current_is_marked() {
   file="$(state_file "$root")" || return 1
   [ -f "$file" ] || return 1
   fp="$(fingerprint "$root")" || return 1
-  [ "$(cat "$file")" = "$fp" ]
+  [ "$(sed -n '1p' "$file")" = "$fp" ]
 }
 
 require_marked() {
@@ -73,15 +74,21 @@ require_marked() {
   fi
 
   cat >&2 <<'MESSAGE'
-middleman context-sync Stop-hook preflight is required before this turn can complete.
+middleman context-sync Stop-hook gate is required before this turn can complete.
 
 Run:
   scripts/context-sync --check
-  scripts/hooks/context-sync-stop.sh mark
+
+Then inspect the turn's diff and conversation for durable context changes:
+  - update or propose context docs for new behavior, design decisions, invariants, or gotchas
+  - if no update belongs in context, be ready to state the concrete reason
+
+Finally mark with that decision, for example:
+  scripts/hooks/context-sync-stop.sh mark "updated context/testing.md for the new API-test rule"
+  scripts/hooks/context-sync-stop.sh mark "no context update: changed only local wording in a hook prompt"
 
 If context-sync reports drift, address it or report the findings before marking.
-For user-requested context documentation updates, run the full context-sync skill
-workflow; this preflight only checks hook-critical routing.
+Do not mark solely because the preflight passed.
 MESSAGE
   exit 2
 }
@@ -100,10 +107,21 @@ main() {
 
   case "$command" in
     stop) require_marked "$root" ;;
-    mark) mark_current "$root" ;;
+    mark)
+      shift
+      if [ "$#" -eq 0 ] || [ -z "${*//[[:space:]]/}" ]; then
+        printf 'context-sync-stop: mark requires a context decision reason\n' >&2
+        usage
+        exit 64
+      fi
+      mark_current "$root" "$*" ;;
     status)
       if current_is_marked "$root"; then
         echo "context-sync-stop: current worktree state is marked"
+        state="$(state_file "$root")" || exit 1
+        if [ "$(wc -l <"$state")" -gt 1 ]; then
+          printf 'context-sync-stop: context decision: %s\n' "$(sed -n '2,$p' "$state")"
+        fi
       else
         echo "context-sync-stop: current worktree state is not marked"
         exit 1

--- a/skills/context-sync/SKILL.md
+++ b/skills/context-sync/SKILL.md
@@ -39,21 +39,33 @@ context-sync workflow.
 
 ## Stop Hook Completion
 
-This repo installs Claude Code and Codex `Stop` hooks that require a cheap context-sync
-preflight before a turn completes. When a Stop hook asks for context sync, run
-`scripts/context-sync --check` first. If it reports drift, address the drift or report
-the findings before marking the state as checked.
+This repo installs Claude Code and Codex `Stop` hooks to make agents remember context
+updates even when the maintainer did not ask for them. Treat the hook as a context
+decision gate, not as a script-only check.
 
-After any successful Stop-hook preflight or full context-sync run, mark the current
-worktree state:
+When the Stop hook asks for context sync:
+
+1. Run `scripts/context-sync --check`. If it reports drift, address the drift or report
+   the findings before marking.
+2. Inspect the current turn's diff and conversation. If code changed in an Area Map path,
+   a maintainer explained a design decision, an agent hit a gotcha, or an invariant/
+   workflow changed, open the matching context doc and decide whether the grep test says
+   to update it.
+3. Apply the context update when the right doc edit is clear, additive, and supported by
+   the diff/conversation. If the update would delete context, reinterpret a design
+   decision, or make a claim the code cannot verify, propose a concrete diff or
+   confidence-tagged suggestion in the final response instead.
+4. Only then mark the current worktree state with the decision:
 
 ```bash
-scripts/hooks/context-sync-stop.sh mark
+scripts/hooks/context-sync-stop.sh mark "updated context/testing.md for the new API-test rule"
+scripts/hooks/context-sync-stop.sh mark "no context update: changed only a greppable helper name"
 ```
 
-Do not mark first. The marker is only a loop guard proving the current git worktree
-fingerprint has already been checked. The marker does not mean the docs were audited,
-updated, or improved.
+Do not mark first, and do not mark solely because `scripts/context-sync --check` passed.
+"No context update" is valid only after checking the diff/conversation against
+`context-guide.md`'s update rules. The marker is a loop guard proving this worktree
+fingerprint already passed the context decision gate.
 
 ## Step 1: Load the Guide
 
@@ -149,11 +161,17 @@ invariant is documented but unguarded, flag it as a gap and propose the smallest
 
 When a guard and a doc disagree, that is a high-priority finding for Step 7.
 
-## Step 7: Present Diffs
+## Step 7: Present Or Apply Diffs
 
-Show all proposed changes. Flag DELETIONS and MODIFICATIONS separately from additions —
-deletions are higher risk (removing context that was actually needed is harder to
-recover from than adding noise). Wait for maintainer approval before applying anything.
+For explicit full-sync/audit requests, show all proposed changes. Flag DELETIONS and
+MODIFICATIONS separately from additions — deletions are higher risk (removing context
+that was actually needed is harder to recover from than adding noise). Wait for
+maintainer approval before applying those broad audit changes.
+
+For Stop-hook self-maintenance, do not wait for the maintainer to ask for context work:
+apply clear, scoped additions or factual corrections that follow directly from the
+current turn. Propose instead of applying when the change would remove context,
+reinterpret a durable decision, or needs maintainer-only domain knowledge.
 
 ## Step 8: Apply, Route, Commit
 

--- a/skills/context-sync/SKILL.md
+++ b/skills/context-sync/SKILL.md
@@ -12,29 +12,48 @@ and draft updates for review. Adapted for this repo's Go + Svelte stack and its
 single-surface context layout: root `CLAUDE.md` routes to flat `context/*.md` topic docs.
 
 **Arguments:**
-- No args: sync every area in the area map below.
+- No args: sync every area in the area map below and produce reviewed context-doc
+  updates or concrete improvement suggestions.
 - `$1 = area`: sync one area (see Area Map, e.g. `platform`, `github-sync`, `db`,
-  `server`, `frontend`, `errors`, `testing`, `mobile`, `kata`, `docs`, `messages`).
-- `--check`: report staleness only, propose nothing.
+  `server`, `frontend`, `errors`, `testing`, `mobile`, `kata`, `docs`, `messages`) and
+  produce reviewed updates or suggestions for that area.
+- `--check`: Stop-hook preflight only. Report structural staleness and obvious drift,
+  but do not propose or apply doc changes.
 - `--audit-claims`: run the four-tag claim verification (see `claim-verifier.md`) over
   every anchored claim in the scanned docs.
 
+## Operating Mode
+
+Default to a full sync whenever the user asks to sync, update, improve, review, or fix
+context documentation. A full sync must end with one of these outcomes:
+
+- proposed doc diffs ready for maintainer approval;
+- applied, approved doc updates;
+- a confidence-tagged list of concrete improvements/gaps when the code alone cannot
+  justify a diff;
+- a clear "no context changes suggested" result with the evidence checked.
+
+Do not satisfy a user-initiated context-sync request by only running
+`scripts/context-sync --check`. That script is a cheap Stop-hook preflight, not the
+context-sync workflow.
+
 ## Stop Hook Completion
 
-This repo installs Claude Code and Codex `Stop` hooks that require context-sync to check
-the current worktree state before a turn completes. When a Stop hook asks for context
-sync, run `scripts/context-sync --check` first. If it reports drift, address the drift
-or report the findings before marking the state as checked.
+This repo installs Claude Code and Codex `Stop` hooks that require a cheap context-sync
+preflight before a turn completes. When a Stop hook asks for context sync, run
+`scripts/context-sync --check` first. If it reports drift, address the drift or report
+the findings before marking the state as checked.
 
-After any successful `scripts/context-sync --check` or full context-sync run, mark the
-current worktree state:
+After any successful Stop-hook preflight or full context-sync run, mark the current
+worktree state:
 
 ```bash
 scripts/hooks/context-sync-stop.sh mark
 ```
 
 Do not mark first. The marker is only a loop guard proving the current git worktree
-fingerprint has already been checked.
+fingerprint has already been checked. The marker does not mean the docs were audited,
+updated, or improved.
 
 ## Step 1: Load the Guide
 


### PR DESCRIPTION
The context-sync Stop hook now requires agents to make and record an explicit context documentation decision before marking a worktree state as checked. This keeps context updates part of normal agent completion instead of relying on a maintainer to trigger them manually.

- Require `context-sync-stop.sh mark` to include a concrete context decision
- Update hook prompts and preflight output to direct agents toward context updates or specific no-update reasons
- Clarify the context-sync skill so clear scoped context updates are applied during ordinary work