### PR TITLE
Disable GitHub self-approval actions

### DIFF
--- a/context/provider-architecture.md
+++ b/context/provider-architecture.md
@@ -65,12 +65,13 @@ Rules:
 - Capability flags and implemented interfaces must agree.
 - Handlers must check capabilities before performing mutations. A missing
   capability is a feature-level failure, not a whole-provider failure.
-- Per-operation availability starts repo-scoped, but item detail responses may
-  overlay item-specific gates when the rule needs the concrete PR/MR or issue.
-  Keep those gates out of repo settings and list summaries: `repoOperations`
-  should answer "can this repo generally perform the operation?", while
-  `repoOperationsForMergeRequest` may additionally answer "can this viewer do
-  it on this PR?" such as GitHub self-approval being unavailable
+- Keep operation availability split by scope. `repoOperations` handles
+  repo-level gates: provider capability, write credentials, rate limits, and
+  repo-wide viewer permissions. Detail responses may add item-level gates with
+  `repoOperationsForMergeRequest`, where the loaded PR/MR is available. For
+  example, GitHub self-approval is disabled only on PR detail because the rule
+  needs both the authenticated viewer and the PR author. Do not put item-level
+  gates in repo settings or list summaries
   (`internal/server/operation_availability.go::repoOperations`,
   `internal/server/operation_availability.go::repoOperationsForMergeRequest`).
 - Read sync should continue for supported resources if optional resources such

--- a/context/provider-architecture.md
+++ b/context/provider-architecture.md
@@ -79,6 +79,16 @@ Rules:
   item-level gates in repo settings or list summaries
   (`internal/server/operation_availability.go::repoOperations`,
   `internal/server/operation_availability.go::repoOperationsForMergeRequest`).
+- An item-level gate such as self-approval must be applied at every mutation
+  entry point that can reach the guarded action and every response the UI reads
+  to decide whether to offer it — not only the detail operations response.
+  Availability alone does not protect direct API callers or stale clients, and a
+  server-side rejection alone still lets the UI advertise an action that fails on
+  submit. For self-approval that means: reject with `selfApprovalProblem` in both
+  review-draft publish and the direct `/approve` handler before calling the
+  review mutator, and drop `approve` from the advertised actions in both the
+  detail operations (`selfApprovalUnavailable`) and the review-draft response's
+  `supported_actions`, keeping `comment` and `request_changes`.
 - Read sync should continue for supported resources if optional resources such
   as releases, tags, CI, or comments fail or are unsupported.
 - Do not fake GitHub behavior for another provider. Add provider-specific

--- a/context/provider-architecture.md
+++ b/context/provider-architecture.md
@@ -65,6 +65,14 @@ Rules:
 - Capability flags and implemented interfaces must agree.
 - Handlers must check capabilities before performing mutations. A missing
   capability is a feature-level failure, not a whole-provider failure.
+- Per-operation availability starts repo-scoped, but item detail responses may
+  overlay item-specific gates when the rule needs the concrete PR/MR or issue.
+  Keep those gates out of repo settings and list summaries: `repoOperations`
+  should answer "can this repo generally perform the operation?", while
+  `repoOperationsForMergeRequest` may additionally answer "can this viewer do
+  it on this PR?" such as GitHub self-approval being unavailable
+  (`internal/server/operation_availability.go::repoOperations`,
+  `internal/server/operation_availability.go::repoOperationsForMergeRequest`).
 - Read sync should continue for supported resources if optional resources such
   as releases, tags, CI, or comments fail or are unsupported.
 - Do not fake GitHub behavior for another provider. Add provider-specific

--- a/context/provider-architecture.md
+++ b/context/provider-architecture.md
@@ -79,16 +79,10 @@ Rules:
   item-level gates in repo settings or list summaries
   (`internal/server/operation_availability.go::repoOperations`,
   `internal/server/operation_availability.go::repoOperationsForMergeRequest`).
-- An item-level gate such as self-approval must be applied at every mutation
-  entry point that can reach the guarded action and every response the UI reads
-  to decide whether to offer it — not only the detail operations response.
-  Availability alone does not protect direct API callers or stale clients, and a
-  server-side rejection alone still lets the UI advertise an action that fails on
-  submit. For self-approval that means: reject with `selfApprovalProblem` in both
-  review-draft publish and the direct `/approve` handler before calling the
-  review mutator, and drop `approve` from the advertised actions in both the
-  detail operations (`selfApprovalUnavailable`) and the review-draft response's
-  `supported_actions`, keeping `comment` and `request_changes`.
+- Enforce item-level gates at every mutation entry point and every UI
+  availability signal, not only the detail response. Self-approval both rejects
+  (`selfApprovalProblem`: review-draft publish, direct `/approve`) and hides the
+  action (detail operations, review-draft `supported_actions`).
 - Read sync should continue for supported resources if optional resources such
   as releases, tags, CI, or comments fail or are unsupported.
 - Do not fake GitHub behavior for another provider. Add provider-specific

--- a/context/provider-architecture.md
+++ b/context/provider-architecture.md
@@ -72,9 +72,11 @@ Rules:
   provider-specific facts, go through provider interfaces. For example, GitHub
   self-approval uses `platform.MergeRequestViewerResolver`; the GitHub provider
   resolves the authenticated viewer with the write credential, caches that
-  login, and compares it to the PR author. Server code must not shell out to
-  provider CLIs or do provider-specific identity matching. Do not put item-level
-  gates in repo settings or list summaries
+  login only for a bounded window keyed to the credential chain, and compares it
+  to the PR author. Viewer-resolution errors fail open in availability because
+  the provider mutation remains authoritative. Server code must not shell out
+  to provider CLIs or do provider-specific identity matching. Do not put
+  item-level gates in repo settings or list summaries
   (`internal/server/operation_availability.go::repoOperations`,
   `internal/server/operation_availability.go::repoOperationsForMergeRequest`).
 - Read sync should continue for supported resources if optional resources such

--- a/context/provider-architecture.md
+++ b/context/provider-architecture.md
@@ -69,8 +69,11 @@ Rules:
   repo-level gates: provider capability, write credentials, rate limits, and
   repo-wide viewer permissions. Detail responses may add item-level gates with
   `repoOperationsForMergeRequest`, where the loaded PR/MR is available. For
