### PR TITLE
Own project intake and host-scoped worktree flows

### DIFF
--- a/cmd/e2e-server/main.go
+++ b/cmd/e2e-server/main.go
@@ -59,6 +59,10 @@ func main() {
 		"default-platform-host", "github.com",
 		"default platform host for seeded config",
 	)
+	fleetKey := flag.String(
+		"fleet-key", "",
+		"fleet self key for seeded config",
+	)
 	visibleImportedModes := flag.Bool(
 		"visible-imported-modes", false,
 		"show imported app modes in the seeded config",
@@ -87,6 +91,7 @@ func main() {
 		*roborev,
 		*serverInfoFile,
 		*defaultPlatformHost,
+		*fleetKey,
 		*visibleImportedModes,
 		*providerCollision,
 	); err != nil {
@@ -671,6 +676,7 @@ func setPR1CIState(
 type appOptions struct {
 	roborevEndpoint      string
 	defaultPlatformHost  string
+	fleetKey             string
 	visibleImportedModes bool
 	providerCollision    bool
 }
@@ -925,6 +931,7 @@ func buildAppState(
 		// tests run unserialized.
 		Tmux: config.Tmux{Command: instanceTmuxCommand()},
 	}
+	cfg.Fleet.Key = strings.TrimSpace(opts.fleetKey)
 	if opts.visibleImportedModes {
 		modes := config.DefaultModeVisibility()
 		*modes.Kata = true
@@ -1759,7 +1766,7 @@ func buildAppState(
 func run(
 	ctx context.Context,
 	port int,
-	roborevEndpoint, serverInfoFile, defaultPlatformHost string,
+	roborevEndpoint, serverInfoFile, defaultPlatformHost, fleetKey string,
 	visibleImportedModes bool,
 	providerCollision bool,
 ) error {
@@ -1771,6 +1778,7 @@ func run(
 	baseOpts := appOptions{
 		roborevEndpoint:      roborevEndpoint,
 		defaultPlatformHost:  defaultPlatformHost,
+		fleetKey:             fleetKey,
 		visibleImportedModes: visibleImportedModes,
 		providerCollision:    providerCollision,
 	}
@@ -1829,9 +1837,10 @@ func run(
 
 			opts := baseOpts
 			var req struct {
-				DefaultPlatformHost  string `json:"default_platform_host"`
-				VisibleImportedModes *bool  `json:"visible_imported_modes"`
-				ProviderCollision    *bool  `json:"provider_collision"`
+				DefaultPlatformHost  string  `json:"default_platform_host"`
+				FleetKey             *string `json:"fleet_key"`
+				VisibleImportedModes *bool   `json:"visible_imported_modes"`
+				ProviderCollision    *bool   `json:"provider_collision"`
 			}
 			// An empty body resets to the startup options; a
 			// non-empty body must be valid JSON so option typos
@@ -1853,6 +1862,9 @@ func run(
 			}
 			if strings.TrimSpace(req.DefaultPlatformHost) != "" {
 				opts.defaultPlatformHost = req.DefaultPlatformHost
+			}
+			if req.FleetKey != nil {
+				opts.fleetKey = strings.TrimSpace(*req.FleetKey)
 			}
 			if req.VisibleImportedModes != nil {
 				opts.visibleImportedModes = *req.VisibleImportedModes

--- a/cmd/e2e-server/main_test.go
+++ b/cmd/e2e-server/main_test.go
@@ -255,7 +255,7 @@ func TestRunDefaultRoborevFailsClosedThroughProxy(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- run(ctx, 0, defaultRoborevEndpoint, serverInfoFile, "github.com", false, false)
+		done <- run(ctx, 0, defaultRoborevEndpoint, serverInfoFile, "github.com", "", false, false)
 	}()
 
 	baseURL := waitForServerInfoBaseURL(t, serverInfoFile, done)
@@ -332,7 +332,7 @@ func TestResetSwapsFixtureState(t *testing.T) {
 	serverInfoFile := filepath.Join(t.TempDir(), "server-info.json")
 	done := make(chan error, 1)
 	go func() {
-		done <- run(ctx, 0, defaultRoborevEndpoint, serverInfoFile, "github.com", false, false)
+		done <- run(ctx, 0, defaultRoborevEndpoint, serverInfoFile, "github.com", "", false, false)
 	}()
 	baseURL := waitForServerInfoBaseURL(t, serverInfoFile, done)
 

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -6362,6 +6362,8 @@ components:
     WorktreeLinkResponse:
       additionalProperties: false
       properties:
+        host_key:
+          type: string
         worktree_branch:
           type: string
         worktree_key:
@@ -7367,6 +7369,33 @@ paths:
       summary: Delete project on fleet host
       tags:
         - Fleet
+    get:
+      operationId: get-fleet-project
+      parameters:
+        - in: path
+          name: host_key
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            type: string
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Response returned by the owning fleet host.
+      summary: Get project on fleet host
+      tags:
+        - Fleet
   /fleet/hosts/{host_key}/projects/{project_id}/branches:
     get:
       operationId: list-fleet-project-branches
@@ -7396,6 +7425,33 @@ paths:
       tags:
         - Fleet
   /fleet/hosts/{host_key}/projects/{project_id}/worktrees:
+    get:
+      operationId: list-fleet-project-worktrees
+      parameters:
+        - in: path
+          name: host_key
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: project_id
+          required: true
+          schema:
+            type: string
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Response returned by the owning fleet host.
+      summary: List project worktrees on fleet host
+      tags:
+        - Fleet
     post:
       operationId: create-fleet-project-worktree
       parameters:

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -30,6 +30,7 @@
   import SettingsPage from "./lib/components/settings/SettingsPage.svelte";
   import WorkspaceTerminalView from "./lib/components/terminal/WorkspaceTerminalView.svelte";
   import WorkspaceEmbedShell from "./lib/components/terminal/WorkspaceEmbedShell.svelte";
+  import WorkspaceFirstRunPanel from "./lib/components/terminal/WorkspaceFirstRunPanel.svelte";
   import DesignSystemPage from "./lib/components/design-system/DesignSystemPage.svelte";
   import KataFeature from "./lib/features/kata/KataFeature.svelte";
   import { fetchKataDaemons } from "./lib/api/kata/daemons.js";
@@ -1192,6 +1193,14 @@
           <ReviewsView jobId={route.jobId} />
         {:else}
           <ReviewsView />
+        {/if}
+      {:else if getPage() === "project-intake"}
+        {@const route = getRoute()}
+        {#if route.page === "project-intake"}
+          <WorkspaceFirstRunPanel
+            firstRun={false}
+            hostKey={route.hostKey}
+          />
         {/if}
       {:else if getPage() === "workspaces" || getPage() === "terminal"}
         {@const r = getRoute()}

--- a/frontend/src/lib/api/fleet-snapshot.ts
+++ b/frontend/src/lib/api/fleet-snapshot.ts
@@ -1,0 +1,15 @@
+import type { components } from "@middleman/ui/api/schema";
+
+import { apiErrorMessage, client } from "./runtime.ts";
+
+export type HostSummary = components["schemas"]["HostSummary"];
+
+export async function loadSnapshotHosts(): Promise<HostSummary[]> {
+  const { data, error } = await client.GET("/snapshot", {
+    params: { query: { include_peers: true } },
+  });
+  if (!data) {
+    throw new Error(apiErrorMessage(error, "Couldn't load hosts."));
+  }
+  return (data.hosts ?? []) as HostSummary[];
+}

--- a/frontend/src/lib/api/project-intake.test.ts
+++ b/frontend/src/lib/api/project-intake.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { cloneProject, listUserRepositories, registerExistingProject } from "./project-intake.ts";
+
+const mocks = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+}));
+
+vi.mock("./runtime.ts", () => ({
+  apiErrorMessage: (error: { detail?: string; title?: string } | undefined, fallback: string) =>
+    error?.detail ?? error?.title ?? fallback,
+  client: {
+    GET: mocks.get,
+    POST: mocks.post,
+  },
+}));
+
+describe("project-intake api", () => {
+  beforeEach(() => {
+    mocks.get.mockReset();
+    mocks.post.mockReset();
+  });
+
+  it("validates an existing path before registering the root", async () => {
+    mocks.get.mockResolvedValue({
+      data: { is_valid: true, root_path: "/repo" },
+      error: undefined,
+    });
+    mocks.post.mockResolvedValue({
+      data: { id: "prj_1" },
+      error: undefined,
+    });
+
+    await expect(registerExistingProject("/repo/subdir")).resolves.toMatchObject({
+      id: "prj_1",
+    });
+
+    expect(mocks.get).toHaveBeenCalledWith("/filesystem/validate-repo", {
+      params: { query: { path: "/repo/subdir" } },
+    });
+    expect(mocks.post).toHaveBeenCalledWith("/projects", { body: { local_path: "/repo" } });
+  });
+
+  it("uses fleet routes when registering on a host", async () => {
+    mocks.get.mockResolvedValue({
+      data: { is_valid: true, root_path: "/srv/repo" },
+      error: undefined,
+    });
+    mocks.post.mockResolvedValue({
+      data: { id: "prj_remote" },
+      error: undefined,
+    });
+
+    await expect(registerExistingProject("/srv/repo/pkg", { hostKey: "epyc" })).resolves.toMatchObject({
+      id: "prj_remote",
+    });
+
+    expect(mocks.get).toHaveBeenCalledWith("/fleet/hosts/{host_key}/filesystem/validate-repo", {
+      params: {
+        path: { host_key: "epyc" },
+        query: { path: "/srv/repo/pkg" },
+      },
+    });
+    expect(mocks.post).toHaveBeenCalledWith("/fleet/hosts/{host_key}/projects", {
+      params: { path: { host_key: "epyc" } },
+      body: { local_path: "/srv/repo" },
+    });
+  });
+
+  it("rejects invalid repository paths before registering", async () => {
+    mocks.get.mockResolvedValue({
+      data: { is_valid: false, message: "Not a git repository" },
+      error: undefined,
+    });
+
+    await expect(registerExistingProject("/tmp")).rejects.toThrow("Not a git repository");
+    expect(mocks.post).not.toHaveBeenCalled();
+  });
+
+  it("posts clone body with an optional branch", async () => {
+    mocks.post.mockResolvedValue({
+      data: { id: "prj_clone" },
+      error: undefined,
+    });
+
+    await expect(cloneProject(" git@github.com:octo/repo.git ", " /tmp/repo ", " main ")).resolves.toMatchObject({
+      id: "prj_clone",
+    });
+
+    expect(mocks.post).toHaveBeenCalledWith("/projects/clone", {
+      body: {
+        url: "git@github.com:octo/repo.git",
+        path: "/tmp/repo",
+        branch: "main",
+      },
+    });
+  });
+
+  it("uses the fleet clone route when cloning on a host", async () => {
+    mocks.post.mockResolvedValue({
+      data: { id: "prj_remote_clone" },
+      error: undefined,
+    });
+
+    await expect(
+      cloneProject("git@github.com:octo/repo.git", "/srv/repo", undefined, { hostKey: "epyc" }),
+    ).resolves.toMatchObject({ id: "prj_remote_clone" });
+
+    expect(mocks.post).toHaveBeenCalledWith("/fleet/hosts/{host_key}/projects/clone", {
+      params: { path: { host_key: "epyc" } },
+      body: {
+        url: "git@github.com:octo/repo.git",
+        path: "/srv/repo",
+      },
+    });
+  });
+
+  it("normalizes a null repository list", async () => {
+    mocks.get.mockResolvedValue({
+      data: { repositories: null },
+      error: undefined,
+    });
+
+    await expect(listUserRepositories()).resolves.toEqual([]);
+  });
+});

--- a/frontend/src/lib/api/project-intake.ts
+++ b/frontend/src/lib/api/project-intake.ts
@@ -1,0 +1,100 @@
+import type { components } from "@middleman/ui/api/schema";
+
+import { apiErrorMessage, client } from "./runtime.ts";
+
+export type ProjectResponse = components["schemas"]["ProjectResponse"];
+export type UserRepository = components["schemas"]["UserRepository"];
+type ProblemError = components["schemas"]["ProblemError"];
+type RepoValidation = components["schemas"]["FilesystemValidateRepoOutputBody"];
+
+export interface ProjectIntakeOptions {
+  hostKey?: string | null;
+}
+
+function normalizedHostKey(options?: ProjectIntakeOptions): string | undefined {
+  const hostKey = options?.hostKey?.trim();
+  return hostKey ? hostKey : undefined;
+}
+
+export async function registerExistingProject(path: string, options?: ProjectIntakeOptions): Promise<ProjectResponse> {
+  const trimmed = path.trim();
+  if (!trimmed) {
+    throw new Error("Repository path is required.");
+  }
+
+  const hostKey = normalizedHostKey(options);
+  const validationResult = hostKey
+    ? await client.GET("/fleet/hosts/{host_key}/filesystem/validate-repo", {
+        params: { path: { host_key: hostKey }, query: { path: trimmed } },
+      })
+    : await client.GET("/filesystem/validate-repo", {
+        params: { query: { path: trimmed } },
+      });
+  const validation = validationResult.data as RepoValidation | undefined;
+  if (!validation) {
+    throw new Error(
+      apiErrorMessage(validationResult.error as ProblemError | undefined, "Couldn't validate repository path."),
+    );
+  }
+  if (!validation.is_valid) {
+    throw new Error(validation.message ?? "Not a git repository.");
+  }
+
+  const body = { local_path: validation.root_path ?? trimmed };
+  const result = hostKey
+    ? await client.POST("/fleet/hosts/{host_key}/projects", {
+        params: { path: { host_key: hostKey } },
+        body,
+      })
+    : await client.POST("/projects", { body });
+  const data = result.data as ProjectResponse | undefined;
+  if (!data) {
+    throw new Error(apiErrorMessage(result.error as ProblemError | undefined, "Couldn't register repository."));
+  }
+  return data;
+}
+
+export async function cloneProject(
+  url: string,
+  path: string,
+  branch?: string,
+  options?: ProjectIntakeOptions,
+): Promise<ProjectResponse> {
+  const trimmedURL = url.trim();
+  const trimmedPath = path.trim();
+  const trimmedBranch = branch?.trim();
+  if (!trimmedURL) {
+    throw new Error("Repository URL is required.");
+  }
+  if (!trimmedPath) {
+    throw new Error("Destination path is required.");
+  }
+
+  const hostKey = normalizedHostKey(options);
+  const body = {
+    url: trimmedURL,
+    path: trimmedPath,
+    ...(trimmedBranch ? { branch: trimmedBranch } : {}),
+  };
+  const result = hostKey
+    ? await client.POST("/fleet/hosts/{host_key}/projects/clone", {
+        params: { path: { host_key: hostKey } },
+        body,
+      })
+    : await client.POST("/projects/clone", { body });
+  const data = result.data as ProjectResponse | undefined;
+  if (!data) {
+    throw new Error(apiErrorMessage(result.error as ProblemError | undefined, "Couldn't clone repository."));
+  }
+  return data;
+}
+
+export async function listUserRepositories(): Promise<UserRepository[]> {
+  const { data, error } = await client.GET("/platform/user-repositories", {
+    params: { query: { limit: 100 } },
+  });
+  if (!data) {
+    throw new Error(apiErrorMessage(error, "Couldn't load GitHub repositories."));
+  }
+  return data.repositories ?? [];
+}

--- a/frontend/src/lib/components/terminal/WorkspaceEmbedShell.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceEmbedShell.svelte
@@ -133,7 +133,10 @@
     {:else if r.page === "embed-workspace-first-run"}
       <WorkspaceFirstRunPanel />
     {:else if r.page === "embed-workspace-project"}
-      <WorkspaceProjectCard projectId={r.projectId} />
+      <WorkspaceProjectCard
+        projectId={r.projectId}
+        hostKey={r.hostKey}
+      />
     {/if}
   </main>
 </Provider>

--- a/frontend/src/lib/components/terminal/WorkspaceFirstRunPanel.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceFirstRunPanel.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   // WorkspaceFirstRunPanel owns project registration for both the
-  // empty-registry first run and explicit add-project routes. Embedders
-  // only need to react after a project exists.
+  // empty-registry first run and explicit add-project routes. Project-card
+  // actions only need to react after a project exists.
 
   import {
     cloneProject,

--- a/frontend/src/lib/components/terminal/WorkspaceFirstRunPanel.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceFirstRunPanel.svelte
@@ -1,20 +1,33 @@
 <script lang="ts">
-  // WorkspaceFirstRunPanel is the embed surface that renders when the
-  // project registry is empty. It is the first surface a fresh
-  // installation lands on, and it must offer at least one action that
-  // progresses toward a worktree - the master spec's "no dead ends"
-  // rule. Every action returns a CommandResult so the surface can
-  // render in-flight, success, and failure states.
+  // WorkspaceFirstRunPanel owns project registration for both the
+  // empty-registry first run and explicit add-project routes. Embedders
+  // only need to react after a project exists.
 
   import {
-    getProjectAction,
+    cloneProject,
+    listUserRepositories,
+    registerExistingProject,
+    type ProjectResponse,
+    type UserRepository,
+  } from "../../api/project-intake.ts";
+  import {
+    loadSnapshotHosts,
+    type HostSummary,
+  } from "../../api/fleet-snapshot.ts";
+  import {
+    emitWorkspaceCommand,
     getWorkspaceData,
-    invokeProjectAction,
   } from "../../stores/embed-config.svelte.ts";
+  import { navigate } from "../../stores/router.svelte.ts";
   import { resolveToolingStatus } from "../../stores/tooling-status.svelte.ts";
   import ToolingStatusBlock from "./ToolingStatusBlock.svelte";
 
   type ActionId = "add-existing" | "clone" | "connect-github";
+
+  interface Props {
+    firstRun?: boolean;
+    hostKey?: string | null | undefined;
+  }
 
   interface ActionDefinition {
     id: ActionId;
@@ -27,42 +40,122 @@
     {
       id: "add-existing",
       label: "Add an existing local repository",
-      description: "Pick a folder you already cloned.",
+      description: "Register a checkout that already exists here.",
       requiresGh: false,
     },
     {
       id: "clone",
       label: "Clone a repository",
-      description: "Provide a URL and we'll clone it.",
+      description: "Clone from a Git URL into a destination path.",
       requiresGh: false,
     },
     {
       id: "connect-github",
       label: "Connect a GitHub repository",
-      description: "Pick from your GitHub repos.",
+      description: "Pick from your GitHub repositories.",
       requiresGh: true,
     },
   ];
 
-  let inFlight = $state<ActionId | null>(null);
+  let { firstRun = true, hostKey = null }: Props = $props();
+  let mode = $state<ActionId | null>(null);
+  let inFlight = $state(false);
   let lastError = $state<string | null>(null);
 
+  let existingPath = $state("");
+  let cloneURL = $state("");
+  let clonePath = $state("");
+  let cloneBranch = $state("");
+
+  let githubLoading = $state(false);
+  let githubRepos = $state<UserRepository[]>([]);
+  let githubFilter = $state("");
+  let selectedGithubRepo = $state("");
+  let githubPath = $state("");
+  let githubBranch = $state("");
+  let snapshotHosts = $state.raw<HostSummary[]>([]);
+
   const tooling = $derived(resolveToolingStatus());
-  const provider = $derived.by(() => {
-    const workspace = getWorkspaceData();
+  const scopedHostKey = $derived(hostKey?.trim() || undefined);
+  const projectOptions = $derived(
+    scopedHostKey ? { hostKey: scopedHostKey } : undefined,
+  );
+  const workspaceData = $derived(getWorkspaceData());
+  const selectedHost = $derived.by(() => {
+    if (snapshotHosts.length > 0) {
+      const host = scopedHostKey
+        ? snapshotHosts.find(
+            (candidate) => candidate.configKey === scopedHostKey,
+          )
+        : snapshotHosts.find((candidate) => candidate.kind === "self") ??
+          snapshotHosts[0];
+      if (host) {
+        return {
+          label: host.name || host.configKey,
+          platform: host.platform,
+        };
+      }
+    }
+    const workspace = workspaceData;
     if (!workspace) return undefined;
-    const selectedHost = workspace.hosts.find(
-      (host) => host.key === workspace.selectedHostKey,
+    if (scopedHostKey) {
+      return workspace.hosts.find(
+        (candidate) => candidate.key === scopedHostKey,
+      );
+    }
+    return workspace.hosts.find(
+      (candidate) => candidate.key === workspace.selectedHostKey,
     ) ?? workspace.hosts[0];
+  });
+  const actionDefinitions = $derived(
+    ACTIONS.map((action) => {
+      if (action.id !== "add-existing") return action;
+      return {
+        ...action,
+        label: scopedHostKey
+          ? "Add an existing repository"
+          : "Add an existing local repository",
+        description: scopedHostKey
+          ? "Register a checkout that already exists on this host."
+          : "Register a checkout that already exists here.",
+      };
+    }),
+  );
+  const title = $derived(
+    firstRun ? "Get to your first worktree." : "Add a project.",
+  );
+  const lede = $derived(
+    firstRun
+      ? "Worktrees keep one branch checked out per directory so each change you start has its own working tree, terminal, and agent. Pick a starting point below."
+      : "Register an existing checkout or clone a repository so it can be used for worktrees.",
+  );
+  const hostLabel = $derived(
+    scopedHostKey
+      ? selectedHost?.label ?? scopedHostKey
+      : null,
+  );
+  const provider = $derived.by(() => {
     return selectedHost?.platform;
   });
   const ghAuthed = $derived(
     tooling?.gh?.available === true &&
       tooling.gh.authenticated === true,
   );
+  const filteredRepos = $derived.by(() => {
+    const query = githubFilter.trim().toLowerCase();
+    if (!query) return githubRepos;
+    return githubRepos.filter((repo) =>
+      repo.name_with_owner.toLowerCase().includes(query),
+    );
+  });
+  const chosenGithubRepo = $derived(
+    githubRepos.find(
+      (repo) => repo.name_with_owner === selectedGithubRepo,
+    ),
+  );
 
   function isDisabled(definition: ActionDefinition): boolean {
-    if (inFlight !== null) return true;
+    if (inFlight) return true;
     if (definition.requiresGh && !ghAuthed) return true;
     return false;
   }
@@ -79,26 +172,131 @@
     return undefined;
   }
 
-  async function runAction(definition: ActionDefinition): Promise<void> {
+  function chooseMode(definition: ActionDefinition): void {
     if (isDisabled(definition)) return;
-    const action = getProjectAction(definition.id);
-    if (!action) {
-      lastError =
-        "This action is not available in this build. Please update " +
-        "the host application.";
-      return;
+    mode = definition.id;
+    lastError = null;
+    if (definition.id === "connect-github") {
+      void loadGitHubRepositories();
     }
-    inFlight = definition.id;
+  }
+
+  $effect(() => {
+    void refreshSnapshotHosts();
+  });
+
+  async function refreshSnapshotHosts(): Promise<void> {
+    try {
+      snapshotHosts = await loadSnapshotHosts();
+    } catch {
+      snapshotHosts = [];
+    }
+  }
+
+  function backToActions(): void {
+    mode = null;
+    lastError = null;
+    inFlight = false;
+  }
+
+  async function loadGitHubRepositories(): Promise<void> {
+    githubLoading = true;
     lastError = null;
     try {
-      const result = await invokeProjectAction(action, {
-        surface: "first-run-panel",
-      });
-      if (!result.ok) {
-        lastError = result.message ?? "Action failed.";
-      }
+      githubRepos = await listUserRepositories();
+      selectedGithubRepo = githubRepos[0]?.name_with_owner ?? "";
+    } catch (err) {
+      lastError = err instanceof Error ? err.message : String(err);
     } finally {
-      inFlight = null;
+      githubLoading = false;
+    }
+  }
+
+  async function finishProject(project: ProjectResponse): Promise<void> {
+    const payload: Record<string, unknown> = {
+      projectId: project.id,
+    };
+    if (scopedHostKey) payload.hostKey = scopedHostKey;
+
+    const result = await emitWorkspaceCommand("project-registered", payload);
+    if (!result.ok) {
+      lastError =
+        result.message ?? "Project registered, but the host did not refresh.";
+      return;
+    }
+    if (scopedHostKey) {
+      navigate("/workspaces");
+    } else {
+      navigate(`/workspaces/embed/project/${encodeURIComponent(project.id)}`);
+    }
+  }
+
+  function registerProject(path: string): Promise<ProjectResponse> {
+    if (projectOptions) {
+      return registerExistingProject(path, projectOptions);
+    }
+    return registerExistingProject(path);
+  }
+
+  function cloneProjectForHost(
+    url: string,
+    path: string,
+    branch?: string,
+  ): Promise<ProjectResponse> {
+    if (projectOptions) {
+      return cloneProject(url, path, branch, projectOptions);
+    }
+    return cloneProject(url, path, branch);
+  }
+
+  async function submitExisting(): Promise<void> {
+    if (inFlight) return;
+    inFlight = true;
+    lastError = null;
+    try {
+      await finishProject(await registerProject(existingPath));
+    } catch (err) {
+      lastError = err instanceof Error ? err.message : String(err);
+    } finally {
+      inFlight = false;
+    }
+  }
+
+  async function submitClone(): Promise<void> {
+    if (inFlight) return;
+    inFlight = true;
+    lastError = null;
+    try {
+      await finishProject(
+        await cloneProjectForHost(cloneURL, clonePath, cloneBranch),
+      );
+    } catch (err) {
+      lastError = err instanceof Error ? err.message : String(err);
+    } finally {
+      inFlight = false;
+    }
+  }
+
+  async function submitGitHub(): Promise<void> {
+    if (inFlight || !chosenGithubRepo) return;
+    if (!chosenGithubRepo.ssh_url) {
+      lastError = "Selected repository does not expose an SSH clone URL.";
+      return;
+    }
+    inFlight = true;
+    lastError = null;
+    try {
+      await finishProject(
+        await cloneProjectForHost(
+          chosenGithubRepo.ssh_url,
+          githubPath,
+          githubBranch,
+        ),
+      );
+    } catch (err) {
+      lastError = err instanceof Error ? err.message : String(err);
+    } finally {
+      inFlight = false;
     }
   }
 </script>
@@ -106,51 +304,220 @@
 <section class="first-run" aria-labelledby="first-run-title">
   <div class="first-run__intro">
     <h1 id="first-run-title" class="first-run__title">
-      Get to your first worktree.
+      {title}
     </h1>
     <p class="first-run__lede">
-      Worktrees keep one branch checked out per directory so each
-      change you start has its own working tree, terminal, and
-      agent. Pick a starting point below.
+      {lede}
     </p>
+    {#if hostLabel}
+      <p class="first-run__host">Host: {hostLabel}</p>
+    {/if}
   </div>
 
-  <ul class="first-run__actions">
-    {#each ACTIONS as action (action.id)}
-      {@const disabled = isDisabled(action)}
-      {@const reason = disabledReason(action)}
-      <li class="first-run-action">
+  {#if mode === null}
+    <ul class="first-run__actions">
+      {#each actionDefinitions as action (action.id)}
+        {@const disabled = isDisabled(action)}
+        {@const reason = disabledReason(action)}
+        <li class="first-run-action">
+          <button
+            type="button"
+            class="first-run-action__button"
+            {disabled}
+            aria-describedby={reason
+              ? `first-run-action-reason-${action.id}`
+              : undefined}
+            onclick={() => chooseMode(action)}
+          >
+            <span class="first-run-action__label">
+              {action.label}
+            </span>
+            <span class="first-run-action__description">
+              {action.description}
+            </span>
+          </button>
+          {#if reason}
+            <p
+              class="first-run-action__reason"
+              id="first-run-action-reason-{action.id}"
+            >
+              {reason}
+            </p>
+          {/if}
+        </li>
+      {/each}
+    </ul>
+  {:else}
+    <div class="first-run-form">
+      <div class="first-run-form__header">
+        <h2 class="first-run-form__title">
+          {actionDefinitions.find((action) => action.id === mode)?.label}
+        </h2>
         <button
           type="button"
-          class="first-run-action__button"
-          {disabled}
-          aria-busy={inFlight === action.id}
-          aria-describedby={reason
-            ? `first-run-action-reason-${action.id}`
-            : undefined}
-          onclick={() => runAction(action)}
+          class="first-run-form__back"
+          onclick={backToActions}
+          disabled={inFlight}
         >
-          <span class="first-run-action__label">
-            {action.label}
-            {#if inFlight === action.id}
-              <span class="first-run-action__spinner" aria-hidden="true">…</span>
-            {/if}
-          </span>
-          <span class="first-run-action__description">
-            {action.description}
-          </span>
+          Back
         </button>
-        {#if reason}
-          <p
-            class="first-run-action__reason"
-            id="first-run-action-reason-{action.id}"
-          >
-            {reason}
-          </p>
-        {/if}
-      </li>
-    {/each}
-  </ul>
+      </div>
+
+      {#if mode === "add-existing"}
+        <form
+          class="first-run-form__body"
+          onsubmit={(event) => {
+            event.preventDefault();
+            void submitExisting();
+          }}
+        >
+          <label class="first-run-field">
+            <span>Repository path</span>
+            <input
+              bind:value={existingPath}
+              placeholder="/Users/you/code/repo"
+              autocomplete="off"
+              disabled={inFlight}
+            />
+          </label>
+
+          <div class="first-run-form__buttons">
+            <button type="button" onclick={backToActions} disabled={inFlight}>
+              Cancel
+            </button>
+            <button type="submit" disabled={inFlight}>
+              {inFlight ? "Adding..." : "Add repository"}
+            </button>
+          </div>
+        </form>
+      {:else if mode === "clone"}
+        <form
+          class="first-run-form__body"
+          onsubmit={(event) => {
+            event.preventDefault();
+            void submitClone();
+          }}
+        >
+          <label class="first-run-field">
+            <span>Repository URL</span>
+            <input
+              bind:value={cloneURL}
+              placeholder="git@github.com:owner/repo.git"
+              autocomplete="off"
+              disabled={inFlight}
+            />
+          </label>
+          <label class="first-run-field">
+            <span>Destination path</span>
+            <input
+              bind:value={clonePath}
+              placeholder="/Users/you/code/repo"
+              autocomplete="off"
+              disabled={inFlight}
+            />
+          </label>
+          <label class="first-run-field">
+            <span>Branch</span>
+            <input
+              bind:value={cloneBranch}
+              placeholder="Optional"
+              autocomplete="off"
+              disabled={inFlight}
+            />
+          </label>
+
+          <div class="first-run-form__buttons">
+            <button type="button" onclick={backToActions} disabled={inFlight}>
+              Cancel
+            </button>
+            <button type="submit" disabled={inFlight}>
+              {inFlight ? "Cloning..." : "Clone repository"}
+            </button>
+          </div>
+        </form>
+      {:else if mode === "connect-github"}
+        <form
+          class="first-run-form__body"
+          onsubmit={(event) => {
+            event.preventDefault();
+            void submitGitHub();
+          }}
+        >
+          {#if githubLoading}
+            <p class="first-run-form__status">Loading repositories...</p>
+          {:else if githubRepos.length === 0}
+            <p class="first-run-form__status">
+              No repositories were returned for this GitHub account.
+            </p>
+            <button
+              type="button"
+              onclick={() => void loadGitHubRepositories()}
+              disabled={inFlight}
+            >
+              Try again
+            </button>
+          {:else}
+            <label class="first-run-field">
+              <span>Filter repositories</span>
+              <input
+                bind:value={githubFilter}
+                placeholder="owner/name"
+                autocomplete="off"
+                disabled={inFlight}
+              />
+            </label>
+            <label class="first-run-field">
+              <span>GitHub repository</span>
+              <select
+                bind:value={selectedGithubRepo}
+                disabled={inFlight}
+              >
+                {#each filteredRepos as repo (repo.name_with_owner)}
+                  <option value={repo.name_with_owner}>
+                    {repo.name_with_owner}
+                  </option>
+                {/each}
+              </select>
+            </label>
+            <label class="first-run-field">
+              <span>Destination path</span>
+              <input
+                bind:value={githubPath}
+                placeholder="/Users/you/code/repo"
+                autocomplete="off"
+                disabled={inFlight}
+              />
+            </label>
+            <label class="first-run-field">
+              <span>Branch</span>
+              <input
+                bind:value={githubBranch}
+                placeholder={chosenGithubRepo?.default_branch ?? "Optional"}
+                autocomplete="off"
+                disabled={inFlight}
+              />
+            </label>
+
+            <div class="first-run-form__buttons">
+              <button
+                type="button"
+                onclick={backToActions}
+                disabled={inFlight}
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={inFlight || !selectedGithubRepo}
+              >
+                {inFlight ? "Cloning..." : "Clone repository"}
+              </button>
+            </div>
+          {/if}
+        </form>
+      {/if}
+    </div>
+  {/if}
 
   {#if lastError}
     <p class="first-run__error" role="alert">
@@ -167,7 +534,7 @@
     flex-direction: column;
     gap: 16px;
     width: 100%;
-    max-width: 480px;
+    max-width: 560px;
     margin: 24px auto;
     padding: 16px;
     box-sizing: border-box;
@@ -191,6 +558,13 @@
     color: var(--text-secondary);
     font-size: var(--font-size-md);
     line-height: 1.5;
+  }
+
+  .first-run__host {
+    margin: 0;
+    color: var(--text-muted);
+    font-family: var(--font-mono, monospace);
+    font-size: var(--font-size-sm);
   }
 
   .first-run__actions {
@@ -234,33 +608,110 @@
 
   .first-run-action__label {
     font-weight: 600;
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
   }
 
-  .first-run-action__spinner {
-    color: var(--text-muted);
-  }
-
-  .first-run-action__description {
+  .first-run-action__description,
+  .first-run-action__reason,
+  .first-run-form__status {
     color: var(--text-secondary);
     font-size: var(--font-size-sm);
+    line-height: 1.4;
   }
 
   .first-run-action__reason {
-    margin: 0 0 0 14px;
-    color: var(--text-muted);
+    margin: 0 0 0 2px;
+  }
+
+  .first-run-form {
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md, 8px);
+    background: var(--bg-surface);
+    padding: 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
+
+  .first-run-form__header,
+  .first-run-form__buttons {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+  }
+
+  .first-run-form__title {
+    margin: 0;
+    color: var(--text-primary);
+    font-size: var(--font-size-md);
+    font-weight: 600;
+  }
+
+  .first-run-form__body {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .first-run-field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    color: var(--text-primary);
     font-size: var(--font-size-sm);
+    font-weight: 600;
+  }
+
+  .first-run-field input,
+  .first-run-field select {
+    box-sizing: border-box;
+    width: 100%;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm, 4px);
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    font: inherit;
+    font-weight: 400;
+    padding: 8px 10px;
+  }
+
+  .first-run-field input:disabled,
+  .first-run-field select:disabled {
+    opacity: 0.6;
+  }
+
+  .first-run-form__buttons {
+    justify-content: flex-end;
+  }
+
+  .first-run-form__buttons button,
+  .first-run-form__back,
+  .first-run-form__body > button {
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm, 4px);
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    font: inherit;
+    padding: 7px 10px;
+  }
+
+  .first-run-form__buttons button[type="submit"] {
+    background: var(--accent-blue);
+    border-color: var(--accent-blue);
+    color: white;
+  }
+
+  .first-run-form__buttons button:disabled,
+  .first-run-form__back:disabled,
+  .first-run-form__body > button:disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
   }
 
   .first-run__error {
     margin: 0;
-    padding: 8px 12px;
-    border: 1px solid var(--accent-red);
-    border-radius: var(--radius-md, 8px);
-    background: color-mix(in srgb, var(--accent-red) 10%, transparent);
     color: var(--accent-red);
-    font-size: var(--font-size-md);
+    font-size: var(--font-size-sm);
+    line-height: 1.4;
   }
 </style>

--- a/frontend/src/lib/components/terminal/WorkspaceFirstRunPanel.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceFirstRunPanel.svelte
@@ -156,6 +156,7 @@
 
   function isDisabled(definition: ActionDefinition): boolean {
     if (inFlight) return true;
+    if (definition.id === "connect-github" && scopedHostKey) return true;
     if (definition.requiresGh && !ghAuthed) return true;
     return false;
   }
@@ -163,6 +164,9 @@
   function disabledReason(
     definition: ActionDefinition,
   ): string | undefined {
+    if (definition.id === "connect-github" && scopedHostKey) {
+      return "Pick from GitHub is only available for the local host. Use Clone a repository for this host.";
+    }
     if (definition.requiresGh && !ghAuthed) {
       if (!tooling?.gh?.available) {
         return "Install gh to use this option.";

--- a/frontend/src/lib/components/terminal/WorkspaceFirstRunPanel.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceFirstRunPanel.test.ts
@@ -1,37 +1,55 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/svelte";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import WorkspaceFirstRunPanel from "./WorkspaceFirstRunPanel.svelte";
 
+const mocks = vi.hoisted(() => ({
+  cloneProject: vi.fn(),
+  listUserRepositories: vi.fn(),
+  loadSnapshotHosts: vi.fn(),
+  navigate: vi.fn(),
+  registerExistingProject: vi.fn(),
+}));
+
+vi.mock("../../api/fleet-snapshot.ts", () => ({
+  loadSnapshotHosts: mocks.loadSnapshotHosts,
+}));
+
+vi.mock("../../api/project-intake.ts", () => ({
+  cloneProject: mocks.cloneProject,
+  listUserRepositories: mocks.listUserRepositories,
+  registerExistingProject: mocks.registerExistingProject,
+}));
+
+vi.mock("../../stores/router.svelte.ts", () => ({
+  navigate: mocks.navigate,
+}));
+
 const win = window as any;
+
+function project(id = "prj_1") {
+  return {
+    id,
+    display_name: "Repo",
+    local_path: "/tmp/repo",
+    created_at: "2026-06-22T00:00:00Z",
+    updated_at: "2026-06-22T00:00:00Z",
+  };
+}
 
 interface SetupArgs {
   ghAuthed: boolean;
   ghAvailable?: boolean;
-  handlers?: Partial<Record<string, (ctx: unknown) => CommandResult | Promise<CommandResult>>>;
+  onWorkspaceCommand?: (command: string, payload: Record<string, unknown>) => CommandResult | Promise<CommandResult>;
 }
 
-function setupConfig({ ghAuthed, ghAvailable = true, handlers = {} }: SetupArgs): void {
+function setupConfig({
+  ghAuthed,
+  ghAvailable = true,
+  onWorkspaceCommand = vi.fn().mockResolvedValue({ ok: true }),
+}: SetupArgs): typeof onWorkspaceCommand {
   win.__middleman_config = {
-    actions: {
-      project: [
-        {
-          id: "add-existing",
-          label: "Add Existing",
-          handler: handlers["add-existing"] ?? vi.fn().mockResolvedValue({ ok: true }),
-        },
-        {
-          id: "clone",
-          label: "Clone",
-          handler: handlers["clone"] ?? vi.fn().mockResolvedValue({ ok: true }),
-        },
-        {
-          id: "connect-github",
-          label: "Connect GH",
-          handler: handlers["connect-github"] ?? vi.fn().mockResolvedValue({ ok: true }),
-        },
-      ],
-    },
+    onWorkspaceCommand,
     embed: {
       tooling: {
         git: { available: true, version: "2.45.0" },
@@ -40,6 +58,7 @@ function setupConfig({ ghAuthed, ghAvailable = true, handlers = {} }: SetupArgs)
     },
   };
   win.__middleman_notify_config_changed?.();
+  return onWorkspaceCommand;
 }
 
 describe("WorkspaceFirstRunPanel", () => {
@@ -48,6 +67,12 @@ describe("WorkspaceFirstRunPanel", () => {
       configurable: true,
       value: { writeText: vi.fn().mockResolvedValue(undefined) },
     });
+    mocks.cloneProject.mockReset();
+    mocks.listUserRepositories.mockReset();
+    mocks.loadSnapshotHosts.mockReset();
+    mocks.loadSnapshotHosts.mockResolvedValue([]);
+    mocks.navigate.mockReset();
+    mocks.registerExistingProject.mockReset();
   });
 
   afterEach(() => {
@@ -90,46 +115,9 @@ describe("WorkspaceFirstRunPanel", () => {
     expect(screen.getByText("Install gh to use this option.")).toBeTruthy();
   });
 
-  it("invokes the action handler when the user clicks", async () => {
-    const handler = vi.fn().mockResolvedValue({ ok: true });
-    setupConfig({
-      ghAuthed: true,
-      handlers: { "add-existing": handler },
-    });
-    render(WorkspaceFirstRunPanel);
-
-    const button = screen.getByRole("button", {
-      name: /Add an existing local repository/i,
-    });
-    await fireEvent.click(button);
-    expect(handler).toHaveBeenCalledWith({
-      surface: "first-run-panel",
-    });
-  });
-
-  it("renders the failure message when an action returns ok: false", async () => {
-    const handler = vi.fn().mockResolvedValue({
-      ok: false,
-      message: "Couldn't reach the remote",
-    });
-    setupConfig({ ghAuthed: true, handlers: { clone: handler } });
-    render(WorkspaceFirstRunPanel);
-
-    await fireEvent.click(screen.getByRole("button", { name: /Clone a repository/i }));
-    expect(await screen.findByText("Couldn't reach the remote")).toBeTruthy();
-  });
-
-  it("renders an upgrade-host hint when the action is not registered", async () => {
-    win.__middleman_config = {
-      actions: { project: [] },
-      embed: {
-        tooling: {
-          git: { available: true },
-          gh: { available: true, authenticated: true },
-        },
-      },
-    };
-    win.__middleman_notify_config_changed?.();
+  it("registers an existing repository and notifies the host", async () => {
+    mocks.registerExistingProject.mockResolvedValue(project("prj_existing"));
+    const command = setupConfig({ ghAuthed: true });
     render(WorkspaceFirstRunPanel);
 
     await fireEvent.click(
@@ -137,7 +125,197 @@ describe("WorkspaceFirstRunPanel", () => {
         name: /Add an existing local repository/i,
       }),
     );
-    expect(await screen.findByText(/not available in this build/i)).toBeTruthy();
+    await fireEvent.input(screen.getByLabelText("Repository path"), {
+      target: { value: "/tmp/repo" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Add repository" }));
+
+    await waitFor(() => {
+      expect(mocks.registerExistingProject).toHaveBeenCalledWith("/tmp/repo");
+    });
+    expect(command).toHaveBeenCalledWith("project-registered", {
+      projectId: "prj_existing",
+    });
+    expect(mocks.navigate).toHaveBeenCalledWith("/workspaces/embed/project/prj_existing");
+  });
+
+  it("adds a project on a scoped host", async () => {
+    mocks.registerExistingProject.mockResolvedValue(project("prj_remote"));
+    mocks.loadSnapshotHosts.mockResolvedValue([
+      {
+        configKey: "local",
+        diagnostics: [],
+        id: "local",
+        kind: "self",
+        name: "Local",
+        operationAvailability: {},
+        platform: "github",
+        preferredTransport: "local",
+        reachable: true,
+        tmuxSessions: [],
+      },
+      {
+        configKey: "epyc",
+        diagnostics: [],
+        id: "epyc",
+        kind: "remote",
+        name: "EPYC",
+        operationAvailability: {},
+        platform: "github",
+        preferredTransport: "ssh",
+        reachable: true,
+        tmuxSessions: [],
+      },
+    ]);
+    const command = setupConfig({ ghAuthed: true });
+    render(WorkspaceFirstRunPanel, {
+      props: { firstRun: false, hostKey: "epyc" },
+    });
+
+    expect(screen.getByText("Add a project.")).toBeTruthy();
+    expect(await screen.findByText("Host: EPYC")).toBeTruthy();
+
+    await fireEvent.click(
+      screen.getByRole("button", {
+        name: /Add an existing repository/i,
+      }),
+    );
+    await fireEvent.input(screen.getByLabelText("Repository path"), {
+      target: { value: "/srv/repo" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Add repository" }));
+
+    await waitFor(() => {
+      expect(mocks.registerExistingProject).toHaveBeenCalledWith("/srv/repo", { hostKey: "epyc" });
+    });
+    expect(command).toHaveBeenCalledWith("project-registered", {
+      projectId: "prj_remote",
+      hostKey: "epyc",
+    });
+    expect(mocks.navigate).toHaveBeenCalledWith("/workspaces");
+  });
+
+  it("falls back to injected workspace host metadata", async () => {
+    mocks.loadSnapshotHosts.mockRejectedValue(new Error("snapshot down"));
+    setupConfig({ ghAuthed: true });
+    win.__middleman_config.workspace = {
+      selectedHostKey: "local",
+      selectedWorktreeKey: null,
+      hosts: [
+        {
+          key: "local",
+          label: "Local",
+          connectionState: "connected",
+          platform: "github",
+          projects: [],
+          sessions: [],
+          resources: null,
+        },
+        {
+          key: "epyc",
+          label: "EPYC",
+          connectionState: "connected",
+          platform: "github",
+          projects: [],
+          sessions: [],
+          resources: null,
+        },
+      ],
+    };
+    win.__middleman_notify_config_changed?.();
+
+    render(WorkspaceFirstRunPanel, {
+      props: { firstRun: false, hostKey: "epyc" },
+    });
+
+    expect(screen.getByText("Add a project.")).toBeTruthy();
+    expect(await screen.findByText("Host: EPYC")).toBeTruthy();
+  });
+
+  it("clones a Git URL and notifies the host", async () => {
+    mocks.cloneProject.mockResolvedValue(project("prj_clone"));
+    const command = setupConfig({ ghAuthed: true });
+    render(WorkspaceFirstRunPanel);
+
+    await fireEvent.click(screen.getByRole("button", { name: /Clone a repository/i }));
+    await fireEvent.input(screen.getByLabelText("Repository URL"), {
+      target: { value: "git@github.com:octo/repo.git" },
+    });
+    await fireEvent.input(screen.getByLabelText("Destination path"), {
+      target: { value: "/tmp/repo" },
+    });
+    await fireEvent.input(screen.getByLabelText("Branch"), {
+      target: { value: "main" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Clone repository" }));
+
+    await waitFor(() => {
+      expect(mocks.cloneProject).toHaveBeenCalledWith("git@github.com:octo/repo.git", "/tmp/repo", "main");
+    });
+    expect(command).toHaveBeenCalledWith("project-registered", {
+      projectId: "prj_clone",
+    });
+  });
+
+  it("loads GitHub repositories and clones the selected repository", async () => {
+    mocks.listUserRepositories.mockResolvedValue([
+      {
+        name_with_owner: "octo/one",
+        ssh_url: "git@github.com:octo/one.git",
+        default_branch: "main",
+      },
+      {
+        name_with_owner: "octo/two",
+        ssh_url: "git@github.com:octo/two.git",
+        default_branch: "trunk",
+      },
+    ]);
+    mocks.cloneProject.mockResolvedValue(project("prj_gh"));
+    setupConfig({ ghAuthed: true });
+    render(WorkspaceFirstRunPanel);
+
+    await fireEvent.click(
+      screen.getByRole("button", {
+        name: /Connect a GitHub repository/i,
+      }),
+    );
+    const repoSelect = await screen.findByLabelText("GitHub repository");
+    await fireEvent.change(repoSelect, {
+      target: { value: "octo/two" },
+    });
+    await fireEvent.input(screen.getByLabelText("Destination path"), {
+      target: { value: "/tmp/two" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Clone repository" }));
+
+    await waitFor(() => {
+      expect(mocks.cloneProject).toHaveBeenCalledWith("git@github.com:octo/two.git", "/tmp/two", "");
+    });
+  });
+
+  it("surfaces host callback failures after registration", async () => {
+    mocks.registerExistingProject.mockResolvedValue(project("prj_existing"));
+    setupConfig({
+      ghAuthed: true,
+      onWorkspaceCommand: vi.fn().mockResolvedValue({
+        ok: false,
+        message: "refresh failed",
+      }),
+    });
+    render(WorkspaceFirstRunPanel);
+
+    await fireEvent.click(
+      screen.getByRole("button", {
+        name: /Add an existing local repository/i,
+      }),
+    );
+    await fireEvent.input(screen.getByLabelText("Repository path"), {
+      target: { value: "/tmp/repo" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Add repository" }));
+
+    expect(await screen.findByText("refresh failed")).toBeTruthy();
+    expect(mocks.navigate).not.toHaveBeenCalled();
   });
 
   it("renders the tooling status block beneath the actions", () => {

--- a/frontend/src/lib/components/terminal/WorkspaceFirstRunPanel.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceFirstRunPanel.test.ts
@@ -195,6 +195,22 @@ describe("WorkspaceFirstRunPanel", () => {
     expect(mocks.navigate).toHaveBeenCalledWith("/workspaces");
   });
 
+  it("disables GitHub repository picking on scoped hosts", () => {
+    setupConfig({ ghAuthed: true });
+    render(WorkspaceFirstRunPanel, {
+      props: { firstRun: false, hostKey: "epyc" },
+    });
+
+    const button = screen.getByRole("button", {
+      name: /Connect a GitHub repository/i,
+    }) as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    expect(
+      screen.getByText("Pick from GitHub is only available for the local host. Use Clone a repository for this host."),
+    ).toBeTruthy();
+    expect(mocks.listUserRepositories).not.toHaveBeenCalled();
+  });
+
   it("falls back to injected workspace host metadata", async () => {
     mocks.loadSnapshotHosts.mockRejectedValue(new Error("snapshot down"));
     setupConfig({ ghAuthed: true });

--- a/frontend/src/lib/components/terminal/WorkspaceProjectCard.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceProjectCard.svelte
@@ -18,6 +18,7 @@
 
   interface Props {
     projectId: string;
+    hostKey?: string | null | undefined;
   }
 
   interface PlatformIdentity {
@@ -42,7 +43,7 @@
     path: string;
   }
 
-  let { projectId }: Props = $props();
+  let { projectId, hostKey = null }: Props = $props();
 
   let project = $state<Project | null>(null);
   let worktrees = $state<Worktree[]>([]);
@@ -50,17 +51,22 @@
   let loading = $state<boolean>(true);
   let inFlight = $state<boolean>(false);
   let actionError = $state<string | null>(null);
+  const scopedHostKey = $derived(hostKey?.trim() || undefined);
 
   async function load(): Promise<void> {
     loading = true;
     loadError = null;
     try {
-      const {
-        data: projectData,
-        error: projectError,
-      } = await client.GET("/projects/{project_id}", {
-        params: { path: { project_id: projectId } },
-      });
+      const projectResult = scopedHostKey
+        ? await client.GET("/fleet/hosts/{host_key}/projects/{project_id}", {
+            params: {
+              path: { host_key: scopedHostKey, project_id: projectId },
+            },
+          })
+        : await client.GET("/projects/{project_id}", {
+            params: { path: { project_id: projectId } },
+          });
+      const { data: projectData, error: projectError } = projectResult;
       if (!projectData) {
         loadError = apiErrorMessage(
           projectError,
@@ -70,12 +76,16 @@
       }
       project = projectData as Project;
 
-      const {
-        data: worktreesData,
-        error: worktreesError,
-      } = await client.GET("/projects/{project_id}/worktrees", {
-        params: { path: { project_id: projectId } },
-      });
+      const worktreesResult = scopedHostKey
+        ? await client.GET("/fleet/hosts/{host_key}/projects/{project_id}/worktrees", {
+            params: {
+              path: { host_key: scopedHostKey, project_id: projectId },
+            },
+          })
+        : await client.GET("/projects/{project_id}/worktrees", {
+            params: { path: { project_id: projectId } },
+          });
+      const { data: worktreesData, error: worktreesError } = worktreesResult;
       if (!worktreesData) {
         loadError = apiErrorMessage(
           worktreesError,
@@ -110,6 +120,7 @@
       const result = await invokeProjectAction(action, {
         surface: "project-card",
         projectId,
+        ...(scopedHostKey ? { hostKey: scopedHostKey } : {}),
       });
       if (!result.ok) {
         actionError = result.message ?? "Couldn't start a new worktree.";

--- a/frontend/src/lib/components/terminal/WorkspaceProjectCard.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceProjectCard.test.ts
@@ -16,7 +16,13 @@ vi.mock("../../api/runtime.ts", () => ({
       if (path === "/projects/{project_id}") {
         return projectGet(options);
       }
+      if (path === "/fleet/hosts/{host_key}/projects/{project_id}") {
+        return projectGet(options);
+      }
       if (path === "/projects/{project_id}/worktrees") {
+        return worktreesGet(options);
+      }
+      if (path === "/fleet/hosts/{host_key}/projects/{project_id}/worktrees") {
         return worktreesGet(options);
       }
       throw new Error(`unexpected GET path ${path}`);
@@ -169,6 +175,27 @@ describe("WorkspaceProjectCard", () => {
     expect(screen.getByRole("button", { name: /Create another worktree/i })).toBeTruthy();
   });
 
+  it("loads project data through fleet routes when host scoped", async () => {
+    setProjectResponse({
+      id: "prj_1",
+      display_name: "myrepo",
+      local_path: "/srv/myrepo",
+    });
+    setWorktreesResponse([]);
+
+    render(WorkspaceProjectCard, {
+      props: { projectId: "prj_1", hostKey: " epyc " },
+    });
+
+    expect(await screen.findByText("myrepo")).toBeTruthy();
+    expect(projectGet).toHaveBeenCalledWith({
+      params: { path: { host_key: "epyc", project_id: "prj_1" } },
+    });
+    expect(worktreesGet).toHaveBeenCalledWith({
+      params: { path: { host_key: "epyc", project_id: "prj_1" } },
+    });
+  });
+
   it("renders an error and a retry button when the project fetch fails", async () => {
     setProjectResponse({ error: "project not found" });
     render(WorkspaceProjectCard, { props: { projectId: "prj_1" } });
@@ -209,6 +236,45 @@ describe("WorkspaceProjectCard", () => {
     expect(newWorktreeHandler).toHaveBeenCalledWith({
       surface: "project-card",
       projectId: "prj_1",
+    });
+  });
+
+  it("includes the host key in new-worktree action context", async () => {
+    const newWorktreeHandler = vi.fn().mockResolvedValue({ ok: true });
+    win.__middleman_config = {
+      actions: {
+        project: [
+          {
+            id: "new-worktree",
+            label: "New Worktree",
+            handler: newWorktreeHandler,
+          },
+        ],
+      },
+    };
+    win.__middleman_notify_config_changed?.();
+
+    setProjectResponse({
+      id: "prj_1",
+      display_name: "myrepo",
+      local_path: "/tmp/myrepo",
+    });
+    setWorktreesResponse([]);
+
+    render(WorkspaceProjectCard, {
+      props: { projectId: "prj_1", hostKey: " epyc " },
+    });
+    await screen.findByText("myrepo");
+
+    await fireEvent.click(
+      screen.getByRole("button", {
+        name: /Create your first worktree/i,
+      }),
+    );
+    expect(newWorktreeHandler).toHaveBeenCalledWith({
+      surface: "project-card",
+      projectId: "prj_1",
+      hostKey: "epyc",
     });
   });
 

--- a/frontend/src/lib/stores/embed-config.svelte.ts
+++ b/frontend/src/lib/stores/embed-config.svelte.ts
@@ -22,6 +22,7 @@ export interface ActionContext {
 export interface ProjectActionContext {
   surface: string;
   projectId?: string;
+  hostKey?: string;
   meta?: Record<string, unknown>;
 }
 

--- a/frontend/src/lib/stores/router.svelte.ts
+++ b/frontend/src/lib/stores/router.svelte.ts
@@ -45,6 +45,7 @@ export type Route =
   | { page: "focus"; itemType: "mrs"; repo?: string }
   | { page: "focus"; itemType: "issues"; repo?: string }
   | { page: "reviews"; jobId?: number }
+  | { page: "project-intake"; hostKey?: string }
   | { page: "terminal"; workspaceId: string; hostKey?: string }
   // Embed-targetable workspace surfaces. Hosts mount these
   // routes to render a single component of the workspaces UX
@@ -67,7 +68,11 @@ export type Route =
     }
   | { page: "embed-workspace-empty"; reason: EmbedEmptyReason }
   | { page: "embed-workspace-first-run" }
-  | { page: "embed-workspace-project"; projectId: string };
+  | {
+      page: "embed-workspace-project";
+      projectId: string;
+      hostKey?: string;
+    };
 
 export type Page = Route["page"];
 
@@ -332,6 +337,14 @@ function parseRoute(fullPath: string): Route {
     }
     return { page: "reviews" };
   }
+  if (path === "/project-intake") {
+    const sp = new URLSearchParams(search);
+    const hostKey = emptyToNull(sp.get("host"));
+    return {
+      page: "project-intake",
+      ...(hostKey ? { hostKey } : {}),
+    };
+  }
   const fleetTerminalMatch = path.match(/^\/terminal\/fleet\/([^/]+)\/([^/]+)$/);
   if (fleetTerminalMatch) {
     return {
@@ -448,9 +461,12 @@ function parseRoute(fullPath: string): Route {
   }
   const embedProjectMatch = path.match(/^\/workspaces\/embed\/project\/([A-Za-z0-9_-]+)$/);
   if (embedProjectMatch) {
+    const sp = new URLSearchParams(search);
+    const hostKey = emptyToNull(sp.get("host"));
     return {
       page: "embed-workspace-project",
       projectId: embedProjectMatch[1]!,
+      ...(hostKey ? { hostKey } : {}),
     };
   }
   if (path === "/workspaces" || path.startsWith("/workspaces/")) {
@@ -533,7 +549,7 @@ export function navigate(path: string, state?: Record<string, unknown>): void {
 
 function buildRouteEvent(r: Route): MiddlemanNavigateEvent {
   const focus = r.page === "focus";
-  let navType: MiddlemanNavigateEvent["type"];
+  let navType: MiddlemanNavigateType;
   if (r.page === "focus") {
     if (r.itemType === "mrs") {
       navType = "pull";
@@ -562,7 +578,7 @@ function buildRouteEvent(r: Route): MiddlemanNavigateEvent {
     navType = "messages";
   } else if (r.page === "reviews") {
     navType = "reviews";
-  } else if (isWorkspacePage(r.page)) {
+  } else if (r.page === "project-intake" || isWorkspacePage(r.page)) {
     navType = "workspaces";
   } else if (r.page === "design-system") {
     navType = "activity";
@@ -570,7 +586,17 @@ function buildRouteEvent(r: Route): MiddlemanNavigateEvent {
     navType = "activity";
   }
 
+  let page: MiddlemanNavigatePage;
+  if (navType === "pull") {
+    page = "pulls";
+  } else if (navType === "issue") {
+    page = "issues";
+  } else {
+    page = navType;
+  }
+
   const event: MiddlemanNavigateEvent = {
+    page,
     type: navType,
     focus,
     view: stripBase(window.location.pathname) + window.location.search,

--- a/frontend/src/lib/stores/router.test.ts
+++ b/frontend/src/lib/stores/router.test.ts
@@ -477,6 +477,24 @@ describe("router embed-workspace routes", () => {
       projectId: "prj_abc123",
     });
     expect(getPage()).toBe("embed-workspace-project");
+
+    navigate("/workspaces/embed/project/prj_abc123?host=epyc");
+    expect(getRoute()).toEqual({
+      page: "embed-workspace-project",
+      projectId: "prj_abc123",
+      hostKey: "epyc",
+    });
+  });
+
+  it("parses /project-intake with an optional host", () => {
+    navigate("/project-intake");
+    expect(getRoute()).toEqual({ page: "project-intake" });
+
+    navigate("/project-intake?host=epyc");
+    expect(getRoute()).toEqual({
+      page: "project-intake",
+      hostKey: "epyc",
+    });
   });
 
   it("falls back to the standalone workspaces page for unknown project_id shapes", () => {
@@ -518,6 +536,7 @@ describe("router navigation events", () => {
 
     expect(spy).toHaveBeenCalledTimes(1);
     const payload = spy.mock.calls[0]![0];
+    expect(payload.page).toBe("pulls");
     expect(payload.type).toBe("pull");
     expect(payload.focus).toBe(false);
     expect(payload.owner).toBe("acme");
@@ -533,7 +552,24 @@ describe("router navigation events", () => {
 
     expect(spy).toHaveBeenCalledTimes(1);
     const payload = spy.mock.calls[0]![0];
+    expect(payload.page).toBe("pulls");
     expect(payload.type).toBe("pull");
+    expect(payload.owner).toBe("acme");
+    expect(payload.name).toBe("widgets");
+    expect(payload.number).toBe(42);
+  });
+
+  it("fires onNavigate with pulls page for focus pull route", () => {
+    const spy = vi.fn();
+    installOnNavigate(spy);
+
+    navigate(focusPrRoute);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const payload = spy.mock.calls[0]![0];
+    expect(payload.page).toBe("pulls");
+    expect(payload.type).toBe("pull");
+    expect(payload.focus).toBe(true);
     expect(payload.owner).toBe("acme");
     expect(payload.name).toBe("widgets");
     expect(payload.number).toBe(42);
@@ -547,7 +583,38 @@ describe("router navigation events", () => {
 
     expect(spy).toHaveBeenCalledTimes(1);
     const payload = spy.mock.calls[0]![0];
-    expect(payload).toEqual({ type: "pull", focus: false, view: "/pulls" });
+    expect(payload).toEqual({
+      page: "pulls",
+      type: "pull",
+      focus: false,
+      view: "/pulls",
+    });
+  });
+
+  it("fires onNavigate with board page for /pulls/board", () => {
+    const spy = vi.fn();
+    installOnNavigate(spy);
+
+    navigate("/pulls/board");
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const payload = spy.mock.calls[0]![0];
+    expect(payload.page).toBe("board");
+    expect(payload.type).toBe("board");
+    expect(payload.focus).toBe(false);
+  });
+
+  it("fires onNavigate with issues page for issue list route", () => {
+    const spy = vi.fn();
+    installOnNavigate(spy);
+
+    navigate("/issues");
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const payload = spy.mock.calls[0]![0];
+    expect(payload.page).toBe("issues");
+    expect(payload.type).toBe("issue");
+    expect(payload.focus).toBe(false);
   });
 
   it("maps /design-system to activity navigation events", () => {
@@ -558,6 +625,7 @@ describe("router navigation events", () => {
 
     expect(spy).toHaveBeenCalledTimes(1);
     const payload = spy.mock.calls[0]![0];
+    expect(payload.page).toBe("activity");
     expect(payload.type).toBe("activity");
     expect(payload.view).toBe("/design-system");
   });
@@ -569,6 +637,7 @@ describe("router navigation events", () => {
     navigate("/kata");
 
     const payload = spy.mock.calls[spy.mock.calls.length - 1]![0];
+    expect(payload.page).toBe("kata");
     expect(payload.type).toBe("kata");
     expect(payload.view).toBe("/kata");
   });
@@ -580,6 +649,7 @@ describe("router navigation events", () => {
     navigate("/docs?folder=notes&doc=Daily%2Ftoday.md");
 
     const payload = spy.mock.calls[spy.mock.calls.length - 1]![0];
+    expect(payload.page).toBe("docs");
     expect(payload.type).toBe("docs");
     expect(payload.view).toBe("/docs?folder=notes&doc=Daily%2Ftoday.md");
   });
@@ -591,6 +661,7 @@ describe("router navigation events", () => {
     navigate("/messages?q=from%3Aops");
 
     const payload = spy.mock.calls[spy.mock.calls.length - 1]![0];
+    expect(payload.page).toBe("messages");
     expect(payload.type).toBe("messages");
     expect(payload.view).toBe("/messages?q=from%3Aops");
   });
@@ -606,12 +677,14 @@ describe("router navigation events", () => {
       "/workspaces/embed/empty/noWorkspace",
       "/workspaces/embed/first-run",
       "/workspaces/embed/project/prj_abc123",
+      "/project-intake?host=epyc",
     ];
 
     for (const path of embedPaths) {
       spy.mockClear();
       navigate(path);
       const payload = spy.mock.calls[spy.mock.calls.length - 1]![0];
+      expect(payload.page, `page for ${path}`).toBe("workspaces");
       expect(payload.type, `type for ${path}`).toBe("workspaces");
       expect(payload.focus, `focus for ${path}`).toBe(false);
     }

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -95,17 +95,17 @@ interface ActionHookDef {
   }) => void | Promise<void>;
 }
 
-// ProjectActionDef is the registry shape for project-scoped actions
-// (add-existing, clone, connect-github, new-worktree). The handler MUST
-// return a CommandResult so the firing surface can render success/failure
-// instead of a fire-and-forget click. The action ID is the identifier the
-// surface uses to look up the handler.
+// ProjectActionDef is the registry shape for project-scoped actions such
+// as new-worktree. The handler MUST return a CommandResult so the firing
+// surface can render success/failure instead of a fire-and-forget click.
+// The action ID is the identifier the surface uses to look up the handler.
 interface ProjectActionDef {
   id: string;
   label: string;
   handler: (context: {
     surface: string;
     projectId?: string;
+    hostKey?: string;
     meta?: Record<string, unknown>;
   }) => CommandResult | Promise<CommandResult>;
 }
@@ -219,8 +219,33 @@ interface WorkspaceDetailContext {
   host: WorkspaceHost | null;
 }
 
+type MiddlemanNavigatePage =
+  | "pulls"
+  | "issues"
+  | "activity"
+  | "repos"
+  | "kata"
+  | "docs"
+  | "messages"
+  | "board"
+  | "reviews"
+  | "workspaces";
+
+type MiddlemanNavigateType =
+  | "pull"
+  | "issue"
+  | "activity"
+  | "repos"
+  | "kata"
+  | "docs"
+  | "messages"
+  | "board"
+  | "reviews"
+  | "workspaces";
+
 interface MiddlemanNavigateEvent {
-  type: "pull" | "issue" | "activity" | "repos" | "kata" | "docs" | "messages" | "board" | "reviews" | "workspaces";
+  page: MiddlemanNavigatePage;
+  type: MiddlemanNavigateType;
   owner?: string;
   name?: string;
   number?: number;

--- a/frontend/tests/e2e-full/embedded-config.spec.ts
+++ b/frontend/tests/e2e-full/embedded-config.spec.ts
@@ -1,4 +1,28 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { expect, test, type Page } from "@playwright/test";
+
+import { startIsolatedE2EServer, startIsolatedE2EServerWithOptions } from "./support/e2eServer";
+
+type ProjectResponse = {
+  id: string;
+  display_name: string;
+  local_path?: string;
+};
+
+type ProjectListResponse = {
+  projects: ProjectResponse[];
+};
+
+type SnapshotResponse = {
+  hosts: Array<{
+    configKey: string;
+    kind: string;
+    name: string;
+  }>;
+};
 
 async function waitForPRList(page: Page): Promise<void> {
   await page.locator(".pull-item").first().waitFor({ state: "visible", timeout: 10_000 });
@@ -98,5 +122,134 @@ test.describe("embedded config", () => {
     await page.goto("/settings");
 
     await page.locator(".settings-page").waitFor({ state: "visible", timeout: 10_000 });
+  });
+
+  test("project intake uses snapshot host metadata and host-scoped registration", async ({ page }) => {
+    const server = await startIsolatedE2EServerWithOptions({ fleetKey: "hub" });
+    const localRepo = realpathSync(mkdtempSync(path.join(os.tmpdir(), "middleman-hosted-intake-")));
+    try {
+      execFileSync("git", ["init", "-b", "main"], { cwd: localRepo, stdio: "ignore" });
+      execFileSync("git", ["config", "user.email", "e2e@example.com"], {
+        cwd: localRepo,
+        stdio: "ignore",
+      });
+      execFileSync("git", ["config", "user.name", "E2E Fixture"], {
+        cwd: localRepo,
+        stdio: "ignore",
+      });
+      execFileSync("git", ["commit", "--allow-empty", "-m", "fixture: seed project"], {
+        cwd: localRepo,
+        stdio: "ignore",
+      });
+
+      const snapshotResponse = await page.request.get(`${server.info.base_url}/api/v1/snapshot?include_peers=true`);
+      expect(snapshotResponse.status(), await snapshotResponse.text()).toBe(200);
+      const snapshot = (await snapshotResponse.json()) as SnapshotResponse;
+      const hubHost = snapshot.hosts.find((host) => host.configKey === "hub");
+      expect(hubHost).toBeDefined();
+      expect(hubHost?.kind).toBe("self");
+
+      const snapshotLoaded = page.waitForResponse((response) => {
+        const url = new URL(response.url());
+        return url.pathname === "/api/v1/snapshot" && url.searchParams.get("include_peers") === "true";
+      });
+      await page.goto(`${server.info.base_url}/project-intake?host=hub`);
+      await snapshotLoaded;
+      await expect(page.getByText(`Host: ${hubHost?.name ?? "hub"}`)).toBeVisible();
+
+      await page.getByRole("button", { name: /Add an existing repository/ }).click();
+      await page.getByLabel("Repository path").fill(localRepo);
+
+      const registerFinished = page.waitForResponse((response) => {
+        const url = new URL(response.url());
+        return response.request().method() === "POST" && url.pathname === "/api/v1/fleet/hosts/hub/projects";
+      });
+      await page.getByRole("button", { name: "Add repository" }).click();
+      const registerResponse = await registerFinished;
+      expect(registerResponse.status(), await registerResponse.text()).toBe(201);
+      const created = (await registerResponse.json()) as ProjectResponse;
+      expect(created.id).not.toBe("");
+
+      await expect(page).toHaveURL(/\/workspaces$/);
+      const listResponse = await page.request.get(`${server.info.base_url}/api/v1/projects`);
+      expect(listResponse.status(), await listResponse.text()).toBe(200);
+      const list = (await listResponse.json()) as ProjectListResponse;
+      expect(list.projects).toContainEqual(
+        expect.objectContaining({
+          id: created.id,
+          local_path: localRepo,
+        }),
+      );
+    } finally {
+      rmSync(localRepo, { recursive: true, force: true });
+      await server.stop();
+    }
+  });
+
+  test("embed project card preserves host key in project actions", async ({ page }) => {
+    const server = await startIsolatedE2EServerWithOptions({ fleetKey: "hub" });
+    const localRepo = realpathSync(mkdtempSync(path.join(os.tmpdir(), "middleman-hosted-card-")));
+    try {
+      execFileSync("git", ["init"], { cwd: localRepo, stdio: "ignore" });
+      const registerResponse = await page.request.post(`${server.info.base_url}/api/v1/projects`, {
+        data: {
+          local_path: localRepo,
+          display_name: "Fleet Project",
+          default_branch: "main",
+        },
+      });
+      expect(registerResponse.status(), await registerResponse.text()).toBe(201);
+      const project = (await registerResponse.json()) as ProjectResponse;
+      expect(project.id).not.toBe("");
+
+      await page.addInitScript(() => {
+        const win = window as unknown as {
+          __middleman_config?: MiddlemanConfig;
+          __middleman_project_action_context?: unknown;
+        };
+        win.__middleman_config = {
+          actions: {
+            project: [
+              {
+                id: "new-worktree",
+                label: "New Worktree",
+                handler: (context) => {
+                  win.__middleman_project_action_context = context;
+                  return { ok: true };
+                },
+              },
+            ],
+          },
+        };
+      });
+
+      await page.goto(`${server.info.base_url}/workspaces/embed/project/${encodeURIComponent(project.id)}?host=hub`);
+      await expect(page.locator("header.app-header")).toHaveCount(0);
+      await expect(page.getByText("Fleet Project")).toBeVisible();
+
+      await page
+        .getByRole("button", {
+          name: /Create (your first|another) worktree/i,
+        })
+        .click();
+
+      await expect
+        .poll(() =>
+          page.evaluate(() => {
+            const win = window as unknown as {
+              __middleman_project_action_context?: unknown;
+            };
+            return win.__middleman_project_action_context;
+          }),
+        )
+        .toEqual({
+          surface: "project-card",
+          projectId: project.id,
+          hostKey: "hub",
+        });
+    } finally {
+      rmSync(localRepo, { recursive: true, force: true });
+      await server.stop();
+    }
   });
 });

--- a/frontend/tests/e2e-full/support/e2eServer.ts
+++ b/frontend/tests/e2e-full/support/e2eServer.ts
@@ -23,6 +23,7 @@ export type IsolatedE2EServer = {
 
 export type IsolatedE2EServerOptions = {
   defaultPlatformHost?: string;
+  fleetKey?: string;
   visibleImportedModes?: boolean;
   providerCollision?: boolean;
   // Spawn a dedicated server process and kill it on stop() instead of
@@ -293,6 +294,9 @@ async function spawnServer(
   if (options.defaultPlatformHost) {
     args.push("-default-platform-host", options.defaultPlatformHost);
   }
+  if (options.fleetKey) {
+    args.push("-fleet-key", options.fleetKey);
+  }
   if (options.visibleImportedModes) {
     args.push("-visible-imported-modes");
   }
@@ -386,6 +390,7 @@ export async function ensureE2EServer(): Promise<E2EServerInfo> {
       // with all imported app modes visible.
       const server = await spawnPooledServer({
         host: defaultPlatformHost,
+        fleetKey: "",
         visibleImportedModes: true,
         providerCollision: false,
       });
@@ -457,6 +462,7 @@ export async function stopE2EServer(): Promise<void> {
 
 type PooledServerOptions = {
   host: string;
+  fleetKey: string;
   visibleImportedModes: boolean;
   providerCollision: boolean;
 };
@@ -473,6 +479,7 @@ type PooledServer = {
 
 const defaultPooledOptions: PooledServerOptions = {
   host: defaultPlatformHost,
+  fleetKey: "",
   visibleImportedModes: false,
   providerCollision: false,
 };
@@ -503,6 +510,7 @@ function assertPooledLeaseEnvUnchanged(): void {
 function normalizedPooledOptions(options: IsolatedE2EServerOptions): PooledServerOptions {
   return {
     host: options.defaultPlatformHost ?? defaultPlatformHost,
+    fleetKey: options.fleetKey ?? "",
     visibleImportedModes: options.visibleImportedModes ?? false,
     providerCollision: options.providerCollision ?? false,
   };
@@ -511,6 +519,7 @@ function normalizedPooledOptions(options: IsolatedE2EServerOptions): PooledServe
 function samePooledOptions(a: PooledServerOptions, b: PooledServerOptions): boolean {
   return (
     a.host === b.host &&
+    a.fleetKey === b.fleetKey &&
     a.visibleImportedModes === b.visibleImportedModes &&
     a.providerCollision === b.providerCollision
   );
@@ -577,6 +586,7 @@ async function postReset(baseURL: string, options: PooledServerOptions): Promise
     request.end(
       JSON.stringify({
         default_platform_host: options.host,
+        fleet_key: options.fleetKey,
         visible_imported_modes: options.visibleImportedModes,
         provider_collision: options.providerCollision,
       }),
@@ -616,6 +626,7 @@ async function spawnPooledServer(options: PooledServerOptions): Promise<PooledSe
   const infoFile = path.join(infoDir, "server-info.json");
   const started = await spawnServer(infoFile, {
     ...(options.host === defaultPlatformHost ? {} : { defaultPlatformHost: options.host }),
+    ...(options.fleetKey ? { fleetKey: options.fleetKey } : {}),
     ...(options.visibleImportedModes ? { visibleImportedModes: true } : {}),
     ...(options.providerCollision ? { providerCollision: true } : {}),
   });

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -2903,6 +2903,7 @@ type WorktreeFromMergeRequestResponse struct {
 
 // WorktreeLinkResponse defines model for WorktreeLinkResponse.
 type WorktreeLinkResponse struct {
+	HostKey        *string `json:"host_key,omitempty"`
 	WorktreeBranch *string `json:"worktree_branch,omitempty"`
 	WorktreeKey    string  `json:"worktree_key"`
 	WorktreePath   *string `json:"worktree_path,omitempty"`
@@ -3899,8 +3900,14 @@ type ClientInterface interface {
 	// DeleteFleetProject request
 	DeleteFleetProject(ctx context.Context, hostKey string, projectId string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// GetFleetProject request
+	GetFleetProject(ctx context.Context, hostKey string, projectId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// ListFleetProjectBranches request
 	ListFleetProjectBranches(ctx context.Context, hostKey string, projectId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListFleetProjectWorktrees request
+	ListFleetProjectWorktrees(ctx context.Context, hostKey string, projectId string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// CreateFleetProjectWorktreeWithBody request with any body
 	CreateFleetProjectWorktreeWithBody(ctx context.Context, hostKey string, projectId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -5215,8 +5222,32 @@ func (c *Client) DeleteFleetProject(ctx context.Context, hostKey string, project
 	return c.Client.Do(req)
 }
 
+func (c *Client) GetFleetProject(ctx context.Context, hostKey string, projectId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetFleetProjectRequest(c.Server, hostKey, projectId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) ListFleetProjectBranches(ctx context.Context, hostKey string, projectId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewListFleetProjectBranchesRequest(c.Server, hostKey, projectId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListFleetProjectWorktrees(ctx context.Context, hostKey string, projectId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListFleetProjectWorktreesRequest(c.Server, hostKey, projectId)
 	if err != nil {
 		return nil, err
 	}
@@ -10510,6 +10541,47 @@ func NewDeleteFleetProjectRequest(server string, hostKey string, projectId strin
 	return req, nil
 }
 
+// NewGetFleetProjectRequest generates requests for GetFleetProject
+func NewGetFleetProjectRequest(server string, hostKey string, projectId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "host_key", hostKey, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "project_id", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/fleet/hosts/%s/projects/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewListFleetProjectBranchesRequest generates requests for ListFleetProjectBranches
 func NewListFleetProjectBranchesRequest(server string, hostKey string, projectId string) (*http.Request, error) {
 	var err error
@@ -10534,6 +10606,47 @@ func NewListFleetProjectBranchesRequest(server string, hostKey string, projectId
 	}
 
 	operationPath := fmt.Sprintf("/fleet/hosts/%s/projects/%s/branches", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewListFleetProjectWorktreesRequest generates requests for ListFleetProjectWorktrees
+func NewListFleetProjectWorktreesRequest(server string, hostKey string, projectId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "host_key", hostKey, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "project_id", projectId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/fleet/hosts/%s/projects/%s/worktrees", pathParam0, pathParam1)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -23918,8 +24031,14 @@ type ClientWithResponsesInterface interface {
 	// DeleteFleetProjectWithResponse request
 	DeleteFleetProjectWithResponse(ctx context.Context, hostKey string, projectId string, reqEditors ...RequestEditorFn) (*DeleteFleetProjectResponse, error)
 
+	// GetFleetProjectWithResponse request
+	GetFleetProjectWithResponse(ctx context.Context, hostKey string, projectId string, reqEditors ...RequestEditorFn) (*GetFleetProjectResponse, error)
+
 	// ListFleetProjectBranchesWithResponse request
 	ListFleetProjectBranchesWithResponse(ctx context.Context, hostKey string, projectId string, reqEditors ...RequestEditorFn) (*ListFleetProjectBranchesResponse, error)
+
+	// ListFleetProjectWorktreesWithResponse request
+	ListFleetProjectWorktreesWithResponse(ctx context.Context, hostKey string, projectId string, reqEditors ...RequestEditorFn) (*ListFleetProjectWorktreesResponse, error)
 
 	// CreateFleetProjectWorktreeWithBodyWithResponse request with any body
 	CreateFleetProjectWorktreeWithBodyWithResponse(ctx context.Context, hostKey string, projectId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateFleetProjectWorktreeResponse, error)
@@ -25396,6 +25515,29 @@ func (r DeleteFleetProjectResponse) StatusCode() int {
 	return 0
 }
 
+type GetFleetProjectResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSONDefault                   *map[string]interface{}
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r GetFleetProjectResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetFleetProjectResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type ListFleetProjectBranchesResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
@@ -25413,6 +25555,29 @@ func (r ListFleetProjectBranchesResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r ListFleetProjectBranchesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListFleetProjectWorktreesResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSONDefault                   *map[string]interface{}
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r ListFleetProjectWorktreesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListFleetProjectWorktreesResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -30907,6 +31072,15 @@ func (c *ClientWithResponses) DeleteFleetProjectWithResponse(ctx context.Context
 	return ParseDeleteFleetProjectResponse(rsp)
 }
 
+// GetFleetProjectWithResponse request returning *GetFleetProjectResponse
+func (c *ClientWithResponses) GetFleetProjectWithResponse(ctx context.Context, hostKey string, projectId string, reqEditors ...RequestEditorFn) (*GetFleetProjectResponse, error) {
+	rsp, err := c.GetFleetProject(ctx, hostKey, projectId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetFleetProjectResponse(rsp)
+}
+
 // ListFleetProjectBranchesWithResponse request returning *ListFleetProjectBranchesResponse
 func (c *ClientWithResponses) ListFleetProjectBranchesWithResponse(ctx context.Context, hostKey string, projectId string, reqEditors ...RequestEditorFn) (*ListFleetProjectBranchesResponse, error) {
 	rsp, err := c.ListFleetProjectBranches(ctx, hostKey, projectId, reqEditors...)
@@ -30914,6 +31088,15 @@ func (c *ClientWithResponses) ListFleetProjectBranchesWithResponse(ctx context.C
 		return nil, err
 	}
 	return ParseListFleetProjectBranchesResponse(rsp)
+}
+
+// ListFleetProjectWorktreesWithResponse request returning *ListFleetProjectWorktreesResponse
+func (c *ClientWithResponses) ListFleetProjectWorktreesWithResponse(ctx context.Context, hostKey string, projectId string, reqEditors ...RequestEditorFn) (*ListFleetProjectWorktreesResponse, error) {
+	rsp, err := c.ListFleetProjectWorktrees(ctx, hostKey, projectId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListFleetProjectWorktreesResponse(rsp)
 }
 
 // CreateFleetProjectWorktreeWithBodyWithResponse request with arbitrary body returning *CreateFleetProjectWorktreeResponse
@@ -34532,6 +34715,39 @@ func ParseDeleteFleetProjectResponse(rsp *http.Response) (*DeleteFleetProjectRes
 	return response, nil
 }
 
+// ParseGetFleetProjectResponse parses an HTTP response from a GetFleetProjectWithResponse call
+func ParseGetFleetProjectResponse(rsp *http.Response) (*GetFleetProjectResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetFleetProjectResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case rsp.Header.Get("Content-Type") == "application/json" && true:
+		var dest map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	case rsp.Header.Get("Content-Type") == "application/problem+json" && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseListFleetProjectBranchesResponse parses an HTTP response from a ListFleetProjectBranchesWithResponse call
 func ParseListFleetProjectBranchesResponse(rsp *http.Response) (*ListFleetProjectBranchesResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -34541,6 +34757,39 @@ func ParseListFleetProjectBranchesResponse(rsp *http.Response) (*ListFleetProjec
 	}
 
 	response := &ListFleetProjectBranchesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case rsp.Header.Get("Content-Type") == "application/json" && true:
+		var dest map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	case rsp.Header.Get("Content-Type") == "application/problem+json" && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListFleetProjectWorktreesResponse parses an HTTP response from a ListFleetProjectWorktreesWithResponse call
+func ParseListFleetProjectWorktreesResponse(rsp *http.Response) (*ListFleetProjectWorktreesResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListFleetProjectWorktreesResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -12176,6 +12176,7 @@ func TestMRListIncludesWorktreeLinks(t *testing.T) {
 	require.Equal(http.StatusOK, rr.Code)
 	body := rr.Body.String()
 	require.Contains(body, `"worktree_links"`)
+	require.Contains(body, `"host_key":"`+srv.fleetSelfKey("")+`"`)
 	require.Contains(body, `"worktree_key":"wt-abc"`)
 	require.Contains(body, `"worktree_path":"/tmp/wt"`)
 	require.Contains(body, `"worktree_branch":"feature"`)
@@ -12206,6 +12207,7 @@ func TestMRDetailIncludesWorktreeLinks(t *testing.T) {
 	require.Equal(http.StatusOK, rr.Code)
 	body := rr.Body.String()
 	require.Contains(body, `"worktree_links"`)
+	require.Contains(body, `"host_key":"`+srv.fleetSelfKey("")+`"`)
 	require.Contains(body, `"worktree_key":"wt-detail"`)
 }
 

--- a/internal/server/api_types.go
+++ b/internal/server/api_types.go
@@ -9,6 +9,7 @@ import (
 )
 
 type worktreeLinkResponse struct {
+	HostKey        string `json:"host_key,omitempty"`
 	WorktreeKey    string `json:"worktree_key"`
 	WorktreePath   string `json:"worktree_path,omitempty"`
 	WorktreeBranch string `json:"worktree_branch,omitempty"`

--- a/internal/server/fleet_project_proxy_test.go
+++ b/internal/server/fleet_project_proxy_test.go
@@ -1,8 +1,12 @@
 package server
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -57,4 +61,74 @@ func TestServeFleetProjectWrite_UnknownHostIs404(t *testing.T) {
 
 	assert.Equal(t, http.StatusNotFound, w.Code,
 		"a host that is neither local nor a configured peer is unreachable")
+}
+
+func TestFleetProjectIntakeSelfRoutePersistsProject(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	require := require.New(t)
+	assert := assert.New(t)
+
+	srv, database := setupTestServer(t)
+	srv.cfg = &config.Config{}
+	srv.cfg.Fleet.Enabled = true
+	srv.cfg.Fleet.Key = "hub"
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	repoDir := t.TempDir()
+	require.NoError(initLocalOnlyGitRepo(t.Context(), repoDir))
+	expectedRoot, err := filepath.EvalSymlinks(repoDir)
+	require.NoError(err)
+
+	validatePath := "/api/v1/fleet/hosts/hub/filesystem/validate-repo?path=" +
+		url.QueryEscape(repoDir)
+	resp := httpDo(t, ts, http.MethodGet, validatePath, nil)
+	require.Equal(http.StatusOK, resp.StatusCode)
+	var validation struct {
+		IsValid  bool   `json:"is_valid"`
+		RootPath string `json:"root_path"`
+	}
+	require.NoError(json.NewDecoder(resp.Body).Decode(&validation))
+	resp.Body.Close()
+	require.True(validation.IsValid, "fleet validation should accept the repo")
+	assert.Equal(expectedRoot, validation.RootPath)
+
+	registerBody := mustMarshal(t, map[string]any{
+		"local_path": validation.RootPath,
+	})
+	resp = httpDo(
+		t, ts, http.MethodPost,
+		"/api/v1/fleet/hosts/hub/projects",
+		registerBody,
+	)
+	require.Equal(http.StatusCreated, resp.StatusCode)
+	var created struct {
+		ID        string `json:"id"`
+		LocalPath string `json:"local_path"`
+	}
+	require.NoError(json.NewDecoder(resp.Body).Decode(&created))
+	resp.Body.Close()
+	require.NotEmpty(created.ID)
+	assert.Equal(expectedRoot, created.LocalPath)
+
+	project, err := database.GetProjectByID(t.Context(), created.ID)
+	require.NoError(err)
+	assert.Equal(expectedRoot, project.LocalPath)
+
+	resp = httpDo(t, ts, http.MethodGet, "/api/v1/projects", nil)
+	require.Equal(http.StatusOK, resp.StatusCode)
+	var listed struct {
+		Projects []struct {
+			ID        string `json:"id"`
+			LocalPath string `json:"local_path"`
+		} `json:"projects"`
+	}
+	require.NoError(json.NewDecoder(resp.Body).Decode(&listed))
+	resp.Body.Close()
+	require.Len(listed.Projects, 1)
+	assert.Equal(created.ID, listed.Projects[0].ID)
+	assert.Equal(expectedRoot, listed.Projects[0].LocalPath)
 }

--- a/internal/server/fleet_project_proxy_test.go
+++ b/internal/server/fleet_project_proxy_test.go
@@ -71,9 +71,10 @@ func TestFleetProjectIntakeSelfRoutePersistsProject(t *testing.T) {
 	assert := assert.New(t)
 
 	srv, database := setupTestServer(t)
-	srv.cfg = &config.Config{}
-	srv.cfg.Fleet.Enabled = true
-	srv.cfg.Fleet.Key = "hub"
+	setTestFleetConfig(srv, func(cfg *config.Config) {
+		cfg.Fleet.Enabled = true
+		cfg.Fleet.Key = "hub"
+	})
 
 	ts := httptest.NewServer(srv)
 	defer ts.Close()

--- a/internal/server/fleet_proxy.go
+++ b/internal/server/fleet_proxy.go
@@ -335,6 +335,27 @@ func (s *Server) registerFleetOperationRoutes(api huma.API) {
 			},
 		},
 		{
+			operationID: "get-fleet-project",
+			method:      http.MethodGet,
+			path:        "/fleet/hosts/{host_key}/projects/{project_id}",
+			summary:     "Get project on fleet host",
+			pathParams:  []string{"host_key", "project_id"},
+			targetPath: func(r *http.Request) string {
+				return "/api/v1/projects/" + escapePath(r.PathValue("project_id"))
+			},
+		},
+		{
+			operationID: "list-fleet-project-worktrees",
+			method:      http.MethodGet,
+			path:        "/fleet/hosts/{host_key}/projects/{project_id}/worktrees",
+			summary:     "List project worktrees on fleet host",
+			pathParams:  []string{"host_key", "project_id"},
+			targetPath: func(r *http.Request) string {
+				return "/api/v1/projects/" + escapePath(r.PathValue("project_id")) +
+					"/worktrees"
+			},
+		},
+		{
 			operationID: "inspect-fleet-project-worktree",
 			method:      http.MethodGet,
 			path:        "/fleet/hosts/{host_key}/projects/{project_id}/worktrees/{worktree_id}/inspect",

--- a/internal/server/fleet_routes_test.go
+++ b/internal/server/fleet_routes_test.go
@@ -75,8 +75,10 @@ func TestSnapshotRoutesRegistered(t *testing.T) {
 	require.NotNil(spec.Paths["/fleet/hosts/{host_key}/projects/{project_id}/worktrees/{worktree_id}/runtime/sessions/{session_key}/attach-spec"].Get, "GET fleet project worktree session attach spec not registered")
 	require.NotNil(spec.Paths["/fleet/hosts/{host_key}/workspaces/{id}"].Delete, "DELETE fleet workspace not registered")
 	require.NotNil(spec.Paths["/fleet/hosts/{host_key}/projects"].Post, "POST fleet project register not registered")
+	require.NotNil(spec.Paths["/fleet/hosts/{host_key}/projects/{project_id}"].Get, "GET fleet project not registered")
 	require.NotNil(spec.Paths["/fleet/hosts/{host_key}/projects/{project_id}"].Delete, "DELETE fleet project not registered")
 
+	require.NotNil(spec.Paths["/fleet/hosts/{host_key}/projects/{project_id}/worktrees"].Get, "GET fleet worktree list not registered")
 	require.NotNil(spec.Paths["/fleet/hosts/{host_key}/projects/{project_id}/worktrees"].Post, "POST fleet worktree create not registered")
 	require.NotNil(spec.Paths["/fleet/hosts/{host_key}/projects/{project_id}/worktrees/from-merge-request"].Post, "POST fleet worktree from-merge-request not registered")
 	require.NotNil(spec.Paths["/fleet/hosts/{host_key}/projects/{project_id}/worktrees/{worktree_id}/delete"].Post, "POST fleet worktree remove not registered")

--- a/internal/server/fleet_worktree_proxy_test.go
+++ b/internal/server/fleet_worktree_proxy_test.go
@@ -60,6 +60,20 @@ func TestFleetWorktreeLifecycleProxiesToPeer(t *testing.T) {
 		wantPath   string
 	}{
 		{
+			name:       "get project",
+			method:     http.MethodGet,
+			path:       "/fleet/hosts/member/projects/prj_1",
+			wantMethod: http.MethodGet,
+			wantPath:   "/api/v1/projects/prj_1",
+		},
+		{
+			name:       "list worktrees",
+			method:     http.MethodGet,
+			path:       "/fleet/hosts/member/projects/prj_1/worktrees",
+			wantMethod: http.MethodGet,
+			wantPath:   "/api/v1/projects/prj_1/worktrees",
+		},
+		{
 			name:       "create worktree",
 			method:     http.MethodPost,
 			path:       "/fleet/hosts/member/projects/prj_1/worktrees",

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -451,10 +451,12 @@ func (s *Server) toRepoSummaryResponse(
 // Returns an empty non-nil slice when input is nil.
 func toWorktreeLinkResponses(
 	links []db.WorktreeLink,
+	hostKey string,
 ) []worktreeLinkResponse {
 	out := make([]worktreeLinkResponse, len(links))
 	for i, l := range links {
 		out[i] = worktreeLinkResponse{
+			HostKey:        hostKey,
 			WorktreeKey:    l.WorktreeKey,
 			WorktreePath:   l.WorktreePath,
 			WorktreeBranch: l.WorktreeBranch,
@@ -467,12 +469,14 @@ func toWorktreeLinkResponses(
 // merge request ID.
 func indexWorktreeLinksByMR(
 	links []db.WorktreeLink,
+	hostKey string,
 ) map[int64][]worktreeLinkResponse {
 	m := make(map[int64][]worktreeLinkResponse)
 	for _, l := range links {
 		m[l.MergeRequestID] = append(
 			m[l.MergeRequestID],
 			worktreeLinkResponse{
+				HostKey:        hostKey,
 				WorktreeKey:    l.WorktreeKey,
 				WorktreePath:   l.WorktreePath,
 				WorktreeBranch: l.WorktreeBranch,

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -1384,7 +1384,10 @@ func (s *Server) listPulls(ctx context.Context, input *listPullsInput) (*listPul
 	if err != nil {
 		return nil, problemInternal("load worktree links failed")
 	}
-	linksByMR := indexWorktreeLinksByMR(links)
+	linksByMR := indexWorktreeLinksByMR(
+		links,
+		s.fleetSelfKey(""),
+	)
 	workspacesByItem, err := s.buildWorkspaceRefLookup(ctx)
 	if err != nil {
 		return nil, problemInternal("load workspace refs failed")
@@ -1577,7 +1580,7 @@ func (s *Server) buildPullDetailResponse(
 		ReviewedHeadSHA:  verifiedReviewedHeadSHA(mr),
 		DiffHeadSHA:      mr.DiffHeadSHA,
 		MergeBaseSHA:     mr.MergeBaseSHA,
-		WorktreeLinks:    toWorktreeLinkResponses(dbLinks),
+		WorktreeLinks:    toWorktreeLinkResponses(dbLinks, s.fleetSelfKey("")),
 		WorkflowApproval: s.workflowApprovalState(ctx, repo.Owner, repo.Name, mr),
 		Warnings:         s.diffWarnings(mr),
 		DetailLoaded:     mr.DetailFetchedAt != nil,

--- a/internal/server/worktree_stale.go
+++ b/internal/server/worktree_stale.go
@@ -34,10 +34,10 @@ type removeStaleWorktreeOutput struct {
 //
 // The worktree must be stale and its path must still be absent: a reappeared
 // checkout is refused so a live worktree is never removed by a racing caller.
-// Removing the registry row cascades the worktree's stored runtime tmux
-// sessions. When removeBranch is set, the worktree's branch is deleted from the
-// owning checkout on a best-effort basis (a missing branch never blocks the
-// removal), mirroring the host behavior this route replaces.
+// Live runtime sessions and stored tmux sessions are stopped before removing
+// the registry row. When removeBranch is set, the worktree's branch is deleted
+// from the owning checkout on a best-effort basis (a missing branch never
+// blocks the removal), mirroring the host behavior this route replaces.
 func (s *Server) removeStaleWorktree(
 	ctx context.Context, input *removeStaleWorktreeInput,
 ) (*removeStaleWorktreeOutput, error) {
@@ -67,6 +67,14 @@ func (s *Server) removeStaleWorktree(
 		// refusing keeps a possibly-live worktree (and its branch) intact.
 		return nil, problemInternal(
 			"stat worktree path: " + statErr.Error(),
+		)
+	}
+
+	release, err := s.stopWorktreeRuntimeState(ctx, worktree.ID)
+	defer release()
+	if err != nil {
+		return nil, problemInternal(
+			"stop worktree runtime sessions: " + err.Error(),
 		)
 	}
 

--- a/internal/server/worktree_stale_test.go
+++ b/internal/server/worktree_stale_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -82,6 +83,40 @@ func TestRemoveStaleWorktreeRoute(t *testing.T) {
 	resp = remove("worktree:" + wtPath)
 	require.Equal(http.StatusNotFound, resp.StatusCode)
 	resp.Body.Close()
+}
+
+func TestRemoveStaleWorktreeRouteStopsRuntimeSessions(t *testing.T) {
+	requirePTYAvailable(t)
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	srv, projectID, worktreeID, recordPath :=
+		setupProjectWorktreeCommandSessionTestWithRecord(t)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	worktree, err := srv.db.GetProjectWorktreeByID(t.Context(), worktreeID)
+	require.NoError(err)
+	tmuxSession := launchCommandSessionForDeleteTest(
+		t, ts, projectID, worktreeID, "surface:host:wt:shell:leaf",
+	)
+	require.NoError(os.RemoveAll(worktree.Path))
+	require.NoError(srv.db.ReconcileProjectInventory(
+		t.Context(), projectID, db.ProjectInventory{}, time.Now(),
+	))
+
+	resp := httpDo(t, ts, http.MethodPost, "/api/v1/worktrees/remove-stale",
+		mustMarshal(t, map[string]any{"scopedKey": "worktree:" + worktree.Path}))
+	require.Equal(http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+
+	assertFakeTmuxKilledSession(t, recordPath, tmuxSession)
+	assert.Empty(srv.runtime.ListSessions(projectWorktreeRuntimeScope(worktreeID)))
+	rows, err := srv.db.ListProjectWorktreeTmuxSessions(
+		context.Background(), worktreeID,
+	)
+	require.NoError(err)
+	assert.Empty(rows)
 }
 
 // TestRemoveStaleWorktreeRoute_RefusesNonStaleAndReappeared keeps the route from

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -390,7 +390,8 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        /** Get project on fleet host */
+        get: operations["get-fleet-project"];
         put?: never;
         post?: never;
         /** Delete project on fleet host */
@@ -424,7 +425,8 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        /** List project worktrees on fleet host */
+        get: operations["list-fleet-project-worktrees"];
         put?: never;
         /** Create project worktree on fleet host */
         post: operations["create-fleet-project-worktree"];
@@ -6716,6 +6718,7 @@ export interface components {
             updated_at: string;
         };
         WorktreeLinkResponse: {
+            host_key?: string;
             worktree_branch?: string;
             worktree_key: string;
             worktree_path?: string;
@@ -7661,6 +7664,32 @@ export interface operations {
             };
         };
     };
+    "get-fleet-project": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                host_key: string;
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Response returned by the owning fleet host. */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
     "delete-fleet-project": {
         parameters: {
             query?: never;
@@ -7688,6 +7717,32 @@ export interface operations {
         };
     };
     "list-fleet-project-branches": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                host_key: string;
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Response returned by the owning fleet host. */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
+    "list-fleet-project-worktrees": {
         parameters: {
             query?: never;
             header?: never;

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -2104,7 +2104,10 @@
                 if (stalePR) return;
                 navigateAction.handler({
                   surface: "pull-detail", owner, name, number,
-                  meta: { worktree_key: link.worktree_key },
+                  meta: {
+                    worktree_key: link.worktree_key,
+                    host_key: link.host_key,
+                  },
                 });
               }}
               disabled={stalePR}

--- a/packages/ui/src/components/detail/PullDetail.test.ts
+++ b/packages/ui/src/components/detail/PullDetail.test.ts
@@ -137,10 +137,12 @@ function renderPullDetail(
       data: {},
     })),
   },
-  options = {
-    hideWorkspaceAction: true,
-  },
+  options: {
+    hideWorkspaceAction?: boolean;
+    actions?: { pull: unknown[] };
+  } = {},
 ) {
+  const actions = options.actions ?? { pull: [] };
   const detailStore = {
     loadDetail: vi.fn(async () => undefined),
     startDetailPolling: vi.fn(),
@@ -166,7 +168,7 @@ function renderPullDetail(
       provider: "github",
       platformHost: "github.com",
       repoPath: "acme/widget",
-      hideWorkspaceAction: options.hideWorkspaceAction,
+      hideWorkspaceAction: options.hideWorkspaceAction ?? true,
     },
     context: new Map<symbol, unknown>([
       [API_CLIENT_KEY, apiClient],
@@ -179,7 +181,7 @@ function renderPullDetail(
           detailActivityView: createDetailActivityViewStore(),
         },
       ],
-      [ACTIONS_KEY, { pull: [] }],
+      [ACTIONS_KEY, actions],
       [UI_CONFIG_KEY, { hideStar: true }],
       [NAVIGATE_KEY, vi.fn()],
     ]),
@@ -235,6 +237,48 @@ describe("PullDetail approvals", () => {
       expect(descriptionId).toBeTruthy();
       expect(document.getElementById(descriptionId ?? "")?.textContent).toContain(button.getAttribute("title"));
     }
+  });
+
+  it("forwards worktree link host key to navigate actions", async () => {
+    const detail = pullDetail();
+    detail.worktree_links = [
+      {
+        host_key: "hub",
+        worktree_key: "worktree:/srv/widget-feature",
+        worktree_path: "/srv/widget-feature",
+        worktree_branch: "feature",
+      },
+    ];
+    const navigate = vi.fn();
+
+    renderPullDetail(detail, undefined, undefined, {
+      actions: {
+        pull: [
+          {
+            id: "navigate-worktree",
+            label: "Open Worktree",
+            handler: navigate,
+          },
+        ],
+      },
+    });
+
+    await fireEvent.click(
+      screen.getByRole("button", {
+        name: "Open Worktree: worktree:/srv/widget-feature",
+      }),
+    );
+
+    expect(navigate).toHaveBeenCalledWith({
+      surface: "pull-detail",
+      owner: "acme",
+      name: "widget",
+      number: 1,
+      meta: {
+        host_key: "hub",
+        worktree_key: "worktree:/srv/widget-feature",
+      },
+    });
   });
 
   it("normalizes backend review decision casing before enabling approver popup", async () => {


### PR DESCRIPTION
Middleman should own project intake and host-scoped project/worktree read paths directly. This branch moves first-run add and clone flows into the Middleman workspace UI, keeps host context on workspace routes and project actions, reads fleet projects for project cards, and includes host keys on PR worktree links so linked worktrees open on the correct fleet host.

Local and fleet workspaces now share one Middleman-owned path for project registration, clone/add, project-card reads, and PR worktree-link navigation.