### PR TITLE
Expose and edit Kata project mappings

### DIFF
--- a/context/retries-and-backoffs.md
+++ b/context/retries-and-backoffs.md
@@ -34,6 +34,10 @@ client behavior). Test the shared helper against `DoWithBackOff` with a fast
 injected backoff, and test package-specific callers for their own classifier and
 budget choices.
 
+Scope upstream timeout child contexts to the upstream call; subsequent local
+database and filesystem work must retain the request context
+(`internal/server/kata_workspace.go::getKataProjectMappings`).
+
 To extend git transient matching, add a substring to the slice in
 `internal/gitclone/retry.go` and a row to `internal/gitclone/retry_test.go`.
 Keep the matcher conservative — false positives turn permanent failures into

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -101,14 +101,10 @@ only allowed per clone when that clone has no usable `project.uid` or
 is required. If no `.kata.toml` mapping matches, the
 resolver may fall back to a case-insensitive exact match between the Kata
 project and exactly one non-stale registered Middleman Project with provider
-identity. Registered Projects participate through `.kata.toml` identity/name
-matching first, then through their display name or provider repository name
-when they have no readable project metadata; their local checkout is also a
-workspace setup base. If no registered Project matches, the resolver may fall
-back to a case-insensitive exact match against one synced tracked repo matched
-by current repo configuration, whether that configuration entry is exact or
-globbed, but only for repos without readable `.kata.toml` project metadata.
-Ambiguous, mismatched, or missing matches mean the Create/Open
+identity; use `.kata.toml` before display/repository name, and reuse the local
+checkout as the workspace base. Only then may one synced repo matched by exact
+or globbed config resolve by name. Ambiguous, mismatched, or missing matches
+mean the Create/Open
 workspace button must not render
 (`internal/server/kata_workspace.go::resolveKataWorkspaceRepo`).
 

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -100,10 +100,15 @@ only allowed per clone when that clone has no usable `project.uid` or
 `project.identity`, and then exactly one case-insensitive `project.name` match
 is required. If no `.kata.toml` mapping matches, the
 resolver may fall back to a case-insensitive exact match between the Kata
-project name and exactly one synced tracked repo matched by current repo
-configuration, whether that configuration entry is exact or globbed, but only
-for repos without readable `.kata.toml` project metadata. Ambiguous, mismatched,
-or missing matches mean the Create/Open
+project and exactly one non-stale registered Middleman Project with provider
+identity. Registered Projects participate through `.kata.toml` identity/name
+matching first, then through their display name or provider repository name
+when they have no readable project metadata; their local checkout is also a
+workspace setup base. If no registered Project matches, the resolver may fall
+back to a case-insensitive exact match against one synced tracked repo matched
+by current repo configuration, whether that configuration entry is exact or
+globbed, but only for repos without readable `.kata.toml` project metadata.
+Ambiguous, mismatched, or missing matches mean the Create/Open
 workspace button must not render
 (`internal/server/kata_workspace.go::resolveKataWorkspaceRepo`).
 

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -85,12 +85,11 @@ owning provider item has not synced yet, the summary leaves
 `item_last_activity_at` absent rather than inventing a value.
 
 Kata task repository resolution is deliberately exact. Manual settings mappings
-key by optional daemon ID plus Kata project UID and point to a configured exact
-repo identity. Config validation rejects mappings whose repo target is no
-longer configured, so settings repo deletion must remove mappings for the
-deleted repo in the same save/rollback path
+key by optional daemon ID plus Kata project UID and point to a known repository
+identity, including registered Middleman Projects. Removing a watched repo does
+not delete an override because a registered Project may still own that identity
 (`internal/config/config.go::validateKataProjectRepoMappings`,
-`internal/server/settings_handlers.go::deleteConfiguredRepo`). Automatic
+`internal/server/kata_workspace.go::kataManualWorkspaceTarget`). Automatic
 resolution first uses watched exact repos with `worktree_base_path` whose clone
 contains a matching `.kata.toml`. Matching first compares both explicit
 identifiers, `project.uid` and `project.identity`, to the Kata project UID. If
@@ -107,6 +106,10 @@ or globbed config resolve by name. Ambiguous, mismatched, or missing matches
 mean the Create/Open
 workspace button must not render
 (`internal/server/kata_workspace.go::resolveKataWorkspaceRepo`).
+
+Settings lists each selected-daemon Kata project with the status and source from
+the workspace resolver, and manual overrides may target watched, tracked, or
+registered repositories (`internal/server/kata_workspace.go::getKataProjectMappings`).
 
 Persisted workspace `worktree_path` values should be absolute. Workspace setup
 runs `git worktree add` from the managed clone or configured base checkout, so

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -108,8 +108,9 @@ workspace button must not render
 (`internal/server/kata_workspace.go::resolveKataWorkspaceRepo`).
 
 Settings lists each selected-daemon Kata project with the status and source from
-the workspace resolver, and manual overrides may target watched, tracked, or
-registered repositories (`internal/server/kata_workspace.go::getKataProjectMappings`).
+the workspace resolver. Its selector lists known registered Middleman Projects,
+defaults to the inferred identity match, and persists the chosen project's repo
+identity (`internal/server/kata_workspace.go::getKataProjectMappings`).
 
 Persisted workspace `worktree_path` values should be absolute. Workspace setup
 runs `git worktree add` from the managed clone or configured base checkout, so

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -100,17 +100,22 @@ only allowed per clone when that clone has no usable `project.uid` or
 is required. If no `.kata.toml` mapping matches, the
 resolver may fall back to a case-insensitive exact match between the Kata
 project and exactly one non-stale registered Middleman Project with provider
-identity; use `.kata.toml` before display/repository name, and reuse the local
-checkout as the workspace base. Only then may one synced repo matched by exact
-or globbed config resolve by name. Ambiguous, mismatched, or missing matches
+identity; use `.kata.toml` before display/repository name. Distinct matching
+registered checkout paths are ambiguous. A unique registered match carries its
+checkout through workspace creation, while a configured clone carries its own
+base path. Only then may one synced repo matched by exact
+or globbed config and lacking readable project metadata resolve by name.
+Ambiguous, mismatched, or missing matches
 mean the Create/Open
 workspace button must not render
 (`internal/server/kata_workspace.go::resolveKataWorkspaceRepo`).
 
 Settings lists each selected-daemon Kata project with the status and source from
-the workspace resolver. Its selector lists known registered Middleman Projects,
-defaults to the inferred identity match, and persists the chosen project's repo
-identity (`internal/server/kata_workspace.go::getKataProjectMappings`).
+the workspace resolver. Its selector lists repository identities known from
+exact watched repositories, currently matched tracked repositories, or
+non-stale registered Projects. It defaults only to an inferred identity match
+and persists that repository identity
+(`internal/server/kata_workspace.go::getKataProjectMappings`).
 
 Persisted workspace `worktree_path` values should be absolute. Workspace setup
 runs `git worktree add` from the managed clone or configured base checkout, so

--- a/docs/superpowers/specs/2026-06-25-kata-task-workspace-launch-design.md
+++ b/docs/superpowers/specs/2026-06-25-kata-task-workspace-launch-design.md
@@ -415,8 +415,9 @@ Frontend coverage:
 
 This can ship behind the existing Kata mode. Automatic mapping needs no config
 migration. Manual mappings require a config schema addition but can default to an
-empty list. Workspaces require a database migration for `item_key` before the
-Kata workspace endpoint ships.
+empty list; the mapping settings category is mounted only while Kata mode is
+enabled. Workspaces require a database migration for `item_key` before the Kata
+workspace endpoint ships.
 
 The implementation should update OpenAPI artifacts after adding the endpoint and
 settings schema, then regenerate the frontend API types through the existing

--- a/docs/superpowers/specs/2026-06-25-kata-task-workspace-launch-design.md
+++ b/docs/superpowers/specs/2026-06-25-kata-task-workspace-launch-design.md
@@ -148,8 +148,8 @@ project name, the resolver treats the mapping as ambiguous and returns no
 workspace target. `.kata.toml` ambiguity is terminal: tracked-name fallback runs
 only when `.kata.toml` produces zero candidates. The UI should not show a
 disabled button or reason text for this state because the user asked for the
-button to be absent when there is no clear mapping; diagnostics need a new API
-field.
+button to be absent when there is no clear mapping. Settings owns mapping
+diagnostics and correction so the task detail stays quiet.
 
 ## Manual Settings
 
@@ -163,10 +163,10 @@ mappings and allows adding, editing, and removing one mapping at a time:
 - Platform host.
 - Repository path.
 
-The repository selector should be backed by configured watched repositories so a
-manual mapping cannot point to an untracked repository accidentally. If the
-underlying repository is later removed from middleman settings, the mapping is
-kept but the resolver treats it as inactive until fixed or deleted.
+The repository selector is backed by watched/tracked repositories and registered
+Middleman Projects. Removing a watched repo keeps its mapping because a registered
+Project may still own the same provider identity; diagnostics report an invalid
+override when no known repository owns it.
 
 Persist manual mappings in middleman config, not in Kata metadata, because they
 describe middleman's local interpretation of external Kata projects.

--- a/docs/superpowers/specs/2026-06-25-kata-task-workspace-launch-design.md
+++ b/docs/superpowers/specs/2026-06-25-kata-task-workspace-launch-design.md
@@ -163,9 +163,10 @@ mappings and allows adding, editing, and removing one mapping at a time:
 - Platform host.
 - Repository path.
 
-The repository selector is backed by watched/tracked repositories and registered
-Middleman Projects. Removing a watched repo keeps its mapping because a registered
-Project may still own the same provider identity; diagnostics report an invalid
+The selector lists registered Middleman Projects with provider identity and
+defaults to the project matching the inferred repository. Saving persists that
+project's provider identity. Removing a watched repo keeps its mapping because a
+registered Project may still own the same identity; diagnostics report an invalid
 override when no known repository owns it.
 
 Persist manual mappings in middleman config, not in Kata metadata, because they

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -2469,12 +2469,9 @@ components:
       properties:
         display_name:
           type: string
-        project_id:
-          type: string
         repo:
           $ref: "#/components/schemas/RepoRefResponse"
       required:
-        - project_id
         - display_name
         - repo
       type: object

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -2464,6 +2464,52 @@ components:
       required:
         - daemons
       type: object
+    KataProjectMappingDiagnostic:
+      additionalProperties: false
+      properties:
+        daemon_id:
+          type: string
+        project_name:
+          type: string
+        project_uid:
+          type: string
+        repo:
+          $ref: "#/components/schemas/RepoRefResponse"
+        source:
+          type: string
+        status:
+          type: string
+      required:
+        - daemon_id
+        - project_uid
+        - project_name
+        - status
+      type: object
+    KataProjectMappingsResponse:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /api/v1/schemas/KataProjectMappingsResponse.json
+          format: uri
+          readOnly: true
+          type: string
+        daemon_id:
+          type: string
+        projects:
+          items:
+            $ref: "#/components/schemas/KataProjectMappingDiagnostic"
+          type: array
+        repositories:
+          items:
+            $ref: "#/components/schemas/RepoRefResponse"
+          type: array
+      required:
+        - daemon_id
+        - projects
+        - repositories
+      type: object
     KataProjectRepoMapping:
       additionalProperties: false
       properties:
@@ -13012,6 +13058,36 @@ paths:
                 $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: List Kata daemons
+      tags:
+        - Kata
+  /kata/project-mappings:
+    get:
+      operationId: get-kata-project-mappings
+      parameters:
+        - description: Kata daemon id; the effective default daemon when empty
+          in: header
+          name: X-Middleman-Kata-Daemon
+          schema:
+            description: Kata daemon id; the effective default daemon when empty
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/KataProjectMappingsResponse"
+          description: OK
+          headers:
+            Vary:
+              schema:
+                type: string
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Error
+      summary: Inspect effective Kata project repository mappings
       tags:
         - Kata
   /kata/tasks/{issue_uid}:

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -2464,6 +2464,20 @@ components:
       required:
         - daemons
       type: object
+    KataMappingTargetResponse:
+      additionalProperties: false
+      properties:
+        display_name:
+          type: string
+        project_id:
+          type: string
+        repo:
+          $ref: "#/components/schemas/RepoRefResponse"
+      required:
+        - project_id
+        - display_name
+        - repo
+      type: object
     KataProjectMappingDiagnostic:
       additionalProperties: false
       properties:
@@ -2501,14 +2515,14 @@ components:
           items:
             $ref: "#/components/schemas/KataProjectMappingDiagnostic"
           type: array
-        repositories:
+        targets:
           items:
-            $ref: "#/components/schemas/RepoRefResponse"
+            $ref: "#/components/schemas/KataMappingTargetResponse"
           type: array
       required:
         - daemon_id
         - projects
-        - repositories
+        - targets
       type: object
     KataProjectRepoMapping:
       additionalProperties: false

--- a/frontend/src/App.settings-search.browser.svelte.ts
+++ b/frontend/src/App.settings-search.browser.svelte.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import { page } from "vite-plus/test/browser";
 
 import { mountBrowserApp, type MountedBrowserApp } from "./test/browserAppHarness.js";
+import { mockSettings } from "./test/mockApiFetch.js";
 
 const WAIT = 10_000;
 
@@ -107,5 +108,28 @@ describe("settings sidebar search", () => {
     expect(document.querySelector(".settings-page")).toBeNull();
     expect(new URL(window.location.href).pathname).toBe("/");
     backSpy.mockRestore();
+  });
+
+  it("hides Kata mapping settings without starting diagnostics when Kata is disabled", async () => {
+    await page.viewport(1280, 900);
+    mounted = await mountBrowserApp("/settings", {
+      overrides: [
+        (req) => {
+          if (req.method !== "GET" || req.url.pathname !== "/api/v1/settings") return null;
+          return new Response(
+            JSON.stringify({
+              ...mockSettings,
+              modes: { ...mockSettings.modes, kata: false },
+            }),
+            { headers: { "content-type": "application/json" } },
+          );
+        },
+      ],
+    });
+
+    await vi.waitFor(() => expect(navLabels()).toHaveLength(7), WAIT);
+    expect(navLabels()).not.toContain("Kata mappings");
+    expect(mounted.api.requests.filter((req) => req.url.pathname.includes("/kata/daemons"))).toHaveLength(1);
+    expect(mounted.api.requests.some((req) => req.url.pathname.includes("/kata/project-mappings"))).toBe(false);
   });
 });

--- a/frontend/src/lib/api/kata/workspaces.ts
+++ b/frontend/src/lib/api/kata/workspaces.ts
@@ -1,6 +1,7 @@
 import type { components } from "@middleman/ui/api/schema";
 
 import { apiErrorMessage, client } from "../runtime.js";
+import { KATA_DAEMON_HEADER } from "./daemons.js";
 import type { KataTaskSummary } from "./taskTypes.js";
 
 export type KataWorkspaceTaskIdentity = components["schemas"]["KataWorkspaceTaskRequest"];
@@ -10,6 +11,8 @@ export type KataWorkspaceResponse = components["schemas"]["WorkspaceResponse"] &
   item_type: "kata_task";
   kata?: KataWorkspaceMetadata;
 };
+export type KataProjectMappingDiagnostic = components["schemas"]["KataProjectMappingDiagnostic"];
+export type KataProjectMappingsResponse = components["schemas"]["KataProjectMappingsResponse"];
 
 function requestErrorMessage(error: { detail?: string; title?: string } | undefined, fallback: string): string {
   return apiErrorMessage(error, fallback);
@@ -45,4 +48,14 @@ export function createKataWorkspaceForTask(identity: KataWorkspaceTaskIdentity):
       }
       return data as KataWorkspaceResponse;
     });
+}
+
+export async function getKataProjectMappings(daemonID?: string): Promise<KataProjectMappingsResponse> {
+  const { data, error, response } = await client.GET("/kata/project-mappings", {
+    params: daemonID ? { header: { [KATA_DAEMON_HEADER]: daemonID } } : {},
+  });
+  if (!data) {
+    throw new Error(requestErrorMessage(error, `GET /kata/project-mappings -> ${response.status}`));
+  }
+  return data;
 }

