### PR TITLE
Resize repo browser rails

### DIFF
--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
@@ -56,10 +56,11 @@
   };
   type RefPickerType = "branch" | "tag";
 
+  const DEFAULT_FILES_WIDTH = 340;
   const DEFAULT_HISTORY_WIDTH = 320;
-  const MIN_HISTORY_WIDTH = 260;
+  const MIN_RAIL_WIDTH = 260;
   const MIN_VIEWER_WIDTH = 360;
-  const HISTORY_RESIZE_HANDLE_WIDTH = 4;
+  const RESIZE_HANDLE_WIDTH = 4;
 
   let { client, route, onRouteChange }: Props = $props();
 
@@ -85,9 +86,11 @@
   let contentEl = $state<HTMLElement | null>(null);
   let sidebarEl = $state<HTMLElement | null>(null);
   let contentWidth = $state(0);
-  let sidebarWidth = $state(0);
+  let filesWidth = $state(DEFAULT_FILES_WIDTH);
+  let filesResizeStartWidth = DEFAULT_FILES_WIDTH;
   let historyWidth = $state(DEFAULT_HISTORY_WIDTH);
   let historyResizeStartWidth = DEFAULT_HISTORY_WIDTH;
+  let historyRailVisible = $state(true);
 
   const selectedPath = $derived(store.getSelectedPath());
   const selectedRef = $derived(store.getSelectedRef());
@@ -388,27 +391,82 @@
 
   function updateSplitMeasurements(): void {
     const nextContentWidth = contentEl?.clientWidth ?? 0;
-    const nextSidebarWidth = sidebarEl?.getBoundingClientRect().width ?? 0;
+    historyRailVisible =
+      typeof window === "undefined" || typeof window.matchMedia !== "function"
+        ? true
+        : window.matchMedia("(min-width: 981px)").matches;
     contentWidth = nextContentWidth;
-    sidebarWidth = nextSidebarWidth;
     if (nextContentWidth <= 0) return;
-    const nextHistoryWidth = clampHistoryWidth(historyWidth, nextContentWidth, nextSidebarWidth);
+    const nextFilesWidth = clampFilesWidth(filesWidth, nextContentWidth, historyWidth, historyRailVisible);
+    if (nextFilesWidth !== filesWidth) {
+      filesWidth = nextFilesWidth;
+    }
+    const nextHistoryWidth = clampHistoryWidth(historyWidth, nextContentWidth, nextFilesWidth, historyRailVisible);
     if (nextHistoryWidth !== historyWidth) {
       historyWidth = nextHistoryWidth;
     }
   }
 
