### PR TITLE
Clean up Kata project navigation and reassignment

### DIFF
--- a/context/testing.md
+++ b/context/testing.md
@@ -126,6 +126,10 @@ polling for state that the app already owns in JavaScript. Browser/e2e tests
 should call `reset()` before assertions, and the graph component clears the
 bridge on unmount so assertions do not read stale graph sessions.
 
+Playwright waits must observe the rendered state consumed by the next assertion,
+not only the request completion or control value that triggered it; route refinement
+can leave new controls paired with old or loading content (`frontend/tests/e2e-full/kata.spec.ts:1625`, `frontend/tests/e2e-full/repo-browser.spec.ts:480`).
+
 ## Huma API Contract
 
 Every public operation in `/api/v1/openapi.json` must have explicit OpenAPI

--- a/docs/superpowers/plans/2026-07-12-kata-project-ux-cleanup.md
+++ b/docs/superpowers/plans/2026-07-12-kata-project-ux-cleanup.md
@@ -1,0 +1,1001 @@
+# Kata Project UX Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Standardize Kata project navigation, remove accidental project-renaming affordances, and move issue reassignment from the breadcrumb into the explicit issue actions menu.
+
+**Architecture:** Keep all daemon and store capabilities intact while changing only frontend interaction composition. `KataSidebar` adopts the shared grouped-sidebar primitives, while `KataIssueOverflowMenu` owns destination eligibility, search, focus, and retry state for the existing `onMoveIssue` callback.
+
+**Tech Stack:** Svelte 5 runes, TypeScript, `@middleman/ui`, `@kenn-io/kit-ui`, Testing Library, Vite+ Vitest unit/browser projects, and Playwright full-stack tests.
+
+## Global Constraints
+
+- Render system views, supplied Kata areas, and the existing new-project control in that order.
+- Areas start expanded; collapse state survives reactive updates while mounted but is not persisted across remounts or reloads.
+- Remove only sidebar rename UI and callback wiring; retain Kata client/store rename capability.
+- Display the issue project breadcrumb as passive text using the existing name/UID fallback order.
+- Expose exact copy **Move to another project** only when an eligible destination exists.
+- Exclude the current project and inbox-role projects from destinations; sort names case-insensitively and show open-task counts.
+- Preserve workspace-owned mutation error presentation and keep the destination picker open after a handled failure.
+- Keep pointer, keyboard, Escape/focus, narrow-width, project creation, navigation, and shared scroll-indicator behavior working.
+- Do not modify backend, database, OpenAPI, generated API, daemon contracts, or shared primitives unless implementation reveals an actual shared defect.
+- Use Bun/Vite+ tooling only; never invoke npm.
+
+---
+
+## File Map
+
+- `frontend/src/lib/components/kata/KataSidebar.svelte`: shared scroll/group composition, mounted collapse state, navigation-only project rows, and project creation.
+- `frontend/src/lib/components/kata/KataSidebar.test.ts`: sidebar grouping, collapse lifetime, ordering, navigation, creation, and absence of rename affordances.
+- `frontend/src/lib/features/kata/KataWorkspace.svelte`: remove sidebar rename forwarding and return move success from the existing task wrapper.
+- `frontend/src/lib/components/terminal/KataWorkspaceSidebarPane.svelte`: match the boolean issue-move callback contract in the embedded workspace.
+- `frontend/src/lib/components/kata/KataIssueDetail.svelte`: passive project breadcrumb and project/move props forwarded to the overflow menu.
+- `frontend/src/lib/components/kata/KataIssueDetail.test.ts`: passive breadcrumb and project-name fallback coverage.
+- `frontend/src/lib/components/kata/KataIssueOverflowMenu.svelte`: explicit move action, searchable destination view, pending/retry state, focus restoration, and issue-identity reset.
+- `frontend/src/lib/components/kata/KataIssueOverflowMenu.test.ts`: destination rules, sorting, search, success/failure, issue reset, and keyboard dismissal.
+- `frontend/tests/e2e-full/kata.spec.ts`: replace obsolete rename workflows and move the real-daemon reassignment flow to More actions.
+
+---
+
+### Task 1: Adopt Shared Kata Sidebar Grouping
+
+**Files:**
+- Modify: `frontend/src/lib/components/kata/KataSidebar.test.ts`
+- Modify: `frontend/src/lib/components/kata/KataSidebar.svelte`
+
+**Interfaces:**
+- Consumes: `GroupedSidebarSection` and `SidebarScrollArea` exported by `@middleman/ui`.
+- Produces: mounted `collapsedAreas: string[]` state and one native project button per visible project.
+
+- [ ] **Step 1: Add failing group and order coverage**
+
+Add a test that renders the existing `areas` fixture and asserts the labeled scroll region contains system navigation before `Personal`, then `Work`, then `New project`; both group buttons begin expanded and expose project counts:
+
+```ts
+it("renders system views, expanded area groups, and project creation in order", () => {
+  renderSidebar();
+
+  const navigation = screen.getByRole("region", { name: "Kata navigation" });
+  const inbox = within(navigation).getByRole("button", { name: /^Inbox\b/ });
+  const personal = within(navigation).getByRole("button", { name: /^Personal\s+1$/ });
+  const work = within(navigation).getByRole("button", { name: /^Work\s+1$/ });
+  const create = within(navigation).getByRole("button", { name: "New project" });
+
+  expect(personal).toHaveAttribute("aria-expanded", "true");
+  expect(work).toHaveAttribute("aria-expanded", "true");
+  expect(
+    [inbox, personal, work, create].map((element) =>
+      inbox.compareDocumentPosition(element) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ),
+  ).toEqual([0, Node.DOCUMENT_POSITION_FOLLOWING, Node.DOCUMENT_POSITION_FOLLOWING, Node.DOCUMENT_POSITION_FOLLOWING]);
+});
+```
+
+Extract a local `renderSidebar(overrides = {})` helper in the test file so every render receives the same valid props. Keep it local because no other test file consumes this fixture.
+
+- [ ] **Step 2: Add failing collapse-lifetime coverage**
+
+```ts
+it("keeps area collapse state while mounted and resets it after remount", async () => {
+  const view = renderSidebar();
+  const personal = screen.getByRole("button", { name: /^Personal\s+1$/ });
+
+  await fireEvent.click(personal);
+  expect(personal).toHaveAttribute("aria-expanded", "false");
+  expect(screen.queryByRole("button", { name: /^Finances\b/ })).toBeNull();
+
+  await view.rerender({ areas: [...areas] });
+  expect(screen.getByRole("button", { name: /^Personal\s+1$/ })).toHaveAttribute("aria-expanded", "false");
+
+  view.unmount();
+  renderSidebar();
+  expect(screen.getByRole("button", { name: /^Personal\s+1$/ })).toHaveAttribute("aria-expanded", "true");
+});
+```
+
+- [ ] **Step 3: Run the focused test to verify failure**
+
+Run from `frontend/`:
+
+```bash
+node ../node_modules/vite-plus/bin/vp test run --project unit src/lib/components/kata/KataSidebar.test.ts
+```
+
+Expected: FAIL because area headings are not expandable buttons and the sidebar is not a labeled `SidebarScrollArea` region.
+
+- [ ] **Step 4: Add shared imports and collapse state**
+
+In `KataSidebar.svelte`, import the shared components and add mounted local state:
+
+```ts
+import { GroupedSidebarSection, SidebarScrollArea } from "@middleman/ui";
+
+let collapsedAreas = $state<string[]>([]);
+
+function toggleArea(name: string): void {
+  collapsedAreas = collapsedAreas.includes(name)
+    ? collapsedAreas.filter((area) => area !== name)
+    : [...collapsedAreas, name];
+}
+```
+
+Do not synchronize this state into URL, local storage, or the workspace store.
+
+- [ ] **Step 5: Replace custom scrolling and area sections**
+
+Keep the outer `aside`, but make `SidebarScrollArea` the only scrolling owner:
+
+```svelte
+<aside class="kata-sidebar">
+  <SidebarScrollArea label="Kata navigation">
+    <nav class="kata-nav" aria-label="System views">
+      <!-- retain the existing keyed system-view loop unchanged -->
+    </nav>
+
+    {#each areas as area (area.name)}
+      <GroupedSidebarSection
+        label={area.name}
+        count={area.projects.length}
+        collapsed={collapsedAreas.includes(area.name)}
+        onclick={() => toggleArea(area.name)}
+      >
+        {#each area.projects as project (project.uid)}
+          <!-- project row retained here until Task 2 removes rename behavior -->
+        {/each}
+      </GroupedSidebarSection>
+    {/each}
+
+    <div class="project-create">
+      <!-- retain existing creation form/control -->
+    </div>
+  </SidebarScrollArea>
+</aside>
+```
+
+Render supplied arrays directly; do not sort or auto-expand a selected project’s area.
+
+- [ ] **Step 6: Align row styling with the shared contract**
+
+Remove `overflow: auto` from `.kata-sidebar`. Preserve the existing `900px` narrow breakpoint and bounded sidebar height, but let the nested scroll area shrink with `min-height: 0`. Set row styles through the existing tokens:
+
+```css
+.kata-sidebar {
+  min-height: 0;
+  background: var(--bg-inset);
+}
+
+.kata-nav button,
+.project-select-button {
+  background: var(--sidebar-row-bg, transparent);
+  padding: var(--sidebar-row-padding, 6px 10px);
+}
+
+.kata-nav button:hover,
+.project-select-button:hover {
+  background: var(--sidebar-row-hover-bg, var(--bg-surface-hover));
+}
+
+.kata-nav button.active,
+.project-row.active .project-select-button {
+  background: var(--bg-row-selected);
+}
+```
+
+Retain Kata-specific grid/name/count layout and existing focus-visible treatment.
+
+- [ ] **Step 7: Run focused tests and commit**
+
+```bash
+node ../node_modules/vite-plus/bin/vp test run --project unit src/lib/components/kata/KataSidebar.test.ts
+git add frontend/src/lib/components/kata/KataSidebar.svelte frontend/src/lib/components/kata/KataSidebar.test.ts
+git commit -m "feat: group Kata project navigation"
+```
+
+Expected: focused test PASS; commit hooks PASS.
+
+---
+
+### Task 2: Make Sidebar Project Rows Navigation-Only
+
+**Files:**
+- Modify: `frontend/src/lib/components/kata/KataSidebar.test.ts`
+- Modify: `frontend/src/lib/components/kata/KataSidebar.svelte`
+- Modify: `frontend/src/lib/features/kata/KataWorkspace.svelte`
+
+**Interfaces:**
+- Removes: `KataSidebar` prop `onRenameProject: (id: number, name: string) => Promise<void>`.
+- Preserves: `KataWorkspaceStore.renameProject(id, name)` and task-client rename operations.
+
+- [ ] **Step 1: Replace contradictory rename tests with a failing navigation-only test**
+
+Delete `double-clicking a project enters rename mode` and `renames a project from the project row`. Add:
+
+```ts
+it("keeps project rows navigation-only without rename affordances", async () => {
+  const onOpenProject = vi.fn();
+  renderSidebar({ onOpenProject });
+
+  const finances = screen.getByRole("button", { name: /^Finances\b/ });
+  expect(screen.queryByRole("button", { name: "Rename Finances" })).toBeNull();
+  expect(screen.queryByRole("textbox", { name: "Rename project" })).toBeNull();
+
+  await fireEvent.doubleClick(finances);
+  expect(screen.queryByRole("textbox", { name: "Rename project" })).toBeNull();
+  expect(onOpenProject).toHaveBeenCalledWith("project-finances");
+});
+```
+
+Do not assert an exact callback count because a synthetic double-click may dispatch two clicks.
+
+- [ ] **Step 2: Run the focused test to verify failure**
+
+```bash
+node ../node_modules/vite-plus/bin/vp test run --project unit src/lib/components/kata/KataSidebar.test.ts
+```
+
+Expected: FAIL because the rename button and double-click form still exist.
+
+- [ ] **Step 3: Remove sidebar rename implementation**
+
+Remove from `KataSidebar.svelte`:
+
+```ts
+import PencilIcon from "@lucide/svelte/icons/pencil";
+onRenameProject: (id: number, name: string) => Promise<void>;
+let renamingProjectID = $state<number | null>(null);
+let renameDraft = $state("");
+let renameSaving = $state(false);
+let renameError = $state<string | null>(null);
+let renameInput: HTMLInputElement | null = $state(null);
+```
+
+Also remove `startRenamingProject`, `cancelRenamingProject`, `submitRenameProject`, the conditional rename form, `ondblclick`, the pencil button, and rename-only CSS. Render each project as a single native button:
+
+```svelte
+<button
+  type="button"
+  class="project-select-button"
+  class:active={isProjectActive(project.uid)}
+  onclick={() => void onOpenProject(project.uid)}
+>
+  <span class="project-name">{project.name}</span>
+  <span class="project-count count">{project.open_count}</span>
+</button>
+```
+
+Do not replace it with a `div role="button"` or nested buttons.
+
+- [ ] **Step 4: Remove workspace callback forwarding**
+
+Delete from `KataWorkspace.svelte`:
+
+```ts
+async function renameKataProject(id: number, name: string): Promise<void> {
+  await store.renameProject(id, name);
+}
+```
+
+Remove `onRenameProject={renameKataProject}` from `<KataSidebar>`. Do not change `store.renameProject`, task types, task client, or the e2e daemon PATCH handler.
+
+- [ ] **Step 5: Run focused and preservation tests**
+
+```bash
+node ../node_modules/vite-plus/bin/vp test run --project unit \
+  src/lib/components/kata/KataSidebar.test.ts \
+  src/lib/stores/kata-workspace.svelte.test.ts \
+  src/lib/api/kata/taskClient.test.ts
+```
+
+Expected: PASS, including existing rename API/store behavior.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/lib/components/kata/KataSidebar.svelte \
+  frontend/src/lib/components/kata/KataSidebar.test.ts \
+  frontend/src/lib/features/kata/KataWorkspace.svelte
+git commit -m "feat: make Kata project rows navigation-only"
+```
+
+---
+
+### Task 3: Make the Issue Project Breadcrumb Passive
+
+**Files:**
+- Modify: `frontend/src/lib/components/kata/KataIssueDetail.test.ts`
+- Modify: `frontend/src/lib/components/kata/KataIssueDetail.svelte`
+
+**Interfaces:**
+- Preserves: `currentProjectName(): string` fallback order.
+- Removes: breadcrumb-owned destination picker; issue reassignment remains available through the unchanged `onMoveIssue` prop until Task 4 forwards it to the overflow menu.
+
+- [ ] **Step 1: Replace the breadcrumb-move test**
+
+Remove the existing `moves to a non-inbox project from the crumb picker` test. Add:
+
+```ts
+it("renders the current project as passive breadcrumb text", () => {
+  renderDetail();
+  const detail = screen.getByRole("region", { name: "Task detail" });
+
+  expect(within(detail).getByText("Inbox")).toBeTruthy();
+  expect(within(detail).queryByRole("button", { name: /^Move issue from/ })).toBeNull();
+  expect(within(detail).queryByRole("combobox", { name: "Move issue project" })).toBeNull();
+});
+```
+
+- [ ] **Step 2: Cover both fallback levels**
+
+Update the existing fallback test to assert loaded project name text, then add the final UID fallback:
+
+```ts
+it("uses the loaded project name when issue project_name is empty", () => {
+  renderDetail({ issue: makeIssue({ project_uid: "project-2", project_name: "" }) });
+  expect(screen.getByText("Roadmap")).toBeTruthy();
+});
+
+it("uses the project UID when no project name can be resolved", () => {
+  renderDetail({
+    issue: makeIssue({ project_id: 99, project_uid: "project-missing", project_name: "" }),
+    projects: [],
+  });
+  expect(screen.getByText("project-missing")).toBeTruthy();
+});
+```
+
+- [ ] **Step 3: Run the focused test to verify failure**
+
+```bash
+node ../node_modules/vite-plus/bin/vp test run --project unit src/lib/components/kata/KataIssueDetail.test.ts
+```
+
+Expected: FAIL because the project remains a `TypeaheadTrigger` button.
+
+- [ ] **Step 4: Render passive text**
+
+In `KataIssueDetail.svelte`, replace the breadcrumb `TypeaheadTrigger` with:
+
+```svelte
+<span class="crumb-project" title={currentProjectName()}>{currentProjectName()}</span>
+<span class="crumb-sep">/</span>
+<span class="crumb-id">{issue.issue.short_id}</span>
+```
+
+Keep `currentProjectName()` unchanged. Remove only breadcrumb-picker imports, options, and CSS; retain `TypeaheadTrigger` if other detail controls still use it. Style `.crumb-project` with truncation and muted text, without a border, hover state, cursor, or chevron.
+
+- [ ] **Step 5: Run and commit**
+
+```bash
+node ../node_modules/vite-plus/bin/vp test run --project unit src/lib/components/kata/KataIssueDetail.test.ts
+git add frontend/src/lib/components/kata/KataIssueDetail.svelte frontend/src/lib/components/kata/KataIssueDetail.test.ts
+git commit -m "feat: make Kata project breadcrumbs passive"
+```
+
+---
+
+### Task 4: Move Issue Reassignment Into More Actions
+
+**Files:**
+- Modify: `frontend/src/lib/components/kata/KataIssueOverflowMenu.test.ts`
+- Modify: `frontend/src/lib/components/kata/KataIssueOverflowMenu.svelte`
+- Modify: `frontend/src/lib/components/kata/KataIssueDetail.svelte`
+- Modify: `frontend/src/lib/features/kata/KataWorkspace.svelte`
+- Modify: `frontend/src/lib/components/terminal/KataWorkspaceSidebarPane.svelte`
+
+**Interfaces:**
+- Adds to `KataIssueOverflowMenu` props:
+  - `projects: KataProjectSummary[]`
+  - `onMoveIssue: (toProjectUID: string) => boolean | Promise<boolean>`
+- Changes `KataIssueDetail.onMoveIssue` to the same non-null boolean contract.
+- Produces: `menuView: "actions" | "move"`, search query, destination derivation, per-destination pending state, and success/failure-aware close behavior.
+
+- [ ] **Step 1: Extend the test fixture**
+
+Add to `KataIssueOverflowMenu.test.ts`:
+
+```ts
+import type { KataProjectSummary, KataTaskDetail } from "../../api/kata/taskTypes.js";
+
+function makeProject(
+  uid: string,
+  name: string,
+  openCount: number,
+  role = "",
+): KataProjectSummary {
+  return {
+    id: uid === "project-1" ? 1 : 2,
+    uid,
+    name,
+    metadata: role ? { role } : {},
+    open_count: openCount,
+    revision: 1,
+    created_at: "2026-06-01T12:00:00Z",
+  };
+}
+
+const projects = [
+  makeProject("project-1", "Inbox", 2, "inbox"),
+  makeProject("project-alpha", "Alpha", 3),
+  makeProject("project-roadmap", "Roadmap", 5),
+];
+```
+
+Update all existing renders to pass `projects` and `onMoveIssue: vi.fn(async () => true)`.
+
+- [ ] **Step 2: Add failing destination eligibility and ordering tests**
+
+```ts
+it("hides move when only the current and inbox projects exist", async () => {
+  renderMenu({ projects: [makeProject("project-1", "Current", 1), makeProject("inbox", "Inbox", 2, "inbox")] });
+  await fireEvent.click(screen.getByRole("button", { name: "More actions" }));
+  expect(screen.queryByRole("menuitem", { name: "Move to another project" })).toBeNull();
+});
+
+it("shows sorted eligible destinations with open counts", async () => {
+  renderMenu({ projects: [...projects].reverse() });
+  await fireEvent.click(screen.getByRole("button", { name: "More actions" }));
+  await fireEvent.click(screen.getByRole("menuitem", { name: "Move to another project" }));
+
+  const options = screen.getAllByRole("button", { name: /Alpha|Roadmap/ });
+  expect(options.map((button) => button.textContent)).toEqual(["Alpha3", "Roadmap5"]);
+  expect(screen.queryByText("Inbox")).toBeNull();
+});
+```
+
+Set the test issue’s current project to a non-inbox project when necessary so the inbox filter and current-project filter are tested independently.
+
+- [ ] **Step 3: Add failing search and result-contract tests**
+
+```ts
+it("filters destinations and closes after a successful move", async () => {
+  const onMoveIssue = vi.fn(async () => true);
+  renderMenu({ onMoveIssue });
+
+  await openMovePicker();
+  await fireEvent.input(screen.getByRole("searchbox", { name: "Find project" }), {
+    target: { value: "road" },
+  });
+  expect(screen.queryByRole("button", { name: /Alpha/ })).toBeNull();
+  await fireEvent.click(screen.getByRole("button", { name: /Roadmap/ }));
+
+  expect(onMoveIssue).toHaveBeenCalledWith("project-roadmap");
+  expect(screen.queryByRole("searchbox", { name: "Find project" })).toBeNull();
+  expect(screen.queryByRole("menu", { name: "Task actions" })).toBeNull();
+});
+
+it("keeps the picker open when the workspace reports move failure", async () => {
+  const onMoveIssue = vi.fn(async () => false);
+  renderMenu({ onMoveIssue });
+  await openMovePicker();
+  await fireEvent.click(screen.getByRole("button", { name: /Roadmap/ }));
+
+  expect(onMoveIssue).toHaveBeenCalledWith("project-roadmap");
+  expect(screen.getByRole("searchbox", { name: "Find project" })).toBeTruthy();
+});
+```
+
+Implement local `renderMenu(overrides)` and `openMovePicker()` helpers with concrete default props from the existing tests.
+
+- [ ] **Step 4: Add failing issue-identity reset coverage**
+
+```ts
+it("resets the destination view when the selected issue changes", async () => {
+  const view = renderMenu();
+  await openMovePicker();
+  await fireEvent.input(screen.getByRole("searchbox", { name: "Find project" }), {
+    target: { value: "road" },
+  });
+
+  await view.rerender({ issue: makeIssue("open", { uid: "issue-2" }), projects });
+  expect(screen.queryByRole("searchbox", { name: "Find project" })).toBeNull();
+  expect(screen.getByRole("button", { name: "More actions" })).toHaveAttribute("aria-expanded", "false");
+});
+```
+
+Adjust `makeIssue` to accept partial issue overrides rather than duplicating fixtures.
+
+- [ ] **Step 5: Run the focused test to verify failure**
+
+```bash
+node ../node_modules/vite-plus/bin/vp test run --project unit src/lib/components/kata/KataIssueOverflowMenu.test.ts
+```
+
+Expected: FAIL because move props and interaction do not exist.
+
+- [ ] **Step 6: Return handled move success from both workspaces**
+
+In `KataWorkspace.svelte`:
+
+```ts
+async function moveSelectedIssue(toProjectUID: string): Promise<boolean> {
+  const selected = store.selectedIssue?.issue;
+  if (!selected) return false;
+  return runViewTask(() => store.moveIssue(selected.uid, actor, toProjectUID));
+}
+```
+
+Apply the same shape in `KataWorkspaceSidebarPane.svelte`, returning its existing `runTask(...)` result. This keeps error copy owned by `requestError`/`error` and gives the menu a close/retry signal.
+
+- [ ] **Step 7: Forward projects and the move callback**
+
+Change `KataIssueDetail` prop typing to:
+
+```ts
+onMoveIssue: (toProjectUID: string) => boolean | Promise<boolean>;
+```
+
+Pass:
+
+```svelte
+<KataIssueOverflowMenu
+  {issue}
+  {projects}
+  hasChecklist={checklistItems().length > 0 || checklistRevealed}
+  hasRecurrence={!canCreateRecurrence}
+  onMoveIssue={onMoveIssue}
+  onAddChecklist={onRevealChecklist}
+  onCreateRecurrence={onCreateRecurrence}
+  onDeleteIssue={onDeleteIssue}
+/>
+```
+
+Update default test callbacks from `async () => {}` to `async () => true`.
+
+- [ ] **Step 8: Implement destinations and explicit menu modes**
+
+In `KataIssueOverflowMenu.svelte`:
+
+```ts
+interface Props {
+  issue: KataTaskDetail;
+  projects: KataProjectSummary[];
+  hasChecklist: boolean;
+  hasRecurrence: boolean;
+  onMoveIssue: (toProjectUID: string) => boolean | Promise<boolean>;
+  onAddChecklist: () => void;
+  onCreateRecurrence: () => void;
+  onDeleteIssue: () => boolean | Promise<boolean>;
+}
+
+let menuView = $state<"actions" | "move">("actions");
+let moveQuery = $state("");
+let movingProjectUID = $state<string | null>(null);
+
+let eligibleProjects = $derived.by(() =>
+  projects
+    .filter((project) => project.uid !== issue.issue.project_uid && project.metadata.role !== "inbox")
+    .toSorted((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" })),
+);
+
+let filteredProjects = $derived.by(() => {
+  const query = moveQuery.trim().toLowerCase();
+  return query
+    ? eligibleProjects.filter((project) => project.name.toLowerCase().includes(query))
+    : eligibleProjects;
+});
+```
+
+Include `eligibleProjects.length > 0` in `hasAnyAction`. Reset `menuView`, `moveQuery`, and move pending state when the issue UID changes or the menu closes.
+
+- [ ] **Step 9: Render the explicit action and searchable picker**
+
+Add exact action copy in the normal menu:
+
+```svelte
+{#if eligibleProjects.length > 0}
+  <li>
+    <button type="button" class="overflow-item" role="menuitem" onclick={openMovePicker}>
+      Move to another project
+    </button>
+  </li>
+{/if}
+```
+
+When `menuView === "move"`, render a popover panel with honest dialog/list semantics, a kit `SearchInput` labeled `Find project`, and native project buttons:
+
+```svelte
+<div class="move-picker kit-popover-card" role="dialog" aria-label="Move to another project" onkeydown={handleMoveKeydown}>
+  <SearchInput
+    bind:value={moveQuery}
+    bind:inputEl={moveSearchInput}
+    block
+    ariaLabel="Find project"
+    placeholder="Search projects"
+  />
+  <div class="move-options" role="listbox" aria-label="Project destinations">
+    {#each filteredProjects as project (project.uid)}
+      <button
+        type="button"
+        role="option"
+        aria-selected="false"
+        disabled={movingProjectUID !== null}
+        onclick={() => void moveIssue(project.uid)}
+      >
+        <span>{project.name}</span>
+        <span>{project.open_count}</span>
+      </button>
+    {:else}
+      <p>No matching projects</p>
+    {/each}
+  </div>
+</div>
+```
+
+Declare `let moveSearchInput: HTMLInputElement | undefined = $state();` and focus it after switching to `menuView = "move"` with `await tick()`. Do not add a one-use shared picker abstraction.
+
+- [ ] **Step 10: Handle stale async completion and retry**
+
+```ts
+async function moveIssue(projectUID: string): Promise<void> {
+  if (movingProjectUID !== null) return;
+  const sourceIssueUID = issue.issue.uid;
+  movingProjectUID = projectUID;
+  try {
+    const moved = await onMoveIssue(projectUID);
+    if (issue.issue.uid !== sourceIssueUID) return;
+    if (moved !== false) closeMenu();
+  } finally {
+    if (issue.issue.uid === sourceIssueUID) movingProjectUID = null;
+  }
+}
+```
+
+Do not duplicate mutation error messages in the menu.
+
+- [ ] **Step 11: Run focused tests and commit**
+
+```bash
+node ../node_modules/vite-plus/bin/vp test run --project unit \
+  src/lib/components/kata/KataIssueDetail.test.ts \
+  src/lib/components/kata/KataIssueOverflowMenu.test.ts \
+  src/lib/features/kata/KataWorkspace.test.ts
+git add frontend/src/lib/components/kata/KataIssueOverflowMenu.svelte \
+  frontend/src/lib/components/kata/KataIssueOverflowMenu.test.ts \
+  frontend/src/lib/components/kata/KataIssueDetail.svelte \
+  frontend/src/lib/components/kata/KataIssueDetail.test.ts \
+  frontend/src/lib/features/kata/KataWorkspace.svelte \
+  frontend/src/lib/components/terminal/KataWorkspaceSidebarPane.svelte
+git commit -m "feat: move Kata reassignment into task actions"
+```
+
+---
+
+### Task 5: Preserve Escape and Focus Behavior
+
+**Files:**
+- Modify: `frontend/src/lib/components/kata/KataIssueOverflowMenu.test.ts`
+- Modify: `frontend/src/lib/components/kata/KataIssueOverflowMenu.svelte`
+- Create only if jsdom cannot reliably assert focus: `frontend/src/lib/components/kata/KataIssueOverflowMenu.browser.svelte.ts`
+
+**Interfaces:**
+- Consumes: kit `SearchInput` behavior where Escape clears a nonempty value before the owner handles an empty-query Escape.
+- Produces: empty-query Escape closes the move picker without moving and restores focus to More actions.
+
+- [ ] **Step 1: Add the failing keyboard test**
+
+```ts
+it("dismisses an empty move picker with Escape and restores trigger focus", async () => {
+  const onMoveIssue = vi.fn(async () => true);
+  renderMenu({ onMoveIssue });
+
+  const trigger = screen.getByRole("button", { name: "More actions" });
+  trigger.focus();
+  await fireEvent.keyDown(trigger, { key: "Enter" });
+  await fireEvent.click(screen.getByRole("menuitem", { name: "Move to another project" }));
+
+  const search = screen.getByRole("searchbox", { name: "Find project" });
+  await waitFor(() => expect(search).toBe(document.activeElement));
+  await fireEvent.keyDown(search, { key: "Escape" });
+
+  expect(onMoveIssue).not.toHaveBeenCalled();
+  expect(screen.queryByRole("searchbox", { name: "Find project" })).toBeNull();
+  await waitFor(() => expect(trigger).toBe(document.activeElement));
+});
+```
+
+If jsdom cannot prove focus movement, move this exact interaction to the browser file and keep sorting/filtering/success tests in the unit project.
+
+- [ ] **Step 2: Add two-stage Escape coverage**
+
+```ts
+it("clears a move query before Escape dismisses the picker", async () => {
+  renderMenu();
+  await openMovePicker();
+  const search = screen.getByRole("searchbox", { name: "Find project" });
+  await fireEvent.input(search, { target: { value: "road" } });
+
+  await fireEvent.keyDown(search, { key: "Escape" });
+  expect(search).toHaveValue("");
+  expect(screen.getByRole("dialog", { name: "Move to another project" })).toBeTruthy();
+
+  await fireEvent.keyDown(search, { key: "Escape" });
+  expect(screen.queryByRole("dialog", { name: "Move to another project" })).toBeNull();
+});
+```
+
+- [ ] **Step 3: Implement local cleanup and focus restoration**
+
+Bind the trigger and move search input. Handle only the empty-query Escape that reaches the picker owner:
+
+```ts
+function handleMoveKeydown(event: KeyboardEvent): void {
+  if (event.key !== "Escape" || moveQuery !== "") return;
+  event.preventDefault();
+  closeMenu();
+  queueMicrotask(() => overflowTrigger?.focus());
+}
+```
+
+Use the same cleanup function for outside-click and issue-change reset, but restore focus only for keyboard dismissal. Do not install a window-level Escape handler.
+
+- [ ] **Step 4: Run the correct lane and commit**
+
+For unit coverage:
+
+```bash
+node ../node_modules/vite-plus/bin/vp test run --project unit src/lib/components/kata/KataIssueOverflowMenu.test.ts
+```
+
+If the browser test was necessary:
+
+```bash
+node ../node_modules/vite-plus/bin/vp test run --project browser src/lib/components/kata/KataIssueOverflowMenu.browser.svelte.ts
+```
+
+Then commit the focused interaction fix:
+
+```bash
+git add frontend/src/lib/components/kata/KataIssueOverflowMenu.svelte \
+  frontend/src/lib/components/kata/KataIssueOverflowMenu.test.ts \
+  frontend/src/lib/components/kata/KataIssueOverflowMenu.browser.svelte.ts
+git commit -m "fix: preserve focus when dismissing Kata moves"
+```
+
+If no browser file exists, omit it from `git add`.
+
+---
+
+### Task 6: Replace Obsolete Full-Stack Rename Workflows
+
+**Files:**
+- Modify: `frontend/tests/e2e-full/kata.spec.ts`
+
+**Interfaces:**
+- Preserves: seeded real backend, project creation, project scope routing, daemon move endpoint, and rename API fixture support.
+- Replaces: four tests that require pencil-button or double-click sidebar renaming.
+
+- [ ] **Step 1: Remove obsolete rename scenarios**
+
+Delete these tests:
+
+```text
+kata project rename submits inline input
+kata project rows can be renamed by double-clicking
+kata project row double-click enters rename
+kata project rename input cancels on Escape
+```
+
+Keep the fixture PATCH handler because daemon rename capability remains supported.
+
+- [ ] **Step 2: Add a navigation-only project-row test**
+
+```ts
+test("kata project rows select scopes without rename controls", async ({ page }) => {
+  const projectPatches: string[] = [];
+  page.on("request", (request) => {
+    if (request.method() === "PATCH" && request.url().includes("/api/v1/projects/1")) {
+      projectPatches.push(request.url());
+    }
+  });
+
+  await page.goto(`${server.info.base_url}/kata`);
+  await expectKataDaemonSwitcherReady(page);
+  const finances = page.getByRole("button", { name: /^Finances\b/ });
+  await expect(page.getByRole("button", { name: "Rename Finances" })).toHaveCount(0);
+  await finances.click();
+  await expect(page).toHaveURL(/scope=project-finance/);
+  await expect(page.getByRole("textbox", { name: "Rename project" })).toHaveCount(0);
+  expect(projectPatches).toEqual([]);
+});
+```
+
+Follow the surrounding tests’ concrete setup sequence: start `startKataBackend()`, call `configureKataHome(backend.url)`, start `startMiddlemanServer({ extraEnv: { KATA_HOME: kataHome.home } })`, navigate to `${server.info.base_url}/kata`, and restore/stop all handles in `finally`. Extract a helper only if at least three of the newly edited tests use the identical sequence.
+
+- [ ] **Step 3: Add the double-click regression**
+
+```ts
+test("kata project double-click remains navigation-only", async ({ page }) => {
+  const projectPatches: string[] = [];
+  page.on("request", (request) => {
+    if (request.method() === "PATCH" && request.url().includes("/api/v1/projects/1")) {
+      projectPatches.push(request.url());
+    }
+  });
+
+  await page.goto(`${server.info.base_url}/kata`);
+  await expectKataDaemonSwitcherReady(page);
+  await page.getByRole("button", { name: /^Finances\b/ }).dblclick();
+  await expect(page).toHaveURL(/scope=project-finance/);
+  await expect(page.getByRole("textbox", { name: "Rename project" })).toHaveCount(0);
+  expect(projectPatches).toEqual([]);
+});
+```
+
+Do not assert exact scoped-list request counts.
+
+- [ ] **Step 4: Update group selectors**
+
+Where the existing test expects area headings, query the new expandable buttons and assert their state:
+
+```ts
+await expect(page.getByRole("button", { name: /^Personal\s+1$/ })).toHaveAttribute("aria-expanded", "true");
+await expect(page.getByRole("button", { name: /^Work\s+1$/ })).toHaveAttribute("aria-expanded", "true");
+```
+
+Keep project creation, system-view switching, and inbox-project hiding tests.
+
+- [ ] **Step 5: Move the real-daemon reassignment flow**
+
+Rename the existing breadcrumb move test to `kata More actions moves tasks through the configured external daemon` and change only the UI path:
+
+```ts
+await page.getByRole("button", { name: "More actions" }).click();
+await page.getByRole("menuitem", { name: "Move to another project" }).click();
+await page.getByRole("searchbox", { name: "Find project" }).fill("kat");
+await page.getByRole("option", { name: /Kata/ }).click();
+await expect(page.getByText("Kata", { exact: true })).toBeVisible();
+```
+
+Retain the existing assertions for `POST /api/v1/projects/1/issues/issue-rent/actions/move` and backend state changing to the Kata project.
+
+- [ ] **Step 6: Add narrow-width keyboard cancellation**
+
+```ts
+test("kata move picker dismisses at narrow width without moving", async ({ page }) => {
+  const moveRequests: string[] = [];
+  await page.setViewportSize({ width: 390, height: 844 });
+  page.on("request", (request) => {
+    if (request.url().includes("/actions/move")) moveRequests.push(request.url());
+  });
+
+  await page.goto(`${server.info.base_url}/kata?issue=issue-rent`);
+  await expect(page.getByRole("region", { name: "Task detail" })).toBeVisible();
+  const trigger = page.getByRole("button", { name: "More actions" });
+  await trigger.focus();
+  await page.keyboard.press("Enter");
+  await page.getByRole("menuitem", { name: "Move to another project" }).press("Enter");
+  const picker = page.getByRole("dialog", { name: "Move to another project" });
+  await expect(picker).toBeInViewport();
+  await page.keyboard.press("Escape");
+  await expect(picker).toHaveCount(0);
+  await expect(trigger).toBeFocused();
+  expect(moveRequests).toEqual([]);
+});
+```
+
+Use the same backend/home/server setup as the surrounding test, navigate directly to `${server.info.base_url}/kata?issue=issue-rent`, and wait for `page.getByRole("region", { name: "Task detail" })` before interacting.
+
+- [ ] **Step 7: Run targeted full-stack tests**
+
+```bash
+node ./scripts/run-e2e-to-file.ts tests/e2e-full/kata.spec.ts --grep "kata (sidebar|project|More actions|move picker)"
+```
+
+Expected: PASS in both configured browser projects. During iteration, `--project=chromium` is acceptable, but this two-browser command must pass before commit.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add frontend/tests/e2e-full/kata.spec.ts
+git commit -m "test: cover the cleaned-up Kata project workflows"
+```
+
+---
+
+### Task 7: Final Verification
+
+**Files:**
+- Verify only; do not edit after these commands without rerunning the affected lane.
+
+**Interfaces:**
+- Confirms all spec acceptance criteria and repository pre-push requirements.
+
+- [ ] **Step 1: Run focused unit coverage**
+
+From `frontend/`:
+
+```bash
+node ../node_modules/vite-plus/bin/vp test run --project unit \
+  src/lib/components/kata/KataSidebar.test.ts \
+  src/lib/components/kata/KataIssueDetail.test.ts \
+  src/lib/components/kata/KataIssueOverflowMenu.test.ts \
+  src/lib/features/kata/KataWorkspace.test.ts \
+  src/lib/stores/kata-workspace.svelte.test.ts \
+  src/lib/api/kata/taskClient.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run browser component coverage if created**
+
+```bash
+node ../node_modules/vite-plus/bin/vp test run --project browser src/lib/components/kata/KataIssueOverflowMenu.browser.svelte.ts
+```
+
+Expected: PASS. Skip only when no browser component file was created because unit coverage proved focus behavior reliably.
+
+- [ ] **Step 3: Run frontend package checks**
+
+```bash
+node ../node_modules/vite-plus/bin/vp run frontend-package-check
+```
+
+Expected: PASS with no Svelte, TypeScript, formatting, or kit-usage errors.
+
+- [ ] **Step 4: Run the complete Vitest projects**
+
+```bash
+node ../node_modules/vite-plus/bin/vp test run --project unit
+node ../node_modules/vite-plus/bin/vp test run --project browser
+```
+
+Expected: PASS. If browser port `63315` is occupied by a sibling worktree, wait and retry; do not kill the other process.
+
+- [ ] **Step 5: Run the complete affected Playwright suites**
+
+```bash
+node ./scripts/run-e2e-to-file.ts tests/e2e-full/kata.spec.ts
+node ./scripts/run-e2e-to-file.ts tests/e2e-full/sidebar-scroll-indicator.spec.ts
+```
+
+Expected: PASS in both configured browser projects. The second file verifies the shared geometry; do not add duplicate Kata-specific scroll math.
+
+- [ ] **Step 6: Exercise the real app flow**
+
+Invoke the repository `verify` skill and drive these observable behaviors:
+
+1. Open Kata navigation and collapse/reopen an area.
+2. Select and double-click a project; both remain navigation-only.
+3. Create a project and enter its scope.
+4. Open an issue and confirm its project breadcrumb is passive.
+5. Open More actions, filter destinations, move the issue, and confirm its project changes.
+6. Open the move picker again, press Escape, and confirm focus returns without a mutation.
+
+Expected: all six behaviors match the spec in the running app.
+
+- [ ] **Step 7: Inspect the final diff**
+
+Run:
+
+```bash
+git diff origin/main...HEAD --check
+git status --short
+rg -n "onRenameProject|Rename project|Rename Finances|ondblclick" \
+  frontend/src/lib/components/kata/KataSidebar.svelte \
+  frontend/src/lib/features/kata/KataWorkspace.svelte
+rg -n "renameProject" \
+  frontend/src/lib/api/kata/taskClient.ts \
+  frontend/src/lib/stores/kata-workspace.svelte.ts
+```
+
+Expected:
+
+- `git diff --check` has no output.
+- Working tree is clean after commits.
+- No sidebar rename references remain.
+- Client/store rename operations still exist.
+- No backend, DB, OpenAPI, generated-client, or unrelated shared-component files changed.
+
+- [ ] **Step 8: Run final code review and simplification**
+
+Invoke `/code-review high` on the branch diff, address verified findings in new commits, then invoke `/simplify` and apply only in-scope quality improvements. Rerun every affected test lane after any edit.
+
+- [ ] **Step 9: Record context decision**
+
+Run:
+
+```bash
+scripts/context-sync --check
+```
+
+If the implementation only realizes this dated feature spec, mark a concrete no-update decision. If it reveals a reusable frontend invariant or gotcha not already in `context/ui-design-system.md` or `context/ui-interaction-contracts.md`, add a terse anchored context update and commit it separately.

--- a/docs/superpowers/plans/2026-07-12-kata-project-ux-cleanup.md
+++ b/docs/superpowers/plans/2026-07-12-kata-project-ux-cleanup.md
@@ -33,7 +33,7 @@
 - `frontend/src/lib/components/kata/KataIssueDetail.test.ts`: passive breadcrumb and project-name fallback coverage.
 - `frontend/src/lib/components/kata/KataIssueOverflowMenu.svelte`: explicit move action, searchable destination view, pending/retry state, focus restoration, and issue-identity reset.
 - `frontend/src/lib/components/kata/KataIssueOverflowMenu.test.ts`: destination rules, sorting, search, success/failure, issue reset, and keyboard dismissal.
-- `frontend/tests/e2e-full/kata.spec.ts`: replace obsolete rename workflows and move the real-daemon reassignment flow to More actions.
+- `frontend/tests/e2e-full/kata.spec.ts`: replace obsolete rename workflows, move real-daemon reassignment to More actions, and add one-shot failure/retry coverage in the local Kata backend fixture.
 
 ---
 
@@ -44,7 +44,7 @@
 - Modify: `frontend/src/lib/components/kata/KataSidebar.svelte`
 
 **Interfaces:**
-- Consumes: `GroupedSidebarSection` and `SidebarScrollArea` exported by `@middleman/ui`.
+- Consumes: `GroupedSidebarSection` and `SidebarScrollArea` already implemented and exported by `@middleman/ui` in merged PR #662 (`packages/ui/src/components/shared/` and `packages/ui/src/index.ts`).
 - Produces: mounted `collapsedAreas: string[]` state and one native project button per visible project.
 
 - [ ] **Step 1: Add failing group and order coverage**
@@ -63,11 +63,11 @@ it("renders system views, expanded area groups, and project creation in order", 
 
   expect(personal).toHaveAttribute("aria-expanded", "true");
   expect(work).toHaveAttribute("aria-expanded", "true");
-  expect(
-    [inbox, personal, work, create].map((element) =>
-      inbox.compareDocumentPosition(element) & Node.DOCUMENT_POSITION_FOLLOWING,
-    ),
-  ).toEqual([0, Node.DOCUMENT_POSITION_FOLLOWING, Node.DOCUMENT_POSITION_FOLLOWING, Node.DOCUMENT_POSITION_FOLLOWING]);
+  const ordered = [inbox, personal, work, create];
+  for (let index = 0; index < ordered.length - 1; index += 1) {
+    expect(ordered[index]!.compareDocumentPosition(ordered[index + 1]!))
+      .toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  }
 });
 ```
 
@@ -176,7 +176,7 @@ Remove `overflow: auto` from `.kata-sidebar`. Preserve the existing `900px` narr
 }
 
 .kata-nav button.active,
-.project-row.active .project-select-button {
+.project-select-button.active {
   background: var(--bg-row-selected);
 }
 ```
@@ -213,9 +213,13 @@ Delete `double-clicking a project enters rename mode` and `renames a project fro
 ```ts
 it("keeps project rows navigation-only without rename affordances", async () => {
   const onOpenProject = vi.fn();
-  renderSidebar({ onOpenProject });
+  renderSidebar({
+    onOpenProject,
+    searchFilters: { ...allScopeFilters, scope: { kind: "project", project_uid: "project-finances" } },
+  });
 
   const finances = screen.getByRole("button", { name: /^Finances\b/ });
+  expect(finances).toHaveClass("active");
   expect(screen.queryByRole("button", { name: "Rename Finances" })).toBeNull();
   expect(screen.queryByRole("textbox", { name: "Rename project" })).toBeNull();
 
@@ -299,81 +303,7 @@ git commit -m "feat: make Kata project rows navigation-only"
 
 ---
 
-### Task 3: Make the Issue Project Breadcrumb Passive
-
-**Files:**
-- Modify: `frontend/src/lib/components/kata/KataIssueDetail.test.ts`
-- Modify: `frontend/src/lib/components/kata/KataIssueDetail.svelte`
-
-**Interfaces:**
-- Preserves: `currentProjectName(): string` fallback order.
-- Removes: breadcrumb-owned destination picker; issue reassignment remains available through the unchanged `onMoveIssue` prop until Task 4 forwards it to the overflow menu.
-
-- [ ] **Step 1: Replace the breadcrumb-move test**
-
-Remove the existing `moves to a non-inbox project from the crumb picker` test. Add:
-
-```ts
-it("renders the current project as passive breadcrumb text", () => {
-  renderDetail();
-  const detail = screen.getByRole("region", { name: "Task detail" });
-
-  expect(within(detail).getByText("Inbox")).toBeTruthy();
-  expect(within(detail).queryByRole("button", { name: /^Move issue from/ })).toBeNull();
-  expect(within(detail).queryByRole("combobox", { name: "Move issue project" })).toBeNull();
-});
-```
-
-- [ ] **Step 2: Cover both fallback levels**
-
-Update the existing fallback test to assert loaded project name text, then add the final UID fallback:
-
-```ts
-it("uses the loaded project name when issue project_name is empty", () => {
-  renderDetail({ issue: makeIssue({ project_uid: "project-2", project_name: "" }) });
-  expect(screen.getByText("Roadmap")).toBeTruthy();
-});
-
-it("uses the project UID when no project name can be resolved", () => {
-  renderDetail({
-    issue: makeIssue({ project_id: 99, project_uid: "project-missing", project_name: "" }),
-    projects: [],
-  });
-  expect(screen.getByText("project-missing")).toBeTruthy();
-});
-```
-
-- [ ] **Step 3: Run the focused test to verify failure**
-
-```bash
-node ../node_modules/vite-plus/bin/vp test run --project unit src/lib/components/kata/KataIssueDetail.test.ts
-```
-
-Expected: FAIL because the project remains a `TypeaheadTrigger` button.
-
-- [ ] **Step 4: Render passive text**
-
-In `KataIssueDetail.svelte`, replace the breadcrumb `TypeaheadTrigger` with:
-
-```svelte
-<span class="crumb-project" title={currentProjectName()}>{currentProjectName()}</span>
-<span class="crumb-sep">/</span>
-<span class="crumb-id">{issue.issue.short_id}</span>
-```
-
-Keep `currentProjectName()` unchanged. Remove only breadcrumb-picker imports, options, and CSS; retain `TypeaheadTrigger` if other detail controls still use it. Style `.crumb-project` with truncation and muted text, without a border, hover state, cursor, or chevron.
-
-- [ ] **Step 5: Run and commit**
-
-```bash
-node ../node_modules/vite-plus/bin/vp test run --project unit src/lib/components/kata/KataIssueDetail.test.ts
-git add frontend/src/lib/components/kata/KataIssueDetail.svelte frontend/src/lib/components/kata/KataIssueDetail.test.ts
-git commit -m "feat: make Kata project breadcrumbs passive"
-```
-
----
-
-### Task 4: Move Issue Reassignment Into More Actions
+### Task 3: Move Issue Reassignment Into More Actions
 
 **Files:**
 - Modify: `frontend/src/lib/components/kata/KataIssueOverflowMenu.test.ts`
@@ -417,6 +347,8 @@ const projects = [
   makeProject("project-1", "Inbox", 2, "inbox"),
   makeProject("project-alpha", "Alpha", 3),
   makeProject("project-roadmap", "Roadmap", 5),
+  { ...makeProject("project-shared-work", "Shared", 2), metadata: { area: "Work" } },
+  { ...makeProject("project-shared-home", "Shared", 4), metadata: { area: "Home" } },
 ];
 ```
 
@@ -436,8 +368,10 @@ it("shows sorted eligible destinations with open counts", async () => {
   await fireEvent.click(screen.getByRole("button", { name: "More actions" }));
   await fireEvent.click(screen.getByRole("menuitem", { name: "Move to another project" }));
 
-  const options = screen.getAllByRole("button", { name: /Alpha|Roadmap/ });
-  expect(options.map((button) => button.textContent)).toEqual(["Alpha3", "Roadmap5"]);
+  const options = screen.getAllByRole("button", { name: /Alpha|Roadmap|Shared/ });
+  expect(options.slice(0, 2).map((button) => button.textContent)).toEqual(["Alpha3", "Roadmap5"]);
+  expect(screen.getByRole("button", { name: /Shared.*Home.*4/ })).toBeTruthy();
+  expect(screen.getByRole("button", { name: /Shared.*Work.*2/ })).toBeTruthy();
   expect(screen.queryByText("Inbox")).toBeNull();
 });
 ```
@@ -567,10 +501,28 @@ let eligibleProjects = $derived.by(() =>
     .toSorted((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" })),
 );
 
+let duplicateNames = $derived.by(() => {
+  const counts = new Map<string, number>();
+  for (const project of eligibleProjects) {
+    const key = project.name.trim().toLocaleLowerCase();
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return counts;
+});
+
+function destinationContext(project: KataProjectSummary): string | null {
+  const duplicate = (duplicateNames.get(project.name.trim().toLocaleLowerCase()) ?? 0) > 1;
+  if (!duplicate) return null;
+  const area = typeof project.metadata.area === "string" ? project.metadata.area.trim() : "";
+  return area || project.uid;
+}
+
 let filteredProjects = $derived.by(() => {
   const query = moveQuery.trim().toLowerCase();
   return query
-    ? eligibleProjects.filter((project) => project.name.toLowerCase().includes(query))
+    ? eligibleProjects.filter((project) =>
+        [project.name, destinationContext(project) ?? ""].some((value) => value.toLowerCase().includes(query)),
+      )
     : eligibleProjects;
 });
 ```
@@ -602,17 +554,18 @@ When `menuView === "move"`, render a popover panel with honest dialog/list seman
     ariaLabel="Find project"
     placeholder="Search projects"
   />
-  <div class="move-options" role="listbox" aria-label="Project destinations">
+  <div class="move-options" aria-label="Project destinations">
     {#each filteredProjects as project (project.uid)}
       <button
         type="button"
-        role="option"
-        aria-selected="false"
         disabled={movingProjectUID !== null}
         onclick={() => void moveIssue(project.uid)}
       >
-        <span>{project.name}</span>
-        <span>{project.open_count}</span>
+        <span class="move-project-name">{project.name}</span>
+        {#if destinationContext(project)}
+          <span class="move-project-context">{destinationContext(project)}</span>
+        {/if}
+        <span class="move-project-count">{project.open_count}</span>
       </button>
     {:else}
       <p>No matching projects</p>
@@ -656,6 +609,80 @@ git add frontend/src/lib/components/kata/KataIssueOverflowMenu.svelte \
   frontend/src/lib/features/kata/KataWorkspace.svelte \
   frontend/src/lib/components/terminal/KataWorkspaceSidebarPane.svelte
 git commit -m "feat: move Kata reassignment into task actions"
+```
+
+---
+
+### Task 4: Make the Issue Project Breadcrumb Passive
+
+**Files:**
+- Modify: `frontend/src/lib/components/kata/KataIssueDetail.test.ts`
+- Modify: `frontend/src/lib/components/kata/KataIssueDetail.svelte`
+
+**Interfaces:**
+- Preserves: `currentProjectName(): string` fallback order.
+- Removes: breadcrumb-owned destination picker; issue reassignment is already available through the overflow menu added in Task 3 before the breadcrumb control is removed.
+
+- [ ] **Step 1: Replace the breadcrumb-move test**
+
+Remove the existing `moves to a non-inbox project from the crumb picker` test. Add:
+
+```ts
+it("renders the current project as passive breadcrumb text", () => {
+  renderDetail();
+  const detail = screen.getByRole("region", { name: "Task detail" });
+
+  expect(within(detail).getByText("Inbox")).toBeTruthy();
+  expect(within(detail).queryByRole("button", { name: /^Move issue from/ })).toBeNull();
+  expect(within(detail).queryByRole("combobox", { name: "Move issue project" })).toBeNull();
+});
+```
+
+- [ ] **Step 2: Cover both fallback levels**
+
+Update the existing fallback test to assert loaded project name text, then add the final UID fallback:
+
+```ts
+it("uses the loaded project name when issue project_name is empty", () => {
+  renderDetail({ issue: makeIssue({ project_uid: "project-2", project_name: "" }) });
+  expect(screen.getByText("Roadmap")).toBeTruthy();
+});
+
+it("uses the project UID when no project name can be resolved", () => {
+  renderDetail({
+    issue: makeIssue({ project_id: 99, project_uid: "project-missing", project_name: "" }),
+    projects: [],
+  });
+  expect(screen.getByText("project-missing")).toBeTruthy();
+});
+```
+
+- [ ] **Step 3: Run the focused test to verify failure**
+
+```bash
+node ../node_modules/vite-plus/bin/vp test run --project unit src/lib/components/kata/KataIssueDetail.test.ts
+```
+
+Expected: FAIL because the project remains a `TypeaheadTrigger` button.
+
+- [ ] **Step 4: Render passive text**
+
+In `KataIssueDetail.svelte`, replace the breadcrumb `TypeaheadTrigger` with:
+
+```svelte
+<span class="crumb-project" title={currentProjectName()}>{currentProjectName()}</span>
+<span class="crumb-sep">/</span>
+<span class="crumb-id">{issue.issue.short_id}</span>
+```
+
+Keep `currentProjectName()` unchanged. Remove only breadcrumb-picker imports, options, and CSS; retain `TypeaheadTrigger` if other detail controls still use it. Style `.crumb-project` with truncation and muted text, without a border, hover state, cursor, or chevron.
+
+- [ ] **Step 5: Run and commit**
+
+```bash
+node ../node_modules/vite-plus/bin/vp test run --project unit src/lib/components/kata/KataIssueDetail.test.ts
+git add frontend/src/lib/components/kata/KataIssueDetail.svelte frontend/src/lib/components/kata/KataIssueDetail.test.ts
+git commit -m "feat: make Kata project breadcrumbs passive"
 ```
 
 ---
@@ -799,7 +826,7 @@ test("kata project rows select scopes without rename controls", async ({ page })
 });
 ```
 
-Follow the surrounding tests’ concrete setup sequence: start `startKataBackend()`, call `configureKataHome(backend.url)`, start `startMiddlemanServer({ extraEnv: { KATA_HOME: kataHome.home } })`, navigate to `${server.info.base_url}/kata`, and restore/stop all handles in `finally`. Extract a helper only if at least three of the newly edited tests use the identical sequence.
+Follow the surrounding tests’ concrete setup sequence: start `startKataBackend()`, call `configureKataHome(backend.url)`, start `startIsolatedE2EServer()`, navigate to `${server.info.base_url}/kata`, and restore/stop all handles in `finally`. Extract a helper only if at least three of the newly edited tests use the identical sequence.
 
 - [ ] **Step 3: Add the double-click regression**
 
@@ -834,21 +861,72 @@ await expect(page.getByRole("button", { name: /^Work\s+1$/ })).toHaveAttribute("
 
 Keep project creation, system-view switching, and inbox-project hiding tests.
 
-- [ ] **Step 5: Move the real-daemon reassignment flow**
+- [ ] **Step 5: Move the real-daemon reassignment flow with keyboard selection**
 
 Rename the existing breadcrumb move test to `kata More actions moves tasks through the configured external daemon` and change only the UI path:
 
 ```ts
-await page.getByRole("button", { name: "More actions" }).click();
-await page.getByRole("menuitem", { name: "Move to another project" }).click();
-await page.getByRole("searchbox", { name: "Find project" }).fill("kat");
-await page.getByRole("option", { name: /Kata/ }).click();
+const moreActions = page.getByRole("button", { name: "More actions" });
+await moreActions.focus();
+await page.keyboard.press("Enter");
+await page.getByRole("menuitem", { name: "Move to another project" }).press("Enter");
+const search = page.getByRole("searchbox", { name: "Find project" });
+await search.fill("kat");
+await page.keyboard.press("Tab");
+await page.keyboard.press("Enter");
 await expect(page.getByText("Kata", { exact: true })).toBeVisible();
 ```
 
 Retain the existing assertions for `POST /api/v1/projects/1/issues/issue-rent/actions/move` and backend state changing to the Kata project.
 
-- [ ] **Step 6: Add narrow-width keyboard cancellation**
+- [ ] **Step 6: Add full-stack failure and retry coverage**
+
+Add `moveFailures?: number[] | undefined` to `KataBackendOptions`, add required `moveFailures: number[]` to `BackendState`, initialize it in `startKataBackend` with `moveFailures: [...(options.moveFailures ?? [])]`, and consume the next status in the move-action handler before mutating state:
+
+```ts
+const moveFailure = state.moveFailures.shift();
+if (moveFailure !== undefined) {
+  writeJSON(res, moveFailure, {
+    error: { code: "internal", message: "move failed" },
+  });
+  return;
+}
+```
+
+Add:
+
+```ts
+test("kata move failure stays retryable through the configured external daemon", async ({ page }) => {
+  const backend = await startKataBackend({ moveFailures: [500] });
+  const kataHome = await configureKataHome(backend.url);
+  const server = await startIsolatedE2EServer();
+
+  try {
+    await page.goto(`${server.info.base_url}/kata?issue=issue-rent`);
+    const detail = page.getByRole("region", { name: "Task detail" });
+    await detail.getByRole("button", { name: "More actions" }).click();
+    await detail.getByRole("menuitem", { name: "Move to another project" }).click();
+    await detail.getByRole("searchbox", { name: "Find project" }).fill("kat");
+    await detail.getByRole("button", { name: /Kata/ }).click();
+
+    await expect(page.getByRole("alert")).toContainText("move failed");
+    await expect(detail.getByRole("dialog", { name: "Move to another project" })).toBeVisible();
+    expect(backend.state.issues.find((issue) => issue.uid === "issue-rent")?.project_uid).toBe("project-finance");
+
+    await detail.getByRole("button", { name: /Kata/ }).click();
+    await expect(detail.getByText("Kata", { exact: true })).toBeVisible();
+    expect(backend.state.issues.find((issue) => issue.uid === "issue-rent")?.project_uid).toBe("project-kata");
+  } finally {
+    await server.stop();
+    kataHome.restore();
+    await backend.close();
+  }
+});
+```
+
+Assert the actual workspace error wording emitted by the implementation if it wraps the daemon message; branch on the stable visible alert, not a CSS selector.
+
+- [ ] **Step 7: Add narrow-width keyboard cancellation**
 
 ```ts
 test("kata move picker dismisses at narrow width without moving", async ({ page }) => {
@@ -875,7 +953,7 @@ test("kata move picker dismisses at narrow width without moving", async ({ page 
 
 Use the same backend/home/server setup as the surrounding test, navigate directly to `${server.info.base_url}/kata?issue=issue-rent`, and wait for `page.getByRole("region", { name: "Task detail" })` before interacting.
 
-- [ ] **Step 7: Run targeted full-stack tests**
+- [ ] **Step 8: Run targeted full-stack tests**
 
 ```bash
 node ./scripts/run-e2e-to-file.ts tests/e2e-full/kata.spec.ts --grep "kata (sidebar|project|More actions|move picker)"
@@ -883,7 +961,7 @@ node ./scripts/run-e2e-to-file.ts tests/e2e-full/kata.spec.ts --grep "kata (side
 
 Expected: PASS in both configured browser projects. During iteration, `--project=chromium` is acceptable, but this two-browser command must pass before commit.
 
-- [ ] **Step 8: Commit**
+- [ ] **Step 9: Commit**
 
 ```bash
 git add frontend/tests/e2e-full/kata.spec.ts

--- a/docs/superpowers/plans/2026-07-12-kata-project-ux-cleanup.md
+++ b/docs/superpowers/plans/2026-07-12-kata-project-ux-cleanup.md
@@ -29,6 +29,7 @@
 - `frontend/src/lib/components/kata/KataSidebar.test.ts`: sidebar grouping, collapse lifetime, ordering, navigation, creation, and absence of rename affordances.
 - `frontend/src/lib/features/kata/KataWorkspace.svelte`: remove sidebar rename forwarding and return move success from the existing task wrapper.
 - `frontend/src/lib/components/terminal/KataWorkspaceSidebarPane.svelte`: match the boolean issue-move callback contract in the embedded workspace.
+- `frontend/src/lib/components/terminal/KataWorkspaceSidebarPane.test.ts`: exercise handled move failure and retry through the embedded host's real task wrapper.
 - `frontend/src/lib/components/kata/KataIssueDetail.svelte`: passive project breadcrumb and project/move props forwarded to the overflow menu.
 - `frontend/src/lib/components/kata/KataIssueDetail.test.ts`: passive breadcrumb and project-name fallback coverage.
 - `frontend/src/lib/components/kata/KataIssueOverflowMenu.svelte`: explicit move action, searchable destination view, pending/retry state, focus restoration, and issue-identity reset.
@@ -40,10 +41,12 @@
 ### Task 1: Adopt Shared Kata Sidebar Grouping
 
 **Files:**
+
 - Modify: `frontend/src/lib/components/kata/KataSidebar.test.ts`
 - Modify: `frontend/src/lib/components/kata/KataSidebar.svelte`
 
 **Interfaces:**
+
 - Consumes: `GroupedSidebarSection` and `SidebarScrollArea` already implemented and exported by `@middleman/ui` in merged PR #662 (`packages/ui/src/components/shared/` and `packages/ui/src/index.ts`).
 - Produces: mounted `collapsedAreas: string[]` state and one native project button per visible project.
 
@@ -65,8 +68,7 @@ it("renders system views, expanded area groups, and project creation in order", 
   expect(work).toHaveAttribute("aria-expanded", "true");
   const ordered = [inbox, personal, work, create];
   for (let index = 0; index < ordered.length - 1; index += 1) {
-    expect(ordered[index]!.compareDocumentPosition(ordered[index + 1]!))
-      .toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(ordered[index]!.compareDocumentPosition(ordered[index + 1]!)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
   }
 });
 ```
@@ -126,7 +128,7 @@ Do not synchronize this state into URL, local storage, or the workspace store.
 Keep the outer `aside`, but make `SidebarScrollArea` the only scrolling owner:
 
 ```svelte
-<aside class="kata-sidebar">
+<aside class="kata-sidebar" aria-label="Kata navigation">
   <SidebarScrollArea label="Kata navigation">
     <nav class="kata-nav" aria-label="System views">
       <!-- retain the existing keyed system-view loop unchanged -->
@@ -198,11 +200,13 @@ Expected: focused test PASS; commit hooks PASS.
 ### Task 2: Make Sidebar Project Rows Navigation-Only
 
 **Files:**
+
 - Modify: `frontend/src/lib/components/kata/KataSidebar.test.ts`
 - Modify: `frontend/src/lib/components/kata/KataSidebar.svelte`
 - Modify: `frontend/src/lib/features/kata/KataWorkspace.svelte`
 
 **Interfaces:**
+
 - Removes: `KataSidebar` prop `onRenameProject: (id: number, name: string) => Promise<void>`.
 - Preserves: `KataWorkspaceStore.renameProject(id, name)` and task-client rename operations.
 
@@ -306,13 +310,16 @@ git commit -m "feat: make Kata project rows navigation-only"
 ### Task 3: Move Issue Reassignment Into More Actions
 
 **Files:**
+
 - Modify: `frontend/src/lib/components/kata/KataIssueOverflowMenu.test.ts`
 - Modify: `frontend/src/lib/components/kata/KataIssueOverflowMenu.svelte`
 - Modify: `frontend/src/lib/components/kata/KataIssueDetail.svelte`
 - Modify: `frontend/src/lib/features/kata/KataWorkspace.svelte`
 - Modify: `frontend/src/lib/components/terminal/KataWorkspaceSidebarPane.svelte`
+- Create: `frontend/src/lib/components/terminal/KataWorkspaceSidebarPane.test.ts`
 
 **Interfaces:**
+
 - Adds to `KataIssueOverflowMenu` props:
   - `projects: KataProjectSummary[]`
   - `onMoveIssue: (toProjectUID: string) => boolean | Promise<boolean>`
@@ -326,12 +333,7 @@ Add to `KataIssueOverflowMenu.test.ts`:
 ```ts
 import type { KataProjectSummary, KataTaskDetail } from "../../api/kata/taskTypes.js";
 
-function makeProject(
-  uid: string,
-  name: string,
-  openCount: number,
-  role = "",
-): KataProjectSummary {
+function makeProject(uid: string, name: string, openCount: number, role = ""): KataProjectSummary {
   return {
     id: uid === "project-1" ? 1 : 2,
     uid,
@@ -349,6 +351,7 @@ const projects = [
   makeProject("project-roadmap", "Roadmap", 5),
   { ...makeProject("project-shared-work", "Shared", 2), metadata: { area: "Work" } },
   { ...makeProject("project-shared-home", "Shared", 4), metadata: { area: "Home" } },
+  { ...makeProject("project-shared-home-2", "Shared", 1), metadata: { area: "Home" } },
 ];
 ```
 
@@ -370,7 +373,8 @@ it("shows sorted eligible destinations with open counts", async () => {
 
   const options = screen.getAllByRole("button", { name: /Alpha|Roadmap|Shared/ });
   expect(options.slice(0, 2).map((button) => button.textContent)).toEqual(["Alpha3", "Roadmap5"]);
-  expect(screen.getByRole("button", { name: /Shared.*Home.*4/ })).toBeTruthy();
+  expect(screen.getByRole("button", { name: /Shared.*project-shared-home.*4/ })).toBeTruthy();
+  expect(screen.getByRole("button", { name: /Shared.*project-shared-home-2.*1/ })).toBeTruthy();
   expect(screen.getByRole("button", { name: /Shared.*Work.*2/ })).toBeTruthy();
   expect(screen.queryByText("Inbox")).toBeNull();
 });
@@ -410,7 +414,7 @@ it("keeps the picker open when the workspace reports move failure", async () => 
 
 Implement local `renderMenu(overrides)` and `openMovePicker()` helpers with concrete default props from the existing tests.
 
-- [ ] **Step 4: Add failing issue-identity reset coverage**
+- [ ] **Step 4: Add failing issue-identity and stale-operation coverage**
 
 ```ts
 it("resets the destination view when the selected issue changes", async () => {
@@ -422,7 +426,46 @@ it("resets the destination view when the selected issue changes", async () => {
 
   await view.rerender({ issue: makeIssue("open", { uid: "issue-2" }), projects });
   expect(screen.queryByRole("searchbox", { name: "Find project" })).toBeNull();
-  expect(screen.getByRole("button", { name: "More actions" })).toHaveAttribute("aria-expanded", "false");
+  expect(screen.getByRole("button", { name: "More actions" }).getAttribute("aria-expanded")).toBe("false");
+});
+
+it("ignores an old A move after navigating A to B to A", async () => {
+  let finishOldMove!: (moved: boolean) => void;
+  const oldMove = new Promise<boolean>((resolve) => {
+    finishOldMove = resolve;
+  });
+  const onMoveIssue = vi.fn(() => oldMove);
+  const view = renderMenu({ onMoveIssue });
+
+  await openMovePicker();
+  await fireEvent.click(screen.getByRole("button", { name: /Roadmap/ }));
+  await view.rerender({ issue: makeIssue("open", { uid: "issue-b" }), projects });
+  await view.rerender({ issue: makeIssue("open", { uid: "issue-1" }), projects });
+  await openMovePicker();
+
+  finishOldMove(true);
+  await oldMove;
+  expect(screen.getByRole("searchbox", { name: "Find project" })).toBeTruthy();
+});
+
+it("does not dismiss or resubmit while a move is pending", async () => {
+  let finishMove!: (moved: boolean) => void;
+  const pendingMove = new Promise<boolean>((resolve) => {
+    finishMove = resolve;
+  });
+  const onMoveIssue = vi.fn(() => pendingMove);
+  renderMenu({ onMoveIssue });
+
+  await openMovePicker();
+  await fireEvent.click(screen.getByRole("button", { name: /Roadmap/ }));
+  await fireEvent.keyDown(screen.getByRole("dialog", { name: "Move to another project" }), { key: "Escape" });
+  await fireEvent.mouseDown(document.body);
+
+  expect(screen.getByRole("searchbox", { name: "Find project" })).toBeTruthy();
+  expect(screen.getByRole("button", { name: /Roadmap/ })).toBeDisabled();
+  expect(onMoveIssue).toHaveBeenCalledTimes(1);
+  finishMove(false);
+  await pendingMove;
 });
 ```
 
@@ -449,6 +492,8 @@ async function moveSelectedIssue(toProjectUID: string): Promise<boolean> {
 ```
 
 Apply the same shape in `KataWorkspaceSidebarPane.svelte`, returning its existing `runTask(...)` result. This keeps error copy owned by `requestError`/`error` and gives the menu a close/retry signal.
+
+Add `frontend/src/lib/components/terminal/KataWorkspaceSidebarPane.test.ts` with a mounted-host fixture that stubs the Kata API bootstrap and move endpoint. Exercise `More actions → Move to another project` through the real pane: one test returns a handled move failure and asserts the pane's alert plus retryable picker, then a retry succeeds and closes it. This is required alongside `KataWorkspace.test.ts`; do not substitute an isolated callback unit test.
 
 - [ ] **Step 7: Forward projects and the move callback**
 
@@ -494,6 +539,9 @@ interface Props {
 let menuView = $state<"actions" | "move">("actions");
 let moveQuery = $state("");
 let movingProjectUID = $state<string | null>(null);
+let interactionGeneration = 0;
+let moveOperationGeneration = 0;
+let activeMoveOperation = $state<number | null>(null);
 
 let eligibleProjects = $derived.by(() =>
   projects
@@ -501,20 +549,31 @@ let eligibleProjects = $derived.by(() =>
     .toSorted((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" })),
 );
 
-let duplicateNames = $derived.by(() => {
-  const counts = new Map<string, number>();
+let duplicateContexts = $derived.by(() => {
+  const groups = new Map<string, KataProjectSummary[]>();
   for (const project of eligibleProjects) {
     const key = project.name.trim().toLocaleLowerCase();
-    counts.set(key, (counts.get(key) ?? 0) + 1);
+    groups.set(key, [...(groups.get(key) ?? []), project]);
   }
-  return counts;
+
+  const contexts = new Map<string, string>();
+  for (const group of groups.values()) {
+    if (group.length < 2) continue;
+    const areaCounts = new Map<string, number>();
+    for (const project of group) {
+      const area = typeof project.metadata.area === "string" ? project.metadata.area.trim() : "";
+      if (area) areaCounts.set(area, (areaCounts.get(area) ?? 0) + 1);
+    }
+    for (const project of group) {
+      const area = typeof project.metadata.area === "string" ? project.metadata.area.trim() : "";
+      contexts.set(project.uid, area && areaCounts.get(area) === 1 ? area : project.uid);
+    }
+  }
+  return contexts;
 });
 
 function destinationContext(project: KataProjectSummary): string | null {
-  const duplicate = (duplicateNames.get(project.name.trim().toLocaleLowerCase()) ?? 0) > 1;
-  if (!duplicate) return null;
-  const area = typeof project.metadata.area === "string" ? project.metadata.area.trim() : "";
-  return area || project.uid;
+  return duplicateContexts.get(project.uid) ?? null;
 }
 
 let filteredProjects = $derived.by(() => {
@@ -527,7 +586,7 @@ let filteredProjects = $derived.by(() => {
 });
 ```
 
-Include `eligibleProjects.length > 0` in `hasAnyAction`. Reset `menuView`, `moveQuery`, and move pending state when the issue UID changes or the menu closes.
+Include `eligibleProjects.length > 0` in `hasAnyAction`. Increment `interactionGeneration` and reset `menuView` and `moveQuery` whenever the issue UID changes or a non-pending interaction closes. Do not clear `activeMoveOperation` or `movingProjectUID` from close/reset helpers while a request is pending; dismissal is disabled until that operation settles. Keep the pending destination in the rendered list if reactive project updates would otherwise remove it.
 
 - [ ] **Step 9: Render the explicit action and searchable picker**
 
@@ -580,15 +639,26 @@ Declare `let moveSearchInput: HTMLInputElement | undefined = $state();` and focu
 
 ```ts
 async function moveIssue(projectUID: string): Promise<void> {
-  if (movingProjectUID !== null) return;
+  if (activeMoveOperation !== null) return;
   const sourceIssueUID = issue.issue.uid;
+  const sourceInteraction = interactionGeneration;
+  const operation = ++moveOperationGeneration;
+  activeMoveOperation = operation;
   movingProjectUID = projectUID;
   try {
     const moved = await onMoveIssue(projectUID);
-    if (issue.issue.uid !== sourceIssueUID) return;
+    if (
+      activeMoveOperation !== operation ||
+      interactionGeneration !== sourceInteraction ||
+      issue.issue.uid !== sourceIssueUID
+    )
+      return;
     if (moved !== false) closeMenu();
   } finally {
-    if (issue.issue.uid === sourceIssueUID) movingProjectUID = null;
+    if (activeMoveOperation === operation) {
+      activeMoveOperation = null;
+      movingProjectUID = null;
+    }
   }
 }
 ```
@@ -601,13 +671,15 @@ Do not duplicate mutation error messages in the menu.
 node ../node_modules/vite-plus/bin/vp test run --project unit \
   src/lib/components/kata/KataIssueDetail.test.ts \
   src/lib/components/kata/KataIssueOverflowMenu.test.ts \
-  src/lib/features/kata/KataWorkspace.test.ts
+  src/lib/features/kata/KataWorkspace.test.ts \
+  src/lib/components/terminal/KataWorkspaceSidebarPane.test.ts
 git add frontend/src/lib/components/kata/KataIssueOverflowMenu.svelte \
   frontend/src/lib/components/kata/KataIssueOverflowMenu.test.ts \
   frontend/src/lib/components/kata/KataIssueDetail.svelte \
   frontend/src/lib/components/kata/KataIssueDetail.test.ts \
   frontend/src/lib/features/kata/KataWorkspace.svelte \
-  frontend/src/lib/components/terminal/KataWorkspaceSidebarPane.svelte
+  frontend/src/lib/components/terminal/KataWorkspaceSidebarPane.svelte \
+  frontend/src/lib/components/terminal/KataWorkspaceSidebarPane.test.ts
 git commit -m "feat: move Kata reassignment into task actions"
 ```
 
@@ -616,10 +688,12 @@ git commit -m "feat: move Kata reassignment into task actions"
 ### Task 4: Make the Issue Project Breadcrumb Passive
 
 **Files:**
+
 - Modify: `frontend/src/lib/components/kata/KataIssueDetail.test.ts`
 - Modify: `frontend/src/lib/components/kata/KataIssueDetail.svelte`
 
 **Interfaces:**
+
 - Preserves: `currentProjectName(): string` fallback order.
 - Removes: breadcrumb-owned destination picker; issue reassignment is already available through the overflow menu added in Task 3 before the breadcrumb control is removed.
 
@@ -690,11 +764,13 @@ git commit -m "feat: make Kata project breadcrumbs passive"
 ### Task 5: Preserve Escape and Focus Behavior
 
 **Files:**
+
 - Modify: `frontend/src/lib/components/kata/KataIssueOverflowMenu.test.ts`
 - Modify: `frontend/src/lib/components/kata/KataIssueOverflowMenu.svelte`
 - Create only if jsdom cannot reliably assert focus: `frontend/src/lib/components/kata/KataIssueOverflowMenu.browser.svelte.ts`
 
 **Interfaces:**
+
 - Consumes: kit `SearchInput` behavior where Escape clears a nonempty value before the owner handles an empty-query Escape.
 - Produces: empty-query Escape closes the move picker without moving and restores focus to More actions.
 
@@ -785,9 +861,11 @@ If no browser file exists, omit it from `git add`.
 ### Task 6: Replace Obsolete Full-Stack Rename Workflows
 
 **Files:**
+
 - Modify: `frontend/tests/e2e-full/kata.spec.ts`
 
 **Interfaces:**
+
 - Preserves: seeded real backend, project creation, project scope routing, daemon move endpoint, and rename API fixture support.
 - Replaces: four tests that require pencil-button or double-click sidebar renaming.
 
@@ -956,7 +1034,7 @@ Use the same backend/home/server setup as the surrounding test, navigate directl
 - [ ] **Step 8: Run targeted full-stack tests**
 
 ```bash
-node ./scripts/run-e2e-to-file.ts tests/e2e-full/kata.spec.ts --grep "kata (sidebar|project|More actions|move picker)"
+node ./scripts/run-e2e-to-file.ts tests/e2e-full/kata.spec.ts --grep "kata (sidebar|project|More actions|move picker|move failure)"
 ```
 
 Expected: PASS in both configured browser projects. During iteration, `--project=chromium` is acceptable, but this two-browser command must pass before commit.
@@ -973,9 +1051,11 @@ git commit -m "test: cover the cleaned-up Kata project workflows"
 ### Task 7: Final Verification
 
 **Files:**
+
 - Verify only; do not edit after these commands without rerunning the affected lane.
 
 **Interfaces:**
+
 - Confirms all spec acceptance criteria and repository pre-push requirements.
 
 - [ ] **Step 1: Run focused unit coverage**
@@ -988,6 +1068,7 @@ node ../node_modules/vite-plus/bin/vp test run --project unit \
   src/lib/components/kata/KataIssueDetail.test.ts \
   src/lib/components/kata/KataIssueOverflowMenu.test.ts \
   src/lib/features/kata/KataWorkspace.test.ts \
+  src/lib/components/terminal/KataWorkspaceSidebarPane.test.ts \
   src/lib/stores/kata-workspace.svelte.test.ts \
   src/lib/api/kata/taskClient.test.ts
 ```

--- a/docs/superpowers/specs/2026-06-08-kata-docs-msgvault-modes-design.md
+++ b/docs/superpowers/specs/2026-06-08-kata-docs-msgvault-modes-design.md
@@ -363,6 +363,9 @@ Kata frontend adaptation:
   (their consumers echo it synchronously); store state that should survive
   navigation lives in the URL
   (`frontend/src/lib/features/kata/KataWorkspace.svelte::reconcileRoute`).
+- Routed issue selection waits for any in-flight view/scope load to settle;
+  intermediate list state may clear selection and abort an early detail read
+  (`frontend/src/lib/features/kata/KataWorkspace.svelte::viewScopeLoadSignature`).
 - Event-driven proxy reads keep switching fail-closed until they settle. The
   Kata proxy applies a 30-second total deadline to ordinary TCP and Unix-socket
   requests, including response bodies, while the live event stream stays

--- a/docs/superpowers/specs/2026-07-12-kata-sidebar-design.md
+++ b/docs/superpowers/specs/2026-07-12-kata-sidebar-design.md
@@ -26,9 +26,11 @@ Only `KataSidebar` project-renaming controls are removed. Project rows will no l
 
 The current project in `KataIssueDetail` will become passive breadcrumb text. It will no longer look like navigation or open a picker when clicked.
 
-The existing issue overflow menu will gain a **Move to another project** action. Selecting it opens a searchable destination picker within the overflow interaction. Eligible destinations preserve the current rules: exclude the current project and inbox-role projects, sort by project name, and show open-task counts. The action is absent when no destination is eligible.
+The existing issue overflow menu will gain a **Move to another project** action. Selecting it replaces the normal action list with a dialog-like searchable destination panel. Eligible destinations preserve the current rules: exclude the current project and inbox-role projects, sort by project name, and show open-task counts. Duplicate names include the project area or UID as a secondary label. The action is absent when no destination is eligible.
 
-Successful selection uses the existing `onMoveIssue` callback and closes the picker. Existing mutation errors continue through the workspace/store error path; the picker stays available when reassignment fails so the user can retry or dismiss it. Opening the menu, its actions, and the destination picker must remain keyboard reachable, with Escape returning focus out of the picker without moving the issue.
+`onMoveIssue` will return `boolean | Promise<boolean>` from both workspace hosts: `true` means the mutation succeeded and `false` means the workspace handled and displayed an error. Success closes the overflow interaction; failure leaves the picker and query available for retry. Destinations are disabled while a move is pending, and an in-flight result cannot update a newly selected issue’s menu state.
+
+The search field and destination buttons use normal Tab/Shift+Tab navigation rather than claiming listbox semantics. Opening the picker focuses search; Escape first clears a nonempty search, then closes the interaction and returns focus to **More actions** when search is empty. Outside click closes without restoring focus, and changing the selected issue resets the interaction.
 
 ## State and Errors
 
@@ -43,22 +45,23 @@ The issue overflow menu owns whether its normal actions or destination picker ar
 - No sidebar control, double-click, or keyboard path starts project renaming.
 - The rename client and store operations remain available.
 - The issue breadcrumb displays the current project name or existing UID fallback as passive text.
-- Issue reassignment is available only through **More actions → Move to another project** and excludes ineligible destinations.
-- The overflow interaction remains usable with pointer and keyboard input at desktop and narrow widths.
+- Issue reassignment is available only through **More actions → Move to another project**, excludes ineligible destinations, and disambiguates duplicate names.
+- Successful reassignment closes the menu; handled failure surfaces the workspace error and remains retryable.
+- The overflow interaction uses normal dialog/button keyboard navigation at desktop and narrow widths, with the specified two-stage Escape behavior.
 
 ## Testing
 
 Component tests will cover area ordering, default expansion, collapse and expansion, collapse-state lifetime, project navigation, project creation, and the absence of sidebar rename controls and inline rename behavior.
 
-Issue-detail and overflow-menu component tests will prove that the project breadcrumb is passive, its fallback text remains correct, the move action is hidden without destinations, and selecting an eligible destination invokes reassignment. Store and client reassignment tests remain unchanged.
+Issue-detail and overflow-menu component tests will prove that the project breadcrumb is passive, its fallback text remains correct, destination names are disambiguated, the move action is hidden without destinations, success closes the picker, failure remains retryable, and keyboard dismissal restores focus. Store and client reassignment tests remain unchanged.
 
-Full-stack Playwright coverage will replace the existing pencil-button and double-click rename scenarios. The replacement must prove project navigation and creation still work and that neither rename affordance is available. Existing browser coverage for grouped-sidebar scrolling remains the geometry-level check for the shared overlay indicator.
+Full-stack Playwright coverage will replace the existing pencil-button and double-click rename scenarios. The replacement must prove project navigation and creation still work and that neither rename affordance is available. The existing real-daemon move scenario will be migrated to **More actions**, including successful keyboard selection and a forced daemon failure that surfaces the workspace error, leaves the picker open, and succeeds on retry. Existing browser coverage for grouped-sidebar scrolling remains the geometry-level check for the shared overlay indicator.
 
 ## Implementation Order
 
 1. Migrate sidebar scrolling and area groups while preserving navigation and creation behavior.
 2. Remove sidebar rename state, controls, callback wiring, and contradictory tests.
-3. Make the issue breadcrumb passive and add overflow-menu reassignment.
+3. Add overflow-menu reassignment, update both workspace callbacks to return success, then make the issue breadcrumb passive in the same reviewable change.
 4. Update component tests for both interactions.
 5. Replace the obsolete full-stack rename scenarios and run the affected frontend suites.
 

--- a/docs/superpowers/specs/2026-07-12-kata-sidebar-design.md
+++ b/docs/superpowers/specs/2026-07-12-kata-sidebar-design.md
@@ -1,33 +1,67 @@
-# Kata Sidebar Design
+# Kata Project UX Cleanup Design
 
 ## Goal
 
-Make Kata navigation use the shared grouped-sidebar behavior introduced by PR #662 and remove conspicuous project renaming from the sidebar.
+Remove two misleading Kata project interactions: easy project renaming in the navigation sidebar and issue reassignment hidden behind a clickable project breadcrumb. Kata navigation will also adopt the grouped-sidebar behavior introduced by PR #662.
 
 ## Sidebar Structure
 
-`KataSidebar` will render its scrollable navigation through `SidebarScrollArea`. Each Kata area will use `GroupedSidebarSection`, matching the grouping, selection, collapse, and scrolling behavior of the pull request, issue, and workspace rails.
+`KataSidebar` will render one `SidebarScrollArea` in this order:
 
-Existing project selection, project status information, task counts, error indicators, and project creation remain available. Project rows will use the shared sidebar styling contract rather than maintaining a parallel set of group and row styles.
+1. The existing system views, in their current order.
+2. Kata areas, in the order supplied by the workspace store.
+3. The existing new-project control.
 
-## Project Renaming
+Each area will use `GroupedSidebarSection`. Its header label is the area name and its count is the number of projects in that area. Areas start expanded. Collapse state lives for the mounted sidebar: it survives project selection and reactive data updates, but resets after the sidebar is remounted or the page reloads.
 
-Project renaming will be removed from the current UI. The sidebar will no longer contain a pencil button, respond to project-row double-clicks by entering rename mode, or render an inline rename form.
+Expanded areas render projects in their existing order. Project selection, active-row state, open-task counts, status and error presentation, and project creation remain unchanged. Project rows use the shared sidebar styling contract, and narrow-viewport and overlay scroll-indicator behavior remain consistent with the other grouped rails.
 
-`KataWorkspace` will stop forwarding a rename callback to the sidebar. The underlying Kata client and workspace-store rename operations will remain intact so a future deliberate project-management surface can use them without restoring easy sidebar renaming.
+## Sidebar Project Renaming
+
+Only `KataSidebar` project-renaming controls are removed. Project rows will no longer contain a pencil button, respond to double-click by entering rename mode, or render an inline rename form. Rows remain native buttons, so pointer and keyboard activation continue to select the project without exposing a second interaction.
+
+`KataWorkspace` will stop forwarding a rename callback to the sidebar. The Kata client and workspace-store rename operations remain available; this change does not remove daemon capability or define a replacement rename surface.
+
+## Issue Project Reassignment
+
+The current project in `KataIssueDetail` will become passive breadcrumb text. It will no longer look like navigation or open a picker when clicked.
+
+The existing issue overflow menu will gain a **Move to another project** action. Selecting it opens a searchable destination picker within the overflow interaction. Eligible destinations preserve the current rules: exclude the current project and inbox-role projects, sort by project name, and show open-task counts. The action is absent when no destination is eligible.
+
+Successful selection uses the existing `onMoveIssue` callback and closes the picker. Existing mutation errors continue through the workspace/store error path; the picker stays available when reassignment fails so the user can retry or dismiss it. Opening the menu, its actions, and the destination picker must remain keyboard reachable, with Escape returning focus out of the picker without moving the issue.
 
 ## State and Errors
 
-The sidebar will own only navigation-related state, including area collapse state required by the shared grouping abstraction. Removing inline rename also removes rename draft, focus, saving, cancellation, and error state from the sidebar.
+The sidebar owns only project-creation and area-collapse state. Removing inline rename also removes rename draft, focus, saving, cancellation, and error state from the sidebar.
 
-Existing project-loading, project-creation, and daemon error behavior remains unchanged.
+The issue overflow menu owns whether its normal actions or destination picker are visible and resets that state when the selected issue changes. Existing project-loading, project-creation, daemon, and issue-mutation error behavior otherwise remains unchanged.
+
+## Acceptance Criteria
+
+- Kata areas use the shared grouped section and scroll-area behavior without changing system-view or project ordering.
+- Project navigation, active selection, open counts, project creation, and existing status/error presentation still work.
+- No sidebar control, double-click, or keyboard path starts project renaming.
+- The rename client and store operations remain available.
+- The issue breadcrumb displays the current project name or existing UID fallback as passive text.
+- Issue reassignment is available only through **More actions → Move to another project** and excludes ineligible destinations.
+- The overflow interaction remains usable with pointer and keyboard input at desktop and narrow widths.
 
 ## Testing
 
-Component tests will cover area grouping, collapse and expansion, project navigation, project creation, and the absence of sidebar rename controls and inline rename behavior.
+Component tests will cover area ordering, default expansion, collapse and expansion, collapse-state lifetime, project navigation, project creation, and the absence of sidebar rename controls and inline rename behavior.
 
-Workspace tests will continue to cover project-scope switching through Kata navigation. Existing full-stack Playwright scenarios that require pencil-button or double-click renaming will be removed or replaced with an assertion that renaming is unavailable from the sidebar. Shared scroll-indicator behavior will continue to be exercised in the browser lane where geometry matters.
+Issue-detail and overflow-menu component tests will prove that the project breadcrumb is passive, its fallback text remains correct, the move action is hidden without destinations, and selecting an eligible destination invokes reassignment. Store and client reassignment tests remain unchanged.
+
+Full-stack Playwright coverage will replace the existing pencil-button and double-click rename scenarios. The replacement must prove project navigation and creation still work and that neither rename affordance is available. Existing browser coverage for grouped-sidebar scrolling remains the geometry-level check for the shared overlay indicator.
+
+## Implementation Order
+
+1. Migrate sidebar scrolling and area groups while preserving navigation and creation behavior.
+2. Remove sidebar rename state, controls, callback wiring, and contradictory tests.
+3. Make the issue breadcrumb passive and add overflow-menu reassignment.
+4. Update component tests for both interactions.
+5. Replace the obsolete full-stack rename scenarios and run the affected frontend suites.
 
 ## Scope
 
-This change does not remove Kata's rename API, add a replacement rename interface, modify daemon behavior, or change backend and database contracts.
+This change does not remove Kata's rename or move APIs, add a project-management page, modify daemon behavior, or change backend and database contracts.

--- a/docs/superpowers/specs/2026-07-12-kata-sidebar-design.md
+++ b/docs/superpowers/specs/2026-07-12-kata-sidebar-design.md
@@ -26,11 +26,13 @@ Only `KataSidebar` project-renaming controls are removed. Project rows will no l
 
 The current project in `KataIssueDetail` will become passive breadcrumb text. It will no longer look like navigation or open a picker when clicked.
 
-The existing issue overflow menu will gain a **Move to another project** action. Selecting it replaces the normal action list with a dialog-like searchable destination panel. Eligible destinations preserve the current rules: exclude the current project and inbox-role projects, sort by project name, and show open-task counts. Duplicate names include the project area or UID as a secondary label. The action is absent when no destination is eligible.
+The existing issue overflow menu will gain a **Move to another project** action. Selecting it replaces the normal action list with a dialog-like searchable destination panel. Eligible destinations preserve the current rules: exclude the current project and inbox-role projects, sort by project name, and show open-task counts. Duplicate names use the project area only when it uniquely identifies the destination within that duplicate-name group; otherwise they show the project UID. The action is absent when no destination is eligible.
 
-`onMoveIssue` will return `boolean | Promise<boolean>` from both workspace hosts: `true` means the mutation succeeded and `false` means the workspace handled and displayed an error. Success closes the overflow interaction; failure leaves the picker and query available for retry. Destinations are disabled while a move is pending, and an in-flight result cannot update a newly selected issue’s menu state.
+`onMoveIssue` will return `boolean | Promise<boolean>` from both workspace hosts: `true` means the mutation succeeded and `false` means the workspace handled and displayed an error. Success closes the overflow interaction; failure leaves the picker and query available for retry. Each request receives a monotonic operation token, and only the current token may close the interaction or clear pending state after navigation, including A → B → A selection sequences.
 
-The search field and destination buttons use normal Tab/Shift+Tab navigation rather than claiming listbox semantics. Opening the picker focuses search; Escape first clears a nonempty search, then closes the interaction and returns focus to **More actions** when search is empty. Outside click closes without restoring focus, and changing the selected issue resets the interaction.
+Destinations are disabled while a move is pending. Escape and outside-click dismissal are ignored until the request settles, so reopening cannot submit a second concurrent move. Project inputs remain reactive while the picker is open: renames and area changes update visible labels, while removed or newly inbox-role projects disappear unless they are the active pending destination, which remains visible and disabled until its request settles.
+
+The search field and destination buttons use normal Tab/Shift+Tab navigation rather than claiming listbox semantics. Opening the picker focuses search; Tab traverses every visible destination and the no-results state is announced as status text. Escape first clears a nonempty search, then closes the interaction and returns focus to **More actions** when search is empty and no move is pending. Outside click closes without restoring focus only when no move is pending, and changing the selected issue resets the visible interaction without invalidating the operation token.
 
 ## State and Errors
 
@@ -61,8 +63,8 @@ Full-stack Playwright coverage will replace the existing pencil-button and doubl
 
 1. Migrate sidebar scrolling and area groups while preserving navigation and creation behavior.
 2. Remove sidebar rename state, controls, callback wiring, and contradictory tests.
-3. Add overflow-menu reassignment, update both workspace callbacks to return success, then make the issue breadcrumb passive in the same reviewable change.
-4. Update component tests for both interactions.
+3. Add overflow-menu reassignment and update both workspace callbacks to return success. This intermediate commit intentionally leaves the existing breadcrumb control available so reassignment is never removed before its replacement lands.
+4. Make the issue breadcrumb passive immediately afterward, then update component tests for both interactions.
 5. Replace the obsolete full-stack rename scenarios and run the affected frontend suites.
 
 ## Scope

--- a/docs/superpowers/specs/2026-07-12-kata-sidebar-design.md
+++ b/docs/superpowers/specs/2026-07-12-kata-sidebar-design.md
@@ -1,0 +1,33 @@
+# Kata Sidebar Design
+
+## Goal
+
+Make Kata navigation use the shared grouped-sidebar behavior introduced by PR #662 and remove conspicuous project renaming from the sidebar.
+
+## Sidebar Structure
+
+`KataSidebar` will render its scrollable navigation through `SidebarScrollArea`. Each Kata area will use `GroupedSidebarSection`, matching the grouping, selection, collapse, and scrolling behavior of the pull request, issue, and workspace rails.
+
+Existing project selection, project status information, task counts, error indicators, and project creation remain available. Project rows will use the shared sidebar styling contract rather than maintaining a parallel set of group and row styles.
+
+## Project Renaming
+
+Project renaming will be removed from the current UI. The sidebar will no longer contain a pencil button, respond to project-row double-clicks by entering rename mode, or render an inline rename form.
+
+`KataWorkspace` will stop forwarding a rename callback to the sidebar. The underlying Kata client and workspace-store rename operations will remain intact so a future deliberate project-management surface can use them without restoring easy sidebar renaming.
+
+## State and Errors
+
+The sidebar will own only navigation-related state, including area collapse state required by the shared grouping abstraction. Removing inline rename also removes rename draft, focus, saving, cancellation, and error state from the sidebar.
+
+Existing project-loading, project-creation, and daemon error behavior remains unchanged.
+
+## Testing
+
+Component tests will cover area grouping, collapse and expansion, project navigation, project creation, and the absence of sidebar rename controls and inline rename behavior.
+
+Workspace tests will continue to cover project-scope switching through Kata navigation. Existing full-stack Playwright scenarios that require pencil-button or double-click renaming will be removed or replaced with an assertion that renaming is unavailable from the sidebar. Shared scroll-indicator behavior will continue to be exercised in the browser lane where geometry matters.
+
+## Scope
+
+This change does not remove Kata's rename API, add a replacement rename interface, modify daemon behavior, or change backend and database contracts.

--- a/frontend/src/lib/components/kata/KataIssueDetail.svelte
+++ b/frontend/src/lib/components/kata/KataIssueDetail.svelte
@@ -43,7 +43,7 @@
     unlinkError: string | null;
     selectedRecurrences: KataRecurrence[];
     checklistRevealed: boolean;
-    onMoveIssue: (toProjectUID: string | null) => void | Promise<void>;
+    onMoveIssue: (toProjectUID: string) => boolean | Promise<boolean>;
     onPatchMetadata: (uid: string, patch: Record<string, unknown>) => boolean | Promise<boolean>;
     onAddComment: (uid: string, body: string) => boolean | Promise<boolean>;
     onEditIssue: (uid: string, patch: KataTaskEditPatch) => boolean | Promise<boolean>;
@@ -162,6 +162,11 @@
     return project?.name ?? issue.issue.project_uid;
   }
 
+  function moveFromBreadcrumb(toProjectUID: string | null): boolean | Promise<boolean> {
+    if (!toProjectUID) return false;
+    return onMoveIssue(toProjectUID);
+  }
+
   function startEditingTitle(): void {
     cancelingTitle = false;
     titleDraft = issue.issue.title;
@@ -232,7 +237,7 @@
             clearLabel={currentProjectName()}
             placeholder="Move to project..."
             emptyLabel="No matching projects"
-            onChange={onMoveIssue}
+            onChange={moveFromBreadcrumb}
           />
         </div>
         <span class="crumb-sep">/</span>
@@ -288,8 +293,10 @@
       {/if}
       <KataIssueOverflowMenu
         {issue}
+        {projects}
         hasChecklist={checklistItems().length > 0 || checklistRevealed}
         hasRecurrence={!canCreateRecurrence}
+        {onMoveIssue}
         onAddChecklist={onRevealChecklist}
         onCreateRecurrence={onCreateRecurrence}
         onDeleteIssue={onDeleteIssue}

--- a/frontend/src/lib/components/kata/KataIssueDetail.svelte
+++ b/frontend/src/lib/components/kata/KataIssueDetail.svelte
@@ -43,6 +43,7 @@
     unlinkError: string | null;
     selectedRecurrences: KataRecurrence[];
     checklistRevealed: boolean;
+    movePending?: boolean | undefined;
     onMoveIssue: (toProjectUID: string) => boolean | Promise<boolean>;
     onPatchMetadata: (uid: string, patch: Record<string, unknown>) => boolean | Promise<boolean>;
     onAddComment: (uid: string, body: string) => boolean | Promise<boolean>;
@@ -82,6 +83,7 @@
     unlinkError,
     selectedRecurrences,
     checklistRevealed,
+    movePending = false,
     onMoveIssue,
     onPatchMetadata,
     onAddComment,
@@ -264,6 +266,7 @@
         {projects}
         hasChecklist={checklistItems().length > 0 || checklistRevealed}
         hasRecurrence={!canCreateRecurrence}
+        {movePending}
         {onMoveIssue}
         onAddChecklist={onRevealChecklist}
         onCreateRecurrence={onCreateRecurrence}

--- a/frontend/src/lib/components/kata/KataIssueDetail.svelte
+++ b/frontend/src/lib/components/kata/KataIssueDetail.svelte
@@ -16,7 +16,7 @@
   import type { MessageLinkRef } from "../../messages/types";
   import IssueMessageLinks from "../../features/kata/IssueMessageLinks.svelte";
   import RecurrencePanel from "../recurrence/RecurrencePanel.svelte";
-  import TypeaheadTrigger, { type TypeaheadOption } from "../shared/TypeaheadTrigger.svelte";
+  import type { TypeaheadOption } from "../shared/TypeaheadTrigger.svelte";
   import KataChecklistEditor from "./KataChecklistEditor.svelte";
   import KataIssueActions from "./KataIssueActions.svelte";
   import KataIssueDiscussion from "./KataIssueDiscussion.svelte";
@@ -137,22 +137,6 @@
     return issue.issue.metadata.checklist ?? [];
   }
 
-  function isTaskInboxProject(project: KataProjectSummary): boolean {
-    return project.metadata.role === "inbox";
-  }
-
-  function moveOptions(): TypeaheadOption[] {
-    return projects
-      .filter((project) => project.uid !== issue.issue.project_uid)
-      .filter((project) => !isTaskInboxProject(project))
-      .sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" }))
-      .map((project) => ({
-        value: project.uid,
-        label: project.name,
-        meta: String(project.open_count),
-      }));
-  }
-
   function currentProjectName(): string {
     const fromIssue = issue.issue.project_name.trim();
     if (fromIssue) return fromIssue;
@@ -160,11 +144,6 @@
       projects.find((candidate) => candidate.uid === issue.issue.project_uid) ??
       projects.find((candidate) => candidate.id === issue.issue.project_id);
     return project?.name ?? issue.issue.project_uid;
-  }
-
-  function moveFromBreadcrumb(toProjectUID: string | null): boolean | Promise<boolean> {
-    if (!toProjectUID) return false;
-    return onMoveIssue(toProjectUID);
   }
 
   function startEditingTitle(): void {
@@ -228,18 +207,7 @@
   <div class="detail-heading">
     <div class="detail-heading-main">
       <div class="detail-kicker">
-        <div class="crumb-project-control">
-          <TypeaheadTrigger
-            ariaLabel="Move issue project"
-            triggerAriaLabel={`Move issue from ${currentProjectName()}`}
-            options={moveOptions()}
-            selected={null}
-            clearLabel={currentProjectName()}
-            placeholder="Move to project..."
-            emptyLabel="No matching projects"
-            onChange={moveFromBreadcrumb}
-          />
-        </div>
+        <span class="crumb-project">{currentProjectName()}</span>
         <span class="crumb-sep">/</span>
         <span class="crumb-id">{issue.issue.short_id}</span>
         <span class="kit-sr-only">{issue.issue.qualified_id}</span>
@@ -426,34 +394,14 @@
     min-width: 0;
   }
 
-  .crumb-project-control {
-    width: clamp(160px, 22vw, 292px);
+  .crumb-project {
     min-width: 0;
-  }
-
-  .crumb-project-control :global(.typeahead-trigger),
-  .crumb-project-control :global(.typeahead-input) {
-    height: 22px;
-    padding: 0 8px;
+    max-width: clamp(160px, 22vw, 292px);
+    overflow: hidden;
     color: var(--text-primary);
-    font-size: var(--font-size-xs);
     font-weight: 600;
-    background: var(--bg-inset);
-    border-color: var(--border-muted);
-  }
-
-  .crumb-project-control :global(.typeahead-list) {
-    width: clamp(240px, 28vw, 320px);
-    right: auto;
-  }
-
-  .crumb-project-control :global(.typeahead-trigger:hover) {
-    background: var(--bg-surface-hover);
-    border-color: var(--border-default);
-  }
-
-  .crumb-project-control :global(.typeahead-trigger > svg) {
-    display: none;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .crumb-id {

--- a/frontend/src/lib/components/kata/KataIssueDetail.test.ts
+++ b/frontend/src/lib/components/kata/KataIssueDetail.test.ts
@@ -184,14 +184,14 @@ describe("KataIssueDetail", () => {
     expect(onEditIssue).toHaveBeenCalledWith("issue-1", { body: "Updated body" });
   });
 
-  it("moves to a non-inbox project from the crumb picker", async () => {
+  it("renders the current project as passive breadcrumb text", () => {
     const onMoveIssue = vi.fn(async () => true);
     renderDetail({ onMoveIssue });
 
-    await fireEvent.click(screen.getByRole("button", { name: /Move issue from Inbox/ }));
-    await fireEvent.keyDown(screen.getByRole("combobox", { name: "Move issue project" }), { key: "Enter" });
-
-    expect(onMoveIssue).toHaveBeenCalledWith("project-2");
+    expect(screen.getAllByText("Inbox").length).toBeGreaterThan(0);
+    expect(screen.queryByRole("button", { name: /Move issue from Inbox/ })).toBeNull();
+    expect(screen.queryByRole("combobox", { name: "Move issue project" })).toBeNull();
+    expect(onMoveIssue).not.toHaveBeenCalled();
   });
 
   it("opens the reachable graph for the selected task", async () => {
@@ -212,7 +212,8 @@ describe("KataIssueDetail", () => {
       }),
     });
 
-    expect(screen.getByRole("button", { name: "Move issue from Roadmap" }).textContent).toContain("Roadmap");
+    expect(screen.getAllByText("Roadmap").length).toBeGreaterThan(0);
+    expect(screen.queryByRole("button", { name: "Move issue from Roadmap" })).toBeNull();
   });
 
   it("renders linked messages through the detail composition", () => {

--- a/frontend/src/lib/components/kata/KataIssueDetail.test.ts
+++ b/frontend/src/lib/components/kata/KataIssueDetail.test.ts
@@ -118,7 +118,7 @@ function renderDetail(props: Partial<KataIssueDetailProps> = {}) {
       unlinkError: null,
       selectedRecurrences: [makeRecurrence()],
       checklistRevealed: false,
-      onMoveIssue: vi.fn(async () => {}),
+      onMoveIssue: vi.fn(async () => true),
       onPatchMetadata: vi.fn(async () => true),
       onAddComment: vi.fn(async () => true),
       onEditIssue: vi.fn(async () => true),
@@ -185,7 +185,7 @@ describe("KataIssueDetail", () => {
   });
 
   it("moves to a non-inbox project from the crumb picker", async () => {
-    const onMoveIssue = vi.fn(async () => {});
+    const onMoveIssue = vi.fn(async () => true);
     renderDetail({ onMoveIssue });
 
     await fireEvent.click(screen.getByRole("button", { name: /Move issue from Inbox/ }));

--- a/frontend/src/lib/components/kata/KataIssueOverflowMenu.svelte
+++ b/frontend/src/lib/components/kata/KataIssueOverflowMenu.svelte
@@ -10,6 +10,7 @@
     projects: KataProjectSummary[];
     hasChecklist: boolean;
     hasRecurrence: boolean;
+    movePending?: boolean | undefined;
     onMoveIssue: (toProjectUID: string) => boolean | Promise<boolean>;
     onAddChecklist: () => void;
     onCreateRecurrence: () => void;
@@ -21,6 +22,7 @@
     projects,
     hasChecklist,
     hasRecurrence,
+    movePending = false,
     onMoveIssue,
     onAddChecklist,
     onCreateRecurrence,
@@ -111,7 +113,7 @@
   $effect(() => {
     if (!menuOpen) return;
     function onPointerDown(event: PointerEvent): void {
-      if (!menuRoot || activeMoveOperation !== null) return;
+      if (!menuRoot || movePending || activeMoveOperation !== null) return;
       if (event.target instanceof Node && menuRoot.contains(event.target)) return;
       closeMenu();
     }
@@ -134,7 +136,7 @@
   }
 
   function closeMenu(force = false, restoreFocus = false): void {
-    if (activeMoveOperation !== null && !force) return;
+    if ((movePending || activeMoveOperation !== null) && !force) return;
     interactionGeneration += 1;
     menuOpen = false;
     menuView = "actions";
@@ -160,7 +162,7 @@
   }
 
   function handleMoveKeydown(event: KeyboardEvent): void {
-    if (event.key !== "Escape" || activeMoveOperation !== null) return;
+    if (event.key !== "Escape" || movePending || activeMoveOperation !== null) return;
     event.preventDefault();
     closeMenu(false, true);
   }
@@ -220,7 +222,7 @@
       ariaHaspopup={menuView === "move" ? "dialog" : "menu"}
       ariaExpanded={menuOpen}
       onclick={() => {
-        if (activeMoveOperation !== null) return;
+        if (movePending || activeMoveOperation !== null) return;
         if (menuOpen) closeMenu();
         else menuOpen = true;
       }}
@@ -280,7 +282,7 @@
           {#each displayedProjects as project (project.uid)}
             <button
               type="button"
-              disabled={activeMoveOperation !== null}
+              disabled={movePending || activeMoveOperation !== null}
               aria-busy={movingProjectUID === project.uid}
               onclick={() => void moveIssue(project)}
             >

--- a/frontend/src/lib/components/kata/KataIssueOverflowMenu.svelte
+++ b/frontend/src/lib/components/kata/KataIssueOverflowMenu.svelte
@@ -1,13 +1,16 @@
 <script lang="ts">
-  import { IconButton } from "@kenn-io/kit-ui";
+  import { IconButton, SearchInput } from "@kenn-io/kit-ui";
   import MoreHorizontalIcon from "@lucide/svelte/icons/more-horizontal";
-  import type { KataTaskDetail } from "../../api/kata/taskTypes.js";
+  import { tick } from "svelte";
+  import type { KataProjectSummary, KataTaskDetail } from "../../api/kata/taskTypes.js";
   import Modal from "../shared/Modal.svelte";
 
   interface Props {
     issue: KataTaskDetail;
+    projects: KataProjectSummary[];
     hasChecklist: boolean;
     hasRecurrence: boolean;
+    onMoveIssue: (toProjectUID: string) => boolean | Promise<boolean>;
     onAddChecklist: () => void;
     onCreateRecurrence: () => void;
     onDeleteIssue: () => boolean | Promise<boolean>;
@@ -15,38 +18,101 @@
 
   let {
     issue,
+    projects,
     hasChecklist,
     hasRecurrence,
+    onMoveIssue,
     onAddChecklist,
     onCreateRecurrence,
     onDeleteIssue,
   }: Props = $props();
 
   let menuOpen = $state(false);
+  let menuView = $state<"actions" | "move">("actions");
   let menuRoot: HTMLDivElement | null = $state(null);
+  let moveSearchInput = $state() as HTMLInputElement;
+  let moveQuery = $state("");
+  let movingProjectUID = $state<string | null>(null);
+  let pendingProject = $state.raw<KataProjectSummary | null>(null);
+  let interactionGeneration = 0;
+  let moveOperationGeneration = 0;
+  let activeMoveOperation = $state<number | null>(null);
   let deleteOpen = $state(false);
-  let pending = $state(false);
+  let deletePending = $state(false);
   let trackedUID = $state<string | null>(null);
 
   const canAddChecklist = $derived(!hasChecklist);
   const canCreateRecurrence = $derived(!hasRecurrence);
   const canDeleteIssue = $derived(issue.issue.status !== "closed");
-  const hasAnyAction = $derived(canAddChecklist || canCreateRecurrence || canDeleteIssue);
+  const eligibleProjects = $derived.by(() =>
+    projects
+      .filter((project) => project.uid !== issue.issue.project_uid && project.metadata.role !== "inbox")
+      .toSorted(
+        (a, b) =>
+          a.name.localeCompare(b.name, undefined, { sensitivity: "base" }) ||
+          a.uid.localeCompare(b.uid),
+      ),
+  );
+  const duplicateContexts = $derived.by(() => {
+    const groups = new Map<string, KataProjectSummary[]>();
+    for (const project of eligibleProjects) {
+      const key = project.name.trim().toLocaleLowerCase();
+      groups.set(key, [...(groups.get(key) ?? []), project]);
+    }
+
+    const contexts = new Map<string, string>();
+    for (const group of groups.values()) {
+      if (group.length < 2) continue;
+      const areaCounts = new Map<string, number>();
+      for (const project of group) {
+        const area = projectArea(project);
+        if (area) areaCounts.set(area, (areaCounts.get(area) ?? 0) + 1);
+      }
+      for (const project of group) {
+        const area = projectArea(project);
+        contexts.set(project.uid, area && areaCounts.get(area) === 1 ? area : project.uid);
+      }
+    }
+    return contexts;
+  });
+  const displayedProjects = $derived.by(() => {
+    const available = [...eligibleProjects];
+    if (pendingProject && !available.some((project) => project.uid === pendingProject?.uid)) {
+      available.push(pendingProject);
+    }
+    const query = moveQuery.trim().toLocaleLowerCase();
+    return query
+      ? available.filter((project) =>
+          [project.name, destinationContext(project) ?? ""].some((value) =>
+            value.toLocaleLowerCase().includes(query),
+          ),
+        )
+      : available;
+  });
+  const hasAnyAction = $derived(
+    canAddChecklist || canCreateRecurrence || canDeleteIssue || eligibleProjects.length > 0,
+  );
 
   $effect(() => {
     if (issue.issue.uid === trackedUID) return;
     trackedUID = issue.issue.uid;
+    interactionGeneration += 1;
+    activeMoveOperation = null;
+    movingProjectUID = null;
+    pendingProject = null;
     menuOpen = false;
+    menuView = "actions";
+    moveQuery = "";
     deleteOpen = false;
-    pending = false;
+    deletePending = false;
   });
 
   $effect(() => {
     if (!menuOpen) return;
     function onPointerDown(event: PointerEvent): void {
-      if (!menuRoot) return;
+      if (!menuRoot || activeMoveOperation !== null) return;
       if (event.target instanceof Node && menuRoot.contains(event.target)) return;
-      menuOpen = false;
+      closeMenu();
     }
     window.addEventListener("pointerdown", onPointerDown, true);
     return () => {
@@ -54,36 +120,95 @@
     };
   });
 
-  function revealChecklist(): void {
+  function projectArea(project: KataProjectSummary): string {
+    return typeof project.metadata.area === "string" ? project.metadata.area.trim() : "";
+  }
+
+  function destinationContext(project: KataProjectSummary): string | null {
+    return duplicateContexts.get(project.uid) ?? null;
+  }
+
+  function triggerButton(): HTMLButtonElement | null {
+    return menuRoot?.querySelector<HTMLButtonElement>(".overflow-trigger") ?? null;
+  }
+
+  function closeMenu(force = false, restoreFocus = false): void {
+    if (activeMoveOperation !== null && !force) return;
+    interactionGeneration += 1;
     menuOpen = false;
+    menuView = "actions";
+    moveQuery = "";
+    if (restoreFocus) queueMicrotask(() => triggerButton()?.focus());
+  }
+
+  function revealChecklist(): void {
+    closeMenu();
     onAddChecklist();
   }
 
   function openCreateRecurrence(): void {
-    menuOpen = false;
+    closeMenu();
     onCreateRecurrence();
   }
 
+  async function openMovePicker(): Promise<void> {
+    menuView = "move";
+    moveQuery = "";
+    await tick();
+    moveSearchInput?.focus();
+  }
+
+  function handleMoveKeydown(event: KeyboardEvent): void {
+    if (event.key !== "Escape" || activeMoveOperation !== null) return;
+    event.preventDefault();
+    closeMenu(false, true);
+  }
+
+  async function moveIssue(project: KataProjectSummary): Promise<void> {
+    if (activeMoveOperation !== null) return;
+    const sourceIssueUID = issue.issue.uid;
+    const sourceInteraction = interactionGeneration;
+    const operation = ++moveOperationGeneration;
+    activeMoveOperation = operation;
+    movingProjectUID = project.uid;
+    pendingProject = project;
+    try {
+      const moved = await onMoveIssue(project.uid);
+      if (
+        activeMoveOperation !== operation ||
+        interactionGeneration !== sourceInteraction ||
+        issue.issue.uid !== sourceIssueUID
+      ) {
+        return;
+      }
+      if (moved !== false) closeMenu(true);
+    } finally {
+      if (activeMoveOperation === operation) {
+        activeMoveOperation = null;
+        movingProjectUID = null;
+        pendingProject = null;
+      }
+    }
+  }
+
   function openDeleteDialog(): void {
-    menuOpen = false;
+    closeMenu();
     deleteOpen = true;
   }
 
   function closeDeleteDialog(): void {
-    if (pending) return;
+    if (deletePending) return;
     deleteOpen = false;
   }
 
   async function deleteIssue(): Promise<void> {
-    if (pending) return;
-    pending = true;
+    if (deletePending) return;
+    deletePending = true;
     try {
       const ok = await onDeleteIssue();
-      if (ok) {
-        deleteOpen = false;
-      }
+      if (ok) deleteOpen = false;
     } finally {
-      pending = false;
+      deletePending = false;
     }
   }
 </script>
@@ -93,16 +218,25 @@
     <IconButton
       class="overflow-trigger"
       ariaLabel="More actions"
-      ariaHaspopup="menu"
+      ariaHaspopup={menuView === "move" ? "dialog" : "menu"}
       ariaExpanded={menuOpen}
       onclick={() => {
-        menuOpen = !menuOpen;
+        if (activeMoveOperation !== null) return;
+        if (menuOpen) closeMenu();
+        else menuOpen = true;
       }}
     >
       <MoreHorizontalIcon size={14} strokeWidth={1.9} />
     </IconButton>
-    {#if menuOpen}
-      <ul class="overflow-menu" role="menu" aria-label="Task actions">
+    {#if menuOpen && menuView === "actions"}
+      <ul class="overflow-menu kit-popover-card" role="menu" aria-label="Task actions">
+        {#if eligibleProjects.length > 0}
+          <li>
+            <button type="button" class="overflow-item" role="menuitem" onclick={() => void openMovePicker()}>
+              Move to another project
+            </button>
+          </li>
+        {/if}
         {#if canAddChecklist}
           <li>
             <button type="button" class="overflow-item" role="menuitem" onclick={revealChecklist}>
@@ -118,7 +252,7 @@
           </li>
         {/if}
         {#if canDeleteIssue}
-          {#if canAddChecklist || canCreateRecurrence}
+          {#if eligibleProjects.length > 0 || canAddChecklist || canCreateRecurrence}
             <li class="overflow-separator" role="separator"></li>
           {/if}
           <li>
@@ -128,6 +262,40 @@
           </li>
         {/if}
       </ul>
+    {:else if menuOpen}
+      <div
+        class="move-picker kit-popover-card"
+        role="dialog"
+        aria-label="Move to another project"
+        tabindex="-1"
+        onkeydown={handleMoveKeydown}
+      >
+        <SearchInput
+          bind:value={moveQuery}
+          bind:inputEl={moveSearchInput}
+          block
+          ariaLabel="Find project"
+          placeholder="Search projects"
+        />
+        <div class="move-options" aria-label="Project destinations">
+          {#each displayedProjects as project (project.uid)}
+            <button
+              type="button"
+              disabled={activeMoveOperation !== null}
+              aria-busy={movingProjectUID === project.uid}
+              onclick={() => void moveIssue(project)}
+            >
+              <span class="move-project-name">{project.name}</span>
+              {#if destinationContext(project)}
+                <span class="move-project-context">{destinationContext(project)}</span>
+              {/if}
+              <span class="move-project-count">{project.open_count}</span>
+            </button>
+          {:else}
+            <p role="status">No matching projects</p>
+          {/each}
+        </div>
+      </div>
     {/if}
   </div>
 {/if}
@@ -143,11 +311,11 @@
   </div>
 
   {#snippet footer()}
-    <button type="button" class="ghost-button" onclick={closeDeleteDialog} disabled={pending}>
+    <button type="button" class="ghost-button" onclick={closeDeleteDialog} disabled={deletePending}>
       Cancel
     </button>
-    <button type="button" class="danger-button" onclick={() => { void deleteIssue(); }} disabled={pending}>
-      {pending ? "Deleting..." : "Delete"}
+    <button type="button" class="danger-button" onclick={() => { void deleteIssue(); }} disabled={deletePending}>
+      {deletePending ? "Deleting..." : "Delete"}
     </button>
   {/snippet}
 </Modal>
@@ -159,15 +327,11 @@
     align-items: center;
     justify-content: center;
     gap: 6px;
+    min-height: 28px;
+    padding: 5px 11px;
     border-radius: 6px;
     font-size: var(--font-size-sm);
     font-weight: 650;
-  }
-
-  .ghost-button,
-  .danger-button {
-    min-height: 28px;
-    padding: 5px 11px;
   }
 
   .ghost-button {
@@ -193,18 +357,18 @@
     display: inline-flex;
   }
 
-  .overflow-menu {
+  .overflow-menu,
+  .move-picker {
     position: absolute;
     top: calc(100% + 6px);
     right: 0;
     z-index: 35;
-    min-width: 190px;
     margin: 0;
+  }
+
+  .overflow-menu {
+    min-width: 210px;
     padding: 5px;
-    border: 1px solid var(--border-default);
-    border-radius: 8px;
-    background: var(--bg-surface);
-    box-shadow: var(--shadow-lg);
     list-style: none;
   }
 
@@ -230,6 +394,69 @@
     height: 1px;
     margin: 5px 2px;
     background: var(--border-muted);
+  }
+
+  .move-picker {
+    display: grid;
+    gap: var(--space-3);
+    width: min(320px, calc(100vw - 24px));
+    padding: var(--space-4);
+  }
+
+  .move-options {
+    display: grid;
+    max-height: 280px;
+    overflow-y: auto;
+  }
+
+  .move-options button {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 2px var(--space-3);
+    width: 100%;
+    padding: 7px 9px;
+    border-radius: 5px;
+    color: var(--text-secondary);
+    text-align: left;
+  }
+
+  .move-options button:hover:not(:disabled) {
+    background: var(--bg-surface-hover);
+    color: var(--text-primary);
+  }
+
+  .move-options button:disabled {
+    opacity: 0.62;
+  }
+
+  .move-project-name {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .move-project-context {
+    grid-column: 1;
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+  }
+
+  .move-project-count {
+    grid-column: 2;
+    grid-row: 1 / span 2;
+    align-self: center;
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .move-options p {
+    margin: 0;
+    padding: var(--space-4);
+    color: var(--text-muted);
+    font-size: var(--font-size-sm);
+    text-align: center;
   }
 
   .delete-dialog {

--- a/frontend/src/lib/components/kata/KataIssueOverflowMenu.svelte
+++ b/frontend/src/lib/components/kata/KataIssueOverflowMenu.svelte
@@ -32,15 +32,19 @@
   let menuRoot: HTMLDivElement | null = $state(null);
   let moveSearchInput = $state() as HTMLInputElement;
   let moveQuery = $state("");
-  let movingProjectUID = $state<string | null>(null);
-  let pendingProject = $state.raw<KataProjectSummary | null>(null);
+  let pendingMoves = $state.raw(
+    new Map<string, { operation: number; project: KataProjectSummary }>(),
+  );
   let interactionGeneration = 0;
   let moveOperationGeneration = 0;
-  let activeMoveOperation = $state<number | null>(null);
   let deleteOpen = $state(false);
   let deletePending = $state(false);
   let trackedUID = $state<string | null>(null);
 
+  const activeMove = $derived(pendingMoves.get(issue.issue.uid) ?? null);
+  const activeMoveOperation = $derived(activeMove?.operation ?? null);
+  const movingProjectUID = $derived(activeMove?.project.uid ?? null);
+  const pendingProject = $derived(activeMove?.project ?? null);
   const canAddChecklist = $derived(!hasChecklist);
   const canCreateRecurrence = $derived(!hasRecurrence);
   const canDeleteIssue = $derived(issue.issue.status !== "closed");
@@ -97,9 +101,6 @@
     if (issue.issue.uid === trackedUID) return;
     trackedUID = issue.issue.uid;
     interactionGeneration += 1;
-    activeMoveOperation = null;
-    movingProjectUID = null;
-    pendingProject = null;
     menuOpen = false;
     menuView = "actions";
     moveQuery = "";
@@ -165,17 +166,15 @@
   }
 
   async function moveIssue(project: KataProjectSummary): Promise<void> {
-    if (activeMoveOperation !== null) return;
     const sourceIssueUID = issue.issue.uid;
+    if (pendingMoves.has(sourceIssueUID)) return;
     const sourceInteraction = interactionGeneration;
     const operation = ++moveOperationGeneration;
-    activeMoveOperation = operation;
-    movingProjectUID = project.uid;
-    pendingProject = project;
+    pendingMoves = new Map(pendingMoves).set(sourceIssueUID, { operation, project });
     try {
       const moved = await onMoveIssue(project.uid);
       if (
-        activeMoveOperation !== operation ||
+        pendingMoves.get(sourceIssueUID)?.operation !== operation ||
         interactionGeneration !== sourceInteraction ||
         issue.issue.uid !== sourceIssueUID
       ) {
@@ -183,10 +182,10 @@
       }
       if (moved !== false) closeMenu(true);
     } finally {
-      if (activeMoveOperation === operation) {
-        activeMoveOperation = null;
-        movingProjectUID = null;
-        pendingProject = null;
+      if (pendingMoves.get(sourceIssueUID)?.operation === operation) {
+        const nextPendingMoves = new Map(pendingMoves);
+        nextPendingMoves.delete(sourceIssueUID);
+        pendingMoves = nextPendingMoves;
       }
     }
   }

--- a/frontend/src/lib/components/kata/KataIssueOverflowMenu.test.ts
+++ b/frontend/src/lib/components/kata/KataIssueOverflowMenu.test.ts
@@ -163,7 +163,7 @@ describe("KataIssueOverflowMenu", () => {
     expect(screen.getByRole("button", { name: "More actions" }).getAttribute("aria-expanded")).toBe("false");
   });
 
-  it("ignores an old A move after navigating A to B to A", async () => {
+  it("blocks a second A move until the old A move settles after A to B to A navigation", async () => {
     let finishOldMove!: (moved: boolean) => void;
     const oldMove = new Promise<boolean>((resolve) => {
       finishOldMove = resolve;
@@ -178,11 +178,18 @@ describe("KataIssueOverflowMenu", () => {
     await fireEvent.click(screen.getByRole("button", { name: /Roadmap/ }));
     await view.rerender({ issue: makeIssue("open", { uid: "issue-b" }) });
     await view.rerender({ issue: makeIssue("open", { uid: "issue-1" }) });
-    await openMovePicker();
+    await fireEvent.click(screen.getByRole("button", { name: "More actions" }));
+
+    expect(screen.queryByRole("menuitem", { name: "Move to another project" })).toBeNull();
+    expect(onMoveIssue).toHaveBeenCalledTimes(1);
 
     finishOldMove(true);
     await oldMove;
-    expect(screen.getByRole("searchbox", { name: "Find project" })).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "More actions" }).getAttribute("aria-expanded")).toBe("false");
+    });
+    await Promise.resolve();
+    await openMovePicker();
     const destination = screen.getByRole("button", { name: /Roadmap/ }) as HTMLButtonElement;
     expect(destination.disabled).toBe(false);
     await fireEvent.click(destination);

--- a/frontend/src/lib/components/kata/KataIssueOverflowMenu.test.ts
+++ b/frontend/src/lib/components/kata/KataIssueOverflowMenu.test.ts
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, within } from "@testing-library/svelte";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/svelte";
 import type { ComponentProps } from "svelte";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import type { KataProjectSummary, KataTaskDetail } from "../../api/kata/taskTypes.js";
@@ -168,7 +168,10 @@ describe("KataIssueOverflowMenu", () => {
     const oldMove = new Promise<boolean>((resolve) => {
       finishOldMove = resolve;
     });
-    const onMoveIssue = vi.fn(() => oldMove);
+    const onMoveIssue = vi
+      .fn()
+      .mockImplementationOnce(() => oldMove)
+      .mockResolvedValueOnce(true);
     const view = renderMenu({ onMoveIssue });
 
     await openMovePicker();
@@ -180,6 +183,71 @@ describe("KataIssueOverflowMenu", () => {
     finishOldMove(true);
     await oldMove;
     expect(screen.getByRole("searchbox", { name: "Find project" })).toBeTruthy();
+    const destination = screen.getByRole("button", { name: /Roadmap/ }) as HTMLButtonElement;
+    expect(destination.disabled).toBe(false);
+    await fireEvent.click(destination);
+    expect(onMoveIssue).toHaveBeenCalledTimes(2);
+    expect(screen.queryByRole("searchbox", { name: "Find project" })).toBeNull();
+  });
+
+  it("updates destinations reactively and retains the pending destination snapshot", async () => {
+    let finishMove!: (moved: boolean) => void;
+    const pendingMove = new Promise<boolean>((resolve) => {
+      finishMove = resolve;
+    });
+    const view = renderMenu({ onMoveIssue: vi.fn(() => pendingMove) });
+
+    await openMovePicker();
+    await view.rerender({
+      projects: projects.map((project) =>
+        project.uid === "project-roadmap" ? { ...project, name: "Roadmap 2027" } : project,
+      ),
+    });
+    expect(screen.getByRole("button", { name: /Roadmap 2027/ })).toBeTruthy();
+
+    await fireEvent.click(screen.getByRole("button", { name: /Roadmap 2027/ }));
+    await view.rerender({
+      projects: projects.filter((project) => project.uid !== "project-roadmap"),
+    });
+    expect((screen.getByRole("button", { name: /Roadmap 2027/ }) as HTMLButtonElement).disabled).toBe(true);
+
+    finishMove(false);
+    await pendingMove;
+    await view.rerender({ projects: projects.filter((project) => project.uid !== "project-roadmap") });
+    expect(screen.queryByRole("button", { name: /Roadmap 2027/ })).toBeNull();
+  });
+
+  it("dismisses an empty move picker with Escape and restores trigger focus", async () => {
+    const onMoveIssue = vi.fn(async () => true);
+    renderMenu({ onMoveIssue });
+
+    const trigger = screen.getByRole("button", { name: "More actions" });
+    trigger.focus();
+    await fireEvent.click(trigger);
+    await fireEvent.click(screen.getByRole("menuitem", { name: "Move to another project" }));
+
+    const search = screen.getByRole("searchbox", { name: "Find project" });
+    await waitFor(() => expect(search).toBe(document.activeElement));
+    await fireEvent.keyDown(search, { key: "Escape" });
+
+    expect(onMoveIssue).not.toHaveBeenCalled();
+    expect(screen.queryByRole("dialog", { name: "Move to another project" })).toBeNull();
+    await waitFor(() => expect(trigger).toBe(document.activeElement));
+  });
+
+  it("clears a move search before Escape dismisses the picker", async () => {
+    renderMenu();
+    await openMovePicker();
+
+    const search = screen.getByRole("searchbox", { name: "Find project" });
+    await fireEvent.input(search, { target: { value: "road" } });
+    await fireEvent.keyDown(search, { key: "Escape" });
+
+    expect((search as HTMLInputElement).value).toBe("");
+    expect(screen.getByRole("dialog", { name: "Move to another project" })).toBeTruthy();
+
+    await fireEvent.keyDown(search, { key: "Escape" });
+    expect(screen.queryByRole("dialog", { name: "Move to another project" })).toBeNull();
   });
 
   it("does not dismiss while a move is pending", async () => {

--- a/frontend/src/lib/components/kata/KataIssueOverflowMenu.test.ts
+++ b/frontend/src/lib/components/kata/KataIssueOverflowMenu.test.ts
@@ -1,17 +1,21 @@
 import { cleanup, fireEvent, render, screen, within } from "@testing-library/svelte";
+import type { ComponentProps } from "svelte";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
-import type { KataTaskDetail } from "../../api/kata/taskTypes.js";
+import type { KataProjectSummary, KataTaskDetail } from "../../api/kata/taskTypes.js";
 
 import KataIssueOverflowMenu from "./KataIssueOverflowMenu.svelte";
 
-function makeIssue(status: "open" | "closed" = "open"): KataTaskDetail {
+function makeIssue(
+  status: "open" | "closed" = "open",
+  overrides: Partial<KataTaskDetail["issue"]> = {},
+): KataTaskDetail {
   return {
     issue: {
       id: 1,
       uid: "issue-1",
-      project_id: 1,
-      project_uid: "project-1",
-      project_name: "Inbox",
+      project_id: 2,
+      project_uid: "project-alpha",
+      project_name: "Alpha",
       short_id: "I-1",
       qualified_id: "INBOX-1",
       title: "Ship the thing",
@@ -22,11 +26,61 @@ function makeIssue(status: "open" | "closed" = "open"): KataTaskDetail {
       author: "wes",
       created_at: "2026-06-01T12:00:00Z",
       updated_at: "2026-06-01T12:00:00Z",
+      ...overrides,
     },
     comments: [],
     labels: [],
     links: [],
   };
+}
+
+function makeProject(
+  uid: string,
+  name: string,
+  openCount: number,
+  metadata: KataProjectSummary["metadata"] = {},
+): KataProjectSummary {
+  return {
+    id: uid === "project-alpha" ? 2 : uid.length,
+    uid,
+    name,
+    metadata,
+    open_count: openCount,
+    revision: 1,
+    created_at: "2026-06-01T12:00:00Z",
+  };
+}
+
+const projects = [
+  makeProject("project-inbox", "Inbox", 2, { role: "inbox" }),
+  makeProject("project-alpha", "Alpha", 3),
+  makeProject("project-roadmap", "Roadmap", 5),
+  makeProject("project-shared-work", "Shared", 2, { area: "Work" }),
+  makeProject("project-shared-home", "Shared", 4, { area: "Home" }),
+  makeProject("project-shared-home-2", "Shared", 1, { area: "Home" }),
+];
+
+type MenuProps = ComponentProps<typeof KataIssueOverflowMenu>;
+
+function renderMenu(overrides: Partial<MenuProps> = {}) {
+  return render(KataIssueOverflowMenu, {
+    props: {
+      issue: makeIssue(),
+      projects,
+      hasChecklist: false,
+      hasRecurrence: false,
+      onMoveIssue: vi.fn(async () => true),
+      onAddChecklist: vi.fn(),
+      onCreateRecurrence: vi.fn(),
+      onDeleteIssue: vi.fn(async () => true),
+      ...overrides,
+    },
+  });
+}
+
+async function openMovePicker(): Promise<void> {
+  await fireEvent.click(screen.getByRole("button", { name: "More actions" }));
+  await fireEvent.click(screen.getByRole("menuitem", { name: "Move to another project" }));
 }
 
 describe("KataIssueOverflowMenu", () => {
@@ -37,17 +91,7 @@ describe("KataIssueOverflowMenu", () => {
   it("routes menu actions to their callbacks", async () => {
     const onAddChecklist = vi.fn();
     const onCreateRecurrence = vi.fn();
-
-    render(KataIssueOverflowMenu, {
-      props: {
-        issue: makeIssue(),
-        hasChecklist: false,
-        hasRecurrence: false,
-        onAddChecklist,
-        onCreateRecurrence,
-        onDeleteIssue: vi.fn(async () => true),
-      },
-    });
+    renderMenu({ onAddChecklist, onCreateRecurrence });
 
     await fireEvent.click(screen.getByRole("button", { name: "More actions" }));
     await fireEvent.click(screen.getByRole("menuitem", { name: "Add checklist" }));
@@ -58,18 +102,113 @@ describe("KataIssueOverflowMenu", () => {
     expect(onCreateRecurrence).toHaveBeenCalledTimes(1);
   });
 
+  it("hides move when only the current and inbox projects exist", async () => {
+    renderMenu({
+      projects: [makeProject("project-alpha", "Alpha", 1), makeProject("project-inbox", "Inbox", 2, { role: "inbox" })],
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: "More actions" }));
+    expect(screen.queryByRole("menuitem", { name: "Move to another project" })).toBeNull();
+  });
+
+  it("shows sorted eligible destinations with unambiguous duplicate context", async () => {
+    renderMenu({ projects: [...projects].reverse() });
+    await openMovePicker();
+
+    const destinations = within(screen.getByLabelText("Project destinations")).getAllByRole("button");
+    expect(destinations.slice(0, 2).map((button) => button.textContent?.replaceAll(/\s/g, ""))).toEqual([
+      "Roadmap5",
+      "Sharedproject-shared-home4",
+    ]);
+    expect(screen.getByRole("button", { name: /Shared.*project-shared-home-2.*1/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Shared.*Work.*2/ })).toBeTruthy();
+    expect(screen.queryByText("Inbox")).toBeNull();
+  });
+
+  it("filters destinations and closes after a successful move", async () => {
+    const onMoveIssue = vi.fn(async () => true);
+    renderMenu({ onMoveIssue });
+
+    await openMovePicker();
+    await fireEvent.input(screen.getByRole("searchbox", { name: "Find project" }), {
+      target: { value: "road" },
+    });
+    expect(screen.queryByRole("button", { name: /Shared/ })).toBeNull();
+    await fireEvent.click(screen.getByRole("button", { name: /Roadmap/ }));
+
+    expect(onMoveIssue).toHaveBeenCalledWith("project-roadmap");
+    expect(screen.queryByRole("searchbox", { name: "Find project" })).toBeNull();
+    expect(screen.queryByRole("menu", { name: "Task actions" })).toBeNull();
+  });
+
+  it("keeps the picker open when the workspace reports move failure", async () => {
+    const onMoveIssue = vi.fn(async () => false);
+    renderMenu({ onMoveIssue });
+    await openMovePicker();
+    await fireEvent.click(screen.getByRole("button", { name: /Roadmap/ }));
+
+    expect(onMoveIssue).toHaveBeenCalledWith("project-roadmap");
+    expect(screen.getByRole("searchbox", { name: "Find project" })).toBeTruthy();
+  });
+
+  it("resets the destination view when the selected issue changes", async () => {
+    const view = renderMenu();
+    await openMovePicker();
+    await fireEvent.input(screen.getByRole("searchbox", { name: "Find project" }), {
+      target: { value: "road" },
+    });
+
+    await view.rerender({ issue: makeIssue("open", { uid: "issue-2" }) });
+    expect(screen.queryByRole("searchbox", { name: "Find project" })).toBeNull();
+    expect(screen.getByRole("button", { name: "More actions" }).getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("ignores an old A move after navigating A to B to A", async () => {
+    let finishOldMove!: (moved: boolean) => void;
+    const oldMove = new Promise<boolean>((resolve) => {
+      finishOldMove = resolve;
+    });
+    const onMoveIssue = vi.fn(() => oldMove);
+    const view = renderMenu({ onMoveIssue });
+
+    await openMovePicker();
+    await fireEvent.click(screen.getByRole("button", { name: /Roadmap/ }));
+    await view.rerender({ issue: makeIssue("open", { uid: "issue-b" }) });
+    await view.rerender({ issue: makeIssue("open", { uid: "issue-1" }) });
+    await openMovePicker();
+
+    finishOldMove(true);
+    await oldMove;
+    expect(screen.getByRole("searchbox", { name: "Find project" })).toBeTruthy();
+  });
+
+  it("does not dismiss while a move is pending", async () => {
+    let finishMove!: (moved: boolean) => void;
+    const pendingMove = new Promise<boolean>((resolve) => {
+      finishMove = resolve;
+    });
+    const onMoveIssue = vi.fn(() => pendingMove);
+    renderMenu({ onMoveIssue });
+
+    await openMovePicker();
+    await fireEvent.click(screen.getByRole("button", { name: /Roadmap/ }));
+    await fireEvent.keyDown(screen.getByRole("dialog", { name: "Move to another project" }), { key: "Escape" });
+    await fireEvent.pointerDown(document.body);
+
+    expect(screen.getByRole("searchbox", { name: "Find project" })).toBeTruthy();
+    expect((screen.getByRole("button", { name: /Roadmap/ }) as HTMLButtonElement).disabled).toBe(true);
+    expect(onMoveIssue).toHaveBeenCalledTimes(1);
+    finishMove(false);
+    await pendingMove;
+  });
+
   it("confirms delete through the menu", async () => {
     const onDeleteIssue = vi.fn(async () => true);
-
-    render(KataIssueOverflowMenu, {
-      props: {
-        issue: makeIssue(),
-        hasChecklist: true,
-        hasRecurrence: true,
-        onAddChecklist: vi.fn(),
-        onCreateRecurrence: vi.fn(),
-        onDeleteIssue,
-      },
+    renderMenu({
+      projects: [],
+      hasChecklist: true,
+      hasRecurrence: true,
+      onDeleteIssue,
     });
 
     await fireEvent.click(screen.getByRole("button", { name: "More actions" }));
@@ -82,15 +221,11 @@ describe("KataIssueOverflowMenu", () => {
   });
 
   it("hides the trigger when no actions are available", () => {
-    render(KataIssueOverflowMenu, {
-      props: {
-        issue: makeIssue("closed"),
-        hasChecklist: true,
-        hasRecurrence: true,
-        onAddChecklist: vi.fn(),
-        onCreateRecurrence: vi.fn(),
-        onDeleteIssue: vi.fn(async () => true),
-      },
+    renderMenu({
+      issue: makeIssue("closed"),
+      projects: [],
+      hasChecklist: true,
+      hasRecurrence: true,
     });
 
     expect(screen.queryByRole("button", { name: "More actions" })).toBeNull();

--- a/frontend/src/lib/components/kata/KataSidebar.svelte
+++ b/frontend/src/lib/components/kata/KataSidebar.svelte
@@ -4,7 +4,6 @@
   import CheckCircleIcon from "@lucide/svelte/icons/check-circle-2";
   import InboxIcon from "@lucide/svelte/icons/inbox";
   import LayersIcon from "@lucide/svelte/icons/layers";
-  import PencilIcon from "@lucide/svelte/icons/pencil";
   import PlusIcon from "@lucide/svelte/icons/plus";
   import StarIcon from "@lucide/svelte/icons/star";
   import { GroupedSidebarSection, SidebarScrollArea } from "@middleman/ui";
@@ -20,7 +19,6 @@
     onOpenView: (name: KataTaskViewName) => void | Promise<void>;
     onOpenProject: (projectUID: string) => void | Promise<void>;
     onCreateProject: (name: string) => Promise<KataProjectSummary>;
-    onRenameProject: (id: number, name: string) => Promise<void>;
   }
 
   let {
@@ -31,7 +29,6 @@
     onOpenView,
     onOpenProject,
     onCreateProject,
-    onRenameProject,
   }: Props = $props();
 
   const systemViews: Array<{
@@ -51,12 +48,7 @@
   let createDraft = $state("");
   let createSaving = $state(false);
   let createError = $state<string | null>(null);
-  let renamingProjectID = $state<number | null>(null);
-  let renameDraft = $state("");
-  let renameSaving = $state(false);
-  let renameError = $state<string | null>(null);
   let createInput: HTMLInputElement | null = $state(null);
-  let renameInput: HTMLInputElement | null = $state(null);
   let collapsedAreas = $state<string[]>([]);
 
   function toggleArea(name: string): void {
@@ -107,42 +99,9 @@
       createSaving = false;
     }
   }
-
-  function startRenamingProject(project: KataProjectSummary): void {
-    renamingProjectID = project.id;
-    renameDraft = project.name;
-    renameError = null;
-    queueMicrotask(() => renameInput?.focus());
-  }
-
-  function cancelRenamingProject(): void {
-    renamingProjectID = null;
-    renameDraft = "";
-    renameError = null;
-  }
-
-  async function submitRenameProject(): Promise<void> {
-    if (renamingProjectID === null || renameSaving) return;
-    const name = renameDraft.trim();
-    if (!name) {
-      renameError = "Project name can't be empty.";
-      return;
-    }
-    renameSaving = true;
-    renameError = null;
-    try {
-      await onRenameProject(renamingProjectID, name);
-      renamingProjectID = null;
-      renameDraft = "";
-    } catch (err) {
-      renameError = err instanceof Error ? err.message : "Could not rename project.";
-    } finally {
-      renameSaving = false;
-    }
-  }
 </script>
 
-<aside class="kata-sidebar">
+<aside class="kata-sidebar" aria-label="Kata navigation">
   <SidebarScrollArea label="Kata navigation">
     <nav class="kata-nav" aria-label="System views">
     {#each systemViews as view (view.name)}
@@ -173,62 +132,15 @@
         onclick={() => toggleArea(area.name)}
       >
         {#each area.projects as project (project.uid)}
-            {#if renamingProjectID === project.id}
-              <form
-                class="project-rename-form"
-                onsubmit={(event) => {
-                  event.preventDefault();
-                  void submitRenameProject();
-                }}
-              >
-                <input
-                  bind:this={renameInput}
-                  aria-label="Rename project"
-                  bind:value={renameDraft}
-                  onkeydown={(event) => {
-                    if (event.key === "Enter") {
-                      event.preventDefault();
-                      void submitRenameProject();
-                    } else if (event.key === "Escape") {
-                      event.preventDefault();
-                      cancelRenamingProject();
-                    }
-                  }}
-                  onblur={() => {
-                    if (!renameSaving) cancelRenamingProject();
-                  }}
-                  disabled={renameSaving}
-                />
-              </form>
-              {#if renameError}
-                <p class="sidebar-error" role="alert">{renameError}</p>
-              {/if}
-            {:else}
-              <div class:active={isProjectActive(project.uid)} class="project-row">
-                <button
-                  type="button"
-                  class="project-select-button"
-                  onclick={() => {
-                    void onOpenProject(project.uid);
-                  }}
-                  ondblclick={(event) => {
-                    event.preventDefault();
-                    startRenamingProject(project);
-                  }}
-                >
-                  <span class="project-name">{project.name}</span>
-                  <span class="project-count count">{project.open_count}</span>
-                </button>
-                <button
-                  type="button"
-                  class="project-rename-button"
-                  aria-label={`Rename ${project.name}`}
-                  onclick={() => startRenamingProject(project)}
-                >
-                  <PencilIcon size={13} strokeWidth={1.8} aria-hidden="true" />
-                </button>
-              </div>
-            {/if}
+          <button
+            type="button"
+            class="project-select-button"
+            class:active={isProjectActive(project.uid)}
+            onclick={() => void onOpenProject(project.uid)}
+          >
+            <span class="project-name">{project.name}</span>
+            <span class="project-count count">{project.open_count}</span>
+          </button>
         {/each}
       </GroupedSidebarSection>
     {/each}
@@ -314,14 +226,14 @@
   }
 
   .kata-nav button:hover,
-  .project-row:hover,
+  .project-select-button:hover,
   .project-create-button:hover {
     background: var(--sidebar-row-hover-bg);
     color: var(--text-primary);
   }
 
   .kata-nav button.active,
-  .project-row.active {
+  .project-select-button.active {
     background: var(--bg-row-selected);
     color: var(--text-primary);
   }
@@ -337,13 +249,13 @@
     color: var(--accent-blue);
   }
 
-  .project-row.active .project-count,
+  .project-select-button.active .project-count,
   .kata-nav button.active .nav-count {
     color: var(--text-primary);
   }
 
   .kata-nav button.active .nav-label,
-  .project-row.active .project-name {
+  .project-select-button.active .project-name {
     font-weight: 650;
   }
 
@@ -366,35 +278,11 @@
     padding: 12px;
   }
 
-  .project-row {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) 26px;
-    align-items: center;
-    border-radius: 6px;
-  }
-
   .project-select-button {
     grid-template-columns: minmax(0, 1fr) auto;
   }
 
-  .project-rename-button {
-    width: 24px;
-    height: 24px;
-    border: 0;
-    border-radius: 5px;
-    background: transparent;
-    color: var(--text-muted);
-    opacity: 0;
-    cursor: pointer;
-  }
-
-  .project-row:hover .project-rename-button,
-  .project-rename-button:focus-visible {
-    opacity: 1;
-  }
-
-  .project-create-form input,
-  .project-rename-form input {
+  .project-create-form input {
     width: 100%;
     min-height: 30px;
     border: 1px solid var(--border-default);
@@ -406,8 +294,7 @@
     padding: 5px 8px;
   }
 
-  .project-create-form input:focus,
-  .project-rename-form input:focus {
+  .project-create-form input:focus {
     outline: none;
     border-color: var(--accent-blue);
     box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-blue) 18%, transparent);

--- a/frontend/src/lib/components/kata/KataSidebar.svelte
+++ b/frontend/src/lib/components/kata/KataSidebar.svelte
@@ -6,7 +6,7 @@
   import LayersIcon from "@lucide/svelte/icons/layers";
   import PlusIcon from "@lucide/svelte/icons/plus";
   import StarIcon from "@lucide/svelte/icons/star";
-  import { GroupedSidebarSection, SidebarScrollArea } from "@middleman/ui";
+  import { GroupedSidebarSection, ScrollBox } from "@middleman/ui";
 
   import type { KataProjectSummary, KataTaskSearchFilters, KataTaskViewName } from "../../api/kata/taskTypes.js";
   import type { KataAreaSummary, KataCurrentView } from "../../stores/kata-workspace.svelte.js";
@@ -102,7 +102,7 @@
 </script>
 
 <aside class="kata-sidebar" aria-label="Kata navigation">
-  <SidebarScrollArea label="Kata navigation">
+  <ScrollBox label="Kata navigation">
     <nav class="kata-nav" aria-label="System views">
     {#each systemViews as view (view.name)}
       {@const Icon = view.icon}
@@ -181,7 +181,7 @@
       </button>
       {/if}
     </div>
-  </SidebarScrollArea>
+  </ScrollBox>
 </aside>
 
 <style>

--- a/frontend/src/lib/components/kata/KataSidebar.svelte
+++ b/frontend/src/lib/components/kata/KataSidebar.svelte
@@ -7,6 +7,7 @@
   import PencilIcon from "@lucide/svelte/icons/pencil";
   import PlusIcon from "@lucide/svelte/icons/plus";
   import StarIcon from "@lucide/svelte/icons/star";
+  import { GroupedSidebarSection, SidebarScrollArea } from "@middleman/ui";
 
   import type { KataProjectSummary, KataTaskSearchFilters, KataTaskViewName } from "../../api/kata/taskTypes.js";
   import type { KataAreaSummary, KataCurrentView } from "../../stores/kata-workspace.svelte.js";
@@ -56,6 +57,13 @@
   let renameError = $state<string | null>(null);
   let createInput: HTMLInputElement | null = $state(null);
   let renameInput: HTMLInputElement | null = $state(null);
+  let collapsedAreas = $state<string[]>([]);
+
+  function toggleArea(name: string): void {
+    collapsedAreas = collapsedAreas.includes(name)
+      ? collapsedAreas.filter((area) => area !== name)
+      : [...collapsedAreas, name];
+  }
 
   function viewCount(name: KataTaskViewName): number | undefined {
     const inboxProject = projects.find((project) => project.metadata.role === "inbox");
@@ -134,8 +142,9 @@
   }
 </script>
 
-<aside class="kata-sidebar" aria-label="Kata navigation">
-  <nav class="kata-nav" aria-label="System views">
+<aside class="kata-sidebar">
+  <SidebarScrollArea label="Kata navigation">
+    <nav class="kata-nav" aria-label="System views">
     {#each systemViews as view (view.name)}
       {@const Icon = view.icon}
       {@const count = viewCount(view.name)}
@@ -156,12 +165,14 @@
     {/each}
   </nav>
 
-  {#if areas.length > 0}
-    <div class="project-groups">
-      {#each areas as area (area.name)}
-        <section class="project-group" aria-labelledby={`kata-area-${area.name}`}>
-          <h2 id={`kata-area-${area.name}`}>{area.name}</h2>
-          {#each area.projects as project (project.uid)}
+    {#each areas as area (area.name)}
+      <GroupedSidebarSection
+        label={area.name}
+        count={area.projects.length}
+        collapsed={collapsedAreas.includes(area.name)}
+        onclick={() => toggleArea(area.name)}
+      >
+        {#each area.projects as project (project.uid)}
             {#if renamingProjectID === project.id}
               <form
                 class="project-rename-form"
@@ -218,13 +229,11 @@
                 </button>
               </div>
             {/if}
-          {/each}
-        </section>
-      {/each}
-    </div>
-  {/if}
+        {/each}
+      </GroupedSidebarSection>
+    {/each}
 
-  <div class="project-create">
+    <div class="project-create">
     {#if creatingProject}
       <form
         class="project-create-form"
@@ -258,23 +267,30 @@
         <PlusIcon size={13} strokeWidth={1.9} />
         <span>New project</span>
       </button>
-    {/if}
-  </div>
+      {/if}
+    </div>
+  </SidebarScrollArea>
 </aside>
 
 <style>
   .kata-sidebar {
+    --sidebar-list-border: var(--border-default);
+    --sidebar-row-bg: transparent;
+    --sidebar-row-hover-bg: var(--bg-surface-hover);
+    --sidebar-row-padding: 6px 10px;
+
+    display: flex;
+    flex-direction: column;
     min-width: 0;
+    min-height: 0;
     border-right: 1px solid var(--border-default);
-    background: var(--bg-secondary);
-    overflow: auto;
-    padding: 12px;
+    background: var(--bg-inset);
   }
 
-  .kata-nav,
-  .project-group {
+  .kata-nav {
     display: grid;
     gap: 4px;
+    padding: 12px;
   }
 
   .kata-nav button,
@@ -284,13 +300,13 @@
     min-height: 30px;
     border: 0;
     border-radius: 6px;
-    background: transparent;
+    background: var(--sidebar-row-bg);
     color: var(--text-secondary);
     display: grid;
     grid-template-columns: 18px minmax(0, 1fr) auto;
     align-items: center;
     gap: var(--space-3);
-    padding: 4px 8px;
+    padding: var(--sidebar-row-padding);
     text-align: left;
     font: inherit;
     font-size: var(--font-size-sm);
@@ -300,16 +316,13 @@
   .kata-nav button:hover,
   .project-row:hover,
   .project-create-button:hover {
-    background: var(--bg-hover);
+    background: var(--sidebar-row-hover-bg);
     color: var(--text-primary);
   }
 
   .kata-nav button.active,
   .project-row.active {
-    background: color-mix(in srgb, var(--accent-blue) 28%, var(--bg-secondary));
-    box-shadow:
-      inset 3px 0 0 var(--accent-blue),
-      inset 0 0 0 1px color-mix(in srgb, var(--accent-blue) 42%, transparent);
+    background: var(--bg-row-selected);
     color: var(--text-primary);
   }
 
@@ -349,22 +362,8 @@
     font-variant-numeric: tabular-nums;
   }
 
-  .project-groups {
-    display: grid;
-    gap: var(--space-6);
-    margin-top: 22px;
-  }
-
   .project-create {
-    margin-top: 16px;
-  }
-
-  .project-group h2 {
-    margin: 0 4px 6px;
-    color: var(--text-muted);
-    font-size: var(--font-size-xs);
-    font-weight: 650;
-    text-transform: uppercase;
+    padding: 12px;
   }
 
   .project-row {

--- a/frontend/src/lib/components/kata/KataSidebar.test.ts
+++ b/frontend/src/lib/components/kata/KataSidebar.test.ts
@@ -43,7 +43,6 @@ function renderSidebar(overrides: Partial<SidebarProps> = {}) {
       onOpenView: vi.fn(),
       onOpenProject: vi.fn(),
       onCreateProject: vi.fn(),
-      onRenameProject: vi.fn(),
       ...overrides,
     },
   });
@@ -101,16 +100,22 @@ describe("KataSidebar", () => {
     expect(onOpenProject).toHaveBeenCalledWith("project-finances");
   });
 
-  it("double-clicking a project enters rename mode", async () => {
+  it("keeps project rows navigation-only without rename affordances", async () => {
     const onOpenProject = vi.fn();
+    renderSidebar({
+      onOpenProject,
+      searchFilters: { ...allScopeFilters, scope: { kind: "project", project_uid: "project-finances" } },
+    });
 
-    renderSidebar({ onOpenProject });
+    const finances = screen.getByRole("button", { name: /^Finances\b/ });
+    expect(finances.classList.contains("active")).toBe(true);
+    expect(screen.queryByRole("button", { name: "Rename Finances" })).toBeNull();
+    expect(screen.queryByRole("textbox", { name: "Rename project" })).toBeNull();
 
-    await fireEvent.doubleClick(screen.getByRole("button", { name: /^Finances\b/ }));
-
-    const input = screen.getByRole("textbox", { name: "Rename project" });
-    expect(input).toBeTruthy();
-    await waitFor(() => expect(input).toBe(document.activeElement));
+    await fireEvent.click(finances);
+    await fireEvent.doubleClick(finances);
+    expect(screen.queryByRole("textbox", { name: "Rename project" })).toBeNull();
+    expect(onOpenProject).toHaveBeenCalledWith("project-finances");
   });
 
   it("creates a project and opens the created scope", async () => {
@@ -129,25 +134,6 @@ describe("KataSidebar", () => {
     await waitFor(() => {
       expect(onCreateProject).toHaveBeenCalledWith("New Project");
       expect(onOpenProject).toHaveBeenCalledWith("project-new");
-    });
-  });
-
-  it("renames a project from the project row", async () => {
-    const onRenameProject = vi.fn(async () => {});
-
-    renderSidebar({
-      searchFilters: { ...allScopeFilters, scope: { kind: "project", project_uid: "project-finances" } },
-      onRenameProject,
-    });
-
-    await fireEvent.click(screen.getByRole("button", { name: "Rename Finances" }));
-
-    const input = screen.getByRole("textbox", { name: "Rename project" });
-    await fireEvent.input(input, { target: { value: "Household" } });
-    await fireEvent.submit(input.closest("form")!);
-
-    await waitFor(() => {
-      expect(onRenameProject).toHaveBeenCalledWith(2, "Household");
     });
   });
 });

--- a/frontend/src/lib/components/kata/KataSidebar.test.ts
+++ b/frontend/src/lib/components/kata/KataSidebar.test.ts
@@ -1,4 +1,5 @@
 import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/svelte";
+import type { ComponentProps } from "svelte";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import type { KataProjectSummary, KataTaskSearchFilters } from "../../api/kata/taskTypes.js";
@@ -30,28 +31,68 @@ const allScopeFilters: KataTaskSearchFilters = {
   query: "",
 };
 
+type SidebarProps = ComponentProps<typeof KataSidebar>;
+
+function renderSidebar(overrides: Partial<SidebarProps> = {}) {
+  return render(KataSidebar, {
+    props: {
+      areas,
+      projects,
+      currentView,
+      searchFilters: allScopeFilters,
+      onOpenView: vi.fn(),
+      onOpenProject: vi.fn(),
+      onCreateProject: vi.fn(),
+      onRenameProject: vi.fn(),
+      ...overrides,
+    },
+  });
+}
+
 describe("KataSidebar", () => {
   afterEach(() => {
     cleanup();
     vi.restoreAllMocks();
   });
 
+  it("renders system views, expanded area groups, and project creation in order", () => {
+    renderSidebar();
+
+    const navigation = screen.getByRole("region", { name: "Kata navigation" });
+    const inbox = within(navigation).getByRole("button", { name: /^Inbox\b/ });
+    const personal = within(navigation).getByRole("button", { name: /^Personal\s+1$/ });
+    const work = within(navigation).getByRole("button", { name: /^Work\s+1$/ });
+    const create = within(navigation).getByRole("button", { name: "New project" });
+
+    expect(personal.getAttribute("aria-expanded")).toBe("true");
+    expect(work.getAttribute("aria-expanded")).toBe("true");
+    const ordered = [inbox, personal, work, create];
+    for (let index = 0; index < ordered.length - 1; index += 1) {
+      expect(ordered[index]!.compareDocumentPosition(ordered[index + 1]!)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    }
+  });
+
+  it("keeps area collapse state while mounted and resets it after remount", async () => {
+    const view = renderSidebar();
+    const personal = screen.getByRole("button", { name: /^Personal\s+1$/ });
+
+    await fireEvent.click(personal);
+    expect(personal.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByRole("button", { name: /^Finances\b/ })).toBeNull();
+
+    await view.rerender({ areas: [...areas] });
+    expect(screen.getByRole("button", { name: /^Personal\s+1$/ }).getAttribute("aria-expanded")).toBe("false");
+
+    view.unmount();
+    renderSidebar();
+    expect(screen.getByRole("button", { name: /^Personal\s+1$/ }).getAttribute("aria-expanded")).toBe("true");
+  });
+
   it("opens system views and project scopes from the restored sidebar", async () => {
     const onOpenView = vi.fn();
     const onOpenProject = vi.fn();
 
-    render(KataSidebar, {
-      props: {
-        areas,
-        projects,
-        currentView,
-        searchFilters: allScopeFilters,
-        onOpenView,
-        onOpenProject,
-        onCreateProject: vi.fn(),
-        onRenameProject: vi.fn(),
-      },
-    });
+    renderSidebar({ onOpenView, onOpenProject });
 
     await fireEvent.click(screen.getByRole("button", { name: /^Inbox\b/ }));
     expect(onOpenView).toHaveBeenCalledWith("inbox");
@@ -63,18 +104,7 @@ describe("KataSidebar", () => {
   it("double-clicking a project enters rename mode", async () => {
     const onOpenProject = vi.fn();
 
-    render(KataSidebar, {
-      props: {
-        areas,
-        projects,
-        currentView,
-        searchFilters: allScopeFilters,
-        onOpenView: vi.fn(),
-        onOpenProject,
-        onCreateProject: vi.fn(),
-        onRenameProject: vi.fn(),
-      },
-    });
+    renderSidebar({ onOpenProject });
 
     await fireEvent.doubleClick(screen.getByRole("button", { name: /^Finances\b/ }));
 
@@ -88,18 +118,7 @@ describe("KataSidebar", () => {
     const onCreateProject = vi.fn(async () => created);
     const onOpenProject = vi.fn();
 
-    render(KataSidebar, {
-      props: {
-        areas,
-        projects,
-        currentView,
-        searchFilters: allScopeFilters,
-        onOpenView: vi.fn(),
-        onOpenProject,
-        onCreateProject,
-        onRenameProject: vi.fn(),
-      },
-    });
+    renderSidebar({ onCreateProject, onOpenProject });
 
     await fireEvent.click(screen.getByRole("button", { name: "New project" }));
     const input = screen.getByRole("textbox", { name: "New project name" });
@@ -116,21 +135,12 @@ describe("KataSidebar", () => {
   it("renames a project from the project row", async () => {
     const onRenameProject = vi.fn(async () => {});
 
-    render(KataSidebar, {
-      props: {
-        areas,
-        projects,
-        currentView,
-        searchFilters: { ...allScopeFilters, scope: { kind: "project", project_uid: "project-finances" } },
-        onOpenView: vi.fn(),
-        onOpenProject: vi.fn(),
-        onCreateProject: vi.fn(),
-        onRenameProject,
-      },
+    renderSidebar({
+      searchFilters: { ...allScopeFilters, scope: { kind: "project", project_uid: "project-finances" } },
+      onRenameProject,
     });
 
-    const personal = screen.getByRole("region", { name: "Personal" });
-    await fireEvent.click(within(personal).getByRole("button", { name: "Rename Finances" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Rename Finances" }));
 
     const input = screen.getByRole("textbox", { name: "Rename project" });
     await fireEvent.input(input, { target: { value: "Household" } });

--- a/frontend/src/lib/components/terminal/KataWorkspaceSidebarPane.svelte
+++ b/frontend/src/lib/components/terminal/KataWorkspaceSidebarPane.svelte
@@ -90,10 +90,10 @@
     }
   }
 
-  async function moveSelectedIssue(toProjectUID: string | null): Promise<void> {
+  async function moveSelectedIssue(toProjectUID: string): Promise<boolean> {
     const selected = store.selectedIssue?.issue;
-    if (!selected || !toProjectUID) return;
-    await runTask(() => store.moveIssue(selected.uid, actor, toProjectUID));
+    if (!selected) return false;
+    return runTask(() => store.moveIssue(selected.uid, actor, toProjectUID));
   }
 
   function patchSelectedMetadata(uid: string, patch: Record<string, unknown>): Promise<boolean> {

--- a/frontend/src/lib/components/terminal/KataWorkspaceSidebarPane.svelte
+++ b/frontend/src/lib/components/terminal/KataWorkspaceSidebarPane.svelte
@@ -28,6 +28,7 @@
   let loading = $state(true);
   let error = $state<string | null>(null);
   let checklistRevealed = $state(false);
+  let pendingMoveIssueUIDs = $state.raw<ReadonlySet<string>>(new Set());
   let unlinkBusyIds = $state<ReadonlySet<number>>(new Set());
   let unlinkError = $state<string | null>(null);
   let loadRequestID = 0;
@@ -99,12 +100,20 @@
 
   async function moveSelectedIssue(toProjectUID: string): Promise<boolean> {
     const selected = store.selectedIssue?.issue;
-    if (!selected) return false;
+    if (!selected || pendingMoveIssueUIDs.has(selected.uid)) return false;
+    const sourceIssueUID = selected.uid;
     const generation = issueContextGeneration;
-    return runTask(
-      () => store.moveIssue(selected.uid, actor, toProjectUID),
-      () => generation === issueContextGeneration,
-    );
+    pendingMoveIssueUIDs = new Set(pendingMoveIssueUIDs).add(sourceIssueUID);
+    try {
+      return await runTask(
+        () => store.moveIssue(sourceIssueUID, actor, toProjectUID),
+        () => generation === issueContextGeneration,
+      );
+    } finally {
+      const nextPendingMoves = new Set(pendingMoveIssueUIDs);
+      nextPendingMoves.delete(sourceIssueUID);
+      pendingMoveIssueUIDs = nextPendingMoves;
+    }
   }
 
   function patchSelectedMetadata(uid: string, patch: Record<string, unknown>): Promise<boolean> {
@@ -226,6 +235,7 @@
       {unlinkError}
       selectedRecurrences={store.selectedRecurrences}
       {checklistRevealed}
+      movePending={pendingMoveIssueUIDs.has(store.selectedIssue.issue.uid)}
       onMoveIssue={moveSelectedIssue}
       onPatchMetadata={patchSelectedMetadata}
       onAddComment={addSelectedComment}

--- a/frontend/src/lib/components/terminal/KataWorkspaceSidebarPane.svelte
+++ b/frontend/src/lib/components/terminal/KataWorkspaceSidebarPane.svelte
@@ -31,6 +31,7 @@
   let unlinkBusyIds = $state<ReadonlySet<number>>(new Set());
   let unlinkError = $state<string | null>(null);
   let loadRequestID = 0;
+  let issueContextGeneration = 0;
   let recurrenceDialogs = $state<{
     openCreateRecurrence: () => void;
     openEditRecurrence: (recurrence: KataRecurrence) => void;
@@ -40,6 +41,7 @@
 
   $effect(() => {
     const issueUID = kata.issue_uid;
+    issueContextGeneration += 1;
     const requestID = ++loadRequestID;
     loading = true;
     error = null;
@@ -70,12 +72,17 @@
     return store.selectedIssue ? readMessageLinks(store.selectedIssue.issue.metadata) : [];
   }
 
-  async function runTask(task: () => Promise<void | boolean>): Promise<boolean> {
+  async function runTask(
+    task: () => Promise<void | boolean>,
+    shouldSurfaceFailure: () => boolean = () => true,
+  ): Promise<boolean> {
     error = null;
     try {
       return (await task()) ?? true;
     } catch (err) {
-      error = err instanceof Error ? err.message : "Kata request failed.";
+      if (shouldSurfaceFailure()) {
+        error = err instanceof Error ? err.message : "Kata request failed.";
+      }
       return false;
     }
   }
@@ -93,7 +100,11 @@
   async function moveSelectedIssue(toProjectUID: string): Promise<boolean> {
     const selected = store.selectedIssue?.issue;
     if (!selected) return false;
-    return runTask(() => store.moveIssue(selected.uid, actor, toProjectUID));
+    const generation = issueContextGeneration;
+    return runTask(
+      () => store.moveIssue(selected.uid, actor, toProjectUID),
+      () => generation === issueContextGeneration,
+    );
   }
 
   function patchSelectedMetadata(uid: string, patch: Record<string, unknown>): Promise<boolean> {
@@ -188,6 +199,7 @@
   }
 
   async function selectIssue(uid: string): Promise<void> {
+    issueContextGeneration += 1;
     await runTask(() => store.selectIssue(uid));
   }
 </script>

--- a/frontend/src/lib/components/terminal/KataWorkspaceSidebarPane.test.ts
+++ b/frontend/src/lib/components/terminal/KataWorkspaceSidebarPane.test.ts
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/svelte";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import type { KataProjectSummary, KataTaskDetail, KataTaskSummary } from "../../api/kata/taskTypes.js";
@@ -111,5 +111,8 @@ describe("KataWorkspaceSidebarPane", () => {
 
     await fireEvent.click(screen.getByRole("button", { name: /Roadmap/ }));
     expect(moveAttempts()).toBe(2);
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Move to another project" })).toBeNull();
+    });
   });
 });

--- a/frontend/src/lib/components/terminal/KataWorkspaceSidebarPane.test.ts
+++ b/frontend/src/lib/components/terminal/KataWorkspaceSidebarPane.test.ts
@@ -1,0 +1,115 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+import type { KataProjectSummary, KataTaskDetail, KataTaskSummary } from "../../api/kata/taskTypes.js";
+import type { KataWorkspaceMetadata } from "../../api/kata/workspaces.js";
+import KataWorkspaceSidebarPane from "./KataWorkspaceSidebarPane.svelte";
+
+const fetchedAt = "2026-06-01T12:00:00Z";
+
+function project(id: number, uid: string, name: string, role?: string): KataProjectSummary {
+  return { id, uid, name, metadata: role ? { role } : {}, open_count: 1 };
+}
+
+const projects = [project(1, "project-alpha", "Alpha"), project(2, "project-roadmap", "Roadmap")];
+
+function issue(): KataTaskSummary {
+  return {
+    id: 1,
+    uid: "issue-1",
+    project_id: 1,
+    project_uid: "project-alpha",
+    project_name: "Alpha",
+    short_id: "A-1",
+    qualified_id: "Alpha#A-1",
+    title: "Ship the thing",
+    body: "Body",
+    status: "open",
+    metadata: {},
+    revision: 1,
+    author: "fixture-user",
+    created_at: fetchedAt,
+    updated_at: fetchedAt,
+  };
+}
+
+function detail(): KataTaskDetail {
+  return { issue: { ...issue(), body: "Body" }, comments: [], labels: [], links: [], etag: '"rev-1"' };
+}
+
+function response(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function createFetchStub() {
+  let moveAttempts = 0;
+  const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
+    const url = new URL(
+      typeof input === "string" ? input : input instanceof URL ? input : input.url,
+      window.location.origin,
+    );
+    const path = `${url.pathname}${url.search}`;
+
+    if (path.endsWith("/api/v1/kata/proxy/api/v1/instance")) {
+      return response({ instance_uid: "instance-1", version: "dev", schema_version: 10 });
+    }
+    if (path.endsWith("/api/v1/kata/proxy/api/v1/projects?include=stats")) {
+      return response({ projects, fetched_at: fetchedAt });
+    }
+    if (path.endsWith("/api/v1/kata/proxy/api/v1/issues?status=open")) {
+      return response({ issues: [issue()], fetched_at: fetchedAt });
+    }
+    if (path.endsWith("/api/v1/kata/tasks/issue-1")) {
+      return response({ detail: detail(), etag: '"rev-1"' });
+    }
+    if (path.endsWith("/api/v1/kata/proxy/api/v1/events?limit=1000")) {
+      return response({ events: [], fetched_at: fetchedAt });
+    }
+    if (path.endsWith("/api/v1/kata/proxy/api/v1/projects/1/recurrences")) {
+      return response({ recurrences: [], fetched_at: fetchedAt });
+    }
+    if (path.endsWith("/api/v1/kata/proxy/api/v1/projects/1/issues/issue-1/actions/move") && init?.method === "POST") {
+      moveAttempts += 1;
+      if (moveAttempts === 1) {
+        return response({ error: { code: "move_failed", message: "Could not move task." } }, 409);
+      }
+      return response({ changed: true, issue: { ...issue(), project_id: 2, project_uid: "project-roadmap" } });
+    }
+
+    return response({ error: { code: "not_found", message: `Unhandled ${path}` } }, 404);
+  });
+  return { fetchImpl, moveAttempts: () => moveAttempts };
+}
+
+const kata: KataWorkspaceMetadata = {
+  daemon_id: "home",
+  issue_uid: "issue-1",
+  project_uid: "project-alpha",
+};
+
+describe("KataWorkspaceSidebarPane", () => {
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps a failed project move retryable through the embedded workspace", async () => {
+    const { fetchImpl, moveAttempts } = createFetchStub();
+    vi.stubGlobal("fetch", fetchImpl);
+    render(KataWorkspaceSidebarPane, { props: { kata } });
+
+    await screen.findByRole("heading", { name: "Ship the thing" });
+    await fireEvent.click(screen.getByRole("button", { name: "More actions" }));
+    await fireEvent.click(screen.getByRole("menuitem", { name: "Move to another project" }));
+    await fireEvent.click(screen.getByRole("button", { name: /Roadmap/ }));
+
+    expect((await screen.findByRole("alert")).textContent).toContain("Could not move task.");
+    expect(screen.getByRole("searchbox", { name: "Find project" })).toBeTruthy();
+
+    await fireEvent.click(screen.getByRole("button", { name: /Roadmap/ }));
+    expect(moveAttempts()).toBe(2);
+  });
+});

--- a/frontend/src/lib/features/kata/KataWorkspace.svelte
+++ b/frontend/src/lib/features/kata/KataWorkspace.svelte
@@ -827,10 +827,6 @@
     return created!;
   }
 
-  async function renameKataProject(id: number, name: string): Promise<void> {
-    await runViewTaskOrThrow(() => store.renameProject(id, name));
-  }
-
   async function submitQuickCapture(title: string): Promise<void> {
     await withRouteEmission(async () => {
       await runViewTaskOrThrow(async () => {
@@ -1184,7 +1180,6 @@
         scheduleProjectScope(projectUID);
       }}
       onCreateProject={createKataProject}
-      onRenameProject={renameKataProject}
     />
 
     <main class="kata-main" aria-label="Kata tasks">

--- a/frontend/src/lib/features/kata/KataWorkspace.svelte
+++ b/frontend/src/lib/features/kata/KataWorkspace.svelte
@@ -236,6 +236,7 @@
   async function runViewTask(
     task: () => Promise<void | boolean>,
     failureSurface: FailureSurface = "request",
+    shouldSurfaceFailure: () => boolean = () => true,
   ): Promise<boolean> {
     const loadingGeneration = beginViewLoading();
     clearTaskErrors();
@@ -247,7 +248,9 @@
       }
       return ok;
     } catch (err) {
-      surfaceTaskError(kataRequestErrorMessage(err), failureSurface);
+      if (shouldSurfaceFailure()) {
+        surfaceTaskError(kataRequestErrorMessage(err), failureSurface);
+      }
       return false;
     } finally {
       endViewLoading(loadingGeneration);
@@ -973,7 +976,12 @@
   async function moveSelectedIssue(toProjectUID: string): Promise<boolean> {
     const selected = store.selectedIssue?.issue;
     if (!selected) return false;
-    return runViewTask(() => store.moveIssue(selected.uid, actor, toProjectUID));
+    const generation = navigationGeneration;
+    return runViewTask(
+      () => store.moveIssue(selected.uid, actor, toProjectUID),
+      "request",
+      () => isCurrentNavigation(generation),
+    );
   }
 
   async function patchSelectedMetadata(uid: string, patch: Record<string, unknown>): Promise<boolean> {

--- a/frontend/src/lib/features/kata/KataWorkspace.svelte
+++ b/frontend/src/lib/features/kata/KataWorkspace.svelte
@@ -610,6 +610,11 @@
       return;
     }
     if (mismatch === "daemon" && daemonSwitchGated()) return;
+    // A project route load applies its scope before its optional view load
+    // finishes. That intermediate state can leave only the issue selection
+    // mismatched, but selecting now would be aborted when the remaining view
+    // load clears selection. Wait for the complete route load to settle.
+    if (viewScopeLoadSignature !== null && mismatch !== "viewScope") return;
     if (mismatch === "viewScope" && viewScopeLoadSignature === fullRouteSignature()) return;
     void untrack(() => reconcileRoute());
   });

--- a/frontend/src/lib/features/kata/KataWorkspace.svelte
+++ b/frontend/src/lib/features/kata/KataWorkspace.svelte
@@ -109,6 +109,7 @@
   let captureOpen = $state(false);
   let listResetGeneration = $state(0);
   let checklistRevealed = $state(false);
+  let pendingMoveIssueUIDs = $state.raw<ReadonlySet<string>>(new Set());
   let recurrenceDialogs = $state<KataRecurrenceDialogController | null>(null);
   let workspaceActionBusy = $state(false);
   let listMode = $state<ListMode>("tasks");
@@ -975,13 +976,21 @@
 
   async function moveSelectedIssue(toProjectUID: string): Promise<boolean> {
     const selected = store.selectedIssue?.issue;
-    if (!selected) return false;
+    if (!selected || pendingMoveIssueUIDs.has(selected.uid)) return false;
+    const sourceIssueUID = selected.uid;
     const generation = navigationGeneration;
-    return runViewTask(
-      () => store.moveIssue(selected.uid, actor, toProjectUID),
-      "request",
-      () => isCurrentNavigation(generation),
-    );
+    pendingMoveIssueUIDs = new Set(pendingMoveIssueUIDs).add(sourceIssueUID);
+    try {
+      return await runViewTask(
+        () => store.moveIssue(sourceIssueUID, actor, toProjectUID),
+        "request",
+        () => isCurrentNavigation(generation),
+      );
+    } finally {
+      const nextPendingMoves = new Set(pendingMoveIssueUIDs);
+      nextPendingMoves.delete(sourceIssueUID);
+      pendingMoveIssueUIDs = nextPendingMoves;
+    }
   }
 
   async function patchSelectedMetadata(uid: string, patch: Record<string, unknown>): Promise<boolean> {
@@ -1269,6 +1278,7 @@
       {unlinkError}
       selectedRecurrences={store.selectedRecurrences}
       {checklistRevealed}
+      movePending={pendingMoveIssueUIDs.has(store.selectedIssue.issue.uid)}
       onMoveIssue={moveSelectedIssue}
       onPatchMetadata={patchSelectedMetadata}
       onAddComment={addSelectedComment}

--- a/frontend/src/lib/features/kata/KataWorkspace.svelte
+++ b/frontend/src/lib/features/kata/KataWorkspace.svelte
@@ -970,10 +970,10 @@
     graphSourceIssue = null;
   }
 
-  async function moveSelectedIssue(toProjectUID: string | null): Promise<void> {
+  async function moveSelectedIssue(toProjectUID: string): Promise<boolean> {
     const selected = store.selectedIssue?.issue;
-    if (!selected || !toProjectUID) return;
-    await runViewTask(() => store.moveIssue(selected.uid, actor, toProjectUID));
+    if (!selected) return false;
+    return runViewTask(() => store.moveIssue(selected.uid, actor, toProjectUID));
   }
 
   async function patchSelectedMetadata(uid: string, patch: Record<string, unknown>): Promise<boolean> {

--- a/frontend/src/lib/features/kata/KataWorkspace.test.ts
+++ b/frontend/src/lib/features/kata/KataWorkspace.test.ts
@@ -1528,6 +1528,10 @@ describe("KataWorkspace", () => {
     await screen.findByRole("heading", { name: "Email Susan re: Q3" });
     await rerender({ api, selectedIssueUID: "issue-pay-rent" });
     await screen.findByRole("heading", { name: "Pay rent" });
+    const returnedDetail = within(screen.getByRole("region", { name: "Task detail" }));
+    await fireEvent.click(returnedDetail.getByRole("button", { name: "More actions" }));
+    expect(returnedDetail.queryByRole("menuitem", { name: "Move to another project" })).toBeNull();
+    expect(moveIssue).toHaveBeenCalledTimes(1);
 
     pendingMove.reject(new Error("old move failed"));
     await pendingMove.promise.catch(() => undefined);

--- a/frontend/src/lib/features/kata/KataWorkspace.test.ts
+++ b/frontend/src/lib/features/kata/KataWorkspace.test.ts
@@ -1496,6 +1496,46 @@ describe("KataWorkspace", () => {
     expect(screen.getByTestId("daemon-chip").textContent).not.toContain("owner unavailable");
   });
 
+  it("does not surface a stale move failure after navigating A to B to A", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [
+          {
+            id: "home",
+            url: "http://127.0.0.1:7777",
+            default: true,
+            auth: "none",
+            health: "connected",
+          },
+        ],
+      }),
+    );
+    const pendingMove = deferred<never>();
+    const { api, moveIssue } = createWorkspaceAPI();
+    moveIssue.mockImplementationOnce(() => pendingMove.promise);
+
+    const { rerender } = render(KataWorkspace, {
+      props: { api, selectedIssueUID: "issue-pay-rent" },
+    });
+
+    await screen.findByRole("heading", { name: "Pay rent" });
+    const detail = within(screen.getByRole("region", { name: "Task detail" }));
+    await fireEvent.click(detail.getByRole("button", { name: "More actions" }));
+    await fireEvent.click(detail.getByRole("menuitem", { name: "Move to another project" }));
+    await fireEvent.click(detail.getByRole("button", { name: /Kata/ }));
+
+    await rerender({ api, selectedIssueUID: "issue-email-susan" });
+    await screen.findByRole("heading", { name: "Email Susan re: Q3" });
+    await rerender({ api, selectedIssueUID: "issue-pay-rent" });
+    await screen.findByRole("heading", { name: "Pay rent" });
+
+    pendingMove.reject(new Error("old move failed"));
+    await pendingMove.promise.catch(() => undefined);
+    await Promise.resolve();
+    expect(moveIssue).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText("old move failed")).toBeNull();
+  });
+
   it("rehydrates linked task titles when switching daemons with matching peer uids", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
       Response.json({

--- a/frontend/src/lib/features/kata/KataWorkspace.test.ts
+++ b/frontend/src/lib/features/kata/KataWorkspace.test.ts
@@ -938,7 +938,7 @@ describe("KataWorkspace", () => {
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: "Pay rent" })).toBeTruthy();
     });
-    const nav = within(screen.getByLabelText("Kata navigation"));
+    const nav = within(screen.getByRole("complementary", { name: "Kata navigation" }));
     expect(nav.getByRole("button", { name: /^Finances\s+1$/ })).toBeTruthy();
     expect(screen.getByText("Pay rent body")).toBeTruthy();
 

--- a/frontend/tests/e2e-full/kata.spec.ts
+++ b/frontend/tests/e2e-full/kata.spec.ts
@@ -121,6 +121,7 @@ type BackendState = {
   failNextIssuesStatus?: number | undefined;
   failNextMetadataMessage?: string | undefined;
   closeBarrier?: Promise<void> | undefined;
+  failNextMoveMessage?: string | undefined;
   eventsBarrier?: Promise<void> | undefined;
   issuesBarrier?: Promise<void> | undefined;
   searchBarriers: Map<string, Promise<void>>;
@@ -1325,6 +1326,12 @@ async function handleIssueMutation(
 
   if (req.method === "POST" && route.kind === "actions" && route.label === "move") {
     const payload = await readJSONBody(req);
+    if (state.failNextMoveMessage !== undefined) {
+      const message = state.failNextMoveMessage;
+      state.failNextMoveMessage = undefined;
+      writeJSON(res, 503, { error: { code: "move_unavailable", message } });
+      return;
+    }
     const toProjectUID = typeof payload.to_project_uid === "string" ? payload.to_project_uid : "";
     const project = state.projects.find((candidate) => candidate.uid === toProjectUID);
     if (!project) {
@@ -3958,104 +3965,6 @@ test("kata project create input cancels on Escape", async ({ page }) => {
   }
 });
 
-test("kata project rename submits inline input", async ({ page }) => {
-  const backend = await startKataBackend();
-  const kataHome = await configureKataHome(backend.url);
-  const server = await startIsolatedE2EServer();
-
-  try {
-    await page.goto(`${server.info.base_url}/kata`);
-    await expectKataDaemonSwitcherReady(page);
-    const listTitle = page.locator(".kata-list h2");
-    const titleBeforeRename = await listTitle.innerText();
-
-    await page.getByRole("button", { name: "Rename Finances" }).click();
-    const input = page.getByRole("textbox", { name: "Rename project" });
-    await expect(input).toBeVisible();
-    await expect(listTitle).toHaveText(titleBeforeRename);
-    await input.fill("Wellness");
-    await input.press("Enter");
-
-    await expect(page.getByRole("button", { name: /^Wellness\s+1$/ })).toBeVisible();
-    await expect(page.getByRole("button", { name: /^Finances\s+1$/ })).toHaveCount(0);
-    await expect.poll(() => backend.state.seenPaths).toContain("PATCH /api/v1/projects/1");
-  } finally {
-    await server.stop();
-    kataHome.restore();
-    await backend.close();
-  }
-});
-
-test("kata project rows can be renamed by double-clicking", async ({ page }) => {
-  const backend = await startKataBackend();
-  const kataHome = await configureKataHome(backend.url);
-  const server = await startIsolatedE2EServer();
-
-  try {
-    await page.goto(`${server.info.base_url}/kata`);
-    await expectKataDaemonSwitcherReady(page);
-
-    await page.getByRole("button", { name: /^Finances\s+1$/ }).dblclick();
-    const input = page.getByRole("textbox", { name: "Rename project" });
-    await expect(input).toBeVisible();
-    await input.fill("Wellness");
-    await input.press("Enter");
-
-    await expect(page.getByRole("button", { name: /^Wellness\s+1$/ })).toBeVisible();
-    await expect(page.getByRole("button", { name: /^Finances\s+1$/ })).toHaveCount(0);
-    await expect.poll(() => backend.state.seenPaths).toContain("PATCH /api/v1/projects/1");
-  } finally {
-    await server.stop();
-    kataHome.restore();
-    await backend.close();
-  }
-});
-
-test("kata project row double-click enters rename", async ({ page }) => {
-  const backend = await startKataBackend();
-  const kataHome = await configureKataHome(backend.url);
-  const server = await startIsolatedE2EServer();
-
-  try {
-    await page.goto(`${server.info.base_url}/kata`);
-    await expectKataDaemonSwitcherReady(page);
-
-    await page.getByRole("button", { name: /^Finances\s+1$/ }).dblclick({ delay: 300 });
-
-    await expect(page.getByRole("textbox", { name: "Rename project" })).toBeVisible();
-  } finally {
-    await server.stop();
-    kataHome.restore();
-    await backend.close();
-  }
-});
-
-test("kata project rename input cancels on Escape", async ({ page }) => {
-  const backend = await startKataBackend();
-  const kataHome = await configureKataHome(backend.url);
-  const server = await startIsolatedE2EServer();
-
-  try {
-    await page.goto(`${server.info.base_url}/kata`);
-    await expectKataDaemonSwitcherReady(page);
-
-    await page.getByRole("button", { name: "Rename Finances" }).click();
-    const input = page.getByRole("textbox", { name: "Rename project" });
-    await expect(input).toBeVisible();
-    await input.fill("Different");
-    await input.press("Escape");
-
-    await expect(page.getByRole("textbox", { name: "Rename project" })).toHaveCount(0);
-    await expect(page.getByRole("button", { name: /^Finances\s+1$/ })).toBeVisible();
-    await expect(page.getByRole("button", { name: /^Different\s+1$/ })).toHaveCount(0);
-    expect(backend.state.seenPaths).not.toContain("PATCH /api/v1/projects/1");
-  } finally {
-    await server.stop();
-    kataHome.restore();
-    await backend.close();
-  }
-});
-
 test("kata parent row expands children loaded from detail", async ({ page }) => {
   const parent = issueSummary({
     id: 101,
@@ -6077,7 +5986,7 @@ test("kata detail property editors reset when switching tasks", async ({ page })
   }
 });
 
-test("kata project crumb moves tasks through the configured external daemon", async ({ page }) => {
+test("kata More actions moves tasks through the configured external daemon", async ({ page }) => {
   const backend = await startKataBackend();
   const kataHome = await configureKataHome(backend.url);
   const server = await startIsolatedE2EServer();
@@ -6087,19 +5996,75 @@ test("kata project crumb moves tasks through the configured external daemon", as
 
     const detail = page.getByRole("region", { name: "Task detail" });
     await expect(detail.getByRole("heading", { name: "Pay rent" })).toBeVisible();
-    await expect(detail.getByRole("button", { name: "Move issue from Finances" })).toBeVisible();
+    await expect(detail.locator(".crumb-project")).toHaveText("Finances");
 
-    await detail.getByRole("button", { name: "Move issue from Finances" }).click();
-    const input = detail.getByRole("combobox", { name: "Move issue project" });
-    await expect(input).toBeFocused();
-    await input.fill("kat");
-    await input.press("Enter");
+    await detail.getByRole("button", { name: "More actions" }).click();
+    await detail.getByRole("menuitem", { name: "Move to another project" }).click();
+    const picker = detail.getByRole("dialog", { name: "Move to another project" });
+    const search = picker.getByRole("searchbox", { name: "Find project" });
+    await expect(search).toBeFocused();
+    await search.fill("kat");
+    await picker.getByRole("button", { name: /Kata/ }).click();
 
-    await expect(detail.getByRole("button", { name: "Move issue from Kata" })).toBeVisible();
-    await expect
-      .poll(() => backend.state.seenPaths)
-      .toContain("POST /api/v1/projects/1/issues/issue-rent/actions/move");
-    expect(backend.state.issues.find((issue) => issue.uid === "issue-rent")?.project_uid).toBe("project-kata");
+    await expect(picker).toHaveCount(0);
+    await expect(detail.locator(".crumb-project")).toHaveText("Kata");
+    await expect(detail.locator(".crumb-id")).toHaveText("kat-11");
+    await expect(page.getByRole("button", { name: /^Finances\s+0$/ })).toBeVisible();
+    await expect(page.getByRole("button", { name: /^Kata\s+2$/ })).toBeVisible();
+
+    const movePath = "POST /api/v1/projects/1/issues/issue-rent/actions/move";
+    await expect.poll(() => backend.state.seenPaths.filter((path) => path === movePath).length).toBe(1);
+    expect(backend.state.issues.find((issue) => issue.uid === "issue-rent")).toMatchObject({
+      project_id: 2,
+      project_uid: "project-kata",
+      project_name: "Kata",
+      short_id: "kat-11",
+      qualified_id: "Kata#kat-11",
+      revision: 2,
+    });
+  } finally {
+    await server.stop();
+    kataHome.restore();
+    await backend.close();
+  }
+});
+
+test("kata More actions keeps a failed daemon move open and retries successfully", async ({ page }) => {
+  const backend = await startKataBackend();
+  backend.state.failNextMoveMessage = "move service unavailable";
+  const kataHome = await configureKataHome(backend.url);
+  const server = await startIsolatedE2EServer();
+
+  try {
+    await page.goto(`${server.info.base_url}/kata?issue=issue-rent`);
+
+    const detail = page.getByRole("region", { name: "Task detail" });
+    await expect(detail.getByRole("heading", { name: "Pay rent" })).toBeVisible();
+    await detail.getByRole("button", { name: "More actions" }).click();
+    await detail.getByRole("menuitem", { name: "Move to another project" }).click();
+
+    const picker = detail.getByRole("dialog", { name: "Move to another project" });
+    const search = picker.getByRole("searchbox", { name: "Find project" });
+    await search.fill("kat");
+    const destination = picker.getByRole("button", { name: /Kata/ });
+    await destination.click();
+
+    await expect(page.getByRole("alert")).toContainText("move service unavailable");
+    await expect(picker).toBeVisible();
+    await expect(search).toHaveValue("kat");
+    await expect(destination).toBeEnabled();
+    expect(backend.state.issues.find((issue) => issue.uid === "issue-rent")).toMatchObject({
+      project_uid: "project-finance",
+      short_id: "FIN-1",
+      revision: 1,
+    });
+
+    await destination.click();
+    await expect(picker).toHaveCount(0);
+    await expect(detail.locator(".crumb-project")).toHaveText("Kata");
+    await expect(detail.locator(".crumb-id")).toHaveText("kat-11");
+    const movePath = "POST /api/v1/projects/1/issues/issue-rent/actions/move";
+    await expect.poll(() => backend.state.seenPaths.filter((path) => path === movePath).length).toBe(2);
   } finally {
     await server.stop();
     kataHome.restore();

--- a/frontend/tests/e2e-full/kata.spec.ts
+++ b/frontend/tests/e2e-full/kata.spec.ts
@@ -6139,7 +6139,7 @@ test("kata complete dialog closes and reopens through the configured external da
   try {
     await page.goto(`${server.info.base_url}/kata?issue=issue-rent`);
     const detail = page.getByRole("region", { name: "Task detail" });
-    const financeCount = page.locator(".project-groups button", { hasText: "Finances" }).locator(".count");
+    const financeCount = page.getByRole("button", { name: /^Finances\s+\d+$/ }).locator(".count");
     await expect(detail.getByRole("heading", { name: "Pay rent" })).toBeVisible();
     await expect(financeCount).toHaveText("1");
 
@@ -6233,7 +6233,7 @@ test("kata overflow menu reveals checklist and deletes through the configured ex
   try {
     await page.goto(`${server.info.base_url}/kata?issue=issue-q3`);
     const detail = page.getByRole("region", { name: "Task detail" });
-    const kataCount = page.locator(".project-groups button", { hasText: "Kata" }).locator(".count");
+    const kataCount = page.getByRole("button", { name: /^Kata\s+\d+$/ }).locator(".count");
     await expect(detail.getByRole("heading", { name: "Email Susan re: Q3" })).toBeVisible();
     await expect(detail.getByRole("region", { name: "Checklist" })).toHaveCount(0);
     await expect(kataCount).toHaveText("1");

--- a/frontend/tests/e2e-full/kata.spec.ts
+++ b/frontend/tests/e2e-full/kata.spec.ts
@@ -3162,7 +3162,7 @@ test("kata daemon switch drops a pending detail load from the previous daemon", 
     work.state.issuesBarrier = stalledIssues;
     await page.getByTestId("daemon-chip").click();
     await page.getByTestId("daemon-row-work").click();
-    await expect(page.getByRole("region", { name: "Kata" })).toHaveAttribute("inert", "");
+    await expect(page.getByRole("region", { name: "Kata", exact: true })).toHaveAttribute("inert", "");
     await expect(rentRow).toHaveCount(0);
     await expect(page.getByRole("button", { name: /^Finances\s+1$/ })).toHaveCount(0);
     releaseDetail();
@@ -4162,8 +4162,9 @@ test("kata workspace switches between configured external daemons", async ({ pag
     await expect(page.getByTestId("daemon-chip")).toContainText("work");
     await expect(taskList.getByRole("button", { name: /Ship the release/ })).toBeVisible();
     await expect(taskList.getByRole("button", { name: /Rake the yard/ })).toHaveCount(0);
-    await expect(page.getByRole("button", { name: /^Work\s+1$/ })).toBeVisible();
-    await expect(page.getByRole("button", { name: /^Home\s+1$/ })).toHaveCount(0);
+    const projectRows = page.locator(".kata-sidebar .project-select-button");
+    await expect(projectRows.filter({ hasText: /^Work\s+1$/ })).toBeVisible();
+    await expect(projectRows.filter({ hasText: /^Home\s+1$/ })).toHaveCount(0);
   } finally {
     await server.stop();
     kataHome.restore();

--- a/frontend/tests/e2e-full/kata.spec.ts
+++ b/frontend/tests/e2e-full/kata.spec.ts
@@ -3853,10 +3853,19 @@ test("kata sidebar switches system views and renders project areas", async ({ pa
     await expect(page.getByRole("button", { name: "Inbox" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Today" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Logbook" })).toBeVisible();
-    await expect(page.getByRole("heading", { name: "Personal" })).toBeVisible();
-    await expect(page.getByRole("heading", { name: "Work" })).toBeVisible();
+    const personal = page.getByRole("button", { name: /^Personal\s+1$/ });
+    const work = page.getByRole("button", { name: /^Work\s+1$/ });
+    await expect(personal).toHaveAttribute("aria-expanded", "true");
+    await expect(work).toHaveAttribute("aria-expanded", "true");
     await expect(page.getByRole("button", { name: /^Finances\s+1$/ })).toBeVisible();
     await expect(page.getByRole("button", { name: /^Kata\s+1$/ })).toBeVisible();
+
+    await personal.click();
+    await expect(personal).toHaveAttribute("aria-expanded", "false");
+    await expect(page.getByRole("button", { name: /^Finances\s+1$/ })).toHaveCount(0);
+    await personal.click();
+    await expect(personal).toHaveAttribute("aria-expanded", "true");
+    await expect(page.getByRole("button", { name: /^Finances\s+1$/ })).toBeVisible();
 
     await page.getByRole("button", { name: "Inbox" }).click();
     await expect(page.getByRole("heading", { name: "Inbox", level: 2 })).toBeVisible();

--- a/frontend/tests/e2e-full/kata.spec.ts
+++ b/frontend/tests/e2e-full/kata.spec.ts
@@ -1624,8 +1624,25 @@ test("kata reachable graph renders and selects tasks through the configured exte
       });
     await selectGraphFilterItem(graph, "depth-full");
     await expect
-      .poll(() => page.evaluate(() => window.__middleman_kata_graph_debug?.snapshot().latestGraph?.depthLimit))
-      .toBe("full");
+      .poll(() =>
+        page.evaluate(() => {
+          const latest = window.__middleman_kata_graph_debug?.snapshot().latestGraph;
+          return latest
+            ? {
+                depthLimit: latest.depthLimit,
+                hasDeepFollowUp: latest.nodeIds.includes("issue-deep-follow-up"),
+                edgeCount: latest.edgeCount,
+                layoutEdgeCount: latest.layoutEdgeCount,
+              }
+            : null;
+        }),
+      )
+      .toMatchObject({
+        depthLimit: "full",
+        hasDeepFollowUp: true,
+        edgeCount: 4,
+        layoutEdgeCount: 3,
+      });
     const fullSnapshotBeforeContext = await page.evaluate(() => {
       const latest = window.__middleman_kata_graph_debug?.snapshot().latestGraph;
       return latest

--- a/frontend/tests/e2e-full/repo-browser.spec.ts
+++ b/frontend/tests/e2e-full/repo-browser.spec.ts
@@ -477,6 +477,7 @@ test.describe("repository source browser", () => {
       const historyHandle = browser.getByRole("button", { name: "Resize file history" });
 
       await expect(viewer.locator(".repo-browser__path")).toContainText("README.md");
+      await expect(viewer.locator(".repo-browser__source")).toContainText("# Widget Service");
       await expect(sidebar).toBeVisible();
       await expect(history).toBeVisible();
       await expect(filesHandle).toBeVisible();

--- a/frontend/tests/e2e-full/sidebar-scroll-indicator.spec.ts
+++ b/frontend/tests/e2e-full/sidebar-scroll-indicator.spec.ts
@@ -61,16 +61,22 @@ test("grouped rail scroll indicator floats above sticky headers", async ({ page 
   await expect(indicator).toHaveCSS("opacity", "0", { timeout: 1_500 });
 });
 
-test("PR, issue, and workspace rails share labeled overlay scroll regions", async ({ page }) => {
+test("grouped rails share labeled overlay scroll regions", async ({ page }) => {
   const rails = [
     { path: "/pulls", label: "Pull requests" },
     { path: "/issues", label: "Issues" },
     { path: "/workspaces", label: "Workspaces" },
+    { path: "/kata", label: "Kata navigation" },
   ];
 
   for (const rail of rails) {
     await page.goto(rail.path);
-    const scope = rail.path === "/workspaces" ? page.locator(".workspace-list-sidebar") : page;
+    const scope =
+      rail.path === "/workspaces"
+        ? page.locator(".workspace-list-sidebar")
+        : rail.path === "/kata"
+          ? page.locator(".kata-sidebar")
+          : page;
     const scrollArea = scope.getByRole("region", { name: rail.label, exact: true });
     await expect(scrollArea).toBeVisible();
     await expect(scrollArea).toHaveAttribute("tabindex", "0");


### PR DESCRIPTION
- Use the shared grouped sidebar with collapsible project areas and navigation-only project rows.
- Make issue project breadcrumbs passive and move reassignment into the More actions menu.
- Keep failed moves retryable while preventing stale completions and errors from affecting another issue.
- Replace obsolete rename workflows with configured-daemon move and keyboard coverage.

<sup>generated by a clanker</sup>