### PR TITLE
Fix Kata workspace mapping for glob-tracked repos

### DIFF
--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -77,10 +77,11 @@ only allowed when the watched clone metadata set has no usable `project.uid` or
 `project.identity` values at all, and then exactly one case-insensitive
 `project.name` match is required. If no `.kata.toml` mapping matches, the
 resolver may fall back to a case-insensitive exact match between the Kata
-project name and one configured exact repo name or repo path, but only for repos
-without readable `.kata.toml` project metadata. Ambiguous, mismatched, or
-missing matches mean the Create/Open workspace button must not render
-(`internal/server/kata_workspace.go::kataAutomaticWorkspaceRepo`).
+project name and one configured exact repo, or one synced repo matched by a
+configured glob, but only for repos without readable `.kata.toml` project
+metadata. Ambiguous, mismatched, or missing matches mean the Create/Open
+workspace button must not render
+(`internal/server/kata_workspace.go::resolveKataWorkspaceRepo`).
 
 Persisted workspace `worktree_path` values should be absolute. Workspace setup
 runs `git worktree add` from the managed clone or configured base checkout, so

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -68,15 +68,18 @@ longer configured, so settings repo deletion must remove mappings for the
 deleted repo in the same save/rollback path
 (`internal/config/config.go::validateKataProjectRepoMappings`,
 `internal/server/settings_handlers.go::deleteConfiguredRepo`). Automatic
-resolution only uses watched exact repos with `worktree_base_path` whose clone
+resolution first uses watched exact repos with `worktree_base_path` whose clone
 contains a matching `.kata.toml`. Matching first compares both explicit
 identifiers, `project.uid` and `project.identity`, to the Kata project UID. If
 either identifier matches exactly, that clone is a candidate; if more than one
-clone matches, the result is ambiguous. Name fallback is only allowed when the
-watched clone metadata set has no usable `project.uid` or `project.identity`
-values at all, and then exactly one case-insensitive `project.name` match is
-required. Ambiguous, mismatched, or missing matches mean the Create/Open
-workspace button must not render.
+clone matches, the result is ambiguous. Name fallback through `.kata.toml` is
+only allowed when the watched clone metadata set has no usable `project.uid` or
+`project.identity` values at all, and then exactly one case-insensitive
+`project.name` match is required. If no `.kata.toml` mapping matches, the
+resolver may fall back to a case-insensitive exact match between the Kata
+project name and one configured exact repo name or repo path, but only for repos
+without readable `.kata.toml` project metadata. Ambiguous, mismatched, or
+missing matches mean the Create/Open workspace button must not render.
 
 Persisted workspace `worktree_path` values should be absolute. Workspace setup
 runs `git worktree add` from the managed clone or configured base checkout, so

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -73,9 +73,9 @@ contains a matching `.kata.toml`. Matching first compares both explicit
 identifiers, `project.uid` and `project.identity`, to the Kata project UID. If
 either identifier matches exactly, that clone is a candidate; if more than one
 clone matches, the result is ambiguous. Name fallback through `.kata.toml` is
-only allowed when the watched clone metadata set has no usable `project.uid` or
-`project.identity` values at all, and then exactly one case-insensitive
-`project.name` match is required. If no `.kata.toml` mapping matches, the
+only allowed per clone when that clone has no usable `project.uid` or
+`project.identity`, and then exactly one case-insensitive `project.name` match
+is required. If no `.kata.toml` mapping matches, the
 resolver may fall back to a case-insensitive exact match between the Kata
 project name and exactly one synced tracked repo matched by current repo
 configuration, whether that configuration entry is exact or globbed, but only

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -79,7 +79,8 @@ only allowed when the watched clone metadata set has no usable `project.uid` or
 resolver may fall back to a case-insensitive exact match between the Kata
 project name and one configured exact repo name or repo path, but only for repos
 without readable `.kata.toml` project metadata. Ambiguous, mismatched, or
-missing matches mean the Create/Open workspace button must not render.
+missing matches mean the Create/Open workspace button must not render
+(`internal/server/kata_workspace.go::kataAutomaticWorkspaceRepo`).
 
 Persisted workspace `worktree_path` values should be absolute. Workspace setup
 runs `git worktree add` from the managed clone or configured base checkout, so

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -77,9 +77,10 @@ only allowed when the watched clone metadata set has no usable `project.uid` or
 `project.identity` values at all, and then exactly one case-insensitive
 `project.name` match is required. If no `.kata.toml` mapping matches, the
 resolver may fall back to a case-insensitive exact match between the Kata
-project name and one configured exact repo, or one synced repo matched by a
-configured glob, but only for repos without readable `.kata.toml` project
-metadata. Ambiguous, mismatched, or missing matches mean the Create/Open
+project name and exactly one synced tracked repo matched by current repo
+configuration, whether that configuration entry is exact or globbed, but only
+for repos without readable `.kata.toml` project metadata. Ambiguous, mismatched,
+or missing matches mean the Create/Open
 workspace button must not render
 (`internal/server/kata_workspace.go::resolveKataWorkspaceRepo`).
 

