### PR TITLE
fix: match diff patches by file path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,11 @@ Coverage of real behavior is non-negotiable; the lane is chosen by the behavior 
 - **Never use npm** — use `bun install` for frontend dependencies and invoke Vite+ directly via `./node_modules/.bin/vp ...` (or `../node_modules/.bin/vp ...` from `frontend/`). Never run `npm install` or `npm run` — this creates `package-lock.json` which conflicts with the bun lockfile
 - Tests should be fast and isolated
 - No emojis in code or output
+- Do not copy names, paths, prose, domain details, data values, or other
+  specifics from developers' private projects into tests, fixtures,
+  implementation, docs, commit messages, or PR text unless the user explicitly
+  asks for those exact details to be preserved. Reproduce bugs with generic
+  synthetic examples instead.
 - For database schema changes, follow `context/db-migrations.md`; `internal/db/migrations/` is the source of truth for schema evolution.
 - For HTTP API error envelopes and frontend error branching, follow `context/error-handling.md`; branch on stable codes/details rather than prose.
 - For retries, backoff, and single-flight dedup against flaky upstreams, follow `context/retries-and-backoffs.md`.

--- a/internal/gitclone/parse.go
+++ b/internal/gitclone/parse.go
@@ -86,18 +86,22 @@ func rawStatusToString(s string) (status string, isRenameOrCopy bool) {
 }
 
 // ParsePatch parses unified diff patch output and merges it with
