### PR TITLE
Keep recently active PRs fresh

### DIFF
--- a/cmd/middleman/main.go
+++ b/cmd/middleman/main.go
@@ -551,6 +551,8 @@ func run(opts serve.Options) error {
 		cfg.BranchActivityRetention(),
 		cfg.Activity.DefaultBranchMaxCommits,
 	)
+	syncer.SetWatchInterval(cfg.ActivePRRefreshDuration())
+	syncer.SetActiveMRWindow(cfg.ActivePRWindowDuration())
 	syncer.SetFetchers(startup.fetchers)
 	syncer.SetWriteRateTrackers(startup.writeRateTrackers)
 	syncer.SetWriteGQLRateTrackers(startup.writeGQLRateTrackers)
@@ -608,6 +610,12 @@ func run(opts serve.Options) error {
 	// than the activity feed's top cursor, so broadcast the same
 	// data-change signal the normal sync uses to nudge a full reload.
 	syncer.SetOnNotificationSyncComplete(func() {
+		srv.Hub().Broadcast(server.Event{
+			Type: "data_changed",
+			Data: struct{}{},
+		})
+	})
+	syncer.SetOnWatchedMRSyncCompleted(func() {
 		srv.Hub().Broadcast(server.Event{
 			Type: "data_changed",
 			Data: struct{}{},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,8 @@ const (
 	defaultForgejoTokenEnv                 = "MIDDLEMAN_FORGEJO_TOKEN"
 	defaultGiteaTokenEnv                   = "MIDDLEMAN_GITEA_TOKEN"
 	defaultSyncInterval                    = "5m"
+	defaultActivePRRefreshInterval         = "2m"
+	defaultActivePRWindow                  = "4h"
 	defaultNotificationSyncInterval        = "2m"
 	defaultNotificationPropagationInterval = "1m"
 	defaultHost                            = "127.0.0.1"
@@ -743,6 +745,8 @@ type Shell struct {
 
 type Config struct {
 	SyncInterval              string `toml:"sync_interval"`
+	ActivePRRefreshInterval   string `toml:"active_pr_refresh_interval"`
+	ActivePRWindow            string `toml:"active_pr_window"`
 	GitHubTokenEnv            string `toml:"github_token_env"`
 	DefaultPlatformHost       string `toml:"default_platform_host"`
 	Host                      string `toml:"host"`
@@ -1129,11 +1133,13 @@ func Load(path string) (*Config, error) {
 // LoadForGitHubAppRepair pick the validation strictness.
 func load(path string) (*Config, error) {
 	cfg := &Config{
-		SyncInterval:        defaultSyncInterval,
-		GitHubTokenEnv:      defaultGitHubTokenEnv,
-		DefaultPlatformHost: defaultPlatformHost,
-		Host:                defaultHost,
-		Port:                defaultPort,
+		SyncInterval:            defaultSyncInterval,
+		ActivePRRefreshInterval: defaultActivePRRefreshInterval,
+		ActivePRWindow:          defaultActivePRWindow,
+		GitHubTokenEnv:          defaultGitHubTokenEnv,
+		DefaultPlatformHost:     defaultPlatformHost,
+		Host:                    defaultHost,
+		Port:                    defaultPort,
 		Activity: Activity{
 			CollapseThreads: true,
 		},
@@ -1340,6 +1346,22 @@ func (c *Config) validate(skipAppCoverage bool) error {
 
 	if _, err := time.ParseDuration(c.SyncInterval); err != nil {
 		return fmt.Errorf("config: invalid sync_interval %q: %w", c.SyncInterval, err)
+	}
+	if c.ActivePRRefreshInterval == "" {
+		c.ActivePRRefreshInterval = defaultActivePRRefreshInterval
+	}
+	if c.ActivePRWindow == "" {
+		c.ActivePRWindow = defaultActivePRWindow
+	}
+	if d, err := time.ParseDuration(c.ActivePRRefreshInterval); err != nil {
+		return fmt.Errorf("config: invalid active_pr_refresh_interval %q: %w", c.ActivePRRefreshInterval, err)
+	} else if d <= 0 {
+		return fmt.Errorf("config: active_pr_refresh_interval must be positive, got %q", c.ActivePRRefreshInterval)
+	}
+	if d, err := time.ParseDuration(c.ActivePRWindow); err != nil {
+		return fmt.Errorf("config: invalid active_pr_window %q: %w", c.ActivePRWindow, err)
+	} else if d <= 0 {
+		return fmt.Errorf("config: active_pr_window must be positive, got %q", c.ActivePRWindow)
 	}
 	if c.Notifications.SyncInterval == "" {
 		c.Notifications.SyncInterval = defaultNotificationSyncInterval
@@ -1924,6 +1946,24 @@ func (c *Config) SyncDuration() time.Duration {
 	return d
 }
 
+func (c *Config) ActivePRRefreshDuration() time.Duration {
+	if c == nil || c.ActivePRRefreshInterval == "" {
+		d, _ := time.ParseDuration(defaultActivePRRefreshInterval)
+		return d
+	}
+	d, _ := time.ParseDuration(c.ActivePRRefreshInterval)
+	return d
+}
+
+func (c *Config) ActivePRWindowDuration() time.Duration {
+	if c == nil || c.ActivePRWindow == "" {
+		d, _ := time.ParseDuration(defaultActivePRWindow)
+		return d
+	}
+	d, _ := time.ParseDuration(c.ActivePRWindow)
+	return d
+}
+
 func (c *Config) BranchActivityRetention() time.Duration {
 	if c == nil || c.Activity.DefaultBranchRetentionDays <= 0 {
 		return time.Duration(defaultBranchActivityRetentionDays) * 24 * time.Hour
@@ -2455,6 +2495,8 @@ func reposForSave(repos []Repo) []Repo {
 // configFile is the subset of Config written to disk.
 type configFile struct {
 	SyncInterval              string            `toml:"sync_interval"`
+	ActivePRRefreshInterval   string            `toml:"active_pr_refresh_interval"`
+	ActivePRWindow            string            `toml:"active_pr_window"`
 	GitHubTokenEnv            string            `toml:"github_token_env"`
 	DefaultPlatformHost       string            `toml:"default_platform_host,omitempty"`
 	Host                      string            `toml:"host"`
@@ -2490,28 +2532,30 @@ func (c *Config) Save(path string) error {
 		return fmt.Errorf("validating config: %w", err)
 	}
 	f := configFile{
-		SyncInterval:        cfg.SyncInterval,
-		GitHubTokenEnv:      cfg.GitHubTokenEnv,
-		DefaultPlatformHost: cfg.DefaultPlatformHost,
-		Host:                cfg.Host,
-		Port:                cfg.Port,
-		AllowedHosts:        slices.Clone(cfg.AllowedHosts),
-		TrustReverseProxy:   cfg.TrustReverseProxy,
-		Repos:               reposForSave(cfg.Repos),
-		Platforms:           cfg.Platforms,
-		GitHubApps:          cfg.GitHubApps,
-		Activity:            cfg.Activity,
-		Notifications:       cfg.Notifications,
-		Terminal:            cfg.Terminal,
-		Modes:               cfg.Modes,
-		Agents:              cfg.Agents,
-		DocFolders:          cfg.DocFolders,
-		Roborev:             cfg.Roborev,
-		Msgvault:            cfg.Msgvault,
-		Tmux:                cfg.Tmux,
-		Shell:               cfg.Shell,
-		Fleet:               cfg.Fleet,
-		API:                 cfg.API,
+		SyncInterval:            cfg.SyncInterval,
+		ActivePRRefreshInterval: cfg.ActivePRRefreshInterval,
+		ActivePRWindow:          cfg.ActivePRWindow,
+		GitHubTokenEnv:          cfg.GitHubTokenEnv,
+		DefaultPlatformHost:     cfg.DefaultPlatformHost,
+		Host:                    cfg.Host,
+		Port:                    cfg.Port,
+		AllowedHosts:            slices.Clone(cfg.AllowedHosts),
+		TrustReverseProxy:       cfg.TrustReverseProxy,
+		Repos:                   reposForSave(cfg.Repos),
+		Platforms:               cfg.Platforms,
+		GitHubApps:              cfg.GitHubApps,
+		Activity:                cfg.Activity,
+		Notifications:           cfg.Notifications,
+		Terminal:                cfg.Terminal,
+		Modes:                   cfg.Modes,
+		Agents:                  cfg.Agents,
+		DocFolders:              cfg.DocFolders,
+		Roborev:                 cfg.Roborev,
+		Msgvault:                cfg.Msgvault,
+		Tmux:                    cfg.Tmux,
+		Shell:                   cfg.Shell,
+		Fleet:                   cfg.Fleet,
+		API:                     cfg.API,
 	}
 	if cfg.DefaultPlatformHost == defaultPlatformHost {
 		f.DefaultPlatformHost = ""
@@ -2591,6 +2635,12 @@ func (c *Config) copyForSave() Config {
 	cfg.Agents = slices.Clone(c.Agents)
 	if cfg.SyncInterval == "" {
 		cfg.SyncInterval = defaultSyncInterval
+	}
+	if cfg.ActivePRRefreshInterval == "" {
+		cfg.ActivePRRefreshInterval = defaultActivePRRefreshInterval
+	}
+	if cfg.ActivePRWindow == "" {
+		cfg.ActivePRWindow = defaultActivePRWindow
 	}
 	if cfg.DefaultPlatformHost == "" {
 		cfg.DefaultPlatformHost = defaultPlatformHost

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -155,6 +155,48 @@ propagation_interval = "-1s"
 	}
 }
 
+func TestLoadAppliesActivePRRefreshDefaults(t *testing.T) {
+	cfg, err := Load(writeConfig(t, ``))
+	require.NoError(t, err)
+
+	assert := Assert.New(t)
+	assert.Equal(defaultActivePRRefreshInterval, cfg.ActivePRRefreshInterval)
+	assert.Equal(defaultActivePRWindow, cfg.ActivePRWindow)
+	assert.Equal(2*time.Minute, cfg.ActivePRRefreshDuration())
+	assert.Equal(4*time.Hour, cfg.ActivePRWindowDuration())
+}
+
+func TestLoadRejectsNonPositiveActivePRRefreshDurations(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		wantErr string
+	}{
+		{
+			name: "refresh interval zero",
+			content: `
+active_pr_refresh_interval = "0s"
+`,
+			wantErr: "active_pr_refresh_interval must be positive",
+		},
+		{
+			name: "window negative",
+			content: `
+active_pr_window = "-1s"
+`,
+			wantErr: "active_pr_window must be positive",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Load(writeConfig(t, tt.content))
+			require.Error(t, err)
+			Assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
 func TestSaveAppliesNotificationDefaultsForInMemoryConfig(t *testing.T) {
 	require := require.New(t)
 	assert := Assert.New(t)

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -422,6 +422,7 @@ type Syncer struct {
 	interval                 time.Duration
 	watchInterval            time.Duration
 	watchedMRs               []WatchedMR
+	activeMRWindow           time.Duration
 	watchMu                  sync.Mutex
 	branchActivityMu         sync.RWMutex
 	branchActivityRetention  time.Duration
@@ -448,7 +449,10 @@ type Syncer struct {
 	displayNameGroup singleflight.Group // dedups concurrent GetUser calls
 	onMRSynced       func(owner, name string, mr *db.MergeRequest)
 	onSyncCompleted  func(results []RepoSyncResult)
-	onStatusChange   func(status *SyncStatus)
+	// onWatchedMRSyncCompleted fires once after a watched-MR fast-sync
+	// pass refreshes at least one MR.
+	onWatchedMRSyncCompleted func()
+	onStatusChange           func(status *SyncStatus)
 	// onNotificationSyncComplete fires after each notification sync run
 	// (periodic, manual, or sidecar) so the server can broadcast the same
 	// data-change signal the normal sync uses. Notification sync can insert
@@ -1781,9 +1785,24 @@ func (p gitHubClientProvider) EditIssueContent(
 }
 
 // SetWatchInterval sets the fast-sync interval for watched MRs.
-// Must be called before Start.
 func (s *Syncer) SetWatchInterval(d time.Duration) {
+	s.watchMu.Lock()
+	defer s.watchMu.Unlock()
 	s.watchInterval = d
+}
+
+// SetActiveMRWindow sets the recency window used to add open, recently
+// active MRs to the fast-sync watch list.
+func (s *Syncer) SetActiveMRWindow(d time.Duration) {
+	s.watchMu.Lock()
+	defer s.watchMu.Unlock()
+	s.activeMRWindow = d
+}
+
+func (s *Syncer) watchSettings() (time.Duration, time.Duration) {
+	s.watchMu.Lock()
+	defer s.watchMu.Unlock()
+	return s.watchSettingsLocked()
 }
 
 // HasDiffSync reports whether the syncer has a clone manager configured
@@ -1833,6 +1852,12 @@ func (s *Syncer) SetOnSyncCompleted(
 	fn func(results []RepoSyncResult),
 ) {
 	s.onSyncCompleted = fn
+}
+
+// SetOnWatchedMRSyncCompleted registers a callback invoked once after a
+// watched-MR fast-sync pass refreshes at least one MR.
+func (s *Syncer) SetOnWatchedMRSyncCompleted(fn func()) {
+	s.onWatchedMRSyncCompleted = fn
 }
 
 // SetParallelism sets the maximum number of repos synced
@@ -2390,10 +2415,6 @@ func (s *Syncer) Start(ctx context.Context) {
 	startMerged, startCancel := s.mergeWithRunCtx(ctx)
 	s.wg.Add(1)
 
-	watchInt := s.watchInterval
-	if watchInt <= 0 {
-		watchInt = 30 * time.Second
-	}
 	watchMerged, watchCancel := s.mergeWithRunCtx(ctx)
 	s.wg.Add(1)
 	s.lifecycleMu.Unlock()
@@ -2419,15 +2440,17 @@ func (s *Syncer) Start(ctx context.Context) {
 	go func() {
 		defer s.wg.Done()
 		defer watchCancel()
-		ticker := time.NewTicker(watchInt)
-		defer ticker.Stop()
 		for {
+			watchInt, _ := s.watchSettings()
+			timer := time.NewTimer(watchInt)
 			select {
-			case <-ticker.C:
+			case <-timer.C:
 				s.syncWatchedMRs(watchMerged)
 			case <-s.stopCh:
+				timer.Stop()
 				return
 			case <-watchMerged.Done():
+				timer.Stop()
 				return
 			}
 		}
@@ -2493,18 +2516,12 @@ func (s *Syncer) advanceNextSync(
 func (s *Syncer) syncWatchedMRs(ctx context.Context) {
 	ctx = WithSyncBudget(ctx)
 
-	s.watchMu.Lock()
-	mrs := slices.Clone(s.watchedMRs)
-	s.watchMu.Unlock()
-
+	mrs := s.watchedMRsForFastSync(ctx, time.Now().UTC())
 	if len(mrs) == 0 {
 		return
 	}
 
-	watchInt := s.watchInterval
-	if watchInt <= 0 {
-		watchInt = 30 * time.Second
-	}
+	watchInt, _ := s.watchSettings()
 	watchBuckets := make([]string, len(mrs))
 	for i, mr := range mrs {
 		watchBuckets[i] = watchedMRRateBucketKey(mr)
@@ -2529,6 +2546,7 @@ func (s *Syncer) syncWatchedMRs(ctx context.Context) {
 		blockedBuckets[bucket] = false
 	}
 
+	syncedAny := false
 	for _, mr := range mrs {
 		host := watchedMRHost(mr)
 		bucket := watchedMRRateBucketKey(mr)
@@ -2557,12 +2575,92 @@ func (s *Syncer) syncWatchedMRs(ctx context.Context) {
 				"number", mr.Number,
 				"err", err,
 			)
+			var diffErr *DiffSyncError
+			if errors.As(err, &diffErr) {
+				syncedAny = true
+			}
+			continue
 		}
+		syncedAny = true
 	}
 
 	s.advanceNextSync(
 		eligibleBuckets, s.nextWatchSyncAfter, watchInt,
 	)
+	if syncedAny && s.onWatchedMRSyncCompleted != nil {
+		s.onWatchedMRSyncCompleted()
+	}
+}
+
+func (s *Syncer) watchedMRsForFastSync(ctx context.Context, now time.Time) []WatchedMR {
+	s.watchMu.Lock()
+	mrs := slices.Clone(s.watchedMRs)
+	_, activeWindow := s.watchSettingsLocked()
+	s.watchMu.Unlock()
+
+	watched := newWatchedMRSet(mrs)
+	if activeWindow > 0 {
+		for _, mr := range s.recentlyActiveOpenMRs(ctx, now, activeWindow) {
+			watched.add(mr)
+		}
+	}
+	return watched.slice()
+}
+
+func (s *Syncer) watchSettingsLocked() (time.Duration, time.Duration) {
+	watchInt := s.watchInterval
+	if watchInt <= 0 {
+		watchInt = 30 * time.Second
+	}
+	return watchInt, s.activeMRWindow
+}
+
+func (s *Syncer) recentlyActiveOpenMRs(
+	ctx context.Context,
+	now time.Time,
+	window time.Duration,
+) []WatchedMR {
+	prs, err := s.db.ListMergeRequests(ctx, db.ListMergeRequestsOpts{State: "open"})
+	if err != nil {
+		slog.Warn("fast-sync active MR selection failed", "err", err)
+		return nil
+	}
+	cutoff := now.Add(-window)
+	repoByID := make(map[int64]*db.Repo)
+	var watched []WatchedMR
+	for _, pr := range prs {
+		if pr.LastActivityAt.Before(cutoff) {
+			continue
+		}
+		repo, ok := repoByID[pr.RepoID]
+		if !ok {
+			var repoErr error
+			repo, repoErr = s.db.GetRepoByID(ctx, pr.RepoID)
+			if repoErr != nil || repo == nil {
+				if repoErr != nil {
+					slog.Warn("fast-sync active MR repo lookup failed",
+						"repo_id", pr.RepoID,
+						"err", repoErr,
+					)
+				}
+				continue
+			}
+			repoByID[pr.RepoID] = repo
+		}
+		if _, ok := s.trackedRepoByIdentity(
+			platform.Kind(repo.Platform), repo.Owner, repo.Name, repo.PlatformHost,
+		); !ok {
+			continue
+		}
+		watched = append(watched, WatchedMR{
+			Platform:     platform.Kind(repo.Platform),
+			PlatformHost: repo.PlatformHost,
+			Owner:        repo.Owner,
+			Name:         repo.Name,
+			Number:       pr.Number,
+		})
+	}
+	return watched
 }
 
 func watchedMRPlatform(mr WatchedMR) platform.Kind {
@@ -2583,6 +2681,32 @@ func watchedMRKey(mr WatchedMR) string {
 	return detailRepoKey(
 		watchedMRPlatform(mr), watchedMRHost(mr), mr.Owner, mr.Name,
 	) + fmt.Sprintf("#%d", mr.Number)
+}
+
+type watchedMRSet struct {
+	seen  map[string]struct{}
+	items []WatchedMR
+}
+
+func newWatchedMRSet(initial []WatchedMR) *watchedMRSet {
+	w := &watchedMRSet{seen: make(map[string]struct{}, len(initial))}
+	for _, mr := range initial {
+		w.add(mr)
+	}
+	return w
+}
+
+func (w *watchedMRSet) add(mr WatchedMR) {
+	key := watchedMRKey(mr)
+	if _, ok := w.seen[key]; ok {
+		return
+	}
+	w.seen[key] = struct{}{}
+	w.items = append(w.items, mr)
+}
+
+func (w *watchedMRSet) slice() []WatchedMR {
+	return slices.Clone(w.items)
 }
 
 // stopGracePeriod bounds how long Stop will wait for in-flight work

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -6800,6 +6800,108 @@ func TestSetWatchedMRsReplacesList(t *testing.T) {
 		"PR #1 should stop being synced after watch list replacement")
 }
 
+func TestWatchedMRsIncludeRecentlyActiveOpenPRs(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	now := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+
+	githubRepoID, err := d.UpsertRepo(ctx, db.RepoIdentity{
+		Platform:     "github",
+		PlatformHost: "github.com",
+		Owner:        "acme",
+		Name:         "app",
+	})
+	require.NoError(err)
+	gheRepoID, err := d.UpsertRepo(ctx, db.RepoIdentity{
+		Platform:     "github",
+		PlatformHost: "ghe.example.com",
+		Owner:        "acme",
+		Name:         "app",
+	})
+	require.NoError(err)
+
+	seedMR := func(repoID int64, number int, state db.MergeRequestState, lastActivity time.Time) {
+		_, upsertErr := d.UpsertMergeRequest(ctx, &db.MergeRequest{
+			RepoID: repoID, PlatformID: int64(number), Number: number,
+			Title: "PR", Author: "octo", State: state,
+			HeadBranch: "feature", BaseBranch: "main",
+			CreatedAt: now.Add(-24 * time.Hour),
+			UpdatedAt: lastActivity, LastActivityAt: lastActivity,
+		})
+		require.NoError(upsertErr)
+	}
+	seedMR(githubRepoID, 1, db.MergeRequestStateOpen, now.Add(-30*time.Minute))
+	seedMR(githubRepoID, 2, db.MergeRequestStateOpen, now.Add(-5*time.Hour))
+	seedMR(githubRepoID, 3, db.MergeRequestStateClosed, now.Add(-10*time.Minute))
+	seedMR(gheRepoID, 4, db.MergeRequestStateOpen, now.Add(-3*time.Hour))
+
+	syncer := NewSyncer(
+		map[string]Client{}, d, nil,
+		[]RepoRef{
+			{Platform: platform.KindGitHub, PlatformHost: "github.com", Owner: "acme", Name: "app"},
+			{Platform: platform.KindGitHub, PlatformHost: "ghe.example.com", Owner: "acme", Name: "app"},
+		},
+		time.Hour, nil, nil,
+	)
+	syncer.SetActiveMRWindow(4 * time.Hour)
+	syncer.SetWatchedMRs([]WatchedMR{{
+		Platform: platform.KindGitHub, PlatformHost: "github.com",
+		Owner: "acme", Name: "app", Number: 99,
+	}})
+
+	got := syncer.watchedMRsForFastSync(ctx, now)
+	assert.ElementsMatch([]WatchedMR{
+		{
+			Platform: platform.KindGitHub, PlatformHost: "github.com",
+			Owner: "acme", Name: "app", Number: 1,
+		},
+		{
+			Platform: platform.KindGitHub, PlatformHost: "ghe.example.com",
+			Owner: "acme", Name: "app", Number: 4,
+		},
+		{
+			Platform: platform.KindGitHub, PlatformHost: "github.com",
+			Owner: "acme", Name: "app", Number: 99,
+		},
+	}, got)
+}
+
+func TestWatchedMRsNotifyOnceAfterFastSync(t *testing.T) {
+	assert := Assert.New(t)
+	d := openTestDB(t)
+	now := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	mc := &mockClient{
+		openPRs:  []*gh.PullRequest{},
+		singlePR: buildOpenPR(5, now),
+		comments: []*gh.IssueComment{},
+		reviews:  []*gh.PullRequestReview{},
+		commits:  []*gh.RepositoryCommit{},
+	}
+
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc}, d, nil,
+		[]RepoRef{{
+			Owner: "acme", Name: "app", PlatformHost: "github.com",
+		}},
+		time.Hour, nil, nil,
+	)
+	syncer.SetWatchedMRs([]WatchedMR{{
+		Owner: "acme", Name: "app", Number: 5, PlatformHost: "github.com",
+	}})
+
+	calls := 0
+	syncer.SetOnWatchedMRSyncCompleted(func() {
+		calls++
+	})
+
+	syncer.syncWatchedMRs(t.Context())
+
+	assert.Equal(1, calls)
+}
+
 func TestWatchedMRsSkipRateLimitedHost(t *testing.T) {
 	assert := Assert.New(t)
 	d := openTestDB(t)

--- a/internal/server/config_reload.go
+++ b/internal/server/config_reload.go
@@ -393,6 +393,8 @@ func (s *Server) applyConfigChange(ctx context.Context) configChangedEvent {
 			newCfg.BranchActivityRetention(),
 			newCfg.Activity.DefaultBranchMaxCommits,
 		)
+		s.syncer.SetWatchInterval(newCfg.ActivePRRefreshDuration())
+		s.syncer.SetActiveMRWindow(newCfg.ActivePRWindowDuration())
 	}
 
 	s.refreshRuntimeTargetsLocked()

--- a/internal/server/config_reload_test.go
+++ b/internal/server/config_reload_test.go
@@ -1660,6 +1660,8 @@ func TestRestartRequiredForNotificationIntervals(t *testing.T) {
 	base := func() *config.Config {
 		cfg := &config.Config{}
 		cfg.SyncInterval = "5m"
+		cfg.ActivePRRefreshInterval = "2m"
+		cfg.ActivePRWindow = "4h"
 		cfg.Notifications.SyncInterval = "30s"
 		cfg.Notifications.PropagationInterval = "1m"
 		cfg.Notifications.BatchSize = 25
@@ -1684,6 +1686,16 @@ func TestRestartRequiredForNotificationIntervals(t *testing.T) {
 	batchSizeChanged.Notifications.BatchSize = 50
 	require.True(snap.restartRequiredFor(batchSizeChanged),
 		"notification batch_size is snapped by the loop")
+
+	activeRefreshChanged := base()
+	activeRefreshChanged.ActivePRRefreshInterval = "30s"
+	require.False(snap.restartRequiredFor(activeRefreshChanged),
+		"active PR refresh interval is hot-reloadable by the syncer")
+
+	activeWindowChanged := base()
+	activeWindowChanged.ActivePRWindow = "8h"
+	require.False(snap.restartRequiredFor(activeWindowChanged),
+		"active PR window is hot-reloadable by the syncer")
 }
 
 const validReloadConfigAuthGate = `


### PR DESCRIPTION
Maintainers spend most of their day in the Activity view, so waiting for the full repository sync interval can make active PRs feel stale when switching context. This keeps recently active open PRs warm on the existing fast-sync path and sends the normal data-change signal after those refreshes so Activity can pick up fresh rows.

The refresh interval and activity window are configurable in config.toml, defaulting to 2 minutes and 4 hours. The implementation keeps the existing provider/host identity and rate-limit gates in the fast-sync path so the extra API traffic stays scoped to the active set.