### PR TITLE
Add machine-readable version output

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Expandable check run section on each PR shows pass/fail/pending status with colo
 - **Copy to clipboard** -- one-click copy of PR/issue bodies and comments
 - **Settings UI** -- add/remove repos and configure activity feed defaults from the browser
 - **Reverse proxy support** -- deploy behind a proxy with the `base_path` config
-- **Version info** -- `middleman version` prints the version, commit, and build date
+- **Version info** -- `middleman version` prints build metadata, with `--json` for integrations
 
 ### Additional modes in this integration branch
 

--- a/cmd/middleman/main.go
+++ b/cmd/middleman/main.go
@@ -86,6 +86,13 @@ var (
 
 var runServer = run
 
+type versionOutput struct {
+	Name      string `json:"name"`
+	Version   string `json:"version"`
+	Commit    string `json:"commit"`
+	BuildDate string `json:"buildDate"`
+}
+
 func main() {
 	closeLog, err := configureLogging(os.Stderr)
 	if err != nil {
@@ -187,12 +194,7 @@ func runCLI(args []string, stdout io.Writer) error {
 	if len(args) > 0 {
 		switch args[0] {
 		case "version":
-			_, err := fmt.Fprintf(
-				stdout,
-				"middleman %s (%s) built %s\n",
-				version, commit, buildDate,
-			)
-			return err
+			return runVersionCLI(args[1:], stdout)
 		case "config":
 			return runConfigCLI(args[1:], stdout)
 		case "docs":
@@ -220,6 +222,27 @@ func runCLI(args []string, stdout io.Writer) error {
 	}
 
 	return serve.Run(args, runServer)
+}
+
+func runVersionCLI(args []string, stdout io.Writer) error {
+	if len(args) == 0 {
+		_, err := fmt.Fprintf(
+			stdout,
+			"middleman %s (%s) built %s\n",
+			version, commit, buildDate,
+		)
+		return err
+	}
+	if len(args) != 1 || args[0] != "--json" {
+		return fmt.Errorf("usage: middleman version [--json]")
+	}
+
+	return json.NewEncoder(stdout).Encode(versionOutput{
+		Name:      "middleman",
+		Version:   version,
+		Commit:    commit,
+		BuildDate: buildDate,
+	})
 }
 
 func runPtyOwnerCLI(args []string) error {

--- a/cmd/middleman/main_test.go
+++ b/cmd/middleman/main_test.go
@@ -866,6 +866,39 @@ func TestRunCLIConfigReadPort(t *testing.T) {
 	assert.Equal("9123\n", stdout.String())
 }
 
+func TestRunCLIVersionPreservesHumanOutput(t *testing.T) {
+	originalVersion, originalCommit, originalBuildDate := version, commit, buildDate
+	version, commit, buildDate = "1.2.3", "abc1234", "2026-07-12T12:00:00Z"
+	t.Cleanup(func() {
+		version, commit, buildDate = originalVersion, originalCommit, originalBuildDate
+	})
+
+	var stdout bytes.Buffer
+	err := runCLI([]string{"version"}, &stdout)
+
+	require.NoError(t, err)
+	assert.Equal(t, "middleman 1.2.3 (abc1234) built 2026-07-12T12:00:00Z\n", stdout.String())
+}
+
+func TestRunCLIVersionJSONReturnsStableBuildMetadata(t *testing.T) {
+	originalVersion, originalCommit, originalBuildDate := version, commit, buildDate
+	version, commit, buildDate = "1.2.3", "abc1234", "2026-07-12T12:00:00Z"
+	t.Cleanup(func() {
+		version, commit, buildDate = originalVersion, originalCommit, originalBuildDate
+	})
+
+	var stdout bytes.Buffer
+	err := runCLI([]string{"version", "--json"}, &stdout)
+
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"name": "middleman",
+		"version": "1.2.3",
+		"commit": "abc1234",
+		"buildDate": "2026-07-12T12:00:00Z"
+	}`, stdout.String())
+}
+
 func TestRunCLIConfigReadPortCreatesDefaultConfig(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -14,9 +14,21 @@ Without a subcommand, `middleman` starts the daemon and web UI.
 
 ```sh
 middleman version
+middleman version --json
 ```
 
-Prints the version, commit, and build date.
+Prints the version, commit, and build date. Use `--json` for fleet inventory
+and other integrations. The JSON contract is a single object written to stdout:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `name` | string | Canonical tool name, always `middleman` |
+| `version` | string | Semantic version for a release build; development identifier otherwise |
+| `commit` | string | Build commit identifier |
+| `buildDate` | string | UTC RFC3339 timestamp for a release build; `unknown` when not injected |
+
+The command does not read configuration, connect to a daemon, or require a
+workspace.
 
 ## Status
 


### PR DESCRIPTION
- Adds `middleman version --json` with stable name, version, commit, and build-date fields.
- Keeps the existing plaintext output and runs without daemon, config, or workspace state.
- Documents the integration contract.

<sup>generated by a clanker</sup>