--- a/frontend/src/lib/components/settings/KataProjectMappingsSettings.svelte
+++ b/frontend/src/lib/components/settings/KataProjectMappingsSettings.svelte
@@ -2,12 +2,19 @@
   import PlusIcon from "@lucide/svelte/icons/plus";
   import RotateCcwIcon from "@lucide/svelte/icons/rotate-ccw";
   import TrashIcon from "@lucide/svelte/icons/trash-2";
-  import { Button, SelectDropdown } from "@middleman/ui";
+  import { onMount } from "svelte";
+  import { Button, Chip, SelectDropdown } from "@middleman/ui";
   import type {
     ConfigRepo,
     KataProjectRepoMapping,
   } from "@middleman/ui/api/types";
   import { updateSettings } from "../../api/settings.js";
+  import { fetchKataDaemons, type KataDaemonInfo } from "../../api/kata/daemons.js";
+  import {
+    getKataProjectMappings,
+    type KataProjectMappingDiagnostic,
+    type KataProjectMappingsResponse,
+  } from "../../api/kata/workspaces.js";
   import { isEmbedded } from "../../stores/embed-config.svelte.js";
 
   interface Props {
@@ -35,21 +42,41 @@
   let nextID = 0;
   let saving = $state(false);
   let error = $state<string | null>(null);
+  let daemons = $state.raw<KataDaemonInfo[]>([]);
+  let selectedDaemonID = $state("");
+  let diagnostics = $state.raw<KataProjectMappingsResponse | null>(null);
+  let diagnosticsLoading = $state(true);
+  let diagnosticsError = $state<string | null>(null);
   // svelte-ignore state_referenced_locally
   let currentMappings = $state(normalizeMappings(mappings));
   // svelte-ignore state_referenced_locally
   let drafts = $state<MappingDraft[]>(draftsFromMappings(currentMappings));
 
-  const repoOptions = $derived.by(() =>
-    repos
+  const repoOptions = $derived.by(() => {
+    const configured = repos
       .filter((repo) => !repo.is_glob)
       .map((repo) => ({
         key: repoKey(repo.provider, repo.platform_host, repo.repo_path),
         label: repoLabel(repo),
         repo,
-      }))
-      .sort((left, right) => left.label.localeCompare(right.label)),
-  );
+      }));
+    const effectiveRepos = (diagnostics?.projects ?? []).flatMap((project) => project.repo ? [project.repo] : []);
+    const discovered = [...(diagnostics?.repositories ?? []), ...effectiveRepos].map((repo) => ({
+      key: repoKey(repo.provider, repo.platform_host, repo.repo_path),
+      label: `${repo.provider} / ${repo.platform_host} / ${repo.repo_path}`,
+      repo: {
+        provider: repo.provider,
+        platform_host: repo.platform_host,
+        owner: repo.owner,
+        name: repo.name,
+        repo_path: repo.repo_path,
+        is_glob: false,
+        matched_repo_count: 1,
+      } satisfies ConfigRepo,
+    }));
+    return [...new Map([...configured, ...discovered].map((option) => [option.key, option])).values()]
+      .sort((left, right) => left.label.localeCompare(right.label));
+  });
   const repoOptionsByKey = $derived.by(() => new Map(repoOptions.map((option) => [option.key, option])));
   const repoSelectOptions = $derived(
     repoOptions.map((option) => ({ value: option.key, label: option.label })),
@@ -62,6 +89,29 @@
     drafts.some((draft) => draft.projectUID.trim() === "" || !repoOptionsByKey.has(draft.repoKey)),
   );
   const canSave = $derived(!embedded && !saving && isDirty && !hasInvalidDraft);
+  const daemonOptions = $derived(daemons.map((daemon) => ({ value: daemon.id, label: daemon.id })));
+
+  onMount(() => {
+    void loadDiagnostics();
+  });
+
+  async function loadDiagnostics(daemonID = selectedDaemonID): Promise<void> {
+    diagnosticsLoading = true;
+    diagnosticsError = null;
+    try {
+      if (daemons.length === 0) {
+        daemons = await fetchKataDaemons();
+      }
+      const effectiveID = daemonID || daemons.find((daemon) => daemon.default)?.id || daemons[0]?.id || "";
+      selectedDaemonID = effectiveID;
+      diagnostics = await getKataProjectMappings(effectiveID || undefined);
+    } catch (err) {
+      diagnosticsError = err instanceof Error ? err.message : String(err);
+      diagnostics = null;
+    } finally {
+      diagnosticsLoading = false;
+    }
+  }
 
   function nextDraftID(): string {
     nextID += 1;
@@ -143,6 +193,50 @@
     ];
   }
 
+  function addOverride(project: KataProjectMappingDiagnostic): void {
+    const daemonID = diagnostics?.daemon_id ?? selectedDaemonID;
+    const existing = drafts.find(
+      (draft) => draft.projectUID === project.project_uid && draft.daemonID === daemonID,
+    );
+    if (existing) return;
+    const mappedRepo = project.repo
+      ? repoKey(project.repo.provider, project.repo.platform_host, project.repo.repo_path)
+      : "";
+    drafts = [
+      ...drafts,
+      {
+        id: nextDraftID(),
+        daemonID,
+        projectUID: project.project_uid,
+        repoKey: repoOptionsByKey.has(mappedRepo) ? mappedRepo : (repoOptions[0]?.key ?? ""),
+      },
+    ];
+  }
+
+  function sourceLabel(source?: string): string {
+    return ({
+      manual_daemon: "Manual, daemon-specific",
+      manual_global: "Manual, all daemons",
+      configured_clone: "Watched clone metadata",
+      registered_project: "Registered project",
+      tracked_repo: "Tracked repository name",
+    } as Record<string, string>)[source ?? ""] ?? "No matching repository";
+  }
+
+  function statusTone(status: string): "success" | "warning" | "danger" | "muted" {
+    if (status === "mapped") return "success";
+    if (status === "ambiguous" || status === "invalid") return "danger";
+    if (status === "unmapped") return "warning";
+    return "muted";
+  }
+
+  function statusLabel(status: string): string {
+    if (status === "mapped") return "Mapped";
+    if (status === "ambiguous") return "Ambiguous";
+    if (status === "invalid") return "Invalid override";
+    return "Unmapped";
+  }
+
   function removeMapping(id: string): void {
     drafts = drafts.filter((draft) => draft.id !== id);
   }
@@ -166,6 +260,7 @@
       currentMappings = normalizeMappings(nextMappings);
       drafts = draftsFromMappings(currentMappings);
       onUpdate(nextMappings);