-  example, GitHub self-approval is disabled only on PR detail because the rule
-  needs both the authenticated viewer and the PR author. Do not put item-level
+  provider-specific facts, go through provider interfaces. For example, GitHub
+  self-approval uses `platform.MergeRequestViewerResolver`; the GitHub provider
+  resolves the authenticated viewer with the write credential, caches that
+  login, and compares it to the PR author. Server code must not shell out to
+  provider CLIs or do provider-specific identity matching. Do not put item-level
   gates in repo settings or list summaries
   (`internal/server/operation_availability.go::repoOperations`,
   `internal/server/operation_availability.go::repoOperationsForMergeRequest`).

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -1491,8 +1491,8 @@ func (c *liveClient) authenticatedLogin(ctx context.Context) (string, error) {
 	if c.viewerLogin != "" {
 		return c.viewerLogin, nil
 	}
-	user, resp, err := c.gh.Users.Get(ctx, "")
-	c.trackRate(resp)
+	user, resp, err := c.writeGH().Users.Get(ctx, "")
+	c.trackWriteRate(resp)
 	if err != nil {
 		return "", fmt.Errorf("getting authenticated user: %w", err)
 	}
@@ -1502,6 +1502,10 @@ func (c *liveClient) authenticatedLogin(ctx context.Context) (string, error) {
 	}
 	c.viewerLogin = login
 	return login, nil
+}
+
+func (c *liveClient) AuthenticatedViewerLogin(ctx context.Context) (string, error) {
+	return c.authenticatedLogin(ctx)
 }
 
 func (c *liveClient) GetIssue(

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -415,6 +415,8 @@ type liveClient struct {
 	etag                    *etagTransport
 	viewerMu                sync.Mutex
 	viewerLogin             string
+	viewerLoginAt           time.Time
+	viewerLoginCacheKey     string
 }
 
 func (c *liveClient) writeGH() *gh.Client {
@@ -1486,9 +1488,13 @@ func (c *liveClient) ListRepositoriesByOwner(
 }
 
 func (c *liveClient) authenticatedLogin(ctx context.Context) (string, error) {
+	cacheKey := c.authenticatedViewerCacheKey()
+	now := time.Now()
 	c.viewerMu.Lock()
 	defer c.viewerMu.Unlock()
-	if c.viewerLogin != "" {
+	if c.viewerLogin != "" &&
+		c.viewerLoginCacheKey == cacheKey &&
+		now.Sub(c.viewerLoginAt) < authenticatedViewerLoginTTL {
 		return c.viewerLogin, nil
 	}
 	user, resp, err := c.writeGH().Users.Get(ctx, "")
@@ -1501,11 +1507,24 @@ func (c *liveClient) authenticatedLogin(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("authenticated user login is empty")
 	}
 	c.viewerLogin = login
+	c.viewerLoginAt = now
+	c.viewerLoginCacheKey = cacheKey
 	return login, nil
 }
 
 func (c *liveClient) AuthenticatedViewerLogin(ctx context.Context) (string, error) {
 	return c.authenticatedLogin(ctx)
+}
+
+func (c *liveClient) AuthenticatedViewerCacheKey() string {
+	return c.authenticatedViewerCacheKey()
+}
+
+func (c *liveClient) authenticatedViewerCacheKey() string {
+	if c.source == nil {
+		return ""
+	}
+	return c.source.Descriptor().CanonicalSourceString()
 }
 
 func (c *liveClient) GetIssue(

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -705,8 +705,14 @@ func NewSyncerWithRegistry(
 }
 
 type gitHubClientProvider struct {
-	host   string
-	client Client
+	host        string
+	client      Client
+	viewerMu    sync.Mutex
+	viewerLogin string
+}
+
+type authenticatedViewerLoginClient interface {
+	AuthenticatedViewerLogin(ctx context.Context) (string, error)
 }
 
 type githubLabelClient interface {
@@ -732,7 +738,7 @@ func registryFromGitHubClients(clients map[string]Client) *platform.Registry {
 		if client == nil {
 			continue
 		}
-		provider := gitHubClientProvider{
+		provider := &gitHubClientProvider{
 			host:   canonicalRepoHost(host),
 			client: client,
 		}
@@ -754,15 +760,15 @@ func NewProviderRegistry(
 	return registry, nil
 }
 
-func (p gitHubClientProvider) Platform() platform.Kind {
+func (p *gitHubClientProvider) Platform() platform.Kind {
 	return platform.KindGitHub
 }
 
-func (p gitHubClientProvider) Host() string {
+func (p *gitHubClientProvider) Host() string {
 	return p.host
 }
 
-func (p gitHubClientProvider) Capabilities() platform.Capabilities {
+func (p *gitHubClientProvider) Capabilities() platform.Capabilities {
 	_, labels := p.client.(githubLabelClient)
 	_, assignees := p.client.(githubAssigneeClient)
 	_, reviewers := p.client.(githubReviewerClient)
@@ -800,25 +806,62 @@ func (p gitHubClientProvider) Capabilities() platform.Capabilities {
 	}
 }
 
-func (p gitHubClientProvider) GitHubClient() Client {
+func (p *gitHubClientProvider) GitHubClient() Client {
 	return p.client
 }
 
-func (p gitHubClientProvider) ListNotifications(
+func (p *gitHubClientProvider) ViewerAuthoredMergeRequest(
+	ctx context.Context,
+	mr platform.MergeRequest,
+) (bool, error) {
+	author := strings.TrimSpace(mr.Author)
+	if author == "" {
+		return false, nil
+	}
+	viewer, err := p.authenticatedViewerLogin(ctx)
+	if err != nil {
+		return false, err
+	}
+	return strings.EqualFold(viewer, author), nil
+}
+
+func (p *gitHubClientProvider) authenticatedViewerLogin(ctx context.Context) (string, error) {
+	p.viewerMu.Lock()
+	defer p.viewerMu.Unlock()
+	if p.viewerLogin != "" {
+		return p.viewerLogin, nil
+	}
+	client, ok := p.client.(authenticatedViewerLoginClient)
+	if !ok {
+		return "", fmt.Errorf("github client does not resolve authenticated viewer")
+	}
+	login, err := client.AuthenticatedViewerLogin(ctx)
+	if err != nil {
+		return "", err
+	}
+	login = strings.TrimSpace(login)
+	if login == "" {
+		return "", fmt.Errorf("authenticated viewer login is empty")
+	}
+	p.viewerLogin = login
+	return login, nil
+}
+
+func (p *gitHubClientProvider) ListNotifications(
 	ctx context.Context,
 	opts platform.NotificationListOptions,
 ) ([]platform.NotificationThread, bool, error) {
 	return p.client.ListNotifications(ctx, opts)
 }
 
-func (p gitHubClientProvider) MarkNotificationThreadRead(
+func (p *gitHubClientProvider) MarkNotificationThreadRead(
 	ctx context.Context,
 	threadID string,
 ) error {
 	return p.client.MarkNotificationThreadRead(ctx, threadID)
 }
 
-func (p gitHubClientProvider) GetRepository(
+func (p *gitHubClientProvider) GetRepository(
 	ctx context.Context,
 	ref platform.RepoRef,
 ) (platform.Repository, error) {
@@ -871,7 +914,7 @@ func gitHubViewerCanMerge(repo *gh.Repository) *bool {
 	return &canMerge
 }
 
-func (p gitHubClientProvider) ListRepositories(
+func (p *gitHubClientProvider) ListRepositories(
 	ctx context.Context,
 	owner string,
 	_ platform.RepositoryListOptions,
@@ -913,7 +956,7 @@ func (p gitHubClientProvider) ListRepositories(
 	return out, nil
 }
 
-func (p gitHubClientProvider) ListOpenMergeRequests(
+func (p *gitHubClientProvider) ListOpenMergeRequests(
 	ctx context.Context,
 	ref platform.RepoRef,
 ) ([]platform.MergeRequest, error) {
@@ -932,7 +975,7 @@ func (p gitHubClientProvider) ListOpenMergeRequests(
 	return out, nil
 }
 
-func (p gitHubClientProvider) GetMergeRequest(
+func (p *gitHubClientProvider) GetMergeRequest(
 	ctx context.Context,
 	ref platform.RepoRef,
 	number int,
@@ -941,7 +984,7 @@ func (p gitHubClientProvider) GetMergeRequest(
 	return mr, err
 }
 
-func (p gitHubClientProvider) GetGitHubPullRequest(
+func (p *gitHubClientProvider) GetGitHubPullRequest(
 	ctx context.Context,
 	ref platform.RepoRef,
 	number int,
@@ -957,7 +1000,7 @@ func (p gitHubClientProvider) GetGitHubPullRequest(
 	return pr, mr, nil
 }
 
-func (p gitHubClientProvider) ListMergeRequestEvents(
+func (p *gitHubClientProvider) ListMergeRequestEvents(
 	ctx context.Context,
 	ref platform.RepoRef,
 	number int,
@@ -1027,7 +1070,7 @@ func (p gitHubClientProvider) ListMergeRequestEvents(
 	return out, nil
 }
 
-func (p gitHubClientProvider) ListOpenIssues(
+func (p *gitHubClientProvider) ListOpenIssues(
 	ctx context.Context,
 	ref platform.RepoRef,
 ) ([]platform.Issue, error) {
@@ -1046,14 +1089,14 @@ func (p gitHubClientProvider) ListOpenIssues(
 	return out, nil
 }
 
-func (p gitHubClientProvider) ListOpenGitHubIssues(
+func (p *gitHubClientProvider) ListOpenGitHubIssues(
 	ctx context.Context,
 	ref platform.RepoRef,
 ) ([]*gh.Issue, error) {
 	return p.client.ListOpenIssues(ctx, ref.Owner, ref.Name)
 }
 
-func (p gitHubClientProvider) ListLabels(
+func (p *gitHubClientProvider) ListLabels(
 	ctx context.Context,
 	ref platform.RepoRef,
 ) (platform.LabelCatalog, error) {
@@ -1068,7 +1111,7 @@ func (p gitHubClientProvider) ListLabels(
 	return platform.LabelCatalog{Labels: platformgithub.NormalizeLabels(ref, labels)}, nil
 }
 
-func (p gitHubClientProvider) GetIssue(
+func (p *gitHubClientProvider) GetIssue(
 	ctx context.Context,
 	ref platform.RepoRef,
 	number int,
@@ -1080,7 +1123,7 @@ func (p gitHubClientProvider) GetIssue(
 	return platformgithub.NormalizeIssue(ref, issue)
 }
 
-func (p gitHubClientProvider) GetGitHubIssue(
+func (p *gitHubClientProvider) GetGitHubIssue(
 	ctx context.Context,
 	ref platform.RepoRef,
 	number int,
@@ -1088,7 +1131,7 @@ func (p gitHubClientProvider) GetGitHubIssue(
 	return p.client.GetIssue(ctx, ref.Owner, ref.Name, number)
 }
 
-func (p gitHubClientProvider) ListIssueEvents(
+func (p *gitHubClientProvider) ListIssueEvents(
 	ctx context.Context,
 	ref platform.RepoRef,
 	number int,
@@ -1137,7 +1180,7 @@ func (p gitHubClientProvider) ListIssueEvents(
 	return out, nil
 }
 
-func (p gitHubClientProvider) CreateMergeRequestComment(
+func (p *gitHubClientProvider) CreateMergeRequestComment(
 	ctx context.Context,
 	ref platform.RepoRef,
 	number int,
@@ -1153,7 +1196,7 @@ func (p gitHubClientProvider) CreateMergeRequestComment(
 	return platformgithub.NormalizeCommentEvent(ref, number, comment), nil
 }
 
-func (p gitHubClientProvider) EditMergeRequestComment(
+func (p *gitHubClientProvider) EditMergeRequestComment(
 	ctx context.Context,
 	ref platform.RepoRef,
 	number int,
@@ -1170,7 +1213,7 @@ func (p gitHubClientProvider) EditMergeRequestComment(
 	return platformgithub.NormalizeCommentEvent(ref, number, comment), nil
 }
 
-func (p gitHubClientProvider) ReplyToThread(
+func (p *gitHubClientProvider) ReplyToThread(
 	ctx context.Context,
 	ref platform.RepoRef,
 	number int,
@@ -1193,7 +1236,7 @@ func (p gitHubClientProvider) ReplyToThread(
 	return platformgithub.NormalizeReviewCommentEvent(ref, number, comment), nil
 }
 
-func (p gitHubClientProvider) CreateIssueComment(
+func (p *gitHubClientProvider) CreateIssueComment(
 	ctx context.Context,
 	ref platform.RepoRef,
 	number int,
@@ -1209,7 +1252,7 @@ func (p gitHubClientProvider) CreateIssueComment(
 	return platformgithub.NormalizeIssueCommentEvent(ref, number, comment), nil
 }
 
-func (p gitHubClientProvider) EditIssueComment(
+func (p *gitHubClientProvider) EditIssueComment(
 	ctx context.Context,
 	ref platform.RepoRef,
 	number int,
@@ -1226,7 +1269,7 @@ func (p gitHubClientProvider) EditIssueComment(
 	return platformgithub.NormalizeIssueCommentEvent(ref, number, comment), nil
 }
 
-func (p gitHubClientProvider) SetMergeRequestState(
+func (p *gitHubClientProvider) SetMergeRequestState(
 	ctx context.Context,
 	ref platform.RepoRef,
 	number int,
@@ -1244,7 +1287,7 @@ func (p gitHubClientProvider) SetMergeRequestState(
 	return platformgithub.NormalizePullRequest(ref, ghPR)
 }
 
-func (p gitHubClientProvider) SetIssueState(
+func (p *gitHubClientProvider) SetIssueState(
 	ctx context.Context,
 	ref platform.RepoRef,
 	number int,
@@ -1263,7 +1306,7 @@ func (p gitHubClientProvider) SetIssueState(
 // MergeMergeRequest passes expectedHeadSHA as the GitHub merge sha
 // parameter: GitHub rejects the merge when the PR head moved past the
 // reviewed commit, and that rejection is classified as stale_state.
-func (p gitHubClientProvider) MergeMergeRequest(
+func (p *gitHubClientProvider) MergeMergeRequest(
 	ctx context.Context,
 	ref platform.RepoRef,
 	number int,
@@ -1312,7 +1355,7 @@ func isGitHubHeadModified(err error) bool {
 	return strings.Contains(strings.ToLower(ghErr.Message), "head branch was modified")
 }
 
-func (p gitHubClientProvider) ApproveWorkflow(
+func (p *gitHubClientProvider) ApproveWorkflow(
 	ctx context.Context,
 	ref platform.RepoRef,
 	runID string,
@@ -1324,7 +1367,7 @@ func (p gitHubClientProvider) ApproveWorkflow(
 	return p.client.ApproveWorkflowRun(ctx, ref.Owner, ref.Name, parsed)
 }
 
-func (p gitHubClientProvider) MarkReadyForReview(
+func (p *gitHubClientProvider) MarkReadyForReview(
 	ctx context.Context,
 	ref platform.RepoRef,
 	number int,
@@ -1339,7 +1382,7 @@ func (p gitHubClientProvider) MarkReadyForReview(
 	return platformgithub.NormalizePullRequest(ref, pr)
 }
 
-func (p gitHubClientProvider) ConvertMergeRequestToDraft(
+func (p *gitHubClientProvider) ConvertMergeRequestToDraft(
 	ctx context.Context,
 	ref platform.RepoRef,
 	number int,
@@ -1354,7 +1397,7 @@ func (p gitHubClientProvider) ConvertMergeRequestToDraft(
 	return nil
 }
 
-func (p gitHubClientProvider) CreateIssue(
+func (p *gitHubClientProvider) CreateIssue(
 	ctx context.Context,
 	ref platform.RepoRef,
 	title string,
@@ -1370,7 +1413,7 @@ func (p gitHubClientProvider) CreateIssue(
 	return platformgithub.NormalizeIssue(ref, issue)
 }
 
-func (p gitHubClientProvider) SetMergeRequestLabels(
+func (p *gitHubClientProvider) SetMergeRequestLabels(
 	ctx context.Context,
 	ref platform.RepoRef,
 	number int,
@@ -1379,7 +1422,7 @@ func (p gitHubClientProvider) SetMergeRequestLabels(
 	return p.setIssueLikeLabels(ctx, ref, number, names)
 }
 
-func (p gitHubClientProvider) SetIssueLabels(
+func (p *gitHubClientProvider) SetIssueLabels(
 	ctx context.Context,
 	ref platform.RepoRef,
 	number int,
@@ -1388,7 +1431,7 @@ func (p gitHubClientProvider) SetIssueLabels(
 	return p.setIssueLikeLabels(ctx, ref, number, names)
 }
 
-func (p gitHubClientProvider) setIssueLikeLabels(
+func (p *gitHubClientProvider) setIssueLikeLabels(
 	ctx context.Context,
 	ref platform.RepoRef,
 	number int,
@@ -1405,7 +1448,7 @@ func (p gitHubClientProvider) setIssueLikeLabels(
 	return platformgithub.NormalizeLabels(ref, labels), nil
 }
 
-func (p gitHubClientProvider) SetMergeRequestAssignees(
+func (p *gitHubClientProvider) SetMergeRequestAssignees(
 	ctx context.Context,
 	ref platform.RepoRef,
 	number int,
@@ -1414,7 +1457,7 @@ func (p gitHubClientProvider) SetMergeRequestAssignees(
 	return p.setIssueLikeAssignees(ctx, ref, number, usernames)
 }
 
-func (p gitHubClientProvider) SetIssueAssignees(
+func (p *gitHubClientProvider) SetIssueAssignees(
 	ctx context.Context,
 	ref platform.RepoRef,
 	number int,
@@ -1423,7 +1466,7 @@ func (p gitHubClientProvider) SetIssueAssignees(
 	return p.setIssueLikeAssignees(ctx, ref, number, usernames)
 }
 
-func (p gitHubClientProvider) setIssueLikeAssignees(
+func (p *gitHubClientProvider) setIssueLikeAssignees(
 	ctx context.Context,
 	ref platform.RepoRef,
 	number int,
@@ -1449,7 +1492,7 @@ func (p gitHubClientProvider) setIssueLikeAssignees(
 	return assignees, nil
 }
 
-func (p gitHubClientProvider) RequestMergeRequestReviewers(
+func (p *gitHubClientProvider) RequestMergeRequestReviewers(
 	ctx context.Context,
 	ref platform.RepoRef,
 	number int,
@@ -1481,7 +1524,7 @@ func (p gitHubClientProvider) RequestMergeRequestReviewers(
 	return githubRequestedReviewerLogins(pr), nil
 }
 
-func (p gitHubClientProvider) RemoveMergeRequestReviewers(
+func (p *gitHubClientProvider) RemoveMergeRequestReviewers(
 	ctx context.Context,
 	ref platform.RepoRef,
 	number int,
@@ -1516,7 +1559,7 @@ func githubRequestedReviewerLogins(pr *gh.PullRequest) []string {
 	return logins
 }
 
-func (p gitHubClientProvider) ApproveMergeRequest(
+func (p *gitHubClientProvider) ApproveMergeRequest(
 	ctx context.Context,
 	ref platform.RepoRef,
 	number int,
@@ -1542,7 +1585,7 @@ func (p gitHubClientProvider) ApproveMergeRequest(
 	return platformgithub.NormalizeReviewEvent(ref, number, review), nil
 }
 
-func (p gitHubClientProvider) ListMergeRequestReviewThreads(
+func (p *gitHubClientProvider) ListMergeRequestReviewThreads(
 	ctx context.Context,
 	ref platform.RepoRef,
 	number int,
@@ -1665,7 +1708,7 @@ func firstNonEmpty(values ...string) string {
 	return ""
 }
 
-func (p gitHubClientProvider) PublishDiffReviewDraft(
+func (p *gitHubClientProvider) PublishDiffReviewDraft(
 	ctx context.Context,
 	ref platform.RepoRef,
 	number int,
@@ -1748,7 +1791,7 @@ func githubDraftReviewComment(comment platform.LocalDiffReviewDraftComment) *gh.
 	return next
 }
 
-func (p gitHubClientProvider) EditMergeRequestContent(
+func (p *gitHubClientProvider) EditMergeRequestContent(
 	ctx context.Context,
 	ref platform.RepoRef,
 	number int,
@@ -1767,7 +1810,7 @@ func (p gitHubClientProvider) EditMergeRequestContent(
 	return platformgithub.NormalizePullRequest(ref, pr)
 }
 
-func (p gitHubClientProvider) EditIssueContent(
+func (p *gitHubClientProvider) EditIssueContent(
 	ctx context.Context,
 	ref platform.RepoRef,
 	number int,

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -705,15 +705,23 @@ func NewSyncerWithRegistry(
 }
 
 type gitHubClientProvider struct {
-	host        string
-	client      Client
-	viewerMu    sync.Mutex
-	viewerLogin string
+	host           string
+	client         Client
+	viewerMu       sync.Mutex
+	viewerLogin    string
+	viewerCacheAt  time.Time
+	viewerCacheKey string
 }
 
 type authenticatedViewerLoginClient interface {
 	AuthenticatedViewerLogin(ctx context.Context) (string, error)
 }
+
+type authenticatedViewerCacheKeyClient interface {
+	AuthenticatedViewerCacheKey() string
+}
+
+const authenticatedViewerLoginTTL = time.Minute
 
 type githubLabelClient interface {
 	ListRepoLabels(ctx context.Context, owner, repo string) ([]*gh.Label, error)
@@ -826,11 +834,16 @@ func (p *gitHubClientProvider) ViewerAuthoredMergeRequest(
 }
 
 func (p *gitHubClientProvider) authenticatedViewerLogin(ctx context.Context) (string, error) {
+	cacheKey := p.authenticatedViewerCacheKey()
+	now := time.Now()
 	p.viewerMu.Lock()
 	defer p.viewerMu.Unlock()
-	if p.viewerLogin != "" {
+	if p.viewerLogin != "" &&
+		p.viewerCacheKey == cacheKey &&
+		now.Sub(p.viewerCacheAt) < authenticatedViewerLoginTTL {
 		return p.viewerLogin, nil
 	}
+
 	client, ok := p.client.(authenticatedViewerLoginClient)
 	if !ok {
 		return "", fmt.Errorf("github client does not resolve authenticated viewer")
@@ -844,7 +857,17 @@ func (p *gitHubClientProvider) authenticatedViewerLogin(ctx context.Context) (st
 		return "", fmt.Errorf("authenticated viewer login is empty")
 	}
 	p.viewerLogin = login
+	p.viewerCacheAt = now
+	p.viewerCacheKey = cacheKey
 	return login, nil
+}
+
+func (p *gitHubClientProvider) authenticatedViewerCacheKey() string {
+	client, ok := p.client.(authenticatedViewerCacheKeyClient)
+	if !ok {
+		return ""
+	}
+	return client.AuthenticatedViewerCacheKey()
 }
 
 func (p *gitHubClientProvider) ListNotifications(

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -8201,7 +8201,7 @@ func TestDetailDrainDisambiguatesSameHostOwnerNameAcrossProviders(t *testing.T) 
 		},
 	}
 	registry, err := platform.NewRegistry(
-		gitHubClientProvider{host: host, client: githubClient},
+		&gitHubClientProvider{host: host, client: githubClient},
 		gitlabProvider,
 	)
 	require.NoError(err)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -489,6 +489,8 @@ type mockClient struct {
 	getPullRequestFn                func(context.Context, string, string, int) (*gh.PullRequest, error)
 	getIssueFn                      func(context.Context, string, string, int) (*gh.Issue, error)
 	getUserFn                       func(context.Context, string) (*gh.User, error)
+	authenticatedViewerLoginFn      func(context.Context) (string, error)
+	authenticatedViewerCalls        atomic.Int32
 	listReposByOwnerFn              func(context.Context, string) ([]*gh.Repository, error)
 	listReleases                    []*gh.RepositoryRelease
 	listReleasesErr                 error
@@ -847,6 +849,15 @@ func (m *mockClient) GetUser(ctx context.Context, login string) (*gh.User, error
 	return &gh.User{Login: &login, Name: &name}, nil
 }
 
+func (m *mockClient) AuthenticatedViewerLogin(ctx context.Context) (string, error) {
+	m.trackCall()
+	m.authenticatedViewerCalls.Add(1)
+	if m.authenticatedViewerLoginFn != nil {
+		return m.authenticatedViewerLoginFn(ctx)
+	}
+	return "", nil
+}
+
 func (m *mockClient) ListRepositoriesByOwner(
 	ctx context.Context, owner string,
 ) ([]*gh.Repository, error) {
@@ -1134,6 +1145,39 @@ func TestGitHubProviderPublishDiffReviewDraftApproveSubmitsReview(t *testing.T) 
 	assert.Equal("reviewed-head", mock.createdReviewCommitID)
 	require.Len(mock.createdReviewComments, 1)
 	assert.Equal("inline note", mock.createdReviewComments[0].GetBody())
+}
+
+func TestGitHubProviderViewerAuthoredMergeRequestCacheExpires(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	logins := []string{"marius", "octocat"}
+	mock := &mockClient{
+		authenticatedViewerLoginFn: func(context.Context) (string, error) {
+			next := logins[0]
+			logins = logins[1:]
+			return next, nil
+		},
+	}
+	provider := &gitHubClientProvider{client: mock, host: "github.com"}
+	mr := platform.MergeRequest{Author: "marius"}
+
+	authored, err := provider.ViewerAuthoredMergeRequest(t.Context(), mr)
+	require.NoError(err)
+	assert.True(authored)
+
+	authored, err = provider.ViewerAuthoredMergeRequest(t.Context(), mr)
+	require.NoError(err)
+	assert.True(authored)
+	assert.EqualValues(1, mock.authenticatedViewerCalls.Load())
+
+	provider.viewerMu.Lock()
+	provider.viewerCacheAt = time.Now().Add(-authenticatedViewerLoginTTL - time.Second)
+	provider.viewerMu.Unlock()
+
+	authored, err = provider.ViewerAuthoredMergeRequest(t.Context(), mr)
+	require.NoError(err)
+	assert.False(authored)
+	assert.EqualValues(2, mock.authenticatedViewerCalls.Load())
 }
 
 func TestGitHubProviderCapabilitiesExposeReviewThreadReads(t *testing.T) {

--- a/internal/platform/client.go
+++ b/internal/platform/client.go
@@ -27,6 +27,10 @@ type MergeRequestReader interface {
 	) ([]MergeRequestEvent, error)
 }
 
+type MergeRequestViewerResolver interface {
+	ViewerAuthoredMergeRequest(ctx context.Context, mr MergeRequest) (bool, error)
+}
+
 type IssueReader interface {
 	ListOpenIssues(ctx context.Context, ref RepoRef) ([]Issue, error)
 	GetIssue(ctx context.Context, ref RepoRef, number int) (Issue, error)

--- a/internal/platform/registry.go
+++ b/internal/platform/registry.go
@@ -92,6 +92,22 @@ func (r *Registry) MergeRequestReader(kind Kind, host string) (MergeRequestReade
 	return reader, nil
 }
 
+func (r *Registry) MergeRequestViewerResolver(
+	kind Kind,
+	host string,
+) (MergeRequestViewerResolver, error) {
+	provider, err := r.Provider(kind, host)
+	if err != nil {
+		return nil, err
+	}
+
+	resolver, ok := provider.(MergeRequestViewerResolver)
+	if !ok {
+		return nil, UnsupportedCapability(kind, host, "merge_request_viewer")
+	}
+	return resolver, nil
+}
+
 func (r *Registry) IssueReader(kind Kind, host string) (IssueReader, error) {
 	provider, err := r.Provider(kind, host)
 	if err != nil {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -13421,6 +13421,67 @@ func TestAPIGitHubPublishReviewDraftSendsCommentsThroughServer(t *testing.T) {
 	assert.Nil(storedDraft)
 }
 
+func TestAPIGitHubPublishReviewDraftRejectsSelfApprovalBeforeProvider(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	var publishCalls int
+	mock := &mockGH{
+		authenticatedViewerLoginFn: func(context.Context) (string, error) {
+			return "marius", nil
+		},
+		createReviewWithCommentsFn: func(
+			context.Context,
+			string, string,
+			int,
+			string,
+			string,
+			string,
+			[]*gh.DraftReviewComment,
+		) (*gh.PullRequestReview, error) {
+			publishCalls++
+			return nil, errors.New("provider should not be called")
+		},
+	}
+	srv, database := setupTestServerWithMock(t, mock)
+	seedPR(t, database, "acme", "widget", 42, withSeedPRAuthor("marius"))
+	mr, err := database.GetMergeRequest(ctx, "github", "github.com", "acme", "widget", 42)
+	require.NoError(err)
+	require.NotNil(mr)
+	require.NoError(database.UpdateDiffSHAs(ctx, mr.RepoID, 42, "github-head", "base", "merge-base"))
+
+	basePath := "/api/v1/pulls/gh/acme/widget/42/review-draft"
+	createRR := doJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
+		"body": "Please tighten this line.",
+		"range": map[string]any{
+			"path":          "src/main.go",
+			"side":          "right",
+			"line":          42,
+			"new_line":      42,
+			"line_type":     "add",
+			"diff_head_sha": "github-head",
+			"commit_sha":    "github-head",
+		},
+	})
+	require.Equal(http.StatusCreated, createRR.Code, createRR.Body.String())
+
+	publishRR := doJSON(t, srv, http.MethodPost, basePath+"/publish", map[string]string{
+		"action": "approve",
+		"body":   "looks good",
+	})
+	require.Equal(http.StatusForbidden, publishRR.Code, publishRR.Body.String())
+	var problem rawProblemDetail
+	require.NoError(json.NewDecoder(publishRR.Body).Decode(&problem))
+	assert.Equal("forbidden", problem.Code)
+	require.NotNil(problem.Details)
+	assert.Equal(availabilityCodeSelfApproval, problem.Details["reason"])
+	assert.Zero(publishCalls)
+
+	storedDraft, err := database.GetMRReviewDraft(ctx, mr.ID)
+	require.NoError(err)
+	assert.NotNil(storedDraft, "rejected self-approval must leave the local draft intact")
+}
+
 func TestAPIPublishReviewDraftRejectsStoredCommentWithoutDiffHeadSHA(t *testing.T) {
 	require := require.New(t)
 	caps := platform.Capabilities{

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -13482,6 +13482,75 @@ func TestAPIGitHubPublishReviewDraftRejectsSelfApprovalBeforeProvider(t *testing
 	assert.NotNil(storedDraft, "rejected self-approval must leave the local draft intact")
 }
 
+func TestAPIGitHubReviewDraftHidesApproveForSelfAuthoredPR(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	mock := &mockGH{
+		authenticatedViewerLoginFn: func(context.Context) (string, error) {
+			return "marius", nil
+		},
+	}
+	srv, database := setupTestServerWithMock(t, mock)
+	seedPR(t, database, "acme", "widget", 42, withSeedPRAuthor("marius"))
+	seedPR(t, database, "acme", "widget", 43, withSeedPRAuthor("someone-else"))
+
+	selfRR := doJSON(t, srv, http.MethodGet, "/api/v1/pulls/gh/acme/widget/42/review-draft", nil)
+	require.Equal(http.StatusOK, selfRR.Code, selfRR.Body.String())
+	var selfDraft map[string]any
+	require.NoError(json.NewDecoder(selfRR.Body).Decode(&selfDraft))
+	assert.Equal(
+		[]any{"comment", "request_changes"},
+		selfDraft["supported_actions"],
+		"self-authored PR draft must not advertise approve",
+	)
+
+	otherRR := doJSON(t, srv, http.MethodGet, "/api/v1/pulls/gh/acme/widget/43/review-draft", nil)
+	require.Equal(http.StatusOK, otherRR.Code, otherRR.Body.String())
+	var otherDraft map[string]any
+	require.NoError(json.NewDecoder(otherRR.Body).Decode(&otherDraft))
+	assert.Equal(
+		[]any{"comment", "approve", "request_changes"},
+		otherDraft["supported_actions"],
+		"other-authored PR draft must still advertise approve",
+	)
+}
+
+func TestAPIGitHubApprovePullRejectsSelfApprovalBeforeProvider(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	var providerCalled atomic.Bool
+	mock := &mockGH{
+		authenticatedViewerLoginFn: func(context.Context) (string, error) {
+			return "marius", nil
+		},
+		createReviewWithCommentsFn: func(
+			context.Context,
+			string, string,
+			int,
+			string, string, string,
+			[]*gh.DraftReviewComment,
+		) (*gh.PullRequestReview, error) {
+			providerCalled.Store(true)
+			return nil, errors.New("provider should not be called")
+		},
+	}
+	srv, database := setupTestServerWithMock(t, mock)
+	seedPR(t, database, "acme", "widget", 42, withSeedPRAuthor("marius"))
+
+	approveRR := doJSON(
+		t, srv, http.MethodPost,
+		"/api/v1/pulls/gh/acme/widget/42/approve",
+		map[string]any{"body": ""},
+	)
+	require.Equal(http.StatusForbidden, approveRR.Code, approveRR.Body.String())
+	var problem rawProblemDetail
+	require.NoError(json.NewDecoder(approveRR.Body).Decode(&problem))
+	assert.Equal("forbidden", problem.Code)
+	require.NotNil(problem.Details)
+	assert.Equal(availabilityCodeSelfApproval, problem.Details["reason"])
+	assert.False(providerCalled.Load(), "self-approval must be rejected before the provider call")
+}
+
 func TestAPIPublishReviewDraftRejectsStoredCommentWithoutDiffHeadSHA(t *testing.T) {
 	require := require.New(t)
 	caps := platform.Capabilities{

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -192,6 +192,8 @@ type mockGH struct {
 	getIssueIfChangedFn        func(context.Context, string, string, int, string) (*gh.Issue, string, bool, error)
 	createIssueFn              func(context.Context, string, string, string, string) (*gh.Issue, error)
 	getUserFn                  func(context.Context, string) (*gh.User, error)
+	authenticatedViewerLoginFn func(context.Context) (string, error)
+	authenticatedViewerCalls   int
 	markReadyForReviewFn       func(context.Context, string, string, int) (*gh.PullRequest, error)
 	convertToDraftFn           func(context.Context, string, string, int) (*gh.PullRequest, error)
 	dismissReviewFn            func(context.Context, string, string, int, int64, string) (*gh.PullRequestReview, error)
@@ -290,6 +292,14 @@ func (m *mockGH) GetUser(ctx context.Context, login string) (*gh.User, error) {
 		return m.getUserFn(ctx, login)
 	}
 	return &gh.User{Login: &login}, nil
+}
+
+func (m *mockGH) AuthenticatedViewerLogin(ctx context.Context) (string, error) {
+	m.authenticatedViewerCalls++
+	if m.authenticatedViewerLoginFn != nil {
+		return m.authenticatedViewerLoginFn(ctx)
+	}
+	return "", nil
 }
 
 func (m *mockGH) GetRateLimitSnapshot(ctx context.Context) (*ghclient.RateLimitSnapshot, error) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -1041,6 +1041,10 @@ func withSeedPRTitle(title string) seedPROpt {
 	return func(pr *db.MergeRequest) { pr.Title = title }
 }
 
+func withSeedPRAuthor(author string) seedPROpt {
+	return func(pr *db.MergeRequest) { pr.Author = author }
+}
+
 func withSeedPRLifecycle(
 	state db.MergeRequestState,
 	mergedAt *time.Time,

--- a/internal/server/diff_review_handlers.go
+++ b/internal/server/diff_review_handlers.go
@@ -30,7 +30,7 @@ func (s *Server) getDiffReviewDraft(
 	if err != nil {
 		return nil, huma.Error500InternalServerError("get review draft failed")
 	}
-	return &getDiffReviewDraftOutput{Body: s.diffReviewDraftResponse(*repo, draft)}, nil
+	return &getDiffReviewDraftOutput{Body: s.diffReviewDraftResponse(ctx, *repo, *mr, draft)}, nil
 }
 
 func (s *Server) createDiffReviewDraftComment(
@@ -547,13 +547,22 @@ func (s *Server) ingestDiffReviewThreads(
 }
 
 func (s *Server) diffReviewDraftResponse(
+	ctx context.Context,
 	repo db.Repo,
+	mr db.MergeRequest,
 	draft *db.MRReviewDraft,
 ) diffReviewDraftResponse {
 	caps := s.capabilitiesForRepo(repo)
+	supportedActions := caps.SupportedReviewActions
+	// A viewer cannot approve their own pull request, and the publish
+	// endpoint rejects such approvals. Drop approve from the advertised
+	// actions so the draft tray never offers an action that fails on submit.
+	if s.mergeRequestAuthoredByViewer(ctx, repo, mr) {
+		supportedActions = reviewActionsExcludingApprove(supportedActions)
+	}
 	resp := diffReviewDraftResponse{
 		Comments:              []diffReviewDraftComment{},
-		SupportedActions:      caps.SupportedReviewActions,
+		SupportedActions:      supportedActions,
 		NativeMultilineRanges: caps.NativeMultilineRanges,
 	}
 	if draft == nil {
@@ -784,4 +793,18 @@ func parseReviewAction(value string) (platform.ReviewAction, error) {
 
 func reviewActionSupported(caps providerCapabilitiesResponse, action platform.ReviewAction) bool {
 	return slices.Contains(caps.SupportedReviewActions, string(action))
+}
+
+// reviewActionsExcludingApprove returns a copy of actions with the approve
+// action removed. Used when the viewer authored the merge request so the
+// draft tray does not advertise an approval the publish endpoint will reject.
+func reviewActionsExcludingApprove(actions []string) []string {
+	filtered := make([]string, 0, len(actions))
+	for _, action := range actions {
+		if action == string(platform.ReviewActionApprove) {
+			continue
+		}
+		filtered = append(filtered, action)
+	}
+	return filtered
 }

--- a/internal/server/diff_review_handlers.go
+++ b/internal/server/diff_review_handlers.go
@@ -185,6 +185,9 @@ func (s *Server) publishDiffReviewDraft(
 	if !reviewActionSupported(caps, action) {
 		return nil, problemUnsupportedCapability(*repo, "review_action_"+string(action))
 	}
+	if action == platform.ReviewActionApprove && s.mergeRequestAuthoredByViewer(ctx, *repo, *mr) {
+		return nil, selfApprovalProblem(*repo)
+	}
 	draft, err := s.db.GetMRReviewDraft(ctx, mr.ID)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("get review draft failed")

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -2818,6 +2818,9 @@ func (s *Server) approvePR(ctx context.Context, input *approvePRInput) (*actionS
 	if mr == nil {
 		return nil, problemNotFound(CodePullNotFound, "pull request not found", nil)
 	}
+	if s.mergeRequestAuthoredByViewer(ctx, *repo, *mr) {
+		return nil, selfApprovalProblem(*repo)
+	}
 
 	expectedHeadSHA := approvalReviewHeadSHA(mr, input.Body.ExpectedHeadSHA)
 

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -1624,7 +1624,7 @@ func (s *Server) buildPullDetailResponse(
 	}
 	resp := mergeRequestDetailResponse{
 		Events:           eventResponses,
-		Repo:             s.repoRefWithOperations(*repo),
+		Repo:             s.repoRefWithMergeRequestOperations(ctx, *repo, *mr),
 		RepoOwner:        repo.Owner,
 		RepoName:         repo.Name,
 		PlatformHost:     repo.PlatformHost,

--- a/internal/server/operation_availability.go
+++ b/internal/server/operation_availability.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"go.kenn.io/middleman/internal/db"
+	"go.kenn.io/middleman/internal/platform"
 	"go.kenn.io/middleman/internal/ratelimit"
 	"go.kenn.io/middleman/internal/tokenauth"
 )
@@ -44,6 +46,7 @@ const (
 	availabilityCodeRateLimited            = "rate_limited"
 	availabilityCodeMissingWriteCredential = "missing_write_credential"
 	availabilityCodeWriteCredentialError   = "write_credential_error"
+	availabilityCodeSelfApproval           = "self_approval"
 )
 
 // apiBucket identifies which API quota an operation consumes. GitHub
@@ -117,6 +120,10 @@ type operationDescriptor struct {
 	bucket               apiBucket
 }
 
+type operationAvailabilityContext struct {
+	selfApproval bool
+}
+
 // Mutations are REST-served except ready-for-review, which GitHub
 // only exposes as a GraphQL mutation and therefore consumes the
 // GraphQL budget. The bucket field keeps each operation gated on the
@@ -160,6 +167,13 @@ var (
 // a paused GraphQL tracker does not block REST-backed operations
 // and vice versa.
 func (s *Server) repoOperations(repo db.Repo) RepoOperations {
+	return s.repoOperationsWithContext(repo, operationAvailabilityContext{})
+}
+
+func (s *Server) repoOperationsWithContext(
+	repo db.Repo,
+	opContext operationAvailabilityContext,
+) RepoOperations {
 	caps := s.capabilitiesForRepo(repo)
 	rates := map[apiBucket]rateLimitAvailability{
 		apiBucketREST:    s.mutationRateLimitedReason(repo, apiBucketREST),
@@ -167,8 +181,8 @@ func (s *Server) repoOperations(repo db.Repo) RepoOperations {
 	}
 	writeCred := s.writeCredentialGateForRepo(repo)
 	derive := func(op operationDescriptor) OperationAvailability {
-		return deriveOperationAvailability(
-			op, caps, repo, rates[op.bucket], writeCred,
+		return deriveOperationAvailabilityWithContext(
+			op, caps, repo, rates[op.bucket], writeCred, opContext,
 		)
 	}
 	return RepoOperations{
@@ -195,12 +209,25 @@ func (s *Server) repoOperations(repo db.Repo) RepoOperations {
 	}
 }
 
-func deriveOperationAvailability(
+func (s *Server) repoOperationsForMergeRequest(
+	ctx context.Context,
+	repo db.Repo,
+	mr db.MergeRequest,
+) RepoOperations {
+	opContext := operationAvailabilityContext{}
+	if s.viewerAuthoredMergeRequest(ctx, repo, mr) {
+		opContext.selfApproval = true
+	}
+	return s.repoOperationsWithContext(repo, opContext)
+}
+
+func deriveOperationAvailabilityWithContext(
 	op operationDescriptor,
 	caps providerCapabilitiesResponse,
 	repo db.Repo,
 	rate rateLimitAvailability,
 	writeCred writeCredentialGate,
+	opContext operationAvailabilityContext,
 ) OperationAvailability {
 	for _, capability := range op.requiredCapabilities {
 		if !capabilityEnabled(caps, capability) {
@@ -223,6 +250,9 @@ func deriveOperationAvailability(
 			UnavailableReason: "You do not have permission to merge in this repository",
 		}
 	}
+	if op.name == operationSubmitReview && opContext.selfApproval {
+		return selfApprovalUnavailable()
+	}
 	if rate.limited {
 		return OperationAvailability{
 			Code:              availabilityCodeRateLimited,
@@ -231,6 +261,43 @@ func deriveOperationAvailability(
 		}
 	}
 	return OperationAvailability{Available: true}
+}
+
+func selfApprovalUnavailable() OperationAvailability {
+	return OperationAvailability{
+		Code:              availabilityCodeSelfApproval,
+		UnavailableReason: "You cannot approve your own pull request",
+	}
+}
+
+func (s *Server) viewerAuthoredMergeRequest(
+	ctx context.Context,
+	repo db.Repo,
+	mr db.MergeRequest,
+) bool {
+	if repoProviderKind(repo) != platform.KindGitHub {
+		return false
+	}
+	author := strings.TrimSpace(mr.Author)
+	if author == "" {
+		return false
+	}
+	viewer := strings.TrimSpace(s.githubAuthenticatedLogin(ctx, repoProviderHost(repo)))
+	return viewer != "" && strings.EqualFold(viewer, author)
+}
+
+func (s *Server) githubAuthenticatedLogin(ctx context.Context, host string) string {
+	run := s.toolingRun
+	if run == nil {
+		run = defaultToolingRunner
+	}
+	out, err := runToolingProbe(
+		ctx, run, "gh", "api", "user", "--hostname", host, "--jq", ".login",
+	)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
 }
 
 // rateLimitAvailability is the result of consulting a rate tracker

--- a/internal/server/operation_availability.go
+++ b/internal/server/operation_availability.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"go.kenn.io/middleman/internal/db"
@@ -215,7 +214,7 @@ func (s *Server) repoOperationsForMergeRequest(
 	mr db.MergeRequest,
 ) RepoOperations {
 	opContext := operationAvailabilityContext{}
-	if s.viewerAuthoredMergeRequest(ctx, repo, mr) {
+	if s.mergeRequestAuthoredByViewer(ctx, repo, mr) {
 		opContext.selfApproval = true
 	}
 	return s.repoOperationsWithContext(repo, opContext)
@@ -270,34 +269,29 @@ func selfApprovalUnavailable() OperationAvailability {
 	}
 }
 
-func (s *Server) viewerAuthoredMergeRequest(
+func (s *Server) mergeRequestAuthoredByViewer(
 	ctx context.Context,
 	repo db.Repo,
 	mr db.MergeRequest,
 ) bool {
-	if repoProviderKind(repo) != platform.KindGitHub {
+	if s == nil || s.syncer == nil || s.syncer.Registry() == nil {
 		return false
 	}
-	author := strings.TrimSpace(mr.Author)
-	if author == "" {
-		return false
-	}
-	viewer := strings.TrimSpace(s.githubAuthenticatedLogin(ctx, repoProviderHost(repo)))
-	return viewer != "" && strings.EqualFold(viewer, author)
-}
-
-func (s *Server) githubAuthenticatedLogin(ctx context.Context, host string) string {
-	run := s.toolingRun
-	if run == nil {
-		run = defaultToolingRunner
-	}
-	out, err := runToolingProbe(
-		ctx, run, "gh", "api", "user", "--hostname", host, "--jq", ".login",
+	resolver, err := s.syncer.Registry().MergeRequestViewerResolver(
+		repoProviderKind(repo), repoProviderHost(repo),
 	)
 	if err != nil {
-		return ""
+		return false
 	}
-	return strings.TrimSpace(string(out))
+	authored, err := resolver.ViewerAuthoredMergeRequest(ctx, platform.MergeRequest{
+		Repo:   platformRepoRefFromDB(repo),
+		Number: mr.Number,
+		Author: mr.Author,
+	})
+	if err != nil {
+		return false
+	}
+	return authored
 }
 
 // rateLimitAvailability is the result of consulting a rate tracker

--- a/internal/server/operation_availability.go
+++ b/internal/server/operation_availability.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/danielgtaylor/huma/v2"
 	"go.kenn.io/middleman/internal/db"
 	"go.kenn.io/middleman/internal/platform"
 	"go.kenn.io/middleman/internal/ratelimit"
@@ -213,11 +214,15 @@ func (s *Server) repoOperationsForMergeRequest(
 	repo db.Repo,
 	mr db.MergeRequest,
 ) RepoOperations {
-	opContext := operationAvailabilityContext{}
-	if s.mergeRequestAuthoredByViewer(ctx, repo, mr) {
-		opContext.selfApproval = true
+	ops := s.repoOperationsWithContext(repo, operationAvailabilityContext{})
+	if !ops.SubmitReview.Available {
+		return ops
 	}
-	return s.repoOperationsWithContext(repo, opContext)
+	if !s.mergeRequestAuthoredByViewer(ctx, repo, mr) {
+		return ops
+	}
+	ops.SubmitReview = selfApprovalUnavailable()
+	return ops
 }
 
 func deriveOperationAvailabilityWithContext(
@@ -267,6 +272,17 @@ func selfApprovalUnavailable() OperationAvailability {
 		Code:              availabilityCodeSelfApproval,
 		UnavailableReason: "You cannot approve your own pull request",
 	}
+}
+
+func selfApprovalProblem(repo db.Repo) huma.StatusError {
+	return problemForbidden(
+		"You cannot approve your own pull request",
+		map[string]any{
+			"reason":       availabilityCodeSelfApproval,
+			"provider":     string(repoProviderKind(repo)),
+			"platformHost": repoProviderHost(repo),
+		},
+	)
 }
 
 func (s *Server) mergeRequestAuthoredByViewer(

--- a/internal/server/operation_availability_test.go
+++ b/internal/server/operation_availability_test.go
@@ -615,13 +615,13 @@ func TestAPIPullDetailOperationsDisableSelfApproval(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
-	srv, database := setupTestServer(t)
-	seedPR(t, database, "acme", "widget", 1, withSeedPRAuthor("marius"))
-	srv.toolingRun = (&recordingToolingRunner{
-		outputs: map[string]string{
-			"gh api user --hostname github.com --jq .login": "marius\n",
+	mock := &mockGH{
+		authenticatedViewerLoginFn: func(context.Context) (string, error) {
+			return "marius", nil
 		},
-	}).run
+	}
+	srv, database := setupTestServerWithMock(t, mock)
+	seedPR(t, database, "acme", "widget", 1, withSeedPRAuthor("marius"))
 
 	rr := doJSON(t, srv, http.MethodGet, "/api/v1/pulls/github/acme/widget/1", nil)
 	require.Equal(http.StatusOK, rr.Code)
@@ -635,4 +635,9 @@ func TestAPIPullDetailOperationsDisableSelfApproval(t *testing.T) {
 	assert.Equal(availabilityCodeSelfApproval, submitReview.Code)
 	assert.Equal("You cannot approve your own pull request", submitReview.UnavailableReason)
 	assert.True(resp.Repo.Operations.MergePR.Available)
+
+	rr = doJSON(t, srv, http.MethodGet, "/api/v1/pulls/github/acme/widget/1", nil)
+	require.Equal(http.StatusOK, rr.Code)
+	assert.Equal(1, mock.authenticatedViewerCalls,
+		"provider should cache the authenticated viewer login")
 }

--- a/internal/server/operation_availability_test.go
+++ b/internal/server/operation_availability_test.go
@@ -42,6 +42,10 @@ func TestDeriveOperationAvailability(t *testing.T) {
 		name:                 operationMergePR,
 		requiredCapabilities: []string{capabilityMergeMutation},
 	}
+	submitReview := operationDescriptor{
+		name:                 operationSubmitReview,
+		requiredCapabilities: []string{capabilityReviewMutation},
+	}
 	addLabel := operationDescriptor{
 		name:                 operationAddLabel,
 		requiredCapabilities: []string{capabilityReadLabels, capabilityLabelMutation},
@@ -62,6 +66,7 @@ func TestDeriveOperationAvailability(t *testing.T) {
 		repo      db.Repo
 		rate      rateLimitAvailability
 		writeCred writeCredentialGate
+		opContext operationAvailabilityContext
 		expected  OperationAvailability
 	}{
 		{
@@ -118,6 +123,17 @@ func TestDeriveOperationAvailability(t *testing.T) {
 			caps:     allCaps,
 			repo:     repoCannotMerge,
 			expected: OperationAvailability{Available: true},
+		},
+		{
+			name:      "viewer cannot approve own pull request",
+			op:        submitReview,
+			caps:      allCaps,
+			repo:      repoCanMerge,
+			opContext: operationAvailabilityContext{selfApproval: true},
+			expected: OperationAvailability{
+				Code:              availabilityCodeSelfApproval,
+				UnavailableReason: "You cannot approve your own pull request",
+			},
 		},
 		{
 			name: "review draft operation uses draft capability without requiring submitted reviews",
@@ -192,7 +208,9 @@ func TestDeriveOperationAvailability(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := deriveOperationAvailability(tc.op, tc.caps, tc.repo, tc.rate, tc.writeCred)
+			got := deriveOperationAvailabilityWithContext(
+				tc.op, tc.caps, tc.repo, tc.rate, tc.writeCred, tc.opContext,
+			)
 			require.Equal(t, tc.expected, got)
 		})
 	}
@@ -591,4 +609,30 @@ func TestAPIRepoResponseIncludesOperationsViewerCannotMerge(t *testing.T) {
 	// Other operations remain available because viewer_can_merge only
 	// gates merge_pr.
 	assert.True(resp.Operations.ClosePR.Available)
+}
+
+func TestAPIPullDetailOperationsDisableSelfApproval(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	srv, database := setupTestServer(t)
+	seedPR(t, database, "acme", "widget", 1, withSeedPRAuthor("marius"))
+	srv.toolingRun = (&recordingToolingRunner{
+		outputs: map[string]string{
+			"gh api user --hostname github.com --jq .login": "marius\n",
+		},
+	}).run
+
+	rr := doJSON(t, srv, http.MethodGet, "/api/v1/pulls/github/acme/widget/1", nil)
+	require.Equal(http.StatusOK, rr.Code)
+
+	var resp mergeRequestDetailResponse
+	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
+	require.NotNil(resp.Repo.Operations)
+
+	submitReview := resp.Repo.Operations.SubmitReview
+	assert.False(submitReview.Available)
+	assert.Equal(availabilityCodeSelfApproval, submitReview.Code)
+	assert.Equal("You cannot approve your own pull request", submitReview.UnavailableReason)
+	assert.True(resp.Repo.Operations.MergePR.Available)
 }

--- a/internal/server/operation_availability_test.go
+++ b/internal/server/operation_availability_test.go
@@ -558,10 +558,16 @@ func splitTestDescriptor(writeCandidate tokenauth.Candidate) tokenauth.Descripto
 func newSplitTestServer(
 	t *testing.T, writeCandidate tokenauth.Candidate,
 ) (*Server, *tokenauth.SourceSet) {
+	return newSplitTestServerWithMock(t, writeCandidate, &mockGH{})
+}
+
+func newSplitTestServerWithMock(
+	t *testing.T, writeCandidate tokenauth.Candidate, mock *mockGH,
+) (*Server, *tokenauth.SourceSet) {
 	t.Helper()
 	database := dbtest.Open(t)
 	syncer := ghclient.NewSyncer(
-		map[string]ghclient.Client{"github.com": &mockGH{}},
+		map[string]ghclient.Client{"github.com": mock},
 		database, nil,
 		[]ghclient.RepoRef{{Owner: "acme", Name: "widget", PlatformHost: "github.com"}},
 		time.Minute, nil, nil,
@@ -640,4 +646,26 @@ func TestAPIPullDetailOperationsDisableSelfApproval(t *testing.T) {
 	require.Equal(http.StatusOK, rr.Code)
 	assert.Equal(1, mock.authenticatedViewerCalls,
 		"provider should cache the authenticated viewer login")
+}
+
+func TestAPIPullDetailOperationsSkipViewerLookupWhenSubmitReviewUnavailable(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	t.Setenv("SPLIT_WRITE_CRED_PAT", "")
+	mock := &mockGH{}
+	srv, _ := newSplitTestServerWithMock(t, tokenauth.Candidate{
+		Kind: tokenauth.SourceKindEnv, EnvName: "SPLIT_WRITE_CRED_PAT",
+	}, mock)
+	seedPR(t, srv.db, "acme", "widget", 1, withSeedPRAuthor("marius"))
+
+	rr := doJSON(t, srv, http.MethodGet, "/api/v1/pulls/github/acme/widget/1", nil)
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+
+	var resp mergeRequestDetailResponse
+	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
+	require.NotNil(resp.Repo.Operations)
+	assert.Equal(availabilityCodeMissingWriteCredential, resp.Repo.Operations.SubmitReview.Code)
+	assert.Zero(mock.authenticatedViewerCalls,
+		"viewer lookup must not run when the write credential already blocks review submission")
 }

--- a/internal/server/repo_ref.go
+++ b/internal/server/repo_ref.go
@@ -119,6 +119,17 @@ func (s *Server) repoRefWithOperations(repo db.Repo) repoRefResponse {
 	return resp
 }
 
+func (s *Server) repoRefWithMergeRequestOperations(
+	ctx context.Context,
+	repo db.Repo,
+	mr db.MergeRequest,
+) repoRefResponse {
+	resp := s.repoRefFromRepo(repo)
+	ops := s.repoOperationsForMergeRequest(ctx, repo, mr)
+	resp.Operations = &ops
+	return resp
+}
+
 func (s *Server) repoResponse(repo db.Repo) repoResponse {
 	return repoResponse{
 		ID:                       repo.ID,


### PR DESCRIPTION
- Disables GitHub PR approval when the write-authenticated viewer authored the PR.
- Keeps viewer identity in the provider layer with bounded caching.
- Rejects self-approval through review-draft publish before provider comments are created.

<sup>generated by a clanker</sup>