### PR TITLE
fix: keep Kata workspace action stable during refresh

### DIFF
--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -25,6 +25,13 @@ Interactive surfaces must agree on which item is selected.
   `{ owner, name, number }`-style shapes.
 - When a view changes from item A to item B, reset transient action state that
   could otherwise submit or render against the wrong item.
+- When a background refresh replaces the selected item's backing object but
+  the stable item identity is unchanged, preserve already-resolved action
+  affordances instead of treating the refresh as item A -> B. Key invalidation
+  on stable route/domain identity, not object reference; the Kata workspace
+  action target is the reference case
+  (`frontend/src/lib/features/kata/KataWorkspace.svelte:158`,
+  `frontend/src/lib/features/kata/KataWorkspace.test.ts:473`).
 
 Responsive layout changes must not change route identity.
 

--- a/frontend/src/lib/features/kata/KataWorkspace.svelte
+++ b/frontend/src/lib/features/kata/KataWorkspace.svelte
@@ -96,8 +96,8 @@
   let checklistRevealed = $state(false);
   let recurrenceDialogs = $state<KataRecurrenceDialogController | null>(null);
   let workspaceTarget = $state.raw<KataWorkspaceTarget | null>(null);
-  let workspaceTargetLoading = $state(false);
   let workspaceActionBusy = $state(false);
+  let workspaceTargetKey: string | null = null;
   let workspaceTargetRequestID = 0;
   const store = createKataWorkspaceStore({ api: untrack(() => api) });
   const actor = "middleman";
@@ -152,27 +152,30 @@
     const selected = store.selectedIssue?.issue;
     const daemonID = activeKataDaemonId ?? null;
     const requestID = ++workspaceTargetRequestID;
-    workspaceTarget = null;
-    workspaceTargetLoading = false;
-    requestError = null;
-    if (!selected || !daemonID) return;
+    if (!selected || !daemonID) {
+      workspaceTargetKey = null;
+      workspaceTarget = null;
+      requestError = null;
+      return;
+    }
 
-    workspaceTargetLoading = true;
     const identity = kataWorkspaceIdentityFromIssue(selected, daemonID, projectNameForIssue(selected));
+    const targetKey = `${identity.daemon_id}:${identity.project_uid}:${identity.project_name ?? ""}:${identity.issue_uid}`;
+    requestError = null;
+    if (targetKey !== workspaceTargetKey) {
+      workspaceTargetKey = targetKey;
+      workspaceTarget = null;
+    }
     void resolveKataWorkspaceTarget(identity)
       .then((target) => {
         if (requestID !== workspaceTargetRequestID) return;
         workspaceTarget = target.available ? target : null;
+        requestError = null;
       })
       .catch((err) => {
         if (requestID !== workspaceTargetRequestID) return;
         requestError = kataRequestErrorMessage(err);
         workspaceTarget = null;
-      })
-      .finally(() => {
-        if (requestID === workspaceTargetRequestID) {
-          workspaceTargetLoading = false;
-        }
       });
   });
 
@@ -748,7 +751,7 @@
   function selectedWorkspaceAction():
     | { label: string; busy?: boolean; disabled?: boolean; onClick: () => void | Promise<void> }
     | undefined {
-    if (workspaceTargetLoading || !workspaceTarget?.available) return undefined;
+    if (!workspaceTarget?.available) return undefined;
     if (workspaceTarget.existing_workspace) {
       const id = workspaceTarget.existing_workspace.id;
       return {

--- a/frontend/src/lib/features/kata/KataWorkspace.test.ts
+++ b/frontend/src/lib/features/kata/KataWorkspace.test.ts
@@ -3,11 +3,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test"
 
 import { KataTaskAPIError } from "../../api/kata/taskClient.js";
 import type { KataTaskDetail, KataTaskSearchFilters, KataTaskSearchResponse } from "../../api/kata/taskTypes.js";
+import type { KataWorkspaceTarget } from "../../api/kata/workspaces.js";
 import {
   getActiveKataDaemon,
   getDefaultKataDaemon,
   getKataDaemonRoster,
 } from "../../stores/active-kata-daemon.svelte.js";
+import { defaultProviderCapabilities } from "../../components/repositories/repoSummary.js";
 import KataWorkspace from "./KataWorkspace.svelte";
 import {
   createDaemonWorkspaceAPI,
@@ -425,6 +427,7 @@ describe("KataWorkspace", () => {
         owner: "acme",
         name: "middleman",
         repo_path: "acme/middleman",
+        capabilities: defaultProviderCapabilities,
       },
       item_type: "kata_task",
       item_key: "issue-pay-rent",
@@ -465,6 +468,56 @@ describe("KataWorkspace", () => {
       );
       expect(mockNavigate).toHaveBeenCalledWith("/terminal/workspace-kata");
     });
+  });
+
+  it("keeps the create workspace action visible while refreshing the same selected task", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [
+          {
+            id: "home",
+            url: "http://127.0.0.1:7777",
+            default: true,
+            auth: "none",
+            health: "connected",
+          },
+        ],
+      }),
+    );
+    const target: KataWorkspaceTarget = {
+      available: true,
+      repo: {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "acme",
+        name: "middleman",
+        repo_path: "acme/middleman",
+        capabilities: defaultProviderCapabilities,
+      },
+      item_type: "kata_task",
+      item_key: "issue-pay-rent",
+    };
+    const refreshedTarget = deferred<KataWorkspaceTarget>();
+    mockResolveKataWorkspaceTarget.mockResolvedValueOnce(target).mockReturnValueOnce(refreshedTarget.promise);
+    const { api, addLabel } = createWorkspaceAPI();
+
+    render(KataWorkspace, { props: { api, selectedIssueUID: "issue-pay-rent" } });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Create workspace" })).toBeTruthy();
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Add label" }));
+    await fireEvent.input(screen.getByLabelText("New label"), { target: { value: "blocked" } });
+    await fireEvent.keyDown(screen.getByLabelText("New label"), { key: "Enter" });
+
+    await waitFor(() => {
+      expect(addLabel).toHaveBeenCalledWith(expect.objectContaining({ ref: "issue-pay-rent" }), "middleman", "blocked");
+      expect(mockResolveKataWorkspaceTarget).toHaveBeenCalledTimes(2);
+    });
+    expect(screen.getByRole("button", { name: "Create workspace" })).toBeTruthy();
+
+    refreshedTarget.resolve(target);
   });
 
   it("opens an existing workspace for the selected Kata task", async () => {


### PR DESCRIPTION
The Kata task detail action now stays mounted while background refreshes replace the selected task object, so the Create/Open workspace button no longer flickers for the same task.

The shared UI interaction context also records the stable-identity rule for future detail actions.

<sup>generated by a clanker</sup>