-  function maxHistoryWidth(nextContentWidth = contentWidth, nextSidebarWidth = sidebarWidth): number {
-    if (nextContentWidth <= 0) return Math.max(DEFAULT_HISTORY_WIDTH, MIN_HISTORY_WIDTH);
-    const availableForViewerAndHistory = nextContentWidth - nextSidebarWidth - HISTORY_RESIZE_HANDLE_WIDTH;
-    if (availableForViewerAndHistory <= 0) return MIN_HISTORY_WIDTH;
-    return Math.max(MIN_HISTORY_WIDTH, availableForViewerAndHistory - MIN_VIEWER_WIDTH);
+  function railHandleCount(nextHistoryRailVisible = historyRailVisible): number {
+    return nextHistoryRailVisible ? 2 : 1;
   }
 
-  function clampHistoryWidth(width: number, nextContentWidth = contentWidth, nextSidebarWidth = sidebarWidth): number {
-    const maxWidth = maxHistoryWidth(nextContentWidth, nextSidebarWidth);
-    const minWidth = Math.min(MIN_HISTORY_WIDTH, maxWidth);
+  function maxFilesWidth(
+    nextContentWidth = contentWidth,
+    nextHistoryWidth = historyWidth,
+    nextHistoryRailVisible = historyRailVisible,
+  ): number {
+    if (nextContentWidth <= 0) return Math.max(DEFAULT_FILES_WIDTH, MIN_RAIL_WIDTH);
+    const visibleHistoryWidth = nextHistoryRailVisible ? nextHistoryWidth : 0;
+    const availableForFiles =
+      nextContentWidth - visibleHistoryWidth - railHandleCount(nextHistoryRailVisible) * RESIZE_HANDLE_WIDTH;
+    if (availableForFiles <= 0) return MIN_RAIL_WIDTH;
+    return Math.max(MIN_RAIL_WIDTH, availableForFiles - MIN_VIEWER_WIDTH);
+  }
+
+  function maxHistoryWidth(
+    nextContentWidth = contentWidth,
+    nextFilesWidth = filesWidth,
+    nextHistoryRailVisible = historyRailVisible,
+  ): number {
+    if (!nextHistoryRailVisible) return Math.max(DEFAULT_HISTORY_WIDTH, MIN_RAIL_WIDTH);
+    if (nextContentWidth <= 0) return Math.max(DEFAULT_HISTORY_WIDTH, MIN_RAIL_WIDTH);
+    const availableForHistory =
+      nextContentWidth - nextFilesWidth - railHandleCount(nextHistoryRailVisible) * RESIZE_HANDLE_WIDTH;
+    if (availableForHistory <= 0) return MIN_RAIL_WIDTH;
+    return Math.max(MIN_RAIL_WIDTH, availableForHistory - MIN_VIEWER_WIDTH);
+  }
+
+  function clampFilesWidth(
+    width: number,
+    nextContentWidth = contentWidth,
+    nextHistoryWidth = historyWidth,
+    nextHistoryRailVisible = historyRailVisible,
+  ): number {
+    const maxWidth = maxFilesWidth(nextContentWidth, nextHistoryWidth, nextHistoryRailVisible);
+    const minWidth = Math.min(MIN_RAIL_WIDTH, maxWidth);
     return Math.max(minWidth, Math.min(maxWidth, width));
+  }
+
+  function clampHistoryWidth(
+    width: number,
+    nextContentWidth = contentWidth,
+    nextFilesWidth = filesWidth,
+    nextHistoryRailVisible = historyRailVisible,
+  ): number {
+    const maxWidth = maxHistoryWidth(nextContentWidth, nextFilesWidth, nextHistoryRailVisible);
+    const minWidth = Math.min(MIN_RAIL_WIDTH, maxWidth);
+    return Math.max(minWidth, Math.min(maxWidth, width));
+  }
+
+  function startFilesResize(): void {
+    updateSplitMeasurements();
+    filesWidth = clampFilesWidth(filesWidth);
+    filesResizeStartWidth = filesWidth;
+  }
+
+  function resizeFiles(event: SplitResizeEvent): void {
+    filesWidth = clampFilesWidth(filesResizeStartWidth + event.deltaX);
   }
 
   function startHistoryResize(): void {
@@ -694,7 +752,12 @@
   </header>
 
   <div class="repo-browser__content" bind:this={contentEl}>
-    <aside class="repo-browser__sidebar" aria-label="Files" bind:this={sidebarEl}>
+    <aside
+      class="repo-browser__sidebar"
+      aria-label="Files"
+      bind:this={sidebarEl}
+      style:width={`${Math.round(filesWidth)}px`}
+    >
       <div class="repo-browser__filter">
         <input
           type="search"
@@ -727,6 +790,13 @@
         />
       </div>
     </aside>
+
+    <SplitResizeHandle
+      class="repo-browser__files-resize"
+      ariaLabel="Resize file tree"
+      onResizeStart={startFilesResize}
+      onResize={resizeFiles}
+    />
 
     <main class="repo-browser__viewer" aria-label="Selected file">
       <div class="repo-browser__filebar">
@@ -1085,7 +1155,7 @@
   }
 
   .repo-browser__sidebar {
-    flex: 0 0 clamp(260px, 28vw, 340px);
+    flex: 0 0 auto;
     border-right: thin solid var(--border-default);
   }
 
@@ -1094,6 +1164,7 @@
     border-left: thin solid var(--border-default);
   }
 
+  :global(.repo-browser__files-resize),
   :global(.repo-browser__history-resize) {
     background: var(--border-default);
   }
@@ -1340,12 +1411,10 @@
       display: none;
     }
 
