### PR TITLE
fix: make repo browser refs searchable

### DIFF
--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { untrack } from "svelte";
+  import { tick, untrack } from "svelte";
   import { SvelteMap } from "svelte/reactivity";
   import {
     buildRepoBrowserRoute,
@@ -16,7 +16,7 @@
   import type { RepoBrowserCommit, RepoBrowserRef } from "@middleman/ui/api/types";
   import { providerDefaultHost } from "@middleman/ui/api/provider-routes";
   import DocMarkdownView from "../../components/docs/DocMarkdownView.svelte";
-  import { RefreshIcon, ExternalLinkIcon, SpinnerIcon } from "../../icons";
+  import { ChevronDownIcon, RefreshIcon, ExternalLinkIcon, SpinnerIcon } from "../../icons";
   import {
     chooseRepoBrowserInitialPath,
     formatRepoBrowserCommitAge,
@@ -52,6 +52,7 @@
   type RepoBrowserRouteUpdate = Partial<Pick<RepoBrowserFeatureRoute, "path" | "mode">> & {
     anchor?: string | null;
   };
+  type RefPickerType = "branch" | "tag";
 
   let { client, route, onRouteChange }: Props = $props();
 
@@ -65,6 +66,15 @@
   let pathFilter = $state("");
   let selectedPathRevealKey = $state(0);
   let pendingMarkdownAnchor = $state(initialMarkdownAnchor());
+  let refPickerOpen = $state(false);
+  let refPickerQuery = $state("");
+  let refPickerType = $state<RefPickerType>("branch");
+  let refPickerHighlightIndex = $state(0);
+  let refPickerInputEl: HTMLInputElement | null = $state(null);
+  let refPickerRootEl: HTMLDivElement | null = $state(null);
+  let refPickerSelectionInFlight = false;
+  const refPickerListID = `repo-browser-ref-${Math.random().toString(36).slice(2)}`;
+  const refPickerRenderLimit = 100;
 
   const selectedPath = $derived(store.getSelectedPath());
   const selectedRef = $derived(store.getSelectedRef());
@@ -87,6 +97,10 @@
   );
   const markdownIndex = $derived(buildMarkdownIndex(store.getFileEntries()));
   const forgeHref = $derived(buildForgeHref(route, selectedRef, selectedPath));
+  const branchRefs = $derived(store.getRefs().filter((ref) => refPickerRefType(ref) === "branch"));
+  const tagRefs = $derived(store.getRefs().filter((ref) => refPickerRefType(ref) === "tag"));
+  const filteredRefs = $derived.by(() => filterRefs(refPickerType === "branch" ? branchRefs : tagRefs, refPickerQuery));
+  const visibleFilteredRefs = $derived(filteredRefs.slice(0, refPickerRenderLimit));
 
   $effect(() => {
     const nextRepoLoadKey = routeKey(route);
@@ -244,6 +258,77 @@
     pushRoute({ path: store.getSelectedPath() ?? undefined });
   }
 
+  async function openRefPicker(): Promise<void> {
+    refPickerQuery = "";
+    refPickerType = initialRefPickerType();
+    refPickerHighlightIndex = 0;
+    refPickerOpen = true;
+    await tick();
+    refPickerInputEl?.focus();
+  }
+
+  function closeRefPicker(): void {
+    refPickerOpen = false;
+    refPickerQuery = "";
+    refPickerHighlightIndex = 0;
+  }
+
+  async function selectRefFromPicker(ref: RepoBrowserRef): Promise<void> {
+    if (refPickerSelectionInFlight) return;
+    refPickerSelectionInFlight = true;
+    closeRefPicker();
+    try {
+      await selectRefByKey(refKey(ref));
+    } finally {
+      refPickerSelectionInFlight = false;
+    }
+  }
+
+  function setRefPickerType(type: RefPickerType): void {
+    refPickerType = type;
+    refPickerHighlightIndex = 0;
+    void tick().then(() => refPickerInputEl?.focus());
+  }
+
+  function handleRefPickerInput(): void {
+    refPickerHighlightIndex = 0;
+  }
+
+  function handleRefPickerKeydown(event: KeyboardEvent): void {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      refPickerHighlightIndex = Math.min(refPickerHighlightIndex + 1, Math.max(visibleFilteredRefs.length - 1, 0));
+      return;
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      refPickerHighlightIndex = Math.max(refPickerHighlightIndex - 1, 0);
+      return;
+    }
+    if (event.key === "Enter") {
+      event.preventDefault();
+      const ref = visibleFilteredRefs[refPickerHighlightIndex];
+      if (ref) void selectRefFromPicker(ref);
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      closeRefPicker();
+    }
+  }
+
+  function handleRefPickerBlur(event: FocusEvent): void {
+    const related = event.relatedTarget as Node | null;
+    if (refPickerRootEl && related && refPickerRootEl.contains(related)) return;
+    closeRefPicker();
+  }
+
+  function initialRefPickerType(): RefPickerType {
+    if (selectedRef?.type === "tag") return "tag";
+    if (selectedRef?.type === "branch") return "branch";
+    return branchRefs.length > 0 ? "branch" : "tag";
+  }
+
   function setCategoryFilter(filter: DiffFileCategoryFilter): void {
     store.setFileCategoryFilter(filter);
   }
@@ -294,6 +379,19 @@
   function refOptionLabel(ref: RepoBrowserRef): string {
     const suffix = ref.sha ? ` ${ref.sha.slice(0, 8)}` : "";
     return `${ref.type}: ${ref.name || ref.sha.slice(0, 12)}${suffix}`;
+  }
+
+  function refPickerRefType(ref: RepoBrowserRef): RefPickerType | null {
+    if (ref.type === "branch" || ref.type === "tag") return ref.type;
+    return null;
+  }
+
+  function filterRefs(refs: readonly RepoBrowserRef[], query: string): RepoBrowserRef[] {
+    const q = query.trim().toLowerCase();
+    if (!q) return [...refs];
+    return refs.filter((ref) =>
+      [ref.type, ref.name, ref.sha, refOptionLabel(ref)].some((part) => part.toLowerCase().includes(q)),
+    );
   }
 
   function buildMarkdownIndex(files: readonly SourceBrowserFileEntry[]): FolderIndex {
@@ -422,16 +520,94 @@
       <span class="repo-browser__ref">{refLabel(selectedRef)}</span>
     </div>
     <div class="repo-browser__actions">
-      <select
-        class="repo-browser__select"
-        aria-label="Select repository ref"
-        value={selectedRef ? refKey(selectedRef) : ""}
-        onchange={(event) => void selectRefByKey(event.currentTarget.value)}
-      >
-        {#each store.getRefs() as ref (refKey(ref))}
-          <option value={refKey(ref)}>{refOptionLabel(ref)}</option>
-        {/each}
-      </select>
+      <div class="repo-browser__ref-picker typeahead" bind:this={refPickerRootEl}>
+        {#if refPickerOpen}
+          <input
+            bind:this={refPickerInputEl}
+            class="typeahead-input"
+            role="combobox"
+            aria-label="Search repository refs"
+            aria-expanded="true"
+            aria-controls={refPickerListID}
+            aria-autocomplete="list"
+            type="text"
+            bind:value={refPickerQuery}
+            placeholder="Search refs"
+            autocomplete="off"
+            oninput={handleRefPickerInput}
+            onkeydown={handleRefPickerKeydown}
+            onblur={handleRefPickerBlur}
+          />
+          <div
+            class="typeahead-list repo-browser__ref-popover"
+            data-surface="solid"
+          >
+            <div class="repo-browser__ref-tabs" role="tablist" aria-label="Repository ref types">
+              <button
+                type="button"
+                role="tab"
+                aria-selected={refPickerType === "branch"}
+                class:repo-browser__ref-tab--active={refPickerType === "branch"}
+                onclick={() => setRefPickerType("branch")}
+              >Branches {branchRefs.length}</button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={refPickerType === "tag"}
+                class:repo-browser__ref-tab--active={refPickerType === "tag"}
+                onclick={() => setRefPickerType("tag")}
+              >Tags {tagRefs.length}</button>
+            </div>
+            <ul
+              id={refPickerListID}
+              class="repo-browser__ref-list"
+              role="listbox"
+              tabindex="-1"
+              aria-label="Repository ref options"
+            >
+              {#each visibleFilteredRefs as ref, index (refKey(ref))}
+                <li
+                  class="typeahead-option"
+                  class:highlighted={index === refPickerHighlightIndex}
+                  class:selected={selectedRef !== null && refKey(ref) === refKey(selectedRef)}
+                  role="option"
+                  aria-selected={selectedRef !== null && refKey(ref) === refKey(selectedRef)}
+                  tabindex="-1"
+                  onclick={() => void selectRefFromPicker(ref)}
+                  onmousedown={() => void selectRefFromPicker(ref)}
+                  onkeydown={(event) => {
+                    if (event.key === "Enter" || event.key === " ") void selectRefFromPicker(ref);
+                  }}
+                  onmouseenter={() => (refPickerHighlightIndex = index)}
+                >
+                  <span class="option-label">{ref.type}: {ref.name || ref.sha.slice(0, 12)}</span>
+                  {#if ref.sha}
+                    <span class="option-meta">{ref.sha.slice(0, 8)}</span>
+                  {/if}
+                </li>
+              {:else}
+                <li class="typeahead-empty">No {refPickerType === "branch" ? "branches" : "tags"} match</li>
+              {/each}
+            </ul>
+            {#if filteredRefs.length > visibleFilteredRefs.length}
+              <div class="repo-browser__ref-more">Showing first {visibleFilteredRefs.length} of {filteredRefs.length}</div>
+            {/if}
+          </div>
+        {:else}
+          <button
+            class="typeahead-trigger"
+            type="button"
+            aria-label={`Select repository ref: ${selectedRef ? refOptionLabel(selectedRef) : "No ref"}`}
+            aria-haspopup="listbox"
+            onclick={() => void openRefPicker()}
+          >
+            <span class="typeahead-value">
+              <span>{selectedRef ? refOptionLabel(selectedRef) : "No ref"}</span>
+            </span>
+            <ChevronDownIcon size={12} strokeWidth={2} aria-hidden="true" />
+          </button>
+        {/if}
+      </div>
       <button class="repo-browser__icon-button" type="button" title="Refresh repository" onclick={refreshRepo}>
         <RefreshIcon size="15" strokeWidth="1.75" aria-hidden="true" />
       </button>
@@ -630,7 +806,6 @@
     flex: 0 0 auto;
   }
 
-  .repo-browser__select,
   .repo-browser__filter input {
     height: 30px;
     border: thin solid var(--border-default);
@@ -639,11 +814,6 @@
     background: var(--bg-inset);
     font: inherit;
     font-size: var(--font-size-sm);
-  }
-
-  .repo-browser__select {
-    min-width: 190px;
-    padding: 0 28px 0 8px;
   }
 
   .repo-browser__icon-button {
@@ -662,6 +832,158 @@
   .repo-browser__icon-button:hover {
     color: var(--text-primary);
     background: var(--bg-surface-hover);
+  }
+
+  .repo-browser__ref-picker {
+    position: relative;
+    width: min(280px, 38vw);
+    min-width: 210px;
+  }
+
+  .typeahead-trigger,
+  .typeahead-input {
+    width: 100%;
+    height: 30px;
+    box-sizing: border-box;
+    border-radius: var(--radius-sm);
+    font-size: var(--font-size-sm);
+  }
+
+  .typeahead-trigger {
+    display: inline-flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 6px;
+    padding: 0 8px;
+    overflow: hidden;
+    color: var(--text-secondary);
+    background: var(--bg-inset);
+    border: 1px solid var(--border-muted);
+    cursor: pointer;
+    text-align: left;
+  }
+
+  .typeahead-trigger:hover {
+    color: var(--text-primary);
+    background: var(--bg-surface-hover);
+    border-color: var(--border-default);
+  }
+
+  .typeahead-value {
+    min-width: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .typeahead-input {
+    padding: 0 8px;
+    color: var(--text-primary);
+    background: var(--bg-surface);
+    border: 1px solid var(--accent-blue);
+    outline: none;
+    box-shadow: 0 0 0 3px var(--accent-blue-soft);
+  }
+
+  .typeahead-list {
+    position: absolute;
+    top: calc(100% + 3px);
+    right: 0;
+    z-index: 80;
+    width: min(380px, calc(100vw - 24px));
+    max-height: min(360px, 60vh);
+    overflow-y: auto;
+    padding: 3px;
+    color: var(--text-secondary);
+    background: var(--bg-surface);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    box-shadow: var(--shadow-lg);
+  }
+
+  .repo-browser__ref-tabs {
+    position: sticky;
+    top: -3px;
+    z-index: 1;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 3px;
+    padding: 3px 3px 5px;
+    background: var(--bg-surface);
+  }
+
+  .repo-browser__ref-tabs button {
+    min-height: 26px;
+    border: 0;
+    border-radius: 3px;
+    color: var(--text-secondary);
+    background: transparent;
+    font-size: var(--font-size-xs);
+    font-weight: 600;
+  }
+
+  .repo-browser__ref-tabs button:hover {
+    color: var(--text-primary);
+    background: var(--bg-surface-hover);
+  }
+
+  .repo-browser__ref-tab--active {
+    color: var(--text-primary) !important;
+    background: var(--bg-inset) !important;
+  }
+
+  .repo-browser__ref-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .typeahead-option {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    min-height: 28px;
+    padding: 5px 8px;
+    border-radius: 3px;
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+    line-height: 1.2;
+    cursor: pointer;
+  }
+
+  .typeahead-option.highlighted {
+    color: var(--text-primary);
+    background: var(--bg-surface-hover);
+  }
+
+  .typeahead-option.selected {
+    color: var(--accent-blue);
+    font-weight: 600;
+  }
+
+  .option-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .option-meta {
+    flex: 0 0 auto;
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .typeahead-empty,
+  .repo-browser__ref-more {
+    padding: 7px 8px;
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
   }
 
   .repo-browser__content {

--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
@@ -274,6 +274,10 @@
   }
 
   async function selectRefFromPicker(ref: RepoBrowserRef): Promise<void> {
+    if (selectedRef !== null && refKey(selectedRef) === refKey(ref)) {
+      closeRefPicker();
+      return;
+    }
     if (refPickerSelectionInFlight) return;
     refPickerSelectionInFlight = true;
     closeRefPicker();

--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.test.ts
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.test.ts
@@ -40,6 +40,7 @@ type TestClientOptions = {
     path: string;
     content: string;
   };
+  refs?: Array<{ type: "branch" | "tag"; name: string; sha: string; stale: boolean }>;
 };
 
 const runtimeQuerySerializerOptions: QuerySerializerOptions = {
@@ -290,9 +291,12 @@ describe("RepoBrowserFeature", () => {
     });
 
     await waitFor(() => expect(client.GET).toHaveBeenCalledTimes(5));
-    await fireEvent.change(await screen.findByRole("combobox", { name: "Select repository ref" }), {
-      target: { value: "tag\0v1.0.0\0tag-sha" },
+    await fireEvent.click(await screen.findByRole("button", { name: "Select repository ref: branch: main main-sha" }));
+    await fireEvent.input(screen.getByRole("combobox", { name: "Search repository refs" }), {
+      target: { value: "v1" },
     });
+    await fireEvent.click(screen.getByRole("tab", { name: "Tags 1" }));
+    await fireEvent.click(screen.getByRole("option", { name: "tag: v1.0.0 tag-sha" }));
     await waitFor(() => expect(client.GET).toHaveBeenCalledTimes(9));
     await waitFor(() => {
       expect(onRouteChange).toHaveBeenLastCalledWith(
@@ -319,6 +323,39 @@ describe("RepoBrowserFeature", () => {
 
     await tick();
     expect(client.GET).toHaveBeenCalledTimes(9);
+  });
+
+  it("filters branch and tag refs in separate typeahead tabs", async () => {
+    const client = testClient({
+      refs: [
+        { type: "branch", name: "main", sha: "main-sha", stale: false },
+        { type: "branch", name: "feature/caching", sha: "feature-sha", stale: false },
+        { type: "branch", name: "release/v1", sha: "release-sha", stale: false },
+        { type: "tag", name: "v1.0.0", sha: "tag-sha", stale: false },
+        { type: "tag", name: "feature-preview", sha: "preview-sha", stale: false },
+      ],
+    });
+    render(RepoBrowserFeature, {
+      props: {
+        client,
+        route,
+        onRouteChange: vi.fn(),
+      },
+    });
+
+    await fireEvent.click(await screen.findByRole("button", { name: "Select repository ref: branch: main main-sha" }));
+    const input = screen.getByRole("combobox", { name: "Search repository refs" });
+    await fireEvent.input(input, { target: { value: "v1" } });
+
+    expect(screen.getByRole("tab", { name: "Branches 3" }).getAttribute("aria-selected")).toBe("true");
+    expect(screen.getByRole("option", { name: "branch: release/v1 release-" })).toBeTruthy();
+    expect(screen.queryByRole("option", { name: "tag: v1.0.0 tag-sha" })).toBeNull();
+
+    await fireEvent.click(screen.getByRole("tab", { name: "Tags 2" }));
+
+    expect(screen.getByRole("tab", { name: "Tags 2" }).getAttribute("aria-selected")).toBe("true");
+    expect(screen.getByRole("option", { name: "tag: v1.0.0 tag-sha" })).toBeTruthy();
+    expect(screen.queryByRole("option", { name: "branch: release/v1 release-" })).toBeNull();
   });
 
   it("renders source files through Pierre file contents", async () => {
@@ -353,6 +390,10 @@ function scrolledHeadingIDs(scrollIntoView: ReturnType<typeof vi.fn>): string[] 
 }
 
 function testClient(clientOptions: TestClientOptions = {}): MiddlemanClient {
+  const refs = clientOptions.refs ?? [
+    { type: "branch" as const, name: "main", sha: "main-sha", stale: false },
+    { type: "tag" as const, name: "v1.0.0", sha: "tag-sha", stale: false },
+  ];
   return {
     GET: vi.fn(async (path: string, options?: TestGetOptions) => {
       const url = testURL(path, options);
@@ -361,10 +402,7 @@ function testClient(clientOptions: TestClientOptions = {}): MiddlemanClient {
         return {
           data: {
             repo,
-            refs: [
-              { type: "branch", name: "main", sha: "main-sha", stale: false },
-              { type: "tag", name: "v1.0.0", sha: "tag-sha", stale: false },
-            ],
+            refs,
             default_ref: { type: "branch", name: "main", sha: "main-sha", stale: false },
           },
           response: new Response(null, { status: 200 }),

--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.test.ts
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.test.ts
@@ -358,6 +358,26 @@ describe("RepoBrowserFeature", () => {
     expect(screen.queryByRole("option", { name: "branch: release/v1 release-" })).toBeNull();
   });
 
+  it("does not reload when the active ref is selected again", async () => {
+    const client = testClient();
+    const onRouteChange = vi.fn();
+    render(RepoBrowserFeature, {
+      props: {
+        client,
+        route,
+        onRouteChange,
+      },
+    });
+
+    await waitFor(() => expect(client.GET).toHaveBeenCalledTimes(5));
+    await fireEvent.click(await screen.findByRole("button", { name: "Select repository ref: branch: main main-sha" }));
+    await fireEvent.click(screen.getByRole("option", { name: "branch: main main-sha" }));
+    await tick();
+
+    expect(client.GET).toHaveBeenCalledTimes(5);
+    expect(onRouteChange).not.toHaveBeenCalled();
+  });
+
   it("renders source files through Pierre file contents", async () => {
     const sourceFile = {
       path: "internal/main.go",

--- a/frontend/tests/e2e-full/repo-browser.spec.ts
+++ b/frontend/tests/e2e-full/repo-browser.spec.ts
@@ -186,6 +186,48 @@ test.describe("repository source browser", () => {
     }
   });
 
+  test("does not reload repository data when the active ref is selected again", async ({ page }) => {
+    const server = await startIsolatedE2EServer();
+    try {
+      const refsURLs = collectRepoBrowserResponseURLs(page, "refs");
+      const treeURLs = collectRepoBrowserResponseURLs(page, "tree", "main");
+      const blobURLs = collectRepoBrowserResponseURLs(page, "blob", undefined, "README.md");
+      const refsLoaded = repoBrowserResponse(page, "refs");
+      const treeLoaded = treeResponse(page, "main");
+      const blobLoaded = blobResponse(page, "README.md");
+
+      await page.goto(
+        `${server.info.base_url}/repo/browser?provider=github&repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&path=README.md`,
+      );
+      await refsLoaded;
+      await treeLoaded;
+      await blobLoaded;
+
+      const browser = page.getByRole("region", { name: "Repository source browser" });
+      await expect(browser.getByRole("main", { name: "Selected file" }).locator(".repo-browser__path")).toContainText(
+        "README.md",
+      );
+      const routeBeforeReselect = page.url();
+
+      await browser.getByRole("button", { name: /Select repository ref: branch: main/ }).click();
+      await browser.getByRole("option", { name: /branch: main/ }).click();
+
+      await expect(browser.getByRole("combobox", { name: "Search repository refs" })).toHaveCount(0);
+      expect(page.url()).toBe(routeBeforeReselect);
+      expect(refsURLs).toHaveLength(1);
+      expect(treeURLs).toHaveLength(1);
+      expect(blobURLs).toHaveLength(1);
+      await expectNoMoreRepoBrowserResponses(page, "refs");
+      await expectNoMoreRepoBrowserResponses(page, "tree", "main");
+      await expectNoMoreRepoBrowserResponses(page, "blob");
+      expect(refsURLs).toHaveLength(1);
+      expect(treeURLs).toHaveLength(1);
+      expect(blobURLs).toHaveLength(1);
+    } finally {
+      await server.stop();
+    }
+  });
+
   test("reloads repository data when a mounted route moves the same branch to a different SHA", async ({ page }) => {
     const server = await startIsolatedE2EServer();
     try {

--- a/frontend/tests/e2e-full/repo-browser.spec.ts
+++ b/frontend/tests/e2e-full/repo-browser.spec.ts
@@ -162,15 +162,14 @@ test.describe("repository source browser", () => {
       await mainTreeLoaded;
 
       const browser = page.getByRole("region", { name: "Repository source browser" });
-      const refSelect = browser.getByLabel("Select repository ref");
-      const featureOption = await refSelect
-        .locator("option")
-        .filter({ hasText: "branch: feature/caching" })
-        .getAttribute("value");
-      expect(featureOption).toBeTruthy();
+      await browser.getByRole("button", { name: /Select repository ref: branch: main/ }).click();
+      await browser.getByRole("combobox", { name: "Search repository refs" }).fill("feature");
+      await expect(browser.getByRole("tab", { name: /Branches/ })).toHaveAttribute("aria-selected", "true");
+      await expect(browser.getByRole("option", { name: /branch: feature\/caching/ })).toBeVisible();
+      await expect(browser.getByRole("option", { name: /tag:/ })).toHaveCount(0);
 
       const featureTreeLoaded = treeResponse(page, "feature/caching");
-      await refSelect.selectOption(featureOption!);
+      await browser.getByRole("option", { name: /branch: feature\/caching/ }).click();
       await featureTreeLoaded;
       await expect(page).toHaveURL(/ref_name=feature%2Fcaching/);
 


### PR DESCRIPTION
Repositories with long ref lists are hard to scan through a native select, and tags should not be visually indistinguishable from branches. This replaces the repo browser ref selector with a searchable branch/tag picker while preserving the existing selected-ref display and route/store update contract.

The picker also keeps active-ref reselects local to the popover so accidental clicks close it without reloading repository data or pushing a duplicate route.

Validation: focused repo-browser component test, full repo-browser e2e spec, frontend package check, Svelte autofixer, and Playwright screenshot capture against the isolated e2e server.

<sup>generated by a clanker</sup>