### PR TITLE
Fix repo browser directory selection

### DIFF
--- a/docs/superpowers/specs/2026-06-23-repo-source-browser-design.md
+++ b/docs/superpowers/specs/2026-06-23-repo-source-browser-design.md
@@ -262,7 +262,7 @@ The repo browser deep link carries:
 - provider and platform host when needed
 - `repo_path` as the canonical repository identity
 - selected ref type, display ref name, and resolved SHA when known
-- selected file path
+- selected path, which may be a file or directory
 - source/preview mode
 
 The app route is query-based to avoid collisions between slash-containing repo
@@ -284,6 +284,14 @@ must include a nested repo path where owner/name alone is insufficient.
 
 When no path is present, the browser auto-selects a README variant if present.
 If no README exists, it shows the tree with no selected file.
+
+Directory paths are valid selection state for navigation and deep links. A
+directory may be an explicit tree entry or an implicit parent synthesized from
+tracked file paths; selecting it keeps the tree row selected and shows an empty
+main pane rather than requesting blob/history data. Missing-path errors apply
+only when the selected path is neither a file nor a directory in the loaded tree
+(`packages/ui/src/stores/repo-browser.svelte::repoBrowserPathKind`,
+`packages/ui/src/stores/repo-browser.svelte.test.ts`).
 
 When switching refs, the browser preserves the selected path if that path exists
 on the new ref. If it does not exist, the route keeps the path and the main pane

--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.test.ts
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.test.ts
@@ -401,6 +401,32 @@ describe("RepoBrowserFeature", () => {
     expect(viewer.textContent).toContain("package main");
   });
 
