### PR TITLE
fix: keep status bar counts open-scoped

### DIFF
--- a/frontend/src/lib/components/layout/StatusBar.counts.browser.svelte.ts
+++ b/frontend/src/lib/components/layout/StatusBar.counts.browser.svelte.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { page } from "vite-plus/test/browser";
+
+import { mountBrowserApp, resetKeyboardModuleState, type MountedBrowserApp } from "../../../test/browserAppHarness.js";
+import { jsonResponse, type MockRouteOverride } from "../../../test/mockApiFetch.js";
+
+const WAIT = 10_000;
+
+let mounted: MountedBrowserApp | null = null;
+
+function repo(owner: string, name: string) {
+  return {
+    provider: "github",
+    platform_host: "github.com",
+    owner,
+    name,
+    repo_path: `${owner}/${name}`,
+  };
+}
+
+function pr(number: number, state: "open" | "closed" | "merged", owner = "acme", name = "widgets") {
+  return {
+    ID: number,
+    Number: number,
+    Title: `PR ${number}`,
+    State: state,
+    repo_owner: owner,
+    repo_name: name,
+    platform_host: "github.com",
+    repo: repo(owner, name),
+  };
+}
+
+function issue(number: number, state: "open" | "closed", owner = "acme", name = "widgets") {
+  return {
+    ID: number,
+    Number: number,
+    Title: `Issue ${number}`,
+    State: state,
+    repo_owner: owner,
+    repo_name: name,
+    platform_host: "github.com",
+    repo: repo(owner, name),
+  };
+}
+
+function pullsWithClosedAndMergedRows(): MockRouteOverride {
+  return (req) => {
+    if (req.method !== "GET" || req.url.pathname !== "/api/v1/pulls") return null;
+    return jsonResponse([
+      pr(1, "open"),
+      pr(2, "open"),
+      pr(3, "closed", "acme", "closed-only"),
+      pr(4, "merged", "acme", "merged-only"),
+    ]);
+  };
+}
+
+function issuesWithClosedRows(): MockRouteOverride {
+  return (req) => {
+    if (req.method !== "GET" || req.url.pathname !== "/api/v1/issues") return null;
+    return jsonResponse([issue(1, "open"), issue(2, "closed", "acme", "closed-issues")]);
+  };
+}
+
+describe("status bar counts", () => {
+  vi.setConfig({ testTimeout: 30_000 });
+
+  beforeEach(async () => {
+    await page.viewport(1280, 900);
+  });
+
+  afterEach(async () => {
+    mounted?.unmount();
+    mounted = null;
+    localStorage.clear();
+    await resetKeyboardModuleState();
+  });
+
+  it("counts only open PRs when the loaded pull cache includes closed and merged rows", async () => {
+    mounted = await mountBrowserApp("/?view=threaded&range=30d", {
+      overrides: [pullsWithClosedAndMergedRows(), issuesWithClosedRows()],
+    });
+
+    await vi.waitFor(() => {
+      const paths = mounted?.api.requests.map((req) => req.url.pathname) ?? [];
+      expect(paths).toContain("/api/v1/pulls");
+      expect(paths).toContain("/api/v1/issues");
+    }, WAIT);
+    await vi.waitFor(() => expect(document.querySelector(".status-bar")).not.toBeNull(), WAIT);
+
+    const statusItems = Array.from(document.querySelectorAll(".status-left .status-item"));
+    expect(statusItems.map((item) => item.textContent?.trim())).toEqual(["2 PRs", "1 issues", "1 repos"]);
+  });
+});

--- a/frontend/src/lib/components/layout/StatusBar.counts.browser.svelte.ts
+++ b/frontend/src/lib/components/layout/StatusBar.counts.browser.svelte.ts
@@ -1,12 +1,24 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { page } from "vite-plus/test/browser";
+import { render } from "vitest-browser-svelte";
 
 import { mountBrowserApp, resetKeyboardModuleState, type MountedBrowserApp } from "../../../test/browserAppHarness.js";
-import { jsonResponse, type MockRouteOverride } from "../../../test/mockApiFetch.js";
+import {
+  createMockApiFetch,
+  jsonResponse,
+  type MockApiHandle,
+  type MockRouteOverride,
+} from "../../../test/mockApiFetch.js";
+import StatusBarTestHost from "./StatusBarTestHost.svelte";
 
 const WAIT = 10_000;
 
