### PR TITLE
fix: keep pierre diffs visible while the shared highlight pool is busy

### DIFF
--- a/packages/ui/src/components/diff/PierreFileDiff.svelte
+++ b/packages/ui/src/components/diff/PierreFileDiff.svelte
@@ -904,9 +904,11 @@
     return !syntaxHighlightWorkerHasPendingWork();
   }
 
-  // Mirrors Pierre's isDiffPlainText/isDiffMassive checks: these diffs render
-  // without styled spans, so waiting on worker-pool idleness would hide them
-  // for as long as any other file still has highlight tasks queued.
+  // Mirrors Pierre's isDiffPlainText/isDiffMassive checks, which @pierre/diffs
+  // does not export as of 1.2.11: these diffs render without styled spans, so
+  // waiting on worker-pool idleness would hide them for as long as any other
+  // file still has highlight tasks queued. Recheck this mirror (and whether
+  // upstream now exports the helpers) when bumping @pierre/diffs.
   function diffRendersPlainText(): boolean {
     const fileDiff = fullContextFileDiff ?? pierreFile;
     if (!fileDiff) return false;

--- a/packages/ui/src/components/diff/PierreFileDiff.svelte
+++ b/packages/ui/src/components/diff/PierreFileDiff.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { FileDiff, VirtualizedFileDiff } from "@pierre/diffs";
+  import { DEFAULT_TOKENIZE_MAX_LENGTH, FileDiff, VirtualizedFileDiff } from "@pierre/diffs";
   import type {
     DiffLineAnnotation,
     ExpansionDirections,
@@ -881,9 +881,12 @@
     applyLineCommentButtons();
     syncLineAnnotationWrappers();
 
-    const ready = renderedDomReady();
-    rendered = ready;
-    if (!ready) return false;
+    // Latch visibility: scroll-driven virtualized re-renders fire onPostRender
+    // too, and the shared worker pool being busy must not hide content that
+    // this render attempt has already shown. Attempt boundaries reset the
+    // latch by assigning `rendered = false` before rendering.
+    if (renderedDomReady()) rendered = true;
+    if (!rendered) return false;
 
     installDemandContextHandler();
     scheduleSelectedRangesApplication();
@@ -896,8 +899,19 @@
 
   function renderedDomReady(): boolean {
     if (!syntaxHighlightWorkerActive) return true;
+    if (diffRendersPlainText()) return true;
     if (host?.shadowRoot?.querySelector("[data-line] span[style]") != null) return true;
     return !syntaxHighlightWorkerHasPendingWork();
+  }
+
+  // Mirrors Pierre's isDiffPlainText/isDiffMassive checks: these diffs render
+  // without styled spans, so waiting on worker-pool idleness would hide them
+  // for as long as any other file still has highlight tasks queued.
+  function diffRendersPlainText(): boolean {
+    const fileDiff = fullContextFileDiff ?? pierreFile;
+    if (!fileDiff) return false;
+    if (fileDiff.lang === "text") return true;
+    return Math.max(fileDiff.additionLines.length, fileDiff.deletionLines.length) > DEFAULT_TOKENIZE_MAX_LENGTH;
   }
 
   function syntaxHighlightWorkerHasPendingWork(): boolean {

--- a/packages/ui/src/components/diff/PierreFileDiff.svelte
+++ b/packages/ui/src/components/diff/PierreFileDiff.svelte
@@ -874,7 +874,46 @@
     return pierreDiff.render(props);
   }
 
+  // Diagnostic for the scroll-position-deterministic blank-band bug: Pierre's
+  // virtual window math places hunks by estimated line positions, and when its
+  // believed file top/height drift from the real DOM it can compute a render
+  // range that misses the viewport (blank spacer where content belongs).
+  // Logging believed-vs-real geometry on every post-render lets a ?debugDiff=1
+  // session show which quantity is off at the moment a band blanks.
+  function debugVirtualizedRenderState(): void {
+    if (!pierreDiffDebugEnabled()) return;
+    if (!host || !(pierreDiff instanceof VirtualizedFileDiff)) return;
+    const instance = pierreDiff as unknown as {
+      height?: number;
+      renderRange?: { bufferAfter: number; bufferBefore: number; startingLine: number; totalLines: number };
+      top?: number;
+    };
+    const area = host.closest(".diff-area");
+    const hostRect = host.getBoundingClientRect();
+    const areaRect = area?.getBoundingClientRect();
+    const scrollTop = area instanceof HTMLElement ? area.scrollTop : undefined;
+    const realTop = areaRect && scrollTop != null ? hostRect.top - areaRect.top + scrollTop : undefined;
+    const windowSpecs = (
+      virtualizer as unknown as { getWindowSpecs?: () => { bottom: number; top: number } } | undefined
+    )?.getWindowSpecs?.();
+    debugPierreDiff("virtualized post-render", {
+      path: renderFile.path,
+      believedTop: instance.top,
+      realTop,
+      topDrift: instance.top != null && realTop != null ? instance.top - realTop : undefined,
+      believedHeight: instance.height,
+      realHeight: hostRect.height,
+      heightDrift: instance.height != null ? instance.height - hostRect.height : undefined,
+      renderRange: instance.renderRange,
+      windowSpecs,
+      scrollTop,
+      viewportHeight: areaRect?.height,
+      hostInViewport: isHostInScrollViewport(),
+    });
+  }
+
   function finalizeRenderedDom(): boolean {
+    debugVirtualizedRenderState();
     removeStalePlaceholderPres();
     applyLineTargetAttributes();
     applyHunkHeaderLabels();

--- a/packages/ui/src/components/diff/PierreFileDiff.test.ts
+++ b/packages/ui/src/components/diff/PierreFileDiff.test.ts
@@ -555,6 +555,28 @@ describe("PierreFileDiff", () => {
     expect(document.querySelector(".pierre-diff-loading")).toBeNull();
   });
 
+  it("shows massive diffs beyond the tokenize cap without waiting for the highlight pool", async () => {
+    const { default: PierreFileDiff } = await import("./PierreFileDiff.svelte");
+    workerPool.set(makeBusyWorkerPool());
+    // Pierre forces plain-text rendering past DEFAULT_TOKENIZE_MAX_LENGTH
+    // (100k lines), so styled spans never appear for this file either.
+    pierre.setMetadata({
+      ...pierre.metadata,
+      additionLines: Array.from({ length: 100_001 }, () => "line\n"),
+    });
+
+    render(PierreFileDiff, {
+      props: { file: makeFile() },
+    });
+
+    await waitFor(() => {
+      expect(pierre.renderCount()).toBe(1);
+      expect(document.querySelector(".pierre-diff-shell")?.getAttribute("aria-busy")).toBe("false");
+    });
+
+    expect(document.querySelector(".pierre-diff-loading")).toBeNull();
+  });
+
   it("rerenders when annotation metadata changes without moving lines", async () => {
     const { default: PierreFileDiff } = await import("./PierreFileDiff.svelte");
     const file = makeFile();

--- a/packages/ui/src/components/diff/PierreFileDiff.test.ts
+++ b/packages/ui/src/components/diff/PierreFileDiff.test.ts
@@ -469,6 +469,32 @@ describe("PierreFileDiff", () => {
     }
   });
 
+  it("logs virtualized render geometry when diff debugging is enabled", async () => {
+    const { default: PierreFileDiff } = await import("./PierreFileDiff.svelte");
+    window.localStorage.setItem("middleman:debug:diff", "1");
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+
+    try {
+      render(PierreFileDiff, {
+        props: { file: makeFile(), virtualizer: { type: "simple" } as never },
+      });
+
+      const call = await waitFor(() => {
+        const found = debugSpy.mock.calls.find(
+          ([tag, message]) => tag === "[middleman:diff]" && message === "virtualized post-render",
+        );
+        expect(found).toBeTruthy();
+        return found!;
+      });
+      expect(call[2]).toMatchObject({ path: "src/foo.ts" });
+      expect(call[2]).toHaveProperty("believedTop");
+      expect(call[2]).toHaveProperty("renderRange");
+    } finally {
+      debugSpy.mockRestore();
+      window.localStorage.removeItem("middleman:debug:diff");
+    }
+  });
+
   it("passes split diff style to Pierre when side-by-side mode is enabled", async () => {
     const { default: PierreFileDiff } = await import("./PierreFileDiff.svelte");
 

--- a/packages/ui/src/components/diff/PierreFileDiff.test.ts
+++ b/packages/ui/src/components/diff/PierreFileDiff.test.ts
@@ -37,6 +37,7 @@ const pierre = (() => {
     virtualized: 0,
   };
   let renderResults: boolean[] = [];
+  let shadowHtml: string | undefined;
   let events: string[] = [];
   let lastExpansion:
     | {
@@ -56,7 +57,9 @@ const pierre = (() => {
     events.push(`render:${String(didRender)}`);
     if (didRender && props?.fileContainer) {
       const root = props.fileContainer.shadowRoot ?? props.fileContainer.attachShadow({ mode: "open" });
-      root.innerHTML = `
+      root.innerHTML =
+        shadowHtml ??
+        `
         <pre data-diff-type="unified">
           <code data-unified>
             <div data-gutter>
@@ -132,6 +135,7 @@ const pierre = (() => {
       lastExpansion = undefined;
       events = [];
       renderResults = [];
+      shadowHtml = undefined;
       lastOptions = undefined;
       lastVirtualizer = undefined;
       parsedMetadata = metadata;
@@ -141,6 +145,9 @@ const pierre = (() => {
     },
     setRenderResults: (results: boolean[]) => {
       renderResults = [...results];
+    },
+    setShadowHtml: (html: string | undefined) => {
+      shadowHtml = html;
     },
     virtualizedCount: () => counts.virtualized,
     VirtualizedFileDiff,
@@ -158,9 +165,29 @@ vi.doMock("@pierre/diffs", async (importOriginal) => {
   };
 });
 
+const workerPool = (() => {
+  let current: unknown;
+  return {
+    get: () => current,
+    reset: () => {
+      current = undefined;
+    },
+    set: (pool: unknown) => {
+      current = pool;
+    },
+  };
+})();
+
+function makeBusyWorkerPool(): unknown {
+  return {
+    getStats: () => ({ activeTasks: 0, queuedTasks: 1 }),
+    subscribeToStatChanges: () => () => {},
+  };
+}
+
 vi.doMock("./pierre-worker-pool.js", () => ({
   diffTokenizeMaxLineLength: 180,
-  getPierreDiffWorkerPool: () => undefined,
+  getPierreDiffWorkerPool: () => workerPool.get(),
   syntaxHighlightingDisabledForAutomation: () => false,
 }));
 
@@ -288,6 +315,7 @@ describe("PierreFileDiff", () => {
     vi.useRealTimers();
     cleanup();
     pierre.reset();
+    workerPool.reset();
   });
 
   it("uses Pierre virtualized diffs when a viewer virtualizer is provided", async () => {
@@ -468,6 +496,63 @@ describe("PierreFileDiff", () => {
     });
 
     expect(pierre.lastOptions()?.tokenizeMaxLineLength).toBe(diffTokenizeMaxLineLength);
+  });
+
+  it("keeps shown content visible when a later post-render has no highlighted spans", async () => {
+    const { default: PierreFileDiff } = await import("./PierreFileDiff.svelte");
+    workerPool.set(makeBusyWorkerPool());
+    pierre.setShadowHtml(`
+      <pre data-diff-type="unified">
+        <code data-unified>
+          <div data-gutter>
+            <div data-line-index="0" data-line-type="change-addition"></div>
+          </div>
+          <div data-content>
+            <div data-line data-line-index="0" data-line-type="change-addition">
+              <span style="color: red">func newName() {}</span>
+            </div>
+          </div>
+        </code>
+      </pre>
+    `);
+
+    render(PierreFileDiff, {
+      props: { file: makeFile() },
+    });
+
+    const shell = await waitFor(() => {
+      const el = document.querySelector(".pierre-diff-shell");
+      expect(el?.getAttribute("aria-busy")).toBe("false");
+      return el!;
+    });
+
+    // Simulate a scroll-driven Pierre re-render whose rendered window has no
+    // highlighted spans yet while the shared worker pool is still busy.
+    const container = document.querySelector<HTMLElement>(".pierre-diff")!;
+    for (const span of container.shadowRoot?.querySelectorAll("[data-line] span[style]") ?? []) {
+      span.removeAttribute("style");
+    }
+    pierre.lastOptions()?.onPostRender?.(container, undefined as never, "update" as never);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(shell.getAttribute("aria-busy")).toBe("false");
+    expect(document.querySelector(".pierre-diff-loading")).toBeNull();
+  });
+
+  it("shows plain-text diffs without waiting for the shared highlight pool to drain", async () => {
+    const { default: PierreFileDiff } = await import("./PierreFileDiff.svelte");
+    workerPool.set(makeBusyWorkerPool());
+
+    render(PierreFileDiff, {
+      props: { file: { ...makeFile(), path: "notes.txt", old_path: "notes.txt" } },
+    });
+
+    await waitFor(() => {
+      expect(pierre.renderCount()).toBe(1);
+      expect(document.querySelector(".pierre-diff-shell")?.getAttribute("aria-busy")).toBe("false");
+    });
+
+    expect(document.querySelector(".pierre-diff-loading")).toBeNull();
   });
 
   it("rerenders when annotation metadata changes without moving lines", async () => {


### PR DESCRIPTION
Scrolling a large PR diff could intermittently show nothing where a file's content should be. Every virtualizer-driven Pierre re-render fires `onPostRender`, and the wrapper's readiness gate re-evaluated visibility each time using pool-global syntax-highlight worker stats. A rendered window with no highlighted span yet — a freshly scrolled-into region, a plain-text file, or an evicted highlight-cache entry — combined with any *other* file's queued highlight task flipped the already-visible component back to `visibility: hidden`. The loading spinner is centered over the whole file shell, so on a viewport-tall file it sits offscreen and the user just sees blank space until the pool drains.

- The `rendered` flag now latches per render attempt: once content has been shown, later post-renders cannot hide it. Attempt boundaries (file change, view-mode change, full-context re-render) still reset the latch, so initial loading behavior is unchanged.
- Diffs that render without styled spans — `lang: text`, or massive diffs beyond Pierre's tokenize cap — are treated as ready immediately; waiting for pool idleness can never make them more ready.

Both regression tests fail against the unfixed component. This does not address a second, scroll-position-deterministic blanking variant (a band toggling with 1px scrolls) that points at Pierre's virtual window math and needs separate instrumentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)