### PR TITLE
fix: make Kata task selection render the detail pane without waiting on slow reads

### DIFF
--- a/context/testing.md
+++ b/context/testing.md
@@ -97,6 +97,11 @@ icon mid-run, re-bundles, and the page reload breaks unrelated suites with
 "Failed to fetch dynamically imported module". Verify with the grep documented
 above that list in the config.
 
+Full-stack e2e serves the frontend embedded in the e2e-server binary
+(`internal/web/dist`), not live sources: run `make frontend` before building
+`cmd/e2e-server` locally, or the suite silently validates a stale bundle and
+passes on frontend changes that CI then fails.
+
 Roborev `hide_classify_jobs` e2e fixtures must cover skipped design rows and classify-typed auto-design rows.
 Seed classify rows terminal unless testing worker mutation; live workers can rewrite queued/running rows during browser assertions (`internal/testutil/roborev_fixtures.go::seedRoborevMutationFixtures`).
 Keep injected Roborev `panel_run` failures controlled until the assertion observes them; drawer/list refresh demand can immediately retry member fetches and clear transient panel errors (`packages/ui/src/stores/roborev/jobs.svelte.ts::wantsPanelMembers`).

--- a/context/testing.md
+++ b/context/testing.md
@@ -102,6 +102,12 @@ Full-stack e2e serves the frontend embedded in the e2e-server binary
 `cmd/e2e-server` locally, or the suite silently validates a stale bundle and
 passes on frontend changes that CI then fails.
 
+Mounting `KataWorkspace.svelte` in Vitest always fetches the daemon roster and
+opens the live SSE event stream; mock both fetch routes (see
+`mockDaemonAndStreamFetch` in `KataWorkspaceEventStream.test.ts`) or the
+stream's error recovery reloads the view mid-test and silently reverts
+selections made by the test.
+
 Roborev `hide_classify_jobs` e2e fixtures must cover skipped design rows and classify-typed auto-design rows.
 Seed classify rows terminal unless testing worker mutation; live workers can rewrite queued/running rows during browser assertions (`internal/testutil/roborev_fixtures.go::seedRoborevMutationFixtures`).
 Keep injected Roborev `panel_run` failures controlled until the assertion observes them; drawer/list refresh demand can immediately retry member fetches and clear transient panel errors (`packages/ui/src/stores/roborev/jobs.svelte.ts::wantsPanelMembers`).

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -29,7 +29,11 @@ state.
   when the issue payload carries no project name. Server-side daemon reads
   never follow redirects, matching the passthrough proxy and health probe.
   The response varies by `X-Middleman-Kata-Daemon` and must keep declaring
-  `Vary` on it.
+  `Vary` on it. The frontend mirrors the critical-path rule: a direct task
+  selection resolves (and syncs the route) as soon as the detail applies,
+  with the event-log read finishing in a guarded background continuation
+  whose failure must not fail the selection
+  (`frontend/src/lib/stores/kata-workspace.svelte.ts::loadSelectedIssue`).
 - `POST /kata/workspaces`: create or reuse a Kata-task-backed workspace. Kata
   tasks are not provider issues, so this path never resolves or syncs a
   provider issue row.

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -18,9 +18,12 @@ state.
 - `POST /repos/{owner}/{name}/issues/{number}/workspace`: create or reuse an
   issue-backed workspace; these start from the repo's current `origin/HEAD`,
   not from a PR head branch.
-- `POST /kata/workspace-target`: resolve whether a Kata task has a clear
-  repository target. The UI should hide the workspace action when this returns
-  `available:false`.
+- `GET /kata/tasks/{issue_uid}`: middleman's combined Kata task read. It
+  fetches the daemon's issue detail server-side and returns it together with
+  the resolved workspace target, so the detail pane and its workspace action
+  render from one response. There is no separate workspace-target endpoint;
+  do not reintroduce one. The UI hides the workspace action when the embedded
+  target has `available:false`.
 - `POST /kata/workspaces`: create or reuse a Kata-task-backed workspace. Kata
   tasks are not provider issues, so this path never resolves or syncs a
   provider issue row.

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -23,7 +23,10 @@ state.
   the resolved workspace target, so the detail pane and its workspace action
   render from one response. There is no separate workspace-target endpoint;
   do not reintroduce one. The UI hides the workspace action when the embedded
-  target has `available:false`.
+  target has `available:false`. The issue read is the critical path: the
+  daemon `/projects` read is best-effort on a short independent budget and
+  must never delay or fail the detail response. The response varies by
+  `X-Middleman-Kata-Daemon` and must keep declaring `Vary` on it.
 - `POST /kata/workspaces`: create or reuse a Kata-task-backed workspace. Kata
   tasks are not provider issues, so this path never resolves or syncs a
   provider issue row.

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -23,16 +23,26 @@ state.
   the resolved workspace target, so the detail pane and its workspace action
   render from one response. There is no separate workspace-target endpoint;
   do not reintroduce one. The UI hides the workspace action when the embedded
-  target has `available:false`. The issue read is the critical path: the
-  daemon `/projects` read is best-effort on a short independent budget and
-  must never delay or fail the detail response; the handler waits on it only
-  when the issue payload carries no project name. Server-side daemon reads
-  never follow redirects, matching the passthrough proxy and health probe.
-  The response varies by `X-Middleman-Kata-Daemon` and must keep declaring
-  `Vary` on it. The frontend mirrors the critical-path rule: a direct task
-  selection resolves (and syncs the route) as soon as the detail applies,
-  with the event-log read finishing in a guarded background continuation
-  whose failure must not fail the selection
+  target has `available:false`. The issue read is the critical path and the
+  `/projects` read is best-effort enrichment that must never fail the detail
+  response. The exact latency contract: when the issue payload carries
+  `project_name`, the handler never waits on `/projects` (it takes the
+  result only if already available); when the payload has no name, it may
+  wait only up to the short `/projects`-specific budget
+  (`internal/server/kata_task_detail.go::kataDaemonProjectsReadTimeout`)
+  before falling back to the (empty) payload name. Server-side daemon reads
+  never follow redirects, matching the passthrough proxy and health probe: a
+  redirected issue read surfaces as a `502 upstream_error`, and a redirected
+  `/projects` read is just a failed best-effort read that falls back to the
+  payload name. All outcomes, including problem responses, depend on the
+  daemon selection and must declare `Vary: X-Middleman-Kata-Daemon`. The
+  frontend mirrors the critical-path rule for direct user selections only: a
+  direct selection resolves (and syncs the route) as soon as the detail
+  applies, with the event-log read finishing in a guarded background
+  continuation whose failure silently leaves the event list empty rather
+  than failing the selection. View/bootstrap loads intentionally stay
+  atomic; do not move them to the background-events behavior, or the
+  route-sync effect can stomp a fresh selection
   (`frontend/src/lib/stores/kata-workspace.svelte.ts::loadSelectedIssue`).
 - `POST /kata/workspaces`: create or reuse a Kata-task-backed workspace. Kata
   tasks are not provider issues, so this path never resolves or syncs a

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -25,8 +25,11 @@ state.
   do not reintroduce one. The UI hides the workspace action when the embedded
   target has `available:false`. The issue read is the critical path: the
   daemon `/projects` read is best-effort on a short independent budget and
-  must never delay or fail the detail response. The response varies by
-  `X-Middleman-Kata-Daemon` and must keep declaring `Vary` on it.
+  must never delay or fail the detail response; the handler waits on it only
+  when the issue payload carries no project name. Server-side daemon reads
+  never follow redirects, matching the passthrough proxy and health probe.
+  The response varies by `X-Middleman-Kata-Daemon` and must keep declaring
+  `Vary` on it.
 - `POST /kata/workspaces`: create or reuse a Kata-task-backed workspace. Kata
   tasks are not provider issues, so this path never resolves or syncs a
   provider issue row.

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -2483,16 +2483,30 @@ components:
         - platform_host
         - repo_path
       type: object
-    KataWorkspaceTargetResponse:
+    KataTaskDetailResponse:
       additionalProperties: false
       properties:
         $schema:
           description: A URL to the JSON Schema for this object.
           examples:
-            - /api/v1/schemas/KataWorkspaceTargetResponse.json
+            - /api/v1/schemas/KataTaskDetailResponse.json
           format: uri
           readOnly: true
           type: string
+        detail:
+          description: Verbatim Kata daemon issue detail payload
+        etag:
+          description: Daemon issue detail ETag, when the daemon provided one
+          type: string
+        workspace_target:
+          $ref: "#/components/schemas/KataWorkspaceTargetResponse"
+      required:
+        - detail
+        - workspace_target
+      type: object
+    KataWorkspaceTargetResponse:
+      additionalProperties: false
+      properties:
         available:
           type: boolean
         existing_workspace:
@@ -12848,21 +12862,29 @@ paths:
       summary: List Kata daemons
       tags:
         - Kata
-  /kata/workspace-target:
-    post:
-      operationId: resolve-kata-workspace-target
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/KataWorkspaceTaskRequest"
-        required: true
+  /kata/tasks/{issue_uid}:
+    get:
+      operationId: get-kata-task-detail
+      parameters:
+        - description: Kata issue UID
+          in: path
+          name: issue_uid
+          required: true
+          schema:
+            description: Kata issue UID
+            type: string
+        - description: Kata daemon id; the effective default daemon when empty
+          in: header
+          name: X-Middleman-Kata-Daemon
+          schema:
+            description: Kata daemon id; the effective default daemon when empty
+            type: string
       responses:
         "200":
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/KataWorkspaceTargetResponse"
+                $ref: "#/components/schemas/KataTaskDetailResponse"
           description: OK
         default:
           content:
@@ -12870,7 +12892,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ProblemError"
           description: Error
-      summary: Resolve Kata workspace target
+      summary: Get Kata task detail with workspace target
       tags:
         - Kata
   /kata/workspaces:

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -12886,6 +12886,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/KataTaskDetailResponse"
           description: OK
+          headers:
+            Vary:
+              schema:
+                type: string
         default:
           content:
             application/problem+json:

--- a/frontend/src/lib/api/kata/daemons.ts
+++ b/frontend/src/lib/api/kata/daemons.ts
@@ -8,6 +8,7 @@ export type KataDaemonInfo = components["schemas"]["KataDaemonResponse"];
 
 const API_PREFIX = "/api" + "/v1";
 const KATA_PROXY_ROUTE = `${API_PREFIX}/kata/proxy`;
