### PR TITLE
Standardize grouped sidebar selection and scrolling

### DIFF
--- a/context/ui-design-system.md
+++ b/context/ui-design-system.md
@@ -185,7 +185,7 @@ Use it inside left sidebar headers and collapsed strips. Pass a specific label s
 
 ### GroupedSidebarSection
 
-Use `GroupedSidebarSection` for collapsible groups in PR, issue, and workspace list rails. Keep group chrome and the `--sidebar-*` surface/row-state tokens shared; domain-specific row content stays with its owner. (`packages/ui/src/components/shared/GroupedSidebarSection.svelte`, `frontend/src/app.css:39`)
+Use `GroupedSidebarSection` for collapsible groups in PR, issue, and workspace list rails. Keep group chrome and the `--sidebar-*` surface/row-state tokens shared; domain-specific row content stays with its owner. Wrap the rail's virtual-list content in `SidebarScrollArea` so its scroll indicator overlays content and only appears during scrolling instead of reserving a permanent gutter. (`packages/ui/src/components/shared/GroupedSidebarSection.svelte`, `packages/ui/src/components/shared/SidebarScrollArea.svelte`, `frontend/src/app.css:39`)
 
 ### SplitResizeHandle
 

--- a/context/ui-design-system.md
+++ b/context/ui-design-system.md
@@ -183,6 +183,10 @@ Intent:
 
 Use it inside left sidebar headers and collapsed strips. Pass a specific label such as `Workspaces sidebar` when the generic `sidebar` label would be ambiguous. The resizable sidebar layout itself is kit-ui's `CollapsibleSidebar`; the container-width-driven floating overlay is requested through its `overlay` prop (hosts pass the container store's `isNarrow()` — kit's `overlayOnNarrow` media query is viewport-based, which is not the same signal).
 
+### GroupedSidebarSection
+
+Use `GroupedSidebarSection` for collapsible groups in PR, issue, and workspace list rails. Keep group chrome and the `--sidebar-*` surface/row-state tokens shared; domain-specific row content stays with its owner. (`packages/ui/src/components/shared/GroupedSidebarSection.svelte`, `frontend/src/app.css:39`)
+
 ### SplitResizeHandle
 
 Use kit-ui's `SplitResizeHandle` (re-exported from `@middleman/ui`) for draggable pane dividers in split views.

--- a/context/ui-design-system.md
+++ b/context/ui-design-system.md
@@ -185,7 +185,7 @@ Use it inside left sidebar headers and collapsed strips. Pass a specific label s
 
 ### GroupedSidebarSection
 
-Use `GroupedSidebarSection` for collapsible groups in PR, issue, and workspace list rails. Keep group chrome and the `--sidebar-*` surface/row-state tokens shared; domain-specific row content stays with its owner. Wrap the rail's virtual-list content in `SidebarScrollArea` so its scroll indicator overlays content and only appears during scrolling instead of reserving a permanent gutter. (`packages/ui/src/components/shared/GroupedSidebarSection.svelte`, `packages/ui/src/components/shared/SidebarScrollArea.svelte`, `frontend/src/app.css:39`)
+Use `GroupedSidebarSection` for collapsible groups in PR, issue, and workspace list rails. Keep group chrome and the `--sidebar-*` surface/row-state tokens shared; domain-specific row content stays with its owner. Wrap scrollable rail content in `SidebarScrollArea` so its scroll indicator overlays rows and sticky group headers, appears only during scrolling, and does not reserve a permanent gutter. Give each scroll area a concise accessible label so keyboard users can identify and scroll the region. (`packages/ui/src/components/shared/GroupedSidebarSection.svelte`, `packages/ui/src/components/shared/SidebarScrollArea.svelte`, `frontend/src/app.css:39`)
 
 ### SplitResizeHandle
 

