### PR TITLE
Allow promoted clones with local hooks

### DIFF
--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -985,9 +985,6 @@ func ValidateWorktreeBasePath(
 	if err := validateNoExecutableLocalGitConfig(ctx, abs); err != nil {
 		return "", err
 	}
-	if err := validateNoExecutableGitHooks(ctx, abs); err != nil {
-		return "", err
-	}
 	if err := validateOriginFetchRefspec(ctx, abs); err != nil {
 		return "", err
 	}
@@ -1029,34 +1026,6 @@ func validateNoExecutableLocalGitConfig(ctx context.Context, dir string) error {
 				"local git config %q may execute or rewrite git commands",
 				key,
 			)
-		}
-	}
-	return nil
-}
-
-func validateNoExecutableGitHooks(ctx context.Context, dir string) error {
-	commonDir, err := worktreeCommonGitDir(ctx, dir)
-	if err != nil {
-		return fmt.Errorf("inspect git hooks dir: %w", err)
-	}
-	hooksDir := filepath.Join(commonDir, "hooks")
-	entries, err := os.ReadDir(hooksDir)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil
-		}
-		return fmt.Errorf("read git hooks dir: %w", err)
-	}
-	for _, entry := range entries {
-		if entry.IsDir() || strings.HasSuffix(entry.Name(), ".sample") {
-			continue
-		}
-		info, err := entry.Info()
-		if err != nil {
-			return fmt.Errorf("inspect git hook %q: %w", entry.Name(), err)
-		}
-		if info.Mode()&0o111 != 0 {
-			return fmt.Errorf("git hook %q must not be executable", entry.Name())
 		}
 	}
 	return nil

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -1068,7 +1068,6 @@ func localGitConfigKeyMayExecute(key string) bool {
 		key == "core.alternaterefscommand" ||
 		key == "core.askpass" ||
 		key == "core.gitproxy" ||
-		key == "core.hookspath" ||
 		key == "core.sshcommand" ||
 		key == "credential.helper" ||
 		key == "diff.external" ||

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -841,7 +841,6 @@ func TestValidateWorktreeBasePathRejectsExecutableLocalConfig(t *testing.T) {
 		{name: "alternate refs command", key: "core.alternateRefsCommand", value: "demo-alternates"},
 		{name: "askpass", key: "core.askPass", value: "demo-askpass"},
 		{name: "git proxy", key: "core.gitProxy", value: "demo-proxy"},
-		{name: "hooks path", key: "core.hooksPath", value: filepath.Join(t.TempDir(), "hooks")},
 		{name: "ssh command", key: "core.sshCommand", value: "demo-ssh"},
 		{name: "credential helper", key: "credential.helper", value: "!demo-helper"},
 		{name: "diff external", key: "diff.external", value: "demo-diff"},
@@ -877,6 +876,24 @@ func TestValidateWorktreeBasePathRejectsExecutableLocalConfig(t *testing.T) {
 			assert.Contains(err.Error(), "may execute or rewrite git commands")
 		})
 	}
+}
+
+func TestValidateWorktreeBasePathAcceptsConfiguredHooksPath(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+
+	localRepo := setupLocalWorktreeBaseForWorkspaceGitTest(t, "feature/thing")
+	hooksPath := t.TempDir()
+	runWorkspaceTestGit(t, localRepo, "config", "core.hooksPath", hooksPath)
+
+	got, err := ValidateWorktreeBasePath(
+		t.Context(), localRepo, "github.com", "acme", "widget",
+	)
+
+	require.NoError(err)
+	canonicalLocalRepo, err := filepath.EvalSymlinks(localRepo)
+	require.NoError(err)
+	assert.Equal(canonicalLocalRepo, got)
 }
 
 func TestValidateWorktreeBasePathRejectsExecutableGitHooks(t *testing.T) {

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -885,6 +885,11 @@ func TestValidateWorktreeBasePathAcceptsConfiguredHooksPath(t *testing.T) {
 	localRepo := setupLocalWorktreeBaseForWorkspaceGitTest(t, "feature/thing")
 	hooksPath := t.TempDir()
 	runWorkspaceTestGit(t, localRepo, "config", "core.hooksPath", hooksPath)
+	commonDir := strings.TrimSpace(string(runWorkspaceTestGit(
+		t, localRepo, "rev-parse", "--path-format=absolute", "--git-common-dir",
+	)))
+	hookPath := filepath.Join(commonDir, "hooks", "post-commit")
+	require.NoError(os.WriteFile(hookPath, []byte("#!/bin/sh\nexit 0\n"), 0o755))
 
 	got, err := ValidateWorktreeBasePath(
 		t.Context(), localRepo, "github.com", "acme", "widget",
@@ -894,27 +899,6 @@ func TestValidateWorktreeBasePathAcceptsConfiguredHooksPath(t *testing.T) {
 	canonicalLocalRepo, err := filepath.EvalSymlinks(localRepo)
 	require.NoError(err)
 	assert.Equal(canonicalLocalRepo, got)
-}
-
-func TestValidateWorktreeBasePathRejectsExecutableGitHooks(t *testing.T) {
-	assert := Assert.New(t)
-	require := require.New(t)
-
-	localRepo := setupLocalWorktreeBaseForWorkspaceGitTest(t, "feature/thing")
-	commonDir := strings.TrimSpace(string(runWorkspaceTestGit(
-		t, localRepo, "rev-parse", "--path-format=absolute", "--git-common-dir",
-	)))
-	hookPath := filepath.Join(commonDir, "hooks", "reference-transaction")
-	require.NoError(os.WriteFile(hookPath, []byte("#!/bin/sh\nexit 1\n"), 0o755))
-
-	got, err := ValidateWorktreeBasePath(
-		t.Context(), localRepo, "github.com", "acme", "widget",
-	)
-
-	require.Empty(got)
-	require.Error(err)
-	assert.Contains(err.Error(), "reference-transaction")
-	assert.Contains(err.Error(), "must not be executable")
 }
 
 func TestValidateWorktreeBasePathRejectsUnsafeOriginSchemes(t *testing.T) {


### PR DESCRIPTION
Promoting a wildcard repository to an exact local checkout should work for normal developer clones, including checkouts with repo-local hooks configured. The previous validation rejected those clones before middleman could save the worktree base, even though middleman disables hooks for its own internal git operations.

This keeps the dangerous git config and repository identity checks while allowing user-owned hook configuration and executable hook files.

<sup>generated by a clanker</sup>