-// pre-populated file metadata from ParseRawZ. Files are correlated by
-// output order (git emits them in the same order).
+// pre-populated file metadata from ParseRawZ.
 func ParsePatch(patch []byte, rawFiles []DiffFile) []DiffFile {
 	fileDiffs, _ := godiff.ParseMultiFileDiff(patch)
 	if len(fileDiffs) == 0 {
 		return rawFiles
 	}
 
-	for i, fd := range fileDiffs {
-		if i >= len(rawFiles) {
-			break
+	pathIndex := diffFilePathIndex(rawFiles)
+	touched := make(map[int]bool, len(fileDiffs))
+
+	for _, fd := range fileDiffs {
+		i, ok := matchFileDiff(rawFiles, pathIndex, fd)
+		if !ok {
+			continue
 		}
+		touched[i] = true
 
 		// Detect binary from extended headers.
 		for _, ext := range fd.Extended {
@@ -176,8 +180,63 @@ func ParsePatch(patch []byte, rawFiles []DiffFile) []DiffFile {
 			}
 			rawFiles[i].Hunks = append(rawFiles[i].Hunks, hunk)
 		}
+	}
+
+	for i := range touched {
 		rawFiles[i].Patch = buildPatch(rawFiles[i])
 	}
 
 	return rawFiles
+}
+
+func diffFilePathIndex(files []DiffFile) map[string]int {
+	index := make(map[string]int, len(files)*2)
+	for i, file := range files {
+		if file.Path != "" {
+			index[file.Path] = i
+		}
+		if file.OldPath != "" {
+			index[file.OldPath] = i
+		}
+	}
+	return index
+}
+
+func matchFileDiff(
+	rawFiles []DiffFile,
+	pathIndex map[string]int,
+	fd *godiff.FileDiff,
+) (int, bool) {
+	for _, path := range fileDiffPaths(fd) {
+		i, ok := pathIndex[path]
+		if !ok {
+			continue
+		}
+		file := rawFiles[i]
+		if file.Path == path || file.OldPath == path {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+func fileDiffPaths(fd *godiff.FileDiff) []string {
+	paths := make([]string, 0, 2)
+	if path := normalizeDiffHeaderPath(fd.NewName); path != "" {
+		paths = append(paths, path)
+	}
+	if path := normalizeDiffHeaderPath(fd.OrigName); path != "" {
+		paths = append(paths, path)
+	}
+	return paths
+}
+
+func normalizeDiffHeaderPath(path string) string {
+	if path == "" || path == "/dev/null" {
+		return ""
+	}
+	if strings.HasPrefix(path, "a/") || strings.HasPrefix(path, "b/") {
+		return path[2:]
+	}
+	return path
 }

--- a/internal/gitclone/parse.go
+++ b/internal/gitclone/parse.go
@@ -96,7 +96,7 @@ func ParsePatch(patch []byte, rawFiles []DiffFile) []DiffFile {
 		rawFiles = []DiffFile{}
 	}
 
-	pathIndex := diffFilePathIndex(rawFiles)
+	pathIndex := newDiffFilePathIndex(rawFiles)
 	touched := make(map[int]bool, len(fileDiffs))
 
 	for _, fd := range fileDiffs {
@@ -192,14 +192,22 @@ func ParsePatch(patch []byte, rawFiles []DiffFile) []DiffFile {
 	return rawFiles
 }
 
-func diffFilePathIndex(files []DiffFile) map[string]int {
-	index := make(map[string]int, len(files)*2)
+type diffFilePathIndex struct {
+	paths    map[string][]int
+	oldPaths map[string][]int
+}
+
+func newDiffFilePathIndex(files []DiffFile) diffFilePathIndex {
+	index := diffFilePathIndex{
+		paths:    make(map[string][]int, len(files)),
+		oldPaths: make(map[string][]int, len(files)),
+	}
 	for i, file := range files {
 		if file.Path != "" {
-			index[file.Path] = i
+			index.paths[file.Path] = append(index.paths[file.Path], i)
 		}
 		if file.OldPath != "" {
-			index[file.OldPath] = i
+			index.oldPaths[file.OldPath] = append(index.oldPaths[file.OldPath], i)
 		}
 	}
 	return index
@@ -207,31 +215,79 @@ func diffFilePathIndex(files []DiffFile) map[string]int {
 
 func matchFileDiff(
 	rawFiles []DiffFile,
-	pathIndex map[string]int,
+	pathIndex diffFilePathIndex,
 	fd *godiff.FileDiff,
 ) (int, bool) {
-	for _, path := range fileDiffPaths(fd) {
-		i, ok := pathIndex[path]
-		if !ok {
-			continue
+	newPath := normalizeDiffHeaderPath(fd.NewName)
+	oldPath := normalizeDiffHeaderPath(fd.OrigName)
+
+	if newPath != "" {
+		candidates := pathIndex.paths[newPath]
+		if len(candidates) == 0 {
+			return 0, false
 		}
-		file := rawFiles[i]
-		if file.Path == path || file.OldPath == path {
+		if oldPath != "" {
+			exact := filterDiffFileCandidates(candidates, func(i int) bool {
+				return rawFiles[i].OldPath == oldPath
+			})
+			if i, ok := uniqueDiffFileCandidate(exact); ok {
+				return i, true
+			}
+			if len(exact) > 0 || candidatesHaveOldPaths(rawFiles, candidates) || oldPath != newPath {
+				return 0, false
+			}
+		}
+		return uniqueDiffFileCandidate(candidates)
+	}
+
+	if oldPath == "" {
+		return 0, false
+	}
+
+	candidates := pathIndex.oldPaths[oldPath]
+	if len(candidates) > 0 {
+		samePath := filterDiffFileCandidates(candidates, func(i int) bool {
+			return rawFiles[i].Path == oldPath
+		})
+		if i, ok := uniqueDiffFileCandidate(samePath); ok {
 			return i, true
 		}
+		if len(samePath) > 0 {
+			return 0, false
+		}
+		return uniqueDiffFileCandidate(candidates)
 	}
-	return 0, false
+
+	return uniqueDiffFileCandidate(pathIndex.paths[oldPath])
 }
 
-func fileDiffPaths(fd *godiff.FileDiff) []string {
-	paths := make([]string, 0, 2)
-	if path := normalizeDiffHeaderPath(fd.NewName); path != "" {
-		paths = append(paths, path)
+func filterDiffFileCandidates(
+	candidates []int,
+	keep func(int) bool,
+) []int {
+	filtered := make([]int, 0, len(candidates))
+	for _, i := range candidates {
+		if keep(i) {
+			filtered = append(filtered, i)
+		}
 	}
-	if path := normalizeDiffHeaderPath(fd.OrigName); path != "" {
-		paths = append(paths, path)
+	return filtered
+}
+
+func uniqueDiffFileCandidate(candidates []int) (int, bool) {
+	if len(candidates) != 1 {
+		return 0, false
 	}
-	return paths
+	return candidates[0], true
+}
+
+func candidatesHaveOldPaths(files []DiffFile, candidates []int) bool {
+	for _, i := range candidates {
+		if files[i].OldPath != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func normalizeDiffHeaderPath(path string) string {

--- a/internal/gitclone/parse.go
+++ b/internal/gitclone/parse.go
@@ -92,6 +92,9 @@ func ParsePatch(patch []byte, rawFiles []DiffFile) []DiffFile {
 	if len(fileDiffs) == 0 {
 		return rawFiles
 	}
+	if rawFiles == nil {
+		rawFiles = []DiffFile{}
+	}
 
 	pathIndex := diffFilePathIndex(rawFiles)
 	touched := make(map[int]bool, len(fileDiffs))

--- a/internal/gitclone/parse_test.go
+++ b/internal/gitclone/parse_test.go
@@ -120,6 +120,57 @@ index abc..def 100644
 	assert.Contains(files[0].Patch, "\\ No newline at end of file\n")
 }
 
+func TestParsePatchMatchesPatchEntriesByPath(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	patch := `diff --git a/docs/guide.md b/docs/guide.md
+deleted file mode 120000
+index 1111111..0000000
+--- a/docs/guide.md
++++ /dev/null
+@@ -1 +0,0 @@
+-README.md
+diff --git a/docs/guide.md b/docs/guide.md
+new file mode 100644
+index 0000000..2222222
+--- /dev/null
++++ b/docs/guide.md
+@@ -0,0 +1,2 @@
++# Example Guide
++Use generic fixture data.
+diff --git a/src/report.go b/src/report.go
+index 3333333..4444444 100644
+--- a/src/report.go
++++ b/src/report.go
+@@ -1,3 +1,2 @@
+ package src
+-func oldReport() {}
+-func removedReport() {}
++func newReport() {}
+`
+
+	rawFiles := []DiffFile{
+		{Path: "docs/guide.md", OldPath: "docs/guide.md", Status: "modified"},
+		{Path: "src/report.go", OldPath: "src/report.go", Status: "modified"},
+	}
+
+	files := ParsePatch([]byte(patch), rawFiles)
+	require.Len(files, 2)
+
+	assert.Equal("docs/guide.md", files[0].Path)
+	assert.Equal(2, files[0].Additions)
+	assert.Equal(1, files[0].Deletions)
+	assert.Contains(files[0].Patch, "+# Example Guide\n")
+
+	assert.Equal("src/report.go", files[1].Path)
+	assert.Equal(1, files[1].Additions)
+	assert.Equal(2, files[1].Deletions)
+	assert.Contains(files[1].Patch, "+func newReport() {}\n")
+	assert.NotContains(files[1].Patch, "# Example Guide")
+	assert.NotContains(files[1].Patch, "Use generic fixture data.")
+}
+
 func TestSortDiffFilesUsesBytewisePathOrder(t *testing.T) {
 	assert := assert.New(t)
 

--- a/internal/gitclone/parse_test.go
+++ b/internal/gitclone/parse_test.go
@@ -171,6 +171,48 @@ index 3333333..4444444 100644
 	assert.NotContains(files[1].Patch, "Use generic fixture data.")
 }
 
+func TestParsePatchKeepsModifiedSourcePatchSeparateFromCopy(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	patch := `diff --git a/src/source.txt b/src/source.txt
+index 1111111..2222222 100644
+--- a/src/source.txt
++++ b/src/source.txt
+@@ -1,2 +1,2 @@
+-base line
++changed line
+ shared line
+diff --git a/src/source.txt b/src/copied.txt
+similarity index 100%
+copy from src/source.txt
+copy to src/copied.txt
+`
+
+	rawFiles := []DiffFile{
+		{Path: "src/source.txt", OldPath: "src/source.txt", Status: "modified"},
+		{Path: "src/copied.txt", OldPath: "src/source.txt", Status: "copied"},
+	}
+
+	files := ParsePatch([]byte(patch), rawFiles)
+	require.Len(files, 2)
+
+	source := files[0]
+	assert.Equal("src/source.txt", source.Path)
+	assert.Equal(1, source.Additions)
+	assert.Equal(1, source.Deletions)
+	assert.Contains(source.Patch, "diff --git a/src/source.txt b/src/source.txt\n")
+	assert.Contains(source.Patch, "+changed line\n")
+	assert.NotContains(source.Patch, "copy to src/copied.txt")
+
+	copied := files[1]
+	assert.Equal("src/copied.txt", copied.Path)
+	assert.Zero(copied.Additions)
+	assert.Zero(copied.Deletions)
+	assert.Empty(copied.Patch)
+	assert.Empty(copied.Hunks)
+}
+
 func TestParsePatchReturnsEmptySliceWithoutRawMetadata(t *testing.T) {
 	assert := assert.New(t)
 

--- a/internal/gitclone/parse_test.go
+++ b/internal/gitclone/parse_test.go
@@ -171,6 +171,24 @@ index 3333333..4444444 100644
 	assert.NotContains(files[1].Patch, "Use generic fixture data.")
 }
 
+func TestParsePatchReturnsEmptySliceWithoutRawMetadata(t *testing.T) {
+	assert := assert.New(t)
+
+	patch := `diff --git a/src/example.go b/src/example.go
+index 1111111..2222222 100644
+--- a/src/example.go
++++ b/src/example.go
+@@ -1 +1 @@
+-old
++new
+`
+
+	files := ParsePatch([]byte(patch), nil)
+
+	assert.NotNil(files)
+	assert.Empty(files)
+}
+
 func TestSortDiffFilesUsesBytewisePathOrder(t *testing.T) {
 	assert := assert.New(t)
 

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -23858,6 +23858,52 @@ func TestWorkspaceDiffEndpointScopesPatchByPathE2E(t *testing.T) {
 	assert.NotContains(workspaceDiffPaths(*diff.Files), "second.go")
 }
 
+func TestWorkspaceDiffEndpointKeepsModifiedSourcePatchSeparateFromCopyE2E(t *testing.T) {
+	t.Parallel()
+
+	require := require.New(t)
+	assert := assert.New(t)
+
+	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, nil)
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+
+	runGit(t, ws.WorktreePath, "config", "user.email", "test@test.com")
+	runGit(t, ws.WorktreePath, "config", "user.name", "Test")
+
+	sourcePath := filepath.Join(ws.WorktreePath, "src", "a.txt")
+	copiedPath := filepath.Join(ws.WorktreePath, "src", "z.txt")
+	require.NoError(os.MkdirAll(filepath.Dir(sourcePath), 0o755))
+	require.NoError(os.WriteFile(sourcePath, []byte("base line\nshared line\n"), 0o644))
+	runGit(t, ws.WorktreePath, "add", ".")
+	runGit(t, ws.WorktreePath, "commit", "-m", "add copy source fixture")
+
+	require.NoError(os.WriteFile(copiedPath, []byte("base line\nshared line\n"), 0o644))
+	require.NoError(os.WriteFile(sourcePath, []byte("changed line\nshared line\n"), 0o644))
+	runGit(t, ws.WorktreePath, "add", "src/z.txt")
+
+	diff := requestWorkspaceDiff(t, srv, ws.Id, "head")
+	require.NotNil(diff.Files)
+	source := requireWorkspaceDiffFile(t, *diff.Files, "src/a.txt")
+	copied := requireWorkspaceDiffFile(t, *diff.Files, "src/z.txt")
+
+	assert.Equal("modified", source.Status)
+	assert.Equal(int64(1), source.Additions)
+	assert.Equal(int64(1), source.Deletions)
+	assert.Contains(source.Patch, "diff --git a/src/a.txt b/src/a.txt\n")
+	assert.Contains(source.Patch, "+changed line\n")
+	assert.NotContains(source.Patch, "copy to src/z.txt")
+	require.NotNil(source.Hunks)
+	require.Len(*source.Hunks, 1)
+
+	assert.Equal("copied", copied.Status)
+	assert.Zero(copied.Additions)
+	assert.Zero(copied.Deletions)
+	assert.Empty(copied.Patch)
+	require.NotNil(copied.Hunks)
+	assert.Empty(*copied.Hunks)
+}
+
 func TestWorkspaceDiffEndpointQuotesDangerousPathsE2E(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Git diffs that include type changes can make the files tab show a later file with patch content from an unrelated path. This fixes the patch-to-file association so PR diffs keep content under the correct changed file.

The regression coverage uses generic fixture paths and content. The agent guidance now also makes that privacy rule explicit for future bug reproductions.