--- a/frontend/src/App.collapsible-repos.browser.svelte.ts
+++ b/frontend/src/App.collapsible-repos.browser.svelte.ts
@@ -127,9 +127,9 @@ function listOverrides(): MockRouteOverride[] {
 
 function header(label: string): HTMLElement | null {
   return (
-    (Array.from(document.querySelectorAll(".repo-header")).find((h) => (h.textContent ?? "").includes(label)) as
-      | HTMLElement
-      | undefined) ?? null
+    (Array.from(document.querySelectorAll(".sidebar-group-header")).find((h) =>
+      (h.textContent ?? "").includes(label),
+    ) as HTMLElement | undefined) ?? null
   );
 }
 
@@ -138,7 +138,7 @@ function expanded(label: string): string | null {
 }
 
 function groupCount(label: string): string {
-  return header(label)?.querySelector(".repo-header__count")?.textContent?.trim() ?? "";
+  return header(label)?.querySelector(".sidebar-group-header__count")?.textContent?.trim() ?? "";
 }
 
 function count(selector: string): number {

--- a/frontend/src/App.grouping-toggle.browser.svelte.ts
+++ b/frontend/src/App.grouping-toggle.browser.svelte.ts
@@ -288,7 +288,7 @@ describe("grouping toggle", () => {
 
   it("PR list defaults to grouped with repo headers and no badges", async () => {
     await mountPulls();
-    await vi.waitFor(() => expect(document.querySelector(".repo-header")).not.toBeNull(), WAIT);
+    await vi.waitFor(() => expect(document.querySelector(".sidebar-group-header")).not.toBeNull(), WAIT);
     expect(count(".repo-chip")).toBe(0);
   });
 
@@ -296,7 +296,7 @@ describe("grouping toggle", () => {
     await mountPulls();
     await selectPullGrouping("All");
 
-    await vi.waitFor(() => expect(count(".repo-header")).toBe(0), WAIT);
+    await vi.waitFor(() => expect(count(".sidebar-group-header")).toBe(0), WAIT);
     await vi.waitFor(() => expect(count(".repo-chip")).toBe(count(".pull-item")), WAIT);
     expect(count(".pull-item")).toBe(pulls.length);
   });
@@ -304,7 +304,7 @@ describe("grouping toggle", () => {
   it("toggle persists across a reload", async () => {
     await mountPulls();
     await selectPullGrouping("All");
-    await vi.waitFor(() => expect(count(".repo-header")).toBe(0), WAIT);
+    await vi.waitFor(() => expect(count(".sidebar-group-header")).toBe(0), WAIT);
 
     // Assert the choice is written to localStorage, not just held in module
     // state: this is what survives a real reload, and proves a regression that
@@ -315,26 +315,26 @@ describe("grouping toggle", () => {
     mounted?.unmount();
     mounted = await mountBrowserApp("/pulls", { overrides: overrides() });
     await vi.waitFor(() => expect(document.querySelector(".pull-item")).not.toBeNull(), WAIT);
-    expect(count(".repo-header")).toBe(0);
+    expect(count(".sidebar-group-header")).toBe(0);
     expect(document.querySelector(".repo-chip")).not.toBeNull();
   });
 
   it("toggle syncs from PRs to the issue list", async () => {
     await mountPulls();
     await selectPullGrouping("All");
-    await vi.waitFor(() => expect(count(".repo-header")).toBe(0), WAIT);
+    await vi.waitFor(() => expect(count(".sidebar-group-header")).toBe(0), WAIT);
 
     mounted?.unmount();
     mounted = await mountBrowserApp("/issues", { overrides: overrides() });
     await vi.waitFor(() => expect(document.querySelector(".issue-item")).not.toBeNull(), WAIT);
-    expect(count(".repo-header")).toBe(0);
+    expect(count(".sidebar-group-header")).toBe(0);
     expect(document.querySelector(".repo-chip")).not.toBeNull();
   });
 
   it("toggle syncs into the threaded activity view", async () => {
     await mountPulls();
     await selectPullGrouping("All");
-    await vi.waitFor(() => expect(count(".repo-header")).toBe(0), WAIT);
+    await vi.waitFor(() => expect(count(".sidebar-group-header")).toBe(0), WAIT);
 
     mounted?.unmount();
     mounted = await mountBrowserApp("/", { overrides: overrides() });

--- a/frontend/src/App.repo-sync.browser.svelte.ts
+++ b/frontend/src/App.repo-sync.browser.svelte.ts
@@ -201,7 +201,7 @@ function typeaheadValue(): string {
 }
 
 function repoHeaderNames(): string[] {
-  return Array.from(document.querySelectorAll(".repo-header__name")).map((el) => el.textContent?.trim() ?? "");
+  return Array.from(document.querySelectorAll(".sidebar-group-header__name")).map((el) => el.textContent?.trim() ?? "");
 }
 
 function clickPullItem(title: string): Promise<void> {

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -97,7 +97,8 @@
 :root.dark {
   --budget-bar-bg: #2a2a3e; /* kit-ui-check-ignore: budget-bar palette */
   --kanban-new: #a8a29e; /* kit-ui-check-ignore: kanban palette */
-  --bg-row-selected: color-mix(in srgb, var(--bg-surface-hover) 50%, var(--bg-surface));
+  --sidebar-row-hover-bg: color-mix(in srgb, var(--bg-surface-hover) 82%, var(--text-muted) 18%);
+  --bg-row-selected: color-mix(in srgb, var(--sidebar-row-hover-bg) 38%, var(--bg-surface));
 
   /* Diff view — dark theme (GitHub Dark palette) */
   --diff-bg: #0d1117; /* kit-ui-check-ignore: GitHub diff palette */

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -36,6 +36,15 @@
   --kanban-reviewing: var(--accent-amber);
   --kanban-waiting: var(--accent-purple);
   --kanban-awaiting-merge: var(--accent-green);
+  --sidebar-list-bg: var(--bg-surface);
+  --sidebar-list-border: var(--border-default);
+  --sidebar-list-border-muted: var(--border-muted);
+  --sidebar-group-header-bg: var(--bg-inset);
+  --sidebar-group-header-padding: 6px 12px 4px;
+  --sidebar-row-bg: var(--bg-surface);
+  --sidebar-row-hover-bg: var(--bg-surface-hover);
+  --sidebar-row-padding: 10px 12px;
+  --bg-row-selected: var(--bg-inset);
 
   /* Review status colors */
   --review-queued: var(--accent-amber);
@@ -88,6 +97,7 @@
 :root.dark {
   --budget-bar-bg: #2a2a3e; /* kit-ui-check-ignore: budget-bar palette */
   --kanban-new: #a8a29e; /* kit-ui-check-ignore: kanban palette */
+  --bg-row-selected: color-mix(in srgb, var(--bg-surface-hover) 50%, var(--bg-surface));
 
   /* Diff view — dark theme (GitHub Dark palette) */
   --diff-bg: #0d1117; /* kit-ui-check-ignore: GitHub diff palette */

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -12,6 +12,7 @@
     DiffStats,
     FilterDropdown,
     GroupedSidebarSection,
+    SidebarScrollArea,
     SidebarToggle,
   } from "@middleman/ui";
   import {
@@ -1046,7 +1047,8 @@
       {/if}
     </section>
   {/if}
-  <div class="sidebar-list">
+  <SidebarScrollArea class="sidebar-list">
+    {#snippet children()}
     {#if sortMode === "repo"}
     {#each grouped as { key: repoKey, items } (repoKey)}
       {@const collapsed =
@@ -1237,7 +1239,8 @@
     {:else if visibleWorkspaces.length === 0}
       <p class="filter-empty">No workspaces yet.</p>
     {/if}
-  </div>
+    {/snippet}
+  </SidebarScrollArea>
 
 </div>
 
@@ -1597,11 +1600,6 @@
     font-family: var(--font-mono);
     font-size: var(--font-size-2xs);
     font-weight: 600;
-  }
-
-  .sidebar-list {
-    flex: 1;
-    overflow-y: auto;
   }
 
   .filter-empty {

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -1047,7 +1047,7 @@
       {/if}
     </section>
   {/if}
-  <SidebarScrollArea class="sidebar-list">
+  <SidebarScrollArea class="sidebar-list" label="Workspaces">
     {#snippet children()}
     {#if sortMode === "repo"}
     {#each grouped as { key: repoKey, items } (repoKey)}

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -2,7 +2,6 @@
   import { copyToClipboard, SearchInput } from "@kenn-io/kit-ui";
   import { onMount, tick } from "svelte";
   import { navigate } from "../../stores/router.svelte.ts";
-  import ChevronDownIcon from "@lucide/svelte/icons/chevron-down";
   import GitBranchIcon from "@lucide/svelte/icons/git-branch";
   import ArrowUpIcon from "@lucide/svelte/icons/arrow-up";
   import ArrowDownIcon from "@lucide/svelte/icons/arrow-down";
@@ -12,6 +11,7 @@
   import {
     DiffStats,
     FilterDropdown,
+    GroupedSidebarSection,
     SidebarToggle,
   } from "@middleman/ui";
   import {
@@ -1051,31 +1051,25 @@
     {#each grouped as { key: repoKey, items } (repoKey)}
       {@const collapsed =
         !normalizedSearchQuery && collapsedGroups.includes(repoKey)}
-      <button
-        class={["group-header", { collapsed }]}
+      <GroupedSidebarSection
+        label={repoLabel(items[0]!)}
+        count={items.length}
+        {collapsed}
         onclick={() => toggleGroup(repoKey)}
       >
-        <ChevronDownIcon
-          class="group-chevron"
-          size="12"
-          strokeWidth="2.25"
-          aria-hidden="true"
-        />
-        {#if showProviderIcons && workspaceProvider(items[0]!)}
-          <ProviderIcon
-            provider={workspaceProvider(items[0]!)!}
-            size={14}
-            class="group-provider-icon"
-          />
-        {/if}
-        <span class="group-label">{repoLabel(items[0]!)}</span>
-        <span class="group-count">{items.length}</span>
-      </button>
-      {#if !collapsed}
+        {#snippet leading()}
+          {#if showProviderIcons && workspaceProvider(items[0]!)}
+            <ProviderIcon
+              provider={workspaceProvider(items[0]!)!}
+              size={14}
+              class="group-provider-icon"
+            />
+          {/if}
+        {/snippet}
         {#each items as ws (workspaceRowKey(ws))}
           {@render workspaceRow(ws, false)}
         {/each}
-      {/if}
+      </GroupedSidebarSection>
     {/each}
     {:else}
       {#each sortedFlat as ws (workspaceRowKey(ws))}
@@ -1420,7 +1414,7 @@
   .workspace-list-sidebar {
     width: 100%;
     height: 100%;
-    background: var(--bg-inset);
+    background: var(--sidebar-list-bg, var(--bg-surface));
     display: flex;
     flex-direction: column;
     overflow: hidden;
@@ -1438,10 +1432,11 @@
   .sidebar-header {
     display: flex;
     align-items: center;
-    gap: 6px;
-    height: 28px;
-    padding: 0 4px 0 12px;
+    gap: var(--space-3);
+    min-height: 40px;
+    padding: 6px 10px;
     border-bottom: 1px solid var(--border-muted);
+    background: var(--bg-surface);
     flex-shrink: 0;
   }
 
@@ -1461,7 +1456,9 @@
   }
 
   .workspace-filter {
-    margin: 6px 8px 4px;
+    padding: 6px 10px;
+    border-bottom: 1px solid var(--border-default);
+    background: var(--bg-surface);
     flex-shrink: 0;
   }
 
@@ -1605,21 +1602,6 @@
   .sidebar-list {
     flex: 1;
     overflow-y: auto;
-    padding: 2px 0 8px;
-  }
-
-  .sidebar-list::-webkit-scrollbar {
-    width: 8px;
-  }
-
-  .sidebar-list::-webkit-scrollbar-thumb {
-    background: var(--border-muted);
-    border-radius: 4px;
-    border: 2px solid var(--bg-inset);
-  }
-
-  .sidebar-list::-webkit-scrollbar-thumb:hover {
-    background: var(--text-muted);
   }
 
   .filter-empty {
@@ -1629,61 +1611,8 @@
     line-height: 1.4;
   }
 
-  .group-header {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    width: 100%;
-    padding: 4px 10px 4px 8px;
-    margin-top: 6px;
-    border: 0;
-    background: transparent;
-    font-family: var(--font-mono);
-    font-size: var(--font-size-xs);
-    font-weight: 600;
-    color: var(--text-muted);
-    text-align: left;
-    cursor: pointer;
-    letter-spacing: 0;
-    transition: color 80ms ease;
-  }
-
-  .group-header:first-of-type {
-    margin-top: 2px;
-  }
-
-  .group-header:hover {
-    color: var(--text-secondary);
-  }
-
-  :global(.group-chevron) {
-    color: var(--text-muted);
-    flex-shrink: 0;
-    transition: transform 100ms ease;
-  }
-
   :global(.group-provider-icon) {
     color: var(--text-secondary);
-  }
-
-  .group-header.collapsed :global(.group-chevron) {
-    transform: rotate(-90deg);
-  }
-
-  .group-label {
-    flex: 1;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    color: var(--text-secondary);
-  }
-
-  .group-count {
-    flex-shrink: 0;
-    font-size: var(--font-size-2xs);
-    color: var(--text-muted);
-    opacity: 0.65;
-    padding: 0 1px;
   }
 
   .ws-row {
@@ -1695,16 +1624,18 @@
      * right edge for every row. */
     display: flex;
     align-items: flex-start;
-    gap: 8px;
-    padding: 4px 8px 5px 14px;
-    border-left: 2px solid transparent;
+    gap: var(--space-4);
+    padding: var(--sidebar-row-padding, 10px 12px);
+    border-bottom: 1px solid var(--sidebar-list-border-muted, var(--border-muted));
+    border-left: 3px solid transparent;
+    background: var(--sidebar-row-bg, var(--bg-surface));
     cursor: pointer;
     position: relative;
     outline: none;
   }
 
   .ws-row:hover {
-    background: var(--bg-surface-hover);
+    background: var(--sidebar-row-hover-bg, var(--bg-surface-hover));
   }
 
   .ws-row:focus-visible {
@@ -1713,12 +1644,12 @@
   }
 
   .ws-row.selected {
-    background: var(--bg-surface);
+    background: var(--bg-row-selected, var(--bg-surface));
     border-left-color: var(--accent-blue);
   }
 
   .ws-row.selected:hover {
-    background: color-mix(in srgb, var(--accent-blue) 8%, var(--bg-surface));
+    background: var(--sidebar-row-hover-bg, var(--bg-surface-hover));
   }
 
   .ws-row-text {

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
@@ -638,7 +638,7 @@ describe("WorkspaceListSidebar", () => {
     // Identical host and repo path, different providers: the rows must
     // not collapse into a single group whose label and icon come from
     // only the first item. Each provider keeps its own group + icon.
-    expect(container.querySelectorAll(".group-header")).toHaveLength(2);
+    expect(container.querySelectorAll(".sidebar-group-header")).toHaveLength(2);
     expect(screen.getByRole("img", { name: "Gitea" })).toBeTruthy();
     expect(screen.getByRole("img", { name: "Forgejo" })).toBeTruthy();
   });
@@ -764,7 +764,7 @@ describe("WorkspaceListSidebar", () => {
     await fireEvent.click(screen.getByRole("button", { name: "Created" }));
 
     expect(rowTitles(container)).toEqual(["Newest created", "Most recently active", "Oldest without activity"]);
-    expect(container.querySelectorAll(".group-header")).toHaveLength(0);
+    expect(container.querySelectorAll(".sidebar-group-header")).toHaveLength(0);
     // Flat rows carry their own repo context instead of a header.
     expect(container.querySelectorAll(".repo-context")).toHaveLength(3);
   });
@@ -899,7 +899,7 @@ describe("WorkspaceListSidebar", () => {
     await fireEvent.click(itemActivitySort);
 
     expect(rowTitles(container)).toEqual(["Issue recently changed", "PR recently changed", "Newest created fallback"]);
-    expect(container.querySelectorAll(".group-header")).toHaveLength(0);
+    expect(container.querySelectorAll(".sidebar-group-header")).toHaveLength(0);
   });
 
   it("persists the selected sort across mounts", async () => {
@@ -922,7 +922,7 @@ describe("WorkspaceListSidebar", () => {
     await screen.findByText("Newest created");
 
     expect(rowTitles(container)).toEqual(["Most recently active", "Newest created", "Oldest without activity"]);
-    expect(container.querySelectorAll(".group-header")).toHaveLength(0);
+    expect(container.querySelectorAll(".sidebar-group-header")).toHaveLength(0);
   });
 
   it("folds sort choices into the workspace view menu", async () => {
@@ -1014,11 +1014,9 @@ describe("WorkspaceListSidebar", () => {
     await fireEvent.click(screen.getByRole("button", { name: "View" }));
     await fireEvent.click(screen.getByRole("button", { name: "Show org names" }));
 
-    expect(Array.from(container.querySelectorAll(".group-label")).map((el) => el.textContent?.trim())).toEqual([
-      "github.com/acme/widgets",
-      "ghe.example.com/acme/widgets",
-      "platform/widgets",
-    ]);
+    expect(
+      Array.from(container.querySelectorAll(".sidebar-group-header__name")).map((el) => el.textContent?.trim()),
+    ).toEqual(["github.com/acme/widgets", "ghe.example.com/acme/widgets", "platform/widgets"]);
 
     await fireEvent.click(screen.getByRole("button", { name: "Created" }));
 
@@ -1060,14 +1058,12 @@ describe("WorkspaceListSidebar", () => {
     });
     await screen.findByText("GitHub acme widgets");
 
-    expect(Array.from(container.querySelectorAll(".group-label")).map((el) => el.textContent?.trim())).toEqual([
-      "github/github.com/acme/widgets",
-      "gitea/github.com/acme/widgets",
-    ]);
-    expect(Array.from(container.querySelectorAll(".group-count")).map((el) => el.textContent?.trim())).toEqual([
-      "1",
-      "1",
-    ]);
+    expect(
+      Array.from(container.querySelectorAll(".sidebar-group-header__name")).map((el) => el.textContent?.trim()),
+    ).toEqual(["github/github.com/acme/widgets", "gitea/github.com/acme/widgets"]);
+    expect(
+      Array.from(container.querySelectorAll(".sidebar-group-header__count")).map((el) => el.textContent?.trim()),
+    ).toEqual(["1", "1"]);
   });
 
   it("can hide PR diff stats while keeping branch metadata visible", async () => {

--- a/frontend/tests/e2e-full/00-workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e-full/00-workspace-sidebar.spec.ts
@@ -211,15 +211,15 @@ test.describe("workspace sidebar full-stack", () => {
 
       await page.goto(`${isolatedServer.info.base_url}/terminal/${githubWorkspace.id}`);
 
-      const githubGroup = page.locator(".workspace-list-sidebar .group-header").filter({
-        has: page.locator(".group-label", {
+      const githubGroup = page.locator(".workspace-list-sidebar .sidebar-group-header").filter({
+        has: page.locator(".sidebar-group-header__name", {
           hasText: "acme/widgets",
         }),
       });
       await expect(githubGroup.getByRole("img", { name: "GitHub" })).toBeVisible();
 
-      const gitlabGroup = page.locator(".workspace-list-sidebar .group-header").filter({
-        has: page.locator(".group-label", {
+      const gitlabGroup = page.locator(".workspace-list-sidebar .sidebar-group-header").filter({
+        has: page.locator(".sidebar-group-header__name", {
           hasText: "group/project",
         }),
       });
@@ -280,7 +280,7 @@ test.describe("workspace sidebar full-stack", () => {
       await page.goto(`${isolatedServer.info.base_url}/terminal/${githubWorkspace.id}`);
 
       const rows = page.locator(".workspace-list-sidebar .ws-row");
-      const headers = page.locator(".workspace-list-sidebar .group-header");
+      const headers = page.locator(".workspace-list-sidebar .sidebar-group-header");
       await expect(rows).toHaveCount(2);
       await expect(headers).toHaveCount(2);
 
@@ -370,7 +370,7 @@ test.describe("workspace sidebar full-stack", () => {
 
       await page.goto(`${isolatedServer.info.base_url}/terminal/${workspace.id}`);
 
-      const groupLabel = page.locator(".workspace-list-sidebar .group-header .group-label");
+      const groupLabel = page.locator(".workspace-list-sidebar .sidebar-group-header .sidebar-group-header__name");
       const diffStats = page.locator(".workspace-list-sidebar .workspace-diff-stats");
       const viewTrigger = page.getByTitle("View workspace options");
       const viewBadge = viewTrigger.locator(".kit-filter-dropdown__badge");
@@ -492,8 +492,8 @@ test.describe("workspace sidebar full-stack", () => {
       await page.goto(`${isolatedServer.info.base_url}/terminal/${safariWorkspace.id}`);
 
       const rows = page.locator(".workspace-list-sidebar .ws-row");
-      const groupHeader = page.locator(".workspace-list-sidebar .group-header").filter({
-        has: page.locator(".group-label", {
+      const groupHeader = page.locator(".workspace-list-sidebar .sidebar-group-header").filter({
+        has: page.locator(".sidebar-group-header__name", {
           hasText: "acme/widgets",
         }),
       });

--- a/frontend/tests/e2e-full/collapsible-repos.spec.ts
+++ b/frontend/tests/e2e-full/collapsible-repos.spec.ts
@@ -14,7 +14,7 @@ async function waitForPullList(page: Page): Promise<void> {
 }
 
 function widgetsHeader(page: Page) {
-  return page.locator(".repo-header", { hasText: "acme/widgets" });
+  return page.locator(".sidebar-group-header", { hasText: "acme/widgets" });
 }
 
 test("PR list — keyboard activation via Enter and Space toggles collapse", async ({ page }) => {

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -3511,8 +3511,11 @@ test.describe("diff view", () => {
     await expect(treeFileItems(detailFiles)).toHaveCount(4);
 
     // Collapse the acme/widgets repo group (containing the selected PR).
-    await page.locator(".repo-header", { hasText: "acme/widgets" }).click();
-    await expect(page.locator(".repo-header", { hasText: "acme/widgets" })).toHaveAttribute("aria-expanded", "false");
+    await page.locator(".sidebar-group-header", { hasText: "acme/widgets" }).click();
+    await expect(page.locator(".sidebar-group-header", { hasText: "acme/widgets" })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
 
     // PR row hidden, but the detail Files pane keeps the file list available.
     await expect(page.locator(".pull-item").filter({ hasText: "caching layer" })).toHaveCount(0);

--- a/frontend/tests/e2e-full/grouping-toggle.spec.ts
+++ b/frontend/tests/e2e-full/grouping-toggle.spec.ts
@@ -54,7 +54,7 @@ test.describe("grouping toggle", () => {
   test("j/k navigation follows flat order in ungrouped mode", async ({ page }) => {
     // Switch to ungrouped.
     await selectPullGrouping(page, "All");
-    await expect(page.locator(".repo-header")).toHaveCount(0, {
+    await expect(page.locator(".sidebar-group-header")).toHaveCount(0, {
       timeout: 5_000,
     });
 

--- a/frontend/tests/e2e-full/navigation.spec.ts
+++ b/frontend/tests/e2e-full/navigation.spec.ts
@@ -50,16 +50,16 @@ test.describe("view navigation", () => {
   test("Kata shell does not expose repo selector or respond to PR number shortcuts", async ({ page }) => {
     await page.goto("/kata");
 
-    await expect(page).toHaveURL(/\/kata$/);
+    await expect.poll(() => new URL(page.url()).pathname).toBe("/kata");
     await expect(page.getByRole("heading", { name: "Kata" })).toBeVisible();
     await expect(page.getByTitle("Select repository")).not.toBeAttached();
 
     await page.locator("main.app-main").click();
     await page.keyboard.press("1");
-    await expect(page).toHaveURL(/\/kata$/);
+    await expect.poll(() => new URL(page.url()).pathname).toBe("/kata");
 
     await page.keyboard.press("2");
-    await expect(page).toHaveURL(/\/kata$/);
+    await expect.poll(() => new URL(page.url()).pathname).toBe("/kata");
   });
 
   test("Docs and Messages routes load their mode shells directly", async ({ page }) => {

--- a/frontend/tests/e2e-full/pull-list.spec.ts
+++ b/frontend/tests/e2e-full/pull-list.spec.ts
@@ -141,9 +141,9 @@ test.describe("PR list view", () => {
 
     await selectPullGrouping(page, "Status");
 
-    const headers = page.locator(".repo-header");
+    const headers = page.locator(".sidebar-group-header");
     await expect(headers).toHaveCount(1);
-    await expect(headers.first().locator(".repo-header__name")).toHaveText("Closed");
+    await expect(headers.first().locator(".sidebar-group-header__name")).toHaveText("Closed");
   });
 
   test("search filters PRs by title", async ({ page }) => {

--- a/frontend/tests/e2e-full/sidebar-collapse.spec.ts
+++ b/frontend/tests/e2e-full/sidebar-collapse.spec.ts
@@ -333,7 +333,7 @@ test.describe("collapsible sidebar", () => {
 
     await dropdown.locator(".kit-filter-dropdown__item", { hasText: "Flat list" }).click();
     await expect(dropdown).toBeVisible();
-    await expect(page.locator(".repo-header")).toHaveCount(0, {
+    await expect(page.locator(".sidebar-group-header")).toHaveCount(0, {
       timeout: 5_000,
     });
     await expect(page.locator(".repo-chip").first()).toBeVisible();
@@ -413,7 +413,7 @@ test.describe("collapsible sidebar", () => {
 
     await dropdown.locator(".kit-filter-dropdown__item", { hasText: "All" }).last().click();
     await expect(dropdown).toBeVisible();
-    await expect(page.locator(".repo-header")).toHaveCount(0, {
+    await expect(page.locator(".sidebar-group-header")).toHaveCount(0, {
       timeout: 5_000,
     });
     await expect(page.locator(".repo-chip").first()).toBeVisible();

--- a/frontend/tests/e2e-full/sidebar-scroll-indicator.spec.ts
+++ b/frontend/tests/e2e-full/sidebar-scroll-indicator.spec.ts
@@ -76,3 +76,33 @@ test("PR, issue, and workspace rails share labeled overlay scroll regions", asyn
     await expect(scrollArea.locator("..").locator(".sidebar-scroll-indicator")).toHaveCount(1);
   }
 });
+
+test("dark grouped rows keep selected between the surface and hover", async ({ page }) => {
+  await page.addInitScript(() => localStorage.setItem("middleman-theme", "dark"));
+  await page.goto("/pulls");
+
+  const lightness = await page.evaluate(() => {
+    const colors = ["--sidebar-row-bg", "--bg-row-selected", "--sidebar-row-hover-bg"].map((token) => {
+      const sample = document.createElement("div");
+      sample.style.background = `var(${token})`;
+      document.body.append(sample);
+      const color = getComputedStyle(sample).backgroundColor;
+      sample.remove();
+      return color;
+    });
+    const canvas = document.createElement("canvas");
+    canvas.width = 1;
+    canvas.height = 1;
+    const context = canvas.getContext("2d", { willReadFrequently: true })!;
+    return colors.map((color) => {
+      context.clearRect(0, 0, 1, 1);
+      context.fillStyle = color;
+      context.fillRect(0, 0, 1, 1);
+      const [red, green, blue] = context.getImageData(0, 0, 1, 1).data;
+      return 0.2126 * red! + 0.7152 * green! + 0.0722 * blue!;
+    });
+  });
+
+  expect(lightness[1]).toBeGreaterThan(lightness[0]!);
+  expect(lightness[1]).toBeLessThan(lightness[2]!);
+});

--- a/frontend/tests/e2e-full/sidebar-scroll-indicator.spec.ts
+++ b/frontend/tests/e2e-full/sidebar-scroll-indicator.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test, type Locator } from "@playwright/test";
+
+async function constrainScrollArea(scrollArea: Locator): Promise<void> {
+  await scrollArea.locator("..").evaluate((node) => {
+    const root = node as HTMLElement;
+    root.style.flex = "0 0 160px";
+    root.style.height = "160px";
+  });
+}
+
+test("grouped rail scroll indicator floats above sticky headers", async ({ page }) => {
+  await page.goto("/pulls");
+  await expect(page.locator(".pull-item").first()).toBeVisible();
+
+  const scrollArea = page.getByRole("region", { name: "Pull requests" });
+  const scrollRoot = scrollArea.locator("..");
+  const indicator = scrollRoot.locator(".sidebar-scroll-indicator");
+  const thumb = indicator.locator(".sidebar-scroll-indicator__thumb");
+  const stickyHeader = scrollArea.locator(".sidebar-group-header").first();
+  await constrainScrollArea(scrollArea);
+
+  const initialGeometry = await scrollArea.evaluate((node) => ({
+    clientWidth: node.clientWidth,
+    offsetWidth: (node as HTMLElement).offsetWidth,
+    clientHeight: node.clientHeight,
+    scrollHeight: node.scrollHeight,
+  }));
+  expect(initialGeometry.scrollHeight).toBeGreaterThan(initialGeometry.clientHeight);
+  expect(initialGeometry.clientWidth).toBe(initialGeometry.offsetWidth);
+  await expect(indicator).toHaveCSS("opacity", "0");
+
+  await scrollArea.evaluate((node) => {
+    node.scrollTop = 20;
+  });
+  await expect(indicator).toHaveCSS("opacity", "1");
+
+  const stacking = await scrollArea.evaluate((node) => {
+    const root = node.parentElement;
+    const header = node.querySelector(".sidebar-group-header");
+    const overlay = root?.querySelector(".sidebar-scroll-indicator");
+    return {
+      header: Number.parseInt(getComputedStyle(header!).zIndex, 10),
+      overlay: Number.parseInt(getComputedStyle(overlay!).zIndex, 10),
+    };
+  });
+  expect(stacking.overlay).toBeGreaterThan(stacking.header);
+
+  const headerBox = await stickyHeader.boundingBox();
+  const thumbBox = await thumb.boundingBox();
+  expect(headerBox).not.toBeNull();
+  expect(thumbBox).not.toBeNull();
+  if (headerBox !== null && thumbBox !== null) {
+    expect(thumbBox.y).toBeLessThan(headerBox.y + headerBox.height);
+    expect(thumbBox.x).toBeGreaterThan(headerBox.x);
+  }
+
+  await scrollArea.focus();
+  await page.keyboard.press("End");
+  await expect.poll(() => scrollArea.evaluate((node) => node.scrollTop)).toBeGreaterThan(20);
+  await expect(indicator).toHaveCSS("opacity", "1");
+  await expect(indicator).toHaveCSS("opacity", "0", { timeout: 1_500 });
+});
+
+test("PR, issue, and workspace rails share labeled overlay scroll regions", async ({ page }) => {
+  const rails = [
+    { path: "/pulls", label: "Pull requests" },
+    { path: "/issues", label: "Issues" },
+    { path: "/workspaces", label: "Workspaces" },
+  ];
+
+  for (const rail of rails) {
+    await page.goto(rail.path);
+    const scrollArea = page.getByRole("region", { name: rail.label });
+    await expect(scrollArea).toBeVisible();
+    await expect(scrollArea).toHaveAttribute("tabindex", "0");
+    await expect(scrollArea.locator("..").locator(".sidebar-scroll-indicator")).toHaveCount(1);
+  }
+});

--- a/frontend/tests/e2e-full/sidebar-scroll-indicator.spec.ts
+++ b/frontend/tests/e2e-full/sidebar-scroll-indicator.spec.ts
@@ -70,7 +70,8 @@ test("PR, issue, and workspace rails share labeled overlay scroll regions", asyn
 
   for (const rail of rails) {
     await page.goto(rail.path);
-    const scrollArea = page.getByRole("region", { name: rail.label });
+    const scope = rail.path === "/workspaces" ? page.locator(".workspace-list-sidebar") : page;
+    const scrollArea = scope.getByRole("region", { name: rail.label, exact: true });
     await expect(scrollArea).toBeVisible();
     await expect(scrollArea).toHaveAttribute("tabindex", "0");
     await expect(scrollArea.locator("..").locator(".sidebar-scroll-indicator")).toHaveCount(1);

--- a/frontend/tests/e2e/app-shell.spec.ts
+++ b/frontend/tests/e2e/app-shell.spec.ts
@@ -21,9 +21,14 @@ test("renders mocked frontend data", async ({ page }) => {
   await page.goto("/pulls");
 
   await expect(page.getByText("Add browser regression coverage")).toBeVisible();
-  await expect(page.getByText("acme/widgets")).toBeVisible();
+  await expect(
+    page
+      .getByRole("region", { name: "Pull requests" })
+      .getByRole("button", { name: /^acme\/widgets \d+$/ })
+      .first(),
+  ).toBeVisible();
   await expect(page.getByRole("contentinfo").getByText("3 PRs")).toBeVisible();
-  await expect(page.getByRole("contentinfo").getByText("1 repos")).toBeVisible();
+  await expect(page.getByRole("contentinfo").getByText("2 repos")).toBeVisible();
 
   await page.getByRole("button", { name: "Issues" }).click();
 

--- a/frontend/tests/e2e/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar.spec.ts
@@ -3559,7 +3559,7 @@ test.describe("workspace list sorting", () => {
     await page.goto("/workspaces");
 
     const names = page.locator(".workspace-list-sidebar .ws-name");
-    const headers = page.locator(".workspace-list-sidebar .group-header");
+    const headers = page.locator(".workspace-list-sidebar .sidebar-group-header");
     await expect(names).toHaveText(["Newest created", "Oldest without activity", "Most recently active"]);
     await expect(headers).toHaveCount(2);
 
@@ -3634,7 +3634,7 @@ test.describe("workspace list sorting", () => {
 
     await page.goto("/workspaces");
 
-    const groupLabels = page.locator(".workspace-list-sidebar .group-label");
+    const groupLabels = page.locator(".workspace-list-sidebar .sidebar-group-header__name");
     await expect(groupLabels).toHaveText([
       "github/github.com/acme/widgets",
       "gitea/github.com/acme/widgets",

--- a/packages/ui/src/components/shared/GroupedSidebarSection.svelte
+++ b/packages/ui/src/components/shared/GroupedSidebarSection.svelte
@@ -63,6 +63,7 @@
     border-bottom: 1px solid var(--sidebar-list-border-muted, var(--border-muted));
     background: var(--sidebar-group-header-bg, var(--bg-inset));
     color: var(--text-muted);
+    cursor: pointer;
     font-family: inherit;
     font-size: var(--font-size-xs);
     font-weight: 600;
@@ -94,6 +95,10 @@
     flex-shrink: 0;
   }
 
+  .sidebar-group-header__leading:empty {
+    display: none;
+  }
+
   .sidebar-group-header__name {
     flex: 1;
     min-width: 0;
@@ -107,5 +112,11 @@
     color: var(--text-muted);
     font-family: var(--font-mono);
     font-size: var(--font-size-2xs);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .sidebar-group-header__chevron {
+      transition: none;
+    }
   }
 </style>

--- a/packages/ui/src/components/shared/GroupedSidebarSection.svelte
+++ b/packages/ui/src/components/shared/GroupedSidebarSection.svelte
@@ -1,0 +1,111 @@
+<script lang="ts">
+  import ChevronDownIcon from "@lucide/svelte/icons/chevron-down";
+  import type { Snippet } from "svelte";
+
+  interface Props {
+    label: string;
+    count: number;
+    collapsed: boolean;
+    onclick: () => void;
+    leading?: Snippet;
+    children: Snippet;
+  }
+
+  const {
+    label,
+    count,
+    collapsed,
+    onclick,
+    leading,
+    children,
+  }: Props = $props();
+</script>
+
+<section class="sidebar-list-group">
+  <button
+    type="button"
+    class="sidebar-group-header"
+    aria-expanded={!collapsed}
+    {onclick}
+  >
+    <span
+      class="sidebar-group-header__chevron"
+      class:sidebar-group-header__chevron--collapsed={collapsed}
+    >
+      <ChevronDownIcon size={10} strokeWidth={1.8} aria-hidden="true" />
+    </span>
+    {#if leading}
+      <span class="sidebar-group-header__leading">{@render leading()}</span>
+    {/if}
+    <span class="sidebar-group-header__name">{label}</span>
+    <span class="sidebar-group-header__count">{count}</span>
+  </button>
+  {#if !collapsed}
+    {@render children()}
+  {/if}
+</section>
+
+<style>
+  .sidebar-list-group {
+    border-bottom: 1px solid var(--sidebar-list-border, var(--border-default));
+  }
+
+  .sidebar-group-header {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    width: 100%;
+    padding: var(--sidebar-group-header-padding, 6px 12px 4px);
+    border: 0;
+    border-bottom: 1px solid var(--sidebar-list-border-muted, var(--border-muted));
+    background: var(--sidebar-group-header-bg, var(--bg-inset));
+    color: var(--text-muted);
+    font-family: inherit;
+    font-size: var(--font-size-xs);
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-align: left;
+    text-transform: uppercase;
+  }
+
+  .sidebar-group-header:hover {
+    background: var(--sidebar-row-hover-bg, var(--bg-surface-hover));
+  }
+
+  .sidebar-group-header[aria-expanded="false"] {
+    border-bottom-color: transparent;
+  }
+
+  .sidebar-group-header__chevron {
+    display: inline-flex;
+    flex-shrink: 0;
+    transition: transform 120ms ease;
+  }
+
+  .sidebar-group-header__chevron--collapsed {
+    transform: rotate(-90deg);
+  }
+
+  .sidebar-group-header__leading {
+    display: inline-flex;
+    flex-shrink: 0;
+  }
+
+  .sidebar-group-header__name {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .sidebar-group-header__count {
+    flex-shrink: 0;
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    font-size: var(--font-size-2xs);
+  }
+</style>

--- a/packages/ui/src/components/shared/SidebarScrollArea.svelte
+++ b/packages/ui/src/components/shared/SidebarScrollArea.svelte
@@ -1,0 +1,139 @@
+<script lang="ts">
+  import { onDestroy, onMount, type Snippet } from "svelte";
+  import type { ClassValue } from "svelte/elements";
+  import { getScrollIndicatorGeometry } from "./sidebarScrollIndicator.js";
+
+  interface Props {
+    class?: ClassValue;
+    dataTest?: string;
+    children: Snippet;
+  }
+
+  const {
+    class: className = "",
+    dataTest,
+    children,
+  }: Props = $props();
+
+  let viewportHeight = $state(0);
+  let contentHeight = $state(0);
+  let scrollTop = $state(0);
+  let visible = $state(false);
+  let hideTimer: number | undefined;
+  let viewport: HTMLDivElement;
+  let content: HTMLDivElement;
+
+  const geometry = $derived(
+    getScrollIndicatorGeometry(
+      viewportHeight,
+      contentHeight,
+      scrollTop,
+    ),
+  );
+
+  function handleScroll(event: Event): void {
+    scrollTop = (event.currentTarget as HTMLDivElement).scrollTop;
+    if (!geometry.scrollable) return;
+
+    visible = true;
+    window.clearTimeout(hideTimer);
+    hideTimer = window.setTimeout(() => {
+      visible = false;
+    }, 700);
+  }
+
+  function updateDimensions(): void {
+    viewportHeight = viewport.clientHeight;
+    contentHeight = content.offsetHeight;
+  }
+
+  onMount(() => {
+    updateDimensions();
+
+    const observer = new ResizeObserver(updateDimensions);
+    observer.observe(viewport);
+    observer.observe(content);
+
+    return () => observer.disconnect();
+  });
+
+  onDestroy(() => window.clearTimeout(hideTimer));
+</script>
+
+<div class={["sidebar-scroll-area", className]} data-test={dataTest}>
+  <div
+    class="sidebar-scroll-area__viewport"
+    bind:this={viewport}
+    onscroll={handleScroll}
+  >
+    <div
+      class="sidebar-scroll-area__content"
+      bind:this={content}
+    >
+      {@render children()}
+    </div>
+  </div>
+  <div
+    class={["sidebar-scroll-indicator", { visible: visible && geometry.scrollable }]}
+    aria-hidden="true"
+  >
+    <span
+      class="sidebar-scroll-indicator__thumb"
+      style:height={`${geometry.height}px`}
+      style:transform={`translateY(${geometry.top}px)`}
+    ></span>
+  </div>
+</div>
+
+<style>
+  .sidebar-scroll-area {
+    position: relative;
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .sidebar-scroll-area__viewport {
+    height: 100%;
+    overflow-y: auto;
+    scrollbar-width: none;
+  }
+
+  .sidebar-scroll-area__viewport::-webkit-scrollbar {
+    display: none;
+    width: 0;
+    height: 0;
+  }
+
+  .sidebar-scroll-area__content {
+    min-height: 100%;
+  }
+
+  .sidebar-scroll-indicator {
+    position: absolute;
+    inset: 0 2px 0 auto;
+    width: 4px;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 160ms cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  .sidebar-scroll-indicator.visible {
+    opacity: 1;
+  }
+
+  .sidebar-scroll-indicator__thumb {
+    display: block;
+    width: 100%;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--text-muted) 72%, transparent);
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--bg-primary) 35%, transparent);
+    will-change: transform;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .sidebar-scroll-indicator {
+      transition: none;
+    }
+  }
+</style>

--- a/packages/ui/src/components/shared/SidebarScrollArea.svelte
+++ b/packages/ui/src/components/shared/SidebarScrollArea.svelte
@@ -6,12 +6,14 @@
   interface Props {
     class?: ClassValue;
     dataTest?: string;
+    label: string;
     children: Snippet;
   }
 
   const {
     class: className = "",
     dataTest,
+    label,
     children,
   }: Props = $props();
 
@@ -61,10 +63,15 @@
 </script>
 
 <div class={["sidebar-scroll-area", className]} data-test={dataTest}>
+  <!-- Scrollable regions need keyboard access. -->
+  <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
   <div
     class="sidebar-scroll-area__viewport"
+    aria-label={label}
     bind:this={viewport}
     onscroll={handleScroll}
+    role="region"
+    tabindex="0"
   >
     <div
       class="sidebar-scroll-area__content"
@@ -112,6 +119,7 @@
   .sidebar-scroll-indicator {
     position: absolute;
     inset: 0 2px 0 auto;
+    z-index: 2;
     width: 4px;
     pointer-events: none;
     opacity: 0;
@@ -134,6 +142,13 @@
   @media (prefers-reduced-motion: reduce) {
     .sidebar-scroll-indicator {
       transition: none;
+    }
+  }
+
+  @media (forced-colors: active) {
+    .sidebar-scroll-indicator__thumb {
+      background: CanvasText;
+      box-shadow: none;
     }
   }
 </style>

--- a/packages/ui/src/components/shared/sidebarScrollIndicator.test.ts
+++ b/packages/ui/src/components/shared/sidebarScrollIndicator.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { getScrollIndicatorGeometry } from "./sidebarScrollIndicator.js";
+
+describe("getScrollIndicatorGeometry", () => {
+  it("hides the indicator when content fits", () => {
+    expect(getScrollIndicatorGeometry(200, 200, 0)).toEqual({
+      scrollable: false,
+      height: 0,
+      top: 0,
+    });
+  });
+
+  it("sizes and positions the indicator within the viewport", () => {
+    expect(getScrollIndicatorGeometry(100, 400, 150)).toEqual({
+      scrollable: true,
+      height: 25,
+      top: 37.5,
+    });
+  });
+
+  it("keeps a usable minimum thumb and clamps overscroll", () => {
+    expect(getScrollIndicatorGeometry(100, 1000, 1200)).toEqual({
+      scrollable: true,
+      height: 24,
+      top: 76,
+    });
+  });
+});

--- a/packages/ui/src/components/shared/sidebarScrollIndicator.ts
+++ b/packages/ui/src/components/shared/sidebarScrollIndicator.ts
@@ -1,0 +1,28 @@
+export interface ScrollIndicatorGeometry {
+  scrollable: boolean;
+  height: number;
+  top: number;
+}
+
+const MIN_THUMB_HEIGHT = 24;
+
+export function getScrollIndicatorGeometry(
+  viewportHeight: number,
+  contentHeight: number,
+  scrollTop: number,
+): ScrollIndicatorGeometry {
+  if (viewportHeight <= 0 || contentHeight <= viewportHeight) {
+    return { scrollable: false, height: 0, top: 0 };
+  }
+
+  const height = Math.max(MIN_THUMB_HEIGHT, (viewportHeight * viewportHeight) / contentHeight);
+  const scrollRange = contentHeight - viewportHeight;
+  const travel = viewportHeight - height;
+  const clampedScrollTop = Math.min(Math.max(scrollTop, 0), scrollRange);
+
+  return {
+    scrollable: true,
+    height,
+    top: (clampedScrollTop / scrollRange) * travel,
+  };
+}

--- a/packages/ui/src/components/sidebar/IssueItem.svelte
+++ b/packages/ui/src/components/sidebar/IssueItem.svelte
@@ -103,21 +103,30 @@
     display: block;
     width: 100%;
     text-align: left;
-    padding: 10px 12px;
-    border-bottom: 1px solid var(--border-muted);
-    background: var(--bg-surface);
+    padding: var(--sidebar-row-padding, 10px 12px);
+    border-bottom: 1px solid var(--sidebar-list-border-muted, var(--border-muted));
+    background: var(--sidebar-row-bg, var(--bg-surface));
     cursor: pointer;
     transition: background 0.1s;
     border-left: 3px solid transparent;
   }
 
   .issue-item:hover {
-    background: var(--bg-surface-hover);
+    background: var(--sidebar-row-hover-bg, var(--bg-surface-hover));
   }
 
   .issue-item.selected {
-    background: var(--bg-inset);
+    background: var(--bg-row-selected, var(--bg-inset));
     border-left-color: var(--accent-blue);
+  }
+
+  .issue-item.selected:hover {
+    background: var(--sidebar-row-hover-bg, var(--bg-surface-hover));
+  }
+
+  .issue-item:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--accent-blue);
   }
 
   .title {

--- a/packages/ui/src/components/sidebar/IssueList.svelte
+++ b/packages/ui/src/components/sidebar/IssueList.svelte
@@ -2,6 +2,7 @@
   import { getStores, getNavigate, getSidebar } from "../../context.js";
   import IssueItem from "./IssueItem.svelte";
   import GroupedSidebarSection from "../shared/GroupedSidebarSection.svelte";
+  import SidebarScrollArea from "../shared/SidebarScrollArea.svelte";
   import { Chip, SearchInput } from "@kenn-io/kit-ui";
   import { FilterDropdown } from "@kenn-io/kit-ui";
   import { SidebarToggle } from "@kenn-io/kit-ui";
@@ -208,7 +209,7 @@
   {#if issues.getIssueFilterState() !== "open"}
     <p class="state-note">Showing items closed after middleman began tracking them</p>
   {/if}
-  <div class="list-body">
+  <SidebarScrollArea class="list-body">
     {#if settings.isSettingsLoaded() && !settings.hasConfiguredRepos()}
       <p class="state-message">No repositories configured.<br />
         {#if !isEmbedded()}<button class="settings-link" onclick={() => navigate("/settings")}>Add one in Settings</button>{/if}</p>
@@ -259,7 +260,7 @@
         {/each}
       {/if}
     {/if}
-  </div>
+  </SidebarScrollArea>
   <div class="sidebar-footer">
     {#if !isEmbedded()}
       <button class="add-repo-link" onclick={() => navigate("/settings")}>
@@ -327,11 +328,6 @@
 
   :global(.list-count-chip) {
     flex-shrink: 0;
-  }
-
-  .list-body {
-    flex: 1;
-    overflow-y: auto;
   }
 
   .state-message {

--- a/packages/ui/src/components/sidebar/IssueList.svelte
+++ b/packages/ui/src/components/sidebar/IssueList.svelte
@@ -209,7 +209,7 @@
   {#if issues.getIssueFilterState() !== "open"}
     <p class="state-note">Showing items closed after middleman began tracking them</p>
   {/if}
-  <SidebarScrollArea class="list-body">
+  <SidebarScrollArea class="list-body" label="Issues">
     {#if settings.isSettingsLoaded() && !settings.hasConfiguredRepos()}
       <p class="state-message">No repositories configured.<br />
         {#if !isEmbedded()}<button class="settings-link" onclick={() => navigate("/settings")}>Add one in Settings</button>{/if}</p>

--- a/packages/ui/src/components/sidebar/IssueList.svelte
+++ b/packages/ui/src/components/sidebar/IssueList.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { getStores, getNavigate, getSidebar } from "../../context.js";
   import IssueItem from "./IssueItem.svelte";
+  import GroupedSidebarSection from "../shared/GroupedSidebarSection.svelte";
   import { Chip, SearchInput } from "@kenn-io/kit-ui";
   import { FilterDropdown } from "@kenn-io/kit-ui";
   import { SidebarToggle } from "@kenn-io/kit-ui";
@@ -229,25 +230,12 @@
         {#each [...issues.issuesByRepo().entries()] as [repo, repoIssues] (repo)}
           {@const collapsed = collapsedRepos.isCollapsed("issues", repo)}
           {@const repoLabel = repoIssues[0]?.repo.repo_path ?? repo}
-          <div class="repo-group">
-            <button
-              type="button"
-              class="repo-header"
-              aria-expanded={!collapsed}
-              onclick={() => collapsedRepos.toggle("issues", repo)}
-            >
-              <svg
-                class="repo-header__chevron"
-                class:repo-header__chevron--collapsed={collapsed}
-                width="10" height="10" viewBox="0 0 10 10"
-                fill="none" stroke="currentColor" stroke-width="1.5"
-              >
-                <polyline points="2,3 5,7 8,3" stroke-linecap="round" stroke-linejoin="round" />
-              </svg>
-              <span class="repo-header__name">{repoLabel}</span>
-              <span class="repo-header__count">{repoIssues.length}</span>
-            </button>
-            {#if !collapsed}
+          <GroupedSidebarSection
+            label={repoLabel}
+            count={repoIssues.length}
+            {collapsed}
+            onclick={() => collapsedRepos.toggle("issues", repo)}
+          >
               {#each repoIssues as issue (issue.ID)}
                 {@const issueRef = routeRefForIssue(issue)}
                 <IssueItem
@@ -257,8 +245,7 @@
                   onclick={() => handleSelect(issueRef)}
                 />
               {/each}
-            {/if}
-          </div>
+          </GroupedSidebarSection>
         {/each}
       {:else}
         {#each issues.getIssues() as issue (issue.ID)}
@@ -388,68 +375,6 @@
   @keyframes pulse {
     0%, 100% { opacity: 0.4; }
     50% { opacity: 1; }
-  }
-
-  .repo-group {
-    border-bottom: 1px solid var(--border-default);
-  }
-
-  .repo-header {
-    font-size: var(--font-size-xs);
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: var(--text-muted);
-    padding: 6px 12px 4px;
-    background: var(--bg-inset);
-    border-bottom: 1px solid var(--border-muted);
-    position: sticky;
-    top: 0;
-    z-index: 1;
-
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    width: 100%;
-    text-align: left;
-    border-top: none;
-    border-left: none;
-    border-right: none;
-    cursor: pointer;
-    font-family: inherit;
-  }
-
-  .repo-header:hover {
-    background: var(--bg-surface-hover);
-  }
-
-  .repo-header[aria-expanded="false"] {
-    border-bottom: none;
-  }
-
-  .repo-header__chevron {
-    color: var(--text-muted);
-    transition: transform 120ms ease;
-    flex-shrink: 0;
-  }
-
-  .repo-header__chevron--collapsed {
-    transform: rotate(-90deg);
-  }
-
-  .repo-header__name {
-    flex: 1;
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .repo-header__count {
-    font-family: var(--font-mono);
-    font-size: var(--font-size-2xs);
-    color: var(--text-muted);
-    flex-shrink: 0;
   }
 
   .sidebar-footer {

--- a/packages/ui/src/components/sidebar/PullItem.svelte
+++ b/packages/ui/src/components/sidebar/PullItem.svelte
@@ -285,21 +285,30 @@
     display: block;
     width: 100%;
     text-align: left;
-    padding: 10px 12px;
-    border-bottom: 1px solid var(--border-muted);
-    background: var(--bg-surface);
+    padding: var(--sidebar-row-padding, 10px 12px);
+    border-bottom: 1px solid var(--sidebar-list-border-muted, var(--border-muted));
+    background: var(--sidebar-row-bg, var(--bg-surface));
     cursor: pointer;
     transition: background 0.1s;
     border-left: 3px solid transparent;
   }
 
   .pull-item:hover {
-    background: var(--bg-surface-hover);
+    background: var(--sidebar-row-hover-bg, var(--bg-surface-hover));
   }
 
   .pull-item.selected {
-    background: var(--bg-inset);
+    background: var(--bg-row-selected, var(--bg-inset));
     border-left-color: var(--accent-blue);
+  }
+
+  .pull-item.selected:hover {
+    background: var(--sidebar-row-hover-bg, var(--bg-surface-hover));
+  }
+
+  .pull-item:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--accent-blue);
   }
 
   .pull-item.active-worktree {

--- a/packages/ui/src/components/sidebar/PullList.svelte
+++ b/packages/ui/src/components/sidebar/PullList.svelte
@@ -2,6 +2,7 @@
   import { getStores, getNavigate, getSidebar, getActions, getHostState } from "../../context.js";
   import { groupByWorkflow } from "../../stores/workflow.svelte.js";
   import DiffSidebar from "../diff/DiffSidebar.svelte";
+  import GroupedSidebarSection from "../shared/GroupedSidebarSection.svelte";
   import PullItem from "./PullItem.svelte";
   import { Chip, SearchInput } from "@kenn-io/kit-ui";
   import { FilterDropdown } from "@kenn-io/kit-ui";
@@ -452,25 +453,12 @@
           {@const userCollapsed = collapsedRepos.isCollapsed("pulls", group.collapseKey)}
           {@const hasSelectedPR = keepSelectedGroupExpanded && selectedPRGroup?.key === group.key}
           {@const collapsed = userCollapsed && !hasSelectedPR}
-          <div class="repo-group">
-            <button
-              type="button"
-              class="repo-header"
-              aria-expanded={!collapsed}
-              onclick={() => collapsedRepos.toggle("pulls", group.collapseKey)}
-            >
-              <svg
-                class="repo-header__chevron"
-                class:repo-header__chevron--collapsed={collapsed}
-                width="10" height="10" viewBox="0 0 10 10"
-                fill="none" stroke="currentColor" stroke-width="1.5"
-              >
-                <polyline points="2,3 5,7 8,3" stroke-linecap="round" stroke-linejoin="round" />
-              </svg>
-              <span class="repo-header__name">{group.label}</span>
-              <span class="repo-header__count">{group.items.length}</span>
-            </button>
-            {#if !collapsed}
+          <GroupedSidebarSection
+            label={group.label}
+            count={group.items.length}
+            {collapsed}
+            onclick={() => collapsedRepos.toggle("pulls", group.collapseKey)}
+          >
               {#each group.items as pr (pr.ID)}
                 {@const prRef = routeRefForPull(pr)}
                 {@const prSelected = isSelected(prRef)}
@@ -487,8 +475,7 @@
                   </div>
                 {/if}
               {/each}
-            {/if}
-          </div>
+          </GroupedSidebarSection>
         {/each}
       {:else}
         {#each visiblePulls as pr (pr.ID)}
@@ -655,68 +642,6 @@
   @keyframes pulse {
     0%, 100% { opacity: 0.4; }
     50% { opacity: 1; }
-  }
-
-  .repo-group {
-    border-bottom: 1px solid var(--border-default);
-  }
-
-  .repo-header {
-    font-size: var(--font-size-xs);
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: var(--text-muted);
-    padding: 6px 12px 4px;
-    background: var(--bg-inset);
-    border-bottom: 1px solid var(--border-muted);
-    position: sticky;
-    top: 0;
-    z-index: 1;
-
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    width: 100%;
-    text-align: left;
-    border-top: none;
-    border-left: none;
-    border-right: none;
-    cursor: pointer;
-    font-family: inherit;
-  }
-
-  .repo-header:hover {
-    background: var(--bg-surface-hover);
-  }
-
-  .repo-header[aria-expanded="false"] {
-    border-bottom: none;
-  }
-
-  .repo-header__chevron {
-    color: var(--text-muted);
-    transition: transform 120ms ease;
-    flex-shrink: 0;
-  }
-
-  .repo-header__chevron--collapsed {
-    transform: rotate(-90deg);
-  }
-
-  .repo-header__name {
-    flex: 1;
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .repo-header__count {
-    font-family: var(--font-mono);
-    font-size: var(--font-size-2xs);
-    color: var(--text-muted);
-    flex-shrink: 0;
   }
 
   .sidebar-footer {

--- a/packages/ui/src/components/sidebar/PullList.svelte
+++ b/packages/ui/src/components/sidebar/PullList.svelte
@@ -3,6 +3,7 @@
   import { groupByWorkflow } from "../../stores/workflow.svelte.js";
   import DiffSidebar from "../diff/DiffSidebar.svelte";
   import GroupedSidebarSection from "../shared/GroupedSidebarSection.svelte";
+  import SidebarScrollArea from "../shared/SidebarScrollArea.svelte";
   import PullItem from "./PullItem.svelte";
   import { Chip, SearchInput } from "@kenn-io/kit-ui";
   import { FilterDropdown } from "@kenn-io/kit-ui";
@@ -423,11 +424,15 @@
   {#if pulls.getFilterState() !== "open"}
     <p class="state-note">Showing items closed after middleman began tracking them</p>
   {/if}
-  <div
-    data-test="pr-list"
-    class="list-body"
-    class:list-body--diff-focus={isDiffFocus}
-    class:list-body--diff-focus-worktree={isDiffFocus && isSelectedActiveWorktree}
+  <SidebarScrollArea
+    dataTest="pr-list"
+    class={[
+      "list-body",
+      {
+        "list-body--diff-focus": isDiffFocus,
+        "list-body--diff-focus-worktree": isDiffFocus && isSelectedActiveWorktree,
+      },
+    ]}
   >
     {#if settings.isSettingsLoaded() && !settings.hasConfiguredRepos()}
       <p class="state-message">No repositories configured.<br />
@@ -496,7 +501,7 @@
         {/each}
       {/if}
     {/if}
-  </div>
+  </SidebarScrollArea>
   {#if needsFallbackFileList}
     <div class="diff-files-wrap">
                   <DiffSidebar showCommits={false} />
@@ -571,33 +576,28 @@
     flex-shrink: 0;
   }
 
-  .list-body {
-    flex: 1;
-    overflow-y: auto;
-  }
-
   /* Diff focus: combine typographic mute on siblings + a continuous
      accent rail that extends from the selected card through the inline
      file list, binding them as one visual unit. */
-  .list-body--diff-focus :global(.pull-item:not(.selected) .title) {
+  .pull-list :global(.list-body--diff-focus .pull-item:not(.selected) .title) {
     color: var(--text-muted);
     font-weight: 400;
     transition: color 0.15s ease;
   }
 
-  .list-body--diff-focus :global(.pull-item:not(.selected) .state-dot) {
+  .pull-list :global(.list-body--diff-focus .pull-item:not(.selected) .state-dot) {
     opacity: 0.45;
   }
 
-  .list-body--diff-focus :global(.pull-item:not(.selected):hover .title) {
+  .pull-list :global(.list-body--diff-focus .pull-item:not(.selected):hover .title) {
     color: var(--text-secondary);
   }
 
-  .list-body--diff-focus .diff-files-wrap {
+  .pull-list :global(.list-body--diff-focus .diff-files-wrap) {
     border-left: 3px solid var(--accent-blue);
   }
 
-  .list-body--diff-focus-worktree .diff-files-wrap {
+  .pull-list :global(.list-body--diff-focus-worktree .diff-files-wrap) {
     border-left-color: var(--accent-teal, var(--accent-green));
   }
 

--- a/packages/ui/src/components/sidebar/PullList.svelte
+++ b/packages/ui/src/components/sidebar/PullList.svelte
@@ -426,6 +426,7 @@
   {/if}
   <SidebarScrollArea
     dataTest="pr-list"
+    label="Pull requests"
     class={[
       "list-body",
       {

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -123,6 +123,7 @@ export { Button } from "@kenn-io/kit-ui";
 export { default as CommentEditor } from "./components/detail/CommentEditor.svelte";
 export { Chip } from "@kenn-io/kit-ui";
 export { default as ItemKindChip } from "./components/shared/ItemKindChip.svelte";
+export { default as GroupedSidebarSection } from "./components/shared/GroupedSidebarSection.svelte";
 export { default as ItemStateChip } from "./components/shared/ItemStateChip.svelte";
 export { CollapsibleSidebar, SidebarToggle } from "@kenn-io/kit-ui";
 export { DiffStats } from "@kenn-io/kit-ui";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -124,6 +124,7 @@ export { default as CommentEditor } from "./components/detail/CommentEditor.svel
 export { Chip } from "@kenn-io/kit-ui";
 export { default as ItemKindChip } from "./components/shared/ItemKindChip.svelte";
 export { default as GroupedSidebarSection } from "./components/shared/GroupedSidebarSection.svelte";
+export { default as SidebarScrollArea } from "./components/shared/SidebarScrollArea.svelte";
 export { default as ItemStateChip } from "./components/shared/ItemStateChip.svelte";
 export { CollapsibleSidebar, SidebarToggle } from "@kenn-io/kit-ui";
 export { DiffStats } from "@kenn-io/kit-ui";


### PR DESCRIPTION
- Makes dark-mode row selection clearer while keeping hover brighter.
- Standardizes grouped PR, issue, and workspace sidebar hierarchy and theming.
- Uses a transient overlay scroll indicator that stays above sticky group headers without reserving content width.

<sup>generated by a clanker</sup>