### PR TITLE
docs: clarify roborev review restriction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,10 +180,11 @@ Coverage of real behavior is non-negotiable; the lane is chosen by the behavior 
 
 ## Roborev
 
-- Never manually invoke `roborev review` in any form unless the user explicitly
-  asks for it. Never invoke a roborev skill (including `roborev-fix` or
-  `roborev-design-review-branch`) unless the user explicitly asks for that
-  skill.
+- Never invoke the `roborev review` CLI command in any form unless the user
+  explicitly asks for it. Use all other `roborev` CLI commands normally when
+  they are appropriate for interacting with roborev. Never invoke a roborev
+  skill (including `roborev-fix` or `roborev-design-review-branch`) unless the
+  user explicitly asks for that skill.
 
 ## Git Workflow
 


### PR DESCRIPTION
The existing instruction can be read as restricting the roborev CLI generally. Clarify that only the `roborev review` subcommand requires an explicit user request and encourage normal use of every other roborev CLI command; roborev skills remain opt-in.