### PR TITLE
Add Kata task tree bulk controls

### DIFF
--- a/docs/superpowers/specs/2026-06-08-kata-docs-msgvault-modes-design.md
+++ b/docs/superpowers/specs/2026-06-08-kata-docs-msgvault-modes-design.md
@@ -310,9 +310,13 @@ Header/navigation changes:
 Kata frontend adaptation:
 
 - Keep the existing task workspace behavior and daemon switcher semantics.
-- Treat task lists as trees: rows with a known parent stay out of the
-  top-level projection until their ancestor chain is expanded, and recursive row
-  rendering must support nested subtasks beyond one level
+- Treat task lists as trees: a row stays out of the top-level projection only
+  when its parent is present in the same result set (so it can fold under that
+  ancestor once expanded). A child whose parent is absent — e.g. a search or
+  filter that matches the child but not the parent — must still render and be
+  selectable as its own top-level row instead of being dropped; otherwise the
+  header counts it while the list shows "No tasks". Recursive row rendering must
+  support nested subtasks beyond one level
   (`frontend/src/lib/components/kata/KataIssueList.svelte::topLevelIssues`,
   `frontend/src/lib/components/kata/KataIssueList.svelte::row`,
   `frontend/src/lib/stores/kata-workspace.svelte.ts::selectableViewIssues`).

--- a/docs/superpowers/specs/2026-06-08-kata-docs-msgvault-modes-design.md
+++ b/docs/superpowers/specs/2026-06-08-kata-docs-msgvault-modes-design.md
@@ -310,6 +310,12 @@ Header/navigation changes:
 Kata frontend adaptation:
 
 - Keep the existing task workspace behavior and daemon switcher semantics.
+- Treat task lists as trees: rows with a known parent stay out of the
+  top-level projection until their ancestor chain is expanded, and recursive row
+  rendering must support nested subtasks beyond one level
+  (`frontend/src/lib/components/kata/KataIssueList.svelte::topLevelIssues`,
+  `frontend/src/lib/components/kata/KataIssueList.svelte::row`,
+  `frontend/src/lib/stores/kata-workspace.svelte.ts::selectableViewIssues`).
 - Replace direct daemon URL/localStorage bootstrap with calls to middleman's
   Kata daemon roster and proxy.
 - Use a middleman-owned selector header for proxied daemon requests.

--- a/docs/superpowers/specs/2026-06-08-kata-docs-msgvault-modes-design.md
+++ b/docs/superpowers/specs/2026-06-08-kata-docs-msgvault-modes-design.md
@@ -316,6 +316,9 @@ Kata frontend adaptation:
   (`frontend/src/lib/components/kata/KataIssueList.svelte::topLevelIssues`,
   `frontend/src/lib/components/kata/KataIssueList.svelte::row`,
   `frontend/src/lib/stores/kata-workspace.svelte.ts::selectableViewIssues`).
+- Task-list header controls should expand every visible task tree recursively
+  through the task-detail API, and collapse should hide cached descendants
+  without reintroducing them as top-level flat rows.
 - Replace direct daemon URL/localStorage bootstrap with calls to middleman's
   Kata daemon roster and proxy.
 - Use a middleman-owned selector header for proxied daemon requests.

--- a/frontend/src/lib/components/kata/KataIssueList.svelte
+++ b/frontend/src/lib/components/kata/KataIssueList.svelte
@@ -85,8 +85,9 @@
         }
       }
     }
+    const allIssues = groups.flatMap((group) => group.issues);
     return groups
-      .map((group) => ({ ...group, issues: topLevelIssues(group.issues) }))
+      .map((group) => ({ ...group, issues: topLevelIssues(group.issues, allIssues) }))
       .filter((group) => group.issues.length > 0);
   });
 
@@ -204,8 +205,19 @@
       .filter((group) => group.issues.length > 0);
   }
 
