### PR TITLE
Fix stable header tabs across modes

### DIFF
--- a/context/ui-design-system.md
+++ b/context/ui-design-system.md
@@ -98,6 +98,9 @@ prebundled: keep it in vite `optimizeDeps.exclude` with transitive deps as
   stay content-sized (a flex-stretched region poisons the frozen
   `expandUsed` footprint and blocks re-expansion). Select tabs via
   `.kit-top-bar__tabs .kit-top-bar__tab`, never the bare class.
+  Provider-mode repo selector visibility must not move the tab row; non-provider
+  modes reserve its footprint unless embed config hides it
+  (`frontend/src/lib/components/layout/AppHeader.svelte::reserveProviderRepoSelectorSlot`).
 - Flash: one shared store (`@middleman/ui/stores/flash`); kit
   `FlashBanner` mounts once per shell; stacking (not latest-wins) is
   intended. Tests assert `.kit-flash-stack`.

--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -79,13 +79,15 @@
   }
 
   const syncing = $derived(sync.getSyncState()?.running ?? false);
-  const showProviderRepoSelector = $derived(
-    !getUIConfig().hideRepoSelector &&
-      (getPage() === "activity" ||
-        getPage() === "repos" ||
-        getPage() === "pulls" ||
-        getPage() === "issues"),
+  const hideProviderRepoSelector = $derived(getUIConfig().hideRepoSelector);
+  const isProviderRepoSelectorPage = $derived(
+    getPage() === "activity" ||
+      getPage() === "repos" ||
+      getPage() === "pulls" ||
+      getPage() === "issues",
   );
+  const showProviderRepoSelector = $derived(!hideProviderRepoSelector && isProviderRepoSelectorPage);
+  const reserveProviderRepoSelectorSlot = $derived(!hideProviderRepoSelector && !isProviderRepoSelectorPage);
   let settingsReturnPath = "/";
 
   function currentAppPath(): string {
@@ -251,6 +253,11 @@
         selected={getGlobalRepo()}
         onchange={setGlobalRepo}
       />
+    {:else if reserveProviderRepoSelectorSlot}
+      <div
+        class="typeahead repo-selector-placeholder"
+        aria-hidden="true"
+      ></div>
     {/if}
   {/snippet}
 
@@ -370,6 +377,13 @@
 
   .sync-label {
     line-height: 1;
+  }
+
+  .repo-selector-placeholder {
+    display: block;
+    height: 26px;
+    pointer-events: none;
+    visibility: hidden;
   }
 
   /* Busy state spins the sync affordance icon itself, matching kit-ui

--- a/frontend/src/lib/components/layout/AppHeader.test.ts
+++ b/frontend/src/lib/components/layout/AppHeader.test.ts
@@ -115,6 +115,13 @@ function showImportedModes(): void {
   };
 }
 
+function expectReservedRepoSelectorSlot(container: HTMLElement): void {
+  const slot = container.querySelector(".repo-selector-placeholder");
+
+  expect(screen.queryByTitle("Select repository")).toBeNull();
+  expect(slot?.getAttribute("aria-hidden")).toBe("true");
+}
+
 describe("AppHeader", () => {
   beforeEach(() => {
     document.documentElement.classList.remove("dark");
@@ -122,6 +129,8 @@ describe("AppHeader", () => {
     mockMatchMedia(false);
     setSidebarCollapsed(false);
     mockedContainerSize.value = "wide";
+    delete window.__middleman_config;
+    window.__middleman_notify_config_changed?.();
     mockedModeVisibility.value = {
       activity: true,
       repos: true,
@@ -145,6 +154,8 @@ describe("AppHeader", () => {
     localStorage.clear();
     setSidebarCollapsed(false);
     mockedContainerSize.value = "wide";
+    delete window.__middleman_config;
+    window.__middleman_notify_config_changed?.();
     mockedModeVisibility.value = {
       activity: true,
       repos: true,
@@ -419,28 +430,39 @@ describe("AppHeader", () => {
     expect(window.location.pathname + window.location.search).toBe("/messages");
   });
 
-  it("does not render the provider repo selector on Kata", () => {
+  it("reserves the provider repo selector slot on Kata without exposing the selector", () => {
     initTheme();
     navigate("/kata");
-    render(AppHeader);
+    const { container } = render(AppHeader);
 
-    expect(screen.queryByTitle("Select repository")).toBeNull();
+    expectReservedRepoSelectorSlot(container);
   });
 
-  it("does not render the provider repo selector on Docs", () => {
+  it("reserves the provider repo selector slot on Docs without exposing the selector", () => {
     initTheme();
     navigate("/docs");
-    render(AppHeader);
+    const { container } = render(AppHeader);
 
-    expect(screen.queryByTitle("Select repository")).toBeNull();
+    expectReservedRepoSelectorSlot(container);
   });
 
-  it("does not render the provider repo selector on Messages", () => {
+  it("reserves the provider repo selector slot on Messages without exposing the selector", () => {
     initTheme();
     navigate("/messages");
-    render(AppHeader);
+    const { container } = render(AppHeader);
+
+    expectReservedRepoSelectorSlot(container);
+  });
+
+  it("does not reserve the repo selector slot when embed config hides it", () => {
+    initTheme();
+    window.__middleman_config = { ui: { hideRepoSelector: true } };
+    window.__middleman_notify_config_changed?.();
+    navigate("/kata");
+    const { container } = render(AppHeader);
 
     expect(screen.queryByTitle("Select repository")).toBeNull();
+    expect(container.querySelector(".repo-selector-placeholder")).toBeNull();
   });
 
   it("remembers sticky mode routes when the nav switches to Activity", async () => {


### PR DESCRIPTION
- Keep the app header tab row stable when switching between provider-backed tabs and Kata, Docs, or Messages.
- Leave the repo selector non-interactive on non-provider modes and still honor embedded `hideRepoSelector`.
- Record the TopBar spacing invariant in UI context so future header changes preserve it.

<sup>generated by a clanker</sup>