### PR TITLE
Fix Kata label editing affordance

### DIFF
--- a/frontend/src/lib/components/kata/KataIssueProperties.svelte
+++ b/frontend/src/lib/components/kata/KataIssueProperties.svelte
@@ -3,6 +3,7 @@
   import ClockIcon from "@lucide/svelte/icons/clock-3";
   import FlagIcon from "@lucide/svelte/icons/flag";
   import UserIcon from "@lucide/svelte/icons/user-round";
+  import XIcon from "@lucide/svelte/icons/x";
   import { ActionButton, Chip } from "@middleman/ui";
   import type { KataTaskDetail } from "../../api/kata/taskTypes.js";
   import DatePicker from "../shared/DatePicker.svelte";
@@ -271,23 +272,26 @@
     <div>
       <dt>Labels</dt>
       <dd>
-        <div class="label-row">
+        <ul class="label-list" aria-label="Labels">
           {#each issue.labels as label (label.label)}
-            <Chip
-              size="sm"
-              tone="muted"
-              interactive
-              uppercase={false}
-              ariaLabel={`Remove ${label.label}`}
-              title={`Remove ${label.label}`}
-              onclick={() => {
-                void onRemoveLabel(uid(), label.label);
-              }}
-            >
-              {label.label} x
-            </Chip>
+            <li class="label-token">
+              <Chip size="sm" tone="muted" uppercase={false} class="kata-label-chip">
+                {label.label}
+              </Chip>
+              <button
+                type="button"
+                class="label-remove"
+                aria-label={`Remove label ${label.label}`}
+                title={`Remove label ${label.label}`}
+                onclick={() => {
+                  void onRemoveLabel(uid(), label.label);
+                }}
+              >
+                <XIcon size={11} strokeWidth={2.2} aria-hidden="true" />
+              </button>
+            </li>
           {/each}
-        </div>
+        </ul>
       </dd>
     </div>
   {/if}
@@ -424,10 +428,53 @@
     font-size: var(--font-size-sm);
   }
 
-  .label-row {
+  .label-list {
     display: flex;
     flex-wrap: wrap;
     gap: 6px;
+    align-items: center;
+    min-width: 0;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .label-token {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    max-width: 100%;
+    min-width: 0;
+  }
+
+  .label-token :global(.kata-label-chip) {
+    max-width: min(220px, 100%);
+  }
+
+  .label-remove {
+    width: 18px;
+    height: 18px;
+    border: 1px solid transparent;
+    border-radius: 999px;
+    background: var(--bg-inset);
+    color: var(--text-muted);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    padding: 0;
+    cursor: pointer;
+  }
+
+  .label-remove:hover {
+    border-color: var(--border-default);
+    background: var(--bg-surface-hover);
+    color: var(--text-primary);
+  }
+
+  .label-remove:focus-visible {
+    outline: 2px solid var(--accent-blue);
+    outline-offset: 2px;
   }
 
   .label-editor {

--- a/frontend/src/lib/components/kata/KataIssueProperties.svelte
+++ b/frontend/src/lib/components/kata/KataIssueProperties.svelte
@@ -46,6 +46,7 @@
   let scheduledDraft = $state("");
   let dueDraft = $state("");
   let addingLabel = $state(false);
+  let editingLabels = $state(false);
   let labelDraft = $state("");
   let trackedUID = $state<string | null>(null);
 
@@ -56,6 +57,7 @@
     scheduledDraft = "";
     dueDraft = "";
     addingLabel = false;
+    editingLabels = false;
     labelDraft = "";
   });
 
@@ -150,6 +152,14 @@
     }
     const ok = await onAddLabel(uid(), label);
     if (ok) {
+      labelDraft = "";
+      addingLabel = false;
+    }
+  }
+
+  function toggleLabelEditing(): void {
+    editingLabels = !editingLabels;
+    if (!editingLabels) {
       labelDraft = "";
       addingLabel = false;
     }
@@ -278,17 +288,19 @@
               <Chip size="sm" tone="muted" uppercase={false} class="kata-label-chip">
                 {label.label}
               </Chip>
-              <button
-                type="button"
-                class="label-remove"
-                aria-label={`Remove label ${label.label}`}
-                title={`Remove label ${label.label}`}
-                onclick={() => {
-                  void onRemoveLabel(uid(), label.label);
-                }}
-              >
-                <XIcon size={11} strokeWidth={2.2} aria-hidden="true" />
-              </button>
+              {#if editingLabels}
+                <button
+                  type="button"
+                  class="label-remove"
+                  aria-label={`Remove label ${label.label}`}
+                  title={`Remove label ${label.label}`}
+                  onclick={() => {
+                    void onRemoveLabel(uid(), label.label);
+                  }}
+                >
+                  <XIcon size={11} strokeWidth={2.2} aria-hidden="true" />
+                </button>
+              {/if}
             </li>
           {/each}
         </ul>
@@ -309,7 +321,18 @@
       }}
     />
   {:else}