-  function topLevelIssues(issues: readonly KataTaskSummary[]): KataTaskSummary[] {
-    return issues.filter((issue) => parentHierarchyKey(issue) === null);
+  function topLevelIssues(
+    issues: readonly KataTaskSummary[],
+    allIssues: readonly KataTaskSummary[] = issues,
+  ): KataTaskSummary[] {
+    // A child collapses into its parent only when that parent is actually
+    // present in the visible set. Search and filter results often surface a
+    // matching child without its parent; those rows must still render as
+    // their own top-level row instead of vanishing into a missing ancestor.
+    const visibleKeys = new Set(allIssues.map(issueHierarchyKey));
+    return issues.filter((issue) => {
+      const parentKey = parentHierarchyKey(issue);
+      return parentKey === null || !visibleKeys.has(parentKey);
+    });
   }
 
   function collectKnownExpandableIssues(issues: readonly KataTaskSummary[]): KataTaskSummary[] {

--- a/frontend/src/lib/components/kata/KataIssueList.svelte
+++ b/frontend/src/lib/components/kata/KataIssueList.svelte
@@ -3,6 +3,8 @@
   import ChevronDownIcon from "@lucide/svelte/icons/chevron-down";
   import ChevronRightIcon from "@lucide/svelte/icons/chevron-right";
   import ChevronUpIcon from "@lucide/svelte/icons/chevron-up";
+  import ListChevronsDownUpIcon from "@lucide/svelte/icons/list-chevrons-down-up";
+  import ListChevronsUpDownIcon from "@lucide/svelte/icons/list-chevrons-up-down";
   import { relativeTime, shortDate } from "../../api/dates.js";
   import type { KataTaskAPI, KataTaskSearchFilters, KataTaskSummary } from "../../api/kata/taskTypes.js";
   import type { KataCurrentView } from "../../stores/kata-workspace.svelte.js";
@@ -46,6 +48,7 @@
   let expanded: Record<string, boolean> = $state({});
   let childrenByUID: Record<string, KataTaskSummary[]> = $state({});
   let loadingChildren: Record<string, boolean> = $state({});
+  let bulkExpanding = $state(false);
   let tableBody: HTMLDivElement | null = $state(null);
   let childLoadGeneration = 0;
   let lastResetGeneration = $state<number | null>(null);
@@ -93,6 +96,17 @@
   // so keep its labeled region instead of dropping it to a bare list.
   let shouldFlatten = $derived(!isProjectScoped && sort.key === "updated" && visibleGroups.length > 1);
   let globalSortedIssues = $derived(shouldFlatten ? sortKataTasks(visibleGroups.flatMap((group) => group.issues), sort) : []);
+  let visibleRootIssues = $derived.by(() => {
+    if (isProjectScoped) return sortKataTasks(flatIssues, sort);
+    if (shouldFlatten) return globalSortedIssues;
+    return visibleGroups.flatMap((group) => sortKataTasks(group.issues, sort));
+  });
+  let knownExpandableIssues = $derived.by(() => collectKnownExpandableIssues(visibleRootIssues));
+  let hasExpandableVisibleRows = $derived(knownExpandableIssues.length > 0);
+  let allKnownExpandableRowsExpanded = $derived(
+    hasExpandableVisibleRows && knownExpandableIssues.every((issue) => expanded[issue.uid] === true),
+  );
+  let hasAnyExpandedRows = $derived(Object.values(expanded).some(Boolean));
 
   function loadSort(): KataTaskSort {
     if (typeof window === "undefined") return DEFAULT_KATA_TASK_SORT;
@@ -136,10 +150,8 @@
     return view.groups.reduce((sum, group) => sum + group.issues.length, 0);
   }
 
-  function totalVisibleIssues(): number {
-    if (isProjectScoped) return flatIssues.length;
-    if (shouldFlatten) return globalSortedIssues.length;
-    return visibleGroups.reduce((sum, group) => sum + group.issues.length, 0);
+  function totalFilteredIssues(): number {
+    return statusVisibleGroups.reduce((sum, group) => sum + group.issues.length, 0);
   }
 
   function isSelected(issue: KataTaskSummary): boolean {
@@ -194,6 +206,84 @@
 
   function topLevelIssues(issues: readonly KataTaskSummary[]): KataTaskSummary[] {
     return issues.filter((issue) => parentHierarchyKey(issue) === null);
+  }
+
+  function collectKnownExpandableIssues(issues: readonly KataTaskSummary[]): KataTaskSummary[] {
+    const expandable: KataTaskSummary[] = [];
+    const seen = new Set<string>();
+
+    const visit = (issue: KataTaskSummary) => {
+      if (seen.has(issue.uid)) return;
+      seen.add(issue.uid);
+      if (hasChildren(issue)) expandable.push(issue);
+      if (expanded[issue.uid] !== true) return;
+      for (const child of visibleChildren(issue)) visit(child);
+    };
+
+    for (const issue of issues) visit(issue);
+    return expandable;
+  }
+
+  async function loadChildren(issue: KataTaskSummary, generation: number): Promise<KataTaskSummary[]> {
+    if (!hasChildren(issue)) return [];
+    if (childrenByUID[issue.uid]) return visibleChildren(issue);
+    if (!api) return [];
+
+    loadingChildren = { ...loadingChildren, [issue.uid]: true };
+    try {
+      const detail = await api.issue(issue.uid);
+      if (generation !== childLoadGeneration || !findIssueByUID(issue.uid)) return [];
+      const children = detail.children ?? [];
+      childrenByUID = { ...childrenByUID, [issue.uid]: children };
+      return children.filter(issueMatchesStatusFilter);
+    } finally {
+      if (generation === childLoadGeneration) {
+        loadingChildren = { ...loadingChildren, [issue.uid]: false };
+      }
+    }
+  }
+
+  async function expandIssueTree(
+    issue: KataTaskSummary,
+    generation: number,
+    nextExpanded: Record<string, boolean>,
+    seen: Set<string>,
+  ) {
+    if (!hasChildren(issue) || seen.has(issue.uid)) return;
+    seen.add(issue.uid);
+    nextExpanded[issue.uid] = true;
+    expanded = { ...expanded, ...nextExpanded };
+
+    const children = await loadChildren(issue, generation);
+    if (generation !== childLoadGeneration) return;
+    for (const child of children) {
+      await expandIssueTree(child, generation, nextExpanded, seen);
+    }
+  }
+
+  async function expandAllVisible() {
+    if (bulkExpanding || allKnownExpandableRowsExpanded) return;
+    const generation = childLoadGeneration;
+    bulkExpanding = true;
+    const nextExpanded = { ...expanded };
+    const seen = new Set<string>();
+    try {
+      for (const issue of visibleRootIssues) {
+        if (generation !== childLoadGeneration) return;
+        await expandIssueTree(issue, generation, nextExpanded, seen);
+      }
+    } finally {
+      if (generation === childLoadGeneration) bulkExpanding = false;
+    }
+  }
+
+  function collapseAllVisible() {
+    if (!hasAnyExpandedRows && !bulkExpanding) return;
+    childLoadGeneration += 1;
+    expanded = {};
+    loadingChildren = {};
+    bulkExpanding = false;
+    cancelPendingKeyboardSelect();
   }
 
   async function toggleExpand(issue: KataTaskSummary, event: MouseEvent | KeyboardEvent) {
@@ -397,6 +487,7 @@
     expanded = {};
     childrenByUID = {};
     loadingChildren = {};
+    bulkExpanding = false;
   });
 
   // A pending keyboard selection dies the moment the workspace starts
@@ -417,9 +508,34 @@
 
 <main class="issue-list" aria-label="Issues">
   <div class="pane-header">
-    <div class="heading">
-      <h2>{viewTitle(currentView)}</h2>
-      <span class="count">{totalVisibleIssues()} {totalVisibleIssues() === 1 ? "task" : "tasks"}</span>
+    <div class="heading-row">
+      <div class="heading">
+        <h2>{viewTitle(currentView)}</h2>
+        <span class="count">{totalFilteredIssues()} {totalFilteredIssues() === 1 ? "task" : "tasks"}</span>
+      </div>
+      {#if hasExpandableVisibleRows || hasAnyExpandedRows || bulkExpanding}
+        <div class="tree-actions" aria-label="Task tree controls">
+          <button
+            class="tree-action"
+            type="button"
+            disabled={bulkExpanding || allKnownExpandableRowsExpanded}
+            aria-busy={bulkExpanding ? "true" : undefined}
+            onclick={() => void expandAllVisible()}
+          >
+            <ListChevronsUpDownIcon size={13} strokeWidth={2} />
+            <span>{bulkExpanding ? "Expanding" : "Expand all"}</span>
+          </button>
+          <button
+            class="tree-action"
+            type="button"
+            disabled={!hasAnyExpandedRows}
+            onclick={collapseAllVisible}
+          >
+            <ListChevronsDownUpIcon size={13} strokeWidth={2} />
+            <span>Collapse all</span>
+          </button>
+        </div>
+      {/if}
     </div>
     {#if loading}
       <span class="sr-only" aria-live="polite">Loading snapshot</span>
@@ -510,7 +626,7 @@
         <span class="col col-tags col-static">Tags</span>
       </div>
 
-      {#if totalVisibleIssues() === 0}
+      {#if visibleRootIssues.length === 0}
         <div class="empty">No tasks</div>
       {/if}
 
@@ -629,7 +745,6 @@
     position: relative;
     flex-shrink: 0;
     padding: 10px 16px 8px;
-    padding-right: 96px;
     background: var(--bg-surface);
     border-bottom: 1px solid var(--border-default);
     display: flex;
@@ -637,10 +752,19 @@
     gap: 2px;
   }
 
+  .heading-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    min-width: 0;
+  }
+
   .heading {
     display: flex;
     align-items: baseline;
     gap: 10px;
+    min-width: 0;
   }
 
   .pane-header h2 {
@@ -654,6 +778,41 @@
     color: var(--text-muted);
     font-size: var(--font-size-xs);
     font-variant-numeric: tabular-nums;
+  }
+
+  .tree-actions {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-shrink: 0;
+  }
+
+  .tree-action {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 5px;
+    min-height: 26px;
+    padding: 0 8px;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    background: var(--bg-elevated);
+    color: var(--text-secondary);
+    font-size: var(--font-size-xs);
+    font-weight: 500;
+    white-space: nowrap;
+    cursor: pointer;
+  }
+
+  .tree-action:hover:not(:disabled),
+  .tree-action:focus-visible {
+    border-color: var(--border-strong);
+    color: var(--text-primary);
+  }
+
+  .tree-action:disabled {
+    cursor: default;
+    opacity: 0.45;
   }
 
   .sr-only {

--- a/frontend/src/lib/components/kata/KataIssueList.svelte
+++ b/frontend/src/lib/components/kata/KataIssueList.svelte
@@ -82,9 +82,8 @@
         }
       }
     }
-    const allIssues = groups.flatMap((group) => group.issues);
     return groups
-      .map((group) => ({ ...group, issues: topLevelIssues(group.issues, allIssues) }))
+      .map((group) => ({ ...group, issues: topLevelIssues(group.issues) }))
       .filter((group) => group.issues.length > 0);
   });
 
@@ -168,7 +167,13 @@
   }
 
   function parentHierarchyKey(issue: KataTaskSummary): string | null {
-    return issue.parent_short_id ? `${issue.project_uid}:${issue.parent_short_id}` : null;
+    if (issue.parent_short_id) return `${issue.project_uid}:${issue.parent_short_id}`;
+    for (const [parentUID, children] of Object.entries(childrenByUID)) {
+      if (!children.some((child) => child.uid === issue.uid)) continue;
+      const parent = findIssueByUID(parentUID);
+      if (parent) return issueHierarchyKey(parent);
+    }
+    return null;
   }
 
   function issueMatchesStatusFilter(issue: KataTaskSummary): boolean {
@@ -187,15 +192,8 @@
       .filter((group) => group.issues.length > 0);
   }
 
