### PR TITLE
Show native Roborev panel reviews in Reviews

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,9 +421,10 @@ jobs:
     needs: detect_changes
     if: needs.detect_changes.outputs.backend == 'true' || needs.detect_changes.outputs.frontend == 'true' || needs.detect_changes.outputs.e2e == 'true'
     env:
-      # Pin to post-v0.50.0 commit with OpenAPI/Huma support.
-      # Update to next release tag when available.
-      ROBOREV_REF: 34091063a7d9c415c35a0faba18d41952b331b0f
+      # Pin to a post-v0.61.2 commit with panel reviews (panel_summary,
+      # omit_prompt, first_started_at). Update to next release tag when
+      # available.
+      ROBOREV_REF: d67d87dbfab7c75b9f4b09f482d5c9d4f705335a
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,10 +421,9 @@ jobs:
     needs: detect_changes
     if: needs.detect_changes.outputs.backend == 'true' || needs.detect_changes.outputs.frontend == 'true' || needs.detect_changes.outputs.e2e == 'true'
     env:
-      # Pin to a post-v0.61.2 commit with panel reviews (panel_summary,
-      # omit_prompt, first_started_at). Update to next release tag when
-      # available.
-      ROBOREV_REF: d67d87dbfab7c75b9f4b09f482d5c9d4f705335a
+      # Pin to v0.61.2, the first release with panel reviews (panel_summary,
+      # omit_prompt, first_started_at).
+      ROBOREV_REF: 4238df4685524fa0b4e308014ae120e677e7b6ed
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/context/testing.md
+++ b/context/testing.md
@@ -79,6 +79,9 @@ real runtime path plus a component or Vitest browser test for presentation. Do
 not require a duplicate full-stack browser test when it would only replay data
 that is already proven at those two boundaries.
 
+Roborev `hide_classify_jobs` e2e fixtures must cover skipped design rows and classify-typed auto-design rows.
+Seed classify rows terminal unless testing worker mutation; live workers can rewrite queued/running rows during browser assertions (`internal/testutil/roborev_fixtures.go::seedRoborevMutationFixtures`).
+
 Kata reachable-graph tests can use `window.__middleman_kata_graph_debug` in
 browser/e2e runs, or `kata-graph-debug.ts` directly in unit tests, to inspect
 recent graph/store events and the latest rendered node IDs. Prefer this bridge

--- a/context/testing.md
+++ b/context/testing.md
@@ -81,6 +81,7 @@ that is already proven at those two boundaries.
 
 Roborev `hide_classify_jobs` e2e fixtures must cover skipped design rows and classify-typed auto-design rows.
 Seed classify rows terminal unless testing worker mutation; live workers can rewrite queued/running rows during browser assertions (`internal/testutil/roborev_fixtures.go::seedRoborevMutationFixtures`).
+Keep injected Roborev `panel_run` failures controlled until the assertion observes them; drawer/list refresh demand can immediately retry member fetches and clear transient panel errors (`packages/ui/src/stores/roborev/jobs.svelte.ts::wantsPanelMembers`).
 
 Kata reachable-graph tests can use `window.__middleman_kata_graph_debug` in
 browser/e2e runs, or `kata-graph-debug.ts` directly in unit tests, to inspect

--- a/context/testing.md
+++ b/context/testing.md
@@ -82,6 +82,7 @@ that is already proven at those two boundaries.
 Roborev `hide_classify_jobs` e2e fixtures must cover skipped design rows and classify-typed auto-design rows.
 Seed classify rows terminal unless testing worker mutation; live workers can rewrite queued/running rows during browser assertions (`internal/testutil/roborev_fixtures.go::seedRoborevMutationFixtures`).
 Keep injected Roborev `panel_run` failures controlled until the assertion observes them; drawer/list refresh demand can immediately retry member fetches and clear transient panel errors (`packages/ui/src/stores/roborev/jobs.svelte.ts::wantsPanelMembers`).
+The `e2e-roborev` daemon pin (`ROBOREV_REF` in `.github/workflows/ci.yml`) must be at or after the roborev commit the generated schema (`packages/ui/src/api/roborev/generated/`) was produced from; a stale pin makes the daemon silently omit newer response fields while seed inserts still succeed, because the seeder creates its own schema.
 
 Kata reachable-graph tests can use `window.__middleman_kata_graph_debug` in
 browser/e2e runs, or `kata-graph-debug.ts` directly in unit tests, to inspect

--- a/context/ui-design-system.md
+++ b/context/ui-design-system.md
@@ -143,6 +143,15 @@ In this repo, the standard term is **chip**, not pill.
 
 When a screen needs semantic chip color, extend `Chip` with a named tone class such as `chip--blue`, `chip--green`, or `chip--red` instead of redefining local badge geometry. Screens may keep legacy class names for test selectors during migration, but sizing, casing, and spacing should come from `Chip`.
 
+### Tree Cells
+
+Tree-like rows inside dense tables should preserve the table's scan line.
+Keep IDs and primary row numbers in their normal column, and put disclosure
+chevrons plus child indentation inside the content cell that owns the
+hierarchy, such as a repo/ref or file-name cell. Do not use terminal/TUI
+connector glyphs, branch-line borders, or extra ornamental strokes to draw the
+tree. Indentation and a standard chevron are the affordance.
+
 ### ActionButton
 
 Use `ActionButton` for repeated action styling.

--- a/frontend/src/lib/stores/roborev-jobs.test.ts
+++ b/frontend/src/lib/stores/roborev-jobs.test.ts
@@ -371,6 +371,43 @@ describe("createJobsStore panel expansion", () => {
     expect(store.getHighlightedJobId()).toBe(10);
   });
 
+  it("refreshes interested panel members on listing reload while the table panel is collapsed", async () => {
+    const parent = makePanelParent(10);
+    let panelCalls = 0;
+    const client = {
+      GET: vi.fn().mockImplementation((_path: string, opts: { params: { query: Record<string, unknown> } }) => {
+        if (opts.params.query.panel_run === "run-10") {
+          panelCalls++;
+          return Promise.resolve({
+            data: {
+              jobs: [parent, makeMember(panelCalls === 1 ? 11 : 12, "run-10", 0)],
+              has_more: false,
+              stats: { done: 0, closed: 0, open: 0 },
+            },
+            error: undefined,
+          });
+        }
+        return Promise.resolve({
+          data: { jobs: [parent], has_more: false, stats: { done: 0, closed: 0, open: 0 } },
+          error: undefined,
+        });
+      }),
+    };
+    const store = createJobsStore({ client: client as never, navigate: vi.fn() });
+    await store.loadJobs();
+
+    store.setPanelMemberInterest("run-10");
+    await vi.waitFor(() => {
+      expect(store.getPanelMembers("run-10")?.map((j) => j.id)).toEqual([11]);
+    });
+
+    await store.loadJobs();
+    await vi.waitFor(() => {
+      expect(panelCalls).toBe(2);
+      expect(store.getPanelMembers("run-10")?.map((j) => j.id)).toEqual([12]);
+    });
+  });
+
   it("sorts panel parents by their displayed aggregate cost", async () => {
     const expensive = {
       ...makePanelParent(10),

--- a/frontend/src/lib/stores/roborev-jobs.test.ts
+++ b/frontend/src/lib/stores/roborev-jobs.test.ts
@@ -144,3 +144,96 @@ describe("createJobsStore auto-design filter", () => {
     expect(lastQuery).not.toHaveProperty("hide_classify_jobs");
   });
 });
+
+describe("createJobsStore panel expansion", () => {
+  function makePanelParent(id: number): ReviewJob {
+    return {
+      ...makeJob(id),
+      job_type: "synthesis",
+      panel_role: "synthesis",
+      panel_run_uuid: `run-${id}`,
+      panel_summary: {
+        panel_run_uuid: `run-${id}`,
+        members_total: 2,
+        members_terminal: 2,
+        members_succeeded: 2,
+        members_failed: 0,
+        members_canceled: 0,
+        members_skipped: 0,
+      },
+    };
+  }
+
+  function makeMember(id: number, runUuid: string, index: number): ReviewJob {
+    return {
+      ...makeJob(id),
+      panel_role: "member",
+      panel_run_uuid: runUuid,
+      panel_member_index: index,
+      panel_member_name: index === 0 ? "default" : "security",
+    };
+  }
+
+  it("lazily fetches members sorted by panel_member_index on first expand", async () => {
+    const parent = makePanelParent(10);
+    const members = [makeMember(12, "run-10", 1), makeMember(11, "run-10", 0)];
+    const client = {
+      GET: vi.fn().mockImplementation((_path: string, opts: { params: { query: Record<string, unknown> } }) => {
+        if (opts.params.query.panel_run === "run-10") {
+          return Promise.resolve({
+            data: { jobs: [parent, ...members], has_more: false, stats: { done: 0, closed: 0, open: 0 } },
+            error: undefined,
+          });
+        }
+        return Promise.resolve({
+          data: { jobs: [parent], has_more: false, stats: { done: 0, closed: 0, open: 0 } },
+          error: undefined,
+        });
+      }),
+    };
+    const store = createJobsStore({ client: client as never, navigate: vi.fn() });
+    await store.loadJobs();
+
+    expect(store.isPanelExpanded("run-10")).toBe(false);
+    store.togglePanel(parent);
+    expect(store.isPanelExpanded("run-10")).toBe(true);
+    await vi.waitFor(() => {
+      expect(store.getPanelMembers("run-10")).toBeDefined();
+    });
+    expect(store.getPanelMembers("run-10")?.map((j) => j.id)).toEqual([11, 12]);
+    expect(client.GET).toHaveBeenCalledWith("/api/jobs", {
+      params: { query: { panel_run: "run-10", limit: 0 } },
+    });
+
+    const calls = client.GET.mock.calls.length;
+    store.togglePanel(parent);
+    store.togglePanel(parent);
+    expect(store.isPanelExpanded("run-10")).toBe(true);
+    expect(client.GET.mock.calls.length).toBe(calls);
+  });
+
+  it("refreshes members of expanded panels when the listing reloads", async () => {
+    const parent = makePanelParent(10);
+    const client = {
+      GET: vi.fn().mockResolvedValue({
+        data: { jobs: [parent], has_more: false, stats: { done: 0, closed: 0, open: 0 } },
+        error: undefined,
+      }),
+    };
+    const store = createJobsStore({ client: client as never, navigate: vi.fn() });
+    await store.loadJobs();
+    store.togglePanel(parent);
+    await vi.waitFor(() => expect(store.getPanelMembers("run-10")).toBeDefined());
+
+    const before = client.GET.mock.calls.filter(
+      (c) => (c[1] as { params: { query: Record<string, unknown> } }).params.query.panel_run === "run-10",
+    ).length;
+    await store.loadJobs();
+    await vi.waitFor(() => {
+      const after = client.GET.mock.calls.filter(
+        (c) => (c[1] as { params: { query: Record<string, unknown> } }).params.query.panel_run === "run-10",
+      ).length;
+      expect(after).toBe(before + 1);
+    });
+  });
+});

--- a/frontend/src/lib/stores/roborev-jobs.test.ts
+++ b/frontend/src/lib/stores/roborev-jobs.test.ts
@@ -409,6 +409,56 @@ describe("createJobsStore panel expansion", () => {
     });
   });
 
+  it("drains queued interested refreshes while the table panel is collapsed", async () => {
+    const parent = makePanelParent(10);
+    const initialFetch = deferred<{
+      data: { jobs: ReviewJob[]; has_more: boolean; stats: { done: number; closed: number; open: number } };
+      error: undefined;
+    }>();
+    let panelCalls = 0;
+    const client = {
+      GET: vi.fn().mockImplementation((_path: string, opts: { params: { query: Record<string, unknown> } }) => {
+        if (opts.params.query.panel_run === "run-10") {
+          panelCalls++;
+          if (panelCalls === 1) return initialFetch.promise;
+          return Promise.resolve({
+            data: {
+              jobs: [parent, makeMember(12, "run-10", 0)],
+              has_more: false,
+              stats: { done: 0, closed: 0, open: 0 },
+            },
+            error: undefined,
+          });
+        }
+        return Promise.resolve({
+          data: { jobs: [parent], has_more: false, stats: { done: 0, closed: 0, open: 0 } },
+          error: undefined,
+        });
+      }),
+    };
+    const store = createJobsStore({ client: client as never, navigate: vi.fn() });
+    await store.loadJobs();
+
+    store.setPanelMemberInterest("run-10");
+    await vi.waitFor(() => expect(panelCalls).toBe(1));
+    await store.loadJobs();
+    expect(panelCalls).toBe(1);
+
+    initialFetch.resolve({
+      data: {
+        jobs: [parent, makeMember(11, "run-10", 0)],
+        has_more: false,
+        stats: { done: 0, closed: 0, open: 0 },
+      },
+      error: undefined,
+    });
+
+    await vi.waitFor(() => {
+      expect(panelCalls).toBe(2);
+      expect(store.getPanelMembers("run-10")?.map((j) => j.id)).toEqual([12]);
+    });
+  });
+
   it("sorts panel parents by their displayed aggregate cost", async () => {
     const expensive = {
       ...makePanelParent(10),

--- a/frontend/src/lib/stores/roborev-jobs.test.ts
+++ b/frontend/src/lib/stores/roborev-jobs.test.ts
@@ -113,3 +113,34 @@ describe("createJobsStore elapsed sorting", () => {
     expect(store.getJobs().map((job) => job.id)).toEqual([8, 2, 6, 5]);
   });
 });
+
+describe("createJobsStore auto-design filter", () => {
+  function makeClient() {
+    return {
+      GET: vi.fn().mockResolvedValue({
+        data: { jobs: [], has_more: false, stats: { done: 0, closed: 0, open: 0 } },
+        error: undefined,
+      }),
+    };
+  }
+
+  it("sends hide_classify_jobs by default and drops it when showAutoDesign is on", async () => {
+    const client = makeClient();
+    const store = createJobsStore({ client: client as never, navigate: vi.fn() });
+
+    await store.loadJobs();
+
+    expect(store.getFilterShowAutoDesign()).toBe(false);
+    expect(client.GET).toHaveBeenLastCalledWith("/api/jobs", {
+      params: { query: expect.objectContaining({ hide_classify_jobs: "true" }) },
+    });
+
+    store.setFilter("showAutoDesign", true);
+    await vi.waitFor(() => {
+      expect(client.GET.mock.calls.length).toBeGreaterThan(1);
+    });
+
+    const lastQuery = client.GET.mock.calls.at(-1)?.[1]?.params?.query as Record<string, unknown>;
+    expect(lastQuery).not.toHaveProperty("hide_classify_jobs");
+  });
+});

--- a/frontend/src/lib/stores/roborev-jobs.test.ts
+++ b/frontend/src/lib/stores/roborev-jobs.test.ts
@@ -146,6 +146,14 @@ describe("createJobsStore auto-design filter", () => {
 });
 
 describe("createJobsStore panel expansion", () => {
+  function deferred<T>() {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((res) => {
+      resolve = res;
+    });
+    return { promise, resolve };
+  }
+
   function makePanelParent(id: number): ReviewJob {
     return {
       ...makeJob(id),
@@ -202,7 +210,7 @@ describe("createJobsStore panel expansion", () => {
     });
     expect(store.getPanelMembers("run-10")?.map((j) => j.id)).toEqual([11, 12]);
     expect(client.GET).toHaveBeenCalledWith("/api/jobs", {
-      params: { query: { panel_run: "run-10", limit: 0 } },
+      params: { query: { panel_run: "run-10", limit: 0, omit_prompt: "true" } },
     });
 
     const calls = client.GET.mock.calls.length;
@@ -234,6 +242,145 @@ describe("createJobsStore panel expansion", () => {
         (c) => (c[1] as { params: { query: Record<string, unknown> } }).params.query.panel_run === "run-10",
       ).length;
       expect(after).toBe(before + 1);
+    });
+  });
+
+  it("includes expanded panel members in highlight navigation", async () => {
+    const parent = makePanelParent(10);
+    const members = [makeMember(12, "run-10", 1), makeMember(11, "run-10", 0)];
+    const client = {
+      GET: vi.fn().mockImplementation((_path: string, opts: { params: { query: Record<string, unknown> } }) => {
+        if (opts.params.query.panel_run === "run-10") {
+          return Promise.resolve({
+            data: { jobs: [parent, ...members], has_more: false, stats: { done: 0, closed: 0, open: 0 } },
+            error: undefined,
+          });
+        }
+        return Promise.resolve({
+          data: { jobs: [parent], has_more: false, stats: { done: 0, closed: 0, open: 0 } },
+          error: undefined,
+        });
+      }),
+    };
+    const store = createJobsStore({ client: client as never, navigate: vi.fn() });
+    await store.loadJobs();
+    store.togglePanel(parent);
+    await vi.waitFor(() => {
+      expect(store.getVisibleJobs().map((j) => j.id)).toEqual([10, 11, 12]);
+    });
+
+    store.highlightJob(10);
+    store.highlightNextJob();
+    expect(store.getHighlightedJobId()).toBe(11);
+    store.highlightNextJob();
+    expect(store.getHighlightedJobId()).toBe(12);
+    store.highlightPrevJob();
+    expect(store.getHighlightedJobId()).toBe(11);
+    await store.loadJobs();
+    expect(store.getHighlightedJobId()).toBe(11);
+  });
+
+  it("sorts panel parents by their displayed aggregate cost", async () => {
+    const expensive = {
+      ...makePanelParent(10),
+      token_usage: JSON.stringify({ has_cost: true, cost_usd: 0.01 }),
+      panel_summary: {
+        ...makePanelParent(10).panel_summary!,
+        members_with_cost: 2,
+        members_cost_usd: 1,
+        members_cost_complete: true,
+      },
+    };
+    const cheaper = {
+      ...makePanelParent(20),
+      token_usage: JSON.stringify({ has_cost: true, cost_usd: 0.5 }),
+      panel_summary: {
+        ...makePanelParent(20).panel_summary!,
+        members_with_cost: 2,
+        members_cost_usd: 0,
+        members_cost_complete: true,
+      },
+    };
+    const client = {
+      GET: vi.fn().mockResolvedValue({
+        data: { jobs: [expensive, cheaper], has_more: false, stats: { done: 0, closed: 0, open: 0 } },
+        error: undefined,
+      }),
+    };
+    const store = createJobsStore({ client: client as never, navigate: vi.fn() });
+    await store.loadJobs();
+
+    store.setSortColumn("cost");
+
+    expect(store.getJobs().map((j) => j.id)).toEqual([20, 10]);
+  });
+
+  it("coalesces panel refreshes while a member request is in flight", async () => {
+    const parent = makePanelParent(10);
+    const duplicateVisibleMember = makeMember(99, "run-10", 1);
+    const slowRefresh = deferred<{
+      data: { jobs: ReviewJob[]; has_more: boolean; stats: { done: number; closed: number; open: number } };
+      error: undefined;
+    }>();
+    let panelCalls = 0;
+    const client = {
+      GET: vi.fn().mockImplementation((_path: string, opts: { params: { query: Record<string, unknown> } }) => {
+        if (opts.params.query.panel_run === "run-10") {
+          panelCalls++;
+          if (panelCalls === 1) {
+            return Promise.resolve({
+              data: {
+                jobs: [parent, makeMember(11, "run-10", 0)],
+                has_more: false,
+                stats: { done: 0, closed: 0, open: 0 },
+              },
+              error: undefined,
+            });
+          }
+          if (panelCalls === 2) return slowRefresh.promise;
+          return Promise.resolve({
+            data: {
+              jobs: [parent, makeMember(13, "run-10", 0)],
+              has_more: false,
+              stats: { done: 0, closed: 0, open: 0 },
+            },
+            error: undefined,
+          });
+        }
+        return Promise.resolve({
+          data: {
+            jobs: [parent, duplicateVisibleMember],
+            has_more: false,
+            stats: { done: 0, closed: 0, open: 0 },
+          },
+          error: undefined,
+        });
+      }),
+    };
+    const store = createJobsStore({ client: client as never, navigate: vi.fn() });
+    await store.loadJobs();
+    store.togglePanel(parent);
+    await vi.waitFor(() => {
+      expect(store.getPanelMembers("run-10")?.map((j) => j.id)).toEqual([11]);
+    });
+
+    await store.loadJobs();
+    await vi.waitFor(() => expect(panelCalls).toBe(2));
+    await store.loadJobs();
+    expect(panelCalls).toBe(2);
+
+    slowRefresh.resolve({
+      data: {
+        jobs: [parent, makeMember(12, "run-10", 0)],
+        has_more: false,
+        stats: { done: 0, closed: 0, open: 0 },
+      },
+      error: undefined,
+    });
+
+    await vi.waitFor(() => {
+      expect(panelCalls).toBe(3);
+      expect(store.getPanelMembers("run-10")?.map((j) => j.id)).toEqual([13]);
     });
   });
 });

--- a/frontend/src/lib/stores/roborev-jobs.test.ts
+++ b/frontend/src/lib/stores/roborev-jobs.test.ts
@@ -277,7 +277,98 @@ describe("createJobsStore panel expansion", () => {
     store.highlightPrevJob();
     expect(store.getHighlightedJobId()).toBe(11);
     await store.loadJobs();
-    expect(store.getHighlightedJobId()).toBe(11);
+    expect(store.getHighlightedJobId()).toBe(10);
+  });
+
+  it("hides cached members from visible navigation while a refresh is loading", async () => {
+    const parent = makePanelParent(10);
+    const slowRefresh = deferred<{
+      data: { jobs: ReviewJob[]; has_more: boolean; stats: { done: number; closed: number; open: number } };
+      error: undefined;
+    }>();
+    let panelCalls = 0;
+    const client = {
+      GET: vi.fn().mockImplementation((_path: string, opts: { params: { query: Record<string, unknown> } }) => {
+        if (opts.params.query.panel_run === "run-10") {
+          panelCalls++;
+          if (panelCalls === 1) {
+            return Promise.resolve({
+              data: {
+                jobs: [parent, makeMember(11, "run-10", 0)],
+                has_more: false,
+                stats: { done: 0, closed: 0, open: 0 },
+              },
+              error: undefined,
+            });
+          }
+          return slowRefresh.promise;
+        }
+        return Promise.resolve({
+          data: { jobs: [parent], has_more: false, stats: { done: 0, closed: 0, open: 0 } },
+          error: undefined,
+        });
+      }),
+    };
+    const store = createJobsStore({ client: client as never, navigate: vi.fn() });
+    await store.loadJobs();
+    store.togglePanel(parent);
+    await vi.waitFor(() => {
+      expect(store.getVisibleJobs().map((j) => j.id)).toEqual([10, 11]);
+    });
+
+    store.highlightJob(11);
+    await store.loadJobs();
+    await vi.waitFor(() => expect(panelCalls).toBe(2));
+
+    expect(store.getVisibleJobs().map((j) => j.id)).toEqual([10]);
+    expect(store.getHighlightedJobId()).toBe(10);
+
+    slowRefresh.resolve({
+      data: {
+        jobs: [parent, makeMember(12, "run-10", 0)],
+        has_more: false,
+        stats: { done: 0, closed: 0, open: 0 },
+      },
+      error: undefined,
+    });
+    await vi.waitFor(() => {
+      expect(store.getVisibleJobs().map((j) => j.id)).toEqual([10, 12]);
+    });
+  });
+
+  it("moves highlight to the parent when closing a panel from a member row", async () => {
+    const parent = makePanelParent(10);
+    const client = {
+      GET: vi.fn().mockImplementation((_path: string, opts: { params: { query: Record<string, unknown> } }) => {
+        if (opts.params.query.panel_run === "run-10") {
+          return Promise.resolve({
+            data: {
+              jobs: [parent, makeMember(11, "run-10", 0)],
+              has_more: false,
+              stats: { done: 0, closed: 0, open: 0 },
+            },
+            error: undefined,
+          });
+        }
+        return Promise.resolve({
+          data: { jobs: [parent], has_more: false, stats: { done: 0, closed: 0, open: 0 } },
+          error: undefined,
+        });
+      }),
+    };
+    const store = createJobsStore({ client: client as never, navigate: vi.fn() });
+    await store.loadJobs();
+    store.togglePanel(parent);
+    await vi.waitFor(() => {
+      expect(store.getVisibleJobs().map((j) => j.id)).toEqual([10, 11]);
+    });
+
+    store.highlightJob(11);
+    store.togglePanel(parent);
+
+    expect(store.isPanelExpanded("run-10")).toBe(false);
+    expect(store.getVisibleJobs().map((j) => j.id)).toEqual([10]);
+    expect(store.getHighlightedJobId()).toBe(10);
   });
 
   it("sorts panel parents by their displayed aggregate cost", async () => {
@@ -382,5 +473,67 @@ describe("createJobsStore panel expansion", () => {
       expect(panelCalls).toBe(3);
       expect(store.getPanelMembers("run-10")?.map((j) => j.id)).toEqual([13]);
     });
+  });
+
+  it("keeps accepted members when a stale in-flight refresh is followed by a failed latest refresh", async () => {
+    const parent = makePanelParent(10);
+    const staleRefresh = deferred<{
+      data: { jobs: ReviewJob[]; has_more: boolean; stats: { done: number; closed: number; open: number } };
+      error: undefined;
+    }>();
+    const onError = vi.fn();
+    let panelCalls = 0;
+    const client = {
+      GET: vi.fn().mockImplementation((_path: string, opts: { params: { query: Record<string, unknown> } }) => {
+        if (opts.params.query.panel_run === "run-10") {
+          panelCalls++;
+          if (panelCalls === 1) {
+            return Promise.resolve({
+              data: {
+                jobs: [parent, makeMember(11, "run-10", 0)],
+                has_more: false,
+                stats: { done: 0, closed: 0, open: 0 },
+              },
+              error: undefined,
+            });
+          }
+          if (panelCalls === 2) return staleRefresh.promise;
+          return Promise.resolve({
+            data: undefined,
+            error: { message: "newest refresh failed" },
+          });
+        }
+        return Promise.resolve({
+          data: { jobs: [parent], has_more: false, stats: { done: 0, closed: 0, open: 0 } },
+          error: undefined,
+        });
+      }),
+    };
+    const store = createJobsStore({ client: client as never, navigate: vi.fn(), onError });
+    await store.loadJobs();
+    store.togglePanel(parent);
+    await vi.waitFor(() => {
+      expect(store.getPanelMembers("run-10")?.map((j) => j.id)).toEqual([11]);
+    });
+
+    await store.loadJobs();
+    await vi.waitFor(() => expect(panelCalls).toBe(2));
+    await store.loadJobs();
+    expect(panelCalls).toBe(2);
+
+    staleRefresh.resolve({
+      data: {
+        jobs: [parent, makeMember(12, "run-10", 0)],
+        has_more: false,
+        stats: { done: 0, closed: 0, open: 0 },
+      },
+      error: undefined,
+    });
+
+    await vi.waitFor(() => {
+      expect(panelCalls).toBe(3);
+      expect(onError).toHaveBeenCalledWith("Failed to load panel members");
+    });
+    expect(store.getPanelMembers("run-10")?.map((j) => j.id)).toEqual([11]);
   });
 });

