### PR TITLE
Highlight repo browser YAML files

### DIFF
--- a/frontend/src/lib/features/repo-browser/PierreFileContents.svelte
+++ b/frontend/src/lib/features/repo-browser/PierreFileContents.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { File as PierreFile } from "@pierre/diffs";
-  import type { FileContents, FileOptions, ThemeTypes } from "@pierre/diffs";
+  import type { FileContents, FileOptions, SupportedLanguages, ThemeTypes } from "@pierre/diffs";
   import { onMount } from "svelte";
 
   interface Props {
@@ -17,10 +17,15 @@
   let themeType = $state<ThemeTypes>(appThemeType());
   let renderFailed = $state(false);
 
-  const fileContents = $derived<FileContents>({
-    name: path,
-    contents,
-    cacheKey: fileContentsCacheKey(path, contents),
+  const fileContents = $derived.by<FileContents>(() => {
+    const lang = sourceLanguageForPath(path);
+
+    return {
+      name: path,
+      contents,
+      ...(lang === undefined ? {} : { lang }),
+      cacheKey: fileContentsCacheKey(path, contents),
+    };
   });
 
   const options = $derived.by<FileOptions<undefined>>(() => ({
@@ -109,6 +114,11 @@
       hash = Math.imul(hash, 16777619);
     }
     return `${filePath}\0${text.length}\0${hash >>> 0}`;
+  }
+
+  function sourceLanguageForPath(filePath: string): SupportedLanguages | undefined {
+    if (/\.ya?ml$/i.test(filePath)) return "yaml";
+    return undefined;
   }
 </script>
 

--- a/frontend/src/lib/features/repo-browser/PierreFileContents.test.ts
+++ b/frontend/src/lib/features/repo-browser/PierreFileContents.test.ts
@@ -55,4 +55,32 @@ describe("PierreFileContents", () => {
     expect(fallback.textContent).toBe("export const value = 1;\n");
     expect(pierreMock.cleanUp).toHaveBeenCalled();
   });
+
+  it.each([
+    [".github/workflows/desktop-release.yml", "yaml"],
+    ["deployment/config.yaml", "yaml"],
+    ["src/main.ts", undefined],
+  ])("maps %s to the expected Pierre language", async (path, expectedLang) => {
+    render(PierreFileContents, {
+      props: {
+        path,
+        contents: "name: release\n",
+      },
+    });
+
+    await vi.waitFor(() => expect(pierreMock.render).toHaveBeenCalled());
+
+    const [{ file }] = pierreMock.render.mock.calls.at(-1) ?? [];
+
+    expect(file).toMatchObject({
+      name: path,
+      contents: "name: release\n",
+    });
+
+    if (expectedLang === undefined) {
+      expect(file).not.toHaveProperty("lang");
+    } else {
+      expect(file).toHaveProperty("lang", expectedLang);
+    }
+  });
 });


### PR DESCRIPTION
- Repo browser source view now treats `.yml` and `.yaml` files as YAML for syntax highlighting.
- Other file extensions continue to use Pierre's normal filename inference.