--- a/docs/superpowers/specs/2026-06-25-kata-task-workspace-launch-design.md
+++ b/docs/superpowers/specs/2026-06-25-kata-task-workspace-launch-design.md
@@ -56,8 +56,9 @@ The resolver uses this precedence:
    repositories with a non-empty `worktree_base_path`.
 4. Automatic mapping by unambiguous `.kata.toml` project name, considering only
    clones whose `.kata.toml` declares no `uid`/`identity`.
-5. Automatic mapping by unambiguous tracked exact repository name when the
-   matching repo has no readable `.kata.toml` project metadata.
+5. Automatic mapping by unambiguous tracked repository name, including synced
+   repos matched by a configured glob, when the matching repo has no readable
+   `.kata.toml` project metadata.
 6. No target when neither source yields exactly one repository.
 
 Manual mappings are a fallback and override only the project they name. Automatic
@@ -361,8 +362,9 @@ Backend coverage:
   return `available: false`.
 - A project name matching exactly one tracked exact repository name resolves
   when that repository has no readable `.kata.toml` project metadata.
-- A project name matching multiple tracked exact repositories is ambiguous and
-  returns `available: false`.
+- A project name matching exactly one synced glob-matched repository name also
+  resolves; multiple tracked repository matches are ambiguous and return
+  `available: false`.
 - Manual mapping resolves to a watched repository and overrides an automatic
   mapping for the same daemon/project.
 - Missing Kata issue UID and removed watched repo mappings return

--- a/docs/superpowers/specs/2026-06-25-kata-task-workspace-launch-design.md
+++ b/docs/superpowers/specs/2026-06-25-kata-task-workspace-launch-design.md
@@ -56,7 +56,9 @@ The resolver uses this precedence:
    repositories with a non-empty `worktree_base_path`.
 4. Automatic mapping by unambiguous `.kata.toml` project name, considering only
    clones whose `.kata.toml` declares no `uid`/`identity`.
-5. No target when neither source yields exactly one repository.
+5. Automatic mapping by unambiguous tracked exact repository name when the
+   matching repo has no readable `.kata.toml` project metadata.
+6. No target when neither source yields exactly one repository.
 
 Manual mappings are a fallback and override only the project they name. Automatic
 discovery remains the default path because it follows the user's existing watched
@@ -357,6 +359,10 @@ Backend coverage:
   mapping.
 - Duplicate `.kata.toml` project UID, identity, or name claims are ambiguous and
   return `available: false`.
+- A project name matching exactly one tracked exact repository name resolves
+  when that repository has no readable `.kata.toml` project metadata.
+- A project name matching multiple tracked exact repositories is ambiguous and
+  returns `available: false`.
 - Manual mapping resolves to a watched repository and overrides an automatic
   mapping for the same daemon/project.
 - Missing Kata issue UID and removed watched repo mappings return

--- a/docs/superpowers/specs/2026-06-25-kata-task-workspace-launch-design.md
+++ b/docs/superpowers/specs/2026-06-25-kata-task-workspace-launch-design.md
@@ -56,9 +56,9 @@ The resolver uses this precedence:
    repositories with a non-empty `worktree_base_path`.
 4. Automatic mapping by unambiguous `.kata.toml` project name, considering only
    clones whose `.kata.toml` declares no `uid`/`identity`.
-5. Automatic mapping by unambiguous tracked repository name, including synced
-   repos matched by a configured glob, when the matching repo has no readable
-   `.kata.toml` project metadata.
+5. Automatic mapping by unambiguous synced tracked repository name, whether the
+   tracked repo was configured exactly or discovered through a configured glob,
+   when the matching repo has no readable `.kata.toml` project metadata.
 6. No target when neither source yields exactly one repository.
 
 Manual mappings are a fallback and override only the project they name. Automatic
@@ -356,15 +356,15 @@ Backend coverage:
 - Automatic mapping succeeds from a configured exact repo with
   `worktree_base_path` and `.kata.toml` project UID, identity, or unambiguous
   project name.
-- Glob repos and repos without local clone paths do not participate in automatic
-  mapping.
+- Glob repos and repos without local clone paths do not participate in
+  `.kata.toml` scanning.
 - Duplicate `.kata.toml` project UID, identity, or name claims are ambiguous and
   return `available: false`.
-- A project name matching exactly one tracked exact repository name resolves
+- A project name matching exactly one synced tracked repository name resolves
   when that repository has no readable `.kata.toml` project metadata.
 - A project name matching exactly one synced glob-matched repository name also
-  resolves; multiple tracked repository matches are ambiguous and return
-  `available: false`.
+  resolves through the same tracked-repo rule; multiple tracked repository
+  matches are ambiguous and return `available: false`.
 - Manual mapping resolves to a watched repository and overrides an automatic
   mapping for the same daemon/project.
 - Missing Kata issue UID and removed watched repo mappings return

