### PR TITLE
Fix reviews repo picker outside-click dismissal

### DIFF
--- a/packages/ui/src/components/roborev/RepoTreePicker.svelte
+++ b/packages/ui/src/components/roborev/RepoTreePicker.svelte
@@ -14,6 +14,7 @@
   let expandedRepo = $state<string | undefined>(undefined);
   let branches = $state<BranchWithCount[]>([]);
   let loadingBranches = $state(false);
+  let pickerRef = $state<HTMLDivElement>();
 
   const selectedRepo = $derived(
     stores.roborevJobs?.getFilterRepo(),
@@ -95,11 +96,19 @@
   function handleKeydown(e: KeyboardEvent): void {
     if (e.key === "Escape") open = false;
   }
+
+  function handleDocumentMousedown(e: MouseEvent): void {
+    if (!open) return;
+    const target = e.target;
+    if (target instanceof Node && pickerRef?.contains(target)) return;
+    open = false;
+  }
 </script>
 
 <svelte:window onkeydown={handleKeydown} />
+<svelte:document onmousedown={handleDocumentMousedown} />
 
-<div class="repo-picker">
+<div class="repo-picker" bind:this={pickerRef}>
   <button
     class="picker-button"
     onclick={toggle}

--- a/packages/ui/src/components/roborev/RepoTreePicker.test.ts
+++ b/packages/ui/src/components/roborev/RepoTreePicker.test.ts
@@ -1,0 +1,70 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vite-plus/test";
+
+import RepoTreePicker from "./RepoTreePicker.svelte";
+
+type JobsStoreStub = {
+  getFilterRepo: () => string | undefined;
+  getFilterBranch: () => string | undefined;
+  setFilter: Mock<(key: string, value: string | undefined) => void>;
+};
+
+const state = {
+  repo: undefined as string | undefined,
+  branch: undefined as string | undefined,
+  jobs: null as JobsStoreStub | null,
+};
+
+const client = {
+  GET: vi.fn(),
+};
+
+vi.mock("../../context.js", () => ({
+  getStores: () => ({
+    roborevJobs: state.jobs,
+  }),
+  getRoborevClient: () => client,
+}));
+
+describe("RepoTreePicker", () => {
+  beforeEach(() => {
+    state.repo = undefined;
+    state.branch = undefined;
+    state.jobs = {
+      getFilterRepo: () => state.repo,
+      getFilterBranch: () => state.branch,
+      setFilter: vi.fn((key: string, value: string | undefined) => {
+        if (key === "repo") state.repo = value;
+        if (key === "branch") state.branch = value;
+      }),
+    };
+    client.GET.mockResolvedValue({
+      data: {
+        repos: [
+          {
+            root_path: "/work/middleman",
+            name: "middleman",
+            count: 4,
+          },
+        ],
+      },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    state.jobs = null;
+    client.GET.mockReset();
+  });
+
+  it("closes when pressing outside the picker", async () => {
+    render(RepoTreePicker);
+
+    await fireEvent.click(screen.getByRole("button", { name: /all repos/i }));
+    expect(screen.getByPlaceholderText("Filter repos...")).toBeTruthy();
+
+    await fireEvent.mouseDown(document.body);
+
+    expect(screen.queryByPlaceholderText("Filter repos...")).toBeNull();
+  });
+});


### PR DESCRIPTION
Clicking outside the Reviews repo picker left it open, unlike the other dropdown controls, which made the filter feel stuck and blocked normal table interaction. This closes the picker on outside clicks while keeping the daemon repo and branch workflow intact.

<sup>generated by a clanker</sup>