### PR TITLE
Require provider-qualified repository identity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,9 @@ This paragraph is the single place CLAUDE.md enumerates supported providers. Do 
 New features must work across every supported provider to the extent each provider's API allows. Concrete rules:
 
 - Provider-specific capability differences go behind the capability model in `internal/platform`. Declare capabilities in `Capabilities()`, check them before mutations, and return typed `unsupported_capability` errors when a provider can't satisfy an operation. Do not silently fall back to GitHub-only behavior for other providers.
-- Identity is `(platform, platform_host, owner, name)` everywhere; never owner/name/number alone. Repo-scoped routes use provider-aware paths like `/pulls/{provider}/{owner}/{name}/{number}`, with `/host/{platform_host}/...` for non-default or self-hosted instances.
+- Repository identity is always the quad `(provider, platform_host, owner, repo)`. In code and schema this same quad is always represented as `(platform, platform_host, owner, name)`. There is no repository identity without both provider and host. The host may be omitted from a user-facing route only when the route helper is intentionally using the provider's default host; the logical identity still includes the normalized host.
+- Never identify, route, cache, dedupe, query, persist, or compare repositories, pull requests, merge requests, issues, comments, checks, releases, workspaces, activity, or events by owner/repo/number alone. Every repo-scoped path and data structure must carry provider and host as well as owner and repo.
+- Repo-scoped routes use provider-aware paths like `/pulls/{provider}/{owner}/{name}/{number}`, with `/host/{platform_host}/...` for non-default or self-hosted instances.
 - GitHub-only optimizations (GraphQL bulk fetch, ETag recovery, detailed diff behavior) stay in `internal/github/` and remain optional around the neutral persistence path.
 - Frontend stores and components must thread the full provider ref (`provider`, `platformHost`, `owner`, `name`, `repoPath`) through the shared route helpers in `packages/ui/src/api/provider-routes.ts`. Do not hand-build `/api/v1` URLs or assume GitHub defaults inside components.
 