+const KATA_TASKS_ROUTE = `${API_PREFIX}/kata/tasks`;
 
 function appPath(path: string): string {
   const basePath = typeof window !== "undefined" ? (window.__BASE_PATH__ ?? "/") : "/";
@@ -25,7 +26,15 @@ export function kataProxyPath(path: string): string {
   return appPath(`${KATA_PROXY_ROUTE}${normalized}`);
 }
 
-function isSameOriginProxyRequest(input: RequestInfo | URL): boolean {
+// Path of middleman's combined task-detail read: daemon detail enriched with
+// the workspace target, served by middleman itself rather than the proxy.
+export function kataTaskDetailPath(uid: string): string {
+  return appPath(`${KATA_TASKS_ROUTE}/${encodeURIComponent(uid)}`);
+}
+
+// Daemon-scoped requests carry the daemon selection header: everything under
+// the passthrough proxy, plus middleman's own daemon-backed task reads.
+function isSameOriginKataDaemonRequest(input: RequestInfo | URL): boolean {
   const origin = globalThis.location?.origin;
   if (!origin) return true;
   let raw: string;
@@ -36,7 +45,11 @@ function isSameOriginProxyRequest(input: RequestInfo | URL): boolean {
 
   try {
     const url = new URL(raw, origin);
-    return url.origin === origin && url.pathname.startsWith(appPath(`${KATA_PROXY_ROUTE}/`));
+    if (url.origin !== origin) return false;
+    return (
+      url.pathname.startsWith(appPath(`${KATA_PROXY_ROUTE}/`)) ||
+      url.pathname.startsWith(appPath(`${KATA_TASKS_ROUTE}/`))
+    );
   } catch {
     return false;
   }
@@ -77,7 +90,7 @@ export function withKataDaemon(fetchImpl: typeof fetch, getId: () => string | un
       new Headers(init.headers).forEach((value, key) => headers.set(key, value));
     }
 
-    if (!isSameOriginProxyRequest(input)) {
+    if (!isSameOriginKataDaemonRequest(input)) {
       if (!headers.has(KATA_DAEMON_HEADER)) return fetchImpl(input, init);
       headers.delete(KATA_DAEMON_HEADER);
       return fetchImpl(input, { ...init, headers });

--- a/frontend/src/lib/api/kata/taskClient.test.ts
+++ b/frontend/src/lib/api/kata/taskClient.test.ts
@@ -299,18 +299,20 @@ describe("kata task HTTP client", () => {
           },
         },
       },
-      "/api/v1/issues/issue-capture": {
-        headers: { etag: '"rev-2"' },
+      "/api/v1/kata/tasks/issue-capture": {
         body: {
-          issue: {
-            ...issue("issue-capture", "Capture retry", "project-inbox", {
-              scheduled_on: "2026-05-20",
-            }),
-            revision: 2,
+          etag: '"rev-2"',
+          detail: {
+            issue: {
+              ...issue("issue-capture", "Capture retry", "project-inbox", {
+                scheduled_on: "2026-05-20",
+              }),
+              revision: 2,
+            },
+            comments: [],
+            labels: [],
+            links: [],
           },
-          comments: [],
-          labels: [],
-          links: [],
         },
       },
     });
@@ -336,7 +338,7 @@ describe("kata task HTTP client", () => {
     expect(calls.map((call) => proxyPath(call.url))).toEqual([
       "/api/v1/projects/7/issues",
       "/api/v1/projects/7/issues/issue-capture/metadata",
-      "/api/v1/issues/issue-capture",
+      "/api/v1/kata/tasks/issue-capture",
     ]);
     expect(calls[0]!.headers.get(KATA_DAEMON_HEADER)).toBe("home");
     expect(calls[1]!.headers.get(KATA_DAEMON_HEADER)).toBe("home");
@@ -632,24 +634,33 @@ describe("kata task HTTP client", () => {
     ]);
   });
 
-  test("calls issue detail by uid and exposes response etags", async () => {
+  test("reads the combined task detail and exposes etags and the workspace target", async () => {
     const { calls, fetchImpl } = createFetchStub({
-      "/api/v1/issues/issue-1": {
-        headers: { etag: '"rev-3"' },
-        body: { issue: { ...issue("issue-1", "Shown issue"), body: "Body" }, comments: [], labels: [], links: [] },
+      "/api/v1/kata/tasks/issue-1": {
+        body: {
+          etag: '"rev-3"',
+          detail: { issue: { ...issue("issue-1", "Shown issue"), body: "Body" }, comments: [], labels: [], links: [] },
+          workspace_target: { available: true, item_type: "kata_task", item_key: "kata:home:project-kata:issue-1" },
+        },
       },
     });
     const api = createKataTaskAPI({ fetchImpl });
 
-    await expect(api.issue("issue-1")).resolves.toMatchObject({ etag: '"rev-3"', issue: { title: "Shown issue" } });
+    await expect(api.issue("issue-1")).resolves.toMatchObject({
+      etag: '"rev-3"',
+      issue: { title: "Shown issue" },
+      workspace_target: { available: true },
+    });
 
-    expect(proxyPath(calls[0]!.url)).toBe("/api/v1/issues/issue-1");
+    expect(proxyPath(calls[0]!.url)).toBe("/api/v1/kata/tasks/issue-1");
   });
 
   test("uses an explicit daemon for pinned issue detail reads", async () => {
     const { calls, fetchImpl } = createFetchStub({
-      "/api/v1/issues/issue-1": {
-        body: { issue: { ...issue("issue-1", "Shown issue"), body: "Body" }, comments: [], labels: [], links: [] },
+      "/api/v1/kata/tasks/issue-1": {
+        body: {
+          detail: { issue: { ...issue("issue-1", "Shown issue"), body: "Body" }, comments: [], labels: [], links: [] },
+        },
       },
     });
     const api = createKataTaskAPI({ fetchImpl, getDaemonId: () => "default" });
@@ -661,10 +672,12 @@ describe("kata task HTTP client", () => {
 
   test("threads abort signals through issue and events fetches", async () => {
     const { fetchImpl } = createFetchStub({
-      "/api/v1/issues/issue-1": {
-        body: { issue: { ...issue("issue-1", "Shown issue"), body: "Body" }, comments: [], labels: [], links: [] },
+      "/api/v1/kata/tasks/issue-1": {
+        body: {
+          detail: { issue: { ...issue("issue-1", "Shown issue"), body: "Body" }, comments: [], labels: [], links: [] },
+        },
       },
-      "/api/v1/events?limit=100": {
+      "/api/v1/events?limit=1000": {
         body: { reset_required: false, events: [], next_after_id: 0 },
       },
     });
@@ -751,9 +764,9 @@ describe("kata task HTTP client", () => {
     expect(graph.nodes[0]?.project_name).toBe("Work");
   });
 
-  test("paginates issue-scoped event reads until the requested filtered limit is reached", async () => {
+  test("paginates issue-scoped event reads in large pages until the requested filtered limit is reached", async () => {
     const { calls, fetchImpl } = createFetchStub({
-      "/api/v1/events?after_id=4&limit=2": {
+      "/api/v1/events?after_id=4&limit=1000": {
         body: {
           reset_required: false,
           events: [
@@ -763,7 +776,7 @@ describe("kata task HTTP client", () => {
           next_after_id: 6,
         },
       },
-      "/api/v1/events?after_id=6&limit=2": {
+      "/api/v1/events?after_id=6&limit=1000": {
         body: {
           reset_required: false,
           events: [
@@ -779,8 +792,8 @@ describe("kata task HTTP client", () => {
     const events = await api.events({ issue_uid: "issue-1", after_id: 4, limit: 2 });
 
     expect(calls.map((call) => proxyPath(call.url))).toEqual([
-      "/api/v1/events?after_id=4&limit=2",
-      "/api/v1/events?after_id=6&limit=2",
+      "/api/v1/events?after_id=4&limit=1000",
+      "/api/v1/events?after_id=6&limit=1000",
     ]);
     expect(events.events.map((event) => event.event_uid)).toEqual(["event-6", "event-8"]);
   });
@@ -1112,11 +1125,11 @@ describe("kata task HTTP client", () => {
 
   test("throws revision conflicts only for current revision_conflict envelopes", async () => {
     const { fetchImpl } = createFetchStub({
-      "/api/v1/issues/issue-1": {
+      "/api/v1/kata/tasks/issue-1": {
         status: 412,
         body: { error: { code: "revision_conflict", message: "stale revision" } },
       },
-      "/api/v1/issues/issue-2": {
+      "/api/v1/kata/tasks/issue-2": {
         status: 412,
         body: { error: { code: "precondition_failed", message: "missing dependency" } },
       },

--- a/frontend/src/lib/api/kata/taskClient.ts
+++ b/frontend/src/lib/api/kata/taskClient.ts
@@ -1,5 +1,5 @@
 import { getActiveKataDaemon } from "../../stores/active-kata-daemon.svelte.js";
-import { KATA_DAEMON_HEADER, kataProxyPath, withKataDaemon } from "./daemons.js";
+import { KATA_DAEMON_HEADER, kataProxyPath, kataTaskDetailPath, withKataDaemon } from "./daemons.js";
 import {
   normalizeKataEvents,
   normalizeKataInstance,
@@ -33,6 +33,7 @@ import type {
   KataTaskSearchFilters,
   KataTaskSearchResponse,
   KataTaskSummary,
+  KataWorkspaceTarget,
 } from "./taskTypes.js";
 import { buildKataTaskView } from "./taskViewBuilder.js";
 import { localDateString } from "../dates.js";
@@ -55,6 +56,9 @@ interface KataRequestInit {
   body?: unknown;
   headers?: Record<string, string> | undefined;
   signal?: AbortSignal | undefined;
+  // The path is already app-rooted (a middleman API route) instead of a
+  // daemon path to send through the passthrough proxy.
+  appRoute?: boolean | undefined;
 }
 
 interface ErrorEnvelope {
@@ -64,6 +68,11 @@ interface ErrorEnvelope {
 }
 
 const KATA_TASK_API_PREFIX = "/api" + "/v1";
+
+// Page size for issue-scoped event-log walks. Both TCP and unix-socket
+// daemons accept limit=1000 on /events; larger pages keep the walk to a
+// handful of round trips even on multi-thousand-event logs.
+const KATA_EVENTS_SCAN_PAGE_LIMIT = 1000;
 const responseHeaders = new WeakMap<KataTaskAPI, Headers>();
 
 function isObject(value: unknown): value is Record<string, unknown> {
@@ -273,7 +282,7 @@ export function createKataTaskAPI(options: CreateKataTaskAPIOptions = {}): KataT
       requestInit.body = JSON.stringify(init.body);
     }
 
-    const response = await fetchImpl(kataProxyPath(path), requestInit);
+    const response = await fetchImpl(init.appRoute ? path : kataProxyPath(path), requestInit);
     responseHeaders.set(api, response.headers);
 
     const text = await response.text();
@@ -353,11 +362,22 @@ export function createKataTaskAPI(options: CreateKataTaskAPIOptions = {}): KataT
     pinned = false,
     signal?: AbortSignal,
   ): Promise<KataTaskDetail> {
-    const result = await request<unknown>(taskPath(`/issues/${encodeURIComponent(uid)}`), {
-      headers: pinned ? pinnedDaemonHeaders(daemonId) : daemonHeaders(daemonId),
-      signal,
-    });
-    return { ...normalizeKataTaskDetail(result.body), etag: result.headers.get("etag") ?? undefined };
+    // Middleman's combined read: the daemon detail plus the resolved
+    // workspace target in one round trip, so the detail pane and its
+    // workspace action render together.
+    const result = await request<{ detail?: unknown; etag?: string; workspace_target?: KataWorkspaceTarget }>(
+      kataTaskDetailPath(uid),
+      {
+        headers: pinned ? pinnedDaemonHeaders(daemonId) : daemonHeaders(daemonId),
+        signal,
+        appRoute: true,
+      },
+    );
+    const body = isObject(result.body) ? result.body : {};
+    const detail = normalizeKataTaskDetail(body.detail);
+    const etag = typeof body.etag === "string" && body.etag !== "" ? body.etag : undefined;
+    const target = isObject(body.workspace_target) ? (body.workspace_target as KataWorkspaceTarget) : undefined;
+    return { ...detail, etag, workspace_target: target };
   }
 
   async function postRecurrence(path: string, input: KataCreateRecurrenceInput) {
@@ -573,11 +593,11 @@ export function createKataTaskAPI(options: CreateKataTaskAPIOptions = {}): KataT
     },
 
     async events(query = {}, opts) {
-      async function fetchPage(afterID?: number): Promise<KataTaskEventsResponse> {
+      async function fetchPage(afterID: number | undefined, pageLimit: number): Promise<KataTaskEventsResponse> {
         const params = new URLSearchParams();
         if (query.project_id !== undefined) params.set("project_id", String(query.project_id));
         if (afterID !== undefined) params.set("after_id", String(afterID));
-        if (query.limit !== undefined) params.set("limit", String(query.limit));
+        params.set("limit", String(pageLimit));
         const suffix = params.toString() ? `?${params.toString()}` : "";
         const result = await request<unknown>(taskPath(`/events${suffix}`), { signal: opts?.signal });
         return normalizeKataEvents(result.body);
@@ -587,9 +607,14 @@ export function createKataTaskAPI(options: CreateKataTaskAPIOptions = {}): KataT
         let afterID = query.after_id;
         let lastResponse: KataTaskEventsResponse | undefined;
         const events: KataTaskEventsResponse["events"] = [];
+        // The daemon has no server-side issue_uid filter, so this walks the
+        // log and filters client-side. Page far beyond the requested limit:
+        // paging at query.limit means one round trip per few matches, which
+        // takes seconds against remote daemons.
+        const pageLimit = Math.max(query.limit, KATA_EVENTS_SCAN_PAGE_LIMIT);
 
         for (;;) {
-          const response = await fetchPage(afterID);
+          const response = await fetchPage(afterID, pageLimit);
           const filtered = response.events.filter((event) => eventMatchesQuery(event, query));
           events.push(...filtered);
           lastResponse = response;

--- a/frontend/src/lib/api/kata/taskTypes.ts
+++ b/frontend/src/lib/api/kata/taskTypes.ts
@@ -203,7 +203,13 @@ export interface KataTaskDetail {
   links: KataTaskLink[];
   parent?: KataTaskRef | undefined;
   children?: KataTaskSummary[] | undefined;
+  // Resolved by middleman alongside the daemon detail read, so the
+  // workspace action renders together with the pane instead of after a
+  // second round trip.
+  workspace_target?: KataWorkspaceTarget | undefined;
 }
+
+export type KataWorkspaceTarget = import("./workspaces.js").KataWorkspaceTarget;
 
 export interface KataTaskEvent {
   event_id: number;

--- a/frontend/src/lib/api/kata/workspaces.ts
+++ b/frontend/src/lib/api/kata/workspaces.ts
@@ -34,19 +34,6 @@ export function kataWorkspaceIdentityFromIssue(
   return identity;
 }
 
-export function resolveKataWorkspaceTarget(identity: KataWorkspaceTaskIdentity): Promise<KataWorkspaceTarget> {
-  return client
-    .POST("/kata/workspace-target", {
-      body: identity,
-    })
-    .then(({ data, error, response }) => {
-      if (!data) {
-        throw new Error(requestErrorMessage(error, `POST /kata/workspace-target -> ${response.status}`));
-      }
-      return data;
-    });
-}
-
 export function createKataWorkspaceForTask(identity: KataWorkspaceTaskIdentity): Promise<KataWorkspaceResponse> {
   return client
     .POST("/kata/workspaces", {

--- a/frontend/src/lib/features/kata/KataWorkspace.svelte
+++ b/frontend/src/lib/features/kata/KataWorkspace.svelte
@@ -385,13 +385,13 @@
     return `${route.view ?? ""}\u0000${route.scope ?? ""}\u0000${route.issue ?? ""}`;
   }
 
-  function routeChangeMatchesPendingSelection(route: KataRouteSnapshot): boolean {
+  function routeChangeMatchesAwaitedSelection(route: KataRouteSnapshot): boolean {
     return (
       route.view === syncedRouteViewName &&
       route.scope === syncedRouteScopeUID &&
       route.issue !== null &&
       route.issue === awaitingSelectedIssueRouteUID &&
-      route.issue === store.pendingSelectionUID
+      (route.issue === store.pendingSelectionUID || route.issue === store.selectedIssue?.issue.uid)
     );
   }
 
@@ -401,7 +401,7 @@
     const signature = routeSignature(snapshot);
     if (signature === observedRouteSignature) return;
     observedRouteSignature = signature;
-    if (routeChangeMatchesPendingSelection(snapshot)) return;
+    if (routeChangeMatchesAwaitedSelection(snapshot)) return;
     beginNavigation();
     store.invalidatePendingLoads();
   });

--- a/frontend/src/lib/features/kata/KataWorkspace.svelte
+++ b/frontend/src/lib/features/kata/KataWorkspace.svelte
@@ -6,12 +6,7 @@
   import PlusIcon from "@lucide/svelte/icons/plus";
 
   import { fetchKataDaemons, type KataDaemonInfo } from "../../api/kata/daemons.js";
-  import {
-    createKataWorkspaceForTask,
-    kataWorkspaceIdentityFromIssue,
-    resolveKataWorkspaceTarget,
-    type KataWorkspaceTarget,
-  } from "../../api/kata/workspaces.js";
+  import { createKataWorkspaceForTask, kataWorkspaceIdentityFromIssue } from "../../api/kata/workspaces.js";
   import type {
     KataCreateRecurrenceInput,
     KataPatchRecurrenceInput,
@@ -104,10 +99,7 @@
   let listResetGeneration = $state(0);
   let checklistRevealed = $state(false);
   let recurrenceDialogs = $state<KataRecurrenceDialogController | null>(null);
-  let workspaceTarget = $state.raw<KataWorkspaceTarget | null>(null);
   let workspaceActionBusy = $state(false);
-  let workspaceTargetKey: string | null = null;
-  let workspaceTargetRequestID = 0;
   let listMode = $state<ListMode>("tasks");
   let graphSourceIssue = $state.raw<KataTaskSummary | null>(null);
   const store = createKataWorkspaceStore({ api: untrack(() => api) });
@@ -161,35 +153,11 @@
     },
   });
 
-  $effect(() => {
-    const selected = store.selectedIssue?.issue;
-    const daemonID = activeKataDaemonId ?? null;
-    const requestID = ++workspaceTargetRequestID;
-    if (!selected || !daemonID) {
-      workspaceTargetKey = null;
-      workspaceTarget = null;
-      return;
-    }
-
-    const identity = kataWorkspaceIdentityFromIssue(selected, daemonID, projectNameForIssue(selected));
-    const targetKey = `${identity.daemon_id}:${identity.project_uid}:${identity.project_name ?? ""}:${identity.issue_uid}`;
-    requestError = null;
-    if (targetKey !== workspaceTargetKey) {
-      workspaceTargetKey = targetKey;
-      workspaceTarget = null;
-    }
-    void resolveKataWorkspaceTarget(identity)
-      .then((target) => {
-        if (requestID !== workspaceTargetRequestID) return;
-        workspaceTarget = target.available ? target : null;
-        requestError = null;
-      })
-      .catch((err) => {
-        if (requestID !== workspaceTargetRequestID) return;
-        requestError = kataRequestErrorMessage(err);
-        workspaceTarget = null;
-      });
-  });
+  // The workspace target arrives with the combined task-detail payload, so
+  // the workspace action renders atomically with the detail pane.
+  const workspaceTarget = $derived(
+    store.selectedIssue?.workspace_target?.available ? store.selectedIssue.workspace_target : null,
+  );
 
   const systemViews = [
     { name: "inbox", label: "Inbox" },

--- a/frontend/src/lib/features/kata/KataWorkspace.test.ts
+++ b/frontend/src/lib/features/kata/KataWorkspace.test.ts
@@ -29,10 +29,9 @@ import {
   resetKataWorkspaceTestState,
 } from "./KataWorkspaceTestSupport.js";
 
-const { mockCreateKataWorkspaceForTask, mockNavigate, mockResolveKataWorkspaceTarget } = vi.hoisted(() => ({
+const { mockCreateKataWorkspaceForTask, mockNavigate } = vi.hoisted(() => ({
   mockCreateKataWorkspaceForTask: vi.fn(),
   mockNavigate: vi.fn(),
-  mockResolveKataWorkspaceTarget: vi.fn(),
 }));
 
 vi.mock("../../api/kata/workspaces.js", async (importOriginal) => {
@@ -40,7 +39,6 @@ vi.mock("../../api/kata/workspaces.js", async (importOriginal) => {
   return {
     ...actual,
     createKataWorkspaceForTask: mockCreateKataWorkspaceForTask,
-    resolveKataWorkspaceTarget: mockResolveKataWorkspaceTarget,
   };
 });
 
@@ -72,8 +70,6 @@ describe("KataWorkspace", () => {
     resetKataWorkspaceTestState();
     mockCreateKataWorkspaceForTask.mockReset();
     mockNavigate.mockReset();
-    mockResolveKataWorkspaceTarget.mockReset();
-    mockResolveKataWorkspaceTarget.mockResolvedValue({ available: false });
   });
 
   afterEach(() => {
@@ -974,7 +970,7 @@ describe("KataWorkspace", () => {
         ],
       }),
     );
-    mockResolveKataWorkspaceTarget.mockResolvedValue({
+    const target: KataWorkspaceTarget = {
       available: true,
       repo: {
         provider: "github",
@@ -986,7 +982,7 @@ describe("KataWorkspace", () => {
       },
       item_type: "kata_task",
       item_key: "issue-pay-rent",
-    });
+    };
     mockCreateKataWorkspaceForTask.mockResolvedValue({
       id: "workspace-kata",
       item_type: "kata_task",
@@ -995,6 +991,10 @@ describe("KataWorkspace", () => {
       status: "creating",
     });
     const { api } = createWorkspaceAPI();
+    vi.mocked(api.issue).mockImplementation(async (uid: string) => ({
+      ...detail(uid, initialIssues),
+      workspace_target: target,
+    }));
 
     render(KataWorkspace, { props: { api, selectedIssueUID: "issue-pay-rent" } });
 
@@ -1002,14 +1002,6 @@ describe("KataWorkspace", () => {
       expect(screen.getByRole("heading", { name: "Pay rent" })).toBeTruthy();
       expect(screen.getByRole("button", { name: "Create workspace" })).toBeTruthy();
     });
-    expect(mockResolveKataWorkspaceTarget).toHaveBeenCalledWith(
-      expect.objectContaining({
-        daemon_id: "home",
-        project_uid: "project-finances",
-        project_name: "Finances",
-        issue_uid: "issue-pay-rent",
-      }),
-    );
     await fireEvent.click(screen.getByRole("button", { name: "Create workspace" }));
 
     await waitFor(() => {
@@ -1052,9 +1044,11 @@ describe("KataWorkspace", () => {
       item_type: "kata_task",
       item_key: "issue-pay-rent",
     };
-    const refreshedTarget = deferred<KataWorkspaceTarget>();
-    mockResolveKataWorkspaceTarget.mockResolvedValueOnce(target).mockReturnValueOnce(refreshedTarget.promise);
     const { api, addLabel } = createWorkspaceAPI();
+    vi.mocked(api.issue).mockImplementation(async (uid: string) => ({
+      ...detail(uid, initialIssues),
+      workspace_target: target,
+    }));
 
     render(KataWorkspace, { props: { api, selectedIssueUID: "issue-pay-rent" } });
 
@@ -1068,11 +1062,63 @@ describe("KataWorkspace", () => {
 
     await waitFor(() => {
       expect(addLabel).toHaveBeenCalledWith(expect.objectContaining({ ref: "issue-pay-rent" }), "middleman", "blocked");
-      expect(mockResolveKataWorkspaceTarget).toHaveBeenCalledTimes(2);
     });
     expect(screen.getByRole("button", { name: "Create workspace" })).toBeTruthy();
+  });
 
-    refreshedTarget.resolve(target);
+  it("renders the workspace action together with the detail payload", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [
+          {
+            id: "home",
+            url: "http://127.0.0.1:7777",
+            default: true,
+            auth: "none",
+            health: "connected",
+          },
+        ],
+      }),
+    );
+    const { api } = createWorkspaceAPI();
+    const slowDetail = deferred<ReturnType<typeof detail>>();
+    let holdEmailSusanDetail = false;
+    vi.mocked(api.issue).mockImplementation(async (uid: string) => {
+      if (holdEmailSusanDetail && uid === "issue-email-susan") return slowDetail.promise;
+      return detail(uid, initialIssues);
+    });
+
+    render(KataWorkspace, { props: { api, selectedIssueUID: "issue-pay-rent" } });
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Pay rent" })).toBeTruthy();
+    });
+
+    holdEmailSusanDetail = true;
+    await fireEvent.click(screen.getByRole("button", { name: /Email Susan re: Q3/ }));
+    expect(screen.queryByRole("heading", { name: "Email Susan re: Q3" })).toBeNull();
+
+    // The combined payload carries the target: pane and action land in the
+    // same flush, with no separate resolution that could pop in later.
+    slowDetail.resolve({
+      ...detail("issue-email-susan", initialIssues),
+      workspace_target: {
+        available: true,
+        repo: {
+          provider: "github",
+          platform_host: "github.com",
+          owner: "acme",
+          name: "middleman",
+          repo_path: "acme/middleman",
+          capabilities: defaultProviderCapabilities,
+        },
+        item_type: "kata_task",
+        item_key: "issue-email-susan",
+      },
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Email Susan re: Q3" })).toBeTruthy();
+      expect(screen.getByRole("button", { name: "Create workspace" })).toBeTruthy();
+    });
   });
 
   it("opens an existing workspace for the selected Kata task", async () => {
@@ -1089,16 +1135,19 @@ describe("KataWorkspace", () => {
         ],
       }),
     );
-    mockResolveKataWorkspaceTarget.mockResolvedValue({
-      available: true,
-      existing_workspace: {
-        id: "workspace-existing",
-        status: "ready",
-      },
-      item_type: "kata_task",
-      item_key: "issue-pay-rent",
-    });
     const { api } = createWorkspaceAPI();
+    vi.mocked(api.issue).mockImplementation(async (uid: string) => ({
+      ...detail(uid, initialIssues),
+      workspace_target: {
+        available: true,
+        existing_workspace: {
+          id: "workspace-existing",
+          status: "ready",
+        },
+        item_type: "kata_task",
+        item_key: "issue-pay-rent",
+      },
+    }));
 
     render(KataWorkspace, { props: { api, selectedIssueUID: "issue-pay-rent" } });
 

--- a/frontend/src/lib/features/kata/KataWorkspaceEventStream.test.ts
+++ b/frontend/src/lib/features/kata/KataWorkspaceEventStream.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test"
 
 import type {
   KataTaskAPI,
+  KataTaskEventsQuery,
   KataTaskEventsResponse,
   KataTaskIssuesQuery,
   KataTaskSummary,
@@ -19,6 +20,35 @@ import {
   projects,
   resetKataWorkspaceTestState,
 } from "./KataWorkspaceTestSupport.js";
+
+// Mounting KataWorkspace always fetches the daemon roster and opens the live
+// event stream; tests that are not about stream behavior still need both to
+// succeed, or the stream error recovery reloads the view mid-test.
+function mockDaemonAndStreamFetch(): void {
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = new URL(input instanceof Request ? input.url : String(input), window.location.origin);
+    if (url.pathname === "/api/v1/kata/daemons") {
+      return Response.json({
+        daemons: [
+          {
+            id: "home",
+            url: "http://127.0.0.1:7777",
+            default: true,
+            auth: "none",
+            health: "connected",
+          },
+        ],
+      });
+    }
+    if (url.pathname === "/api/v1/kata/proxy/api/v1/events/stream") {
+      return new Response(new ReadableStream<Uint8Array>({}), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      });
+    }
+    return new Response("not found", { status: 404 });
+  });
+}
 
 describe("KataWorkspace", () => {
   beforeEach(() => {
@@ -182,6 +212,97 @@ describe("KataWorkspace", () => {
       expect(screen.queryByText("Select a task")).toBeNull();
     });
     expect(onSelectedIssueChange).toHaveBeenCalledWith("issue-email-susan");
+  });
+
+  it("routes a clicked task before its event-log read completes", async () => {
+    mockDaemonAndStreamFetch();
+    const { api } = createWorkspaceAPI();
+    const slowEvents = deferred<KataTaskEventsResponse>();
+    vi.mocked(api.events).mockImplementation(async (query: KataTaskEventsQuery = {}, opts) => {
+      if (query.issue_uid === "issue-email-susan") {
+        return await new Promise<KataTaskEventsResponse>((resolve, reject) => {
+          const abort = () => reject(new DOMException("Aborted", "AbortError"));
+          if (opts?.signal?.aborted) {
+            abort();
+            return;
+          }
+          opts?.signal?.addEventListener("abort", abort, { once: true });
+          slowEvents.promise.then(resolve, reject);
+        });
+      }
+      return { reset_required: false, events: [], next_after_id: 0 };
+    });
+    const onSelectedIssueChange = vi.fn();
+
+    const { rerender } = render(KataWorkspace, { props: { api, onSelectedIssueChange } });
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Email Susan re: Q3/ })).toBeTruthy();
+    });
+    onSelectedIssueChange.mockClear();
+
+    await fireEvent.click(screen.getByRole("button", { name: /Email Susan re: Q3/ }));
+
+    // The detail pane and the route callback both land while the event-log
+    // read is still held open; a slow walk must not leave the URL on the
+    // previous task.
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Email Susan re: Q3" })).toBeTruthy();
+    });
+    await waitFor(() => {
+      expect(onSelectedIssueChange).toHaveBeenCalledWith("issue-email-susan");
+    });
+    await rerender({ api, onSelectedIssueChange, selectedIssueUID: "issue-email-susan" });
+
+    slowEvents.resolve({
+      reset_required: false,
+      events: [
+        {
+          event_id: 10,
+          event_uid: "event-email-susan-created",
+          origin_instance_uid: "instance-1",
+          type: "issue.created",
+          project_id: 3,
+          project_uid: "project-kata",
+          project_name: "Kata",
+          issue_id: 2,
+          issue_uid: "issue-email-susan",
+          issue_short_id: "email-susan",
+          actor: "fixture-user",
+          created_at: fetchedAt,
+        },
+      ],
+      next_after_id: 10,
+    });
+    await waitFor(() => {
+      expect(screen.getByText("created the task")).toBeTruthy();
+    });
+  });
+
+  it("routes a clicked task even when its event-log read fails", async () => {
+    mockDaemonAndStreamFetch();
+    const { api } = createWorkspaceAPI();
+    vi.mocked(api.events).mockImplementation(async (query: KataTaskEventsQuery = {}) => {
+      if (query.issue_uid === "issue-email-susan") throw new Error("event log walk failed");
+      return { reset_required: false, events: [], next_after_id: 0 };
+    });
+    const onSelectedIssueChange = vi.fn();
+
+    render(KataWorkspace, { props: { api, onSelectedIssueChange } });
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Email Susan re: Q3/ })).toBeTruthy();
+    });
+    onSelectedIssueChange.mockClear();
+
+    await fireEvent.click(screen.getByRole("button", { name: /Email Susan re: Q3/ }));
+
+    // The failed best-effort events read must neither fail the selection
+    // nor block the route update.
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Email Susan re: Q3" })).toBeTruthy();
+    });
+    await waitFor(() => {
+      expect(onSelectedIssueChange).toHaveBeenCalledWith("issue-email-susan");
+    });
   });
 
   it("surfaces a disconnected live Kata event stream", async () => {

--- a/frontend/src/lib/features/kata/KataWorkspaceTestSupport.ts
+++ b/frontend/src/lib/features/kata/KataWorkspaceTestSupport.ts
@@ -6,6 +6,7 @@ import type {
   KataReachableGraphResponse,
   KataRecurrence,
   KataTaskAPI,
+  KataTaskDetail,
   KataTaskEvent,
   KataTaskEventsResponse,
   KataTaskIssuesQuery,
@@ -175,7 +176,7 @@ function detail(
   uid: string,
   rows = initialIssues,
   commentsByUID = new Map<string, ReturnType<typeof makeComment>[]>(),
-) {
+): KataTaskDetail {
   const found = rows.find((candidate) => candidate.uid === uid) ?? rows[0]!;
   const labels = (found.labels ?? []).map((label) => ({
     issue_id: found.id,

--- a/frontend/src/lib/instrumentation/interactionTiming.test.ts
+++ b/frontend/src/lib/instrumentation/interactionTiming.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, test } from "vite-plus/test";
+
+import { clearInteraction, markInteractionStart, measureInteraction } from "./interactionTiming.js";
+
+describe("interaction timing", () => {
+  beforeEach(() => {
+    performance.clearMarks();
+    performance.clearMeasures();
+  });
+
+  test("measures a phase against the interaction start mark", () => {
+    markInteractionStart("test:interaction", "1");
+
+    measureInteraction("test:interaction", "phase-one", "1");
+    measureInteraction("test:interaction", "phase-two", "1");
+
+    expect(performance.getEntriesByName("test:interaction:phase-one", "measure")).toHaveLength(1);
+    expect(performance.getEntriesByName("test:interaction:phase-two", "measure")).toHaveLength(1);
+  });
+
+  test("a phase without a start mark records nothing", () => {
+    measureInteraction("test:interaction", "phase-one", "missing");
+
+    expect(performance.getEntriesByName("test:interaction:phase-one", "measure")).toHaveLength(0);
+  });
+
+  test("clearing an interaction drops its start mark", () => {
+    markInteractionStart("test:interaction", "1");
+    clearInteraction("test:interaction", "1");
+
+    measureInteraction("test:interaction", "phase-one", "1");
+
+    expect(performance.getEntriesByName("test:interaction:phase-one", "measure")).toHaveLength(0);
+  });
+
+  test("tokens keep concurrent interactions separate", () => {
+    markInteractionStart("test:interaction", "1");
+    markInteractionStart("test:interaction", "2");
+    clearInteraction("test:interaction", "1");
+
+    measureInteraction("test:interaction", "phase-one", "1");
+    measureInteraction("test:interaction", "phase-one", "2");
+
+    expect(performance.getEntriesByName("test:interaction:phase-one", "measure")).toHaveLength(1);
+  });
+});

--- a/frontend/src/lib/instrumentation/interactionTiming.ts
+++ b/frontend/src/lib/instrumentation/interactionTiming.ts
@@ -1,0 +1,59 @@
+// Interaction timing scaffolding on the standard User Timing API. Measures
+// land in the DevTools Performance panel (Timings track) and are queryable
+// anywhere via performance.getEntriesByName("<interaction>:<phase>"), so
+// slow interactions can be quantified in the browser, Playwright, or tests
+// without bespoke logging.
+//
+// An interaction is opened with a start mark keyed by a caller-chosen token
+// (so overlapping instances of the same interaction stay separate), then any
+// number of phases are measured against that mark. Clearing the interaction
+// drops the mark so superseded or failed instances record nothing further.
+
+type InteractionDetail = Record<string, unknown>;
+
+function startMarkName(interaction: string, token: string): string {
+  return `${interaction}:start:${token}`;
+}
+
+function perf(): Performance | null {
+  return typeof performance === "undefined" ? null : performance;
+}
+
+export function markInteractionStart(interaction: string, token: string): void {
+  const p = perf();
+  if (typeof p?.mark !== "function") return;
+  try {
+    p.mark(startMarkName(interaction, token));
+  } catch {
+    // Timing is diagnostics only; never let it break the interaction itself.
+  }
+}
+
+export function measureInteraction(
+  interaction: string,
+  phase: string,
+  token: string,
+  detail?: InteractionDetail,
+): void {
+  const p = perf();
+  if (typeof p?.measure !== "function" || typeof p.getEntriesByName !== "function") return;
+  const start = startMarkName(interaction, token);
+  if (p.getEntriesByName(start, "mark").length === 0) return;
+  const name = `${interaction}:${phase}`;
+  try {
+    p.measure(name, { start, detail });
+  } catch {
+    // Older User Timing implementations only accept positional arguments.
+    try {
+      p.measure(name, start);
+    } catch {
+      // Timing is diagnostics only; never let it break the interaction itself.
+    }
+  }
+}
+
+export function clearInteraction(interaction: string, token: string): void {
+  const p = perf();
+  if (typeof p?.clearMarks !== "function") return;
+  p.clearMarks(startMarkName(interaction, token));
+}

--- a/frontend/src/lib/stores/kata-graph-debug.ts
+++ b/frontend/src/lib/stores/kata-graph-debug.ts
@@ -3,6 +3,7 @@ export type KataGraphDebugEventKind =
   | "detail-load-complete"
   | "detail-load-stale"
   | "detail-load-start"
+  | "events-load-error"
   | "graph-load-complete"
   | "graph-load-error"
   | "graph-load-start"

--- a/frontend/src/lib/stores/kata-workspace.svelte.test.ts
+++ b/frontend/src/lib/stores/kata-workspace.svelte.test.ts
@@ -933,7 +933,9 @@ describe("kata workspace store", () => {
     expect(api.mocks.issues).not.toHaveBeenCalled();
     expect(store.currentView.name).toBe("today");
     expect(store.selectedIssue?.issue.title).toBe("Call dentist");
-    expect(store.selectedEvents.map((event) => event.issue_uid)).toEqual(["issue-call-dentist"]);
+    await vi.waitFor(() => {
+      expect(store.selectedEvents.map((event) => event.issue_uid)).toEqual(["issue-call-dentist"]);
+    });
   });
 
   test("loading an issue loads the full recurrence list for that issue project", async () => {
@@ -1009,16 +1011,35 @@ describe("kata workspace store", () => {
     api.mocks.events.mockReturnValue(slowEvents.promise);
     const store = createKataWorkspaceStore({ api });
 
-    const selection = store.selectIssue("issue-pay-rent");
-    await vi.waitFor(() => {
-      expect(store.selectedIssue?.issue.uid).toBe("issue-pay-rent");
-    });
+    // The selection itself resolves while the events read is still in
+    // flight: callers sync the route from this promise, so a slow event-log
+    // walk must not hold it.
+    await expect(store.selectIssue("issue-pay-rent")).resolves.toBe(true);
+    expect(store.selectedIssue?.issue.uid).toBe("issue-pay-rent");
     expect(store.pendingSelectionUID).toBeNull();
     expect(store.selectedEvents).toEqual([]);
 
     slowEvents.resolve({ reset_required: false, events: [events[0]!], next_after_id: 1 });
-    await expect(selection).resolves.toBe(true);
-    expect(store.selectedEvents.map((event) => event.issue_uid)).toEqual(["issue-pay-rent"]);
+    await vi.waitFor(() => {
+      expect(store.selectedEvents.map((event) => event.issue_uid)).toEqual(["issue-pay-rent"]);
+    });
+  });
+
+  test("a failed events read does not fail an already-rendered selection", async () => {
+    const api = createFakeKataTaskAPI();
+    api.mocks.events.mockRejectedValue(new Error("event log walk failed"));
+    const store = createKataWorkspaceStore({ api });
+
+    await expect(store.selectIssue("issue-pay-rent")).resolves.toBe(true);
+
+    expect(store.selectedIssue?.issue.uid).toBe("issue-pay-rent");
+    expect(store.pendingSelectionUID).toBeNull();
+    // Flush the background events continuation before proving it left the
+    // rendered detail in place with an empty event log.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(store.selectedIssue?.issue.uid).toBe("issue-pay-rent");
+    expect(store.selectedEvents).toEqual([]);
   });
 
   test("a selection superseded while its events read is in flight keeps the newer selection", async () => {
@@ -1033,17 +1054,21 @@ describe("kata workspace store", () => {
     const store = createKataWorkspaceStore({ api });
 
     holdPayRentEvents = true;
-    const first = store.selectIssue("issue-pay-rent");
-    await vi.waitFor(() => {
-      expect(store.selectedIssue?.issue.uid).toBe("issue-pay-rent");
-    });
+    // The first selection resolves once its detail is applied, even though
+    // its events read is still held open.
+    await expect(store.selectIssue("issue-pay-rent")).resolves.toBe(true);
+    expect(store.selectedIssue?.issue.uid).toBe("issue-pay-rent");
     holdPayRentEvents = false;
     await expect(store.selectIssue("issue-call-dentist")).resolves.toBe(true);
 
+    // The stale events finally landing must not leak into the newer
+    // selection's event log.
     slowEvents.resolve({ reset_required: false, events: [events[0]!], next_after_id: 1 });
-    await expect(first).resolves.toBe(false);
     expect(store.selectedIssue?.issue.uid).toBe("issue-call-dentist");
-    expect(store.selectedEvents.map((event) => event.issue_uid)).toEqual(["issue-call-dentist"]);
+    await vi.waitFor(() => {
+      expect(store.selectedEvents.map((event) => event.issue_uid)).toEqual(["issue-call-dentist"]);
+    });
+    expect(store.selectedIssue?.issue.uid).toBe("issue-call-dentist");
   });
 
   test("failed recurrence loading does not block issue selection", async () => {
@@ -1061,7 +1086,9 @@ describe("kata workspace store", () => {
     await expect(store.selectIssue("issue-call-dentist")).resolves.toBe(true);
 
     expect(store.selectedIssue?.issue.uid).toBe("issue-call-dentist");
-    expect(store.selectedEvents.map((event) => event.issue_uid)).toEqual(["issue-call-dentist"]);
+    await vi.waitFor(() => {
+      expect(store.selectedEvents.map((event) => event.issue_uid)).toEqual(["issue-call-dentist"]);
+    });
     expect(store.selectedRecurrences).toEqual([]);
     expect(store.pendingSelectionUID).toBeNull();
   });
@@ -1551,7 +1578,9 @@ describe("kata workspace store", () => {
       "Payment is scheduled.",
     );
     expect(store.selectedIssue?.issue.uid).toBe("issue-call-dentist");
-    expect(store.selectedEvents.map((event) => event.issue_uid)).toEqual(["issue-call-dentist"]);
+    await vi.waitFor(() => {
+      expect(store.selectedEvents.map((event) => event.issue_uid)).toEqual(["issue-call-dentist"]);
+    });
   });
 
   test("delayed mutation detail load does not overwrite a newer manual selection", async () => {
@@ -1582,7 +1611,9 @@ describe("kata workspace store", () => {
     await mutation;
 
     expect(store.selectedIssue?.issue.uid).toBe("issue-call-dentist");
-    expect(store.selectedEvents.map((event) => event.issue_uid)).toEqual(["issue-call-dentist"]);
+    await vi.waitFor(() => {
+      expect(store.selectedEvents.map((event) => event.issue_uid)).toEqual(["issue-call-dentist"]);
+    });
   });
 
   test("a selection made while a remote-event view refresh is in flight is not discarded", async () => {

--- a/frontend/src/lib/stores/kata-workspace.svelte.test.ts
+++ b/frontend/src/lib/stores/kata-workspace.svelte.test.ts
@@ -973,6 +973,79 @@ describe("kata workspace store", () => {
     });
   });
 
+  test("selecting an issue records detail-visible and events-loaded timing measures", async () => {
+    performance.clearMarks();
+    performance.clearMeasures();
+    const api = createFakeKataTaskAPI();
+    const store = createKataWorkspaceStore({ api });
+
+    await store.selectIssue("issue-pay-rent");
+
+    await vi.waitFor(() => {
+      expect(performance.getEntriesByName("kata:select-issue:detail-visible", "measure")).toHaveLength(1);
+      expect(performance.getEntriesByName("kata:select-issue:events-loaded", "measure")).toHaveLength(1);
+    });
+  });
+
+  test("a superseded selection does not record timing measures", async () => {
+    performance.clearMarks();
+    performance.clearMeasures();
+    const { api, signals } = apiWithHangingIssueDetail();
+    const store = createKataWorkspaceStore({ api });
+
+    const first = store.selectIssue("issue-pay-rent");
+    const second = store.selectIssue("issue-call-dentist");
+    await expect(second).resolves.toBe(true);
+    await expect(first).resolves.toBe(false);
+
+    expect(signals[0]?.aborted).toBe(true);
+    expect(performance.getEntriesByName("kata:select-issue:detail-visible", "measure")).toHaveLength(1);
+    expect(performance.getEntriesByName("kata:select-issue:events-loaded", "measure")).toHaveLength(1);
+  });
+
+  test("slow events loading does not delay showing the selected issue detail", async () => {
+    const api = createFakeKataTaskAPI();
+    const slowEvents = deferred<KataTaskEventsResponse>();
+    api.mocks.events.mockReturnValue(slowEvents.promise);
+    const store = createKataWorkspaceStore({ api });
+
+    const selection = store.selectIssue("issue-pay-rent");
+    await vi.waitFor(() => {
+      expect(store.selectedIssue?.issue.uid).toBe("issue-pay-rent");
+    });
+    expect(store.pendingSelectionUID).toBeNull();
+    expect(store.selectedEvents).toEqual([]);
+
+    slowEvents.resolve({ reset_required: false, events: [events[0]!], next_after_id: 1 });
+    await expect(selection).resolves.toBe(true);
+    expect(store.selectedEvents.map((event) => event.issue_uid)).toEqual(["issue-pay-rent"]);
+  });
+
+  test("a selection superseded while its events read is in flight keeps the newer selection", async () => {
+    const api = createFakeKataTaskAPI();
+    const slowEvents = deferred<KataTaskEventsResponse>();
+    let holdPayRentEvents = false;
+    api.mocks.events.mockImplementation((query: KataTaskEventsQuery = {}) => {
+      if (holdPayRentEvents && query.issue_uid === "issue-pay-rent") return slowEvents.promise;
+      const rows = events.filter((event) => (query.issue_uid ? event.issue_uid === query.issue_uid : true));
+      return Promise.resolve({ reset_required: false, events: rows, next_after_id: rows.at(-1)?.event_id ?? 0 });
+    });
+    const store = createKataWorkspaceStore({ api });
+
+    holdPayRentEvents = true;
+    const first = store.selectIssue("issue-pay-rent");
+    await vi.waitFor(() => {
+      expect(store.selectedIssue?.issue.uid).toBe("issue-pay-rent");
+    });
+    holdPayRentEvents = false;
+    await expect(store.selectIssue("issue-call-dentist")).resolves.toBe(true);
+
+    slowEvents.resolve({ reset_required: false, events: [events[0]!], next_after_id: 1 });
+    await expect(first).resolves.toBe(false);
+    expect(store.selectedIssue?.issue.uid).toBe("issue-call-dentist");
+    expect(store.selectedEvents.map((event) => event.issue_uid)).toEqual(["issue-call-dentist"]);
+  });
+
   test("failed recurrence loading does not block issue selection", async () => {
     const loaded = [recurrence({ id: 1, template_title: "Loaded recurrence" })];
     const api = createFakeKataTaskAPI();

--- a/frontend/src/lib/stores/kata-workspace.svelte.ts
+++ b/frontend/src/lib/stores/kata-workspace.svelte.ts
@@ -1043,13 +1043,19 @@ export class KataWorkspaceStore {
       clearInteraction(KATA_SELECT_ISSUE_INTERACTION, timingToken);
       return false;
     }
-    // Direct selections render the pane as soon as the detail lands. View
-    // loads keep the original atomic apply: their callers update route
-    // bookkeeping only after this promise settles, and an intermediate
-    // reactive flush would let the workspace route-sync effect stomp the
-    // fresh selection with the stale route issue.
-    const applyDetailEarly = viewRequestID === undefined;
-    if (applyDetailEarly) applyDetail();
+    // Direct selections render the pane and resolve as soon as the detail
+    // lands: callers sync the route from this promise, so it must not wait
+    // on (or fail with) the event-log walk, which finishes in a guarded
+    // background continuation. View loads keep the original atomic apply:
+    // their callers update route bookkeeping only after this promise
+    // settles, and an intermediate reactive flush would let the workspace
+    // route-sync effect stomp the fresh selection with the stale route
+    // issue.
+    if (viewRequestID === undefined) {
+      applyDetail();
+      void this.finishSelectedEvents(eventsPromise, abort, uid, detailRequestID, timingToken);
+      return true;
+    }
 
     let events: KataTaskEventsResponse;
     try {
@@ -1061,7 +1067,7 @@ export class KataWorkspaceStore {
     } finally {
       if (this.detailAbort === abort) this.detailAbort = null;
     }
-    if (viewRequestID !== undefined && viewRequestID !== this.viewRequestID) {
+    if (viewRequestID !== this.viewRequestID) {
       this.observeGraphStore("detail-load-stale", { uid, detailRequestID, viewRequestID });
       clearInteraction(KATA_SELECT_ISSUE_INTERACTION, timingToken);
       return false;
@@ -1070,7 +1076,7 @@ export class KataWorkspaceStore {
       clearInteraction(KATA_SELECT_ISSUE_INTERACTION, timingToken);
       return false;
     }
-    if (!applyDetailEarly) applyDetail();
+    applyDetail();
     this.selectedEvents = events.events;
     measureInteraction(KATA_SELECT_ISSUE_INTERACTION, "events-loaded", timingToken, {
       uid,
@@ -1078,6 +1084,41 @@ export class KataWorkspaceStore {
     });
     clearInteraction(KATA_SELECT_ISSUE_INTERACTION, timingToken);
     return true;
+  }
+
+  // Completes a direct selection's best-effort event-log read after the
+  // detail has already been applied and the selection promise resolved. A
+  // failed or superseded read leaves the rendered detail in place with an
+  // empty event log instead of failing the selection.
+  private async finishSelectedEvents(
+    eventsPromise: Promise<KataTaskEventsResponse>,
+    abort: AbortController,
+    uid: string,
+    detailRequestID: number,
+    timingToken: string,
+  ): Promise<void> {
+    let events: KataTaskEventsResponse;
+    try {
+      events = await eventsPromise;
+    } catch {
+      clearInteraction(KATA_SELECT_ISSUE_INTERACTION, timingToken);
+      if (!abort.signal.aborted) {
+        this.observeGraphStore("events-load-error", { uid, detailRequestID });
+      }
+      return;
+    } finally {
+      if (this.detailAbort === abort) this.detailAbort = null;
+    }
+    if (detailRequestID !== this.detailRequestID) {
+      clearInteraction(KATA_SELECT_ISSUE_INTERACTION, timingToken);
+      return;
+    }
+    this.selectedEvents = events.events;
+    measureInteraction(KATA_SELECT_ISSUE_INTERACTION, "events-loaded", timingToken, {
+      uid,
+      count: events.events.length,
+    });
+    clearInteraction(KATA_SELECT_ISSUE_INTERACTION, timingToken);
   }
 
   private async loadSelectedRecurrences(projectID: number, detailRequestID: number): Promise<void> {

--- a/frontend/src/lib/stores/kata-workspace.svelte.ts
+++ b/frontend/src/lib/stores/kata-workspace.svelte.ts
@@ -25,7 +25,13 @@ import type {
   KataTaskViewResponse,
 } from "../api/kata/taskTypes.js";
 import { createULID } from "../api/ulid.js";
+import { clearInteraction, markInteractionStart, measureInteraction } from "../instrumentation/interactionTiming.js";
 import { recordKataGraphDebugEvent, setKataGraphDebugStore } from "./kata-graph-debug.js";
+
+// User Timing interaction name for selecting a task: measures
+// "kata:select-issue:detail-visible" (click to detail pane rendered) and
+// "kata:select-issue:events-loaded" (click to events section populated).
+export const KATA_SELECT_ISSUE_INTERACTION = "kata:select-issue";
 
 export interface KataConnectionState {
   status: "offline" | "connecting" | "online" | "error";
@@ -988,44 +994,89 @@ export class KataWorkspaceStore {
     const abort = new AbortController();
     this.detailAbort = abort;
     this.observeGraphStore("detail-load-start", { uid, detailRequestID });
+    const timingToken = String(detailRequestID);
+    markInteractionStart(KATA_SELECT_ISSUE_INTERACTION, timingToken);
+    // The events read may walk the daemon's whole event log (the daemon has
+    // no issue_uid filter), which takes seconds against remote daemons. Start
+    // it alongside the detail read so the pane never waits on the walk.
+    const eventsPromise = this.api.events({ issue_uid: uid, limit: 100 }, { signal: abort.signal });
+    eventsPromise.catch(() => {});
     let detail: KataTaskDetail;
-    let events: KataTaskEventsResponse;
     try {
-      [detail, events] = await Promise.all([
-        this.api.issue(uid, { signal: abort.signal }),
-        this.api.events({ issue_uid: uid, limit: 100 }, { signal: abort.signal }),
-      ]);
+      detail = await this.api.issue(uid, { signal: abort.signal });
     } catch (error) {
+      if (this.detailAbort === abort) this.detailAbort = null;
+      clearInteraction(KATA_SELECT_ISSUE_INTERACTION, timingToken);
       // Aborted means superseded: a newer selection owns the pane now, so
       // this failure must not surface as a user-facing error.
       if (abort.signal.aborted) {
         this.observeGraphStore("detail-load-abort", { uid, detailRequestID });
         return false;
       }
+      abort.abort();
+      throw error;
+    }
+
+    const applyDetail = () => {
+      this.cacheDetail(detail);
+      this.selectedIssue = detail;
+      if (detail.etag) {
+        this.issueETags.set(detail.issue.uid, detail.etag);
+      } else {
+        this.issueETags.set(detail.issue.uid, `"rev-${detail.issue.revision}"`);
+      }
+      this.selectedEvents = [];
+      this.selectedRecurrences = [];
+      this.pendingSelectionUID = null;
+      this.observeGraphStore("detail-load-complete", { uid, detailRequestID });
+      measureInteraction(KATA_SELECT_ISSUE_INTERACTION, "detail-visible", timingToken, { uid });
+      void this.loadSelectedRecurrences(detail.issue.project_id, detailRequestID);
+    };
+
+    if (viewRequestID !== undefined && viewRequestID !== this.viewRequestID) {
+      this.observeGraphStore("detail-load-stale", { uid, detailRequestID, viewRequestID });
+      clearInteraction(KATA_SELECT_ISSUE_INTERACTION, timingToken);
+      return false;
+    }
+    if (detailRequestID !== this.detailRequestID) {
+      this.observeGraphStore("detail-load-stale", { uid, detailRequestID });
+      clearInteraction(KATA_SELECT_ISSUE_INTERACTION, timingToken);
+      return false;
+    }
+    // Direct selections render the pane as soon as the detail lands. View
+    // loads keep the original atomic apply: their callers update route
+    // bookkeeping only after this promise settles, and an intermediate
+    // reactive flush would let the workspace route-sync effect stomp the
+    // fresh selection with the stale route issue.
+    const applyDetailEarly = viewRequestID === undefined;
+    if (applyDetailEarly) applyDetail();
+
+    let events: KataTaskEventsResponse;
+    try {
+      events = await eventsPromise;
+    } catch (error) {
+      clearInteraction(KATA_SELECT_ISSUE_INTERACTION, timingToken);
+      if (abort.signal.aborted) return false;
       throw error;
     } finally {
       if (this.detailAbort === abort) this.detailAbort = null;
     }
     if (viewRequestID !== undefined && viewRequestID !== this.viewRequestID) {
       this.observeGraphStore("detail-load-stale", { uid, detailRequestID, viewRequestID });
+      clearInteraction(KATA_SELECT_ISSUE_INTERACTION, timingToken);
       return false;
     }
     if (detailRequestID !== this.detailRequestID) {
-      this.observeGraphStore("detail-load-stale", { uid, detailRequestID });
+      clearInteraction(KATA_SELECT_ISSUE_INTERACTION, timingToken);
       return false;
     }
-    this.cacheDetail(detail);
-    this.selectedIssue = detail;
-    if (detail.etag) {
-      this.issueETags.set(detail.issue.uid, detail.etag);
-    } else {
-      this.issueETags.set(detail.issue.uid, `"rev-${detail.issue.revision}"`);
-    }
+    if (!applyDetailEarly) applyDetail();
     this.selectedEvents = events.events;
-    this.selectedRecurrences = [];
-    this.pendingSelectionUID = null;
-    this.observeGraphStore("detail-load-complete", { uid, detailRequestID });
-    void this.loadSelectedRecurrences(detail.issue.project_id, detailRequestID);
+    measureInteraction(KATA_SELECT_ISSUE_INTERACTION, "events-loaded", timingToken, {
+      uid,
+      count: events.events.length,
+    });
+    clearInteraction(KATA_SELECT_ISSUE_INTERACTION, timingToken);
     return true;
   }
 

--- a/frontend/tests/e2e-full/kata.spec.ts
+++ b/frontend/tests/e2e-full/kata.spec.ts
@@ -2463,7 +2463,7 @@ test("kata detail formats task events from the configured external daemon", asyn
     await expect(detail).toContainText("+blocks");
     await expect(detail).toContainText("-related (2)");
     await expect(detail).not.toContainText("issue.links_changed");
-    await expect.poll(() => backend.state.seenPaths).toContain("GET /api/v1/events?limit=100");
+    await expect.poll(() => backend.state.seenPaths).toContain("GET /api/v1/events?limit=1000");
   } finally {
     await server.stop();
     kataHome.restore();
@@ -3671,7 +3671,7 @@ test("kata daemon switch restarts the target stream after stale route churn", as
     await expect(page.getByRole("button", { name: /Rake the yard/ })).toBeVisible();
     await page.getByTestId("daemon-chip").click();
     await page.getByTestId("daemon-row-work").click();
-    await expect.poll(() => work.state.seenPaths).toContain("GET /api/v1/events?limit=100");
+    await expect.poll(() => work.state.seenPaths).toContain("GET /api/v1/events?limit=1000");
 
     await page.getByRole("button", { name: "All Open" }).click();
     releaseEvents();

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -1502,10 +1502,21 @@ type KataProjectRepoMapping struct {
 	RepoPath     string  `json:"repo_path"`
 }
 
+// KataTaskDetailResponse defines model for KataTaskDetailResponse.
+type KataTaskDetailResponse struct {
+	// Schema A URL to the JSON Schema for this object.
+	Schema *string `json:"$schema,omitempty"`
+
+	// Detail Verbatim Kata daemon issue detail payload
+	Detail interface{} `json:"detail"`
+
+	// Etag Daemon issue detail ETag, when the daemon provided one
+	Etag            *string                     `json:"etag,omitempty"`
+	WorkspaceTarget KataWorkspaceTargetResponse `json:"workspace_target"`
+}
+
 // KataWorkspaceTargetResponse defines model for KataWorkspaceTargetResponse.
 type KataWorkspaceTargetResponse struct {
-	// Schema A URL to the JSON Schema for this object.
-	Schema            *string          `json:"$schema,omitempty"`
 	Available         bool             `json:"available"`
 	ExistingWorkspace *WorkspaceRef    `json:"existing_workspace,omitempty"`
 	ItemKey           *string          `json:"item_key,omitempty"`
@@ -3573,6 +3584,12 @@ type ListIssuesParams struct {
 	Offset   *int64  `form:"offset,omitempty" json:"offset,omitempty"`
 }
 
+// GetKataTaskDetailParams defines parameters for GetKataTaskDetail.
+type GetKataTaskDetailParams struct {
+	// XMiddlemanKataDaemon Kata daemon id; the effective default daemon when empty
+	XMiddlemanKataDaemon *string `json:"X-Middleman-Kata-Daemon,omitempty"`
+}
+
 // ReplaceMessagesSavedSearchesParams defines parameters for ReplaceMessagesSavedSearches.
 type ReplaceMessagesSavedSearchesParams struct {
 	IfMatch        *string `json:"If-Match,omitempty"`
@@ -4015,9 +4032,6 @@ type SetIssueLabelsJSONRequestBody = SetLabelsRequest
 
 // CreateIssueWorkspaceJSONRequestBody defines body for CreateIssueWorkspace for application/json ContentType.
 type CreateIssueWorkspaceJSONRequestBody = CreateIssueWorkspaceInputBody
-
-// ResolveKataWorkspaceTargetJSONRequestBody defines body for ResolveKataWorkspaceTarget for application/json ContentType.
-type ResolveKataWorkspaceTargetJSONRequestBody = KataWorkspaceTaskRequest
 
 // CreateKataWorkspaceJSONRequestBody defines body for CreateKataWorkspace for application/json ContentType.
 type CreateKataWorkspaceJSONRequestBody = KataWorkspaceTaskRequest
@@ -4755,10 +4769,8 @@ type ClientInterface interface {
 	// ListKataDaemons request
 	ListKataDaemons(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// ResolveKataWorkspaceTargetWithBody request with any body
-	ResolveKataWorkspaceTargetWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	ResolveKataWorkspaceTarget(ctx context.Context, body ResolveKataWorkspaceTargetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetKataTaskDetail request
+	GetKataTaskDetail(ctx context.Context, issueUid string, params *GetKataTaskDetailParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// CreateKataWorkspaceWithBody request with any body
 	CreateKataWorkspaceWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -7560,20 +7572,8 @@ func (c *Client) ListKataDaemons(ctx context.Context, reqEditors ...RequestEdito
 	return c.Client.Do(req)
 }
 
-func (c *Client) ResolveKataWorkspaceTargetWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewResolveKataWorkspaceTargetRequestWithBody(c.Server, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) ResolveKataWorkspaceTarget(ctx context.Context, body ResolveKataWorkspaceTargetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewResolveKataWorkspaceTargetRequest(c.Server, body)
+func (c *Client) GetKataTaskDetail(ctx context.Context, issueUid string, params *GetKataTaskDetailParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetKataTaskDetailRequest(c.Server, issueUid, params)
 	if err != nil {
 		return nil, err
 	}
@@ -18871,27 +18871,23 @@ func NewListKataDaemonsRequest(server string) (*http.Request, error) {
 	return req, nil
 }
 
-// NewResolveKataWorkspaceTargetRequest calls the generic ResolveKataWorkspaceTarget builder with application/json body
-func NewResolveKataWorkspaceTargetRequest(server string, body ResolveKataWorkspaceTargetJSONRequestBody) (*http.Request, error) {
-	var bodyReader io.Reader
-	buf, err := json.Marshal(body)
+// NewGetKataTaskDetailRequest generates requests for GetKataTaskDetail
+func NewGetKataTaskDetailRequest(server string, issueUid string, params *GetKataTaskDetailParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "issue_uid", issueUid, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
 	if err != nil {
 		return nil, err
 	}
-	bodyReader = bytes.NewReader(buf)
-	return NewResolveKataWorkspaceTargetRequestWithBody(server, "application/json", bodyReader)
-}
-
-// NewResolveKataWorkspaceTargetRequestWithBody generates requests for ResolveKataWorkspaceTarget with any type of body
-func NewResolveKataWorkspaceTargetRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
-	var err error
 
 	serverURL, err := url.Parse(server)
 	if err != nil {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/kata/workspace-target")
+	operationPath := fmt.Sprintf("/kata/tasks/%s", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -18901,12 +18897,25 @@ func NewResolveKataWorkspaceTargetRequestWithBody(server string, contentType str
 		return nil, err
 	}
 
-	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
 	if err != nil {
 		return nil, err
 	}
 
-	req.Header.Add("Content-Type", contentType)
+	if params != nil {
+
+		if params.XMiddlemanKataDaemon != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithOptions("simple", false, "X-Middleman-Kata-Daemon", *params.XMiddlemanKataDaemon, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationHeader, Type: "string", Format: ""})
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Middleman-Kata-Daemon", headerParam0)
+		}
+
+	}
 
 	return req, nil
 }
@@ -27110,10 +27119,8 @@ type ClientWithResponsesInterface interface {
 	// ListKataDaemonsWithResponse request
 	ListKataDaemonsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListKataDaemonsResponse, error)
 
-	// ResolveKataWorkspaceTargetWithBodyWithResponse request with any body
-	ResolveKataWorkspaceTargetWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ResolveKataWorkspaceTargetResponse, error)
-
-	ResolveKataWorkspaceTargetWithResponse(ctx context.Context, body ResolveKataWorkspaceTargetJSONRequestBody, reqEditors ...RequestEditorFn) (*ResolveKataWorkspaceTargetResponse, error)
+	// GetKataTaskDetailWithResponse request
+	GetKataTaskDetailWithResponse(ctx context.Context, issueUid string, params *GetKataTaskDetailParams, reqEditors ...RequestEditorFn) (*GetKataTaskDetailResponse, error)
 
 	// CreateKataWorkspaceWithBodyWithResponse request with any body
 	CreateKataWorkspaceWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateKataWorkspaceResponse, error)
@@ -30737,15 +30744,15 @@ func (r ListKataDaemonsResponse) StatusCode() int {
 	return 0
 }
 
-type ResolveKataWorkspaceTargetResponse struct {
+type GetKataTaskDetailResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
-	JSON200                       *KataWorkspaceTargetResponse
+	JSON200                       *KataTaskDetailResponse
 	ApplicationproblemJSONDefault *ProblemError
 }
 
 // Status returns HTTPResponse.Status
-func (r ResolveKataWorkspaceTargetResponse) Status() string {
+func (r GetKataTaskDetailResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -30753,7 +30760,7 @@ func (r ResolveKataWorkspaceTargetResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r ResolveKataWorkspaceTargetResponse) StatusCode() int {
+func (r GetKataTaskDetailResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -35543,21 +35550,13 @@ func (c *ClientWithResponses) ListKataDaemonsWithResponse(ctx context.Context, r
 	return ParseListKataDaemonsResponse(rsp)
 }
 
-// ResolveKataWorkspaceTargetWithBodyWithResponse request with arbitrary body returning *ResolveKataWorkspaceTargetResponse
-func (c *ClientWithResponses) ResolveKataWorkspaceTargetWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ResolveKataWorkspaceTargetResponse, error) {
-	rsp, err := c.ResolveKataWorkspaceTargetWithBody(ctx, contentType, body, reqEditors...)
+// GetKataTaskDetailWithResponse request returning *GetKataTaskDetailResponse
+func (c *ClientWithResponses) GetKataTaskDetailWithResponse(ctx context.Context, issueUid string, params *GetKataTaskDetailParams, reqEditors ...RequestEditorFn) (*GetKataTaskDetailResponse, error) {
+	rsp, err := c.GetKataTaskDetail(ctx, issueUid, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseResolveKataWorkspaceTargetResponse(rsp)
-}
-
-func (c *ClientWithResponses) ResolveKataWorkspaceTargetWithResponse(ctx context.Context, body ResolveKataWorkspaceTargetJSONRequestBody, reqEditors ...RequestEditorFn) (*ResolveKataWorkspaceTargetResponse, error) {
-	rsp, err := c.ResolveKataWorkspaceTarget(ctx, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseResolveKataWorkspaceTargetResponse(rsp)
+	return ParseGetKataTaskDetailResponse(rsp)
 }
 
 // CreateKataWorkspaceWithBodyWithResponse request with arbitrary body returning *CreateKataWorkspaceResponse
@@ -41567,22 +41566,22 @@ func ParseListKataDaemonsResponse(rsp *http.Response) (*ListKataDaemonsResponse,
 	return response, nil
 }
 
-// ParseResolveKataWorkspaceTargetResponse parses an HTTP response from a ResolveKataWorkspaceTargetWithResponse call
-func ParseResolveKataWorkspaceTargetResponse(rsp *http.Response) (*ResolveKataWorkspaceTargetResponse, error) {
+// ParseGetKataTaskDetailResponse parses an HTTP response from a GetKataTaskDetailWithResponse call
+func ParseGetKataTaskDetailResponse(rsp *http.Response) (*GetKataTaskDetailResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &ResolveKataWorkspaceTargetResponse{
+	response := &GetKataTaskDetailResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest KataWorkspaceTargetResponse
+		var dest KataTaskDetailResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/internal/server/kata_proxy.go
+++ b/internal/server/kata_proxy.go
@@ -106,27 +106,38 @@ func (s *Server) closeKataProxyIdleConnections() {
 }
 
 func (s *Server) selectKataProxyDaemon(w http.ResponseWriter, r *http.Request) (kata.Daemon, bool) {
+	selected, problem := selectKataDaemonForID(r.Header.Get(kataDaemonHeaderName))
+	if problem != nil {
+		writeProblemResponse(w, problem)
+		return kata.Daemon{}, false
+	}
+	return selected, true
+}
+
+// selectKataDaemonForID resolves the catalog daemon addressed by the
+// X-Middleman-Kata-Daemon header value (the effective default daemon when
+// empty) to a reachable target. Shared by the passthrough proxy and the
+// server-side Kata task reads.
+func selectKataDaemonForID(headerID string) (kata.Daemon, *ProblemError) {
 	catalog, err := kata.LoadCatalog()
 	if err != nil {
-		writeProblemResponse(w, newProblem(
+		return kata.Daemon{}, newProblem(
 			http.StatusBadRequest,
 			CodeBadRequest,
 			err.Error(),
 			nil,
-		))
-		return kata.Daemon{}, false
+		)
 	}
 	if len(catalog.Daemons) == 0 {
-		writeProblemResponse(w, newProblem(
+		return kata.Daemon{}, newProblem(
 			http.StatusServiceUnavailable,
 			CodeServiceUnavailable,
 			"no Kata daemon configured",
 			nil,
-		))
-		return kata.Daemon{}, false
+		)
 	}
 
-	id := strings.TrimSpace(r.Header.Get(kataDaemonHeaderName))
+	id := strings.TrimSpace(headerID)
 	if id == "" {
 		id = effectiveKataDefaultID(catalog.Daemons)
 	}
@@ -140,24 +151,22 @@ func (s *Server) selectKataProxyDaemon(w http.ResponseWriter, r *http.Request) (
 		}
 	}
 	if !found {
-		writeProblemResponse(w, newProblem(
+		return kata.Daemon{}, newProblem(
 			http.StatusBadRequest,
 			CodeBadRequest,
 			"unknown Kata daemon",
 			map[string]any{"daemon": id},
-		))
-		return kata.Daemon{}, false
+		)
 	}
 
 	selected, err := kata.ResolveDaemon(configured)
 	if err != nil {
-		writeProblemResponse(w, newProblem(
+		return kata.Daemon{}, newProblem(
 			http.StatusBadRequest,
 			CodeBadRequest,
 			err.Error(),
 			map[string]any{"daemon": configured.ID},
-		))
-		return kata.Daemon{}, false
+		)
 	}
 	if selected.Local && selected.URL == "" {
 		selected.URL = kata.DiscoverLocalDaemonURL()
@@ -170,15 +179,14 @@ func (s *Server) selectKataProxyDaemon(w http.ResponseWriter, r *http.Request) (
 		}
 	}
 	if selected.URL == "" {
-		writeProblemResponse(w, newProblem(
+		return kata.Daemon{}, newProblem(
 			http.StatusServiceUnavailable,
 			CodeServiceUnavailable,
 			"Kata daemon is not reachable",
 			map[string]any{"daemon": selected.ID},
-		))
-		return kata.Daemon{}, false
+		)
 	}
-	return selected, true
+	return selected, nil
 }
 
 func newKataDaemonProxyEntry(d kata.Daemon) (kataProxyCacheEntry, error) {

--- a/internal/server/kata_task_detail.go
+++ b/internal/server/kata_task_detail.go
@@ -19,9 +19,9 @@ import (
 const kataDaemonReadTimeout = 20 * time.Second
 
 // kataDaemonProjectsReadTimeout bounds the best-effort project-name read.
-// The issue detail is the critical path; a slow or hung projects route must
-// not hold the detail response, so this budget is much shorter and expiry
-// falls back to the name carried by the issue payload.
+// The issue detail is the critical path: the handler waits on this budget
+// only when the issue payload carries no project name of its own, and
+// expiry falls back to that payload name.
 const kataDaemonProjectsReadTimeout = 3 * time.Second
 
 // maxKataDaemonReadBytes caps how much of a daemon response middleman will
@@ -134,11 +134,24 @@ func (s *Server) kataTaskDetail(
 		)
 	}
 
-	projects := <-projectsCh
+	projectName := parsedDetail.Issue.ProjectName
+	if projectName == "" {
+		// Only an empty payload name is worth waiting (briefly) for the
+		// projects listing; otherwise take it only when already available so
+		// a slow projects route never delays the detail response.
+		projects := <-projectsCh
+		projectName = kataProjectNameForUID(projects, parsedDetail.Issue.ProjectUID, projectName)
+	} else {
+		select {
+		case projects := <-projectsCh:
+			projectName = kataProjectNameForUID(projects, parsedDetail.Issue.ProjectUID, projectName)
+		default:
+		}
+	}
 	metadata := db.WorkspaceKataMetadata{
 		DaemonID:    daemon.ID,
 		ProjectUID:  parsedDetail.Issue.ProjectUID,
-		ProjectName: kataProjectNameForUID(projects, parsedDetail.Issue.ProjectUID, parsedDetail.Issue.ProjectName),
+		ProjectName: projectName,
 		IssueUID:    issueUID,
 		ShortID:     parsedDetail.Issue.ShortID,
 		QualifiedID: parsedDetail.Issue.QualifiedID,
@@ -191,7 +204,15 @@ func kataDaemonHTTPClient(d kata.Daemon) (*http.Client, string, error) {
 		transport = newDefaultKataDaemonTransport()
 	}
 	base := strings.TrimSuffix(target.String(), "/")
-	return &http.Client{Transport: transport}, base, nil
+	// Like the proxy and health probe, never follow daemon redirects: a
+	// misconfigured or malicious daemon must not bounce server-side reads
+	// (and their Authorization header) to another target.
+	return &http.Client{
+		Transport: transport,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}, base, nil
 }
 
 // kataProjectNameForUID resolves the project name for repo mapping from the

--- a/internal/server/kata_task_detail.go
+++ b/internal/server/kata_task_detail.go
@@ -18,6 +18,12 @@ import (
 // hung remote daemon cannot pin the API handler.
 const kataDaemonReadTimeout = 20 * time.Second
 
+// kataDaemonProjectsReadTimeout bounds the best-effort project-name read.
+// The issue detail is the critical path; a slow or hung projects route must
+// not hold the detail response, so this budget is much shorter and expiry
+// falls back to the name carried by the issue payload.
+const kataDaemonProjectsReadTimeout = 3 * time.Second
+
 // maxKataDaemonReadBytes caps how much of a daemon response middleman will
 // buffer for a single task detail read.
 const maxKataDaemonReadBytes = 8 << 20
@@ -33,7 +39,12 @@ type kataTaskDetailResponse struct {
 	WorkspaceTarget kataWorkspaceTargetResponse `json:"workspace_target"`
 }
 
-type kataTaskDetailOutput = bodyOutput[kataTaskDetailResponse]
+type kataTaskDetailOutput struct {
+	// The response depends on the selected daemon, so caches must key on the
+	// daemon header just like the passthrough proxy does.
+	Vary string `header:"Vary"`
+	Body kataTaskDetailResponse
+}
 
 type kataDaemonReadResult struct {
 	status int
@@ -65,6 +76,8 @@ func (s *Server) kataTaskDetail(
 
 	ctx, cancel := context.WithTimeout(ctx, kataDaemonReadTimeout)
 	defer cancel()
+	projectsCtx, cancelProjects := context.WithTimeout(ctx, kataDaemonProjectsReadTimeout)
+	defer cancelProjects()
 
 	detailCh := make(chan kataDaemonReadResult, 1)
 	projectsCh := make(chan kataDaemonReadResult, 1)
@@ -72,10 +85,12 @@ func (s *Server) kataTaskDetail(
 		detailCh <- kataDaemonGet(ctx, client, daemon, baseURL+"/api/v1/issues/"+url.PathEscape(issueUID))
 	}()
 	go func() {
-		projectsCh <- kataDaemonGet(ctx, client, daemon, baseURL+"/api/v1/projects")
+		projectsCh <- kataDaemonGet(projectsCtx, client, daemon, baseURL+"/api/v1/projects")
 	}()
+	// Issue read outcomes (including errors) return without joining the
+	// best-effort projects read; the buffered channel lets its goroutine
+	// finish on its own after the handler returns.
 	detail := <-detailCh
-	projects := <-projectsCh
 
 	if detail.err != nil {
 		return nil, newProblem(
@@ -119,6 +134,7 @@ func (s *Server) kataTaskDetail(
 		)
 	}
 
+	projects := <-projectsCh
 	metadata := db.WorkspaceKataMetadata{
 		DaemonID:    daemon.ID,
 		ProjectUID:  parsedDetail.Issue.ProjectUID,
@@ -134,6 +150,7 @@ func (s *Server) kataTaskDetail(
 	}
 
 	return &kataTaskDetailOutput{
+		Vary: kataDaemonHeaderName,
 		Body: kataTaskDetailResponse{
 			Detail:          json.RawMessage(detail.body),
 			ETag:            detail.header.Get("ETag"),

--- a/internal/server/kata_task_detail.go
+++ b/internal/server/kata_task_detail.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/danielgtaylor/huma/v2"
+
 	"go.kenn.io/middleman/internal/db"
 	"go.kenn.io/middleman/internal/kata"
 )
@@ -60,7 +62,16 @@ type kataDaemonReadResult struct {
 func (s *Server) kataTaskDetail(
 	ctx context.Context,
 	input *kataTaskDetailInput,
-) (*kataTaskDetailOutput, error) {
+) (out *kataTaskDetailOutput, err error) {
+	// Every outcome of this handler depends on the daemon selection header,
+	// so problem responses must declare Vary just like the success path (and
+	// the passthrough proxy); otherwise a cache could reuse one daemon's
+	// error for another daemon's request.
+	defer func() {
+		if err != nil {
+			err = huma.ErrorWithHeaders(err, http.Header{"Vary": []string{kataDaemonHeaderName}})
+		}
+	}()
 	issueUID := strings.TrimSpace(input.IssueUID)
 	if issueUID == "" {
 		return nil, problemValidation("path.issue_uid", "issue_uid is required")

--- a/internal/server/kata_task_detail.go
+++ b/internal/server/kata_task_detail.go
@@ -1,0 +1,202 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"go.kenn.io/middleman/internal/db"
+	"go.kenn.io/middleman/internal/kata"
+)
+
+// kataDaemonReadTimeout bounds server-side reads against a Kata daemon so a
+// hung remote daemon cannot pin the API handler.
+const kataDaemonReadTimeout = 20 * time.Second
+
+// maxKataDaemonReadBytes caps how much of a daemon response middleman will
+// buffer for a single task detail read.
+const maxKataDaemonReadBytes = 8 << 20
+
+type kataTaskDetailInput struct {
+	IssueUID string `path:"issue_uid" doc:"Kata issue UID"`
+	DaemonID string `header:"X-Middleman-Kata-Daemon" doc:"Kata daemon id; the effective default daemon when empty"`
+}
+
+type kataTaskDetailResponse struct {
+	Detail          any                         `json:"detail" doc:"Verbatim Kata daemon issue detail payload"`
+	ETag            string                      `json:"etag,omitempty" doc:"Daemon issue detail ETag, when the daemon provided one"`
+	WorkspaceTarget kataWorkspaceTargetResponse `json:"workspace_target"`
+}
+
+type kataTaskDetailOutput = bodyOutput[kataTaskDetailResponse]
+
+type kataDaemonReadResult struct {
+	status int
+	header http.Header
+	body   []byte
+	err    error
+}
+
+// kataTaskDetail serves the task detail pane in one round trip: it reads the
+// issue detail (and project names) from the selected daemon server-side and
+// attaches the resolved workspace target, so the frontend does not need a
+// separate workspace-target request that would land after the pane renders.
+func (s *Server) kataTaskDetail(
+	ctx context.Context,
+	input *kataTaskDetailInput,
+) (*kataTaskDetailOutput, error) {
+	issueUID := strings.TrimSpace(input.IssueUID)
+	if issueUID == "" {
+		return nil, problemValidation("path.issue_uid", "issue_uid is required")
+	}
+	daemon, problem := selectKataDaemonForID(input.DaemonID)
+	if problem != nil {
+		return nil, problem
+	}
+	client, baseURL, err := kataDaemonHTTPClient(daemon)
+	if err != nil {
+		return nil, problemBadRequest("", "invalid Kata daemon target", map[string]any{"daemon": daemon.ID})
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, kataDaemonReadTimeout)
+	defer cancel()
+
+	detailCh := make(chan kataDaemonReadResult, 1)
+	projectsCh := make(chan kataDaemonReadResult, 1)
+	go func() {
+		detailCh <- kataDaemonGet(ctx, client, daemon, baseURL+"/api/v1/issues/"+url.PathEscape(issueUID))
+	}()
+	go func() {
+		projectsCh <- kataDaemonGet(ctx, client, daemon, baseURL+"/api/v1/projects")
+	}()
+	detail := <-detailCh
+	projects := <-projectsCh
+
+	if detail.err != nil {
+		return nil, newProblem(
+			http.StatusBadGateway,
+			CodeUpstreamError,
+			"Kata daemon is unreachable",
+			map[string]any{"daemon": daemon.ID},
+		)
+	}
+	if detail.status == http.StatusNotFound {
+		return nil, problemNotFound(CodeNotFound, "Kata task not found", map[string]any{
+			"daemon":    daemon.ID,
+			"issue_uid": issueUID,
+		})
+	}
+	if detail.status < http.StatusOK || detail.status >= http.StatusMultipleChoices {
+		return nil, newProblem(
+			http.StatusBadGateway,
+			CodeUpstreamError,
+			fmt.Sprintf("Kata daemon issue read failed with status %d", detail.status),
+			map[string]any{"daemon": daemon.ID},
+		)
+	}
+
+	var parsedDetail struct {
+		Issue struct {
+			UID         string `json:"uid"`
+			ProjectUID  string `json:"project_uid"`
+			ProjectName string `json:"project_name"`
+			ShortID     string `json:"short_id"`
+			QualifiedID string `json:"qualified_id"`
+			Title       string `json:"title"`
+		} `json:"issue"`
+	}
+	if err := json.Unmarshal(detail.body, &parsedDetail); err != nil || parsedDetail.Issue.ProjectUID == "" {
+		return nil, newProblem(
+			http.StatusBadGateway,
+			CodeUpstreamError,
+			"Kata daemon returned an unexpected issue payload",
+			map[string]any{"daemon": daemon.ID},
+		)
+	}
+
+	metadata := db.WorkspaceKataMetadata{
+		DaemonID:    daemon.ID,
+		ProjectUID:  parsedDetail.Issue.ProjectUID,
+		ProjectName: kataProjectNameForUID(projects, parsedDetail.Issue.ProjectUID, parsedDetail.Issue.ProjectName),
+		IssueUID:    issueUID,
+		ShortID:     parsedDetail.Issue.ShortID,
+		QualifiedID: parsedDetail.Issue.QualifiedID,
+		Title:       parsedDetail.Issue.Title,
+	}
+	target, err := s.kataWorkspaceTargetForMetadata(ctx, metadata)
+	if err != nil {
+		return nil, err
+	}
+
+	return &kataTaskDetailOutput{
+		Body: kataTaskDetailResponse{
+			Detail:          json.RawMessage(detail.body),
+			ETag:            detail.header.Get("ETag"),
+			WorkspaceTarget: target,
+		},
+	}, nil
+}
+
+func kataDaemonGet(ctx context.Context, client *http.Client, d kata.Daemon, target string) kataDaemonReadResult {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		return kataDaemonReadResult{err: err}
+	}
+	if token := kataDaemonForwardToken(d); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return kataDaemonReadResult{err: err}
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxKataDaemonReadBytes))
+	if err != nil {
+		return kataDaemonReadResult{err: err}
+	}
+	return kataDaemonReadResult{status: resp.StatusCode, header: resp.Header, body: body}
+}
+
+// kataDaemonHTTPClient builds an HTTP client and base URL for server-side
+// reads against a resolved daemon, reusing the proxy's target parsing so
+// unix-socket daemons work identically.
+func kataDaemonHTTPClient(d kata.Daemon) (*http.Client, string, error) {
+	target, transport, err := kataDaemonProxyTarget(d.URL)
+	if err != nil {
+		return nil, "", err
+	}
+	if transport == nil {
+		transport = newDefaultKataDaemonTransport()
+	}
+	base := strings.TrimSuffix(target.String(), "/")
+	return &http.Client{Transport: transport}, base, nil
+}
+
+// kataProjectNameForUID resolves the project name for repo mapping from the
+// daemon's projects listing, falling back to whatever name the issue payload
+// itself carried.
+func kataProjectNameForUID(projects kataDaemonReadResult, projectUID, fallback string) string {
+	if projects.err != nil || projects.status != http.StatusOK {
+		return fallback
+	}
+	var parsed struct {
+		Projects []struct {
+			UID  string `json:"uid"`
+			Name string `json:"name"`
+		} `json:"projects"`
+	}
+	if err := json.Unmarshal(projects.body, &parsed); err != nil {
+		return fallback
+	}
+	for _, project := range parsed.Projects {
+		if project.UID == projectUID && project.Name != "" {
+			return project.Name
+		}
+	}
+	return fallback
+}

--- a/internal/server/kata_task_detail_test.go
+++ b/internal/server/kata_task_detail_test.go
@@ -1,0 +1,264 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/middleman/internal/db"
+)
+
+func startKataTaskDetailDaemon(t *testing.T, detailBody, projectsBody string) *httptest.Server {
+	t.Helper()
+	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/issues/issue-kata-1":
+			w.Header().Set("ETag", `"rev-4"`)
+			_, _ = w.Write([]byte(detailBody))
+		case "/api/v1/projects":
+			_, _ = w.Write([]byte(projectsBody))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(daemon.Close)
+	return daemon
+}
+
+func kataTaskDetailTestConfig(t *testing.T, kataTOML string) string {
+	t.Helper()
+	cloneDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(cloneDir, ".kata.toml"), []byte(kataTOML), 0o644))
+	return fmt.Sprintf(`
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "widget"
+worktree_base_path = %q
+`, cloneDir)
+}
+
+// kataWorkspaceTargetViaTaskDetail resolves a workspace target through the
+// combined task-detail endpoint, standing up a fake daemon that serves the
+// supplied identity fields as its issue detail and projects listing.
+func kataWorkspaceTargetViaTaskDetail(t *testing.T, srv *Server, identity map[string]string) kataWorkspaceTargetResponse {
+	t.Helper()
+	issueUID := identity["issue_uid"]
+	issue := map[string]any{
+		"uid":         issueUID,
+		"project_id":  7,
+		"project_uid": identity["project_uid"],
+		"revision":    1,
+	}
+	for _, key := range []string{"short_id", "qualified_id", "title"} {
+		if value := identity[key]; value != "" {
+			issue[key] = value
+		}
+	}
+	detailBody, err := json.Marshal(map[string]any{"issue": issue, "comments": []any{}, "labels": []any{}, "links": []any{}})
+	require.NoError(t, err)
+	projectsBody, err := json.Marshal(map[string]any{"projects": []map[string]any{{
+		"id": 7, "uid": identity["project_uid"], "name": identity["project_name"],
+	}}})
+	require.NoError(t, err)
+
+	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/issues/" + issueUID:
+			_, _ = w.Write(detailBody)
+		case "/api/v1/projects":
+			_, _ = w.Write(projectsBody)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(daemon.Close)
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	writeKataProxyCatalog(t, home, "\n[[daemon]]\nname = \""+identity["daemon_id"]+"\"\nurl = \""+daemon.URL+"\"\n")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/kata/tasks/"+url.PathEscape(issueUID), nil)
+	req.Host = "127.0.0.1:8091"
+	req.Header.Set("X-Middleman-Kata-Daemon", identity["daemon_id"])
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	var resp struct {
+		WorkspaceTarget kataWorkspaceTargetResponse `json:"workspace_target"`
+	}
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	return resp.WorkspaceTarget
+}
+
+func TestKataTaskDetailReturnsDetailAndWorkspaceTarget(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	daemon := startKataTaskDetailDaemon(t,
+		`{"issue":{"uid":"issue-kata-1","project_id":7,"project_uid":"project-kata","short_id":"task-123","title":"Fix widget","revision":4},"comments":[],"labels":[],"links":[]}`,
+		`{"projects":[{"id":7,"uid":"project-kata","name":"Kata"}]}`,
+	)
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	writeKataProxyCatalog(t, home, `
+[[daemon]]
+name = "desktop"
+url = "`+daemon.URL+`"
+`)
+	// Name-based mapping: only the daemon's projects list carries the
+	// project name, so a passing test proves the endpoint fetched it.
+	srv, database, _ := setupTestServerWithConfigContent(t, kataTaskDetailTestConfig(t, "[project]\nname = \"Kata\"\n"), &mockGH{})
+	_, err := database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
+	require.NoError(err)
+
+	rr := doJSON(t, srv, http.MethodGet, "/api/v1/kata/tasks/issue-kata-1", nil)
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+
+	var resp struct {
+		Detail struct {
+			Issue struct {
+				UID   string `json:"uid"`
+				Title string `json:"title"`
+			} `json:"issue"`
+		} `json:"detail"`
+		ETag            string                      `json:"etag"`
+		WorkspaceTarget kataWorkspaceTargetResponse `json:"workspace_target"`
+	}
+	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal("issue-kata-1", resp.Detail.Issue.UID)
+	assert.Equal("Fix widget", resp.Detail.Issue.Title)
+	assert.Equal(`"rev-4"`, resp.ETag)
+	assert.True(resp.WorkspaceTarget.Available)
+	require.NotNil(resp.WorkspaceTarget.Repo)
+	assert.Equal("acme", resp.WorkspaceTarget.Repo.Owner)
+	assert.Equal("widget", resp.WorkspaceTarget.Repo.Name)
+	assert.Equal(db.KataWorkspaceItemKey(db.WorkspaceKataMetadata{
+		DaemonID:   "desktop",
+		ProjectUID: "project-kata",
+		IssueUID:   "issue-kata-1",
+	}), resp.WorkspaceTarget.ItemKey)
+}
+
+func TestKataTaskDetailWithoutMappingStillReturnsDetail(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	daemon := startKataTaskDetailDaemon(t,
+		`{"issue":{"uid":"issue-kata-1","project_id":7,"project_uid":"project-unmapped","short_id":"task-123","title":"Fix widget","revision":4},"comments":[],"labels":[],"links":[]}`,
+		`{"projects":[{"id":7,"uid":"project-unmapped","name":"Unmapped"}]}`,
+	)
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	writeKataProxyCatalog(t, home, `
+[[daemon]]
+name = "desktop"
+url = "`+daemon.URL+`"
+`)
+	srv, _ := setupTestServer(t)
+
+	rr := doJSON(t, srv, http.MethodGet, "/api/v1/kata/tasks/issue-kata-1", nil)
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+
+	var resp struct {
+		Detail struct {
+			Issue struct {
+				UID string `json:"uid"`
+			} `json:"issue"`
+		} `json:"detail"`
+		WorkspaceTarget kataWorkspaceTargetResponse `json:"workspace_target"`
+	}
+	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal("issue-kata-1", resp.Detail.Issue.UID)
+	assert.False(resp.WorkspaceTarget.Available)
+}
+
+func TestKataTaskDetailUnknownIssueReturnsNotFound(t *testing.T) {
+	require := require.New(t)
+
+	daemon := startKataTaskDetailDaemon(t, `{}`, `{"projects":[]}`)
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	writeKataProxyCatalog(t, home, `
+[[daemon]]
+name = "desktop"
+url = "`+daemon.URL+`"
+`)
+	srv, _ := setupTestServer(t)
+
+	rr := doJSON(t, srv, http.MethodGet, "/api/v1/kata/tasks/issue-missing", nil)
+	require.Equal(http.StatusNotFound, rr.Code, rr.Body.String())
+}
+
+func TestKataTaskDetailUnreachableDaemonReturnsUpstreamError(t *testing.T) {
+	require := require.New(t)
+
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	writeKataProxyCatalog(t, home, `
+[[daemon]]
+name = "desktop"
+url = "http://127.0.0.1:1"
+`)
+	srv, _ := setupTestServer(t)
+
+	rr := doJSON(t, srv, http.MethodGet, "/api/v1/kata/tasks/issue-kata-1", nil)
+	require.Equal(http.StatusBadGateway, rr.Code, rr.Body.String())
+}
+
+func TestKataTaskDetailSelectsDaemonFromHeader(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	daemon := startKataTaskDetailDaemon(t,
+		`{"issue":{"uid":"issue-kata-1","project_id":7,"project_uid":"project-kata","short_id":"task-123","title":"Fix widget","revision":4},"comments":[],"labels":[],"links":[]}`,
+		`{"projects":[{"id":7,"uid":"project-kata","name":"Kata"}]}`,
+	)
+	other := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "wrong daemon", http.StatusInternalServerError)
+	}))
+	t.Cleanup(other.Close)
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	writeKataProxyCatalog(t, home, `
+[[daemon]]
+name = "other"
+url = "`+other.URL+`"
+
+[[daemon]]
+name = "work"
+url = "`+daemon.URL+`"
+`)
+	srv, _ := setupTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/kata/tasks/issue-kata-1", nil)
+	req.Host = "127.0.0.1:8091"
+	req.Header.Set("X-Middleman-Kata-Daemon", "work")
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	// The "other" daemon (the default) answers 500, so a 200 with the issue
+	// payload proves the header routed the read to the "work" daemon.
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+	var resp struct {
+		Detail struct {
+			Issue struct {
+				UID string `json:"uid"`
+			} `json:"issue"`
+		} `json:"detail"`
+	}
+	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal("issue-kata-1", resp.Detail.Issue.UID)
+}

--- a/internal/server/kata_task_detail_test.go
+++ b/internal/server/kata_task_detail_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -244,9 +245,9 @@ url = "`+daemon.URL+`"
 	elapsed := time.Since(start)
 
 	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
-	// The projects read is best-effort: a hung daemon route must not hold
-	// the detail response anywhere near the full daemon read timeout.
-	assert.Less(elapsed, kataDaemonReadTimeout/2)
+	// The issue payload already carries project_name, so the hung projects
+	// read must not hold the detail response even for its own short budget.
+	assert.Less(elapsed, kataDaemonProjectsReadTimeout)
 
 	var resp struct {
 		Detail struct {
@@ -291,6 +292,38 @@ url = "`+daemon.URL+`"
 	// Issue read outcomes return immediately; they never join the
 	// best-effort projects read.
 	assert.Less(elapsed, 2*time.Second)
+}
+
+func TestKataTaskDetailDoesNotFollowDaemonRedirects(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// A daemon must not be able to bounce server-side reads to another
+	// target; the redirect itself is treated as an upstream failure.
+	var redirectTargetHits atomic.Int32
+	redirectTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		redirectTargetHits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"issue":{"uid":"issue-kata-1","project_id":7,"project_uid":"project-kata","title":"Fix widget","revision":4},"comments":[],"labels":[],"links":[]}`))
+	}))
+	t.Cleanup(redirectTarget.Close)
+	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, redirectTarget.URL+r.URL.Path, http.StatusFound)
+	}))
+	t.Cleanup(daemon.Close)
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	writeKataProxyCatalog(t, home, `
+[[daemon]]
+name = "desktop"
+url = "`+daemon.URL+`"
+`)
+	srv, _ := setupTestServer(t)
+
+	rr := doJSON(t, srv, http.MethodGet, "/api/v1/kata/tasks/issue-kata-1", nil)
+
+	require.Equal(http.StatusBadGateway, rr.Code, rr.Body.String())
+	assert.Zero(redirectTargetHits.Load())
 }
 
 func TestKataTaskDetailUnknownIssueReturnsNotFound(t *testing.T) {

--- a/internal/server/kata_task_detail_test.go
+++ b/internal/server/kata_task_detail_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -183,6 +184,113 @@ url = "`+daemon.URL+`"
 	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
 	assert.Equal("issue-kata-1", resp.Detail.Issue.UID)
 	assert.False(resp.WorkspaceTarget.Available)
+}
+
+func TestKataTaskDetailSetsDaemonVaryHeader(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	daemon := startKataTaskDetailDaemon(t,
+		`{"issue":{"uid":"issue-kata-1","project_id":7,"project_uid":"project-kata","short_id":"task-123","title":"Fix widget","revision":4},"comments":[],"labels":[],"links":[]}`,
+		`{"projects":[{"id":7,"uid":"project-kata","name":"Kata"}]}`,
+	)
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	writeKataProxyCatalog(t, home, `
+[[daemon]]
+name = "desktop"
+url = "`+daemon.URL+`"
+`)
+	srv, _ := setupTestServer(t)
+
+	rr := doJSON(t, srv, http.MethodGet, "/api/v1/kata/tasks/issue-kata-1", nil)
+
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+	assert.Contains(rr.Header().Values("Vary"), "X-Middleman-Kata-Daemon")
+}
+
+func TestKataTaskDetailDoesNotWaitOnHungProjectsRead(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	release := make(chan struct{})
+	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/issues/issue-kata-1":
+			_, _ = w.Write([]byte(`{"issue":{"uid":"issue-kata-1","project_id":7,"project_uid":"project-kata","project_name":"Kata","short_id":"task-123","title":"Fix widget","revision":4},"comments":[],"labels":[],"links":[]}`))
+		case "/api/v1/projects":
+			<-release
+			_, _ = w.Write([]byte(`{"projects":[]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(func() {
+		close(release)
+		daemon.Close()
+	})
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	writeKataProxyCatalog(t, home, `
+[[daemon]]
+name = "desktop"
+url = "`+daemon.URL+`"
+`)
+	srv, _ := setupTestServer(t)
+
+	start := time.Now()
+	rr := doJSON(t, srv, http.MethodGet, "/api/v1/kata/tasks/issue-kata-1", nil)
+	elapsed := time.Since(start)
+
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+	// The projects read is best-effort: a hung daemon route must not hold
+	// the detail response anywhere near the full daemon read timeout.
+	assert.Less(elapsed, kataDaemonReadTimeout/2)
+
+	var resp struct {
+		Detail struct {
+			Issue struct {
+				UID string `json:"uid"`
+			} `json:"issue"`
+		} `json:"detail"`
+	}
+	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal("issue-kata-1", resp.Detail.Issue.UID)
+}
+
+func TestKataTaskDetailIssueErrorDoesNotWaitOnProjectsRead(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	release := make(chan struct{})
+	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/projects" {
+			<-release
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(func() {
+		close(release)
+		daemon.Close()
+	})
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	writeKataProxyCatalog(t, home, `
+[[daemon]]
+name = "desktop"
+url = "`+daemon.URL+`"
+`)
+	srv, _ := setupTestServer(t)
+
+	start := time.Now()
+	rr := doJSON(t, srv, http.MethodGet, "/api/v1/kata/tasks/issue-missing", nil)
+	elapsed := time.Since(start)
+
+	require.Equal(http.StatusNotFound, rr.Code, rr.Body.String())
+	// Issue read outcomes return immediately; they never join the
+	// best-effort projects read.
+	assert.Less(elapsed, 2*time.Second)
 }
 
 func TestKataTaskDetailUnknownIssueReturnsNotFound(t *testing.T) {

--- a/internal/server/kata_task_detail_test.go
+++ b/internal/server/kata_task_detail_test.go
@@ -341,6 +341,9 @@ url = "`+daemon.URL+`"
 
 	rr := doJSON(t, srv, http.MethodGet, "/api/v1/kata/tasks/issue-missing", nil)
 	require.Equal(http.StatusNotFound, rr.Code, rr.Body.String())
+	// Error outcomes depend on the daemon selection just like successes, so
+	// they must not be cache-shared across daemon headers.
+	require.Contains(rr.Header().Values("Vary"), kataDaemonHeaderName)
 }
 
 func TestKataTaskDetailUnreachableDaemonReturnsUpstreamError(t *testing.T) {
@@ -357,6 +360,58 @@ url = "http://127.0.0.1:1"
 
 	rr := doJSON(t, srv, http.MethodGet, "/api/v1/kata/tasks/issue-kata-1", nil)
 	require.Equal(http.StatusBadGateway, rr.Code, rr.Body.String())
+	require.Contains(rr.Header().Values("Vary"), kataDaemonHeaderName)
+}
+
+func TestKataTaskDetailProjectsRedirectFallsBackToPayloadName(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// Only the /projects route redirects; the unfollowed redirect must be
+	// treated as a failed best-effort read that falls back to the issue
+	// payload, not followed to another target and not an error.
+	var redirectTargetHits atomic.Int32
+	redirectTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		redirectTargetHits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"projects":[{"id":7,"uid":"project-kata","name":"Kata"}]}`))
+	}))
+	t.Cleanup(redirectTarget.Close)
+	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/issues/issue-kata-1":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"issue":{"uid":"issue-kata-1","project_id":7,"project_uid":"project-kata","project_name":"Payload name","short_id":"task-123","title":"Fix widget","revision":4},"comments":[],"labels":[],"links":[]}`))
+		case "/api/v1/projects":
+			http.Redirect(w, r, redirectTarget.URL+r.URL.Path, http.StatusFound)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(daemon.Close)
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	writeKataProxyCatalog(t, home, `
+[[daemon]]
+name = "desktop"
+url = "`+daemon.URL+`"
+`)
+	// Name-based mapping against the payload name proves the fallback was
+	// used: the projects listing (which the redirect withheld) is the only
+	// other source of a project name.
+	srv, database, _ := setupTestServerWithConfigContent(t, kataTaskDetailTestConfig(t, "[project]\nname = \"Payload name\"\n"), &mockGH{})
+	_, err := database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
+	require.NoError(err)
+
+	rr := doJSON(t, srv, http.MethodGet, "/api/v1/kata/tasks/issue-kata-1", nil)
+
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+	var resp struct {
+		WorkspaceTarget kataWorkspaceTargetResponse `json:"workspace_target"`
+	}
+	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
+	assert.True(resp.WorkspaceTarget.Available)
+	assert.Zero(redirectTargetHits.Load())
 }
 
 func TestKataTaskDetailSelectsDaemonFromHeader(t *testing.T) {

--- a/internal/server/kata_workspace.go
+++ b/internal/server/kata_workspace.go
@@ -45,8 +45,6 @@ type kataWorkspaceTargetResponse struct {
 	ExistingWorkspace *workspaceRef    `json:"existing_workspace,omitempty"`
 }
 
-type kataWorkspaceTargetOutput = bodyOutput[kataWorkspaceTargetResponse]
-
 type kataResolvedWorkspaceRepo struct {
 	Provider     string
 	PlatformHost string
@@ -76,22 +74,16 @@ func (body kataWorkspaceTaskRequest) metadata() (db.WorkspaceKataMetadata, error
 	return metadata, nil
 }
 
-func (s *Server) kataWorkspaceTarget(
+func (s *Server) kataWorkspaceTargetForMetadata(
 	ctx context.Context,
-	input *kataWorkspaceTaskInput,
-) (*kataWorkspaceTargetOutput, error) {
-	metadata, err := input.Body.metadata()
-	if err != nil {
-		return nil, err
-	}
+	metadata db.WorkspaceKataMetadata,
+) (kataWorkspaceTargetResponse, error) {
 	target, ok, err := s.resolveKataWorkspaceRepo(ctx, metadata)
 	if err != nil {
-		return nil, err
+		return kataWorkspaceTargetResponse{}, err
 	}
 	if !ok {
-		return &kataWorkspaceTargetOutput{
-			Body: kataWorkspaceTargetResponse{Available: false},
-		}, nil
+		return kataWorkspaceTargetResponse{Available: false}, nil
 	}
 	repoRef := s.repoRefFromParts(
 		target.Provider, target.PlatformHost, target.Owner, target.Name,
@@ -112,7 +104,7 @@ func (s *Server) kataWorkspaceTarget(
 		resp.ItemKey,
 	)
 	if err != nil {
-		return nil, problemInternal("lookup existing Kata workspace: " + err.Error())
+		return kataWorkspaceTargetResponse{}, problemInternal("lookup existing Kata workspace: " + err.Error())
 	}
 	if existing != nil {
 		resp.ExistingWorkspace = &workspaceRef{
@@ -120,7 +112,7 @@ func (s *Server) kataWorkspaceTarget(
 			Status: existing.Status,
 		}
 	}
-	return &kataWorkspaceTargetOutput{Body: resp}, nil
+	return resp, nil
 }
 
 func (s *Server) createKataWorkspace(
@@ -507,12 +499,12 @@ const httpStatusAccepted = 202
 
 func registerKataWorkspaceAPI(api huma.API, s *Server) {
 	huma.Register(api, huma.Operation{
-		OperationID: "resolve-kata-workspace-target",
-		Method:      "POST",
-		Path:        "/kata/workspace-target",
-		Summary:     "Resolve Kata workspace target",
+		OperationID: "get-kata-task-detail",
+		Method:      "GET",
+		Path:        "/kata/tasks/{issue_uid}",
+		Summary:     "Get Kata task detail with workspace target",
 		Tags:        []string{"Kata"},
-	}, s.kataWorkspaceTarget)
+	}, s.kataTaskDetail)
 	huma.Register(api, huma.Operation{
 		OperationID:   "create-kata-workspace",
 		Method:        "POST",

--- a/internal/server/kata_workspace_test.go
+++ b/internal/server/kata_workspace_test.go
@@ -40,7 +40,7 @@ worktree_base_path = %q
 	_, err := database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/kata/workspace-target", map[string]any{
+	resp := kataWorkspaceTargetViaTaskDetail(t, srv, map[string]string{
 		"daemon_id":    "desktop",
 		"project_uid":  "project-kata",
 		"project_name": "Kata",
@@ -49,10 +49,6 @@ worktree_base_path = %q
 		"qualified_id": "Kata#task-123",
 		"title":        "Fix widget",
 	})
-	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
-
-	var resp kataWorkspaceTargetResponse
-	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
 	assert.True(resp.Available)
 	require.NotNil(resp.Repo)
 	assert.Equal("github", resp.Repo.Provider)
@@ -93,7 +89,7 @@ worktree_base_path = %q
 	_, err := database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/kata/workspace-target", map[string]any{
+	resp := kataWorkspaceTargetViaTaskDetail(t, srv, map[string]string{
 		"daemon_id":    "desktop",
 		"project_uid":  "github.com/acme/widget",
 		"project_name": "widget",
@@ -101,10 +97,6 @@ worktree_base_path = %q
 		"short_id":     "task-123",
 		"title":        "Fix widget",
 	})
-	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
-
-	var resp kataWorkspaceTargetResponse
-	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
 	assert.True(resp.Available)
 	require.NotNil(resp.Repo)
 	assert.Equal("acme", resp.Repo.Owner)
@@ -136,16 +128,12 @@ worktree_base_path = %q
 	_, err := database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/kata/workspace-target", map[string]any{
+	resp := kataWorkspaceTargetViaTaskDetail(t, srv, map[string]string{
 		"daemon_id":    "desktop",
 		"project_uid":  "project-kata",
 		"project_name": "widget",
 		"issue_uid":    "issue-kata-1",
 	})
-	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
-
-	var resp kataWorkspaceTargetResponse
-	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
 	assert.True(resp.Available)
 	require.NotNil(resp.Repo)
 	assert.Equal("acme", resp.Repo.Owner)
@@ -177,16 +165,12 @@ worktree_base_path = %q
 	_, err := database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/kata/workspace-target", map[string]any{
+	resp := kataWorkspaceTargetViaTaskDetail(t, srv, map[string]string{
 		"daemon_id":    "desktop",
 		"project_uid":  "project-kata-opaque",
 		"project_name": "widget",
 		"issue_uid":    "issue-kata-1",
 	})
-	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
-
-	var resp kataWorkspaceTargetResponse
-	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
 	assert.True(resp.Available)
 	require.NotNil(resp.Repo)
 	assert.Equal("acme", resp.Repo.Owner)
@@ -223,16 +207,12 @@ worktree_base_path = %q
 	_, err := database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/kata/workspace-target", map[string]any{
+	resp := kataWorkspaceTargetViaTaskDetail(t, srv, map[string]string{
 		"daemon_id":    "desktop",
 		"project_uid":  "project-kata",
 		"project_name": "Widget",
 		"issue_uid":    "issue-kata-1",
 	})
-	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
-
-	var resp kataWorkspaceTargetResponse
-	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
 	assert.False(resp.Available)
 	assert.Nil(resp.Repo)
 }
@@ -275,16 +255,12 @@ worktree_base_path = %q
 	_, err = database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "other"))
 	require.NoError(err)
 
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/kata/workspace-target", map[string]any{
+	resp := kataWorkspaceTargetViaTaskDetail(t, srv, map[string]string{
 		"daemon_id":    "desktop",
 		"project_uid":  "project-kata-opaque",
 		"project_name": "Widget",
 		"issue_uid":    "issue-kata-1",
 	})
-	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
-
-	var resp kataWorkspaceTargetResponse
-	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
 	assert.True(resp.Available)
 	require.NotNil(resp.Repo)
 	assert.Equal("acme", resp.Repo.Owner)
@@ -308,7 +284,7 @@ name = "middleman"
 	_, err := database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "middleman"))
 	require.NoError(err)
 
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/kata/workspace-target", map[string]any{
+	resp := kataWorkspaceTargetViaTaskDetail(t, srv, map[string]string{
 		"daemon_id":    "desktop",
 		"project_uid":  "project-middleman",
 		"project_name": "middleman",
@@ -316,10 +292,6 @@ name = "middleman"
 		"short_id":     "task-123",
 		"title":        "Fix workspace affordance",
 	})
-	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
-
-	var resp kataWorkspaceTargetResponse
-	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
 	assert.True(resp.Available)
 	require.NotNil(resp.Repo)
 	assert.Equal("github", resp.Repo.Provider)
@@ -357,23 +329,18 @@ name = "middleman"
 	_, err = database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "forks", "middleman"))
 	require.NoError(err)
 
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/kata/workspace-target", map[string]any{
+	resp := kataWorkspaceTargetViaTaskDetail(t, srv, map[string]string{
 		"daemon_id":    "desktop",
 		"project_uid":  "project-middleman",
 		"project_name": "middleman",
 		"issue_uid":    "issue-kata-1",
 	})
-	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
-
-	var resp kataWorkspaceTargetResponse
-	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
 	assert.False(resp.Available)
 	assert.Nil(resp.Repo)
 }
 
 func TestKataWorkspaceTargetTrackedRepoNameFallbackRequiresTrackedRepo(t *testing.T) {
 	assert := assert.New(t)
-	require := require.New(t)
 
 	srv, _, _ := setupTestServerWithConfigContent(t, `
 sync_interval = "5m"
@@ -386,16 +353,12 @@ owner = "acme"
 name = "middleman"
 `, &mockGH{})
 
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/kata/workspace-target", map[string]any{
+	resp := kataWorkspaceTargetViaTaskDetail(t, srv, map[string]string{
 		"daemon_id":    "desktop",
 		"project_uid":  "project-middleman",
 		"project_name": "middleman",
 		"issue_uid":    "issue-kata-1",
 	})
-	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
-
-	var resp kataWorkspaceTargetResponse
-	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
 	assert.False(resp.Available)
 	assert.Nil(resp.Repo)
 }
@@ -419,16 +382,12 @@ name = "middle*"
 	_, err = database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "middle-earth"))
 	require.NoError(err)
 
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/kata/workspace-target", map[string]any{
+	resp := kataWorkspaceTargetViaTaskDetail(t, srv, map[string]string{
 		"daemon_id":    "desktop",
 		"project_uid":  "project-middleman",
 		"project_name": "middleman",
 		"issue_uid":    "issue-kata-1",
 	})
-	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
-
-	var resp kataWorkspaceTargetResponse
-	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
 	assert.True(resp.Available)
 	require.NotNil(resp.Repo)
 	assert.Equal("github", resp.Repo.Provider)
@@ -461,16 +420,12 @@ name = "middle*"
 	_, err = database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "forks", "middleman"))
 	require.NoError(err)
 
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/kata/workspace-target", map[string]any{
+	resp := kataWorkspaceTargetViaTaskDetail(t, srv, map[string]string{
 		"daemon_id":    "desktop",
 		"project_uid":  "project-middleman",
 		"project_name": "middleman",
 		"issue_uid":    "issue-kata-1",
 	})
-	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
-
-	var resp kataWorkspaceTargetResponse
-	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
 	assert.False(resp.Available)
 	assert.Nil(resp.Repo)
 }
@@ -498,16 +453,12 @@ name = "middle*"
 	_, err = database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "forks", "middleman"))
 	require.NoError(err)
 
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/kata/workspace-target", map[string]any{
+	resp := kataWorkspaceTargetViaTaskDetail(t, srv, map[string]string{
 		"daemon_id":    "desktop",
 		"project_uid":  "project-middleman",
 		"project_name": "middleman",
 		"issue_uid":    "issue-kata-1",
 	})
-	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
-
-	var resp kataWorkspaceTargetResponse
-	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
 	assert.False(resp.Available)
 	assert.Nil(resp.Repo)
 }
@@ -537,16 +488,12 @@ worktree_base_path = %q
 	_, err := database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/kata/workspace-target", map[string]any{
+	resp := kataWorkspaceTargetViaTaskDetail(t, srv, map[string]string{
 		"daemon_id":    "desktop",
 		"project_uid":  "project-kata",
 		"project_name": "widget",
 		"issue_uid":    "issue-kata-1",
 	})
-	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
-
-	var resp kataWorkspaceTargetResponse
-	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
 	assert.True(resp.Available)
 	require.NotNil(resp.Repo)
 	assert.Equal("acme", resp.Repo.Owner)
@@ -601,17 +548,6 @@ func TestReadKataProjectTOMLReadsRegularFile(t *testing.T) {
 	assert.Equal("Widget", project.Name)
 }
 
-func TestKataWorkspaceTargetRequiresDaemonID(t *testing.T) {
-	require := require.New(t)
-
-	srv, _, _ := setupTestServerWithConfig(t)
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/kata/workspace-target", map[string]any{
-		"project_uid": "project-kata",
-		"issue_uid":   "issue-kata-1",
-	})
-	require.Equal(http.StatusUnprocessableEntity, rr.Code, rr.Body.String())
-}
-
 func TestKataWorkspaceTargetUnavailableWhenAutomaticMappingAmbiguous(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -650,16 +586,12 @@ worktree_base_path = %q
 	_, err = database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "other"))
 	require.NoError(err)
 
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/kata/workspace-target", map[string]any{
+	resp := kataWorkspaceTargetViaTaskDetail(t, srv, map[string]string{
 		"daemon_id":    "desktop",
 		"project_uid":  "project-kata",
 		"project_name": "Widget",
 		"issue_uid":    "issue-kata-1",
 	})
-	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
-
-	var resp kataWorkspaceTargetResponse
-	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
 	assert.False(resp.Available)
 	assert.Nil(resp.Repo)
 }
@@ -708,16 +640,12 @@ name = "middleman"
 	_, err = database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "middleman"))
 	require.NoError(err)
 
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/kata/workspace-target", map[string]any{
+	resp := kataWorkspaceTargetViaTaskDetail(t, srv, map[string]string{
 		"daemon_id":    "desktop",
 		"project_uid":  "project-kata",
 		"project_name": "middleman",
 		"issue_uid":    "issue-kata-1",
 	})
-	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
-
-	var resp kataWorkspaceTargetResponse
-	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
 	assert.False(resp.Available)
 	assert.Nil(resp.Repo)
 }
@@ -757,26 +685,21 @@ worktree_base_path = %q
 	_, err = database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "other"))
 	require.NoError(err)
 
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/kata/workspace-target", map[string]any{
+	resp := kataWorkspaceTargetViaTaskDetail(t, srv, map[string]string{
 		"daemon_id":    "desktop",
 		"project_uid":  "project-kata-opaque",
 		"project_name": "Widget",
 		"issue_uid":    "issue-kata-1",
 	})
-	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
-
-	var resp kataWorkspaceTargetResponse
-	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
 	assert.False(resp.Available)
 	assert.Nil(resp.Repo)
 }
 
 func TestKataWorkspaceTargetUnavailableWhenMappingMissing(t *testing.T) {
 	assert := assert.New(t)
-	require := require.New(t)
 
 	srv, _, _ := setupTestServerWithConfig(t)
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/kata/workspace-target", map[string]any{
+	resp := kataWorkspaceTargetViaTaskDetail(t, srv, map[string]string{
 		"daemon_id":    "desktop",
 		"project_uid":  "project-kata",
 		"project_name": "Kata",
@@ -784,10 +707,6 @@ func TestKataWorkspaceTargetUnavailableWhenMappingMissing(t *testing.T) {
 		"short_id":     "task-123",
 		"title":        "Fix widget",
 	})
-	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
-
-	var resp kataWorkspaceTargetResponse
-	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
 	assert.False(resp.Available)
 	assert.Nil(resp.Repo)
 	assert.Nil(resp.ExistingWorkspace)
@@ -844,7 +763,7 @@ repo_path = "acme/widget"
 		},
 	}))
 
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/kata/workspace-target", map[string]any{
+	resp := kataWorkspaceTargetViaTaskDetail(t, srv, map[string]string{
 		"daemon_id":    "desktop",
 		"project_uid":  "project-kata",
 		"project_name": "Kata",
@@ -852,10 +771,6 @@ repo_path = "acme/widget"
 		"short_id":     "task-123",
 		"title":        "Fix widget",
 	})
-	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
-
-	var resp kataWorkspaceTargetResponse
-	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
 	assert.True(resp.Available)
 	require.NotNil(resp.ExistingWorkspace)
 	assert.Equal("ws-kata-existing", resp.ExistingWorkspace.ID)

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -12054,6 +12054,7 @@ export interface operations {
             /** @description OK */
             200: {
                 headers: {
+                    Vary?: string;
                     [name: string]: unknown;
                 };
                 content: {

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -2080,17 +2080,17 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/kata/workspace-target": {
+    "/kata/tasks/{issue_uid}": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        /** Get Kata task detail with workspace target */
+        get: operations["get-kata-task-detail"];
         put?: never;
-        /** Resolve Kata workspace target */
-        post: operations["resolve-kata-workspace-target"];
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -5327,13 +5327,20 @@ export interface components {
             provider: string;
             repo_path: string;
         };
-        KataWorkspaceTargetResponse: {
+        KataTaskDetailResponse: {
             /**
              * Format: uri
              * @description A URL to the JSON Schema for this object.
-             * @example /api/v1/schemas/KataWorkspaceTargetResponse.json
+             * @example /api/v1/schemas/KataTaskDetailResponse.json
              */
             readonly $schema?: string;
+            /** @description Verbatim Kata daemon issue detail payload */
+            detail: unknown;
+            /** @description Daemon issue detail ETag, when the daemon provided one */
+            etag?: string;
+            workspace_target: components["schemas"]["KataWorkspaceTargetResponse"];
+        };
+        KataWorkspaceTargetResponse: {
             available: boolean;
             existing_workspace?: components["schemas"]["WorkspaceRef"];
             item_key?: string;
@@ -12029,18 +12036,20 @@ export interface operations {
             };
         };
     };
-    "resolve-kata-workspace-target": {
+    "get-kata-task-detail": {
         parameters: {
             query?: never;
-            header?: never;
-            path?: never;
+            header?: {
+                /** @description Kata daemon id; the effective default daemon when empty */
+                "X-Middleman-Kata-Daemon"?: string;
+            };
+            path: {
+                /** @description Kata issue UID */
+                issue_uid: string;
+            };
             cookie?: never;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["KataWorkspaceTaskRequest"];
-            };
-        };
+        requestBody?: never;
         responses: {
             /** @description OK */
             200: {
@@ -12048,7 +12057,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["KataWorkspaceTargetResponse"];
+                    "application/json": components["schemas"]["KataTaskDetailResponse"];
                 };
             };
             /** @description Error */


### PR DESCRIPTION
Clicking a task in Kata mode took multiple seconds to show the detail pane against a remote daemon, and the Create workspace button popped in a further round trip later. The pane was blocked on an events read that walks the daemon's whole event log in pages of 100 (the daemon has no `issue_uid` filter — ~34 sequential round trips / ~3s per click over Tailscale), and the workspace action was resolved by a separate `POST /kata/workspace-target` request that only started after the detail landed.

The detail read is now middleman's combined `GET /kata/tasks/{issue_uid}`: the backend fetches the daemon detail (and project names) server-side and returns it together with the resolved workspace target, so the pane and its workspace action render atomically from one response. `POST /kata/workspace-target` is removed so the target has a single canonical carrier.

User-visible changes:
- Task detail renders as soon as the detail read returns (~60ms observed against a remote daemon, previously ~3s); the events section fills in asynchronously
- The Create/Open workspace button appears together with the detail pane instead of popping in afterwards
- Selection latency is observable via User Timing measures (`kata:select-issue:detail-visible` / `events-loaded`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)