### PR TITLE
Remove redundant ref type labels

### DIFF
--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.svelte
@@ -713,7 +713,7 @@
                   }}
                   onmouseenter={() => (refPickerHighlightIndex = index)}
                 >
-                  <span class="option-label">{ref.type}: {ref.name || ref.sha.slice(0, 12)}</span>
+                  <span class="option-label">{ref.name || ref.sha.slice(0, 12)}</span>
                   {#if ref.sha}
                     <span class="option-meta">{ref.sha.slice(0, 8)}</span>
                   {/if}

--- a/frontend/src/lib/features/repo-browser/RepoBrowserFeature.test.ts
+++ b/frontend/src/lib/features/repo-browser/RepoBrowserFeature.test.ts
@@ -296,7 +296,7 @@ describe("RepoBrowserFeature", () => {
       target: { value: "v1" },
     });
     await fireEvent.click(screen.getByRole("tab", { name: "Tags 1" }));
-    await fireEvent.click(screen.getByRole("option", { name: "tag: v1.0.0 tag-sha" }));
+    await fireEvent.click(screen.getByRole("option", { name: "v1.0.0 tag-sha" }));
     await waitFor(() => expect(client.GET).toHaveBeenCalledTimes(9));
     await waitFor(() => {
       expect(onRouteChange).toHaveBeenLastCalledWith(
@@ -348,13 +348,13 @@ describe("RepoBrowserFeature", () => {
     await fireEvent.input(input, { target: { value: "v1" } });
 
     expect(screen.getByRole("tab", { name: "Branches 3" }).getAttribute("aria-selected")).toBe("true");
-    expect(screen.getByRole("option", { name: "branch: release/v1 release-" })).toBeTruthy();
+    expect(screen.getByRole("option", { name: "release/v1 release-" })).toBeTruthy();
     expect(screen.queryByRole("option", { name: "tag: v1.0.0 tag-sha" })).toBeNull();
 
     await fireEvent.click(screen.getByRole("tab", { name: "Tags 2" }));
 
     expect(screen.getByRole("tab", { name: "Tags 2" }).getAttribute("aria-selected")).toBe("true");
-    expect(screen.getByRole("option", { name: "tag: v1.0.0 tag-sha" })).toBeTruthy();
+    expect(screen.getByRole("option", { name: "v1.0.0 tag-sha" })).toBeTruthy();
     expect(screen.queryByRole("option", { name: "branch: release/v1 release-" })).toBeNull();
   });
 
@@ -371,7 +371,7 @@ describe("RepoBrowserFeature", () => {
 
     await waitFor(() => expect(client.GET).toHaveBeenCalledTimes(5));
     await fireEvent.click(await screen.findByRole("button", { name: "Select repository ref: branch: main main-sha" }));
-    await fireEvent.click(screen.getByRole("option", { name: "branch: main main-sha" }));
+    await fireEvent.click(screen.getByRole("option", { name: "main main-sha" }));
     await tick();
 
     expect(client.GET).toHaveBeenCalledTimes(5);

--- a/frontend/tests/e2e-full/repo-browser.spec.ts
+++ b/frontend/tests/e2e-full/repo-browser.spec.ts
@@ -244,11 +244,11 @@ test.describe("repository source browser", () => {
       await browser.getByRole("button", { name: /Select repository ref: branch: main/ }).click();
       await browser.getByRole("combobox", { name: "Search repository refs" }).fill("feature");
       await expect(browser.getByRole("tab", { name: /Branches/ })).toHaveAttribute("aria-selected", "true");
-      await expect(browser.getByRole("option", { name: /branch: feature\/caching/ })).toBeVisible();
+      await expect(browser.getByRole("option", { name: /feature\/caching/ })).toBeVisible();
       await expect(browser.getByRole("option", { name: /tag:/ })).toHaveCount(0);
 
       const featureTreeLoaded = treeResponse(page, "feature/caching");
-      await browser.getByRole("option", { name: /branch: feature\/caching/ }).click();
+      await browser.getByRole("option", { name: /feature\/caching/ }).click();
       await featureTreeLoaded;
       await expect(page).toHaveURL(/ref_name=feature%2Fcaching/);
 
@@ -289,7 +289,7 @@ test.describe("repository source browser", () => {
       const routeBeforeReselect = page.url();
 
       await browser.getByRole("button", { name: /Select repository ref: branch: main/ }).click();
-      await browser.getByRole("option", { name: /branch: main/ }).click();
+      await browser.getByRole("option", { name: /main/ }).click();
 
       await expect(browser.getByRole("combobox", { name: "Search repository refs" })).toHaveCount(0);
       expect(page.url()).toBe(routeBeforeReselect);


### PR DESCRIPTION
Repo browser ref rows now rely on the active Branches/Tags tab for type context instead of repeating `branch:` or `tag:` on every option. The closed trigger label keeps the type prefix because it appears outside the tabbed menu.

- Removes redundant row prefixes in the ref picker menu.
- Keeps branch/tag filtering and selection behavior aligned in unit and full-stack coverage.

Validated locally with the full frontend `vp test` suite and the repo-browser full-stack Playwright suite.

<sup>generated by a clanker</sup>