-    .repo-browser__sidebar {
-      flex-basis: clamp(220px, 32vw, 300px);
-    }
   }
 
   @media (max-width: 720px) {
+    :global(.repo-browser__files-resize),
     .repo-browser__sidebar {
       display: none;
     }

--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
@@ -6,12 +6,14 @@
     createRepoBrowserStore,
     diffFileCategoryOptions,
     PierreFileTree,
+    SplitResizeHandle,
     type DiffFileCategoryFilter,
     type FileTreeEntry,
     type MiddlemanClient,
     type RepoBrowserRouteRef,
     type RepoBrowserViewMode,
     type SourceBrowserFileEntry,
+    type SplitResizeEvent,
   } from "@middleman/ui";
   import type { RepoBrowserCommit, RepoBrowserRef } from "@middleman/ui/api/types";
   import { providerDefaultHost } from "@middleman/ui/api/provider-routes";
@@ -54,6 +56,11 @@
   };
   type RefPickerType = "branch" | "tag";
 
+  const DEFAULT_HISTORY_WIDTH = 320;
+  const MIN_HISTORY_WIDTH = 260;
+  const MIN_VIEWER_WIDTH = 360;
+  const HISTORY_RESIZE_HANDLE_WIDTH = 4;
+
   let { client, route, onRouteChange }: Props = $props();
 
   // svelte-ignore state_referenced_locally
@@ -75,6 +82,12 @@
   let refPickerSelectionInFlight = false;
   const refPickerListID = `repo-browser-ref-${Math.random().toString(36).slice(2)}`;
   const refPickerRenderLimit = 100;
+  let contentEl = $state<HTMLElement | null>(null);
+  let sidebarEl = $state<HTMLElement | null>(null);
+  let contentWidth = $state(0);
+  let sidebarWidth = $state(0);
+  let historyWidth = $state(DEFAULT_HISTORY_WIDTH);
+  let historyResizeStartWidth = DEFAULT_HISTORY_WIDTH;
 
   const selectedPath = $derived(store.getSelectedPath());
   const selectedRef = $derived(store.getSelectedRef());
@@ -101,6 +114,28 @@
   const tagRefs = $derived(store.getRefs().filter((ref) => refPickerRefType(ref) === "tag"));
   const filteredRefs = $derived.by(() => filterRefs(refPickerType === "branch" ? branchRefs : tagRefs, refPickerQuery));
   const visibleFilteredRefs = $derived(filteredRefs.slice(0, refPickerRenderLimit));