-  function topLevelIssues(
-    issues: readonly KataTaskSummary[],
-    allIssues: readonly KataTaskSummary[] = issues,
-  ): KataTaskSummary[] {
-    const visibleKeys = new Set(allIssues.map(issueHierarchyKey));
-    return issues.filter((issue) => {
-      const parentKey = parentHierarchyKey(issue);
-      return parentKey === null || !visibleKeys.has(parentKey);
-    });
+  function topLevelIssues(issues: readonly KataTaskSummary[]): KataTaskSummary[] {
+    return issues.filter((issue) => parentHierarchyKey(issue) === null);
   }
 
   async function toggleExpand(issue: KataTaskSummary, event: MouseEvent | KeyboardEvent) {
@@ -541,17 +539,19 @@
   </div>
 </main>
 
-{#snippet row(issue: KataTaskSummary)}
+{#snippet row(issue: KataTaskSummary, depth = 0)}
   {@const priority = priorityLabel(issue.priority)}
   {@const labels = issue.labels?.join(" · ") ?? ""}
   {@const expandable = hasChildren(issue)}
   {@const isExpanded = expanded[issue.uid] === true}
   <button
     class="row issue-row"
+    class:row--child={depth > 0}
     class:selected={isSelected(issue)}
     aria-current={isSelected(issue) ? "true" : undefined}
     aria-expanded={expandable ? isExpanded : undefined}
     data-uid={issue.uid}
+    style:--task-depth={String(depth)}
     onclick={() => selectNow(issue)}
   >
     <span class="cell cell-id"><span class="id-badge">{displayId(issue)}</span></span>
@@ -599,47 +599,12 @@
 
   {#if isExpanded}
     {#if loadingChildren[issue.uid]}
-      <div class="children-status">Loading subtasks…</div>
+      <div class="children-status" style:--task-depth={String(depth + 1)}>Loading subtasks…</div>
     {:else if visibleChildren(issue).length === 0}
-      <div class="children-status">No subtasks.</div>
+      <div class="children-status" style:--task-depth={String(depth + 1)}>No subtasks.</div>
     {:else}
       {#each visibleChildren(issue) as child (child.uid)}
-        {@const childPriority = priorityLabel(child.priority)}
-        {@const childLabels = child.labels?.join(" · ") ?? ""}
-        <button
-          class="row issue-row row--child"
-          class:selected={isSelected(child)}
-          aria-current={isSelected(child) ? "true" : undefined}
-          data-uid={child.uid}
-          onclick={() => selectNow(child)}
-        >
-          <span class="cell cell-id"><span class="id-badge">{displayId(child)}</span></span>
-          <span class="cell cell-title">
-            <span class="chevron chevron--placeholder" aria-hidden="true"></span>
-            <span class="title-text">{child.title}</span>
-          </span>
-          <span class="cell cell-updated" title={child.updated_at}>
-            {relativeTime(child.updated_at)}
-          </span>
-          <span class="cell cell-priority">
-            {#if childPriority}
-              <span class={`pri-pill priority-${child.priority}`}>{childPriority}</span>
-            {/if}
-          </span>
-          <span class="cell cell-due" title={child.metadata.deadline_on ?? ""}>
-            {#if child.metadata.deadline_on}{shortDate(child.metadata.deadline_on)}{/if}
-          </span>
-          <span class="cell cell-owner">{child.owner ?? ""}</span>
-          <span class="cell cell-tags" title={childLabels}>
-            {#if childLabels}{childLabels}{/if}
-          </span>
-          <span class="sr-keywords">
-            <span>project: {child.project_name}</span>
-            {#if child.metadata.deadline_on}<span> · Due {shortDate(child.metadata.deadline_on)}</span>{/if}
-            {#if child.owner}<span> · owner: {child.owner}</span>{/if}
-            {#if child.priority !== undefined}<span> · priority: {child.priority}</span>{/if}
-          </span>
-        </button>
+        {@render row(child, depth + 1)}
       {/each}
     {/if}
   {/if}
@@ -1026,11 +991,11 @@
   }
 
   .row--child .cell-title {
-    padding-left: 18px;
+    padding-left: calc(var(--task-depth, 1) * 18px);
   }
 
   .children-status {
-    padding: 4px 14px 4px 32px;
+    padding: 4px 14px 4px calc(14px + (var(--task-depth, 1) * 18px));
     color: var(--text-muted);
     font-size: var(--font-size-2xs);
     font-style: italic;

--- a/frontend/src/lib/components/kata/KataIssueList.test.ts
+++ b/frontend/src/lib/components/kata/KataIssueList.test.ts
@@ -300,6 +300,34 @@ describe("KataIssueList", () => {
     expect(screen.getByRole("button", { name: /Child task/ }).classList.contains("row--child")).toBe(true);
   });
 
+  it("renders a matched child as a top-level row when its parent is absent", async () => {
+    // A search or filter can surface a child whose parent is not in the
+    // result set. The child has a parent_short_id, but with no visible
+    // ancestor to fold into it must still render as its own row instead of
+    // being dropped — otherwise the header counts it while the list shows
+    // "No tasks".
+    const child = task({
+      uid: "issue-child",
+      short_id: "child",
+      qualified_id: "Finances#child",
+      title: "Child task",
+      parent_short_id: "parent",
+    });
+
+    render(KataIssueList, {
+      props: {
+        currentView: viewWithIssues([child]),
+        selectedIssueUID: null,
+        loading: false,
+        onSelect: () => {},
+      },
+    });
+
+    expect(screen.getByRole("button", { name: /Child task/ })).toBeTruthy();
+    expect(screen.queryByText("No tasks")).toBeNull();
+    expect(screen.getByText("1 task")).toBeTruthy();
+  });
+
   it("expands nested child rows beyond one level", async () => {
     const parent = task({
       uid: "issue-parent",

--- a/frontend/src/lib/components/kata/KataIssueList.test.ts
+++ b/frontend/src/lib/components/kata/KataIssueList.test.ts
@@ -237,6 +237,7 @@ describe("KataIssueList", () => {
 
     expect(screen.getByText("Parent task")).toBeTruthy();
     expect(screen.queryByText("Child task")).toBeNull();
+    expect(screen.getByText("2 tasks")).toBeTruthy();
 
     const parentRow = screen.getByRole("button", { name: /Parent task/ });
     await fireEvent.keyDown(parentRow, { key: "ArrowRight" });
@@ -244,6 +245,7 @@ describe("KataIssueList", () => {
     const childRow = await screen.findByRole("button", { name: /Child task/ });
     expect(childRow).toBeTruthy();
     expect(parentRow.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByText("2 tasks")).toBeTruthy();
 
     parentRow.focus();
     await fireEvent.keyDown(parentRow, { key: "j" });
@@ -350,6 +352,73 @@ describe("KataIssueList", () => {
     expect(grandchildRow.classList.contains("row--child")).toBe(true);
     expect(api.issue).toHaveBeenCalledWith(parent.uid);
     expect(api.issue).toHaveBeenCalledWith(child.uid);
+  });
+
+  it("expands and collapses every visible task tree from the header controls", async () => {
+    const parent = task({
+      uid: "issue-parent",
+      short_id: "parent",
+      qualified_id: "Finances#parent",
+      title: "Parent task",
+      child_counts: { open: 1, total: 1 },
+    });
+    const child = task({
+      uid: "issue-child",
+      short_id: "child",
+      qualified_id: "Finances#child",
+      title: "Child task",
+      child_counts: { open: 1, total: 1 },
+      parent_short_id: parent.short_id,
+    });
+    const grandchild = task({
+      uid: "issue-grandchild",
+      short_id: "grandchild",
+      qualified_id: "Finances#grandchild",
+      title: "Grandchild task",
+      parent_short_id: child.short_id,
+    });
+    const api = {
+      issue: vi.fn(async (uid: string) => {
+        if (uid === parent.uid) return apiDetail(parent, [child]);
+        return apiDetail(child, [grandchild]);
+      }),
+    } as unknown as KataTaskAPI;
+
+    render(KataIssueList, {
+      props: {
+        currentView: viewWithIssues([parent]),
+        selectedIssueUID: null,
+        loading: false,
+        api,
+        onSelect: () => {},
+      },
+    });
+
+    const expandAll = screen.getByRole("button", { name: "Expand all" });
+    const collapseAll = screen.getByRole("button", { name: "Collapse all" });
+    expect(collapseAll.hasAttribute("disabled")).toBe(true);
+
+    await fireEvent.click(expandAll);
+
+    const parentRow = screen.getByRole("button", { name: /Parent task/ });
+    const childRow = await screen.findByRole("button", { name: /Child task/ });
+    const grandchildRow = await screen.findByRole("button", { name: /Grandchild task/ });
+    expect(parentRow.getAttribute("aria-expanded")).toBe("true");
+    expect(childRow.getAttribute("aria-expanded")).toBe("true");
+    expect(grandchildRow.classList.contains("row--child")).toBe(true);
+    expect(api.issue).toHaveBeenCalledWith(parent.uid);
+    expect(api.issue).toHaveBeenCalledWith(child.uid);
+    expect(expandAll.hasAttribute("disabled")).toBe(true);
+    expect(collapseAll.hasAttribute("disabled")).toBe(false);
+
+    await fireEvent.click(collapseAll);
+
+    await waitFor(() => {
+      expect(parentRow.getAttribute("aria-expanded")).toBe("false");
+    });
+    expect(screen.queryByRole("button", { name: /Child task/ })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Grandchild task/ })).toBeNull();
+    expect(collapseAll.hasAttribute("disabled")).toBe(true);
   });
 
   it("j and k move focus and selection through rows", async () => {

--- a/frontend/src/lib/components/kata/KataIssueList.test.ts
+++ b/frontend/src/lib/components/kata/KataIssueList.test.ts
@@ -260,6 +260,98 @@ describe("KataIssueList", () => {
     expect(screen.queryByRole("button", { name: /Child task/ })).toBeNull();
   });
 
+  it("does not show an expanded child again as a flat row", async () => {
+    const parent = task({
+      uid: "issue-parent",
+      short_id: "parent",
+      qualified_id: "Finances#parent",
+      title: "Parent task",
+      child_counts: { open: 1, total: 1 },
+    });
+    const child = task({
+      uid: "issue-child",
+      short_id: "child",
+      qualified_id: "Finances#child",
+      title: "Child task",
+      parent_short_id: parent.short_id,
+    });
+    const api = apiWithDetail(parent, [child]);
+
+    render(KataIssueList, {
+      props: {
+        currentView: viewWithIssues([parent, child]),
+        selectedIssueUID: null,
+        loading: false,
+        api,
+        onSelect: () => {},
+      },
+    });
+
+    expect(screen.queryByRole("button", { name: /Child task/ })).toBeNull();
+
+    const parentRow = screen.getByRole("button", { name: /Parent task/ });
+    await fireEvent.keyDown(parentRow, { key: "ArrowRight" });
+
+    await waitFor(() => {
+      expect(screen.getAllByRole("button", { name: /Child task/ })).toHaveLength(1);
+    });
+    expect(screen.getByRole("button", { name: /Child task/ }).classList.contains("row--child")).toBe(true);
+  });
+
+  it("expands nested child rows beyond one level", async () => {
+    const parent = task({
+      uid: "issue-parent",
+      short_id: "parent",
+      qualified_id: "Finances#parent",
+      title: "Parent task",
+      child_counts: { open: 1, total: 1 },
+    });
+    const child = task({
+      uid: "issue-child",
+      short_id: "child",
+      qualified_id: "Finances#child",
+      title: "Child task",
+      child_counts: { open: 1, total: 1 },
+      parent_short_id: parent.short_id,
+    });
+    const grandchild = task({
+      uid: "issue-grandchild",
+      short_id: "grandchild",
+      qualified_id: "Finances#grandchild",
+      title: "Grandchild task",
+      parent_short_id: child.short_id,
+    });
+    const api = {
+      issue: vi.fn(async (uid: string) => {
+        if (uid === parent.uid) return apiDetail(parent, [child]);
+        return apiDetail(child, [grandchild]);
+      }),
+    } as unknown as KataTaskAPI;
+
+    render(KataIssueList, {
+      props: {
+        currentView: viewWithIssues([parent]),
+        selectedIssueUID: null,
+        loading: false,
+        api,
+        onSelect: () => {},
+      },
+    });
+
+    const parentRow = screen.getByRole("button", { name: /Parent task/ });
+    await fireEvent.keyDown(parentRow, { key: "ArrowRight" });
+
+    const childRow = await screen.findByRole("button", { name: /Child task/ });
+    expect(childRow.getAttribute("aria-expanded")).toBe("false");
+
+    await fireEvent.keyDown(childRow, { key: "ArrowRight" });
+
+    const grandchildRow = await screen.findByRole("button", { name: /Grandchild task/ });
+    expect(grandchildRow.classList.contains("row--child")).toBe(true);
+    expect(api.issue).toHaveBeenCalledWith(parent.uid);
+    expect(api.issue).toHaveBeenCalledWith(child.uid);
+  });
+
   it("j and k move focus and selection through rows", async () => {
     const selected: string[] = [];
     render(KataIssueList, {

--- a/frontend/src/lib/dev/viteConfig.test.ts
+++ b/frontend/src/lib/dev/viteConfig.test.ts
@@ -30,6 +30,8 @@ describe("vite config", () => {
     const includes = config.optimizeDeps?.include ?? [];
 
     expect(includes).toContain("@middleman/ui > shiki");
+    expect(includes).toContain("@lucide/svelte/icons/list-chevrons-down-up");
+    expect(includes).toContain("@lucide/svelte/icons/list-chevrons-up-down");
   });
 
   it("pins the dev server host to IPv4 loopback", () => {

--- a/frontend/src/lib/stores/kata-workspace.svelte.test.ts
+++ b/frontend/src/lib/stores/kata-workspace.svelte.test.ts
@@ -900,7 +900,7 @@ describe("kata workspace store", () => {
     expect(store.selectedIssue?.issue.uid).toBe("issue-parent");
   });
 
-  test("search-backed views do not select child-only rows as visible", async () => {
+  test("search-backed views select a child whose parent is absent from the results", async () => {
     const child = {
       ...issue("issue-child", "Child task", "project-kata"),
       short_id: "child",
@@ -913,13 +913,19 @@ describe("kata workspace store", () => {
       issues: [child],
       fetched_at: fetchedAt,
     });
+    api.mocks.issue.mockImplementation(async (uid: string) => ({
+      ...detailFor(uid),
+      issue: { ...child, body: `${uid} body` },
+    }));
     const store = createKataWorkspaceStore({ api });
     await store.bootstrap();
 
     await store.updateSearchFilters({ query: "child" });
 
+    // The parent is not in the result set, so the child cannot fold into a
+    // missing ancestor: it stays a top-level row and is selected like one.
     expect(store.currentView.groups.flatMap((group) => group.issues).map((item) => item.uid)).toEqual(["issue-child"]);
-    expect(store.selectedIssue).toBeNull();
+    expect(store.selectedIssue?.issue.uid).toBe("issue-child");
   });
 
   test("system view navigation keeps the selected project scope", async () => {

--- a/frontend/src/lib/stores/kata-workspace.svelte.test.ts
+++ b/frontend/src/lib/stores/kata-workspace.svelte.test.ts
@@ -900,6 +900,28 @@ describe("kata workspace store", () => {
     expect(store.selectedIssue?.issue.uid).toBe("issue-parent");
   });
 
+  test("search-backed views do not select child-only rows as visible", async () => {
+    const child = {
+      ...issue("issue-child", "Child task", "project-kata"),
+      short_id: "child",
+      qualified_id: "Kata#child",
+      parent_short_id: "parent",
+    };
+    const api = createFakeKataTaskAPI();
+    api.mocks.search.mockResolvedValueOnce({
+      filters: { scope: { kind: "all" }, status: "open", owner: "", label: "", query: "child" },
+      issues: [child],
+      fetched_at: fetchedAt,
+    });
+    const store = createKataWorkspaceStore({ api });
+    await store.bootstrap();
+
+    await store.updateSearchFilters({ query: "child" });
+
+    expect(store.currentView.groups.flatMap((group) => group.issues).map((item) => item.uid)).toEqual(["issue-child"]);
+    expect(store.selectedIssue).toBeNull();
+  });
+
   test("system view navigation keeps the selected project scope", async () => {
     const store = createKataWorkspaceStore({ api: createFakeKataTaskAPI() });
     await store.bootstrap();

--- a/frontend/src/lib/stores/kata-workspace.svelte.ts
+++ b/frontend/src/lib/stores/kata-workspace.svelte.ts
@@ -73,16 +73,28 @@ function groupSearchIssues(issues: KataTaskSummary[]): KataTaskViewResponse["gro
   return issues.length > 0 ? [{ id: "search-results", title: "Results", issues }] : [];
 }
 
+function issueHierarchyKey(issue: KataTaskSummary): string {
+  return `${issue.project_uid}:${issue.short_id}`;
+}
+
 function parentHierarchyKey(issue: KataTaskSummary): string | null {
   return issue.parent_short_id ? `${issue.project_uid}:${issue.parent_short_id}` : null;
 }
 
-function topLevelIssues(issues: readonly KataTaskSummary[]): KataTaskSummary[] {
-  return issues.filter((issue) => parentHierarchyKey(issue) === null);
+function topLevelIssues(issues: readonly KataTaskSummary[], allIssues: readonly KataTaskSummary[]): KataTaskSummary[] {
+  // Mirror the list view: a child is only folded into its parent when that
+  // parent is present in the same result set. A search that returns a child
+  // without its parent keeps the child as a selectable top-level row.
+  const visibleKeys = new Set(allIssues.map(issueHierarchyKey));
+  return issues.filter((issue) => {
+    const parentKey = parentHierarchyKey(issue);
+    return parentKey === null || !visibleKeys.has(parentKey);
+  });
 }
 
 function selectableViewIssues(groups: KataTaskViewResponse["groups"]): KataTaskSummary[] {
-  return groups.flatMap((group) => topLevelIssues(group.issues));
+  const allIssues = groups.flatMap((group) => group.issues);
+  return groups.flatMap((group) => topLevelIssues(group.issues, allIssues));
 }
 
 function projectArea(project: KataProjectSummary): string {

--- a/frontend/src/lib/stores/kata-workspace.svelte.ts
+++ b/frontend/src/lib/stores/kata-workspace.svelte.ts
@@ -73,25 +73,16 @@ function groupSearchIssues(issues: KataTaskSummary[]): KataTaskViewResponse["gro
   return issues.length > 0 ? [{ id: "search-results", title: "Results", issues }] : [];
 }
 
-function issueHierarchyKey(issue: KataTaskSummary): string {
-  return `${issue.project_uid}:${issue.short_id}`;
-}
-
 function parentHierarchyKey(issue: KataTaskSummary): string | null {
   return issue.parent_short_id ? `${issue.project_uid}:${issue.parent_short_id}` : null;
 }
 
-function topLevelIssues(issues: readonly KataTaskSummary[], allIssues: readonly KataTaskSummary[]): KataTaskSummary[] {
-  const visibleKeys = new Set(allIssues.map(issueHierarchyKey));
-  return issues.filter((issue) => {
-    const parentKey = parentHierarchyKey(issue);
-    return parentKey === null || !visibleKeys.has(parentKey);
-  });
+function topLevelIssues(issues: readonly KataTaskSummary[]): KataTaskSummary[] {
+  return issues.filter((issue) => parentHierarchyKey(issue) === null);
 }
 
 function selectableViewIssues(groups: KataTaskViewResponse["groups"]): KataTaskSummary[] {
-  const allIssues = groups.flatMap((group) => group.issues);
-  return groups.flatMap((group) => topLevelIssues(group.issues, allIssues));
+  return groups.flatMap((group) => topLevelIssues(group.issues));
 }
 
 function projectArea(project: KataProjectSummary): string {

--- a/frontend/tests/e2e-full/kata.spec.ts
+++ b/frontend/tests/e2e-full/kata.spec.ts
@@ -2921,7 +2921,7 @@ test("kata parent row expands children loaded from detail", async ({ page }) => 
     const parentRow = page.getByRole("button", { name: /Parent task/ });
     await expect(parentRow).toBeVisible();
     await expect(page.getByRole("button", { name: /Child task/ })).toHaveCount(0);
-    await expect(page.getByText("1 task")).toBeVisible();
+    await expect(page.getByText("2 tasks")).toBeVisible();
 
     await parentRow.press("ArrowRight");
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -390,6 +390,8 @@ const config = {
       "@lucide/svelte/icons/layout-panel-left",
       "@lucide/svelte/icons/layout-panel-top",
       "@lucide/svelte/icons/link",
+      "@lucide/svelte/icons/list-chevrons-down-up",
+      "@lucide/svelte/icons/list-chevrons-up-down",
       "@lucide/svelte/icons/loader-circle",
       "@lucide/svelte/icons/message-square",
       "@lucide/svelte/icons/message-square-reply",


### PR DESCRIPTION
Kata task lists were mixing tree and flat-list behavior, which made hidden child rows hard to reason about once a project had nested work. This PR gives the task table explicit tree controls: expand all recursively opens visible task trees through task detail data, while collapse all hides descendants without making cached children reappear as top-level rows.

The header count remains scoped to the filtered task set rather than the current expanded row projection, so expanding a tree does not make the project appear to have fewer tasks.

Validation: full frontend Vitest suite passed locally.

<sup>generated by a clanker</sup>