-let mounted: MountedBrowserApp | null = null;
+let mounted: (MountedBrowserApp | MountedStatusBar) | null = null;
+
+interface MountedStatusBar {
+  api: MockApiHandle;
+  unmount: () => void;
+}
 
 function repo(owner: string, name: string) {
   return {
@@ -175,6 +187,29 @@ function activityWithNotificationOnlyRows(): MockRouteOverride {
   };
 }
 
+async function mountStatusBar(path: string, overrides: MockRouteOverride[]): Promise<MountedStatusBar> {
+  const api = createMockApiFetch(overrides);
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = api.fetch;
+
+  window.history.replaceState(null, "", path);
+  const { replaceUrl } = await import("../../stores/router.svelte.js");
+  replaceUrl(path);
+
+  const target = document.createElement("div");
+  document.body.appendChild(target);
+  const { unmount } = render(StatusBarTestHost, { target });
+
+  return {
+    api,
+    unmount: () => {
+      unmount();
+      target.remove();
+      globalThis.fetch = originalFetch;
+    },
+  };
+}
+
 describe("status bar counts", () => {
   vi.setConfig({ testTimeout: 30_000 });
 
@@ -218,8 +253,31 @@ describe("status bar counts", () => {
     }, WAIT);
     await vi.waitFor(() => expect(document.querySelector(".status-bar")).not.toBeNull(), WAIT);
 
-    const statusItems = Array.from(document.querySelectorAll(".status-left .status-item"));
-    expect(statusItems.map((item) => item.textContent?.trim())).toEqual(["3 PRs", "2 issues", "3 repos"]);
+    await vi.waitFor(() => {
+      const statusItems = Array.from(document.querySelectorAll(".status-left .status-item"));
+      expect(statusItems.map((item) => item.textContent?.trim())).toEqual(["3 PRs", "2 issues", "3 repos"]);
+    }, WAIT);
+  });
+
+  it("uses open activity threads for mobile activity counts", async () => {
+    mounted = await mountStatusBar("/m/activity?view=threaded&range=30d", [
+      pullsWithExtraOpenRows(),
+      issuesWithExtraOpenRows(),
+      activityWithNewRows(),
+    ]);
+
+    await vi.waitFor(() => {
+      const paths = mounted?.api.requests.map((req) => req.url.pathname) ?? [];
+      expect(paths).toContain("/api/v1/pulls");
+      expect(paths).toContain("/api/v1/issues");
+      expect(paths).toContain("/api/v1/activity");
+    }, WAIT);
+    await vi.waitFor(() => expect(document.querySelector(".status-bar")).not.toBeNull(), WAIT);
+
+    await vi.waitFor(() => {
+      const statusItems = Array.from(document.querySelectorAll(".status-left .status-item"));
+      expect(statusItems.map((item) => item.textContent?.trim())).toEqual(["3 PRs", "2 issues", "3 repos"]);
+    }, WAIT);
   });
 
   it("uses notification subject state for activity-page counts", async () => {

--- a/frontend/src/lib/components/layout/StatusBar.counts.browser.svelte.ts
+++ b/frontend/src/lib/components/layout/StatusBar.counts.browser.svelte.ts
@@ -63,6 +63,73 @@ function issuesWithClosedRows(): MockRouteOverride {
   };
 }
 
+function activityItem(
+  id: string,
+  number: number,
+  activityType: "new_pr" | "new_issue" | "comment",
+  itemType: "pr" | "issue",
+  state: "open" | "closed" | "merged",
+  owner = "acme",
+  name = "widgets",
+) {
+  return {
+    id,
+    cursor: id,
+    repo: repo(owner, name),
+    repo_owner: owner,
+    repo_name: name,
+    platform_host: "github.com",
+    item_type: itemType,
+    item_number: number,
+    item_title: `${itemType} ${number}`,
+    item_url: `https://github.com/${owner}/${name}/${itemType === "pr" ? "pull" : "issues"}/${number}`,
+    item_state: state,
+    activity_type: activityType,
+    activity_url: "",
+    author: "octo",
+    author_name: "Octo",
+    body_preview: "",
+    branch_name: "main",
+    created_at: "2026-03-30T14:00:00Z",
+  };
+}
+
+function pullsWithExtraOpenRows(): MockRouteOverride {
+  return (req) => {
+    if (req.method !== "GET" || req.url.pathname !== "/api/v1/pulls") return null;
+    return jsonResponse([
+      pr(1, "open"),
+      pr(2, "open"),
+      pr(3, "open", "acme", "quiet-open"),
+      pr(4, "open", "acme", "older-open"),
+    ]);
+  };
+}
+
+function issuesWithExtraOpenRows(): MockRouteOverride {
+  return (req) => {
+    if (req.method !== "GET" || req.url.pathname !== "/api/v1/issues") return null;
+    return jsonResponse([issue(1, "open"), issue(2, "open", "acme", "quiet-issues")]);
+  };
+}
+
+function activityWithNewRows(): MockRouteOverride {
+  return (req) => {
+    if (req.method !== "GET" || req.url.pathname !== "/api/v1/activity") return null;
+    return jsonResponse({
+      capped: false,
+      items: [
+        activityItem("pr-1-new", 1, "new_pr", "pr", "open"),
+        activityItem("pr-1-comment", 1, "comment", "pr", "open"),
+        activityItem("pr-2-new", 2, "new_pr", "pr", "open"),
+        activityItem("pr-3-comment", 3, "comment", "pr", "open", "acme", "quiet-open"),
+        activityItem("issue-1-new", 1, "new_issue", "issue", "open"),
+        activityItem("issue-2-comment", 2, "comment", "issue", "open", "acme", "quiet-issues"),
+      ],
+    });
+  };
+}
+
 describe("status bar counts", () => {
   vi.setConfig({ testTimeout: 30_000 });
 
@@ -78,7 +145,7 @@ describe("status bar counts", () => {
   });
 
   it("counts only open PRs when the loaded pull cache includes closed and merged rows", async () => {
-    mounted = await mountBrowserApp("/?view=threaded&range=30d", {
+    mounted = await mountBrowserApp("/repos", {
       overrides: [pullsWithClosedAndMergedRows(), issuesWithClosedRows()],
     });
 
@@ -86,6 +153,23 @@ describe("status bar counts", () => {
       const paths = mounted?.api.requests.map((req) => req.url.pathname) ?? [];
       expect(paths).toContain("/api/v1/pulls");
       expect(paths).toContain("/api/v1/issues");
+    }, WAIT);
+    await vi.waitFor(() => expect(document.querySelector(".status-bar")).not.toBeNull(), WAIT);
+
+    const statusItems = Array.from(document.querySelectorAll(".status-left .status-item"));
+    expect(statusItems.map((item) => item.textContent?.trim())).toEqual(["2 PRs", "1 issues", "1 repos"]);
+  });
+
+  it("uses new open activity rows for activity-page counts", async () => {
+    mounted = await mountBrowserApp("/?view=threaded&range=30d", {
+      overrides: [pullsWithExtraOpenRows(), issuesWithExtraOpenRows(), activityWithNewRows()],
+    });
+
+    await vi.waitFor(() => {
+      const paths = mounted?.api.requests.map((req) => req.url.pathname) ?? [];
+      expect(paths).toContain("/api/v1/pulls");
+      expect(paths).toContain("/api/v1/issues");
+      expect(paths).toContain("/api/v1/activity");
     }, WAIT);
     await vi.waitFor(() => expect(document.querySelector(".status-bar")).not.toBeNull(), WAIT);
 

--- a/frontend/src/lib/components/layout/StatusBar.counts.browser.svelte.ts
+++ b/frontend/src/lib/components/layout/StatusBar.counts.browser.svelte.ts
@@ -210,6 +210,10 @@ async function mountStatusBar(path: string, overrides: MockRouteOverride[]): Pro
   };
 }
 
+function statusItemTexts(): (string | undefined)[] {
+  return Array.from(document.querySelectorAll(".status-left .status-item")).map((item) => item.textContent?.trim());
+}
+
 describe("status bar counts", () => {
   vi.setConfig({ testTimeout: 30_000 });
 
@@ -236,8 +240,9 @@ describe("status bar counts", () => {
     }, WAIT);
     await vi.waitFor(() => expect(document.querySelector(".status-bar")).not.toBeNull(), WAIT);
 
-    const statusItems = Array.from(document.querySelectorAll(".status-left .status-item"));
-    expect(statusItems.map((item) => item.textContent?.trim())).toEqual(["2 PRs", "1 issues", "1 repos"]);
+    await vi.waitFor(() => {
+      expect(statusItemTexts()).toEqual(["2 PRs", "1 issues", "1 repos"]);
+    }, WAIT);
   });
 
   it("uses open activity threads for activity-page counts", async () => {
@@ -254,8 +259,7 @@ describe("status bar counts", () => {
     await vi.waitFor(() => expect(document.querySelector(".status-bar")).not.toBeNull(), WAIT);
 
     await vi.waitFor(() => {
-      const statusItems = Array.from(document.querySelectorAll(".status-left .status-item"));
-      expect(statusItems.map((item) => item.textContent?.trim())).toEqual(["3 PRs", "2 issues", "3 repos"]);
+      expect(statusItemTexts()).toEqual(["3 PRs", "2 issues", "3 repos"]);
     }, WAIT);
   });
 
@@ -275,8 +279,7 @@ describe("status bar counts", () => {
     await vi.waitFor(() => expect(document.querySelector(".status-bar")).not.toBeNull(), WAIT);
 
     await vi.waitFor(() => {
-      const statusItems = Array.from(document.querySelectorAll(".status-left .status-item"));
-      expect(statusItems.map((item) => item.textContent?.trim())).toEqual(["3 PRs", "2 issues", "3 repos"]);
+      expect(statusItemTexts()).toEqual(["3 PRs", "2 issues", "3 repos"]);
     }, WAIT);
   });
 
@@ -291,7 +294,8 @@ describe("status bar counts", () => {
     }, WAIT);
     await vi.waitFor(() => expect(document.querySelector(".status-bar")).not.toBeNull(), WAIT);
 
-    const statusItems = Array.from(document.querySelectorAll(".status-left .status-item"));
-    expect(statusItems.map((item) => item.textContent?.trim())).toEqual(["1 PRs", "1 issues", "1 repos"]);
+    await vi.waitFor(() => {
+      expect(statusItemTexts()).toEqual(["1 PRs", "1 issues", "1 repos"]);
+    }, WAIT);
   });
 });

--- a/frontend/src/lib/components/layout/StatusBar.counts.browser.svelte.ts
+++ b/frontend/src/lib/components/layout/StatusBar.counts.browser.svelte.ts
@@ -94,6 +94,37 @@ function activityItem(
   };
 }
 
+function notificationActivityItem(
+  id: string,
+  number: number,
+  itemType: "pr" | "issue",
+  subjectState: "open" | "closed" | "merged" | "",
+  owner = "acme",
+  name = "widgets",
+) {
+  return {
+    id,
+    cursor: id,
+    repo: repo(owner, name),
+    repo_owner: owner,
+    repo_name: name,
+    platform_host: "github.com",
+    item_type: itemType,
+    item_number: number,
+    item_title: `${itemType} ${number}`,
+    item_url: `https://github.com/${owner}/${name}/${itemType === "pr" ? "pull" : "issues"}/${number}`,
+    item_state: "unread",
+    subject_state: subjectState,
+    activity_type: "notification",
+    activity_url: "",
+    author: "octo",
+    author_name: "Octo",
+    body_preview: "review_requested",
+    branch_name: "main",
+    created_at: "2026-03-30T14:00:00Z",
+  };
+}
+
 function pullsWithExtraOpenRows(): MockRouteOverride {
   return (req) => {
     if (req.method !== "GET" || req.url.pathname !== "/api/v1/pulls") return null;
@@ -125,6 +156,20 @@ function activityWithNewRows(): MockRouteOverride {
         activityItem("pr-3-comment", 3, "comment", "pr", "open", "acme", "quiet-open"),
         activityItem("issue-1-new", 1, "new_issue", "issue", "open"),
         activityItem("issue-2-comment", 2, "comment", "issue", "open", "acme", "quiet-issues"),
+      ],
+    });
+  };
+}
+
+function activityWithNotificationOnlyRows(): MockRouteOverride {
+  return (req) => {
+    if (req.method !== "GET" || req.url.pathname !== "/api/v1/activity") return null;
+    return jsonResponse({
+      capped: false,
+      items: [
+        notificationActivityItem("ntf-pr-open", 10, "pr", "open"),
+        notificationActivityItem("ntf-issue-open", 11, "issue", "open"),
+        notificationActivityItem("ntf-pr-closed", 12, "pr", "closed", "acme", "closed-notification"),
       ],
     });
   };
@@ -175,5 +220,20 @@ describe("status bar counts", () => {
 
     const statusItems = Array.from(document.querySelectorAll(".status-left .status-item"));
     expect(statusItems.map((item) => item.textContent?.trim())).toEqual(["3 PRs", "2 issues", "3 repos"]);
+  });
+
+  it("uses notification subject state for activity-page counts", async () => {
+    mounted = await mountBrowserApp("/?view=threaded&range=30d", {
+      overrides: [pullsWithExtraOpenRows(), issuesWithExtraOpenRows(), activityWithNotificationOnlyRows()],
+    });
+
+    await vi.waitFor(() => {
+      const paths = mounted?.api.requests.map((req) => req.url.pathname) ?? [];
+      expect(paths).toContain("/api/v1/activity");
+    }, WAIT);
+    await vi.waitFor(() => expect(document.querySelector(".status-bar")).not.toBeNull(), WAIT);
+
+    const statusItems = Array.from(document.querySelectorAll(".status-left .status-item"));
+    expect(statusItems.map((item) => item.textContent?.trim())).toEqual(["1 PRs", "1 issues", "1 repos"]);
   });
 });

