### PR TITLE
Require rendered Zensical asset checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,7 @@ Coverage of real behavior is non-negotiable; the lane is chosen by the behavior 
 - Regenerate API artifacts with `make api-generate`; the Go client also supports `go generate ./internal/apiclient/generated`
 - User-facing docs should be concise and workflow-oriented: state the UI capabilities and the maintainer workflows middleman enables, avoid overexplaining internals, and treat the HTTP API as an internal/thin-client concern rather than regular user guidance.
 - User-facing workflow screenshots live under `docs/assets/generated/` and must be regenerated with the Playwright task in `docs/screenshots/`; those captures use the real seeded e2e backend, not mocked API fixtures or a developer daemon.
+- Verify Zensical screenshot asset-path findings against rendered `site/` output; raw HTML source paths can be rewritten when `use_directory_urls` is enabled.
 - Tests, docs, fixtures, commit messages, and PR text should use generic synthetic examples unless the user explicitly asks to preserve exact private project names, paths, prose, or domain details.
 - **Never use npm** — use `bun install` for frontend dependencies and invoke Vite+ directly via `./node_modules/.bin/vp ...` (or `../node_modules/.bin/vp ...` from `frontend/`). Never run `npm install` or `npm run` — this creates `package-lock.json` which conflicts with the bun lockfile
 - Tests should be fast and isolated


### PR DESCRIPTION
- Adds contributor guidance to verify Zensical screenshot asset-path feedback against rendered `site/` output before changing source paths.
- Captures the #600 review lesson without changing the published docs content.

<sup>generated by a clanker</sup>