### PR TITLE
fix: reduce active PR refresh budget spend

### DIFF
--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -68,11 +68,15 @@ For pull requests, that means:
   a slower cadence so the Activity view stays fresh without spending the same
   request rate on hours-old rows. A missing `detail_fetched_at` remains due
   immediately (`internal/github/sync.go::activeMRDueForFastSync`).
-- GitHub detail ETags reduce the work for unchanged PRs, but a `304 Not
-  Modified` still consumes a provider request. Do not use the ETag path as the
-  only rate-limit mitigation for broad background refresh loops
-  (`internal/github/sync.go::getPullRequestForDetail`,
-  `internal/github/sync.go::markUnchangedMRDetailFetched`).
+- GitHub detail ETags reduce both payload work and middleman's eager-refresh
+  budget spend for unchanged PRs; the sync budget transport does not count
+  `304 Not Modified` responses (`internal/github/budget_transport.go::budgetTransport`).
+  Active watched-PR sync must use the same persisted pull-request ETag path as
+  detail drain (`internal/github/sync.go::syncMRForRepo`,
+  `internal/github/sync.go::getPullRequestForDetail`,
+  `internal/github/sync.go::markUnchangedMRDetailFetched`). Cadence control is
+  still required because changed PRs correctly fall through to comments,
+  reviews, commits, CI, and workflow approval refreshes.
 
 ## Timeline Event Rules
 

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -74,9 +74,13 @@ For pull requests, that means:
   Active watched-PR sync must use the same persisted pull-request ETag path as
   detail drain (`internal/github/sync.go::syncMRForRepo`,
   `internal/github/sync.go::getPullRequestForDetail`,
-  `internal/github/sync.go::markUnchangedMRDetailFetched`). Cadence control is
-  still required because changed PRs correctly fall through to comments,
-  reviews, commits, CI, and workflow approval refreshes.
+  `internal/github/sync.go::markUnchangedMRDetailFetched`). Manual/API PR
+  refreshes must bypass that PR ETag gate so rerun checks, workflow approval,
+  comments, reviews, and commits can refresh even when GitHub's PR resource is
+  unchanged (`internal/github/sync.go::SyncMR`,
+  `internal/server/huma_routes.go::syncPR`). Cadence control is still required
+  because changed PRs correctly fall through to comments, reviews, commits, CI,
+  and workflow approval refreshes.
 
 ## Timeline Event Rules
 

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -61,6 +61,18 @@ For pull requests, that means:
   persisted activity, not just one subset of the detail payload.
 - Background sync cooldowns are allowed, but user-initiated refreshes must still
   be able to promote a stronger sync intent over an in-flight background fetch.
+- Recently active open PRs in the fast-sync lane are cadence-gated by activity
+  age, not just by membership in `active_pr_window`
+  (`internal/github/sync.go::activeMRRefreshInterval`). Hot PRs use
+  `active_pr_refresh_interval`; older PRs still inside the window fall back to
+  a slower cadence so the Activity view stays fresh without spending the same
+  request rate on hours-old rows. A missing `detail_fetched_at` remains due
+  immediately (`internal/github/sync.go::activeMRDueForFastSync`).
+- GitHub detail ETags reduce the work for unchanged PRs, but a `304 Not
+  Modified` still consumes a provider request. Do not use the ETag path as the
+  only rate-limit mitigation for broad background refresh loops
+  (`internal/github/sync.go::getPullRequestForDetail`,
+  `internal/github/sync.go::markUnchangedMRDetailFetched`).
 
 ## Timeline Event Rules
 

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -7768,6 +7768,9 @@ func (s *Syncer) syncMRForRepo(
 		}
 		return fmt.Errorf("get MR %s/%s#%d: %w", owner, name, number, err)
 	}