--- a/cmd/e2e-server/main.go
+++ b/cmd/e2e-server/main.go
@@ -305,7 +305,9 @@ func seedLabelEditingFixture(
 	database *db.DB,
 	fc *testutil.FixtureClient,
 ) error {
-	repo, err := database.GetRepoByOwnerName(ctx, "acme", "widgets")
+	repo, err := database.GetRepoByIdentity(
+		ctx, db.GitHubRepoIdentity("github.com", "acme", "widgets"),
+	)
 	if err != nil {
 		return fmt.Errorf("get widgets repo: %w", err)
 	}
@@ -387,7 +389,9 @@ func seedAssigneeReviewerFixture(
 	database *db.DB,
 	fc *testutil.FixtureClient,
 ) error {
-	repo, err := database.GetRepoByOwnerName(ctx, "acme", "widgets")
+	repo, err := database.GetRepoByIdentity(
+		ctx, db.GitHubRepoIdentity("github.com", "acme", "widgets"),
+	)
 	if err != nil {
 		return fmt.Errorf("get widgets repo: %w", err)
 	}
@@ -615,7 +619,9 @@ func setPR1CIState(
 	label string,
 	opts ciFixtureOptions,
 ) {
-	repo, err := database.GetRepoByOwnerName(r.Context(), "acme", "widgets")
+	repo, err := database.GetRepoByIdentity(
+		r.Context(), db.GitHubRepoIdentity("github.com", "acme", "widgets"),
+	)
 	if err != nil || repo == nil {
 		http.Error(w, "repo not found", http.StatusNotFound)
 		return
@@ -861,7 +867,9 @@ func buildAppState(
 		{"acme", "widgets"},
 		{"acme", "tools"},
 	} {
-		repo, err := database.GetRepoByOwnerName(ctx, rp.owner, rp.name)
+		repo, err := database.GetRepoByIdentity(
+			ctx, db.GitHubRepoIdentity("github.com", rp.owner, rp.name),
+		)
 		if err != nil || repo == nil {
 			continue
 		}
@@ -1035,7 +1043,9 @@ func buildAppState(
 		{owner: "acme", name: "widgets", number: 7},
 		{owner: "acme", name: "tools", number: 1},
 	} {
-		repo, err := database.GetRepoByOwnerName(ctx, target.owner, target.name)
+		repo, err := database.GetRepoByIdentity(
+			ctx, db.GitHubRepoIdentity("github.com", target.owner, target.name),
+		)
 		if err != nil {
 			return nil, fmt.Errorf("get %s/%s repo: %w", target.owner, target.name, err)
 		}
@@ -1305,8 +1315,8 @@ func buildAppState(
 	rootHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost &&
 			r.URL.Path == "/__e2e/pr-workflow-approval/required" {
-			repo, err := database.GetRepoByOwnerName(
-				r.Context(), "acme", "widgets",
+			repo, err := database.GetRepoByIdentity(
+				r.Context(), db.GitHubRepoIdentity("github.com", "acme", "widgets"),
 			)
 			if err != nil || repo == nil {
 				http.Error(w, "repo not found", http.StatusNotFound)
@@ -1362,8 +1372,8 @@ func buildAppState(
 		}
 		if r.Method == http.MethodPost &&
 			r.URL.Path == "/__e2e/repo-settings/viewer-can-merge/deny" {
-			repo, err := database.GetRepoByOwnerName(
-				r.Context(), "acme", "widgets",
+			repo, err := database.GetRepoByIdentity(
+				r.Context(), db.GitHubRepoIdentity("github.com", "acme", "widgets"),
 			)
 			if err != nil || repo == nil {
 				http.Error(w, "repo not found", http.StatusNotFound)
@@ -1627,8 +1637,8 @@ func buildAppState(
 		}
 		if r.Method == http.MethodPost &&
 			r.URL.Path == "/__e2e/pr-diff-summary/advance-head" {
-			repo, err := database.GetRepoByOwnerName(
-				r.Context(), "acme", "widgets",
+			repo, err := database.GetRepoByIdentity(
+				r.Context(), db.GitHubRepoIdentity("github.com", "acme", "widgets"),
 			)
 			if err != nil || repo == nil {
 				http.Error(w, "repo not found", http.StatusNotFound)
@@ -1662,8 +1672,8 @@ func buildAppState(
 		}
 		if r.Method == http.MethodPost &&
 			r.URL.Path == "/__e2e/pr-review-thread-regroup/add-reply" {
-			repo, err := database.GetRepoByOwnerName(
-				r.Context(), "acme", "widgets",
+			repo, err := database.GetRepoByIdentity(
+				r.Context(), db.GitHubRepoIdentity("github.com", "acme", "widgets"),
 			)
 			if err != nil || repo == nil {
 				http.Error(w, "repo not found", http.StatusNotFound)

--- a/cmd/e2e-server/main_test.go
+++ b/cmd/e2e-server/main_test.go
@@ -17,6 +17,7 @@ import (
 	gh "github.com/google/go-github/v84/github"
 	Assert "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/middleman/internal/db"
 	"go.kenn.io/middleman/internal/testutil"
 	"go.kenn.io/middleman/internal/web"
 )
@@ -198,8 +199,8 @@ func TestBuildAppStateSeedsReviewedHeadsForUTCMergeTargets(t *testing.T) {
 			require := require.New(t)
 			assert := Assert.New(t)
 
-			repo, err := state.database.GetRepoByOwnerName(
-				t.Context(), target.owner, target.repo,
+			repo, err := state.database.GetRepoByIdentity(
+				t.Context(), db.GitHubRepoIdentity("github.com", target.owner, target.repo),
 			)
 			require.NoError(err)
 			require.NotNil(repo)

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -692,6 +692,7 @@ components:
         provider:
           type: string
       required:
+        - provider
         - platform_host
         - owner
         - name
@@ -5861,11 +5862,15 @@ components:
           type: string
         platform_host:
           type: string
+        provider:
+          type: string
       required:
         - item_type
+        - provider
         - owner
         - name
         - number
+        - platform_host
       type: object
     SyncStatus:
       additionalProperties: false
@@ -6507,12 +6512,12 @@ paths:
     get:
       operationId: list-activity
       parameters:
-        - description: Repository filter. Accepts owner/name, platform_host/repo_path, comma-separated values, or provider|platform_host/repo_path for provider-qualified matches.
+        - description: Repository filter. Accepts provider|platform_host/repo_path, with comma-separated values for multiple repositories.
           explode: false
           in: query
           name: repo
           schema:
-            description: Repository filter. Accepts owner/name, platform_host/repo_path, comma-separated values, or provider|platform_host/repo_path for provider-qualified matches.
+            description: Repository filter. Accepts provider|platform_host/repo_path, with comma-separated values for multiple repositories.
             type: string
         - explode: false
           in: query
@@ -11145,12 +11150,12 @@ paths:
     get:
       operationId: list-issues
       parameters:
-        - description: Repository filter. Accepts owner/name, platform_host/repo_path, comma-separated values, or provider|platform_host/repo_path for provider-qualified matches.
+        - description: Repository filter. Accepts provider|platform_host/repo_path, with comma-separated values for multiple repositories.
           explode: false
           in: query
           name: repo
           schema:
-            description: Repository filter. Accepts owner/name, platform_host/repo_path, comma-separated values, or provider|platform_host/repo_path for provider-qualified matches.
+            description: Repository filter. Accepts provider|platform_host/repo_path, with comma-separated values for multiple repositories.
             type: string
         - explode: false
           in: query
@@ -12953,12 +12958,12 @@ paths:
     get:
       operationId: list-pulls
       parameters:
-        - description: Repository filter. Accepts owner/name, platform_host/repo_path, comma-separated values, or provider|platform_host/repo_path for provider-qualified matches.
+        - description: Repository filter. Accepts provider|platform_host/repo_path, with comma-separated values for multiple repositories.
           explode: false
           in: query
           name: repo
           schema:
-            description: Repository filter. Accepts owner/name, platform_host/repo_path, comma-separated values, or provider|platform_host/repo_path for provider-qualified matches.
+            description: Repository filter. Accepts provider|platform_host/repo_path, with comma-separated values for multiple repositories.
             type: string
         - explode: false
           in: query
@@ -15368,12 +15373,12 @@ paths:
     post:
       operationId: trigger-sync
       parameters:
-        - description: Optional repository filters to sync first. Accepts repeated values or comma-separated values. Each value may be provider-qualified as provider|platform_host/owner/name, host-qualified as platform_host/owner/name, or bare as owner/name; bare values match the first tracked repo with that repo path.
+        - description: Optional repository filters to sync first. Accepts repeated provider|platform_host/repo_path values or comma-separated values.
           explode: false
           in: query
           name: priority_repo
           schema:
-            description: Optional repository filters to sync first. Accepts repeated values or comma-separated values. Each value may be provider-qualified as provider|platform_host/owner/name, host-qualified as platform_host/owner/name, or bare as owner/name; bare values match the first tracked repo with that repo path.
+            description: Optional repository filters to sync first. Accepts repeated provider|platform_host/repo_path values or comma-separated values.
             items:
               type: string
             type:

--- a/frontend/src/App.repo-sync.browser.svelte.ts
+++ b/frontend/src/App.repo-sync.browser.svelte.ts
@@ -138,6 +138,7 @@ function pullSummary(owner: string, name: string, number: number, title: string,
     ClosedAt: null,
     KanbanStatus: "new",
     Starred: false,
+    provider: "github",
     repo_owner: owner,
     repo_name: name,
     platform_host: "github.com",
@@ -169,14 +170,14 @@ function pullDetail(owner: string, name: string, number: number) {
   };
 }
 
-// The pulls store appends `repo=<host/owner/name>` when a global repo is set, so
+// The pulls store appends `repo=<provider|host/owner/name>` when a global repo is set, so
 // the list honors it exactly the way the live backend filters.
 function listOverride(): MockRouteOverride {
   return (req) => {
     if (req.method !== "GET" || req.url.pathname !== "/api/v1/pulls") return null;
     const repo = req.url.searchParams.get("repo");
     const filtered = repo
-      ? allPulls.filter((p) => `${p.platform_host}/${p.repo_owner}/${p.repo_name}` === repo)
+      ? allPulls.filter((p) => `${p.provider}|${p.platform_host}/${p.repo_owner}/${p.repo_name}` === repo)
       : allPulls;
     return jsonResponse(filtered);
   };
@@ -227,21 +228,21 @@ describe("deep-link repo dropdown + sidebar sync", () => {
   });
 
   it("navigating to a PR in a different repo updates the dropdown and the sidebar list", async () => {
-    setGlobalRepo("github.com/acme/widgets");
+    setGlobalRepo("github|github.com/acme/widgets");
     mounted = await mountBrowserApp("/pulls/github/acme/tools/1", { overrides: overrides() });
 
     await vi.waitFor(() => expect(document.querySelector(".pull-detail")).not.toBeNull(), WAIT);
-    await vi.waitFor(() => expect(typeaheadValue()).toBe("github.com/acme/tools"), WAIT);
+    await vi.waitFor(() => expect(typeaheadValue()).toBe("github/github.com/acme/tools"), WAIT);
     await vi.waitFor(() => expect(repoHeaderNames()).toEqual(["acme/tools"]), WAIT);
   });
 
   it("navigating between PRs in different repos updates the dropdown each time", async () => {
-    setGlobalRepo("github.com/acme/widgets");
+    setGlobalRepo("github|github.com/acme/widgets");
     mounted = await mountBrowserApp("/pulls/github/acme/widgets/1", { overrides: overrides() });
-    await vi.waitFor(() => expect(typeaheadValue()).toBe("github.com/acme/widgets"), WAIT);
+    await vi.waitFor(() => expect(typeaheadValue()).toBe("github/github.com/acme/widgets"), WAIT);
 
     firePopstate("/pulls/github/acme/tools/1");
-    await vi.waitFor(() => expect(typeaheadValue()).toBe("github.com/acme/tools"), WAIT);
+    await vi.waitFor(() => expect(typeaheadValue()).toBe("github/github.com/acme/tools"), WAIT);
   });
 
   it("selecting an item from All repos keeps the all-repo filter", async () => {
@@ -256,10 +257,10 @@ describe("deep-link repo dropdown + sidebar sync", () => {
   });
 
   it("opening /pulls without a selection preserves the user's chosen repo", async () => {
-    setGlobalRepo("github.com/acme/widgets");
+    setGlobalRepo("github|github.com/acme/widgets");
     mounted = await mountBrowserApp("/pulls", { overrides: overrides() });
 
     await vi.waitFor(() => expect(document.querySelector(".pull-item")).not.toBeNull(), WAIT);
-    await vi.waitFor(() => expect(typeaheadValue()).toBe("github.com/acme/widgets"), WAIT);
+    await vi.waitFor(() => expect(typeaheadValue()).toBe("github/github.com/acme/widgets"), WAIT);
   });
 });

--- a/frontend/src/lib/components/RepoTypeahead.svelte
+++ b/frontend/src/lib/components/RepoTypeahead.svelte
@@ -216,7 +216,7 @@
       return;
     }
     const validValues = new Set(options.map((option) => option.value));
-    const next = selectedValues.filter((value) => validValues.has(value) || value.includes("|"));
+    const next = selectedValues.filter((value) => validValues.has(value) || (value.includes("|") && !settingsLoaded));
     if (next.length === selectedValues.length) return;
     onchange(serializeRepoFilterValue(next));
   });

--- a/frontend/src/lib/components/RepoTypeahead.svelte
+++ b/frontend/src/lib/components/RepoTypeahead.svelte
@@ -216,7 +216,7 @@
       return;
     }
     const validValues = new Set(options.map((option) => option.value));
-    const next = selectedValues.filter((value) => validValues.has(value));
+    const next = selectedValues.filter((value) => validValues.has(value) || value.includes("|"));
     if (next.length === selectedValues.length) return;
     onchange(serializeRepoFilterValue(next));
   });

--- a/frontend/src/lib/components/RepoTypeahead.test.ts
+++ b/frontend/src/lib/components/RepoTypeahead.test.ts
@@ -152,10 +152,10 @@ describe("RepoTypeahead", () => {
         name: /github.com\/import-lab\/api/i,
       }),
     );
-    expect(onchange).toHaveBeenLastCalledWith("github.com/import-lab/api");
+    expect(onchange).toHaveBeenLastCalledWith("github|github.com/import-lab/api");
 
     await view.rerender({
-      selected: "github.com/import-lab/api",
+      selected: "github|github.com/import-lab/api",
       onchange,
     });
     await fireEvent.mouseDown(
@@ -163,7 +163,7 @@ describe("RepoTypeahead", () => {
         name: /github.com\/import-lab\/web/i,
       }),
     );
-    expect(onchange).toHaveBeenLastCalledWith("github.com/import-lab/api,github.com/import-lab/web");
+    expect(onchange).toHaveBeenLastCalledWith("github|github.com/import-lab/api,github|github.com/import-lab/web");
   });
 
   it("selecting an owner row selects all repos beneath it", async () => {
@@ -197,7 +197,7 @@ describe("RepoTypeahead", () => {
       .querySelector("input[type='checkbox']") as HTMLInputElement;
     await fireEvent.mouseDown(ownerCheckbox);
 
-    expect(onchange).toHaveBeenLastCalledWith("github.com/import-lab/api,github.com/import-lab/web");
+    expect(onchange).toHaveBeenLastCalledWith("github|github.com/import-lab/api,github|github.com/import-lab/web");
   });
 
   it("filters to matching leaves while keeping their owner visible", async () => {
@@ -234,12 +234,12 @@ describe("RepoTypeahead", () => {
     await waitFor(() => {
       expect(
         screen.getByRole("option", {
-          name: "github.com/import-lab/web",
+          name: "github/github.com/import-lab/web",
         }),
       ).toBeTruthy();
       expect(
         screen.queryByRole("option", {
-          name: "github.com/import-lab/api",
+          name: "github/github.com/import-lab/api",
         }),
       ).toBeNull();
     });
@@ -273,7 +273,7 @@ describe("RepoTypeahead", () => {
     await fireEvent.click(screen.getByRole("button", { name: /all repos/i }));
 
     // leaves visible initially
-    expect(screen.getByRole("option", { name: "github.com/import-lab/api" })).toBeTruthy();
+    expect(screen.getByRole("option", { name: "github/github.com/import-lab/api" })).toBeTruthy();
     // click the owner row body (its caret button has aria-label "Toggle import-lab";
     // click the row <li> itself, not the caret) -> collapses, hides leaves, selects nothing
     await fireEvent.mouseDown(screen.getByRole("option", { name: "github.com/import-lab" }));
@@ -281,7 +281,7 @@ describe("RepoTypeahead", () => {
     await waitFor(() => {
       expect(
         screen.queryByRole("option", {
-          name: "github.com/import-lab/api",
+          name: "github/github.com/import-lab/api",
         }),
       ).toBeNull();
     });
@@ -313,11 +313,11 @@ describe("RepoTypeahead", () => {
     render(RepoTypeahead, { props: { selected: undefined, onchange } });
     await fireEvent.click(screen.getByRole("button", { name: /all repos/i }));
     const leaf = screen.getByRole("option", {
-      name: "github.com/import-lab/api",
+      name: "github/github.com/import-lab/api",
     });
     const checkbox = leaf.querySelector("input[type='checkbox']") as HTMLInputElement;
     await fireEvent.mouseDown(checkbox);
-    expect(onchange).toHaveBeenLastCalledWith("github.com/import-lab/api");
+    expect(onchange).toHaveBeenLastCalledWith("github|github.com/import-lab/api");
   });
 
   it("drops removed repos after settings remove matching entries", async () => {
@@ -414,7 +414,7 @@ describe("RepoTypeahead", () => {
     const input = screen.getByPlaceholderText("Filter repos...");
 
     // leaves visible by default
-    expect(screen.getByRole("option", { name: "github.com/import-lab/api" })).toBeTruthy();
+    expect(screen.getByRole("option", { name: "github/github.com/import-lab/api" })).toBeTruthy();
 
     // move highlight onto the owner row (index 1) and collapse it
     await fireEvent.keyDown(input, { key: "ArrowDown" });
@@ -423,7 +423,7 @@ describe("RepoTypeahead", () => {
     await waitFor(() => {
       expect(
         screen.queryByRole("option", {
-          name: "github.com/import-lab/api",
+          name: "github/github.com/import-lab/api",
         }),
       ).toBeNull();
     });
@@ -432,7 +432,7 @@ describe("RepoTypeahead", () => {
     await waitFor(() => {
       expect(
         screen.getByRole("option", {
-          name: "github.com/import-lab/api",
+          name: "github/github.com/import-lab/api",
         }),
       ).toBeTruthy();
     });
@@ -474,7 +474,7 @@ describe("RepoTypeahead", () => {
     await fireEvent.keyDown(input, { key: "ArrowDown" });
     await fireEvent.keyDown(input, { key: "ArrowDown" });
     const leaf = screen.getByRole("option", {
-      name: "github.com/import-lab/api",
+      name: "github/github.com/import-lab/api",
     });
     await waitFor(() => expect(leaf.classList.contains("highlighted")).toBe(true));
 
@@ -485,9 +485,9 @@ describe("RepoTypeahead", () => {
         name: "github.com/import-lab",
       });
       expect(owner.classList.contains("highlighted")).toBe(true);
-      expect(screen.getByRole("option", { name: "github.com/import-lab/api" }).classList.contains("highlighted")).toBe(
-        false,
-      );
+      expect(
+        screen.getByRole("option", { name: "github/github.com/import-lab/api" }).classList.contains("highlighted"),
+      ).toBe(false);
     });
   });
 
@@ -523,7 +523,7 @@ describe("RepoTypeahead", () => {
     await fireEvent.keyDown(input, { key: "ArrowDown" });
     await fireEvent.keyDown(input, { key: " " });
 
-    expect(onchange).toHaveBeenLastCalledWith("github.com/import-lab/api,github.com/import-lab/web");
+    expect(onchange).toHaveBeenLastCalledWith("github|github.com/import-lab/api,github|github.com/import-lab/web");
   });
 
   it("uses provider-qualified values when configured repos collide by host and path", async () => {
@@ -605,7 +605,7 @@ describe("RepoTypeahead", () => {
     expect(onchange).not.toHaveBeenCalled();
   });
 
-  it("normalizes stale provider slash values before desktop validation removes missing repos", async () => {
+  it("drops stale provider slash values before desktop validation removes missing repos", async () => {
     const onchange = vi.fn();
     settingsStore.setConfiguredRepos([
       {
@@ -621,13 +621,13 @@ describe("RepoTypeahead", () => {
 
     render(RepoTypeahead, {
       props: {
-        selected: "github/github.com/acme/widgets,github.com/acme/missing",
+        selected: "github/github.com/acme/widgets,github|github.com/acme/missing",
         onchange,
       },
     });
 
     await waitFor(() => {
-      expect(onchange).toHaveBeenCalledWith("github.com/acme/widgets,github.com/acme/missing");
+      expect(onchange).toHaveBeenCalledWith("github|github.com/acme/missing");
     });
   });
 });

--- a/frontend/src/lib/components/repoTree.test.ts
+++ b/frontend/src/lib/components/repoTree.test.ts
@@ -13,7 +13,7 @@ import {
 function opt(platformHost: string, repoPath: string, provider = "github"): RepoTreeOption {
   const segments = repoPath.split("/");
   return {
-    value: `${platformHost}/${repoPath}`,
+    value: `${provider}|${platformHost}/${repoPath}`,
     owner: segments.slice(0, -1).join("/"),
     name: segments[segments.length - 1] ?? repoPath,
     provider,
@@ -40,8 +40,8 @@ describe("buildRepoTree", () => {
     const acme = host.children[0]!;
     expect(acme.id).toBe("github.com/acme");
     expect(acme.children.map((r) => r.label)).toEqual(["api", "web"]);
-    expect(acme.children[0]!.value).toBe("github.com/acme/api");
-    expect(acme.children[0]!.id).toBe("github.com/acme/api");
+    expect(acme.children[0]!.value).toBe("github|github.com/acme/api");
+    expect(acme.children[0]!.id).toBe("github|github.com/acme/api");
   });
 
   it("keeps GitLab nested groups as one slashed owner node", () => {
@@ -53,7 +53,7 @@ describe("buildRepoTree", () => {
     expect(owner.label).toBe("platform/frontend");
     expect(owner.id).toBe("gitlab.com/platform/frontend");
     expect(owner.children[0]!.label).toBe("web-ui");
-    expect(owner.children[0]!.value).toBe("gitlab.com/platform/frontend/web-ui");
+    expect(owner.children[0]!.value).toBe("gitlab|gitlab.com/platform/frontend/web-ui");
   });
 
   it("separates hosts and sorts them by label", () => {
@@ -237,18 +237,18 @@ describe("visibleRows", () => {
     const acme = rows.find((r) => r.node.label === "acme")!;
     // selection logic sees all three repos, not just the matching "api"
     expect(collectLeafValues(acme.node).sort()).toEqual([
-      "github.com/acme/api",
-      "github.com/acme/infra",
-      "github.com/acme/web",
+      "github|github.com/acme/api",
+      "github|github.com/acme/infra",
+      "github|github.com/acme/web",
     ]);
     // with only "api" selected, the owner is partial (not "checked"), proving
     // tri-state reflects hidden siblings too
-    expect(nodeSelectionState(acme.node, new Set(["github.com/acme/api"]))).toBe("partial");
+    expect(nodeSelectionState(acme.node, new Set(["github|github.com/acme/api"]))).toBe("partial");
     // toggling the owner cascades to the entire subtree, including hidden repos
-    expect(toggleSubtree(acme.node, ["github.com/acme/api"]).sort()).toEqual([
-      "github.com/acme/api",
-      "github.com/acme/infra",
-      "github.com/acme/web",
+    expect(toggleSubtree(acme.node, ["github|github.com/acme/api"]).sort()).toEqual([
+      "github|github.com/acme/api",
+      "github|github.com/acme/infra",
+      "github|github.com/acme/web",
     ]);
   });
 
@@ -264,7 +264,7 @@ describe("visibleRows", () => {
     // node identity is still the leaf (value/id unchanged for selection)
     const teamA = rows.find((r) => r.displayLabel === "team-a/api")!;
     expect(teamA.node.kind).toBe("repo");
-    expect((teamA.node as { value: string }).value).toBe("github.com/team-a/api");
+    expect((teamA.node as { value: string }).value).toBe("github|github.com/team-a/api");
   });
 
   it("still flattens a genuinely single-repo owner under a filter", () => {
@@ -334,38 +334,41 @@ describe("selection helpers", () => {
 
   it("collects all descendant leaf values", () => {
     expect(collectLeafValues(acme).sort()).toEqual([
-      "github.com/acme/api",
-      "github.com/acme/infra",
-      "github.com/acme/web",
+      "github|github.com/acme/api",
+      "github|github.com/acme/infra",
+      "github|github.com/acme/web",
     ]);
-    expect(collectLeafValues(acme.children[0]!)).toEqual(["github.com/acme/api"]);
+    expect(collectLeafValues(acme.children[0]!)).toEqual(["github|github.com/acme/api"]);
   });
 
   it("computes tri-state from the active set", () => {
     expect(nodeSelectionState(acme, new Set())).toBe("unchecked");
-    expect(nodeSelectionState(acme, new Set(["github.com/acme/api"]))).toBe("partial");
+    expect(nodeSelectionState(acme, new Set(["github|github.com/acme/api"]))).toBe("partial");
     expect(
-      nodeSelectionState(acme, new Set(["github.com/acme/api", "github.com/acme/web", "github.com/acme/infra"])),
+      nodeSelectionState(
+        acme,
+        new Set(["github|github.com/acme/api", "github|github.com/acme/web", "github|github.com/acme/infra"]),
+      ),
     ).toBe("checked");
   });
 
   it("adds all subtree leaves when not fully checked", () => {
-    expect(toggleSubtree(acme, ["github.com/acme/api"]).sort()).toEqual([
-      "github.com/acme/api",
-      "github.com/acme/infra",
-      "github.com/acme/web",
+    expect(toggleSubtree(acme, ["github|github.com/acme/api"]).sort()).toEqual([
+      "github|github.com/acme/api",
+      "github|github.com/acme/infra",
+      "github|github.com/acme/web",
     ]);
   });
 
   it("removes all subtree leaves when fully checked", () => {
-    const all = ["github.com/acme/api", "github.com/acme/web", "github.com/acme/infra"];
+    const all = ["github|github.com/acme/api", "github|github.com/acme/web", "github|github.com/acme/infra"];
     expect(toggleSubtree(acme, all)).toEqual([]);
   });
 
   it("toggles a single leaf without touching siblings", () => {
-    expect(toggleSubtree(acme.children[0]!, ["github.com/acme/web"]).sort()).toEqual([
-      "github.com/acme/api",
-      "github.com/acme/web",
+    expect(toggleSubtree(acme.children[0]!, ["github|github.com/acme/web"]).sort()).toEqual([
+      "github|github.com/acme/api",
+      "github|github.com/acme/web",
     ]);
   });
 });

--- a/frontend/src/lib/components/repoTree.ts
+++ b/frontend/src/lib/components/repoTree.ts
@@ -1,5 +1,5 @@
 export interface RepoTreeOption {
-  value: string; // `${platformHost}/${repoPath}` or `${provider}|${platformHost}/${repoPath}`
+  value: string; // `${provider}|${platformHost}/${repoPath}`
   owner: string;
   name: string;
   provider: string; // canonical, lowercase
@@ -41,8 +41,8 @@ function stripHostPrefix(value: string, platformHost: string): string {
   return concreteValue.replace(/^[^/]+\//, "");
 }
 
-function providerQualifiedLeafLabel(option: RepoTreeOption, name: string): string | undefined {
-  return option.value.includes("|") ? `${option.provider}/${name}` : undefined;
+function providerQualifiedLeafLabel(option: RepoTreeOption, name: string, needsProvider: boolean): string | undefined {
+  return needsProvider ? `${option.provider}/${name}` : undefined;
 }
 
 function slashDisplayValue(value: string): string {
@@ -65,6 +65,16 @@ function leafMatches(leaf: RepoLeaf, ownerLabel: string, query: string): boolean
 
 export function buildRepoTree(options: readonly RepoTreeOption[]): HostNode[] {
   const hosts = new Map<string, HostNode>();
+  const providersByHost = new Map<string, Set<string>>();
+
+  for (const option of options) {
+    let providers = providersByHost.get(option.platformHost);
+    if (!providers) {
+      providers = new Set<string>();
+      providersByHost.set(option.platformHost, providers);
+    }
+    providers.add(option.provider);
+  }
 
   for (const option of options) {
     const repoPath = stripHostPrefix(option.value, option.platformHost);
@@ -99,7 +109,11 @@ export function buildRepoTree(options: readonly RepoTreeOption[]): HostNode[] {
       host.children.push(owner);
     }
 
-    const displayLabel = providerQualifiedLeafLabel(option, name);
+    const displayLabel = providerQualifiedLeafLabel(
+      option,
+      name,
+      (providersByHost.get(option.platformHost)?.size ?? 0) > 1,
+    );
     owner.children.push({
       kind: "repo",
       id: option.value,

--- a/frontend/src/lib/components/repositories/RepoSummaryPage.test.ts
+++ b/frontend/src/lib/components/repositories/RepoSummaryPage.test.ts
@@ -386,11 +386,11 @@ describe("RepoSummaryPage", () => {
     expect(screen.queryByRole("button", { name: "View issues" })).toBeNull();
 
     await fireEvent.click(screen.getByRole("button", { name: /3\s+Open PRs/ }));
-    expect(mockSetGlobalRepo).toHaveBeenCalledWith("github.com/acme/widgets");
+    expect(mockSetGlobalRepo).toHaveBeenCalledWith("github|github.com/acme/widgets");
     expect(mockNavigate).toHaveBeenCalledWith("/pulls");
 
     await fireEvent.click(screen.getByRole("button", { name: /2\s+Open issues/ }));
-    expect(mockSetGlobalRepo).toHaveBeenCalledWith("github.com/acme/widgets");
+    expect(mockSetGlobalRepo).toHaveBeenCalledWith("github|github.com/acme/widgets");
     expect(mockNavigate).toHaveBeenCalledWith("/issues");
   });
 
@@ -656,7 +656,7 @@ describe("RepoSummaryPage", () => {
           },
         }),
       );
-      expect(mockSetGlobalRepo).toHaveBeenCalledWith("github.com/acme/widgets");
+      expect(mockSetGlobalRepo).toHaveBeenCalledWith("github|github.com/acme/widgets");
       expect(mockNavigate).toHaveBeenCalledWith("/issues/github/acme/widgets/27");
     });
   });
@@ -829,7 +829,7 @@ describe("RepoSummaryPage", () => {
           }),
         }),
       );
-      expect(mockSetGlobalRepo).toHaveBeenCalledWith("ghe.example.com/acme/widgets");
+      expect(mockSetGlobalRepo).toHaveBeenCalledWith("github|ghe.example.com/acme/widgets");
       expect(mockNavigate).toHaveBeenCalledWith("/host/ghe.example.com/issues/github/acme/widgets/42");
     });
   });

--- a/frontend/src/lib/components/repositories/repoSummary.ts
+++ b/frontend/src/lib/components/repositories/repoSummary.ts
@@ -73,8 +73,10 @@ export function repoKey(summary: {
   return `${summary.owner}/${summary.name}`;
 }
 
-export function repoStateKey(summary: { platform_host: string; owner: string; name: string }): string {
-  return `${summary.platform_host}/${summary.owner}/${summary.name}`;
+export function repoStateKey(summary: {
+  repo: { provider: string; platform_host: string; repo_path: string };
+}): string {
+  return `${summary.repo.provider}|${summary.repo.platform_host}/${summary.repo.repo_path}`;
 }
 
 export function shouldShowPlatformHost(summary: {

--- a/frontend/src/lib/stores/filter.svelte.ts
+++ b/frontend/src/lib/stores/filter.svelte.ts
@@ -40,10 +40,25 @@ export function setGlobalRepo(repo: string | undefined): void {
   }
 }
 
-export function applyConfigRepo(repo: { owner: string; name: string } | undefined, hideSelector: boolean): void {
+export function applyConfigRepo(
+  repo:
+    | {
+        provider?: string;
+        host?: string;
+        platform_host?: string;
+        repo_path?: string;
+        owner: string;
+        name: string;
+      }
+    | undefined,
+  hideSelector: boolean,
+): void {
   if (hideSelector) {
-    if (repo) {
-      filterRepo = `${repo.owner}/${repo.name}`;
+    const provider = repo?.provider?.trim();
+    const host = (repo?.platform_host ?? repo?.host)?.trim();
+    const repoPath = (repo?.repo_path ?? (repo ? `${repo.owner}/${repo.name}` : "")).trim();
+    if (provider && host && repoPath) {
+      filterRepo = `${provider}|${host}/${repoPath}`;
     } else {
       filterRepo = undefined;
     }

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -57,7 +57,14 @@ interface MiddlemanConfig {
     hideRepoSelector?: boolean;
     hideStar?: boolean;
     sidebarCollapsed?: boolean;
-    repo?: { owner: string; name: string };
+    repo?: {
+      provider?: string;
+      host?: string;
+      platform_host?: string;
+      repo_path?: string;
+      owner: string;
+      name: string;
+    };
     host?: string;
     activeWorktreeKey?: string;
   };

--- a/frontend/tests/e2e-full/00-workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e-full/00-workspace-sidebar.spec.ts
@@ -338,6 +338,7 @@ test.describe("workspace sidebar full-stack", () => {
       // data rather than a route mock.
       const createResponse = await api.post("/api/v1/workspaces", {
         data: {
+          provider: "github",
           platform_host: "github.com",
           owner: "acme",
           name: "widgets",

--- a/frontend/tests/e2e-full/link-navigation-repo-sync.spec.ts
+++ b/frontend/tests/e2e-full/link-navigation-repo-sync.spec.ts
@@ -14,13 +14,13 @@ async function waitForIssueDetail(page: Page): Promise<void> {
 
 test("navigating to an issue in a different repo updates the dropdown", async ({ page }) => {
   await page.addInitScript(() => {
-    localStorage.setItem("middleman-filter-repo", "github.com/acme/tools");
+    localStorage.setItem("middleman-filter-repo", "github|github.com/acme/tools");
   });
 
   await page.goto("/issues/github/acme/widgets/10");
   await waitForIssueDetail(page);
 
-  await expect(page.locator(".typeahead-value")).toHaveText("github.com/acme/widgets", {
+  await expect(page.locator(".typeahead-value")).toHaveText("github/github.com/acme/widgets", {
     timeout: 5_000,
   });
 });

--- a/frontend/tests/e2e-full/mobile-routes.spec.ts
+++ b/frontend/tests/e2e-full/mobile-routes.spec.ts
@@ -322,7 +322,7 @@ test.describe("phone routes", () => {
     });
     await page.getByRole("combobox", { name: /Repository/ }).click();
     await page.getByRole("option", { name: "github/github.com/acme/widgets" }).click();
-    await expect(page.getByRole("combobox", { name: "Repository: github/github.com/acme/widgets" })).toBeVisible();
+    await expect(page.getByRole("combobox", { name: "Repository: acme/widgets" })).toHaveText("acme/widgets");
     await activityForRepo;
   });
 

--- a/frontend/tests/e2e-full/mobile-routes.spec.ts
+++ b/frontend/tests/e2e-full/mobile-routes.spec.ts
@@ -318,11 +318,11 @@ test.describe("phone routes", () => {
 
     const activityForRepo = page.waitForResponse((response) => {
       const url = response.url();
-      return url.includes("/api/v1/activity") && url.includes("repo=github.com%2Facme%2Fwidgets");
+      return url.includes("/api/v1/activity") && url.includes("repo=github%7Cgithub.com%2Facme%2Fwidgets");
     });
     await page.getByRole("combobox", { name: /Repository/ }).click();
-    await page.getByRole("option", { name: "github.com/acme/widgets" }).click();
-    await expect(page.getByRole("combobox", { name: "Repository: acme/widgets" })).toBeVisible();
+    await page.getByRole("option", { name: "github/github.com/acme/widgets" }).click();
+    await expect(page.getByRole("combobox", { name: "Repository: github/github.com/acme/widgets" })).toBeVisible();
     await activityForRepo;
   });
 

--- a/frontend/tests/e2e-full/repo-filter-multiselect.spec.ts
+++ b/frontend/tests/e2e-full/repo-filter-multiselect.spec.ts
@@ -73,7 +73,7 @@ test("keyboard navigation survives a real checkbox click", async ({ page }) => {
   // Real click on a leaf repo's checkbox.
   await page
     .getByRole("option", {
-      name: "github.com/acme/widgets",
+      name: "github/github.com/acme/widgets",
       exact: true,
     })
     .locator("input[type='checkbox']")
@@ -81,7 +81,7 @@ test("keyboard navigation survives a real checkbox click", async ({ page }) => {
   await expect(
     page
       .getByRole("option", {
-        name: "github.com/acme/widgets",
+        name: "github/github.com/acme/widgets",
         exact: true,
       })
       .locator("input[type='checkbox']"),

--- a/frontend/tests/e2e-full/routed-items.spec.ts
+++ b/frontend/tests/e2e-full/routed-items.spec.ts
@@ -47,7 +47,7 @@ test.describe("routed item builders through the UI", () => {
   });
 
   test("focus PR list routes selected rows to focus detail", async ({ page }) => {
-    await page.goto("/focus/mrs?repo=acme%2Fwidgets");
+    await page.goto("/focus/mrs?repo=github%7Cgithub.com%2Facme%2Fwidgets");
     await page.locator(".focus-list .pull-item").first().waitFor({ state: "visible", timeout: 10_000 });
 
     const detailLoaded = detailResponse(page, "/api/v1/pulls/github/acme/widgets/1");
@@ -60,7 +60,7 @@ test.describe("routed item builders through the UI", () => {
   });
 
   test("focus issue list routes selected rows with platform_host", async ({ page }) => {
-    await page.goto("/focus/issues?repo=acme%2Fwidgets");
+    await page.goto("/focus/issues?repo=github%7Cgithub.com%2Facme%2Fwidgets");
     await page.locator(".focus-list .issue-item").first().waitFor({ state: "visible", timeout: 10_000 });
 
     const detailLoaded = issueDetailResponse(page, "/api/v1/issues/github/acme/widgets/10");

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -696,7 +696,7 @@ type CreateWorkspaceInputBody struct {
 	Name         string  `json:"name"`
 	Owner        string  `json:"owner"`
 	PlatformHost string  `json:"platform_host"`
-	Provider     *string `json:"provider,omitempty"`
+	Provider     string  `json:"provider"`
 }
 
 // CreateWorktreeFromMergeRequestInputBody defines model for CreateWorktreeFromMergeRequestInputBody.
@@ -2692,7 +2692,8 @@ type StarredRequest struct {
 	Name         string  `json:"name"`
 	Number       int64   `json:"number"`
 	Owner        string  `json:"owner"`
-	PlatformHost *string `json:"platform_host,omitempty"`
+	PlatformHost string  `json:"platform_host"`
+	Provider     string  `json:"provider"`
 }
 
 // SyncStatus defines model for SyncStatus.
@@ -2955,7 +2956,7 @@ type WorktreeSummary struct {
 
 // ListActivityParams defines parameters for ListActivity.
 type ListActivityParams struct {
-	// Repo Repository filter. Accepts owner/name, platform_host/repo_path, comma-separated values, or provider|platform_host/repo_path for provider-qualified matches.
+	// Repo Repository filter. Accepts provider|platform_host/repo_path, with comma-separated values for multiple repositories.
 	Repo   *string   `form:"repo,omitempty" json:"repo,omitempty"`
 	Types  *[]string `form:"types,omitempty" json:"types,omitempty"`
 	Search *string   `form:"search,omitempty" json:"search,omitempty"`
@@ -3193,7 +3194,7 @@ type ResolveRepoItemOnHostParamsItemType string
 
 // ListIssuesParams defines parameters for ListIssues.
 type ListIssuesParams struct {
-	// Repo Repository filter. Accepts owner/name, platform_host/repo_path, comma-separated values, or provider|platform_host/repo_path for provider-qualified matches.
+	// Repo Repository filter. Accepts provider|platform_host/repo_path, with comma-separated values for multiple repositories.
 	Repo     *string `form:"repo,omitempty" json:"repo,omitempty"`
 	State    *string `form:"state,omitempty" json:"state,omitempty"`
 	Starred  *bool   `form:"starred,omitempty" json:"starred,omitempty"`
@@ -3265,7 +3266,7 @@ type ListUserRepositoriesParams struct {
 
 // ListPullsParams defines parameters for ListPulls.
 type ListPullsParams struct {
-	// Repo Repository filter. Accepts owner/name, platform_host/repo_path, comma-separated values, or provider|platform_host/repo_path for provider-qualified matches.
+	// Repo Repository filter. Accepts provider|platform_host/repo_path, with comma-separated values for multiple repositories.
 	Repo    *string `form:"repo,omitempty" json:"repo,omitempty"`
 	State   *string `form:"state,omitempty" json:"state,omitempty"`
 	Kanban  *string `form:"kanban,omitempty" json:"kanban,omitempty"`
@@ -3344,7 +3345,7 @@ type ListStacksParams struct {
 
 // TriggerSyncParams defines parameters for TriggerSync.
 type TriggerSyncParams struct {
-	// PriorityRepo Optional repository filters to sync first. Accepts repeated values or comma-separated values. Each value may be provider-qualified as provider|platform_host/owner/name, host-qualified as platform_host/owner/name, or bare as owner/name; bare values match the first tracked repo with that repo path.
+	// PriorityRepo Optional repository filters to sync first. Accepts repeated provider|platform_host/repo_path values or comma-separated values.
 	PriorityRepo *[]string `form:"priority_repo,omitempty" json:"priority_repo,omitempty"`
 }
 

--- a/internal/cli/ctl/ctl_test.go
+++ b/internal/cli/ctl/ctl_test.go
@@ -413,7 +413,7 @@ func TestMiddlemanctlCommandsUseRealAPIAndSQLite(t *testing.T) {
 	starOut := runMiddleman(
 		t, ts.URL,
 		"api", "PUT", "/starred",
-		"item_type: pr, owner: acme, name: widgets, number: 1",
+		"item_type: pr, provider: github, platform_host: github.com, owner: acme, name: widgets, number: 1",
 	)
 	assert.Empty(starOut)
 	starredOut := runMiddleman(t, ts.URL, "--output", "jsonl", "pulls", "--starred")

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -1969,57 +1969,6 @@ func (d *DB) UpdateRepoProviderMetadata(
 	return nil
 }
 
-// GetRepoByOwnerName returns the repo for the given owner/name, or nil if not found.
-// Config validation rejects duplicate owner/name across hosts, so this should
-// always be unambiguous. The ORDER BY provides deterministic results as a
-// safety net if stale data from a previous config exists in the database.
-func (d *DB) GetRepoByOwnerName(ctx context.Context, owner, name string) (*Repo, error) {
-	_, owner, name = canonicalRepoIdentifier("", owner, name)
-	var r Repo
-	err := d.ro.QueryRowContext(ctx,
-		`SELECT id, platform, platform_host, platform_repo_id,
-		        owner, name, repo_path,
-		        owner_key, name_key, repo_path_key,
-		        web_url, clone_url, default_branch,
-		        last_sync_started_at, last_sync_completed_at,
-		        last_sync_error, allow_squash_merge, allow_merge_commit,
-		        allow_rebase_merge, viewer_can_merge,
-		        backfill_pr_page, backfill_pr_complete,
-		        backfill_pr_completed_at,
-		        backfill_issue_page, backfill_issue_complete,
-		        backfill_issue_completed_at,
-		        label_catalog_synced_at, label_catalog_checked_at,
-		        label_catalog_sync_error,
-		        created_at
-		 FROM middleman_repos WHERE owner_key = ? AND name_key = ?
-		 ORDER BY platform_host ASC LIMIT 1`, owner, name,
-	).Scan(
-		&r.ID, &r.Platform, &r.PlatformHost, &r.PlatformRepoID,
-		&r.Owner, &r.Name, &r.RepoPath,
-		&r.OwnerKey, &r.NameKey, &r.RepoPathKey,
-		&r.WebURL, &r.CloneURL, &r.DefaultBranch,
-		&r.LastSyncStartedAt, &r.LastSyncCompletedAt,
-		&r.LastSyncError,
-		&r.AllowSquashMerge, &r.AllowMergeCommit, &r.AllowRebaseMerge,
-		&r.ViewerCanMerge,
-		&r.BackfillPRPage, &r.BackfillPRComplete,
-		&r.BackfillPRCompletedAt,
-		&r.BackfillIssuePage, &r.BackfillIssueComplete,
-		&r.BackfillIssueCompletedAt,
-		&r.LabelCatalogSyncedAt, &r.LabelCatalogCheckedAt,
-		&r.LabelCatalogSyncError,
-		&r.CreatedAt,
-	)
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, fmt.Errorf("get repo by owner/name: %w", err)
-	}
-	normalizeRepoTimestamps(&r)
-	return &r, nil
-}
-
 // GetRepoByIdentity returns the repo for the provider-qualified identity,
 // or nil if not found.
 func (d *DB) GetRepoByIdentity(ctx context.Context, identity RepoIdentity) (*Repo, error) {
@@ -2335,9 +2284,14 @@ func (d *DB) UpsertMergeRequest(ctx context.Context, mr *MergeRequest) (int64, e
 	return id, nil
 }
 
-// GetMergeRequest returns a merge request by repo owner/name and MR number, or nil if not found.
-func (d *DB) GetMergeRequest(ctx context.Context, owner, name string, number int) (*MergeRequest, error) {
-	_, owner, name = canonicalRepoLookupIdentifier("", owner, name)
+// GetMergeRequest returns a merge request by repository identity and MR number, or nil if not found.
+func (d *DB) GetMergeRequest(
+	ctx context.Context,
+	platform, platformHost, owner, name string,
+	number int,
+) (*MergeRequest, error) {
+	platform = canonicalRepoPlatform(platform)
+	platformHost, owner, name = canonicalRepoLookupIdentifier(platformHost, owner, name)
 	var mr MergeRequest
 	err := d.ro.QueryRowContext(ctx, `
 		SELECT p.id, p.repo_id, p.platform_id, p.platform_external_id, p.number, p.url, p.title,
@@ -2361,8 +2315,10 @@ func (d *DB) GetMergeRequest(ctx context.Context, owner, name string, number int
 		LEFT JOIN middleman_kanban_state k ON k.merge_request_id = p.id
 		LEFT JOIN middleman_starred_items s
 		    ON s.item_type = 'pr' AND s.repo_id = p.repo_id AND s.number = p.number
-		WHERE r.owner_key = ? AND r.name_key = ? AND p.number = ?`,
-		owner, name, number,
+		WHERE r.platform = ? AND r.platform_host = ?
+		  AND r.owner_key = ? AND r.name_key = ?
+		  AND p.number = ?`,
+		platform, platformHost, owner, name, number,
 	).Scan(
 		&mr.ID, &mr.RepoID, &mr.PlatformID, &mr.PlatformExternalID, &mr.Number, &mr.URL, &mr.Title,
 		&mr.Author, &mr.AuthorDisplayName, &mr.State, &mr.IsDraft, &mr.IsLocked,
@@ -2813,27 +2769,6 @@ func (d *DB) GetKanbanState(ctx context.Context, mrID int64) (*KanbanState, erro
 	return &k, nil
 }
 
-// --- Helpers ---
-
-// GetMRIDByRepoAndNumber returns the internal MR ID for a given repo+number.
-func (d *DB) GetMRIDByRepoAndNumber(ctx context.Context, owner, name string, number int) (int64, error) {
-	_, owner, name = canonicalRepoLookupIdentifier("", owner, name)
-	var id int64
-	err := d.ro.QueryRowContext(ctx, `
-		SELECT p.id FROM middleman_merge_requests p
-		JOIN middleman_repos r ON r.id = p.repo_id
-		WHERE r.owner_key = ? AND r.name_key = ? AND p.number = ?`,
-		owner, name, number,
-	).Scan(&id)
-	if errors.Is(err, sql.ErrNoRows) {
-		return 0, fmt.Errorf("MR %s/%s#%d not found", owner, name, number)
-	}
-	if err != nil {
-		return 0, fmt.Errorf("get mr id by repo and number: %w", err)
-	}
-	return id, nil
-}
-
 // GetPreviouslyOpenMRNumbers returns MR numbers that are open in the DB but
 // not in the stillOpen set — i.e. MRs that were closed/merged since the last sync.
 func (d *DB) GetPreviouslyOpenMRNumbers(
@@ -3124,13 +3059,20 @@ func (s *DiffSHAs) Stale() bool {
 }
 
 // GetDiffSHAs returns the diff-related SHAs for a merge request.
-func (d *DB) GetDiffSHAs(ctx context.Context, owner, name string, number int) (*DiffSHAs, error) {
-	_, owner, name = canonicalRepoLookupIdentifier("", owner, name)
+func (d *DB) GetDiffSHAs(
+	ctx context.Context,
+	platform, platformHost, owner, name string,
+	number int,
+) (*DiffSHAs, error) {
+	platform = canonicalRepoPlatform(platform)
+	platformHost, owner, name = canonicalRepoLookupIdentifier(platformHost, owner, name)
 	return d.getDiffSHAs(
 		ctx,
 		`JOIN middleman_repos r ON r.id = p.repo_id
-		 WHERE r.owner_key = ? AND r.name_key = ? AND p.number = ?`,
-		owner, name, number,
+		 WHERE r.platform = ? AND r.platform_host = ?
+		   AND r.owner_key = ? AND r.name_key = ?
+		   AND p.number = ?`,
+		platform, platformHost, owner, name, number,
 	)
 }
 
@@ -3281,11 +3223,14 @@ func (d *DB) UpsertIssue(ctx context.Context, issue *Issue) (int64, error) {
 	return id, nil
 }
 
-// GetIssue returns an issue by repo owner/name and issue number, or nil if not found.
+// GetIssue returns an issue by repository identity and issue number, or nil if not found.
 func (d *DB) GetIssue(
-	ctx context.Context, owner, name string, number int,
+	ctx context.Context,
+	platform, platformHost, owner, name string,
+	number int,
 ) (*Issue, error) {
-	_, owner, name = canonicalRepoLookupIdentifier("", owner, name)
+	platform = canonicalRepoPlatform(platform)
+	platformHost, owner, name = canonicalRepoLookupIdentifier(platformHost, owner, name)
 	var issue Issue
 	err := d.ro.QueryRowContext(ctx, `
 		SELECT i.id, i.repo_id, i.platform_id, i.platform_external_id, i.number, i.url, i.title,
@@ -3297,8 +3242,10 @@ func (d *DB) GetIssue(
 		JOIN middleman_repos r ON r.id = i.repo_id
 		LEFT JOIN middleman_starred_items s
 		    ON s.item_type = 'issue' AND s.repo_id = i.repo_id AND s.number = i.number
-		WHERE r.owner_key = ? AND r.name_key = ? AND i.number = ?`,
-		owner, name, number,
+		WHERE r.platform = ? AND r.platform_host = ?
+		  AND r.owner_key = ? AND r.name_key = ?
+		  AND i.number = ?`,
+		platform, platformHost, owner, name, number,
 	).Scan(
 		&issue.ID, &issue.RepoID, &issue.PlatformID, &issue.PlatformExternalID, &issue.Number,
 		&issue.URL, &issue.Title, &issue.Author, &issue.State,
@@ -3489,27 +3436,6 @@ func (d *DB) ListIssues(
 	return issues, nil
 }
 
-// GetIssueIDByRepoAndNumber returns the internal issue ID for a given repo+number.
-func (d *DB) GetIssueIDByRepoAndNumber(
-	ctx context.Context, owner, name string, number int,
-) (int64, error) {
-	_, owner, name = canonicalRepoLookupIdentifier("", owner, name)
-	var id int64
-	err := d.ro.QueryRowContext(ctx, `
-		SELECT i.id FROM middleman_issues i
-		JOIN middleman_repos r ON r.id = i.repo_id
-		WHERE r.owner_key = ? AND r.name_key = ? AND i.number = ?`,
-		owner, name, number,
-	).Scan(&id)
-	if errors.Is(err, sql.ErrNoRows) {
-		return 0, fmt.Errorf("issue %s/%s#%d not found", owner, name, number)
-	}
-	if err != nil {
-		return 0, fmt.Errorf("get issue id by repo and number: %w", err)
-	}
-	return id, nil
-}
-
 // ResolveItemNumber checks whether the given number in a repo is a MR
 // or issue. Returns the item type ("pr" or "issue") and whether it was
 // found. MRs take precedence if both somehow exist.
@@ -3692,9 +3618,10 @@ func (d *DB) UpsertHTTPEtag(
 // detail fetched and records whether CI had pending checks.
 func (d *DB) UpdateMRDetailFetched(
 	ctx context.Context,
-	platformHost, repoOwner, repoName string,
+	platform, platformHost, repoOwner, repoName string,
 	number int, ciHadPending bool,
 ) error {
+	platform = canonicalRepoPlatform(platform)
 	platformHost, repoOwner, repoName = canonicalRepoLookupIdentifier(
 		platformHost, repoOwner, repoName,
 	)
@@ -3704,9 +3631,9 @@ func (d *DB) UpdateMRDetailFetched(
 		    ci_had_pending = ?
 		WHERE repo_id = (
 		    SELECT id FROM middleman_repos
-		    WHERE platform_host = ? AND owner_key = ? AND name_key = ?
+		    WHERE platform = ? AND platform_host = ? AND owner_key = ? AND name_key = ?
 		) AND number = ?`,
-		ciHadPending, platformHost, repoOwner, repoName, number,
+		ciHadPending, platform, platformHost, repoOwner, repoName, number,
 	)
 	if err != nil {
 		return fmt.Errorf("update mr detail fetched: %w", err)
@@ -3787,8 +3714,9 @@ func (d *DB) UpdateMRWorkflowApproval(
 // detail fetched.
 func (d *DB) UpdateIssueDetailFetched(
 	ctx context.Context,
-	platformHost, repoOwner, repoName string, number int,
+	platform, platformHost, repoOwner, repoName string, number int,
 ) error {
+	platform = canonicalRepoPlatform(platform)
 	platformHost, repoOwner, repoName = canonicalRepoLookupIdentifier(
 		platformHost, repoOwner, repoName,
 	)
@@ -3797,9 +3725,9 @@ func (d *DB) UpdateIssueDetailFetched(
 		SET detail_fetched_at = datetime('now')
 		WHERE repo_id = (
 		    SELECT id FROM middleman_repos
-		    WHERE platform_host = ? AND owner_key = ? AND name_key = ?
+		    WHERE platform = ? AND platform_host = ? AND owner_key = ? AND name_key = ?
 		) AND number = ?`,
-		platformHost, repoOwner, repoName, number,
+		platform, platformHost, repoOwner, repoName, number,
 	)
 	if err != nil {
 		return fmt.Errorf("update issue detail fetched: %w", err)
@@ -4395,82 +4323,6 @@ func (d *DB) GetAllWorktreeLinks(
 	}
 	defer rows.Close()
 	return scanWorktreeLinks(rows)
-}
-
-// GetRepoByHostOwnerName returns the repo for the given
-// host/owner/name triple, or nil if not found.
-func (d *DB) GetRepoByHostOwnerName(
-	ctx context.Context,
-	host, owner, name string,
-) (*Repo, error) {
-	host, owner, name = canonicalRepoIdentifier(host, owner, name)
-	var r Repo
-	err := d.ro.QueryRowContext(ctx,
-		`SELECT id, platform, platform_host, platform_repo_id,
-		        owner, name, repo_path,
-		        owner_key, name_key, repo_path_key,
-		        web_url, clone_url, default_branch,
-		        last_sync_started_at, last_sync_completed_at,
-		        last_sync_error, allow_squash_merge, allow_merge_commit,
-		        allow_rebase_merge, viewer_can_merge,
-		        backfill_pr_page, backfill_pr_complete,
-		        backfill_pr_completed_at,
-		        backfill_issue_page, backfill_issue_complete,
-		        backfill_issue_completed_at,
-		        label_catalog_synced_at, label_catalog_checked_at,
-		        label_catalog_sync_error,
-		        created_at
-		 FROM middleman_repos
-		 WHERE platform_host = ? AND owner_key = ? AND name_key = ?
-		 ORDER BY platform ASC LIMIT 1`,
-		host, owner, name,
-	).Scan(
-		&r.ID, &r.Platform, &r.PlatformHost, &r.PlatformRepoID,
-		&r.Owner, &r.Name, &r.RepoPath,
-		&r.OwnerKey, &r.NameKey, &r.RepoPathKey,
-		&r.WebURL, &r.CloneURL, &r.DefaultBranch,
-		&r.LastSyncStartedAt, &r.LastSyncCompletedAt,
-		&r.LastSyncError,
-		&r.AllowSquashMerge, &r.AllowMergeCommit, &r.AllowRebaseMerge,
-		&r.ViewerCanMerge,
-		&r.BackfillPRPage, &r.BackfillPRComplete,
-		&r.BackfillPRCompletedAt,
-		&r.BackfillIssuePage, &r.BackfillIssueComplete,
-		&r.BackfillIssueCompletedAt,
-		&r.LabelCatalogSyncedAt, &r.LabelCatalogCheckedAt,
-		&r.LabelCatalogSyncError,
-		&r.CreatedAt,
-	)
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, fmt.Errorf(
-			"get repo by host/owner/name: %w", err,
-		)
-	}
-	normalizeRepoTimestamps(&r)
-	return &r, nil
-}
-
-// CountReposByHostOwnerName returns how many provider identities share a
-// host/owner/name lookup key.
-func (d *DB) CountReposByHostOwnerName(
-	ctx context.Context,
-	host, owner, name string,
-) (int, error) {
-	host, owner, name = canonicalRepoIdentifier(host, owner, name)
-	var count int
-	err := d.ro.QueryRowContext(ctx, `
-		SELECT COUNT(*)
-		FROM middleman_repos
-		WHERE platform_host = ? AND owner_key = ? AND name_key = ?`,
-		host, owner, name,
-	).Scan(&count)
-	if err != nil {
-		return 0, fmt.Errorf("count repos by host/owner/name: %w", err)
-	}
-	return count, nil
 }
 
 // --- Workspaces ---

--- a/internal/db/queries_notifications.go
+++ b/internal/db/queries_notifications.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 )
@@ -919,22 +920,33 @@ func (d *DB) MarkClosedLinkedNotificationsDone(ctx context.Context, now time.Tim
 	return nil
 }
 
-func ParseNotificationRepo(repo string) (host string, owner string, name string, ok bool) {
-	parts := strings.Split(repo, "/")
-	switch len(parts) {
-	case 2:
-		if parts[0] == "" || parts[1] == "" {
-			return "", "", "", false
-		}
-		host, owner, name = canonicalRepoIdentifier("", parts[0], parts[1])
-		return host, owner, name, true
-	case 3:
-		if parts[0] == "" || parts[1] == "" || parts[2] == "" {
-			return "", "", "", false
-		}
-		host, owner, name = canonicalRepoIdentifier(parts[0], parts[1], parts[2])
-		return host, owner, name, true
-	default:
-		return "", "", "", false
+func ParseNotificationRepo(repo string) (
+	platform string,
+	host string,
+	owner string,
+	name string,
+	ok bool,
+) {
+	rawPlatform, rawPath, found := strings.Cut(repo, "|")
+	if !found {
+		return "", "", "", "", false
 	}
+	platform, err := canonicalizeRequiredNotificationPlatform(rawPlatform)
+	if err != nil {
+		return "", "", "", "", false
+	}
+	parts := strings.Split(rawPath, "/")
+	if len(parts) < 3 {
+		return "", "", "", "", false
+	}
+	if slices.Contains(parts, "") {
+		return "", "", "", "", false
+	}
+	host, owner, name = canonicalRepoIdentifier(
+		parts[0], strings.Join(parts[1:len(parts)-1], "/"), parts[len(parts)-1],
+	)
+	if host == "" || owner == "" || name == "" {
+		return "", "", "", "", false
+	}
+	return platform, host, owner, name, true
 }

--- a/internal/db/queries_stacks.go
+++ b/internal/db/queries_stacks.go
@@ -229,12 +229,19 @@ func (d *DB) DeleteStaleStacks(ctx context.Context, repoID int64, activeStackIDs
 }
 
 // GetStackForPR returns the stack and members for a specific PR, or nil if not in a stack.
-func (d *DB) GetStackForPR(ctx context.Context, owner, name string, number int) (*Stack, []StackMemberWithPR, error) {
-	_, owner, name = canonicalRepoLookupIdentifier("", owner, name)
+func (d *DB) GetStackForPR(
+	ctx context.Context,
+	platform, platformHost, owner, name string,
+	number int,
+) (*Stack, []StackMemberWithPR, error) {
+	platform = canonicalRepoPlatform(platform)
+	platformHost, owner, name = canonicalRepoLookupIdentifier(platformHost, owner, name)
 	return d.getStackForPRWhere(
 		ctx,
-		`WHERE r.owner_key = ? AND r.name_key = ? AND p.number = ?`,
-		owner, name, number,
+		`WHERE r.platform = ? AND r.platform_host = ?
+		    AND r.owner_key = ? AND r.name_key = ?
+		    AND p.number = ?`,
+		platform, platformHost, owner, name, number,
 	)
 }
 

--- a/internal/db/queries_stacks_test.go
+++ b/internal/db/queries_stacks_test.go
@@ -234,14 +234,14 @@ func TestGetStackForPR(t *testing.T) {
 	require.NoError(err)
 
 	// Found
-	stack, members, err := d.GetStackForPR(ctx, "org", "repo", 10)
+	stack, members, err := d.GetStackForPR(ctx, "github", "github.com", "org", "repo", 10)
 	require.NoError(err)
 	require.NotNil(stack)
 	assert.Equal("feature", stack.Name)
 	assert.Len(members, 2)
 
 	// Not found
-	stack2, _, err := d.GetStackForPR(ctx, "org", "repo", 999)
+	stack2, _, err := d.GetStackForPR(ctx, "github", "github.com", "org", "repo", 999)
 	require.NoError(err)
 	assert.Nil(stack2)
 }

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -208,7 +208,7 @@ func TestPurgeOtherHosts(t *testing.T) {
 	assert.Equal("acme", repos[0].Owner)
 
 	// github.com MR should remain.
-	ghMR, err := d.GetMergeRequest(ctx, "acme", "widget", 1)
+	ghMR, err := d.GetMergeRequest(ctx, "github", "github.com", "acme", "widget", 1)
 	require.NoError(err)
 	require.NotNil(ghMR)
 
@@ -902,7 +902,7 @@ func TestProviderCanonicalReadPathsUseLookupKeys(t *testing.T) {
 	mrID := insertTestMRWithOptions(t, d, testMR(repoID, 7, withMRTitle("GitLab PR")))
 	issueID := insertTestIssueWithOptions(t, d, testIssue(repoID, 8, withIssueTitle("GitLab issue")))
 
-	gotMR, err := d.GetMergeRequest(ctx, "group/subgroup", "projectname", 7)
+	gotMR, err := d.GetMergeRequest(ctx, "gitlab", "gitlab.example.com", "group/subgroup", "projectname", 7)
 	require.NoError(err)
 	require.NotNil(gotMR)
 	assert.Equal(mrID, gotMR.ID)
@@ -916,17 +916,13 @@ func TestProviderCanonicalReadPathsUseLookupKeys(t *testing.T) {
 	require.Len(listedMRs, 1)
 	assert.Equal(mrID, listedMRs[0].ID)
 
-	gotMRID, err := d.GetMRIDByRepoAndNumber(ctx, "GROUP/SubGroup", "PROJECTName", 7)
-	require.NoError(err)
-	assert.Equal(mrID, gotMRID)
-
 	require.NoError(d.UpdateDiffSHAs(ctx, repoID, 7, "head", "base", "merge"))
-	shas, err := d.GetDiffSHAs(ctx, "group/subgroup", "projectname", 7)
+	shas, err := d.GetDiffSHAs(ctx, "gitlab", "gitlab.example.com", "group/subgroup", "projectname", 7)
 	require.NoError(err)
 	require.NotNil(shas)
 	assert.Equal("head", shas.DiffHeadSHA)
 
-	gotIssue, err := d.GetIssue(ctx, "group/subgroup", "projectname", 8)
+	gotIssue, err := d.GetIssue(ctx, "gitlab", "gitlab.example.com", "group/subgroup", "projectname", 8)
 	require.NoError(err)
 	require.NotNil(gotIssue)
 	assert.Equal(issueID, gotIssue.ID)
@@ -940,18 +936,14 @@ func TestProviderCanonicalReadPathsUseLookupKeys(t *testing.T) {
 	require.Len(listedIssues, 1)
 	assert.Equal(issueID, listedIssues[0].ID)
 
-	gotIssueID, err := d.GetIssueIDByRepoAndNumber(ctx, "GROUP/SubGroup", "PROJECTName", 8)
-	require.NoError(err)
-	assert.Equal(issueID, gotIssueID)
-
-	require.NoError(d.UpdateMRDetailFetched(ctx, "gitlab.example.com", "group/subgroup", "projectname", 7, true))
+	require.NoError(d.UpdateMRDetailFetched(ctx, "gitlab", "gitlab.example.com", "group/subgroup", "projectname", 7, true))
 	refreshedMR, err := d.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
 	require.NoError(err)
 	require.NotNil(refreshedMR)
 	require.NotNil(refreshedMR.DetailFetchedAt)
 	assert.True(refreshedMR.CIHadPending)
 
-	require.NoError(d.UpdateIssueDetailFetched(ctx, "gitlab.example.com", "group/subgroup", "projectname", 8))
+	require.NoError(d.UpdateIssueDetailFetched(ctx, "gitlab", "gitlab.example.com", "group/subgroup", "projectname", 8))
 	refreshedIssue, err := d.GetIssueByRepoIDAndNumber(ctx, repoID, 8)
 	require.NoError(err)
 	require.NotNil(refreshedIssue)
@@ -991,7 +983,7 @@ func TestProviderCanonicalReadPathsUseLookupKeys(t *testing.T) {
 	require.Len(members[stackID], 1)
 	assert.Equal(mrID, members[stackID][0].MergeRequestID)
 
-	stack, stackMembers, err := d.GetStackForPR(ctx, "group/subgroup", "projectname", 7)
+	stack, stackMembers, err := d.GetStackForPR(ctx, "gitlab", "gitlab.example.com", "group/subgroup", "projectname", 7)
 	require.NoError(err)
 	require.NotNil(stack)
 	assert.Equal(stackID, stack.ID)
@@ -2069,56 +2061,6 @@ func TestUpsertRepoCasefoldsOwnerAndName(t *testing.T) {
 	assert.Equal("foo", repos[0].Name)
 }
 
-func TestGetRepoByOwnerName(t *testing.T) {
-	assert := Assert.New(t)
-	d := openTestDB(t)
-	ctx := t.Context()
-
-	id := insertTestRepo(t, d, "owner", "repo")
-
-	r, err := d.GetRepoByOwnerName(ctx, "owner", "repo")
-	require.NoError(t, err)
-	require.NotNil(t, r)
-	assert.Equal(id, r.ID)
-
-	missing, err := d.GetRepoByOwnerName(ctx, "no", "such")
-	require.NoError(t, err)
-	assert.Nil(missing)
-}
-
-func TestGetRepoByOwnerNameUsesLookupKeysForNonGitHubRows(t *testing.T) {
-	assert := Assert.New(t)
-	require := require.New(t)
-	d := openTestDB(t)
-	ctx := t.Context()
-
-	firstID, err := d.UpsertRepo(ctx, RepoIdentity{
-		Platform:     "gitlab",
-		PlatformHost: "gitlab-a.example.com",
-		Owner:        "Group/SubGroup",
-		Name:         "ProjectName",
-		RepoPath:     "Group/SubGroup/ProjectName",
-	})
-	require.NoError(err)
-	secondID, err := d.UpsertRepo(ctx, RepoIdentity{
-		Platform:     "gitlab",
-		PlatformHost: "gitlab-b.example.com",
-		Owner:        "GROUP/SubGroup",
-		Name:         "PROJECTName",
-		RepoPath:     "GROUP/SubGroup/PROJECTName",
-	})
-	require.NoError(err)
-	assert.NotEqual(firstID, secondID)
-
-	repo, err := d.GetRepoByOwnerName(ctx, "group/subgroup", "projectname")
-	require.NoError(err)
-	require.NotNil(repo)
-	assert.Equal(firstID, repo.ID)
-	assert.Equal("gitlab-a.example.com", repo.PlatformHost)
-	assert.Equal("Group/SubGroup", repo.Owner)
-	assert.Equal("ProjectName", repo.Name)
-}
-
 func TestUpdateRepoSync(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
@@ -2132,7 +2074,7 @@ func TestUpdateRepoSync(t *testing.T) {
 	later := now.Add(time.Minute)
 	require.NoError(d.UpdateRepoSyncCompleted(ctx, id, later, ""))
 
-	r, err := d.GetRepoByOwnerName(ctx, "o", "r")
+	r, err := d.GetRepoByIdentity(ctx, GitHubRepoIdentity("github.com", "o", "r"))
 	require.NoError(err)
 	require.NotNil(r)
 	require.NotNil(r.LastSyncStartedAt)
@@ -2143,7 +2085,7 @@ func TestUpdateRepoSync(t *testing.T) {
 
 	// Record a sync error.
 	require.NoError(d.UpdateRepoSyncCompleted(ctx, id, later, "rate limited"))
-	r2, _ := d.GetRepoByOwnerName(ctx, "o", "r")
+	r2, _ := d.GetRepoByIdentity(ctx, GitHubRepoIdentity("github.com", "o", "r"))
 	require.NotNil(r2)
 	assert.Equal("rate limited", r2.LastSyncError)
 }
@@ -2184,7 +2126,7 @@ func TestUpsertAndGetPullRequest(t *testing.T) {
 	require.NoError(err)
 	assert.NotZero(id)
 
-	got, err := d.GetMergeRequest(ctx, "owner", "repo", 7)
+	got, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 7)
 	require.NoError(err)
 	require.NotNil(got)
 	assert.Equal(id, got.ID)
@@ -2204,7 +2146,7 @@ func TestUpsertAndGetPullRequest(t *testing.T) {
 	require.NoError(err)
 	assert.Equal(id, id2)
 
-	got2, _ := d.GetMergeRequest(ctx, "owner", "repo", 7)
+	got2, _ := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 7)
 	require.NotNil(got2)
 	assert.Equal("fix: something updated", got2.Title)
 	assert.Equal(20, got2.Additions)
@@ -2213,7 +2155,7 @@ func TestUpsertAndGetPullRequest(t *testing.T) {
 	assert.True(got2.CreatedAt.Equal(now))
 
 	// Missing PR returns nil.
-	missing, err := d.GetMergeRequest(ctx, "owner", "repo", 999)
+	missing, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 999)
 	require.NoError(err)
 	assert.Nil(missing)
 }
@@ -2423,7 +2365,7 @@ func TestPullRequestRepoScopedQueriesCanonicalizeOwnerName(t *testing.T) {
 	prID := insertTestMR(t, d, repoID, 7, "mixed case path", baseTime())
 	require.NoError(d.UpdateDiffSHAs(ctx, repoID, 7, "head", "base", "merge"))
 
-	got, err := d.GetMergeRequest(ctx, "Owner", "Repo", 7)
+	got, err := d.GetMergeRequest(ctx, "github", "github.com", "Owner", "Repo", 7)
 	require.NoError(err)
 	require.NotNil(got)
 	assert.Equal(prID, got.ID)
@@ -2436,11 +2378,7 @@ func TestPullRequestRepoScopedQueriesCanonicalizeOwnerName(t *testing.T) {
 	require.Len(filtered, 1)
 	assert.Equal(prID, filtered[0].ID)
 
-	gotID, err := d.GetMRIDByRepoAndNumber(ctx, "Owner", "Repo", 7)
-	require.NoError(err)
-	assert.Equal(prID, gotID)
-
-	shas, err := d.GetDiffSHAs(ctx, "Owner", "Repo", 7)
+	shas, err := d.GetDiffSHAs(ctx, "github", "github.com", "Owner", "Repo", 7)
 	require.NoError(err)
 	require.NotNil(shas)
 	assert.Equal("head", shas.DiffHeadSHA)
@@ -2627,7 +2565,7 @@ func TestListMergeRequests_AttachesLabels(t *testing.T) {
 	repoID, err := d.UpsertRepo(ctx, GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 
-	_, err = d.UpsertMergeRequest(ctx, &MergeRequest{
+	mrID, err := d.UpsertMergeRequest(ctx, &MergeRequest{
 		RepoID:         repoID,
 		PlatformID:     101,
 		Number:         7,
@@ -2641,8 +2579,6 @@ func TestListMergeRequests_AttachesLabels(t *testing.T) {
 	})
 	require.NoError(err)
 
-	mrID, err := d.GetMRIDByRepoAndNumber(ctx, "acme", "widget", 7)
-	require.NoError(err)
 	require.NoError(d.ReplaceMergeRequestLabels(ctx, repoID, mrID, []Label{{
 		PlatformID:  5001,
 		Name:        "needs-review",
@@ -2670,7 +2606,7 @@ func TestGetMergeRequest_AttachesLabels(t *testing.T) {
 	now := baseTime()
 
 	repoID := insertTestRepo(t, d, "acme", "widget")
-	_, err := d.UpsertMergeRequest(ctx, &MergeRequest{
+	mrID, err := d.UpsertMergeRequest(ctx, &MergeRequest{
 		RepoID:         repoID,
 		PlatformID:     102,
 		Number:         8,
@@ -2684,8 +2620,6 @@ func TestGetMergeRequest_AttachesLabels(t *testing.T) {
 	})
 	require.NoError(err)
 
-	mrID, err := d.GetMRIDByRepoAndNumber(ctx, "acme", "widget", 8)
-	require.NoError(err)
 	require.NoError(d.ReplaceMergeRequestLabels(ctx, repoID, mrID, []Label{{
 		PlatformID:  5002,
 		Name:        "backend",
@@ -2695,7 +2629,7 @@ func TestGetMergeRequest_AttachesLabels(t *testing.T) {
 		UpdatedAt:   now,
 	}}))
 
-	mr, err := d.GetMergeRequest(ctx, "acme", "widget", 8)
+	mr, err := d.GetMergeRequest(ctx, "github", "github.com", "acme", "widget", 8)
 	require.NoError(err)
 	require.NotNil(mr)
 	require.Len(mr.Labels, 1)
@@ -2725,7 +2659,7 @@ func TestReplaceMergeRequestLabels_RejectsWrongRepoID(t *testing.T) {
 	}})
 	require.Error(err)
 
-	mr, err := d.GetMergeRequest(ctx, "acme", "widget", 9)
+	mr, err := d.GetMergeRequest(ctx, "github", "github.com", "acme", "widget", 9)
 	require.NoError(err)
 	require.NotNil(mr)
 	require.Empty(mr.Labels)
@@ -2885,14 +2819,14 @@ func TestUpsertLabels_MergesStaleNameOnlyRowIntoPlatformRow(t *testing.T) {
 	require.Equal("333333", color)
 	require.True(isDefault)
 
-	mr, err := d.GetMergeRequest(ctx, "acme", "widget", 17)
+	mr, err := d.GetMergeRequest(ctx, "github", "github.com", "acme", "widget", 17)
 	require.NoError(err)
 	require.NotNil(mr)
 	require.Len(mr.Labels, 1)
 	require.Equal(labelID, mr.Labels[0].ID)
 	require.Equal("new-name", mr.Labels[0].Name)
 
-	issue, err := d.GetIssue(ctx, "acme", "widget", 23)
+	issue, err := d.GetIssue(ctx, "github", "github.com", "acme", "widget", 23)
 	require.NoError(err)
 	require.NotNil(issue)
 	require.Len(issue.Labels, 1)
@@ -3143,21 +3077,6 @@ func TestListMREventsHandlesNonUTCTimes(t *testing.T) {
 	}
 }
 
-func TestGetPRIDByRepoAndNumber(t *testing.T) {
-	d := openTestDB(t)
-	ctx := t.Context()
-
-	repoID := insertTestRepo(t, d, "o", "r")
-	insertTestMR(t, d, repoID, 5, "pr five", baseTime())
-
-	id, err := d.GetMRIDByRepoAndNumber(ctx, "o", "r", 5)
-	require.NoError(t, err)
-	Assert.NotZero(t, id)
-
-	_, err = d.GetMRIDByRepoAndNumber(ctx, "o", "r", 999)
-	require.Error(t, err)
-}
-
 func TestGetDiffSHAsByRepoIDScopesDuplicateProviderRepos(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
@@ -3303,7 +3222,7 @@ func TestUpsertPullRequestMergeableState(t *testing.T) {
 	_, err := d.UpsertMergeRequest(ctx, pr)
 	require.NoError(err)
 
-	got, err := d.GetMergeRequest(ctx, "acme", "widget", 42)
+	got, err := d.GetMergeRequest(ctx, "github", "github.com", "acme", "widget", 42)
 	require.NoError(err)
 	require.NotNil(got)
 	assert.Equal("dirty", got.MergeableState)
@@ -3312,7 +3231,7 @@ func TestUpsertPullRequestMergeableState(t *testing.T) {
 	_, err = d.UpsertMergeRequest(ctx, pr)
 	require.NoError(err)
 
-	got, err = d.GetMergeRequest(ctx, "acme", "widget", 42)
+	got, err = d.GetMergeRequest(ctx, "github", "github.com", "acme", "widget", 42)
 	require.NoError(err)
 	assert.Equal("clean", got.MergeableState)
 }
@@ -3430,7 +3349,7 @@ func TestUpdatePRState(t *testing.T) {
 	mergedAt := baseTime().Add(time.Hour)
 	require.NoError(d.UpdateMRState(ctx, repoID, 1, "merged", &mergedAt, nil))
 
-	pr, err := d.GetMergeRequest(ctx, "o", "r", 1)
+	pr, err := d.GetMergeRequest(ctx, "github", "github.com", "o", "r", 1)
 	require.NoError(err)
 	require.NotNil(pr)
 	assert.Equal(MergeRequestStateMerged, pr.State)
@@ -3455,7 +3374,7 @@ func TestUpdateMRDraftStateAdvancesTimestampToRejectStaleSync(t *testing.T) {
 	_, err := d.UpsertMergeRequest(ctx, staleSync)
 	require.NoError(err)
 
-	pr, err := d.GetMergeRequest(ctx, "o", "r", 1)
+	pr, err := d.GetMergeRequest(ctx, "github", "github.com", "o", "r", 1)
 	require.NoError(err)
 	require.NotNil(pr)
 	assert.True(pr.IsDraft)
@@ -3545,7 +3464,7 @@ func TestGetIssue_AttachesLabels(t *testing.T) {
 		UpdatedAt:   now,
 	}}))
 
-	issue, err := d.GetIssue(ctx, "acme", "widget", 4)
+	issue, err := d.GetIssue(ctx, "github", "github.com", "acme", "widget", 4)
 	require.NoError(err)
 	require.NotNil(issue)
 	require.Len(issue.Labels, 1)
@@ -3565,7 +3484,7 @@ func TestIssueRepoScopedQueriesCanonicalizeOwnerName(t *testing.T) {
 	repoID := insertTestRepo(t, d, "owner", "repo")
 	issueID := insertTestIssue(t, d, repoID, 7, "mixed case issue", baseTime())
 
-	got, err := d.GetIssue(ctx, "Owner", "Repo", 7)
+	got, err := d.GetIssue(ctx, "github", "github.com", "Owner", "Repo", 7)
 	require.NoError(err)
 	require.NotNil(got)
 	assert.Equal(issueID, got.ID)
@@ -3578,9 +3497,6 @@ func TestIssueRepoScopedQueriesCanonicalizeOwnerName(t *testing.T) {
 	require.Len(filtered, 1)
 	assert.Equal(issueID, filtered[0].ID)
 
-	gotID, err := d.GetIssueIDByRepoAndNumber(ctx, "Owner", "Repo", 7)
-	require.NoError(err)
-	assert.Equal(issueID, gotID)
 }
 
 func TestListIssuesFilterByHostedRepoPath(t *testing.T) {
@@ -3774,7 +3690,7 @@ func TestReplaceIssueLabels_RejectsWrongRepoID(t *testing.T) {
 	}})
 	require.Error(err)
 
-	issue, err := d.GetIssue(ctx, "acme", "widget", 6)
+	issue, err := d.GetIssue(ctx, "github", "github.com", "acme", "widget", 6)
 	require.NoError(err)
 	require.NotNil(issue)
 	require.Empty(issue.Labels)
@@ -4132,107 +4048,6 @@ func TestWorktreeAndPurgeRespectCanceledContext(t *testing.T) {
 
 	_, err = d.GetAllWorktreeLinks(canceled)
 	require.ErrorIs(err, context.Canceled)
-}
-
-func TestGetRepoByHostOwnerName(t *testing.T) {
-	assert := Assert.New(t)
-	require := require.New(t)
-	d := openTestDB(t)
-	ctx := t.Context()
-
-	// Insert two repos with same owner/name but different hosts.
-	ghID := insertTestRepoWithHost(t, d, "acme", "widget", "github.com")
-	gheID := insertTestRepoWithHost(
-		t, d, "acme", "widget", "ghes.corp.com",
-	)
-
-	// Each found by its host.
-	gh, err := d.GetRepoByHostOwnerName(
-		ctx, "github.com", "acme", "widget",
-	)
-	require.NoError(err)
-	require.NotNil(gh)
-	assert.Equal(ghID, gh.ID)
-	assert.Equal("github.com", gh.PlatformHost)
-
-	ghe, err := d.GetRepoByHostOwnerName(
-		ctx, "ghes.corp.com", "acme", "widget",
-	)
-	require.NoError(err)
-	require.NotNil(ghe)
-	assert.Equal(gheID, ghe.ID)
-	assert.Equal("ghes.corp.com", ghe.PlatformHost)
-
-	// Missing host returns nil.
-	missing, err := d.GetRepoByHostOwnerName(
-		ctx, "gitlab.com", "acme", "widget",
-	)
-	require.NoError(err)
-	assert.Nil(missing)
-}
-
-func TestGetRepoByHostOwnerNameUsesLookupKeysForNonGitHubRows(t *testing.T) {
-	assert := Assert.New(t)
-	require := require.New(t)
-	d := openTestDB(t)
-	ctx := t.Context()
-
-	id, err := d.UpsertRepo(ctx, RepoIdentity{
-		Platform:     "gitlab",
-		PlatformHost: "gitlab.example.com",
-		Owner:        "Group/SubGroup",
-		Name:         "ProjectName",
-		RepoPath:     "Group/SubGroup/ProjectName",
-	})
-	require.NoError(err)
-
-	repo, err := d.GetRepoByHostOwnerName(
-		ctx, "gitlab.example.com", "group/subgroup", "projectname",
-	)
-	require.NoError(err)
-	require.NotNil(repo)
-	assert.Equal(id, repo.ID)
-	assert.Equal("gitlab", repo.Platform)
-	assert.Equal("gitlab.example.com", repo.PlatformHost)
-	assert.Equal("Group/SubGroup", repo.Owner)
-	assert.Equal("ProjectName", repo.Name)
-	assert.Equal("Group/SubGroup/ProjectName", repo.RepoPath)
-	assert.Equal("group/subgroup", repo.OwnerKey)
-	assert.Equal("projectname", repo.NameKey)
-}
-
-func TestCountReposByHostOwnerNameCountsProviders(t *testing.T) {
-	assert := Assert.New(t)
-	require := require.New(t)
-	d := openTestDB(t)
-	ctx := t.Context()
-
-	_, err := d.UpsertRepo(ctx, RepoIdentity{
-		Platform:     "github",
-		PlatformHost: "forge.example.com",
-		Owner:        "acme",
-		Name:         "widget",
-	})
-	require.NoError(err)
-	_, err = d.UpsertRepo(ctx, RepoIdentity{
-		Platform:     "gitlab",
-		PlatformHost: "forge.example.com",
-		Owner:        "acme",
-		Name:         "widget",
-	})
-	require.NoError(err)
-
-	count, err := d.CountReposByHostOwnerName(
-		ctx, "forge.example.com", "acme", "widget",
-	)
-	require.NoError(err)
-	assert.Equal(2, count)
-
-	miss, err := d.CountReposByHostOwnerName(
-		ctx, "forge.example.com", "acme", "missing",
-	)
-	require.NoError(err)
-	assert.Equal(0, miss)
 }
 
 func TestRepoIdentifierCasefoldTriggers(t *testing.T) {

--- a/internal/github/merged_diff_test.go
+++ b/internal/github/merged_diff_test.go
@@ -68,7 +68,7 @@ func setupSyncer(t *testing.T, ctx context.Context, mgr *gitclone.Manager) (*Syn
 	mc := &mockClient{}
 	syncer := NewSyncer(map[string]Client{"github.com": mc}, d, mgr, []RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}}, time.Minute, nil, testBudget(500))
 	syncer.RunOnce(ctx) // creates repo row
-	repoRow, err := d.GetRepoByOwnerName(ctx, "owner", "repo")
+	repoRow, err := d.GetRepoByIdentity(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(t, err)
 	require.NotNil(t, repoRow)
 	return syncer, repoRow.ID
@@ -124,7 +124,7 @@ func TestComputeMergedPRDiffSHAs_MergeCommit(t *testing.T) {
 
 	require.NoError(syncer.computeMergedMRDiffSHAs(ctx, RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}, repoID, 1, mergeCommit, false))
 
-	shas, err := syncer.db.GetDiffSHAs(ctx, "owner", "repo", 1)
+	shas, err := syncer.db.GetDiffSHAs(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.NotNil(shas)
 	assert.Equal(prHead, shas.DiffHeadSHA, "diff_head_sha should be the PR head")
@@ -165,13 +165,13 @@ func TestComputeMergedPRDiffSHAs_ForceOverwritesIncorrectSHAs(t *testing.T) {
 
 	// Without force, the existing (incorrect) SHAs are preserved.
 	require.NoError(syncer.computeMergedMRDiffSHAs(ctx, RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}, repoID, 1, mergeCommit, false))
-	shas, err := syncer.db.GetDiffSHAs(ctx, "owner", "repo", 1)
+	shas, err := syncer.db.GetDiffSHAs(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	assert.Equal("bad-head", shas.DiffHeadSHA, "force=false should not overwrite existing SHAs")
 
 	// With force, the incorrect SHAs are replaced with correct values.
 	require.NoError(syncer.computeMergedMRDiffSHAs(ctx, RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}, repoID, 1, mergeCommit, true))
-	shas, err = syncer.db.GetDiffSHAs(ctx, "owner", "repo", 1)
+	shas, err = syncer.db.GetDiffSHAs(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.NotNil(shas)
 	assert.Equal(prHead, shas.DiffHeadSHA, "force=true should overwrite with correct PR head")
@@ -210,7 +210,7 @@ func TestComputeMergedPRDiffSHAs_SquashMerge(t *testing.T) {
 
 	require.NoError(syncer.computeMergedMRDiffSHAs(ctx, RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}, repoID, 2, squashCommit, false))
 
-	shas, err := syncer.db.GetDiffSHAs(ctx, "owner", "repo", 2)
+	shas, err := syncer.db.GetDiffSHAs(ctx, "github", "github.com", "owner", "repo", 2)
 	require.NoError(err)
 	require.NotNil(shas)
 	assert.Equal(prHead, shas.DiffHeadSHA)
@@ -262,7 +262,7 @@ func TestComputeMergedPRDiffSHAs_RebaseMerge(t *testing.T) {
 
 	require.NoError(syncer.computeMergedMRDiffSHAs(ctx, RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}, repoID, 3, rebaseLastCommit, false))
 
-	shas, err := syncer.db.GetDiffSHAs(ctx, "owner", "repo", 3)
+	shas, err := syncer.db.GetDiffSHAs(ctx, "github", "github.com", "owner", "repo", 3)
 	require.NoError(err)
 	require.NotNil(shas)
 	assert.Equal(prHead, shas.DiffHeadSHA)
@@ -342,13 +342,13 @@ func TestSyncOpenToMergedTransition(t *testing.T) {
 	syncer := NewSyncer(map[string]Client{"github.com": mc}, d, mgr, []RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}}, time.Minute, nil, testBudget(500))
 	syncer.RunOnce(ctx)
 
-	pr, err := d.GetMergeRequest(ctx, "owner", "repo", number)
+	pr, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", number)
 	require.NoError(err)
 	require.NotNil(pr)
 	assert.Equal(db.MergeRequestStateOpen, pr.State)
 
 	// Verify diff SHAs were computed during open-state sync.
-	shasBeforeMerge, err := d.GetDiffSHAs(ctx, "owner", "repo", number)
+	shasBeforeMerge, err := d.GetDiffSHAs(ctx, "github", "github.com", "owner", "repo", number)
 	require.NoError(err)
 	require.NotNil(shasBeforeMerge)
 	assert.Equal(prHead, shasBeforeMerge.DiffHeadSHA, "open-state diff_head_sha")
@@ -395,7 +395,7 @@ func TestSyncOpenToMergedTransition(t *testing.T) {
 	syncer.RunOnce(ctx)
 
 	// Verify PR transitioned to merged state.
-	shas, err := d.GetDiffSHAs(ctx, "owner", "repo", number)
+	shas, err := d.GetDiffSHAs(ctx, "github", "github.com", "owner", "repo", number)
 	require.NoError(err)
 	require.NotNil(shas)
 	assert.Equal("merged", shas.State, "PR state should be merged")
@@ -461,7 +461,7 @@ func TestSyncFirstSeenMergedPR(t *testing.T) {
 	syncer := NewSyncer(map[string]Client{"github.com": mc}, d, nil, []RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}}, time.Minute, nil, nil)
 	syncer.RunOnce(ctx)
 
-	shasEmpty, err := d.GetDiffSHAs(ctx, "owner", "repo", number)
+	shasEmpty, err := d.GetDiffSHAs(ctx, "github", "github.com", "owner", "repo", number)
 	require.NoError(err)
 	require.NotNil(shasEmpty)
 	assert.Empty(shasEmpty.DiffHeadSHA, "diff SHAs should be empty without clone manager")
@@ -500,7 +500,7 @@ func TestSyncFirstSeenMergedPR(t *testing.T) {
 	syncer2 := NewSyncer(map[string]Client{"github.com": mc}, d, mgr, []RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}}, time.Minute, nil, nil)
 	syncer2.RunOnce(ctx)
 
-	shas, err := d.GetDiffSHAs(ctx, "owner", "repo", number)
+	shas, err := d.GetDiffSHAs(ctx, "github", "github.com", "owner", "repo", number)
 	require.NoError(err)
 	require.NotNil(shas)
 	assert.Equal("merged", shas.State)
@@ -603,13 +603,13 @@ func TestSyncMRWrapsDiffFailureAsDiffSyncError(t *testing.T) {
 	assert.NotContains(userMsg, "rev-parse", "user message should not leak git command stderr")
 
 	// PR row was still upserted despite the diff failure.
-	mr, err := d.GetMergeRequest(ctx, "owner", "repo", number)
+	mr, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", number)
 	require.NoError(err)
 	require.NotNil(mr)
 	assert.Equal(db.MergeRequestStateMerged, mr.State, "PR state should be persisted")
 
 	// Diff SHAs are absent because rev-parse never found the merge commit.
-	shas, err := d.GetDiffSHAs(ctx, "owner", "repo", number)
+	shas, err := d.GetDiffSHAs(ctx, "github", "github.com", "owner", "repo", number)
 	require.NoError(err)
 	require.NotNil(shas)
 	assert.Empty(shas.DiffHeadSHA, "diff SHAs should remain unset when computation failed")
@@ -701,7 +701,7 @@ func TestSyncItemByNumberReturnsTypeOnDiffSyncError(t *testing.T) {
 	assert.Equal("pr", itemType, "type should be reported even when diff sync failed")
 
 	// PR row was still upserted, so the resolve endpoint can route the user.
-	mr, err := d.GetMergeRequest(ctx, "owner", "repo", number)
+	mr, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", number)
 	require.NoError(err)
 	require.NotNil(mr)
 	assert.Equal(db.MergeRequestStateMerged, mr.State)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -162,7 +162,12 @@ func syncActivityForcePushes(t *testing.T, d *db.DB) []db.ActivityItem {
 
 func requireSyncActivityRepoRow(t *testing.T, d *db.DB) db.Repo {
 	t.Helper()
-	repoRow, err := d.GetRepoByOwnerName(t.Context(), "group", "project")
+	repoRow, err := d.GetRepoByIdentity(t.Context(), db.RepoIdentity{
+		Platform:     string(platform.KindGitLab),
+		PlatformHost: "gitlab.example.com",
+		Owner:        "group",
+		Name:         "project",
+	})
 	require.NoError(t, err)
 	require.NotNil(t, repoRow)
 	return *repoRow
@@ -3188,7 +3193,7 @@ func TestSyncCreatesAndUpdatesPRs(t *testing.T) {
 	syncer.RunOnce(ctx)
 
 	// PR should be in the DB.
-	pr, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	pr, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.NotNil(pr)
 	assert.Equal(1, pr.Number)
@@ -3445,7 +3450,7 @@ func TestSyncStoresForcePushEvent(t *testing.T) {
 	syncer := NewSyncer(map[string]Client{"github.com": mc}, d, nil, []RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}}, time.Minute, nil, testBudget(500))
 	syncer.RunOnce(ctx)
 
-	pr, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	pr, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.NotNil(pr)
 
@@ -3627,7 +3632,7 @@ func TestSyncStoresPullRequestTimelineEvents(t *testing.T) {
 	syncer := NewSyncer(map[string]Client{"github.com": mc}, d, nil, []RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}}, time.Minute, nil, testBudget(500))
 	syncer.RunOnce(ctx)
 
-	pr, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	pr, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.NotNil(pr)
 
@@ -3673,7 +3678,7 @@ func TestSyncIgnoresPullRequestTimelineFetchFailures(t *testing.T) {
 	syncer := NewSyncer(map[string]Client{"github.com": mc}, d, nil, []RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}}, time.Minute, nil, testBudget(500))
 	syncer.RunOnce(ctx)
 
-	pr, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	pr, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.NotNil(pr)
 	events, err := d.ListMREvents(ctx, pr.ID)
@@ -3703,7 +3708,7 @@ func TestSyncStoresPRLabels(t *testing.T) {
 	syncer := NewSyncer(map[string]Client{"github.com": mc}, d, nil, []RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}}, time.Minute, nil, testBudget(500))
 	syncer.RunOnce(ctx)
 
-	stored, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	stored, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.NotNil(stored)
 	require.Len(stored.Labels, 1)
@@ -3735,7 +3740,7 @@ func TestSyncRefreshesRepoLabelCatalog(t *testing.T) {
 	syncer := NewSyncer(map[string]Client{"github.com": client}, d, nil, []RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}}, time.Minute, nil, testBudget(500))
 	syncer.RunOnce(ctx)
 
-	repo, err := d.GetRepoByOwnerName(ctx, "owner", "repo")
+	repo, err := d.GetRepoByIdentity(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
 	require.NotNil(repo)
 	labels, freshness, err := d.ListRepoLabelCatalog(ctx, repo.ID)
@@ -3770,7 +3775,7 @@ func TestSyncMRReplacesLabelsOnResync(t *testing.T) {
 
 	require.NoError(syncer.SyncMR(ctx, "owner", "repo", 1))
 
-	stored, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	stored, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.NotNil(stored)
 	require.Len(stored.Labels, 1)
@@ -3821,7 +3826,7 @@ func TestSyncIssueReplacesLabelsOnResync(t *testing.T) {
 
 	require.NoError(syncer.SyncIssue(ctx, "owner", "repo", issueNumber))
 
-	stored, err := d.GetIssue(ctx, "owner", "repo", issueNumber)
+	stored, err := d.GetIssue(ctx, "github", "github.com", "owner", "repo", issueNumber)
 	require.NoError(err)
 	require.NotNil(stored)
 	require.Len(stored.Labels, 1)
@@ -3897,7 +3902,7 @@ func TestSyncIssueNilUpdatedAt(t *testing.T) {
 		syncer.SyncIssue(ctx, "owner", "repo", issueNumber),
 	)
 
-	stored, err := d.GetIssue(ctx, "owner", "repo", issueNumber)
+	stored, err := d.GetIssue(ctx, "github", "github.com", "owner", "repo", issueNumber)
 	require.NoError(err)
 	require.NotNil(stored)
 	// last_activity_at should track the comment timestamp
@@ -3955,7 +3960,7 @@ func TestSyncIssueNilUpdatedAtNoComments(t *testing.T) {
 		syncer.SyncIssue(ctx, "owner", "repo", issueNumber),
 	)
 
-	stored, err := d.GetIssue(ctx, "owner", "repo", issueNumber)
+	stored, err := d.GetIssue(ctx, "github", "github.com", "owner", "repo", issueNumber)
 	require.NoError(err)
 	require.NotNil(stored)
 	assert.Equal(created.UTC(), stored.LastActivityAt.UTC(),
@@ -4057,7 +4062,7 @@ func TestSyncIgnoresForcePushFetchFailures(t *testing.T) {
 	syncer := NewSyncer(map[string]Client{"github.com": mc}, d, nil, []RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}}, time.Minute, nil, testBudget(500))
 	syncer.RunOnce(ctx)
 
-	pr, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	pr, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.NotNil(pr)
 
@@ -4101,7 +4106,7 @@ func TestSyncSingleFlight(t *testing.T) {
 	syncer.running.Store(false)
 
 	// Verify no DB side-effects: repo row should not exist because the RunOnce was skipped.
-	repo, err := d.GetRepoByOwnerName(ctx, "owner", "repo")
+	repo, err := d.GetRepoByIdentity(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(t, err)
 	Assert.Nil(t, repo)
 
@@ -4138,7 +4143,7 @@ func TestSyncPreservesMergeableState(t *testing.T) {
 	// First sync: full fetch occurs, MergeableState is stored.
 	syncer.RunOnce(ctx)
 
-	stored, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	stored, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.NotNil(stored)
 	assert.Equal("dirty", stored.MergeableState)
@@ -4161,7 +4166,7 @@ func TestSyncPreservesMergeableState(t *testing.T) {
 
 	syncer.RunOnce(ctx)
 
-	stored2, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	stored2, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.NotNil(stored2)
 	assert.Equal("dirty", stored2.MergeableState, "MergeableState should be preserved when full fetch is skipped")
@@ -4205,7 +4210,7 @@ func TestIndexUpsertMergeRequestUpdatesKnownMergeableState(t *testing.T) {
 	)
 	require.NoError(err)
 
-	stored, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	stored, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.NotNil(stored)
 	assert.Equal("dirty", stored.MergeableState)
@@ -4261,7 +4266,7 @@ func TestIndexUpsertMergeRequestPreservesCachedCIForSameHead(t *testing.T) {
 	)
 	require.NoError(err)
 
-	stored, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	stored, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.NotNil(stored)
 	assert.Equal("failure", stored.CIStatus)
@@ -4317,7 +4322,7 @@ func TestIndexUpsertMergeRequestPreservesReviewDecisionWhenOmitted(t *testing.T)
 	)
 	require.NoError(err)
 
-	stored, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	stored, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.NotNil(stored)
 	assert.Equal("APPROVED", stored.ReviewDecision)
@@ -4524,7 +4529,7 @@ func TestSyncTriggersFullFetchForUnknownMergeableState(t *testing.T) {
 	// full PR (returns "unknown" MergeableState).
 	syncer.RunOnce(ctx)
 
-	stored, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	stored, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.NotNil(stored)
 	assert.Equal("unknown", stored.MergeableState)
@@ -4560,7 +4565,7 @@ func TestSyncPreservesFieldsOnFullFetchFailure(t *testing.T) {
 	syncer := NewSyncer(map[string]Client{"github.com": mc}, d, nil, []RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}}, time.Minute, nil, testBudget(500))
 	syncer.RunOnce(ctx)
 
-	stored, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	stored, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.Equal("dirty", stored.MergeableState)
 	require.Equal(10, stored.Additions)
@@ -4577,7 +4582,7 @@ func TestSyncPreservesFieldsOnFullFetchFailure(t *testing.T) {
 
 	syncer.RunOnce(ctx)
 
-	stored2, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	stored2, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	assert.Equal("dirty", stored2.MergeableState, "MergeableState should survive a failed full fetch")
 	assert.Equal(10, stored2.Additions, "Additions should survive a failed full fetch")
@@ -4693,7 +4698,7 @@ func TestRunOnceSyncOpenMRSurvivesNilFullPR(t *testing.T) {
 
 	// The list-derived PR should still be persisted because the
 	// nil full-PR fetch is non-fatal.
-	pr, err := d.GetMergeRequest(ctx, "owner", "repo", 7)
+	pr, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 7)
 	require.NoError(err)
 	require.NotNil(pr)
 	assert.Equal(7, pr.Number)
@@ -5004,7 +5009,7 @@ func TestSyncItemByNumber_Issue(t *testing.T) {
 	require.NoError(err)
 	assert.Equal("issue", itemType)
 
-	issue, err := database.GetIssue(ctx, "acme", "widget", number)
+	issue, err := database.GetIssue(ctx, "github", "github.com", "acme", "widget", number)
 	require.NoError(err)
 	assert.NotNil(issue)
 	assert.Equal(title, issue.Title)
@@ -5065,7 +5070,7 @@ func TestSyncItemByNumber_PR(t *testing.T) {
 	require.NoError(err)
 	assert.Equal("pr", itemType)
 
-	pr, err := database.GetMergeRequest(ctx, "acme", "widget", number)
+	pr, err := database.GetMergeRequest(ctx, "github", "github.com", "acme", "widget", number)
 	require.NoError(err)
 	assert.NotNil(pr)
 	assert.Equal(title, pr.Title)
@@ -5511,7 +5516,7 @@ func TestSyncMRUsesConfiguredProviderRegistry(t *testing.T) {
 
 	require.NoError(syncer.SyncMR(ctx, "acme", "widget", 10))
 
-	mr, err := database.GetMergeRequest(ctx, "acme", "widget", 10)
+	mr, err := database.GetMergeRequest(ctx, "gitlab", "gitlab.com", "acme", "widget", 10)
 	require.NoError(err)
 	require.NotNil(mr)
 	assert.Equal("gitlab mr", mr.Title)
@@ -6129,7 +6134,7 @@ func TestSyncMRReturnsErrorWhenClientReturnsNilPR(t *testing.T) {
 	require.Error(err)
 	require.ErrorContains(err, "client returned nil pull request")
 
-	stored, getErr := database.GetMergeRequest(ctx, "acme", "widget", 10)
+	stored, getErr := database.GetMergeRequest(ctx, "github", "github.com", "acme", "widget", 10)
 	require.NoError(getErr)
 	require.Nil(stored)
 }
@@ -6152,7 +6157,7 @@ func TestSyncIssueReturnsErrorWhenClientReturnsNilIssue(t *testing.T) {
 	require.Error(err)
 	require.ErrorContains(err, "client returned nil issue")
 
-	stored, getErr := database.GetIssue(ctx, "acme", "widget", 5)
+	stored, getErr := database.GetIssue(ctx, "github", "github.com", "acme", "widget", 5)
 	require.NoError(getErr)
 	require.Nil(stored)
 }
@@ -6262,12 +6267,12 @@ func TestSyncRunUsesProviderReadersForIndexSync(t *testing.T) {
 
 	assert.Equal(int32(1), provider.listMRCalls.Load())
 	assert.Equal(int32(1), provider.listIssueCalls.Load())
-	mr, err := d.GetMergeRequest(t.Context(), "acme", "widget", 7)
+	mr, err := d.GetMergeRequest(t.Context(), "gitlab", "gitlab.com", "acme", "widget", 7)
 	require.NoError(err)
 	require.NotNil(mr)
 	assert.Equal("Provider MR", mr.Title)
 	assert.Equal("abc123", mr.PlatformHeadSHA)
-	issue, err := d.GetIssue(t.Context(), "acme", "widget", 11)
+	issue, err := d.GetIssue(t.Context(), "gitlab", "gitlab.com", "acme", "widget", 11)
 	require.NoError(err)
 	require.NotNil(issue)
 	assert.Equal("Provider issue", issue.Title)
@@ -6324,7 +6329,7 @@ func TestSyncRunAllowsMergeRequestOnlyProvider(t *testing.T) {
 	require.Equal("gitlab.com", results[0].PlatformHost)
 	require.Empty(results[0].Error)
 	assert.Equal(int32(1), provider.listMRCalls.Load())
-	mr, err := d.GetMergeRequest(t.Context(), "acme", "widget", 7)
+	mr, err := d.GetMergeRequest(t.Context(), "gitlab", "gitlab.com", "acme", "widget", 7)
 	require.NoError(err)
 	require.NotNil(mr)
 	assert.Equal("MR-only provider", mr.Title)
@@ -6377,7 +6382,7 @@ func TestSyncRunAllowsIssueOnlyProvider(t *testing.T) {
 	require.Equal("gitlab.com", results[0].PlatformHost)
 	require.Empty(results[0].Error)
 	assert.Equal(int32(1), provider.listIssueCalls.Load())
-	issue, err := d.GetIssue(t.Context(), "acme", "widget", 11)
+	issue, err := d.GetIssue(t.Context(), "gitlab", "gitlab.com", "acme", "widget", 11)
 	require.NoError(err)
 	require.NotNil(issue)
 	assert.Equal("Issue-only provider", issue.Title)
@@ -6425,7 +6430,7 @@ func TestSyncMRUsesProviderMergeRequestReader(t *testing.T) {
 
 	require.NoError(err)
 	assert.Equal(int32(1), provider.getMRCalls.Load())
-	mr, err := d.GetMergeRequest(t.Context(), "acme", "widget", 7)
+	mr, err := d.GetMergeRequest(t.Context(), "gitlab", "gitlab.com", "acme", "widget", 7)
 	require.NoError(err)
 	require.NotNil(mr)
 	assert.Equal("Provider MR detail", mr.Title)
@@ -6470,7 +6475,7 @@ func TestSyncIssueUsesProviderIssueReader(t *testing.T) {
 
 	require.NoError(err)
 	assert.Equal(int32(1), provider.getIssueCalls.Load())
-	issue, err := d.GetIssue(t.Context(), "acme", "widget", 11)
+	issue, err := d.GetIssue(t.Context(), "gitlab", "gitlab.com", "acme", "widget", 11)
 	require.NoError(err)
 	require.NotNil(issue)
 	assert.Equal("Provider issue detail", issue.Title)
@@ -6683,7 +6688,7 @@ func TestWatchedMRsSyncedOnFastInterval(t *testing.T) {
 	}, 2*time.Second, 20*time.Millisecond)
 
 	// Verify the MR was persisted.
-	mr, err := d.GetMergeRequest(ctx, "acme", "app", 7)
+	mr, err := d.GetMergeRequest(ctx, "github", "github.com", "acme", "app", 7)
 	require.NoError(err)
 	require.NotNil(mr)
 	assert.Equal(7, mr.Number)
@@ -6891,7 +6896,7 @@ func TestWatchedMROnGHEHost(t *testing.T) {
 	syncer.syncWatchedMRs(ctx)
 
 	// The MR should have been synced via the GHE client.
-	mr, err := d.GetMergeRequest(ctx, "corp", "internal", 3)
+	mr, err := d.GetMergeRequest(ctx, "github", "ghes.corp.com", "corp", "internal", 3)
 	require.NoError(err)
 	require.NotNil(mr)
 	assert.Equal(3, mr.Number)
@@ -6899,7 +6904,7 @@ func TestWatchedMROnGHEHost(t *testing.T) {
 	assert.Equal("internal", hookedName)
 
 	// Verify the MR is associated with the GHE repo row, not github.com.
-	repo, err := d.GetRepoByOwnerName(ctx, "corp", "internal")
+	repo, err := d.GetRepoByIdentity(ctx, db.GitHubRepoIdentity("ghes.corp.com", "corp", "internal"))
 	require.NoError(err)
 	require.NotNil(repo)
 	assert.Equal("ghes.corp.com", repo.PlatformHost)
@@ -7180,14 +7185,14 @@ func TestRunOnceIndexOnly(t *testing.T) {
 		"index-only sync should not call GetPullRequest")
 
 	// PRs should be in DB with nil detail_fetched_at.
-	pr1, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	pr1, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.NotNil(pr1)
 	assert.Equal(1, pr1.Number)
 	assert.Nil(pr1.DetailFetchedAt,
 		"detail_fetched_at should be nil after index-only sync")
 
-	pr2, err := d.GetMergeRequest(ctx, "owner", "repo", 2)
+	pr2, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 2)
 	require.NoError(err)
 	require.NotNil(pr2)
 	assert.Equal(2, pr2.Number)
@@ -7238,13 +7243,13 @@ func TestRunOnceDetailDrain(t *testing.T) {
 		"detail drain should call GetPullRequest for open PRs")
 
 	// Both PRs should have detail_fetched_at set.
-	pr1, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	pr1, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.NotNil(pr1)
 	assert.NotNil(pr1.DetailFetchedAt,
 		"detail_fetched_at should be set after detail drain")
 
-	pr2, err := d.GetMergeRequest(ctx, "owner", "repo", 2)
+	pr2, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 2)
 	require.NoError(err)
 	require.NotNil(pr2)
 	assert.NotNil(pr2.DetailFetchedAt,
@@ -7666,7 +7671,7 @@ func TestRunOnceLargeExistingRepoSkipsBulkGraphQLAndFetchesChangedPRDetail(t *te
 		"large existing repo refresh should not bulk-fetch every PR through GraphQL")
 	assert.Equal(int32(1), mc.getPRCalls.Load(),
 		"only the changed PR should be fetched by the detail drain")
-	pr, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	pr, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.NotNil(pr)
 	assert.True(pr.UpdatedAt.Equal(changedAt))
@@ -7763,12 +7768,12 @@ func TestDetailDrainUsesProviderReadersForNonGitHub(t *testing.T) {
 
 	assert.Equal(int32(1), provider.getMRCalls.Load())
 	assert.Equal(int32(1), provider.getIssueCalls.Load())
-	mr, err := d.GetMergeRequest(ctx, "acme", "widget", 7)
+	mr, err := d.GetMergeRequest(ctx, "gitlab", "gitlab.com", "acme", "widget", 7)
 	require.NoError(err)
 	require.NotNil(mr)
 	assert.Equal("fresh MR detail", mr.Title)
 	assert.NotNil(mr.DetailFetchedAt)
-	issue, err := d.GetIssue(ctx, "acme", "widget", 11)
+	issue, err := d.GetIssue(ctx, "gitlab", "gitlab.com", "acme", "widget", 11)
 	require.NoError(err)
 	require.NotNil(issue)
 	assert.Equal("fresh issue detail", issue.Title)
@@ -8019,7 +8024,7 @@ func TestDetailDrainRespectsBudget(t *testing.T) {
 	// All 5 PRs should be in DB (index scan).
 	for i := 1; i <= 5; i++ {
 		pr, err := d.GetMergeRequest(
-			ctx, "owner", "repo", i,
+			ctx, "github", "github.com", "owner", "repo", i,
 		)
 		require.NoError(err)
 		require.NotNil(pr, "PR #%d should exist", i)
@@ -8030,7 +8035,7 @@ func TestDetailDrainRespectsBudget(t *testing.T) {
 	detailCount := 0
 	for i := 1; i <= 5; i++ {
 		pr, _ := d.GetMergeRequest(
-			ctx, "owner", "repo", i,
+			ctx, "github", "github.com", "owner", "repo", i,
 		)
 		if pr != nil && pr.DetailFetchedAt != nil {
 			detailCount++
@@ -8507,7 +8512,7 @@ func TestSyncerPRList304MakesNoAPICalls(t *testing.T) {
 	)
 	seedSyncer.RunOnce(ctx)
 
-	pr, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	pr, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.Equal("pending", pr.CIStatus)
 
@@ -8535,7 +8540,7 @@ func TestSyncerPRList304MakesNoAPICalls(t *testing.T) {
 		"304 on PR list must not trigger any CI API calls")
 
 	// CI state should be unchanged — still pending from seed.
-	pr, err = d.GetMergeRequest(ctx, "owner", "repo", 1)
+	pr, err = d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.Equal("pending", pr.CIStatus,
 		"CI should remain stale until detail drain refreshes it")
@@ -8602,7 +8607,7 @@ func TestSyncerSyncsIssuesOnPRList304(t *testing.T) {
 	)
 	syncer.RunOnce(ctx)
 
-	issue, err := d.GetIssue(ctx, "owner", "repo", issueNumber)
+	issue, err := d.GetIssue(ctx, "github", "github.com", "owner", "repo", issueNumber)
 	require.NoError(err)
 	require.NotNil(issue, "issue sync must run even when PR list returns 304")
 	assert.Equal(issueNumber, issue.Number)
@@ -8646,7 +8651,7 @@ func TestSyncStoresIssueLabels(t *testing.T) {
 	)
 	syncer.RunOnce(ctx)
 
-	issue, err := d.GetIssue(ctx, "owner", "repo", issueNumber)
+	issue, err := d.GetIssue(ctx, "github", "github.com", "owner", "repo", issueNumber)
 	require.NoError(err)
 	require.NotNil(issue)
 	require.Len(issue.Labels, 1)
@@ -8675,7 +8680,7 @@ func TestFetchAndUpdateClosedRefreshesPRLabels(t *testing.T) {
 	require.NoError(err)
 	_, err = d.UpsertMergeRequest(ctx, normalizedPR)
 	require.NoError(err)
-	storedBefore, err := d.GetMergeRequest(ctx, "owner", "repo", 7)
+	storedBefore, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 7)
 	require.NoError(err)
 	require.NoError(d.ReplaceMergeRequestLabels(ctx, repoID, storedBefore.ID, []db.Label{{
 		PlatformID:  901,
@@ -8693,7 +8698,7 @@ func TestFetchAndUpdateClosedRefreshesPRLabels(t *testing.T) {
 
 	require.NoError(syncer.fetchAndUpdateClosed(ctx, RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}, repoID, 7, false))
 
-	storedAfter, err := d.GetMergeRequest(ctx, "owner", "repo", 7)
+	storedAfter, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 7)
 	require.NoError(err)
 	require.Len(storedAfter.Labels, 1)
 	require.Equal("release", storedAfter.Labels[0].Name)
@@ -8803,7 +8808,7 @@ func TestFetchAndUpdateClosedRefreshesIssueLabels(t *testing.T) {
 
 	require.NoError(syncer.fetchAndUpdateClosedIssue(ctx, RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}, repoID, issueNumber))
 
-	stored, err := d.GetIssue(ctx, "owner", "repo", issueNumber)
+	stored, err := d.GetIssue(ctx, "github", "github.com", "owner", "repo", issueNumber)
 	require.NoError(err)
 	require.Len(stored.Labels, 1)
 	require.Equal("docs", stored.Labels[0].Name)
@@ -8884,7 +8889,7 @@ func TestBackfillRepoPersistsPRLabels(t *testing.T) {
 
 	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
-	repoRow, err := d.GetRepoByOwnerName(ctx, "owner", "repo")
+	repoRow, err := d.GetRepoByIdentity(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
 	require.NotNil(repoRow)
 	now := time.Date(2024, 6, 7, 12, 0, 0, 0, time.UTC)
@@ -8899,7 +8904,7 @@ func TestBackfillRepoPersistsPRLabels(t *testing.T) {
 
 	syncer.backfillRepo(ctx, RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}, repoRow, NewSyncBudget(10))
 
-	stored, err := d.GetMergeRequest(ctx, "owner", "repo", 21)
+	stored, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 21)
 	require.NoError(err)
 	require.NotNil(stored)
 	require.Equal(repoID, stored.RepoID)
@@ -8914,7 +8919,7 @@ func TestBackfillRepoPersistsIssueLabels(t *testing.T) {
 
 	_, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
-	repoRow, err := d.GetRepoByOwnerName(ctx, "owner", "repo")
+	repoRow, err := d.GetRepoByIdentity(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
 	require.NotNil(repoRow)
 	now := time.Date(2024, 6, 8, 12, 0, 0, 0, time.UTC)
@@ -8933,7 +8938,7 @@ func TestBackfillRepoPersistsIssueLabels(t *testing.T) {
 
 	syncer.backfillRepo(ctx, RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}, repoRow, NewSyncBudget(10))
 
-	stored, err := d.GetIssue(ctx, "owner", "repo", issueNumber)
+	stored, err := d.GetIssue(ctx, "github", "github.com", "owner", "repo", issueNumber)
 	require.NoError(err)
 	require.NotNil(stored)
 	require.Len(stored.Labels, 1)
@@ -8952,7 +8957,7 @@ func TestBackfillRepoSkipsNonGitHubProviders(t *testing.T) {
 	}
 	_, err := d.UpsertRepo(ctx, platform.DBRepoIdentity(platformRepoRef(repo)))
 	require.NoError(err)
-	repoRow, err := d.GetRepoByOwnerName(ctx, "owner", "repo")
+	repoRow, err := d.GetRepoByIdentity(ctx, platform.DBRepoIdentity(platformRepoRef(repo)))
 	require.NoError(err)
 	require.NotNil(repoRow)
 
@@ -8971,7 +8976,7 @@ func TestBackfillRepoSkipsNonGitHubProviders(t *testing.T) {
 
 	syncer.backfillRepo(ctx, repo, repoRow, NewSyncBudget(10))
 
-	repoAfter, err := d.GetRepoByOwnerName(ctx, "owner", "repo")
+	repoAfter, err := d.GetRepoByIdentity(ctx, platform.DBRepoIdentity(platformRepoRef(repo)))
 	require.NoError(err)
 	require.NotNil(repoAfter)
 	require.False(repoAfter.BackfillPRComplete)
@@ -9042,7 +9047,7 @@ func TestBackfillRepoStoresCompletionTimestampsInUTC(t *testing.T) {
 
 	_, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
-	repoRow, err := d.GetRepoByOwnerName(ctx, "owner", "repo")
+	repoRow, err := d.GetRepoByIdentity(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
 	require.NotNil(repoRow)
 	now := time.Date(2024, 6, 8, 12, 0, 0, 0, time.UTC)
@@ -9069,7 +9074,7 @@ func TestBackfillRepoStoresCompletionTimestampsInUTC(t *testing.T) {
 
 	syncer.backfillRepo(ctx, RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}, repoRow, NewSyncBudget(10))
 
-	repoAfter, err := d.GetRepoByOwnerName(ctx, "owner", "repo")
+	repoAfter, err := d.GetRepoByIdentity(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
 	require.NotNil(repoAfter)
 	require.True(repoAfter.BackfillPRComplete)
@@ -9087,7 +9092,7 @@ func TestBackfillRepoDoesNotAdvancePRCursorWhenLabelPersistenceFails(t *testing.
 
 	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
-	repoRow, err := d.GetRepoByOwnerName(ctx, "owner", "repo")
+	repoRow, err := d.GetRepoByIdentity(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
 	require.NotNil(repoRow)
 	now := time.Date(2024, 6, 9, 12, 0, 0, 0, time.UTC)
@@ -9118,14 +9123,14 @@ func TestBackfillRepoDoesNotAdvancePRCursorWhenLabelPersistenceFails(t *testing.
 
 	syncer.backfillRepo(ctx, RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}, repoRow, NewSyncBudget(10))
 
-	repoAfter, err := d.GetRepoByOwnerName(ctx, "owner", "repo")
+	repoAfter, err := d.GetRepoByIdentity(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
 	require.NotNil(repoAfter)
 	require.Equal(0, repoAfter.BackfillPRPage)
 	require.False(repoAfter.BackfillPRComplete)
 	require.Nil(repoAfter.BackfillPRCompletedAt)
 
-	stored, err := d.GetMergeRequest(ctx, "owner", "repo", 31)
+	stored, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 31)
 	require.NoError(err)
 	require.NotNil(stored)
 	require.Empty(stored.Labels)
@@ -9138,7 +9143,7 @@ func TestBackfillRepoDoesNotAdvanceIssueCursorWhenLabelPersistenceFails(t *testi
 
 	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
-	repoRow, err := d.GetRepoByOwnerName(ctx, "owner", "repo")
+	repoRow, err := d.GetRepoByIdentity(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
 	require.NotNil(repoRow)
 	now := time.Date(2024, 6, 10, 12, 0, 0, 0, time.UTC)
@@ -9173,14 +9178,14 @@ func TestBackfillRepoDoesNotAdvanceIssueCursorWhenLabelPersistenceFails(t *testi
 
 	syncer.backfillRepo(ctx, RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}, repoRow, NewSyncBudget(10))
 
-	repoAfter, err := d.GetRepoByOwnerName(ctx, "owner", "repo")
+	repoAfter, err := d.GetRepoByIdentity(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(err)
 	require.NotNil(repoAfter)
 	require.Equal(0, repoAfter.BackfillIssuePage)
 	require.False(repoAfter.BackfillIssueComplete)
 	require.Nil(repoAfter.BackfillIssueCompletedAt)
 
-	stored, err := d.GetIssue(ctx, "owner", "repo", issueNumber)
+	stored, err := d.GetIssue(ctx, "github", "github.com", "owner", "repo", issueNumber)
 	require.NoError(err)
 	require.NotNil(stored)
 	require.Empty(stored.Labels)
@@ -9339,7 +9344,7 @@ func TestSyncerSyncOpenIssueFailureMarksRepoFailed(t *testing.T) {
 	syncer.RunOnce(ctx)
 
 	// Issue row lands in DB (upsert happened before timeline).
-	issue, err := d.GetIssue(ctx, "owner", "repo", issueNumber)
+	issue, err := d.GetIssue(ctx, "github", "github.com", "owner", "repo", issueNumber)
 	require.NoError(err)
 	require.NotNil(issue, "issue should be upserted even though timeline failed")
 
@@ -9366,7 +9371,7 @@ func TestSyncerSyncOpenIssueFailureMarksRepoFailed(t *testing.T) {
 		"next cycle should call InvalidateListETagsForRepo")
 
 	// Verify timeline was actually refreshed: the comment should be in DB.
-	issue, err = d.GetIssue(ctx, "owner", "repo", issueNumber)
+	issue, err = d.GetIssue(ctx, "github", "github.com", "owner", "repo", issueNumber)
 	require.NoError(err)
 	events, err = d.ListIssueEvents(ctx, issue.ID)
 	require.NoError(err)
@@ -9423,7 +9428,7 @@ func TestSyncerClosedIssueFailureMarksRepoFailed(t *testing.T) {
 	)
 	seedSyncer.RunOnce(ctx)
 
-	seeded, err := d.GetIssue(ctx, "owner", "repo", issueNumber)
+	seeded, err := d.GetIssue(ctx, "github", "github.com", "owner", "repo", issueNumber)
 	require.NoError(err)
 	require.NotNil(seeded, "seed cycle should persist issue #7")
 
@@ -9451,7 +9456,7 @@ func TestSyncerClosedIssueFailureMarksRepoFailed(t *testing.T) {
 	assert.True(flagged, "failedRepos must be set after fetchAndUpdateClosedIssue failure")
 
 	// Verify issue is still open in DB (closure update failed).
-	stillOpen, err := d.GetIssue(ctx, "owner", "repo", issueNumber)
+	stillOpen, err := d.GetIssue(ctx, "github", "github.com", "owner", "repo", issueNumber)
 	require.NoError(err)
 	require.NotNil(stillOpen)
 	assert.Equal("open", stillOpen.State, "issue should still be open because closure update failed")
@@ -9486,7 +9491,7 @@ func TestSyncerClosedIssueFailureMarksRepoFailed(t *testing.T) {
 	assert.Greater(mc.invalidateCalls.Load(), invalidateBefore,
 		"next cycle should call InvalidateListETagsForRepo")
 
-	updated, err := d.GetIssue(ctx, "owner", "repo", issueNumber)
+	updated, err := d.GetIssue(ctx, "github", "github.com", "owner", "repo", issueNumber)
 	require.NoError(err)
 	require.NotNil(updated)
 	assert.Equal("closed", updated.State, "issue should be closed after successful retry")
@@ -9525,7 +9530,7 @@ func TestSyncerMRListFailureMarksRepoFailed(t *testing.T) {
 	// Cycle 1: PR list fails → failMR set, issues unaffected.
 	syncer.RunOnce(ctx)
 
-	mr, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	mr, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	assert.Nil(mr, "MR should not be upserted when PR list failed")
 
@@ -9552,7 +9557,7 @@ func TestSyncerMRListFailureMarksRepoFailed(t *testing.T) {
 	assert.True(mc.issuesCached,
 		"issue cache should stay warm when only MR path failed")
 
-	mr, err = d.GetMergeRequest(ctx, "owner", "repo", 1)
+	mr, err = d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.NotNil(mr, "MR should be upserted after successful retry")
 
@@ -9593,7 +9598,7 @@ func TestSyncerMRDetailFailureRetries(t *testing.T) {
 	// refreshTimeline fails at ListReviews → detail_fetched_at stays nil.
 	syncer.RunOnce(ctx)
 
-	mr, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	mr, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.NotNil(mr, "MR should be upserted by index phase")
 	assert.Nil(mr.DetailFetchedAt,
@@ -9621,7 +9626,7 @@ func TestSyncerMRDetailFailureRetries(t *testing.T) {
 	// → fetchMRDetail succeeds → timeline events land.
 	syncer.RunOnce(ctx)
 
-	mr, err = d.GetMergeRequest(ctx, "owner", "repo", 1)
+	mr, err = d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.NotNil(mr)
 	assert.NotNil(mr.DetailFetchedAt,
@@ -9678,7 +9683,7 @@ func TestSyncerRefreshesEditedPRCommentWhenPRListIsUnchanged(t *testing.T) {
 
 	syncer.RunOnce(ctx)
 
-	mr, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	mr, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.NotNil(mr)
 
@@ -9699,7 +9704,7 @@ func TestSyncerRefreshesEditedPRCommentWhenPRListIsUnchanged(t *testing.T) {
 
 	syncer.RunOnce(ctx)
 
-	mr, err = d.GetMergeRequest(ctx, "owner", "repo", 1)
+	mr, err = d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.NotNil(mr)
 
@@ -9755,7 +9760,7 @@ func TestSyncerRemovesDeletedPRCommentWhenPRListIsUnchanged(t *testing.T) {
 
 	syncer.RunOnce(ctx)
 
-	mr, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	mr, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.NotNil(mr)
 	require.Equal(1, mr.CommentCount)
@@ -9768,7 +9773,7 @@ func TestSyncerRemovesDeletedPRCommentWhenPRListIsUnchanged(t *testing.T) {
 
 	syncer.RunOnce(ctx)
 
-	mr, err = d.GetMergeRequest(ctx, "owner", "repo", 1)
+	mr, err = d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.NotNil(mr)
 	assert.Equal(0, mr.CommentCount)
@@ -9831,7 +9836,7 @@ func TestSyncerRemovesDeletedIssueCommentWhenIssueListIsUnchanged(t *testing.T) 
 
 	syncer.RunOnce(ctx)
 
-	issue, err := d.GetIssue(ctx, "owner", "repo", issueNumber)
+	issue, err := d.GetIssue(ctx, "github", "github.com", "owner", "repo", issueNumber)
 	require.NoError(err)
 	require.NotNil(issue)
 	require.Equal(1, issue.CommentCount)
@@ -9845,7 +9850,7 @@ func TestSyncerRemovesDeletedIssueCommentWhenIssueListIsUnchanged(t *testing.T) 
 
 	syncer.RunOnce(ctx)
 
-	issue, err = d.GetIssue(ctx, "owner", "repo", issueNumber)
+	issue, err = d.GetIssue(ctx, "github", "github.com", "owner", "repo", issueNumber)
 	require.NoError(err)
 	require.NotNil(issue)
 	assert.Equal(0, issue.CommentCount)
@@ -9903,7 +9908,7 @@ func TestFetchMRDetailRemovesDeletedCommentDuringFullRefresh(t *testing.T) {
 	)
 	require.NoError(err)
 
-	mr, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	mr, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.NotNil(mr)
 	require.Equal(1, mr.CommentCount)
@@ -9921,7 +9926,7 @@ func TestFetchMRDetailRemovesDeletedCommentDuringFullRefresh(t *testing.T) {
 	)
 	require.NoError(err)
 
-	mr, err = d.GetMergeRequest(ctx, "owner", "repo", 1)
+	mr, err = d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.NotNil(mr)
 	assert.Equal(0, mr.CommentCount)
@@ -9993,7 +9998,7 @@ func TestFetchIssueDetailRemovesDeletedCommentDuringFullRefresh(t *testing.T) {
 	)
 	require.NoError(err)
 
-	issue, err := d.GetIssue(ctx, "owner", "repo", issueNumber)
+	issue, err := d.GetIssue(ctx, "github", "github.com", "owner", "repo", issueNumber)
 	require.NoError(err)
 	require.NotNil(issue)
 	require.Equal(1, issue.CommentCount)
@@ -10011,7 +10016,7 @@ func TestFetchIssueDetailRemovesDeletedCommentDuringFullRefresh(t *testing.T) {
 	)
 	require.NoError(err)
 
-	issue, err = d.GetIssue(ctx, "owner", "repo", issueNumber)
+	issue, err = d.GetIssue(ctx, "github", "github.com", "owner", "repo", issueNumber)
 	require.NoError(err)
 	require.NotNil(issue)
 	assert.Equal(0, issue.CommentCount)
@@ -10066,7 +10071,7 @@ func TestSyncOpenMRFromBulkRemovesDeletedCommentsWhenCommentsAreComplete(t *test
 	}, false)
 	require.NoError(err)
 
-	mr, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	mr, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.NotNil(mr)
 	require.Equal(1, mr.CommentCount)
@@ -10088,7 +10093,7 @@ func TestSyncOpenMRFromBulkRemovesDeletedCommentsWhenCommentsAreComplete(t *test
 	}, false)
 	require.NoError(err)
 
-	mr, err = d.GetMergeRequest(ctx, "owner", "repo", 1)
+	mr, err = d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.NotNil(mr)
 	assert.Equal(0, mr.CommentCount)
@@ -10148,7 +10153,7 @@ func TestSyncOpenMRFromBulkPersistsWorkflowApproval(t *testing.T) {
 	}, false)
 	require.NoError(err)
 
-	got, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	got, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.NotNil(got)
 	require.NotNil(got.WorkflowApprovalCheckedAt,
@@ -10203,7 +10208,7 @@ func TestSyncOpenMRFromBulkSkipsWorkflowApprovalWhenBudgetExhausted(t *testing.T
 	}, false)
 	require.NoError(err)
 
-	got, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	got, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.NotNil(got)
 	assert.Nil(got.WorkflowApprovalCheckedAt)
@@ -10258,7 +10263,7 @@ func TestSyncOpenMRFromBulkSkipsWorkflowApprovalWhenIncomplete(t *testing.T) {
 	}, false)
 	require.NoError(err)
 
-	got, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	got, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.NotNil(got)
 	assert.Nil(got.WorkflowApprovalCheckedAt,
@@ -10307,7 +10312,7 @@ func TestSyncOpenMRFromBulkUpdatesCommentFieldsWhenOnlyCommentsAreComplete(t *te
 	}, false)
 	require.NoError(err)
 
-	mr, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	mr, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.NotNil(mr)
 	assert.Equal(1, mr.CommentCount)
@@ -10327,7 +10332,7 @@ func TestSyncOpenMRFromBulkUpdatesCommentFieldsWhenOnlyCommentsAreComplete(t *te
 	}, false)
 	require.NoError(err)
 
-	mr, err = d.GetMergeRequest(ctx, "owner", "repo", 1)
+	mr, err = d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.NotNil(mr)
 	assert.Equal(0, mr.CommentCount)
@@ -10392,7 +10397,7 @@ func TestSyncOpenMRFromBulkStoresTimelineEvents(t *testing.T) {
 	}, false)
 	require.NoError(err)
 
-	mr, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	mr, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.NotNil(mr)
 	require.NotNil(mr.DetailFetchedAt)
@@ -10475,7 +10480,7 @@ func TestSyncOpenMRFromBulkClearsCIWhenHeadSHAChanges(t *testing.T) {
 	}, false)
 	require.NoError(err)
 
-	mr, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	mr, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.NotNil(mr)
 	assert.Equal("newhead", mr.PlatformHeadSHA)
@@ -10535,7 +10540,7 @@ func TestSyncOpenMRFromBulkPreservesCIWhenHeadSHAUnchanged(t *testing.T) {
 	}, false)
 	require.NoError(err)
 
-	mr, err := d.GetMergeRequest(ctx, "owner", "repo", 1)
+	mr, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.NotNil(mr)
 	assert.Equal(sameSHA, mr.PlatformHeadSHA)
@@ -10601,7 +10606,7 @@ func TestSyncOpenIssueFromBulkRemovesDeletedCommentsWhenCommentsAreComplete(t *t
 	})
 	require.NoError(err)
 
-	issue, err := d.GetIssue(ctx, "owner", "repo", issueNumber)
+	issue, err := d.GetIssue(ctx, "github", "github.com", "owner", "repo", issueNumber)
 	require.NoError(err)
 	require.NotNil(issue)
 	require.Equal(1, issue.CommentCount)
@@ -10631,7 +10636,7 @@ func TestSyncOpenIssueFromBulkRemovesDeletedCommentsWhenCommentsAreComplete(t *t
 	})
 	require.NoError(err)
 
-	issue, err = d.GetIssue(ctx, "owner", "repo", issueNumber)
+	issue, err = d.GetIssue(ctx, "github", "github.com", "owner", "repo", issueNumber)
 	require.NoError(err)
 	require.NotNil(issue)
 	assert.Equal(0, issue.CommentCount)
@@ -10709,7 +10714,7 @@ func TestSyncOpenIssueFromBulkStoresTimelineEvents(t *testing.T) {
 	})
 	require.NoError(err)
 
-	issue, err := d.GetIssue(ctx, "owner", "repo", issueNumber)
+	issue, err := d.GetIssue(ctx, "github", "github.com", "owner", "repo", issueNumber)
 	require.NoError(err)
 	require.NotNil(issue)
 	assert.NotNil(issue.DetailFetchedAt)
@@ -10858,7 +10863,7 @@ func TestSyncRepoGraphQLIssues(t *testing.T) {
 	require.NoError(err)
 
 	// Verify issue in DB.
-	issue, err := d.GetIssue(ctx, "owner", "repo", 10)
+	issue, err := d.GetIssue(ctx, "github", "github.com", "owner", "repo", 10)
 	require.NoError(err)
 	require.NotNil(issue)
 	assert.Equal("Bug report", issue.Title)
@@ -11091,7 +11096,7 @@ func TestSyncRepoGraphQLIssuesCommentsIncomplete(t *testing.T) {
 	assert.Equal(int32(1), mock.listIssueCommentsCalled.Load())
 
 	// Verify the REST comment landed
-	issue, err := d.GetIssue(ctx, "owner", "repo", 20)
+	issue, err := d.GetIssue(ctx, "github", "github.com", "owner", "repo", 20)
 	require.NoError(err)
 	require.NotNil(issue)
 
@@ -11165,7 +11170,7 @@ func TestSyncRepoGraphQLIssuesClosureDetection(t *testing.T) {
 	require.NoError(err)
 
 	// Issue should now be closed
-	issue, err := d.GetIssue(ctx, "owner", "repo", 30)
+	issue, err := d.GetIssue(ctx, "github", "github.com", "owner", "repo", 30)
 	require.NoError(err)
 	require.NotNil(issue)
 	assert.Equal("closed", issue.State)
@@ -11244,7 +11249,7 @@ func TestSyncRepoGraphQLIssuesPreservesExistingFields(t *testing.T) {
 	// DetailFetchedAt is cleared before REST fallback, then re-set
 	// after successful refreshIssueTimeline. CommentCount is updated
 	// by the REST fallback (0 comments returned by the mock).
-	issue, err := d.GetIssue(ctx, "owner", "repo", 40)
+	issue, err := d.GetIssue(ctx, "github", "github.com", "owner", "repo", 40)
 	require.NoError(err)
 	require.NotNil(issue)
 	assert.NotNil(issue.DetailFetchedAt)
@@ -11324,7 +11329,7 @@ func TestSyncRepoGraphQLIssuesClearsDetailFetchedAtOnFailedFallback(t *testing.T
 	require.Error(err)
 
 	// DetailFetchedAt must be nil so the detail drain re-queues this issue.
-	issue, err := d.GetIssue(ctx, "owner", "repo", 45)
+	issue, err := d.GetIssue(ctx, "github", "github.com", "owner", "repo", 45)
 	require.NoError(err)
 	require.NotNil(issue)
 	assert.Nil(issue.DetailFetchedAt)
@@ -11385,7 +11390,7 @@ func TestSyncRepoGraphQLIssuesFallbackToREST(t *testing.T) {
 
 	syncer.RunOnce(ctx)
 
-	issue, err := d.GetIssue(ctx, "owner", "repo", 50)
+	issue, err := d.GetIssue(ctx, "github", "github.com", "owner", "repo", 50)
 	require.NoError(t, err)
 	require.NotNil(t, issue)
 	assert.Equal("REST issue", issue.Title)
@@ -11473,7 +11478,7 @@ func TestSyncRepoGraphQLIssuesFullFlow(t *testing.T) {
 	syncer.RunOnce(ctx)
 
 	// Verify issue persisted with GraphQL data.
-	issue, err := d.GetIssue(ctx, "owner", "repo", 70)
+	issue, err := d.GetIssue(ctx, "github", "github.com", "owner", "repo", 70)
 	require.NoError(err)
 	require.NotNil(issue)
 	assert.Equal("Full flow issue", issue.Title)
@@ -11981,7 +11986,7 @@ func TestDeferredCommentRefreshYieldsBudgetToDetailDrain(t *testing.T) {
 	syncer.drainDetailQueue(ctx, map[string]bool{"github.com": true})
 	syncer.drainPendingCommentSyncs(ctx, map[string]bool{"github.com": true})
 
-	pr, err := d.GetMergeRequest(ctx, "owner", "repo", 2)
+	pr, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 2)
 	require.NoError(err)
 	require.NotNil(pr)
 	assert.NotNil(pr.DetailFetchedAt,
@@ -12264,7 +12269,7 @@ func TestDisplayNameCacheSurvivesRunOnce(t *testing.T) {
 		"first RunOnce should have fetched the display name")
 
 	// Verify the display name landed in SQLite.
-	mr, err := d.GetMergeRequest(ctx, "owner", "repo", prNumber)
+	mr, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", prNumber)
 	require.NoError(err)
 	require.NotNil(mr)
 	assert.Equal("Alice Smith", mr.AuthorDisplayName,
@@ -12276,7 +12281,7 @@ func TestDisplayNameCacheSurvivesRunOnce(t *testing.T) {
 		"second RunOnce must not re-fetch cached display names")
 
 	// DB still has the name after the cache-hit sync pass.
-	mr2, err := d.GetMergeRequest(ctx, "owner", "repo", prNumber)
+	mr2, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", prNumber)
 	require.NoError(err)
 	require.NotNil(mr2)
 	assert.Equal("Alice Smith", mr2.AuthorDisplayName,

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -15275,8 +15275,15 @@ func TestAPIGitealikeMutationsPersistThroughServer(t *testing.T) {
 	mrEvents, err = database.ListMREvents(ctx, mrSeven.ID)
 	require.NoError(err)
 	require.Len(mrEvents, 2)
-	assert.Equal("review", mrEvents[1].EventType)
-	assert.Equal("APPROVED", mrEvents[1].Summary)
+	var reviewEvent *db.MREvent
+	for i := range mrEvents {
+		if mrEvents[i].EventType == "review" {
+			reviewEvent = &mrEvents[i]
+			break
+		}
+	}
+	require.NotNil(reviewEvent)
+	assert.Equal("APPROVED", reviewEvent.Summary)
 
 	mergeResp, err := client.HTTP.MergePullOnHostWithResponse(
 		ctx, "gitea.test", "gitea", "tea", "kettle", 7,

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -1520,7 +1520,7 @@ func TestAPIMergePRStoresUTCTimestamps(t *testing.T) {
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
 
-	pr, err := database.GetMergeRequest(t.Context(), "acme", "widget", 1)
+	pr, err := database.GetMergeRequest(t.Context(), "github", "github.com", "acme", "widget", 1)
 	require.NoError(err)
 	require.Equal(db.MergeRequestStateMerged, pr.State)
 	assertTimePtrEqualsUTC(t, pr.MergedAt, handlerNow)
@@ -1914,7 +1914,7 @@ func TestAPIRepoFilterAcceptsMultipleRepos(t *testing.T) {
 	seedIssueOnHost(t, database, "github.com", "acme", "worker", 12, "open", "worker issue")
 	seedIssueOnHost(t, database, "github.com", "acme", "ignored", 13, "open", "ignored issue")
 
-	filter := url.QueryEscape("github.com/acme/widget,github.com/acme/worker")
+	filter := url.QueryEscape("github|github.com/acme/widget,github|github.com/acme/worker")
 
 	rawPulls := doJSON(t, srv, http.MethodGet, "/api/v1/pulls?repo="+filter, nil)
 	require.Equal(http.StatusOK, rawPulls.Code)
@@ -2264,7 +2264,7 @@ func TestAPISyncPRPersistsMergeableState(t *testing.T) {
 	require.NotNil(resp.JSON200)
 	assert.Equal("dirty", resp.JSON200.MergeRequest.MergeableState)
 
-	stored, err := database.GetMergeRequest(t.Context(), "acme", "widget", 1)
+	stored, err := database.GetMergeRequest(t.Context(), "github", "github.com", "acme", "widget", 1)
 	require.NoError(err)
 	require.NotNil(stored)
 	assert.Equal("dirty", stored.MergeableState)
@@ -2323,7 +2323,7 @@ func TestAPISyncPRPreservesMergeableStateWhenRefreshHasNoAnswer(t *testing.T) {
 			require.NotNil(resp.JSON200)
 			assert.Equal("dirty", resp.JSON200.MergeRequest.MergeableState)
 
-			stored, err := database.GetMergeRequest(t.Context(), "acme", "widget", 1)
+			stored, err := database.GetMergeRequest(t.Context(), "github", "github.com", "acme", "widget", 1)
 			require.NoError(err)
 			require.NotNil(stored)
 			assert.Equal("dirty", stored.MergeableState)
@@ -2541,7 +2541,7 @@ func TestAPIApproveWorkflows(t *testing.T) {
 
 	srv, database := setupTestServerWithMock(t, mock)
 	seedPR(t, database, "acme", "widget", 1)
-	repo, err := database.GetRepoByHostOwnerName(t.Context(), "github.com", "acme", "widget")
+	repo, err := database.GetRepoByIdentity(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	require.NotNil(repo)
 	require.NoError(database.UpdateMRWorkflowApproval(
@@ -2560,7 +2560,7 @@ func TestAPIApproveWorkflows(t *testing.T) {
 	assert.EqualValues(2, *resp.JSON200.ApprovedCount)
 	assert.Equal([]int64{81, 82}, approvedRunIDs)
 
-	pr, err := database.GetMergeRequest(t.Context(), "acme", "widget", 1)
+	pr, err := database.GetMergeRequest(t.Context(), "github", "github.com", "acme", "widget", 1)
 	require.NoError(err)
 	require.NotNil(pr)
 	assert.Equal("abc123", pr.PlatformHeadSHA)
@@ -2612,7 +2612,7 @@ func TestAPIApproveWorkflowsZeroMatchesStillSyncsPR(t *testing.T) {
 	require.NotNil(resp.JSON200)
 	assert.Equal("approved_workflows", resp.JSON200.Status)
 
-	pr, err := database.GetMergeRequest(t.Context(), "acme", "widget", 1)
+	pr, err := database.GetMergeRequest(t.Context(), "github", "github.com", "acme", "widget", 1)
 	require.NoError(err)
 	require.NotNil(pr)
 	assert.Equal("abc123", pr.PlatformHeadSHA)
@@ -2683,7 +2683,7 @@ func TestAPIApproveWorkflowsReturnsUnderlyingApprovalErrorAfterPartialFailure(t 
 	assert.Contains(*resp.ApplicationproblemJSONDefault.Detail, "permission denied")
 	assert.Equal([]int64{91, 92}, approvedRunIDs)
 
-	pr, err := database.GetMergeRequest(t.Context(), "acme", "widget", 1)
+	pr, err := database.GetMergeRequest(t.Context(), "github", "github.com", "acme", "widget", 1)
 	require.NoError(err)
 	require.NotNil(pr)
 	assert.Equal("abc123", pr.PlatformHeadSHA)
@@ -3529,7 +3529,7 @@ func TestAPISetKanbanState(t *testing.T) {
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
 
-	pr, err := database.GetMergeRequest(t.Context(), "acme", "widget", 1)
+	pr, err := database.GetMergeRequest(t.Context(), "github", "github.com", "acme", "widget", 1)
 	require.NoError(err)
 	require.NotNil(pr)
 	require.Equal(db.KanbanStatusReviewing, pr.KanbanStatus)
@@ -5088,7 +5088,7 @@ func TestAPIListRepoSummaries(t *testing.T) {
 
 	_, err := testutil.SeedFixtures(context.Background(), database)
 	require.NoError(err)
-	widgetsRepo, err := database.GetRepoByOwnerName(context.Background(), "acme", "widgets")
+	widgetsRepo, err := database.GetRepoByIdentity(context.Background(), db.GitHubRepoIdentity("github.com", "acme", "widgets"))
 	require.NoError(err)
 	require.NotNil(widgetsRepo)
 	publishedAt := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
@@ -5549,7 +5549,7 @@ func TestAPICreateIssue(t *testing.T) {
 		IsDefault: false,
 	}}, *resp.JSON201.Labels)
 
-	issue, err := database.GetIssue(context.Background(), "acme", "widgets", 27)
+	issue, err := database.GetIssue(context.Background(), "github", "github.com", "acme", "widgets", 27)
 	require.NoError(err)
 	require.NotNil(issue)
 	assert.Equal("Ship repo summaries", issue.Title)
@@ -5625,7 +5625,7 @@ func TestAPIEditPRContentRejectsNilProviderPayload(t *testing.T) {
 	require.NoError(err)
 	require.Equal(http.StatusBadGateway, resp.StatusCode())
 
-	mr, err := database.GetMergeRequest(t.Context(), "acme", "widget", 1)
+	mr, err := database.GetMergeRequest(t.Context(), "github", "github.com", "acme", "widget", 1)
 	require.NoError(err)
 	require.NotNil(mr)
 	assert.Equal("Test PR #1", mr.Title)
@@ -5851,7 +5851,7 @@ func TestAPIMergePRRejectsNilProviderPayload(t *testing.T) {
 	require.NoError(err)
 	require.Equal(http.StatusBadGateway, resp.StatusCode())
 
-	mr, err := database.GetMergeRequest(t.Context(), "acme", "widget", 1)
+	mr, err := database.GetMergeRequest(t.Context(), "github", "github.com", "acme", "widget", 1)
 	require.NoError(err)
 	require.NotNil(mr)
 	assert.Equal(db.MergeRequestStateOpen, mr.State)
@@ -6593,7 +6593,7 @@ func TestAPITriggerSyncBypassesNextSyncAfter(t *testing.T) {
 	}
 }
 
-func TestMatchPriorityRepoSupportsNestedBareRepoPaths(t *testing.T) {
+func TestMatchPriorityRepoRequiresProviderQualifiedRepoPaths(t *testing.T) {
 	assert := Assert.New(t)
 
 	tracked := []ghclient.RepoRef{
@@ -6620,17 +6620,13 @@ func TestMatchPriorityRepoSupportsNestedBareRepoPaths(t *testing.T) {
 		},
 	}
 
-	repo, ok := matchPriorityRepo("group/subgroup/project", tracked)
-	assert.True(ok)
-	assert.Equal(platform.KindGitLab, repo.Platform)
-	assert.Equal("group/subgroup/project", repo.RepoPath)
+	_, ok := matchPriorityRepo("group/subgroup/project", tracked)
+	assert.False(ok)
 
-	repo, ok = matchPriorityRepo("github.com/acme/widget", tracked)
-	assert.True(ok)
-	assert.Equal(platform.KindGitHub, repo.Platform)
-	assert.Equal("acme/widget", repo.RepoPath)
+	_, ok = matchPriorityRepo("github.com/acme/widget", tracked)
+	assert.False(ok)
 
-	repo, ok = matchPriorityRepo("gitea|github.com/acme/widget", tracked)
+	repo, ok := matchPriorityRepo("gitea|github.com/acme/widget", tracked)
 	assert.True(ok)
 	assert.Equal(platform.KindGitea, repo.Platform)
 	assert.Equal("github.com", repo.PlatformHost)
@@ -6714,7 +6710,7 @@ func TestAPIReadyForReview(t *testing.T) {
 	require.Equal(http.StatusOK, resp.StatusCode())
 	require.NotNil(resp.JSON200)
 
-	pr, err := database.GetMergeRequest(t.Context(), "acme", "widget", 1)
+	pr, err := database.GetMergeRequest(t.Context(), "github", "github.com", "acme", "widget", 1)
 	require.NoError(err)
 	require.NotNil(pr)
 	require.False(pr.IsDraft)
@@ -6727,10 +6723,12 @@ func TestAPISetStarred(t *testing.T) {
 	client := setupTestClient(t, srv)
 
 	resp, err := client.HTTP.SetStarredWithResponse(t.Context(), generated.SetStarredJSONRequestBody{
-		ItemType: "pr",
-		Owner:    "acme",
-		Name:     "widget",
-		Number:   1,
+		ItemType:     "pr",
+		Provider:     "github",
+		PlatformHost: "github.com",
+		Owner:        "acme",
+		Name:         "widget",
+		Number:       1,
 	})
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -6748,10 +6746,12 @@ func TestAPIUnsetStarred(t *testing.T) {
 	client := setupTestClient(t, srv)
 
 	resp, err := client.HTTP.UnsetStarredWithResponse(t.Context(), generated.UnsetStarredJSONRequestBody{
-		ItemType: "pr",
-		Owner:    "acme",
-		Name:     "widget",
-		Number:   1,
+		ItemType:     "pr",
+		Provider:     "github",
+		PlatformHost: "github.com",
+		Owner:        "acme",
+		Name:         "widget",
+		Number:       1,
 	})
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
@@ -6767,10 +6767,12 @@ func TestAPISetStarredRejectsInvalidItemType(t *testing.T) {
 	client := setupTestClient(t, srv)
 
 	resp, err := client.HTTP.SetStarredWithResponse(t.Context(), generated.SetStarredJSONRequestBody{
-		ItemType: "repo",
-		Owner:    "acme",
-		Name:     "widget",
-		Number:   1,
+		ItemType:     "repo",
+		Provider:     "github",
+		PlatformHost: "github.com",
+		Owner:        "acme",
+		Name:         "widget",
+		Number:       1,
 	})
 	require.NoError(err)
 	require.Equal(http.StatusBadRequest, resp.StatusCode())
@@ -6846,7 +6848,7 @@ func seedIssueWithLabels(t *testing.T, database *db.DB, owner, name string, numb
 	t.Helper()
 	ctx := t.Context()
 	issueID := seedIssue(t, database, owner, name, number, state)
-	repo, err := database.GetRepoByOwnerName(ctx, owner, name)
+	repo, err := database.GetRepoByIdentity(ctx, db.GitHubRepoIdentity("github.com", owner, name))
 	require.NoError(t, err)
 	require.NoError(t, database.ReplaceIssueLabels(ctx, repo.ID, issueID, labels))
 	return issueID
@@ -6904,7 +6906,7 @@ func TestAPIClosePR(t *testing.T) {
 	handlerNow := testEDTTime(9, 15)
 	setTestServerNow(t, srv, handlerNow)
 	seedPR(t, database, "acme", "widget", 1)
-	repo, err := database.GetRepoByOwnerName(t.Context(), "acme", "widget")
+	repo, err := database.GetRepoByIdentity(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	updatedAt := handlerNow.Add(-time.Hour)
 	number := 1
@@ -6934,7 +6936,7 @@ func TestAPIClosePR(t *testing.T) {
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
 
-	pr, err := database.GetMergeRequest(t.Context(), "acme", "widget", 1)
+	pr, err := database.GetMergeRequest(t.Context(), "github", "github.com", "acme", "widget", 1)
 	require.NoError(err)
 	assert.Equal(db.MergeRequestStateClosed, pr.State)
 	assertTimePtrEqualsUTC(t, pr.ClosedAt, handlerNow)
@@ -6952,7 +6954,7 @@ func TestAPIReopenPR(t *testing.T) {
 	ctx := t.Context()
 
 	// Close it first.
-	repo, err := database.GetRepoByOwnerName(ctx, "acme", "widget")
+	repo, err := database.GetRepoByIdentity(ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	now := time.Now()
 	require.NoError(database.UpdateMRState(ctx, repo.ID, 1, "closed", nil, &now))
@@ -6965,7 +6967,7 @@ func TestAPIReopenPR(t *testing.T) {
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
 
-	pr, err := database.GetMergeRequest(ctx, "acme", "widget", 1)
+	pr, err := database.GetMergeRequest(ctx, "github", "github.com", "acme", "widget", 1)
 	require.NoError(err)
 	require.Equal(db.MergeRequestStateOpen, pr.State)
 	require.Nil(pr.ClosedAt, "closed_at should be cleared on reopen")
@@ -6977,7 +6979,7 @@ func TestAPIClosePRRejectsMerged(t *testing.T) {
 	seedPR(t, database, "acme", "widget", 1)
 	ctx := t.Context()
 
-	repo, err := database.GetRepoByOwnerName(ctx, "acme", "widget")
+	repo, err := database.GetRepoByIdentity(ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	now := time.Now()
 	require.NoError(database.UpdateMRState(ctx, repo.ID, 1, "merged", &now, &now))
@@ -7020,7 +7022,7 @@ func TestAPICloseIssue(t *testing.T) {
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
 
-	issue, err := database.GetIssue(t.Context(), "acme", "widget", 5)
+	issue, err := database.GetIssue(t.Context(), "github", "github.com", "acme", "widget", 5)
 	require.NoError(err)
 	require.Equal("closed", issue.State)
 	assertTimePtrEqualsUTC(t, issue.ClosedAt, handlerNow)
@@ -7039,7 +7041,7 @@ func TestAPIReopenIssue(t *testing.T) {
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
 
-	issue, err := database.GetIssue(t.Context(), "acme", "widget", 5)
+	issue, err := database.GetIssue(t.Context(), "github", "github.com", "acme", "widget", 5)
 	require.NoError(err)
 	require.Equal("open", issue.State)
 	require.Nil(issue.ClosedAt, "closed_at should be cleared on reopen")
@@ -7109,7 +7111,7 @@ func TestAPISyncPRDoesNotOverwriteNewerStateChange(t *testing.T) {
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
 
-	closedPR, err := database.GetMergeRequest(t.Context(), "acme", "widget", 1)
+	closedPR, err := database.GetMergeRequest(t.Context(), "github", "github.com", "acme", "widget", 1)
 	require.NoError(err)
 	require.Equal(db.MergeRequestStateClosed, closedPR.State)
 	require.NotNil(closedPR.ClosedAt)
@@ -7128,7 +7130,7 @@ func TestAPISyncPRDoesNotOverwriteNewerStateChange(t *testing.T) {
 	}
 	require.True(completed, "timed out waiting for stale PR sync")
 
-	finalPR, err := database.GetMergeRequest(t.Context(), "acme", "widget", 1)
+	finalPR, err := database.GetMergeRequest(t.Context(), "github", "github.com", "acme", "widget", 1)
 	require.NoError(err)
 	assert.Equal(db.MergeRequestStateClosed, finalPR.State)
 	assert.NotNil(finalPR.ClosedAt)
@@ -7189,7 +7191,7 @@ func TestAPISyncPRPreservesCIStatusWhileRefreshingCI(t *testing.T) {
 
 	srv, database := setupTestServerWithMock(t, mock)
 	seedPR(t, database, "acme", "widget", 1, withSeedPRHeadSHA("abc123"))
-	repo, err := database.GetRepoByOwnerName(t.Context(), "acme", "widget")
+	repo, err := database.GetRepoByIdentity(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	require.NotNil(repo)
 	existingChecksJSON := `[{"name":"tests","status":"completed","conclusion":"success"}]`
@@ -7278,7 +7280,7 @@ func TestAPISyncPRClearsCIWhenHeadSHAChanges(t *testing.T) {
 
 	srv, database := setupTestServerWithMock(t, mock)
 	seedPR(t, database, "acme", "widget", 1, withSeedPRHeadSHA("oldhead"))
-	repo, err := database.GetRepoByOwnerName(t.Context(), "acme", "widget")
+	repo, err := database.GetRepoByIdentity(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	require.NotNil(repo)
 	existingChecksJSON := `[{"name":"tests","status":"completed","conclusion":"success"}]`
@@ -7291,7 +7293,7 @@ func TestAPISyncPRClearsCIWhenHeadSHAChanges(t *testing.T) {
 	// upserts, so without an explicit clear it would survive a
 	// head-SHA change.
 	require.NoError(database.UpdateMRDetailFetched(
-		t.Context(), "github.com", "acme", "widget", 1, true,
+		t.Context(), "github", "github.com", "acme", "widget", 1, true,
 	))
 	client := setupTestClient(t, srv)
 
@@ -7552,7 +7554,7 @@ func TestAPIReadyForReviewDoesNotGetRevertedByStaleSync(t *testing.T) {
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
 
-	readyPR, err := database.GetMergeRequest(t.Context(), "acme", "widget", 1)
+	readyPR, err := database.GetMergeRequest(t.Context(), "github", "github.com", "acme", "widget", 1)
 	require.NoError(err)
 	require.False(readyPR.IsDraft)
 	assert.True(readyPR.UpdatedAt.Equal(readyUpdatedAt))
@@ -7571,7 +7573,7 @@ func TestAPIReadyForReviewDoesNotGetRevertedByStaleSync(t *testing.T) {
 	}
 	require.True(completed, "timed out waiting for stale draft sync")
 
-	finalPR, err := database.GetMergeRequest(t.Context(), "acme", "widget", 1)
+	finalPR, err := database.GetMergeRequest(t.Context(), "github", "github.com", "acme", "widget", 1)
 	require.NoError(err)
 	assert.False(finalPR.IsDraft)
 	assert.Equal("ready for review", finalPR.Title)
@@ -7683,7 +7685,7 @@ func TestAPIMarkDraftDoesNotGetRevertedByStaleSync(t *testing.T) {
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
 
-	draftPR, err := database.GetMergeRequest(t.Context(), "acme", "widget", 1)
+	draftPR, err := database.GetMergeRequest(t.Context(), "github", "github.com", "acme", "widget", 1)
 	require.NoError(err)
 	require.True(draftPR.IsDraft)
 	assert.True(draftPR.UpdatedAt.After(staleUpdatedAt))
@@ -7702,7 +7704,7 @@ func TestAPIMarkDraftDoesNotGetRevertedByStaleSync(t *testing.T) {
 	}
 	require.True(completed, "timed out waiting for stale draft sync")
 
-	finalPR, err := database.GetMergeRequest(t.Context(), "acme", "widget", 1)
+	finalPR, err := database.GetMergeRequest(t.Context(), "github", "github.com", "acme", "widget", 1)
 	require.NoError(err)
 	assert.True(finalPR.IsDraft)
 	assert.Equal("ready PR", finalPR.Title)
@@ -7767,7 +7769,7 @@ func TestAPISyncIssueDoesNotOverwriteNewerStateChange(t *testing.T) {
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
 
-	closedIssue, err := database.GetIssue(t.Context(), "acme", "widget", 5)
+	closedIssue, err := database.GetIssue(t.Context(), "github", "github.com", "acme", "widget", 5)
 	require.NoError(err)
 	require.Equal("closed", closedIssue.State)
 	require.NotNil(closedIssue.ClosedAt)
@@ -7786,7 +7788,7 @@ func TestAPISyncIssueDoesNotOverwriteNewerStateChange(t *testing.T) {
 	}
 	require.True(completed, "timed out waiting for stale issue sync")
 
-	finalIssue, err := database.GetIssue(t.Context(), "acme", "widget", 5)
+	finalIssue, err := database.GetIssue(t.Context(), "github", "github.com", "acme", "widget", 5)
 	require.NoError(err)
 	assert.Equal("closed", finalIssue.State)
 	assert.NotNil(finalIssue.ClosedAt)
@@ -7867,7 +7869,7 @@ func TestAPIListPullsSearchByNumber(t *testing.T) {
 	seedPR(t, database, "acme", "widget", 290, withSeedPRTitle("another change"))
 	seedPR(t, database, "tools", "worker", 301, withSeedPRTitle("repair bug"))
 	seedPR(t, database, "docs", "reader", 302, withSeedPRTitle("can't reproduce"))
-	repo, err := database.GetRepoByOwnerName(ctx, "acme", "widget")
+	repo, err := database.GetRepoByIdentity(ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	require.NoError(database.ReplaceMergeRequestLabels(ctx, repo.ID, prID, []db.Label{{
 		PlatformID: 200,
@@ -7932,7 +7934,7 @@ func TestAPIListIssuesSearchByNumber(t *testing.T) {
 	seedIssueOnHost(t, database, "github.com", "acme", "widget", 290, "open", "another change")
 	seedIssueOnHost(t, database, "github.com", "tools", "worker", 301, "open", "triage bug")
 	seedIssueOnHost(t, database, "github.com", "docs", "reader", 302, "open", "O'Reilly reference")
-	repo, err := database.GetRepoByOwnerName(ctx, "acme", "widget")
+	repo, err := database.GetRepoByIdentity(ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	require.NoError(database.ReplaceIssueLabels(ctx, repo.ID, issueID, []db.Label{{
 		PlatformID: 300,
@@ -8129,7 +8131,7 @@ func TestAPIListPullsCasefoldsRepoNames(t *testing.T) {
 	assert.Equal("foo", (*resp.JSON200)[0].RepoName)
 }
 
-func TestAPIListPullsFiltersHostedNestedRepoPath(t *testing.T) {
+func TestAPIListPullsFiltersProviderQualifiedHostedNestedRepoPath(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
 	srv, database := setupTestServerWithRepos(t, &mockGH{}, []ghclient.RepoRef{
@@ -8141,7 +8143,7 @@ func TestAPIListPullsFiltersHostedNestedRepoPath(t *testing.T) {
 	seedPROnHost(t, database, "ghe.example.com", "other", "repo", 2)
 
 	client := setupTestClient(t, srv)
-	repo := "ghe.example.com/Group/SubGroup/Project.Special"
+	repo := "github|ghe.example.com/Group/SubGroup/Project.Special"
 	resp, err := client.HTTP.ListPullsWithResponse(t.Context(), &generated.ListPullsParams{
 		Repo: &repo,
 	})
@@ -8229,13 +8231,13 @@ func TestAPIGetIssueAcceptsMixedCaseRepoPath(t *testing.T) {
 	require.Equal("widget", resp.JSON200.RepoName)
 }
 
-func TestAPIListIssuesAcceptsMixedCaseRepoFilter(t *testing.T) {
+func TestAPIListIssuesAcceptsMixedCaseProviderQualifiedRepoFilter(t *testing.T) {
 	require := require.New(t)
 	srv, database := setupTestServer(t)
 	seedIssue(t, database, "acme", "widget", 5, "open")
 	client := setupTestClient(t, srv)
 
-	repo := "Acme/Widget"
+	repo := "github|github.com/Acme/Widget"
 	resp, err := client.HTTP.ListIssuesWithResponse(
 		t.Context(), &generated.ListIssuesParams{Repo: &repo},
 	)
@@ -8247,7 +8249,7 @@ func TestAPIListIssuesAcceptsMixedCaseRepoFilter(t *testing.T) {
 	require.Equal("widget", (*resp.JSON200)[0].RepoName)
 }
 
-func TestAPIListIssuesAcceptsHostQualifiedRepoFilter(t *testing.T) {
+func TestAPIListIssuesAcceptsProviderAndHostQualifiedRepoFilter(t *testing.T) {
 	require := require.New(t)
 	assert := Assert.New(t)
 
@@ -8256,7 +8258,7 @@ func TestAPIListIssuesAcceptsHostQualifiedRepoFilter(t *testing.T) {
 	seedIssueOnHost(t, database, "ghe.example.com", "acme", "widget", 7, "open", "Enterprise issue")
 	client := setupTestClient(t, srv)
 
-	repo := "ghe.example.com/acme/widget"
+	repo := "github|ghe.example.com/acme/widget"
 	resp, err := client.HTTP.ListIssuesWithResponse(
 		t.Context(), &generated.ListIssuesParams{Repo: &repo},
 	)
@@ -8270,7 +8272,7 @@ func TestAPIListIssuesAcceptsHostQualifiedRepoFilter(t *testing.T) {
 	assert.EqualValues(7, (*resp.JSON200)[0].Number)
 }
 
-func TestAPIListIssuesFiltersHostedNestedRepoPath(t *testing.T) {
+func TestAPIListIssuesFiltersProviderQualifiedHostedNestedRepoPath(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
 
@@ -8290,7 +8292,7 @@ func TestAPIListIssuesFiltersHostedNestedRepoPath(t *testing.T) {
 	)
 	client := setupTestClient(t, srv)
 
-	repo := "ghe.example.com/Group/SubGroup/Project.Special"
+	repo := "github|ghe.example.com/Group/SubGroup/Project.Special"
 	resp, err := client.HTTP.ListIssuesWithResponse(
 		t.Context(), &generated.ListIssuesParams{Repo: &repo},
 	)
@@ -8606,7 +8608,7 @@ func TestAPICreateWorkspaceRejectsEmptyProviderForAmbiguousRepo(t *testing.T) {
 	resp, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
-			Provider:     &provider,
+			Provider:     provider,
 			PlatformHost: "forge.example.com",
 			Owner:        "acme",
 			Name:         "widget",
@@ -8622,7 +8624,7 @@ func TestAPICreateWorkspaceRejectsEmptyProviderForAmbiguousRepo(t *testing.T) {
 	assert.Equal("body.provider", problem.Details["field"])
 }
 
-func TestAPICreateWorkspaceAllowsOmittedProviderForUnambiguousRepo(t *testing.T) {
+func TestAPICreateWorkspaceRejectsOmittedProviderForUnambiguousRepo(t *testing.T) {
 	require := require.New(t)
 	ctx := t.Context()
 
@@ -8662,7 +8664,7 @@ func TestAPICreateWorkspaceAllowsOmittedProviderForUnambiguousRepo(t *testing.T)
 	rr := httptest.NewRecorder()
 	srv.ServeHTTP(rr, req)
 
-	require.Equal(http.StatusAccepted, rr.Code, rr.Body.String())
+	require.Equal(http.StatusUnprocessableEntity, rr.Code, rr.Body.String())
 }
 
 func TestAPISyncIssueUsesPlatformHostQuery(t *testing.T) {
@@ -8776,9 +8778,7 @@ func TestAPISyncIssueUsesPlatformHostQuery(t *testing.T) {
 	require.NotNil(withOps.Repo.Operations,
 		"issue sync response must include repo.operations")
 
-	githubRepo, err := database.GetRepoByHostOwnerName(
-		ctx, "github.com", "acme", "widget",
-	)
+	githubRepo, err := database.GetRepoByIdentity(ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	require.NotNil(githubRepo)
 	githubIssue, err := database.GetIssueByRepoIDAndNumber(
@@ -8788,9 +8788,7 @@ func TestAPISyncIssueUsesPlatformHostQuery(t *testing.T) {
 	require.NotNil(githubIssue)
 	assert.Equal("GitHub stale issue", githubIssue.Title)
 
-	ghesRepo, err := database.GetRepoByHostOwnerName(
-		ctx, "ghe.example.com", "acme", "widget",
-	)
+	ghesRepo, err := database.GetRepoByIdentity(ctx, db.GitHubRepoIdentity("ghe.example.com", "acme", "widget"))
 	require.NoError(err)
 	require.NotNil(ghesRepo)
 	ghesIssue, err := database.GetIssueByRepoIDAndNumber(
@@ -8895,9 +8893,7 @@ func TestAPISetIssueStateUsesPlatformHostBody(t *testing.T) {
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
 
-	githubRepo, err := database.GetRepoByHostOwnerName(
-		ctx, "github.com", "acme", "widget",
-	)
+	githubRepo, err := database.GetRepoByIdentity(ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	require.NotNil(githubRepo)
 	githubIssue, err := database.GetIssueByRepoIDAndNumber(
@@ -8907,9 +8903,7 @@ func TestAPISetIssueStateUsesPlatformHostBody(t *testing.T) {
 	require.NotNil(githubIssue)
 	assert.Equal("open", githubIssue.State)
 
-	ghesRepo, err := database.GetRepoByHostOwnerName(
-		ctx, "ghe.example.com", "acme", "widget",
-	)
+	ghesRepo, err := database.GetRepoByIdentity(ctx, db.GitHubRepoIdentity("ghe.example.com", "acme", "widget"))
 	require.NoError(err)
 	require.NotNil(ghesRepo)
 	ghesIssue, err := database.GetIssueByRepoIDAndNumber(
@@ -11497,7 +11491,7 @@ func TestAPIClosePR422NilFallbackPayloadDoesNotCorruptDB(t *testing.T) {
 	}
 	srv, database := setupTestServerWithMock(t, mock)
 	seedPR(t, database, "acme", "widget", 1)
-	before, err := database.GetMergeRequest(t.Context(), "acme", "widget", 1)
+	before, err := database.GetMergeRequest(t.Context(), "github", "github.com", "acme", "widget", 1)
 	require.NoError(err)
 	require.NotNil(before)
 
@@ -11509,7 +11503,7 @@ func TestAPIClosePR422NilFallbackPayloadDoesNotCorruptDB(t *testing.T) {
 	require.NoError(err)
 	require.Equal(http.StatusBadGateway, resp.StatusCode())
 
-	after, err := database.GetMergeRequest(t.Context(), "acme", "widget", 1)
+	after, err := database.GetMergeRequest(t.Context(), "github", "github.com", "acme", "widget", 1)
 	require.NoError(err)
 	require.NotNil(after)
 	assert.Equal(before.State, after.State)
@@ -11530,7 +11524,7 @@ func TestAPICloseIssue422NilFallbackPayloadDoesNotCorruptDB(t *testing.T) {
 	}
 	srv, database := setupTestServerWithMock(t, mock)
 	seedIssue(t, database, "acme", "widget", 5, "open")
-	before, err := database.GetIssue(t.Context(), "acme", "widget", 5)
+	before, err := database.GetIssue(t.Context(), "github", "github.com", "acme", "widget", 5)
 	require.NoError(err)
 	require.NotNil(before)
 
@@ -11542,7 +11536,7 @@ func TestAPICloseIssue422NilFallbackPayloadDoesNotCorruptDB(t *testing.T) {
 	require.NoError(err)
 	require.Equal(http.StatusBadGateway, resp.StatusCode())
 
-	after, err := database.GetIssue(t.Context(), "acme", "widget", 5)
+	after, err := database.GetIssue(t.Context(), "github", "github.com", "acme", "widget", 5)
 	require.NoError(err)
 	require.NotNil(after)
 	assert.Equal(before.State, after.State)
@@ -11584,7 +11578,7 @@ func TestAPIClosePR422AlreadyClosed(t *testing.T) {
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
 
-	pr, _ := database.GetMergeRequest(t.Context(), "acme", "widget", 1)
+	pr, _ := database.GetMergeRequest(t.Context(), "github", "github.com", "acme", "widget", 1)
 	require.Equal(db.MergeRequestStateClosed, pr.State)
 }
 
@@ -11627,7 +11621,7 @@ func TestAPIMarkPRDraftPersistsDraftFlag(t *testing.T) {
 	}
 	srv, database := setupTestServerWithMock(t, mock)
 	seedPR(t, database, "acme", "widget", 1)
-	before, err := database.GetMergeRequest(t.Context(), "acme", "widget", 1)
+	before, err := database.GetMergeRequest(t.Context(), "github", "github.com", "acme", "widget", 1)
 	require.NoError(err)
 	require.NotNil(before)
 	before.CommentCount = 7
@@ -11651,7 +11645,7 @@ func TestAPIMarkPRDraftPersistsDraftFlag(t *testing.T) {
 	assert.Equal("acme", gotOwner)
 	assert.Equal("widget", gotRepo)
 	assert.Equal(1, gotNumber)
-	pr, err := database.GetMergeRequest(t.Context(), "acme", "widget", 1)
+	pr, err := database.GetMergeRequest(t.Context(), "github", "github.com", "acme", "widget", 1)
 	require.NoError(err)
 	require.NotNil(pr)
 	assert.Equal(db.MergeRequestStateOpen, pr.State)
@@ -11752,7 +11746,7 @@ func TestAPIReadyForReviewStaleStateRefreshesAndReturnsSuccess(t *testing.T) {
 	srv, database := setupTestServerWithMock(t, mock)
 	seedPR(t, database, "acme", "widget", 1)
 
-	pr, err := database.GetMergeRequest(t.Context(), "acme", "widget", 1)
+	pr, err := database.GetMergeRequest(t.Context(), "github", "github.com", "acme", "widget", 1)
 	require.NoError(err)
 	require.NotNil(pr)
 	pr.IsDraft = true
@@ -11767,7 +11761,7 @@ func TestAPIReadyForReviewStaleStateRefreshesAndReturnsSuccess(t *testing.T) {
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
 
-	pr, err = database.GetMergeRequest(t.Context(), "acme", "widget", 1)
+	pr, err = database.GetMergeRequest(t.Context(), "github", "github.com", "acme", "widget", 1)
 	require.NoError(err)
 	require.NotNil(pr)
 	require.False(pr.IsDraft)
@@ -11820,7 +11814,7 @@ func TestAPIReadyForReview404RefreshesStaleDraftState(t *testing.T) {
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
 
-	pr, err := database.GetMergeRequest(t.Context(), "acme", "widget", 1)
+	pr, err := database.GetMergeRequest(t.Context(), "github", "github.com", "acme", "widget", 1)
 	require.NoError(err)
 	require.NotNil(pr)
 	require.False(pr.IsDraft)
@@ -12048,7 +12042,7 @@ func TestAPICloseIssue422AlreadyClosed(t *testing.T) {
 	require.NoError(err)
 	require.Equal(http.StatusOK, resp.StatusCode())
 
-	issue, _ := database.GetIssue(t.Context(), "acme", "widget", 5)
+	issue, _ := database.GetIssue(t.Context(), "github", "github.com", "acme", "widget", 5)
 	require.Equal("closed", issue.State)
 }
 
@@ -13197,7 +13191,7 @@ func TestAPIGitHubPublishReviewDraftSendsCommentsThroughServer(t *testing.T) {
 	}
 	srv, database := setupTestServerWithMock(t, mock)
 	seedPR(t, database, "acme", "widget", 42)
-	mr, err := database.GetMergeRequest(ctx, "acme", "widget", 42)
+	mr, err := database.GetMergeRequest(ctx, "github", "github.com", "acme", "widget", 42)
 	require.NoError(err)
 	require.NotNil(mr)
 	require.NoError(database.UpdateDiffSHAs(ctx, mr.RepoID, 42, "github-head", "base", "merge-base"))
@@ -19263,7 +19257,7 @@ func TestAPIListActivityCanHideDefaultBranchActivity(t *testing.T) {
 	assert.Equal(int64(1), (*resp.JSON200.Items)[0].ItemNumber)
 }
 
-func TestAPIListActivityAcceptsHostQualifiedRepoFilter(t *testing.T) {
+func TestAPIListActivityAcceptsProviderAndHostQualifiedRepoFilter(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
 	srv, database := setupTestServer(t)
@@ -19273,7 +19267,7 @@ func TestAPIListActivityAcceptsHostQualifiedRepoFilter(t *testing.T) {
 	seedPROnHost(t, database, "ghe.example.com", "acme", "widget", 2)
 
 	since := time.Now().UTC().AddDate(0, 0, -7).Format(time.RFC3339)
-	repo := "ghe.example.com/acme/widget"
+	repo := "github|ghe.example.com/acme/widget"
 	resp, err := client.HTTP.ListActivityWithResponse(
 		t.Context(), &generated.ListActivityParams{Since: &since, Repo: &repo},
 	)
@@ -19331,7 +19325,7 @@ func TestAPIListActivityAcceptsProviderQualifiedRepoFilter(t *testing.T) {
 	}
 }
 
-func TestAPIListActivityKeepsProviderNamedHostsHostQualified(t *testing.T) {
+func TestAPIListActivityKeepsProviderNamedHostsProviderQualified(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
 	srv, database := setupTestServer(t)
@@ -19349,7 +19343,7 @@ func TestAPIListActivityKeepsProviderNamedHostsHostQualified(t *testing.T) {
 	seedPROnHost(t, database, "github.com", "acme", "widget", 2)
 
 	since := time.Now().UTC().AddDate(0, 0, -7).Format(time.RFC3339)
-	repo := "gitea/acme/team/widget"
+	repo := "github|gitea/acme/team/widget"
 	resp, err := client.HTTP.ListActivityWithResponse(
 		ctx, &generated.ListActivityParams{Since: &since, Repo: &repo},
 	)
@@ -19458,7 +19452,7 @@ func seedStackedPRState(
 func runStackDetection(t *testing.T, database *db.DB, owner, name string) {
 	t.Helper()
 	ctx := t.Context()
-	repo, err := database.GetRepoByOwnerName(ctx, owner, name)
+	repo, err := database.GetRepoByIdentity(ctx, db.GitHubRepoIdentity("github.com", owner, name))
 	require.NoError(t, err)
 	require.NotNil(t, repo)
 	require.NoError(t, stacks.RunDetection(ctx, database, repo.ID))
@@ -19600,7 +19594,7 @@ func TestAPIStackBaseConflictMarksDownstreamPRsDirty(t *testing.T) {
 	seedStackedPR(t, database, "acme", "widget", 11, "feat/api-retry", "feat/api-base", db.MergeRequestStateOpen, "success", "APPROVED")
 	runStackDetection(t, database, "acme", "widget")
 
-	repo, err := database.GetRepoByOwnerName(ctx, "acme", "widget")
+	repo, err := database.GetRepoByIdentity(ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	require.NotNil(repo)
 	assert.Empty(requireMR(t, database, repo.ID, 11).MergeableState)
@@ -20713,9 +20707,7 @@ func TestListWorkspacesIncludesItemLastActivityAt(t *testing.T) {
 	client, database, _, _ := setupTestServerWithWorkspaces(t)
 	ctx := t.Context()
 
-	repo, err := database.GetRepoByHostOwnerName(
-		ctx, "github.com", "acme", "widget",
-	)
+	repo, err := database.GetRepoByIdentity(ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	require.NotNil(repo)
 
@@ -25337,6 +25329,7 @@ func createReadyWorkspace(
 	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",
@@ -25695,6 +25688,7 @@ func TestWorkspaceCRUDE2E(t *testing.T) {
 	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",
@@ -25771,6 +25765,7 @@ func TestWorkspaceRetryErroredWorkspaceE2E(t *testing.T) {
 	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",
@@ -25813,6 +25808,7 @@ func TestWorkspaceRetryReadyWorkspaceConflictE2E(t *testing.T) {
 	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",
@@ -25867,6 +25863,7 @@ func TestWorkspaceReadyStatusImpliesReadySetupEventE2E(t *testing.T) {
 	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",
@@ -25908,6 +25905,7 @@ func TestWorkspaceCreateNotFound(t *testing.T) {
 	resp, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "nope",
 			Name:         "missing",
@@ -25921,6 +25919,7 @@ func TestWorkspaceCreateNotFound(t *testing.T) {
 	resp2, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",
@@ -25944,6 +25943,7 @@ func TestWorkspaceMRDetailHasWorkspace(t *testing.T) {
 	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",
@@ -25987,6 +25987,7 @@ func TestWorkspaceCreateDuplicate(t *testing.T) {
 	ctx := t.Context()
 
 	body := generated.CreateWorkspaceInputBody{
+		Provider:     "github",
 		PlatformHost: "github.com",
 		Owner:        "acme",
 		Name:         "widget",
@@ -26030,6 +26031,7 @@ func TestWorkspaceCreateFetchesCloneThroughAPI(t *testing.T) {
 	createResp, err := fixture.client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",
@@ -26276,6 +26278,7 @@ func TestWorkspaceCreatePRAndIssueCanCoexistForSameRepoNumber(t *testing.T) {
 	prResp, err := fixture.client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",
@@ -26410,9 +26413,7 @@ func prepareIssueWorkspaceAssociationFixture(
 	ctx := context.Background()
 
 	seedIssue(t, fixture.database, "acme", "widget", 7, "open")
-	repo, err := fixture.database.GetRepoByHostOwnerName(
-		ctx, "github.com", "acme", "widget",
-	)
+	repo, err := fixture.database.GetRepoByIdentity(ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	require.NotNil(repo)
 
@@ -26692,9 +26693,7 @@ func TestWorkspaceManualRefreshDiscoversAndSyncsAssociatedPR(t *testing.T) {
 	require.NotNil(stored.AssociatedPRNumber)
 	assert.Equal(42, *stored.AssociatedPRNumber)
 
-	repo, err := fixture.database.GetRepoByHostOwnerName(
-		ctx, "github.com", "acme", "widget",
-	)
+	repo, err := fixture.database.GetRepoByIdentity(ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	require.NotNil(repo)
 	pr, err := fixture.database.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, 42)
@@ -26810,6 +26809,7 @@ func TestWorkspaceCreateUsesPRBranchAndFallbackBranch(t *testing.T) {
 	createResp1, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",
@@ -26844,6 +26844,7 @@ func TestWorkspaceCreateUsesPRBranchAndFallbackBranch(t *testing.T) {
 	createResp2, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",
@@ -26904,6 +26905,7 @@ func TestWorkspaceCreateWithLocalBaseUsesPullRefWhenHeadBranchDeleted(
 	createResp, err := fixture.client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: platformHost,
 			Owner:        "acme",
 			Name:         "widget",
@@ -26979,7 +26981,7 @@ func TestWorkspaceCreateGitLabUsesSpecificMergeRequestHeadRefE2E(
 	createResp, err := fixture.client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
-			Provider:     &provider,
+			Provider:     provider,
 			PlatformHost: platformHost,
 			Owner:        "acme",
 			Name:         "widget",
@@ -27038,6 +27040,7 @@ func TestWorkspaceCreateReusesExistingWorktreeThroughAPI(t *testing.T) {
 	createResp, err := fixture.client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: platformHost,
 			Owner:        "acme",
 			Name:         "widget",
@@ -27098,6 +27101,7 @@ func TestWorkspaceRetryReusesExistingLocalHeadBranchThroughAPI(t *testing.T) {
 	createResp, err := fixture.client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: platformHost,
 			Owner:        "acme",
 			Name:         "widget",
@@ -27209,6 +27213,7 @@ func TestWorkspaceCreateSameRepoHeadCloneURLTracksOriginBranchE2E(t *testing.T) 
 	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",
@@ -27268,6 +27273,7 @@ func TestWorkspaceCreatePortQualifiedHostTracksOriginBranchE2E(t *testing.T) {
 	createResp, err := fixture.client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "ghe.example.com:8443",
 			Owner:        "acme",
 			Name:         "widget",
@@ -27302,9 +27308,7 @@ func TestWorkspaceDeleteRecreatesForkBranchName(t *testing.T) {
 	client, database, _, remotePath := setupTestServerWithWorkspaces(t)
 	ctx := t.Context()
 
-	repo, err := database.GetRepoByHostOwnerName(
-		ctx, "github.com", "acme", "widget",
-	)
+	repo, err := database.GetRepoByIdentity(ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	require.NotNil(repo)
 
@@ -27335,6 +27339,7 @@ func TestWorkspaceDeleteRecreatesForkBranchName(t *testing.T) {
 	create1, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",
@@ -27362,6 +27367,7 @@ func TestWorkspaceDeleteRecreatesForkBranchName(t *testing.T) {
 	create2, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",
@@ -27395,6 +27401,7 @@ func TestWorkspaceDeletePreservesUserCreatedBranch(t *testing.T) {
 	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",
@@ -27567,6 +27574,7 @@ func TestWorkspaceCreatePreservesExistingLocalPreferredBranch(t *testing.T) {
 	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",
@@ -27624,6 +27632,7 @@ func TestWorkspaceDeleteLegacySyntheticBranchAllowsRecreate(t *testing.T) {
 	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",
@@ -27661,6 +27670,7 @@ func TestWorkspaceDeleteLegacySyntheticBranchAllowsRecreate(t *testing.T) {
 	recreateResp, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",
@@ -27810,6 +27820,7 @@ func TestWorkspaceDeleteDirty(t *testing.T) {
 	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",
@@ -27859,6 +27870,7 @@ func TestWorkspaceDeleteDirty(t *testing.T) {
 	create2, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",
@@ -27909,7 +27921,7 @@ func TestAPIEditPRTitleAndBody(t *testing.T) {
 	require.Equal(http.StatusOK, rr.Code)
 
 	mr, err := database.GetMergeRequest(
-		t.Context(), "acme", "widget", 1,
+		t.Context(), "github", "github.com", "acme", "widget", 1,
 	)
 	require.NoError(err)
 	require.Equal("updated title", mr.Title)
@@ -27927,7 +27939,7 @@ func TestAPIEditPRTitleOnly(t *testing.T) {
 	require.Equal(http.StatusOK, rr.Code)
 
 	mr, err := database.GetMergeRequest(
-		t.Context(), "acme", "widget", 1,
+		t.Context(), "github", "github.com", "acme", "widget", 1,
 	)
 	require.NoError(err)
 	require.Equal("new title", mr.Title)
@@ -27945,7 +27957,7 @@ func TestAPIEditPRBodyOnly(t *testing.T) {
 	require.Equal(http.StatusOK, rr.Code)
 
 	mr, err := database.GetMergeRequest(
-		t.Context(), "acme", "widget", 1,
+		t.Context(), "github", "github.com", "acme", "widget", 1,
 	)
 	require.NoError(err)
 	require.Equal("Test PR #1", mr.Title)
@@ -27963,7 +27975,7 @@ func TestAPIEditPRClearBody(t *testing.T) {
 	require.Equal(http.StatusOK, rr.Code)
 
 	mr, err := database.GetMergeRequest(
-		t.Context(), "acme", "widget", 1,
+		t.Context(), "github", "github.com", "acme", "widget", 1,
 	)
 	require.NoError(err)
 	require.Equal("Test PR #1", mr.Title)
@@ -28000,7 +28012,7 @@ func TestAPIEditPRPreservesDerivedFields(t *testing.T) {
 	ctx := t.Context()
 
 	// Seed non-default derived fields so we can detect clobbering.
-	repo, err := database.GetRepoByOwnerName(ctx, "acme", "widget")
+	repo, err := database.GetRepoByIdentity(ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	now := time.Now().UTC().Truncate(time.Second)
 	require.NoError(database.UpdateMRDerivedFields(ctx, repo.ID, 1, db.MRDerivedFields{
@@ -28015,7 +28027,7 @@ func TestAPIEditPRPreservesDerivedFields(t *testing.T) {
 		map[string]string{"title": "changed title"})
 	require.Equal(http.StatusOK, rr.Code)
 
-	after, err := database.GetMergeRequest(ctx, "acme", "widget", 1)
+	after, err := database.GetMergeRequest(ctx, "github", "github.com", "acme", "widget", 1)
 	require.NoError(err)
 	require.Equal("changed title", after.Title)
 	require.Equal(7, after.CommentCount)
@@ -28036,7 +28048,7 @@ func TestAPIEditIssueBodyOnly(t *testing.T) {
 		map[string]string{"body": "- [x] task done"})
 	require.Equal(http.StatusOK, rr.Code)
 
-	issue, err := database.GetIssue(t.Context(), "acme", "widget", 5)
+	issue, err := database.GetIssue(t.Context(), "github", "github.com", "acme", "widget", 5)
 	require.NoError(err)
 	require.NotNil(issue)
 	require.Equal("Test Issue", issue.Title)
@@ -28053,7 +28065,7 @@ func TestAPIEditIssueTitleAndBody(t *testing.T) {
 		map[string]string{"title": "new title", "body": "new body"})
 	require.Equal(http.StatusOK, rr.Code)
 
-	issue, err := database.GetIssue(t.Context(), "acme", "widget", 5)
+	issue, err := database.GetIssue(t.Context(), "github", "github.com", "acme", "widget", 5)
 	require.NoError(err)
 	require.NotNil(issue)
 	require.Equal("new title", issue.Title)

--- a/internal/server/apitest/api_test.go
+++ b/internal/server/apitest/api_test.go
@@ -73,13 +73,13 @@ func TestAPIGetPullAcceptsMixedCaseRepoPath(t *testing.T) {
 	require.Equal("widget", resp.JSON200.RepoName)
 }
 
-func TestAPIListPullsAcceptsMixedCaseRepoFilter(t *testing.T) {
+func TestAPIListPullsAcceptsMixedCaseProviderQualifiedRepoFilter(t *testing.T) {
 	require := require.New(t)
 	srv, database := setupTestServer(t)
 	seedPR(t, database, "acme", "widget", 1)
 	client := setupTestClient(t, srv)
 
-	repo := "Acme/Widget"
+	repo := "github|github.com/Acme/Widget"
 	resp, err := client.HTTP.ListPullsWithResponse(
 		t.Context(), &generated.ListPullsParams{Repo: &repo},
 	)
@@ -91,7 +91,7 @@ func TestAPIListPullsAcceptsMixedCaseRepoFilter(t *testing.T) {
 	require.Equal("widget", (*resp.JSON200)[0].RepoName)
 }
 
-func TestAPIListPullsAcceptsHostQualifiedRepoFilter(t *testing.T) {
+func TestAPIListPullsAcceptsProviderAndHostQualifiedRepoFilter(t *testing.T) {
 	require := require.New(t)
 	assert := Assert.New(t)
 
@@ -100,7 +100,7 @@ func TestAPIListPullsAcceptsHostQualifiedRepoFilter(t *testing.T) {
 	seedPROnHost(t, database, "ghe.example.com", "acme", "widget", 2)
 	client := setupTestClient(t, srv)
 
-	repo := "ghe.example.com/acme/widget"
+	repo := "github|ghe.example.com/acme/widget"
 	resp, err := client.HTTP.ListPullsWithResponse(
 		t.Context(), &generated.ListPullsParams{Repo: &repo},
 	)
@@ -165,7 +165,7 @@ func TestAPIListPullsStateFilter(t *testing.T) {
 	seedPR(t, database, "acme", "widget", 2)
 	seedPR(t, database, "acme", "widget", 3)
 
-	repo, _ := database.GetRepoByOwnerName(ctx, "acme", "widget")
+	repo, _ := database.GetRepoByIdentity(ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	now := time.Now()
 	require.NoError(database.UpdateMRState(ctx, repo.ID, 2, "closed", nil, &now))
 	require.NoError(database.UpdateMRState(ctx, repo.ID, 3, "merged", &now, &now))
@@ -309,7 +309,7 @@ func TestAPISyncIssuePersistsAssigneesFromProvider(t *testing.T) {
 
 	require.NoError(syncer.SyncIssue(ctx, "acme", "widget", issueNumber))
 
-	repo, err := database.GetRepoByOwnerName(ctx, "acme", "widget")
+	repo, err := database.GetRepoByIdentity(ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	require.NotNil(repo)
 	persisted, err := database.GetIssueByRepoIDAndNumber(ctx, repo.ID, issueNumber)

--- a/internal/server/apitest/assignees_reviewers_test.go
+++ b/internal/server/apitest/assignees_reviewers_test.go
@@ -86,7 +86,7 @@ func TestAPISetPullAssigneesUpdatesProviderAndPersists(t *testing.T) {
 	require.NoError(json.Unmarshal(rr.Body.Bytes(), &body))
 	assert.Equal([]string{"alice", "bob"}, body.Assignees)
 
-	repo, err := database.GetRepoByOwnerName(t.Context(), "acme", "widget")
+	repo, err := database.GetRepoByIdentity(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	require.NotNil(repo)
 	pr, err := database.GetMergeRequestByRepoIDAndNumber(t.Context(), repo.ID, 1)
@@ -127,7 +127,7 @@ func TestAPISetPullAssigneesClearsAssignees(t *testing.T) {
 	require.NoError(json.Unmarshal(rr.Body.Bytes(), &body))
 	assert.Empty(body.Assignees)
 
-	repo, err := database.GetRepoByOwnerName(t.Context(), "acme", "widget")
+	repo, err := database.GetRepoByIdentity(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	pr, err := database.GetMergeRequestByRepoIDAndNumber(t.Context(), repo.ID, 1)
 	require.NoError(err)
@@ -151,7 +151,7 @@ func TestAPISetIssueAssigneesUpdatesProviderAndPersists(t *testing.T) {
 	require.NoError(json.Unmarshal(rr.Body.Bytes(), &body))
 	assert.Equal([]string{"dana"}, body.Assignees)
 
-	repo, err := database.GetRepoByOwnerName(t.Context(), "acme", "widget")
+	repo, err := database.GetRepoByIdentity(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	issue, err := database.GetIssueByRepoIDAndNumber(t.Context(), repo.ID, 7)
 	require.NoError(err)

--- a/internal/server/apitest/fixtures_test.go
+++ b/internal/server/apitest/fixtures_test.go
@@ -247,7 +247,7 @@ func seedIssueWithLabels(t *testing.T, database *db.DB, owner, name string, numb
 	t.Helper()
 	ctx := t.Context()
 	issueID := seedIssue(t, database, owner, name, number, state)
-	repo, err := database.GetRepoByOwnerName(ctx, owner, name)
+	repo, err := database.GetRepoByIdentity(ctx, db.GitHubRepoIdentity("github.com", owner, name))
 	require.NoError(t, err)
 	require.NoError(t, database.ReplaceIssueLabels(ctx, repo.ID, issueID, labels))
 	return issueID

--- a/internal/server/apitest/labels_test.go
+++ b/internal/server/apitest/labels_test.go
@@ -111,7 +111,7 @@ func seedRepoLabelCatalog(
 ) int64 {
 	t.Helper()
 	ctx := t.Context()
-	repo, err := database.GetRepoByOwnerName(ctx, owner, name)
+	repo, err := database.GetRepoByIdentity(ctx, db.GitHubRepoIdentity("github.com", owner, name))
 	require.NoError(t, err)
 	require.NotNil(t, repo)
 	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
@@ -126,7 +126,7 @@ func TestAPIListRepoLabelsRefreshesStaleCatalogFromProvider(t *testing.T) {
 	require := require.New(t)
 	srv, database, _, _ := setupLabelTestServer(t)
 	seedPR(t, database, "acme", "widget", 1)
-	repo, err := database.GetRepoByOwnerName(t.Context(), "acme", "widget")
+	repo, err := database.GetRepoByIdentity(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	require.NotNil(repo)
 

--- a/internal/server/e2etest/github_app_split_auth_test.go
+++ b/internal/server/e2etest/github_app_split_auth_test.go
@@ -312,7 +312,7 @@ repository_selection = "all"
 
 	// The repo settings refresh resolved with the PAT, so the stored
 	// merge permission must reflect the user, not the read-only app.
-	dbRepo, err := database.GetRepoByOwnerName(t.Context(), "kenn-io", "middleman")
+	dbRepo, err := database.GetRepoByIdentity(t.Context(), db.GitHubRepoIdentity("github.com", "kenn-io", "middleman"))
 	require.NoError(err)
 	assert.True(dbRepo.ViewerCanMerge,
 		"viewer_can_merge must come from the PAT-visible permissions, not the app's")

--- a/internal/server/e2etest/settings_test.go
+++ b/internal/server/e2etest/settings_test.go
@@ -836,6 +836,7 @@ func TestRepoConfigAPIE2EWorkspaceCreationUsesWorktreeBasePath(t *testing.T) {
 	createResp, err := client.CreateWorkspaceWithResponse(
 		t.Context(),
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: platformHost,
 			Owner:        "acme",
 			Name:         "widget",
@@ -887,6 +888,7 @@ func TestRepoConfigAPIE2EWorkspaceCreationUsesFallbackBranchWhenPreferredChecked
 	createResp, err := client.CreateWorkspaceWithResponse(
 		t.Context(),
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: platformHost,
 			Owner:        "acme",
 			Name:         "widget",
@@ -949,7 +951,7 @@ func TestWorkspaceAPIE2ERejectsEmptyProviderForAmbiguousRepo(t *testing.T) {
 	resp, err := client.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
-			Provider:     &provider,
+			Provider:     provider,
 			PlatformHost: "forge.example.com",
 			Owner:        "acme",
 			Name:         "widget",

--- a/internal/server/e2etest/sync_cooldown_test.go
+++ b/internal/server/e2etest/sync_cooldown_test.go
@@ -170,7 +170,7 @@ name = "third"
 
 	status, body := postJSON(
 		t, client,
-		baseURL+"/api/v1/sync?priority_repo=github.com/acme/third,github.com/acme/second",
+		baseURL+"/api/v1/sync?priority_repo=github|github.com/acme/third,github|github.com/acme/second",
 		nil,
 	)
 	require.Equal(http.StatusAccepted, status, body)
@@ -236,7 +236,7 @@ platform_host = "gitea"
 
 	status, body := postJSON(
 		t, client,
-		baseURL+"/api/v1/sync?priority_repo=gitea/acme/second",
+		baseURL+"/api/v1/sync?priority_repo=github|gitea/acme/second",
 		nil,
 	)
 	require.Equal(http.StatusAccepted, status, body)
@@ -551,8 +551,8 @@ func waitForRepoSynced(
 
 	var repo *db.Repo
 	require.Eventually(func() bool {
-		got, err := database.GetRepoByOwnerName(
-			t.Context(), owner, name,
+		got, err := database.GetRepoByIdentity(
+			t.Context(), db.GitHubRepoIdentity("github.com", owner, name),
 		)
 		if err != nil || got == nil || got.LastSyncCompletedAt == nil {
 			return false

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -13,6 +13,7 @@ import (
 )
 
 type repoNumberPathRef struct {
+	repoID       int64
 	owner        string
 	name         string
 	number       int
@@ -21,10 +22,11 @@ type repoNumberPathRef struct {
 
 type starredRequest struct {
 	ItemType     string `json:"item_type"`
+	Provider     string `json:"provider"`
 	Owner        string `json:"owner"`
 	Name         string `json:"name"`
 	Number       int    `json:"number"`
-	PlatformHost string `json:"platform_host,omitempty"`
+	PlatformHost string `json:"platform_host"`
 }
 
 var errRepoNotFound = errors.New("repo not found")
@@ -151,31 +153,6 @@ func (s *Server) filterConfiguredRepos(repos []db.Repo) []db.Repo {
 	return filtered
 }
 
-// lookupRepo resolves a repository from owner/name and optional host inputs.
-func (s *Server) lookupRepo(
-	ctx context.Context,
-	owner, name, platformHost string,
-) (*db.Repo, error) {
-	var (
-		repo *db.Repo
-		err  error
-	)
-	if platformHost != "" {
-		repo, err = s.db.GetRepoByHostOwnerName(
-			ctx, platformHost, owner, name,
-		)
-	} else {
-		repo, err = s.db.GetRepoByOwnerName(ctx, owner, name)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("get repo: %w", err)
-	}
-	if repo == nil {
-		return nil, errRepoNotFound
-	}
-	return repo, nil
-}
-
 func (s *Server) filterConfiguredRepoSummaries(
 	summaries []db.RepoSummary,
 ) []db.RepoSummary {
@@ -214,87 +191,43 @@ func (s *Server) isConfiguredRepoTracked(repo db.Repo) bool {
 	return ok
 }
 
-// lookupRepoID resolves a repository from owner/name inputs and returns a
-// stable not-found error for handlers that need repo identity only.
-func (s *Server) lookupRepoID(ctx context.Context, owner, name string) (int64, error) {
-	repo, err := s.lookupRepo(ctx, owner, name, "")
-	if err != nil {
-		return 0, err
-	}
-	return repo.ID, nil
-}
-
-func (s *Server) lookupRepoIDOnHost(
-	ctx context.Context,
-	owner, name, platformHost string,
-) (int64, error) {
-	repo, err := s.lookupRepo(ctx, owner, name, platformHost)
-	if err != nil {
-		return 0, err
-	}
-	return repo.ID, nil
-}
-
 // lookupMRID resolves the internal MR id from the common route tuple.
 func (s *Server) lookupMRID(ctx context.Context, ref repoNumberPathRef) (int64, error) {
-	if ref.platformHost != "" {
-		repoID, err := s.lookupRepoIDOnHost(
-			ctx, ref.owner, ref.name, ref.platformHost,
-		)
-		if err != nil {
-			return 0, err
-		}
-		mr, err := s.db.GetMergeRequestByRepoIDAndNumber(
-			ctx, repoID, ref.number,
-		)
-		if err != nil {
-			return 0, err
-		}
-		if mr == nil {
-			return 0, fmt.Errorf(
-				"pull request %s/%s#%d not found",
-				ref.owner, ref.name, ref.number,
-			)
-		}
-		return mr.ID, nil
-	}
-	return s.db.GetMRIDByRepoAndNumber(ctx, ref.owner, ref.name, ref.number)
-}
-
-// lookupIssueID resolves the internal issue id from the common route tuple.
-func (s *Server) lookupIssueID(ctx context.Context, ref repoNumberPathRef) (int64, error) {
-	if ref.platformHost == "" {
-		return s.db.GetIssueIDByRepoAndNumber(
-			ctx, ref.owner, ref.name, ref.number,
-		)
-	}
-	repoID, err := s.lookupRepoIDOnHost(
-		ctx, ref.owner, ref.name, ref.platformHost,
+	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(
+		ctx, ref.repoID, ref.number,
 	)
 	if err != nil {
 		return 0, err
 	}
+	if mr == nil {
+		return 0, fmt.Errorf(
+			"pull request %s/%s#%d on %s not found",
+			ref.owner, ref.name, ref.number, ref.platformHost,
+		)
+	}
+	return mr.ID, nil
+}
+
+// lookupIssueID resolves the internal issue id from the common route tuple.
+func (s *Server) lookupIssueID(ctx context.Context, ref repoNumberPathRef) (int64, error) {
 	issue, err := s.db.GetIssueByRepoIDAndNumber(
-		ctx, repoID, ref.number,
+		ctx, ref.repoID, ref.number,
 	)
 	if err != nil {
 		return 0, err
 	}
 	if issue == nil {
 		return 0, fmt.Errorf(
-			"issue %s/%s#%d not found", ref.owner, ref.name, ref.number,
+			"issue %s/%s#%d on %s not found", ref.owner, ref.name, ref.number, ref.platformHost,
 		)
 	}
 	return issue.ID, nil
 }
 
 // parseRepoFilter splits the shared repo query parameter used by pull, issue,
-// and activity list endpoints. The accepted wire forms are owner/name,
-// platform_host/repo_path, and provider|platform_host/repo_path. Slash-qualified
-// provider labels such as provider/platform_host/repo_path are display-only and
-// intentionally parse as host-qualified values to keep nested repo paths
-// unambiguous. Repo paths can contain slashes, so hosted filters keep everything
-// after the host together as repoPath.
+// and activity list endpoints. Repository filters must be provider-qualified as
+// provider|platform_host/repo_path. Repo paths can contain slashes, so hosted
+// filters keep everything after the host together as repoPath.
 func parseRepoFilter(repo string) (provider, platformHost, owner, name, repoPath string) {
 	repo = strings.Trim(repo, "/ ")
 	if providerPart, hostedPath, ok := strings.Cut(repo, "|"); ok {
@@ -308,17 +241,7 @@ func parseRepoFilter(repo string) (provider, platformHost, owner, name, repoPath
 		}
 		return provider, parts[0], "", "", strings.Join(parts[1:], "/")
 	}
-
-	parts := strings.Split(repo, "/")
-	switch len(parts) {
-	case 2:
-		return "", "", parts[0], parts[1], ""
-	default:
-		if len(parts) >= 3 {
-			return "", parts[0], "", "", strings.Join(parts[1:], "/")
-		}
-		return "", "", "", "", ""
-	}
+	return "", "", "", "", ""
 }
 
 func parseRepoFilters(repo string) []db.RepoFilter {
@@ -342,6 +265,20 @@ func parseRepoFilters(repo string) []db.RepoFilter {
 		}
 	}
 	return filters
+}
+
+func hasInvalidRepoFilter(repo string) bool {
+	for part := range strings.SplitSeq(repo, ",") {
+		part = strings.Trim(part, "/ ")
+		if part == "" {
+			continue
+		}
+		_, _, owner, _, repoPath := parseRepoFilter(part)
+		if owner == "" && repoPath == "" {
+			return true
+		}
+	}
+	return false
 }
 
 func validateStarredRequest(body starredRequest) bool {

--- a/internal/server/helpers_test.go
+++ b/internal/server/helpers_test.go
@@ -16,9 +16,7 @@ func TestParseRepoFiltersAcceptsProviderQualifiedRepoPath(t *testing.T) {
 	}}, parseRepoFilters("Gitea|github.com/acme/widgets"))
 }
 
-func TestParseRepoFiltersKeepsProviderNamedHostsHostQualified(t *testing.T) {
-	assert.Equal(t, []db.RepoFilter{{
-		PlatformHost: "gitea",
-		RepoPath:     "acme/team/widgets",
-	}}, parseRepoFilters("gitea/acme/team/widgets"))
+func TestParseRepoFiltersRejectsUnqualifiedRepoPath(t *testing.T) {
+	assert.Empty(t, parseRepoFilters("gitea/acme/team/widgets"))
+	assert.Empty(t, parseRepoFilters("acme/widgets"))
 }

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -32,7 +32,7 @@ import (
 )
 
 type listPullsInput struct {
-	Repo    string `query:"repo" doc:"Repository filter. Accepts owner/name, platform_host/repo_path, comma-separated values, or provider|platform_host/repo_path for provider-qualified matches."`
+	Repo    string `query:"repo" doc:"Repository filter. Accepts provider|platform_host/repo_path, with comma-separated values for multiple repositories."`
 	State   string `query:"state"`
 	Kanban  string `query:"kanban"`
 	Starred bool   `query:"starred"`
@@ -173,7 +173,7 @@ type resolveDiffReviewThreadInput struct {
 }
 
 type listIssuesInput struct {
-	Repo     string `query:"repo" doc:"Repository filter. Accepts owner/name, platform_host/repo_path, comma-separated values, or provider|platform_host/repo_path for provider-qualified matches."`
+	Repo     string `query:"repo" doc:"Repository filter. Accepts provider|platform_host/repo_path, with comma-separated values for multiple repositories."`
 	State    string `query:"state"`
 	Starred  bool   `query:"starred"`
 	Q        string `query:"q"`
@@ -465,7 +465,7 @@ type getStackForPROutput = bodyOutput[stackContextResponse]
 
 type createWorkspaceInput struct {
 	Body struct {
-		Provider     string `json:"provider,omitempty"`
+		Provider     string `json:"provider"`
 		PlatformHost string `json:"platform_host"`
 		Owner        string `json:"owner"`
 		Name         string `json:"name"`
@@ -600,7 +600,7 @@ type workspaceDiffRequest struct {
 }
 
 type listActivityInput struct {
-	Repo   string   `query:"repo" doc:"Repository filter. Accepts owner/name, platform_host/repo_path, comma-separated values, or provider|platform_host/repo_path for provider-qualified matches."`
+	Repo   string   `query:"repo" doc:"Repository filter. Accepts provider|platform_host/repo_path, with comma-separated values for multiple repositories."`
 	Types  []string `query:"types"`
 	Search string   `query:"search"`
 	After  string   `query:"after"`
@@ -608,7 +608,7 @@ type listActivityInput struct {
 }
 
 type triggerSyncInput struct {
-	PriorityRepos []string `query:"priority_repo" doc:"Optional repository filters to sync first. Accepts repeated values or comma-separated values. Each value may be provider-qualified as provider|platform_host/owner/name, host-qualified as platform_host/owner/name, or bare as owner/name; bare values match the first tracked repo with that repo path."`
+	PriorityRepos []string `query:"priority_repo" doc:"Optional repository filters to sync first. Accepts repeated provider|platform_host/repo_path values or comma-separated values."`
 }
 
 type listActivityOutput = bodyOutput[activityResponse]
@@ -1341,6 +1341,9 @@ func (s *Server) listPulls(ctx context.Context, input *listPullsInput) (*listPul
 			)
 		}
 	}
+	if hasInvalidRepoFilter(input.Repo) {
+		return nil, problemValidation("query.repo", "repo filter must be provider|platform_host/repo_path")
+	}
 
 	opts := db.ListMergeRequestsOpts{
 		State:       input.State,
@@ -1350,16 +1353,6 @@ func (s *Server) listPulls(ctx context.Context, input *listPullsInput) (*listPul
 		Limit:       input.Limit,
 		Offset:      input.Offset,
 		RepoFilters: parseRepoFilters(input.Repo),
-	}
-	if len(opts.RepoFilters) == 0 {
-		if _, platformHost, owner, name, repoPath := parseRepoFilter(input.Repo); repoPath != "" {
-			opts.PlatformHost = platformHost
-			opts.RepoPath = repoPath
-		} else if owner != "" {
-			opts.PlatformHost = platformHost
-			opts.RepoOwner = owner
-			opts.RepoName = name
-		}
 	}
 
 	mrs, err := s.db.ListMergeRequests(ctx, opts)
@@ -1834,6 +1827,7 @@ func (s *Server) setKanbanState(ctx context.Context, input *setKanbanStateInput)
 		return nil, providerRouteLookupError(err)
 	}
 	ref := repoNumberPathRef{
+		repoID:       repo.ID,
 		owner:        repo.Owner,
 		name:         repo.Name,
 		number:       input.Number,
@@ -2056,6 +2050,7 @@ func (s *Server) postComment(ctx context.Context, input *postCommentInput) (*pos
 	}
 
 	ref := repoNumberPathRef{
+		repoID:       repo.ID,
 		owner:        repo.Owner,
 		name:         repo.Name,
 		number:       input.Number,
@@ -2099,6 +2094,7 @@ func (s *Server) editComment(ctx context.Context, input *editCommentInput) (*edi
 	}
 
 	ref := repoNumberPathRef{
+		repoID:       repo.ID,
 		owner:        repo.Owner,
 		name:         repo.Name,
 		number:       input.Number,
@@ -2316,6 +2312,9 @@ func (s *Server) listIssues(ctx context.Context, input *listIssuesInput) (*listI
 			)
 		}
 	}
+	if hasInvalidRepoFilter(input.Repo) {
+		return nil, problemValidation("query.repo", "repo filter must be provider|platform_host/repo_path")
+	}
 
 	opts := db.ListIssuesOpts{
 		State:       input.State,
@@ -2325,16 +2324,6 @@ func (s *Server) listIssues(ctx context.Context, input *listIssuesInput) (*listI
 		Limit:       input.Limit,
 		Offset:      input.Offset,
 		RepoFilters: parseRepoFilters(input.Repo),
-	}
-	if len(opts.RepoFilters) == 0 {
-		if _, platformHost, owner, name, repoPath := parseRepoFilter(input.Repo); repoPath != "" {
-			opts.PlatformHost = platformHost
-			opts.RepoPath = repoPath
-		} else if owner != "" {
-			opts.PlatformHost = platformHost
-			opts.RepoOwner = owner
-			opts.RepoName = name
-		}
 	}
 
 	issues, err := s.db.ListIssues(ctx, opts)
@@ -2546,8 +2535,9 @@ func (s *Server) postIssueComment(ctx context.Context, input *postIssueCommentIn
 	}
 
 	ref := repoNumberPathRef{
-		owner:        input.Owner,
-		name:         input.Name,
+		repoID:       repo.ID,
+		owner:        repo.Owner,
+		name:         repo.Name,
 		number:       input.Number,
 		platformHost: repo.PlatformHost,
 	}
@@ -2590,8 +2580,9 @@ func (s *Server) editIssueComment(ctx context.Context, input *editIssueCommentIn
 	}
 
 	ref := repoNumberPathRef{
-		owner:        input.Owner,
-		name:         input.Name,
+		repoID:       repo.ID,
+		owner:        repo.Owner,
+		name:         repo.Name,
 		number:       input.Number,
 		platformHost: repo.PlatformHost,
 	}
@@ -3691,26 +3682,6 @@ func matchPriorityRepo(
 		}
 		return ghclient.RepoRef{}, false
 	}
-
-	for _, repo := range tracked {
-		if strings.EqualFold(repoPathForPriority(repo), filter) {
-			return repo, true
-		}
-	}
-
-	parts := strings.Split(filter, "/")
-	if len(parts) < 3 {
-		return ghclient.RepoRef{}, false
-	}
-
-	host := parts[0]
-	path := strings.Join(parts[1:], "/")
-	for _, repo := range tracked {
-		if strings.EqualFold(repoHostForPriority(repo), host) &&
-			strings.EqualFold(repoPathForPriority(repo), path) {
-			return repo, true
-		}
-	}
 	return ghclient.RepoRef{}, false
 }
 
@@ -4050,6 +4021,10 @@ func (s *Server) enqueueIssueSync(ctx context.Context, input *issueRepoNumberInp
 }
 
 func (s *Server) listActivity(ctx context.Context, input *listActivityInput) (*listActivityOutput, error) {
+	if hasInvalidRepoFilter(input.Repo) {
+		return nil, problemValidation("query.repo", "repo filter must be provider|platform_host/repo_path")
+	}
+
 	opts := db.ListActivityOpts{
 		Repo:        input.Repo,
 		RepoFilters: parseRepoFilters(input.Repo),
@@ -4387,26 +4362,21 @@ func (s *Server) lookupStarredRepoID(ctx context.Context, body starredRequest) (
 		return 0, problemValidation("body.item_type",
 			"item_type must be 'pr' or 'issue'", "pr", "issue")
 	}
-
-	var (
-		repoID int64
-		err    error
-	)
-	if body.PlatformHost != "" {
-		repoID, err = s.lookupRepoIDOnHost(
-			ctx, body.Owner, body.Name, body.PlatformHost,
-		)
-	} else {
-		repoID, err = s.lookupRepoID(ctx, body.Owner, body.Name)
+	if strings.TrimSpace(body.Provider) == "" {
+		return 0, problemValidation("body.provider", "provider is required")
 	}
+
+	repo, err := s.lookupRepoByProviderRoute(
+		ctx, body.Provider, body.PlatformHost, body.Owner, body.Name,
+	)
 	if err != nil {
 		if errors.Is(err, errRepoNotFound) {
 			return 0, problemNotFound(CodeRepoNotFound, err.Error(), nil)
 		}
-		return 0, problemInternal("repo lookup failed")
+		return 0, providerRouteLookupError(err)
 	}
 
-	return repoID, nil
+	return repo.ID, nil
 }
 
 // --- Commits ---
@@ -4945,28 +4915,8 @@ func (s *Server) createWorkspaceProvider(
 		}
 		return provider, nil
 	}
-	count, err := s.db.CountReposByHostOwnerName(
-		ctx, input.Body.PlatformHost, input.Body.Owner, input.Body.Name,
-	)
-	if err != nil {
-		return "", problemInternal("count matching repos: " + err.Error())
-	}
-	if count > 1 {
-		return "", problemValidation(
-			"body.provider",
-			"provider is required when multiple providers share this host and repository",
-		)
-	}
-	repo, err := s.db.GetRepoByHostOwnerName(
-		ctx, input.Body.PlatformHost, input.Body.Owner, input.Body.Name,
-	)
-	if err != nil {
-		return "", problemInternal("lookup workspace repo: " + err.Error())
-	}
-	if repo == nil {
-		return "", nil
-	}
-	return repo.Platform, nil
+	_ = ctx
+	return "", problemValidation("body.provider", "provider is required")
 }
 
 func (s *Server) runWorkspaceSetup(ws *workspace.Workspace) {
@@ -5925,12 +5875,12 @@ func (s *Server) workspaceMergeTargetBranch(
 		prNumber = *summary.AssociatedPRNumber
 	}
 
-	repo, err := s.db.GetRepoByHostOwnerName(
-		ctx,
-		summary.PlatformHost,
-		summary.RepoOwner,
-		summary.RepoName,
-	)
+	repo, err := s.db.GetRepoByIdentity(ctx, db.RepoIdentity{
+		Platform:     summary.Platform,
+		PlatformHost: summary.PlatformHost,
+		Owner:        summary.RepoOwner,
+		Name:         summary.RepoName,
+	})
 	if err != nil {
 		return "", false, problemInternal("get workspace repo failed")
 	}

--- a/internal/server/notifications.go
+++ b/internal/server/notifications.go
@@ -34,10 +34,11 @@ func (s *Server) listNotifications(ctx context.Context, input *listNotifications
 	}
 	opts.Repos = trackedRepos
 	if input.Repo != "" {
-		host, owner, name, ok := db.ParseNotificationRepo(input.Repo)
+		platform, host, owner, name, ok := db.ParseNotificationRepo(input.Repo)
 		if !ok {
-			return nil, huma.Error400BadRequest("repo must be owner/name or platform_host/owner/name")
+			return nil, huma.Error400BadRequest("repo must be provider|platform_host/owner/name")
 		}
+		opts.Platform = platform
 		opts.PlatformHost = host
 		opts.RepoOwner = owner
 		opts.RepoName = name

--- a/internal/server/notifications_test.go
+++ b/internal/server/notifications_test.go
@@ -333,7 +333,7 @@ func TestNotificationsAPIUsesActiveTrackedRepos(t *testing.T) {
 	assert.Equal(map[string]int{"github.com/acme/widget": 1}, listed.Summary.ByRepo)
 }
 
-func TestNotificationsAPIAcceptsHostQualifiedRepoFilter(t *testing.T) {
+func TestNotificationsAPIAcceptsProviderAndHostQualifiedRepoFilter(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	database := openTestDB(t)
@@ -368,7 +368,7 @@ func TestNotificationsAPIAcceptsHostQualifiedRepoFilter(t *testing.T) {
 	ts := httptest.NewServer(s)
 	defer ts.Close()
 
-	resp, err := http.Get(ts.URL + "/api/v1/notifications?state=all&repo=ghe.example.com/acme/widget")
+	resp, err := http.Get(ts.URL + "/api/v1/notifications?state=all&repo=github|ghe.example.com/acme/widget")
 	require.NoError(err)
 	defer resp.Body.Close()
 	require.Equal(http.StatusOK, resp.StatusCode)

--- a/internal/server/tmux_wrapper_test.go
+++ b/internal/server/tmux_wrapper_test.go
@@ -322,6 +322,7 @@ func TestTmuxWrapperNewSession(t *testing.T) {
 	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
 		t.Context(),
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",
@@ -382,6 +383,7 @@ func TestWorkspaceResponseIncludesTmuxWorkingState(t *testing.T) {
 	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",
@@ -479,6 +481,7 @@ func TestWorkspaceResponseTracksTmuxOutputActivity(t *testing.T) {
 	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",
@@ -594,6 +597,7 @@ func TestListWorkspacesFetchesTmuxActivityConcurrently(t *testing.T) {
 	createResp1, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",
@@ -608,6 +612,7 @@ func TestListWorkspacesFetchesTmuxActivityConcurrently(t *testing.T) {
 	createResp2, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",
@@ -1100,6 +1105,7 @@ func TestWorkspaceCreateFailureLogsAndPersistsAuditEvent(t *testing.T) {
 	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",
@@ -1180,6 +1186,7 @@ func TestWorkspaceShutdownCancellationPersistsFailureViaAPI(t *testing.T) {
 	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",
@@ -1294,6 +1301,7 @@ func TestWorkspaceSetupFailureRollbackCleansWorktreeViaAPI(t *testing.T) {
 	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",
@@ -1385,6 +1393,7 @@ func TestWorkspaceRetryWhileCreatingQueuesAndRunsAfterFailureViaAPI(t *testing.T
 	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",
@@ -1489,6 +1498,7 @@ func TestWorkspaceShutdownCancellationDoesNotPersistAfterDeadlineBudgetExhausted
 	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
 		t.Context(),
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",
@@ -1594,6 +1604,7 @@ func TestTmuxWrapperAttachSession(t *testing.T) {
 	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",
@@ -1716,6 +1727,7 @@ func TestWorkspaceSetupResourceExhaustionGetsHelpfulErrorViaAPI(t *testing.T) {
 	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",
@@ -1765,6 +1777,7 @@ func TestWorkspaceListWaitsForSubprocessCapacityThenCompletesViaAPI(t *testing.T
 	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",
@@ -1843,6 +1856,7 @@ func TestWorkspaceSetupLimiterTimeoutSurfacesResourceExhaustionViaAPI(t *testing
 	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",
@@ -1911,6 +1925,7 @@ func TestTmuxWrapperKillSession(t *testing.T) {
 	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",
@@ -1987,6 +2002,7 @@ func TestDeleteWorkspacePreservesRowWhenTmuxKillFails(t *testing.T) {
 	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",
@@ -2060,6 +2076,7 @@ func TestDeleteWorkspaceTreatsTmuxServerExitAsGoneE2E(t *testing.T) {
 	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
 		t.Context(),
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",
@@ -2130,6 +2147,7 @@ func TestDeleteErroredWorkspaceAllowsUnavailableTmux(t *testing.T) {
 	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",
@@ -2209,6 +2227,7 @@ func attachWebsocketAndExpectInternalError(t *testing.T, scriptBody string) {
 	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",

--- a/internal/server/workspace_concurrent_e2e_test.go
+++ b/internal/server/workspace_concurrent_e2e_test.go
@@ -48,6 +48,7 @@ func TestWorkspaceConcurrentSameRepoOperationsE2E(t *testing.T) {
 			resp, err := client.HTTP.CreateWorkspaceWithResponse(
 				ctx,
 				generated.CreateWorkspaceInputBody{
+					Provider:     "github",
 					PlatformHost: "github.com",
 					Owner:        "acme",
 					Name:         "widget",

--- a/internal/server/workspacetest/fixtures_test.go
+++ b/internal/server/workspacetest/fixtures_test.go
@@ -258,6 +258,7 @@ func createReadyWorkspace(
 	createResp, err := client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
 			PlatformHost: "github.com",
 			Owner:        "acme",
 			Name:         "widget",

--- a/internal/stacks/detect_test.go
+++ b/internal/stacks/detect_test.go
@@ -307,7 +307,7 @@ func TestRunDetection(t *testing.T) {
 	err = RunDetection(ctx, d, repoID)
 	require.NoError(err)
 
-	stack, members, err := d.GetStackForPR(ctx, "org", "repo", 101)
+	stack, members, err := d.GetStackForPR(ctx, "github", "github.com", "org", "repo", 101)
 	require.NoError(err)
 	assert.NotNil(stack)
 	assert.Equal("auth", stack.Name)
@@ -360,7 +360,7 @@ func TestRunDetection_ForkBranchNameDoesNotShadowUpstreamStackBranch(t *testing.
 
 	require.NoError(RunDetection(ctx, d, repoID))
 
-	stack, members, err := d.GetStackForPR(ctx, "org", "repo", 101)
+	stack, members, err := d.GetStackForPR(ctx, "github", "github.com", "org", "repo", 101)
 	require.NoError(err)
 	require.NotNil(stack)
 	assert.Equal("auth", stack.Name)
@@ -400,7 +400,7 @@ func TestRunDetection_FullyMergedStackDeleted(t *testing.T) {
 
 	err = RunDetection(ctx, d, repoID)
 	require.NoError(err)
-	stack, _, err := d.GetStackForPR(ctx, "org", "repo", 100)
+	stack, _, err := d.GetStackForPR(ctx, "github", "github.com", "org", "repo", 100)
 	require.NoError(err)
 	assert.NotNil(stack, "stack should exist while PRs are open")
 
@@ -425,7 +425,7 @@ func TestRunDetection_FullyMergedStackDeleted(t *testing.T) {
 	err = RunDetection(ctx, d, repoID)
 	require.NoError(err)
 
-	stack2, _, err := d.GetStackForPR(ctx, "org", "repo", 100)
+	stack2, _, err := d.GetStackForPR(ctx, "github", "github.com", "org", "repo", 100)
 	require.NoError(err)
 	assert.Nil(stack2, "fully merged stack should be deleted")
 }

--- a/internal/testutil/dbtest/dbtest_test.go
+++ b/internal/testutil/dbtest/dbtest_test.go
@@ -22,7 +22,7 @@ func TestOpenUsesIsolatedCopiesOfCachedMigratedTemplate(t *testing.T) {
 	require.NoError(err)
 	require.NotZero(firstRepoID)
 
-	got, err := second.GetRepoByOwnerName(t.Context(), "acme", "widget")
+	got, err := second.GetRepoByIdentity(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	require.Nil(got)
 	require.Equal(1, templateBuildCountForTest())

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -1002,7 +1002,7 @@ func (m *Manager) workspaceRepo(
 ) (*db.Repo, error) {
 	provider = strings.TrimSpace(provider)
 	if provider == "" {
-		return m.db.GetRepoByHostOwnerName(ctx, platformHost, owner, name)
+		return nil, fmt.Errorf("provider is required")
 	}
 	kind, err := platform.NormalizeKind(provider)
 	if err != nil {

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -337,7 +337,7 @@ func TestCreateIssueDefaultBranchSluggified(t *testing.T) {
 
 			ws, err := mgr.CreateIssue(
 				ctx, "github.com", "acme", "widget", 7,
-				CreateIssueOptions{},
+				CreateIssueOptions{Provider: "github"},
 			)
 			require.NoError(err)
 			require.NotNil(ws)
@@ -361,7 +361,7 @@ func TestCreateIssueExplicitGitHeadRefBypassesSlug(t *testing.T) {
 
 	ws, err := mgr.CreateIssue(
 		ctx, "github.com", "acme", "widget", 7,
-		CreateIssueOptions{GitHeadRef: "custom/branch"},
+		CreateIssueOptions{Provider: "github", GitHeadRef: "custom/branch"},
 	)
 	require.NoError(err)
 	require.NotNil(ws)
@@ -390,7 +390,7 @@ func TestCreateIssueReuseLocalBaseBranchCheckedOutReturnsConflict(t *testing.T) 
 
 	ws, err := mgr.CreateIssue(
 		ctx, "github.com", "acme", "widget", 7,
-		CreateIssueOptions{ReuseExistingBranch: true},
+		CreateIssueOptions{Provider: "github", ReuseExistingBranch: true},
 	)
 
 	require.Nil(ws)
@@ -1396,7 +1396,7 @@ func TestSetupRefreshesConfiguredWorktreeBaseOriginHead(t *testing.T) {
 	mgr.SetWorktreeBasePathResolver(staticBaseResolver(localRepo))
 
 	ws, err := mgr.CreateIssue(
-		t.Context(), platformHost, "acme", "widget", 7, CreateIssueOptions{},
+		t.Context(), platformHost, "acme", "widget", 7, CreateIssueOptions{Provider: "github"},
 	)
 	require.NoError(err)
 	require.NoError(mgr.Setup(t.Context(), ws))

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -4177,7 +4177,7 @@ export interface components {
             name: string;
             owner: string;
             platform_host: string;
-            provider?: string;
+            provider: string;
         };
         CreateWorktreeFromMergeRequestInputBody: {
             /**
@@ -6483,7 +6483,8 @@ export interface components {
             /** Format: int64 */
             number: number;
             owner: string;
-            platform_host?: string;
+            platform_host: string;
+            provider: string;
         };
         SyncStatus: {
             /**
@@ -6784,7 +6785,7 @@ export interface operations {
     "list-activity": {
         parameters: {
             query?: {
-                /** @description Repository filter. Accepts owner/name, platform_host/repo_path, comma-separated values, or provider|platform_host/repo_path for provider-qualified matches. */
+                /** @description Repository filter. Accepts provider|platform_host/repo_path, with comma-separated values for multiple repositories. */
                 repo?: string;
                 types?: string[] | null;
                 search?: string;
@@ -10627,7 +10628,7 @@ export interface operations {
     "list-issues": {
         parameters: {
             query?: {
-                /** @description Repository filter. Accepts owner/name, platform_host/repo_path, comma-separated values, or provider|platform_host/repo_path for provider-qualified matches. */
+                /** @description Repository filter. Accepts provider|platform_host/repo_path, with comma-separated values for multiple repositories. */
                 repo?: string;
                 state?: string;
                 starred?: boolean;
@@ -12360,7 +12361,7 @@ export interface operations {
     "list-pulls": {
         parameters: {
             query?: {
-                /** @description Repository filter. Accepts owner/name, platform_host/repo_path, comma-separated values, or provider|platform_host/repo_path for provider-qualified matches. */
+                /** @description Repository filter. Accepts provider|platform_host/repo_path, with comma-separated values for multiple repositories. */
                 repo?: string;
                 state?: string;
                 kanban?: string;
@@ -14579,7 +14580,7 @@ export interface operations {
     "trigger-sync": {
         parameters: {
             query?: {
-                /** @description Optional repository filters to sync first. Accepts repeated values or comma-separated values. Each value may be provider-qualified as provider|platform_host/owner/name, host-qualified as platform_host/owner/name, or bare as owner/name; bare values match the first tracked repo with that repo path. */
+                /** @description Optional repository filters to sync first. Accepts repeated provider|platform_host/repo_path values or comma-separated values. */
                 priority_repo?: string[] | null;
             };
             header?: never;

--- a/packages/ui/src/components/detail/IssueDetail.svelte
+++ b/packages/ui/src/components/detail/IssueDetail.svelte
@@ -387,8 +387,13 @@
     const detail = issues.getIssueDetail();
     if (!detail) return;
     void issues.toggleIssueStar(
-      owner,
-      name,
+      {
+        provider,
+        platformHost,
+        owner,
+        name,
+        repoPath,
+      },
       number,
       detail.issue.Starred,
     );

--- a/packages/ui/src/components/sidebar/IssueItem.svelte
+++ b/packages/ui/src/components/sidebar/IssueItem.svelte
@@ -33,8 +33,13 @@
   function handleStarClick(e: MouseEvent): void {
     e.stopPropagation();
     void issues.toggleIssueStar(
-      issue.repo_owner ?? "",
-      issue.repo_name ?? "",
+      {
+        provider: issue.repo.provider,
+        platformHost: issue.repo.platform_host,
+        owner: issue.repo.owner,
+        name: issue.repo.name,
+        repoPath: issue.repo.repo_path,
+      },
       issue.Number,
       issue.Starred,
     );

--- a/packages/ui/src/components/sidebar/IssueList.svelte
+++ b/packages/ui/src/components/sidebar/IssueList.svelte
@@ -128,6 +128,7 @@
       && sel.owner === ref.owner
       && sel.name === ref.name
       && sel.number === ref.number
+      && sel.provider === ref.provider
       && sel.platformHost === ref.platformHost;
   }
 </script>
@@ -231,6 +232,7 @@
       {#if grouping.getGroupByRepo()}
         {#each [...issues.issuesByRepo().entries()] as [repo, repoIssues] (repo)}
           {@const collapsed = collapsedRepos.isCollapsed("issues", repo)}
+          {@const repoLabel = repoIssues[0]?.repo.repo_path ?? repo}
           <div class="repo-group">
             <button
               type="button"
@@ -246,7 +248,7 @@
               >
                 <polyline points="2,3 5,7 8,3" stroke-linecap="round" stroke-linejoin="round" />
               </svg>
-              <span class="repo-header__name">{repo}</span>
+              <span class="repo-header__name">{repoLabel}</span>
               <span class="repo-header__count">{repoIssues.length}</span>
             </button>
             {#if !collapsed}

--- a/packages/ui/src/components/sidebar/PullItem.svelte
+++ b/packages/ui/src/components/sidebar/PullItem.svelte
@@ -43,8 +43,13 @@
   function handleStarClick(e: MouseEvent): void {
     e.stopPropagation();
     void pulls.togglePRStar(
-      pr.repo_owner ?? "",
-      pr.repo_name ?? "",
+      {
+        provider: pr.repo.provider,
+        platformHost: pr.repo.platform_host,
+        owner: pr.repo.owner,
+        name: pr.repo.name,
+        repoPath: pr.repo.repo_path,
+      },
       pr.Number,
       pr.Starred,
     );

--- a/packages/ui/src/components/sidebar/PullList.svelte
+++ b/packages/ui/src/components/sidebar/PullList.svelte
@@ -214,7 +214,7 @@
       return [...pulls.pullsByRepo().entries()].map(([repo, prs]) => ({
         key: `repo:${repo}`,
         collapseKey: repo,
-        label: repo,
+        label: prs[0]?.repo.repo_path ?? repo,
         showRepo: false,
         items: prs,
       }));
@@ -264,7 +264,17 @@
       && sel.owner === ref.owner
       && sel.name === ref.name
       && sel.number === ref.number
+      && sel.provider === ref.provider
       && sel.platformHost === ref.platformHost;
+  }
+
+  function pullMatchesSelection(pr: PullRequest, sel: NonNullable<ReturnType<typeof pulls.getSelectedPR>>): boolean {
+    return pr.Number === sel.number
+      && pr.repo.provider === sel.provider
+      && pr.repo.platform_host === sel.platformHost
+      && pr.repo.repo_path === sel.repoPath
+      && pr.repo.owner === sel.owner
+      && pr.repo.name === sel.name;
   }
 
   const selectedPRGroup = $derived.by(() => {
@@ -272,12 +282,7 @@
     const groups = groupedPulls;
     if (sel === null || groups === null) return null;
     return groups.find((group) =>
-      group.items.some((p) =>
-        (p.repo_owner ?? "") === sel.owner
-        && (p.repo_name ?? "") === sel.name
-        && p.Number === sel.number
-        && (!sel.platformHost || p.platform_host === sel.platformHost),
-      ),
+      group.items.some((p) => pullMatchesSelection(p, sel)),
     ) ?? null;
   });
 
@@ -290,12 +295,7 @@
   const selectedVisiblePR = $derived.by(() => {
     const sel = pulls.getSelectedPR();
     if (sel === null) return null;
-    const pr = visiblePulls.find(
-      (p) => (p.repo_owner ?? "") === sel.owner
-        && (p.repo_name ?? "") === sel.name
-        && p.Number === sel.number
-        && (!sel.platformHost || p.platform_host === sel.platformHost),
-    );
+    const pr = visiblePulls.find((p) => pullMatchesSelection(p, sel));
     if (!pr) return null;
     // Collapsed grouped modes hide the selected PR row, so the files tab
     // renders the fallback file list instead of losing the diff sidebar.

--- a/packages/ui/src/routes.test.ts
+++ b/packages/ui/src/routes.test.ts
@@ -92,7 +92,9 @@ describe("route item builders", () => {
     ).toBe("/focus/host/ghe.example.com/issues/github/acme/widgets/7");
     expect(buildFocusListRoute({ itemType: "mrs" })).toBe("/focus/mrs");
     expect(buildFocusListRoute({ itemType: "issues" })).toBe("/focus/issues");
-    expect(buildFocusListRoute({ itemType: "mrs", repo: "acme/widgets" })).toBe("/focus/mrs?repo=acme%2Fwidgets");
+    expect(buildFocusListRoute({ itemType: "mrs", repo: "github|github.com/acme/widgets" })).toBe(
+      "/focus/mrs?repo=github%7Cgithub.com%2Facme%2Fwidgets",
+    );
   });
 
   it("builds routed item routes for normal and focus surfaces", () => {

--- a/packages/ui/src/stores/detail.svelte.ts
+++ b/packages/ui/src/stores/detail.svelte.ts
@@ -1,5 +1,10 @@
 import type { KanbanStatus, Label, PullDetail } from "../api/types.js";
-import { providerItemPath, providerRouteParams } from "../api/provider-routes.js";
+import {
+  providerDefaultHost,
+  providerItemPath,
+  providerRouteParams,
+  type ProviderRouteRef,
+} from "../api/provider-routes.js";
 import type { MiddlemanClient } from "../types.js";
 import { showFlash } from "./flash.svelte.js";
 
@@ -27,8 +32,8 @@ export interface DetailStoreOptions {
   getPage?: () => string;
   pulls?: {
     loadPulls: (params?: unknown) => Promise<void>;
-    optimisticKanbanUpdate?: (owner: string, name: string, number: number, status: KanbanStatus) => void;
-    getPullKanbanStatus?: (owner: string, name: string, number: number) => KanbanStatus | undefined;
+    optimisticKanbanUpdate?: (ref: ProviderRouteRef, number: number, status: KanbanStatus) => void;
+    getPullKanbanStatus?: (ref: ProviderRouteRef, number: number) => KanbanStatus | undefined;
   };
   sync?: {
     subscribeSyncComplete: (cb: () => void) => () => void;
@@ -165,15 +170,6 @@ export function createDetailStore(opts: DetailStoreOptions) {
     };
   }
 
-  function isDetailShowing(owner: string, name: string, number: number): boolean {
-    return (
-      detail !== null &&
-      detail.repo_owner === owner &&
-      detail.repo_name === name &&
-      detail.merge_request.Number === number
-    );
-  }
-
   // Apply a fresh PullDetail from the server. When the user has an
   // unsynced local body edit on the same PR, keep that body so a
   // polling refresh can't revert a pending optimistic toggle. Match on
@@ -233,6 +229,12 @@ export function createDetailStore(opts: DetailStoreOptions) {
       platformHost: detail.repo.platform_host,
       repoPath: detail.repo.repo_path,
     });
+  }
+
+  function concretePlatformHost(ref: Pick<DetailRequestRef, "provider" | "platformHost">): string {
+    const host = ref.platformHost ?? providerDefaultHost(ref.provider);
+    if (!host) throw new Error("pull detail missing platform host");
+    return host;
   }
 
   async function refreshPullsIfActive(): Promise<void> {
@@ -480,8 +482,8 @@ export function createDetailStore(opts: DetailStoreOptions) {
     number: number,
     identity: DetailRequestOptions,
   ): Promise<void> {
-    if (!isDetailShowing(owner, name, number)) return;
     const ref = detailRequestRef(owner, name, number, identity);
+    if (!isDetailShowingRef(ref)) return;
     const key = prKey(ref);
     if (activeCIRefresh?.key === key) {
       return activeCIRefresh.promise;
@@ -536,10 +538,8 @@ export function createDetailStore(opts: DetailStoreOptions) {
     const seq = (kanbanSeqByPR.get(key) ?? 0) + 1;
     kanbanSeqByPR.set(key, seq);
 
-    const prevDetailStatus = isDetailShowing(owner, name, number)
-      ? (detail!.merge_request.KanbanStatus as KanbanStatus)
-      : undefined;
-    const prevPullsStatus = pullsDep?.getPullKanbanStatus?.(owner, name, number);
+    const prevDetailStatus = isDetailShowingRef(ref) ? (detail!.merge_request.KanbanStatus as KanbanStatus) : undefined;
+    const prevPullsStatus = pullsDep?.getPullKanbanStatus?.(ref, number);
 
     if (prevDetailStatus !== undefined) {
       detail = {
@@ -550,7 +550,7 @@ export function createDetailStore(opts: DetailStoreOptions) {
         },
       };
     }
-    pullsDep?.optimisticKanbanUpdate?.(owner, name, number, status);
+    pullsDep?.optimisticKanbanUpdate?.(ref, number, status);
 
     try {
       const { error: requestError } = await apiClient.PUT(providerItemPath("pulls", ref, "/state"), {
@@ -565,7 +565,7 @@ export function createDetailStore(opts: DetailStoreOptions) {
     } catch (err) {
       if (seq === kanbanSeqByPR.get(key)) {
         storeError = err instanceof Error ? err.message : String(err);
-        if (prevDetailStatus !== undefined && isDetailShowing(owner, name, number)) {
+        if (prevDetailStatus !== undefined && isDetailShowingRef(ref)) {
           detail = {
             ...detail!,
             merge_request: {
@@ -575,11 +575,11 @@ export function createDetailStore(opts: DetailStoreOptions) {
           };
         }
         if (prevPullsStatus !== undefined) {
-          pullsDep?.optimisticKanbanUpdate?.(owner, name, number, prevPullsStatus);
+          pullsDep?.optimisticKanbanUpdate?.(ref, number, prevPullsStatus);
         }
         const reloads: Promise<void>[] = [];
         if (pullsDep) reloads.push(pullsDep.loadPulls());
-        if (isDetailShowing(owner, name, number)) {
+        if (isDetailShowingRef(ref)) {
           reloads.push(loadDetail(owner, name, number, ref));
         }
         await Promise.all(reloads);
@@ -592,7 +592,7 @@ export function createDetailStore(opts: DetailStoreOptions) {
 
     if (seq === kanbanSeqByPR.get(key)) {
       const refreshes: Promise<void>[] = [refreshPullsIfActive()];
-      if (isDetailShowing(owner, name, number)) {
+      if (isDetailShowingRef(ref)) {
         refreshes.push(loadDetail(owner, name, number, ref));
       }
       await Promise.all(refreshes);
@@ -686,8 +686,8 @@ export function createDetailStore(opts: DetailStoreOptions) {
     number: number,
     fields: { title?: string; body?: string },
   ): Promise<void> {
-    if (!detail || !isDetailShowing(owner, name, number)) return;
     const ref = currentDetailRef(owner, name, number);
+    if (!detail || !isDetailShowingRef(ref)) return;
 
     const prevTitle = detail.merge_request.Title;
     const prevBody = detail.merge_request.Body;
@@ -717,7 +717,7 @@ export function createDetailStore(opts: DetailStoreOptions) {
         throw new Error(apiErrorMessage(requestError, "failed to update PR"));
       }
       // Apply server-canonical response.
-      if (data && isDetailShowing(owner, name, number)) {
+      if (data && isDetailShowingRef(ref)) {
         detail = data as PullDetail;
         if (
           unsavedLocalBody &&
@@ -733,7 +733,7 @@ export function createDetailStore(opts: DetailStoreOptions) {
     } catch (err) {
       storeError = err instanceof Error ? err.message : String(err);
       // Revert optimistic update.
-      if (isDetailShowing(owner, name, number) && detail) {
+      if (isDetailShowingRef(ref) && detail) {
         detail = {
           ...detail,
           merge_request: {
@@ -764,7 +764,16 @@ export function createDetailStore(opts: DetailStoreOptions) {
     number: number,
     body: string,
   ): void {
-    if (!detail || !isDetailShowing(owner, name, number)) return;
+    if (
+      !detail ||
+      detail.repo?.provider !== provider ||
+      detail.repo?.platform_host !== platformHost ||
+      detail.repo_owner !== owner ||
+      detail.repo_name !== name ||
+      detail.merge_request.Number !== number
+    ) {
+      return;
+    }
     unsavedLocalBody = { provider, platformHost, owner, name, number };
     detail = {
       ...detail,
@@ -835,7 +844,9 @@ export function createDetailStore(opts: DetailStoreOptions) {
       succeeded = true;
       localBodyMatchesSent =
         detail !== null &&
-        isDetailShowing(owner, name, number) &&
+        detail.repo_owner === owner &&
+        detail.repo_name === name &&
+        detail.merge_request.Number === number &&
         detail.repo?.provider === routeRef.provider &&
         detail.repo?.platform_host === routeRef.platformHost &&
         detail.merge_request.Body === body;
@@ -945,11 +956,14 @@ export function createDetailStore(opts: DetailStoreOptions) {
     }
     try {
       if (currentlyStarred) {
+        const ref = currentDetailRef(owner, name, number);
         const { error: requestError } = await apiClient.DELETE("/starred", {
           body: {
             item_type: "pr",
-            owner,
-            name,
+            provider: ref.provider,
+            platform_host: concretePlatformHost(ref),
+            owner: ref.owner,
+            name: ref.name,
             number,
           },
         });
@@ -957,11 +971,14 @@ export function createDetailStore(opts: DetailStoreOptions) {
           throw new Error(requestError.detail ?? requestError.title ?? "failed to unstar pull request");
         }
       } else {
+        const ref = currentDetailRef(owner, name, number);
         const { error: requestError } = await apiClient.PUT("/starred", {
           body: {
             item_type: "pr",
-            owner,
-            name,
+            provider: ref.provider,
+            platform_host: concretePlatformHost(ref),
+            owner: ref.owner,
+            name: ref.name,
             number,
           },
         });

--- a/packages/ui/src/stores/issues.svelte.ts
+++ b/packages/ui/src/stores/issues.svelte.ts
@@ -1,5 +1,10 @@
 import type { Issue, IssueDetail, IssuesParams, Label } from "../api/types.js";
-import { providerItemPath, providerRouteParams } from "../api/provider-routes.js";
+import {
+  providerDefaultHost,
+  providerItemPath,
+  providerRouteParams,
+  type ProviderRouteRef,
+} from "../api/provider-routes.js";
 import type { MiddlemanClient } from "../types.js";
 
 export type IssueDetailSyncMode = boolean | "background";
@@ -132,7 +137,7 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
   function issuesByRepo(): Map<string, Issue[]> {
     const map = new Map<string, Issue[]>();
     for (const issue of issues) {
-      const key = `${issue.repo_owner ?? ""}/${issue.repo_name ?? ""}`;
+      const key = issueIdentityKey(issueRef(issue));
       const existing = map.get(key);
       if (existing) existing.push(issue);
       else map.set(key, [issue]);
@@ -141,6 +146,37 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
   }
 
   // --- detail reads ---
+
+  function issueIdentityKey(ref: Pick<ProviderRouteRef, "provider" | "platformHost" | "repoPath">): string {
+    return JSON.stringify([ref.provider, ref.platformHost ?? "", ref.repoPath]);
+  }
+
+  function issueRef(issue: Issue): ProviderRouteRef {
+    return {
+      provider: issue.repo.provider,
+      platformHost: issue.repo.platform_host,
+      owner: issue.repo.owner,
+      name: issue.repo.name,
+      repoPath: issue.repo.repo_path,
+    };
+  }
+
+  function issueMatchesSelection(issue: Issue, sel: IssueSelection): boolean {
+    return (
+      issue.Number === sel.number &&
+      issue.repo.provider === sel.provider &&
+      issue.repo.platform_host === sel.platformHost &&
+      issue.repo.repo_path === sel.repoPath &&
+      issue.repo.owner === sel.owner &&
+      issue.repo.name === sel.name
+    );
+  }
+
+  function concretePlatformHost(ref: Pick<ProviderRouteRef, "provider" | "platformHost">): string {
+    const host = ref.platformHost ?? providerDefaultHost(ref.provider);
+    if (!host) throw new Error("issue missing platform host");
+    return host;
+  }
 
   function getIssueDetail(): IssueDetail | null {
     return issueDetail;
@@ -271,26 +307,6 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
 
   function hasUnsavedLocalBody(): boolean {
     return unsavedLocalBody !== null;
-  }
-
-  function currentIssuePlatformHost(owner: string, name: string, number: number): string | undefined {
-    if (
-      issueDetail &&
-      issueDetail.repo_owner === owner &&
-      issueDetail.repo_name === name &&
-      issueDetail.issue.Number === number
-    ) {
-      return issueDetail.platform_host;
-    }
-    if (
-      selectedIssue &&
-      selectedIssue.owner === owner &&
-      selectedIssue.name === name &&
-      selectedIssue.number === number
-    ) {
-      return selectedIssue.platformHost;
-    }
-    return undefined;
   }
 
   function isIssueDetailShowingRef(ref: IssueDetailRequestRef): boolean {
@@ -686,7 +702,13 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
     body: string,
   ): void {
     if (!issueDetail) return;
-    if (issueDetail.repo_owner !== owner || issueDetail.repo_name !== name || issueDetail.issue.Number !== number) {
+    if (
+      issueDetail.repo?.provider !== provider ||
+      issueDetail.repo?.platform_host !== platformHost ||
+      issueDetail.repo_owner !== owner ||
+      issueDetail.repo_name !== name ||
+      issueDetail.issue.Number !== number
+    ) {
       return;
     }
     unsavedLocalBody = { provider, platformHost, owner, name, number };
@@ -826,25 +848,17 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
     return flight;
   }
 
-  async function toggleIssueStar(
-    owner: string,
-    name: string,
-    number: number,
-    currentlyStarred: boolean,
-  ): Promise<void> {
-    const platformHost = currentIssuePlatformHost(owner, name, number);
-
+  async function toggleIssueStar(ref: ProviderRouteRef, number: number, currentlyStarred: boolean): Promise<void> {
     try {
       if (currentlyStarred) {
         const { error: requestError } = await apiClient.DELETE("/starred", {
           body: {
             item_type: "issue",
-            owner,
-            name,
+            provider: ref.provider,
+            platform_host: concretePlatformHost(ref),
+            owner: ref.owner,
+            name: ref.name,
             number,
-            ...(platformHost && {
-              platform_host: platformHost,
-            }),
           },
         });
         if (requestError) {
@@ -854,12 +868,11 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
         const { error: requestError } = await apiClient.PUT("/starred", {
           body: {
             item_type: "issue",
-            owner,
-            name,
+            provider: ref.provider,
+            platform_host: concretePlatformHost(ref),
+            owner: ref.owner,
+            name: ref.name,
             number,
-            ...(platformHost && {
-              platform_host: platformHost,
-            }),
           },
         });
         if (requestError) {
@@ -871,13 +884,9 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
       return;
     }
     await loadIssues();
-    if (
-      issueDetail &&
-      issueDetail.repo_owner === owner &&
-      issueDetail.repo_name === name &&
-      issueDetail.issue.Number === number
-    ) {
-      await loadIssueDetail(owner, name, number, currentIssueDetailRef(owner, name, number));
+    const detailRef = issueDetailRequestRef(ref.owner, ref.name, number, ref);
+    if (isIssueDetailShowingRef(detailRef)) {
+      await loadIssueDetail(ref.owner, ref.name, number, detailRef);
     }
   }
 
@@ -912,13 +921,7 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
       }
       return;
     }
-    const idx = list.findIndex(
-      (i) =>
-        (i.repo_owner ?? "") === selectedIssue!.owner &&
-        (i.repo_name ?? "") === selectedIssue!.name &&
-        i.Number === selectedIssue!.number &&
-        (!selectedIssue!.platformHost || i.platform_host === selectedIssue!.platformHost),
-    );
+    const idx = list.findIndex((i) => issueMatchesSelection(i, selectedIssue!));
     if (idx < list.length - 1) {
       const next = list[idx + 1];
       if (next !== undefined) {
@@ -951,13 +954,7 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
       }
       return;
     }
-    const idx = list.findIndex(
-      (i) =>
-        (i.repo_owner ?? "") === selectedIssue!.owner &&
-        (i.repo_name ?? "") === selectedIssue!.name &&
-        i.Number === selectedIssue!.number &&
-        (!selectedIssue!.platformHost || i.platform_host === selectedIssue!.platformHost),
-    );
+    const idx = list.findIndex((i) => issueMatchesSelection(i, selectedIssue!));
     if (idx > 0) {
       const prev = list[idx - 1];
       if (prev !== undefined) {

--- a/packages/ui/src/stores/pulls.svelte.test.ts
+++ b/packages/ui/src/stores/pulls.svelte.test.ts
@@ -4,19 +4,25 @@ import type { MiddlemanClient } from "../types.js";
 import { createPullsStore } from "./pulls.svelte.js";
 
 function pull(id: number, repoName: string, lastActivityAt: string, overrides: Partial<PullRequest> = {}): PullRequest {
+  const provider = overrides.repo?.provider ?? "github";
+  const platformHost = overrides.repo?.platform_host ?? "github.com";
+  const owner = overrides.repo?.owner ?? overrides.repo_owner ?? "acme";
+  const name = overrides.repo?.name ?? overrides.repo_name ?? repoName;
+  const repoPath = overrides.repo?.repo_path ?? `${owner}/${name}`;
   return {
     ID: id,
     Number: id,
     Title: `PR ${id}`,
     LastActivityAt: lastActivityAt,
-    repo_owner: "acme",
-    repo_name: repoName,
+    repo_owner: owner,
+    repo_name: name,
+    platform_host: platformHost,
     repo: {
-      provider: "github",
-      platform_host: "github.com",
-      owner: "acme",
-      name: repoName,
-      repo_path: `acme/${repoName}`,
+      provider,
+      platform_host: platformHost,
+      owner,
+      name,
+      repo_path: repoPath,
     },
     State: "open",
     IsDraft: false,

--- a/packages/ui/src/stores/pulls.svelte.ts
+++ b/packages/ui/src/stores/pulls.svelte.ts
@@ -1,5 +1,10 @@
 import type { KanbanStatus, PullRequest } from "../api/types.js";
-import { providerItemPath, providerRouteParams, type ProviderRouteRef } from "../api/provider-routes.js";
+import {
+  providerDefaultHost,
+  providerItemPath,
+  providerRouteParams,
+  type ProviderRouteRef,
+} from "../api/provider-routes.js";
 import type { MiddlemanClient } from "../types.js";
 import { bucketCIChecks, parseCIChecks } from "../utils/ci-buckets.js";
 import { normalizeKanbanStatus } from "./workflow.svelte.js";
@@ -17,6 +22,8 @@ export interface PullSelection {
   repoPath: string;
   number: number;
 }
+
+type PullIdentityRef = ProviderRouteRef;
 
 type PullsParams = {
   repo?: string;
@@ -82,11 +89,46 @@ export function createPullsStore(opts: PullsStoreOptions) {
     return selectedPR;
   }
 
-  /** Groups pulls by "owner/name" into a Map. */
+  function pullIdentityKey(ref: Pick<PullIdentityRef, "provider" | "platformHost" | "repoPath">): string {
+    return JSON.stringify([ref.provider, ref.platformHost ?? "", ref.repoPath]);
+  }
+
+  function pullRef(pr: PullRequest): PullIdentityRef {
+    return {
+      provider: pr.repo.provider,
+      platformHost: pr.repo.platform_host,
+      owner: pr.repo.owner,
+      name: pr.repo.name,
+      repoPath: pr.repo.repo_path,
+    };
+  }
+
+  function pullMatchesRef(pr: PullRequest, ref: PullIdentityRef, number: number): boolean {
+    return (
+      pr.Number === number &&
+      pr.repo.provider === ref.provider &&
+      pr.repo.platform_host === ref.platformHost &&
+      pr.repo.repo_path === ref.repoPath &&
+      pr.repo.owner === ref.owner &&
+      pr.repo.name === ref.name
+    );
+  }
+
+  function pullMatchesSelection(pr: PullRequest, sel: PullSelection): boolean {
+    return pullMatchesRef(pr, sel, sel.number);
+  }
+
+  function concretePlatformHost(ref: Pick<PullIdentityRef, "provider" | "platformHost">): string {
+    const host = ref.platformHost ?? providerDefaultHost(ref.provider);
+    if (!host) throw new Error("pull request missing platform host");
+    return host;
+  }
+
+  /** Groups pulls by full provider identity into a Map. */
   function pullsByRepo(): Map<string, PullRequest[]> {
     const map = new Map<string, PullRequest[]>();
     for (const pr of getFilteredPulls()) {
-      const key = `${pr.repo_owner ?? ""}/${pr.repo_name ?? ""}`;
+      const key = pullIdentityKey(pullRef(pr));
       const existing = map.get(key);
       if (existing !== undefined) {
         existing.push(pr);
@@ -157,9 +199,7 @@ export function createPullsStore(opts: PullsStoreOptions) {
       }
       return;
     }
-    const idx = list.findIndex(
-      (pr) => (pr.repo_owner ?? "") === sel.owner && (pr.repo_name ?? "") === sel.name && pr.Number === sel.number,
-    );
+    const idx = list.findIndex((pr) => pullMatchesSelection(pr, sel));
     const next = list[idx + 1];
     if (next !== undefined) {
       selectPRFromPull(next);
@@ -177,9 +217,7 @@ export function createPullsStore(opts: PullsStoreOptions) {
       }
       return;
     }
-    const idx = list.findIndex(
-      (pr) => (pr.repo_owner ?? "") === sel.owner && (pr.repo_name ?? "") === sel.name && pr.Number === sel.number,
-    );
+    const idx = list.findIndex((pr) => pullMatchesSelection(pr, sel));
     if (idx > 0) {
       const prev = list[idx - 1];
       if (prev !== undefined) {
@@ -234,7 +272,8 @@ export function createPullsStore(opts: PullsStoreOptions) {
   }
 
   function selectPRFromPull(pr: PullRequest): void {
-    selectPR(pr.repo.owner, pr.repo.name, pr.Number, pr.repo.provider, pr.repo.platform_host, pr.repo.repo_path);
+    const ref = pullRef(pr);
+    selectPR(ref.owner, ref.name, pr.Number, ref.provider, ref.platformHost, ref.repoPath);
   }
 
   function clearSelection(): void {
@@ -242,26 +281,26 @@ export function createPullsStore(opts: PullsStoreOptions) {
   }
 
   /** Returns the current kanban status for a PR. */
-  function getPullKanbanStatus(owner: string, name: string, number: number): KanbanStatus | undefined {
-    const pr = pulls.find((p) => p.repo_owner === owner && p.repo_name === name && p.Number === number);
+  function getPullKanbanStatus(ref: PullIdentityRef, number: number): KanbanStatus | undefined {
+    const pr = pulls.find((p) => pullMatchesRef(p, ref, number));
     return pr?.KanbanStatus as KanbanStatus | undefined;
   }
 
   /** Optimistically update a single PR's kanban status. */
-  function optimisticKanbanUpdate(owner: string, name: string, number: number, status: KanbanStatus): void {
-    pulls = pulls.map((pr) =>
-      pr.repo_owner === owner && pr.repo_name === name && pr.Number === number ? { ...pr, KanbanStatus: status } : pr,
-    );
+  function optimisticKanbanUpdate(ref: PullIdentityRef, number: number, status: KanbanStatus): void {
+    pulls = pulls.map((pr) => (pullMatchesRef(pr, ref, number) ? { ...pr, KanbanStatus: status } : pr));
   }
 
-  async function togglePRStar(owner: string, name: string, number: number, currentlyStarred: boolean): Promise<void> {
+  async function togglePRStar(ref: PullIdentityRef, number: number, currentlyStarred: boolean): Promise<void> {
     try {
       if (currentlyStarred) {
         const { error } = await apiClient.DELETE("/starred", {
           body: {
             item_type: "pr",
-            owner,
-            name,
+            provider: ref.provider,
+            platform_host: concretePlatformHost(ref),
+            owner: ref.owner,
+            name: ref.name,
             number,
           },
         });
@@ -272,8 +311,10 @@ export function createPullsStore(opts: PullsStoreOptions) {
         const { error } = await apiClient.PUT("/starred", {
           body: {
             item_type: "pr",
-            owner,
-            name,
+            provider: ref.provider,
+            platform_host: concretePlatformHost(ref),
+            owner: ref.owner,
+            name: ref.name,
             number,
           },
         });

--- a/packages/ui/src/stores/sync.svelte.test.ts
+++ b/packages/ui/src/stores/sync.svelte.test.ts
@@ -18,7 +18,7 @@ describe("sync store", () => {
         GET: get,
         POST: post,
       } as unknown as MiddlemanClient,
-      getPriorityRepos: () => "github.com/acme/first, github.com/acme/second",
+      getPriorityRepos: () => "github|github.com/acme/first, github|github.com/acme/second",
     });
 
     await store.triggerSync();
@@ -26,7 +26,7 @@ describe("sync store", () => {
     expect(post).toHaveBeenCalledWith("/sync", {
       params: {
         query: {
-          priority_repo: ["github.com/acme/first", "github.com/acme/second"],
+          priority_repo: ["github|github.com/acme/first", "github|github.com/acme/second"],
         },
       },
     });

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -36,7 +36,7 @@ export interface NavigateEvent {
     number?: number;
     jobId?: number;
   };
-  repo?: { host?: string; owner: string; name: string };
+  repo?: { provider?: string; host?: string; platform_host?: string; repo_path?: string; owner: string; name: string };
 }
 
 export type NavigateCallback = (event: string | NavigateEvent) => void;

--- a/packages/ui/src/utils/repo-filter-values.test.ts
+++ b/packages/ui/src/utils/repo-filter-values.test.ts
@@ -23,22 +23,24 @@ describe("repo filter values", () => {
     expect(canonicalRepoFilterValue(repos[1]!, repos)).toBe("gitea|github.com/acme/widgets");
   });
 
-  it("uses host-qualified canonical values when provider identities no longer collide", () => {
-    expect(canonicalRepoFilterValue(widgets, [widgets])).toBe("github.com/acme/widgets");
+  it("uses provider-qualified canonical values when provider identities do not collide", () => {
+    expect(canonicalRepoFilterValue(widgets, [widgets])).toBe("github|github.com/acme/widgets");
   });
 
-  it("normalizes stale slash-qualified provider values to pipe values while a collision exists", () => {
+  it("drops slash-qualified provider values while a collision exists", () => {
     const repos: RepoFilterIdentity[] = [widgets, { ...widgets, provider: "gitea" }];
 
-    expect(normalizeRepoFilterValue("gitea/github.com/acme/widgets", repos)).toBe("gitea|github.com/acme/widgets");
+    expect(normalizeRepoFilterValue("gitea/github.com/acme/widgets", repos)).toBe("");
   });
 
-  it("normalizes stale slash-qualified provider values back to host-qualified values after a collision is removed", () => {
-    expect(normalizeRepoFilterValue("github/github.com/acme/widgets", [widgets])).toBe("github.com/acme/widgets");
+  it("drops slash-qualified provider values without a collision", () => {
+    expect(normalizeRepoFilterValue("github/github.com/acme/widgets", [widgets])).toBe("");
   });
 
-  it("normalizes stale pipe-qualified provider values back to host-qualified values after a collision is removed", () => {
-    expect(normalizeRepoFilterValue("github|github.com/acme/widgets", [widgets])).toBe("github.com/acme/widgets");
+  it("keeps pipe-qualified provider values after a collision is removed", () => {
+    expect(normalizeRepoFilterValue("github|github.com/acme/widgets", [widgets])).toBe(
+      "github|github.com/acme/widgets",
+    );
   });
 
   it("normalizes each value in a comma-separated filter independently", () => {
@@ -54,13 +56,13 @@ describe("repo filter values", () => {
 
     expect(
       normalizeRepoFilterSelection(
-        "gitea/github.com/acme/widgets,github/github.com/acme/widgets,github.com/acme/api",
+        "gitea|github.com/acme/widgets,github|github.com/acme/widgets,github.com/acme/api",
         repos,
       ),
-    ).toBe("gitea|github.com/acme/widgets,github|github.com/acme/widgets,github.com/acme/api");
+    ).toBe("gitea|github.com/acme/widgets,github|github.com/acme/widgets");
   });
 
-  it("keeps slash-qualified selections when they match a current host-qualified option", () => {
+  it("drops slash-qualified selections when they match a current host-qualified option", () => {
     const repos = [
       {
         provider: "github",
@@ -69,7 +71,7 @@ describe("repo filter values", () => {
       },
     ];
 
-    expect(normalizeRepoFilterValue("gitea/github.com/acme/widgets", repos)).toBe("gitea/github.com/acme/widgets");
+    expect(normalizeRepoFilterValue("gitea/github.com/acme/widgets", repos)).toBe("");
   });
 
   it("displays pipe-qualified values as slash-qualified labels", () => {

--- a/packages/ui/src/utils/repo-filter-values.ts
+++ b/packages/ui/src/utils/repo-filter-values.ts
@@ -50,13 +50,13 @@ export function concreteRepoFilterValue(repo: RepoFilterIdentity): string | null
 export function providerQualifiedRepoFilterValue(repo: RepoFilterIdentity): string | null {
   const provider = normalizeProvider(repo.provider);
   const concreteValue = concreteRepoFilterValue(repo);
-  return provider && concreteValue ? `${provider}|${concreteValue}` : concreteValue;
+  return provider && concreteValue ? `${provider}|${concreteValue}` : null;
 }
 
 export function providerQualifiedRepoFilterLabel(repo: RepoFilterIdentity): string | null {
   const provider = normalizeProvider(repo.provider);
   const concreteValue = concreteRepoFilterValue(repo);
-  return provider && concreteValue ? `${provider}/${concreteValue}` : concreteValue;
+  return provider && concreteValue ? `${provider}/${concreteValue}` : null;
 }
 
 export function repoFilterValueNeedsProvider(repo: RepoFilterIdentity, repos: readonly RepoFilterIdentity[]): boolean {
@@ -67,12 +67,9 @@ export function repoFilterValueNeedsProvider(repo: RepoFilterIdentity, repos: re
 
 export function canonicalRepoFilterValue(
   repo: RepoFilterIdentity,
-  repos: readonly RepoFilterIdentity[],
+  _repos: readonly RepoFilterIdentity[],
 ): string | null {
-  if (repoFilterValueNeedsProvider(repo, repos)) {
-    return providerQualifiedRepoFilterValue(repo);
-  }
-  return concreteRepoFilterValue(repo);
+  return providerQualifiedRepoFilterValue(repo);
 }
 
 export function displayRepoFilterValue(value: string): string {
@@ -97,22 +94,15 @@ export function normalizeRepoFilterValue(selected: string, repos: readonly RepoF
   if (currentCanonicalValues(repos).has(value)) return value;
 
   const pipeSeparator = value.indexOf("|");
-  if (pipeSeparator !== -1) {
-    const provider = normalizeProvider(value.slice(0, pipeSeparator));
-    const concreteValue = value.slice(pipeSeparator + 1);
-    for (const identity of concreteIdentities(repos)) {
-      if (identity.provider !== provider || identity.concreteValue !== concreteValue) continue;
-      return canonicalRepoFilterValue(identity.repo, repos) ?? value;
-    }
-    return value;
+  if (pipeSeparator === -1) {
+    return "";
   }
 
+  const provider = normalizeProvider(value.slice(0, pipeSeparator));
+  const concreteValue = value.slice(pipeSeparator + 1);
   for (const identity of concreteIdentities(repos)) {
-    if (!identity.provider) continue;
-    const legacyValue = `${identity.provider}/${identity.concreteValue}`;
-    if (legacyValue === value) {
-      return canonicalRepoFilterValue(identity.repo, repos) ?? value;
-    }
+    if (identity.provider !== provider || identity.concreteValue !== concreteValue) continue;
+    return canonicalRepoFilterValue(identity.repo, repos) ?? value;
   }
   return value;
 }

--- a/packages/ui/src/views/mobileActivityRepoOptions.test.ts
+++ b/packages/ui/src/views/mobileActivityRepoOptions.test.ts
@@ -12,7 +12,7 @@ const baseRepo = {
 };
 
 describe("buildMobileActivityRepoOptions", () => {
-  it("uses host-qualified trigger labels when duplicate repo paths exist", () => {
+  it("uses provider-qualified values when duplicate repo paths exist", () => {
     const options = buildMobileActivityRepoOptions([
       { ...baseRepo, platform_host: "github.com" },
       { ...baseRepo, platform_host: "ghe.example.com" },
@@ -20,14 +20,14 @@ describe("buildMobileActivityRepoOptions", () => {
 
     expect(options).toEqual([
       {
-        value: "ghe.example.com/acme/widgets",
-        label: "ghe.example.com/acme/widgets",
-        triggerLabel: "ghe.example.com/acme/widgets",
+        value: "github|ghe.example.com/acme/widgets",
+        label: "github/ghe.example.com/acme/widgets",
+        triggerLabel: "github/ghe.example.com/acme/widgets",
       },
       {
-        value: "github.com/acme/widgets",
-        label: "github.com/acme/widgets",
-        triggerLabel: "github.com/acme/widgets",
+        value: "github|github.com/acme/widgets",
+        label: "github/github.com/acme/widgets",
+        triggerLabel: "github/github.com/acme/widgets",
       },
     ]);
   });
@@ -68,13 +68,13 @@ describe("buildMobileActivityRepoOptions", () => {
 
     expect(options).toEqual([
       {
-        value: "ghe.example.com/acme/api",
-        label: "ghe.example.com/acme/api",
+        value: "github|ghe.example.com/acme/api",
+        label: "github/ghe.example.com/acme/api",
         triggerLabel: "acme/api",
       },
       {
-        value: "github.com/acme/widgets",
-        label: "github.com/acme/widgets",
+        value: "github|github.com/acme/widgets",
+        label: "github/github.com/acme/widgets",
         triggerLabel: "acme/widgets",
       },
     ]);
@@ -100,9 +100,9 @@ describe("buildMobileActivityRepoOptions", () => {
     ]);
 
     expect(options.map((option) => option.label)).toEqual([
-      "ghe.example.com/acme/api",
-      "github.com/acme/widgets",
-      "github.com/zeta/widgets",
+      "github/ghe.example.com/acme/api",
+      "github/github.com/acme/widgets",
+      "github/github.com/zeta/widgets",
     ]);
   });
 
@@ -123,8 +123,8 @@ describe("buildMobileActivityRepoOptions", () => {
 
     expect(options).toEqual([
       {
-        value: "ghe.example.com/acme/widgets",
-        label: "ghe.example.com/acme/widgets",
+        value: "github|ghe.example.com/acme/widgets",
+        label: "github/ghe.example.com/acme/widgets",
         triggerLabel: "acme/widgets",
       },
     ]);

--- a/packages/ui/src/views/mobileActivityRepoOptions.ts
+++ b/packages/ui/src/views/mobileActivityRepoOptions.ts
@@ -42,12 +42,12 @@ export function buildMobileActivityRepoOptions(repos: ConfigRepo[]): MobileActiv
     const identity = repoFilterIdentity(repo);
     const concreteValue = concreteRepoFilterValue(identity);
     if (!concreteValue) continue;
-    const providerCollision = repoFilterValueNeedsProvider(identity, identities);
     const value = canonicalRepoFilterValue(identity, identities);
     if (!value || seen.has(value)) continue;
     seen.add(value);
     const repoPath = repo.repo_path.trim();
-    const label = providerCollision ? providerQualifiedRepoFilterLabel(identity) : value;
+    const providerCollision = repoFilterValueNeedsProvider(identity, identities);
+    const label = providerQualifiedRepoFilterLabel(identity);
     if (!label) continue;
     const triggerLabel = providerCollision || (valuesByRepoPath.get(repoPath)?.size ?? 0) > 1 ? label : repoPath;
     options.push({ value, label, triggerLabel });

--- a/tools/devephemeral/main_test.go
+++ b/tools/devephemeral/main_test.go
@@ -632,12 +632,16 @@ func TestRunWritesStatusAndReusesLiveDefaultStack(t *testing.T) {
 	assert.Equal("http://127.0.0.1:39502", status.FrontendURL)
 	assert.Equal("workflow state", readSQLiteMarker(t, filepath.Join(workDir, "data", "middleman.db")))
 
-	require.NoError(run(context.Background(), []string{
-		"-config", sourcePath,
-		"-work-dir", workDir,
-		"-backend-port", "39503",
-		"-frontend-port", "39504",
-	}))
+	var reuseErr error
+	require.Eventually(func() bool {
+		reuseErr = run(context.Background(), []string{
+			"-config", sourcePath,
+			"-work-dir", workDir,
+			"-backend-port", "39503",
+			"-frontend-port", "39504",
+		})
+		return reuseErr == nil
+	}, 2*time.Second, 10*time.Millisecond, "reuse run failed: %v", reuseErr)
 	reused := readStatusFile(t, statusPath)
 	assert.Equal(status.BackendPID, reused.BackendPID)
 	assert.Equal(status.FrontendPID, reused.FrontendPID)


### PR DESCRIPTION
- Requires repository-scoped API, DB, workspace, sync, notification, and frontend filter paths to carry provider plus platform host.
- Removes the remaining owner/name-only helper paths and legacy repo filter shapes that could collapse distinct repositories.

<sup>generated by a clanker</sup>