### PR TITLE
feat: request changes from the approval form

### DIFF
--- a/context/platform-sync-invariants.md
+++ b/context/platform-sync-invariants.md
@@ -126,7 +126,10 @@ registry helpers return typed errors for missing providers or capabilities.
   reviewed heads, renamed/deleted/binary files, unsupported encodings,
   whitespace-padded paths) fail the entire batch with stable reasons.
 - Forgejo and Gitea currently expose only SDK-proven mutations: comments,
-  issue creation, issue and PR content/state edits, merge, and review approval.
+  issue creation, issue and PR content/state edits, merge, review approval, and
+  request changes. Their shared review mutations must map SDK failures through
+  the provider error mapper so permission and not-found responses retain typed
+  platform errors.
   Workflow approval and ready-for-review must remain hidden or return typed
   `unsupported_capability` errors until proven per provider.
 - GitHub GraphQL bulk fetch, ETag recovery, and detailed diff behavior are

--- a/context/testing.md
+++ b/context/testing.md
@@ -190,6 +190,10 @@ clones its own bare repo and worktree root. Keep tests serial when they call
 resources, or intentionally verify ordering against another test-visible shared
 resource.
 
+Disable Git auto-GC and auto-maintenance in synthetic repositories under
+`t.TempDir`; detached maintenance can recreate files during fixture cleanup
+(`internal/gitclone/commits_test.go::commitTestRun`).
+
 Real tmux and PTY tests can still run in parallel when each test owns its
 session names, temp dirs, sockets, and cleanup. If the bottleneck is external
 resource pressure rather than correctness, keep `t.Parallel()` and gate the

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -202,6 +202,8 @@ context.
 ## Inline Review Drafts
 
 Inline diff review draft comments are local staged review state until publish.
+Direct detail-form review actions must leave that staged state untouched; do not
+route them through draft publish (`internal/server/huma_routes.go::requestChangesPR`).
 Editing a saved draft comment should change only the body and preserve the
 original diff range, so the PATCH path must rebuild the range from the stored
 comment rather than from whichever line is currently selected

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -203,7 +203,7 @@ context.
 
 Inline diff review draft comments are local staged review state until publish.
 Direct detail-form review actions must leave that staged state untouched; do not
-route them through draft publish (`internal/server/huma_routes.go::requestChangesPR`).
+load or publish saved draft comments (`internal/server/huma_routes.go::requestChangesPR`).
 Editing a saved draft comment should change only the body and preserve the
 original diff range, so the PATCH path must rebuild the range from the stored
 comment rather than from whichever line is currently selected

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -204,6 +204,11 @@ context.
 Inline diff review draft comments are local staged review state until publish.
 Direct detail-form review actions must leave that staged state untouched; do not
 load or publish saved draft comments (`internal/server/huma_routes.go::requestChangesPR`).
+Direct approve and request-changes share one submission contract end to end —
+the same head pin, the same provider-side binding, the same post-success refresh
+handling. Do not give either action stronger client-side verification, staleness
+checks, or revocation behavior than the other
+(`internal/server/huma_routes.go::approvalReviewHeadSHA`).
 Editing a saved draft comment should change only the body and preserve the
 original diff range, so the PATCH path must rebuild the range from the stored
 comment rather than from whichever line is currently selected

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -209,6 +209,9 @@ the same head pin, the same provider-side binding, the same post-success refresh
 handling. Do not give either action stronger client-side verification, staleness
 checks, or revocation behavior than the other
 (`internal/server/huma_routes.go::approvalReviewHeadSHA`).
+Once either provider mutation succeeds, close and clear its form before the
+follow-up refresh. A refresh failure may show a warning, but must not leave the
+successful mutation available for an accidental duplicate submission.
 Editing a saved draft comment should change only the body and preserve the
 original diff range, so the PATCH path must rebuild the range from the stored
 comment rather than from whichever line is currently selected

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -5746,6 +5746,40 @@ components:
       required:
         - worktree_base_path
       type: object
+    RequestChangesPRHostInputBody:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /api/v1/schemas/RequestChangesPRHostInputBody.json
+          format: uri
+          readOnly: true
+          type: string
+        body:
+          type: string
+        expected_head_sha:
+          type: string
+      required:
+        - body
+      type: object
+    RequestChangesPRInputBody:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /api/v1/schemas/RequestChangesPRInputBody.json
+          format: uri
+          readOnly: true
+          type: string
+        body:
+          type: string
+        expected_head_sha:
+          type: string
+      required:
+        - body
+      type: object
     ResolveDiscussionHostInputBody:
       additionalProperties: false
       properties:
@@ -10769,6 +10803,58 @@ paths:
       summary: Mark pull request ready for review
       tags:
         - Pull Requests
+  /host/{platform_host}/pulls/{provider}/{owner}/{name}/{number}/request-changes:
+    post:
+      operationId: request-pull-changes-on-host
+      parameters:
+        - in: path
+          name: provider
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: platform_host
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: owner
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: number
+          required: true
+          schema:
+            format: int64
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RequestChangesPRHostInputBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActionStatusBody"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Error
+      summary: Request pull request changes
+      tags:
+        - Pull Requests
   /host/{platform_host}/pulls/{provider}/{owner}/{name}/{number}/review-draft:
     delete:
       operationId: discard-pr-review-draft-on-host
@@ -15178,6 +15264,53 @@ paths:
                 $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: Mark pull request ready for review
+      tags:
+        - Pull Requests
+  /pulls/{provider}/{owner}/{name}/{number}/request-changes:
+    post:
+      operationId: request-pull-changes
+      parameters:
+        - in: path
+          name: provider
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: owner
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: number
+          required: true
+          schema:
+            format: int64
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RequestChangesPRInputBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActionStatusBody"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Error
+      summary: Request pull request changes
       tags:
         - Pull Requests
   /pulls/{provider}/{owner}/{name}/{number}/review-draft:

