### PR TITLE
Prevent accidental mid-stack merges

### DIFF
--- a/context/config-persistence.md
+++ b/context/config-persistence.md
@@ -1,0 +1,4 @@
+# Config Persistence Invariants
+
+- `configFile` in `internal/config/config.go` is the hand-maintained subset of `Config` that `Save` writes to disk. A `Config` field absent from `configFile` (or from the `Save` initializer) loads from TOML fine but is silently dropped on the next save or restart.
+- Every new persisted config field or section must be wired in three places — `Config`, `configFile`, and the `Save` initializer — and covered by a save/load round-trip test with a non-default value (see `TestPullRequestsConfigRoundTrip` in `internal/config/config_test.go`).

--- a/context/error-handling.md
+++ b/context/error-handling.md
@@ -78,6 +78,8 @@ Rules for handler code:
   of the generic `notFound` fallback.
 - Branch-conflict payloads put branch names in top-level `details`; do not rely
   on nested `errors[].value` payloads.
+- Mid-stack merges fail closed for immediate and deferred paths unless explicitly
+  enabled; return `conflict` with reason `mid_stack_merge_disallowed` and `blocking_number` (`internal/server/huma_routes.go::requireMidStackMergeAllowed`).
 - Huma's `errors[]` field is reserved for Huma validation compatibility. Do not
   add new machine-readable contracts there.
 

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -4470,6 +4470,14 @@ components:
         - pushed
         - files
       type: object
+    PullRequests:
+      additionalProperties: false
+      properties:
+        allow_mid_stack_merges:
+          type: boolean
+      required:
+        - allow_mid_stack_merges
+      type: object
     RateLimitHostStatus:
       additionalProperties: false
       properties:
@@ -6137,6 +6145,8 @@ components:
           $ref: "#/components/schemas/ModeVisibility"
         notifications:
           $ref: "#/components/schemas/NotificationsSettingsResponse"
+        pull_requests:
+          $ref: "#/components/schemas/PullRequests"
         repos:
           items:
             $ref: "#/components/schemas/ConfiguredRepoStatus"
@@ -6146,6 +6156,7 @@ components:
       required:
         - repos
         - activity
+        - pull_requests
         - notifications
         - terminal
         - agents
@@ -6629,6 +6640,8 @@ components:
           type: array
         modes:
           $ref: "#/components/schemas/ModeVisibility"
+        pull_requests:
+          $ref: "#/components/schemas/PullRequests"
         terminal:
           $ref: "#/components/schemas/Terminal"
       type: object

--- a/frontend/src/App.navigation.browser.svelte.ts
+++ b/frontend/src/App.navigation.browser.svelte.ts
@@ -134,6 +134,7 @@ function flatSettings(): MockRouteOverride {
         },
       ],
       activity: { view_mode: "flat", time_range: "7d", hide_closed: false, hide_bots: false, collapse_threads: false },
