### PR TITLE
feat: add repo source browser API

### DIFF
--- a/docs/superpowers/plans/2026-06-23-repo-source-browser.md
+++ b/docs/superpowers/plans/2026-06-23-repo-source-browser.md
@@ -132,6 +132,7 @@ func TestRepoBrowserListTreeCapsAndIncludesTrackedDotfiles(t *testing.T)
 func TestRepoBrowserReadBlobWorksWhenTreeIsTruncated(t *testing.T)
 func TestRepoBrowserReadBlobRejectsTraversalAndReportsLargeState(t *testing.T)
 func TestRepoBrowserLastChangedBatchCapsPaths(t *testing.T)
+func TestRepoBrowserLastChangedFallsBackPastBatchLogLimit(t *testing.T)
 func TestRepoBrowserFileHistoryIsBoundedAtSelectedSHA(t *testing.T)
 func TestRepoBrowserResponsesIncludeRefMetadata(t *testing.T)
 func TestRepoBrowserCloneIdentitySeparatesProvidersAndNestedPaths(t *testing.T)
@@ -178,6 +179,7 @@ const (
 	RepoBrowserTreeEntryLimit      = 20000
 	RepoBrowserBlobSizeLimit       = 1 << 20
 	RepoBrowserLastChangedBatchMax = 250
+	RepoBrowserLastChangedLogLimit = 500
 	RepoBrowserHistoryLimit        = 50
 )
 
@@ -318,6 +320,7 @@ func TestRepoBrowserRoutesRequireRepoPathForNestedRepos(t *testing.T)
 func TestRepoBrowserBranchSHAReportsStaleRef(t *testing.T)
 func TestRepoBrowserTreeTruncationKeepsDirectBlobReadable(t *testing.T)
 func TestRepoBrowserBlobReturnsTypedLargeAndBinaryStates(t *testing.T)
+func TestRepoBrowserLastChangedFallsBackPastBatchLogLimit(t *testing.T)
 func TestRepoBrowserMarkdownAssetReturnsSafeMimeAndCacheHeaders(t *testing.T)
 func TestRepoBrowserAssetBytesRejectsNonRenderableStates(t *testing.T)
 func TestRepoBrowserRejectsUnknownRefAndUnsafePath(t *testing.T)

--- a/docs/superpowers/plans/2026-06-23-repo-source-browser.md
+++ b/docs/superpowers/plans/2026-06-23-repo-source-browser.md
@@ -261,7 +261,7 @@ type RepoBrowserCommitDetail struct {
 Add methods on `*Manager`:
 
 ```go
-ListRepoBrowserRefs(ctx context.Context, repo RepoBrowserRepoRef, defaultBranch string) ([]RepoBrowserRef, RepoBrowserRef, error)
+ListRepoBrowserRefs(ctx context.Context, repo RepoBrowserRepoRef, defaultBranch string) ([]RepoBrowserRef, RepoBrowserRef, bool, error)
 ListRepoBrowserTree(ctx context.Context, repo RepoBrowserRepoRef, ref RepoBrowserRef) (RepoBrowserTree, error)
 ProbeRepoBrowserREADME(ctx context.Context, repo RepoBrowserRepoRef, ref RepoBrowserRef) (RepoBrowserREADMEProbe, error)
 ReadRepoBrowserBlob(ctx context.Context, repo RepoBrowserRepoRef, ref RepoBrowserRef, path string) (RepoBrowserBlob, error)

--- a/docs/superpowers/plans/2026-06-23-repo-source-browser.md
+++ b/docs/superpowers/plans/2026-06-23-repo-source-browser.md
@@ -117,7 +117,9 @@ Write the API contract in server request/response types before handlers:
 - Markdown asset contract:
   separate `asset-metadata` JSON preflight and `asset-bytes` byte routes; metadata emits commit-pinned byte URLs only for renderable assets; path/ref validation, MIME detection, unsupported SVG state with no byte URL, byte route problem envelopes for SVG/non-renderable assets, blob-size caps, conservative branch/tag metadata cache headers, immutable byte cache headers
 - fetch behavior:
-  repo-browser ensure/fetch/read and manual refresh hot paths must fetch branch/tag updates without pruning tags from the middleman-owned clone; deleted remote tags can remain visible until a separate cache maintenance or repair path cleans them up
+  repo-browser ensure/fetch/read and manual refresh hot paths must fetch branch/tag updates without pruning tags from the middleman-owned clone; deleted remote tags can remain visible until an explicit cache maintenance path such as clone repair/rebuild cleans them up, and no request-time or periodic sync path should add tag pruning implicitly
+- last-changed fallback budget:
+  the batch scan is capped by `RepoBrowserLastChangedLogLimit`; fallback may run at most one `git log --max-count=1` process per requested path missed by the batch, so total fallback processes are bounded by `RepoBrowserLastChangedBatchMax`. This returns complete metadata for the requested batch under that process cap but can still traverse deep history inside Git; UI callers must request visible/filtered rows rather than entire truncated trees.
 
 - [ ] **Step 3: Write failing gitclone tests**
 
@@ -150,7 +152,8 @@ ensure/fetch and manual refresh behavior does not pass tag-pruning options and
 does not remove an existing local tag when the remote tag has disappeared. It
 must also prove new remote tags pointing at already-present objects are fetched
 without pruning tags. Deleted remote tags are allowed to remain visible until a
-separate maintenance path handles cache cleanup.
+explicit cache maintenance path such as clone repair/rebuild handles cleanup.
+Do not add request-time or periodic tag pruning as part of repo-browser fetch.
 `TestRepoBrowserCloneIdentitySeparatesProvidersAndNestedPaths` must cover two
 repositories with the same `platform_host` and `repo_path` but different
 providers, plus slash-containing nested `repo_path` values. It must prove clone
@@ -287,9 +290,12 @@ owner/name are display hints only and must not participate in clone paths or
 cache keys. The shared identity helper must be the only place that encodes
 provider, canonical platform host, and slash-containing repo path for clone
 paths and fetch singleflight keys. Last-changed batches should use one bounded
-Git history walk for the batch, then a bounded `--max-count=1` per-path fallback
-only for requested paths not found in that capped batch so old paths do not look
-historyless.
+Git history walk for the batch, then a `--max-count=1` per-path fallback only
+for requested paths not found in that capped batch so old paths do not look
+historyless. The fallback process count is bounded by
+`RepoBrowserLastChangedBatchMax`, but each fallback can still traverse deep
+history inside Git; frontend callers must keep last-changed batches scoped to
+visible/filtered rows, not whole large repositories.
 
 - [ ] **Step 6: Run gitclone tests green**
 

--- a/docs/superpowers/plans/2026-06-23-repo-source-browser.md
+++ b/docs/superpowers/plans/2026-06-23-repo-source-browser.md
@@ -109,7 +109,11 @@ Write the API contract in server request/response types before handlers:
 - error/state contract:
   use existing camelCase problem codes for failures; put repo-browser reasons such as `clone_unavailable`, `unavailable_ref`, and `missing_path` in `details.reason`; model truncation, stale-token, binary, oversized, and unsupported-SVG cases as successful response states
 - caps:
-  `RepoBrowserTreeEntryLimit`, `RepoBrowserBlobSizeLimit`, `RepoBrowserLastChangedBatchMax`, `RepoBrowserHistoryLimit`
+  `RepoBrowserRefLimit`, `RepoBrowserTreeEntryLimit`, `RepoBrowserBlobSizeLimit`, `RepoBrowserLastChangedBatchMax`, `RepoBrowserLastChangedLogLimit`, `RepoBrowserHistoryLimit`
+- truncation semantics:
+  ref lists are sorted by refname before applying `RepoBrowserRefLimit`; `refs/remotes/origin/HEAD` is not displayable and must not consume the cap; `default_ref` is returned separately and may be absent from a truncated `refs` array; tree truncation is bounded by Git traversal order before UI sorting and the UI must present it as a partial tree
+- pathspec safety:
+  every caller-controlled repo path passed to Git must use a shared literal pathspec helper after `--`; `--` alone is not sufficient because filenames can begin with Git pathspec magic such as `:(glob)`
 - Markdown asset contract:
   separate `asset-metadata` JSON preflight and `asset-bytes` byte routes; metadata emits commit-pinned byte URLs only for renderable assets; path/ref validation, MIME detection, unsupported SVG state with no byte URL, byte route problem envelopes for SVG/non-renderable assets, blob-size caps, conservative branch/tag metadata cache headers, immutable byte cache headers
 - fetch behavior:
@@ -143,9 +147,10 @@ envelopes, status codes, and response headers belong in `internal/server`
 tests.
 `TestRepoBrowserFetchDoesNotPruneTagsOnHotPath` must prove repo-browser
 ensure/fetch and manual refresh behavior does not pass tag-pruning options and
-does not remove an existing local tag when the remote tag has disappeared.
-Deleted remote tags are allowed to remain visible until a separate maintenance
-path handles cache cleanup.
+does not remove an existing local tag when the remote tag has disappeared. It
+must also prove new remote tags pointing at already-present objects are fetched
+without pruning tags. Deleted remote tags are allowed to remain visible until a
+separate maintenance path handles cache cleanup.
 `TestRepoBrowserCloneIdentitySeparatesProvidersAndNestedPaths` must cover two
 repositories with the same `platform_host` and `repo_path` but different
 providers, plus slash-containing nested `repo_path` values. It must prove clone
@@ -271,17 +276,20 @@ RepoBrowserFileHistory(ctx context.Context, repo RepoBrowserRepoRef, ref RepoBro
 RepoBrowserCommitDetail(ctx context.Context, repo RepoBrowserRepoRef, root RepoBrowserRef, path string, sha string) (RepoBrowserCommitDetail, error)
 ```
 
-All methods must validate repo-relative paths, use `--` before paths, resolve
-refs statelessly through typed ref inputs, and return typed errors for missing
-refs/paths. Every successful read operation after `ListRepoBrowserRefs` must
-return `RepoBrowserResolvedRef` so the server can emit `resolvedSha`,
-`requestedSha`, and `stale` without separately re-resolving the branch or tag.
-Clone/cache identity must use `(Provider, PlatformHost, RepoPath)` from
-`RepoBrowserRepoRef`; owner/name are display hints only and must not participate
-in clone paths or cache keys. The shared identity helper must be the only place
-that encodes provider, canonical platform host, and slash-containing repo path
-for clone paths and fetch singleflight keys. Last-changed batches must use a
-single bounded Git history walk per batch, not one process per path.
+All methods must validate repo-relative paths, pass caller-controlled paths only
+through the shared literal pathspec helper after `--`, resolve refs statelessly
+through typed ref inputs, and return typed errors for missing refs/paths. Every
+successful read operation after `ListRepoBrowserRefs` must return
+`RepoBrowserResolvedRef` so the server can emit `resolvedSha`, `requestedSha`,
+and `stale` without separately re-resolving the branch or tag. Clone/cache
+identity must use `(Provider, PlatformHost, RepoPath)` from `RepoBrowserRepoRef`;
+owner/name are display hints only and must not participate in clone paths or
+cache keys. The shared identity helper must be the only place that encodes
+provider, canonical platform host, and slash-containing repo path for clone
+paths and fetch singleflight keys. Last-changed batches should use one bounded
+Git history walk for the batch, then a bounded `--max-count=1` per-path fallback
+only for requested paths not found in that capped batch so old paths do not look
+historyless.
 
 - [ ] **Step 6: Run gitclone tests green**
 

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -11161,6 +11161,7 @@ paths:
         - Repositories
   /host/{platform_host}/repo/{provider}/{owner}/{name}/browser/asset:
     get:
+      description: Returns raw image bytes for a repository file. Asset reads require ref_type=commit with ref_sha set to a full 40-character commit SHA; branch and tag refs are rejected with mutable_ref_not_allowed.
       operationId: get-repo-browser-asset-on-host
       parameters:
         - in: path
@@ -15401,6 +15402,7 @@ paths:
         - Repositories
   /repo/{provider}/{owner}/{name}/browser/asset:
     get:
+      description: Returns raw image bytes for a repository file. Asset reads require ref_type=commit with ref_sha set to a full 40-character commit SHA; branch and tag refs are rejected with mutable_ref_not_allowed.
       operationId: get-repo-browser-asset
       parameters:
         - in: path

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -4940,14 +4940,19 @@ components:
       additionalProperties: false
       properties:
         name:
+          description: Selected branch or tag name. Commit refs leave this empty.
           type: string
         requested_sha:
+          description: Caller-supplied branch or tag SHA when it differs from the resolved SHA.
           type: string
         sha:
+          description: Resolved commit SHA used for the read.
           type: string
         stale:
+          description: True when a caller-supplied branch or tag SHA no longer matches the current ref target.
           type: boolean
         type:
+          description: "Selected ref type: branch, tag, or commit."
           type: string
       required:
         - type

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -4941,14 +4941,19 @@ components:
       properties:
         name:
           type: string
+        requested_sha:
+          type: string
         sha:
           type: string
+        stale:
+          type: boolean
         type:
           type: string
       required:
         - type
         - name
         - sha
+        - stale
       type: object
     RepoBrowserRefsResponse:
       additionalProperties: false

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -4980,10 +4980,13 @@ components:
             - "null"
         repo:
           $ref: "#/components/schemas/RepoRefResponse"
+        truncated:
+          type: boolean
       required:
         - repo
         - refs
         - default_ref
+        - truncated
       type: object
     RepoBrowserTreeEntry:
       additionalProperties: false

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -4786,6 +4786,238 @@ components:
       required:
         - body
       type: object
+    RepoBrowserBlob:
+      additionalProperties: false
+      properties:
+        binary:
+          type: boolean
+        content:
+          type: string
+        encoding:
+          type: string
+        media_type:
+          type: string
+        path:
+          type: string
+        sha:
+          type: string
+        size:
+          format: int64
+          type: integer
+        too_large:
+          type: boolean
+      required:
+        - path
+        - sha
+        - size
+        - media_type
+        - encoding
+        - content
+        - binary
+        - too_large
+      type: object
+    RepoBrowserBlobResponse:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /api/v1/schemas/RepoBrowserBlobResponse.json
+          format: uri
+          readOnly: true
+          type: string
+        blob:
+          $ref: "#/components/schemas/RepoBrowserBlob"
+        ref:
+          $ref: "#/components/schemas/RepoBrowserRef"
+        repo:
+          $ref: "#/components/schemas/RepoRefResponse"
+      required:
+        - repo
+        - ref
+        - blob
+      type: object
+    RepoBrowserCommit:
+      additionalProperties: false
+      properties:
+        author_email:
+          type: string
+        author_name:
+          type: string
+        authored_at:
+          format: date-time
+          type: string
+        body:
+          type: string
+        sha:
+          type: string
+        subject:
+          type: string
+      required:
+        - sha
+        - subject
+        - body
+        - author_name
+        - author_email
+        - authored_at
+      type: object
+    RepoBrowserCommitResponse:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /api/v1/schemas/RepoBrowserCommitResponse.json
+          format: uri
+          readOnly: true
+          type: string
+        commit:
+          $ref: "#/components/schemas/RepoBrowserCommit"
+        path:
+          type: string
+        ref:
+          $ref: "#/components/schemas/RepoBrowserRef"
+        repo:
+          $ref: "#/components/schemas/RepoRefResponse"
+      required:
+        - repo
+        - ref
+        - path
+        - commit
+      type: object
+    RepoBrowserHistoryResponse:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /api/v1/schemas/RepoBrowserHistoryResponse.json
+          format: uri
+          readOnly: true
+          type: string
+        commits:
+          items:
+            $ref: "#/components/schemas/RepoBrowserCommit"
+          type:
+            - array
+            - "null"
+        path:
+          type: string
+        ref:
+          $ref: "#/components/schemas/RepoBrowserRef"
+        repo:
+          $ref: "#/components/schemas/RepoRefResponse"
+      required:
+        - repo
+        - ref
+        - path
+        - commits
+      type: object
+    RepoBrowserLastChangedResponse:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /api/v1/schemas/RepoBrowserLastChangedResponse.json
+          format: uri
+          readOnly: true
+          type: string
+        commits:
+          additionalProperties:
+            $ref: "#/components/schemas/RepoBrowserCommit"
+          type: object
+        ref:
+          $ref: "#/components/schemas/RepoBrowserRef"
+        repo:
+          $ref: "#/components/schemas/RepoRefResponse"
+      required:
+        - repo
+        - ref
+        - commits
+      type: object
+    RepoBrowserRef:
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+        sha:
+          type: string
+        type:
+          type: string
+      required:
+        - type
+        - name
+        - sha
+      type: object
+    RepoBrowserRefsResponse:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /api/v1/schemas/RepoBrowserRefsResponse.json
+          format: uri
+          readOnly: true
+          type: string
+        default_ref:
+          $ref: "#/components/schemas/RepoBrowserRef"
+        refs:
+          items:
+            $ref: "#/components/schemas/RepoBrowserRef"
+          type:
+            - array
+            - "null"
+        repo:
+          $ref: "#/components/schemas/RepoRefResponse"
+      required:
+        - repo
+        - refs
+        - default_ref
+      type: object
+    RepoBrowserTreeEntry:
+      additionalProperties: false
+      properties:
+        path:
+          type: string
+        size:
+          format: int64
+          type: integer
+        type:
+          type: string
+      required:
+        - path
+        - type
+        - size
+      type: object
+    RepoBrowserTreeResponse:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /api/v1/schemas/RepoBrowserTreeResponse.json
+          format: uri
+          readOnly: true
+          type: string
+        entries:
+          items:
+            $ref: "#/components/schemas/RepoBrowserTreeEntry"
+          type:
+            - array
+            - "null"
+        ref:
+          $ref: "#/components/schemas/RepoBrowserRef"
+        repo:
+          $ref: "#/components/schemas/RepoRefResponse"
+        truncated:
+          type: boolean
+      required:
+        - repo
+        - ref
+        - entries
+        - truncated
+      type: object
     RepoLabelsResponse:
       additionalProperties: false
       properties:
@@ -10914,6 +11146,459 @@ paths:
       summary: Get repository
       tags:
         - Repositories
+  /host/{platform_host}/repo/{provider}/{owner}/{name}/browser/asset:
+    get:
+      operationId: get-repo-browser-asset-on-host
+      parameters:
+        - in: path
+          name: provider
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: platform_host
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: owner
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: repo_path
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: ref_type
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: ref_name
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: ref_sha
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: path
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                contentEncoding: base64
+                type: string
+          description: OK
+          headers:
+            Cache-Control:
+              schema:
+                type: string
+            Content-Length:
+              schema:
+                type: string
+            Content-Type:
+              schema:
+                type: string
+            X-Content-Type-Options:
+              schema:
+                type: string
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Error
+      summary: Get repository browser asset
+      tags:
+        - Repositories
+  /host/{platform_host}/repo/{provider}/{owner}/{name}/browser/blob:
+    get:
+      operationId: get-repo-browser-blob-on-host
+      parameters:
+        - in: path
+          name: provider
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: platform_host
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: owner
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: repo_path
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: ref_type
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: ref_name
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: ref_sha
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: path
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RepoBrowserBlobResponse"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Error
+      summary: Get repository browser blob
+      tags:
+        - Repositories
+  /host/{platform_host}/repo/{provider}/{owner}/{name}/browser/commit:
+    get:
+      operationId: get-repo-browser-commit-on-host
+      parameters:
+        - in: path
+          name: provider
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: platform_host
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: owner
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: repo_path
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: ref_type
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: ref_name
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: ref_sha
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: path
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: sha
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RepoBrowserCommitResponse"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Error
+      summary: Get repository browser commit
+      tags:
+        - Repositories
+  /host/{platform_host}/repo/{provider}/{owner}/{name}/browser/history:
+    get:
+      operationId: get-repo-browser-history-on-host
+      parameters:
+        - in: path
+          name: provider
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: platform_host
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: owner
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: repo_path
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: ref_type
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: ref_name
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: ref_sha
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: path
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RepoBrowserHistoryResponse"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Error
+      summary: Get repository browser file history
+      tags:
+        - Repositories
+  /host/{platform_host}/repo/{provider}/{owner}/{name}/browser/last-changed:
+    get:
+      operationId: get-repo-browser-last-changed-on-host
+      parameters:
+        - in: path
+          name: provider
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: platform_host
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: owner
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: repo_path
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: ref_type
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: ref_name
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: ref_sha
+          schema:
+            type: string
+        - explode: true
+          in: query
+          name: path
+          schema:
+            items:
+              type: string
+            type:
+              - array
+              - "null"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RepoBrowserLastChangedResponse"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Error
+      summary: Get repository browser last changed commits
+      tags:
+        - Repositories
+  /host/{platform_host}/repo/{provider}/{owner}/{name}/browser/refs:
+    get:
+      operationId: list-repo-browser-refs-on-host
+      parameters:
+        - in: path
+          name: provider
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: platform_host
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: owner
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: repo_path
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RepoBrowserRefsResponse"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Error
+      summary: List repository browser refs
+      tags:
+        - Repositories
+  /host/{platform_host}/repo/{provider}/{owner}/{name}/browser/tree:
+    get:
+      operationId: list-repo-browser-tree-on-host
+      parameters:
+        - in: path
+          name: provider
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: platform_host
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: owner
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: repo_path
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: ref_type
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: ref_name
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: ref_sha
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RepoBrowserTreeResponse"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Error
+      summary: List repository browser tree
+      tags:
+        - Repositories
   /host/{platform_host}/repo/{provider}/{owner}/{name}/comment-autocomplete:
     get:
       operationId: get-comment-autocomplete-on-host
@@ -14673,6 +15358,424 @@ paths:
                 $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Get repository
+      tags:
+        - Repositories
+  /repo/{provider}/{owner}/{name}/browser/asset:
+    get:
+      operationId: get-repo-browser-asset
+      parameters:
+        - in: path
+          name: provider
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: owner
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: repo_path
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: ref_type
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: ref_name
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: ref_sha
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: path
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                contentEncoding: base64
+                type: string
+          description: OK
+          headers:
+            Cache-Control:
+              schema:
+                type: string
+            Content-Length:
+              schema:
+                type: string
+            Content-Type:
+              schema:
+                type: string
+            X-Content-Type-Options:
+              schema:
+                type: string
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Error
+      summary: Get repository browser asset
+      tags:
+        - Repositories
+  /repo/{provider}/{owner}/{name}/browser/blob:
+    get:
+      operationId: get-repo-browser-blob
+      parameters:
+        - in: path
+          name: provider
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: owner
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: repo_path
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: ref_type
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: ref_name
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: ref_sha
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: path
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RepoBrowserBlobResponse"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Error
+      summary: Get repository browser blob
+      tags:
+        - Repositories
+  /repo/{provider}/{owner}/{name}/browser/commit:
+    get:
+      operationId: get-repo-browser-commit
+      parameters:
+        - in: path
+          name: provider
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: owner
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: repo_path
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: ref_type
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: ref_name
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: ref_sha
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: path
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: sha
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RepoBrowserCommitResponse"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Error
+      summary: Get repository browser commit
+      tags:
+        - Repositories
+  /repo/{provider}/{owner}/{name}/browser/history:
+    get:
+      operationId: get-repo-browser-history
+      parameters:
+        - in: path
+          name: provider
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: owner
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: repo_path
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: ref_type
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: ref_name
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: ref_sha
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: path
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RepoBrowserHistoryResponse"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Error
+      summary: Get repository browser file history
+      tags:
+        - Repositories
+  /repo/{provider}/{owner}/{name}/browser/last-changed:
+    get:
+      operationId: get-repo-browser-last-changed
+      parameters:
+        - in: path
+          name: provider
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: owner
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: repo_path
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: ref_type
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: ref_name
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: ref_sha
+          schema:
+            type: string
+        - explode: true
+          in: query
+          name: path
+          schema:
+            items:
+              type: string
+            type:
+              - array
+              - "null"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RepoBrowserLastChangedResponse"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Error
+      summary: Get repository browser last changed commits
+      tags:
+        - Repositories
+  /repo/{provider}/{owner}/{name}/browser/refs:
+    get:
+      operationId: list-repo-browser-refs
+      parameters:
+        - in: path
+          name: provider
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: owner
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: repo_path
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RepoBrowserRefsResponse"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Error
+      summary: List repository browser refs
+      tags:
+        - Repositories
+  /repo/{provider}/{owner}/{name}/browser/tree:
+    get:
+      operationId: list-repo-browser-tree
+      parameters:
+        - in: path
+          name: provider
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: owner
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: repo_path
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: ref_type
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: ref_name
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: ref_sha
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RepoBrowserTreeResponse"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Error
+      summary: List repository browser tree
       tags:
         - Repositories
   /repo/{provider}/{owner}/{name}/comment-autocomplete:

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -11208,11 +11208,37 @@ paths:
       responses:
         "200":
           content:
-            application/json:
+            image/avif:
               schema:
-                contentEncoding: base64
+                contentMediaType: application/octet-stream
+                format: binary
                 type: string
-          description: OK
+            image/bmp:
+              schema:
+                contentMediaType: application/octet-stream
+                format: binary
+                type: string
+            image/gif:
+              schema:
+                contentMediaType: application/octet-stream
+                format: binary
+                type: string
+            image/jpeg:
+              schema:
+                contentMediaType: application/octet-stream
+                format: binary
+                type: string
+            image/png:
+              schema:
+                contentMediaType: application/octet-stream
+                format: binary
+                type: string
+            image/webp:
+              schema:
+                contentMediaType: application/octet-stream
+                format: binary
+                type: string
+          description: Image response
           headers:
             Cache-Control:
               schema:
@@ -15417,11 +15443,37 @@ paths:
       responses:
         "200":
           content:
-            application/json:
+            image/avif:
               schema:
-                contentEncoding: base64
+                contentMediaType: application/octet-stream
+                format: binary
                 type: string
-          description: OK
+            image/bmp:
+              schema:
+                contentMediaType: application/octet-stream
+                format: binary
+                type: string
+            image/gif:
+              schema:
+                contentMediaType: application/octet-stream
+                format: binary
+                type: string
+            image/jpeg:
+              schema:
+                contentMediaType: application/octet-stream
+                format: binary
+                type: string
+            image/png:
+              schema:
+                contentMediaType: application/octet-stream
+                format: binary
+                type: string
+            image/webp:
+              schema:
+                contentMediaType: application/octet-stream
+                format: binary
+                type: string
+          description: Image response
           headers:
             Cache-Control:
               schema:

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -29545,7 +29545,6 @@ func (r GetRepoOnHostResponse) StatusCode() int {
 type GetRepoBrowserAssetOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
-	JSON200                       *string
 	ApplicationproblemJSONDefault *ProblemError
 }
 
@@ -31852,7 +31851,6 @@ func (r GetRepoResponse) StatusCode() int {
 type GetRepoBrowserAssetResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
-	JSON200                       *string
 	ApplicationproblemJSONDefault *ProblemError
 }
 
@@ -39970,13 +39968,6 @@ func ParseGetRepoBrowserAssetOnHostResponse(rsp *http.Response) (*GetRepoBrowser
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest string
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
 		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -43191,13 +43182,6 @@ func ParseGetRepoBrowserAssetResponse(rsp *http.Response) (*GetRepoBrowserAssetR
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest string
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
 		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -2286,6 +2286,99 @@ type ReplyToDiscussionInputBody struct {
 	Body   string  `json:"body"`
 }
 
+// RepoBrowserBlob defines model for RepoBrowserBlob.
+type RepoBrowserBlob struct {
+	Binary    bool   `json:"binary"`
+	Content   string `json:"content"`
+	Encoding  string `json:"encoding"`
+	MediaType string `json:"media_type"`
+	Path      string `json:"path"`
+	Sha       string `json:"sha"`
+	Size      int64  `json:"size"`
+	TooLarge  bool   `json:"too_large"`
+}
+
+// RepoBrowserBlobResponse defines model for RepoBrowserBlobResponse.
+type RepoBrowserBlobResponse struct {
+	// Schema A URL to the JSON Schema for this object.
+	Schema *string         `json:"$schema,omitempty"`
+	Blob   RepoBrowserBlob `json:"blob"`
+	Ref    RepoBrowserRef  `json:"ref"`
+	Repo   RepoRefResponse `json:"repo"`
+}
+
+// RepoBrowserCommit defines model for RepoBrowserCommit.
+type RepoBrowserCommit struct {
+	AuthorEmail string    `json:"author_email"`
+	AuthorName  string    `json:"author_name"`
+	AuthoredAt  time.Time `json:"authored_at"`
+	Body        string    `json:"body"`
+	Sha         string    `json:"sha"`
+	Subject     string    `json:"subject"`
+}
+
+// RepoBrowserCommitResponse defines model for RepoBrowserCommitResponse.
+type RepoBrowserCommitResponse struct {
+	// Schema A URL to the JSON Schema for this object.
+	Schema *string           `json:"$schema,omitempty"`
+	Commit RepoBrowserCommit `json:"commit"`
+	Path   string            `json:"path"`
+	Ref    RepoBrowserRef    `json:"ref"`
+	Repo   RepoRefResponse   `json:"repo"`
+}
+
+// RepoBrowserHistoryResponse defines model for RepoBrowserHistoryResponse.
+type RepoBrowserHistoryResponse struct {
+	// Schema A URL to the JSON Schema for this object.
+	Schema  *string              `json:"$schema,omitempty"`
+	Commits *[]RepoBrowserCommit `json:"commits"`
+	Path    string               `json:"path"`
+	Ref     RepoBrowserRef       `json:"ref"`
+	Repo    RepoRefResponse      `json:"repo"`
+}
+
+// RepoBrowserLastChangedResponse defines model for RepoBrowserLastChangedResponse.
+type RepoBrowserLastChangedResponse struct {
+	// Schema A URL to the JSON Schema for this object.
+	Schema  *string                      `json:"$schema,omitempty"`
+	Commits map[string]RepoBrowserCommit `json:"commits"`
+	Ref     RepoBrowserRef               `json:"ref"`
+	Repo    RepoRefResponse              `json:"repo"`
+}
+
+// RepoBrowserRef defines model for RepoBrowserRef.
+type RepoBrowserRef struct {
+	Name string `json:"name"`
+	Sha  string `json:"sha"`
+	Type string `json:"type"`
+}
+
+// RepoBrowserRefsResponse defines model for RepoBrowserRefsResponse.
+type RepoBrowserRefsResponse struct {
+	// Schema A URL to the JSON Schema for this object.
+	Schema     *string           `json:"$schema,omitempty"`
+	DefaultRef RepoBrowserRef    `json:"default_ref"`
+	Refs       *[]RepoBrowserRef `json:"refs"`
+	Repo       RepoRefResponse   `json:"repo"`
+}
+
+// RepoBrowserTreeEntry defines model for RepoBrowserTreeEntry.
+type RepoBrowserTreeEntry struct {
+	Path string `json:"path"`
+	Size int64  `json:"size"`
+	Type string `json:"type"`
+}
+
+// RepoBrowserTreeResponse defines model for RepoBrowserTreeResponse.
+type RepoBrowserTreeResponse struct {
+	// Schema A URL to the JSON Schema for this object.
+	Schema    *string                 `json:"$schema,omitempty"`
+	Entries   *[]RepoBrowserTreeEntry `json:"entries"`
+	Ref       RepoBrowserRef          `json:"ref"`
+	Repo      RepoRefResponse         `json:"repo"`
+	Truncated bool                    `json:"truncated"`
+}
+
 // RepoLabelsResponse defines model for RepoLabelsResponse.
 type RepoLabelsResponse struct {
 	// Schema A URL to the JSON Schema for this object.
@@ -3172,6 +3265,65 @@ type GetPullFilePreviewOnHostParams struct {
 // GetPullFilePreviewOnHostParamsSide defines parameters for GetPullFilePreviewOnHost.
 type GetPullFilePreviewOnHostParamsSide string
 
+// GetRepoBrowserAssetOnHostParams defines parameters for GetRepoBrowserAssetOnHost.
+type GetRepoBrowserAssetOnHostParams struct {
+	RepoPath *string `form:"repo_path,omitempty" json:"repo_path,omitempty"`
+	RefType  *string `form:"ref_type,omitempty" json:"ref_type,omitempty"`
+	RefName  *string `form:"ref_name,omitempty" json:"ref_name,omitempty"`
+	RefSha   *string `form:"ref_sha,omitempty" json:"ref_sha,omitempty"`
+	Path     *string `form:"path,omitempty" json:"path,omitempty"`
+}
+
+// GetRepoBrowserBlobOnHostParams defines parameters for GetRepoBrowserBlobOnHost.
+type GetRepoBrowserBlobOnHostParams struct {
+	RepoPath *string `form:"repo_path,omitempty" json:"repo_path,omitempty"`
+	RefType  *string `form:"ref_type,omitempty" json:"ref_type,omitempty"`
+	RefName  *string `form:"ref_name,omitempty" json:"ref_name,omitempty"`
+	RefSha   *string `form:"ref_sha,omitempty" json:"ref_sha,omitempty"`
+	Path     *string `form:"path,omitempty" json:"path,omitempty"`
+}
+
+// GetRepoBrowserCommitOnHostParams defines parameters for GetRepoBrowserCommitOnHost.
+type GetRepoBrowserCommitOnHostParams struct {
+	RepoPath *string `form:"repo_path,omitempty" json:"repo_path,omitempty"`
+	RefType  *string `form:"ref_type,omitempty" json:"ref_type,omitempty"`
+	RefName  *string `form:"ref_name,omitempty" json:"ref_name,omitempty"`
+	RefSha   *string `form:"ref_sha,omitempty" json:"ref_sha,omitempty"`
+	Path     *string `form:"path,omitempty" json:"path,omitempty"`
+	Sha      *string `form:"sha,omitempty" json:"sha,omitempty"`
+}
+
+// GetRepoBrowserHistoryOnHostParams defines parameters for GetRepoBrowserHistoryOnHost.
+type GetRepoBrowserHistoryOnHostParams struct {
+	RepoPath *string `form:"repo_path,omitempty" json:"repo_path,omitempty"`
+	RefType  *string `form:"ref_type,omitempty" json:"ref_type,omitempty"`
+	RefName  *string `form:"ref_name,omitempty" json:"ref_name,omitempty"`
+	RefSha   *string `form:"ref_sha,omitempty" json:"ref_sha,omitempty"`
+	Path     *string `form:"path,omitempty" json:"path,omitempty"`
+}
+
+// GetRepoBrowserLastChangedOnHostParams defines parameters for GetRepoBrowserLastChangedOnHost.
+type GetRepoBrowserLastChangedOnHostParams struct {
+	RepoPath *string   `form:"repo_path,omitempty" json:"repo_path,omitempty"`
+	RefType  *string   `form:"ref_type,omitempty" json:"ref_type,omitempty"`
+	RefName  *string   `form:"ref_name,omitempty" json:"ref_name,omitempty"`
+	RefSha   *string   `form:"ref_sha,omitempty" json:"ref_sha,omitempty"`
+	Path     *[]string `form:"path,omitempty" json:"path,omitempty"`
+}
+
+// ListRepoBrowserRefsOnHostParams defines parameters for ListRepoBrowserRefsOnHost.
+type ListRepoBrowserRefsOnHostParams struct {
+	RepoPath *string `form:"repo_path,omitempty" json:"repo_path,omitempty"`
+}
+
+// ListRepoBrowserTreeOnHostParams defines parameters for ListRepoBrowserTreeOnHost.
+type ListRepoBrowserTreeOnHostParams struct {
+	RepoPath *string `form:"repo_path,omitempty" json:"repo_path,omitempty"`
+	RefType  *string `form:"ref_type,omitempty" json:"ref_type,omitempty"`
+	RefName  *string `form:"ref_name,omitempty" json:"ref_name,omitempty"`
+	RefSha   *string `form:"ref_sha,omitempty" json:"ref_sha,omitempty"`
+}
+
 // GetCommentAutocompleteOnHostParams defines parameters for GetCommentAutocompleteOnHost.
 type GetCommentAutocompleteOnHostParams struct {
 	Trigger *string `form:"trigger,omitempty" json:"trigger,omitempty"`
@@ -3311,6 +3463,65 @@ type GetPullFilePreviewParams struct {
 
 // GetPullFilePreviewParamsSide defines parameters for GetPullFilePreview.
 type GetPullFilePreviewParamsSide string
+
+// GetRepoBrowserAssetParams defines parameters for GetRepoBrowserAsset.
+type GetRepoBrowserAssetParams struct {
+	RepoPath *string `form:"repo_path,omitempty" json:"repo_path,omitempty"`
+	RefType  *string `form:"ref_type,omitempty" json:"ref_type,omitempty"`
+	RefName  *string `form:"ref_name,omitempty" json:"ref_name,omitempty"`
+	RefSha   *string `form:"ref_sha,omitempty" json:"ref_sha,omitempty"`
+	Path     *string `form:"path,omitempty" json:"path,omitempty"`
+}
+
+// GetRepoBrowserBlobParams defines parameters for GetRepoBrowserBlob.
+type GetRepoBrowserBlobParams struct {
+	RepoPath *string `form:"repo_path,omitempty" json:"repo_path,omitempty"`
+	RefType  *string `form:"ref_type,omitempty" json:"ref_type,omitempty"`
+	RefName  *string `form:"ref_name,omitempty" json:"ref_name,omitempty"`
+	RefSha   *string `form:"ref_sha,omitempty" json:"ref_sha,omitempty"`
+	Path     *string `form:"path,omitempty" json:"path,omitempty"`
+}
+
+// GetRepoBrowserCommitParams defines parameters for GetRepoBrowserCommit.
+type GetRepoBrowserCommitParams struct {
+	RepoPath *string `form:"repo_path,omitempty" json:"repo_path,omitempty"`
+	RefType  *string `form:"ref_type,omitempty" json:"ref_type,omitempty"`
+	RefName  *string `form:"ref_name,omitempty" json:"ref_name,omitempty"`
+	RefSha   *string `form:"ref_sha,omitempty" json:"ref_sha,omitempty"`
+	Path     *string `form:"path,omitempty" json:"path,omitempty"`
+	Sha      *string `form:"sha,omitempty" json:"sha,omitempty"`
+}
+
+// GetRepoBrowserHistoryParams defines parameters for GetRepoBrowserHistory.
+type GetRepoBrowserHistoryParams struct {
+	RepoPath *string `form:"repo_path,omitempty" json:"repo_path,omitempty"`
+	RefType  *string `form:"ref_type,omitempty" json:"ref_type,omitempty"`
+	RefName  *string `form:"ref_name,omitempty" json:"ref_name,omitempty"`
+	RefSha   *string `form:"ref_sha,omitempty" json:"ref_sha,omitempty"`
+	Path     *string `form:"path,omitempty" json:"path,omitempty"`
+}
+
+// GetRepoBrowserLastChangedParams defines parameters for GetRepoBrowserLastChanged.
+type GetRepoBrowserLastChangedParams struct {
+	RepoPath *string   `form:"repo_path,omitempty" json:"repo_path,omitempty"`
+	RefType  *string   `form:"ref_type,omitempty" json:"ref_type,omitempty"`
+	RefName  *string   `form:"ref_name,omitempty" json:"ref_name,omitempty"`
+	RefSha   *string   `form:"ref_sha,omitempty" json:"ref_sha,omitempty"`
+	Path     *[]string `form:"path,omitempty" json:"path,omitempty"`
+}
+
+// ListRepoBrowserRefsParams defines parameters for ListRepoBrowserRefs.
+type ListRepoBrowserRefsParams struct {
+	RepoPath *string `form:"repo_path,omitempty" json:"repo_path,omitempty"`
+}
+
+// ListRepoBrowserTreeParams defines parameters for ListRepoBrowserTree.
+type ListRepoBrowserTreeParams struct {
+	RepoPath *string `form:"repo_path,omitempty" json:"repo_path,omitempty"`
+	RefType  *string `form:"ref_type,omitempty" json:"ref_type,omitempty"`
+	RefName  *string `form:"ref_name,omitempty" json:"ref_name,omitempty"`
+	RefSha   *string `form:"ref_sha,omitempty" json:"ref_sha,omitempty"`
+}
 
 // GetCommentAutocompleteParams defines parameters for GetCommentAutocomplete.
 type GetCommentAutocompleteParams struct {
@@ -4215,6 +4426,27 @@ type ClientInterface interface {
 	// GetRepoOnHost request
 	GetRepoOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// GetRepoBrowserAssetOnHost request
+	GetRepoBrowserAssetOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, params *GetRepoBrowserAssetOnHostParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetRepoBrowserBlobOnHost request
+	GetRepoBrowserBlobOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, params *GetRepoBrowserBlobOnHostParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetRepoBrowserCommitOnHost request
+	GetRepoBrowserCommitOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, params *GetRepoBrowserCommitOnHostParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetRepoBrowserHistoryOnHost request
+	GetRepoBrowserHistoryOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, params *GetRepoBrowserHistoryOnHostParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetRepoBrowserLastChangedOnHost request
+	GetRepoBrowserLastChangedOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, params *GetRepoBrowserLastChangedOnHostParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListRepoBrowserRefsOnHost request
+	ListRepoBrowserRefsOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, params *ListRepoBrowserRefsOnHostParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListRepoBrowserTreeOnHost request
+	ListRepoBrowserTreeOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, params *ListRepoBrowserTreeOnHostParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetCommentAutocompleteOnHost request
 	GetCommentAutocompleteOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, params *GetCommentAutocompleteOnHostParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -4574,6 +4806,27 @@ type ClientInterface interface {
 
 	// GetRepo request
 	GetRepo(ctx context.Context, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetRepoBrowserAsset request
+	GetRepoBrowserAsset(ctx context.Context, provider string, owner string, name string, params *GetRepoBrowserAssetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetRepoBrowserBlob request
+	GetRepoBrowserBlob(ctx context.Context, provider string, owner string, name string, params *GetRepoBrowserBlobParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetRepoBrowserCommit request
+	GetRepoBrowserCommit(ctx context.Context, provider string, owner string, name string, params *GetRepoBrowserCommitParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetRepoBrowserHistory request
+	GetRepoBrowserHistory(ctx context.Context, provider string, owner string, name string, params *GetRepoBrowserHistoryParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetRepoBrowserLastChanged request
+	GetRepoBrowserLastChanged(ctx context.Context, provider string, owner string, name string, params *GetRepoBrowserLastChangedParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListRepoBrowserRefs request
+	ListRepoBrowserRefs(ctx context.Context, provider string, owner string, name string, params *ListRepoBrowserRefsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListRepoBrowserTree request
+	ListRepoBrowserTree(ctx context.Context, provider string, owner string, name string, params *ListRepoBrowserTreeParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetCommentAutocomplete request
 	GetCommentAutocomplete(ctx context.Context, provider string, owner string, name string, params *GetCommentAutocompleteParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -6615,6 +6868,90 @@ func (c *Client) GetRepoOnHost(ctx context.Context, platformHost string, provide
 	return c.Client.Do(req)
 }
 
+func (c *Client) GetRepoBrowserAssetOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, params *GetRepoBrowserAssetOnHostParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetRepoBrowserAssetOnHostRequest(c.Server, platformHost, provider, owner, name, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetRepoBrowserBlobOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, params *GetRepoBrowserBlobOnHostParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetRepoBrowserBlobOnHostRequest(c.Server, platformHost, provider, owner, name, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetRepoBrowserCommitOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, params *GetRepoBrowserCommitOnHostParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetRepoBrowserCommitOnHostRequest(c.Server, platformHost, provider, owner, name, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetRepoBrowserHistoryOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, params *GetRepoBrowserHistoryOnHostParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetRepoBrowserHistoryOnHostRequest(c.Server, platformHost, provider, owner, name, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetRepoBrowserLastChangedOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, params *GetRepoBrowserLastChangedOnHostParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetRepoBrowserLastChangedOnHostRequest(c.Server, platformHost, provider, owner, name, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListRepoBrowserRefsOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, params *ListRepoBrowserRefsOnHostParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListRepoBrowserRefsOnHostRequest(c.Server, platformHost, provider, owner, name, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListRepoBrowserTreeOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, params *ListRepoBrowserTreeOnHostParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListRepoBrowserTreeOnHostRequest(c.Server, platformHost, provider, owner, name, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) GetCommentAutocompleteOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, params *GetCommentAutocompleteOnHostParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetCommentAutocompleteOnHostRequest(c.Server, platformHost, provider, owner, name, params)
 	if err != nil {
@@ -8201,6 +8538,90 @@ func (c *Client) DeleteRepo(ctx context.Context, provider string, owner string, 
 
 func (c *Client) GetRepo(ctx context.Context, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetRepoRequest(c.Server, provider, owner, name)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetRepoBrowserAsset(ctx context.Context, provider string, owner string, name string, params *GetRepoBrowserAssetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetRepoBrowserAssetRequest(c.Server, provider, owner, name, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetRepoBrowserBlob(ctx context.Context, provider string, owner string, name string, params *GetRepoBrowserBlobParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetRepoBrowserBlobRequest(c.Server, provider, owner, name, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetRepoBrowserCommit(ctx context.Context, provider string, owner string, name string, params *GetRepoBrowserCommitParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetRepoBrowserCommitRequest(c.Server, provider, owner, name, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetRepoBrowserHistory(ctx context.Context, provider string, owner string, name string, params *GetRepoBrowserHistoryParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetRepoBrowserHistoryRequest(c.Server, provider, owner, name, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetRepoBrowserLastChanged(ctx context.Context, provider string, owner string, name string, params *GetRepoBrowserLastChangedParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetRepoBrowserLastChangedRequest(c.Server, provider, owner, name, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListRepoBrowserRefs(ctx context.Context, provider string, owner string, name string, params *ListRepoBrowserRefsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListRepoBrowserRefsRequest(c.Server, provider, owner, name, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListRepoBrowserTree(ctx context.Context, provider string, owner string, name string, params *ListRepoBrowserTreeParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListRepoBrowserTreeRequest(c.Server, provider, owner, name, params)
 	if err != nil {
 		return nil, err
 	}
@@ -15845,6 +16266,868 @@ func NewGetRepoOnHostRequest(server string, platformHost string, provider string
 	return req, nil
 }
 
+// NewGetRepoBrowserAssetOnHostRequest generates requests for GetRepoBrowserAssetOnHost
+func NewGetRepoBrowserAssetOnHostRequest(server string, platformHost string, provider string, owner string, name string, params *GetRepoBrowserAssetOnHostParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "platform_host", platformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "provider", provider, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "owner", owner, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam3 string
+
+	pathParam3, err = runtime.StyleParamWithOptions("simple", false, "name", name, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/host/%s/repo/%s/%s/%s/browser/asset", pathParam0, pathParam1, pathParam2, pathParam3)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if params.RepoPath != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "repo_path", *params.RepoPath, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.RefType != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "ref_type", *params.RefType, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.RefName != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "ref_name", *params.RefName, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.RefSha != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "ref_sha", *params.RefSha, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.Path != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "path", *params.Path, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetRepoBrowserBlobOnHostRequest generates requests for GetRepoBrowserBlobOnHost
+func NewGetRepoBrowserBlobOnHostRequest(server string, platformHost string, provider string, owner string, name string, params *GetRepoBrowserBlobOnHostParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "platform_host", platformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "provider", provider, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "owner", owner, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam3 string
+
+	pathParam3, err = runtime.StyleParamWithOptions("simple", false, "name", name, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/host/%s/repo/%s/%s/%s/browser/blob", pathParam0, pathParam1, pathParam2, pathParam3)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if params.RepoPath != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "repo_path", *params.RepoPath, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.RefType != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "ref_type", *params.RefType, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.RefName != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "ref_name", *params.RefName, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.RefSha != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "ref_sha", *params.RefSha, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.Path != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "path", *params.Path, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetRepoBrowserCommitOnHostRequest generates requests for GetRepoBrowserCommitOnHost
+func NewGetRepoBrowserCommitOnHostRequest(server string, platformHost string, provider string, owner string, name string, params *GetRepoBrowserCommitOnHostParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "platform_host", platformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "provider", provider, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "owner", owner, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam3 string
+
+	pathParam3, err = runtime.StyleParamWithOptions("simple", false, "name", name, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/host/%s/repo/%s/%s/%s/browser/commit", pathParam0, pathParam1, pathParam2, pathParam3)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if params.RepoPath != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "repo_path", *params.RepoPath, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.RefType != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "ref_type", *params.RefType, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.RefName != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "ref_name", *params.RefName, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.RefSha != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "ref_sha", *params.RefSha, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.Path != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "path", *params.Path, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.Sha != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "sha", *params.Sha, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetRepoBrowserHistoryOnHostRequest generates requests for GetRepoBrowserHistoryOnHost
+func NewGetRepoBrowserHistoryOnHostRequest(server string, platformHost string, provider string, owner string, name string, params *GetRepoBrowserHistoryOnHostParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "platform_host", platformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "provider", provider, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "owner", owner, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam3 string
+
+	pathParam3, err = runtime.StyleParamWithOptions("simple", false, "name", name, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/host/%s/repo/%s/%s/%s/browser/history", pathParam0, pathParam1, pathParam2, pathParam3)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if params.RepoPath != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "repo_path", *params.RepoPath, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.RefType != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "ref_type", *params.RefType, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.RefName != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "ref_name", *params.RefName, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.RefSha != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "ref_sha", *params.RefSha, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.Path != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "path", *params.Path, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetRepoBrowserLastChangedOnHostRequest generates requests for GetRepoBrowserLastChangedOnHost
+func NewGetRepoBrowserLastChangedOnHostRequest(server string, platformHost string, provider string, owner string, name string, params *GetRepoBrowserLastChangedOnHostParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "platform_host", platformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "provider", provider, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "owner", owner, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam3 string
+
+	pathParam3, err = runtime.StyleParamWithOptions("simple", false, "name", name, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/host/%s/repo/%s/%s/%s/browser/last-changed", pathParam0, pathParam1, pathParam2, pathParam3)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if params.RepoPath != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "repo_path", *params.RepoPath, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.RefType != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "ref_type", *params.RefType, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.RefName != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "ref_name", *params.RefName, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.RefSha != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "ref_sha", *params.RefSha, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.Path != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "path", *params.Path, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "array", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewListRepoBrowserRefsOnHostRequest generates requests for ListRepoBrowserRefsOnHost
+func NewListRepoBrowserRefsOnHostRequest(server string, platformHost string, provider string, owner string, name string, params *ListRepoBrowserRefsOnHostParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "platform_host", platformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "provider", provider, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "owner", owner, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam3 string
+
+	pathParam3, err = runtime.StyleParamWithOptions("simple", false, "name", name, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/host/%s/repo/%s/%s/%s/browser/refs", pathParam0, pathParam1, pathParam2, pathParam3)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if params.RepoPath != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "repo_path", *params.RepoPath, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewListRepoBrowserTreeOnHostRequest generates requests for ListRepoBrowserTreeOnHost
+func NewListRepoBrowserTreeOnHostRequest(server string, platformHost string, provider string, owner string, name string, params *ListRepoBrowserTreeOnHostParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "platform_host", platformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "provider", provider, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "owner", owner, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam3 string
+
+	pathParam3, err = runtime.StyleParamWithOptions("simple", false, "name", name, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/host/%s/repo/%s/%s/%s/browser/tree", pathParam0, pathParam1, pathParam2, pathParam3)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if params.RepoPath != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "repo_path", *params.RepoPath, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.RefType != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "ref_type", *params.RefType, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.RefName != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "ref_name", *params.RefName, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.RefSha != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "ref_sha", *params.RefSha, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewGetCommentAutocompleteOnHostRequest generates requests for GetCommentAutocompleteOnHost
 func NewGetCommentAutocompleteOnHostRequest(server string, platformHost string, provider string, owner string, name string, params *GetCommentAutocompleteOnHostParams) (*http.Request, error) {
 	var err error
@@ -21488,6 +22771,819 @@ func NewGetRepoRequest(server string, provider string, owner string, name string
 	return req, nil
 }
 
+// NewGetRepoBrowserAssetRequest generates requests for GetRepoBrowserAsset
+func NewGetRepoBrowserAssetRequest(server string, provider string, owner string, name string, params *GetRepoBrowserAssetParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "provider", provider, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "owner", owner, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "name", name, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/repo/%s/%s/%s/browser/asset", pathParam0, pathParam1, pathParam2)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if params.RepoPath != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "repo_path", *params.RepoPath, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.RefType != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "ref_type", *params.RefType, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.RefName != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "ref_name", *params.RefName, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.RefSha != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "ref_sha", *params.RefSha, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.Path != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "path", *params.Path, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetRepoBrowserBlobRequest generates requests for GetRepoBrowserBlob
+func NewGetRepoBrowserBlobRequest(server string, provider string, owner string, name string, params *GetRepoBrowserBlobParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "provider", provider, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "owner", owner, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "name", name, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/repo/%s/%s/%s/browser/blob", pathParam0, pathParam1, pathParam2)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if params.RepoPath != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "repo_path", *params.RepoPath, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.RefType != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "ref_type", *params.RefType, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.RefName != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "ref_name", *params.RefName, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.RefSha != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "ref_sha", *params.RefSha, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.Path != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "path", *params.Path, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetRepoBrowserCommitRequest generates requests for GetRepoBrowserCommit
+func NewGetRepoBrowserCommitRequest(server string, provider string, owner string, name string, params *GetRepoBrowserCommitParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "provider", provider, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "owner", owner, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "name", name, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/repo/%s/%s/%s/browser/commit", pathParam0, pathParam1, pathParam2)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if params.RepoPath != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "repo_path", *params.RepoPath, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.RefType != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "ref_type", *params.RefType, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.RefName != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "ref_name", *params.RefName, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.RefSha != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "ref_sha", *params.RefSha, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.Path != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "path", *params.Path, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.Sha != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "sha", *params.Sha, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetRepoBrowserHistoryRequest generates requests for GetRepoBrowserHistory
+func NewGetRepoBrowserHistoryRequest(server string, provider string, owner string, name string, params *GetRepoBrowserHistoryParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "provider", provider, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "owner", owner, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "name", name, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/repo/%s/%s/%s/browser/history", pathParam0, pathParam1, pathParam2)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if params.RepoPath != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "repo_path", *params.RepoPath, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.RefType != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "ref_type", *params.RefType, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.RefName != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "ref_name", *params.RefName, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.RefSha != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "ref_sha", *params.RefSha, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.Path != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "path", *params.Path, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetRepoBrowserLastChangedRequest generates requests for GetRepoBrowserLastChanged
+func NewGetRepoBrowserLastChangedRequest(server string, provider string, owner string, name string, params *GetRepoBrowserLastChangedParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "provider", provider, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "owner", owner, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "name", name, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/repo/%s/%s/%s/browser/last-changed", pathParam0, pathParam1, pathParam2)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if params.RepoPath != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "repo_path", *params.RepoPath, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.RefType != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "ref_type", *params.RefType, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.RefName != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "ref_name", *params.RefName, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.RefSha != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "ref_sha", *params.RefSha, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.Path != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "path", *params.Path, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "array", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewListRepoBrowserRefsRequest generates requests for ListRepoBrowserRefs
+func NewListRepoBrowserRefsRequest(server string, provider string, owner string, name string, params *ListRepoBrowserRefsParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "provider", provider, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "owner", owner, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "name", name, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/repo/%s/%s/%s/browser/refs", pathParam0, pathParam1, pathParam2)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if params.RepoPath != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "repo_path", *params.RepoPath, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewListRepoBrowserTreeRequest generates requests for ListRepoBrowserTree
+func NewListRepoBrowserTreeRequest(server string, provider string, owner string, name string, params *ListRepoBrowserTreeParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "provider", provider, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "owner", owner, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "name", name, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/repo/%s/%s/%s/browser/tree", pathParam0, pathParam1, pathParam2)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if params.RepoPath != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "repo_path", *params.RepoPath, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.RefType != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "ref_type", *params.RefType, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.RefName != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "ref_name", *params.RefName, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.RefSha != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "ref_sha", *params.RefSha, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewGetCommentAutocompleteRequest generates requests for GetCommentAutocomplete
 func NewGetCommentAutocompleteRequest(server string, provider string, owner string, name string, params *GetCommentAutocompleteParams) (*http.Request, error) {
 	var err error
@@ -24346,6 +26442,27 @@ type ClientWithResponsesInterface interface {
 	// GetRepoOnHostWithResponse request
 	GetRepoOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*GetRepoOnHostResponse, error)
 
+	// GetRepoBrowserAssetOnHostWithResponse request
+	GetRepoBrowserAssetOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, params *GetRepoBrowserAssetOnHostParams, reqEditors ...RequestEditorFn) (*GetRepoBrowserAssetOnHostResponse, error)
+
+	// GetRepoBrowserBlobOnHostWithResponse request
+	GetRepoBrowserBlobOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, params *GetRepoBrowserBlobOnHostParams, reqEditors ...RequestEditorFn) (*GetRepoBrowserBlobOnHostResponse, error)
+
+	// GetRepoBrowserCommitOnHostWithResponse request
+	GetRepoBrowserCommitOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, params *GetRepoBrowserCommitOnHostParams, reqEditors ...RequestEditorFn) (*GetRepoBrowserCommitOnHostResponse, error)
+
+	// GetRepoBrowserHistoryOnHostWithResponse request
+	GetRepoBrowserHistoryOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, params *GetRepoBrowserHistoryOnHostParams, reqEditors ...RequestEditorFn) (*GetRepoBrowserHistoryOnHostResponse, error)
+
+	// GetRepoBrowserLastChangedOnHostWithResponse request
+	GetRepoBrowserLastChangedOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, params *GetRepoBrowserLastChangedOnHostParams, reqEditors ...RequestEditorFn) (*GetRepoBrowserLastChangedOnHostResponse, error)
+
+	// ListRepoBrowserRefsOnHostWithResponse request
+	ListRepoBrowserRefsOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, params *ListRepoBrowserRefsOnHostParams, reqEditors ...RequestEditorFn) (*ListRepoBrowserRefsOnHostResponse, error)
+
+	// ListRepoBrowserTreeOnHostWithResponse request
+	ListRepoBrowserTreeOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, params *ListRepoBrowserTreeOnHostParams, reqEditors ...RequestEditorFn) (*ListRepoBrowserTreeOnHostResponse, error)
+
 	// GetCommentAutocompleteOnHostWithResponse request
 	GetCommentAutocompleteOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, params *GetCommentAutocompleteOnHostParams, reqEditors ...RequestEditorFn) (*GetCommentAutocompleteOnHostResponse, error)
 
@@ -24705,6 +26822,27 @@ type ClientWithResponsesInterface interface {
 
 	// GetRepoWithResponse request
 	GetRepoWithResponse(ctx context.Context, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*GetRepoResponse, error)
+
+	// GetRepoBrowserAssetWithResponse request
+	GetRepoBrowserAssetWithResponse(ctx context.Context, provider string, owner string, name string, params *GetRepoBrowserAssetParams, reqEditors ...RequestEditorFn) (*GetRepoBrowserAssetResponse, error)
+
+	// GetRepoBrowserBlobWithResponse request
+	GetRepoBrowserBlobWithResponse(ctx context.Context, provider string, owner string, name string, params *GetRepoBrowserBlobParams, reqEditors ...RequestEditorFn) (*GetRepoBrowserBlobResponse, error)
+
+	// GetRepoBrowserCommitWithResponse request
+	GetRepoBrowserCommitWithResponse(ctx context.Context, provider string, owner string, name string, params *GetRepoBrowserCommitParams, reqEditors ...RequestEditorFn) (*GetRepoBrowserCommitResponse, error)
+
+	// GetRepoBrowserHistoryWithResponse request
+	GetRepoBrowserHistoryWithResponse(ctx context.Context, provider string, owner string, name string, params *GetRepoBrowserHistoryParams, reqEditors ...RequestEditorFn) (*GetRepoBrowserHistoryResponse, error)
+
+	// GetRepoBrowserLastChangedWithResponse request
+	GetRepoBrowserLastChangedWithResponse(ctx context.Context, provider string, owner string, name string, params *GetRepoBrowserLastChangedParams, reqEditors ...RequestEditorFn) (*GetRepoBrowserLastChangedResponse, error)
+
+	// ListRepoBrowserRefsWithResponse request
+	ListRepoBrowserRefsWithResponse(ctx context.Context, provider string, owner string, name string, params *ListRepoBrowserRefsParams, reqEditors ...RequestEditorFn) (*ListRepoBrowserRefsResponse, error)
+
+	// ListRepoBrowserTreeWithResponse request
+	ListRepoBrowserTreeWithResponse(ctx context.Context, provider string, owner string, name string, params *ListRepoBrowserTreeParams, reqEditors ...RequestEditorFn) (*ListRepoBrowserTreeResponse, error)
 
 	// GetCommentAutocompleteWithResponse request
 	GetCommentAutocompleteWithResponse(ctx context.Context, provider string, owner string, name string, params *GetCommentAutocompleteParams, reqEditors ...RequestEditorFn) (*GetCommentAutocompleteResponse, error)
@@ -27393,6 +29531,167 @@ func (r GetRepoOnHostResponse) StatusCode() int {
 	return 0
 }
 
+type GetRepoBrowserAssetOnHostResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *string
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r GetRepoBrowserAssetOnHostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetRepoBrowserAssetOnHostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetRepoBrowserBlobOnHostResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *RepoBrowserBlobResponse
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r GetRepoBrowserBlobOnHostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetRepoBrowserBlobOnHostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetRepoBrowserCommitOnHostResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *RepoBrowserCommitResponse
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r GetRepoBrowserCommitOnHostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetRepoBrowserCommitOnHostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetRepoBrowserHistoryOnHostResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *RepoBrowserHistoryResponse
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r GetRepoBrowserHistoryOnHostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetRepoBrowserHistoryOnHostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetRepoBrowserLastChangedOnHostResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *RepoBrowserLastChangedResponse
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r GetRepoBrowserLastChangedOnHostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetRepoBrowserLastChangedOnHostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListRepoBrowserRefsOnHostResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *RepoBrowserRefsResponse
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r ListRepoBrowserRefsOnHostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListRepoBrowserRefsOnHostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListRepoBrowserTreeOnHostResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *RepoBrowserTreeResponse
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r ListRepoBrowserTreeOnHostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListRepoBrowserTreeOnHostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type GetCommentAutocompleteOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
@@ -29533,6 +31832,167 @@ func (r GetRepoResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r GetRepoResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetRepoBrowserAssetResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *string
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r GetRepoBrowserAssetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetRepoBrowserAssetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetRepoBrowserBlobResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *RepoBrowserBlobResponse
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r GetRepoBrowserBlobResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetRepoBrowserBlobResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetRepoBrowserCommitResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *RepoBrowserCommitResponse
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r GetRepoBrowserCommitResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetRepoBrowserCommitResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetRepoBrowserHistoryResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *RepoBrowserHistoryResponse
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r GetRepoBrowserHistoryResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetRepoBrowserHistoryResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetRepoBrowserLastChangedResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *RepoBrowserLastChangedResponse
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r GetRepoBrowserLastChangedResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetRepoBrowserLastChangedResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListRepoBrowserRefsResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *RepoBrowserRefsResponse
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r ListRepoBrowserRefsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListRepoBrowserRefsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListRepoBrowserTreeResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *RepoBrowserTreeResponse
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r ListRepoBrowserTreeResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListRepoBrowserTreeResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -32083,6 +34543,69 @@ func (c *ClientWithResponses) GetRepoOnHostWithResponse(ctx context.Context, pla
 	return ParseGetRepoOnHostResponse(rsp)
 }
 
+// GetRepoBrowserAssetOnHostWithResponse request returning *GetRepoBrowserAssetOnHostResponse
+func (c *ClientWithResponses) GetRepoBrowserAssetOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, params *GetRepoBrowserAssetOnHostParams, reqEditors ...RequestEditorFn) (*GetRepoBrowserAssetOnHostResponse, error) {
+	rsp, err := c.GetRepoBrowserAssetOnHost(ctx, platformHost, provider, owner, name, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetRepoBrowserAssetOnHostResponse(rsp)
+}
+
+// GetRepoBrowserBlobOnHostWithResponse request returning *GetRepoBrowserBlobOnHostResponse
+func (c *ClientWithResponses) GetRepoBrowserBlobOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, params *GetRepoBrowserBlobOnHostParams, reqEditors ...RequestEditorFn) (*GetRepoBrowserBlobOnHostResponse, error) {
+	rsp, err := c.GetRepoBrowserBlobOnHost(ctx, platformHost, provider, owner, name, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetRepoBrowserBlobOnHostResponse(rsp)
+}
+
+// GetRepoBrowserCommitOnHostWithResponse request returning *GetRepoBrowserCommitOnHostResponse
+func (c *ClientWithResponses) GetRepoBrowserCommitOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, params *GetRepoBrowserCommitOnHostParams, reqEditors ...RequestEditorFn) (*GetRepoBrowserCommitOnHostResponse, error) {
+	rsp, err := c.GetRepoBrowserCommitOnHost(ctx, platformHost, provider, owner, name, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetRepoBrowserCommitOnHostResponse(rsp)
+}
+
+// GetRepoBrowserHistoryOnHostWithResponse request returning *GetRepoBrowserHistoryOnHostResponse
+func (c *ClientWithResponses) GetRepoBrowserHistoryOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, params *GetRepoBrowserHistoryOnHostParams, reqEditors ...RequestEditorFn) (*GetRepoBrowserHistoryOnHostResponse, error) {
+	rsp, err := c.GetRepoBrowserHistoryOnHost(ctx, platformHost, provider, owner, name, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetRepoBrowserHistoryOnHostResponse(rsp)
+}
+
+// GetRepoBrowserLastChangedOnHostWithResponse request returning *GetRepoBrowserLastChangedOnHostResponse
+func (c *ClientWithResponses) GetRepoBrowserLastChangedOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, params *GetRepoBrowserLastChangedOnHostParams, reqEditors ...RequestEditorFn) (*GetRepoBrowserLastChangedOnHostResponse, error) {
+	rsp, err := c.GetRepoBrowserLastChangedOnHost(ctx, platformHost, provider, owner, name, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetRepoBrowserLastChangedOnHostResponse(rsp)
+}
+
+// ListRepoBrowserRefsOnHostWithResponse request returning *ListRepoBrowserRefsOnHostResponse
+func (c *ClientWithResponses) ListRepoBrowserRefsOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, params *ListRepoBrowserRefsOnHostParams, reqEditors ...RequestEditorFn) (*ListRepoBrowserRefsOnHostResponse, error) {
+	rsp, err := c.ListRepoBrowserRefsOnHost(ctx, platformHost, provider, owner, name, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListRepoBrowserRefsOnHostResponse(rsp)
+}
+
+// ListRepoBrowserTreeOnHostWithResponse request returning *ListRepoBrowserTreeOnHostResponse
+func (c *ClientWithResponses) ListRepoBrowserTreeOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, params *ListRepoBrowserTreeOnHostParams, reqEditors ...RequestEditorFn) (*ListRepoBrowserTreeOnHostResponse, error) {
+	rsp, err := c.ListRepoBrowserTreeOnHost(ctx, platformHost, provider, owner, name, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListRepoBrowserTreeOnHostResponse(rsp)
+}
+
 // GetCommentAutocompleteOnHostWithResponse request returning *GetCommentAutocompleteOnHostResponse
 func (c *ClientWithResponses) GetCommentAutocompleteOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, params *GetCommentAutocompleteOnHostParams, reqEditors ...RequestEditorFn) (*GetCommentAutocompleteOnHostResponse, error) {
 	rsp, err := c.GetCommentAutocompleteOnHost(ctx, platformHost, provider, owner, name, params, reqEditors...)
@@ -33239,6 +35762,69 @@ func (c *ClientWithResponses) GetRepoWithResponse(ctx context.Context, provider 
 		return nil, err
 	}
 	return ParseGetRepoResponse(rsp)
+}
+
+// GetRepoBrowserAssetWithResponse request returning *GetRepoBrowserAssetResponse
+func (c *ClientWithResponses) GetRepoBrowserAssetWithResponse(ctx context.Context, provider string, owner string, name string, params *GetRepoBrowserAssetParams, reqEditors ...RequestEditorFn) (*GetRepoBrowserAssetResponse, error) {
+	rsp, err := c.GetRepoBrowserAsset(ctx, provider, owner, name, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetRepoBrowserAssetResponse(rsp)
+}
+
+// GetRepoBrowserBlobWithResponse request returning *GetRepoBrowserBlobResponse
+func (c *ClientWithResponses) GetRepoBrowserBlobWithResponse(ctx context.Context, provider string, owner string, name string, params *GetRepoBrowserBlobParams, reqEditors ...RequestEditorFn) (*GetRepoBrowserBlobResponse, error) {
+	rsp, err := c.GetRepoBrowserBlob(ctx, provider, owner, name, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetRepoBrowserBlobResponse(rsp)
+}
+
+// GetRepoBrowserCommitWithResponse request returning *GetRepoBrowserCommitResponse
+func (c *ClientWithResponses) GetRepoBrowserCommitWithResponse(ctx context.Context, provider string, owner string, name string, params *GetRepoBrowserCommitParams, reqEditors ...RequestEditorFn) (*GetRepoBrowserCommitResponse, error) {
+	rsp, err := c.GetRepoBrowserCommit(ctx, provider, owner, name, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetRepoBrowserCommitResponse(rsp)
+}
+
+// GetRepoBrowserHistoryWithResponse request returning *GetRepoBrowserHistoryResponse
+func (c *ClientWithResponses) GetRepoBrowserHistoryWithResponse(ctx context.Context, provider string, owner string, name string, params *GetRepoBrowserHistoryParams, reqEditors ...RequestEditorFn) (*GetRepoBrowserHistoryResponse, error) {
+	rsp, err := c.GetRepoBrowserHistory(ctx, provider, owner, name, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetRepoBrowserHistoryResponse(rsp)
+}
+
+// GetRepoBrowserLastChangedWithResponse request returning *GetRepoBrowserLastChangedResponse
+func (c *ClientWithResponses) GetRepoBrowserLastChangedWithResponse(ctx context.Context, provider string, owner string, name string, params *GetRepoBrowserLastChangedParams, reqEditors ...RequestEditorFn) (*GetRepoBrowserLastChangedResponse, error) {
+	rsp, err := c.GetRepoBrowserLastChanged(ctx, provider, owner, name, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetRepoBrowserLastChangedResponse(rsp)
+}
+
+// ListRepoBrowserRefsWithResponse request returning *ListRepoBrowserRefsResponse
+func (c *ClientWithResponses) ListRepoBrowserRefsWithResponse(ctx context.Context, provider string, owner string, name string, params *ListRepoBrowserRefsParams, reqEditors ...RequestEditorFn) (*ListRepoBrowserRefsResponse, error) {
+	rsp, err := c.ListRepoBrowserRefs(ctx, provider, owner, name, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListRepoBrowserRefsResponse(rsp)
+}
+
+// ListRepoBrowserTreeWithResponse request returning *ListRepoBrowserTreeResponse
+func (c *ClientWithResponses) ListRepoBrowserTreeWithResponse(ctx context.Context, provider string, owner string, name string, params *ListRepoBrowserTreeParams, reqEditors ...RequestEditorFn) (*ListRepoBrowserTreeResponse, error) {
+	rsp, err := c.ListRepoBrowserTree(ctx, provider, owner, name, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListRepoBrowserTreeResponse(rsp)
 }
 
 // GetCommentAutocompleteWithResponse request returning *GetCommentAutocompleteResponse
@@ -37359,6 +39945,237 @@ func ParseGetRepoOnHostResponse(rsp *http.Response) (*GetRepoOnHostResponse, err
 	return response, nil
 }
 
+// ParseGetRepoBrowserAssetOnHostResponse parses an HTTP response from a GetRepoBrowserAssetOnHostWithResponse call
+func ParseGetRepoBrowserAssetOnHostResponse(rsp *http.Response) (*GetRepoBrowserAssetOnHostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetRepoBrowserAssetOnHostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest string
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetRepoBrowserBlobOnHostResponse parses an HTTP response from a GetRepoBrowserBlobOnHostWithResponse call
+func ParseGetRepoBrowserBlobOnHostResponse(rsp *http.Response) (*GetRepoBrowserBlobOnHostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetRepoBrowserBlobOnHostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest RepoBrowserBlobResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetRepoBrowserCommitOnHostResponse parses an HTTP response from a GetRepoBrowserCommitOnHostWithResponse call
+func ParseGetRepoBrowserCommitOnHostResponse(rsp *http.Response) (*GetRepoBrowserCommitOnHostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetRepoBrowserCommitOnHostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest RepoBrowserCommitResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetRepoBrowserHistoryOnHostResponse parses an HTTP response from a GetRepoBrowserHistoryOnHostWithResponse call
+func ParseGetRepoBrowserHistoryOnHostResponse(rsp *http.Response) (*GetRepoBrowserHistoryOnHostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetRepoBrowserHistoryOnHostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest RepoBrowserHistoryResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetRepoBrowserLastChangedOnHostResponse parses an HTTP response from a GetRepoBrowserLastChangedOnHostWithResponse call
+func ParseGetRepoBrowserLastChangedOnHostResponse(rsp *http.Response) (*GetRepoBrowserLastChangedOnHostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetRepoBrowserLastChangedOnHostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest RepoBrowserLastChangedResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListRepoBrowserRefsOnHostResponse parses an HTTP response from a ListRepoBrowserRefsOnHostWithResponse call
+func ParseListRepoBrowserRefsOnHostResponse(rsp *http.Response) (*ListRepoBrowserRefsOnHostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListRepoBrowserRefsOnHostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest RepoBrowserRefsResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListRepoBrowserTreeOnHostResponse parses an HTTP response from a ListRepoBrowserTreeOnHostWithResponse call
+func ParseListRepoBrowserTreeOnHostResponse(rsp *http.Response) (*ListRepoBrowserTreeOnHostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListRepoBrowserTreeOnHostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest RepoBrowserTreeResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseGetCommentAutocompleteOnHostResponse parses an HTTP response from a GetCommentAutocompleteOnHostWithResponse call
 func ParseGetCommentAutocompleteOnHostResponse(rsp *http.Response) (*GetCommentAutocompleteOnHostResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -40332,6 +43149,237 @@ func ParseGetRepoResponse(rsp *http.Response) (*GetRepoResponse, error) {
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest RepoResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetRepoBrowserAssetResponse parses an HTTP response from a GetRepoBrowserAssetWithResponse call
+func ParseGetRepoBrowserAssetResponse(rsp *http.Response) (*GetRepoBrowserAssetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetRepoBrowserAssetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest string
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetRepoBrowserBlobResponse parses an HTTP response from a GetRepoBrowserBlobWithResponse call
+func ParseGetRepoBrowserBlobResponse(rsp *http.Response) (*GetRepoBrowserBlobResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetRepoBrowserBlobResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest RepoBrowserBlobResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetRepoBrowserCommitResponse parses an HTTP response from a GetRepoBrowserCommitWithResponse call
+func ParseGetRepoBrowserCommitResponse(rsp *http.Response) (*GetRepoBrowserCommitResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetRepoBrowserCommitResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest RepoBrowserCommitResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetRepoBrowserHistoryResponse parses an HTTP response from a GetRepoBrowserHistoryWithResponse call
+func ParseGetRepoBrowserHistoryResponse(rsp *http.Response) (*GetRepoBrowserHistoryResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetRepoBrowserHistoryResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest RepoBrowserHistoryResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetRepoBrowserLastChangedResponse parses an HTTP response from a GetRepoBrowserLastChangedWithResponse call
+func ParseGetRepoBrowserLastChangedResponse(rsp *http.Response) (*GetRepoBrowserLastChangedResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetRepoBrowserLastChangedResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest RepoBrowserLastChangedResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListRepoBrowserRefsResponse parses an HTTP response from a ListRepoBrowserRefsWithResponse call
+func ParseListRepoBrowserRefsResponse(rsp *http.Response) (*ListRepoBrowserRefsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListRepoBrowserRefsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest RepoBrowserRefsResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListRepoBrowserTreeResponse parses an HTTP response from a ListRepoBrowserTreeWithResponse call
+func ParseListRepoBrowserTreeResponse(rsp *http.Response) (*ListRepoBrowserTreeResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListRepoBrowserTreeResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest RepoBrowserTreeResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -2348,11 +2348,20 @@ type RepoBrowserLastChangedResponse struct {
 
 // RepoBrowserRef defines model for RepoBrowserRef.
 type RepoBrowserRef struct {
-	Name         string  `json:"name"`
+	// Name Selected branch or tag name. Commit refs leave this empty.
+	Name string `json:"name"`
+
+	// RequestedSha Caller-supplied branch or tag SHA when it differs from the resolved SHA.
 	RequestedSha *string `json:"requested_sha,omitempty"`
-	Sha          string  `json:"sha"`
-	Stale        bool    `json:"stale"`
-	Type         string  `json:"type"`
+
+	// Sha Resolved commit SHA used for the read.
+	Sha string `json:"sha"`
+
+	// Stale True when a caller-supplied branch or tag SHA no longer matches the current ref target.
+	Stale bool `json:"stale"`
+
+	// Type Selected ref type: branch, tag, or commit.
+	Type string `json:"type"`
 }
 
 // RepoBrowserRefsResponse defines model for RepoBrowserRefsResponse.

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -2371,6 +2371,7 @@ type RepoBrowserRefsResponse struct {
 	DefaultRef RepoBrowserRef    `json:"default_ref"`
 	Refs       *[]RepoBrowserRef `json:"refs"`
 	Repo       RepoRefResponse   `json:"repo"`
+	Truncated  bool              `json:"truncated"`
 }
 
 // RepoBrowserTreeEntry defines model for RepoBrowserTreeEntry.

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -2348,9 +2348,11 @@ type RepoBrowserLastChangedResponse struct {
 
 // RepoBrowserRef defines model for RepoBrowserRef.
 type RepoBrowserRef struct {
-	Name string `json:"name"`
-	Sha  string `json:"sha"`
-	Type string `json:"type"`
+	Name         string  `json:"name"`
+	RequestedSha *string `json:"requested_sha,omitempty"`
+	Sha          string  `json:"sha"`
+	Stale        bool    `json:"stale"`
+	Type         string  `json:"type"`
 }
 
 // RepoBrowserRefsResponse defines model for RepoBrowserRefsResponse.

--- a/internal/gitclone/clone.go
+++ b/internal/gitclone/clone.go
@@ -325,7 +325,7 @@ func (m *Manager) fetch(
 	// GitHub's smart-HTTP endpoint sporadically returns 5xx on /info/refs.
 	// Retry inline so a transient blip does not drop the entire sync cycle.
 	_, err := retryTransient(ctx, "git fetch", func() ([]byte, error) {
-		return m.gitNetworked(ctx, host, clonePath, nil, "fetch", "--prune", "origin")
+		return m.gitNetworked(ctx, host, clonePath, nil, "fetch", "--prune", "--tags", "origin")
 	})
 	if err != nil {
 		return fmt.Errorf("git fetch: %w", err)

--- a/internal/gitclone/clone.go
+++ b/internal/gitclone/clone.go
@@ -325,7 +325,7 @@ func (m *Manager) fetch(
 	// GitHub's smart-HTTP endpoint sporadically returns 5xx on /info/refs.
 	// Retry inline so a transient blip does not drop the entire sync cycle.
 	_, err := retryTransient(ctx, "git fetch", func() ([]byte, error) {
-		return m.gitNetworked(ctx, host, clonePath, nil, "fetch", "--prune", "--prune-tags", "origin")
+		return m.gitNetworked(ctx, host, clonePath, nil, "fetch", "--prune", "origin")
 	})
 	if err != nil {
 		return fmt.Errorf("git fetch: %w", err)

--- a/internal/gitclone/clone.go
+++ b/internal/gitclone/clone.go
@@ -45,8 +45,9 @@ type Manager struct {
 	// which GitHub's smart-HTTP edge throttles with sporadic 5xx.
 	ensureSF singleflight.Group
 
-	repoBrowserMu    sync.Mutex
-	repoBrowserRepos map[string]RepoBrowserRepoRef
+	repoBrowserRefreshSF singleflight.Group
+	repoBrowserMu        sync.Mutex
+	repoBrowserRepos     map[string]RepoBrowserRepoRef
 }
 
 // New creates a Manager that stores bare clones under baseDir.

--- a/internal/gitclone/clone.go
+++ b/internal/gitclone/clone.go
@@ -325,10 +325,16 @@ func (m *Manager) fetch(
 	// GitHub's smart-HTTP endpoint sporadically returns 5xx on /info/refs.
 	// Retry inline so a transient blip does not drop the entire sync cycle.
 	_, err := retryTransient(ctx, "git fetch", func() ([]byte, error) {
-		return m.gitNetworked(ctx, host, clonePath, nil, "fetch", "--prune", "--tags", "origin")
+		return m.gitNetworked(ctx, host, clonePath, nil, "fetch", "--prune", "origin")
 	})
 	if err != nil {
 		return fmt.Errorf("git fetch: %w", err)
+	}
+	_, err = retryTransient(ctx, "git fetch tags", func() ([]byte, error) {
+		return m.gitNetworked(ctx, host, clonePath, nil, "fetch", "origin", "+refs/tags/*:refs/tags/*")
+	})
+	if err != nil {
+		return fmt.Errorf("git fetch tags: %w", err)
 	}
 	// set-head -a is networked (it consults the remote's HEAD via
 	// /info/refs) and so subject to the same transient 5xx as fetch.

--- a/internal/gitclone/clone.go
+++ b/internal/gitclone/clone.go
@@ -325,7 +325,7 @@ func (m *Manager) fetch(
 	// GitHub's smart-HTTP endpoint sporadically returns 5xx on /info/refs.
 	// Retry inline so a transient blip does not drop the entire sync cycle.
 	_, err := retryTransient(ctx, "git fetch", func() ([]byte, error) {
-		return m.gitNetworked(ctx, host, clonePath, nil, "fetch", "--prune", "origin")
+		return m.gitNetworked(ctx, host, clonePath, nil, "fetch", "--prune", "--prune-tags", "origin")
 	})
 	if err != nil {
 		return fmt.Errorf("git fetch: %w", err)

--- a/internal/gitclone/clone.go
+++ b/internal/gitclone/clone.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	gitcmd "go.kenn.io/kit/git/cmd"
@@ -43,13 +44,20 @@ type Manager struct {
 	// same bare clone and trigger a stampede of identical git fetches,
 	// which GitHub's smart-HTTP edge throttles with sporadic 5xx.
 	ensureSF singleflight.Group
+
+	repoBrowserMu    sync.Mutex
+	repoBrowserRepos map[string]RepoBrowserRepoRef
 }
 
 // New creates a Manager that stores bare clones under baseDir.
 // tokenSources maps each host (e.g., "github.com") to its auth token source.
 // A nil or empty map means all operations proceed without auth.
 func New(baseDir string, tokenSources map[string]tokenauth.Source) *Manager {
-	return &Manager{baseDir: baseDir, tokenSources: tokenSources}
+	return &Manager{
+		baseDir:          baseDir,
+		tokenSources:     tokenSources,
+		repoBrowserRepos: make(map[string]RepoBrowserRepoRef),
+	}
 }
 
 // ClonePath returns the filesystem path for a repo's bare clone.

--- a/internal/gitclone/clone.go
+++ b/internal/gitclone/clone.go
@@ -330,6 +330,9 @@ func (m *Manager) fetch(
 	if err != nil {
 		return fmt.Errorf("git fetch: %w", err)
 	}
+	// Force-update moved tags for repo-browser refs, but do not prune deleted
+	// remote tags on this hot path. Stale tag cleanup belongs in explicit cache
+	// maintenance so normal sync/diff/refresh work is not coupled to tag pruning.
 	_, err = retryTransient(ctx, "git fetch tags", func() ([]byte, error) {
 		return m.gitNetworked(ctx, host, clonePath, nil, "fetch", "origin", "+refs/tags/*:refs/tags/*")
 	})

--- a/internal/gitclone/clone.go
+++ b/internal/gitclone/clone.go
@@ -325,19 +325,10 @@ func (m *Manager) fetch(
 	// GitHub's smart-HTTP endpoint sporadically returns 5xx on /info/refs.
 	// Retry inline so a transient blip does not drop the entire sync cycle.
 	_, err := retryTransient(ctx, "git fetch", func() ([]byte, error) {
-		return m.gitNetworked(ctx, host, clonePath, nil, "fetch", "--prune", "origin")
+		return m.gitNetworked(ctx, host, clonePath, nil, "fetch", "--prune", "--no-tags", "origin")
 	})
 	if err != nil {
 		return fmt.Errorf("git fetch: %w", err)
-	}
-	// Force-update moved tags for repo-browser refs, but do not prune deleted
-	// remote tags on this hot path. Stale tag cleanup belongs in explicit cache
-	// maintenance so normal sync/diff/refresh work is not coupled to tag pruning.
-	_, err = retryTransient(ctx, "git fetch tags", func() ([]byte, error) {
-		return m.gitNetworked(ctx, host, clonePath, nil, "fetch", "origin", "+refs/tags/*:refs/tags/*")
-	})
-	if err != nil {
-		return fmt.Errorf("git fetch tags: %w", err)
 	}
 	// set-head -a is networked (it consults the remote's HEAD via
 	// /info/refs) and so subject to the same transient 5xx as fetch.

--- a/internal/gitclone/clone_test.go
+++ b/internal/gitclone/clone_test.go
@@ -199,6 +199,33 @@ func TestEnsureCloneFetchesNewBranchCommits(t *testing.T) {
 	assert.Equal(newSHA, got)
 }
 
+func TestEnsureCloneToleratesMovedRemoteTags(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	remote, work := setupTestRepo(t)
+	initialSHA := gitSHA(t, work, "HEAD")
+	run(t, work, "git", "tag", "v1.0.0", initialSHA)
+	run(t, work, "git", "push", "origin", "refs/tags/v1.0.0")
+	clonesDir := t.TempDir()
+	mgr := New(clonesDir, nil)
+
+	ctx := t.Context()
+	require.NoError(mgr.EnsureClone(
+		ctx, "github.com", "testowner", "testrepo", remote))
+
+	movedSHA := commitAndPush(t, work, "retag.go", "package main\n", "retag target")
+	run(t, work, "git", "tag", "-f", "v1.0.0", movedSHA)
+	run(t, work, "git", "push", "--force", "origin", "refs/tags/v1.0.0")
+
+	require.NoError(mgr.EnsureClone(
+		ctx, "github.com", "testowner", "testrepo", remote))
+
+	got, err := mgr.RevParse(ctx, "github.com", "testowner", "testrepo", "refs/tags/v1.0.0")
+	require.NoError(err)
+	assert.Equal(movedSHA, got)
+}
+
 func TestEnsureCloneDoesNotFetchGitLabMergeRequestHeadsByDefault(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/gitclone/clone_test.go
+++ b/internal/gitclone/clone_test.go
@@ -199,7 +199,7 @@ func TestEnsureCloneFetchesNewBranchCommits(t *testing.T) {
 	assert.Equal(newSHA, got)
 }
 
-func TestEnsureCloneToleratesMovedRemoteTags(t *testing.T) {
+func TestEnsureCloneDoesNotRefreshMovedRemoteTags(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -223,7 +223,9 @@ func TestEnsureCloneToleratesMovedRemoteTags(t *testing.T) {
 
 	got, err := mgr.RevParse(ctx, "github.com", "testowner", "testrepo", "refs/tags/v1.0.0")
 	require.NoError(err)
-	assert.Equal(movedSHA, got)
+	assert.Equal(initialSHA, got)
+	_, err = mgr.RevParse(ctx, "github.com", "testowner", "testrepo", movedSHA)
+	require.NoError(err)
 }
 
 func TestEnsureCloneDoesNotFetchGitLabMergeRequestHeadsByDefault(t *testing.T) {

--- a/internal/gitclone/commits.go
+++ b/internal/gitclone/commits.go
@@ -134,6 +134,9 @@ func (m *Manager) CommitTimelineSinceTag(
 	if err != nil {
 		return 0, nil, err
 	}
+	if err := m.fetchTimelineTag(ctx, host, dir, tagName); err != nil {
+		return 0, nil, err
+	}
 	defaultRef := m.defaultTimelineRef(ctx, dir)
 	rangeSpec := tagName + ".." + defaultRef
 	countOut, err := m.git(ctx, dir,
@@ -184,6 +187,24 @@ func (m *Manager) CommitTimelineSinceTag(
 		return 0, nil, err
 	}
 	return count, points, nil
+}
+
+func (m *Manager) fetchTimelineTag(ctx context.Context, host, dir, tagName string) error {
+	tagName = strings.TrimSpace(tagName)
+	if tagName == "" {
+		return nil
+	}
+	ref := "refs/tags/" + tagName
+	if _, err := m.git(ctx, dir, "check-ref-format", ref); err != nil {
+		return fmt.Errorf("validate release tag %q: %w", tagName, err)
+	}
+	_, err := retryTransient(ctx, "git fetch release tag", func() ([]byte, error) {
+		return m.gitNetworked(ctx, host, dir, nil, "fetch", "origin", "+"+ref+":"+ref)
+	})
+	if err != nil {
+		return fmt.Errorf("fetch release tag %s: %w", tagName, err)
+	}
+	return nil
 }
 
 func (m *Manager) defaultTimelineRef(

--- a/internal/gitclone/commits_test.go
+++ b/internal/gitclone/commits_test.go
@@ -174,6 +174,46 @@ func TestCommitTimelineSinceTag(t *testing.T) {
 	assert.False(points[0].CommittedAt.IsZero())
 }
 
+func TestCommitTimelineSinceTagFetchesMovedTag(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	dir := t.TempDir()
+	remote := filepath.Join(dir, "remote.git")
+	commitTestRun(t, dir, "git", "init", "--bare", "--initial-branch=main", remote)
+
+	work := filepath.Join(dir, "work")
+	commitTestRun(t, dir, "git", "clone", remote, work)
+	commitTestRun(t, work, "git", "config", "user.email", "alice@test.com")
+	commitTestRun(t, work, "git", "config", "user.name", "Alice")
+
+	require.NoError(os.WriteFile(filepath.Join(work, "base.txt"), []byte("base\n"), 0o644))
+	commitTestRun(t, work, "git", "add", ".")
+	commitTestRun(t, work, "git", "commit", "-m", "release commit")
+	commitTestRun(t, work, "git", "tag", "v1.0.0")
+	require.NoError(os.WriteFile(filepath.Join(work, "next.txt"), []byte("next\n"), 0o644))
+	commitTestRun(t, work, "git", "add", ".")
+	commitTestRun(t, work, "git", "commit", "-m", "next")
+	commitTestRun(t, work, "git", "push", "--tags", "origin", "main")
+
+	mgr := New(filepath.Join(dir, "clones"), nil)
+	require.NoError(mgr.EnsureClone(t.Context(), "github.com", "acme", "widgets", remote))
+	count, _, err := mgr.CommitTimelineSinceTag(
+		t.Context(), "github.com", "acme", "widgets", "v1.0.0", 2,
+	)
+	require.NoError(err)
+	assert.Equal(1, count)
+
+	commitTestRun(t, work, "git", "tag", "-f", "v1.0.0", "HEAD")
+	commitTestRun(t, work, "git", "push", "--force", "origin", "refs/tags/v1.0.0")
+	count, points, err := mgr.CommitTimelineSinceTag(
+		t.Context(), "github.com", "acme", "widgets", "v1.0.0", 2,
+	)
+	require.NoError(err)
+	assert.Equal(0, count)
+	assert.Empty(points)
+}
+
 func TestCommitTimelineSinceTagWithoutOriginHEAD(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/gitclone/repo_browser.go
+++ b/internal/gitclone/repo_browser.go
@@ -766,10 +766,28 @@ func (m *Manager) EnsureRepoBrowserClone(ctx context.Context, repo RepoBrowserRe
 }
 
 func (m *Manager) RefreshRepoBrowserClone(ctx context.Context, repo RepoBrowserRepoRef) error {
-	return m.refreshRepoBrowserClone(ctx, repo)
+	return m.refreshRepoBrowserClone(ctx, repo, repoBrowserRefreshRespectCaller)
 }
 
-func (m *Manager) refreshRepoBrowserClone(ctx context.Context, repo RepoBrowserRepoRef) error {
+type repoBrowserRefreshWorkMode uint8
+
+const (
+	repoBrowserRefreshRespectCaller repoBrowserRefreshWorkMode = iota
+	repoBrowserRefreshDetachCaller
+)
+
+func repoBrowserRefreshWorkParent(ctx context.Context, mode repoBrowserRefreshWorkMode) context.Context {
+	if mode == repoBrowserRefreshDetachCaller {
+		return context.WithoutCancel(ctx)
+	}
+	return ctx
+}
+
+func (m *Manager) refreshRepoBrowserClone(
+	ctx context.Context,
+	repo RepoBrowserRepoRef,
+	mode repoBrowserRefreshWorkMode,
+) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -782,7 +800,10 @@ func (m *Manager) refreshRepoBrowserClone(ctx context.Context, repo RepoBrowserR
 	}
 	key := ensureCloneKey(namespace, repo.Host, repo.Owner, repo.Name)
 	ch := m.repoBrowserRefreshSF.DoChan(key, func() (any, error) {
-		opCtx, cancel := context.WithTimeout(ctx, ensureCloneTimeout)
+		opCtx, cancel := context.WithTimeout(
+			repoBrowserRefreshWorkParent(ctx, mode),
+			ensureCloneTimeout,
+		)
 		defer cancel()
 		if err := m.ensureCloneNowInNamespace(
 			opCtx,
@@ -817,7 +838,7 @@ func (m *Manager) RefreshRepoBrowserClones(ctx context.Context) {
 		if err := ctx.Err(); err != nil {
 			return
 		}
-		if err := m.refreshRepoBrowserClone(ctx, repo); err != nil {
+		if err := m.refreshRepoBrowserClone(ctx, repo, repoBrowserRefreshRespectCaller); err != nil {
 			slog.Warn("repo browser clone refresh failed",
 				"provider", repo.Provider,
 				"host", repo.Host,
@@ -866,7 +887,7 @@ func (m *Manager) ensureRepoBrowserCloneLocal(ctx context.Context, repo RepoBrow
 		return err
 	}
 	if _, err := os.Stat(filepath.Join(dir, "HEAD")); os.IsNotExist(err) {
-		return m.refreshRepoBrowserClone(ctx, repo)
+		return m.refreshRepoBrowserClone(ctx, repo, repoBrowserRefreshDetachCaller)
 	} else if err != nil {
 		return err
 	}

--- a/internal/gitclone/repo_browser.go
+++ b/internal/gitclone/repo_browser.go
@@ -766,10 +766,10 @@ func (m *Manager) EnsureRepoBrowserClone(ctx context.Context, repo RepoBrowserRe
 }
 
 func (m *Manager) RefreshRepoBrowserClone(ctx context.Context, repo RepoBrowserRepoRef) error {
-	return m.refreshRepoBrowserClone(ctx, repo, true)
+	return m.refreshRepoBrowserClone(ctx, repo)
 }
 
-func (m *Manager) refreshRepoBrowserClone(ctx context.Context, repo RepoBrowserRepoRef, detach bool) error {
+func (m *Manager) refreshRepoBrowserClone(ctx context.Context, repo RepoBrowserRepoRef) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -782,9 +782,9 @@ func (m *Manager) refreshRepoBrowserClone(ctx context.Context, repo RepoBrowserR
 	}
 	key := ensureCloneKey(namespace, repo.Host, repo.Owner, repo.Name)
 	ch := m.repoBrowserRefreshSF.DoChan(key, func() (any, error) {
-		opCtx, cancel := repoBrowserRefreshOperationContext(ctx, detach)
+		opCtx, cancel := context.WithTimeout(ctx, ensureCloneTimeout)
 		defer cancel()
-		if err := m.EnsureCloneInNamespace(
+		if err := m.ensureCloneNowInNamespace(
 			opCtx,
 			namespace,
 			repo.Host,
@@ -812,19 +812,12 @@ func (m *Manager) refreshRepoBrowserClone(ctx context.Context, repo RepoBrowserR
 	return nil
 }
 
-func repoBrowserRefreshOperationContext(ctx context.Context, detach bool) (context.Context, context.CancelFunc) {
-	if detach {
-		ctx = context.WithoutCancel(ctx)
-	}
-	return context.WithTimeout(ctx, ensureCloneTimeout)
-}
-
 func (m *Manager) RefreshRepoBrowserClones(ctx context.Context) {
 	for _, repo := range m.repoBrowserReposSnapshot() {
 		if err := ctx.Err(); err != nil {
 			return
 		}
-		if err := m.refreshRepoBrowserClone(ctx, repo, false); err != nil {
+		if err := m.refreshRepoBrowserClone(ctx, repo); err != nil {
 			slog.Warn("repo browser clone refresh failed",
 				"provider", repo.Provider,
 				"host", repo.Host,
@@ -873,7 +866,7 @@ func (m *Manager) ensureRepoBrowserCloneLocal(ctx context.Context, repo RepoBrow
 		return err
 	}
 	if _, err := os.Stat(filepath.Join(dir, "HEAD")); os.IsNotExist(err) {
-		return m.EnsureCloneInNamespace(ctx, namespace, repo.Host, repo.Owner, repo.Name, repo.RemoteURL)
+		return m.refreshRepoBrowserClone(ctx, repo)
 	} else if err != nil {
 		return err
 	}

--- a/internal/gitclone/repo_browser.go
+++ b/internal/gitclone/repo_browser.go
@@ -614,6 +614,7 @@ func (m *Manager) repoBrowserCommitTouchesPath(
 		"--no-commit-id",
 		"--name-only",
 		"-r",
+		"-m",
 		"-z",
 		"--root",
 		sha,

--- a/internal/gitclone/repo_browser.go
+++ b/internal/gitclone/repo_browser.go
@@ -787,6 +787,32 @@ func (m *Manager) RefreshRepoBrowserClones(ctx context.Context) {
 	}
 }
 
+func (m *Manager) RegisterExistingRepoBrowserClone(ctx context.Context, repo RepoBrowserRepoRef) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	if err := validateRemoteURLIdentity(repo.Host, repo.Owner, repo.Name, repo.RemoteURL); err != nil {
+		return false, err
+	}
+	dir, err := m.repoBrowserClonePath(repo)
+	if err != nil {
+		return false, err
+	}
+	if _, err := os.Stat(filepath.Join(dir, "HEAD")); os.IsNotExist(err) {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+	if out, err := m.git(ctx, dir, "config", "--get", "remote.origin.url"); err == nil {
+		if err := validateRemoteURLIdentity(repo.Host, repo.Owner, repo.Name, strings.TrimSpace(string(out))); err != nil {
+			return false, err
+		}
+	}
+	m.ensureRefspecs(ctx, dir)
+	m.registerRepoBrowserRepo(repo)
+	return true, nil
+}
+
 func (m *Manager) ensureRepoBrowserCloneLocal(ctx context.Context, repo RepoBrowserRepoRef) error {
 	if err := ctx.Err(); err != nil {
 		return err

--- a/internal/gitclone/repo_browser.go
+++ b/internal/gitclone/repo_browser.go
@@ -4,6 +4,8 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -46,6 +48,7 @@ const (
 )
 
 type RepoBrowserRepoRef struct {
+	Provider  string
 	Host      string
 	Owner     string
 	Name      string
@@ -116,7 +119,7 @@ func (m *Manager) ListRepoBrowserRefs(
 		}
 		return refs[i].Name < refs[j].Name
 	})
-	branch, sha, err := m.ResolveDefaultBranch(ctx, repo.Host, repo.Owner, repo.Name, defaultBranch)
+	branch, sha, err := m.resolveRepoBrowserDefaultBranch(ctx, repo, defaultBranch)
 	if err != nil {
 		return refs, RepoBrowserRef{}, truncated, err
 	}
@@ -681,12 +684,12 @@ func (m *Manager) resolveRepoBrowserRef(
 		if strings.TrimSpace(ref.Name) == "" {
 			return "", "", false, fmt.Errorf("%w: empty branch", ErrNotFound)
 		}
-		sha, err = m.resolveRefInDir(ctx, dir, remoteBranchRef(ref.Name))
+		sha, err = m.resolveExactRefInDir(ctx, dir, remoteBranchRef(ref.Name))
 	case RepoBrowserRefTag:
 		if strings.TrimSpace(ref.Name) == "" {
 			return "", "", false, fmt.Errorf("%w: empty tag", ErrNotFound)
 		}
-		sha, err = m.resolveRefInDir(ctx, dir, "refs/tags/"+ref.Name)
+		sha, err = m.resolveExactRefInDir(ctx, dir, "refs/tags/"+ref.Name)
 	case RepoBrowserRefCommit:
 		if !isFullHexSHA(ref.SHA) {
 			return "", "", false, fmt.Errorf("%w: %s", ErrNotFound, ref.SHA)
@@ -702,7 +705,85 @@ func (m *Manager) resolveRepoBrowserRef(
 }
 
 func (m *Manager) repoBrowserClonePath(repo RepoBrowserRepoRef) (string, error) {
-	return m.ClonePath(repo.Host, repo.Owner, repo.Name)
+	return m.ClonePathInNamespace(repoBrowserCloneNamespace(repo), repo.Host, repo.Owner, repo.Name)
+}
+
+func (m *Manager) EnsureRepoBrowserClone(ctx context.Context, repo RepoBrowserRepoRef) error {
+	return m.EnsureCloneInNamespace(
+		ctx,
+		repoBrowserCloneNamespace(repo),
+		repo.Host,
+		repo.Owner,
+		repo.Name,
+		repo.RemoteURL,
+	)
+}
+
+func repoBrowserCloneNamespace(repo RepoBrowserRepoRef) string {
+	identity := strings.Join([]string{
+		strings.TrimSpace(repo.Provider),
+		strings.TrimSpace(repo.Host),
+		strings.Trim(strings.TrimSpace(repo.RepoPath), "/"),
+	}, "\x00")
+	sum := sha256.Sum256([]byte(identity))
+	return "repo-browser-" + hex.EncodeToString(sum[:8])
+}
+
+func (m *Manager) resolveRepoBrowserDefaultBranch(
+	ctx context.Context,
+	repo RepoBrowserRepoRef,
+	preferred string,
+) (branch string, ref string, err error) {
+	dir, err := m.repoBrowserClonePath(repo)
+	if err != nil {
+		return "", "", err
+	}
+
+	preferred = strings.TrimSpace(preferred)
+	if preferred != "" {
+		for _, candidate := range branchActivityRefCandidates(preferred) {
+			if sha, err := m.resolveExactRefInDir(ctx, dir, candidate); err == nil {
+				return defaultBranchNameForResolvedCandidate(preferred, candidate), sha, nil
+			} else if !isMissingRefError(err) {
+				return "", "", fmt.Errorf("resolve preferred default branch %s: %w", preferred, err)
+			}
+		}
+	}
+
+	out, err := m.git(ctx, dir,
+		"symbolic-ref", "--quiet", "refs/remotes/origin/HEAD",
+	)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve origin HEAD: %w", err)
+	}
+	remoteRef := strings.TrimSpace(string(out))
+	branch, ok := strings.CutPrefix(remoteRef, "refs/remotes/origin/")
+	if !ok || branch == "" || branch == "HEAD" {
+		return "", "", fmt.Errorf("resolve origin HEAD: %w", ErrNotFound)
+	}
+	sha, err := m.resolveExactRefInDir(ctx, dir, remoteRef)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve origin HEAD target %s: %w", remoteRef, err)
+	}
+	return branch, sha, nil
+}
+
+func (m *Manager) resolveExactRefInDir(
+	ctx context.Context,
+	dir string,
+	ref string,
+) (string, error) {
+	out, err := m.git(ctx, dir,
+		"show-ref", "--verify", "--hash", ref,
+	)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrNotFound, err)
+	}
+	objectID := strings.TrimSpace(string(out))
+	if objectID == "" {
+		return "", fmt.Errorf("%w: %s", ErrNotFound, ref)
+	}
+	return m.resolveRefInDir(ctx, dir, objectID)
 }
 
 func cleanRepoBrowserPath(pathName string) (string, error) {

--- a/internal/gitclone/repo_browser.go
+++ b/internal/gitclone/repo_browser.go
@@ -738,6 +738,10 @@ func (m *Manager) EnsureRepoBrowserClone(ctx context.Context, repo RepoBrowserRe
 }
 
 func (m *Manager) RefreshRepoBrowserClone(ctx context.Context, repo RepoBrowserRepoRef) error {
+	return m.refreshRepoBrowserClone(ctx, repo, true)
+}
+
+func (m *Manager) refreshRepoBrowserClone(ctx context.Context, repo RepoBrowserRepoRef, detach bool) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -750,7 +754,7 @@ func (m *Manager) RefreshRepoBrowserClone(ctx context.Context, repo RepoBrowserR
 	}
 	key := ensureCloneKey(namespace, repo.Host, repo.Owner, repo.Name)
 	ch := m.repoBrowserRefreshSF.DoChan(key, func() (any, error) {
-		opCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), ensureCloneTimeout)
+		opCtx, cancel := repoBrowserRefreshOperationContext(ctx, detach)
 		defer cancel()
 		if err := m.EnsureCloneInNamespace(
 			opCtx,
@@ -780,12 +784,19 @@ func (m *Manager) RefreshRepoBrowserClone(ctx context.Context, repo RepoBrowserR
 	return nil
 }
 
+func repoBrowserRefreshOperationContext(ctx context.Context, detach bool) (context.Context, context.CancelFunc) {
+	if detach {
+		ctx = context.WithoutCancel(ctx)
+	}
+	return context.WithTimeout(ctx, ensureCloneTimeout)
+}
+
 func (m *Manager) RefreshRepoBrowserClones(ctx context.Context) {
 	for _, repo := range m.repoBrowserReposSnapshot() {
 		if err := ctx.Err(); err != nil {
 			return
 		}
-		if err := m.RefreshRepoBrowserClone(ctx, repo); err != nil {
+		if err := m.refreshRepoBrowserClone(ctx, repo, false); err != nil {
 			slog.Warn("repo browser clone refresh failed",
 				"provider", repo.Provider,
 				"host", repo.Host,

--- a/internal/gitclone/repo_browser.go
+++ b/internal/gitclone/repo_browser.go
@@ -29,6 +29,7 @@ var (
 	ErrTooManyPaths     = errors.New("too many repo browser paths")
 	ErrTooLargeAsset    = errors.New("repo browser asset too large")
 	ErrUnsupportedAsset = errors.New("unsupported repo browser asset type")
+	ErrCommitOutOfScope = errors.New("repo browser commit outside selected file history")
 )
 
 type RepoBrowserRefType string
@@ -48,11 +49,11 @@ type RepoBrowserRepoRef struct {
 }
 
 type RepoBrowserRef struct {
-	Type         RepoBrowserRefType `json:"type"`
-	Name         string             `json:"name"`
-	SHA          string             `json:"sha"`
-	RequestedSHA string             `json:"requested_sha,omitempty"`
-	Stale        bool               `json:"stale"`
+	Type         RepoBrowserRefType `json:"type" doc:"Selected ref type: branch, tag, or commit."`
+	Name         string             `json:"name" doc:"Selected branch or tag name. Commit refs leave this empty."`
+	SHA          string             `json:"sha" doc:"Resolved commit SHA used for the read."`
+	RequestedSHA string             `json:"requested_sha,omitempty" doc:"Caller-supplied branch or tag SHA when it differs from the resolved SHA."`
+	Stale        bool               `json:"stale" doc:"True when a caller-supplied branch or tag SHA no longer matches the current ref target."`
 }
 
 type RepoBrowserTreeEntry struct {
@@ -433,15 +434,23 @@ func (m *Manager) RepoBrowserCommitDetail(
 	pathName string,
 	sha string,
 ) (RepoBrowserCommit, error) {
-	if _, err := cleanRepoBrowserPath(pathName); err != nil {
+	cleanPath, err := cleanRepoBrowserPath(pathName)
+	if err != nil {
 		return RepoBrowserCommit{}, err
 	}
 	if !isFullHexSHA(sha) {
 		return RepoBrowserCommit{}, fmt.Errorf("%w: %s", ErrNotFound, sha)
 	}
-	dir, _, _, err := m.resolveRepoBrowserRef(ctx, repo, root)
+	dir, rootSHA, _, err := m.resolveRepoBrowserRef(ctx, repo, root)
 	if err != nil {
 		return RepoBrowserCommit{}, err
+	}
+	inScope, err := m.repoBrowserCommitTouchesPath(ctx, dir, rootSHA, cleanPath, sha)
+	if err != nil {
+		return RepoBrowserCommit{}, err
+	}
+	if !inScope {
+		return RepoBrowserCommit{}, fmt.Errorf("%w: %s", ErrCommitOutOfScope, sha)
 	}
 	out, err := m.git(ctx, dir,
 		"show", "-s", "--format="+repoBrowserCommitFormat, "--end-of-options", sha,
@@ -457,6 +466,34 @@ func (m *Manager) RepoBrowserCommitDetail(
 		return RepoBrowserCommit{}, fmt.Errorf("%w: %s", ErrNotFound, sha)
 	}
 	return commits[0], nil
+}
+
+func (m *Manager) repoBrowserCommitTouchesPath(
+	ctx context.Context,
+	dir string,
+	rootSHA string,
+	pathName string,
+	sha string,
+) (bool, error) {
+	out, err := m.git(ctx, dir,
+		"log",
+		"--max-count="+strconv.Itoa(RepoBrowserHistoryLimit),
+		"--format=%H",
+		"--end-of-options",
+		rootSHA,
+		"--",
+		pathName,
+	)
+	if err != nil {
+		return false, fmt.Errorf("repo browser commit scope %s: %w", pathName, err)
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+	for scanner.Scan() {
+		if scanner.Text() == sha {
+			return true, nil
+		}
+	}
+	return false, scanner.Err()
 }
 
 func (m *Manager) ResolveRepoBrowserRef(

--- a/internal/gitclone/repo_browser.go
+++ b/internal/gitclone/repo_browser.go
@@ -424,7 +424,7 @@ func (m *Manager) RepoBrowserLastChanged(
 		"log",
 		"-z",
 		"--max-count=" + strconv.Itoa(RepoBrowserLastChangedLogLimit),
-		"--format=" + repoBrowserCommitFormat,
+		"--format=" + repoBrowserLastChangedCommitFormat,
 		"--name-only",
 		"--end-of-options",
 		sha,
@@ -460,14 +460,21 @@ func parseRepoBrowserLastChanged(out []byte, wanted map[string]bool) (map[string
 	changed := make(map[string]RepoBrowserCommit, len(wanted))
 	var current RepoBrowserCommit
 	var haveCurrent bool
+	var nextTokenIsCommit bool
 	for part := range bytes.SplitSeq(out, []byte{0}) {
 		token := strings.TrimPrefix(string(part), "\n")
 		if token == "" {
+			nextTokenIsCommit = true
 			continue
 		}
-		if commit, err := parseRepoBrowserCommitLine(token); err == nil {
+		if nextTokenIsCommit {
+			commit, err := parseRepoBrowserCommitLine(token)
+			if err != nil {
+				return nil, err
+			}
 			current = commit
 			haveCurrent = true
+			nextTokenIsCommit = false
 			continue
 		}
 		if wanted[token] && haveCurrent {
@@ -634,7 +641,8 @@ func (m *Manager) ResolveRepoBrowserRef(
 }
 
 const (
-	repoBrowserCommitFormat = "%H%x1f%an%x1f%ae%x1f%aI%x1f%s"
+	repoBrowserCommitFormat            = "%H%x1f%an%x1f%ae%x1f%aI%x1f%s"
+	repoBrowserLastChangedCommitFormat = "%x00" + repoBrowserCommitFormat
 )
 
 func parseRepoBrowserCommitLines(out []byte) ([]RepoBrowserCommit, error) {
@@ -780,13 +788,33 @@ func (m *Manager) resolveExactRefInDir(
 		"show-ref", "--verify", "--hash", ref,
 	)
 	if err != nil {
-		return "", fmt.Errorf("%w: %w", ErrNotFound, err)
+		if isShowRefMissingError(err) {
+			return "", fmt.Errorf("%w: %w", ErrNotFound, err)
+		}
+		return "", err
 	}
 	objectID := strings.TrimSpace(string(out))
 	if objectID == "" {
 		return "", fmt.Errorf("%w: %s", ErrNotFound, ref)
 	}
 	return m.resolveRefInDir(ctx, dir, objectID)
+}
+
+func isShowRefMissingError(err error) bool {
+	if errors.Is(err, ErrNotFound) {
+		return true
+	}
+	if strings.Contains(strings.ToLower(err.Error()), "not a valid ref") {
+		return true
+	}
+	var exitErr interface {
+		ExitCode() (int, bool)
+	}
+	if errors.As(err, &exitErr) {
+		code, ok := exitErr.ExitCode()
+		return ok && code == 1
+	}
+	return false
 }
 
 func cleanRepoBrowserPath(pathName string) (string, error) {

--- a/internal/gitclone/repo_browser.go
+++ b/internal/gitclone/repo_browser.go
@@ -1,0 +1,568 @@
+package gitclone
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"mime"
+	"net/http"
+	"path"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+const (
+	RepoBrowserTreeEntryLimit      = 20000
+	RepoBrowserBlobSizeLimit       = 1 << 20
+	RepoBrowserLastChangedBatchMax = 250
+	RepoBrowserHistoryLimit        = 50
+)
+
+var (
+	ErrUnsafePath    = errors.New("unsafe repo browser path")
+	ErrTooManyPaths  = errors.New("too many repo browser paths")
+	ErrTooLargeAsset = errors.New("repo browser asset too large")
+)
+
+type RepoBrowserRefType string
+
+const (
+	RepoBrowserRefBranch RepoBrowserRefType = "branch"
+	RepoBrowserRefTag    RepoBrowserRefType = "tag"
+	RepoBrowserRefCommit RepoBrowserRefType = "commit"
+)
+
+type RepoBrowserRepoRef struct {
+	Host      string
+	Owner     string
+	Name      string
+	RepoPath  string
+	RemoteURL string
+}
+
+type RepoBrowserRef struct {
+	Type RepoBrowserRefType `json:"type"`
+	Name string             `json:"name"`
+	SHA  string             `json:"sha"`
+}
+
+type RepoBrowserTreeEntry struct {
+	Path string `json:"path"`
+	Type string `json:"type"`
+	Size int64  `json:"size"`
+}
+
+type RepoBrowserBlob struct {
+	Path      string `json:"path"`
+	SHA       string `json:"sha"`
+	Size      int64  `json:"size"`
+	MediaType string `json:"media_type"`
+	Encoding  string `json:"encoding"`
+	Content   string `json:"content"`
+	Binary    bool   `json:"binary"`
+	TooLarge  bool   `json:"too_large"`
+}
+
+type RepoBrowserCommit struct {
+	SHA         string    `json:"sha"`
+	Subject     string    `json:"subject"`
+	Body        string    `json:"body"`
+	AuthorName  string    `json:"author_name"`
+	AuthorEmail string    `json:"author_email"`
+	AuthoredAt  time.Time `json:"authored_at"`
+}
+
+func (m *Manager) ListRepoBrowserRefs(
+	ctx context.Context,
+	repo RepoBrowserRepoRef,
+	defaultBranch string,
+) ([]RepoBrowserRef, RepoBrowserRef, error) {
+	dir, err := m.repoBrowserClonePath(repo)
+	if err != nil {
+		return nil, RepoBrowserRef{}, err
+	}
+	out, err := m.git(ctx, dir,
+		"for-each-ref",
+		"--format=%(refname)%00%(objectname)%00%(*objectname)",
+		"refs/remotes/origin",
+		"refs/tags",
+	)
+	if err != nil {
+		return nil, RepoBrowserRef{}, fmt.Errorf("list repo browser refs: %w", err)
+	}
+	refs := parseRepoBrowserRefs(out)
+	sort.Slice(refs, func(i, j int) bool {
+		if refs[i].Type != refs[j].Type {
+			return refs[i].Type < refs[j].Type
+		}
+		return refs[i].Name < refs[j].Name
+	})
+	branch, sha, err := m.ResolveDefaultBranch(ctx, repo.Host, repo.Owner, repo.Name, defaultBranch)
+	if err != nil {
+		return refs, RepoBrowserRef{}, err
+	}
+	return refs, RepoBrowserRef{Type: RepoBrowserRefBranch, Name: branch, SHA: sha}, nil
+}
+
+func parseRepoBrowserRefs(out []byte) []RepoBrowserRef {
+	var refs []RepoBrowserRef
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+	scanner.Buffer(make([]byte, 0, bufio.MaxScanTokenSize), 1024*1024)
+	for scanner.Scan() {
+		parts := strings.Split(scanner.Text(), "\x00")
+		if len(parts) < 2 {
+			continue
+		}
+		refName := parts[0]
+		sha := parts[1]
+		if len(parts) > 2 && parts[2] != "" {
+			sha = parts[2]
+		}
+		switch {
+		case refName == "refs/remotes/origin/HEAD":
+			continue
+		case strings.HasPrefix(refName, "refs/remotes/origin/"):
+			name := strings.TrimPrefix(refName, "refs/remotes/origin/")
+			if name != "" {
+				refs = append(refs, RepoBrowserRef{Type: RepoBrowserRefBranch, Name: name, SHA: sha})
+			}
+		case strings.HasPrefix(refName, "refs/tags/"):
+			name := strings.TrimPrefix(refName, "refs/tags/")
+			if name != "" {
+				refs = append(refs, RepoBrowserRef{Type: RepoBrowserRefTag, Name: name, SHA: sha})
+			}
+		}
+	}
+	return refs
+}
+
+func (m *Manager) ListRepoBrowserTree(
+	ctx context.Context,
+	repo RepoBrowserRepoRef,
+	ref RepoBrowserRef,
+) ([]RepoBrowserTreeEntry, bool, error) {
+	dir, sha, _, err := m.resolveRepoBrowserRef(ctx, repo, ref)
+	if err != nil {
+		return nil, false, err
+	}
+	out, err := m.git(ctx, dir,
+		"ls-tree", "-r", "-z", "-l", "--full-tree", "--end-of-options", sha,
+	)
+	if err != nil {
+		return nil, false, fmt.Errorf("list repo browser tree: %w", err)
+	}
+	entries := parseRepoBrowserTree(out)
+	truncated := len(entries) > RepoBrowserTreeEntryLimit
+	if truncated {
+		entries = entries[:RepoBrowserTreeEntryLimit]
+	}
+	return entries, truncated, nil
+}
+
+func parseRepoBrowserTree(out []byte) []RepoBrowserTreeEntry {
+	records := bytes.Split(out, []byte{0})
+	entries := make([]RepoBrowserTreeEntry, 0, len(records))
+	for _, record := range records {
+		if len(record) == 0 {
+			continue
+		}
+		header, pathBytes, ok := bytes.Cut(record, []byte{'\t'})
+		if !ok {
+			continue
+		}
+		fields := strings.Fields(string(header))
+		if len(fields) < 4 {
+			continue
+		}
+		size := int64(0)
+		if fields[3] != "-" {
+			size, _ = strconv.ParseInt(fields[3], 10, 64)
+		}
+		entries = append(entries, RepoBrowserTreeEntry{
+			Path: string(pathBytes),
+			Type: fields[1],
+			Size: size,
+		})
+	}
+	SortRepoBrowserTree(entries)
+	return entries
+}
+
+func SortRepoBrowserTree(entries []RepoBrowserTreeEntry) {
+	sort.Slice(entries, func(i, j int) bool {
+		return compareDiffFilePaths(entries[i].Path, entries[j].Path) < 0
+	})
+}
+
+func (m *Manager) ReadRepoBrowserBlob(
+	ctx context.Context,
+	repo RepoBrowserRepoRef,
+	ref RepoBrowserRef,
+	pathName string,
+) (RepoBrowserBlob, error) {
+	return m.readRepoBrowserBlob(ctx, repo, ref, pathName, false)
+}
+
+func (m *Manager) ReadRepoBrowserAsset(
+	ctx context.Context,
+	repo RepoBrowserRepoRef,
+	ref RepoBrowserRef,
+	pathName string,
+) (RepoBrowserBlob, error) {
+	blob, err := m.readRepoBrowserBlob(ctx, repo, ref, pathName, true)
+	if err != nil {
+		return RepoBrowserBlob{}, err
+	}
+	if blob.TooLarge {
+		return RepoBrowserBlob{}, fmt.Errorf("%w: %w", ErrTooLargeAsset, ErrTooLarge)
+	}
+	return blob, nil
+}
+
+func (m *Manager) readRepoBrowserBlob(
+	ctx context.Context,
+	repo RepoBrowserRepoRef,
+	ref RepoBrowserRef,
+	pathName string,
+	asset bool,
+) (RepoBrowserBlob, error) {
+	cleanPath, err := cleanRepoBrowserPath(pathName)
+	if err != nil {
+		return RepoBrowserBlob{}, err
+	}
+	dir, sha, _, err := m.resolveRepoBrowserRef(ctx, repo, ref)
+	if err != nil {
+		return RepoBrowserBlob{}, err
+	}
+	entry, err := m.lookupRepoBrowserTreeEntry(ctx, dir, sha, cleanPath)
+	if err != nil {
+		return RepoBrowserBlob{}, err
+	}
+	if entry.Type != "blob" {
+		return RepoBrowserBlob{}, fmt.Errorf("%w: %s", ErrNotFound, cleanPath)
+	}
+	blob := RepoBrowserBlob{
+		Path:      cleanPath,
+		SHA:       entry.SHA,
+		Size:      entry.Size,
+		MediaType: mediaTypeForRepoBrowserPath(cleanPath),
+	}
+	if blob.Size > RepoBrowserBlobSizeLimit {
+		blob.TooLarge = true
+		return blob, nil
+	}
+	data, err := m.git(ctx, dir, "cat-file", "blob", entry.SHA)
+	if err != nil {
+		return RepoBrowserBlob{}, fmt.Errorf("read repo browser blob %s: %w", cleanPath, err)
+	}
+	if blob.MediaType == "" {
+		blob.MediaType = http.DetectContentType(data)
+	}
+	blob.Binary = bytes.IndexByte(data, 0) >= 0 || !utf8.Valid(data)
+	if blob.Binary && !asset {
+		return blob, nil
+	}
+	blob.Encoding = "utf-8"
+	blob.Content = string(data)
+	return blob, nil
+}
+
+type repoBrowserTreeEntryLookup struct {
+	Path string
+	Type string
+	SHA  string
+	Size int64
+}
+
+func (m *Manager) lookupRepoBrowserTreeEntry(
+	ctx context.Context,
+	dir, sha, pathName string,
+) (repoBrowserTreeEntryLookup, error) {
+	out, err := m.git(ctx, dir,
+		"ls-tree", "-z", "-l", "--full-tree", "--end-of-options", sha, "--", pathName,
+	)
+	if err != nil {
+		return repoBrowserTreeEntryLookup{}, fmt.Errorf("lookup repo browser path %s: %w", pathName, err)
+	}
+	for record := range bytes.SplitSeq(out, []byte{0}) {
+		if len(record) == 0 {
+			continue
+		}
+		header, pathBytes, ok := bytes.Cut(record, []byte{'\t'})
+		if !ok || string(pathBytes) != pathName {
+			continue
+		}
+		fields := strings.Fields(string(header))
+		if len(fields) < 4 {
+			continue
+		}
+		size := int64(0)
+		if fields[3] != "-" {
+			size, _ = strconv.ParseInt(fields[3], 10, 64)
+		}
+		return repoBrowserTreeEntryLookup{
+			Path: pathName,
+			Type: fields[1],
+			SHA:  fields[2],
+			Size: size,
+		}, nil
+	}
+	return repoBrowserTreeEntryLookup{}, fmt.Errorf("%w: %s", ErrNotFound, pathName)
+}
+
+func (m *Manager) RepoBrowserLastChanged(
+	ctx context.Context,
+	repo RepoBrowserRepoRef,
+	ref RepoBrowserRef,
+	paths []string,
+) (map[string]RepoBrowserCommit, error) {
+	if len(paths) > RepoBrowserLastChangedBatchMax {
+		return nil, ErrTooManyPaths
+	}
+	cleanPaths := make([]string, 0, len(paths))
+	seen := make(map[string]bool, len(paths))
+	for _, pathName := range paths {
+		cleanPath, err := cleanRepoBrowserPath(pathName)
+		if err != nil {
+			return nil, err
+		}
+		if seen[cleanPath] {
+			continue
+		}
+		seen[cleanPath] = true
+		cleanPaths = append(cleanPaths, cleanPath)
+	}
+	if len(cleanPaths) == 0 {
+		return map[string]RepoBrowserCommit{}, nil
+	}
+	dir, sha, _, err := m.resolveRepoBrowserRef(ctx, repo, ref)
+	if err != nil {
+		return nil, err
+	}
+	args := []string{
+		"log",
+		"--format=" + repoBrowserCommitMarker + repoBrowserCommitFormat,
+		"--name-only",
+		"--end-of-options",
+		sha,
+		"--",
+	}
+	args = append(args, cleanPaths...)
+	out, err := m.git(ctx, dir, args...)
+	if err != nil {
+		return nil, fmt.Errorf("repo browser last changed: %w", err)
+	}
+	return parseRepoBrowserLastChanged(out, seen)
+}
+
+func parseRepoBrowserLastChanged(out []byte, wanted map[string]bool) (map[string]RepoBrowserCommit, error) {
+	changed := make(map[string]RepoBrowserCommit, len(wanted))
+	var current RepoBrowserCommit
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+	scanner.Buffer(make([]byte, 0, bufio.MaxScanTokenSize), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+		if payload, ok := strings.CutPrefix(line, repoBrowserCommitMarker); ok {
+			commit, err := parseRepoBrowserCommitLine(payload)
+			if err != nil {
+				return nil, err
+			}
+			current = commit
+			continue
+		}
+		if wanted[line] {
+			if _, exists := changed[line]; !exists {
+				changed[line] = current
+			}
+		}
+		if len(changed) == len(wanted) {
+			break
+		}
+	}
+	return changed, scanner.Err()
+}
+
+func (m *Manager) RepoBrowserFileHistory(
+	ctx context.Context,
+	repo RepoBrowserRepoRef,
+	ref RepoBrowserRef,
+	pathName string,
+) ([]RepoBrowserCommit, error) {
+	cleanPath, err := cleanRepoBrowserPath(pathName)
+	if err != nil {
+		return nil, err
+	}
+	dir, sha, _, err := m.resolveRepoBrowserRef(ctx, repo, ref)
+	if err != nil {
+		return nil, err
+	}
+	out, err := m.git(ctx, dir,
+		"log",
+		"--max-count="+strconv.Itoa(RepoBrowserHistoryLimit),
+		"--format="+repoBrowserCommitFormat,
+		"--end-of-options",
+		sha,
+		"--",
+		cleanPath,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("repo browser file history %s: %w", cleanPath, err)
+	}
+	return parseRepoBrowserCommitLines(out)
+}
+
+func (m *Manager) RepoBrowserCommitDetail(
+	ctx context.Context,
+	repo RepoBrowserRepoRef,
+	root RepoBrowserRef,
+	pathName string,
+	sha string,
+) (RepoBrowserCommit, error) {
+	if _, err := cleanRepoBrowserPath(pathName); err != nil {
+		return RepoBrowserCommit{}, err
+	}
+	if !isFullHexSHA(sha) {
+		return RepoBrowserCommit{}, fmt.Errorf("%w: %s", ErrNotFound, sha)
+	}
+	dir, _, _, err := m.resolveRepoBrowserRef(ctx, repo, root)
+	if err != nil {
+		return RepoBrowserCommit{}, err
+	}
+	out, err := m.git(ctx, dir,
+		"show", "-s", "--format="+repoBrowserCommitFormat, "--end-of-options", sha,
+	)
+	if err != nil {
+		return RepoBrowserCommit{}, fmt.Errorf("repo browser commit detail %s: %w", sha, err)
+	}
+	commits, err := parseRepoBrowserCommitLines(out)
+	if err != nil {
+		return RepoBrowserCommit{}, err
+	}
+	if len(commits) == 0 {
+		return RepoBrowserCommit{}, fmt.Errorf("%w: %s", ErrNotFound, sha)
+	}
+	return commits[0], nil
+}
+
+const (
+	repoBrowserCommitMarker = "commit:"
+	repoBrowserCommitFormat = "%H%x1f%an%x1f%ae%x1f%aI%x1f%s"
+)
+
+func parseRepoBrowserCommitLines(out []byte) ([]RepoBrowserCommit, error) {
+	var commits []RepoBrowserCommit
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+	scanner.Buffer(make([]byte, 0, bufio.MaxScanTokenSize), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+		commit, err := parseRepoBrowserCommitLine(line)
+		if err != nil {
+			return nil, err
+		}
+		commits = append(commits, commit)
+	}
+	return commits, scanner.Err()
+}
+
+func parseRepoBrowserCommitLine(line string) (RepoBrowserCommit, error) {
+	parts := strings.SplitN(line, "\x1f", 5)
+	if len(parts) != 5 {
+		return RepoBrowserCommit{}, fmt.Errorf("unexpected repo browser commit line: %q", line)
+	}
+	authoredAt, err := time.Parse(time.RFC3339, parts[3])
+	if err != nil {
+		return RepoBrowserCommit{}, fmt.Errorf("parse repo browser commit time %q: %w", parts[3], err)
+	}
+	return RepoBrowserCommit{
+		SHA:         parts[0],
+		AuthorName:  truncateCommitText(parts[1], commitIdentityMaxBytes),
+		AuthorEmail: truncateCommitText(parts[2], commitIdentityMaxBytes),
+		AuthoredAt:  authoredAt,
+		Subject:     truncateCommitText(parts[4], commitMessageMaxBytes),
+	}, nil
+}
+
+func (m *Manager) resolveRepoBrowserRef(
+	ctx context.Context,
+	repo RepoBrowserRepoRef,
+	ref RepoBrowserRef,
+) (dir string, sha string, stale bool, err error) {
+	dir, err = m.repoBrowserClonePath(repo)
+	if err != nil {
+		return "", "", false, err
+	}
+	switch ref.Type {
+	case RepoBrowserRefBranch:
+		if strings.TrimSpace(ref.Name) == "" {
+			return "", "", false, fmt.Errorf("%w: empty branch", ErrNotFound)
+		}
+		sha, err = m.resolveRefInDir(ctx, dir, remoteBranchRef(ref.Name))
+	case RepoBrowserRefTag:
+		if strings.TrimSpace(ref.Name) == "" {
+			return "", "", false, fmt.Errorf("%w: empty tag", ErrNotFound)
+		}
+		sha, err = m.resolveRefInDir(ctx, dir, "refs/tags/"+ref.Name)
+	case RepoBrowserRefCommit:
+		if !isFullHexSHA(ref.SHA) {
+			return "", "", false, fmt.Errorf("%w: %s", ErrNotFound, ref.SHA)
+		}
+		sha, err = m.resolveRefInDir(ctx, dir, ref.SHA)
+	default:
+		err = fmt.Errorf("%w: unsupported ref type %q", ErrNotFound, ref.Type)
+	}
+	if err != nil {
+		return "", "", false, err
+	}
+	return dir, sha, ref.SHA != "" && ref.SHA != sha, nil
+}
+
+func (m *Manager) repoBrowserClonePath(repo RepoBrowserRepoRef) (string, error) {
+	return m.ClonePath(repo.Host, repo.Owner, repo.Name)
+}
+
+func cleanRepoBrowserPath(pathName string) (string, error) {
+	if pathName == "" || strings.ContainsRune(pathName, 0) || path.IsAbs(pathName) {
+		return "", ErrUnsafePath
+	}
+	cleaned := path.Clean(strings.ReplaceAll(pathName, "\\", "/"))
+	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return "", ErrUnsafePath
+	}
+	return cleaned, nil
+}
+
+func mediaTypeForRepoBrowserPath(pathName string) string {
+	ext := strings.ToLower(filepath.Ext(pathName))
+	if ext == ".svg" {
+		return "image/svg+xml"
+	}
+	if typ := mime.TypeByExtension(ext); typ != "" {
+		return typ
+	}
+	return ""
+}
+
+func isFullHexSHA(sha string) bool {
+	if len(sha) != 40 {
+		return false
+	}
+	for _, r := range sha {
+		if (r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F') {
+			continue
+		}
+		return false
+	}
+	return true
+}

--- a/internal/gitclone/repo_browser.go
+++ b/internal/gitclone/repo_browser.go
@@ -573,7 +573,11 @@ func (m *Manager) RepoBrowserCommitDetail(
 	if err != nil {
 		return RepoBrowserCommit{}, err
 	}
-	inScope, err := m.repoBrowserCommitTouchesPath(ctx, dir, rootSHA, cleanPath, sha)
+	commitSHA, err := m.resolveRefInDir(ctx, dir, sha)
+	if err != nil {
+		return RepoBrowserCommit{}, err
+	}
+	inScope, err := m.repoBrowserCommitTouchesPath(ctx, dir, rootSHA, cleanPath, commitSHA)
 	if err != nil {
 		return RepoBrowserCommit{}, err
 	}
@@ -581,7 +585,7 @@ func (m *Manager) RepoBrowserCommitDetail(
 		return RepoBrowserCommit{}, fmt.Errorf("%w: %s", ErrCommitOutOfScope, sha)
 	}
 	out, err := m.git(ctx, dir,
-		"show", "-s", "--format="+repoBrowserCommitFormat, "--end-of-options", sha,
+		"show", "-s", "--format="+repoBrowserCommitFormat, "--end-of-options", commitSHA,
 	)
 	if err != nil {
 		return RepoBrowserCommit{}, fmt.Errorf("repo browser commit detail %s: %w", sha, err)

--- a/internal/gitclone/repo_browser.go
+++ b/internal/gitclone/repo_browser.go
@@ -422,8 +422,9 @@ func (m *Manager) RepoBrowserLastChanged(
 	}
 	args := []string{
 		"log",
+		"-z",
 		"--max-count=" + strconv.Itoa(RepoBrowserLastChangedLogLimit),
-		"--format=" + repoBrowserCommitMarker + repoBrowserCommitFormat,
+		"--format=" + repoBrowserCommitFormat,
 		"--name-only",
 		"--end-of-options",
 		sha,
@@ -458,31 +459,27 @@ func (m *Manager) RepoBrowserLastChanged(
 func parseRepoBrowserLastChanged(out []byte, wanted map[string]bool) (map[string]RepoBrowserCommit, error) {
 	changed := make(map[string]RepoBrowserCommit, len(wanted))
 	var current RepoBrowserCommit
-	scanner := bufio.NewScanner(bytes.NewReader(out))
-	scanner.Buffer(make([]byte, 0, bufio.MaxScanTokenSize), 1024*1024)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if line == "" {
+	var haveCurrent bool
+	for part := range bytes.SplitSeq(out, []byte{0}) {
+		token := strings.TrimPrefix(string(part), "\n")
+		if token == "" {
 			continue
 		}
-		if payload, ok := strings.CutPrefix(line, repoBrowserCommitMarker); ok {
-			commit, err := parseRepoBrowserCommitLine(payload)
-			if err != nil {
-				return nil, err
-			}
+		if commit, err := parseRepoBrowserCommitLine(token); err == nil {
 			current = commit
+			haveCurrent = true
 			continue
 		}
-		if wanted[line] {
-			if _, exists := changed[line]; !exists {
-				changed[line] = current
+		if wanted[token] && haveCurrent {
+			if _, exists := changed[token]; !exists {
+				changed[token] = current
 			}
 		}
 		if len(changed) == len(wanted) {
 			break
 		}
 	}
-	return changed, scanner.Err()
+	return changed, nil
 }
 
 func (m *Manager) repoBrowserLastChangedForPath(
@@ -630,7 +627,6 @@ func (m *Manager) ResolveRepoBrowserRef(
 }
 
 const (
-	repoBrowserCommitMarker = "commit:"
 	repoBrowserCommitFormat = "%H%x1f%an%x1f%ae%x1f%aI%x1f%s"
 )
 
@@ -665,7 +661,7 @@ func parseRepoBrowserCommitLine(line string) (RepoBrowserCommit, error) {
 		SHA:         parts[0],
 		AuthorName:  truncateCommitText(parts[1], commitIdentityMaxBytes),
 		AuthorEmail: truncateCommitText(parts[2], commitIdentityMaxBytes),
-		AuthoredAt:  authoredAt,
+		AuthoredAt:  authoredAt.UTC(),
 		Subject:     truncateCommitText(parts[4], commitMessageMaxBytes),
 	}, nil
 }

--- a/internal/gitclone/repo_browser.go
+++ b/internal/gitclone/repo_browser.go
@@ -524,6 +524,13 @@ func (m *Manager) RepoBrowserFileHistory(
 	if err != nil {
 		return nil, err
 	}
+	entry, err := m.lookupRepoBrowserTreeEntry(ctx, dir, sha, cleanPath)
+	if err != nil {
+		return nil, err
+	}
+	if entry.Type != "blob" {
+		return nil, fmt.Errorf("%w: %s", ErrNotFound, cleanPath)
+	}
 	out, err := m.git(ctx, dir,
 		"log",
 		"--max-count="+strconv.Itoa(RepoBrowserHistoryLimit),

--- a/internal/gitclone/repo_browser.go
+++ b/internal/gitclone/repo_browser.go
@@ -730,22 +730,46 @@ func (m *Manager) EnsureRepoBrowserClone(ctx context.Context, repo RepoBrowserRe
 }
 
 func (m *Manager) RefreshRepoBrowserClone(ctx context.Context, repo RepoBrowserRepoRef) error {
-	if err := m.EnsureCloneInNamespace(
-		ctx,
-		repoBrowserCloneNamespace(repo),
-		repo.Host,
-		repo.Owner,
-		repo.Name,
-		repo.RemoteURL,
-	); err != nil {
+	if err := ctx.Err(); err != nil {
 		return err
 	}
-	dir, err := m.repoBrowserClonePath(repo)
-	if err != nil {
+	namespace := repoBrowserCloneNamespace(repo)
+	if err := validateRemoteURLIdentity(repo.Host, repo.Owner, repo.Name, repo.RemoteURL); err != nil {
 		return err
+	}
+	if _, err := m.ClonePathInNamespace(namespace, repo.Host, repo.Owner, repo.Name); err != nil {
+		return err
+	}
+	key := ensureCloneKey(namespace, repo.Host, repo.Owner, repo.Name)
+	ch := m.repoBrowserRefreshSF.DoChan(key, func() (any, error) {
+		opCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), ensureCloneTimeout)
+		defer cancel()
+		if err := m.EnsureCloneInNamespace(
+			opCtx,
+			namespace,
+			repo.Host,
+			repo.Owner,
+			repo.Name,
+			repo.RemoteURL,
+		); err != nil {
+			return nil, err
+		}
+		dir, err := m.repoBrowserClonePath(repo)
+		if err != nil {
+			return nil, err
+		}
+		return nil, m.fetchRepoBrowserTags(opCtx, repo.Host, dir)
+	})
+	select {
+	case res := <-ch:
+		if res.Err != nil {
+			return res.Err
+		}
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 	m.registerRepoBrowserRepo(repo)
-	return m.fetchRepoBrowserTags(ctx, repo.Host, dir)
+	return nil
 }
 
 func (m *Manager) RefreshRepoBrowserClones(ctx context.Context) {

--- a/internal/gitclone/repo_browser.go
+++ b/internal/gitclone/repo_browser.go
@@ -21,6 +21,7 @@ import (
 )
 
 const (
+	RepoBrowserRefLimit            = 1000
 	RepoBrowserTreeEntryLimit      = 20000
 	RepoBrowserBlobSizeLimit       = 1 << 20
 	RepoBrowserLastChangedBatchMax = 250
@@ -90,21 +91,23 @@ func (m *Manager) ListRepoBrowserRefs(
 	ctx context.Context,
 	repo RepoBrowserRepoRef,
 	defaultBranch string,
-) ([]RepoBrowserRef, RepoBrowserRef, error) {
+) ([]RepoBrowserRef, RepoBrowserRef, bool, error) {
 	dir, err := m.repoBrowserClonePath(repo)
 	if err != nil {
-		return nil, RepoBrowserRef{}, err
+		return nil, RepoBrowserRef{}, false, err
 	}
 	out, err := m.git(ctx, dir,
 		"for-each-ref",
+		"--count="+strconv.Itoa(RepoBrowserRefLimit+1),
 		"--format=%(refname)%00%(objectname)%00%(*objectname)",
 		"refs/remotes/origin",
 		"refs/tags",
 	)
 	if err != nil {
-		return nil, RepoBrowserRef{}, fmt.Errorf("list repo browser refs: %w", err)
+		return nil, RepoBrowserRef{}, false, fmt.Errorf("list repo browser refs: %w", err)
 	}
 	refs := parseRepoBrowserRefs(out)
+	refs, truncated := capRepoBrowserRefs(refs)
 	sort.Slice(refs, func(i, j int) bool {
 		if refs[i].Type != refs[j].Type {
 			return refs[i].Type < refs[j].Type
@@ -113,9 +116,9 @@ func (m *Manager) ListRepoBrowserRefs(
 	})
 	branch, sha, err := m.ResolveDefaultBranch(ctx, repo.Host, repo.Owner, repo.Name, defaultBranch)
 	if err != nil {
-		return refs, RepoBrowserRef{}, err
+		return refs, RepoBrowserRef{}, truncated, err
 	}
-	return refs, RepoBrowserRef{Type: RepoBrowserRefBranch, Name: branch, SHA: sha}, nil
+	return refs, RepoBrowserRef{Type: RepoBrowserRefBranch, Name: branch, SHA: sha}, truncated, nil
 }
 
 func parseRepoBrowserRefs(out []byte) []RepoBrowserRef {
@@ -148,6 +151,13 @@ func parseRepoBrowserRefs(out []byte) []RepoBrowserRef {
 		}
 	}
 	return refs
+}
+
+func capRepoBrowserRefs(refs []RepoBrowserRef) ([]RepoBrowserRef, bool) {
+	if len(refs) <= RepoBrowserRefLimit {
+		return refs, false
+	}
+	return refs[:RepoBrowserRefLimit], true
 }
 
 func (m *Manager) ListRepoBrowserTree(
@@ -345,7 +355,7 @@ func (m *Manager) lookupRepoBrowserTreeEntry(
 	dir, sha, pathName string,
 ) (repoBrowserTreeEntryLookup, error) {
 	out, err := m.git(ctx, dir,
-		"ls-tree", "-z", "-l", "--full-tree", "--end-of-options", sha, "--", pathName,
+		"ls-tree", "-z", "-l", "--full-tree", "--end-of-options", sha, "--", literalRepoBrowserPathspec(pathName),
 	)
 	if err != nil {
 		return repoBrowserTreeEntryLookup{}, fmt.Errorf("lookup repo browser path %s: %w", pathName, err)
@@ -414,7 +424,9 @@ func (m *Manager) RepoBrowserLastChanged(
 		sha,
 		"--",
 	}
-	args = append(args, cleanPaths...)
+	for _, cleanPath := range cleanPaths {
+		args = append(args, literalRepoBrowserPathspec(cleanPath))
+	}
 	out, err := m.git(ctx, dir, args...)
 	if err != nil {
 		return nil, fmt.Errorf("repo browser last changed: %w", err)
@@ -473,7 +485,7 @@ func (m *Manager) RepoBrowserFileHistory(
 		"--end-of-options",
 		sha,
 		"--",
-		cleanPath,
+		literalRepoBrowserPathspec(cleanPath),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("repo browser file history %s: %w", cleanPath, err)
@@ -536,7 +548,7 @@ func (m *Manager) repoBrowserCommitTouchesPath(
 		"--end-of-options",
 		rootSHA,
 		"--",
-		pathName,
+		literalRepoBrowserPathspec(pathName),
 	)
 	if err != nil {
 		return false, fmt.Errorf("repo browser commit scope %s: %w", pathName, err)
@@ -656,6 +668,10 @@ func cleanRepoBrowserPath(pathName string) (string, error) {
 		return "", ErrUnsafePath
 	}
 	return cleaned, nil
+}
+
+func literalRepoBrowserPathspec(pathName string) string {
+	return ":(literal)" + pathName
 }
 
 func mediaTypeForRepoBrowserPath(pathName string) string {

--- a/internal/gitclone/repo_browser.go
+++ b/internal/gitclone/repo_browser.go
@@ -25,9 +25,10 @@ const (
 )
 
 var (
-	ErrUnsafePath    = errors.New("unsafe repo browser path")
-	ErrTooManyPaths  = errors.New("too many repo browser paths")
-	ErrTooLargeAsset = errors.New("repo browser asset too large")
+	ErrUnsafePath       = errors.New("unsafe repo browser path")
+	ErrTooManyPaths     = errors.New("too many repo browser paths")
+	ErrTooLargeAsset    = errors.New("repo browser asset too large")
+	ErrUnsupportedAsset = errors.New("unsupported repo browser asset type")
 )
 
 type RepoBrowserRefType string
@@ -47,9 +48,11 @@ type RepoBrowserRepoRef struct {
 }
 
 type RepoBrowserRef struct {
-	Type RepoBrowserRefType `json:"type"`
-	Name string             `json:"name"`
-	SHA  string             `json:"sha"`
+	Type         RepoBrowserRefType `json:"type"`
+	Name         string             `json:"name"`
+	SHA          string             `json:"sha"`
+	RequestedSHA string             `json:"requested_sha,omitempty"`
+	Stale        bool               `json:"stale"`
 }
 
 type RepoBrowserTreeEntry struct {
@@ -221,6 +224,9 @@ func (m *Manager) ReadRepoBrowserAsset(
 	}
 	if blob.TooLarge {
 		return RepoBrowserBlob{}, fmt.Errorf("%w: %w", ErrTooLargeAsset, ErrTooLarge)
+	}
+	if !repoBrowserAssetMediaTypeAllowed(blob.MediaType) {
+		return RepoBrowserBlob{}, fmt.Errorf("%w: %s", ErrUnsupportedAsset, blob.MediaType)
 	}
 	return blob, nil
 }
@@ -453,6 +459,24 @@ func (m *Manager) RepoBrowserCommitDetail(
 	return commits[0], nil
 }
 
+func (m *Manager) ResolveRepoBrowserRef(
+	ctx context.Context,
+	repo RepoBrowserRepoRef,
+	ref RepoBrowserRef,
+) (RepoBrowserRef, error) {
+	_, sha, stale, err := m.resolveRepoBrowserRef(ctx, repo, ref)
+	if err != nil {
+		return RepoBrowserRef{}, err
+	}
+	resolved := ref
+	resolved.SHA = sha
+	resolved.Stale = stale
+	if stale {
+		resolved.RequestedSHA = strings.TrimSpace(ref.SHA)
+	}
+	return resolved, nil
+}
+
 const (
 	repoBrowserCommitMarker = "commit:"
 	repoBrowserCommitFormat = "%H%x1f%an%x1f%ae%x1f%aI%x1f%s"
@@ -552,6 +576,19 @@ func mediaTypeForRepoBrowserPath(pathName string) string {
 		return typ
 	}
 	return ""
+}
+
+func repoBrowserAssetMediaTypeAllowed(mediaType string) bool {
+	typ, _, err := mime.ParseMediaType(mediaType)
+	if err != nil {
+		typ = mediaType
+	}
+	switch strings.ToLower(strings.TrimSpace(typ)) {
+	case "image/avif", "image/bmp", "image/gif", "image/jpeg", "image/png", "image/webp":
+		return true
+	default:
+		return false
+	}
 }
 
 func isFullHexSHA(sha string) bool {

--- a/internal/gitclone/repo_browser.go
+++ b/internal/gitclone/repo_browser.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"mime"
 	"net/http"
 	"path"
@@ -15,12 +16,15 @@ import (
 	"strings"
 	"time"
 	"unicode/utf8"
+
+	"go.kenn.io/middleman/internal/procutil"
 )
 
 const (
 	RepoBrowserTreeEntryLimit      = 20000
 	RepoBrowserBlobSizeLimit       = 1 << 20
 	RepoBrowserLastChangedBatchMax = 250
+	RepoBrowserLastChangedLogLimit = 500
 	RepoBrowserHistoryLimit        = 50
 )
 
@@ -155,47 +159,96 @@ func (m *Manager) ListRepoBrowserTree(
 	if err != nil {
 		return nil, false, err
 	}
-	out, err := m.git(ctx, dir,
+	return m.listRepoBrowserTreeEntries(ctx, dir, sha)
+}
+
+func (m *Manager) listRepoBrowserTreeEntries(
+	ctx context.Context,
+	dir string,
+	sha string,
+) ([]RepoBrowserTreeEntry, bool, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	cmd := newGitRunner().Command(ctx, dir,
 		"ls-tree", "-r", "-z", "-l", "--full-tree", "--end-of-options", sha,
 	)
+	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return nil, false, fmt.Errorf("list repo browser tree: %w", err)
+		return nil, false, fmt.Errorf("list repo browser tree pipe: %w", err)
 	}
-	entries := parseRepoBrowserTree(out)
-	truncated := len(entries) > RepoBrowserTreeEntryLimit
-	if truncated {
-		entries = entries[:RepoBrowserTreeEntryLimit]
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	release, err := procutil.TryAcquire(ctx, "git subprocess capacity")
+	if err != nil {
+		return nil, false, err
 	}
+	defer release()
+
+	if err := cmd.Start(); err != nil {
+		return nil, false, fmt.Errorf("list repo browser tree start: %w", err)
+	}
+
+	entries, truncated, readErr := readRepoBrowserTreeEntries(stdout, cancel)
+	waitErr := cmd.Wait()
+	if readErr != nil {
+		return nil, false, fmt.Errorf("list repo browser tree read: %w", readErr)
+	}
+	if waitErr != nil && !truncated {
+		return nil, false, fmt.Errorf("list repo browser tree: %w", wrapGitError(waitErr, stderr.Bytes()))
+	}
+	SortRepoBrowserTree(entries)
 	return entries, truncated, nil
 }
 
-func parseRepoBrowserTree(out []byte) []RepoBrowserTreeEntry {
-	records := bytes.Split(out, []byte{0})
-	entries := make([]RepoBrowserTreeEntry, 0, len(records))
-	for _, record := range records {
-		if len(record) == 0 {
-			continue
+func readRepoBrowserTreeEntries(
+	r io.Reader,
+	cancel context.CancelFunc,
+) ([]RepoBrowserTreeEntry, bool, error) {
+	reader := bufio.NewReader(r)
+	entries := make([]RepoBrowserTreeEntry, 0, RepoBrowserTreeEntryLimit)
+	for {
+		record, err := reader.ReadBytes(0)
+		if len(record) > 0 {
+			record = bytes.TrimSuffix(record, []byte{0})
+			if entry, ok := parseRepoBrowserTreeRecord(record); ok {
+				if len(entries) == RepoBrowserTreeEntryLimit {
+					cancel()
+					return entries, true, nil
+				}
+				entries = append(entries, entry)
+			}
 		}
-		header, pathBytes, ok := bytes.Cut(record, []byte{'\t'})
-		if !ok {
-			continue
+		if errors.Is(err, io.EOF) {
+			return entries, false, nil
 		}
-		fields := strings.Fields(string(header))
-		if len(fields) < 4 {
-			continue
+		if err != nil {
+			return nil, false, err
 		}
-		size := int64(0)
-		if fields[3] != "-" {
-			size, _ = strconv.ParseInt(fields[3], 10, 64)
-		}
-		entries = append(entries, RepoBrowserTreeEntry{
-			Path: string(pathBytes),
-			Type: fields[1],
-			Size: size,
-		})
 	}
-	SortRepoBrowserTree(entries)
-	return entries
+}
+
+func parseRepoBrowserTreeRecord(record []byte) (RepoBrowserTreeEntry, bool) {
+	if len(record) == 0 {
+		return RepoBrowserTreeEntry{}, false
+	}
+	header, pathBytes, ok := bytes.Cut(record, []byte{'\t'})
+	if !ok {
+		return RepoBrowserTreeEntry{}, false
+	}
+	fields := strings.Fields(string(header))
+	if len(fields) < 4 {
+		return RepoBrowserTreeEntry{}, false
+	}
+	size := int64(0)
+	if fields[3] != "-" {
+		size, _ = strconv.ParseInt(fields[3], 10, 64)
+	}
+	return RepoBrowserTreeEntry{
+		Path: string(pathBytes),
+		Type: fields[1],
+		Size: size,
+	}, true
 }
 
 func SortRepoBrowserTree(entries []RepoBrowserTreeEntry) {
@@ -354,6 +407,7 @@ func (m *Manager) RepoBrowserLastChanged(
 	}
 	args := []string{
 		"log",
+		"--max-count=" + strconv.Itoa(RepoBrowserLastChangedLogLimit),
 		"--format=" + repoBrowserCommitMarker + repoBrowserCommitFormat,
 		"--name-only",
 		"--end-of-options",

--- a/internal/gitclone/repo_browser.go
+++ b/internal/gitclone/repo_browser.go
@@ -585,19 +585,19 @@ func (m *Manager) RepoBrowserCommitDetail(
 		return RepoBrowserCommit{}, fmt.Errorf("%w: %s", ErrCommitOutOfScope, sha)
 	}
 	out, err := m.git(ctx, dir,
-		"show", "-s", "--format="+repoBrowserCommitFormat, "--end-of-options", commitSHA,
+		"show", "-s", "--format="+repoBrowserCommitDetailFormat, "--end-of-options", commitSHA,
 	)
 	if err != nil {
 		return RepoBrowserCommit{}, fmt.Errorf("repo browser commit detail %s: %w", sha, err)
 	}
-	commits, err := parseRepoBrowserCommitLines(out)
+	commit, err := parseRepoBrowserCommitDetail(out)
 	if err != nil {
 		return RepoBrowserCommit{}, err
 	}
-	if len(commits) == 0 {
+	if commit.SHA == "" {
 		return RepoBrowserCommit{}, fmt.Errorf("%w: %s", ErrNotFound, sha)
 	}
-	return commits[0], nil
+	return commit, nil
 }
 
 func (m *Manager) repoBrowserCommitTouchesPath(
@@ -656,6 +656,7 @@ func (m *Manager) ResolveRepoBrowserRef(
 
 const (
 	repoBrowserCommitFormat            = "%H%x1f%an%x1f%ae%x1f%aI%x1f%s"
+	repoBrowserCommitDetailFormat      = "%H%x00%an%x00%ae%x00%aI%x00%s%x00%b"
 	repoBrowserLastChangedCommitFormat = "%x00" + repoBrowserCommitFormat
 )
 
@@ -692,6 +693,29 @@ func parseRepoBrowserCommitLine(line string) (RepoBrowserCommit, error) {
 		AuthorEmail: truncateCommitText(parts[2], commitIdentityMaxBytes),
 		AuthoredAt:  authoredAt.UTC(),
 		Subject:     truncateCommitText(parts[4], commitMessageMaxBytes),
+	}, nil
+}
+
+func parseRepoBrowserCommitDetail(out []byte) (RepoBrowserCommit, error) {
+	raw := strings.TrimSuffix(string(out), "\n")
+	if raw == "" {
+		return RepoBrowserCommit{}, nil
+	}
+	parts := strings.SplitN(raw, "\x00", 6)
+	if len(parts) != 6 {
+		return RepoBrowserCommit{}, fmt.Errorf("unexpected repo browser commit detail: %q", raw)
+	}
+	authoredAt, err := time.Parse(time.RFC3339, parts[3])
+	if err != nil {
+		return RepoBrowserCommit{}, fmt.Errorf("parse repo browser commit time %q: %w", parts[3], err)
+	}
+	return RepoBrowserCommit{
+		SHA:         parts[0],
+		AuthorName:  truncateCommitText(parts[1], commitIdentityMaxBytes),
+		AuthorEmail: truncateCommitText(parts[2], commitIdentityMaxBytes),
+		AuthoredAt:  authoredAt.UTC(),
+		Subject:     truncateCommitText(parts[4], commitMessageMaxBytes),
+		Body:        truncateCommitText(strings.TrimSuffix(parts[5], "\n"), commitMessageMaxBytes),
 	}, nil
 }
 

--- a/internal/gitclone/repo_browser.go
+++ b/internal/gitclone/repo_browser.go
@@ -99,6 +99,8 @@ func (m *Manager) ListRepoBrowserRefs(
 	out, err := m.git(ctx, dir,
 		"for-each-ref",
 		"--count="+strconv.Itoa(RepoBrowserRefLimit+1),
+		"--exclude=refs/remotes/origin/HEAD",
+		"--sort=refname",
 		"--format=%(refname)%00%(objectname)%00%(*objectname)",
 		"refs/remotes/origin",
 		"refs/tags",
@@ -431,7 +433,23 @@ func (m *Manager) RepoBrowserLastChanged(
 	if err != nil {
 		return nil, fmt.Errorf("repo browser last changed: %w", err)
 	}
-	return parseRepoBrowserLastChanged(out, seen)
+	changed, err := parseRepoBrowserLastChanged(out, seen)
+	if err != nil {
+		return nil, err
+	}
+	for _, cleanPath := range cleanPaths {
+		if _, ok := changed[cleanPath]; ok {
+			continue
+		}
+		commit, ok, err := m.repoBrowserLastChangedForPath(ctx, dir, sha, cleanPath)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			changed[cleanPath] = commit
+		}
+	}
+	return changed, nil
 }
 
 func parseRepoBrowserLastChanged(out []byte, wanted map[string]bool) (map[string]RepoBrowserCommit, error) {
@@ -462,6 +480,34 @@ func parseRepoBrowserLastChanged(out []byte, wanted map[string]bool) (map[string
 		}
 	}
 	return changed, scanner.Err()
+}
+
+func (m *Manager) repoBrowserLastChangedForPath(
+	ctx context.Context,
+	dir string,
+	sha string,
+	pathName string,
+) (RepoBrowserCommit, bool, error) {
+	out, err := m.git(ctx, dir,
+		"log",
+		"--max-count=1",
+		"--format="+repoBrowserCommitFormat,
+		"--end-of-options",
+		sha,
+		"--",
+		literalRepoBrowserPathspec(pathName),
+	)
+	if err != nil {
+		return RepoBrowserCommit{}, false, fmt.Errorf("repo browser last changed %s: %w", pathName, err)
+	}
+	commits, err := parseRepoBrowserCommitLines(out)
+	if err != nil {
+		return RepoBrowserCommit{}, false, err
+	}
+	if len(commits) == 0 {
+		return RepoBrowserCommit{}, false, nil
+	}
+	return commits[0], true, nil
 }
 
 func (m *Manager) RepoBrowserFileHistory(

--- a/internal/gitclone/repo_browser.go
+++ b/internal/gitclone/repo_browser.go
@@ -720,14 +720,34 @@ func (m *Manager) repoBrowserClonePath(repo RepoBrowserRepoRef) (string, error) 
 }
 
 func (m *Manager) EnsureRepoBrowserClone(ctx context.Context, repo RepoBrowserRepoRef) error {
-	return m.EnsureCloneInNamespace(
+	if err := m.EnsureCloneInNamespace(
 		ctx,
 		repoBrowserCloneNamespace(repo),
 		repo.Host,
 		repo.Owner,
 		repo.Name,
 		repo.RemoteURL,
-	)
+	); err != nil {
+		return err
+	}
+	dir, err := m.repoBrowserClonePath(repo)
+	if err != nil {
+		return err
+	}
+	return m.fetchRepoBrowserTags(ctx, repo.Host, dir)
+}
+
+func (m *Manager) fetchRepoBrowserTags(ctx context.Context, host, clonePath string) error {
+	// Repo browser refs need current tag targets, but general clone refreshes
+	// deliberately fetch with --no-tags so sync/diff hot paths are not coupled
+	// to tag namespace size or moved-tag failures.
+	_, err := retryTransient(ctx, "git fetch repo browser tags", func() ([]byte, error) {
+		return m.gitNetworked(ctx, host, clonePath, nil, "fetch", "origin", "+refs/tags/*:refs/tags/*")
+	})
+	if err != nil {
+		return fmt.Errorf("git fetch repo browser tags: %w", err)
+	}
+	return nil
 }
 
 func repoBrowserCloneNamespace(repo RepoBrowserRepoRef) string {

--- a/internal/gitclone/repo_browser.go
+++ b/internal/gitclone/repo_browser.go
@@ -603,25 +603,32 @@ func (m *Manager) repoBrowserCommitTouchesPath(
 	pathName string,
 	sha string,
 ) (bool, error) {
+	if _, err := m.git(ctx, dir, "merge-base", "--is-ancestor", sha, rootSHA); err != nil {
+		if code, ok := gitExitCode(err); ok && code == 1 {
+			return false, nil
+		}
+		return false, fmt.Errorf("repo browser commit ancestry %s: %w", sha, err)
+	}
 	out, err := m.git(ctx, dir,
-		"log",
-		"--max-count="+strconv.Itoa(RepoBrowserHistoryLimit),
-		"--format=%H",
-		"--end-of-options",
-		rootSHA,
+		"diff-tree",
+		"--no-commit-id",
+		"--name-only",
+		"-r",
+		"-z",
+		"--root",
+		sha,
 		"--",
 		literalRepoBrowserPathspec(pathName),
 	)
 	if err != nil {
 		return false, fmt.Errorf("repo browser commit scope %s: %w", pathName, err)
 	}
-	scanner := bufio.NewScanner(bytes.NewReader(out))
-	for scanner.Scan() {
-		if scanner.Text() == sha {
+	for entry := range bytes.SplitSeq(out, []byte{0}) {
+		if string(entry) == pathName {
 			return true, nil
 		}
 	}
-	return false, scanner.Err()
+	return false, nil
 }
 
 func (m *Manager) ResolveRepoBrowserRef(

--- a/internal/gitclone/repo_browser.go
+++ b/internal/gitclone/repo_browser.go
@@ -9,8 +9,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"mime"
 	"net/http"
+	"os"
 	"path"
 	"path/filepath"
 	"sort"
@@ -720,6 +722,14 @@ func (m *Manager) repoBrowserClonePath(repo RepoBrowserRepoRef) (string, error) 
 }
 
 func (m *Manager) EnsureRepoBrowserClone(ctx context.Context, repo RepoBrowserRepoRef) error {
+	if err := m.ensureRepoBrowserCloneLocal(ctx, repo); err != nil {
+		return err
+	}
+	m.registerRepoBrowserRepo(repo)
+	return nil
+}
+
+func (m *Manager) RefreshRepoBrowserClone(ctx context.Context, repo RepoBrowserRepoRef) error {
 	if err := m.EnsureCloneInNamespace(
 		ctx,
 		repoBrowserCloneNamespace(repo),
@@ -734,7 +744,65 @@ func (m *Manager) EnsureRepoBrowserClone(ctx context.Context, repo RepoBrowserRe
 	if err != nil {
 		return err
 	}
+	m.registerRepoBrowserRepo(repo)
 	return m.fetchRepoBrowserTags(ctx, repo.Host, dir)
+}
+
+func (m *Manager) RefreshRepoBrowserClones(ctx context.Context) {
+	for _, repo := range m.repoBrowserReposSnapshot() {
+		if err := ctx.Err(); err != nil {
+			return
+		}
+		if err := m.RefreshRepoBrowserClone(ctx, repo); err != nil {
+			slog.Warn("repo browser clone refresh failed",
+				"provider", repo.Provider,
+				"host", repo.Host,
+				"repo", repo.RepoPath,
+				"err", err)
+		}
+	}
+}
+
+func (m *Manager) ensureRepoBrowserCloneLocal(ctx context.Context, repo RepoBrowserRepoRef) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	namespace := repoBrowserCloneNamespace(repo)
+	if err := validateRemoteURLIdentity(repo.Host, repo.Owner, repo.Name, repo.RemoteURL); err != nil {
+		return err
+	}
+	dir, err := m.ClonePathInNamespace(namespace, repo.Host, repo.Owner, repo.Name)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(filepath.Join(dir, "HEAD")); os.IsNotExist(err) {
+		return m.EnsureCloneInNamespace(ctx, namespace, repo.Host, repo.Owner, repo.Name, repo.RemoteURL)
+	} else if err != nil {
+		return err
+	}
+	if out, err := m.git(ctx, dir, "config", "--get", "remote.origin.url"); err == nil {
+		if err := validateRemoteURLIdentity(repo.Host, repo.Owner, repo.Name, strings.TrimSpace(string(out))); err != nil {
+			return err
+		}
+	}
+	m.ensureRefspecs(ctx, dir)
+	return nil
+}
+
+func (m *Manager) registerRepoBrowserRepo(repo RepoBrowserRepoRef) {
+	m.repoBrowserMu.Lock()
+	defer m.repoBrowserMu.Unlock()
+	m.repoBrowserRepos[repoBrowserCloneNamespace(repo)] = repo
+}
+
+func (m *Manager) repoBrowserReposSnapshot() []RepoBrowserRepoRef {
+	m.repoBrowserMu.Lock()
+	defer m.repoBrowserMu.Unlock()
+	repos := make([]RepoBrowserRepoRef, 0, len(m.repoBrowserRepos))
+	for _, repo := range m.repoBrowserRepos {
+		repos = append(repos, repo)
+	}
+	return repos
 }
 
 func (m *Manager) fetchRepoBrowserTags(ctx context.Context, host, clonePath string) error {

--- a/internal/gitclone/repo_browser_test.go
+++ b/internal/gitclone/repo_browser_test.go
@@ -2,8 +2,10 @@ package gitclone
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -37,7 +39,7 @@ func TestRepoBrowserListRefsDisambiguatesBranchAndTag(t *testing.T) {
 	assert.Contains(refs, RepoBrowserRef{Type: RepoBrowserRefTag, Name: "release", SHA: mainSHA})
 }
 
-func TestRepoBrowserFetchPrunesDeletedTags(t *testing.T) {
+func TestRepoBrowserFetchDoesNotPruneTagsOnHotPath(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	mgr, repo, work := setupRepoBrowserTestRepo(t)
@@ -56,7 +58,27 @@ func TestRepoBrowserFetchPrunesDeletedTags(t *testing.T) {
 
 	refs, _, err = mgr.ListRepoBrowserRefs(t.Context(), repo, "main")
 	require.NoError(err)
-	assert.NotContains(refs, RepoBrowserRef{Type: RepoBrowserRefTag, Name: "v1.0.0", SHA: mainSHA})
+	assert.Contains(refs, RepoBrowserRef{Type: RepoBrowserRefTag, Name: "v1.0.0", SHA: mainSHA})
+}
+
+func TestRepoBrowserListTreeReaderStopsAtEntryLimit(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	var input strings.Builder
+	for i := range RepoBrowserTreeEntryLimit + 1 {
+		_, err := fmt.Fprintf(&input, "100644 blob %040d %d\tfile-%05d.txt\x00", i, i, i)
+		require.NoError(err)
+	}
+	canceled := false
+
+	entries, truncated, err := readRepoBrowserTreeEntries(strings.NewReader(input.String()), func() {
+		canceled = true
+	})
+
+	require.NoError(err)
+	assert.True(truncated)
+	assert.True(canceled)
+	assert.Len(entries, RepoBrowserTreeEntryLimit)
 }
 
 func TestRepoBrowserListTreeIncludesTrackedDotfiles(t *testing.T) {

--- a/internal/gitclone/repo_browser_test.go
+++ b/internal/gitclone/repo_browser_test.go
@@ -273,6 +273,21 @@ func TestRepoBrowserFileHistoryIsBoundedAtSelectedSHA(t *testing.T) {
 	}
 }
 
+func TestRepoBrowserFileHistoryRequiresSelectedTreePath(t *testing.T) {
+	require := require.New(t)
+	mgr, repo, work := setupRepoBrowserTestRepo(t)
+
+	require.NoError(os.WriteFile(filepath.Join(work, "later.md"), []byte("later\n"), 0o644))
+	commitTestRun(t, work, "git", "add", ".")
+	commitTestRun(t, work, "git", "commit", "-m", "later file")
+	commitTestRun(t, work, "git", "push", "origin", "main")
+	require.NoError(mgr.EnsureRepoBrowserClone(t.Context(), repo))
+	ref := RepoBrowserRef{Type: RepoBrowserRefCommit, SHA: gitSHA(t, work, "HEAD~1")}
+
+	_, err := mgr.RepoBrowserFileHistory(t.Context(), repo, ref, "later.md")
+	require.ErrorIs(err, ErrNotFound)
+}
+
 func TestRepoBrowserCommitDetailRequiresSelectedFileHistory(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/gitclone/repo_browser_test.go
+++ b/internal/gitclone/repo_browser_test.go
@@ -150,6 +150,28 @@ func TestRepoBrowserFileHistoryIsBoundedAtSelectedSHA(t *testing.T) {
 	}
 }
 
+func TestRepoBrowserCommitDetailRequiresSelectedFileHistory(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	mgr, repo, work := setupRepoBrowserTestRepo(t)
+
+	require.NoError(os.WriteFile(filepath.Join(work, "other.txt"), []byte("other\n"), 0o644))
+	commitTestRun(t, work, "git", "add", ".")
+	commitTestRun(t, work, "git", "commit", "-m", "other file")
+	otherSHA := gitSHA(t, work, "HEAD")
+	commitTestRun(t, work, "git", "push", "origin", "main")
+	require.NoError(mgr.EnsureClone(t.Context(), repo.Host, repo.Owner, repo.Name, repo.RemoteURL))
+	ref := repoBrowserMainRef(t, mgr, repo)
+
+	_, err := mgr.RepoBrowserCommitDetail(t.Context(), repo, ref, "README.md", otherSHA)
+	require.ErrorIs(err, ErrCommitOutOfScope)
+
+	commit, err := mgr.RepoBrowserCommitDetail(t.Context(), repo, ref, "other.txt", otherSHA)
+	require.NoError(err)
+	assert.Equal(otherSHA, commit.SHA)
+	assert.Equal("other file", commit.Subject)
+}
+
 func TestRepoBrowserMarkdownAssetRejectsUnsafeAndOversizedPaths(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/gitclone/repo_browser_test.go
+++ b/internal/gitclone/repo_browser_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -219,6 +220,27 @@ func TestRepoBrowserLastChangedFallsBackPastBatchLogLimit(t *testing.T) {
 	require.NoError(err)
 	assert.Equal(readmeSHA, changed["README.md"].SHA)
 	assert.Equal(gitSHA(t, work, "HEAD"), changed["churn.txt"].SHA)
+}
+
+func TestRepoBrowserLastChangedHandlesCommitPrefixedPathsAndUTCTimes(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	mgr, repo, work := setupRepoBrowserTestRepo(t)
+
+	pathName := "commit:notes.md"
+	require.NoError(os.WriteFile(filepath.Join(work, pathName), []byte("notes\n"), 0o644))
+	commitTestRun(t, work, "git", "add", ".")
+	commitTestRun(t, work, "git", "commit", "--date=2026-06-01T12:34:56-07:00", "-m", "commit-prefixed path")
+	commitTestRun(t, work, "git", "push", "origin", "main")
+	require.NoError(mgr.EnsureRepoBrowserClone(t.Context(), repo))
+	ref := repoBrowserMainRef(t, mgr, repo)
+
+	changed, err := mgr.RepoBrowserLastChanged(t.Context(), repo, ref, []string{pathName})
+	require.NoError(err)
+
+	require.Contains(changed, pathName)
+	assert.Equal(gitSHA(t, work, "HEAD"), changed[pathName].SHA)
+	assert.Equal(time.Date(2026, 6, 1, 19, 34, 56, 0, time.UTC), changed[pathName].AuthoredAt)
 }
 
 func TestRepoBrowserFileHistoryIsBoundedAtSelectedSHA(t *testing.T) {

--- a/internal/gitclone/repo_browser_test.go
+++ b/internal/gitclone/repo_browser_test.go
@@ -29,14 +29,31 @@ func TestRepoBrowserListRefsDisambiguatesBranchAndTag(t *testing.T) {
 	commitTestRun(t, work, "git", "push", "origin", "refs/tags/release")
 	require.NoError(mgr.EnsureClone(t.Context(), repo.Host, repo.Owner, repo.Name, repo.RemoteURL))
 
-	refs, defaultRef, err := mgr.ListRepoBrowserRefs(t.Context(), repo, "main")
+	refs, defaultRef, truncated, err := mgr.ListRepoBrowserRefs(t.Context(), repo, "main")
 	require.NoError(err)
 
 	assert.Equal(RepoBrowserRefBranch, defaultRef.Type)
 	assert.Equal("main", defaultRef.Name)
 	assert.Equal(mainSHA, defaultRef.SHA)
+	assert.False(truncated)
 	assert.Contains(refs, RepoBrowserRef{Type: RepoBrowserRefBranch, Name: "release", SHA: branchSHA})
 	assert.Contains(refs, RepoBrowserRef{Type: RepoBrowserRefTag, Name: "release", SHA: mainSHA})
+}
+
+func TestRepoBrowserListRefsCapsLargeRefSets(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	refs := make([]RepoBrowserRef, RepoBrowserRefLimit+1)
+	for i := range refs {
+		refs[i] = RepoBrowserRef{Type: RepoBrowserRefBranch, Name: fmt.Sprintf("branch-%04d", i), SHA: fmt.Sprintf("%040d", i)}
+	}
+
+	capped, truncated := capRepoBrowserRefs(refs)
+
+	assert.True(truncated)
+	require.Len(capped, RepoBrowserRefLimit)
+	assert.Equal("branch-0000", capped[0].Name)
+	assert.Equal(fmt.Sprintf("branch-%04d", RepoBrowserRefLimit-1), capped[len(capped)-1].Name)
 }
 
 func TestRepoBrowserFetchDoesNotPruneTagsOnHotPath(t *testing.T) {
@@ -48,16 +65,18 @@ func TestRepoBrowserFetchDoesNotPruneTagsOnHotPath(t *testing.T) {
 	commitTestRun(t, work, "git", "tag", "v1.0.0", mainSHA)
 	commitTestRun(t, work, "git", "push", "origin", "refs/tags/v1.0.0")
 	require.NoError(mgr.EnsureClone(t.Context(), repo.Host, repo.Owner, repo.Name, repo.RemoteURL))
-	refs, _, err := mgr.ListRepoBrowserRefs(t.Context(), repo, "main")
+	refs, _, truncated, err := mgr.ListRepoBrowserRefs(t.Context(), repo, "main")
 	require.NoError(err)
+	assert.False(truncated)
 	assert.Contains(refs, RepoBrowserRef{Type: RepoBrowserRefTag, Name: "v1.0.0", SHA: mainSHA})
 
 	commitTestRun(t, work, "git", "tag", "-d", "v1.0.0")
 	commitTestRun(t, work, "git", "push", "origin", ":refs/tags/v1.0.0")
 	require.NoError(mgr.EnsureClone(t.Context(), repo.Host, repo.Owner, repo.Name, repo.RemoteURL))
 
-	refs, _, err = mgr.ListRepoBrowserRefs(t.Context(), repo, "main")
+	refs, _, truncated, err = mgr.ListRepoBrowserRefs(t.Context(), repo, "main")
 	require.NoError(err)
+	assert.False(truncated)
 	assert.Contains(refs, RepoBrowserRef{Type: RepoBrowserRefTag, Name: "v1.0.0", SHA: mainSHA})
 }
 
@@ -192,6 +211,37 @@ func TestRepoBrowserCommitDetailRequiresSelectedFileHistory(t *testing.T) {
 	require.NoError(err)
 	assert.Equal(otherSHA, commit.SHA)
 	assert.Equal("other file", commit.Subject)
+}
+
+func TestRepoBrowserHistoryTreatsPathspecMagicAsLiteral(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	mgr, repo, work := setupRepoBrowserTestRepo(t)
+
+	magicPath := ":(glob)*.md"
+	require.NoError(os.WriteFile(filepath.Join(work, magicPath), []byte("literal\n"), 0o644))
+	commitTestRun(t, work, "git", "add", ".")
+	commitTestRun(t, work, "git", "commit", "-m", "literal pathspec file")
+	literalSHA := gitSHA(t, work, "HEAD")
+
+	require.NoError(os.WriteFile(filepath.Join(work, "README.md"), []byte("# Widgets\n\nUpdated\n"), 0o644))
+	commitTestRun(t, work, "git", "add", ".")
+	commitTestRun(t, work, "git", "commit", "-m", "readme update")
+	readmeSHA := gitSHA(t, work, "HEAD")
+	commitTestRun(t, work, "git", "push", "origin", "main")
+	require.NoError(mgr.EnsureClone(t.Context(), repo.Host, repo.Owner, repo.Name, repo.RemoteURL))
+	ref := repoBrowserMainRef(t, mgr, repo)
+
+	history, err := mgr.RepoBrowserFileHistory(t.Context(), repo, ref, magicPath)
+	require.NoError(err)
+	require.NotEmpty(history)
+	assert.Equal(literalSHA, history[0].SHA)
+	for _, commit := range history {
+		assert.NotEqual(readmeSHA, commit.SHA)
+	}
+
+	_, err = mgr.RepoBrowserCommitDetail(t.Context(), repo, ref, magicPath, readmeSHA)
+	require.ErrorIs(err, ErrCommitOutOfScope)
 }
 
 func TestRepoBrowserMarkdownAssetRejectsUnsafeAndOversizedPaths(t *testing.T) {

--- a/internal/gitclone/repo_browser_test.go
+++ b/internal/gitclone/repo_browser_test.go
@@ -1,6 +1,7 @@
 package gitclone
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -112,6 +113,22 @@ func TestRefreshRepoBrowserClonesUsesSeededExistingClones(t *testing.T) {
 	})
 	require.NoError(err)
 	assert.Equal(updatedSHA, resolved.SHA)
+}
+
+func TestRepoBrowserScheduledRefreshContextStaysCancelable(t *testing.T) {
+	require := require.New(t)
+
+	parent, cancel := context.WithCancel(t.Context())
+	opCtx, opCancel := repoBrowserRefreshOperationContext(parent, false)
+	cancel()
+	defer opCancel()
+	require.ErrorIs(opCtx.Err(), context.Canceled)
+
+	detachedParent, detachedCancel := context.WithCancel(t.Context())
+	detachedCtx, detachedOpCancel := repoBrowserRefreshOperationContext(detachedParent, true)
+	detachedCancel()
+	defer detachedOpCancel()
+	require.NoError(detachedCtx.Err())
 }
 
 func TestRepoBrowserRefreshFetchesTagsWithoutPruning(t *testing.T) {

--- a/internal/gitclone/repo_browser_test.go
+++ b/internal/gitclone/repo_browser_test.go
@@ -78,6 +78,16 @@ func TestRepoBrowserFetchDoesNotPruneTagsOnHotPath(t *testing.T) {
 	require.NoError(err)
 	assert.False(truncated)
 	assert.Contains(refs, RepoBrowserRef{Type: RepoBrowserRefTag, Name: "v1.0.0", SHA: mainSHA})
+
+	commitTestRun(t, work, "git", "tag", "v1.0.1", mainSHA)
+	commitTestRun(t, work, "git", "push", "origin", "refs/tags/v1.0.1")
+	require.NoError(mgr.EnsureClone(t.Context(), repo.Host, repo.Owner, repo.Name, repo.RemoteURL))
+
+	refs, _, truncated, err = mgr.ListRepoBrowserRefs(t.Context(), repo, "main")
+	require.NoError(err)
+	assert.False(truncated)
+	assert.Contains(refs, RepoBrowserRef{Type: RepoBrowserRefTag, Name: "v1.0.0", SHA: mainSHA})
+	assert.Contains(refs, RepoBrowserRef{Type: RepoBrowserRefTag, Name: "v1.0.1", SHA: mainSHA})
 }
 
 func TestRepoBrowserListTreeReaderStopsAtEntryLimit(t *testing.T) {
@@ -161,6 +171,28 @@ func TestRepoBrowserLastChangedBatchCapsPaths(t *testing.T) {
 	assert.ErrorIs(err, ErrTooManyPaths)
 }
 
+func TestRepoBrowserLastChangedFallsBackPastBatchLogLimit(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	mgr, repo, work := setupRepoBrowserTestRepo(t)
+	readmeSHA := gitSHA(t, work, "HEAD")
+
+	for i := range RepoBrowserLastChangedLogLimit + 1 {
+		require.NoError(os.WriteFile(filepath.Join(work, "churn.txt"), fmt.Appendf(nil, "%d\n", i), 0o644))
+		commitTestRun(t, work, "git", "add", ".")
+		commitTestRun(t, work, "git", "commit", "-m", fmt.Sprintf("churn %03d", i))
+	}
+	commitTestRun(t, work, "git", "push", "origin", "main")
+	require.NoError(mgr.EnsureClone(t.Context(), repo.Host, repo.Owner, repo.Name, repo.RemoteURL))
+	ref := repoBrowserMainRef(t, mgr, repo)
+
+	changed, err := mgr.RepoBrowserLastChanged(t.Context(), repo, ref, []string{"README.md", "churn.txt"})
+
+	require.NoError(err)
+	assert.Equal(readmeSHA, changed["README.md"].SHA)
+	assert.Equal(gitSHA(t, work, "HEAD"), changed["churn.txt"].SHA)
+}
+
 func TestRepoBrowserFileHistoryIsBoundedAtSelectedSHA(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -231,6 +263,14 @@ func TestRepoBrowserHistoryTreatsPathspecMagicAsLiteral(t *testing.T) {
 	commitTestRun(t, work, "git", "push", "origin", "main")
 	require.NoError(mgr.EnsureClone(t.Context(), repo.Host, repo.Owner, repo.Name, repo.RemoteURL))
 	ref := repoBrowserMainRef(t, mgr, repo)
+
+	blob, err := mgr.ReadRepoBrowserBlob(t.Context(), repo, ref, magicPath)
+	require.NoError(err)
+	assert.Equal("literal\n", blob.Content)
+
+	changed, err := mgr.RepoBrowserLastChanged(t.Context(), repo, ref, []string{magicPath})
+	require.NoError(err)
+	assert.Equal(literalSHA, changed[magicPath].SHA)
 
 	history, err := mgr.RepoBrowserFileHistory(t.Context(), repo, ref, magicPath)
 	require.NoError(err)

--- a/internal/gitclone/repo_browser_test.go
+++ b/internal/gitclone/repo_browser_test.go
@@ -439,6 +439,31 @@ func TestRepoBrowserCommitDetailAcceptsOlderFileHistory(t *testing.T) {
 	assert.Equal("initial", commit.Subject)
 }
 
+func TestRepoBrowserCommitDetailAcceptsMergeCommitTouchingPath(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	mgr, repo, work := setupRepoBrowserTestRepo(t)
+
+	commitTestRun(t, work, "git", "checkout", "-b", "feature")
+	require.NoError(os.WriteFile(filepath.Join(work, "README.md"), []byte("# Widgets\n\nFeature\n"), 0o644))
+	commitTestRun(t, work, "git", "add", ".")
+	commitTestRun(t, work, "git", "commit", "-m", "feature readme")
+	commitTestRun(t, work, "git", "checkout", "main")
+	require.NoError(os.WriteFile(filepath.Join(work, "main.txt"), []byte("main\n"), 0o644))
+	commitTestRun(t, work, "git", "add", ".")
+	commitTestRun(t, work, "git", "commit", "-m", "main work")
+	commitTestRun(t, work, "git", "merge", "--no-ff", "feature", "-m", "merge feature")
+	mergeSHA := gitSHA(t, work, "HEAD")
+	commitTestRun(t, work, "git", "push", "origin", "main")
+	require.NoError(mgr.RefreshRepoBrowserClone(t.Context(), repo))
+	ref := repoBrowserMainRef(t, mgr, repo)
+
+	commit, err := mgr.RepoBrowserCommitDetail(t.Context(), repo, ref, "README.md", mergeSHA)
+	require.NoError(err)
+	assert.Equal(mergeSHA, commit.SHA)
+	assert.Equal("merge feature", commit.Subject)
+}
+
 func TestRepoBrowserHistoryTreatsPathspecMagicAsLiteral(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/gitclone/repo_browser_test.go
+++ b/internal/gitclone/repo_browser_test.go
@@ -414,6 +414,31 @@ func TestRepoBrowserCommitDetailRequiresSelectedFileHistory(t *testing.T) {
 	assert.Equal("other file", commit.Subject)
 }
 
+func TestRepoBrowserCommitDetailAcceptsOlderFileHistory(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	mgr, repo, work := setupRepoBrowserTestRepo(t)
+	readmeSHA := gitSHA(t, work, "HEAD")
+
+	for i := range RepoBrowserHistoryLimit + 1 {
+		require.NoError(os.WriteFile(
+			filepath.Join(work, fmt.Sprintf("later-%02d.txt", i)),
+			[]byte("later\n"),
+			0o644,
+		))
+		commitTestRun(t, work, "git", "add", ".")
+		commitTestRun(t, work, "git", "commit", "-m", fmt.Sprintf("later %02d", i))
+	}
+	commitTestRun(t, work, "git", "push", "origin", "main")
+	require.NoError(mgr.RefreshRepoBrowserClone(t.Context(), repo))
+	ref := repoBrowserMainRef(t, mgr, repo)
+
+	commit, err := mgr.RepoBrowserCommitDetail(t.Context(), repo, ref, "README.md", readmeSHA)
+	require.NoError(err)
+	assert.Equal(readmeSHA, commit.SHA)
+	assert.Equal("initial", commit.Subject)
+}
+
 func TestRepoBrowserHistoryTreatsPathspecMagicAsLiteral(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/gitclone/repo_browser_test.go
+++ b/internal/gitclone/repo_browser_test.go
@@ -1,0 +1,215 @@
+package gitclone
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRepoBrowserListRefsDisambiguatesBranchAndTag(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	mgr, repo, work := setupRepoBrowserTestRepo(t)
+
+	mainSHA := gitSHA(t, work, "main")
+	commitTestRun(t, work, "git", "checkout", "-b", "release")
+	require.NoError(os.WriteFile(filepath.Join(work, "release.txt"), []byte("release\n"), 0o644))
+	commitTestRun(t, work, "git", "add", ".")
+	commitTestRun(t, work, "git", "commit", "-m", "release branch")
+	branchSHA := gitSHA(t, work, "HEAD")
+	commitTestRun(t, work, "git", "push", "origin", "HEAD:refs/heads/release")
+	commitTestRun(t, work, "git", "checkout", "main")
+	commitTestRun(t, work, "git", "tag", "release", mainSHA)
+	commitTestRun(t, work, "git", "push", "origin", "refs/tags/release")
+	require.NoError(mgr.EnsureClone(t.Context(), repo.Host, repo.Owner, repo.Name, repo.RemoteURL))
+
+	refs, defaultRef, err := mgr.ListRepoBrowserRefs(t.Context(), repo, "main")
+	require.NoError(err)
+
+	assert.Equal(RepoBrowserRefBranch, defaultRef.Type)
+	assert.Equal("main", defaultRef.Name)
+	assert.Equal(mainSHA, defaultRef.SHA)
+	assert.Contains(refs, RepoBrowserRef{Type: RepoBrowserRefBranch, Name: "release", SHA: branchSHA})
+	assert.Contains(refs, RepoBrowserRef{Type: RepoBrowserRefTag, Name: "release", SHA: mainSHA})
+}
+
+func TestRepoBrowserFetchPrunesDeletedTags(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	mgr, repo, work := setupRepoBrowserTestRepo(t)
+	mainSHA := gitSHA(t, work, "main")
+
+	commitTestRun(t, work, "git", "tag", "v1.0.0", mainSHA)
+	commitTestRun(t, work, "git", "push", "origin", "refs/tags/v1.0.0")
+	require.NoError(mgr.EnsureClone(t.Context(), repo.Host, repo.Owner, repo.Name, repo.RemoteURL))
+	refs, _, err := mgr.ListRepoBrowserRefs(t.Context(), repo, "main")
+	require.NoError(err)
+	assert.Contains(refs, RepoBrowserRef{Type: RepoBrowserRefTag, Name: "v1.0.0", SHA: mainSHA})
+
+	commitTestRun(t, work, "git", "tag", "-d", "v1.0.0")
+	commitTestRun(t, work, "git", "push", "origin", ":refs/tags/v1.0.0")
+	require.NoError(mgr.EnsureClone(t.Context(), repo.Host, repo.Owner, repo.Name, repo.RemoteURL))
+
+	refs, _, err = mgr.ListRepoBrowserRefs(t.Context(), repo, "main")
+	require.NoError(err)
+	assert.NotContains(refs, RepoBrowserRef{Type: RepoBrowserRefTag, Name: "v1.0.0", SHA: mainSHA})
+}
+
+func TestRepoBrowserListTreeIncludesTrackedDotfiles(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	mgr, repo, work := setupRepoBrowserTestRepo(t)
+	ref := repoBrowserMainRef(t, mgr, repo)
+
+	entries, truncated, err := mgr.ListRepoBrowserTree(t.Context(), repo, ref)
+	require.NoError(err)
+
+	var paths []string
+	for _, entry := range entries {
+		paths = append(paths, entry.Path)
+	}
+	assert.False(truncated)
+	assert.Contains(paths, ".github/workflows/ci.yml")
+	assert.Contains(paths, ".gitignore")
+	assert.Contains(paths, "README.md")
+	assert.Contains(paths, "src/main.go")
+	assert.NotContains(paths, ".git")
+	assert.Equal(gitSHA(t, work, "main"), ref.SHA)
+}
+
+func TestRepoBrowserReadBlobRejectsTraversalAndLargeFiles(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	mgr, repo, work := setupRepoBrowserTestRepo(t)
+
+	largePath := filepath.Join(work, "large.txt")
+	require.NoError(os.WriteFile(largePath, []byte(string(make([]byte, RepoBrowserBlobSizeLimit+1))), 0o644))
+	commitTestRun(t, work, "git", "add", ".")
+	commitTestRun(t, work, "git", "commit", "-m", "large file")
+	commitTestRun(t, work, "git", "push", "origin", "main")
+	require.NoError(mgr.EnsureClone(t.Context(), repo.Host, repo.Owner, repo.Name, repo.RemoteURL))
+	ref := repoBrowserMainRef(t, mgr, repo)
+
+	_, err := mgr.ReadRepoBrowserBlob(t.Context(), repo, ref, "../secret.txt")
+	require.ErrorIs(err, ErrUnsafePath)
+
+	blob, err := mgr.ReadRepoBrowserBlob(t.Context(), repo, ref, "large.txt")
+	require.NoError(err)
+	assert.True(blob.TooLarge)
+	assert.Equal(int64(RepoBrowserBlobSizeLimit+1), blob.Size)
+	assert.Empty(blob.Content)
+}
+
+func TestRepoBrowserLastChangedBatchCapsPaths(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	mgr, repo, _ := setupRepoBrowserTestRepo(t)
+	ref := repoBrowserMainRef(t, mgr, repo)
+	paths := make([]string, RepoBrowserLastChangedBatchMax+1)
+	for i := range paths {
+		paths[i] = "README.md"
+	}
+
+	_, err := mgr.RepoBrowserLastChanged(t.Context(), repo, ref, paths)
+
+	require.Error(err)
+	assert.ErrorIs(err, ErrTooManyPaths)
+}
+
+func TestRepoBrowserFileHistoryIsBoundedAtSelectedSHA(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	mgr, repo, work := setupRepoBrowserTestRepo(t)
+
+	require.NoError(os.WriteFile(filepath.Join(work, "README.md"), []byte("two\n"), 0o644))
+	commitTestRun(t, work, "git", "add", ".")
+	commitTestRun(t, work, "git", "commit", "-m", "readme two")
+	selectedSHA := gitSHA(t, work, "HEAD")
+	require.NoError(os.WriteFile(filepath.Join(work, "README.md"), []byte("three\n"), 0o644))
+	commitTestRun(t, work, "git", "add", ".")
+	commitTestRun(t, work, "git", "commit", "-m", "readme three")
+	commitTestRun(t, work, "git", "push", "origin", "main")
+	require.NoError(mgr.EnsureClone(t.Context(), repo.Host, repo.Owner, repo.Name, repo.RemoteURL))
+
+	history, err := mgr.RepoBrowserFileHistory(
+		t.Context(),
+		repo,
+		RepoBrowserRef{Type: RepoBrowserRefCommit, SHA: selectedSHA},
+		"README.md",
+	)
+	require.NoError(err)
+	require.NotEmpty(history)
+	assert.Equal(selectedSHA, history[0].SHA)
+	assert.Equal("readme two", history[0].Subject)
+	for _, commit := range history {
+		assert.NotEqual("readme three", commit.Subject)
+	}
+}
+
+func TestRepoBrowserMarkdownAssetRejectsUnsafeAndOversizedPaths(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	mgr, repo, work := setupRepoBrowserTestRepo(t)
+
+	require.NoError(os.WriteFile(filepath.Join(work, "image.svg"), []byte(`<svg xmlns="http://www.w3.org/2000/svg"></svg>`), 0o644))
+	require.NoError(os.WriteFile(filepath.Join(work, "huge.png"), []byte(string(make([]byte, RepoBrowserBlobSizeLimit+1))), 0o644))
+	commitTestRun(t, work, "git", "add", ".")
+	commitTestRun(t, work, "git", "commit", "-m", "assets")
+	commitTestRun(t, work, "git", "push", "origin", "main")
+	require.NoError(mgr.EnsureClone(t.Context(), repo.Host, repo.Owner, repo.Name, repo.RemoteURL))
+	ref := repoBrowserMainRef(t, mgr, repo)
+
+	_, err := mgr.ReadRepoBrowserAsset(t.Context(), repo, ref, "/etc/passwd")
+	require.ErrorIs(err, ErrUnsafePath)
+
+	asset, err := mgr.ReadRepoBrowserAsset(t.Context(), repo, ref, "image.svg")
+	require.NoError(err)
+	assert.Equal("image/svg+xml", asset.MediaType)
+	assert.False(asset.Binary)
+
+	_, err = mgr.ReadRepoBrowserAsset(t.Context(), repo, ref, "huge.png")
+	assert.True(errors.Is(err, ErrTooLarge) || errors.Is(err, ErrTooLargeAsset))
+}
+
+func setupRepoBrowserTestRepo(t *testing.T) (*Manager, RepoBrowserRepoRef, string) {
+	t.Helper()
+	dir := t.TempDir()
+	remote := filepath.Join(dir, "remote.git")
+	commitTestRun(t, dir, "git", "init", "--bare", "--initial-branch=main", remote)
+
+	work := filepath.Join(dir, "work")
+	commitTestRun(t, dir, "git", "clone", remote, work)
+	commitTestRun(t, work, "git", "config", "user.email", "alice@example.com")
+	commitTestRun(t, work, "git", "config", "user.name", "Alice")
+	require.NoError(t, os.MkdirAll(filepath.Join(work, ".github", "workflows"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(work, "src"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(work, ".github", "workflows", "ci.yml"), []byte("name: ci\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(work, ".gitignore"), []byte("tmp\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(work, "README.md"), []byte("# Widgets\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(work, "src", "main.go"), []byte("package main\n"), 0o644))
+	commitTestRun(t, work, "git", "add", ".")
+	commitTestRun(t, work, "git", "commit", "-m", "initial")
+	commitTestRun(t, work, "git", "push", "origin", "main")
+
+	mgr := New(filepath.Join(dir, "clones"), nil)
+	repo := RepoBrowserRepoRef{
+		Host:      "github.com",
+		Owner:     "acme",
+		Name:      "widgets",
+		RepoPath:  "acme/widgets",
+		RemoteURL: remote,
+	}
+	require.NoError(t, mgr.EnsureClone(t.Context(), repo.Host, repo.Owner, repo.Name, repo.RemoteURL))
+	return mgr, repo, work
+}
+
+func repoBrowserMainRef(t *testing.T, mgr *Manager, repo RepoBrowserRepoRef) RepoBrowserRef {
+	t.Helper()
+	_, ref, err := mgr.ResolveDefaultBranch(t.Context(), repo.Host, repo.Owner, repo.Name, "main")
+	require.NoError(t, err)
+	return RepoBrowserRef{Type: RepoBrowserRefBranch, Name: "main", SHA: ref}
+}

--- a/internal/gitclone/repo_browser_test.go
+++ b/internal/gitclone/repo_browser_test.go
@@ -27,7 +27,7 @@ func TestRepoBrowserListRefsDisambiguatesBranchAndTag(t *testing.T) {
 	commitTestRun(t, work, "git", "checkout", "main")
 	commitTestRun(t, work, "git", "tag", "release", mainSHA)
 	commitTestRun(t, work, "git", "push", "origin", "refs/tags/release")
-	require.NoError(mgr.EnsureClone(t.Context(), repo.Host, repo.Owner, repo.Name, repo.RemoteURL))
+	require.NoError(mgr.EnsureRepoBrowserClone(t.Context(), repo))
 
 	refs, defaultRef, truncated, err := mgr.ListRepoBrowserRefs(t.Context(), repo, "main")
 	require.NoError(err)
@@ -64,7 +64,7 @@ func TestRepoBrowserFetchDoesNotPruneTagsOnHotPath(t *testing.T) {
 
 	commitTestRun(t, work, "git", "tag", "v1.0.0", mainSHA)
 	commitTestRun(t, work, "git", "push", "origin", "refs/tags/v1.0.0")
-	require.NoError(mgr.EnsureClone(t.Context(), repo.Host, repo.Owner, repo.Name, repo.RemoteURL))
+	require.NoError(mgr.EnsureRepoBrowserClone(t.Context(), repo))
 	refs, _, truncated, err := mgr.ListRepoBrowserRefs(t.Context(), repo, "main")
 	require.NoError(err)
 	assert.False(truncated)
@@ -72,7 +72,7 @@ func TestRepoBrowserFetchDoesNotPruneTagsOnHotPath(t *testing.T) {
 
 	commitTestRun(t, work, "git", "tag", "-d", "v1.0.0")
 	commitTestRun(t, work, "git", "push", "origin", ":refs/tags/v1.0.0")
-	require.NoError(mgr.EnsureClone(t.Context(), repo.Host, repo.Owner, repo.Name, repo.RemoteURL))
+	require.NoError(mgr.EnsureRepoBrowserClone(t.Context(), repo))
 
 	refs, _, truncated, err = mgr.ListRepoBrowserRefs(t.Context(), repo, "main")
 	require.NoError(err)
@@ -81,13 +81,41 @@ func TestRepoBrowserFetchDoesNotPruneTagsOnHotPath(t *testing.T) {
 
 	commitTestRun(t, work, "git", "tag", "v1.0.1", mainSHA)
 	commitTestRun(t, work, "git", "push", "origin", "refs/tags/v1.0.1")
-	require.NoError(mgr.EnsureClone(t.Context(), repo.Host, repo.Owner, repo.Name, repo.RemoteURL))
+	require.NoError(mgr.EnsureRepoBrowserClone(t.Context(), repo))
 
 	refs, _, truncated, err = mgr.ListRepoBrowserRefs(t.Context(), repo, "main")
 	require.NoError(err)
 	assert.False(truncated)
 	assert.Contains(refs, RepoBrowserRef{Type: RepoBrowserRefTag, Name: "v1.0.0", SHA: mainSHA})
 	assert.Contains(refs, RepoBrowserRef{Type: RepoBrowserRefTag, Name: "v1.0.1", SHA: mainSHA})
+}
+
+func TestRepoBrowserRefNamesResolveAsExactRefs(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	mgr, repo, work := setupRepoBrowserTestRepo(t)
+
+	initialSHA := gitSHA(t, work, "main")
+	require.NoError(os.WriteFile(filepath.Join(work, "README.md"), []byte("updated\n"), 0o644))
+	commitTestRun(t, work, "git", "add", ".")
+	commitTestRun(t, work, "git", "commit", "-m", "move main")
+	mainSHA := gitSHA(t, work, "HEAD")
+	commitTestRun(t, work, "git", "tag", "release", mainSHA)
+	commitTestRun(t, work, "git", "push", "origin", "main", "refs/tags/release")
+	require.NoError(mgr.EnsureRepoBrowserClone(t.Context(), repo))
+
+	ref, err := mgr.ResolveRepoBrowserRef(t.Context(), repo, RepoBrowserRef{Type: RepoBrowserRefBranch, Name: "main"})
+	require.NoError(err)
+	assert.Equal(mainSHA, ref.SHA)
+
+	_, err = mgr.ResolveRepoBrowserRef(t.Context(), repo, RepoBrowserRef{Type: RepoBrowserRefBranch, Name: "main~1"})
+	require.ErrorIs(err, ErrNotFound)
+
+	_, err = mgr.ResolveRepoBrowserRef(t.Context(), repo, RepoBrowserRef{Type: RepoBrowserRefTag, Name: "release^{}"})
+	require.ErrorIs(err, ErrNotFound)
+
+	_, err = mgr.ResolveRepoBrowserRef(t.Context(), repo, RepoBrowserRef{Type: RepoBrowserRefCommit, SHA: initialSHA})
+	assert.NoError(err)
 }
 
 func TestRepoBrowserListTreeReaderStopsAtEntryLimit(t *testing.T) {
@@ -142,7 +170,7 @@ func TestRepoBrowserReadBlobRejectsTraversalAndLargeFiles(t *testing.T) {
 	commitTestRun(t, work, "git", "add", ".")
 	commitTestRun(t, work, "git", "commit", "-m", "large file")
 	commitTestRun(t, work, "git", "push", "origin", "main")
-	require.NoError(mgr.EnsureClone(t.Context(), repo.Host, repo.Owner, repo.Name, repo.RemoteURL))
+	require.NoError(mgr.EnsureRepoBrowserClone(t.Context(), repo))
 	ref := repoBrowserMainRef(t, mgr, repo)
 
 	_, err := mgr.ReadRepoBrowserBlob(t.Context(), repo, ref, "../secret.txt")
@@ -183,7 +211,7 @@ func TestRepoBrowserLastChangedFallsBackPastBatchLogLimit(t *testing.T) {
 		commitTestRun(t, work, "git", "commit", "-m", fmt.Sprintf("churn %03d", i))
 	}
 	commitTestRun(t, work, "git", "push", "origin", "main")
-	require.NoError(mgr.EnsureClone(t.Context(), repo.Host, repo.Owner, repo.Name, repo.RemoteURL))
+	require.NoError(mgr.EnsureRepoBrowserClone(t.Context(), repo))
 	ref := repoBrowserMainRef(t, mgr, repo)
 
 	changed, err := mgr.RepoBrowserLastChanged(t.Context(), repo, ref, []string{"README.md", "churn.txt"})
@@ -206,7 +234,7 @@ func TestRepoBrowserFileHistoryIsBoundedAtSelectedSHA(t *testing.T) {
 	commitTestRun(t, work, "git", "add", ".")
 	commitTestRun(t, work, "git", "commit", "-m", "readme three")
 	commitTestRun(t, work, "git", "push", "origin", "main")
-	require.NoError(mgr.EnsureClone(t.Context(), repo.Host, repo.Owner, repo.Name, repo.RemoteURL))
+	require.NoError(mgr.EnsureRepoBrowserClone(t.Context(), repo))
 
 	history, err := mgr.RepoBrowserFileHistory(
 		t.Context(),
@@ -233,7 +261,7 @@ func TestRepoBrowserCommitDetailRequiresSelectedFileHistory(t *testing.T) {
 	commitTestRun(t, work, "git", "commit", "-m", "other file")
 	otherSHA := gitSHA(t, work, "HEAD")
 	commitTestRun(t, work, "git", "push", "origin", "main")
-	require.NoError(mgr.EnsureClone(t.Context(), repo.Host, repo.Owner, repo.Name, repo.RemoteURL))
+	require.NoError(mgr.EnsureRepoBrowserClone(t.Context(), repo))
 	ref := repoBrowserMainRef(t, mgr, repo)
 
 	_, err := mgr.RepoBrowserCommitDetail(t.Context(), repo, ref, "README.md", otherSHA)
@@ -261,7 +289,7 @@ func TestRepoBrowserHistoryTreatsPathspecMagicAsLiteral(t *testing.T) {
 	commitTestRun(t, work, "git", "commit", "-m", "readme update")
 	readmeSHA := gitSHA(t, work, "HEAD")
 	commitTestRun(t, work, "git", "push", "origin", "main")
-	require.NoError(mgr.EnsureClone(t.Context(), repo.Host, repo.Owner, repo.Name, repo.RemoteURL))
+	require.NoError(mgr.EnsureRepoBrowserClone(t.Context(), repo))
 	ref := repoBrowserMainRef(t, mgr, repo)
 
 	blob, err := mgr.ReadRepoBrowserBlob(t.Context(), repo, ref, magicPath)
@@ -297,7 +325,7 @@ func TestRepoBrowserMarkdownAssetRejectsUnsafeAndOversizedPaths(t *testing.T) {
 	commitTestRun(t, work, "git", "add", ".")
 	commitTestRun(t, work, "git", "commit", "-m", "assets")
 	commitTestRun(t, work, "git", "push", "origin", "main")
-	require.NoError(mgr.EnsureClone(t.Context(), repo.Host, repo.Owner, repo.Name, repo.RemoteURL))
+	require.NoError(mgr.EnsureRepoBrowserClone(t.Context(), repo))
 	ref := repoBrowserMainRef(t, mgr, repo)
 
 	_, err := mgr.ReadRepoBrowserAsset(t.Context(), repo, ref, "/etc/passwd")
@@ -338,19 +366,20 @@ func setupRepoBrowserTestRepo(t *testing.T) (*Manager, RepoBrowserRepoRef, strin
 
 	mgr := New(filepath.Join(dir, "clones"), nil)
 	repo := RepoBrowserRepoRef{
+		Provider:  "github",
 		Host:      "github.com",
 		Owner:     "acme",
 		Name:      "widgets",
 		RepoPath:  "acme/widgets",
 		RemoteURL: remote,
 	}
-	require.NoError(t, mgr.EnsureClone(t.Context(), repo.Host, repo.Owner, repo.Name, repo.RemoteURL))
+	require.NoError(t, mgr.EnsureRepoBrowserClone(t.Context(), repo))
 	return mgr, repo, work
 }
 
 func repoBrowserMainRef(t *testing.T, mgr *Manager, repo RepoBrowserRepoRef) RepoBrowserRef {
 	t.Helper()
-	_, ref, err := mgr.ResolveDefaultBranch(t.Context(), repo.Host, repo.Owner, repo.Name, "main")
+	_, ref, err := mgr.resolveRepoBrowserDefaultBranch(t.Context(), repo, "main")
 	require.NoError(t, err)
 	return RepoBrowserRef{Type: RepoBrowserRefBranch, Name: "main", SHA: ref}
 }

--- a/internal/gitclone/repo_browser_test.go
+++ b/internal/gitclone/repo_browser_test.go
@@ -115,20 +115,40 @@ func TestRefreshRepoBrowserClonesUsesSeededExistingClones(t *testing.T) {
 	assert.Equal(updatedSHA, resolved.SHA)
 }
 
+func TestEnsureRepoBrowserCloneDoesNotRefreshExistingClone(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	mgr, repo, work := setupRepoBrowserTestRepo(t)
+	initial := repoBrowserMainRef(t, mgr, repo)
+
+	require.NoError(os.WriteFile(filepath.Join(work, "README.md"), []byte("# Updated\n"), 0o644))
+	commitTestRun(t, work, "git", "add", ".")
+	commitTestRun(t, work, "git", "commit", "-m", "update readme")
+	updatedSHA := gitSHA(t, work, "main")
+	commitTestRun(t, work, "git", "push", "origin", "main")
+
+	require.NoError(mgr.EnsureRepoBrowserClone(t.Context(), repo))
+	stale := repoBrowserMainRef(t, mgr, repo)
+	assert.Equal(initial.SHA, stale.SHA)
+
+	require.NoError(mgr.RefreshRepoBrowserClone(t.Context(), repo))
+	refreshed := repoBrowserMainRef(t, mgr, repo)
+	assert.Equal(updatedSHA, refreshed.SHA)
+}
+
 func TestRepoBrowserScheduledRefreshContextStaysCancelable(t *testing.T) {
 	require := require.New(t)
+	assert := assert.New(t)
+	_, repo, _ := setupRepoBrowserTestRepo(t)
+	mgr := New(filepath.Join(t.TempDir(), "clones-canceled"), nil)
 
-	parent, cancel := context.WithCancel(t.Context())
-	opCtx, opCancel := repoBrowserRefreshOperationContext(parent, false)
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
-	defer opCancel()
-	require.ErrorIs(opCtx.Err(), context.Canceled)
 
-	detachedParent, detachedCancel := context.WithCancel(t.Context())
-	detachedCtx, detachedOpCancel := repoBrowserRefreshOperationContext(detachedParent, true)
-	detachedCancel()
-	defer detachedOpCancel()
-	require.NoError(detachedCtx.Err())
+	err := mgr.RefreshRepoBrowserClone(ctx, repo)
+	require.ErrorIs(err, context.Canceled)
+	repos := mgr.repoBrowserReposSnapshot()
+	assert.Empty(repos)
 }
 
 func TestRepoBrowserRefreshFetchesTagsWithoutPruning(t *testing.T) {

--- a/internal/gitclone/repo_browser_test.go
+++ b/internal/gitclone/repo_browser_test.go
@@ -151,6 +151,19 @@ func TestRepoBrowserScheduledRefreshContextStaysCancelable(t *testing.T) {
 	assert.Empty(repos)
 }
 
+func TestRepoBrowserRequestRefreshWorkDetachesCallerCancellation(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	requestWork := repoBrowserRefreshWorkParent(ctx, repoBrowserRefreshDetachCaller)
+	scheduledWork := repoBrowserRefreshWorkParent(ctx, repoBrowserRefreshRespectCaller)
+
+	cancel()
+
+	require.NoError(requestWork.Err())
+	assert.ErrorIs(scheduledWork.Err(), context.Canceled)
+}
+
 func TestRepoBrowserRefreshFetchesTagsWithoutPruning(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/gitclone/repo_browser_test.go
+++ b/internal/gitclone/repo_browser_test.go
@@ -416,7 +416,7 @@ func TestRepoBrowserCommitDetailRequiresSelectedFileHistory(t *testing.T) {
 
 	require.NoError(os.WriteFile(filepath.Join(work, "other.txt"), []byte("other\n"), 0o644))
 	commitTestRun(t, work, "git", "add", ".")
-	commitTestRun(t, work, "git", "commit", "-m", "other file")
+	commitTestRun(t, work, "git", "commit", "-m", "other file", "-m", "Explain the file change.\n\nKeep the body visible.")
 	otherSHA := gitSHA(t, work, "HEAD")
 	commitTestRun(t, work, "git", "push", "origin", "main")
 	require.NoError(mgr.RefreshRepoBrowserClone(t.Context(), repo))
@@ -429,6 +429,7 @@ func TestRepoBrowserCommitDetailRequiresSelectedFileHistory(t *testing.T) {
 	require.NoError(err)
 	assert.Equal(otherSHA, commit.SHA)
 	assert.Equal("other file", commit.Subject)
+	assert.Equal("Explain the file change.\n\nKeep the body visible.", commit.Body)
 }
 
 func TestRepoBrowserCommitDetailRejectsUnknownFullSHA(t *testing.T) {

--- a/internal/gitclone/repo_browser_test.go
+++ b/internal/gitclone/repo_browser_test.go
@@ -89,6 +89,31 @@ func TestRefreshRepoBrowserClonesRefreshesRegisteredRepos(t *testing.T) {
 	assert.Contains(refs, RepoBrowserRef{Type: RepoBrowserRefTag, Name: "v1.0.0", SHA: mainSHA})
 }
 
+func TestRefreshRepoBrowserClonesUsesSeededExistingClones(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	mgr, repo, work := setupRepoBrowserTestRepo(t)
+	restarted := New(mgr.baseDir, nil)
+
+	require.NoError(os.WriteFile(filepath.Join(work, "README.md"), []byte("# Updated\n"), 0o644))
+	commitTestRun(t, work, "git", "add", ".")
+	commitTestRun(t, work, "git", "commit", "-m", "update readme")
+	updatedSHA := gitSHA(t, work, "main")
+	commitTestRun(t, work, "git", "push", "origin", "main")
+
+	registered, err := restarted.RegisterExistingRepoBrowserClone(t.Context(), repo)
+	require.NoError(err)
+	require.True(registered)
+	restarted.RefreshRepoBrowserClones(t.Context())
+
+	resolved, err := restarted.ResolveRepoBrowserRef(t.Context(), repo, RepoBrowserRef{
+		Type: RepoBrowserRefBranch,
+		Name: "main",
+	})
+	require.NoError(err)
+	assert.Equal(updatedSHA, resolved.SHA)
+}
+
 func TestRepoBrowserRefreshFetchesTagsWithoutPruning(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/gitclone/repo_browser_test.go
+++ b/internal/gitclone/repo_browser_test.go
@@ -431,6 +431,16 @@ func TestRepoBrowserCommitDetailRequiresSelectedFileHistory(t *testing.T) {
 	assert.Equal("other file", commit.Subject)
 }
 
+func TestRepoBrowserCommitDetailRejectsUnknownFullSHA(t *testing.T) {
+	require := require.New(t)
+	mgr, repo, _ := setupRepoBrowserTestRepo(t)
+	ref := repoBrowserMainRef(t, mgr, repo)
+
+	_, err := mgr.RepoBrowserCommitDetail(t.Context(), repo, ref, "README.md", strings.Repeat("a", 40))
+
+	require.ErrorIs(err, ErrNotFound)
+}
+
 func TestRepoBrowserCommitDetailAcceptsOlderFileHistory(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/gitclone/repo_browser_test.go
+++ b/internal/gitclone/repo_browser_test.go
@@ -156,6 +156,9 @@ func TestRepoBrowserMarkdownAssetRejectsUnsafeAndOversizedPaths(t *testing.T) {
 	mgr, repo, work := setupRepoBrowserTestRepo(t)
 
 	require.NoError(os.WriteFile(filepath.Join(work, "image.svg"), []byte(`<svg xmlns="http://www.w3.org/2000/svg"></svg>`), 0o644))
+	require.NoError(os.WriteFile(filepath.Join(work, "page.html"), []byte(`<script>alert(1)</script>`), 0o644))
+	require.NoError(os.WriteFile(filepath.Join(work, "script.js"), []byte(`alert(1)`), 0o644))
+	require.NoError(os.WriteFile(filepath.Join(work, "image.png"), []byte{0x89, 0x50, 0x4e, 0x47}, 0o644))
 	require.NoError(os.WriteFile(filepath.Join(work, "huge.png"), []byte(string(make([]byte, RepoBrowserBlobSizeLimit+1))), 0o644))
 	commitTestRun(t, work, "git", "add", ".")
 	commitTestRun(t, work, "git", "commit", "-m", "assets")
@@ -166,10 +169,14 @@ func TestRepoBrowserMarkdownAssetRejectsUnsafeAndOversizedPaths(t *testing.T) {
 	_, err := mgr.ReadRepoBrowserAsset(t.Context(), repo, ref, "/etc/passwd")
 	require.ErrorIs(err, ErrUnsafePath)
 
-	asset, err := mgr.ReadRepoBrowserAsset(t.Context(), repo, ref, "image.svg")
+	for _, path := range []string{"image.svg", "page.html", "script.js"} {
+		_, err = mgr.ReadRepoBrowserAsset(t.Context(), repo, ref, path)
+		require.ErrorIs(err, ErrUnsupportedAsset, path)
+	}
+
+	asset, err := mgr.ReadRepoBrowserAsset(t.Context(), repo, ref, "image.png")
 	require.NoError(err)
-	assert.Equal("image/svg+xml", asset.MediaType)
-	assert.False(asset.Binary)
+	assert.Equal("image/png", asset.MediaType)
 
 	_, err = mgr.ReadRepoBrowserAsset(t.Context(), repo, ref, "huge.png")
 	assert.True(errors.Is(err, ErrTooLarge) || errors.Is(err, ErrTooLargeAsset))

--- a/internal/gitclone/repo_browser_test.go
+++ b/internal/gitclone/repo_browser_test.go
@@ -89,6 +89,21 @@ func TestRepoBrowserFetchDoesNotPruneTagsOnHotPath(t *testing.T) {
 	assert.False(truncated)
 	assert.Contains(refs, RepoBrowserRef{Type: RepoBrowserRefTag, Name: "v1.0.0", SHA: mainSHA})
 	assert.Contains(refs, RepoBrowserRef{Type: RepoBrowserRefTag, Name: "v1.0.1", SHA: mainSHA})
+
+	require.NoError(os.WriteFile(filepath.Join(work, "retag.txt"), []byte("retag\n"), 0o644))
+	commitTestRun(t, work, "git", "add", ".")
+	commitTestRun(t, work, "git", "commit", "-m", "retag target")
+	movedSHA := gitSHA(t, work, "HEAD")
+	commitTestRun(t, work, "git", "tag", "-f", "v1.0.1", movedSHA)
+	commitTestRun(t, work, "git", "push", "origin", "main")
+	commitTestRun(t, work, "git", "push", "--force", "origin", "refs/tags/v1.0.1")
+	require.NoError(mgr.EnsureRepoBrowserClone(t.Context(), repo))
+
+	refs, _, truncated, err = mgr.ListRepoBrowserRefs(t.Context(), repo, "main")
+	require.NoError(err)
+	assert.False(truncated)
+	assert.Contains(refs, RepoBrowserRef{Type: RepoBrowserRefTag, Name: "v1.0.0", SHA: mainSHA})
+	assert.Contains(refs, RepoBrowserRef{Type: RepoBrowserRefTag, Name: "v1.0.1", SHA: movedSHA})
 }
 
 func TestRepoBrowserRefNamesResolveAsExactRefs(t *testing.T) {

--- a/internal/gitclone/repo_browser_test.go
+++ b/internal/gitclone/repo_browser_test.go
@@ -243,6 +243,38 @@ func TestRepoBrowserLastChangedHandlesCommitPrefixedPathsAndUTCTimes(t *testing.
 	assert.Equal(time.Date(2026, 6, 1, 19, 34, 56, 0, time.UTC), changed[pathName].AuthoredAt)
 }
 
+func TestRepoBrowserLastChangedTreatsCommitFormatShapedPathAsPath(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	mgr, repo, work := setupRepoBrowserTestRepo(t)
+
+	commitShapedPath := strings.Join([]string{
+		strings.Repeat("a", 40),
+		"Fake Author",
+		"fake@example.com",
+		"2026-06-01T12:34:56Z",
+		"fake subject",
+	}, "\x1f")
+	secondPath := "zz-after.md"
+	require.NoError(os.WriteFile(filepath.Join(work, commitShapedPath), []byte("literal\n"), 0o644))
+	require.NoError(os.WriteFile(filepath.Join(work, secondPath), []byte("after\n"), 0o644))
+	commitTestRun(t, work, "git", "add", ".")
+	commitTestRun(t, work, "git", "commit", "-m", "commit-shaped path")
+	commitTestRun(t, work, "git", "push", "origin", "main")
+	require.NoError(mgr.EnsureRepoBrowserClone(t.Context(), repo))
+	ref := repoBrowserMainRef(t, mgr, repo)
+	wantSHA := gitSHA(t, work, "HEAD")
+
+	changed, err := mgr.RepoBrowserLastChanged(t.Context(), repo, ref, []string{commitShapedPath, secondPath})
+	require.NoError(err)
+
+	require.Contains(changed, commitShapedPath)
+	require.Contains(changed, secondPath)
+	assert.Equal(wantSHA, changed[commitShapedPath].SHA)
+	assert.Equal(wantSHA, changed[secondPath].SHA)
+	assert.Equal("commit-shaped path", changed[secondPath].Subject)
+}
+
 func TestRepoBrowserFileHistoryIsBoundedAtSelectedSHA(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/gitclone/repo_browser_test.go
+++ b/internal/gitclone/repo_browser_test.go
@@ -28,7 +28,7 @@ func TestRepoBrowserListRefsDisambiguatesBranchAndTag(t *testing.T) {
 	commitTestRun(t, work, "git", "checkout", "main")
 	commitTestRun(t, work, "git", "tag", "release", mainSHA)
 	commitTestRun(t, work, "git", "push", "origin", "refs/tags/release")
-	require.NoError(mgr.EnsureRepoBrowserClone(t.Context(), repo))
+	require.NoError(mgr.RefreshRepoBrowserClone(t.Context(), repo))
 
 	refs, defaultRef, truncated, err := mgr.ListRepoBrowserRefs(t.Context(), repo, "main")
 	require.NoError(err)
@@ -57,7 +57,7 @@ func TestRepoBrowserListRefsCapsLargeRefSets(t *testing.T) {
 	assert.Equal(fmt.Sprintf("branch-%04d", RepoBrowserRefLimit-1), capped[len(capped)-1].Name)
 }
 
-func TestRepoBrowserFetchDoesNotPruneTagsOnHotPath(t *testing.T) {
+func TestEnsureRepoBrowserCloneDoesNotFetchTagsForExistingClone(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	mgr, repo, work := setupRepoBrowserTestRepo(t)
@@ -66,6 +66,38 @@ func TestRepoBrowserFetchDoesNotPruneTagsOnHotPath(t *testing.T) {
 	commitTestRun(t, work, "git", "tag", "v1.0.0", mainSHA)
 	commitTestRun(t, work, "git", "push", "origin", "refs/tags/v1.0.0")
 	require.NoError(mgr.EnsureRepoBrowserClone(t.Context(), repo))
+
+	refs, _, truncated, err := mgr.ListRepoBrowserRefs(t.Context(), repo, "main")
+	require.NoError(err)
+	assert.False(truncated)
+	assert.NotContains(refs, RepoBrowserRef{Type: RepoBrowserRefTag, Name: "v1.0.0", SHA: mainSHA})
+}
+
+func TestRefreshRepoBrowserClonesRefreshesRegisteredRepos(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	mgr, repo, work := setupRepoBrowserTestRepo(t)
+	mainSHA := gitSHA(t, work, "main")
+
+	commitTestRun(t, work, "git", "tag", "v1.0.0", mainSHA)
+	commitTestRun(t, work, "git", "push", "origin", "refs/tags/v1.0.0")
+	mgr.RefreshRepoBrowserClones(t.Context())
+
+	refs, _, truncated, err := mgr.ListRepoBrowserRefs(t.Context(), repo, "main")
+	require.NoError(err)
+	assert.False(truncated)
+	assert.Contains(refs, RepoBrowserRef{Type: RepoBrowserRefTag, Name: "v1.0.0", SHA: mainSHA})
+}
+
+func TestRepoBrowserRefreshFetchesTagsWithoutPruning(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	mgr, repo, work := setupRepoBrowserTestRepo(t)
+	mainSHA := gitSHA(t, work, "main")
+
+	commitTestRun(t, work, "git", "tag", "v1.0.0", mainSHA)
+	commitTestRun(t, work, "git", "push", "origin", "refs/tags/v1.0.0")
+	require.NoError(mgr.RefreshRepoBrowserClone(t.Context(), repo))
 	refs, _, truncated, err := mgr.ListRepoBrowserRefs(t.Context(), repo, "main")
 	require.NoError(err)
 	assert.False(truncated)
@@ -73,7 +105,7 @@ func TestRepoBrowserFetchDoesNotPruneTagsOnHotPath(t *testing.T) {
 
 	commitTestRun(t, work, "git", "tag", "-d", "v1.0.0")
 	commitTestRun(t, work, "git", "push", "origin", ":refs/tags/v1.0.0")
-	require.NoError(mgr.EnsureRepoBrowserClone(t.Context(), repo))
+	require.NoError(mgr.RefreshRepoBrowserClone(t.Context(), repo))
 
 	refs, _, truncated, err = mgr.ListRepoBrowserRefs(t.Context(), repo, "main")
 	require.NoError(err)
@@ -82,7 +114,7 @@ func TestRepoBrowserFetchDoesNotPruneTagsOnHotPath(t *testing.T) {
 
 	commitTestRun(t, work, "git", "tag", "v1.0.1", mainSHA)
 	commitTestRun(t, work, "git", "push", "origin", "refs/tags/v1.0.1")
-	require.NoError(mgr.EnsureRepoBrowserClone(t.Context(), repo))
+	require.NoError(mgr.RefreshRepoBrowserClone(t.Context(), repo))
 
 	refs, _, truncated, err = mgr.ListRepoBrowserRefs(t.Context(), repo, "main")
 	require.NoError(err)
@@ -97,7 +129,7 @@ func TestRepoBrowserFetchDoesNotPruneTagsOnHotPath(t *testing.T) {
 	commitTestRun(t, work, "git", "tag", "-f", "v1.0.1", movedSHA)
 	commitTestRun(t, work, "git", "push", "origin", "main")
 	commitTestRun(t, work, "git", "push", "--force", "origin", "refs/tags/v1.0.1")
-	require.NoError(mgr.EnsureRepoBrowserClone(t.Context(), repo))
+	require.NoError(mgr.RefreshRepoBrowserClone(t.Context(), repo))
 
 	refs, _, truncated, err = mgr.ListRepoBrowserRefs(t.Context(), repo, "main")
 	require.NoError(err)
@@ -118,7 +150,7 @@ func TestRepoBrowserRefNamesResolveAsExactRefs(t *testing.T) {
 	mainSHA := gitSHA(t, work, "HEAD")
 	commitTestRun(t, work, "git", "tag", "release", mainSHA)
 	commitTestRun(t, work, "git", "push", "origin", "main", "refs/tags/release")
-	require.NoError(mgr.EnsureRepoBrowserClone(t.Context(), repo))
+	require.NoError(mgr.RefreshRepoBrowserClone(t.Context(), repo))
 
 	ref, err := mgr.ResolveRepoBrowserRef(t.Context(), repo, RepoBrowserRef{Type: RepoBrowserRefBranch, Name: "main"})
 	require.NoError(err)
@@ -186,7 +218,7 @@ func TestRepoBrowserReadBlobRejectsTraversalAndLargeFiles(t *testing.T) {
 	commitTestRun(t, work, "git", "add", ".")
 	commitTestRun(t, work, "git", "commit", "-m", "large file")
 	commitTestRun(t, work, "git", "push", "origin", "main")
-	require.NoError(mgr.EnsureRepoBrowserClone(t.Context(), repo))
+	require.NoError(mgr.RefreshRepoBrowserClone(t.Context(), repo))
 	ref := repoBrowserMainRef(t, mgr, repo)
 
 	_, err := mgr.ReadRepoBrowserBlob(t.Context(), repo, ref, "../secret.txt")
@@ -227,7 +259,7 @@ func TestRepoBrowserLastChangedFallsBackPastBatchLogLimit(t *testing.T) {
 		commitTestRun(t, work, "git", "commit", "-m", fmt.Sprintf("churn %03d", i))
 	}
 	commitTestRun(t, work, "git", "push", "origin", "main")
-	require.NoError(mgr.EnsureRepoBrowserClone(t.Context(), repo))
+	require.NoError(mgr.RefreshRepoBrowserClone(t.Context(), repo))
 	ref := repoBrowserMainRef(t, mgr, repo)
 
 	changed, err := mgr.RepoBrowserLastChanged(t.Context(), repo, ref, []string{"README.md", "churn.txt"})
@@ -247,7 +279,7 @@ func TestRepoBrowserLastChangedHandlesCommitPrefixedPathsAndUTCTimes(t *testing.
 	commitTestRun(t, work, "git", "add", ".")
 	commitTestRun(t, work, "git", "commit", "--date=2026-06-01T12:34:56-07:00", "-m", "commit-prefixed path")
 	commitTestRun(t, work, "git", "push", "origin", "main")
-	require.NoError(mgr.EnsureRepoBrowserClone(t.Context(), repo))
+	require.NoError(mgr.RefreshRepoBrowserClone(t.Context(), repo))
 	ref := repoBrowserMainRef(t, mgr, repo)
 
 	changed, err := mgr.RepoBrowserLastChanged(t.Context(), repo, ref, []string{pathName})
@@ -276,7 +308,7 @@ func TestRepoBrowserLastChangedTreatsCommitFormatShapedPathAsPath(t *testing.T) 
 	commitTestRun(t, work, "git", "add", ".")
 	commitTestRun(t, work, "git", "commit", "-m", "commit-shaped path")
 	commitTestRun(t, work, "git", "push", "origin", "main")
-	require.NoError(mgr.EnsureRepoBrowserClone(t.Context(), repo))
+	require.NoError(mgr.RefreshRepoBrowserClone(t.Context(), repo))
 	ref := repoBrowserMainRef(t, mgr, repo)
 	wantSHA := gitSHA(t, work, "HEAD")
 
@@ -303,7 +335,7 @@ func TestRepoBrowserFileHistoryIsBoundedAtSelectedSHA(t *testing.T) {
 	commitTestRun(t, work, "git", "add", ".")
 	commitTestRun(t, work, "git", "commit", "-m", "readme three")
 	commitTestRun(t, work, "git", "push", "origin", "main")
-	require.NoError(mgr.EnsureRepoBrowserClone(t.Context(), repo))
+	require.NoError(mgr.RefreshRepoBrowserClone(t.Context(), repo))
 
 	history, err := mgr.RepoBrowserFileHistory(
 		t.Context(),
@@ -328,7 +360,7 @@ func TestRepoBrowserFileHistoryRequiresSelectedTreePath(t *testing.T) {
 	commitTestRun(t, work, "git", "add", ".")
 	commitTestRun(t, work, "git", "commit", "-m", "later file")
 	commitTestRun(t, work, "git", "push", "origin", "main")
-	require.NoError(mgr.EnsureRepoBrowserClone(t.Context(), repo))
+	require.NoError(mgr.RefreshRepoBrowserClone(t.Context(), repo))
 	ref := RepoBrowserRef{Type: RepoBrowserRefCommit, SHA: gitSHA(t, work, "HEAD~1")}
 
 	_, err := mgr.RepoBrowserFileHistory(t.Context(), repo, ref, "later.md")
@@ -345,7 +377,7 @@ func TestRepoBrowserCommitDetailRequiresSelectedFileHistory(t *testing.T) {
 	commitTestRun(t, work, "git", "commit", "-m", "other file")
 	otherSHA := gitSHA(t, work, "HEAD")
 	commitTestRun(t, work, "git", "push", "origin", "main")
-	require.NoError(mgr.EnsureRepoBrowserClone(t.Context(), repo))
+	require.NoError(mgr.RefreshRepoBrowserClone(t.Context(), repo))
 	ref := repoBrowserMainRef(t, mgr, repo)
 
 	_, err := mgr.RepoBrowserCommitDetail(t.Context(), repo, ref, "README.md", otherSHA)
@@ -373,7 +405,7 @@ func TestRepoBrowserHistoryTreatsPathspecMagicAsLiteral(t *testing.T) {
 	commitTestRun(t, work, "git", "commit", "-m", "readme update")
 	readmeSHA := gitSHA(t, work, "HEAD")
 	commitTestRun(t, work, "git", "push", "origin", "main")
-	require.NoError(mgr.EnsureRepoBrowserClone(t.Context(), repo))
+	require.NoError(mgr.RefreshRepoBrowserClone(t.Context(), repo))
 	ref := repoBrowserMainRef(t, mgr, repo)
 
 	blob, err := mgr.ReadRepoBrowserBlob(t.Context(), repo, ref, magicPath)
@@ -409,7 +441,7 @@ func TestRepoBrowserMarkdownAssetRejectsUnsafeAndOversizedPaths(t *testing.T) {
 	commitTestRun(t, work, "git", "add", ".")
 	commitTestRun(t, work, "git", "commit", "-m", "assets")
 	commitTestRun(t, work, "git", "push", "origin", "main")
-	require.NoError(mgr.EnsureRepoBrowserClone(t.Context(), repo))
+	require.NoError(mgr.RefreshRepoBrowserClone(t.Context(), repo))
 	ref := repoBrowserMainRef(t, mgr, repo)
 
 	_, err := mgr.ReadRepoBrowserAsset(t.Context(), repo, ref, "/etc/passwd")

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -346,9 +346,7 @@ case "$*" in
 		echo "+refs/heads/*:refs/remotes/origin/*"
 		echo "+refs/pull/*/head:refs/pull/*/head"
 		;;
-	"fetch --prune origin")
-		;;
-	"fetch origin +refs/tags/*:refs/tags/*")
+	"fetch --prune --no-tags origin")
 		;;
 	"remote set-head origin -a")
 		touch "${MIDDLEMAN_TEST_CANCEL_FILE:?}"

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -346,7 +346,7 @@ case "$*" in
 		echo "+refs/heads/*:refs/remotes/origin/*"
 		echo "+refs/pull/*/head:refs/pull/*/head"
 		;;
-	"fetch --prune --prune-tags origin")
+	"fetch --prune origin")
 		;;
 	"remote set-head origin -a")
 		touch "${MIDDLEMAN_TEST_CANCEL_FILE:?}"

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -346,7 +346,9 @@ case "$*" in
 		echo "+refs/heads/*:refs/remotes/origin/*"
 		echo "+refs/pull/*/head:refs/pull/*/head"
 		;;
-	"fetch --prune --tags origin")
+	"fetch --prune origin")
+		;;
+	"fetch origin +refs/tags/*:refs/tags/*")
 		;;
 	"remote set-head origin -a")
 		touch "${MIDDLEMAN_TEST_CANCEL_FILE:?}"

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -346,7 +346,7 @@ case "$*" in
 		echo "+refs/heads/*:refs/remotes/origin/*"
 		echo "+refs/pull/*/head:refs/pull/*/head"
 		;;
-	"fetch --prune origin")
+	"fetch --prune --prune-tags origin")
 		;;
 	"remote set-head origin -a")
 		touch "${MIDDLEMAN_TEST_CANCEL_FILE:?}"

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -346,7 +346,7 @@ case "$*" in
 		echo "+refs/heads/*:refs/remotes/origin/*"
 		echo "+refs/pull/*/head:refs/pull/*/head"
 		;;
-	"fetch --prune origin")
+	"fetch --prune --tags origin")
 		;;
 	"remote set-head origin -a")
 		touch "${MIDDLEMAN_TEST_CANCEL_FILE:?}"

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -5318,6 +5318,26 @@ func TestAPIListRepoSummariesIncludesSyncedReleaseTimeline(t *testing.T) {
 	assert.Equal("post latest 2", (*widgets.CommitTimeline)[0].Message)
 	assert.Equal("post latest 1", (*widgets.CommitTimeline)[1].Message)
 	assert.Len((*widgets.CommitTimeline)[0].Sha, 40)
+
+	runGit(t, work, "tag", "-f", "v3.0.0", "HEAD")
+	runGit(t, work, "tag", "-f", "v1.0.0", "HEAD")
+	runGit(t, work, "push", "--force", "origin", "refs/tags/v3.0.0")
+	runGit(t, work, "push", "--force", "origin", "refs/tags/v1.0.0")
+	syncer.RunOnce(ctx)
+
+	resp, err = client.HTTP.ListRepoSummariesWithResponse(ctx)
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode())
+	require.NotNil(resp.JSON200)
+	require.Len(*resp.JSON200, 1)
+
+	widgets = (*resp.JSON200)[0]
+	require.NotNil(widgets.LatestRelease)
+	require.NotNil(widgets.CommitsSinceRelease)
+	require.NotNil(widgets.CommitTimeline)
+	assert.Equal("v3.0.0", widgets.LatestRelease.TagName)
+	assert.Equal(int64(0), *widgets.CommitsSinceRelease)
+	assert.Empty(*widgets.CommitTimeline)
 }
 
 func TestAPIListRepoSummariesUsesTagsWhenNoReleases(t *testing.T) {

--- a/internal/server/api_types.go
+++ b/internal/server/api_types.go
@@ -215,6 +215,7 @@ type repoBrowserRefsResponse struct {
 	Repo       repoRefResponse           `json:"repo"`
 	Refs       []gitclone.RepoBrowserRef `json:"refs"`
 	DefaultRef gitclone.RepoBrowserRef   `json:"default_ref"`
+	Truncated  bool                      `json:"truncated"`
 }
 
 type repoBrowserTreeResponse struct {

--- a/internal/server/api_types.go
+++ b/internal/server/api_types.go
@@ -211,6 +211,45 @@ type repoSummaryResponse struct {
 	Operations           RepoOperations                   `json:"operations"`
 }
 
+type repoBrowserRefsResponse struct {
+	Repo       repoRefResponse           `json:"repo"`
+	Refs       []gitclone.RepoBrowserRef `json:"refs"`
+	DefaultRef gitclone.RepoBrowserRef   `json:"default_ref"`
+}
+
+type repoBrowserTreeResponse struct {
+	Repo      repoRefResponse                 `json:"repo"`
+	Ref       gitclone.RepoBrowserRef         `json:"ref"`
+	Entries   []gitclone.RepoBrowserTreeEntry `json:"entries"`
+	Truncated bool                            `json:"truncated"`
+}
+
+type repoBrowserBlobResponse struct {
+	Repo repoRefResponse          `json:"repo"`
+	Ref  gitclone.RepoBrowserRef  `json:"ref"`
+	Blob gitclone.RepoBrowserBlob `json:"blob"`
+}
+
+type repoBrowserLastChangedResponse struct {
+	Repo    repoRefResponse                       `json:"repo"`
+	Ref     gitclone.RepoBrowserRef               `json:"ref"`
+	Commits map[string]gitclone.RepoBrowserCommit `json:"commits"`
+}
+
+type repoBrowserHistoryResponse struct {
+	Repo    repoRefResponse              `json:"repo"`
+	Ref     gitclone.RepoBrowserRef      `json:"ref"`
+	Path    string                       `json:"path"`
+	Commits []gitclone.RepoBrowserCommit `json:"commits"`
+}
+
+type repoBrowserCommitResponse struct {
+	Repo   repoRefResponse            `json:"repo"`
+	Ref    gitclone.RepoBrowserRef    `json:"ref"`
+	Path   string                     `json:"path"`
+	Commit gitclone.RepoBrowserCommit `json:"commit"`
+}
+
 type commentAutocompleteResponse struct {
 	Users      []string                          `json:"users,omitempty"`
 	References []db.CommentAutocompleteReference `json:"references,omitempty"`

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -665,6 +665,22 @@ func documentOperation(
 	}
 }
 
+func repoBrowserAssetResponses() map[string]*huma.Response {
+	return map[string]*huma.Response{
+		"200": {
+			Description: "Image response",
+			Content: map[string]*huma.MediaType{
+				"image/avif": {Schema: &huma.Schema{Type: "string", Format: "binary"}},
+				"image/bmp":  {Schema: &huma.Schema{Type: "string", Format: "binary"}},
+				"image/gif":  {Schema: &huma.Schema{Type: "string", Format: "binary"}},
+				"image/jpeg": {Schema: &huma.Schema{Type: "string", Format: "binary"}},
+				"image/png":  {Schema: &huma.Schema{Type: "string", Format: "binary"}},
+				"image/webp": {Schema: &huma.Schema{Type: "string", Format: "binary"}},
+			},
+		},
+	}
+}
+
 func (s *Server) registerAPI(api huma.API) {
 	huma.Register(api, huma.Operation{
 		OperationID: "get-version",
@@ -1244,10 +1260,24 @@ func (s *Server) registerProviderRepoAPI(api huma.API) {
 		documentOperation("get-repo-browser-blob", "Get repository browser blob", "Repositories"))
 	huma.Get(api, hostRepoPath+"/browser/blob", s.getRepoBrowserBlobOnHost,
 		documentOperation("get-repo-browser-blob-on-host", "Get repository browser blob", "Repositories"))
-	huma.Get(api, repoPath+"/browser/asset", s.getRepoBrowserAsset,
-		documentOperation("get-repo-browser-asset", "Get repository browser asset", "Repositories"))
-	huma.Get(api, hostRepoPath+"/browser/asset", s.getRepoBrowserAssetOnHost,
-		documentOperation("get-repo-browser-asset-on-host", "Get repository browser asset", "Repositories"))
+	huma.Register(api, huma.Operation{
+		OperationID:   "get-repo-browser-asset",
+		Method:        http.MethodGet,
+		Path:          repoPath + "/browser/asset",
+		DefaultStatus: http.StatusOK,
+		Summary:       "Get repository browser asset",
+		Tags:          []string{"Repositories"},
+		Responses:     repoBrowserAssetResponses(),
+	}, s.getRepoBrowserAsset)
+	huma.Register(api, huma.Operation{
+		OperationID:   "get-repo-browser-asset-on-host",
+		Method:        http.MethodGet,
+		Path:          hostRepoPath + "/browser/asset",
+		DefaultStatus: http.StatusOK,
+		Summary:       "Get repository browser asset",
+		Tags:          []string{"Repositories"},
+		Responses:     repoBrowserAssetResponses(),
+	}, s.getRepoBrowserAssetOnHost)
 	huma.Get(api, repoPath+"/browser/last-changed", s.getRepoBrowserLastChanged,
 		documentOperation("get-repo-browser-last-changed", "Get repository browser last changed commits", "Repositories"))
 	huma.Get(api, hostRepoPath+"/browser/last-changed", s.getRepoBrowserLastChangedOnHost,

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -1232,6 +1232,34 @@ func (s *Server) registerProviderRepoAPI(api huma.API) {
 		documentOperation("get-repo", "Get repository", "Repositories"))
 	huma.Get(api, hostRepoPath, s.getRepoOnHost,
 		documentOperation("get-repo-on-host", "Get repository", "Repositories"))
+	huma.Get(api, repoPath+"/browser/refs", s.listRepoBrowserRefs,
+		documentOperation("list-repo-browser-refs", "List repository browser refs", "Repositories"))
+	huma.Get(api, hostRepoPath+"/browser/refs", s.listRepoBrowserRefsOnHost,
+		documentOperation("list-repo-browser-refs-on-host", "List repository browser refs", "Repositories"))
+	huma.Get(api, repoPath+"/browser/tree", s.listRepoBrowserTree,
+		documentOperation("list-repo-browser-tree", "List repository browser tree", "Repositories"))
+	huma.Get(api, hostRepoPath+"/browser/tree", s.listRepoBrowserTreeOnHost,
+		documentOperation("list-repo-browser-tree-on-host", "List repository browser tree", "Repositories"))
+	huma.Get(api, repoPath+"/browser/blob", s.getRepoBrowserBlob,
+		documentOperation("get-repo-browser-blob", "Get repository browser blob", "Repositories"))
+	huma.Get(api, hostRepoPath+"/browser/blob", s.getRepoBrowserBlobOnHost,
+		documentOperation("get-repo-browser-blob-on-host", "Get repository browser blob", "Repositories"))
+	huma.Get(api, repoPath+"/browser/asset", s.getRepoBrowserAsset,
+		documentOperation("get-repo-browser-asset", "Get repository browser asset", "Repositories"))
+	huma.Get(api, hostRepoPath+"/browser/asset", s.getRepoBrowserAssetOnHost,
+		documentOperation("get-repo-browser-asset-on-host", "Get repository browser asset", "Repositories"))
+	huma.Get(api, repoPath+"/browser/last-changed", s.getRepoBrowserLastChanged,
+		documentOperation("get-repo-browser-last-changed", "Get repository browser last changed commits", "Repositories"))
+	huma.Get(api, hostRepoPath+"/browser/last-changed", s.getRepoBrowserLastChangedOnHost,
+		documentOperation("get-repo-browser-last-changed-on-host", "Get repository browser last changed commits", "Repositories"))
+	huma.Get(api, repoPath+"/browser/history", s.getRepoBrowserHistory,
+		documentOperation("get-repo-browser-history", "Get repository browser file history", "Repositories"))
+	huma.Get(api, hostRepoPath+"/browser/history", s.getRepoBrowserHistoryOnHost,
+		documentOperation("get-repo-browser-history-on-host", "Get repository browser file history", "Repositories"))
+	huma.Get(api, repoPath+"/browser/commit", s.getRepoBrowserCommit,
+		documentOperation("get-repo-browser-commit", "Get repository browser commit", "Repositories"))
+	huma.Get(api, hostRepoPath+"/browser/commit", s.getRepoBrowserCommitOnHost,
+		documentOperation("get-repo-browser-commit-on-host", "Get repository browser commit", "Repositories"))
 	huma.Get(api, repoPath+"/commits/{sha}/diff", s.getRepoCommitDiff,
 		documentOperation("get-repo-commit-diff", "Get repository commit diff", "Repositories"))
 	huma.Get(api, hostRepoPath+"/commits/{sha}/diff", s.getRepoCommitDiffOnHost,

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -1266,6 +1266,7 @@ func (s *Server) registerProviderRepoAPI(api huma.API) {
 		Path:          repoPath + "/browser/asset",
 		DefaultStatus: http.StatusOK,
 		Summary:       "Get repository browser asset",
+		Description:   "Returns raw image bytes for a repository file. Asset reads require ref_type=commit with ref_sha set to a full 40-character commit SHA; branch and tag refs are rejected with mutable_ref_not_allowed.",
 		Tags:          []string{"Repositories"},
 		Responses:     repoBrowserAssetResponses(),
 	}, s.getRepoBrowserAsset)
@@ -1275,6 +1276,7 @@ func (s *Server) registerProviderRepoAPI(api huma.API) {
 		Path:          hostRepoPath + "/browser/asset",
 		DefaultStatus: http.StatusOK,
 		Summary:       "Get repository browser asset",
+		Description:   "Returns raw image bytes for a repository file. Asset reads require ref_type=commit with ref_sha set to a full 40-character commit SHA; branch and tag refs are rejected with mutable_ref_not_allowed.",
 		Tags:          []string{"Repositories"},
 		Responses:     repoBrowserAssetResponses(),
 	}, s.getRepoBrowserAssetOnHost)

--- a/internal/server/repo_browser.go
+++ b/internal/server/repo_browser.go
@@ -263,6 +263,9 @@ func (s *Server) getRepoBrowserAssetFor(
 	ref gitclone.RepoBrowserRef,
 	path string,
 ) (*repoBrowserAssetOutput, error) {
+	if !repoBrowserAssetRefIsImmutable(ref) {
+		return nil, repoBrowserProblem(errRepoBrowserMutableAssetRef)
+	}
 	_, repoRef, err := s.ensureRepoBrowserClone(ctx, provider, platformHost, owner, name, repoPath)
 	if err != nil {
 		return nil, repoBrowserProblem(err)
@@ -282,6 +285,25 @@ func (s *Server) getRepoBrowserAssetFor(
 		ContentTypeOptions: "nosniff",
 		Body:               []byte(blob.Content),
 	}, nil
+}
+
+func repoBrowserAssetRefIsImmutable(ref gitclone.RepoBrowserRef) bool {
+	return ref.Type == gitclone.RepoBrowserRefCommit && isRepoBrowserFullHexSHA(ref.SHA)
+}
+
+func isRepoBrowserFullHexSHA(value string) bool {
+	if len(value) != 40 {
+		return false
+	}
+	for _, ch := range value {
+		if (ch >= '0' && ch <= '9') ||
+			(ch >= 'a' && ch <= 'f') ||
+			(ch >= 'A' && ch <= 'F') {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func (s *Server) getRepoBrowserLastChanged(
@@ -465,6 +487,7 @@ func canonicalRepoBrowserRepoPath(owner, name, repoPath string) string {
 }
 
 var errRepoBrowserCloneUnavailable = errors.New("repo browser clone unavailable")
+var errRepoBrowserMutableAssetRef = errors.New("repo browser asset requires immutable commit ref")
 
 func repoBrowserRef(refType, name, sha string) gitclone.RepoBrowserRef {
 	typ := gitclone.RepoBrowserRefType(strings.TrimSpace(refType))
@@ -490,6 +513,9 @@ func repoBrowserProblem(err error) error {
 	}
 	if errors.Is(err, errRepoBrowserCloneUnavailable) {
 		return problemNotFound(CodeNotFound, "repo browser clone unavailable", map[string]any{"reason": "clone_unavailable"})
+	}
+	if errors.Is(err, errRepoBrowserMutableAssetRef) {
+		return problemBadRequest(CodeBadRequest, err.Error(), map[string]any{"reason": "mutable_ref_not_allowed"})
 	}
 	if errors.Is(err, gitclone.ErrUnsafePath) {
 		return problemBadRequest(CodeBadRequest, err.Error(), map[string]any{"reason": "unsafe_path"})

--- a/internal/server/repo_browser.go
+++ b/internal/server/repo_browser.go
@@ -1,0 +1,460 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"go.kenn.io/middleman/internal/db"
+	"go.kenn.io/middleman/internal/gitclone"
+)
+
+type repoBrowserInput struct {
+	Provider     string `path:"provider"`
+	PlatformHost string
+	Owner        string `path:"owner"`
+	Name         string `path:"name"`
+	RepoPath     string `query:"repo_path"`
+}
+
+type repoBrowserHostInput struct {
+	Provider     string `path:"provider"`
+	PlatformHost string `path:"platform_host"`
+	Owner        string `path:"owner"`
+	Name         string `path:"name"`
+	RepoPath     string `query:"repo_path"`
+}
+
+type repoBrowserRefInput struct {
+	Provider     string `path:"provider"`
+	PlatformHost string
+	Owner        string `path:"owner"`
+	Name         string `path:"name"`
+	RepoPath     string `query:"repo_path"`
+	RefType      string `query:"ref_type"`
+	RefName      string `query:"ref_name"`
+	RefSHA       string `query:"ref_sha"`
+}
+
+type repoBrowserHostRefInput struct {
+	Provider     string `path:"provider"`
+	PlatformHost string `path:"platform_host"`
+	Owner        string `path:"owner"`
+	Name         string `path:"name"`
+	RepoPath     string `query:"repo_path"`
+	RefType      string `query:"ref_type"`
+	RefName      string `query:"ref_name"`
+	RefSHA       string `query:"ref_sha"`
+}
+
+type repoBrowserPathInput struct {
+	Provider     string `path:"provider"`
+	PlatformHost string
+	Owner        string `path:"owner"`
+	Name         string `path:"name"`
+	RepoPath     string `query:"repo_path"`
+	RefType      string `query:"ref_type"`
+	RefName      string `query:"ref_name"`
+	RefSHA       string `query:"ref_sha"`
+	Path         string `query:"path"`
+}
+
+type repoBrowserHostPathInput struct {
+	Provider     string `path:"provider"`
+	PlatformHost string `path:"platform_host"`
+	Owner        string `path:"owner"`
+	Name         string `path:"name"`
+	RepoPath     string `query:"repo_path"`
+	RefType      string `query:"ref_type"`
+	RefName      string `query:"ref_name"`
+	RefSHA       string `query:"ref_sha"`
+	Path         string `query:"path"`
+}
+
+type repoBrowserLastChangedInput struct {
+	Provider     string `path:"provider"`
+	PlatformHost string
+	Owner        string   `path:"owner"`
+	Name         string   `path:"name"`
+	RepoPath     string   `query:"repo_path"`
+	RefType      string   `query:"ref_type"`
+	RefName      string   `query:"ref_name"`
+	RefSHA       string   `query:"ref_sha"`
+	Paths        []string `query:"path,explode"`
+}
+
+type repoBrowserHostLastChangedInput struct {
+	Provider     string   `path:"provider"`
+	PlatformHost string   `path:"platform_host"`
+	Owner        string   `path:"owner"`
+	Name         string   `path:"name"`
+	RepoPath     string   `query:"repo_path"`
+	RefType      string   `query:"ref_type"`
+	RefName      string   `query:"ref_name"`
+	RefSHA       string   `query:"ref_sha"`
+	Paths        []string `query:"path,explode"`
+}
+
+type repoBrowserCommitInput struct {
+	Provider     string `path:"provider"`
+	PlatformHost string
+	Owner        string `path:"owner"`
+	Name         string `path:"name"`
+	RepoPath     string `query:"repo_path"`
+	RefType      string `query:"ref_type"`
+	RefName      string `query:"ref_name"`
+	RefSHA       string `query:"ref_sha"`
+	Path         string `query:"path"`
+	SHA          string `query:"sha"`
+}
+
+type repoBrowserHostCommitInput struct {
+	Provider     string `path:"provider"`
+	PlatformHost string `path:"platform_host"`
+	Owner        string `path:"owner"`
+	Name         string `path:"name"`
+	RepoPath     string `query:"repo_path"`
+	RefType      string `query:"ref_type"`
+	RefName      string `query:"ref_name"`
+	RefSHA       string `query:"ref_sha"`
+	Path         string `query:"path"`
+	SHA          string `query:"sha"`
+}
+
+type repoBrowserAssetOutput struct {
+	ContentType        string `header:"Content-Type"`
+	CacheControl       string `header:"Cache-Control"`
+	ContentLength      string `header:"Content-Length"`
+	ContentTypeOptions string `header:"X-Content-Type-Options"`
+	Body               []byte
+}
+
+func (s *Server) listRepoBrowserRefs(
+	ctx context.Context,
+	input *repoBrowserInput,
+) (*bodyOutput[repoBrowserRefsResponse], error) {
+	return s.listRepoBrowserRefsFor(ctx, input.Provider, input.PlatformHost, input.RepoPath)
+}
+
+func (s *Server) listRepoBrowserRefsOnHost(
+	ctx context.Context,
+	input *repoBrowserHostInput,
+) (*bodyOutput[repoBrowserRefsResponse], error) {
+	return s.listRepoBrowserRefsFor(ctx, input.Provider, input.PlatformHost, input.RepoPath)
+}
+
+func (s *Server) listRepoBrowserRefsFor(
+	ctx context.Context,
+	provider, platformHost, repoPath string,
+) (*bodyOutput[repoBrowserRefsResponse], error) {
+	repo, repoRef, err := s.ensureRepoBrowserClone(ctx, provider, platformHost, repoPath)
+	if err != nil {
+		return nil, repoBrowserProblem(err)
+	}
+	refs, defaultRef, err := s.clones.ListRepoBrowserRefs(ctx, repoRef, repo.DefaultBranch)
+	if err != nil {
+		return nil, repoBrowserProblem(err)
+	}
+	return &bodyOutput[repoBrowserRefsResponse]{Body: repoBrowserRefsResponse{
+		Repo:       s.repoRefFromRepo(*repo),
+		Refs:       refs,
+		DefaultRef: defaultRef,
+	}}, nil
+}
+
+func (s *Server) listRepoBrowserTree(
+	ctx context.Context,
+	input *repoBrowserRefInput,
+) (*bodyOutput[repoBrowserTreeResponse], error) {
+	return s.listRepoBrowserTreeFor(ctx, input.Provider, input.PlatformHost, input.RepoPath, repoBrowserRef(input.RefType, input.RefName, input.RefSHA))
+}
+
+func (s *Server) listRepoBrowserTreeOnHost(
+	ctx context.Context,
+	input *repoBrowserHostRefInput,
+) (*bodyOutput[repoBrowserTreeResponse], error) {
+	return s.listRepoBrowserTreeFor(ctx, input.Provider, input.PlatformHost, input.RepoPath, repoBrowserRef(input.RefType, input.RefName, input.RefSHA))
+}
+
+func (s *Server) listRepoBrowserTreeFor(
+	ctx context.Context,
+	provider, platformHost, repoPath string,
+	ref gitclone.RepoBrowserRef,
+) (*bodyOutput[repoBrowserTreeResponse], error) {
+	repo, repoRef, err := s.ensureRepoBrowserClone(ctx, provider, platformHost, repoPath)
+	if err != nil {
+		return nil, repoBrowserProblem(err)
+	}
+	entries, truncated, err := s.clones.ListRepoBrowserTree(ctx, repoRef, ref)
+	if err != nil {
+		return nil, repoBrowserProblem(err)
+	}
+	return &bodyOutput[repoBrowserTreeResponse]{Body: repoBrowserTreeResponse{
+		Repo:      s.repoRefFromRepo(*repo),
+		Ref:       ref,
+		Entries:   entries,
+		Truncated: truncated,
+	}}, nil
+}
+
+func (s *Server) getRepoBrowserBlob(
+	ctx context.Context,
+	input *repoBrowserPathInput,
+) (*bodyOutput[repoBrowserBlobResponse], error) {
+	return s.getRepoBrowserBlobFor(ctx, input.Provider, input.PlatformHost, input.RepoPath, repoBrowserRef(input.RefType, input.RefName, input.RefSHA), input.Path)
+}
+
+func (s *Server) getRepoBrowserBlobOnHost(
+	ctx context.Context,
+	input *repoBrowserHostPathInput,
+) (*bodyOutput[repoBrowserBlobResponse], error) {
+	return s.getRepoBrowserBlobFor(ctx, input.Provider, input.PlatformHost, input.RepoPath, repoBrowserRef(input.RefType, input.RefName, input.RefSHA), input.Path)
+}
+
+func (s *Server) getRepoBrowserBlobFor(
+	ctx context.Context,
+	provider, platformHost, repoPath string,
+	ref gitclone.RepoBrowserRef,
+	path string,
+) (*bodyOutput[repoBrowserBlobResponse], error) {
+	repo, repoRef, err := s.ensureRepoBrowserClone(ctx, provider, platformHost, repoPath)
+	if err != nil {
+		return nil, repoBrowserProblem(err)
+	}
+	blob, err := s.clones.ReadRepoBrowserBlob(ctx, repoRef, ref, path)
+	if err != nil {
+		return nil, repoBrowserProblem(err)
+	}
+	return &bodyOutput[repoBrowserBlobResponse]{Body: repoBrowserBlobResponse{
+		Repo: s.repoRefFromRepo(*repo),
+		Ref:  ref,
+		Blob: blob,
+	}}, nil
+}
+
+func (s *Server) getRepoBrowserAsset(
+	ctx context.Context,
+	input *repoBrowserPathInput,
+) (*repoBrowserAssetOutput, error) {
+	return s.getRepoBrowserAssetFor(ctx, input.Provider, input.PlatformHost, input.RepoPath, repoBrowserRef(input.RefType, input.RefName, input.RefSHA), input.Path)
+}
+
+func (s *Server) getRepoBrowserAssetOnHost(
+	ctx context.Context,
+	input *repoBrowserHostPathInput,
+) (*repoBrowserAssetOutput, error) {
+	return s.getRepoBrowserAssetFor(ctx, input.Provider, input.PlatformHost, input.RepoPath, repoBrowserRef(input.RefType, input.RefName, input.RefSHA), input.Path)
+}
+
+func (s *Server) getRepoBrowserAssetFor(
+	ctx context.Context,
+	provider, platformHost, repoPath string,
+	ref gitclone.RepoBrowserRef,
+	path string,
+) (*repoBrowserAssetOutput, error) {
+	_, repoRef, err := s.ensureRepoBrowserClone(ctx, provider, platformHost, repoPath)
+	if err != nil {
+		return nil, repoBrowserProblem(err)
+	}
+	blob, err := s.clones.ReadRepoBrowserAsset(ctx, repoRef, ref, path)
+	if err != nil {
+		return nil, repoBrowserProblem(err)
+	}
+	return &repoBrowserAssetOutput{
+		ContentType:        blob.MediaType,
+		CacheControl:       "private, max-age=300",
+		ContentLength:      strconvFormatInt(blob.Size),
+		ContentTypeOptions: "nosniff",
+		Body:               []byte(blob.Content),
+	}, nil
+}
+
+func (s *Server) getRepoBrowserLastChanged(
+	ctx context.Context,
+	input *repoBrowserLastChangedInput,
+) (*bodyOutput[repoBrowserLastChangedResponse], error) {
+	return s.getRepoBrowserLastChangedFor(ctx, input.Provider, input.PlatformHost, input.RepoPath, repoBrowserRef(input.RefType, input.RefName, input.RefSHA), input.Paths)
+}
+
+func (s *Server) getRepoBrowserLastChangedOnHost(
+	ctx context.Context,
+	input *repoBrowserHostLastChangedInput,
+) (*bodyOutput[repoBrowserLastChangedResponse], error) {
+	return s.getRepoBrowserLastChangedFor(ctx, input.Provider, input.PlatformHost, input.RepoPath, repoBrowserRef(input.RefType, input.RefName, input.RefSHA), input.Paths)
+}
+
+func (s *Server) getRepoBrowserLastChangedFor(
+	ctx context.Context,
+	provider, platformHost, repoPath string,
+	ref gitclone.RepoBrowserRef,
+	paths []string,
+) (*bodyOutput[repoBrowserLastChangedResponse], error) {
+	repo, repoRef, err := s.ensureRepoBrowserClone(ctx, provider, platformHost, repoPath)
+	if err != nil {
+		return nil, repoBrowserProblem(err)
+	}
+	commits, err := s.clones.RepoBrowserLastChanged(ctx, repoRef, ref, paths)
+	if err != nil {
+		return nil, repoBrowserProblem(err)
+	}
+	return &bodyOutput[repoBrowserLastChangedResponse]{Body: repoBrowserLastChangedResponse{
+		Repo:    s.repoRefFromRepo(*repo),
+		Ref:     ref,
+		Commits: commits,
+	}}, nil
+}
+
+func (s *Server) getRepoBrowserHistory(
+	ctx context.Context,
+	input *repoBrowserPathInput,
+) (*bodyOutput[repoBrowserHistoryResponse], error) {
+	return s.getRepoBrowserHistoryFor(ctx, input.Provider, input.PlatformHost, input.RepoPath, repoBrowserRef(input.RefType, input.RefName, input.RefSHA), input.Path)
+}
+
+func (s *Server) getRepoBrowserHistoryOnHost(
+	ctx context.Context,
+	input *repoBrowserHostPathInput,
+) (*bodyOutput[repoBrowserHistoryResponse], error) {
+	return s.getRepoBrowserHistoryFor(ctx, input.Provider, input.PlatformHost, input.RepoPath, repoBrowserRef(input.RefType, input.RefName, input.RefSHA), input.Path)
+}
+
+func (s *Server) getRepoBrowserHistoryFor(
+	ctx context.Context,
+	provider, platformHost, repoPath string,
+	ref gitclone.RepoBrowserRef,
+	path string,
+) (*bodyOutput[repoBrowserHistoryResponse], error) {
+	repo, repoRef, err := s.ensureRepoBrowserClone(ctx, provider, platformHost, repoPath)
+	if err != nil {
+		return nil, repoBrowserProblem(err)
+	}
+	commits, err := s.clones.RepoBrowserFileHistory(ctx, repoRef, ref, path)
+	if err != nil {
+		return nil, repoBrowserProblem(err)
+	}
+	return &bodyOutput[repoBrowserHistoryResponse]{Body: repoBrowserHistoryResponse{
+		Repo:    s.repoRefFromRepo(*repo),
+		Ref:     ref,
+		Path:    path,
+		Commits: commits,
+	}}, nil
+}
+
+func (s *Server) getRepoBrowserCommit(
+	ctx context.Context,
+	input *repoBrowserCommitInput,
+) (*bodyOutput[repoBrowserCommitResponse], error) {
+	return s.getRepoBrowserCommitFor(ctx, input.Provider, input.PlatformHost, input.RepoPath, repoBrowserRef(input.RefType, input.RefName, input.RefSHA), input.Path, input.SHA)
+}
+
+func (s *Server) getRepoBrowserCommitOnHost(
+	ctx context.Context,
+	input *repoBrowserHostCommitInput,
+) (*bodyOutput[repoBrowserCommitResponse], error) {
+	return s.getRepoBrowserCommitFor(ctx, input.Provider, input.PlatformHost, input.RepoPath, repoBrowserRef(input.RefType, input.RefName, input.RefSHA), input.Path, input.SHA)
+}
+
+func (s *Server) getRepoBrowserCommitFor(
+	ctx context.Context,
+	provider, platformHost, repoPath string,
+	ref gitclone.RepoBrowserRef,
+	path, sha string,
+) (*bodyOutput[repoBrowserCommitResponse], error) {
+	repo, repoRef, err := s.ensureRepoBrowserClone(ctx, provider, platformHost, repoPath)
+	if err != nil {
+		return nil, repoBrowserProblem(err)
+	}
+	commit, err := s.clones.RepoBrowserCommitDetail(ctx, repoRef, ref, path, sha)
+	if err != nil {
+		return nil, repoBrowserProblem(err)
+	}
+	return &bodyOutput[repoBrowserCommitResponse]{Body: repoBrowserCommitResponse{
+		Repo:   s.repoRefFromRepo(*repo),
+		Ref:    ref,
+		Path:   path,
+		Commit: commit,
+	}}, nil
+}
+
+func (s *Server) ensureRepoBrowserClone(
+	ctx context.Context,
+	provider, platformHost, repoPath string,
+) (*db.Repo, gitclone.RepoBrowserRepoRef, error) {
+	if s.clones == nil {
+		return nil, gitclone.RepoBrowserRepoRef{}, errRepoBrowserCloneUnavailable
+	}
+	repo, err := s.lookupRepoByRefInput(ctx, repoRefInput{
+		Provider:     provider,
+		PlatformHost: platformHost,
+		RepoPath:     repoPath,
+	})
+	if err != nil {
+		return nil, gitclone.RepoBrowserRepoRef{}, err
+	}
+	if strings.TrimSpace(repo.CloneURL) == "" {
+		return nil, gitclone.RepoBrowserRepoRef{}, errRepoBrowserCloneUnavailable
+	}
+	repoRef := gitclone.RepoBrowserRepoRef{
+		Host:      repo.PlatformHost,
+		Owner:     repo.Owner,
+		Name:      repo.Name,
+		RepoPath:  repo.RepoPath,
+		RemoteURL: repo.CloneURL,
+	}
+	if err := s.clones.EnsureClone(ctx, repoRef.Host, repoRef.Owner, repoRef.Name, repoRef.RemoteURL); err != nil {
+		return nil, gitclone.RepoBrowserRepoRef{}, err
+	}
+	return repo, repoRef, nil
+}
+
+var errRepoBrowserCloneUnavailable = errors.New("repo browser clone unavailable")
+
+func repoBrowserRef(refType, name, sha string) gitclone.RepoBrowserRef {
+	typ := gitclone.RepoBrowserRefType(strings.TrimSpace(refType))
+	if typ == "" {
+		typ = gitclone.RepoBrowserRefBranch
+	}
+	return gitclone.RepoBrowserRef{
+		Type: typ,
+		Name: strings.TrimSpace(name),
+		SHA:  strings.TrimSpace(sha),
+	}
+}
+
+func repoBrowserProblem(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, errRepoPathRequired) {
+		return problemBadRequest(CodeBadRequest, err.Error(), map[string]any{"reason": "missing_repo_path"})
+	}
+	if errors.Is(err, errRepoNotFound) {
+		return problemNotFound(CodeRepoNotFound, "repo not found", map[string]any{"reason": "repo_not_found"})
+	}
+	if errors.Is(err, errRepoBrowserCloneUnavailable) {
+		return problemNotFound(CodeNotFound, "repo browser clone unavailable", map[string]any{"reason": "clone_unavailable"})
+	}
+	if errors.Is(err, gitclone.ErrUnsafePath) {
+		return problemBadRequest(CodeBadRequest, err.Error(), map[string]any{"reason": "unsafe_path"})
+	}
+	if errors.Is(err, gitclone.ErrTooManyPaths) {
+		return problemBadRequest(CodeBadRequest, err.Error(), map[string]any{"reason": "too_many_paths"})
+	}
+	if errors.Is(err, gitclone.ErrTooLarge) || errors.Is(err, gitclone.ErrTooLargeAsset) {
+		return newProblem(http.StatusRequestEntityTooLarge, CodeBadRequest, err.Error(), map[string]any{"reason": "too_large"})
+	}
+	if errors.Is(err, gitclone.ErrNotFound) {
+		return problemNotFound(CodeNotFound, err.Error(), map[string]any{"reason": "not_found"})
+	}
+	if strings.Contains(err.Error(), "platform_host is required") ||
+		strings.Contains(err.Error(), "unsupported platform") {
+		return problemBadRequest(CodeBadRequest, err.Error(), nil)
+	}
+	return problemInternal(err.Error())
+}
+
+func strconvFormatInt(v int64) string {
+	return strconv.FormatInt(v, 10)
+}

--- a/internal/server/repo_browser.go
+++ b/internal/server/repo_browser.go
@@ -501,6 +501,9 @@ func repoBrowserProblem(err error) error {
 	if errors.Is(err, gitclone.ErrUnsupportedAsset) {
 		return newProblem(http.StatusUnsupportedMediaType, CodeBadRequest, err.Error(), map[string]any{"reason": "unsupported_asset"})
 	}
+	if errors.Is(err, gitclone.ErrCommitOutOfScope) {
+		return problemNotFound(CodeNotFound, err.Error(), map[string]any{"reason": "commit_out_of_scope"})
+	}
 	if errors.Is(err, gitclone.ErrNotFound) {
 		return problemNotFound(CodeNotFound, err.Error(), map[string]any{"reason": "not_found"})
 	}

--- a/internal/server/repo_browser.go
+++ b/internal/server/repo_browser.go
@@ -153,7 +153,7 @@ func (s *Server) listRepoBrowserRefsFor(
 	if err != nil {
 		return nil, repoBrowserProblem(err)
 	}
-	refs, defaultRef, err := s.clones.ListRepoBrowserRefs(ctx, repoRef, repo.DefaultBranch)
+	refs, defaultRef, truncated, err := s.clones.ListRepoBrowserRefs(ctx, repoRef, repo.DefaultBranch)
 	if err != nil {
 		return nil, repoBrowserProblem(err)
 	}
@@ -161,6 +161,7 @@ func (s *Server) listRepoBrowserRefsFor(
 		Repo:       s.repoRefFromRepo(*repo),
 		Refs:       refs,
 		DefaultRef: defaultRef,
+		Truncated:  truncated,
 	}}, nil
 }
 

--- a/internal/server/repo_browser.go
+++ b/internal/server/repo_browser.go
@@ -423,13 +423,14 @@ func (s *Server) ensureRepoBrowserClone(
 		return nil, gitclone.RepoBrowserRepoRef{}, errRepoBrowserCloneUnavailable
 	}
 	repoRef := gitclone.RepoBrowserRepoRef{
+		Provider:  repo.Platform,
 		Host:      repo.PlatformHost,
 		Owner:     repo.Owner,
 		Name:      repo.Name,
 		RepoPath:  repo.RepoPath,
 		RemoteURL: repo.CloneURL,
 	}
-	if err := s.clones.EnsureClone(ctx, repoRef.Host, repoRef.Owner, repoRef.Name, repoRef.RemoteURL); err != nil {
+	if err := s.clones.EnsureRepoBrowserClone(ctx, repoRef); err != nil {
 		return nil, gitclone.RepoBrowserRepoRef{}, err
 	}
 	return repo, repoRef, nil

--- a/internal/server/repo_browser.go
+++ b/internal/server/repo_browser.go
@@ -135,21 +135,21 @@ func (s *Server) listRepoBrowserRefs(
 	ctx context.Context,
 	input *repoBrowserInput,
 ) (*bodyOutput[repoBrowserRefsResponse], error) {
-	return s.listRepoBrowserRefsFor(ctx, input.Provider, input.PlatformHost, input.RepoPath)
+	return s.listRepoBrowserRefsFor(ctx, input.Provider, input.PlatformHost, input.Owner, input.Name, input.RepoPath)
 }
 
 func (s *Server) listRepoBrowserRefsOnHost(
 	ctx context.Context,
 	input *repoBrowserHostInput,
 ) (*bodyOutput[repoBrowserRefsResponse], error) {
-	return s.listRepoBrowserRefsFor(ctx, input.Provider, input.PlatformHost, input.RepoPath)
+	return s.listRepoBrowserRefsFor(ctx, input.Provider, input.PlatformHost, input.Owner, input.Name, input.RepoPath)
 }
 
 func (s *Server) listRepoBrowserRefsFor(
 	ctx context.Context,
-	provider, platformHost, repoPath string,
+	provider, platformHost, owner, name, repoPath string,
 ) (*bodyOutput[repoBrowserRefsResponse], error) {
-	repo, repoRef, err := s.ensureRepoBrowserClone(ctx, provider, platformHost, repoPath)
+	repo, repoRef, err := s.ensureRepoBrowserClone(ctx, provider, platformHost, owner, name, repoPath)
 	if err != nil {
 		return nil, repoBrowserProblem(err)
 	}
@@ -168,32 +168,36 @@ func (s *Server) listRepoBrowserTree(
 	ctx context.Context,
 	input *repoBrowserRefInput,
 ) (*bodyOutput[repoBrowserTreeResponse], error) {
-	return s.listRepoBrowserTreeFor(ctx, input.Provider, input.PlatformHost, input.RepoPath, repoBrowserRef(input.RefType, input.RefName, input.RefSHA))
+	return s.listRepoBrowserTreeFor(ctx, input.Provider, input.PlatformHost, input.Owner, input.Name, input.RepoPath, repoBrowserRef(input.RefType, input.RefName, input.RefSHA))
 }
 
 func (s *Server) listRepoBrowserTreeOnHost(
 	ctx context.Context,
 	input *repoBrowserHostRefInput,
 ) (*bodyOutput[repoBrowserTreeResponse], error) {
-	return s.listRepoBrowserTreeFor(ctx, input.Provider, input.PlatformHost, input.RepoPath, repoBrowserRef(input.RefType, input.RefName, input.RefSHA))
+	return s.listRepoBrowserTreeFor(ctx, input.Provider, input.PlatformHost, input.Owner, input.Name, input.RepoPath, repoBrowserRef(input.RefType, input.RefName, input.RefSHA))
 }
 
 func (s *Server) listRepoBrowserTreeFor(
 	ctx context.Context,
-	provider, platformHost, repoPath string,
+	provider, platformHost, owner, name, repoPath string,
 	ref gitclone.RepoBrowserRef,
 ) (*bodyOutput[repoBrowserTreeResponse], error) {
-	repo, repoRef, err := s.ensureRepoBrowserClone(ctx, provider, platformHost, repoPath)
+	repo, repoRef, err := s.ensureRepoBrowserClone(ctx, provider, platformHost, owner, name, repoPath)
 	if err != nil {
 		return nil, repoBrowserProblem(err)
 	}
-	entries, truncated, err := s.clones.ListRepoBrowserTree(ctx, repoRef, ref)
+	resolvedRef, err := s.resolveRepoBrowserReadRef(ctx, repoRef, ref)
+	if err != nil {
+		return nil, repoBrowserProblem(err)
+	}
+	entries, truncated, err := s.clones.ListRepoBrowserTree(ctx, repoRef, repoBrowserPinnedRef(resolvedRef))
 	if err != nil {
 		return nil, repoBrowserProblem(err)
 	}
 	return &bodyOutput[repoBrowserTreeResponse]{Body: repoBrowserTreeResponse{
 		Repo:      s.repoRefFromRepo(*repo),
-		Ref:       ref,
+		Ref:       resolvedRef,
 		Entries:   entries,
 		Truncated: truncated,
 	}}, nil
@@ -203,33 +207,37 @@ func (s *Server) getRepoBrowserBlob(
 	ctx context.Context,
 	input *repoBrowserPathInput,
 ) (*bodyOutput[repoBrowserBlobResponse], error) {
-	return s.getRepoBrowserBlobFor(ctx, input.Provider, input.PlatformHost, input.RepoPath, repoBrowserRef(input.RefType, input.RefName, input.RefSHA), input.Path)
+	return s.getRepoBrowserBlobFor(ctx, input.Provider, input.PlatformHost, input.Owner, input.Name, input.RepoPath, repoBrowserRef(input.RefType, input.RefName, input.RefSHA), input.Path)
 }
 
 func (s *Server) getRepoBrowserBlobOnHost(
 	ctx context.Context,
 	input *repoBrowserHostPathInput,
 ) (*bodyOutput[repoBrowserBlobResponse], error) {
-	return s.getRepoBrowserBlobFor(ctx, input.Provider, input.PlatformHost, input.RepoPath, repoBrowserRef(input.RefType, input.RefName, input.RefSHA), input.Path)
+	return s.getRepoBrowserBlobFor(ctx, input.Provider, input.PlatformHost, input.Owner, input.Name, input.RepoPath, repoBrowserRef(input.RefType, input.RefName, input.RefSHA), input.Path)
 }
 
 func (s *Server) getRepoBrowserBlobFor(
 	ctx context.Context,
-	provider, platformHost, repoPath string,
+	provider, platformHost, owner, name, repoPath string,
 	ref gitclone.RepoBrowserRef,
 	path string,
 ) (*bodyOutput[repoBrowserBlobResponse], error) {
-	repo, repoRef, err := s.ensureRepoBrowserClone(ctx, provider, platformHost, repoPath)
+	repo, repoRef, err := s.ensureRepoBrowserClone(ctx, provider, platformHost, owner, name, repoPath)
 	if err != nil {
 		return nil, repoBrowserProblem(err)
 	}
-	blob, err := s.clones.ReadRepoBrowserBlob(ctx, repoRef, ref, path)
+	resolvedRef, err := s.resolveRepoBrowserReadRef(ctx, repoRef, ref)
+	if err != nil {
+		return nil, repoBrowserProblem(err)
+	}
+	blob, err := s.clones.ReadRepoBrowserBlob(ctx, repoRef, repoBrowserPinnedRef(resolvedRef), path)
 	if err != nil {
 		return nil, repoBrowserProblem(err)
 	}
 	return &bodyOutput[repoBrowserBlobResponse]{Body: repoBrowserBlobResponse{
 		Repo: s.repoRefFromRepo(*repo),
-		Ref:  ref,
+		Ref:  resolvedRef,
 		Blob: blob,
 	}}, nil
 }
@@ -238,27 +246,31 @@ func (s *Server) getRepoBrowserAsset(
 	ctx context.Context,
 	input *repoBrowserPathInput,
 ) (*repoBrowserAssetOutput, error) {
-	return s.getRepoBrowserAssetFor(ctx, input.Provider, input.PlatformHost, input.RepoPath, repoBrowserRef(input.RefType, input.RefName, input.RefSHA), input.Path)
+	return s.getRepoBrowserAssetFor(ctx, input.Provider, input.PlatformHost, input.Owner, input.Name, input.RepoPath, repoBrowserRef(input.RefType, input.RefName, input.RefSHA), input.Path)
 }
 
 func (s *Server) getRepoBrowserAssetOnHost(
 	ctx context.Context,
 	input *repoBrowserHostPathInput,
 ) (*repoBrowserAssetOutput, error) {
-	return s.getRepoBrowserAssetFor(ctx, input.Provider, input.PlatformHost, input.RepoPath, repoBrowserRef(input.RefType, input.RefName, input.RefSHA), input.Path)
+	return s.getRepoBrowserAssetFor(ctx, input.Provider, input.PlatformHost, input.Owner, input.Name, input.RepoPath, repoBrowserRef(input.RefType, input.RefName, input.RefSHA), input.Path)
 }
 
 func (s *Server) getRepoBrowserAssetFor(
 	ctx context.Context,
-	provider, platformHost, repoPath string,
+	provider, platformHost, owner, name, repoPath string,
 	ref gitclone.RepoBrowserRef,
 	path string,
 ) (*repoBrowserAssetOutput, error) {
-	_, repoRef, err := s.ensureRepoBrowserClone(ctx, provider, platformHost, repoPath)
+	_, repoRef, err := s.ensureRepoBrowserClone(ctx, provider, platformHost, owner, name, repoPath)
 	if err != nil {
 		return nil, repoBrowserProblem(err)
 	}
-	blob, err := s.clones.ReadRepoBrowserAsset(ctx, repoRef, ref, path)
+	resolvedRef, err := s.resolveRepoBrowserReadRef(ctx, repoRef, ref)
+	if err != nil {
+		return nil, repoBrowserProblem(err)
+	}
+	blob, err := s.clones.ReadRepoBrowserAsset(ctx, repoRef, repoBrowserPinnedRef(resolvedRef), path)
 	if err != nil {
 		return nil, repoBrowserProblem(err)
 	}
@@ -275,33 +287,37 @@ func (s *Server) getRepoBrowserLastChanged(
 	ctx context.Context,
 	input *repoBrowserLastChangedInput,
 ) (*bodyOutput[repoBrowserLastChangedResponse], error) {
-	return s.getRepoBrowserLastChangedFor(ctx, input.Provider, input.PlatformHost, input.RepoPath, repoBrowserRef(input.RefType, input.RefName, input.RefSHA), input.Paths)
+	return s.getRepoBrowserLastChangedFor(ctx, input.Provider, input.PlatformHost, input.Owner, input.Name, input.RepoPath, repoBrowserRef(input.RefType, input.RefName, input.RefSHA), input.Paths)
 }
 
 func (s *Server) getRepoBrowserLastChangedOnHost(
 	ctx context.Context,
 	input *repoBrowserHostLastChangedInput,
 ) (*bodyOutput[repoBrowserLastChangedResponse], error) {
-	return s.getRepoBrowserLastChangedFor(ctx, input.Provider, input.PlatformHost, input.RepoPath, repoBrowserRef(input.RefType, input.RefName, input.RefSHA), input.Paths)
+	return s.getRepoBrowserLastChangedFor(ctx, input.Provider, input.PlatformHost, input.Owner, input.Name, input.RepoPath, repoBrowserRef(input.RefType, input.RefName, input.RefSHA), input.Paths)
 }
 
 func (s *Server) getRepoBrowserLastChangedFor(
 	ctx context.Context,
-	provider, platformHost, repoPath string,
+	provider, platformHost, owner, name, repoPath string,
 	ref gitclone.RepoBrowserRef,
 	paths []string,
 ) (*bodyOutput[repoBrowserLastChangedResponse], error) {
-	repo, repoRef, err := s.ensureRepoBrowserClone(ctx, provider, platformHost, repoPath)
+	repo, repoRef, err := s.ensureRepoBrowserClone(ctx, provider, platformHost, owner, name, repoPath)
 	if err != nil {
 		return nil, repoBrowserProblem(err)
 	}
-	commits, err := s.clones.RepoBrowserLastChanged(ctx, repoRef, ref, paths)
+	resolvedRef, err := s.resolveRepoBrowserReadRef(ctx, repoRef, ref)
+	if err != nil {
+		return nil, repoBrowserProblem(err)
+	}
+	commits, err := s.clones.RepoBrowserLastChanged(ctx, repoRef, repoBrowserPinnedRef(resolvedRef), paths)
 	if err != nil {
 		return nil, repoBrowserProblem(err)
 	}
 	return &bodyOutput[repoBrowserLastChangedResponse]{Body: repoBrowserLastChangedResponse{
 		Repo:    s.repoRefFromRepo(*repo),
-		Ref:     ref,
+		Ref:     resolvedRef,
 		Commits: commits,
 	}}, nil
 }
@@ -310,33 +326,37 @@ func (s *Server) getRepoBrowserHistory(
 	ctx context.Context,
 	input *repoBrowserPathInput,
 ) (*bodyOutput[repoBrowserHistoryResponse], error) {
-	return s.getRepoBrowserHistoryFor(ctx, input.Provider, input.PlatformHost, input.RepoPath, repoBrowserRef(input.RefType, input.RefName, input.RefSHA), input.Path)
+	return s.getRepoBrowserHistoryFor(ctx, input.Provider, input.PlatformHost, input.Owner, input.Name, input.RepoPath, repoBrowserRef(input.RefType, input.RefName, input.RefSHA), input.Path)
 }
 
 func (s *Server) getRepoBrowserHistoryOnHost(
 	ctx context.Context,
 	input *repoBrowserHostPathInput,
 ) (*bodyOutput[repoBrowserHistoryResponse], error) {
-	return s.getRepoBrowserHistoryFor(ctx, input.Provider, input.PlatformHost, input.RepoPath, repoBrowserRef(input.RefType, input.RefName, input.RefSHA), input.Path)
+	return s.getRepoBrowserHistoryFor(ctx, input.Provider, input.PlatformHost, input.Owner, input.Name, input.RepoPath, repoBrowserRef(input.RefType, input.RefName, input.RefSHA), input.Path)
 }
 
 func (s *Server) getRepoBrowserHistoryFor(
 	ctx context.Context,
-	provider, platformHost, repoPath string,
+	provider, platformHost, owner, name, repoPath string,
 	ref gitclone.RepoBrowserRef,
 	path string,
 ) (*bodyOutput[repoBrowserHistoryResponse], error) {
-	repo, repoRef, err := s.ensureRepoBrowserClone(ctx, provider, platformHost, repoPath)
+	repo, repoRef, err := s.ensureRepoBrowserClone(ctx, provider, platformHost, owner, name, repoPath)
 	if err != nil {
 		return nil, repoBrowserProblem(err)
 	}
-	commits, err := s.clones.RepoBrowserFileHistory(ctx, repoRef, ref, path)
+	resolvedRef, err := s.resolveRepoBrowserReadRef(ctx, repoRef, ref)
+	if err != nil {
+		return nil, repoBrowserProblem(err)
+	}
+	commits, err := s.clones.RepoBrowserFileHistory(ctx, repoRef, repoBrowserPinnedRef(resolvedRef), path)
 	if err != nil {
 		return nil, repoBrowserProblem(err)
 	}
 	return &bodyOutput[repoBrowserHistoryResponse]{Body: repoBrowserHistoryResponse{
 		Repo:    s.repoRefFromRepo(*repo),
-		Ref:     ref,
+		Ref:     resolvedRef,
 		Path:    path,
 		Commits: commits,
 	}}, nil
@@ -346,33 +366,37 @@ func (s *Server) getRepoBrowserCommit(
 	ctx context.Context,
 	input *repoBrowserCommitInput,
 ) (*bodyOutput[repoBrowserCommitResponse], error) {
-	return s.getRepoBrowserCommitFor(ctx, input.Provider, input.PlatformHost, input.RepoPath, repoBrowserRef(input.RefType, input.RefName, input.RefSHA), input.Path, input.SHA)
+	return s.getRepoBrowserCommitFor(ctx, input.Provider, input.PlatformHost, input.Owner, input.Name, input.RepoPath, repoBrowserRef(input.RefType, input.RefName, input.RefSHA), input.Path, input.SHA)
 }
 
 func (s *Server) getRepoBrowserCommitOnHost(
 	ctx context.Context,
 	input *repoBrowserHostCommitInput,
 ) (*bodyOutput[repoBrowserCommitResponse], error) {
-	return s.getRepoBrowserCommitFor(ctx, input.Provider, input.PlatformHost, input.RepoPath, repoBrowserRef(input.RefType, input.RefName, input.RefSHA), input.Path, input.SHA)
+	return s.getRepoBrowserCommitFor(ctx, input.Provider, input.PlatformHost, input.Owner, input.Name, input.RepoPath, repoBrowserRef(input.RefType, input.RefName, input.RefSHA), input.Path, input.SHA)
 }
 
 func (s *Server) getRepoBrowserCommitFor(
 	ctx context.Context,
-	provider, platformHost, repoPath string,
+	provider, platformHost, owner, name, repoPath string,
 	ref gitclone.RepoBrowserRef,
 	path, sha string,
 ) (*bodyOutput[repoBrowserCommitResponse], error) {
-	repo, repoRef, err := s.ensureRepoBrowserClone(ctx, provider, platformHost, repoPath)
+	repo, repoRef, err := s.ensureRepoBrowserClone(ctx, provider, platformHost, owner, name, repoPath)
 	if err != nil {
 		return nil, repoBrowserProblem(err)
 	}
-	commit, err := s.clones.RepoBrowserCommitDetail(ctx, repoRef, ref, path, sha)
+	resolvedRef, err := s.resolveRepoBrowserReadRef(ctx, repoRef, ref)
+	if err != nil {
+		return nil, repoBrowserProblem(err)
+	}
+	commit, err := s.clones.RepoBrowserCommitDetail(ctx, repoRef, repoBrowserPinnedRef(resolvedRef), path, sha)
 	if err != nil {
 		return nil, repoBrowserProblem(err)
 	}
 	return &bodyOutput[repoBrowserCommitResponse]{Body: repoBrowserCommitResponse{
 		Repo:   s.repoRefFromRepo(*repo),
-		Ref:    ref,
+		Ref:    resolvedRef,
 		Path:   path,
 		Commit: commit,
 	}}, nil
@@ -380,11 +404,12 @@ func (s *Server) getRepoBrowserCommitFor(
 
 func (s *Server) ensureRepoBrowserClone(
 	ctx context.Context,
-	provider, platformHost, repoPath string,
+	provider, platformHost, owner, name, repoPath string,
 ) (*db.Repo, gitclone.RepoBrowserRepoRef, error) {
 	if s.clones == nil {
 		return nil, gitclone.RepoBrowserRepoRef{}, errRepoBrowserCloneUnavailable
 	}
+	repoPath = canonicalRepoBrowserRepoPath(owner, name, repoPath)
 	repo, err := s.lookupRepoByRefInput(ctx, repoRefInput{
 		Provider:     provider,
 		PlatformHost: platformHost,
@@ -407,6 +432,34 @@ func (s *Server) ensureRepoBrowserClone(
 		return nil, gitclone.RepoBrowserRepoRef{}, err
 	}
 	return repo, repoRef, nil
+}
+
+func (s *Server) resolveRepoBrowserReadRef(
+	ctx context.Context,
+	repo gitclone.RepoBrowserRepoRef,
+	ref gitclone.RepoBrowserRef,
+) (gitclone.RepoBrowserRef, error) {
+	return s.clones.ResolveRepoBrowserRef(ctx, repo, ref)
+}
+
+func repoBrowserPinnedRef(ref gitclone.RepoBrowserRef) gitclone.RepoBrowserRef {
+	return gitclone.RepoBrowserRef{
+		Type: gitclone.RepoBrowserRefCommit,
+		SHA:  ref.SHA,
+	}
+}
+
+func canonicalRepoBrowserRepoPath(owner, name, repoPath string) string {
+	repoPath = strings.Trim(repoPath, "/ ")
+	if repoPath != "" {
+		return repoPath
+	}
+	owner = strings.Trim(owner, "/ ")
+	name = strings.Trim(name, "/ ")
+	if owner == "" || name == "" {
+		return ""
+	}
+	return owner + "/" + name
 }
 
 var errRepoBrowserCloneUnavailable = errors.New("repo browser clone unavailable")
@@ -444,6 +497,9 @@ func repoBrowserProblem(err error) error {
 	}
 	if errors.Is(err, gitclone.ErrTooLarge) || errors.Is(err, gitclone.ErrTooLargeAsset) {
 		return newProblem(http.StatusRequestEntityTooLarge, CodeBadRequest, err.Error(), map[string]any{"reason": "too_large"})
+	}
+	if errors.Is(err, gitclone.ErrUnsupportedAsset) {
+		return newProblem(http.StatusUnsupportedMediaType, CodeBadRequest, err.Error(), map[string]any{"reason": "unsupported_asset"})
 	}
 	if errors.Is(err, gitclone.ErrNotFound) {
 		return problemNotFound(CodeNotFound, err.Error(), map[string]any{"reason": "not_found"})

--- a/internal/server/repo_browser_refresh.go
+++ b/internal/server/repo_browser_refresh.go
@@ -3,7 +3,11 @@ package server
 import (
 	"context"
 	"log/slog"
+	"strings"
 	"time"
+
+	"go.kenn.io/middleman/internal/config"
+	"go.kenn.io/middleman/internal/gitclone"
 )
 
 const defaultRepoBrowserRefreshInterval = 5 * time.Minute
@@ -12,7 +16,10 @@ func (s *Server) runRepoBrowserRefreshLoop(ctx context.Context) {
 	if s.clones == nil {
 		return
 	}
-	interval := s.repoBrowserRefreshInterval()
+	interval := s.repoBrowserRefreshEvery
+	if interval <= 0 {
+		interval = defaultRepoBrowserRefreshInterval
+	}
 	s.runRepoBrowserRefreshPass(ctx)
 
 	ticker := time.NewTicker(interval)
@@ -27,14 +34,53 @@ func (s *Server) runRepoBrowserRefreshLoop(ctx context.Context) {
 	}
 }
 
-func (s *Server) repoBrowserRefreshInterval() time.Duration {
-	if s.cfg == nil {
+func repoBrowserRefreshIntervalForConfig(cfg *config.Config) time.Duration {
+	if cfg == nil {
 		return defaultRepoBrowserRefreshInterval
 	}
-	if interval := s.cfg.SyncDuration(); interval > 0 {
+	if interval := cfg.SyncDuration(); interval > 0 {
 		return interval
 	}
 	return defaultRepoBrowserRefreshInterval
+}
+
+func (s *Server) seedRepoBrowserRefreshRepos(ctx context.Context) {
+	if s.clones == nil || s.db == nil {
+		return
+	}
+	repos, err := s.db.ListRepos(ctx)
+	if err != nil {
+		slog.Warn("failed to seed repo browser refresh repos", "err", err)
+		return
+	}
+	for _, repo := range repos {
+		if strings.TrimSpace(repo.CloneURL) == "" {
+			continue
+		}
+		repoRef := gitclone.RepoBrowserRepoRef{
+			Provider:  repo.Platform,
+			Host:      repo.PlatformHost,
+			Owner:     repo.Owner,
+			Name:      repo.Name,
+			RepoPath:  repo.RepoPath,
+			RemoteURL: repo.CloneURL,
+		}
+		registered, err := s.clones.RegisterExistingRepoBrowserClone(ctx, repoRef)
+		if err != nil {
+			slog.Warn("failed to seed repo browser refresh repo",
+				"provider", repo.Platform,
+				"host", repo.PlatformHost,
+				"repo", repo.RepoPath,
+				"err", err)
+			continue
+		}
+		if registered {
+			slog.Debug("seeded repo browser refresh repo",
+				"provider", repo.Platform,
+				"host", repo.PlatformHost,
+				"repo", repo.RepoPath)
+		}
+	}
 }
 
 func (s *Server) runRepoBrowserRefreshPass(ctx context.Context) {

--- a/internal/server/repo_browser_refresh.go
+++ b/internal/server/repo_browser_refresh.go
@@ -1,0 +1,46 @@
+package server
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+const defaultRepoBrowserRefreshInterval = 5 * time.Minute
+
+func (s *Server) runRepoBrowserRefreshLoop(ctx context.Context) {
+	if s.clones == nil {
+		return
+	}
+	interval := s.repoBrowserRefreshInterval()
+	s.runRepoBrowserRefreshPass(ctx)
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.runRepoBrowserRefreshPass(ctx)
+		}
+	}
+}
+
+func (s *Server) repoBrowserRefreshInterval() time.Duration {
+	if s.cfg == nil {
+		return defaultRepoBrowserRefreshInterval
+	}
+	if interval := s.cfg.SyncDuration(); interval > 0 {
+		return interval
+	}
+	return defaultRepoBrowserRefreshInterval
+}
+
+func (s *Server) runRepoBrowserRefreshPass(ctx context.Context) {
+	if s.clones == nil {
+		return
+	}
+	slog.Debug("refreshing repo browser clones")
+	s.clones.RefreshRepoBrowserClones(ctx)
+}

--- a/internal/server/repo_browser_test.go
+++ b/internal/server/repo_browser_test.go
@@ -212,6 +212,7 @@ func TestRepoBrowserTreeAssetLastChangedAndHistory(t *testing.T) {
 	require.NoError(os.WriteFile(filepath.Join(work, "README.md"), []byte("# Test\n\nUpdated\n"), 0o644))
 	serverRepoBrowserGit(t, work, "add", ".")
 	serverRepoBrowserGit(t, work, "commit", "-m", "docs asset")
+	currentSHA := testGitSHA(t, work, "HEAD")
 	serverRepoBrowserGit(t, work, "push", "origin", "main")
 
 	tree := repoBrowserRequest(t, srv, http.MethodGet,
@@ -224,7 +225,7 @@ func TestRepoBrowserTreeAssetLastChangedAndHistory(t *testing.T) {
 	assert.Contains(repoBrowserEntryPaths(treeBody.Entries), "docs/image.png")
 
 	asset := repoBrowserRequest(t, srv, http.MethodGet,
-		"/api/v1/repo/github/acme/widgets/browser/asset?repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&path=docs%2Fimage.png",
+		"/api/v1/repo/github/acme/widgets/browser/asset?repo_path=acme%2Fwidgets&ref_type=commit&ref_sha="+url.QueryEscape(currentSHA)+"&path=docs%2Fimage.png",
 	)
 	require.Equal(http.StatusOK, asset.Code)
 	assert.Equal("image/png", asset.Header().Get("Content-Type"))
@@ -256,6 +257,18 @@ func TestRepoBrowserTreeAssetLastChangedAndHistory(t *testing.T) {
 	var commitBody repoBrowserCommitResponse
 	require.NoError(json.Unmarshal(commitDetail.Body.Bytes(), &commitBody))
 	assert.Equal(historyBody.Commits[0].SHA, commitBody.Commit.SHA)
+
+	mutableAsset := repoBrowserRequest(t, srv, http.MethodGet,
+		"/api/v1/repo/github/acme/widgets/browser/asset?repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&path=docs%2Fimage.png",
+	)
+	require.Equal(http.StatusBadRequest, mutableAsset.Code)
+	assert.Contains(mutableAsset.Body.String(), "mutable_ref_not_allowed")
+
+	missingHistory := repoBrowserRequest(t, srv, http.MethodGet,
+		"/api/v1/repo/github/acme/widgets/browser/history?repo_path=acme%2Fwidgets&ref_type=commit&ref_sha="+url.QueryEscape(currentSHA)+"&path=missing.md",
+	)
+	require.Equal(http.StatusNotFound, missingHistory.Code)
+	assert.Contains(missingHistory.Body.String(), "not_found")
 }
 
 func TestRepoBrowserLastChangedFallsBackPastBatchLogLimit(t *testing.T) {
@@ -292,11 +305,12 @@ func TestRepoBrowserAssetRejectsActiveContentTypes(t *testing.T) {
 	require.NoError(os.WriteFile(filepath.Join(work, "script.js"), []byte(`alert(1)`), 0o644))
 	serverRepoBrowserGit(t, work, "add", ".")
 	serverRepoBrowserGit(t, work, "commit", "-m", "active assets")
+	currentSHA := testGitSHA(t, work, "HEAD")
 	serverRepoBrowserGit(t, work, "push", "origin", "main")
 
 	for _, path := range []string{"image.svg", "page.html", "script.js"} {
 		rr := repoBrowserRequest(t, srv, http.MethodGet,
-			"/api/v1/repo/github/acme/widgets/browser/asset?ref_type=branch&ref_name=main&path="+url.QueryEscape(path),
+			"/api/v1/repo/github/acme/widgets/browser/asset?ref_type=commit&ref_sha="+url.QueryEscape(currentSHA)+"&path="+url.QueryEscape(path),
 		)
 		assert.Equal(http.StatusUnsupportedMediaType, rr.Code, path)
 		assert.Contains(rr.Body.String(), "unsupported_asset")

--- a/internal/server/repo_browser_test.go
+++ b/internal/server/repo_browser_test.go
@@ -390,6 +390,158 @@ func TestRepoBrowserCommitRejectsSHAOutsideSelectedFileHistory(t *testing.T) {
 	assert.Equal("other file", body.Commit.Subject)
 }
 
+func TestRepoBrowserCommitAcceptsOlderFileHistoryThroughHTTP(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	srv, work := setupRepoBrowserServer(t, "github", "github.com", "acme/widgets")
+	readmeSHA := testGitSHA(t, work, "HEAD")
+
+	for i := range gitclone.RepoBrowserHistoryLimit + 1 {
+		require.NoError(os.WriteFile(
+			filepath.Join(work, fmt.Sprintf("later-%02d.txt", i)),
+			[]byte("later\n"),
+			0o644,
+		))
+		serverRepoBrowserGit(t, work, "add", ".")
+		serverRepoBrowserGit(t, work, "commit", "-m", fmt.Sprintf("later %02d", i))
+	}
+	serverRepoBrowserGit(t, work, "push", "origin", "main")
+
+	rr := repoBrowserRequest(t, srv, http.MethodGet,
+		"/api/v1/repo/github/acme/widgets/browser/commit?ref_type=branch&ref_name=main&path=README.md&sha="+url.QueryEscape(readmeSHA),
+	)
+
+	require.Equal(http.StatusOK, rr.Code)
+	var body repoBrowserCommitResponse
+	require.NoError(json.Unmarshal(rr.Body.Bytes(), &body))
+	assert.Equal(readmeSHA, body.Commit.SHA)
+	assert.Equal("initial", body.Commit.Subject)
+}
+
+func TestRepoBrowserStartupRefreshSeedsExistingClone(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	database := openTestDB(t)
+	remote, work := setupServerRepoBrowserGitRepo(t)
+	repoID, err := database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widgets"))
+	require.NoError(err)
+	require.NoError(database.UpdateRepoProviderMetadata(
+		t.Context(),
+		repoID,
+		db.RepoProviderMetadata{
+			WebURL:        "https://github.com/acme/widgets",
+			CloneURL:      remote,
+			DefaultBranch: "main",
+		},
+	))
+	cloneBase := filepath.Join(t.TempDir(), "clones")
+	initialClones := gitclone.New(cloneBase, nil)
+	initialSyncer := ghclient.NewSyncer(nil, database, nil, nil, time.Minute, nil, nil)
+	t.Cleanup(initialSyncer.Stop)
+	initialServer := New(database, initialSyncer, nil, "/", nil, ServerOptions{
+		Clones:                             initialClones,
+		DisableWorkspaceBackgroundMonitors: true,
+	})
+	initialRefs := repoBrowserRequest(t, initialServer, http.MethodGet,
+		"/api/v1/repo/github/acme/widgets/browser/refs",
+	)
+	require.Equal(http.StatusOK, initialRefs.Code)
+	gracefulShutdown(t, initialServer)
+
+	require.NoError(os.WriteFile(filepath.Join(work, "README.md"), []byte("# Updated\n"), 0o644))
+	serverRepoBrowserGit(t, work, "add", ".")
+	serverRepoBrowserGit(t, work, "commit", "-m", "update readme")
+	updatedSHA := testGitSHA(t, work, "main")
+	serverRepoBrowserGit(t, work, "push", "origin", "main")
+
+	restartedClones := gitclone.New(cloneBase, nil)
+	restartedSyncer := ghclient.NewSyncer(nil, database, nil, nil, time.Minute, nil, nil)
+	t.Cleanup(restartedSyncer.Stop)
+	restartedServer := New(database, restartedSyncer, nil, "/", nil, ServerOptions{Clones: restartedClones})
+	t.Cleanup(func() { gracefulShutdown(t, restartedServer) })
+
+	require.Eventually(func() bool {
+		rr := repoBrowserRequest(t, restartedServer, http.MethodGet,
+			"/api/v1/repo/github/acme/widgets/browser/refs",
+		)
+		if rr.Code != http.StatusOK {
+			return false
+		}
+		var body repoBrowserRefsResponse
+		if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+			return false
+		}
+		return body.DefaultRef.SHA == updatedSHA
+	}, 2*time.Second, 25*time.Millisecond)
+
+	rr := repoBrowserRequest(t, restartedServer, http.MethodGet,
+		"/api/v1/repo/github/acme/widgets/browser/blob?ref_type=branch&ref_name=main&path=README.md",
+	)
+	require.Equal(http.StatusOK, rr.Code)
+	var body repoBrowserBlobResponse
+	require.NoError(json.Unmarshal(rr.Body.Bytes(), &body))
+	assert.Equal("# Updated\n", body.Blob.Content)
+}
+
+func TestRepoBrowserStartupRefreshHonorsDisabledBackgroundMonitors(t *testing.T) {
+	require := require.New(t)
+	database := openTestDB(t)
+	remote, work := setupServerRepoBrowserGitRepo(t)
+	repoID, err := database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widgets"))
+	require.NoError(err)
+	require.NoError(database.UpdateRepoProviderMetadata(
+		t.Context(),
+		repoID,
+		db.RepoProviderMetadata{
+			WebURL:        "https://github.com/acme/widgets",
+			CloneURL:      remote,
+			DefaultBranch: "main",
+		},
+	))
+	cloneBase := filepath.Join(t.TempDir(), "clones")
+	initialClones := gitclone.New(cloneBase, nil)
+	initialSyncer := ghclient.NewSyncer(nil, database, nil, nil, time.Minute, nil, nil)
+	t.Cleanup(initialSyncer.Stop)
+	initialServer := New(database, initialSyncer, nil, "/", nil, ServerOptions{
+		Clones:                             initialClones,
+		DisableWorkspaceBackgroundMonitors: true,
+	})
+	initialRefs := repoBrowserRequest(t, initialServer, http.MethodGet,
+		"/api/v1/repo/github/acme/widgets/browser/refs",
+	)
+	require.Equal(http.StatusOK, initialRefs.Code)
+	gracefulShutdown(t, initialServer)
+
+	require.NoError(os.WriteFile(filepath.Join(work, "README.md"), []byte("# Updated\n"), 0o644))
+	serverRepoBrowserGit(t, work, "add", ".")
+	serverRepoBrowserGit(t, work, "commit", "-m", "update readme")
+	updatedSHA := testGitSHA(t, work, "main")
+	serverRepoBrowserGit(t, work, "push", "origin", "main")
+
+	disabledClones := gitclone.New(cloneBase, nil)
+	disabledSyncer := ghclient.NewSyncer(nil, database, nil, nil, time.Minute, nil, nil)
+	t.Cleanup(disabledSyncer.Stop)
+	disabledServer := New(database, disabledSyncer, nil, "/", nil, ServerOptions{
+		Clones:                             disabledClones,
+		DisableWorkspaceBackgroundMonitors: true,
+	})
+	t.Cleanup(func() { gracefulShutdown(t, disabledServer) })
+
+	require.Never(func() bool {
+		rr := repoBrowserRequest(t, disabledServer, http.MethodGet,
+			"/api/v1/repo/github/acme/widgets/browser/refs",
+		)
+		if rr.Code != http.StatusOK {
+			return false
+		}
+		var body repoBrowserRefsResponse
+		if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+			return false
+		}
+		return body.DefaultRef.SHA == updatedSHA
+	}, 250*time.Millisecond, 25*time.Millisecond)
+}
+
 func TestRepoBrowserRejectsUnsafePath(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/server/repo_browser_test.go
+++ b/internal/server/repo_browser_test.go
@@ -157,6 +157,14 @@ func TestRepoBrowserTreeAssetLastChangedAndHistory(t *testing.T) {
 	require.NoError(json.Unmarshal(history.Body.Bytes(), &historyBody))
 	require.NotEmpty(historyBody.Commits)
 	assert.Equal("docs asset", historyBody.Commits[0].Subject)
+
+	commitDetail := repoBrowserRequest(t, srv, http.MethodGet,
+		"/api/v1/repo/github/acme/widgets/browser/commit?repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&path=README.md&sha="+url.QueryEscape(historyBody.Commits[0].SHA),
+	)
+	require.Equal(http.StatusOK, commitDetail.Code)
+	var commitBody repoBrowserCommitResponse
+	require.NoError(json.Unmarshal(commitDetail.Body.Bytes(), &commitBody))
+	assert.Equal(historyBody.Commits[0].SHA, commitBody.Commit.SHA)
 }
 
 func TestRepoBrowserAssetRejectsActiveContentTypes(t *testing.T) {
@@ -177,6 +185,33 @@ func TestRepoBrowserAssetRejectsActiveContentTypes(t *testing.T) {
 		assert.Equal(http.StatusUnsupportedMediaType, rr.Code, path)
 		assert.Contains(rr.Body.String(), "unsupported_asset")
 	}
+}
+
+func TestRepoBrowserCommitRejectsSHAOutsideSelectedFileHistory(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	srv, work := setupRepoBrowserServer(t, "github", "github.com", "acme/widgets")
+	require.NoError(os.WriteFile(filepath.Join(work, "other.txt"), []byte("other\n"), 0o644))
+	serverRepoBrowserGit(t, work, "add", ".")
+	serverRepoBrowserGit(t, work, "commit", "-m", "other file")
+	otherSHA := testGitSHA(t, work, "HEAD")
+	serverRepoBrowserGit(t, work, "push", "origin", "main")
+
+	rr := repoBrowserRequest(t, srv, http.MethodGet,
+		"/api/v1/repo/github/acme/widgets/browser/commit?ref_type=branch&ref_name=main&path=README.md&sha="+url.QueryEscape(otherSHA),
+	)
+
+	require.Equal(http.StatusNotFound, rr.Code)
+	assert.Contains(rr.Body.String(), "commit_out_of_scope")
+
+	ok := repoBrowserRequest(t, srv, http.MethodGet,
+		"/api/v1/repo/github/acme/widgets/browser/commit?ref_type=branch&ref_name=main&path=other.txt&sha="+url.QueryEscape(otherSHA),
+	)
+	require.Equal(http.StatusOK, ok.Code)
+	var body repoBrowserCommitResponse
+	require.NoError(json.Unmarshal(ok.Body.Bytes(), &body))
+	assert.Equal(otherSHA, body.Commit.SHA)
+	assert.Equal("other file", body.Commit.Subject)
 }
 
 func TestRepoBrowserRejectsUnsafePath(t *testing.T) {

--- a/internal/server/repo_browser_test.go
+++ b/internal/server/repo_browser_test.go
@@ -37,6 +37,24 @@ func TestRepoBrowserRefsUsesRepoPathIdentity(t *testing.T) {
 	assert.Equal(gitclone.RepoBrowserRefBranch, body.DefaultRef.Type)
 }
 
+func TestRepoBrowserRefsUsesProviderRouteWhenRepoPathMissing(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	srv, _ := setupRepoBrowserServer(t, "github", "github.com", "acme/widgets")
+
+	rr := repoBrowserRequest(t, srv, http.MethodGet,
+		"/api/v1/repo/github/acme/widgets/browser/refs",
+	)
+
+	require.Equal(http.StatusOK, rr.Code)
+	var body repoBrowserRefsResponse
+	require.NoError(json.Unmarshal(rr.Body.Bytes(), &body))
+	assert.Equal("github", body.Repo.Provider)
+	assert.Equal("github.com", body.Repo.PlatformHost)
+	assert.Equal("acme/widgets", body.Repo.RepoPath)
+	assert.Equal("main", body.DefaultRef.Name)
+}
+
 func TestRepoBrowserBlobReturnsTypedLargeAndBinaryStates(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -66,6 +84,31 @@ func TestRepoBrowserBlobReturnsTypedLargeAndBinaryStates(t *testing.T) {
 	assert.True(binaryBody.Blob.Binary)
 	assert.False(binaryBody.Blob.TooLarge)
 	assert.Empty(binaryBody.Blob.Content)
+}
+
+func TestRepoBrowserBranchRefReportsStaleRequestedSHA(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	srv, work := setupRepoBrowserServer(t, "github", "github.com", "acme/widgets")
+	oldSHA := testGitSHA(t, work, "main")
+	require.NoError(os.WriteFile(filepath.Join(work, "README.md"), []byte("# Test\n\nUpdated\n"), 0o644))
+	serverRepoBrowserGit(t, work, "add", ".")
+	serverRepoBrowserGit(t, work, "commit", "-m", "move main")
+	currentSHA := testGitSHA(t, work, "main")
+	serverRepoBrowserGit(t, work, "push", "origin", "main")
+
+	tree := repoBrowserRequest(t, srv, http.MethodGet,
+		"/api/v1/repo/github/acme/widgets/browser/tree?ref_type=branch&ref_name=main&ref_sha="+url.QueryEscape(oldSHA),
+	)
+
+	require.Equal(http.StatusOK, tree.Code)
+	var body repoBrowserTreeResponse
+	require.NoError(json.Unmarshal(tree.Body.Bytes(), &body))
+	assert.Equal(gitclone.RepoBrowserRefBranch, body.Ref.Type)
+	assert.Equal("main", body.Ref.Name)
+	assert.Equal(currentSHA, body.Ref.SHA)
+	assert.Equal(oldSHA, body.Ref.RequestedSHA)
+	assert.True(body.Ref.Stale)
 }
 
 func TestRepoBrowserTreeAssetLastChangedAndHistory(t *testing.T) {
@@ -114,6 +157,26 @@ func TestRepoBrowserTreeAssetLastChangedAndHistory(t *testing.T) {
 	require.NoError(json.Unmarshal(history.Body.Bytes(), &historyBody))
 	require.NotEmpty(historyBody.Commits)
 	assert.Equal("docs asset", historyBody.Commits[0].Subject)
+}
+
+func TestRepoBrowserAssetRejectsActiveContentTypes(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	srv, work := setupRepoBrowserServer(t, "github", "github.com", "acme/widgets")
+	require.NoError(os.WriteFile(filepath.Join(work, "image.svg"), []byte(`<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>`), 0o644))
+	require.NoError(os.WriteFile(filepath.Join(work, "page.html"), []byte(`<script>alert(1)</script>`), 0o644))
+	require.NoError(os.WriteFile(filepath.Join(work, "script.js"), []byte(`alert(1)`), 0o644))
+	serverRepoBrowserGit(t, work, "add", ".")
+	serverRepoBrowserGit(t, work, "commit", "-m", "active assets")
+	serverRepoBrowserGit(t, work, "push", "origin", "main")
+
+	for _, path := range []string{"image.svg", "page.html", "script.js"} {
+		rr := repoBrowserRequest(t, srv, http.MethodGet,
+			"/api/v1/repo/github/acme/widgets/browser/asset?ref_type=branch&ref_name=main&path="+url.QueryEscape(path),
+		)
+		assert.Equal(http.StatusUnsupportedMediaType, rr.Code, path)
+		assert.Contains(rr.Body.String(), "unsupported_asset")
+	}
 }
 
 func TestRepoBrowserRejectsUnsafePath(t *testing.T) {

--- a/internal/server/repo_browser_test.go
+++ b/internal/server/repo_browser_test.go
@@ -79,6 +79,73 @@ func TestRepoBrowserRefsReportsTruncationForLargeRefSets(t *testing.T) {
 	assert.Equal(mainSHA, body.DefaultRef.SHA)
 }
 
+func TestRepoBrowserCloneCacheSeparatesProvidersWithSameHostAndPath(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	database := openTestDB(t)
+	githubRemote, githubWork := setupServerRepoBrowserGitRepo(t)
+	gitlabRemote, gitlabWork := setupServerRepoBrowserGitRepo(t)
+	require.NoError(os.WriteFile(filepath.Join(githubWork, "README.md"), []byte("github repo\n"), 0o644))
+	serverRepoBrowserGit(t, githubWork, "add", ".")
+	serverRepoBrowserGit(t, githubWork, "commit", "-m", "github content")
+	serverRepoBrowserGit(t, githubWork, "push", "origin", "main")
+	require.NoError(os.WriteFile(filepath.Join(gitlabWork, "README.md"), []byte("gitlab repo\n"), 0o644))
+	serverRepoBrowserGit(t, gitlabWork, "add", ".")
+	serverRepoBrowserGit(t, gitlabWork, "commit", "-m", "gitlab content")
+	serverRepoBrowserGit(t, gitlabWork, "push", "origin", "main")
+
+	for _, repo := range []struct {
+		provider string
+		cloneURL string
+	}{
+		{provider: "github", cloneURL: githubRemote},
+		{provider: "gitlab", cloneURL: gitlabRemote},
+	} {
+		repoID, err := database.UpsertRepo(t.Context(), db.RepoIdentity{
+			Platform:     repo.provider,
+			PlatformHost: "git.example.com",
+			Owner:        "acme",
+			Name:         "widgets",
+			RepoPath:     "acme/widgets",
+		})
+		require.NoError(err)
+		require.NoError(database.UpdateRepoProviderMetadata(
+			t.Context(),
+			repoID,
+			db.RepoProviderMetadata{
+				WebURL:        "https://git.example.com/acme/widgets",
+				CloneURL:      repo.cloneURL,
+				DefaultBranch: "main",
+			},
+		))
+	}
+	clones := gitclone.New(filepath.Join(t.TempDir(), "clones"), nil)
+	syncer := ghclient.NewSyncer(nil, database, nil, nil, time.Minute, nil, nil)
+	t.Cleanup(syncer.Stop)
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{Clones: clones})
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		require.NoError(srv.Shutdown(ctx))
+	})
+
+	githubBlob := repoBrowserRequest(t, srv, http.MethodGet,
+		"/api/v1/host/git.example.com/repo/github/acme/widgets/browser/blob?repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&path=README.md",
+	)
+	require.Equal(http.StatusOK, githubBlob.Code)
+	var githubBody repoBrowserBlobResponse
+	require.NoError(json.Unmarshal(githubBlob.Body.Bytes(), &githubBody))
+	assert.Equal("github repo\n", githubBody.Blob.Content)
+
+	gitlabBlob := repoBrowserRequest(t, srv, http.MethodGet,
+		"/api/v1/host/git.example.com/repo/gitlab/acme/widgets/browser/blob?repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&path=README.md",
+	)
+	require.Equal(http.StatusOK, gitlabBlob.Code)
+	var gitlabBody repoBrowserBlobResponse
+	require.NoError(json.Unmarshal(gitlabBlob.Body.Bytes(), &gitlabBody))
+	assert.Equal("gitlab repo\n", gitlabBody.Blob.Content)
+}
+
 func TestRepoBrowserBlobReturnsTypedLargeAndBinaryStates(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/server/repo_browser_test.go
+++ b/internal/server/repo_browser_test.go
@@ -1,0 +1,212 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/middleman/internal/db"
+	"go.kenn.io/middleman/internal/gitclone"
+	ghclient "go.kenn.io/middleman/internal/github"
+)
+
+func TestRepoBrowserRefsUsesRepoPathIdentity(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	srv, _ := setupRepoBrowserServer(t, "gitlab", "gitlab.example.com", "group/subgroup/project")
+
+	rr := repoBrowserRequest(t, srv, http.MethodGet,
+		"/api/v1/host/gitlab.example.com/repo/gitlab/group/project/browser/refs?repo_path="+url.QueryEscape("group/subgroup/project"),
+	)
+
+	require.Equal(http.StatusOK, rr.Code)
+	var body repoBrowserRefsResponse
+	require.NoError(json.Unmarshal(rr.Body.Bytes(), &body))
+	assert.Equal("gitlab", body.Repo.Provider)
+	assert.Equal("gitlab.example.com", body.Repo.PlatformHost)
+	assert.Equal("group/subgroup/project", body.Repo.RepoPath)
+	assert.Equal("main", body.DefaultRef.Name)
+	assert.Equal(gitclone.RepoBrowserRefBranch, body.DefaultRef.Type)
+}
+
+func TestRepoBrowserBlobReturnsTypedLargeAndBinaryStates(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	srv, work := setupRepoBrowserServer(t, "github", "github.com", "acme/widgets")
+	require.NoError(os.WriteFile(filepath.Join(work, "large.txt"), make([]byte, gitclone.RepoBrowserBlobSizeLimit+1), 0o644))
+	require.NoError(os.WriteFile(filepath.Join(work, "bin.dat"), []byte{0, 1, 2, 3}, 0o644))
+	serverRepoBrowserGit(t, work, "add", ".")
+	serverRepoBrowserGit(t, work, "commit", "-m", "blob states")
+	serverRepoBrowserGit(t, work, "push", "origin", "main")
+
+	large := repoBrowserRequest(t, srv, http.MethodGet,
+		"/api/v1/repo/github/acme/widgets/browser/blob?repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&path=large.txt",
+	)
+	require.Equal(http.StatusOK, large.Code)
+	var largeBody repoBrowserBlobResponse
+	require.NoError(json.Unmarshal(large.Body.Bytes(), &largeBody))
+	assert.True(largeBody.Blob.TooLarge)
+	assert.False(largeBody.Blob.Binary)
+	assert.Empty(largeBody.Blob.Content)
+
+	binary := repoBrowserRequest(t, srv, http.MethodGet,
+		"/api/v1/repo/github/acme/widgets/browser/blob?repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&path=bin.dat",
+	)
+	require.Equal(http.StatusOK, binary.Code)
+	var binaryBody repoBrowserBlobResponse
+	require.NoError(json.Unmarshal(binary.Body.Bytes(), &binaryBody))
+	assert.True(binaryBody.Blob.Binary)
+	assert.False(binaryBody.Blob.TooLarge)
+	assert.Empty(binaryBody.Blob.Content)
+}
+
+func TestRepoBrowserTreeAssetLastChangedAndHistory(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	srv, work := setupRepoBrowserServer(t, "github", "github.com", "acme/widgets")
+	require.NoError(os.MkdirAll(filepath.Join(work, "docs"), 0o755))
+	image := []byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a}
+	require.NoError(os.WriteFile(filepath.Join(work, "docs", "image.png"), image, 0o644))
+	require.NoError(os.WriteFile(filepath.Join(work, "README.md"), []byte("# Test\n\nUpdated\n"), 0o644))
+	serverRepoBrowserGit(t, work, "add", ".")
+	serverRepoBrowserGit(t, work, "commit", "-m", "docs asset")
+	serverRepoBrowserGit(t, work, "push", "origin", "main")
+
+	tree := repoBrowserRequest(t, srv, http.MethodGet,
+		"/api/v1/repo/github/acme/widgets/browser/tree?repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main",
+	)
+	require.Equal(http.StatusOK, tree.Code)
+	var treeBody repoBrowserTreeResponse
+	require.NoError(json.Unmarshal(tree.Body.Bytes(), &treeBody))
+	assert.False(treeBody.Truncated)
+	assert.Contains(repoBrowserEntryPaths(treeBody.Entries), "docs/image.png")
+
+	asset := repoBrowserRequest(t, srv, http.MethodGet,
+		"/api/v1/repo/github/acme/widgets/browser/asset?repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&path=docs%2Fimage.png",
+	)
+	require.Equal(http.StatusOK, asset.Code)
+	assert.Equal("image/png", asset.Header().Get("Content-Type"))
+	assert.Equal("nosniff", asset.Header().Get("X-Content-Type-Options"))
+	assert.Equal(image, asset.Body.Bytes())
+
+	lastChanged := repoBrowserRequest(t, srv, http.MethodGet,
+		"/api/v1/repo/github/acme/widgets/browser/last-changed?repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&path=README.md&path=docs%2Fimage.png",
+	)
+	require.Equal(http.StatusOK, lastChanged.Code)
+	var lastChangedBody repoBrowserLastChangedResponse
+	require.NoError(json.Unmarshal(lastChanged.Body.Bytes(), &lastChangedBody))
+	assert.Equal("docs asset", lastChangedBody.Commits["README.md"].Subject)
+	assert.Equal("docs asset", lastChangedBody.Commits["docs/image.png"].Subject)
+
+	history := repoBrowserRequest(t, srv, http.MethodGet,
+		"/api/v1/repo/github/acme/widgets/browser/history?repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&path=README.md",
+	)
+	require.Equal(http.StatusOK, history.Code)
+	var historyBody repoBrowserHistoryResponse
+	require.NoError(json.Unmarshal(history.Body.Bytes(), &historyBody))
+	require.NotEmpty(historyBody.Commits)
+	assert.Equal("docs asset", historyBody.Commits[0].Subject)
+}
+
+func TestRepoBrowserRejectsUnsafePath(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	srv, _ := setupRepoBrowserServer(t, "github", "github.com", "acme/widgets")
+
+	rr := repoBrowserRequest(t, srv, http.MethodGet,
+		"/api/v1/repo/github/acme/widgets/browser/blob?repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&path=..%2Fsecret.txt",
+	)
+
+	require.Equal(http.StatusBadRequest, rr.Code)
+	var problem map[string]any
+	require.NoError(json.Unmarshal(rr.Body.Bytes(), &problem))
+	assert.Contains(rr.Body.String(), "unsafe_path")
+}
+
+func repoBrowserEntryPaths(entries []gitclone.RepoBrowserTreeEntry) []string {
+	paths := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		paths = append(paths, entry.Path)
+	}
+	return paths
+}
+
+func setupRepoBrowserServer(t *testing.T, provider, host, repoPath string) (*Server, string) {
+	t.Helper()
+	database := openTestDB(t)
+	remote, work := setupServerRepoBrowserGitRepo(t)
+	owner, name := splitServerRepoPathForTest(repoPath)
+	repoID, err := database.UpsertRepo(t.Context(), db.RepoIdentity{
+		Platform:     provider,
+		PlatformHost: host,
+		Owner:        owner,
+		Name:         name,
+		RepoPath:     repoPath,
+	})
+	require.NoError(t, err)
+	require.NoError(t, database.UpdateRepoProviderMetadata(
+		t.Context(),
+		repoID,
+		db.RepoProviderMetadata{
+			WebURL:        "https://" + host + "/" + repoPath,
+			CloneURL:      remote,
+			DefaultBranch: "main",
+		},
+	))
+	clones := gitclone.New(filepath.Join(t.TempDir(), "clones"), nil)
+	syncer := ghclient.NewSyncer(nil, database, nil, nil, time.Minute, nil, nil)
+	t.Cleanup(syncer.Stop)
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{Clones: clones})
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		require.NoError(t, srv.Shutdown(ctx))
+	})
+	return srv, work
+}
+
+func setupServerRepoBrowserGitRepo(t *testing.T) (remote string, work string) {
+	t.Helper()
+	dir := t.TempDir()
+	remote = filepath.Join(dir, "remote.git")
+	serverRepoBrowserGit(t, dir, "init", "--bare", "--initial-branch=main", remote)
+	work = filepath.Join(dir, "work")
+	serverRepoBrowserGit(t, dir, "clone", remote, work)
+	serverRepoBrowserGit(t, work, "config", "user.email", "alice@example.com")
+	serverRepoBrowserGit(t, work, "config", "user.name", "Alice")
+	require.NoError(t, os.WriteFile(filepath.Join(work, "README.md"), []byte("# Test\n"), 0o644))
+	serverRepoBrowserGit(t, work, "add", ".")
+	serverRepoBrowserGit(t, work, "commit", "-m", "initial")
+	serverRepoBrowserGit(t, work, "push", "origin", "main")
+	return remote, work
+}
+
+func serverRepoBrowserGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	runGit(t, dir, args...)
+}
+
+func repoBrowserRequest(t *testing.T, srv *Server, method, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, path, nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	return rr
+}
+
+func splitServerRepoPathForTest(repoPath string) (string, string) {
+	for i := len(repoPath) - 1; i >= 0; i-- {
+		if repoPath[i] == '/' {
+			return repoPath[:i], repoPath[i+1:]
+		}
+	}
+	return "", repoPath
+}

--- a/internal/server/repo_browser_test.go
+++ b/internal/server/repo_browser_test.go
@@ -229,7 +229,11 @@ func TestRepoBrowserTreeAssetLastChangedAndHistory(t *testing.T) {
 	require.NoError(os.WriteFile(filepath.Join(work, "docs", "image.png"), image, 0o644))
 	require.NoError(os.WriteFile(filepath.Join(work, "README.md"), []byte("# Test\n\nUpdated\n"), 0o644))
 	serverRepoBrowserGit(t, work, "add", ".")
-	serverRepoBrowserGit(t, work, "commit", "--date=2026-06-01T12:34:56-07:00", "-m", "docs asset")
+	serverRepoBrowserGit(t, work, "commit",
+		"--date=2026-06-01T12:34:56-07:00",
+		"-m", "docs asset",
+		"-m", "Document asset changes.\n\nKeep preview useful.",
+	)
 	currentSHA := testGitSHA(t, work, "HEAD")
 	serverRepoBrowserGit(t, work, "push", "origin", "main")
 	expectedAuthoredAt := time.Date(2026, 6, 1, 19, 34, 56, 0, time.UTC)
@@ -278,6 +282,7 @@ func TestRepoBrowserTreeAssetLastChangedAndHistory(t *testing.T) {
 	var commitBody repoBrowserCommitResponse
 	require.NoError(json.Unmarshal(commitDetail.Body.Bytes(), &commitBody))
 	assert.Equal(historyBody.Commits[0].SHA, commitBody.Commit.SHA)
+	assert.Equal("Document asset changes.\n\nKeep preview useful.", commitBody.Commit.Body)
 
 	mutableAsset := repoBrowserRequest(t, srv, http.MethodGet,
 		"/api/v1/repo/github/acme/widgets/browser/asset?repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&path=docs%2Fimage.png",
@@ -370,7 +375,10 @@ func TestRepoBrowserCommitRejectsSHAOutsideSelectedFileHistory(t *testing.T) {
 	srv, work := setupRepoBrowserServer(t, "github", "github.com", "acme/widgets")
 	require.NoError(os.WriteFile(filepath.Join(work, "other.txt"), []byte("other\n"), 0o644))
 	serverRepoBrowserGit(t, work, "add", ".")
-	serverRepoBrowserGit(t, work, "commit", "-m", "other file")
+	serverRepoBrowserGit(t, work, "commit",
+		"-m", "other file",
+		"-m", "Explain the file change.\n\nKeep the body visible.",
+	)
 	otherSHA := testGitSHA(t, work, "HEAD")
 	serverRepoBrowserGit(t, work, "push", "origin", "main")
 
@@ -389,6 +397,35 @@ func TestRepoBrowserCommitRejectsSHAOutsideSelectedFileHistory(t *testing.T) {
 	require.NoError(json.Unmarshal(ok.Body.Bytes(), &body))
 	assert.Equal(otherSHA, body.Commit.SHA)
 	assert.Equal("other file", body.Commit.Subject)
+	assert.Equal("Explain the file change.\n\nKeep the body visible.", body.Commit.Body)
+}
+
+func TestRepoBrowserCommitAcceptsMergeCommitTouchingPathThroughHTTP(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	srv, work := setupRepoBrowserServer(t, "github", "github.com", "acme/widgets")
+
+	serverRepoBrowserGit(t, work, "checkout", "-b", "feature")
+	require.NoError(os.WriteFile(filepath.Join(work, "README.md"), []byte("# Widgets\n\nFeature\n"), 0o644))
+	serverRepoBrowserGit(t, work, "add", ".")
+	serverRepoBrowserGit(t, work, "commit", "-m", "feature readme")
+	serverRepoBrowserGit(t, work, "checkout", "main")
+	require.NoError(os.WriteFile(filepath.Join(work, "main.txt"), []byte("main\n"), 0o644))
+	serverRepoBrowserGit(t, work, "add", ".")
+	serverRepoBrowserGit(t, work, "commit", "-m", "main work")
+	serverRepoBrowserGit(t, work, "merge", "--no-ff", "feature", "-m", "merge feature")
+	mergeSHA := testGitSHA(t, work, "HEAD")
+	serverRepoBrowserGit(t, work, "push", "origin", "main")
+
+	rr := repoBrowserRequest(t, srv, http.MethodGet,
+		"/api/v1/repo/github/acme/widgets/browser/commit?ref_type=branch&ref_name=main&path=README.md&sha="+url.QueryEscape(mergeSHA),
+	)
+
+	require.Equal(http.StatusOK, rr.Code)
+	var body repoBrowserCommitResponse
+	require.NoError(json.Unmarshal(rr.Body.Bytes(), &body))
+	assert.Equal(mergeSHA, body.Commit.SHA)
+	assert.Equal("merge feature", body.Commit.Subject)
 }
 
 func TestRepoBrowserCommitRejectsUnknownFullSHA(t *testing.T) {
@@ -542,17 +579,21 @@ func TestRepoBrowserStartupRefreshHonorsDisabledBackgroundMonitors(t *testing.T)
 	t.Cleanup(func() { gracefulShutdown(t, disabledServer) })
 
 	require.Never(func() bool {
-		rr := repoBrowserRequest(t, disabledServer, http.MethodGet,
-			"/api/v1/repo/github/acme/widgets/browser/refs",
-		)
-		if rr.Code != http.StatusOK {
+		resolved, err := disabledClones.ResolveRepoBrowserRef(t.Context(), gitclone.RepoBrowserRepoRef{
+			Provider:  "github",
+			Host:      "github.com",
+			Owner:     "acme",
+			Name:      "widgets",
+			RepoPath:  "acme/widgets",
+			RemoteURL: remote,
+		}, gitclone.RepoBrowserRef{
+			Type: gitclone.RepoBrowserRefBranch,
+			Name: "main",
+		})
+		if err != nil {
 			return false
 		}
-		var body repoBrowserRefsResponse
-		if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
-			return false
-		}
-		return body.DefaultRef.SHA == updatedSHA
+		return resolved.SHA == updatedSHA
 	}, 250*time.Millisecond, 25*time.Millisecond)
 }
 

--- a/internal/server/repo_browser_test.go
+++ b/internal/server/repo_browser_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -388,6 +389,19 @@ func TestRepoBrowserCommitRejectsSHAOutsideSelectedFileHistory(t *testing.T) {
 	require.NoError(json.Unmarshal(ok.Body.Bytes(), &body))
 	assert.Equal(otherSHA, body.Commit.SHA)
 	assert.Equal("other file", body.Commit.Subject)
+}
+
+func TestRepoBrowserCommitRejectsUnknownFullSHA(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	srv, _ := setupRepoBrowserServer(t, "github", "github.com", "acme/widgets")
+
+	rr := repoBrowserRequest(t, srv, http.MethodGet,
+		"/api/v1/repo/github/acme/widgets/browser/commit?ref_type=branch&ref_name=main&path=README.md&sha="+strings.Repeat("a", 40),
+	)
+
+	require.Equal(http.StatusNotFound, rr.Code)
+	assert.Contains(rr.Body.String(), "not_found")
 }
 
 func TestRepoBrowserCommitAcceptsOlderFileHistoryThroughHTTP(t *testing.T) {

--- a/internal/server/repo_browser_test.go
+++ b/internal/server/repo_browser_test.go
@@ -187,6 +187,30 @@ func TestRepoBrowserAssetRejectsActiveContentTypes(t *testing.T) {
 	}
 }
 
+func TestRepoBrowserAssetOpenAPIResponseIsBinary(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	doc := NewOpenAPI()
+	for _, path := range []string{
+		"/repo/{provider}/{owner}/{name}/browser/asset",
+		"/host/{platform_host}/repo/{provider}/{owner}/{name}/browser/asset",
+	} {
+		item := doc.Paths[path]
+		require.NotNil(item, path)
+		require.NotNil(item.Get, path)
+		resp := item.Get.Responses["200"]
+		require.NotNil(resp, path)
+
+		assert.Contains(resp.Content, "image/png", path)
+		assert.Contains(resp.Content, "image/jpeg", path)
+		assert.NotContains(resp.Content, "application/json", path)
+		schema := resp.Content["image/png"].Schema
+		require.NotNil(schema, path)
+		assert.Equal("string", schema.Type, path)
+		assert.Equal("binary", schema.Format, path)
+	}
+}
+
 func TestRepoBrowserCommitRejectsSHAOutsideSelectedFileHistory(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/server/repo_browser_test.go
+++ b/internal/server/repo_browser_test.go
@@ -191,6 +191,31 @@ func TestRepoBrowserTreeAssetLastChangedAndHistory(t *testing.T) {
 	assert.Equal(historyBody.Commits[0].SHA, commitBody.Commit.SHA)
 }
 
+func TestRepoBrowserLastChangedFallsBackPastBatchLogLimit(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	srv, work := setupRepoBrowserServer(t, "github", "github.com", "acme/widgets")
+	readmeSHA := testGitSHA(t, work, "HEAD")
+
+	for i := range gitclone.RepoBrowserLastChangedLogLimit + 1 {
+		require.NoError(os.WriteFile(filepath.Join(work, "churn.txt"), fmt.Appendf(nil, "%d\n", i), 0o644))
+		serverRepoBrowserGit(t, work, "add", ".")
+		serverRepoBrowserGit(t, work, "commit", "-m", fmt.Sprintf("churn %03d", i))
+	}
+	churnSHA := testGitSHA(t, work, "HEAD")
+	serverRepoBrowserGit(t, work, "push", "origin", "main")
+
+	rr := repoBrowserRequest(t, srv, http.MethodGet,
+		"/api/v1/repo/github/acme/widgets/browser/last-changed?repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&path=README.md&path=churn.txt",
+	)
+
+	require.Equal(http.StatusOK, rr.Code)
+	var body repoBrowserLastChangedResponse
+	require.NoError(json.Unmarshal(rr.Body.Bytes(), &body))
+	assert.Equal(readmeSHA, body.Commits["README.md"].SHA)
+	assert.Equal(churnSHA, body.Commits["churn.txt"].SHA)
+}
+
 func TestRepoBrowserAssetRejectsActiveContentTypes(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/server/repo_browser_test.go
+++ b/internal/server/repo_browser_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -53,6 +54,29 @@ func TestRepoBrowserRefsUsesProviderRouteWhenRepoPathMissing(t *testing.T) {
 	assert.Equal("github.com", body.Repo.PlatformHost)
 	assert.Equal("acme/widgets", body.Repo.RepoPath)
 	assert.Equal("main", body.DefaultRef.Name)
+}
+
+func TestRepoBrowserRefsReportsTruncationForLargeRefSets(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	srv, work := setupRepoBrowserServer(t, "github", "github.com", "acme/widgets")
+	remote := filepath.Join(filepath.Dir(work), "remote.git")
+	mainSHA := testGitSHA(t, work, "main")
+	for i := range gitclone.RepoBrowserRefLimit + 1 {
+		serverRepoBrowserGit(t, remote, "update-ref", fmt.Sprintf("refs/heads/branch-%04d", i), mainSHA)
+	}
+
+	rr := repoBrowserRequest(t, srv, http.MethodGet,
+		"/api/v1/repo/github/acme/widgets/browser/refs",
+	)
+
+	require.Equal(http.StatusOK, rr.Code)
+	var body repoBrowserRefsResponse
+	require.NoError(json.Unmarshal(rr.Body.Bytes(), &body))
+	assert.True(body.Truncated)
+	assert.Len(body.Refs, gitclone.RepoBrowserRefLimit)
+	assert.Equal("main", body.DefaultRef.Name)
+	assert.Equal(mainSHA, body.DefaultRef.SHA)
 }
 
 func TestRepoBrowserBlobReturnsTypedLargeAndBinaryStates(t *testing.T) {

--- a/internal/server/repo_browser_test.go
+++ b/internal/server/repo_browser_test.go
@@ -202,6 +202,23 @@ func TestRepoBrowserBranchRefReportsStaleRequestedSHA(t *testing.T) {
 	assert.True(body.Ref.Stale)
 }
 
+func TestRepoBrowserRejectsRevisionExpressionRefs(t *testing.T) {
+	assert := assert.New(t)
+	srv, work := setupRepoBrowserServer(t, "github", "github.com", "acme/widgets")
+	mainSHA := testGitSHA(t, work, "main")
+	serverRepoBrowserGit(t, work, "tag", "release", mainSHA)
+	serverRepoBrowserGit(t, work, "push", "origin", "refs/tags/release")
+
+	for _, path := range []string{
+		"/api/v1/repo/github/acme/widgets/browser/blob?repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main~1&path=README.md",
+		"/api/v1/repo/github/acme/widgets/browser/blob?repo_path=acme%2Fwidgets&ref_type=tag&ref_name=release%5E%7B%7D&path=README.md",
+	} {
+		rr := repoBrowserRequest(t, srv, http.MethodGet, path)
+		assert.Equal(http.StatusNotFound, rr.Code, path)
+		assert.Contains(rr.Body.String(), "not_found", path)
+	}
+}
+
 func TestRepoBrowserTreeAssetLastChangedAndHistory(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -211,9 +228,10 @@ func TestRepoBrowserTreeAssetLastChangedAndHistory(t *testing.T) {
 	require.NoError(os.WriteFile(filepath.Join(work, "docs", "image.png"), image, 0o644))
 	require.NoError(os.WriteFile(filepath.Join(work, "README.md"), []byte("# Test\n\nUpdated\n"), 0o644))
 	serverRepoBrowserGit(t, work, "add", ".")
-	serverRepoBrowserGit(t, work, "commit", "-m", "docs asset")
+	serverRepoBrowserGit(t, work, "commit", "--date=2026-06-01T12:34:56-07:00", "-m", "docs asset")
 	currentSHA := testGitSHA(t, work, "HEAD")
 	serverRepoBrowserGit(t, work, "push", "origin", "main")
+	expectedAuthoredAt := time.Date(2026, 6, 1, 19, 34, 56, 0, time.UTC)
 
 	tree := repoBrowserRequest(t, srv, http.MethodGet,
 		"/api/v1/repo/github/acme/widgets/browser/tree?repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main",
@@ -240,6 +258,8 @@ func TestRepoBrowserTreeAssetLastChangedAndHistory(t *testing.T) {
 	require.NoError(json.Unmarshal(lastChanged.Body.Bytes(), &lastChangedBody))
 	assert.Equal("docs asset", lastChangedBody.Commits["README.md"].Subject)
 	assert.Equal("docs asset", lastChangedBody.Commits["docs/image.png"].Subject)
+	assert.Equal(expectedAuthoredAt, lastChangedBody.Commits["README.md"].AuthoredAt)
+	assert.Equal(expectedAuthoredAt, lastChangedBody.Commits["docs/image.png"].AuthoredAt)
 
 	history := repoBrowserRequest(t, srv, http.MethodGet,
 		"/api/v1/repo/github/acme/widgets/browser/history?repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&path=README.md",
@@ -328,6 +348,8 @@ func TestRepoBrowserAssetOpenAPIResponseIsBinary(t *testing.T) {
 		item := doc.Paths[path]
 		require.NotNil(item, path)
 		require.NotNil(item.Get, path)
+		assert.Contains(item.Get.Description, "ref_type=commit", path)
+		assert.Contains(item.Get.Description, "mutable_ref_not_allowed", path)
 		resp := item.Get.Responses["200"]
 		require.NotNil(resp, path)
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -835,7 +835,7 @@ func newServer(
 	if s.fleetPlatformAuthMonitor != nil && !options.DisableWorkspaceBackgroundMonitors {
 		s.runBackground(s.fleetPlatformAuthMonitor.run)
 	}
-	if clones != nil {
+	if clones != nil && !options.DisableWorkspaceBackgroundMonitors {
 		s.runBackground(s.runRepoBrowserRefreshLoop)
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -835,6 +835,9 @@ func newServer(
 	if s.fleetPlatformAuthMonitor != nil && !options.DisableWorkspaceBackgroundMonitors {
 		s.runBackground(s.fleetPlatformAuthMonitor.run)
 	}
+	if clones != nil {
+		s.runBackground(s.runRepoBrowserRefreshLoop)
+	}
 
 	// Watch the config file so an external edit (vim, dotfiles deploy,
 	// sd -i, etc.) is picked up without a restart. Watcher init failures

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -148,6 +148,7 @@ type Server struct {
 	cfg                         *config.Config
 	cfgPath                     string
 	tokenSources                *tokenauth.SourceSet
+	repoBrowserRefreshEvery     time.Duration
 	cfgMu                       sync.Mutex
 	configReloadMu              sync.Mutex
 	// bootCfgSnapshot freezes the subset of config fields that are
@@ -675,25 +676,26 @@ func newServer(
 	}
 
 	s := &Server{
-		db:                     database,
-		basePath:               basePath,
-		syncer:                 syncer,
-		clones:                 clones,
-		telemetry:              options.Telemetry,
-		cfg:                    cfg,
-		cfgPath:                cfgPath,
-		tokenSources:           options.TokenSources,
-		bootCfgSnapshot:        snapshotStartupConfig(cfg),
-		runtimeStripEnvVars:    initialRuntimeStripEnvNames(cfg),
-		options:                options,
-		apiAuthToken:           options.APIAuthToken,
-		now:                    time.Now,
-		hub:                    NewEventHubWithCapacity(cfg.SSEBufferSizeOrDefault()),
-		tmuxActivity:           newTmuxActivityTracker(nil),
-		labelCatalogRefreshIDs: make(map[int64]struct{}),
-		deferredMergeMaxWait:   deferredMergeMaxWait,
-		docsPublishLocks:       newDocsPublishLockSet(),
-		msgvault:               newMsgvaultHandler(cfg, basePath, options.msgvaultRemoteImageDeps),
+		db:                      database,
+		basePath:                basePath,
+		syncer:                  syncer,
+		clones:                  clones,
+		telemetry:               options.Telemetry,
+		cfg:                     cfg,
+		cfgPath:                 cfgPath,
+		tokenSources:            options.TokenSources,
+		repoBrowserRefreshEvery: repoBrowserRefreshIntervalForConfig(cfg),
+		bootCfgSnapshot:         snapshotStartupConfig(cfg),
+		runtimeStripEnvVars:     initialRuntimeStripEnvNames(cfg),
+		options:                 options,
+		apiAuthToken:            options.APIAuthToken,
+		now:                     time.Now,
+		hub:                     NewEventHubWithCapacity(cfg.SSEBufferSizeOrDefault()),
+		tmuxActivity:            newTmuxActivityTracker(nil),
+		labelCatalogRefreshIDs:  make(map[int64]struct{}),
+		deferredMergeMaxWait:    deferredMergeMaxWait,
+		docsPublishLocks:        newDocsPublishLockSet(),
+		msgvault:                newMsgvaultHandler(cfg, basePath, options.msgvaultRemoteImageDeps),
 		bgCtx: shutdownAwareContext{
 			parent:   bgBaseCtx,
 			deadline: bgDeadline,
@@ -836,6 +838,7 @@ func newServer(
 		s.runBackground(s.fleetPlatformAuthMonitor.run)
 	}
 	if clones != nil && !options.DisableWorkspaceBackgroundMonitors {
+		s.seedRepoBrowserRefreshRepos(context.Background())
 		s.runBackground(s.runRepoBrowserRefreshLoop)
 	}
 

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -6347,6 +6347,7 @@ export interface components {
             default_ref: components["schemas"]["RepoBrowserRef"];
             refs: components["schemas"]["RepoBrowserRef"][] | null;
             repo: components["schemas"]["RepoRefResponse"];
+            truncated: boolean;
         };
         RepoBrowserTreeEntry: {
             path: string;

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -6327,7 +6327,9 @@ export interface components {
         };
         RepoBrowserRef: {
             name: string;
+            requested_sha?: string;
             sha: string;
+            stale: boolean;
             type: string;
         };
         RepoBrowserRefsResponse: {

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -6326,10 +6326,15 @@ export interface components {
             repo: components["schemas"]["RepoRefResponse"];
         };
         RepoBrowserRef: {
+            /** @description Selected branch or tag name. Commit refs leave this empty. */
             name: string;
+            /** @description Caller-supplied branch or tag SHA when it differs from the resolved SHA. */
             requested_sha?: string;
+            /** @description Resolved commit SHA used for the read. */
             sha: string;
+            /** @description True when a caller-supplied branch or tag SHA no longer matches the current ref target. */
             stale: boolean;
+            /** @description Selected ref type: branch, tag, or commit. */
             type: string;
         };
         RepoBrowserRefsResponse: {

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -10828,7 +10828,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description OK */
+            /** @description Image response */
             200: {
                 headers: {
                     "Cache-Control"?: string;
@@ -10838,7 +10838,12 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": string;
+                    "image/avif": string;
+                    "image/bmp": string;
+                    "image/gif": string;
+                    "image/jpeg": string;
+                    "image/png": string;
+                    "image/webp": string;
                 };
             };
             /** @description Error */
@@ -14388,7 +14393,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description OK */
+            /** @description Image response */
             200: {
                 headers: {
                     "Cache-Control"?: string;
@@ -14398,7 +14403,12 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": string;
+                    "image/avif": string;
+                    "image/bmp": string;
+                    "image/gif": string;
+                    "image/jpeg": string;
+                    "image/png": string;
+                    "image/webp": string;
                 };
             };
             /** @description Error */

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -1641,7 +1641,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get repository browser asset */
+        /**
+         * Get repository browser asset
+         * @description Returns raw image bytes for a repository file. Asset reads require ref_type=commit with ref_sha set to a full 40-character commit SHA; branch and tag refs are rejected with mutable_ref_not_allowed.
+         */
         get: operations["get-repo-browser-asset-on-host"];
         put?: never;
         post?: never;
@@ -3214,7 +3217,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get repository browser asset */
+        /**
+         * Get repository browser asset
+         * @description Returns raw image bytes for a repository file. Asset reads require ref_type=commit with ref_sha set to a full 40-character commit SHA; branch and tag refs are rejected with mutable_ref_not_allowed.
+         */
         get: operations["get-repo-browser-asset"];
         put?: never;
         post?: never;

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -1634,6 +1634,125 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/host/{platform_host}/repo/{provider}/{owner}/{name}/browser/asset": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get repository browser asset */
+        get: operations["get-repo-browser-asset-on-host"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/host/{platform_host}/repo/{provider}/{owner}/{name}/browser/blob": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get repository browser blob */
+        get: operations["get-repo-browser-blob-on-host"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/host/{platform_host}/repo/{provider}/{owner}/{name}/browser/commit": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get repository browser commit */
+        get: operations["get-repo-browser-commit-on-host"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/host/{platform_host}/repo/{provider}/{owner}/{name}/browser/history": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get repository browser file history */
+        get: operations["get-repo-browser-history-on-host"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/host/{platform_host}/repo/{provider}/{owner}/{name}/browser/last-changed": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get repository browser last changed commits */
+        get: operations["get-repo-browser-last-changed-on-host"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/host/{platform_host}/repo/{provider}/{owner}/{name}/browser/refs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List repository browser refs */
+        get: operations["list-repo-browser-refs-on-host"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/host/{platform_host}/repo/{provider}/{owner}/{name}/browser/tree": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List repository browser tree */
+        get: operations["list-repo-browser-tree-on-host"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/host/{platform_host}/repo/{provider}/{owner}/{name}/comment-autocomplete": {
         parameters: {
             query?: never;
@@ -3083,6 +3202,125 @@ export interface paths {
         post?: never;
         /** Delete repository */
         delete: operations["delete-repo"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/repo/{provider}/{owner}/{name}/browser/asset": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get repository browser asset */
+        get: operations["get-repo-browser-asset"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/repo/{provider}/{owner}/{name}/browser/blob": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get repository browser blob */
+        get: operations["get-repo-browser-blob"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/repo/{provider}/{owner}/{name}/browser/commit": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get repository browser commit */
+        get: operations["get-repo-browser-commit"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/repo/{provider}/{owner}/{name}/browser/history": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get repository browser file history */
+        get: operations["get-repo-browser-history"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/repo/{provider}/{owner}/{name}/browser/last-changed": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get repository browser last changed commits */
+        get: operations["get-repo-browser-last-changed"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/repo/{provider}/{owner}/{name}/browser/refs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List repository browser refs */
+        get: operations["list-repo-browser-refs"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/repo/{provider}/{owner}/{name}/browser/tree": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List repository browser tree */
+        get: operations["list-repo-browser-tree"];
+        put?: never;
+        post?: never;
+        delete?: never;
         options?: never;
         head?: never;
         patch?: never;
@@ -6018,6 +6256,108 @@ export interface components {
              */
             readonly $schema?: string;
             body: string;
+        };
+        RepoBrowserBlob: {
+            binary: boolean;
+            content: string;
+            encoding: string;
+            media_type: string;
+            path: string;
+            sha: string;
+            /** Format: int64 */
+            size: number;
+            too_large: boolean;
+        };
+        RepoBrowserBlobResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example /api/v1/schemas/RepoBrowserBlobResponse.json
+             */
+            readonly $schema?: string;
+            blob: components["schemas"]["RepoBrowserBlob"];
+            ref: components["schemas"]["RepoBrowserRef"];
+            repo: components["schemas"]["RepoRefResponse"];
+        };
+        RepoBrowserCommit: {
+            author_email: string;
+            author_name: string;
+            /** Format: date-time */
+            authored_at: string;
+            body: string;
+            sha: string;
+            subject: string;
+        };
+        RepoBrowserCommitResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example /api/v1/schemas/RepoBrowserCommitResponse.json
+             */
+            readonly $schema?: string;
+            commit: components["schemas"]["RepoBrowserCommit"];
+            path: string;
+            ref: components["schemas"]["RepoBrowserRef"];
+            repo: components["schemas"]["RepoRefResponse"];
+        };
+        RepoBrowserHistoryResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example /api/v1/schemas/RepoBrowserHistoryResponse.json
+             */
+            readonly $schema?: string;
+            commits: components["schemas"]["RepoBrowserCommit"][] | null;
+            path: string;
+            ref: components["schemas"]["RepoBrowserRef"];
+            repo: components["schemas"]["RepoRefResponse"];
+        };
+        RepoBrowserLastChangedResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example /api/v1/schemas/RepoBrowserLastChangedResponse.json
+             */
+            readonly $schema?: string;
+            commits: {
+                [key: string]: components["schemas"]["RepoBrowserCommit"];
+            };
+            ref: components["schemas"]["RepoBrowserRef"];
+            repo: components["schemas"]["RepoRefResponse"];
+        };
+        RepoBrowserRef: {
+            name: string;
+            sha: string;
+            type: string;
+        };
+        RepoBrowserRefsResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example /api/v1/schemas/RepoBrowserRefsResponse.json
+             */
+            readonly $schema?: string;
+            default_ref: components["schemas"]["RepoBrowserRef"];
+            refs: components["schemas"]["RepoBrowserRef"][] | null;
+            repo: components["schemas"]["RepoRefResponse"];
+        };
+        RepoBrowserTreeEntry: {
+            path: string;
+            /** Format: int64 */
+            size: number;
+            type: string;
+        };
+        RepoBrowserTreeResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example /api/v1/schemas/RepoBrowserTreeResponse.json
+             */
+            readonly $schema?: string;
+            entries: components["schemas"]["RepoBrowserTreeEntry"][] | null;
+            ref: components["schemas"]["RepoBrowserRef"];
+            repo: components["schemas"]["RepoRefResponse"];
+            truncated: boolean;
         };
         RepoLabelsResponse: {
             /**
@@ -10461,6 +10801,286 @@ export interface operations {
             };
         };
     };
+    "get-repo-browser-asset-on-host": {
+        parameters: {
+            query?: {
+                repo_path?: string;
+                ref_type?: string;
+                ref_name?: string;
+                ref_sha?: string;
+                path?: string;
+            };
+            header?: never;
+            path: {
+                provider: string;
+                platform_host: string;
+                owner: string;
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    "Cache-Control"?: string;
+                    "Content-Length"?: string;
+                    "Content-Type"?: string;
+                    "X-Content-Type-Options"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": string;
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
+    "get-repo-browser-blob-on-host": {
+        parameters: {
+            query?: {
+                repo_path?: string;
+                ref_type?: string;
+                ref_name?: string;
+                ref_sha?: string;
+                path?: string;
+            };
+            header?: never;
+            path: {
+                provider: string;
+                platform_host: string;
+                owner: string;
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RepoBrowserBlobResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
+    "get-repo-browser-commit-on-host": {
+        parameters: {
+            query?: {
+                repo_path?: string;
+                ref_type?: string;
+                ref_name?: string;
+                ref_sha?: string;
+                path?: string;
+                sha?: string;
+            };
+            header?: never;
+            path: {
+                provider: string;
+                platform_host: string;
+                owner: string;
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RepoBrowserCommitResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
+    "get-repo-browser-history-on-host": {
+        parameters: {
+            query?: {
+                repo_path?: string;
+                ref_type?: string;
+                ref_name?: string;
+                ref_sha?: string;
+                path?: string;
+            };
+            header?: never;
+            path: {
+                provider: string;
+                platform_host: string;
+                owner: string;
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RepoBrowserHistoryResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
+    "get-repo-browser-last-changed-on-host": {
+        parameters: {
+            query?: {
+                repo_path?: string;
+                ref_type?: string;
+                ref_name?: string;
+                ref_sha?: string;
+                path?: string[] | null;
+            };
+            header?: never;
+            path: {
+                provider: string;
+                platform_host: string;
+                owner: string;
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RepoBrowserLastChangedResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
+    "list-repo-browser-refs-on-host": {
+        parameters: {
+            query?: {
+                repo_path?: string;
+            };
+            header?: never;
+            path: {
+                provider: string;
+                platform_host: string;
+                owner: string;
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RepoBrowserRefsResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
+    "list-repo-browser-tree-on-host": {
+        parameters: {
+            query?: {
+                repo_path?: string;
+                ref_type?: string;
+                ref_name?: string;
+                ref_sha?: string;
+            };
+            header?: never;
+            path: {
+                provider: string;
+                platform_host: string;
+                owner: string;
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RepoBrowserTreeResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
     "get-comment-autocomplete-on-host": {
         parameters: {
             query?: {
@@ -13730,6 +14350,279 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
+    "get-repo-browser-asset": {
+        parameters: {
+            query?: {
+                repo_path?: string;
+                ref_type?: string;
+                ref_name?: string;
+                ref_sha?: string;
+                path?: string;
+            };
+            header?: never;
+            path: {
+                provider: string;
+                owner: string;
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    "Cache-Control"?: string;
+                    "Content-Length"?: string;
+                    "Content-Type"?: string;
+                    "X-Content-Type-Options"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": string;
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
+    "get-repo-browser-blob": {
+        parameters: {
+            query?: {
+                repo_path?: string;
+                ref_type?: string;
+                ref_name?: string;
+                ref_sha?: string;
+                path?: string;
+            };
+            header?: never;
+            path: {
+                provider: string;
+                owner: string;
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RepoBrowserBlobResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
+    "get-repo-browser-commit": {
+        parameters: {
+            query?: {
+                repo_path?: string;
+                ref_type?: string;
+                ref_name?: string;
+                ref_sha?: string;
+                path?: string;
+                sha?: string;
+            };
+            header?: never;
+            path: {
+                provider: string;
+                owner: string;
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RepoBrowserCommitResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
+    "get-repo-browser-history": {
+        parameters: {
+            query?: {
+                repo_path?: string;
+                ref_type?: string;
+                ref_name?: string;
+                ref_sha?: string;
+                path?: string;
+            };
+            header?: never;
+            path: {
+                provider: string;
+                owner: string;
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RepoBrowserHistoryResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
+    "get-repo-browser-last-changed": {
+        parameters: {
+            query?: {
+                repo_path?: string;
+                ref_type?: string;
+                ref_name?: string;
+                ref_sha?: string;
+                path?: string[] | null;
+            };
+            header?: never;
+            path: {
+                provider: string;
+                owner: string;
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RepoBrowserLastChangedResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
+    "list-repo-browser-refs": {
+        parameters: {
+            query?: {
+                repo_path?: string;
+            };
+            header?: never;
+            path: {
+                provider: string;
+                owner: string;
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RepoBrowserRefsResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
+    "list-repo-browser-tree": {
+        parameters: {
+            query?: {
+                repo_path?: string;
+                ref_type?: string;
+                ref_name?: string;
+                ref_sha?: string;
+            };
+            header?: never;
+            path: {
+                provider: string;
+                owner: string;
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RepoBrowserTreeResponse"];
+                };
             };
             /** @description Error */
             default: {

--- a/packages/ui/src/api/provider-routes.ts
+++ b/packages/ui/src/api/provider-routes.ts
@@ -118,6 +118,13 @@ export function providerItemPath(kind: "pulls" | "issues", ref: ProviderRouteRef
 
 type RepoSuffix =
   | ""
+  | "/browser/asset"
+  | "/browser/blob"
+  | "/browser/commit"
+  | "/browser/history"
+  | "/browser/last-changed"
+  | "/browser/refs"
+  | "/browser/tree"
   | "/comment-autocomplete"
   | "/commits/{sha}/diff"
   | "/labels"


### PR DESCRIPTION
The UI needs a repo-code API that preserves provider identity all the way to clone and cache selection; owner/name route placeholders are not enough for nested repos, self-hosted hosts, or default-host routing. This PR adds the read-only backend foundation so later UI branches can depend on generated, bounded contracts instead of inventing filesystem access in the frontend.

The API keeps risky behavior out of request hot paths: reads come from middleman-owned local clones, refs resolve with explicit stale-token metadata, large/binary/unsupported assets become typed states, and tag pruning is left to separate maintenance rather than source-browser refreshes.
