### PR TITLE
chore: group renovate updates by category to cut PR noise

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,6 +27,26 @@
       "matchManagers": ["bun", "custom.regex"],
       "groupName": "JavaScript dependencies",
       "groupSlug": "javascript-dependencies"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions",
+      "groupSlug": "github-actions"
+    },
+    {
+      "matchManagers": ["docker-compose", "dockerfile"],
+      "groupName": "Docker images",
+      "groupSlug": "docker-images"
+    },
+    {
+      "matchManagers": ["mise"],
+      "groupName": "Developer tools",
+      "groupSlug": "dev-tools"
+    },
+    {
+      "matchDepNames": ["golangci-lint", "golangci/golangci-lint"],
+      "groupName": "golangci-lint",
+      "groupSlug": "golangci-lint"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
The dependency dashboard was dominated by isolated single-dependency PRs: nine separate GitHub Actions bumps, per-image Docker tag PRs for the e2e fixtures, one PR per mise tool, and two PRs for the same golangci-lint version pinned in both mise.toml and ci.yml (which had already drifted to 2.11.4 vs v2.10.1). Only gomod, cargo, and bun updates were grouped. A local renovate dry run showed the 89 currently pending updates would branchify into 10 PRs with these rules instead.

- GitHub Actions updates arrive as one grouped PR (majors still split out separately)
- Docker image tags for the e2e fixture containers arrive as one grouped PR, including the gitlab-ce pin shared between compose and Dockerfile.fixture
- mise-managed developer tools (node, vite-plus, samesame-rolling) arrive as one grouped PR
- The golangci-lint pins in mise.toml and the CI workflow update together in a single cross-manager PR so they can no longer drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sup>generated by a clanker</sup>