### PR TITLE
docs: make context-sync produce terse additions, not walkthroughs

### DIFF
--- a/skills/context-sync/SKILL.md
+++ b/skills/context-sync/SKILL.md
@@ -52,7 +52,9 @@ When the Stop hook asks for context sync:
    workflow changed, open the matching context doc and decide whether the grep test says
    to update it.
 3. Apply the context update when the right doc edit is clear, additive, and supported by
-   the diff/conversation. If the update would delete context, reinterpret a design
+   the diff/conversation. Compress it to the per-addition budget in
+   `context-guide.md` first — terse invariants, never implementation
+   walkthroughs. If the update would delete context, reinterpret a design
    decision, or make a claim the code cannot verify, propose a concrete diff or
    confidence-tagged suggestion in the final response instead.
 4. Only then mark the current worktree state with the decision:
@@ -162,6 +164,11 @@ invariant is documented but unguarded, flag it as a gap and propose the smallest
 When a guard and a doc disagree, that is a high-priority finding for Step 7.
 
 ## Step 7: Present Or Apply Diffs
+
+Before presenting or applying any diff, compress each addition to the
+per-addition budget in `context-guide.md` — additions are terse invariants
+(a few lines), never implementation walkthroughs. If a draft needs a
+paragraph, it is either an ADR or it contains greppable material to cut.
 
 For explicit full-sync/audit requests, show all proposed changes. Flag DELETIONS and
 MODIFICATIONS separately from additions — deletions are higher risk (removing context

--- a/skills/context-sync/context-guide.md
+++ b/skills/context-sync/context-guide.md
@@ -18,14 +18,33 @@ style that `golangci-lint` / `gofmt` / `oxfmt` already enforce.
 ### Good vs Bad Context
 
 BAD (greppable): "`Registry` is defined in `internal/platform/registry.go`."
-GOOD (not greppable): "Provider identity is always the tuple `(platform, platform_host,
+WORDY: "Provider identity is always the tuple `(platform, platform_host,
 owner, name)`; code that keys repos by `owner/name/number` alone will silently collide
 across hosts once a self-hosted Forgejo and github.com share an owner."
+GOOD: "Provider identity is always `(platform, platform_host, owner, name)`;
+keying by owner/name alone collides across hosts."
 
 BAD (greppable): "`internal/github/graphql.go` has a `BulkFetch` function."
 GOOD (not greppable): "GitHub GraphQL bulk fetch is an optimization layered *around* the
 neutral persistence path, not through it — keep it optional so other providers keep
 working when the GraphQL path is skipped."
+
+## Write Terse: Per-Addition Budget
+
+The size ceilings below are per-doc; these are per-change:
+
+- One new fact = one bullet, ≤ 3 lines. A new `##` section only when a doc
+  gains a genuinely new concern, and even then ≤ 10 lines total.
+- Invariant first; rationale as one trailing clause, only when the invariant
+  is surprising without it. Rationale that needs more than a clause is an
+  ADR, not a context bullet.
+- No implementation walkthroughs. State the constraint the next agent must
+  respect, not how the current change satisfied it — the diff and git
+  history own the "how."
+- Do not list the tests/files that cover a claim (greppable). One anchor per
+  claim, in a trailing parenthetical.
+- Before applying, reread each addition and delete every clause whose removal
+  doesn't change what the next agent would do.
 
 ## Single-Surface Layout
 
@@ -176,3 +195,7 @@ reference it.
 When proposing updates, present DELETIONS and MODIFICATIONS separately from additions and
 justify each removal. Removing context that turns out to be load-bearing is more costly
 than leaving a redundant line.
+
+This asymmetry applies to deletions of existing context only. Padding new
+additions is its own poisoning: every redundant line dilutes the
+load-bearing ones a future agent must find.


### PR DESCRIPTION
Context-sync runs and the Stop hook have been landing 20-75 line narrative sections in `context/` docs (e.g. the kit-ui contract block) when the target is 3-5 line invariants. The verbosity was taught by the skill itself: its size ceilings were per-doc only so no single addition ever hit one, its GOOD examples modeled multi-clause failure narratives that drafting subagents imitate, the context-poisoning safeguard implied more words are the safe direction, and nothing between drafting and applying asked whether an addition could be shorter.

- `context-guide.md` gains a per-addition budget: one fact = one bullet of at most 3 lines, new sections at most 10 lines, rationale as a single trailing clause (anything longer is an ADR), no test/file coverage lists, and a final delete-every-inert-clause pass
- The good/bad examples now include a WORDY tier so the expected compression is demonstrated, not just stated
- The poisoning safeguard is scoped to deletions of existing context; padding new additions is called out as its own form of poisoning
- SKILL.md Step 7 and the Stop-hook apply path now require compressing drafts to the budget before presenting or applying

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sup>generated by a clanker</sup>