### PR TITLE
Fix merged timeline actor copy

### DIFF
--- a/frontend/src/App.pr-timeline-filters.browser.svelte.ts
+++ b/frontend/src/App.pr-timeline-filters.browser.svelte.ts
@@ -339,7 +339,8 @@ describe("PR timeline filters", () => {
     const mergedRows = inDetail(".event--compact").filter((el) => (el.textContent ?? "").includes("Merged"));
     expect(mergedRows.length).toBe(1);
     expect(mergedRows[0]!.textContent ?? "").toContain("alice");
-    expect(mergedRows[0]!.textContent ?? "").toContain("merged this");
+    expect(mergedRows[0]!.textContent ?? "").toContain("by alice");
+    expect(mergedRows[0]!.textContent ?? "").not.toContain("merged this");
     const mergedType = mergedRows[0]!.querySelector(".event-type");
     expect(mergedType?.getAttribute("style") ?? "").toContain("var(--accent-purple)");
     expect(mergedRows[0]!.querySelector(".dot")?.getAttribute("style") ?? "").toContain("var(--accent-purple)");

--- a/frontend/tests/e2e-full/pr-timeline-filters.spec.ts
+++ b/frontend/tests/e2e-full/pr-timeline-filters.spec.ts
@@ -173,7 +173,10 @@ test.describe("PR timeline filters", () => {
       .toBe("compact");
 
     await openPRTimelinePath(page, "/pulls/github/acme/tools/2");
-    await expect(page.locator(".pull-detail .event-card--compact-row").first()).toBeVisible();
+    const mergedRows = page.locator(".pull-detail .event-card--compact-row", { hasText: "MERGED" });
+    await expect(mergedRows).toHaveCount(1);
+    await expect(mergedRows.first()).toContainText("by alice");
+    await expect(mergedRows.first()).not.toContainText("merged this");
 
     await openIssueTimeline(page);
     await expect(page.locator(".issue-detail").getByRole("button", { name: "View", exact: true })).toContainText(

--- a/internal/github/graphql.go
+++ b/internal/github/graphql.go
@@ -47,6 +47,7 @@ type gqlPR struct {
 	CreatedAt      time.Time
 	UpdatedAt      time.Time
 	MergedAt       *time.Time
+	MergedBy       *struct{ Login string }
 	ClosedAt       *time.Time
 	Additions      int
 	Deletions      int
@@ -390,6 +391,9 @@ func adaptPR(gql *gqlPR) *gh.PullRequest {
 		t := gh.Timestamp{Time: *gql.MergedAt}
 		pr.MergedAt = &t
 		pr.Merged = new(true)
+	}
+	if gql.MergedBy != nil {
+		pr.MergedBy = &gh.User{Login: new(gql.MergedBy.Login)}
 	}
 	if gql.ClosedAt != nil {
 		t := gh.Timestamp{Time: *gql.ClosedAt}

--- a/internal/github/graphql_test.go
+++ b/internal/github/graphql_test.go
@@ -45,6 +45,7 @@ func TestAdaptPR(t *testing.T) {
 	}
 	gql.Author.Login = "alice"
 	gql.MergedAt = &merged
+	gql.MergedBy = &struct{ Login string }{Login: "merge-admin"}
 	gql.HeadRepository = &struct{ URL string }{URL: "https://github.com/o/r"}
 
 	pr := adaptPR(&gql)
@@ -68,6 +69,7 @@ func TestAdaptPR(t *testing.T) {
 	assert.Equal("clean", pr.GetMergeableState())
 	require.NotNil(t, pr.MergedAt)
 	assert.True(pr.GetMerged())
+	assert.Equal("merge-admin", pr.GetMergedBy().GetLogin())
 }
 
 func TestAdaptComment(t *testing.T) {

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -8637,12 +8637,7 @@ func (s *Syncer) authoredMergedLifecycleEventExists(
 }
 
 func authoredMergedLifecycleEventExists(events []db.MREvent) bool {
-	for _, event := range events {
-		if isAuthoredMergedLifecycleEvent(event) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(events, isAuthoredMergedLifecycleEvent)
 }
 
 func isAuthoredMergedLifecycleEvent(event db.MREvent) bool {

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -8381,10 +8381,14 @@ func (s *Syncer) persistMergedTransitionEvent(
 	ghPR *gh.PullRequest,
 	mergedAt *time.Time,
 ) error {
-	if !pullRequestWasMerged(ghPR) || mergedAt == nil {
+	if ghPR == nil || mergedAt == nil || !pullRequestWasMerged(ghPR) {
 		return nil
 	}
-	actor := ghPR.GetMergedBy().GetLogin()
+	mergedBy := ghPR.GetMergedBy()
+	if mergedBy == nil {
+		return nil
+	}
+	actor := mergedBy.GetLogin()
 	if actor == "" {
 		return nil
 	}

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -8617,7 +8617,7 @@ func (s *Syncer) filterDuplicateMergedLifecycleEvents(
 	out := events[:0]
 	for _, event := range events {
 		if isAuthoredMergedLifecycleEvent(event) &&
-			authoredMergedLifecycleEventExistsAt(existing, event.CreatedAt) {
+			authoredMergedLifecycleEventExists(existing) {
 			continue
 		}
 		out = append(out, event)
@@ -8625,26 +8625,20 @@ func (s *Syncer) filterDuplicateMergedLifecycleEvents(
 	return out, nil
 }
 
-func (s *Syncer) authoredMergedLifecycleEventExistsAt(
+func (s *Syncer) authoredMergedLifecycleEventExists(
 	ctx context.Context,
 	mrID int64,
-	mergedAt time.Time,
 ) (bool, error) {
 	events, err := s.db.ListMREvents(ctx, mrID)
 	if err != nil {
 		return false, err
 	}
-	return authoredMergedLifecycleEventExistsAt(events, mergedAt), nil
+	return authoredMergedLifecycleEventExists(events), nil
 }
 
-func authoredMergedLifecycleEventExistsAt(
-	events []db.MREvent,
-	mergedAt time.Time,
-) bool {
-	mergedAt = mergedAt.UTC()
+func authoredMergedLifecycleEventExists(events []db.MREvent) bool {
 	for _, event := range events {
-		if isAuthoredMergedLifecycleEvent(event) &&
-			event.CreatedAt.UTC().Equal(mergedAt) {
+		if isAuthoredMergedLifecycleEvent(event) {
 			return true
 		}
 	}
@@ -8673,7 +8667,7 @@ func (s *Syncer) persistMergedTransitionEvent(
 	if actor == "" {
 		return false, nil
 	}
-	exists, err := s.authoredMergedLifecycleEventExistsAt(ctx, mrID, *mergedAt)
+	exists, err := s.authoredMergedLifecycleEventExists(ctx, mrID)
 	if err != nil {
 		return false, err
 	}

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -5421,6 +5421,13 @@ func (s *Syncer) fetchMRDetail(
 	calls++
 	if err == nil && fullPR == nil {
 		if notModified && existing != nil {
+			backfillCalls, backfillErr := s.backfillMergedActorAfterUnchangedDetail(
+				ctx, client, repo, existing,
+			)
+			calls += backfillCalls
+			if backfillErr != nil {
+				return calls, backfillErr
+			}
 			return s.markUnchangedMRDetailFetched(
 				ctx, repo, repoID, number, existing, calls,
 			)
@@ -5654,6 +5661,70 @@ func (s *Syncer) markUnchangedMRDetailFetched(
 		}
 	}
 	return calls, nil
+}
+
+func (s *Syncer) backfillMergedActorAfterUnchangedDetail(
+	ctx context.Context,
+	client Client,
+	repo RepoRef,
+	existing *db.MergeRequest,
+) (int, error) {
+	needed, err := s.mergedActorBackfillNeeded(ctx, existing)
+	if err != nil {
+		return 0, err
+	}
+	if !needed {
+		return 0, nil
+	}
+	fullPR, err := client.GetPullRequest(
+		ctx, repo.Owner, repo.Name, existing.Number,
+	)
+	if err != nil {
+		return 1, fmt.Errorf(
+			"get PR #%d for merged actor backfill: %w",
+			existing.Number, err,
+		)
+	}
+	if fullPR == nil {
+		return 1, fmt.Errorf(
+			"get PR #%d for merged actor backfill: client returned nil pull request",
+			existing.Number,
+		)
+	}
+	if err := s.persistMergedTransitionEvent(
+		ctx, existing.ID, fullPR, existing.MergedAt,
+	); err != nil {
+		return 1, fmt.Errorf(
+			"persist merged lifecycle event for MR #%d: %w",
+			existing.Number, err,
+		)
+	}
+	return 1, nil
+}
+
+func (s *Syncer) mergedActorBackfillNeeded(
+	ctx context.Context,
+	existing *db.MergeRequest,
+) (bool, error) {
+	if existing == nil ||
+		existing.State != db.MergeRequestStateMerged ||
+		existing.MergedAt == nil {
+		return false, nil
+	}
+	events, err := s.db.ListMREvents(ctx, existing.ID)
+	if err != nil {
+		return false, fmt.Errorf(
+			"list merged lifecycle events for MR #%d: %w",
+			existing.Number, err,
+		)
+	}
+	for _, event := range events {
+		if event.EventType == "merged" &&
+			strings.TrimSpace(event.Author) != "" {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 func (s *Syncer) fetchProviderMRDetail(
@@ -7739,6 +7810,11 @@ func (s *Syncer) syncMRForRepo(
 			)
 			if err == nil && ghPR == nil {
 				if notModified && existing != nil {
+					if _, backfillErr := s.backfillMergedActorAfterUnchangedDetail(
+						ctx, client, repo, existing,
+					); backfillErr != nil {
+						return backfillErr
+					}
 					_, err := s.markUnchangedMRDetailFetched(
 						ctx, repo, repoID, number, existing, 1,
 					)

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -5208,6 +5208,10 @@ func (s *Syncer) syncOpenMRFromBulk(
 			events = append(events, *event)
 		}
 	}
+	events, err = s.filterDuplicateMergedLifecycleEvents(ctx, mrID, events)
+	if err != nil {
+		return fmt.Errorf("dedupe merged lifecycle events for MR #%d: %w", number, err)
+	}
 	if bulk.CommentsComplete {
 		if err := s.replacePRCommentEvents(ctx, mrID, bulk.Comments); err != nil {
 			return fmt.Errorf(
@@ -5219,6 +5223,9 @@ func (s *Syncer) syncOpenMRFromBulk(
 		return fmt.Errorf(
 			"upsert events for MR #%d: %w", number, err,
 		)
+	}
+	if err := s.persistMergedTransitionEvent(ctx, mrID, bulk.PR, normalized.MergedAt); err != nil {
+		return fmt.Errorf("persist merged lifecycle event for MR #%d: %w", number, err)
 	}
 
 	// CI status — only write if complete (don't write
@@ -5465,9 +5472,6 @@ func (s *Syncer) fetchMRDetail(
 			"upsert MR #%d: %w", number, err,
 		)
 	}
-	if err := s.persistMergedTransitionEvent(ctx, mrID, fullPR, normalized.MergedAt); err != nil {
-		return calls, fmt.Errorf("persist merged lifecycle event for MR #%d: %w", number, err)
-	}
 	if err := s.replaceMergeRequestLabels(ctx, repoID, mrID, normalized.Labels); err != nil {
 		return calls, fmt.Errorf("persist labels for MR #%d: %w", number, err)
 	}
@@ -5519,6 +5523,9 @@ func (s *Syncer) fetchMRDetail(
 		return calls, err
 	}
 	calls += 4
+	if err := s.persistMergedTransitionEvent(ctx, mrID, fullPR, normalized.MergedAt); err != nil {
+		return calls, fmt.Errorf("persist merged lifecycle event for MR #%d: %w", number, err)
+	}
 
 	ciHeadSHA := ""
 	if fullPR.GetHead() != nil {
@@ -5725,6 +5732,53 @@ func (s *Syncer) mergedActorBackfillNeeded(
 		}
 	}
 	return true, nil
+}
+
+// BackfillMergedActorForDetail fills the merge lifecycle actor for stale rows
+// before the DB-backed detail response is built. It deliberately does only the
+// one PR request needed to read GitHub's MergedBy field; full detail sync still
+// owns comments, reviews, commits, and checks.
+func (s *Syncer) BackfillMergedActorForDetail(
+	ctx context.Context,
+	existing *db.MergeRequest,
+) (bool, error) {
+	needed, err := s.mergedActorBackfillNeeded(ctx, existing)
+	if err != nil || !needed {
+		return false, err
+	}
+	repoRow, err := s.db.GetRepoByID(ctx, existing.RepoID)
+	if err != nil {
+		return false, fmt.Errorf(
+			"get repo for merged actor backfill on MR #%d: %w",
+			existing.Number, err,
+		)
+	}
+	if repoRow == nil {
+		return false, nil
+	}
+	kind := platform.Kind(repoRow.Platform)
+	if kind != platform.KindGitHub {
+		return false, nil
+	}
+	repo := RepoRef{
+		Platform:      kind,
+		PlatformHost:  repoRow.PlatformHost,
+		Owner:         repoRow.Owner,
+		Name:          repoRow.Name,
+		RepoPath:      repoRow.RepoPath,
+		WebURL:        repoRow.WebURL,
+		CloneURL:      repoRow.CloneURL,
+		DefaultBranch: repoRow.DefaultBranch,
+	}
+	client, err := s.clientFor(repo)
+	if err != nil {
+		return false, fmt.Errorf(
+			"resolve client for merged actor backfill on MR #%d: %w",
+			existing.Number, err,
+		)
+	}
+	calls, err := s.backfillMergedActorAfterUnchangedDetail(ctx, client, repo, existing)
+	return calls > 0, err
 }
 
 func (s *Syncer) fetchProviderMRDetail(
@@ -6249,6 +6303,10 @@ func (s *Syncer) refreshTimeline(
 			continue
 		}
 		events = append(events, *event)
+	}
+	events, err = s.filterDuplicateMergedLifecycleEvents(ctx, mrID, events)
+	if err != nil {
+		return fmt.Errorf("dedupe merged lifecycle events for MR #%d: %w", number, err)
 	}
 
 	if err := s.replacePRCommentEvents(ctx, mrID, comments); err != nil {
@@ -7888,11 +7946,6 @@ func (s *Syncer) syncMRForRepo(
 	if err != nil {
 		return fmt.Errorf("upsert MR #%d: %w", number, err)
 	}
-	if ghPR != nil {
-		if err := s.persistMergedTransitionEvent(ctx, mrID, ghPR, normalized.MergedAt); err != nil {
-			return fmt.Errorf("persist merged lifecycle event for MR #%d: %w", number, err)
-		}
-	}
 	if err := s.markClosedLinkedNotificationsDone(ctx); err != nil {
 		return err
 	}
@@ -7921,6 +7974,9 @@ func (s *Syncer) syncMRForRepo(
 
 		if err := s.refreshTimeline(ctx, repo, repoID, mrID, ghPR); err != nil {
 			return fmt.Errorf("refresh timeline for MR #%d: %w", number, err)
+		}
+		if err := s.persistMergedTransitionEvent(ctx, mrID, ghPR, normalized.MergedAt); err != nil {
+			return fmt.Errorf("persist merged lifecycle event for MR #%d: %w", number, err)
 		}
 
 		syncMRHeadSHA := ""
@@ -8451,6 +8507,67 @@ func (s *Syncer) fetchAndUpdateClosed(ctx context.Context, repo RepoRef, repoID 
 	return s.markClosedLinkedNotificationsDone(ctx)
 }
 
+func (s *Syncer) filterDuplicateMergedLifecycleEvents(
+	ctx context.Context,
+	mrID int64,
+	events []db.MREvent,
+) ([]db.MREvent, error) {
+	needsExisting := false
+	for _, event := range events {
+		if isAuthoredMergedLifecycleEvent(event) {
+			needsExisting = true
+			break
+		}
+	}
+	if !needsExisting {
+		return events, nil
+	}
+	existing, err := s.db.ListMREvents(ctx, mrID)
+	if err != nil {
+		return nil, err
+	}
+	out := events[:0]
+	for _, event := range events {
+		if isAuthoredMergedLifecycleEvent(event) &&
+			authoredMergedLifecycleEventExistsAt(existing, event.CreatedAt) {
+			continue
+		}
+		out = append(out, event)
+	}
+	return out, nil
+}
+
+func (s *Syncer) authoredMergedLifecycleEventExistsAt(
+	ctx context.Context,
+	mrID int64,
+	mergedAt time.Time,
+) (bool, error) {
+	events, err := s.db.ListMREvents(ctx, mrID)
+	if err != nil {
+		return false, err
+	}
+	return authoredMergedLifecycleEventExistsAt(events, mergedAt), nil
+}
+
+func authoredMergedLifecycleEventExistsAt(
+	events []db.MREvent,
+	mergedAt time.Time,
+) bool {
+	mergedAt = mergedAt.UTC()
+	for _, event := range events {
+		if isAuthoredMergedLifecycleEvent(event) &&
+			event.CreatedAt.UTC().Equal(mergedAt) {
+			return true
+		}
+	}
+	return false
+}
+
+func isAuthoredMergedLifecycleEvent(event db.MREvent) bool {
+	return event.EventType == "merged" &&
+		strings.TrimSpace(event.Author) != ""
+}
+
 func (s *Syncer) persistMergedTransitionEvent(
 	ctx context.Context,
 	mrID int64,
@@ -8466,6 +8583,13 @@ func (s *Syncer) persistMergedTransitionEvent(
 	}
 	actor := mergedBy.GetLogin()
 	if actor == "" {
+		return nil
+	}
+	exists, err := s.authoredMergedLifecycleEventExistsAt(ctx, mrID, *mergedAt)
+	if err != nil {
+		return err
+	}
+	if exists {
 		return nil
 	}
 	event := NormalizeTimelineEvent(mrID, PullRequestTimelineEvent{

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -5871,6 +5871,9 @@ func (s *Syncer) fetchProviderMRDetail(
 	if err != nil {
 		return calls, err
 	}
+	if _, err := s.persistMergedActorEvent(ctx, mrID, mr.MergedBy, normalized.MergedAt); err != nil {
+		return calls, fmt.Errorf("persist merged lifecycle event for MR #%d: %w", number, err)
+	}
 
 	if err := s.updateMRDetailFetchedByRepoID(ctx, repoID, number, pending); err != nil {
 		return calls, fmt.Errorf("mark detail fetched for MR #%d: %w", number, err)
@@ -7899,6 +7902,7 @@ func (s *Syncer) syncMRForRepo(
 	}
 
 	var ghPR *gh.PullRequest
+	var platformMR platform.MergeRequest
 	var normalized *db.MergeRequest
 	var newETag string
 	if rawReader, ok := mrReader.(interface {
@@ -7931,14 +7935,12 @@ func (s *Syncer) syncMRForRepo(
 				normalized, err = NormalizePR(repoID, ghPR)
 			}
 		} else {
-			var platformMR platform.MergeRequest
 			ghPR, platformMR, err = rawReader.GetGitHubPullRequest(ctx, platformRepoRef(repo), number)
 			if err == nil {
 				normalized = platform.DBMergeRequest(repoID, platformMR)
 			}
 		}
 	} else {
-		var platformMR platform.MergeRequest
 		platformMR, err = mrReader.GetMergeRequest(ctx, platformRepoRef(repo), number)
 		if err == nil {
 			normalized = platform.DBMergeRequest(repoID, platformMR)
@@ -8064,6 +8066,9 @@ func (s *Syncer) syncMRForRepo(
 		)
 		if err != nil {
 			return err
+		}
+		if _, err := s.persistMergedActorEvent(ctx, mrID, platformMR.MergedBy, normalized.MergedAt); err != nil {
+			return fmt.Errorf("persist merged lifecycle event for MR #%d: %w", number, err)
 		}
 		if err := s.updateMRDetailFetchedByRepoID(ctx, repoID, number, pending); err != nil {
 			return fmt.Errorf("mark detail fetched for MR #%d: %w", number, err)

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -5458,6 +5458,9 @@ func (s *Syncer) fetchMRDetail(
 			"upsert MR #%d: %w", number, err,
 		)
 	}
+	if err := s.persistMergedTransitionEvent(ctx, mrID, fullPR, normalized.MergedAt); err != nil {
+		return calls, fmt.Errorf("persist merged lifecycle event for MR #%d: %w", number, err)
+	}
 	if err := s.replaceMergeRequestLabels(ctx, repoID, mrID, normalized.Labels); err != nil {
 		return calls, fmt.Errorf("persist labels for MR #%d: %w", number, err)
 	}
@@ -7809,6 +7812,11 @@ func (s *Syncer) syncMRForRepo(
 	if err != nil {
 		return fmt.Errorf("upsert MR #%d: %w", number, err)
 	}
+	if ghPR != nil {
+		if err := s.persistMergedTransitionEvent(ctx, mrID, ghPR, normalized.MergedAt); err != nil {
+			return fmt.Errorf("persist merged lifecycle event for MR #%d: %w", number, err)
+		}
+	}
 	if err := s.markClosedLinkedNotificationsDone(ctx); err != nil {
 		return err
 	}
@@ -8313,6 +8321,9 @@ func (s *Syncer) fetchAndUpdateClosed(ctx context.Context, repo RepoRef, repoID 
 		return fmt.Errorf("get closed MR #%d for labels: %w", number, err)
 	}
 	if mr != nil {
+		if err := s.persistMergedTransitionEvent(ctx, mr.ID, ghPR, mergedAt); err != nil {
+			return fmt.Errorf("persist merged lifecycle event for MR #%d: %w", number, err)
+		}
 		normalized, err := NormalizePR(repoID, ghPR)
 		if err != nil {
 			return fmt.Errorf("normalize closed PR #%d: %w", number, err)
@@ -8362,6 +8373,30 @@ func (s *Syncer) fetchAndUpdateClosed(ctx context.Context, repo RepoRef, repoID 
 		}
 	}
 	return s.markClosedLinkedNotificationsDone(ctx)
+}
+
+func (s *Syncer) persistMergedTransitionEvent(
+	ctx context.Context,
+	mrID int64,
+	ghPR *gh.PullRequest,
+	mergedAt *time.Time,
+) error {
+	if !pullRequestWasMerged(ghPR) || mergedAt == nil {
+		return nil
+	}
+	actor := ghPR.GetMergedBy().GetLogin()
+	if actor == "" {
+		return nil
+	}
+	event := NormalizeTimelineEvent(mrID, PullRequestTimelineEvent{
+		EventType: "merged",
+		Actor:     actor,
+		CreatedAt: *mergedAt,
+	})
+	if event == nil {
+		return nil
+	}
+	return s.db.UpsertMREvents(ctx, []db.MREvent{*event})
 }
 
 func (s *Syncer) fetchAndUpdateClosedMergeRequest(

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -5445,7 +5445,11 @@ func (s *Syncer) fetchMRDetail(
 			)
 			calls += backfillCalls
 			if backfillErr != nil {
-				return calls, backfillErr
+				slog.Warn("merged actor backfill after unchanged detail failed",
+					"repo", repo.Owner+"/"+repo.Name,
+					"number", number,
+					"err", backfillErr,
+				)
 			}
 			return s.markUnchangedMRDetailFetched(
 				ctx, repo, repoID, number, existing, calls,
@@ -7994,7 +7998,11 @@ func (s *Syncer) syncMRForRepo(
 					if _, _, backfillErr := s.backfillMergedActorAfterUnchangedDetail(
 						ctx, client, repo, existing,
 					); backfillErr != nil {
-						return backfillErr
+						slog.Warn("merged actor backfill after unchanged detail failed",
+							"repo", owner+"/"+name,
+							"number", number,
+							"err", backfillErr,
+						)
 					}
 					_, err := s.markUnchangedMRDetailFetched(
 						ctx, repo, repoID, number, existing, 1,

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -4604,6 +4604,9 @@ func (s *Syncer) indexUpsertMR(
 	if err := s.replaceMergeRequestLabels(ctx, repoID, mrID, normalized.Labels); err != nil {
 		return fmt.Errorf("persist labels for MR #%d: %w", ghPR.GetNumber(), err)
 	}
+	if _, err := s.persistMergedTransitionEvent(ctx, mrID, ghPR, normalized.MergedAt); err != nil {
+		return fmt.Errorf("persist merged lifecycle event for MR #%d: %w", ghPR.GetNumber(), err)
+	}
 
 	if err := s.db.EnsureKanbanState(ctx, mrID); err != nil {
 		return fmt.Errorf(

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -5434,17 +5434,6 @@ func (s *Syncer) fetchMRDetail(
 	calls++
 	if err == nil && fullPR == nil {
 		if notModified && existing != nil {
-			backfillCalls, _, backfillErr := s.backfillMergedActorAfterUnchangedDetail(
-				ctx, client, repo, existing,
-			)
-			calls += backfillCalls
-			if backfillErr != nil {
-				slog.Warn("merged actor backfill after unchanged detail failed",
-					"repo", repo.Owner+"/"+repo.Name,
-					"number", number,
-					"err", backfillErr,
-				)
-			}
 			return s.markUnchangedMRDetailFetched(
 				ctx, repo, repoID, number, existing, calls,
 			)
@@ -5678,150 +5667,6 @@ func (s *Syncer) markUnchangedMRDetailFetched(
 		}
 	}
 	return calls, nil
-}
-
-func (s *Syncer) backfillMergedActorAfterUnchangedDetail(
-	ctx context.Context,
-	client Client,
-	repo RepoRef,
-	existing *db.MergeRequest,
-) (int, bool, error) {
-	needed, err := s.mergedActorBackfillNeeded(ctx, existing)
-	if err != nil {
-		return 0, false, err
-	}
-	if !needed {
-		return 0, false, nil
-	}
-	return s.backfillMergedActorWithKnownNeed(ctx, client, repo, existing)
-}
-
-func (s *Syncer) backfillMergedActorWithKnownNeed(
-	ctx context.Context,
-	client Client,
-	repo RepoRef,
-	existing *db.MergeRequest,
-) (int, bool, error) {
-	calls := 0
-	fullPR, err := client.GetPullRequest(
-		ctx, repo.Owner, repo.Name, existing.Number,
-	)
-	calls++
-	if err != nil {
-		return calls, false, fmt.Errorf(
-			"get PR #%d for merged actor backfill: %w",
-			existing.Number, err,
-		)
-	}
-	if fullPR == nil {
-		return calls, false, fmt.Errorf(
-			"get PR #%d for merged actor backfill: client returned nil pull request",
-			existing.Number,
-		)
-	}
-	wrote, err := s.persistMergedTransitionEvent(
-		ctx, existing.ID, fullPR, existing.MergedAt,
-	)
-	if err != nil {
-		return calls, false, fmt.Errorf(
-			"persist merged lifecycle event for MR #%d: %w",
-			existing.Number, err,
-		)
-	}
-	if !wrote {
-		timelineEvents, timelineErr := client.ListPullRequestTimelineEvents(
-			ctx, repo.Owner, repo.Name, existing.Number,
-		)
-		calls++
-		if timelineErr != nil {
-			return calls, false, fmt.Errorf(
-				"list timeline events for merged actor backfill on MR #%d: %w",
-				existing.Number, timelineErr,
-			)
-		}
-		wrote, err = s.persistMergedTimelineTransitionEvent(
-			ctx, existing.ID, timelineEvents,
-		)
-		if err != nil {
-			return calls, false, fmt.Errorf(
-				"persist timeline merged lifecycle event for MR #%d: %w",
-				existing.Number, err,
-			)
-		}
-	}
-	return calls, wrote, nil
-}
-
-func (s *Syncer) mergedActorBackfillNeeded(
-	ctx context.Context,
-	existing *db.MergeRequest,
-) (bool, error) {
-	if existing == nil ||
-		existing.State != db.MergeRequestStateMerged ||
-		existing.MergedAt == nil {
-		return false, nil
-	}
-	events, err := s.db.ListMREvents(ctx, existing.ID)
-	if err != nil {
-		return false, fmt.Errorf(
-			"list merged lifecycle events for MR #%d: %w",
-			existing.Number, err,
-		)
-	}
-	for _, event := range events {
-		if event.EventType == "merged" &&
-			strings.TrimSpace(event.Author) != "" {
-			return false, nil
-		}
-	}
-	return true, nil
-}
-
-// BackfillMergedActorForDetail fills the merge lifecycle actor for stale rows
-// before the DB-backed detail response is built. It reads the focused PR field
-// first, then falls back to the PR timeline when the provider omits MergedBy;
-// full detail sync still owns comments, reviews, commits, and checks.
-func (s *Syncer) BackfillMergedActorForDetail(
-	ctx context.Context,
-	existing *db.MergeRequest,
-) (bool, error) {
-	needed, err := s.mergedActorBackfillNeeded(ctx, existing)
-	if err != nil || !needed {
-		return false, err
-	}
-	repoRow, err := s.db.GetRepoByID(ctx, existing.RepoID)
-	if err != nil {
-		return false, fmt.Errorf(
-			"get repo for merged actor backfill on MR #%d: %w",
-			existing.Number, err,
-		)
-	}
-	if repoRow == nil {
-		return false, nil
-	}
-	kind := platform.Kind(repoRow.Platform)
-	if kind != platform.KindGitHub {
-		return false, nil
-	}
-	repo := RepoRef{
-		Platform:      kind,
-		PlatformHost:  repoRow.PlatformHost,
-		Owner:         repoRow.Owner,
-		Name:          repoRow.Name,
-		RepoPath:      repoRow.RepoPath,
-		WebURL:        repoRow.WebURL,
-		CloneURL:      repoRow.CloneURL,
-		DefaultBranch: repoRow.DefaultBranch,
-	}
-	client, err := s.clientFor(repo)
-	if err != nil {
-		return false, fmt.Errorf(
-			"resolve client for merged actor backfill on MR #%d: %w",
-			existing.Number, err,
-		)
-	}
-	_, wrote, err := s.backfillMergedActorWithKnownNeed(ctx, client, repo, existing)
-	return wrote, err
 }
 
 func (s *Syncer) fetchProviderMRDetail(
@@ -7915,15 +7760,6 @@ func (s *Syncer) syncMRForRepo(
 			)
 			if err == nil && ghPR == nil {
 				if notModified && existing != nil {
-					if _, _, backfillErr := s.backfillMergedActorAfterUnchangedDetail(
-						ctx, client, repo, existing,
-					); backfillErr != nil {
-						slog.Warn("merged actor backfill after unchanged detail failed",
-							"repo", owner+"/"+name,
-							"number", number,
-							"err", backfillErr,
-						)
-					}
 					_, err := s.markUnchangedMRDetailFetched(
 						ctx, repo, repoID, number, existing, 1,
 					)
@@ -8650,34 +8486,6 @@ func (s *Syncer) persistMergedActorEvent(
 		return false, err
 	}
 	return true, nil
-}
-
-func (s *Syncer) persistMergedTimelineTransitionEvent(
-	ctx context.Context,
-	mrID int64,
-	timelineEvents []PullRequestTimelineEvent,
-) (bool, error) {
-	for _, timelineEvent := range timelineEvents {
-		if timelineEvent.EventType != "merged" || strings.TrimSpace(timelineEvent.Actor) == "" {
-			continue
-		}
-		exists, err := s.authoredMergedLifecycleEventExists(ctx, mrID)
-		if err != nil {
-			return false, err
-		}
-		if exists {
-			return false, nil
-		}
-		event := NormalizeTimelineEvent(mrID, timelineEvent)
-		if event == nil {
-			return false, nil
-		}
-		if err := s.db.UpsertMREvents(ctx, []db.MREvent{*event}); err != nil {
-			return false, err
-		}
-		return true, nil
-	}
-	return false, nil
 }
 
 func (s *Syncer) fetchAndUpdateClosedMergeRequest(

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -5841,6 +5841,9 @@ func (s *Syncer) BackfillMergedActorForDetail(
 	if err != nil || !needed {
 		return false, err
 	}
+	if s.skipMergedActorDetailBackfill(existing, time.Now()) {
+		return false, nil
+	}
 	repoRow, err := s.db.GetRepoByID(ctx, existing.RepoID)
 	if err != nil {
 		return false, fmt.Errorf(

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -5707,19 +5707,21 @@ func (s *Syncer) backfillMergedActorWithKnownNeed(
 	if s.skipMergedActorDetailBackfill(existing, time.Now()) {
 		return 0, false, nil
 	}
+	calls := 0
 	fullPR, err := client.GetPullRequest(
 		ctx, repo.Owner, repo.Name, existing.Number,
 	)
+	calls++
 	if err != nil {
 		s.recordMergedActorDetailBackfillRetry(existing, time.Now().Add(mergedActorDetailBackfillErrorBackoff))
-		return 1, false, fmt.Errorf(
+		return calls, false, fmt.Errorf(
 			"get PR #%d for merged actor backfill: %w",
 			existing.Number, err,
 		)
 	}
 	if fullPR == nil {
 		s.recordMergedActorDetailBackfillRetry(existing, time.Now().Add(mergedActorDetailBackfillErrorBackoff))
-		return 1, false, fmt.Errorf(
+		return calls, false, fmt.Errorf(
 			"get PR #%d for merged actor backfill: client returned nil pull request",
 			existing.Number,
 		)
@@ -5729,17 +5731,40 @@ func (s *Syncer) backfillMergedActorWithKnownNeed(
 	)
 	if err != nil {
 		s.recordMergedActorDetailBackfillRetry(existing, time.Now().Add(mergedActorDetailBackfillErrorBackoff))
-		return 1, false, fmt.Errorf(
+		return calls, false, fmt.Errorf(
 			"persist merged lifecycle event for MR #%d: %w",
 			existing.Number, err,
 		)
+	}
+	if !wrote {
+		timelineEvents, timelineErr := client.ListPullRequestTimelineEvents(
+			ctx, repo.Owner, repo.Name, existing.Number,
+		)
+		calls++
+		if timelineErr != nil {
+			s.recordMergedActorDetailBackfillRetry(existing, time.Now().Add(mergedActorDetailBackfillErrorBackoff))
+			return calls, false, fmt.Errorf(
+				"list timeline events for merged actor backfill on MR #%d: %w",
+				existing.Number, timelineErr,
+			)
+		}
+		wrote, err = s.persistMergedTimelineTransitionEvent(
+			ctx, existing.ID, timelineEvents,
+		)
+		if err != nil {
+			s.recordMergedActorDetailBackfillRetry(existing, time.Now().Add(mergedActorDetailBackfillErrorBackoff))
+			return calls, false, fmt.Errorf(
+				"persist timeline merged lifecycle event for MR #%d: %w",
+				existing.Number, err,
+			)
+		}
 	}
 	if wrote {
 		s.clearMergedActorDetailBackfillAttempt(existing)
 	} else {
 		s.recordMergedActorDetailBackfillTerminalMiss(existing)
 	}
-	return 1, wrote, nil
+	return calls, wrote, nil
 }
 
 func (s *Syncer) mergedActorBackfillNeeded(
@@ -8684,6 +8709,34 @@ func (s *Syncer) persistMergedTransitionEvent(
 		return false, err
 	}
 	return true, nil
+}
+
+func (s *Syncer) persistMergedTimelineTransitionEvent(
+	ctx context.Context,
+	mrID int64,
+	timelineEvents []PullRequestTimelineEvent,
+) (bool, error) {
+	for _, timelineEvent := range timelineEvents {
+		if timelineEvent.EventType != "merged" || strings.TrimSpace(timelineEvent.Actor) == "" {
+			continue
+		}
+		exists, err := s.authoredMergedLifecycleEventExists(ctx, mrID)
+		if err != nil {
+			return false, err
+		}
+		if exists {
+			return false, nil
+		}
+		event := NormalizeTimelineEvent(mrID, timelineEvent)
+		if event == nil {
+			return false, nil
+		}
+		if err := s.db.UpsertMREvents(ctx, []db.MREvent{*event}); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	return false, nil
 }
 
 func (s *Syncer) fetchAndUpdateClosedMergeRequest(

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -8512,14 +8512,7 @@ func (s *Syncer) filterDuplicateMergedLifecycleEvents(
 	mrID int64,
 	events []db.MREvent,
 ) ([]db.MREvent, error) {
-	needsExisting := false
-	for _, event := range events {
-		if isAuthoredMergedLifecycleEvent(event) {
-			needsExisting = true
-			break
-		}
-	}
-	if !needsExisting {
+	if !slices.ContainsFunc(events, isAuthoredMergedLifecycleEvent) {
 		return events, nil
 	}
 	existing, err := s.db.ListMREvents(ctx, mrID)

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -5776,6 +5776,10 @@ func (s *Syncer) syncProviderMRDetailExtras(
 		if err := s.db.DeleteMissingMRCommentEvents(ctx, mrID, commentDedupeKeys); err != nil {
 			return calls, false, fmt.Errorf("delete missing comment events for MR #%d: %w", number, err)
 		}
+		dbEvents, err = s.filterDuplicateMergedLifecycleEvents(ctx, mrID, dbEvents)
+		if err != nil {
+			return calls, false, fmt.Errorf("dedupe merged lifecycle events for MR #%d: %w", number, err)
+		}
 		if err := s.db.UpsertMREvents(ctx, dbEvents); err != nil {
 			return calls, false, fmt.Errorf("upsert events for MR #%d: %w", number, err)
 		}

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -183,13 +183,6 @@ const (
 	DiffSyncCodeInternal DiffSyncErrorCode = "internal"
 )
 
-const mergedActorDetailBackfillErrorBackoff = 5 * time.Minute
-
-type mergedActorDetailBackfillAttempt struct {
-	retryAfter time.Time
-	terminal   bool
-}
-
 // DiffSyncError reports a non-fatal failure to compute or update the diff SHAs
 // for a PR. SyncMR returns this when only the diff portion of the sync failed:
 // the PR row, timeline, and CI status were updated successfully, so callers
@@ -483,11 +476,6 @@ type Syncer struct {
 	// instead of being skipped by a silent 304. Keyed by
 	// "host/owner/name". Cleared on the next successful sync.
 	failedRepos sync.Map
-
-	// mergedActorDetailBackfillAttempts throttles foreground detail reads when
-	// a targeted merge-actor lookup cannot produce an authored merged event.
-	// Values are mergedActorDetailBackfillAttempt keyed by MR id and merge time.
-	mergedActorDetailBackfillAttempts sync.Map
 
 	// runCtx is the syncer's lifetime context. It is canceled in
 	// Stop so in-flight RunOnce / TriggerRun goroutines observe
@@ -4497,6 +4485,9 @@ func (s *Syncer) indexUpsertMergeRequest(
 	if err := s.replaceMergeRequestLabels(ctx, repoID, mrID, normalized.Labels); err != nil {
 		return fmt.Errorf("persist labels for MR #%d: %w", mr.Number, err)
 	}
+	if _, err := s.persistMergedActorEvent(ctx, mrID, mr.MergedBy, normalized.MergedAt); err != nil {
+		return fmt.Errorf("persist merged lifecycle event for MR #%d: %w", mr.Number, err)
+	}
 
 	if err := s.db.EnsureKanbanState(ctx, mrID); err != nil {
 		return fmt.Errorf(
@@ -5711,23 +5702,18 @@ func (s *Syncer) backfillMergedActorWithKnownNeed(
 	repo RepoRef,
 	existing *db.MergeRequest,
 ) (int, bool, error) {
-	if s.skipMergedActorDetailBackfill(existing, time.Now()) {
-		return 0, false, nil
-	}
 	calls := 0
 	fullPR, err := client.GetPullRequest(
 		ctx, repo.Owner, repo.Name, existing.Number,
 	)
 	calls++
 	if err != nil {
-		s.recordMergedActorDetailBackfillRetry(existing, time.Now().Add(mergedActorDetailBackfillErrorBackoff))
 		return calls, false, fmt.Errorf(
 			"get PR #%d for merged actor backfill: %w",
 			existing.Number, err,
 		)
 	}
 	if fullPR == nil {
-		s.recordMergedActorDetailBackfillRetry(existing, time.Now().Add(mergedActorDetailBackfillErrorBackoff))
 		return calls, false, fmt.Errorf(
 			"get PR #%d for merged actor backfill: client returned nil pull request",
 			existing.Number,
@@ -5737,7 +5723,6 @@ func (s *Syncer) backfillMergedActorWithKnownNeed(
 		ctx, existing.ID, fullPR, existing.MergedAt,
 	)
 	if err != nil {
-		s.recordMergedActorDetailBackfillRetry(existing, time.Now().Add(mergedActorDetailBackfillErrorBackoff))
 		return calls, false, fmt.Errorf(
 			"persist merged lifecycle event for MR #%d: %w",
 			existing.Number, err,
@@ -5749,7 +5734,6 @@ func (s *Syncer) backfillMergedActorWithKnownNeed(
 		)
 		calls++
 		if timelineErr != nil {
-			s.recordMergedActorDetailBackfillRetry(existing, time.Now().Add(mergedActorDetailBackfillErrorBackoff))
 			return calls, false, fmt.Errorf(
 				"list timeline events for merged actor backfill on MR #%d: %w",
 				existing.Number, timelineErr,
@@ -5759,17 +5743,11 @@ func (s *Syncer) backfillMergedActorWithKnownNeed(
 			ctx, existing.ID, timelineEvents,
 		)
 		if err != nil {
-			s.recordMergedActorDetailBackfillRetry(existing, time.Now().Add(mergedActorDetailBackfillErrorBackoff))
 			return calls, false, fmt.Errorf(
 				"persist timeline merged lifecycle event for MR #%d: %w",
 				existing.Number, err,
 			)
 		}
-	}
-	if wrote {
-		s.clearMergedActorDetailBackfillAttempt(existing)
-	} else {
-		s.recordMergedActorDetailBackfillTerminalMiss(existing)
 	}
 	return calls, wrote, nil
 }
@@ -5799,72 +5777,10 @@ func (s *Syncer) mergedActorBackfillNeeded(
 	return true, nil
 }
 
-func mergedActorDetailBackfillKey(existing *db.MergeRequest) string {
-	if existing == nil || existing.MergedAt == nil {
-		return ""
-	}
-	return fmt.Sprintf(
-		"%d/%s",
-		existing.ID,
-		existing.MergedAt.UTC().Format(time.RFC3339Nano),
-	)
-}
-
-func (s *Syncer) skipMergedActorDetailBackfill(
-	existing *db.MergeRequest,
-	now time.Time,
-) bool {
-	key := mergedActorDetailBackfillKey(existing)
-	if key == "" {
-		return false
-	}
-	raw, ok := s.mergedActorDetailBackfillAttempts.Load(key)
-	if !ok {
-		return false
-	}
-	attempt := raw.(mergedActorDetailBackfillAttempt)
-	if attempt.terminal || now.Before(attempt.retryAfter) {
-		return true
-	}
-	s.mergedActorDetailBackfillAttempts.Delete(key)
-	return false
-}
-
-func (s *Syncer) recordMergedActorDetailBackfillRetry(
-	existing *db.MergeRequest,
-	retryAfter time.Time,
-) {
-	key := mergedActorDetailBackfillKey(existing)
-	if key == "" {
-		return
-	}
-	s.mergedActorDetailBackfillAttempts.Store(key, mergedActorDetailBackfillAttempt{
-		retryAfter: retryAfter.UTC(),
-	})
-}
-
-func (s *Syncer) recordMergedActorDetailBackfillTerminalMiss(existing *db.MergeRequest) {
-	key := mergedActorDetailBackfillKey(existing)
-	if key == "" {
-		return
-	}
-	s.mergedActorDetailBackfillAttempts.Store(key, mergedActorDetailBackfillAttempt{
-		terminal: true,
-	})
-}
-
-func (s *Syncer) clearMergedActorDetailBackfillAttempt(existing *db.MergeRequest) {
-	key := mergedActorDetailBackfillKey(existing)
-	if key == "" {
-		return
-	}
-	s.mergedActorDetailBackfillAttempts.Delete(key)
-}
-
 // BackfillMergedActorForDetail fills the merge lifecycle actor for stale rows
-// before the DB-backed detail response is built. It deliberately does only the
-// one PR request needed to read GitHub's MergedBy field; full detail sync still
-// owns comments, reviews, commits, and checks.
+// before the DB-backed detail response is built. It reads the focused PR field
+// first, then falls back to the PR timeline when the provider omits MergedBy;
+// full detail sync still owns comments, reviews, commits, and checks.
 func (s *Syncer) BackfillMergedActorForDetail(
 	ctx context.Context,
 	existing *db.MergeRequest,
@@ -5872,9 +5788,6 @@ func (s *Syncer) BackfillMergedActorForDetail(
 	needed, err := s.mergedActorBackfillNeeded(ctx, existing)
 	if err != nil || !needed {
 		return false, err
-	}
-	if s.skipMergedActorDetailBackfill(existing, time.Now()) {
-		return false, nil
 	}
 	repoRow, err := s.db.GetRepoByID(ctx, existing.RepoID)
 	if err != nil {
@@ -8697,7 +8610,19 @@ func (s *Syncer) persistMergedTransitionEvent(
 	if mergedBy == nil {
 		return false, nil
 	}
-	actor := mergedBy.GetLogin()
+	return s.persistMergedActorEvent(ctx, mrID, mergedBy.GetLogin(), mergedAt)
+}
+
+func (s *Syncer) persistMergedActorEvent(
+	ctx context.Context,
+	mrID int64,
+	actor string,
+	mergedAt *time.Time,
+) (bool, error) {
+	if mergedAt == nil {
+		return false, nil
+	}
+	actor = strings.TrimSpace(actor)
 	if actor == "" {
 		return false, nil
 	}
@@ -8775,6 +8700,9 @@ func (s *Syncer) fetchAndUpdateClosedMergeRequest(
 	}
 	if err := s.replaceMergeRequestLabels(ctx, repoID, mrID, normalized.Labels); err != nil {
 		return fmt.Errorf("persist labels for closed MR #%d: %w", number, err)
+	}
+	if _, err := s.persistMergedActorEvent(ctx, mrID, mr.MergedBy, normalized.MergedAt); err != nil {
+		return fmt.Errorf("persist merged lifecycle event for closed MR #%d: %w", number, err)
 	}
 	return nil
 }

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -5695,16 +5695,30 @@ func (s *Syncer) backfillMergedActorAfterUnchangedDetail(
 	if !needed {
 		return 0, false, nil
 	}
+	return s.backfillMergedActorWithKnownNeed(ctx, client, repo, existing)
+}
+
+func (s *Syncer) backfillMergedActorWithKnownNeed(
+	ctx context.Context,
+	client Client,
+	repo RepoRef,
+	existing *db.MergeRequest,
+) (int, bool, error) {
+	if s.skipMergedActorDetailBackfill(existing, time.Now()) {
+		return 0, false, nil
+	}
 	fullPR, err := client.GetPullRequest(
 		ctx, repo.Owner, repo.Name, existing.Number,
 	)
 	if err != nil {
+		s.recordMergedActorDetailBackfillRetry(existing, time.Now().Add(mergedActorDetailBackfillErrorBackoff))
 		return 1, false, fmt.Errorf(
 			"get PR #%d for merged actor backfill: %w",
 			existing.Number, err,
 		)
 	}
 	if fullPR == nil {
+		s.recordMergedActorDetailBackfillRetry(existing, time.Now().Add(mergedActorDetailBackfillErrorBackoff))
 		return 1, false, fmt.Errorf(
 			"get PR #%d for merged actor backfill: client returned nil pull request",
 			existing.Number,
@@ -5714,10 +5728,16 @@ func (s *Syncer) backfillMergedActorAfterUnchangedDetail(
 		ctx, existing.ID, fullPR, existing.MergedAt,
 	)
 	if err != nil {
+		s.recordMergedActorDetailBackfillRetry(existing, time.Now().Add(mergedActorDetailBackfillErrorBackoff))
 		return 1, false, fmt.Errorf(
 			"persist merged lifecycle event for MR #%d: %w",
 			existing.Number, err,
 		)
+	}
+	if wrote {
+		s.clearMergedActorDetailBackfillAttempt(existing)
+	} else {
+		s.recordMergedActorDetailBackfillTerminalMiss(existing)
 	}
 	return 1, wrote, nil
 }
@@ -5821,9 +5841,6 @@ func (s *Syncer) BackfillMergedActorForDetail(
 	if err != nil || !needed {
 		return false, err
 	}
-	if s.skipMergedActorDetailBackfill(existing, time.Now()) {
-		return false, nil
-	}
 	repoRow, err := s.db.GetRepoByID(ctx, existing.RepoID)
 	if err != nil {
 		return false, fmt.Errorf(
@@ -5855,19 +5872,8 @@ func (s *Syncer) BackfillMergedActorForDetail(
 			existing.Number, err,
 		)
 	}
-	calls, wrote, err := s.backfillMergedActorAfterUnchangedDetail(ctx, client, repo, existing)
-	if err != nil {
-		s.recordMergedActorDetailBackfillRetry(existing, time.Now().Add(mergedActorDetailBackfillErrorBackoff))
-		return false, err
-	}
-	if wrote {
-		s.clearMergedActorDetailBackfillAttempt(existing)
-		return true, nil
-	}
-	if calls > 0 {
-		s.recordMergedActorDetailBackfillTerminalMiss(existing)
-	}
-	return false, nil
+	_, wrote, err := s.backfillMergedActorWithKnownNeed(ctx, client, repo, existing)
+	return wrote, err
 }
 
 func (s *Syncer) fetchProviderMRDetail(

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -183,6 +183,13 @@ const (
 	DiffSyncCodeInternal DiffSyncErrorCode = "internal"
 )
 
+const mergedActorDetailBackfillErrorBackoff = 5 * time.Minute
+
+type mergedActorDetailBackfillAttempt struct {
+	retryAfter time.Time
+	terminal   bool
+}
+
 // DiffSyncError reports a non-fatal failure to compute or update the diff SHAs
 // for a PR. SyncMR returns this when only the diff portion of the sync failed:
 // the PR row, timeline, and CI status were updated successfully, so callers
@@ -476,6 +483,11 @@ type Syncer struct {
 	// instead of being skipped by a silent 304. Keyed by
 	// "host/owner/name". Cleared on the next successful sync.
 	failedRepos sync.Map
+
+	// mergedActorDetailBackfillAttempts throttles foreground detail reads when
+	// a targeted merge-actor lookup cannot produce an authored merged event.
+	// Values are mergedActorDetailBackfillAttempt keyed by MR id and merge time.
+	mergedActorDetailBackfillAttempts sync.Map
 
 	// runCtx is the syncer's lifetime context. It is canceled in
 	// Stop so in-flight RunOnce / TriggerRun goroutines observe
@@ -5224,7 +5236,7 @@ func (s *Syncer) syncOpenMRFromBulk(
 			"upsert events for MR #%d: %w", number, err,
 		)
 	}
-	if err := s.persistMergedTransitionEvent(ctx, mrID, bulk.PR, normalized.MergedAt); err != nil {
+	if _, err := s.persistMergedTransitionEvent(ctx, mrID, bulk.PR, normalized.MergedAt); err != nil {
 		return fmt.Errorf("persist merged lifecycle event for MR #%d: %w", number, err)
 	}
 
@@ -5428,7 +5440,7 @@ func (s *Syncer) fetchMRDetail(
 	calls++
 	if err == nil && fullPR == nil {
 		if notModified && existing != nil {
-			backfillCalls, backfillErr := s.backfillMergedActorAfterUnchangedDetail(
+			backfillCalls, _, backfillErr := s.backfillMergedActorAfterUnchangedDetail(
 				ctx, client, repo, existing,
 			)
 			calls += backfillCalls
@@ -5523,7 +5535,7 @@ func (s *Syncer) fetchMRDetail(
 		return calls, err
 	}
 	calls += 4
-	if err := s.persistMergedTransitionEvent(ctx, mrID, fullPR, normalized.MergedAt); err != nil {
+	if _, err := s.persistMergedTransitionEvent(ctx, mrID, fullPR, normalized.MergedAt); err != nil {
 		return calls, fmt.Errorf("persist merged lifecycle event for MR #%d: %w", number, err)
 	}
 
@@ -5675,38 +5687,39 @@ func (s *Syncer) backfillMergedActorAfterUnchangedDetail(
 	client Client,
 	repo RepoRef,
 	existing *db.MergeRequest,
-) (int, error) {
+) (int, bool, error) {
 	needed, err := s.mergedActorBackfillNeeded(ctx, existing)
 	if err != nil {
-		return 0, err
+		return 0, false, err
 	}
 	if !needed {
-		return 0, nil
+		return 0, false, nil
 	}
 	fullPR, err := client.GetPullRequest(
 		ctx, repo.Owner, repo.Name, existing.Number,
 	)
 	if err != nil {
-		return 1, fmt.Errorf(
+		return 1, false, fmt.Errorf(
 			"get PR #%d for merged actor backfill: %w",
 			existing.Number, err,
 		)
 	}
 	if fullPR == nil {
-		return 1, fmt.Errorf(
+		return 1, false, fmt.Errorf(
 			"get PR #%d for merged actor backfill: client returned nil pull request",
 			existing.Number,
 		)
 	}
-	if err := s.persistMergedTransitionEvent(
+	wrote, err := s.persistMergedTransitionEvent(
 		ctx, existing.ID, fullPR, existing.MergedAt,
-	); err != nil {
-		return 1, fmt.Errorf(
+	)
+	if err != nil {
+		return 1, false, fmt.Errorf(
 			"persist merged lifecycle event for MR #%d: %w",
 			existing.Number, err,
 		)
 	}
-	return 1, nil
+	return 1, wrote, nil
 }
 
 func (s *Syncer) mergedActorBackfillNeeded(
@@ -5734,6 +5747,68 @@ func (s *Syncer) mergedActorBackfillNeeded(
 	return true, nil
 }
 
+func mergedActorDetailBackfillKey(existing *db.MergeRequest) string {
+	if existing == nil || existing.MergedAt == nil {
+		return ""
+	}
+	return fmt.Sprintf(
+		"%d/%s",
+		existing.ID,
+		existing.MergedAt.UTC().Format(time.RFC3339Nano),
+	)
+}
+
+func (s *Syncer) skipMergedActorDetailBackfill(
+	existing *db.MergeRequest,
+	now time.Time,
+) bool {
+	key := mergedActorDetailBackfillKey(existing)
+	if key == "" {
+		return false
+	}
+	raw, ok := s.mergedActorDetailBackfillAttempts.Load(key)
+	if !ok {
+		return false
+	}
+	attempt := raw.(mergedActorDetailBackfillAttempt)
+	if attempt.terminal || now.Before(attempt.retryAfter) {
+		return true
+	}
+	s.mergedActorDetailBackfillAttempts.Delete(key)
+	return false
+}
+
+func (s *Syncer) recordMergedActorDetailBackfillRetry(
+	existing *db.MergeRequest,
+	retryAfter time.Time,
+) {
+	key := mergedActorDetailBackfillKey(existing)
+	if key == "" {
+		return
+	}
+	s.mergedActorDetailBackfillAttempts.Store(key, mergedActorDetailBackfillAttempt{
+		retryAfter: retryAfter.UTC(),
+	})
+}
+
+func (s *Syncer) recordMergedActorDetailBackfillTerminalMiss(existing *db.MergeRequest) {
+	key := mergedActorDetailBackfillKey(existing)
+	if key == "" {
+		return
+	}
+	s.mergedActorDetailBackfillAttempts.Store(key, mergedActorDetailBackfillAttempt{
+		terminal: true,
+	})
+}
+
+func (s *Syncer) clearMergedActorDetailBackfillAttempt(existing *db.MergeRequest) {
+	key := mergedActorDetailBackfillKey(existing)
+	if key == "" {
+		return
+	}
+	s.mergedActorDetailBackfillAttempts.Delete(key)
+}
+
 // BackfillMergedActorForDetail fills the merge lifecycle actor for stale rows
 // before the DB-backed detail response is built. It deliberately does only the
 // one PR request needed to read GitHub's MergedBy field; full detail sync still
@@ -5745,6 +5820,9 @@ func (s *Syncer) BackfillMergedActorForDetail(
 	needed, err := s.mergedActorBackfillNeeded(ctx, existing)
 	if err != nil || !needed {
 		return false, err
+	}
+	if s.skipMergedActorDetailBackfill(existing, time.Now()) {
+		return false, nil
 	}
 	repoRow, err := s.db.GetRepoByID(ctx, existing.RepoID)
 	if err != nil {
@@ -5777,8 +5855,19 @@ func (s *Syncer) BackfillMergedActorForDetail(
 			existing.Number, err,
 		)
 	}
-	calls, err := s.backfillMergedActorAfterUnchangedDetail(ctx, client, repo, existing)
-	return calls > 0, err
+	calls, wrote, err := s.backfillMergedActorAfterUnchangedDetail(ctx, client, repo, existing)
+	if err != nil {
+		s.recordMergedActorDetailBackfillRetry(existing, time.Now().Add(mergedActorDetailBackfillErrorBackoff))
+		return false, err
+	}
+	if wrote {
+		s.clearMergedActorDetailBackfillAttempt(existing)
+		return true, nil
+	}
+	if calls > 0 {
+		s.recordMergedActorDetailBackfillTerminalMiss(existing)
+	}
+	return false, nil
 }
 
 func (s *Syncer) fetchProviderMRDetail(
@@ -7868,7 +7957,7 @@ func (s *Syncer) syncMRForRepo(
 			)
 			if err == nil && ghPR == nil {
 				if notModified && existing != nil {
-					if _, backfillErr := s.backfillMergedActorAfterUnchangedDetail(
+					if _, _, backfillErr := s.backfillMergedActorAfterUnchangedDetail(
 						ctx, client, repo, existing,
 					); backfillErr != nil {
 						return backfillErr
@@ -7975,7 +8064,7 @@ func (s *Syncer) syncMRForRepo(
 		if err := s.refreshTimeline(ctx, repo, repoID, mrID, ghPR); err != nil {
 			return fmt.Errorf("refresh timeline for MR #%d: %w", number, err)
 		}
-		if err := s.persistMergedTransitionEvent(ctx, mrID, ghPR, normalized.MergedAt); err != nil {
+		if _, err := s.persistMergedTransitionEvent(ctx, mrID, ghPR, normalized.MergedAt); err != nil {
 			return fmt.Errorf("persist merged lifecycle event for MR #%d: %w", number, err)
 		}
 
@@ -8453,7 +8542,7 @@ func (s *Syncer) fetchAndUpdateClosed(ctx context.Context, repo RepoRef, repoID 
 		return fmt.Errorf("get closed MR #%d for labels: %w", number, err)
 	}
 	if mr != nil {
-		if err := s.persistMergedTransitionEvent(ctx, mr.ID, ghPR, mergedAt); err != nil {
+		if _, err := s.persistMergedTransitionEvent(ctx, mr.ID, ghPR, mergedAt); err != nil {
 			return fmt.Errorf("persist merged lifecycle event for MR #%d: %w", number, err)
 		}
 		normalized, err := NormalizePR(repoID, ghPR)
@@ -8566,24 +8655,24 @@ func (s *Syncer) persistMergedTransitionEvent(
 	mrID int64,
 	ghPR *gh.PullRequest,
 	mergedAt *time.Time,
-) error {
+) (bool, error) {
 	if ghPR == nil || mergedAt == nil || !pullRequestWasMerged(ghPR) {
-		return nil
+		return false, nil
 	}
 	mergedBy := ghPR.GetMergedBy()
 	if mergedBy == nil {
-		return nil
+		return false, nil
 	}
 	actor := mergedBy.GetLogin()
 	if actor == "" {
-		return nil
+		return false, nil
 	}
 	exists, err := s.authoredMergedLifecycleEventExistsAt(ctx, mrID, *mergedAt)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if exists {
-		return nil
+		return false, nil
 	}
 	event := NormalizeTimelineEvent(mrID, PullRequestTimelineEvent{
 		EventType: "merged",
@@ -8591,9 +8680,12 @@ func (s *Syncer) persistMergedTransitionEvent(
 		CreatedAt: *mergedAt,
 	})
 	if event == nil {
-		return nil
+		return false, nil
 	}
-	return s.db.UpsertMREvents(ctx, []db.MREvent{*event})
+	if err := s.db.UpsertMREvents(ctx, []db.MREvent{*event}); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (s *Syncer) fetchAndUpdateClosedMergeRequest(

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -8654,7 +8654,7 @@ func (s *Syncer) persistMergedTransitionEvent(
 	ghPR *gh.PullRequest,
 	mergedAt *time.Time,
 ) (bool, error) {
-	if ghPR == nil || mergedAt == nil || !pullRequestWasMerged(ghPR) {
+	if ghPR == nil || mergedAt == nil {
 		return false, nil
 	}
 	mergedBy := ghPR.GetMergedBy()

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -8207,7 +8207,7 @@ func TestBackfillMergedActorForDetailRecordsRetryOnTimelineError(t *testing.T) {
 
 	wrote, err := syncer.BackfillMergedActorForDetail(ctx, existing)
 	require.Error(err)
-	assert.ErrorContains(err, "list timeline events for merged actor backfill")
+	require.ErrorContains(err, "list timeline events for merged actor backfill")
 	assert.False(wrote)
 	assert.Equal(int32(1), client.getPRCalls.Load())
 

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -5749,6 +5749,50 @@ func TestIndexUpsertMRReadsExistingByRepoID(t *testing.T) {
 	assert.NotNil(gitlabMR.DetailFetchedAt)
 }
 
+func TestIndexUpsertMRPersistsMergedActorEventFromPullRequest(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	now := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+	mergedAt := now.Add(time.Minute)
+
+	repo := RepoRef{
+		Platform:     platform.KindGitHub,
+		PlatformHost: "github.com",
+		Owner:        "acme",
+		Name:         "widget",
+	}
+	repoID, err := d.UpsertRepo(ctx, platform.DBRepoIdentity(platformRepoRef(repo)))
+	require.NoError(err)
+
+	merged := true
+	mergedBy := "merge-admin"
+	pr := buildOpenPR(7, now)
+	pr.State = new("closed")
+	pr.Merged = &merged
+	pr.MergedAt = makeTimestamp(mergedAt)
+	pr.ClosedAt = makeTimestamp(mergedAt)
+	pr.UpdatedAt = makeTimestamp(mergedAt)
+	pr.MergedBy = &gh.User{Login: &mergedBy}
+	syncer := NewSyncer(nil, d, nil, []RepoRef{repo}, time.Minute, nil, nil)
+
+	require.NoError(syncer.indexUpsertMR(ctx, &mockClient{}, repo, repoID, pr))
+
+	got, err := d.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
+	require.NoError(err)
+	require.NotNil(got)
+	assert.Equal(db.MergeRequestStateMerged, got.State)
+
+	events, err := d.ListMREvents(ctx, got.ID)
+	require.NoError(err)
+	require.Len(events, 1)
+	assert.Equal("merged", events[0].EventType)
+	assert.Equal("merge-admin", events[0].Author)
+	assert.Equal("merged this", events[0].Summary)
+	assert.True(events[0].CreatedAt.Equal(mergedAt))
+}
+
 func TestFetchMRDetailUsesRepoIDForPendingAndCallback(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -7609,6 +7609,79 @@ func TestFetchMRDetailUsesPersistedPullRequestETag(t *testing.T) {
 		"304 should skip timeline/comment refresh")
 }
 
+func TestFetchMRDetailBackfillsMergedActorOn304(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	repo := RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", repo.Owner, repo.Name))
+	require.NoError(err)
+	updatedAt := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
+	mergedAt := updatedAt.Add(time.Minute)
+	detailFetchedAt := updatedAt.Add(-time.Hour)
+	mrID, err := d.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:          repoID,
+		PlatformID:      1000,
+		Number:          1,
+		URL:             "https://github.com/owner/repo/pull/1",
+		Title:           "test PR",
+		Author:          "alice",
+		State:           db.MergeRequestStateMerged,
+		HeadBranch:      "feature-branch",
+		BaseBranch:      "main",
+		PlatformHeadSHA: "abc123def456",
+		CreatedAt:       updatedAt,
+		UpdatedAt:       updatedAt,
+		LastActivityAt:  updatedAt,
+		MergedAt:        &mergedAt,
+		ClosedAt:        &mergedAt,
+		DetailFetchedAt: &detailFetchedAt,
+	})
+	require.NoError(err)
+	require.NoError(d.UpsertHTTPEtag(
+		ctx, "github", "github.com", "owner", "repo",
+		"pull_request", 1, `"etag-v1"`,
+	))
+
+	merged := true
+	mergedBy := "merge-admin"
+	pr := buildOpenPR(1, updatedAt)
+	pr.State = new("closed")
+	pr.Merged = &merged
+	pr.MergedAt = makeTimestamp(mergedAt)
+	pr.ClosedAt = makeTimestamp(mergedAt)
+	pr.MergedBy = &gh.User{Login: &mergedBy}
+	mc := &conditionalPRTrackingClient{
+		detailTrackingClient: detailTrackingClient{
+			mockClient: mockClient{singlePR: pr},
+		},
+		notModified: true,
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc}, d, nil,
+		[]RepoRef{repo},
+		time.Minute, nil, testBudget(1000),
+	)
+
+	calls, err := syncer.fetchMRDetail(ctx, repo, repoID, 1, false)
+	require.NoError(err)
+
+	assert.Equal(2, calls)
+	assert.Equal(int32(1), mc.conditionalCalls.Load())
+	assert.Equal(`"etag-v1"`, mc.receivedETag)
+	assert.Equal(int32(1), mc.getPRCalls.Load())
+	assert.Zero(int(mc.listIssueCommentsCalled.Load()),
+		"304 backfill should not run a timeline refresh")
+	events, err := d.ListMREvents(ctx, mrID)
+	require.NoError(err)
+	require.Len(events, 1)
+	assert.Equal("merged", events[0].EventType)
+	assert.Equal("merge-admin", events[0].Author)
+	assert.True(events[0].CreatedAt.Equal(mergedAt))
+}
+
 func TestWatchedSyncMRUsesPersistedPullRequestETag(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -7663,6 +7736,79 @@ func TestWatchedSyncMRUsesPersistedPullRequestETag(t *testing.T) {
 		"304 should skip the unconditional PR detail fetch")
 	assert.Zero(int(mc.listIssueCommentsCalled.Load()),
 		"304 should skip timeline/comment refresh")
+}
+
+func TestWatchedSyncMRBackfillsMergedActorOn304(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	repo := RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", repo.Owner, repo.Name))
+	require.NoError(err)
+	updatedAt := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
+	mergedAt := updatedAt.Add(time.Minute)
+	detailFetchedAt := updatedAt.Add(-time.Hour)
+	mrID, err := d.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:          repoID,
+		PlatformID:      1000,
+		Number:          1,
+		URL:             "https://github.com/owner/repo/pull/1",
+		Title:           "test PR",
+		Author:          "alice",
+		State:           db.MergeRequestStateMerged,
+		HeadBranch:      "feature-branch",
+		BaseBranch:      "main",
+		PlatformHeadSHA: "abc123def456",
+		CreatedAt:       updatedAt,
+		UpdatedAt:       updatedAt,
+		LastActivityAt:  updatedAt,
+		MergedAt:        &mergedAt,
+		ClosedAt:        &mergedAt,
+		DetailFetchedAt: &detailFetchedAt,
+	})
+	require.NoError(err)
+	require.NoError(d.UpsertHTTPEtag(
+		ctx, "github", "github.com", "owner", "repo",
+		"pull_request", 1, `"etag-v1"`,
+	))
+
+	merged := true
+	mergedBy := "merge-admin"
+	pr := buildOpenPR(1, updatedAt)
+	pr.State = new("closed")
+	pr.Merged = &merged
+	pr.MergedAt = makeTimestamp(mergedAt)
+	pr.ClosedAt = makeTimestamp(mergedAt)
+	pr.MergedBy = &gh.User{Login: &mergedBy}
+	mc := &conditionalPRTrackingClient{
+		detailTrackingClient: detailTrackingClient{
+			mockClient: mockClient{singlePR: pr},
+		},
+		notModified: true,
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc}, d, nil,
+		[]RepoRef{repo},
+		time.Minute, nil, testBudget(1000),
+	)
+
+	require.NoError(syncer.syncMRWithWatchedRef(ctx, WatchedMR{
+		Owner: "owner", Name: "repo", Number: 1, PlatformHost: "github.com",
+	}))
+
+	assert.Equal(int32(1), mc.conditionalCalls.Load())
+	assert.Equal(`"etag-v1"`, mc.receivedETag)
+	assert.Equal(int32(1), mc.getPRCalls.Load())
+	assert.Zero(int(mc.listIssueCommentsCalled.Load()),
+		"304 backfill should not run a timeline refresh")
+	events, err := d.ListMREvents(ctx, mrID)
+	require.NoError(err)
+	require.Len(events, 1)
+	assert.Equal("merged", events[0].EventType)
+	assert.Equal("merge-admin", events[0].Author)
+	assert.True(events[0].CreatedAt.Equal(mergedAt))
 }
 
 func TestSyncMRBypassesPersistedPullRequestETag(t *testing.T) {

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -5989,6 +5989,69 @@ func TestFetchMRDetailPersistsMergedActorEventFromPullRequest(t *testing.T) {
 	assert.True(events[0].CreatedAt.Equal(now.Add(time.Minute)))
 }
 
+func TestFetchProviderMRDetailPersistsMergedActorEventFromMergeRequest(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	now := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+	mergedAt := now.Add(time.Minute)
+
+	repo := RepoRef{
+		Platform:     platform.KindGitLab,
+		PlatformHost: "gitlab.example.com",
+		Owner:        "group",
+		Name:         "project",
+		RepoPath:     "group/project",
+	}
+	repoID, err := d.UpsertRepo(ctx, platform.DBRepoIdentity(platformRepoRef(repo)))
+	require.NoError(err)
+
+	provider := &syncTestReadProvider{
+		syncTestProvider: syncTestProvider{kind: platform.KindGitLab, host: "gitlab.example.com"},
+		mergeRequests: []platform.MergeRequest{{
+			Repo:           platformRepoRef(repo),
+			PlatformID:     7001,
+			Number:         7,
+			URL:            "https://gitlab.example.com/group/project/-/merge_requests/7",
+			Title:          "Merged GitLab MR",
+			Author:         "ada",
+			State:          "merged",
+			HeadBranch:     "feature",
+			BaseBranch:     "main",
+			HeadSHA:        "head-sha",
+			BaseSHA:        "base-sha",
+			CreatedAt:      now,
+			UpdatedAt:      mergedAt,
+			LastActivityAt: mergedAt,
+			MergedAt:       &mergedAt,
+			ClosedAt:       &mergedAt,
+			MergedBy:       "merge-admin",
+		}},
+	}
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+	syncer := NewSyncerWithRegistry(
+		registry, d, nil, []RepoRef{repo}, time.Minute, nil, nil,
+	)
+
+	_, err = syncer.fetchMRDetail(ctx, repo, repoID, 7, true)
+	require.NoError(err)
+
+	got, err := d.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
+	require.NoError(err)
+	require.NotNil(got)
+	assert.Equal(db.MergeRequestStateMerged, got.State)
+
+	events, err := d.ListMREvents(ctx, got.ID)
+	require.NoError(err)
+	require.Len(events, 1)
+	assert.Equal("merged", events[0].EventType)
+	assert.Equal("merge-admin", events[0].Author)
+	assert.Equal("merged this", events[0].Summary)
+	assert.True(events[0].CreatedAt.Equal(mergedAt))
+}
+
 func TestFetchMRDetailDoesNotDuplicateMergedTimelineEvent(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -5778,6 +5778,7 @@ func TestIndexUpsertMRPersistsMergedActorEventFromPullRequest(t *testing.T) {
 	syncer := NewSyncer(nil, d, nil, []RepoRef{repo}, time.Minute, nil, nil)
 
 	require.NoError(syncer.indexUpsertMR(ctx, &mockClient{}, repo, repoID, pr))
+	require.NoError(syncer.indexUpsertMR(ctx, &mockClient{}, repo, repoID, pr))
 
 	got, err := d.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
 	require.NoError(err)
@@ -8002,7 +8003,7 @@ func TestFetchMRDetailBackfillsMergedActorOn304(t *testing.T) {
 	assert.True(events[0].CreatedAt.Equal(mergedAt))
 }
 
-func TestFetchMRDetailDoesNotRepeatNoActorBackfillOn304(t *testing.T) {
+func TestFetchMRDetailRetriesNoActorBackfillOn304(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	ctx := t.Context()
@@ -8062,9 +8063,9 @@ func TestFetchMRDetailDoesNotRepeatNoActorBackfillOn304(t *testing.T) {
 
 	calls, err = syncer.fetchMRDetail(ctx, repo, repoID, 1, false)
 	require.NoError(err)
-	assert.Equal(1, calls)
+	assert.Equal(3, calls)
 	assert.Equal(int32(2), mc.conditionalCalls.Load())
-	assert.Equal(int32(1), mc.getPRCalls.Load())
+	assert.Equal(int32(2), mc.getPRCalls.Load())
 	events, err := d.ListMREvents(ctx, mrID)
 	require.NoError(err)
 	assert.Empty(events)
@@ -8133,9 +8134,9 @@ func TestFetchMRDetailKeeps304FreshWhenMergedActorTimelineBackfillFails(t *testi
 
 	calls, err = syncer.fetchMRDetail(ctx, repo, repoID, 1, false)
 	require.NoError(err)
-	assert.Equal(1, calls)
+	assert.Equal(3, calls)
 	assert.Equal(int32(2), mc.conditionalCalls.Load())
-	assert.Equal(int32(1), mc.getPRCalls.Load())
+	assert.Equal(int32(2), mc.getPRCalls.Load())
 	events, err := d.ListMREvents(ctx, mrID)
 	require.NoError(err)
 	assert.Empty(events)
@@ -8146,62 +8147,7 @@ func TestFetchMRDetailKeeps304FreshWhenMergedActorTimelineBackfillFails(t *testi
 	assert.True(fresh.DetailFetchedAt.After(detailFetchedAt))
 }
 
-func TestMergedActorDetailBackfillRetryExpires(t *testing.T) {
-	assert := assert.New(t)
-	mergedAt := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
-	existing := &db.MergeRequest{ID: 10, MergedAt: &mergedAt}
-	retryAfter := mergedAt.Add(mergedActorDetailBackfillErrorBackoff)
-	syncer := &Syncer{}
-
-	syncer.recordMergedActorDetailBackfillRetry(existing, retryAfter)
-	assert.True(syncer.skipMergedActorDetailBackfill(existing, retryAfter.Add(-time.Nanosecond)))
-	assert.False(syncer.skipMergedActorDetailBackfill(existing, retryAfter))
-	assert.False(syncer.skipMergedActorDetailBackfill(existing, retryAfter.Add(time.Second)))
-}
-
-func TestBackfillMergedActorForDetailSkipsThrottledBeforeClientLookup(t *testing.T) {
-	require := require.New(t)
-	assert := assert.New(t)
-	ctx := t.Context()
-	d := openTestDB(t)
-
-	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
-	require.NoError(err)
-	now := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
-	mergedAt := now.Add(time.Minute)
-	existing := &db.MergeRequest{
-		RepoID:         repoID,
-		PlatformID:     1000,
-		Number:         1,
-		URL:            "https://github.com/owner/repo/pull/1",
-		Title:          "test PR",
-		Author:         "alice",
-		State:          db.MergeRequestStateMerged,
-		HeadBranch:     "feature-branch",
-		BaseBranch:     "main",
-		CreatedAt:      now,
-		UpdatedAt:      mergedAt,
-		LastActivityAt: mergedAt,
-		MergedAt:       &mergedAt,
-		ClosedAt:       &mergedAt,
-	}
-	existing.ID, err = d.UpsertMergeRequest(ctx, existing)
-	require.NoError(err)
-
-	syncer := NewSyncer(
-		map[string]Client{},
-		d, nil,
-		[]RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}},
-		time.Minute, nil, nil,
-	)
-	syncer.recordMergedActorDetailBackfillTerminalMiss(existing)
-
-	wrote, err := syncer.BackfillMergedActorForDetail(ctx, existing)
-	require.NoError(err)
-	assert.False(wrote)
-}
-
-func TestBackfillMergedActorForDetailRecordsRetryOnTimelineError(t *testing.T) {
+func TestBackfillMergedActorForDetailRetriesAfterTimelineError(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -8256,9 +8202,10 @@ func TestBackfillMergedActorForDetailRecordsRetryOnTimelineError(t *testing.T) {
 	assert.Equal(int32(1), client.getPRCalls.Load())
 
 	wrote, err = syncer.BackfillMergedActorForDetail(ctx, existing)
-	require.NoError(err)
+	require.Error(err)
+	require.ErrorContains(err, "list timeline events for merged actor backfill")
 	assert.False(wrote)
-	assert.Equal(int32(1), client.getPRCalls.Load())
+	assert.Equal(int32(2), client.getPRCalls.Load())
 }
 
 func TestWatchedSyncMRUsesPersistedPullRequestETag(t *testing.T) {

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -5887,6 +5887,63 @@ func TestFetchMRDetailPersistsWorkflowApproval(t *testing.T) {
 	assert.Equal(1, got.WorkflowApprovalCount)
 }
 
+func TestFetchMRDetailPersistsMergedActorEventFromPullRequest(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	now := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+
+	repo := RepoRef{
+		Platform:     platform.KindGitHub,
+		PlatformHost: "github.com",
+		Owner:        "acme",
+		Name:         "widget",
+	}
+	repoID, err := d.UpsertRepo(ctx, platform.DBRepoIdentity(platformRepoRef(repo)))
+	require.NoError(err)
+
+	merged := true
+	mergedBy := "merge-admin"
+	pr := buildOpenPR(7, now)
+	pr.State = new("closed")
+	pr.Merged = &merged
+	pr.MergedAt = makeTimestamp(now.Add(time.Minute))
+	pr.ClosedAt = makeTimestamp(now.Add(time.Minute))
+	pr.UpdatedAt = makeTimestamp(now.Add(time.Minute))
+	pr.MergedBy = &gh.User{Login: &mergedBy}
+	mc := &mockClient{
+		singlePR: pr,
+		comments: []*gh.IssueComment{},
+		reviews:  []*gh.PullRequestReview{},
+		commits:  []*gh.RepositoryCommit{},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc},
+		d, nil,
+		[]RepoRef{repo},
+		time.Minute,
+		nil,
+		nil,
+	)
+
+	_, err = syncer.fetchMRDetail(ctx, repo, repoID, 7, true)
+	require.NoError(err)
+
+	got, err := d.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
+	require.NoError(err)
+	require.NotNil(got)
+	assert.Equal(db.MergeRequestStateMerged, got.State)
+
+	events, err := d.ListMREvents(ctx, got.ID)
+	require.NoError(err)
+	require.Len(events, 1)
+	assert.Equal("merged", events[0].EventType)
+	assert.Equal("merge-admin", events[0].Author)
+	assert.Equal("merged this", events[0].Summary)
+	assert.True(events[0].CreatedAt.Equal(now.Add(time.Minute)))
+}
+
 func TestFetchProviderMRDetailSyncsReviewThreads(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -9053,6 +9110,49 @@ func TestFetchAndUpdateClosedRefreshesPRLabels(t *testing.T) {
 	require.Len(storedAfter.Labels, 1)
 	require.Equal("release", storedAfter.Labels[0].Name)
 	require.Equal(int64(902), storedAfter.Labels[0].PlatformID)
+}
+
+func TestFetchAndUpdateClosedPersistsMergedActorEvent(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
+	require.NoError(err)
+	now := time.Date(2024, 6, 5, 12, 0, 0, 0, time.UTC)
+	pr := buildOpenPR(7, now)
+	normalizedPR, err := NormalizePR(repoID, pr)
+	require.NoError(err)
+	_, err = d.UpsertMergeRequest(ctx, normalizedPR)
+	require.NoError(err)
+
+	merged := true
+	mergedBy := "merge-admin"
+	pr.State = new("closed")
+	pr.Merged = &merged
+	pr.MergedAt = makeTimestamp(now.Add(time.Minute))
+	pr.ClosedAt = makeTimestamp(now.Add(time.Minute))
+	pr.UpdatedAt = makeTimestamp(now.Add(time.Minute))
+	pr.MergedBy = &gh.User{Login: &mergedBy}
+
+	mc := &mockClient{singlePR: pr}
+	syncer := NewSyncer(map[string]Client{"github.com": mc}, d, nil, []RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}}, time.Minute, nil, nil)
+
+	require.NoError(syncer.fetchAndUpdateClosed(ctx, RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}, repoID, 7, false))
+
+	storedAfter, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 7)
+	require.NoError(err)
+	require.NotNil(storedAfter)
+	assert.Equal(db.MergeRequestStateMerged, storedAfter.State)
+
+	events, err := d.ListMREvents(ctx, storedAfter.ID)
+	require.NoError(err)
+	require.Len(events, 1)
+	assert.Equal("merged", events[0].EventType)
+	assert.Equal("merge-admin", events[0].Author)
+	assert.Equal("merged this", events[0].Summary)
+	assert.True(events[0].CreatedAt.Equal(now.Add(time.Minute)))
 }
 
 func TestFetchAndUpdateClosedRefreshesPRLabelsWithSameRepoOnAnotherHost(t *testing.T) {

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -6055,7 +6055,7 @@ func TestRefreshTimelineSkipsMergedEventWhenAuthoredMergedEventAlreadyExists(t *
 			NodeID:    "ME_1",
 			EventType: "merged",
 			Actor:     mergedBy,
-			CreatedAt: mergedAt,
+			CreatedAt: mergedAt.Add(time.Second),
 		}},
 	}
 	syncer := NewSyncer(

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -5944,6 +5944,200 @@ func TestFetchMRDetailPersistsMergedActorEventFromPullRequest(t *testing.T) {
 	assert.True(events[0].CreatedAt.Equal(now.Add(time.Minute)))
 }
 
+func TestFetchMRDetailDoesNotDuplicateMergedTimelineEvent(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	now := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+	mergedAt := now.Add(time.Minute)
+
+	repo := RepoRef{
+		Platform:     platform.KindGitHub,
+		PlatformHost: "github.com",
+		Owner:        "acme",
+		Name:         "widget",
+	}
+	repoID, err := d.UpsertRepo(ctx, platform.DBRepoIdentity(platformRepoRef(repo)))
+	require.NoError(err)
+
+	merged := true
+	mergedBy := "merge-admin"
+	pr := buildOpenPR(7, now)
+	pr.State = new("closed")
+	pr.Merged = &merged
+	pr.MergedAt = makeTimestamp(mergedAt)
+	pr.ClosedAt = makeTimestamp(mergedAt)
+	pr.UpdatedAt = makeTimestamp(mergedAt)
+	pr.MergedBy = &gh.User{Login: &mergedBy}
+	mc := &mockClient{
+		singlePR: pr,
+		comments: []*gh.IssueComment{},
+		reviews:  []*gh.PullRequestReview{},
+		commits:  []*gh.RepositoryCommit{},
+		timelineEvents: []PullRequestTimelineEvent{{
+			NodeID:    "ME_1",
+			EventType: "merged",
+			Actor:     mergedBy,
+			CreatedAt: mergedAt,
+		}},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc},
+		d, nil,
+		[]RepoRef{repo},
+		time.Minute,
+		nil,
+		nil,
+	)
+
+	_, err = syncer.fetchMRDetail(ctx, repo, repoID, 7, true)
+	require.NoError(err)
+
+	got, err := d.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
+	require.NoError(err)
+	require.NotNil(got)
+	assert.Equal(db.MergeRequestStateMerged, got.State)
+
+	events, err := d.ListMREvents(ctx, got.ID)
+	require.NoError(err)
+	require.Len(events, 1)
+	assert.Equal("merged", events[0].EventType)
+	assert.Equal("merge-admin", events[0].Author)
+	assert.Equal("merged this", events[0].Summary)
+	assert.True(events[0].CreatedAt.Equal(mergedAt))
+}
+
+func TestRefreshTimelineSkipsMergedEventWhenAuthoredMergedEventAlreadyExists(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	now := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+	mergedAt := now.Add(time.Minute)
+
+	repo := RepoRef{
+		Platform:     platform.KindGitHub,
+		PlatformHost: "github.com",
+		Owner:        "acme",
+		Name:         "widget",
+	}
+	repoID, err := d.UpsertRepo(ctx, platform.DBRepoIdentity(platformRepoRef(repo)))
+	require.NoError(err)
+
+	merged := true
+	mergedBy := "merge-admin"
+	pr := buildOpenPR(7, now)
+	pr.State = new("closed")
+	pr.Merged = &merged
+	pr.MergedAt = makeTimestamp(mergedAt)
+	pr.ClosedAt = makeTimestamp(mergedAt)
+	pr.UpdatedAt = makeTimestamp(mergedAt)
+	pr.MergedBy = &gh.User{Login: &mergedBy}
+	normalized, err := NormalizePR(repoID, pr)
+	require.NoError(err)
+	mrID, err := d.UpsertMergeRequest(ctx, normalized)
+	require.NoError(err)
+	require.NoError(d.UpsertMREvents(ctx, []db.MREvent{{
+		MergeRequestID: mrID,
+		EventType:      "merged",
+		Author:         mergedBy,
+		Summary:        "merged this",
+		CreatedAt:      mergedAt,
+		DedupeKey:      "timeline-fallback",
+	}}))
+
+	mc := &mockClient{
+		comments: []*gh.IssueComment{},
+		reviews:  []*gh.PullRequestReview{},
+		commits:  []*gh.RepositoryCommit{},
+		timelineEvents: []PullRequestTimelineEvent{{
+			NodeID:    "ME_1",
+			EventType: "merged",
+			Actor:     mergedBy,
+			CreatedAt: mergedAt,
+		}},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc},
+		d, nil,
+		[]RepoRef{repo},
+		time.Minute,
+		nil,
+		nil,
+	)
+
+	require.NoError(syncer.refreshTimeline(ctx, repo, repoID, mrID, pr))
+
+	events, err := d.ListMREvents(ctx, mrID)
+	require.NoError(err)
+	require.Len(events, 1)
+	assert.Equal("merged", events[0].EventType)
+	assert.Equal("merge-admin", events[0].Author)
+	assert.Equal("timeline-fallback", events[0].DedupeKey)
+	assert.True(events[0].CreatedAt.Equal(mergedAt))
+}
+
+func TestSyncOpenMRFromBulkPersistsMergedActorEventFromPullRequest(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	now := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+	mergedAt := now.Add(time.Minute)
+
+	repo := RepoRef{
+		Platform:     platform.KindGitHub,
+		PlatformHost: "github.com",
+		Owner:        "acme",
+		Name:         "widget",
+	}
+	repoID, err := d.UpsertRepo(ctx, platform.DBRepoIdentity(platformRepoRef(repo)))
+	require.NoError(err)
+
+	merged := true
+	mergedBy := "merge-admin"
+	pr := buildOpenPR(7, now)
+	pr.State = new("closed")
+	pr.Merged = &merged
+	pr.MergedAt = makeTimestamp(mergedAt)
+	pr.ClosedAt = makeTimestamp(mergedAt)
+	pr.UpdatedAt = makeTimestamp(mergedAt)
+	pr.MergedBy = &gh.User{Login: &mergedBy}
+
+	syncer := NewSyncer(
+		map[string]Client{"github.com": &mockClient{}},
+		d, nil,
+		[]RepoRef{repo},
+		time.Minute,
+		nil,
+		nil,
+	)
+
+	err = syncer.syncOpenMRFromBulk(ctx, repo, repoID, &BulkPR{
+		PR:               pr,
+		CommentsComplete: true,
+		ReviewsComplete:  true,
+		CommitsComplete:  true,
+		TimelineComplete: true,
+		CIComplete:       true,
+	}, true)
+	require.NoError(err)
+
+	got, err := d.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
+	require.NoError(err)
+	require.NotNil(got)
+	assert.Equal(db.MergeRequestStateMerged, got.State)
+
+	events, err := d.ListMREvents(ctx, got.ID)
+	require.NoError(err)
+	require.Len(events, 1)
+	assert.Equal("merged", events[0].EventType)
+	assert.Equal("merge-admin", events[0].Author)
+	assert.Equal("merged this", events[0].Summary)
+	assert.True(events[0].CreatedAt.Equal(mergedAt))
+}
+
 func TestFetchProviderMRDetailSyncsReviewThreads(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -7876,6 +7876,87 @@ func TestFetchMRDetailBackfillsMergedActorOn304(t *testing.T) {
 	assert.True(events[0].CreatedAt.Equal(mergedAt))
 }
 
+func TestFetchMRDetailDoesNotRepeatNoActorBackfillOn304(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	repo := RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", repo.Owner, repo.Name))
+	require.NoError(err)
+	updatedAt := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
+	mergedAt := updatedAt.Add(time.Minute)
+	detailFetchedAt := updatedAt.Add(-time.Hour)
+	mrID, err := d.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:          repoID,
+		PlatformID:      1000,
+		Number:          1,
+		URL:             "https://github.com/owner/repo/pull/1",
+		Title:           "test PR",
+		Author:          "alice",
+		State:           db.MergeRequestStateMerged,
+		HeadBranch:      "feature-branch",
+		BaseBranch:      "main",
+		PlatformHeadSHA: "abc123def456",
+		CreatedAt:       updatedAt,
+		UpdatedAt:       updatedAt,
+		LastActivityAt:  updatedAt,
+		MergedAt:        &mergedAt,
+		ClosedAt:        &mergedAt,
+		DetailFetchedAt: &detailFetchedAt,
+	})
+	require.NoError(err)
+	require.NoError(d.UpsertHTTPEtag(
+		ctx, "github", "github.com", "owner", "repo",
+		"pull_request", 1, `"etag-v1"`,
+	))
+
+	merged := true
+	pr := buildOpenPR(1, updatedAt)
+	pr.State = new("closed")
+	pr.Merged = &merged
+	pr.MergedAt = makeTimestamp(mergedAt)
+	pr.ClosedAt = makeTimestamp(mergedAt)
+	mc := &conditionalPRTrackingClient{
+		detailTrackingClient: detailTrackingClient{
+			mockClient: mockClient{singlePR: pr},
+		},
+		notModified: true,
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc}, d, nil,
+		[]RepoRef{repo},
+		time.Minute, nil, testBudget(1000),
+	)
+
+	calls, err := syncer.fetchMRDetail(ctx, repo, repoID, 1, false)
+	require.NoError(err)
+	assert.Equal(2, calls)
+
+	calls, err = syncer.fetchMRDetail(ctx, repo, repoID, 1, false)
+	require.NoError(err)
+	assert.Equal(1, calls)
+	assert.Equal(int32(2), mc.conditionalCalls.Load())
+	assert.Equal(int32(1), mc.getPRCalls.Load())
+	events, err := d.ListMREvents(ctx, mrID)
+	require.NoError(err)
+	assert.Empty(events)
+}
+
+func TestMergedActorDetailBackfillRetryExpires(t *testing.T) {
+	assert := assert.New(t)
+	mergedAt := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
+	existing := &db.MergeRequest{ID: 10, MergedAt: &mergedAt}
+	retryAfter := mergedAt.Add(mergedActorDetailBackfillErrorBackoff)
+	syncer := &Syncer{}
+
+	syncer.recordMergedActorDetailBackfillRetry(existing, retryAfter)
+	assert.True(syncer.skipMergedActorDetailBackfill(existing, retryAfter.Add(-time.Nanosecond)))
+	assert.False(syncer.skipMergedActorDetailBackfill(existing, retryAfter))
+	assert.False(syncer.skipMergedActorDetailBackfill(existing, retryAfter.Add(time.Second)))
+}
+
 func TestWatchedSyncMRUsesPersistedPullRequestETag(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -8026,6 +8026,82 @@ func TestFetchMRDetailDoesNotRepeatNoActorBackfillOn304(t *testing.T) {
 	assert.Empty(events)
 }
 
+func TestFetchMRDetailKeeps304FreshWhenMergedActorTimelineBackfillFails(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	repo := RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", repo.Owner, repo.Name))
+	require.NoError(err)
+	updatedAt := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
+	mergedAt := updatedAt.Add(time.Minute)
+	detailFetchedAt := updatedAt.Add(-time.Hour)
+	mrID, err := d.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:          repoID,
+		PlatformID:      1000,
+		Number:          1,
+		URL:             "https://github.com/owner/repo/pull/1",
+		Title:           "test PR",
+		Author:          "alice",
+		State:           db.MergeRequestStateMerged,
+		HeadBranch:      "feature-branch",
+		BaseBranch:      "main",
+		PlatformHeadSHA: "abc123def456",
+		CreatedAt:       updatedAt,
+		UpdatedAt:       updatedAt,
+		LastActivityAt:  updatedAt,
+		MergedAt:        &mergedAt,
+		ClosedAt:        &mergedAt,
+		DetailFetchedAt: &detailFetchedAt,
+	})
+	require.NoError(err)
+	require.NoError(d.UpsertHTTPEtag(
+		ctx, "github", "github.com", "owner", "repo",
+		"pull_request", 1, `"etag-v1"`,
+	))
+
+	merged := true
+	pr := buildOpenPR(1, updatedAt)
+	pr.State = new("closed")
+	pr.Merged = &merged
+	pr.MergedAt = makeTimestamp(mergedAt)
+	pr.ClosedAt = makeTimestamp(mergedAt)
+	mc := &conditionalPRTrackingClient{
+		detailTrackingClient: detailTrackingClient{
+			mockClient: mockClient{
+				singlePR:          pr,
+				timelineEventsErr: errors.New("graphql unavailable"),
+			},
+		},
+		notModified: true,
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc}, d, nil,
+		[]RepoRef{repo},
+		time.Minute, nil, testBudget(1000),
+	)
+
+	calls, err := syncer.fetchMRDetail(ctx, repo, repoID, 1, false)
+	require.NoError(err)
+	assert.Equal(3, calls)
+
+	calls, err = syncer.fetchMRDetail(ctx, repo, repoID, 1, false)
+	require.NoError(err)
+	assert.Equal(1, calls)
+	assert.Equal(int32(2), mc.conditionalCalls.Load())
+	assert.Equal(int32(1), mc.getPRCalls.Load())
+	events, err := d.ListMREvents(ctx, mrID)
+	require.NoError(err)
+	assert.Empty(events)
+	fresh, err := d.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 1)
+	require.NoError(err)
+	require.NotNil(fresh)
+	require.NotNil(fresh.DetailFetchedAt)
+	assert.True(fresh.DetailFetchedAt.After(detailFetchedAt))
+}
+
 func TestMergedActorDetailBackfillRetryExpires(t *testing.T) {
 	assert := assert.New(t)
 	mergedAt := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
@@ -8079,6 +8155,66 @@ func TestBackfillMergedActorForDetailSkipsThrottledBeforeClientLookup(t *testing
 	wrote, err := syncer.BackfillMergedActorForDetail(ctx, existing)
 	require.NoError(err)
 	assert.False(wrote)
+}
+
+func TestBackfillMergedActorForDetailRecordsRetryOnTimelineError(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
+	require.NoError(err)
+	now := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
+	mergedAt := now.Add(time.Minute)
+	existing := &db.MergeRequest{
+		RepoID:         repoID,
+		PlatformID:     1000,
+		Number:         1,
+		URL:            "https://github.com/owner/repo/pull/1",
+		Title:          "test PR",
+		Author:         "alice",
+		State:          db.MergeRequestStateMerged,
+		HeadBranch:     "feature-branch",
+		BaseBranch:     "main",
+		CreatedAt:      now,
+		UpdatedAt:      mergedAt,
+		LastActivityAt: mergedAt,
+		MergedAt:       &mergedAt,
+		ClosedAt:       &mergedAt,
+	}
+	existing.ID, err = d.UpsertMergeRequest(ctx, existing)
+	require.NoError(err)
+
+	merged := true
+	pr := buildOpenPR(1, now)
+	pr.State = new("closed")
+	pr.Merged = &merged
+	pr.MergedAt = makeTimestamp(mergedAt)
+	pr.ClosedAt = makeTimestamp(mergedAt)
+	client := &detailTrackingClient{
+		mockClient: mockClient{
+			singlePR:          pr,
+			timelineEventsErr: errors.New("graphql unavailable"),
+		},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client},
+		d, nil,
+		[]RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}},
+		time.Minute, nil, nil,
+	)
+
+	wrote, err := syncer.BackfillMergedActorForDetail(ctx, existing)
+	require.Error(err)
+	assert.ErrorContains(err, "list timeline events for merged actor backfill")
+	assert.False(wrote)
+	assert.Equal(int32(1), client.getPRCalls.Load())
+
+	wrote, err = syncer.BackfillMergedActorForDetail(ctx, existing)
+	require.NoError(err)
+	assert.False(wrote)
+	assert.Equal(int32(1), client.getPRCalls.Load())
 }
 
 func TestWatchedSyncMRUsesPersistedPullRequestETag(t *testing.T) {
@@ -8208,6 +8344,82 @@ func TestWatchedSyncMRBackfillsMergedActorOn304(t *testing.T) {
 	assert.Equal("merged", events[0].EventType)
 	assert.Equal("merge-admin", events[0].Author)
 	assert.True(events[0].CreatedAt.Equal(mergedAt))
+}
+
+func TestWatchedSyncMRKeeps304FreshWhenMergedActorTimelineBackfillFails(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	repo := RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", repo.Owner, repo.Name))
+	require.NoError(err)
+	updatedAt := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
+	mergedAt := updatedAt.Add(time.Minute)
+	detailFetchedAt := updatedAt.Add(-time.Hour)
+	mrID, err := d.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:          repoID,
+		PlatformID:      1000,
+		Number:          1,
+		URL:             "https://github.com/owner/repo/pull/1",
+		Title:           "test PR",
+		Author:          "alice",
+		State:           db.MergeRequestStateMerged,
+		HeadBranch:      "feature-branch",
+		BaseBranch:      "main",
+		PlatformHeadSHA: "abc123def456",
+		CreatedAt:       updatedAt,
+		UpdatedAt:       updatedAt,
+		LastActivityAt:  updatedAt,
+		MergedAt:        &mergedAt,
+		ClosedAt:        &mergedAt,
+		DetailFetchedAt: &detailFetchedAt,
+	})
+	require.NoError(err)
+	require.NoError(d.UpsertHTTPEtag(
+		ctx, "github", "github.com", "owner", "repo",
+		"pull_request", 1, `"etag-v1"`,
+	))
+
+	merged := true
+	pr := buildOpenPR(1, updatedAt)
+	pr.State = new("closed")
+	pr.Merged = &merged
+	pr.MergedAt = makeTimestamp(mergedAt)
+	pr.ClosedAt = makeTimestamp(mergedAt)
+	mc := &conditionalPRTrackingClient{
+		detailTrackingClient: detailTrackingClient{
+			mockClient: mockClient{
+				singlePR:          pr,
+				timelineEventsErr: errors.New("graphql unavailable"),
+			},
+		},
+		notModified: true,
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc}, d, nil,
+		[]RepoRef{repo},
+		time.Minute, nil, testBudget(1000),
+	)
+
+	require.NoError(syncer.syncMRWithWatchedRef(ctx, WatchedMR{
+		Owner: "owner", Name: "repo", Number: 1, PlatformHost: "github.com",
+	}))
+
+	assert.Equal(int32(1), mc.conditionalCalls.Load())
+	assert.Equal(`"etag-v1"`, mc.receivedETag)
+	assert.Equal(int32(1), mc.getPRCalls.Load())
+	assert.Zero(int(mc.listIssueCommentsCalled.Load()),
+		"304 backfill should not run a timeline refresh")
+	events, err := d.ListMREvents(ctx, mrID)
+	require.NoError(err)
+	assert.Empty(events)
+	fresh, err := d.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 1)
+	require.NoError(err)
+	require.NotNil(fresh)
+	require.NotNil(fresh.DetailFetchedAt)
+	assert.True(fresh.DetailFetchedAt.After(detailFetchedAt))
 }
 
 func TestSyncMRBypassesPersistedPullRequestETag(t *testing.T) {

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -6138,6 +6138,88 @@ func TestSyncOpenMRFromBulkPersistsMergedActorEventFromPullRequest(t *testing.T)
 	assert.True(events[0].CreatedAt.Equal(mergedAt))
 }
 
+func TestSyncOpenMRFromBulkSkipsMergedActorFallbackWhenAuthoredMergedEventExists(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	now := time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC)
+	existingMergedAt := now.Add(time.Minute)
+	incomingMergedAt := existingMergedAt.Add(time.Second)
+
+	repo := RepoRef{
+		Platform:     platform.KindGitHub,
+		PlatformHost: "github.com",
+		Owner:        "acme",
+		Name:         "widget",
+	}
+	repoID, err := d.UpsertRepo(ctx, platform.DBRepoIdentity(platformRepoRef(repo)))
+	require.NoError(err)
+
+	mrID, err := d.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:         repoID,
+		PlatformID:     7000,
+		Number:         7,
+		URL:            "https://github.com/acme/widget/pull/7",
+		Title:          "Merged PR",
+		Author:         "alice",
+		State:          db.MergeRequestStateMerged,
+		HeadBranch:     "feature",
+		BaseBranch:     "main",
+		CreatedAt:      now,
+		UpdatedAt:      existingMergedAt,
+		LastActivityAt: existingMergedAt,
+		MergedAt:       &existingMergedAt,
+		ClosedAt:       &existingMergedAt,
+	})
+	require.NoError(err)
+	require.NoError(d.UpsertMREvents(ctx, []db.MREvent{{
+		MergeRequestID: mrID,
+		EventType:      "merged",
+		Author:         "merge-admin",
+		Summary:        "merged this",
+		CreatedAt:      existingMergedAt,
+		DedupeKey:      "timeline-existing",
+	}}))
+
+	merged := true
+	mergedBy := "merge-admin"
+	pr := buildOpenPR(7, now)
+	pr.State = new("closed")
+	pr.Merged = &merged
+	pr.MergedAt = makeTimestamp(incomingMergedAt)
+	pr.ClosedAt = makeTimestamp(incomingMergedAt)
+	pr.UpdatedAt = makeTimestamp(incomingMergedAt)
+	pr.MergedBy = &gh.User{Login: &mergedBy}
+
+	syncer := NewSyncer(
+		map[string]Client{"github.com": &mockClient{}},
+		d, nil,
+		[]RepoRef{repo},
+		time.Minute,
+		nil,
+		nil,
+	)
+
+	err = syncer.syncOpenMRFromBulk(ctx, repo, repoID, &BulkPR{
+		PR:               pr,
+		CommentsComplete: true,
+		ReviewsComplete:  true,
+		CommitsComplete:  true,
+		TimelineComplete: true,
+		CIComplete:       true,
+	}, true)
+	require.NoError(err)
+
+	events, err := d.ListMREvents(ctx, mrID)
+	require.NoError(err)
+	require.Len(events, 1)
+	assert.Equal("merged", events[0].EventType)
+	assert.Equal("merge-admin", events[0].Author)
+	assert.Equal("timeline-existing", events[0].DedupeKey)
+	assert.True(events[0].CreatedAt.Equal(existingMergedAt))
+}
+
 func TestFetchProviderMRDetailSyncsReviewThreads(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -8014,7 +8014,7 @@ func TestFetchMRDetailDoesNotRepeatNoActorBackfillOn304(t *testing.T) {
 
 	calls, err := syncer.fetchMRDetail(ctx, repo, repoID, 1, false)
 	require.NoError(err)
-	assert.Equal(2, calls)
+	assert.Equal(3, calls)
 
 	calls, err = syncer.fetchMRDetail(ctx, repo, repoID, 1, false)
 	require.NoError(err)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -8039,6 +8039,48 @@ func TestMergedActorDetailBackfillRetryExpires(t *testing.T) {
 	assert.False(syncer.skipMergedActorDetailBackfill(existing, retryAfter.Add(time.Second)))
 }
 
+func TestBackfillMergedActorForDetailSkipsThrottledBeforeClientLookup(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
+	require.NoError(err)
+	now := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
+	mergedAt := now.Add(time.Minute)
+	existing := &db.MergeRequest{
+		RepoID:         repoID,
+		PlatformID:     1000,
+		Number:         1,
+		URL:            "https://github.com/owner/repo/pull/1",
+		Title:          "test PR",
+		Author:         "alice",
+		State:          db.MergeRequestStateMerged,
+		HeadBranch:     "feature-branch",
+		BaseBranch:     "main",
+		CreatedAt:      now,
+		UpdatedAt:      mergedAt,
+		LastActivityAt: mergedAt,
+		MergedAt:       &mergedAt,
+		ClosedAt:       &mergedAt,
+	}
+	existing.ID, err = d.UpsertMergeRequest(ctx, existing)
+	require.NoError(err)
+
+	syncer := NewSyncer(
+		map[string]Client{},
+		d, nil,
+		[]RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}},
+		time.Minute, nil, nil,
+	)
+	syncer.recordMergedActorDetailBackfillTerminalMiss(existing)
+
+	wrote, err := syncer.BackfillMergedActorForDetail(ctx, existing)
+	require.NoError(err)
+	assert.False(wrote)
+}
+
 func TestWatchedSyncMRUsesPersistedPullRequestETag(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -7993,7 +7993,7 @@ func TestFetchMRDetailUsesPersistedPullRequestETag(t *testing.T) {
 		"304 should skip timeline/comment refresh")
 }
 
-func TestFetchMRDetailBackfillsMergedActorOn304(t *testing.T) {
+func TestFetchMRDetailDoesNotBackfillMergedActorOn304(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	ctx := t.Context()
@@ -8029,158 +8029,10 @@ func TestFetchMRDetailBackfillsMergedActorOn304(t *testing.T) {
 		"pull_request", 1, `"etag-v1"`,
 	))
 
-	merged := true
-	mergedBy := "merge-admin"
-	pr := buildOpenPR(1, updatedAt)
-	pr.State = new("closed")
-	pr.Merged = &merged
-	pr.MergedAt = makeTimestamp(mergedAt)
-	pr.ClosedAt = makeTimestamp(mergedAt)
-	pr.MergedBy = &gh.User{Login: &mergedBy}
-	mc := &conditionalPRTrackingClient{
-		detailTrackingClient: detailTrackingClient{
-			mockClient: mockClient{singlePR: pr},
-		},
-		notModified: true,
-	}
-	syncer := NewSyncer(
-		map[string]Client{"github.com": mc}, d, nil,
-		[]RepoRef{repo},
-		time.Minute, nil, testBudget(1000),
-	)
-
-	calls, err := syncer.fetchMRDetail(ctx, repo, repoID, 1, false)
-	require.NoError(err)
-
-	assert.Equal(2, calls)
-	assert.Equal(int32(1), mc.conditionalCalls.Load())
-	assert.Equal(`"etag-v1"`, mc.receivedETag)
-	assert.Equal(int32(1), mc.getPRCalls.Load())
-	assert.Zero(int(mc.listIssueCommentsCalled.Load()),
-		"304 backfill should not run a timeline refresh")
-	events, err := d.ListMREvents(ctx, mrID)
-	require.NoError(err)
-	require.Len(events, 1)
-	assert.Equal("merged", events[0].EventType)
-	assert.Equal("merge-admin", events[0].Author)
-	assert.True(events[0].CreatedAt.Equal(mergedAt))
-}
-
-func TestFetchMRDetailRetriesNoActorBackfillOn304(t *testing.T) {
-	assert := assert.New(t)
-	require := require.New(t)
-	ctx := t.Context()
-	d := openTestDB(t)
-
-	repo := RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}
-	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", repo.Owner, repo.Name))
-	require.NoError(err)
-	updatedAt := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
-	mergedAt := updatedAt.Add(time.Minute)
-	detailFetchedAt := updatedAt.Add(-time.Hour)
-	mrID, err := d.UpsertMergeRequest(ctx, &db.MergeRequest{
-		RepoID:          repoID,
-		PlatformID:      1000,
-		Number:          1,
-		URL:             "https://github.com/owner/repo/pull/1",
-		Title:           "test PR",
-		Author:          "alice",
-		State:           db.MergeRequestStateMerged,
-		HeadBranch:      "feature-branch",
-		BaseBranch:      "main",
-		PlatformHeadSHA: "abc123def456",
-		CreatedAt:       updatedAt,
-		UpdatedAt:       updatedAt,
-		LastActivityAt:  updatedAt,
-		MergedAt:        &mergedAt,
-		ClosedAt:        &mergedAt,
-		DetailFetchedAt: &detailFetchedAt,
-	})
-	require.NoError(err)
-	require.NoError(d.UpsertHTTPEtag(
-		ctx, "github", "github.com", "owner", "repo",
-		"pull_request", 1, `"etag-v1"`,
-	))
-
-	merged := true
-	pr := buildOpenPR(1, updatedAt)
-	pr.State = new("closed")
-	pr.Merged = &merged
-	pr.MergedAt = makeTimestamp(mergedAt)
-	pr.ClosedAt = makeTimestamp(mergedAt)
-	mc := &conditionalPRTrackingClient{
-		detailTrackingClient: detailTrackingClient{
-			mockClient: mockClient{singlePR: pr},
-		},
-		notModified: true,
-	}
-	syncer := NewSyncer(
-		map[string]Client{"github.com": mc}, d, nil,
-		[]RepoRef{repo},
-		time.Minute, nil, testBudget(1000),
-	)
-
-	calls, err := syncer.fetchMRDetail(ctx, repo, repoID, 1, false)
-	require.NoError(err)
-	assert.Equal(3, calls)
-
-	calls, err = syncer.fetchMRDetail(ctx, repo, repoID, 1, false)
-	require.NoError(err)
-	assert.Equal(3, calls)
-	assert.Equal(int32(2), mc.conditionalCalls.Load())
-	assert.Equal(int32(2), mc.getPRCalls.Load())
-	events, err := d.ListMREvents(ctx, mrID)
-	require.NoError(err)
-	assert.Empty(events)
-}
-
-func TestFetchMRDetailKeeps304FreshWhenMergedActorTimelineBackfillFails(t *testing.T) {
-	assert := assert.New(t)
-	require := require.New(t)
-	ctx := t.Context()
-	d := openTestDB(t)
-
-	repo := RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}
-	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", repo.Owner, repo.Name))
-	require.NoError(err)
-	updatedAt := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
-	mergedAt := updatedAt.Add(time.Minute)
-	detailFetchedAt := updatedAt.Add(-time.Hour)
-	mrID, err := d.UpsertMergeRequest(ctx, &db.MergeRequest{
-		RepoID:          repoID,
-		PlatformID:      1000,
-		Number:          1,
-		URL:             "https://github.com/owner/repo/pull/1",
-		Title:           "test PR",
-		Author:          "alice",
-		State:           db.MergeRequestStateMerged,
-		HeadBranch:      "feature-branch",
-		BaseBranch:      "main",
-		PlatformHeadSHA: "abc123def456",
-		CreatedAt:       updatedAt,
-		UpdatedAt:       updatedAt,
-		LastActivityAt:  updatedAt,
-		MergedAt:        &mergedAt,
-		ClosedAt:        &mergedAt,
-		DetailFetchedAt: &detailFetchedAt,
-	})
-	require.NoError(err)
-	require.NoError(d.UpsertHTTPEtag(
-		ctx, "github", "github.com", "owner", "repo",
-		"pull_request", 1, `"etag-v1"`,
-	))
-
-	merged := true
-	pr := buildOpenPR(1, updatedAt)
-	pr.State = new("closed")
-	pr.Merged = &merged
-	pr.MergedAt = makeTimestamp(mergedAt)
-	pr.ClosedAt = makeTimestamp(mergedAt)
 	mc := &conditionalPRTrackingClient{
 		detailTrackingClient: detailTrackingClient{
 			mockClient: mockClient{
-				singlePR:          pr,
-				timelineEventsErr: errors.New("graphql unavailable"),
+				timelineEventsErr: errors.New("304 detail path must not fetch timeline events"),
 			},
 		},
 		notModified: true,
@@ -8193,13 +8045,14 @@ func TestFetchMRDetailKeeps304FreshWhenMergedActorTimelineBackfillFails(t *testi
 
 	calls, err := syncer.fetchMRDetail(ctx, repo, repoID, 1, false)
 	require.NoError(err)
-	assert.Equal(3, calls)
 
-	calls, err = syncer.fetchMRDetail(ctx, repo, repoID, 1, false)
-	require.NoError(err)
-	assert.Equal(3, calls)
-	assert.Equal(int32(2), mc.conditionalCalls.Load())
-	assert.Equal(int32(2), mc.getPRCalls.Load())
+	assert.Equal(1, calls)
+	assert.Equal(int32(1), mc.conditionalCalls.Load())
+	assert.Equal(`"etag-v1"`, mc.receivedETag)
+	assert.Zero(int(mc.getPRCalls.Load()),
+		"304 should skip the unconditional PR detail fetch")
+	assert.Zero(int(mc.listIssueCommentsCalled.Load()),
+		"304 should skip timeline/comment refresh")
 	events, err := d.ListMREvents(ctx, mrID)
 	require.NoError(err)
 	assert.Empty(events)
@@ -8208,67 +8061,6 @@ func TestFetchMRDetailKeeps304FreshWhenMergedActorTimelineBackfillFails(t *testi
 	require.NotNil(fresh)
 	require.NotNil(fresh.DetailFetchedAt)
 	assert.True(fresh.DetailFetchedAt.After(detailFetchedAt))
-}
-
-func TestBackfillMergedActorForDetailRetriesAfterTimelineError(t *testing.T) {
-	require := require.New(t)
-	assert := assert.New(t)
-	ctx := t.Context()
-	d := openTestDB(t)
-
-	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
-	require.NoError(err)
-	now := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
-	mergedAt := now.Add(time.Minute)
-	existing := &db.MergeRequest{
-		RepoID:         repoID,
-		PlatformID:     1000,
-		Number:         1,
-		URL:            "https://github.com/owner/repo/pull/1",
-		Title:          "test PR",
-		Author:         "alice",
-		State:          db.MergeRequestStateMerged,
-		HeadBranch:     "feature-branch",
-		BaseBranch:     "main",
-		CreatedAt:      now,
-		UpdatedAt:      mergedAt,
-		LastActivityAt: mergedAt,
-		MergedAt:       &mergedAt,
-		ClosedAt:       &mergedAt,
-	}
-	existing.ID, err = d.UpsertMergeRequest(ctx, existing)
-	require.NoError(err)
-
-	merged := true
-	pr := buildOpenPR(1, now)
-	pr.State = new("closed")
-	pr.Merged = &merged
-	pr.MergedAt = makeTimestamp(mergedAt)
-	pr.ClosedAt = makeTimestamp(mergedAt)
-	client := &detailTrackingClient{
-		mockClient: mockClient{
-			singlePR:          pr,
-			timelineEventsErr: errors.New("graphql unavailable"),
-		},
-	}
-	syncer := NewSyncer(
-		map[string]Client{"github.com": client},
-		d, nil,
-		[]RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}},
-		time.Minute, nil, nil,
-	)
-
-	wrote, err := syncer.BackfillMergedActorForDetail(ctx, existing)
-	require.Error(err)
-	require.ErrorContains(err, "list timeline events for merged actor backfill")
-	assert.False(wrote)
-	assert.Equal(int32(1), client.getPRCalls.Load())
-
-	wrote, err = syncer.BackfillMergedActorForDetail(ctx, existing)
-	require.Error(err)
-	require.ErrorContains(err, "list timeline events for merged actor backfill")
-	assert.False(wrote)
-	assert.Equal(int32(2), client.getPRCalls.Load())
 }
 
 func TestWatchedSyncMRUsesPersistedPullRequestETag(t *testing.T) {
@@ -8327,7 +8119,7 @@ func TestWatchedSyncMRUsesPersistedPullRequestETag(t *testing.T) {
 		"304 should skip timeline/comment refresh")
 }
 
-func TestWatchedSyncMRBackfillsMergedActorOn304(t *testing.T) {
+func TestWatchedSyncMRDoesNotBackfillMergedActorOn304(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	ctx := t.Context()
@@ -8363,90 +8155,10 @@ func TestWatchedSyncMRBackfillsMergedActorOn304(t *testing.T) {
 		"pull_request", 1, `"etag-v1"`,
 	))
 
-	merged := true
-	mergedBy := "merge-admin"
-	pr := buildOpenPR(1, updatedAt)
-	pr.State = new("closed")
-	pr.Merged = &merged
-	pr.MergedAt = makeTimestamp(mergedAt)
-	pr.ClosedAt = makeTimestamp(mergedAt)
-	pr.MergedBy = &gh.User{Login: &mergedBy}
-	mc := &conditionalPRTrackingClient{
-		detailTrackingClient: detailTrackingClient{
-			mockClient: mockClient{singlePR: pr},
-		},
-		notModified: true,
-	}
-	syncer := NewSyncer(
-		map[string]Client{"github.com": mc}, d, nil,
-		[]RepoRef{repo},
-		time.Minute, nil, testBudget(1000),
-	)
-
-	require.NoError(syncer.syncMRWithWatchedRef(ctx, WatchedMR{
-		Owner: "owner", Name: "repo", Number: 1, PlatformHost: "github.com",
-	}))
-
-	assert.Equal(int32(1), mc.conditionalCalls.Load())
-	assert.Equal(`"etag-v1"`, mc.receivedETag)
-	assert.Equal(int32(1), mc.getPRCalls.Load())
-	assert.Zero(int(mc.listIssueCommentsCalled.Load()),
-		"304 backfill should not run a timeline refresh")
-	events, err := d.ListMREvents(ctx, mrID)
-	require.NoError(err)
-	require.Len(events, 1)
-	assert.Equal("merged", events[0].EventType)
-	assert.Equal("merge-admin", events[0].Author)
-	assert.True(events[0].CreatedAt.Equal(mergedAt))
-}
-
-func TestWatchedSyncMRKeeps304FreshWhenMergedActorTimelineBackfillFails(t *testing.T) {
-	assert := assert.New(t)
-	require := require.New(t)
-	ctx := t.Context()
-	d := openTestDB(t)
-
-	repo := RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}
-	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", repo.Owner, repo.Name))
-	require.NoError(err)
-	updatedAt := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
-	mergedAt := updatedAt.Add(time.Minute)
-	detailFetchedAt := updatedAt.Add(-time.Hour)
-	mrID, err := d.UpsertMergeRequest(ctx, &db.MergeRequest{
-		RepoID:          repoID,
-		PlatformID:      1000,
-		Number:          1,
-		URL:             "https://github.com/owner/repo/pull/1",
-		Title:           "test PR",
-		Author:          "alice",
-		State:           db.MergeRequestStateMerged,
-		HeadBranch:      "feature-branch",
-		BaseBranch:      "main",
-		PlatformHeadSHA: "abc123def456",
-		CreatedAt:       updatedAt,
-		UpdatedAt:       updatedAt,
-		LastActivityAt:  updatedAt,
-		MergedAt:        &mergedAt,
-		ClosedAt:        &mergedAt,
-		DetailFetchedAt: &detailFetchedAt,
-	})
-	require.NoError(err)
-	require.NoError(d.UpsertHTTPEtag(
-		ctx, "github", "github.com", "owner", "repo",
-		"pull_request", 1, `"etag-v1"`,
-	))
-
-	merged := true
-	pr := buildOpenPR(1, updatedAt)
-	pr.State = new("closed")
-	pr.Merged = &merged
-	pr.MergedAt = makeTimestamp(mergedAt)
-	pr.ClosedAt = makeTimestamp(mergedAt)
 	mc := &conditionalPRTrackingClient{
 		detailTrackingClient: detailTrackingClient{
 			mockClient: mockClient{
-				singlePR:          pr,
-				timelineEventsErr: errors.New("graphql unavailable"),
+				timelineEventsErr: errors.New("304 watched sync must not fetch timeline events"),
 			},
 		},
 		notModified: true,
@@ -8463,9 +8175,10 @@ func TestWatchedSyncMRKeeps304FreshWhenMergedActorTimelineBackfillFails(t *testi
 
 	assert.Equal(int32(1), mc.conditionalCalls.Load())
 	assert.Equal(`"etag-v1"`, mc.receivedETag)
-	assert.Equal(int32(1), mc.getPRCalls.Load())
+	assert.Zero(int(mc.getPRCalls.Load()),
+		"304 should skip the unconditional PR detail fetch")
 	assert.Zero(int(mc.listIssueCommentsCalled.Load()),
-		"304 backfill should not run a timeline refresh")
+		"304 should skip timeline/comment refresh")
 	events, err := d.ListMREvents(ctx, mrID)
 	require.NoError(err)
 	assert.Empty(events)

--- a/internal/platform/forgejo/convert.go
+++ b/internal/platform/forgejo/convert.go
@@ -63,6 +63,7 @@ func convertPullRequest(pr *forgejosdk.PullRequest, mergeable *bool) gitealike.P
 		Updated:   timeValue(pr.Updated),
 		Merged:    pr.HasMerged,
 		MergedAt:  timePtrValue(pr.Merged),
+		MergedBy:  convertUser(pr.MergedBy),
 		Closed:    timePtrValue(pr.Closed),
 		// The Forgejo SDK pull request has no requested-reviewers
 		// field, so RequestedReviewers stays nil (unknown) and

--- a/internal/platform/forgejo/convert_test.go
+++ b/internal/platform/forgejo/convert_test.go
@@ -103,6 +103,11 @@ func TestConvertForgejoSDKRecords(t *testing.T) {
 	assert.Equal("feature", pr.Labels[0].Name)
 	assert.Equal(&closed, pr.MergedAt)
 
+	unmergedPR := convertPullRequest(&forgejosdk.PullRequest{
+		Index: 5,
+	}, nil)
+	assert.Empty(unmergedPR.MergedBy.UserName)
+
 	issue := convertIssue(&forgejosdk.Issue{
 		ID:          7,
 		Index:       8,

--- a/internal/platform/forgejo/convert_test.go
+++ b/internal/platform/forgejo/convert_test.go
@@ -72,9 +72,14 @@ func TestConvertForgejoSDKRecords(t *testing.T) {
 		Updated: &updated,
 		Closed:  &closed,
 		Merged:  &closed,
+		MergedBy: &forgejosdk.User{
+			UserName: "merge-admin",
+			FullName: "Merge Admin",
+		},
 	}, &mergeable)
 	assert.Equal(4, pr.Index)
 	assert.Equal("alice", pr.User.UserName)
+	assert.Equal("merge-admin", pr.MergedBy.UserName)
 	assert.Equal("open", pr.State)
 	assert.True(pr.IsLocked)
 	assert.False(pr.Draft)

--- a/internal/platform/gitea/convert.go
+++ b/internal/platform/gitea/convert.go
@@ -62,6 +62,7 @@ func convertPullRequest(pr *giteasdk.PullRequest, mergeable *bool) gitealike.Pul
 		Updated:   timeValue(pr.Updated),
 		Merged:    pr.HasMerged,
 		MergedAt:  timePtrValue(pr.Merged),
+		MergedBy:  convertUser(pr.MergedBy),
 		Closed:    timePtrValue(pr.Closed),
 		// convertUsers never returns nil, so both fields read as
 		// provider-confirmed sets: the Gitea API always serializes

--- a/internal/platform/gitea/convert_test.go
+++ b/internal/platform/gitea/convert_test.go
@@ -73,9 +73,14 @@ func TestConvertGiteaSDKRecords(t *testing.T) {
 		Updated: &updated,
 		Closed:  &closed,
 		Merged:  &closed,
+		MergedBy: &giteasdk.User{
+			UserName: "merge-admin",
+			FullName: "Merge Admin",
+		},
 	}, &mergeable)
 	assert.Equal(4, pr.Index)
 	assert.Equal("alice", pr.User.UserName)
+	assert.Equal("merge-admin", pr.MergedBy.UserName)
 	assert.Equal("open", pr.State)
 	assert.True(pr.IsLocked)
 	assert.True(pr.Draft)

--- a/internal/platform/gitea/convert_test.go
+++ b/internal/platform/gitea/convert_test.go
@@ -93,6 +93,11 @@ func TestConvertGiteaSDKRecords(t *testing.T) {
 	assert.Equal("feature", pr.Labels[0].Name)
 	assert.Equal(&closed, pr.MergedAt)
 
+	unmergedPR := convertPullRequest(&giteasdk.PullRequest{
+		Index: 5,
+	}, nil)
+	assert.Empty(unmergedPR.MergedBy.UserName)
+
 	issue := convertIssue(&giteasdk.Issue{
 		ID:          7,
 		Index:       8,

--- a/internal/platform/gitealike/normalize.go
+++ b/internal/platform/gitealike/normalize.go
@@ -94,6 +94,7 @@ func NormalizePullRequest(repo platform.RepoRef, pr PullRequestDTO) platform.Mer
 		UpdatedAt:          pr.Updated.UTC(),
 		LastActivityAt:     pr.Updated.UTC(),
 		MergedAt:           timePtrUTC(pr.MergedAt),
+		MergedBy:           pr.MergedBy.UserName,
 		ClosedAt:           timePtrUTC(pr.Closed),
 		Labels:             NormalizeLabels(repo, pr.Labels),
 		Assignees:          userDTONames(pr.Assignees),

--- a/internal/platform/gitealike/normalize_test.go
+++ b/internal/platform/gitealike/normalize_test.go
@@ -105,6 +105,12 @@ func TestNormalizeMergeRequestIssueEventsAndArtifacts(t *testing.T) {
 	assert.Equal("abc123", pr.HeadSHA)
 	assert.False(pr.IsDraft)
 
+	unmergedPR := NormalizePullRequest(repo, PullRequestDTO{
+		Index: 8,
+		State: "open",
+	})
+	assert.Empty(unmergedPR.MergedBy)
+
 	draftPR := NormalizePullRequest(repo, PullRequestDTO{
 		ID:       101,
 		Index:    8,

--- a/internal/platform/gitealike/normalize_test.go
+++ b/internal/platform/gitealike/normalize_test.go
@@ -92,11 +92,13 @@ func TestNormalizeMergeRequestIssueEventsAndArtifacts(t *testing.T) {
 		Mergeable: &mergeable,
 		Merged:    true,
 		MergedAt:  &closed,
+		MergedBy:  UserDTO{UserName: "merge-admin"},
 		Closed:    &closed,
 	})
 	assert.Equal("merged", pr.State)
 	assert.Equal(7, pr.Number)
 	assert.Equal("alice", pr.Author)
+	assert.Equal("merge-admin", pr.MergedBy)
 	assert.Equal("Alice", pr.AuthorDisplayName)
 	assert.Equal("clean", pr.MergeableState)
 	assert.Equal("feature", pr.HeadBranch)

--- a/internal/platform/gitealike/types.go
+++ b/internal/platform/gitealike/types.go
@@ -135,6 +135,7 @@ type PullRequestDTO struct {
 	Updated   time.Time
 	Merged    bool
 	MergedAt  *time.Time
+	MergedBy  UserDTO
 	Closed    *time.Time
 	// Assignees and RequestedReviewers are nil when the transport's SDK
 	// does not expose the field (unknown) and an empty non-nil slice

--- a/internal/platform/github/normalize.go
+++ b/internal/platform/github/normalize.go
@@ -50,6 +50,7 @@ func NormalizePullRequest(repo platform.RepoRef, ghPR *gh.PullRequest) (platform
 		t := ghPR.MergedAt.Time
 		mr.MergedAt = &t
 	}
+	mr.MergedBy = loginOrEmpty(ghPR.GetMergedBy())
 	if ghPR.ClosedAt != nil {
 		t := ghPR.ClosedAt.Time
 		mr.ClosedAt = &t

--- a/internal/platform/gitlab/client_test.go
+++ b/internal/platform/gitlab/client_test.go
@@ -286,6 +286,42 @@ func TestClientGetMergeRequestPropagatesTransientForkHeadRepoLookupFailures(t *t
 	assert.Equal("get_source_project", platformErr.Capability)
 }
 
+func TestClientGetMergeRequestUsesMergedByFallback(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.EscapedPath() {
+		case "/api/v4/projects/42/merge_requests/7":
+			writeJSON(w, `{
+				"id": 1001,
+				"iid": 7,
+				"project_id": 42,
+				"title": "Merged legacy MR",
+				"state": "merged",
+				"web_url": "https://gitlab.example.com/group/project/-/merge_requests/7",
+				"author": {"username": "ada"},
+				"source_branch": "feature",
+				"target_branch": "main",
+				"sha": "abc",
+				"created_at": "2026-04-01T10:00:00Z",
+				"updated_at": "2026-04-02T10:00:00Z",
+				"merged_at": "2026-04-02T10:00:00Z",
+				"merged_by": {"username": "legacy-admin"}
+			}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	ref := platform.RepoRef{Platform: platform.KindGitLab, Host: "gitlab.example.com", PlatformID: 42}
+
+	mr, err := client.GetMergeRequest(context.Background(), ref, 7)
+	require.NoError(err)
+	assert.Equal("legacy-admin", mr.MergedBy)
+}
+
 func TestClientRecordsRateLimitRequests(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/platform/gitlab/normalize.go
+++ b/internal/platform/gitlab/normalize.go
@@ -179,9 +179,13 @@ func normalizeMergeRequest(
 		CreatedAt:          timeValue(mr.CreatedAt),
 		UpdatedAt:          timeValue(mr.UpdatedAt),
 		LastActivityAt:     timeValue(mr.UpdatedAt),
+		MergedBy:           basicUsername(mr.MergeUser),
 		Labels:             normalizeLabelNames(repo, mr.Labels),
 		Assignees:          basicUsernames(mr.Assignees),
 		RequestedReviewers: basicUsernames(mr.Reviewers),
+	}
+	if out.MergedBy == "" {
+		out.MergedBy = basicUsername(mr.MergedBy)
 	}
 	if mr.MergedAt != nil {
 		t := mr.MergedAt.UTC()

--- a/internal/platform/gitlab/normalize.go
+++ b/internal/platform/gitlab/normalize.go
@@ -184,6 +184,10 @@ func normalizeMergeRequest(
 		Assignees:          basicUsernames(mr.Assignees),
 		RequestedReviewers: basicUsernames(mr.Reviewers),
 	}
+	if out.MergedBy == "" {
+		//nolint:staticcheck // GitLab < 14.7 can populate merged_by without merge_user.
+		out.MergedBy = basicUsername(mr.MergedBy)
+	}
 	if mr.MergedAt != nil {
 		t := mr.MergedAt.UTC()
 		out.MergedAt = &t

--- a/internal/platform/gitlab/normalize.go
+++ b/internal/platform/gitlab/normalize.go
@@ -184,9 +184,6 @@ func normalizeMergeRequest(
 		Assignees:          basicUsernames(mr.Assignees),
 		RequestedReviewers: basicUsernames(mr.Reviewers),
 	}
-	if out.MergedBy == "" {
-		out.MergedBy = basicUsername(mr.MergedBy)
-	}
 	if mr.MergedAt != nil {
 		t := mr.MergedAt.UTC()
 		out.MergedAt = &t

--- a/internal/platform/gitlab/normalize_test.go
+++ b/internal/platform/gitlab/normalize_test.go
@@ -151,6 +151,7 @@ func TestNormalizeMergeRequestUsesIIDAndPipelineStatus(t *testing.T) {
 		Draft:               true,
 		WebURL:              "https://gitlab.example.com/group/project/-/merge_requests/7",
 		Author:              &gitlab.BasicUser{Username: "alice", Name: "Alice A."},
+		MergeUser:           &gitlab.BasicUser{Username: "merge-admin"},
 		CreatedAt:           &createdAt,
 		UpdatedAt:           &updatedAt,
 		MergedAt:            &mergedAt,
@@ -163,6 +164,7 @@ func TestNormalizeMergeRequestUsesIIDAndPipelineStatus(t *testing.T) {
 	assert.Equal(7, mr.Number)
 	assert.Equal("alice", mr.Author)
 	assert.Equal("Alice A.", mr.AuthorDisplayName)
+	assert.Equal("merge-admin", mr.MergedBy)
 	assert.Equal("merged", mr.State)
 	assert.True(mr.IsDraft)
 	assert.Equal("feature", mr.HeadBranch)
@@ -178,6 +180,17 @@ func TestNormalizeMergeRequestUsesIIDAndPipelineStatus(t *testing.T) {
 	assert.Equal(mergedAt, *mr.MergedAt)
 	require.Len(t, mr.Labels, 1)
 	assert.Equal("bug", mr.Labels[0].Name)
+}
+
+func TestNormalizeMergeRequestLeavesMergedByEmptyWhenGitLabOmitsMergeUser(t *testing.T) {
+	mr := NormalizeMergeRequest(testGitLabRepoRef(), &gitlab.BasicMergeRequest{
+		ID:       1001,
+		IID:      7,
+		State:    "merged",
+		MergedAt: &time.Time{},
+	}, nil)
+
+	assert.Empty(t, mr.MergedBy)
 }
 
 func TestNormalizeMergeRequestMapsGitLabMergeability(t *testing.T) {

--- a/internal/platform/gitlab/normalize_test.go
+++ b/internal/platform/gitlab/normalize_test.go
@@ -193,6 +193,18 @@ func TestNormalizeMergeRequestLeavesMergedByEmptyWhenGitLabOmitsMergeUser(t *tes
 	assert.Empty(t, mr.MergedBy)
 }
 
+func TestNormalizeMergeRequestUsesMergedByWhenGitLabOmitsMergeUser(t *testing.T) {
+	mr := NormalizeMergeRequest(testGitLabRepoRef(), &gitlab.BasicMergeRequest{
+		ID:    1001,
+		IID:   7,
+		State: "merged",
+		//nolint:staticcheck // Exercise GitLab < 14.7 fallback when merge_user is absent.
+		MergedBy: &gitlab.BasicUser{Username: "legacy-admin"},
+	}, nil)
+
+	assert.Equal(t, "legacy-admin", mr.MergedBy)
+}
+
 func TestNormalizeMergeRequestMapsGitLabMergeability(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/internal/platform/types.go
+++ b/internal/platform/types.go
@@ -94,6 +94,7 @@ type MergeRequest struct {
 	UpdatedAt          time.Time
 	LastActivityAt     time.Time
 	MergedAt           *time.Time
+	MergedBy           string
 	ClosedAt           *time.Time
 	Labels             []Label
 	// Assignees and RequestedReviewers carry usernames. nil means the

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -214,6 +214,7 @@ type mockGH struct {
 	listIssuesPageFn           func(context.Context, string, string, string, int) ([]*gh.Issue, bool, error)
 	listCheckRunsForRefFn      func(context.Context, string, string, string) ([]*gh.CheckRun, error)
 	getCombinedStatusFn        func(context.Context, string, string, string) (*gh.CombinedStatus, error)
+	listPRTimelineEventsFn     func(context.Context, string, string, int) ([]ghclient.PullRequestTimelineEvent, error)
 	listOpenPRsErr             error
 	listOpenIssuesFn           func(context.Context, string, string) ([]*gh.Issue, error)
 	listIssueCommentsFn        func(context.Context, string, string, int) ([]*gh.IssueComment, error)
@@ -401,8 +402,11 @@ func (m *mockGH) ListForcePushEvents(
 }
 
 func (m *mockGH) ListPullRequestTimelineEvents(
-	_ context.Context, _, _ string, _ int,
+	ctx context.Context, owner, repo string, number int,
 ) ([]ghclient.PullRequestTimelineEvent, error) {
+	if m.listPRTimelineEventsFn != nil {
+		return m.listPRTimelineEventsFn(ctx, owner, repo, number)
+	}
 	return nil, nil
 }
 
@@ -2482,6 +2486,70 @@ func TestAPIGetPullBackfillsMergedActorFromCachedMergeState(t *testing.T) {
 				Head:      &gh.PullRequestBranch{SHA: &sha, Ref: new("feature")},
 				Base:      &gh.PullRequestBranch{SHA: &baseSHA, Ref: new("main")},
 			}, nil
+		},
+	}
+
+	srv, database := setupTestServerWithMock(t, mock)
+	seedPR(t, database, "acme", "widget", 1,
+		withSeedPRLifecycle(db.MergeRequestStateMerged, &mergedAt, &mergedAt),
+	)
+	client := setupTestClient(t, srv)
+
+	detailResp, err := client.HTTP.GetPullWithResponse(
+		ctx, "gh", "acme", "widget", 1,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, detailResp.StatusCode(), string(detailResp.Body))
+	require.NotNil(detailResp.JSON200)
+	require.NotNil(detailResp.JSON200.Events)
+	require.Len(*detailResp.JSON200.Events, 1)
+	event := (*detailResp.JSON200.Events)[0]
+	assert.Equal("merged", event.EventType)
+	assert.Equal("merge-admin", event.Author)
+	assert.Equal("merged this", event.Summary)
+	assert.True(event.CreatedAt.Equal(mergedAt))
+}
+
+func TestAPIGetPullBackfillsMergedActorFromTimelineWhenRestActorMissing(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	now := time.Now().UTC().Truncate(time.Second)
+	mergedAt := now.Add(time.Minute)
+	mock := &mockGH{
+		getPullRequestFn: func(_ context.Context, _ string, _ string, number int) (*gh.PullRequest, error) {
+			id := int64(1001)
+			sha := "abc123"
+			baseSHA := "def456"
+			state := "closed"
+			title := "Merged PR"
+			url := "https://github.com/acme/widget/pull/1"
+			updatedAt := gh.Timestamp{Time: mergedAt}
+			createdAt := gh.Timestamp{Time: now}
+			mergedAtTimestamp := gh.Timestamp{Time: mergedAt}
+			merged := true
+			return &gh.PullRequest{
+				ID:        &id,
+				Number:    &number,
+				State:     &state,
+				Title:     &title,
+				HTMLURL:   &url,
+				UpdatedAt: &updatedAt,
+				CreatedAt: &createdAt,
+				Merged:    &merged,
+				MergedAt:  &mergedAtTimestamp,
+				ClosedAt:  &mergedAtTimestamp,
+				Head:      &gh.PullRequestBranch{SHA: &sha, Ref: new("feature")},
+				Base:      &gh.PullRequestBranch{SHA: &baseSHA, Ref: new("main")},
+			}, nil
+		},
+		listPRTimelineEventsFn: func(_ context.Context, _ string, _ string, _ int) ([]ghclient.PullRequestTimelineEvent, error) {
+			return []ghclient.PullRequestTimelineEvent{{
+				NodeID:    "ME_merged_1",
+				EventType: "merged",
+				Actor:     "merge-admin",
+				CreatedAt: mergedAt,
+			}}, nil
 		},
 	}
 

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -666,6 +666,7 @@ type apiTestGitLabProvider struct {
 	ref                platform.RepoRef
 	capabilities       *platform.Capabilities
 	mergeRequests      []platform.MergeRequest
+	mergeRequestDetail map[int]platform.MergeRequest
 	mergeRequestEvents map[int][]platform.MergeRequestEvent
 	issues             []platform.Issue
 	issueEvents        map[int][]platform.IssueEvent
@@ -782,6 +783,11 @@ func (p *apiTestGitLabProvider) GetMergeRequest(
 	_ platform.RepoRef,
 	number int,
 ) (platform.MergeRequest, error) {
+	if p.mergeRequestDetail != nil {
+		if mr, ok := p.mergeRequestDetail[number]; ok {
+			return mr, nil
+		}
+	}
 	for _, mr := range p.mergeRequests {
 		if mr.Number == number {
 			return mr, nil
@@ -2724,7 +2730,7 @@ func TestAPIGetPullRetriesMergedActorBackfillUntilTimelineHasActor(t *testing.T)
 	require.NotNil(first.JSON200)
 	require.NotNil(first.JSON200.Events)
 	require.Len(*first.JSON200.Events, 1)
-	assert.Equal("", (*first.JSON200.Events)[0].Author)
+	assert.Empty((*first.JSON200.Events)[0].Author)
 
 	second, err := client.HTTP.GetPullWithResponse(
 		ctx, "gh", "acme", "widget", 1,
@@ -4206,6 +4212,97 @@ func TestAPIGitLabConfiguredRepoSyncThroughProviderRegistry(t *testing.T) {
 	assert.Equal("project", (*pullsResp.JSON200)[0].RepoName)
 	assert.Equal("GitLab provider MR", (*pullsResp.JSON200)[0].Title)
 	assert.Equal("dirty", (*pullsResp.JSON200)[0].MergeableState)
+}
+
+func TestAPIGitLabClosedSyncPersistsMergedActorForImmediateDetail(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	now := time.Now().UTC().Truncate(time.Second)
+	mergedAt := now.Add(time.Minute)
+
+	database := dbtest.Open(t)
+	ref := platform.RepoRef{
+		Platform:           platform.KindGitLab,
+		Host:               "gitlab.example.com",
+		Owner:              "group",
+		Name:               "project",
+		RepoPath:           "group/project",
+		PlatformID:         4242,
+		PlatformExternalID: "gid://gitlab/Project/4242",
+		WebURL:             "https://gitlab.example.com/group/project",
+		CloneURL:           "https://gitlab.example.com/group/project.git",
+		DefaultBranch:      "main",
+	}
+	openMR := platform.MergeRequest{
+		Repo:               ref,
+		PlatformID:         7001,
+		PlatformExternalID: "gid://gitlab/MergeRequest/7001",
+		Number:             7,
+		URL:                "https://gitlab.example.com/group/project/-/merge_requests/7",
+		Title:              "GitLab provider MR",
+		Author:             "ada",
+		State:              "open",
+		HeadBranch:         "feature/gitlab",
+		BaseBranch:         "main",
+		HeadSHA:            "abc123",
+		BaseSHA:            "def456",
+		CreatedAt:          now,
+		UpdatedAt:          now,
+		LastActivityAt:     now,
+	}
+	mergedMR := openMR
+	mergedMR.State = "merged"
+	mergedMR.MergedAt = &mergedAt
+	mergedMR.ClosedAt = &mergedAt
+	mergedMR.MergedBy = "merge-admin"
+	mergedMR.UpdatedAt = mergedAt
+	mergedMR.LastActivityAt = mergedAt
+	provider := &apiTestGitLabProvider{
+		ref:                ref,
+		mergeRequests:      []platform.MergeRequest{openMR},
+		mergeRequestDetail: map[int]platform.MergeRequest{7: mergedMR},
+	}
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+
+	repo := ghclient.RepoRef{
+		Platform:           platform.KindGitLab,
+		Owner:              ref.Owner,
+		Name:               ref.Name,
+		PlatformHost:       ref.Host,
+		RepoPath:           ref.RepoPath,
+		PlatformRepoID:     ref.PlatformID,
+		PlatformExternalID: ref.PlatformExternalID,
+		WebURL:             ref.WebURL,
+		CloneURL:           ref.CloneURL,
+		DefaultBranch:      ref.DefaultBranch,
+	}
+	syncer := ghclient.NewSyncerWithRegistry(
+		registry, database, nil, []ghclient.RepoRef{repo}, time.Minute, nil, nil,
+	)
+	t.Cleanup(syncer.Stop)
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	client := setupTestClient(t, srv)
+
+	syncer.RunOnce(ctx)
+	provider.mergeRequests = nil
+	syncer.RunOnce(ctx)
+
+	detailResp, err := client.HTTP.GetPullOnHostWithResponse(
+		ctx, ref.Host, "gitlab", ref.Owner, ref.Name, 7,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, detailResp.StatusCode(), string(detailResp.Body))
+	require.NotNil(detailResp.JSON200)
+	require.NotNil(detailResp.JSON200.Events)
+	require.Len(*detailResp.JSON200.Events, 1)
+	event := (*detailResp.JSON200.Events)[0]
+	assert.Equal("merged", event.EventType)
+	assert.Equal("merge-admin", event.Author)
+	assert.Equal("merged this", event.Summary)
+	assert.True(event.CreatedAt.Equal(mergedAt))
 }
 
 func TestAPIGitLabSyncReadsTokenFileAfterRotation(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -2453,6 +2453,88 @@ func TestAPIGetPullBackfillsMergedActorBeforeDetailResponse(t *testing.T) {
 	assert.True(event.CreatedAt.Equal(mergedAt))
 }
 
+func TestAPIGetPullMergedActorBackfillDoesNotRepeatNoop(t *testing.T) {
+	tests := []struct {
+		name string
+		pr   func(number int, now, mergedAt time.Time) (*gh.PullRequest, error)
+	}{
+		{
+			name: "no merged actor",
+			pr: func(number int, now, mergedAt time.Time) (*gh.PullRequest, error) {
+				id := int64(1001)
+				sha := "abc123"
+				baseSHA := "def456"
+				headRef := "feature"
+				baseRef := "main"
+				state := "closed"
+				title := "Merged PR"
+				url := "https://github.com/acme/widget/pull/1"
+				updatedAt := gh.Timestamp{Time: mergedAt}
+				createdAt := gh.Timestamp{Time: now}
+				mergedAtTimestamp := gh.Timestamp{Time: mergedAt}
+				merged := true
+				return &gh.PullRequest{
+					ID:        &id,
+					Number:    &number,
+					State:     &state,
+					Title:     &title,
+					HTMLURL:   &url,
+					UpdatedAt: &updatedAt,
+					CreatedAt: &createdAt,
+					Merged:    &merged,
+					MergedAt:  &mergedAtTimestamp,
+					ClosedAt:  &mergedAtTimestamp,
+					Head:      &gh.PullRequestBranch{SHA: &sha, Ref: &headRef},
+					Base:      &gh.PullRequestBranch{SHA: &baseSHA, Ref: &baseRef},
+				}, nil
+			},
+		},
+		{
+			name: "provider error",
+			pr: func(_ int, _, _ time.Time) (*gh.PullRequest, error) {
+				return nil, errors.New("provider unavailable")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			ctx := t.Context()
+			now := time.Now().UTC().Truncate(time.Second)
+			mergedAt := now.Add(time.Minute)
+			var calls atomic.Int32
+			mock := &mockGH{
+				getPullRequestFn: func(_ context.Context, _ string, _ string, number int) (*gh.PullRequest, error) {
+					calls.Add(1)
+					return tt.pr(number, now, mergedAt)
+				},
+			}
+
+			srv, database := setupTestServerWithMock(t, mock)
+			seedPR(t, database, "acme", "widget", 1,
+				withSeedPRLifecycle(db.MergeRequestStateMerged, &mergedAt, &mergedAt),
+			)
+			client := setupTestClient(t, srv)
+
+			first, err := client.HTTP.GetPullWithResponse(
+				ctx, "gh", "acme", "widget", 1,
+			)
+			require.NoError(err)
+			require.Equal(http.StatusOK, first.StatusCode(), string(first.Body))
+			assert.Equal(int32(1), calls.Load())
+
+			second, err := client.HTTP.GetPullWithResponse(
+				ctx, "gh", "acme", "widget", 1,
+			)
+			require.NoError(err)
+			require.Equal(http.StatusOK, second.StatusCode(), string(second.Body))
+			assert.Equal(int32(1), calls.Load())
+		})
+	}
+}
+
 func TestAPISyncPRPreservesMergeableStateWhenRefreshHasNoAnswer(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -2395,6 +2395,64 @@ func TestAPISyncPRPersistsMergedActorInDetail(t *testing.T) {
 	assert.True(event.CreatedAt.Equal(mergedAt))
 }
 
+func TestAPIGetPullBackfillsMergedActorBeforeDetailResponse(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	now := time.Now().UTC().Truncate(time.Second)
+	mergedAt := now.Add(time.Minute)
+	mergedBy := "merge-admin"
+	mock := &mockGH{
+		getPullRequestFn: func(_ context.Context, _ string, _ string, number int) (*gh.PullRequest, error) {
+			id := int64(1001)
+			sha := "abc123"
+			baseSHA := "def456"
+			state := "closed"
+			title := "Merged PR"
+			url := "https://github.com/acme/widget/pull/1"
+			updatedAt := gh.Timestamp{Time: mergedAt}
+			createdAt := gh.Timestamp{Time: now}
+			mergedAtTimestamp := gh.Timestamp{Time: mergedAt}
+			merged := true
+			return &gh.PullRequest{
+				ID:        &id,
+				Number:    &number,
+				State:     &state,
+				Title:     &title,
+				HTMLURL:   &url,
+				UpdatedAt: &updatedAt,
+				CreatedAt: &createdAt,
+				Merged:    &merged,
+				MergedAt:  &mergedAtTimestamp,
+				ClosedAt:  &mergedAtTimestamp,
+				MergedBy:  &gh.User{Login: &mergedBy},
+				Head:      &gh.PullRequestBranch{SHA: &sha, Ref: new("feature")},
+				Base:      &gh.PullRequestBranch{SHA: &baseSHA, Ref: new("main")},
+			}, nil
+		},
+	}
+
+	srv, database := setupTestServerWithMock(t, mock)
+	seedPR(t, database, "acme", "widget", 1,
+		withSeedPRLifecycle(db.MergeRequestStateMerged, &mergedAt, &mergedAt),
+	)
+	client := setupTestClient(t, srv)
+
+	detailResp, err := client.HTTP.GetPullWithResponse(
+		ctx, "gh", "acme", "widget", 1,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, detailResp.StatusCode(), string(detailResp.Body))
+	require.NotNil(detailResp.JSON200)
+	require.NotNil(detailResp.JSON200.Events)
+	require.Len(*detailResp.JSON200.Events, 1)
+	event := (*detailResp.JSON200.Events)[0]
+	assert.Equal("merged", event.EventType)
+	assert.Equal("merge-admin", event.Author)
+	assert.Equal("merged this", event.Summary)
+	assert.True(event.CreatedAt.Equal(mergedAt))
+}
+
 func TestAPISyncPRPreservesMergeableStateWhenRefreshHasNoAnswer(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -2399,6 +2399,91 @@ func TestAPISyncPRPersistsMergedActorInDetail(t *testing.T) {
 	assert.True(event.CreatedAt.Equal(mergedAt))
 }
 
+func TestAPIIndexSyncPersistsMergedActorForImmediateDetail(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	now := time.Now().UTC().Truncate(time.Second)
+	mergedAt := now.Add(time.Minute)
+	mergedBy := "merge-admin"
+	var getPullCalls atomic.Int32
+	mock := &mockGH{
+		listOpenPullRequestsFn: func(_ context.Context, _, _ string) ([]*gh.PullRequest, error) {
+			number := 1
+			id := int64(1001)
+			sha := "abc123"
+			baseSHA := "def456"
+			headRef := "feature"
+			baseRef := "main"
+			state := "closed"
+			title := "Merged PR"
+			url := "https://github.com/acme/widget/pull/1"
+			updatedAt := gh.Timestamp{Time: mergedAt}
+			createdAt := gh.Timestamp{Time: now}
+			mergedAtTimestamp := gh.Timestamp{Time: mergedAt}
+			merged := true
+			return []*gh.PullRequest{{
+				ID:        &id,
+				Number:    &number,
+				State:     &state,
+				Title:     &title,
+				HTMLURL:   &url,
+				UpdatedAt: &updatedAt,
+				CreatedAt: &createdAt,
+				Merged:    &merged,
+				MergedAt:  &mergedAtTimestamp,
+				ClosedAt:  &mergedAtTimestamp,
+				MergedBy:  &gh.User{Login: &mergedBy},
+				Head:      &gh.PullRequestBranch{SHA: &sha, Ref: &headRef},
+				Base:      &gh.PullRequestBranch{SHA: &baseSHA, Ref: &baseRef},
+			}}, nil
+		},
+		getPullRequestFn: func(_ context.Context, _ string, _ string, _ int) (*gh.PullRequest, error) {
+			getPullCalls.Add(1)
+			return nil, errors.New("detail lookup should not run")
+		},
+	}
+
+	srv, database := setupTestServerWithMock(t, mock)
+	client := setupTestClient(t, srv)
+
+	syncResp, err := client.HTTP.TriggerSyncWithResponse(ctx, nil)
+	require.NoError(err)
+	require.Equal(http.StatusAccepted, syncResp.StatusCode(), string(syncResp.Body))
+
+	require.Eventually(func() bool {
+		mr, mrErr := database.GetMergeRequest(ctx, "github", "github.com", "acme", "widget", 1)
+		if mrErr != nil || mr == nil {
+			return false
+		}
+		events, eventsErr := database.ListMREvents(ctx, mr.ID)
+		if eventsErr != nil {
+			return false
+		}
+		for _, event := range events {
+			if event.EventType == "merged" && event.Author == "merge-admin" {
+				return true
+			}
+		}
+		return false
+	}, 3*time.Second, 25*time.Millisecond)
+
+	detailResp, err := client.HTTP.GetPullWithResponse(
+		ctx, "gh", "acme", "widget", 1,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, detailResp.StatusCode(), string(detailResp.Body))
+	require.NotNil(detailResp.JSON200)
+	require.NotNil(detailResp.JSON200.Events)
+	require.Len(*detailResp.JSON200.Events, 1)
+	event := (*detailResp.JSON200.Events)[0]
+	assert.Equal("merged", event.EventType)
+	assert.Equal("merge-admin", event.Author)
+	assert.Equal("merged this", event.Summary)
+	assert.True(event.CreatedAt.Equal(mergedAt))
+	assert.Equal(int32(0), getPullCalls.Load())
+}
+
 func TestAPIGetPullBackfillsMergedActorBeforeDetailResponse(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -2574,86 +2659,88 @@ func TestAPIGetPullBackfillsMergedActorFromTimelineWhenRestActorMissing(t *testi
 	assert.True(event.CreatedAt.Equal(mergedAt))
 }
 
-func TestAPIGetPullMergedActorBackfillDoesNotRepeatNoop(t *testing.T) {
-	tests := []struct {
-		name string
-		pr   func(number int, now, mergedAt time.Time) (*gh.PullRequest, error)
-	}{
-		{
-			name: "no merged actor",
-			pr: func(number int, now, mergedAt time.Time) (*gh.PullRequest, error) {
-				id := int64(1001)
-				sha := "abc123"
-				baseSHA := "def456"
-				headRef := "feature"
-				baseRef := "main"
-				state := "closed"
-				title := "Merged PR"
-				url := "https://github.com/acme/widget/pull/1"
-				updatedAt := gh.Timestamp{Time: mergedAt}
-				createdAt := gh.Timestamp{Time: now}
-				mergedAtTimestamp := gh.Timestamp{Time: mergedAt}
-				merged := true
-				return &gh.PullRequest{
-					ID:        &id,
-					Number:    &number,
-					State:     &state,
-					Title:     &title,
-					HTMLURL:   &url,
-					UpdatedAt: &updatedAt,
-					CreatedAt: &createdAt,
-					Merged:    &merged,
-					MergedAt:  &mergedAtTimestamp,
-					ClosedAt:  &mergedAtTimestamp,
-					Head:      &gh.PullRequestBranch{SHA: &sha, Ref: &headRef},
-					Base:      &gh.PullRequestBranch{SHA: &baseSHA, Ref: &baseRef},
-				}, nil
-			},
+func TestAPIGetPullRetriesMergedActorBackfillUntilTimelineHasActor(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	now := time.Now().UTC().Truncate(time.Second)
+	mergedAt := now.Add(time.Minute)
+	var getPullCalls atomic.Int32
+	var timelineCalls atomic.Int32
+	mock := &mockGH{
+		getPullRequestFn: func(_ context.Context, _ string, _ string, number int) (*gh.PullRequest, error) {
+			getPullCalls.Add(1)
+			id := int64(1001)
+			sha := "abc123"
+			baseSHA := "def456"
+			headRef := "feature"
+			baseRef := "main"
+			state := "closed"
+			title := "Merged PR"
+			url := "https://github.com/acme/widget/pull/1"
+			updatedAt := gh.Timestamp{Time: mergedAt}
+			createdAt := gh.Timestamp{Time: now}
+			mergedAtTimestamp := gh.Timestamp{Time: mergedAt}
+			merged := true
+			return &gh.PullRequest{
+				ID:        &id,
+				Number:    &number,
+				State:     &state,
+				Title:     &title,
+				HTMLURL:   &url,
+				UpdatedAt: &updatedAt,
+				CreatedAt: &createdAt,
+				Merged:    &merged,
+				MergedAt:  &mergedAtTimestamp,
+				ClosedAt:  &mergedAtTimestamp,
+				Head:      &gh.PullRequestBranch{SHA: &sha, Ref: &headRef},
+				Base:      &gh.PullRequestBranch{SHA: &baseSHA, Ref: &baseRef},
+			}, nil
 		},
-		{
-			name: "provider error",
-			pr: func(_ int, _, _ time.Time) (*gh.PullRequest, error) {
-				return nil, errors.New("provider unavailable")
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require := require.New(t)
-			assert := assert.New(t)
-			ctx := t.Context()
-			now := time.Now().UTC().Truncate(time.Second)
-			mergedAt := now.Add(time.Minute)
-			var calls atomic.Int32
-			mock := &mockGH{
-				getPullRequestFn: func(_ context.Context, _ string, _ string, number int) (*gh.PullRequest, error) {
-					calls.Add(1)
-					return tt.pr(number, now, mergedAt)
-				},
+		listPRTimelineEventsFn: func(_ context.Context, _ string, _ string, _ int) ([]ghclient.PullRequestTimelineEvent, error) {
+			if timelineCalls.Add(1) == 1 {
+				return nil, nil
 			}
-
-			srv, database := setupTestServerWithMock(t, mock)
-			seedPR(t, database, "acme", "widget", 1,
-				withSeedPRLifecycle(db.MergeRequestStateMerged, &mergedAt, &mergedAt),
-			)
-			client := setupTestClient(t, srv)
-
-			first, err := client.HTTP.GetPullWithResponse(
-				ctx, "gh", "acme", "widget", 1,
-			)
-			require.NoError(err)
-			require.Equal(http.StatusOK, first.StatusCode(), string(first.Body))
-			assert.Equal(int32(1), calls.Load())
-
-			second, err := client.HTTP.GetPullWithResponse(
-				ctx, "gh", "acme", "widget", 1,
-			)
-			require.NoError(err)
-			require.Equal(http.StatusOK, second.StatusCode(), string(second.Body))
-			assert.Equal(int32(1), calls.Load())
-		})
+			return []ghclient.PullRequestTimelineEvent{{
+				NodeID:    "ME_merged_1",
+				EventType: "merged",
+				Actor:     "merge-admin",
+				CreatedAt: mergedAt,
+			}}, nil
+		},
 	}
+
+	srv, database := setupTestServerWithMock(t, mock)
+	seedPR(t, database, "acme", "widget", 1,
+		withSeedPRLifecycle(db.MergeRequestStateMerged, &mergedAt, &mergedAt),
+	)
+	client := setupTestClient(t, srv)
+
+	first, err := client.HTTP.GetPullWithResponse(
+		ctx, "gh", "acme", "widget", 1,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, first.StatusCode(), string(first.Body))
+	require.NotNil(first.JSON200)
+	require.NotNil(first.JSON200.Events)
+	require.Len(*first.JSON200.Events, 1)
+	assert.Equal("", (*first.JSON200.Events)[0].Author)
+
+	second, err := client.HTTP.GetPullWithResponse(
+		ctx, "gh", "acme", "widget", 1,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, second.StatusCode(), string(second.Body))
+	require.NotNil(second.JSON200)
+	require.NotNil(second.JSON200.Events)
+	require.Len(*second.JSON200.Events, 1)
+	event := (*second.JSON200.Events)[0]
+	assert.Equal("merged", event.EventType)
+	assert.Equal("merge-admin", event.Author)
+	assert.Equal("merged this", event.Summary)
+	assert.True(event.CreatedAt.Equal(mergedAt))
+	assert.Equal(int32(2), getPullCalls.Load())
+	assert.Equal(int32(2), timelineCalls.Load())
 }
 
 func TestAPISyncPRPreservesMergeableStateWhenRefreshHasNoAnswer(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -4305,6 +4305,105 @@ func TestAPIGitLabClosedSyncPersistsMergedActorForImmediateDetail(t *testing.T) 
 	assert.True(event.CreatedAt.Equal(mergedAt))
 }
 
+func TestAPIGitLabDirectSyncPersistsMergedActorForImmediateDetail(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	now := time.Now().UTC().Truncate(time.Second)
+	mergedAt := now.Add(time.Minute)
+
+	database := dbtest.Open(t)
+	ref := platform.RepoRef{
+		Platform:           platform.KindGitLab,
+		Host:               "gitlab.example.com",
+		Owner:              "group",
+		Name:               "project",
+		RepoPath:           "group/project",
+		PlatformID:         4242,
+		PlatformExternalID: "gid://gitlab/Project/4242",
+		WebURL:             "https://gitlab.example.com/group/project",
+		CloneURL:           "https://gitlab.example.com/group/project.git",
+		DefaultBranch:      "main",
+	}
+	openMR := platform.MergeRequest{
+		Repo:               ref,
+		PlatformID:         7001,
+		PlatformExternalID: "gid://gitlab/MergeRequest/7001",
+		Number:             7,
+		URL:                "https://gitlab.example.com/group/project/-/merge_requests/7",
+		Title:              "GitLab provider MR",
+		Author:             "ada",
+		State:              "open",
+		HeadBranch:         "feature/gitlab",
+		BaseBranch:         "main",
+		HeadSHA:            "abc123",
+		BaseSHA:            "def456",
+		CreatedAt:          now,
+		UpdatedAt:          now,
+		LastActivityAt:     now,
+	}
+	mergedMR := openMR
+	mergedMR.State = "merged"
+	mergedMR.MergedAt = &mergedAt
+	mergedMR.ClosedAt = &mergedAt
+	mergedMR.MergedBy = "merge-admin"
+	mergedMR.UpdatedAt = mergedAt
+	mergedMR.LastActivityAt = mergedAt
+	provider := &apiTestGitLabProvider{
+		ref:                ref,
+		mergeRequests:      []platform.MergeRequest{openMR},
+		mergeRequestDetail: map[int]platform.MergeRequest{7: mergedMR},
+	}
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+
+	repo := ghclient.RepoRef{
+		Platform:           platform.KindGitLab,
+		Owner:              ref.Owner,
+		Name:               ref.Name,
+		PlatformHost:       ref.Host,
+		RepoPath:           ref.RepoPath,
+		PlatformRepoID:     ref.PlatformID,
+		PlatformExternalID: ref.PlatformExternalID,
+		WebURL:             ref.WebURL,
+		CloneURL:           ref.CloneURL,
+		DefaultBranch:      ref.DefaultBranch,
+	}
+	syncer := ghclient.NewSyncerWithRegistry(
+		registry, database, nil, []ghclient.RepoRef{repo}, time.Minute, nil, nil,
+	)
+	t.Cleanup(syncer.Stop)
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	client := setupTestClient(t, srv)
+
+	syncer.RunOnce(ctx)
+
+	syncResp, err := client.HTTP.SyncPullOnHostWithResponse(
+		ctx, ref.Host, "gitlab", ref.Owner, ref.Name, 7,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, syncResp.StatusCode(), string(syncResp.Body))
+	require.NotNil(syncResp.JSON200)
+	require.NotNil(syncResp.JSON200.Events)
+	require.Len(*syncResp.JSON200.Events, 1)
+	event := (*syncResp.JSON200.Events)[0]
+	assert.Equal("merged", event.EventType)
+	assert.Equal("merge-admin", event.Author)
+	assert.Equal("merged this", event.Summary)
+	assert.True(event.CreatedAt.Equal(mergedAt))
+
+	detailResp, err := client.HTTP.GetPullOnHostWithResponse(
+		ctx, ref.Host, "gitlab", ref.Owner, ref.Name, 7,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, detailResp.StatusCode(), string(detailResp.Body))
+	require.NotNil(detailResp.JSON200)
+	require.NotNil(detailResp.JSON200.Events)
+	require.Len(*detailResp.JSON200.Events, 1)
+	assert.Equal("merge-admin", (*detailResp.JSON200.Events)[0].Author)
+}
+
 func TestAPIGitLabSyncReadsTokenFileAfterRotation(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -2333,6 +2333,68 @@ func TestAPISyncPRPersistsMergeableState(t *testing.T) {
 	assert.Equal("dirty", stored.MergeableState)
 }
 
+func TestAPISyncPRPersistsMergedActorInDetail(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	now := time.Now().UTC().Truncate(time.Second)
+	mergedAt := now.Add(time.Minute)
+	mergedBy := "merge-admin"
+	mock := &mockGH{
+		getPullRequestFn: func(_ context.Context, _ string, _ string, number int) (*gh.PullRequest, error) {
+			id := int64(1001)
+			sha := "abc123"
+			baseSHA := "def456"
+			state := "closed"
+			title := "Merged PR"
+			url := "https://github.com/acme/widget/pull/1"
+			updatedAt := gh.Timestamp{Time: mergedAt}
+			createdAt := gh.Timestamp{Time: now}
+			mergedAtTimestamp := gh.Timestamp{Time: mergedAt}
+			merged := true
+			return &gh.PullRequest{
+				ID:        &id,
+				Number:    &number,
+				State:     &state,
+				Title:     &title,
+				HTMLURL:   &url,
+				UpdatedAt: &updatedAt,
+				CreatedAt: &createdAt,
+				Merged:    &merged,
+				MergedAt:  &mergedAtTimestamp,
+				ClosedAt:  &mergedAtTimestamp,
+				MergedBy:  &gh.User{Login: &mergedBy},
+				Head:      &gh.PullRequestBranch{SHA: &sha, Ref: new("feature")},
+				Base:      &gh.PullRequestBranch{SHA: &baseSHA, Ref: new("main")},
+			}, nil
+		},
+	}
+
+	srv, database := setupTestServerWithMock(t, mock)
+	seedPR(t, database, "acme", "widget", 1)
+	client := setupTestClient(t, srv)
+
+	syncResp, err := client.HTTP.SyncPullWithResponse(
+		ctx, "gh", "acme", "widget", 1,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, syncResp.StatusCode(), string(syncResp.Body))
+
+	detailResp, err := client.HTTP.GetPullWithResponse(
+		ctx, "gh", "acme", "widget", 1,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, detailResp.StatusCode(), string(detailResp.Body))
+	require.NotNil(detailResp.JSON200)
+	require.NotNil(detailResp.JSON200.Events)
+	require.Len(*detailResp.JSON200.Events, 1)
+	event := (*detailResp.JSON200.Events)[0]
+	assert.Equal("merged", event.EventType)
+	assert.Equal("merge-admin", event.Author)
+	assert.Equal("merged this", event.Summary)
+	assert.True(event.CreatedAt.Equal(mergedAt))
+}
+
 func TestAPISyncPRPreservesMergeableStateWhenRefreshHasNoAnswer(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -4187,6 +4187,123 @@ func TestAPIGitLabDirectSyncPersistsMergedActorForImmediateDetail(t *testing.T) 
 	assert.Equal("merge-admin", (*detailResp.JSON200.Events)[0].Author)
 }
 
+func TestAPIGitLabDirectSyncDoesNotDuplicateMergedActorAfterClosedFallback(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	now := time.Now().UTC().Truncate(time.Second)
+	mergedAt := now.Add(time.Minute)
+
+	database := dbtest.Open(t)
+	ref := platform.RepoRef{
+		Platform:           platform.KindGitLab,
+		Host:               "gitlab.example.com",
+		Owner:              "group",
+		Name:               "project",
+		RepoPath:           "group/project",
+		PlatformID:         4242,
+		PlatformExternalID: "gid://gitlab/Project/4242",
+		WebURL:             "https://gitlab.example.com/group/project",
+		CloneURL:           "https://gitlab.example.com/group/project.git",
+		DefaultBranch:      "main",
+	}
+	openMR := platform.MergeRequest{
+		Repo:               ref,
+		PlatformID:         7001,
+		PlatformExternalID: "gid://gitlab/MergeRequest/7001",
+		Number:             7,
+		URL:                "https://gitlab.example.com/group/project/-/merge_requests/7",
+		Title:              "GitLab provider MR",
+		Author:             "ada",
+		State:              "open",
+		HeadBranch:         "feature/gitlab",
+		BaseBranch:         "main",
+		HeadSHA:            "abc123",
+		BaseSHA:            "def456",
+		CreatedAt:          now,
+		UpdatedAt:          now,
+		LastActivityAt:     now,
+	}
+	mergedMR := openMR
+	mergedMR.State = "merged"
+	mergedMR.MergedAt = &mergedAt
+	mergedMR.ClosedAt = &mergedAt
+	mergedMR.MergedBy = "merge-admin"
+	mergedMR.UpdatedAt = mergedAt
+	mergedMR.LastActivityAt = mergedAt
+	provider := &apiTestGitLabProvider{
+		ref:                ref,
+		mergeRequests:      []platform.MergeRequest{openMR},
+		mergeRequestDetail: map[int]platform.MergeRequest{7: mergedMR},
+	}
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+
+	repo := ghclient.RepoRef{
+		Platform:           platform.KindGitLab,
+		Owner:              ref.Owner,
+		Name:               ref.Name,
+		PlatformHost:       ref.Host,
+		RepoPath:           ref.RepoPath,
+		PlatformRepoID:     ref.PlatformID,
+		PlatformExternalID: ref.PlatformExternalID,
+		WebURL:             ref.WebURL,
+		CloneURL:           ref.CloneURL,
+		DefaultBranch:      ref.DefaultBranch,
+	}
+	syncer := ghclient.NewSyncerWithRegistry(
+		registry, database, nil, []ghclient.RepoRef{repo}, time.Minute, nil, nil,
+	)
+	t.Cleanup(syncer.Stop)
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	client := setupTestClient(t, srv)
+
+	syncer.RunOnce(ctx)
+	provider.mergeRequests = nil
+	syncer.RunOnce(ctx)
+
+	stored, err := database.GetMergeRequest(
+		ctx, string(ref.Platform), ref.Host, ref.Owner, ref.Name, 7,
+	)
+	require.NoError(err)
+	require.NotNil(stored)
+	events, err := database.ListMREvents(ctx, stored.ID)
+	require.NoError(err)
+	require.Len(events, 1)
+	require.Equal("merged", events[0].EventType)
+	require.Equal("merge-admin", events[0].Author)
+
+	provider.mergeRequestEvents = map[int][]platform.MergeRequestEvent{7: {{
+		Repo:               ref,
+		PlatformID:         9001,
+		PlatformExternalID: "gid://gitlab/Note/9001",
+		MergeRequestNumber: 7,
+		EventType:          "merged",
+		Author:             "merge-admin",
+		Summary:            "merged this",
+		CreatedAt:          mergedAt,
+		DedupeKey:          "gitlab:merged-note:9001",
+	}}}
+	syncResp, err := client.HTTP.SyncPullOnHostWithResponse(
+		ctx, ref.Host, "gitlab", ref.Owner, ref.Name, 7,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, syncResp.StatusCode(), string(syncResp.Body))
+	require.NotNil(syncResp.JSON200)
+	require.NotNil(syncResp.JSON200.Events)
+	require.Len(*syncResp.JSON200.Events, 1)
+	assert.Equal("merged", (*syncResp.JSON200.Events)[0].EventType)
+	assert.Equal("merge-admin", (*syncResp.JSON200.Events)[0].Author)
+
+	events, err = database.ListMREvents(ctx, stored.ID)
+	require.NoError(err)
+	require.Len(events, 1)
+	assert.Equal("merged", events[0].EventType)
+	assert.Equal("merge-admin", events[0].Author)
+	assert.Equal("merged this", events[0].Summary)
+}
+
 func TestAPIGitLabSyncReadsTokenFileAfterRotation(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -2490,182 +2490,7 @@ func TestAPIIndexSyncPersistsMergedActorForImmediateDetail(t *testing.T) {
 	assert.Equal(int32(0), getPullCalls.Load())
 }
 
-func TestAPIGetPullBackfillsMergedActorBeforeDetailResponse(t *testing.T) {
-	require := require.New(t)
-	assert := assert.New(t)
-	ctx := t.Context()
-	now := time.Now().UTC().Truncate(time.Second)
-	mergedAt := now.Add(time.Minute)
-	mergedBy := "merge-admin"
-	mock := &mockGH{
-		getPullRequestFn: func(_ context.Context, _ string, _ string, number int) (*gh.PullRequest, error) {
-			id := int64(1001)
-			sha := "abc123"
-			baseSHA := "def456"
-			state := "closed"
-			title := "Merged PR"
-			url := "https://github.com/acme/widget/pull/1"
-			updatedAt := gh.Timestamp{Time: mergedAt}
-			createdAt := gh.Timestamp{Time: now}
-			mergedAtTimestamp := gh.Timestamp{Time: mergedAt}
-			merged := true
-			return &gh.PullRequest{
-				ID:        &id,
-				Number:    &number,
-				State:     &state,
-				Title:     &title,
-				HTMLURL:   &url,
-				UpdatedAt: &updatedAt,
-				CreatedAt: &createdAt,
-				Merged:    &merged,
-				MergedAt:  &mergedAtTimestamp,
-				ClosedAt:  &mergedAtTimestamp,
-				MergedBy:  &gh.User{Login: &mergedBy},
-				Head:      &gh.PullRequestBranch{SHA: &sha, Ref: new("feature")},
-				Base:      &gh.PullRequestBranch{SHA: &baseSHA, Ref: new("main")},
-			}, nil
-		},
-	}
-
-	srv, database := setupTestServerWithMock(t, mock)
-	seedPR(t, database, "acme", "widget", 1,
-		withSeedPRLifecycle(db.MergeRequestStateMerged, &mergedAt, &mergedAt),
-	)
-	client := setupTestClient(t, srv)
-
-	detailResp, err := client.HTTP.GetPullWithResponse(
-		ctx, "gh", "acme", "widget", 1,
-	)
-	require.NoError(err)
-	require.Equal(http.StatusOK, detailResp.StatusCode(), string(detailResp.Body))
-	require.NotNil(detailResp.JSON200)
-	require.NotNil(detailResp.JSON200.Events)
-	require.Len(*detailResp.JSON200.Events, 1)
-	event := (*detailResp.JSON200.Events)[0]
-	assert.Equal("merged", event.EventType)
-	assert.Equal("merge-admin", event.Author)
-	assert.Equal("merged this", event.Summary)
-	assert.True(event.CreatedAt.Equal(mergedAt))
-}
-
-func TestAPIGetPullBackfillsMergedActorFromCachedMergeState(t *testing.T) {
-	require := require.New(t)
-	assert := assert.New(t)
-	ctx := t.Context()
-	now := time.Now().UTC().Truncate(time.Second)
-	mergedAt := now.Add(time.Minute)
-	mergedBy := "merge-admin"
-	mock := &mockGH{
-		getPullRequestFn: func(_ context.Context, _ string, _ string, number int) (*gh.PullRequest, error) {
-			id := int64(1001)
-			sha := "abc123"
-			baseSHA := "def456"
-			state := "closed"
-			title := "Merged PR"
-			url := "https://github.com/acme/widget/pull/1"
-			updatedAt := gh.Timestamp{Time: mergedAt}
-			createdAt := gh.Timestamp{Time: now}
-			return &gh.PullRequest{
-				ID:        &id,
-				Number:    &number,
-				State:     &state,
-				Title:     &title,
-				HTMLURL:   &url,
-				UpdatedAt: &updatedAt,
-				CreatedAt: &createdAt,
-				MergedBy:  &gh.User{Login: &mergedBy},
-				Head:      &gh.PullRequestBranch{SHA: &sha, Ref: new("feature")},
-				Base:      &gh.PullRequestBranch{SHA: &baseSHA, Ref: new("main")},
-			}, nil
-		},
-	}
-
-	srv, database := setupTestServerWithMock(t, mock)
-	seedPR(t, database, "acme", "widget", 1,
-		withSeedPRLifecycle(db.MergeRequestStateMerged, &mergedAt, &mergedAt),
-	)
-	client := setupTestClient(t, srv)
-
-	detailResp, err := client.HTTP.GetPullWithResponse(
-		ctx, "gh", "acme", "widget", 1,
-	)
-	require.NoError(err)
-	require.Equal(http.StatusOK, detailResp.StatusCode(), string(detailResp.Body))
-	require.NotNil(detailResp.JSON200)
-	require.NotNil(detailResp.JSON200.Events)
-	require.Len(*detailResp.JSON200.Events, 1)
-	event := (*detailResp.JSON200.Events)[0]
-	assert.Equal("merged", event.EventType)
-	assert.Equal("merge-admin", event.Author)
-	assert.Equal("merged this", event.Summary)
-	assert.True(event.CreatedAt.Equal(mergedAt))
-}
-
-func TestAPIGetPullBackfillsMergedActorFromTimelineWhenRestActorMissing(t *testing.T) {
-	require := require.New(t)
-	assert := assert.New(t)
-	ctx := t.Context()
-	now := time.Now().UTC().Truncate(time.Second)
-	mergedAt := now.Add(time.Minute)
-	mock := &mockGH{
-		getPullRequestFn: func(_ context.Context, _ string, _ string, number int) (*gh.PullRequest, error) {
-			id := int64(1001)
-			sha := "abc123"
-			baseSHA := "def456"
-			state := "closed"
-			title := "Merged PR"
-			url := "https://github.com/acme/widget/pull/1"
-			updatedAt := gh.Timestamp{Time: mergedAt}
-			createdAt := gh.Timestamp{Time: now}
-			mergedAtTimestamp := gh.Timestamp{Time: mergedAt}
-			merged := true
-			return &gh.PullRequest{
-				ID:        &id,
-				Number:    &number,
-				State:     &state,
-				Title:     &title,
-				HTMLURL:   &url,
-				UpdatedAt: &updatedAt,
-				CreatedAt: &createdAt,
-				Merged:    &merged,
-				MergedAt:  &mergedAtTimestamp,
-				ClosedAt:  &mergedAtTimestamp,
-				Head:      &gh.PullRequestBranch{SHA: &sha, Ref: new("feature")},
-				Base:      &gh.PullRequestBranch{SHA: &baseSHA, Ref: new("main")},
-			}, nil
-		},
-		listPRTimelineEventsFn: func(_ context.Context, _ string, _ string, _ int) ([]ghclient.PullRequestTimelineEvent, error) {
-			return []ghclient.PullRequestTimelineEvent{{
-				NodeID:    "ME_merged_1",
-				EventType: "merged",
-				Actor:     "merge-admin",
-				CreatedAt: mergedAt,
-			}}, nil
-		},
-	}
-
-	srv, database := setupTestServerWithMock(t, mock)
-	seedPR(t, database, "acme", "widget", 1,
-		withSeedPRLifecycle(db.MergeRequestStateMerged, &mergedAt, &mergedAt),
-	)
-	client := setupTestClient(t, srv)
-
-	detailResp, err := client.HTTP.GetPullWithResponse(
-		ctx, "gh", "acme", "widget", 1,
-	)
-	require.NoError(err)
-	require.Equal(http.StatusOK, detailResp.StatusCode(), string(detailResp.Body))
-	require.NotNil(detailResp.JSON200)
-	require.NotNil(detailResp.JSON200.Events)
-	require.Len(*detailResp.JSON200.Events, 1)
-	event := (*detailResp.JSON200.Events)[0]
-	assert.Equal("merged", event.EventType)
-	assert.Equal("merge-admin", event.Author)
-	assert.Equal("merged this", event.Summary)
-	assert.True(event.CreatedAt.Equal(mergedAt))
-}
-
-func TestAPIGetPullRetriesMergedActorBackfillUntilTimelineHasActor(t *testing.T) {
+func TestAPIGetPullDoesNotFetchProviderForMissingMergedActor(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	ctx := t.Context()
@@ -2674,45 +2499,13 @@ func TestAPIGetPullRetriesMergedActorBackfillUntilTimelineHasActor(t *testing.T)
 	var getPullCalls atomic.Int32
 	var timelineCalls atomic.Int32
 	mock := &mockGH{
-		getPullRequestFn: func(_ context.Context, _ string, _ string, number int) (*gh.PullRequest, error) {
+		getPullRequestFn: func(_ context.Context, _ string, _ string, _ int) (*gh.PullRequest, error) {
 			getPullCalls.Add(1)
-			id := int64(1001)
-			sha := "abc123"
-			baseSHA := "def456"
-			headRef := "feature"
-			baseRef := "main"
-			state := "closed"
-			title := "Merged PR"
-			url := "https://github.com/acme/widget/pull/1"
-			updatedAt := gh.Timestamp{Time: mergedAt}
-			createdAt := gh.Timestamp{Time: now}
-			mergedAtTimestamp := gh.Timestamp{Time: mergedAt}
-			merged := true
-			return &gh.PullRequest{
-				ID:        &id,
-				Number:    &number,
-				State:     &state,
-				Title:     &title,
-				HTMLURL:   &url,
-				UpdatedAt: &updatedAt,
-				CreatedAt: &createdAt,
-				Merged:    &merged,
-				MergedAt:  &mergedAtTimestamp,
-				ClosedAt:  &mergedAtTimestamp,
-				Head:      &gh.PullRequestBranch{SHA: &sha, Ref: &headRef},
-				Base:      &gh.PullRequestBranch{SHA: &baseSHA, Ref: &baseRef},
-			}, nil
+			return nil, errors.New("detail reads must not fetch pull request data")
 		},
 		listPRTimelineEventsFn: func(_ context.Context, _ string, _ string, _ int) ([]ghclient.PullRequestTimelineEvent, error) {
-			if timelineCalls.Add(1) == 1 {
-				return nil, nil
-			}
-			return []ghclient.PullRequestTimelineEvent{{
-				NodeID:    "ME_merged_1",
-				EventType: "merged",
-				Actor:     "merge-admin",
-				CreatedAt: mergedAt,
-			}}, nil
+			timelineCalls.Add(1)
+			return nil, errors.New("detail reads must not fetch timeline data")
 		},
 	}
 
@@ -2722,31 +2515,21 @@ func TestAPIGetPullRetriesMergedActorBackfillUntilTimelineHasActor(t *testing.T)
 	)
 	client := setupTestClient(t, srv)
 
-	first, err := client.HTTP.GetPullWithResponse(
+	detailResp, err := client.HTTP.GetPullWithResponse(
 		ctx, "gh", "acme", "widget", 1,
 	)
 	require.NoError(err)
-	require.Equal(http.StatusOK, first.StatusCode(), string(first.Body))
-	require.NotNil(first.JSON200)
-	require.NotNil(first.JSON200.Events)
-	require.Len(*first.JSON200.Events, 1)
-	assert.Empty((*first.JSON200.Events)[0].Author)
-
-	second, err := client.HTTP.GetPullWithResponse(
-		ctx, "gh", "acme", "widget", 1,
-	)
-	require.NoError(err)
-	require.Equal(http.StatusOK, second.StatusCode(), string(second.Body))
-	require.NotNil(second.JSON200)
-	require.NotNil(second.JSON200.Events)
-	require.Len(*second.JSON200.Events, 1)
-	event := (*second.JSON200.Events)[0]
+	require.Equal(http.StatusOK, detailResp.StatusCode(), string(detailResp.Body))
+	require.NotNil(detailResp.JSON200)
+	require.NotNil(detailResp.JSON200.Events)
+	require.Len(*detailResp.JSON200.Events, 1)
+	event := (*detailResp.JSON200.Events)[0]
 	assert.Equal("merged", event.EventType)
-	assert.Equal("merge-admin", event.Author)
+	assert.Empty(event.Author)
 	assert.Equal("merged this", event.Summary)
 	assert.True(event.CreatedAt.Equal(mergedAt))
-	assert.Equal(int32(2), getPullCalls.Load())
-	assert.Equal(int32(2), timelineCalls.Load())
+	assert.Equal(int32(0), getPullCalls.Load())
+	assert.Equal(int32(0), timelineCalls.Load())
 }
 
 func TestAPISyncPRPreservesMergeableStateWhenRefreshHasNoAnswer(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -2453,6 +2453,59 @@ func TestAPIGetPullBackfillsMergedActorBeforeDetailResponse(t *testing.T) {
 	assert.True(event.CreatedAt.Equal(mergedAt))
 }
 
+func TestAPIGetPullBackfillsMergedActorFromCachedMergeState(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	now := time.Now().UTC().Truncate(time.Second)
+	mergedAt := now.Add(time.Minute)
+	mergedBy := "merge-admin"
+	mock := &mockGH{
+		getPullRequestFn: func(_ context.Context, _ string, _ string, number int) (*gh.PullRequest, error) {
+			id := int64(1001)
+			sha := "abc123"
+			baseSHA := "def456"
+			state := "closed"
+			title := "Merged PR"
+			url := "https://github.com/acme/widget/pull/1"
+			updatedAt := gh.Timestamp{Time: mergedAt}
+			createdAt := gh.Timestamp{Time: now}
+			return &gh.PullRequest{
+				ID:        &id,
+				Number:    &number,
+				State:     &state,
+				Title:     &title,
+				HTMLURL:   &url,
+				UpdatedAt: &updatedAt,
+				CreatedAt: &createdAt,
+				MergedBy:  &gh.User{Login: &mergedBy},
+				Head:      &gh.PullRequestBranch{SHA: &sha, Ref: new("feature")},
+				Base:      &gh.PullRequestBranch{SHA: &baseSHA, Ref: new("main")},
+			}, nil
+		},
+	}
+
+	srv, database := setupTestServerWithMock(t, mock)
+	seedPR(t, database, "acme", "widget", 1,
+		withSeedPRLifecycle(db.MergeRequestStateMerged, &mergedAt, &mergedAt),
+	)
+	client := setupTestClient(t, srv)
+
+	detailResp, err := client.HTTP.GetPullWithResponse(
+		ctx, "gh", "acme", "widget", 1,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, detailResp.StatusCode(), string(detailResp.Body))
+	require.NotNil(detailResp.JSON200)
+	require.NotNil(detailResp.JSON200.Events)
+	require.Len(*detailResp.JSON200.Events, 1)
+	event := (*detailResp.JSON200.Events)[0]
+	assert.Equal("merged", event.EventType)
+	assert.Equal("merge-admin", event.Author)
+	assert.Equal("merged this", event.Summary)
+	assert.True(event.CreatedAt.Equal(mergedAt))
+}
+
 func TestAPIGetPullMergedActorBackfillDoesNotRepeatNoop(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -1494,24 +1494,6 @@ func (s *Server) getPull(ctx context.Context, input *repoNumberInput) (*getPullO
 	if mr == nil {
 		return nil, problemNotFound(CodePullNotFound, "pull request not found", nil)
 	}
-	if s.syncer != nil {
-		refreshed, backfillErr := s.syncer.BackfillMergedActorForDetail(ctx, mr)
-		if backfillErr != nil {
-			slog.Warn("merged actor backfill before detail response failed",
-				"repo_id", repo.ID,
-				"number", input.Number,
-				"err", backfillErr,
-			)
-		} else if refreshed {
-			mr, err = s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
-			if err != nil {
-				return nil, problemInternal("get pull request failed")
-			}
-			if mr == nil {
-				return nil, problemNotFound(CodePullNotFound, "pull request not found", nil)
-			}
-		}
-	}
 
 	body, err := s.buildPullDetailResponse(ctx, mr)
 	if err != nil {

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -1494,6 +1494,24 @@ func (s *Server) getPull(ctx context.Context, input *repoNumberInput) (*getPullO
 	if mr == nil {
 		return nil, problemNotFound(CodePullNotFound, "pull request not found", nil)
 	}
+	if s.syncer != nil {
+		refreshed, backfillErr := s.syncer.BackfillMergedActorForDetail(ctx, mr)
+		if backfillErr != nil {
+			slog.Warn("merged actor backfill before detail response failed",
+				"repo_id", repo.ID,
+				"number", input.Number,
+				"err", backfillErr,
+			)
+		} else if refreshed {
+			mr, err = s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
+			if err != nil {
+				return nil, problemInternal("get pull request failed")
+			}
+			if mr == nil {
+				return nil, problemNotFound(CodePullNotFound, "pull request not found", nil)
+			}
+		}
+	}
 
 	body, err := s.buildPullDetailResponse(ctx, mr)
 	if err != nil {

--- a/packages/ui/src/components/detail/EventTimeline.svelte
+++ b/packages/ui/src/components/detail/EventTimeline.svelte
@@ -209,6 +209,23 @@
     return elapsedAfterMerge >= 0 && elapsedAfterMerge < mergedCloseCoalesceWindowMs;
   }
 
+  function coalescedMergedCloseEvent(
+    sourceEvents: Array<PREvent | IssueEvent>,
+    mergedEvent: PREvent | IssueEvent,
+  ): PREvent | IssueEvent | null {
+    return sourceEvents
+      .filter((event) => event.EventType === "closed" && isCoalescedMergedCloseEvent(event, mergedEvent))
+      .reduce<PREvent | IssueEvent | null>(preferredLifecycleEvent, null);
+  }
+
+  function mergedEventWithCoalescedAuthor(
+    mergedEvent: PREvent | IssueEvent,
+    coalescedCloseEvent: PREvent | IssueEvent | null,
+  ): PREvent | IssueEvent {
+    if (mergedEvent.Author || !coalescedCloseEvent?.Author) return mergedEvent;
+    return { ...mergedEvent, Author: coalescedCloseEvent.Author };
+  }
+
   function collapseLifecycleTransitions(
     sourceEvents: Array<PREvent | IssueEvent>,
   ): Array<PREvent | IssueEvent> {
@@ -217,12 +234,16 @@
       .reduce<PREvent | IssueEvent | null>(preferredLifecycleEvent, null);
 
     if (mergedEvent === null) return sourceEvents;
+    const closeEvent = coalescedMergedCloseEvent(sourceEvents, mergedEvent);
+    const displayMergedEvent = mergedEventWithCoalescedAuthor(mergedEvent, closeEvent);
 
-    return sourceEvents.filter((event) => {
-      if (event.EventType === "merged") return event.ID === mergedEvent.ID;
-      if (event.EventType === "closed" && isCoalescedMergedCloseEvent(event, mergedEvent)) return false;
-      return true;
-    });
+    return sourceEvents
+      .filter((event) => {
+        if (event.EventType === "merged") return event.ID === mergedEvent.ID;
+        if (event.EventType === "closed" && isCoalescedMergedCloseEvent(event, mergedEvent)) return false;
+        return true;
+      })
+      .map((event) => (event.ID === mergedEvent.ID ? displayMergedEvent : event));
   }
 
   function compareEventsAscending(a: PREvent | IssueEvent, b: PREvent | IssueEvent): number {
@@ -604,6 +625,10 @@
     );
   }
 
+  function isLifecycleTransitionEvent(eventType: string): boolean {
+    return eventType === "merged" || eventType === "closed" || eventType === "reopened";
+  }
+
   function shortCommit(summary: string): string {
     return summary.length > 7 ? summary.slice(0, 7) : summary;
   }
@@ -738,6 +763,9 @@
     }
     if (event.EventType === "cross_referenced") {
       return metadataString(parseMetadata(event), "source_title") ?? event.Summary;
+    }
+    if (isLifecycleTransitionEvent(event.EventType)) {
+      return "";
     }
     return event.Summary || compactMarkdownPreview(event.Body) || systemEventLabel(event.EventType);
   }
@@ -1313,6 +1341,16 @@
 	{/if}
 {/snippet}
 
+{#snippet eventAuthorByline(event: PREvent | IssueEvent, compact = false)}
+  <span class={["event-author", compact && "compact-event-author", isLifecycleTransitionEvent(event.EventType) && event.Author && "event-author--lifecycle"]}>
+    {#if isLifecycleTransitionEvent(event.EventType) && event.Author}
+      <span class="event-author-prefix">by</span> {event.Author}
+    {:else}
+      {event.Author || "Unknown"}
+    {/if}
+  </span>
+{/snippet}
+
 {#snippet threadReplyPanel(entry: TimelineEntry, targetID: string)}
 	{#if provider && repoOwner && repoName && repoPath}
 	  <div class="thread-reply-panel">
@@ -1405,7 +1443,7 @@
                   >
                     {compactEventLabel(event.EventType)}
                   </span>
-                  <span class="event-author compact-event-author">{event.Author || "Unknown"}</span>
+                  {@render eventAuthorByline(event, true)}
                   <span class="compact-event-context" title={compactContext}>
                     {compactContext}
                   </span>
@@ -1423,7 +1461,7 @@
                   >
                     {compactEventLabel(event.EventType)}
                   </span>
-                  <span class="event-author compact-event-author">{event.Author || "Unknown"}</span>
+                  {@render eventAuthorByline(event, true)}
                   <span class="compact-event-context" title={compactContext}>
                     {compactContext}
                   </span>
@@ -1509,6 +1547,11 @@
                   <span class="event-author">{event.Author}</span>
                 {/if}
                 <span class="system-event-summary system-event-summary--sentence">{event.Summary}</span>
+                <span class="event-time">{timeAgo(event.CreatedAt)}</span>
+              {:else if isLifecycleTransitionEvent(event.EventType)}
+                {#if event.Author}
+                  {@render eventAuthorByline(event)}
+                {/if}
                 <span class="event-time">{timeAgo(event.CreatedAt)}</span>
               {:else if event.EventType === "cross_referenced"}
                 {#if event.Author}
@@ -1713,6 +1756,10 @@
     margin-left: 0;
   }
 
+  .event-header--compact .event-type + .event-author--lifecycle {
+    margin-left: calc(var(--focus-detail-space-xs, 0.46rem) * -0.5);
+  }
+
   .event-card--compact-row {
     overflow: hidden;
   }
@@ -1815,6 +1862,11 @@
     font-size: var(--font-size-sm);
     font-weight: 500;
     color: var(--text-primary);
+  }
+
+  .event-author-prefix {
+    color: var(--text-muted);
+    font-weight: 400;
   }
 
   .event-time {

--- a/packages/ui/src/components/detail/EventTimeline.test.ts
+++ b/packages/ui/src/components/detail/EventTimeline.test.ts
@@ -215,25 +215,28 @@ describe("EventTimeline", () => {
     expect(screen.getByText("aaaaaaa -> bbbbbbb")).toBeTruthy();
   });
 
-  it("renders lifecycle event labels and summaries", () => {
+  it("renders lifecycle event labels with actor bylines", () => {
     render(EventTimeline, {
       props: {
         events: [
           makeEvent({
             ID: 3,
             EventType: "merged",
+            Author: "merge-admin",
             Summary: "merged this",
             CreatedAt: "2024-06-01T12:03:00Z",
           }),
           makeEvent({
             ID: 2,
             EventType: "closed",
+            Author: "reviewer",
             Summary: "closed this",
             CreatedAt: "2024-06-01T12:02:00Z",
           }),
           makeEvent({
             ID: 1,
             EventType: "reopened",
+            Author: "maintainer",
             Summary: "reopened this",
             CreatedAt: "2024-06-01T12:01:00Z",
           }),
@@ -244,9 +247,24 @@ describe("EventTimeline", () => {
     expect(screen.getByText("Merged")).toBeTruthy();
     expect(screen.getByText("Closed")).toBeTruthy();
     expect(screen.getByText("Reopened")).toBeTruthy();
-    expect(screen.getByText("merged this")).toBeTruthy();
-    expect(screen.getByText("closed this")).toBeTruthy();
-    expect(screen.getByText("reopened this")).toBeTruthy();
+    const authors = Array.from(document.querySelectorAll(".event-author")).map((element) =>
+      element.textContent?.replace(/\s+/g, " ").trim(),
+    );
+    expect(authors).toContain("by merge-admin");
+    expect(authors).toContain("by reviewer");
+    expect(authors).toContain("by maintainer");
+    expect(document.querySelector(".event-author-prefix")?.textContent).toBe("by");
+    expect(document.querySelector(".event-author--lifecycle")?.textContent?.replace(/\s+/g, " ").trim()).toBe(
+      "by merge-admin",
+    );
+    const prefixStyle = findCompiledStyleRule(".event-author-prefix");
+    expect(prefixStyle.color).toBe("var(--text-muted)");
+    expect(prefixStyle.fontWeight).toBe("400");
+    expect(compiledCss).toContain(".event-author--lifecycle");
+    expect(compiledCss).toContain("margin-left: calc(var(--focus-detail-space-xs, 0.46rem) * -0.5)");
+    expect(screen.queryByText("merged this")).toBeNull();
+    expect(screen.queryByText("closed this")).toBeNull();
+    expect(screen.queryByText("reopened this")).toBeNull();
     expect(document.querySelectorAll(".event--compact")).toHaveLength(3);
   });
 
@@ -266,6 +284,28 @@ describe("EventTimeline", () => {
     const dot = document.querySelector(".dot");
     expect(label.getAttribute("style")).toContain("var(--accent-purple)");
     expect(dot?.getAttribute("style")).toContain("var(--accent-purple)");
+  });
+
+  it("renders compact activity lifecycle rows with actor bylines", () => {
+    const { container } = render(EventTimeline, {
+      props: {
+        activityViewMode: "compact",
+        events: [
+          makeEvent({
+            EventType: "merged",
+            Author: "alice",
+            Summary: "merged this",
+          }),
+        ],
+      },
+    });
+
+    const row = container.querySelector<HTMLElement>(".event-card--compact-row");
+    const rowText = row?.textContent?.replace(/\s+/g, " ").trim() ?? "";
+    expect(rowText).toContain("Merged by alice");
+    expect(rowText).not.toContain("merged this");
+    expect(row?.querySelector(".event-author-prefix")?.textContent).toBe("by");
+    expect(row?.querySelector(".compact-event-summary")?.textContent?.trim()).toBe("");
   });
 
   it("collapses duplicate merge lifecycle rows into the single authored transition", () => {
@@ -303,7 +343,38 @@ describe("EventTimeline", () => {
     expect(screen.getAllByText("Merged")).toHaveLength(1);
     expect(screen.queryByText("Closed")).toBeNull();
     expect(screen.queryByText("closed this")).toBeNull();
-    expect(screen.getByText("mariusvniekerk")).toBeTruthy();
+    expect(document.querySelector(".event--compact")?.textContent).toContain("by mariusvniekerk");
+    expect(document.querySelectorAll(".event--compact")).toHaveLength(1);
+  });
+
+  it("uses the authored close transition when an anonymous merged row is coalesced", () => {
+    render(EventTimeline, {
+      props: {
+        events: [
+          makeEvent({
+            ID: 1,
+            EventType: "merged",
+            Author: "",
+            Summary: "merged this",
+            CreatedAt: "2024-06-01T12:03:00Z",
+            DedupeKey: "timeline-merge-fallback",
+          }),
+          makeEvent({
+            ID: 2,
+            EventType: "closed",
+            Author: "merge-admin",
+            Summary: "closed this",
+            CreatedAt: "2024-06-01T12:03:00Z",
+            DedupeKey: "timeline-close-provider",
+          }),
+        ],
+      },
+    });
+
+    expect(screen.getAllByText("Merged")).toHaveLength(1);
+    expect(screen.queryByText("Closed")).toBeNull();
+    expect(document.querySelector(".event--compact")?.textContent).toContain("by merge-admin");
+    expect(screen.queryByText("merged this")).toBeNull();
     expect(document.querySelectorAll(".event--compact")).toHaveLength(1);
   });
 
@@ -339,7 +410,11 @@ describe("EventTimeline", () => {
     expect(screen.getByText("Merged")).toBeTruthy();
     expect(screen.getByText("Reopened")).toBeTruthy();
     expect(screen.getByText("Closed")).toBeTruthy();
-    expect(screen.getByText("closed this")).toBeTruthy();
+    const authors = Array.from(document.querySelectorAll(".event-author")).map((element) =>
+      element.textContent?.replace(/\s+/g, " ").trim(),
+    );
+    expect(authors.filter((author) => author === "by mariusvniekerk")).toHaveLength(3);
+    expect(screen.queryByText("closed this")).toBeNull();
     expect(document.querySelectorAll(".event--compact")).toHaveLength(3);
   });
 


### PR DESCRIPTION
## Summary

- Render lifecycle rows as `MERGED by <actor> <time>` with quieter `by` styling.
- Carry merge actors through provider-neutral index, closed-transition, and detail sync paths so Conversation loads can show the actor from SQLite immediately.
- Keep PR detail reads and unchanged GitHub detail syncs from doing extra provider/timeline fetches just to migrate stale missing actors.
- Preserve GitLab legacy `merged_by` actor fallback while preferring `merge_user` when available.
- Deduplicate authored merged events when repeated index, detail, and timeline paths describe the same merge.