--- a/docs/superpowers/specs/2026-06-25-kata-task-workspace-launch-design.md
+++ b/docs/superpowers/specs/2026-06-25-kata-task-workspace-launch-design.md
@@ -61,9 +61,9 @@ The resolver uses this precedence:
    when the matching repo has no readable `.kata.toml` project metadata.
 6. No target when neither source yields exactly one repository.
 
-Manual mappings are a fallback and override only the project they name. Automatic
-discovery remains the default path because it follows the user's existing watched
-repo clone setup.
+Manual mappings are explicit overrides for the project they name. Automatic
+discovery runs only when no matching manual mapping exists and remains the
+default path because it follows the user's existing watched repo clone setup.
 
 ## Alternatives Considered
 
@@ -105,8 +105,9 @@ it accepts only a regular file (rejecting symlinks, devices, and other
 non-regular entries) and reads through a small explicit size cap before
 decoding. This stops a malicious clone from pointing the file at an endless or
 oversized target (for example a symlink to `/dev/zero`) and stalling or
-exhausting the process during a worktree scan. A symlinked, oversized, or
-otherwise non-regular `.kata.toml` contributes no mapping.
+exhausting the process during a worktree scan. A symlinked, oversized,
+malformed, or otherwise non-regular `.kata.toml` contributes no mapping and is
+treated as absent for tracked-name fallback.
 
 The `.kata.toml` parser accepts a small, explicit shape:
 
@@ -134,6 +135,11 @@ cover. Restricting name matching to identifier-less clones is the guardrail: a
 valid name-only project still resolves even when an unrelated watched clone
 carries identity metadata, and a clone with stable identity is never silently
 matched by a colliding name.
+
+Tracked-name fallback uses the synced repository catalog filtered through
+current repo configuration. Readable `.kata.toml` project metadata suppresses
+that fallback for the same repo; stale synced rows remain candidates until sync
+or config removes them, and workspace creation still owns clone/fetch failure.
 
 Automatic `.kata.toml` mappings are global by project UID, identity, or name
 because the file does not carry daemon identity. If two repositories claim the

--- a/docs/superpowers/specs/2026-06-25-kata-task-workspace-launch-design.md
+++ b/docs/superpowers/specs/2026-06-25-kata-task-workspace-launch-design.md
@@ -145,9 +145,11 @@ Automatic `.kata.toml` mappings are global by project UID, identity, or name
 because the file does not carry daemon identity. If two repositories claim the
 same Kata project identity, or two identifier-less repositories claim the same
 project name, the resolver treats the mapping as ambiguous and returns no
-workspace target. The UI should not show a disabled button for this state
-because the user asked for the button to be absent when there is no clear
-mapping.
+workspace target. `.kata.toml` ambiguity is terminal: tracked-name fallback runs
+only when `.kata.toml` produces zero candidates. The UI should not show a
+disabled button or reason text for this state because the user asked for the
+button to be absent when there is no clear mapping; diagnostics need a new API
+field.
 
 ## Manual Settings
 

