### PR TITLE
fix: search activity by author

### DIFF
--- a/context/testing.md
+++ b/context/testing.md
@@ -172,6 +172,12 @@ the fake or callback that observed the exact event under test. If the behavior
 is inherently observable only by polling, check once immediately, then poll with
 a short ticker bounded by a context deadline.
 
+When server e2e tests chain `POST /api/v1/sync` with another ad-hoc sync
+trigger, treat the HTTP 202 and DB row timestamps as intermediate observations.
+`TriggerRun` is non-blocking and single-flight; wait for `/api/v1/sync/status`
+to report `running=false` with a `last_run_at` before issuing the next trigger,
+or the next trigger can race the still-running sync and be skipped.
+
 `testing/synctest` is appropriate only when all goroutines and timers under test
 are pure in-process work created inside the `synctest.Run` bubble. Good
 candidates include fake-client backoff, cooldown, cancellation, and event-hub

--- a/internal/db/queries_activity.go
+++ b/internal/db/queries_activity.go
@@ -53,15 +53,16 @@ func (d *DB) ListActivity(
 	}
 
 	if opts.Search != "" {
-		pattern := "%" + opts.Search + "%"
+		pattern := "%" + strings.ToLower(opts.Search) + "%"
 		whereClauses = append(whereClauses,
-			"(item_title LIKE ? OR body_preview LIKE ? OR branch_name LIKE ? OR "+
-				"commit_sha LIKE ? OR before_sha LIKE ? OR after_sha LIKE ? OR "+
-				"author_name LIKE ? OR author_email LIKE ? OR "+
-				"committer_name LIKE ? OR committer_email LIKE ?)")
+			"(LOWER(item_title) LIKE ? OR LOWER(body_preview) LIKE ? OR LOWER(branch_name) LIKE ? OR "+
+				"LOWER(commit_sha) LIKE ? OR LOWER(before_sha) LIKE ? OR LOWER(after_sha) LIKE ? OR "+
+				"LOWER(author) LIKE ? OR LOWER(item_author) LIKE ? OR "+
+				"LOWER(author_name) LIKE ? OR LOWER(author_email) LIKE ? OR "+
+				"LOWER(committer_name) LIKE ? OR LOWER(committer_email) LIKE ?)")
 		args = append(args,
 			pattern, pattern, pattern, pattern, pattern, pattern,
-			pattern, pattern, pattern, pattern)
+			pattern, pattern, pattern, pattern, pattern, pattern)
 	}
 
 	// Time window filter.

--- a/internal/db/queries_activity_test.go
+++ b/internal/db/queries_activity_test.go
@@ -214,6 +214,48 @@ func TestListActivity(t *testing.T) {
 		}
 	})
 
+	t.Run("search matches activity actor and item author", func(t *testing.T) {
+		assert := assert.New(t)
+		require := require.New(t)
+		d := openTestDB(t)
+		ctx := t.Context()
+		base := baseTime()
+		repoID := insertTestRepo(t, d, "example", "activity-authors")
+		prID := insertTestMRWithOptions(t, d, testMR(
+			repoID,
+			1,
+			withMRTitle("Refactor cache invalidation"),
+			withMRAuthor("item-author-one"),
+			withMRActivity(base),
+		))
+		err := d.UpsertMREvents(ctx, []MREvent{{
+			MergeRequestID: prID,
+			EventType:      "issue_comment",
+			Author:         "commenter-one",
+			Body:           "Looks ready",
+			CreatedAt:      base.Add(time.Minute),
+			DedupeKey:      "comment-author-one",
+		}})
+		require.NoError(err)
+
+		actorItems, err := d.ListActivity(ctx, ListActivityOpts{
+			Search: "COMMENTER-ONE", Limit: 50,
+		})
+		require.NoError(err)
+		require.Len(actorItems, 1)
+		assert.Equal("comment", actorItems[0].ActivityType)
+		assert.Equal("commenter-one", actorItems[0].Author)
+
+		itemAuthorItems, err := d.ListActivity(ctx, ListActivityOpts{
+			Search: "ITEM-AUTHOR-ONE", Limit: 50,
+		})
+		require.NoError(err)
+		require.Len(itemAuthorItems, 2)
+		for _, it := range itemAuthorItems {
+			assert.Equal("item-author-one", it.ItemAuthor)
+		}
+	})
+
 	t.Run("limit and before cursor", func(t *testing.T) {
 		assert := assert.New(t)
 		require := require.New(t)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -18654,6 +18654,18 @@ func TestAPIListActivity(t *testing.T) {
 	assert.NotEmpty(*resp.JSON200.Items,
 		"activity feed should contain PR and comment items")
 	assert.Equal("github.com", (*resp.JSON200.Items)[0].PlatformHost)
+
+	search := "reviewer"
+	filtered, err := client.HTTP.ListActivityWithResponse(
+		ctx, &generated.ListActivityParams{Since: &since, Search: &search},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, filtered.StatusCode())
+	require.NotNil(filtered.JSON200)
+	require.NotNil(filtered.JSON200.Items)
+	require.Len(*filtered.JSON200.Items, 1)
+	assert.Equal("comment", (*filtered.JSON200.Items)[0].ActivityType)
+	assert.Equal("reviewer", (*filtered.JSON200.Items)[0].Author)
 }
 
 func TestAPIListActivityIncludesNotificationSyncedBeforeRepo(t *testing.T) {

--- a/internal/server/e2etest/sync_cooldown_test.go
+++ b/internal/server/e2etest/sync_cooldown_test.go
@@ -354,6 +354,7 @@ name = "widget"
 	)
 	require.Equal(http.StatusAccepted, status, body)
 	waitForRepoSynced(t, database, "acme", "widget", nil)
+	waitForSyncIdle(t, client, baseURL)
 
 	status, body = postJSON(t, client, baseURL+"/api/v1/repos", map[string]string{
 		"provider": "github",
@@ -409,6 +410,7 @@ name = "*"
 	)
 	require.Equal(http.StatusAccepted, status, body)
 	waitForRepoSynced(t, database, "roborev-dev", "middleman", nil)
+	waitForSyncIdle(t, client, baseURL)
 
 	includeRefreshRepo.Store(true)
 


### PR DESCRIPTION
Activity search should let maintainers narrow a noisy feed to activity from a person, but the backend predicate ignored the visible author fields. That made flat and threaded activity searches miss rows even when the actor or parent item author matched the typed handle.

This adds those author fields to the activity query and makes the match explicitly case-insensitive, with regression coverage at the DB and API boundary.