--- a/frontend/src/lib/stores/roborev-jobs.test.ts
+++ b/frontend/src/lib/stores/roborev-jobs.test.ts
@@ -277,10 +277,10 @@ describe("createJobsStore panel expansion", () => {
     store.highlightPrevJob();
     expect(store.getHighlightedJobId()).toBe(11);
     await store.loadJobs();
-    expect(store.getHighlightedJobId()).toBe(10);
+    expect(store.getHighlightedJobId()).toBe(11);
   });
 
-  it("hides cached members from visible navigation while a refresh is loading", async () => {
+  it("keeps cached members visible in navigation while a refresh is loading", async () => {
     const parent = makePanelParent(10);
     const slowRefresh = deferred<{
       data: { jobs: ReviewJob[]; has_more: boolean; stats: { done: number; closed: number; open: number } };
@@ -320,8 +320,8 @@ describe("createJobsStore panel expansion", () => {
     await store.loadJobs();
     await vi.waitFor(() => expect(panelCalls).toBe(2));
 
-    expect(store.getVisibleJobs().map((j) => j.id)).toEqual([10]);
-    expect(store.getHighlightedJobId()).toBe(10);
+    expect(store.getVisibleJobs().map((j) => j.id)).toEqual([10, 11]);
+    expect(store.getHighlightedJobId()).toBe(11);
 
     slowRefresh.resolve({
       data: {
@@ -334,6 +334,7 @@ describe("createJobsStore panel expansion", () => {
     await vi.waitFor(() => {
       expect(store.getVisibleJobs().map((j) => j.id)).toEqual([10, 12]);
     });
+    expect(store.getHighlightedJobId()).toBe(10);
   });
 
   it("moves highlight to the parent when closing a panel from a member row", async () => {
@@ -572,5 +573,6 @@ describe("createJobsStore panel expansion", () => {
       expect(onError).toHaveBeenCalledWith("Failed to load panel members");
     });
     expect(store.getPanelMembers("run-10")?.map((j) => j.id)).toEqual([11]);
+    expect(store.getPanelMemberError("run-10")).toBe("Failed to load panel members");
   });
 });

--- a/frontend/src/lib/stores/roborev-log.test.ts
+++ b/frontend/src/lib/stores/roborev-log.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { createLogStore } from "@middleman/ui";
+
+const encoder = new TextEncoder();
+
+function ndjsonResponse(lines: unknown[]): Response {
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const line of lines) {
+        controller.enqueue(encoder.encode(`${JSON.stringify(line)}\n`));
+      }
+      controller.close();
+    },
+  });
+  return new Response(body, {
+    status: 200,
+    headers: { "Content-Type": "application/x-ndjson" },
+  });
+}
+
+describe("createLogStore", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("loads completed job output snapshots from the JSON response", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          lines: [
+            {
+              ts: "2026-04-11T11:00:00Z",
+              text: "finished review",
+              line_type: "text",
+            },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const store = createLogStore({ client: {} as never, baseUrl: "http://roborev.test" });
+
+    await store.loadSnapshot(42);
+
+    expect(fetchMock).toHaveBeenCalledWith("http://roborev.test/api/job/output?job_id=42");
+    expect(store.getLines()).toEqual([
+      {
+        ts: "2026-04-11T11:00:00Z",
+        text: "finished review",
+        lineType: "text",
+      },
+    ]);
+  });
+
+  it("streams live job output from the NDJSON job output endpoint", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(ndjsonResponse([{ ts: "2026-04-11T11:00:01Z", text: "running review", line_type: "tool" }]));
+    const store = createLogStore({ client: {} as never, baseUrl: "http://roborev.test" });
+
+    await store.startStreaming(77);
+
+    expect(fetchMock).toHaveBeenCalledWith("http://roborev.test/api/job/output?job_id=77&stream=1", {
+      signal: expect.any(AbortSignal),
+    });
+    expect(store.getLines()).toEqual([
+      {
+        ts: "2026-04-11T11:00:01Z",
+        text: "running review",
+        lineType: "tool",
+      },
+    ]);
+  });
+});

--- a/frontend/tests/e2e-full/roborev-e2e.spec.ts
+++ b/frontend/tests/e2e-full/roborev-e2e.spec.ts
@@ -110,6 +110,41 @@ test.describe.serial("Roborev", () => {
       await page.keyboard.press("ArrowRight");
       await expect(members).toHaveCount(2);
 
+      let releaseRefresh: (() => void) | undefined;
+      let delayedRefresh = false;
+      let resolveRefreshStarted!: () => void;
+      const refreshStarted = new Promise<void>((resolve) => {
+        resolveRefreshStarted = resolve;
+      });
+      let resolveRefreshContinued!: () => void;
+      const refreshContinued = new Promise<void>((resolve) => {
+        resolveRefreshContinued = resolve;
+      });
+      await page.route("**/api/roborev/api/jobs?**", async (route) => {
+        const url = new URL(route.request().url());
+        let heldRefresh = false;
+        if (!delayedRefresh && url.searchParams.get("panel_run") === "panel-e2e-1") {
+          delayedRefresh = true;
+          heldRefresh = true;
+          resolveRefreshStarted();
+          await new Promise<void>((release) => {
+            releaseRefresh = release;
+          });
+        }
+        await route.continue();
+        if (heldRefresh) resolveRefreshContinued();
+      });
+
+      await page.keyboard.press("Enter");
+      await refreshStarted;
+      await expect(members).toHaveCount(2);
+      await expect(page.locator(".members-status-row")).toContainText("Refreshing reviewers");
+      releaseRefresh?.();
+      await refreshContinued;
+      await expect(page.locator(".members-status-row", { hasText: "Refreshing reviewers" })).toHaveCount(0);
+      await expect(page).toHaveURL(/\/reviews\/79$/);
+      await page.keyboard.press("Escape");
+      await expect(page).toHaveURL(/\/reviews$/);
       await page.keyboard.press("j");
       await expect(members.nth(0)).toHaveClass(/highlighted/);
       await page.keyboard.press("ArrowLeft");

--- a/frontend/tests/e2e-full/roborev-e2e.spec.ts
+++ b/frontend/tests/e2e-full/roborev-e2e.spec.ts
@@ -311,8 +311,7 @@ test.describe.serial("Roborev", () => {
 
       const beforeCount = await page.locator(".job-row").count();
 
-      // Check the hide-closed checkbox
-      await page.locator(".hide-closed input[type=checkbox]").check();
+      await page.getByLabel("Hide closed").check();
 
       // Auto-retry until the row count drops to or below the
       // unfiltered baseline. The seed has closed jobs that should
@@ -323,6 +322,21 @@ test.describe.serial("Roborev", () => {
         const afterCount = await page.locator(".job-row").count();
         expect(afterCount).toBeLessThanOrEqual(beforeCount);
       }).toPass({ timeout: 5_000 });
+    });
+
+    test("show auto-design reveals skipped router byproducts", async ({ page }) => {
+      await waitForReviewsReady(page);
+      await waitForJobRows(page, 10);
+
+      const autoDesignRef = page.locator(".git-ref[title='auto-design-skip']");
+      await expect(autoDesignRef).toHaveCount(0);
+
+      await page.getByLabel("Show auto-design").check();
+
+      await expect(autoDesignRef).toBeVisible({ timeout: 5_000 });
+      const autoDesignRow = page.locator(".job-row", { has: autoDesignRef });
+      await expect(autoDesignRow.locator(".status-badge")).toHaveText("skipped");
+      await expect(autoDesignRow.locator(".col-type")).toHaveText("review");
     });
 
     test("reset each filter to default restores full list", async ({ page }) => {

--- a/frontend/tests/e2e-full/roborev-e2e.spec.ts
+++ b/frontend/tests/e2e-full/roborev-e2e.spec.ts
@@ -227,6 +227,93 @@ test.describe.serial("Roborev", () => {
       await expect(page.locator(".header-start .review-type", { hasText: "default" })).toBeVisible();
     });
 
+    test("route-selected panel drawer drains queued member refresh while table stays collapsed", async ({ page }) => {
+      let panelMemberRequests = 0;
+      let releaseFirstMemberFetch: (() => void) | undefined;
+      let resolveFirstMemberFetchStarted!: () => void;
+      const firstMemberFetchStarted = new Promise<void>((resolve) => {
+        resolveFirstMemberFetchStarted = resolve;
+      });
+      let resolveLatestMemberFetchServed!: () => void;
+      const latestMemberFetchServed = new Promise<void>((resolve) => {
+        resolveLatestMemberFetchServed = resolve;
+      });
+
+      await page.route("**/api/roborev/api/jobs?**", async (route) => {
+        const url = new URL(route.request().url());
+        if (url.searchParams.get("panel_run") !== "panel-e2e-1") {
+          await route.continue();
+          return;
+        }
+
+        panelMemberRequests++;
+        if (panelMemberRequests === 1) {
+          resolveFirstMemberFetchStarted();
+          await new Promise<void>((resolve) => {
+            releaseFirstMemberFetch = resolve;
+          });
+          await route.continue();
+          return;
+        }
+
+        const response = await route.fetch();
+        const body = (await response.json()) as {
+          jobs?: Array<Record<string, unknown>> | null;
+          [key: string]: unknown;
+        };
+        const jobs = (body.jobs ?? []).map((job) => {
+          if (job["id"] === 77) {
+            return { ...job, panel_member_name: "fresh-default", verdict: "pass" };
+          }
+          if (job["id"] === 78) {
+            return { ...job, panel_member_name: "fresh-security", verdict: "pass" };
+          }
+          return job;
+        });
+        await route.fulfill({
+          response,
+          body: JSON.stringify({ ...body, jobs }),
+        });
+        resolveLatestMemberFetchServed();
+      });
+
+      await page.goto("/reviews/79");
+      await expect(page).toHaveURL(/\/reviews\/79$/);
+      await expect(page.locator(".job-table")).toBeVisible({
+        timeout: 15_000,
+      });
+      const parent = jobRowById(page, 79);
+      await expect(parent).toBeVisible();
+      await expect(parent).toHaveAttribute("aria-expanded", "false");
+      await expect(page.locator(".job-row.member")).toHaveCount(0);
+      await expect(page.locator(".drawer")).toBeVisible();
+      await firstMemberFetchStarted;
+      await expect(page.locator(".panel-line")).toContainText("Refreshing reviewers");
+
+      const listingReload = page.waitForResponse((response) => {
+        const url = new URL(response.url());
+        return (
+          response.ok() &&
+          url.pathname.endsWith("/api/roborev/api/jobs") &&
+          url.searchParams.get("panel_run") === null &&
+          url.searchParams.get("status") === "done"
+        );
+      });
+      await selectStatusFilter(page, "Done");
+      await listingReload;
+      await expect(page.locator(".status-badge.status-done").first()).toBeVisible({
+        timeout: 5_000,
+      });
+      await expect(page.locator(".status-badge:not(.status-done)")).toHaveCount(0);
+
+      releaseFirstMemberFetch?.();
+      await latestMemberFetchServed;
+      await expect(page.locator(".panel-line")).toContainText("fresh-default pass");
+      await expect(page.locator(".panel-line")).toContainText("fresh-security pass");
+      await expect(parent).toHaveAttribute("aria-expanded", "false");
+      await expect(page.locator(".job-row.member")).toHaveCount(0);
+    });
+
     test("status badges show correct classes for each status", async ({ page }) => {
       await waitForReviewsReady(page);
       await waitForJobRows(page, 10);

--- a/frontend/tests/e2e-full/roborev-e2e.spec.ts
+++ b/frontend/tests/e2e-full/roborev-e2e.spec.ts
@@ -120,10 +120,27 @@ test.describe.serial("Roborev", () => {
       const refreshContinued = new Promise<void>((resolve) => {
         resolveRefreshContinued = resolve;
       });
+      let failNextRefresh = false;
+      let allowRetryRefresh = false;
+      let failedRefresh = false;
+      let retryRefresh = false;
+      let resolveFailureServed!: () => void;
+      const failureServed = new Promise<void>((resolve) => {
+        resolveFailureServed = resolve;
+      });
+      let resolveRetryContinued!: () => void;
+      const retryContinued = new Promise<void>((resolve) => {
+        resolveRetryContinued = resolve;
+      });
       await page.route("**/api/roborev/api/jobs?**", async (route) => {
         const url = new URL(route.request().url());
+        if (url.searchParams.get("panel_run") !== "panel-e2e-1") {
+          await route.continue();
+          return;
+        }
+
         let heldRefresh = false;
-        if (!delayedRefresh && url.searchParams.get("panel_run") === "panel-e2e-1") {
+        if (!delayedRefresh) {
           delayedRefresh = true;
           heldRefresh = true;
           resolveRefreshStarted();
@@ -131,8 +148,34 @@ test.describe.serial("Roborev", () => {
             releaseRefresh = release;
           });
         }
+        if (heldRefresh) {
+          await route.continue();
+          resolveRefreshContinued();
+          return;
+        }
+        if (failNextRefresh && !failedRefresh) {
+          failedRefresh = true;
+          await route.fulfill({
+            status: 502,
+            contentType: "application/json",
+            body: JSON.stringify({ error: "seeded panel refresh failure" }),
+          });
+          resolveFailureServed();
+          return;
+        }
+        if (failedRefresh && !allowRetryRefresh) {
+          await route.fulfill({
+            status: 502,
+            contentType: "application/json",
+            body: JSON.stringify({ error: "seeded panel refresh failure" }),
+          });
+          return;
+        }
         await route.continue();
-        if (heldRefresh) resolveRefreshContinued();
+        if (!retryRefresh) {
+          retryRefresh = true;
+          resolveRetryContinued();
+        }
       });
 
       await page.keyboard.press("Enter");
@@ -143,6 +186,30 @@ test.describe.serial("Roborev", () => {
       await refreshContinued;
       await expect(page.locator(".members-status-row", { hasText: "Refreshing reviewers" })).toHaveCount(0);
       await expect(page).toHaveURL(/\/reviews\/79$/);
+      await page.keyboard.press("Escape");
+      await expect(page).toHaveURL(/\/reviews$/);
+      failNextRefresh = true;
+      await parent.click();
+      await failureServed;
+      await expect(page).toHaveURL(/\/reviews\/79$/);
+      await expect(page.locator(".drawer")).toBeVisible();
+      await expect(page.locator(".panel-error")).toContainText("Could not refresh reviewers.");
+      await expect(page.locator(".members-status-row.error")).toContainText("Could not refresh reviewers.");
+      allowRetryRefresh = true;
+      const retryResponse = page.waitForResponse((response) => {
+        const url = new URL(response.url());
+        return (
+          response.ok() &&
+          url.pathname.endsWith("/api/roborev/api/jobs") &&
+          url.searchParams.get("panel_run") === "panel-e2e-1" &&
+          url.searchParams.get("omit_prompt") === "true"
+        );
+      });
+      await page.locator(".panel-retry").click();
+      await retryContinued;
+      await retryResponse;
+      await expect(page.locator(".panel-error")).toHaveCount(0);
+      await expect(page.locator(".members-status-row.error")).toHaveCount(0);
       await page.keyboard.press("Escape");
       await expect(page).toHaveURL(/\/reviews$/);
       await page.keyboard.press("j");

--- a/frontend/tests/e2e-full/roborev-e2e.spec.ts
+++ b/frontend/tests/e2e-full/roborev-e2e.spec.ts
@@ -22,6 +22,12 @@ function parseElapsed(text: string): number {
   );
 }
 
+function jobRowById(page: Page, id: number) {
+  return page.locator(".job-row").filter({
+    has: page.locator(".col-id .mono", { hasText: new RegExp(`^${id}$`) }),
+  });
+}
+
 test.describe.serial("Roborev", () => {
   // Refuse to run if the e2e server is not proxying to the
   // script-managed seeded daemon. This catches the failure mode
@@ -52,15 +58,56 @@ test.describe.serial("Roborev", () => {
       await waitForReviewsReady(page);
       await waitForJobRows(page, 10);
 
-      // Job 74 is the highest ID (first row in desc order):
-      // agent=claude, status=done (zero-duration fixture).
-      const firstRow = page.locator(".job-row").first();
-      await expect(firstRow).toBeVisible();
-      await expect(firstRow.locator(".col-id")).toContainText("74");
-      await expect(firstRow.locator(".col-agent")).toContainText("claude");
-      await expect(firstRow.locator(".status-badge")).toContainText("done");
+      // Job 74 is a stable zero-duration fixture:
+      // agent=claude, status=done, cost=$0.42.
+      const row = jobRowById(page, 74);
+      await expect(row).toBeVisible();
+      await expect(row.locator(".col-agent")).toContainText("claude");
+      await expect(row.locator(".status-badge")).toContainText("done");
       await expect(page.locator("th").filter({ hasText: "Cost" })).toBeVisible();
-      await expect(firstRow.locator(".col-cost")).toHaveText("~$0.42");
+      await expect(row.locator(".col-cost")).toHaveText("~$0.42");
+    });
+
+    test("panel parent expands to real member rows through the daemon proxy", async ({ page }) => {
+      await waitForReviewsReady(page);
+      await waitForJobRows(page, 10);
+
+      const parent = jobRowById(page, 79);
+      await expect(parent).toBeVisible();
+      await expect(parent.locator(".panel-status")).toContainText("1 ok · 1 failed");
+      await expect(parent.locator(".col-cost")).toHaveText("~$0.35");
+
+      const panelRunResponse = page.waitForResponse((response) => {
+        const url = new URL(response.url());
+        return (
+          response.ok() &&
+          url.pathname.endsWith("/api/roborev/api/jobs") &&
+          url.searchParams.get("panel_run") === "panel-e2e-1" &&
+          url.searchParams.get("omit_prompt") === "true"
+        );
+      });
+      await page.keyboard.press("j");
+      await expect(parent).toHaveClass(/highlighted/);
+      await page.keyboard.press("ArrowRight");
+      await panelRunResponse;
+
+      const members = page.locator(".job-row.member");
+      await expect(members).toHaveCount(2);
+      await expect(members.nth(0).locator(".member-name")).toHaveText("default");
+      await expect(members.nth(0).locator(".col-id")).toContainText("77");
+      await expect(members.nth(1).locator(".member-name")).toHaveText("security");
+      await expect(members.nth(1).locator(".col-id")).toContainText("78");
+
+      await page.keyboard.press("ArrowLeft");
+      await expect(members).toHaveCount(0);
+      await page.keyboard.press("ArrowRight");
+      await expect(members).toHaveCount(2);
+
+      await page.keyboard.press("j");
+      await expect(members.nth(0)).toHaveClass(/highlighted/);
+      await page.keyboard.press("Enter");
+      await expect(page).toHaveURL(/\/reviews\/77$/);
+      await expect(page.locator(".drawer")).toBeVisible();
     });
 
     test("status badges show correct classes for each status", async ({ page }) => {
@@ -180,7 +227,7 @@ test.describe.serial("Roborev", () => {
       }
 
       const totalCount = await page.locator(".job-row").count();
-      // Seed has 74 jobs total
+      // Seed has 77 parent-visible rows; panel members are hidden until expanded.
       expect(totalCount).toBeGreaterThanOrEqual(70);
     });
 

--- a/frontend/tests/e2e-full/roborev-e2e.spec.ts
+++ b/frontend/tests/e2e-full/roborev-e2e.spec.ts
@@ -112,6 +112,13 @@ test.describe.serial("Roborev", () => {
 
       await page.keyboard.press("j");
       await expect(members.nth(0)).toHaveClass(/highlighted/);
+      await page.keyboard.press("ArrowLeft");
+      await expect(members).toHaveCount(0);
+      await expect(parent).toHaveClass(/highlighted/);
+      await page.keyboard.press("ArrowRight");
+      await expect(members).toHaveCount(2);
+      await page.keyboard.press("j");
+      await expect(members.nth(0)).toHaveClass(/highlighted/);
       await page.keyboard.press("Enter");
       await expect(page).toHaveURL(/\/reviews\/77$/);
       await expect(page.locator(".drawer")).toBeVisible();

--- a/frontend/tests/e2e-full/roborev-e2e.spec.ts
+++ b/frontend/tests/e2e-full/roborev-e2e.spec.ts
@@ -98,6 +98,13 @@ test.describe.serial("Roborev", () => {
       await expect(members.nth(1).locator(".member-name")).toHaveText("security");
       await expect(members.nth(1).locator(".col-id")).toContainText("78");
 
+      await page.keyboard.press("Enter");
+      await expect(page).toHaveURL(/\/reviews\/79$/);
+      await expect(page.locator(".panel-line")).toContainText("2 reviewers:");
+      await expect(page.locator(".panel-line")).toContainText("default");
+      await page.keyboard.press("Escape");
+      await expect(page).toHaveURL(/\/reviews$/);
+
       await page.keyboard.press("ArrowLeft");
       await expect(members).toHaveCount(0);
       await page.keyboard.press("ArrowRight");
@@ -108,6 +115,7 @@ test.describe.serial("Roborev", () => {
       await page.keyboard.press("Enter");
       await expect(page).toHaveURL(/\/reviews\/77$/);
       await expect(page.locator(".drawer")).toBeVisible();
+      await expect(page.locator(".header-start .review-type", { hasText: "default" })).toBeVisible();
     });
 
     test("status badges show correct classes for each status", async ({ page }) => {
@@ -386,6 +394,10 @@ test.describe.serial("Roborev", () => {
       const autoDesignSkipRow = page.locator(".job-row", { has: autoDesignSkipRef });
       await expect(autoDesignSkipRow.locator(".status-badge")).toHaveText("skipped");
       await expect(autoDesignSkipRow.locator(".col-type")).toHaveText("review");
+      await autoDesignSkipRow.click();
+      await expect(page.locator(".header-start .review-type", { hasText: "auto-design" })).toBeVisible();
+      await expect(page.locator(".skip-reason")).toHaveText("Skipped: trivial diff");
+      await page.keyboard.press("Escape");
 
       await expect(autoDesignClassifyRef).toBeVisible({ timeout: 5_000 });
       const autoDesignClassifyRow = page.locator(".job-row", { has: autoDesignClassifyRef });

--- a/frontend/tests/e2e-full/roborev-e2e.spec.ts
+++ b/frontend/tests/e2e-full/roborev-e2e.spec.ts
@@ -328,15 +328,22 @@ test.describe.serial("Roborev", () => {
       await waitForReviewsReady(page);
       await waitForJobRows(page, 10);
 
-      const autoDesignRef = page.locator(".git-ref[title='auto-design-skip']");
-      await expect(autoDesignRef).toHaveCount(0);
+      const autoDesignSkipRef = page.locator(".git-ref[title='auto-design-skip']");
+      const autoDesignClassifyRef = page.locator(".git-ref[title='auto-design-classify']");
+      await expect(autoDesignSkipRef).toHaveCount(0);
+      await expect(autoDesignClassifyRef).toHaveCount(0);
 
       await page.getByLabel("Show auto-design").check();
 
-      await expect(autoDesignRef).toBeVisible({ timeout: 5_000 });
-      const autoDesignRow = page.locator(".job-row", { has: autoDesignRef });
-      await expect(autoDesignRow.locator(".status-badge")).toHaveText("skipped");
-      await expect(autoDesignRow.locator(".col-type")).toHaveText("review");
+      await expect(autoDesignSkipRef).toBeVisible({ timeout: 5_000 });
+      const autoDesignSkipRow = page.locator(".job-row", { has: autoDesignSkipRef });
+      await expect(autoDesignSkipRow.locator(".status-badge")).toHaveText("skipped");
+      await expect(autoDesignSkipRow.locator(".col-type")).toHaveText("review");
+
+      await expect(autoDesignClassifyRef).toBeVisible({ timeout: 5_000 });
+      const autoDesignClassifyRow = page.locator(".job-row", { has: autoDesignClassifyRef });
+      await expect(autoDesignClassifyRow.locator(".status-badge")).toHaveText("failed");
+      await expect(autoDesignClassifyRow.locator(".col-type")).toHaveText("classify");
     });
 
     test("reset each filter to default restores full list", async ({ page }) => {

--- a/frontend/tests/e2e-full/roborev-log-proxy.spec.ts
+++ b/frontend/tests/e2e-full/roborev-log-proxy.spec.ts
@@ -1,0 +1,168 @@
+import { once } from "node:events";
+import { createServer, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import { test, expect } from "@playwright/test";
+
+import { startIsolatedE2EServerWithOptions, type IsolatedE2EServer } from "./support/e2eServer";
+
+const job = {
+  id: 501,
+  repo_id: 1,
+  repo_name: "fake-repo",
+  repo_path: "/tmp/fake-repo",
+  git_ref: "feedface",
+  branch: "main",
+  agent: "codex",
+  model: "gpt-test",
+  status: "done",
+  job_type: "review",
+  enqueued_at: "2026-04-11T11:00:00Z",
+  started_at: "2026-04-11T11:01:00Z",
+  finished_at: "2026-04-11T11:02:00Z",
+  agentic: false,
+  prompt_prebuilt: false,
+  retry_count: 0,
+  closed: false,
+  verdict: "P",
+  commit_subject: "render log output",
+};
+
+function writeJSON(res: ServerResponse, body: unknown, status = 200): void {
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(body));
+}
+
+async function startFakeRoborevDaemon(): Promise<{
+  url: string;
+  requests: string[];
+  close: () => Promise<void>;
+}> {
+  const requests: string[] = [];
+  const server = createServer((req, res) => {
+    const url = new URL(req.url ?? "/", "http://127.0.0.1");
+    requests.push(`${url.pathname}${url.search}`);
+
+    switch (url.pathname) {
+      case "/api/status":
+        writeJSON(res, {
+          version: "fake-log-daemon",
+          queued_jobs: 0,
+          running_jobs: 0,
+          completed_jobs: 1,
+          failed_jobs: 0,
+          canceled_jobs: 0,
+          active_workers: 0,
+          max_workers: 0,
+        });
+        return;
+      case "/api/jobs":
+        writeJSON(res, {
+          jobs: [job],
+          has_more: false,
+          stats: { done: 1, closed: 0, open: 1 },
+        });
+        return;
+      case "/api/review":
+        writeJSON(res, {
+          id: 601,
+          job_id: job.id,
+          agent: job.agent,
+          prompt: "Review commit",
+          output: "No issues found.",
+          created_at: "2026-04-11T11:02:10Z",
+          closed: false,
+          verdict_bool: 1,
+          job,
+        });
+        return;
+      case "/api/comments":
+        writeJSON(res, { responses: [] });
+        return;
+      case "/api/repos":
+        writeJSON(res, {
+          repos: [
+            {
+              id: 1,
+              root_path: job.repo_path,
+              name: job.repo_name,
+              total_count: 1,
+            },
+          ],
+          total_count: 1,
+        });
+        return;
+      case "/api/job/output":
+        writeJSON(res, {
+          job_id: job.id,
+          status: job.status,
+          has_more: false,
+          lines: [
+            {
+              ts: "2026-04-11T11:01:30Z",
+              text: "proxy rendered log line",
+              line_type: "text",
+            },
+          ],
+        });
+        return;
+      case "/api/stream/events":
+        res.writeHead(204);
+        res.end();
+        return;
+      default:
+        writeJSON(res, { error: `unexpected ${url.pathname}` }, 404);
+    }
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address() as AddressInfo;
+
+  return {
+    url: `http://127.0.0.1:${port}`,
+    requests,
+    close: async () => {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+    },
+  };
+}
+
+async function startMiddlemanWithRoborev(endpoint: string): Promise<IsolatedE2EServer> {
+  const previous = process.env.ROBOREV_ENDPOINT;
+  process.env.ROBOREV_ENDPOINT = endpoint;
+  try {
+    return await startIsolatedE2EServerWithOptions({
+      visibleImportedModes: true,
+      freshProcess: true,
+    });
+  } finally {
+    if (previous === undefined) {
+      delete process.env.ROBOREV_ENDPOINT;
+    } else {
+      process.env.ROBOREV_ENDPOINT = previous;
+    }
+  }
+}
+
+test("completed job Log tab renders output through the middleman roborev proxy", async ({ page }) => {
+  const daemon = await startFakeRoborevDaemon();
+  let middleman: IsolatedE2EServer | undefined;
+  try {
+    middleman = await startMiddlemanWithRoborev(daemon.url);
+
+    await page.goto(`${middleman.info.base_url}/reviews/${job.id}`);
+    await expect(page.locator(".drawer")).toBeVisible();
+
+    await page.locator(".tab-bar .tab", { hasText: "Log" }).click();
+
+    await expect(page.locator(".log-text")).toContainText("proxy rendered log line");
+    expect(daemon.requests).toContain(`/api/job/output?job_id=${job.id}`);
+  } finally {
+    await middleman?.stop();
+    await daemon.close();
+  }
+});

--- a/frontend/tests/e2e-full/support/roborev-helpers.ts
+++ b/frontend/tests/e2e-full/support/roborev-helpers.ts
@@ -127,9 +127,9 @@ export async function assertSeededRoborevDaemon(): Promise<void> {
   }
 
   const total = SEEDED_STATUS_KEYS.reduce((sum, k) => sum + (counters[k] ?? 0), 0);
-  // The seed creates exactly 75 jobs (bulk IDs 1-69 + mutation
-  // fixtures 70-75). The rerun test re-enqueues job 73 in place
-  // (no new ID), so total stays at 75 throughout. Allow a little
+  // The seed creates exactly 76 jobs (bulk IDs 1-69 + mutation
+  // fixtures 70-76). The rerun test re-enqueues job 73 in place
+  // (no new ID), so total stays at 76 throughout. Allow a little
   // headroom but reject anything outside the tight seeded band so
   // unmanaged daemons cannot slip through.
   const minSeededJobs = 70;

--- a/frontend/tests/e2e-full/support/roborev-helpers.ts
+++ b/frontend/tests/e2e-full/support/roborev-helpers.ts
@@ -127,9 +127,9 @@ export async function assertSeededRoborevDaemon(): Promise<void> {
   }
 
   const total = SEEDED_STATUS_KEYS.reduce((sum, k) => sum + (counters[k] ?? 0), 0);
-  // The seed creates exactly 74 jobs (bulk IDs 1-69 + mutation
-  // fixtures 70-74). The rerun test re-enqueues job 73 in place
-  // (no new ID), so total stays at 74 throughout. Allow a little
+  // The seed creates exactly 75 jobs (bulk IDs 1-69 + mutation
+  // fixtures 70-75). The rerun test re-enqueues job 73 in place
+  // (no new ID), so total stays at 75 throughout. Allow a little
   // headroom but reject anything outside the tight seeded band so
   // unmanaged daemons cannot slip through.
   const minSeededJobs = 70;

--- a/frontend/tests/e2e-full/support/roborev-helpers.ts
+++ b/frontend/tests/e2e-full/support/roborev-helpers.ts
@@ -127,9 +127,10 @@ export async function assertSeededRoborevDaemon(): Promise<void> {
   }
 
   const total = SEEDED_STATUS_KEYS.reduce((sum, k) => sum + (counters[k] ?? 0), 0);
-  // The seed creates exactly 76 jobs (bulk IDs 1-69 + mutation
-  // fixtures 70-76). The rerun test re-enqueues job 73 in place
-  // (no new ID), so total stays at 76 throughout. Allow a little
+  // The seed creates exactly 79 jobs (bulk IDs 1-69 + mutation
+  // fixtures 70-76 + panel fixtures 77-79). The rerun test
+  // re-enqueues job 73 in place (no new ID), so total stays at
+  // 79 throughout. Allow a little
   // headroom but reject anything outside the tight seeded band so
   // unmanaged daemons cannot slip through.
   const minSeededJobs = 70;

--- a/internal/testutil/roborev_fixtures.go
+++ b/internal/testutil/roborev_fixtures.go
@@ -63,6 +63,13 @@ CREATE TABLE IF NOT EXISTS review_jobs (
   skip_reason TEXT,
   source TEXT,
   token_usage TEXT,
+  panel_run_uuid TEXT,
+  panel_role TEXT,
+  panel_name TEXT,
+  panel_member_name TEXT,
+  panel_member_index INTEGER,
+  panel_member_config_json TEXT,
+  claim_blocked INTEGER NOT NULL DEFAULT 0,
   uuid TEXT,
   agentic INTEGER NOT NULL DEFAULT 0,
   patch_id TEXT,
@@ -128,7 +135,7 @@ var roborevBaseTime = time.Date(
 )
 
 // SeedRoborevDB creates a roborev-compatible SQLite database at path
-// with deterministic test data. The database contains 76 review jobs
+// with deterministic test data. The database contains 79 review jobs
 // across 2 repos, 5 branches, 3 agents, and all statuses.
 func SeedRoborevDB(path string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
@@ -168,6 +175,9 @@ func SeedRoborevDB(path string) error {
 	if err := seedRoborevMutationFixtures(tx); err != nil {
 		return err
 	}
+	if err := seedRoborevPanelFixtures(tx); err != nil {
+		return err
+	}
 	if err := seedRoborevReviews(tx); err != nil {
 		return err
 	}
@@ -205,7 +215,7 @@ func seedRoborevRepos(tx *sql.Tx) error {
 }
 
 func seedRoborevCommits(tx *sql.Tx) error {
-	for i := 1; i <= 76; i++ {
+	for i := 1; i <= 79; i++ {
 		repoID := 1
 		if i > 45 {
 			repoID = 2
@@ -550,6 +560,88 @@ func seedRoborevMutationFixtures(tx *sql.Tx) error {
 		}
 	}
 
+	return nil
+}
+
+func seedRoborevPanelFixtures(tx *sql.Tx) error {
+	type panelJob struct {
+		id          int
+		agent       string
+		model       string
+		status      string
+		jobType     string
+		panelRole   string
+		memberName  any
+		memberIndex any
+		tokenUsage  string
+	}
+
+	const runUUID = "panel-e2e-1"
+	jobs := []panelJob{
+		{
+			id:          77,
+			agent:       "codex",
+			model:       "gpt-5.4",
+			status:      "done",
+			jobType:     "review",
+			panelRole:   "member",
+			memberName:  "default",
+			memberIndex: 0,
+			tokenUsage:  `{"total_output_tokens":1200,"cost_usd":0.10,"has_cost":true}`,
+		},
+		{
+			id:          78,
+			agent:       "claude",
+			model:       "claude-sonnet-4-6",
+			status:      "failed",
+			jobType:     "review",
+			panelRole:   "member",
+			memberName:  "security",
+			memberIndex: 1,
+			tokenUsage:  `{"total_output_tokens":2400,"cost_usd":0.20,"has_cost":true}`,
+		},
+		{
+			id:          79,
+			agent:       "codex",
+			model:       "gpt-5.4",
+			status:      "done",
+			jobType:     "synthesis",
+			panelRole:   "synthesis",
+			memberName:  nil,
+			memberIndex: nil,
+			tokenUsage:  `{"total_output_tokens":600,"cost_usd":0.05,"has_cost":true}`,
+		},
+	}
+
+	for _, j := range jobs {
+		enq := jobTime(j.id)
+		started := enq.Add(2 * time.Minute)
+		finished := started.Add(4 * time.Minute)
+		_, err := tx.Exec(
+			`INSERT INTO review_jobs
+			 (id, repo_id, commit_id, git_ref, branch,
+			  agent, model, status, enqueued_at,
+			  started_at, finished_at, job_type, token_usage,
+			  panel_run_uuid, panel_role, panel_name,
+			  panel_member_name, panel_member_index,
+			  panel_member_config_json, claim_blocked)
+			 VALUES (?, 1, ?, 'panel-e2e-1', 'main',
+			         ?, ?, ?, ?, ?, ?, ?, ?,
+			         ?, ?, 'seeded review panel',
+			         ?, ?, '{}', 0)`,
+			j.id, j.id,
+			j.agent, j.model, j.status,
+			enq.Format(roborevTimeFmt),
+			started.Format(roborevTimeFmt),
+			finished.Format(roborevTimeFmt),
+			j.jobType, j.tokenUsage,
+			runUUID, j.panelRole,
+			j.memberName, j.memberIndex,
+		)
+		if err != nil {
+			return fmt.Errorf("insert panel job %d: %w", j.id, err)
+		}
+	}
 	return nil
 }
 

--- a/internal/testutil/roborev_fixtures.go
+++ b/internal/testutil/roborev_fixtures.go
@@ -128,7 +128,7 @@ var roborevBaseTime = time.Date(
 )
 
 // SeedRoborevDB creates a roborev-compatible SQLite database at path
-// with deterministic test data. The database contains 75 review jobs
+// with deterministic test data. The database contains 76 review jobs
 // across 2 repos, 5 branches, 3 agents, and all statuses.
 func SeedRoborevDB(path string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
@@ -205,7 +205,7 @@ func seedRoborevRepos(tx *sql.Tx) error {
 }
 
 func seedRoborevCommits(tx *sql.Tx) error {
-	for i := 1; i <= 75; i++ {
+	for i := 1; i <= 76; i++ {
 		repoID := 1
 		if i > 45 {
 			repoID = 2
@@ -231,7 +231,7 @@ func seedRoborevCommits(tx *sql.Tx) error {
 
 // Bulk jobs: IDs 1-69
 // IDs 1-45 in test-repo-alpha, IDs 46-69 in test-repo-beta.
-// Mutation fixtures (70-74) are inserted separately; we skip
+// Mutation fixtures (70-76) are inserted separately; we skip
 // IDs 70+ in the bulk insert to avoid conflicts.
 func seedRoborevBulkJobs(tx *sql.Tx) error {
 	type agentSpec struct {
@@ -502,6 +502,27 @@ func seedRoborevMutationFixtures(tx *sql.Tx) error {
 	)
 	if err != nil {
 		return fmt.Errorf("insert mutation job 75: %w", err)
+	}
+
+	// ID 76: failed auto-design classifier byproduct. It should be
+	// hidden by the same default filter as skipped auto-design rows.
+	enq76 := jobTime(76)
+	_, err = tx.Exec(
+		`INSERT INTO review_jobs
+		 (id, repo_id, commit_id, git_ref, branch,
+		  agent, model, status,
+		  enqueued_at, started_at, finished_at, error,
+		  job_type, review_type, source)
+		 VALUES (76, 1, 76, 'auto-design-classify', 'main',
+		         'auto-design', '', 'failed', ?, ?, ?,
+		         'classifier unavailable', 'classify', 'design',
+		         'auto_design')`,
+		enq76.Format(roborevTimeFmt),
+		enq76.Add(2*time.Minute).Format(roborevTimeFmt),
+		enq76.Add(3*time.Minute).Format(roborevTimeFmt),
+	)
+	if err != nil {
+		return fmt.Errorf("insert mutation job 76: %w", err)
 	}
 
 	// Reviews for mutation jobs 71 and 72 (fail, open)

--- a/internal/testutil/roborev_fixtures.go
+++ b/internal/testutil/roborev_fixtures.go
@@ -46,7 +46,7 @@ CREATE TABLE IF NOT EXISTS review_jobs (
   requested_provider TEXT,
   reasoning TEXT NOT NULL DEFAULT 'thorough',
   status TEXT NOT NULL CHECK(status IN (
-    'queued','running','done','failed','canceled','applied','rebased'
+    'queued','running','done','failed','canceled','applied','rebased','skipped'
   )) DEFAULT 'queued',
   enqueued_at TEXT NOT NULL DEFAULT (datetime('now')),
   started_at TEXT,
@@ -60,6 +60,8 @@ CREATE TABLE IF NOT EXISTS review_jobs (
   job_type TEXT NOT NULL DEFAULT 'review',
   review_type TEXT NOT NULL DEFAULT '',
   provider TEXT,
+  skip_reason TEXT,
+  source TEXT,
   token_usage TEXT,
   uuid TEXT,
   agentic INTEGER NOT NULL DEFAULT 0,
@@ -126,7 +128,7 @@ var roborevBaseTime = time.Date(
 )
 
 // SeedRoborevDB creates a roborev-compatible SQLite database at path
-// with deterministic test data. The database contains ~75 review jobs
+// with deterministic test data. The database contains 75 review jobs
 // across 2 repos, 5 branches, 3 agents, and all statuses.
 func SeedRoborevDB(path string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
@@ -478,6 +480,28 @@ func seedRoborevMutationFixtures(tx *sql.Tx) error {
 	)
 	if err != nil {
 		return fmt.Errorf("insert mutation job 74: %w", err)
+	}
+
+	// ID 75: skipped auto-design byproduct. It should be hidden
+	// by default via hide_classify_jobs=true, then visible when
+	// the Reviews UI opts in to auto-design rows.
+	enq75 := jobTime(75)
+	_, err = tx.Exec(
+		`INSERT INTO review_jobs
+		 (id, repo_id, commit_id, git_ref, branch,
+		  agent, model, status,
+		  enqueued_at, started_at, finished_at, job_type,
+		  review_type, skip_reason, source)
+		 VALUES (75, 1, 75, 'auto-design-skip', 'main',
+		         'auto-design', '', 'skipped', ?, ?, ?,
+		         'review', 'design', 'trivial diff',
+		         'auto_design')`,
+		enq75.Format(roborevTimeFmt),
+		enq75.Add(2*time.Minute).Format(roborevTimeFmt),
+		enq75.Add(2*time.Minute).Format(roborevTimeFmt),
+	)
+	if err != nil {
+		return fmt.Errorf("insert mutation job 75: %w", err)
 	}
 
 	// Reviews for mutation jobs 71 and 72 (fail, open)

--- a/packages/ui/src/api/roborev/generated/schema.ts
+++ b/packages/ui/src/api/roborev/generated/schema.ts
@@ -4,6 +4,23 @@
  */
 
 export interface paths {
+    "/api/activity": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List recent daemon activity */
+        get: operations["list-activity"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/branches": {
         parameters: {
             query?: never;
@@ -55,6 +72,91 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/cost": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get aggregate review cost */
+        get: operations["get-cost"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/enqueue": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Enqueue a daemon job */
+        post: operations["enqueue-job"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/export/reviews": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Export completed reviews */
+        get: operations["export-reviews"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/health": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get daemon health */
+        get: operations["get-health"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/job/applied": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Mark a fix job as applied */
+        post: operations["mark-job-applied"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/job/cancel": {
         parameters: {
             query?: never;
@@ -72,6 +174,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/job/fix": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create a background fix job */
+        post: operations["create-fix-job"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/job/log": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get raw job log bytes */
+        get: operations["get-job-log"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/job/output": {
         parameters: {
             query?: never;
@@ -79,10 +215,44 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get live output for a running job */
+        /** Get or stream in-memory job output */
         get: operations["get-job-output"];
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/job/patch": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a stored fix patch */
+        get: operations["get-job-patch"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/job/rebased": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Mark a fix job as rebased */
+        post: operations["mark-job-rebased"];
         delete?: never;
         options?: never;
         head?: never;
@@ -106,6 +276,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/job/update-branch": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Update a job branch */
+        post: operations["update-job-branch"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/jobs": {
         parameters: {
             query?: never;
@@ -123,6 +310,91 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/jobs/batch": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Fetch jobs with reviews by ID */
+        post: operations["batch-jobs"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/ping": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get daemon liveness identity */
+        get: operations["ping"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/queue/pause": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Pause queue processing */
+        post: operations["pause-queue"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/queue/unpause": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Resume queue processing */
+        post: operations["unpause-queue"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/remap": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Remap jobs after git history rewrite */
+        post: operations["remap-jobs"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/repos": {
         parameters: {
             query?: never;
@@ -132,6 +404,40 @@ export interface paths {
         };
         /** List repos with job counts */
         get: operations["list-repos"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/repos/register": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Register a repository */
+        post: operations["register-repo"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/repos/resolve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Resolve whether a path belongs to a tracked repo */
+        get: operations["resolve-repo"];
         put?: never;
         post?: never;
         delete?: never;
@@ -174,6 +480,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/shutdown": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Gracefully shut down the daemon */
+        post: operations["shutdown"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/status": {
         parameters: {
             query?: never;
@@ -183,6 +506,23 @@ export interface paths {
         };
         /** Get daemon status */
         get: operations["get-status"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/stream/events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Stream daemon events */
+        get: operations["stream-events"];
         put?: never;
         post?: never;
         delete?: never;
@@ -208,10 +548,80 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/sync/now": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Run an immediate sync */
+        post: operations["sync-now"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/sync/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get sync worker status */
+        get: operations["get-sync-status"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/tokens/backfill": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Backfill token usage from AgentsView payloads */
+        post: operations["backfill-tokens"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        ActivityEntry: {
+            component: string;
+            details?: {
+                [key: string]: string;
+            };
+            event: string;
+            message: string;
+            /** Format: date-time */
+            ts: string;
+        };
+        ActivityOutputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/ActivityOutputBody.json
+             */
+            readonly $schema?: string;
+            entries: components["schemas"]["ActivityEntry"][] | null;
+        };
         AddCommentRequest: {
             /**
              * Format: uri
@@ -239,6 +649,49 @@ export interface components {
             passed: number;
             /** Format: int64 */
             total: number;
+        };
+        AutoDesignStatus: {
+            /** Format: int64 */
+            classifier_failed: number;
+            enabled: boolean;
+            /** Format: int64 */
+            skipped_classifier: number;
+            /** Format: int64 */
+            skipped_heuristic: number;
+            /** Format: int64 */
+            triggered_classifier: number;
+            /** Format: int64 */
+            triggered_heuristic: number;
+        };
+        BackfillTokensRequest: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/BackfillTokensRequest.json
+             */
+            readonly $schema?: string;
+            dry_run?: boolean;
+            sessions: components["schemas"]["SessionUsagePayload"][] | null;
+        };
+        BatchJobsOutputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/BatchJobsOutputBody.json
+             */
+            readonly $schema?: string;
+            results: {
+                [key: string]: components["schemas"]["JobWithReview"];
+            };
+        };
+        BatchJobsRequest: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/BatchJobsRequest.json
+             */
+            readonly $schema?: string;
+            job_ids: number[] | null;
         };
         BranchWithCount: {
             /** Format: int64 */
@@ -284,6 +737,26 @@ export interface components {
             /** Format: int64 */
             job_id: number;
         };
+        ComponentHealth: {
+            healthy: boolean;
+            message?: string;
+            name: string;
+        };
+        CostAggregate: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/CostAggregate.json
+             */
+            readonly $schema?: string;
+            complete: boolean;
+            /** Format: int64 */
+            jobs_total: number;
+            /** Format: int64 */
+            jobs_with_cost: number;
+            /** Format: double */
+            total_usd: number;
+        };
         DaemonStatus: {
             /**
              * Format: uri
@@ -293,8 +766,10 @@ export interface components {
             readonly $schema?: string;
             /** Format: int64 */
             active_workers: number;
+            address?: string;
             /** Format: int64 */
             applied_jobs: number;
+            auto_design?: components["schemas"]["AutoDesignStatus"];
             /** Format: int64 */
             canceled_jobs: number;
             /** Format: int64 */
@@ -307,12 +782,18 @@ export interface components {
             machine_id?: string;
             /** Format: int64 */
             max_workers: number;
+            network?: string;
+            /** Format: int64 */
+            port?: number;
+            queue_paused: boolean;
             /** Format: int64 */
             queued_jobs: number;
             /** Format: int64 */
             rebased_jobs: number;
             /** Format: int64 */
             running_jobs: number;
+            /** Format: int64 */
+            skipped_jobs: number;
             version: string;
         };
         DurationStats: {
@@ -329,6 +810,37 @@ export interface components {
             /** Format: double */
             review_p99_secs: number;
         };
+        EnqueueRequest: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/EnqueueRequest.json
+             */
+            readonly $schema?: string;
+            agent?: string;
+            agentic?: boolean;
+            branch?: string;
+            commit_sha?: string;
+            custom_prompt?: string;
+            diff_content?: string;
+            dirty_files?: string[] | null;
+            git_ref?: string;
+            job_type?: string;
+            min_severity?: string;
+            model?: string;
+            output_prefix?: string;
+            panel?: string;
+            provider?: string;
+            reasoning?: string;
+            repo_path: string;
+            review_type?: string;
+            since?: string;
+            source?: string;
+        };
+        EnqueueSkippedResponse: {
+            reason: string;
+            skipped: boolean;
+        };
         ErrorDetail: {
             /** @description Where the error occurred, e.g. 'body.items[3].tags' or 'path.thing-id' */
             location?: string;
@@ -336,6 +848,15 @@ export interface components {
             message?: string;
             /** @description The value at the given location */
             value?: unknown;
+        };
+        ErrorEntry: {
+            component: string;
+            /** Format: int64 */
+            job_id?: number;
+            level: string;
+            message: string;
+            /** Format: date-time */
+            ts: string;
         };
         ErrorModel: {
             /**
@@ -376,6 +897,84 @@ export interface components {
              */
             type: string;
         };
+        ErrorResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/ErrorResponse.json
+             */
+            readonly $schema?: string;
+            error: string;
+        };
+        ExportReview: {
+            agent: string;
+            branch: string | null;
+            commit_sha: string | null;
+            completed_at: string;
+            content: string | null;
+            cost: components["schemas"]["ExportReviewCost"];
+            created_at: string;
+            /** Format: int64 */
+            duration_ms: number | null;
+            model: string | null;
+            /** Format: int64 */
+            pr_number: number | null;
+            pr_url: string | null;
+            project: string;
+            repo: string;
+            review_id: string;
+            status: string;
+            subagents: components["schemas"]["ExportSubagent"][] | null;
+            verdict: string;
+        };
+        ExportReviewCost: {
+            /** Format: int64 */
+            tokens_in: number | null;
+            /** Format: int64 */
+            tokens_out: number | null;
+            /** Format: double */
+            usd: number | null;
+        };
+        ExportReviewsDocument: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/ExportReviewsDocument.json
+             */
+            readonly $schema?: string;
+            /** @description Stable identity for the local review database; changes when the database is recreated. */
+            database_id: string;
+            generated_at: string;
+            /** @description Opaque resume cursor emitted when reviews is non-empty; pass as cursor to resume after the last returned review. */
+            next_cursor: string | null;
+            profile: string;
+            reviews: components["schemas"]["ExportReview"][] | null;
+            /** Format: int64 */
+            schema_version: number;
+            tool: string;
+            tool_version: string;
+            /** @description True when more matching rows are available immediately. */
+            truncated: boolean;
+            window: components["schemas"]["ExportReviewsWindow"];
+        };
+        ExportReviewsWindow: {
+            field: string;
+            since: string | null;
+            until: string | null;
+        };
+        ExportSubagent: {
+            agent: string;
+            completed_at: string;
+            content: string | null;
+            cost: components["schemas"]["ExportReviewCost"];
+            /** Format: int64 */
+            duration_ms: number | null;
+            model: string | null;
+            name: string;
+            review_id: string;
+            review_type: string | null;
+            verdict: string;
+        };
         FailureStats: {
             errors: {
                 [key: string]: number;
@@ -385,18 +984,44 @@ export interface components {
             /** Format: int64 */
             total: number;
         };
-        JobOutputResponse: {
+        FixJobRequest: {
             /**
              * Format: uri
              * @description A URL to the JSON Schema for this object.
-             * @example https://example.com/JobOutputResponse.json
+             * @example https://example.com/FixJobRequest.json
              */
             readonly $schema?: string;
-            has_more: boolean;
+            git_ref?: string;
+            /** Format: int64 */
+            parent_job_id: number;
+            prompt?: string;
+            /** Format: int64 */
+            stale_job_id?: number;
+        };
+        HealthStatus: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/HealthStatus.json
+             */
+            readonly $schema?: string;
+            components: components["schemas"]["ComponentHealth"][] | null;
+            /** Format: int64 */
+            error_count_24h: number;
+            healthy: boolean;
+            recent_errors: components["schemas"]["ErrorEntry"][] | null;
+            uptime: string;
+            version: string;
+        };
+        JobIDRequest: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/JobIDRequest.json
+             */
+            readonly $schema?: string;
             /** Format: int64 */
             job_id: number;
-            lines: components["schemas"]["OutputLine"][] | null;
-            status: string;
         };
         JobStats: {
             /** Format: int64 */
@@ -406,6 +1031,15 @@ export interface components {
             /** Format: int64 */
             open: number;
         };
+        JobStatusOutputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/JobStatusOutputBody.json
+             */
+            readonly $schema?: string;
+            status: string;
+        };
         JobTypeStats: {
             /** Format: int64 */
             applied?: number;
@@ -414,6 +1048,10 @@ export interface components {
             /** Format: int64 */
             rebased?: number;
             type: string;
+        };
+        JobWithReview: {
+            job: components["schemas"]["ReviewJob"];
+            review?: components["schemas"]["Review"];
         };
         ListBranchesOutputBody: {
             /**
@@ -446,7 +1084,7 @@ export interface components {
             readonly $schema?: string;
             has_more: boolean;
             jobs: components["schemas"]["ReviewJob"][] | null;
-            stats: components["schemas"]["JobStats"];
+            stats?: components["schemas"]["JobStats"];
         };
         ListReposOutputBody: {
             /**
@@ -458,12 +1096,6 @@ export interface components {
             repos: components["schemas"]["RepoWithCount"][] | null;
             /** Format: int64 */
             total_count: number;
-        };
-        OutputLine: {
-            line_type: string;
-            text: string;
-            /** Format: date-time */
-            ts: string;
         };
         OverviewStats: {
             /** Format: int64 */
@@ -483,6 +1115,104 @@ export interface components {
             /** Format: int64 */
             total: number;
         };
+        PanelSummary: {
+            /** Format: date-time */
+            first_started_at?: string;
+            /** Format: int64 */
+            members_canceled: number;
+            members_cost_complete?: boolean;
+            /** Format: double */
+            members_cost_usd?: number;
+            /** Format: int64 */
+            members_failed: number;
+            /** Format: int64 */
+            members_skipped: number;
+            /** Format: int64 */
+            members_succeeded: number;
+            /** Format: int64 */
+            members_terminal: number;
+            /** Format: int64 */
+            members_total: number;
+            /** Format: int64 */
+            members_with_cost?: number;
+            panel_run_uuid: string;
+        };
+        PingInfo: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/PingInfo.json
+             */
+            readonly $schema?: string;
+            ok: boolean;
+            /** Format: int64 */
+            pid?: number;
+            service: string;
+            version: string;
+        };
+        QueuePauseOutputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/QueuePauseOutputBody.json
+             */
+            readonly $schema?: string;
+            queue_paused: boolean;
+        };
+        RegisterRepoRequest: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/RegisterRepoRequest.json
+             */
+            readonly $schema?: string;
+            repo_path: string;
+        };
+        RemapMapping: {
+            author: string;
+            new_sha: string;
+            old_sha: string;
+            patch_id: string;
+            subject: string;
+            timestamp: string;
+        };
+        RemapRequest: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/RemapRequest.json
+             */
+            readonly $schema?: string;
+            mappings: components["schemas"]["RemapMapping"][] | null;
+            repo_path: string;
+        };
+        RemapResult: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/RemapResult.json
+             */
+            readonly $schema?: string;
+            /** Format: int64 */
+            remapped: number;
+            /** Format: int64 */
+            skipped: number;
+        };
+        Repo: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/Repo.json
+             */
+            readonly $schema?: string;
+            /** Format: date-time */
+            created_at: string;
+            /** Format: int64 */
+            id: number;
+            identity?: string;
+            name: string;
+            root_path: string;
+        };
         RepoSummary: {
             /** Format: int64 */
             addressed: number;
@@ -498,6 +1228,7 @@ export interface components {
         RepoWithCount: {
             /** Format: int64 */
             count: number;
+            identity?: string;
             name: string;
             root_path: string;
         };
@@ -519,6 +1250,21 @@ export interface components {
             readonly $schema?: string;
             /** Format: int64 */
             job_id: number;
+        };
+        ResolveRepoOutputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/ResolveRepoOutputBody.json
+             */
+            readonly $schema?: string;
+            repo?: components["schemas"]["ResolvedRepo"];
+            tracked: boolean;
+        };
+        ResolvedRepo: {
+            identity: string;
+            name: string;
+            root_path: string;
         };
         Response: {
             /**
@@ -570,14 +1316,25 @@ export interface components {
             verdict_bool?: number;
         };
         ReviewJob: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/ReviewJob.json
+             */
+            readonly $schema?: string;
             agent: string;
             agentic: boolean;
+            backup_agent?: string;
+            backup_model?: string;
             branch?: string;
+            claim_blocked?: boolean;
             closed?: boolean;
+            command_line?: string;
             /** Format: int64 */
             commit_id?: number;
             commit_subject?: string;
             diff_content?: string;
+            dirty_files?: string[] | null;
             /** Format: date-time */
             enqueued_at: string;
             error?: string;
@@ -587,8 +1344,17 @@ export interface components {
             /** Format: int64 */
             id: number;
             job_type: string;
+            min_severity?: string;
             model?: string;
             output_prefix?: string;
+            panel_member_config_json?: string;
+            /** Format: int64 */
+            panel_member_index?: number;
+            panel_member_name?: string;
+            panel_name?: string;
+            panel_role?: string;
+            panel_run_uuid?: string;
+            panel_summary?: components["schemas"]["PanelSummary"];
             /** Format: int64 */
             parent_job_id?: number;
             patch?: string;
@@ -607,6 +1373,8 @@ export interface components {
             retry_count: number;
             review_type?: string;
             session_id?: string;
+            skip_reason?: string;
+            source?: string;
             source_machine_id?: string;
             /** Format: date-time */
             started_at?: string;
@@ -621,6 +1389,32 @@ export interface components {
             worker_id?: string;
             worktree_path?: string;
         };
+        SessionUsagePayload: {
+            agent?: string;
+            /** Format: int64 */
+            cached_input_tokens?: number;
+            /** Format: double */
+            cost_usd?: number;
+            has_cost: boolean | null;
+            has_token_data: boolean | null;
+            /** Format: int64 */
+            input_tokens?: number;
+            /** Format: int64 */
+            peak_context_tokens?: number;
+            project?: string;
+            session_id: string;
+            /** Format: int64 */
+            total_output_tokens?: number;
+        };
+        ShutdownOutputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/ShutdownOutputBody.json
+             */
+            readonly $schema?: string;
+            status: string;
+        };
         Summary: {
             /**
              * Format: uri
@@ -630,6 +1424,7 @@ export interface components {
             readonly $schema?: string;
             agents: components["schemas"]["AgentStats"][] | null;
             branch?: string;
+            cost: components["schemas"]["CostAggregate"];
             duration: components["schemas"]["DurationStats"];
             failures: components["schemas"]["FailureStats"];
             job_types: components["schemas"]["JobTypeStats"][] | null;
@@ -639,6 +1434,64 @@ export interface components {
             /** Format: date-time */
             since: string;
             verdicts: components["schemas"]["VerdictStats"];
+        };
+        SyncStatusOutputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/SyncStatusOutputBody.json
+             */
+            readonly $schema?: string;
+            connected: boolean;
+            enabled: boolean;
+            message: string;
+        };
+        TokenResult: {
+            agent?: string;
+            /** Format: int64 */
+            job_id?: number;
+            reason?: string;
+            session_id: string;
+            status: string;
+            summary?: string;
+        };
+        TokenSummary: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/TokenSummary.json
+             */
+            readonly $schema?: string;
+            /** Format: int64 */
+            failed: number;
+            results: components["schemas"]["TokenResult"][] | null;
+            /** Format: int64 */
+            skipped: number;
+            /** Format: int64 */
+            total: number;
+            /** Format: int64 */
+            updated: number;
+        };
+        UpdateJobBranchOutputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/UpdateJobBranchOutputBody.json
+             */
+            readonly $schema?: string;
+            success: boolean;
+            updated: boolean;
+        };
+        UpdateJobBranchRequest: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/UpdateJobBranchRequest.json
+             */
+            readonly $schema?: string;
+            branch: string;
+            /** Format: int64 */
+            job_id: number;
         };
         VerdictStats: {
             /** Format: int64 */
@@ -663,6 +1516,38 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+    "list-activity": {
+        parameters: {
+            query?: {
+                /** @description Maximum entries to return */
+                limit?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ActivityOutputBody"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
     "list-branches": {
         parameters: {
             query?: {
@@ -764,6 +1649,227 @@ export interface operations {
             };
         };
     };
+    "get-cost": {
+        parameters: {
+            query?: {
+                /** @description Repo root paths (repeatable) */
+                repo?: string[] | null;
+                /** @description Filter by branch name */
+                branch?: string;
+                /** @description Only jobs with empty/unset branch */
+                branch_empty?: "true" | "false";
+                /** @description Time window (e.g. 7d); default all-time */
+                since?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CostAggregate"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    "enqueue-job": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EnqueueRequest"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReviewJob"] | components["schemas"]["EnqueueSkippedResponse"];
+                };
+            };
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReviewJob"] | components["schemas"]["EnqueueSkippedResponse"];
+                };
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            413: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    "export-reviews": {
+        parameters: {
+            query?: {
+                /** @description Output format; only json is supported */
+                format?: string;
+                /** @description Export profile: content or metadata */
+                profile?: string;
+                /** @description Inclusive completed_at lower bound (RFC3339 or YYYY-MM-DD) */
+                since?: string;
+                /** @description Exclusive completed_at upper bound (RFC3339 or YYYY-MM-DD; date-only means through that UTC day) */
+                until?: string;
+                /** @description Only include reviews marked closed */
+                closed_only?: boolean;
+                /** @description Exact exported repo identifier filter */
+                repo?: string;
+                /** @description Exact project display-name filter */
+                project?: string;
+                /** @description Maximum top-level reviews in this page */
+                limit?: number;
+                /** @description Opaque next_cursor from a previous page. Resumes strictly after its (completed_at, review_id) position; mutually exclusive with since. */
+                cursor?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ExportReviewsDocument"];
+                };
+            };
+            /** @description Cursor database_id does not match this local database */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    "get-health": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HealthStatus"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    "mark-job-applied": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["JobIDRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JobStatusOutputBody"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
     "cancel-job": {
         parameters: {
             query?: never;
@@ -797,11 +1903,69 @@ export interface operations {
             };
         };
     };
-    "get-job-output": {
+    "create-fix-job": {
         parameters: {
-            query: {
-                /** @description Job ID to fetch output for */
-                job_id: number;
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["FixJobRequest"];
+            };
+        };
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReviewJob"];
+                };
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    "get-job-log": {
+        parameters: {
+            query?: {
+                /** @description Job ID */
+                job_id?: string;
+                /** @description Byte offset into the log file */
+                offset?: string;
             };
             header?: never;
             path?: never;
@@ -814,8 +1978,101 @@ export interface operations {
                 headers: {
                     [name: string]: unknown;
                 };
+                content?: never;
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
                 content: {
-                    "application/json": components["schemas"]["JobOutputResponse"];
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    "get-job-output": {
+        parameters: {
+            query?: {
+                /** @description Job ID */
+                job_id?: string;
+                /** @description Stream output as NDJSON when set to 1 */
+                stream?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    "get-job-patch": {
+        parameters: {
+            query?: {
+                /** @description Job ID */
+                job_id?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    "mark-job-rebased": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["JobIDRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JobStatusOutputBody"];
                 };
             };
             /** @description Error */
@@ -862,6 +2119,39 @@ export interface operations {
             };
         };
     };
+    "update-job-branch": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateJobBranchRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UpdateJobBranchOutputBody"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
     "list-jobs": {
         parameters: {
             query?: {
@@ -869,8 +2159,8 @@ export interface operations {
                 id?: number;
                 /** @description Filter by job status */
                 status?: string;
-                /** @description Filter by repo root path */
-                repo?: string;
+                /** @description Filter by repo root path (repeatable) */
+                repo?: string[] | null;
                 /** @description Filter by git ref */
                 git_ref?: string;
                 /** @description Filter by branch name */
@@ -883,6 +2173,12 @@ export interface operations {
                 job_type?: string;
                 /** @description Exclude jobs of this type */
                 exclude_job_type?: string;
+                /** @description Hide auto-design-router rows (job_type=classify and status=skipped) */
+                hide_classify_jobs?: "true" | "false" | "";
+                /** @description Return all jobs (members + synthesis) of one panel run */
+                panel_run?: string;
+                /** @description Omit prompt and diff content from returned jobs (metadata-only listing) */
+                omit_prompt?: "true" | "false" | "";
                 /** @description Filter repos by path prefix */
                 repo_prefix?: string;
                 /** @description Max results (default 50, 0=unlimited, max 10000) */
@@ -918,6 +2214,159 @@ export interface operations {
             };
         };
     };
+    "batch-jobs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BatchJobsRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BatchJobsOutputBody"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    ping: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PingInfo"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    "pause-queue": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["QueuePauseOutputBody"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    "unpause-queue": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["QueuePauseOutputBody"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    "remap-jobs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RemapRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RemapResult"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
     "list-repos": {
         parameters: {
             query?: {
@@ -939,6 +2388,71 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ListReposOutputBody"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    "register-repo": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RegisterRepoRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Repo"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    "resolve-repo": {
+        parameters: {
+            query?: {
+                /** @description Absolute path or path inside a repository */
+                path?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ResolveRepoOutputBody"];
                 };
             };
             /** @description Error */
@@ -1019,6 +2533,35 @@ export interface operations {
             };
         };
     };
+    shutdown: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ShutdownOutputBody"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
     "get-status": {
         parameters: {
             query?: never;
@@ -1036,6 +2579,36 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["DaemonStatus"];
                 };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    "stream-events": {
+        parameters: {
+            query?: {
+                /** @description Filter events by repo root path */
+                repo?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Error */
             default: {
@@ -1082,6 +2655,105 @@ export interface operations {
                 };
                 content: {
                     "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    "sync-now": {
+        parameters: {
+            query?: {
+                /** @description Stream sync progress as NDJSON when set to 1 */
+                stream?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    "get-sync-status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SyncStatusOutputBody"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    "backfill-tokens": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BackfillTokensRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TokenSummary"];
+                };
+            };
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
         };

--- a/packages/ui/src/api/roborev/openapi.json
+++ b/packages/ui/src/api/roborev/openapi.json
@@ -1,12 +1,59 @@
 {
   "components": {
     "schemas": {
+      "ActivityEntry": {
+        "additionalProperties": false,
+        "properties": {
+          "component": {
+            "type": "string"
+          },
+          "details": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "event": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "ts": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": ["ts", "event", "component", "message"],
+        "type": "object"
+      },
+      "ActivityOutputBody": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "example": "https://example.com/ActivityOutputBody.json",
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "entries": {
+            "items": {
+              "$ref": "#/components/schemas/ActivityEntry"
+            },
+            "nullable": true,
+            "type": "array"
+          }
+        },
+        "required": ["entries"],
+        "type": "object"
+      },
       "AddCommentRequest": {
         "additionalProperties": false,
         "properties": {
           "$schema": {
             "description": "A URL to the JSON Schema for this object.",
-            "examples": ["https://example.com/AddCommentRequest.json"],
+            "example": "https://example.com/AddCommentRequest.json",
             "format": "uri",
             "readOnly": true,
             "type": "string"
@@ -62,6 +109,109 @@
         "required": ["agent", "total", "passed", "failed", "errors", "pass_rate", "median_duration_secs"],
         "type": "object"
       },
+      "AutoDesignStatus": {
+        "additionalProperties": false,
+        "properties": {
+          "classifier_failed": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "skipped_classifier": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "skipped_heuristic": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "triggered_classifier": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "triggered_heuristic": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "enabled",
+          "triggered_heuristic",
+          "skipped_heuristic",
+          "triggered_classifier",
+          "skipped_classifier",
+          "classifier_failed"
+        ],
+        "type": "object"
+      },
+      "BackfillTokensRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "example": "https://example.com/BackfillTokensRequest.json",
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "dry_run": {
+            "type": "boolean"
+          },
+          "sessions": {
+            "items": {
+              "$ref": "#/components/schemas/SessionUsagePayload"
+            },
+            "nullable": true,
+            "type": "array"
+          }
+        },
+        "required": ["sessions"],
+        "type": "object"
+      },
+      "BatchJobsOutputBody": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "example": "https://example.com/BatchJobsOutputBody.json",
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "results": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/JobWithReview"
+            },
+            "type": "object"
+          }
+        },
+        "required": ["results"],
+        "type": "object"
+      },
+      "BatchJobsRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "example": "https://example.com/BatchJobsRequest.json",
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "job_ids": {
+            "items": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "nullable": true,
+            "type": "array"
+          }
+        },
+        "required": ["job_ids"],
+        "type": "object"
+      },
       "BranchWithCount": {
         "additionalProperties": false,
         "properties": {
@@ -81,7 +231,7 @@
         "properties": {
           "$schema": {
             "description": "A URL to the JSON Schema for this object.",
-            "examples": ["https://example.com/CancelJobOutputBody.json"],
+            "example": "https://example.com/CancelJobOutputBody.json",
             "format": "uri",
             "readOnly": true,
             "type": "string"
@@ -98,7 +248,7 @@
         "properties": {
           "$schema": {
             "description": "A URL to the JSON Schema for this object.",
-            "examples": ["https://example.com/CancelJobRequest.json"],
+            "example": "https://example.com/CancelJobRequest.json",
             "format": "uri",
             "readOnly": true,
             "type": "string"
@@ -116,7 +266,7 @@
         "properties": {
           "$schema": {
             "description": "A URL to the JSON Schema for this object.",
-            "examples": ["https://example.com/CloseReviewOutputBody.json"],
+            "example": "https://example.com/CloseReviewOutputBody.json",
             "format": "uri",
             "readOnly": true,
             "type": "string"
@@ -133,7 +283,7 @@
         "properties": {
           "$schema": {
             "description": "A URL to the JSON Schema for this object.",
-            "examples": ["https://example.com/CloseReviewRequest.json"],
+            "example": "https://example.com/CloseReviewRequest.json",
             "format": "uri",
             "readOnly": true,
             "type": "string"
@@ -149,12 +299,57 @@
         "required": ["job_id", "closed"],
         "type": "object"
       },
+      "ComponentHealth": {
+        "additionalProperties": false,
+        "properties": {
+          "healthy": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": ["name", "healthy"],
+        "type": "object"
+      },
+      "CostAggregate": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "example": "https://example.com/CostAggregate.json",
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "complete": {
+            "type": "boolean"
+          },
+          "jobs_total": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "jobs_with_cost": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "total_usd": {
+            "format": "double",
+            "type": "number"
+          }
+        },
+        "required": ["total_usd", "jobs_with_cost", "jobs_total", "complete"],
+        "type": "object"
+      },
       "DaemonStatus": {
         "additionalProperties": false,
         "properties": {
           "$schema": {
             "description": "A URL to the JSON Schema for this object.",
-            "examples": ["https://example.com/DaemonStatus.json"],
+            "example": "https://example.com/DaemonStatus.json",
             "format": "uri",
             "readOnly": true,
             "type": "string"
@@ -163,9 +358,15 @@
             "format": "int64",
             "type": "integer"
           },
+          "address": {
+            "type": "string"
+          },
           "applied_jobs": {
             "format": "int64",
             "type": "integer"
+          },
+          "auto_design": {
+            "$ref": "#/components/schemas/AutoDesignStatus"
           },
           "canceled_jobs": {
             "format": "int64",
@@ -194,6 +395,16 @@
             "format": "int64",
             "type": "integer"
           },
+          "network": {
+            "type": "string"
+          },
+          "port": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "queue_paused": {
+            "type": "boolean"
+          },
           "queued_jobs": {
             "format": "int64",
             "type": "integer"
@@ -203,6 +414,10 @@
             "type": "integer"
           },
           "running_jobs": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "skipped_jobs": {
             "format": "int64",
             "type": "integer"
           },
@@ -219,8 +434,10 @@
           "canceled_jobs",
           "applied_jobs",
           "rebased_jobs",
+          "skipped_jobs",
           "active_workers",
-          "max_workers"
+          "max_workers",
+          "queue_paused"
         ],
         "type": "object"
       },
@@ -262,6 +479,94 @@
         ],
         "type": "object"
       },
+      "EnqueueRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "example": "https://example.com/EnqueueRequest.json",
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "agent": {
+            "type": "string"
+          },
+          "agentic": {
+            "type": "boolean"
+          },
+          "branch": {
+            "type": "string"
+          },
+          "commit_sha": {
+            "type": "string"
+          },
+          "custom_prompt": {
+            "type": "string"
+          },
+          "diff_content": {
+            "type": "string"
+          },
+          "dirty_files": {
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "git_ref": {
+            "type": "string"
+          },
+          "job_type": {
+            "type": "string"
+          },
+          "min_severity": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "output_prefix": {
+            "type": "string"
+          },
+          "panel": {
+            "type": "string"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "reasoning": {
+            "type": "string"
+          },
+          "repo_path": {
+            "type": "string"
+          },
+          "review_type": {
+            "type": "string"
+          },
+          "since": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          }
+        },
+        "required": ["repo_path"],
+        "type": "object"
+      },
+      "EnqueueSkippedResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "reason": {
+            "type": "string"
+          },
+          "skipped": {
+            "type": "boolean"
+          }
+        },
+        "required": ["skipped", "reason"],
+        "type": "object"
+      },
       "ErrorDetail": {
         "additionalProperties": false,
         "properties": {
@@ -279,19 +584,43 @@
         },
         "type": "object"
       },
+      "ErrorEntry": {
+        "additionalProperties": false,
+        "properties": {
+          "component": {
+            "type": "string"
+          },
+          "job_id": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "level": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "ts": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": ["ts", "level", "component", "message"],
+        "type": "object"
+      },
       "ErrorModel": {
         "additionalProperties": false,
         "properties": {
           "$schema": {
             "description": "A URL to the JSON Schema for this object.",
-            "examples": ["https://example.com/ErrorModel.json"],
+            "example": "https://example.com/ErrorModel.json",
             "format": "uri",
             "readOnly": true,
             "type": "string"
           },
           "detail": {
             "description": "A human-readable explanation specific to this occurrence of the problem.",
-            "examples": ["Property foo is required but is missing."],
+            "example": "Property foo is required but is missing.",
             "type": "string"
           },
           "errors": {
@@ -299,33 +628,297 @@
             "items": {
               "$ref": "#/components/schemas/ErrorDetail"
             },
-            "type": ["array", "null"]
+            "nullable": true,
+            "type": "array"
           },
           "instance": {
             "description": "A URI reference that identifies the specific occurrence of the problem.",
-            "examples": ["https://example.com/error-log/abc123"],
+            "example": "https://example.com/error-log/abc123",
             "format": "uri",
             "type": "string"
           },
           "status": {
             "description": "HTTP status code",
-            "examples": [400],
+            "example": 400,
             "format": "int64",
             "type": "integer"
           },
           "title": {
             "description": "A short, human-readable summary of the problem type. This value should not change between occurrences of the error.",
-            "examples": ["Bad Request"],
+            "example": "Bad Request",
             "type": "string"
           },
           "type": {
             "default": "about:blank",
             "description": "A URI reference to human-readable documentation for the error.",
-            "examples": ["https://example.com/errors/example"],
+            "example": "https://example.com/errors/example",
             "format": "uri",
             "type": "string"
           }
         },
+        "type": "object"
+      },
+      "ErrorResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "example": "https://example.com/ErrorResponse.json",
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "error": {
+            "type": "string"
+          }
+        },
+        "required": ["error"],
+        "type": "object"
+      },
+      "ExportReview": {
+        "additionalProperties": false,
+        "properties": {
+          "agent": {
+            "type": "string"
+          },
+          "branch": {
+            "nullable": true,
+            "type": "string"
+          },
+          "commit_sha": {
+            "nullable": true,
+            "type": "string"
+          },
+          "completed_at": {
+            "type": "string"
+          },
+          "content": {
+            "nullable": true,
+            "type": "string"
+          },
+          "cost": {
+            "$ref": "#/components/schemas/ExportReviewCost"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "duration_ms": {
+            "format": "int64",
+            "nullable": true,
+            "type": "integer"
+          },
+          "model": {
+            "nullable": true,
+            "type": "string"
+          },
+          "pr_number": {
+            "format": "int64",
+            "nullable": true,
+            "type": "integer"
+          },
+          "pr_url": {
+            "nullable": true,
+            "type": "string"
+          },
+          "project": {
+            "type": "string"
+          },
+          "repo": {
+            "type": "string"
+          },
+          "review_id": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "subagents": {
+            "items": {
+              "$ref": "#/components/schemas/ExportSubagent"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "verdict": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "review_id",
+          "status",
+          "verdict",
+          "created_at",
+          "completed_at",
+          "duration_ms",
+          "project",
+          "repo",
+          "branch",
+          "commit_sha",
+          "pr_number",
+          "pr_url",
+          "agent",
+          "model",
+          "cost",
+          "content",
+          "subagents"
+        ],
+        "type": "object"
+      },
+      "ExportReviewCost": {
+        "additionalProperties": false,
+        "properties": {
+          "tokens_in": {
+            "format": "int64",
+            "nullable": true,
+            "type": "integer"
+          },
+          "tokens_out": {
+            "format": "int64",
+            "nullable": true,
+            "type": "integer"
+          },
+          "usd": {
+            "format": "double",
+            "nullable": true,
+            "type": "number"
+          }
+        },
+        "required": ["tokens_in", "tokens_out", "usd"],
+        "type": "object"
+      },
+      "ExportReviewsDocument": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "example": "https://example.com/ExportReviewsDocument.json",
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "database_id": {
+            "description": "Stable identity for the local review database; changes when the database is recreated.",
+            "type": "string"
+          },
+          "generated_at": {
+            "type": "string"
+          },
+          "next_cursor": {
+            "description": "Opaque resume cursor emitted when reviews is non-empty; pass as cursor to resume after the last returned review.",
+            "nullable": true,
+            "type": "string"
+          },
+          "profile": {
+            "type": "string"
+          },
+          "reviews": {
+            "items": {
+              "$ref": "#/components/schemas/ExportReview"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "schema_version": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "tool": {
+            "type": "string"
+          },
+          "tool_version": {
+            "type": "string"
+          },
+          "truncated": {
+            "description": "True when more matching rows are available immediately.",
+            "type": "boolean"
+          },
+          "window": {
+            "$ref": "#/components/schemas/ExportReviewsWindow"
+          }
+        },
+        "required": [
+          "schema_version",
+          "tool",
+          "tool_version",
+          "generated_at",
+          "database_id",
+          "profile",
+          "window",
+          "truncated",
+          "next_cursor",
+          "reviews"
+        ],
+        "type": "object"
+      },
+      "ExportReviewsWindow": {
+        "additionalProperties": false,
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "since": {
+            "nullable": true,
+            "type": "string"
+          },
+          "until": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": ["field", "since", "until"],
+        "type": "object"
+      },
+      "ExportSubagent": {
+        "additionalProperties": false,
+        "properties": {
+          "agent": {
+            "type": "string"
+          },
+          "completed_at": {
+            "type": "string"
+          },
+          "content": {
+            "nullable": true,
+            "type": "string"
+          },
+          "cost": {
+            "$ref": "#/components/schemas/ExportReviewCost"
+          },
+          "duration_ms": {
+            "format": "int64",
+            "nullable": true,
+            "type": "integer"
+          },
+          "model": {
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "review_id": {
+            "type": "string"
+          },
+          "review_type": {
+            "nullable": true,
+            "type": "string"
+          },
+          "verdict": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "review_id",
+          "name",
+          "agent",
+          "model",
+          "review_type",
+          "verdict",
+          "completed_at",
+          "duration_ms",
+          "cost",
+          "content"
+        ],
         "type": "object"
       },
       "FailureStats": {
@@ -350,34 +943,91 @@
         "required": ["total", "retries", "errors"],
         "type": "object"
       },
-      "JobOutputResponse": {
+      "FixJobRequest": {
         "additionalProperties": false,
         "properties": {
           "$schema": {
             "description": "A URL to the JSON Schema for this object.",
-            "examples": ["https://example.com/JobOutputResponse.json"],
+            "example": "https://example.com/FixJobRequest.json",
             "format": "uri",
             "readOnly": true,
             "type": "string"
           },
-          "has_more": {
+          "git_ref": {
+            "type": "string"
+          },
+          "parent_job_id": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "prompt": {
+            "type": "string"
+          },
+          "stale_job_id": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": ["parent_job_id"],
+        "type": "object"
+      },
+      "HealthStatus": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "example": "https://example.com/HealthStatus.json",
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "components": {
+            "items": {
+              "$ref": "#/components/schemas/ComponentHealth"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "error_count_24h": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "healthy": {
             "type": "boolean"
+          },
+          "recent_errors": {
+            "items": {
+              "$ref": "#/components/schemas/ErrorEntry"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "uptime": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "required": ["healthy", "uptime", "version", "components", "recent_errors", "error_count_24h"],
+        "type": "object"
+      },
+      "JobIDRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "example": "https://example.com/JobIDRequest.json",
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
           },
           "job_id": {
             "format": "int64",
             "type": "integer"
-          },
-          "lines": {
-            "items": {
-              "$ref": "#/components/schemas/OutputLine"
-            },
-            "type": ["array", "null"]
-          },
-          "status": {
-            "type": "string"
           }
         },
-        "required": ["job_id", "status", "lines", "has_more"],
+        "required": ["job_id"],
         "type": "object"
       },
       "JobStats": {
@@ -397,6 +1047,23 @@
           }
         },
         "required": ["done", "closed", "open"],
+        "type": "object"
+      },
+      "JobStatusOutputBody": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "example": "https://example.com/JobStatusOutputBody.json",
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          }
+        },
+        "required": ["status"],
         "type": "object"
       },
       "JobTypeStats": {
@@ -421,12 +1088,25 @@
         "required": ["type", "count"],
         "type": "object"
       },
+      "JobWithReview": {
+        "additionalProperties": false,
+        "properties": {
+          "job": {
+            "$ref": "#/components/schemas/ReviewJob"
+          },
+          "review": {
+            "$ref": "#/components/schemas/Review"
+          }
+        },
+        "required": ["job"],
+        "type": "object"
+      },
       "ListBranchesOutputBody": {
         "additionalProperties": false,
         "properties": {
           "$schema": {
             "description": "A URL to the JSON Schema for this object.",
-            "examples": ["https://example.com/ListBranchesOutputBody.json"],
+            "example": "https://example.com/ListBranchesOutputBody.json",
             "format": "uri",
             "readOnly": true,
             "type": "string"
@@ -435,7 +1115,8 @@
             "items": {
               "$ref": "#/components/schemas/BranchWithCount"
             },
-            "type": ["array", "null"]
+            "nullable": true,
+            "type": "array"
           },
           "nulls_remaining": {
             "format": "int64",
@@ -454,7 +1135,7 @@
         "properties": {
           "$schema": {
             "description": "A URL to the JSON Schema for this object.",
-            "examples": ["https://example.com/ListCommentsOutputBody.json"],
+            "example": "https://example.com/ListCommentsOutputBody.json",
             "format": "uri",
             "readOnly": true,
             "type": "string"
@@ -463,7 +1144,8 @@
             "items": {
               "$ref": "#/components/schemas/Response"
             },
-            "type": ["array", "null"]
+            "nullable": true,
+            "type": "array"
           }
         },
         "required": ["responses"],
@@ -474,7 +1156,7 @@
         "properties": {
           "$schema": {
             "description": "A URL to the JSON Schema for this object.",
-            "examples": ["https://example.com/ListJobsOutputBody.json"],
+            "example": "https://example.com/ListJobsOutputBody.json",
             "format": "uri",
             "readOnly": true,
             "type": "string"
@@ -486,13 +1168,14 @@
             "items": {
               "$ref": "#/components/schemas/ReviewJob"
             },
-            "type": ["array", "null"]
+            "nullable": true,
+            "type": "array"
           },
           "stats": {
             "$ref": "#/components/schemas/JobStats"
           }
         },
-        "required": ["jobs", "has_more", "stats"],
+        "required": ["jobs", "has_more"],
         "type": "object"
       },
       "ListReposOutputBody": {
@@ -500,7 +1183,7 @@
         "properties": {
           "$schema": {
             "description": "A URL to the JSON Schema for this object.",
-            "examples": ["https://example.com/ListReposOutputBody.json"],
+            "example": "https://example.com/ListReposOutputBody.json",
             "format": "uri",
             "readOnly": true,
             "type": "string"
@@ -509,7 +1192,8 @@
             "items": {
               "$ref": "#/components/schemas/RepoWithCount"
             },
-            "type": ["array", "null"]
+            "nullable": true,
+            "type": "array"
           },
           "total_count": {
             "format": "int64",
@@ -517,23 +1201,6 @@
           }
         },
         "required": ["repos", "total_count"],
-        "type": "object"
-      },
-      "OutputLine": {
-        "additionalProperties": false,
-        "properties": {
-          "line_type": {
-            "type": "string"
-          },
-          "text": {
-            "type": "string"
-          },
-          "ts": {
-            "format": "date-time",
-            "type": "string"
-          }
-        },
-        "required": ["ts", "text", "line_type"],
         "type": "object"
       },
       "OverviewStats": {
@@ -575,6 +1242,226 @@
         "required": ["total", "queued", "running", "done", "failed", "canceled", "applied", "rebased"],
         "type": "object"
       },
+      "PanelSummary": {
+        "additionalProperties": false,
+        "properties": {
+          "first_started_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "members_canceled": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "members_cost_complete": {
+            "type": "boolean"
+          },
+          "members_cost_usd": {
+            "format": "double",
+            "type": "number"
+          },
+          "members_failed": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "members_skipped": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "members_succeeded": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "members_terminal": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "members_total": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "members_with_cost": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "panel_run_uuid": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "panel_run_uuid",
+          "members_total",
+          "members_terminal",
+          "members_succeeded",
+          "members_failed",
+          "members_canceled",
+          "members_skipped"
+        ],
+        "type": "object"
+      },
+      "PingInfo": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "example": "https://example.com/PingInfo.json",
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "ok": {
+            "type": "boolean"
+          },
+          "pid": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "service": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "required": ["ok", "service", "version"],
+        "type": "object"
+      },
+      "QueuePauseOutputBody": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "example": "https://example.com/QueuePauseOutputBody.json",
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "queue_paused": {
+            "type": "boolean"
+          }
+        },
+        "required": ["queue_paused"],
+        "type": "object"
+      },
+      "RegisterRepoRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "example": "https://example.com/RegisterRepoRequest.json",
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "repo_path": {
+            "type": "string"
+          }
+        },
+        "required": ["repo_path"],
+        "type": "object"
+      },
+      "RemapMapping": {
+        "additionalProperties": false,
+        "properties": {
+          "author": {
+            "type": "string"
+          },
+          "new_sha": {
+            "type": "string"
+          },
+          "old_sha": {
+            "type": "string"
+          },
+          "patch_id": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "string"
+          }
+        },
+        "required": ["old_sha", "new_sha", "patch_id", "author", "subject", "timestamp"],
+        "type": "object"
+      },
+      "RemapRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "example": "https://example.com/RemapRequest.json",
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "mappings": {
+            "items": {
+              "$ref": "#/components/schemas/RemapMapping"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "repo_path": {
+            "type": "string"
+          }
+        },
+        "required": ["repo_path", "mappings"],
+        "type": "object"
+      },
+      "RemapResult": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "example": "https://example.com/RemapResult.json",
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "remapped": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "skipped": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": ["remapped", "skipped"],
+        "type": "object"
+      },
+      "Repo": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "example": "https://example.com/Repo.json",
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "created_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "id": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "identity": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "root_path": {
+            "type": "string"
+          }
+        },
+        "required": ["id", "root_path", "name", "created_at"],
+        "type": "object"
+      },
       "RepoSummary": {
         "additionalProperties": false,
         "properties": {
@@ -611,6 +1498,9 @@
             "format": "int64",
             "type": "integer"
           },
+          "identity": {
+            "type": "string"
+          },
           "name": {
             "type": "string"
           },
@@ -626,7 +1516,7 @@
         "properties": {
           "$schema": {
             "description": "A URL to the JSON Schema for this object.",
-            "examples": ["https://example.com/RerunJobOutputBody.json"],
+            "example": "https://example.com/RerunJobOutputBody.json",
             "format": "uri",
             "readOnly": true,
             "type": "string"
@@ -643,7 +1533,7 @@
         "properties": {
           "$schema": {
             "description": "A URL to the JSON Schema for this object.",
-            "examples": ["https://example.com/RerunJobRequest.json"],
+            "example": "https://example.com/RerunJobRequest.json",
             "format": "uri",
             "readOnly": true,
             "type": "string"
@@ -656,12 +1546,48 @@
         "required": ["job_id"],
         "type": "object"
       },
+      "ResolveRepoOutputBody": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "example": "https://example.com/ResolveRepoOutputBody.json",
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "repo": {
+            "$ref": "#/components/schemas/ResolvedRepo"
+          },
+          "tracked": {
+            "type": "boolean"
+          }
+        },
+        "required": ["tracked"],
+        "type": "object"
+      },
+      "ResolvedRepo": {
+        "additionalProperties": false,
+        "properties": {
+          "identity": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "root_path": {
+            "type": "string"
+          }
+        },
+        "required": ["root_path", "identity", "name"],
+        "type": "object"
+      },
       "Response": {
         "additionalProperties": false,
         "properties": {
           "$schema": {
             "description": "A URL to the JSON Schema for this object.",
-            "examples": ["https://example.com/Response.json"],
+            "example": "https://example.com/Response.json",
             "format": "uri",
             "readOnly": true,
             "type": "string"
@@ -707,7 +1633,7 @@
         "properties": {
           "$schema": {
             "description": "A URL to the JSON Schema for this object.",
-            "examples": ["https://example.com/Review.json"],
+            "example": "https://example.com/Review.json",
             "format": "uri",
             "readOnly": true,
             "type": "string"
@@ -764,17 +1690,36 @@
       "ReviewJob": {
         "additionalProperties": false,
         "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "example": "https://example.com/ReviewJob.json",
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
           "agent": {
             "type": "string"
           },
           "agentic": {
             "type": "boolean"
           },
+          "backup_agent": {
+            "type": "string"
+          },
+          "backup_model": {
+            "type": "string"
+          },
           "branch": {
             "type": "string"
           },
+          "claim_blocked": {
+            "type": "boolean"
+          },
           "closed": {
             "type": "boolean"
+          },
+          "command_line": {
+            "type": "string"
           },
           "commit_id": {
             "format": "int64",
@@ -785,6 +1730,13 @@
           },
           "diff_content": {
             "type": "string"
+          },
+          "dirty_files": {
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "type": "array"
           },
           "enqueued_at": {
             "format": "date-time",
@@ -807,11 +1759,36 @@
           "job_type": {
             "type": "string"
           },
+          "min_severity": {
+            "type": "string"
+          },
           "model": {
             "type": "string"
           },
           "output_prefix": {
             "type": "string"
+          },
+          "panel_member_config_json": {
+            "type": "string"
+          },
+          "panel_member_index": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "panel_member_name": {
+            "type": "string"
+          },
+          "panel_name": {
+            "type": "string"
+          },
+          "panel_role": {
+            "type": "string"
+          },
+          "panel_run_uuid": {
+            "type": "string"
+          },
+          "panel_summary": {
+            "$ref": "#/components/schemas/PanelSummary"
           },
           "parent_job_id": {
             "format": "int64",
@@ -859,6 +1836,12 @@
             "type": "string"
           },
           "session_id": {
+            "type": "string"
+          },
+          "skip_reason": {
+            "type": "string"
+          },
+          "source": {
             "type": "string"
           },
           "source_machine_id": {
@@ -909,12 +1892,73 @@
         ],
         "type": "object"
       },
+      "SessionUsagePayload": {
+        "additionalProperties": false,
+        "properties": {
+          "agent": {
+            "type": "string"
+          },
+          "cached_input_tokens": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "cost_usd": {
+            "format": "double",
+            "type": "number"
+          },
+          "has_cost": {
+            "nullable": true,
+            "type": "boolean"
+          },
+          "has_token_data": {
+            "nullable": true,
+            "type": "boolean"
+          },
+          "input_tokens": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "peak_context_tokens": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "project": {
+            "type": "string"
+          },
+          "session_id": {
+            "type": "string"
+          },
+          "total_output_tokens": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": ["session_id", "has_token_data", "has_cost"],
+        "type": "object"
+      },
+      "ShutdownOutputBody": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "example": "https://example.com/ShutdownOutputBody.json",
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          }
+        },
+        "required": ["status"],
+        "type": "object"
+      },
       "Summary": {
         "additionalProperties": false,
         "properties": {
           "$schema": {
             "description": "A URL to the JSON Schema for this object.",
-            "examples": ["https://example.com/Summary.json"],
+            "example": "https://example.com/Summary.json",
             "format": "uri",
             "readOnly": true,
             "type": "string"
@@ -923,10 +1967,14 @@
             "items": {
               "$ref": "#/components/schemas/AgentStats"
             },
-            "type": ["array", "null"]
+            "nullable": true,
+            "type": "array"
           },
           "branch": {
             "type": "string"
+          },
+          "cost": {
+            "$ref": "#/components/schemas/CostAggregate"
           },
           "duration": {
             "$ref": "#/components/schemas/DurationStats"
@@ -938,7 +1986,8 @@
             "items": {
               "$ref": "#/components/schemas/JobTypeStats"
             },
-            "type": ["array", "null"]
+            "nullable": true,
+            "type": "array"
           },
           "overview": {
             "$ref": "#/components/schemas/OverviewStats"
@@ -950,7 +1999,8 @@
             "items": {
               "$ref": "#/components/schemas/RepoSummary"
             },
-            "type": ["array", "null"]
+            "nullable": true,
+            "type": "array"
           },
           "since": {
             "format": "date-time",
@@ -960,7 +2010,134 @@
             "$ref": "#/components/schemas/VerdictStats"
           }
         },
-        "required": ["since", "overview", "verdicts", "agents", "duration", "job_types", "failures"],
+        "required": ["since", "overview", "verdicts", "agents", "duration", "job_types", "failures", "cost"],
+        "type": "object"
+      },
+      "SyncStatusOutputBody": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "example": "https://example.com/SyncStatusOutputBody.json",
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "connected": {
+            "type": "boolean"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": ["enabled", "connected", "message"],
+        "type": "object"
+      },
+      "TokenResult": {
+        "additionalProperties": false,
+        "properties": {
+          "agent": {
+            "type": "string"
+          },
+          "job_id": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "session_id": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          }
+        },
+        "required": ["session_id", "status"],
+        "type": "object"
+      },
+      "TokenSummary": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "example": "https://example.com/TokenSummary.json",
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "failed": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "results": {
+            "items": {
+              "$ref": "#/components/schemas/TokenResult"
+            },
+            "nullable": true,
+            "type": "array"
+          },
+          "skipped": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "total": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "updated": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": ["total", "updated", "skipped", "failed", "results"],
+        "type": "object"
+      },
+      "UpdateJobBranchOutputBody": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "example": "https://example.com/UpdateJobBranchOutputBody.json",
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "success": {
+            "type": "boolean"
+          },
+          "updated": {
+            "type": "boolean"
+          }
+        },
+        "required": ["success", "updated"],
+        "type": "object"
+      },
+      "UpdateJobBranchRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "example": "https://example.com/UpdateJobBranchRequest.json",
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "branch": {
+            "type": "string"
+          },
+          "job_id": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": ["job_id", "branch"],
         "type": "object"
       },
       "VerdictStats": {
@@ -1000,8 +2177,49 @@
     "title": "roborev",
     "version": "dev"
   },
-  "openapi": "3.1.0",
+  "openapi": "3.0.3",
   "paths": {
+    "/api/activity": {
+      "get": {
+        "operationId": "list-activity",
+        "parameters": [
+          {
+            "description": "Maximum entries to return",
+            "explode": false,
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "description": "Maximum entries to return",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityOutputBody"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "default": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "summary": "List recent daemon activity",
+        "tags": ["daemon"]
+      }
+    },
     "/api/branches": {
       "get": {
         "operationId": "list-branches",
@@ -1016,7 +2234,8 @@
               "items": {
                 "type": "string"
               },
-              "type": ["array", "null"]
+              "nullable": true,
+              "type": "array"
             }
           }
         ],
@@ -1095,7 +2314,7 @@
             "in": "query",
             "name": "job_id",
             "schema": {
-              "default": 0,
+              "default": -1,
               "description": "List comments by job ID",
               "format": "int64",
               "type": "integer"
@@ -1107,7 +2326,7 @@
             "in": "query",
             "name": "commit_id",
             "schema": {
-              "default": 0,
+              "default": -1,
               "description": "List comments by commit ID",
               "format": "int64",
               "type": "integer"
@@ -1150,6 +2369,373 @@
         "tags": ["comments"]
       }
     },
+    "/api/cost": {
+      "get": {
+        "operationId": "get-cost",
+        "parameters": [
+          {
+            "description": "Repo root paths (repeatable)",
+            "explode": true,
+            "in": "query",
+            "name": "repo",
+            "schema": {
+              "description": "Repo root paths (repeatable)",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true,
+              "type": "array"
+            }
+          },
+          {
+            "description": "Filter by branch name",
+            "explode": false,
+            "in": "query",
+            "name": "branch",
+            "schema": {
+              "description": "Filter by branch name",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Only jobs with empty/unset branch",
+            "explode": false,
+            "in": "query",
+            "name": "branch_empty",
+            "schema": {
+              "description": "Only jobs with empty/unset branch",
+              "enum": ["true", "false"],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Time window (e.g. 7d); default all-time",
+            "explode": false,
+            "in": "query",
+            "name": "since",
+            "schema": {
+              "description": "Time window (e.g. 7d); default all-time",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CostAggregate"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "default": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "summary": "Get aggregate review cost",
+        "tags": ["daemon"]
+      }
+    },
+    "/api/enqueue": {
+      "post": {
+        "operationId": "enqueue-job",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EnqueueRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ReviewJob"
+                    },
+                    {
+                      "$ref": "#/components/schemas/EnqueueSkippedResponse"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ReviewJob"
+                    },
+                    {
+                      "$ref": "#/components/schemas/EnqueueSkippedResponse"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Enqueue a daemon job",
+        "tags": ["jobs"]
+      }
+    },
+    "/api/export/reviews": {
+      "get": {
+        "operationId": "export-reviews",
+        "parameters": [
+          {
+            "description": "Output format; only json is supported",
+            "explode": false,
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "default": "json",
+              "description": "Output format; only json is supported",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Export profile: content or metadata",
+            "explode": false,
+            "in": "query",
+            "name": "profile",
+            "schema": {
+              "default": "content",
+              "description": "Export profile: content or metadata",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Inclusive completed_at lower bound (RFC3339 or YYYY-MM-DD)",
+            "explode": false,
+            "in": "query",
+            "name": "since",
+            "schema": {
+              "description": "Inclusive completed_at lower bound (RFC3339 or YYYY-MM-DD)",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Exclusive completed_at upper bound (RFC3339 or YYYY-MM-DD; date-only means through that UTC day)",
+            "explode": false,
+            "in": "query",
+            "name": "until",
+            "schema": {
+              "description": "Exclusive completed_at upper bound (RFC3339 or YYYY-MM-DD; date-only means through that UTC day)",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Only include reviews marked closed",
+            "explode": false,
+            "in": "query",
+            "name": "closed_only",
+            "schema": {
+              "description": "Only include reviews marked closed",
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Exact exported repo identifier filter",
+            "explode": false,
+            "in": "query",
+            "name": "repo",
+            "schema": {
+              "description": "Exact exported repo identifier filter",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Exact project display-name filter",
+            "explode": false,
+            "in": "query",
+            "name": "project",
+            "schema": {
+              "description": "Exact project display-name filter",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum top-level reviews in this page",
+            "explode": false,
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "default": 500,
+              "description": "Maximum top-level reviews in this page",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Opaque next_cursor from a previous page. Resumes strictly after its (completed_at, review_id) position; mutually exclusive with since.",
+            "explode": false,
+            "in": "query",
+            "name": "cursor",
+            "schema": {
+              "description": "Opaque next_cursor from a previous page. Resumes strictly after its (completed_at, review_id) position; mutually exclusive with since.",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExportReviewsDocument"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Cursor database_id does not match this local database"
+          },
+          "default": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "summary": "Export completed reviews",
+        "tags": ["reviews"]
+      }
+    },
+    "/api/health": {
+      "get": {
+        "operationId": "get-health",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthStatus"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "default": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "summary": "Get daemon health",
+        "tags": ["daemon"]
+      }
+    },
+    "/api/job/applied": {
+      "post": {
+        "operationId": "mark-job-applied",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JobIDRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobStatusOutputBody"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "default": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "summary": "Mark a fix job as applied",
+        "tags": ["jobs"]
+      }
+    },
     "/api/job/cancel": {
       "post": {
         "operationId": "cancel-job",
@@ -1189,29 +2775,212 @@
         "tags": ["jobs"]
       }
     },
-    "/api/job/output": {
+    "/api/job/fix": {
+      "post": {
+        "operationId": "create-fix-job",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FixJobRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReviewJob"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Create a background fix job",
+        "tags": ["jobs"]
+      }
+    },
+    "/api/job/log": {
       "get": {
-        "operationId": "get-job-output",
+        "operationId": "get-job-log",
         "parameters": [
           {
-            "description": "Job ID to fetch output for",
+            "description": "Job ID",
             "explode": false,
             "in": "query",
             "name": "job_id",
-            "required": true,
             "schema": {
-              "description": "Job ID to fetch output for",
-              "format": "int64",
-              "type": "integer"
+              "description": "Job ID",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Byte offset into the log file",
+            "explode": false,
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "description": "Byte offset into the log file",
+              "type": "string"
             }
           }
         ],
         "responses": {
           "200": {
+            "description": "OK"
+          },
+          "default": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "summary": "Get raw job log bytes",
+        "tags": ["jobs"]
+      }
+    },
+    "/api/job/output": {
+      "get": {
+        "operationId": "get-job-output",
+        "parameters": [
+          {
+            "description": "Job ID",
+            "explode": false,
+            "in": "query",
+            "name": "job_id",
+            "schema": {
+              "description": "Job ID",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Stream output as NDJSON when set to 1",
+            "explode": false,
+            "in": "query",
+            "name": "stream",
+            "schema": {
+              "description": "Stream output as NDJSON when set to 1",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "default": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "summary": "Get or stream in-memory job output",
+        "tags": ["jobs"]
+      }
+    },
+    "/api/job/patch": {
+      "get": {
+        "operationId": "get-job-patch",
+        "parameters": [
+          {
+            "description": "Job ID",
+            "explode": false,
+            "in": "query",
+            "name": "job_id",
+            "schema": {
+              "description": "Job ID",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "default": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "summary": "Get a stored fix patch",
+        "tags": ["jobs"]
+      }
+    },
+    "/api/job/rebased": {
+      "post": {
+        "operationId": "mark-job-rebased",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JobIDRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/JobOutputResponse"
+                  "$ref": "#/components/schemas/JobStatusOutputBody"
                 }
               }
             },
@@ -1228,7 +2997,7 @@
             "description": "Error"
           }
         },
-        "summary": "Get live output for a running job",
+        "summary": "Mark a fix job as rebased",
         "tags": ["jobs"]
       }
     },
@@ -1271,6 +3040,45 @@
         "tags": ["jobs"]
       }
     },
+    "/api/job/update-branch": {
+      "post": {
+        "operationId": "update-job-branch",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateJobBranchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateJobBranchOutputBody"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "default": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "summary": "Update a job branch",
+        "tags": ["jobs"]
+      }
+    },
     "/api/jobs": {
       "get": {
         "operationId": "list-jobs",
@@ -1281,7 +3089,7 @@
             "in": "query",
             "name": "id",
             "schema": {
-              "default": 0,
+              "default": -1,
               "description": "Return a single job by ID",
               "format": "int64",
               "type": "integer"
@@ -1298,13 +3106,17 @@
             }
           },
           {
-            "description": "Filter by repo root path",
-            "explode": false,
+            "description": "Filter by repo root path (repeatable)",
+            "explode": true,
             "in": "query",
             "name": "repo",
             "schema": {
-              "description": "Filter by repo root path",
-              "type": "string"
+              "description": "Filter by repo root path (repeatable)",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true,
+              "type": "array"
             }
           },
           {
@@ -1370,6 +3182,38 @@
             }
           },
           {
+            "description": "Hide auto-design-router rows (job_type=classify and status=skipped)",
+            "explode": false,
+            "in": "query",
+            "name": "hide_classify_jobs",
+            "schema": {
+              "description": "Hide auto-design-router rows (job_type=classify and status=skipped)",
+              "enum": ["true", "false", ""],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Return all jobs (members + synthesis) of one panel run",
+            "explode": false,
+            "in": "query",
+            "name": "panel_run",
+            "schema": {
+              "description": "Return all jobs (members + synthesis) of one panel run",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Omit prompt and diff content from returned jobs (metadata-only listing)",
+            "explode": false,
+            "in": "query",
+            "name": "omit_prompt",
+            "schema": {
+              "description": "Omit prompt and diff content from returned jobs (metadata-only listing)",
+              "enum": ["true", "false", ""],
+              "type": "string"
+            }
+          },
+          {
             "description": "Filter repos by path prefix",
             "explode": false,
             "in": "query",
@@ -1385,7 +3229,7 @@
             "in": "query",
             "name": "limit",
             "schema": {
-              "default": -1,
+              "default": -999999,
               "description": "Max results (default 50, 0=unlimited, max 10000)",
               "format": "int64",
               "type": "integer"
@@ -1409,7 +3253,7 @@
             "in": "query",
             "name": "before",
             "schema": {
-              "default": 0,
+              "default": -1,
               "description": "Cursor: return jobs with ID \u003c this value",
               "format": "int64",
               "type": "integer"
@@ -1439,6 +3283,171 @@
           }
         },
         "summary": "List review jobs",
+        "tags": ["jobs"]
+      }
+    },
+    "/api/jobs/batch": {
+      "post": {
+        "operationId": "batch-jobs",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BatchJobsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchJobsOutputBody"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "default": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "summary": "Fetch jobs with reviews by ID",
+        "tags": ["jobs"]
+      }
+    },
+    "/api/ping": {
+      "get": {
+        "operationId": "ping",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PingInfo"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "default": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "summary": "Get daemon liveness identity",
+        "tags": ["daemon"]
+      }
+    },
+    "/api/queue/pause": {
+      "post": {
+        "operationId": "pause-queue",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueuePauseOutputBody"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "default": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "summary": "Pause queue processing",
+        "tags": ["daemon"]
+      }
+    },
+    "/api/queue/unpause": {
+      "post": {
+        "operationId": "unpause-queue",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueuePauseOutputBody"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "default": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "summary": "Resume queue processing",
+        "tags": ["daemon"]
+      }
+    },
+    "/api/remap": {
+      "post": {
+        "operationId": "remap-jobs",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RemapRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RemapResult"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "default": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "summary": "Remap jobs after git history rewrite",
         "tags": ["jobs"]
       }
     },
@@ -1493,6 +3502,86 @@
         "tags": ["repos"]
       }
     },
+    "/api/repos/register": {
+      "post": {
+        "operationId": "register-repo",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegisterRepoRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Repo"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "default": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "summary": "Register a repository",
+        "tags": ["repos"]
+      }
+    },
+    "/api/repos/resolve": {
+      "get": {
+        "operationId": "resolve-repo",
+        "parameters": [
+          {
+            "description": "Absolute path or path inside a repository",
+            "explode": false,
+            "in": "query",
+            "name": "path",
+            "schema": {
+              "description": "Absolute path or path inside a repository",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResolveRepoOutputBody"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "default": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "summary": "Resolve whether a path belongs to a tracked repo",
+        "tags": ["repos"]
+      }
+    },
     "/api/review": {
       "get": {
         "operationId": "get-review",
@@ -1503,7 +3592,7 @@
             "in": "query",
             "name": "job_id",
             "schema": {
-              "default": 0,
+              "default": -1,
               "description": "Look up review by job ID",
               "format": "int64",
               "type": "integer"
@@ -1585,6 +3674,35 @@
         "tags": ["reviews"]
       }
     },
+    "/api/shutdown": {
+      "post": {
+        "operationId": "shutdown",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShutdownOutputBody"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "default": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "summary": "Gracefully shut down the daemon",
+        "tags": ["daemon"]
+      }
+    },
     "/api/status": {
       "get": {
         "operationId": "get-status",
@@ -1611,6 +3729,40 @@
           }
         },
         "summary": "Get daemon status",
+        "tags": ["daemon"]
+      }
+    },
+    "/api/stream/events": {
+      "get": {
+        "operationId": "stream-events",
+        "parameters": [
+          {
+            "description": "Filter events by repo root path",
+            "explode": false,
+            "in": "query",
+            "name": "repo",
+            "schema": {
+              "description": "Filter events by repo root path",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "default": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "summary": "Stream daemon events",
         "tags": ["daemon"]
       }
     },
@@ -1684,6 +3836,116 @@
         },
         "summary": "Get review summary statistics",
         "tags": ["daemon"]
+      }
+    },
+    "/api/sync/now": {
+      "post": {
+        "operationId": "sync-now",
+        "parameters": [
+          {
+            "description": "Stream sync progress as NDJSON when set to 1",
+            "explode": false,
+            "in": "query",
+            "name": "stream",
+            "schema": {
+              "description": "Stream sync progress as NDJSON when set to 1",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "default": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "summary": "Run an immediate sync",
+        "tags": ["sync"]
+      }
+    },
+    "/api/sync/status": {
+      "get": {
+        "operationId": "get-sync-status",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SyncStatusOutputBody"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "default": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorModel"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "summary": "Get sync worker status",
+        "tags": ["sync"]
+      }
+    },
+    "/api/tokens/backfill": {
+      "post": {
+        "operationId": "backfill-tokens",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BackfillTokensRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenSummary"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Backfill token usage from AgentsView payloads",
+        "tags": ["jobs"]
       }
     }
   }

--- a/packages/ui/src/components/roborev/FilterBar.svelte
+++ b/packages/ui/src/components/roborev/FilterBar.svelte
@@ -82,6 +82,15 @@
       e.currentTarget.checked,
     );
   }
+
+  function onShowAutoDesignChange(
+    e: Event & { currentTarget: HTMLInputElement },
+  ): void {
+    jobsStore?.setFilter(
+      "showAutoDesign",
+      e.currentTarget.checked,
+    );
+  }
 </script>
 
 <div class="filter-bar">
@@ -120,6 +129,16 @@
       {disabled}
     />
     Hide closed
+  </label>
+
+  <label class="hide-closed">
+    <input
+      type="checkbox"
+      checked={jobsStore?.getFilterShowAutoDesign() ?? false}
+      onchange={onShowAutoDesignChange}
+      {disabled}
+    />
+    Show auto-design
   </label>
 
   <button

--- a/packages/ui/src/components/roborev/FilterBar.test.ts
+++ b/packages/ui/src/components/roborev/FilterBar.test.ts
@@ -1,0 +1,65 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vite-plus/test";
+
+import FilterBar from "./FilterBar.svelte";
+
+type JobsStoreStub = {
+  getFilterSearch: () => string | undefined;
+  getFilterStatus: () => string | undefined;
+  getFilterHideClosed: () => boolean;
+  getFilterShowAutoDesign: () => boolean;
+  getFilterRepo: () => string | undefined;
+  getFilterBranch: () => string | undefined;
+  setFilter: Mock<(key: string, value: string | boolean | undefined) => void>;
+};
+
+const state = {
+  showAutoDesign: false,
+  jobs: null as JobsStoreStub | null,
+};
+
+const client = {
+  GET: vi.fn(),
+};
+
+vi.mock("../../context.js", () => ({
+  getStores: () => ({
+    roborevJobs: state.jobs,
+  }),
+  getRoborevClient: () => client,
+}));
+
+describe("FilterBar", () => {
+  beforeEach(() => {
+    state.showAutoDesign = false;
+    state.jobs = {
+      getFilterSearch: () => undefined,
+      getFilterStatus: () => undefined,
+      getFilterHideClosed: () => false,
+      getFilterShowAutoDesign: () => state.showAutoDesign,
+      getFilterRepo: () => undefined,
+      getFilterBranch: () => undefined,
+      setFilter: vi.fn((key: string, value: string | boolean | undefined) => {
+        if (key === "showAutoDesign") state.showAutoDesign = value === true;
+      }),
+    };
+    client.GET.mockResolvedValue({ data: { repos: [] }, error: undefined });
+  });
+
+  afterEach(() => {
+    cleanup();
+    state.jobs = null;
+    client.GET.mockReset();
+  });
+
+  it("shows an unchecked auto-design toggle that enables the filter", async () => {
+    render(FilterBar);
+
+    const checkbox = screen.getByLabelText("Show auto-design") as HTMLInputElement;
+    expect(checkbox.checked).toBe(false);
+
+    await fireEvent.click(checkbox);
+
+    expect(state.jobs?.setFilter).toHaveBeenCalledWith("showAutoDesign", true);
+  });
+});

--- a/packages/ui/src/components/roborev/JobRow.svelte
+++ b/packages/ui/src/components/roborev/JobRow.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
+  import ChevronRightIcon from "@lucide/svelte/icons/chevron-right";
   import type { components } from "../../api/roborev/generated/schema.js";
-  import { parseCostUsd } from "../../utils/roborev-cost.js";
+  import {
+    panelCostUsd,
+    panelElapsedStart,
+    panelStatusLabel,
+  } from "../../utils/roborev-panel.js";
   import { formatRelativeTime } from "@kenn-io/kit-ui";
   import StatusBadge from "./StatusBadge.svelte";
   import VerdictBadge from "./VerdictBadge.svelte";
@@ -12,13 +17,32 @@
     selected: boolean;
     highlighted: boolean;
     onclick: () => void;
+    members?: ReviewJob[] | undefined;
+    member?: boolean;
+    lastMember?: boolean;
+    expandable?: boolean;
+    expanded?: boolean;
+    ontoggle?: (() => void) | undefined;
   }
-  let { job, selected, highlighted, onclick }: Props =
-    $props();
+  let {
+    job,
+    selected,
+    highlighted,
+    onclick,
+    members,
+    member = false,
+    lastMember = false,
+    expandable = false,
+    expanded = false,
+    ontoggle,
+  }: Props = $props();
+
+  const panelStatus = $derived(panelStatusLabel(job));
 
   function formatElapsed(j: ReviewJob): string {
-    if (!j.started_at) return "--";
-    const start = new Date(j.started_at).getTime();
+    const startedAt = panelElapsedStart(j, members);
+    if (!startedAt) return "--";
+    const start = new Date(startedAt).getTime();
     const end = j.finished_at
       ? new Date(j.finished_at).getTime()
       : Date.now();
@@ -32,8 +56,8 @@
     return `${hrs}h ${remMins}m`;
   }
 
-  function formatCost(tokenUsage: string | undefined): string {
-    const cost = parseCostUsd(tokenUsage);
+  function formatCost(j: ReviewJob): string {
+    const cost = panelCostUsd(j, members);
     if (cost === null) return "--";
     return `~$${cost.toFixed(2)}`;
   }
@@ -48,6 +72,8 @@
   class="job-row"
   class:selected
   class:highlighted
+  class:member
+  aria-expanded={expandable ? expanded : undefined}
   role="button"
   tabindex="0"
   onclick={onclick}
@@ -56,6 +82,25 @@
   }}
 >
   <td class="col-id">
+    {#if expandable}
+      <button
+        class="chevron"
+        class:open={expanded}
+        type="button"
+        tabindex="-1"
+        aria-label={expanded ? "Collapse panel" : "Expand panel"}
+        onclick={(e) => {
+          e.stopPropagation();
+          ontoggle?.();
+        }}
+      >
+        <ChevronRightIcon size={12} strokeWidth={2} />
+      </button>
+    {:else if member}
+      <span class="member-connector mono" aria-hidden="true">
+        {lastMember ? "└" : "├"}
+      </span>
+    {/if}
     <span class="mono">{job.id}</span>
   </td>
   <td class="col-ref">
@@ -75,6 +120,12 @@
         {job.commit_subject}
       </span>
     {/if}
+    {#if member && job.panel_member_name}
+      <span class="member-name">{job.panel_member_name}</span>
+    {/if}
+    {#if panelStatus}
+      <span class="panel-status">{panelStatus}</span>
+    {/if}
   </td>
   <td class="col-agent">{job.agent}</td>
   <td class="col-status">
@@ -87,7 +138,7 @@
     {formatElapsed(job)}
   </td>
   <td class="col-cost mono">
-    {formatCost(job.token_usage)}
+    {formatCost(job)}
   </td>
   <td class="col-type">{job.job_type}</td>
   <td class="col-queued" title={job.enqueued_at}>
@@ -129,6 +180,10 @@
     );
   }
 
+  .job-row.member td {
+    background: var(--bg-inset);
+  }
+
   .job-row td {
     padding: 6px 10px;
     font-size: var(--font-size-sm);
@@ -146,6 +201,34 @@
     width: 60px;
     color: var(--text-muted);
     text-align: right;
+    white-space: nowrap;
+  }
+
+  .job-row.member .col-id {
+    padding-left: 24px;
+  }
+
+  .chevron {
+    display: inline-flex;
+    align-items: center;
+    color: var(--text-muted);
+    transition: transform 0.1s ease;
+    vertical-align: middle;
+    margin-right: 2px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    cursor: pointer;
+  }
+
+  .chevron.open {
+    transform: rotate(90deg);
+    color: var(--accent-blue);
+  }
+
+  .member-connector {
+    color: var(--text-muted);
+    margin-right: 2px;
   }
 
   .col-ref {
@@ -183,6 +266,19 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     max-width: 280px;
+  }
+
+  .member-name {
+    display: block;
+    font-size: var(--font-size-xs);
+    color: var(--accent-blue);
+    font-weight: 500;
+  }
+
+  .panel-status {
+    display: block;
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
   }
 
   .col-agent {

--- a/packages/ui/src/components/roborev/JobRow.svelte
+++ b/packages/ui/src/components/roborev/JobRow.svelte
@@ -19,7 +19,6 @@
     onclick: () => void;
     members?: ReviewJob[] | undefined;
     member?: boolean;
-    lastMember?: boolean;
     expandable?: boolean;
     expanded?: boolean;
     ontoggle?: (() => void) | undefined;
@@ -31,7 +30,6 @@
     onclick,
     members,
     member = false,
-    lastMember = false,
     expandable = false,
     expanded = false,
     ontoggle,
@@ -82,50 +80,52 @@
   }}
 >
   <td class="col-id">
-    {#if expandable}
-      <button
-        class="chevron"
-        class:open={expanded}
-        type="button"
-        tabindex="-1"
-        aria-label={expanded ? "Collapse panel" : "Expand panel"}
-        onclick={(e) => {
-          e.stopPropagation();
-          ontoggle?.();
-        }}
-      >
-        <ChevronRightIcon size={12} strokeWidth={2} />
-      </button>
-    {:else if member}
-      <span class="member-connector mono" aria-hidden="true">
-        {lastMember ? "└" : "├"}
-      </span>
-    {/if}
     <span class="mono">{job.id}</span>
   </td>
-  <td class="col-ref">
-    <span class="ref-group">
-      {#if job.repo_name}
-        <span class="repo-name">{job.repo_name}</span>
+  <td class="col-ref" class:tree-cell={expandable || member}>
+    <span class="ref-line" class:ref-line--member={member}>
+      {#if expandable}
+        <button
+          class="chevron"
+          class:open={expanded}
+          type="button"
+          tabindex="-1"
+          aria-label={expanded ? "Collapse panel" : "Expand panel"}
+          onclick={(e) => {
+            e.stopPropagation();
+            ontoggle?.();
+          }}
+        >
+          <ChevronRightIcon size={12} strokeWidth={2} aria-hidden="true" />
+        </button>
+      {:else if member}
+        <span class="tree-spacer" aria-hidden="true"></span>
       {/if}
-      {#if job.branch}
-        <span class="branch-name">{job.branch}</span>
-      {/if}
-      <span class="git-ref mono" title={job.git_ref}>
-        {shortRef(job.git_ref)}
+      <span class="ref-stack">
+        <span class="ref-group">
+          {#if job.repo_name}
+            <span class="repo-name">{job.repo_name}</span>
+          {/if}
+          {#if job.branch}
+            <span class="branch-name">{job.branch}</span>
+          {/if}
+          <span class="git-ref mono" title={job.git_ref}>
+            {shortRef(job.git_ref)}
+          </span>
+        </span>
+        {#if job.commit_subject}
+          <span class="commit-subject" title={job.commit_subject}>
+            {job.commit_subject}
+          </span>
+        {/if}
+        {#if member && job.panel_member_name}
+          <span class="member-name">{job.panel_member_name}</span>
+        {/if}
+        {#if panelStatus}
+          <span class="panel-status">{panelStatus}</span>
+        {/if}
       </span>
     </span>
-    {#if job.commit_subject}
-      <span class="commit-subject" title={job.commit_subject}>
-        {job.commit_subject}
-      </span>
-    {/if}
-    {#if member && job.panel_member_name}
-      <span class="member-name">{job.panel_member_name}</span>
-    {/if}
-    {#if panelStatus}
-      <span class="panel-status">{panelStatus}</span>
-    {/if}
   </td>
   <td class="col-agent">{job.agent}</td>
   <td class="col-status">
@@ -204,15 +204,16 @@
     white-space: nowrap;
   }
 
-  .job-row.member .col-id {
-    padding-left: 24px;
-  }
-
   .chevron {
     display: inline-flex;
     align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 14px;
+    height: 14px;
+    border-radius: var(--radius-sm);
     color: var(--text-muted);
-    transition: transform 0.1s ease;
+    transition: transform 0.1s, background 0.1s, color 0.1s;
     vertical-align: middle;
     margin-right: 2px;
     padding: 0;
@@ -221,20 +222,42 @@
     cursor: pointer;
   }
 
+  .chevron:hover {
+    background: var(--bg-inset);
+    color: var(--text-primary);
+  }
+
   .chevron.open {
     transform: rotate(90deg);
     color: var(--accent-blue);
-  }
-
-  .member-connector {
-    color: var(--text-muted);
-    margin-right: 2px;
   }
 
   .col-ref {
     min-width: 160px;
     max-width: 300px;
     white-space: normal;
+  }
+
+  .ref-line {
+    display: flex;
+    align-items: flex-start;
+    gap: 4px;
+    min-width: 0;
+  }
+
+  .tree-cell .ref-line--member {
+    padding-left: 18px;
+  }
+
+  .tree-spacer {
+    flex: 0 0 14px;
+    width: 14px;
+    height: 14px;
+  }
+
+  .ref-stack {
+    display: block;
+    min-width: 0;
   }
 
   .ref-group {

--- a/packages/ui/src/components/roborev/JobRow.test.ts
+++ b/packages/ui/src/components/roborev/JobRow.test.ts
@@ -82,7 +82,7 @@ describe("JobRow", () => {
       expect(screen.getByRole("button", { name: /expand panel/i })).toBeTruthy();
     });
 
-    it("renders a member row with connector and member name", () => {
+    it("renders a member row with indented ref content and member name", () => {
       const member: ReviewJob = {
         ...makeJob(),
         id: 11,
@@ -100,12 +100,15 @@ describe("JobRow", () => {
           highlighted: false,
           onclick: () => {},
           member: true,
-          lastMember: true,
         },
       });
 
       expect(screen.getByText("security")).toBeTruthy();
-      expect(screen.getByText("└")).toBeTruthy();
+      const refCell = screen.getByText("security").closest(".col-ref");
+      expect(refCell?.classList.contains("tree-cell")).toBe(true);
+      expect(refCell?.querySelector(".tree-spacer")).toBeTruthy();
+      expect(screen.queryByText("└")).toBeNull();
+      expect(screen.queryByText("├")).toBeNull();
     });
   });
 });

--- a/packages/ui/src/components/roborev/JobRow.test.ts
+++ b/packages/ui/src/components/roborev/JobRow.test.ts
@@ -41,4 +41,71 @@ describe("JobRow", () => {
 
     expect(screen.getByText("~$0.42")).toBeTruthy();
   });
+
+  describe("panel rows", () => {
+    it("renders a chevron, outcome split, and aggregate cost on a panel parent", () => {
+      const parent: ReviewJob = {
+        ...makeJob(JSON.stringify({ has_cost: true, cost_usd: 0.05 })),
+        id: 10,
+        job_type: "synthesis",
+        panel_role: "synthesis",
+        panel_run_uuid: "run-10",
+        status: "done",
+        panel_summary: {
+          panel_run_uuid: "run-10",
+          members_total: 3,
+          members_terminal: 3,
+          members_succeeded: 2,
+          members_failed: 1,
+          members_canceled: 0,
+          members_skipped: 0,
+          members_with_cost: 3,
+          members_cost_usd: 0.3,
+          members_cost_complete: true,
+        },
+      };
+
+      render(JobRow, {
+        props: {
+          job: parent,
+          selected: false,
+          highlighted: false,
+          onclick: () => {},
+          expandable: true,
+          expanded: false,
+          ontoggle: () => {},
+        },
+      });
+
+      expect(screen.getByText("2 ok · 1 failed")).toBeTruthy();
+      expect(screen.getByText("~$0.35")).toBeTruthy();
+      expect(screen.getByRole("button", { name: /expand panel/i })).toBeTruthy();
+    });
+
+    it("renders a member row with connector and member name", () => {
+      const member: ReviewJob = {
+        ...makeJob(),
+        id: 11,
+        panel_role: "member",
+        panel_run_uuid: "run-10",
+        panel_member_index: 0,
+        panel_member_name: "security",
+        verdict: "F",
+      };
+
+      render(JobRow, {
+        props: {
+          job: member,
+          selected: false,
+          highlighted: false,
+          onclick: () => {},
+          member: true,
+          lastMember: true,
+        },
+      });
+
+      expect(screen.getByText("security")).toBeTruthy();
+      expect(screen.getByText("└")).toBeTruthy();
+    });
+  });
 });

--- a/packages/ui/src/components/roborev/JobTable.svelte
+++ b/packages/ui/src/components/roborev/JobTable.svelte
@@ -96,6 +96,10 @@
             runUuid !== undefined
               ? jobsStore.getPanelMembers(runUuid)
               : undefined}
+          {@const memberError =
+            runUuid !== undefined
+              ? jobsStore.getPanelMemberError(runUuid)
+              : undefined}
           <JobRow
             {job}
             {members}
@@ -107,7 +111,7 @@
             ontoggle={() => jobsStore.togglePanel(job)}
           />
           {#if expanded && runUuid !== undefined}
-            {#if jobsStore.isLoadingMembers(runUuid)}
+            {#if jobsStore.isLoadingMembers(runUuid) && members === undefined}
               <tr class="members-status-row">
                 <td colspan={columns.length}>Loading reviewers…</td>
               </tr>
@@ -122,6 +126,25 @@
                   onclick={() => jobsStore.selectJob(panelMember.id)}
                 />
               {/each}
+              {#if jobsStore.isLoadingMembers(runUuid)}
+                <tr class="members-status-row">
+                  <td colspan={columns.length}>Refreshing reviewers…</td>
+                </tr>
+              {/if}
+              {#if memberError}
+                <tr class="members-status-row error">
+                  <td colspan={columns.length}>
+                    Could not refresh reviewers.
+                    <button
+                      type="button"
+                      class="members-retry"
+                      onclick={() => jobsStore.refreshPanelMembers(runUuid)}
+                    >
+                      Retry
+                    </button>
+                  </td>
+                </tr>
+              {/if}
             {/if}
           {/if}
         {/each}
@@ -221,6 +244,21 @@
     font-size: var(--font-size-xs);
     color: var(--text-muted);
     background: var(--bg-inset);
+  }
+
+  .members-status-row.error td {
+    color: var(--accent-red);
+  }
+
+  .members-retry {
+    margin-left: 8px;
+    border: 0;
+    padding: 0;
+    background: transparent;
+    color: var(--text-primary);
+    font: inherit;
+    text-decoration: underline;
+    cursor: pointer;
   }
 
   .load-more {

--- a/packages/ui/src/components/roborev/JobTable.svelte
+++ b/packages/ui/src/components/roborev/JobTable.svelte
@@ -120,7 +120,6 @@
                 <JobRow
                   job={panelMember}
                   member
-                  lastMember={i === (members?.length ?? 0) - 1}
                   selected={jobsStore.getSelectedJobId() === panelMember.id}
                   highlighted={jobsStore.getHighlightedJobId() === panelMember.id}
                   onclick={() => jobsStore.selectJob(panelMember.id)}

--- a/packages/ui/src/components/roborev/JobTable.svelte
+++ b/packages/ui/src/components/roborev/JobTable.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { EmptyState } from "@kenn-io/kit-ui";
   import { getStores } from "../../context.js";
+  import { isPanelParent } from "../../utils/roborev-panel.js";
   import JobRow from "./JobRow.svelte";
 
   const stores = getStores();
@@ -85,12 +86,44 @@
     <tbody>
       {#if jobsStore}
         {#each jobsStore.getJobs() as job (job.id)}
+          {@const runUuid = job.panel_run_uuid ?? undefined}
+          {@const expandable = isPanelParent(job) && runUuid !== undefined}
+          {@const expanded =
+            expandable &&
+            runUuid !== undefined &&
+            jobsStore.isPanelExpanded(runUuid)}
+          {@const members =
+            runUuid !== undefined
+              ? jobsStore.getPanelMembers(runUuid)
+              : undefined}
           <JobRow
             {job}
+            {members}
+            {expandable}
+            {expanded}
             selected={jobsStore.getSelectedJobId() === job.id}
             highlighted={jobsStore.getHighlightedJobId() === job.id}
             onclick={() => jobsStore.selectJob(job.id)}
+            ontoggle={() => jobsStore.togglePanel(job)}
           />
+          {#if expanded && runUuid !== undefined}
+            {#if jobsStore.isLoadingMembers(runUuid)}
+              <tr class="members-status-row">
+                <td colspan={columns.length}>Loading reviewers…</td>
+              </tr>
+            {:else}
+              {#each members ?? [] as panelMember, i (panelMember.id)}
+                <JobRow
+                  job={panelMember}
+                  member
+                  lastMember={i === (members?.length ?? 0) - 1}
+                  selected={jobsStore.getSelectedJobId() === panelMember.id}
+                  highlighted={jobsStore.getHighlightedJobId() === panelMember.id}
+                  onclick={() => jobsStore.selectJob(panelMember.id)}
+                />
+              {/each}
+            {/if}
+          {/if}
         {/each}
       {/if}
     </tbody>
@@ -183,6 +216,12 @@
     color: var(--accent-red);
   }
 
+  .members-status-row td {
+    padding: 6px 10px 6px 34px;
+    font-size: var(--font-size-xs);
+    color: var(--text-muted);
+    background: var(--bg-inset);
+  }
 
   .load-more {
     padding: 8px 12px;

--- a/packages/ui/src/components/roborev/ReviewDrawer.svelte
+++ b/packages/ui/src/components/roborev/ReviewDrawer.svelte
@@ -92,6 +92,7 @@
   const reviewIsClosed = $derived(
     stores.roborevReview?.isClosed() ?? false,
   );
+  let interestedPanelRun: string | undefined;
 
   const panelMembers = $derived.by(() => {
     const runUuid = selectedJob?.panel_run_uuid;
@@ -106,14 +107,13 @@
   );
 
   $effect(() => {
-    const runUuid = selectedJob?.panel_run_uuid;
-    if (
-      selectedJob &&
-      isPanelParent(selectedJob) &&
-      runUuid
-    ) {
-      stores.roborevJobs?.ensurePanelMembers(runUuid);
-    }
+    const runUuid =
+      selectedJob && isPanelParent(selectedJob)
+        ? selectedJob.panel_run_uuid
+        : undefined;
+    if (interestedPanelRun === runUuid) return;
+    interestedPanelRun = runUuid;
+    stores.roborevJobs?.setPanelMemberInterest(runUuid);
   });
 </script>
 

--- a/packages/ui/src/components/roborev/ReviewDrawer.svelte
+++ b/packages/ui/src/components/roborev/ReviewDrawer.svelte
@@ -7,6 +7,11 @@
   import ResponseList from "./ResponseList.svelte";
   import LogViewer from "./LogViewer.svelte";
   import PromptViewer from "./PromptViewer.svelte";
+  import {
+    isPanelParent,
+    isTerminalStatus,
+    panelReviewHeader,
+  } from "../../utils/roborev-panel.js";
 
   // NOTE: intentionally NOT kit-ui DetailDrawer. This is a resizable bottom
   // dock (height: 50vh; resize: vertical; accent border-top) that lives
@@ -25,7 +30,7 @@
   // Fall back to the review store's fetched job for
   // off-page deep links where the job isn't in the table.
   const selectedJob = $derived(
-    stores.roborevJobs?.getJobs().find(
+    stores.roborevJobs?.getVisibleJobs().find(
       (j) =>
         j.id ===
         stores.roborevJobs?.getSelectedJobId(),
@@ -87,6 +92,29 @@
   const reviewIsClosed = $derived(
     stores.roborevReview?.isClosed() ?? false,
   );
+
+  const panelMembers = $derived.by(() => {
+    const runUuid = selectedJob?.panel_run_uuid;
+    if (!runUuid) return undefined;
+    return stores.roborevJobs?.getPanelMembers(runUuid);
+  });
+
+  const panelHeader = $derived(
+    selectedJob
+      ? panelReviewHeader(selectedJob, panelMembers)
+      : null,
+  );
+
+  $effect(() => {
+    const runUuid = selectedJob?.panel_run_uuid;
+    if (
+      selectedJob &&
+      isPanelParent(selectedJob) &&
+      runUuid
+    ) {
+      stores.roborevJobs?.ensurePanelMembers(runUuid);
+    }
+  });
 </script>
 
 {#if isOpen}
@@ -131,6 +159,16 @@
               {selectedJob.review_type}
             </span>
           {/if}
+          {#if selectedJob.source === "auto_design"}
+            <span class="review-type">
+              auto-design
+            </span>
+          {/if}
+          {#if selectedJob.panel_member_name}
+            <span class="review-type">
+              {selectedJob.panel_member_name}
+            </span>
+          {/if}
           <StatusBadge status={selectedJob.status} />
         {/if}
       </div>
@@ -156,6 +194,17 @@
         </svg>
       </button>
     </div>
+
+    {#if panelHeader}
+      <div class="panel-line">
+        {panelHeader}
+        {#if selectedJob && !isTerminalStatus(selectedJob.status)}
+          <span class="panel-progress">
+            Panel still synthesizing...
+          </span>
+        {/if}
+      </div>
+    {/if}
 
     <div class="tab-bar">
       <button
@@ -184,6 +233,11 @@
     <!-- kit-ui-check-ignore: resizable inline bottom dock, not a kit side-sheet -->
     <div class="drawer-body">
       {#if activeTab === "review"}
+        {#if selectedJob?.status === "skipped" && selectedJob.skip_reason}
+          <div class="skip-reason">
+            Skipped: {selectedJob.skip_reason}
+          </div>
+        {/if}
         <ReviewContent />
         <div class="responses-section">
           <ResponseList />
@@ -324,6 +378,25 @@
     border: 1px solid var(--border-muted);
     border-radius: var(--radius-sm);
     white-space: nowrap;
+  }
+
+  .panel-line {
+    padding: 4px 16px;
+    font-size: var(--font-size-xs);
+    color: var(--text-secondary);
+    border-bottom: 1px solid var(--border-muted);
+    display: flex;
+    gap: 12px;
+  }
+
+  .panel-progress {
+    color: var(--accent-amber);
+  }
+
+  .skip-reason {
+    padding: 8px 12px;
+    font-size: var(--font-size-sm);
+    color: var(--text-secondary);
   }
 
   .close-btn {

--- a/packages/ui/src/components/roborev/ReviewDrawer.svelte
+++ b/packages/ui/src/components/roborev/ReviewDrawer.svelte
@@ -94,6 +94,24 @@
   );
   let interestedPanelRun: string | undefined;
 
+  const selectedPanelRun = $derived(
+    selectedJob && isPanelParent(selectedJob)
+      ? selectedJob.panel_run_uuid
+      : undefined,
+  );
+
+  const panelError = $derived(
+    selectedPanelRun
+      ? stores.roborevJobs?.getPanelMemberError(selectedPanelRun)
+      : undefined,
+  );
+
+  const panelLoading = $derived(
+    selectedPanelRun
+      ? (stores.roborevJobs?.isLoadingMembers(selectedPanelRun) ?? false)
+      : false,
+  );
+
   const panelMembers = $derived.by(() => {
     const runUuid = selectedJob?.panel_run_uuid;
     if (!runUuid) return undefined;
@@ -107,13 +125,9 @@
   );
 
   $effect(() => {
-    const runUuid =
-      selectedJob && isPanelParent(selectedJob)
-        ? selectedJob.panel_run_uuid
-        : undefined;
-    if (interestedPanelRun === runUuid) return;
-    interestedPanelRun = runUuid;
-    stores.roborevJobs?.setPanelMemberInterest(runUuid);
+    if (interestedPanelRun === selectedPanelRun) return;
+    interestedPanelRun = selectedPanelRun;
+    stores.roborevJobs?.setPanelMemberInterest(selectedPanelRun);
   });
 </script>
 
@@ -198,7 +212,27 @@
     {#if panelHeader}
       <div class="panel-line">
         {panelHeader}
-        {#if selectedJob && !isTerminalStatus(selectedJob.status)}
+        {#if panelError}
+          <span class="panel-error">
+            Could not refresh reviewers.
+          </span>
+          {#if selectedPanelRun}
+            <button
+              type="button"
+              class="panel-retry"
+              onclick={() =>
+                stores.roborevJobs?.refreshPanelMembers(
+                  selectedPanelRun,
+                )}
+            >
+              Retry
+            </button>
+          {/if}
+        {:else if panelLoading}
+          <span class="panel-progress">
+            Refreshing reviewers...
+          </span>
+        {:else if selectedJob && !isTerminalStatus(selectedJob.status)}
           <span class="panel-progress">
             Panel still synthesizing...
           </span>
@@ -391,6 +425,20 @@
 
   .panel-progress {
     color: var(--accent-amber);
+  }
+
+  .panel-error {
+    color: var(--accent-red);
+  }
+
+  .panel-retry {
+    border: 0;
+    padding: 0;
+    background: transparent;
+    color: var(--text-primary);
+    font: inherit;
+    text-decoration: underline;
+    cursor: pointer;
   }
 
   .skip-reason {

--- a/packages/ui/src/components/roborev/ShortcutHelpModal.svelte
+++ b/packages/ui/src/components/roborev/ShortcutHelpModal.svelte
@@ -32,6 +32,10 @@
             <dd>Open drawer for selected row</dd>
           </div>
           <div class="shortcut-row">
+            <dt><KbdBadge keys={["→"]} /> / <KbdBadge keys={["←"]} /></dt>
+            <dd>Expand / collapse review panel</dd>
+          </div>
+          <div class="shortcut-row">
             <dt><KbdBadge keys={["x"]} /></dt>
             <dd>Cancel selected job</dd>
           </div>

--- a/packages/ui/src/stores/roborev/jobs.svelte.ts
+++ b/packages/ui/src/stores/roborev/jobs.svelte.ts
@@ -34,6 +34,7 @@ export function createJobsStore(opts: JobsStoreOptions) {
   let filterSearch = $state<string | undefined>(undefined);
   let filterHideClosed = $state(false);
   let filterJobType = $state<string | undefined>(undefined);
+  let filterShowAutoDesign = $state(false);
 
   // Sorting (client-side)
   let sortColumn = $state<SortColumn>("id");
@@ -54,6 +55,7 @@ export function createJobsStore(opts: JobsStoreOptions) {
     if (filterSearch) q.git_ref = filterSearch;
     if (filterHideClosed) q.closed = "false";
     if (filterJobType) q.job_type = filterJobType;
+    if (!filterShowAutoDesign) q.hide_classify_jobs = "true";
     return q;
   }
 
@@ -177,6 +179,9 @@ export function createJobsStore(opts: JobsStoreOptions) {
         break;
       case "jobType":
         filterJobType = value as string | undefined;
+        break;
+      case "showAutoDesign":
+        filterShowAutoDesign = value as boolean;
         break;
     }
     void loadJobs();
@@ -361,6 +366,9 @@ export function createJobsStore(opts: JobsStoreOptions) {
   function getFilterJobType(): string | undefined {
     return filterJobType;
   }
+  function getFilterShowAutoDesign(): boolean {
+    return filterShowAutoDesign;
+  }
   function getSortColumn(): SortColumn {
     return sortColumn;
   }
@@ -385,6 +393,7 @@ export function createJobsStore(opts: JobsStoreOptions) {
     getFilterSearch,
     getFilterHideClosed,
     getFilterJobType,
+    getFilterShowAutoDesign,
     getSortColumn,
     getSortDirection,
     isSSEConnected,

--- a/packages/ui/src/stores/roborev/jobs.svelte.ts
+++ b/packages/ui/src/stores/roborev/jobs.svelte.ts
@@ -45,6 +45,7 @@ export function createJobsStore(opts: JobsStoreOptions) {
   // expanded panels live.
   let expandedPanels = $state<Record<string, boolean>>({});
   let panelMembers = $state<Record<string, ReviewJob[]>>({});
+  let panelMemberErrors = $state<Record<string, string>>({});
   let loadingMembers = $state<Record<string, boolean>>({});
   let panelRequestedVersions: Record<string, number> = {};
   let activePanelFetchVersions: Record<string, number> = {};
@@ -154,11 +155,7 @@ export function createJobsStore(opts: JobsStoreOptions) {
       // Do NOT clear selectedJobId — the selected job may
       // be on a later page (deep link, older job). The
       // drawer fetches its review independently.
-      if (highlightedJobId !== undefined) {
-        if (!getVisibleJobs().some((job) => job.id === highlightedJobId)) {
-          highlightedJobId = getPanelParentForMemberId(highlightedJobId)?.id;
-        }
-      }
+      adjustHiddenHighlight();
     } catch (err) {
       if (version !== requestVersion) return;
       storeError = err instanceof Error ? err.message : String(err);
@@ -271,6 +268,8 @@ export function createJobsStore(opts: JobsStoreOptions) {
   async function runPanelMembersFetch(runUuid: string, version: number): Promise<void> {
     activePanelFetchVersions = { ...activePanelFetchVersions, [runUuid]: version };
     loadingMembers = { ...loadingMembers, [runUuid]: true };
+    const { [runUuid]: _startedError, ...startedErrors } = panelMemberErrors;
+    panelMemberErrors = startedErrors;
     try {
       const { data, error } = await client.GET("/api/jobs", {
         params: { query: { panel_run: runUuid, limit: 0, omit_prompt: "true" } },
@@ -281,12 +280,17 @@ export function createJobsStore(opts: JobsStoreOptions) {
         .filter((job) => job.panel_role === "member")
         .sort((a, b) => (a.panel_member_index ?? 0) - (b.panel_member_index ?? 0));
       panelMembers = { ...panelMembers, [runUuid]: members };
+      const { [runUuid]: _memberError, ...memberErrors } = panelMemberErrors;
+      panelMemberErrors = memberErrors;
+      adjustHiddenHighlight(runUuid);
       if (sortColumn === "cost" || sortColumn === "elapsed") {
         jobs = sortJobs(jobs);
       }
     } catch (err) {
       if (panelRequestedVersions[runUuid] === version) {
-        opts.onError?.(err instanceof Error ? err.message : String(err));
+        const message = err instanceof Error ? err.message : String(err);
+        panelMemberErrors = { ...panelMemberErrors, [runUuid]: message };
+        opts.onError?.(message);
       }
     } finally {
       if (activePanelFetchVersions[runUuid] === version) {
@@ -331,12 +335,30 @@ export function createJobsStore(opts: JobsStoreOptions) {
     if (runUuid !== undefined) void fetchPanelMembers(runUuid);
   }
 
+  function refreshPanelMembers(runUuid: string): void {
+    void fetchPanelMembers(runUuid);
+  }
+
+  function adjustHiddenHighlight(runUuid?: string): void {
+    if (highlightedJobId === undefined) return;
+    if (getVisibleJobs().some((job) => job.id === highlightedJobId)) return;
+    const parent =
+      runUuid !== undefined
+        ? jobs.find((job) => isPanelParent(job) && job.panel_run_uuid === runUuid)
+        : getPanelParentForMemberId(highlightedJobId);
+    highlightedJobId = parent?.id;
+  }
+
   function isPanelExpanded(runUuid: string): boolean {
     return expandedPanels[runUuid] === true;
   }
 
   function getPanelMembers(runUuid: string): ReviewJob[] | undefined {
     return panelMembers[runUuid];
+  }
+
+  function getPanelMemberError(runUuid: string): string | undefined {
+    return panelMemberErrors[runUuid];
   }
 
   function isLoadingMembers(runUuid: string): boolean {
@@ -426,7 +448,7 @@ export function createJobsStore(opts: JobsStoreOptions) {
     for (const job of jobs) {
       visible.push(job);
       const runUuid = job.panel_run_uuid;
-      if (runUuid && expandedPanels[runUuid] === true && loadingMembers[runUuid] !== true) {
+      if (runUuid && expandedPanels[runUuid] === true && panelMembers[runUuid] !== undefined) {
         visible.push(...(panelMembers[runUuid] ?? []));
       }
     }
@@ -539,8 +561,10 @@ export function createJobsStore(opts: JobsStoreOptions) {
     togglePanel,
     ensurePanelMembers,
     setPanelMemberInterest,
+    refreshPanelMembers,
     isPanelExpanded,
     getPanelMembers,
+    getPanelMemberError,
     isLoadingMembers,
     loadJobs,
     loadMore,

--- a/packages/ui/src/stores/roborev/jobs.svelte.ts
+++ b/packages/ui/src/stores/roborev/jobs.svelte.ts
@@ -48,7 +48,7 @@ export function createJobsStore(opts: JobsStoreOptions) {
 
   function buildQuery(): ListJobsQuery {
     const q: ListJobsQuery = { limit: 50 };
-    if (filterRepo) q.repo = filterRepo;
+    if (filterRepo) q.repo = [filterRepo];
     if (filterBranch) q.branch = filterBranch;
     if (filterStatus) q.status = filterStatus;
     if (filterSearch) q.git_ref = filterSearch;

--- a/packages/ui/src/stores/roborev/jobs.svelte.ts
+++ b/packages/ui/src/stores/roborev/jobs.svelte.ts
@@ -1,6 +1,7 @@
 import type { RoborevClient } from "../../api/roborev/client.js";
 import type { components, operations } from "../../api/roborev/generated/schema.js";
 import { parseCostUsd } from "../../utils/roborev-cost.js";
+import { isPanelParent } from "../../utils/roborev-panel.js";
 
 type ReviewJob = components["schemas"]["ReviewJob"];
 type JobStats = components["schemas"]["JobStats"];
@@ -39,6 +40,13 @@ export function createJobsStore(opts: JobsStoreOptions) {
   // Sorting (client-side)
   let sortColumn = $state<SortColumn>("id");
   let sortDirection = $state<SortDirection>("desc");
+
+  // Panel expansion, keyed by panel_run_uuid. Member lists are cached per
+  // run and refreshed alongside the listing so SSE-driven reloads keep
+  // expanded panels live.
+  let expandedPanels = $state<Record<string, boolean>>({});
+  let panelMembers = $state<Record<string, ReviewJob[]>>({});
+  let loadingMembers = $state<Record<string, boolean>>({});
 
   // SSE
   let sseConnected = $state(false);
@@ -113,6 +121,12 @@ export function createJobsStore(opts: JobsStoreOptions) {
       jobs = sortJobs(data?.jobs ?? []);
       hasMore = data?.has_more ?? false;
       stats = data?.stats ?? { done: 0, closed: 0, open: 0 };
+      for (const job of jobs) {
+        const runUuid = job.panel_run_uuid;
+        if (runUuid && expandedPanels[runUuid] === true && panelMembers[runUuid] !== undefined) {
+          void fetchPanelMembers(runUuid);
+        }
+      }
       // Clear highlight if the row is no longer visible.
       // Do NOT clear selectedJobId — the selected job may
       // be on a later page (deep link, older job). The
@@ -219,6 +233,53 @@ export function createJobsStore(opts: JobsStoreOptions) {
       return;
     }
     void loadJobs();
+  }
+
+  async function fetchPanelMembers(runUuid: string): Promise<void> {
+    loadingMembers = { ...loadingMembers, [runUuid]: true };
+    try {
+      const { data, error } = await client.GET("/api/jobs", {
+        params: { query: { panel_run: runUuid, limit: 0 } },
+      });
+      if (error) throw new Error("Failed to load panel members");
+      const members = (data?.jobs ?? [])
+        .filter((job) => job.panel_role === "member")
+        .sort((a, b) => (a.panel_member_index ?? 0) - (b.panel_member_index ?? 0));
+      panelMembers = { ...panelMembers, [runUuid]: members };
+    } catch (err) {
+      opts.onError?.(err instanceof Error ? err.message : String(err));
+    } finally {
+      loadingMembers = { ...loadingMembers, [runUuid]: false };
+    }
+  }
+
+  function togglePanel(job: ReviewJob): void {
+    if (!isPanelParent(job)) return;
+    const runUuid = job.panel_run_uuid;
+    if (!runUuid) return;
+    const open = expandedPanels[runUuid] === true;
+    expandedPanels = { ...expandedPanels, [runUuid]: !open };
+    if (!open && panelMembers[runUuid] === undefined && loadingMembers[runUuid] !== true) {
+      void fetchPanelMembers(runUuid);
+    }
+  }
+
+  function ensurePanelMembers(runUuid: string): void {
+    if (panelMembers[runUuid] === undefined && loadingMembers[runUuid] !== true) {
+      void fetchPanelMembers(runUuid);
+    }
+  }
+
+  function isPanelExpanded(runUuid: string): boolean {
+    return expandedPanels[runUuid] === true;
+  }
+
+  function getPanelMembers(runUuid: string): ReviewJob[] | undefined {
+    return panelMembers[runUuid];
+  }
+
+  function isLoadingMembers(runUuid: string): boolean {
+    return loadingMembers[runUuid] === true;
   }
 
   // Selection — setSelectedJobId sets state only (no
@@ -397,6 +458,11 @@ export function createJobsStore(opts: JobsStoreOptions) {
     getSortColumn,
     getSortDirection,
     isSSEConnected,
+    togglePanel,
+    ensurePanelMembers,
+    isPanelExpanded,
+    getPanelMembers,
+    isLoadingMembers,
     loadJobs,
     loadMore,
     setFilter,

--- a/packages/ui/src/stores/roborev/jobs.svelte.ts
+++ b/packages/ui/src/stores/roborev/jobs.svelte.ts
@@ -95,6 +95,10 @@ export function createJobsStore(opts: JobsStoreOptions) {
     return undefined;
   }
 
+  function wantsPanelMembers(runUuid: string): boolean {
+    return expandedPanels[runUuid] === true || interestedPanelRun === runUuid;
+  }
+
   function getSortValue(job: ReviewJob, col: SortColumn): string | number {
     switch (col) {
       case "id":
@@ -145,7 +149,7 @@ export function createJobsStore(opts: JobsStoreOptions) {
       const expandedRuns: Record<string, true> = {};
       for (const job of jobs) {
         const runUuid = job.panel_run_uuid;
-        if (runUuid && expandedPanels[runUuid] === true) {
+        if (runUuid && wantsPanelMembers(runUuid)) {
           expandedRuns[runUuid] = true;
         }
       }
@@ -301,7 +305,7 @@ export function createJobsStore(opts: JobsStoreOptions) {
           const { [runUuid]: _pending, ...rest } = pendingPanelRefreshes;
           pendingPanelRefreshes = rest;
           const queuedVersion = panelRequestedVersions[runUuid];
-          if (queuedVersion !== undefined && queuedVersion > version && expandedPanels[runUuid] === true) {
+          if (queuedVersion !== undefined && queuedVersion > version && wantsPanelMembers(runUuid)) {
             void runPanelMembersFetch(runUuid, queuedVersion);
           }
         }

--- a/packages/ui/src/stores/roborev/jobs.svelte.ts
+++ b/packages/ui/src/stores/roborev/jobs.svelte.ts
@@ -1,7 +1,6 @@
 import type { RoborevClient } from "../../api/roborev/client.js";
 import type { components, operations } from "../../api/roborev/generated/schema.js";
-import { parseCostUsd } from "../../utils/roborev-cost.js";
-import { isPanelParent } from "../../utils/roborev-panel.js";
+import { isPanelParent, panelCostUsd, panelElapsedStart } from "../../utils/roborev-panel.js";
 
 type ReviewJob = components["schemas"]["ReviewJob"];
 type JobStats = components["schemas"]["JobStats"];
@@ -47,6 +46,8 @@ export function createJobsStore(opts: JobsStoreOptions) {
   let expandedPanels = $state<Record<string, boolean>>({});
   let panelMembers = $state<Record<string, ReviewJob[]>>({});
   let loadingMembers = $state<Record<string, boolean>>({});
+  let panelFetchVersions: Record<string, number> = {};
+  let pendingPanelRefreshes: Record<string, boolean> = {};
 
   // SSE
   let sseConnected = $state(false);
@@ -68,10 +69,16 @@ export function createJobsStore(opts: JobsStoreOptions) {
   }
 
   function getElapsedSeconds(job: ReviewJob): number {
-    if (!job.started_at) return -1;
-    const start = new Date(job.started_at).getTime();
+    const startedAt = panelElapsedStart(job, getPanelMembersForJob(job));
+    if (!startedAt) return -1;
+    const start = new Date(startedAt).getTime();
     const end = job.finished_at ? new Date(job.finished_at).getTime() : Date.now();
     return Math.max(0, Math.floor((end - start) / 1000));
+  }
+
+  function getPanelMembersForJob(job: ReviewJob): ReviewJob[] | undefined {
+    const runUuid = job.panel_run_uuid;
+    return runUuid ? panelMembers[runUuid] : undefined;
   }
 
   function getSortValue(job: ReviewJob, col: SortColumn): string | number {
@@ -87,7 +94,7 @@ export function createJobsStore(opts: JobsStoreOptions) {
       case "elapsed":
         return getElapsedSeconds(job);
       case "cost":
-        return parseCostUsd(job.token_usage) ?? -1;
+        return panelCostUsd(job, getPanelMembersForJob(job)) ?? -1;
       case "job_type":
         return job.job_type;
       case "enqueued_at":
@@ -121,19 +128,20 @@ export function createJobsStore(opts: JobsStoreOptions) {
       jobs = sortJobs(data?.jobs ?? []);
       hasMore = data?.has_more ?? false;
       stats = data?.stats ?? { done: 0, closed: 0, open: 0 };
+      const expandedRuns: Record<string, true> = {};
       for (const job of jobs) {
         const runUuid = job.panel_run_uuid;
         if (runUuid && expandedPanels[runUuid] === true && panelMembers[runUuid] !== undefined) {
-          void fetchPanelMembers(runUuid);
+          expandedRuns[runUuid] = true;
         }
       }
+      for (const runUuid of Object.keys(expandedRuns)) void fetchPanelMembers(runUuid);
       // Clear highlight if the row is no longer visible.
       // Do NOT clear selectedJobId — the selected job may
       // be on a later page (deep link, older job). The
       // drawer fetches its review independently.
       if (highlightedJobId !== undefined) {
-        const ids = new Set(jobs.map((j) => j.id));
-        if (!ids.has(highlightedJobId)) {
+        if (!getVisibleJobs().some((job) => job.id === highlightedJobId)) {
           highlightedJobId = undefined;
         }
       }
@@ -236,20 +244,40 @@ export function createJobsStore(opts: JobsStoreOptions) {
   }
 
   async function fetchPanelMembers(runUuid: string): Promise<void> {
+    if (loadingMembers[runUuid] === true) {
+      pendingPanelRefreshes = { ...pendingPanelRefreshes, [runUuid]: true };
+      return;
+    }
+
+    const version = (panelFetchVersions[runUuid] ?? 0) + 1;
+    panelFetchVersions = { ...panelFetchVersions, [runUuid]: version };
     loadingMembers = { ...loadingMembers, [runUuid]: true };
     try {
       const { data, error } = await client.GET("/api/jobs", {
-        params: { query: { panel_run: runUuid, limit: 0 } },
+        params: { query: { panel_run: runUuid, limit: 0, omit_prompt: "true" } },
       });
       if (error) throw new Error("Failed to load panel members");
+      if (panelFetchVersions[runUuid] !== version) return;
       const members = (data?.jobs ?? [])
         .filter((job) => job.panel_role === "member")
         .sort((a, b) => (a.panel_member_index ?? 0) - (b.panel_member_index ?? 0));
       panelMembers = { ...panelMembers, [runUuid]: members };
+      if (sortColumn === "cost" || sortColumn === "elapsed") {
+        jobs = sortJobs(jobs);
+      }
     } catch (err) {
-      opts.onError?.(err instanceof Error ? err.message : String(err));
+      if (panelFetchVersions[runUuid] === version) {
+        opts.onError?.(err instanceof Error ? err.message : String(err));
+      }
     } finally {
-      loadingMembers = { ...loadingMembers, [runUuid]: false };
+      if (panelFetchVersions[runUuid] === version) {
+        loadingMembers = { ...loadingMembers, [runUuid]: false };
+        if (pendingPanelRefreshes[runUuid] === true) {
+          const { [runUuid]: _pending, ...rest } = pendingPanelRefreshes;
+          pendingPanelRefreshes = rest;
+          if (expandedPanels[runUuid] === true) void fetchPanelMembers(runUuid);
+        }
+      }
     }
   }
 
@@ -335,27 +363,41 @@ export function createJobsStore(opts: JobsStoreOptions) {
 
   // Selection helpers for keyboard nav
   function selectNextJob(): void {
-    if (jobs.length === 0) return;
+    const visibleJobs = getVisibleJobs();
+    if (visibleJobs.length === 0) return;
     if (selectedJobId === undefined) {
-      selectJob(jobs[0]!.id);
+      selectJob(visibleJobs[0]!.id);
       return;
     }
-    const idx = jobs.findIndex((j) => j.id === selectedJobId);
-    if (idx < jobs.length - 1) {
-      selectJob(jobs[idx + 1]!.id);
+    const idx = visibleJobs.findIndex((j) => j.id === selectedJobId);
+    if (idx < visibleJobs.length - 1) {
+      selectJob(visibleJobs[idx + 1]!.id);
     }
   }
 
   function selectPrevJob(): void {
-    if (jobs.length === 0) return;
+    const visibleJobs = getVisibleJobs();
+    if (visibleJobs.length === 0) return;
     if (selectedJobId === undefined) {
-      selectJob(jobs[jobs.length - 1]!.id);
+      selectJob(visibleJobs[visibleJobs.length - 1]!.id);
       return;
     }
-    const idx = jobs.findIndex((j) => j.id === selectedJobId);
+    const idx = visibleJobs.findIndex((j) => j.id === selectedJobId);
     if (idx > 0) {
-      selectJob(jobs[idx - 1]!.id);
+      selectJob(visibleJobs[idx - 1]!.id);
     }
+  }
+
+  function getVisibleJobs(): ReviewJob[] {
+    const visible: ReviewJob[] = [];
+    for (const job of jobs) {
+      visible.push(job);
+      const runUuid = job.panel_run_uuid;
+      if (runUuid && expandedPanels[runUuid] === true) {
+        visible.push(...(panelMembers[runUuid] ?? []));
+      }
+    }
+    return visible;
   }
 
   // Highlight navigation (j/k without opening drawer)
@@ -364,26 +406,28 @@ export function createJobsStore(opts: JobsStoreOptions) {
   }
 
   function highlightNextJob(): void {
-    if (jobs.length === 0) return;
+    const visibleJobs = getVisibleJobs();
+    if (visibleJobs.length === 0) return;
     if (highlightedJobId === undefined) {
-      highlightedJobId = jobs[0]!.id;
+      highlightedJobId = visibleJobs[0]!.id;
       return;
     }
-    const idx = jobs.findIndex((j) => j.id === highlightedJobId);
-    if (idx < jobs.length - 1) {
-      highlightedJobId = jobs[idx + 1]!.id;
+    const idx = visibleJobs.findIndex((j) => j.id === highlightedJobId);
+    if (idx < visibleJobs.length - 1) {
+      highlightedJobId = visibleJobs[idx + 1]!.id;
     }
   }
 
   function highlightPrevJob(): void {
-    if (jobs.length === 0) return;
+    const visibleJobs = getVisibleJobs();
+    if (visibleJobs.length === 0) return;
     if (highlightedJobId === undefined) {
-      highlightedJobId = jobs[jobs.length - 1]!.id;
+      highlightedJobId = visibleJobs[visibleJobs.length - 1]!.id;
       return;
     }
-    const idx = jobs.findIndex((j) => j.id === highlightedJobId);
+    const idx = visibleJobs.findIndex((j) => j.id === highlightedJobId);
     if (idx > 0) {
-      highlightedJobId = jobs[idx - 1]!.id;
+      highlightedJobId = visibleJobs[idx - 1]!.id;
     }
   }
 
@@ -442,6 +486,7 @@ export function createJobsStore(opts: JobsStoreOptions) {
 
   return {
     getJobs,
+    getVisibleJobs,
     isLoading,
     getHasMore,
     getStats,

--- a/packages/ui/src/stores/roborev/jobs.svelte.ts
+++ b/packages/ui/src/stores/roborev/jobs.svelte.ts
@@ -46,7 +46,8 @@ export function createJobsStore(opts: JobsStoreOptions) {
   let expandedPanels = $state<Record<string, boolean>>({});
   let panelMembers = $state<Record<string, ReviewJob[]>>({});
   let loadingMembers = $state<Record<string, boolean>>({});
-  let panelFetchVersions: Record<string, number> = {};
+  let panelRequestedVersions: Record<string, number> = {};
+  let activePanelFetchVersions: Record<string, number> = {};
   let pendingPanelRefreshes: Record<string, boolean> = {};
 
   // SSE
@@ -79,6 +80,17 @@ export function createJobsStore(opts: JobsStoreOptions) {
   function getPanelMembersForJob(job: ReviewJob): ReviewJob[] | undefined {
     const runUuid = job.panel_run_uuid;
     return runUuid ? panelMembers[runUuid] : undefined;
+  }
+
+  function getPanelParentForMemberId(memberId: number): ReviewJob | undefined {
+    for (const job of jobs) {
+      const runUuid = job.panel_run_uuid;
+      if (!runUuid || !isPanelParent(job)) continue;
+      if (panelMembers[runUuid]?.some((member) => member.id === memberId)) {
+        return job;
+      }
+    }
+    return undefined;
   }
 
   function getSortValue(job: ReviewJob, col: SortColumn): string | number {
@@ -131,7 +143,7 @@ export function createJobsStore(opts: JobsStoreOptions) {
       const expandedRuns: Record<string, true> = {};
       for (const job of jobs) {
         const runUuid = job.panel_run_uuid;
-        if (runUuid && expandedPanels[runUuid] === true && panelMembers[runUuid] !== undefined) {
+        if (runUuid && expandedPanels[runUuid] === true) {
           expandedRuns[runUuid] = true;
         }
       }
@@ -142,7 +154,7 @@ export function createJobsStore(opts: JobsStoreOptions) {
       // drawer fetches its review independently.
       if (highlightedJobId !== undefined) {
         if (!getVisibleJobs().some((job) => job.id === highlightedJobId)) {
-          highlightedJobId = undefined;
+          highlightedJobId = getPanelParentForMemberId(highlightedJobId)?.id;
         }
       }
     } catch (err) {
@@ -244,20 +256,25 @@ export function createJobsStore(opts: JobsStoreOptions) {
   }
 
   async function fetchPanelMembers(runUuid: string): Promise<void> {
+    const version = (panelRequestedVersions[runUuid] ?? 0) + 1;
+    panelRequestedVersions = { ...panelRequestedVersions, [runUuid]: version };
     if (loadingMembers[runUuid] === true) {
       pendingPanelRefreshes = { ...pendingPanelRefreshes, [runUuid]: true };
       return;
     }
 
-    const version = (panelFetchVersions[runUuid] ?? 0) + 1;
-    panelFetchVersions = { ...panelFetchVersions, [runUuid]: version };
+    await runPanelMembersFetch(runUuid, version);
+  }
+
+  async function runPanelMembersFetch(runUuid: string, version: number): Promise<void> {
+    activePanelFetchVersions = { ...activePanelFetchVersions, [runUuid]: version };
     loadingMembers = { ...loadingMembers, [runUuid]: true };
     try {
       const { data, error } = await client.GET("/api/jobs", {
         params: { query: { panel_run: runUuid, limit: 0, omit_prompt: "true" } },
       });
       if (error) throw new Error("Failed to load panel members");
-      if (panelFetchVersions[runUuid] !== version) return;
+      if (panelRequestedVersions[runUuid] !== version) return;
       const members = (data?.jobs ?? [])
         .filter((job) => job.panel_role === "member")
         .sort((a, b) => (a.panel_member_index ?? 0) - (b.panel_member_index ?? 0));
@@ -266,16 +283,21 @@ export function createJobsStore(opts: JobsStoreOptions) {
         jobs = sortJobs(jobs);
       }
     } catch (err) {
-      if (panelFetchVersions[runUuid] === version) {
+      if (panelRequestedVersions[runUuid] === version) {
         opts.onError?.(err instanceof Error ? err.message : String(err));
       }
     } finally {
-      if (panelFetchVersions[runUuid] === version) {
+      if (activePanelFetchVersions[runUuid] === version) {
+        const { [runUuid]: _active, ...activeRest } = activePanelFetchVersions;
+        activePanelFetchVersions = activeRest;
         loadingMembers = { ...loadingMembers, [runUuid]: false };
         if (pendingPanelRefreshes[runUuid] === true) {
           const { [runUuid]: _pending, ...rest } = pendingPanelRefreshes;
           pendingPanelRefreshes = rest;
-          if (expandedPanels[runUuid] === true) void fetchPanelMembers(runUuid);
+          const queuedVersion = panelRequestedVersions[runUuid];
+          if (queuedVersion !== undefined && queuedVersion > version && expandedPanels[runUuid] === true) {
+            void runPanelMembersFetch(runUuid, queuedVersion);
+          }
         }
       }
     }
@@ -286,6 +308,10 @@ export function createJobsStore(opts: JobsStoreOptions) {
     const runUuid = job.panel_run_uuid;
     if (!runUuid) return;
     const open = expandedPanels[runUuid] === true;
+    if (open && highlightedJobId !== undefined) {
+      const highlightedMember = panelMembers[runUuid]?.some((member) => member.id === highlightedJobId) ?? false;
+      if (highlightedMember) highlightedJobId = job.id;
+    }
     expandedPanels = { ...expandedPanels, [runUuid]: !open };
     if (!open && panelMembers[runUuid] === undefined && loadingMembers[runUuid] !== true) {
       void fetchPanelMembers(runUuid);
@@ -393,7 +419,7 @@ export function createJobsStore(opts: JobsStoreOptions) {
     for (const job of jobs) {
       visible.push(job);
       const runUuid = job.panel_run_uuid;
-      if (runUuid && expandedPanels[runUuid] === true) {
+      if (runUuid && expandedPanels[runUuid] === true && loadingMembers[runUuid] !== true) {
         visible.push(...(panelMembers[runUuid] ?? []));
       }
     }

--- a/packages/ui/src/stores/roborev/jobs.svelte.ts
+++ b/packages/ui/src/stores/roborev/jobs.svelte.ts
@@ -49,6 +49,7 @@ export function createJobsStore(opts: JobsStoreOptions) {
   let panelRequestedVersions: Record<string, number> = {};
   let activePanelFetchVersions: Record<string, number> = {};
   let pendingPanelRefreshes: Record<string, boolean> = {};
+  let interestedPanelRun: string | undefined = undefined;
 
   // SSE
   let sseConnected = $state(false);
@@ -147,6 +148,7 @@ export function createJobsStore(opts: JobsStoreOptions) {
           expandedRuns[runUuid] = true;
         }
       }
+      if (interestedPanelRun) expandedRuns[interestedPanelRun] = true;
       for (const runUuid of Object.keys(expandedRuns)) void fetchPanelMembers(runUuid);
       // Clear highlight if the row is no longer visible.
       // Do NOT clear selectedJobId — the selected job may
@@ -322,6 +324,11 @@ export function createJobsStore(opts: JobsStoreOptions) {
     if (panelMembers[runUuid] === undefined && loadingMembers[runUuid] !== true) {
       void fetchPanelMembers(runUuid);
     }
+  }
+
+  function setPanelMemberInterest(runUuid: string | undefined): void {
+    interestedPanelRun = runUuid;
+    if (runUuid !== undefined) void fetchPanelMembers(runUuid);
   }
 
   function isPanelExpanded(runUuid: string): boolean {
@@ -531,6 +538,7 @@ export function createJobsStore(opts: JobsStoreOptions) {
     isSSEConnected,
     togglePanel,
     ensurePanelMembers,
+    setPanelMemberInterest,
     isPanelExpanded,
     getPanelMembers,
     isLoadingMembers,

--- a/packages/ui/src/stores/roborev/log.svelte.ts
+++ b/packages/ui/src/stores/roborev/log.svelte.ts
@@ -6,20 +6,36 @@ interface LogLine {
   lineType: string;
 }
 
+interface RawLogLine {
+  ts?: unknown;
+  text?: unknown;
+  line_type?: unknown;
+}
+
+interface JobOutputSnapshot {
+  lines?: RawLogLine[] | null;
+}
+
 export interface LogStoreOptions {
   client: RoborevClient;
   baseUrl: string;
 }
 
 export function createLogStore(opts: LogStoreOptions) {
-  const client = opts.client;
-
   let lines = $state<LogLine[]>([]);
   let streaming = $state(false);
   let followMode = $state(true);
   let connectedJobId = $state<number | undefined>(undefined);
   let abortController: AbortController | null = null;
   let requestVersion = 0;
+
+  function logLineFromRaw(raw: RawLogLine): LogLine {
+    return {
+      ts: typeof raw.ts === "string" ? raw.ts : "",
+      text: typeof raw.text === "string" ? raw.text : "",
+      lineType: typeof raw.line_type === "string" ? raw.line_type : "",
+    };
+  }
 
   async function startStreaming(jobId: number): Promise<void> {
     stopStreaming();
@@ -60,15 +76,8 @@ export function createLogStore(opts: LogStoreOptions) {
           const trimmed = part.trim();
           if (!trimmed) continue;
           try {
-            const parsed = JSON.parse(trimmed);
-            lines = [
-              ...lines,
-              {
-                ts: parsed.ts ?? "",
-                text: parsed.text ?? "",
-                lineType: parsed.line_type ?? "",
-              },
-            ];
+            const parsed = JSON.parse(trimmed) as RawLogLine;
+            lines = [...lines, logLineFromRaw(parsed)];
           } catch {
             // Skip malformed NDJSON lines
           }
@@ -98,16 +107,12 @@ export function createLogStore(opts: LogStoreOptions) {
     stopStreaming();
     const version = ++requestVersion;
     lines = [];
-    const { data, error } = await client.GET("/api/job/output", {
-      params: { query: { job_id: jobId } },
-    });
-    if (error || !data) return;
+    const params = new URLSearchParams({ job_id: String(jobId) });
+    const resp = await fetch(`${opts.baseUrl}/api/job/output?${params}`);
+    if (!resp.ok) return;
+    const data = (await resp.json()) as JobOutputSnapshot;
     if (version !== requestVersion) return;
-    lines = (data.lines ?? []).map((l) => ({
-      ts: l.ts,
-      text: l.text,
-      lineType: l.line_type,
-    }));
+    lines = (data.lines ?? []).map(logLineFromRaw);
   }
 
   function toggleFollow(): void {

--- a/packages/ui/src/stores/roborev/log.svelte.ts
+++ b/packages/ui/src/stores/roborev/log.svelte.ts
@@ -45,7 +45,8 @@ export function createLogStore(opts: LogStoreOptions) {
     lines = [];
 
     abortController = new AbortController();
-    const url = `${opts.baseUrl}/api/job/log?job_id=${jobId}`;
+    const params = new URLSearchParams({ job_id: String(jobId), stream: "1" });
+    const url = `${opts.baseUrl}/api/job/output?${params}`;
 
     try {
       const resp = await fetch(url, {
@@ -110,7 +111,12 @@ export function createLogStore(opts: LogStoreOptions) {
     const params = new URLSearchParams({ job_id: String(jobId) });
     const resp = await fetch(`${opts.baseUrl}/api/job/output?${params}`);
     if (!resp.ok) return;
-    const data = (await resp.json()) as JobOutputSnapshot;
+    let data: JobOutputSnapshot;
+    try {
+      data = (await resp.json()) as JobOutputSnapshot;
+    } catch {
+      return;
+    }
     if (version !== requestVersion) return;
     lines = (data.lines ?? []).map(logLineFromRaw);
   }

--- a/packages/ui/src/utils/roborev-panel.test.ts
+++ b/packages/ui/src/utils/roborev-panel.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vite-plus/test";
+import type { components } from "../api/roborev/generated/schema.js";
+import {
+  isPanelParent,
+  isTerminalStatus,
+  panelCostUsd,
+  panelElapsedStart,
+  panelReviewHeader,
+  panelStatusLabel,
+} from "./roborev-panel.js";
+
+type ReviewJob = components["schemas"]["ReviewJob"];
+type PanelSummary = components["schemas"]["PanelSummary"];
+
+function makeJob(overrides: Partial<ReviewJob> = {}): ReviewJob {
+  return {
+    id: 1,
+    agent: "codex",
+    agentic: false,
+    enqueued_at: "2026-04-11T11:00:00Z",
+    git_ref: "deadbeef1",
+    job_type: "review",
+    prompt_prebuilt: false,
+    repo_id: 1,
+    retry_count: 0,
+    status: "done",
+    ...overrides,
+  };
+}
+
+function makeSummary(overrides: Partial<PanelSummary> = {}): PanelSummary {
+  return {
+    panel_run_uuid: "run-1",
+    members_total: 3,
+    members_terminal: 3,
+    members_succeeded: 3,
+    members_failed: 0,
+    members_canceled: 0,
+    members_skipped: 0,
+    ...overrides,
+  };
+}
+
+function makeParent(summary: Partial<PanelSummary> = {}, overrides: Partial<ReviewJob> = {}): ReviewJob {
+  return makeJob({
+    job_type: "synthesis",
+    panel_role: "synthesis",
+    panel_run_uuid: "run-1",
+    panel_summary: makeSummary(summary),
+    ...overrides,
+  });
+}
+
+function makeMember(index: number, overrides: Partial<ReviewJob> = {}): ReviewJob {
+  return makeJob({
+    id: 100 + index,
+    panel_role: "member",
+    panel_run_uuid: "run-1",
+    panel_member_index: index,
+    panel_member_name: ["default", "security", "design"][index] ?? `member-${index}`,
+    ...overrides,
+  });
+}
+
+describe("isPanelParent", () => {
+  it("is true only for synthesis rows with a non-empty summary", () => {
+    expect(isPanelParent(makeParent())).toBe(true);
+    expect(isPanelParent(makeJob())).toBe(false);
+    expect(isPanelParent(makeParent({ members_total: 0 }))).toBe(false);
+    expect(isPanelParent(makeMember(0))).toBe(false);
+  });
+});
+
+describe("isTerminalStatus", () => {
+  it("matches roborev terminal statuses", () => {
+    for (const s of ["done", "applied", "rebased", "failed", "canceled", "skipped"]) {
+      expect(isTerminalStatus(s)).toBe(true);
+    }
+    expect(isTerminalStatus("running")).toBe(false);
+    expect(isTerminalStatus("queued")).toBe(false);
+  });
+});
+
+describe("panelStatusLabel", () => {
+  it("shows progress while the parent is not terminal", () => {
+    const job = makeParent({ members_terminal: 2 }, { status: "running" });
+    expect(panelStatusLabel(job)).toBe("synthesizing… 2/3 reviewers done");
+  });
+
+  it("shows the outcome split when terminal", () => {
+    const job = makeParent({
+      members_succeeded: 2,
+      members_failed: 1,
+      members_skipped: 1,
+      members_total: 4,
+      members_terminal: 4,
+    });
+    expect(panelStatusLabel(job)).toBe("2 ok · 1 failed · 1 skipped");
+  });
+
+  it("returns null for non-panel jobs", () => {
+    expect(panelStatusLabel(makeJob())).toBeNull();
+  });
+});
+
+describe("panelCostUsd", () => {
+  const priced = (usd: number) => JSON.stringify({ has_cost: true, cost_usd: usd });
+
+  it("returns own cost for non-panel jobs", () => {
+    expect(panelCostUsd(makeJob({ token_usage: priced(0.1) }), undefined)).toBeCloseTo(0.1);
+    expect(panelCostUsd(makeJob(), undefined)).toBeNull();
+  });
+
+  it("sums own plus fetched member costs, skipping unpriced members", () => {
+    const parent = makeParent({}, { token_usage: priced(0.05) });
+    const members = [makeMember(0, { token_usage: priced(0.2) }), makeMember(1)];
+    expect(panelCostUsd(parent, members)).toBeCloseTo(0.25);
+  });
+
+  it("falls back to the summary aggregate when members are not fetched", () => {
+    const parent = makeParent(
+      { members_with_cost: 2, members_cost_usd: 0.3, members_cost_complete: false },
+      { token_usage: priced(0.05) },
+    );
+    expect(panelCostUsd(parent, undefined)).toBeCloseTo(0.35);
+  });
+
+  it("returns null when nothing is priced", () => {
+    expect(panelCostUsd(makeParent(), undefined)).toBeNull();
+    expect(panelCostUsd(makeParent(), [makeMember(0)])).toBeNull();
+  });
+});
+
+describe("panelElapsedStart", () => {
+  it("prefers the earliest of summary first start, member starts, and own start", () => {
+    const parent = makeParent({ first_started_at: "2026-04-11T11:10:00Z" }, { started_at: "2026-04-11T11:30:00Z" });
+    expect(panelElapsedStart(parent, undefined)).toBe("2026-04-11T11:10:00Z");
+    const members = [makeMember(0, { started_at: "2026-04-11T11:05:00Z" })];
+    expect(panelElapsedStart(parent, members)).toBe("2026-04-11T11:05:00Z");
+  });
+
+  it("returns own start for non-panel jobs", () => {
+    expect(panelElapsedStart(makeJob({ started_at: "2026-04-11T11:00:00Z" }), undefined)).toBe("2026-04-11T11:00:00Z");
+    expect(panelElapsedStart(makeJob(), undefined)).toBeUndefined();
+  });
+});
+
+describe("panelReviewHeader", () => {
+  it("lists member names and verdicts when members are loaded", () => {
+    const members = [makeMember(0, { verdict: "P" }), makeMember(1, { verdict: "F" }), makeMember(2)];
+    expect(panelReviewHeader(makeParent(), members)).toBe("3 reviewers: default P, security F, design ·");
+  });
+
+  it("falls back to the summary split without members", () => {
+    const parent = makeParent({ members_succeeded: 2, members_failed: 1 });
+    expect(panelReviewHeader(parent, undefined)).toBe("3 reviewers: 2 ok · 1 failed");
+  });
+
+  it("returns null for non-panel jobs", () => {
+    expect(panelReviewHeader(makeJob(), undefined)).toBeNull();
+  });
+});

--- a/packages/ui/src/utils/roborev-panel.ts
+++ b/packages/ui/src/utils/roborev-panel.ts
@@ -1,0 +1,88 @@
+import type { components } from "../api/roborev/generated/schema.js";
+import { parseCostUsd } from "./roborev-cost.js";
+
+type ReviewJob = components["schemas"]["ReviewJob"];
+
+const TERMINAL_STATUSES = new Set(["done", "applied", "rebased", "failed", "canceled", "skipped"]);
+
+export function isTerminalStatus(status: string): boolean {
+  return TERMINAL_STATUSES.has(status);
+}
+
+export function isPanelParent(job: ReviewJob): boolean {
+  return job.panel_role === "synthesis" && (job.panel_summary?.members_total ?? 0) > 0;
+}
+
+export function panelStatusLabel(job: ReviewJob): string | null {
+  const summary = job.panel_summary;
+  if (!isPanelParent(job) || !summary) return null;
+
+  if (!isTerminalStatus(job.status)) {
+    return `synthesizing… ${summary.members_terminal}/${summary.members_total} reviewers done`;
+  }
+
+  const parts: string[] = [];
+  if (summary.members_succeeded > 0) parts.push(`${summary.members_succeeded} ok`);
+  if (summary.members_failed > 0) parts.push(`${summary.members_failed} failed`);
+  if (summary.members_canceled > 0) parts.push(`${summary.members_canceled} canceled`);
+  if (summary.members_skipped > 0) parts.push(`${summary.members_skipped} skipped`);
+  if (parts.length === 0) return `${summary.members_terminal}/${summary.members_total} done`;
+  return parts.join(" · ");
+}
+
+export function panelCostUsd(job: ReviewJob, members: ReviewJob[] | undefined): number | null {
+  const ownCost = parseCostUsd(job.token_usage);
+  if (!isPanelParent(job)) return ownCost;
+
+  let total = ownCost ?? 0;
+  let hasAnyCost = ownCost !== null;
+
+  if (members !== undefined) {
+    for (const member of members) {
+      const memberCost = parseCostUsd(member.token_usage);
+      if (memberCost !== null) {
+        total += memberCost;
+        hasAnyCost = true;
+      }
+    }
+    return hasAnyCost ? total : null;
+  }
+
+  const summary = job.panel_summary;
+  if (summary && ((summary.members_with_cost ?? 0) > 0 || summary.members_cost_complete === true)) {
+    return total + (summary.members_cost_usd ?? 0);
+  }
+
+  return hasAnyCost ? total : null;
+}
+
+export function panelElapsedStart(job: ReviewJob, members: ReviewJob[] | undefined): string | undefined {
+  let earliest = job.started_at;
+
+  function consider(candidate: string | undefined): void {
+    if (!candidate) return;
+    if (!earliest || new Date(candidate).getTime() < new Date(earliest).getTime()) {
+      earliest = candidate;
+    }
+  }
+
+  if (isPanelParent(job)) {
+    consider(job.panel_summary?.first_started_at);
+    for (const member of members ?? []) consider(member.started_at);
+  }
+
+  return earliest;
+}
+
+export function panelReviewHeader(job: ReviewJob, members: ReviewJob[] | undefined): string | null {
+  const summary = job.panel_summary;
+  if (!isPanelParent(job) || !summary) return null;
+
+  if (members !== undefined && members.length > 0) {
+    const parts = members.map((member) => `${member.panel_member_name || member.agent} ${member.verdict ?? "·"}`);
+    return `${members.length} reviewers: ${parts.join(", ")}`;
+  }
+
+  const split = panelStatusLabel(job);
+  return split ? `${summary.members_total} reviewers: ${split}` : null;
+}

--- a/packages/ui/src/views/ReviewsView.svelte
+++ b/packages/ui/src/views/ReviewsView.svelte
@@ -97,26 +97,36 @@
         if (!jobsStore) break;
         const highlightedId =
           jobsStore.getHighlightedJobId();
-        const job = jobsStore
-          .getJobs()
+        const highlighted = jobsStore
+          .getVisibleJobs()
           .find(
             (candidate) =>
               candidate.id === highlightedId,
           );
+        const panelParent =
+          highlighted && isPanelParent(highlighted)
+            ? highlighted
+            : jobsStore
+                .getJobs()
+                .find(
+                  (candidate) =>
+                    isPanelParent(candidate) &&
+                    candidate.panel_run_uuid ===
+                      highlighted?.panel_run_uuid,
+                );
         if (
-          job &&
-          isPanelParent(job) &&
-          job.panel_run_uuid
+          panelParent &&
+          panelParent.panel_run_uuid
         ) {
           const open = jobsStore.isPanelExpanded(
-            job.panel_run_uuid,
+            panelParent.panel_run_uuid,
           );
           if (
             (e.key === "ArrowRight" && !open) ||
             (e.key === "ArrowLeft" && open)
           ) {
             e.preventDefault();
-            jobsStore.togglePanel(job);
+            jobsStore.togglePanel(panelParent);
           }
         }
         break;

--- a/packages/ui/src/views/ReviewsView.svelte
+++ b/packages/ui/src/views/ReviewsView.svelte
@@ -15,6 +15,7 @@
     from "../components/roborev/ReviewDrawer.svelte";
   import ShortcutHelpModal
     from "../components/roborev/ShortcutHelpModal.svelte";
+  import { isPanelParent } from "../utils/roborev-panel.js";
 
   interface Props {
     jobId?: number;
@@ -90,6 +91,36 @@
         e.preventDefault();
         stores.roborevJobs?.highlightPrevJob();
         break;
+      case "ArrowRight":
+      case "ArrowLeft": {
+        const jobsStore = stores.roborevJobs;
+        if (!jobsStore) break;
+        const highlightedId =
+          jobsStore.getHighlightedJobId();
+        const job = jobsStore
+          .getJobs()
+          .find(
+            (candidate) =>
+              candidate.id === highlightedId,
+          );
+        if (
+          job &&
+          isPanelParent(job) &&
+          job.panel_run_uuid
+        ) {
+          const open = jobsStore.isPanelExpanded(
+            job.panel_run_uuid,
+          );
+          if (
+            (e.key === "ArrowRight" && !open) ||
+            (e.key === "ArrowLeft" && open)
+          ) {
+            e.preventDefault();
+            jobsStore.togglePanel(job);
+          }
+        }
+        break;
+      }
       case "Enter": {
         const highlighted =
           stores.roborevJobs?.getHighlightedJobId();


### PR DESCRIPTION
- Hide auto-design router byproducts by default, with a Show auto-design toggle in the Reviews filters.
- Render Roborev synthesis panels as expandable parent rows with inline reviewer member rows.
- Show panel reviewer verdicts and aggregate status, elapsed time, and cost in the table and drawer.