--- a/internal/server/kata_workspace.go
+++ b/internal/server/kata_workspace.go
@@ -233,9 +233,12 @@ func (s *Server) resolveKataWorkspaceRepo(
 	if repo, ok := kataManualWorkspaceRepo(repos, mappings, metadata, false); ok {
 		return kataResolvedRepoFromConfig(repo), true, nil
 	}
-	repo, ok := kataAutomaticWorkspaceRepo(repos, metadata.ProjectUID, metadata.ProjectName)
-	if ok {
+	repo, matches := kataAutomaticWorkspaceRepo(repos, metadata.ProjectUID, metadata.ProjectName)
+	if matches == 1 {
 		return kataResolvedRepoFromConfig(repo), true, nil
+	}
+	if matches > 1 {
+		return kataResolvedWorkspaceRepo{}, false, nil
 	}
 	tracked, err := s.db.ListRepos(ctx)
 	if err != nil {
@@ -282,17 +285,17 @@ func kataMappingMatchesRepo(mapping config.KataProjectRepoMapping, repo config.R
 		strings.EqualFold(mapping.RepoPath, configRepoPath(repo))
 }
 
-func kataAutomaticWorkspaceRepo(repos []config.Repo, projectUID string, projectName string) (config.Repo, bool) {
+func kataAutomaticWorkspaceRepo(repos []config.Repo, projectUID string, projectName string) (config.Repo, int) {
 	if repo, matches := kataAutomaticWorkspaceRepoByTOML(repos, func(project kataProjectTOML) bool {
 		return project.matchesProjectUID(projectUID)
 	}); matches == 1 {
-		return repo, true
+		return repo, 1
 	} else if matches > 1 {
-		return config.Repo{}, false
+		return config.Repo{}, matches
 	}
 	name := strings.TrimSpace(projectName)
 	if name == "" {
-		return config.Repo{}, false
+		return config.Repo{}, 0
 	}
 	// Name fallback is only for clones whose .kata.toml carries no stable
 	// UID/identity. Restricting the match to identifier-less entries is the
@@ -303,12 +306,12 @@ func kataAutomaticWorkspaceRepo(repos []config.Repo, projectUID string, projectN
 		return !project.hasIdentifier() && strings.EqualFold(project.Name, name)
 	})
 	if matches == 1 {
-		return repo, true
+		return repo, 1
 	}
 	if matches > 1 {
-		return config.Repo{}, false
+		return config.Repo{}, matches
 	}
-	return config.Repo{}, false
+	return config.Repo{}, 0
 }
 
 func kataAutomaticWorkspaceRepoByTOML(repos []config.Repo, matches func(kataProjectTOML) bool) (config.Repo, int) {

--- a/internal/server/kata_workspace.go
+++ b/internal/server/kata_workspace.go
@@ -3,8 +3,10 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -82,7 +84,7 @@ func (s *Server) kataWorkspaceTarget(
 	if err != nil {
 		return nil, err
 	}
-	target, ok, err := s.resolveKataWorkspaceRepo(metadata)
+	target, ok, err := s.resolveKataWorkspaceRepo(ctx, metadata)
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +134,7 @@ func (s *Server) createKataWorkspace(
 	if err != nil {
 		return nil, err
 	}
-	target, ok, err := s.resolveKataWorkspaceRepo(metadata)
+	target, ok, err := s.resolveKataWorkspaceRepo(ctx, metadata)
 	if err != nil {
 		return nil, err
 	}
@@ -214,6 +216,7 @@ func (s *Server) kataWorkspaceCreateOutput(
 }
 
 func (s *Server) resolveKataWorkspaceRepo(
+	ctx context.Context,
 	metadata db.WorkspaceKataMetadata,
 ) (kataResolvedWorkspaceRepo, bool, error) {
 	if s.cfg == nil {
@@ -231,10 +234,17 @@ func (s *Server) resolveKataWorkspaceRepo(
 		return kataResolvedRepoFromConfig(repo), true, nil
 	}
 	repo, ok := kataAutomaticWorkspaceRepo(repos, metadata.ProjectUID, metadata.ProjectName)
-	if !ok {
-		return kataResolvedWorkspaceRepo{}, false, nil
+	if ok {
+		return kataResolvedRepoFromConfig(repo), true, nil
 	}
-	return kataResolvedRepoFromConfig(repo), true, nil
+	tracked, err := s.db.ListRepos(ctx)
+	if err != nil {
+		return kataResolvedWorkspaceRepo{}, false, fmt.Errorf("list tracked repos for Kata workspace: %w", err)
+	}
+	if target, matches := kataAutomaticWorkspaceRepoByTrackedRepos(repos, tracked, metadata.ProjectName); matches == 1 {
+		return target, true, nil
+	}
+	return kataResolvedWorkspaceRepo{}, false, nil
 }
 
 func kataManualWorkspaceRepo(
@@ -347,6 +357,93 @@ func kataAutomaticWorkspaceRepoByTrackedName(repos []config.Repo, projectName st
 	return matched[0], 1
 }
 
+func kataAutomaticWorkspaceRepoByTrackedRepos(
+	configured []config.Repo,
+	tracked []db.Repo,
+	projectName string,
+) (kataResolvedWorkspaceRepo, int) {
+	projectName = strings.TrimSpace(projectName)
+	if projectName == "" {
+		return kataResolvedWorkspaceRepo{}, 0
+	}
+	var matched []kataResolvedWorkspaceRepo
+	seen := make(map[string]struct{})
+	for _, repo := range tracked {
+		if !kataTrackedRepoMatchesAnyConfig(repo, configured) {
+			continue
+		}
+		if kataTrackedRepoHasConfiguredProjectMetadata(repo, configured) {
+			continue
+		}
+		if !strings.EqualFold(repo.Name, projectName) && !strings.EqualFold(kataTrackedRepoPath(repo), projectName) {
+			continue
+		}
+		target := kataResolvedRepoFromDB(repo)
+		key := strings.ToLower(target.Provider) + "\x00" +
+			strings.ToLower(target.PlatformHost) + "\x00" +
+			strings.ToLower(kataTrackedRepoPath(repo))
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		matched = append(matched, target)
+	}
+	if len(matched) != 1 {
+		return kataResolvedWorkspaceRepo{}, len(matched)
+	}
+	return matched[0], 1
+}
+
+func kataTrackedRepoMatchesAnyConfig(repo db.Repo, configured []config.Repo) bool {
+	for _, raw := range configured {
+		if kataTrackedRepoMatchesConfig(repo, raw) {
+			return true
+		}
+	}
+	return false
+}
+
+func kataTrackedRepoMatchesConfig(repo db.Repo, raw config.Repo) bool {
+	if !strings.EqualFold(repo.Platform, raw.PlatformOrDefault()) ||
+		!samePlatformHost(repo.PlatformHost, raw.PlatformHostOrDefault()) {
+		return false
+	}
+	if raw.HasNameGlob() {
+		if !strings.EqualFold(repo.Owner, raw.Owner) {
+			return false
+		}
+		matched, _ := path.Match(
+			strings.ToLower(raw.Name),
+			strings.ToLower(repo.Name),
+		)
+		return matched
+	}
+	return strings.EqualFold(kataTrackedRepoPath(repo), configRepoPath(raw))
+}
+
+func kataTrackedRepoHasConfiguredProjectMetadata(repo db.Repo, configured []config.Repo) bool {
+	for _, raw := range configured {
+		if raw.HasNameGlob() || strings.TrimSpace(raw.WorktreeBasePath) == "" {
+			continue
+		}
+		if !kataTrackedRepoMatchesConfig(repo, raw) {
+			continue
+		}
+		project, ok := readKataProjectTOML(raw.WorktreeBasePath)
+		if ok && project.hasAnyProjectMetadata() {
+			return true
+		}
+	}
+	return false
+}
+
+func kataTrackedRepoPath(repo db.Repo) string {
+	if strings.TrimSpace(repo.RepoPath) != "" {
+		return strings.TrimSpace(repo.RepoPath)
+	}
+	return repo.Owner + "/" + repo.Name
+}
+
 type kataProjectTOML struct {
 	UID      string
 	Identity string
@@ -418,6 +515,15 @@ func kataResolvedRepoFromConfig(repo config.Repo) kataResolvedWorkspaceRepo {
 	return kataResolvedWorkspaceRepo{
 		Provider:     repo.PlatformOrDefault(),
 		PlatformHost: repo.PlatformHostOrDefault(),
+		Owner:        repo.Owner,
+		Name:         repo.Name,
+	}
+}
+
+func kataResolvedRepoFromDB(repo db.Repo) kataResolvedWorkspaceRepo {
+	return kataResolvedWorkspaceRepo{
+		Provider:     repo.Platform,
+		PlatformHost: repo.PlatformHost,
 		Owner:        repo.Owner,
 		Name:         repo.Name,
 	}

--- a/internal/server/kata_workspace.go
+++ b/internal/server/kata_workspace.go
@@ -308,11 +308,7 @@ func kataAutomaticWorkspaceRepo(repos []config.Repo, projectUID string, projectN
 	if matches > 1 {
 		return config.Repo{}, false
 	}
-	repo, matches = kataAutomaticWorkspaceRepoByTrackedName(repos, name)
-	if matches != 1 {
-		return config.Repo{}, false
-	}
-	return repo, true
+	return config.Repo{}, false
 }
 
 func kataAutomaticWorkspaceRepoByTOML(repos []config.Repo, matches func(kataProjectTOML) bool) (config.Repo, int) {
@@ -323,31 +319,6 @@ func kataAutomaticWorkspaceRepoByTOML(repos []config.Repo, matches func(kataProj
 		}
 		project, ok := readKataProjectTOML(repo.WorktreeBasePath)
 		if ok && matches(project) {
-			matched = append(matched, repo)
-		}
-	}
-	if len(matched) != 1 {
-		return config.Repo{}, len(matched)
-	}
-	return matched[0], 1
-}
-
-func kataAutomaticWorkspaceRepoByTrackedName(repos []config.Repo, projectName string) (config.Repo, int) {
-	projectName = strings.TrimSpace(projectName)
-	if projectName == "" {
-		return config.Repo{}, 0
-	}
-	var matched []config.Repo
-	for _, repo := range repos {
-		if repo.HasNameGlob() {
-			continue
-		}
-		if strings.TrimSpace(repo.WorktreeBasePath) != "" {
-			if project, ok := readKataProjectTOML(repo.WorktreeBasePath); ok && project.hasAnyProjectMetadata() {
-				continue
-			}
-		}
-		if strings.EqualFold(repo.Name, projectName) || strings.EqualFold(configRepoPath(repo), projectName) {
 			matched = append(matched, repo)
 		}
 	}

--- a/internal/server/kata_workspace.go
+++ b/internal/server/kata_workspace.go
@@ -292,6 +292,13 @@ func kataAutomaticWorkspaceRepo(repos []config.Repo, projectUID string, projectN
 	repo, matches := kataAutomaticWorkspaceRepoByTOML(repos, func(project kataProjectTOML) bool {
 		return !project.hasIdentifier() && strings.EqualFold(project.Name, name)
 	})
+	if matches == 1 {
+		return repo, true
+	}
+	if matches > 1 {
+		return config.Repo{}, false
+	}
+	repo, matches = kataAutomaticWorkspaceRepoByTrackedName(repos, name)
 	if matches != 1 {
 		return config.Repo{}, false
 	}
@@ -306,6 +313,31 @@ func kataAutomaticWorkspaceRepoByTOML(repos []config.Repo, matches func(kataProj
 		}
 		project, ok := readKataProjectTOML(repo.WorktreeBasePath)
 		if ok && matches(project) {
+			matched = append(matched, repo)
+		}
+	}
+	if len(matched) != 1 {
+		return config.Repo{}, len(matched)
+	}
+	return matched[0], 1
+}
+
+func kataAutomaticWorkspaceRepoByTrackedName(repos []config.Repo, projectName string) (config.Repo, int) {
+	projectName = strings.TrimSpace(projectName)
+	if projectName == "" {
+		return config.Repo{}, 0
+	}
+	var matched []config.Repo
+	for _, repo := range repos {
+		if repo.HasNameGlob() {
+			continue
+		}
+		if strings.TrimSpace(repo.WorktreeBasePath) != "" {
+			if project, ok := readKataProjectTOML(repo.WorktreeBasePath); ok && project.hasAnyProjectMetadata() {
+				continue
+			}
+		}
+		if strings.EqualFold(repo.Name, projectName) || strings.EqualFold(configRepoPath(repo), projectName) {
 			matched = append(matched, repo)
 		}
 	}
@@ -333,6 +365,10 @@ func (project kataProjectTOML) matchesProjectUID(projectUID string) bool {
 func (project kataProjectTOML) hasIdentifier() bool {
 	return strings.TrimSpace(project.UID) != "" ||
 		strings.TrimSpace(project.Identity) != ""
+}
+
+func (project kataProjectTOML) hasAnyProjectMetadata() bool {
+	return project.hasIdentifier() || strings.TrimSpace(project.Name) != ""
 }
 
 func readKataProjectTOML(root string) (kataProjectTOML, bool) {

--- a/internal/server/kata_workspace_test.go
+++ b/internal/server/kata_workspace_test.go
@@ -291,6 +291,86 @@ worktree_base_path = %q
 	assert.Equal("widget", resp.Repo.Name)
 }
 
+func TestKataWorkspaceTargetAutomaticMappingFromTrackedRepoName(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	srv, database, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "middleman"
+`, &mockGH{})
+	_, err := database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "middleman"))
+	require.NoError(err)
+
+	rr := doJSON(t, srv, http.MethodPost, "/api/v1/kata/workspace-target", map[string]any{
+		"daemon_id":    "desktop",
+		"project_uid":  "project-middleman",
+		"project_name": "middleman",
+		"issue_uid":    "issue-kata-1",
+		"short_id":     "task-123",
+		"title":        "Fix workspace affordance",
+	})
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+
+	var resp kataWorkspaceTargetResponse
+	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
+	assert.True(resp.Available)
+	require.NotNil(resp.Repo)
+	assert.Equal("github", resp.Repo.Provider)
+	assert.Equal("github.com", resp.Repo.PlatformHost)
+	assert.Equal("acme", resp.Repo.Owner)
+	assert.Equal("middleman", resp.Repo.Name)
+	assert.Equal(db.WorkspaceItemTypeKataTask, resp.ItemType)
+	assert.Equal(db.KataWorkspaceItemKey(db.WorkspaceKataMetadata{
+		DaemonID:   "desktop",
+		ProjectUID: "project-middleman",
+		IssueUID:   "issue-kata-1",
+	}), resp.ItemKey)
+}
+
+func TestKataWorkspaceTargetTrackedRepoNameFallbackRequiresOneMatch(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	srv, database, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "middleman"
+
+[[repos]]
+owner = "forks"
+name = "middleman"
+`, &mockGH{})
+	_, err := database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "middleman"))
+	require.NoError(err)
+	_, err = database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "forks", "middleman"))
+	require.NoError(err)
+
+	rr := doJSON(t, srv, http.MethodPost, "/api/v1/kata/workspace-target", map[string]any{
+		"daemon_id":    "desktop",
+		"project_uid":  "project-middleman",
+		"project_name": "middleman",
+		"issue_uid":    "issue-kata-1",
+	})
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+
+	var resp kataWorkspaceTargetResponse
+	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
+	assert.False(resp.Available)
+	assert.Nil(resp.Repo)
+}
+
 func TestKataWorkspaceTargetAutomaticMappingFromProjectUIDWhenIdentityPresent(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/server/kata_workspace_test.go
+++ b/internal/server/kata_workspace_test.go
@@ -371,6 +371,35 @@ name = "middleman"
 	assert.Nil(resp.Repo)
 }
 
+func TestKataWorkspaceTargetTrackedRepoNameFallbackRequiresTrackedRepo(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	srv, _, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "middleman"
+`, &mockGH{})
+
+	rr := doJSON(t, srv, http.MethodPost, "/api/v1/kata/workspace-target", map[string]any{
+		"daemon_id":    "desktop",
+		"project_uid":  "project-middleman",
+		"project_name": "middleman",
+		"issue_uid":    "issue-kata-1",
+	})
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+
+	var resp kataWorkspaceTargetResponse
+	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
+	assert.False(resp.Available)
+	assert.Nil(resp.Repo)
+}
+
 func TestKataWorkspaceTargetAutomaticMappingFromGlobTrackedRepoName(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/server/kata_workspace_test.go
+++ b/internal/server/kata_workspace_test.go
@@ -921,10 +921,20 @@ repo_path = "acme/widget"
 }
 
 func TestCreateKataWorkspaceFromGlobTrackedRepoName(t *testing.T) {
+	testCreateKataWorkspaceFromTrackedRepoName(t, "middle*")
+}
+
+func TestCreateKataWorkspaceFromExactTrackedRepoName(t *testing.T) {
+	testCreateKataWorkspaceFromTrackedRepoName(t, "middleman")
+}
+
+func testCreateKataWorkspaceFromTrackedRepoName(t *testing.T, configuredRepoName string) {
+	t.Helper()
+
 	assert := assert.New(t)
 	require := require.New(t)
 
-	srv, database, _ := setupTestServerWithConfigContent(t, `
+	cfg := fmt.Sprintf(`
 sync_interval = "5m"
 github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
 host = "127.0.0.1"
@@ -932,8 +942,9 @@ port = 8091
 
 [[repos]]
 owner = "acme"
-name = "middle*"
-`, &mockGH{})
+name = %q
+`, configuredRepoName)
+	srv, database, _ := setupTestServerWithConfigContent(t, cfg, &mockGH{})
 	_, err := database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "middleman"))
 	require.NoError(err)
 	srv.workspaces = workspace.NewManager(database, t.TempDir())

--- a/internal/server/kata_workspace_test.go
+++ b/internal/server/kata_workspace_test.go
@@ -371,6 +371,81 @@ name = "middleman"
 	assert.Nil(resp.Repo)
 }
 
+func TestKataWorkspaceTargetAutomaticMappingFromGlobTrackedRepoName(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	srv, database, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "middle*"
+`, &mockGH{})
+	_, err := database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "middleman"))
+	require.NoError(err)
+	_, err = database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "middle-earth"))
+	require.NoError(err)
+
+	rr := doJSON(t, srv, http.MethodPost, "/api/v1/kata/workspace-target", map[string]any{
+		"daemon_id":    "desktop",
+		"project_uid":  "project-middleman",
+		"project_name": "middleman",
+		"issue_uid":    "issue-kata-1",
+	})
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+
+	var resp kataWorkspaceTargetResponse
+	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
+	assert.True(resp.Available)
+	require.NotNil(resp.Repo)
+	assert.Equal("github", resp.Repo.Provider)
+	assert.Equal("github.com", resp.Repo.PlatformHost)
+	assert.Equal("acme", resp.Repo.Owner)
+	assert.Equal("middleman", resp.Repo.Name)
+	assert.Equal(db.WorkspaceItemTypeKataTask, resp.ItemType)
+}
+
+func TestKataWorkspaceTargetGlobTrackedRepoNameFallbackRequiresOneMatch(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	srv, database, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "middle*"
+
+[[repos]]
+owner = "forks"
+name = "middle*"
+`, &mockGH{})
+	_, err := database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "middleman"))
+	require.NoError(err)
+	_, err = database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "forks", "middleman"))
+	require.NoError(err)
+
+	rr := doJSON(t, srv, http.MethodPost, "/api/v1/kata/workspace-target", map[string]any{
+		"daemon_id":    "desktop",
+		"project_uid":  "project-middleman",
+		"project_name": "middleman",
+		"issue_uid":    "issue-kata-1",
+	})
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+
+	var resp kataWorkspaceTargetResponse
+	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
+	assert.False(resp.Available)
+	assert.Nil(resp.Repo)
+}
+
 func TestKataWorkspaceTargetAutomaticMappingFromProjectUIDWhenIdentityPresent(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/server/kata_workspace_test.go
+++ b/internal/server/kata_workspace_test.go
@@ -475,6 +475,43 @@ name = "middle*"
 	assert.Nil(resp.Repo)
 }
 
+func TestKataWorkspaceTargetTrackedRepoNameFallbackCombinesExactAndGlobMatches(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	srv, database, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "middleman"
+
+[[repos]]
+owner = "forks"
+name = "middle*"
+`, &mockGH{})
+	_, err := database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "middleman"))
+	require.NoError(err)
+	_, err = database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "forks", "middleman"))
+	require.NoError(err)
+
+	rr := doJSON(t, srv, http.MethodPost, "/api/v1/kata/workspace-target", map[string]any{
+		"daemon_id":    "desktop",
+		"project_uid":  "project-middleman",
+		"project_name": "middleman",
+		"issue_uid":    "issue-kata-1",
+	})
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+
+	var resp kataWorkspaceTargetResponse
+	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
+	assert.False(resp.Available)
+	assert.Nil(resp.Repo)
+}
+
 func TestKataWorkspaceTargetAutomaticMappingFromProjectUIDWhenIdentityPresent(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -617,6 +654,64 @@ worktree_base_path = %q
 		"daemon_id":    "desktop",
 		"project_uid":  "project-kata",
 		"project_name": "Widget",
+		"issue_uid":    "issue-kata-1",
+	})
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+
+	var resp kataWorkspaceTargetResponse
+	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
+	assert.False(resp.Available)
+	assert.Nil(resp.Repo)
+}
+
+func TestKataWorkspaceTargetTOMLAmbiguityBlocksTrackedRepoNameFallback(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	firstClone := t.TempDir()
+	secondClone := t.TempDir()
+	require.NoError(os.WriteFile(
+		filepath.Join(firstClone, ".kata.toml"),
+		[]byte("[project]\nuid = \"project-kata\"\nname = \"Widget\"\n"),
+		0o644,
+	))
+	require.NoError(os.WriteFile(
+		filepath.Join(secondClone, ".kata.toml"),
+		[]byte("[project]\nuid = \"project-kata\"\nname = \"Other\"\n"),
+		0o644,
+	))
+	cfg := fmt.Sprintf(`
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "widget"
+worktree_base_path = %q
+
+[[repos]]
+owner = "acme"
+name = "other"
+worktree_base_path = %q
+
+[[repos]]
+owner = "acme"
+name = "middleman"
+`, firstClone, secondClone)
+	srv, database, _ := setupTestServerWithConfigContent(t, cfg, &mockGH{})
+	_, err := database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
+	require.NoError(err)
+	_, err = database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "other"))
+	require.NoError(err)
+	_, err = database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "middleman"))
+	require.NoError(err)
+
+	rr := doJSON(t, srv, http.MethodPost, "/api/v1/kata/workspace-target", map[string]any{
+		"daemon_id":    "desktop",
+		"project_uid":  "project-kata",
+		"project_name": "middleman",
 		"issue_uid":    "issue-kata-1",
 	})
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
@@ -823,6 +918,70 @@ repo_path = "acme/widget"
 	assert.Equal("task-123", created.Kata.ShortID)
 	assert.Equal("Kata#task-123", created.Kata.QualifiedID)
 	assert.Equal("Fix widget", created.Kata.Title)
