### PR TITLE
fix: include force pushes in PR latest activity

### DIFF
--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -95,6 +95,10 @@ PR timeline storage is intentionally selective.
 - Optional timeline fetch failures may degrade that event family, but should not
   drop the entire PR detail refresh when the rest of the detail payload is still
   usable.
+- When an optional timeline fetch fails after earlier timeline data was stored,
+  derived `last_activity_at` must still preserve the latest stored non-comment
+  event time. A transient failure must not make an already-observed force push,
+  review, commit, or other PR system event stop driving dashboard freshness.
 
 ## SHA-Sensitive Rules
 

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -6166,6 +6166,7 @@ func (s *Syncer) refreshTimeline(
 		return fmt.Errorf("list commits for MR #%d: %w", number, err)
 	}
 
+	timelineEventsFetched := true
 	timelineEvents, err := client.ListPullRequestTimelineEvents(ctx, repo.Owner, repo.Name, number)
 	if err != nil {
 		slog.Warn("timeline event fetch failed during timeline refresh",
@@ -6173,6 +6174,7 @@ func (s *Syncer) refreshTimeline(
 			"number", number,
 			"err", err,
 		)
+		timelineEventsFetched = false
 		timelineEvents = nil
 	}
 
@@ -6216,6 +6218,15 @@ func (s *Syncer) refreshTimeline(
 
 	reviewDecision := DeriveReviewDecision(reviews)
 	lastActivityAt := computeLastActivity(ghPR, comments, reviews, commits, timelineEvents)
+	if !timelineEventsFetched {
+		nonCommentLatest, err := s.db.GetMRLatestNonCommentEventTime(ctx, mrID)
+		if err != nil {
+			return fmt.Errorf("load stored non-comment activity for MR #%d: %w", number, err)
+		}
+		if nonCommentLatest.After(lastActivityAt) {
+			lastActivityAt = nonCommentLatest
+		}
+	}
 
 	return s.db.UpdateMRDerivedFields(ctx, repoID, number, db.MRDerivedFields{
 		ReviewDecision: reviewDecision,

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -5262,7 +5262,7 @@ func (s *Syncer) syncOpenMRFromBulk(
 	// a full REST fetch. Derived fields from truncated data would
 	// overwrite correct values with partial counts.
 	if bulk.CommentsComplete {
-		lastActivity := computeLastActivity(bulk.PR, bulk.Comments, nil, nil)
+		lastActivity := computeLastActivity(bulk.PR, bulk.Comments, nil, nil, nil)
 		// When reviews/commits are truncated this cycle, any stored
 		// review/commit/force-push event with a newer timestamp must
 		// still win so the dashboard ordering doesn't regress.
@@ -5297,7 +5297,7 @@ func (s *Syncer) syncOpenMRFromBulk(
 	if allComplete {
 		reviewDecision := DeriveReviewDecision(bulk.Reviews)
 		lastActivity := computeLastActivity(
-			bulk.PR, bulk.Comments, bulk.Reviews, bulk.Commits,
+			bulk.PR, bulk.Comments, bulk.Reviews, bulk.Commits, bulk.TimelineEvents,
 		)
 		if err := s.db.UpdateMRDerivedFields(
 			ctx, repoID, number, db.MRDerivedFields{
@@ -6215,7 +6215,7 @@ func (s *Syncer) refreshTimeline(
 	}
 
 	reviewDecision := DeriveReviewDecision(reviews)
-	lastActivityAt := computeLastActivity(ghPR, comments, reviews, commits)
+	lastActivityAt := computeLastActivity(ghPR, comments, reviews, commits, timelineEvents)
 
 	return s.db.UpdateMRDerivedFields(ctx, repoID, number, db.MRDerivedFields{
 		ReviewDecision: reviewDecision,
@@ -6470,6 +6470,7 @@ func computeLastActivity(
 	comments []*gh.IssueComment,
 	reviews []*gh.PullRequestReview,
 	commits []*gh.RepositoryCommit,
+	timelineEvents []PullRequestTimelineEvent,
 ) time.Time {
 	latest := time.Time{}
 	if ghPR.UpdatedAt != nil {
@@ -6491,6 +6492,11 @@ func computeLastActivity(
 			c.GetCommit().Author.Date != nil &&
 			c.GetCommit().Author.Date.After(latest) {
 			latest = c.GetCommit().Author.Date.Time
+		}
+	}
+	for _, event := range timelineEvents {
+		if event.CreatedAt.After(latest) {
+			latest = event.CreatedAt
 		}
 	}
 	return latest

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -3615,6 +3615,66 @@ func TestRefreshTimelineUsesForcePushForLastActivity(t *testing.T) {
 	assert.Equal(forcePushAt, pr.LastActivityAt)
 }
 
+func TestRefreshTimelineFetchFailurePreservesStoredForcePushActivity(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	forcePushAt := now.Add(30 * time.Minute)
+	commitSHA := "abc123def456"
+	commitMsg := "fix: tighten validation"
+
+	repo := RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", repo.Owner, repo.Name))
+	require.NoError(err)
+	mrID, err := d.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:         repoID,
+		PlatformID:     1,
+		Number:         1,
+		URL:            "https://github.com/owner/repo/pull/1",
+		Title:          "force push activity",
+		Author:         "dev",
+		State:          "open",
+		HeadBranch:     "feature",
+		BaseBranch:     "main",
+		CreatedAt:      now.Add(-3 * time.Hour),
+		UpdatedAt:      now.Add(-2 * time.Hour),
+		LastActivityAt: forcePushAt,
+	})
+	require.NoError(err)
+	require.NoError(d.UpsertMREvents(ctx, []db.MREvent{{
+		MergeRequestID: mrID,
+		EventType:      "force_push",
+		Author:         "alice",
+		Summary:        "aaaaaaa -> bbbbbbb",
+		MetadataJSON:   `{"ref":"feature"}`,
+		CreatedAt:      forcePushAt,
+		DedupeKey:      "force-push-feature-bbbbbbbbbbbb",
+	}}))
+
+	mc := &mockClient{
+		commits: []*gh.RepositoryCommit{{
+			SHA: &commitSHA,
+			Commit: &gh.Commit{
+				Message: &commitMsg,
+				Author:  &gh.CommitAuthor{Name: new("dev"), Date: makeTimestamp(now.Add(-1 * time.Hour))},
+			},
+		}},
+		timelineEventsErr: errors.New("graphql unavailable"),
+		reviews:           []*gh.PullRequestReview{},
+		comments:          []*gh.IssueComment{},
+	}
+
+	syncer := NewSyncer(map[string]Client{"github.com": mc}, d, nil, []RepoRef{repo}, time.Minute, nil, testBudget(500))
+	require.NoError(syncer.refreshTimeline(ctx, repo, repoID, mrID, buildOpenPR(1, now.Add(-2*time.Hour))))
+
+	pr, err := d.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 1)
+	require.NoError(err)
+	require.NotNil(pr)
+	assert.Equal(forcePushAt, pr.LastActivityAt)
+}
+
 func TestSyncAssignsStableCommitOrderKeysAcrossForcePushReplacement(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -3557,6 +3557,64 @@ func TestSyncStoresForcePushEvent(t *testing.T) {
 	assert.Contains(commit.MetadataJSON, `"commit_order":1`)
 }
 
+func TestRefreshTimelineUsesForcePushForLastActivity(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	forcePushAt := now.Add(30 * time.Minute)
+	commitSHA := "abc123def456"
+	commitMsg := "fix: tighten validation"
+
+	repo := RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}
+	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", repo.Owner, repo.Name))
+	require.NoError(err)
+	mrID, err := d.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:         repoID,
+		PlatformID:     1,
+		Number:         1,
+		URL:            "https://github.com/owner/repo/pull/1",
+		Title:          "force push activity",
+		Author:         "dev",
+		State:          "open",
+		HeadBranch:     "feature",
+		BaseBranch:     "main",
+		CreatedAt:      now.Add(-3 * time.Hour),
+		UpdatedAt:      now.Add(-2 * time.Hour),
+		LastActivityAt: now.Add(-2 * time.Hour),
+	})
+	require.NoError(err)
+
+	mc := &mockClient{
+		commits: []*gh.RepositoryCommit{{
+			SHA: &commitSHA,
+			Commit: &gh.Commit{
+				Message: &commitMsg,
+				Author:  &gh.CommitAuthor{Name: new("dev"), Date: makeTimestamp(now.Add(-1 * time.Hour))},
+			},
+		}},
+		timelineEvents: []PullRequestTimelineEvent{{
+			EventType: "force_push",
+			Actor:     "alice",
+			BeforeSHA: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			AfterSHA:  "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+			Ref:       "feature",
+			CreatedAt: forcePushAt,
+		}},
+		reviews:  []*gh.PullRequestReview{},
+		comments: []*gh.IssueComment{},
+	}
+
+	syncer := NewSyncer(map[string]Client{"github.com": mc}, d, nil, []RepoRef{repo}, time.Minute, nil, testBudget(500))
+	require.NoError(syncer.refreshTimeline(ctx, repo, repoID, mrID, buildOpenPR(1, now.Add(-2*time.Hour))))
+
+	pr, err := d.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 1)
+	require.NoError(err)
+	require.NotNil(pr)
+	assert.Equal(forcePushAt, pr.LastActivityAt)
+}
+
 func TestSyncAssignsStableCommitOrderKeysAcrossForcePushReplacement(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -11375,7 +11433,7 @@ func TestSyncOpenMRFromBulkStoresTimelineEvents(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(mr)
 	require.NotNil(mr.DetailFetchedAt)
-	assert.Equal(now.UTC(), mr.LastActivityAt.UTC())
+	assert.Equal(timelineAt.Add(time.Minute).UTC(), mr.LastActivityAt.UTC())
 
 	events, err := d.ListMREvents(ctx, mr.ID)
 	require.NoError(err)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -1833,6 +1833,79 @@ func TestAPIListPullsPreservesNewerActivityAfterIndexSync(t *testing.T) {
 	assert.Equal(int64(2), (*resp.JSON200)[1].Number)
 }
 
+func TestAPISyncPRUsesForcePushTimelineForPullListActivity(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	base := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	forcePushAt := base.Add(3 * time.Hour)
+	otherActivity := base.Add(2 * time.Hour)
+	headSHA := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+	str := func(v string) *string { return &v }
+	mock := &mockGH{
+		getPullRequestFn: func(_ context.Context, _, _ string, number int) (*gh.PullRequest, error) {
+			id := int64(1001)
+			return &gh.PullRequest{
+				ID:        &id,
+				Number:    &number,
+				Title:     str("Force push activity"),
+				State:     str("open"),
+				HTMLURL:   str("https://github.com/acme/widget/pull/1"),
+				User:      &gh.User{Login: str("octocat")},
+				CreatedAt: &gh.Timestamp{Time: base.Add(-time.Hour)},
+				UpdatedAt: &gh.Timestamp{Time: base},
+				Head:      &gh.PullRequestBranch{Ref: str("feature"), SHA: &headSHA},
+				Base:      &gh.PullRequestBranch{Ref: str("main")},
+			}, nil
+		},
+		listIssueCommentsFn: func(context.Context, string, string, int) ([]*gh.IssueComment, error) {
+			return nil, nil
+		},
+		listPRTimelineEventsFn: func(context.Context, string, string, int) ([]ghclient.PullRequestTimelineEvent, error) {
+			return []ghclient.PullRequestTimelineEvent{{
+				EventType: "force_push",
+				Actor:     "octocat",
+				BeforeSHA: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				AfterSHA:  headSHA,
+				Ref:       "feature",
+				CreatedAt: forcePushAt,
+			}}, nil
+		},
+	}
+	srv, database := setupTestServerWithMock(t, mock)
+	seedPR(t, database, "acme", "widget", 1,
+		withSeedPRTitle("Force push activity"),
+		withSeedPRTimes(base.Add(-time.Hour), base, base),
+	)
+	seedPR(t, database, "acme", "widget", 2,
+		withSeedPRTitle("Other activity"),
+		withSeedPRTimes(base.Add(-time.Hour), otherActivity, otherActivity),
+	)
+	client := setupTestClient(t, srv)
+
+	syncResp, err := client.HTTP.SyncPullWithResponse(ctx, "gh", "acme", "widget", 1)
+	require.NoError(err)
+	require.Equal(http.StatusOK, syncResp.StatusCode(), string(syncResp.Body))
+	require.NotNil(syncResp.JSON200)
+	assert.Equal(forcePushAt, syncResp.JSON200.MergeRequest.LastActivityAt.UTC())
+
+	detailResp, err := client.HTTP.GetPullWithResponse(ctx, "gh", "acme", "widget", 1)
+	require.NoError(err)
+	require.Equal(http.StatusOK, detailResp.StatusCode(), string(detailResp.Body))
+	require.NotNil(detailResp.JSON200)
+	assert.Equal(forcePushAt, detailResp.JSON200.MergeRequest.LastActivityAt.UTC())
+
+	listResp, err := client.HTTP.ListPullsWithResponse(ctx, nil)
+	require.NoError(err)
+	require.Equal(http.StatusOK, listResp.StatusCode(), string(listResp.Body))
+	require.NotNil(listResp.JSON200)
+	require.Len(*listResp.JSON200, 2)
+	assert.Equal(int64(1), (*listResp.JSON200)[0].Number)
+	assert.Equal(forcePushAt, (*listResp.JSON200)[0].LastActivityAt.UTC())
+	assert.Equal(int64(2), (*listResp.JSON200)[1].Number)
+}
+
 func TestAPIListPullsKeepsCachedCIDecorationsAfterIndexSync(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)


### PR DESCRIPTION
GitHub force-push timeline events were already stored, but latest-activity ordering could still be anchored to older commit metadata. That made a PR look fresh without reliably showing that the newest activity was a force push.\n\nThis updates GitHub sync so complete timeline event data participates in PR latest-activity calculations, while truncated bulk timeline pages keep the existing conservative fallback.