### PR TITLE
Allow editing draft review comments

### DIFF
--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -207,6 +207,16 @@ original diff range, so the PATCH path must rebuild the range from the stored
 comment rather than from whichever line is currently selected
 (`packages/ui/src/stores/diff-review-draft.svelte.ts::editComment`).
 
+An open saved-draft comment editor is also pending local state, even before its
+body differs from the saved text. Review-level publish and discard must stay
+unavailable until every draft comment editor is saved or canceled; otherwise the
+provider mutation can submit the old saved body while the UI still shows an
+unsaved edit. Track that state in the draft-review store and have both tray and
+inline editors clear it on save, cancel, and unmount
+(`packages/ui/src/stores/diff-review-draft.svelte.ts::hasPendingCommentEdits`,
+`packages/ui/src/components/diff/DiffReviewDraftTray.svelte::publish`,
+`packages/ui/src/components/diff/DiffReviewDraftInlineComment.svelte::reportEditState`).
+
 Draft authoring and the sticky publish tray are gated by the repo operation
 `review_draft`, not `submit_review`. `submit_review` gates submitted review
 actions in the detail header, while Files-tab draft authoring must disappear

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -199,6 +199,21 @@ context.
   can anchor to a file/line position, but their compact timeline summaries
   should still use root-comment context plus newest-first replies.
 
+## Inline Review Drafts
+
+Inline diff review draft comments are local staged review state until publish.
+Editing a saved draft comment should change only the body and preserve the
+original diff range, so the PATCH path must rebuild the range from the stored
+comment rather than from whichever line is currently selected
+(`packages/ui/src/stores/diff-review-draft.svelte.ts::editComment`).
+
+Draft authoring and the sticky publish tray are gated by the repo operation
+`review_draft`, not `submit_review`. `submit_review` gates submitted review
+actions in the detail header, while Files-tab draft authoring must disappear
+when `review_draft` is unavailable and show that operation's reason instead
+(`packages/ui/src/components/diff/DiffFilesLayout.svelte:44`,
+`frontend/tests/e2e/inline-review.spec.ts:655`).
+
 ## Optional Metadata Controls
 
 Optional metadata must not reserve empty rows or placeholders when absent. Put

--- a/frontend/tests/e2e/inline-review.spec.ts
+++ b/frontend/tests/e2e/inline-review.spec.ts
@@ -555,6 +555,40 @@ async function mockInlineReviewAPI(
     ];
     await fulfillJson(route, draftComments[0], 201);
   });
