### PR TITLE
Allow pending-CI merge override

### DIFF
--- a/frontend/tests/e2e-full/detail-action-buttons.spec.ts
+++ b/frontend/tests/e2e-full/detail-action-buttons.spec.ts
@@ -455,6 +455,44 @@ test.describe("detail action buttons", () => {
     }
   });
 
+  test("pending CI merge override sends the immediate merge request", async ({ page }) => {
+    let isolatedServer: IsolatedE2EServer | null = null;
+    try {
+      isolatedServer = await startIsolatedE2EServer();
+      const baseURL = isolatedServer.info.base_url;
+      const mergeRequestPaths: string[] = [];
+
+      page.on("request", (request) => {
+        if (request.method() !== "POST") return;
+        const url = new URL(request.url());
+        if (url.pathname.includes("/api/v1/pulls/github/acme/widgets/1/merge")) {
+          mergeRequestPaths.push(url.pathname);
+        }
+      });
+
+      await page.goto(`${baseURL}/pulls/github/acme/widgets/1`);
+      await expect(page.locator(".pull-detail")).toBeVisible();
+
+      await page.locator(".btn--merge").first().click();
+      const modal = page.locator(".modal", { hasText: "Merge Pull Request" });
+      await expect(modal).toBeVisible();
+      await expect(modal.getByRole("button", { name: "Merge after CI is complete" })).toBeVisible();
+
+      const mergeResponse = page.waitForResponse((response) => {
+        const url = new URL(response.url());
+        return response.request().method() === "POST" && url.pathname === "/api/v1/pulls/github/acme/widgets/1/merge";
+      });
+      await modal.getByRole("button", { name: "Merge Anyway" }).click();
+      expect((await mergeResponse).status()).toBe(200);
+
+      expect(mergeRequestPaths).toEqual(["/api/v1/pulls/github/acme/widgets/1/merge"]);
+      await expect(modal).toHaveCount(0);
+      await expect(page.locator(".pull-detail")).toBeVisible();
+    } finally {
+      await isolatedServer?.stop();
+    }
+  });
+
   test("aggregate pending CI merge action enqueues deferred merge when check rows are empty", async ({ page }) => {
     let isolatedServer: IsolatedE2EServer | null = null;
     try {

--- a/packages/ui/src/components/detail/MergeModal.svelte
+++ b/packages/ui/src/components/detail/MergeModal.svelte
@@ -110,8 +110,9 @@
   let commitTitle = $state(initialCommitTitle());
   let commitMessage = $state(initialCommitMessage());
 
-  let merging = $state(false);
+  let activeMergeSubmission = $state<"deferred" | "immediate" | null>(null);
   let error = $state<string | null>(null);
+  const merging = $derived(activeMergeSubmission !== null);
 
   function mergeParams(): MergeParams {
     return {
@@ -135,7 +136,7 @@
 
   async function submitMerge(deferred: boolean): Promise<void> {
     if (headPinMissing) return;
-    merging = true;
+    activeMergeSubmission = deferred ? "deferred" : "immediate";
     error = null;
     try {
       // Pin the merge to the head the user reviewed; the server rejects
@@ -160,7 +161,7 @@
     } catch (err) {
       error = err instanceof Error ? err.message : String(err);
     } finally {
-      merging = false;
+      activeMergeSubmission = null;
     }
   }
 
@@ -169,6 +170,10 @@
       void submitMerge(true);
       return;
     }
+    void submitMerge(false);
+  }
+
+  function handleMergeAnyway(): void {
     void submitMerge(false);
   }
 
@@ -188,8 +193,13 @@
   }
 
   function primaryButtonLabel(): string {
-    if (merging) return deferUntilChecksPass ? "Merge scheduled..." : "Merging...";
+    if (activeMergeSubmission === "deferred") return "Merge scheduled...";
+    if (activeMergeSubmission === "immediate" && !deferUntilChecksPass) return "Merging...";
     return deferUntilChecksPass ? "Merge after CI is complete" : methodLabel();
+  }
+
+  function mergeAnywayButtonLabel(): string {
+    return activeMergeSubmission === "immediate" ? "Merging..." : "Merge Anyway";
   }
 </script>
 
@@ -303,6 +313,17 @@
       >
         {primaryButtonLabel()}
       </ActionButton>
+      {#if deferUntilChecksPass}
+        <ActionButton
+          class="btn btn--merge-anyway"
+          onclick={handleMergeAnyway}
+          disabled={merging || headPinMissing}
+          tone="success"
+          surface="soft"
+        >
+          {mergeAnywayButtonLabel()}
+        </ActionButton>
+      {/if}
     </div>
   </div>
 </div>

--- a/packages/ui/src/components/detail/MergeModal.svelte.test.ts
+++ b/packages/ui/src/components/detail/MergeModal.svelte.test.ts
@@ -175,6 +175,24 @@ describe("MergeModal head pinning", () => {
     expect(onclose).toHaveBeenCalledTimes(1);
   });
 
+  it("offers an immediate merge override while CI is still pending", async () => {
+    const post = vi.fn().mockResolvedValue({ data: {}, error: undefined, response: new Response("{}") });
+    const onmerged = vi.fn();
+    renderModal(post, {
+      deferUntilChecksPass: true,
+      onmerged,
+    });
+
+    expect(screen.getByRole("button", { name: "Merge after CI is complete" })).toBeTruthy();
+    await fireEvent.click(screen.getByRole("button", { name: "Merge Anyway" }));
+
+    await waitFor(() => expect(post).toHaveBeenCalledTimes(1));
+    const [path, init] = post.mock.calls[0];
+    expect(path).toBe("/pulls/{provider}/{owner}/{name}/{number}/merge");
+    expect(init.body.method).toBe("squash");
+    expect(onmerged).toHaveBeenCalledTimes(1);
+  });
+
   it("disables the deferred merge action while scheduling the merge", async () => {
     const scheduled = deferred<{ data: Record<string, never>; error: undefined; response: Response }>();
     const post = vi.fn().mockReturnValue(scheduled.promise);


### PR DESCRIPTION
Pending CI should offer the safer deferred merge path without making it the only way forward. Maintainers sometimes need to merge while non-blocking checks such as roborev are still pending.

This keeps the existing deferred merge action visible and adds an explicit immediate override in the merge modal so the user chooses between waiting for currently pending checks and merging now.

Screenshot:

![merge-anyway-modal.png](https://github.com/user-attachments/assets/c55e8e69-6c52-4e93-b8d6-b56fc60e7fd0)