+      pull_requests: { allow_mid_stack_merges: false },
       terminal: {
         font_family: "",
         font_size: 14,

--- a/frontend/src/App.settings-search.browser.svelte.ts
+++ b/frontend/src/App.settings-search.browser.svelte.ts
@@ -28,7 +28,7 @@ describe("settings sidebar search", () => {
   it("filters categories by keywords, shows an empty notice, and restores on clear", async () => {
     await page.viewport(1280, 900);
     mounted = await mountBrowserApp("/settings");
-    await vi.waitFor(() => expect(navLabels()).toHaveLength(7), WAIT);
+    await vi.waitFor(() => expect(navLabels()).toHaveLength(8), WAIT);
 
     const search = document.querySelector<HTMLInputElement>(".kit-settings__sidebar-header input[type='search']");
     expect(search).not.toBeNull();
@@ -53,14 +53,14 @@ describe("settings sidebar search", () => {
     expect(document.querySelector(".settings-page")?.textContent).toContain("No matching settings");
 
     await setQuery("");
-    await vi.waitFor(() => expect(navLabels()).toHaveLength(7), WAIT);
+    await vi.waitFor(() => expect(navLabels()).toHaveLength(8), WAIT);
     expect(document.querySelector(".settings-page")?.textContent).not.toContain("No matching settings");
   });
 
   it("keeps the selected category while it is filtered out and restores it on clear", async () => {
     await page.viewport(1280, 900);
     mounted = await mountBrowserApp("/settings");
-    await vi.waitFor(() => expect(navLabels()).toHaveLength(7), WAIT);
+    await vi.waitFor(() => expect(navLabels()).toHaveLength(8), WAIT);
 
     const terminalButton = Array.from(document.querySelectorAll<HTMLButtonElement>(".kit-settings__nav-item")).find(
       (btn) => btn.textContent?.includes("Terminal"),
@@ -87,7 +87,7 @@ describe("settings sidebar search", () => {
   it("'Back to app' routes to an in-app view rather than browser history", async () => {
     await page.viewport(1280, 900);
     mounted = await mountBrowserApp("/settings");
-    await vi.waitFor(() => expect(navLabels()).toHaveLength(7), WAIT);
+    await vi.waitFor(() => expect(navLabels()).toHaveLength(8), WAIT);
 
     // The fix's contract is that this control must not fall back to
     // window.history.back(): on a direct or bookmarked /settings entry the

--- a/frontend/src/Provider.test.ts
+++ b/frontend/src/Provider.test.ts
@@ -102,6 +102,8 @@ vi.mock("@middleman/ui/stores/settings", () => ({
   createSettingsStore: () => ({
     getConfiguredRepos: () => [],
     setConfiguredRepos: vi.fn(),
+    getPullRequestSettings: () => ({ allow_mid_stack_merges: false }),
+    setPullRequestSettings: vi.fn(),
     getModeVisibility: () => ({
       activity: true,
       repos: true,

--- a/frontend/src/lib/api/settings.ts
+++ b/frontend/src/lib/api/settings.ts
@@ -26,6 +26,7 @@ export interface RepoInput extends RepoRequestOptions {
 
 function normalizeUpdateRequest(settings: {
   activity?: Settings["activity"];
+  pull_requests?: Settings["pull_requests"];
   modes?: Settings["modes"];
   terminal?: Settings["terminal"];
   agents?: Settings["agents"];
@@ -34,6 +35,9 @@ function normalizeUpdateRequest(settings: {
   const request: UpdateSettingsRequest = {};
   if (settings.activity) {
     request.activity = settings.activity;
+  }
+  if (settings.pull_requests) {
+    request.pull_requests = settings.pull_requests;
   }
   if (settings.modes) {
     request.modes = settings.modes;
@@ -60,6 +64,7 @@ export async function getSettings(): Promise<Settings> {
 
 export async function updateSettings(settings: {
   activity?: Settings["activity"];
+  pull_requests?: Settings["pull_requests"];
   modes?: Settings["modes"];
   terminal?: Settings["terminal"];
   agents?: Settings["agents"];

--- a/frontend/src/lib/components/settings/PullRequestSettings.svelte
+++ b/frontend/src/lib/components/settings/PullRequestSettings.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+  import { getStores } from "@middleman/ui";
+  import type { PullRequestSettings as PullRequestSettingsType } from "@middleman/ui/api/types";
+
+  import { updateSettings } from "../../api/settings.js";
+  import { isEmbedded } from "../../stores/embed-config.svelte.js";
+
+  interface Props {
+    pullRequests: PullRequestSettingsType;
+    onUpdate: (settings: PullRequestSettingsType) => void;
+  }
+
+  let { pullRequests, onUpdate }: Props = $props();
+  const { settings: settingsStore } = getStores();
+  const embedded = isEmbedded();
+  let saving = $state(false);
+
+  async function toggleMidStackMerges(): Promise<void> {
+    if (embedded || saving) return;
+    const previous = pullRequests;
+    const pending = {
+      ...pullRequests,
+      allow_mid_stack_merges: !pullRequests.allow_mid_stack_merges,
+    };
+    onUpdate(pending);
+    saving = true;
+    try {
+      const settings = await updateSettings({ pull_requests: pending });
+      onUpdate(settings.pull_requests);
+      settingsStore.setPullRequestSettings(settings.pull_requests);
+    } catch (err) {
+      onUpdate(previous);
+      console.warn("Failed to save pull request settings:", err);
+    } finally {
+      saving = false;
+    }
+  }
+</script>
+
+<div class="setting-row">
+  <div class="setting-copy">
+    <span class="setting-label">Allow mid-stack merges</span>
+    <span class="setting-description">
+      When off, only the bottom unmerged branch in a stack can be merged. When on, middleman warns before merging another stack member.
+    </span>
+  </div>
+  <button
+    class="toggle-btn"
+    class:toggle-on={pullRequests.allow_mid_stack_merges}
+    type="button"
+    disabled={saving}
+    onclick={toggleMidStackMerges}
+    aria-label="Allow mid-stack merges"
+    aria-pressed={pullRequests.allow_mid_stack_merges}
+  >
+    <span class="toggle-track"><span class="toggle-thumb"></span></span>
+  </button>
+</div>
+
+<style>
+  .setting-row { display: flex; align-items: center; justify-content: space-between; gap: var(--space-5); min-height: 44px; }
+  .setting-copy { display: flex; flex-direction: column; gap: 4px; }
+  .setting-label { color: var(--text-secondary); font-size: var(--font-size-md); }
+  .setting-description { max-width: 64ch; color: var(--text-muted); font-size: var(--font-size-sm); line-height: 1.4; }
+  .toggle-btn { flex: 0 0 auto; cursor: pointer; padding: 0; background: none; }
+  .toggle-btn:disabled { cursor: wait; opacity: 0.6; }
+  .toggle-track { display: block; width: 36px; height: 20px; border-radius: 10px; background: var(--bg-inset); border: 1px solid var(--border-muted); position: relative; transition: background 0.15s, border-color 0.15s; }
+  .toggle-on .toggle-track { background: var(--accent-blue); border-color: var(--accent-blue); }
+  .toggle-thumb { display: block; width: 14px; height: 14px; border-radius: 50%; background: white; position: absolute; top: 2px; left: 2px; transition: transform 0.15s; box-shadow: var(--shadow-sm); }
+  .toggle-on .toggle-thumb { transform: translateX(16px); }
+</style>

--- a/frontend/src/lib/components/settings/RepoImportModal.test.ts
+++ b/frontend/src/lib/components/settings/RepoImportModal.test.ts
@@ -125,6 +125,7 @@ describe("RepoImportModal", () => {
     bulk.mockResolvedValue({
       repos: [],
       kata_projects: [],
+      pull_requests: { allow_mid_stack_merges: false },
       activity: {
         view_mode: "threaded",
         time_range: "7d",
@@ -202,6 +203,7 @@ describe("RepoImportModal", () => {
     bulk.mockResolvedValue({
       repos: [],
       kata_projects: [],
+      pull_requests: { allow_mid_stack_merges: false },
       activity: {
         view_mode: "threaded",
         time_range: "7d",

--- a/frontend/src/lib/components/settings/RepoSettings.test.ts
+++ b/frontend/src/lib/components/settings/RepoSettings.test.ts
@@ -181,6 +181,7 @@ describe("RepoSettings", () => {
     mockAddRepo.mockResolvedValue({
       repos: [],
       kata_projects: [],
+      pull_requests: { allow_mid_stack_merges: false },
       activity: {
         view_mode: "threaded",
         time_range: "7d",
@@ -210,6 +211,7 @@ describe("RepoSettings", () => {
     mockRefreshRepo.mockResolvedValue({
       repos: [],
       kata_projects: [],
+      pull_requests: { allow_mid_stack_merges: false },
       activity: {
         view_mode: "threaded",
         time_range: "7d",
@@ -287,6 +289,7 @@ describe("RepoSettings", () => {
     mockUpdateRepoWorktreeBasePath.mockResolvedValue({
       repos: updatedRepos,
       kata_projects: [],
+      pull_requests: { allow_mid_stack_merges: false },
       activity: {
         view_mode: "threaded",
         time_range: "7d",
@@ -402,6 +405,7 @@ describe("RepoSettings", () => {
     mockBulkAddRepos.mockResolvedValue({
       repos: addedRepos,
       kata_projects: [],
+      pull_requests: { allow_mid_stack_merges: false },
       activity: {
         view_mode: "threaded",
         time_range: "7d",
@@ -428,6 +432,7 @@ describe("RepoSettings", () => {
     mockUpdateRepoWorktreeBasePath.mockResolvedValue({
       repos: promotedRepos,
       kata_projects: [],
+      pull_requests: { allow_mid_stack_merges: false },
       activity: {
         view_mode: "threaded",
         time_range: "7d",
@@ -603,6 +608,7 @@ describe("RepoSettings", () => {
     mockBulkAddRepos.mockResolvedValue({
       repos: addedRepos,
       kata_projects: [],
+      pull_requests: { allow_mid_stack_merges: false },
       activity: {
         view_mode: "threaded",
         time_range: "7d",
@@ -700,6 +706,7 @@ describe("RepoSettings", () => {
     mockBulkAddRepos.mockResolvedValue({
       repos: importedRepos,
       kata_projects: [],
+      pull_requests: { allow_mid_stack_merges: false },
       activity: {
         view_mode: "threaded",
         time_range: "7d",

--- a/frontend/src/lib/components/settings/SettingsPage.svelte
+++ b/frontend/src/lib/components/settings/SettingsPage.svelte
@@ -13,6 +13,7 @@
   import AgentSettings from "./AgentSettings.svelte";
   import FleetSettings from "./FleetSettings.svelte";
   import KataProjectMappingsSettings from "./KataProjectMappingsSettings.svelte";
+  import PullRequestSettings from "./PullRequestSettings.svelte";
 
   // Switched-panel model on kit SettingsLayout: this list is the single
   // source of category order, sidebar labels, and per-panel section header
@@ -36,6 +37,14 @@
       group: "Providers",
       description: "Tracked repositories and import tools",
       keywords: "repos repositories providers github gitlab forgejo gitea import glob",
+    },
+    {
+      id: "settings-pull-requests",
+      label: "Pull requests",
+      title: "Pull request safeguards",
+      group: "Workflow",
+      description: "Merge safeguards for stacked branches",
+      keywords: "pull requests merge stack stacked branches safety",
     },
     {
       id: "settings-activity",
@@ -124,6 +133,7 @@
       settingsStore.setConfiguredRepos(settings.repos);
       settingsStore.setModeVisibility(settings.modes);
       settingsStore.setTerminalSettings(settings.terminal);
+      settingsStore.setPullRequestSettings(settings.pull_requests);
     } catch (err) {
       error = err instanceof Error ? err.message : String(err);
     } finally {
@@ -187,6 +197,14 @@
               activity={loaded.activity}
               onUpdate={(activity) => {
                 settings = { ...settings!, activity };
+              }}
+            />
+          {:else if meta.id === "settings-pull-requests"}
+            <PullRequestSettings
+              pullRequests={loaded.pull_requests}
+              onUpdate={(pull_requests) => {
+                settings = { ...settings!, pull_requests };
+                settingsStore.setPullRequestSettings(pull_requests);
               }}
             />
           {:else if meta.id === "settings-terminal"}

--- a/frontend/src/lib/utils/appStartup.test.ts
+++ b/frontend/src/lib/utils/appStartup.test.ts
@@ -9,6 +9,7 @@ function makeStores(): StoreInstances {
       setConfiguredRepos: vi.fn(),
       setModeVisibility: vi.fn(),
       setTerminalSettings: vi.fn(),
+      setPullRequestSettings: vi.fn(),
       setTerminalFontFamily: vi.fn(),
       setTerminalRenderer: vi.fn(),
     },
@@ -37,6 +38,7 @@ function makeStores(): StoreInstances {
 function makeSettings(): Settings {
   return {
     repos: [],
+    pull_requests: { allow_mid_stack_merges: false },
     kata_projects: [],
     fleet: {
       enabled: false,

--- a/frontend/src/lib/utils/appStartup.ts
+++ b/frontend/src/lib/utils/appStartup.ts
@@ -63,6 +63,7 @@ export function runAppStartup(deps: AppStartupDeps): () => void {
         stores.settings.setConfiguredRepos(settings.repos);
         stores.settings.setModeVisibility(settings.modes);
         stores.settings.setTerminalSettings(settings.terminal);
+        stores.settings.setPullRequestSettings(settings.pull_requests);
         stores.activity.hydrateDefaults(settings.activity);
       }
     } catch (err) {

--- a/frontend/src/test/mockApiFetch.ts
+++ b/frontend/src/test/mockApiFetch.ts
@@ -279,6 +279,9 @@ const settings = {
     hide_closed: false,
     hide_bots: false,
   },
+  pull_requests: {
+    allow_mid_stack_merges: false,
+  },
   terminal: {
     font_family: "",
     font_size: 14,

--- a/frontend/tests/e2e/viewport-fit.spec.ts
+++ b/frontend/tests/e2e/viewport-fit.spec.ts
@@ -102,6 +102,7 @@ test("settings sidebar lists every panel in declaration order under group headin
     "Providers",
     "Repositories",
     "Workflow",
+    "Pull requests",
     "Activity",
     "Workspace",
     "Terminal",

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -2236,6 +2236,11 @@ type PublishResponse struct {
 	Upstream    *string          `json:"upstream,omitempty"`
 }
 
+// PullRequests defines model for PullRequests.
+type PullRequests struct {
+	AllowMidStackMerges bool `json:"allow_mid_stack_merges"`
+}
+
 // RateLimitHostStatus defines model for RateLimitHostStatus.
 type RateLimitHostStatus struct {
 	BudgetLimit        int64  `json:"budget_limit"`
@@ -2912,6 +2917,7 @@ type SettingsResponse struct {
 	LaunchTargets *[]LaunchTarget               `json:"launch_targets,omitempty"`
 	Modes         *ModeVisibility               `json:"modes,omitempty"`
 	Notifications NotificationsSettingsResponse `json:"notifications"`
+	PullRequests  PullRequests                  `json:"pull_requests"`
 	Repos         []ConfiguredRepoStatus        `json:"repos"`
 	Terminal      Terminal                      `json:"terminal"`
 }
@@ -3103,6 +3109,7 @@ type UpdateSettingsRequest struct {
 	Agents       *[]Agent                  `json:"agents,omitempty"`
 	KataProjects *[]KataProjectRepoMapping `json:"kata_projects,omitempty"`
 	Modes        *ModeVisibility           `json:"modes,omitempty"`
+	PullRequests *PullRequests             `json:"pull_requests,omitempty"`
 	Terminal     *Terminal                 `json:"terminal,omitempty"`
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2646,6 +2646,7 @@ type configFile struct {
 	Agents                    []Agent                  `toml:"agents,omitempty"`
 	DocFolders                []DocFolder              `toml:"doc_folders,omitempty"`
 	Roborev                   Roborev                  `toml:"roborev,omitempty"`
+	PullRequests              PullRequests             `toml:"pull_requests,omitempty"`
 	Msgvault                  *Msgvault                `toml:"msgvault,omitempty"`
 	Tmux                      Tmux                     `toml:"tmux,omitempty"`
 	Shell                     Shell                    `toml:"shell,omitempty"`
@@ -2680,6 +2681,7 @@ func (c *Config) Save(path string) error {
 		Agents:                  cfg.Agents,
 		DocFolders:              cfg.DocFolders,
 		Roborev:                 cfg.Roborev,
+		PullRequests:            cfg.PullRequests,
 		Msgvault:                cfg.Msgvault,
 		Tmux:                    cfg.Tmux,
 		Shell:                   cfg.Shell,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -550,6 +550,13 @@ type Activity struct {
 	DefaultBranchMaxCommits    int    `toml:"default_branch_max_commits" json:"default_branch_max_commits"`
 }
 
+// PullRequests configures safeguards around pull-request mutations.
+type PullRequests struct {
+	// AllowMidStackMerges permits merging a stack member while an earlier
+	// member remains unmerged. The default is deliberately false.
+	AllowMidStackMerges bool `toml:"allow_mid_stack_merges,omitempty" json:"allow_mid_stack_merges"`
+}
+
 const (
 	TerminalRendererXterm   = "xterm"
 	TerminalRendererGhostty = "ghostty-web"
@@ -780,6 +787,7 @@ type Config struct {
 	Platforms         []PlatformConfig         `toml:"platforms"`
 	GitHubApps        []GitHubAppConfig        `toml:"github_apps"`
 	Activity          Activity                 `toml:"activity"`
+	PullRequests      PullRequests             `toml:"pull_requests"`
 	Notifications     Notifications            `toml:"notifications"`
 	Terminal          Terminal                 `toml:"terminal"`
 	Modes             ModeVisibility           `toml:"modes"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2333,6 +2333,28 @@ endpoint = "http://custom:9999"
 	assert.Equal("http://custom:9999", cfg2.RoborevEndpoint())
 }
 
+func TestPullRequestsConfigRoundTrip(t *testing.T) {
+	assert := assert.New(t)
+	path := writeConfig(t, `
+[[repos]]
+owner = "a"
+name = "b"
+
+[pull_requests]
+allow_mid_stack_merges = true
+`)
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.True(cfg.PullRequests.AllowMidStackMerges)
+
+	savePath := filepath.Join(t.TempDir(), "saved.toml")
+	require.NoError(t, cfg.Save(savePath))
+
+	cfg2, err := Load(savePath)
+	require.NoError(t, err)
+	assert.True(cfg2.PullRequests.AllowMidStackMerges)
+}
+
 func TestTerminalConfigRoundTrip(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/server/deferred_merge.go
+++ b/internal/server/deferred_merge.go
@@ -126,6 +126,9 @@ func (s *Server) enqueueDeferredMerge(
 			map[string]any{"reason": "not_open"},
 		)
 	}
+	if err := s.requireMidStackMergeAllowed(ctx, repo.ID, number); err != nil {
+		return deferMergePRBody{}, err
+	}
 	expectedHeadSHA, err := s.preflightMergePR(repo, mr, number, body)
 	if err != nil {
 		return deferMergePRBody{}, err

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -3204,6 +3204,9 @@ func (s *Server) mergePRWithBody(
 	if mr == nil {
 		return mergePRBody{}, problemNotFound(CodePullNotFound, "pull request not found", nil)
 	}
+	if err := s.requireMidStackMergeAllowed(ctx, repo.ID, number); err != nil {
+		return mergePRBody{}, err
+	}
 	expectedHeadSHA, err := s.preflightMergePR(repo, mr, number, body)
 	if err != nil {
 		return mergePRBody{}, err
@@ -3289,6 +3292,40 @@ func (s *Server) mergePRWithBody(
 		SHA:     result.SHA,
 		Message: result.Message,
 	}, nil
+}
+
+func (s *Server) requireMidStackMergeAllowed(ctx context.Context, repoID int64, number int) error {
+	s.cfgMu.Lock()
+	allowed := s.cfg != nil && s.cfg.PullRequests.AllowMidStackMerges
+	s.cfgMu.Unlock()
+	if allowed {
+		return nil
+	}
+
+	stack, members, err := s.db.GetStackForPRByRepoID(ctx, repoID, number)
+	if err != nil {
+		return problemInternal("get stack for pull request failed")
+	}
+	if stack == nil {
+		return nil
+	}
+
+	for _, member := range members {
+		if member.Number == number {
+			return nil
+		}
+		if member.State != string(db.MergeRequestStateMerged) {
+			return problemConflict(
+				CodeConflict,
+				"mid-stack merges are disabled; merge the bottom unmerged branch first",
+				map[string]any{
+					"reason":          "mid_stack_merge_disallowed",
+					"blocking_number": member.Number,
+				},
+			)
+		}
+	}
+	return nil
 }
 
 func (s *Server) preflightMergePR(

--- a/internal/server/mid_stack_merge_test.go
+++ b/internal/server/mid_stack_merge_test.go
@@ -1,0 +1,77 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	gh "github.com/google/go-github/v88/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/middleman/internal/apiclient/generated"
+	"go.kenn.io/middleman/internal/config"
+	"go.kenn.io/middleman/internal/db"
+)
+
+func seedMergeStack(t *testing.T, database *db.DB) {
+	t.Helper()
+	bottomID := seedPR(t, database, "acme", "widget", 1, withSeedPRHeadSHA("bottom-head"))
+	middleID := seedPR(t, database, "acme", "widget", 2, withSeedPRHeadSHA("middle-head"))
+	repo, err := database.GetRepoByIdentity(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
+	require.NoError(t, err)
+	require.NotNil(t, repo)
+	stackID, err := database.UpsertStack(t.Context(), repo.ID, 1, "feature")
+	require.NoError(t, err)
+	require.NoError(t, database.ReplaceStackMembers(t.Context(), stackID, []db.StackMember{
+		{StackID: stackID, MergeRequestID: bottomID, Position: 1},
+		{StackID: stackID, MergeRequestID: middleID, Position: 2},
+	}))
+}
+
+func TestAPIMergePRRejectsMidStackMergeByDefault(t *testing.T) {
+	assert := assert.New(t)
+	mergeCalls := 0
+	mock := &mockGH{
+		mergePullRequestFn: func(_ context.Context, _, _ string, _ int, _, _, _ string) (*gh.PullRequestMergeResult, error) {
+			mergeCalls++
+			return &gh.PullRequestMergeResult{}, nil
+		},
+	}
+
+	srv, database := setupTestServerWithMock(t, mock)
+	seedMergeStack(t, database)
+	client := setupTestClient(t, srv)
+	resp, err := client.HTTP.MergePullWithResponse(
+		t.Context(), "gh", "acme", "widget", 2,
+		generated.MergePRInputBody{Method: "squash", ExpectedHeadSha: new("middle-head")},
+	)
+	require.NoError(t, err)
+	assert.Equal(http.StatusConflict, resp.StatusCode())
+	assert.Contains(string(resp.Body), `"reason":"mid_stack_merge_disallowed"`)
+	assert.Contains(string(resp.Body), `"blocking_number":1`)
+	assert.Zero(mergeCalls)
+}
+
+func TestAPIMergePRAllowsMidStackMergeWhenConfigured(t *testing.T) {
+	mergeCalls := 0
+	mock := &mockGH{
+		mergePullRequestFn: func(_ context.Context, _, _ string, _ int, _, _, _ string) (*gh.PullRequestMergeResult, error) {
+			mergeCalls++
+			return &gh.PullRequestMergeResult{Merged: new(true)}, nil
+		},
+	}
+
+	srv, database := setupTestServerWithMock(t, mock)
+	srv.cfgMu.Lock()
+	srv.cfg = &config.Config{PullRequests: config.PullRequests{AllowMidStackMerges: true}}
+	srv.cfgMu.Unlock()
+	seedMergeStack(t, database)
+	client := setupTestClient(t, srv)
+	resp, err := client.HTTP.MergePullWithResponse(
+		t.Context(), "gh", "acme", "widget", 2,
+		generated.MergePRInputBody{Method: "squash", ExpectedHeadSha: new("middle-head")},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode())
+	assert.Equal(t, 1, mergeCalls)
+}

--- a/internal/server/settings_handlers.go
+++ b/internal/server/settings_handlers.go
@@ -20,6 +20,7 @@ import (
 type settingsResponse struct {
 	Repos         []ghclient.ConfiguredRepoStatus `json:"repos" nullable:"false"`
 	Activity      config.Activity                 `json:"activity"`
+	PullRequests  config.PullRequests             `json:"pull_requests"`
 	Notifications notificationsSettingsResponse   `json:"notifications"`
 	Terminal      config.Terminal                 `json:"terminal"`
 	Modes         config.ModeVisibility           `json:"modes,omitzero"`
@@ -35,6 +36,7 @@ type notificationsSettingsResponse struct {
 
 type updateSettingsRequest struct {
 	Activity     *config.Activity                 `json:"activity,omitempty"`
+	PullRequests *config.PullRequests             `json:"pull_requests,omitempty"`
 	Terminal     *config.Terminal                 `json:"terminal,omitempty"`
 	Modes        *config.ModeVisibility           `json:"modes,omitempty"`
 	Agents       *[]config.Agent                  `json:"agents,omitempty"`
@@ -65,6 +67,7 @@ func (s *Server) buildLocalSettingsResponse() settingsResponse {
 	s.cfgMu.Lock()
 	repos := slices.Clone(s.cfg.Repos)
 	activity := s.cfg.Activity
+	pullRequests := s.cfg.PullRequests
 	terminal := s.cfg.Terminal
 	modes := cloneModeVisibility(s.cfg.Modes).WithDefaults()
 	agents := cloneConfigAgents(s.cfg.Agents)
@@ -100,8 +103,9 @@ func (s *Server) buildLocalSettingsResponse() settingsResponse {
 		}
 	}
 	return settingsResponse{
-		Repos:    configured,
-		Activity: activity,
+		Repos:        configured,
+		Activity:     activity,
+		PullRequests: pullRequests,
 		// Notifications are a built-in capability with no enable/disable
 		// setting; report them as always available.
 		Notifications: notificationsSettingsResponse{Enabled: true},
@@ -402,6 +406,7 @@ func (s *Server) updateSettings(
 
 	s.cfgMu.Lock()
 	prevActivity := s.cfg.Activity
+	prevPullRequests := s.cfg.PullRequests
 	prevTerminal := s.cfg.Terminal
 	prevModes := cloneModeVisibility(s.cfg.Modes)
 	prevAgents := cloneConfigAgents(s.cfg.Agents)
@@ -415,6 +420,9 @@ func (s *Server) updateSettings(
 			candidate.TimeRange = "7d"
 		}
 		s.cfg.Activity = candidate
+	}
+	if input.Body.PullRequests != nil {
+		s.cfg.PullRequests = *input.Body.PullRequests
 	}
 	if input.Body.Terminal != nil {
 		s.cfg.Terminal = *input.Body.Terminal
@@ -430,6 +438,7 @@ func (s *Server) updateSettings(
 	}
 	if err := s.cfg.Validate(); err != nil {
 		s.cfg.Activity = prevActivity
+		s.cfg.PullRequests = prevPullRequests
 		s.cfg.Terminal = prevTerminal
 		s.cfg.Modes = prevModes
 		s.cfg.Agents = prevAgents
@@ -439,6 +448,7 @@ func (s *Server) updateSettings(
 	}
 	if err := s.cfg.Save(s.cfgPath); err != nil {
 		s.cfg.Activity = prevActivity
+		s.cfg.PullRequests = prevPullRequests
 		s.cfg.Terminal = prevTerminal
 		s.cfg.Modes = prevModes
 		s.cfg.Agents = prevAgents

--- a/packages/ui/src/Provider.svelte
+++ b/packages/ui/src/Provider.svelte
@@ -237,10 +237,12 @@
       activity: ActivitySettings,
       terminal: TerminalSettings,
       modes: Settings["modes"],
+      pullRequests: Settings["pull_requests"],
     ): void {
       settingsStore.setConfiguredRepos(repos);
       settingsStore.setTerminalSettings(terminal);
       settingsStore.setModeVisibility(modes);
+      settingsStore.setPullRequestSettings(pullRequests);
       activityStore.hydrateDefaults(activity);
     }
 
@@ -252,6 +254,7 @@
         data.activity,
         data.terminal,
         data.modes,
+        data.pull_requests,
       );
     }
 

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -6170,6 +6170,9 @@ export interface components {
             short_commit: string;
             upstream?: string;
         };
+        PullRequests: {
+            allow_mid_stack_merges: boolean;
+        };
         RateLimitHostStatus: {
             /** Format: int64 */
             budget_limit: number;
@@ -6934,6 +6937,7 @@ export interface components {
             launch_targets?: components["schemas"]["LaunchTarget"][] | null;
             modes?: components["schemas"]["ModeVisibility"];
             notifications: components["schemas"]["NotificationsSettingsResponse"];
+            pull_requests: components["schemas"]["PullRequests"];
             repos: components["schemas"]["ConfiguredRepoStatus"][];
             terminal: components["schemas"]["Terminal"];
         };
@@ -7152,6 +7156,7 @@ export interface components {
             agents?: components["schemas"]["Agent"][];
             kata_projects?: components["schemas"]["KataProjectRepoMapping"][];
             modes?: components["schemas"]["ModeVisibility"];
+            pull_requests?: components["schemas"]["PullRequests"];
             terminal?: components["schemas"]["Terminal"];
         };
         UserRepository: {

--- a/packages/ui/src/api/types.ts
+++ b/packages/ui/src/api/types.ts
@@ -62,6 +62,7 @@ export interface CICheck {
 }
 
 export type ActivitySettings = components["schemas"]["Activity"];
+export type PullRequestSettings = components["schemas"]["PullRequests"];
 export type TerminalSettings = components["schemas"]["Terminal"];
 export type TerminalRenderer = TerminalSettings["renderer"];
 export type ModeVisibility = components["schemas"]["ModeVisibility"];
@@ -89,6 +90,10 @@ export const DEFAULT_MODE_VISIBILITY: ModeVisibility = {
   board: true,
   reviews: true,
   workspaces: true,
+};
+
+export const DEFAULT_PULL_REQUEST_SETTINGS: PullRequestSettings = {
+  allow_mid_stack_merges: false,
 };
 
 export type AgentSettings = components["schemas"]["Agent"];

--- a/packages/ui/src/components/detail/MergeModal.svelte
+++ b/packages/ui/src/components/detail/MergeModal.svelte
@@ -37,6 +37,8 @@
      * queue) and the modal offers an immediate merge instead.
      */
     alreadyQueued?: boolean;
+    /** Warning shown when the configured override permits a mid-stack merge. */
+    midStackWarning?: string | undefined;
     onclose: () => void;
     onmerged: () => void;
     /** Called when a deferred merge was accepted and now waits on CI. */
@@ -50,7 +52,7 @@
     allowSquash, allowMerge, allowRebase,
     expectedHeadSha, requireHeadPin = false,
     deferUntilChecksPass = false,
-    alreadyQueued = false,
+    alreadyQueued = false, midStackWarning,
     onclose, onmerged, onqueued, onheadconflict,
   }: Props = $props();
 
@@ -207,6 +209,12 @@
   {onclose}
 >
   <div class="merge-body">
+      {#if midStackWarning}
+        <div class="mid-stack-warning" role="alert">
+          <strong>Warning: this is a mid-stack merge.</strong>
+          <span>{midStackWarning} Merging now can leave the remaining stack based on an unexpected branch.</span>
+        </div>
+      {/if}
       {#if methods.length > 1}
         <div class="field" role="group" aria-label="Merge method">
           <span class="field-label">Merge method</span>
@@ -310,6 +318,23 @@
 </Modal>
 
 <style>
+  .mid-stack-warning {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 10px 12px;
+    border: 1px solid var(--accent-amber-soft, rgba(217, 119, 6, 0.45));
+    border-radius: var(--radius-sm);
+    background: var(--accent-amber-soft, rgba(217, 119, 6, 0.12));
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+    line-height: 1.4;
+  }
+
+  .mid-stack-warning strong {
+    color: var(--text-primary);
+  }
+
   .ci-defer-note {
     padding: 8px 10px;
     border: 1px solid var(--accent-amber-soft, rgba(217, 119, 6, 0.35));

--- a/packages/ui/src/components/detail/MergeModal.svelte.test.ts
+++ b/packages/ui/src/components/detail/MergeModal.svelte.test.ts
@@ -43,6 +43,19 @@ describe("MergeModal modal frame integration", () => {
     unmount();
     expect(getStackDepth()).toBe(0);
   });
+
+  it("warns when the override permits a mid-stack merge", () => {
+    render(MergeModal, {
+      props: {
+        ...baseProps,
+        midStackWarning: "This is stack position 2 of 3. Branch #1 below it has not been merged.",
+      },
+    });
+
+    const warning = screen.getByRole("alert");
+    expect(warning.textContent).toContain("Warning: this is a mid-stack merge.");
+    expect(warning.textContent).toContain("Branch #1 below it has not been merged.");
+  });
 });
 
 describe("MergeModal head pinning", () => {

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -91,7 +91,7 @@
 
   const CLEAR_LABELS_PENDING = "__clear-label-selection__";
 
-  const { detail: detailStore, pulls, activity, diff: diffStore, detailActivityView } = getStores();
+  const { detail: detailStore, pulls, activity, diff: diffStore, detailActivityView, settings } = getStores();
   const client = getClient();
   const actions = getActions();
   const uiConfig = getUIConfig();
@@ -697,6 +697,19 @@
   const deferredMergePending = $derived(
     detailStore.getDetail()?.deferred_merge_pending ?? false,
   );
+  const midStackBlocker = $derived.by(() => {
+    const stack = detailStore.getDetail()?.stack;
+    if (!stack) return undefined;
+    return stack.members?.find(
+      (member) => member.position < stack.position && member.state !== "merged",
+    );
+  });
+  const allowMidStackMerges = $derived(
+    settings.getPullRequestSettings().allow_mid_stack_merges,
+  );
+  const midStackMergeBlocked = $derived(
+    midStackBlocker !== undefined && !allowMidStackMerges,
+  );
 
   function handleHeadConflict(
     reason: "stale_state" | "head_unknown",
@@ -835,7 +848,7 @@
       repoSettings,
       // Treat a blocked head as stale for gating: the merge modal must
       // not open while the reviewed head is unknown.
-      stale: stalePR || headActionsBlocked,
+      stale: stalePR || headActionsBlocked || midStackMergeBlocked,
       stores: { detail: detailStore, pulls },
       client,
       requireHeadPin: capabilities.mutation_head_binding,
@@ -1935,8 +1948,10 @@
               || (capabilities.merge_mutation && repoSettings.viewerCanMerge))}
             {@const mergeSettings = repoSettings}
             {@const mergeDisabledByConflicts = hasMergeConflicts(pr)}
-            {@const mergeTitle = mergeDisabledByConflicts
-              ? "Resolve merge conflicts before merging"
+            {@const mergeTitle = midStackMergeBlocked
+              ? `Merge #${midStackBlocker?.number ?? "the bottom branch"} first; mid-stack merges are disabled in settings`
+              : mergeDisabledByConflicts
+                ? "Resolve merge conflicts before merging"
               : headPinMissing
                 ? "The reviewed head commit has not been synced yet; merging is disabled until the next sync records it"
                 : mergeOpUnavailable
@@ -1946,10 +1961,10 @@
                     : ""}
             <Button
               class={deferredMergePending ? "btn--merge btn--merge-queued" : "btn--merge"}
-              disabled={stalePR || mergeDisabledByConflicts || mergeOpUnavailable || headActionsBlocked || headPinMissing}
+              disabled={stalePR || midStackMergeBlocked || mergeDisabledByConflicts || mergeOpUnavailable || headActionsBlocked || headPinMissing}
               title={mergeTitle}
               onclick={() => {
-                if (stalePR || mergeOpUnavailable || headActionsBlocked || headPinMissing) return;
+                if (stalePR || midStackMergeBlocked || mergeOpUnavailable || headActionsBlocked || headPinMissing) return;
                 runOpenMerge(buildOpenMergeInput(pr, capabilities));
               }}
               tone="success"
@@ -2216,6 +2231,9 @@
           requireHeadPin={capabilities.mutation_head_binding}
           deferUntilChecksPass={shouldDeferMergeForCI(p.CIStatus, p.CIChecksJSON)}
           alreadyQueued={deferredMergePending}
+          midStackWarning={midStackBlocker
+            ? `This is stack position ${d.stack?.position ?? "?"} of ${d.stack?.size ?? "?"}. Branch #${midStackBlocker.number} below it has not been merged.`
+            : undefined}
           onheadconflict={handleHeadConflict}
           onclose={() => { showMergeModal = false; }}
           onqueued={() => {

--- a/packages/ui/src/stores/settings.svelte.ts
+++ b/packages/ui/src/stores/settings.svelte.ts
@@ -1,8 +1,10 @@
 import {
   DEFAULT_MODE_VISIBILITY,
+  DEFAULT_PULL_REQUEST_SETTINGS,
   DEFAULT_TERMINAL_SETTINGS,
   type ConfigRepo,
   type ModeVisibility,
+  type PullRequestSettings,
   type TerminalRenderer,
   type TerminalSettings,
 } from "../api/types.js";
@@ -14,6 +16,9 @@ export function createSettingsStore() {
   });
   let modeVisibility = $state<ModeVisibility>({
     ...DEFAULT_MODE_VISIBILITY,
+  });
+  let pullRequestSettings = $state<PullRequestSettings>({
+    ...DEFAULT_PULL_REQUEST_SETTINGS,
   });
   let loaded = $state(false);
 
@@ -47,6 +52,17 @@ export function createSettingsStore() {
 
   function isModeVisible(mode: keyof ModeVisibility): boolean {
     return modeVisibility[mode] ?? DEFAULT_MODE_VISIBILITY[mode];
+  }
+
+  function getPullRequestSettings(): PullRequestSettings {
+    return pullRequestSettings;
+  }
+
+  function setPullRequestSettings(settings: PullRequestSettings | null | undefined): void {
+    pullRequestSettings = {
+      ...DEFAULT_PULL_REQUEST_SETTINGS,
+      ...(settings ?? {}),
+    };
   }
 
   function getTerminalFontFamily(): string {
@@ -111,6 +127,8 @@ export function createSettingsStore() {
     getModeVisibility,
     setModeVisibility,
     isModeVisible,
+    getPullRequestSettings,
+    setPullRequestSettings,
     getTerminalFontFamily,
     setTerminalFontFamily,
     getTerminalFontSize,


### PR DESCRIPTION
- Blocks merges for stack members above the bottom unmerged branch by default
- Adds a Pull Requests setting to allow mid-stack merges when needed
- Shows a warning in the merge dialog when the override is used

<sup>generated by a clanker</sup>