### PR TITLE
feat: add repo browser entry points

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,7 @@
         "@codemirror/view": "^6.43.0",
         "@lucide/svelte": "1.17.0",
         "@middleman/ui": "workspace:*",
+        "@pierre/diffs": "1.2.10",
         "@pierre/trees": "1.0.0-beta.4",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-ligatures": "^0.10.0",

--- a/context/platform-sync-invariants.md
+++ b/context/platform-sync-invariants.md
@@ -156,6 +156,11 @@ Repository import requests and route/query shapes should carry
   characters exactly once, via shared provider route helpers.
 - New provider-aware routes should not require ad hoc URL construction in
   stores/components.
+- Embedded navigation events for repo-bound routes must publish identity from
+  parsed route state, not from global embed config. When a route carries repo
+  identity, event payloads should include `provider`, `platform_host`, and
+  `repo_path` and may keep `repo` as the display/canonical path. Global
+  `ui.repo` config is only a fallback for non-repo-bound pages.
 
 ## Testing
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
     "@codemirror/view": "^6.43.0",
     "@lucide/svelte": "1.17.0",
     "@middleman/ui": "workspace:*",
+    "@pierre/diffs": "1.2.10",
     "@pierre/trees": "1.0.0-beta.4",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-ligatures": "^0.10.0",

--- a/frontend/src/lib/components/repositories/RepoSummaryCard.svelte
+++ b/frontend/src/lib/components/repositories/RepoSummaryCard.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { ActionButton, Chip, operationGate } from "@middleman/ui";
   import { timeAgo } from "@middleman/ui/utils/time";
-  import { ExternalLinkIcon } from "../../icons.js";
+  import { ExternalLinkIcon, FolderTreeIcon } from "../../icons.js";
   import ProviderIcon from "../provider/ProviderIcon.svelte";
   import RepoMetricGrid from "./RepoMetricGrid.svelte";
   import {
@@ -29,6 +29,7 @@
     showProviderIcon?: boolean;
     onviewprs: () => void;
     onviewissues: () => void;
+    onviewrepo: () => void;
     onopencomposer: () => void;
     onopenissue: (number: number) => void;
   }
@@ -38,6 +39,7 @@
     showProviderIcon = false,
     onviewprs,
     onviewissues,
+    onviewrepo,
     onopencomposer,
     onopenissue,
   }: Props = $props();
@@ -222,9 +224,18 @@
       {/if}
     </div>
 