+
+  $effect(() => {
+    if (!contentEl || !sidebarEl) return;
+
+    updateSplitMeasurements();
+
+    const observers: ResizeObserver[] = [];
+    if (typeof ResizeObserver !== "undefined") {
+      const observer = new ResizeObserver(updateSplitMeasurements);
+      observer.observe(contentEl);
+      observer.observe(sidebarEl);
+      observers.push(observer);
+    }
+
+    window.addEventListener("resize", updateSplitMeasurements);
+    return () => {
+      window.removeEventListener("resize", updateSplitMeasurements);
+      for (const observer of observers) {
+        observer.disconnect();
+      }
+    };
+  });
 
   $effect(() => {
     const nextRepoLoadKey = routeKey(route);
@@ -349,6 +384,41 @@
 
   function selectHistoryCommit(commit: RepoBrowserCommit): void {
     void store.selectCommit(commit.sha);
+  }
+
+  function updateSplitMeasurements(): void {
+    const nextContentWidth = contentEl?.clientWidth ?? 0;
+    const nextSidebarWidth = sidebarEl?.getBoundingClientRect().width ?? 0;
+    contentWidth = nextContentWidth;
+    sidebarWidth = nextSidebarWidth;
+    if (nextContentWidth <= 0) return;
+    const nextHistoryWidth = clampHistoryWidth(historyWidth, nextContentWidth, nextSidebarWidth);
+    if (nextHistoryWidth !== historyWidth) {
+      historyWidth = nextHistoryWidth;
+    }
+  }
+
+  function maxHistoryWidth(nextContentWidth = contentWidth, nextSidebarWidth = sidebarWidth): number {
+    if (nextContentWidth <= 0) return Math.max(DEFAULT_HISTORY_WIDTH, MIN_HISTORY_WIDTH);
+    const availableForViewerAndHistory = nextContentWidth - nextSidebarWidth - HISTORY_RESIZE_HANDLE_WIDTH;
+    if (availableForViewerAndHistory <= 0) return MIN_HISTORY_WIDTH;
+    return Math.max(MIN_HISTORY_WIDTH, availableForViewerAndHistory - MIN_VIEWER_WIDTH);
+  }
+
+  function clampHistoryWidth(width: number, nextContentWidth = contentWidth, nextSidebarWidth = sidebarWidth): number {
+    const maxWidth = maxHistoryWidth(nextContentWidth, nextSidebarWidth);
+    const minWidth = Math.min(MIN_HISTORY_WIDTH, maxWidth);
+    return Math.max(minWidth, Math.min(maxWidth, width));
+  }
+
+  function startHistoryResize(): void {
+    updateSplitMeasurements();
+    historyWidth = clampHistoryWidth(historyWidth);
+    historyResizeStartWidth = historyWidth;
+  }
+
+  function resizeHistory(event: SplitResizeEvent): void {
+    historyWidth = clampHistoryWidth(historyResizeStartWidth - event.deltaX);
   }
 
   function toTreeEntry(file: SourceBrowserFileEntry): FileTreeEntry {
@@ -623,8 +693,8 @@
     </div>
   </header>
 
-  <div class="repo-browser__content">
-    <aside class="repo-browser__sidebar" aria-label="Files">
+  <div class="repo-browser__content" bind:this={contentEl}>
+    <aside class="repo-browser__sidebar" aria-label="Files" bind:this={sidebarEl}>
       <div class="repo-browser__filter">
         <input
           type="search"
@@ -719,7 +789,14 @@
       {/if}
     </main>
 
-    <aside class="repo-browser__history" aria-label="File history">
+    <SplitResizeHandle
+      class="repo-browser__history-resize"
+      ariaLabel="Resize file history"
+      onResizeStart={startHistoryResize}
+      onResize={resizeHistory}
+    />
+
+    <aside class="repo-browser__history" aria-label="File history" style:width={`${Math.round(historyWidth)}px`}>
       <header class="repo-browser__history-header">
         <span>History</span>
         <span>{store.getFileHistory().length}</span>
@@ -993,8 +1070,7 @@
   .repo-browser__content {
     flex: 1 1 auto;
     min-height: 0;
-    display: grid;
-    grid-template-columns: minmax(260px, 340px) minmax(0, 1fr) minmax(250px, 320px);
+    display: flex;
     overflow: hidden;
   }
 
@@ -1009,11 +1085,17 @@
   }
 
   .repo-browser__sidebar {
+    flex: 0 0 clamp(260px, 28vw, 340px);
     border-right: thin solid var(--border-default);
   }
 
   .repo-browser__history {
+    flex: 0 0 auto;
     border-left: thin solid var(--border-default);
+  }
+
+  :global(.repo-browser__history-resize) {
+    background: var(--border-default);
   }
 
   .repo-browser__filter {
@@ -1253,20 +1335,17 @@
   }
 
   @media (max-width: 980px) {
-    .repo-browser__content {
-      grid-template-columns: minmax(220px, 300px) minmax(0, 1fr);
-    }
-
+    :global(.repo-browser__history-resize),
     .repo-browser__history {
       display: none;
+    }
+
+    .repo-browser__sidebar {
+      flex-basis: clamp(220px, 32vw, 300px);
     }
   }
 
   @media (max-width: 720px) {
-    .repo-browser__content {
-      grid-template-columns: 1fr;
-    }
-
     .repo-browser__sidebar {
       display: none;
     }

--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
@@ -1219,6 +1219,7 @@
   }
 
   .repo-browser__viewer {
+    flex: 1 1 0;
     min-width: 0;
     min-height: 0;
     display: flex;

--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.test.ts
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.test.ts
@@ -400,12 +400,59 @@ describe("RepoBrowserFeature", () => {
     expect(viewer.getAttribute("data-path")).toBe(sourceFile.path);
     expect(viewer.textContent).toContain("package main");
   });
+
+  it("resizes the history rail within usable viewer constraints across view modes", async () => {
+    render(RepoBrowserFeature, {
+      props: {
+        client: testClient(),
+        route,
+        onRouteChange: vi.fn(),
+      },
+    });
+
+    const history = await screen.findByLabelText("File history");
+    const content = document.querySelector(".repo-browser__content") as HTMLElement | null;
+    const sidebar = document.querySelector(".repo-browser__sidebar") as HTMLElement | null;
+    expect(content).not.toBeNull();
+    expect(sidebar).not.toBeNull();
+    setReadonlyNumber(content!, "clientWidth", 1200);
+    sidebar!.getBoundingClientRect = () => ({ width: 340 }) as DOMRect;
+
+    const handle = screen.getByRole("button", { name: "Resize file history" });
+    expect(history.getAttribute("style")).toContain("width: 320px");
+
+    await fireEvent.mouseDown(handle, { clientX: 800 });
+    await fireEvent.mouseMove(window, { clientX: 700 });
+    expect(history.getAttribute("style")).toContain("width: 420px");
+
+    await fireEvent.mouseMove(window, { clientX: 350 });
+    expect(history.getAttribute("style")).toContain("width: 496px");
+
+    await fireEvent.mouseMove(window, { clientX: 1200 });
+    expect(history.getAttribute("style")).toContain("width: 260px");
+    await fireEvent.mouseUp(window, { clientX: 1200 });
+
+    await fireEvent.keyDown(handle, { key: "ArrowLeft" });
+    expect(history.getAttribute("style")).toContain("width: 284px");
+
+    await fireEvent.click(screen.getByRole("button", { name: "Source" }));
+    expect(history.getAttribute("style")).toContain("width: 284px");
+    await fireEvent.click(screen.getByRole("button", { name: "Preview" }));
+    expect(history.getAttribute("style")).toContain("width: 284px");
+  });
 });
 
 function scrolledHeadingIDs(scrollIntoView: ReturnType<typeof vi.fn>): string[] {
   return scrollIntoView.mock.contexts.flatMap((context) => {
     if (context instanceof HTMLElement && context.id) return [context.id];
     return [];
+  });
+}
+
+function setReadonlyNumber(element: HTMLElement, property: "clientWidth", value: number): void {
+  Object.defineProperty(element, property, {
+    configurable: true,
+    get: () => value,
   });
 }
 

--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.test.ts
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.test.ts
@@ -401,7 +401,7 @@ describe("RepoBrowserFeature", () => {
     expect(viewer.textContent).toContain("package main");
   });
 
-  it("resizes the history rail within usable viewer constraints across view modes", async () => {
+  it("resizes both side rails within usable viewer constraints across view modes", async () => {
     render(RepoBrowserFeature, {
       props: {
         client: testClient(),
@@ -416,29 +416,48 @@ describe("RepoBrowserFeature", () => {
     expect(content).not.toBeNull();
     expect(sidebar).not.toBeNull();
     setReadonlyNumber(content!, "clientWidth", 1200);
-    sidebar!.getBoundingClientRect = () => ({ width: 340 }) as DOMRect;
+    sidebar!.getBoundingClientRect = () => ({ width: Number.parseInt(sidebar!.style.width || "340", 10) }) as DOMRect;
 
-    const handle = screen.getByRole("button", { name: "Resize file history" });
+    const filesHandle = screen.getByRole("button", { name: "Resize file tree" });
+    expect(sidebar!.getAttribute("style")).toContain("width: 340px");
+
+    await fireEvent.mouseDown(filesHandle, { clientX: 200 });
+    await fireEvent.mouseMove(window, { clientX: 300 });
+    expect(sidebar!.getAttribute("style")).toContain("width: 440px");
+
+    await fireEvent.mouseMove(window, { clientX: 700 });
+    expect(sidebar!.getAttribute("style")).toContain("width: 512px");
+
+    await fireEvent.mouseMove(window, { clientX: -100 });
+    expect(sidebar!.getAttribute("style")).toContain("width: 260px");
+    await fireEvent.mouseUp(window, { clientX: -100 });
+
+    await fireEvent.keyDown(filesHandle, { key: "ArrowRight" });
+    expect(sidebar!.getAttribute("style")).toContain("width: 284px");
+
+    const historyHandle = screen.getByRole("button", { name: "Resize file history" });
     expect(history.getAttribute("style")).toContain("width: 320px");
 
-    await fireEvent.mouseDown(handle, { clientX: 800 });
+    await fireEvent.mouseDown(historyHandle, { clientX: 800 });
     await fireEvent.mouseMove(window, { clientX: 700 });
     expect(history.getAttribute("style")).toContain("width: 420px");
 
     await fireEvent.mouseMove(window, { clientX: 350 });
-    expect(history.getAttribute("style")).toContain("width: 496px");
+    expect(history.getAttribute("style")).toContain("width: 548px");
 
     await fireEvent.mouseMove(window, { clientX: 1200 });
     expect(history.getAttribute("style")).toContain("width: 260px");
     await fireEvent.mouseUp(window, { clientX: 1200 });
 
-    await fireEvent.keyDown(handle, { key: "ArrowLeft" });
+    await fireEvent.keyDown(historyHandle, { key: "ArrowLeft" });
     expect(history.getAttribute("style")).toContain("width: 284px");
 
     await fireEvent.click(screen.getByRole("button", { name: "Source" }));
     expect(history.getAttribute("style")).toContain("width: 284px");
+    expect(sidebar!.getAttribute("style")).toContain("width: 284px");
     await fireEvent.click(screen.getByRole("button", { name: "Preview" }));
     expect(history.getAttribute("style")).toContain("width: 284px");
+    expect(sidebar!.getAttribute("style")).toContain("width: 284px");
   });
 });
 

--- a/frontend/tests/e2e-full/repo-browser.spec.ts
+++ b/frontend/tests/e2e-full/repo-browser.spec.ts
@@ -97,6 +97,28 @@ async function expectHeadingScrolledIntoView(heading: Locator): Promise<void> {
   expect(scrollTop).toBeGreaterThan(100);
 }
 
+async function boundingWidth(locator: Locator): Promise<number> {
+  const box = await locator.boundingBox();
+  expect(box).not.toBeNull();
+  if (!box) throw new Error("missing element box");
+  return box.width;
+}
+
+async function dragResizeHandle(page: Page, handle: Locator, deltaX: number): Promise<void> {
+  const box = await handle.boundingBox();
+  expect(box).not.toBeNull();
+  if (!box) throw new Error("resize handle missing");
+
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(box.x + box.width / 2 + deltaX, box.y + box.height / 2, { steps: 10 });
+  await page.mouse.up();
+}
+
+async function expectWidthAtLeast(locator: Locator, minWidth: number): Promise<void> {
+  await expect.poll(async () => Math.round(await boundingWidth(locator))).toBeGreaterThanOrEqual(minWidth);
+}
+
 test.describe("repository source browser", () => {
   test("does not reload repository data when the no-ref route is replaced with the default ref", async ({ page }) => {
     const server = await startIsolatedE2EServer();
@@ -371,6 +393,87 @@ test.describe("repository source browser", () => {
       await expect(history).toContainText("Initial commit");
       await history.getByRole("button", { name: /Initial commit/ }).click();
       await expect(history.locator(".repo-browser__commit-detail")).toContainText("Initial commit");
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("resizes both source browser rails with stable viewer constraints", async ({ page }) => {
+    const server = await startIsolatedE2EServer();
+    try {
+      await page.setViewportSize({ width: 1280, height: 900 });
+
+      const treeLoaded = treeResponse(page, "main");
+      const blobLoaded = blobResponse(page, "README.md");
+      await page.goto(
+        `${server.info.base_url}/repo/browser?provider=github&repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&path=README.md&desktop=1`,
+      );
+      await treeLoaded;
+      await blobLoaded;
+
+      const browser = page.getByRole("region", { name: "Repository source browser" });
+      const content = browser.locator(".repo-browser__content");
+      const sidebar = browser.locator(".repo-browser__sidebar");
+      const viewer = browser.getByRole("main", { name: "Selected file" });
+      const history = browser.getByRole("complementary", { name: "File history" });
+      const filesHandle = browser.getByRole("button", { name: "Resize file tree" });
+      const historyHandle = browser.getByRole("button", { name: "Resize file history" });
+
+      await expect(viewer.locator(".repo-browser__path")).toContainText("README.md");
+      await expect(sidebar).toBeVisible();
+      await expect(history).toBeVisible();
+      await expect(filesHandle).toBeVisible();
+      await expect(historyHandle).toBeVisible();
+
+      const initialContentWidth = await boundingWidth(content);
+      const initialFilesWidth = await boundingWidth(sidebar);
+      const initialViewerWidth = await boundingWidth(viewer);
+      const initialHistoryWidth = await boundingWidth(history);
+      expect(Math.round(initialFilesWidth)).toBe(340);
+      expect(Math.round(initialHistoryWidth)).toBe(320);
+      expect(initialViewerWidth).toBeGreaterThanOrEqual(360);
+
+      await dragResizeHandle(page, filesHandle, 80);
+      await expect.poll(async () => Math.round(await boundingWidth(sidebar))).toBe(420);
+      await expectWidthAtLeast(viewer, 360);
+      await expect.poll(async () => Math.round(await boundingWidth(history))).toBe(320);
+
+      await dragResizeHandle(page, historyHandle, -80);
+      await expect.poll(async () => Math.round(await boundingWidth(history))).toBe(400);
+      await expectWidthAtLeast(viewer, 360);
+
+      await dragResizeHandle(page, filesHandle, 1000);
+      await expectWidthAtLeast(viewer, 360);
+      await expectWidthAtLeast(history, 260);
+
+      await dragResizeHandle(page, historyHandle, -1000);
+      await expectWidthAtLeast(viewer, 360);
+      await expectWidthAtLeast(sidebar, 260);
+      await expect.poll(async () => Math.round(await boundingWidth(content))).toBe(Math.round(initialContentWidth));
+
+      const constrainedFilesWidth = Math.round(await boundingWidth(sidebar));
+      const constrainedHistoryWidth = Math.round(await boundingWidth(history));
+      const constrainedViewerWidth = Math.round(await boundingWidth(viewer));
+      await browser.getByRole("button", { name: "Preview" }).click();
+      await expect(viewer.locator(".repo-browser__markdown h1")).toHaveText("Widget Service");
+      expect(Math.round(await boundingWidth(sidebar))).toBe(constrainedFilesWidth);
+      expect(Math.round(await boundingWidth(history))).toBe(constrainedHistoryWidth);
+      expect(Math.round(await boundingWidth(viewer))).toBe(constrainedViewerWidth);
+      await browser.getByRole("button", { name: "Source" }).click();
+      await expect(viewer.locator(".repo-browser__source")).toContainText("# Widget Service");
+      expect(Math.round(await boundingWidth(sidebar))).toBe(constrainedFilesWidth);
+      expect(Math.round(await boundingWidth(history))).toBe(constrainedHistoryWidth);
+      expect(Math.round(await boundingWidth(viewer))).toBe(constrainedViewerWidth);
+
+      await page.setViewportSize({ width: 900, height: 900 });
+      await expect(history).toBeHidden();
+      await expect(historyHandle).toBeHidden();
+      await expect(sidebar).toBeVisible();
+      await expect(filesHandle).toBeVisible();
+
+      await page.setViewportSize({ width: 680, height: 900 });
+      await expect(sidebar).toBeHidden();
+      await expect(filesHandle).toBeHidden();
     } finally {
       await server.stop();
     }

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -517,7 +517,7 @@ type mockClient struct {
 	checkRunsErr                    error
 	workflowRuns                    []*gh.WorkflowRun
 	approveWorkflowRunFn            func(context.Context, string, string, int64) error
-	listOpenPRsCalled               bool
+	listOpenPRsCalled               atomic.Bool
 	getUserCalls                    atomic.Int32
 	getCombinedCalls                atomic.Int32
 	invalidateCalls                 atomic.Int32
@@ -799,7 +799,7 @@ func (m *mockClient) InvalidateListETagsForRepo(_, _ string, _ ...string) {
 
 func (m *mockClient) ListOpenPullRequests(ctx context.Context, owner, repo string) ([]*gh.PullRequest, error) {
 	m.trackCall()
-	m.listOpenPRsCalled = true
+	m.listOpenPRsCalled.Store(true)
 	if m.listOpenPRsFn != nil {
 		return m.listOpenPRsFn(ctx, owner, repo)
 	}
@@ -6206,9 +6206,9 @@ func TestSyncerMultiHostClientDispatch(t *testing.T) {
 	syncer := NewSyncer(clients, d, nil, repos, time.Minute, nil, nil)
 	syncer.RunOnce(t.Context())
 
-	assert.True(ghMock.listOpenPRsCalled,
+	assert.True(ghMock.listOpenPRsCalled.Load(),
 		"github.com mock should have been called")
-	assert.True(gheMock.listOpenPRsCalled,
+	assert.True(gheMock.listOpenPRsCalled.Load(),
 		"ghe.corp.com mock should have been called")
 }
 
@@ -7124,9 +7124,9 @@ func TestRunOnceSkipsThrottledHosts(t *testing.T) {
 		"ghe.corp.com repo should be skipped when paused")
 
 	// github.com mock should have been called, GHE should not.
-	assert.True(ghMock.listOpenPRsCalled,
+	assert.True(ghMock.listOpenPRsCalled.Load(),
 		"github.com client should have been called")
-	assert.False(gheMock.listOpenPRsCalled,
+	assert.False(gheMock.listOpenPRsCalled.Load(),
 		"ghe.corp.com client should NOT have been called")
 }
 
@@ -7279,7 +7279,7 @@ func TestRunOnceIndexOnly(t *testing.T) {
 	syncer.RunOnce(ctx)
 
 	// ListOpenPullRequests should have been called.
-	assert.True(mc.listOpenPRsCalled,
+	assert.True(mc.listOpenPRsCalled.Load(),
 		"index scan should call ListOpenPullRequests")
 
 	// GetPullRequest should NOT have been called (no detail fetch).
@@ -7767,7 +7767,7 @@ func TestRunOnceLargeExistingRepoSkipsBulkGraphQLAndFetchesChangedPRDetail(t *te
 
 	syncer.RunOnce(ctx)
 
-	assert.True(mc.listOpenPRsCalled,
+	assert.True(mc.listOpenPRsCalled.Load(),
 		"large repo refresh should still read the open PR index")
 	assert.Zero(int(graphQLPRCalls.Load()),
 		"large existing repo refresh should not bulk-fetch every PR through GraphQL")
@@ -12267,7 +12267,7 @@ func TestRunOnceRecoveredRateLimitSnapshotClearsStaleThrottleGate(t *testing.T) 
 	beforeRun := time.Now().UTC()
 	syncer.RunOnce(t.Context())
 
-	assert.True(mock.listOpenPRsCalled)
+	assert.True(mock.listOpenPRsCalled.Load())
 	nextSyncAfter, ok := syncer.nextSyncAfter["github.com"]
 	if assert.True(ok) {
 		assert.Less(nextSyncAfter.Sub(beforeRun), 2*interval)


### PR DESCRIPTION
- Resize the repo browser Files and History rails with the shared split-pane handle.
- Clamp both rails so the selected-file viewer remains usable across source and Markdown preview modes.

<sup>generated by a clanker</sup>