### PR TITLE
fix: replace native selects with the shared SelectDropdown combobox

### DIFF
--- a/context/ui-design-system.md
+++ b/context/ui-design-system.md
@@ -146,7 +146,7 @@ Intent:
 - avoid mixing browser-native select styling with custom app dropdowns
 - keep selection affordances consistent across detail headers, filters, and compact command surfaces
 
-Do not add new native `<select>` controls for visible app UI unless there is a platform-specific accessibility need that cannot be met by `SelectDropdown`. This is enforced by `frontend/src/no-native-select.test.ts`, which scans the component source trees and fails when a native `<select>` element is reintroduced.
+Do not add native `<select>` controls for visible app UI; use `SelectDropdown` instead. This is enforced by `frontend/src/no-native-select.test.ts`, which scans the component source trees and fails when a native `<select>` element is reintroduced. There is no allowlist or per-component exemption: if `SelectDropdown` cannot express a case, extend the primitive rather than reaching for a native `<select>`.
 
 ### Overlays
 

--- a/context/ui-design-system.md
+++ b/context/ui-design-system.md
@@ -146,7 +146,7 @@ Intent:
 - avoid mixing browser-native select styling with custom app dropdowns
 - keep selection affordances consistent across detail headers, filters, and compact command surfaces
 
-Do not add new native `<select>` controls for visible app UI unless there is a platform-specific accessibility need that cannot be met by `SelectDropdown`.
+Do not add new native `<select>` controls for visible app UI unless there is a platform-specific accessibility need that cannot be met by `SelectDropdown`. This is enforced by `frontend/src/no-native-select.test.ts`, which scans the component source trees and fails when a native `<select>` element is reintroduced.
 
 ### Overlays
 

--- a/frontend/src/lib/components/docs/AddFolderDialog.svelte
+++ b/frontend/src/lib/components/docs/AddFolderDialog.svelte
@@ -3,6 +3,7 @@
   import FolderIcon from "@lucide/svelte/icons/folder";
   import FolderOpen from "@lucide/svelte/icons/folder-open";
   import RefreshCw from "@lucide/svelte/icons/refresh-cw";
+  import { SelectDropdown } from "@middleman/ui";
   import Modal from "./DocsModal.svelte";
   import type { DocsAPI } from "../../api/docs/api";
   import type { BrowseEntry, DocsAPIError, Folder } from "../../api/docs/types";
@@ -34,6 +35,10 @@
   let daemon = $state("");
   let showAdvanced = $state(false);
   let daemonRoster = $derived(getKataDaemonRoster());
+  let daemonOptions = $derived([
+    { value: "", label: "Follow active daemon" },
+    ...daemonRoster.map((daemonID) => ({ value: daemonID, label: daemonID })),
+  ]);
 
   let browsePath = $state("");
   let entries = $state<BrowseEntry[]>([]);
