### PR TITLE
fix: reveal PRs linked to Kata workspaces

### DIFF
--- a/docs/superpowers/specs/2026-06-08-kata-docs-msgvault-modes-design.md
+++ b/docs/superpowers/specs/2026-06-08-kata-docs-msgvault-modes-design.md
@@ -310,9 +310,12 @@ Header/navigation changes:
 Kata frontend adaptation:
 
 - Keep the existing task workspace behavior and daemon switcher semantics.
-- Ready Kata workspaces use the same unique branch/upstream/HEAD PR association as
-  issue workspaces; refresh must reveal a pushed PR without replacing the Kata source
-  identity (`internal/workspace/monitor.go::workspacePRMonitorEligible`).
+- Ready Kata workspaces use the issue-workspace association order: prefer one unique
+  upstream branch/remote match, then one unique local branch/HEAD match; absent or
+  ambiguous matches stay unassociated (`internal/workspace/monitor.go::detectAssociatedPR`).
+- Association uses repo sync and local Git independently of Kata daemon availability,
+  and must not change `ItemType`, `ItemKey`, or `KataMetadata`
+  (`internal/workspace/monitor.go::refreshWorkspaceAssociation`).
 - Treat task lists as trees: a row stays out of the top-level projection only
   when its parent is present in the same result set (so it can fold under that
   ancestor once expanded). A child whose parent is absent — e.g. a search or

--- a/docs/superpowers/specs/2026-06-08-kata-docs-msgvault-modes-design.md
+++ b/docs/superpowers/specs/2026-06-08-kata-docs-msgvault-modes-design.md
@@ -310,6 +310,9 @@ Header/navigation changes:
 Kata frontend adaptation:
 
 - Keep the existing task workspace behavior and daemon switcher semantics.