--- a/frontend/src/ApproveButton.test.ts
+++ b/frontend/src/ApproveButton.test.ts
@@ -22,6 +22,7 @@ const defaultProps = {
   name: "widget",
   repoPath: "acme/widget",
   number: 1,
+  supportedReviewActions: [] as string[],
 };
 
 function renderApproveButton(overrides: Partial<typeof defaultProps> = {}) {
@@ -67,7 +68,7 @@ describe("ApproveButton tooltips", () => {
     await fireEvent.click(trigger);
 
     expect(trigger.getAttribute("aria-expanded")).toBe("true");
-    expect(screen.getByRole("dialog", { name: "Approve pull request" })).toBeTruthy();
+    expect(screen.getByRole("dialog", { name: "Submit pull request review" })).toBeTruthy();
 
     await waitFor(() => {
       expect(document.activeElement).toBe(screen.getByRole("textbox"));
@@ -81,6 +82,27 @@ describe("ApproveButton tooltips", () => {
 
     expect(screen.getByPlaceholderText("Leave an optional comment…")).toBeTruthy();
     expect(screen.queryByPlaceholderText(/\\u2026/)).toBeNull();
+  });
+
+  it("submits a change request with the typed review comment", async () => {
+    renderApproveButton({ supportedReviewActions: ["approve", "request_changes"] });
+
+    await fireEvent.click(screen.getByRole("button", { name: /^approve$/i }));
+    const requestChanges = screen.getByRole("button", { name: "Request changes" });
+    expect(requestChanges.hasAttribute("disabled")).toBe(true);
+
+    await fireEvent.input(screen.getByRole("textbox"), {
+      target: { value: "Please cover the empty state." },
+    });
+    await fireEvent.click(requestChanges);
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledTimes(1);
+    });
+    expect(mockPost.mock.calls[0]?.[0]).toContain("/request-changes");
+    const [, init] = mockPost.mock.calls[0] as [string, { body: { body: string } }];
+    expect(init.body.body).toBe("Please cover the empty state.");
+    expect(screen.queryByRole("dialog", { name: "Submit pull request review" })).toBeNull();
   });
 
   it("collapses the approval popover from cancel without removing the trigger", async () => {
@@ -113,15 +135,15 @@ describe("ApproveButton tooltips", () => {
     await waitFor(() => {
       expect(trigger.hasAttribute("disabled")).toBe(true);
     });
-    expect(screen.getByRole("dialog", { name: "Approve pull request" })).toBeTruthy();
+    expect(screen.getByRole("dialog", { name: "Submit pull request review" })).toBeTruthy();
 
     await fireEvent.click(trigger);
-    expect(screen.getByRole("dialog", { name: "Approve pull request" })).toBeTruthy();
+    expect(screen.getByRole("dialog", { name: "Submit pull request review" })).toBeTruthy();
 
     resolvePost({ data: { status: "approved" } });
 
     await waitFor(() => {
-      expect(screen.queryByRole("dialog", { name: "Approve pull request" })).toBeNull();
+      expect(screen.queryByRole("dialog", { name: "Submit pull request review" })).toBeNull();
     });
   });
 
@@ -132,7 +154,7 @@ describe("ApproveButton tooltips", () => {
 
     const trigger = screen.getByRole("button", { name: /^approve$/i });
     await fireEvent.click(trigger);
-    expect(screen.getByRole("dialog", { name: "Approve pull request" })).toBeTruthy();
+    expect(screen.getByRole("dialog", { name: "Submit pull request review" })).toBeTruthy();
 
     // Same owner/name/number on a different provider+host+repoPath:
     // the open form and its captured pin must not survive the route.
@@ -144,7 +166,7 @@ describe("ApproveButton tooltips", () => {
       expectedHeadSha: "gitea-pin",
     });
 
-    expect(screen.queryByRole("dialog", { name: "Approve pull request" })).toBeNull();
+    expect(screen.queryByRole("dialog", { name: "Submit pull request review" })).toBeNull();
 
     await fireEvent.click(screen.getByRole("button", { name: /^approve$/i }));
     await fireEvent.click(screen.getByTitle("Submit an approving code review on this pull request"));
@@ -179,7 +201,7 @@ describe("ApproveButton tooltips", () => {
     await waitFor(() => {
       expect(onHeadConflict).toHaveBeenCalledWith("stale_state", undefined);
     });
-    expect(screen.queryByRole("dialog", { name: "Approve pull request" })).toBeNull();
+    expect(screen.queryByRole("dialog", { name: "Submit pull request review" })).toBeNull();
 
     await rerender({
       ...defaultProps,

--- a/frontend/src/ApproveButton.test.ts
+++ b/frontend/src/ApproveButton.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test"
 const mockPost = vi.hoisted(() => vi.fn());
 const mockLoadDetail = vi.hoisted(() => vi.fn());
 const mockLoadPulls = vi.hoisted(() => vi.fn());
+const mockShowFlash = vi.hoisted(() => vi.fn());
 
 vi.mock("../../packages/ui/src/context.js", () => ({
   getClient: () => ({ POST: mockPost }),
@@ -11,6 +12,10 @@ vi.mock("../../packages/ui/src/context.js", () => ({
     detail: { loadDetail: mockLoadDetail },
     pulls: { loadPulls: mockLoadPulls },
   }),
+}));
+
+vi.mock("../../packages/ui/src/stores/flash.svelte.js", () => ({
+  showFlash: mockShowFlash,
 }));
 
 import ApproveButton from "../../packages/ui/src/components/detail/ApproveButton.svelte";
@@ -36,6 +41,7 @@ describe("ApproveButton tooltips", () => {
     mockPost.mockResolvedValue({ data: { status: "approved" } });
     mockLoadDetail.mockResolvedValue(undefined);
     mockLoadPulls.mockResolvedValue(undefined);
+    mockShowFlash.mockReset();
   });
 
   afterEach(() => {
@@ -103,6 +109,23 @@ describe("ApproveButton tooltips", () => {
     const [, init] = mockPost.mock.calls[0] as [string, { body: { body: string } }];
     expect(init.body.body).toBe("Please cover the empty state.");
     expect(screen.queryByRole("dialog", { name: "Submit pull request review" })).toBeNull();
+  });
+
+  it("closes a successful change request before reporting a refresh failure", async () => {
+    mockLoadDetail.mockRejectedValueOnce(new Error("offline"));
+    renderApproveButton({ supportedReviewActions: ["approve", "request_changes"] });
+
+    await fireEvent.click(screen.getByRole("button", { name: /^approve$/i }));
+    await fireEvent.input(screen.getByRole("textbox"), {
+      target: { value: "Please cover the empty state." },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Request changes" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Submit pull request review" })).toBeNull();
+    });
+    expect(mockPost).toHaveBeenCalledTimes(1);
+    expect(mockShowFlash).toHaveBeenCalledWith("Changes were requested, but the pull request could not be refreshed.");
   });
 
   it("collapses the approval popover from cancel without removing the trigger", async () => {

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -2750,6 +2750,22 @@ type RepoWorktreeBaseRequest struct {
 	WorktreeBasePath string  `json:"worktree_base_path"`
 }
 
+// RequestChangesPRHostInputBody defines model for RequestChangesPRHostInputBody.
+type RequestChangesPRHostInputBody struct {
+	// Schema A URL to the JSON Schema for this object.
+	Schema          *string `json:"$schema,omitempty"`
+	Body            string  `json:"body"`
+	ExpectedHeadSha *string `json:"expected_head_sha,omitempty"`
+}
+
+// RequestChangesPRInputBody defines model for RequestChangesPRInputBody.
+type RequestChangesPRInputBody struct {
+	// Schema A URL to the JSON Schema for this object.
+	Schema          *string `json:"$schema,omitempty"`
+	Body            string  `json:"body"`
+	ExpectedHeadSha *string `json:"expected_head_sha,omitempty"`
+}
+
 // ResolveDiscussionHostInputBody defines model for ResolveDiscussionHostInputBody.
 type ResolveDiscussionHostInputBody struct {
 	// Schema A URL to the JSON Schema for this object.
@@ -3988,6 +4004,9 @@ type MergePullOnHostJSONRequestBody = MergePRInputBody
 // DeferMergePullOnHostJSONRequestBody defines body for DeferMergePullOnHost for application/json ContentType.
 type DeferMergePullOnHostJSONRequestBody = MergePRInputBody
 
+// RequestPullChangesOnHostJSONRequestBody defines body for RequestPullChangesOnHost for application/json ContentType.
+type RequestPullChangesOnHostJSONRequestBody = RequestChangesPRHostInputBody
+
 // CreatePrReviewDraftCommentOnHostJSONRequestBody defines body for CreatePrReviewDraftCommentOnHost for application/json ContentType.
 type CreatePrReviewDraftCommentOnHostJSONRequestBody = CreateDiffReviewDraftCommentHostInputBody
 
@@ -4110,6 +4129,9 @@ type MergePullJSONRequestBody = MergePRInputBody
 
 // DeferMergePullJSONRequestBody defines body for DeferMergePull for application/json ContentType.
 type DeferMergePullJSONRequestBody = MergePRInputBody
+
+// RequestPullChangesJSONRequestBody defines body for RequestPullChanges for application/json ContentType.
+type RequestPullChangesJSONRequestBody = RequestChangesPRInputBody
 
 // CreatePrReviewDraftCommentJSONRequestBody defines body for CreatePrReviewDraftComment for application/json ContentType.
 type CreatePrReviewDraftCommentJSONRequestBody = CreateDiffReviewDraftCommentInputBody
@@ -4613,6 +4635,11 @@ type ClientInterface interface {
 	// MarkPullReadyForReviewOnHost request
 	MarkPullReadyForReviewOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// RequestPullChangesOnHostWithBody request with any body
+	RequestPullChangesOnHostWithBody(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	RequestPullChangesOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body RequestPullChangesOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// DiscardPrReviewDraftOnHost request
 	DiscardPrReviewDraftOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -5003,6 +5030,11 @@ type ClientInterface interface {
 
 	// MarkPullReadyForReview request
 	MarkPullReadyForReview(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// RequestPullChangesWithBody request with any body
+	RequestPullChangesWithBody(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	RequestPullChanges(ctx context.Context, provider string, owner string, name string, number int64, body RequestPullChangesJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// DiscardPrReviewDraft request
 	DiscardPrReviewDraft(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -6888,6 +6920,30 @@ func (c *Client) MarkPullReadyForReviewOnHost(ctx context.Context, platformHost 
 	return c.Client.Do(req)
 }
 
+func (c *Client) RequestPullChangesOnHostWithBody(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRequestPullChangesOnHostRequestWithBody(c.Server, platformHost, provider, owner, name, number, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RequestPullChangesOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body RequestPullChangesOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRequestPullChangesOnHostRequest(c.Server, platformHost, provider, owner, name, number, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) DiscardPrReviewDraftOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewDiscardPrReviewDraftOnHostRequest(c.Server, platformHost, provider, owner, name, number)
 	if err != nil {
@@ -8606,6 +8662,30 @@ func (c *Client) DeferMergePull(ctx context.Context, provider string, owner stri
 
 func (c *Client) MarkPullReadyForReview(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewMarkPullReadyForReviewRequest(c.Server, provider, owner, name, number)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RequestPullChangesWithBody(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRequestPullChangesRequestWithBody(c.Server, provider, owner, name, number, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RequestPullChanges(ctx context.Context, provider string, owner string, name string, number int64, body RequestPullChangesJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRequestPullChangesRequest(c.Server, provider, owner, name, number, body)
 	if err != nil {
 		return nil, err
 	}
@@ -15601,6 +15681,81 @@ func NewMarkPullReadyForReviewOnHostRequest(server string, platformHost string, 
 	return req, nil
 }
 
+// NewRequestPullChangesOnHostRequest calls the generic RequestPullChangesOnHost builder with application/json body
+func NewRequestPullChangesOnHostRequest(server string, platformHost string, provider string, owner string, name string, number int64, body RequestPullChangesOnHostJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewRequestPullChangesOnHostRequestWithBody(server, platformHost, provider, owner, name, number, "application/json", bodyReader)
+}
+
+// NewRequestPullChangesOnHostRequestWithBody generates requests for RequestPullChangesOnHost with any type of body
+func NewRequestPullChangesOnHostRequestWithBody(server string, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "platform_host", platformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "provider", provider, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "owner", owner, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam3 string
+
+	pathParam3, err = runtime.StyleParamWithOptions("simple", false, "name", name, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam4 string
+
+	pathParam4, err = runtime.StyleParamWithOptions("simple", false, "number", number, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "integer", Format: "int64"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/host/%s/pulls/%s/%s/%s/%s/request-changes", pathParam0, pathParam1, pathParam2, pathParam3, pathParam4)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewDiscardPrReviewDraftOnHostRequest generates requests for DiscardPrReviewDraftOnHost
 func NewDiscardPrReviewDraftOnHostRequest(server string, platformHost string, provider string, owner string, name string, number int64) (*http.Request, error) {
 	var err error
@@ -22348,6 +22503,74 @@ func NewMarkPullReadyForReviewRequest(server string, provider string, owner stri
 	return req, nil
 }
 
+// NewRequestPullChangesRequest calls the generic RequestPullChanges builder with application/json body
+func NewRequestPullChangesRequest(server string, provider string, owner string, name string, number int64, body RequestPullChangesJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewRequestPullChangesRequestWithBody(server, provider, owner, name, number, "application/json", bodyReader)
+}
+
+// NewRequestPullChangesRequestWithBody generates requests for RequestPullChanges with any type of body
+func NewRequestPullChangesRequestWithBody(server string, provider string, owner string, name string, number int64, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "provider", provider, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "owner", owner, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "name", name, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam3 string
+
+	pathParam3, err = runtime.StyleParamWithOptions("simple", false, "number", number, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "integer", Format: "int64"})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/pulls/%s/%s/%s/%s/request-changes", pathParam0, pathParam1, pathParam2, pathParam3)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewDiscardPrReviewDraftRequest generates requests for DiscardPrReviewDraft
 func NewDiscardPrReviewDraftRequest(server string, provider string, owner string, name string, number int64) (*http.Request, error) {
 	var err error
@@ -26963,6 +27186,11 @@ type ClientWithResponsesInterface interface {
 	// MarkPullReadyForReviewOnHostWithResponse request
 	MarkPullReadyForReviewOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*MarkPullReadyForReviewOnHostResponse, error)
 
+	// RequestPullChangesOnHostWithBodyWithResponse request with any body
+	RequestPullChangesOnHostWithBodyWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RequestPullChangesOnHostResponse, error)
+
+	RequestPullChangesOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body RequestPullChangesOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*RequestPullChangesOnHostResponse, error)
+
 	// DiscardPrReviewDraftOnHostWithResponse request
 	DiscardPrReviewDraftOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*DiscardPrReviewDraftOnHostResponse, error)
 
@@ -27353,6 +27581,11 @@ type ClientWithResponsesInterface interface {
 
 	// MarkPullReadyForReviewWithResponse request
 	MarkPullReadyForReviewWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*MarkPullReadyForReviewResponse, error)
+
+	// RequestPullChangesWithBodyWithResponse request with any body
+	RequestPullChangesWithBodyWithResponse(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RequestPullChangesResponse, error)
+
+	RequestPullChangesWithResponse(ctx context.Context, provider string, owner string, name string, number int64, body RequestPullChangesJSONRequestBody, reqEditors ...RequestEditorFn) (*RequestPullChangesResponse, error)
 
 	// DiscardPrReviewDraftWithResponse request
 	DiscardPrReviewDraftWithResponse(ctx context.Context, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*DiscardPrReviewDraftResponse, error)
@@ -29787,6 +30020,29 @@ func (r MarkPullReadyForReviewOnHostResponse) StatusCode() int {
 	return 0
 }
 
+type RequestPullChangesOnHostResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *ActionStatusBody
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r RequestPullChangesOnHostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RequestPullChangesOnHostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type DiscardPrReviewDraftOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
@@ -32133,6 +32389,29 @@ func (r MarkPullReadyForReviewResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r MarkPullReadyForReviewResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type RequestPullChangesResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *ActionStatusBody
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r RequestPullChangesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RequestPullChangesResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -35052,6 +35331,23 @@ func (c *ClientWithResponses) MarkPullReadyForReviewOnHostWithResponse(ctx conte
 	return ParseMarkPullReadyForReviewOnHostResponse(rsp)
 }
 
+// RequestPullChangesOnHostWithBodyWithResponse request with arbitrary body returning *RequestPullChangesOnHostResponse
+func (c *ClientWithResponses) RequestPullChangesOnHostWithBodyWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RequestPullChangesOnHostResponse, error) {
+	rsp, err := c.RequestPullChangesOnHostWithBody(ctx, platformHost, provider, owner, name, number, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRequestPullChangesOnHostResponse(rsp)
+}
+
+func (c *ClientWithResponses) RequestPullChangesOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, body RequestPullChangesOnHostJSONRequestBody, reqEditors ...RequestEditorFn) (*RequestPullChangesOnHostResponse, error) {
+	rsp, err := c.RequestPullChangesOnHost(ctx, platformHost, provider, owner, name, number, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRequestPullChangesOnHostResponse(rsp)
+}
+
 // DiscardPrReviewDraftOnHostWithResponse request returning *DiscardPrReviewDraftOnHostResponse
 func (c *ClientWithResponses) DiscardPrReviewDraftOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, number int64, reqEditors ...RequestEditorFn) (*DiscardPrReviewDraftOnHostResponse, error) {
 	rsp, err := c.DiscardPrReviewDraftOnHost(ctx, platformHost, provider, owner, name, number, reqEditors...)
@@ -36305,6 +36601,23 @@ func (c *ClientWithResponses) MarkPullReadyForReviewWithResponse(ctx context.Con
 		return nil, err
 	}
 	return ParseMarkPullReadyForReviewResponse(rsp)
+}
+
+// RequestPullChangesWithBodyWithResponse request with arbitrary body returning *RequestPullChangesResponse
+func (c *ClientWithResponses) RequestPullChangesWithBodyWithResponse(ctx context.Context, provider string, owner string, name string, number int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*RequestPullChangesResponse, error) {
+	rsp, err := c.RequestPullChangesWithBody(ctx, provider, owner, name, number, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRequestPullChangesResponse(rsp)
+}
+
+func (c *ClientWithResponses) RequestPullChangesWithResponse(ctx context.Context, provider string, owner string, name string, number int64, body RequestPullChangesJSONRequestBody, reqEditors ...RequestEditorFn) (*RequestPullChangesResponse, error) {
+	rsp, err := c.RequestPullChanges(ctx, provider, owner, name, number, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRequestPullChangesResponse(rsp)
 }
 
 // DiscardPrReviewDraftWithResponse request returning *DiscardPrReviewDraftResponse
@@ -40243,6 +40556,39 @@ func ParseMarkPullReadyForReviewOnHostResponse(rsp *http.Response) (*MarkPullRea
 	return response, nil
 }
 
+// ParseRequestPullChangesOnHostResponse parses an HTTP response from a RequestPullChangesOnHostWithResponse call
+func ParseRequestPullChangesOnHostResponse(rsp *http.Response) (*RequestPullChangesOnHostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RequestPullChangesOnHostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ActionStatusBody
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseDiscardPrReviewDraftOnHostResponse parses an HTTP response from a DiscardPrReviewDraftOnHostWithResponse call
 func ParseDiscardPrReviewDraftOnHostResponse(rsp *http.Response) (*DiscardPrReviewDraftOnHostResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -43499,6 +43845,39 @@ func ParseMarkPullReadyForReviewResponse(rsp *http.Response) (*MarkPullReadyForR
 	}
 
 	response := &MarkPullReadyForReviewResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ActionStatusBody
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseRequestPullChangesResponse parses an HTTP response from a RequestPullChangesWithResponse call
+func ParseRequestPullChangesResponse(rsp *http.Response) (*RequestPullChangesResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RequestPullChangesResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}

--- a/internal/gitclone/commits_test.go
+++ b/internal/gitclone/commits_test.go
@@ -14,6 +14,7 @@ import (
 func commitTestRun(t *testing.T, dir string, name string, args ...string) {
 	t.Helper()
 	require.Equal(t, "git", name)
+	args = append([]string{"-c", "gc.auto=0", "-c", "maintenance.auto=false"}, args...)
 	out, stderr, err := gitcmd.New().Run(t.Context(), dir, nil, args...)
 	require.NoError(t, err, "command %s %v failed: %s%s", name, args, out, stderr)
 }

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -1621,6 +1621,76 @@ func (p *gitHubClientProvider) ApproveMergeRequest(
 	return platformgithub.NormalizeReviewEvent(ref, number, review), nil
 }
 
+func (p *gitHubClientProvider) RequestChanges(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+	body string,
+	expectedHeadSHA string,
+) error {
+	if err := p.requireReviewHead(ctx, ref, number, expectedHeadSHA); err != nil {
+		return err
+	}
+	review, err := p.client.CreateReviewWithComments(
+		ctx, ref.Owner, ref.Name, number, "REQUEST_CHANGES", body, expectedHeadSHA, nil,
+	)
+	if err != nil {
+		return err
+	}
+	if review == nil {
+		return fmt.Errorf("provider returned no review")
+	}
+	if err := p.requireReviewHead(ctx, ref, number, expectedHeadSHA); err == nil {
+		return nil
+	}
+	reviewID := review.GetID()
+	_, dismissErr := p.client.DismissReview(
+		ctx, ref.Owner, ref.Name, number, reviewID,
+		"The pull request head changed while this review was submitted.",
+	)
+	if dismissErr != nil {
+		return &platform.Error{
+			Code:         platform.ErrCodeStaleState,
+			Provider:     platform.KindGitHub,
+			PlatformHost: p.host,
+			Capability:   "review_action_request_changes",
+			Hint:         fmt.Sprintf("request-changes review %d could not be removed after the head moved", reviewID),
+			Details:      map[string]string{"revocation": "failed", "review_id": strconv.FormatInt(reviewID, 10)},
+			Err:          dismissErr,
+		}
+	}
+	return &platform.Error{
+		Code:         platform.ErrCodeStaleState,
+		Provider:     platform.KindGitHub,
+		PlatformHost: p.host,
+		Capability:   "review_action_request_changes",
+		Hint:         fmt.Sprintf("request-changes review %d was removed after the head moved", reviewID),
+		Details:      map[string]string{"revocation": "succeeded", "review_id": strconv.FormatInt(reviewID, 10)},
+	}
+}
+
+func (p *gitHubClientProvider) requireReviewHead(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+	expectedHeadSHA string,
+) error {
+	if expectedHeadSHA == "" {
+		return nil
+	}
+	pr, err := p.client.GetPullRequest(ctx, ref.Owner, ref.Name, number)
+	if err != nil {
+		return err
+	}
+	if pr == nil || pr.GetHead().GetSHA() != expectedHeadSHA {
+		return &platform.Error{
+			Code: platform.ErrCodeStaleState, Provider: platform.KindGitHub,
+			PlatformHost: p.host, Capability: "review_action_request_changes",
+		}
+	}
+	return nil
+}
+
 func (p *gitHubClientProvider) ListMergeRequestReviewThreads(
 	ctx context.Context,
 	ref platform.RepoRef,
@@ -2292,6 +2362,13 @@ func (s *Syncer) ReviewMutator(
 	host string,
 ) (platform.ReviewMutator, error) {
 	return s.clients.ReviewMutator(kind, canonicalRepoHost(host))
+}
+
+func (s *Syncer) RequestChangesMutator(
+	kind platform.Kind,
+	host string,
+) (platform.RequestChangesMutator, error) {
+	return s.clients.RequestChangesMutator(kind, canonicalRepoHost(host))
 }
 
 func (s *Syncer) AssigneeMutator(

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -1621,6 +1621,12 @@ func (p *gitHubClientProvider) ApproveMergeRequest(
 	return platformgithub.NormalizeReviewEvent(ref, number, review), nil
 }
 
+// RequestChanges submits a blocking review with exactly the head-binding
+// contract of ApproveMergeRequest: the pin is forwarded as the review
+// commit and GitHub attaches the review to it. No client-side head
+// verification or post-submit revocation is layered on top — a change
+// request from the review form must not carry a stronger submission
+// contract than an approval from the same form.
 func (p *gitHubClientProvider) RequestChanges(
 	ctx context.Context,
 	ref platform.RepoRef,
@@ -1628,9 +1634,6 @@ func (p *gitHubClientProvider) RequestChanges(
 	body string,
 	expectedHeadSHA string,
 ) error {
-	if err := p.requireReviewHead(ctx, ref, number, expectedHeadSHA); err != nil {
-		return err
-	}
 	review, err := p.client.CreateReviewWithComments(
 		ctx, ref.Owner, ref.Name, number, "REQUEST_CHANGES", body, expectedHeadSHA, nil,
 	)
@@ -1639,54 +1642,6 @@ func (p *gitHubClientProvider) RequestChanges(
 	}
 	if review == nil {
 		return fmt.Errorf("provider returned no review")
-	}
-	if err := p.requireReviewHead(ctx, ref, number, expectedHeadSHA); err == nil {
-		return nil
-	}
-	reviewID := review.GetID()
-	_, dismissErr := p.client.DismissReview(
-		ctx, ref.Owner, ref.Name, number, reviewID,
-		"The pull request head changed while this review was submitted.",
-	)
-	if dismissErr != nil {
-		return &platform.Error{
-			Code:         platform.ErrCodeStaleState,
-			Provider:     platform.KindGitHub,
-			PlatformHost: p.host,
-			Capability:   "review_action_request_changes",
-			Hint:         fmt.Sprintf("request-changes review %d could not be removed after the head moved", reviewID),
-			Details:      map[string]string{"revocation": "failed", "review_id": strconv.FormatInt(reviewID, 10)},
-			Err:          dismissErr,
-		}
-	}
-	return &platform.Error{
-		Code:         platform.ErrCodeStaleState,
-		Provider:     platform.KindGitHub,
-		PlatformHost: p.host,
-		Capability:   "review_action_request_changes",
-		Hint:         fmt.Sprintf("request-changes review %d was removed after the head moved", reviewID),
-		Details:      map[string]string{"revocation": "succeeded", "review_id": strconv.FormatInt(reviewID, 10)},
-	}
-}
-
-func (p *gitHubClientProvider) requireReviewHead(
-	ctx context.Context,
-	ref platform.RepoRef,
-	number int,
-	expectedHeadSHA string,
-) error {
-	if expectedHeadSHA == "" {
-		return nil
-	}
-	pr, err := p.client.GetPullRequest(ctx, ref.Owner, ref.Name, number)
-	if err != nil {
-		return err
-	}
-	if pr == nil || pr.GetHead().GetSHA() != expectedHeadSHA {
-		return &platform.Error{
-			Code: platform.ErrCodeStaleState, Provider: platform.KindGitHub,
-			PlatformHost: p.host, Capability: "review_action_request_changes",
-		}
 	}
 	return nil
 }

--- a/internal/platform/client.go
+++ b/internal/platform/client.go
@@ -176,9 +176,13 @@ type ReviewMutator interface {
 }
 
 type RequestChangesMutator interface {
-	// RequestChanges submits a blocking review against expectedHeadSHA.
-	// Implementations must reject a stale target and revoke a review if the
-	// head moves while the provider request is in flight.
+	// RequestChanges submits a blocking review pinned to expectedHeadSHA
+	// with the same head-binding semantics as
+	// ReviewMutator.ApproveMergeRequest: the pin is forwarded to the
+	// provider, which attaches the review to that commit or rejects a
+	// stale head where it can natively. Implementations must not layer
+	// extra client-side head verification or post-submit revocation on
+	// top — request changes and approve share one submission contract.
 	RequestChanges(
 		ctx context.Context,
 		ref RepoRef,

--- a/internal/platform/client.go
+++ b/internal/platform/client.go
@@ -175,6 +175,19 @@ type ReviewMutator interface {
 	) (MergeRequestEvent, error)
 }
 
+type RequestChangesMutator interface {
+	// RequestChanges submits a blocking review against expectedHeadSHA.
+	// Implementations must reject a stale target and revoke a review if the
+	// head moves while the provider request is in flight.
+	RequestChanges(
+		ctx context.Context,
+		ref RepoRef,
+		number int,
+		body string,
+		expectedHeadSHA string,
+	) error
+}
+
 type ThreadReplier interface {
 	ReplyToThread(
 		ctx context.Context,

--- a/internal/platform/forgejo/client.go
+++ b/internal/platform/forgejo/client.go
@@ -145,11 +145,6 @@ func (c *Client) Capabilities() platform.Capabilities {
 	caps.ReviewDraftMutation = true
 	caps.ReadReviewThreads = true
 	caps.NativeMultilineRanges = false
-	caps.SupportedReviewActions = []platform.ReviewAction{
-		platform.ReviewActionComment,
-		platform.ReviewActionApprove,
-		platform.ReviewActionRequestChanges,
-	}
 	return caps
 }
 

--- a/internal/platform/forgejo/diff_review.go
+++ b/internal/platform/forgejo/diff_review.go
@@ -10,6 +10,12 @@ import (
 	"go.kenn.io/middleman/internal/platform"
 )
 
+// RequestChanges submits a blocking review with exactly the head-binding
+// contract of ApproveMergeRequest: the pin is forwarded as the review
+// commit and Forgejo attaches the review to it. No client-side head
+// verification or post-submit revocation is layered on top — a change
+// request from the review form must not carry a stronger submission
+// contract than an approval from the same form.
 func (c *Client) RequestChanges(
 	ctx context.Context,
 	ref platform.RepoRef,
@@ -17,68 +23,10 @@ func (c *Client) RequestChanges(
 	body string,
 	expectedHeadSHA string,
 ) error {
-	if err := c.requireReviewHead(ctx, ref, number, expectedHeadSHA); err != nil {
-		return err
-	}
-	published, err := c.PublishDiffReviewDraft(ctx, ref, number, platform.PublishDiffReviewDraftInput{
+	_, err := c.PublishDiffReviewDraft(ctx, ref, number, platform.PublishDiffReviewDraftInput{
 		Body: body, Action: platform.ReviewActionRequestChanges, HeadSHA: expectedHeadSHA,
 	})
-	if err != nil {
-		return err
-	}
-	if err := c.requireReviewHead(ctx, ref, number, expectedHeadSHA); err == nil {
-		return nil
-	}
-	reviewID, parseErr := strconv.ParseInt(published.ProviderReviewID, 10, 64)
-	if parseErr != nil {
-		return fmt.Errorf("parse stale review id: %w", parseErr)
-	}
-	var resp *forgejosdk.Response
-	dismissErr := c.transport.withRequestContext(ctx, func() error {
-		var err error
-		resp, err = c.transport.api.DismissPullReview(
-			ref.Owner, ref.Name, int64(number), reviewID,
-			forgejosdk.DismissPullReviewOptions{Message: "The pull request head changed while this review was submitted."},
-		)
-		return err
-	})
-	if dismissErr != nil {
-		dismissErr = forgejoHTTPError(resp, dismissErr)
-		return &platform.Error{
-			Code: platform.ErrCodeStaleState, Provider: platform.KindForgejo,
-			PlatformHost: c.host, Capability: "review_action_request_changes",
-			Hint:    fmt.Sprintf("request-changes review %d could not be removed after the head moved", reviewID),
-			Details: map[string]string{"revocation": "failed", "review_id": strconv.FormatInt(reviewID, 10)}, Err: dismissErr,
-		}
-	}
-	return &platform.Error{
-		Code: platform.ErrCodeStaleState, Provider: platform.KindForgejo,
-		PlatformHost: c.host, Capability: "review_action_request_changes",
-		Hint:    fmt.Sprintf("request-changes review %d was removed after the head moved", reviewID),
-		Details: map[string]string{"revocation": "succeeded", "review_id": strconv.FormatInt(reviewID, 10)},
-	}
-}
-
-func (c *Client) requireReviewHead(
-	ctx context.Context,
-	ref platform.RepoRef,
-	number int,
-	expectedHeadSHA string,
-) error {
-	if expectedHeadSHA == "" {
-		return nil
-	}
-	mr, err := c.GetMergeRequest(ctx, ref, number)
-	if err != nil {
-		return err
-	}
-	if mr.HeadSHA != expectedHeadSHA {
-		return &platform.Error{
-			Code: platform.ErrCodeStaleState, Provider: platform.KindForgejo,
-			PlatformHost: c.host, Capability: "review_action_request_changes",
-		}
-	}
-	return nil
+	return err
 }
 
 func (c *Client) PublishDiffReviewDraft(

--- a/internal/platform/forgejo/diff_review.go
+++ b/internal/platform/forgejo/diff_review.go
@@ -10,12 +10,6 @@ import (
 	"go.kenn.io/middleman/internal/platform"
 )
 
-// RequestChanges submits a blocking review with exactly the head-binding
-// contract of ApproveMergeRequest: the pin is forwarded as the review
-// commit and Forgejo attaches the review to it. No client-side head
-// verification or post-submit revocation is layered on top — a change
-// request from the review form must not carry a stronger submission
-// contract than an approval from the same form.
 func (c *Client) RequestChanges(
 	ctx context.Context,
 	ref platform.RepoRef,
@@ -23,10 +17,7 @@ func (c *Client) RequestChanges(
 	body string,
 	expectedHeadSHA string,
 ) error {
-	_, err := c.PublishDiffReviewDraft(ctx, ref, number, platform.PublishDiffReviewDraftInput{
-		Body: body, Action: platform.ReviewActionRequestChanges, HeadSHA: expectedHeadSHA,
-	})
-	return err
+	return c.provider.RequestChanges(ctx, ref, number, body, expectedHeadSHA)
 }
 
 func (c *Client) PublishDiffReviewDraft(

--- a/internal/platform/forgejo/diff_review.go
+++ b/internal/platform/forgejo/diff_review.go
@@ -10,6 +10,77 @@ import (
 	"go.kenn.io/middleman/internal/platform"
 )
 
+func (c *Client) RequestChanges(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+	body string,
+	expectedHeadSHA string,
+) error {
+	if err := c.requireReviewHead(ctx, ref, number, expectedHeadSHA); err != nil {
+		return err
+	}
+	published, err := c.PublishDiffReviewDraft(ctx, ref, number, platform.PublishDiffReviewDraftInput{
+		Body: body, Action: platform.ReviewActionRequestChanges, HeadSHA: expectedHeadSHA,
+	})
+	if err != nil {
+		return err
+	}
+	if err := c.requireReviewHead(ctx, ref, number, expectedHeadSHA); err == nil {
+		return nil
+	}
+	reviewID, parseErr := strconv.ParseInt(published.ProviderReviewID, 10, 64)
+	if parseErr != nil {
+		return fmt.Errorf("parse stale review id: %w", parseErr)
+	}
+	var resp *forgejosdk.Response
+	dismissErr := c.transport.withRequestContext(ctx, func() error {
+		var err error
+		resp, err = c.transport.api.DismissPullReview(
+			ref.Owner, ref.Name, int64(number), reviewID,
+			forgejosdk.DismissPullReviewOptions{Message: "The pull request head changed while this review was submitted."},
+		)
+		return err
+	})
+	if dismissErr != nil {
+		dismissErr = forgejoHTTPError(resp, dismissErr)
+		return &platform.Error{
+			Code: platform.ErrCodeStaleState, Provider: platform.KindForgejo,
+			PlatformHost: c.host, Capability: "review_action_request_changes",
+			Hint:    fmt.Sprintf("request-changes review %d could not be removed after the head moved", reviewID),
+			Details: map[string]string{"revocation": "failed", "review_id": strconv.FormatInt(reviewID, 10)}, Err: dismissErr,
+		}
+	}
+	return &platform.Error{
+		Code: platform.ErrCodeStaleState, Provider: platform.KindForgejo,
+		PlatformHost: c.host, Capability: "review_action_request_changes",
+		Hint:    fmt.Sprintf("request-changes review %d was removed after the head moved", reviewID),
+		Details: map[string]string{"revocation": "succeeded", "review_id": strconv.FormatInt(reviewID, 10)},
+	}
+}
+
+func (c *Client) requireReviewHead(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+	expectedHeadSHA string,
+) error {
+	if expectedHeadSHA == "" {
+		return nil
+	}
+	mr, err := c.GetMergeRequest(ctx, ref, number)
+	if err != nil {
+		return err
+	}
+	if mr.HeadSHA != expectedHeadSHA {
+		return &platform.Error{
+			Code: platform.ErrCodeStaleState, Provider: platform.KindForgejo,
+			PlatformHost: c.host, Capability: "review_action_request_changes",
+		}
+	}
+	return nil
+}
+
 func (c *Client) PublishDiffReviewDraft(
 	ctx context.Context,
 	ref platform.RepoRef,

--- a/internal/platform/forgejo/diff_review_test.go
+++ b/internal/platform/forgejo/diff_review_test.go
@@ -126,6 +126,24 @@ func TestPublishDiffReviewDraftApproveSubmitsReview(t *testing.T) {
 	assert.Equal(submitted, result.SubmittedAt)
 }
 
+func TestRequestChangesMapsNotFoundResponse(t *testing.T) {
+	require := Require.New(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client, err := NewClient("codeberg.test", testTokenSource("token"), WithBaseURLForTesting(server.URL))
+	require.NoError(err)
+	err = client.RequestChanges(
+		context.Background(), platform.RepoRef{Owner: "acme", Name: "widgets"},
+		42, "needs work", "reviewed-head",
+	)
+
+	require.Error(err)
+	require.ErrorIs(err, platform.ErrNotFound)
+}
+
 func TestListMergeRequestReviewThreadsReadsForgejoReviewComments(t *testing.T) {
 	assert := assert.New(t)
 	require := Require.New(t)

--- a/internal/platform/gitea/client_test.go
+++ b/internal/platform/gitea/client_test.go
@@ -261,6 +261,11 @@ func TestClientProviderIdentityExposesReadCapabilities(t *testing.T) {
 		AssigneeMutation:    true,
 		ReviewerMutation:    true,
 		MutationHeadBinding: true,
+		SupportedReviewActions: []platform.ReviewAction{
+			platform.ReviewActionComment,
+			platform.ReviewActionApprove,
+			platform.ReviewActionRequestChanges,
+		},
 	}, client.Capabilities())
 }
 
@@ -555,6 +560,40 @@ func TestClientApproveMergeRequestSubmitsReview(t *testing.T) {
 	assert.True(sawRequest)
 	assert.Equal("review", event.EventType)
 	assert.Equal("APPROVED", event.Summary)
+}
+
+func TestClientRequestChangesSubmitsReview(t *testing.T) {
+	assert := assert.New(t)
+	require := Require.New(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(http.MethodPost, r.Method)
+		assert.Equal("/api/v1/repos/owner/repo/pulls/7/reviews", r.URL.Path)
+		var body struct {
+			Event    string `json:"event"`
+			Body     string `json:"body"`
+			CommitID string `json:"commit_id"`
+		}
+		if !assert.NoError(json.NewDecoder(r.Body).Decode(&body)) {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		assert.Equal("REQUEST_CHANGES", body.Event)
+		assert.Equal("needs work", body.Body)
+		assert.Equal("reviewed-head", body.CommitID)
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(json.NewEncoder(w).Encode(map[string]any{
+			"id": 41, "state": "REQUEST_CHANGES", "body": "needs work",
+			"user": map[string]any{"login": "dana"}, "submitted_at": "2026-05-01T12:00:00Z",
+		}))
+	}))
+	defer server.Close()
+
+	client, err := NewClient("gitea.test", testTokenSource("gitea-token"), WithBaseURLForTesting(server.URL))
+	require.NoError(err)
+	require.NoError(client.RequestChanges(
+		context.Background(), platform.RepoRef{Owner: "owner", Name: "repo"},
+		7, "needs work", "reviewed-head",
+	))
 }
 
 func TestClientMapsNotFoundResponsesToPlatformError(t *testing.T) {

--- a/internal/platform/gitea/mutation.go
+++ b/internal/platform/gitea/mutation.go
@@ -95,6 +95,16 @@ func (c *Client) ApproveMergeRequest(
 	return c.provider.ApproveMergeRequest(ctx, ref, number, body, expectedHeadSHA)
 }
 
+func (c *Client) RequestChanges(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+	body string,
+	expectedHeadSHA string,
+) error {
+	return c.provider.RequestChanges(ctx, ref, number, body, expectedHeadSHA)
+}
+
 func (t *transport) CreatePullReview(
 	ctx context.Context,
 	ref platform.RepoRef,

--- a/internal/platform/gitealike/provider.go
+++ b/internal/platform/gitealike/provider.go
@@ -84,6 +84,11 @@ func (p *Provider) Capabilities() platform.Capabilities {
 		caps.AssigneeMutation = true
 		if _, ok := p.transport.(ReviewMutationTransport); ok {
 			caps.ReviewMutation = true
+			caps.SupportedReviewActions = []platform.ReviewAction{
+				platform.ReviewActionComment,
+				platform.ReviewActionApprove,
+				platform.ReviewActionRequestChanges,
+			}
 		}
 		if _, ok := p.transport.(ReviewRequestTransport); ok {
 			caps.ReviewerMutation = true
@@ -589,6 +594,28 @@ func (p *Provider) ApproveMergeRequest(
 		return platform.MergeRequestEvent{}, fmt.Errorf("provider returned no review event")
 	}
 	return events[0], nil
+}
+
+func (p *Provider) RequestChanges(
+	ctx context.Context,
+	ref platform.RepoRef,
+	number int,
+	body string,
+	expectedHeadSHA string,
+) error {
+	transport, ok := p.transport.(ReviewMutationTransport)
+	if !ok || !p.options.Mutations {
+		return platform.UnsupportedCapability(p.kind, p.host, "review_action_request_changes")
+	}
+	_, err := transport.CreatePullReview(ctx, ref, number, ReviewOptions{
+		State:    "REQUEST_CHANGES",
+		Body:     body,
+		CommitID: expectedHeadSHA,
+	})
+	if err != nil {
+		return p.mapError(err)
+	}
+	return nil
 }
 
 func (p *Provider) EditMergeRequestContent(

--- a/internal/platform/gitealike/provider_test.go
+++ b/internal/platform/gitealike/provider_test.go
@@ -46,12 +46,17 @@ func TestProviderCapabilitiesEnableProvenMutations(t *testing.T) {
 		IssueMutation:       true,
 		AssigneeMutation:    true,
 		MutationHeadBinding: true,
+		SupportedReviewActions: []platform.ReviewAction{
+			platform.ReviewActionComment,
+			platform.ReviewActionApprove,
+			platform.ReviewActionRequestChanges,
+		},
 		// ReviewerMutation stays false: fakeTransport does not
 		// implement ReviewRequestTransport.
 	}, provider.Capabilities())
 }
 
-func TestProviderCapabilitiesDoNotAdvertiseInlineReviewSupportByDefault(t *testing.T) {
+func TestProviderCapabilitiesDoNotAdvertiseInlineReviewDraftSupportByDefault(t *testing.T) {
 	assert := assert.New(t)
 	provider := NewProvider(
 		platform.KindForgejo,
@@ -67,7 +72,6 @@ func TestProviderCapabilitiesDoNotAdvertiseInlineReviewSupportByDefault(t *testi
 	assert.False(caps.ReviewThreadResolution)
 	assert.False(caps.ReadReviewThreads)
 	assert.False(caps.NativeMultilineRanges)
-	assert.Empty(caps.SupportedReviewActions)
 }
 
 func TestProviderMutationsNormalizeTransportResponses(t *testing.T) {
@@ -366,6 +370,7 @@ type fakeTransport struct {
 	issue       IssueDTO
 	merge       MergeResultDTO
 	review      ReviewDTO
+	reviewErr   error
 
 	userRepoPages []int
 	orgRepoPages  []int
@@ -518,7 +523,7 @@ func (t *fakeTransport) MergePullRequest(_ context.Context, _ platform.RepoRef, 
 
 func (t *fakeTransport) CreatePullReview(_ context.Context, _ platform.RepoRef, _ int, opts ReviewOptions) (ReviewDTO, error) {
 	t.mutationCalls = append(t.mutationCalls, "review:"+opts.State+":"+opts.CommitID)
-	return t.review, nil
+	return t.review, t.reviewErr
 }
 
 func pageFor[T any](pages [][]T, page int) ([]T, Page, error) {
@@ -585,4 +590,21 @@ func TestProviderApproveSubmitsReview(t *testing.T) {
 	assert.Equal("review", event.EventType)
 	assert.Equal("APPROVED", event.Summary)
 	assert.Equal("review:APPROVED:reviewed-head", transport.mutationCalls[len(transport.mutationCalls)-1])
+}
+
+func TestProviderRequestChangesSubmitsReviewAndMapsErrors(t *testing.T) {
+	require := Require.New(t)
+	assert := assert.New(t)
+	ref := platform.RepoRef{Owner: "acme", Name: "widget"}
+	transport := &fakeTransport{}
+	provider := NewProvider(platform.KindGitea, "gitea.example.com", transport, WithMutations())
+
+	err := provider.RequestChanges(context.Background(), ref, 7, "needs work", "reviewed-head")
+	require.NoError(err)
+	assert.Equal("review:REQUEST_CHANGES:reviewed-head", transport.mutationCalls[len(transport.mutationCalls)-1])
+
+	transport.reviewErr = &HTTPError{StatusCode: 403, Message: "forbidden"}
+	err = provider.RequestChanges(context.Background(), ref, 7, "needs work", "reviewed-head")
+	require.Error(err)
+	assert.ErrorIs(err, platform.ErrPermissionDenied)
 }

--- a/internal/platform/registry.go
+++ b/internal/platform/registry.go
@@ -336,6 +336,18 @@ func (r *Registry) ReviewMutator(kind Kind, host string) (ReviewMutator, error) 
 	return mutator, nil
 }
 
+func (r *Registry) RequestChangesMutator(kind Kind, host string) (RequestChangesMutator, error) {
+	provider, err := r.Provider(kind, host)
+	if err != nil {
+		return nil, err
+	}
+	mutator, ok := provider.(RequestChangesMutator)
+	if !ok {
+		return nil, UnsupportedCapability(kind, host, "review_action_request_changes")
+	}
+	return mutator, nil
+}
+
 func (r *Registry) DiffReviewDraftMutator(
 	kind Kind,
 	host string,

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -14041,6 +14041,68 @@ func TestAPIGitHubPublishReviewDraftSendsCommentsThroughServer(t *testing.T) {
 	assert.Nil(storedDraft)
 }
 
+func TestAPIGitHubRequestChangesDoesNotPublishSavedDraftComments(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	var captured platform.PublishDiffReviewDraftInput
+	mock := &mockGH{
+		createReviewWithCommentsFn: func(
+			_ context.Context,
+			_, _ string,
+			_ int,
+			event string,
+			body string,
+			commitID string,
+			comments []*gh.DraftReviewComment,
+		) (*gh.PullRequestReview, error) {
+			captured = platform.PublishDiffReviewDraftInput{
+				Body:    body,
+				Action:  platform.ReviewActionRequestChanges,
+				HeadSHA: commitID,
+			}
+			assert.Equal("REQUEST_CHANGES", event)
+			assert.Empty(comments)
+			id := int64(502)
+			state := "CHANGES_REQUESTED"
+			return &gh.PullRequestReview{ID: &id, State: &state}, nil
+		},
+	}
+	srv, database := setupTestServerWithMock(t, mock)
+	seedPR(t, database, "acme", "widget", 42)
+	mr, err := database.GetMergeRequest(ctx, "github", "github.com", "acme", "widget", 42)
+	require.NoError(err)
+	require.NotNil(mr)
+	require.NoError(database.UpdateDiffSHAs(ctx, mr.RepoID, 42, "reviewed-head", "base", "merge-base"))
+
+	basePath := "/api/v1/pulls/gh/acme/widget/42/review-draft"
+	createRR := doJSON(t, srv, http.MethodPost, basePath+"/comments", map[string]any{
+		"body": "Saved for the later inline review.",
+		"range": map[string]any{
+			"path": "src/main.go", "side": "right", "line": 42,
+			"new_line": 42, "line_type": "add", "diff_head_sha": "reviewed-head",
+		},
+	})
+	require.Equal(http.StatusCreated, createRR.Code, createRR.Body.String())
+
+	requestRR := doJSON(t, srv, http.MethodPost, "/api/v1/pulls/gh/acme/widget/42/request-changes", map[string]string{
+		"body":              " Please cover the empty state. ",
+		"expected_head_sha": "provider-head",
+	})
+	require.Equal(http.StatusOK, requestRR.Code, requestRR.Body.String())
+	assert.Equal("Please cover the empty state.", captured.Body)
+	assert.Equal(platform.ReviewActionRequestChanges, captured.Action)
+	assert.Equal("provider-head", captured.HeadSHA)
+
+	storedDraft, err := database.GetMRReviewDraft(ctx, mr.ID)
+	require.NoError(err)
+	require.NotNil(storedDraft)
+	comments, err := database.ListMRReviewDraftComments(ctx, storedDraft.ID)
+	require.NoError(err)
+	require.Len(comments, 1)
+	assert.Equal("Saved for the later inline review.", comments[0].Body)
+}
+
 func TestAPIGitHubPublishReviewDraftRejectsSelfApprovalBeforeProvider(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -14047,6 +14047,10 @@ func TestAPIGitHubRequestChangesDoesNotPublishSavedDraftComments(t *testing.T) {
 	ctx := t.Context()
 	var captured platform.PublishDiffReviewDraftInput
 	mock := &mockGH{
+		getPullRequestFn: func(context.Context, string, string, int) (*gh.PullRequest, error) {
+			head := "provider-head"
+			return &gh.PullRequest{Head: &gh.PullRequestBranch{SHA: &head}}, nil
+		},
 		createReviewWithCommentsFn: func(
 			_ context.Context,
 			_, _ string,
@@ -14101,6 +14105,52 @@ func TestAPIGitHubRequestChangesDoesNotPublishSavedDraftComments(t *testing.T) {
 	require.NoError(err)
 	require.Len(comments, 1)
 	assert.Equal("Saved for the later inline review.", comments[0].Body)
+}
+
+func TestAPIGitHubRequestChangesRevokesReviewWhenHeadMovesDuringSubmit(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	var headReads int
+	var dismissedReviewID int64
+	mock := &mockGH{
+		getPullRequestFn: func(context.Context, string, string, int) (*gh.PullRequest, error) {
+			headReads++
+			head := "provider-head"
+			if headReads > 1 {
+				head = "moved-head"
+			}
+			return &gh.PullRequest{Head: &gh.PullRequestBranch{SHA: &head}}, nil
+		},
+		createReviewWithCommentsFn: func(
+			context.Context, string, string, int, string, string, string, []*gh.DraftReviewComment,
+		) (*gh.PullRequestReview, error) {
+			id := int64(503)
+			return &gh.PullRequestReview{ID: &id}, nil
+		},
+		dismissReviewFn: func(
+			_ context.Context, _, _ string, _ int, reviewID int64, _ string,
+		) (*gh.PullRequestReview, error) {
+			dismissedReviewID = reviewID
+			return &gh.PullRequestReview{ID: &reviewID}, nil
+		},
+	}
+	srv, database := setupTestServerWithMock(t, mock)
+	seedPR(t, database, "acme", "widget", 42)
+	mr, err := database.GetMergeRequest(ctx, "github", "github.com", "acme", "widget", 42)
+	require.NoError(err)
+	require.NotNil(mr)
+
+	rr := doJSON(t, srv, http.MethodPost, "/api/v1/pulls/gh/acme/widget/42/request-changes", map[string]string{
+		"body": "Please cover the empty state.", "expected_head_sha": "provider-head",
+	})
+	require.Equal(http.StatusConflict, rr.Code, rr.Body.String())
+	var problem rawProblemDetail
+	require.NoError(json.NewDecoder(rr.Body).Decode(&problem))
+	assert.Equal("stale_state", problem.Details["reason"])
+	assert.Equal("succeeded", problem.Details["revocation"])
+	assert.Equal("503", problem.Details["review_id"])
+	assert.EqualValues(503, dismissedReviewID)
 }
 
 func TestAPIGitHubPublishReviewDraftRejectsSelfApprovalBeforeProvider(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -13441,6 +13441,13 @@ func TestAPICapabilityGatedMutationsHandleMissingSyncer(t *testing.T) {
 			capability: "review_mutation",
 		},
 		{
+			name:       "request changes",
+			method:     http.MethodPost,
+			path:       "/api/v1/pulls/gh/acme/widget/7/request-changes",
+			body:       map[string]string{"body": "needs work"},
+			capability: "review_mutation",
+		},
+		{
 			name:       "workflow approval",
 			method:     http.MethodPost,
 			path:       "/api/v1/pulls/gh/acme/widget/7/approve-workflows",
@@ -17831,6 +17838,29 @@ func TestAPIGitealikeApproveBeforeHeadRace(t *testing.T) {
 	assert.Contains(transport.mutationCalls, "review:7:approved:abc123")
 }
 
+func TestAPIGitealikeRequestChangesPassesReviewedHeadPinToProvider(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	transport := newAPIGitealikeHeadPinTransport(t)
+	client, _ := setupAPIGitealikeHeadPinServer(t, transport)
+	expectedHeadSHA := "abc123"
+
+	resp, err := client.HTTP.RequestPullChangesOnHostWithResponse(
+		ctx, "gitea.test", "gitea", "tea", "kettle", 7,
+		generated.RequestPullChangesOnHostJSONRequestBody{
+			Body:            "needs work",
+			ExpectedHeadSha: &expectedHeadSHA,
+		},
+	)
+
+	require.NoError(err)
+	require.Equal(http.StatusOK, resp.StatusCode(), string(resp.Body))
+	assert.Equal("REQUEST_CHANGES", transport.lastReviewOpts.State)
+	assert.Equal("needs work", transport.lastReviewOpts.Body)
+	assert.Equal("abc123", transport.lastReviewOpts.CommitID)
+}
+
 type apiTestGitealikeTransport struct {
 	repo           gitealike.RepositoryDTO
 	pulls          []gitealike.PullRequestDTO
@@ -17845,6 +17875,7 @@ type apiTestGitealikeTransport struct {
 	nextIssueIndex int
 	mutationCalls  []string
 	mergeHeadPins  []string
+	lastReviewOpts gitealike.ReviewOptions
 
 	lastMergeOpts gitealike.MergeOptions
 	// headOverrides, when non-empty, replaces the head SHA returned by
@@ -18169,6 +18200,7 @@ func (t *apiTestGitealikeTransport) CreatePullReview(
 		return gitealike.ReviewDTO{}, platform.ErrNotFound
 	}
 	t.mutationCalls = append(t.mutationCalls, fmt.Sprintf("review:%d:%s:%s", number, opts.Body, opts.CommitID))
+	t.lastReviewOpts = opts
 	return gitealike.ReviewDTO{
 		ID:        980,
 		User:      gitealike.UserDTO{UserName: "mutation-bot"},

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -14046,11 +14046,10 @@ func TestAPIGitHubRequestChangesDoesNotPublishSavedDraftComments(t *testing.T) {
 	assert := assert.New(t)
 	ctx := t.Context()
 	var captured platform.PublishDiffReviewDraftInput
+	// No getPullRequestFn: the default mock returns no PR, so this test
+	// also proves direct request-changes performs no provider head reads
+	// beyond the review submission — the same call shape as /approve.
 	mock := &mockGH{
-		getPullRequestFn: func(context.Context, string, string, int) (*gh.PullRequest, error) {
-			head := "provider-head"
-			return &gh.PullRequest{Head: &gh.PullRequestBranch{SHA: &head}}, nil
-		},
 		createReviewWithCommentsFn: func(
 			_ context.Context,
 			_, _ string,
@@ -14105,52 +14104,6 @@ func TestAPIGitHubRequestChangesDoesNotPublishSavedDraftComments(t *testing.T) {
 	require.NoError(err)
 	require.Len(comments, 1)
 	assert.Equal("Saved for the later inline review.", comments[0].Body)
-}
-
-func TestAPIGitHubRequestChangesRevokesReviewWhenHeadMovesDuringSubmit(t *testing.T) {
-	require := require.New(t)
-	assert := assert.New(t)
-	ctx := t.Context()
-	var headReads int
-	var dismissedReviewID int64
-	mock := &mockGH{
-		getPullRequestFn: func(context.Context, string, string, int) (*gh.PullRequest, error) {
-			headReads++
-			head := "provider-head"
-			if headReads > 1 {
-				head = "moved-head"
-			}
-			return &gh.PullRequest{Head: &gh.PullRequestBranch{SHA: &head}}, nil
-		},
-		createReviewWithCommentsFn: func(
-			context.Context, string, string, int, string, string, string, []*gh.DraftReviewComment,
-		) (*gh.PullRequestReview, error) {
-			id := int64(503)
-			return &gh.PullRequestReview{ID: &id}, nil
-		},
-		dismissReviewFn: func(
-			_ context.Context, _, _ string, _ int, reviewID int64, _ string,
-		) (*gh.PullRequestReview, error) {
-			dismissedReviewID = reviewID
-			return &gh.PullRequestReview{ID: &reviewID}, nil
-		},
-	}
-	srv, database := setupTestServerWithMock(t, mock)
-	seedPR(t, database, "acme", "widget", 42)
-	mr, err := database.GetMergeRequest(ctx, "github", "github.com", "acme", "widget", 42)
-	require.NoError(err)
-	require.NotNil(mr)
-
-	rr := doJSON(t, srv, http.MethodPost, "/api/v1/pulls/gh/acme/widget/42/request-changes", map[string]string{
-		"body": "Please cover the empty state.", "expected_head_sha": "provider-head",
-	})
-	require.Equal(http.StatusConflict, rr.Code, rr.Body.String())
-	var problem rawProblemDetail
-	require.NoError(json.NewDecoder(rr.Body).Decode(&problem))
-	assert.Equal("stale_state", problem.Details["reason"])
-	assert.Equal("succeeded", problem.Details["revocation"])
-	assert.Equal("503", problem.Details["review_id"])
-	assert.EqualValues(503, dismissedReviewID)
 }
 
 func TestAPIGitHubPublishReviewDraftRejectsSelfApprovalBeforeProvider(t *testing.T) {

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -2969,7 +2969,7 @@ func (s *Server) requestChangesPR(ctx context.Context, input *requestChangesPRIn
 	repo, err := s.requireRepoRouteCapability(
 		ctx,
 		input.Provider, input.PlatformHost, input.Owner, input.Name,
-		capabilityReviewDraftMutation,
+		capabilityReviewMutation,
 	)
 	if err != nil {
 		return nil, err
@@ -2990,18 +2990,20 @@ func (s *Server) requestChangesPR(ctx context.Context, input *requestChangesPRIn
 	if mr == nil {
 		return nil, problemNotFound(CodePullNotFound, "pull request not found", nil)
 	}
-	mutator, err := s.syncer.DiffReviewDraftMutator(
+	if s.mergeRequestAuthoredByViewer(ctx, *repo, *mr) {
+		return nil, problemForbidden(
+			"You cannot request changes on your own pull request",
+			map[string]any{"reason": availabilityCodeSelfApproval, "provider": string(repoProviderKind(*repo)), "platformHost": repoProviderHost(*repo)},
+		)
+	}
+	mutator, err := s.syncer.RequestChangesMutator(
 		repoProviderKind(*repo), repoProviderHost(*repo),
 	)
 	if err != nil {
-		return nil, unsupportedCapabilityProblem(*repo, capabilityReviewDraftMutation)
+		return nil, problemUnsupportedCapability(*repo, "review_action_request_changes")
 	}
 	expectedHeadSHA := approvalReviewHeadSHA(mr, input.Body.ExpectedHeadSHA)
-	_, err = mutator.PublishDiffReviewDraft(ctx, platformRepoRefFromDB(*repo), input.Number, platform.PublishDiffReviewDraftInput{
-		Body:    body,
-		Action:  platform.ReviewActionRequestChanges,
-		HeadSHA: expectedHeadSHA,
-	})
+	err = mutator.RequestChanges(ctx, platformRepoRefFromDB(*repo), input.Number, body, expectedHeadSHA)
 	if err != nil {
 		if errors.Is(err, platform.ErrStaleState) {
 			s.syncAfterStaleReviewDraftPublish(*repo, input.Number)

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -368,6 +368,18 @@ type approvePRInput struct {
 	}
 }
 
+type requestChangesPRInput struct {
+	Provider     string `path:"provider"`
+	PlatformHost string
+	Owner        string `path:"owner"`
+	Name         string `path:"name"`
+	Number       int    `path:"number"`
+	Body         struct {
+		Body            string `json:"body"`
+		ExpectedHeadSHA string `json:"expected_head_sha,omitempty"`
+	}
+}
+
 type actionStatusBody struct {
 	Status        string `json:"status"`
 	ApprovedCount int    `json:"approved_count,omitempty"`
@@ -1335,6 +1347,10 @@ func (s *Server) registerProviderRepoAPI(api huma.API) {
 		documentOperation("approve-pull", "Approve pull request", "Pull Requests"))
 	huma.Post(api, hostPullPath+"/approve", s.approvePROnHost,
 		documentOperation("approve-pull-on-host", "Approve pull request", "Pull Requests"))
+	huma.Post(api, pullPath+"/request-changes", s.requestChangesPR,
+		documentOperation("request-pull-changes", "Request pull request changes", "Pull Requests"))
+	huma.Post(api, hostPullPath+"/request-changes", s.requestChangesPROnHost,
+		documentOperation("request-pull-changes-on-host", "Request pull request changes", "Pull Requests"))
 	huma.Post(api, pullPath+"/approve-workflows", s.approveWorkflows,
 		documentOperation("approve-pull-workflows", "Approve pull request workflows", "Pull Requests"))
 	huma.Post(api, hostPullPath+"/approve-workflows", s.approveWorkflowsOnHost,
@@ -2947,6 +2963,64 @@ func (s *Server) approvePR(ctx context.Context, input *approvePRInput) (*actionS
 	}
 
 	return &actionStatusOutput{Body: actionStatusBody{Status: "approved"}}, nil
+}
+
+func (s *Server) requestChangesPR(ctx context.Context, input *requestChangesPRInput) (*actionStatusOutput, error) {
+	repo, err := s.requireRepoRouteCapability(
+		ctx,
+		input.Provider, input.PlatformHost, input.Owner, input.Name,
+		capabilityReviewDraftMutation,
+	)
+	if err != nil {
+		return nil, err
+	}
+	caps := s.capabilitiesForRepo(*repo)
+	if !reviewActionSupported(caps, platform.ReviewActionRequestChanges) {
+		return nil, problemUnsupportedCapability(*repo, "review_action_request_changes")
+	}
+	body := strings.TrimSpace(input.Body.Body)
+	if body == "" {
+		return nil, huma.Error400BadRequest("request changes review body is required")
+	}
+
+	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
+	if err != nil {
+		return nil, problemInternal("get pull request failed")
+	}
+	if mr == nil {
+		return nil, problemNotFound(CodePullNotFound, "pull request not found", nil)
+	}
+	mutator, err := s.syncer.DiffReviewDraftMutator(
+		repoProviderKind(*repo), repoProviderHost(*repo),
+	)
+	if err != nil {
+		return nil, unsupportedCapabilityProblem(*repo, capabilityReviewDraftMutation)
+	}
+	expectedHeadSHA := approvalReviewHeadSHA(mr, input.Body.ExpectedHeadSHA)
+	_, err = mutator.PublishDiffReviewDraft(ctx, platformRepoRefFromDB(*repo), input.Number, platform.PublishDiffReviewDraftInput{
+		Body:    body,
+		Action:  platform.ReviewActionRequestChanges,
+		HeadSHA: expectedHeadSHA,
+	})
+	if err != nil {
+		if errors.Is(err, platform.ErrStaleState) {
+			s.syncAfterStaleReviewDraftPublish(*repo, input.Number)
+		}
+		return nil, providerCallProblemWithDetail(
+			err,
+			string(repoProviderKind(*repo)), repoProviderHost(*repo),
+			"provider API error",
+		)
+	}
+
+	if syncErr := s.syncer.SyncMROnProvider(
+		ctx,
+		repoProviderKind(*repo), repoProviderHost(*repo),
+		repo.Owner, repo.Name, input.Number,
+	); syncErr != nil {
+		slog.Warn("sync after requesting changes", "err", syncErr)
+	}
+	return &actionStatusOutput{Body: actionStatusBody{Status: "changes_requested"}}, nil
 }
 
 // approvalReviewHeadSHA resolves the provider commit to attach a direct

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -2974,6 +2974,9 @@ func (s *Server) requestChangesPR(ctx context.Context, input *requestChangesPRIn
 	if err != nil {
 		return nil, err
 	}
+	if err := s.requireSyncerCapability(*repo, capabilityReviewMutation); err != nil {
+		return nil, err
+	}
 	caps := s.capabilitiesForRepo(*repo)
 	if !reviewActionSupported(caps, platform.ReviewActionRequestChanges) {
 		return nil, problemUnsupportedCapability(*repo, "review_action_request_changes")

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -3026,14 +3026,17 @@ func (s *Server) requestChangesPR(ctx context.Context, input *requestChangesPRIn
 }
 
 // approvalReviewHeadSHA resolves the provider commit to attach a direct
-// approval to. Direct /approve is a provider-head mutation: clients should
-// send the head captured when the approval UI opened, normally
-// platform_head_sha. Omitting the pin is a compatibility path for older
-// clients; in that case middleman binds the approval to the best stored
-// provider head rather than rejecting the request. Stale supplied pins are
-// delegated to provider head-binding where available and mapped through the
-// normal stale_state path. Merge and draft-review publish use reviewedHeadSHA
-// instead because those paths require a verified diff snapshot.
+// review to. Direct /approve and /request-changes are provider-head
+// mutations sharing this resolution on purpose: both come from the same
+// review form, and a change request must not be pinned more strictly (or
+// more loosely) than an approval. Clients should send the head captured
+// when the review UI opened, normally platform_head_sha. Omitting the pin
+// is a compatibility path for older clients; in that case middleman binds
+// the review to the best stored provider head rather than rejecting the
+// request. Stale supplied pins are delegated to provider head-binding where
+// available and mapped through the normal stale_state path. Merge and
+// draft-review publish use reviewedHeadSHA instead because those paths
+// require a verified diff snapshot.
 func approvalReviewHeadSHA(mr *db.MergeRequest, clientSHA string) string {
 	if sha := strings.TrimSpace(clientSHA); sha != "" {
 		return sha

--- a/internal/server/provider_route_wrappers.go
+++ b/internal/server/provider_route_wrappers.go
@@ -125,6 +125,18 @@ type publishDiffReviewDraftHostInput struct {
 	}
 }
 
+type requestChangesPRHostInput struct {
+	Provider     string `path:"provider"`
+	PlatformHost string `path:"platform_host"`
+	Owner        string `path:"owner"`
+	Name         string `path:"name"`
+	Number       int    `path:"number"`
+	Body         struct {
+		Body            string `json:"body"`
+		ExpectedHeadSHA string `json:"expected_head_sha,omitempty"`
+	}
+}
+
 type applyReviewSuggestionHostInput struct {
 	Provider     string `path:"provider"`
 	PlatformHost string `path:"platform_host"`
@@ -730,6 +742,21 @@ func (s *Server) approvePROnHost(ctx context.Context, input *approvePRHostInput)
 		Body:         input.Body,
 	}
 	return s.approvePR(ctx, &next)
+}
+
+func (s *Server) requestChangesPROnHost(
+	ctx context.Context,
+	input *requestChangesPRHostInput,
+) (*actionStatusOutput, error) {
+	next := requestChangesPRInput{
+		Provider:     input.Provider,
+		PlatformHost: input.PlatformHost,
+		Owner:        input.Owner,
+		Name:         input.Name,
+		Number:       input.Number,
+		Body:         input.Body,
+	}
+	return s.requestChangesPR(ctx, &next)
 }
 
 func (s *Server) approveWorkflowsOnHost(ctx context.Context, input *repoNumberHostInput) (*actionStatusOutput, error) {

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -1427,6 +1427,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/host/{platform_host}/pulls/{provider}/{owner}/{name}/{number}/request-changes": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Request pull request changes */
+        post: operations["request-pull-changes-on-host"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/host/{platform_host}/pulls/{provider}/{owner}/{name}/{number}/review-draft": {
         parameters: {
             query?: never;
@@ -3031,6 +3048,23 @@ export interface paths {
         put?: never;
         /** Mark pull request ready for review */
         post: operations["mark-pull-ready-for-review"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/pulls/{provider}/{owner}/{name}/{number}/request-changes": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Request pull request changes */
+        post: operations["request-pull-changes"];
         delete?: never;
         options?: never;
         head?: never;
@@ -6735,6 +6769,26 @@ export interface components {
              */
             readonly $schema?: string;
             worktree_base_path: string;
+        };
+        RequestChangesPRHostInputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example /api/v1/schemas/RequestChangesPRHostInputBody.json
+             */
+            readonly $schema?: string;
+            body: string;
+            expected_head_sha?: string;
+        };
+        RequestChangesPRInputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example /api/v1/schemas/RequestChangesPRInputBody.json
+             */
+            readonly $schema?: string;
+            body: string;
+            expected_head_sha?: string;
         };
         ResolveDiscussionHostInputBody: {
             /**
@@ -10489,6 +10543,45 @@ export interface operations {
             };
         };
     };
+    "request-pull-changes-on-host": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                provider: string;
+                platform_host: string;
+                owner: string;
+                name: string;
+                number: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RequestChangesPRHostInputBody"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ActionStatusBody"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
     "get-pr-review-draft-on-host": {
         parameters: {
             query?: never;
@@ -14128,6 +14221,44 @@ export interface operations {
             cookie?: never;
         };
         requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ActionStatusBody"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
+    "request-pull-changes": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                provider: string;
+                owner: string;
+                name: string;
+                number: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RequestChangesPRInputBody"];
+            };
+        };
         responses: {
             /** @description OK */
             200: {

--- a/packages/ui/src/api/provider-routes.ts
+++ b/packages/ui/src/api/provider-routes.ts
@@ -73,6 +73,7 @@ type PullSuffix =
   | "/merge"
   | "/merge/deferred"
   | "/ready-for-review"
+  | "/request-changes"
   | "/reviewers"
   | "/discussions/{discussion_id}/reply"
   | "/review-draft"

--- a/packages/ui/src/components/detail/ApproveButton.svelte
+++ b/packages/ui/src/components/detail/ApproveButton.svelte
@@ -6,7 +6,7 @@
   import { isProblem, problemConflictContext, problemConflictReason } from "../../api/problems.js";
   import { providerItemPath, providerRouteParams } from "../../api/provider-routes.js";
   import { showFlash } from "../../stores/flash.svelte.js";
-  import { runApprovePR, type PRDetailActionInput } from "./keyboard-actions.js";
+  import { submitApprovePR, type PRDetailActionInput } from "./keyboard-actions.js";
 
   const client = getClient();
   const { detail, pulls } = getStores();
@@ -127,10 +127,19 @@
     submittingAction = "approve";
     error = null;
     try {
-      await runApprovePR(buildInput());
+      const approved = await submitApprovePR(buildInput());
+      if (!approved) return;
       body = "";
       expanded = false;
       oncompleted?.();
+      try {
+        await Promise.all([
+          detail.loadDetail(owner, name, number, { provider, platformHost, repoPath }),
+          pulls.loadPulls(),
+        ]);
+      } catch {
+        showFlash("Pull request approved, but it could not be refreshed.");
+      }
     } catch (err) {
       if (expanded) {
         error = err instanceof Error ? err.message : String(err);
@@ -141,7 +150,7 @@
     }
   }
 
-  // Mirrors handleApprove/runApprovePR on purpose: the same pinAtOpen
+  // Mirrors handleApprove/submitApprovePR on purpose: the same pinAtOpen
   // captured when the form opened is submitted as expected_head_sha.
   // Request changes must not carry a stronger (or weaker) provider
   // submission contract than approve.

--- a/packages/ui/src/components/detail/ApproveButton.svelte
+++ b/packages/ui/src/components/detail/ApproveButton.svelte
@@ -5,6 +5,7 @@
   import { getClient, getStores } from "../../context.js";
   import { isProblem, problemConflictContext, problemConflictReason } from "../../api/problems.js";
   import { providerItemPath, providerRouteParams } from "../../api/provider-routes.js";
+  import { showFlash } from "../../stores/flash.svelte.js";
   import { runApprovePR, type PRDetailActionInput } from "./keyboard-actions.js";
 
   const client = getClient();
@@ -141,10 +142,9 @@
   }
 
   // Mirrors handleApprove/runApprovePR on purpose: the same pinAtOpen
-  // captured when the form opened is submitted as expected_head_sha, and
-  // a refresh failure after a successful POST surfaces in the form the
-  // same way an approve refresh failure does. Request changes must not
-  // carry a stronger (or weaker) submission contract than approve.
+  // captured when the form opened is submitted as expected_head_sha.
+  // Request changes must not carry a stronger (or weaker) provider
+  // submission contract than approve.
   async function handleRequestChanges(): Promise<void> {
     if (disabled || submitting || body.trim() === "") return;
     submitting = true;
@@ -170,11 +170,17 @@
         }
         throw new Error(requestError.detail ?? requestError.title ?? "failed to request changes");
       }
-      await detail.loadDetail(owner, name, number, { provider, platformHost, repoPath });
-      await pulls.loadPulls();
       body = "";
       expanded = false;
       oncompleted?.();
+      try {
+        await Promise.all([
+          detail.loadDetail(owner, name, number, { provider, platformHost, repoPath }),
+          pulls.loadPulls(),
+        ]);
+      } catch {
+        showFlash("Changes were requested, but the pull request could not be refreshed.");
+      }
     } catch (err) {
       if (expanded) {
         error = err instanceof Error ? err.message : String(err);

--- a/packages/ui/src/components/detail/ApproveButton.svelte
+++ b/packages/ui/src/components/detail/ApproveButton.svelte
@@ -3,7 +3,9 @@
   import CheckIcon from "@lucide/svelte/icons/check";
   import { tick } from "svelte";
   import { getClient, getStores } from "../../context.js";
-    import { runApprovePR, type PRDetailActionInput } from "./keyboard-actions.js";
+  import { isProblem, problemConflictContext, problemConflictReason } from "../../api/problems.js";
+  import { providerItemPath, providerRouteParams } from "../../api/provider-routes.js";
+  import { runApprovePR, type PRDetailActionInput } from "./keyboard-actions.js";
 
   const client = getClient();
   const { detail, pulls } = getStores();
@@ -23,6 +25,7 @@
     platformHeadSha?: string | undefined;
     /** capabilities.mutation_head_binding for this repo's provider. */
     requireHeadPin?: boolean;
+    supportedReviewActions?: string[];
     onheadconflict?: ((reason: "stale_state" | "head_unknown", context?: string) => void) | undefined;
     oncompleted?: (() => void) | undefined;
     /** Tooltip override; pass the unavailable_reason when disabling. */
@@ -41,6 +44,7 @@
     expectedHeadSha,
     platformHeadSha,
     requireHeadPin = false,
+    supportedReviewActions = [],
     onheadconflict,
     oncompleted,
     title = undefined,
@@ -54,8 +58,10 @@
   let expanded = $state(false);
   let body = $state("");
   let submitting = $state(false);
+  let submittingAction = $state<"approve" | "request_changes" | null>(null);
   let error = $state<string | null>(null);
   let commentInput = $state<HTMLTextAreaElement | undefined>();
+  const canRequestChanges = $derived(supportedReviewActions.includes("request_changes"));
 
   // Reset draft state on full provider-aware PR identity change so an
   // open form with PR A's body or head pin cannot submit to PR B once
@@ -115,6 +121,7 @@
   async function handleApprove(): Promise<void> {
     if (disabled || submitting) return;
     submitting = true;
+    submittingAction = "approve";
     error = null;
     try {
       await runApprovePR(buildInput());
@@ -127,6 +134,47 @@
       }
     } finally {
       submitting = false;
+      submittingAction = null;
+    }
+  }
+
+  async function handleRequestChanges(): Promise<void> {
+    if (disabled || submitting || body.trim() === "") return;
+    submitting = true;
+    submittingAction = "request_changes";
+    error = null;
+    try {
+      const { error: requestError } = await client.POST(providerItemPath("pulls", {
+        provider, platformHost, owner, name, repoPath,
+      }, "/request-changes"), {
+        params: { path: { ...providerRouteParams({ provider, platformHost, owner, name, repoPath }), number } },
+        body: {
+          body: body.trim(),
+          ...(pinAtOpen !== "" && { expected_head_sha: pinAtOpen }),
+        },
+      });
+      if (requestError) {
+        const reason = isProblem(requestError) ? problemConflictReason(requestError) : undefined;
+        if (reason === "stale_state" || reason === "head_unknown") {
+          handleHeadConflict(
+            reason,
+            isProblem(requestError) ? problemConflictContext(requestError) : undefined,
+          );
+        }
+        throw new Error(requestError.detail ?? requestError.title ?? "failed to request changes");
+      }
+      await detail.loadDetail(owner, name, number, { provider, platformHost, repoPath });
+      await pulls.loadPulls();
+      body = "";
+      expanded = false;
+      oncompleted?.();
+    } catch (err) {
+      if (expanded) {
+        error = err instanceof Error ? err.message : String(err);
+      }
+    } finally {
+      submitting = false;
+      submittingAction = null;
     }
   }
 </script>
@@ -154,7 +202,7 @@
   </Button>
 
   {#if expanded}
-    <div class="approve-popover kit-popover-card" role="dialog" aria-label="Approve pull request">
+    <div class="approve-popover kit-popover-card" role="dialog" aria-label="Submit pull request review">
       <textarea
         bind:this={commentInput}
         class="approve-comment"
@@ -175,6 +223,20 @@
         >
           Cancel
         </Button>
+        {#if canRequestChanges}
+          <Button
+            class="btn btn--request-changes"
+            onclick={() => void handleRequestChanges()}
+            disabled={submitting || disabled || body.trim() === ""}
+            tone="danger"
+            surface="solid"
+            title={body.trim() === ""
+              ? "Add a comment explaining the requested changes"
+              : "Submit a review requesting changes on this pull request"}
+          >
+            {submittingAction === "request_changes" ? "Submitting…" : "Request changes"}
+          </Button>
+        {/if}
         <Button
           class="btn btn--primary btn--green"
           onclick={() => void handleApprove()}
@@ -183,7 +245,7 @@
           surface="solid"
           title="Submit an approving code review on this pull request"
         >
-          {submitting ? "Approving\u2026" : "Approve"}
+          {submittingAction === "approve" ? "Approving\u2026" : "Approve"}
         </Button>
       </div>
     </div>

--- a/packages/ui/src/components/detail/ApproveButton.svelte
+++ b/packages/ui/src/components/detail/ApproveButton.svelte
@@ -53,6 +53,8 @@
   // Captured when the approval form opens: a background detail refresh
   // must not silently rebind the pin while the form is on screen. A
   // provider with SHA guards can reject a moved head against this pin.
+  // Approve and Request changes submit this same pin — the two form
+  // actions share one head-binding contract.
   let pinAtOpen = $state("");
 
   let expanded = $state(false);
@@ -138,6 +140,11 @@
     }
   }
 
+  // Mirrors handleApprove/runApprovePR on purpose: the same pinAtOpen
+  // captured when the form opened is submitted as expected_head_sha, and
+  // a refresh failure after a successful POST surfaces in the form the
+  // same way an approve refresh failure does. Request changes must not
+  // carry a stronger (or weaker) submission contract than approve.
   async function handleRequestChanges(): Promise<void> {
     if (disabled || submitting || body.trim() === "") return;
     submitting = true;

--- a/packages/ui/src/components/detail/ApproveButton.svelte.test.ts
+++ b/packages/ui/src/components/detail/ApproveButton.svelte.test.ts
@@ -4,9 +4,14 @@ import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import ApproveButton from "./ApproveButton.svelte";
 import { API_CLIENT_KEY, STORES_KEY } from "../../context.js";
 
-describe("ApproveButton head conflicts", () => {
+const { showFlash } = vi.hoisted(() => ({ showFlash: vi.fn() }));
+
+vi.mock("../../stores/flash.svelte.js", () => ({ showFlash }));
+
+describe("ApproveButton", () => {
   afterEach(() => {
     cleanup();
+    showFlash.mockReset();
   });
 
   it("closes the form without keeping the stale conflict as inline error", async () => {
@@ -105,5 +110,45 @@ describe("ApproveButton head conflicts", () => {
     await waitFor(() => expect(post).toHaveBeenCalledTimes(1));
     const [, init] = post.mock.calls[0] as [string, { body: { expected_head_sha?: string } }];
     expect(init.body.expected_head_sha).toBe("platform-head-sha");
+  });
+
+  it("closes a successful approval before reporting a refresh failure", async () => {
+    const post = vi.fn().mockResolvedValue({
+      data: { status: "approved" },
+      error: undefined,
+      response: new Response("{}"),
+    });
+    const oncompleted = vi.fn();
+    render(ApproveButton, {
+      props: {
+        owner: "acme",
+        name: "widget",
+        number: 7,
+        provider: "github",
+        platformHost: "github.com",
+        repoPath: "acme/widget",
+        oncompleted,
+      },
+      context: new Map<symbol, unknown>([
+        [API_CLIENT_KEY, { POST: post }],
+        [
+          STORES_KEY,
+          {
+            detail: { loadDetail: vi.fn().mockRejectedValue(new Error("refresh failed")) },
+            pulls: { loadPulls: vi.fn().mockResolvedValue(undefined) },
+          },
+        ],
+      ]),
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Approve" }));
+    const dialog = screen.getByRole("dialog", { name: "Submit pull request review" });
+    await fireEvent.click(within(dialog).getByRole("button", { name: "Approve" }));
+
+    await waitFor(() => expect(oncompleted).toHaveBeenCalledTimes(1));
+    expect(screen.queryByRole("dialog", { name: "Submit pull request review" })).toBeNull();
+    await waitFor(() => {
+      expect(showFlash).toHaveBeenCalledWith("Pull request approved, but it could not be refreshed.");
+    });
   });
 });

--- a/packages/ui/src/components/detail/ApproveButton.svelte.test.ts
+++ b/packages/ui/src/components/detail/ApproveButton.svelte.test.ts
@@ -53,14 +53,14 @@ describe("ApproveButton head conflicts", () => {
     });
 
     await fireEvent.click(screen.getByRole("button", { name: "Approve" }));
-    const dialog = screen.getByRole("dialog", { name: "Approve pull request" });
+    const dialog = screen.getByRole("dialog", { name: "Submit pull request review" });
     await fireEvent.click(within(dialog).getByRole("button", { name: "Approve" }));
 
     await waitFor(() => expect(onheadconflict).toHaveBeenCalledWith("stale_state", undefined));
-    expect(screen.queryByRole("dialog", { name: "Approve pull request" })).toBeNull();
+    expect(screen.queryByRole("dialog", { name: "Submit pull request review" })).toBeNull();
 
     await fireEvent.click(screen.getByRole("button", { name: "Approve" }));
-    expect(screen.getByRole("dialog", { name: "Approve pull request" })).toBeTruthy();
+    expect(screen.getByRole("dialog", { name: "Submit pull request review" })).toBeTruthy();
     expect(screen.queryByText("target changed since it was reviewed; refresh and retry")).toBeNull();
   });
 
@@ -99,7 +99,7 @@ describe("ApproveButton head conflicts", () => {
     });
 
     await fireEvent.click(screen.getByRole("button", { name: "Approve" }));
-    const dialog = screen.getByRole("dialog", { name: "Approve pull request" });
+    const dialog = screen.getByRole("dialog", { name: "Submit pull request review" });
     await fireEvent.click(within(dialog).getByRole("button", { name: "Approve" }));
 
     await waitFor(() => expect(post).toHaveBeenCalledTimes(1));

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -1908,6 +1908,7 @@
               expectedHeadSha={detailHeadSha}
               platformHeadSha={latestPlatformHeadSha}
               requireHeadPin={capabilities.mutation_head_binding}
+              supportedReviewActions={capabilities.supported_review_actions ?? []}
               title={approveGate.unavailable ? approveGate.reason : undefined}
               onheadconflict={handleHeadConflict}
               oncompleted={() => { headConflict = null; headConflictContext = null; }}

--- a/packages/ui/src/components/detail/keyboard-actions.ts
+++ b/packages/ui/src/components/detail/keyboard-actions.ts
@@ -27,17 +27,16 @@
  *          body: { body: body.trim() }
  *        on error -> throw `error.detail ?? error.title ??
  *                            "failed to approve pull request"`
- *        on success:
- *          body = ""; expanded = false;
- *          await detail.loadDetail(owner, name, number, ref)
- *          await pulls.loadPulls()
+ *        on success, the component closes and clears the form before
+ *          starting its best-effort detail and pull-list refresh
  *        finally -> submitting = false
  *    - Input props: owner, name, number, provider, platformHost,
  *      repoPath, size, disabled.
  *    - Endpoint: POST /pulls/.../approve.
- *    - Refresh path: detail.loadDetail(...) + pulls.loadPulls().
- *    - Toast/flash: none. Errors render inline as the button's own
- *      `let error = $state<string|null>(null)` text.
+ *    - Refresh path: owned by ApproveButton so mutation success closes
+ *      the form even when the follow-up refresh fails.
+ *    - Toast/flash: mutation errors render inline; refresh errors use
+ *      the shared flash store.
  *
  * 2. ApproveWorkflowsButton.svelte
  *    - Render guard: rendered when caller passes it in (PullDetail
@@ -266,8 +265,8 @@ export function canApprovePR(input: PRDetailActionInput): boolean {
   return input.pr.State === "open" && input.viewerCan.approve && !input.stale;
 }
 
-export async function runApprovePR(input: PRDetailActionInput): Promise<void> {
-  if (!canApprovePR(input)) return;
+export async function submitApprovePR(input: PRDetailActionInput): Promise<boolean> {
+  if (!canApprovePR(input)) return false;
   const { ref, number } = input;
   const body = (input.approveCommentBody ?? "").trim();
   // Include the latest synced PR head when available. Providers that
@@ -292,6 +291,12 @@ export async function runApprovePR(input: PRDetailActionInput): Promise<void> {
     input.onError?.(msg);
     throw new Error(msg);
   }
+  return true;
+}
+
+export async function runApprovePR(input: PRDetailActionInput): Promise<void> {
+  if (!(await submitApprovePR(input))) return;
+  const { ref, number } = input;
   await input.stores.detail.loadDetail(ref.owner, ref.name, number, {
     provider: ref.provider,
     platformHost: ref.platformHost,


### PR DESCRIPTION
- Add a red Request changes action beside Approve when the provider supports it.
- Require an explanatory comment while preserving saved inline-review drafts.