### PR TITLE
feat: add repo browser source view

### DIFF
--- a/cmd/middleman-github-app/e2e_test.go
+++ b/cmd/middleman-github-app/e2e_test.go
@@ -104,26 +104,21 @@ func scriptBrowserWithInstall(
 ) func(string) error {
 	t.Helper()
 	return func(target string) error {
-		go func() {
-			if m := installSlugRe.FindStringSubmatch(target); m != nil {
-				app, ok := fake.AppBySlug(m[1])
-				if !assert.True(t, ok, "install URL for unknown app slug %q", m[1]) {
-					return
-				}
-				assert.NoError(t, install(app.ID))
-				return
+		if m := installSlugRe.FindStringSubmatch(target); m != nil {
+			app, ok := fake.AppBySlug(m[1])
+			if !ok {
+				return fmt.Errorf("install URL for unknown app slug %q", m[1])
 			}
-			if m := settingsSlugRe.FindStringSubmatch(target); m != nil {
-				app, ok := fake.AppBySlug(m[1])
-				if !assert.True(t, ok, "settings URL for unknown app slug %q", m[1]) {
-					return
-				}
-				assert.NoError(t, fake.DeleteApp(app.ID))
-				return
+			return install(app.ID)
+		}
+		if m := settingsSlugRe.FindStringSubmatch(target); m != nil {
+			app, ok := fake.AppBySlug(m[1])
+			if !ok {
+				return fmt.Errorf("settings URL for unknown app slug %q", m[1])
 			}
-			assert.NoError(t, submitManifestForm(target))
-		}()
-		return nil
+			return fake.DeleteApp(app.ID)
+		}
+		return submitManifestForm(target)
 	}
 }
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -16,8 +16,10 @@
   import {
     buildFocusPullRequestFilesRoute,
     buildFocusPullRequestRoute,
+    buildRepoBrowserRoute,
     buildRoutedItemRoute,
     type PullRequestRouteRef,
+    type RepoBrowserRouteRef,
     type RoutedItemRef,
   } from "@middleman/ui/routes";
   import { client } from "./lib/api/runtime.js";
@@ -33,6 +35,7 @@
   import WorkspaceFirstRunPanel from "./lib/components/terminal/WorkspaceFirstRunPanel.svelte";
   import DesignSystemPage from "./lib/components/design-system/DesignSystemPage.svelte";
   import KataFeature from "./lib/features/kata/KataFeature.svelte";
+  import RepoBrowserFeature from "./lib/features/repo-browser/RepoBrowserFeature.svelte";
   import { fetchKataDaemons } from "./lib/api/kata/daemons.js";
   import { kataLinkingEnabledForEffectiveDaemon } from "./lib/api/kata/daemonSelection.js";
   import { createKataTaskAPI } from "./lib/api/kata/taskClient.js";
@@ -242,6 +245,12 @@
 
   function updateKataRoute(update: KataRouteUpdate): void {
     navigate(kataHref({ ...currentKataRouteUpdate(), ...update }));
+  }
+
+  function updateRepoBrowserRoute(route: RepoBrowserRouteRef, options?: { replace?: boolean }): void {
+    const href = buildRepoBrowserRoute(route);
+    if (options?.replace) replaceUrl(href);
+    else navigate(href);
   }
 
   function openMessage(messageId: number): void {
@@ -1113,6 +1122,15 @@
         />
       {:else if getPage() === "repos"}
         <RepoSummaryPage />
+      {:else if getPage() === "repo-browser"}
+        {@const route = getRoute()}
+        {#if route.page === "repo-browser"}
+          <RepoBrowserFeature
+            {client}
+            {route}
+            onRouteChange={updateRepoBrowserRoute}
+          />
+        {/if}
       {:else if getPage() === "kata"}
         {@const route = getRoute()}
         {#if route.page === "kata"}

--- a/frontend/src/lib/api/docs/markdown.test.ts
+++ b/frontend/src/lib/api/docs/markdown.test.ts
@@ -225,6 +225,15 @@ describe("hardened rendering", () => {
     expect(html).toMatch(/<img[^>]+src="https:\/\/example.com\/logo.png"/);
   });
 
+  test("renders external https images as links when image loading is disabled", () => {
+    const html = renderDocsMarkdown("![Logo](https://example.com/logo.png)", {
+      ...baseOptions,
+      allowExternalImages: false,
+    });
+    expect(html).not.toContain("<img");
+    expect(html).toMatch(/<a[^>]+href="https:\/\/example.com\/logo.png"[^>]*>Logo<\/a>/);
+  });
+
   test("drops protocol-relative markdown link and image", () => {
     const linkHtml = renderDocsMarkdown("[click](//evil.com/x)", baseOptions);
     expect(linkHtml).not.toContain("evil.com");

--- a/frontend/src/lib/api/docs/markdown.test.ts
+++ b/frontend/src/lib/api/docs/markdown.test.ts
@@ -155,6 +155,23 @@ describe("renderDocsMarkdown", () => {
     expect(html).not.toContain('data-kata-short-id="12"');
   });
 
+  test("does not turn repo references inside raw code into provider item links", () => {
+    const html = renderDocsMarkdown("<code>#12</code>", {
+      ...baseOptions,
+      repoContext: {
+        provider: "github",
+        platformHost: "",
+        owner: "acme",
+        name: "widgets",
+        repoPath: "acme/widgets",
+      },
+    });
+
+    expect(html).toContain("<code>#12</code>");
+    expect(html).not.toContain("item-ref");
+    expect(html).not.toContain('data-number="12"');
+  });
+
   test("mention regex stops on trailing sentence punctuation", () => {
     const html = renderDocsMarkdown("Hello @wes.", baseOptions);
     expect(html).toMatch(/data-kata-mention="wes"/);

--- a/frontend/src/lib/api/docs/markdown.test.ts
+++ b/frontend/src/lib/api/docs/markdown.test.ts
@@ -135,6 +135,26 @@ describe("renderDocsMarkdown", () => {
     expect(html).toMatch(/see #abc/);
   });
 
+  test("renders numeric repo references as provider item links when repo context is present", () => {
+    const html = renderDocsMarkdown("See #12 and group/project!13.", {
+      ...baseOptions,
+      repoContext: {
+        provider: "gitlab",
+        platformHost: "gitlab.example.com",
+        owner: "group",
+        name: "project",
+        repoPath: "group/project",
+      },
+    });
+
+    expect(html).toContain('class="item-ref" href="/host/gitlab.example.com/issues/gitlab/group/project/12"');
+    expect(html).toContain('data-number="12" data-item-type="issue"');
+    expect(html).toContain('data-external-url="https://gitlab.example.com/group/project/-/issues/12"');
+    expect(html).toContain('href="/host/gitlab.example.com/pulls/gitlab/group/project/13"');
+    expect(html).toContain('data-number="13" data-item-type="pr"');
+    expect(html).not.toContain('data-kata-short-id="12"');
+  });
+
   test("mention regex stops on trailing sentence punctuation", () => {
     const html = renderDocsMarkdown("Hello @wes.", baseOptions);
     expect(html).toMatch(/data-kata-mention="wes"/);

--- a/frontend/src/lib/api/docs/markdown.test.ts
+++ b/frontend/src/lib/api/docs/markdown.test.ts
@@ -234,6 +234,15 @@ describe("hardened rendering", () => {
     expect(html).toMatch(/<a[^>]+href="https:\/\/example.com\/logo.png"[^>]*>Logo<\/a>/);
   });
 
+  test("renders obfuscated external images as links when image loading is disabled", () => {
+    const html = renderDocsMarkdown("![Logo](<h\tttps://example.com/logo.png>)", {
+      ...baseOptions,
+      allowExternalImages: false,
+    });
+    expect(html).not.toContain("<img");
+    expect(html).toContain(">Logo</a>");
+  });
+
   test("drops protocol-relative markdown link and image", () => {
     const linkHtml = renderDocsMarkdown("[click](//evil.com/x)", baseOptions);
     expect(linkHtml).not.toContain("evil.com");

--- a/frontend/src/lib/api/docs/markdown.ts
+++ b/frontend/src/lib/api/docs/markdown.ts
@@ -26,6 +26,9 @@ export interface DocsMarkdownOptions {
   // Resolves an image path (relative or absolute within the folder) to a
   // network URL the browser can fetch.
   buildBlobURL: (folderID: string, relPath: string) => string;
+  // Repository previews disable this so contributor-controlled Markdown
+  // cannot make the maintainer's browser fetch arbitrary network URLs.
+  allowExternalImages?: boolean;
 }
 
 export interface FrontmatterSplit {
@@ -437,6 +440,10 @@ function docsRenderer(options: DocsMarkdownOptions, imageToken: string) {
       }
       const imgAttrs = `loading="lazy" decoding="async"`;
       if (isExternal(href)) {
+        if (options.allowExternalImages === false) {
+          const label = token.text ? escapeHtml(token.text) : escapeHtml(href);
+          return `<a href="${escapeAttr(href)}" target="_blank" rel="noreferrer"${title}>${label}</a>`;
+        }
         return `<img ${trustedImageAttr(imageToken)} src="${escapeAttr(href)}" alt="${alt}" ${imgAttrs}${title}>`;
       }
       if (!isAssetRef(href)) {

--- a/frontend/src/lib/api/docs/markdown.ts
+++ b/frontend/src/lib/api/docs/markdown.ts
@@ -1,5 +1,6 @@
 import DOMPurify, { type UponSanitizeElementHook, type UponSanitizeElementHookEvent } from "dompurify";
 import { Marked, type MarkedExtension, type Tokens } from "marked";
+import { providerItemRefExtension, type RepoContext } from "@middleman/ui/utils/markdown";
 import {
   joinFolderPath,
   parseWikilink,
@@ -29,6 +30,9 @@ export interface DocsMarkdownOptions {
   // Repository previews disable this so contributor-controlled Markdown
   // cannot make the maintainer's browser fetch arbitrary network URLs.
   allowExternalImages?: boolean;
+  // Repository previews provide this so #123-style references render like
+  // issue/PR comments instead of Docs/Kata short-id links.
+  repoContext?: RepoContext | undefined;
 }
 
 export interface FrontmatterSplit {
@@ -90,12 +94,20 @@ const ALLOWED_ATTR = [
   "data-doc-link",
   "data-doc-image-token",
   "data-doc-path",
+  "data-external-url",
   "data-kata-link",
   "data-kata-mention",
   "data-kata-project",
   "data-kata-short-id",
   "data-kata-uid",
   "data-folder",
+  "data-item-type",
+  "data-name",
+  "data-number",
+  "data-owner",
+  "data-platform-host",
+  "data-provider",
+  "data-repo-path",
   "data-wikilink",
   "decoding",
   "href",
@@ -114,7 +126,12 @@ export function renderDocsMarkdown(source: string, options: DocsMarkdownOptions)
   const md = new Marked();
   md.use({ gfm: true, breaks: false, async: false } satisfies MarkedExtension);
   md.use({
-    extensions: [wikilinkExtension(options, imageToken), kataLinkExtension(), mentionExtension()],
+    extensions: [
+      wikilinkExtension(options, imageToken),
+      ...(options.repoContext ? [providerItemRefExtension(options.repoContext)] : []),
+      ...(options.repoContext ? [] : [kataLinkExtension()]),
+      mentionExtension(),
+    ],
   });
   md.use({ renderer: docsRenderer(options, imageToken) });
   const rawHtml = md.parse(body) as string;

--- a/frontend/src/lib/api/docs/markdown.ts
+++ b/frontend/src/lib/api/docs/markdown.ts
@@ -396,7 +396,8 @@ function docsRenderer(options: DocsMarkdownOptions, imageToken: string) {
       }
       if (isUnsafeUri(href)) return `<span>${inner}</span>`;
       if (isExternal(href)) {
-        return `<a href="${escapeAttr(href)}" target="_blank" rel="noreferrer"${title}>${inner}</a>`;
+        const externalHref = cleanURIForScheme(href);
+        return `<a href="${escapeAttr(externalHref)}" target="_blank" rel="noreferrer"${title}>${inner}</a>`;
       }
       if (href.startsWith("#")) {
         // In-page anchor — pass through. The viewer wires up scroll behavior.
@@ -440,11 +441,12 @@ function docsRenderer(options: DocsMarkdownOptions, imageToken: string) {
       }
       const imgAttrs = `loading="lazy" decoding="async"`;
       if (isExternal(href)) {
+        const externalHref = cleanURIForScheme(href);
         if (options.allowExternalImages === false) {
           const label = token.text ? escapeHtml(token.text) : escapeHtml(href);
-          return `<a href="${escapeAttr(href)}" target="_blank" rel="noreferrer"${title}>${label}</a>`;
+          return `<a href="${escapeAttr(externalHref)}" target="_blank" rel="noreferrer"${title}>${label}</a>`;
         }
-        return `<img ${trustedImageAttr(imageToken)} src="${escapeAttr(href)}" alt="${alt}" ${imgAttrs}${title}>`;
+        return `<img ${trustedImageAttr(imageToken)} src="${escapeAttr(externalHref)}" alt="${alt}" ${imgAttrs}${title}>`;
       }
       if (!isAssetRef(href)) {
         return `<img ${trustedImageAttr(imageToken)} src="${escapeAttr(href)}" alt="${alt}" ${imgAttrs}${title}>`;
@@ -467,7 +469,7 @@ function isMermaidFence(lang: string | undefined): boolean {
 }
 
 function isExternal(href: string): boolean {
-  return /^(https?:|mailto:)/i.test(href);
+  return /^(https?:|mailto:)/i.test(normalizeURIForScheme(href));
 }
 
 // URI schemes we refuse to render. javascript:/vbscript: are always
@@ -479,10 +481,7 @@ function isUnsafeUri(href: string): boolean {
   // as forward slashes, so normalize before classifying — otherwise
   // `/<tab>/evil.com` or `/\evil.com` smuggles a protocol-relative
   // navigation past the leading-slash checks below.
-  const trimmed = href
-    .replace(/[\t\n\r]/g, "")
-    .trim()
-    .toLowerCase();
+  const trimmed = normalizeURIForScheme(href);
   // Protocol-relative references (//host, \\host, and mixed-slash variants)
   // navigate same-tab to an arbitrary host with no explicit scheme, bypassing
   // the external-link handling that adds target/rel. A single leading slash is
@@ -496,6 +495,14 @@ function isUnsafeUri(href: string): boolean {
     return !/^(https?:|mailto:)/i.test(trimmed);
   }
   return false;
+}
+
+function normalizeURIForScheme(href: string): string {
+  return cleanURIForScheme(href).toLowerCase();
+}
+
+function cleanURIForScheme(href: string): string {
+  return href.replace(/[\t\n\r]/g, "").trim();
 }
 
 // Only treat hrefs that clearly point at folder-bundled assets as blobs.

--- a/frontend/src/lib/api/runtime.ts
+++ b/frontend/src/lib/api/runtime.ts
@@ -10,6 +10,8 @@ const baseUrl =
     ? new URL(`${basePath.replace(/\/$/, "")}/api/v1`, window.location.origin).toString()
     : "http://localhost/api/v1";
 
+export const apiBaseURL = baseUrl;
+
 export const querySerializer: QuerySerializerOptions = {
   array: {
     style: "form",

--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -130,6 +130,8 @@
       ? "board"
       : getPage() === "terminal"
         ? "workspaces"
+        : getPage() === "repo-browser"
+          ? "repos"
       : getPage(),
   );
   type StickyMode = "kata" | "docs" | "messages";
@@ -270,7 +272,11 @@
           </button>
         {/if}
         {#if showMode("repos")}
-          <button class="view-tab" class:active={getPage() === "repos"} onclick={() => navigateTab("repos")}>
+          <button
+            class="view-tab"
+            class:active={getPage() === "repos" || getPage() === "repo-browser"}
+            onclick={() => navigateTab("repos")}
+          >
             Repos
           </button>
         {/if}

--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
@@ -134,7 +134,7 @@
     return {
       type,
       name: value.refName ?? value.refSHA ?? "",
-      sha: value.refSHA ?? value.refName ?? "",
+      sha: value.refSHA ?? (type === "commit" ? (value.refName ?? "") : ""),
       stale: false,
     };
   }

--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { untrack } from "svelte";
   import { SvelteMap } from "svelte/reactivity";
   import {
     buildRepoBrowserRoute,
@@ -90,13 +91,15 @@
       void loadRoute(route);
       return;
     }
-    if (route.path && route.path !== store.getSelectedPath()) {
+    const currentPath = untrack(() => store.getSelectedPath());
+    if (route.path && route.path !== currentPath) {
       const generation = routeLoadGeneration + 1;
       routeLoadGeneration = generation;
       void syncRoutePath(route.path, generation);
     }
     const nextMode = routeViewMode(route);
-    if (nextMode !== store.getViewMode()) {
+    const currentMode = untrack(() => store.getViewMode());
+    if (nextMode !== currentMode) {
       store.setViewMode(nextMode);
     }
   });

--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
@@ -37,6 +37,7 @@
     refSHA?: string | undefined;
     path?: string | undefined;
     mode?: RepoBrowserViewMode | undefined;
+    anchor?: string | undefined;
   };
 
   interface Props {
@@ -56,6 +57,8 @@
 
   let repoLoadKey = "";
   let routeLoadGeneration = 0;
+  let pathSelectionGeneration = 0;
+  let routeAnchorKey = "";
   let pathFilter = $state("");
   let selectedPathRevealKey = $state(0);
   let pendingMarkdownAnchor = $state(initialMarkdownAnchor());
@@ -81,6 +84,7 @@
 
   $effect(() => {
     const nextRepoLoadKey = routeKey(route);
+    applyRouteAnchor(route);
     if (nextRepoLoadKey !== repoLoadKey) {
       repoLoadKey = nextRepoLoadKey;
       void loadRoute(route);
@@ -110,6 +114,7 @@
 
   async function loadRoute(value: RepoBrowserFeatureRoute): Promise<void> {
     const generation = routeLoadGeneration + 1;
+    const selectionGeneration = nextPathSelectionGeneration();
     routeLoadGeneration = generation;
     store.setViewMode(routeViewMode(value));
     const requestedRef = routeRef(value);
@@ -117,16 +122,16 @@
       ...(requestedRef ? { ref: requestedRef } : {}),
       path: value.path ?? null,
     });
-    if (generation !== routeLoadGeneration) return;
+    if (generation !== routeLoadGeneration || selectionGeneration !== pathSelectionGeneration) return;
     if (!value.path) {
       const initialPath = chooseRepoBrowserInitialPath(store.getTree());
       if (initialPath && initialPath !== store.getSelectedPath()) {
         await store.selectPath(initialPath);
-        if (generation !== routeLoadGeneration) return;
+        if (generation !== routeLoadGeneration || !pathSelectionStillCurrent(selectionGeneration, initialPath)) return;
       }
       if (initialPath) pushRoute({ path: initialPath }, { replace: true });
     }
-    if (generation !== routeLoadGeneration) return;
+    if (generation !== routeLoadGeneration || selectionGeneration !== pathSelectionGeneration) return;
     selectedPathRevealKey += 1;
   }
 
@@ -183,15 +188,27 @@
   }
 
   async function selectPath(path: string, options?: { replace?: boolean }): Promise<void> {
+    const generation = nextPathSelectionGeneration();
     await store.selectPath(path);
+    if (!pathSelectionStillCurrent(generation, path)) return;
     selectedPathRevealKey += 1;
     pushRoute({ path }, options);
   }
 
   async function syncRoutePath(path: string, generation: number): Promise<void> {
+    const selectionGeneration = nextPathSelectionGeneration();
     await store.selectPath(path);
-    if (generation !== routeLoadGeneration) return;
+    if (generation !== routeLoadGeneration || !pathSelectionStillCurrent(selectionGeneration, path)) return;
     selectedPathRevealKey += 1;
+  }
+
+  function nextPathSelectionGeneration(): number {
+    pathSelectionGeneration += 1;
+    return pathSelectionGeneration;
+  }
+
+  function pathSelectionStillCurrent(generation: number, path: string): boolean {
+    return generation === pathSelectionGeneration && store.getSelectedPath() === path;
   }
 
   async function selectRefByKey(key: string): Promise<void> {
@@ -283,7 +300,8 @@
           } : {}),
           path: relPath,
           viewMode: "preview",
-        }) + (anchor ? `#${encodeURIComponent(anchor)}` : ""),
+          ...(anchor ? { anchor } : {}),
+        }),
       buildBlobURL: (_folderID: string, relPath: string) => assetURL(relPath),
       allowExternalImages: false,
     };
@@ -293,9 +311,8 @@
     const params = new URLSearchParams();
     params.set("repo_path", route.repoPath);
     params.set("path", path);
-    if (selectedRef) {
-      params.set("ref_type", selectedRef.type);
-      params.set("ref_name", selectedRef.name);
+    if (selectedRef?.sha) {
+      params.set("ref_type", "commit");
       params.set("ref_sha", selectedRef.sha);
     }
     const hostPath = route.platformHost
@@ -324,10 +341,14 @@
 
   function openMarkdownDoc(path: string, anchor?: string): void {
     void (async () => {
+      const generation = nextPathSelectionGeneration();
       if (path !== store.getSelectedPath()) {
         await store.selectPath(path);
+        if (!pathSelectionStillCurrent(generation, path)) return;
         selectedPathRevealKey += 1;
       }
+      if (!pathSelectionStillCurrent(generation, path)) return;
+      routeAnchorKey = routeAnchorStateKey(path, anchor ?? null);
       pendingMarkdownAnchor = anchor ?? null;
       store.setViewMode("preview");
       pushRoute({ path, mode: "preview", anchor: anchor ?? null });
@@ -353,6 +374,17 @@
       return `https://${host}/${encodedRepo}/src/${refKind}/${encodedRef}/${encodedPath}`;
     }
     return `https://${host}/${encodedRepo}/blob/${encodedRef}/${encodedPath}`;
+  }
+
+  function applyRouteAnchor(value: RepoBrowserFeatureRoute): void {
+    const key = routeAnchorStateKey(value.path ?? null, value.anchor ?? null);
+    if (key === routeAnchorKey) return;
+    routeAnchorKey = key;
+    pendingMarkdownAnchor = value.anchor ?? null;
+  }
+
+  function routeAnchorStateKey(path: string | null, anchor: string | null): string {
+    return `${path ?? ""}\0${anchor ?? ""}`;
   }
 </script>
 

--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
@@ -105,7 +105,7 @@
   });
 
   function routeKey(value: RepoBrowserFeatureRoute): string {
-    const refSHA = value.refType === "commit" ? (value.refSHA ?? value.refName ?? "") : "";
+    const refSHA = value.refSHA ?? (value.refType === "commit" ? (value.refName ?? "") : "");
     return [
       value.provider,
       value.platformHost ?? "",

--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
@@ -324,6 +324,7 @@
         }),
       buildBlobURL: (_folderID: string, relPath: string) => assetURL(relPath),
       allowExternalImages: false,
+      repoContext: repoRef(route),
     };
   }
 

--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
@@ -25,7 +25,7 @@
   import { apiBaseURL } from "../../api/runtime.js";
   import type { FolderIndex } from "../../api/docs/folderLinks";
 
-  export type RepoBrowserFeatureRoute = {
+  type RepoBrowserFeatureRoute = {
     page: "repo-browser";
     provider: string;
     platformHost?: string | undefined;
@@ -44,6 +44,10 @@
     route: RepoBrowserFeatureRoute;
     onRouteChange: (route: RepoBrowserRouteRef, options?: { replace?: boolean }) => void;
   }
+
+  type RepoBrowserRouteUpdate = Partial<Pick<RepoBrowserFeatureRoute, "path" | "mode">> & {
+    anchor?: string | null;
+  };
 
   let { client, route, onRouteChange }: Props = $props();
 
@@ -151,7 +155,7 @@
   }
 
   function pushRoute(
-    update: Partial<Pick<RepoBrowserFeatureRoute, "path" | "mode">> = {},
+    update: RepoBrowserRouteUpdate = {},
     options?: { replace?: boolean },
   ): void {
     const ref = store.getSelectedRef();
@@ -171,6 +175,7 @@
         } : {}),
         ...(path ? { path } : {}),
         viewMode: mode,
+        ...(update.anchor ? { anchor: update.anchor } : {}),
       },
       options,
     );
@@ -313,10 +318,12 @@
   function openMarkdownDoc(path: string, anchor?: string): void {
     void (async () => {
       if (path !== store.getSelectedPath()) {
-        await selectPath(path, { replace: false });
+        await store.selectPath(path);
+        selectedPathRevealKey += 1;
       }
       pendingMarkdownAnchor = anchor ?? null;
-      setViewMode("preview");
+      store.setViewMode("preview");
+      pushRoute({ path, mode: "preview", anchor: anchor ?? null });
     })();
   }
 

--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
@@ -51,6 +51,7 @@
   const store = createRepoBrowserStore({ client });
 
   let repoLoadKey = "";
+  let routeLoadGeneration = 0;
   let pathFilter = $state("");
   let selectedPathRevealKey = $state(0);
   let pendingMarkdownAnchor = $state(initialMarkdownAnchor());
@@ -82,6 +83,7 @@
       return;
     }
     if (route.path && route.path !== store.getSelectedPath()) {
+      routeLoadGeneration += 1;
       void selectPath(route.path, { replace: true });
     }
     const nextMode = routeViewMode(route);
@@ -102,19 +104,24 @@
   }
 
   async function loadRoute(value: RepoBrowserFeatureRoute): Promise<void> {
+    const generation = routeLoadGeneration + 1;
+    routeLoadGeneration = generation;
     store.setViewMode(routeViewMode(value));
     const requestedRef = routeRef(value);
     await store.loadRepo(repoRef(value), {
       ...(requestedRef ? { ref: requestedRef } : {}),
       path: value.path ?? null,
     });
+    if (generation !== routeLoadGeneration) return;
     if (!value.path) {
       const initialPath = chooseRepoBrowserInitialPath(store.getTree());
       if (initialPath && initialPath !== store.getSelectedPath()) {
         await store.selectPath(initialPath);
+        if (generation !== routeLoadGeneration) return;
       }
       if (initialPath) pushRoute({ path: initialPath }, { replace: true });
     }
+    if (generation !== routeLoadGeneration) return;
     selectedPathRevealKey += 1;
   }
 
@@ -266,6 +273,7 @@
           viewMode: "preview",
         }) + (anchor ? `#${encodeURIComponent(anchor)}` : ""),
       buildBlobURL: (_folderID: string, relPath: string) => assetURL(relPath),
+      allowExternalImages: false,
     };
   }
 

--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
@@ -220,6 +220,12 @@
     if (!ref) return;
     await store.selectRef(ref);
     selectedPathRevealKey += 1;
+    repoLoadKey = routeKey({
+      ...route,
+      refType: ref.type,
+      refName: ref.name,
+      refSHA: ref.sha,
+    });
     pushRoute({ path: store.getSelectedPath() ?? undefined });
   }
 

--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
@@ -102,13 +102,14 @@
   });
 
   function routeKey(value: RepoBrowserFeatureRoute): string {
+    const refSHA = value.refType === "commit" ? (value.refSHA ?? value.refName ?? "") : "";
     return [
       value.provider,
       value.platformHost ?? "",
       value.repoPath,
       value.refType ?? "",
       value.refName ?? "",
-      value.refSHA ?? "",
+      refSHA,
     ].join("\0");
   }
 

--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
@@ -1,0 +1,823 @@
+<script lang="ts">
+  import { SvelteMap } from "svelte/reactivity";
+  import {
+    buildRepoBrowserRoute,
+    createRepoBrowserStore,
+    diffFileCategoryOptions,
+    PierreFileTree,
+    type DiffFileCategoryFilter,
+    type FileTreeEntry,
+    type MiddlemanClient,
+    type RepoBrowserRouteRef,
+    type RepoBrowserViewMode,
+    type SourceBrowserFileEntry,
+  } from "@middleman/ui";
+  import type { RepoBrowserCommit, RepoBrowserRef } from "@middleman/ui/api/types";
+  import { providerDefaultHost } from "@middleman/ui/api/provider-routes";
+  import DocMarkdownView from "../../components/docs/DocMarkdownView.svelte";
+  import { RefreshIcon, ExternalLinkIcon, SpinnerIcon } from "../../icons";
+  import {
+    chooseRepoBrowserInitialPath,
+    formatRepoBrowserCommitDate,
+    formatRepoBrowserFileSize,
+    isRepoBrowserMarkdownPath,
+  } from "./repoBrowserViewState.js";
+  import { apiBaseURL } from "../../api/runtime.js";
+  import type { FolderIndex } from "../../api/docs/folderLinks";
+
+  export type RepoBrowserFeatureRoute = {
+    page: "repo-browser";
+    provider: string;
+    platformHost?: string | undefined;
+    repoPath: string;
+    owner: string;
+    name: string;
+    refType?: string | undefined;
+    refName?: string | undefined;
+    refSHA?: string | undefined;
+    path?: string | undefined;
+    mode?: RepoBrowserViewMode | undefined;
+  };
+
+  interface Props {
+    client: MiddlemanClient;
+    route: RepoBrowserFeatureRoute;
+    onRouteChange: (route: RepoBrowserRouteRef, options?: { replace?: boolean }) => void;
+  }
+
+  let { client, route, onRouteChange }: Props = $props();
+
+  // svelte-ignore state_referenced_locally
+  const store = createRepoBrowserStore({ client });
+
+  let repoLoadKey = "";
+  let pathFilter = $state("");
+  let selectedPathRevealKey = $state(0);
+
+  const selectedPath = $derived(store.getSelectedPath());
+  const selectedRef = $derived(store.getSelectedRef());
+  const selectedBlob = $derived(store.getBlob());
+  const selectedCommitDetail = $derived(store.getSelectedCommit());
+  const selectedFile = $derived(findSelectedFile(store.getFileEntries(), selectedPath));
+  const selectedIsMarkdown = $derived(isRepoBrowserMarkdownPath(selectedPath));
+  const viewMode = $derived(store.getViewMode());
+  const canPreview = $derived(selectedIsMarkdown && selectedBlob !== null && !selectedBlob.binary && !selectedBlob.too_large);
+  const shownFiles = $derived.by(() => {
+    const query = pathFilter.trim().toLowerCase();
+    const files = store.getVisibleFileEntries();
+    if (!query) return files;
+    return files.filter((entry) => entry.path.toLowerCase().includes(query));
+  });
+  const treeEntries = $derived(shownFiles.map(toTreeEntry));
+  const categoryCounts = $derived(store.getFileCategoryCounts());
+  const markdownIndex = $derived(buildMarkdownIndex(store.getFileEntries()));
+  const forgeHref = $derived(buildForgeHref(route, selectedRef, selectedPath));
+
+  $effect(() => {
+    const nextRepoLoadKey = routeKey(route);
+    if (nextRepoLoadKey !== repoLoadKey) {
+      repoLoadKey = nextRepoLoadKey;
+      void loadRoute(route);
+      return;
+    }
+    if (route.path && route.path !== store.getSelectedPath()) {
+      void selectPath(route.path, { replace: true });
+    }
+    if (route.mode && route.mode !== store.getViewMode()) {
+      store.setViewMode(route.mode);
+    }
+  });
+
+  function routeKey(value: RepoBrowserFeatureRoute): string {
+    return [
+      value.provider,
+      value.platformHost ?? "",
+      value.repoPath,
+      value.refType ?? "",
+      value.refName ?? "",
+      value.refSHA ?? "",
+    ].join("\0");
+  }
+
+  async function loadRoute(value: RepoBrowserFeatureRoute): Promise<void> {
+    if (value.mode) store.setViewMode(value.mode);
+    const requestedRef = routeRef(value);
+    await store.loadRepo(repoRef(value), {
+      ...(requestedRef ? { ref: requestedRef } : {}),
+      path: value.path ?? null,
+    });
+    if (!value.path) {
+      const initialPath = chooseRepoBrowserInitialPath(store.getTree());
+      if (initialPath && initialPath !== store.getSelectedPath()) {
+        await store.selectPath(initialPath);
+      }
+      if (initialPath) pushRoute({ path: initialPath }, { replace: true });
+    }
+    selectedPathRevealKey += 1;
+  }
+
+  function repoRef(value: RepoBrowserFeatureRoute) {
+    return {
+      provider: value.provider,
+      ...(value.platformHost ? { platformHost: value.platformHost } : {}),
+      owner: value.owner,
+      name: value.name,
+      repoPath: value.repoPath,
+    };
+  }
+
+  function routeRef(value: RepoBrowserFeatureRoute): RepoBrowserRef | undefined {
+    if (!value.refType && !value.refName && !value.refSHA) return undefined;
+    const type = value.refType ?? "branch";
+    return {
+      type,
+      name: value.refName ?? value.refSHA ?? "",
+      sha: value.refSHA ?? value.refName ?? "",
+    };
+  }
+
+  function pushRoute(
+    update: Partial<Pick<RepoBrowserFeatureRoute, "path" | "mode">> = {},
+    options?: { replace?: boolean },
+  ): void {
+    const ref = store.getSelectedRef();
+    const path = update.path ?? store.getSelectedPath() ?? undefined;
+    const mode = update.mode ?? store.getViewMode();
+    onRouteChange(
+      {
+        provider: route.provider,
+        ...(route.platformHost ? { platformHost: route.platformHost } : {}),
+        owner: route.owner,
+        name: route.name,
+        repoPath: route.repoPath,
+        ...(ref ? {
+          refType: ref.type,
+          refName: ref.name,
+          refSHA: ref.sha,
+        } : {}),
+        ...(path ? { path } : {}),
+        viewMode: mode,
+      },
+      options,
+    );
+  }
+
+  async function selectPath(path: string, options?: { replace?: boolean }): Promise<void> {
+    await store.selectPath(path);
+    selectedPathRevealKey += 1;
+    pushRoute({ path }, options);
+  }
+
+  async function selectRefByKey(key: string): Promise<void> {
+    const ref = store.getRefs().find((candidate) => refKey(candidate) === key);
+    if (!ref) return;
+    await store.selectRef(ref);
+    selectedPathRevealKey += 1;
+    pushRoute({ path: store.getSelectedPath() ?? undefined });
+  }
+
+  function setCategoryFilter(filter: DiffFileCategoryFilter): void {
+    store.setFileCategoryFilter(filter);
+  }
+
+  function setViewMode(mode: RepoBrowserViewMode): void {
+    store.setViewMode(mode);
+    pushRoute({ mode }, { replace: true });
+  }
+
+  function refreshRepo(): void {
+    repoLoadKey = "";
+    void loadRoute(route);
+  }
+
+  function selectHistoryCommit(commit: RepoBrowserCommit): void {
+    void store.selectCommit(commit.sha);
+  }
+
+  function toTreeEntry(file: SourceBrowserFileEntry): FileTreeEntry {
+    const lastChanged = file.lastChanged;
+    return {
+      path: file.path,
+      ...(lastChanged ? {
+        decoration: formatRepoBrowserCommitDate(lastChanged.authored_at),
+        decorationTitle: `${lastChanged.subject} (${lastChanged.sha.slice(0, 12)})`,
+      } : {}),
+    };
+  }
+
+  function findSelectedFile(
+    files: readonly SourceBrowserFileEntry[],
+    path: string | null,
+  ): SourceBrowserFileEntry | null {
+    if (!path) return null;
+    return files.find((entry) => entry.path === path) ?? null;
+  }
+
+  function refLabel(ref: RepoBrowserRef | null): string {
+    if (!ref) return "No ref";
+    if (ref.type === "commit") return ref.sha.slice(0, 12);
+    return ref.name || ref.sha.slice(0, 12);
+  }
+
+  function refKey(ref: RepoBrowserRef): string {
+    return `${ref.type}\0${ref.name}\0${ref.sha}`;
+  }
+
+  function refOptionLabel(ref: RepoBrowserRef): string {
+    const suffix = ref.sha ? ` ${ref.sha.slice(0, 8)}` : "";
+    return `${ref.type}: ${ref.name || ref.sha.slice(0, 12)}${suffix}`;
+  }
+
+  function buildMarkdownIndex(files: readonly SourceBrowserFileEntry[]): FolderIndex {
+    const byPath = new SvelteMap<string, string>();
+    const byBasename = new SvelteMap<string, string[]>();
+    for (const file of files) {
+      if (!isRepoBrowserMarkdownPath(file.path)) continue;
+      const lowerPath = file.path.toLowerCase();
+      byPath.set(lowerPath, file.path);
+      byPath.set(lowerPath.replace(/\.(md|mdx)$/i, ""), file.path);
+      const base = lowerPath.split("/").at(-1)?.replace(/\.(md|mdx)$/i, "") ?? lowerPath;
+      byBasename.set(base, [...(byBasename.get(base) ?? []), file.path]);
+    }
+    return { byPath, byBasename };
+  }
+
+  function markdownOptions(path: string) {
+    return {
+      folderID: route.repoPath,
+      currentDocPath: path,
+      index: markdownIndex,
+      buildDocURL: (_folderID: string, relPath: string, anchor?: string) =>
+        buildRepoBrowserRoute({
+          ...repoRef(route),
+          ...(selectedRef ? {
+            refType: selectedRef.type,
+            refName: selectedRef.name,
+            refSHA: selectedRef.sha,
+          } : {}),
+          path: relPath,
+          viewMode: "preview",
+        }) + (anchor ? `#${encodeURIComponent(anchor)}` : ""),
+      buildBlobURL: (_folderID: string, relPath: string) => assetURL(relPath),
+    };
+  }
+
+  function assetURL(path: string): string {
+    const params = new URLSearchParams();
+    params.set("repo_path", route.repoPath);
+    params.set("path", path);
+    if (selectedRef) {
+      params.set("ref_type", selectedRef.type);
+      params.set("ref_name", selectedRef.name);
+      params.set("ref_sha", selectedRef.sha);
+    }
+    const hostPath = route.platformHost
+      ? `/host/${encodeURIComponent(route.platformHost)}`
+      : "";
+    const endpointPath = `${hostPath}/repo/${encodeURIComponent(route.provider)}/${encodeURIComponent(route.owner)}/${encodeURIComponent(route.name)}/browser/asset`;
+    const url = new URL(endpointPath.replace(/^\//, ""), withTrailingSlash(apiBaseURL));
+    url.search = params.toString();
+    return url.toString();
+  }
+
+  function withTrailingSlash(value: string): string {
+    return value.endsWith("/") ? value : `${value}/`;
+  }
+
+  function openMarkdownDoc(path: string): void {
+    void selectPath(path, { replace: false }).then(() => setViewMode("preview"));
+  }
+
+  function buildForgeHref(
+    value: RepoBrowserFeatureRoute,
+    ref: RepoBrowserRef | null,
+    path: string | null,
+  ): string | null {
+    if (!ref || !path) return null;
+    const host = value.platformHost ?? providerDefaultHost(value.provider);
+    if (!host) return null;
+    const encodedRepo = value.repoPath.split("/").map(encodeURIComponent).join("/");
+    const encodedPath = path.split("/").map(encodeURIComponent).join("/");
+    const encodedRef = encodeURIComponent(ref.name || ref.sha);
+    if (value.provider === "gitlab") {
+      return `https://${host}/${encodedRepo}/-/blob/${encodedRef}/${encodedPath}`;
+    }
+    if (value.provider === "forgejo" || value.provider === "gitea") {
+      const refKind = ref.type === "tag" ? "tag" : ref.type === "commit" ? "commit" : "branch";
+      return `https://${host}/${encodedRepo}/src/${refKind}/${encodedRef}/${encodedPath}`;
+    }
+    return `https://${host}/${encodedRepo}/blob/${encodedRef}/${encodedPath}`;
+  }
+</script>
+
+<section class="repo-browser" aria-label="Repository source browser">
+  <header class="repo-browser__toolbar">
+    <div class="repo-browser__identity">
+      <span class="repo-browser__provider">{route.provider}</span>
+      <span class="repo-browser__repo">{route.repoPath}</span>
+      <span class="repo-browser__ref">{refLabel(selectedRef)}</span>
+    </div>
+    <div class="repo-browser__actions">
+      <select
+        class="repo-browser__select"
+        aria-label="Select repository ref"
+        value={selectedRef ? refKey(selectedRef) : ""}
+        onchange={(event) => void selectRefByKey(event.currentTarget.value)}
+      >
+        {#each store.getRefs() as ref (refKey(ref))}
+          <option value={refKey(ref)}>{refOptionLabel(ref)}</option>
+        {/each}
+      </select>
+      <button class="repo-browser__icon-button" type="button" title="Refresh repository" onclick={refreshRepo}>
+        <RefreshIcon size="15" strokeWidth="1.75" aria-hidden="true" />
+      </button>
+      {#if forgeHref}
+        <a class="repo-browser__icon-button" href={forgeHref} target="_blank" rel="noreferrer" title="Open on forge">
+          <ExternalLinkIcon size="15" strokeWidth="1.75" aria-hidden="true" />
+        </a>
+      {/if}
+    </div>
+  </header>
+
+  <div class="repo-browser__content">
+    <aside class="repo-browser__sidebar" aria-label="Files">
+      <div class="repo-browser__filter">
+        <input
+          type="search"
+          placeholder="Filter files"
+          aria-label="Filter files"
+          bind:value={pathFilter}
+        />
+      </div>
+      <div class="repo-browser__categories" aria-label="File category filters">
+        {#each diffFileCategoryOptions as option (option.value)}
+          <button
+            type="button"
+            class:repo-browser__category--active={store.getFileCategoryFilter() === option.value}
+            onclick={() => setCategoryFilter(option.value)}
+          >
+            <span>{option.label}</span>
+            <span>{categoryCounts[option.value]}</span>
+          </button>
+        {/each}
+      </div>
+      <div class="repo-browser__tree">
+        <PierreFileTree
+          files={null}
+          entries={treeEntries}
+          selectedPath={selectedPath}
+          {selectedPathRevealKey}
+          ariaLabel="Repository files"
+          onSelect={(path) => void selectPath(path)}
+        />
+      </div>
+    </aside>
+
+    <main class="repo-browser__viewer" aria-label="Selected file">
+      <div class="repo-browser__filebar">
+        <div class="repo-browser__path">
+          {#if selectedPath}
+            {selectedPath}
+          {:else}
+            No file selected
+          {/if}
+        </div>
+        <div class="repo-browser__filemeta">
+          {#if selectedFile}
+            <span>{formatRepoBrowserFileSize(selectedFile.size)}</span>
+          {/if}
+          {#if selectedIsMarkdown}
+            <div class="repo-browser__segmented" aria-label="View mode">
+              <button
+                type="button"
+                class:repo-browser__segment--active={viewMode === "source"}
+                onclick={() => setViewMode("source")}
+              >Source</button>
+              <button
+                type="button"
+                class:repo-browser__segment--active={viewMode === "preview"}
+                disabled={!canPreview}
+                onclick={() => setViewMode("preview")}
+              >Preview</button>
+            </div>
+          {/if}
+        </div>
+      </div>
+
+      {#if store.isLoading() || store.isBlobLoading()}
+        <div class="repo-browser__state">
+          <SpinnerIcon size="18" strokeWidth="2" aria-hidden="true" />
+          Loading
+        </div>
+      {:else if store.getError()}
+        <div class="repo-browser__state repo-browser__state--error">{store.getError()}</div>
+      {:else if !selectedBlob}
+        <div class="repo-browser__state">Select a file</div>
+      {:else if selectedBlob.too_large}
+        <div class="repo-browser__state">File is too large to display</div>
+      {:else if selectedBlob.binary}
+        <div class="repo-browser__state">Binary file cannot be previewed</div>
+      {:else if viewMode === "preview" && selectedIsMarkdown}
+        <article class="repo-browser__markdown">
+          <DocMarkdownView
+            source={selectedBlob.content}
+            options={markdownOptions(selectedBlob.path)}
+            onSelectDoc={(path) => openMarkdownDoc(path)}
+          />
+        </article>
+      {:else}
+        <pre class="repo-browser__source"><code>{selectedBlob.content}</code></pre>
+      {/if}
+    </main>
+
+    <aside class="repo-browser__history" aria-label="File history">
+      <header class="repo-browser__history-header">
+        <span>History</span>
+        <span>{store.getFileHistory().length}</span>
+      </header>
+      <div class="repo-browser__history-list">
+        {#each store.getFileHistory() as commit (commit.sha)}
+          <button
+            type="button"
+            class:repo-browser__history-row--active={store.getSelectedCommit()?.sha === commit.sha}
+            onclick={() => selectHistoryCommit(commit)}
+          >
+            <span>{commit.subject}</span>
+            <span>{commit.author_name} · {formatRepoBrowserCommitDate(commit.authored_at)}</span>
+          </button>
+        {/each}
+      </div>
+      {#if selectedCommitDetail}
+        <section class="repo-browser__commit-detail" aria-label="Selected commit">
+          <div class="repo-browser__commit-sha">{selectedCommitDetail.sha.slice(0, 12)}</div>
+          <h2>{selectedCommitDetail.subject}</h2>
+          <p>
+            {selectedCommitDetail.author_name} · {formatRepoBrowserCommitDate(selectedCommitDetail.authored_at)}
+          </p>
+          {#if selectedCommitDetail.body}
+            <pre>{selectedCommitDetail.body}</pre>
+          {/if}
+        </section>
+      {/if}
+    </aside>
+  </div>
+</section>
+
+<style>
+  .repo-browser {
+    flex: 1 1 auto;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    background: var(--bg-primary);
+  }
+
+  .repo-browser__toolbar {
+    min-height: 46px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 8px 12px;
+    border-bottom: thin solid var(--border-default);
+    background: var(--bg-surface);
+  }
+
+  .repo-browser__identity,
+  .repo-browser__actions,
+  .repo-browser__filemeta,
+  .repo-browser__history-header {
+    display: flex;
+    align-items: center;
+    min-width: 0;
+  }
+
+  .repo-browser__identity {
+    gap: 8px;
+    font-size: var(--font-size-sm);
+  }
+
+  .repo-browser__provider {
+    color: var(--text-muted);
+    text-transform: uppercase;
+    font-size: var(--font-size-2xs);
+    font-weight: 700;
+  }
+
+  .repo-browser__repo {
+    color: var(--text-primary);
+    font-weight: 650;
+  }
+
+  .repo-browser__ref,
+  .repo-browser__filemeta {
+    color: var(--text-secondary);
+    font-size: var(--font-size-xs);
+  }
+
+  .repo-browser__actions {
+    gap: 8px;
+    flex: 0 0 auto;
+  }
+
+  .repo-browser__select,
+  .repo-browser__filter input {
+    height: 30px;
+    border: thin solid var(--border-default);
+    border-radius: var(--radius-sm);
+    color: var(--text-primary);
+    background: var(--bg-inset);
+    font: inherit;
+    font-size: var(--font-size-sm);
+  }
+
+  .repo-browser__select {
+    min-width: 190px;
+    padding: 0 28px 0 8px;
+  }
+
+  .repo-browser__icon-button {
+    width: 30px;
+    height: 30px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: thin solid var(--border-default);
+    border-radius: var(--radius-sm);
+    color: var(--text-secondary);
+    background: var(--bg-surface);
+    text-decoration: none;
+  }
+
+  .repo-browser__icon-button:hover {
+    color: var(--text-primary);
+    background: var(--bg-surface-hover);
+  }
+
+  .repo-browser__content {
+    flex: 1 1 auto;
+    min-height: 0;
+    display: grid;
+    grid-template-columns: minmax(260px, 340px) minmax(0, 1fr) minmax(250px, 320px);
+    overflow: hidden;
+  }
+
+  .repo-browser__sidebar,
+  .repo-browser__history {
+    min-width: 0;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    background: var(--bg-surface);
+  }
+
+  .repo-browser__sidebar {
+    border-right: thin solid var(--border-default);
+  }
+
+  .repo-browser__history {
+    border-left: thin solid var(--border-default);
+  }
+
+  .repo-browser__filter {
+    padding: 10px 10px 6px;
+  }
+
+  .repo-browser__filter input {
+    width: 100%;
+    padding: 0 9px;
+  }
+
+  .repo-browser__categories {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    padding: 0 10px 10px;
+  }
+
+  .repo-browser__categories button {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    min-height: 24px;
+    padding: 0 7px;
+    border: thin solid var(--border-default);
+    border-radius: var(--radius-sm);
+    color: var(--text-secondary);
+    background: var(--bg-surface);
+    font-size: var(--font-size-xs);
+  }
+
+  .repo-browser__categories button:hover,
+  .repo-browser__category--active {
+    color: var(--text-primary);
+    background: var(--bg-surface-hover);
+  }
+
+  .repo-browser__tree {
+    flex: 1 1 auto;
+    min-height: 0;
+    padding: 0 4px 8px;
+  }
+
+  .repo-browser__viewer {
+    min-width: 0;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    background: var(--bg-primary);
+  }
+
+  .repo-browser__filebar {
+    min-height: 42px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 7px 12px;
+    border-bottom: thin solid var(--border-default);
+    background: var(--bg-surface);
+  }
+
+  .repo-browser__path {
+    min-width: 0;
+    overflow: hidden;
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: var(--font-size-sm);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .repo-browser__filemeta {
+    flex: 0 0 auto;
+    gap: 10px;
+  }
+
+  .repo-browser__segmented {
+    display: inline-flex;
+    padding: 2px;
+    border: thin solid var(--border-default);
+    border-radius: var(--radius-sm);
+    background: var(--bg-inset);
+  }
+
+  .repo-browser__segmented button {
+    min-height: 24px;
+    padding: 0 8px;
+    border: 0;
+    border-radius: calc(var(--radius-sm) - 1px);
+    color: var(--text-secondary);
+    background: transparent;
+    font-size: var(--font-size-xs);
+  }
+
+  .repo-browser__segmented button:disabled {
+    color: var(--text-muted);
+  }
+
+  .repo-browser__segment--active {
+    color: var(--text-primary) !important;
+    background: var(--bg-surface) !important;
+  }
+
+  .repo-browser__source,
+  .repo-browser__markdown {
+    flex: 1 1 auto;
+    min-height: 0;
+    margin: 0;
+    overflow: auto;
+  }
+
+  .repo-browser__source {
+    padding: 14px 16px;
+    color: var(--text-primary);
+    background: var(--bg-primary);
+    font-family: var(--font-mono);
+    font-size: var(--font-size-sm);
+    line-height: 1.55;
+    tab-size: 2;
+  }
+
+  .repo-browser__markdown {
+    padding: 18px 24px 40px;
+  }
+
+  .repo-browser__state {
+    flex: 1 1 auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+  }
+
+  .repo-browser__state--error {
+    color: var(--accent-red);
+  }
+
+  .repo-browser__history-header {
+    justify-content: space-between;
+    min-height: 38px;
+    padding: 0 12px;
+    border-bottom: thin solid var(--border-default);
+    color: var(--text-secondary);
+    font-size: var(--font-size-xs);
+    font-weight: 650;
+  }
+
+  .repo-browser__history-list {
+    flex: 0 0 auto;
+    max-height: 48%;
+    overflow: auto;
+    border-bottom: thin solid var(--border-default);
+  }
+
+  .repo-browser__history-list button {
+    width: 100%;
+    display: grid;
+    gap: 3px;
+    padding: 9px 12px;
+    border: 0;
+    border-bottom: thin solid var(--border-muted);
+    color: var(--text-primary);
+    background: transparent;
+    text-align: left;
+  }
+
+  .repo-browser__history-list button:hover,
+  .repo-browser__history-row--active {
+    background: var(--bg-surface-hover) !important;
+  }
+
+  .repo-browser__history-list button span:first-child {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: var(--font-size-sm);
+    font-weight: 600;
+  }
+
+  .repo-browser__history-list button span:last-child,
+  .repo-browser__commit-detail p {
+    color: var(--text-secondary);
+    font-size: var(--font-size-xs);
+  }
+
+  .repo-browser__commit-detail {
+    flex: 1 1 auto;
+    min-height: 0;
+    padding: 12px;
+    overflow: auto;
+  }
+
+  .repo-browser__commit-detail h2 {
+    margin: 5px 0 5px;
+    color: var(--text-primary);
+    font-size: var(--font-size-md);
+    line-height: 1.35;
+  }
+
+  .repo-browser__commit-detail p {
+    margin: 0 0 10px;
+  }
+
+  .repo-browser__commit-detail pre {
+    margin: 0;
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
+    font-size: var(--font-size-xs);
+    line-height: 1.45;
+    white-space: pre-wrap;
+  }
+
+  .repo-browser__commit-sha {
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    font-size: var(--font-size-xs);
+  }
+
+  @media (max-width: 980px) {
+    .repo-browser__content {
+      grid-template-columns: minmax(220px, 300px) minmax(0, 1fr);
+    }
+
+    .repo-browser__history {
+      display: none;
+    }
+  }
+
+  @media (max-width: 720px) {
+    .repo-browser__content {
+      grid-template-columns: 1fr;
+    }
+
+    .repo-browser__sidebar {
+      display: none;
+    }
+  }
+</style>

--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
@@ -83,8 +83,9 @@
     if (route.path && route.path !== store.getSelectedPath()) {
       void selectPath(route.path, { replace: true });
     }
-    if (route.mode && route.mode !== store.getViewMode()) {
-      store.setViewMode(route.mode);
+    const nextMode = routeViewMode(route);
+    if (nextMode !== store.getViewMode()) {
+      store.setViewMode(nextMode);
     }
   });
 
@@ -100,7 +101,7 @@
   }
 
   async function loadRoute(value: RepoBrowserFeatureRoute): Promise<void> {
-    if (value.mode) store.setViewMode(value.mode);
+    store.setViewMode(routeViewMode(value));
     const requestedRef = routeRef(value);
     await store.loadRepo(repoRef(value), {
       ...(requestedRef ? { ref: requestedRef } : {}),
@@ -133,7 +134,12 @@
       type,
       name: value.refName ?? value.refSHA ?? "",
       sha: value.refSHA ?? value.refName ?? "",
+      stale: false,
     };
+  }
+
+  function routeViewMode(value: RepoBrowserFeatureRoute): RepoBrowserViewMode {
+    return value.mode ?? "source";
   }
 
   function pushRoute(

--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
@@ -53,6 +53,7 @@
   let repoLoadKey = "";
   let pathFilter = $state("");
   let selectedPathRevealKey = $state(0);
+  let pendingMarkdownAnchor = $state<string | null>(null);
 
   const selectedPath = $derived(store.getSelectedPath());
   const selectedRef = $derived(store.getSelectedRef());
@@ -290,8 +291,14 @@
     return value.endsWith("/") ? value : `${value}/`;
   }
 
-  function openMarkdownDoc(path: string): void {
-    void selectPath(path, { replace: false }).then(() => setViewMode("preview"));
+  function openMarkdownDoc(path: string, anchor?: string): void {
+    pendingMarkdownAnchor = anchor ?? null;
+    void (async () => {
+      if (path !== store.getSelectedPath()) {
+        await selectPath(path, { replace: false });
+      }
+      setViewMode("preview");
+    })();
   }
 
   function buildForgeHref(
@@ -428,7 +435,9 @@
           <DocMarkdownView
             source={selectedBlob.content}
             options={markdownOptions(selectedBlob.path)}
-            onSelectDoc={(path) => openMarkdownDoc(path)}
+            onSelectDoc={(path, anchor) => openMarkdownDoc(path, anchor)}
+            scrollToAnchor={pendingMarkdownAnchor}
+            onAnchorConsumed={() => (pendingMarkdownAnchor = null)}
           />
         </article>
       {:else}

--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
@@ -87,8 +87,9 @@
       return;
     }
     if (route.path && route.path !== store.getSelectedPath()) {
-      routeLoadGeneration += 1;
-      void selectPath(route.path, { replace: true });
+      const generation = routeLoadGeneration + 1;
+      routeLoadGeneration = generation;
+      void syncRoutePath(route.path, generation);
     }
     const nextMode = routeViewMode(route);
     if (nextMode !== store.getViewMode()) {
@@ -185,6 +186,12 @@
     await store.selectPath(path);
     selectedPathRevealKey += 1;
     pushRoute({ path }, options);
+  }
+
+  async function syncRoutePath(path: string, generation: number): Promise<void> {
+    await store.selectPath(path);
+    if (generation !== routeLoadGeneration) return;
+    selectedPathRevealKey += 1;
   }
 
   async function selectRefByKey(key: string): Promise<void> {

--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
@@ -53,7 +53,7 @@
   let repoLoadKey = "";
   let pathFilter = $state("");
   let selectedPathRevealKey = $state(0);
-  let pendingMarkdownAnchor = $state<string | null>(null);
+  let pendingMarkdownAnchor = $state(initialMarkdownAnchor());
 
   const selectedPath = $derived(store.getSelectedPath());
   const selectedRef = $derived(store.getSelectedRef());
@@ -291,12 +291,23 @@
     return value.endsWith("/") ? value : `${value}/`;
   }
 
+  function initialMarkdownAnchor(): string | null {
+    if (typeof window === "undefined") return null;
+    const raw = window.location.hash.replace(/^#/, "");
+    if (!raw) return null;
+    try {
+      return decodeURIComponent(raw);
+    } catch {
+      return raw;
+    }
+  }
+
   function openMarkdownDoc(path: string, anchor?: string): void {
-    pendingMarkdownAnchor = anchor ?? null;
     void (async () => {
       if (path !== store.getSelectedPath()) {
         await selectPath(path, { replace: false });
       }
+      pendingMarkdownAnchor = anchor ?? null;
       setViewMode("preview");
     })();
   }

--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
@@ -133,7 +133,10 @@
         await store.selectPath(initialPath);
         if (generation !== routeLoadGeneration || !pathSelectionStillCurrent(selectionGeneration, initialPath)) return;
       }
-      if (initialPath) pushRoute({ path: initialPath }, { replace: true });
+      if (initialPath) {
+        repoLoadKey = routeKeyWithSelectedRef(value);
+        pushRoute({ path: initialPath }, { replace: true });
+      }
     }
     if (generation !== routeLoadGeneration || selectionGeneration !== pathSelectionGeneration) return;
     selectedPathRevealKey += 1;
@@ -162,6 +165,18 @@
 
   function routeViewMode(value: RepoBrowserFeatureRoute): RepoBrowserViewMode {
     return value.mode ?? "source";
+  }
+
+  function routeKeyWithSelectedRef(value: RepoBrowserFeatureRoute): string {
+    const ref = store.getSelectedRef();
+    return routeKey({
+      ...value,
+      ...(ref ? {
+        refType: ref.type,
+        refName: ref.name,
+        refSHA: ref.sha,
+      } : {}),
+    });
   }
 
   function pushRoute(
@@ -220,12 +235,7 @@
     if (!ref) return;
     await store.selectRef(ref);
     selectedPathRevealKey += 1;
-    repoLoadKey = routeKey({
-      ...route,
-      refType: ref.type,
-      refName: ref.name,
-      refSHA: ref.sha,
-    });
+    repoLoadKey = routeKeyWithSelectedRef(route);
     pushRoute({ path: store.getSelectedPath() ?? undefined });
   }
 

--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.test.ts
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.test.ts
@@ -149,6 +149,45 @@ describe("RepoBrowserFeature", () => {
     expect(client.GET).toHaveBeenCalledTimes(5);
   });
 
+  it("reloads the repo when the same branch route moves to a different resolved SHA", async () => {
+    const client = testClient();
+    const onRouteChange = vi.fn();
+    const { rerender } = render(RepoBrowserFeature, {
+      props: {
+        client,
+        route: {
+          ...route,
+          refType: "branch",
+          refName: "main",
+          refSHA: "main-sha",
+          path: "README.md",
+        },
+        onRouteChange,
+      },
+    });
+
+    await waitFor(() => expect(client.GET).toHaveBeenCalledTimes(5));
+    await rerender({
+      client,
+      route: {
+        ...route,
+        refType: "branch",
+        refName: "main",
+        refSHA: "main-next-sha",
+        path: "README.md",
+      },
+      onRouteChange,
+    });
+
+    await waitFor(() => expect(client.GET).toHaveBeenCalledTimes(10));
+    const calls = (client.GET as unknown as { mock: { calls: Array<[string, TestGetOptions | undefined]> } }).mock
+      .calls;
+    const urls = calls.map(([path, options]) => testURL(path, options));
+    expect(urls).toContain(
+      "/repo/github/acme/widgets/browser/tree?repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&ref_sha=main-next-sha",
+    );
+  });
+
   it("does not reload the repo when a no-ref route is self-replaced with the default ref", async () => {
     const client = testClient();
     const onRouteChange = vi.fn();
@@ -279,6 +318,23 @@ function testClient(): MiddlemanClient {
       }
       if (
         url ===
+        "/repo/github/acme/widgets/browser/tree?repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&ref_sha=main-next-sha"
+      ) {
+        return {
+          data: {
+            repo,
+            ref: { type: "branch", name: "main", sha: "main-next-sha", stale: false },
+            entries: [
+              { path: "README.md", type: "blob", size: 13 },
+              { path: "docs/guide.md", type: "blob", size: 18 },
+            ],
+            truncated: false,
+          },
+          response: new Response(null, { status: 200 }),
+        };
+      }
+      if (
+        url ===
         "/repo/github/acme/widgets/browser/tree?repo_path=acme%2Fwidgets&ref_type=tag&ref_name=v1.0.0&ref_sha=tag-sha"
       ) {
         return {
@@ -309,6 +365,19 @@ function testClient(): MiddlemanClient {
       }
       if (
         url ===
+        "/repo/github/acme/widgets/browser/last-changed?repo_path=acme%2Fwidgets&ref_type=commit&ref_sha=main-next-sha&path=README.md&path=docs%2Fguide.md"
+      ) {
+        return {
+          data: {
+            repo,
+            ref: { type: "branch", name: "main", sha: "main-next-sha", stale: false },
+            commits: {},
+          },
+          response: new Response(null, { status: 200 }),
+        };
+      }
+      if (
+        url ===
         "/repo/github/acme/widgets/browser/last-changed?repo_path=acme%2Fwidgets&ref_type=commit&ref_sha=tag-sha&path=README.md&path=docs%2Fguide.md"
       ) {
         return {
@@ -328,6 +397,12 @@ function testClient(): MiddlemanClient {
       }
       if (
         url ===
+        "/repo/github/acme/widgets/browser/blob?repo_path=acme%2Fwidgets&ref_type=commit&ref_sha=main-next-sha&path=README.md"
+      ) {
+        return blobResponse("README.md", "Updated README\n");
+      }
+      if (
+        url ===
         "/repo/github/acme/widgets/browser/blob?repo_path=acme%2Fwidgets&ref_type=commit&ref_sha=tag-sha&path=README.md"
       ) {
         return blobResponse("README.md", "[Guide](docs/guide.md#install)\n");
@@ -335,6 +410,12 @@ function testClient(): MiddlemanClient {
       if (
         url ===
         "/repo/github/acme/widgets/browser/history?repo_path=acme%2Fwidgets&ref_type=commit&ref_sha=main-sha&path=README.md"
+      ) {
+        return historyResponse("README.md");
+      }
+      if (
+        url ===
+        "/repo/github/acme/widgets/browser/history?repo_path=acme%2Fwidgets&ref_type=commit&ref_sha=main-next-sha&path=README.md"
       ) {
         return historyResponse("README.md");
       }

--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.test.ts
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.test.ts
@@ -2,6 +2,7 @@
 
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/svelte";
 import { createQuerySerializer, type QuerySerializerOptions } from "openapi-fetch";
+import { tick } from "svelte";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import type { MiddlemanClient } from "@middleman/ui";
 import RepoBrowserFeature from "./RepoBrowserFeature.svelte";
@@ -100,6 +101,51 @@ describe("RepoBrowserFeature", () => {
 
     await screen.findByRole("heading", { name: "Usage" });
     await waitFor(() => expect(scrolledHeadingIDs(scrollIntoView)).toContain("usage"));
+  });
+
+  it("does not reload the repo when the resolved branch SHA is added to the route", async () => {
+    const client = testClient();
+    const onRouteChange = vi.fn();
+    const { rerender } = render(RepoBrowserFeature, {
+      props: {
+        client,
+        route: {
+          ...route,
+          refType: "branch",
+          refName: "main",
+          path: undefined,
+        },
+        onRouteChange,
+      },
+    });
+
+    await waitFor(() => expect(client.GET).toHaveBeenCalledTimes(5));
+    await waitFor(() => {
+      expect(onRouteChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          refType: "branch",
+          refName: "main",
+          refSHA: "main-sha",
+          path: "README.md",
+        }),
+        { replace: true },
+      );
+    });
+
+    await rerender({
+      client,
+      route: {
+        ...route,
+        refType: "branch",
+        refName: "main",
+        refSHA: "main-sha",
+        path: "README.md",
+      },
+      onRouteChange,
+    });
+
+    await tick();
+    expect(client.GET).toHaveBeenCalledTimes(5);
   });
 });
 

--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.test.ts
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.test.ts
@@ -69,6 +69,24 @@ describe("RepoBrowserFeature", () => {
     });
   });
 
+  it("renders markdown issue references as provider item links", async () => {
+    render(RepoBrowserFeature, {
+      props: {
+        client: testClient(),
+        route,
+        onRouteChange: vi.fn(),
+      },
+    });
+
+    const issueLink = await screen.findByRole("link", { name: "#12" });
+
+    expect(issueLink.classList.contains("item-ref")).toBe(true);
+    expect(issueLink.getAttribute("href")).toBe("/issues/github/acme/widgets/12");
+    expect(issueLink.getAttribute("data-provider")).toBe("github");
+    expect(issueLink.getAttribute("data-repo-path")).toBe("acme/widgets");
+    expect(issueLink.getAttribute("data-external-url")).toBe("https://github.com/acme/widgets/issues/12");
+  });
+
   it("applies route anchor changes for the selected markdown file", async () => {
     const scrollIntoView = vi.fn();
     Element.prototype.scrollIntoView = scrollIntoView;
@@ -393,7 +411,7 @@ function testClient(): MiddlemanClient {
         url ===
         "/repo/github/acme/widgets/browser/blob?repo_path=acme%2Fwidgets&ref_type=commit&ref_sha=main-sha&path=README.md"
       ) {
-        return blobResponse("README.md", "[Guide](docs/guide.md#install)\n");
+        return blobResponse("README.md", "[Guide](docs/guide.md#install)\n\nSee #12.\n");
       }
       if (
         url ===
@@ -405,7 +423,7 @@ function testClient(): MiddlemanClient {
         url ===
         "/repo/github/acme/widgets/browser/blob?repo_path=acme%2Fwidgets&ref_type=commit&ref_sha=tag-sha&path=README.md"
       ) {
-        return blobResponse("README.md", "[Guide](docs/guide.md#install)\n");
+        return blobResponse("README.md", "[Guide](docs/guide.md#install)\n\nSee #12.\n");
       }
       if (
         url ===

--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.test.ts
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.test.ts
@@ -296,7 +296,7 @@ function testClient(): MiddlemanClient {
       }
       if (
         url ===
-        "/repo/github/acme/widgets/browser/last-changed?repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&ref_sha=main-sha&path=README.md&path=docs%2Fguide.md"
+        "/repo/github/acme/widgets/browser/last-changed?repo_path=acme%2Fwidgets&ref_type=commit&ref_sha=main-sha&path=README.md&path=docs%2Fguide.md"
       ) {
         return {
           data: {
@@ -309,7 +309,7 @@ function testClient(): MiddlemanClient {
       }
       if (
         url ===
-        "/repo/github/acme/widgets/browser/last-changed?repo_path=acme%2Fwidgets&ref_type=tag&ref_name=v1.0.0&ref_sha=tag-sha&path=README.md&path=docs%2Fguide.md"
+        "/repo/github/acme/widgets/browser/last-changed?repo_path=acme%2Fwidgets&ref_type=commit&ref_sha=tag-sha&path=README.md&path=docs%2Fguide.md"
       ) {
         return {
           data: {
@@ -322,37 +322,37 @@ function testClient(): MiddlemanClient {
       }
       if (
         url ===
-        "/repo/github/acme/widgets/browser/blob?repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&ref_sha=main-sha&path=README.md"
+        "/repo/github/acme/widgets/browser/blob?repo_path=acme%2Fwidgets&ref_type=commit&ref_sha=main-sha&path=README.md"
       ) {
         return blobResponse("README.md", "[Guide](docs/guide.md#install)\n");
       }
       if (
         url ===
-        "/repo/github/acme/widgets/browser/blob?repo_path=acme%2Fwidgets&ref_type=tag&ref_name=v1.0.0&ref_sha=tag-sha&path=README.md"
+        "/repo/github/acme/widgets/browser/blob?repo_path=acme%2Fwidgets&ref_type=commit&ref_sha=tag-sha&path=README.md"
       ) {
         return blobResponse("README.md", "[Guide](docs/guide.md#install)\n");
       }
       if (
         url ===
-        "/repo/github/acme/widgets/browser/history?repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&ref_sha=main-sha&path=README.md"
+        "/repo/github/acme/widgets/browser/history?repo_path=acme%2Fwidgets&ref_type=commit&ref_sha=main-sha&path=README.md"
       ) {
         return historyResponse("README.md");
       }
       if (
         url ===
-        "/repo/github/acme/widgets/browser/history?repo_path=acme%2Fwidgets&ref_type=tag&ref_name=v1.0.0&ref_sha=tag-sha&path=README.md"
+        "/repo/github/acme/widgets/browser/history?repo_path=acme%2Fwidgets&ref_type=commit&ref_sha=tag-sha&path=README.md"
       ) {
         return historyResponse("README.md");
       }
       if (
         url ===
-        "/repo/github/acme/widgets/browser/blob?repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&ref_sha=main-sha&path=docs%2Fguide.md"
+        "/repo/github/acme/widgets/browser/blob?repo_path=acme%2Fwidgets&ref_type=commit&ref_sha=main-sha&path=docs%2Fguide.md"
       ) {
         return blobResponse("docs/guide.md", "# Install\n\n## Usage\n");
       }
       if (
         url ===
-        "/repo/github/acme/widgets/browser/history?repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&ref_sha=main-sha&path=docs%2Fguide.md"
+        "/repo/github/acme/widgets/browser/history?repo_path=acme%2Fwidgets&ref_type=commit&ref_sha=main-sha&path=docs%2Fguide.md"
       ) {
         return historyResponse("docs/guide.md");
       }

--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.test.ts
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.test.ts
@@ -66,7 +66,49 @@ describe("RepoBrowserFeature", () => {
       );
     });
   });
+
+  it("applies route anchor changes for the selected markdown file", async () => {
+    const scrollIntoView = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoView;
+    const client = testClient();
+    const onRouteChange = vi.fn();
+    const { rerender } = render(RepoBrowserFeature, {
+      props: {
+        client,
+        route: {
+          ...route,
+          path: "docs/guide.md",
+          anchor: "install",
+        },
+        onRouteChange,
+      },
+    });
+
+    await screen.findByRole("heading", { name: "Install" });
+    await waitFor(() => expect(scrolledHeadingIDs(scrollIntoView)).toContain("install"));
+
+    scrollIntoView.mockClear();
+    await rerender({
+      client,
+      route: {
+        ...route,
+        path: "docs/guide.md",
+        anchor: "usage",
+      },
+      onRouteChange,
+    });
+
+    await screen.findByRole("heading", { name: "Usage" });
+    await waitFor(() => expect(scrolledHeadingIDs(scrollIntoView)).toContain("usage"));
+  });
 });
+
+function scrolledHeadingIDs(scrollIntoView: ReturnType<typeof vi.fn>): string[] {
+  return scrollIntoView.mock.contexts.flatMap((context) => {
+    if (context instanceof HTMLElement && context.id) return [context.id];
+    return [];
+  });
+}
 
 function testClient(): MiddlemanClient {
   return {
@@ -128,7 +170,7 @@ function testClient(): MiddlemanClient {
         url ===
         "/repo/github/acme/widgets/browser/blob?repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&ref_sha=main-sha&path=docs%2Fguide.md"
       ) {
-        return blobResponse("docs/guide.md", "# Install\n");
+        return blobResponse("docs/guide.md", "# Install\n\n## Usage\n");
       }
       if (
         url ===

--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.test.ts
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.test.ts
@@ -149,6 +149,49 @@ describe("RepoBrowserFeature", () => {
     expect(client.GET).toHaveBeenCalledTimes(5);
   });
 
+  it("does not reload the repo when a no-ref route is self-replaced with the default ref", async () => {
+    const client = testClient();
+    const onRouteChange = vi.fn();
+    const { rerender } = render(RepoBrowserFeature, {
+      props: {
+        client,
+        route: {
+          ...route,
+          path: undefined,
+        },
+        onRouteChange,
+      },
+    });
+
+    await waitFor(() => expect(client.GET).toHaveBeenCalledTimes(5));
+    await waitFor(() => {
+      expect(onRouteChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          refType: "branch",
+          refName: "main",
+          refSHA: "main-sha",
+          path: "README.md",
+        }),
+        { replace: true },
+      );
+    });
+
+    await rerender({
+      client,
+      route: {
+        ...route,
+        refType: "branch",
+        refName: "main",
+        refSHA: "main-sha",
+        path: "README.md",
+      },
+      onRouteChange,
+    });
+
+    await tick();
+    expect(client.GET).toHaveBeenCalledTimes(5);
+  });
+
   it("does not reload the repo again after a user ref change updates the route", async () => {
     const client = testClient();
     const onRouteChange = vi.fn();

--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.test.ts
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.test.ts
@@ -1,0 +1,187 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/svelte";
+import { createQuerySerializer, type QuerySerializerOptions } from "openapi-fetch";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import type { MiddlemanClient } from "@middleman/ui";
+import RepoBrowserFeature from "./RepoBrowserFeature.svelte";
+
+const repo = {
+  provider: "github",
+  platformHost: "github.com",
+  owner: "acme",
+  name: "widgets",
+  repoPath: "acme/widgets",
+};
+
+const route = {
+  page: "repo-browser",
+  provider: "github",
+  owner: "acme",
+  name: "widgets",
+  repoPath: "acme/widgets",
+  path: "README.md",
+  mode: "preview",
+} as const;
+
+type TestGetOptions = {
+  params?: { path?: Record<string, string>; query?: Record<string, unknown> };
+  querySerializer?: QuerySerializerOptions;
+};
+
+const runtimeQuerySerializerOptions: QuerySerializerOptions = {
+  array: {
+    style: "form",
+    explode: false,
+  },
+};
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("RepoBrowserFeature", () => {
+  it("preserves markdown anchor fragments when opening repo docs", async () => {
+    Element.prototype.scrollIntoView = vi.fn();
+    const onRouteChange = vi.fn();
+    render(RepoBrowserFeature, {
+      props: {
+        client: testClient(),
+        route,
+        onRouteChange,
+      },
+    });
+
+    await fireEvent.click(await screen.findByRole("link", { name: "Guide" }));
+
+    await waitFor(() => {
+      expect(onRouteChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          path: "docs/guide.md",
+          viewMode: "preview",
+          anchor: "install",
+        }),
+        undefined,
+      );
+    });
+  });
+});
+
+function testClient(): MiddlemanClient {
+  return {
+    GET: vi.fn(async (path: string, options?: TestGetOptions) => {
+      const url = testURL(path, options);
+      if (url === "/repo/github/acme/widgets/browser/refs?repo_path=acme%2Fwidgets") {
+        return {
+          data: {
+            repo,
+            refs: [{ type: "branch", name: "main", sha: "main-sha", stale: false }],
+            default_ref: { type: "branch", name: "main", sha: "main-sha", stale: false },
+          },
+          response: new Response(null, { status: 200 }),
+        };
+      }
+      if (
+        url ===
+        "/repo/github/acme/widgets/browser/tree?repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&ref_sha=main-sha"
+      ) {
+        return {
+          data: {
+            repo,
+            ref: { type: "branch", name: "main", sha: "main-sha", stale: false },
+            entries: [
+              { path: "README.md", type: "blob", size: 31 },
+              { path: "docs/guide.md", type: "blob", size: 18 },
+            ],
+            truncated: false,
+          },
+          response: new Response(null, { status: 200 }),
+        };
+      }
+      if (
+        url ===
+        "/repo/github/acme/widgets/browser/last-changed?repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&ref_sha=main-sha&path=README.md&path=docs%2Fguide.md"
+      ) {
+        return {
+          data: {
+            repo,
+            ref: { type: "branch", name: "main", sha: "main-sha", stale: false },
+            commits: {},
+          },
+          response: new Response(null, { status: 200 }),
+        };
+      }
+      if (
+        url ===
+        "/repo/github/acme/widgets/browser/blob?repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&ref_sha=main-sha&path=README.md"
+      ) {
+        return blobResponse("README.md", "[Guide](docs/guide.md#install)\n");
+      }
+      if (
+        url ===
+        "/repo/github/acme/widgets/browser/history?repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&ref_sha=main-sha&path=README.md"
+      ) {
+        return historyResponse("README.md");
+      }
+      if (
+        url ===
+        "/repo/github/acme/widgets/browser/blob?repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&ref_sha=main-sha&path=docs%2Fguide.md"
+      ) {
+        return blobResponse("docs/guide.md", "# Install\n");
+      }
+      if (
+        url ===
+        "/repo/github/acme/widgets/browser/history?repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&ref_sha=main-sha&path=docs%2Fguide.md"
+      ) {
+        return historyResponse("docs/guide.md");
+      }
+      return {
+        error: { detail: `unexpected ${url}` },
+        response: new Response(null, { status: 404 }),
+      };
+    }),
+  } as unknown as MiddlemanClient;
+}
+
+function testURL(path: string, options?: TestGetOptions): string {
+  let url = path;
+  for (const [key, value] of Object.entries(options?.params?.path ?? {})) {
+    url = url.replace(`{${key}}`, encodeURIComponent(String(value)));
+  }
+  const serializer = createQuerySerializer(options?.querySerializer ?? runtimeQuerySerializerOptions);
+  const qs = serializer(options?.params?.query ?? {});
+  return qs ? `${url}?${qs}` : url;
+}
+
+function blobResponse(path: string, content: string) {
+  return {
+    data: {
+      repo,
+      ref: { type: "branch", name: "main", sha: "main-sha", stale: false },
+      blob: {
+        path,
+        sha: `${path}-blob-sha`,
+        size: content.length,
+        media_type: "text/markdown; charset=utf-8",
+        encoding: "utf-8",
+        content,
+        binary: false,
+        too_large: false,
+      },
+    },
+    response: new Response(null, { status: 200 }),
+  };
+}
+
+function historyResponse(path: string) {
+  return {
+    data: {
+      repo,
+      ref: { type: "branch", name: "main", sha: "main-sha", stale: false },
+      path,
+      commits: [],
+    },
+    response: new Response(null, { status: 200 }),
+  };
+}

--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.test.ts
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.test.ts
@@ -148,6 +148,49 @@ describe("RepoBrowserFeature", () => {
     await tick();
     expect(client.GET).toHaveBeenCalledTimes(5);
   });
+
+  it("does not reload the repo again after a user ref change updates the route", async () => {
+    const client = testClient();
+    const onRouteChange = vi.fn();
+    const { rerender } = render(RepoBrowserFeature, {
+      props: {
+        client,
+        route,
+        onRouteChange,
+      },
+    });
+
+    await waitFor(() => expect(client.GET).toHaveBeenCalledTimes(5));
+    await fireEvent.change(await screen.findByRole("combobox", { name: "Select repository ref" }), {
+      target: { value: "tag\0v1.0.0\0tag-sha" },
+    });
+    await waitFor(() => expect(client.GET).toHaveBeenCalledTimes(9));
+    await waitFor(() => {
+      expect(onRouteChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          refType: "tag",
+          refName: "v1.0.0",
+          refSHA: "tag-sha",
+          path: "README.md",
+        }),
+        undefined,
+      );
+    });
+
+    await rerender({
+      client,
+      route: {
+        ...route,
+        refType: "tag",
+        refName: "v1.0.0",
+        refSHA: "tag-sha",
+      },
+      onRouteChange,
+    });
+
+    await tick();
+    expect(client.GET).toHaveBeenCalledTimes(9);
+  });
 });
 
 function scrolledHeadingIDs(scrollIntoView: ReturnType<typeof vi.fn>): string[] {
@@ -165,7 +208,10 @@ function testClient(): MiddlemanClient {
         return {
           data: {
             repo,
-            refs: [{ type: "branch", name: "main", sha: "main-sha", stale: false }],
+            refs: [
+              { type: "branch", name: "main", sha: "main-sha", stale: false },
+              { type: "tag", name: "v1.0.0", sha: "tag-sha", stale: false },
+            ],
             default_ref: { type: "branch", name: "main", sha: "main-sha", stale: false },
           },
           response: new Response(null, { status: 200 }),
@@ -190,6 +236,23 @@ function testClient(): MiddlemanClient {
       }
       if (
         url ===
+        "/repo/github/acme/widgets/browser/tree?repo_path=acme%2Fwidgets&ref_type=tag&ref_name=v1.0.0&ref_sha=tag-sha"
+      ) {
+        return {
+          data: {
+            repo,
+            ref: { type: "tag", name: "v1.0.0", sha: "tag-sha", stale: false },
+            entries: [
+              { path: "README.md", type: "blob", size: 31 },
+              { path: "docs/guide.md", type: "blob", size: 18 },
+            ],
+            truncated: false,
+          },
+          response: new Response(null, { status: 200 }),
+        };
+      }
+      if (
+        url ===
         "/repo/github/acme/widgets/browser/last-changed?repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&ref_sha=main-sha&path=README.md&path=docs%2Fguide.md"
       ) {
         return {
@@ -203,13 +266,38 @@ function testClient(): MiddlemanClient {
       }
       if (
         url ===
+        "/repo/github/acme/widgets/browser/last-changed?repo_path=acme%2Fwidgets&ref_type=tag&ref_name=v1.0.0&ref_sha=tag-sha&path=README.md&path=docs%2Fguide.md"
+      ) {
+        return {
+          data: {
+            repo,
+            ref: { type: "tag", name: "v1.0.0", sha: "tag-sha", stale: false },
+            commits: {},
+          },
+          response: new Response(null, { status: 200 }),
+        };
+      }
+      if (
+        url ===
         "/repo/github/acme/widgets/browser/blob?repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&ref_sha=main-sha&path=README.md"
       ) {
         return blobResponse("README.md", "[Guide](docs/guide.md#install)\n");
       }
       if (
         url ===
+        "/repo/github/acme/widgets/browser/blob?repo_path=acme%2Fwidgets&ref_type=tag&ref_name=v1.0.0&ref_sha=tag-sha&path=README.md"
+      ) {
+        return blobResponse("README.md", "[Guide](docs/guide.md#install)\n");
+      }
+      if (
+        url ===
         "/repo/github/acme/widgets/browser/history?repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&ref_sha=main-sha&path=README.md"
+      ) {
+        return historyResponse("README.md");
+      }
+      if (
+        url ===
+        "/repo/github/acme/widgets/browser/history?repo_path=acme%2Fwidgets&ref_type=tag&ref_name=v1.0.0&ref_sha=tag-sha&path=README.md"
       ) {
         return historyResponse("README.md");
       }

--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.test.ts
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.test.ts
@@ -56,6 +56,7 @@ describe("RepoBrowserFeature", () => {
 
     await fireEvent.click(await screen.findByRole("link", { name: "Guide" }));
 
+    await screen.findByRole("heading", { name: "Install" });
     await waitFor(() => {
       expect(onRouteChange).toHaveBeenLastCalledWith(
         expect.objectContaining({

--- a/frontend/src/lib/features/repo-browser/repoBrowserViewState.test.ts
+++ b/frontend/src/lib/features/repo-browser/repoBrowserViewState.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  chooseRepoBrowserInitialPath,
+  formatRepoBrowserCommitDate,
+  formatRepoBrowserFileSize,
+  isRepoBrowserMarkdownPath,
+} from "./repoBrowserViewState.js";
+
+describe("repo browser view state", () => {
+  it("prefers a root README when no path is selected", () => {
+    expect(
+      chooseRepoBrowserInitialPath([
+        { path: "src/main.go", type: "blob" },
+        { path: "docs/README.md", type: "blob" },
+        { path: "README.md", type: "blob" },
+      ]),
+    ).toBe("README.md");
+  });
+
+  it("falls back to the first tracked file when no README exists", () => {
+    expect(
+      chooseRepoBrowserInitialPath([
+        { path: "cmd/", type: "tree" },
+        { path: "cmd/main.go", type: "blob" },
+      ]),
+    ).toBe("cmd/main.go");
+  });
+
+  it("recognizes Markdown files for preview mode", () => {
+    expect(isRepoBrowserMarkdownPath("README.md")).toBe(true);
+    expect(isRepoBrowserMarkdownPath("docs/design.MDX")).toBe(true);
+    expect(isRepoBrowserMarkdownPath("src/main.go")).toBe(false);
+  });
+
+  it("formats compact file sizes", () => {
+    expect(formatRepoBrowserFileSize(0)).toBe("0 B");
+    expect(formatRepoBrowserFileSize(512)).toBe("512 B");
+    expect(formatRepoBrowserFileSize(1536)).toBe("1.5 KB");
+    expect(formatRepoBrowserFileSize(1024 * 1024 * 2.25)).toBe("2.3 MB");
+  });
+
+  it("formats commit timestamps as stable local dates", () => {
+    expect(formatRepoBrowserCommitDate("2026-06-23T14:30:00Z")).toBe("Jun 23, 2026");
+    expect(formatRepoBrowserCommitDate("not-a-date")).toBe("");
+  });
+});

--- a/frontend/src/lib/features/repo-browser/repoBrowserViewState.ts
+++ b/frontend/src/lib/features/repo-browser/repoBrowserViewState.ts
@@ -1,0 +1,59 @@
+import type { RepoBrowserTreeEntry } from "@middleman/ui/api/types";
+
+const markdownExtensions = new Set([".md", ".mdx"]);
+
+export function chooseRepoBrowserInitialPath(
+  entries: readonly Pick<RepoBrowserTreeEntry, "path" | "type">[],
+): string | null {
+  const files = entries.filter((entry) => entry.type === "file" || entry.type === "blob");
+  const rootReadme = files.find((entry) => isReadme(entry.path) && !entry.path.includes("/"));
+  const nestedReadme = files.find((entry) => isReadme(entry.path));
+  return rootReadme?.path ?? nestedReadme?.path ?? files[0]?.path ?? null;
+}
+
+export function isRepoBrowserMarkdownPath(path: string | null | undefined): boolean {
+  if (!path) return false;
+  return markdownExtensions.has(extension(path));
+}
+
+export function formatRepoBrowserFileSize(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+  if (bytes < 1024) return `${Math.round(bytes)} B`;
+  const kib = bytes / 1024;
+  if (kib < 1024) return `${formatDecimal(kib)} KB`;
+  return `${formatDecimal(kib / 1024)} MB`;
+}
+
+export function formatRepoBrowserCommitDate(value: string | null | undefined): string {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(date);
+}
+
+function basename(path: string): string {
+  return (
+    path
+      .split(/[\\/]+/)
+      .filter(Boolean)
+      .at(-1) ?? ""
+  );
+}
+
+function isReadme(path: string): boolean {
+  return /^readme(?:\.[^.]+)?$/i.test(basename(path));
+}
+
+function extension(path: string): string {
+  const base = basename(path).toLowerCase();
+  const dot = base.lastIndexOf(".");
+  return dot >= 0 ? base.slice(dot) : "";
+}
+
+function formatDecimal(value: number): string {
+  return value >= 10 ? value.toFixed(0) : value.toFixed(1).replace(/\.0$/, "");
+}

--- a/frontend/src/lib/stores/router.svelte.ts
+++ b/frontend/src/lib/stores/router.svelte.ts
@@ -39,6 +39,7 @@ export type Route =
       refSHA?: string | undefined;
       path?: string | undefined;
       mode?: "source" | "preview" | undefined;
+      anchor?: string | undefined;
     }
   | { page: "workspaces" }
   | {
@@ -122,7 +123,7 @@ function stripBase(path: string): string {
 }
 
 function currentLocationPath(): string {
-  return window.location.pathname + window.location.search;
+  return window.location.pathname + window.location.search + window.location.hash;
 }
 
 const defaultPlatformHosts: Record<string, string> = {
@@ -143,6 +144,15 @@ function decodeRouteSegment(segment: string): string | undefined {
     return decodeURIComponent(segment);
   } catch {
     return undefined;
+  }
+}
+
+function decodeRouteHash(hash: string): string | undefined {
+  if (!hash) return undefined;
+  try {
+    return decodeURIComponent(hash);
+  } catch {
+    return hash;
   }
 }
 
@@ -208,6 +218,7 @@ function splitRepoPath(repoPath: string): { owner: string; name: string } | unde
 function parseRoute(fullPath: string): Route {
   const hashIdx = fullPath.indexOf("#");
   const routePath = hashIdx >= 0 ? fullPath.slice(0, hashIdx) : fullPath;
+  const anchor = hashIdx >= 0 ? decodeRouteHash(fullPath.slice(hashIdx + 1)) : undefined;
   const qIdx = routePath.indexOf("?");
   const pathname = qIdx >= 0 ? routePath.slice(0, qIdx) : routePath;
   const search = qIdx >= 0 ? routePath.slice(qIdx + 1) : "";
@@ -304,6 +315,7 @@ function parseRoute(fullPath: string): Route {
       ...(refSHA ? { refSHA } : {}),
       ...(selectedPath ? { path: selectedPath } : {}),
       ...(mode ? { mode } : {}),
+      ...(anchor ? { anchor } : {}),
     };
   }
   if (path === "/kata") {

--- a/frontend/src/lib/stores/router.svelte.ts
+++ b/frontend/src/lib/stores/router.svelte.ts
@@ -27,6 +27,19 @@ export type Route =
   | { page: "kata"; issue?: string; view?: KataTaskViewName; scope?: string }
   | { page: "docs"; folder: string | null; doc: string | null }
   | { page: "messages"; q: string | null; message: string | null; view?: "linked" }
+  | {
+      page: "repo-browser";
+      provider: string;
+      platformHost?: string | undefined;
+      repoPath: string;
+      owner: string;
+      name: string;
+      refType?: string | undefined;
+      refName?: string | undefined;
+      refSHA?: string | undefined;
+      path?: string | undefined;
+      mode?: "source" | "preview" | undefined;
+    }
   | { page: "workspaces" }
   | {
       page: "pulls";
@@ -264,6 +277,32 @@ function parseRoute(fullPath: string): Route {
   }
   if (path === "/repos") {
     return { page: "repos" };
+  }
+  if (path === "/repo/browser") {
+    const sp = new URLSearchParams(search);
+    const provider = emptyToNull(sp.get("provider"));
+    const repoPath = emptyToNull(sp.get("repo_path"))?.replace(/^\/+|\/+$/g, "");
+    const repo = repoPath ? splitRepoPath(repoPath) : undefined;
+    if (!provider || !repoPath || !repo) return { page: "repos" };
+    const platformHost = emptyToNull(sp.get("platform_host")) ?? defaultPlatformHost(provider);
+    const refType = parseRepoBrowserRefType(sp.get("ref_type"));
+    const refName = emptyToNull(sp.get("ref_name"));
+    const refSHA = emptyToNull(sp.get("ref_sha"));
+    const selectedPath = emptyToNull(sp.get("path"));
+    const mode = parseRepoBrowserViewMode(sp.get("mode"));
+    return {
+      page: "repo-browser",
+      provider,
+      ...(platformHost ? { platformHost } : {}),
+      repoPath,
+      owner: repo.owner,
+      name: repo.name,
+      ...(refType ? { refType } : {}),
+      ...(refName ? { refName } : {}),
+      ...(refSHA ? { refSHA } : {}),
+      ...(selectedPath ? { path: selectedPath } : {}),
+      ...(mode ? { mode } : {}),
+    };
   }
   if (path === "/kata") {
     const sp = new URLSearchParams(search);
@@ -641,6 +680,14 @@ function emptyToNull(value: string | null): string | null {
 function parseKataView(value: string | null): KataTaskViewName | undefined {
   if (value === null) return undefined;
   return kataViewNames.has(value as KataTaskViewName) ? (value as KataTaskViewName) : undefined;
+}
+
+function parseRepoBrowserRefType(value: string | null): "branch" | "tag" | "commit" | undefined {
+  return value === "branch" || value === "tag" || value === "commit" ? value : undefined;
+}
+
+function parseRepoBrowserViewMode(value: string | null): "source" | "preview" | undefined {
+  return value === "source" || value === "preview" ? value : undefined;
 }
 
 export function isWorkspacePage(page: Page): boolean {

--- a/frontend/src/lib/stores/router.svelte.ts
+++ b/frontend/src/lib/stores/router.svelte.ts
@@ -206,9 +206,11 @@ function splitRepoPath(repoPath: string): { owner: string; name: string } | unde
 }
 
 function parseRoute(fullPath: string): Route {
-  const qIdx = fullPath.indexOf("?");
-  const pathname = qIdx >= 0 ? fullPath.slice(0, qIdx) : fullPath;
-  const search = qIdx >= 0 ? fullPath.slice(qIdx + 1) : "";
+  const hashIdx = fullPath.indexOf("#");
+  const routePath = hashIdx >= 0 ? fullPath.slice(0, hashIdx) : fullPath;
+  const qIdx = routePath.indexOf("?");
+  const pathname = qIdx >= 0 ? routePath.slice(0, qIdx) : routePath;
+  const search = qIdx >= 0 ? routePath.slice(qIdx + 1) : "";
   const path = stripBase(pathname).replace(/\/+$/, "") || "/";
   const parts = path.split("/").filter(Boolean);
   if (path === "/m" || path === "/m/activity") {

--- a/frontend/src/lib/stores/router.svelte.ts
+++ b/frontend/src/lib/stores/router.svelte.ts
@@ -621,7 +621,7 @@ function buildRouteEvent(r: Route): MiddlemanNavigateEvent {
     navType = r.view === "board" ? "board" : "pull";
   } else if (r.page === "issues") {
     navType = "issue";
-  } else if (r.page === "repos") {
+  } else if (r.page === "repos" || r.page === "repo-browser") {
     navType = "repos";
   } else if (r.page === "kata") {
     navType = "kata";
@@ -652,7 +652,7 @@ function buildRouteEvent(r: Route): MiddlemanNavigateEvent {
     page,
     type: navType,
     focus,
-    view: stripBase(window.location.pathname) + window.location.search,
+    view: stripBase(currentLocationPath()),
   };
 
   if (r.page === "focus" && "owner" in r) {

--- a/frontend/src/lib/stores/router.test.ts
+++ b/frontend/src/lib/stores/router.test.ts
@@ -229,6 +229,27 @@ describe("router basic routes", () => {
     expect(getRoute()).toEqual({ page: "repos" });
   });
 
+  it("parses repo browser routes with selected ref, path, and view mode", () => {
+    navigate(
+      "/repo/browser?provider=gitlab&platform_host=gitlab.example.com&repo_path=Group%2FSub%20Team%2FProject&ref_type=branch&ref_name=feature%2Frepo-browser&ref_sha=abc123&path=docs%2FREADME.md&mode=preview",
+    );
+
+    expect(getRoute()).toEqual({
+      page: "repo-browser",
+      provider: "gitlab",
+      platformHost: "gitlab.example.com",
+      repoPath: "Group/Sub Team/Project",
+      owner: "Group/Sub Team",
+      name: "Project",
+      refType: "branch",
+      refName: "feature/repo-browser",
+      refSHA: "abc123",
+      path: "docs/README.md",
+      mode: "preview",
+    });
+    expect(getPage()).toBe("repo-browser");
+  });
+
   it("parses /kata", () => {
     navigate("/kata");
     expect(getRoute()).toEqual({ page: "kata" });

--- a/frontend/src/lib/stores/router.test.ts
+++ b/frontend/src/lib/stores/router.test.ts
@@ -262,6 +262,7 @@ describe("router basic routes", () => {
       name: "widgets",
       path: "docs/guide.md",
       mode: "preview",
+      anchor: "api-reference",
     });
   });
 

--- a/frontend/src/lib/stores/router.test.ts
+++ b/frontend/src/lib/stores/router.test.ts
@@ -250,6 +250,21 @@ describe("router basic routes", () => {
     expect(getPage()).toBe("repo-browser");
   });
 
+  it("parses repo browser routes without letting URL fragments corrupt query params", () => {
+    navigate("/repo/browser?provider=github&repo_path=acme%2Fwidgets&path=docs%2Fguide.md&mode=preview#api-reference");
+
+    expect(getRoute()).toEqual({
+      page: "repo-browser",
+      provider: "github",
+      platformHost: "github.com",
+      repoPath: "acme/widgets",
+      owner: "acme",
+      name: "widgets",
+      path: "docs/guide.md",
+      mode: "preview",
+    });
+  });
+
   it("parses /kata", () => {
     navigate("/kata");
     expect(getRoute()).toEqual({ page: "kata" });

--- a/frontend/src/lib/stores/router.test.ts
+++ b/frontend/src/lib/stores/router.test.ts
@@ -703,6 +703,19 @@ describe("router navigation events", () => {
     expect(payload.view).toBe("/messages?q=from%3Aops");
   });
 
+  it("maps repo browser routes to repos navigation events and preserves URL fragments", () => {
+    const spy = vi.fn();
+    installOnNavigate(spy);
+
+    navigate("/repo/browser?provider=github&repo_path=acme%2Fwidgets&path=README.md&mode=preview#install");
+
+    const payload = spy.mock.calls[spy.mock.calls.length - 1]![0];
+    expect(payload.type).toBe("repos");
+    expect(payload.view).toBe(
+      "/repo/browser?provider=github&repo_path=acme%2Fwidgets&path=README.md&mode=preview#install",
+    );
+  });
+
   it("maps every embed-workspace route to a workspaces navigation event", () => {
     const spy = vi.fn();
     installOnNavigate(spy);

--- a/frontend/tests/e2e-full/repo-browser.spec.ts
+++ b/frontend/tests/e2e-full/repo-browser.spec.ts
@@ -73,11 +73,17 @@ test.describe("repository source browser", () => {
       await expect(viewer.locator(".repo-browser__markdown h1")).toHaveText("Widget Service");
       await expect(viewer.locator(".repo-browser__source")).toHaveCount(0);
       await expect(page).toHaveURL(/mode=preview/);
+      await expect(viewer.getByRole("link", { name: "Tracker" })).toHaveAttribute(
+        "href",
+        "https://example.com/tracker.png",
+      );
+      await expect(viewer.locator('.repo-browser__markdown img[src="https://example.com/tracker.png"]')).toHaveCount(0);
 
       const guideBlobLoaded = blobResponse(page, "docs/guide.md");
       await viewer.getByRole("link", { name: "API reference" }).click();
       await guideBlobLoaded;
       await expect(viewer.locator(".repo-browser__path")).toContainText("docs/guide.md");
+      await expect(page).toHaveURL(/path=docs%2Fguide\.md&mode=preview#api-reference$/);
       await expectHeadingScrolledIntoView(viewer.locator("#api-reference"));
 
       const directGuideBlobLoaded = blobResponse(page, "docs/guide.md");

--- a/frontend/tests/e2e-full/repo-browser.spec.ts
+++ b/frontend/tests/e2e-full/repo-browser.spec.ts
@@ -93,6 +93,19 @@ test.describe("repository source browser", () => {
       await directGuideBlobLoaded;
       await expectHeadingScrolledIntoView(viewer.locator("#api-reference"));
 
+      await page.evaluate(() => {
+        window.__middleman_navigate_to_route?.(
+          "/repo/browser?provider=github&repo_path=acme%2Fwidgets&path=docs%2Fguide.md&mode=preview",
+        );
+      });
+      await expect(page).toHaveURL(/path=docs%2Fguide\.md&mode=preview$/);
+      await viewer.locator(".repo-browser__markdown").evaluate((node) => {
+        node.scrollTop = 0;
+      });
+      await page.goBack();
+      await expect(page).toHaveURL(/path=docs%2Fguide\.md&mode=preview#api-reference$/);
+      await expectHeadingScrolledIntoView(viewer.locator("#api-reference"));
+
       const history = browser.getByRole("complementary", { name: "File history" });
       await expect(history).toContainText("Initial commit");
       await history.getByRole("button", { name: /Initial commit/ }).click();

--- a/frontend/tests/e2e-full/repo-browser.spec.ts
+++ b/frontend/tests/e2e-full/repo-browser.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "@playwright/test";
+
+import { startIsolatedE2EServer } from "./support/e2eServer";
+
+test.describe("repository source browser", () => {
+  test("opens a seeded repository through the real browser API", async ({ page }) => {
+    const server = await startIsolatedE2EServer();
+    try {
+      await page.addInitScript(() => {
+        localStorage.setItem("repo-browser-view-mode", "preview");
+      });
+
+      const blobLoaded = page.waitForResponse((response) => {
+        const url = new URL(response.url());
+        return (
+          response.request().method() === "GET" &&
+          url.pathname === "/api/v1/repo/github/acme/widgets/browser/blob" &&
+          url.searchParams.get("path") === "README.md" &&
+          response.ok()
+        );
+      });
+
+      await page.goto(`${server.info.base_url}/repo/browser?provider=github&repo_path=acme%2Fwidgets&path=README.md`);
+      await blobLoaded;
+
+      const browser = page.getByRole("region", { name: "Repository source browser" });
+      await expect(browser).toBeVisible();
+      await expect(browser.locator(".repo-browser__repo")).toHaveText("acme/widgets");
+      await expect(browser.locator(".repo-browser__ref")).toHaveText("main");
+      await expect(browser.locator(".repo-browser__tree")).toContainText("handler");
+
+      const viewer = browser.getByRole("main", { name: "Selected file" });
+      await expect(viewer.locator(".repo-browser__path")).toContainText("README.md");
+      await expect(viewer.locator(".repo-browser__source")).toContainText("# Widget Service");
+      await expect(viewer.locator(".repo-browser__markdown")).toHaveCount(0);
+      await expect(page).not.toHaveURL(/mode=preview/);
+
+      await browser.getByRole("button", { name: "Preview" }).click();
+      await expect(viewer.locator(".repo-browser__markdown h1")).toHaveText("Widget Service");
+      await expect(viewer.locator(".repo-browser__source")).toHaveCount(0);
+      await expect(page).toHaveURL(/mode=preview/);
+
+      const history = browser.getByRole("complementary", { name: "File history" });
+      await expect(history).toContainText("Initial commit");
+      await history.getByRole("button", { name: /Initial commit/ }).click();
+      await expect(history.locator(".repo-browser__commit-detail")).toContainText("Initial commit");
+    } finally {
+      await server.stop();
+    }
+  });
+});

--- a/frontend/tests/e2e-full/repo-browser.spec.ts
+++ b/frontend/tests/e2e-full/repo-browser.spec.ts
@@ -2,6 +2,8 @@ import { expect, test, type Locator, type Page, type Response } from "@playwrigh
 
 import { startIsolatedE2EServer } from "./support/e2eServer";
 
+type RepoBrowserEndpoint = "refs" | "tree" | "blob";
+
 function blobResponse(page: Page, path: string): Promise<Response> {
   return page.waitForResponse((response) => {
     const url = new URL(response.url());
@@ -14,17 +16,23 @@ function blobResponse(page: Page, path: string): Promise<Response> {
   });
 }
 
-function repoBrowserResponseMatches(response: Response, endpoint: "refs" | "tree", refName?: string): boolean {
+function repoBrowserResponseMatches(
+  response: Response,
+  endpoint: RepoBrowserEndpoint,
+  refName?: string,
+  path?: string,
+): boolean {
   const url = new URL(response.url());
   return (
     response.request().method() === "GET" &&
     url.pathname === `/api/v1/repo/github/acme/widgets/browser/${endpoint}` &&
     (refName === undefined || url.searchParams.get("ref_name") === refName) &&
+    (path === undefined || url.searchParams.get("path") === path) &&
     response.ok()
   );
 }
 
-function repoBrowserResponse(page: Page, endpoint: "refs" | "tree", refName?: string): Promise<Response> {
+function repoBrowserResponse(page: Page, endpoint: RepoBrowserEndpoint, refName?: string): Promise<Response> {
   return page.waitForResponse((response) => repoBrowserResponseMatches(response, endpoint, refName));
 }
 
@@ -32,10 +40,15 @@ function treeResponse(page: Page, refName: string): Promise<Response> {
   return repoBrowserResponse(page, "tree", refName);
 }
 
-function collectRepoBrowserResponseURLs(page: Page, endpoint: "refs" | "tree", refName?: string): string[] {
+function collectRepoBrowserResponseURLs(
+  page: Page,
+  endpoint: RepoBrowserEndpoint,
+  refName?: string,
+  path?: string,
+): string[] {
   const urls: string[] = [];
   page.on("response", (response) => {
-    if (repoBrowserResponseMatches(response, endpoint, refName)) {
+    if (repoBrowserResponseMatches(response, endpoint, refName, path)) {
       urls.push(response.url());
     }
   });
@@ -44,7 +57,7 @@ function collectRepoBrowserResponseURLs(page: Page, endpoint: "refs" | "tree", r
 
 async function expectNoMoreRepoBrowserResponses(
   page: Page,
-  endpoint: "refs" | "tree",
+  endpoint: RepoBrowserEndpoint,
   refName?: string,
 ): Promise<void> {
   await expect(
@@ -85,6 +98,29 @@ async function expectHeadingScrolledIntoView(heading: Locator): Promise<void> {
 }
 
 test.describe("repository source browser", () => {
+  test("does not reload repository data when the no-ref route is replaced with the default ref", async ({ page }) => {
+    const server = await startIsolatedE2EServer();
+    try {
+      const refsURLs = collectRepoBrowserResponseURLs(page, "refs");
+      const treeURLs = collectRepoBrowserResponseURLs(page, "tree", "main");
+      const refsLoaded = repoBrowserResponse(page, "refs");
+      const treeLoaded = treeResponse(page, "main");
+
+      await page.goto(`${server.info.base_url}/repo/browser?provider=github&repo_path=acme%2Fwidgets`);
+      await refsLoaded;
+      await treeLoaded;
+
+      const browser = page.getByRole("region", { name: "Repository source browser" });
+      const viewer = browser.getByRole("main", { name: "Selected file" });
+      await expect(viewer.locator(".repo-browser__path")).toContainText("README.md");
+      await expectResolvedBranchURL(page);
+
+      await expectSingleRepoLoad(page, refsURLs, treeURLs);
+    } finally {
+      await server.stop();
+    }
+  });
+
   test("does not reload repository data when the resolved branch SHA is added to the route", async ({ page }) => {
     const server = await startIsolatedE2EServer();
     try {
@@ -105,6 +141,85 @@ test.describe("repository source browser", () => {
       await expectResolvedBranchURL(page);
 
       await expectSingleRepoLoad(page, refsURLs, treeURLs);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("does not reload repository data after a user ref change updates the route", async ({ page }) => {
+    const server = await startIsolatedE2EServer();
+    try {
+      const refsURLs = collectRepoBrowserResponseURLs(page, "refs");
+      const mainTreeURLs = collectRepoBrowserResponseURLs(page, "tree", "main");
+      const featureTreeURLs = collectRepoBrowserResponseURLs(page, "tree", "feature/caching");
+      const refsLoaded = repoBrowserResponse(page, "refs");
+      const mainTreeLoaded = treeResponse(page, "main");
+
+      await page.goto(
+        `${server.info.base_url}/repo/browser?provider=github&repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&path=README.md`,
+      );
+      await refsLoaded;
+      await mainTreeLoaded;
+
+      const browser = page.getByRole("region", { name: "Repository source browser" });
+      const refSelect = browser.getByLabel("Select repository ref");
+      const featureOption = await refSelect
+        .locator("option")
+        .filter({ hasText: "branch: feature/caching" })
+        .getAttribute("value");
+      expect(featureOption).toBeTruthy();
+
+      const featureTreeLoaded = treeResponse(page, "feature/caching");
+      await refSelect.selectOption(featureOption!);
+      await featureTreeLoaded;
+      await expect(page).toHaveURL(/ref_name=feature%2Fcaching/);
+
+      expect(refsURLs).toHaveLength(1);
+      expect(mainTreeURLs).toHaveLength(1);
+      expect(featureTreeURLs).toHaveLength(1);
+      await expectNoMoreRepoBrowserResponses(page, "refs");
+      await expectNoMoreRepoBrowserResponses(page, "tree", "feature/caching");
+      expect(refsURLs).toHaveLength(1);
+      expect(mainTreeURLs).toHaveLength(1);
+      expect(featureTreeURLs).toHaveLength(1);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("reloads repository data when a mounted route moves the same branch to a different SHA", async ({ page }) => {
+    const server = await startIsolatedE2EServer();
+    try {
+      const staleSHA = "0".repeat(40);
+      const treeURLs = collectRepoBrowserResponseURLs(page, "tree", "main");
+      const blobURLs = collectRepoBrowserResponseURLs(page, "blob", undefined, "README.md");
+      const initialTreeLoaded = treeResponse(page, "main");
+      const initialBlobLoaded = blobResponse(page, "README.md");
+
+      await page.goto(
+        `${server.info.base_url}/repo/browser?provider=github&repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&path=README.md`,
+      );
+      const initialTree = await initialTreeLoaded;
+      const initialTreeBody = (await initialTree.json()) as { ref: { sha: string } };
+      await initialBlobLoaded;
+
+      const movedTreeLoaded = treeResponse(page, "main");
+      const movedBlobLoaded = blobResponse(page, "README.md");
+      await page.evaluate((route) => {
+        window.__middleman_navigate_to_route?.(route);
+      }, `/repo/browser?provider=github&repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&ref_sha=${staleSHA}&path=README.md`);
+      const movedTree = await movedTreeLoaded;
+      const movedTreeBody = (await movedTree.json()) as {
+        ref: { sha: string; requested_sha?: string; stale: boolean };
+      };
+      await movedBlobLoaded;
+
+      expect(treeURLs).toHaveLength(2);
+      expect(blobURLs).toHaveLength(2);
+      expect(new URL(treeURLs[1]!).searchParams.get("ref_sha")).toBe(staleSHA);
+      expect(movedTreeBody.ref.sha).toBe(initialTreeBody.ref.sha);
+      expect(movedTreeBody.ref.requested_sha).toBe(staleSHA);
+      expect(movedTreeBody.ref.stale).toBe(true);
     } finally {
       await server.stop();
     }

--- a/frontend/tests/e2e-full/repo-browser.spec.ts
+++ b/frontend/tests/e2e-full/repo-browser.spec.ts
@@ -14,6 +14,18 @@ function blobResponse(page: Page, path: string): Promise<Response> {
   });
 }
 
+function treeResponse(page: Page, refName: string): Promise<Response> {
+  return page.waitForResponse((response) => {
+    const url = new URL(response.url());
+    return (
+      response.request().method() === "GET" &&
+      url.pathname === "/api/v1/repo/github/acme/widgets/browser/tree" &&
+      url.searchParams.get("ref_name") === refName &&
+      response.ok()
+    );
+  });
+}
+
 async function expectHeadingScrolledIntoView(heading: Locator): Promise<void> {
   await expect(heading).toBeVisible();
   const scrollTop = await heading.evaluate((node) => {
@@ -32,9 +44,17 @@ test.describe("repository source browser", () => {
         localStorage.setItem("repo-browser-view-mode", "preview");
       });
 
+      const treeLoaded = treeResponse(page, "main");
       const blobLoaded = blobResponse(page, "README.md");
 
-      await page.goto(`${server.info.base_url}/repo/browser?provider=github&repo_path=acme%2Fwidgets&path=README.md`);
+      await page.goto(
+        `${server.info.base_url}/repo/browser?provider=github&repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&path=README.md`,
+      );
+      const initialTree = await treeLoaded;
+      const initialTreeURL = new URL(initialTree.url());
+      expect(initialTreeURL.searchParams.get("ref_sha")).not.toBe("main");
+      const initialTreeBody = (await initialTree.json()) as { ref: { stale: boolean } };
+      expect(initialTreeBody.ref.stale).toBe(false);
       await blobLoaded;
 
       const browser = page.getByRole("region", { name: "Repository source browser" });

--- a/frontend/tests/e2e-full/repo-browser.spec.ts
+++ b/frontend/tests/e2e-full/repo-browser.spec.ts
@@ -14,16 +14,64 @@ function blobResponse(page: Page, path: string): Promise<Response> {
   });
 }
 
+function repoBrowserResponseMatches(response: Response, endpoint: "refs" | "tree", refName?: string): boolean {
+  const url = new URL(response.url());
+  return (
+    response.request().method() === "GET" &&
+    url.pathname === `/api/v1/repo/github/acme/widgets/browser/${endpoint}` &&
+    (refName === undefined || url.searchParams.get("ref_name") === refName) &&
+    response.ok()
+  );
+}
+
+function repoBrowserResponse(page: Page, endpoint: "refs" | "tree", refName?: string): Promise<Response> {
+  return page.waitForResponse((response) => repoBrowserResponseMatches(response, endpoint, refName));
+}
+
 function treeResponse(page: Page, refName: string): Promise<Response> {
-  return page.waitForResponse((response) => {
-    const url = new URL(response.url());
-    return (
-      response.request().method() === "GET" &&
-      url.pathname === "/api/v1/repo/github/acme/widgets/browser/tree" &&
-      url.searchParams.get("ref_name") === refName &&
-      response.ok()
-    );
+  return repoBrowserResponse(page, "tree", refName);
+}
+
+function collectRepoBrowserResponseURLs(page: Page, endpoint: "refs" | "tree", refName?: string): string[] {
+  const urls: string[] = [];
+  page.on("response", (response) => {
+    if (repoBrowserResponseMatches(response, endpoint, refName)) {
+      urls.push(response.url());
+    }
   });
+  return urls;
+}
+
+async function expectNoMoreRepoBrowserResponses(
+  page: Page,
+  endpoint: "refs" | "tree",
+  refName?: string,
+): Promise<void> {
+  await expect(
+    page.waitForResponse((response) => repoBrowserResponseMatches(response, endpoint, refName), { timeout: 500 }),
+  ).rejects.toThrow();
+}
+
+async function expectSingleRepoLoad(page: Page, refsURLs: string[], treeURLs: string[]): Promise<void> {
+  expect(refsURLs).toHaveLength(1);
+  expect(treeURLs).toHaveLength(1);
+  await expectNoMoreRepoBrowserResponses(page, "refs");
+  await expectNoMoreRepoBrowserResponses(page, "tree", "main");
+  expect(refsURLs).toHaveLength(1);
+  expect(treeURLs).toHaveLength(1);
+}
+
+async function expectResolvedBranchURL(page: Page): Promise<void> {
+  await expect(page).toHaveURL(/\/repo\/browser\?.*ref_sha=[0-9a-f]{40}/);
+  const url = new URL(page.url());
+  expect(url.pathname).toBe("/repo/browser");
+  expect(url.searchParams.get("provider")).toBe("github");
+  expect(url.searchParams.get("platform_host")).toBe("github.com");
+  expect(url.searchParams.get("repo_path")).toBe("acme/widgets");
+  expect(url.searchParams.get("ref_type")).toBe("branch");
+  expect(url.searchParams.get("ref_name")).toBe("main");
+  expect(url.searchParams.get("path")).toBe("README.md");
+  expect(url.searchParams.get("ref_sha")).toMatch(/^[0-9a-f]{40}$/);
 }
 
 async function expectHeadingScrolledIntoView(heading: Locator): Promise<void> {
@@ -37,6 +85,31 @@ async function expectHeadingScrolledIntoView(heading: Locator): Promise<void> {
 }
 
 test.describe("repository source browser", () => {
+  test("does not reload repository data when the resolved branch SHA is added to the route", async ({ page }) => {
+    const server = await startIsolatedE2EServer();
+    try {
+      const refsURLs = collectRepoBrowserResponseURLs(page, "refs");
+      const treeURLs = collectRepoBrowserResponseURLs(page, "tree", "main");
+      const refsLoaded = repoBrowserResponse(page, "refs");
+      const treeLoaded = treeResponse(page, "main");
+
+      await page.goto(
+        `${server.info.base_url}/repo/browser?provider=github&repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main`,
+      );
+      await refsLoaded;
+      await treeLoaded;
+
+      const browser = page.getByRole("region", { name: "Repository source browser" });
+      const viewer = browser.getByRole("main", { name: "Selected file" });
+      await expect(viewer.locator(".repo-browser__path")).toContainText("README.md");
+      await expectResolvedBranchURL(page);
+
+      await expectSingleRepoLoad(page, refsURLs, treeURLs);
+    } finally {
+      await server.stop();
+    }
+  });
+
   test("opens a seeded repository through the real browser API", async ({ page }) => {
     const server = await startIsolatedE2EServer();
     try {

--- a/frontend/tests/e2e-full/repo-browser.spec.ts
+++ b/frontend/tests/e2e-full/repo-browser.spec.ts
@@ -1,6 +1,28 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Locator, type Page, type Response } from "@playwright/test";
 
 import { startIsolatedE2EServer } from "./support/e2eServer";
+
+function blobResponse(page: Page, path: string): Promise<Response> {
+  return page.waitForResponse((response) => {
+    const url = new URL(response.url());
+    return (
+      response.request().method() === "GET" &&
+      url.pathname === "/api/v1/repo/github/acme/widgets/browser/blob" &&
+      url.searchParams.get("path") === path &&
+      response.ok()
+    );
+  });
+}
+
+async function expectHeadingScrolledIntoView(heading: Locator): Promise<void> {
+  await expect(heading).toBeVisible();
+  const scrollTop = await heading.evaluate((node) => {
+    const markdown = node.closest(".repo-browser__markdown");
+    if (!markdown) throw new Error("missing markdown scroller");
+    return markdown.scrollTop;
+  });
+  expect(scrollTop).toBeGreaterThan(100);
+}
 
 test.describe("repository source browser", () => {
   test("opens a seeded repository through the real browser API", async ({ page }) => {
@@ -10,15 +32,7 @@ test.describe("repository source browser", () => {
         localStorage.setItem("repo-browser-view-mode", "preview");
       });
 
-      const blobLoaded = page.waitForResponse((response) => {
-        const url = new URL(response.url());
-        return (
-          response.request().method() === "GET" &&
-          url.pathname === "/api/v1/repo/github/acme/widgets/browser/blob" &&
-          url.searchParams.get("path") === "README.md" &&
-          response.ok()
-        );
-      });
+      const blobLoaded = blobResponse(page, "README.md");
 
       await page.goto(`${server.info.base_url}/repo/browser?provider=github&repo_path=acme%2Fwidgets&path=README.md`);
       await blobLoaded;
@@ -39,6 +53,19 @@ test.describe("repository source browser", () => {
       await expect(viewer.locator(".repo-browser__markdown h1")).toHaveText("Widget Service");
       await expect(viewer.locator(".repo-browser__source")).toHaveCount(0);
       await expect(page).toHaveURL(/mode=preview/);
+
+      const guideBlobLoaded = blobResponse(page, "docs/guide.md");
+      await viewer.getByRole("link", { name: "API reference" }).click();
+      await guideBlobLoaded;
+      await expect(viewer.locator(".repo-browser__path")).toContainText("docs/guide.md");
+      await expectHeadingScrolledIntoView(viewer.locator("#api-reference"));
+
+      const directGuideBlobLoaded = blobResponse(page, "docs/guide.md");
+      await page.goto(
+        `${server.info.base_url}/repo/browser?provider=github&repo_path=acme%2Fwidgets&path=docs%2Fguide.md&mode=preview#api-reference`,
+      );
+      await directGuideBlobLoaded;
+      await expectHeadingScrolledIntoView(viewer.locator("#api-reference"));
 
       const history = browser.getByRole("complementary", { name: "File history" });
       await expect(history).toContainText("Initial commit");

--- a/internal/testutil/diff_repo.go
+++ b/internal/testutil/diff_repo.go
@@ -179,6 +179,17 @@ func SetupDiffRepo(
 		ctx, repoID, 1, headSHA, baseSHA); err != nil {
 		return nil, fmt.Errorf("update platform SHAs: %w", err)
 	}
+	if err := d.UpdateRepoProviderMetadata(
+		ctx,
+		repoID,
+		db.RepoProviderMetadata{
+			WebURL:        "https://github.com/acme/widgets",
+			CloneURL:      barePath,
+			DefaultBranch: "main",
+		},
+	); err != nil {
+		return nil, fmt.Errorf("update repo provider metadata: %w", err)
+	}
 
 	mgr := gitclone.New(cloneBase, nil)
 

--- a/internal/testutil/diff_repo.go
+++ b/internal/testutil/diff_repo.go
@@ -78,6 +78,10 @@ func SetupDiffRepo(
 		"README.md", readmeBase); err != nil {
 		return nil, err
 	}
+	if err := writeFile(workDir,
+		"docs/guide.md", guideMarkdownContent()); err != nil {
+		return nil, err
+	}
 
 	if err := git(ctx, workDir, "add", "-A"); err != nil {
 		return nil, err
@@ -445,6 +449,8 @@ const readmeBase = `# Widget Service
 
 A simple HTTP service for widget management.
 
+See the [API reference](docs/guide.md#api-reference).
+
 ## Getting Started
 
 Run the server with:
@@ -457,9 +463,35 @@ const readmeHead = `# Widget Service
 
 A simple HTTP service for widget management.
 
+See the [API reference](docs/guide.md#api-reference).
+
 ## Getting Started
 
 Run the server with:
 
       go run .
 `
+
+func guideMarkdownContent() string {
+	var b strings.Builder
+	b.WriteString(`# Widget Guide
+
+This guide is long enough for anchored navigation to require a scroll.
+
+## Overview
+
+The widget service keeps operational notes close to the code.
+`)
+	for i := 1; i <= 70; i++ {
+		fmt.Fprintf(&b, "\nParagraph %02d: background details for maintainers.\n", i)
+	}
+	b.WriteString(`
+## API Reference
+
+Use the widget API to list, cache, and refresh widget records.
+`)
+	for i := 1; i <= 20; i++ {
+		fmt.Fprintf(&b, "\nReference detail %02d: endpoint behavior.\n", i)
+	}
+	return b.String()
+}

--- a/internal/testutil/diff_repo.go
+++ b/internal/testutil/diff_repo.go
@@ -451,6 +451,8 @@ A simple HTTP service for widget management.
 
 See the [API reference](docs/guide.md#api-reference).
 
+![Tracker](https://example.com/tracker.png)
+
 ## Getting Started
 
 Run the server with:
@@ -464,6 +466,8 @@ const readmeHead = `# Widget Service
 A simple HTTP service for widget management.
 
 See the [API reference](docs/guide.md#api-reference).
+
+![Tracker](https://example.com/tracker.png)
 
 ## Getting Started
 

--- a/packages/ui/src/components/diff/PierreFileTree.svelte
+++ b/packages/ui/src/components/diff/PierreFileTree.svelte
@@ -3,16 +3,10 @@
   import type { FileTreeOptions } from "@pierre/trees";
   import { onMount, untrack } from "svelte";
   import type { DiffFile } from "../../api/types.js";
+  import type { FileTreeEntry } from "./file-tree-entry.js";
 
   type TreeGitStatus = NonNullable<FileTreeOptions["gitStatus"]>[number];
   type TreeRowDecoration = NonNullable<FileTreeOptions["renderRowDecoration"]>;
-
-  export interface FileTreeEntry {
-    path: string;
-    status?: TreeGitStatus["status"] | undefined;
-    decoration?: string | null | undefined;
-    decorationTitle?: string | undefined;
-  }
 
   interface Props {
     files: readonly DiffFile[] | null | undefined;

--- a/packages/ui/src/components/diff/file-tree-entry.ts
+++ b/packages/ui/src/components/diff/file-tree-entry.ts
@@ -1,0 +1,10 @@
+import type { FileTreeOptions } from "@pierre/trees";
+
+type TreeGitStatus = NonNullable<FileTreeOptions["gitStatus"]>[number];
+
+export interface FileTreeEntry {
+  path: string;
+  status?: TreeGitStatus["status"] | undefined;
+  decoration?: string | null | undefined;
+  decorationTitle?: string | undefined;
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -50,6 +50,7 @@ export {
   buildIssueRoute,
   buildPullRequestFilesRoute,
   buildPullRequestRoute,
+  buildRepoBrowserRoute,
   buildRoutedItemRoute,
 } from "./routes.js";
 export { supportsLocked } from "./api/provider-capabilities.js";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -63,6 +63,8 @@ export {
   filterSourceBrowserFileEntriesByCategory,
 } from "./utils/source-browser-files.js";
 export type { SourceBrowserFileEntry } from "./utils/source-browser-files.js";
+export { diffFileCategoryOptions } from "./utils/diff-categories.js";
+export type { DiffFileCategoryFilter } from "./utils/diff-categories.js";
 export type {
   FocusListRouteRef,
   IssueRouteRef,
@@ -164,4 +166,6 @@ export { default as WorkspaceDiffPanel } from "./components/workspace/WorkspaceD
 export { default as DiffSidebar } from "./components/diff/DiffSidebar.svelte";
 export { default as DiffToolbar } from "./components/diff/DiffToolbar.svelte";
 export { default as DiffView } from "./components/diff/DiffView.svelte";
+export { default as PierreFileTree } from "./components/diff/PierreFileTree.svelte";
+export type { FileTreeEntry } from "./components/diff/file-tree-entry.js";
 export { default as KbdBadge } from "./components/keyboard/KbdBadge.svelte";

--- a/packages/ui/src/routes.test.ts
+++ b/packages/ui/src/routes.test.ts
@@ -8,6 +8,7 @@ import {
   buildProviderIssueRoute,
   buildProviderPullRequestFilesRoute,
   buildProviderPullRequestRoute,
+  buildRepoBrowserRoute,
   buildPullRequestFilesRoute,
   buildPullRequestRoute,
   buildRoutedItemRoute,
@@ -116,5 +117,38 @@ describe("route item builders", () => {
     expect(buildRoutedItemRoute(issue, { focus: true })).toBe(
       "/focus/host/ghe.example.com/issues/github/acme/widgets/7",
     );
+  });
+
+  it("builds repo browser deep links with repo identity and selected source state", () => {
+    expect(
+      buildRepoBrowserRoute({
+        provider: "gitlab",
+        platformHost: "gitlab.example.com",
+        owner: "Group/SubGroup",
+        name: "Project",
+        repoPath: "Group/SubGroup/Project",
+        refType: "branch",
+        refName: "feature/search",
+        refSHA: "abcd",
+        path: "docs/README.md",
+        viewMode: "preview",
+      }),
+    ).toBe(
+      "/repo/browser?provider=gitlab&platform_host=gitlab.example.com&repo_path=Group%2FSubGroup%2FProject&ref_type=branch&ref_name=feature%2Fsearch&ref_sha=abcd&path=docs%2FREADME.md&mode=preview",
+    );
+  });
+
+  it("builds repo browser markdown anchor links with URL fragments", () => {
+    expect(
+      buildRepoBrowserRoute({
+        provider: "github",
+        owner: "acme",
+        name: "widgets",
+        repoPath: "acme/widgets",
+        path: "README.md",
+        viewMode: "preview",
+        anchor: "install guide",
+      }),
+    ).toBe("/repo/browser?provider=github&repo_path=acme%2Fwidgets&path=README.md&mode=preview#install%20guide");
   });
 });

--- a/packages/ui/src/routes.ts
+++ b/packages/ui/src/routes.ts
@@ -37,6 +37,7 @@ export type RepoBrowserRouteRef = RepositoryRouteRef & {
   refSHA?: string | undefined;
   path?: string | undefined;
   viewMode?: RepoBrowserViewMode | undefined;
+  anchor?: string | undefined;
 };
 
 export function buildPullRequestRoute(ref: PullRequestRouteRef): string {
@@ -78,6 +79,20 @@ export function buildFocusIssueRoute(ref: IssueRouteRef): string {
 export function buildFocusListRoute(ref: FocusListRouteRef): string {
   const route = `/focus/${ref.itemType}`;
   return ref.repo ? `${route}?repo=${encodeURIComponent(ref.repo)}` : route;
+}
+
+export function buildRepoBrowserRoute(ref: RepoBrowserRouteRef): string {
+  const params = new URLSearchParams();
+  params.set("provider", requireRouteText(ref.provider, "provider"));
+  if (ref.platformHost) params.set("platform_host", ref.platformHost);
+  params.set("repo_path", requireRouteText(ref.repoPath, "repoPath").replace(/^\/+|\/+$/g, ""));
+  if (ref.refType) params.set("ref_type", ref.refType);
+  if (ref.refName) params.set("ref_name", ref.refName);
+  if (ref.refSHA) params.set("ref_sha", ref.refSHA);
+  if (ref.path) params.set("path", ref.path);
+  if (ref.viewMode && ref.viewMode !== "source") params.set("mode", ref.viewMode);
+  const route = `/repo/browser?${params.toString()}`;
+  return ref.anchor ? `${route}#${encodeURIComponent(ref.anchor)}` : route;
 }
 
 export function buildRoutedItemRoute(ref: RoutedItemRef, options: { focus?: boolean } = {}): string {

--- a/packages/ui/src/stores/repo-browser.svelte.ts
+++ b/packages/ui/src/stores/repo-browser.svelte.ts
@@ -97,8 +97,8 @@ export function createRepoBrowserStore(opts: RepoBrowserStoreOptions = {}) {
       ...(selected && {
         ref_type: selected.type,
         ...(selected.name ? { ref_name: selected.name } : {}),
-        ...(selected.sha ? { ref_sha: selected.sha } : {}),
       }),
+      ...(selected?.sha ? { ref_sha: selected.sha } : {}),
     };
   }
 
@@ -161,7 +161,15 @@ export function createRepoBrowserStore(opts: RepoBrowserStoreOptions = {}) {
   }
 
   function chooseSelectedRef(requestedRef?: RepoBrowserRef | undefined): RepoBrowserRef | null {
-    if (requestedRef) return requestedRef;
+    if (requestedRef) {
+      if (!requestedRef.sha && requestedRef.type !== "commit") {
+        const resolved = refs.find(
+          (candidate) => candidate.type === requestedRef.type && candidate.name === requestedRef.name,
+        );
+        if (resolved) return resolved;
+      }
+      return requestedRef;
+    }
     return defaultRef ?? refs[0] ?? null;
   }
 

--- a/packages/ui/src/utils/markdown.ts
+++ b/packages/ui/src/utils/markdown.ts
@@ -48,7 +48,7 @@ function renderItemRefToken(token: Tokens.Generic): string {
   return `<a ${itemReferenceAnchorAttributes(token)}>${token.text}</a>`;
 }
 
-function itemRefExtension(repo?: RepoContext): TokenizerAndRendererExtension {
+export function providerItemRefExtension(repo?: RepoContext): TokenizerAndRendererExtension {
   const supportsBangMR = canonicalProvider(repo?.provider ?? "") === "gitlab";
   return {
     name: "itemRef",
@@ -267,7 +267,7 @@ function getMarked(repo?: RepoContext): Marked {
   let instance = markedCache.get(key);
   if (!instance) {
     instance = new Marked({ breaks: true, gfm: true });
-    instance.use({ extensions: [itemRefExtension(repo)] });
+    instance.use({ extensions: [providerItemRefExtension(repo)] });
     instance.use({
       renderer: taskListRenderer,
     });

--- a/packages/ui/src/utils/markdown.ts
+++ b/packages/ui/src/utils/markdown.ts
@@ -63,8 +63,12 @@ export function providerItemRefExtension(repo?: RepoContext): TokenizerAndRender
       const adjustedMR = mrBareIdx >= 0 && src[mrBareIdx] !== "!" ? mrBareIdx + 1 : mrBareIdx;
       return [crossIdx, adjusted, adjustedMR].filter((idx) => idx >= 0).sort((a, b) => a - b)[0];
     },
-    tokenizer(this: { lexer: { state: { inLink: boolean } } }, src: string): ItemRefToken | undefined {
-      if (this.lexer.state.inLink || !repo) return undefined;
+    tokenizer(
+      this: { lexer?: { state?: { inLink?: boolean; inRawBlock?: boolean } } },
+      src: string,
+    ): ItemRefToken | undefined {
+      const state = this.lexer?.state;
+      if (state?.inLink || state?.inRawBlock || !repo) return undefined;
 
       const crossMatch = src.match(/^([\w.-]+(?:\/[\w.-]+)+)([#!])(\d+)(?!\w)/);
       if (crossMatch) {


### PR DESCRIPTION
With the API and store boundary in place, maintainers need an actual code-reading workspace rather than another summary-card drilldown. This PR assembles the source view around ref and path navigation, the reusable file tree, source and Markdown rendering, and selected-file commit history.

Repository content is untrusted and refs can move, so the view keeps raw bytes and asset decisions behind backend preflight contracts while still giving reviewers a usable, forge-like repository browser.