-    <ActionButton size="sm" surface="outline" label="Add label" onclick={() => { addingLabel = true; }} />
+    <div class="label-actions">
+      <ActionButton size="sm" surface="outline" label="Add label" onclick={() => { addingLabel = true; }} />
+      {#if issue.labels.length > 0}
+        <ActionButton
+          size="sm"
+          surface="outline"
+          label={editingLabels ? "Done" : "Edit labels"}
+          ariaLabel={editingLabels ? "Done editing labels" : undefined}
+          onclick={toggleLabelEditing}
+        />
+      {/if}
+    </div>
   {/if}
 </section>
 
@@ -479,6 +502,12 @@
 
   .label-editor {
     margin: 0 0 22px;
+  }
+
+  .label-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
   }
 
   .label-input {

--- a/frontend/src/lib/components/kata/KataIssueProperties.svelte
+++ b/frontend/src/lib/components/kata/KataIssueProperties.svelte
@@ -284,11 +284,9 @@
       <dd>
         <ul class="label-list" aria-label="Labels">
           {#each issue.labels as label (label.label)}
-            <li class="label-token">
-              <Chip size="sm" tone="muted" uppercase={false} class="kata-label-chip">
-                {label.label}
-              </Chip>
+            <li class={["label-token", editingLabels && "label-token--editing"]}>
               {#if editingLabels}
+                <span class="label-token-name">{label.label}</span>
                 <button
                   type="button"
                   class="label-remove"
@@ -300,6 +298,10 @@
                 >
                   <XIcon size={11} strokeWidth={2.2} aria-hidden="true" />
                 </button>
+              {:else}
+                <Chip size="sm" tone="muted" uppercase={false} class="kata-label-chip">
+                  {label.label}
+                </Chip>
               {/if}
             </li>
           {/each}
@@ -465,22 +467,43 @@
   .label-token {
     display: inline-flex;
     align-items: center;
-    gap: 3px;
     max-width: 100%;
     min-width: 0;
+  }
+
+  .label-token--editing {
+    overflow: hidden;
+    border: 1px solid var(--border-default);
+    border-radius: 999px;
+    background: var(--bg-inset);
+    color: var(--text-muted);
   }
 
   .label-token :global(.kata-label-chip) {
     max-width: min(220px, 100%);
   }
 
+  .label-token-name {
+    max-width: min(220px, 100%);
+    min-height: 18px;
+    display: inline-flex;
+    align-items: center;
+    padding: 0 7px;
+    font-size: var(--font-size-2xs);
+    font-weight: 600;
+    line-height: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
   .label-remove {
-    width: 18px;
+    width: 19px;
     height: 18px;
-    border: 1px solid transparent;
-    border-radius: 999px;
-    background: var(--bg-inset);
-    color: var(--text-muted);
+    border: 0;
+    border-left: 1px solid var(--border-default);
+    background: transparent;
+    color: inherit;
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -490,8 +513,7 @@
   }
 
   .label-remove:hover {
-    border-color: var(--border-default);
-    background: var(--bg-surface-hover);
+    background: color-mix(in srgb, var(--accent-red) 10%, var(--bg-surface-hover));
     color: var(--text-primary);
   }
 

--- a/frontend/src/lib/components/kata/KataIssueProperties.test.ts
+++ b/frontend/src/lib/components/kata/KataIssueProperties.test.ts
@@ -95,8 +95,23 @@ describe("KataIssueProperties", () => {
 
     expect(onAddLabel).toHaveBeenCalledWith("issue-1", "blocked");
 
-    await fireEvent.click(screen.getByRole("button", { name: "Remove review" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Remove label review" }));
 
+    expect(onRemoveLabel).toHaveBeenCalledWith("issue-1", "review");
+  });
+
+  it("keeps label text passive and removes labels only from a dedicated button", async () => {
+    const onRemoveLabel = vi.fn();
+    renderProperties({ onRemoveLabel });
+
+    const labels = screen.getByRole("list", { name: "Labels" });
+    const labelText = within(labels).getByText("review");
+    expect(labelText.closest("button")).toBeNull();
+
+    await fireEvent.click(labelText);
+    expect(onRemoveLabel).not.toHaveBeenCalled();
+
+    await fireEvent.click(within(labels).getByRole("button", { name: "Remove label review" }));
     expect(onRemoveLabel).toHaveBeenCalledWith("issue-1", "review");
   });
 

--- a/frontend/src/lib/components/kata/KataIssueProperties.test.ts
+++ b/frontend/src/lib/components/kata/KataIssueProperties.test.ts
@@ -95,24 +95,30 @@ describe("KataIssueProperties", () => {
 
     expect(onAddLabel).toHaveBeenCalledWith("issue-1", "blocked");
 
+    await fireEvent.click(screen.getByRole("button", { name: "Edit labels" }));
     await fireEvent.click(screen.getByRole("button", { name: "Remove label review" }));
 
     expect(onRemoveLabel).toHaveBeenCalledWith("issue-1", "review");
   });
 
-  it("keeps label text passive and removes labels only from a dedicated button", async () => {
+  it("keeps labels passive until label editing is enabled", async () => {
     const onRemoveLabel = vi.fn();
     renderProperties({ onRemoveLabel });
 
     const labels = screen.getByRole("list", { name: "Labels" });
     const labelText = within(labels).getByText("review");
     expect(labelText.closest("button")).toBeNull();
+    expect(within(labels).queryByRole("button", { name: "Remove label review" })).toBeNull();
 
     await fireEvent.click(labelText);
     expect(onRemoveLabel).not.toHaveBeenCalled();
 
+    await fireEvent.click(screen.getByRole("button", { name: "Edit labels" }));
     await fireEvent.click(within(labels).getByRole("button", { name: "Remove label review" }));
     expect(onRemoveLabel).toHaveBeenCalledWith("issue-1", "review");
+
+    await fireEvent.click(screen.getByRole("button", { name: "Done editing labels" }));
+    expect(within(labels).queryByRole("button", { name: "Remove label review" })).toBeNull();
   });
 
   it("keeps the label draft visible when label creation fails", async () => {

--- a/frontend/src/lib/components/kata/KataIssueProperties.test.ts
+++ b/frontend/src/lib/components/kata/KataIssueProperties.test.ts
@@ -114,7 +114,9 @@ describe("KataIssueProperties", () => {
     expect(onRemoveLabel).not.toHaveBeenCalled();
 
     await fireEvent.click(screen.getByRole("button", { name: "Edit labels" }));
-    await fireEvent.click(within(labels).getByRole("button", { name: "Remove label review" }));
+    const removeButton = within(labels).getByRole("button", { name: "Remove label review" });
+    expect(removeButton.closest(".label-token--editing")).not.toBeNull();
+    await fireEvent.click(removeButton);
     expect(onRemoveLabel).toHaveBeenCalledWith("issue-1", "review");
 
     await fireEvent.click(screen.getByRole("button", { name: "Done editing labels" }));

--- a/frontend/tests/e2e-full/kata.spec.ts
+++ b/frontend/tests/e2e-full/kata.spec.ts
@@ -4248,7 +4248,7 @@ test("kata detail comments and labels mutate through the configured external dae
 
     const detail = page.getByRole("region", { name: "Task detail" });
     await expect(detail).toContainText("Verify amount against the lease.");
-    await expect(detail.getByRole("button", { name: "Remove label home" })).toBeVisible();
+    await expect(detail.getByRole("button", { name: "Remove label home" })).toHaveCount(0);
 
     const composer = detail.getByRole("textbox", { name: "Comment" });
     await composer.fill("see #");
@@ -4272,9 +4272,10 @@ test("kata detail comments and labels mutate through the configured external dae
     await detail.getByRole("button", { name: "Add label" }).click();
     await detail.getByLabel("New label").fill("urgent");
     await detail.getByLabel("New label").press("Enter");
-    await expect(detail.getByRole("button", { name: "Remove label urgent" })).toBeVisible();
     await expect.poll(() => backend.state.seenPaths).toContain("POST /api/v1/projects/1/issues/issue-rent/labels");
 
+    await detail.getByRole("button", { name: "Edit labels" }).click();
+    await expect(detail.getByRole("button", { name: "Remove label urgent" })).toBeVisible();
     await detail.getByRole("button", { name: "Remove label home" }).click();
     await expect(detail.getByRole("button", { name: "Remove label home" })).toHaveCount(0);
     await expect

--- a/frontend/tests/e2e-full/kata.spec.ts
+++ b/frontend/tests/e2e-full/kata.spec.ts
@@ -4248,7 +4248,7 @@ test("kata detail comments and labels mutate through the configured external dae
 
     const detail = page.getByRole("region", { name: "Task detail" });
     await expect(detail).toContainText("Verify amount against the lease.");
-    await expect(detail.getByRole("button", { name: "Remove home" })).toBeVisible();
+    await expect(detail.getByRole("button", { name: "Remove label home" })).toBeVisible();
 
     const composer = detail.getByRole("textbox", { name: "Comment" });
     await composer.fill("see #");
@@ -4272,11 +4272,11 @@ test("kata detail comments and labels mutate through the configured external dae
     await detail.getByRole("button", { name: "Add label" }).click();
     await detail.getByLabel("New label").fill("urgent");
     await detail.getByLabel("New label").press("Enter");
-    await expect(detail.getByRole("button", { name: "Remove urgent" })).toBeVisible();
+    await expect(detail.getByRole("button", { name: "Remove label urgent" })).toBeVisible();
     await expect.poll(() => backend.state.seenPaths).toContain("POST /api/v1/projects/1/issues/issue-rent/labels");
 
-    await detail.getByRole("button", { name: "Remove home" }).click();
-    await expect(detail.getByRole("button", { name: "Remove home" })).toHaveCount(0);
+    await detail.getByRole("button", { name: "Remove label home" }).click();
+    await expect(detail.getByRole("button", { name: "Remove label home" })).toHaveCount(0);
     await expect
       .poll(() => backend.state.seenPaths)
       .toContain("DELETE /api/v1/projects/1/issues/issue-rent/labels/home?actor=middleman");


### PR DESCRIPTION
Fixes the Kata task detail label affordance so labels stay passive during normal scanning.

- Keeps label text as passive metadata.
- Shows remove controls only after `Edit labels`.
- Renders edit-mode labels as a segmented pill with the X attached to the label token.
- Preserves adding labels as a separate action.

Passive labels:
![kata-labels-passive.png](https://github.com/user-attachments/assets/e153fdcd-2a1a-4c7c-a93d-ee59e37eec02)

Editing labels:
![kata-labels-editing.png](https://github.com/user-attachments/assets/50b6af81-c43c-43d5-bcd6-400f89084a2d)

<sup>generated by a clanker</sup>