+      await loadDiagnostics();
     } catch (err) {
       error = err instanceof Error ? err.message : String(err);
     } finally {
@@ -179,11 +274,92 @@
     <p class="settings-error" role="alert">{error}</p>
   {/if}
 
+  <section class="mapping-section" aria-label="Effective Kata project mappings">
+    <div class="mapping-section-header">
+      <div>
+        <h3>Effective mappings</h3>
+        <p>What workspace creation resolves for each project reported by Kata.</p>
+      </div>
+      {#if daemonOptions.length > 1}
+        <div class="daemon-picker">
+          <span>Daemon</span>
+          <SelectDropdown
+            title="Kata mapping daemon"
+            value={selectedDaemonID}
+            options={daemonOptions}
+            onchange={(value) => { void loadDiagnostics(value); }}
+            disabled={diagnosticsLoading}
+          />
+        </div>
+      {/if}
+    </div>
+
+    {#if diagnosticsLoading}
+      <p class="empty-mappings">Loading effective mappings...</p>
+    {:else if diagnosticsError}
+      <p class="settings-error" role="alert">{diagnosticsError}</p>
+    {:else if !diagnostics || diagnostics.projects.length === 0}
+      <p class="empty-mappings">This Kata daemon reports no projects.</p>
+    {:else}
+      <div class="mapping-table-wrap">
+        <table class="mapping-table effective-table" aria-label="Effective Kata project mappings">
+          <thead>
+            <tr>
+              <th scope="col">Kata project</th>
+              <th scope="col">Repository</th>
+              <th scope="col">Resolution</th>
+              <th scope="col" aria-label="Mapping actions"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each diagnostics.projects as project (project.project_uid)}
+              <tr>
+                <td>
+                  <strong>{project.project_name || project.project_uid}</strong>
+                  <span class="mapping-meta">{project.project_uid}</span>
+                </td>
+                <td>
+                  {#if project.repo}
+                    <span>{project.repo.repo_path}</span>
+                    <span class="mapping-meta">{project.repo.provider} / {project.repo.platform_host}</span>
+                  {:else}
+                    <span class="mapping-empty">No repository</span>
+                  {/if}
+                </td>
+                <td>
+                  <Chip size="xs" tone={statusTone(project.status)} uppercase={false}>
+                    {statusLabel(project.status)}
+                  </Chip>
+                  <span class="mapping-meta">{sourceLabel(project.source)}</span>
+                </td>
+                <td class="action-cell">
+                  {#if !project.source?.startsWith("manual_")}
+                    <Button
+                      size="sm"
+                      surface="outline"
+                      type="button"
+                      onclick={() => addOverride(project)}
+                      disabled={embedded || saving || repoOptions.length === 0}
+                    >
+                      Add override
+                    </Button>
+                  {:else}
+                    <span class="mapping-meta">Edit below</span>
+                  {/if}
+                </td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      </div>
+    {/if}
+  </section>
+
   <section class="mapping-section" aria-label="Kata project repository mappings">
     <div class="mapping-section-header">
       <div>
         <h3>Manual mappings</h3>
-        <p>Automatic `.kata.toml` matches are used when no row is configured here.</p>
+        <p>Overrides take precedence over the effective automatic mapping shown above.</p>
       </div>
       <Button
         size="sm"
@@ -197,7 +373,7 @@
     </div>
 
     {#if repoOptions.length === 0}
-      <p class="empty-mappings">No exact watched repositories are configured.</p>
+      <p class="empty-mappings">No watched repositories or registered projects are available.</p>
     {:else if drafts.length === 0}
       <p class="empty-mappings">No manual Kata project mappings configured.</p>
     {:else}
@@ -306,7 +482,7 @@
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
-    gap: 12px;
+    gap: var(--space-5);
   }
 
   .mapping-section-header h3 {
@@ -383,6 +559,39 @@
     background: var(--bg-inset);
   }
 
+  .effective-table strong,
+  .effective-table > tbody > tr > td > span:first-child {
+    display: block;
+    color: var(--text-primary);
+    font-size: var(--font-size-sm);
+    font-weight: 600;
+  }
+
+  .mapping-meta {
+    display: block;
+    margin-top: var(--space-1);
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    line-height: 1.35;
+  }
+
+  .mapping-empty {
+    color: var(--text-muted);
+    font-size: var(--font-size-sm);
+  }
+
+  .daemon-picker {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    color: var(--text-secondary);
+    font-size: var(--font-size-xs);
+  }
+
+  .daemon-picker :global(.kit-select-dropdown) {
+    min-width: 160px;
+  }
+
   .mapping-table :global(.kit-select-dropdown) {
     width: 100%;
     min-width: 0;
@@ -417,7 +626,7 @@
   .settings-actions {
     display: flex;
     justify-content: flex-end;
-    gap: 8px;
+    gap: var(--space-4);
   }
 
   @media (max-width: 759px) {

--- a/frontend/src/lib/components/settings/KataProjectMappingsSettings.svelte
+++ b/frontend/src/lib/components/settings/KataProjectMappingsSettings.svelte
@@ -2,7 +2,7 @@
   import PlusIcon from "@lucide/svelte/icons/plus";
   import RotateCcwIcon from "@lucide/svelte/icons/rotate-ccw";
   import TrashIcon from "@lucide/svelte/icons/trash-2";
-  import { onMount } from "svelte";
+  import { onMount, untrack } from "svelte";
   import { Button, Chip, SelectDropdown } from "@middleman/ui";
   import type { KataProjectRepoMapping } from "@middleman/ui/api/types";
   import { updateSettings } from "../../api/settings.js";
@@ -16,6 +16,7 @@
 
   interface Props {
     mappings?: KataProjectRepoMapping[] | undefined;
+    enabled?: boolean;
     onUpdate: (mappings: KataProjectRepoMapping[]) => void;
   }
 
@@ -26,14 +27,19 @@
     repoKey: string;
   }
 
+  type MappingRepoRef = Pick<
+    KataProjectMappingsResponse["targets"][number]["repo"],
+    "provider" | "platform_host" | "owner" | "name" | "repo_path"
+  >;
+
   interface RepoOption {
     key: string;
     label: string;
     displayName: string;
-    repo: KataProjectMappingsResponse["targets"][number]["repo"];
+    repo: MappingRepoRef;
   }
 
-  let { mappings, onUpdate }: Props = $props();
+  let { mappings, enabled = true, onUpdate }: Props = $props();
 
   const embedded = isEmbedded();
   let nextID = 0;
@@ -44,18 +50,36 @@
   let diagnostics = $state.raw<KataProjectMappingsResponse | null>(null);
   let diagnosticsLoading = $state(true);
   let diagnosticsError = $state<string | null>(null);
+  let diagnosticsEnabled = false;
+  let previousEnabled = false;
   // svelte-ignore state_referenced_locally
   let currentMappings = $state(normalizeMappings(mappings));
   // svelte-ignore state_referenced_locally
   let drafts = $state<MappingDraft[]>(draftsFromMappings(currentMappings));
 
   const repoOptions = $derived.by(() => {
-    const targets = (diagnostics?.targets ?? []).map((target) => ({
+    const targets: RepoOption[] = (diagnostics?.targets ?? []).map((target) => ({
       key: repoKey(target.repo.provider, target.repo.platform_host, target.repo.repo_path),
       label: `${target.display_name} · ${target.repo.repo_path}`,
       displayName: target.display_name,
       repo: target.repo,
     }));
+    for (const mapping of currentMappings) {
+      const key = repoKeyFromMapping(mapping);
+      if (targets.some((option) => option.key === key)) continue;
+      targets.push({
+        key,
+        label: `${mapping.repo_path} · unavailable`,
+        displayName: mapping.repo_path,
+        repo: {
+          provider: mapping.provider,
+          platform_host: mapping.platform_host,
+          owner: mapping.repo_path.slice(0, mapping.repo_path.lastIndexOf("/")),
+          name: mapping.repo_path.slice(mapping.repo_path.lastIndexOf("/") + 1),
+          repo_path: mapping.repo_path,
+        },
+      });
+    }
     return [...new Map(targets.map((option) => [option.key, option])).values()]
       .sort((left, right) => left.label.localeCompare(right.label));
   });
@@ -74,7 +98,22 @@
   const daemonOptions = $derived(daemons.map((daemon) => ({ value: daemon.id, label: daemon.id })));
 
   onMount(() => {
-    void loadDiagnostics();
+    diagnosticsEnabled = true;
+  });
+
+  $effect(() => {
+    if (!diagnosticsEnabled) return;
+    if (!enabled) {
+      diagnostics = null;
+      diagnosticsError = null;
+      diagnosticsLoading = false;
+      previousEnabled = false;
+      return;
+    }
+    if (!previousEnabled) {
+      previousEnabled = true;
+      untrack(() => void loadDiagnostics());
+    }
   });
 
   async function loadDiagnostics(daemonID = selectedDaemonID): Promise<void> {
@@ -159,14 +198,13 @@
   }
 
   function addMapping(): void {
-    const firstRepo = repoOptions[0]?.key ?? "";
     drafts = [
       ...drafts,
       {
         id: nextDraftID(),
         daemonID: "",
         projectUID: "",
-        repoKey: firstRepo,
+        repoKey: "",
       },
     ];
   }
@@ -186,7 +224,7 @@
         id: nextDraftID(),
         daemonID,
         projectUID: project.project_uid,
-        repoKey: repoOptionsByKey.has(mappedRepo) ? mappedRepo : (repoOptions[0]?.key ?? ""),
+        repoKey: repoOptionsByKey.has(mappedRepo) ? mappedRepo : "",
       },
     ];
   }
@@ -284,7 +322,7 @@
           <thead>
             <tr>
               <th scope="col">Kata project</th>
-              <th scope="col">Middleman project</th>
+              <th scope="col">Repository target</th>
               <th scope="col">Resolution</th>
               <th scope="col" aria-label="Mapping actions"></th>
             </tr>
@@ -304,7 +342,7 @@
                     <span>{inferredTarget.displayName}</span>
                     <span class="mapping-meta">{inferredTarget.repo.repo_path}</span>
                   {:else if project.repo}
-                    <span class="mapping-empty">No registered project</span>
+                    <span class="mapping-empty">No selectable repository</span>
                     <span class="mapping-meta">Inferred repository: {project.repo.repo_path}</span>
                   {:else}
                     <span class="mapping-empty">No inferred project</span>
@@ -356,10 +394,12 @@
       </Button>
     </div>
 
-    {#if repoOptions.length === 0}
-      <p class="empty-mappings">No registered Middleman projects with repository identity are available.</p>
-    {:else if drafts.length === 0}
-      <p class="empty-mappings">No manual Kata project mappings configured.</p>
+    {#if drafts.length === 0}
+      <p class="empty-mappings">
+        {repoOptions.length === 0
+          ? "No known repository targets are available."
+          : "No manual Kata project mappings configured."}
+      </p>
     {:else}
       <div class="mapping-table-wrap">
         <table class="mapping-table" aria-label="Kata project mappings">
@@ -373,7 +413,7 @@
             <tr>
               <th scope="col">Daemon</th>
               <th scope="col">Project UID</th>
-              <th scope="col">Middleman project</th>
+              <th scope="col">Repository target</th>
               <th scope="col" aria-label="Mapping actions"></th>
             </tr>
           </thead>
@@ -398,9 +438,9 @@
                 </td>
                 <td>
                   <SelectDropdown
-                    title={`Kata project ${label} Middleman project`}
+                    title={`Kata project ${label} repository target`}
                     value={draft.repoKey}
-                    options={repoSelectOptions}
+                    options={[{ value: "", label: "Select a repository" }, ...repoSelectOptions]}
                     onchange={(value) => { draft.repoKey = value; }}
                     disabled={embedded || saving}
                   />

--- a/frontend/src/lib/components/settings/KataProjectMappingsSettings.svelte
+++ b/frontend/src/lib/components/settings/KataProjectMappingsSettings.svelte
@@ -4,10 +4,7 @@
   import TrashIcon from "@lucide/svelte/icons/trash-2";
   import { onMount } from "svelte";
   import { Button, Chip, SelectDropdown } from "@middleman/ui";
-  import type {
-    ConfigRepo,
-    KataProjectRepoMapping,
-  } from "@middleman/ui/api/types";
+  import type { KataProjectRepoMapping } from "@middleman/ui/api/types";
   import { updateSettings } from "../../api/settings.js";
   import { fetchKataDaemons, type KataDaemonInfo } from "../../api/kata/daemons.js";
   import {
@@ -19,7 +16,6 @@
 
   interface Props {
     mappings?: KataProjectRepoMapping[] | undefined;
-    repos: ConfigRepo[];
     onUpdate: (mappings: KataProjectRepoMapping[]) => void;
   }
 
@@ -33,10 +29,11 @@
   interface RepoOption {
     key: string;
     label: string;
-    repo: ConfigRepo;
+    displayName: string;
+    repo: KataProjectMappingsResponse["targets"][number]["repo"];
   }
 
-  let { mappings, repos, onUpdate }: Props = $props();
+  let { mappings, onUpdate }: Props = $props();
 
   const embedded = isEmbedded();
   let nextID = 0;
@@ -53,28 +50,13 @@
   let drafts = $state<MappingDraft[]>(draftsFromMappings(currentMappings));
 
   const repoOptions = $derived.by(() => {
-    const configured = repos
-      .filter((repo) => !repo.is_glob)
-      .map((repo) => ({
-        key: repoKey(repo.provider, repo.platform_host, repo.repo_path),
-        label: repoLabel(repo),
-        repo,
-      }));
-    const effectiveRepos = (diagnostics?.projects ?? []).flatMap((project) => project.repo ? [project.repo] : []);
-    const discovered = [...(diagnostics?.repositories ?? []), ...effectiveRepos].map((repo) => ({
-      key: repoKey(repo.provider, repo.platform_host, repo.repo_path),
-      label: `${repo.provider} / ${repo.platform_host} / ${repo.repo_path}`,
-      repo: {
-        provider: repo.provider,
-        platform_host: repo.platform_host,
-        owner: repo.owner,
-        name: repo.name,
-        repo_path: repo.repo_path,
-        is_glob: false,
-        matched_repo_count: 1,
-      } satisfies ConfigRepo,
+    const targets = (diagnostics?.targets ?? []).map((target) => ({
+      key: repoKey(target.repo.provider, target.repo.platform_host, target.repo.repo_path),
+      label: `${target.display_name} · ${target.repo.repo_path}`,
+      displayName: target.display_name,
+      repo: target.repo,
     }));
-    return [...new Map([...configured, ...discovered].map((option) => [option.key, option])).values()]
+    return [...new Map(targets.map((option) => [option.key, option])).values()]
       .sort((left, right) => left.label.localeCompare(right.label));
   });
   const repoOptionsByKey = $derived.by(() => new Map(repoOptions.map((option) => [option.key, option])));
@@ -120,10 +102,6 @@
 
   function repoKey(provider: string, platformHost: string, repoPath: string): string {
     return `${provider}\u0000${platformHost}\u0000${repoPath}`;
-  }
-
-  function repoLabel(repo: ConfigRepo): string {
-    return `${repo.provider} / ${repo.platform_host} / ${repo.repo_path}`;
   }
 
   function repoKeyFromMapping(mapping: KataProjectRepoMapping): string {
@@ -306,24 +284,30 @@
           <thead>
             <tr>
               <th scope="col">Kata project</th>
-              <th scope="col">Repository</th>
+              <th scope="col">Middleman project</th>
               <th scope="col">Resolution</th>
               <th scope="col" aria-label="Mapping actions"></th>
             </tr>
           </thead>
           <tbody>
             {#each diagnostics.projects as project (project.project_uid)}
+              {@const inferredTarget = project.repo
+                ? repoOptionsByKey.get(repoKey(project.repo.provider, project.repo.platform_host, project.repo.repo_path))
+                : undefined}
               <tr>
                 <td>
                   <strong>{project.project_name || project.project_uid}</strong>
                   <span class="mapping-meta">{project.project_uid}</span>
                 </td>
                 <td>
-                  {#if project.repo}
-                    <span>{project.repo.repo_path}</span>
-                    <span class="mapping-meta">{project.repo.provider} / {project.repo.platform_host}</span>
+                  {#if inferredTarget}
+                    <span>{inferredTarget.displayName}</span>
+                    <span class="mapping-meta">{inferredTarget.repo.repo_path}</span>
+                  {:else if project.repo}
+                    <span class="mapping-empty">No registered project</span>
+                    <span class="mapping-meta">Inferred repository: {project.repo.repo_path}</span>
                   {:else}
-                    <span class="mapping-empty">No repository</span>
+                    <span class="mapping-empty">No inferred project</span>
                   {/if}
                 </td>
                 <td>
@@ -373,7 +357,7 @@
     </div>
 
     {#if repoOptions.length === 0}
-      <p class="empty-mappings">No watched repositories or registered projects are available.</p>
+      <p class="empty-mappings">No registered Middleman projects with repository identity are available.</p>
     {:else if drafts.length === 0}
       <p class="empty-mappings">No manual Kata project mappings configured.</p>
     {:else}
@@ -389,7 +373,7 @@
             <tr>
               <th scope="col">Daemon</th>
               <th scope="col">Project UID</th>
-              <th scope="col">Repository</th>
+              <th scope="col">Middleman project</th>
               <th scope="col" aria-label="Mapping actions"></th>
             </tr>
           </thead>
@@ -414,7 +398,7 @@
                 </td>
                 <td>
                   <SelectDropdown
-                    title={`Kata project ${label} repository`}
+                    title={`Kata project ${label} Middleman project`}
                     value={draft.repoKey}
                     options={repoSelectOptions}
                     onchange={(value) => { draft.repoKey = value; }}

--- a/frontend/src/lib/components/settings/KataProjectMappingsSettings.test.ts
+++ b/frontend/src/lib/components/settings/KataProjectMappingsSettings.test.ts
@@ -49,7 +49,17 @@ describe("KataProjectMappingsSettings", () => {
     });
 
     expect(screen.getByRole("button", { name: "Add mapping" })).toBeTruthy();
-    expect(screen.getByText("No registered Middleman projects with repository identity are available.")).toBeTruthy();
+    expect(screen.getByText("No known repository targets are available.")).toBeTruthy();
+  });
+
+  it("does not load diagnostics while Kata mode is disabled", async () => {
+    render(KataProjectMappingsSettings, {
+      props: { mappings: [], enabled: false, onUpdate: vi.fn() },
+    });
+
+    await Promise.resolve();
+    expect(mockFetchKataDaemons).not.toHaveBeenCalled();
+    expect(mockGetKataProjectMappings).not.toHaveBeenCalled();
   });
 
   it("shows the effective mapping and prefills a registered-project override", async () => {
@@ -74,7 +84,6 @@ describe("KataProjectMappingsSettings", () => {
       ],
       targets: [
         {
-          project_id: "project-middleman",
           display_name: "Middleman",
           repo: {
             provider: "github",
@@ -100,7 +109,7 @@ describe("KataProjectMappingsSettings", () => {
 
     expect((screen.getByLabelText("Kata project project-kata daemon ID") as HTMLInputElement).value).toBe("work");
     expect((screen.getByLabelText("Kata project project-kata UID") as HTMLInputElement).value).toBe("project-kata");
-    expect(screen.getByRole("combobox", { name: /project-kata Middleman project/ }).textContent).toContain("Middleman");
+    expect(screen.getByRole("combobox", { name: /project-kata repository target/ }).textContent).toContain("Middleman");
   });
 
   it("saves a Kata mapping to a selected known Middleman project", async () => {
@@ -119,7 +128,6 @@ describe("KataProjectMappingsSettings", () => {
       projects: [],
       targets: [
         {
-          project_id: "project-middleman",
           display_name: "Middleman",
           repo: {
             provider: "github",
@@ -152,8 +160,10 @@ describe("KataProjectMappingsSettings", () => {
       target: { value: "project-kata" },
     });
 
-    await fireEvent.click(screen.getByRole("combobox", { name: /Middleman project/ }));
-    expect(screen.getByRole("option", { name: "Middleman · kenn-io/middleman" })).toBeTruthy();
+    await fireEvent.click(screen.getByRole("combobox", { name: /repository target/ }));
+    const option = screen.getByRole("option", { name: "Middleman · kenn-io/middleman" });
+    expect(option).toBeTruthy();
+    await fireEvent.click(option);
 
     await fireEvent.click(screen.getByRole("button", { name: "Save Kata mappings" }));
 
@@ -161,5 +171,59 @@ describe("KataProjectMappingsSettings", () => {
       expect(mockUpdateSettings).toHaveBeenCalledWith({ kata_projects: savedMappings });
       expect(onUpdate).toHaveBeenCalledWith(savedMappings);
     });
+  });
+
+  it("requires an explicit repository choice when inference has no selectable target", async () => {
+    mockGetKataProjectMappings.mockResolvedValue({
+      daemon_id: "work",
+      projects: [
+        {
+          daemon_id: "work",
+          project_uid: "project-unmapped",
+          project_name: "Unmapped",
+          status: "unmapped",
+        },
+      ],
+      targets: [
+        {
+          display_name: "Unrelated",
+          repo: {
+            provider: "github",
+            platform_host: "github.com",
+            owner: "acme",
+            name: "other",
+            repo_path: "acme/other",
+            capabilities: defaultProviderCapabilities,
+          },
+        },
+      ],
+    });
+
+    render(KataProjectMappingsSettings, { props: { mappings: [], onUpdate: vi.fn() } });
+    await fireEvent.click(await screen.findByRole("button", { name: "Add override" }));
+
+    expect(screen.getByRole("combobox", { name: /project-unmapped repository target/ }).textContent).toContain(
+      "Select a repository",
+    );
+    expect((screen.getByRole("button", { name: "Save Kata mappings" }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("keeps an unavailable configured mapping visible so it can be removed", async () => {
+    render(KataProjectMappingsSettings, {
+      props: {
+        mappings: [
+          {
+            project_uid: "project-old",
+            provider: "github",
+            platform_host: "github.com",
+            repo_path: "acme/old",
+          },
+        ],
+        onUpdate: vi.fn(),
+      },
+    });
+
+    expect(screen.getByText("acme/old · unavailable")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Remove Kata project mapping project-old" })).toBeTruthy();
   });
 });

--- a/frontend/src/lib/components/settings/KataProjectMappingsSettings.test.ts
+++ b/frontend/src/lib/components/settings/KataProjectMappingsSettings.test.ts
@@ -1,9 +1,12 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/svelte";
-import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { defaultProviderCapabilities } from "../repositories/repoSummary.js";
 import KataProjectMappingsSettings from "./KataProjectMappingsSettings.svelte";
 
-const { mockUpdateSettings } = vi.hoisted(() => ({
+const { mockUpdateSettings, mockFetchKataDaemons, mockGetKataProjectMappings } = vi.hoisted(() => ({
   mockUpdateSettings: vi.fn(),
+  mockFetchKataDaemons: vi.fn(),
+  mockGetKataProjectMappings: vi.fn(),
 }));
 
 vi.mock("../../api/settings.js", () => ({
@@ -14,10 +17,27 @@ vi.mock("../../stores/embed-config.svelte.js", () => ({
   isEmbedded: () => false,
 }));
 
+vi.mock("../../api/kata/daemons.js", () => ({
+  fetchKataDaemons: mockFetchKataDaemons,
+}));
+
+vi.mock("../../api/kata/workspaces.js", () => ({
+  getKataProjectMappings: mockGetKataProjectMappings,
+}));
+
 describe("KataProjectMappingsSettings", () => {
+  beforeEach(() => {
+    mockFetchKataDaemons.mockResolvedValue([
+      { id: "work", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" },
+    ]);
+    mockGetKataProjectMappings.mockResolvedValue({ daemon_id: "work", projects: [], repositories: [] });
+  });
+
   afterEach(() => {
     cleanup();
     mockUpdateSettings.mockReset();
+    mockFetchKataDaemons.mockReset();
+    mockGetKataProjectMappings.mockReset();
   });
 
   it("treats missing Kata project mappings as empty settings", () => {
@@ -30,7 +50,54 @@ describe("KataProjectMappingsSettings", () => {
     });
 
     expect(screen.getByRole("button", { name: "Add mapping" })).toBeTruthy();
-    expect(screen.getByText("No exact watched repositories are configured.")).toBeTruthy();
+    expect(screen.getByText("No watched repositories or registered projects are available.")).toBeTruthy();
+  });
+
+  it("shows the effective mapping and prefills a registered-project override", async () => {
+    mockGetKataProjectMappings.mockResolvedValue({
+      daemon_id: "work",
+      projects: [
+        {
+          daemon_id: "work",
+          project_uid: "project-kata",
+          project_name: "Kata",
+          status: "mapped",
+          source: "registered_project",
+          repo: {
+            provider: "github",
+            platform_host: "github.com",
+            owner: "kenn-io",
+            name: "middleman",
+            repo_path: "kenn-io/middleman",
+            capabilities: defaultProviderCapabilities,
+          },
+        },
+      ],
+      repositories: [
+        {
+          provider: "github",
+          platform_host: "github.com",
+          owner: "kenn-io",
+          name: "middleman",
+          repo_path: "kenn-io/middleman",
+          capabilities: defaultProviderCapabilities,
+        },
+      ],
+    });
+
+    render(KataProjectMappingsSettings, {
+      props: { mappings: [], repos: [], onUpdate: vi.fn() },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Registered project")).toBeTruthy();
+      expect(screen.getByText("kenn-io/middleman")).toBeTruthy();
+    });
+    await fireEvent.click(screen.getByRole("button", { name: "Add override" }));
+
+    expect((screen.getByLabelText("Kata project project-kata daemon ID") as HTMLInputElement).value).toBe("work");
+    expect((screen.getByLabelText("Kata project project-kata UID") as HTMLInputElement).value).toBe("project-kata");
+    expect(screen.getByRole("combobox", { name: /project-kata repository/ })).toBeTruthy();
   });
 
   it("saves a Kata project mapping to an exact watched repository", async () => {

--- a/frontend/src/lib/components/settings/KataProjectMappingsSettings.test.ts
+++ b/frontend/src/lib/components/settings/KataProjectMappingsSettings.test.ts
@@ -30,7 +30,7 @@ describe("KataProjectMappingsSettings", () => {
     mockFetchKataDaemons.mockResolvedValue([
       { id: "work", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" },
     ]);
-    mockGetKataProjectMappings.mockResolvedValue({ daemon_id: "work", projects: [], repositories: [] });
+    mockGetKataProjectMappings.mockResolvedValue({ daemon_id: "work", projects: [], targets: [] });
   });
 
   afterEach(() => {
@@ -44,13 +44,12 @@ describe("KataProjectMappingsSettings", () => {
     render(KataProjectMappingsSettings, {
       props: {
         mappings: undefined,
-        repos: [],
         onUpdate: vi.fn(),
       },
     });
 
     expect(screen.getByRole("button", { name: "Add mapping" })).toBeTruthy();
-    expect(screen.getByText("No watched repositories or registered projects are available.")).toBeTruthy();
+    expect(screen.getByText("No registered Middleman projects with repository identity are available.")).toBeTruthy();
   });
 
   it("shows the effective mapping and prefills a registered-project override", async () => {
@@ -73,20 +72,24 @@ describe("KataProjectMappingsSettings", () => {
           },
         },
       ],
-      repositories: [
+      targets: [
         {
-          provider: "github",
-          platform_host: "github.com",
-          owner: "kenn-io",
-          name: "middleman",
-          repo_path: "kenn-io/middleman",
-          capabilities: defaultProviderCapabilities,
+          project_id: "project-middleman",
+          display_name: "Middleman",
+          repo: {
+            provider: "github",
+            platform_host: "github.com",
+            owner: "kenn-io",
+            name: "middleman",
+            repo_path: "kenn-io/middleman",
+            capabilities: defaultProviderCapabilities,
+          },
         },
       ],
     });
 
     render(KataProjectMappingsSettings, {
-      props: { mappings: [], repos: [], onUpdate: vi.fn() },
+      props: { mappings: [], onUpdate: vi.fn() },
     });
 
     await waitFor(() => {
@@ -97,10 +100,10 @@ describe("KataProjectMappingsSettings", () => {
 
     expect((screen.getByLabelText("Kata project project-kata daemon ID") as HTMLInputElement).value).toBe("work");
     expect((screen.getByLabelText("Kata project project-kata UID") as HTMLInputElement).value).toBe("project-kata");
-    expect(screen.getByRole("combobox", { name: /project-kata repository/ })).toBeTruthy();
+    expect(screen.getByRole("combobox", { name: /project-kata Middleman project/ }).textContent).toContain("Middleman");
   });
 
-  it("saves a Kata project mapping to an exact watched repository", async () => {
+  it("saves a Kata mapping to a selected known Middleman project", async () => {
     const savedMappings = [
       {
         daemon_id: "work",
@@ -111,35 +114,36 @@ describe("KataProjectMappingsSettings", () => {
       },
     ];
     mockUpdateSettings.mockResolvedValue({ kata_projects: savedMappings });
-    const onUpdate = vi.fn();
-
-    render(KataProjectMappingsSettings, {
-      props: {
-        mappings: [],
-        repos: [
-          {
+    mockGetKataProjectMappings.mockResolvedValue({
+      daemon_id: "work",
+      projects: [],
+      targets: [
+        {
+          project_id: "project-middleman",
+          display_name: "Middleman",
+          repo: {
             provider: "github",
             platform_host: "github.com",
             owner: "kenn-io",
             name: "middleman",
             repo_path: "kenn-io/middleman",
-            is_glob: false,
-            matched_repo_count: 1,
+            capabilities: defaultProviderCapabilities,
           },
-          {
-            provider: "github",
-            platform_host: "github.com",
-            owner: "kenn-io",
-            name: "*",
-            repo_path: "kenn-io/*",
-            is_glob: true,
-            matched_repo_count: 3,
-          },
-        ],
+        },
+      ],
+    });
+    const onUpdate = vi.fn();
+
+    render(KataProjectMappingsSettings, {
+      props: {
+        mappings: [],
         onUpdate,
       },
     });
 
+    await waitFor(() => {
+      expect((screen.getByRole("button", { name: "Add mapping" }) as HTMLButtonElement).disabled).toBe(false);
+    });
     await fireEvent.click(screen.getByRole("button", { name: "Add mapping" }));
     await fireEvent.input(screen.getByLabelText("Kata project mapping 1 daemon ID"), {
       target: { value: "work" },
@@ -148,9 +152,8 @@ describe("KataProjectMappingsSettings", () => {
       target: { value: "project-kata" },
     });
 
-    await fireEvent.click(screen.getByRole("combobox", { name: /repository/ }));
-    expect(screen.getByRole("option", { name: "github / github.com / kenn-io/middleman" })).toBeTruthy();
-    expect(screen.queryByRole("option", { name: "github / github.com / kenn-io/*" })).toBeNull();
+    await fireEvent.click(screen.getByRole("combobox", { name: /Middleman project/ }));
+    expect(screen.getByRole("option", { name: "Middleman · kenn-io/middleman" })).toBeTruthy();
 
     await fireEvent.click(screen.getByRole("button", { name: "Save Kata mappings" }));
 

--- a/frontend/src/lib/components/settings/SettingsPage.svelte
+++ b/frontend/src/lib/components/settings/SettingsPage.svelte
@@ -144,7 +144,6 @@
           {:else if meta.id === "settings-kata-projects"}
             <KataProjectMappingsSettings
               mappings={loaded.kata_projects}
-              repos={loaded.repos}
               onUpdate={(kata_projects) => {
                 settings = { ...settings!, kata_projects };
               }}

--- a/frontend/src/lib/components/settings/SettingsPage.svelte
+++ b/frontend/src/lib/components/settings/SettingsPage.svelte
@@ -14,112 +14,38 @@
   import FleetSettings from "./FleetSettings.svelte";
   import KataProjectMappingsSettings from "./KataProjectMappingsSettings.svelte";
   import PullRequestSettings from "./PullRequestSettings.svelte";
+  import { SETTINGS_PANELS, settingsPanelsForModes } from "./settingsPanels.js";
 
   // Switched-panel model on kit SettingsLayout: this list is the single
   // source of category order, sidebar labels, and per-panel section header
   // copy. The old scroll-spy page let the nav and section orders drift
   // apart; here they cannot.
-  interface SettingsPanelMeta {
-    id: string;
-    label: string;
-    title: string;
-    group: string;
-    description: string;
-    /** Extra search-only terms; never rendered. */
-    keywords: string;
-  }
-
-  const panels: SettingsPanelMeta[] = [
-    {
-      id: "settings-repositories",
-      label: "Repositories",
-      title: "Repositories",
-      group: "Providers",
-      description: "Tracked repositories and import tools",
-      keywords: "repos repositories providers github gitlab forgejo gitea import glob",
-    },
-    {
-      id: "settings-pull-requests",
-      label: "Pull requests",
-      title: "Pull request safeguards",
-      group: "Workflow",
-      description: "Merge safeguards for stacked branches",
-      keywords: "pull requests merge stack stacked branches safety",
-    },
-    {
-      id: "settings-activity",
-      label: "Activity",
-      title: "Activity feed defaults",
-      group: "Workflow",
-      description: "Default activity feed filters",
-      keywords: "activity feed defaults filters time range closed bots",
-    },
-    {
-      id: "settings-terminal",
-      label: "Terminal",
-      title: "Workspace terminal",
-      group: "Workspace",
-      description: "Workspace terminal rendering and behavior",
-      keywords: "workspace terminal font renderer cursor scrollback ligatures",
-    },
-    {
-      id: "settings-kata-projects",
-      label: "Kata mappings",
-      title: "Kata project mappings",
-      group: "Workspace",
-      description: "Kata project repository identity overrides",
-      keywords: "kata projects repositories mappings workspaces daemon project uid",
-    },
-    {
-      id: "settings-agents",
-      label: "Workspace agents",
-      title: "Workspace agents",
-      group: "Workspace",
-      description: "Agent commands available in workspaces",
-      keywords: "workspace agents codex claude gemini opencode aider binary arguments",
-    },
-    {
-      id: "settings-fleet",
-      label: "Fleet federation",
-      title: "Fleet federation",
-      group: "Workspace",
-      description: "Remote hosts and fleet membership",
-      keywords: "fleet federation remote hosts peers ssh http membership",
-    },
-    {
-      id: "settings-modes",
-      label: "Visible modes",
-      title: "Visible modes",
-      group: "Navigation",
-      description: "Modes shown in the app header",
-      keywords: "visible modes navigation tabs prs issues board reviews docs messages kata",
-    },
-  ];
-
   let searchQuery = $state("");
+  const { settings: settingsStore } = getStores();
+  let settings = $state<Settings | null>(null);
+  let loading = $state(true);
+  let error = $state<string | null>(null);
+  let active = $state(SETTINGS_PANELS[0]!.id);
 
   // The host owns search semantics: kit renders whatever category list it is
   // given, and its display falls back to the first visible category while the
   // bound `active` id is filtered out (the selection itself survives clearing
   // the query). kit renders group headings between runs in array order, so
-  // `panels` keeps each group's entries contiguous.
+  // `visiblePanels` keeps each group's entries contiguous.
+  const visiblePanels = $derived.by(() => {
+    const loaded = settings;
+    return loaded ? settingsPanelsForModes(loaded.modes?.kata === true) : SETTINGS_PANELS;
+  });
   const categories: SettingsCategory[] = $derived.by(() => {
     const query = searchQuery.trim().toLowerCase();
     const visible =
       query === ""
-        ? panels
-        : panels.filter((p) =>
+        ? visiblePanels
+        : visiblePanels.filter((p) =>
             `${p.label} ${p.group} ${p.description} ${p.keywords}`.toLowerCase().includes(query),
           );
     return visible.map((p) => ({ id: p.id, label: p.label, group: p.group, summary: p.description }));
   });
-
-  const { settings: settingsStore } = getStores();
-
-  let settings = $state<Settings | null>(null);
-  let loading = $state(true);
-  let error = $state<string | null>(null);
-  let active = $state(panels[0]!.id);
 
   onMount(() => {
     void loadSettings();
@@ -181,7 +107,7 @@
         <!-- Every panel stays mounted; only the active one is shown. Panel
              components keep unsaved edits in local draft state, so switching
              categories must hide, not unmount, or drafts are silently lost. -->
-        {#each panels as meta (meta.id)}
+        {#each visiblePanels as meta (meta.id)}
           <div class="settings-panel" hidden={meta.id !== activeId}>
             <SettingsSection title={meta.title} description={meta.description}>
               {#if meta.id === "settings-repositories"}

--- a/frontend/src/lib/components/settings/SettingsPage.svelte
+++ b/frontend/src/lib/components/settings/SettingsPage.svelte
@@ -107,8 +107,9 @@
         <!-- Every panel stays mounted; only the active one is shown. Panel
              components keep unsaved edits in local draft state, so switching
              categories must hide, not unmount, or drafts are silently lost. -->
-        {#each visiblePanels as meta (meta.id)}
-          <div class="settings-panel" hidden={meta.id !== activeId}>
+        {#each SETTINGS_PANELS as meta (meta.id)}
+          {@const panelVisible = visiblePanels.some((panel) => panel.id === meta.id)}
+          <div class="settings-panel" hidden={!panelVisible || meta.id !== activeId}>
             <SettingsSection title={meta.title} description={meta.description}>
               {#if meta.id === "settings-repositories"}
             <RepoSettings
@@ -144,6 +145,7 @@
           {:else if meta.id === "settings-kata-projects"}
             <KataProjectMappingsSettings
               mappings={loaded.kata_projects}
+              enabled={loaded.modes?.kata === true}
               onUpdate={(kata_projects) => {
                 settings = { ...settings!, kata_projects };
               }}

--- a/frontend/src/lib/components/settings/settingsPanels.test.ts
+++ b/frontend/src/lib/components/settings/settingsPanels.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vite-plus/test";
+import { settingsPanelsForModes } from "./settingsPanels.js";
+
+describe("settingsPanelsForModes", () => {
+  it("includes Kata mappings only while Kata mode is enabled", () => {
+    expect(settingsPanelsForModes(false).some((panel) => panel.id === "settings-kata-projects")).toBe(false);
+    expect(settingsPanelsForModes(true).some((panel) => panel.id === "settings-kata-projects")).toBe(true);
+  });
+});

--- a/frontend/src/lib/components/settings/settingsPanels.ts
+++ b/frontend/src/lib/components/settings/settingsPanels.ts
@@ -1,0 +1,82 @@
+export interface SettingsPanelMeta {
+  id: string;
+  label: string;
+  title: string;
+  group: string;
+  description: string;
+  /** Extra search-only terms; never rendered. */
+  keywords: string;
+  requiresKata?: boolean;
+}
+
+export const SETTINGS_PANELS: SettingsPanelMeta[] = [
+  {
+    id: "settings-repositories",
+    label: "Repositories",
+    title: "Repositories",
+    group: "Providers",
+    description: "Tracked repositories and import tools",
+    keywords: "repos repositories providers github gitlab forgejo gitea import glob",
+  },
+  {
+    id: "settings-pull-requests",
+    label: "Pull requests",
+    title: "Pull request safeguards",
+    group: "Workflow",
+    description: "Merge safeguards for stacked branches",
+    keywords: "pull requests merge stack stacked branches safety",
+  },
+  {
+    id: "settings-activity",
+    label: "Activity",
+    title: "Activity feed defaults",
+    group: "Workflow",
+    description: "Default activity feed filters",
+    keywords: "activity feed defaults filters time range closed bots",
+  },
+  {
+    id: "settings-terminal",
+    label: "Terminal",
+    title: "Workspace terminal",
+    group: "Workspace",
+    description: "Workspace terminal rendering and behavior",
+    keywords: "workspace terminal font renderer cursor scrollback ligatures",
+  },
+  {
+    id: "settings-kata-projects",
+    label: "Kata mappings",
+    title: "Kata project mappings",
+    group: "Workspace",
+    description: "Kata project repository identity overrides",
+    keywords: "kata projects repositories mappings workspaces daemon project uid",
+    requiresKata: true,
+  },
+  {
+    id: "settings-agents",
+    label: "Workspace agents",
+    title: "Workspace agents",
+    group: "Workspace",
+    description: "Agent commands available in workspaces",
+    keywords: "workspace agents codex claude gemini opencode aider binary arguments",
+  },
+  {
+    id: "settings-fleet",
+    label: "Fleet federation",
+    title: "Fleet federation",
+    group: "Workspace",
+    description: "Remote hosts and fleet membership",
+    keywords: "fleet federation remote hosts peers ssh http membership",
+  },
+  {
+    id: "settings-modes",
+    label: "Visible modes",
+    title: "Visible modes",
+    group: "Navigation",
+    description: "Modes shown in the app header",
+    keywords: "visible modes navigation tabs prs issues board reviews docs messages kata",
+  },
+];
+
+export function settingsPanelsForModes(kataEnabled: boolean): SettingsPanelMeta[] {
+  return SETTINGS_PANELS.filter((panel) => !panel.requiresKata || kataEnabled);
+}

--- a/frontend/src/test/mockApiFetch.ts
+++ b/frontend/src/test/mockApiFetch.ts
@@ -261,7 +261,7 @@ const syncStatus = {
   last_error: "",
 };
 
-const settings = {
+export const mockSettings = {
   repos: [
     {
       provider: "github",
@@ -282,6 +282,10 @@ const settings = {
   pull_requests: {
     allow_mid_stack_merges: false,
   },
+  modes: {
+    kata: true,
+  },
+  kata_projects: [],
   terminal: {
     font_family: "",
     font_size: 14,
@@ -672,7 +676,7 @@ export function createMockApiHandler(overrides: MockRouteOverride[] = []): MockA
     }
 
     if (method === "GET" && pathname === "/api/v1/settings") {
-      return jsonResponse(settings);
+      return jsonResponse(mockSettings);
     }
 
     if (method === "GET" && pathname === "/api/v1/rate-limits") {

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -1493,6 +1493,13 @@ type KataDaemonRosterResponse struct {
 	Source  *string               `json:"source,omitempty"`
 }
 
+// KataMappingTargetResponse defines model for KataMappingTargetResponse.
+type KataMappingTargetResponse struct {
+	DisplayName string          `json:"display_name"`
+	ProjectId   string          `json:"project_id"`
+	Repo        RepoRefResponse `json:"repo"`
+}
+
 // KataProjectMappingDiagnostic defines model for KataProjectMappingDiagnostic.
 type KataProjectMappingDiagnostic struct {
 	DaemonId    string           `json:"daemon_id"`
@@ -1506,10 +1513,10 @@ type KataProjectMappingDiagnostic struct {
 // KataProjectMappingsResponse defines model for KataProjectMappingsResponse.
 type KataProjectMappingsResponse struct {
 	// Schema A URL to the JSON Schema for this object.
-	Schema       *string                        `json:"$schema,omitempty"`
-	DaemonId     string                         `json:"daemon_id"`
-	Projects     []KataProjectMappingDiagnostic `json:"projects"`
-	Repositories []RepoRefResponse              `json:"repositories"`
+	Schema   *string                        `json:"$schema,omitempty"`
+	DaemonId string                         `json:"daemon_id"`
+	Projects []KataProjectMappingDiagnostic `json:"projects"`
+	Targets  []KataMappingTargetResponse    `json:"targets"`
 }
 
 // KataProjectRepoMapping defines model for KataProjectRepoMapping.

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -1493,6 +1493,25 @@ type KataDaemonRosterResponse struct {
 	Source  *string               `json:"source,omitempty"`
 }
 
+// KataProjectMappingDiagnostic defines model for KataProjectMappingDiagnostic.
+type KataProjectMappingDiagnostic struct {
+	DaemonId    string           `json:"daemon_id"`
+	ProjectName string           `json:"project_name"`
+	ProjectUid  string           `json:"project_uid"`
+	Repo        *RepoRefResponse `json:"repo,omitempty"`
+	Source      *string          `json:"source,omitempty"`
+	Status      string           `json:"status"`
+}
+
+// KataProjectMappingsResponse defines model for KataProjectMappingsResponse.
+type KataProjectMappingsResponse struct {
+	// Schema A URL to the JSON Schema for this object.
+	Schema       *string                        `json:"$schema,omitempty"`
+	DaemonId     string                         `json:"daemon_id"`
+	Projects     []KataProjectMappingDiagnostic `json:"projects"`
+	Repositories []RepoRefResponse              `json:"repositories"`
+}
+
 // KataProjectRepoMapping defines model for KataProjectRepoMapping.
 type KataProjectRepoMapping struct {
 	DaemonId     *string `json:"daemon_id,omitempty"`
@@ -3592,6 +3611,12 @@ type ListIssuesParams struct {
 	Offset   *int64  `form:"offset,omitempty" json:"offset,omitempty"`
 }
 
+// GetKataProjectMappingsParams defines parameters for GetKataProjectMappings.
+type GetKataProjectMappingsParams struct {
+	// XMiddlemanKataDaemon Kata daemon id; the effective default daemon when empty
+	XMiddlemanKataDaemon *string `json:"X-Middleman-Kata-Daemon,omitempty"`
+}
+
 // GetKataTaskDetailParams defines parameters for GetKataTaskDetail.
 type GetKataTaskDetailParams struct {
 	// XMiddlemanKataDaemon Kata daemon id; the effective default daemon when empty
@@ -4785,6 +4810,9 @@ type ClientInterface interface {
 
 	// ListKataDaemons request
 	ListKataDaemons(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetKataProjectMappings request
+	GetKataProjectMappings(ctx context.Context, params *GetKataProjectMappingsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetKataTaskDetail request
 	GetKataTaskDetail(ctx context.Context, issueUid string, params *GetKataTaskDetailParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -7618,6 +7646,18 @@ func (c *Client) CreateIssueWorkspace(ctx context.Context, provider string, owne
 
 func (c *Client) ListKataDaemons(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewListKataDaemonsRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetKataProjectMappings(ctx context.Context, params *GetKataProjectMappingsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetKataProjectMappingsRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -19139,6 +19179,48 @@ func NewListKataDaemonsRequest(server string) (*http.Request, error) {
 	return req, nil
 }
 
+// NewGetKataProjectMappingsRequest generates requests for GetKataProjectMappings
+func NewGetKataProjectMappingsRequest(server string, params *GetKataProjectMappingsParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/kata/project-mappings")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.XMiddlemanKataDaemon != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithOptions("simple", false, "X-Middleman-Kata-Daemon", *params.XMiddlemanKataDaemon, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationHeader, Type: "string", Format: ""})
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("X-Middleman-Kata-Daemon", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
 // NewGetKataTaskDetailRequest generates requests for GetKataTaskDetail
 func NewGetKataTaskDetailRequest(server string, issueUid string, params *GetKataTaskDetailParams) (*http.Request, error) {
 	var err error
@@ -27458,6 +27540,9 @@ type ClientWithResponsesInterface interface {
 	// ListKataDaemonsWithResponse request
 	ListKataDaemonsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListKataDaemonsResponse, error)
 
+	// GetKataProjectMappingsWithResponse request
+	GetKataProjectMappingsWithResponse(ctx context.Context, params *GetKataProjectMappingsParams, reqEditors ...RequestEditorFn) (*GetKataProjectMappingsResponse, error)
+
 	// GetKataTaskDetailWithResponse request
 	GetKataTaskDetailWithResponse(ctx context.Context, issueUid string, params *GetKataTaskDetailParams, reqEditors ...RequestEditorFn) (*GetKataTaskDetailResponse, error)
 
@@ -31146,6 +31231,29 @@ func (r ListKataDaemonsResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r ListKataDaemonsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetKataProjectMappingsResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *KataProjectMappingsResponse
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r GetKataProjectMappingsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetKataProjectMappingsResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -36005,6 +36113,15 @@ func (c *ClientWithResponses) ListKataDaemonsWithResponse(ctx context.Context, r
 		return nil, err
 	}
 	return ParseListKataDaemonsResponse(rsp)
+}
+
+// GetKataProjectMappingsWithResponse request returning *GetKataProjectMappingsResponse
+func (c *ClientWithResponses) GetKataProjectMappingsWithResponse(ctx context.Context, params *GetKataProjectMappingsParams, reqEditors ...RequestEditorFn) (*GetKataProjectMappingsResponse, error) {
+	rsp, err := c.GetKataProjectMappings(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetKataProjectMappingsResponse(rsp)
 }
 
 // GetKataTaskDetailWithResponse request returning *GetKataTaskDetailResponse
@@ -42093,6 +42210,39 @@ func ParseListKataDaemonsResponse(rsp *http.Response) (*ListKataDaemonsResponse,
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest KataDaemonRosterResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetKataProjectMappingsResponse parses an HTTP response from a GetKataProjectMappingsWithResponse call
+func ParseGetKataProjectMappingsResponse(rsp *http.Response) (*GetKataProjectMappingsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetKataProjectMappingsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest KataProjectMappingsResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -1496,7 +1496,6 @@ type KataDaemonRosterResponse struct {
 // KataMappingTargetResponse defines model for KataMappingTargetResponse.
 type KataMappingTargetResponse struct {
 	DisplayName string          `json:"display_name"`
-	ProjectId   string          `json:"project_id"`
 	Repo        RepoRefResponse `json:"repo"`
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1336,7 +1336,7 @@ func (c *Config) validate(skipAppCoverage bool) error {
 		}
 		seen[key] = display
 	}
-	if err := c.validateKataProjectRepoMappings(seen); err != nil {
+	if err := c.validateKataProjectRepoMappings(); err != nil {
 		return err
 	}
 
@@ -1971,7 +1971,7 @@ func kataProjectMappingKey(mapping KataProjectRepoMapping) string {
 	return strings.TrimSpace(mapping.DaemonID) + "\x00" + strings.TrimSpace(mapping.ProjectUID)
 }
 
-func (c *Config) validateKataProjectRepoMappings(configuredExact map[string]string) error {
+func (c *Config) validateKataProjectRepoMappings() error {
 	seen := make(map[string]struct{}, len(c.KataProjects))
 	for i := range c.KataProjects {
 		mapping := &c.KataProjects[i]
@@ -2017,13 +2017,6 @@ func (c *Config) validateKataProjectRepoMappings(configuredExact map[string]stri
 		}
 		seen[dupKey] = struct{}{}
 
-		if _, ok := configuredExact[repoIdentityKey(repo)]; !ok {
-			return fmt.Errorf(
-				"config: kata_projects[%d]: repo_path %q does not match a configured exact repo",
-				i,
-				mapping.RepoPath,
-			)
-		}
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2567,8 +2567,8 @@ repo_path = "acme/widget"
 	assert.Contains(t, err.Error(), "duplicate kata project mapping")
 }
 
-func TestKataProjectMappingsRejectUnconfiguredRepos(t *testing.T) {
-	_, err := Load(writeConfig(t, `
+func TestKataProjectMappingsAllowRegisteredProjectTargets(t *testing.T) {
+	cfg, err := Load(writeConfig(t, `
 [[repos]]
 owner = "acme"
 name = "widget"
@@ -2579,8 +2579,9 @@ provider = "github"
 platform_host = "github.com"
 repo_path = "acme/other"
 `))
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "does not match a configured exact repo")
+	require.NoError(t, err)
+	require.Len(t, cfg.KataProjects, 1)
+	assert.Equal(t, "acme/other", cfg.KataProjects[0].RepoPath)
 }
 
 func TestTerminalRendererRejectsInvalidValue(t *testing.T) {

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -5205,9 +5205,13 @@ func (s *Server) createWorkspaceProvider(
 }
 
 func (s *Server) runWorkspaceSetup(ws *workspace.Workspace) {
+	s.runWorkspaceSetupWithBasePath(ws, "")
+}
+
+func (s *Server) runWorkspaceSetupWithBasePath(ws *workspace.Workspace, basePath string) {
 	s.runBackground(func(bgCtx context.Context) {
 		for {
-			setupErr := s.workspaces.Setup(bgCtx, ws)
+			setupErr := s.workspaces.SetupWithWorktreeBasePath(bgCtx, ws, basePath)
 			summary, getErr := s.workspaces.GetSummary(
 				bgCtx, ws.ID,
 			)

--- a/internal/server/kata_workspace.go
+++ b/internal/server/kata_workspace.go
@@ -2,13 +2,16 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path"
 	"path/filepath"
 	"slices"
+	"sort"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -50,6 +53,36 @@ type kataResolvedWorkspaceRepo struct {
 	PlatformHost string
 	Owner        string
 	Name         string
+}
+
+type kataWorkspaceRepoResolution struct {
+	Target kataResolvedWorkspaceRepo
+	Status string
+	Source string
+}
+
+type kataProjectMappingDiagnostic struct {
+	DaemonID    string           `json:"daemon_id"`
+	ProjectUID  string           `json:"project_uid"`
+	ProjectName string           `json:"project_name"`
+	Status      string           `json:"status"`
+	Source      string           `json:"source,omitempty"`
+	Repo        *repoRefResponse `json:"repo,omitempty"`
+}
+
+type kataProjectMappingsInput struct {
+	DaemonID string `header:"X-Middleman-Kata-Daemon" doc:"Kata daemon id; the effective default daemon when empty"`
+}
+
+type kataProjectMappingsResponse struct {
+	DaemonID     string                         `json:"daemon_id"`
+	Projects     []kataProjectMappingDiagnostic `json:"projects" nullable:"false"`
+	Repositories []repoRefResponse              `json:"repositories" nullable:"false"`
+}
+
+type kataProjectMappingsOutput struct {
+	Vary string `header:"Vary"`
+	Body kataProjectMappingsResponse
 }
 
 func (body kataWorkspaceTaskRequest) metadata() (db.WorkspaceKataMetadata, error) {
@@ -211,6 +244,14 @@ func (s *Server) resolveKataWorkspaceRepo(
 	ctx context.Context,
 	metadata db.WorkspaceKataMetadata,
 ) (kataResolvedWorkspaceRepo, bool, error) {
+	resolution, err := s.resolveKataWorkspaceRepoResolution(ctx, metadata)
+	return resolution.Target, resolution.Status == "mapped", err
+}
+
+func (s *Server) resolveKataWorkspaceRepoResolution(
+	ctx context.Context,
+	metadata db.WorkspaceKataMetadata,
+) (kataWorkspaceRepoResolution, error) {
 	var repos []config.Repo
 	var mappings []config.KataProjectRepoMapping
 	if s.cfg != nil {
@@ -220,38 +261,111 @@ func (s *Server) resolveKataWorkspaceRepo(
 		s.cfgMu.Unlock()
 	}
 
-	if repo, ok := kataManualWorkspaceRepo(repos, mappings, metadata, true); ok {
-		return kataResolvedRepoFromConfig(repo), true, nil
+	projects, err := s.db.ListProjects(ctx)
+	if err != nil {
+		return kataWorkspaceRepoResolution{}, fmt.Errorf("list registered projects for Kata workspace: %w", err)
 	}
-	if repo, ok := kataManualWorkspaceRepo(repos, mappings, metadata, false); ok {
-		return kataResolvedRepoFromConfig(repo), true, nil
+	for _, candidate := range []struct {
+		daemonSpecific bool
+		source         string
+	}{{true, "manual_daemon"}, {false, "manual_global"}} {
+		target, found, valid, err := s.kataManualWorkspaceTarget(
+			ctx, repos, projects, mappings, metadata, candidate.daemonSpecific,
+		)
+		if err != nil {
+			return kataWorkspaceRepoResolution{}, err
+		}
+		if found {
+			if !valid {
+				return kataWorkspaceRepoResolution{Status: "invalid", Source: candidate.source}, nil
+			}
+			return kataWorkspaceRepoResolution{Target: target, Status: "mapped", Source: candidate.source}, nil
+		}
 	}
 	repo, matches := kataAutomaticWorkspaceRepo(repos, metadata.ProjectUID, metadata.ProjectName)
 	if matches == 1 {
-		return kataResolvedRepoFromConfig(repo), true, nil
+		return kataWorkspaceRepoResolution{Target: kataResolvedRepoFromConfig(repo), Status: "mapped", Source: "configured_clone"}, nil
 	}
 	if matches > 1 {
-		return kataResolvedWorkspaceRepo{}, false, nil
-	}
-	projects, err := s.db.ListProjects(ctx)
-	if err != nil {
-		return kataResolvedWorkspaceRepo{}, false, fmt.Errorf("list registered projects for Kata workspace: %w", err)
+		return kataWorkspaceRepoResolution{Status: "ambiguous", Source: "configured_clone"}, nil
 	}
 	if target, matches := kataAutomaticWorkspaceRepoByRegisteredProjects(
 		projects, metadata.ProjectUID, metadata.ProjectName,
 	); matches == 1 {
-		return target, true, nil
+		return kataWorkspaceRepoResolution{Target: target, Status: "mapped", Source: "registered_project"}, nil
 	} else if matches > 1 {
-		return kataResolvedWorkspaceRepo{}, false, nil
+		return kataWorkspaceRepoResolution{Status: "ambiguous", Source: "registered_project"}, nil
 	}
 	tracked, err := s.db.ListRepos(ctx)
 	if err != nil {
-		return kataResolvedWorkspaceRepo{}, false, fmt.Errorf("list tracked repos for Kata workspace: %w", err)
+		return kataWorkspaceRepoResolution{}, fmt.Errorf("list tracked repos for Kata workspace: %w", err)
 	}
 	if target, matches := kataAutomaticWorkspaceRepoByTrackedRepos(repos, tracked, metadata.ProjectName); matches == 1 {
-		return target, true, nil
+		return kataWorkspaceRepoResolution{Target: target, Status: "mapped", Source: "tracked_repo"}, nil
+	} else if matches > 1 {
+		return kataWorkspaceRepoResolution{Status: "ambiguous", Source: "tracked_repo"}, nil
 	}
-	return kataResolvedWorkspaceRepo{}, false, nil
+	return kataWorkspaceRepoResolution{Status: "unmapped"}, nil
+}
+
+func (s *Server) kataManualWorkspaceTarget(
+	ctx context.Context,
+	repos []config.Repo,
+	projects []db.Project,
+	mappings []config.KataProjectRepoMapping,
+	metadata db.WorkspaceKataMetadata,
+	daemonSpecific bool,
+) (kataResolvedWorkspaceRepo, bool, bool, error) {
+	for _, mapping := range mappings {
+		if mapping.ProjectUID != metadata.ProjectUID {
+			continue
+		}
+		if daemonSpecific {
+			if mapping.DaemonID == "" || mapping.DaemonID != metadata.DaemonID {
+				continue
+			}
+		} else if mapping.DaemonID != "" {
+			continue
+		}
+		target, ok := kataResolvedRepoFromMapping(mapping)
+		if !ok {
+			return kataResolvedWorkspaceRepo{}, true, false, nil
+		}
+		for _, repo := range repos {
+			if !repo.HasNameGlob() && kataMappingMatchesRepo(mapping, repo) {
+				return target, true, true, nil
+			}
+		}
+		for _, project := range projects {
+			if project.IsStale || project.PlatformIdentity == nil {
+				continue
+			}
+			if kataResolvedRepoKey(kataResolvedRepoFromProject(project)) == kataResolvedRepoKey(target) {
+				return target, true, true, nil
+			}
+		}
+		repo, err := s.db.GetRepoByIdentity(ctx, db.RepoIdentity{
+			Platform: target.Provider, PlatformHost: target.PlatformHost,
+			Owner: target.Owner, Name: target.Name,
+		})
+		if err != nil {
+			return kataResolvedWorkspaceRepo{}, false, false, err
+		}
+		return target, true, repo != nil, nil
+	}
+	return kataResolvedWorkspaceRepo{}, false, false, nil
+}
+
+func kataResolvedRepoFromMapping(mapping config.KataProjectRepoMapping) (kataResolvedWorkspaceRepo, bool) {
+	repoPath := strings.Trim(strings.TrimSpace(mapping.RepoPath), "/")
+	cut := strings.LastIndex(repoPath, "/")
+	if cut <= 0 || cut == len(repoPath)-1 {
+		return kataResolvedWorkspaceRepo{}, false
+	}
+	return kataResolvedWorkspaceRepo{
+		Provider: mapping.Provider, PlatformHost: mapping.PlatformHost,
+		Owner: repoPath[:cut], Name: repoPath[cut+1:],
+	}, true
 }
 
 func kataAutomaticWorkspaceRepoByRegisteredProjects(
@@ -314,32 +428,6 @@ func kataResolvedRepoKey(repo kataResolvedWorkspaceRepo) string {
 		strings.ToLower(repo.PlatformHost) + "\x00" +
 		strings.ToLower(repo.Owner) + "\x00" +
 		strings.ToLower(repo.Name)
-}
-
-func kataManualWorkspaceRepo(
-	repos []config.Repo,
-	mappings []config.KataProjectRepoMapping,
-	metadata db.WorkspaceKataMetadata,
-	daemonSpecific bool,
-) (config.Repo, bool) {
-	for _, mapping := range mappings {
-		if mapping.ProjectUID != metadata.ProjectUID {
-			continue
-		}
-		if daemonSpecific {
-			if mapping.DaemonID == "" || mapping.DaemonID != metadata.DaemonID {
-				continue
-			}
-		} else if mapping.DaemonID != "" {
-			continue
-		}
-		for _, repo := range repos {
-			if kataMappingMatchesRepo(mapping, repo) {
-				return repo, true
-			}
-		}
-	}
-	return config.Repo{}, false
 }
 
 func kataMappingMatchesRepo(mapping config.KataProjectRepoMapping, repo config.Repo) bool {
@@ -579,9 +667,136 @@ func kataResolvedRepoFromProject(project db.Project) kataResolvedWorkspaceRepo {
 	}
 }
 
+func (s *Server) getKataProjectMappings(
+	ctx context.Context,
+	input *kataProjectMappingsInput,
+) (out *kataProjectMappingsOutput, err error) {
+	defer func() {
+		if err != nil {
+			err = huma.ErrorWithHeaders(err, http.Header{"Vary": []string{kataDaemonHeaderName}})
+		}
+	}()
+	daemon, problem := selectKataDaemonForID(input.DaemonID)
+	if problem != nil {
+		return nil, problem
+	}
+	client, baseURL, err := kataDaemonHTTPClient(daemon)
+	if err != nil {
+		return nil, problemBadRequest("", "invalid Kata daemon target", map[string]any{"daemon": daemon.ID})
+	}
+	ctx, cancel := context.WithTimeout(ctx, kataDaemonReadTimeout)
+	defer cancel()
+	result := kataDaemonGet(ctx, client, daemon, baseURL+"/api/v1/projects")
+	if result.err != nil || result.status < http.StatusOK || result.status >= http.StatusMultipleChoices {
+		return nil, newProblem(http.StatusBadGateway, CodeUpstreamError, "Kata daemon projects read failed", map[string]any{"daemon": daemon.ID})
+	}
+	var payload struct {
+		Projects []struct {
+			UID  string `json:"uid"`
+			Name string `json:"name"`
+		} `json:"projects"`
+	}
+	if err := json.Unmarshal(result.body, &payload); err != nil {
+		return nil, newProblem(http.StatusBadGateway, CodeUpstreamError, "Kata daemon returned an unexpected projects payload", map[string]any{"daemon": daemon.ID})
+	}
+	out = &kataProjectMappingsOutput{Vary: kataDaemonHeaderName}
+	out.Body.DaemonID = daemon.ID
+	out.Body.Projects = make([]kataProjectMappingDiagnostic, 0, len(payload.Projects))
+	for _, project := range payload.Projects {
+		uid := strings.TrimSpace(project.UID)
+		if uid == "" {
+			continue
+		}
+		resolution, err := s.resolveKataWorkspaceRepoResolution(ctx, db.WorkspaceKataMetadata{
+			DaemonID: daemon.ID, ProjectUID: uid, ProjectName: strings.TrimSpace(project.Name),
+		})
+		if err != nil {
+			return nil, problemInternal("resolve Kata project mapping: " + err.Error())
+		}
+		diagnostic := kataProjectMappingDiagnostic{
+			DaemonID: daemon.ID, ProjectUID: uid, ProjectName: strings.TrimSpace(project.Name),
+			Status: resolution.Status, Source: resolution.Source,
+		}
+		if resolution.Status == "mapped" {
+			repo := s.repoRefFromParts(
+				resolution.Target.Provider, resolution.Target.PlatformHost,
+				resolution.Target.Owner, resolution.Target.Name,
+			)
+			diagnostic.Repo = &repo
+		}
+		out.Body.Projects = append(out.Body.Projects, diagnostic)
+	}
+	sort.Slice(out.Body.Projects, func(i, j int) bool {
+		return strings.ToLower(out.Body.Projects[i].ProjectName) < strings.ToLower(out.Body.Projects[j].ProjectName)
+	})
+	out.Body.Repositories, err = s.kataMappingRepositories(ctx)
+	if err != nil {
+		return nil, problemInternal("list Kata mapping repositories: " + err.Error())
+	}
+	return out, nil
+}
+
+func (s *Server) kataMappingRepositories(ctx context.Context) ([]repoRefResponse, error) {
+	seen := make(map[string]repoRefResponse)
+	var configured []config.Repo
+	if s.cfg != nil {
+		s.cfgMu.Lock()
+		configured = slices.Clone(s.cfg.Repos)
+		s.cfgMu.Unlock()
+		for _, repo := range configured {
+			if repo.HasNameGlob() {
+				continue
+			}
+			target := kataResolvedRepoFromConfig(repo)
+			seen[kataResolvedRepoKey(target)] = s.repoRefFromParts(
+				target.Provider, target.PlatformHost, target.Owner, target.Name,
+			)
+		}
+	}
+	tracked, err := s.db.ListRepos(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, repo := range tracked {
+		if !kataTrackedRepoMatchesAnyConfig(repo, configured) {
+			continue
+		}
+		target := kataResolvedRepoFromDB(repo)
+		seen[kataResolvedRepoKey(target)] = s.repoRefFromParts(
+			target.Provider, target.PlatformHost, target.Owner, target.Name,
+		)
+	}
+	projects, err := s.db.ListProjects(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, project := range projects {
+		if project.IsStale || project.PlatformIdentity == nil {
+			continue
+		}
+		target := kataResolvedRepoFromProject(project)
+		seen[kataResolvedRepoKey(target)] = s.repoRefFromParts(
+			target.Provider, target.PlatformHost, target.Owner, target.Name,
+		)
+	}
+	result := make([]repoRefResponse, 0, len(seen))
+	for _, repo := range seen {
+		result = append(result, repo)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].RepoPath < result[j].RepoPath })
+	return result, nil
+}
+
 const httpStatusAccepted = 202
 
 func registerKataWorkspaceAPI(api huma.API, s *Server) {
+	huma.Register(api, huma.Operation{
+		OperationID: "get-kata-project-mappings",
+		Method:      "GET",
+		Path:        "/kata/project-mappings",
+		Summary:     "Inspect effective Kata project repository mappings",
+		Tags:        []string{"Kata"},
+	}, s.getKataProjectMappings)
 	huma.Register(api, huma.Operation{
 		OperationID: "get-kata-task-detail",
 		Method:      "GET",

--- a/internal/server/kata_workspace.go
+++ b/internal/server/kata_workspace.go
@@ -211,13 +211,14 @@ func (s *Server) resolveKataWorkspaceRepo(
 	ctx context.Context,
 	metadata db.WorkspaceKataMetadata,
 ) (kataResolvedWorkspaceRepo, bool, error) {
-	if s.cfg == nil {
-		return kataResolvedWorkspaceRepo{}, false, nil
+	var repos []config.Repo
+	var mappings []config.KataProjectRepoMapping
+	if s.cfg != nil {
+		s.cfgMu.Lock()
+		repos = slices.Clone(s.cfg.Repos)
+		mappings = slices.Clone(s.cfg.KataProjects)
+		s.cfgMu.Unlock()
 	}
-	s.cfgMu.Lock()
-	repos := slices.Clone(s.cfg.Repos)
-	mappings := slices.Clone(s.cfg.KataProjects)
-	s.cfgMu.Unlock()
 
 	if repo, ok := kataManualWorkspaceRepo(repos, mappings, metadata, true); ok {
 		return kataResolvedRepoFromConfig(repo), true, nil
@@ -232,6 +233,17 @@ func (s *Server) resolveKataWorkspaceRepo(
 	if matches > 1 {
 		return kataResolvedWorkspaceRepo{}, false, nil
 	}
+	projects, err := s.db.ListProjects(ctx)
+	if err != nil {
+		return kataResolvedWorkspaceRepo{}, false, fmt.Errorf("list registered projects for Kata workspace: %w", err)
+	}
+	if target, matches := kataAutomaticWorkspaceRepoByRegisteredProjects(
+		projects, metadata.ProjectUID, metadata.ProjectName,
+	); matches == 1 {
+		return target, true, nil
+	} else if matches > 1 {
+		return kataResolvedWorkspaceRepo{}, false, nil
+	}
 	tracked, err := s.db.ListRepos(ctx)
 	if err != nil {
 		return kataResolvedWorkspaceRepo{}, false, fmt.Errorf("list tracked repos for Kata workspace: %w", err)
@@ -240,6 +252,68 @@ func (s *Server) resolveKataWorkspaceRepo(
 		return target, true, nil
 	}
 	return kataResolvedWorkspaceRepo{}, false, nil
+}
+
+func kataAutomaticWorkspaceRepoByRegisteredProjects(
+	projects []db.Project,
+	projectUID string,
+	projectName string,
+) (kataResolvedWorkspaceRepo, int) {
+	if target, matches := kataRegisteredProjectRepoMatches(projects, func(project db.Project) bool {
+		metadata, ok := readKataProjectTOML(project.LocalPath)
+		return ok && metadata.matchesProjectUID(projectUID)
+	}); matches != 0 {
+		return target, matches
+	}
+
+	name := strings.TrimSpace(projectName)
+	if name == "" {
+		return kataResolvedWorkspaceRepo{}, 0
+	}
+	if target, matches := kataRegisteredProjectRepoMatches(projects, func(project db.Project) bool {
+		metadata, ok := readKataProjectTOML(project.LocalPath)
+		return ok && !metadata.hasIdentifier() && strings.EqualFold(metadata.Name, name)
+	}); matches != 0 {
+		return target, matches
+	}
+
+	return kataRegisteredProjectRepoMatches(projects, func(project db.Project) bool {
+		if metadata, ok := readKataProjectTOML(project.LocalPath); ok && metadata.hasAnyProjectMetadata() {
+			return false
+		}
+		identity := project.PlatformIdentity
+		return strings.EqualFold(project.DisplayName, name) ||
+			strings.EqualFold(identity.Name, name) ||
+			strings.EqualFold(identity.Owner+"/"+identity.Name, name)
+	})
+}
+
+func kataRegisteredProjectRepoMatches(
+	projects []db.Project,
+	matches func(db.Project) bool,
+) (kataResolvedWorkspaceRepo, int) {
+	matched := make(map[string]kataResolvedWorkspaceRepo)
+	for _, project := range projects {
+		if project.IsStale || project.PlatformIdentity == nil || !matches(project) {
+			continue
+		}
+		target := kataResolvedRepoFromProject(project)
+		matched[kataResolvedRepoKey(target)] = target
+	}
+	if len(matched) != 1 {
+		return kataResolvedWorkspaceRepo{}, len(matched)
+	}
+	for _, target := range matched {
+		return target, 1
+	}
+	return kataResolvedWorkspaceRepo{}, 0
+}
+
+func kataResolvedRepoKey(repo kataResolvedWorkspaceRepo) string {
+	return strings.ToLower(repo.Provider) + "\x00" +
+		strings.ToLower(repo.PlatformHost) + "\x00" +
+		strings.ToLower(repo.Owner) + "\x00" +
+		strings.ToLower(repo.Name)
 }
 
 func kataManualWorkspaceRepo(
@@ -492,6 +566,16 @@ func kataResolvedRepoFromDB(repo db.Repo) kataResolvedWorkspaceRepo {
 		PlatformHost: repo.PlatformHost,
 		Owner:        repo.Owner,
 		Name:         repo.Name,
+	}
+}
+
+func kataResolvedRepoFromProject(project db.Project) kataResolvedWorkspaceRepo {
+	identity := project.PlatformIdentity
+	return kataResolvedWorkspaceRepo{
+		Provider:     identity.Platform,
+		PlatformHost: identity.Host,
+		Owner:        identity.Owner,
+		Name:         identity.Name,
 	}
 }
 

--- a/internal/server/kata_workspace.go
+++ b/internal/server/kata_workspace.go
@@ -700,9 +700,9 @@ func (s *Server) getKataProjectMappings(
 	if err != nil {
 		return nil, problemBadRequest("", "invalid Kata daemon target", map[string]any{"daemon": daemon.ID})
 	}
-	ctx, cancel := context.WithTimeout(ctx, kataDaemonReadTimeout)
-	defer cancel()
-	result := kataDaemonGet(ctx, client, daemon, baseURL+"/api/v1/projects")
+	upstreamCtx, cancel := context.WithTimeout(ctx, kataDaemonReadTimeout)
+	result := kataDaemonGet(upstreamCtx, client, daemon, baseURL+"/api/v1/projects")
+	cancel()
 	if result.err != nil || result.status < http.StatusOK || result.status >= http.StatusMultipleChoices {
 		return nil, newProblem(http.StatusBadGateway, CodeUpstreamError, "Kata daemon projects read failed", map[string]any{"daemon": daemon.ID})
 	}

--- a/internal/server/kata_workspace.go
+++ b/internal/server/kata_workspace.go
@@ -53,6 +53,7 @@ type kataResolvedWorkspaceRepo struct {
 	PlatformHost string
 	Owner        string
 	Name         string
+	BasePath     string
 }
 
 type kataWorkspaceRepoResolution struct {
@@ -81,7 +82,6 @@ type kataProjectMappingsResponse struct {
 }
 
 type kataMappingTargetResponse struct {
-	ProjectID   string          `json:"project_id"`
 	DisplayName string          `json:"display_name"`
 	Repo        repoRefResponse `json:"repo"`
 }
@@ -165,11 +165,12 @@ func (s *Server) createKataWorkspace(
 	if err != nil {
 		return nil, err
 	}
-	target, ok, err := s.resolveKataWorkspaceRepo(ctx, metadata)
+	resolution, err := s.resolveKataWorkspaceRepoResolution(ctx, metadata)
 	if err != nil {
 		return nil, err
 	}
-	if !ok {
+	target := resolution.Target
+	if resolution.Status != "mapped" {
 		return nil, problemNotFound(
 			CodeNotFound,
 			"no repository mapping for Kata project",
@@ -226,7 +227,7 @@ func (s *Server) createKataWorkspace(
 		return nil, problemInternal("create Kata workspace: " + err.Error())
 	}
 
-	s.runWorkspaceSetup(ws)
+	s.runWorkspaceSetupWithBasePath(ws, target.BasePath)
 	return s.kataWorkspaceCreateOutput(ctx, ws.ID)
 }
 
@@ -339,16 +340,23 @@ func (s *Server) kataManualWorkspaceTarget(
 		}
 		for _, repo := range repos {
 			if !repo.HasNameGlob() && kataMappingMatchesRepo(mapping, repo) {
-				return target, true, true, nil
+				return kataResolvedRepoFromConfig(repo), true, true, nil
 			}
 		}
+		var registered []kataResolvedWorkspaceRepo
 		for _, project := range projects {
 			if project.IsStale || project.PlatformIdentity == nil {
 				continue
 			}
 			if kataResolvedRepoKey(kataResolvedRepoFromProject(project)) == kataResolvedRepoKey(target) {
-				return target, true, true, nil
+				registered = append(registered, kataResolvedRepoFromProject(project))
 			}
+		}
+		if len(registered) == 1 {
+			return registered[0], true, true, nil
+		}
+		if len(registered) > 1 {
+			return kataResolvedWorkspaceRepo{}, true, false, nil
 		}
 		repo, err := s.db.GetRepoByIdentity(ctx, db.RepoIdentity{
 			Platform: target.Provider, PlatformHost: target.PlatformHost,
@@ -357,7 +365,7 @@ func (s *Server) kataManualWorkspaceTarget(
 		if err != nil {
 			return kataResolvedWorkspaceRepo{}, false, false, err
 		}
-		return target, true, repo != nil, nil
+		return target, true, repo != nil && kataTrackedRepoMatchesAnyConfig(*repo, repos), nil
 	}
 	return kataResolvedWorkspaceRepo{}, false, false, nil
 }
@@ -418,7 +426,7 @@ func kataRegisteredProjectRepoMatches(
 			continue
 		}
 		target := kataResolvedRepoFromProject(project)
-		matched[kataResolvedRepoKey(target)] = target
+		matched[kataResolvedRepoKey(target)+"\x00"+filepath.Clean(project.LocalPath)] = target
 	}
 	if len(matched) != 1 {
 		return kataResolvedWorkspaceRepo{}, len(matched)
@@ -651,6 +659,7 @@ func kataResolvedRepoFromConfig(repo config.Repo) kataResolvedWorkspaceRepo {
 		PlatformHost: repo.PlatformHostOrDefault(),
 		Owner:        repo.Owner,
 		Name:         repo.Name,
+		BasePath:     repo.WorktreeBasePath,
 	}
 }
 
@@ -670,6 +679,7 @@ func kataResolvedRepoFromProject(project db.Project) kataResolvedWorkspaceRepo {
 		PlatformHost: identity.Host,
 		Owner:        identity.Owner,
 		Name:         identity.Name,
+		BasePath:     project.LocalPath,
 	}
 }
 
@@ -743,23 +753,66 @@ func (s *Server) getKataProjectMappings(
 }
 
 func (s *Server) kataMappingTargets(ctx context.Context) ([]kataMappingTargetResponse, error) {
+	seen := make(map[string]kataMappingTargetResponse)
+	var configured []config.Repo
+	if s.cfg != nil {
+		s.cfgMu.Lock()
+		configured = slices.Clone(s.cfg.Repos)
+		s.cfgMu.Unlock()
+	}
+	for _, repo := range configured {
+		if repo.HasNameGlob() {
+			continue
+		}
+		target := kataResolvedRepoFromConfig(repo)
+		seen[kataResolvedRepoKey(target)] = kataMappingTargetResponse{
+			DisplayName: configRepoPath(repo),
+			Repo:        s.repoRefFromParts(target.Provider, target.PlatformHost, target.Owner, target.Name),
+		}
+	}
+	tracked, err := s.db.ListRepos(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, repo := range tracked {
+		if !kataTrackedRepoMatchesAnyConfig(repo, configured) {
+			continue
+		}
+		target := kataResolvedRepoFromDB(repo)
+		key := kataResolvedRepoKey(target)
+		if _, exists := seen[key]; !exists {
+			seen[key] = kataMappingTargetResponse{
+				DisplayName: kataTrackedRepoPath(repo),
+				Repo:        s.repoRefFromParts(target.Provider, target.PlatformHost, target.Owner, target.Name),
+			}
+		}
+	}
 	projects, err := s.db.ListProjects(ctx)
 	if err != nil {
 		return nil, err
 	}
-	result := make([]kataMappingTargetResponse, 0, len(projects))
 	for _, project := range projects {
 		if project.IsStale || project.PlatformIdentity == nil {
 			continue
 		}
 		target := kataResolvedRepoFromProject(project)
-		result = append(result, kataMappingTargetResponse{
-			ProjectID: project.ID, DisplayName: project.DisplayName,
-			Repo: s.repoRefFromParts(target.Provider, target.PlatformHost, target.Owner, target.Name),
-		})
+		key := kataResolvedRepoKey(target)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = kataMappingTargetResponse{
+			DisplayName: project.DisplayName,
+			Repo:        s.repoRefFromParts(target.Provider, target.PlatformHost, target.Owner, target.Name),
+		}
+	}
+	result := make([]kataMappingTargetResponse, 0, len(seen))
+	for _, target := range seen {
+		result = append(result, target)
 	}
 	sort.Slice(result, func(i, j int) bool {
-		return strings.ToLower(result[i].DisplayName) < strings.ToLower(result[j].DisplayName)
+		left := strings.ToLower(result[i].DisplayName) + "\x00" + result[i].Repo.RepoPath
+		right := strings.ToLower(result[j].DisplayName) + "\x00" + result[j].Repo.RepoPath
+		return left < right
 	})
 	return result, nil
 }

--- a/internal/server/kata_workspace.go
+++ b/internal/server/kata_workspace.go
@@ -75,9 +75,15 @@ type kataProjectMappingsInput struct {
 }
 
 type kataProjectMappingsResponse struct {
-	DaemonID     string                         `json:"daemon_id"`
-	Projects     []kataProjectMappingDiagnostic `json:"projects" nullable:"false"`
-	Repositories []repoRefResponse              `json:"repositories" nullable:"false"`
+	DaemonID string                         `json:"daemon_id"`
+	Projects []kataProjectMappingDiagnostic `json:"projects" nullable:"false"`
+	Targets  []kataMappingTargetResponse    `json:"targets" nullable:"false"`
+}
+
+type kataMappingTargetResponse struct {
+	ProjectID   string          `json:"project_id"`
+	DisplayName string          `json:"display_name"`
+	Repo        repoRefResponse `json:"repo"`
 }
 
 type kataProjectMappingsOutput struct {
@@ -729,61 +735,32 @@ func (s *Server) getKataProjectMappings(
 	sort.Slice(out.Body.Projects, func(i, j int) bool {
 		return strings.ToLower(out.Body.Projects[i].ProjectName) < strings.ToLower(out.Body.Projects[j].ProjectName)
 	})
-	out.Body.Repositories, err = s.kataMappingRepositories(ctx)
+	out.Body.Targets, err = s.kataMappingTargets(ctx)
 	if err != nil {
-		return nil, problemInternal("list Kata mapping repositories: " + err.Error())
+		return nil, problemInternal("list Kata mapping targets: " + err.Error())
 	}
 	return out, nil
 }
 
-func (s *Server) kataMappingRepositories(ctx context.Context) ([]repoRefResponse, error) {
-	seen := make(map[string]repoRefResponse)
-	var configured []config.Repo
-	if s.cfg != nil {
-		s.cfgMu.Lock()
-		configured = slices.Clone(s.cfg.Repos)
-		s.cfgMu.Unlock()
-		for _, repo := range configured {
-			if repo.HasNameGlob() {
-				continue
-			}
-			target := kataResolvedRepoFromConfig(repo)
-			seen[kataResolvedRepoKey(target)] = s.repoRefFromParts(
-				target.Provider, target.PlatformHost, target.Owner, target.Name,
-			)
-		}
-	}
-	tracked, err := s.db.ListRepos(ctx)
-	if err != nil {
-		return nil, err
-	}
-	for _, repo := range tracked {
-		if !kataTrackedRepoMatchesAnyConfig(repo, configured) {
-			continue
-		}
-		target := kataResolvedRepoFromDB(repo)
-		seen[kataResolvedRepoKey(target)] = s.repoRefFromParts(
-			target.Provider, target.PlatformHost, target.Owner, target.Name,
-		)
-	}
+func (s *Server) kataMappingTargets(ctx context.Context) ([]kataMappingTargetResponse, error) {
 	projects, err := s.db.ListProjects(ctx)
 	if err != nil {
 		return nil, err
 	}
+	result := make([]kataMappingTargetResponse, 0, len(projects))
 	for _, project := range projects {
 		if project.IsStale || project.PlatformIdentity == nil {
 			continue
 		}
 		target := kataResolvedRepoFromProject(project)
-		seen[kataResolvedRepoKey(target)] = s.repoRefFromParts(
-			target.Provider, target.PlatformHost, target.Owner, target.Name,
-		)
+		result = append(result, kataMappingTargetResponse{
+			ProjectID: project.ID, DisplayName: project.DisplayName,
+			Repo: s.repoRefFromParts(target.Provider, target.PlatformHost, target.Owner, target.Name),
+		})
 	}
-	result := make([]repoRefResponse, 0, len(seen))
-	for _, repo := range seen {
-		result = append(result, repo)
-	}
-	sort.Slice(result, func(i, j int) bool { return result[i].RepoPath < result[j].RepoPath })
+	sort.Slice(result, func(i, j int) bool {
+		return strings.ToLower(result[i].DisplayName) < strings.ToLower(result[j].DisplayName)
+	})
 	return result, nil
 }
 

--- a/internal/server/kata_workspace_test.go
+++ b/internal/server/kata_workspace_test.go
@@ -346,6 +346,58 @@ port = 8091
 	assert.Equal(projectPath, basePath)
 }
 
+func TestKataProjectMappingsReportsManualRegisteredProjectTarget(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	daemon := startKataTaskDetailDaemon(t, `{}`, `{"projects":[
+		{"id":7,"uid":"project-kata","name":"Kata"},
+		{"id":8,"uid":"project-unmapped","name":"Unmapped"}
+	]}`)
+	home := t.TempDir()
+	t.Setenv("KATA_HOME", home)
+	writeKataProxyCatalog(t, home, `
+[[daemon]]
+name = "desktop"
+url = "`+daemon.URL+`"
+`)
+	srv, database, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[kata_projects]]
+daemon_id = "desktop"
+project_uid = "project-kata"
+provider = "github"
+platform_host = "github.com"
+repo_path = "acme/middleman"
+`, &mockGH{})
+	repoID, err := database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "middleman"))
+	require.NoError(err)
+	_, err = database.CreateProject(t.Context(), db.CreateProjectInput{
+		DisplayName: "Middleman",
+		LocalPath:   t.TempDir(),
+		RepoID:      sql.NullInt64{Int64: repoID, Valid: true},
+	})
+	require.NoError(err)
+
+	rr := doJSON(t, srv, http.MethodGet, "/api/v1/kata/project-mappings", nil)
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+	assert.Contains(rr.Header().Values("Vary"), kataDaemonHeaderName)
+	var resp kataProjectMappingsResponse
+	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
+	require.Len(resp.Projects, 2)
+	assert.Equal("mapped", resp.Projects[0].Status)
+	assert.Equal("manual_daemon", resp.Projects[0].Source)
+	require.NotNil(resp.Projects[0].Repo)
+	assert.Equal("acme/middleman", resp.Projects[0].Repo.RepoPath)
+	assert.Equal("unmapped", resp.Projects[1].Status)
+	require.Len(resp.Repositories, 1)
+	assert.Equal("acme/middleman", resp.Repositories[0].RepoPath)
+}
+
 func TestKataWorkspaceTargetTrackedRepoNameFallbackRequiresOneMatch(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/server/kata_workspace_test.go
+++ b/internal/server/kata_workspace_test.go
@@ -394,8 +394,9 @@ repo_path = "acme/middleman"
 	require.NotNil(resp.Projects[0].Repo)
 	assert.Equal("acme/middleman", resp.Projects[0].Repo.RepoPath)
 	assert.Equal("unmapped", resp.Projects[1].Status)
-	require.Len(resp.Repositories, 1)
-	assert.Equal("acme/middleman", resp.Repositories[0].RepoPath)
+	require.Len(resp.Targets, 1)
+	assert.Equal("Middleman", resp.Targets[0].DisplayName)
+	assert.Equal("acme/middleman", resp.Targets[0].Repo.RepoPath)
 }
 
 func TestKataWorkspaceTargetTrackedRepoNameFallbackRequiresOneMatch(t *testing.T) {

--- a/internal/server/kata_workspace_test.go
+++ b/internal/server/kata_workspace_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -344,6 +345,144 @@ port = 8091
 	require.NoError(err)
 	assert.True(ok)
 	assert.Equal(projectPath, basePath)
+}
+
+func TestKataWorkspaceTargetRegisteredProjectsWithDifferentCheckoutsAreAmbiguous(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	srv, database, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+`, &mockGH{})
+	repoID, err := database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "kata"))
+	require.NoError(err)
+	for _, localPath := range []string{t.TempDir(), t.TempDir()} {
+		_, err = database.CreateProject(t.Context(), db.CreateProjectInput{
+			DisplayName: "Kata",
+			LocalPath:   localPath,
+			RepoID:      sql.NullInt64{Int64: repoID, Valid: true},
+		})
+		require.NoError(err)
+	}
+
+	resp := kataWorkspaceTargetViaTaskDetail(t, srv, map[string]string{
+		"daemon_id":    "desktop",
+		"project_uid":  "project-kata",
+		"project_name": "Kata",
+		"issue_uid":    "issue-kata-1",
+	})
+
+	assert.False(resp.Available)
+	assert.Nil(resp.Repo)
+}
+
+func TestCreateKataWorkspaceUsesRegisteredProjectCheckout(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	projectPath, _, platformHost := setupHTTPWorktreeBaseForServerTest(t, "feature")
+
+	srv, database, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+`, &mockGH{})
+	repoID, err := database.UpsertRepo(t.Context(), db.GitHubRepoIdentity(platformHost, "acme", "widget"))
+	require.NoError(err)
+	_, err = database.CreateProject(t.Context(), db.CreateProjectInput{
+		DisplayName: "Widget",
+		LocalPath:   projectPath,
+		RepoID:      sql.NullInt64{Int64: repoID, Valid: true},
+	})
+	require.NoError(err)
+	srv.workspaces = workspace.NewManager(database, t.TempDir())
+	srv.workspaces.SetTmuxCommand([]string{"sh", "-c", "exit 0"})
+
+	rr := doJSON(t, srv, http.MethodPost, "/api/v1/kata/workspaces", map[string]any{
+		"daemon_id":    "desktop",
+		"project_uid":  "project-kata",
+		"project_name": "Widget",
+		"issue_uid":    "issue-kata-1",
+		"short_id":     "task-123",
+		"title":        "Use registered checkout",
+	})
+	require.Equal(http.StatusAccepted, rr.Code, rr.Body.String())
+	var created workspaceResponse
+	require.NoError(json.NewDecoder(rr.Body).Decode(&created))
+
+	var stored *db.Workspace
+	require.Eventually(func() bool {
+		stored, err = database.GetWorkspace(t.Context(), created.ID)
+		return err == nil && stored != nil && stored.Status == "ready"
+	}, 10*time.Second, 25*time.Millisecond)
+	commonDir := strings.TrimSpace(gitOutput(t, stored.WorktreePath, "rev-parse", "--git-common-dir"))
+	if !filepath.IsAbs(commonDir) {
+		commonDir = filepath.Join(stored.WorktreePath, commonDir)
+	}
+	commonDir, err = filepath.EvalSymlinks(commonDir)
+	require.NoError(err)
+	wantCommonDir, err := filepath.EvalSymlinks(filepath.Join(projectPath, ".git"))
+	require.NoError(err)
+	assert.Equal(wantCommonDir, commonDir)
+}
+
+func TestKataManualMappingRejectsHistoricalUnconfiguredRepo(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	srv, database, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[kata_projects]]
+project_uid = "project-kata"
+provider = "github"
+platform_host = "github.com"
+repo_path = "acme/old"
+`, &mockGH{})
+	_, err := database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "old"))
+	require.NoError(err)
+
+	resolution, err := srv.resolveKataWorkspaceRepoResolution(t.Context(), db.WorkspaceKataMetadata{
+		DaemonID: "desktop", ProjectUID: "project-kata", ProjectName: "Kata",
+	})
+	require.NoError(err)
+	assert.Equal("invalid", resolution.Status)
+	assert.Equal("manual_global", resolution.Source)
+}
+
+func TestKataMappingTargetsIncludeConfiguredRepositories(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	srv, database, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "exact"
+
+[[repos]]
+owner = "acme"
+name = "glob-*"
+`, &mockGH{})
+	_, err := database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "glob-match"))
+	require.NoError(err)
+
+	targets, err := srv.kataMappingTargets(t.Context())
+	require.NoError(err)
+	require.Len(targets, 2)
+	assert.Equal("acme/exact", targets[0].Repo.RepoPath)
+	assert.Equal("acme/glob-match", targets[1].Repo.RepoPath)
 }
 
 func TestKataProjectMappingsReportsManualRegisteredProjectTarget(t *testing.T) {

--- a/internal/server/kata_workspace_test.go
+++ b/internal/server/kata_workspace_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -304,6 +305,45 @@ name = "middleman"
 		ProjectUID: "project-middleman",
 		IssueUID:   "issue-kata-1",
 	}), resp.ItemKey)
+}
+
+func TestKataWorkspaceTargetAutomaticMappingFromRegisteredProject(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	srv, database, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+`, &mockGH{})
+	repoID, err := database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "kata"))
+	require.NoError(err)
+	projectPath := t.TempDir()
+	_, err = database.CreateProject(t.Context(), db.CreateProjectInput{
+		DisplayName: "Kata",
+		LocalPath:   projectPath,
+		RepoID:      sql.NullInt64{Int64: repoID, Valid: true},
+	})
+	require.NoError(err)
+
+	resp := kataWorkspaceTargetViaTaskDetail(t, srv, map[string]string{
+		"daemon_id":    "desktop",
+		"project_uid":  "project-kata",
+		"project_name": "Kata",
+		"issue_uid":    "issue-kata-1",
+	})
+
+	assert.True(resp.Available)
+	require.NotNil(resp.Repo)
+	assert.Equal("acme", resp.Repo.Owner)
+	assert.Equal("kata", resp.Repo.Name)
+	basePath, ok, err := srv.worktreeBasePathForRepo(
+		t.Context(), "github", "github.com", "acme", "kata",
+	)
+	require.NoError(err)
+	assert.True(ok)
+	assert.Equal(projectPath, basePath)
 }
 
 func TestKataWorkspaceTargetTrackedRepoNameFallbackRequiresOneMatch(t *testing.T) {

--- a/internal/server/settings_handlers.go
+++ b/internal/server/settings_handlers.go
@@ -233,26 +233,56 @@ func sameConfiguredRepo(left, right config.Repo) bool {
 }
 
 func (s *Server) worktreeBasePathForRepo(
-	_ context.Context, provider, platformHost, owner, name string,
+	ctx context.Context, provider, platformHost, owner, name string,
 ) (string, bool, error) {
-	if s.cfg == nil {
+	if s.cfg != nil {
+		target := config.Repo{
+			Platform:     provider,
+			PlatformHost: platformHost,
+			Owner:        owner,
+			Name:         name,
+		}
+		configuredPath := func() string {
+			s.cfgMu.Lock()
+			defer s.cfgMu.Unlock()
+			for _, repo := range s.cfg.Repos {
+				if repo.HasNameGlob() || strings.TrimSpace(repo.WorktreeBasePath) == "" {
+					continue
+				}
+				if sameConfiguredRepo(repo, target) {
+					return repo.WorktreeBasePath
+				}
+			}
+			return ""
+		}()
+		if configuredPath != "" {
+			return configuredPath, true, nil
+		}
+	}
+	if s.db == nil {
 		return "", false, nil
 	}
-	target := config.Repo{
-		Platform:     provider,
-		PlatformHost: platformHost,
-		Owner:        owner,
-		Name:         name,
+	projects, err := s.db.ListProjects(ctx)
+	if err != nil {
+		return "", false, fmt.Errorf("list registered projects: %w", err)
 	}
-	s.cfgMu.Lock()
-	defer s.cfgMu.Unlock()
-	for _, repo := range s.cfg.Repos {
-		if repo.HasNameGlob() || strings.TrimSpace(repo.WorktreeBasePath) == "" {
+	var matchedPath string
+	for _, project := range projects {
+		identity := project.PlatformIdentity
+		if project.IsStale || identity == nil ||
+			!strings.EqualFold(identity.Platform, provider) ||
+			!samePlatformHost(identity.Host, platformHost) ||
+			!strings.EqualFold(identity.Owner, owner) ||
+			!strings.EqualFold(identity.Name, name) {
 			continue
 		}
-		if sameConfiguredRepo(repo, target) {
-			return repo.WorktreeBasePath, true, nil
+		if matchedPath != "" && matchedPath != project.LocalPath {
+			return "", false, nil
 		}
+		matchedPath = project.LocalPath
+	}
+	if matchedPath != "" {
+		return matchedPath, true, nil
 	}
 	return "", false, nil
 }

--- a/internal/server/settings_handlers.go
+++ b/internal/server/settings_handlers.go
@@ -890,17 +890,11 @@ func (s *Server) deleteConfiguredRepo(
 	}
 
 	prevRepos := slices.Clone(s.cfg.Repos)
-	prevKataProjects := slices.Clone(s.cfg.KataProjects)
 	s.cfg.Repos = append(
 		s.cfg.Repos[:idx], s.cfg.Repos[idx+1:]...,
 	)
-	s.cfg.KataProjects = filterKataProjectMappingsForDeletedRepo(
-		s.cfg.KataProjects,
-		targetRef,
-	)
 	if err := s.cfg.Save(s.cfgPath); err != nil {
 		s.cfg.Repos = prevRepos
-		s.cfg.KataProjects = prevKataProjects
 		s.cfgMu.Unlock()
 		return nil, problemInternal("save config: " + err.Error())
 	}
@@ -908,35 +902,6 @@ func (s *Server) deleteConfiguredRepo(
 	s.cfgMu.Unlock()
 
 	return nil, nil
-}
-
-func filterKataProjectMappingsForDeletedRepo(
-	mappings []config.KataProjectRepoMapping,
-	repo config.Repo,
-) []config.KataProjectRepoMapping {
-	filtered := make([]config.KataProjectRepoMapping, 0, len(mappings))
-	for _, mapping := range mappings {
-		if kataProjectMappingTargetsRepo(mapping, repo) {
-			continue
-		}
-		filtered = append(filtered, mapping)
-	}
-	return filtered
-}
-
-func kataProjectMappingTargetsRepo(
-	mapping config.KataProjectRepoMapping,
-	repo config.Repo,
-) bool {
-	return strings.EqualFold(
-		strings.TrimSpace(mapping.Provider),
-		repo.PlatformOrDefault(),
-	) &&
-		samePlatformHost(mapping.PlatformHost, repo.PlatformHostOrDefault()) &&
-		strings.EqualFold(
-			strings.Trim(strings.TrimSpace(mapping.RepoPath), "/"),
-			strings.Trim(configRepoPath(repo), "/"),
-		)
 }
 
 func normalizeRouteProvider(raw string) (string, error) {

--- a/internal/server/settings_test.go
+++ b/internal/server/settings_test.go
@@ -830,7 +830,7 @@ func TestHandleDeleteRepo(t *testing.T) {
 	assert.Equal(t, "other-org", cfg2.Repos[0].Owner)
 }
 
-func TestHandleDeleteRepoRemovesKataProjectMappings(t *testing.T) {
+func TestHandleDeleteRepoPreservesKataProjectMappings(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	srv, _, cfgPath := setupTestServerWithConfig(t)
@@ -878,9 +878,9 @@ func TestHandleDeleteRepoRemovesKataProjectMappings(t *testing.T) {
 	require.NoError(err)
 	require.Len(cfg2.Repos, 1)
 	assert.Equal("other-org", cfg2.Repos[0].Owner)
-	require.Len(cfg2.KataProjects, 1)
-	assert.Equal("project-other", cfg2.KataProjects[0].ProjectUID)
-	assert.Equal("other-org/other-repo", cfg2.KataProjects[0].RepoPath)
+	require.Len(cfg2.KataProjects, 2)
+	assert.Equal("project-widget", cfg2.KataProjects[0].ProjectUID)
+	assert.Equal("acme/widget", cfg2.KataProjects[0].RepoPath)
 }
 
 func TestGetSettingsWithoutPersistence(t *testing.T) {

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -634,6 +634,15 @@ func workspaceHeadRepo(platformHost, owner, name, cloneURL string) *string {
 func (m *Manager) Setup(
 	ctx context.Context, ws *Workspace,
 ) error {
+	return m.SetupWithWorktreeBasePath(ctx, ws, "")
+}
+
+// SetupWithWorktreeBasePath sets up a workspace from the exact checkout that
+// justified a caller's repository resolution. An empty path uses the manager's
+// normal repository-identity resolver.
+func (m *Manager) SetupWithWorktreeBasePath(
+	ctx context.Context, ws *Workspace, worktreeBasePath string,
+) error {
 	m.recordSetupEvent(
 		ctx,
 		ws.ID, workspaceSetupStageSetup, "started",
@@ -647,7 +656,7 @@ func (m *Manager) Setup(
 	}
 	if !reusedWorktree {
 		var refreshBeforeAdd bool
-		gitDir, refreshBeforeAdd, err = m.workspaceSetupGitDir(ctx, ws)
+		gitDir, refreshBeforeAdd, err = m.workspaceSetupGitDir(ctx, ws, worktreeBasePath)
 		if err != nil {
 			return m.failSetup(
 				ctx,
@@ -990,9 +999,15 @@ func worktreeCurrentBranch(ctx context.Context, path string) (string, error) {
 }
 
 func (m *Manager) workspaceSetupGitDir(
-	ctx context.Context, ws *Workspace,
+	ctx context.Context, ws *Workspace, worktreeBasePath string,
 ) (string, bool, error) {
 	if ws.MRHeadRepo == nil {
+		if strings.TrimSpace(worktreeBasePath) != "" {
+			baseDir, err := ValidateWorktreeBasePath(
+				ctx, worktreeBasePath, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
+			)
+			return baseDir, err == nil, err
+		}
 		if baseDir, ok, err := m.localWorktreeBaseDir(
 			ctx, ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
 		); err != nil || ok {

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -2083,6 +2083,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/kata/project-mappings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Inspect effective Kata project repository mappings */
+        get: operations["get-kata-project-mappings"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/kata/tasks/{issue_uid}": {
         parameters: {
             query?: never;
@@ -5323,6 +5340,25 @@ export interface components {
             readonly $schema?: string;
             daemons: components["schemas"]["KataDaemonResponse"][] | null;
             source?: string;
+        };
+        KataProjectMappingDiagnostic: {
+            daemon_id: string;
+            project_name: string;
+            project_uid: string;
+            repo?: components["schemas"]["RepoRefResponse"];
+            source?: string;
+            status: string;
+        };
+        KataProjectMappingsResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example /api/v1/schemas/KataProjectMappingsResponse.json
+             */
+            readonly $schema?: string;
+            daemon_id: string;
+            projects: components["schemas"]["KataProjectMappingDiagnostic"][];
+            repositories: components["schemas"]["RepoRefResponse"][];
         };
         KataProjectRepoMapping: {
             daemon_id?: string;
@@ -12134,6 +12170,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["KataDaemonRosterResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
+    "get-kata-project-mappings": {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description Kata daemon id; the effective default daemon when empty */
+                "X-Middleman-Kata-Daemon"?: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    Vary?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["KataProjectMappingsResponse"];
                 };
             };
             /** @description Error */

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -5341,6 +5341,11 @@ export interface components {
             daemons: components["schemas"]["KataDaemonResponse"][] | null;
             source?: string;
         };
+        KataMappingTargetResponse: {
+            display_name: string;
+            project_id: string;
+            repo: components["schemas"]["RepoRefResponse"];
+        };
         KataProjectMappingDiagnostic: {
             daemon_id: string;
             project_name: string;
@@ -5358,7 +5363,7 @@ export interface components {
             readonly $schema?: string;
             daemon_id: string;
             projects: components["schemas"]["KataProjectMappingDiagnostic"][];
-            repositories: components["schemas"]["RepoRefResponse"][];
+            targets: components["schemas"]["KataMappingTargetResponse"][];
         };
         KataProjectRepoMapping: {
             daemon_id?: string;

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -5343,7 +5343,6 @@ export interface components {
         };
         KataMappingTargetResponse: {
             display_name: string;
-            project_id: string;
             repo: components["schemas"]["RepoRefResponse"];
         };
         KataProjectMappingDiagnostic: {


### PR DESCRIPTION
## Summary

- Shows the effective Kata-to-Middleman project mapping and its resolution source in Settings.
- Lets maintainers override mappings using known registered projects, preselecting the inferred project.
- Keeps automatic inference for unconfigured projects and hides mapping controls when Kata is disabled.

<sup>generated by a clanker</sup>