+}
+
+func TestCreateKataWorkspaceFromGlobTrackedRepoName(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	srv, database, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "middle*"
+`, &mockGH{})
+	_, err := database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "middleman"))
+	require.NoError(err)
+	srv.workspaces = workspace.NewManager(database, t.TempDir())
+
+	metadata := db.WorkspaceKataMetadata{
+		DaemonID:    "desktop",
+		ProjectUID:  "project-middleman",
+		ProjectName: "middleman",
+		IssueUID:    "issue-kata-1",
+		ShortID:     "task-123",
+		Title:       "Fix workspace affordance",
+	}
+	rr := doJSON(t, srv, http.MethodPost, "/api/v1/kata/workspaces", map[string]any{
+		"daemon_id":    metadata.DaemonID,
+		"project_uid":  metadata.ProjectUID,
+		"project_name": metadata.ProjectName,
+		"issue_uid":    metadata.IssueUID,
+		"short_id":     metadata.ShortID,
+		"title":        metadata.Title,
+	})
+	require.Equal(http.StatusAccepted, rr.Code, rr.Body.String())
+
+	var created workspaceResponse
+	require.NoError(json.NewDecoder(rr.Body).Decode(&created))
+	assert.Equal("github", created.Repo.Provider)
+	assert.Equal("github.com", created.Repo.PlatformHost)
+	assert.Equal("acme", created.Repo.Owner)
+	assert.Equal("middleman", created.Repo.Name)
+	assert.Equal("acme/middleman", created.Repo.RepoPath)
+	assert.Equal(db.WorkspaceItemTypeKataTask, created.ItemType)
+	assert.Equal(db.KataWorkspaceItemKey(metadata), created.ItemKey)
+	require.NotNil(created.Kata)
+	assert.Equal(metadata.ProjectUID, created.Kata.ProjectUID)
+	assert.Equal(metadata.IssueUID, created.Kata.IssueUID)
+
+	stored, err := database.GetWorkspaceByItemKeyForProvider(
+		t.Context(),
+		"github",
+		"github.com",
+		"acme",
+		"middleman",
+		db.WorkspaceItemTypeKataTask,
+		db.KataWorkspaceItemKey(metadata),
+	)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.Equal("acme", stored.RepoOwner)
+	assert.Equal("middleman", stored.RepoName)
 }
 
 func TestCreateKataWorkspaceReusesExistingScopedTaskWorkspace(t *testing.T) {


### PR DESCRIPTION
- Restores Kata workspace creation for Kata projects that match tracked repos, including repos discovered from glob config entries.
- Keeps ambiguous matches and mismatched workspace metadata non-actionable so middleman does not launch against the wrong repo.

<sup>generated by a clanker</sup>