+	if normalized == nil {
+		return fmt.Errorf("get MR %s/%s#%d: provider returned no merge request", owner, name, number)
+	}
 	headChanged := existing != nil &&
 		existing.PlatformHeadSHA != normalized.PlatformHeadSHA
 	if existing != nil {

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -262,6 +262,8 @@ type WatchedMR struct {
 // per-host GitHub rate limit / abuse-detection thresholds.
 const defaultParallelism = 4
 const rateLimitSnapshotRefreshInterval = time.Minute
+const activeMRHotActivityWindow = 30 * time.Minute
+const activeMRWarmRefreshInterval = 5 * time.Minute
 
 // Display-name cache parameters. Display names rarely change,
 // so the success TTL is long enough to skip lookups across many
@@ -2595,12 +2597,12 @@ func (s *Syncer) syncWatchedMRs(ctx context.Context) {
 func (s *Syncer) watchedMRsForFastSync(ctx context.Context, now time.Time) []WatchedMR {
 	s.watchMu.Lock()
 	mrs := slices.Clone(s.watchedMRs)
-	_, activeWindow := s.watchSettingsLocked()
+	watchInt, activeWindow := s.watchSettingsLocked()
 	s.watchMu.Unlock()
 
 	watched := newWatchedMRSet(mrs)
 	if activeWindow > 0 {
-		for _, mr := range s.recentlyActiveOpenMRs(ctx, now, activeWindow) {
+		for _, mr := range s.recentlyActiveOpenMRs(ctx, now, activeWindow, watchInt) {
 			watched.add(mr)
 		}
 	}
@@ -2619,6 +2621,7 @@ func (s *Syncer) recentlyActiveOpenMRs(
 	ctx context.Context,
 	now time.Time,
 	window time.Duration,
+	hotInterval time.Duration,
 ) []WatchedMR {
 	prs, err := s.db.ListMergeRequests(ctx, db.ListMergeRequestsOpts{State: "open"})
 	if err != nil {
@@ -2630,6 +2633,9 @@ func (s *Syncer) recentlyActiveOpenMRs(
 	var watched []WatchedMR
 	for _, pr := range prs {
 		if pr.LastActivityAt.Before(cutoff) {
+			continue
+		}
+		if !activeMRDueForFastSync(pr, now, hotInterval) {
 			continue
 		}
 		repo, ok := repoByID[pr.RepoID]
@@ -2661,6 +2667,27 @@ func (s *Syncer) recentlyActiveOpenMRs(
 		})
 	}
 	return watched
+}
+
+func activeMRDueForFastSync(pr db.MergeRequest, now time.Time, hotInterval time.Duration) bool {
+	if pr.DetailFetchedAt == nil {
+		return true
+	}
+	interval := activeMRRefreshInterval(pr.LastActivityAt, now, hotInterval)
+	return !pr.DetailFetchedAt.Add(interval).After(now)
+}
+
+func activeMRRefreshInterval(lastActivity, now time.Time, hotInterval time.Duration) time.Duration {
+	if hotInterval <= 0 {
+		hotInterval = 30 * time.Second
+	}
+	if now.Sub(lastActivity) <= activeMRHotActivityWindow {
+		return hotInterval
+	}
+	if hotInterval > activeMRWarmRefreshInterval {
+		return hotInterval
+	}
+	return activeMRWarmRefreshInterval
 }
 
 func watchedMRPlatform(mr WatchedMR) platform.Kind {

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -7636,7 +7636,7 @@ func (s *Syncer) SyncMROnProvider(
 	repo.Owner = owner
 	repo.Name = name
 	repo.PlatformHost = repoHost(repo)
-	return s.syncMRForRepo(ctx, repo, number)
+	return s.syncMRForRepo(ctx, repo, number, false)
 }
 
 // syncMRWithHost is the internal implementation of SyncMR.
@@ -7674,7 +7674,7 @@ func (s *Syncer) syncMRWithHost(
 	repo.Owner = owner
 	repo.Name = name
 	repo.PlatformHost = repoHost(repo)
-	return s.syncMRForRepo(ctx, repo, number)
+	return s.syncMRForRepo(ctx, repo, number, false)
 }
 
 func (s *Syncer) syncMRWithWatchedRef(
@@ -7692,13 +7692,14 @@ func (s *Syncer) syncMRWithWatchedRef(
 			mr.Owner, mr.Name, kind, host,
 		)
 	}
-	return s.syncMRForRepo(ctx, repo, mr.Number)
+	return s.syncMRForRepo(ctx, repo, mr.Number, true)
 }
 
 func (s *Syncer) syncMRForRepo(
 	ctx context.Context,
 	repo RepoRef,
 	number int,
+	useConditionalPRDetail bool,
 ) error {
 	owner := repo.Owner
 	name := repo.Name
@@ -7728,7 +7729,7 @@ func (s *Syncer) syncMRForRepo(
 	if rawReader, ok := mrReader.(interface {
 		GetGitHubPullRequest(context.Context, platform.RepoRef, int) (*gh.PullRequest, platform.MergeRequest, error)
 	}); ok {
-		if client, ok := s.optionalGitHubClientFor(repo); ok {
+		if client, ok := s.optionalGitHubClientFor(repo); ok && useConditionalPRDetail {
 			var notModified bool
 			ghPR, newETag, notModified, err = s.getPullRequestForDetail(
 				ctx, client, repo, number,

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -7712,14 +7712,52 @@ func (s *Syncer) syncMRForRepo(
 		return fmt.Errorf("upsert repo %s/%s: %w", owner, name, err)
 	}
 
+	// Preserve derived fields that provider detail doesn't populate. CI is
+	// refreshed later in this sync path; keeping the previous values here
+	// prevents detail reads from briefly seeing "no CI" during refresh.
+	existing, err := s.db.GetMergeRequestByRepoIDAndNumber(
+		ctx, repoID, number,
+	)
+	if err != nil {
+		return fmt.Errorf("get existing MR #%d: %w", number, err)
+	}
+
 	var ghPR *gh.PullRequest
-	var platformMR platform.MergeRequest
+	var normalized *db.MergeRequest
+	var newETag string
 	if rawReader, ok := mrReader.(interface {
 		GetGitHubPullRequest(context.Context, platform.RepoRef, int) (*gh.PullRequest, platform.MergeRequest, error)
 	}); ok {
-		ghPR, platformMR, err = rawReader.GetGitHubPullRequest(ctx, platformRepoRef(repo), number)
+		if client, ok := s.optionalGitHubClientFor(repo); ok {
+			var notModified bool
+			ghPR, newETag, notModified, err = s.getPullRequestForDetail(
+				ctx, client, repo, number,
+			)
+			if err == nil && ghPR == nil {
+				if notModified && existing != nil {
+					_, err := s.markUnchangedMRDetailFetched(
+						ctx, repo, repoID, number, existing, 1,
+					)
+					return err
+				}
+				err = fmt.Errorf("client returned nil pull request")
+			}
+			if err == nil {
+				normalized, err = NormalizePR(repoID, ghPR)
+			}
+		} else {
+			var platformMR platform.MergeRequest
+			ghPR, platformMR, err = rawReader.GetGitHubPullRequest(ctx, platformRepoRef(repo), number)
+			if err == nil {
+				normalized = platform.DBMergeRequest(repoID, platformMR)
+			}
+		}
 	} else {
+		var platformMR platform.MergeRequest
 		platformMR, err = mrReader.GetMergeRequest(ctx, platformRepoRef(repo), number)
+		if err == nil {
+			normalized = platform.DBMergeRequest(repoID, platformMR)
+		}
 	}
 	if err != nil {
 		if errors.Is(err, ErrNilPullRequest) {
@@ -7729,17 +7767,6 @@ func (s *Syncer) syncMRForRepo(
 			)
 		}
 		return fmt.Errorf("get MR %s/%s#%d: %w", owner, name, number, err)
-	}
-	normalized := platform.DBMergeRequest(repoID, platformMR)
-
-	// Preserve derived fields that provider detail doesn't populate. CI is
-	// refreshed later in this sync path; keeping the previous values here
-	// prevents detail reads from briefly seeing "no CI" during refresh.
-	existing, err := s.db.GetMergeRequestByRepoIDAndNumber(
-		ctx, repoID, number,
-	)
-	if err != nil {
-		return fmt.Errorf("get existing MR #%d: %w", number, err)
 	}
 	headChanged := existing != nil &&
 		existing.PlatformHeadSHA != normalized.PlatformHeadSHA
@@ -7873,6 +7900,18 @@ func (s *Syncer) syncMRForRepo(
 	}
 	if diffErr != nil {
 		return diffErr
+	}
+	if newETag != "" {
+		if err := s.db.UpsertHTTPEtag(
+			ctx, string(repoPlatform(repo)), repoHost(repo),
+			repo.Owner, repo.Name, "pull_request", number, newETag,
+		); err != nil {
+			slog.Warn("persist pull request ETag failed",
+				"repo", repo.Owner+"/"+repo.Name,
+				"number", number,
+				"err", err,
+			)
+		}
 	}
 	return nil
 }

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -7471,6 +7471,60 @@ func TestFetchMRDetailUsesPersistedPullRequestETag(t *testing.T) {
 		"304 should skip timeline/comment refresh")
 }
 
+func TestSyncMRUsesPersistedPullRequestETag(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	repo := RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", repo.Owner, repo.Name))
+	require.NoError(err)
+	updatedAt := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
+	detailFetchedAt := time.Date(2024, 6, 1, 9, 0, 0, 0, time.UTC)
+	_, err = d.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:          repoID,
+		PlatformID:      1000,
+		Number:          1,
+		URL:             "https://github.com/owner/repo/pull/1",
+		Title:           "test PR",
+		Author:          "alice",
+		State:           "open",
+		HeadBranch:      "feature-branch",
+		BaseBranch:      "main",
+		PlatformHeadSHA: "abc123def456",
+		CreatedAt:       updatedAt,
+		UpdatedAt:       updatedAt,
+		LastActivityAt:  updatedAt,
+		DetailFetchedAt: &detailFetchedAt,
+	})
+	require.NoError(err)
+	require.NoError(d.UpsertHTTPEtag(
+		ctx, "github", "github.com", "owner", "repo",
+		"pull_request", 1, `"etag-v1"`,
+	))
+
+	mc := &conditionalPRTrackingClient{notModified: true}
+	mc.singlePR = buildOpenPR(1, updatedAt)
+	mc.comments = []*gh.IssueComment{{ID: new(int64)}}
+	mc.reviews = []*gh.PullRequestReview{{ID: new(int64)}}
+	mc.commits = []*gh.RepositoryCommit{{SHA: new(string)}}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc}, d, nil,
+		[]RepoRef{repo},
+		time.Minute, nil, testBudget(1000),
+	)
+
+	require.NoError(syncer.SyncMR(ctx, "owner", "repo", 1))
+
+	assert.Equal(int32(1), mc.conditionalCalls.Load())
+	assert.Equal(`"etag-v1"`, mc.receivedETag)
+	assert.Zero(int(mc.getPRCalls.Load()),
+		"304 should skip the unconditional PR detail fetch")
+	assert.Zero(int(mc.listIssueCommentsCalled.Load()),
+		"304 should skip timeline/comment refresh")
+}
+
 func TestFetchMRDetailPersistsPullRequestETag(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -6868,6 +6868,65 @@ func TestWatchedMRsIncludeRecentlyActiveOpenPRs(t *testing.T) {
 	}, got)
 }
 
+func TestWatchedMRsThrottleRecentlyActiveOpenPRsByActivityAge(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	now := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+
+	repoID, err := d.UpsertRepo(ctx, db.RepoIdentity{
+		Platform:     "github",
+		PlatformHost: "github.com",
+		Owner:        "acme",
+		Name:         "app",
+	})
+	require.NoError(err)
+
+	seedMR := func(number int, lastActivity time.Time, detailFetchedAt *time.Time) {
+		_, upsertErr := d.UpsertMergeRequest(ctx, &db.MergeRequest{
+			RepoID: repoID, PlatformID: int64(number), Number: number,
+			Title: "PR", Author: "octo", State: db.MergeRequestStateOpen,
+			HeadBranch: "feature", BaseBranch: "main",
+			CreatedAt: now.Add(-24 * time.Hour),
+			UpdatedAt: lastActivity, LastActivityAt: lastActivity,
+			DetailFetchedAt: detailFetchedAt,
+		})
+		require.NoError(upsertErr)
+	}
+	hotNotDue := now.Add(-1 * time.Minute)
+	hotDue := now.Add(-2 * time.Minute)
+	warmNotDue := now.Add(-4 * time.Minute)
+	warmDue := now.Add(-5 * time.Minute)
+	seedMR(1, now.Add(-10*time.Minute), &hotNotDue)
+	seedMR(2, now.Add(-10*time.Minute), &hotDue)
+	seedMR(3, now.Add(-45*time.Minute), &warmNotDue)
+	seedMR(4, now.Add(-45*time.Minute), &warmDue)
+
+	syncer := NewSyncer(
+		map[string]Client{}, d, nil,
+		[]RepoRef{{
+			Platform: platform.KindGitHub, PlatformHost: "github.com",
+			Owner: "acme", Name: "app",
+		}},
+		time.Hour, nil, nil,
+	)
+	syncer.SetWatchInterval(2 * time.Minute)
+	syncer.SetActiveMRWindow(4 * time.Hour)
+
+	got := syncer.watchedMRsForFastSync(ctx, now)
+	assert.ElementsMatch([]WatchedMR{
+		{
+			Platform: platform.KindGitHub, PlatformHost: "github.com",
+			Owner: "acme", Name: "app", Number: 2,
+		},
+		{
+			Platform: platform.KindGitHub, PlatformHost: "github.com",
+			Owner: "acme", Name: "app", Number: 4,
+		},
+	}, got)
+}
+
 func TestWatchedMRsNotifyOnceAfterFastSync(t *testing.T) {
 	assert := Assert.New(t)
 	d := openTestDB(t)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -7471,7 +7471,7 @@ func TestFetchMRDetailUsesPersistedPullRequestETag(t *testing.T) {
 		"304 should skip timeline/comment refresh")
 }
 
-func TestSyncMRUsesPersistedPullRequestETag(t *testing.T) {
+func TestWatchedSyncMRUsesPersistedPullRequestETag(t *testing.T) {
 	assert := Assert.New(t)
 	require := require.New(t)
 	ctx := t.Context()
@@ -7515,7 +7515,9 @@ func TestSyncMRUsesPersistedPullRequestETag(t *testing.T) {
 		time.Minute, nil, testBudget(1000),
 	)
 
-	require.NoError(syncer.SyncMR(ctx, "owner", "repo", 1))
+	require.NoError(syncer.syncMRWithWatchedRef(ctx, WatchedMR{
+		Owner: "owner", Name: "repo", Number: 1, PlatformHost: "github.com",
+	}))
 
 	assert.Equal(int32(1), mc.conditionalCalls.Load())
 	assert.Equal(`"etag-v1"`, mc.receivedETag)
@@ -7523,6 +7525,58 @@ func TestSyncMRUsesPersistedPullRequestETag(t *testing.T) {
 		"304 should skip the unconditional PR detail fetch")
 	assert.Zero(int(mc.listIssueCommentsCalled.Load()),
 		"304 should skip timeline/comment refresh")
+}
+
+func TestSyncMRBypassesPersistedPullRequestETag(t *testing.T) {
+	assert := Assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	repo := RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", repo.Owner, repo.Name))
+	require.NoError(err)
+	updatedAt := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
+	detailFetchedAt := time.Date(2024, 6, 1, 9, 0, 0, 0, time.UTC)
+	_, err = d.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID: repoID, PlatformID: 1000, Number: 1,
+		URL:             "https://github.com/owner/repo/pull/1",
+		Title:           "test PR",
+		Author:          "alice",
+		State:           "open",
+		HeadBranch:      "feature-branch",
+		BaseBranch:      "main",
+		PlatformHeadSHA: "abc123def456",
+		CreatedAt:       updatedAt,
+		UpdatedAt:       updatedAt,
+		LastActivityAt:  updatedAt,
+		DetailFetchedAt: &detailFetchedAt,
+	})
+	require.NoError(err)
+	require.NoError(d.UpsertHTTPEtag(
+		ctx, "github", "github.com", "owner", "repo",
+		"pull_request", 1, `"etag-v1"`,
+	))
+
+	ciState := "success"
+	mc := &conditionalPRTrackingClient{notModified: true}
+	mc.singlePR = buildOpenPR(1, updatedAt)
+	mc.comments = []*gh.IssueComment{}
+	mc.reviews = []*gh.PullRequestReview{}
+	mc.commits = []*gh.RepositoryCommit{}
+	mc.ciStatus = &gh.CombinedStatus{State: &ciState}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc}, d, nil,
+		[]RepoRef{repo},
+		time.Minute, nil, testBudget(1000),
+	)
+
+	require.NoError(syncer.SyncMR(ctx, "owner", "repo", 1))
+
+	assert.Zero(int(mc.conditionalCalls.Load()))
+	assert.Equal(1, int(mc.getPRCalls.Load()))
+	assert.Equal(int32(1), mc.listIssueCommentsCalled.Load(),
+		"manual SyncMR should refresh timeline/comments")
 }
 
 func TestFetchMRDetailPersistsPullRequestETag(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -7260,6 +7260,86 @@ func TestAPISyncPRPreservesCIStatusWhileRefreshingCI(t *testing.T) {
 	}
 }
 
+func TestAPISyncPRBypassesPullRequestETagForCIRefresh(t *testing.T) {
+	require := require.New(t)
+	assert := Assert.New(t)
+
+	headSHA := "abc123"
+	success := "success"
+	getPRCalls := 0
+	conditionalCalls := 0
+	ciCalls := 0
+	mock := &mockGH{
+		getPullRequestFn: func(_ context.Context, _ string, _ string, number int) (*gh.PullRequest, error) {
+			getPRCalls++
+			state := "open"
+			title := "manual sync"
+			url := "https://github.com/acme/widget/pull/1"
+			author := "alice"
+			baseSHA := "def456"
+			featureRef := "feature"
+			mainRef := "main"
+			now := gh.Timestamp{Time: time.Now().UTC()}
+			return &gh.PullRequest{
+				Number:    &number,
+				State:     &state,
+				Title:     &title,
+				HTMLURL:   &url,
+				User:      &gh.User{Login: &author},
+				CreatedAt: &now,
+				UpdatedAt: &now,
+				Head:      &gh.PullRequestBranch{SHA: &headSHA, Ref: &featureRef},
+				Base:      &gh.PullRequestBranch{SHA: &baseSHA, Ref: &mainRef},
+			}, nil
+		},
+		getPullRequestIfChangedFn: func(_ context.Context, _ string, _ string, _ int, etag string) (*gh.PullRequest, string, bool, error) {
+			conditionalCalls++
+			require.Equal(`"etag-v1"`, etag)
+			return nil, etag, true, nil
+		},
+		listCheckRunsForRefFn: func(_ context.Context, _, _ string, ref string) ([]*gh.CheckRun, error) {
+			ciCalls++
+			require.Equal(headSHA, ref)
+			name := "tests"
+			status := "completed"
+			conclusion := "success"
+			return []*gh.CheckRun{{
+				Name:       &name,
+				Status:     &status,
+				Conclusion: &conclusion,
+			}}, nil
+		},
+		getCombinedStatusFn: func(_ context.Context, _, _, ref string) (*gh.CombinedStatus, error) {
+			require.Equal(headSHA, ref)
+			return &gh.CombinedStatus{State: &success}, nil
+		},
+	}
+
+	srv, database := setupTestServerWithMock(t, mock)
+	seedPR(t, database, "acme", "widget", 1,
+		withSeedPRHeadSHA(headSHA),
+		withSeedPRCI("failure", `[{"name":"tests","status":"completed","conclusion":"failure"}]`),
+	)
+	repo, err := database.GetRepoByIdentity(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
+	require.NoError(err)
+	require.NotNil(repo)
+	require.NoError(database.UpsertHTTPEtag(
+		t.Context(), "github", "github.com", "acme", "widget",
+		"pull_request", 1, `"etag-v1"`,
+	))
+
+	rr := doJSON(t, srv, http.MethodPost, "/api/v1/pulls/gh/acme/widget/1/sync", nil)
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+
+	stored, err := database.GetMergeRequestByRepoIDAndNumber(t.Context(), repo.ID, 1)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.Equal("success", stored.CIStatus)
+	assert.Equal(1, getPRCalls)
+	assert.Zero(conditionalCalls)
+	assert.Equal(1, ciCalls)
+}
+
 // When the head SHA changes, previously-recorded CI is tied to the old
 // commit and must not be carried forward. If the in-flight CI refresh
 // then fails, the detail must show "no CI" rather than stale checks


### PR DESCRIPTION
Active PR refreshes need to stay quick for PRs that are likely to be changing, but the prior active-window behavior put every recently active open PR on the same fast lane. That burned GitHub and middleman eager-refresh budget on rows that had been quiet for hours.

This PR makes the active refresh cadence depend on last activity age: hot PRs stay on the configured fast interval, older rows inside the active window fall back to a slower cadence, and never-detail-fetched PRs are still picked up immediately. It also routes GitHub active PR refreshes through the persisted pull-request ETag path so unchanged PRs can return as not modified without spending the full comments/timeline/CI refresh budget.

The important reviewer consequence is that active PRs should still show updates quickly when GitHub reports a change, while unchanged or stale-active rows stop dominating the eager-refresh budget.