+- Ready Kata workspaces use the same unique branch/upstream/HEAD PR association as
+  issue workspaces; refresh must reveal a pushed PR without replacing the Kata source
+  identity (`internal/workspace/monitor.go::workspacePRMonitorEligible`).
 - Treat task lists as trees: a row stays out of the top-level projection only
   when its parent is present in the same result set (so it can fold under that
   ancestor once expanded). A child whose parent is absent — e.g. a search or

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -27336,18 +27336,20 @@ func gitOutput(t *testing.T, dir string, args ...string) string {
 }
 
 type rawWorkspaceStatusResponse struct {
-	ID                 string  `json:"id"`
-	PlatformHost       string  `json:"platform_host"`
-	RepoOwner          string  `json:"repo_owner"`
-	RepoName           string  `json:"repo_name"`
-	ItemType           string  `json:"item_type"`
-	ItemNumber         int     `json:"item_number"`
-	GitHeadRef         string  `json:"git_head_ref"`
-	WorktreePath       string  `json:"worktree_path"`
-	TmuxSession        string  `json:"tmux_session"`
-	Status             string  `json:"status"`
-	ErrorMessage       *string `json:"error_message"`
-	AssociatedPRNumber *int    `json:"associated_pr_number"`
+	ID                 string                    `json:"id"`
+	PlatformHost       string                    `json:"platform_host"`
+	RepoOwner          string                    `json:"repo_owner"`
+	RepoName           string                    `json:"repo_name"`
+	ItemType           string                    `json:"item_type"`
+	ItemNumber         int                       `json:"item_number"`
+	ItemKey            string                    `json:"item_key"`
+	GitHeadRef         string                    `json:"git_head_ref"`
+	WorktreePath       string                    `json:"worktree_path"`
+	TmuxSession        string                    `json:"tmux_session"`
+	Status             string                    `json:"status"`
+	ErrorMessage       *string                   `json:"error_message"`
+	AssociatedPRNumber *int                      `json:"associated_pr_number"`
+	Kata               *db.WorkspaceKataMetadata `json:"kata"`
 }
 
 type rawIssueWorkspaceRef struct {
@@ -28517,6 +28519,7 @@ func TestKataWorkspaceManualRefreshDiscoversAndSyncsAssociatedPR(t *testing.T) {
 		ShortID:    "task-1",
 		Title:      "Track Kata workspace association",
 	}
+	kataItemKey := db.KataWorkspaceItemKey(kataMetadata)
 	require.NoError(fixture.database.InsertWorkspace(ctx, &db.Workspace{
 		ID:              "ws-kata-refresh",
 		Platform:        "github",
@@ -28524,7 +28527,7 @@ func TestKataWorkspaceManualRefreshDiscoversAndSyncsAssociatedPR(t *testing.T) {
 		RepoOwner:       "acme",
 		RepoName:        "widget",
 		ItemType:        db.WorkspaceItemTypeKataTask,
-		ItemKey:         db.KataWorkspaceItemKey(kataMetadata),
+		ItemKey:         kataItemKey,
 		GitHeadRef:      headRef,
 		WorkspaceBranch: headRef,
 		WorktreePath:    worktreePath,
@@ -28545,12 +28548,18 @@ func TestKataWorkspaceManualRefreshDiscoversAndSyncsAssociatedPR(t *testing.T) {
 	var refreshed rawWorkspaceStatusResponse
 	require.NoError(json.NewDecoder(refreshRR.Body).Decode(&refreshed))
 	assert.Equal(db.WorkspaceItemTypeKataTask, refreshed.ItemType)
+	assert.Equal(kataItemKey, refreshed.ItemKey)
+	require.NotNil(refreshed.Kata)
+	assert.Equal(kataMetadata, *refreshed.Kata)
 	require.NotNil(refreshed.AssociatedPRNumber)
 	assert.Equal(42, *refreshed.AssociatedPRNumber)
 
 	stored, err := fixture.database.GetWorkspace(ctx, "ws-kata-refresh")
 	require.NoError(err)
 	require.NotNil(stored)
+	assert.Equal(kataItemKey, stored.ItemKey)
+	require.NotNil(stored.KataMetadata)
+	assert.Equal(kataMetadata, *stored.KataMetadata)
 	require.NotNil(stored.AssociatedPRNumber)
 	assert.Equal(42, *stored.AssociatedPRNumber)
 

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -28424,6 +28424,149 @@ func TestWorkspaceManualRefreshDiscoversAndSyncsAssociatedPR(t *testing.T) {
 	assert.Equal(headSHA, pr.PlatformHeadSHA)
 }
 
+func TestKataWorkspaceManualRefreshDiscoversAndSyncsAssociatedPR(t *testing.T) {
+	t.Parallel()
+
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+
+	const headRef = "kata-task-1"
+	var headSHA string
+	now := time.Now().UTC().Truncate(time.Second)
+	prID := int64(42001)
+	prTitleFromList := "Indexed PR title"
+	prTitleFromDetail := "Fresh PR detail title"
+	prState := "open"
+	prBody := "fresh body"
+	prURL := "https://github.com/acme/widget/pull/42"
+	baseRef := "main"
+	baseSHA := "base-sha"
+	author := "alice"
+	cloneURL := "https://github.com/acme/widget.git"
+	intPointer := func(value int) *int { return &value }
+	mock := &mockGH{
+		listOpenPullRequestsFn: func(context.Context, string, string) ([]*gh.PullRequest, error) {
+			return []*gh.PullRequest{{
+				ID:        &prID,
+				Number:    intPointer(42),
+				Title:     &prTitleFromList,
+				State:     &prState,
+				HTMLURL:   &prURL,
+				User:      &gh.User{Login: &author},
+				CreatedAt: &gh.Timestamp{Time: now},
+				UpdatedAt: &gh.Timestamp{Time: now},
+				Head: &gh.PullRequestBranch{
+					Ref:  new(headRef),
+					SHA:  &headSHA,
+					Repo: &gh.Repository{CloneURL: &cloneURL},
+				},
+				Base: &gh.PullRequestBranch{Ref: &baseRef, SHA: &baseSHA},
+			}}, nil
+		},
+		getPullRequestFn: func(context.Context, string, string, int) (*gh.PullRequest, error) {
+			return &gh.PullRequest{
+				ID:        &prID,
+				Number:    intPointer(42),
+				Title:     &prTitleFromDetail,
+				Body:      &prBody,
+				State:     &prState,
+				HTMLURL:   &prURL,
+				User:      &gh.User{Login: &author},
+				CreatedAt: &gh.Timestamp{Time: now},
+				UpdatedAt: &gh.Timestamp{Time: now},
+				Head: &gh.PullRequestBranch{
+					Ref:  new(headRef),
+					SHA:  &headSHA,
+					Repo: &gh.Repository{CloneURL: &cloneURL},
+				},
+				Base: &gh.PullRequestBranch{Ref: &baseRef, SHA: &baseSHA},
+			}, nil
+		},
+	}
+	fixture := setupWorkspaceServerFixtureWithMockHostAndOptions(
+		t, nil, mock, "github.com",
+		ServerOptions{
+			PtyOwnerInProcess:                  true,
+			DisableWorkspaceBackgroundMonitors: true,
+		},
+	)
+
+	worktreePath := filepath.Join(t.TempDir(), "kata-worktree")
+	runGit(t, t.TempDir(), "clone", fixture.remote, worktreePath)
+	runGit(t, worktreePath, "config", "user.email", "test@test.com")
+	runGit(t, worktreePath, "config", "user.name", "Test")
+	runGit(t, worktreePath, "checkout", "-b", headRef)
+	require.NoError(os.WriteFile(
+		filepath.Join(worktreePath, "feature.txt"),
+		[]byte("feature\n"),
+		0o644,
+	))
+	runGit(t, worktreePath, "add", ".")
+	runGit(t, worktreePath, "commit", "-m", "feature commit")
+	runGit(t, worktreePath, "push", "-u", "origin", headRef)
+	runGit(
+		t, worktreePath,
+		"remote", "set-url", "origin", "git@github.com:acme/widget.git",
+	)
+	headSHA = testGitSHA(t, worktreePath, "HEAD")
+	kataMetadata := db.WorkspaceKataMetadata{
+		DaemonID:   "local",
+		ProjectUID: "project-1",
+		IssueUID:   "issue-1",
+		ShortID:    "task-1",
+		Title:      "Track Kata workspace association",
+	}
+	require.NoError(fixture.database.InsertWorkspace(ctx, &db.Workspace{
+		ID:              "ws-kata-refresh",
+		Platform:        "github",
+		PlatformHost:    "github.com",
+		RepoOwner:       "acme",
+		RepoName:        "widget",
+		ItemType:        db.WorkspaceItemTypeKataTask,
+		ItemKey:         db.KataWorkspaceItemKey(kataMetadata),
+		GitHeadRef:      headRef,
+		WorkspaceBranch: headRef,
+		WorktreePath:    worktreePath,
+		TmuxSession:     "middleman-ws-kata-refresh",
+		Status:          "ready",
+		KataMetadata:    &kataMetadata,
+	}))
+
+	refreshRR := doJSON(
+		t,
+		fixture.server,
+		http.MethodPost,
+		"/api/v1/workspaces/ws-kata-refresh/refresh",
+		nil,
+	)
+	require.Equal(http.StatusOK, refreshRR.Code, refreshRR.Body.String())
+
+	var refreshed rawWorkspaceStatusResponse
+	require.NoError(json.NewDecoder(refreshRR.Body).Decode(&refreshed))
+	assert.Equal(db.WorkspaceItemTypeKataTask, refreshed.ItemType)
+	require.NotNil(refreshed.AssociatedPRNumber)
+	assert.Equal(42, *refreshed.AssociatedPRNumber)
+
+	stored, err := fixture.database.GetWorkspace(ctx, "ws-kata-refresh")
+	require.NoError(err)
+	require.NotNil(stored)
+	require.NotNil(stored.AssociatedPRNumber)
+	assert.Equal(42, *stored.AssociatedPRNumber)
+
+	repo, err := fixture.database.GetRepoByIdentity(
+		ctx,
+		db.GitHubRepoIdentity("github.com", "acme", "widget"),
+	)
+	require.NoError(err)
+	require.NotNil(repo)
+	pr, err := fixture.database.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, 42)
+	require.NoError(err)
+	require.NotNil(pr)
+	assert.Equal(prTitleFromDetail, pr.Title)
+	assert.Equal(headSHA, pr.PlatformHeadSHA)
+}
+
 func TestWorkspaceManualRefreshReturnsAssociationInspectionError(t *testing.T) {
 	t.Parallel()
 

--- a/internal/workspace/monitor.go
+++ b/internal/workspace/monitor.go
@@ -114,7 +114,8 @@ func (m *PRMonitor) refreshWorkspaceAssociation(
 
 func workspacePRMonitorEligible(ws *Workspace) bool {
 	return ws != nil &&
-		ws.ItemType == db.WorkspaceItemTypeIssue &&
+		(ws.ItemType == db.WorkspaceItemTypeIssue ||
+			ws.ItemType == db.WorkspaceItemTypeKataTask) &&
 		ws.AssociatedPRNumber == nil &&
 		ws.Status == "ready" &&
 		strings.TrimSpace(ws.WorktreePath) != ""

--- a/internal/workspace/monitor_test.go
+++ b/internal/workspace/monitor_test.go
@@ -192,6 +192,51 @@ func TestPRMonitorRunOnceFallsBackToLocalBranchNameAndHeadSHA(t *testing.T) {
 	assert.Equal(42, *ws.AssociatedPRNumber)
 }
 
+func TestPRMonitorRefreshWorkspaceAssociationAssociatesKataTask(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := context.Background()
+
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
+	worktreePath := setupMonitorRepo(t)
+	runWorkspaceTestGit(t, worktreePath, "checkout", "-b", "feature/kata-task")
+	headSHA, err := gitHeadSHA(ctx, worktreePath)
+	require.NoError(err)
+	seedMRWithPlatformHead(t, d, repoID, 42, "feature/kata-task", headSHA)
+	kataMetadata := db.WorkspaceKataMetadata{
+		DaemonID:   "local",
+		ProjectUID: "project-1",
+		IssueUID:   "issue-1",
+	}
+	require.NoError(d.InsertWorkspace(ctx, &db.Workspace{
+		ID:           "ws-kata",
+		Platform:     "github",
+		PlatformHost: "github.com",
+		RepoOwner:    "acme",
+		RepoName:     "widget",
+		ItemType:     db.WorkspaceItemTypeKataTask,
+		ItemKey:      db.KataWorkspaceItemKey(kataMetadata),
+		GitHeadRef:   "feature/kata-task",
+		WorktreePath: worktreePath,
+		TmuxSession:  "middleman-ws-kata",
+		Status:       "ready",
+		KataMetadata: &kataMetadata,
+	}))
+
+	monitor := NewPRMonitor(d)
+	update, changed, err := monitor.RefreshWorkspaceAssociation(ctx, "ws-kata")
+	require.NoError(err)
+	assert.True(changed)
+	assert.Equal(PRAssociationUpdate{WorkspaceID: "ws-kata", PRNumber: 42}, update)
+
+	ws, err := d.GetWorkspace(ctx, "ws-kata")
+	require.NoError(err)
+	require.NotNil(ws)
+	require.NotNil(ws.AssociatedPRNumber)
+	assert.Equal(42, *ws.AssociatedPRNumber)
+}
+
 func TestPRMonitorRunOnceFallsBackToLocalHeadSHAWhenUpstreamRepoMetadataMissing(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -679,6 +724,15 @@ func TestWorkspacePRMonitorEligible(t *testing.T) {
 			name: "ready issue workspace without association",
 			ws: &db.Workspace{
 				ItemType:     db.WorkspaceItemTypeIssue,
+				Status:       "ready",
+				WorktreePath: "/tmp/work",
+			},
+			want: true,
+		},
+		{
+			name: "ready kata task workspace without association",
+			ws: &db.Workspace{
+				ItemType:     db.WorkspaceItemTypeKataTask,
 				Status:       "ready",
 				WorktreePath: "/tmp/work",
 			},


### PR DESCRIPTION
Kata-created workspaces could sync a newly pushed pull request without associating it, so Refresh left the workspace in task-only mode even though the PR existed. This restores the same ordered PR discovery used by issue workspaces while keeping the Kata task as the workspace’s source identity.

- Refresh reveals a uniquely matching pushed PR for ready Kata workspaces.
- Missing or ambiguous matches remain unassociated.
- Kata item keys and metadata remain unchanged, and discovery does not depend on daemon availability.

Validated with the full Go suite: 4,595 tests passed and 11 environment-dependent tests skipped.

<sup>generated by a clanker</sup>