@@ -169,12 +174,13 @@
     {#if daemonRoster.length > 1}
       <label class="modal-field">
         <span>Daemon</span>
-        <select aria-label="Daemon" bind:value={daemon} disabled={saving}>
-          <option value="">Follow active daemon</option>
-          {#each daemonRoster as id (id)}
-            <option value={id}>{id}</option>
-          {/each}
-        </select>
+        <SelectDropdown
+          title="Daemon"
+          value={daemon}
+          options={daemonOptions}
+          onchange={(value) => { daemon = value; }}
+          disabled={saving}
+        />
       </label>
     {/if}
 
@@ -336,8 +342,7 @@
     letter-spacing: 0.05em;
   }
 
-  .modal-field input,
-  .modal-field select {
+  .modal-field input {
     width: 100%;
     padding: 6px 8px;
     border: 1px solid var(--border-default);
@@ -347,10 +352,20 @@
     font-size: var(--font-size-sm);
   }
 
-  .modal-field input:focus,
-  .modal-field select:focus {
+  .modal-field input:focus {
     outline: none;
     border-color: var(--border-focus);
+  }
+
+  .modal-field :global(.select-dropdown) {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .modal-field :global(.select-dropdown-trigger) {
+    height: 32px;
+    font-size: var(--font-size-sm);
+    font-weight: 400;
   }
 
   .picker {

--- a/frontend/src/lib/components/docs/AddFolderDialog.test.ts
+++ b/frontend/src/lib/components/docs/AddFolderDialog.test.ts
@@ -80,7 +80,8 @@ describe("AddFolderDialog", () => {
     renderDialog({ api });
     await waitFor(() => screen.getByText("Documents"));
 
-    await fireEvent.change(screen.getByLabelText("Daemon"), { target: { value: "work" } });
+    await fireEvent.click(screen.getByRole("combobox", { name: /Daemon/ }));
+    await fireEvent.click(screen.getByRole("option", { name: "work" }));
     const input = screen.getByPlaceholderText("~/Notes") as HTMLInputElement;
     await fireEvent.input(input, { target: { value: "/mock/shared-notes" } });
     await fireEvent.click(screen.getByRole("button", { name: "Add folder" }));
@@ -111,7 +112,8 @@ describe("AddFolderDialog", () => {
     renderDialog({ api });
     await waitFor(() => screen.getByText("Documents"));
 
-    await fireEvent.change(screen.getByLabelText("Daemon"), { target: { value: "work" } });
+    await fireEvent.click(screen.getByRole("combobox", { name: /Daemon/ }));
+    await fireEvent.click(screen.getByRole("option", { name: "work" }));
     setKataDaemonRoster(["home"], "home");
     const input = screen.getByPlaceholderText("~/Notes") as HTMLInputElement;
     await fireEvent.input(input, { target: { value: "/mock/shared-notes" } });

--- a/frontend/src/lib/components/kata/KataIssueProperties.svelte
+++ b/frontend/src/lib/components/kata/KataIssueProperties.svelte
@@ -4,7 +4,7 @@
   import FlagIcon from "@lucide/svelte/icons/flag";
   import UserIcon from "@lucide/svelte/icons/user-round";
   import XIcon from "@lucide/svelte/icons/x";
-  import { ActionButton, Chip } from "@middleman/ui";
+  import { ActionButton, Chip, SelectDropdown } from "@middleman/ui";
   import type { KataTaskDetail } from "../../api/kata/taskTypes.js";
   import DatePicker from "../shared/DatePicker.svelte";
   import TypeaheadTrigger, { type TypeaheadOption } from "../shared/TypeaheadTrigger.svelte";
@@ -247,23 +247,20 @@
   </div>
 
   {#if activeProperty === "priority"}
-    <label class="property-pill property-pill--editing">
+    <div class="property-pill property-pill--editing property-pill--select" role="group" aria-label="Edit priority">
       <FlagIcon size={13} strokeWidth={1.8} />
       <span>Priority</span>
-      <select
-        aria-label="Priority"
+      <SelectDropdown
+        title="Priority"
         value={issue.issue.priority === undefined || issue.issue.priority === null
           ? ""
           : String(issue.issue.priority)}
-        onchange={(event) => {
-          void updatePriority(event.currentTarget.value);
+        options={priorityOptions}
+        onchange={(value) => {
+          void updatePriority(value);
         }}
-      >
-        {#each priorityOptions as option (option.value)}
-          <option value={option.value}>{option.label}</option>
-        {/each}
-      </select>
-    </label>
+      />
+    </div>
   {:else}
     <button type="button" class="property-pill" aria-label="Edit priority" onclick={() => openProperty("priority")}>
       <FlagIcon size={13} strokeWidth={1.8} />
@@ -420,15 +417,21 @@
     background: var(--bg-surface-hover);
   }
 
-  .property-pill select {
-    min-height: 22px;
-    min-width: 0;
-    border: 0;
-    border-radius: 4px;
+  .property-pill--select :global(.select-dropdown) {
+    min-width: 104px;
+  }
+
+  .property-pill--select :global(.select-dropdown-trigger) {
+    height: 22px;
+    border-color: transparent;
     background: transparent;
     color: var(--text-primary);
-    font: inherit;
-    font-size: var(--font-size-sm);
+  }
+
+  .property-pill--select :global(.select-dropdown-trigger:hover:not(:disabled)),
+  .property-pill--select :global(.select-dropdown-trigger[aria-expanded="true"]) {
+    border-color: var(--border-default);
+    background: var(--bg-inset);
   }
 
   .detail-properties {

--- a/frontend/src/lib/components/kata/KataIssueProperties.test.ts
+++ b/frontend/src/lib/components/kata/KataIssueProperties.test.ts
@@ -161,9 +161,8 @@ describe("KataIssueProperties", () => {
     expect(onPatchMetadata).toHaveBeenCalledWith("issue-1", { deadline_on: "2026-06-08" });
 
     await fireEvent.click(screen.getByRole("button", { name: "Edit priority" }));
-    await fireEvent.change(screen.getByLabelText("Priority"), {
-      target: { value: "1" },
-    });
+    await fireEvent.click(screen.getByRole("combobox", { name: /Priority/ }));
+    await fireEvent.click(screen.getByRole("option", { name: "P1" }));
 
     expect(onSetPriority).toHaveBeenCalledWith("issue-1", 1);
   });
@@ -282,7 +281,8 @@ describe("KataIssueProperties", () => {
     renderProperties({ issue: makeIssue({ priority: 2 }), onSetPriority });
 
     await fireEvent.click(screen.getByRole("button", { name: "Edit priority" }));
-    await fireEvent.change(screen.getByLabelText("Priority"), { target: { value: "" } });
+    await fireEvent.click(screen.getByRole("combobox", { name: /Priority/ }));
+    await fireEvent.click(screen.getByRole("option", { name: "No priority" }));
 
     expect(onSetPriority).toHaveBeenCalledWith("issue-1", null);
   });

--- a/frontend/src/lib/components/settings/KataProjectMappingsSettings.svelte
+++ b/frontend/src/lib/components/settings/KataProjectMappingsSettings.svelte
@@ -2,7 +2,7 @@
   import PlusIcon from "@lucide/svelte/icons/plus";
   import RotateCcwIcon from "@lucide/svelte/icons/rotate-ccw";
   import TrashIcon from "@lucide/svelte/icons/trash-2";
-  import { ActionButton } from "@middleman/ui";
+  import { ActionButton, SelectDropdown } from "@middleman/ui";
   import type {
     ConfigRepo,
     KataProjectRepoMapping,
@@ -51,6 +51,9 @@
       .sort((left, right) => left.label.localeCompare(right.label)),
   );
   const repoOptionsByKey = $derived.by(() => new Map(repoOptions.map((option) => [option.key, option])));
+  const repoSelectOptions = $derived(
+    repoOptions.map((option) => ({ value: option.key, label: option.label })),
+  );
   const pendingMappings = $derived(buildPendingMappings());
   const isDirty = $derived(
     JSON.stringify(pendingMappings) !== JSON.stringify(currentMappings),
@@ -234,15 +237,13 @@
                   />
                 </td>
                 <td>
-                  <select
-                    bind:value={draft.repoKey}
+                  <SelectDropdown
+                    title={`Kata project ${label} repository`}
+                    value={draft.repoKey}
+                    options={repoSelectOptions}
+                    onchange={(value) => { draft.repoKey = value; }}
                     disabled={embedded || saving}
-                    aria-label={`Kata project ${label} repository`}
-                  >
-                    {#each repoOptions as option (option.key)}
-                      <option value={option.key}>{option.label}</option>
-                    {/each}
-                  </select>
+                  />
                 </td>
                 <td class="action-cell">
                   <ActionButton
@@ -365,8 +366,7 @@
     background: var(--bg-inset);
   }
 
-  .mapping-table input,
-  .mapping-table select {
+  .mapping-table input {
     width: 100%;
     min-height: 30px;
     padding: 4px 8px;
@@ -378,10 +378,20 @@
     font-weight: 400;
   }
 
-  .mapping-table input:disabled,
-  .mapping-table select:disabled {
+  .mapping-table input:disabled {
     color: var(--text-muted);
     background: var(--bg-inset);
+  }
+
+  .mapping-table :global(.select-dropdown) {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .mapping-table :global(.select-dropdown-trigger) {
+    height: 30px;
+    font-size: var(--font-size-sm);
+    font-weight: 400;
   }
 
   .daemon-col {

--- a/frontend/src/lib/components/settings/KataProjectMappingsSettings.test.ts
+++ b/frontend/src/lib/components/settings/KataProjectMappingsSettings.test.ts
@@ -81,6 +81,7 @@ describe("KataProjectMappingsSettings", () => {
       target: { value: "project-kata" },
     });
 
+    await fireEvent.click(screen.getByRole("combobox", { name: /repository/ }));
     expect(screen.getByRole("option", { name: "github / github.com / kenn-io/middleman" })).toBeTruthy();
     expect(screen.queryByRole("option", { name: "github / github.com / kenn-io/*" })).toBeNull();
 

--- a/frontend/src/lib/components/settings/RepoImportModal.browser.svelte.ts
+++ b/frontend/src/lib/components/settings/RepoImportModal.browser.svelte.ts
@@ -53,4 +53,27 @@ describe("RepoImportModal focus trap (browser)", () => {
     pressKey("Tab", {}, cancel);
     expect(document.activeElement).toBe(close);
   });
+
+  it("keeps Tab out of the open provider dropdown's option buttons", async () => {
+    render(RepoImportModal, {
+      props: { open: true, onClose: vi.fn(), onImported: vi.fn() },
+    });
+
+    await expect.element(page.getByRole("dialog", { name: "Add repositories" })).toBeVisible();
+
+    const provider = controlByLabel<HTMLButtonElement>("Provider", ".select-dropdown-trigger");
+    const host = controlByLabel<HTMLInputElement>("Host", "input");
+
+    // Open the dropdown so its option buttons are rendered. They carry
+    // tabindex="-1" precisely so they stay out of the modal's tab order.
+    provider.click();
+    const option = await vi.waitFor(() => requireElement<HTMLButtonElement>(".select-dropdown-option"));
+    expect(option.getAttribute("tabindex")).toBe("-1");
+
+    // Tabbing forward from the trigger must skip the option buttons and land on
+    // the next modal control, not descend into the open dropdown.
+    provider.focus();
+    pressKey("Tab", {}, provider);
+    expect(document.activeElement).toBe(host);
+  });
 });

--- a/frontend/src/lib/components/settings/RepoImportModal.browser.svelte.ts
+++ b/frontend/src/lib/components/settings/RepoImportModal.browser.svelte.ts
@@ -31,7 +31,7 @@ describe("RepoImportModal focus trap (browser)", () => {
     await expect.element(page.getByRole("dialog", { name: "Add repositories" })).toBeVisible();
 
     const close = requireElement<HTMLButtonElement>("button[aria-label='Close']");
-    const provider = controlByLabel<HTMLSelectElement>("Provider", "select");
+    const provider = controlByLabel<HTMLButtonElement>("Provider", ".select-dropdown-trigger");
     const host = controlByLabel<HTMLInputElement>("Host", "input");
     const pattern = controlByLabel<HTMLInputElement>("Repository pattern", "input");
     const cancel = page.getByRole("button", { name: "Cancel" }).element() as HTMLButtonElement;

--- a/frontend/src/lib/components/settings/RepoImportModal.svelte
+++ b/frontend/src/lib/components/settings/RepoImportModal.svelte
@@ -205,7 +205,7 @@
     if (!(modal instanceof HTMLElement)) return;
     const focusable = Array.from(
       modal.querySelectorAll<HTMLElement>(
-        "button:not(:disabled), input:not(:disabled), select:not(:disabled), [tabindex]:not([tabindex='-1'])",
+        "button:not(:disabled):not([tabindex='-1']), input:not(:disabled), [tabindex]:not([tabindex='-1'])",
       ),
     ).sort(compareDocumentOrder);
     if (focusable.length === 0) return;

--- a/frontend/src/lib/components/settings/RepoImportModal.svelte
+++ b/frontend/src/lib/components/settings/RepoImportModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { tick, untrack } from "svelte";
+  import { SelectDropdown, type SelectDropdownOption } from "@middleman/ui";
   import type { Settings } from "@middleman/ui/api/types";
   import { pushModalFrame } from "@middleman/ui/stores/keyboard/modal-stack";
   import { bulkAddRepos, previewRepos, type RepoPreviewRow } from "../../api/settings.js";
@@ -24,6 +25,11 @@
   }
 
   let { open, onClose, onImported }: Props = $props();
+
+  const providerOptions: SelectDropdownOption[] = repoImportProviders.map((option) => ({
+    value: option.id,
+    label: option.label,
+  }));
 
   let patternInput = $state("");
   let provider = $state("github");
@@ -226,14 +232,13 @@
       <div class="preview-form">
         <label class="provider-field">
           <span>Provider</span>
-          <select
+          <SelectDropdown
+            class="provider-select"
+            title="Provider"
             value={provider}
-            onchange={(event) => handleProviderChange(event.currentTarget.value)}
-          >
-            {#each repoImportProviders as option (option.id)}
-              <option value={option.id}>{option.label}</option>
-            {/each}
-          </select>
+            options={providerOptions}
+            onchange={handleProviderChange}
+          />
         </label>
         <label class="host-field">
           <span>Host</span>
@@ -308,7 +313,9 @@
   label { flex: 1; display: flex; flex-direction: column; gap: 6px; font-size: var(--font-size-sm); color: var(--text-secondary); }
   .provider-field { flex: 0 0 120px; }
   .host-field { flex: 0 0 190px; }
-  input, select { font-size: var(--font-size-md); padding: 7px 10px; color: var(--text-primary); background: var(--bg-inset); border: 1px solid var(--border-muted); border-radius: var(--radius-sm); }
+  input { font-size: var(--font-size-md); padding: 7px 10px; color: var(--text-primary); background: var(--bg-inset); border: 1px solid var(--border-muted); border-radius: var(--radius-sm); }
+  .provider-field :global(.provider-select) { width: 100%; min-width: 0; }
+  .provider-field :global(.select-dropdown-trigger) { height: 34px; font-size: var(--font-size-md); font-weight: 400; }
   .preview-btn, .submit-btn { padding: 7px 14px; font-size: var(--font-size-md); font-weight: 600; color: white; background: var(--accent-blue); border-radius: var(--radius-sm); }
   .secondary-btn { padding: 7px 14px; font-size: var(--font-size-md); color: var(--text-secondary); background: var(--bg-inset); border: 1px solid var(--border-muted); border-radius: var(--radius-sm); }
   button:disabled { opacity: 0.5; cursor: not-allowed; }

--- a/frontend/src/lib/components/settings/RepoImportModal.test.ts
+++ b/frontend/src/lib/components/settings/RepoImportModal.test.ts
@@ -281,11 +281,11 @@ describe("RepoImportModal", () => {
       props: { open: true, onClose: vi.fn(), onImported: vi.fn() },
     });
 
-    const provider = screen.getByLabelText("Provider");
     const host = screen.getByLabelText("Host") as HTMLInputElement;
     const pattern = screen.getByLabelText("Repository pattern");
 
-    await fireEvent.change(provider, { target: { value: "forgejo" } });
+    await fireEvent.click(screen.getByRole("combobox", { name: /Provider/ }));
+    await fireEvent.click(screen.getByRole("option", { name: "Forgejo" }));
     expect(host.value).toBe("codeberg.org");
     await fireEvent.input(pattern, {
       target: { value: "team/subgroup/project-*" },
@@ -294,7 +294,8 @@ describe("RepoImportModal", () => {
     expect((await screen.findByRole("alert")).textContent).toContain("Format: owner/pattern");
     expect(preview).not.toHaveBeenCalled();
 
-    await fireEvent.change(provider, { target: { value: "gitea" } });
+    await fireEvent.click(screen.getByRole("combobox", { name: /Provider/ }));
+    await fireEvent.click(screen.getByRole("option", { name: "Gitea" }));
     expect(host.value).toBe("gitea.com");
     await fireEvent.input(pattern, {
       target: { value: "team/service-*" },

--- a/frontend/src/lib/components/settings/RepoPreviewTable.svelte
+++ b/frontend/src/lib/components/settings/RepoPreviewTable.svelte
@@ -1,6 +1,14 @@
 <script lang="ts">
+  import { SelectDropdown, type SelectDropdownOption } from "@middleman/ui";
   import type { RepoImportRow, SortState, StatusFilter } from "./repoImportSelection.js";
   import { rowKey } from "./repoImportSelection.js";
+
+  const statusFilterOptions: SelectDropdownOption[] = [
+    { value: "all", label: "All rows" },
+    { value: "selected", label: "Selected" },
+    { value: "unselected", label: "Unselected" },
+    { value: "already-added", label: "Already added" },
+  ];
 
   interface Props {
     rows: RepoImportRow[];
@@ -67,16 +75,12 @@
     value={filterText}
     oninput={(event) => onFilterText(event.currentTarget.value)}
   />
-  <select
-    aria-label="Repository selection filter"
+  <SelectDropdown
+    title="Repository status filter"
     value={statusFilter}
-    onchange={(event) => onStatusFilter(event.currentTarget.value as StatusFilter)}
-  >
-    <option value="all">All rows</option>
-    <option value="selected">Selected</option>
-    <option value="unselected">Unselected</option>
-    <option value="already-added">Already added</option>
-  </select>
+    options={statusFilterOptions}
+    onchange={(value) => onStatusFilter(value as StatusFilter)}
+  />
   <label class="toggle-filter">
     <input
       type="checkbox"
@@ -141,7 +145,6 @@
 <style>
   .repo-preview-controls { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
   .filter-input { flex: 1; min-width: 220px; font-size: var(--font-size-md); padding: 6px 10px; background: var(--bg-inset); border: 1px solid var(--border-muted); border-radius: var(--radius-sm); }
-  select { font-size: var(--font-size-md); padding: 6px 8px; background: var(--bg-inset); color: var(--text-primary); border: 1px solid var(--border-muted); border-radius: var(--radius-sm); }
   .toggle-filter { display: inline-flex; align-items: center; gap: 5px; font-size: var(--font-size-sm); color: var(--text-secondary); white-space: nowrap; }
   .toggle-filter input { margin: 0; }
   .shortcut-btn, .sort-btn { font-size: var(--font-size-sm); color: var(--accent-blue); }

--- a/frontend/src/lib/components/settings/RepoSettings.test.ts
+++ b/frontend/src/lib/components/settings/RepoSettings.test.ts
@@ -3,7 +3,8 @@ import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 const mockRefreshSyncStatus = vi.fn();
 
-vi.mock("@middleman/ui", () => ({
+vi.mock("@middleman/ui", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@middleman/ui")>()),
   getStores: () => ({
     sync: {
       refreshSyncStatus: mockRefreshSyncStatus,

--- a/frontend/src/lib/components/terminal/WorkspaceFirstRunPanel.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceFirstRunPanel.svelte
@@ -149,10 +149,14 @@
       repo.name_with_owner.toLowerCase().includes(query),
     );
   });
+  // Resolve against the filtered list with the same fallback SelectDropdown
+  // uses to render (selected value, else first option). This keeps the cloned
+  // repo identical to the one shown: if a filter hides the current selection,
+  // both the dropdown and submit fall back to the first visible repo instead of
+  // cloning a stale, no-longer-visible selection.
   const chosenGithubRepo = $derived(
-    githubRepos.find(
-      (repo) => repo.name_with_owner === selectedGithubRepo,
-    ),
+    filteredRepos.find((repo) => repo.name_with_owner === selectedGithubRepo) ??
+      filteredRepos[0],
   );
   const githubRepoOptions = $derived(
     filteredRepos.map((repo) => ({
@@ -516,7 +520,7 @@
               </button>
               <button
                 type="submit"
-                disabled={inFlight || !selectedGithubRepo}
+                disabled={inFlight || !chosenGithubRepo}
               >
                 {inFlight ? "Cloning..." : "Clone repository"}
               </button>

--- a/frontend/src/lib/components/terminal/WorkspaceFirstRunPanel.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceFirstRunPanel.svelte
@@ -14,6 +14,7 @@
     loadSnapshotHosts,
     type HostSummary,
   } from "../../api/fleet-snapshot.ts";
+  import { SelectDropdown } from "@middleman/ui";
   import {
     emitWorkspaceCommand,
     getWorkspaceData,
@@ -152,6 +153,12 @@
     githubRepos.find(
       (repo) => repo.name_with_owner === selectedGithubRepo,
     ),
+  );
+  const githubRepoOptions = $derived(
+    filteredRepos.map((repo) => ({
+      value: repo.name_with_owner,
+      label: repo.name_with_owner,
+    })),
   );
 
   function isDisabled(definition: ActionDefinition): boolean {
@@ -472,16 +479,13 @@
             </label>
             <label class="first-run-field">
               <span>GitHub repository</span>
-              <select
-                bind:value={selectedGithubRepo}
+              <SelectDropdown
+                title="GitHub repository"
+                value={selectedGithubRepo}
+                options={githubRepoOptions}
+                onchange={(value) => { selectedGithubRepo = value; }}
                 disabled={inFlight}
-              >
-                {#each filteredRepos as repo (repo.name_with_owner)}
-                  <option value={repo.name_with_owner}>
-                    {repo.name_with_owner}
-                  </option>
-                {/each}
-              </select>
+              />
             </label>
             <label class="first-run-field">
               <span>Destination path</span>
@@ -666,8 +670,7 @@
     font-weight: 600;
   }
 
-  .first-run-field input,
-  .first-run-field select {
+  .first-run-field input {
     box-sizing: border-box;
     width: 100%;
     border: 1px solid var(--border-default);
@@ -679,9 +682,19 @@
     padding: 8px 10px;
   }
 
-  .first-run-field input:disabled,
-  .first-run-field select:disabled {
+  .first-run-field input:disabled {
     opacity: 0.6;
+  }
+
+  .first-run-field :global(.select-dropdown) {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .first-run-field :global(.select-dropdown-trigger) {
+    height: 36px;
+    font-size: var(--font-size-sm);
+    font-weight: 400;
   }
 
   .first-run-form__buttons {

--- a/frontend/src/lib/components/terminal/WorkspaceFirstRunPanel.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceFirstRunPanel.test.ts
@@ -295,10 +295,8 @@ describe("WorkspaceFirstRunPanel", () => {
         name: /Connect a GitHub repository/i,
       }),
     );
-    const repoSelect = await screen.findByLabelText("GitHub repository");
-    await fireEvent.change(repoSelect, {
-      target: { value: "octo/two" },
-    });
+    await fireEvent.click(await screen.findByRole("combobox", { name: /GitHub repository/ }));
+    await fireEvent.click(screen.getByRole("option", { name: "octo/two" }));
     await fireEvent.input(screen.getByLabelText("Destination path"), {
       target: { value: "/tmp/two" },
     });

--- a/frontend/src/lib/components/terminal/WorkspaceFirstRunPanel.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceFirstRunPanel.test.ts
@@ -307,6 +307,44 @@ describe("WorkspaceFirstRunPanel", () => {
     });
   });
 
+  it("clones the repository shown after a filter hides the default selection", async () => {
+    mocks.listUserRepositories.mockResolvedValue([
+      {
+        name_with_owner: "octo/one",
+        ssh_url: "git@github.com:octo/one.git",
+        default_branch: "main",
+      },
+      {
+        name_with_owner: "octo/two",
+        ssh_url: "git@github.com:octo/two.git",
+        default_branch: "trunk",
+      },
+    ]);
+    mocks.cloneProject.mockResolvedValue(project("prj_filtered"));
+    setupConfig({ ghAuthed: true });
+    render(WorkspaceFirstRunPanel);
+
+    await fireEvent.click(
+      screen.getByRole("button", {
+        name: /Connect a GitHub repository/i,
+      }),
+    );
+    // The first repo (octo/one) is selected by default. Filtering to the other
+    // repo hides that selection; without an explicit pick, submit must clone
+    // the repo now shown (octo/two), not the stale default.
+    await fireEvent.input(await screen.findByLabelText("Filter repositories"), {
+      target: { value: "two" },
+    });
+    await fireEvent.input(screen.getByLabelText("Destination path"), {
+      target: { value: "/tmp/two" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Clone repository" }));
+
+    await waitFor(() => {
+      expect(mocks.cloneProject).toHaveBeenCalledWith("git@github.com:octo/two.git", "/tmp/two", "");
+    });
+  });
+
   it("surfaces host callback failures after registration", async () => {
     mocks.registerExistingProject.mockResolvedValue(project("prj_existing"));
     setupConfig({

--- a/frontend/src/no-native-select.test.ts
+++ b/frontend/src/no-native-select.test.ts
@@ -1,0 +1,57 @@
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vite-plus/test";
+
+// Guards the design-system rule documented in context/ui-design-system.md
+// (SelectDropdown section): visible app UI must not use native `<select>`
+// controls; use the shared `SelectDropdown` primitive instead. This scans the
+// component source trees so a reintroduced native select fails CI rather than
+// only being caught in review.
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const roots = [currentDir, path.resolve(currentDir, "../../packages/ui/src")];
+
+// Matches the opening tag of a native `<select>` element. Case-sensitive so
+// the `<SelectDropdown>` component and words like "selected"/"selection" are
+// not flagged; the lookahead requires a tag boundary (whitespace, `>`, or `/`)
+// so it only matches the element, not a substring.
+const NATIVE_SELECT = /<select(?=[\s/>])/g;
+
+function svelteFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === "node_modules" || entry.name === "dist") continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...svelteFiles(full));
+    } else if (entry.name.endsWith(".svelte")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function violationsIn(file: string): string[] {
+  const source = readFileSync(file, "utf8");
+  const hits: string[] = [];
+  for (const match of source.matchAll(NATIVE_SELECT)) {
+    const line = source.slice(0, match.index).split("\n").length;
+    hits.push(`${file}:${line}`);
+  }
+  return hits;
+}
+
+describe("no native select elements", () => {
+  it("uses SelectDropdown instead of native <select> in app UI", () => {
+    const files = roots.flatMap((root) => svelteFiles(root));
+    // Sanity: ensure the scan actually reached the component trees.
+    expect(files.length).toBeGreaterThan(0);
+
+    const violations = files.flatMap(violationsIn);
+    expect(
+      violations,
+      `Found native <select> elements. Use the SelectDropdown primitive from @middleman/ui instead:\n${violations.join("\n")}`,
+    ).toEqual([]);
+  });
+});

--- a/frontend/tests/e2e-full/kata.spec.ts
+++ b/frontend/tests/e2e-full/kata.spec.ts
@@ -4410,7 +4410,8 @@ test("kata detail properties mutate through the configured external daemon", asy
     expect(backend.state.issues.find((issue) => issue.uid === "issue-rent")?.owner).toBeUndefined();
 
     await detail.getByRole("button", { name: "Edit priority" }).click();
-    await detail.getByLabel("Priority", { exact: true }).selectOption("2");
+    await detail.getByRole("combobox", { name: /Priority/ }).click();
+    await detail.getByRole("option", { name: "P2" }).click();
     await expect(detail.getByRole("button", { name: "Edit priority" })).toContainText("P2");
     await expect
       .poll(() => backend.state.seenPaths)

--- a/frontend/tests/e2e-full/settings-globs.spec.ts
+++ b/frontend/tests/e2e-full/settings-globs.spec.ts
@@ -430,7 +430,8 @@ test("repository import previews and adds Forgejo and Gitea repositories through
   await page.getByRole("button", { name: "Add repositories…" }).click();
   const dialog = page.getByRole("dialog", { name: "Add repositories" });
 
-  await dialog.getByLabel("Provider").selectOption("forgejo");
+  await dialog.getByRole("combobox", { name: /Provider/ }).click();
+  await dialog.getByRole("option", { name: "Forgejo" }).click();
   await expect(dialog.getByLabel("Host")).toHaveValue("codeberg.org");
   await dialog.getByLabel("Repository pattern").fill("team/subgroup/service-*");
   await dialog.getByRole("button", { name: "Preview" }).click();
@@ -484,7 +485,8 @@ test("repository import previews and adds Forgejo and Gitea repositories through
   const giteaDialog = page.getByRole("dialog", {
     name: "Add repositories",
   });
-  await giteaDialog.getByLabel("Provider").selectOption("gitea");
+  await giteaDialog.getByRole("combobox", { name: /Provider/ }).click();
+  await giteaDialog.getByRole("option", { name: "Gitea" }).click();
   await expect(giteaDialog.getByLabel("Host")).toHaveValue("gitea.com");
   await giteaDialog.getByLabel("Repository pattern").fill("gitea-team/*");
   await giteaDialog.getByRole("button", { name: "Preview" }).click();

--- a/packages/ui/src/components/shared/SelectDropdown.svelte
+++ b/packages/ui/src/components/shared/SelectDropdown.svelte
@@ -38,6 +38,11 @@
   const dropdownID = allocateSelectDropdownID();
   const listboxID = `${dropdownID}-listbox`;
 
+  // Unlike a native select element, an unmatched `value` does not render blank:
+  // it falls back to the first option. Callers that feed `options` from a
+  // filtered or async list must keep `value` consistent with the visible
+  // options (or derive anything used for submission with the same fallback),
+  // otherwise the trigger can show one option while submit acts on a stale value.
   const selectedOption = $derived(
     options.find((option) => option.value === value) ?? options[0],
   );


### PR DESCRIPTION
The Kata task detail priority picker rendered as a browser-native `<select>` instead of the app's custom dropdown language. Five other single-value pickers had the same inconsistency, all violating the design-system rule in `context/ui-design-system.md` that visible app UI uses `SelectDropdown`. Nothing enforced that rule, so the violations accumulated unnoticed.

User-visible changes — these pickers now use the shared `SelectDropdown` combobox:

- Kata task detail priority
- Repository import provider selector and status filter
- Kata project repository mapping
- Docs add-folder daemon selector
- Workspace first-run GitHub repository selector

A new guard test (`frontend/src/no-native-select.test.ts`) scans the component source trees and fails when a native `<select>` is reintroduced, so the rule holds going forward.

<sup>generated by a clanker</sup>