+  it("renders an empty viewer for a direct directory route without loading a blob", async () => {
+    const client = testClient();
+    render(RepoBrowserFeature, {
+      props: {
+        client,
+        route: {
+          ...route,
+          path: "docs",
+          mode: "source",
+        },
+        onRouteChange: vi.fn(),
+      },
+    });
+
+    await screen.findByText("docs");
+    expect(await screen.findByText("Select a file")).toBeTruthy();
+    expect(screen.queryByTestId("repo-browser-pierre-file-contents")).toBeNull();
+    expect(document.body.textContent).not.toContain("unexpected");
+    expect(requestedURLs(client)).not.toContain(
+      "/repo/github/acme/widgets/browser/blob?repo_path=acme%2Fwidgets&ref_type=commit&ref_sha=main-sha&path=docs",
+    );
+    expect(requestedURLs(client)).not.toContain(
+      "/repo/github/acme/widgets/browser/history?repo_path=acme%2Fwidgets&ref_type=commit&ref_sha=main-sha&path=docs",
+    );
+  });
+
   it("resizes both side rails within usable viewer constraints across view modes", async () => {
     render(RepoBrowserFeature, {
       props: {
@@ -674,6 +700,12 @@ function testURL(path: string, options?: TestGetOptions): string {
   const serializer = createQuerySerializer(options?.querySerializer ?? runtimeQuerySerializerOptions);
   const qs = serializer(options?.params?.query ?? {});
   return qs ? `${url}?${qs}` : url;
+}
+
+function requestedURLs(client: MiddlemanClient): string[] {
+  return (client.GET as unknown as { mock: { calls: Array<[string, TestGetOptions | undefined]> } }).mock.calls.map(
+    ([path, options]) => testURL(path, options),
+  );
 }
 
 function blobResponse(path: string, content: string) {

--- a/frontend/tests/e2e-full/repo-browser.spec.ts
+++ b/frontend/tests/e2e-full/repo-browser.spec.ts
@@ -1,8 +1,8 @@
-import { expect, test, type Locator, type Page, type Response } from "@playwright/test";
+import { expect, test, type Locator, type Page, type Request, type Response } from "@playwright/test";
 
 import { startIsolatedE2EServer } from "./support/e2eServer";
 
-type RepoBrowserEndpoint = "refs" | "tree" | "blob";
+type RepoBrowserEndpoint = "refs" | "tree" | "blob" | "history";
 
 function blobResponse(page: Page, path: string): Promise<Response> {
   return page.waitForResponse((response) => {
@@ -32,6 +32,21 @@ function repoBrowserResponseMatches(
   );
 }
 
+function repoBrowserRequestMatches(
+  request: Request,
+  endpoint: RepoBrowserEndpoint,
+  refName?: string,
+  path?: string,
+): boolean {
+  const url = new URL(request.url());
+  return (
+    request.method() === "GET" &&
+    url.pathname === `/api/v1/repo/github/acme/widgets/browser/${endpoint}` &&
+    (refName === undefined || url.searchParams.get("ref_name") === refName) &&
+    (path === undefined || url.searchParams.get("path") === path)
+  );
+}
+
 function repoBrowserResponse(page: Page, endpoint: RepoBrowserEndpoint, refName?: string): Promise<Response> {
   return page.waitForResponse((response) => repoBrowserResponseMatches(response, endpoint, refName));
 }
@@ -50,6 +65,21 @@ function collectRepoBrowserResponseURLs(
   page.on("response", (response) => {
     if (repoBrowserResponseMatches(response, endpoint, refName, path)) {
       urls.push(response.url());
+    }
+  });
+  return urls;
+}
+
+function collectRepoBrowserRequestURLs(
+  page: Page,
+  endpoint: RepoBrowserEndpoint,
+  refName?: string,
+  path?: string,
+): string[] {
+  const urls: string[] = [];
+  page.on("request", (request) => {
+    if (repoBrowserRequestMatches(request, endpoint, refName, path)) {
+      urls.push(request.url());
     }
   });
   return urls;
@@ -138,6 +168,33 @@ test.describe("repository source browser", () => {
       await expectResolvedBranchURL(page);
 
       await expectSingleRepoLoad(page, refsURLs, treeURLs);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("opens a direct directory route without reading it as a blob", async ({ page }) => {
+    const server = await startIsolatedE2EServer();
+    try {
+      const blobURLs = collectRepoBrowserRequestURLs(page, "blob", undefined, "docs");
+      const historyURLs = collectRepoBrowserRequestURLs(page, "history", undefined, "docs");
+      const treeLoaded = treeResponse(page, "main");
+
+      await page.goto(
+        `${server.info.base_url}/repo/browser?provider=github&repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&path=docs`,
+      );
+      await treeLoaded;
+
+      const browser = page.getByRole("region", { name: "Repository source browser" });
+      const viewer = browser.getByRole("main", { name: "Selected file" });
+      await expect(viewer.locator(".repo-browser__path")).toContainText("docs");
+      await expect(viewer.locator(".repo-browser__state")).toHaveText("Select a file");
+      await expect(viewer.locator(".repo-browser__source")).toHaveCount(0);
+      await expect(viewer.locator(".repo-browser__state--error")).toHaveCount(0);
+      await page.waitForTimeout(500);
+
+      expect(blobURLs).toEqual([]);
+      expect(historyURLs).toEqual([]);
     } finally {
       await server.stop();
     }

--- a/packages/ui/src/stores/repo-browser.svelte.test.ts
+++ b/packages/ui/src/stores/repo-browser.svelte.test.ts
@@ -704,6 +704,47 @@ describe("createRepoBrowserStore", () => {
       "/repo/github/acme/widgets/browser/history?repo_path=acme%2Fwidgets&ref_type=commit&ref_sha=main-sha&path=src",
     );
   });
+
+  it("keeps unknown path selections loading while probing blob and history", async () => {
+    const base = testClient();
+    const missingBlob = deferredResponse();
+    const missingHistory = deferredResponse();
+    const client = {
+      GET: vi.fn((path: string, options?: TestGetOptions) => {
+        const url = testURL(path, options);
+        if (
+          url ===
+          "/repo/github/acme/widgets/browser/blob?repo_path=acme%2Fwidgets&ref_type=commit&ref_sha=main-sha&path=missing.md"
+        ) {
+          return missingBlob.promise;
+        }
+        if (
+          url ===
+          "/repo/github/acme/widgets/browser/history?repo_path=acme%2Fwidgets&ref_type=commit&ref_sha=main-sha&path=missing.md"
+        ) {
+          return missingHistory.promise;
+        }
+        return base.GET(path, options);
+      }),
+    } as unknown as TestClient;
+    const store = createRepoBrowserStore({ client });
+    await store.loadRepo(repo);
+
+    const pending = store.selectPath("missing.md");
+
+    expect(store.getSelectedPath()).toBe("missing.md");
+    expect(store.isBlobLoading()).toBe(true);
+
+    missingBlob.resolve({
+      error: { detail: "git object not found" },
+      response: new Response(null, { status: 404 }),
+    });
+    missingHistory.resolve(historyResponse("missing.md", "unreachable"));
+    await pending;
+
+    expect(store.isBlobLoading()).toBe(false);
+    expect(store.getError()).toBe("git object not found");
+  });
 });
 
 function testURL(path: string, options?: TestGetOptions): string {

--- a/packages/ui/src/stores/repo-browser.svelte.test.ts
+++ b/packages/ui/src/stores/repo-browser.svelte.test.ts
@@ -665,6 +665,45 @@ describe("createRepoBrowserStore", () => {
     expect(store.getSelectedCommit()).toBeNull();
     expect(store.getError()).toBe("Path not found: missing.md");
   });
+
+  it("retains an explicit directory path without loading it as a blob", async () => {
+    const client = testClient();
+    const store = createRepoBrowserStore({ client });
+
+    await store.loadRepo(repo, { path: "src" });
+
+    expect(store.getSelectedPath()).toBe("src");
+    expect(store.getBlob()).toBeNull();
+    expect(store.getFileHistory()).toEqual([]);
+    expect(store.getSelectedCommit()).toBeNull();
+    expect(store.getError()).toBeNull();
+    expect(requestedURLs(client)).not.toContain(
+      "/repo/github/acme/widgets/browser/blob?repo_path=acme%2Fwidgets&ref_type=commit&ref_sha=main-sha&path=src",
+    );
+    expect(requestedURLs(client)).not.toContain(
+      "/repo/github/acme/widgets/browser/history?repo_path=acme%2Fwidgets&ref_type=commit&ref_sha=main-sha&path=src",
+    );
+  });
+
+  it("selects an implicit directory path without loading it as a blob", async () => {
+    const client = testClient();
+    const store = createRepoBrowserStore({ client });
+    await store.loadRepo(repo);
+
+    await store.selectPath("src");
+
+    expect(store.getSelectedPath()).toBe("src");
+    expect(store.getBlob()).toBeNull();
+    expect(store.getFileHistory()).toEqual([]);
+    expect(store.getSelectedCommit()).toBeNull();
+    expect(store.getError()).toBeNull();
+    expect(requestedURLs(client)).not.toContain(
+      "/repo/github/acme/widgets/browser/blob?repo_path=acme%2Fwidgets&ref_type=commit&ref_sha=main-sha&path=src",
+    );
+    expect(requestedURLs(client)).not.toContain(
+      "/repo/github/acme/widgets/browser/history?repo_path=acme%2Fwidgets&ref_type=commit&ref_sha=main-sha&path=src",
+    );
+  });
 });
 
 function testURL(path: string, options?: TestGetOptions): string {
@@ -675,6 +714,12 @@ function testURL(path: string, options?: TestGetOptions): string {
   const serializer = createQuerySerializer(options?.querySerializer ?? runtimeQuerySerializerOptions);
   const qs = serializer(options?.params?.query ?? {});
   return qs ? `${url}?${qs}` : url;
+}
+
+function requestedURLs(client: TestClient): string[] {
+  return (client.GET as unknown as { mock: { calls: Array<[string, TestGetOptions | undefined]> } }).mock.calls.map(
+    ([path, options]) => testURL(path, options),
+  );
 }
 
 function commit(subject: string) {

--- a/packages/ui/src/stores/repo-browser.svelte.ts
+++ b/packages/ui/src/stores/repo-browser.svelte.ts
@@ -25,6 +25,7 @@ type RepoBrowserHistoryResponse = components["schemas"]["RepoBrowserHistoryRespo
 type RepoBrowserLastChangedResponse = components["schemas"]["RepoBrowserLastChangedResponse"];
 type RepoBrowserCommitResponse = components["schemas"]["RepoBrowserCommitResponse"];
 type MissingRequestedPathBehavior = "fallback" | "retain";
+type RepoBrowserPathKind = "file" | "directory" | "missing";
 
 const viewModeStorageKey = "repo-browser-view-mode";
 const lastChangedBatchSize = 250;
@@ -63,6 +64,10 @@ function apiErrorMessage(error: Problem | undefined, fallback: string): string {
 
 function defaultRepoBrowserClient(): MiddlemanClient {
   throw new Error("repo browser store requires a client");
+}
+
+function normalizeRepoBrowserTreePath(path: string): string {
+  return path.replace(/^\/+|\/+$/g, "");
 }
 
 export function createRepoBrowserStore(opts: RepoBrowserStoreOptions = {}) {
@@ -208,7 +213,8 @@ export function createRepoBrowserStore(opts: RepoBrowserStoreOptions = {}) {
     lastChanged = {};
     const autoSelectPathGeneration = pathRequestGeneration;
     if (pathRequestGeneration !== autoSelectPathGeneration) return;
-    const requestedPathExists = requestedPath && tree.some((entry) => entry.path === requestedPath);
+    const requestedPathKind = requestedPath ? repoBrowserPathKind(requestedPath) : "missing";
+    const requestedPathExists = requestedPathKind === "file" || requestedPathKind === "directory";
     const firstPath =
       requestedPathExists || !requestedPath || missingPathBehavior === "fallback"
         ? requestedPathExists
@@ -295,11 +301,13 @@ export function createRepoBrowserStore(opts: RepoBrowserStoreOptions = {}) {
     if (!ref || !requestedRef) return;
     const generation = nextPathRequestGeneration();
     selectedPath = path;
-    blobLoading = true;
+    const pathKind = repoBrowserPathKind(path);
+    blobLoading = pathKind === "file";
     error = null;
     blob = null;
     fileHistory = [];
     selectedCommit = null;
+    if (pathKind === "directory") return;
     try {
       const [{ data: blobData, error: blobError, response: blobResponse }, historyResponse] = await Promise.all([
         client.GET(providerRepoPath(ref, "/browser/blob"), {
@@ -339,6 +347,21 @@ export function createRepoBrowserStore(opts: RepoBrowserStoreOptions = {}) {
     } finally {
       if (isCurrentPathRequest(generation)) blobLoading = false;
     }
+  }
+
+  function repoBrowserPathKind(path: string): RepoBrowserPathKind {
+    const normalized = normalizeRepoBrowserTreePath(path);
+    if (!normalized) return "missing";
+    const entry = tree.find((candidate) => normalizeRepoBrowserTreePath(candidate.path) === normalized);
+    if (entry) return isRepoBrowserFileEntry(entry) ? "file" : "directory";
+    if (tree.some((candidate) => normalizeRepoBrowserTreePath(candidate.path).startsWith(`${normalized}/`))) {
+      return "directory";
+    }
+    return "missing";
+  }
+
+  function isRepoBrowserFileEntry(entry: RepoBrowserTreeEntry): boolean {
+    return entry.type === "blob" || entry.type === "file";
   }
 
   async function selectCommit(sha: string): Promise<void> {

--- a/packages/ui/src/stores/repo-browser.svelte.ts
+++ b/packages/ui/src/stores/repo-browser.svelte.ts
@@ -302,7 +302,7 @@ export function createRepoBrowserStore(opts: RepoBrowserStoreOptions = {}) {
     const generation = nextPathRequestGeneration();
     selectedPath = path;
     const pathKind = repoBrowserPathKind(path);
-    blobLoading = pathKind === "file";
+    blobLoading = pathKind !== "directory";
     error = null;
     blob = null;
     fileHistory = [];


### PR DESCRIPTION
Directory selections in the repo browser now stay as navigation state instead of being read as files.

- Direct folder links show an empty viewer instead of a blob/git-object error.
- Folder rows can remain selected in the tree without triggering blob or history reads.
- Missing file/blob errors still surface normally.