### PR TITLE
fix: keep Kata task short id visible in detail breadcrumb

### DIFF
--- a/frontend/src/lib/components/kata/KataIssueDetail.svelte
+++ b/frontend/src/lib/components/kata/KataIssueDetail.svelte
@@ -450,13 +450,11 @@
   }
 
   .crumb-id {
-    min-width: 0;
+    flex: none;
     color: var(--text-secondary);
     font-family: var(--font-mono);
     font-size: var(--font-size-xs);
     font-weight: 650;
-    overflow: hidden;
-    text-overflow: ellipsis;
     white-space: nowrap;
   }
 


### PR DESCRIPTION
The short id in the Kata task detail breadcrumb could collapse to an ellipsis (e.g. `14…`) when the kicker row ran out of room, hiding the identifier users rely on to reference tasks. The id is the part that must always be readable; the project selector next to it already truncates its own label gracefully, so it is the right element to absorb the shrinkage.

- The task short id in the detail breadcrumb no longer truncates; the project control shrinks instead.

Narrow-width capture with the id fully visible next to the shrunken project control:

![crumb-capture.png](https://github.com/user-attachments/assets/459ac522-2b94-4517-afbe-1c057af3cc5e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)