### PR TITLE
Show all CI jobs in PR detail

### DIFF
--- a/frontend/tests/e2e-full/ci-dropdown.spec.ts
+++ b/frontend/tests/e2e-full/ci-dropdown.spec.ts
@@ -248,7 +248,7 @@ test.describe("CI dropdown", () => {
     }
   });
 
-  test("dropdown shows summary header, five sections, show-N-more toggle", async ({ page }) => {
+  test("dropdown shows summary header, five sections, and all jobs", async ({ page }) => {
     const server = await startIsolatedE2EServer();
     try {
       // The payload below contains pending checks, which arm the
@@ -285,36 +285,10 @@ test.describe("CI dropdown", () => {
       await expect(headings.nth(3)).toContainText(/Passed \(12\)/);
       await expect(headings.nth(4)).toContainText(/Skipped \(2\)/);
 
-      // The route-load background sync can refetch the detail
-      // payload at any point in the first seconds of the page; the
-      // resulting remount collapses the show-more state. Re-apply
-      // the user action when that happens — the assertions inside
-      // still pin the expand/collapse behavior itself.
-      const showMore = panel.getByRole("button", {
-        name: /Show 4 more passed/i,
-      });
-      await expect(showMore).toBeVisible();
-      await expect(async () => {
-        if (await showMore.count()) {
-          await showMore.evaluate((button: HTMLElement) => button.click());
-        }
-        await expect(
-          panel.getByRole("button", {
-            name: /Show fewer passed/i,
-          }),
-        ).toBeVisible({ timeout: 1_000 });
-        await expect(panel.locator(".ci-section-passed .ci-row")).toHaveCount(12, { timeout: 1_000 });
-      }).toPass({ timeout: 15_000 });
-
-      const showFewer = panel.getByRole("button", {
-        name: /Show fewer passed/i,
-      });
-      await expect(async () => {
-        if (await showFewer.count()) {
-          await showFewer.evaluate((button: HTMLElement) => button.click());
-        }
-        await expect(panel.locator(".ci-section-passed .ci-row")).toHaveCount(8, { timeout: 1_000 });
-      }).toPass({ timeout: 15_000 });
+      await expect(panel.locator(".ci-section-passed .ci-row")).toHaveCount(12);
+      await expect(panel.locator(".ci-section-skipped .ci-row")).toHaveCount(2);
+      await expect(panel.getByRole("button", { name: /Show \d+ more/i })).toHaveCount(0);
+      await expect(panel.getByRole("button", { name: /Show fewer/i })).toHaveCount(0);
     } finally {
       await server.stop();
     }

--- a/packages/ui/src/components/detail/CIStatus.svelte
+++ b/packages/ui/src/components/detail/CIStatus.svelte
@@ -56,7 +56,6 @@
   }: Props = $props();
 
   const instanceId = ++_ciStatusInstanceCounter.value;
-  const SHOW_MORE_THRESHOLD = 8;
 
   const parsed = $derived(parseCIChecks(checksJSON));
   const parseError = $derived(parsed.error);
@@ -66,20 +65,6 @@
   const shouldRender = $derived(hasCheckBucket || isUnavailable);
 
   const pendingAnimated = $derived(!prefersReducedMotion());
-
-  const expandedSections = $state<Record<"passed" | "skipped", boolean>>({
-    passed: false,
-    skipped: false,
-  });
-
-  $effect(() => {
-    // Referencing prKey registers the dependency so this fires on PR
-    // navigation. Reset the per-PR expansion state so a fresh PR starts
-    // collapsed.
-    void prKey;
-    expandedSections.passed = false;
-    expandedSections.skipped = false;
-  });
 
   $effect(() => {
     if (bucketed.unknown.length > 0) {
@@ -98,17 +83,6 @@
       });
     }
   });
-
-  const passedVisible = $derived(
-    expandedSections.passed
-      ? bucketed.passed
-      : bucketed.passed.slice(0, SHOW_MORE_THRESHOLD),
-  );
-  const skippedVisible = $derived(
-    expandedSections.skipped
-      ? bucketed.skipped
-      : bucketed.skipped.slice(0, SHOW_MORE_THRESHOLD),
-  );
 
   function formatDuration(seconds: number | undefined): string {
     if (seconds === undefined || seconds < 0 || !Number.isFinite(seconds)) {
@@ -282,36 +256,10 @@
               {@render sectionBlock("unknown", "Unknown", "ci-section-heading--purple", bucketed.unknown)}
             {/if}
             {#if bucketed.passed.length > 0}
-              {@render sectionBlock("passed", "Passed", "ci-section-heading--green", passedVisible)}
-              {#if bucketed.passed.length > SHOW_MORE_THRESHOLD}
-                <button
-                  type="button"
-                  class="ci-show-toggle"
-                  onclick={() => { expandedSections.passed = !expandedSections.passed; }}
-                >
-                  {#if expandedSections.passed}
-                    Show fewer passed
-                  {:else}
-                    Show {bucketed.passed.length - SHOW_MORE_THRESHOLD} more passed
-                  {/if}
-                </button>
-              {/if}
+              {@render sectionBlock("passed", "Passed", "ci-section-heading--green", bucketed.passed)}
             {/if}
             {#if bucketed.skipped.length > 0}
-              {@render sectionBlock("skipped", "Skipped", "ci-section-heading--muted", skippedVisible)}
-              {#if bucketed.skipped.length > SHOW_MORE_THRESHOLD}
-                <button
-                  type="button"
-                  class="ci-show-toggle"
-                  onclick={() => { expandedSections.skipped = !expandedSections.skipped; }}
-                >
-                  {#if expandedSections.skipped}
-                    Show fewer skipped
-                  {:else}
-                    Show {bucketed.skipped.length - SHOW_MORE_THRESHOLD} more skipped
-                  {/if}
-                </button>
-              {/if}
+              {@render sectionBlock("skipped", "Skipped", "ci-section-heading--muted", bucketed.skipped)}
             {/if}
           </div>
         {/if}
@@ -469,23 +417,6 @@
     color: var(--text-muted);
     flex-shrink: 0;
     font-size: var(--font-size-sm);
-  }
-
-  .ci-show-toggle {
-    align-self: flex-start;
-    margin: 4px 12px 8px;
-    padding: 2px 8px;
-    background: transparent;
-    border: 1px solid var(--border-muted);
-    border-radius: var(--radius-sm);
-    color: var(--text-muted);
-    font-size: var(--font-size-2xs);
-    cursor: pointer;
-  }
-
-  .ci-show-toggle:hover {
-    color: var(--text-primary);
-    background: var(--bg-surface-hover);
   }
 
   .loading-placeholder {

--- a/packages/ui/src/components/detail/CIStatus.test.ts
+++ b/packages/ui/src/components/detail/CIStatus.test.ts
@@ -295,7 +295,7 @@ describe("CIStatus", () => {
     expect(document.querySelector("[data-testid='ci-section-passed']")).not.toBeNull();
   });
 
-  it("Passed section shows first 8 + Show 1 more toggle when count > 8", async () => {
+  it("renders every passed check without a show-more toggle", () => {
     const checks = Array.from({ length: 9 }, (_, i) => mkCheck({ name: `p${i}` }));
     render(CIStatus, {
       props: {
@@ -304,17 +304,9 @@ describe("CIStatus", () => {
         checksJSON: JSON.stringify(checks),
       },
     });
-    expect(document.querySelectorAll(".ci-row")).toHaveLength(8);
-    const toggle = screen.getByRole("button", {
-      name: /Show 1 more passed/i,
-    });
-    await fireEvent.click(toggle);
     expect(document.querySelectorAll(".ci-row")).toHaveLength(9);
-    const collapseToggle = screen.getByRole("button", {
-      name: /Show fewer passed/i,
-    });
-    await fireEvent.click(collapseToggle);
-    expect(document.querySelectorAll(".ci-row")).toHaveLength(8);
+    expect(screen.queryByRole("button", { name: /Show \d+ more passed/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Show fewer passed/i })).toBeNull();
   });
 
   it("dropdown row uses bucket Lucide icon (not ASCII glyph)", () => {
@@ -330,7 +322,7 @@ describe("CIStatus", () => {
     expect(row.textContent).not.toContain("✗");
   });
 
-  it("expansion state resets when prKey changes", async () => {
+  it("keeps every passed check visible when prKey changes", async () => {
     const checks = Array.from({ length: 9 }, (_, i) => mkCheck({ name: `p${i}` }));
     const { rerender } = render(CIStatus, {
       props: {
@@ -340,7 +332,6 @@ describe("CIStatus", () => {
         checksJSON: JSON.stringify(checks),
       },
     });
-    await fireEvent.click(screen.getByRole("button", { name: /Show 1 more passed/i }));
     expect(document.querySelectorAll(".ci-row")).toHaveLength(9);
     await rerender({
       ...chipBaseProps,
@@ -348,7 +339,7 @@ describe("CIStatus", () => {
       expanded: true,
       checksJSON: JSON.stringify(checks),
     });
-    expect(document.querySelectorAll(".ci-row")).toHaveLength(8);
+    expect(document.querySelectorAll(".ci-row")).toHaveLength(9);
   });
 
   it("renders static circle for pending row under prefers-reduced-motion", () => {


### PR DESCRIPTION
The PR detail CI dropdown is meant to be the complete job view for a pull request, but the previous passed/skipped cap hid part of that list behind a secondary toggle. That made the dropdown less useful for scanning a run and added expansion state that could be reset by background refreshes.

This removes the row cap so reviewers can scroll one complete CI list directly in the dropdown, while keeping the existing bucket ordering and compact chip summary.

![ci-dropdown-all-jobs.png](https://github.com/user-attachments/assets/b00856ba-70ae-4880-8cb9-df3b50166d46)
![ci-dropdown-all-jobs-bottom.png](https://github.com/user-attachments/assets/0ee32c39-e8ba-42c3-99a1-47e3d2e1cea3)
