### PR TITLE
fix: drain duplicate workspace create setup in tests

### DIFF
--- a/context/workspace-runtime-lifecycle.md
+++ b/context/workspace-runtime-lifecycle.md
@@ -141,6 +141,11 @@ behavior.
 
 - Use real SQLite-backed server tests for delete ordering, tmux cleanup, and
   runtime-session API behavior.
+- A server test that creates a workspace must wait for setup to reach a terminal
+  state (`waitForWorkspaceReady`) before it returns. The `202 Accepted` create
+  runs clone/setup in a background goroutine; if the test returns first, that
+  goroutine can keep writing into the test's `t.TempDir` clone path and race
+  `RemoveAll` teardown, failing intermittently with "directory not empty".
 - Use tmux wrappers/fakes for missing-session and dead-server cases.
 - Add frontend or Playwright coverage when the regression is visible in tab
   selection, shell drawer state, or workspace navigation.

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -26131,11 +26131,17 @@ func TestWorkspaceCreateDuplicate(t *testing.T) {
 	resp1, err := client.HTTP.CreateWorkspaceWithResponse(ctx, body)
 	require.NoError(err)
 	require.Equal(http.StatusAccepted, resp1.StatusCode())
+	require.NotNil(resp1.JSON202)
 
 	// Duplicate create returns 409.
 	resp2, err := client.HTTP.CreateWorkspaceWithResponse(ctx, body)
 	require.NoError(err)
 	require.Equal(http.StatusConflict, resp2.StatusCode())
+
+	// Drain the first create's async setup before the test returns. Otherwise
+	// the background clone can keep writing into the bare-clone temp dir and
+	// race t.TempDir cleanup, which fails RemoveAll with "directory not empty".
+	waitForWorkspaceReady(t, ctx, client, resp1.JSON202.Id)
 }
 
 func TestWorkspaceCreateFetchesCloneThroughAPI(t *testing.T) {


### PR DESCRIPTION
The duplicate-create server test accepts one workspace create, verifies the next call conflicts, and then returned while the first setup could still be cloning. That left cleanup racing a background writer in its temp directory and could surface as intermittent `directory not empty` failures. This PR waits for the accepted setup to finish and records the expectation in the workspace lifecycle test guidance.

Validation: `go test ./internal/server -run TestWorkspaceCreateDuplicate -shuffle=on`