--- a/frontend/src/lib/components/layout/StatusBar.counts.browser.svelte.ts
+++ b/frontend/src/lib/components/layout/StatusBar.counts.browser.svelte.ts
@@ -160,7 +160,7 @@ describe("status bar counts", () => {
     expect(statusItems.map((item) => item.textContent?.trim())).toEqual(["2 PRs", "1 issues", "1 repos"]);
   });
 
-  it("uses new open activity rows for activity-page counts", async () => {
+  it("uses open activity threads for activity-page counts", async () => {
     mounted = await mountBrowserApp("/?view=threaded&range=30d", {
       overrides: [pullsWithExtraOpenRows(), issuesWithExtraOpenRows(), activityWithNewRows()],
     });
@@ -174,6 +174,6 @@ describe("status bar counts", () => {
     await vi.waitFor(() => expect(document.querySelector(".status-bar")).not.toBeNull(), WAIT);
 
     const statusItems = Array.from(document.querySelectorAll(".status-left .status-item"));
-    expect(statusItems.map((item) => item.textContent?.trim())).toEqual(["2 PRs", "1 issues", "1 repos"]);
+    expect(statusItems.map((item) => item.textContent?.trim())).toEqual(["3 PRs", "2 issues", "3 repos"]);
   });
 });

--- a/frontend/src/lib/components/layout/StatusBar.svelte
+++ b/frontend/src/lib/components/layout/StatusBar.svelte
@@ -84,6 +84,13 @@
     return BOT_SUFFIXES.some((suffix) => lower.endsWith(suffix));
   }
 
+  function activityLifecycleState(item: ActivityItem): string {
+    if (item.activity_type === "notification") {
+      return item.subject_state || item.item_state;
+    }
+    return item.item_state;
+  }
+
   const globalCounts = $derived.by((): StatusCounts => {
     const repos = new Set<string>();
     for (const pr of openPulls) repos.add(repoKey(pr));
@@ -107,10 +114,11 @@
       if (itemFilter === "prs" && item.item_type !== "pr") continue;
       if (itemFilter === "issues" && item.item_type !== "issue") continue;
 
+      const lifecycleState = activityLifecycleState(item);
       const isOpenPullRequest = item.item_type === "pr"
-        && item.item_state === "open";
+        && lifecycleState === "open";
       const isOpenIssue = item.item_type === "issue"
-        && item.item_state === "open";
+        && lifecycleState === "open";
 
       if (isOpenPullRequest) {
         pullRequests.add(activityItemKey(item));

--- a/frontend/src/lib/components/layout/StatusBar.svelte
+++ b/frontend/src/lib/components/layout/StatusBar.svelte
@@ -107,17 +107,15 @@
       if (itemFilter === "prs" && item.item_type !== "pr") continue;
       if (itemFilter === "issues" && item.item_type !== "issue") continue;
 
-      const isNewOpenPullRequest = item.activity_type === "new_pr"
-        && item.item_type === "pr"
+      const isOpenPullRequest = item.item_type === "pr"
         && item.item_state === "open";
-      const isNewOpenIssue = item.activity_type === "new_issue"
-        && item.item_type === "issue"
+      const isOpenIssue = item.item_type === "issue"
         && item.item_state === "open";
 
-      if (isNewOpenPullRequest) {
+      if (isOpenPullRequest) {
         pullRequests.add(activityItemKey(item));
         repos.add(repoKey(item));
-      } else if (isNewOpenIssue) {
+      } else if (isOpenIssue) {
         issueKeys.add(activityItemKey(item));
         repos.add(repoKey(item));
       }

--- a/frontend/src/lib/components/layout/StatusBar.svelte
+++ b/frontend/src/lib/components/layout/StatusBar.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
   import { getStores } from "@middleman/ui";
+  import type { ActivityItem } from "@middleman/ui/api/types";
   import BudgetBars from "./BudgetBars.svelte";
   import BudgetPopover from "./BudgetPopover.svelte";
   import { client } from "../../api/runtime.js";
+  import { getPage } from "../../stores/router.svelte.ts";
 
-  const { pulls, issues, sync } = getStores();
+  const { activity, pulls, issues, sync } = getStores();
 
   let appVersion = $state("");
 
@@ -42,16 +44,93 @@
   const openPulls = $derived(pulls.getPulls().filter((pr) => pr.State === "open"));
   const openIssues = $derived(issues.getIssues().filter((issue) => issue.State === "open"));
 
-  function repoKey(item: { repo: { provider: string; platform_host: string; repo_path: string } }): string {
-    return `${item.repo.provider}|${item.repo.platform_host}/${item.repo.repo_path}`;
+  interface RepoBackedItem {
+    repo?: {
+      provider?: string | undefined;
+      platform_host?: string | undefined;
+      repo_path?: string | undefined;
+      owner?: string | undefined;
+      name?: string | undefined;
+    } | undefined;
+    platform_host?: string | undefined;
+    repo_owner?: string | undefined;
+    repo_name?: string | undefined;
   }
 
-  function repoCount(): number {
+  interface StatusCounts {
+    pullRequests: number;
+    issues: number;
+    repos: number;
+  }
+
+  const BOT_SUFFIXES = ["[bot]", "-bot", "bot"];
+
+  function repoKey(item: RepoBackedItem): string {
+    const provider = item.repo?.provider ?? "";
+    const platformHost = item.repo?.platform_host ?? item.platform_host ?? "";
+    const repoPath = item.repo?.repo_path
+      ?? [item.repo?.owner ?? item.repo_owner, item.repo?.name ?? item.repo_name]
+        .filter(Boolean)
+        .join("/");
+    return `${provider}|${platformHost}/${repoPath}`;
+  }
+
+  function activityItemKey(item: ActivityItem): string {
+    return `${repoKey(item)}|${item.item_type}|${item.item_number}`;
+  }
+
+  function isBot(author: string): boolean {
+    const lower = author.toLowerCase();
+    return BOT_SUFFIXES.some((suffix) => lower.endsWith(suffix));
+  }
+
+  const globalCounts = $derived.by((): StatusCounts => {
     const repos = new Set<string>();
     for (const pr of openPulls) repos.add(repoKey(pr));
     for (const issue of openIssues) repos.add(repoKey(issue));
-    return repos.size;
-  }
+    return {
+      pullRequests: openPulls.length,
+      issues: openIssues.length,
+      repos: repos.size,
+    };
+  });
+
+  const activityCounts = $derived.by((): StatusCounts => {
+    const pullRequests = new Set<string>();
+    const issueKeys = new Set<string>();
+    const repos = new Set<string>();
+    const itemFilter = activity.getItemFilter();
+    const hideBots = activity.getHideBots();
+
+    for (const item of activity.getActivityItems()) {
+      if (hideBots && isBot(item.author)) continue;
+      if (itemFilter === "prs" && item.item_type !== "pr") continue;
+      if (itemFilter === "issues" && item.item_type !== "issue") continue;
+
+      const isNewOpenPullRequest = item.activity_type === "new_pr"
+        && item.item_type === "pr"
+        && item.item_state === "open";
+      const isNewOpenIssue = item.activity_type === "new_issue"
+        && item.item_type === "issue"
+        && item.item_state === "open";
+
+      if (isNewOpenPullRequest) {
+        pullRequests.add(activityItemKey(item));
+        repos.add(repoKey(item));
+      } else if (isNewOpenIssue) {
+        issueKeys.add(activityItemKey(item));
+        repos.add(repoKey(item));
+      }
+    }
+
+    return {
+      pullRequests: pullRequests.size,
+      issues: issueKeys.size,
+      repos: repos.size,
+    };
+  });
+
+  const counts = $derived(getPage() === "activity" ? activityCounts : globalCounts);
 
   let popoverOpen = $state(false);
 
@@ -72,11 +151,11 @@
 
 <footer class="status-bar">
   <div class="status-left">
-    <span class="status-item">{openPulls.length} PRs</span>
+    <span class="status-item">{counts.pullRequests} PRs</span>
     <span class="status-sep">&middot;</span>
-    <span class="status-item">{openIssues.length} issues</span>
+    <span class="status-item">{counts.issues} issues</span>
     <span class="status-sep">&middot;</span>
-    <span class="status-item">{repoCount()} repos</span>
+    <span class="status-item">{counts.repos} repos</span>
   </div>
   <div class="status-right">
     {#if hasHosts}

--- a/frontend/src/lib/components/layout/StatusBar.svelte
+++ b/frontend/src/lib/components/layout/StatusBar.svelte
@@ -136,7 +136,12 @@
     };
   });
 
-  const counts = $derived(getPage() === "activity" ? activityCounts : globalCounts);
+  function isActivityStatusSurface(): boolean {
+    const page = getPage();
+    return page === "activity" || page === "mobile-activity";
+  }
+
+  const counts = $derived(isActivityStatusSurface() ? activityCounts : globalCounts);
 
   let popoverOpen = $state(false);
 

--- a/frontend/src/lib/components/layout/StatusBar.svelte
+++ b/frontend/src/lib/components/layout/StatusBar.svelte
@@ -39,10 +39,17 @@
     return `synced ${Math.floor(mins / 60)}h ago`;
   }
 
+  const openPulls = $derived(pulls.getPulls().filter((pr) => pr.State === "open"));
+  const openIssues = $derived(issues.getIssues().filter((issue) => issue.State === "open"));
+
+  function repoKey(item: { repo: { provider: string; platform_host: string; repo_path: string } }): string {
+    return `${item.repo.provider}|${item.repo.platform_host}/${item.repo.repo_path}`;
+  }
+
   function repoCount(): number {
     const repos = new Set<string>();
-    for (const pr of pulls.getPulls()) repos.add(`${pr.repo_owner}/${pr.repo_name}`);
-    for (const issue of issues.getIssues()) repos.add(`${issue.repo_owner}/${issue.repo_name}`);
+    for (const pr of openPulls) repos.add(repoKey(pr));
+    for (const issue of openIssues) repos.add(repoKey(issue));
     return repos.size;
   }
 
@@ -65,9 +72,9 @@
 
 <footer class="status-bar">
   <div class="status-left">
-    <span class="status-item">{pulls.getPulls().length} PRs</span>
+    <span class="status-item">{openPulls.length} PRs</span>
     <span class="status-sep">&middot;</span>
-    <span class="status-item">{issues.getIssues().length} issues</span>
+    <span class="status-item">{openIssues.length} issues</span>
     <span class="status-sep">&middot;</span>
     <span class="status-item">{repoCount()} repos</span>
   </div>

--- a/frontend/src/lib/components/layout/StatusBarTestHost.svelte
+++ b/frontend/src/lib/components/layout/StatusBarTestHost.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import { Provider, type StoreInstances } from "@middleman/ui";
+  import { client } from "../../api/runtime.js";
+  import { getPage } from "../../stores/router.svelte.ts";
+  import StatusBar from "./StatusBar.svelte";
+
+  let stores = $state<StoreInstances>();
+  let loaded = false;
+
+  $effect(() => {
+    if (!stores || loaded) return;
+    loaded = true;
+    stores.activity.initializeFromMount();
+    void Promise.all([
+      stores.pulls.loadPulls(),
+      stores.issues.loadIssues(),
+      stores.activity.loadActivity(),
+    ]);
+  });
+</script>
+
+<Provider {client} {getPage} bind:stores>
+  <StatusBar />
+</Provider>


### PR DESCRIPTION
The activity page can load PR and issue cache entries whose lifecycle is already closed or merged, but the footer previously reported those cache sizes as if they were the open work count. That made the status bar disagree with the visible open PR list and made closed-only repositories inflate the repo total.

This keeps the footer summary scoped to open PRs and issues, and derives the repo total from the same open rows using full provider repository identity so the status line reflects active work rather than historical cache contents.