+  await page.route(`**${path}/review-draft/comments/*`, async (route) => {
+    const request = route.request();
+    const commentID = new URL(request.url()).pathname.split("/").pop();
+    if (request.method() === "PATCH") {
+      const body = JSON.parse(request.postData() ?? "{}") as {
+        body: string;
+        range: Record<string, unknown>;
+      };
+      const updated = {
+        id: commentID,
+        body: body.body,
+        path: body.range.path,
+        side: body.range.side,
+        line: body.range.line,
+        new_line: body.range.new_line,
+        old_line: body.range.old_line,
+        start_line: body.range.start_line,
+        start_side: body.range.start_side,
+        line_type: body.range.line_type,
+        diff_head_sha: body.range.diff_head_sha,
+        created_at: "2026-03-30T14:01:00Z",
+        updated_at: "2026-03-30T14:03:00Z",
+      };
+      draftComments = draftComments.map((comment) => (comment.id === commentID ? updated : comment));
+      await fulfillJson(route, updated);
+      return;
+    }
+    if (request.method() === "DELETE") {
+      draftComments = draftComments.filter((comment) => comment.id !== commentID);
+      await fulfillJson(route, { status: "ok" });
+      return;
+    }
+    await route.fallback();
+  });
   await page.route(`**${path}/review-draft/publish`, async (route) => {
     draftComments = options.remainingDraftComments ?? [];
     await fulfillJson(route, {
@@ -586,7 +620,7 @@ test.beforeEach(async ({ page }) => {
 
 test("unavailable operations disable inline review authoring and thread replies", async ({ page }) => {
   // A GitHub App split host with no user write credential reports
-  // submit_review and reply_review_thread unavailable; the Files tab
+  // review_draft and reply_review_thread unavailable; the Files tab
   // must not offer inline review authoring or thread replies that
   // would fail at publish/reply time.
   const unavailableOp = {
@@ -603,7 +637,7 @@ test("unavailable operations disable inline review authoring and thread replies"
     }
   });
   await mockInlineReviewAPI(page, baseCapabilities, "github", "github.com", diffResponse, undefined, {
-    operations: { submit_review: unavailableOp, reply_review_thread: unavailableOp },
+    operations: { review_draft: unavailableOp, reply_review_thread: unavailableOp },
   });
 
   await page.goto("/pulls/github/acme/widgets/42/files");
@@ -618,9 +652,9 @@ test("unavailable operations disable inline review authoring and thread replies"
   expect(replyCalls).toEqual([]);
 });
 
-test("a loaded draft becomes unpublishable when submit_review flips unavailable", async ({ page }) => {
+test("a loaded draft becomes unpublishable when review_draft flips unavailable", async ({ page }) => {
   // The riskiest Files-tab path: a draft that is already loaded and
-  // publishable must lose its publish affordance when submit_review
+  // publishable must lose its publish affordance when review_draft
   // becomes unavailable while the diff stays mounted. Split view
   // keeps the conversation pane (which polls the detail payload) and
   // the files pane mounted together, so the flip arrives through the
@@ -654,8 +688,8 @@ test("a loaded draft becomes unpublishable when submit_review flips unavailable"
     ],
   });
   // Override the detail route (last registered wins) so the test can
-  // flip submit_review availability between detail polls.
-  let submitReviewOp: Record<string, unknown> | undefined;
+  // flip review_draft availability between detail polls.
+  let reviewDraftOp: Record<string, unknown> | undefined;
   let detailGets = 0;
   await page.route("**/api/v1/pulls/github/acme/widgets/42", async (route) => {
     if (route.request().method() !== "GET") {
@@ -663,7 +697,7 @@ test("a loaded draft becomes unpublishable when submit_review flips unavailable"
       return;
     }
     detailGets += 1;
-    const operations = submitReviewOp !== undefined ? { submit_review: submitReviewOp } : undefined;
+    const operations = reviewDraftOp !== undefined ? { review_draft: reviewDraftOp } : undefined;
     await fulfillJson(route, pullDetail(false, baseCapabilities, "github", "github.com", operations));
   });
 
@@ -676,7 +710,7 @@ test("a loaded draft becomes unpublishable when submit_review flips unavailable"
 
   // Flip off: the next detail poll delivers the exhausted budget and
   // the mounted diff swaps the publishable tray for the reason.
-  submitReviewOp = {
+  reviewDraftOp = {
     available: false,
     code: "rate_limited",
     unavailable_reason: rateLimitedReason,
@@ -690,7 +724,7 @@ test("a loaded draft becomes unpublishable when submit_review flips unavailable"
 
   // Flip back: the server-side draft survived the gated window and
   // the view restores it, publishable again.
-  submitReviewOp = undefined;
+  reviewDraftOp = undefined;
   getsBefore = detailGets;
   await page.clock.fastForward(61_000);
   await expect.poll(() => detailGets).toBeGreaterThan(getsBefore);
@@ -717,6 +751,52 @@ test("adds and publishes an inline draft review comment", async ({ page }) => {
   await expect(page.getByRole("button", { name: "Show full comment" })).toHaveCount(0);
   await page.getByRole("button", { name: "Publish review" }).click();
   await expect(page.getByText("1 draft comment")).toBeHidden();
+});
+
+test("edits an existing inline draft review comment before publishing", async ({ page }) => {
+  await mockInlineReviewAPI(page, baseCapabilities, "github", "github.com", diffResponse, undefined, {
+    initialDraftComments: [
+      {
+        id: "draft-1",
+        body: "Please cover this line.",
+        path: "src/main.ts",
+        side: "right",
+        line: 2,
+        new_line: 2,
+        line_type: "add",
+        diff_head_sha: "diff-head",
+        created_at: "2026-03-30T14:01:00Z",
+        updated_at: "2026-03-30T14:01:00Z",
+      },
+    ],
+  });
+
+  await page.goto("/pulls/github/acme/widgets/42/files");
+  const inlineDraft = page.locator(".inline-draft-comment");
+  await expect(inlineDraft).toContainText("Please cover this line.");
+
+  await page.getByRole("button", { name: "Edit draft comment" }).first().click();
+  const editor = page.getByLabel("Draft comment body").first();
+  await expect(editor).toHaveValue("Please cover this line.");
+  await editor.fill("Please cover this line and the nearby branch.");
+
+  const patchRequest = page.waitForRequest((request) => {
+    const path = new URL(request.url()).pathname;
+    return request.method() === "PATCH" && path.endsWith("/review-draft/comments/draft-1");
+  });
+  await page.getByRole("button", { name: "Save draft comment" }).first().click();
+  expect((await patchRequest).postDataJSON()).toMatchObject({
+    body: "Please cover this line and the nearby branch.",
+    range: {
+      path: "src/main.ts",
+      side: "right",
+      line: 2,
+      line_type: "add",
+      diff_head_sha: "diff-head",
+    },
+  });
+
+  await expect(inlineDraft).toContainText("Please cover this line and the nearby branch.");
 });
 
 test("keeps split-mode inline composers on trailing right-side hunk lines", async ({ page }) => {

--- a/packages/ui/src/components/diff/DiffFile.inline-comment.bench.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.inline-comment.bench.test.ts
@@ -147,6 +147,8 @@ function renderDiffFile(file: DiffFileType) {
     getError: () => null,
     createComment: (_body: string, _range: DiffReviewLineRange) => Promise.resolve(true),
     deleteComment: () => Promise.resolve(true),
+    editComment: () => Promise.resolve(true),
+    setCommentEditState: vi.fn(),
   };
 
   return render(DiffFile, {

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -280,6 +280,8 @@ function renderDiffFile(
     getError: () => null,
     createComment: options.createComment ?? (() => Promise.resolve(true)),
     deleteComment: () => Promise.resolve(true),
+    editComment: () => Promise.resolve(true),
+    setCommentEditState: vi.fn(),
   };
   const owner = options.owner ?? uniqueOwner();
   const result = render(DiffFile, {

--- a/packages/ui/src/components/diff/DiffReviewDraftInlineComment.svelte
+++ b/packages/ui/src/components/diff/DiffReviewDraftInlineComment.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { tick } from "svelte";
+  import { onDestroy, tick } from "svelte";
   import CheckIcon from "@lucide/svelte/icons/check";
   import PencilIcon from "@lucide/svelte/icons/pencil";
   import XIcon from "@lucide/svelte/icons/x";
@@ -17,6 +17,7 @@
   let draftBody = $state("");
   let saving = $state(false);
   let editorElement: HTMLTextAreaElement | undefined = $state();
+  const editStateID = $derived(`inline:${comment.id}`);
   const editDisabled = $derived(submitting || saving);
   const saveDisabled = $derived(editDisabled || draftBody.trim() === "");
 
@@ -30,12 +31,30 @@
   function beginEdit(): void {
     draftBody = comment.body;
     editing = true;
+    reportEditState(true);
     void tick().then(() => editorElement?.focus());
   }
 
   function cancelEdit(): void {
     draftBody = comment.body;
     editing = false;
+    reportEditState(false);
+  }
+
+  function draftDirty(body: string): boolean {
+    return body.trim() !== comment.body;
+  }
+
+  function reportEditState(active: boolean, body = draftBody): void {
+    diffReviewDraft.setCommentEditState(editStateID, {
+      active,
+      dirty: active && draftDirty(body),
+    });
+  }
+
+  function handleDraftBodyInput(event: Event): void {
+    draftBody = (event.currentTarget as HTMLTextAreaElement).value;
+    reportEditState(true);
   }
 
   async function saveEdit(): Promise<void> {
@@ -43,6 +62,7 @@
     if (!nextBody || saveDisabled) return;
     if (nextBody === comment.body) {
       editing = false;
+      reportEditState(false);
       return;
     }
     saving = true;
@@ -50,11 +70,16 @@
       const ok = await diffReviewDraft.editComment(comment, nextBody);
       if (ok) {
         editing = false;
+        reportEditState(false);
       }
     } finally {
       saving = false;
     }
   }
+
+  onDestroy(() => {
+    reportEditState(false);
+  });
 </script>
 
 <div
@@ -114,11 +139,12 @@
   {#if editing}
     <textarea
       bind:this={editorElement}
-      bind:value={draftBody}
+      value={draftBody}
       class="draft-comment-editor"
       aria-label="Draft comment body"
       rows="3"
       disabled={editDisabled}
+      oninput={handleDraftBodyInput}
     ></textarea>
   {:else}
     <p class="draft-comment-body">{comment.body}</p>

--- a/packages/ui/src/components/diff/DiffReviewDraftInlineComment.svelte
+++ b/packages/ui/src/components/diff/DiffReviewDraftInlineComment.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import { tick } from "svelte";
+  import CheckIcon from "@lucide/svelte/icons/check";
+  import PencilIcon from "@lucide/svelte/icons/pencil";
   import XIcon from "@lucide/svelte/icons/x";
   import type { DiffReviewDraftComment } from "../../stores/diff-review-draft.svelte.js";
   import { getStores } from "../../context.js";
@@ -10,12 +13,47 @@
   const { comment }: Props = $props();
   const { diffReviewDraft } = getStores();
   const submitting = $derived(diffReviewDraft.isSubmitting());
+  let editing = $state(false);
+  let draftBody = $state("");
+  let saving = $state(false);
+  let editorElement: HTMLTextAreaElement | undefined = $state();
+  const editDisabled = $derived(submitting || saving);
+  const saveDisabled = $derived(editDisabled || draftBody.trim() === "");
 
   function lineLabel(comment: DiffReviewDraftComment): string {
     if (comment.start_line != null && comment.start_line !== comment.line) {
       return `${comment.path}:${comment.start_line}-${comment.line}`;
     }
     return `${comment.path}:${comment.line}`;
+  }
+
+  function beginEdit(): void {
+    draftBody = comment.body;
+    editing = true;
+    void tick().then(() => editorElement?.focus());
+  }
+
+  function cancelEdit(): void {
+    draftBody = comment.body;
+    editing = false;
+  }
+
+  async function saveEdit(): Promise<void> {
+    const nextBody = draftBody.trim();
+    if (!nextBody || saveDisabled) return;
+    if (nextBody === comment.body) {
+      editing = false;
+      return;
+    }
+    saving = true;
+    try {
+      const ok = await diffReviewDraft.editComment(comment, nextBody);
+      if (ok) {
+        editing = false;
+      }
+    } finally {
+      saving = false;
+    }
   }
 </script>
 
@@ -27,17 +65,64 @@
   <div class="draft-comment-header">
     <span class="draft-comment-state">Draft</span>
     <span class="draft-comment-location">{lineLabel(comment)}</span>
-    <button
-      class="draft-comment-delete"
-      title="Delete draft comment"
-      aria-label="Delete draft comment"
-      onclick={() => void diffReviewDraft.deleteComment(comment.id)}
-      disabled={submitting}
-    >
-      <XIcon size={13} />
-    </button>
+    <div class="draft-comment-actions">
+      {#if editing}
+        <button
+          class="draft-comment-action"
+          type="button"
+          title="Save draft comment"
+          aria-label="Save draft comment"
+          onclick={() => void saveEdit()}
+          disabled={saveDisabled}
+        >
+          <CheckIcon size={13} />
+        </button>
+        <button
+          class="draft-comment-action"
+          type="button"
+          title="Cancel editing draft comment"
+          aria-label="Cancel editing draft comment"
+          onclick={cancelEdit}
+          disabled={editDisabled}
+        >
+          <XIcon size={13} />
+        </button>
+      {:else}
+        <button
+          class="draft-comment-action"
+          type="button"
+          title="Edit draft comment"
+          aria-label="Edit draft comment"
+          onclick={beginEdit}
+          disabled={submitting}
+        >
+          <PencilIcon size={13} />
+        </button>
+        <button
+          class="draft-comment-action"
+          type="button"
+          title="Delete draft comment"
+          aria-label="Delete draft comment"
+          onclick={() => void diffReviewDraft.deleteComment(comment.id)}
+          disabled={submitting}
+        >
+          <XIcon size={13} />
+        </button>
+      {/if}
+    </div>
   </div>
-  <p class="draft-comment-body">{comment.body}</p>
+  {#if editing}
+    <textarea
+      bind:this={editorElement}
+      bind:value={draftBody}
+      class="draft-comment-editor"
+      aria-label="Draft comment body"
+      rows="3"
+      disabled={editDisabled}
+    ></textarea>
+  {:else}
+    <p class="draft-comment-body">{comment.body}</p>
+  {/if}
 </div>
 
 <style>
@@ -95,14 +180,19 @@
     white-space: nowrap;
   }
 
-  .draft-comment-delete {
+  .draft-comment-actions {
+    display: flex;
+    flex-shrink: 0;
+    gap: 4px;
+    margin-left: auto;
+  }
+
+  .draft-comment-action {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    flex-shrink: 0;
     width: 24px;
     height: 24px;
-    margin-left: auto;
     padding: 0;
     border: 1px solid var(--border-muted);
     border-radius: 4px;
@@ -111,7 +201,7 @@
     cursor: pointer;
   }
 
-  .draft-comment-delete:disabled {
+  .draft-comment-action:disabled {
     opacity: 0.55;
     cursor: default;
   }
@@ -122,5 +212,21 @@
     font-size: var(--font-size-sm);
     white-space: pre-wrap;
     overflow-wrap: anywhere;
+  }
+
+  .draft-comment-editor {
+    box-sizing: border-box;
+    width: 100%;
+    min-height: 76px;
+    margin-top: 6px;
+    resize: vertical;
+    padding: 7px 8px;
+    border: 1px solid var(--border-muted);
+    border-radius: var(--radius-md);
+    background: var(--bg-inset);
+    color: var(--text-primary);
+    font: inherit;
+    font-size: var(--font-size-sm);
+    line-height: 1.42;
   }
 </style>

--- a/packages/ui/src/components/diff/DiffReviewDraftTray.svelte
+++ b/packages/ui/src/components/diff/DiffReviewDraftTray.svelte
@@ -31,9 +31,12 @@
       : (supportedActions[0] ?? "comment"),
   );
   const submitting = $derived(diffReviewDraft.isSubmitting());
+  const pendingCommentEdits = $derived(diffReviewDraft.hasPendingCommentEdits());
   const error = $derived(diffReviewDraft.getError());
+  const draftActionDisabled = $derived(submitting || pendingCommentEdits);
 
   async function publish(): Promise<void> {
+    if (pendingCommentEdits) return;
     const ok = await diffReviewDraft.publish(selectedAction, body);
     if (ok) {
       body = "";
@@ -64,7 +67,7 @@
         ariaLabel="Discard review draft"
         size="sm"
         onclick={() => void diffReviewDraft.discard()}
-        disabled={submitting}
+        disabled={draftActionDisabled}
       >
         <TrashIcon size={14} />
       </ActionButton>
@@ -78,6 +81,7 @@
           {onjump}
           ondelete={(id) => void diffReviewDraft.deleteComment(id)}
           onsave={(draftComment, draftBody) => diffReviewDraft.editComment(draftComment, draftBody)}
+          oneditstatechange={(id, state) => diffReviewDraft.setCommentEditState(id, state)}
         />
       {/each}
     </div>
@@ -104,8 +108,9 @@
         tone="info"
         surface="solid"
         size="sm"
+        title={pendingCommentEdits ? "Save or cancel draft comment edits before publishing" : undefined}
         onclick={() => void publish()}
-        disabled={submitting || supportedActions.length === 0}
+        disabled={draftActionDisabled || supportedActions.length === 0}
       >
         <SendIcon size={14} />
         {submitting ? "Publishing..." : "Publish review"}

--- a/packages/ui/src/components/diff/DiffReviewDraftTray.svelte
+++ b/packages/ui/src/components/diff/DiffReviewDraftTray.svelte
@@ -77,6 +77,7 @@
           disabled={submitting}
           {onjump}
           ondelete={(id) => void diffReviewDraft.deleteComment(id)}
+          onsave={(draftComment, draftBody) => diffReviewDraft.editComment(draftComment, draftBody)}
         />
       {/each}
     </div>

--- a/packages/ui/src/components/diff/DiffReviewDraftTray.test.ts
+++ b/packages/ui/src/components/diff/DiffReviewDraftTray.test.ts
@@ -1,35 +1,91 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/svelte";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { STORES_KEY } from "../../context.js";
+import type { MiddlemanClient } from "../../types.js";
+import type { ProviderRouteRef } from "../../api/provider-routes.js";
+import { createDiffReviewDraftStore } from "../../stores/diff-review-draft.svelte.js";
+import DiffReviewDraftInlineComment from "./DiffReviewDraftInlineComment.svelte";
 import DiffReviewDraftTray from "./DiffReviewDraftTray.svelte";
 
-function renderTray(publishResult: boolean) {
-  const publish = vi.fn(() => Promise.resolve(publishResult));
-  const editComment = vi.fn(() => Promise.resolve(true));
-  const diffReviewDraft = {
-    getComments: () => [
-      {
-        id: "1",
-        body: "Draft note",
-        path: "src/foo.ts",
-        line: 12,
-      },
-    ],
-    getDraft: () => ({
-      supported_actions: ["comment"],
-    }),
-    isSubmitting: () => false,
-    getError: () => (publishResult ? null : "publish failed"),
-    publish,
-    discard: () => Promise.resolve(true),
-    deleteComment: () => Promise.resolve(true),
-    editComment,
+function providerRef(): ProviderRouteRef {
+  return {
+    provider: "github",
+    platformHost: "github.com",
+    owner: "acme",
+    name: "widgets",
+    repoPath: "acme/widgets",
   };
-  const rendered = render(DiffReviewDraftTray, {
-    context: new Map([[STORES_KEY, { diffReviewDraft }]]),
+}
+
+function draftComment() {
+  return {
+    id: "1",
+    body: "Draft note",
+    path: "src/foo.ts",
+    side: "right",
+    line: 12,
+    new_line: 12,
+    line_type: "add",
+    diff_head_sha: "head-sha",
+    created_at: "2026-03-30T14:01:00Z",
+    updated_at: "2026-03-30T14:01:00Z",
+  };
+}
+
+async function renderTray(publishResult: boolean) {
+  const publish = vi.fn(() => Promise.resolve(publishResult));
+  const discard = vi.fn(() => Promise.resolve(true));
+  const editComment = vi.fn(() => Promise.resolve(true));
+  const comment = draftComment();
+  const client = {
+    GET: vi.fn(() =>
+      Promise.resolve({
+        data: {
+          comments: [comment],
+          supported_actions: ["comment"],
+          native_multiline_ranges: true,
+        },
+        response: { ok: true, status: 200 },
+      }),
+    ),
+    POST: vi.fn((_path: string, opts: { body?: { action?: string; body?: string } }) => {
+      publish(opts.body?.action, opts.body?.body);
+      if (publishResult) {
+        return Promise.resolve({
+          data: { status: "published" },
+          response: { ok: true, status: 200 },
+        });
+      }
+      return Promise.resolve({
+        error: { title: "publish failed" },
+        response: { ok: false, status: 500 },
+      });
+    }),
+    PATCH: vi.fn((_path: string, opts: { body?: { body?: string } }) => {
+      editComment(comment, opts.body?.body);
+      return Promise.resolve({
+        data: { ...comment, body: opts.body?.body ?? comment.body },
+        response: { ok: true, status: 200 },
+      });
+    }),
+    DELETE: vi.fn(() => {
+      discard();
+      return Promise.resolve({
+        response: { ok: true, status: 200 },
+      });
+    }),
+  } as unknown as MiddlemanClient;
+  const diffReviewDraft = createDiffReviewDraftStore({ client });
+  diffReviewDraft.setContext(providerRef(), 12, true, "head-sha");
+  await waitFor(() => {
+    expect(diffReviewDraft.getComments()).toHaveLength(1);
   });
-  return { ...rendered, editComment, publish };
+  const context = new Map([[STORES_KEY, { diffReviewDraft }]]);
+  const rendered = render(DiffReviewDraftTray, {
+    context,
+  });
+  return { ...rendered, context, diffReviewDraft, discard, editComment, publish };
 }
 
 describe("DiffReviewDraftTray", () => {
@@ -38,7 +94,7 @@ describe("DiffReviewDraftTray", () => {
   });
 
   it("keeps review summary text when publishing fails", async () => {
-    const { publish } = renderTray(false);
+    const { publish } = await renderTray(false);
     const summary = screen.getByPlaceholderText("Review summary") as HTMLTextAreaElement;
 
     await fireEvent.input(summary, {
@@ -51,7 +107,7 @@ describe("DiffReviewDraftTray", () => {
   });
 
   it("lets a draft comment body be edited before publishing", async () => {
-    const { editComment } = renderTray(true);
+    const { editComment } = await renderTray(true);
 
     await fireEvent.click(screen.getByRole("button", { name: "Edit draft comment" }));
     const editor = screen.getByLabelText("Draft comment body") as HTMLTextAreaElement;
@@ -66,6 +122,61 @@ describe("DiffReviewDraftTray", () => {
       expect.objectContaining({ id: "1", body: "Draft note" }),
       "Updated draft note",
     );
-    expect(screen.queryByLabelText("Draft comment body")).toBeNull();
+    await waitFor(() => {
+      expect(screen.queryByLabelText("Draft comment body")).toBeNull();
+    });
+  });
+
+  it("keeps publish and discard unavailable while a draft comment edit is open", async () => {
+    const { discard, publish } = await renderTray(true);
+
+    await fireEvent.click(screen.getByRole("button", { name: "Edit draft comment" }));
+    const editor = screen.getByLabelText("Draft comment body") as HTMLTextAreaElement;
+    await fireEvent.input(editor, {
+      target: { value: "Visible unsaved edit" },
+    });
+
+    const publishButton = screen.getByRole("button", { name: "Publish review" }) as HTMLButtonElement;
+    const discardButton = screen.getByRole("button", { name: "Discard review draft" }) as HTMLButtonElement;
+    expect(publishButton.disabled).toBe(true);
+    expect(discardButton.disabled).toBe(true);
+
+    await fireEvent.click(publishButton);
+    await fireEvent.click(discardButton);
+
+    expect(publish).not.toHaveBeenCalled();
+    expect(discard).not.toHaveBeenCalled();
+
+    await fireEvent.click(screen.getByRole("button", { name: "Cancel editing draft comment" }));
+
+    expect(publishButton.disabled).toBe(false);
+    expect(discardButton.disabled).toBe(false);
+  });
+
+  it("keeps publish and discard unavailable while an inline draft comment edit is open", async () => {
+    const { context, diffReviewDraft, discard, publish } = await renderTray(true);
+    render(DiffReviewDraftInlineComment, {
+      props: { comment: diffReviewDraft.getComments()[0] },
+      context,
+    });
+    const inlineComment = document.querySelector("[data-draft-comment-id='1']");
+    expect(inlineComment).not.toBeNull();
+
+    await fireEvent.click(within(inlineComment as HTMLElement).getByRole("button", { name: "Edit draft comment" }));
+    const editor = within(inlineComment as HTMLElement).getByLabelText("Draft comment body") as HTMLTextAreaElement;
+    await fireEvent.input(editor, {
+      target: { value: "Inline visible unsaved edit" },
+    });
+
+    const publishButton = screen.getByRole("button", { name: "Publish review" }) as HTMLButtonElement;
+    const discardButton = screen.getByRole("button", { name: "Discard review draft" }) as HTMLButtonElement;
+    expect(publishButton.disabled).toBe(true);
+    expect(discardButton.disabled).toBe(true);
+
+    await fireEvent.click(publishButton);
+    await fireEvent.click(discardButton);
+
+    expect(publish).not.toHaveBeenCalled();
+    expect(discard).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/components/diff/DiffReviewDraftTray.test.ts
+++ b/packages/ui/src/components/diff/DiffReviewDraftTray.test.ts
@@ -6,6 +6,7 @@ import DiffReviewDraftTray from "./DiffReviewDraftTray.svelte";
 
 function renderTray(publishResult: boolean) {
   const publish = vi.fn(() => Promise.resolve(publishResult));
+  const editComment = vi.fn(() => Promise.resolve(true));
   const diffReviewDraft = {
     getComments: () => [
       {
@@ -23,11 +24,12 @@ function renderTray(publishResult: boolean) {
     publish,
     discard: () => Promise.resolve(true),
     deleteComment: () => Promise.resolve(true),
+    editComment,
   };
   const rendered = render(DiffReviewDraftTray, {
     context: new Map([[STORES_KEY, { diffReviewDraft }]]),
   });
-  return { ...rendered, publish };
+  return { ...rendered, editComment, publish };
 }
 
 describe("DiffReviewDraftTray", () => {
@@ -46,5 +48,24 @@ describe("DiffReviewDraftTray", () => {
 
     expect(publish).toHaveBeenCalledWith("comment", "Keep this summary");
     expect(summary.value).toBe("Keep this summary");
+  });
+
+  it("lets a draft comment body be edited before publishing", async () => {
+    const { editComment } = renderTray(true);
+
+    await fireEvent.click(screen.getByRole("button", { name: "Edit draft comment" }));
+    const editor = screen.getByLabelText("Draft comment body") as HTMLTextAreaElement;
+    expect(editor.value).toBe("Draft note");
+
+    await fireEvent.input(editor, {
+      target: { value: "Updated draft note" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Save draft comment" }));
+
+    expect(editComment).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "1", body: "Draft note" }),
+      "Updated draft note",
+    );
+    expect(screen.queryByLabelText("Draft comment body")).toBeNull();
   });
 });

--- a/packages/ui/src/components/diff/DiffReviewDraftTrayItem.svelte
+++ b/packages/ui/src/components/diff/DiffReviewDraftTrayItem.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
-  import { onMount, tick } from "svelte";
+  import { onDestroy, onMount, tick } from "svelte";
   import CheckIcon from "@lucide/svelte/icons/check";
   import PencilIcon from "@lucide/svelte/icons/pencil";
   import XIcon from "@lucide/svelte/icons/x";
-  import type { DiffReviewDraftComment } from "../../stores/diff-review-draft.svelte.js";
+  import type {
+    DiffReviewDraftComment,
+    DiffReviewDraftCommentEditState,
+  } from "../../stores/diff-review-draft.svelte.js";
   import ActionButton from "../shared/ActionButton.svelte";
 
   interface Props {
@@ -13,9 +16,10 @@
     onjump?: ((comment: DiffReviewDraftComment) => void) | undefined;
     ondelete: (id: string) => void;
     onsave: (comment: DiffReviewDraftComment, body: string) => Promise<boolean> | boolean;
+    oneditstatechange: (id: string, state: DiffReviewDraftCommentEditState) => void;
   }
 
-  const { comment, location, disabled, onjump, ondelete, onsave }: Props = $props();
+  const { comment, location, disabled, onjump, ondelete, onsave, oneditstatechange }: Props = $props();
 
   let expanded = $state(false);
   let editing = $state(false);
@@ -25,6 +29,7 @@
   let bodyElement: HTMLParagraphElement | undefined = $state();
   let editorElement: HTMLTextAreaElement | undefined = $state();
   let measureFrame: number | undefined;
+  const editStateID = $derived(`tray:${comment.id}`);
   const editDisabled = $derived(disabled || saving);
   const saveDisabled = $derived(editDisabled || draftBody.trim() === "");
 
@@ -52,9 +57,21 @@
     void tick().then(queueMeasure);
   }
 
+  function draftDirty(body: string): boolean {
+    return body.trim() !== comment.body;
+  }
+
+  function reportEditState(active: boolean, body = draftBody): void {
+    oneditstatechange(editStateID, {
+      active,
+      dirty: active && draftDirty(body),
+    });
+  }
+
   function beginEdit(): void {
     draftBody = comment.body;
     editing = true;
+    reportEditState(true);
     expanded = true;
     void tick().then(() => editorElement?.focus());
   }
@@ -62,6 +79,12 @@
   function cancelEdit(): void {
     draftBody = comment.body;
     editing = false;
+    reportEditState(false);
+  }
+
+  function handleDraftBodyInput(event: Event): void {
+    draftBody = (event.currentTarget as HTMLTextAreaElement).value;
+    reportEditState(true);
   }
 
   async function saveEdit(): Promise<void> {
@@ -69,6 +92,7 @@
     if (!nextBody || saveDisabled) return;
     if (nextBody === comment.body) {
       editing = false;
+      reportEditState(false);
       return;
     }
     saving = true;
@@ -76,6 +100,7 @@
       const ok = await onsave(comment, nextBody);
       if (ok) {
         editing = false;
+        reportEditState(false);
       }
     } finally {
       saving = false;
@@ -101,6 +126,10 @@
     };
   });
 
+  onDestroy(() => {
+    reportEditState(false);
+  });
+
   $effect(() => scheduleMeasure(comment.body, expanded));
 </script>
 
@@ -116,11 +145,12 @@
     {#if editing}
       <textarea
         bind:this={editorElement}
-        bind:value={draftBody}
+        value={draftBody}
         class="draft-editor"
         aria-label="Draft comment body"
         rows="3"
         disabled={editDisabled}
+        oninput={handleDraftBodyInput}
       ></textarea>
     {:else}
       <p

--- a/packages/ui/src/components/diff/DiffReviewDraftTrayItem.svelte
+++ b/packages/ui/src/components/diff/DiffReviewDraftTrayItem.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import { onMount, tick } from "svelte";
+  import CheckIcon from "@lucide/svelte/icons/check";
+  import PencilIcon from "@lucide/svelte/icons/pencil";
   import XIcon from "@lucide/svelte/icons/x";
   import type { DiffReviewDraftComment } from "../../stores/diff-review-draft.svelte.js";
   import ActionButton from "../shared/ActionButton.svelte";
@@ -10,14 +12,21 @@
     disabled: boolean;
     onjump?: ((comment: DiffReviewDraftComment) => void) | undefined;
     ondelete: (id: string) => void;
+    onsave: (comment: DiffReviewDraftComment, body: string) => Promise<boolean> | boolean;
   }
 
-  const { comment, location, disabled, onjump, ondelete }: Props = $props();
+  const { comment, location, disabled, onjump, ondelete, onsave }: Props = $props();
 
   let expanded = $state(false);
+  let editing = $state(false);
+  let draftBody = $state("");
+  let saving = $state(false);
   let truncated = $state(false);
   let bodyElement: HTMLParagraphElement | undefined = $state();
+  let editorElement: HTMLTextAreaElement | undefined = $state();
   let measureFrame: number | undefined;
+  const editDisabled = $derived(disabled || saving);
+  const saveDisabled = $derived(editDisabled || draftBody.trim() === "");
 
   function measureTruncation(): void {
     if (!bodyElement) {
@@ -41,6 +50,36 @@
   function toggleExpanded(): void {
     expanded = !expanded;
     void tick().then(queueMeasure);
+  }
+
+  function beginEdit(): void {
+    draftBody = comment.body;
+    editing = true;
+    expanded = true;
+    void tick().then(() => editorElement?.focus());
+  }
+
+  function cancelEdit(): void {
+    draftBody = comment.body;
+    editing = false;
+  }
+
+  async function saveEdit(): Promise<void> {
+    const nextBody = draftBody.trim();
+    if (!nextBody || saveDisabled) return;
+    if (nextBody === comment.body) {
+      editing = false;
+      return;
+    }
+    saving = true;
+    try {
+      const ok = await onsave(comment, nextBody);
+      if (ok) {
+        editing = false;
+      }
+    } finally {
+      saving = false;
+    }
   }
 
   function scheduleMeasure(_body: string, _expanded: boolean): void {
@@ -74,34 +113,80 @@
     >
       {location}
     </button>
-    <p
-      bind:this={bodyElement}
-      class={["draft-body", expanded && "draft-body--expanded"]}
-    >
-      {comment.body}
-    </p>
-    {#if truncated || expanded}
-      <button class="draft-expand" type="button" onclick={toggleExpanded}>
-        {expanded ? "Show less" : "Show full comment"}
-      </button>
+    {#if editing}
+      <textarea
+        bind:this={editorElement}
+        bind:value={draftBody}
+        class="draft-editor"
+        aria-label="Draft comment body"
+        rows="3"
+        disabled={editDisabled}
+      ></textarea>
+    {:else}
+      <p
+        bind:this={bodyElement}
+        class={["draft-body", expanded && "draft-body--expanded"]}
+      >
+        {comment.body}
+      </p>
+      {#if truncated || expanded}
+        <button class="draft-expand" type="button" onclick={toggleExpanded}>
+          {expanded ? "Show less" : "Show full comment"}
+        </button>
+      {/if}
     {/if}
   </div>
-  <ActionButton
-    class="icon-btn"
-    title="Delete draft comment"
-    ariaLabel="Delete draft comment"
-    size="sm"
-    onclick={() => ondelete(comment.id)}
-    disabled={disabled}
-  >
-    <XIcon size={13} />
-  </ActionButton>
+  <div class="draft-actions">
+    {#if editing}
+      <ActionButton
+        class="icon-btn"
+        title="Save draft comment"
+        ariaLabel="Save draft comment"
+        size="sm"
+        onclick={() => void saveEdit()}
+        disabled={saveDisabled}
+      >
+        <CheckIcon size={13} />
+      </ActionButton>
+      <ActionButton
+        class="icon-btn"
+        title="Cancel editing draft comment"
+        ariaLabel="Cancel editing draft comment"
+        size="sm"
+        onclick={cancelEdit}
+        disabled={editDisabled}
+      >
+        <XIcon size={13} />
+      </ActionButton>
+    {:else}
+      <ActionButton
+        class="icon-btn"
+        title="Edit draft comment"
+        ariaLabel="Edit draft comment"
+        size="sm"
+        onclick={beginEdit}
+        disabled={disabled}
+      >
+        <PencilIcon size={13} />
+      </ActionButton>
+      <ActionButton
+        class="icon-btn"
+        title="Delete draft comment"
+        ariaLabel="Delete draft comment"
+        size="sm"
+        onclick={() => ondelete(comment.id)}
+        disabled={disabled}
+      >
+        <XIcon size={13} />
+      </ActionButton>
+    {/if}
+  </div>
 </div>
 
 <style>
   .draft-item {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) 26px;
+    grid-template-columns: minmax(0, 1fr) auto;
     align-items: start;
     gap: 10px;
     min-width: 0;
@@ -134,6 +219,21 @@
     display: block;
     line-clamp: unset;
     -webkit-line-clamp: unset;
+  }
+
+  .draft-editor {
+    box-sizing: border-box;
+    width: 100%;
+    min-height: 78px;
+    resize: vertical;
+    padding: 7px 8px;
+    border: 1px solid var(--border-muted);
+    border-radius: var(--radius-md);
+    background: var(--bg-inset);
+    color: var(--text-primary);
+    font: inherit;
+    font-size: var(--font-size-sm);
+    line-height: 1.42;
   }
 
   .draft-jump {
@@ -172,6 +272,11 @@
 
   .draft-expand:hover {
     text-decoration: underline;
+  }
+
+  .draft-actions {
+    display: flex;
+    gap: 4px;
   }
 
   :global(.icon-btn.action-button) {

--- a/packages/ui/src/stores/diff-review-draft.svelte.test.ts
+++ b/packages/ui/src/stores/diff-review-draft.svelte.test.ts
@@ -14,7 +14,7 @@ interface MockDraftLoad {
 }
 
 interface MockMutation {
-  data?: { status?: string };
+  data?: Record<string, unknown>;
   error?: { code?: string; detail?: string; title?: string; details?: Record<string, unknown> };
   response: { status: number; ok: boolean };
 }
@@ -67,11 +67,31 @@ function failedMutation(): MockMutation {
   });
 }
 
+function draftComment(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "draft-1",
+    body: "needs work",
+    path: "src/main.ts",
+    side: "right",
+    line: 7,
+    new_line: 7,
+    line_type: "add",
+    diff_head_sha: "head-sha",
+    created_at: "2026-03-30T14:01:00Z",
+    updated_at: "2026-03-30T14:01:00Z",
+    ...overrides,
+  };
+}
+
 function mockGet(result: MockDraftLoad | Promise<MockDraftLoad> = draftLoad()) {
   return vi.fn(() => Promise.resolve(result));
 }
 
 function mockPost(result: MockMutation | Promise<MockMutation> = mutation()) {
+  return vi.fn(() => Promise.resolve(result));
+}
+
+function mockPatch(result: MockMutation | Promise<MockMutation> = mutation()) {
   return vi.fn(() => Promise.resolve(result));
 }
 
@@ -82,13 +102,15 @@ function mockDelete(result: MockMutation | Promise<MockMutation> = mutation()) {
 function mockClient({
   GET = mockGet(),
   POST = mockPost(),
+  PATCH = mockPatch(),
   DELETE = mockDelete(),
 }: {
   GET?: ReturnType<typeof vi.fn>;
   POST?: ReturnType<typeof vi.fn>;
+  PATCH?: ReturnType<typeof vi.fn>;
   DELETE?: ReturnType<typeof vi.fn>;
 } = {}): MiddlemanClient {
-  return { GET, POST, DELETE } as unknown as MiddlemanClient;
+  return { GET, POST, PATCH, DELETE } as unknown as MiddlemanClient;
 }
 
 function deferred<T>() {
@@ -214,6 +236,56 @@ describe("createDiffReviewDraftStore", () => {
 
     expect(store.getComments()).toEqual([{ id: "new", body: "new draft" }]);
     expect(store.isLoading()).toBe(false);
+  });
+
+  it("patches a draft comment body while preserving its review range", async () => {
+    const original = draftComment({ id: "draft-7", body: "before" });
+    const updated = draftComment({
+      id: "draft-7",
+      body: "after",
+      updated_at: "2026-03-30T14:02:00Z",
+    });
+    const client = mockClient({
+      GET: vi
+        .fn()
+        .mockResolvedValueOnce(draftLoad({ comments: [original] }))
+        .mockResolvedValueOnce(draftLoad({ comments: [updated] })),
+      PATCH: mockPatch(mutation({ data: updated })),
+    });
+    const store = createDiffReviewDraftStore({ client });
+    const ref = providerRef();
+
+    store.setContext(ref, 42, true);
+    await Promise.resolve();
+    const comment = store.getComments()[0];
+
+    await expect(store.editComment(comment, "after")).resolves.toBe(true);
+    expect(client.PATCH).toHaveBeenCalledWith(
+      "/pulls/{provider}/{owner}/{name}/{number}/review-draft/comments/{draft_comment_id}",
+      {
+        params: {
+          path: {
+            provider: "forgejo",
+            owner: "acme",
+            name: "widgets",
+            number: 42,
+            draft_comment_id: "draft-7",
+          },
+        },
+        body: {
+          body: "after",
+          range: {
+            path: "src/main.ts",
+            side: "right",
+            line: 7,
+            new_line: 7,
+            line_type: "add",
+            diff_head_sha: "head-sha",
+          },
+        },
+      },
+    );
+    expect(store.getComments()).toEqual([updated]);
   });
 
   it("surfaces partial publish status while clearing the draft", async () => {

--- a/packages/ui/src/stores/diff-review-draft.svelte.ts
+++ b/packages/ui/src/stores/diff-review-draft.svelte.ts
@@ -7,6 +7,11 @@ export type DiffReviewDraft = components["schemas"]["DiffReviewDraftResponse"];
 export type DiffReviewDraftComment = components["schemas"]["DiffReviewDraftComment"];
 export type DiffReviewLineRange = components["schemas"]["DiffReviewLineRange"];
 
+export interface DiffReviewDraftCommentEditState {
+  active: boolean;
+  dirty: boolean;
+}
+
 export interface DiffReviewDraftStoreOptions {
   client: MiddlemanClient;
   onPublished?: (ref: ProviderRouteRef, number: number) => Promise<void> | void;
@@ -29,6 +34,7 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
   let submitting = $state(false);
   let storeError = $state<string | null>(null);
   let storeWarning = $state<string | null>(null);
+  let commentEditStates = $state<Record<string, DiffReviewDraftCommentEditState>>({});
   let wasEnabled = false;
   let draftVersion = 0;
   let submitVersion = 0;
@@ -59,6 +65,35 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
 
   function getWarning(): string | null {
     return storeWarning;
+  }
+
+  function setCommentEditState(editID: string, state: DiffReviewDraftCommentEditState): void {
+    if (!state.active && !state.dirty) {
+      clearCommentEditState(editID);
+      return;
+    }
+    commentEditStates = {
+      ...commentEditStates,
+      [editID]: {
+        active: state.active,
+        dirty: state.dirty,
+      },
+    };
+  }
+
+  function clearCommentEditState(editID: string): void {
+    if (commentEditStates[editID] === undefined) return;
+    const next = { ...commentEditStates };
+    delete next[editID];
+    commentEditStates = next;
+  }
+
+  function clearCommentEditStates(): void {
+    commentEditStates = {};
+  }
+
+  function hasPendingCommentEdits(): boolean {
+    return Object.values(commentEditStates).some((state) => state.active || state.dirty);
   }
 
   function currentParams() {
@@ -137,12 +172,14 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
       draft = null;
       storeError = null;
       storeWarning = null;
+      clearCommentEditStates();
       cancelSubmit();
       return;
     }
     if (changed || enabling) {
       draft = null;
       storeWarning = null;
+      clearCommentEditStates();
       cancelSubmit();
       void loadDraft();
     }
@@ -160,6 +197,7 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
     if (changed) {
       draftVersion += 1;
       cancelSubmit();
+      clearCommentEditStates();
       storeError = null;
       storeWarning = null;
     }
@@ -182,6 +220,7 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
     loading = false;
     storeError = null;
     storeWarning = null;
+    clearCommentEditStates();
   }
 
   async function loadDraft(): Promise<void> {
@@ -344,6 +383,7 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
 
   async function publish(action: string, body = ""): Promise<boolean> {
     if (!enabled || !ref) return false;
+    if (hasPendingCommentEdits()) return false;
     const params = currentParams();
     if (!params) return false;
     const publishedRef = ref;
@@ -399,6 +439,7 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
 
   async function discard(): Promise<boolean> {
     if (!enabled || !ref) return false;
+    if (hasPendingCommentEdits()) return false;
     const params = currentParams();
     if (!params) return false;
     const key = requestKey();
@@ -470,6 +511,8 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
     isSubmitting,
     getError,
     getWarning,
+    hasPendingCommentEdits,
+    setCommentEditState,
     setContext,
     setRouteContext,
     clear,

--- a/packages/ui/src/stores/diff-review-draft.svelte.ts
+++ b/packages/ui/src/stores/diff-review-draft.svelte.ts
@@ -97,6 +97,23 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
     submitting = false;
   }
 
+  function draftCommentRange(comment: DiffReviewDraftComment): DiffReviewLineRange {
+    const range: DiffReviewLineRange = {
+      path: comment.path,
+      side: comment.side,
+      line: comment.line,
+      line_type: comment.line_type,
+    };
+    if (comment.old_path !== undefined) range.old_path = comment.old_path;
+    if (comment.start_side !== undefined) range.start_side = comment.start_side;
+    if (comment.start_line !== undefined) range.start_line = comment.start_line;
+    if (comment.old_line !== undefined) range.old_line = comment.old_line;
+    if (comment.new_line !== undefined) range.new_line = comment.new_line;
+    if (comment.diff_head_sha !== undefined) range.diff_head_sha = comment.diff_head_sha;
+    if (comment.commit_sha !== undefined) range.commit_sha = comment.commit_sha;
+    return range;
+  }
+
   function setContext(
     nextRef: ProviderRouteRef,
     nextNumber: number,
@@ -282,6 +299,49 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
     }
   }
 
+  async function editComment(comment: DiffReviewDraftComment, body: string): Promise<boolean> {
+    if (!enabled || !ref) return false;
+    const params = currentParams();
+    if (!params) return false;
+    const key = requestKey();
+    invalidateDraftLoad();
+    const version = draftVersion;
+    const isCurrent = () => requestKey() === key && draftVersion === version;
+    const submitToken = beginSubmit();
+    storeError = null;
+    storeWarning = null;
+    try {
+      const { data, error, response } = await apiClient.PATCH(
+        providerItemPath("pulls", ref, "/review-draft/comments/{draft_comment_id}"),
+        {
+          params: {
+            path: {
+              ...params.path,
+              draft_comment_id: comment.id,
+            },
+          },
+          body: {
+            body,
+            range: draftCommentRange(comment),
+          },
+        },
+      );
+      if (!data) {
+        throw new Error(apiErrorMessage(error, `HTTP ${response.status}`));
+      }
+      if (!isCurrent()) return true;
+      await loadDraft();
+      return true;
+    } catch (err) {
+      if (isCurrent()) {
+        storeError = err instanceof Error ? err.message : String(err);
+      }
+      return false;
+    } finally {
+      finishSubmit(submitToken);
+    }
+  }
+
   async function publish(action: string, body = ""): Promise<boolean> {
     if (!enabled || !ref) return false;
     const params = currentParams();
@@ -416,6 +476,7 @@ export function createDiffReviewDraftStore(opts: DiffReviewDraftStoreOptions) {
     loadDraft,
     createComment,
     deleteComment,
+    editComment,
     publish,
     discard,
     setThreadResolved,


### PR DESCRIPTION
## Summary
- Add edit/save/cancel controls for staged inline review draft comments.
- Keep draft comment diff range metadata intact while saving body edits.
- Document the draft-review permission gate used by Files-tab draft authoring.

<sup>generated by a clanker</sup>