-    {#if summary.repo.capabilities.issue_mutation}
-      {@const createIssueGate = operationGate(summary.operations?.create_issue)}
-      <div class="repo-card__actions">
+    <div class="repo-card__actions">
+      <ActionButton
+        size="sm"
+        tone="neutral"
+        surface="outline"
+        onclick={onviewrepo}
+      >
+        <FolderTreeIcon size="14" strokeWidth="2" aria-hidden="true" />
+        View repo
+      </ActionButton>
+      {#if summary.repo.capabilities.issue_mutation}
+        {@const createIssueGate = operationGate(summary.operations?.create_issue)}
         <ActionButton
           size="sm"
           tone="neutral"
@@ -235,8 +246,8 @@
         >
           New issue
         </ActionButton>
-      </div>
-    {/if}
+      {/if}
+    </div>
   </div>
 
   <RepoMetricGrid {metrics} compact />

--- a/frontend/src/lib/components/repositories/RepoSummaryCard.svelte
+++ b/frontend/src/lib/components/repositories/RepoSummaryCard.svelte
@@ -229,6 +229,7 @@
         size="sm"
         tone="neutral"
         surface="outline"
+        ariaLabel={`View repository source for ${summary.owner} ${summary.name} on ${summary.platform_host}`}
         onclick={onviewrepo}
       >
         <FolderTreeIcon size="14" strokeWidth="2" aria-hidden="true" />

--- a/frontend/src/lib/components/repositories/RepoSummaryPage.svelte
+++ b/frontend/src/lib/components/repositories/RepoSummaryPage.svelte
@@ -6,7 +6,7 @@
     providerRouteParams,
   } from "@middleman/ui/api/provider-routes";
   import type { RepoSummary } from "@middleman/ui/api/types";
-  import { buildIssueRoute } from "@middleman/ui/routes";
+  import { buildIssueRoute, buildRepoBrowserRoute } from "@middleman/ui/routes";
 
   import {
     RefreshIcon,
@@ -226,6 +226,19 @@
   ): void {
     setGlobalRepo(repoStateKey(summary));
     navigate(path);
+  }
+
+  function viewRepo(summary: RepoSummaryCardData): void {
+    filterAndNavigate(
+      summary,
+      buildRepoBrowserRoute({
+        provider: summary.repo.provider,
+        platformHost: summary.repo.platform_host,
+        owner: summary.repo.owner,
+        name: summary.repo.name,
+        repoPath: summary.repo.repo_path,
+      }),
+    );
   }
 
   function openComposer(summary: RepoSummaryCardData): void {
@@ -477,6 +490,7 @@
             filterAndNavigate(summary, "/pulls")}
           onviewissues={() =>
             filterAndNavigate(summary, "/issues")}
+          onviewrepo={() => viewRepo(summary)}
           onopencomposer={() => openComposer(summary)}
           onopenissue={(number) =>
             filterAndNavigate(

--- a/frontend/src/lib/components/repositories/RepoSummaryPage.test.ts
+++ b/frontend/src/lib/components/repositories/RepoSummaryPage.test.ts
@@ -410,7 +410,11 @@ describe("RepoSummaryPage", () => {
     render(RepoSummaryPage);
 
     await screen.findByRole("button", { name: /acme\s*\/\s*widgets/ });
-    await fireEvent.click(screen.getByRole("button", { name: "View repo" }));
+    await fireEvent.click(
+      screen.getByRole("button", {
+        name: "View repository source for acme widgets on github.com",
+      }),
+    );
 
     expect(mockSetGlobalRepo).toHaveBeenCalledWith("github.com/acme/widgets");
     expect(mockNavigate).toHaveBeenCalledWith(

--- a/frontend/src/lib/components/repositories/RepoSummaryPage.test.ts
+++ b/frontend/src/lib/components/repositories/RepoSummaryPage.test.ts
@@ -394,6 +394,30 @@ describe("RepoSummaryPage", () => {
     expect(mockNavigate).toHaveBeenCalledWith("/issues");
   });
 
+  it("opens the source browser from repository cards", async () => {
+    mockGet.mockResolvedValue({
+      data: [
+        repoSummaryFixture({
+          provider: "github",
+          platformHost: "github.com",
+          owner: "acme",
+          name: "widgets",
+        }),
+      ],
+      error: undefined,
+    });
+
+    render(RepoSummaryPage);
+
+    await screen.findByRole("button", { name: /acme\s*\/\s*widgets/ });
+    await fireEvent.click(screen.getByRole("button", { name: "View repo" }));
+
+    expect(mockSetGlobalRepo).toHaveBeenCalledWith("github.com/acme/widgets");
+    expect(mockNavigate).toHaveBeenCalledWith(
+      "/repo/browser?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets",
+    );
+  });
+
   it("filters repositories by search and stale release state", async () => {
     mockGet.mockResolvedValue({
       data: [

--- a/frontend/src/lib/components/repositories/RepoSummaryPage.test.ts
+++ b/frontend/src/lib/components/repositories/RepoSummaryPage.test.ts
@@ -416,7 +416,7 @@ describe("RepoSummaryPage", () => {
       }),
     );
 
-    expect(mockSetGlobalRepo).toHaveBeenCalledWith("github.com/acme/widgets");
+    expect(mockSetGlobalRepo).toHaveBeenCalledWith("github|github.com/acme/widgets");
     expect(mockNavigate).toHaveBeenCalledWith(
       "/repo/browser?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets",
     );

--- a/frontend/src/lib/features/repo-browser/PierreFileContents.svelte
+++ b/frontend/src/lib/features/repo-browser/PierreFileContents.svelte
@@ -15,6 +15,7 @@
   let host: HTMLElement | undefined = $state();
   let pierreFile: PierreFile<undefined> | undefined;
   let themeType = $state<ThemeTypes>(appThemeType());
+  let renderFailed = $state(false);
 
   const fileContents = $derived<FileContents>({
     name: path,
@@ -25,7 +26,6 @@
   const options = $derived.by<FileOptions<undefined>>(() => ({
     disableFileHeader: true,
     disableVirtualizationBuffers: true,
-    disableErrorHandling: true,
     overflow: wordWrap ? "wrap" : "scroll",
     theme: { dark: "pierre-dark", light: "pierre-light" },
     themeType,
@@ -71,19 +71,26 @@
 
   $effect(() => {
     if (!host) return;
-    pierreFile ??= new PierreFile<undefined>(options, undefined, true);
-    pierreFile.setOptions(options);
-    pierreFile.render({
-      file: fileContents,
-      fileContainer: host,
-      forceRender: true,
-      renderRange: {
-        startingLine: 0,
-        totalLines: Number.POSITIVE_INFINITY,
-        bufferBefore: 0,
-        bufferAfter: 0,
-      },
-    });
+    try {
+      renderFailed = false;
+      pierreFile ??= new PierreFile<undefined>(options, undefined, true);
+      pierreFile.setOptions(options);
+      pierreFile.render({
+        file: fileContents,
+        fileContainer: host,
+        forceRender: true,
+        renderRange: {
+          startingLine: 0,
+          totalLines: Number.POSITIVE_INFINITY,
+          bufferBefore: 0,
+          bufferAfter: 0,
+        },
+      });
+    } catch {
+      renderFailed = true;
+      pierreFile?.cleanUp();
+      pierreFile = undefined;
+    }
   });
 
   $effect(() => {
@@ -108,13 +115,33 @@
 <diffs-container
   bind:this={host}
   class="pierre-file-contents"
+  class:pierre-file-contents--hidden={renderFailed}
   data-testid="repo-browser-pierre-file-contents"
 ></diffs-container>
+{#if renderFailed}
+  <pre class="pierre-file-contents__fallback" data-testid="repo-browser-plaintext-file-contents"><code>{contents}</code></pre>
+{/if}
 
 <style>
   .pierre-file-contents {
     width: 100%;
     min-width: max-content;
     min-height: 100%;
+  }
+
+  .pierre-file-contents--hidden {
+    display: none;
+  }
+
+  .pierre-file-contents__fallback {
+    min-width: max-content;
+    min-height: 100%;
+    margin: 0;
+    background: var(--bg-primary, transparent);
+    color: var(--text-primary);
+    font: inherit;
+    line-height: 1.55;
+    tab-size: var(--diffs-tab-size, 2);
+    white-space: pre;
   }
 </style>

--- a/frontend/src/lib/features/repo-browser/PierreFileContents.svelte
+++ b/frontend/src/lib/features/repo-browser/PierreFileContents.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+  import { File as PierreFile } from "@pierre/diffs";
+  import type { FileContents, FileOptions, ThemeTypes } from "@pierre/diffs";
+  import { onMount } from "svelte";
+
+  interface Props {
+    path: string;
+    contents: string;
+    tabWidth?: number;
+    wordWrap?: boolean;
+  }
+
+  const { path, contents, tabWidth = 2, wordWrap = false }: Props = $props();
+
+  let host: HTMLElement | undefined = $state();
+  let pierreFile: PierreFile<undefined> | undefined;
+  let themeType = $state<ThemeTypes>(appThemeType());
+
+  const fileContents = $derived<FileContents>({
+    name: path,
+    contents,
+    cacheKey: fileContentsCacheKey(path, contents),
+  });
+
+  const options = $derived.by<FileOptions<undefined>>(() => ({
+    disableFileHeader: true,
+    disableVirtualizationBuffers: true,
+    disableErrorHandling: true,
+    overflow: wordWrap ? "wrap" : "scroll",
+    theme: { dark: "pierre-dark", light: "pierre-light" },
+    themeType,
+    tokenizeMaxLineLength: 180,
+    unsafeCSS: `
+      :host {
+        display: block;
+        min-height: 100%;
+        font-family: var(--font-mono);
+        --diffs-font-family: var(--font-mono);
+        --diffs-tab-size: ${tabWidth};
+        --diffs-light-bg: var(--bg-primary, #fff);
+        --diffs-dark-bg: var(--bg-primary, #0d0d12);
+      }
+      pre {
+        min-height: 100%;
+        margin: 0;
+        border-radius: 0;
+        background: var(--bg-primary, transparent);
+        font: inherit;
+        line-height: 1.55;
+      }
+    `,
+  }));
+
+  onMount(() => {
+    let themeObserver: MutationObserver | undefined;
+    if (typeof MutationObserver !== "undefined") {
+      themeObserver = new MutationObserver(() => {
+        themeType = appThemeType();
+      });
+      themeObserver.observe(document.documentElement, {
+        attributeFilter: ["class"],
+      });
+    }
+
+    return () => {
+      themeObserver?.disconnect();
+      pierreFile?.cleanUp();
+      pierreFile = undefined;
+    };
+  });
+
+  $effect(() => {
+    if (!host) return;
+    pierreFile ??= new PierreFile<undefined>(options, undefined, true);
+    pierreFile.setOptions(options);
+    pierreFile.render({
+      file: fileContents,
+      fileContainer: host,
+      forceRender: true,
+      renderRange: {
+        startingLine: 0,
+        totalLines: Number.POSITIVE_INFINITY,
+        bufferBefore: 0,
+        bufferAfter: 0,
+      },
+    });
+  });
+
+  $effect(() => {
+    pierreFile?.setThemeType(themeType);
+  });
+
+  function appThemeType(): ThemeTypes {
+    if (typeof document === "undefined") return "system";
+    return document.documentElement.classList.contains("dark") ? "dark" : "light";
+  }
+
+  function fileContentsCacheKey(filePath: string, text: string): string {
+    let hash = 2166136261;
+    for (let index = 0; index < text.length; index += 1) {
+      hash ^= text.charCodeAt(index);
+      hash = Math.imul(hash, 16777619);
+    }
+    return `${filePath}\0${text.length}\0${hash >>> 0}`;
+  }
+</script>
+
+<diffs-container
+  bind:this={host}
+  class="pierre-file-contents"
+  data-testid="repo-browser-pierre-file-contents"
+></diffs-container>
+
+<style>
+  .pierre-file-contents {
+    width: 100%;
+    min-width: max-content;
+    min-height: 100%;
+  }
+</style>

--- a/frontend/src/lib/features/repo-browser/PierreFileContents.test.ts
+++ b/frontend/src/lib/features/repo-browser/PierreFileContents.test.ts
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/svelte";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const pierreMock = vi.hoisted(() => ({
+  render: vi.fn(),
+  setOptions: vi.fn(),
+  setThemeType: vi.fn(),
+  cleanUp: vi.fn(),
+}));
+
+vi.mock("@pierre/diffs", () => ({
+  File: class {
+    setOptions(...args: unknown[]) {
+      return pierreMock.setOptions(...args);
+    }
+
+    render(...args: unknown[]) {
+      return pierreMock.render(...args);
+    }
+
+    setThemeType(...args: unknown[]) {
+      return pierreMock.setThemeType(...args);
+    }
+
+    cleanUp(...args: unknown[]) {
+      return pierreMock.cleanUp(...args);
+    }
+  },
+}));
+
+import PierreFileContents from "./PierreFileContents.svelte";
+
+describe("PierreFileContents", () => {
+  beforeEach(() => {
+    pierreMock.render.mockReset();
+    pierreMock.setOptions.mockReset();
+    pierreMock.setThemeType.mockReset();
+    pierreMock.cleanUp.mockReset();
+  });
+
+  it("falls back to plaintext when Pierre rendering throws", async () => {
+    pierreMock.render.mockImplementation(() => {
+      throw new Error("render failed");
+    });
+
+    render(PierreFileContents, {
+      props: {
+        path: "src/main.ts",
+        contents: "export const value = 1;\n",
+      },
+    });
+
+    const fallback = await screen.findByTestId("repo-browser-plaintext-file-contents");
+
+    expect(fallback.textContent).toBe("export const value = 1;\n");
+    expect(pierreMock.cleanUp).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
@@ -19,10 +19,12 @@
   import { RefreshIcon, ExternalLinkIcon, SpinnerIcon } from "../../icons";
   import {
     chooseRepoBrowserInitialPath,
+    formatRepoBrowserCommitAge,
     formatRepoBrowserCommitDate,
     formatRepoBrowserFileSize,
     isRepoBrowserMarkdownPath,
   } from "./repoBrowserViewState.js";
+  import PierreFileContents from "./PierreFileContents.svelte";
   import { apiBaseURL } from "../../api/runtime.js";
   import type { FolderIndex } from "../../api/docs/folderLinks";
 
@@ -262,8 +264,8 @@
     return {
       path: file.path,
       ...(lastChanged ? {
-        decoration: formatRepoBrowserCommitDate(lastChanged.authored_at),
-        decorationTitle: `${lastChanged.subject} (${lastChanged.sha.slice(0, 12)})`,
+        decoration: formatRepoBrowserCommitAge(lastChanged.authored_at),
+        decorationTitle: `${formatRepoBrowserCommitDate(lastChanged.authored_at)} · ${lastChanged.subject} (${lastChanged.sha.slice(0, 12)})`,
       } : {}),
     };
   }
@@ -452,6 +454,7 @@
         {#each diffFileCategoryOptions as option (option.value)}
           <button
             type="button"
+            aria-pressed={store.getFileCategoryFilter() === option.value}
             class:repo-browser__category--active={store.getFileCategoryFilter() === option.value}
             onclick={() => setCategoryFilter(option.value)}
           >
@@ -527,7 +530,9 @@
           />
         </article>
       {:else}
-        <pre class="repo-browser__source"><code>{selectedBlob.content}</code></pre>
+        <div class="repo-browser__source repo-browser__source--pierre">
+          <PierreFileContents path={selectedBlob.path} contents={selectedBlob.content} />
+        </div>
       {/if}
     </main>
 
@@ -711,10 +716,18 @@
     font-size: var(--font-size-xs);
   }
 
-  .repo-browser__categories button:hover,
-  .repo-browser__category--active {
+  .repo-browser__categories button:hover {
     color: var(--text-primary);
     background: var(--bg-surface-hover);
+  }
+
+  .repo-browser__categories button.repo-browser__category--active {
+    border-color: var(--accent-blue);
+    color: var(--accent-blue);
+    background: var(--bg-surface-hover);
+    box-shadow:
+      inset 0 0 0 1px color-mix(in srgb, var(--accent-blue) 55%, transparent),
+      0 0 0 1px color-mix(in srgb, var(--accent-blue) 18%, transparent);
   }
 
   .repo-browser__tree {
@@ -801,6 +814,14 @@
     font-size: var(--font-size-sm);
     line-height: 1.55;
     tab-size: 2;
+  }
+
+  .repo-browser__source--pierre {
+    padding: 0;
+  }
+
+  .repo-browser__source--pierre :global(.pierre-file-contents) {
+    padding: 14px 16px;
   }
 
   .repo-browser__markdown {

--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
@@ -82,6 +82,9 @@
   });
   const treeEntries = $derived(shownFiles.map(toTreeEntry));
   const categoryCounts = $derived(store.getFileCategoryCounts());
+  const visibleCategoryOptions = $derived(
+    diffFileCategoryOptions.filter((option) => option.value === "all" || categoryCounts[option.value] > 0),
+  );
   const markdownIndex = $derived(buildMarkdownIndex(store.getFileEntries()));
   const forgeHref = $derived(buildForgeHref(route, selectedRef, selectedPath));
 
@@ -451,7 +454,7 @@
         />
       </div>
       <div class="repo-browser__categories" aria-label="File category filters">
-        {#each diffFileCategoryOptions as option (option.value)}
+        {#each visibleCategoryOptions as option (option.value)}
           <button
             type="button"
             aria-pressed={store.getFileCategoryFilter() === option.value}

--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.test.ts
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.test.ts
@@ -99,6 +99,23 @@ describe("RepoBrowserFeature", () => {
     expect(issueLink.getAttribute("data-external-url")).toBe("https://github.com/acme/widgets/issues/12");
   });
 
+  it("hides zero-count file category filters", async () => {
+    render(RepoBrowserFeature, {
+      props: {
+        client: testClient(),
+        route,
+        onRouteChange: vi.fn(),
+      },
+    });
+
+    expect(await screen.findByRole("button", { name: "Plans/docs 2" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "All 2" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Code 0" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Tests 0" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Other 0" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Generated 0" })).toBeNull();
+  });
+
   it("applies route anchor changes for the selected markdown file", async () => {
     const scrollIntoView = vi.fn();
     Element.prototype.scrollIntoView = scrollIntoView;

--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.test.ts
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.test.ts
@@ -5,6 +5,11 @@ import { createQuerySerializer, type QuerySerializerOptions } from "openapi-fetc
 import { tick } from "svelte";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import type { MiddlemanClient } from "@middleman/ui";
+
+vi.mock("./PierreFileContents.svelte", async () => ({
+  default: (await import("./RepoBrowserFeatureTestPierreFileContents.svelte")).default,
+}));
+
 import RepoBrowserFeature from "./RepoBrowserFeature.svelte";
 
 const repo = {
@@ -28,6 +33,13 @@ const route = {
 type TestGetOptions = {
   params?: { path?: Record<string, string>; query?: Record<string, unknown> };
   querySerializer?: QuerySerializerOptions;
+};
+
+type TestClientOptions = {
+  sourceFile?: {
+    path: string;
+    content: string;
+  };
 };
 
 const runtimeQuerySerializerOptions: QuerySerializerOptions = {
@@ -291,6 +303,29 @@ describe("RepoBrowserFeature", () => {
     await tick();
     expect(client.GET).toHaveBeenCalledTimes(9);
   });
+
+  it("renders source files through Pierre file contents", async () => {
+    const sourceFile = {
+      path: "internal/main.go",
+      content: "package main\n\nfunc main() {}\n",
+    };
+    render(RepoBrowserFeature, {
+      props: {
+        client: testClient({ sourceFile }),
+        route: {
+          ...route,
+          path: sourceFile.path,
+          mode: "source",
+        },
+        onRouteChange: vi.fn(),
+      },
+    });
+
+    const viewer = await screen.findByTestId("repo-browser-pierre-file-contents");
+
+    expect(viewer.getAttribute("data-path")).toBe(sourceFile.path);
+    expect(viewer.textContent).toContain("package main");
+  });
 });
 
 function scrolledHeadingIDs(scrollIntoView: ReturnType<typeof vi.fn>): string[] {
@@ -300,10 +335,11 @@ function scrolledHeadingIDs(scrollIntoView: ReturnType<typeof vi.fn>): string[] 
   });
 }
 
-function testClient(): MiddlemanClient {
+function testClient(clientOptions: TestClientOptions = {}): MiddlemanClient {
   return {
     GET: vi.fn(async (path: string, options?: TestGetOptions) => {
       const url = testURL(path, options);
+      const treeEntries = testTreeEntries(clientOptions);
       if (url === "/repo/github/acme/widgets/browser/refs?repo_path=acme%2Fwidgets") {
         return {
           data: {
@@ -325,10 +361,7 @@ function testClient(): MiddlemanClient {
           data: {
             repo,
             ref: { type: "branch", name: "main", sha: "main-sha", stale: false },
-            entries: [
-              { path: "README.md", type: "blob", size: 31 },
-              { path: "docs/guide.md", type: "blob", size: 18 },
-            ],
+            entries: treeEntries,
             truncated: false,
           },
           response: new Response(null, { status: 200 }),
@@ -342,10 +375,7 @@ function testClient(): MiddlemanClient {
           data: {
             repo,
             ref: { type: "branch", name: "main", sha: "main-next-sha", stale: false },
-            entries: [
-              { path: "README.md", type: "blob", size: 13 },
-              { path: "docs/guide.md", type: "blob", size: 18 },
-            ],
+            entries: treeEntries,
             truncated: false,
           },
           response: new Response(null, { status: 200 }),
@@ -359,14 +389,20 @@ function testClient(): MiddlemanClient {
           data: {
             repo,
             ref: { type: "tag", name: "v1.0.0", sha: "tag-sha", stale: false },
-            entries: [
-              { path: "README.md", type: "blob", size: 31 },
-              { path: "docs/guide.md", type: "blob", size: 18 },
-            ],
+            entries: treeEntries,
             truncated: false,
           },
           response: new Response(null, { status: 200 }),
         };
+      }
+      if (url === lastChangedURL("main-sha", treeEntries)) {
+        return lastChangedResponse("main-sha");
+      }
+      if (url === lastChangedURL("main-next-sha", treeEntries)) {
+        return lastChangedResponse("main-next-sha");
+      }
+      if (url === lastChangedURL("tag-sha", treeEntries)) {
+        return lastChangedResponse("tag-sha");
       }
       if (
         url ===
@@ -455,12 +491,38 @@ function testClient(): MiddlemanClient {
       ) {
         return historyResponse("docs/guide.md");
       }
+      if (clientOptions.sourceFile && url === sourceEndpointURL("blob", "main-sha", clientOptions.sourceFile.path)) {
+        const file = clientOptions.sourceFile;
+        return blobResponse(file.path, file.content);
+      }
+      if (clientOptions.sourceFile && url === sourceEndpointURL("history", "main-sha", clientOptions.sourceFile.path)) {
+        return historyResponse(clientOptions.sourceFile.path);
+      }
       return {
         error: { detail: `unexpected ${url}` },
         response: new Response(null, { status: 404 }),
       };
     }),
   } as unknown as MiddlemanClient;
+}
+
+function testTreeEntries(options: TestClientOptions) {
+  return [
+    { path: "README.md", type: "blob", size: 31 },
+    { path: "docs/guide.md", type: "blob", size: 18 },
+    ...(options.sourceFile
+      ? [{ path: options.sourceFile.path, type: "blob", size: options.sourceFile.content.length }]
+      : []),
+  ];
+}
+
+function lastChangedURL(refSHA: string, entries: ReturnType<typeof testTreeEntries>): string {
+  const paths = entries.map((entry) => `path=${encodeURIComponent(entry.path)}`).join("&");
+  return `/repo/github/acme/widgets/browser/last-changed?repo_path=acme%2Fwidgets&ref_type=commit&ref_sha=${refSHA}&${paths}`;
+}
+
+function sourceEndpointURL(endpoint: "blob" | "history", refSHA: string, path: string): string {
+  return `/repo/github/acme/widgets/browser/${endpoint}?repo_path=acme%2Fwidgets&ref_type=commit&ref_sha=${refSHA}&path=${encodeURIComponent(path)}`;
 }
 
 function testURL(path: string, options?: TestGetOptions): string {
@@ -500,6 +562,17 @@ function historyResponse(path: string) {
       ref: { type: "branch", name: "main", sha: "main-sha", stale: false },
       path,
       commits: [],
+    },
+    response: new Response(null, { status: 200 }),
+  };
+}
+
+function lastChangedResponse(refSHA: string) {
+  return {
+    data: {
+      repo,
+      ref: { type: "branch", name: "main", sha: refSHA, stale: false },
+      commits: {},
     },
     response: new Response(null, { status: 200 }),
   };

--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeatureTestPierreFileContents.svelte
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeatureTestPierreFileContents.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  interface Props {
+    path: string;
+    contents: string;
+  }
+
+  const { path, contents }: Props = $props();
+</script>
+
+<pre data-testid="repo-browser-pierre-file-contents" data-path={path}><code>{contents}</code></pre>

--- a/frontend/src/lib/features/repo-browser/repoBrowserViewState.test.ts
+++ b/frontend/src/lib/features/repo-browser/repoBrowserViewState.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 import {
   chooseRepoBrowserInitialPath,
+  formatRepoBrowserCommitAge,
   formatRepoBrowserCommitDate,
   formatRepoBrowserFileSize,
   isRepoBrowserMarkdownPath,
@@ -42,5 +43,16 @@ describe("repo browser view state", () => {
   it("formats commit timestamps as stable local dates", () => {
     expect(formatRepoBrowserCommitDate("2026-06-23T14:30:00Z")).toBe("Jun 23, 2026");
     expect(formatRepoBrowserCommitDate("not-a-date")).toBe("");
+  });
+
+  it("formats commit timestamps as compact file tree ages", () => {
+    const now = new Date("2026-06-25T12:00:00Z");
+
+    expect(formatRepoBrowserCommitAge("2026-06-25T11:45:00Z", now)).toBe("15m");
+    expect(formatRepoBrowserCommitAge("2026-06-25T09:00:00Z", now)).toBe("3h");
+    expect(formatRepoBrowserCommitAge("2026-06-22T12:00:00Z", now)).toBe("3d");
+    expect(formatRepoBrowserCommitAge("2026-05-28T12:00:00Z", now)).toBe("4w");
+    expect(formatRepoBrowserCommitAge("2025-06-25T12:00:00Z", now)).toBe("12mo");
+    expect(formatRepoBrowserCommitAge("not-a-date", now)).toBe("");
   });
 });

--- a/frontend/src/lib/features/repo-browser/repoBrowserViewState.ts
+++ b/frontend/src/lib/features/repo-browser/repoBrowserViewState.ts
@@ -35,6 +35,25 @@ export function formatRepoBrowserCommitDate(value: string | null | undefined): s
   }).format(date);
 }
 
+export function formatRepoBrowserCommitAge(value: string | null | undefined, now: Date = new Date()): string {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime()) || Number.isNaN(now.getTime())) return "";
+  const diffMs = Math.max(0, now.getTime() - date.getTime());
+  const minuteMs = 60 * 1000;
+  const hourMs = 60 * minuteMs;
+  const dayMs = 24 * hourMs;
+  if (diffMs < hourMs) return `${Math.max(1, Math.floor(diffMs / minuteMs))}m`;
+  if (diffMs < dayMs) return `${Math.floor(diffMs / hourMs)}h`;
+  const days = Math.floor(diffMs / dayMs);
+  if (days < 14) return `${days}d`;
+  const weeks = Math.floor(days / 7);
+  if (weeks < 10) return `${weeks}w`;
+  const months = Math.floor(days / 30);
+  if (months < 18) return `${months}mo`;
+  return `${Math.floor(days / 365)}y`;
+}
+
 function basename(path: string): string {
   return (
     path

--- a/frontend/src/lib/icons.test.ts
+++ b/frontend/src/lib/icons.test.ts
@@ -7,6 +7,7 @@ const approvedIconNames = [
   "AlertIcon",
   "ChevronDownIcon",
   "ExternalLinkIcon",
+  "FolderTreeIcon",
   "MergeConflictIcon",
   "MonitorIcon",
   "MoonIcon",

--- a/frontend/src/lib/icons.ts
+++ b/frontend/src/lib/icons.ts
@@ -1,6 +1,7 @@
 export { default as AlertIcon } from "@lucide/svelte/icons/alert-triangle";
 export { default as ChevronDownIcon } from "@lucide/svelte/icons/chevron-down";
 export { default as ExternalLinkIcon } from "@lucide/svelte/icons/external-link";
+export { default as FolderTreeIcon } from "@lucide/svelte/icons/folder-tree";
 export { default as MergeConflictIcon } from "@lucide/svelte/icons/git-merge";
 export { default as MonitorIcon } from "@lucide/svelte/icons/monitor";
 export { default as MoonIcon } from "@lucide/svelte/icons/moon";

--- a/frontend/src/lib/stores/embed-config.svelte.ts
+++ b/frontend/src/lib/stores/embed-config.svelte.ts
@@ -37,12 +37,14 @@ export interface ProjectActionHook {
 // up ambient globals declared in vite-env.d.ts.
 export type ToolingStatusValue = ToolingStatus;
 
+type UIRepoConfig = NonNullable<NonNullable<MiddlemanConfig["ui"]>["repo"]>;
+
 interface UIDefaults {
   hideSync: boolean;
   hideRepoSelector: boolean;
   hideStar: boolean;
   sidebarCollapsed: boolean | undefined;
-  repo: { owner: string; name: string } | undefined;
+  repo: UIRepoConfig | undefined;
 }
 
 const UI_DEFAULTS: UIDefaults = {

--- a/frontend/src/lib/stores/filter.svelte.ts
+++ b/frontend/src/lib/stores/filter.svelte.ts
@@ -47,8 +47,8 @@ export function applyConfigRepo(
         host?: string;
         platform_host?: string;
         repo_path?: string;
-        owner: string;
-        name: string;
+        owner?: string;
+        name?: string;
       }
     | undefined,
   hideSelector: boolean,
@@ -56,7 +56,7 @@ export function applyConfigRepo(
   if (hideSelector) {
     const provider = repo?.provider?.trim();
     const host = (repo?.platform_host ?? repo?.host)?.trim();
-    const repoPath = (repo?.repo_path ?? (repo ? `${repo.owner}/${repo.name}` : "")).trim();
+    const repoPath = (repo?.repo_path ?? (repo?.owner && repo.name ? `${repo.owner}/${repo.name}` : "")).trim();
     if (provider && host && repoPath) {
       filterRepo = `${provider}|${host}/${repoPath}`;
     } else {

--- a/frontend/src/lib/stores/keyboard/actions.test.ts
+++ b/frontend/src/lib/stores/keyboard/actions.test.ts
@@ -473,6 +473,28 @@ describe("defaultActions", () => {
     expect(locationPath()).toBe("/repo/browser?provider=gitea&platform_host=code.example.com&repo_path=team%2Fwidgets");
   });
 
+  it("opens the repo browser from canonical workspace repo identity", () => {
+    const action = command("repo.browser.open");
+    window.__middleman_config = {
+      ui: {
+        repo: {
+          provider: "gitlab",
+          platform_host: "gitlab.example.com",
+          repo_path: "group/subgroup/widgets",
+        },
+      },
+    };
+    setConfiguredRepos([]);
+    const context = ctx("workspaces", { selectedPR: staleSelected });
+
+    expect(action.when(context)).toBe(true);
+    action.handler(context);
+
+    expect(locationPath()).toBe(
+      "/repo/browser?provider=gitlab&platform_host=gitlab.example.com&repo_path=group%2Fsubgroup%2Fwidgets",
+    );
+  });
+
   it("uses workspace provider and host hints when matching configured repos", () => {
     const action = command("repo.browser.open");
     window.__middleman_config = {

--- a/frontend/src/lib/stores/keyboard/actions.test.ts
+++ b/frontend/src/lib/stores/keyboard/actions.test.ts
@@ -358,6 +358,46 @@ describe("defaultActions", () => {
     expect(locationPath()).toBe("/repo/browser?provider=forgejo&platform_host=code.example.com&repo_path=team%2Ftools");
   });
 
+  it("opens the repo browser from focus routes without stale selected item state", () => {
+    const action = command("repo.browser.open");
+    const pullContext = ctx("focus", {
+      selectedPR: staleSelected,
+      route: {
+        page: "focus",
+        itemType: "pr",
+        provider: "gitlab",
+        platformHost: "gitlab.example.com",
+        owner: "group",
+        name: "project",
+        repoPath: "group/project",
+        number: 42,
+      } as never,
+    });
+
+    expect(action.when(pullContext)).toBe(true);
+    action.handler(pullContext);
+    expect(locationPath()).toBe(
+      "/repo/browser?provider=gitlab&platform_host=gitlab.example.com&repo_path=group%2Fproject",
+    );
+
+    const issueContext = ctx("focus", {
+      selectedIssue: staleSelected,
+      route: {
+        page: "focus",
+        itemType: "issue",
+        provider: "forgejo",
+        platformHost: "code.example.com",
+        owner: "team",
+        name: "docs",
+        repoPath: "team/docs",
+        number: 7,
+      } as never,
+    });
+
+    action.handler(issueContext);
+    expect(locationPath()).toBe("/repo/browser?provider=forgejo&platform_host=code.example.com&repo_path=team%2Fdocs");
+  });
+
   it("opens the repo browser for a uniquely configured workspace repo", () => {
     const action = command("repo.browser.open");
     window.__middleman_config = {

--- a/frontend/src/lib/stores/keyboard/actions.test.ts
+++ b/frontend/src/lib/stores/keyboard/actions.test.ts
@@ -39,9 +39,52 @@ const selected = {
   number: 1,
 };
 
+function command(id: string) {
+  const action = defaultActions.find((a) => a.id === id);
+  expect(action).toBeDefined();
+  return action!;
+}
+
+function locationPath(): string {
+  return window.location.pathname + window.location.search;
+}
+
+function configuredRepo(overrides: {
+  provider?: string;
+  platformHost?: string;
+  owner: string;
+  name: string;
+  repoPath?: string;
+  isGlob?: boolean;
+}) {
+  const repoPath = overrides.repoPath ?? `${overrides.owner}/${overrides.name}`;
+  return {
+    provider: overrides.provider ?? "github",
+    platform_host: overrides.platformHost ?? "github.com",
+    owner: overrides.owner,
+    name: overrides.name,
+    repo_path: repoPath,
+    is_glob: overrides.isGlob ?? false,
+    matched_repo_count: 1,
+  };
+}
+
+function setConfiguredRepos(repos: ReturnType<typeof configuredRepo>[]): void {
+  setStoreInstances(
+    () =>
+      ({
+        settings: {
+          getConfiguredRepos: () => repos,
+        },
+      }) as never,
+  );
+}
+
 describe("defaultActions", () => {
   afterEach(() => {
     setSidebarCollapsed(false);
+    delete window.__middleman_config;
+    window.history.replaceState(null, "", "/");
   });
 
   it("includes the migrated globals", () => {
@@ -57,6 +100,7 @@ describe("defaultActions", () => {
         "nav.pulls.board",
         "sidebar.toggle",
         "palette.open",
+        "repo.browser.open",
         "cheatsheet.open",
         "sync.repos",
         "theme.toggle",
@@ -251,5 +295,98 @@ describe("defaultActions", () => {
     expect(board!.when(ctx("kata"))).toBe(false);
     expect(list!.when(ctx("pulls"))).toBe(true);
     expect(board!.when(ctx("pulls"))).toBe(true);
+  });
+
+  it("opens the repo browser from a selected pull request", () => {
+    const action = command("repo.browser.open");
+    const context = ctx("pulls", { selectedPR: selected });
+
+    expect(action.when(context)).toBe(true);
+    action.handler(context);
+
+    expect(locationPath()).toBe("/repo/browser?provider=github&platform_host=github.com&repo_path=octo%2Frepo");
+  });
+
+  it("opens the repo browser from selected issue and activity contexts", () => {
+    const action = command("repo.browser.open");
+
+    expect(action.when(ctx("issues", { selectedIssue: selected }))).toBe(true);
+
+    window.history.replaceState(
+      null,
+      "",
+      "/?selected=issue:8&provider=gitlab&platform_host=gitlab.example.com&repo_path=group%2Fproject",
+    );
+    const context = ctx("activity");
+    expect(action.when(context)).toBe(true);
+    action.handler(context);
+
+    expect(locationPath()).toBe(
+      "/repo/browser?provider=gitlab&platform_host=gitlab.example.com&repo_path=group%2Fproject",
+    );
+  });
+
+  it("opens the repo browser for the current repo-browser route", () => {
+    const action = command("repo.browser.open");
+    const context = ctx("repo-browser", {
+      route: {
+        page: "repo-browser",
+        provider: "forgejo",
+        platformHost: "code.example.com",
+        owner: "team",
+        name: "tools",
+        repoPath: "team/tools",
+      },
+    });
+
+    expect(action.when(context)).toBe(true);
+    action.handler(context);
+
+    expect(locationPath()).toBe("/repo/browser?provider=forgejo&platform_host=code.example.com&repo_path=team%2Ftools");
+  });
+
+  it("opens the repo browser for a uniquely configured workspace repo", () => {
+    const action = command("repo.browser.open");
+    window.__middleman_config = {
+      ui: {
+        repo: { owner: "acme", name: "widgets" },
+      },
+    };
+    setConfiguredRepos([
+      configuredRepo({
+        owner: "acme",
+        name: "widgets",
+        repoPath: "acme/widgets",
+      }),
+    ]);
+    const context = ctx("workspaces");
+
+    expect(action.when(context)).toBe(true);
+    action.handler(context);
+
+    expect(locationPath()).toBe("/repo/browser?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets");
+  });
+
+  it("hides the repo browser command when workspace repo context is ambiguous", () => {
+    const action = command("repo.browser.open");
+    window.__middleman_config = {
+      ui: {
+        repo: { owner: "acme", name: "widgets" },
+      },
+    };
+    setConfiguredRepos([
+      configuredRepo({
+        owner: "acme",
+        name: "widgets",
+        platformHost: "github.com",
+      }),
+      configuredRepo({
+        owner: "acme",
+        name: "widgets",
+        platformHost: "ghe.example.com",
+      }),
+    ]);
+
+    expect(action.when(ctx("workspaces"))).toBe(false);
   });
 });

--- a/frontend/src/lib/stores/keyboard/actions.test.ts
+++ b/frontend/src/lib/stores/keyboard/actions.test.ts
@@ -436,6 +436,81 @@ describe("defaultActions", () => {
     expect(locationPath()).toBe("/repo/browser?provider=github&platform_host=github.com&repo_path=acme%2Fwidgets");
   });
 
+  it("opens the repo browser from fully qualified workspace repo config", () => {
+    const action = command("repo.browser.open");
+    window.__middleman_config = {
+      ui: {
+        repo: {
+          provider: "gitea",
+          platform_host: "code.example.com",
+          repo_path: "team/widgets",
+          owner: "acme",
+          name: "widgets",
+        },
+      },
+    };
+    setConfiguredRepos([
+      configuredRepo({
+        provider: "github",
+        platformHost: "github.com",
+        owner: "acme",
+        name: "widgets",
+        repoPath: "acme/widgets",
+      }),
+      configuredRepo({
+        provider: "gitlab",
+        platformHost: "gitlab.example.com",
+        owner: "acme",
+        name: "widgets",
+        repoPath: "acme/widgets",
+      }),
+    ]);
+    const context = ctx("workspaces", { selectedPR: staleSelected });
+
+    expect(action.when(context)).toBe(true);
+    action.handler(context);
+
+    expect(locationPath()).toBe("/repo/browser?provider=gitea&platform_host=code.example.com&repo_path=team%2Fwidgets");
+  });
+
+  it("uses workspace provider and host hints when matching configured repos", () => {
+    const action = command("repo.browser.open");
+    window.__middleman_config = {
+      ui: {
+        repo: {
+          provider: "gitlab",
+          platform_host: "gitlab.example.com",
+          owner: "acme",
+          name: "widgets",
+        },
+      },
+    };
+    setConfiguredRepos([
+      configuredRepo({
+        provider: "github",
+        platformHost: "github.com",
+        owner: "acme",
+        name: "widgets",
+        repoPath: "acme/widgets",
+      }),
+      configuredRepo({
+        provider: "gitlab",
+        platformHost: "gitlab.example.com",
+        owner: "acme",
+        name: "widgets",
+        repoPath: "group/widgets",
+      }),
+    ]);
+    const context = ctx("workspaces", { selectedPR: staleSelected });
+
+    expect(action.when(context)).toBe(true);
+    action.handler(context);
+
+    expect(locationPath()).toBe(
+      "/repo/browser?provider=gitlab&platform_host=gitlab.example.com&repo_path=group%2Fwidgets",
+    );
+  });
+
   it("hides the repo browser command when workspace repo context is ambiguous", () => {
     const action = command("repo.browser.open");
     window.__middleman_config = {

--- a/frontend/src/lib/stores/keyboard/actions.test.ts
+++ b/frontend/src/lib/stores/keyboard/actions.test.ts
@@ -39,6 +39,13 @@ const selected = {
   number: 1,
 };
 
+const staleSelected = {
+  ...selected,
+  owner: "stale",
+  name: "selection",
+  repoPath: "stale/selection",
+};
+
 function command(id: string) {
   const action = defaultActions.find((a) => a.id === id);
   expect(action).toBeDefined();
@@ -310,14 +317,20 @@ describe("defaultActions", () => {
   it("opens the repo browser from selected issue and activity contexts", () => {
     const action = command("repo.browser.open");
 
-    expect(action.when(ctx("issues", { selectedIssue: selected }))).toBe(true);
+    const issueContext = ctx("issues", {
+      selectedPR: staleSelected,
+      selectedIssue: selected,
+    });
+    expect(action.when(issueContext)).toBe(true);
+    action.handler(issueContext);
+    expect(locationPath()).toBe("/repo/browser?provider=github&platform_host=github.com&repo_path=octo%2Frepo");
 
     window.history.replaceState(
       null,
       "",
       "/?selected=issue:8&provider=gitlab&platform_host=gitlab.example.com&repo_path=group%2Fproject",
     );
-    const context = ctx("activity");
+    const context = ctx("activity", { selectedPR: staleSelected });
     expect(action.when(context)).toBe(true);
     action.handler(context);
 
@@ -359,7 +372,7 @@ describe("defaultActions", () => {
         repoPath: "acme/widgets",
       }),
     ]);
-    const context = ctx("workspaces");
+    const context = ctx("workspaces", { selectedPR: staleSelected });
 
     expect(action.when(context)).toBe(true);
     action.handler(context);

--- a/frontend/src/lib/stores/keyboard/actions.test.ts
+++ b/frontend/src/lib/stores/keyboard/actions.test.ts
@@ -339,6 +339,22 @@ describe("defaultActions", () => {
     );
   });
 
+  it("opens the repo browser from the route-selected issue before stale issue store state", () => {
+    const action = command("repo.browser.open");
+    const context = ctx("issues", {
+      selectedIssue: staleSelected,
+      route: {
+        page: "issues",
+        selected,
+      },
+    });
+
+    expect(action.when(context)).toBe(true);
+    action.handler(context);
+
+    expect(locationPath()).toBe("/repo/browser?provider=github&platform_host=github.com&repo_path=octo%2Frepo");
+  });
+
   it("opens the repo browser for the current repo-browser route", () => {
     const action = command("repo.browser.open");
     const context = ctx("repo-browser", {

--- a/frontend/src/lib/stores/keyboard/actions.ts
+++ b/frontend/src/lib/stores/keyboard/actions.ts
@@ -219,17 +219,39 @@ function workspacePageRepoRef(ctx: Context): RepositoryRouteRef | null {
   }
 }
 
+function pageSelectedPRRef(ctx: Context): RepositoryRouteRef | null {
+  if (
+    ctx.page === "pulls" ||
+    ctx.page === "mobile-pulls" ||
+    (ctx.route.page === "focus" && ctx.route.itemType === "pr")
+  ) {
+    return itemRepoRef(ctx.selectedPR);
+  }
+  return null;
+}
+
+function pageSelectedIssueRef(ctx: Context): RepositoryRouteRef | null {
+  if (
+    ctx.page === "issues" ||
+    ctx.page === "mobile-issues" ||
+    (ctx.route.page === "focus" && ctx.route.itemType === "issue")
+  ) {
+    return itemRepoRef(ctx.selectedIssue);
+  }
+  return null;
+}
+
 function repoBrowserCommandRef(ctx: Context): RepositoryRouteRef | null {
   const routeRef = routeRepoRef(ctx);
   if (routeRef) return routeRef;
-  const selectedPRRef = itemRepoRef(ctx.selectedPR);
-  if (selectedPRRef) return selectedPRRef;
-  const selectedIssueRef = itemRepoRef(ctx.selectedIssue);
-  if (selectedIssueRef) return selectedIssueRef;
   if (ctx.page === "activity") {
     return itemRepoRef(parseActivitySelection(window.location.search));
   }
-  return workspacePageRepoRef(ctx);
+  const workspaceRef = workspacePageRepoRef(ctx);
+  if (workspaceRef) return workspaceRef;
+  const selectedPRRef = pageSelectedPRRef(ctx);
+  if (selectedPRRef) return selectedPRRef;
+  return pageSelectedIssueRef(ctx);
 }
 
 function repoBrowserSubtitle(ref: RepositoryRouteRef | null): string | undefined {

--- a/frontend/src/lib/stores/keyboard/actions.ts
+++ b/frontend/src/lib/stores/keyboard/actions.ts
@@ -1,4 +1,5 @@
 import { getDetailTab, getSelectedPRFromRoute, navigate, replaceUrl } from "../router.svelte.js";
+import { getUIConfig } from "../embed-config.svelte.js";
 import { isSidebarToggleEnabled, toggleSidebar } from "../sidebar.svelte.js";
 import { toggleTheme } from "../theme.svelte.js";
 import { toggleCheatsheet } from "./cheatsheet-state.svelte.js";
@@ -7,9 +8,16 @@ import {
   openLabelPickerFor,
   type OpenLabelPickerDetail,
 } from "../../../../../packages/ui/src/components/detail/labelPickerCommand.js";
-import { buildPullRequestFilesRoute, buildPullRequestRoute } from "@middleman/ui/routes";
+import {
+  buildPullRequestFilesRoute,
+  buildPullRequestRoute,
+  buildRepoBrowserRoute,
+  type RepositoryRouteRef,
+} from "@middleman/ui/routes";
+import type { ConfigRepo } from "@middleman/ui/api/types";
 import type { StoreInstances } from "@middleman/ui";
-import type { Action, Context } from "./types.js";
+import type { Action, Context, PreviewBlock } from "./types.js";
+import { parseActivitySelection } from "../../utils/activitySelection.js";
 
 let storesGetter: (() => StoreInstances) | null = null;
 
@@ -120,6 +128,126 @@ function labelPickerDetail(ctx: Context): OpenLabelPickerDetail | null {
   if (ctx.page === "pulls") return prLabelPickerDetail(ctx);
   if (ctx.page === "issues") return issueLabelPickerDetail(ctx);
   return null;
+}
+
+function cleanRepoPath(repoPath: string | undefined): string {
+  return (repoPath ?? "").replace(/^\/+|\/+$/g, "");
+}
+
+type RepoSelectionRef = {
+  provider?: string | undefined;
+  platformHost?: string | undefined;
+  owner?: string | undefined;
+  name?: string | undefined;
+  repoPath?: string | undefined;
+};
+
+function itemRepoRef(ref: RepoSelectionRef | null): RepositoryRouteRef | null {
+  if (!ref) return null;
+  const repoPath = cleanRepoPath(ref.repoPath);
+  if (!ref.provider || !repoPath || !ref.owner || !ref.name) return null;
+  return {
+    provider: ref.provider,
+    platformHost: ref.platformHost,
+    owner: ref.owner,
+    name: ref.name,
+    repoPath,
+  };
+}
+
+function configuredRepoRef(repo: ConfigRepo): RepositoryRouteRef | null {
+  if (repo.is_glob) return null;
+  const repoPath = cleanRepoPath(repo.repo_path || `${repo.owner}/${repo.name}`);
+  if (!repo.provider || !repo.platform_host || !repo.owner || !repo.name || !repoPath) {
+    return null;
+  }
+  return {
+    provider: repo.provider,
+    platformHost: repo.platform_host,
+    owner: repo.owner,
+    name: repo.name,
+    repoPath,
+  };
+}
+
+function workspaceRepoRef(): RepositoryRouteRef | null {
+  const selectedRepo = getUIConfig().repo;
+  if (!selectedRepo) return null;
+  if (!storesGetter) return null;
+
+  const matches = stores()
+    .settings.getConfiguredRepos()
+    .filter((repo) => !repo.is_glob)
+    .filter((repo) => repo.owner === selectedRepo.owner && repo.name === selectedRepo.name)
+    .map(configuredRepoRef)
+    .filter((repo): repo is RepositoryRouteRef => repo !== null);
+  return matches.length === 1 ? (matches[0] ?? null) : null;
+}
+
+function routeRepoRef(ctx: Context): RepositoryRouteRef | null {
+  switch (ctx.route.page) {
+    case "repo-browser":
+      return {
+        provider: ctx.route.provider,
+        platformHost: ctx.route.platformHost,
+        owner: ctx.route.owner,
+        name: ctx.route.name,
+        repoPath: cleanRepoPath(ctx.route.repoPath),
+      };
+    case "embed-workspace-detail":
+      return {
+        provider: ctx.route.provider,
+        platformHost: ctx.route.platformHost,
+        owner: ctx.route.owner,
+        name: ctx.route.name,
+        repoPath: cleanRepoPath(ctx.route.repoPath),
+      };
+    default:
+      return null;
+  }
+}
+
+function workspacePageRepoRef(ctx: Context): RepositoryRouteRef | null {
+  switch (ctx.page) {
+    case "workspaces":
+    case "terminal":
+    case "embed-workspace-terminal":
+    case "embed-workspace-project":
+      return workspaceRepoRef();
+    default:
+      return null;
+  }
+}
+
+function repoBrowserCommandRef(ctx: Context): RepositoryRouteRef | null {
+  const routeRef = routeRepoRef(ctx);
+  if (routeRef) return routeRef;
+  const selectedPRRef = itemRepoRef(ctx.selectedPR);
+  if (selectedPRRef) return selectedPRRef;
+  const selectedIssueRef = itemRepoRef(ctx.selectedIssue);
+  if (selectedIssueRef) return selectedIssueRef;
+  if (ctx.page === "activity") {
+    return itemRepoRef(parseActivitySelection(window.location.search));
+  }
+  return workspacePageRepoRef(ctx);
+}
+
+function repoBrowserSubtitle(ref: RepositoryRouteRef | null): string | undefined {
+  if (!ref) return undefined;
+  return ref.platformHost ? `${ref.platformHost}/${ref.repoPath}` : ref.repoPath;
+}
+
+function repoBrowserPreview(ctx: Context): PreviewBlock {
+  const subtitle = repoBrowserSubtitle(repoBrowserCommandRef(ctx));
+  if (subtitle) {
+    return {
+      title: "View repository source",
+      subtitle,
+    };
+  }
+  return {
+    title: "View repository source",
+  };
 }
 
 // Mirrors App.svelte's pre-migration page exclusions for `1`/`2`/`f`/etc.:
@@ -276,6 +404,20 @@ export const defaultActions: Action[] = [
     priority: 0,
     when: always,
     handler: () => togglePalette(),
+  },
+  {
+    id: "repo.browser.open",
+    label: "View repository source",
+    scope: "global",
+    binding: null,
+    priority: 0,
+    when: (ctx) => repoBrowserCommandRef(ctx) !== null,
+    handler: (ctx) => {
+      const ref = repoBrowserCommandRef(ctx);
+      if (!ref) return;
+      navigate(buildRepoBrowserRoute(ref));
+    },
+    preview: repoBrowserPreview,
   },
   {
     id: "cheatsheet.open",

--- a/frontend/src/lib/stores/keyboard/actions.ts
+++ b/frontend/src/lib/stores/keyboard/actions.ts
@@ -134,6 +134,15 @@ function cleanRepoPath(repoPath: string | undefined): string {
   return (repoPath ?? "").replace(/^\/+|\/+$/g, "");
 }
 
+function repoIdentityFromPath(repoPath: string): { owner: string; name: string } | null {
+  const separator = repoPath.lastIndexOf("/");
+  if (separator <= 0 || separator === repoPath.length - 1) return null;
+  return {
+    owner: repoPath.slice(0, separator),
+    name: repoPath.slice(separator + 1),
+  };
+}
+
 type RepoSelectionRef = {
   provider?: string | undefined;
   platformHost?: string | undefined;
@@ -161,12 +170,14 @@ function workspaceConfigRepoRef(repo: WorkspaceConfigRepo): RepositoryRouteRef |
   const provider = repo.provider?.trim();
   const platformHost = (repo.platform_host ?? repo.host)?.trim();
   const repoPath = cleanRepoPath(repo.repo_path);
-  if (!provider || !platformHost || !repo.owner || !repo.name || !repoPath) return null;
+  if (!provider || !platformHost || !repoPath) return null;
+  const identity = repo.owner && repo.name ? { owner: repo.owner, name: repo.name } : repoIdentityFromPath(repoPath);
+  if (!identity) return null;
   return {
     provider,
     platformHost,
-    owner: repo.owner,
-    name: repo.name,
+    owner: identity.owner,
+    name: identity.name,
     repoPath,
   };
 }

--- a/frontend/src/lib/stores/keyboard/actions.ts
+++ b/frontend/src/lib/stores/keyboard/actions.ts
@@ -240,6 +240,9 @@ function pageSelectedPRRef(ctx: Context): RepositoryRouteRef | null {
 }
 
 function pageSelectedIssueRef(ctx: Context): RepositoryRouteRef | null {
+  if (ctx.route.page === "issues" && ctx.route.selected) {
+    return itemRepoRef(ctx.route.selected);
+  }
   if (
     ctx.page === "issues" ||
     ctx.page === "mobile-issues" ||

--- a/frontend/src/lib/stores/keyboard/actions.ts
+++ b/frontend/src/lib/stores/keyboard/actions.ts
@@ -142,6 +142,8 @@ type RepoSelectionRef = {
   repoPath?: string | undefined;
 };
 
+type WorkspaceConfigRepo = NonNullable<ReturnType<typeof getUIConfig>["repo"]>;
+
 function itemRepoRef(ref: RepoSelectionRef | null): RepositoryRouteRef | null {
   if (!ref) return null;
   const repoPath = cleanRepoPath(ref.repoPath);
@@ -151,6 +153,20 @@ function itemRepoRef(ref: RepoSelectionRef | null): RepositoryRouteRef | null {
     platformHost: ref.platformHost,
     owner: ref.owner,
     name: ref.name,
+    repoPath,
+  };
+}
+
+function workspaceConfigRepoRef(repo: WorkspaceConfigRepo): RepositoryRouteRef | null {
+  const provider = repo.provider?.trim();
+  const platformHost = (repo.platform_host ?? repo.host)?.trim();
+  const repoPath = cleanRepoPath(repo.repo_path);
+  if (!provider || !platformHost || !repo.owner || !repo.name || !repoPath) return null;
+  return {
+    provider,
+    platformHost,
+    owner: repo.owner,
+    name: repo.name,
     repoPath,
   };
 }
@@ -170,15 +186,29 @@ function configuredRepoRef(repo: ConfigRepo): RepositoryRouteRef | null {
   };
 }
 
+function configuredRepoMatchesWorkspace(repo: ConfigRepo, selectedRepo: WorkspaceConfigRepo): boolean {
+  if (repo.owner !== selectedRepo.owner || repo.name !== selectedRepo.name) return false;
+  if (selectedRepo.provider && repo.provider !== selectedRepo.provider) return false;
+  const selectedHost = selectedRepo.platform_host ?? selectedRepo.host;
+  if (selectedHost && repo.platform_host !== selectedHost) return false;
+  const selectedRepoPath = cleanRepoPath(selectedRepo.repo_path);
+  if (selectedRepoPath && cleanRepoPath(repo.repo_path || `${repo.owner}/${repo.name}`) !== selectedRepoPath) {
+    return false;
+  }
+  return true;
+}
+
 function workspaceRepoRef(): RepositoryRouteRef | null {
   const selectedRepo = getUIConfig().repo;
   if (!selectedRepo) return null;
+  const directRef = workspaceConfigRepoRef(selectedRepo);
+  if (directRef) return directRef;
   if (!storesGetter) return null;
 
   const matches = stores()
     .settings.getConfiguredRepos()
     .filter((repo) => !repo.is_glob)
-    .filter((repo) => repo.owner === selectedRepo.owner && repo.name === selectedRepo.name)
+    .filter((repo) => configuredRepoMatchesWorkspace(repo, selectedRepo))
     .map(configuredRepoRef)
     .filter((repo): repo is RepositoryRouteRef => repo !== null);
   return matches.length === 1 ? (matches[0] ?? null) : null;

--- a/frontend/src/lib/stores/keyboard/actions.ts
+++ b/frontend/src/lib/stores/keyboard/actions.ts
@@ -202,6 +202,15 @@ function routeRepoRef(ctx: Context): RepositoryRouteRef | null {
         name: ctx.route.name,
         repoPath: cleanRepoPath(ctx.route.repoPath),
       };
+    case "focus":
+      if (ctx.route.itemType !== "pr" && ctx.route.itemType !== "issue") return null;
+      return {
+        provider: ctx.route.provider,
+        platformHost: ctx.route.platformHost,
+        owner: ctx.route.owner,
+        name: ctx.route.name,
+        repoPath: cleanRepoPath(ctx.route.repoPath),
+      };
     default:
       return null;
   }

--- a/frontend/src/lib/stores/router.svelte.ts
+++ b/frontend/src/lib/stores/router.svelte.ts
@@ -675,7 +675,8 @@ function buildRouteEvent(r: Route): MiddlemanNavigateEvent {
   } else {
     const cfgRepo = getEmbedUIConfig().repo;
     if (cfgRepo) {
-      event.repo = `${cfgRepo.owner}/${cfgRepo.name}`;
+      const repo = embedConfigRepoName(cfgRepo);
+      if (repo) event.repo = repo;
     }
   }
 
@@ -685,6 +686,14 @@ function buildRouteEvent(r: Route): MiddlemanNavigateEvent {
   }
 
   return event;
+}
+
+function embedConfigRepoName(repo: NonNullable<ReturnType<typeof getEmbedUIConfig>["repo"]>): string | undefined {
+  const repoPath = repo.repo_path?.trim().replace(/^\/+|\/+$/g, "");
+  if (repoPath) return repoPath;
+  const owner = repo.owner?.trim().replace(/^\/+|\/+$/g, "");
+  const name = repo.name?.trim().replace(/^\/+|\/+$/g, "");
+  return owner && name ? `${owner}/${name}` : undefined;
 }
 
 function emptyToNull(value: string | null): string | null {

--- a/frontend/src/lib/stores/router.svelte.ts
+++ b/frontend/src/lib/stores/router.svelte.ts
@@ -655,24 +655,23 @@ function buildRouteEvent(r: Route): MiddlemanNavigateEvent {
     view: stripBase(currentLocationPath()),
   };
 
-  if (r.page === "focus" && "owner" in r) {
-    event.owner = r.owner;
-    event.name = r.name;
+  if (r.page === "focus" && "repoPath" in r) {
+    applyRouteRepoIdentity(event, r);
     event.number = r.number;
   } else if (r.page === "pulls" && "selected" in r && r.selected) {
-    event.owner = r.selected.owner;
-    event.name = r.selected.name;
+    applyRouteRepoIdentity(event, r.selected);
     event.number = r.selected.number;
   } else if (r.page === "issues" && "selected" in r && r.selected) {
-    event.owner = r.selected.owner;
-    event.name = r.selected.name;
+    applyRouteRepoIdentity(event, r.selected);
     event.number = r.selected.number;
+  } else if ("repoPath" in r) {
+    applyRouteRepoIdentity(event, r);
   }
 
   // Populate repo from focus list route or global config.
   if (r.page === "focus" && "repo" in r && r.repo) {
     event.repo = r.repo;
-  } else {
+  } else if (!event.repo_path) {
     const cfgRepo = getEmbedUIConfig().repo;
     if (cfgRepo) {
       const repo = embedConfigRepoName(cfgRepo);
@@ -686,6 +685,15 @@ function buildRouteEvent(r: Route): MiddlemanNavigateEvent {
   }
 
   return event;
+}
+
+function applyRouteRepoIdentity(event: MiddlemanNavigateEvent, ref: RepoRef): void {
+  event.provider = ref.provider;
+  if (ref.platformHost) event.platform_host = ref.platformHost;
+  event.repo_path = ref.repoPath;
+  event.repo = ref.repoPath;
+  event.owner = ref.owner;
+  event.name = ref.name;
 }
 
 function embedConfigRepoName(repo: NonNullable<ReturnType<typeof getEmbedUIConfig>["repo"]>): string | undefined {

--- a/frontend/src/lib/stores/router.svelte.ts
+++ b/frontend/src/lib/stores/router.svelte.ts
@@ -670,7 +670,12 @@ function buildRouteEvent(r: Route): MiddlemanNavigateEvent {
 
   // Populate repo from focus list route or global config.
   if (r.page === "focus" && "repo" in r && r.repo) {
-    event.repo = r.repo;
+    const repoIdentity = parseFocusListRepoIdentity(r.repo);
+    if (repoIdentity) {
+      applyRouteRepoIdentity(event, repoIdentity);
+    } else {
+      event.repo = r.repo;
+    }
   } else if (!event.repo_path) {
     const cfgRepo = getEmbedUIConfig().repo;
     if (cfgRepo) {
@@ -694,6 +699,31 @@ function applyRouteRepoIdentity(event: MiddlemanNavigateEvent, ref: RepoRef): vo
   event.repo = ref.repoPath;
   event.owner = ref.owner;
   event.name = ref.name;
+}
+
+function parseFocusListRepoIdentity(repo: string): RepoRef | undefined {
+  const raw = repo.trim();
+  if (!raw || raw.includes(",")) return undefined;
+  const pipeIndex = raw.indexOf("|");
+  if (pipeIndex <= 0) return undefined;
+  const provider = raw.slice(0, pipeIndex).trim();
+  const hostAndPath = raw.slice(pipeIndex + 1);
+  const slashIndex = hostAndPath.indexOf("/");
+  if (!provider || slashIndex <= 0) return undefined;
+  const platformHost = hostAndPath.slice(0, slashIndex).trim();
+  const repoPath = hostAndPath
+    .slice(slashIndex + 1)
+    .trim()
+    .replace(/^\/+|\/+$/g, "");
+  const repoParts = repoPath ? splitRepoPath(repoPath) : undefined;
+  if (!platformHost || !repoPath || !repoParts) return undefined;
+  return {
+    provider,
+    platformHost,
+    repoPath,
+    owner: repoParts.owner,
+    name: repoParts.name,
+  };
 }
 
 function embedConfigRepoName(repo: NonNullable<ReturnType<typeof getEmbedUIConfig>["repo"]>): string | undefined {

--- a/frontend/src/lib/stores/router.test.ts
+++ b/frontend/src/lib/stores/router.test.ts
@@ -554,8 +554,9 @@ describe("router navigation events", () => {
     ).__middleman_notify_config_changed?.();
   });
 
-  function installOnNavigate(spy: ReturnType<typeof vi.fn>): void {
+  function installOnNavigate(spy: ReturnType<typeof vi.fn>, config: Record<string, unknown> = {}): void {
     (window as unknown as { __middleman_config?: unknown }).__middleman_config = {
+      ...config,
       onNavigate: spy,
     };
     (
@@ -714,6 +715,45 @@ describe("router navigation events", () => {
     expect(payload.view).toBe(
       "/repo/browser?provider=github&repo_path=acme%2Fwidgets&path=README.md&mode=preview#install",
     );
+  });
+
+  it("uses embed repo_path for navigation event repo names", () => {
+    const spy = vi.fn();
+    installOnNavigate(spy, {
+      ui: {
+        repo: {
+          provider: "gitlab",
+          platform_host: "gitlab.example.com",
+          repo_path: "group/subgroup/project",
+        },
+      },
+    });
+
+    navigate("/repo/browser?provider=gitlab&platform_host=gitlab.example.com&repo_path=group%2Fsubgroup%2Fproject");
+
+    const payload = spy.mock.calls[spy.mock.calls.length - 1]![0];
+    expect(payload.type).toBe("repos");
+    expect(payload.repo).toBe("group/subgroup/project");
+  });
+
+  it("falls back to embed owner and name for navigation event repo names", () => {
+    const spy = vi.fn();
+    installOnNavigate(spy, {
+      ui: {
+        repo: {
+          provider: "github",
+          platform_host: "github.com",
+          owner: "acme",
+          name: "widgets",
+        },
+      },
+    });
+
+    navigate("/repos");
+
+    const payload = spy.mock.calls[spy.mock.calls.length - 1]![0];
+    expect(payload.type).toBe("repos");
+    expect(payload.repo).toBe("acme/widgets");
   });
 
   it("maps every embed-workspace route to a workspaces navigation event", () => {

--- a/frontend/src/lib/stores/router.test.ts
+++ b/frontend/src/lib/stores/router.test.ts
@@ -617,6 +617,40 @@ describe("router navigation events", () => {
     expect(payload.number).toBe(42);
   });
 
+  it("fires provider-aware repo payloads for focus list repo filters", () => {
+    const spy = vi.fn();
+    installOnNavigate(spy);
+
+    navigate("/focus/mrs?repo=gitlab%7Cgitlab.example.com%2Fgroup%2Fsubgroup%2Fproject");
+
+    const payload = spy.mock.calls[spy.mock.calls.length - 1]![0];
+    expect(payload.page).toBe("pulls");
+    expect(payload.type).toBe("pull");
+    expect(payload.focus).toBe(true);
+    expect(payload.provider).toBe("gitlab");
+    expect(payload.platform_host).toBe("gitlab.example.com");
+    expect(payload.repo_path).toBe("group/subgroup/project");
+    expect(payload.owner).toBe("group/subgroup");
+    expect(payload.name).toBe("project");
+    expect(payload.repo).toBe("group/subgroup/project");
+  });
+
+  it("keeps legacy focus list repo filters opaque in navigation events", () => {
+    const spy = vi.fn();
+    installOnNavigate(spy);
+
+    navigate("/focus/issues?repo=acme%2Fwidgets");
+
+    const payload = spy.mock.calls[spy.mock.calls.length - 1]![0];
+    expect(payload.page).toBe("issues");
+    expect(payload.type).toBe("issue");
+    expect(payload.focus).toBe(true);
+    expect(payload.repo).toBe("acme/widgets");
+    expect(payload.provider).toBeUndefined();
+    expect(payload.platform_host).toBeUndefined();
+    expect(payload.repo_path).toBeUndefined();
+  });
+
   it("fires onNavigate without owner/name/number for /pulls list", () => {
     const spy = vi.fn();
     installOnNavigate(spy);

--- a/frontend/src/lib/stores/router.test.ts
+++ b/frontend/src/lib/stores/router.test.ts
@@ -580,6 +580,10 @@ describe("router navigation events", () => {
     expect(payload.owner).toBe("acme");
     expect(payload.name).toBe("widgets");
     expect(payload.number).toBe(42);
+    expect(payload.provider).toBe("github");
+    expect(payload.platform_host).toBe("github.com");
+    expect(payload.repo_path).toBe("acme/widgets");
+    expect(payload.repo).toBe("acme/widgets");
   });
 
   it("fires onNavigate with pull payload for conversation route", () => {
@@ -704,27 +708,35 @@ describe("router navigation events", () => {
     expect(payload.view).toBe("/messages?q=from%3Aops");
   });
 
-  it("maps repo browser routes to repos navigation events and preserves URL fragments", () => {
+  it("maps repo browser routes to provider-aware repos navigation events and preserves URL fragments", () => {
     const spy = vi.fn();
     installOnNavigate(spy);
 
-    navigate("/repo/browser?provider=github&repo_path=acme%2Fwidgets&path=README.md&mode=preview#install");
+    navigate(
+      "/repo/browser?provider=gitlab&platform_host=gitlab.example.com&repo_path=group%2Fsubgroup%2Fproject&path=README.md&mode=preview#install",
+    );
 
     const payload = spy.mock.calls[spy.mock.calls.length - 1]![0];
     expect(payload.type).toBe("repos");
+    expect(payload.provider).toBe("gitlab");
+    expect(payload.platform_host).toBe("gitlab.example.com");
+    expect(payload.repo_path).toBe("group/subgroup/project");
+    expect(payload.owner).toBe("group/subgroup");
+    expect(payload.name).toBe("project");
+    expect(payload.repo).toBe("group/subgroup/project");
     expect(payload.view).toBe(
-      "/repo/browser?provider=github&repo_path=acme%2Fwidgets&path=README.md&mode=preview#install",
+      "/repo/browser?provider=gitlab&platform_host=gitlab.example.com&repo_path=group%2Fsubgroup%2Fproject&path=README.md&mode=preview#install",
     );
   });
 
-  it("uses embed repo_path for navigation event repo names", () => {
+  it("prefers route repo identity over embed repo config for repo browser navigation events", () => {
     const spy = vi.fn();
     installOnNavigate(spy, {
       ui: {
         repo: {
           provider: "gitlab",
           platform_host: "gitlab.example.com",
-          repo_path: "group/subgroup/project",
+          repo_path: "other/group/project",
         },
       },
     });
@@ -734,6 +746,9 @@ describe("router navigation events", () => {
     const payload = spy.mock.calls[spy.mock.calls.length - 1]![0];
     expect(payload.type).toBe("repos");
     expect(payload.repo).toBe("group/subgroup/project");
+    expect(payload.provider).toBe("gitlab");
+    expect(payload.platform_host).toBe("gitlab.example.com");
+    expect(payload.repo_path).toBe("group/subgroup/project");
   });
 
   it("falls back to embed owner and name for navigation event repo names", () => {

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -253,6 +253,9 @@ type MiddlemanNavigateType =
 interface MiddlemanNavigateEvent {
   page: MiddlemanNavigatePage;
   type: MiddlemanNavigateType;
+  provider?: string;
+  platform_host?: string;
+  repo_path?: string;
   owner?: string;
   name?: string;
   number?: number;

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -62,8 +62,8 @@ interface MiddlemanConfig {
       host?: string;
       platform_host?: string;
       repo_path?: string;
-      owner: string;
-      name: string;
+      owner?: string;
+      name?: string;
     };
     host?: string;
     activeWorktreeKey?: string;

--- a/frontend/tests/e2e-full/repo-browser.spec.ts
+++ b/frontend/tests/e2e-full/repo-browser.spec.ts
@@ -225,6 +225,36 @@ test.describe("repository source browser", () => {
     }
   });
 
+  test("opens the focused route repo from the command palette when a stale PR selection exists", async ({ page }) => {
+    const server = await startIsolatedE2EServer();
+    try {
+      await page.goto(`${server.info.base_url}/pulls/github/acme/tools/1`);
+      await page.locator(".pull-detail").waitFor({ state: "visible", timeout: 10_000 });
+
+      await page.goto(`${server.info.base_url}/focus/pulls/github/acme/widgets/1`);
+      await page.locator(".focus-layout .pull-detail").waitFor({ state: "visible", timeout: 10_000 });
+
+      const readmeLoaded = blobResponse(page, "README.md");
+      await page.keyboard.press(process.platform === "darwin" ? "Meta+K" : "Control+K");
+      const palette = page.getByRole("dialog", { name: "Command palette" });
+      await expect(palette).toBeVisible();
+      await palette.locator(".palette-input").fill("repo.browser.open");
+      await palette.getByRole("button", { name: /View repository source/ }).click();
+      await readmeLoaded;
+
+      const route = new URL(page.url());
+      expect(route.pathname).toBe("/repo/browser");
+      expect(route.searchParams.get("repo_path")).toBe("acme/widgets");
+      const browser = page.getByRole("region", { name: "Repository source browser" });
+      await expect(browser.locator(".repo-browser__repo")).toHaveText("acme/widgets");
+      await expect(browser.getByRole("main", { name: "Selected file" }).locator(".repo-browser__source")).toContainText(
+        "# Widget Service",
+      );
+    } finally {
+      await server.stop();
+    }
+  });
+
   test("opens a seeded repository through the real browser API", async ({ page }) => {
     const server = await startIsolatedE2EServer();
     try {

--- a/frontend/tests/e2e-full/repo-browser.spec.ts
+++ b/frontend/tests/e2e-full/repo-browser.spec.ts
@@ -231,7 +231,9 @@ test.describe("repository source browser", () => {
       await page.goto(`${server.info.base_url}/pulls/github/acme/tools/1`);
       await page.locator(".pull-detail").waitFor({ state: "visible", timeout: 10_000 });
 
-      await page.goto(`${server.info.base_url}/focus/pulls/github/acme/widgets/1`);
+      await page.evaluate((route) => {
+        window.__middleman_navigate_to_route?.(route);
+      }, "/focus/pulls/github/acme/widgets/1");
       await page.locator(".focus-layout .pull-detail").waitFor({ state: "visible", timeout: 10_000 });
 
       const readmeLoaded = blobResponse(page, "README.md");

--- a/frontend/tests/e2e-full/repo-summaries.spec.ts
+++ b/frontend/tests/e2e-full/repo-summaries.spec.ts
@@ -1,5 +1,17 @@
-import { expect, test } from "@playwright/test";
-import { startIsolatedE2EServerWithOptions } from "./support/e2eServer";
+import { expect, test, type Page } from "@playwright/test";
+import { startIsolatedE2EServer, startIsolatedE2EServerWithOptions } from "./support/e2eServer";
+
+function repoBrowserBlobLoaded(page: Page, path: string) {
+  return page.waitForResponse((response) => {
+    const url = new URL(response.url());
+    return (
+      response.request().method() === "GET" &&
+      url.pathname === "/api/v1/repo/github/acme/widgets/browser/blob" &&
+      url.searchParams.get("path") === path &&
+      response.ok()
+    );
+  });
+}
 
 test.describe("repository summaries", () => {
   test("hides a configured non-github default host in repo labels", async ({ page }) => {
@@ -29,6 +41,36 @@ test.describe("repository summaries", () => {
         .first();
       await expect(githubCard).toBeVisible();
       await expect(githubCard.getByText("github.com")).toBeVisible();
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("opens the source browser from a repository card through the real backend", async ({ page }) => {
+    const server = await startIsolatedE2EServer();
+    try {
+      const readmeLoaded = repoBrowserBlobLoaded(page, "README.md");
+      await page.goto(`${server.info.base_url}/repos`);
+
+      const widgetsCard = page
+        .locator(".repo-card")
+        .filter({
+          has: page.getByRole("button", {
+            name: /acme\s*\/\s*widgets/,
+          }),
+        })
+        .first();
+      await widgetsCard.waitFor({ state: "visible", timeout: 10_000 });
+      await widgetsCard.getByRole("button", { name: "View repository source for acme widgets on github.com" }).click();
+      await readmeLoaded;
+
+      await expect(page).toHaveURL(/\/repo\/browser\?provider=github/);
+      const browser = page.getByRole("region", { name: "Repository source browser" });
+      await expect(browser).toBeVisible();
+      await expect(browser.locator(".repo-browser__repo")).toHaveText("acme/widgets");
+      const viewer = browser.getByRole("main", { name: "Selected file" });
+      await expect(viewer.locator(".repo-browser__path")).toContainText("README.md");
+      await expect(viewer.locator(".repo-browser__source")).toContainText("# Widget Service");
     } finally {
       await server.stop();
     }

--- a/packages/ui/src/components/diff/PierreFileTree.svelte
+++ b/packages/ui/src/components/diff/PierreFileTree.svelte
@@ -80,8 +80,15 @@
       }
       [data-item-section='icon'],
       [data-item-section='git'],
+      [data-item-section='decoration'],
       [data-item-section='action'] {
         flex-shrink: 0;
+      }
+      [data-item-section='decoration'] {
+        max-width: 4ch;
+        overflow: hidden;
+        color: var(--text-muted);
+        text-overflow: ellipsis;
       }
       [data-item-section='content'] {
         flex: 1 1 auto;

--- a/packages/ui/src/stores/repo-browser.svelte.test.ts
+++ b/packages/ui/src/stores/repo-browser.svelte.test.ts
@@ -246,6 +246,68 @@ describe("createRepoBrowserStore", () => {
     expect(store.getFileHistory().map((item) => item.subject)).toEqual(["readme changed"]);
   });
 
+  it("loads last-changed metadata for file trees larger than one backend batch", async () => {
+    const entries = Array.from({ length: 251 }, (_, index) => ({
+      path: `src/file-${index.toString().padStart(3, "0")}.ts`,
+      type: "blob",
+      size: 10,
+    }));
+    const lastChangedBatches: string[][] = [];
+    const base = testClient();
+    const client = {
+      GET: vi.fn((path: string, options?: TestGetOptions) => {
+        const url = testURL(path, options);
+        if (
+          url ===
+          "/repo/github/acme/widgets/browser/tree?repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&ref_sha=main-sha"
+        ) {
+          return Promise.resolve({
+            data: {
+              repo,
+              ref: { type: "branch", name: "main", sha: "main-sha", stale: false },
+              entries,
+              truncated: false,
+            },
+            response: new Response(null, { status: 200 }),
+          });
+        }
+        if (url.startsWith("/repo/github/acme/widgets/browser/last-changed?")) {
+          const params = new URL(`http://middleman.test${url}`).searchParams;
+          const paths = params.getAll("path");
+          lastChangedBatches.push(paths);
+          return Promise.resolve({
+            data: {
+              repo,
+              ref: { type: "branch", name: "main", sha: "main-sha", stale: false },
+              commits: Object.fromEntries(paths.map((filePath) => [filePath, commit(`changed ${filePath}`)])),
+            },
+            response: new Response(null, { status: 200 }),
+          });
+        }
+        if (
+          url ===
+          "/repo/github/acme/widgets/browser/blob?repo_path=acme%2Fwidgets&ref_type=commit&ref_sha=main-sha&path=src%2Ffile-250.ts"
+        ) {
+          return Promise.resolve(blobResponse("src/file-250.ts", "export const selected = true;\n"));
+        }
+        if (
+          url ===
+          "/repo/github/acme/widgets/browser/history?repo_path=acme%2Fwidgets&ref_type=commit&ref_sha=main-sha&path=src%2Ffile-250.ts"
+        ) {
+          return Promise.resolve(historyResponse("src/file-250.ts", "changed src/file-250.ts"));
+        }
+        return base.GET(path, options);
+      }),
+    } as unknown as TestClient;
+    const store = createRepoBrowserStore({ client });
+
+    await store.loadRepo(repo, { path: "src/file-250.ts" });
+
+    expect(lastChangedBatches.map((batch) => batch.length)).toEqual([250, 1]);
+    expect(store.getFileEntries()[0]?.lastChanged?.subject).toBe("changed src/file-000.ts");
+    expect(store.getFileEntries()[250]?.lastChanged?.subject).toBe("changed src/file-250.ts");
+  });
+
   it("persists source and preview view mode", () => {
     const store = createRepoBrowserStore({ client: testClient() });
 

--- a/packages/ui/src/stores/repo-browser.svelte.test.ts
+++ b/packages/ui/src/stores/repo-browser.svelte.test.ts
@@ -238,12 +238,14 @@ describe("createRepoBrowserStore", () => {
 
     expect(store.getDefaultRef()?.name).toBe("main");
     expect(store.getSelectedPath()).toBe("README.md");
-    expect(store.getFileEntries().map((entry) => [entry.path, entry.lastChanged?.subject])).toEqual([
-      ["README.md", "readme changed"],
-      ["src/app.ts", "app changed"],
-    ]);
     expect(store.getBlob()?.content).toBe("# Widgets\n");
     expect(store.getFileHistory().map((item) => item.subject)).toEqual(["readme changed"]);
+    await vi.waitFor(() => {
+      expect(store.getFileEntries().map((entry) => [entry.path, entry.lastChanged?.subject])).toEqual([
+        ["README.md", "readme changed"],
+        ["src/app.ts", "app changed"],
+      ]);
+    });
   });
 
   it("loads last-changed metadata for file trees larger than one backend batch", async () => {
@@ -303,9 +305,56 @@ describe("createRepoBrowserStore", () => {
 
     await store.loadRepo(repo, { path: "src/file-250.ts" });
 
-    expect(lastChangedBatches.map((batch) => batch.length)).toEqual([250, 1]);
-    expect(store.getFileEntries()[0]?.lastChanged?.subject).toBe("changed src/file-000.ts");
-    expect(store.getFileEntries()[250]?.lastChanged?.subject).toBe("changed src/file-250.ts");
+    expect(store.getBlob()?.path).toBe("src/file-250.ts");
+    await vi.waitFor(() => {
+      expect(lastChangedBatches.map((batch) => batch.length)).toEqual([250, 1]);
+      expect(lastChangedBatches[0]?.[0]).toBe("src/file-250.ts");
+      expect(store.getFileEntries()[0]?.lastChanged?.subject).toBe("changed src/file-000.ts");
+      expect(store.getFileEntries()[250]?.lastChanged?.subject).toBe("changed src/file-250.ts");
+    });
+  });
+
+  it("loads the selected blob before delayed last-changed metadata", async () => {
+    const base = testClient();
+    const lastChanged = deferredResponse();
+    const client = {
+      GET: vi.fn((path: string, options?: TestGetOptions) => {
+        const url = testURL(path, options);
+        if (
+          url ===
+          "/repo/github/acme/widgets/browser/last-changed?repo_path=acme%2Fwidgets&ref_type=commit&ref_sha=main-sha&path=src%2Fapp.ts&path=README.md"
+        ) {
+          return lastChanged.promise;
+        }
+        return base.GET(path, options);
+      }),
+    } as unknown as TestClient;
+    const store = createRepoBrowserStore({ client });
+
+    await store.loadRepo(repo, { path: "src/app.ts" });
+
+    expect(store.getSelectedPath()).toBe("src/app.ts");
+    expect(store.getBlob()?.path).toBe("src/app.ts");
+    expect(store.getFileHistory().map((item) => item.subject)).toEqual(["app changed"]);
+    expect(store.getFileEntries().map((entry) => entry.lastChanged)).toEqual([undefined, undefined]);
+
+    lastChanged.resolve({
+      data: {
+        repo,
+        ref: { type: "branch", name: "main", sha: "main-sha", stale: false },
+        commits: {
+          "README.md": commit("readme changed"),
+          "src/app.ts": commit("app changed"),
+        },
+      },
+      response: new Response(null, { status: 200 }),
+    });
+    await vi.waitFor(() => {
+      expect(store.getFileEntries().map((entry) => entry.lastChanged?.subject)).toEqual([
+        "readme changed",
+        "app changed",
+      ]);
+    });
   });
 
   it("persists source and preview view mode", () => {

--- a/packages/ui/src/stores/repo-browser.svelte.ts
+++ b/packages/ui/src/stores/repo-browser.svelte.ts
@@ -27,6 +27,7 @@ type RepoBrowserCommitResponse = components["schemas"]["RepoBrowserCommitRespons
 type MissingRequestedPathBehavior = "fallback" | "retain";
 
 const viewModeStorageKey = "repo-browser-view-mode";
+const lastChangedBatchSize = 250;
 const validViewModes: RepoBrowserViewMode[] = ["source", "preview"];
 const repeatedPathQuerySerializer: QuerySerializerOptions = {
   array: {
@@ -233,28 +234,34 @@ export function createRepoBrowserStore(opts: RepoBrowserStoreOptions = {}) {
     const ref = repo;
     const requestedRef = treeContentQueryRef();
     if (!ref || !requestedRef) return;
-    const paths = tree.slice(0, 250).map((entry) => entry.path);
+    const paths = tree.map((entry) => entry.path);
     if (paths.length === 0) {
       lastChanged = {};
       return;
     }
-    const {
-      data,
-      error: apiError,
-      response,
-    } = await client.GET(providerRepoPath(ref, "/browser/last-changed"), {
-      querySerializer: repeatedPathQuerySerializer,
-      params: {
-        path: providerRouteParams(ref),
-        query: {
-          ...queryFor(ref, requestedRef),
-          path: paths,
+    const commits: Record<string, RepoBrowserCommit> = {};
+    for (let start = 0; start < paths.length; start += lastChangedBatchSize) {
+      const batch = paths.slice(start, start + lastChangedBatchSize);
+      const {
+        data,
+        error: apiError,
+        response,
+      } = await client.GET(providerRepoPath(ref, "/browser/last-changed"), {
+        querySerializer: repeatedPathQuerySerializer,
+        params: {
+          path: providerRouteParams(ref),
+          query: {
+            ...queryFor(ref, requestedRef),
+            path: batch,
+          },
         },
-      },
-    });
+      });
+      if (!isCurrentTreeRequest(generation)) return;
+      if (!data) throw new Error(apiErrorMessage(apiError, `HTTP ${response.status}`));
+      Object.assign(commits, (data as RepoBrowserLastChangedResponse).commits ?? {});
+    }
     if (!isCurrentTreeRequest(generation)) return;
-    if (!data) throw new Error(apiErrorMessage(apiError, `HTTP ${response.status}`));
-    lastChanged = (data as RepoBrowserLastChangedResponse).commits ?? {};
+    lastChanged = commits;
   }
 
   async function selectRef(ref: RepoBrowserRef): Promise<void> {

--- a/packages/ui/src/stores/repo-browser.svelte.ts
+++ b/packages/ui/src/stores/repo-browser.svelte.ts
@@ -114,6 +114,13 @@ export function createRepoBrowserStore(opts: RepoBrowserStoreOptions = {}) {
     };
   }
 
+  function prioritizePath(paths: string[], priorityPath: string | undefined): string[] {
+    if (!priorityPath) return paths;
+    const index = paths.indexOf(priorityPath);
+    if (index <= 0) return paths;
+    return [priorityPath, ...paths.slice(0, index), ...paths.slice(index + 1)];
+  }
+
   async function loadRepo(
     nextRepo: ProviderRouteRef,
     initial?: { ref?: RepoBrowserRef; path?: string | null },
@@ -198,14 +205,8 @@ export function createRepoBrowserStore(opts: RepoBrowserStoreOptions = {}) {
     selectedRef = payload.ref ?? requestedRef;
     tree = payload.entries ?? [];
     treeTruncated = payload.truncated;
+    lastChanged = {};
     const autoSelectPathGeneration = pathRequestGeneration;
-    try {
-      await loadLastChanged(generation);
-    } catch {
-      if (!isCurrentTreeRequest(generation)) return;
-      lastChanged = {};
-    }
-    if (!isCurrentTreeRequest(generation)) return;
     if (pathRequestGeneration !== autoSelectPathGeneration) return;
     const requestedPathExists = requestedPath && tree.some((entry) => entry.path === requestedPath);
     const firstPath =
@@ -228,13 +229,19 @@ export function createRepoBrowserStore(opts: RepoBrowserStoreOptions = {}) {
       fileHistory = [];
       selectedCommit = null;
     }
+    void loadLastChanged(generation, selectedPath ?? firstPath ?? undefined).catch(() => {
+      // Last-changed metadata is decorative; keep the tree/blob usable if it fails.
+    });
   }
 
-  async function loadLastChanged(generation = treeRequestGeneration): Promise<void> {
+  async function loadLastChanged(generation = treeRequestGeneration, priorityPath?: string): Promise<void> {
     const ref = repo;
     const requestedRef = treeContentQueryRef();
     if (!ref || !requestedRef) return;
-    const paths = tree.map((entry) => entry.path);
+    const paths = prioritizePath(
+      tree.map((entry) => entry.path),
+      priorityPath,
+    );
     if (paths.length === 0) {
       lastChanged = {};
       return;
@@ -259,9 +266,8 @@ export function createRepoBrowserStore(opts: RepoBrowserStoreOptions = {}) {
       if (!isCurrentTreeRequest(generation)) return;
       if (!data) throw new Error(apiErrorMessage(apiError, `HTTP ${response.status}`));
       Object.assign(commits, (data as RepoBrowserLastChangedResponse).commits ?? {});
+      lastChanged = { ...commits };
     }
-    if (!isCurrentTreeRequest(generation)) return;
-    lastChanged = commits;
   }
 
   async function selectRef(ref: RepoBrowserRef): Promise<void> {

--- a/packages/ui/src/utils/diff-categories.test.ts
+++ b/packages/ui/src/utils/diff-categories.test.ts
@@ -29,6 +29,8 @@ describe("diff file categorization", () => {
     expect(categorizeDiffFile(file("flake.nix"))).toBe("code");
     expect(categorizeDiffFile(file("config/middleman.toml"))).toBe("code");
     expect(categorizeDiffFile(file("Makefile"))).toBe("code");
+    expect(categorizeDiffFile(file("docs/scripts/bootstrap.sh"))).toBe("code");
+    expect(categorizeDiffFile(file("docs/screenshots/playwright.config.ts"))).toBe("code");
   });
 
   it("treats lockfiles as generated", () => {

--- a/packages/ui/src/utils/diff-categories.ts
+++ b/packages/ui/src/utils/diff-categories.ts
@@ -22,7 +22,6 @@ export const diffFileCategoryOptions: {
 
 const docsExtensions = new Set([".adoc", ".md", ".mdx", ".rst", ".txt"]);
 
-const docsDirectoryNames = new Set(["doc", "docs", "documentation"]);
 const generatedBasenames = new Set([
   "bun.lock",
   "bun.lockb",
@@ -79,14 +78,11 @@ function hasTestSignal(parts: string[], base: string): boolean {
   );
 }
 
-function hasDocsSignal(parts: string[], base: string, ext: string): boolean {
-  return (
-    parts.some((part) => docsDirectoryNames.has(part)) ||
-    docsExtensions.has(ext) ||
-    ["changelog", "code_of_conduct", "contributing", "license", "notice", "readme", "security"].some(
-      (name) => base === name || base.startsWith(`${name}.`),
-    )
+function hasDocsSignal(base: string, ext: string): boolean {
+  const docsName = ["changelog", "code_of_conduct", "contributing", "license", "notice", "readme", "security"].some(
+    (name) => base === name || base.startsWith(`${name}.`),
   );
+  return docsExtensions.has(ext) || docsName;
 }
 
 function hasGeneratedSignal(base: string): boolean {
@@ -105,7 +101,7 @@ export function categorizeDiffFile(file: string | CategorizableDiffFile): DiffFi
   if (generatedMetadata !== false && hasGeneratedSignal(base)) return "generated";
   if (binaryMetadata === true) return "other";
   if (hasTestSignal(parts, base)) return "tests";
-  if (hasDocsSignal(parts, base, ext)) return "plansDocs";
+  if (hasDocsSignal(base, ext)) return "plansDocs";
   return "code";
 }
 


### PR DESCRIPTION
Repo browsing is only useful if it is reachable from the contexts maintainers already work in. This PR adds repository-card and command-palette entry points, resolving selected PR, issue, activity, repository, and workspace context into the same provider-aware browser route when the repository is unambiguous.

The entry points make source lookup part of triage without weakening the routing model: contextual branches are used only when they resolve in the fetched clone, and uncertain workspace or fork contexts fall back to safe defaults instead of inventing local-only refs.
