### PR TITLE
Persist Kata workspace state across navigation

### DIFF
--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -268,6 +268,9 @@ breakage.
 - Store tests for persistence scope and normalization logic.
 - Playwright/e2e tests for navigation away/back, Escape behavior, nested button
   activation, and other multi-surface flows.
+- Component tests for inert transactional surfaces must await an explicitly
+  enabled control before firing events; jsdom does not enforce browser inertness
+  (`frontend/src/lib/features/kata/KataWorkspace.svelte::workspaceActionsBlocked`).
 - For controlled native form controls, assert behavior under a real
   `fireEvent.click`, not only `fireEvent.mouseDown`. A mousedown-only test skips
   the native default action (e.g. a checkbox's own toggle) and will pass while a

--- a/docs/superpowers/specs/2026-06-08-kata-docs-msgvault-modes-design.md
+++ b/docs/superpowers/specs/2026-06-08-kata-docs-msgvault-modes-design.md
@@ -329,6 +329,29 @@ Kata frontend adaptation:
 - Task-list header controls should expand every visible task tree recursively
   through the task-detail API, and collapse should hide cached descendants
   without reintroducing them as top-level flat rows.
+- Restored nested-task ancestor reconstruction is presentation-only. Temporary
+  ancestors and each contextual successor bypass only the active status filter
+  for the selected path; unrelated children still obey that filter and all
+  other active filters. Context rows do not affect task counts, membership
+  checks, or persisted workspace state. Their synthetic edges and reveal-owned
+  expansion disappear when the reveal is cleared or superseded. Clicking a
+  contextual row's disclosure control or invoking the task-list Expand all
+  control promotes that row to user-owned expansion; ordinary selection does
+  not. User-owned expansion survives reveal cleanup. An authoritative
+  child response replaces cached edges and a transient refresh failure retains
+  the seeded path for that reveal. A task
+  admitted by raw filtered membership remains selected if resolution finds a
+  cycle, missing parent, depth limit, missing ancestor detail, ancestor 404, or
+  a transient ancestor request failure; only the temporary reveal chain is
+  omitted, and transient failure remains retryable. Definitive absence of the
+  selected task itself still clears persisted selection. Ancestor reconstruction
+  walks serially to a maximum depth of 32 with one active walk per workspace.
+  Route change, selection change, switch, or unmount aborts the walk where
+  supported and prevents subsequent ancestor requests. At most one stale
+  non-abortable request may drain; further changes coalesce to the latest
+  selected UID. Retry starts a new walk only for the current UID and generation.
+  Candidate ancestor data remains transaction-local and is published only after
+  the candidate workspace is accepted.
 - Project-scoped task filters must resolve the Kata project UID and read the
   daemon's project issue list instead of filtering the all-project issue list
   locally (`frontend/src/lib/api/kata/taskClient.ts::searchProject`).
@@ -338,37 +361,141 @@ Kata frontend adaptation:
 - Removed accepted daemons remain selected and visibly unavailable until the
   user chooses a configured daemon (`frontend/src/lib/features/kata/KataDaemonSwitcher.svelte::displayId`).
 - Daemon switching is disabled during initial bootstrap, writes, view work
-  (including live-event refresh callbacks), and switches. The entire Kata
-  workspace is inert while a switch is provisional. Cursor catch-up is part of
-  target and rollback acceptance; dual failure clears partial state and stops
-  the stream
+  (including live-event refresh callbacks), and switches. Restoration is one
+  discriminated transaction state, not a set of independent booleans. Each
+  variant owns its accepted or candidate stores, daemon binding, route
+  signature, generation, persistence delta, Retry owner, and stream state;
+  transitions are the only operations allowed to publish those resources:
+
+  | State             | Displayed daemon      | Persisted preference  | Accepted binding / staged reads                                    | Live workspace and actions                                                  |
+  | ----------------- | --------------------- | --------------------- | ------------------------------------------------------------------ | --------------------------------------------------------------------------- |
+  | accepted          | accepted daemon       | accepted daemon       | shared binding is accepted daemon                                  | accepted snapshot, one stream, interactive                                  |
+  | provisional       | prior accepted daemon | prior accepted daemon | shared binding stays prior; candidate reads name target explicitly | prior snapshot displayed inert; target state staged                         |
+  | rollback          | prior accepted daemon | prior accepted daemon | shared binding restored to prior accepted daemon                   | prior snapshot displayed inert while network state is rebuilt               |
+  | terminal-retained | prior accepted daemon | prior accepted daemon | prior accepted daemon                                              | last accepted snapshot retained read-only; stream stopped; Retry exposed    |
+  | terminal-cold     | none                  | unchanged or none     | none                                                               | inert empty workspace; stream stopped; Retry exposes initial restoration    |
+  | superseded        | prior accepted daemon | prior accepted daemon | restored prior accepted daemon                                     | late target success/error is inert; current route owns the next transaction |
+
+  A target is accepted only after catalog load, route restoration, and required
+  cursor acceptance. Before that commit, target persistence deltas, route
+  cleanup, selection cleanup, cursor state, and stream startup remain staged in
+  a candidate workspace. The displayed snapshot, persisted preference, shared
+  request binding, candidate read target, and accepted live workspace are
+  separate concepts and must not be inferred from one another
   (`frontend/src/lib/features/kata/KataWorkspace.svelte::switchKataDaemon`).
+  Only `accepted` owns a live stream. Leaving it detaches that stream before
+  candidate reads begin. Provisional, rollback, terminal, and superseded states
+  own no stream. Stream callbacks and queued events carry daemon plus generation;
+  detached or superseded delivery is discarded and recovered through cursor
+  catch-up. Acceptance atomically starts exactly one stream after cursor
+  acceptance.
+
+- A routed Retry captures the full route signature plus a monotonically
+  increasing restoration generation. Any route change invalidates the
+  generation before restoring the prior accepted daemon. A running request need
+  not be physically abortable, but its late success or rejection must not
+  mutate the store, reinstall Retry, publish route cleanup, persist target
+  state, or start a target stream. Cancelling a settled or running Retry performs
+  full fallback rehydration: catalog, accepted route state, health validation,
+  cursor catch-up, persistence deltas, and exactly one stream restart. A terminal
+  state records URL changes without applying them. Retry captures the then-current
+  full route signature and a new generation, never the originally failed
+  signature; a route change during Retry supersedes that attempt and leaves Retry
+  available for the newest signature.
+- Target failures use network-backed rollback except for the initial and routed
+  zero-progress cursor outcomes below. Rollback restores the prior accepted
+  daemon, or the roster default when no explicit accepted preference exists. If
+  target and rollback both fail after a workspace was accepted, enter
+  `terminal-retained`: retain that snapshot read-only, stop its stream, suppress
+  persistence and route reconciliation, and expose Retry. If initial restoration
+  has no accepted snapshot, enter `terminal-cold` with an inert empty workspace
+  and Retry. Retained Retry revalidates the prior daemon, catches up its cursor,
+  applies selection and route correction, and restarts one stream before actions
+  resume; cold Retry repeats initial acceptance without publishing provisional
+  state.
+- Cursor catch-up is serialized with SSE delivery and scoped by daemon plus
+  workspace generation. Cursor state is session-local memory: it is neither
+  written to daemon workspace persistence nor restored after page reload.
+  Acceptance is defined by transaction and outcome:
+
+  | Transaction                   | Failure before progress                                                                                                                                     | Partial progress then failure                                                                                          | Success                                      |
+  | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+  | Initial, no accepted snapshot | enter `terminal-cold`; publish no persistence or stream; Retry owns the latest full route signature                                                         | accept target degraded at the last cursor, commit it, start one stream, and bind cursor Retry to the target generation | accept and commit target; start one stream   |
+  | Routed, prior snapshot exists | remain `provisional`; retain the prior snapshot read-only with unchanged binding and persistence; start no stream; routed Retry owns the captured signature | accept target degraded, commit it, start one stream, and bind cursor Retry to the target generation                    | accept and commit target; start one stream   |
+  | Manual switch                 | enter network-backed rollback; target publishes nothing                                                                                                     | accept target degraded, commit it, start one stream, and bind cursor Retry to the target generation                    | accept and commit target; start one stream   |
+  | Rollback or rehydration       | enter retained terminal when a prior snapshot exists, otherwise cold terminal; start no stream                                                              | accept recovered daemon degraded at the last cursor and start one stream                                               | accept recovered daemon and start one stream |
+
+  Cursor catch-up uses 100-event pages and coalesces each accepted batch into one
+  view/detail reconciliation. Implementations must impose a finite acceptance
+  budget of 1,000 events or two seconds and perform one authoritative reset at
+  the daemon high-water cursor when either bound is exceeded rather than issue an
+  unbounded request chain. Cursor and stream
+  delivery remain serialized through the same daemon/generation queue.
+
+  A cursor Retry whose daemon or generation no longer matches is inert. If
+  accepted delivery removes the selected task from raw filtered membership,
+  clear in-memory detail, replace the route with `issue` removed, and set only
+  that daemon snapshot's `selectedIssueUID` to null; retain its view, filters,
+  scope, and accepted cursor progress.
+
 - Cross-mode task links carry their daemon target in route state until the
   workspace accepts that switch; linked issue selection must not run against
   the previously accepted daemon (`frontend/src/App.svelte::openKataIssue`).
 - Daemon-route cleanup replaces the transient history entry. Unknown targets
   stay unresolved with an error, and failed initial acceptance restores the
   prior daemon preference (`frontend/src/lib/features/kata/KataWorkspace.svelte::routedDaemonError`).
-- Browser route changes remain queued while a daemon switch or rollback is
-  provisional, then apply to the accepted workspace after the transaction
-  settles. A successful bootstrap does not publish its provisional selection
-  when the route signature changed during the switch. If target and rollback
-  both fail, no workspace is accepted and route effects remain suppressed until
-  a later successful bootstrap
-  (`frontend/src/lib/features/kata/KataWorkspace.svelte::routeSignature`).
-- Kata route synchronization is level-triggered: the URL is the source of
-  truth and a single reconciler converges the workspace to it whenever they
-  differ, with no memory of what was previously synchronized. Interactions
-  load optimistically and must emit the matching route update afterwards
-  (their consumers echo it synchronously); store state that should survive
-  navigation lives in the URL
+- Route changes preempt routed restoration, routed Retry, manual switching, and
+  fallback rehydration by invalidating the owning full-route signature and
+  generation. Non-abortable requests may finish, but late target results are
+  inert. Routed restoration and fallback immediately restart against the latest
+  route on the prior accepted daemon; a manual switch restores the accepted
+  binding/stream and lets the level-triggered reconciler apply the new route.
+  Rollback continues only to recover the prior daemon, then applies the latest
+  route. Terminal states suppress route effects until Retry accepts a workspace.
+  Each workspace permits one current restoration chain and one draining stale
+  non-abortable request per catalog, view, detail, cursor, or ancestor request
+  class. Further route changes coalesce to the latest full signature. All task
+  client methods accept `AbortSignal`; the proxy deadline remains the outer bound
+  for requests that cannot abort
+  (`frontend/src/lib/features/kata/KataWorkspace.svelte::fullRouteSignature`).
+- Kata route synchronization is level-triggered after workspace acceptance:
+  the reconciler converges the workspace to the canonical URL whenever they
+  differ. Persistence inheritance is initial-bootstrap-only. On that bootstrap,
+  an explicit URL `view`, `scope`, or `issue` overrides only its corresponding
+  persisted field; an omitted field inherits the persisted value, including a
+  persisted null selection, or the default when no snapshot exists. After mount,
+  omission means clear that route-owned field rather than re-inherit persistence:
+  omitted `issue` deselects and persists null, omitted `scope` becomes unscoped,
+  omitted `view` becomes the canonical default, and omitted `daemon` means the
+  already accepted daemon rather than a new persisted lookup. Persisted
+  non-route filters remain in force. A definitive task 404 clears in-memory
+  detail and the route; transient catalog, list, detail, or cursor failure
+  preserves source state for Retry. Invalid explicit scope canonicalizes to an
+  unscoped route without deleting the saved daemon snapshot. Invalid persisted
+  scope invalidates the entire daemon snapshot so its remaining fields cannot be
+  partially inherited. Accepted state replaces the current history entry;
+  interactions load optimistically and emit their matching route update.
+- Routed issue selection waits only for the view/scope load whose complete
+  route signature matches the current route. Superseded list loads are not
+  awaited, and request/generation guards discard late results so stale work
+  neither delays current selection nor aborts a newer detail request
   (`frontend/src/lib/features/kata/KataWorkspace.svelte::reconcileRoute`).
-- Superseded route detail reads remain retryable; only a real request failure
-  may pin a route as failed, or an event refresh can strand a valid deep link
-  (`frontend/src/lib/features/kata/KataWorkspace.svelte::reconcileRoute`).
-- Routed issue selection waits for any in-flight view/scope load to settle;
-  intermediate list state may clear selection and abort an early detail read
-  (`frontend/src/lib/features/kata/KataWorkspace.svelte::viewScopeLoadSignature`).
+- Daemon-scoped persistence contains view, filters, scope, and selected issue.
+  Selection provenance is explicit: persisted selection is inherited only during
+  initial bootstrap and changes only after a definitive replacement; explicit
+  routed selection is staged and replaces that daemon snapshot only after detail
+  and workspace acceptance; routed 404 clears only the route-owned candidate;
+  default null selection is written only on commit; direct accepted selection
+  persists after definitive detail success and direct deselection persists null;
+  accepted membership loss or definitive absence clears the accepted daemon's
+  saved selection. Invalid persisted scope invalidates that whole snapshot,
+  whereas invalid explicit scope affects only the route candidate. Contextual
+  ancestors are never selection or membership evidence. Persistence is versioned
+  per daemon; unsupported old schemas are discarded rather than migrated. Storage
+  reads and writes are best-effort and failures expose non-blocking unsaved-status
+  feedback. Cross-tab events merge per daemon and revision so one daemon cannot
+  overwrite another. Global browser layout preferences continue to persist
+  independently. Scroll, expansion, pending work, and task caches do not persist.
 - Event-driven proxy reads keep switching fail-closed until they settle. The
   Kata proxy applies a 30-second total deadline to ordinary TCP and Unix-socket
   requests, including response bodies, while the live event stream stays
@@ -480,6 +607,24 @@ Backend test inventory:
 
 Frontend test inventory:
 
+- Kata completion requires deterministic coverage for initial and running
+  routed-Retry supersession (late success and late rejection), settled Retry
+  cancellation with full fallback catalog/cursor/stream restoration, manual
+  switch route/unmount cancellation, rollback failure and retained/cold terminal
+  Retry, all cursor acceptance outcomes, invalid explicit versus persisted
+  scope, initial inheritance versus post-mount omission for every route field,
+  bare-route deselection persistence, and contextual ancestor status filtering
+  and expansion ownership. Transition-table tests assert displayed daemon,
+  accepted binding, persistence delta, Retry owner, queued-event disposal, and
+  zero-or-one stream ownership for every transaction/cursor outcome.
+  Deterministic coverage also owns catch-up budget reset, stale-request
+  coalescing, the 32-request ancestor bound, storage unavailable/quota behavior,
+  per-daemon cross-tab merging, and old-schema discard. Full-stack coverage must
+  include failed routed Retry followed by successful acceptance, same-mounted
+  late-resolve and late-reject route supersession, and initial zero-progress
+  `terminal-cold` failure followed by a URL change and successful Retry against
+  the latest full route signature with exactly one target stream, in Chromium
+  and Firefox; component/store tests own the remainder of the race matrix.
 - Kata API wrappers, daemon switcher, route parsing, stores, task workspace,
   issue detail/list/actions, metadata editors, recurrence, command palette, and
   e2e harness behavior.
@@ -528,9 +673,31 @@ new navigation can stay hidden until each mode passes its migrated tests.
    switching and base-path tests pass.
 9. Restore cross-mode links between Kata tasks, docs references, and msgvault
    messages. Done when links are covered in focused frontend and API tests.
-10. Flip visible navigation for completed modes, run focused tests
-    slice-by-slice, then run full affected Go/frontend/e2e suites before
-    merging.
+10. Keep visible navigation guarded while the remaining state contracts are
+    implemented and validated.
+11. Add versioned per-daemon persistence, corrupt/old-schema discard,
+    storage-failure UI, and cross-tab merge behavior.
+12. Add the discriminated restoration state and common candidate-workspace
+    transaction primitive, including side-effect ownership and exactly-one-stream
+    invariants.
+13. Add daemon/generation cursor transport, serialized cursor/SSE delivery,
+    stale-request coalescing, and bounded catch-up/reset behavior without
+    selection mutation.
+14. Add URL/persistence precedence and selection provenance, then add
+    cursor-driven membership reconciliation using that policy.
+15. Add routed target staging and acceptance commit points.
+16. Add routed Retry, latest-signature terminal semantics, cancellation, and
+    supersession.
+17. Add manual target staging using the same candidate primitive.
+18. Add rollback, retained/cold terminal recovery, and default-daemon fallback.
+19. Add bounded temporary ancestor reconstruction and reveal ownership.
+20. Run focused transition, persistence, cursor-budget, cancellation, and
+    stream-invariant tests.
+21. Run full-stack routed and terminal-cold failure-to-success transactions,
+    including same-mounted late resolve/reject, in Chromium and Firefox.
+22. Flip visible navigation as a separate edit.
+23. Rerun affected shell, routing, frontend, Chromium, and Firefox suites after
+    the navigation edit.
 
 ## Documentation Updates
 

--- a/frontend/src/lib/api/kata/taskClient.test.ts
+++ b/frontend/src/lib/api/kata/taskClient.test.ts
@@ -1502,6 +1502,17 @@ describe("kata task HTTP client", () => {
     expect(proxyPath(calls[0]!.url)).toBe("/api/v1/projects/7/recurrences");
   });
 
+  test("pins project recurrence reads to an explicit daemon", async () => {
+    const { calls, fetchImpl } = createFetchStub({
+      "/api/v1/projects/7/recurrences": { body: { recurrences: [] } },
+    });
+    const api = createKataTaskAPI({ fetchImpl });
+
+    await api.recurrences(7, { daemonId: "work" });
+
+    expect(calls[0]!.headers.get(KATA_DAEMON_HEADER)).toBe("work");
+  });
+
   test("creates, patches, shows, and deletes recurrences with ETag handling", async () => {
     const created = {
       id: 9,

--- a/frontend/src/lib/api/kata/taskClient.ts
+++ b/frontend/src/lib/api/kata/taskClient.ts
@@ -530,12 +530,15 @@ export function createKataTaskAPI(options: CreateKataTaskAPIOptions = {}): KataT
     },
 
     async instance(opts) {
-      const result = await request<unknown>(taskPath("/instance"), { signal: opts?.signal });
+      const result = await request<unknown>(taskPath("/instance"), {
+        headers: daemonHeaders(opts?.daemonId),
+        signal: opts?.signal,
+      });
       return normalizeKataInstance(result.body);
     },
 
     projects(opts) {
-      return fetchProjects(undefined, false, opts?.signal);
+      return fetchProjects(opts?.daemonId, opts?.daemonId !== undefined, opts?.signal);
     },
 
     async createProject(name) {
@@ -698,7 +701,7 @@ export function createKataTaskAPI(options: CreateKataTaskAPIOptions = {}): KataT
     },
 
     async events(query = {}, opts) {
-      const daemonId = await resolveOperationDaemonId(undefined, true);
+      const daemonId = await resolveOperationDaemonId(opts?.daemonId, true);
 
       async function fetchPage(afterID: number | undefined, pageLimit: number): Promise<KataTaskEventsResponse> {
         const params = new URLSearchParams();
@@ -817,8 +820,11 @@ export function createKataTaskAPI(options: CreateKataTaskAPIOptions = {}): KataT
       return normalizeMoveResponse(result.body, result.headers);
     },
 
-    async recurrences(projectID) {
-      const result = await request<unknown>(taskPath(`/projects/${projectID}/recurrences`));
+    async recurrences(projectID, opts) {
+      const result = await request<unknown>(taskPath(`/projects/${projectID}/recurrences`), {
+        headers: daemonHeaders(opts?.daemonId),
+        signal: opts?.signal,
+      });
       return normalizeKataRecurrences(result.body);
     },
 

--- a/frontend/src/lib/api/kata/taskTypes.ts
+++ b/frontend/src/lib/api/kata/taskTypes.ts
@@ -381,10 +381,15 @@ export interface KataTaskIssuesQuery {
   area?: string | undefined;
 }
 
+export interface KataTaskRequestOptions {
+  daemonId?: string | undefined;
+  signal?: AbortSignal | undefined;
+}
+
 export interface KataTaskAPI {
   bindWorkflowDaemon?(daemonId?: string): void;
-  instance(opts?: { signal?: AbortSignal }): Promise<KataInstanceResponse>;
-  projects(opts?: { signal?: AbortSignal }): Promise<KataProjectsResponse>;
+  instance(opts?: KataTaskRequestOptions): Promise<KataInstanceResponse>;
+  projects(opts?: KataTaskRequestOptions): Promise<KataProjectsResponse>;
   createProject(name: string): Promise<KataProjectSummary>;
   renameProject(projectID: number, name: string): Promise<KataProjectSummary>;
   patchProjectMetadata(
@@ -399,19 +404,19 @@ export interface KataTaskAPI {
     draft: KataTaskCreateDraft,
     idempotencyKey?: string | undefined,
   ): Promise<KataTaskMutationResponse>;
-  issues(query: KataTaskIssuesQuery, opts?: { daemonId?: string; signal?: AbortSignal }): Promise<KataTaskViewResponse>;
-  search(
-    filters: KataTaskSearchFilters,
-    opts?: { daemonId?: string; signal?: AbortSignal },
-  ): Promise<KataTaskSearchResponse>;
-  issue(uid: string, opts?: { daemonId?: string; pinned?: boolean; signal?: AbortSignal }): Promise<KataTaskDetail>;
+  issues(query: KataTaskIssuesQuery, opts?: KataTaskRequestOptions): Promise<KataTaskViewResponse>;
+  search(filters: KataTaskSearchFilters, opts?: KataTaskRequestOptions): Promise<KataTaskSearchResponse>;
+  issue(uid: string, opts?: KataTaskRequestOptions & { pinned?: boolean | undefined }): Promise<KataTaskDetail>;
   reachableGraph(
     projectID: number,
     ref: string,
     query?: KataReachableGraphQuery,
     opts?: { daemonId?: string; signal?: AbortSignal },
   ): Promise<KataReachableGraphResponse>;
-  events(query?: KataTaskEventsQuery, opts?: { signal?: AbortSignal }): Promise<KataTaskEventsResponse>;
+  events(
+    query?: KataTaskEventsQuery,
+    opts?: KataTaskRequestOptions & { signal?: AbortSignal },
+  ): Promise<KataTaskEventsResponse>;
   addComment(target: KataTaskMutationTarget, actor: string, body: string): Promise<KataTaskMutationResponse>;
   addLabel(target: KataTaskMutationTarget, actor: string, label: string): Promise<KataTaskMutationResponse>;
   removeLabel(target: KataTaskMutationTarget, actor: string, label: string): Promise<KataTaskMutationResponse>;
@@ -441,7 +446,7 @@ export interface KataTaskAPI {
     toProjectUID: string,
     ifMatch: string,
   ): Promise<KataTaskMoveResponse>;
-  recurrences(projectID: number): Promise<KataRecurrencesResponse>;
+  recurrences(projectID: number, opts?: KataTaskRequestOptions): Promise<KataRecurrencesResponse>;
   createRecurrence(projectID: number, input: KataCreateRecurrenceInput): Promise<KataRecurrenceResponse>;
   showRecurrence(projectID: number, recurrenceUID: string): Promise<KataRecurrenceResponse>;
   patchRecurrence(

--- a/frontend/src/lib/components/kata/KataIssueList.svelte
+++ b/frontend/src/lib/components/kata/KataIssueList.svelte
@@ -397,20 +397,18 @@
 
   onDestroy(cancelPendingKeyboardSelect);
 
-  function clearTemporaryReveal(preserveExpansion = false) {
+  function clearTemporaryReveal() {
     if (revealOwnedExpansionUIDs.size > 0) {
-      if (!preserveExpansion) {
-        expanded = Object.fromEntries(
-          Object.entries(expanded).filter(([uid]) => !revealOwnedExpansionUIDs.has(uid)),
-        );
-      }
+      expanded = Object.fromEntries(
+        Object.entries(expanded).filter(([uid]) => !revealOwnedExpansionUIDs.has(uid)),
+      );
       revealOwnedExpansionUIDs = new Set();
     }
     if (temporaryRevealChain.length > 0) temporaryRevealChain = [];
   }
 
   function selectNow(issue: KataTaskSummary) {
-    clearTemporaryReveal(true);
+    clearTemporaryReveal();
     cancelPendingKeyboardSelect();
     onSelect(issue);
   }

--- a/frontend/src/lib/components/kata/KataIssueList.svelte
+++ b/frontend/src/lib/components/kata/KataIssueList.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onDestroy } from "svelte";
+  import { onDestroy, tick } from "svelte";
   import ChevronDownIcon from "@lucide/svelte/icons/chevron-down";
   import ChevronRightIcon from "@lucide/svelte/icons/chevron-right";
   import ChevronUpIcon from "@lucide/svelte/icons/chevron-up";
@@ -17,6 +17,12 @@
     type KataTaskSortKey,
   } from "../../features/kata/taskSort.js";
 
+  export interface KataIssueRevealRequest {
+    uid: string;
+    chain: readonly KataTaskSummary[];
+    generation: number;
+  }
+
   interface Props {
     currentView: KataCurrentView;
     scopeLabel?: string;
@@ -26,6 +32,7 @@
     statusFilter?: KataTaskSearchFilters["status"];
     resetGeneration?: number;
     navigationGeneration?: number;
+    revealRequest?: KataIssueRevealRequest | null;
     api?: KataTaskAPI;
     onSelect: (issue: KataTaskSummary) => void;
     onOpenGraph?: ((issue: KataTaskSummary) => void) | undefined;
@@ -41,6 +48,7 @@
     statusFilter = "all",
     resetGeneration = 0,
     navigationGeneration = 0,
+    revealRequest = null,
     api = undefined,
     onSelect,
     onOpenGraph = undefined,
@@ -57,6 +65,9 @@
   let tableBody: HTMLDivElement | null = $state(null);
   let childLoadGeneration = 0;
   let lastResetGeneration = $state<number | null>(null);
+  let temporaryRevealChain = $state<readonly KataTaskSummary[]>([]);
+  let revealOwnedExpansionUIDs = $state<ReadonlySet<string>>(new Set());
+  let lastRevealGeneration: number | null = null;
 
   // When the user is scoped to a single project, server-side groupings
   // like "Today / This Evening" feel like noise — they're a kata
@@ -102,10 +113,19 @@
   // so keep its labeled region instead of dropping it to a bare list.
   let shouldFlatten = $derived(!isProjectScoped && sort.key === "updated" && visibleGroups.length > 1);
   let globalSortedIssues = $derived(shouldFlatten ? sortKataTasks(visibleGroups.flatMap((group) => group.issues), sort) : []);
-  let visibleRootIssues = $derived.by(() => {
+  let ordinaryRootIssues = $derived.by(() => {
     if (isProjectScoped) return sortKataTasks(flatIssues, sort);
     if (shouldFlatten) return globalSortedIssues;
     return visibleGroups.flatMap((group) => sortKataTasks(group.issues, sort));
+  });
+  let hasTemporaryReveal = $derived(temporaryRevealChain.length > 0);
+  let visibleRootIssues = $derived.by(() => {
+    const chainUIDs = new Set(temporaryRevealChain.map((issue) => issue.uid));
+    const ordinary = ordinaryRootIssues.filter(
+      (issue) => !chainUIDs.has(issue.uid) || issue.uid === temporaryRevealChain[0]?.uid,
+    );
+    const root = temporaryRevealChain[0];
+    return root && !ordinary.some((issue) => issue.uid === root.uid) ? [root, ...ordinary] : ordinary;
   });
   let knownExpandableIssues = $derived.by(() => collectKnownExpandableIssues(visibleRootIssues));
   let hasExpandableVisibleRows = $derived(knownExpandableIssues.length > 0);
@@ -164,8 +184,13 @@
     return selectedIssueUID === issue.uid;
   }
 
+  function revealSuccessor(issue: KataTaskSummary): KataTaskSummary | undefined {
+    const index = temporaryRevealChain.findIndex((candidate) => candidate.uid === issue.uid);
+    return index >= 0 ? temporaryRevealChain[index + 1] : undefined;
+  }
+
   function hasChildren(issue: KataTaskSummary): boolean {
-    return (issue.child_counts?.total ?? 0) > 0;
+    return revealSuccessor(issue) !== undefined || (issue.child_counts?.total ?? 0) > 0;
   }
 
   function priorityLabel(priority: number | undefined): string | null {
@@ -243,16 +268,20 @@
 
   async function loadChildren(issue: KataTaskSummary, generation: number): Promise<KataTaskSummary[]> {
     if (!hasChildren(issue)) return [];
-    if (childrenByUID[issue.uid]) return visibleChildren(issue);
-    if (!api) return [];
+    const successor = revealSuccessor(issue);
+    if (childrenByUID[issue.uid] && !successor) return visibleChildren(issue);
+    if (!api) return visibleChildren(issue);
 
     loadingChildren = { ...loadingChildren, [issue.uid]: true };
     try {
       const detail = await api.issue(issue.uid);
       if (generation !== childLoadGeneration || !findIssueByUID(issue.uid)) return [];
       const children = detail.children ?? [];
+      onRememberTasks?.([detail.issue, ...children]);
       childrenByUID = { ...childrenByUID, [issue.uid]: children };
-      return children.filter(issueMatchesStatusFilter);
+      return visibleChildren(issue);
+    } catch {
+      return visibleChildren(issue);
     } finally {
       if (generation === childLoadGeneration) {
         loadingChildren = { ...loadingChildren, [issue.uid]: false };
@@ -268,6 +297,9 @@
   ) {
     if (!hasChildren(issue) || seen.has(issue.uid)) return;
     seen.add(issue.uid);
+    revealOwnedExpansionUIDs = new Set(
+      [...revealOwnedExpansionUIDs].filter((uid) => uid !== issue.uid),
+    );
     nextExpanded[issue.uid] = true;
     expanded = { ...expanded, ...nextExpanded };
 
@@ -298,6 +330,7 @@
     if (!hasAnyExpandedRows && !bulkExpanding) return;
     childLoadGeneration += 1;
     expanded = {};
+    revealOwnedExpansionUIDs = new Set();
     loadingChildren = {};
     bulkExpanding = false;
     cancelPendingKeyboardSelect();
@@ -307,6 +340,9 @@
     event.stopPropagation();
     const uid = issue.uid;
     const currentlyExpanded = expanded[uid] === true;
+    revealOwnedExpansionUIDs = new Set(
+      [...revealOwnedExpansionUIDs].filter((ownedUID) => ownedUID !== uid),
+    );
     expanded = { ...expanded, [uid]: !currentlyExpanded };
     if (!currentlyExpanded && !childrenByUID[uid] && api) {
       const generation = childLoadGeneration;
@@ -361,7 +397,20 @@
 
   onDestroy(cancelPendingKeyboardSelect);
 
+  function clearTemporaryReveal(preserveExpansion = false) {
+    if (revealOwnedExpansionUIDs.size > 0) {
+      if (!preserveExpansion) {
+        expanded = Object.fromEntries(
+          Object.entries(expanded).filter(([uid]) => !revealOwnedExpansionUIDs.has(uid)),
+        );
+      }
+      revealOwnedExpansionUIDs = new Set();
+    }
+    if (temporaryRevealChain.length > 0) temporaryRevealChain = [];
+  }
+
   function selectNow(issue: KataTaskSummary) {
+    clearTemporaryReveal(true);
     cancelPendingKeyboardSelect();
     onSelect(issue);
   }
@@ -485,6 +534,8 @@
   }
 
   function findIssueByUID(uid: string): KataTaskSummary | undefined {
+    const temporary = temporaryRevealChain.find((issue) => issue.uid === uid);
+    if (temporary) return temporary;
     for (const group of statusVisibleGroups) {
       const match = group.issues.find((issue) => issue.uid === uid);
       if (match) return match;
@@ -497,8 +548,46 @@
   }
 
   function visibleChildren(issue: KataTaskSummary): KataTaskSummary[] {
-    return (childrenByUID[issue.uid] ?? []).filter(issueMatchesStatusFilter);
+    const children = childrenByUID[issue.uid] ?? [];
+    const successor = revealSuccessor(issue);
+    const visible = children.filter(
+      (child) => issueMatchesStatusFilter(child) || child.uid === successor?.uid,
+    );
+    if (successor && !visible.some((child) => child.uid === successor.uid)) {
+      visible.push(successor);
+    }
+    return visible;
   }
+
+  $effect(() => {
+    if (!revealRequest) {
+      clearTemporaryReveal();
+      lastRevealGeneration = null;
+      return;
+    }
+    if (revealRequest.generation === lastRevealGeneration) return;
+    clearTemporaryReveal();
+    lastRevealGeneration = revealRequest.generation;
+    temporaryRevealChain = revealRequest.chain.length > 1 ? revealRequest.chain : [];
+    const generation = childLoadGeneration;
+    void (async () => {
+      const request = revealRequest;
+      for (const issue of request.chain.slice(0, -1)) {
+        if (generation !== childLoadGeneration || revealRequest?.generation !== request.generation) return;
+        if (expanded[issue.uid] !== true) {
+          expanded = { ...expanded, [issue.uid]: true };
+          revealOwnedExpansionUIDs = new Set([...revealOwnedExpansionUIDs, issue.uid]);
+        }
+        await loadChildren(issue, generation);
+        if (generation !== childLoadGeneration || revealRequest?.generation !== request.generation) return;
+      }
+      await tick();
+      if (generation !== childLoadGeneration || revealRequest?.generation !== request.generation) return;
+      tableBody?.querySelector<HTMLElement>(`button.row[data-uid="${request.uid}"]`)?.scrollIntoView({
+        block: "nearest",
+      });
+    })();
+  });
 
   $effect(() => {
     if (lastResetGeneration === null) {
@@ -508,6 +597,7 @@
     if (resetGeneration === lastResetGeneration) return;
     lastResetGeneration = resetGeneration;
     childLoadGeneration += 1;
+    clearTemporaryReveal();
     expanded = {};
     childrenByUID = {};
     loadingChildren = {};
@@ -522,6 +612,8 @@
   let lastNavigationGeneration: number | null = null;
   $effect(() => {
     if (lastNavigationGeneration !== null && navigationGeneration !== lastNavigationGeneration) {
+      childLoadGeneration += 1;
+      clearTemporaryReveal();
       cancelPendingKeyboardSelect();
     }
     lastNavigationGeneration = navigationGeneration;
@@ -654,8 +746,12 @@
         <div class="empty">No tasks</div>
       {/if}
 
-      {#if isProjectScoped}
-        {#each sortKataTasks(flatIssues, sort) as issue (issue.uid)}
+      {#if hasTemporaryReveal}
+        {#each visibleRootIssues as issue (issue.uid)}
+          {@render row(issue)}
+        {/each}
+      {:else if isProjectScoped}
+        {#each visibleRootIssues as issue (issue.uid)}
           {@render row(issue)}
         {/each}
       {:else if shouldFlatten}

--- a/frontend/src/lib/components/kata/KataIssueList.test.ts
+++ b/frontend/src/lib/components/kata/KataIssueList.test.ts
@@ -699,6 +699,503 @@ describe("KataIssueList", () => {
     expect(screen.getByRole("button", { name: /Parent task/ }).getAttribute("aria-expanded")).toBe("true");
   });
 
+  it("expands restored ancestors root-first and scrolls the selected row nearest", async () => {
+    const root = task({
+      uid: "issue-reveal-root",
+      short_id: "reveal-root",
+      qualified_id: "Finances#reveal-root",
+      title: "Root task",
+    });
+    const parent = task({
+      uid: "issue-reveal-parent",
+      short_id: "reveal-parent",
+      qualified_id: "Finances#reveal-parent",
+      title: "Parent task",
+      parent_short_id: root.short_id,
+    });
+    const child = task({
+      uid: "issue-reveal-child",
+      short_id: "reveal-child",
+      qualified_id: "Finances#reveal-child",
+      title: "Child task",
+      parent_short_id: parent.short_id,
+    });
+    const scrollIntoView = vi.fn();
+    vi.spyOn(Element.prototype, "scrollIntoView").mockImplementation(scrollIntoView);
+    const api = {
+      issue: vi.fn(async (uid: string) => (uid === root.uid ? apiDetail(root, [parent]) : apiDetail(parent, [child]))),
+    } as unknown as KataTaskAPI;
+
+    const { rerender } = render(KataIssueList, {
+      props: {
+        currentView: viewWithIssues([child]),
+        selectedIssueUID: child.uid,
+        loading: false,
+        api,
+        onSelect: () => {},
+      },
+    });
+
+    await rerender({
+      currentView: viewWithIssues([child]),
+      selectedIssueUID: child.uid,
+      loading: false,
+      api,
+      revealRequest: { uid: child.uid, chain: [root, parent, child], generation: 1 },
+      onSelect: () => {},
+    });
+
+    const rootRow = await screen.findByRole("button", { name: /Root task/ });
+    const childRow = screen.getByRole("button", { name: /Child task/ });
+    await waitFor(() => expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" }));
+    expect(rootRow.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByRole("button", { name: /Parent task/ }).getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getAllByRole("button", { name: /Child task/ })).toHaveLength(1);
+    expect(document.activeElement).not.toBe(childRow);
+  });
+
+  it("merges a restored reveal chain with authoritative siblings during expand all", async () => {
+    const root = task({
+      uid: "issue-reveal-root",
+      short_id: "reveal-root",
+      qualified_id: "Finances#reveal-root",
+      title: "Root task",
+      child_counts: { open: 2, total: 2 },
+    });
+    const restoredChild = task({
+      uid: "issue-reveal-child",
+      short_id: "reveal-child",
+      qualified_id: "Finances#reveal-child",
+      title: "Restored child",
+      child_counts: { open: 1, total: 1 },
+      parent_short_id: root.short_id,
+    });
+    const restoredGrandchild = task({
+      uid: "issue-reveal-restored-grandchild",
+      short_id: "reveal-restored-grandchild",
+      qualified_id: "Finances#reveal-restored-grandchild",
+      title: "Restored grandchild",
+      parent_short_id: restoredChild.short_id,
+    });
+    const sibling = task({
+      uid: "issue-reveal-sibling",
+      short_id: "reveal-sibling",
+      qualified_id: "Finances#reveal-sibling",
+      title: "Sibling task",
+      child_counts: { open: 1, total: 1 },
+      parent_short_id: root.short_id,
+    });
+    const grandchild = task({
+      uid: "issue-reveal-grandchild",
+      short_id: "reveal-grandchild",
+      qualified_id: "Finances#reveal-grandchild",
+      title: "Sibling grandchild",
+      parent_short_id: sibling.short_id,
+    });
+    const api = {
+      issue: vi.fn(async (uid: string) => {
+        if (uid === root.uid) return apiDetail(root, [sibling, restoredChild]);
+        if (uid === restoredChild.uid) return apiDetail(restoredChild, [restoredGrandchild]);
+        return apiDetail(sibling, [grandchild]);
+      }),
+    } as unknown as KataTaskAPI;
+
+    const { rerender } = render(KataIssueList, {
+      props: {
+        currentView: viewWithIssues([restoredChild]),
+        selectedIssueUID: restoredChild.uid,
+        loading: false,
+        api,
+        onSelect: () => {},
+      },
+    });
+
+    await rerender({
+      currentView: viewWithIssues([restoredChild]),
+      selectedIssueUID: restoredChild.uid,
+      loading: false,
+      api,
+      revealRequest: { uid: restoredChild.uid, chain: [root, restoredChild], generation: 1 },
+      onSelect: () => {},
+    });
+
+    expect(await screen.findByRole("button", { name: /Sibling task/ })).toBeTruthy();
+    expect(screen.getAllByRole("button", { name: /Restored child/ })).toHaveLength(1);
+    expect(api.issue).toHaveBeenCalledWith(root.uid);
+
+    await fireEvent.click(screen.getByRole("button", { name: "Expand all" }));
+
+    expect(await screen.findByRole("button", { name: /Sibling grandchild/ })).toBeTruthy();
+    expect(await screen.findByRole("button", { name: /Restored grandchild/ })).toBeTruthy();
+    expect(api.issue).toHaveBeenCalledWith(sibling.uid);
+    expect(api.issue).toHaveBeenCalledWith(restoredChild.uid);
+    expect(screen.getAllByRole("button", { name: /Restored child/ })).toHaveLength(1);
+
+    await rerender({
+      currentView: viewWithIssues([root]),
+      selectedIssueUID: null,
+      loading: false,
+      api,
+      revealRequest: null,
+      onSelect: () => {},
+    });
+    expect(screen.getByRole("button", { name: /Restored child/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Restored grandchild/ })).toBeTruthy();
+  });
+
+  it("keeps a contextual successor visible without admitting unrelated filtered siblings", async () => {
+    const root = task({
+      uid: "issue-filtered-reveal-root",
+      short_id: "filtered-reveal-root",
+      qualified_id: "Finances#filtered-reveal-root",
+      title: "Filtered reveal root",
+      child_counts: { open: 1, total: 3 },
+    });
+    const contextualChild = task({
+      uid: "issue-filtered-contextual-child",
+      short_id: "filtered-contextual-child",
+      qualified_id: "Finances#filtered-contextual-child",
+      title: "Closed contextual child",
+      status: "closed",
+      parent_short_id: root.short_id,
+    });
+    const openSibling = task({
+      uid: "issue-filtered-open-sibling",
+      short_id: "filtered-open-sibling",
+      qualified_id: "Finances#filtered-open-sibling",
+      title: "Open sibling",
+      parent_short_id: root.short_id,
+    });
+    const closedSibling = task({
+      uid: "issue-filtered-closed-sibling",
+      short_id: "filtered-closed-sibling",
+      qualified_id: "Finances#filtered-closed-sibling",
+      title: "Unrelated closed sibling",
+      status: "closed",
+      parent_short_id: root.short_id,
+    });
+    const api = apiWithDetail(root, [closedSibling, openSibling, contextualChild]);
+
+    const { rerender } = render(KataIssueList, {
+      props: {
+        currentView: viewWithIssues([root]),
+        selectedIssueUID: contextualChild.uid,
+        loading: false,
+        statusFilter: "open",
+        api,
+        onSelect: () => {},
+      },
+    });
+
+    await rerender({
+      currentView: viewWithIssues([root]),
+      selectedIssueUID: contextualChild.uid,
+      loading: false,
+      statusFilter: "open",
+      api,
+      revealRequest: {
+        uid: contextualChild.uid,
+        chain: [root, contextualChild],
+        generation: 1,
+      },
+      onSelect: () => {},
+    });
+
+    expect(await screen.findByRole("button", { name: /Closed contextual child/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Open sibling/ })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Unrelated closed sibling/ })).toBeNull();
+  });
+
+  it("drops a synthetic reveal successor and its owned expansion after reveal cleanup", async () => {
+    const root = task({
+      uid: "issue-reveal-root-cleanup",
+      short_id: "reveal-root-cleanup",
+      qualified_id: "Finances#reveal-root-cleanup",
+      title: "Cleanup root",
+      child_counts: { open: 1, total: 1 },
+    });
+    const restoredChild = task({
+      uid: "issue-reveal-child-cleanup",
+      short_id: "reveal-child-cleanup",
+      qualified_id: "Finances#reveal-child-cleanup",
+      title: "Temporary restored child",
+      parent_short_id: root.short_id,
+    });
+    const api = apiWithDetail(root, []);
+
+    const { rerender } = render(KataIssueList, {
+      props: {
+        currentView: viewWithIssues([restoredChild]),
+        selectedIssueUID: restoredChild.uid,
+        loading: false,
+        api,
+        onSelect: () => {},
+      },
+    });
+
+    await rerender({
+      currentView: viewWithIssues([restoredChild]),
+      selectedIssueUID: restoredChild.uid,
+      loading: false,
+      api,
+      revealRequest: { uid: restoredChild.uid, chain: [root, restoredChild], generation: 1 },
+      onSelect: () => {},
+    });
+    expect(await screen.findByRole("button", { name: /Temporary restored child/ })).toBeTruthy();
+
+    await rerender({
+      currentView: viewWithIssues([root]),
+      selectedIssueUID: null,
+      loading: false,
+      api,
+      revealRequest: null,
+      onSelect: () => {},
+    });
+
+    await waitFor(() => expect(screen.queryByRole("button", { name: /Temporary restored child/ })).toBeNull());
+    expect(screen.getByRole("button", { name: /Cleanup root/ }).getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("releases the previous reveal expansion when a newer chain supersedes it", async () => {
+    const oldRoot = task({
+      uid: "issue-old-reveal-root",
+      short_id: "old-reveal-root",
+      qualified_id: "Finances#old-reveal-root",
+      title: "Old reveal root",
+      child_counts: { open: 1, total: 1 },
+    });
+    const oldChild = task({
+      uid: "issue-old-reveal-child",
+      short_id: "old-reveal-child",
+      qualified_id: "Finances#old-reveal-child",
+      title: "Old reveal child",
+      parent_short_id: oldRoot.short_id,
+    });
+    const newRoot = task({
+      uid: "issue-new-reveal-root",
+      short_id: "new-reveal-root",
+      qualified_id: "Finances#new-reveal-root",
+      title: "New reveal root",
+      child_counts: { open: 1, total: 1 },
+    });
+    const newChild = task({
+      uid: "issue-new-reveal-child",
+      short_id: "new-reveal-child",
+      qualified_id: "Finances#new-reveal-child",
+      title: "New reveal child",
+      parent_short_id: newRoot.short_id,
+    });
+    const api = {
+      issue: vi.fn(async (uid: string) =>
+        uid === oldRoot.uid ? apiDetail(oldRoot, [oldChild]) : apiDetail(newRoot, [newChild]),
+      ),
+    } as unknown as KataTaskAPI;
+
+    const { rerender } = render(KataIssueList, {
+      props: {
+        currentView: viewWithIssues([oldRoot, newRoot]),
+        selectedIssueUID: oldChild.uid,
+        loading: false,
+        api,
+        onSelect: () => {},
+      },
+    });
+
+    await rerender({
+      currentView: viewWithIssues([oldRoot, newRoot]),
+      selectedIssueUID: oldChild.uid,
+      loading: false,
+      api,
+      revealRequest: { uid: oldChild.uid, chain: [oldRoot, oldChild], generation: 1 },
+      onSelect: () => {},
+    });
+    expect(await screen.findByRole("button", { name: /Old reveal child/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Old reveal root/ }).getAttribute("aria-expanded")).toBe("true");
+
+    await rerender({
+      currentView: viewWithIssues([oldRoot, newRoot]),
+      selectedIssueUID: newChild.uid,
+      loading: false,
+      api,
+      revealRequest: { uid: newChild.uid, chain: [newRoot, newChild], generation: 2 },
+      onSelect: () => {},
+    });
+
+    expect(await screen.findByRole("button", { name: /New reveal child/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Old reveal root/ }).getAttribute("aria-expanded")).toBe("false");
+    expect(screen.getByRole("button", { name: /New reveal root/ }).getAttribute("aria-expanded")).toBe("true");
+    expect(screen.queryByRole("button", { name: /Old reveal child/ })).toBeNull();
+  });
+
+  it("preserves a user-owned expansion when reveal cleanup crosses the same chain", async () => {
+    const root = task({
+      uid: "issue-user-expanded-root",
+      short_id: "user-expanded-root",
+      qualified_id: "Finances#user-expanded-root",
+      title: "User expanded root",
+      child_counts: { open: 1, total: 1 },
+    });
+    const child = task({
+      uid: "issue-user-expanded-child",
+      short_id: "user-expanded-child",
+      qualified_id: "Finances#user-expanded-child",
+      title: "User expanded child",
+      parent_short_id: root.short_id,
+    });
+    const api = apiWithDetail(root, [child]);
+
+    const { rerender } = render(KataIssueList, {
+      props: {
+        currentView: viewWithIssues([root]),
+        selectedIssueUID: null,
+        loading: false,
+        api,
+        onSelect: () => {},
+      },
+    });
+
+    const rootRow = screen.getByRole("button", { name: /User expanded root/ });
+    await fireEvent.keyDown(rootRow, { key: "ArrowRight" });
+    expect(await screen.findByRole("button", { name: /User expanded child/ })).toBeTruthy();
+
+    await rerender({
+      currentView: viewWithIssues([root]),
+      selectedIssueUID: child.uid,
+      loading: false,
+      api,
+      revealRequest: { uid: child.uid, chain: [root, child], generation: 1 },
+      onSelect: () => {},
+    });
+    await rerender({
+      currentView: viewWithIssues([root]),
+      selectedIssueUID: null,
+      loading: false,
+      api,
+      revealRequest: null,
+      onSelect: () => {},
+    });
+
+    expect(screen.getByRole("button", { name: /User expanded root/ }).getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByRole("button", { name: /User expanded child/ })).toBeTruthy();
+  });
+
+  it("continues a seeded reveal chain when authoritative refresh fails", async () => {
+    const root = task({
+      uid: "issue-reveal-root-failure",
+      short_id: "reveal-root-failure",
+      qualified_id: "Finances#reveal-root-failure",
+      title: "Fallback root",
+    });
+    const child = task({
+      uid: "issue-reveal-child-failure",
+      short_id: "reveal-child-failure",
+      qualified_id: "Finances#reveal-child-failure",
+      title: "Fallback child",
+      parent_short_id: root.short_id,
+    });
+    const api = {
+      issue: vi.fn(async () => {
+        throw new Error("child refresh failed");
+      }),
+    } as unknown as KataTaskAPI;
+
+    const { rerender } = render(KataIssueList, {
+      props: {
+        currentView: viewWithIssues([child]),
+        selectedIssueUID: child.uid,
+        loading: false,
+        api,
+        onSelect: () => {},
+      },
+    });
+
+    await rerender({
+      currentView: viewWithIssues([child]),
+      selectedIssueUID: child.uid,
+      loading: false,
+      api,
+      revealRequest: { uid: child.uid, chain: [root, child], generation: 1 },
+      onSelect: () => {},
+    });
+
+    const rootRow = await screen.findByRole("button", { name: /Fallback root/ });
+    expect(await screen.findByRole("button", { name: /Fallback child/ })).toBeTruthy();
+    expect(rootRow.getAttribute("aria-expanded")).toBe("true");
+    expect(api.issue).toHaveBeenCalledWith(root.uid);
+  });
+
+  it("keeps group headings while scrolling to a restored top-level task", async () => {
+    const scrollIntoView = vi.fn();
+    vi.spyOn(Element.prototype, "scrollIntoView").mockImplementation(scrollIntoView);
+
+    const { rerender } = render(KataIssueList, {
+      props: {
+        currentView,
+        selectedIssueUID: baseIssues[0]!.uid,
+        loading: false,
+        onSelect: () => {},
+      },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: /Sort by Priority/ }));
+
+    await rerender({
+      currentView,
+      selectedIssueUID: baseIssues[0]!.uid,
+      loading: false,
+      revealRequest: { uid: baseIssues[0]!.uid, chain: [baseIssues[0]!], generation: 1 },
+      onSelect: () => {},
+    });
+
+    await waitFor(() => expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" }));
+    expect(screen.getByRole("heading", { level: 3, name: /^Overdue\s+1$/ })).toBeTruthy();
+    expect(screen.getByRole("heading", { level: 3, name: /^Today\s+1$/ })).toBeTruthy();
+  });
+
+  it("keeps a restored nested row visible after selecting it", async () => {
+    const parent = task({
+      uid: "issue-reveal-parent",
+      short_id: "reveal-parent",
+      qualified_id: "Finances#reveal-parent",
+      title: "Parent task",
+      child_counts: { open: 1, total: 1 },
+    });
+    const child = task({
+      uid: "issue-reveal-child",
+      short_id: "reveal-child",
+      qualified_id: "Finances#reveal-child",
+      title: "Child task",
+      parent_short_id: parent.short_id,
+    });
+    const onSelect = vi.fn();
+    const api = apiWithDetail(parent, [child]);
+
+    const { rerender } = render(KataIssueList, {
+      props: {
+        currentView: viewWithIssues([parent, child]),
+        selectedIssueUID: child.uid,
+        loading: false,
+        api,
+        onSelect,
+      },
+    });
+
+    await rerender({
+      currentView: viewWithIssues([parent, child]),
+      selectedIssueUID: child.uid,
+      loading: false,
+      api,
+      revealRequest: { uid: child.uid, chain: [parent, child], generation: 1 },
+      onSelect,
+    });
+
+    const childRow = await screen.findByRole("button", { name: /Child task/ });
+    await fireEvent.click(childRow);
+
+    await waitFor(() => expect(onSelect).toHaveBeenCalledWith(child));
+    expect(screen.getByRole("button", { name: /Child task/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Parent task/ }).getAttribute("aria-expanded")).toBe("true");
+  });
+
   it("ignores stale child loads that finish after the list resets", async () => {
     const parent = task({
       uid: "issue-parent",

--- a/frontend/src/lib/components/kata/KataIssueList.test.ts
+++ b/frontend/src/lib/components/kata/KataIssueList.test.ts
@@ -1151,7 +1151,7 @@ describe("KataIssueList", () => {
     expect(screen.getByRole("heading", { level: 3, name: /^Today\s+1$/ })).toBeTruthy();
   });
 
-  it("keeps a restored nested row visible after selecting it", async () => {
+  it("clears reveal-owned expansion after ordinary row selection", async () => {
     const parent = task({
       uid: "issue-reveal-parent",
       short_id: "reveal-parent",
@@ -1192,8 +1192,8 @@ describe("KataIssueList", () => {
     await fireEvent.click(childRow);
 
     await waitFor(() => expect(onSelect).toHaveBeenCalledWith(child));
-    expect(screen.getByRole("button", { name: /Child task/ })).toBeTruthy();
-    expect(screen.getByRole("button", { name: /Parent task/ }).getAttribute("aria-expanded")).toBe("true");
+    await waitFor(() => expect(screen.queryByRole("button", { name: /Child task/ })).toBeNull());
+    expect(screen.getByRole("button", { name: /Parent task/ }).getAttribute("aria-expanded")).toBe("false");
   });
 
   it("ignores stale child loads that finish after the list resets", async () => {

--- a/frontend/src/lib/components/shared/QuickCapture.svelte
+++ b/frontend/src/lib/components/shared/QuickCapture.svelte
@@ -5,11 +5,12 @@
 
   interface Props {
     open: boolean;
+    disabled?: boolean | undefined;
     onClose: () => void;
     onSubmit: (title: string) => void | Promise<void>;
   }
 
-  let { open, onClose, onSubmit }: Props = $props();
+  let { open, disabled = false, onClose, onSubmit }: Props = $props();
 
   let title = $state("");
   let pending = $state(false);
@@ -23,7 +24,7 @@
 
   async function submit(): Promise<void> {
     const value = title.trim();
-    if (!value || pending) return;
+    if (!value || pending || disabled) return;
     pending = true;
     try {
       await onSubmit(value);
@@ -57,7 +58,7 @@
       placeholder="Task title"
       bind:value={title}
       onkeydown={handleKeydown}
-      disabled={pending}
+      disabled={pending || disabled}
     />
   </form>
   {#snippet footer()}
@@ -66,7 +67,7 @@
       class="modal-btn modal-btn-primary"
       type="button"
       onclick={submit}
-      disabled={pending || title.trim().length === 0}
+      disabled={disabled || pending || title.trim().length === 0}
     >
       <PlusIcon size={12} strokeWidth={2} />
       <span>Capture</span>

--- a/frontend/src/lib/features/kata/KataDaemonSwitcher.svelte
+++ b/frontend/src/lib/features/kata/KataDaemonSwitcher.svelte
@@ -34,14 +34,14 @@
   }
 
   function daemonStatusLabel(daemon: KataDaemonInfo): string {
-    if (daemon.id === active?.id && activeStatusLabel) return activeStatusLabel;
+    if (daemon.id === displayId && activeStatusLabel) return activeStatusLabel;
     if (daemon.health === "connected") return "connected";
     if (daemon.health === "auth_required") return "needs auth";
     return "unreachable";
   }
 
   function daemonStatusTone(daemon: KataDaemonInfo): string {
-    if (daemon.id === active?.id && activeStatusTone) return activeStatusTone;
+    if (daemon.id === displayId && activeStatusTone) return activeStatusTone;
     return daemon.health;
   }
 </script>

--- a/frontend/src/lib/features/kata/KataWorkspace.svelte
+++ b/frontend/src/lib/features/kata/KataWorkspace.svelte
@@ -37,7 +37,20 @@
     setKataDaemonRoster,
   } from "../../stores/active-kata-daemon.svelte.js";
   import { navigate } from "../../stores/router.svelte.js";
-  import { createKataWorkspaceStore } from "../../stores/kata-workspace.svelte.js";
+  import {
+    createKataWorkspaceStore,
+    defaultKataTaskSearchFilters,
+    KataEventCursorSyncError,
+    type KataWorkspaceStoreSnapshot,
+  } from "../../stores/kata-workspace.svelte.js";
+  import { KataTaskAPIError } from "../../api/kata/taskClient.js";
+  import {
+    clearKataWorkspaceSelection,
+    clearKataWorkspaceState,
+    loadKataWorkspaceState,
+    saveKataWorkspaceState,
+    type KataPersistedWorkspaceState,
+  } from "./kataWorkspacePersistence.js";
   import KataDaemonSwitcher from "./KataDaemonSwitcher.svelte";
   import KataReachableGraph from "./KataReachableGraph.svelte";
   import KataRecurrenceDialogs from "./KataRecurrenceDialogs.svelte";
@@ -67,6 +80,29 @@
     view: KataTaskViewName | null;
     scope: string | null;
     issue: string | null;
+  }
+
+  type RestoreSource = "url" | "persisted" | "default";
+  type RestorePolicy = "daemon-generation" | "route-authoritative";
+
+  interface RestoreSources {
+    view: RestoreSource;
+    scope: RestoreSource;
+    selection: RestoreSource;
+  }
+
+  interface RestorePersistenceDelta {
+    clearState?: boolean;
+    clearSelection?: boolean;
+  }
+
+  interface RestoreResult {
+    route: KataRouteSnapshot;
+    sources: RestoreSources;
+    restoredSelectionUID: string | null;
+    startEventStream: boolean;
+    persistenceDelta: RestorePersistenceDelta | undefined;
+    ancestorReveal: { uid: string; chain: readonly KataTaskSummary[] } | null;
   }
 
   interface KataRecurrenceDialogController {
@@ -101,17 +137,26 @@
   let viewWorkCount = $state(0);
   let error = $state<string | null>(null);
   let viewError = $state<string | null>(null);
+  let cursorCatchupError = $state<string | null>(null);
+  let cursorCatchupRetry = $state<(() => Promise<void>) | null>(null);
+  let cursorCatchupRetrying = $state(false);
+  let cursorCatchupGeneration = 0;
+  let cursorCatchupMounted = true;
+  let workspaceMounted = true;
   let lastTaskError: string | null = null;
   let unlinkBusyIds = $state<ReadonlySet<number>>(new Set());
   let daemonInfos = $state.raw<KataDaemonInfo[]>([]);
   let switchingDaemon = $state(false);
   let terminalDaemonFailure = $state(false);
+  let terminalRecovery = $state<(() => Promise<void>) | null>(null);
+  let terminalRecovering = $state(false);
   let captureOpen = $state(false);
   let listResetGeneration = $state(0);
   let checklistRevealed = $state(false);
   let pendingMoveIssueUIDs = $state.raw<ReadonlySet<string>>(new Set());
   let recurrenceDialogs = $state<KataRecurrenceDialogController | null>(null);
   let workspaceActionBusy = $state(false);
+  let workspaceOwnershipPending = $state(true);
   let listMode = $state<ListMode>("tasks");
   let graphSourceIssue = $state.raw<KataTaskSummary | null>(null);
   const store = createKataWorkspaceStore({ api: untrack(() => api) });
@@ -135,6 +180,29 @@
   // the list only remounts after the new view's data arrives, which is
   // too late for a selection released mid-transition.
   let navigationEpoch = $state(0);
+  let restoredSelectionUID = $state<string | null>(null);
+  let pendingDirectGraphSelectionUID: string | null = null;
+  let restoreRetry = $state<(() => Promise<void>) | null>(null);
+  let restoreRetryRouteSignature = $state<string | null>(null);
+  let restoreRetrying = $state(false);
+  let restoreError = $state<string | null>(null);
+  let ancestorRevealRetry = $state<(() => Promise<void>) | null>(null);
+  let ancestorRevealRetryRouteSignature = $state<string | null>(null);
+  let ancestorRevealError = $state<string | null>(null);
+  let provisionalRoutedDaemon = $state<string | null>(null);
+  let routedRestoreFallbackDaemon = $state<string | undefined>(undefined);
+  let routedRestoreGeneration = 0;
+  let routedRestoreRouteSignature: string | null = null;
+  let routedFallbackRecovering = $state(false);
+  let routedFallbackRequestedDaemon: string | null = null;
+  let switchGeneration = 0;
+  let switchRouteSignature: string | null = null;
+  let switchPreviousCursorCatchupError: string | null = null;
+  let switchPreviousCursorCatchupRetry: (() => Promise<void>) | null = null;
+  let switchPreviousEventStreamRunning = false;
+  let eventStreamRunning = false;
+  let revealRequest = $state<{ uid: string; chain: readonly KataTaskSummary[]; generation: number } | null>(null);
+  let revealGeneration = 0;
   const layoutStorageKey = "middleman:kata:task-layout/v1";
   const defaultSplitSizes: Record<SplitOrientation, number> = {
     vertical: 420,
@@ -144,29 +212,54 @@
   let splitSizes = $state<Record<SplitOrientation, number>>({ ...defaultSplitSizes });
   const activeSplitSize = $derived(splitSizes[splitOrientation]);
   const graphLayoutDirection = $derived(graphLayoutDirectionForSplit(splitOrientation));
-  const activeKataDaemonId = $derived(
-    store.daemonId ??
-      getActiveKataDaemon() ??
+  const acceptedKataDaemonId = $derived(
+    getActiveKataDaemon() ??
       getDefaultKataDaemon() ??
       daemonInfos.find((daemon) => daemon.default)?.id ??
       daemonInfos[0]?.id,
+  );
+  const activeKataDaemonId = $derived(store.daemonId ?? acceptedKataDaemonId);
+  const requestKataDaemonId = $derived(store.daemonId ?? activeKataDaemonId);
+  const workspaceReadOnly = $derived(
+    provisionalRoutedDaemon !== null ||
+      routedFallbackRecovering ||
+      restoreRetry !== null ||
+      terminalDaemonFailure,
   );
   const routedDaemonError = $derived(
     requestedDaemonId && daemonInfos.length > 0 && !daemonInfos.some((daemon) => daemon.id === requestedDaemonId)
       ? `Kata daemon ${requestedDaemonId} is not configured.`
       : null,
   );
+  const workspaceActionsBlocked = $derived(
+    workspaceOwnershipPending ||
+      switchingDaemon ||
+      workspaceReadOnly ||
+      restoreRetrying ||
+      terminalRecovering ||
+      routedDaemonError !== null ||
+      workspaceActionBusy,
+  );
   const listStatusFilter = $derived<KataTaskSearchFilters["status"]>(
     store.currentView.name === "logbook" ? "all" : store.searchFilters.status,
   );
   const eventStream = createKataEventStreamController({
-    getDaemonId: () => store.daemonId ?? activeKataDaemonId,
+    getDaemonId: () => requestKataDaemonId,
     getLastEventID: () => store.eventCursor,
     onOpen: () => {
       store.connection = { status: "online" };
     },
     onMessage: async (message) => {
-      await trackViewWork(() => store.applyEventStreamMessage(message));
+      await trackViewWork(async () => {
+        const scope = captureCursorCatchupScope();
+        const selectedUID = store.selectedIssue?.issue.uid ?? null;
+        const refreshed = await store.applyEventStreamMessage(message, {
+          shouldApply: () => isCursorCatchupScopeCurrent(scope),
+        });
+        if (refreshed && isCursorCatchupScopeCurrent(scope)) {
+          reconcilePersistedSelection(false, selectedUID);
+        }
+      });
     },
     onReset: () => {
       resetIssueExpansion();
@@ -184,6 +277,10 @@
   const workspaceTarget = $derived(
     store.selectedIssue?.workspace_target?.available ? store.selectedIssue.workspace_target : null,
   );
+  // A daemon switch is transactional. Catalog data loaded while the target
+  // is still provisional must not repaint either daemon's project controls.
+  const visibleProjects = $derived(switchingDaemon ? [] : store.projects);
+  const visibleAreas = $derived(switchingDaemon ? [] : store.areas);
 
   const systemViews = [
     { name: "inbox", label: "Inbox" },
@@ -276,6 +373,458 @@
     }
   }
 
+  function projectScopeExists(scopeUID: string, workspaceStore = store): boolean {
+    return workspaceStore.projects.some((project) => project.uid === scopeUID);
+  }
+
+  function effectiveViewName(view: KataTaskViewName): KataTaskViewName {
+    return view === "all" ? "all" : view;
+  }
+
+  function canonicalRoute(
+    view: KataTaskViewName,
+    scopeUID: string | null,
+    issueUID: string | null,
+    preserveScopedView = false,
+  ): KataRouteSnapshot {
+    return {
+      view: view === "all" || (scopeUID !== null && !preserveScopedView) ? null : view,
+      scope: scopeUID,
+      issue: issueUID,
+    };
+  }
+
+  function statusMatches(issue: KataTaskSummary, status: KataTaskSearchFilters["status"]): boolean {
+    return status === "all" || issue.status === status;
+  }
+
+  function isDefinitiveRestoreFailure(error: unknown): boolean {
+    return error instanceof KataTaskAPIError && error.status === 404;
+  }
+
+  async function resolveRestoredAncestorChain(
+    selected: KataTaskSummary,
+    daemonID: string,
+    generation: number,
+    shouldApply: () => boolean,
+    workspaceStore = store,
+  ): Promise<readonly KataTaskSummary[] | null | undefined> {
+    const chain = [selected];
+    const visited = new Set([selected.uid]);
+    let current = selected;
+    for (let depth = 0; current.parent; depth += 1) {
+      if (generation !== navigationGeneration || !shouldApply()) return undefined;
+      if (depth >= 32 || visited.has(current.parent.uid)) return null;
+      visited.add(current.parent.uid);
+      let detail: KataTaskDetail;
+      try {
+        detail = await workspaceStore.api.issue(current.parent.uid, { daemonId: daemonID });
+      } catch (error) {
+        if (isDefinitiveRestoreFailure(error)) return null;
+        throw error;
+      }
+      if (generation !== navigationGeneration || !shouldApply()) return undefined;
+      if (!detail.issue) return null;
+      workspaceStore.rememberTasks([detail.issue, ...(detail.children ?? [])]);
+      current = detail.issue;
+      chain.push(current);
+    }
+    return chain.reverse();
+  }
+
+  async function revealSelectedAncestors(
+    selected: KataTaskSummary,
+    daemonID: string,
+    shouldApply: () => boolean,
+    workspaceStore = store,
+  ): Promise<void> {
+    const retrySignature = fullRouteSignature();
+    try {
+      const restoreGeneration = navigationGeneration;
+      const chain = await resolveRestoredAncestorChain(
+        selected,
+        daemonID,
+        restoreGeneration,
+        shouldApply,
+        workspaceStore,
+      );
+      if (chain === undefined || restoreGeneration !== navigationGeneration || !shouldApply()) return;
+      ancestorRevealError = null;
+      ancestorRevealRetry = null;
+      ancestorRevealRetryRouteSignature = null;
+      if (chain) revealRequest = { uid: selected.uid, chain, generation: ++revealGeneration };
+    } catch (error) {
+      if (
+        !shouldApply() ||
+        (workspaceStore.daemonId !== undefined && workspaceStore.daemonId !== daemonID) ||
+        fullRouteSignature() !== retrySignature ||
+        workspaceStore.selectedIssue?.issue.uid !== selected.uid
+      ) {
+        return;
+      }
+      ancestorRevealError = kataRequestErrorMessage(error);
+      ancestorRevealRetryRouteSignature = retrySignature;
+      ancestorRevealRetry = async () => {
+        if (!shouldApply() || retrySignature !== fullRouteSignature()) return;
+        ancestorRevealError = null;
+        await revealSelectedAncestors(selected, daemonID, shouldApply, workspaceStore);
+      };
+    }
+  }
+
+  function synchronizeRestoredRoute(route: KataRouteSnapshot, restoredUID: string | null): void {
+    selectionFromRoute = route.issue !== null && route.issue === selectedIssueUID;
+    restoredSelectionUID = restoredUID;
+    // Restoration reconciles the current entry; it must not add a duplicate
+    // Kata entry that traps Back/Forward navigation inside the workspace.
+    onRouteStateChange?.(route, { replace: true });
+  }
+
+  function mergeRestorePersistenceDelta(
+    current: RestorePersistenceDelta | undefined,
+    next: RestorePersistenceDelta | undefined,
+  ): RestorePersistenceDelta | undefined {
+    if (!current) return next;
+    if (!next) return current;
+    const merged: RestorePersistenceDelta = {};
+    if (current.clearState || next.clearState) merged.clearState = true;
+    if (current.clearSelection || next.clearSelection) merged.clearSelection = true;
+    return merged;
+  }
+
+  function applyRestorePersistenceDelta(
+    daemonID: string,
+    delta: RestorePersistenceDelta | undefined,
+  ): void {
+    if (delta?.clearState) {
+      clearKataWorkspaceState(daemonID);
+    } else if (delta?.clearSelection) {
+      clearKataWorkspaceSelection(daemonID);
+    }
+  }
+
+  async function restoreKataWorkspaceState(
+    daemonID: string,
+    route: KataRouteSnapshot,
+    synchronizeRoute = true,
+    mutatePersistence = true,
+    selectDefault = false,
+    expectedRouteSignature: string | null = null,
+    shouldApply: () => boolean = () => true,
+    policy: RestorePolicy = "daemon-generation",
+    workspaceStore = store,
+  ): Promise<RestoreResult> {
+    let synchronizationSignature = expectedRouteSignature;
+    const synchronize = (restoredRoute: KataRouteSnapshot, restoredUID: string | null): void => {
+      if (
+        workspaceMounted &&
+        shouldApply() &&
+        synchronizeRoute &&
+        (synchronizationSignature === null || fullRouteSignature() === synchronizationSignature)
+      ) {
+        synchronizeRestoredRoute(restoredRoute, restoredUID);
+        synchronizationSignature = fullRouteSignatureFor(restoredRoute);
+      }
+    };
+    const persisted = daemonID ? loadKataWorkspaceState(daemonID) : null;
+    const inheritRouteFields = policy === "daemon-generation";
+    const hasExplicitScope = route.scope !== null;
+    const sources: RestoreSources = {
+      view: route.view ? "url" : inheritRouteFields && persisted ? "persisted" : "default",
+      scope:
+        hasExplicitScope
+          ? "url"
+          : inheritRouteFields && persisted?.filters.scope.kind === "project"
+            ? "persisted"
+            : "default",
+      selection: route.issue ? "url" : inheritRouteFields && persisted?.selectedIssueUID ? "persisted" : "default",
+    };
+    const defaults = defaultKataTaskSearchFilters();
+    let acceptedPersisted: KataPersistedWorkspaceState | null = persisted;
+    let persistenceDelta: RestorePersistenceDelta | undefined;
+    let ancestorReveal: RestoreResult["ancestorReveal"] = null;
+    let scopeUID = route.scope;
+    let view = route.view ?? (inheritRouteFields ? persisted?.view : undefined) ?? "all";
+    let issueUID = route.issue ?? (inheritRouteFields ? persisted?.selectedIssueUID : null) ?? null;
+    let filters: KataTaskSearchFilters = persisted
+      ? {
+          ...persisted.filters,
+          scope: inheritRouteFields ? persisted.filters.scope : { kind: "all" },
+        }
+      : defaults;
+
+    await workspaceStore.loadProjectCatalog(shouldApply);
+    if (!shouldApply()) {
+      return {
+        route,
+        sources,
+        restoredSelectionUID: null,
+        startEventStream: false,
+        persistenceDelta,
+        ancestorReveal: null,
+      };
+    }
+
+    if (scopeUID && !projectScopeExists(scopeUID, workspaceStore)) {
+      scopeUID = null;
+      sources.scope = "default";
+    }
+    if (acceptedPersisted?.filters.scope.kind === "project") {
+      const persistedScope = acceptedPersisted.filters.scope.project_uid;
+      if (!projectScopeExists(persistedScope, workspaceStore)) {
+        if (mutatePersistence && shouldApply()) clearKataWorkspaceState(daemonID);
+        else persistenceDelta = { clearState: true };
+        acceptedPersisted = null;
+        view = route.view ?? "all";
+        issueUID = route.issue;
+        filters = defaults;
+        sources.view = route.view ? "url" : "default";
+        sources.selection = route.issue ? "url" : "default";
+      } else if (inheritRouteFields && !hasExplicitScope && !scopeUID) {
+        scopeUID = persistedScope;
+        sources.scope = "persisted";
+      }
+    }
+
+    if (
+      !scopeUID &&
+      !route.scope &&
+      !route.view &&
+      !route.issue &&
+      acceptedPersisted === null &&
+      persisted !== null &&
+      mutatePersistence &&
+      shouldApply()
+    ) {
+      workspaceStore.resetToInertWorkspace();
+      const inertRoute = canonicalRoute("all", null, null);
+      synchronize(inertRoute, null);
+      return {
+        route: inertRoute,
+        sources,
+        restoredSelectionUID: null,
+        startEventStream: false,
+        persistenceDelta,
+        ancestorReveal: null,
+      };
+    }
+
+    if (acceptedPersisted === null) {
+      if (!shouldApply()) {
+        return {
+          route,
+          sources,
+          restoredSelectionUID: null,
+          startEventStream: false,
+          persistenceDelta,
+          ancestorReveal: null,
+        };
+      }
+      if (persisted !== null) {
+        if (scopeUID) {
+          await workspaceStore.updateSearchFilters(
+            { ...defaults, scope: { kind: "project", project_uid: scopeUID } },
+            { selectFirst: false, shouldApply },
+          );
+        } else {
+          await workspaceStore.openView(route.view ?? "all", { selectFirst: false, shouldApply });
+        }
+        const resetRoute = canonicalRoute(
+          route.view ?? "all",
+          scopeUID,
+          route.issue,
+          sources.view === "url",
+        );
+        synchronize(resetRoute, null);
+        return { route: resetRoute, sources, restoredSelectionUID: null, startEventStream: true, persistenceDelta, ancestorReveal: null };
+      }
+      await workspaceStore.bootstrap(route.view ?? "all", null, { selectFirst: selectDefault, shouldApply });
+      if (scopeUID && shouldApply()) {
+        await workspaceStore.updateSearchFilters(
+          { ...defaults, scope: { kind: "project", project_uid: scopeUID } },
+          { selectFirst: false, shouldApply },
+        );
+      }
+      const initialRoute = canonicalRoute(
+        route.view ?? "all",
+        scopeUID,
+        route.issue,
+        sources.view === "url",
+      );
+      synchronize(initialRoute, null);
+      return { route: initialRoute, sources, restoredSelectionUID: null, startEventStream: true, persistenceDelta, ancestorReveal: null };
+    }
+
+    if (scopeUID) {
+      filters = { ...filters, scope: { kind: "project", project_uid: scopeUID } };
+    } else {
+      filters = { ...filters, scope: { kind: "all" } };
+    }
+    if (route.view) view = route.view;
+
+    if (!shouldApply()) {
+      return {
+        route,
+        sources,
+        restoredSelectionUID: null,
+        startEventStream: false,
+        persistenceDelta,
+        ancestorReveal: null,
+      };
+    }
+    workspaceStore.clearSelection();
+    await workspaceStore.restoreViewAndFilters(effectiveViewName(view), filters, {
+      selectFirst: false,
+      shouldApply,
+    });
+    if (!shouldApply()) {
+      return {
+        route,
+        sources,
+        restoredSelectionUID: null,
+        startEventStream: false,
+        persistenceDelta,
+        ancestorReveal: null,
+      };
+    }
+
+    const canonical = canonicalRoute(view, scopeUID, null, sources.view === "url");
+    const rawIssues = workspaceStore.currentView.groups.flatMap((group) => group.issues);
+    const routedSelection = sources.selection === "url" ? issueUID : null;
+    const persistedSelection = sources.selection === "persisted" ? issueUID : null;
+    const effectiveStatus = view === "logbook" ? "all" : filters.status;
+    if (persistedSelection && !rawIssues.some((issue) => issue.uid === persistedSelection && statusMatches(issue, effectiveStatus))) {
+      if (mutatePersistence && shouldApply()) clearKataWorkspaceSelection(daemonID);
+      else persistenceDelta = mergeRestorePersistenceDelta(persistenceDelta, { clearSelection: true });
+      if (!shouldApply()) {
+        return {
+          route,
+          sources,
+          restoredSelectionUID: null,
+          startEventStream: false,
+          persistenceDelta,
+          ancestorReveal: null,
+        };
+      }
+      workspaceStore.clearSelection();
+      synchronize(canonical, null);
+      return { route: canonical, sources, restoredSelectionUID: null, startEventStream: true, persistenceDelta, ancestorReveal: null };
+    }
+
+    const select = async (): Promise<void> => {
+      if (
+        !shouldApply() ||
+        !issueUID ||
+        (workspaceStore.daemonId !== undefined && workspaceStore.daemonId !== daemonID)
+      ) {
+        return;
+      }
+      const retrying = restoreRetryRouteSignature !== null;
+      if (retrying && restoreRetryRouteSignature !== fullRouteSignature()) return;
+      try {
+        await workspaceStore.selectIssue(issueUID, { shouldApply });
+      } catch (error) {
+        if (!shouldApply()) return;
+        if (workspaceStore.daemonId !== undefined && workspaceStore.daemonId !== daemonID) return;
+        if (retrying && restoreRetryRouteSignature !== fullRouteSignature()) return;
+        workspaceStore.clearSelection();
+        const failureRoute = canonicalRoute(view, scopeUID, null, sources.view === "url");
+        if (isDefinitiveRestoreFailure(error)) {
+          if (sources.selection === "persisted") {
+            if (mutatePersistence && shouldApply()) clearKataWorkspaceSelection(daemonID);
+            else persistenceDelta = mergeRestorePersistenceDelta(persistenceDelta, { clearSelection: true });
+          }
+          restoreError = null;
+          restoreRetry = null;
+          restoreRetryRouteSignature = null;
+          synchronize(failureRoute, null);
+          return;
+        }
+        restoreError = kataRequestErrorMessage(error);
+        synchronize(failureRoute, null);
+        const retrySignature = fullRouteSignature();
+        restoreRetryRouteSignature = retrySignature;
+        restoreRetry = async () => {
+          if (retrySignature !== fullRouteSignature()) return;
+          restoreError = null;
+          await select();
+        };
+        return;
+      }
+
+      if (!shouldApply()) return;
+      if (workspaceStore.daemonId !== undefined && workspaceStore.daemonId !== daemonID) return;
+      if (retrying && restoreRetryRouteSignature !== fullRouteSignature()) return;
+      if (workspaceStore.selectedIssue?.issue.uid !== issueUID) {
+        workspaceStore.clearSelection();
+        if (sources.selection === "persisted") {
+          if (mutatePersistence && shouldApply()) clearKataWorkspaceSelection(daemonID);
+          else persistenceDelta = mergeRestorePersistenceDelta(persistenceDelta, { clearSelection: true });
+        }
+        synchronize(canonicalRoute(view, scopeUID, null, sources.view === "url"), null);
+        return;
+      }
+
+      const selectedRoute = { ...canonical, issue: issueUID };
+      synchronize(selectedRoute, sources.selection === "persisted" ? issueUID : null);
+      restoreError = null;
+      restoreRetry = null;
+      restoreRetryRouteSignature = null;
+      if (sources.selection === "persisted") {
+        const restoredIssue = workspaceStore.selectedIssue.issue;
+        workspaceStore.rememberTasks([restoredIssue, ...(workspaceStore.selectedIssue.children ?? [])]);
+        if (workspaceStore === store) {
+          void revealSelectedAncestors(restoredIssue, daemonID, shouldApply, workspaceStore);
+        } else {
+          const chain = await resolveRestoredAncestorChain(
+            restoredIssue,
+            daemonID,
+            navigationGeneration,
+            shouldApply,
+            workspaceStore,
+          );
+          if (chain && shouldApply()) ancestorReveal = { uid: restoredIssue.uid, chain };
+        }
+      }
+    };
+
+    if (!shouldApply()) {
+      return {
+        route,
+        sources,
+        restoredSelectionUID: null,
+        startEventStream: false,
+        persistenceDelta,
+        ancestorReveal: null,
+      };
+    }
+    restoreError = null;
+    restoreRetry = null;
+    restoreRetryRouteSignature = null;
+    if (!routedSelection) await select();
+    if (!shouldApply()) {
+      return {
+        route,
+        sources,
+        restoredSelectionUID: null,
+        startEventStream: false,
+        persistenceDelta,
+        ancestorReveal: null,
+      };
+    }
+    if (!issueUID || routedSelection) synchronize({ ...canonical, issue: routedSelection }, null);
+    return {
+      route: workspaceStore.selectedIssue
+        ? { ...canonical, issue: workspaceStore.selectedIssue.issue.uid }
+        : { ...canonical, issue: routedSelection },
+      sources,
+      restoredSelectionUID,
+      startEventStream: true,
+      persistenceDelta,
+      ancestorReveal,
+    };
+  }
+
   onMount(() => {
     let cancelled = false;
     loadLayoutPrefs();
@@ -291,47 +840,224 @@
           daemons.map((daemon) => daemon.id),
           daemons.find((daemon) => daemon.default)?.id,
         );
-        const bootstrapRoute = currentRouteSnapshot();
-        const bootstrapViewName = bootstrapRoute.view ?? "all";
-        const bootstrapIssueUID = bootstrapRoute.issue;
-        const hasDaemonRoute = requestedDaemonId !== null;
-        routedDaemonId = daemons.some((daemon) => daemon.id === requestedDaemonId) ? requestedDaemonId : null;
+        const unknownRoutedDaemon = requestedDaemonId !== null && !daemons.some((daemon) => daemon.id === requestedDaemonId);
+        if (unknownRoutedDaemon) {
+          store.resetToInertWorkspace();
+          stopEventStream();
+          workspaceOwnershipPending = false;
+          return;
+        }
+        routedDaemonId = requestedDaemonId;
         if (routedDaemonId) {
           previousExplicitDaemon = getActiveKataDaemon();
+          routedRestoreFallbackDaemon = previousExplicitDaemon ?? getDefaultKataDaemon();
+          provisionalRoutedDaemon = routedDaemonId;
           store.bindDaemonForBootstrap(routedDaemonId);
         }
-        await store.bootstrap(
-          bootstrapViewName,
-          hasDaemonRoute ? null : bootstrapIssueUID,
-          { selectFirst: !hasDaemonRoute && bootstrapIssueUID !== null },
-        );
-        if (bootstrapRoute.scope) {
-          await loadRouteViewScope(bootstrapRoute.view, bootstrapRoute.scope);
-        }
-        await store.syncEventCursor();
-        if (routedDaemonId) {
-          setActiveKataDaemon(routedDaemonId);
-        }
-        const routedIssueUID = bootstrapIssueUID && store.selectedIssue?.issue.uid !== bootstrapIssueUID
-          ? bootstrapIssueUID
-          : null;
-        if (routedIssueUID) {
-          const selected = await runViewTask(() => store.selectIssue(routedIssueUID));
-          if (!selected) {
-            failedRouteSignature = fullRouteSignature();
+        const daemonID = routedDaemonId ?? activeKataDaemonId ?? "home";
+        if (!routedDaemonId) store.api.bindWorkflowDaemon?.(daemonID);
+        const finalizeRestoration = async (
+          restored: RestoreResult,
+          attemptedRoute: KataRouteSnapshot,
+          attemptedSignature: string,
+          catchUpCursor: boolean,
+          restoreGeneration: number,
+        ): Promise<void> => {
+          if (cancelled || (routedDaemonId !== null && !routedRestoreIsCurrent(restoreGeneration, attemptedSignature))) return;
+          let persistenceDelta = restored.persistenceDelta;
+          selectionFromRoute =
+            attemptedRoute.issue !== null && store.selectedIssue?.issue.uid === attemptedRoute.issue;
+          if (
+            attemptedRoute.issue !== null &&
+            currentRouteSnapshot().issue === attemptedRoute.issue &&
+            store.selectedIssue?.issue.uid !== attemptedRoute.issue
+          ) {
+            let selectionError: unknown;
+            const ok = await runViewTask(
+              async () => {
+                try {
+                  return await store.selectIssue(attemptedRoute.issue!, {
+                    shouldApply: () =>
+                      routedDaemonId === null ||
+                      routedRestoreIsCurrent(restoreGeneration, attemptedSignature),
+                  });
+                } catch (error) {
+                  selectionError = error;
+                  throw error;
+                }
+              },
+              "none",
+            );
+            if (cancelled || (routedDaemonId !== null && !routedRestoreIsCurrent(restoreGeneration, attemptedSignature))) return;
+            if (ok) {
+              selectionFromRoute = true;
+              if (store.selectedIssue) {
+                const restoredIssue = store.selectedIssue.issue;
+                store.rememberTasks([restoredIssue, ...(store.selectedIssue.children ?? [])]);
+                void revealSelectedAncestors(restoredIssue, daemonID, () =>
+                  routedDaemonId === null || routedRestoreIsCurrent(restoreGeneration, attemptedSignature),
+                );
+              }
+            } else if (
+              isDefinitiveRestoreFailure(selectionError) &&
+              currentRouteSnapshot().issue === attemptedRoute.issue
+            ) {
+              store.clearSelection();
+              selectionFromRoute = false;
+            } else if (selectionError !== undefined) {
+              throw selectionError;
+            }
           }
+          if (cancelled || (routedDaemonId !== null && !routedRestoreIsCurrent(restoreGeneration, attemptedSignature))) return;
+          if (restored.startEventStream && catchUpCursor) {
+            const cursorDelta = await syncEventCursorAndReconcileSelection(
+              captureCursorCatchupScope(),
+              routedDaemonId === null,
+              routedDaemonId === null,
+            );
+            persistenceDelta = mergeRestorePersistenceDelta(persistenceDelta, cursorDelta);
+          }
+          if (cancelled || (routedDaemonId !== null && !routedRestoreIsCurrent(restoreGeneration, attemptedSignature))) return;
+          if (routedDaemonId) {
+            setActiveKataDaemon(routedDaemonId);
+            workspaceOwnershipPending = false;
+            provisionalRoutedDaemon = null;
+            routedRestoreFallbackDaemon = undefined;
+            routedRestoreRouteSignature = null;
+            applyRestorePersistenceDelta(routedDaemonId, persistenceDelta);
+            const route =
+              fullRouteSignature() === attemptedSignature
+                ? {
+                    ...restored.route,
+                    issue: store.selectedIssue?.issue.uid ?? null,
+                  }
+                : currentRouteSnapshot();
+            onRouteStateChange?.({ ...route, daemon: null }, { replace: true });
+          }
+          if (restored.startEventStream && catchUpCursor) startEventStream();
+          error = null;
+          if (restoreRetryRouteSignature === null) {
+            restoreError = null;
+            restoreRetry = null;
+          }
+        };
+        const restoreInitialWorkspace = async (catchUpCursor: boolean): Promise<RestoreResult> =>
+          withRouteEmission(async () => {
+            const attemptedRoute = currentRouteSnapshot();
+            const attemptedSignature = currentFullRouteSignature();
+            const restoreGeneration = ++routedRestoreGeneration;
+            if (routedDaemonId !== null) routedRestoreRouteSignature = attemptedSignature;
+            const restored = await restoreKataWorkspaceState(
+              daemonID,
+              attemptedRoute,
+              routedDaemonId === null,
+              routedDaemonId === null,
+              false,
+              attemptedSignature,
+              () => routedDaemonId === null || routedRestoreIsCurrent(restoreGeneration, attemptedSignature),
+            );
+            await finalizeRestoration(
+              restored,
+              attemptedRoute,
+              attemptedSignature,
+              catchUpCursor,
+              restoreGeneration,
+            );
+            return restored;
+          });
+        const routedAttemptStillOwnsRoute = (): boolean =>
+          routedDaemonId !== null &&
+          provisionalRoutedDaemon === routedDaemonId &&
+          requestedDaemonId === routedDaemonId;
+        const abandonRoutedRestore = (): void => {
+          if (provisionalRoutedDaemon === null) return;
+          const fallbackDaemon = routedRestoreFallbackDaemon ?? acceptedKataDaemonId;
+          routedRestoreGeneration += 1;
+          routedRestoreRouteSignature = null;
+          provisionalRoutedDaemon = null;
+          routedRestoreFallbackDaemon = undefined;
+          restoreError = null;
+          restoreRetry = null;
+          restoreRetryRouteSignature = null;
+          if (fallbackDaemon) void recoverRoutedFallbackDaemon(fallbackDaemon);
+        };
+        const installRestoreRetry = (): void => {
+          restoreRetryRouteSignature = currentFullRouteSignature();
+          restoreRetry = async () => {
+            if (restoreRetrying) return;
+            restoreRetrying = true;
+            restoreError = null;
+            try {
+              await restoreInitialWorkspace(true);
+              if (provisionalRoutedDaemon === null) {
+                restoreRetry = null;
+                restoreRetryRouteSignature = null;
+                return;
+              }
+              if (
+                routedDaemonId !== null &&
+                !routedAttemptStillOwnsRoute()
+              ) {
+                abandonRoutedRestore();
+                return;
+              }
+              restoreRetry = null;
+              restoreRetryRouteSignature = null;
+            } catch (retryError) {
+              if (cancelled) return;
+              if (
+                routedDaemonId !== null &&
+                !routedAttemptStillOwnsRoute()
+              ) {
+                abandonRoutedRestore();
+                return;
+              }
+              if (routedDaemonId) {
+                setActiveKataDaemon(previousExplicitDaemon, false);
+                restoreCursorCatchupError(null, null);
+              }
+              restoreError = kataRequestErrorMessage(retryError);
+              installRestoreRetry();
+            } finally {
+              restoreRetrying = false;
+            }
+          };
+        };
+        let restored: RestoreResult;
+        try {
+          restored = await restoreInitialWorkspace(routedDaemonId !== null);
+        } catch (err) {
+          if (routedDaemonId !== null && !routedAttemptStillOwnsRoute()) {
+            abandonRoutedRestore();
+            return;
+          }
+          if (store.connection.status === "error" && daemonInfos.length > 0) {
+            error = store.connection.message ?? "Connection failed";
+          } else {
+            restoreError = kataRequestErrorMessage(err);
+          }
+          installRestoreRetry();
+          return;
         }
-        selectionFromRoute = bootstrapIssueUID !== null && store.selectedIssue?.issue.uid === bootstrapIssueUID;
-        if (routedDaemonId && store.daemonId === routedDaemonId) {
-          onRouteStateChange?.({
-            view: bootstrapRoute.view,
-            scope: bootstrapRoute.scope,
-            issue: bootstrapRoute.issue,
-            daemon: null,
-          }, { replace: true });
-        }
-        if (!cancelled) {
-          startEventStream();
+        if (routedDaemonId === null && !restored.startEventStream) workspaceOwnershipPending = false;
+        if (restored.startEventStream && routedDaemonId === null) {
+          try {
+            const cursorDelta = await syncEventCursorAndReconcileSelection();
+            applyRestorePersistenceDelta(daemonID, cursorDelta);
+            if (!cancelled) {
+              startEventStream();
+              workspaceOwnershipPending = false;
+            }
+          } catch (cursorError) {
+            if (cancelled) return;
+            cursorCatchupError = kataRequestErrorMessage(cursorError);
+            cursorCatchupRetry = () => retryEventCursorCatchup(true);
+            workspaceOwnershipPending = false;
+            terminalDaemonFailure = false;
+            terminalRecovery = null;
+            error = null;
+            stopEventStream();
+          }
         }
       } catch (err) {
         if (!cancelled) {
@@ -348,14 +1074,17 @@
                 : "Kata request failed.";
         }
       } finally {
-        if (!cancelled) {
-          loading = false;
-        }
+        if (!cancelled) loading = false;
       }
     })();
 
     return () => {
       cancelled = true;
+      workspaceMounted = false;
+      switchGeneration += 1;
+      switchRouteSignature = null;
+      cursorCatchupMounted = false;
+      invalidateCursorCatchup();
       stopEventStream();
     };
   });
@@ -365,6 +1094,8 @@
   }
 
   function beginNavigation(): number {
+    revealRequest = null;
+    captureOpen = false;
     navigationGeneration += 1;
     navigationEpoch = navigationGeneration;
     return navigationGeneration;
@@ -382,12 +1113,110 @@
     };
   }
 
+  function currentFullRouteSignature(): string {
+    const route = currentRouteSnapshot();
+    return `${route.view ?? ""}\u0000${route.scope ?? ""}\u0000${route.issue ?? ""}\u0000${requestedDaemonId ?? ""}`;
+  }
+
+  function routedRestoreIsCurrent(generation: number, signature: string): boolean {
+    return (
+      workspaceMounted &&
+      generation === routedRestoreGeneration &&
+      signature === routedRestoreRouteSignature &&
+      signature === currentFullRouteSignature()
+    );
+  }
+
+  async function recoverRoutedFallbackDaemon(daemonID: string): Promise<void> {
+    routedFallbackRequestedDaemon = daemonID;
+    if (routedFallbackRecovering) return;
+    routedFallbackRecovering = true;
+    terminalDaemonFailure = false;
+    terminalRecovery = null;
+    stopEventStream();
+    try {
+      while (workspaceMounted && routedFallbackRequestedDaemon !== null) {
+        const recoveryDaemonID = routedFallbackRequestedDaemon;
+        routedFallbackRequestedDaemon = null;
+        const recoveryGeneration = ++routedRestoreGeneration;
+        const recoverySignature = currentFullRouteSignature();
+        const recoveryRoute = currentRouteSnapshot();
+        routedRestoreRouteSignature = recoverySignature;
+        const isCurrent = (): boolean =>
+          workspaceMounted &&
+          recoveryGeneration === routedRestoreGeneration &&
+          recoverySignature === currentFullRouteSignature();
+        try {
+          if (!isCurrent()) continue;
+          store.clearDaemonState();
+          store.bindDaemonForBootstrap(recoveryDaemonID);
+          const restored = await restoreKataWorkspaceState(
+            recoveryDaemonID,
+            recoveryRoute,
+            false,
+            true,
+            false,
+            null,
+            isCurrent,
+            "route-authoritative",
+          );
+          if (!isCurrent()) continue;
+          await store.api.instance();
+          if (!isCurrent()) continue;
+          const cursorDelta = await syncEventCursorAndReconcileSelection(
+            { daemonID: recoveryDaemonID, generation: cursorCatchupGeneration },
+            true,
+            false,
+          );
+          if (!isCurrent()) continue;
+          applyRestorePersistenceDelta(
+            recoveryDaemonID,
+            mergeRestorePersistenceDelta(restored.persistenceDelta, cursorDelta),
+          );
+          setActiveKataDaemon(recoveryDaemonID);
+          terminalDaemonFailure = false;
+          terminalRecovery = null;
+          error = null;
+          if (restored.startEventStream) startEventStream();
+          routedRestoreRouteSignature = null;
+          break;
+        } catch (recoveryError) {
+          if (!isCurrent()) continue;
+          error = kataRequestErrorMessage(recoveryError);
+          terminalDaemonFailure = true;
+          stopEventStream();
+          terminalRecovery = async () => {
+            if (terminalRecovering) return;
+            terminalRecovering = true;
+            terminalDaemonFailure = false;
+            try {
+              routedFallbackRequestedDaemon = recoveryDaemonID;
+              await recoverRoutedFallbackDaemon(recoveryDaemonID);
+            } finally {
+              terminalRecovering = false;
+            }
+          };
+          break;
+        }
+      }
+    } finally {
+      routedFallbackRecovering = false;
+      if (workspaceMounted && routedFallbackRequestedDaemon !== null && !terminalDaemonFailure) {
+        void recoverRoutedFallbackDaemon(routedFallbackRequestedDaemon);
+      }
+    }
+  }
+
   function routeSignature(route: KataRouteSnapshot): string {
     return `${route.view ?? ""}\u0000${route.scope ?? ""}\u0000${route.issue ?? ""}`;
   }
 
+  function fullRouteSignatureFor(route: KataRouteSnapshot): string {
+    return `${routeSignature(route)}\u0000${requestedDaemonId ?? ""}`;
+  }
+
   function fullRouteSignature(): string {
-    return `${routeSignature(currentRouteSnapshot())} ${requestedDaemonId ?? ""}`;
+    return fullRouteSignatureFor(currentRouteSnapshot());
   }
 
   function actualIssueUID(): string | null {
@@ -409,7 +1238,15 @@
   }
 
   function reconcilerBusy(): boolean {
-    return loading || switchingDaemon || terminalDaemonFailure || routeEmissionWork > 0;
+    return (
+      loading ||
+      switchingDaemon ||
+      routedFallbackRecovering ||
+      terminalDaemonFailure ||
+      restoreRetry !== null ||
+      restoreRetrying ||
+      routeEmissionWork > 0
+    );
   }
 
   type RouteMismatch = "daemon" | "viewScope" | "select" | "clear" | null;
@@ -419,7 +1256,7 @@
   // completions cannot repaint the new daemon. Only ownership setup, another
   // switch transaction, or non-supersedable writes hold the exclusive lock.
   function daemonSwitchLocked(): boolean {
-    return loading || switchingDaemon || store.hasPendingMutations || workspaceActionBusy;
+    return loading || switchingDaemon || workspaceReadOnly || store.hasPendingMutations || workspaceActionBusy;
   }
 
   // The reconciler starts route list loads without awaiting so a newer
@@ -450,7 +1287,7 @@
   }
 
   function routeMismatch(): RouteMismatch {
-    if (requestedDaemonId !== null && requestedDaemonId !== store.daemonId) {
+    if (requestedDaemonId !== null && requestedDaemonId !== activeKataDaemonId) {
       // An unknown routed daemon surfaces routedDaemonError instead of
       // looping; a roster change re-evaluates through daemonInfos.
       return daemonInfos.some((daemon) => daemon.id === requestedDaemonId) ? "daemon" : null;
@@ -509,7 +1346,7 @@
         if (mismatch === "daemon") {
           if (daemonSwitchLocked()) return;
           await switchKataDaemon(requestedDaemonId!);
-          if (requestedDaemonId !== null && requestedDaemonId !== store.daemonId) {
+          if (requestedDaemonId !== null && requestedDaemonId !== activeKataDaemonId) {
             // The switch refused or failed; the effect re-fires when its
             // gates clear or the route moves.
             return;
@@ -525,11 +1362,27 @@
           return;
         }
         if (mismatch === "select") {
+          // The current route's list must settle before its detail selection
+          // starts. A superseded non-abortable load is harmless: the store's
+          // request guard drops its late result.
+          if (viewScopeLoadSignature === signature) return;
           beginNavigation();
           resetDetailDrafts();
           const uid = selectedIssueUID!;
-          const ok = await runViewTask(() => store.selectIssue(uid), "view");
+          let selectionError: unknown;
+          const ok = await runViewTask(
+            async () => {
+              try {
+                return await store.selectIssue(uid);
+              } catch (error) {
+                selectionError = error;
+                throw error;
+              }
+            },
+            "view",
+          );
           if (!ok) {
+            if (pendingDirectGraphSelectionUID === uid) pendingDirectGraphSelectionUID = null;
             // A competing refresh can supersede this detail read without an
             // error. Leave the route retryable; the refresh completion will
             // re-run the reconciler. Only an actual request failure makes the
@@ -538,13 +1391,28 @@
             // The routed task cannot be shown; keeping the previous
             // detail under the new URL would lie about what is open.
             if (fullRouteSignature() === signature) {
-              failedRouteSignature = signature;
               store.clearSelection();
               selectionFromRoute = false;
+              if (isDefinitiveRestoreFailure(selectionError)) {
+                onRouteStateChange?.({ issue: null }, { replace: true });
+              } else {
+                failedRouteSignature = signature;
+              }
               return;
             }
           } else {
             selectionFromRoute = true;
+            if (store.selectedIssue) {
+              const selected = store.selectedIssue.issue;
+              store.rememberTasks([selected, ...(store.selectedIssue.children ?? [])]);
+              void revealSelectedAncestors(selected, activeKataDaemonId ?? "home", () =>
+                fullRouteSignature() === signature && store.selectedIssue?.issue.uid === uid,
+              );
+            }
+            if (pendingDirectGraphSelectionUID === uid) {
+              pendingDirectGraphSelectionUID = null;
+              persistActiveWorkspaceState();
+            }
           }
           continue;
         }
@@ -554,6 +1422,7 @@
         resetDetailDrafts();
         store.clearSelection();
         selectionFromRoute = false;
+        persistActiveWorkspaceState();
       }
     } finally {
       reconciling = false;
@@ -570,8 +1439,33 @@
     void routeScopeUID;
     void selectedIssueUID;
     untrack(() => {
-      // The daemon-switch transaction owns its loads; queued route
-      // changes converge through the reconciler once it settles.
+      if (pendingDirectGraphSelectionUID !== null && pendingDirectGraphSelectionUID !== (selectedIssueUID ?? null)) {
+        pendingDirectGraphSelectionUID = null;
+      }
+      if (loading && provisionalRoutedDaemon !== null && routedRestoreRouteSignature !== currentFullRouteSignature()) {
+        const fallbackDaemon = routedRestoreFallbackDaemon ?? acceptedKataDaemonId;
+        routedRestoreGeneration += 1;
+        routedRestoreRouteSignature = null;
+        provisionalRoutedDaemon = null;
+        routedRestoreFallbackDaemon = undefined;
+        restoreError = null;
+        restoreRetry = null;
+        restoreRetryRouteSignature = null;
+        if (fallbackDaemon) void recoverRoutedFallbackDaemon(fallbackDaemon);
+      }
+      if (routedFallbackRecovering && routedRestoreRouteSignature !== currentFullRouteSignature()) {
+        routedRestoreGeneration += 1;
+        routedRestoreRouteSignature = null;
+        if (acceptedKataDaemonId) routedFallbackRequestedDaemon = acceptedKataDaemonId;
+      }
+      if (switchingDaemon && switchRouteSignature !== currentFullRouteSignature()) {
+        switchGeneration += 1;
+        switchingDaemon = false;
+        switchRouteSignature = null;
+        store.bindDaemonForBootstrap(acceptedKataDaemonId ?? "home");
+        restoreCursorCatchupError(switchPreviousCursorCatchupError, switchPreviousCursorCatchupRetry);
+        if (switchPreviousEventStreamRunning) startEventStream();
+      }
       if (loading || switchingDaemon) return;
       // Echoes of already-applied interactions (the store converged
       // before emitting) must not abort their own follow-up reads,
@@ -591,11 +1485,30 @@
     void routeScopeUID;
     void selectedIssueUID;
     void store.daemonId;
+    void activeKataDaemonId;
     void store.currentView.name;
     void store.searchFilters;
     void store.pendingSelectionUID;
     void store.selectedIssue;
     void daemonInfos;
+    if (ancestorRevealRetryRouteSignature !== null && ancestorRevealRetryRouteSignature !== fullRouteSignature()) {
+      ancestorRevealError = null;
+      ancestorRevealRetry = null;
+      ancestorRevealRetryRouteSignature = null;
+    }
+    if (restoreRetryRouteSignature !== null && restoreRetryRouteSignature !== currentFullRouteSignature()) {
+      restoreError = null;
+      restoreRetry = null;
+      restoreRetryRouteSignature = null;
+      if (provisionalRoutedDaemon !== null) {
+        const fallbackDaemon = routedRestoreFallbackDaemon ?? acceptedKataDaemonId;
+        routedRestoreGeneration += 1;
+        routedRestoreRouteSignature = null;
+        provisionalRoutedDaemon = null;
+        routedRestoreFallbackDaemon = undefined;
+        if (fallbackDaemon) void untrack(() => recoverRoutedFallbackDaemon(fallbackDaemon));
+      }
+    }
     void viewWorkCount;
     void store.hasPendingMutations;
     void workspaceActionBusy;
@@ -618,9 +1531,11 @@
     // A project route load applies its scope before its optional view load
     // finishes. That intermediate state can leave only the issue selection
     // mismatched, but selecting now would be aborted when the remaining view
-    // load clears selection. Wait for the complete route load to settle.
-    if (viewScopeLoadSignature !== null && mismatch !== "viewScope") return;
-    if (mismatch === "viewScope" && viewScopeLoadSignature === fullRouteSignature()) return;
+    // load clears selection. Only the current route's load must settle; stale
+    // loads are rejected by the store when they eventually return.
+    const signature = fullRouteSignature();
+    if (viewScopeLoadSignature === signature && mismatch !== "viewScope") return;
+    if (mismatch === "viewScope" && viewScopeLoadSignature === signature) return;
     void untrack(() => reconcileRoute());
   });
 
@@ -695,6 +1610,73 @@
     return store.currentView.groups.flatMap((group) => group.issues);
   }
 
+  function persistActiveWorkspaceState(): void {
+    const daemonID = activeKataDaemonId;
+    if (!daemonID || switchingDaemon || restoreRetry !== null || provisionalRoutedDaemon !== null || terminalDaemonFailure) return;
+    saveKataWorkspaceState(daemonID, {
+      view: store.currentView.name,
+      filters: store.searchFilters,
+      selectedIssueUID: store.selectedIssue?.issue.uid ?? null,
+    });
+  }
+
+  function selectedIssueHasRawResultMembership(selectedUID: string | null | undefined = store.selectedIssue?.issue.uid): boolean {
+    if (!selectedUID) return true;
+    return store.currentView.groups
+      .flatMap((group) => group.issues)
+      .some((issue) => issue.uid === selectedUID && statusMatches(issue, listStatusFilter));
+  }
+
+  function canonicalizeClearedSelection(): void {
+    const route = canonicalRoute(
+      store.currentView.name,
+      scopeUIDFromFilters(store.searchFilters),
+      null,
+      routeViewName !== null,
+    );
+    selectionFromRoute = false;
+    onRouteStateChange?.(route, { replace: true });
+    if (!onRouteStateChange) onSelectedIssueChange?.(null);
+  }
+
+  function reconcileSelectionMembership(
+    daemonID: string,
+    afterAcceptedMutation: boolean,
+    selectedUID?: string | null,
+    emitRoute = true,
+    mutatePersistence = true,
+  ): RestorePersistenceDelta | undefined {
+    const capturedUID = selectedUID === undefined
+      ? (store.pendingSelectionUID ?? store.selectedIssue?.issue.uid ?? null)
+      : selectedUID;
+    const currentUID = store.pendingSelectionUID ?? store.selectedIssue?.issue.uid ?? null;
+    // A completed new selection wins a stale refresh, but a missing current
+    // selection means the authoritative refresh itself removed the capture.
+    if (!capturedUID || (currentUID !== null && currentUID !== capturedUID)) return;
+    if (!selectedIssueHasRawResultMembership(capturedUID)) {
+      resetDetailDrafts();
+      store.clearSelection();
+      if (emitRoute) canonicalizeClearedSelection();
+      if (afterAcceptedMutation) {
+        persistActiveWorkspaceState();
+      } else if (mutatePersistence) {
+        clearKataWorkspaceSelection(daemonID);
+      } else {
+        return { clearSelection: true };
+      }
+      return;
+    }
+
+    if (afterAcceptedMutation) persistActiveWorkspaceState();
+    return undefined;
+  }
+
+  function reconcilePersistedSelection(afterAcceptedMutation: boolean, selectedUID?: string | null): void {
+    const daemonID = activeKataDaemonId;
+    if (!daemonID || switchingDaemon) return;
+    reconcileSelectionMembership(daemonID, afterAcceptedMutation, selectedUID);
+  }
+
   function selectedIssueMatchesStatusFilter(status: KataTaskSearchFilters["status"]): boolean {
     const selected = store.selectedIssue?.issue;
     return !selected || status === "all" || selected.status === status;
@@ -749,16 +1731,100 @@
   }
 
   function stopEventStream(resetReconnect = true): void {
+    eventStreamRunning = false;
     eventStream.stop(resetReconnect);
   }
 
   function startEventStream(reconnecting = false): void {
+    eventStreamRunning = true;
     eventStream.start(reconnecting);
+  }
+
+  interface CursorCatchupScope {
+    daemonID: string | undefined;
+    generation: number;
+  }
+
+  function captureCursorCatchupScope(): CursorCatchupScope {
+    return { daemonID: activeKataDaemonId, generation: cursorCatchupGeneration };
+  }
+
+  function isCursorCatchupScopeCurrent(scope: CursorCatchupScope): boolean {
+    return cursorCatchupMounted && scope.generation === cursorCatchupGeneration && scope.daemonID === activeKataDaemonId;
+  }
+
+  function invalidateCursorCatchup(): void {
+    cursorCatchupGeneration += 1;
+    cursorCatchupRetrying = false;
+    cursorCatchupError = null;
+    cursorCatchupRetry = null;
+  }
+
+  function restoreCursorCatchupError(error: string | null, retry: (() => Promise<void>) | null): void {
+    cursorCatchupError = error;
+    cursorCatchupRetry = retry;
+    cursorCatchupRetrying = false;
+  }
+
+  async function retryEventCursorCatchup(startStreamAfterSuccess = false): Promise<void> {
+    if (cursorCatchupRetrying) return;
+    const scope = captureCursorCatchupScope();
+    cursorCatchupRetrying = true;
+    try {
+      await syncEventCursorAndReconcileSelection(scope);
+      if (isCursorCatchupScopeCurrent(scope)) {
+        terminalDaemonFailure = false;
+        terminalRecovery = null;
+        error = null;
+        if (startStreamAfterSuccess) startEventStream();
+      }
+    } catch (error) {
+      if (isCursorCatchupScopeCurrent(scope)) {
+        cursorCatchupError = kataRequestErrorMessage(error);
+        cursorCatchupRetry = () => retryEventCursorCatchup(startStreamAfterSuccess);
+      }
+    } finally {
+      if (isCursorCatchupScopeCurrent(scope)) cursorCatchupRetrying = false;
+    }
+  }
+
+  async function syncEventCursorAndReconcileSelection(
+    scope = captureCursorCatchupScope(),
+    mutatePersistence = true,
+    emitRoute = true,
+  ): Promise<RestorePersistenceDelta | undefined> {
+    const selectedUID = store.selectedIssue?.issue.uid ?? null;
+    try {
+      const membershipRefreshed = await store.syncEventCursor({ shouldApply: () => isCursorCatchupScopeCurrent(scope) });
+      if (!isCursorCatchupScopeCurrent(scope)) return;
+      const persistenceDelta = membershipRefreshed
+        ? reconcileSelectionMembership(scope.daemonID ?? "", false, selectedUID, emitRoute, mutatePersistence)
+        : undefined;
+      cursorCatchupError = null;
+      cursorCatchupRetry = null;
+      return persistenceDelta;
+    } catch (error) {
+      if (!isCursorCatchupScopeCurrent(scope)) return;
+      if (error instanceof KataEventCursorSyncError) {
+        const persistenceDelta = reconcileSelectionMembership(
+          scope.daemonID ?? "",
+          false,
+          selectedUID,
+          emitRoute,
+          mutatePersistence,
+        );
+        cursorCatchupError = kataRequestErrorMessage(error.cursorSyncCause);
+        cursorCatchupRetry = retryEventCursorCatchup;
+        return persistenceDelta;
+      }
+      throw error;
+    }
   }
 
   async function updateSearchFilters(filters: Partial<KataTaskSearchFilters>): Promise<void> {
     await withRouteEmission(async () => {
       const generation = beginNavigation();
+      const memory = captureWorkspaceMemory();
       const nextStatus = filters.status ?? store.searchFilters.status;
       closeReachableGraph();
       resetDetailDrafts();
@@ -768,25 +1834,55 @@
       if (!selectedIssueMatchesStatusFilter(nextStatus)) {
         store.clearSelection();
       }
-      await runViewTask(() => store.updateSearchFilters(filters), "view");
+      const ok = await runViewTask(() => store.updateSearchFilters(filters), "view");
+      if (!ok) {
+        if (isCurrentNavigation(generation)) restoreWorkspaceMemory(memory);
+        return;
+      }
       if (!isCurrentNavigation(generation)) return;
       const nextScopeUID = scopeUIDFromFilters(store.searchFilters);
       if (nextScopeUID !== (routeScopeUID ?? null)) {
-        const nextViewName = nextScopeUID ? null : store.currentView.name === "all" ? null : store.currentView.name;
+        const nextViewName = nextScopeUID
+          ? null
+          : routeViewName ?? (store.currentView.name === "all" ? null : store.currentView.name);
         onRouteStateChange?.({
           view: nextViewName,
           scope: nextScopeUID,
           issue: store.selectedIssue?.issue.uid ?? null,
         });
-        return;
+      } else {
+        emitRouteSelectionSync();
       }
-      emitRouteSelectionSync();
+      persistActiveWorkspaceState();
     });
   }
 
-  async function openRoutedSystemView(viewName: KataTaskViewName): Promise<void> {
+  async function openRoutedSystemView(viewName: KataTaskViewName, direct = false): Promise<void> {
+    const filters = store.searchFilters;
+    const viewAlreadyLoaded =
+      store.currentView.fetched_at !== undefined &&
+      store.currentView.name === viewName &&
+      filters.scope.kind === "all" &&
+      filters.status === "open" &&
+      filters.owner.trim() === "" &&
+      filters.label.trim() === "" &&
+      filters.query.trim() === "";
+    const routeAlreadyCanonical =
+      ((routeViewName ?? null) === viewName || (viewName === "all" && routeViewName === null)) &&
+      (routeScopeUID ?? null) === null &&
+      (selectedIssueUID ?? null) === null;
+    if (
+      viewAlreadyLoaded &&
+      routeAlreadyCanonical &&
+      actualIssueUID() === null &&
+      listMode === "tasks" &&
+      viewScopeLoadSignature === null
+    ) {
+      return;
+    }
     await withRouteEmission(async () => {
       const generation = beginNavigation();
+      const memory = captureWorkspaceMemory();
       closeReachableGraph();
       resetDetailDrafts();
       store.resetSearchFilters();
@@ -796,19 +1892,37 @@
       // this navigation has already discarded.
       store.clearSelection();
       selectionFromRoute = false;
-      await runViewTask(() => store.openView(viewName, { selectFirst: false }), "view");
-      if (!isCurrentNavigation(generation)) return;
-      onRouteStateChange?.({
-        view: viewName,
-        scope: null,
-        issue: null,
-      });
+      if (viewAlreadyLoaded) {
+        // Re-selecting the loaded view still preempts a superseded routed
+        // list load. Its response cannot be allowed to repaint after this
+        // interaction has declared the current view authoritative.
+        if (viewScopeLoadSignature !== null) {
+          store.invalidatePendingLoads();
+          viewScopeLoadSignature = null;
+        }
+      } else {
+        const ok = await runViewTask(() => store.openView(viewName, { selectFirst: false }), "view");
+        if (!ok) {
+          if (isCurrentNavigation(generation)) restoreWorkspaceMemory(memory);
+          return;
+        }
+        if (!isCurrentNavigation(generation)) return;
+      }
+      if (!routeAlreadyCanonical) {
+        onRouteStateChange?.({
+          view: viewName,
+          scope: null,
+          issue: null,
+        });
+      }
+      if (direct) persistActiveWorkspaceState();
     });
   }
 
-  async function openRoutedProjectScope(projectUID: string): Promise<void> {
+  async function openRoutedProjectScope(projectUID: string, direct = false): Promise<void> {
     await withRouteEmission(async () => {
       const generation = beginNavigation();
+      const memory = captureWorkspaceMemory();
       closeReachableGraph();
       resetDetailDrafts();
       // Scope changes keep a completed selection but abandon an in-flight
@@ -821,17 +1935,22 @@
         () => store.updateSearchFilters({ scope: { kind: "project", project_uid: projectUID } }),
         "view",
       );
-      if (!ok || !isCurrentNavigation(generation)) return;
+      if (!ok) {
+        if (isCurrentNavigation(generation)) restoreWorkspaceMemory(memory);
+        return;
+      }
+      if (!isCurrentNavigation(generation)) return;
       onRouteStateChange?.({
         view: null,
         scope: projectUID,
         issue: store.selectedIssue?.issue.uid ?? null,
       });
+      if (direct) persistActiveWorkspaceState();
     });
   }
 
   function scheduleProjectScope(projectUID: string): void {
-    void openRoutedProjectScope(projectUID);
+    void openRoutedProjectScope(projectUID, true);
   }
 
   async function createKataProject(name: string): Promise<KataProjectSummary> {
@@ -843,6 +1962,7 @@
   }
 
   async function submitQuickCapture(title: string): Promise<void> {
+    if (workspaceActionsBlocked) return;
     await withRouteEmission(async () => {
       await runViewTaskOrThrow(async () => {
         closeReachableGraph();
@@ -856,92 +1976,257 @@
         scope: scopeUIDFromFilters(store.searchFilters),
         issue: actualIssueUID(),
       });
+      persistActiveWorkspaceState();
     });
+  }
+
+  interface KataWorkspaceMemory {
+    store: KataWorkspaceStoreSnapshot;
+    selectionFromRoute: boolean;
+    restoredSelectionUID: string | null;
+  }
+
+  function captureWorkspaceMemory(): KataWorkspaceMemory {
+    return {
+      store: store.captureSnapshot(),
+      selectionFromRoute,
+      restoredSelectionUID,
+    };
+  }
+
+  function restoreWorkspaceMemory(memory: KataWorkspaceMemory): void {
+    store.restoreSnapshot(memory.store);
+    selectionFromRoute = memory.selectionFromRoute;
+    restoredSelectionUID = memory.restoredSelectionUID;
+  }
+
+  function acceptWorkspaceStore(candidate: ReturnType<typeof createKataWorkspaceStore>): void {
+    store.restoreSnapshot(candidate.captureSnapshot());
+  }
+
+  function switchOwnsTransaction(generation: number, routeSignature: string): boolean {
+    return (
+      workspaceMounted &&
+      switchingDaemon &&
+      generation === switchGeneration &&
+      routeSignature === switchRouteSignature
+    );
   }
 
   async function switchKataDaemon(id: string): Promise<void> {
     if (daemonSwitchLocked()) return;
-    const previousExplicitDaemon = getActiveKataDaemon();
-    const previousDaemon = store.daemonId ?? activeKataDaemonId;
-    if (id === store.daemonId) return;
+    const previousDaemonID = store.daemonId ?? activeKataDaemonId;
+    if (id === previousDaemonID) {
+      if (requestedDaemonId === id) {
+        onRouteStateChange?.({ ...currentRouteSnapshot(), daemon: null }, { replace: true });
+      }
+      return;
+    }
 
-    const generation = beginNavigation();
     const previousView = store.currentView.name;
-    const previousFilters = store.searchFilters;
-    const previousIssueUID = store.selectedIssue?.issue.uid ?? null;
-    const routeAtSwitchStart = routeSignature(currentRouteSnapshot());
+    const previousWorkspace = captureWorkspaceMemory();
+    const ownedRouteSignature = fullRouteSignature();
+    let committedRouteSignature: string | null = null;
+    const switchTransactionCanApply = (): boolean =>
+      switchOwnsTransaction(ownedSwitchGeneration, ownedRouteSignature) ||
+      (committedRouteSignature !== null &&
+        workspaceMounted &&
+        !switchingDaemon &&
+        store.daemonId === id &&
+        fullRouteSignature() === committedRouteSignature);
+    const routeMatchesOwnedSwitch = (): boolean => fullRouteSignature() === ownedRouteSignature;
+    const routedSwitchRoute = requestedDaemonId === id ? currentRouteSnapshot() : null;
+    const previousCursorCatchupError = cursorCatchupError;
+    const previousCursorCatchupRetry = cursorCatchupRetry;
+    switchPreviousCursorCatchupError = previousCursorCatchupError;
+    switchPreviousCursorCatchupRetry = previousCursorCatchupRetry;
+    switchPreviousEventStreamRunning = eventStreamRunning;
+    invalidateCursorCatchup();
     switchingDaemon = true;
     terminalDaemonFailure = false;
+    terminalRecovery = null;
+    const ownedSwitchGeneration = ++switchGeneration;
+    switchRouteSignature = ownedRouteSignature;
+    beginNavigation();
     closeReachableGraph();
     resetDetailDrafts();
     resetIssueExpansion();
-    // The switch abandons any in-flight detail load (only a completed
-    // selection is captured for restore above), so drop it before the
-    // daemon reload: its failure mid-switch would otherwise surface a
-    // stale error from the previous daemon.
     store.invalidatePendingLoads();
-    store.clearDaemonState(previousView);
-    setActiveKataDaemon(id);
     stopEventStream();
-    try {
-      const ok = await runViewTask(async () => {
-        await store.bootstrap(previousView, null, { selectFirst: requestedDaemonId !== id });
-        store.resetSearchFilters();
-        await store.syncEventCursor();
-      }, "daemon");
-      if (!ok) {
-        store.clearDaemonState(previousView);
-        setActiveKataDaemon(previousDaemon);
-        const restored = await runViewTask(async () => {
-          await store.bootstrap(previousView, previousIssueUID);
-          await store.updateSearchFilters(previousFilters);
-          if (store.currentView.name !== previousView) {
-            await store.openView(previousView);
-          }
-          if (previousIssueUID && store.selectedIssue?.issue.uid !== previousIssueUID) {
-            await store.selectIssue(previousIssueUID);
-          }
-          await store.syncEventCursor();
-        }, "daemon");
-        if (restored) {
-          setActiveKataDaemon(previousExplicitDaemon);
-          if (requestedDaemonId === id) {
-            onRouteStateChange?.({
-              view: previousView,
-              scope: scopeUIDFromFilters(previousFilters),
-              issue: previousIssueUID,
-              daemon: null,
-            }, { replace: true });
-          }
-          startEventStream();
-        } else {
-          store.clearDaemonState(previousView);
-          terminalDaemonFailure = true;
-        }
-        return;
-      }
 
-      if (!isCurrentNavigation(generation)) {
-        startEventStream();
-        return;
+    const recoverPreviousWorkspace = async (): Promise<void> => {
+      if (!previousDaemonID) throw new Error("Previous Kata daemon is unavailable.");
+      store.clearDaemonState(previousView);
+      store.bindDaemonForBootstrap(previousDaemonID);
+      setActiveKataDaemon(previousDaemonID, false);
+      restoreWorkspaceMemory(previousWorkspace);
+      store.bindDaemonForBootstrap(previousDaemonID);
+      await store.api.instance();
+      const rollbackSelectedUID = store.selectedIssue?.issue.uid ?? null;
+      let rollbackMembershipRefreshed = false;
+      try {
+        rollbackMembershipRefreshed = await store.syncEventCursor();
+        restoreCursorCatchupError(previousCursorCatchupError, previousCursorCatchupRetry);
+      } catch (catchupError) {
+        if (!(catchupError instanceof KataEventCursorSyncError)) throw catchupError;
+        rollbackMembershipRefreshed = true;
+        cursorCatchupError = kataRequestErrorMessage(catchupError.cursorSyncCause);
+        cursorCatchupRetry = retryEventCursorCatchup;
       }
-      const nextUID = store.selectedIssue?.issue.uid ?? null;
+      if (rollbackMembershipRefreshed) {
+        reconcileSelectionMembership(previousDaemonID, false, rollbackSelectedUID, false);
+      }
+      const rollbackIssueUID = store.selectedIssue?.issue.uid ?? null;
+      const rollbackRoute = canonicalRoute(
+        store.currentView.name,
+        scopeUIDFromFilters(store.searchFilters),
+        rollbackIssueUID,
+      );
+      selectionFromRoute = rollbackIssueUID !== null && previousWorkspace.selectionFromRoute;
+      restoredSelectionUID = previousWorkspace.restoredSelectionUID;
       if (requestedDaemonId === id) {
-        // Consume the transient daemon param; the current route (which
-        // may have changed while the switch was in flight) stays put and
-        // the reconciler converges the fresh workspace to it.
-        onRouteStateChange?.({
-          view: routeViewName,
-          scope: routeScopeUID,
-          issue: selectedIssueUID,
-          daemon: null,
-        }, { replace: true });
-      } else if (routeSignature(currentRouteSnapshot()) === routeAtSwitchStart) {
-        onSelectedIssueChange?.(nextUID);
+        onRouteStateChange?.({ ...rollbackRoute, daemon: null }, { replace: true });
+      } else if (fullRouteSignature() === ownedRouteSignature) {
+        if (onRouteStateChange) {
+          onRouteStateChange(rollbackRoute, { replace: true });
+        } else {
+          onSelectedIssueChange?.(rollbackIssueUID);
+        }
+      }
+      terminalDaemonFailure = false;
+      terminalRecovery = null;
+      error = null;
+      startEventStream();
+    };
+
+    try {
+      const candidate = createKataWorkspaceStore({ api: store.api });
+      candidate.bindDaemonForBootstrap(id, false);
+      await candidate.api.instance({ daemonId: id });
+      const restored = await restoreKataWorkspaceState(
+        id,
+        routedSwitchRoute ?? { view: null, scope: null, issue: null },
+        false,
+        false,
+        routedSwitchRoute === null,
+        null,
+        switchTransactionCanApply,
+        "daemon-generation",
+        candidate,
+      );
+      if (!switchOwnsTransaction(ownedSwitchGeneration, ownedRouteSignature) || !restored.startEventStream) {
+        throw new Error("Kata daemon workspace could not be restored.");
+      }
+      if (restoreRetry !== null) {
+        throw new Error(restoreError ?? "Kata daemon workspace could not be restored.");
+      }
+      if (routedSwitchRoute?.issue && candidate.selectedIssue?.issue.uid !== routedSwitchRoute.issue) {
+        try {
+          await candidate.selectIssue(routedSwitchRoute.issue, {
+            shouldApply: () => switchOwnsTransaction(ownedSwitchGeneration, ownedRouteSignature),
+          });
+        } catch (selectionError) {
+          if (!isDefinitiveRestoreFailure(selectionError)) throw selectionError;
+          candidate.clearSelection();
+          restored.route = { ...restored.route, issue: null };
+        }
+      }
+      await candidate.awaitSelectedAuxiliaryReads();
+      const targetSelectedUID = candidate.selectedIssue?.issue.uid ?? null;
+      let targetMembershipRefreshed = false;
+      try {
+        targetMembershipRefreshed = await candidate.syncEventCursor({
+          shouldApply: () => switchOwnsTransaction(ownedSwitchGeneration, ownedRouteSignature),
+        });
+        cursorCatchupError = null;
+        cursorCatchupRetry = null;
+      } catch (catchupError) {
+        if (!(catchupError instanceof KataEventCursorSyncError)) throw catchupError;
+        if (!switchOwnsTransaction(ownedSwitchGeneration, ownedRouteSignature)) {
+          throw new Error("Kata daemon switch was superseded.");
+        }
+        targetMembershipRefreshed = true;
+        cursorCatchupError = kataRequestErrorMessage(catchupError.cursorSyncCause);
+        cursorCatchupRetry = retryEventCursorCatchup;
+      }
+      if (!switchOwnsTransaction(ownedSwitchGeneration, ownedRouteSignature)) {
+        throw new Error("Kata daemon switch was superseded.");
+      }
+      if (!routeMatchesOwnedSwitch()) throw new Error("Kata daemon switch was superseded.");
+      acceptWorkspaceStore(candidate);
+      store.bindDaemonForBootstrap(id);
+      const cursorPersistenceDelta = targetMembershipRefreshed
+        ? reconcileSelectionMembership(id, false, targetSelectedUID, false, false)
+        : undefined;
+
+      setActiveKataDaemon(id);
+      clearTaskErrors("view");
+      applyRestorePersistenceDelta(
+        id,
+        mergeRestorePersistenceDelta(restored.persistenceDelta, cursorPersistenceDelta),
+      );
+      const acceptedIssueUID =
+        store.selectedIssue?.issue.uid ??
+        (restored.sources.selection === "url" ? restored.route.issue : null);
+      const acceptedRoute = { ...restored.route, issue: acceptedIssueUID };
+      selectionFromRoute = acceptedIssueUID !== null && acceptedIssueUID === selectedIssueUID;
+      restoredSelectionUID = acceptedIssueUID === restored.restoredSelectionUID ? restored.restoredSelectionUID : null;
+      if (requestedDaemonId === id) {
+        onRouteStateChange?.({ ...acceptedRoute, daemon: null }, { replace: true });
+      } else if (fullRouteSignature() === ownedRouteSignature) {
+        if (onRouteStateChange) {
+          onRouteStateChange(acceptedRoute);
+        } else {
+          onSelectedIssueChange?.(acceptedIssueUID);
+        }
+      }
+      committedRouteSignature = fullRouteSignature();
+      if (restored.ancestorReveal) {
+        revealRequest = { ...restored.ancestorReveal, generation: ++revealGeneration };
       }
       startEventStream();
+    } catch (targetError) {
+      restoreError = null;
+      restoreRetry = null;
+      restoreRetryRouteSignature = null;
+      ancestorRevealError = null;
+      ancestorRevealRetry = null;
+      ancestorRevealRetryRouteSignature = null;
+      const targetMessage = kataRequestErrorMessage(targetError);
+      try {
+        if (!workspaceMounted) return;
+        if (!switchOwnsTransaction(ownedSwitchGeneration, ownedRouteSignature)) return;
+        await recoverPreviousWorkspace();
+        if (workspaceMounted) showFlash(targetMessage, { tone: "danger" });
+      } catch (rollbackError) {
+        terminalDaemonFailure = true;
+        setActiveKataDaemon(previousDaemonID, false);
+        restoreWorkspaceMemory(previousWorkspace);
+        if (previousDaemonID) store.bindDaemonForBootstrap(previousDaemonID);
+        stopEventStream();
+        error = `${targetMessage} ${kataRequestErrorMessage(rollbackError)}`;
+        terminalRecovery = async () => {
+          if (terminalRecovering) return;
+          terminalRecovering = true;
+          try {
+            await recoverPreviousWorkspace();
+          } catch (recoveryError) {
+            terminalDaemonFailure = true;
+            error = `${targetMessage} ${kataRequestErrorMessage(recoveryError)}`;
+          } finally {
+            terminalRecovering = false;
+          }
+        };
+      }
     } finally {
-      switchingDaemon = false;
+      if (ownedSwitchGeneration === switchGeneration) {
+        switchingDaemon = false;
+        switchRouteSignature = null;
+        if (workspaceMounted && routeMismatch() !== null) {
+          beginNavigation();
+          store.invalidatePendingLoads();
+        }
+      }
     }
   }
 
@@ -950,13 +2235,14 @@
     recurrenceDialogs?.closeAll();
   }
 
-  async function selectIssue(uid: string, notify = true): Promise<void> {
+  async function selectIssue(uid: string, notify = true, direct = notify): Promise<void> {
     await withRouteEmission(async () => {
       const generation = beginNavigation();
       resetDetailDrafts();
       const ok = await runViewTask(() => store.selectIssue(uid), "view");
       if (!ok || !isCurrentNavigation(generation)) return;
       if (notify) onSelectedIssueChange?.(uid);
+      if (direct) persistActiveWorkspaceState();
     });
   }
 
@@ -964,10 +2250,11 @@
     if (onSelectedIssueChange && selectedIssueUID !== uid) {
       // Route the node first; the echo lands synchronously and the
       // reconciler applies the selection (and owns its failure surface).
+      pendingDirectGraphSelectionUID = uid;
       onSelectedIssueChange(uid);
       return;
     }
-    void selectIssue(uid, false);
+    void selectIssue(uid, false, true);
   }
 
   function openReachableGraph(issue: KataTaskSummary): void {
@@ -987,16 +2274,18 @@
 
   async function moveSelectedIssue(toProjectUID: string): Promise<boolean> {
     const selected = store.selectedIssue?.issue;
-    if (!selected || pendingMoveIssueUIDs.has(selected.uid)) return false;
+    if (!selected || !toProjectUID || pendingMoveIssueUIDs.has(selected.uid)) return false;
     const sourceIssueUID = selected.uid;
     const generation = navigationGeneration;
     pendingMoveIssueUIDs = new Set(pendingMoveIssueUIDs).add(sourceIssueUID);
     try {
-      return await runViewTask(
+      const ok = await runViewTask(
         () => store.moveIssue(sourceIssueUID, actor, toProjectUID),
         "flash",
         () => isCurrentNavigation(generation),
       );
+      if (ok && isCurrentNavigation(generation)) reconcilePersistedSelection(true);
+      return ok;
     } finally {
       const nextPendingMoves = new Set(pendingMoveIssueUIDs);
       nextPendingMoves.delete(sourceIssueUID);
@@ -1005,7 +2294,9 @@
   }
 
   async function patchSelectedMetadata(uid: string, patch: Record<string, unknown>): Promise<boolean> {
-    return runViewTask(() => store.patchMetadata(uid, actor, patch), "flash");
+    const ok = await runViewTask(() => store.patchMetadata(uid, actor, patch), "flash");
+    if (ok) reconcilePersistedSelection(true);
+    return ok;
   }
 
   async function addSelectedComment(uid: string, body: string): Promise<boolean> {
@@ -1013,27 +2304,38 @@
   }
 
   async function editSelectedIssue(uid: string, patch: KataTaskEditPatch): Promise<boolean> {
-    return runViewTask(() => store.editIssue(uid, actor, patch), "flash");
+    const ok = await runViewTask(() => store.editIssue(uid, actor, patch), "flash");
+    if (ok) reconcilePersistedSelection(true);
+    return ok;
   }
 
   async function assignSelectedOwner(uid: string, owner: string): Promise<boolean> {
-    return runViewTask(() => store.assignOwner(uid, actor, owner), "flash");
+    const ok = await runViewTask(() => store.assignOwner(uid, actor, owner), "flash");
+    if (ok) reconcilePersistedSelection(true);
+    return ok;
   }
 
   async function unassignSelectedOwner(uid: string): Promise<boolean> {
-    return runViewTask(() => store.unassignOwner(uid, actor), "flash");
+    const ok = await runViewTask(() => store.unassignOwner(uid, actor), "flash");
+    if (ok) reconcilePersistedSelection(true);
+    return ok;
   }
 
   async function setSelectedPriority(uid: string, priority: number | null): Promise<boolean> {
-    return runViewTask(() => store.setPriority(uid, actor, priority), "flash");
+    const ok = await runViewTask(() => store.setPriority(uid, actor, priority), "flash");
+    if (ok) reconcilePersistedSelection(true);
+    return ok;
   }
 
   async function addSelectedLabel(uid: string, label: string): Promise<boolean> {
-    return runViewTask(() => store.addLabel(uid, actor, label), "flash");
+    const ok = await runViewTask(() => store.addLabel(uid, actor, label), "flash");
+    if (ok) reconcilePersistedSelection(true);
+    return ok;
   }
 
   async function removeSelectedLabel(uid: string, label: string): Promise<void> {
-    await runViewTask(() => store.removeLabel(uid, actor, label), "flash");
+    const ok = await runViewTask(() => store.removeLabel(uid, actor, label), "flash");
+    if (ok) reconcilePersistedSelection(true);
   }
 
   function selectedMessageLinks(): MessageLinkRef[] {
@@ -1109,7 +2411,7 @@
   ): Promise<boolean> {
     const selected = store.selectedIssue;
     if (!selected) return false;
-    return runViewTask(
+    const ok = await runViewTask(
       () =>
         store.closeIssue(selected.issue.uid, actor, {
           reason,
@@ -1117,12 +2419,15 @@
         }),
       "flash",
     );
+    if (ok) reconcilePersistedSelection(true);
+    return ok;
   }
 
   async function reopenSelectedIssue(): Promise<void> {
     const selected = store.selectedIssue;
     if (!selected) return;
-    await runViewTask(() => store.reopenIssue(selected.issue.uid, actor), "flash");
+    const ok = await runViewTask(() => store.reopenIssue(selected.issue.uid, actor), "flash");
+    if (ok) reconcilePersistedSelection(true);
   }
 
   async function deleteSelectedIssue(): Promise<boolean> {
@@ -1151,14 +2456,14 @@
   }
 </script>
 
-<section class="kata-feature" aria-labelledby="kata-title" inert={switchingDaemon} aria-busy={switchingDaemon}>
+<section class="kata-feature" aria-labelledby="kata-title" inert={switchingDaemon} aria-busy={switchingDaemon || restoreRetrying}>
   <header class="kata-header">
     <div class="kata-header-title">
       <h1 id="kata-title">Kata</h1>
       {#if daemonInfos.length > 0}
         <KataDaemonSwitcher
           daemons={daemonInfos}
-          activeId={activeKataDaemonId}
+          activeId={provisionalRoutedDaemon === null ? activeKataDaemonId : acceptedKataDaemonId}
           activeStatusLabel={activeDaemonStatusLabel()}
           activeStatusTone={activeDaemonStatusLabel() ? "error" : undefined}
           disabled={daemonSwitchLocked()}
@@ -1184,22 +2489,79 @@
           <LayoutPanelTopIcon size={15} strokeWidth={1.8} aria-hidden="true" />
         {/if}
       </IconButton>
-      <button type="button" class="accent-button header-action" onclick={() => { captureOpen = true; }}>
+      <button
+        type="button"
+        class="accent-button header-action"
+        disabled={workspaceActionsBlocked}
+        onclick={() => { if (!workspaceActionsBlocked) captureOpen = true; }}
+      >
         <PlusIcon size={13} strokeWidth={1.9} aria-hidden="true" />
         <span>New task</span>
       </button>
     </div>
   </header>
 
+  {#if cursorCatchupError}
+    <p class="kata-request-error" role="alert">
+      {cursorCatchupError}
+      {#if cursorCatchupRetry}
+        <button
+          type="button"
+          disabled={cursorCatchupRetrying}
+          aria-busy={cursorCatchupRetrying}
+          onclick={() => { void cursorCatchupRetry?.(); }}
+        >{cursorCatchupRetrying ? "Retrying…" : "Retry"}</button>
+      {/if}
+    </p>
+  {/if}
+  {#if restoreError}
+    <p class="kata-request-error" role="alert">
+      {restoreError}
+      {#if restoreRetry}
+        <button
+          type="button"
+          onclick={() => {
+            const retry = restoreRetry;
+            if (retry) void retry();
+          }}
+        >Retry</button>
+      {/if}
+    </p>
+  {/if}
+  {#if ancestorRevealError}
+    <p class="kata-request-error" role="alert">
+      {ancestorRevealError}
+      {#if ancestorRevealRetry}
+        <button
+          type="button"
+          onclick={() => {
+            const retry = ancestorRevealRetry;
+            if (retry) void retry();
+          }}
+        >Retry</button>
+      {/if}
+    </p>
+  {/if}
+  {#if terminalDaemonFailure && terminalRecovery}
+    <p class="kata-request-error" role="alert">
+      The retained Kata workspace is read-only until its daemon reconnects.
+      <button
+        type="button"
+        disabled={terminalRecovering}
+        aria-busy={terminalRecovering}
+        onclick={() => { void terminalRecovery?.(); }}
+      >{terminalRecovering ? "Retrying…" : "Retry"}</button>
+    </p>
+  {/if}
 
-  <div class="kata-layout">
+  <div class="kata-layout" inert={workspaceReadOnly} aria-busy={restoreRetrying || terminalRecovering}>
     <KataSidebar
-      areas={store.areas}
-      projects={store.projects}
+      areas={visibleAreas}
+      projects={visibleProjects}
       currentView={store.currentView}
       searchFilters={store.searchFilters}
       onOpenView={(name) => {
-        void openRoutedSystemView(name);
+        void openRoutedSystemView(name, true);
       }}
       onOpenProject={(projectUID) => {
         scheduleProjectScope(projectUID);
@@ -1242,7 +2604,7 @@
     {:else}
       <KataSearchPanel
         filters={store.searchFilters}
-        projects={store.projects}
+        projects={visibleProjects}
         duplicateCandidates={store.duplicateCandidates}
         onChange={updateSearchFilters}
       />
@@ -1256,6 +2618,7 @@
           statusFilter={listStatusFilter}
           resetGeneration={listResetGeneration}
           navigationGeneration={navigationEpoch}
+          {revealRequest}
           api={store.api}
           onSelect={(issue) => {
             void selectIssue(issue.uid);
@@ -1326,6 +2689,7 @@
 
 <QuickCapture
   open={captureOpen}
+  disabled={workspaceActionsBlocked}
   onClose={() => { captureOpen = false; }}
   onSubmit={submitQuickCapture}
 />

--- a/frontend/src/lib/features/kata/KataWorkspace.svelte
+++ b/frontend/src/lib/features/kata/KataWorkspace.svelte
@@ -103,6 +103,7 @@
     startEventStream: boolean;
     persistenceDelta: RestorePersistenceDelta | undefined;
     ancestorReveal: { uid: string; chain: readonly KataTaskSummary[] } | null;
+    ancestorRevealError?: string | undefined;
   }
 
   interface KataRecurrenceDialogController {
@@ -157,6 +158,7 @@
   let recurrenceDialogs = $state<KataRecurrenceDialogController | null>(null);
   let workspaceActionBusy = $state(false);
   let workspaceOwnershipPending = $state(true);
+  let unknownRoutedBootstrapPending = $state(false);
   let listMode = $state<ListMode>("tasks");
   let graphSourceIssue = $state.raw<KataTaskSummary | null>(null);
   const store = createKataWorkspaceStore({ api: untrack(() => api) });
@@ -405,7 +407,6 @@
   async function resolveRestoredAncestorChain(
     selected: KataTaskSummary,
     daemonID: string,
-    generation: number,
     shouldApply: () => boolean,
     workspaceStore = store,
   ): Promise<readonly KataTaskSummary[] | null | undefined> {
@@ -413,7 +414,7 @@
     const visited = new Set([selected.uid]);
     let current = selected;
     for (let depth = 0; current.parent; depth += 1) {
-      if (generation !== navigationGeneration || !shouldApply()) return undefined;
+      if (!shouldApply()) return undefined;
       if (depth >= 32 || visited.has(current.parent.uid)) return null;
       visited.add(current.parent.uid);
       let detail: KataTaskDetail;
@@ -423,7 +424,7 @@
         if (isDefinitiveRestoreFailure(error)) return null;
         throw error;
       }
-      if (generation !== navigationGeneration || !shouldApply()) return undefined;
+      if (!shouldApply()) return undefined;
       if (!detail.issue) return null;
       workspaceStore.rememberTasks([detail.issue, ...(detail.children ?? [])]);
       current = detail.issue;
@@ -439,33 +440,33 @@
     workspaceStore = store,
   ): Promise<void> {
     const retrySignature = fullRouteSignature();
+    const isCurrent = (): boolean =>
+      shouldApply() &&
+      retrySignature === fullRouteSignature() &&
+      (workspaceStore.daemonId === undefined || workspaceStore.daemonId === daemonID) &&
+      workspaceStore.selectedIssue?.issue.uid === selected.uid;
     try {
-      const restoreGeneration = navigationGeneration;
       const chain = await resolveRestoredAncestorChain(
         selected,
         daemonID,
-        restoreGeneration,
-        shouldApply,
+        isCurrent,
         workspaceStore,
       );
-      if (chain === undefined || restoreGeneration !== navigationGeneration || !shouldApply()) return;
+      if (chain === undefined || !isCurrent()) return;
       ancestorRevealError = null;
       ancestorRevealRetry = null;
       ancestorRevealRetryRouteSignature = null;
       if (chain) revealRequest = { uid: selected.uid, chain, generation: ++revealGeneration };
     } catch (error) {
       if (
-        !shouldApply() ||
-        (workspaceStore.daemonId !== undefined && workspaceStore.daemonId !== daemonID) ||
-        fullRouteSignature() !== retrySignature ||
-        workspaceStore.selectedIssue?.issue.uid !== selected.uid
+        !isCurrent()
       ) {
         return;
       }
       ancestorRevealError = kataRequestErrorMessage(error);
       ancestorRevealRetryRouteSignature = retrySignature;
       ancestorRevealRetry = async () => {
-        if (!shouldApply() || retrySignature !== fullRouteSignature()) return;
+        if (!isCurrent()) return;
         ancestorRevealError = null;
         await revealSelectedAncestors(selected, daemonID, shouldApply, workspaceStore);
       };
@@ -543,6 +544,7 @@
     let acceptedPersisted: KataPersistedWorkspaceState | null = persisted;
     let persistenceDelta: RestorePersistenceDelta | undefined;
     let ancestorReveal: RestoreResult["ancestorReveal"] = null;
+    let ancestorRevealErrorMessage: string | undefined;
     let scopeUID = route.scope;
     let view = route.view ?? (inheritRouteFields ? persisted?.view : undefined) ?? "all";
     let issueUID = route.issue ?? (inheritRouteFields ? persisted?.selectedIssueUID : null) ?? null;
@@ -773,17 +775,19 @@
       if (sources.selection === "persisted") {
         const restoredIssue = workspaceStore.selectedIssue.issue;
         workspaceStore.rememberTasks([restoredIssue, ...(workspaceStore.selectedIssue.children ?? [])]);
-        if (workspaceStore === store) {
-          void revealSelectedAncestors(restoredIssue, daemonID, shouldApply, workspaceStore);
-        } else {
-          const chain = await resolveRestoredAncestorChain(
-            restoredIssue,
-            daemonID,
-            navigationGeneration,
-            shouldApply,
-            workspaceStore,
-          );
-          if (chain && shouldApply()) ancestorReveal = { uid: restoredIssue.uid, chain };
+        if (workspaceStore !== store) {
+          try {
+            const chain = await resolveRestoredAncestorChain(
+              restoredIssue,
+              daemonID,
+              shouldApply,
+              workspaceStore,
+            );
+            if (chain && shouldApply()) ancestorReveal = { uid: restoredIssue.uid, chain };
+          } catch (error) {
+            if (!shouldApply()) return;
+            ancestorRevealErrorMessage = kataRequestErrorMessage(error);
+          }
         }
       }
     };
@@ -822,6 +826,7 @@
       startEventStream: true,
       persistenceDelta,
       ancestorReveal,
+      ancestorRevealError: ancestorRevealErrorMessage,
     };
   }
 
@@ -843,8 +848,10 @@
         const unknownRoutedDaemon = requestedDaemonId !== null && !daemons.some((daemon) => daemon.id === requestedDaemonId);
         if (unknownRoutedDaemon) {
           store.resetToInertWorkspace();
+          store.clearDaemonBinding();
           stopEventStream();
-          workspaceOwnershipPending = false;
+          unknownRoutedBootstrapPending = true;
+          workspaceOwnershipPending = true;
           return;
         }
         routedDaemonId = requestedDaemonId;
@@ -894,9 +901,6 @@
               if (store.selectedIssue) {
                 const restoredIssue = store.selectedIssue.issue;
                 store.rememberTasks([restoredIssue, ...(store.selectedIssue.children ?? [])]);
-                void revealSelectedAncestors(restoredIssue, daemonID, () =>
-                  routedDaemonId === null || routedRestoreIsCurrent(restoreGeneration, attemptedSignature),
-                );
               }
             } else if (
               isDefinitiveRestoreFailure(selectionError) &&
@@ -933,8 +937,29 @@
                   }
                 : currentRouteSnapshot();
             onRouteStateChange?.({ ...route, daemon: null }, { replace: true });
+            persistActiveWorkspaceState();
+            if (store.selectedIssue) {
+              const restoredIssue = store.selectedIssue.issue;
+              void revealSelectedAncestors(restoredIssue, routedDaemonId, () =>
+                store.daemonId === routedDaemonId &&
+                fullRouteSignature() === fullRouteSignatureFor(route),
+              );
+            }
+          } else if (restored.startEventStream && catchUpCursor) {
+            workspaceOwnershipPending = false;
+          } else if (routedDaemonId === null && !restored.startEventStream) {
+            workspaceOwnershipPending = false;
           }
-          if (restored.startEventStream && catchUpCursor) startEventStream();
+          if (restored.startEventStream && catchUpCursor) {
+            startEventStream();
+            if (store.selectedIssue) {
+              const restoredIssue = store.selectedIssue.issue;
+              void revealSelectedAncestors(restoredIssue, daemonID, () =>
+                (store.daemonId === undefined || store.daemonId === daemonID) &&
+                store.selectedIssue?.issue.uid === restoredIssue.uid,
+              );
+            }
+          }
           error = null;
           if (restoreRetryRouteSignature === null) {
             restoreError = null;
@@ -1047,12 +1072,19 @@
             if (!cancelled) {
               startEventStream();
               workspaceOwnershipPending = false;
+              if (store.selectedIssue) {
+                const restoredIssue = store.selectedIssue.issue;
+                void revealSelectedAncestors(restoredIssue, daemonID, () =>
+                  (store.daemonId === undefined || store.daemonId === daemonID) &&
+                  store.selectedIssue?.issue.uid === restoredIssue.uid,
+                );
+              }
             }
           } catch (cursorError) {
             if (cancelled) return;
             cursorCatchupError = kataRequestErrorMessage(cursorError);
             cursorCatchupRetry = () => retryEventCursorCatchup(true);
-            workspaceOwnershipPending = false;
+            workspaceOwnershipPending = true;
             terminalDaemonFailure = false;
             terminalRecovery = null;
             error = null;
@@ -1176,6 +1208,7 @@
           setActiveKataDaemon(recoveryDaemonID);
           terminalDaemonFailure = false;
           terminalRecovery = null;
+          workspaceOwnershipPending = false;
           error = null;
           if (restored.startEventStream) startEventStream();
           routedRestoreRouteSignature = null;
@@ -1256,7 +1289,16 @@
   // completions cannot repaint the new daemon. Only ownership setup, another
   // switch transaction, or non-supersedable writes hold the exclusive lock.
   function daemonSwitchLocked(): boolean {
-    return loading || switchingDaemon || workspaceReadOnly || store.hasPendingMutations || workspaceActionBusy;
+    return (
+      loading ||
+      switchingDaemon ||
+      provisionalRoutedDaemon !== null ||
+      routedFallbackRecovering ||
+      restoreRetry !== null ||
+      terminalDaemonFailure ||
+      store.hasPendingMutations ||
+      workspaceActionBusy
+    );
   }
 
   // The reconciler starts route list loads without awaiting so a newer
@@ -1439,6 +1481,11 @@
     void routeScopeUID;
     void selectedIssueUID;
     untrack(() => {
+      if (unknownRoutedBootstrapPending && requestedDaemonId === null) {
+        unknownRoutedBootstrapPending = false;
+        workspaceOwnershipPending = true;
+        if (acceptedKataDaemonId) void recoverRoutedFallbackDaemon(acceptedKataDaemonId);
+      }
       if (pendingDirectGraphSelectionUID !== null && pendingDirectGraphSelectionUID !== (selectedIssueUID ?? null)) {
         pendingDirectGraphSelectionUID = null;
       }
@@ -1776,7 +1823,10 @@
         terminalDaemonFailure = false;
         terminalRecovery = null;
         error = null;
-        if (startStreamAfterSuccess) startEventStream();
+        if (startStreamAfterSuccess) {
+          workspaceOwnershipPending = false;
+          startEventStream();
+        }
       }
     } catch (error) {
       if (isCursorCatchupScopeCurrent(scope)) {
@@ -1954,6 +2004,7 @@
   }
 
   async function createKataProject(name: string): Promise<KataProjectSummary> {
+    if (workspaceActionsBlocked) throw new Error("Kata workspace is not writable.");
     let created: KataProjectSummary | undefined;
     await runViewTaskOrThrow(async () => {
       created = await store.createProject(name);
@@ -2054,25 +2105,32 @@
     store.invalidatePendingLoads();
     stopEventStream();
 
-    const recoverPreviousWorkspace = async (): Promise<void> => {
+    const recoverPreviousWorkspace = async (
+      shouldApply: () => boolean = () => switchOwnsTransaction(ownedSwitchGeneration, ownedRouteSignature),
+    ): Promise<boolean> => {
       if (!previousDaemonID) throw new Error("Previous Kata daemon is unavailable.");
+      if (!shouldApply()) return false;
       store.clearDaemonState(previousView);
       store.bindDaemonForBootstrap(previousDaemonID);
       setActiveKataDaemon(previousDaemonID, false);
       restoreWorkspaceMemory(previousWorkspace);
       store.bindDaemonForBootstrap(previousDaemonID);
       await store.api.instance();
+      if (!shouldApply()) return false;
       const rollbackSelectedUID = store.selectedIssue?.issue.uid ?? null;
       let rollbackMembershipRefreshed = false;
       try {
-        rollbackMembershipRefreshed = await store.syncEventCursor();
+        rollbackMembershipRefreshed = await store.syncEventCursor({ shouldApply });
+        if (!shouldApply()) return false;
         restoreCursorCatchupError(previousCursorCatchupError, previousCursorCatchupRetry);
       } catch (catchupError) {
+        if (!shouldApply()) return false;
         if (!(catchupError instanceof KataEventCursorSyncError)) throw catchupError;
         rollbackMembershipRefreshed = true;
         cursorCatchupError = kataRequestErrorMessage(catchupError.cursorSyncCause);
         cursorCatchupRetry = retryEventCursorCatchup;
       }
+      if (!shouldApply()) return false;
       if (rollbackMembershipRefreshed) {
         reconcileSelectionMembership(previousDaemonID, false, rollbackSelectedUID, false);
       }
@@ -2097,6 +2155,7 @@
       terminalRecovery = null;
       error = null;
       startEventStream();
+      return true;
     };
 
     try {
@@ -2183,7 +2242,17 @@
       committedRouteSignature = fullRouteSignature();
       if (restored.ancestorReveal) {
         revealRequest = { ...restored.ancestorReveal, generation: ++revealGeneration };
+      } else if (restored.ancestorRevealError && store.selectedIssue) {
+        ancestorRevealError = restored.ancestorRevealError;
+        const restoredIssue = store.selectedIssue.issue;
+        ancestorRevealRetryRouteSignature = committedRouteSignature;
+        ancestorRevealRetry = async () => {
+          if (!switchTransactionCanApply() || store.selectedIssue?.issue.uid !== restoredIssue.uid) return;
+          ancestorRevealError = null;
+          await revealSelectedAncestors(restoredIssue, id, switchTransactionCanApply);
+        };
       }
+      persistActiveWorkspaceState();
       startEventStream();
     } catch (targetError) {
       restoreError = null;
@@ -2196,8 +2265,8 @@
       try {
         if (!workspaceMounted) return;
         if (!switchOwnsTransaction(ownedSwitchGeneration, ownedRouteSignature)) return;
-        await recoverPreviousWorkspace();
-        if (workspaceMounted) showFlash(targetMessage, { tone: "danger" });
+        const recovered = await recoverPreviousWorkspace();
+        if (recovered && workspaceMounted) showFlash(targetMessage, { tone: "danger" });
       } catch (rollbackError) {
         terminalDaemonFailure = true;
         setActiveKataDaemon(previousDaemonID, false);
@@ -2207,9 +2276,12 @@
         error = `${targetMessage} ${kataRequestErrorMessage(rollbackError)}`;
         terminalRecovery = async () => {
           if (terminalRecovering) return;
+          const recoveryRouteSignature = fullRouteSignature();
           terminalRecovering = true;
           try {
-            await recoverPreviousWorkspace();
+            await recoverPreviousWorkspace(
+              () => workspaceMounted && terminalRecovering && fullRouteSignature() === recoveryRouteSignature,
+            );
           } catch (recoveryError) {
             terminalDaemonFailure = true;
             error = `${targetMessage} ${kataRequestErrorMessage(recoveryError)}`;
@@ -2274,7 +2346,7 @@
 
   async function moveSelectedIssue(toProjectUID: string): Promise<boolean> {
     const selected = store.selectedIssue?.issue;
-    if (!selected || !toProjectUID || pendingMoveIssueUIDs.has(selected.uid)) return false;
+    if (workspaceActionsBlocked || !selected || !toProjectUID || pendingMoveIssueUIDs.has(selected.uid)) return false;
     const sourceIssueUID = selected.uid;
     const generation = navigationGeneration;
     pendingMoveIssueUIDs = new Set(pendingMoveIssueUIDs).add(sourceIssueUID);
@@ -2294,46 +2366,54 @@
   }
 
   async function patchSelectedMetadata(uid: string, patch: Record<string, unknown>): Promise<boolean> {
+    if (workspaceActionsBlocked) return false;
     const ok = await runViewTask(() => store.patchMetadata(uid, actor, patch), "flash");
     if (ok) reconcilePersistedSelection(true);
     return ok;
   }
 
   async function addSelectedComment(uid: string, body: string): Promise<boolean> {
+    if (workspaceActionsBlocked) return false;
     return runViewTask(() => store.addComment(uid, actor, body), "flash");
   }
 
   async function editSelectedIssue(uid: string, patch: KataTaskEditPatch): Promise<boolean> {
+    if (workspaceActionsBlocked) return false;
     const ok = await runViewTask(() => store.editIssue(uid, actor, patch), "flash");
     if (ok) reconcilePersistedSelection(true);
     return ok;
   }
 
   async function assignSelectedOwner(uid: string, owner: string): Promise<boolean> {
+    if (workspaceActionsBlocked) return false;
     const ok = await runViewTask(() => store.assignOwner(uid, actor, owner), "flash");
     if (ok) reconcilePersistedSelection(true);
     return ok;
   }
 
   async function unassignSelectedOwner(uid: string): Promise<boolean> {
+    if (workspaceActionsBlocked) return false;
     const ok = await runViewTask(() => store.unassignOwner(uid, actor), "flash");
     if (ok) reconcilePersistedSelection(true);
     return ok;
   }
 
   async function setSelectedPriority(uid: string, priority: number | null): Promise<boolean> {
+    if (workspaceActionsBlocked) return false;
     const ok = await runViewTask(() => store.setPriority(uid, actor, priority), "flash");
     if (ok) reconcilePersistedSelection(true);
     return ok;
   }
 
   async function addSelectedLabel(uid: string, label: string): Promise<boolean> {
+    if (workspaceActionsBlocked) return false;
     const ok = await runViewTask(() => store.addLabel(uid, actor, label), "flash");
     if (ok) reconcilePersistedSelection(true);
     return ok;
   }
 
   async function removeSelectedLabel(uid: string, label: string): Promise<void> {
+    if (workspaceActionsBlocked) return;
     const ok = await runViewTask(() => store.removeLabel(uid, actor, label), "flash");
     if (ok) reconcilePersistedSelection(true);
   }
@@ -2348,7 +2428,7 @@
 
   async function createWorkspaceForSelectedIssue(): Promise<void> {
     const selected = store.selectedIssue?.issue;
-    if (!selected || workspaceActionBusy) return;
+    if (workspaceActionsBlocked || !selected || workspaceActionBusy) return;
     workspaceActionBusy = true;
     try {
       const created = await createKataWorkspaceForTask(
@@ -2380,7 +2460,7 @@
     return {
       label: "Create workspace",
       busy: workspaceActionBusy,
-      disabled: workspaceActionBusy,
+      disabled: workspaceActionsBlocked,
       onClick: createWorkspaceForSelectedIssue,
     };
   }
@@ -2390,18 +2470,21 @@
   }
 
   async function createRecurrence(projectID: number, input: KataCreateRecurrenceInput): Promise<void> {
+    if (workspaceActionsBlocked) return;
     await runViewTaskOrThrow(async () => {
       await store.createRecurrence(projectID, input);
     }, "none");
   }
 
   async function patchRecurrence(id: number, input: KataPatchRecurrenceInput, etag: string): Promise<void> {
+    if (workspaceActionsBlocked) return;
     await runViewTaskOrThrow(async () => {
       await store.patchRecurrence(id, input, etag);
     }, "none");
   }
 
   async function deleteRecurrence(recurrence: KataRecurrence): Promise<boolean> {
+    if (workspaceActionsBlocked) return false;
     return runViewTask(() => store.deleteRecurrence(recurrence.id, actor), "flash");
   }
 
@@ -2410,7 +2493,7 @@
     message: string,
   ): Promise<boolean> {
     const selected = store.selectedIssue;
-    if (!selected) return false;
+    if (workspaceActionsBlocked || !selected) return false;
     const ok = await runViewTask(
       () =>
         store.closeIssue(selected.issue.uid, actor, {
@@ -2425,7 +2508,7 @@
 
   async function reopenSelectedIssue(): Promise<void> {
     const selected = store.selectedIssue;
-    if (!selected) return;
+    if (workspaceActionsBlocked || !selected) return;
     const ok = await runViewTask(() => store.reopenIssue(selected.issue.uid, actor), "flash");
     if (ok) reconcilePersistedSelection(true);
   }
@@ -2435,7 +2518,7 @@
   }
 
   async function unlinkMessageLink(link: MessageLinkRef): Promise<void> {
-    if (unlinkBusyIds.size > 0) return;
+    if (workspaceActionsBlocked || unlinkBusyIds.size > 0) return;
     const selected = store.selectedIssue;
     if (!selected) return;
     const uid = selected.issue.uid;
@@ -2554,7 +2637,7 @@
     </p>
   {/if}
 
-  <div class="kata-layout" inert={workspaceReadOnly} aria-busy={restoreRetrying || terminalRecovering}>
+  <div class="kata-layout" inert={workspaceOwnershipPending || workspaceReadOnly} aria-busy={restoreRetrying || terminalRecovering}>
     <KataSidebar
       areas={visibleAreas}
       projects={visibleProjects}

--- a/frontend/src/lib/features/kata/KataWorkspace.test.ts
+++ b/frontend/src/lib/features/kata/KataWorkspace.test.ts
@@ -91,6 +91,12 @@ function acceptHomeDaemon(): void {
   setActiveKataDaemon("home");
 }
 
+async function waitForWorkspaceWritable(): Promise<void> {
+  await waitFor(() =>
+    expect((screen.getByRole("button", { name: "New task" }) as HTMLButtonElement).disabled).toBe(false),
+  );
+}
+
 describe("KataWorkspace", () => {
   beforeEach(() => {
     resetKataWorkspaceTestState();
@@ -560,7 +566,7 @@ describe("KataWorkspace", () => {
     parentDetail.resolve(detail(parent.uid, [parent, child]));
   });
 
-  it("drops a superseded routed ancestor walk before it crosses into the fallback daemon", async () => {
+  it("drops an accepted routed ancestor walk when the route selection changes", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
       Response.json({
         daemons: [
@@ -603,11 +609,13 @@ describe("KataWorkspace", () => {
     await waitFor(() => expect(api.issue).toHaveBeenCalledWith(parent.uid, { daemonId: "work" }));
 
     component.setRoute({ issue: null, daemon: null });
-    await waitFor(() => expect(vi.mocked(api.bindWorkflowDaemon!).mock.calls.at(-1)?.[0]).toBe("home"));
+    await tick();
+    expect(component.route().issue).toBeNull();
     parentDetail.resolve(detail(parent.uid, [grandparent, parent, child]));
     await Promise.resolve();
     await Promise.resolve();
 
+    expect(getActiveKataDaemon()).toBe("work");
     expect(api.issue).not.toHaveBeenCalledWith(grandparent.uid);
     expect(screen.queryByText("ancestor crossed daemon boundary")).toBeNull();
   });
@@ -625,8 +633,10 @@ describe("KataWorkspace", () => {
     render(KataWorkspaceRouteHost, { props: { api, initialIssue: child.uid } });
 
     await waitFor(() => expect(screen.getByRole("heading", { name: "Routed child" })).toBeTruthy());
+    await waitFor(() =>
+      expect(issueDetail).toHaveBeenCalledWith(parent.uid, expect.objectContaining({ daemonId: "home" })),
+    );
     await waitFor(() => expect(screen.getByText("Routed child", { selector: ".title-text" })).toBeTruthy());
-    expect(issueDetail).toHaveBeenCalledWith(parent.uid, expect.objectContaining({ daemonId: "home" }));
   });
 
   it("keeps an accepted task selected while retrying transient ancestor failures", async () => {
@@ -658,10 +668,8 @@ describe("KataWorkspace", () => {
     const layout = screen.getByLabelText("Kata tasks").parentElement as HTMLElement & {
       inert: boolean;
     };
+    await waitForWorkspaceWritable();
     expect(layout.inert).toBe(false);
-    await waitFor(() =>
-      expect((screen.getByRole("button", { name: "New task" }) as HTMLButtonElement).disabled).toBe(false),
-    );
     expect(screen.getByRole("heading", { name: "Child retry task" })).toBeTruthy();
     expect(component.route().issue).toBe(child.uid);
     expect(loadKataWorkspaceState("home")?.selectedIssueUID).toBe(child.uid);
@@ -1788,6 +1796,9 @@ describe("KataWorkspace", () => {
 
       render(KataWorkspaceRouteHost, { props: { api, initialView: view, initialIssue: initial.uid } });
       await waitFor(() => expect(screen.getByRole("heading", { name: initial.title })).toBeTruthy());
+      await waitFor(() =>
+        expect((screen.getByRole("button", { name: "New task" }) as HTMLButtonElement).disabled).toBe(false),
+      );
       saveKataWorkspaceState("home", {
         view,
         filters: { scope: { kind: "all" }, status: "open", owner: "", label: "", query: "" },
@@ -2091,6 +2102,29 @@ describe("KataWorkspace", () => {
     expect(screen.getByText("Select a task")).toBeTruthy();
   });
 
+  it("recovers the accepted daemon when an unknown routed daemon is removed on the same mount", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [{ id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" }],
+      }),
+    );
+    setActiveKataDaemon("home");
+    const home = initialIssues[0]!;
+    const api = createDaemonWorkspaceAPI({ home: [home] });
+
+    const { component } = render(KataWorkspaceRouteHost, {
+      props: { api, initialIssue: home.uid, initialDaemon: "missing" },
+    });
+
+    await screen.findByText("Kata daemon missing is not configured.");
+    component.setRoute({ issue: home.uid, daemon: null });
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Pay rent" })).toBeTruthy());
+    expect(getActiveKataDaemon()).toBe("home");
+    expect(api.issue).toHaveBeenCalledWith(home.uid, expect.objectContaining({ signal: expect.any(AbortSignal) }));
+    expect((screen.getByRole("button", { name: "New task" }) as HTMLButtonElement).disabled).toBe(false);
+  });
+
   it("accepts a routed daemon after a successful restoration retry", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
       Response.json({
@@ -2124,6 +2158,37 @@ describe("KataWorkspace", () => {
       expect(component.route().daemon).toBeNull();
       expect(screen.getByRole("heading", { name: "Email Susan re: Q3" })).toBeTruthy();
     });
+  });
+
+  it("persists a routed daemon selection only after the target is accepted", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [
+          { id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" },
+          { id: "work", url: "http://127.0.0.1:8888", default: false, auth: "none", health: "connected" },
+        ],
+      }),
+    );
+    setActiveKataDaemon("home");
+    const home = initialIssues[0]!;
+    const work = initialIssues[1]!;
+    const api = createDaemonWorkspaceAPI({ home: [home], work: [work] });
+    saveKataWorkspaceState("work", {
+      view: "all",
+      filters: { scope: { kind: "all" }, status: "open", owner: "", label: "", query: "" },
+      selectedIssueUID: null,
+    });
+
+    const { component } = render(KataWorkspaceRouteHost, {
+      props: { api, initialIssue: work.uid, initialDaemon: "work" },
+    });
+
+    await waitFor(() => {
+      expect(getActiveKataDaemon()).toBe("work");
+      expect(component.route().daemon).toBeNull();
+      expect(screen.getByRole("heading", { name: "Email Susan re: Q3" })).toBeTruthy();
+    });
+    expect(loadKataWorkspaceState("work")?.selectedIssueUID).toBe(work.uid);
   });
 
   it("keeps transient routed detail failures provisional and read-only", async () => {
@@ -2691,6 +2756,55 @@ describe("KataWorkspace", () => {
     expect(getActiveKataDaemon()).toBe("work");
   });
 
+  it("accepts a target daemon when candidate ancestor reconstruction fails transiently", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [
+          { id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" },
+          { id: "work", url: "http://127.0.0.1:8888", default: false, auth: "none", health: "connected" },
+        ],
+      }),
+    );
+    setActiveKataDaemon("home");
+    const home = initialIssues[0]!;
+    const parent = issue("issue-work-parent-failed", "Unavailable parent", "project-kata");
+    const child = {
+      ...issue("issue-work-child-accepted", "Accepted child", "project-kata"),
+      parent: { uid: parent.uid, short_id: parent.short_id },
+      parent_short_id: parent.short_id,
+    };
+    const api = createDaemonWorkspaceAPI({ home: [home], work: [child] });
+    saveKataWorkspaceState("home", {
+      view: "all",
+      filters: { scope: { kind: "all" }, status: "open", owner: "", label: "", query: "" },
+      selectedIssueUID: home.uid,
+    });
+    vi.mocked(api.issue).mockImplementation(async (uid, opts) => {
+      if (uid === child.uid && opts?.daemonId === "work") return detail(child.uid, [child]);
+      if (uid === parent.uid && opts?.daemonId === "work") throw new Error("ancestor timed out");
+      return detail(uid, [home]);
+    });
+    saveKataWorkspaceState("work", {
+      view: "all",
+      filters: { scope: { kind: "all" }, status: "open", owner: "", label: "", query: "" },
+      selectedIssueUID: child.uid,
+    });
+
+    render(KataWorkspace, { props: { api } });
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Pay rent" })).toBeTruthy());
+    await fireEvent.click(screen.getByTestId("daemon-chip"));
+    const workDaemonRow = (await screen.findByTestId("daemon-row-work")) as HTMLButtonElement;
+    await waitFor(() => expect(workDaemonRow.disabled).toBe(false));
+    await fireEvent.click(workDaemonRow);
+
+    await waitFor(() => {
+      expect(getActiveKataDaemon()).toBe("work");
+      expect(screen.getByRole("heading", { name: "Accepted child" })).toBeTruthy();
+      expect(screen.getByText("ancestor timed out")).toBeTruthy();
+    });
+    expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+  });
+
   it("does not reveal candidate ancestors while rollback is pending", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
       Response.json({
@@ -2767,6 +2881,60 @@ describe("KataWorkspace", () => {
 
     rollbackCursor.resolve({ reset_required: false, events: [], next_after_id: 0 });
     await waitFor(() => expect(getActiveKataDaemon()).toBe("home"));
+  });
+
+  it("drops rollback cursor work after a route change supersedes the switch", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [
+          { id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" },
+          { id: "work", url: "http://127.0.0.1:8888", default: false, auth: "none", health: "connected" },
+        ],
+      }),
+    );
+    setActiveKataDaemon("home");
+    const home = initialIssues[0]!;
+    const api = createDaemonWorkspaceAPI({ home: [home], work: [initialIssues[1]!] });
+    const rollbackInstance = deferred<Awaited<ReturnType<KataTaskAPI["instance"]>>>();
+    let workAttempted = false;
+    let homeCursorCalls = 0;
+    vi.mocked(api.instance).mockImplementation(async (opts) => {
+      const daemonID = opts?.daemonId ?? vi.mocked(api.bindWorkflowDaemon!).mock.calls.at(-1)?.[0];
+      if (daemonID === "work") {
+        workAttempted = true;
+        throw new Error("work unavailable");
+      }
+      if (workAttempted && daemonID === "home") return rollbackInstance.promise;
+      return { instance_uid: "instance-1", version: "dev", schema_version: 1 };
+    });
+    vi.mocked(api.events).mockImplementation(async (query = {}, opts) => {
+      const daemonID = opts?.daemonId ?? vi.mocked(api.bindWorkflowDaemon!).mock.calls.at(-1)?.[0];
+      if (daemonID === "home" && query.after_id !== undefined && query.issue_uid === undefined) {
+        homeCursorCalls += 1;
+      }
+      return { reset_required: false, events: [], next_after_id: query.after_id ?? 0 };
+    });
+
+    const { component } = render(KataWorkspaceRouteHost, {
+      props: { api, initialIssue: home.uid },
+    });
+    await waitForWorkspaceWritable();
+    expect(homeCursorCalls).toBe(1);
+
+    await fireEvent.click(screen.getByTestId("daemon-chip"));
+    const workDaemonRow = (await screen.findByTestId("daemon-row-work")) as HTMLButtonElement;
+    await waitFor(() => expect(workDaemonRow.disabled).toBe(false));
+    await fireEvent.click(workDaemonRow);
+    await waitFor(() => expect(workAttempted).toBe(true));
+
+    component.setRoute({ issue: null, daemon: null });
+    await tick();
+    rollbackInstance.resolve({ instance_uid: "instance-1", version: "dev", schema_version: 1 });
+    await tick();
+    await tick();
+
+    expect(component.route().issue).toBeNull();
+    expect(homeCursorCalls).toBe(1);
   });
 
   it("waits for candidate history and recurrence reads before adopting the target detail", async () => {
@@ -2988,6 +3156,50 @@ describe("KataWorkspace", () => {
     cursor.resolve({ reset_required: false, events: [], next_after_id: 0 });
 
     await waitFor(() => expect(captureButton.disabled).toBe(false));
+  });
+
+  it("keeps the workspace inert after an initial cursor failure until Retry accepts ownership", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = new URL(input instanceof Request ? input.url : String(input), window.location.origin);
+      if (url.pathname === "/api/v1/kata/daemons") {
+        return Response.json({
+          daemons: [
+            {
+              id: "home",
+              url: "http://127.0.0.1:7777",
+              default: true,
+              auth: "none",
+              health: "connected",
+            },
+          ],
+        });
+      }
+      if (url.pathname === "/api/v1/kata/proxy/api/v1/events/stream") {
+        return new Response(new ReadableStream<Uint8Array>({}), {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    });
+    const api = createDaemonWorkspaceAPI({ home: [...initialIssues] });
+    vi.mocked(api.events)
+      .mockRejectedValueOnce(new Error("initial cursor unavailable"))
+      .mockResolvedValue({ reset_required: false, events: [], next_after_id: 0 });
+
+    render(KataWorkspace, { props: { api } });
+
+    const retry = await screen.findByRole("button", { name: "Retry" });
+    const captureButton = screen.getByRole("button", { name: "New task" }) as HTMLButtonElement;
+    const layout = screen.getByLabelText("Kata tasks").parentElement as HTMLElement & { inert: boolean };
+    expect(captureButton.disabled).toBe(true);
+    expect(layout.inert).toBe(true);
+    expect(screen.getByText("Select a task")).toBeTruthy();
+
+    await fireEvent.click(retry);
+
+    await waitFor(() => expect(captureButton.disabled).toBe(false));
+    expect(layout.inert).toBe(false);
   });
 
   it("preserves a selection made while cursor catch-up that started unselected refreshes membership", async () => {
@@ -3637,6 +3849,7 @@ describe("KataWorkspace", () => {
       expect(screen.getByRole("heading", { name: "Pay rent" })).toBeTruthy();
       expect(screen.getByRole("button", { name: "Create workspace" })).toBeTruthy();
     });
+    await waitForWorkspaceWritable();
     await fireEvent.click(screen.getByRole("button", { name: "Create workspace" }));
     await fireEvent.click(screen.getByTestId("daemon-chip"));
     const workDaemonRow = screen.getByTestId("daemon-row-work") as HTMLButtonElement;
@@ -3693,6 +3906,7 @@ describe("KataWorkspace", () => {
 
     render(KataWorkspace, { props: { api, selectedIssueUID: "issue-pay-rent" } });
     await waitFor(() => expect(screen.getByRole("button", { name: "Create workspace" })).toBeTruthy());
+    await waitForWorkspaceWritable();
 
     await fireEvent.click(screen.getByRole("button", { name: "Create workspace" }));
 
@@ -3736,6 +3950,7 @@ describe("KataWorkspace", () => {
 
     render(KataWorkspace, { props: { api, selectedIssueUID: "issue-pay-rent" } });
     const createButton = await screen.findByRole("button", { name: "Create workspace" });
+    await waitForWorkspaceWritable();
     await fireEvent.click(createButton);
 
     await waitFor(() => {
@@ -3783,6 +3998,7 @@ describe("KataWorkspace", () => {
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Create workspace" })).toBeTruthy();
     });
+    await waitForWorkspaceWritable();
 
     await fireEvent.click(screen.getByRole("button", { name: "Add label" }));
     await fireEvent.input(screen.getByLabelText("New label"), { target: { value: "blocked" } });
@@ -4226,6 +4442,7 @@ describe("KataWorkspace", () => {
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: "Pay rent" })).toBeTruthy();
     });
+    await waitForWorkspaceWritable();
     const detailRegion = within(screen.getByRole("region", { name: "Task detail" }));
     await fireEvent.click(detailRegion.getByRole("button", { name: "Owner: fixture-user" }));
     const ownerInput = detailRegion.getByRole("combobox", { name: "Owner" }) as HTMLInputElement;
@@ -4263,6 +4480,7 @@ describe("KataWorkspace", () => {
     });
 
     await screen.findByRole("heading", { name: "Pay rent" });
+    await waitForWorkspaceWritable();
     const detail = within(screen.getByRole("region", { name: "Task detail" }));
     await fireEvent.click(detail.getByRole("button", { name: "More actions" }));
     await fireEvent.click(detail.getByRole("menuitem", { name: "Move to another project" }));
@@ -4438,6 +4656,7 @@ describe("KataWorkspace", () => {
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: "Pay rent" })).toBeTruthy();
     });
+    await waitForWorkspaceWritable();
     await fireEvent.click(screen.getByRole("button", { name: "Unlink Lease renewal" }));
 
     await waitFor(() => {
@@ -4469,6 +4688,7 @@ describe("KataWorkspace", () => {
 
     render(KataWorkspace, { props: { api, selectedIssueUID: "issue-pay-rent" } });
     await waitFor(() => expect(screen.getByRole("button", { name: "Unlink Lease renewal" })).toBeTruthy());
+    await waitForWorkspaceWritable();
 
     await fireEvent.click(screen.getByRole("button", { name: "Unlink Lease renewal" }));
 

--- a/frontend/src/lib/features/kata/KataWorkspace.test.ts
+++ b/frontend/src/lib/features/kata/KataWorkspace.test.ts
@@ -1,23 +1,29 @@
 import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/svelte";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import * as flash from "@middleman/ui/stores/flash";
+import { tick } from "svelte";
 
 import { KataTaskAPIError } from "../../api/kata/taskClient.js";
 import type {
+  KataTaskAPI,
   KataTaskDetail,
+  KataTaskEventsResponse,
   KataTaskLink,
   KataTaskSearchFilters,
   KataTaskSearchResponse,
+  KataTaskViewName,
 } from "../../api/kata/taskTypes.js";
 import type { KataWorkspaceTarget } from "../../api/kata/workspaces.js";
 import {
   getActiveKataDaemon,
   getDefaultKataDaemon,
   getKataDaemonRoster,
+  setActiveKataDaemon,
 } from "../../stores/active-kata-daemon.svelte.js";
 import { defaultProviderCapabilities } from "../../components/repositories/repoSummary.js";
 import KataWorkspace from "./KataWorkspace.svelte";
 import KataWorkspaceRouteHost from "./KataWorkspaceRouteHost.svelte";
+import { loadKataWorkspaceState, saveKataWorkspaceState } from "./kataWorkspacePersistence.js";
 import {
   createDaemonWorkspaceAPI,
   createWorkspaceAPI,
@@ -28,6 +34,7 @@ import {
   issue,
   messageLink,
   projects,
+  recurrence,
   resetKataWorkspaceTestState,
 } from "./KataWorkspaceTestSupport.js";
 
@@ -67,6 +74,23 @@ function graphNodeButtonWithText(text: string): HTMLButtonElement {
   return button!;
 }
 
+function acceptHomeDaemon(): void {
+  vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+    Response.json({
+      daemons: [
+        {
+          id: "home",
+          url: "http://127.0.0.1:7777",
+          default: true,
+          auth: "none",
+          health: "connected",
+        },
+      ],
+    }),
+  );
+  setActiveKataDaemon("home");
+}
+
 describe("KataWorkspace", () => {
   beforeEach(() => {
     resetKataWorkspaceTestState();
@@ -79,6 +103,603 @@ describe("KataWorkspace", () => {
     for (const item of flash.getFlashes()) flash.dismissFlash(item.id);
     vi.useRealTimers();
     vi.restoreAllMocks();
+  });
+
+  it("restores the accepted daemon's filters and selected issue on a bare route", async () => {
+    const child = {
+      ...issue("issue-child", "Child task", "project-kata"),
+      parent: { uid: "issue-parent", short_id: "parent" },
+      parent_short_id: "parent",
+    };
+    const { api } = createWorkspaceAPI([issue("issue-parent", "Parent task", "project-kata"), child]);
+    saveKataWorkspaceState("home", {
+      view: "all",
+      filters: {
+        scope: { kind: "project", project_uid: "project-kata" },
+        status: "all",
+        owner: "Susan",
+        label: "work",
+        query: "child",
+      },
+      selectedIssueUID: child.uid,
+    });
+    const onRouteStateChange = vi.fn();
+
+    render(KataWorkspace, { props: { api, onRouteStateChange } });
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Child task" })).toBeTruthy());
+    expect(api.search).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: { kind: "project", project_uid: "project-kata" },
+        status: "all",
+        owner: "Susan",
+        label: "work",
+        query: "child",
+      }),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(onRouteStateChange).toHaveBeenCalledWith(
+      { view: null, scope: "project-kata", issue: child.uid },
+      { replace: true },
+    );
+  });
+
+  it("uses explicit route fields without writing them over persisted non-route filters", async () => {
+    const explicit = issue("issue-explicit", "Explicit task", "project-finances");
+    const { api, search } = createWorkspaceAPI([explicit]);
+    const persisted = {
+      view: "inbox" as const,
+      filters: {
+        scope: { kind: "project" as const, project_uid: "project-kata" },
+        status: "closed" as const,
+        owner: "Susan",
+        label: "work",
+        query: "omits explicit",
+      },
+      selectedIssueUID: "issue-stale",
+    };
+    saveKataWorkspaceState("home", persisted);
+
+    render(KataWorkspace, {
+      props: {
+        api,
+        routeViewName: "today",
+        routeScopeUID: "project-finances",
+        selectedIssueUID: explicit.uid,
+      },
+    });
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Explicit task" })).toBeTruthy());
+    expect(search).toHaveBeenCalledWith(
+      {
+        ...persisted.filters,
+        scope: { kind: "project", project_uid: "project-finances" },
+      },
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(loadKataWorkspaceState("home")).toEqual(persisted);
+  });
+
+  it("rejects a missing persisted project before loading rows or detail", async () => {
+    const { api, projects: projectCatalog, search, issue: issueDetail } = createWorkspaceAPI();
+    saveKataWorkspaceState("home", {
+      view: "inbox",
+      filters: {
+        scope: { kind: "project", project_uid: "project-missing" },
+        status: "all",
+        owner: "Susan",
+        label: "stale",
+        query: "discard",
+      },
+      selectedIssueUID: "issue-stale",
+    });
+    const onRouteStateChange = vi.fn();
+
+    render(KataWorkspace, { props: { api, onRouteStateChange } });
+
+    await waitFor(() => expect(projectCatalog).toHaveBeenCalledTimes(1));
+    expect(screen.getByText("Select a task")).toBeTruthy();
+    expect(search).not.toHaveBeenCalled();
+    expect(issueDetail).not.toHaveBeenCalled();
+    expect(screen.getByRole("heading", { name: "All Open" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Project scope: All projects/i })).toBeTruthy();
+    expect(onRouteStateChange).toHaveBeenCalledTimes(1);
+    expect(onRouteStateChange).toHaveBeenCalledWith({ view: null, scope: null, issue: null }, { replace: true });
+    expect(loadKataWorkspaceState("home")).toBeNull();
+  });
+
+  it("discards an invalid persisted scope without discarding an explicit URL view", async () => {
+    const { api, projects: projectCatalog, issues } = createWorkspaceAPI();
+    saveKataWorkspaceState("home", {
+      view: "inbox",
+      filters: {
+        scope: { kind: "project", project_uid: "project-missing" },
+        status: "all",
+        owner: "Susan",
+        label: "stale",
+        query: "discard",
+      },
+      selectedIssueUID: "issue-stale",
+    });
+
+    render(KataWorkspace, { props: { api, routeViewName: "today" } });
+
+    await waitFor(() => expect(projectCatalog).toHaveBeenCalledTimes(1));
+    expect(screen.getByRole("heading", { name: "Today" })).toBeTruthy();
+    expect(issues).toHaveBeenCalledWith(
+      expect.objectContaining({ view: "today" }),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(loadKataWorkspaceState("home")).toBeNull();
+  });
+
+  it("discards an invalid persisted scope without discarding an explicit URL issue", async () => {
+    const explicit = initialIssues[0]!;
+    const { api, issue: issueDetail } = createWorkspaceAPI();
+    saveKataWorkspaceState("home", {
+      view: "inbox",
+      filters: {
+        scope: { kind: "project", project_uid: "project-missing" },
+        status: "all",
+        owner: "Susan",
+        label: "stale",
+        query: "discard",
+      },
+      selectedIssueUID: "issue-stale",
+    });
+
+    render(KataWorkspace, { props: { api, selectedIssueUID: explicit.uid } });
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: explicit.title })).toBeTruthy());
+    expect(issueDetail).toHaveBeenCalledWith(
+      explicit.uid,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(loadKataWorkspaceState("home")).toBeNull();
+  });
+
+  it("discards an invalid persisted scope but initializes a valid URL scope with defaults", async () => {
+    const { api, projects: projectCatalog, search } = createWorkspaceAPI();
+    saveKataWorkspaceState("home", {
+      view: "inbox",
+      filters: {
+        scope: { kind: "project", project_uid: "project-missing" },
+        status: "all",
+        owner: "Susan",
+        label: "stale",
+        query: "discard",
+      },
+      selectedIssueUID: "issue-stale",
+    });
+
+    render(KataWorkspace, { props: { api, routeScopeUID: "project-kata" } });
+
+    await waitFor(() => expect(search).toHaveBeenCalled());
+    expect(projectCatalog).toHaveBeenCalledTimes(1);
+    expect(search).toHaveBeenCalledWith(
+      {
+        scope: { kind: "project", project_uid: "project-kata" },
+        status: "open",
+        owner: "",
+        label: "",
+        query: "",
+      },
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(loadKataWorkspaceState("home")).toBeNull();
+  });
+
+  it("keeps an invalid explicit URL scope authoritative over persisted scope", async () => {
+    const { api, search } = createWorkspaceAPI();
+    const persisted = {
+      view: "all" as const,
+      filters: {
+        scope: { kind: "project" as const, project_uid: "project-kata" },
+        status: "all" as const,
+        owner: "Susan",
+        label: "work",
+        query: "saved",
+      },
+      selectedIssueUID: null,
+    };
+    saveKataWorkspaceState("home", persisted);
+    const onRouteStateChange = vi.fn();
+
+    render(KataWorkspace, { props: { api, routeScopeUID: "project-missing", onRouteStateChange } });
+
+    await waitFor(() =>
+      expect(onRouteStateChange).toHaveBeenCalledWith({ view: null, scope: null, issue: null }, { replace: true }),
+    );
+    expect(search).toHaveBeenCalledWith(
+      { ...persisted.filters, scope: { kind: "all" } },
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(loadKataWorkspaceState("home")).toEqual(persisted);
+  });
+
+  it("clears only a persisted selection missing from the filtered raw result", async () => {
+    const selected = { ...issue("issue-closed", "Closed task", "project-kata"), status: "closed" as const };
+    const { api, issue: issueDetail } = createWorkspaceAPI([selected]);
+    saveKataWorkspaceState("home", {
+      view: "all",
+      filters: {
+        scope: { kind: "project", project_uid: "project-kata" },
+        status: "open",
+        owner: "Susan",
+        label: "work",
+        query: "saved",
+      },
+      selectedIssueUID: selected.uid,
+    });
+
+    render(KataWorkspace, { props: { api } });
+
+    await waitFor(() => expect(loadKataWorkspaceState("home")?.selectedIssueUID).toBeNull());
+    expect(screen.getByText("Select a task")).toBeTruthy();
+    expect(issueDetail).not.toHaveBeenCalled();
+    expect(loadKataWorkspaceState("home")).toEqual({
+      view: "all",
+      filters: expect.objectContaining({ owner: "Susan", label: "work", query: "saved" }),
+      selectedIssueUID: null,
+    });
+  });
+
+  it("clears only the persisted selection after a definitive detail absence", async () => {
+    const selected = issue("issue-missing-detail", "Missing detail", "project-kata");
+    const { api, issue: issueDetail } = createWorkspaceAPI([selected]);
+    issueDetail.mockRejectedValue(
+      new KataTaskAPIError({ status: 404, code: "not_found", message: "not found", headers: new Headers() }),
+    );
+    saveKataWorkspaceState("home", {
+      view: "all",
+      filters: {
+        scope: { kind: "project", project_uid: "project-kata" },
+        status: "all",
+        owner: "Susan",
+        label: "work",
+        query: "saved",
+      },
+      selectedIssueUID: selected.uid,
+    });
+    const onRouteStateChange = vi.fn();
+
+    render(KataWorkspace, { props: { api, onRouteStateChange } });
+
+    await waitFor(() =>
+      expect(onRouteStateChange).toHaveBeenLastCalledWith(
+        { view: null, scope: "project-kata", issue: null },
+        { replace: true },
+      ),
+    );
+    expect(screen.getByText("Select a task")).toBeTruthy();
+    expect(loadKataWorkspaceState("home")?.selectedIssueUID).toBeNull();
+    expect(loadKataWorkspaceState("home")?.filters.owner).toBe("Susan");
+  });
+
+  it("retries a transient catalog failure without clearing the persisted snapshot", async () => {
+    const selected = issue("issue-catalog-retry", "Catalog retry task", "project-kata");
+    const { api, projects: projectCatalog, search } = createWorkspaceAPI([selected]);
+    projectCatalog.mockRejectedValueOnce(new Error("catalog timed out"));
+    saveKataWorkspaceState("home", {
+      view: "all",
+      filters: {
+        scope: { kind: "project", project_uid: "project-kata" },
+        status: "all",
+        owner: "Susan",
+        label: "work",
+        query: "saved",
+      },
+      selectedIssueUID: selected.uid,
+    });
+
+    render(KataWorkspace, { props: { api } });
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy());
+    expect(loadKataWorkspaceState("home")?.selectedIssueUID).toBe(selected.uid);
+    expect(search).not.toHaveBeenCalled();
+    await fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Catalog retry task" })).toBeTruthy());
+    expect(projectCatalog).toHaveBeenCalledTimes(2);
+    expect(search).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not emit a restored route after unmount", async () => {
+    const { api, projects: projectCatalog } = createWorkspaceAPI();
+    const catalog = deferred<Awaited<ReturnType<typeof api.projects>>>();
+    projectCatalog.mockReturnValue(catalog.promise);
+    const onRouteStateChange = vi.fn();
+
+    const rendered = render(KataWorkspace, { props: { api, onRouteStateChange } });
+    await waitFor(() => expect(projectCatalog).toHaveBeenCalledTimes(1));
+    rendered.unmount();
+    catalog.resolve({ projects, fetched_at: fetchedAt });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onRouteStateChange).not.toHaveBeenCalled();
+  });
+
+  it("retries only transient persisted detail restoration and later clears a definitive failure", async () => {
+    const selected = issue("issue-retry", "Retry task", "project-kata");
+    const { api, projects: projectCatalog, search, issue: issueDetail } = createWorkspaceAPI([selected]);
+    issueDetail
+      .mockRejectedValueOnce(new Error("timed out"))
+      .mockRejectedValueOnce(
+        new KataTaskAPIError({ status: 404, code: "not_found", message: "not found", headers: new Headers() }),
+      );
+    saveKataWorkspaceState("home", {
+      view: "all",
+      filters: {
+        scope: { kind: "project", project_uid: "project-kata" },
+        status: "all",
+        owner: "Susan",
+        label: "work",
+        query: "saved",
+      },
+      selectedIssueUID: selected.uid,
+    });
+    const onRouteStateChange = vi.fn();
+
+    render(KataWorkspace, { props: { api, onRouteStateChange } });
+
+    await screen.findByRole("button", { name: "Retry" });
+    expect(loadKataWorkspaceState("home")?.selectedIssueUID).toBe(selected.uid);
+    expect(projectCatalog).toHaveBeenCalledTimes(1);
+    expect(search).toHaveBeenCalledTimes(1);
+    await fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    await waitFor(() => expect(issueDetail).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.queryByRole("button", { name: "Retry" })).toBeNull());
+    expect(projectCatalog).toHaveBeenCalledTimes(1);
+    expect(search).toHaveBeenCalledTimes(1);
+    expect(loadKataWorkspaceState("home")?.selectedIssueUID).toBeNull();
+    expect(onRouteStateChange).toHaveBeenLastCalledWith(
+      { view: null, scope: "project-kata", issue: null },
+      { replace: true },
+    );
+  });
+
+  it("invalidates a persisted-selection Retry when the route navigates elsewhere", async () => {
+    const selected = issue("issue-retry-route", "Retry route task", "project-kata");
+    const { api, issue: issueDetail } = createWorkspaceAPI([selected]);
+    issueDetail.mockRejectedValueOnce(new Error("timed out"));
+    saveKataWorkspaceState("home", {
+      view: "all",
+      filters: {
+        scope: { kind: "project", project_uid: "project-kata" },
+        status: "all",
+        owner: "Susan",
+        label: "work",
+        query: "saved",
+      },
+      selectedIssueUID: selected.uid,
+    });
+
+    const { component } = render(KataWorkspaceRouteHost, { props: { api } });
+
+    const retry = await screen.findByRole("button", { name: "Retry" });
+    component.setRoute({ view: "today", scope: null, issue: null });
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Today" })).toBeTruthy());
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+
+    await fireEvent.click(retry);
+    await Promise.resolve();
+
+    expect(issueDetail).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("heading", { name: "Today" })).toBeTruthy();
+    expect(screen.getByText("Select a task")).toBeTruthy();
+  });
+
+  it("removes a definitively missing explicit URL issue from the route", async () => {
+    const { api, issue: issueDetail } = createWorkspaceAPI();
+    issueDetail.mockRejectedValue(
+      new KataTaskAPIError({ status: 404, code: "not_found", message: "not found", headers: new Headers() }),
+    );
+    const onRouteStateChange = vi.fn();
+
+    const { component } = render(KataWorkspaceRouteHost, {
+      props: {
+        api,
+        initialIssue: "issue-missing",
+        onRouteStateChange,
+      },
+    });
+
+    await waitFor(() => expect(component.route().issue).toBeNull());
+    expect(screen.getByText("Select a task")).toBeTruthy();
+    expect(onRouteStateChange).toHaveBeenCalledWith({ issue: null }, { replace: true });
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+  });
+
+  it("accepts a restored selection before its ancestor request settles", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.includes("/api/v1/kata/daemons")) {
+        return Response.json({
+          daemons: [{ id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" }],
+        });
+      }
+      if (url.includes("/api/v1/kata/proxy/api/v1/events/stream")) {
+        return new Response(new ReadableStream({ start() {} }), {
+          headers: { "Content-Type": "text/event-stream" },
+        });
+      }
+      return Response.json({});
+    });
+    const parent = issue("issue-parent-slow", "Slow parent task", "project-kata");
+    const child = {
+      ...issue("issue-child-slow", "Child before parent", "project-kata"),
+      parent: { uid: parent.uid, short_id: "parent-slow" },
+      parent_short_id: "parent-slow",
+    };
+    const parentDetail = deferred<KataTaskDetail>();
+    const { api, issue: issueDetail } = createWorkspaceAPI([child]);
+    issueDetail.mockImplementation(async (uid: string) => {
+      if (uid === child.uid) return detail(uid, [child]);
+      if (uid === parent.uid) return parentDetail.promise;
+      return detail(uid, [parent, child]);
+    });
+    saveKataWorkspaceState("home", {
+      view: "all",
+      filters: { scope: { kind: "all" }, status: "open", owner: "", label: "", query: "" },
+      selectedIssueUID: child.uid,
+    });
+
+    render(KataWorkspace, { props: { api } });
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Child before parent" })).toBeTruthy());
+    await waitFor(() => expect(api.events).toHaveBeenCalledWith({ after_id: 0, limit: 100 }, {}));
+    await waitFor(() =>
+      expect(
+        vi
+          .mocked(globalThis.fetch)
+          .mock.calls.some(([input]) => String(input).includes("/api/v1/kata/proxy/api/v1/events/stream")),
+      ).toBe(true),
+    );
+    expect(issueDetail.mock.calls.filter(([uid]) => uid === parent.uid)).toHaveLength(1);
+
+    parentDetail.resolve(detail(parent.uid, [parent, child]));
+  });
+
+  it("drops a superseded routed ancestor walk before it crosses into the fallback daemon", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [
+          { id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" },
+          { id: "work", url: "http://127.0.0.1:8888", default: false, auth: "none", health: "connected" },
+        ],
+      }),
+    );
+    setActiveKataDaemon("home");
+    const grandparent = issue("issue-work-grandparent", "Work grandparent", "project-kata");
+    const parent = {
+      ...issue("issue-work-parent", "Work parent", "project-kata"),
+      parent: { uid: grandparent.uid, short_id: grandparent.short_id },
+      parent_short_id: grandparent.short_id,
+    };
+    const child = {
+      ...issue("issue-work-child", "Work child", "project-kata"),
+      parent: { uid: parent.uid, short_id: parent.short_id },
+      parent_short_id: parent.short_id,
+    };
+    const api = createDaemonWorkspaceAPI({ home: [initialIssues[0]!], work: [child] });
+    const parentDetail = deferred<KataTaskDetail>();
+    vi.mocked(api.issue).mockImplementation(async (uid: string) => {
+      const binding = vi.mocked(api.bindWorkflowDaemon!).mock.calls.at(-1)?.[0];
+      if (uid === child.uid) return detail(child.uid, [child]);
+      if (uid === parent.uid) return parentDetail.promise;
+      if (uid === grandparent.uid && binding !== "work") throw new Error("ancestor crossed daemon boundary");
+      return detail(uid, [grandparent, parent, child]);
+    });
+    saveKataWorkspaceState("work", {
+      view: "all",
+      filters: { scope: { kind: "all" }, status: "open", owner: "", label: "", query: "" },
+      selectedIssueUID: child.uid,
+    });
+
+    const { component } = render(KataWorkspaceRouteHost, {
+      props: { api, initialDaemon: "work" },
+    });
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Work child" })).toBeTruthy());
+    await waitFor(() => expect(api.issue).toHaveBeenCalledWith(parent.uid, { daemonId: "work" }));
+
+    component.setRoute({ issue: null, daemon: null });
+    await waitFor(() => expect(vi.mocked(api.bindWorkflowDaemon!).mock.calls.at(-1)?.[0]).toBe("home"));
+    parentDetail.resolve(detail(parent.uid, [grandparent, parent, child]));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(api.issue).not.toHaveBeenCalledWith(grandparent.uid);
+    expect(screen.queryByText("ancestor crossed daemon boundary")).toBeNull();
+  });
+
+  it("reveals the ancestor chain for an accepted routed nested task", async () => {
+    const parent = issue("issue-routed-parent", "Routed parent", "project-kata");
+    const child = {
+      ...issue("issue-routed-child", "Routed child", "project-kata"),
+      parent: { uid: parent.uid, short_id: parent.short_id },
+      parent_short_id: parent.short_id,
+    };
+    const { api, issue: issueDetail } = createWorkspaceAPI([parent, child]);
+    issueDetail.mockImplementation(async (uid: string) => detail(uid, [parent, child]));
+
+    render(KataWorkspaceRouteHost, { props: { api, initialIssue: child.uid } });
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Routed child" })).toBeTruthy());
+    await waitFor(() => expect(screen.getByText("Routed child", { selector: ".title-text" })).toBeTruthy());
+    expect(issueDetail).toHaveBeenCalledWith(parent.uid, expect.objectContaining({ daemonId: "home" }));
+  });
+
+  it("keeps an accepted task selected while retrying transient ancestor failures", async () => {
+    const parent = issue("issue-parent-retry", "Parent retry task", "project-kata");
+    const child = {
+      ...issue("issue-child-retry", "Child retry task", "project-kata"),
+      parent: { uid: parent.uid, short_id: "parent-retry" },
+      parent_short_id: "parent-retry",
+    };
+    const { api, issue: issueDetail } = createWorkspaceAPI([child]);
+    issueDetail.mockImplementation(async (uid: string) => {
+      if (uid === child.uid) return detail(uid, [child]);
+      if (uid === parent.uid) {
+        const attempts = issueDetail.mock.calls.filter(([ref]) => ref === parent.uid).length;
+        if (attempts === 1) throw new Error("ancestor timed out");
+        if (attempts === 2) throw new Error("ancestor timed out again");
+      }
+      return detail(uid, [parent, child]);
+    });
+    saveKataWorkspaceState("home", {
+      view: "all",
+      filters: { scope: { kind: "all" }, status: "open", owner: "", label: "", query: "" },
+      selectedIssueUID: child.uid,
+    });
+
+    const { component } = render(KataWorkspaceRouteHost, { props: { api } });
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy());
+    const layout = screen.getByLabelText("Kata tasks").parentElement as HTMLElement & {
+      inert: boolean;
+    };
+    expect(layout.inert).toBe(false);
+    await waitFor(() =>
+      expect((screen.getByRole("button", { name: "New task" }) as HTMLButtonElement).disabled).toBe(false),
+    );
+    expect(screen.getByRole("heading", { name: "Child retry task" })).toBeTruthy();
+    expect(component.route().issue).toBe(child.uid);
+    expect(loadKataWorkspaceState("home")?.selectedIssueUID).toBe(child.uid);
+
+    await fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    await waitFor(() => {
+      expect(issueDetail.mock.calls.filter(([ref]) => ref === parent.uid)).toHaveLength(2);
+      expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+    });
+    expect(screen.getByRole("heading", { name: "Child retry task" })).toBeTruthy();
+    expect(component.route().issue).toBe(child.uid);
+
+    const repeatedFailure = await screen.findByText("ancestor timed out again");
+    expect(within(repeatedFailure).getByRole("button", { name: "Retry" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Child retry task" })).toBeTruthy();
+  });
+
+  it("reconciles a stale configured daemon to the roster default", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [
+          {
+            id: "home",
+            url: "http://127.0.0.1:7777",
+            default: true,
+            auth: "none",
+            health: "connected",
+          },
+        ],
+      }),
+    );
+    setActiveKataDaemon("removed");
+    const { api } = createWorkspaceAPI();
+
+    render(KataWorkspace, { props: { api } });
+
+    await waitFor(() => expect(getActiveKataDaemon()).toBe("home"));
+    expect(screen.getByTestId("daemon-chip").textContent).toContain("home");
   });
 
   it("loads the daemon roster on mount", async () => {
@@ -646,6 +1267,156 @@ describe("KataWorkspace", () => {
     });
   });
 
+  it("reloads All Open from an inert invalid-persistence workspace", async () => {
+    const { api, issues } = createWorkspaceAPI();
+    saveKataWorkspaceState("home", {
+      view: "all",
+      filters: {
+        scope: { kind: "project", project_uid: "project-missing" },
+        status: "all",
+        owner: "Stale",
+        label: "stale",
+        query: "discard",
+      },
+      selectedIssueUID: "issue-stale",
+    });
+
+    render(KataWorkspaceRouteHost, { props: { api } });
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "All Open" })).toBeTruthy());
+    expect(issues).not.toHaveBeenCalled();
+
+    await fireEvent.click(screen.getByRole("button", { name: "All Open" }));
+
+    await waitFor(() =>
+      expect(issues).toHaveBeenCalledWith(
+        expect.objectContaining({ view: "all" }),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      ),
+    );
+    expect(screen.getByRole("button", { name: /Pay rent/ })).toBeTruthy();
+  });
+
+  it("does not reload an already active system view", async () => {
+    const { api, issues } = createWorkspaceAPI();
+    const onRouteStateChange = vi.fn();
+
+    render(KataWorkspaceRouteHost, { props: { api, onRouteStateChange } });
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "All Open" })).toBeTruthy());
+    const issueLoads = issues.mock.calls.length;
+    onRouteStateChange.mockClear();
+
+    await fireEvent.click(screen.getByRole("button", { name: "All Open" }));
+
+    expect(issues).toHaveBeenCalledTimes(issueLoads);
+    expect(onRouteStateChange).not.toHaveBeenCalled();
+  });
+
+  it("clears an active selection without reloading the current system view", async () => {
+    const { api, issues } = createWorkspaceAPI();
+    const onRouteStateChange = vi.fn();
+
+    render(KataWorkspaceRouteHost, {
+      props: {
+        api,
+        initialIssue: "issue-pay-rent",
+        onRouteStateChange,
+      },
+    });
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Pay rent" })).toBeTruthy());
+    const issueLoads = issues.mock.calls.length;
+    onRouteStateChange.mockClear();
+
+    await fireEvent.click(screen.getByRole("button", { name: "All Open" }));
+
+    await waitFor(() => expect(screen.getByText("Select a task")).toBeTruthy());
+    expect(issues).toHaveBeenCalledTimes(issueLoads);
+    expect(onRouteStateChange).toHaveBeenCalledWith({ view: "all", scope: null, issue: null });
+  });
+
+  it("closes the reachable graph without reloading the current system view", async () => {
+    const root = {
+      ...issue("issue-root", "Root graph task", "project-kata"),
+      blocks: [{ uid: "issue-blocked", short_id: "blocked" }],
+    };
+    const blocked = issue("issue-blocked", "Blocked follow-up", "project-kata");
+    const { api, issues } = createWorkspaceAPI([root, blocked]);
+    const onRouteStateChange = vi.fn();
+
+    render(KataWorkspaceRouteHost, { props: { api, onRouteStateChange } });
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /Root graph task/ })).toBeTruthy());
+    const rootRow = screen.getByRole("button", { name: /Root graph task/ });
+    await fireEvent.click(within(rootRow.parentElement!).getByRole("button", { name: "Open reachable graph" }));
+    expect(screen.getByRole("region", { name: "Reachable task graph" })).toBeTruthy();
+    const issueLoads = issues.mock.calls.length;
+    onRouteStateChange.mockClear();
+
+    await fireEvent.click(screen.getByRole("button", { name: "All Open" }));
+
+    expect(screen.queryByRole("region", { name: "Reachable task graph" })).toBeNull();
+    expect(screen.getByLabelText("Search tasks")).toBeTruthy();
+    expect(issues).toHaveBeenCalledTimes(issueLoads);
+    expect(onRouteStateChange).not.toHaveBeenCalled();
+  });
+
+  it("selects the current route while a superseded view load is still pending", async () => {
+    const target = issue("issue-target", "Current route task", "project-kata");
+    const { api, issues } = createWorkspaceAPI([target]);
+    const stalledInbox = deferred<Awaited<ReturnType<typeof api.issues>>>();
+    vi.mocked(api.issues).mockImplementation(async (query) => {
+      if (query.view === "inbox") return stalledInbox.promise;
+      return {
+        view: query.view,
+        groups: [{ id: "all", title: "All", issues: [target] }],
+        fetched_at: fetchedAt,
+      };
+    });
+
+    const { component } = render(KataWorkspaceRouteHost, { props: { api } });
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "All Open" })).toBeTruthy());
+    component.setRoute({ view: "inbox", issue: null });
+    await waitFor(() =>
+      expect(issues).toHaveBeenCalledWith(
+        expect.objectContaining({ view: "inbox" }),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      ),
+    );
+
+    component.setRoute({ view: "all", issue: target.uid });
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Current route task" })).toBeTruthy());
+    expect(api.issue).toHaveBeenCalledWith(target.uid, expect.objectContaining({ signal: expect.any(AbortSignal) }));
+
+    stalledInbox.resolve({
+      view: "inbox",
+      groups: [{ id: "inbox", title: "Inbox", issues: [] }],
+      fetched_at: fetchedAt,
+    });
+  });
+
+  it("resets active filters when reopening the current system view", async () => {
+    const { api, issues } = createWorkspaceAPI();
+    const onRouteStateChange = vi.fn();
+
+    render(KataWorkspaceRouteHost, { props: { api, onRouteStateChange } });
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "All Open" })).toBeTruthy());
+    await fireEvent.input(screen.getByLabelText("Search tasks"), { target: { value: "rent" } });
+    await waitFor(() => expect((screen.getByLabelText("Search tasks") as HTMLInputElement).value).toBe("rent"));
+    const issueLoads = issues.mock.calls.length;
+    onRouteStateChange.mockClear();
+
+    await fireEvent.click(screen.getByRole("button", { name: "All Open" }));
+
+    await waitFor(() => expect((screen.getByLabelText("Search tasks") as HTMLInputElement).value).toBe(""));
+    expect(issues.mock.calls.length).toBeGreaterThan(issueLoads);
+    expect(onRouteStateChange).not.toHaveBeenCalled();
+  });
+
   it("opens system views without auto-selecting the first task", async () => {
     const rows = initialIssues.map((item) => (item.uid === "issue-pay-rent" ? { ...item, project_name: "" } : item));
     const { api } = createWorkspaceAPI(rows);
@@ -670,6 +1441,466 @@ describe("KataWorkspace", () => {
       scope: null,
       issue: null,
     });
+  });
+
+  it("preserves accepted workspace state after a failed system-view request", async () => {
+    acceptHomeDaemon();
+    const selected = initialIssues[0]!;
+    const persisted = {
+      view: "all" as const,
+      filters: { scope: { kind: "all" as const }, status: "open" as const, owner: "", label: "", query: "" },
+      selectedIssueUID: selected.uid,
+    };
+    const { api, issues } = createWorkspaceAPI();
+    saveKataWorkspaceState("home", persisted);
+    const onRouteStateChange = vi.fn();
+
+    render(KataWorkspace, { props: { api, selectedIssueUID: selected.uid, onRouteStateChange } });
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Pay rent" })).toBeTruthy());
+    issues.mockRejectedValueOnce(new Error("inbox unavailable"));
+    onRouteStateChange.mockClear();
+
+    await fireEvent.click(screen.getByRole("button", { name: /^Inbox\s+1$/ }));
+
+    await waitFor(() => expect(screen.getByText("inbox unavailable")).toBeTruthy());
+    expect(screen.getByRole("heading", { name: "All Open" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Pay rent" })).toBeTruthy();
+    expect(onRouteStateChange).not.toHaveBeenCalled();
+    expect(loadKataWorkspaceState("home")).toEqual(persisted);
+  });
+
+  it("persists an accepted filter change after deliberately clearing an incompatible selection", async () => {
+    const selected = initialIssues[0]!;
+    acceptHomeDaemon();
+    const { api, search } = createWorkspaceAPI();
+    search.mockImplementation(async (filters: KataTaskSearchFilters) => ({
+      filters,
+      issues: filters.status === "closed" ? [] : initialIssues,
+      fetched_at: fetchedAt,
+    }));
+
+    render(KataWorkspace, { props: { api, selectedIssueUID: selected.uid } });
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Pay rent" })).toBeTruthy());
+    await fireEvent.click(screen.getByRole("combobox", { name: "Status: Open" }));
+    await fireEvent.click(screen.getByRole("option", { name: "Closed" }));
+
+    await waitFor(() =>
+      expect(loadKataWorkspaceState("home")).toEqual({
+        view: "all",
+        filters: { scope: { kind: "all" }, status: "closed", owner: "", label: "", query: "" },
+        selectedIssueUID: null,
+      }),
+    );
+  });
+
+  it.each([
+    {
+      name: "system-view navigation",
+      select: () => fireEvent.click(screen.getByRole("button", { name: /^Inbox\s+1$/ })),
+      expected: {
+        view: "inbox" as const,
+        filters: { scope: { kind: "all" as const }, status: "open" as const, owner: "", label: "", query: "" },
+        selectedIssueUID: null,
+      },
+    },
+    {
+      name: "project-scope navigation",
+      select: () =>
+        fireEvent.click(
+          within(screen.getByRole("complementary", { name: "Kata navigation" })).getByRole("button", {
+            name: /^Kata\s+1$/,
+          }),
+        ),
+      expected: {
+        view: "all" as const,
+        filters: {
+          scope: { kind: "project" as const, project_uid: "project-kata" },
+          status: "open" as const,
+          owner: "",
+          label: "",
+          query: "",
+        },
+        selectedIssueUID: "issue-email-susan",
+      },
+    },
+  ])("persists accepted $name", async ({ select, expected }) => {
+    acceptHomeDaemon();
+    const { api } = createWorkspaceAPI();
+
+    render(KataWorkspace, { props: { api, selectedIssueUID: "issue-pay-rent" } });
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Pay rent" })).toBeTruthy());
+    await select();
+
+    await waitFor(() => expect(loadKataWorkspaceState("home")).toEqual(expected));
+  });
+
+  it("persists a completed manual list selection", async () => {
+    acceptHomeDaemon();
+    const { api } = createWorkspaceAPI();
+
+    render(KataWorkspace, { props: { api } });
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /Email Susan re: Q3/ })).toBeTruthy());
+    await fireEvent.click(screen.getByRole("button", { name: /Email Susan re: Q3/ }));
+
+    await waitFor(() =>
+      expect(loadKataWorkspaceState("home")).toEqual({
+        view: "all",
+        filters: { scope: { kind: "all" }, status: "open", owner: "", label: "", query: "" },
+        selectedIssueUID: "issue-email-susan",
+      }),
+    );
+  });
+
+  it("persists a completed graph task-node selection through route reconciliation", async () => {
+    acceptHomeDaemon();
+    const root = {
+      ...issue("issue-root", "Root graph task", "project-kata"),
+      blocks: [{ uid: "issue-blocked", short_id: "blocked" }],
+    };
+    const blocked = issue("issue-blocked", "Blocked follow-up", "project-kata");
+    const { api } = createWorkspaceAPI([root, blocked]);
+
+    const { component } = render(KataWorkspaceRouteHost, { props: { api, initialIssue: root.uid } });
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Root graph task" })).toBeTruthy());
+    await fireEvent.click(
+      within(screen.getByRole("region", { name: "Task detail" })).getByRole("button", {
+        name: "Open reachable graph",
+      }),
+    );
+    await fireEvent.click(graphNodeWithText("Blocked follow-up"));
+
+    await waitFor(() =>
+      expect(loadKataWorkspaceState("home")).toEqual({
+        view: "all",
+        filters: { scope: { kind: "all" }, status: "open", owner: "", label: "", query: "" },
+        selectedIssueUID: blocked.uid,
+      }),
+    );
+    expect(component.route().issue).toBe(blocked.uid);
+  });
+
+  it.each([
+    {
+      name: "move",
+      expectedSelection: "issue-pay-rent",
+      configure: (
+        api: ReturnType<typeof createDaemonWorkspaceAPI>,
+        replaceSelected: (changes: Record<string, unknown>) => void,
+      ) => {
+        api.moveIssue = vi.fn(async () => {
+          replaceSelected({ project_id: projects[2]!.id, project_uid: "project-kata", project_name: "Kata" });
+          return { changed: true, new_short_id: "moved" };
+        });
+      },
+      perform: async () => {
+        await fireEvent.click(screen.getByRole("button", { name: "More actions" }));
+        await fireEvent.click(screen.getByRole("menuitem", { name: "Move to another project" }));
+        await fireEvent.input(screen.getByRole("searchbox", { name: "Find project" }), {
+          target: { value: "Kata" },
+        });
+        await fireEvent.click(
+          within(screen.getByRole("dialog", { name: "Move to another project" })).getByRole("button", {
+            name: /^Kata\s+1$/,
+          }),
+        );
+      },
+      accepted: (api: ReturnType<typeof createDaemonWorkspaceAPI>) => expect(api.moveIssue).toHaveBeenCalledTimes(1),
+    },
+    {
+      name: "close",
+      expectedSelection: null,
+      configure: (
+        api: ReturnType<typeof createDaemonWorkspaceAPI>,
+        replaceSelected: (changes: Record<string, unknown>) => void,
+      ) => {
+        api.closeIssue = vi.fn(async () => {
+          replaceSelected({ status: "closed", closed_at: fetchedAt });
+          return { changed: true };
+        });
+      },
+      perform: async () => {
+        await fireEvent.click(screen.getByRole("button", { name: "Complete" }));
+        await fireEvent.click(
+          within(screen.getByRole("dialog", { name: "Complete task" })).getByRole("button", { name: "Complete" }),
+        );
+      },
+      accepted: (api: ReturnType<typeof createDaemonWorkspaceAPI>) => expect(api.closeIssue).toHaveBeenCalledTimes(1),
+    },
+    {
+      name: "delete",
+      expectedSelection: null,
+      configure: (
+        api: ReturnType<typeof createDaemonWorkspaceAPI>,
+        replaceSelected: (changes: Record<string, unknown>) => void,
+      ) => {
+        api.closeIssue = vi.fn(async () => {
+          replaceSelected({ status: "closed", closed_at: fetchedAt });
+          return { changed: true };
+        });
+      },
+      perform: async () => {
+        await fireEvent.click(screen.getByRole("button", { name: "More actions" }));
+        await fireEvent.click(
+          within(screen.getByRole("menu", { name: "Task actions" })).getByRole("menuitem", { name: "Delete issue" }),
+        );
+        await fireEvent.click(
+          within(screen.getByRole("dialog", { name: "Delete issue" })).getByRole("button", { name: "Delete" }),
+        );
+      },
+      accepted: (api: ReturnType<typeof createDaemonWorkspaceAPI>) => expect(api.closeIssue).toHaveBeenCalledTimes(1),
+    },
+    {
+      name: "reopen",
+      initial: { ...initialIssues[0]!, status: "closed" as const, closed_at: fetchedAt },
+      view: "logbook" as const,
+      expectedSelection: null,
+      configure: (
+        api: ReturnType<typeof createDaemonWorkspaceAPI>,
+        replaceSelected: (changes: Record<string, unknown>) => void,
+      ) => {
+        api.reopenIssue = vi.fn(async () => {
+          replaceSelected({ status: "open", closed_at: undefined, closed_reason: undefined });
+          return { changed: true };
+        });
+      },
+      perform: async () => {
+        await fireEvent.click(screen.getByRole("button", { name: "Reopen" }));
+      },
+      accepted: (api: ReturnType<typeof createDaemonWorkspaceAPI>) => expect(api.reopenIssue).toHaveBeenCalledTimes(1),
+    },
+    {
+      name: "edit",
+      expectedSelection: "issue-pay-rent",
+      expectedTitle: "Pay rent now",
+      configure: (
+        api: ReturnType<typeof createDaemonWorkspaceAPI>,
+        replaceSelected: (changes: Record<string, unknown>) => void,
+      ) => {
+        api.editIssue = vi.fn(async (_target, _actor, patch) => {
+          replaceSelected(patch);
+          return { changed: true };
+        });
+      },
+      perform: async () => {
+        await fireEvent.click(screen.getByRole("button", { name: "Edit title" }));
+        const input = screen.getByRole("textbox", { name: "Edit title" });
+        await fireEvent.input(input, { target: { value: "Pay rent now" } });
+        await fireEvent.keyDown(input, { key: "Enter" });
+      },
+      accepted: (api: ReturnType<typeof createDaemonWorkspaceAPI>) => expect(api.editIssue).toHaveBeenCalledTimes(1),
+    },
+    {
+      name: "assign owner",
+      expectedSelection: "issue-pay-rent",
+      configure: () => {},
+      perform: async () => {
+        await fireEvent.click(screen.getByRole("button", { name: "Owner: fixture-user" }));
+        const owner = screen.getByRole("combobox", { name: "Owner" });
+        await fireEvent.input(owner, { target: { value: "agent:new" } });
+        await fireEvent.keyDown(owner, { key: "Enter" });
+      },
+      accepted: (api: ReturnType<typeof createDaemonWorkspaceAPI>) => expect(api.assignOwner).toHaveBeenCalledTimes(1),
+    },
+    {
+      name: "unassign owner",
+      expectedSelection: "issue-pay-rent",
+      configure: () => {},
+      perform: async () => {
+        await fireEvent.click(screen.getByRole("button", { name: "Owner: fixture-user" }));
+        const owner = screen.getByRole("combobox", { name: "Owner" });
+        await fireEvent.keyDown(owner, { key: "ArrowUp" });
+        await fireEvent.keyDown(owner, { key: "Enter" });
+      },
+      accepted: (api: ReturnType<typeof createDaemonWorkspaceAPI>) =>
+        expect(api.unassignOwner).toHaveBeenCalledTimes(1),
+    },
+    {
+      name: "add label",
+      expectedSelection: "issue-pay-rent",
+      configure: () => {},
+      perform: async () => {
+        await fireEvent.click(screen.getByRole("button", { name: "Add label" }));
+        const label = screen.getByRole("textbox", { name: "New label" });
+        await fireEvent.input(label, { target: { value: "urgent" } });
+        await fireEvent.keyDown(label, { key: "Enter" });
+      },
+      accepted: (api: ReturnType<typeof createDaemonWorkspaceAPI>) => expect(api.addLabel).toHaveBeenCalledTimes(1),
+    },
+    {
+      name: "remove label",
+      expectedSelection: "issue-pay-rent",
+      configure: () => {},
+      perform: async () => {
+        await fireEvent.click(screen.getByRole("button", { name: "Edit labels" }));
+        await fireEvent.click(screen.getByRole("button", { name: "Remove label home" }));
+      },
+      accepted: (api: ReturnType<typeof createDaemonWorkspaceAPI>) => expect(api.removeLabel).toHaveBeenCalledTimes(1),
+    },
+    {
+      name: "set priority",
+      expectedSelection: "issue-pay-rent",
+      configure: () => {},
+      perform: async () => {
+        await fireEvent.click(screen.getByRole("button", { name: "Edit priority" }));
+        await fireEvent.click(screen.getByRole("combobox", { name: "Priority: No priority" }));
+        await fireEvent.click(screen.getByRole("option", { name: "P0" }));
+      },
+      accepted: (api: ReturnType<typeof createDaemonWorkspaceAPI>) => expect(api.setPriority).toHaveBeenCalledTimes(1),
+    },
+    {
+      name: "metadata patch",
+      expectedSelection: "issue-pay-rent",
+      configure: () => {},
+      perform: async () => {
+        await fireEvent.click(screen.getByRole("button", { name: "More actions" }));
+        await fireEvent.click(
+          within(screen.getByRole("menu", { name: "Task actions" })).getByRole("menuitem", { name: "Add checklist" }),
+        );
+        const checklist = screen.getByRole("textbox", { name: "New checklist item" });
+        await fireEvent.input(checklist, { target: { value: "Confirm amount" } });
+        await fireEvent.keyDown(checklist, { key: "Enter" });
+      },
+      accepted: (api: ReturnType<typeof createDaemonWorkspaceAPI>) =>
+        expect(api.patchIssueMetadata).toHaveBeenCalledTimes(1),
+    },
+  ])(
+    "reconciles and persists an accepted selected-task $name mutation",
+    async ({
+      initial = initialIssues[0]!,
+      view = "all" as KataTaskViewName,
+      expectedSelection,
+      expectedTitle = initial.title,
+      configure,
+      perform,
+      accepted,
+    }) => {
+      acceptHomeDaemon();
+      const rowsByDaemon = { home: [{ ...initial }] };
+      const api = createDaemonWorkspaceAPI(rowsByDaemon);
+      const replaceSelected = (changes: Record<string, unknown>): void => {
+        rowsByDaemon.home = rowsByDaemon.home.map((row) => ({ ...row, ...changes }));
+      };
+      configure(api, replaceSelected);
+
+      render(KataWorkspaceRouteHost, { props: { api, initialView: view, initialIssue: initial.uid } });
+      await waitFor(() => expect(screen.getByRole("heading", { name: initial.title })).toBeTruthy());
+      saveKataWorkspaceState("home", {
+        view,
+        filters: { scope: { kind: "all" }, status: "open", owner: "", label: "", query: "" },
+        selectedIssueUID: initial.uid,
+      });
+      await perform();
+
+      await waitFor(() => accepted(api));
+      await waitFor(() => expect(loadKataWorkspaceState("home")?.selectedIssueUID).toBe(expectedSelection));
+      expect(loadKataWorkspaceState("home")?.filters).toEqual({
+        scope: { kind: "all" },
+        status: "open",
+        owner: "",
+        label: "",
+        query: "",
+      });
+      if (expectedSelection === null) {
+        expect(screen.getByText("Select a task")).toBeTruthy();
+      } else {
+        await waitFor(() => expect(screen.getByRole("heading", { name: expectedTitle })).toBeTruthy());
+      }
+    },
+  );
+
+  it("persists quick capture after Inbox opens and the new task is selected", async () => {
+    acceptHomeDaemon();
+    const { api } = createWorkspaceAPI();
+
+    render(KataWorkspace, { props: { api } });
+    await waitFor(() => expect(screen.getByRole("heading", { name: "All Open" })).toBeTruthy());
+    await waitFor(() =>
+      expect((screen.getByRole("button", { name: "New task" }) as HTMLButtonElement).disabled).toBe(false),
+    );
+
+    await fireEvent.click(screen.getByRole("button", { name: "New task" }));
+    const dialog = screen.getByRole("dialog", { name: "New task" });
+    await fireEvent.input(within(dialog).getByRole("textbox", { name: "Quick capture" }), {
+      target: { value: "Persist captured task" },
+    });
+    await fireEvent.click(within(dialog).getByRole("button", { name: "Capture" }));
+
+    await waitFor(() =>
+      expect(loadKataWorkspaceState("home")).toEqual({
+        view: "inbox",
+        filters: { scope: { kind: "all" }, status: "open", owner: "", label: "", query: "" },
+        selectedIssueUID: "issue-capture",
+      }),
+    );
+  });
+
+  it("does not persist graph display changes without a task selection", async () => {
+    acceptHomeDaemon();
+    const persisted = {
+      view: "inbox" as const,
+      filters: { scope: { kind: "all" as const }, status: "open" as const, owner: "", label: "", query: "" },
+      selectedIssueUID: null,
+    };
+    const root = issue("issue-root", "Root graph task", "project-kata");
+    const { api } = createWorkspaceAPI([root]);
+    saveKataWorkspaceState("home", persisted);
+
+    render(KataWorkspace, { props: { api, selectedIssueUID: root.uid } });
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Root graph task" })).toBeTruthy());
+
+    await fireEvent.click(
+      within(screen.getByRole("region", { name: "Task detail" })).getByRole("button", {
+        name: "Open reachable graph",
+      }),
+    );
+    await waitFor(() => expect(screen.getByRole("button", { name: "Back to task list" })).toBeTruthy());
+
+    expect(loadKataWorkspaceState("home")).toEqual(persisted);
+  });
+
+  it("does not persist a failed filter request", async () => {
+    acceptHomeDaemon();
+    const persisted = {
+      view: "all" as const,
+      filters: { scope: { kind: "all" as const }, status: "open" as const, owner: "", label: "", query: "" },
+      selectedIssueUID: null,
+    };
+    const { api, search } = createWorkspaceAPI();
+    search.mockRejectedValueOnce(new Error("search failed"));
+    saveKataWorkspaceState("home", persisted);
+
+    render(KataWorkspace, { props: { api } });
+    await waitFor(() => expect(screen.getByRole("heading", { name: "All Open" })).toBeTruthy());
+
+    await fireEvent.input(screen.getByLabelText("Search tasks"), { target: { value: "failed" } });
+
+    await waitFor(() => expect(screen.getByText("search failed")).toBeTruthy());
+    expect((screen.getByLabelText("Search tasks") as HTMLInputElement).value).toBe("");
+    expect(screen.getByRole("button", { name: /Pay rent/ })).toBeTruthy();
+    expect(loadKataWorkspaceState("home")).toEqual(persisted);
+  });
+
+  it("does not persist external URL selection", async () => {
+    acceptHomeDaemon();
+    const persisted = {
+      view: "inbox" as const,
+      filters: { scope: { kind: "all" as const }, status: "open" as const, owner: "", label: "", query: "" },
+      selectedIssueUID: null,
+    };
+    const { api } = createWorkspaceAPI();
+    saveKataWorkspaceState("home", persisted);
+
+    const { rerender } = render(KataWorkspace, { props: { api } });
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Inbox" })).toBeTruthy());
+
+    await rerender({ api, selectedIssueUID: "issue-pay-rent" });
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Pay rent" })).toBeTruthy());
+    expect(loadKataWorkspaceState("home")).toEqual(persisted);
   });
 
   it("toggles and persists the task detail layout", async () => {
@@ -736,12 +1967,34 @@ describe("KataWorkspace", () => {
     expect(screen.queryByText("No tasks")).toBeNull();
   });
 
+  it("restores a closed Logbook selection while the persisted status remains open", async () => {
+    const closedIssue = {
+      ...issue("issue-done-restored", "Restored done work", "project-kata"),
+      status: "closed" as const,
+      closed_at: "2026-05-15T12:00:00.000Z",
+    };
+    const { api } = createWorkspaceAPI([closedIssue]);
+    saveKataWorkspaceState("home", {
+      view: "logbook",
+      filters: { scope: { kind: "all" }, status: "open", owner: "", label: "", query: "" },
+      selectedIssueUID: closedIssue.uid,
+    });
+
+    const { component } = render(KataWorkspaceRouteHost, { props: { api } });
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Restored done work" })).toBeTruthy());
+    expect(screen.getByRole("combobox", { name: "Status: Open" })).toBeTruthy();
+    expect(component.route().issue).toBe(closedIssue.uid);
+    expect(loadKataWorkspaceState("home")?.selectedIssueUID).toBe(closedIssue.uid);
+  });
+
   it("captures a new task into the inbox from the feature toolbar", async () => {
     const { api, createIssue } = createWorkspaceAPI();
 
     render(KataWorkspace, { props: { api } });
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: "All Open" })).toBeTruthy();
+      expect((screen.getByRole("button", { name: "New task" }) as HTMLButtonElement).disabled).toBe(false);
     });
 
     await fireEvent.click(screen.getByRole("button", { name: "New task" }));
@@ -761,6 +2014,1289 @@ describe("KataWorkspace", () => {
       );
       expect(screen.getByRole("heading", { name: "Capture from notes" })).toBeTruthy();
     });
+  });
+
+  it("restores the target daemon snapshot only after accepting the daemon switch", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [
+          { id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" },
+          { id: "work", url: "http://127.0.0.1:8888", default: false, auth: "none", health: "connected" },
+        ],
+      }),
+    );
+    const home = initialIssues[0]!;
+    const firstWork = initialIssues[1]!;
+    const restoredWork = issue("issue-work-restored", "Restored work task", "project-kata");
+    const api = createDaemonWorkspaceAPI(
+      { home: [home], work: [firstWork, restoredWork] },
+      {
+        home: projects.filter((project) => project.uid !== "project-kata"),
+        work: projects.filter((project) => project.uid === "project-kata"),
+      },
+    );
+    const homeSnapshot = {
+      view: "all" as const,
+      filters: { scope: { kind: "all" as const }, status: "open" as const, owner: "Home", label: "", query: "" },
+      selectedIssueUID: home.uid,
+    };
+    const workSnapshot = {
+      view: "all" as const,
+      filters: {
+        scope: { kind: "project" as const, project_uid: "project-kata" },
+        status: "all" as const,
+        owner: "Work",
+        label: "",
+        query: "saved",
+      },
+      selectedIssueUID: restoredWork.uid,
+    };
+    saveKataWorkspaceState("home", homeSnapshot);
+    saveKataWorkspaceState("work", workSnapshot);
+
+    render(KataWorkspaceRouteHost, { props: { api } });
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Pay rent" })).toBeTruthy());
+
+    await fireEvent.click(screen.getByTestId("daemon-chip"));
+    const workDaemonRow = (await screen.findByTestId("daemon-row-work")) as HTMLButtonElement;
+    await waitFor(() => expect(workDaemonRow.disabled).toBe(false));
+    await fireEvent.click(workDaemonRow);
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Restored work task" })).toBeTruthy());
+    expect((screen.getByLabelText("Search tasks") as HTMLInputElement).value).toBe("saved");
+    expect(screen.getByRole("combobox", { name: "Status: All" })).toBeTruthy();
+    expect(loadKataWorkspaceState("home")).toEqual(homeSnapshot);
+    expect(loadKataWorkspaceState("work")).toEqual(workSnapshot);
+  });
+
+  it("keeps an unknown routed daemon inert without resolving its issue through the accepted daemon", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [{ id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" }],
+      }),
+    );
+    setActiveKataDaemon("home");
+    const api = createDaemonWorkspaceAPI({ home: [initialIssues[0]!] });
+
+    render(KataWorkspaceRouteHost, {
+      props: { api, initialIssue: initialIssues[0]!.uid, initialDaemon: "missing" },
+    });
+
+    await screen.findByText("Kata daemon missing is not configured.");
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(api.issue).not.toHaveBeenCalled();
+    expect(api.issues).not.toHaveBeenCalled();
+    expect(api.search).not.toHaveBeenCalled();
+    expect((screen.getByRole("button", { name: "New task" }) as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.getByText("Select a task")).toBeTruthy();
+  });
+
+  it("accepts a routed daemon after a successful restoration retry", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [
+          { id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" },
+          { id: "work", url: "http://127.0.0.1:8888", default: false, auth: "none", health: "connected" },
+        ],
+      }),
+    );
+    setActiveKataDaemon("home");
+    const work = initialIssues[1]!;
+    const api = createDaemonWorkspaceAPI({ home: [initialIssues[0]!], work: [work] });
+    vi.mocked(api.projects).mockRejectedValueOnce(new Error("catalog timed out"));
+    vi.mocked(api.issue).mockImplementation(async (uid: string) => {
+      const restored = detail(uid, [work]);
+      return { ...restored, issue: { ...restored.issue, body: "" } };
+    });
+
+    const { component } = render(KataWorkspaceRouteHost, {
+      props: { api, initialIssue: work.uid, initialDaemon: "work" },
+    });
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy());
+    expect(getActiveKataDaemon()).toBe("home");
+    expect(component.route().daemon).toBe("work");
+
+    await fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() => {
+      expect(getActiveKataDaemon()).toBe("work");
+      expect(component.route().daemon).toBeNull();
+      expect(screen.getByRole("heading", { name: "Email Susan re: Q3" })).toBeTruthy();
+    });
+  });
+
+  it("keeps transient routed detail failures provisional and read-only", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [
+          { id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" },
+          { id: "work", url: "http://127.0.0.1:8888", default: false, auth: "none", health: "connected" },
+        ],
+      }),
+    );
+    setActiveKataDaemon("home");
+    const work = initialIssues[1]!;
+    const api = createDaemonWorkspaceAPI({ home: [initialIssues[0]!], work: [work] });
+    vi.mocked(api.issue).mockRejectedValueOnce(new Error("detail timed out"));
+
+    const { component } = render(KataWorkspaceRouteHost, {
+      props: { api, initialIssue: work.uid, initialDaemon: "work" },
+    });
+
+    const retry = await screen.findByRole("button", { name: "Retry" });
+    const layout = screen.getByLabelText("Kata tasks").parentElement;
+    expect(getActiveKataDaemon()).toBe("home");
+    expect(component.route().daemon).toBe("work");
+    expect(screen.getByTestId("daemon-chip").textContent).toContain("home");
+    expect((layout as HTMLElement & { inert: boolean }).inert).toBe(true);
+    expect((screen.getByRole("button", { name: "New task" }) as HTMLButtonElement).disabled).toBe(true);
+    expect(retry.closest("[inert]")).toBeNull();
+    expect(vi.mocked(api.events).mock.calls.every(([query]) => !(query && "after_id" in query))).toBe(true);
+  });
+
+  it("rolls back a same-mount routed daemon when its routed detail fails transiently", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [
+          { id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" },
+          { id: "work", url: "http://127.0.0.1:8888", default: false, auth: "none", health: "connected" },
+        ],
+      }),
+    );
+    setActiveKataDaemon("home");
+    const home = initialIssues[0]!;
+    const work = initialIssues[1]!;
+    const api = createDaemonWorkspaceAPI({ home: [home], work: [work] });
+    vi.mocked(api.issue).mockImplementation(async (uid, opts) => {
+      if (uid === work.uid && opts?.daemonId === "work") throw new Error("routed detail timed out");
+      return detail(uid, opts?.daemonId === "work" ? [work] : [home]);
+    });
+
+    const { component } = render(KataWorkspaceRouteHost, { props: { api, initialIssue: home.uid } });
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Pay rent" })).toBeTruthy());
+
+    component.setRoute({ issue: work.uid, daemon: "work" });
+
+    await waitFor(() => expect(flash.getFlash()).toMatchObject({ message: "routed detail timed out", tone: "danger" }));
+    expect(getActiveKataDaemon()).toBe("home");
+    expect(screen.getByRole("heading", { name: "Pay rent" })).toBeTruthy();
+    expect(
+      vi
+        .mocked(api.events)
+        .mock.calls.every(([query, opts]) => query?.after_id === undefined || opts?.daemonId !== "work"),
+    ).toBe(true);
+  });
+
+  it("commits a routed missing task as a cleared route", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [
+          { id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" },
+          { id: "work", url: "http://127.0.0.1:8888", default: false, auth: "none", health: "connected" },
+        ],
+      }),
+    );
+    setActiveKataDaemon("home");
+    const missingUID = "issue-work-missing";
+    const api = createDaemonWorkspaceAPI({ home: [initialIssues[0]!], work: [initialIssues[1]!] });
+    vi.mocked(api.issue).mockImplementation(async (uid: string) => {
+      if (uid === missingUID) {
+        throw new KataTaskAPIError({ status: 404, code: "not_found", message: "not found", headers: new Headers() });
+      }
+      return detail(uid, initialIssues);
+    });
+
+    const { component } = render(KataWorkspaceRouteHost, {
+      props: { api, initialIssue: missingUID, initialDaemon: "work" },
+    });
+
+    await waitFor(() => {
+      expect(getActiveKataDaemon()).toBe("work");
+      expect(component.route()).toEqual({ issue: null, view: null, scope: null, daemon: null });
+    });
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+  });
+
+  it("abandons an in-flight routed restoration when navigation supersedes it", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [
+          { id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" },
+          { id: "work", url: "http://127.0.0.1:8888", default: false, auth: "none", health: "connected" },
+        ],
+      }),
+    );
+    setActiveKataDaemon("home");
+    const home = initialIssues[0]!;
+    const work = initialIssues[1]!;
+    const api = createDaemonWorkspaceAPI({ home: [home], work: [work] });
+    const workCatalog = deferred<Awaited<ReturnType<typeof api.projects>>>();
+    vi.mocked(api.projects).mockImplementation(async () => {
+      const binding = vi.mocked(api.bindWorkflowDaemon!).mock.calls.at(-1)?.[0];
+      if (binding === "work") return workCatalog.promise;
+      return { projects, fetched_at: fetchedAt };
+    });
+    saveKataWorkspaceState("home", {
+      view: "all",
+      filters: { scope: { kind: "all" }, status: "open", owner: "Home", label: "", query: "" },
+      selectedIssueUID: home.uid,
+    });
+
+    const { component } = render(KataWorkspaceRouteHost, {
+      props: { api, initialIssue: work.uid, initialDaemon: "work" },
+    });
+    await waitFor(() =>
+      expect(
+        vi
+          .mocked(api.projects)
+          .mock.calls.some(() => vi.mocked(api.bindWorkflowDaemon!).mock.calls.some(([daemon]) => daemon === "work")),
+      ).toBe(true),
+    );
+
+    component.setRoute({ issue: null, daemon: null });
+    workCatalog.resolve({ projects, fetched_at: fetchedAt });
+
+    await waitFor(() => expect(vi.mocked(api.bindWorkflowDaemon!).mock.calls.at(-1)?.[0]).toBe("home"));
+    expect(getActiveKataDaemon()).toBe("home");
+    expect(component.route().daemon).toBeNull();
+    expect(screen.queryByRole("heading", { name: work.title })).toBeNull();
+    expect(screen.getByText("Select a task")).toBeTruthy();
+    expect(screen.getByTestId("daemon-chip").textContent).toContain("home");
+  });
+
+  it("applies the latest bare route when fallback recovery is superseded", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [
+          { id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" },
+          { id: "work", url: "http://127.0.0.1:8888", default: false, auth: "none", health: "connected" },
+        ],
+      }),
+    );
+    setActiveKataDaemon("home");
+    const home = initialIssues[0]!;
+    const work = initialIssues[1]!;
+    const api = createDaemonWorkspaceAPI({ home: [home], work: [work] });
+    const workCatalog = deferred<Awaited<ReturnType<typeof api.projects>>>();
+    const homeCatalog = deferred<Awaited<ReturnType<typeof api.projects>>>();
+    vi.mocked(api.projects).mockImplementation(async () => {
+      const binding = vi.mocked(api.bindWorkflowDaemon!).mock.calls.at(-1)?.[0];
+      if (binding === "work") return workCatalog.promise;
+      if (binding === "home") return homeCatalog.promise;
+      return { projects, fetched_at: fetchedAt };
+    });
+    saveKataWorkspaceState("home", {
+      view: "today",
+      filters: {
+        scope: { kind: "project", project_uid: "project-finances" },
+        status: "open",
+        owner: "Home",
+        label: "saved",
+        query: "saved",
+      },
+      selectedIssueUID: home.uid,
+    });
+
+    const { component } = render(KataWorkspaceRouteHost, {
+      props: { api, initialIssue: work.uid, initialDaemon: "work" },
+    });
+    await waitFor(() => expect(vi.mocked(api.projects)).toHaveBeenCalledTimes(1));
+
+    component.setRoute({ view: "inbox", scope: null, issue: null, daemon: null });
+    await waitFor(() => expect(vi.mocked(api.bindWorkflowDaemon!).mock.calls.at(-1)?.[0]).toBe("home"));
+    component.setRoute({ view: null, scope: null, issue: null, daemon: null });
+    workCatalog.resolve({ projects, fetched_at: fetchedAt });
+    homeCatalog.resolve({ projects, fetched_at: fetchedAt });
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "All Open" })).toBeTruthy());
+    expect(component.route()).toEqual({ issue: null, view: null, scope: null, daemon: null });
+    expect(screen.getByText("Select a task")).toBeTruthy();
+    expect((screen.getByLabelText("Search tasks") as HTMLInputElement).value).toBe("saved");
+    expect(loadKataWorkspaceState("home")?.selectedIssueUID).toBe(home.uid);
+  });
+
+  it("restores the accepted daemon binding when navigation invalidates routed Retry", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [
+          { id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" },
+          { id: "work", url: "http://127.0.0.1:8888", default: false, auth: "none", health: "connected" },
+        ],
+      }),
+    );
+    setActiveKataDaemon("home");
+    const work = initialIssues[1]!;
+    const api = createDaemonWorkspaceAPI({ home: [initialIssues[0]!], work: [work] });
+    vi.mocked(api.issue).mockRejectedValueOnce(new Error("detail timed out"));
+
+    const { component } = render(KataWorkspaceRouteHost, {
+      props: { api, initialIssue: work.uid, initialDaemon: "work" },
+    });
+    await screen.findByRole("button", { name: "Retry" });
+
+    component.setRoute({ issue: null, daemon: null });
+
+    await waitFor(() => expect(screen.queryByRole("button", { name: "Retry" })).toBeNull());
+    expect(getActiveKataDaemon()).toBe("home");
+    expect(vi.mocked(api.bindWorkflowDaemon!).mock.calls.at(-1)?.[0]).toBe("home");
+    expect(screen.getByTestId("daemon-chip").textContent).toContain("home");
+  });
+
+  it("ignores a running routed Retry after navigation supersedes it", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [
+          { id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" },
+          { id: "work", url: "http://127.0.0.1:8888", default: false, auth: "none", health: "connected" },
+        ],
+      }),
+    );
+    setActiveKataDaemon("home");
+    const home = initialIssues[0]!;
+    const work = initialIssues[1]!;
+    const api = createDaemonWorkspaceAPI({ home: [home], work: [work] });
+    const retryCatalog = deferred<Awaited<ReturnType<typeof api.projects>>>();
+    let workCatalogAttempts = 0;
+    vi.mocked(api.projects).mockImplementation(async () => {
+      const binding = vi.mocked(api.bindWorkflowDaemon!).mock.calls.at(-1)?.[0];
+      if (binding === "work") {
+        workCatalogAttempts += 1;
+        if (workCatalogAttempts === 1) throw new Error("catalog timed out");
+        if (workCatalogAttempts === 2) return retryCatalog.promise;
+      }
+      return { projects, fetched_at: fetchedAt };
+    });
+    saveKataWorkspaceState("home", {
+      view: "all",
+      filters: { scope: { kind: "all" }, status: "open", owner: "Home", label: "", query: "" },
+      selectedIssueUID: home.uid,
+    });
+
+    const { component } = render(KataWorkspaceRouteHost, {
+      props: { api, initialIssue: work.uid, initialDaemon: "work" },
+    });
+    await screen.findByRole("button", { name: "Retry" });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    await waitFor(() => expect(workCatalogAttempts).toBe(2));
+    component.setRoute({ issue: null, daemon: null });
+    retryCatalog.resolve({ projects, fetched_at: fetchedAt });
+
+    await waitFor(() => expect(vi.mocked(api.bindWorkflowDaemon!).mock.calls.at(-1)?.[0]).toBe("home"));
+    expect(getActiveKataDaemon()).toBe("home");
+    expect(component.route().daemon).toBeNull();
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+    expect(screen.queryByRole("heading", { name: work.title })).toBeNull();
+    expect(screen.getByTestId("daemon-chip").textContent).toContain("home");
+  });
+
+  it("does not reinstall routed Retry when a superseded attempt rejects late", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [
+          { id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" },
+          { id: "work", url: "http://127.0.0.1:8888", default: false, auth: "none", health: "connected" },
+        ],
+      }),
+    );
+    setActiveKataDaemon("home");
+    const home = initialIssues[0]!;
+    const work = initialIssues[1]!;
+    const api = createDaemonWorkspaceAPI({ home: [home], work: [work] });
+    const retryCatalog = deferred<Awaited<ReturnType<typeof api.projects>>>();
+    let workCatalogAttempts = 0;
+    vi.mocked(api.projects).mockImplementation(async () => {
+      const binding = vi.mocked(api.bindWorkflowDaemon!).mock.calls.at(-1)?.[0];
+      if (binding === "work") {
+        workCatalogAttempts += 1;
+        if (workCatalogAttempts === 1) throw new Error("catalog timed out");
+        if (workCatalogAttempts === 2) return retryCatalog.promise;
+      }
+      return { projects, fetched_at: fetchedAt };
+    });
+
+    const { component } = render(KataWorkspaceRouteHost, {
+      props: { api, initialIssue: work.uid, initialDaemon: "work" },
+    });
+    await screen.findByRole("button", { name: "Retry" });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    await waitFor(() => expect(workCatalogAttempts).toBe(2));
+    component.setRoute({ issue: null, daemon: null });
+    retryCatalog.reject(new Error("late retry failure"));
+
+    await waitFor(() => expect(vi.mocked(api.bindWorkflowDaemon!).mock.calls.at(-1)?.[0]).toBe("home"));
+    expect(getActiveKataDaemon()).toBe("home");
+    expect(component.route().daemon).toBeNull();
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+    expect(screen.queryByText("late retry failure")).toBeNull();
+    expect(screen.getByTestId("daemon-chip").textContent).toContain("home");
+  });
+
+  it("defers invalid routed target cleanup until cursor catch-up accepts it", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [
+          { id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" },
+          { id: "work", url: "http://127.0.0.1:8888", default: false, auth: "none", health: "connected" },
+        ],
+      }),
+    );
+    setActiveKataDaemon("home");
+    const home = initialIssues[0]!;
+    const work = initialIssues[1]!;
+    const api = createDaemonWorkspaceAPI(
+      { home: [home], work: [work] },
+      { home: projects, work: projects.filter((project) => project.uid !== "project-finances") },
+    );
+    let workCursorAttempts = 0;
+    vi.mocked(api.events).mockImplementation(async (params) => {
+      const binding = vi.mocked(api.bindWorkflowDaemon!).mock.calls.at(-1)?.[0];
+      if (binding === "work" && params && "after_id" in params && ++workCursorAttempts === 1) {
+        throw new Error("cursor timed out");
+      }
+      return { reset_required: false, events: [], next_after_id: 0 };
+    });
+    const workSnapshot = {
+      view: "all" as const,
+      filters: {
+        scope: { kind: "project" as const, project_uid: "project-missing" },
+        status: "all" as const,
+        owner: "Work",
+        label: "stale",
+        query: "discard",
+      },
+      selectedIssueUID: work.uid,
+    };
+    saveKataWorkspaceState("work", workSnapshot);
+
+    const { component } = render(KataWorkspaceRouteHost, {
+      props: { api, initialIssue: work.uid, initialDaemon: "work" },
+    });
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy());
+    expect(workCursorAttempts).toBe(1);
+    expect(getActiveKataDaemon()).toBe("home");
+    expect(component.route().daemon).toBe("work");
+    expect(loadKataWorkspaceState("work")).toEqual(workSnapshot);
+
+    await fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() => {
+      expect(getActiveKataDaemon()).toBe("work");
+      expect(component.route().daemon).toBeNull();
+      expect(loadKataWorkspaceState("work")).toBeNull();
+    });
+  });
+
+  it("defers stale routed target selection cleanup until cursor catch-up accepts it", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [
+          { id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" },
+          { id: "work", url: "http://127.0.0.1:8888", default: false, auth: "none", health: "connected" },
+        ],
+      }),
+    );
+    setActiveKataDaemon("home");
+    const staleUID = "issue-work-missing";
+    const api = createDaemonWorkspaceAPI({ home: [initialIssues[0]!], work: [initialIssues[1]!] });
+    vi.mocked(api.issue).mockImplementation(async (uid: string) => {
+      if (uid === staleUID) {
+        throw new KataTaskAPIError({ status: 404, code: "not_found", message: "not found", headers: new Headers() });
+      }
+      return detail(uid, initialIssues);
+    });
+    let workCursorAttempts = 0;
+    vi.mocked(api.events).mockImplementation(async (params) => {
+      const binding = vi.mocked(api.bindWorkflowDaemon!).mock.calls.at(-1)?.[0];
+      if (binding === "work" && params && "after_id" in params && ++workCursorAttempts === 1) {
+        throw new Error("cursor timed out");
+      }
+      return { reset_required: false, events: [], next_after_id: 0 };
+    });
+    const workSnapshot = {
+      view: "all" as const,
+      filters: { scope: { kind: "all" as const }, status: "open" as const, owner: "Work", label: "", query: "saved" },
+      selectedIssueUID: staleUID,
+    };
+    saveKataWorkspaceState("work", workSnapshot);
+
+    const { component } = render(KataWorkspaceRouteHost, {
+      props: { api, initialDaemon: "work" },
+    });
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy());
+    expect(workCursorAttempts).toBe(1);
+    expect(getActiveKataDaemon()).toBe("home");
+    expect(component.route().daemon).toBe("work");
+    expect(loadKataWorkspaceState("work")).toEqual(workSnapshot);
+
+    await fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() => {
+      expect(getActiveKataDaemon()).toBe("work");
+      expect(component.route().daemon).toBeNull();
+      expect(loadKataWorkspaceState("work")?.selectedIssueUID).toBeNull();
+    });
+  });
+
+  it("keeps routed daemon Retry provisional until cursor catch-up succeeds", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [
+          { id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" },
+          { id: "work", url: "http://127.0.0.1:8888", default: false, auth: "none", health: "connected" },
+        ],
+      }),
+    );
+    setActiveKataDaemon("home");
+    const work = initialIssues[1]!;
+    const api = createDaemonWorkspaceAPI({ home: [initialIssues[0]!], work: [work] });
+    vi.mocked(api.projects).mockRejectedValueOnce(new Error("catalog timed out"));
+    let workCursorAttempts = 0;
+    vi.mocked(api.events).mockImplementation(async (params) => {
+      const binding = vi.mocked(api.bindWorkflowDaemon!).mock.calls.at(-1)?.[0];
+      if (binding === "work" && params && "after_id" in params && ++workCursorAttempts === 1) {
+        throw new Error("cursor timed out");
+      }
+      return { reset_required: false, events: [], next_after_id: 0 };
+    });
+    const workSnapshot = {
+      view: "all" as const,
+      filters: { scope: { kind: "all" as const }, status: "open" as const, owner: "Work", label: "", query: "saved" },
+      selectedIssueUID: work.uid,
+    };
+    saveKataWorkspaceState("work", workSnapshot);
+
+    const { component } = render(KataWorkspaceRouteHost, {
+      props: { api, initialIssue: work.uid, initialDaemon: "work" },
+    });
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy());
+    await fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() => {
+      expect(workCursorAttempts).toBe(1);
+      expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+    });
+    expect(getActiveKataDaemon()).toBe("home");
+    expect(component.route().daemon).toBe("work");
+    expect(loadKataWorkspaceState("work")).toEqual(workSnapshot);
+
+    await fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() => {
+      expect(getActiveKataDaemon()).toBe("work");
+      expect(component.route().daemon).toBeNull();
+      expect(screen.getByRole("heading", { name: "Email Susan re: Q3" })).toBeTruthy();
+    });
+  });
+
+  it("rolls back a manual switch when its persisted detail fails transiently", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [
+          { id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" },
+          { id: "work", url: "http://127.0.0.1:8888", default: false, auth: "none", health: "connected" },
+        ],
+      }),
+    );
+    setActiveKataDaemon("home");
+    const home = initialIssues[0]!;
+    const work = initialIssues[1]!;
+    const api = createDaemonWorkspaceAPI({ home: [home], work: [work] });
+    saveKataWorkspaceState("home", {
+      view: "all",
+      filters: { scope: { kind: "all" }, status: "open", owner: "", label: "", query: "" },
+      selectedIssueUID: home.uid,
+    });
+    vi.mocked(api.issue).mockImplementation(async (uid, opts) => {
+      if (uid === work.uid && opts?.daemonId === "work") throw new Error("work detail timed out");
+      return detail(uid, uid === work.uid ? [work] : [home]);
+    });
+    saveKataWorkspaceState("work", {
+      view: "all",
+      filters: { scope: { kind: "all" }, status: "open", owner: "", label: "", query: "" },
+      selectedIssueUID: work.uid,
+    });
+
+    render(KataWorkspace, { props: { api } });
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Pay rent" })).toBeTruthy());
+    await fireEvent.click(screen.getByTestId("daemon-chip"));
+    const workDaemonRow = (await screen.findByTestId("daemon-row-work")) as HTMLButtonElement;
+    await waitFor(() => expect(workDaemonRow.disabled).toBe(false));
+    await fireEvent.click(workDaemonRow);
+
+    await waitFor(() => expect(screen.getByText("work detail timed out")).toBeTruthy());
+    expect(getActiveKataDaemon()).toBe("home");
+    expect(screen.getByRole("heading", { name: "Pay rent" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+  });
+
+  it("loads candidate ancestors through the target daemon without mutating the accepted workspace", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [
+          { id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" },
+          { id: "work", url: "http://127.0.0.1:8888", default: false, auth: "none", health: "connected" },
+        ],
+      }),
+    );
+    setActiveKataDaemon("home");
+    const home = initialIssues[0]!;
+    const parent = issue("issue-work-parent", "Work parent", "project-kata");
+    const child = {
+      ...issue("issue-work-child", "Work child", "project-kata"),
+      parent: { uid: parent.uid, short_id: parent.short_id },
+      parent_short_id: parent.short_id,
+    };
+    const api = createDaemonWorkspaceAPI({ home: [home], work: [child] });
+    saveKataWorkspaceState("home", {
+      view: "all",
+      filters: { scope: { kind: "all" }, status: "open", owner: "", label: "", query: "" },
+      selectedIssueUID: home.uid,
+    });
+    const parentDetail = deferred<KataTaskDetail>();
+    vi.mocked(api.issue).mockImplementation(async (uid, opts) => {
+      if (uid === child.uid) return detail(child.uid, [child]);
+      if (uid === parent.uid) {
+        if (opts?.daemonId !== "work") throw new Error("ancestor used accepted daemon");
+        return parentDetail.promise;
+      }
+      return detail(uid, [home]);
+    });
+    saveKataWorkspaceState("work", {
+      view: "all",
+      filters: { scope: { kind: "all" }, status: "open", owner: "", label: "", query: "" },
+      selectedIssueUID: child.uid,
+    });
+
+    render(KataWorkspace, { props: { api } });
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Pay rent" })).toBeTruthy());
+    await fireEvent.click(screen.getByTestId("daemon-chip"));
+    const workDaemonRow = (await screen.findByTestId("daemon-row-work")) as HTMLButtonElement;
+    await waitFor(() => expect(workDaemonRow.disabled).toBe(false));
+    await fireEvent.click(workDaemonRow);
+
+    await waitFor(() => expect(api.issue).toHaveBeenCalledWith(parent.uid, { daemonId: "work" }));
+    expect(getActiveKataDaemon()).toBe("home");
+    expect(screen.getByRole("heading", { name: "Pay rent" })).toBeTruthy();
+    expect(screen.queryByText("Work parent")).toBeNull();
+    expect(screen.queryByText("ancestor used accepted daemon")).toBeNull();
+
+    parentDetail.resolve(detail(parent.uid, [parent, child]));
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Work child" })).toBeTruthy());
+    expect(getActiveKataDaemon()).toBe("work");
+  });
+
+  it("does not reveal candidate ancestors while rollback is pending", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [
+          { id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" },
+          { id: "work", url: "http://127.0.0.1:8888", default: false, auth: "none", health: "connected" },
+        ],
+      }),
+    );
+    setActiveKataDaemon("home");
+    const home = initialIssues[0]!;
+    const parent = issue("issue-work-rollback-parent", "Rollback work parent", "project-kata");
+    const child = {
+      ...issue("issue-work-rollback-child", "Rollback work child", "project-kata"),
+      parent: { uid: parent.uid, short_id: parent.short_id },
+      parent_short_id: parent.short_id,
+    };
+    const api = createDaemonWorkspaceAPI({ home: [home], work: [child] });
+    const parentDetail = deferred<KataTaskDetail>();
+    const rollbackCursor = deferred<KataTaskEventsResponse>();
+    let homeCursorCalls = 0;
+    vi.mocked(api.issue).mockImplementation(async (uid, opts) => {
+      if (uid === child.uid && opts?.daemonId === "work") return detail(child.uid, [child]);
+      if (uid === parent.uid && opts?.daemonId === "work") return parentDetail.promise;
+      return detail(uid, [home]);
+    });
+    vi.mocked(api.events).mockImplementation(async (query = {}, opts) => {
+      if (query.after_id !== undefined && query.issue_uid === undefined && opts?.daemonId === "work") {
+        throw new Error("work cursor failed");
+      }
+      if (query.after_id !== undefined && query.issue_uid === undefined && opts?.daemonId === "home") {
+        homeCursorCalls += 1;
+        if (homeCursorCalls === 2) return rollbackCursor.promise;
+      }
+      return { reset_required: false, events: [], next_after_id: query.after_id ?? 0 };
+    });
+    saveKataWorkspaceState("home", {
+      view: "all",
+      filters: { scope: { kind: "all" }, status: "open", owner: "", label: "", query: "" },
+      selectedIssueUID: home.uid,
+    });
+    saveKataWorkspaceState("work", {
+      view: "all",
+      filters: { scope: { kind: "all" }, status: "open", owner: "", label: "", query: "" },
+      selectedIssueUID: child.uid,
+    });
+
+    render(KataWorkspace, { props: { api } });
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Pay rent" })).toBeTruthy());
+    await fireEvent.click(screen.getByTestId("daemon-chip"));
+    const workDaemonRow = (await screen.findByTestId("daemon-row-work")) as HTMLButtonElement;
+    await waitFor(() => expect(workDaemonRow.disabled).toBe(false));
+    await fireEvent.click(workDaemonRow);
+    await waitFor(() => expect(api.issue).toHaveBeenCalledWith(parent.uid, { daemonId: "work" }));
+    parentDetail.resolve(detail(parent.uid, [parent, child]));
+    await waitFor(() =>
+      expect(
+        vi
+          .mocked(api.events)
+          .mock.calls.some(
+            ([query, opts]) =>
+              query?.after_id !== undefined && query.issue_uid === undefined && opts?.daemonId === "work",
+          ),
+      ).toBe(true),
+    );
+    await waitFor(() => expect(homeCursorCalls).toBe(2));
+    await tick();
+    await tick();
+
+    expect(getActiveKataDaemon()).toBe("home");
+    expect(screen.getByRole("heading", { name: "Pay rent" })).toBeTruthy();
+    expect(screen.queryByText("Rollback work child", { selector: ".title-text" })).toBeNull();
+    expect(screen.queryByText("Rollback work parent", { selector: ".title-text" })).toBeNull();
+
+    rollbackCursor.resolve({ reset_required: false, events: [], next_after_id: 0 });
+    await waitFor(() => expect(getActiveKataDaemon()).toBe("home"));
+  });
+
+  it("waits for candidate history and recurrence reads before adopting the target detail", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [
+          { id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" },
+          { id: "work", url: "http://127.0.0.1:8888", default: false, auth: "none", health: "connected" },
+        ],
+      }),
+    );
+    setActiveKataDaemon("home");
+    const home = initialIssues[0]!;
+    const work = { ...initialIssues[1]!, recurrence_id: 9 };
+    const api = createDaemonWorkspaceAPI({ home: [home], work: [work] });
+    const workEvents = deferred<Awaited<ReturnType<KataTaskAPI["events"]>>>();
+    const workRecurrences = deferred<Awaited<ReturnType<KataTaskAPI["recurrences"]>>>();
+    vi.mocked(api.events).mockImplementation(async (query = {}, opts) =>
+      query.issue_uid === work.uid && opts?.daemonId === "work"
+        ? workEvents.promise
+        : { reset_required: false, events: [], next_after_id: 0 },
+    );
+    vi.mocked(api.recurrences).mockImplementation(async (_projectID, opts) =>
+      opts?.daemonId === "work" ? workRecurrences.promise : { recurrences: [], fetched_at: fetchedAt },
+    );
+    saveKataWorkspaceState("work", {
+      view: "all",
+      filters: { scope: { kind: "all" }, status: "open", owner: "", label: "", query: "" },
+      selectedIssueUID: work.uid,
+    });
+
+    render(KataWorkspace, { props: { api } });
+    await waitFor(() => expect((screen.getByTestId("daemon-chip") as HTMLButtonElement).disabled).toBe(false));
+    await fireEvent.click(screen.getByTestId("daemon-chip"));
+    const workDaemonRow = (await screen.findByTestId("daemon-row-work")) as HTMLButtonElement;
+    await waitFor(() => expect(workDaemonRow.disabled).toBe(false));
+    await fireEvent.click(workDaemonRow);
+    await waitFor(() =>
+      expect(api.issue).toHaveBeenCalledWith(work.uid, { daemonId: "work", signal: expect.any(AbortSignal) }),
+    );
+    expect(getActiveKataDaemon()).toBe("home");
+
+    workEvents.resolve({
+      reset_required: false,
+      events: [
+        {
+          event_id: 9,
+          event_uid: "event-work-created",
+          origin_instance_uid: "instance-work",
+          type: "issue.created",
+          project_id: work.project_id,
+          project_uid: work.project_uid,
+          project_name: work.project_name,
+          issue_uid: work.uid,
+          issue_short_id: work.short_id,
+          actor: "fixture-user",
+          created_at: fetchedAt,
+        },
+      ],
+      next_after_id: 9,
+    });
+    workRecurrences.resolve({
+      recurrences: [recurrence({ id: 9, project_id: work.project_id })],
+      fetched_at: fetchedAt,
+    });
+
+    await waitFor(() => {
+      expect(getActiveKataDaemon()).toBe("work");
+      expect(screen.getByRole("heading", { name: "Email Susan re: Q3" })).toBeTruthy();
+      expect(screen.getByRole("region", { name: "Recurrence" })).toBeTruthy();
+    });
+  });
+
+  it("clears an invalid target snapshot only after accepting the daemon switch", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [
+          { id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" },
+          { id: "work", url: "http://127.0.0.1:8888", default: false, auth: "none", health: "connected" },
+        ],
+      }),
+    );
+    const home = initialIssues[0]!;
+    const work = initialIssues[1]!;
+    const api = createDaemonWorkspaceAPI(
+      { home: [home], work: [work] },
+      { home: projects, work: projects.filter((project) => project.uid !== "project-finances") },
+    );
+    saveKataWorkspaceState("work", {
+      view: "all",
+      filters: {
+        scope: { kind: "project", project_uid: "project-missing" },
+        status: "all",
+        owner: "Work",
+        label: "stale",
+        query: "discard",
+      },
+      selectedIssueUID: work.uid,
+    });
+
+    render(KataWorkspace, { props: { api } });
+    await waitFor(() => expect(screen.getByRole("heading", { name: "All Open" })).toBeTruthy());
+    await fireEvent.click(screen.getByTestId("daemon-chip"));
+    const workDaemonRow = (await screen.findByTestId("daemon-row-work")) as HTMLButtonElement;
+    await waitFor(() => expect(workDaemonRow.disabled).toBe(false));
+    await fireEvent.click(workDaemonRow);
+
+    await waitFor(() => expect(getActiveKataDaemon()).toBe("work"));
+    expect(screen.getByRole("button", { name: /Email Susan re: Q3/ })).toBeTruthy();
+    expect(loadKataWorkspaceState("work")).toBeNull();
+  });
+
+  it("clears a restored target selection removed by cursor catch-up", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [
+          { id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" },
+          { id: "work", url: "http://127.0.0.1:8888", default: false, auth: "none", health: "connected" },
+        ],
+      }),
+    );
+    const home = initialIssues[0]!;
+    const restoredWork = issue("issue-work-stale", "Stale work task", "project-kata");
+    const api = createDaemonWorkspaceAPI({ home: [home], work: [restoredWork] });
+    let workRows = [restoredWork];
+    vi.mocked(api.issues).mockImplementation(async (query, opts) => {
+      const daemonID = opts?.daemonId ?? vi.mocked(api.bindWorkflowDaemon!).mock.calls.at(-1)?.[0] ?? "home";
+      const rows = daemonID === "work" ? workRows : [home];
+      return {
+        view: query.view,
+        groups: [{ id: "all", title: "All", issues: rows }],
+        fetched_at: fetchedAt,
+        daemon_id: daemonID,
+      };
+    });
+    vi.mocked(api.events).mockImplementation(async (_query, opts) => {
+      const daemonID = opts?.daemonId ?? vi.mocked(api.bindWorkflowDaemon!).mock.calls.at(-1)?.[0] ?? "home";
+      if (daemonID === "work") {
+        workRows = [];
+        return {
+          reset_required: true,
+          reset_after_id: 1,
+          events: [],
+          next_after_id: 1,
+        };
+      }
+      return { reset_required: false, events: [], next_after_id: 0 };
+    });
+    saveKataWorkspaceState("home", {
+      view: "all",
+      filters: { scope: { kind: "all" }, status: "open", owner: "", label: "", query: "" },
+      selectedIssueUID: home.uid,
+    });
+    saveKataWorkspaceState("work", {
+      view: "all",
+      filters: { scope: { kind: "all" }, status: "open", owner: "", label: "", query: "" },
+      selectedIssueUID: restoredWork.uid,
+    });
+
+    const { component } = render(KataWorkspaceRouteHost, { props: { api } });
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Pay rent" })).toBeTruthy());
+
+    await fireEvent.click(screen.getByTestId("daemon-chip"));
+    const workDaemonRow = (await screen.findByTestId("daemon-row-work")) as HTMLButtonElement;
+    await waitFor(() => expect(workDaemonRow.disabled).toBe(false));
+    await fireEvent.click(workDaemonRow);
+
+    await waitFor(() => {
+      expect(getActiveKataDaemon()).toBe("work");
+      expect(screen.queryByRole("heading", { name: "Stale work task" })).toBeNull();
+      expect(loadKataWorkspaceState("work")?.selectedIssueUID).toBeNull();
+      expect(component.route().issue).toBeNull();
+    });
+    expect(vi.mocked(api.issue).mock.calls.filter(([uid]) => uid === restoredWork.uid)).toHaveLength(2);
+  });
+
+  it("blocks capture until initial cursor acceptance establishes the workspace owner", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = new URL(input instanceof Request ? input.url : String(input), window.location.origin);
+      if (url.pathname === "/api/v1/kata/daemons") {
+        return Response.json({
+          daemons: [
+            {
+              id: "home",
+              url: "http://127.0.0.1:7777",
+              default: true,
+              auth: "none",
+              health: "connected",
+            },
+          ],
+        });
+      }
+      if (url.pathname === "/api/v1/kata/proxy/api/v1/events/stream") {
+        return new Response(new ReadableStream<Uint8Array>({}), {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    });
+    setActiveKataDaemon("home");
+    const api = createDaemonWorkspaceAPI({ home: [...initialIssues] });
+    const cursor = deferred<Awaited<ReturnType<typeof api.events>>>();
+    vi.mocked(api.events).mockImplementation(async (query = {}) => {
+      if (query.after_id !== undefined && query.issue_uid === undefined) return cursor.promise;
+      return { reset_required: false, events: [], next_after_id: 0 };
+    });
+
+    render(KataWorkspace, { props: { api } });
+
+    await waitFor(() =>
+      expect(vi.mocked(api.events)).toHaveBeenCalledWith({ after_id: 0, limit: 100 }, { daemonId: "home" }),
+    );
+    const captureButton = screen.getByRole("button", { name: "New task" }) as HTMLButtonElement;
+    expect(captureButton.disabled).toBe(true);
+    await fireEvent.click(captureButton);
+    expect(screen.queryByRole("dialog", { name: "New task" })).toBeNull();
+
+    cursor.resolve({ reset_required: false, events: [], next_after_id: 0 });
+
+    await waitFor(() => expect(captureButton.disabled).toBe(false));
+  });
+
+  it("preserves a selection made while cursor catch-up that started unselected refreshes membership", async () => {
+    acceptHomeDaemon();
+    const payRent = initialIssues[0]!;
+    const emailSusan = initialIssues[1]!;
+    const rowsByDaemon = { home: [...initialIssues] };
+    const api = createDaemonWorkspaceAPI(rowsByDaemon);
+    const cursor = deferred<Awaited<ReturnType<typeof api.events>>>();
+    vi.mocked(api.events).mockImplementationOnce(async () => cursor.promise);
+    vi.mocked(api.issue).mockImplementation(async (uid) => {
+      const found = initialIssues.find((candidate) => candidate.uid === uid);
+      if (!found) throw new Error(`missing ${uid}`);
+      return detail(uid, [found]);
+    });
+
+    const { component } = render(KataWorkspaceRouteHost, { props: { api } });
+    await waitFor(() =>
+      expect(vi.mocked(api.events)).toHaveBeenCalledWith({ after_id: 0, limit: 100 }, { daemonId: "home" }),
+    );
+
+    await fireEvent.click(screen.getByRole("button", { name: /Email Susan re: Q3/ }));
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Email Susan re: Q3" })).toBeTruthy());
+    rowsByDaemon.home = [payRent];
+    cursor.resolve({ reset_required: true, reset_after_id: 1, events: [], next_after_id: 1 });
+
+    await waitFor(() => expect(vi.mocked(api.issues).mock.calls.length).toBeGreaterThan(1));
+    expect(screen.getByRole("heading", { name: "Email Susan re: Q3" })).toBeTruthy();
+    expect(component.route().issue).toBe(emailSusan.uid);
+    expect(loadKataWorkspaceState("home")?.selectedIssueUID).toBe(emailSusan.uid);
+  });
+
+  it("accepts a target daemon after partial cursor catch-up and retries from the accepted cursor", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [
+          { id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" },
+          { id: "work", url: "http://127.0.0.1:8888", default: false, auth: "none", health: "connected" },
+        ],
+      }),
+    );
+    const home = initialIssues[0]!;
+    const work = initialIssues[1]!;
+    const api = createDaemonWorkspaceAPI({ home: [home], work: [work] });
+    saveKataWorkspaceState("home", {
+      view: "all",
+      filters: { scope: { kind: "all" }, status: "open", owner: "", label: "", query: "" },
+      selectedIssueUID: home.uid,
+    });
+    saveKataWorkspaceState("work", {
+      view: "all",
+      filters: { scope: { kind: "all" }, status: "open", owner: "", label: "", query: "" },
+      selectedIssueUID: work.uid,
+    });
+    let failedLaterPage = false;
+    vi.mocked(api.events).mockImplementation(async (query = {}, opts) => {
+      const daemonID = opts?.daemonId ?? vi.mocked(api.bindWorkflowDaemon!).mock.calls.at(-1)?.[0] ?? "home";
+      if (daemonID !== "work") return { reset_required: false, events: [], next_after_id: 0 };
+      if (query.after_id === 0) {
+        return {
+          reset_required: false,
+          events: [
+            {
+              event_id: 10,
+              event_uid: "event-work-catch-up",
+              origin_instance_uid: "instance-1",
+              type: "issue.edited",
+              project_id: work.project_id,
+              project_uid: work.project_uid,
+              project_name: work.project_name,
+              issue_uid: work.uid,
+              issue_short_id: work.short_id,
+              actor: "fixture-user",
+              created_at: fetchedAt,
+            },
+          ],
+          next_after_id: 10,
+        };
+      }
+      if (query.after_id === 10 && !failedLaterPage) {
+        failedLaterPage = true;
+        throw new Error("later cursor page failed");
+      }
+      return { reset_required: false, events: [], next_after_id: 10 };
+    });
+
+    render(KataWorkspace, { props: { api } });
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Pay rent" })).toBeTruthy());
+    await fireEvent.click(screen.getByTestId("daemon-chip"));
+    const workDaemonRow = (await screen.findByTestId("daemon-row-work")) as HTMLButtonElement;
+    await waitFor(() => expect(workDaemonRow.disabled).toBe(false));
+    await fireEvent.click(workDaemonRow);
+
+    await waitFor(() => {
+      expect(getActiveKataDaemon()).toBe("work");
+      expect(screen.getByRole("heading", { name: "Email Susan re: Q3" })).toBeTruthy();
+      expect(screen.getByRole("alert").textContent).toContain("later cursor page failed");
+    });
+    expect(vi.mocked(api.events).mock.calls.some(([query]) => query?.after_id === 10)).toBe(true);
+
+    await fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() => expect(screen.queryByRole("alert")).toBeNull());
+    expect(vi.mocked(api.events).mock.calls.filter(([query]) => query?.after_id === 10)).toHaveLength(2);
+  });
+
+  it("rolls back to the persisted home workspace when the target daemon rejects", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [
+          { id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" },
+          { id: "work", url: "http://127.0.0.1:8888", default: false, auth: "none", health: "connected" },
+        ],
+      }),
+    );
+    const home = initialIssues[0]!;
+    const api = createDaemonWorkspaceAPI({ home: [home], work: [initialIssues[1]!] });
+    const homeSnapshot = {
+      view: "all" as const,
+      filters: { scope: { kind: "all" as const }, status: "all" as const, owner: "Home", label: "", query: "captured" },
+      selectedIssueUID: home.uid,
+    };
+    const workSnapshot = {
+      view: "inbox" as const,
+      filters: {
+        scope: { kind: "all" as const },
+        status: "open" as const,
+        owner: "Work",
+        label: "",
+        query: "unchanged",
+      },
+      selectedIssueUID: null,
+    };
+    saveKataWorkspaceState("home", homeSnapshot);
+    saveKataWorkspaceState("work", workSnapshot);
+    vi.mocked(api.instance).mockImplementation(async (opts) => {
+      const daemonID = opts?.daemonId ?? vi.mocked(api.bindWorkflowDaemon!).mock.calls.at(-1)?.[0];
+      if (daemonID === "work") throw new Error("work unavailable");
+      return { instance_uid: "instance-1", version: "dev", schema_version: 1 };
+    });
+
+    render(KataWorkspace, { props: { api } });
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Pay rent" })).toBeTruthy());
+
+    await fireEvent.click(screen.getByTestId("daemon-chip"));
+    const workDaemonRow = (await screen.findByTestId("daemon-row-work")) as HTMLButtonElement;
+    await waitFor(() => expect(workDaemonRow.disabled).toBe(false));
+    await fireEvent.click(workDaemonRow);
+
+    await waitFor(() => expect(getActiveKataDaemon()).toBe("home"));
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Pay rent" })).toBeTruthy());
+    expect((screen.getByLabelText("Search tasks") as HTMLInputElement).value).toBe("captured");
+    expect(screen.getByRole("combobox", { name: "Status: All" })).toBeTruthy();
+    expect(loadKataWorkspaceState("home")).toEqual(homeSnapshot);
+    expect(loadKataWorkspaceState("work")).toEqual(workSnapshot);
+  });
+
+  it("rolls back to the roster default without an explicit daemon preference", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [
+          { id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" },
+          { id: "work", url: "http://127.0.0.1:8888", default: false, auth: "none", health: "connected" },
+        ],
+      }),
+    );
+    const api = createDaemonWorkspaceAPI({ home: [initialIssues[0]!], work: [initialIssues[1]!] });
+    vi.mocked(api.instance).mockImplementation(async (opts) => {
+      const daemonID = opts?.daemonId ?? vi.mocked(api.bindWorkflowDaemon!).mock.calls.at(-1)?.[0];
+      if (daemonID === "work") throw new Error("work unavailable");
+      return { instance_uid: "instance-1", version: "dev", schema_version: 1 };
+    });
+
+    render(KataWorkspace, { props: { api } });
+    await waitFor(() => expect(screen.getByRole("heading", { name: "All Open" })).toBeTruthy());
+    expect(getActiveKataDaemon()).toBeUndefined();
+    expect(getDefaultKataDaemon()).toBe("home");
+
+    await fireEvent.click(screen.getByTestId("daemon-chip"));
+    const workDaemonRow = (await screen.findByTestId("daemon-row-work")) as HTMLButtonElement;
+    await waitFor(() => expect(workDaemonRow.disabled).toBe(false));
+    await fireEvent.click(workDaemonRow);
+
+    await waitFor(() => expect(getActiveKataDaemon()).toBe("home"));
+    expect(screen.getByTestId("daemon-chip").textContent).toContain("home");
+    expect(screen.queryByText(/Previous Kata daemon is unavailable/)).toBeNull();
+    expect(vi.mocked(api.instance).mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(vi.mocked(api.bindWorkflowDaemon!).mock.calls.at(-1)?.[0]).toBe("home");
+  });
+
+  it("clears the routed issue when manual-switch rollback catch-up removes the prior selection", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [
+          { id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" },
+          { id: "work", url: "http://127.0.0.1:8888", default: false, auth: "none", health: "connected" },
+        ],
+      }),
+    );
+    setActiveKataDaemon("home");
+    const payRent = initialIssues[0]!;
+    const rowsByDaemon = { home: [payRent], work: [initialIssues[1]!] };
+    const api = createDaemonWorkspaceAPI(rowsByDaemon);
+    let homeCursorCalls = 0;
+    vi.mocked(api.events).mockImplementation(async (_query, opts) => {
+      const daemonID = opts?.daemonId ?? vi.mocked(api.bindWorkflowDaemon!).mock.calls.at(-1)?.[0];
+      if (daemonID === "home" && ++homeCursorCalls === 2) {
+        rowsByDaemon.home = [];
+        return { reset_required: true, reset_after_id: 1, events: [], next_after_id: 1 };
+      }
+      return { reset_required: false, events: [], next_after_id: 0 };
+    });
+    vi.mocked(api.issue).mockImplementation(async (uid) => detail(uid, [payRent]));
+    vi.mocked(api.instance).mockImplementation(async (opts) => {
+      const daemonID = opts?.daemonId ?? vi.mocked(api.bindWorkflowDaemon!).mock.calls.at(-1)?.[0];
+      if (daemonID === "work") throw new Error("work unavailable");
+      return { instance_uid: "instance-1", version: "dev", schema_version: 1 };
+    });
+    saveKataWorkspaceState("home", {
+      view: "all",
+      filters: { scope: { kind: "all" }, status: "open", owner: "", label: "", query: "" },
+      selectedIssueUID: payRent.uid,
+    });
+
+    const { component } = render(KataWorkspaceRouteHost, {
+      props: { api, initialIssue: payRent.uid },
+    });
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Pay rent" })).toBeTruthy());
+
+    await fireEvent.click(screen.getByTestId("daemon-chip"));
+    const workDaemonRow = (await screen.findByTestId("daemon-row-work")) as HTMLButtonElement;
+    await waitFor(() => expect(workDaemonRow.disabled).toBe(false));
+    await fireEvent.click(workDaemonRow);
+
+    await waitFor(() => {
+      expect(getActiveKataDaemon()).toBe("home");
+      expect(component.route().issue).toBeNull();
+      expect(screen.getByRole("region", { name: "Task detail" }).textContent).toContain("Select a task");
+    });
+    expect(loadKataWorkspaceState("home")).toMatchObject({
+      view: "all",
+      filters: { scope: { kind: "all" }, status: "open", owner: "", label: "", query: "" },
+      selectedIssueUID: null,
+    });
+  });
+
+  it("keeps the captured workspace when rollback health recovery fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [
+          { id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" },
+          { id: "work", url: "http://127.0.0.1:8888", default: false, auth: "none", health: "connected" },
+        ],
+      }),
+    );
+    const home = initialIssues[0]!;
+    const api = createDaemonWorkspaceAPI({ home: [home], work: [initialIssues[1]!] });
+    const homeSnapshot = {
+      view: "all" as const,
+      filters: { scope: { kind: "all" as const }, status: "open" as const, owner: "", label: "", query: "" },
+      selectedIssueUID: home.uid,
+    };
+    const workSnapshot = {
+      view: "all" as const,
+      filters: { scope: { kind: "all" as const }, status: "open" as const, owner: "", label: "", query: "" },
+      selectedIssueUID: null,
+    };
+    saveKataWorkspaceState("home", homeSnapshot);
+    saveKataWorkspaceState("work", workSnapshot);
+    let targetAttempted = false;
+    vi.mocked(api.instance).mockImplementation(async (opts) => {
+      const daemonID = opts?.daemonId ?? vi.mocked(api.bindWorkflowDaemon!).mock.calls.at(-1)?.[0];
+      if (daemonID === "work") {
+        targetAttempted = true;
+        throw new Error("work unavailable");
+      }
+      if (targetAttempted && daemonID === "home") throw new Error("home unavailable");
+      return { instance_uid: "instance-1", version: "dev", schema_version: 1 };
+    });
+    const onRouteStateChange = vi.fn();
+
+    render(KataWorkspace, { props: { api, onRouteStateChange } });
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Pay rent" })).toBeTruthy());
+    onRouteStateChange.mockClear();
+
+    await fireEvent.click(screen.getByTestId("daemon-chip"));
+    const workDaemonRow = (await screen.findByTestId("daemon-row-work")) as HTMLButtonElement;
+    await waitFor(() => expect(workDaemonRow.disabled).toBe(false));
+    await fireEvent.click(workDaemonRow);
+
+    await waitFor(() => expect(screen.getByRole("status", { name: "Connection: error" })).toBeTruthy());
+    expect(getActiveKataDaemon()).toBe("home");
+    expect(screen.getByRole("heading", { name: "Pay rent" })).toBeTruthy();
+    expect(screen.getByRole("combobox", { name: "Status: Open" })).toBeTruthy();
+    expect((screen.getByLabelText("Search tasks") as HTMLInputElement).value).toBe("");
+    expect(onRouteStateChange).not.toHaveBeenCalled();
+    expect(loadKataWorkspaceState("home")).toEqual(homeSnapshot);
+    expect(loadKataWorkspaceState("work")).toEqual(workSnapshot);
+    expect(screen.getByText(/retained Kata workspace is read-only/)).toBeTruthy();
+    expect((screen.getByLabelText("Kata tasks").parentElement as HTMLElement & { inert: boolean }).inert).toBe(true);
+
+    targetAttempted = false;
+    await fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/retained Kata workspace is read-only/)).toBeNull();
+      expect((screen.getByLabelText("Kata tasks").parentElement as HTMLElement & { inert: boolean }).inert).toBe(false);
+    });
+    expect(getActiveKataDaemon()).toBe("home");
   });
 
   it("shows the daemon switcher and reloads tasks after daemon selection", async () => {
@@ -797,9 +3333,10 @@ describe("KataWorkspace", () => {
     });
     expect(screen.queryByRole("heading", { name: "Email Susan re: Q3" })).toBeNull();
 
-    await waitFor(() => expect((screen.getByTestId("daemon-chip") as HTMLButtonElement).disabled).toBe(false));
     await fireEvent.click(screen.getByTestId("daemon-chip"));
-    await fireEvent.click(screen.getByTestId("daemon-row-work"));
+    const workDaemonRow = (await screen.findByTestId("daemon-row-work")) as HTMLButtonElement;
+    await waitFor(() => expect(workDaemonRow.disabled).toBe(false));
+    await fireEvent.click(workDaemonRow);
 
     await waitFor(() => {
       expect(getActiveKataDaemon()).toBe("work");
@@ -808,7 +3345,67 @@ describe("KataWorkspace", () => {
     });
     expect(screen.queryByRole("heading", { name: "Pay rent" })).toBeNull();
     expect(api.issues).toHaveBeenCalledTimes(2);
-    expect(api.bindWorkflowDaemon).toHaveBeenCalledWith();
+    await waitFor(() => expect(api.bindWorkflowDaemon).toHaveBeenLastCalledWith("work"));
+  });
+
+  it("clears a stale routed task error after accepting a daemon switch", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [
+          {
+            id: "home",
+            url: "http://127.0.0.1:7777",
+            default: true,
+            auth: "none",
+            health: "connected",
+          },
+          {
+            id: "work",
+            url: "http://127.0.0.1:8888",
+            default: false,
+            auth: "none",
+            health: "connected",
+          },
+        ],
+      }),
+    );
+    const api = createDaemonWorkspaceAPI({
+      home: [initialIssues[0]!],
+      work: [initialIssues[1]!],
+    });
+    vi.mocked(api.issue).mockImplementation(async (uid: string) => {
+      if (uid === "issue-missing") {
+        throw new KataTaskAPIError({
+          status: 404,
+          code: "not_found",
+          message: "Kata task not found",
+          headers: new Headers(),
+        });
+      }
+      return detail(uid, [initialIssues[0]!, initialIssues[1]!]);
+    });
+
+    render(KataWorkspaceRouteHost, {
+      props: {
+        api,
+        initialIssue: "issue-missing",
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert").textContent).toContain("Kata task not found");
+    });
+
+    await fireEvent.click(screen.getByTestId("daemon-chip"));
+    const workDaemonRow = (await screen.findByTestId("daemon-row-work")) as HTMLButtonElement;
+    await waitFor(() => expect(workDaemonRow.disabled).toBe(false));
+    await fireEvent.click(workDaemonRow);
+
+    await waitFor(() => {
+      expect(getActiveKataDaemon()).toBe("work");
+      expect(screen.getByRole("heading", { name: "Email Susan re: Q3" })).toBeTruthy();
+    });
+    expect(screen.queryByRole("alert")).toBeNull();
   });
 
   it("keeps the daemon switcher visible for a single daemon after connecting", async () => {
@@ -907,17 +3504,40 @@ describe("KataWorkspace", () => {
     });
     vi.mocked(api.issue).mockClear();
 
-    await waitFor(() => expect((screen.getByTestId("daemon-chip") as HTMLButtonElement).disabled).toBe(false));
     await fireEvent.click(screen.getByTestId("daemon-chip"));
-    await fireEvent.click(screen.getByTestId("daemon-row-empty"));
+    const emptyDaemonRow = screen.getByTestId("daemon-row-empty") as HTMLButtonElement;
+    await waitFor(() => expect(emptyDaemonRow.disabled).toBe(false));
+    await fireEvent.click(emptyDaemonRow);
 
     await waitFor(() => {
       expect(getActiveKataDaemon()).toBe("empty");
-      expect(onSelectedIssueChange).toHaveBeenCalledWith(null);
       expect(screen.getByText("No tasks")).toBeTruthy();
     });
     expect(api.issue).not.toHaveBeenCalled();
     expect(screen.queryByRole("heading", { name: "Pay rent" })).toBeNull();
+  });
+
+  it("restores the accepted workspace when a project scope load fails", async () => {
+    const { api, search } = createWorkspaceAPI();
+    const onRouteStateChange = vi.fn();
+
+    render(KataWorkspaceRouteHost, {
+      props: { api, initialIssue: "issue-pay-rent", onRouteStateChange },
+    });
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Pay rent" })).toBeTruthy());
+    const acceptedPersistence = loadKataWorkspaceState("home");
+    search.mockRejectedValueOnce(new Error("project scope timed out"));
+    onRouteStateChange.mockClear();
+
+    const nav = within(screen.getByRole("complementary", { name: "Kata navigation" }));
+    await fireEvent.click(nav.getByRole("button", { name: /^Kata\s+1$/ }));
+
+    await waitFor(() => expect(screen.getByRole("alert").textContent).toContain("project scope timed out"));
+    expect(screen.getByRole("heading", { name: "Pay rent" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Pay rent/ })).toBeTruthy();
+    expect(onRouteStateChange).not.toHaveBeenCalled();
+    expect(loadKataWorkspaceState("home")).toEqual(acceptedPersistence);
   });
 
   it("renders the read-only task workspace and switches project scope", async () => {
@@ -1035,6 +3655,49 @@ describe("KataWorkspace", () => {
       expect(mockNavigate).toHaveBeenCalledWith("/terminal/workspace-kata");
       expect(workDaemonRow.disabled).toBe(false);
     });
+  });
+
+  it("does not persist workspace fields when creating a terminal workspace", async () => {
+    acceptHomeDaemon();
+    const persisted = {
+      view: "all" as const,
+      filters: { scope: { kind: "all" as const }, status: "open" as const, owner: "", label: "", query: "" },
+      selectedIssueUID: null,
+    };
+    const target: KataWorkspaceTarget = {
+      available: true,
+      repo: {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "acme",
+        name: "middleman",
+        repo_path: "acme/middleman",
+        capabilities: defaultProviderCapabilities,
+      },
+      item_type: "kata_task",
+      item_key: "issue-pay-rent",
+    };
+    mockCreateKataWorkspaceForTask.mockResolvedValue({
+      id: "workspace-kata",
+      item_type: "kata_task",
+      item_key: "issue-pay-rent",
+      git_head_ref: "middleman/kata/pay-rent",
+      status: "creating",
+    });
+    const { api } = createWorkspaceAPI();
+    vi.mocked(api.issue).mockImplementation(async (uid: string) => ({
+      ...detail(uid, initialIssues),
+      workspace_target: target,
+    }));
+    saveKataWorkspaceState("home", persisted);
+
+    render(KataWorkspace, { props: { api, selectedIssueUID: "issue-pay-rent" } });
+    await waitFor(() => expect(screen.getByRole("button", { name: "Create workspace" })).toBeTruthy());
+
+    await fireEvent.click(screen.getByRole("button", { name: "Create workspace" }));
+
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/terminal/workspace-kata"));
+    expect(loadKataWorkspaceState("home")).toEqual(persisted);
   });
 
   it("flashes workspace creation failures and leaves the action retryable", async () => {
@@ -1519,8 +4182,9 @@ describe("KataWorkspace", () => {
     await waitFor(() => {
       expect(screen.getByTestId("daemon-chip").textContent).toContain("home");
     });
+    await waitFor(() => expect((screen.getByTestId("daemon-chip") as HTMLButtonElement).disabled).toBe(false));
     await fireEvent.click(screen.getByTestId("daemon-chip"));
-    expect(within(screen.getByTestId("daemon-row-home")).getByText("Authentication required")).toBeTruthy();
+    expect(within(await screen.findByTestId("daemon-row-home")).getByText("Authentication required")).toBeTruthy();
     expect(screen.queryByText("daemon token missing")).toBeNull();
   });
 
@@ -1657,7 +4321,8 @@ describe("KataWorkspace", () => {
       work: [payRent],
     });
     const issueMock = vi.fn(async (uid: string): Promise<KataTaskDetail> => {
-      const active = getActiveKataDaemon() === "work" ? "work" : "home";
+      const binding = vi.mocked(api.bindWorkflowDaemon!).mock.calls.at(-1)?.[0];
+      const active = (binding ?? getActiveKataDaemon()) === "work" ? "work" : "home";
       const linked = active === "work" ? linkedWork : linkedHome;
       if (uid === payRent.uid) {
         return {
@@ -1696,7 +4361,9 @@ describe("KataWorkspace", () => {
     });
 
     await fireEvent.click(screen.getByTestId("daemon-chip"));
-    await fireEvent.click(screen.getByTestId("daemon-row-work"));
+    const workDaemonRow = (await screen.findByTestId("daemon-row-work")) as HTMLButtonElement;
+    await waitFor(() => expect(workDaemonRow.disabled).toBe(false));
+    await fireEvent.click(workDaemonRow);
 
     await waitFor(() => {
       expect(getActiveKataDaemon()).toBe("work");
@@ -1784,5 +4451,28 @@ describe("KataWorkspace", () => {
     await waitFor(() => {
       expect(screen.queryByText("Lease renewal")).toBeNull();
     });
+  });
+
+  it("does not persist workspace fields when unlinking a message", async () => {
+    acceptHomeDaemon();
+    const persisted = {
+      view: "all" as const,
+      filters: { scope: { kind: "all" as const }, status: "open" as const, owner: "", label: "", query: "" },
+      selectedIssueUID: null,
+    };
+    const link = messageLink({ message_id: 2001, subject: "Lease renewal" });
+    const rows = initialIssues.map((item) =>
+      item.uid === "issue-pay-rent" ? { ...item, metadata: { ...item.metadata, mail_links: [link] } } : item,
+    );
+    const { api } = createWorkspaceAPI(rows);
+    saveKataWorkspaceState("home", persisted);
+
+    render(KataWorkspace, { props: { api, selectedIssueUID: "issue-pay-rent" } });
+    await waitFor(() => expect(screen.getByRole("button", { name: "Unlink Lease renewal" })).toBeTruthy());
+
+    await fireEvent.click(screen.getByRole("button", { name: "Unlink Lease renewal" }));
+
+    await waitFor(() => expect(screen.queryByText("Lease renewal")).toBeNull());
+    expect(loadKataWorkspaceState("home")).toEqual(persisted);
   });
 });

--- a/frontend/src/lib/features/kata/KataWorkspaceEventStream.test.ts
+++ b/frontend/src/lib/features/kata/KataWorkspaceEventStream.test.ts
@@ -9,8 +9,14 @@ import type {
   KataTaskSummary,
 } from "../../api/kata/taskTypes.js";
 import { buildKataTaskView } from "../../api/kata/taskViewBuilder.js";
-import { getActiveKataDaemon, getDefaultKataDaemon } from "../../stores/active-kata-daemon.svelte.js";
+import {
+  getActiveKataDaemon,
+  getDefaultKataDaemon,
+  setActiveKataDaemon,
+} from "../../stores/active-kata-daemon.svelte.js";
 import KataWorkspace from "./KataWorkspace.svelte";
+import KataWorkspaceRouteHost from "./KataWorkspaceRouteHost.svelte";
+import { loadKataWorkspaceState, saveKataWorkspaceState } from "./kataWorkspacePersistence.js";
 import {
   createDaemonWorkspaceAPI,
   createWorkspaceAPI,
@@ -129,6 +135,453 @@ describe("KataWorkspace", () => {
     await waitFor(() => {
       expect(streamController).toBeUndefined();
     });
+  });
+
+  it.each([
+    {
+      name: "deletion",
+      rows: [],
+      event: { type: "issue.deleted" },
+    },
+    {
+      name: "move out of scope",
+      rows: [{ ...initialIssues[0]!, project_uid: "project-kata", project_id: projects[2]!.id, project_name: "Kata" }],
+      event: { type: "issue.moved" },
+    },
+    {
+      name: "status reclassification",
+      rows: [{ ...initialIssues[0]!, status: "closed" as const, closed_at: fetchedAt }],
+      event: { type: "issue.closed" },
+    },
+    {
+      name: "owner reclassification",
+      rows: [{ ...initialIssues[0]!, owner: "other" }],
+      event: { type: "issue.owner_changed" },
+      filters: { owner: "fixture-user" },
+    },
+    {
+      name: "label reclassification",
+      rows: [{ ...initialIssues[0]!, labels: ["other"] }],
+      event: { type: "issue.label_removed" },
+      filters: { label: "urgent" },
+    },
+    {
+      name: "query reclassification",
+      rows: [{ ...initialIssues[0]!, title: "Renew lease" }],
+      event: { type: "issue.edited" },
+      filters: { query: "Pay" },
+    },
+  ])(
+    "clears a persisted selection after a $name event refresh loses raw-result membership",
+    async ({ rows, event, filters: filterPatch = {} }) => {
+      let streamController: ReadableStreamDefaultController<Uint8Array> | undefined;
+      vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+        const url = new URL(input instanceof Request ? input.url : String(input), window.location.origin);
+        if (url.pathname === "/api/v1/kata/daemons") {
+          return Response.json({
+            daemons: [{ id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" }],
+          });
+        }
+        if (url.pathname === "/api/v1/kata/proxy/api/v1/events/stream") {
+          return new Response(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                streamController = controller;
+              },
+            }),
+            { status: 200, headers: { "Content-Type": "text/event-stream" } },
+          );
+        }
+        return new Response("not found", { status: 404 });
+      });
+      setActiveKataDaemon("home");
+      const rowsByDaemon = { home: [initialIssues[0]!] };
+      const api = createDaemonWorkspaceAPI(rowsByDaemon);
+      const filters = {
+        scope: { kind: "project" as const, project_uid: "project-finances" },
+        status: "open" as const,
+        owner: "",
+        label: "",
+        query: "",
+        ...filterPatch,
+      };
+      vi.mocked(api.search).mockImplementation(async (requestedFilters) => ({
+        filters: requestedFilters,
+        issues: rowsByDaemon.home.filter(
+          (issue) =>
+            (requestedFilters.scope.kind !== "project" || issue.project_uid === requestedFilters.scope.project_uid) &&
+            (requestedFilters.owner === "" || issue.owner === requestedFilters.owner) &&
+            (requestedFilters.label === "" || issue.labels?.includes(requestedFilters.label)) &&
+            (requestedFilters.query === "" || issue.title.includes(requestedFilters.query)),
+        ),
+        fetched_at: fetchedAt,
+      }));
+      saveKataWorkspaceState("home", { view: "all", filters, selectedIssueUID: "issue-pay-rent" });
+      render(KataWorkspaceRouteHost, {
+        props: { api, initialScope: "project-finances", initialIssue: "issue-pay-rent" },
+      });
+      await waitFor(() => {
+        expect(screen.getByRole("heading", { name: "Pay rent" })).toBeTruthy();
+        expect(streamController).toBeTruthy();
+      });
+      rowsByDaemon.home = rows;
+      streamController?.enqueue(
+        new TextEncoder().encode(
+          `id: 6\nevent: ${event.type}\ndata: ${JSON.stringify({
+            event_id: 6,
+            event_uid: "event-selection-reclassified",
+            origin_instance_uid: "instance-1",
+            project_id: projects[1]!.id,
+            project_uid: "project-finances",
+            project_name: "Finances",
+            issue_id: initialIssues[0]!.id,
+            issue_uid: initialIssues[0]!.uid,
+            issue_short_id: initialIssues[0]!.short_id,
+            actor: "fixture-user",
+            created_at: fetchedAt,
+            payload: event,
+          })}\n\n`,
+        ),
+      );
+
+      await waitFor(() => expect(loadKataWorkspaceState("home")?.selectedIssueUID).toBeNull());
+      expect(screen.getByText("Select a task")).toBeTruthy();
+      expect(loadKataWorkspaceState("home")?.filters).toEqual(filters);
+    },
+  );
+
+  it("starts streaming and retries accepted cursor membership after a later page failure", async () => {
+    const streamControllers: ReadableStreamDefaultController<Uint8Array>[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = new URL(input instanceof Request ? input.url : String(input), window.location.origin);
+      if (url.pathname === "/api/v1/kata/daemons") {
+        return Response.json({
+          daemons: [{ id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" }],
+        });
+      }
+      if (url.pathname === "/api/v1/kata/proxy/api/v1/events/stream") {
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              streamControllers.push(controller);
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "text/event-stream" } },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    });
+    setActiveKataDaemon("home");
+    const rowsByDaemon = { home: [initialIssues[0]!, initialIssues[1]!] };
+    const api = createDaemonWorkspaceAPI(rowsByDaemon);
+    const cursorPage = deferred<KataTaskEventsResponse>();
+    const retryPage = deferred<KataTaskEventsResponse>();
+    let afterEightyeightReads = 0;
+    vi.mocked(api.events).mockImplementation(async (query) => {
+      if (query?.issue_uid) {
+        return { reset_required: false, events: [], next_after_id: 0 };
+      }
+      if (query?.after_id === 0) return cursorPage.promise;
+      if (query?.after_id === 88) {
+        afterEightyeightReads += 1;
+        if (afterEightyeightReads === 1) throw new Error("later cursor page failed");
+        if (afterEightyeightReads === 2) return retryPage.promise;
+      }
+      return { reset_required: false, events: [], next_after_id: query?.after_id ?? 0 };
+    });
+    const persisted = {
+      view: "all" as const,
+      filters: { scope: { kind: "all" as const }, status: "open" as const, owner: "", label: "", query: "" },
+      selectedIssueUID: initialIssues[0]!.uid,
+    };
+    saveKataWorkspaceState("home", persisted);
+    const onRouteStateChange = vi.fn();
+    render(KataWorkspace, {
+      props: { api, selectedIssueUID: initialIssues[0]!.uid, onRouteStateChange },
+    });
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Pay rent" })).toBeTruthy());
+
+    rowsByDaemon.home = [initialIssues[1]!];
+    vi.mocked(api.issue).mockImplementation(async (uid) => {
+      if (uid === initialIssues[0]!.uid) throw new Error("detail unavailable");
+      return {
+        issue: { ...initialIssues[1]!, body: "Email Susan re: Q3 body" },
+        comments: [],
+        labels: [],
+        links: [],
+        children: [],
+      };
+    });
+    cursorPage.resolve({
+      reset_required: false,
+      events: [
+        {
+          event_id: 88,
+          event_uid: "event-removed-before-pagination-failure",
+          origin_instance_uid: "instance-1",
+          type: "issue.deleted",
+          project_id: initialIssues[0]!.project_id,
+          project_uid: initialIssues[0]!.project_uid,
+          project_name: initialIssues[0]!.project_name,
+          issue_id: initialIssues[0]!.id,
+          issue_uid: initialIssues[0]!.uid,
+          issue_short_id: initialIssues[0]!.short_id,
+          actor: "fixture-user",
+          created_at: fetchedAt,
+        },
+      ],
+      next_after_id: 88,
+    });
+
+    await waitFor(() => expect(screen.getByText("Select a task")).toBeTruthy());
+    await waitFor(() =>
+      expect(vi.mocked(api.events)).toHaveBeenCalledWith({ after_id: 88, limit: 100 }, { daemonId: "home" }),
+    );
+    await waitFor(() => expect(streamControllers).toHaveLength(1));
+    expect(screen.getByText(/later cursor page failed/)).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+    expect(loadKataWorkspaceState("home")?.selectedIssueUID).toBeNull();
+    expect(onRouteStateChange).toHaveBeenCalledWith({ view: null, scope: null, issue: null }, { replace: true });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() =>
+      expect(vi.mocked(api.events)).toHaveBeenLastCalledWith({ after_id: 88, limit: 100 }, { daemonId: "home" }),
+    );
+    expect(screen.getByText(/later cursor page failed/).closest('[role="alert"]')).toBeTruthy();
+    expect((screen.getByRole("button", { name: "Retrying…" }) as HTMLButtonElement).disabled).toBe(true);
+    retryPage.reject(new Error("retry still failing"));
+
+    await waitFor(() => expect(screen.getByText(/retry still failing/).closest('[role="alert"]')).toBeTruthy());
+    expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+
+    await fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    await waitFor(() =>
+      expect(vi.mocked(api.events)).toHaveBeenLastCalledWith({ after_id: 88, limit: 100 }, { daemonId: "home" }),
+    );
+    await waitFor(() => expect(screen.queryByText(/later cursor page failed|retry still failing/)).toBeNull());
+    expect(streamControllers).toHaveLength(1);
+  });
+
+  it("ignores a retry completion from a daemon after switching away", async () => {
+    const streamControllers: ReadableStreamDefaultController<Uint8Array>[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = new URL(input instanceof Request ? input.url : String(input), window.location.origin);
+      if (url.pathname === "/api/v1/kata/daemons") {
+        return Response.json({
+          daemons: [
+            { id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" },
+            { id: "work", url: "http://127.0.0.1:8888", default: false, auth: "none", health: "connected" },
+          ],
+        });
+      }
+      if (url.pathname === "/api/v1/kata/proxy/api/v1/events/stream") {
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              streamControllers.push(controller);
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "text/event-stream" } },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    });
+    setActiveKataDaemon("home");
+    const api = createDaemonWorkspaceAPI({ home: [initialIssues[0]!], work: [initialIssues[1]!] });
+    const delayedHomeRetry = deferred<KataTaskEventsResponse>();
+    let homeRetry = false;
+    vi.mocked(api.events).mockImplementation(async (query = {}, opts) => {
+      const daemonID =
+        opts?.daemonId ?? vi.mocked(api.bindWorkflowDaemon!).mock.calls.at(-1)?.[0] ?? getActiveKataDaemon();
+      if (query.issue_uid) return { reset_required: false, events: [], next_after_id: 0 };
+      if (daemonID === "home" && query.after_id === 0) {
+        return {
+          reset_required: false,
+          events: [
+            {
+              event_id: 5,
+              event_uid: "home-cursor-event",
+              origin_instance_uid: "instance-1",
+              type: "issue.edited",
+              project_id: initialIssues[0]!.project_id,
+              project_uid: initialIssues[0]!.project_uid,
+              project_name: initialIssues[0]!.project_name,
+              issue_id: initialIssues[0]!.id,
+              issue_uid: initialIssues[0]!.uid,
+              issue_short_id: initialIssues[0]!.short_id,
+              actor: "fixture-user",
+              created_at: fetchedAt,
+            },
+          ],
+          next_after_id: 5,
+        };
+      }
+      if (daemonID === "home" && query.after_id === 5) {
+        if (!homeRetry) {
+          homeRetry = true;
+          throw new Error("home cursor failed");
+        }
+        return delayedHomeRetry.promise;
+      }
+      return { reset_required: false, events: [], next_after_id: query.after_id ?? 0 };
+    });
+
+    render(KataWorkspace, { props: { api } });
+    await waitFor(() => expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy());
+    expect(streamControllers).toHaveLength(1);
+
+    await fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Retrying…" })).toBeTruthy());
+    await fireEvent.click(screen.getByTestId("daemon-chip"));
+    await fireEvent.click(screen.getByTestId("daemon-row-work"));
+    await waitFor(() => expect(getActiveKataDaemon()).toBe("work"));
+    await waitFor(() => expect(screen.getByRole("button", { name: /Email Susan re: Q3/ })).toBeTruthy());
+
+    delayedHomeRetry.resolve({ reset_required: false, events: [], next_after_id: 5 });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(screen.queryByText("home cursor failed")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+    await waitFor(() => expect(streamControllers).toHaveLength(2));
+  });
+
+  it("does not clear a newer selection when the event refresh removes the prior selection", async () => {
+    let streamController: ReadableStreamDefaultController<Uint8Array> | undefined;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = new URL(input instanceof Request ? input.url : String(input), window.location.origin);
+      if (url.pathname === "/api/v1/kata/daemons") {
+        return Response.json({
+          daemons: [{ id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" }],
+        });
+      }
+      if (url.pathname === "/api/v1/kata/proxy/api/v1/events/stream") {
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              streamController = controller;
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "text/event-stream" } },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    });
+    setActiveKataDaemon("home");
+    const replacement = initialIssues[1]!;
+    const rowsByDaemon = { home: [initialIssues[0]!, replacement] };
+    const api = createDaemonWorkspaceAPI(rowsByDaemon);
+    const stalledRefresh = deferred<Awaited<ReturnType<KataTaskAPI["issues"]>>>();
+    let refresh = false;
+    vi.mocked(api.issues).mockImplementation(async (query) => {
+      if (refresh) return stalledRefresh.promise;
+      return buildKataTaskView({
+        view: query.view,
+        issues: rowsByDaemon.home,
+        projects,
+        today: "2026-05-15",
+        fetched_at: fetchedAt,
+      });
+    });
+    const persisted = {
+      view: "all" as const,
+      filters: { scope: { kind: "all" as const }, status: "open" as const, owner: "", label: "", query: "" },
+      selectedIssueUID: initialIssues[0]!.uid,
+    };
+    saveKataWorkspaceState("home", persisted);
+    render(KataWorkspaceRouteHost, { props: { api, initialIssue: initialIssues[0]!.uid } });
+    await waitFor(() => expect(streamController).toBeTruthy());
+
+    refresh = true;
+    streamController?.enqueue(
+      new TextEncoder().encode(
+        `id: 6\nevent: issue.deleted\ndata: ${JSON.stringify({
+          event_id: 6,
+          event_uid: "event-old-selection-deleted",
+          origin_instance_uid: "instance-1",
+          type: "issue.deleted",
+          project_id: initialIssues[0]!.project_id,
+          project_uid: initialIssues[0]!.project_uid,
+          project_name: initialIssues[0]!.project_name,
+          issue_id: initialIssues[0]!.id,
+          issue_uid: initialIssues[0]!.uid,
+          issue_short_id: initialIssues[0]!.short_id,
+          actor: "fixture-user",
+          created_at: fetchedAt,
+          payload: {},
+        })}\n\n`,
+      ),
+    );
+    await waitFor(() => expect(api.issues).toHaveBeenCalledTimes(2));
+    await fireEvent.click(screen.getByRole("button", { name: /Email Susan re: Q3/ }));
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Email Susan re: Q3" })).toBeTruthy());
+    stalledRefresh.resolve(
+      buildKataTaskView({ view: "all", issues: [replacement], projects, today: "2026-05-15", fetched_at: fetchedAt }),
+    );
+
+    await waitFor(() => expect(loadKataWorkspaceState("home")?.selectedIssueUID).toBe(replacement.uid));
+    expect(screen.getByRole("heading", { name: "Email Susan re: Q3" })).toBeTruthy();
+  });
+
+  it("does not write a workspace snapshot for an event-only content refresh that preserves selected membership", async () => {
+    let streamController: ReadableStreamDefaultController<Uint8Array> | undefined;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = new URL(input instanceof Request ? input.url : String(input), window.location.origin);
+      if (url.pathname === "/api/v1/kata/daemons") {
+        return Response.json({
+          daemons: [{ id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" }],
+        });
+      }
+      if (url.pathname === "/api/v1/kata/proxy/api/v1/events/stream") {
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              streamController = controller;
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "text/event-stream" } },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    });
+    setActiveKataDaemon("home");
+    const rowsByDaemon = { home: [initialIssues[0]!] };
+    const api = createDaemonWorkspaceAPI(rowsByDaemon);
+    const persisted = {
+      view: "all" as const,
+      filters: { scope: { kind: "all" as const }, status: "open" as const, owner: "", label: "", query: "" },
+      selectedIssueUID: "issue-pay-rent",
+    };
+    render(KataWorkspace, { props: { api, selectedIssueUID: "issue-pay-rent" } });
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Pay rent" })).toBeTruthy();
+      expect(streamController).toBeTruthy();
+    });
+    saveKataWorkspaceState("home", persisted);
+
+    streamController?.enqueue(
+      new TextEncoder().encode(
+        `id: 6\nevent: issue.edited\ndata: ${JSON.stringify({
+          event_id: 6,
+          event_uid: "event-content-refresh",
+          origin_instance_uid: "instance-1",
+          type: "issue.edited",
+          project_id: projects[1]!.id,
+          project_uid: "project-finances",
+          project_name: "Finances",
+          issue_id: initialIssues[0]!.id,
+          issue_uid: initialIssues[0]!.uid,
+          issue_short_id: initialIssues[0]!.short_id,
+          actor: "fixture-user",
+          created_at: fetchedAt,
+          payload: {},
+        })}\n\n`,
+      ),
+    );
+
+    await waitFor(() => expect(vi.mocked(api.issues).mock.calls.length).toBeGreaterThan(1));
+    expect(loadKataWorkspaceState("home")).toEqual(persisted);
   });
 
   it("keeps a row selection made while a stream-triggered reload is in flight", async () => {
@@ -508,6 +961,53 @@ describe("KataWorkspace", () => {
     expect(streamHeaders[2]?.get("Last-Event-ID")).toBe("6");
   });
 
+  it("retries an initial cursor failure before opening the stream", async () => {
+    const streamControllers: ReadableStreamDefaultController<Uint8Array>[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = new URL(input instanceof Request ? input.url : String(input), window.location.origin);
+      if (url.pathname === "/api/v1/kata/daemons") {
+        return Response.json({
+          daemons: [
+            {
+              id: "home",
+              url: "http://127.0.0.1:7777",
+              default: true,
+              auth: "none",
+              health: "connected",
+            },
+          ],
+        });
+      }
+      if (url.pathname === "/api/v1/kata/proxy/api/v1/events/stream") {
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              streamControllers.push(controller);
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "text/event-stream" } },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    });
+    const api = createDaemonWorkspaceAPI({ home: [initialIssues[0]!] });
+    vi.mocked(api.events)
+      .mockRejectedValueOnce(new Error("initial cursor unavailable"))
+      .mockResolvedValue({ reset_required: false, events: [], next_after_id: 9 });
+
+    render(KataWorkspace, { props: { api } });
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy());
+    expect(screen.getByRole("button", { name: /Pay rent/ })).toBeTruthy();
+    expect(streamControllers).toHaveLength(0);
+
+    await fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() => expect(streamControllers).toHaveLength(1));
+    expect(screen.queryByText("initial cursor unavailable")).toBeNull();
+    expect(api.events).toHaveBeenCalledTimes(2);
+  });
+
   it("keeps daemon switching available while draining queued old-stream messages", async () => {
     const streamControllers: ReadableStreamDefaultController<Uint8Array>[] = [];
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
@@ -594,7 +1094,6 @@ describe("KataWorkspace", () => {
     releaseOldStreamRefresh.resolve();
     await waitFor(() => {
       expect(completedViewLoads).toBe(viewLoadsBeforeEvents + 2);
-      expect(homeDaemonRow.disabled).toBe(false);
     });
 
     const viewLoadsAfterDrain = vi.mocked(api.issues).mock.calls.length;
@@ -604,7 +1103,7 @@ describe("KataWorkspace", () => {
     expect(api.issues).toHaveBeenCalledTimes(viewLoadsAfterDrain);
   });
 
-  it("keeps daemon switching available and reconnects when a stream refresh fails", async () => {
+  it("releases the daemon switch gate and reconnects when a stream refresh fails", async () => {
     const streamControllers: ReadableStreamDefaultController<Uint8Array>[] = [];
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
       const url = new URL(input instanceof Request ? input.url : String(input), window.location.origin);
@@ -650,16 +1149,236 @@ describe("KataWorkspace", () => {
     );
     await fireEvent.click(screen.getByTestId("daemon-chip"));
     const homeDaemonRow = screen.getByTestId("daemon-row-home") as HTMLButtonElement;
-    await waitFor(() => {
-      expect(homeDaemonRow.disabled).toBe(false);
-    });
+    expect(homeDaemonRow.disabled).toBe(false);
 
     failedRefresh.reject(new Error("stream refresh failed"));
     await waitFor(() => {
-      expect(homeDaemonRow.disabled).toBe(false);
       expect(streamControllers).toHaveLength(2);
     });
     expect(screen.getByRole("button", { name: /Pay rent/ })).toBeTruthy();
+  });
+
+  it("keeps the accepted workspace visible until a daemon switch commits", async () => {
+    const streamControllers: ReadableStreamDefaultController<Uint8Array>[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = new URL(input instanceof Request ? input.url : String(input), window.location.origin);
+      if (url.pathname === "/api/v1/kata/daemons") {
+        return Response.json({
+          daemons: [
+            { id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" },
+            { id: "work", url: "http://127.0.0.1:8888", default: false, auth: "none", health: "connected" },
+          ],
+        });
+      }
+      if (url.pathname === "/api/v1/kata/proxy/api/v1/events/stream") {
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              streamControllers.push(controller);
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "text/event-stream" } },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    });
+    const api = createDaemonWorkspaceAPI({ home: [initialIssues[0]!], work: [initialIssues[1]!] });
+    const stalledEvents = deferred<KataTaskEventsResponse>();
+    setActiveKataDaemon("home");
+
+    render(KataWorkspace, { props: { api } });
+    await waitFor(() => expect(screen.getByRole("button", { name: /Pay rent/ })).toBeTruthy());
+
+    await fireEvent.click(screen.getByTestId("daemon-chip"));
+    const workDaemonRow = screen.getByTestId("daemon-row-work") as HTMLButtonElement;
+    await waitFor(() => expect(workDaemonRow.disabled).toBe(false));
+    vi.mocked(api.events).mockImplementation(async (query = {}, options) =>
+      query.after_id !== undefined && options?.daemonId === "work"
+        ? stalledEvents.promise
+        : { reset_required: false, events: [], next_after_id: 0 },
+    );
+    await fireEvent.click(workDaemonRow);
+    await waitFor(() =>
+      expect(api.events).toHaveBeenCalledWith(
+        expect.objectContaining({ after_id: expect.any(Number) }),
+        expect.objectContaining({ daemonId: "work" }),
+      ),
+    );
+
+    expect(screen.getByRole("button", { name: /Pay rent/ })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Email Susan re: Q3/ })).toBeNull();
+    expect(getActiveKataDaemon()).toBe("home");
+
+    stalledEvents.resolve({ reset_required: false, events: [], next_after_id: 0 });
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Email Susan re: Q3" })).toBeTruthy());
+    expect(getActiveKataDaemon()).toBe("work");
+  });
+
+  it("restores a stopped cursor retry when a route change cancels a daemon switch", async () => {
+    const streamControllers: ReadableStreamDefaultController<Uint8Array>[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = new URL(input instanceof Request ? input.url : String(input), window.location.origin);
+      if (url.pathname === "/api/v1/kata/daemons") {
+        return Response.json({
+          daemons: [
+            { id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" },
+            { id: "work", url: "http://127.0.0.1:8888", default: false, auth: "none", health: "connected" },
+          ],
+        });
+      }
+      if (url.pathname === "/api/v1/kata/proxy/api/v1/events/stream") {
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              streamControllers.push(controller);
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "text/event-stream" } },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    });
+    const api = createDaemonWorkspaceAPI({ home: [initialIssues[0]!], work: [initialIssues[1]!] });
+    const stalledWorkCursor = deferred<KataTaskEventsResponse>();
+    let homeCursorAttempts = 0;
+    vi.mocked(api.events).mockImplementation(async (query = {}, options) => {
+      if (query.after_id !== undefined && options?.daemonId === "work") return stalledWorkCursor.promise;
+      if (query.after_id !== undefined && options?.daemonId === "home") {
+        homeCursorAttempts += 1;
+        if (homeCursorAttempts === 1) throw new Error("initial cursor unavailable");
+      }
+      return { reset_required: false, events: [], next_after_id: query.after_id ?? 0 };
+    });
+    setActiveKataDaemon("home");
+    const { component } = render(KataWorkspaceRouteHost, { props: { api } });
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy());
+    expect(streamControllers).toHaveLength(0);
+
+    await fireEvent.click(screen.getByTestId("daemon-chip"));
+    const workDaemonRow = screen.getByTestId("daemon-row-work") as HTMLButtonElement;
+    await waitFor(() => expect(workDaemonRow.disabled).toBe(false));
+    await fireEvent.click(workDaemonRow);
+    await waitFor(() =>
+      expect(api.events).toHaveBeenCalledWith(
+        expect.objectContaining({ after_id: expect.any(Number) }),
+        expect.objectContaining({ daemonId: "work" }),
+      ),
+    );
+
+    component.setRoute({ view: "inbox", issue: null });
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Inbox" })).toBeTruthy());
+    expect(screen.getByText("initial cursor unavailable")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+    expect(streamControllers).toHaveLength(0);
+
+    await fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    await waitFor(() => expect(streamControllers).toHaveLength(1));
+    expect(screen.queryByText("initial cursor unavailable")).toBeNull();
+
+    stalledWorkCursor.resolve({ reset_required: false, events: [], next_after_id: 0 });
+  });
+
+  it("does not commit a daemon switch after its route changes", async () => {
+    const streamControllers: ReadableStreamDefaultController<Uint8Array>[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = new URL(input instanceof Request ? input.url : String(input), window.location.origin);
+      if (url.pathname === "/api/v1/kata/daemons") {
+        return Response.json({
+          daemons: [
+            { id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" },
+            { id: "work", url: "http://127.0.0.1:8888", default: false, auth: "none", health: "connected" },
+          ],
+        });
+      }
+      if (url.pathname === "/api/v1/kata/proxy/api/v1/events/stream") {
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              streamControllers.push(controller);
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "text/event-stream" } },
+        );
+      }
+      return new Response("not found", { status: 404 });
+    });
+    const api = createDaemonWorkspaceAPI({ home: [initialIssues[0]!], work: [initialIssues[1]!] });
+    const stalledEvents = deferred<KataTaskEventsResponse>();
+    setActiveKataDaemon("home");
+    const { component } = render(KataWorkspaceRouteHost, { props: { api } });
+    await waitFor(() => expect(screen.getByRole("button", { name: /Pay rent/ })).toBeTruthy());
+
+    await fireEvent.click(screen.getByTestId("daemon-chip"));
+    const workDaemonRow = screen.getByTestId("daemon-row-work") as HTMLButtonElement;
+    await waitFor(() => expect(workDaemonRow.disabled).toBe(false));
+    vi.mocked(api.events).mockImplementation(async (query = {}, options) =>
+      query.after_id !== undefined && options?.daemonId === "work"
+        ? stalledEvents.promise
+        : { reset_required: false, events: [], next_after_id: 0 },
+    );
+    await fireEvent.click(workDaemonRow);
+    await waitFor(() =>
+      expect(api.events).toHaveBeenCalledWith(
+        expect.objectContaining({ after_id: expect.any(Number) }),
+        expect.objectContaining({ daemonId: "work" }),
+      ),
+    );
+    component.setRoute({ view: "inbox", issue: null });
+    stalledEvents.resolve({ reset_required: false, events: [], next_after_id: 0 });
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Inbox" })).toBeTruthy());
+    expect(getActiveKataDaemon()).toBe("home");
+    expect(streamControllers).toHaveLength(2);
+  });
+
+  it("does not commit a daemon switch after unmount", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = new URL(input instanceof Request ? input.url : String(input), window.location.origin);
+      if (url.pathname === "/api/v1/kata/daemons") {
+        return Response.json({
+          daemons: [
+            { id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" },
+            { id: "work", url: "http://127.0.0.1:8888", default: false, auth: "none", health: "connected" },
+          ],
+        });
+      }
+      if (url.pathname === "/api/v1/kata/proxy/api/v1/events/stream") {
+        return new Response(new ReadableStream<Uint8Array>({}), {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    });
+    const api = createDaemonWorkspaceAPI({ home: [initialIssues[0]!], work: [initialIssues[1]!] });
+    const stalledEvents = deferred<KataTaskEventsResponse>();
+    setActiveKataDaemon("home");
+    const rendered = render(KataWorkspace, { props: { api } });
+    await waitFor(() => expect(screen.getByRole("button", { name: /Pay rent/ })).toBeTruthy());
+
+    await fireEvent.click(screen.getByTestId("daemon-chip"));
+    const workDaemonRow = screen.getByTestId("daemon-row-work") as HTMLButtonElement;
+    await waitFor(() => expect(workDaemonRow.disabled).toBe(false));
+    vi.mocked(api.events).mockImplementation(async (query = {}, options) =>
+      query.after_id !== undefined && options?.daemonId === "work"
+        ? stalledEvents.promise
+        : { reset_required: false, events: [], next_after_id: 0 },
+    );
+    await fireEvent.click(workDaemonRow);
+    await waitFor(() =>
+      expect(api.events).toHaveBeenCalledWith(
+        expect.objectContaining({ after_id: expect.any(Number) }),
+        expect.objectContaining({ daemonId: "work" }),
+      ),
+    );
+    rendered.unmount();
+    stalledEvents.resolve({ reset_required: false, events: [], next_after_id: 0 });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(getActiveKataDaemon()).toBe("home");
   });
 
   it("restarts the live stream after a stale daemon switch completion", async () => {
@@ -709,11 +1428,19 @@ describe("KataWorkspace", () => {
       expect(screen.getByRole("button", { name: /Pay rent/ })).toBeTruthy();
       expect(streamControllers).toHaveLength(1);
     });
-    const eventCallCount = vi.mocked(api.events).mock.calls.length;
-    vi.mocked(api.events).mockImplementationOnce(async () => stalledEvents.promise);
+    vi.mocked(api.events).mockImplementation(async (query = {}, options) =>
+      query.after_id !== undefined && options?.daemonId === "work"
+        ? stalledEvents.promise
+        : { reset_required: false, events: [], next_after_id: 0 },
+    );
     await fireEvent.click(screen.getByTestId("daemon-chip"));
     await fireEvent.click(screen.getByTestId("daemon-row-work"));
-    await waitFor(() => expect(api.events).toHaveBeenCalledTimes(eventCallCount + 1));
+    await waitFor(() =>
+      expect(api.events).toHaveBeenCalledWith(
+        expect.objectContaining({ after_id: expect.any(Number) }),
+        expect.objectContaining({ daemonId: "work" }),
+      ),
+    );
 
     await rerender({ api, routeViewName: "inbox" });
     stalledEvents.resolve({

--- a/frontend/src/lib/features/kata/KataWorkspaceRecurrence.test.ts
+++ b/frontend/src/lib/features/kata/KataWorkspaceRecurrence.test.ts
@@ -10,6 +10,12 @@ import {
   resetKataWorkspaceTestState,
 } from "./KataWorkspaceTestSupport.js";
 
+async function waitForWorkspaceWritable(): Promise<void> {
+  await waitFor(() =>
+    expect((screen.getByRole("button", { name: "New task" }) as HTMLButtonElement).disabled).toBe(false),
+  );
+}
+
 describe("KataWorkspace", () => {
   beforeEach(() => {
     resetKataWorkspaceTestState();
@@ -42,6 +48,7 @@ describe("KataWorkspace", () => {
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: "Pay rent" })).toBeTruthy();
     });
+    await waitForWorkspaceWritable();
     const detail = screen.getByRole("region", { name: "Task detail" });
 
     await fireEvent.click(within(detail).getByRole("button", { name: "More actions" }));
@@ -72,6 +79,7 @@ describe("KataWorkspace", () => {
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: "Pay rent" })).toBeTruthy();
     });
+    await waitForWorkspaceWritable();
     const detail = screen.getByRole("region", { name: "Task detail" });
     await fireEvent.click(within(detail).getByRole("button", { name: "More actions" }));
     await fireEvent.click(within(detail).getByRole("menuitem", { name: "Mark as recurring..." }));

--- a/frontend/src/lib/features/kata/KataWorkspaceTestSupport.ts
+++ b/frontend/src/lib/features/kata/KataWorkspaceTestSupport.ts
@@ -236,13 +236,28 @@ function reachableGraph(
   };
 }
 
-function createDaemonWorkspaceAPI(rowsByDaemon: Record<string, KataTaskSummary[]>): KataTaskAPI {
-  function rows(): KataTaskSummary[] {
-    return rowsByDaemon[getActiveKataDaemon() ?? getDefaultKataDaemon() ?? "home"] ?? [];
+function createDaemonWorkspaceAPI(
+  rowsByDaemon: Record<string, KataTaskSummary[]>,
+  projectsByDaemon: Record<string, KataProjectSummary[]> = {},
+): KataTaskAPI {
+  let workflowDaemonID: string | undefined;
+
+  function daemonID(explicitDaemonID?: string): string {
+    return explicitDaemonID ?? workflowDaemonID ?? getActiveKataDaemon() ?? getDefaultKataDaemon() ?? "home";
+  }
+
+  function rows(explicitDaemonID?: string): KataTaskSummary[] {
+    return rowsByDaemon[daemonID(explicitDaemonID)] ?? [];
+  }
+
+  function projectCatalog(explicitDaemonID?: string): KataProjectSummary[] {
+    return projectsByDaemon[daemonID(explicitDaemonID)] ?? projects;
   }
 
   return {
-    bindWorkflowDaemon: vi.fn(),
+    bindWorkflowDaemon: vi.fn((daemonID?: string) => {
+      workflowDaemonID = daemonID;
+    }),
     instance: vi.fn(
       async (): Promise<KataInstanceResponse> => ({
         instance_uid: "instance-1",
@@ -250,7 +265,7 @@ function createDaemonWorkspaceAPI(rowsByDaemon: Record<string, KataTaskSummary[]
         schema_version: 1,
       }),
     ),
-    projects: vi.fn(async () => ({ projects, fetched_at: fetchedAt })),
+    projects: vi.fn(async (opts) => ({ projects: projectCatalog(opts?.daemonId), fetched_at: fetchedAt })),
     createProject: vi.fn(async (name: string) => ({
       id: 90,
       uid: `project-${name.toLowerCase()}`,
@@ -282,30 +297,34 @@ function createDaemonWorkspaceAPI(rowsByDaemon: Record<string, KataTaskSummary[]
       },
       etag: '"rev-1"',
     })),
-    issues: vi.fn(async (query: KataTaskIssuesQuery) =>
-      buildKataTaskView({
+    issues: vi.fn(async (query: KataTaskIssuesQuery, opts) => ({
+      ...buildKataTaskView({
         view: query.view,
-        issues: rows().filter((item) => (query.project_uid ? item.project_uid === query.project_uid : true)),
-        projects,
+        issues: rows(opts?.daemonId).filter((item) =>
+          query.project_uid ? item.project_uid === query.project_uid : true,
+        ),
+        projects: projectCatalog(opts?.daemonId),
         today: "2026-05-15",
         fetched_at: fetchedAt,
       }),
-    ),
+      daemon_id: daemonID(opts?.daemonId),
+    })),
     search: vi.fn(
-      async (filters: KataTaskSearchFilters): Promise<KataTaskSearchResponse> => ({
+      async (filters: KataTaskSearchFilters, opts): Promise<KataTaskSearchResponse> => ({
         filters,
-        issues: rows().filter((item) =>
+        issues: rows(opts?.daemonId).filter((item) =>
           filters.scope.kind === "project" ? item.project_uid === filters.scope.project_uid : true,
         ),
         fetched_at: fetchedAt,
+        daemon_id: daemonID(opts?.daemonId),
       }),
     ),
-    issue: vi.fn(async (uid: string) => detail(uid, rows())),
+    issue: vi.fn(async (uid: string, opts) => detail(uid, rows(opts?.daemonId))),
     reachableGraph: vi.fn(async (_projectID: number, ref: string, query = {}) =>
       reachableGraph(ref, rows(), query.depth ?? "full", query.hide_done === true),
     ),
     events: vi.fn(
-      async (): Promise<KataTaskEventsResponse> => ({
+      async (_query, _opts): Promise<KataTaskEventsResponse> => ({
         reset_required: false,
         events: [],
         next_after_id: 0,
@@ -336,6 +355,9 @@ function createWorkspaceAPI(
 ): {
   api: KataTaskAPI;
   instance: ReturnType<typeof vi.fn>;
+  projects: ReturnType<typeof vi.fn>;
+  issues: ReturnType<typeof vi.fn>;
+  issue: ReturnType<typeof vi.fn>;
   search: ReturnType<typeof vi.fn>;
   addComment: ReturnType<typeof vi.fn>;
   addLabel: ReturnType<typeof vi.fn>;
@@ -427,10 +449,21 @@ function createWorkspaceAPI(
       schema_version: 1,
     }),
   );
+  const projectCatalog = vi.fn(async () => ({ projects, fetched_at: fetchedAt }));
+  const issues = vi.fn(async (query: KataTaskIssuesQuery) =>
+    buildKataTaskView({
+      view: query.view,
+      issues: rows.filter((item) => (query.project_uid ? item.project_uid === query.project_uid : true)),
+      projects,
+      today: "2026-05-15",
+      fetched_at: fetchedAt,
+    }),
+  );
+  const issueDetail = vi.fn(async (uid: string) => detail(uid, rows, commentsByUID));
   return {
     api: {
       instance,
-      projects: vi.fn(async () => ({ projects, fetched_at: fetchedAt })),
+      projects: projectCatalog,
       createProject: vi.fn(async (name: string) => ({
         id: 90,
         uid: `project-${name.toLowerCase()}`,
@@ -454,17 +487,9 @@ function createWorkspaceAPI(
         };
       }),
       createIssue,
-      issues: vi.fn(async (query: KataTaskIssuesQuery) =>
-        buildKataTaskView({
-          view: query.view,
-          issues: rows.filter((item) => (query.project_uid ? item.project_uid === query.project_uid : true)),
-          projects,
-          today: "2026-05-15",
-          fetched_at: fetchedAt,
-        }),
-      ),
+      issues,
       search,
-      issue: vi.fn(async (uid: string) => detail(uid, rows, commentsByUID)),
+      issue: issueDetail,
       reachableGraph: vi.fn(async (_projectID: number, ref: string, query = {}) =>
         reachableGraph(ref, rows, query.depth ?? "full", query.hide_done === true),
       ),
@@ -496,6 +521,9 @@ function createWorkspaceAPI(
       deleteRecurrence: vi.fn(async () => undefined),
     },
     instance,
+    projects: projectCatalog,
+    issues,
+    issue: issueDetail,
     search,
     addComment,
     addLabel,

--- a/frontend/src/lib/features/kata/kataWorkspacePersistence.test.ts
+++ b/frontend/src/lib/features/kata/kataWorkspacePersistence.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import {
+  KATA_WORKSPACE_STATE_STORAGE_KEY,
+  clearKataWorkspaceSelection,
+  clearKataWorkspaceState,
+  loadKataWorkspaceState,
+  saveKataWorkspaceState,
+} from "./kataWorkspacePersistence.js";
+
+const home = {
+  view: "today" as const,
+  filters: {
+    scope: { kind: "project" as const, project_uid: "project-kata" },
+    status: "all" as const,
+    owner: "Susan",
+    label: "work",
+    query: "q3",
+  },
+  selectedIssueUID: "issue-child",
+};
+
+beforeEach(() => window.localStorage.clear());
+afterEach(() => vi.restoreAllMocks());
+
+describe("Kata workspace persistence", () => {
+  it("round-trips independent daemon snapshots", () => {
+    saveKataWorkspaceState("home", home);
+    saveKataWorkspaceState("work", {
+      view: "inbox",
+      filters: { scope: { kind: "all" }, status: "open", owner: "", label: "", query: "" },
+      selectedIssueUID: "work-issue",
+    });
+
+    expect(loadKataWorkspaceState("home")).toEqual(home);
+    expect(loadKataWorkspaceState("work")?.selectedIssueUID).toBe("work-issue");
+  });
+
+  it("round-trips daemon IDs that collide with object prototypes", () => {
+    saveKataWorkspaceState("__proto__", home);
+    saveKataWorkspaceState("constructor", { ...home, selectedIssueUID: "constructor-issue" });
+    saveKataWorkspaceState("toString", { ...home, selectedIssueUID: "string-issue" });
+
+    clearKataWorkspaceSelection("__proto__");
+    clearKataWorkspaceState("constructor");
+
+    expect(loadKataWorkspaceState("__proto__")).toEqual({ ...home, selectedIssueUID: null });
+    expect(loadKataWorkspaceState("constructor")).toBeNull();
+    expect(loadKataWorkspaceState("toString")?.selectedIssueUID).toBe("string-issue");
+  });
+
+  it.each([
+    "not json",
+    JSON.stringify({ version: 2, daemons: {} }),
+    JSON.stringify({ version: 1, daemons: { home: { view: "invalid" } } }),
+    JSON.stringify({ version: 1, daemons: { home: { ...home, filters: { ...home.filters, status: "later" } } } }),
+  ])("ignores malformed or incompatible data: %s", (raw) => {
+    window.localStorage.setItem(KATA_WORKSPACE_STATE_STORAGE_KEY, raw);
+
+    expect(loadKataWorkspaceState("home")).toBeNull();
+  });
+
+  it.each(["not json", JSON.stringify({ version: 2, daemons: { work: home } })])(
+    "replaces corrupt or incompatible top-level data only on a valid save: %s",
+    (raw) => {
+      window.localStorage.setItem(KATA_WORKSPACE_STATE_STORAGE_KEY, raw);
+      expect(loadKataWorkspaceState("home")).toBeNull();
+      expect(window.localStorage.getItem(KATA_WORKSPACE_STATE_STORAGE_KEY)).toBe(raw);
+
+      saveKataWorkspaceState("home", home);
+
+      expect(JSON.parse(window.localStorage.getItem(KATA_WORKSPACE_STATE_STORAGE_KEY)!)).toEqual({
+        version: 1,
+        daemons: { home },
+      });
+    },
+  );
+
+  it("clears only a stale selection", () => {
+    saveKataWorkspaceState("home", home);
+
+    clearKataWorkspaceSelection("home");
+
+    expect(loadKataWorkspaceState("home")).toEqual({ ...home, selectedIssueUID: null });
+  });
+
+  it("drops an invalid daemon entry while retaining a valid sibling", () => {
+    window.localStorage.setItem(
+      KATA_WORKSPACE_STATE_STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        daemons: { home: { ...home, view: "invalid" }, work: { ...home, selectedIssueUID: "work-issue" } },
+      }),
+    );
+
+    expect(loadKataWorkspaceState("home")).toBeNull();
+    expect(loadKataWorkspaceState("work")?.selectedIssueUID).toBe("work-issue");
+  });
+
+  it("deletes only one daemon snapshot", () => {
+    saveKataWorkspaceState("home", home);
+    saveKataWorkspaceState("work", { ...home, selectedIssueUID: "work-issue" });
+
+    clearKataWorkspaceState("home");
+
+    expect(loadKataWorkspaceState("home")).toBeNull();
+    expect(loadKataWorkspaceState("work")?.selectedIssueUID).toBe("work-issue");
+  });
+
+  it("removes invalid entries when clearing an absent daemon", () => {
+    window.localStorage.setItem(
+      KATA_WORKSPACE_STATE_STORAGE_KEY,
+      JSON.stringify({ version: 1, daemons: { home, stale: { view: "invalid" } } }),
+    );
+
+    clearKataWorkspaceState("stale");
+
+    expect(JSON.parse(window.localStorage.getItem(KATA_WORKSPACE_STATE_STORAGE_KEY)!)).toEqual({
+      version: 1,
+      daemons: { home },
+    });
+  });
+
+  it("does not return aliases of stored snapshots", () => {
+    saveKataWorkspaceState("home", home);
+    const loaded = loadKataWorkspaceState("home");
+    loaded!.filters.scope = { kind: "all" };
+    loaded!.filters.owner = "Changed";
+
+    expect(loadKataWorkspaceState("home")).toEqual(home);
+  });
+
+  it("does not overwrite sibling snapshots when reading storage fails", () => {
+    saveKataWorkspaceState("home", home);
+    const getItem = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+    const setItem = vi.spyOn(Storage.prototype, "setItem");
+
+    saveKataWorkspaceState("work", { ...home, selectedIssueUID: "work-issue" });
+
+    expect(setItem).not.toHaveBeenCalled();
+    getItem.mockRestore();
+    expect(loadKataWorkspaceState("home")).toEqual(home);
+    expect(loadKataWorkspaceState("work")).toBeNull();
+  });
+
+  it("keeps the session usable when storage throws", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+    expect(loadKataWorkspaceState("home")).toBeNull();
+
+    vi.restoreAllMocks();
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("quota");
+    });
+    expect(() => saveKataWorkspaceState("home", home)).not.toThrow();
+  });
+});

--- a/frontend/src/lib/features/kata/kataWorkspacePersistence.ts
+++ b/frontend/src/lib/features/kata/kataWorkspacePersistence.ts
@@ -1,0 +1,217 @@
+import type { KataTaskSearchFilters, KataTaskViewName } from "../../api/kata/taskTypes.js";
+
+export const KATA_WORKSPACE_STATE_STORAGE_KEY = "middleman:kata:workspace-state/v1";
+
+export interface KataPersistedWorkspaceState {
+  view: KataTaskViewName;
+  filters: KataTaskSearchFilters;
+  selectedIssueUID: string | null;
+}
+
+interface StoredKataWorkspaceState {
+  version: 1;
+  daemons: Record<string, KataPersistedWorkspaceState>;
+}
+
+type StorageReadResult = { kind: "state"; state: StoredKataWorkspaceState } | { kind: "reset" } | { kind: "failed" };
+
+const viewNames = new Set<KataTaskViewName>(["inbox", "today", "upcoming", "deadlines", "all", "logbook"]);
+const statusFilters = new Set<KataTaskSearchFilters["status"]>(["open", "closed", "all"]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function createDaemonMap(): Record<string, KataPersistedWorkspaceState> {
+  return Object.create(null) as Record<string, KataPersistedWorkspaceState>;
+}
+
+function hasDaemon(map: Record<string, KataPersistedWorkspaceState>, daemonID: string): boolean {
+  return Object.prototype.hasOwnProperty.call(map, daemonID);
+}
+
+function cloneState(state: KataPersistedWorkspaceState): KataPersistedWorkspaceState {
+  return {
+    view: state.view,
+    filters: {
+      scope:
+        state.filters.scope.kind === "all"
+          ? { kind: "all" }
+          : { kind: "project", project_uid: state.filters.scope.project_uid },
+      status: state.filters.status,
+      owner: state.filters.owner,
+      label: state.filters.label,
+      query: state.filters.query,
+    },
+    selectedIssueUID: state.selectedIssueUID,
+  };
+}
+
+function parseState(value: unknown): KataPersistedWorkspaceState | null {
+  if (!isRecord(value) || !viewNames.has(value.view as KataTaskViewName) || !isRecord(value.filters)) {
+    return null;
+  }
+
+  const { filters } = value;
+  if (
+    !statusFilters.has(filters.status as KataTaskSearchFilters["status"]) ||
+    typeof filters.owner !== "string" ||
+    typeof filters.label !== "string" ||
+    typeof filters.query !== "string" ||
+    (typeof value.selectedIssueUID !== "string" && value.selectedIssueUID !== null)
+  ) {
+    return null;
+  }
+
+  const scope = filters.scope;
+  if (!isRecord(scope) || (scope.kind !== "all" && scope.kind !== "project")) {
+    return null;
+  }
+  if (scope.kind === "project" && (typeof scope.project_uid !== "string" || scope.project_uid.length === 0)) {
+    return null;
+  }
+
+  return {
+    view: value.view as KataTaskViewName,
+    filters: {
+      scope: scope.kind === "all" ? { kind: "all" } : { kind: "project", project_uid: scope.project_uid as string },
+      status: filters.status as KataTaskSearchFilters["status"],
+      owner: filters.owner,
+      label: filters.label,
+      query: filters.query,
+    },
+    selectedIssueUID: value.selectedIssueUID,
+  };
+}
+
+function parseStorage(value: unknown): StoredKataWorkspaceState | null {
+  if (!isRecord(value) || value.version !== 1 || !isRecord(value.daemons)) {
+    return null;
+  }
+
+  const daemons = createDaemonMap();
+  for (const [daemonID, state] of Object.entries(value.daemons)) {
+    const parsed = parseState(state);
+    if (parsed) {
+      daemons[daemonID] = parsed;
+    }
+  }
+
+  return { version: 1, daemons };
+}
+
+function readStorage(): StorageReadResult {
+  if (typeof window === "undefined") {
+    return { kind: "failed" };
+  }
+
+  let raw: string | null;
+  try {
+    raw = window.localStorage.getItem(KATA_WORKSPACE_STATE_STORAGE_KEY);
+  } catch {
+    return { kind: "failed" };
+  }
+
+  if (raw === null) {
+    return { kind: "state", state: { version: 1, daemons: createDaemonMap() } };
+  }
+
+  try {
+    const state = parseStorage(JSON.parse(raw));
+    // A corrupt or unsupported top-level value is reset only by a later valid save.
+    return state ? { kind: "state", state } : { kind: "reset" };
+  } catch {
+    return { kind: "reset" };
+  }
+}
+
+function writeStorage(state: StoredKataWorkspaceState): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(KATA_WORKSPACE_STATE_STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // Local storage can be unavailable or full; persistence must not disrupt the workspace.
+  }
+}
+
+function copyDaemons(
+  daemons: Record<string, KataPersistedWorkspaceState>,
+): Record<string, KataPersistedWorkspaceState> {
+  const copy = createDaemonMap();
+  for (const [daemonID, state] of Object.entries(daemons)) {
+    copy[daemonID] = cloneState(state);
+  }
+  return copy;
+}
+
+export function loadKataWorkspaceState(daemonID: string): KataPersistedWorkspaceState | null {
+  if (daemonID.length === 0) {
+    return null;
+  }
+
+  const result = readStorage();
+  if (result.kind !== "state" || !hasDaemon(result.state.daemons, daemonID)) {
+    return null;
+  }
+
+  const state = result.state.daemons[daemonID];
+  return state ? cloneState(state) : null;
+}
+
+export function saveKataWorkspaceState(daemonID: string, state: KataPersistedWorkspaceState): void {
+  const parsed = parseState(state);
+  if (daemonID.length === 0 || !parsed) {
+    return;
+  }
+
+  const result = readStorage();
+  if (result.kind === "failed") {
+    return;
+  }
+
+  // Whole-map writes are intentionally last-writer-wins; a valid save resets corrupt or unsupported top-level data.
+  const daemons = result.kind === "state" ? copyDaemons(result.state.daemons) : createDaemonMap();
+  daemons[daemonID] = cloneState(parsed);
+  writeStorage({ version: 1, daemons });
+}
+
+export function clearKataWorkspaceSelection(daemonID: string): void {
+  if (daemonID.length === 0) {
+    return;
+  }
+
+  const result = readStorage();
+  if (result.kind !== "state" || !hasDaemon(result.state.daemons, daemonID)) {
+    return;
+  }
+
+  // Whole-map writes are intentionally last-writer-wins; orphan IDs persist until explicitly cleared.
+  const daemons = copyDaemons(result.state.daemons);
+  const state = daemons[daemonID];
+  if (!state) {
+    return;
+  }
+  daemons[daemonID] = { ...state, selectedIssueUID: null };
+  writeStorage({ version: 1, daemons });
+}
+
+export function clearKataWorkspaceState(daemonID: string): void {
+  if (daemonID.length === 0) {
+    return;
+  }
+
+  const result = readStorage();
+  if (result.kind !== "state") {
+    return;
+  }
+
+  const daemons = copyDaemons(result.state.daemons);
+  if (hasDaemon(daemons, daemonID)) {
+    delete daemons[daemonID];
+  }
+  // Whole-map writes are intentionally last-writer-wins; orphan IDs persist until explicitly cleared.
+  writeStorage({ version: 1, daemons });
+}

--- a/frontend/src/lib/stores/active-kata-daemon.svelte.ts
+++ b/frontend/src/lib/stores/active-kata-daemon.svelte.ts
@@ -29,8 +29,9 @@ export function getDefaultKataDaemon(): string | undefined {
   return defaultKataDaemon;
 }
 
-export function setActiveKataDaemon(id: string | undefined): void {
+export function setActiveKataDaemon(id: string | undefined, persist = true): void {
   activeKataDaemon = id;
+  if (!persist) return;
   try {
     if (id) {
       localStorage.setItem(STORAGE_KEY, id);

--- a/frontend/src/lib/stores/kata-workspace.svelte.test.ts
+++ b/frontend/src/lib/stores/kata-workspace.svelte.test.ts
@@ -23,7 +23,12 @@ import type {
 } from "../api/kata/taskTypes.js";
 import { buildKataTaskView } from "../api/kata/taskViewBuilder.js";
 import { getKataGraphDebugSnapshot, resetKataGraphDebug } from "./kata-graph-debug.js";
-import { createKataWorkspaceStore, deriveKataAreas, duplicateCandidatesFromError } from "./kata-workspace.svelte.js";
+import {
+  createKataWorkspaceStore,
+  deriveKataAreas,
+  duplicateCandidatesFromError,
+  KataEventCursorSyncError,
+} from "./kata-workspace.svelte.js";
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -966,6 +971,18 @@ describe("kata workspace store", () => {
     });
   });
 
+  test("loads selected recurrences through the store daemon binding", async () => {
+    const api = createFakeKataTaskAPI();
+    const store = createKataWorkspaceStore({ api });
+    store.bindDaemonForBootstrap("work", false);
+
+    await store.selectIssue("issue-pay-rent");
+
+    await vi.waitFor(() => {
+      expect(api.mocks.recurrences).toHaveBeenCalledWith(projects[1]!.id, { daemonId: "work" });
+    });
+  });
+
   test("slow recurrence loading does not delay issue detail selection", async () => {
     const api = createFakeKataTaskAPI();
     const slowRecurrences = deferred<Awaited<ReturnType<KataTaskAPI["recurrences"]>>>();
@@ -1033,6 +1050,30 @@ describe("kata workspace store", () => {
     await vi.waitFor(() => {
       expect(store.selectedEvents.map((event) => event.issue_uid)).toEqual(["issue-pay-rent"]);
     });
+  });
+
+  test("can await the selected issue's background events and recurrence reads before adoption", async () => {
+    const api = createFakeKataTaskAPI();
+    const slowEvents = deferred<KataTaskEventsResponse>();
+    const slowRecurrences = deferred<Awaited<ReturnType<KataTaskAPI["recurrences"]>>>();
+    api.mocks.events.mockReturnValue(slowEvents.promise);
+    api.mocks.recurrences.mockReturnValue(slowRecurrences.promise);
+    const store = createKataWorkspaceStore({ api });
+
+    await expect(store.selectIssue("issue-pay-rent")).resolves.toBe(true);
+    let settled = false;
+    const auxiliaryReads = store.awaitSelectedAuxiliaryReads().then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    slowEvents.resolve({ reset_required: false, events: [events[0]!], next_after_id: 1 });
+    slowRecurrences.resolve({ recurrences: [recurrence({ id: 9 })], fetched_at: "t1" });
+    await auxiliaryReads;
+
+    expect(store.selectedEvents.map((event) => event.issue_uid)).toEqual(["issue-pay-rent"]);
+    expect(store.selectedRecurrences.map((item) => item.id)).toEqual([9]);
   });
 
   test("a failed events read does not fail an already-rendered selection", async () => {
@@ -1129,32 +1170,6 @@ describe("kata workspace store", () => {
     expect(store.pendingSelectionUID).toBeNull();
   });
 
-  test("invalidating pending loads aborts the in-flight view load", async () => {
-    const api = createFakeKataTaskAPI();
-    const response = deferred<KataTaskViewResponse>();
-    api.mocks.issues.mockImplementationOnce(() => response.promise);
-    const store = createKataWorkspaceStore({ api });
-
-    const pending = store.openView("all");
-    await vi.waitFor(() => expect(api.mocks.issues).toHaveBeenCalledOnce());
-    const signal = api.mocks.issues.mock.calls[0]?.[1]?.signal as AbortSignal | undefined;
-    store.invalidatePendingLoads();
-    response.resolve({
-      ...buildKataTaskView({
-        view: "all",
-        issues,
-        projects,
-        today: "2026-05-15",
-        fetched_at: fetchedAt,
-      }),
-      daemon_id: "home",
-    });
-
-    await pending;
-    expect(signal).toBeInstanceOf(AbortSignal);
-    expect(signal?.aborted).toBe(true);
-  });
-
   test("explicit empty relationship fields clear stale cached graph links", () => {
     const store = createKataWorkspaceStore({ api: createFakeKataTaskAPI() });
     const stale = {
@@ -1206,6 +1221,26 @@ describe("kata workspace store", () => {
     expect(store.currentView.name).toBe("inbox");
     expect(store.currentView.groups[0]?.title).toBe("Inbox");
     expect(store.selectedIssue?.issue.title).toBe("Renew passport");
+  });
+
+  test("restoring filters rolls back when its filtered search fails", async () => {
+    const api = createFakeKataTaskAPI();
+    const store = createKataWorkspaceStore({ api });
+    await store.bootstrap("all", "issue-pay-rent");
+    const accepted = store.captureSnapshot();
+    api.mocks.search.mockRejectedValueOnce(new Error("search unavailable"));
+
+    await expect(
+      store.restoreViewAndFilters("all", {
+        scope: { kind: "all" },
+        status: "open",
+        owner: "",
+        label: "",
+        query: "rent",
+      }),
+    ).rejects.toThrow("search unavailable");
+
+    expect(store.captureSnapshot()).toEqual(accepted);
   });
 
   test("project scope shows the project backlog instead of filtering the current system view", async () => {
@@ -1365,7 +1400,10 @@ describe("kata workspace store", () => {
       '"rev-1"',
     );
     expect(store.selectedIssue?.issue.uid).toBe("issue-pay-rent");
-    expect(api.mocks.issue).toHaveBeenCalledWith("issue-pay-rent", { signal: expect.any(AbortSignal) });
+    expect(api.mocks.issue).toHaveBeenCalledWith(
+      "issue-pay-rent",
+      expect.objectContaining({ daemonId: "home", signal: expect.any(AbortSignal) }),
+    );
   });
 
   test("serializes metadata patches so rapid edits use the refreshed ETag", async () => {
@@ -1579,7 +1617,7 @@ describe("kata workspace store", () => {
     ]);
     expect(store.selectedIssue?.issue.uid).toBe("issue-call-dentist");
     expect(store.daemonId).toBe("work");
-    expect(api.mocks.bindWorkflowDaemon).toHaveBeenLastCalledWith("work");
+    expect(api.mocks.bindWorkflowDaemon).not.toHaveBeenCalled();
   });
 
   test("ignores stale bootstrap view data after newer navigation", async () => {
@@ -1674,7 +1712,10 @@ describe("kata workspace store", () => {
     const mutation = store.addComment("issue-pay-rent", "fixture-user", "Payment is scheduled.");
     await Promise.resolve();
     await Promise.resolve();
-    expect(api.mocks.issue).toHaveBeenCalledWith("issue-pay-rent", { signal: expect.any(AbortSignal) });
+    expect(api.mocks.issue).toHaveBeenCalledWith(
+      "issue-pay-rent",
+      expect.objectContaining({ daemonId: "home", signal: expect.any(AbortSignal) }),
+    );
 
     await store.selectIssue("issue-call-dentist");
     expect(store.selectedIssue?.issue.uid).toBe("issue-call-dentist");
@@ -1795,37 +1836,6 @@ describe("kata workspace store", () => {
     expect(store.eventCursor).toBe(99);
   });
 
-  test("an unrelated remote event preserves the cached selected detail", async () => {
-    const api = createFakeKataTaskAPI();
-    const store = createKataWorkspaceStore({ api });
-    await store.bootstrap();
-    expect(store.selectedIssue?.issue.uid).toBe("issue-pay-rent");
-    api.mocks.issue.mockClear();
-
-    await store.applyRemoteEvent({ ...events[1]!, event_id: 99 });
-
-    expect(store.selectedIssue?.issue.uid).toBe("issue-pay-rent");
-    expect(api.mocks.issue).not.toHaveBeenCalled();
-  });
-
-  test("view loads do not wait for selected issue history", async () => {
-    const api = createFakeKataTaskAPI();
-    const slowEvents = deferred<KataTaskEventsResponse>();
-    api.mocks.events.mockImplementationOnce(() => slowEvents.promise);
-    const store = createKataWorkspaceStore({ api });
-
-    const bootstrap = store.bootstrap();
-    try {
-      await vi.waitFor(() => {
-        expect(store.selectedIssue?.issue.uid).toBe("issue-pay-rent");
-      });
-      await bootstrap;
-    } finally {
-      slowEvents.resolve({ reset_required: false, events: [], next_after_id: 0 });
-      await bootstrap;
-    }
-  });
-
   test("syncs event cursor through paged event reads", async () => {
     const api = createFakeKataTaskAPI();
     api.mocks.events.mockImplementation(async (query: KataTaskEventsQuery = {}) => {
@@ -1851,30 +1861,6 @@ describe("kata workspace store", () => {
     expect(cursorReads.map(([query]) => query?.after_id)).toEqual([0, 1, 2]);
   });
 
-  test("syncing a multi-page event backlog revalidates the view once", async () => {
-    const api = createFakeKataTaskAPI();
-    api.mocks.events
-      .mockResolvedValueOnce({
-        reset_required: false,
-        events: [{ ...events[0]!, event_id: 100 }],
-        next_after_id: 100,
-      })
-      .mockResolvedValueOnce({
-        reset_required: false,
-        events: [{ ...events[1]!, event_id: 101 }],
-        next_after_id: 101,
-      })
-      .mockResolvedValueOnce({ reset_required: false, events: [], next_after_id: 101 });
-    const store = createKataWorkspaceStore({ api });
-    await store.bootstrap("all", null, { selectFirst: false });
-    api.mocks.issues.mockClear();
-
-    await store.syncEventCursor();
-
-    expect(store.eventCursor).toBe(101);
-    expect(api.mocks.issues).toHaveBeenCalledOnce();
-  });
-
   test("syncing the event cursor applies observed events before advancing", async () => {
     const api = createFakeKataTaskAPI();
     const store = createKataWorkspaceStore({ api });
@@ -1891,7 +1877,7 @@ describe("kata workspace store", () => {
     expect(store.selectedIssue?.issue.uid).toBe("issue-renew-passport");
   });
 
-  test("syncing the event cursor does not advance when batched revalidation is unapplied", async () => {
+  test("syncing the event cursor stops after an unapplied event in a multi-event page", async () => {
     const api = createFakeKataTaskAPI();
     const store = createKataWorkspaceStore({ api });
     await store.bootstrap("all");
@@ -1962,6 +1948,124 @@ describe("kata workspace store", () => {
     expect(store.eventCursor).toBe(0);
   });
 
+  test("serializes retry catch-up with a concurrent live event without duplicate visible refresh", async () => {
+    const api = createFakeKataTaskAPI();
+    const store = createKataWorkspaceStore({ api });
+    await store.bootstrap();
+    const retryPage = deferred<KataTaskEventsResponse>();
+    let afterEightyeightReads = 0;
+    api.mocks.events.mockImplementation(async (query: KataTaskEventsQuery = {}) => {
+      if (query.issue_uid) return { reset_required: false, events: [], next_after_id: 0 };
+      if (query.after_id === 0) {
+        return { reset_required: false, events: [{ ...events[0]!, event_id: 88 }], next_after_id: 88 };
+      }
+      if (query.after_id === 88) {
+        afterEightyeightReads += 1;
+        if (afterEightyeightReads === 1) throw new Error("cursor page failed");
+        return retryPage.promise;
+      }
+      return { reset_required: false, events: [], next_after_id: query.after_id ?? 0 };
+    });
+
+    await expect(store.syncEventCursor()).rejects.toBeInstanceOf(KataEventCursorSyncError);
+    expect(store.eventCursor).toBe(88);
+    api.mocks.issues.mockClear();
+
+    const retry = store.syncEventCursor();
+    await vi.waitFor(() => expect(afterEightyeightReads).toBe(2));
+    const live = store.applyRemoteEvent({ ...events[0]!, event_id: 89 });
+    retryPage.resolve({
+      reset_required: false,
+      events: [{ ...events[0]!, event_id: 89 }],
+      next_after_id: 89,
+    });
+
+    await retry;
+    await live;
+
+    expect(store.eventCursor).toBe(89);
+    expect(api.mocks.issues).toHaveBeenCalledTimes(1);
+  });
+
+  test("event cursor catch-up exposes accepted membership when a later page fails", async () => {
+    const api = createFakeKataTaskAPI();
+    const store = createKataWorkspaceStore({ api });
+    await store.bootstrap("all", "issue-pay-rent");
+    api.mocks.events.mockImplementation(async (query: KataTaskEventsQuery = {}) => {
+      if (query.issue_uid) {
+        return { reset_required: false, events: [], next_after_id: 0 };
+      }
+      if (query.after_id === 0) {
+        return {
+          reset_required: false,
+          events: [{ ...events[0]!, event_id: 88 }],
+          next_after_id: 88,
+        };
+      }
+      throw new Error("later cursor page failed");
+    });
+    api.mocks.issues.mockResolvedValueOnce(
+      buildKataTaskView({
+        view: "all",
+        issues: issues.filter((issue) => issue.uid !== "issue-pay-rent"),
+        projects,
+        fetched_at: fetchedAt,
+      }),
+    );
+
+    let caught: unknown;
+    try {
+      await store.syncEventCursor();
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(KataEventCursorSyncError);
+    expect(caught).toMatchObject({
+      cursorSyncCause: expect.objectContaining({ message: "later cursor page failed" }),
+    });
+    expect(store.eventCursor).toBe(88);
+    expect(store.currentView.groups.flatMap((group) => group.issues).map((issue) => issue.uid)).not.toContain(
+      "issue-pay-rent",
+    );
+  });
+
+  test("event cursor catch-up retains stale detail after a selected task leaves membership", async () => {
+    const api = createFakeKataTaskAPI();
+    const store = createKataWorkspaceStore({ api });
+    await store.bootstrap("all", "issue-pay-rent");
+    const selectedBeforeRefresh = store.selectedIssue;
+    api.mocks.events
+      .mockResolvedValueOnce({ reset_required: false, events: [{ ...events[0]!, event_id: 88 }], next_after_id: 88 })
+      .mockResolvedValueOnce({ reset_required: false, events: [], next_after_id: 88 });
+    api.mocks.issues.mockResolvedValueOnce(
+      buildKataTaskView({
+        view: "all",
+        issues: issues.filter((issue) => issue.uid !== "issue-pay-rent"),
+        projects,
+        fetched_at: fetchedAt,
+      }),
+    );
+    api.mocks.issue.mockRejectedValueOnce(new Error("detail unavailable"));
+
+    await store.syncEventCursor();
+
+    expect(store.eventCursor).toBe(88);
+    expect(store.currentView.groups.flatMap((group) => group.issues).map((issue) => issue.uid)).not.toContain(
+      "issue-pay-rent",
+    );
+    expect(store.selectedIssue).toEqual(selectedBeforeRefresh);
+  });
+
+  test("interactive refreshes report selected-detail failures", async () => {
+    const api = createFakeKataTaskAPI();
+    const store = createKataWorkspaceStore({ api });
+    await store.bootstrap("all", "issue-pay-rent");
+    api.mocks.issue.mockRejectedValueOnce(new Error("detail unavailable"));
+
+    await expect(store.renameProject(1, "Updated finances")).rejects.toThrow("detail unavailable");
+  });
+
   test("remote thin events invalidate the active view and selected detail", async () => {
     const api = createFakeKataTaskAPI();
     const store = createKataWorkspaceStore({ api });
@@ -2001,7 +2105,10 @@ describe("kata workspace store", () => {
       { view: "today" },
       expect.objectContaining({ daemonId: "home", signal: expect.any(AbortSignal) }),
     );
-    expect(api.mocks.issue).toHaveBeenCalledWith("issue-pay-rent", { signal: expect.any(AbortSignal) });
+    expect(api.mocks.issue).toHaveBeenCalledWith(
+      "issue-pay-rent",
+      expect.objectContaining({ daemonId: "home", signal: expect.any(AbortSignal) }),
+    );
     expect(store.selectedIssue?.comments.map((comment) => comment.body)).toContain("Remote note.");
   });
 

--- a/frontend/src/lib/stores/kata-workspace.svelte.ts
+++ b/frontend/src/lib/stores/kata-workspace.svelte.ts
@@ -58,8 +58,18 @@ interface KataLoadOptions {
   selectFirst?: boolean | undefined;
 }
 
-interface KataBootstrapOptions {
-  selectFirst?: boolean | undefined;
+interface KataBootstrapOptions extends KataLoadOptions {}
+
+interface KataRefreshOptions extends KataLoadOptions {
+  refreshSelectedDetail?: boolean | undefined;
+  eventDriven?: boolean | undefined;
+}
+
+export interface KataEventDeliveryOptions {
+  // The workspace owns daemon identity, while the store owns cursor mutation.
+  // This guard lets an abandoned daemon generation finish its request without
+  // applying its response to the active daemon's shared store.
+  shouldApply?: (() => boolean) | undefined;
 }
 
 function emptyView(name: KataTaskViewName = "today"): KataCurrentView {
@@ -282,6 +292,31 @@ export function duplicateCandidatesFromError(error: unknown): KataDuplicateCandi
   });
 }
 
+export interface KataWorkspaceStoreSnapshot {
+  connection: KataConnectionState;
+  projects: KataProjectSummary[];
+  areas: KataAreaSummary[];
+  currentView: KataCurrentView;
+  selectedIssue: KataTaskDetail | null;
+  selectedEvents: KataTaskEvent[];
+  selectedRecurrences: KataRecurrence[];
+  searchFilters: KataTaskSearchFilters;
+  duplicateCandidates: KataDuplicateCandidateDisplay[];
+  cachedTasks: KataTaskSummary[];
+  eventCursor: number;
+  unscopedViewName: KataTaskViewName;
+}
+
+export class KataEventCursorSyncError extends Error {
+  readonly cursorSyncCause: unknown;
+
+  constructor(cursorSyncCause: unknown) {
+    super(cursorSyncCause instanceof Error ? cursorSyncCause.message : "Kata event cursor sync failed.");
+    this.name = "KataEventCursorSyncError";
+    this.cursorSyncCause = cursorSyncCause;
+  }
+}
+
 export class KataWorkspaceStore {
   readonly api: KataTaskAPI;
   connection = $state<KataConnectionState>({ status: "offline" });
@@ -305,9 +340,18 @@ export class KataWorkspaceStore {
   private viewAbort: AbortController | null = null;
   private detailRequestID = 0;
   private detailAbort: AbortController | null = null;
+  private selectedEventsRead: Promise<void> = Promise.resolve();
+  private selectedRecurrencesRead: Promise<void> = Promise.resolve();
   private unscopedViewName: KataTaskViewName = "today";
   private issueETags = new Map<string, string>();
   private metadataQueues = new Map<string, Promise<void>>();
+  // Cursor delivery is one ordered lane shared by paginated catch-up and SSE.
+  // A task starts only after its predecessor settles, so an event observed by
+  // both transports is deduplicated against the cursor before it can refresh
+  // the visible workspace a second time.
+  private eventDeliveryGeneration = 0;
+  private activeEventDeliveryGenerations = new Set<number>();
+  private pendingEventDeliveries = new Map<number, Array<() => void>>();
 
   constructor(options: CreateKataWorkspaceStoreOptions = {}) {
     this.api = options.api ?? createKataTaskAPI();
@@ -321,25 +365,81 @@ export class KataWorkspaceStore {
   }
 
   clearDaemonBinding(): void {
-    this.daemonId = undefined;
     this.api.bindWorkflowDaemon?.();
   }
 
-  bindDaemonForBootstrap(daemonId: string): void {
+  bindDaemonForBootstrap(daemonId: string, bindSharedAPI = true): void {
     this.daemonId = daemonId;
-    this.api.bindWorkflowDaemon?.(daemonId);
+    if (bindSharedAPI) this.api.bindWorkflowDaemon?.(daemonId);
   }
 
   clearDaemonState(viewName: KataTaskViewName = this.currentView.name): void {
+    this.eventDeliveryGeneration += 1;
     this.clearSelection();
+    this.daemonId = undefined;
     this.clearDaemonBinding();
     this.projects = [];
     this.areas = [];
     this.currentView = emptyView(viewName);
-    this.duplicateCandidates = [];
+    this.resetSearchFilters();
     this.clearTaskCache();
     this.issueETags.clear();
     this.resetEventCursor();
+  }
+
+  async loadProjectCatalog(shouldApply: () => boolean = () => true): Promise<void> {
+    const projects = await this.loadProjects();
+    if (!shouldApply()) return;
+    this.projects = projects.projects;
+    this.areas = deriveKataAreas(projects.projects);
+  }
+
+  resetToInertWorkspace(): void {
+    this.invalidatePendingLoads();
+    this.clearTaskCache();
+    this.issueETags.clear();
+    this.currentView = emptyView("all");
+    this.searchFilters = defaultKataTaskSearchFilters();
+    this.duplicateCandidates = [];
+    this.selectedIssue = null;
+    this.selectedEvents = [];
+    this.selectedRecurrences = [];
+    this.pendingSelectionUID = null;
+    this.unscopedViewName = "all";
+    this.connection = { status: "offline" };
+  }
+
+  captureSnapshot(): KataWorkspaceStoreSnapshot {
+    return {
+      connection: this.connection,
+      projects: this.projects,
+      areas: this.areas,
+      currentView: this.currentView,
+      selectedIssue: this.selectedIssue,
+      selectedEvents: this.selectedEvents,
+      selectedRecurrences: this.selectedRecurrences,
+      searchFilters: this.searchFilters,
+      duplicateCandidates: this.duplicateCandidates,
+      cachedTasks: this.cachedTasks,
+      eventCursor: this.eventCursor,
+      unscopedViewName: this.unscopedViewName,
+    };
+  }
+
+  restoreSnapshot(snapshot: KataWorkspaceStoreSnapshot): void {
+    this.resetToInertWorkspace();
+    this.connection = snapshot.connection;
+    this.projects = snapshot.projects;
+    this.areas = snapshot.areas;
+    this.currentView = snapshot.currentView;
+    this.selectedIssue = snapshot.selectedIssue;
+    this.selectedEvents = snapshot.selectedEvents;
+    this.selectedRecurrences = snapshot.selectedRecurrences;
+    this.searchFilters = snapshot.searchFilters;
+    this.duplicateCandidates = snapshot.duplicateCandidates;
+    this.cacheTasks(snapshot.cachedTasks);
+    this.eventCursor = snapshot.eventCursor;
+    this.unscopedViewName = snapshot.unscopedViewName;
   }
 
   async bootstrap(
@@ -347,14 +447,17 @@ export class KataWorkspaceStore {
     preferredIssueUID?: string | null,
     options: KataBootstrapOptions = {},
   ): Promise<void> {
+    if (!shouldApplyLoad(options)) return;
     const { requestID, signal } = this.beginViewRequest();
     this.connection = { status: "connecting" };
     try {
-      await this.api.instance({ signal });
+      await this.loadInstance(signal);
+      if (!shouldApplyLoad(options)) return;
       const [projects, view] = await Promise.all([
-        this.api.projects({ signal }),
+        this.loadProjects(signal),
         this.loadIssues({ view: viewName }, signal),
       ]);
+      if (!shouldApplyLoad(options)) return;
       if (requestID !== this.viewRequestID) {
         this.connection = { status: "online" };
         return;
@@ -377,14 +480,40 @@ export class KataWorkspaceStore {
         preferredIssueUID && rawIssues.some((issue) => issue.uid === preferredIssueUID)
           ? preferredIssueUID
           : firstIssue?.uid;
-      await this.loadSelectedIssue(nextUID ?? preferredIssueUID ?? null, requestID, ++this.detailRequestID);
-      this.connection = { status: "online" };
+      await this.loadSelectedIssue(nextUID ?? preferredIssueUID ?? null, requestID, ++this.detailRequestID, options);
+      if (shouldApplyLoad(options)) this.connection = { status: "online" };
     } catch (error) {
-      if (requestID !== this.viewRequestID) return;
+      if (requestID !== this.viewRequestID || !shouldApplyLoad(options)) return;
       this.connection = {
         status: "error",
         message: connectionErrorMessage(error),
       };
+      throw error;
+    }
+  }
+
+  async restoreViewAndFilters(
+    viewName: KataTaskViewName,
+    filters: KataTaskSearchFilters,
+    options: KataLoadOptions = {},
+  ): Promise<void> {
+    const snapshot = this.captureSnapshot();
+    const expectedRequestID = () => this.viewRequestID + 1;
+    let rollbackRequestID = expectedRequestID();
+    try {
+      this.searchFilters = filters;
+      this.duplicateCandidates = [];
+      await this.openView(viewName, { ...options, selectFirst: false });
+      if (hasActiveSearchFilters(filters)) {
+        rollbackRequestID = expectedRequestID();
+        await this.updateSearchFilters({}, { ...options, selectFirst: false });
+      }
+    } catch (error) {
+      // A restored workspace is accepted only after every required load
+      // succeeds. Do not roll back over a newer navigation that superseded it.
+      if (this.viewRequestID === rollbackRequestID) {
+        this.restoreSnapshot(snapshot);
+      }
       throw error;
     }
   }
@@ -411,7 +540,7 @@ export class KataWorkspaceStore {
       this.unscopedViewName = view.view;
     }
     const firstIssue = options.selectFirst === false ? undefined : selectableViewIssues(view.groups)[0];
-    await this.loadSelectedIssue(firstIssue?.uid ?? null, requestID, ++this.detailRequestID);
+    await this.loadSelectedIssue(firstIssue?.uid ?? null, requestID, ++this.detailRequestID, options);
   }
 
   async updateSearchFilters(next: Partial<KataTaskSearchFilters>, options: KataLoadOptions = {}): Promise<void> {
@@ -450,7 +579,7 @@ export class KataWorkspaceStore {
         fetched_at: results.fetched_at,
       };
       const firstIssue = options.selectFirst === false ? undefined : selectableViewIssues(groups)[0];
-      await this.loadSelectedIssue(firstIssue?.uid ?? null, requestID, ++this.detailRequestID);
+      await this.loadSelectedIssue(firstIssue?.uid ?? null, requestID, ++this.detailRequestID, options);
     } catch (error) {
       if (requestID !== this.viewRequestID || !shouldApplyLoad(options)) return;
       this.duplicateCandidates = duplicateCandidatesFromError(error);
@@ -491,7 +620,7 @@ export class KataWorkspaceStore {
         this.unscopedViewName = view.view;
       }
       const firstIssue = options.selectFirst === false ? undefined : selectableViewIssues(view.groups)[0];
-      await this.loadSelectedIssue(firstIssue?.uid ?? null, requestID, ++this.detailRequestID);
+      await this.loadSelectedIssue(firstIssue?.uid ?? null, requestID, ++this.detailRequestID, options);
       return;
     }
 
@@ -513,7 +642,7 @@ export class KataWorkspaceStore {
         fetched_at: results.fetched_at,
       };
       const firstIssue = options.selectFirst === false ? undefined : selectableViewIssues(groups)[0];
-      await this.loadSelectedIssue(firstIssue?.uid ?? null, requestID, ++this.detailRequestID);
+      await this.loadSelectedIssue(firstIssue?.uid ?? null, requestID, ++this.detailRequestID, options);
     } catch (error) {
       if (requestID !== this.viewRequestID || !shouldApplyLoad(options)) return;
       this.searchFilters = nextFilters;
@@ -534,7 +663,7 @@ export class KataWorkspaceStore {
     await this.withMutation(async () => {
       const inbox =
         this.projects.find(isTaskInboxProject) ??
-        (await this.api.projects()).projects.find((project) => isTaskInboxProject(project));
+        (await this.loadProjects()).projects.find((project) => isTaskInboxProject(project));
       if (!inbox) throw new Error("task inbox project is not available");
 
       const result = await this.api.createIssue(inbox.id, actor, draft, idempotencyKey);
@@ -566,12 +695,13 @@ export class KataWorkspaceStore {
     });
   }
 
-  async selectIssue(uid: string): Promise<boolean> {
+  async selectIssue(uid: string, options: KataLoadOptions = {}): Promise<boolean> {
+    if (!shouldApplyLoad(options)) return false;
     this.pendingSelectionUID = uid;
     const requestID = ++this.detailRequestID;
     this.observeGraphStore("selection-start", { uid, detailRequestID: requestID });
     try {
-      return await this.loadSelectedIssue(uid, undefined, requestID);
+      return await this.loadSelectedIssue(uid, undefined, requestID, options);
     } catch (error) {
       if (this.detailRequestID === requestID && this.pendingSelectionUID === uid) {
         this.pendingSelectionUID = null;
@@ -587,6 +717,10 @@ export class KataWorkspaceStore {
     this.selectedEvents = [];
     this.selectedRecurrences = [];
     this.pendingSelectionUID = null;
+  }
+
+  async awaitSelectedAuxiliaryReads(): Promise<void> {
+    await Promise.all([this.selectedEventsRead, this.selectedRecurrencesRead]);
   }
 
   async addComment(uid: string, actor: string, body: string): Promise<void> {
@@ -736,65 +870,147 @@ export class KataWorkspaceStore {
     this.eventCursor = 0;
   }
 
-  async syncEventCursor(): Promise<void> {
+  async syncEventCursor(options: KataEventDeliveryOptions = {}): Promise<boolean> {
+    return this.enqueueEventDelivery(() => this.syncEventCursorNow(options));
+  }
+
+  async applyRemoteEvent(event: KataTaskEvent, options: KataEventDeliveryOptions = {}): Promise<boolean> {
+    return this.enqueueEventDelivery(() => this.applyRemoteEventNow(event, options));
+  }
+
+  async applyEventStreamMessage(
+    message: KataTaskEventStreamMessage,
+    options: KataEventDeliveryOptions = {},
+  ): Promise<boolean> {
+    return this.enqueueEventDelivery(() => this.applyEventStreamMessageNow(message, options));
+  }
+
+  private enqueueEventDelivery<T>(operation: () => Promise<T>): Promise<T> {
+    const generation = this.eventDeliveryGeneration;
+    return new Promise<T>((resolve, reject) => {
+      const run = () => {
+        void operation()
+          .then(resolve, reject)
+          .finally(() => {
+            const queue = this.pendingEventDeliveries.get(generation);
+            const next = queue?.shift();
+            if (next) {
+              next();
+            } else {
+              this.pendingEventDeliveries.delete(generation);
+              this.activeEventDeliveryGenerations.delete(generation);
+            }
+          });
+      };
+      if (this.activeEventDeliveryGenerations.has(generation)) {
+        const queue = this.pendingEventDeliveries.get(generation) ?? [];
+        queue.push(run);
+        this.pendingEventDeliveries.set(generation, queue);
+      } else {
+        this.activeEventDeliveryGenerations.add(generation);
+        run();
+      }
+    });
+  }
+
+  private shouldApplyEventDelivery(options: KataEventDeliveryOptions): boolean {
+    return options.shouldApply?.() ?? true;
+  }
+
+  private async syncEventCursorNow(options: KataEventDeliveryOptions): Promise<boolean> {
+    if (!this.shouldApplyEventDelivery(options)) return false;
+
     let afterID = this.eventCursor;
     const pendingEvents: KataTaskEvent[] = [];
+    let pageError: unknown;
+
     for (;;) {
-      const response = await this.api.events({ after_id: afterID, limit: 100 });
+      let response: KataTaskEventsResponse;
+      try {
+        response = await this.loadEvents({ after_id: afterID, limit: 100 });
+      } catch (error) {
+        pageError = error;
+        break;
+      }
+      if (!this.shouldApplyEventDelivery(options)) return false;
+
       const nextAfterID = Math.max(afterID, response.next_after_id, ...response.events.map((event) => event.event_id));
       if (response.reset_required) {
-        await this.applyEventStreamMessage({
-          kind: "reset",
-          event_id: nextAfterID,
-          reset_after_id: response.reset_after_id ?? nextAfterID,
-          lastEventID: nextAfterID,
-        });
-        return;
+        return this.applyEventStreamMessageNow(
+          {
+            kind: "reset",
+            event_id: nextAfterID,
+            reset_after_id: response.reset_after_id ?? nextAfterID,
+            lastEventID: nextAfterID,
+          },
+          options,
+        );
       }
+
       pendingEvents.push(...response.events.filter((event) => event.event_id > this.eventCursor));
       const reachedEnd = response.events.length === 0 || nextAfterID === afterID;
       afterID = nextAfterID;
       if (reachedEnd) break;
     }
-    if (pendingEvents.length === 0) {
+
+    let membershipRefreshed = false;
+    if (pendingEvents.length > 0) {
+      membershipRefreshed = await this.refreshForRemoteEvents(pendingEvents, options);
+      if (!this.shouldApplyEventDelivery(options)) return false;
+      if (membershipRefreshed) this.eventCursor = Math.max(this.eventCursor, afterID);
+    } else if (pageError === undefined) {
       this.eventCursor = Math.max(this.eventCursor, afterID);
-      return;
     }
-    const refreshed = await this.refreshForRemoteEvents(pendingEvents);
-    if (!refreshed) return;
-    this.eventCursor = Math.max(this.eventCursor, afterID);
+
+    if (pageError !== undefined) {
+      if (membershipRefreshed) throw new KataEventCursorSyncError(pageError);
+      throw pageError;
+    }
+    return membershipRefreshed;
   }
 
-  async applyRemoteEvent(event: KataTaskEvent): Promise<boolean> {
+  private async applyRemoteEventNow(event: KataTaskEvent, options: KataEventDeliveryOptions): Promise<boolean> {
+    if (!this.shouldApplyEventDelivery(options)) return false;
     if (event.event_id <= this.eventCursor) return true;
-    const refreshed = await this.refreshForRemoteEvents([event]);
-    if (!refreshed) return false;
-    this.eventCursor = event.event_id;
+    const refreshed = await this.refreshForRemoteEvents([event], options);
+    if (!this.shouldApplyEventDelivery(options) || !refreshed) return false;
+    this.eventCursor = Math.max(this.eventCursor, event.event_id);
     return true;
   }
 
-  async applyEventStreamMessage(message: KataTaskEventStreamMessage): Promise<void> {
+  private async applyEventStreamMessageNow(
+    message: KataTaskEventStreamMessage,
+    options: KataEventDeliveryOptions,
+  ): Promise<boolean> {
+    if (!this.shouldApplyEventDelivery(options)) return false;
     if (message.kind === "reset") {
+      if (message.reset_after_id <= this.eventCursor) return true;
       const refreshed = await this.refreshCurrentView(
         this.pendingSelectionUID ?? this.selectedIssue?.issue.uid ?? null,
+        { eventDriven: true, shouldApply: options.shouldApply },
       );
-      if (refreshed) {
+      if (refreshed && this.shouldApplyEventDelivery(options)) {
         this.eventCursor = Math.max(this.eventCursor, message.reset_after_id);
       }
-      return;
+      return refreshed && this.shouldApplyEventDelivery(options);
     }
-    await this.applyRemoteEvent(message.event);
+    return this.applyRemoteEventNow(message.event, options);
   }
 
-  private async reloadProjects(): Promise<void> {
-    const projects = await this.api.projects();
+  private async reloadProjects(shouldApply?: () => boolean): Promise<void> {
+    const projects = await this.loadProjects();
+    if (shouldApply?.() === false) return;
     this.projects = projects.projects;
     this.areas = deriveKataAreas(projects.projects);
   }
 
-  private async refreshForRemoteEvents(events: readonly KataTaskEvent[]): Promise<boolean> {
+  private async refreshForRemoteEvents(
+    events: readonly KataTaskEvent[],
+    options: KataEventDeliveryOptions = {},
+  ): Promise<boolean> {
     if (events.some((event) => event.type.startsWith("project."))) {
-      await this.reloadProjects();
+      await this.reloadProjects(options.shouldApply);
+      if (!this.shouldApplyEventDelivery(options)) return false;
     }
     const preferredUID = this.pendingSelectionUID ?? this.selectedIssue?.issue.uid ?? null;
     const selectedProjectID = this.selectedIssue?.issue.project_id;
@@ -804,11 +1020,13 @@ export class KataWorkspaceStore {
         event.related_issue_uid === preferredUID ||
         (event.type.startsWith("project.") && event.project_id === selectedProjectID),
     );
-    const refreshed = await this.refreshCurrentView(preferredUID, { refreshSelectedDetail });
-    if (!refreshed) return false;
-    for (const event of events) {
-      this.applyTrivialMetadataEvent(event);
-    }
+    const refreshed = await this.refreshCurrentView(preferredUID, {
+      refreshSelectedDetail,
+      eventDriven: true,
+      shouldApply: options.shouldApply,
+    });
+    if (!this.shouldApplyEventDelivery(options) || !refreshed) return false;
+    for (const event of events) this.applyTrivialMetadataEvent(event);
     return true;
   }
 
@@ -841,7 +1059,6 @@ export class KataWorkspaceStore {
     const daemonId = result.daemon_id?.trim();
     if (!daemonId) return;
     this.daemonId = daemonId;
-    this.api.bindWorkflowDaemon?.(daemonId);
   }
 
   private workflowRequestOptions(signal?: AbortSignal): { daemonId?: string; signal?: AbortSignal } | undefined {
@@ -850,6 +1067,24 @@ export class KataWorkspaceStore {
       ...(this.daemonId ? { daemonId: this.daemonId } : {}),
       ...(signal ? { signal } : {}),
     };
+  }
+
+  private loadInstance(signal?: AbortSignal): Promise<Awaited<ReturnType<KataTaskAPI["instance"]>>> {
+    const options = this.workflowRequestOptions(signal);
+    return options ? this.api.instance(options) : this.api.instance();
+  }
+
+  private loadProjects(signal?: AbortSignal): Promise<Awaited<ReturnType<KataTaskAPI["projects"]>>> {
+    const options = this.workflowRequestOptions(signal);
+    return options ? this.api.projects(options) : this.api.projects();
+  }
+
+  private loadEvents(
+    query: Parameters<KataTaskAPI["events"]>[0],
+    options: Omit<NonNullable<Parameters<KataTaskAPI["events"]>[1]>, "daemonId"> = {},
+  ): Promise<KataTaskEventsResponse> {
+    const workflowOptions = this.workflowRequestOptions(options.signal);
+    return this.api.events(query, { ...options, ...workflowOptions });
   }
 
   private loadIssues(query: KataTaskIssuesQuery, signal?: AbortSignal): Promise<KataTaskViewResponse> {
@@ -1032,10 +1267,8 @@ export class KataWorkspaceStore {
     }
   }
 
-  private async refreshCurrentView(
-    preferredUID?: string | null,
-    options: { refreshSelectedDetail?: boolean } = {},
-  ): Promise<boolean> {
+  private async refreshCurrentView(preferredUID?: string | null, options: KataRefreshOptions = {}): Promise<boolean> {
+    if (!shouldApplyLoad(options)) return false;
     const { requestID, signal } = this.beginViewRequest();
     // Selection epoch at refresh start: any selection or clear that lands
     // while the view fetch below is in flight bumps detailRequestID,
@@ -1048,12 +1281,12 @@ export class KataWorkspaceStore {
       try {
         results = await this.searchIssues(this.searchFilters, signal);
       } catch (error) {
-        if (requestID !== this.viewRequestID) return false;
+        if (requestID !== this.viewRequestID || !shouldApplyLoad(options)) return false;
         this.duplicateCandidates = duplicateCandidatesFromError(error);
         if (this.duplicateCandidates.length === 0) throw error;
         return false;
       }
-      if (requestID !== this.viewRequestID) return false;
+      if (requestID !== this.viewRequestID || !shouldApplyLoad(options)) return false;
       this.acceptWorkflowResult(results);
       this.duplicateCandidates = [];
       this.cacheTasks(results.issues);
@@ -1069,12 +1302,12 @@ export class KataWorkspaceStore {
       try {
         view = await this.loadIssues({ view: this.currentView.name, ...scopedIssueQuery(this.searchFilters) }, signal);
       } catch (error) {
-        if (requestID !== this.viewRequestID) return false;
+        if (requestID !== this.viewRequestID || !shouldApplyLoad(options)) return false;
         this.duplicateCandidates = duplicateCandidatesFromError(error);
         if (this.duplicateCandidates.length === 0) throw error;
         return false;
       }
-      if (requestID !== this.viewRequestID) return false;
+      if (requestID !== this.viewRequestID || !shouldApplyLoad(options)) return false;
       this.acceptWorkflowResult(view);
       this.duplicateCandidates = [];
       this.cacheView(view);
@@ -1105,18 +1338,28 @@ export class KataWorkspaceStore {
       resolvedUID = this.pendingSelectionUID ?? this.selectedIssue?.issue.uid ?? null;
     }
     const nextSelectedUID = resolvedUID === undefined ? (issues[0]?.uid ?? null) : resolvedUID;
-    return await this.loadSelectedIssue(nextSelectedUID, requestID, ++this.detailRequestID);
+    try {
+      return await this.loadSelectedIssue(nextSelectedUID, requestID, ++this.detailRequestID, options);
+    } catch (error) {
+      if (!shouldApplyLoad(options)) return false;
+      // Event delivery can accept authoritative list membership even if a
+      // selected detail cannot be refreshed. Interactive callers must retain
+      // the failure so their action is not reported as fully refreshed.
+      if (options.eventDriven) return true;
+      throw error;
+    }
   }
 
   private async loadSelectedIssue(
     uid: string | null,
     viewRequestID: number | undefined,
     detailRequestID: number,
+    options: KataLoadOptions = {},
   ): Promise<boolean> {
     this.abortPendingDetail();
 
     if (!uid) {
-      if (viewRequestID === undefined || viewRequestID === this.viewRequestID) {
+      if (shouldApplyLoad(options) && (viewRequestID === undefined || viewRequestID === this.viewRequestID)) {
         this.selectedIssue = null;
         this.selectedEvents = [];
         this.selectedRecurrences = [];
@@ -1135,11 +1378,12 @@ export class KataWorkspaceStore {
     // The events read may walk the daemon's whole event log (the daemon has
     // no issue_uid filter), which takes seconds against remote daemons. Start
     // it alongside the detail read so the pane never waits on the walk.
-    const eventsPromise = this.api.events({ issue_uid: uid, limit: 100 }, { signal: abort.signal });
+    const requestOptions = this.workflowRequestOptions();
+    const eventsPromise = this.loadEvents({ issue_uid: uid, limit: 100 }, { signal: abort.signal });
     eventsPromise.catch(() => {});
     let detail: KataTaskDetail;
     try {
-      detail = await this.api.issue(uid, { signal: abort.signal });
+      detail = await this.api.issue(uid, { signal: abort.signal, ...requestOptions });
     } catch (error) {
       if (this.detailAbort === abort) this.detailAbort = null;
       clearInteraction(KATA_SELECT_ISSUE_INTERACTION, timingToken);
@@ -1166,10 +1410,10 @@ export class KataWorkspaceStore {
       this.pendingSelectionUID = null;
       this.observeGraphStore("detail-load-complete", { uid, detailRequestID });
       measureInteraction(KATA_SELECT_ISSUE_INTERACTION, "detail-visible", timingToken, { uid });
-      void this.loadSelectedRecurrences(detail.issue.project_id, detailRequestID);
+      this.selectedRecurrencesRead = this.loadSelectedRecurrences(detail.issue.project_id, detailRequestID);
     };
 
-    if (viewRequestID !== undefined && viewRequestID !== this.viewRequestID) {
+    if (!shouldApplyLoad(options) || (viewRequestID !== undefined && viewRequestID !== this.viewRequestID)) {
       this.observeGraphStore("detail-load-stale", { uid, detailRequestID, viewRequestID });
       clearInteraction(KATA_SELECT_ISSUE_INTERACTION, timingToken);
       return false;
@@ -1183,7 +1427,7 @@ export class KataWorkspaceStore {
     // event log. The selected detail is already usable, so history fills in
     // as a guarded continuation instead of extending list/view loading.
     applyDetail();
-    void this.finishSelectedEvents(eventsPromise, abort, uid, detailRequestID, timingToken);
+    this.selectedEventsRead = this.finishSelectedEvents(eventsPromise, abort, uid, detailRequestID, timingToken);
     return true;
   }
 
@@ -1236,7 +1480,8 @@ export class KataWorkspaceStore {
   }
 
   private async recurrencesForProject(projectID: number): Promise<KataRecurrence[]> {
-    const response = await this.api.recurrences(projectID);
+    const options = this.workflowRequestOptions();
+    const response = options ? await this.api.recurrences(projectID, options) : await this.api.recurrences(projectID);
     return response.recurrences;
   }
 }

--- a/frontend/tests/e2e-full/kata.spec.ts
+++ b/frontend/tests/e2e-full/kata.spec.ts
@@ -119,12 +119,16 @@ type BackendState = {
   failNextAssignOwner?: string | undefined;
   failNextCursorStatus?: number | undefined;
   failNextIssuesStatus?: number | undefined;
+  failNextProjectsStatus?: number | undefined;
   failNextMetadataMessage?: string | undefined;
   closeBarrier?: Promise<void> | undefined;
   failNextMoveMessage?: string | undefined;
+  failEventCursorAfterID?: number | undefined;
   eventsBarrier?: Promise<void> | undefined;
+  eventCursorBarriers: Map<number, Promise<void>>;
   issuesBarrier?: Promise<void> | undefined;
   searchBarriers: Map<string, Promise<void>>;
+  searchIssueUIDs: Set<string> | null;
   issueDetailGates: Map<string, IssueDetailGate>;
   onEventsRequest?: ((state: BackendState, url: URL) => void) | undefined;
   projectsBarrier?: Promise<void> | undefined;
@@ -250,12 +254,15 @@ type KataBackendOptions = {
   links?: LinkRow[] | undefined;
   recurrences?: RecurrenceRow[] | undefined;
   duplicateProjectSearches?: DuplicateProjectSearchResponse[] | undefined;
+  failEventCursorAfterID?: number | undefined;
   eventsBarrier?: Promise<void> | undefined;
+  eventCursorBarriers?: Map<number, Promise<void>> | undefined;
   issuesBarrier?: Promise<void> | undefined;
   searchBarriers?: Map<string, Promise<void>> | undefined;
   issueDetailGates?: Map<string, IssueDetailGate> | undefined;
   onEventsRequest?: ((state: BackendState, url: URL) => void) | undefined;
   failNextCursorStatus?: number | undefined;
+  failNextProjectsStatus?: number | undefined;
   projectsBarrier?: Promise<void> | undefined;
   closeBarrier?: Promise<void> | undefined;
 };
@@ -275,6 +282,7 @@ function issueSummary(input: {
   owner?: string | undefined;
   priority?: number | undefined;
   labels: string[];
+  parent?: { uid: string; short_id: string } | undefined;
   parent_short_id?: string | undefined;
   child_counts?: { open: number; total: number } | undefined;
   metadata?: Record<string, unknown> | undefined;
@@ -292,6 +300,81 @@ function issueSummary(input: {
     created_at: now,
     updated_at: now,
   };
+}
+
+function workspaceStateFixture() {
+  const parent = issueSummary({
+    id: 101,
+    uid: "issue-child-workflow-parent",
+    project_id: 2,
+    project_uid: "project-kata",
+    project_name: "Kata",
+    short_id: "kat-child-parent",
+    qualified_id: "Kata#kat-child-parent",
+    title: "Parent child workflow",
+    body: "Parent task for the child workflow.",
+    owner: "Susan",
+    labels: ["work"],
+    child_counts: { open: 1, total: 1 },
+  });
+  const child = issueSummary({
+    id: 102,
+    uid: "issue-child-workflow",
+    project_id: 2,
+    project_uid: "project-kata",
+    project_name: "Kata",
+    short_id: "kat-child",
+    qualified_id: "Kata#kat-child",
+    title: "Child child workflow",
+    body: "Child task in the child workflow.",
+    owner: "Susan",
+    labels: ["work"],
+    parent: { uid: parent.uid, short_id: parent.short_id },
+    parent_short_id: parent.short_id,
+  });
+  return {
+    child,
+    issues: [...issues, parent, child],
+    parent,
+    projects: [
+      inboxProject,
+      ...projects.map((project) =>
+        project.uid === "project-kata" ? { ...project, open_count: project.open_count + 2 } : project,
+      ),
+    ],
+  };
+}
+
+async function seedRestoredKataWorkspace(
+  page: Page,
+  baseURL: string,
+  options: { projectScoped?: boolean } = {},
+): Promise<void> {
+  await page.goto(`${baseURL}/kata`);
+  if (options.projectScoped ?? true) {
+    await page.getByRole("button", { name: /Project scope: All projects/ }).click();
+    const projectInput = page.getByRole("combobox", { name: "Project scope" });
+    await projectInput.fill("kata");
+    await projectInput.press("Enter");
+  }
+  await page.getByRole("combobox", { name: "Status: Open" }).click();
+  await page.getByRole("option", { name: "All" }).click();
+  await page.getByRole("textbox", { name: "Owner" }).fill("Susan");
+  await page.getByRole("textbox", { name: "Label" }).fill("work");
+  await page.getByLabel("Search tasks").fill("child");
+  await page.getByTestId("daemon-chip").click();
+  const daemonRow = page.getByRole("menu", { name: "Configured Kata daemons" }).locator(".daemon-row").first();
+  await expect(daemonRow).toBeEnabled();
+  await page.getByTestId("daemon-chip").click();
+
+  const parentRow = page.getByRole("button", { name: /Parent child workflow/ });
+  await expect(parentRow).toBeVisible();
+  await parentRow.press("ArrowRight");
+  await expect(parentRow).toHaveAttribute("aria-expanded", "true");
+  const childRow = page.getByRole("button", { name: /Child child workflow/ });
+  await expect(childRow).toBeVisible();
+  await childRow.click();
+  await expect(page.getByRole("heading", { name: "Child child workflow" })).toBeVisible();
 }
 
 function commentRow(input: { id: number; issue_id: number; author: string; body: string; created_at?: string }) {
@@ -449,10 +532,14 @@ async function startKataBackend(options: KataBackendOptions = {}): Promise<Backe
     seenPaths: [],
     streams: new Set(),
     failNextCursorStatus: options.failNextCursorStatus,
+    failNextProjectsStatus: options.failNextProjectsStatus,
     closeBarrier: options.closeBarrier,
+    failEventCursorAfterID: options.failEventCursorAfterID,
     eventsBarrier: options.eventsBarrier,
+    eventCursorBarriers: options.eventCursorBarriers ?? new Map(),
     issuesBarrier: options.issuesBarrier,
     searchBarriers: options.searchBarriers ?? new Map(),
+    searchIssueUIDs: null,
     issueDetailGates: options.issueDetailGates ?? new Map(),
     onEventsRequest: options.onEventsRequest,
     projectsBarrier: options.projectsBarrier,
@@ -660,6 +747,13 @@ async function handleKataRequest(state: BackendState, req: IncomingMessage, res:
         return;
       }
       await state.projectsBarrier;
+      state.projectsBarrier = undefined;
+      if (state.failNextProjectsStatus !== undefined) {
+        const status = state.failNextProjectsStatus;
+        state.failNextProjectsStatus = undefined;
+        writeJSON(res, status, { error: { code: "internal", message: "project catalog failed" } });
+        return;
+      }
       writeJSON(res, 200, {
         projects: state.projects,
         fetched_at: now,
@@ -706,11 +800,13 @@ async function handleKataRequest(state: BackendState, req: IncomingMessage, res:
           return;
         }
         const issueUID = url.searchParams.get("issue_uid");
-        if (url.searchParams.get("after_id") === "0") {
+        if (url.searchParams.get("after_id") === "0" && issueUID === null) {
           await state.eventsBarrier;
           state.eventsBarrier = undefined;
         }
         const afterID = Number(url.searchParams.get("after_id") ?? "0");
+        await state.eventCursorBarriers.get(afterID);
+        state.eventCursorBarriers.delete(afterID);
         const projectID = url.searchParams.get("project_id");
         const events = state.events.filter((event) => {
           if (event.event_id <= afterID) return false;
@@ -721,6 +817,11 @@ async function handleKataRequest(state: BackendState, req: IncomingMessage, res:
         const limit = Number(url.searchParams.get("limit") ?? "0");
         const page = limit > 0 ? events.slice(0, limit) : events;
         state.onEventsRequest?.(state, url);
+        if (afterID === state.failEventCursorAfterID && url.searchParams.get("limit") === "100") {
+          state.failEventCursorAfterID = undefined;
+          writeJSON(res, 503, { error: { code: "cursor_unavailable", message: "cursor catch-up failed" } });
+          return;
+        }
         writeJSON(res, 200, {
           reset_required: false,
           events: page,
@@ -931,12 +1032,17 @@ function searchIssues(state: BackendState, input: { projectID: number; q: string
   const q = input.q.trim().toLowerCase();
   return state.issues.filter((issue) => {
     if (issue.project_id !== input.projectID) return false;
-    if (!q) return true;
-    return [issue.title, issue.body, issue.qualified_id, issue.project_name, issue.owner, issue.labels.join(" ")]
-      .filter(Boolean)
-      .join(" ")
-      .toLowerCase()
-      .includes(q);
+    if (
+      q &&
+      ![issue.title, issue.body, issue.qualified_id, issue.project_name, issue.owner, issue.labels.join(" ")]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase()
+        .includes(q)
+    ) {
+      return false;
+    }
+    return state.searchIssueUIDs === null || state.searchIssueUIDs.has(issue.uid);
   });
 }
 
@@ -1410,6 +1516,7 @@ function writeIssueDetail(state: BackendState, res: ServerResponse, uid: string)
   }
   writeJSON(res, 200, {
     issue: found,
+    parent: found.parent,
     comments: state.commentsByUID.get(found.uid) ?? [],
     labels: found.labels.map((label) => ({ issue_id: found.id, label, author: "e2e", created_at: now })),
     links: state.links.filter((link) => link.from.uid === found.uid || link.to.uid === found.uid),
@@ -1498,6 +1605,7 @@ async function closeServer(server: Server): Promise<void> {
       if (err) reject(err);
       else resolve();
     });
+    server.closeIdleConnections();
   });
 }
 
@@ -2590,6 +2698,185 @@ test("kata workspace applies cursor catch-up events before opening the configure
   }
 });
 
+test("kata cursor catch-up clears a removed selected task when its detail refresh fails", async ({ page }) => {
+  let releaseEvents!: () => void;
+  const eventsBarrier = new Promise<void>((resolve) => {
+    releaseEvents = resolve;
+  });
+  const backend = await startKataBackend({
+    events: [
+      eventRow({
+        event_id: 10,
+        event_uid: "event-rent-removed",
+        type: "issue.closed",
+        project_id: issues[0]!.project_id,
+        project_uid: issues[0]!.project_uid,
+        project_name: issues[0]!.project_name,
+        issue: issues[0]!,
+      }),
+    ],
+    eventsBarrier,
+  });
+  const kataHome = await configureKataHome(backend.url);
+  const server = await startIsolatedE2EServer();
+
+  try {
+    await page.goto(`${server.info.base_url}/kata?issue=issue-rent`);
+    const detail = page.getByRole("region", { name: "Task detail" });
+    await expect(detail.getByRole("heading", { name: "Pay rent" })).toBeVisible();
+    await expect.poll(() => backend.state.seenPaths).toContain("GET /api/v1/events?after_id=0&limit=100");
+
+    backend.state.issues = backend.state.issues.filter((issue) => issue.uid !== "issue-rent");
+    backend.state.issueDetailGates.set("issue-rent", { barrier: Promise.resolve(), status: 500 });
+    releaseEvents();
+
+    await expect(page.locator(".kata-list").getByRole("button", { name: /Pay rent/ })).toHaveCount(0);
+    await expect(detail).toContainText("Select a task");
+    await expect(page).not.toHaveURL(/issue=issue-rent/);
+    await expect
+      .poll(async () =>
+        page.evaluate(() => JSON.parse(window.localStorage.getItem("middleman:kata:workspace-state/v1") ?? "{}")),
+      )
+      .toEqual({});
+  } finally {
+    releaseEvents();
+    await server.stop();
+    kataHome.restore();
+    await backend.close();
+  }
+});
+
+test("kata cursor catch-up clears a removed selected task when a later cursor page fails", async ({ page }) => {
+  let releaseEvents!: () => void;
+  const eventsBarrier = new Promise<void>((resolve) => {
+    releaseEvents = resolve;
+  });
+  const backend = await startKataBackend({
+    events: [
+      eventRow({
+        event_id: 10,
+        event_uid: "event-rent-removed-before-cursor-failure",
+        type: "issue.closed",
+        project_id: issues[0]!.project_id,
+        project_uid: issues[0]!.project_uid,
+        project_name: issues[0]!.project_name,
+        issue: issues[0]!,
+      }),
+    ],
+    eventsBarrier,
+  });
+  const kataHome = await configureKataHome(backend.url);
+  const server = await startIsolatedE2EServer();
+
+  try {
+    await page.goto(`${server.info.base_url}/kata?issue=issue-rent`);
+    const detail = page.getByRole("region", { name: "Task detail" });
+    await expect(detail.getByRole("heading", { name: "Pay rent" })).toBeVisible();
+    await expect.poll(() => backend.state.seenPaths).toContain("GET /api/v1/events?after_id=0&limit=100");
+
+    backend.state.issues = backend.state.issues.filter((issue) => issue.uid !== "issue-rent");
+    backend.state.failEventCursorAfterID = 10;
+    releaseEvents();
+
+    await expect.poll(() => backend.state.seenPaths).toContain("GET /api/v1/events?after_id=10&limit=100");
+    await expect(page.locator(".kata-list").getByRole("button", { name: /Pay rent/ })).toHaveCount(0);
+    await expect(detail).toContainText("Select a task");
+    await expect(page).not.toHaveURL(/issue=issue-rent/);
+    await expect(page.getByRole("alert")).toContainText("cursor catch-up failed");
+    await expect
+      .poll(() => backend.state.seenPaths.some((path) => path.startsWith("GET /api/v1/events/stream")))
+      .toBe(true);
+    await expect
+      .poll(async () =>
+        page.evaluate(() => JSON.parse(window.localStorage.getItem("middleman:kata:workspace-state/v1") ?? "{}")),
+      )
+      .toEqual({});
+
+    await page.getByRole("button", { name: "Retry" }).click();
+    await expect
+      .poll(() => backend.state.seenPaths.filter((path) => path === "GET /api/v1/events?after_id=10&limit=100").length)
+      .toBe(2);
+    await expect(page.getByRole("alert")).toHaveCount(0);
+
+    backend.state.issues = [];
+    emitKataEvent(
+      backend.state,
+      eventRow({
+        event_id: 11,
+        event_uid: "event-q3-removed-after-cursor-recovery",
+        type: "issue.closed",
+        project_id: issues[1]!.project_id,
+        project_uid: issues[1]!.project_uid,
+        project_name: issues[1]!.project_name,
+        issue: issues[1]!,
+      }),
+    );
+    await expect(page.locator(".kata-list").getByRole("button", { name: /Email Susan re: Q3/ })).toHaveCount(0);
+  } finally {
+    releaseEvents();
+    await server.stop();
+    kataHome.restore();
+    await backend.close();
+  }
+});
+
+test("kata cursor retry serializes a live stream event without duplicate refresh", async ({ page }) => {
+  let releaseRetry!: () => void;
+  const retryBarrier = new Promise<void>((resolve) => {
+    releaseRetry = resolve;
+  });
+  const backend = await startKataBackend({
+    events: [
+      eventRow({
+        event_id: 10,
+        event_uid: "event-cursor-retry",
+        type: "issue.edited",
+        project_id: issues[0]!.project_id,
+        project_uid: issues[0]!.project_uid,
+        project_name: issues[0]!.project_name,
+        issue: issues[0]!,
+      }),
+    ],
+  });
+  const kataHome = await configureKataHome(backend.url);
+  const server = await startIsolatedE2EServer();
+
+  try {
+    backend.state.failEventCursorAfterID = 10;
+    await page.goto(`${server.info.base_url}/kata`);
+    await expect.poll(() => backend.state.seenPaths).toContain("GET /api/v1/events?after_id=10&limit=100");
+    await expect(page.getByRole("button", { name: "Retry" })).toBeVisible();
+
+    backend.state.eventCursorBarriers.set(10, retryBarrier);
+    await page.getByRole("button", { name: "Retry" }).click();
+    await expect(page.getByRole("button", { name: "Retrying…" })).toBeDisabled();
+    emitKataEvent(
+      backend.state,
+      eventRow({
+        event_id: 11,
+        event_uid: "event-live-during-cursor-retry",
+        type: "issue.edited",
+        project_id: issues[0]!.project_id,
+        project_uid: issues[0]!.project_uid,
+        project_name: issues[0]!.project_name,
+        issue: issues[0]!,
+      }),
+    );
+    releaseRetry();
+
+    await expect(page.getByRole("alert")).toHaveCount(0);
+    await expect.poll(() => backend.state.seenStreamLastEventIDs).toEqual(["10"]);
+    await expect
+      .poll(() => backend.state.seenPaths.filter((path) => path === "GET /api/v1/events?after_id=10&limit=100").length)
+      .toBe(2);
+  } finally {
+    releaseRetry();
+    await server.stop();
+    kataHome.restore();
+    await backend.close();
+  }
+});
+
 test("kata workspace reconnects after a closed configured daemon stream", async ({ page }) => {
   const backend = await startKataBackend();
   const kataHome = await configureKataHome(backend.url);
@@ -3168,8 +3455,8 @@ test("kata daemon switch drops a pending detail load from the previous daemon", 
 
     // Select Pay rent on the home daemon with its detail stalled, then
     // switch daemons while the new daemon's issue list is also stalled.
-    // The switch abandons the selection, so the old daemon's failing
-    // detail request must not paint an error over the switch.
+    // The accepted list stays visible but inert while the target is staged,
+    // and the abandoned detail failure must not paint over the switch.
     home.state.issueDetailGates.set("issue-rent", { barrier: stalledDetail, status: 500 });
     await rentRow.click();
     await expect.poll(() => home.state.seenPaths).toContain("GET /api/v1/issues/issue-rent");
@@ -3178,7 +3465,7 @@ test("kata daemon switch drops a pending detail load from the previous daemon", 
     await page.getByTestId("daemon-chip").click();
     await page.getByTestId("daemon-row-work").click();
     await expect(page.getByRole("region", { name: "Kata", exact: true })).toHaveAttribute("inert", "");
-    await expect(rentRow).toHaveCount(0);
+    await expect(rentRow).toBeVisible();
     await expect(page.getByRole("button", { name: /^Finances\s+1$/ })).toHaveCount(0);
     releaseDetail();
     await page.waitForTimeout(750);
@@ -3272,9 +3559,9 @@ test("kata daemon switch restores the previous workspace after target bootstrap 
     await expect(page.getByRole("region", { name: "Task detail" })).toContainText(
       "Confirm the Q3 project review agenda.",
     );
-    await expect
-      .poll(() => home.state.seenPaths.filter((seenPath) => seenPath === "GET /api/v1/issues?status=open").length)
-      .toBeGreaterThan(homeListsBeforeSwitch);
+    expect(home.state.seenPaths.filter((seenPath) => seenPath === "GET /api/v1/issues?status=open")).toHaveLength(
+      homeListsBeforeSwitch,
+    );
     await expect
       .poll(() => home.state.seenPaths.filter((seenPath) => seenPath.startsWith("GET /api/v1/events/stream")).length)
       .toBeGreaterThan(homeStreamsBeforeSwitch);
@@ -3287,7 +3574,7 @@ test("kata daemon switch restores the previous workspace after target bootstrap 
   }
 });
 
-test("kata daemon switch leaves empty stopped state when target and rollback fail", async ({ page }) => {
+test("kata daemon switch retains captured state when target and rollback fail", async ({ page }) => {
   let releaseIssues!: () => void;
   const issuesBarrier = new Promise<void>((resolve) => {
     releaseIssues = resolve;
@@ -3306,33 +3593,28 @@ test("kata daemon switch leaves empty stopped state when target and rollback fai
   try {
     await page.goto(`${server.info.base_url}/kata?view=all&issue=issue-rent`);
     await expectKataDaemonSwitcherReady(page);
+    await expect.poll(() => home.state.streams.size).toBeGreaterThan(0);
     const homeStreamsBeforeSwitch = home.state.seenPaths.filter((seenPath) =>
       seenPath.startsWith("GET /api/v1/events/stream"),
     ).length;
     const collision = { candidates: [{ title: "Foreign collision", qualified_id: "Work#foreign" }] };
     work.state.duplicateIssueListResponses.push(collision);
-    home.state.issueDetailGates.set("issue-rent", { barrier: Promise.resolve(), status: 500 });
+    home.state.failNextCursorStatus = 500;
 
     await page.getByTestId("daemon-chip").click();
     await page.getByTestId("daemon-row-work").click();
     await expect.poll(() => work.state.seenPaths).toContain("GET /api/v1/issues?status=open");
-    await page.evaluate(() => {
-      window.history.pushState({}, "", "/kata?view=all&scope=project-kata");
-      window.dispatchEvent(new PopStateEvent("popstate"));
-    });
     releaseIssues();
 
     await expect(page.getByTestId("daemon-chip")).toContainText("home");
     await expect(page.getByRole("status", { name: "Connection: error" })).toBeVisible();
-    await expect(page.getByRole("button", { name: /^Finances\s+1$/ })).toHaveCount(0);
-    await expect(page.locator(".kata-list").getByRole("button", { name: /Pay rent/ })).toHaveCount(0);
-    await expect(page.getByRole("region", { name: "Task detail" })).not.toContainText("Send June rent from checking.");
+    await expect(page.getByRole("button", { name: /^Finances\s+1$/ })).toBeVisible();
+    await expect(page.locator(".kata-list").getByRole("button", { name: /Pay rent/ })).toBeVisible();
+    await expect(page.getByRole("region", { name: "Task detail" })).toContainText("Send June rent from checking.");
     await expect.poll(() => home.state.streams.size).toBe(0);
     expect(home.state.seenPaths.filter((seenPath) => seenPath.startsWith("GET /api/v1/events/stream")).length).toBe(
       homeStreamsBeforeSwitch,
     );
-    await page.waitForTimeout(250);
-    expect(home.state.seenPaths).not.toContain("GET /api/v1/projects/2/issues?status=open");
   } finally {
     releaseIssues();
     await server.stop();
@@ -3379,7 +3661,7 @@ test("kata daemon switch rolls back when target event cursor synchronization fai
   }
 });
 
-test("kata daemon switch stops with empty state when target and rollback cursor synchronization fail", async ({
+test("kata daemon switch retains the captured workspace when rollback cursor synchronization fails", async ({
   page,
 }) => {
   const home = await startKataBackend();
@@ -3405,8 +3687,8 @@ test("kata daemon switch stops with empty state when target and rollback cursor 
     await page.getByTestId("daemon-row-work").click();
 
     await expect(page.getByRole("status", { name: "Connection: error" })).toBeVisible();
-    await expect(page.locator(".kata-list").getByRole("button", { name: /Pay rent/ })).toHaveCount(0);
-    await expect(page.getByRole("region", { name: "Task detail" })).not.toContainText("Send June rent from checking.");
+    await expect(page.locator(".kata-list").getByRole("button", { name: /Pay rent/ })).toBeVisible();
+    await expect(page.getByRole("region", { name: "Task detail" })).toContainText("Send June rent from checking.");
     await expect.poll(() => home.state.streams.size).toBe(0);
     expect(home.state.seenPaths.filter((seenPath) => seenPath.startsWith("GET /api/v1/events/stream")).length).toBe(
       homeStreamsBeforeSwitch,
@@ -3433,7 +3715,9 @@ test("kata route does not resolve an issue through an unknown daemon", async ({ 
       "Kata daemon missing is not configured.",
     );
     await expect(page.getByRole("region", { name: "Task detail" })).toContainText("Select a task");
-    expect(backend.state.seenPaths).not.toContain("GET /api/v1/issues/issue-rent");
+    await expect
+      .poll(() => backend.state.seenPaths.includes("GET /api/v1/issues/issue-rent"), { timeout: 1_000 })
+      .toBe(false);
   } finally {
     await server.stop();
     kataHome.restore();
@@ -3456,11 +3740,79 @@ test("failed initial routed daemon restores the previous daemon preference", asy
   try {
     await page.addInitScript(() => localStorage.setItem("middleman:kata:active_daemon", "home"));
     await page.goto(`${server.info.base_url}/kata?issue=issue-q3&daemon=work`);
-    await expect(page.getByRole("status", { name: "Connection: error" })).toBeVisible();
+    await expect(page.getByRole("alert")).toContainText("event cursor synchronization failed");
+    await expect(page.getByRole("button", { name: "Retry" })).toBeVisible();
+    await expect(page).toHaveURL(/daemon=work/);
 
     await page.goto(`${server.info.base_url}/kata?issue=issue-rent`);
     await expect(page.getByTestId("daemon-chip")).toContainText("home");
     await expect(page.getByRole("region", { name: "Task detail" })).toContainText("Send June rent from checking.");
+  } finally {
+    await server.stop();
+    kataHome.restore();
+    await home.close();
+    await work.close();
+  }
+});
+
+test("routed daemon Retry commits preference, state, route, and stream only after success", async ({ page }) => {
+  const home = await startKataBackend();
+  const work = await startKataBackend({ failNextCursorStatus: 500 });
+  const kataHome = await configureKataHomeDaemons(
+    [
+      { name: "home", url: home.url },
+      { name: "work", url: work.url },
+    ],
+    "home",
+  );
+  const server = await startIsolatedE2EServer();
+  const workState = {
+    version: 1,
+    daemons: {
+      work: {
+        view: "all",
+        filters: { scope: { kind: "all" }, status: "open", owner: "", label: "", query: "saved" },
+        selectedIssueUID: "issue-q3",
+      },
+    },
+  };
+
+  try {
+    await page.addInitScript((state) => {
+      localStorage.setItem("middleman:kata:active_daemon", "home");
+      localStorage.setItem("middleman:kata:workspace-state/v1", JSON.stringify(state));
+    }, workState);
+    await page.goto(`${server.info.base_url}/kata?issue=issue-q3&daemon=work`);
+
+    const retry = page.getByRole("button", { name: "Retry" });
+    await expect(retry).toBeVisible();
+    await expect(page.getByTestId("daemon-chip")).toContainText("home");
+    await expect(page.locator(".kata-layout")).toHaveAttribute("inert");
+    await expect.poll(() => page.evaluate(() => localStorage.getItem("middleman:kata:active_daemon"))).toBe("home");
+    await expect
+      .poll(() => page.evaluate(() => localStorage.getItem("middleman:kata:workspace-state/v1")))
+      .toBe(JSON.stringify(workState));
+    await expect(page).toHaveURL(/daemon=work/);
+    expect(work.state.seenPaths.some((path) => path.startsWith("GET /api/v1/events/stream"))).toBe(false);
+
+    work.state.failNextCursorStatus = 500;
+    await retry.click();
+    await expect(retry).toBeVisible();
+    await expect.poll(() => page.evaluate(() => localStorage.getItem("middleman:kata:active_daemon"))).toBe("home");
+    await expect
+      .poll(() => page.evaluate(() => localStorage.getItem("middleman:kata:workspace-state/v1")))
+      .toBe(JSON.stringify(workState));
+    await expect(page).toHaveURL(/daemon=work/);
+    expect(work.state.seenPaths.some((path) => path.startsWith("GET /api/v1/events/stream"))).toBe(false);
+
+    await retry.click();
+
+    await expect(page).toHaveURL(/\/kata\?issue=issue-q3$/);
+    await expect(page.getByTestId("daemon-chip")).toContainText("work");
+    await expect(page.getByRole("heading", { name: "Email Susan re: Q3" })).toBeVisible();
+    await expect.poll(() => page.evaluate(() => localStorage.getItem("middleman:kata:active_daemon"))).toBe("work");
+    await expect.poll(() => work.state.streams.size).toBeGreaterThan(0);
+    expect(work.state.seenPaths.filter((path) => path.startsWith("GET /api/v1/events/stream"))).toHaveLength(1);
   } finally {
     await server.stop();
     kataHome.restore();
@@ -3477,11 +3829,11 @@ test("missing routed issue leaves its accepted daemon workspace usable", async (
   try {
     await page.goto(`${server.info.base_url}/kata?issue=issue-missing&daemon=e2e`);
 
-    await expect(page).toHaveURL(/\/kata\?issue=issue-missing$/);
+    await expect(page).toHaveURL(/\/kata$/);
     await expect(page.getByTestId("daemon-chip")).toContainText("e2e");
     await expect(page.locator(".kata-list").getByRole("button", { name: /Pay rent/ })).toBeVisible();
     await expect(page.getByRole("region", { name: "Task detail" })).toContainText("Select a task");
-    await expect(page.getByRole("alert")).toContainText("Kata task not found");
+    await expect(page.locator(".kata-request-error")).toBeHidden();
     await expect.poll(() => backend.state.seenPaths).toContain("GET /api/v1/events/stream");
   } finally {
     await server.stop();
@@ -3583,6 +3935,7 @@ test("kata routed daemon open keeps the project scope on the target daemon", asy
     await expect(page.getByTestId("daemon-chip")).toContainText("work");
     await expect(page).toHaveURL(/scope=project-shared/);
     await expect(page).not.toHaveURL(/daemon=/);
+    await expect(page).toHaveURL(/scope=project-shared/);
     // The scoped list must load from the target daemon: the routed scope
     // may not be dropped into an unscoped backlog after the switch.
     await expect(taskList.getByRole("button", { name: /Work scoped task/ })).toBeVisible();
@@ -4113,6 +4466,113 @@ test("kata task list selects visible parent when child sorts first", async ({ pa
   }
 });
 
+test("kata workspace restores filtered expanded child selection after leaving Kata", async ({ page }) => {
+  const fixture = workspaceStateFixture();
+  const backend = await startKataBackend({ issues: fixture.issues, projects: fixture.projects });
+  const kataHome = await configureKataHome(backend.url);
+  const server = await startIsolatedE2EServer();
+
+  try {
+    await seedRestoredKataWorkspace(page, server.info.base_url);
+    await expect
+      .poll(() => page.evaluate(() => window.localStorage.getItem("middleman:kata:workspace-state/v1")))
+      .toContain(fixture.child.uid);
+    const focusUIDBeforeLeave = await page.evaluate(() => document.activeElement?.getAttribute("data-uid"));
+    expect(focusUIDBeforeLeave).toBe(fixture.child.uid);
+
+    await appHeaderTab(page, "PRs").click();
+    await expect(page).toHaveURL(/\/pulls/);
+    await page.goto(`${server.info.base_url}/kata`);
+
+    await expect(page.getByRole("button", { name: /Project scope: Kata/ })).toBeVisible();
+    await expect(page.getByRole("combobox", { name: "Status: All" })).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "Owner" })).toHaveValue("Susan");
+    await expect(page.getByRole("textbox", { name: "Label" })).toHaveValue("work");
+    await expect(page.getByLabel("Search tasks")).toHaveValue("child");
+    await expect.poll(() => backend.state.seenPaths).toContain("GET /api/v1/issues/issue-child-workflow-parent");
+    const parentRow = page.getByRole("button", { name: /Parent child workflow/ });
+    const childRow = page.getByRole("button", { name: /Child child workflow/ });
+    await expect(parentRow).toHaveAttribute("aria-expanded", "true");
+    await expect(childRow).toHaveAttribute("aria-current", "true");
+    await expect(childRow).toBeInViewport();
+    await expect(page.getByRole("heading", { name: "Child child workflow" })).toBeVisible();
+    await expect(childRow).not.toBeFocused();
+    expect(await page.evaluate(() => document.activeElement?.getAttribute("data-uid"))).not.toBe(focusUIDBeforeLeave);
+  } finally {
+    await server.stop();
+    kataHome.restore();
+    await backend.close();
+  }
+});
+
+test("kata workspace reconstructs an omitted parent for restored child selection", async ({ page }) => {
+  const fixture = workspaceStateFixture();
+  const backend = await startKataBackend({ issues: fixture.issues, projects: fixture.projects });
+  const kataHome = await configureKataHome(backend.url);
+  const server = await startIsolatedE2EServer();
+
+  try {
+    await seedRestoredKataWorkspace(page, server.info.base_url);
+    await expect
+      .poll(() => page.evaluate(() => window.localStorage.getItem("middleman:kata:workspace-state/v1")))
+      .toContain(fixture.child.uid);
+    const searchPath = "GET /api/v1/projects/2/search?q=child";
+    const searchesBeforeRemount = backend.state.seenPaths.filter((path) => path === searchPath).length;
+    backend.state.searchIssueUIDs = new Set([fixture.child.uid]);
+    const focusUIDBeforeLeave = await page.evaluate(() => document.activeElement?.getAttribute("data-uid"));
+    expect(focusUIDBeforeLeave).toBe(fixture.child.uid);
+
+    await appHeaderTab(page, "PRs").click();
+    await page.goto(`${server.info.base_url}/kata`);
+
+    await expect
+      .poll(() => backend.state.seenPaths.filter((path) => path === searchPath).length)
+      .toBeGreaterThan(searchesBeforeRemount);
+    await expect.poll(() => backend.state.seenPaths).toContain("GET /api/v1/issues/issue-child-workflow-parent");
+    const parentRow = page.getByRole("button", { name: /Parent child workflow/ });
+    const childRow = page.getByRole("button", { name: /Child child workflow/ });
+    await expect(parentRow).toHaveAttribute("aria-expanded", "true");
+    await expect(childRow).toHaveAttribute("aria-current", "true");
+    await expect(childRow).toBeInViewport();
+    await expect(page.getByRole("heading", { name: "Child child workflow" })).toBeVisible();
+    await expect(childRow).not.toBeFocused();
+    expect(await page.evaluate(() => document.activeElement?.getAttribute("data-uid"))).not.toBe(focusUIDBeforeLeave);
+  } finally {
+    backend.state.searchIssueUIDs = null;
+    await server.stop();
+    kataHome.restore();
+    await backend.close();
+  }
+});
+
+test("kata explicit URL wins over persisted selection without clearing filters", async ({ page }) => {
+  const fixture = workspaceStateFixture();
+  const backend = await startKataBackend({ issues: fixture.issues, projects: fixture.projects });
+  const kataHome = await configureKataHome(backend.url);
+  const server = await startIsolatedE2EServer();
+
+  try {
+    await seedRestoredKataWorkspace(page, server.info.base_url, { projectScoped: false });
+    await expect
+      .poll(() => page.evaluate(() => window.localStorage.getItem("middleman:kata:workspace-state/v1")))
+      .toContain(fixture.child.uid);
+
+    await appHeaderTab(page, "PRs").click();
+    await page.goto(`${server.info.base_url}/kata?view=inbox&issue=issue-rent`);
+
+    await expect(page.getByRole("heading", { name: "Inbox", level: 2, exact: true })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Pay rent" })).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "Owner" })).toHaveValue("Susan");
+    await expect(page.getByRole("textbox", { name: "Label" })).toHaveValue("work");
+    await expect(page.getByLabel("Search tasks")).toHaveValue("child");
+    await expect(page.locator(".kata-list").getByRole("button", { name: /Pay rent/ })).toHaveCount(0);
+  } finally {
+    await server.stop();
+    kataHome.restore();
+    await backend.close();
+  }
+});
+
 test("kata workspace switches between configured external daemons", async ({ page }) => {
   const homeProject = {
     id: 101,
@@ -4192,6 +4652,7 @@ test("kata workspace switches between configured external daemons", async ({ pag
     await expect(projectRows.filter({ hasText: /^Work\s+1$/ })).toBeVisible();
     await expect(projectRows.filter({ hasText: /^Home\s+1$/ })).toHaveCount(0);
   } finally {
+    await page.close();
     await server.stop();
     kataHome.restore();
     await home.close();
@@ -4463,7 +4924,7 @@ test("kata project scope stays on the starting default daemon when configuration
   }
 });
 
-test("kata daemon switch restarts the target stream after stale route churn", async ({ page }) => {
+test("kata route change cancels a stalled daemon switch and keeps the accepted stream", async ({ page }) => {
   let releaseEvents = () => {};
   const stalledEvents = new Promise<void>((resolve) => {
     releaseEvents = resolve;
@@ -4482,19 +4943,6 @@ test("kata daemon switch restarts the target stream after stale route churn", as
     metadata: { area: "Work", sidebar_order: 1 },
     open_count: 1,
   };
-  const queuedWorkIssue = issueSummary({
-    id: 2020,
-    uid: "issue-work-queued",
-    project_id: workProject.id,
-    project_uid: workProject.uid,
-    project_name: workProject.name,
-    short_id: "work-2",
-    qualified_id: "Work#work-2",
-    title: "Verify the rollout",
-    body: "Selected by browser history during the daemon switch.",
-    labels: ["work"],
-    metadata: { scheduled_on: today },
-  });
   const home = await startKataBackend({
     projects: [homeProject],
     issues: [
@@ -4529,7 +4977,6 @@ test("kata daemon switch restarts the target stream after stale route churn", as
         labels: ["work"],
         metadata: { scheduled_on: today },
       }),
-      queuedWorkIssue,
     ],
     eventsBarrier: stalledEvents,
   });
@@ -4550,33 +4997,77 @@ test("kata daemon switch restarts the target stream after stale route churn", as
     await page.getByTestId("daemon-chip").click();
     await page.getByTestId("daemon-row-work").click();
     await expect.poll(() => work.state.seenPaths).toContain("GET /api/v1/events?limit=1000");
-    await expect(page.getByRole("region", { name: "Task detail" })).toContainText("Visible only from the work daemon.");
+    await expect(page.getByTestId("daemon-chip")).toContainText("home");
+    await expect(page.getByRole("button", { name: /Rake the yard/ })).toBeVisible();
 
     await page.evaluate(() => {
-      window.history.pushState({}, "", "/kata?view=all&scope=project-work&issue=issue-work-queued");
+      window.history.pushState({}, "", "/kata?view=all&scope=project-home&issue=issue-home-yard");
       window.dispatchEvent(new PopStateEvent("popstate"));
     });
-    await expect(page).toHaveURL(/scope=project-work/);
+    await expect(page).toHaveURL(/scope=project-home/);
     await page.evaluate(
       () => new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve()))),
     );
     expect(work.state.seenPaths).not.toContain("GET /api/v1/projects/202/issues?status=open");
     releaseEvents();
 
-    await expect(page.getByTestId("daemon-chip")).toContainText("work");
-    await expect(page).toHaveURL(/scope=project-work/);
-    await expect(page.getByRole("button", { name: /Ship the release/ })).toBeVisible();
-    await expect.poll(() => work.state.seenPaths).toContain("GET /api/v1/issues/issue-work-queued");
-    await expect(page.getByRole("region", { name: "Task detail" })).toContainText(queuedWorkIssue.body);
-    // The queued route also changed the project scope, so the accepted
-    // daemon must serve the scoped backlog; the abandoned daemon must not.
-    await expect.poll(() => work.state.seenPaths).toContain("GET /api/v1/projects/202/issues?status=open");
-    expect(home.state.seenPaths).not.toContain("GET /api/v1/projects/202/issues?status=open");
+    await expect(page.getByTestId("daemon-chip")).toContainText("home");
+    await expect(page).toHaveURL(/scope=project-home/);
+    await expect(page.getByRole("button", { name: /Rake the yard/ })).toBeVisible();
+    await expect(page.getByRole("region", { name: "Task detail" })).toContainText("Visible only from the home daemon.");
+    expect(work.state.seenPaths).not.toContain("GET /api/v1/issues/issue-work-queued");
+    expect(work.state.seenPaths).not.toContain("GET /api/v1/projects/202/issues?status=open");
     await expect
-      .poll(() => work.state.seenPaths.filter((path) => path.startsWith("GET /api/v1/events/stream")).length)
-      .toBeGreaterThanOrEqual(1);
+      .poll(() => home.state.seenPaths.filter((path) => path.startsWith("GET /api/v1/events/stream")).length)
+      .toBeGreaterThanOrEqual(2);
   } finally {
     releaseEvents();
+    await server.stop();
+    kataHome.restore();
+    await home.close();
+    await work.close();
+  }
+});
+
+test("kata route change ignores a stalled daemon-switch rejection on the same mount", async ({ page }) => {
+  let releaseProjects = () => {};
+  const stalledProjects = new Promise<void>((resolve) => {
+    releaseProjects = resolve;
+  });
+  const home = await startKataBackend();
+  const work = await startKataBackend({ projectsBarrier: stalledProjects, failNextProjectsStatus: 500 });
+  const kataHome = await configureKataHomeDaemons(
+    [
+      { name: "home", url: home.url },
+      { name: "work", url: work.url },
+    ],
+    "home",
+  );
+  const server = await startIsolatedE2EServer();
+
+  try {
+    await page.goto(`${server.info.base_url}/kata`);
+    await expect(page.getByTestId("daemon-chip")).toContainText("home");
+    await expect(page.getByRole("button", { name: /Pay rent/ })).toBeVisible();
+
+    await page.getByTestId("daemon-chip").click();
+    await page.getByTestId("daemon-row-work").click();
+    await expect.poll(() => work.state.seenPaths).toContain("GET /api/v1/projects?include=stats");
+
+    await page.evaluate(() => {
+      window.history.pushState({}, "", "/kata?view=inbox");
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    });
+    releaseProjects();
+
+    await expect(page).toHaveURL(/view=inbox/);
+    await expect(page.getByTestId("daemon-chip")).toContainText("home");
+    await expect(page.getByRole("heading", { name: "Inbox" })).toBeVisible();
+    await expect(page.locator(".kata-request-error")).toBeHidden();
+    expect(work.state.seenPaths.some((path) => path.startsWith("GET /api/v1/events/stream"))).toBe(false);
+    await expect.poll(() => home.state.streams.size).toBeGreaterThan(0);
+  } finally {
+    releaseProjects();
     await server.stop();
     kataHome.restore();
     await home.close();
@@ -4747,6 +5238,7 @@ test("kata daemon switch clears stale task route when the target daemon has no t
     await expect(page.getByRole("alert")).toHaveCount(0);
     await expect(page.getByRole("region", { name: "Task detail" })).not.toContainText("Rake the yard");
   } finally {
+    await page.close();
     await server.stop();
     kataHome.restore();
     await home.close();
@@ -5332,6 +5824,98 @@ test("docs task links switch an accepted workspace to the folder-bound external 
     await page.goBack();
     await expect(page).toHaveURL(/\/docs\?folder=work-notes&doc=bound-link\.md/);
     await expect(page.getByRole("heading", { name: "Bound Link" })).toBeVisible();
+  } finally {
+    await server.stop();
+    kataHome.restore();
+    await home.close();
+    await work.close();
+  }
+});
+
+test("docs task links resolve distinct task IDs through the folder-bound external daemon", async ({ page }) => {
+  const homeProject = {
+    id: 101,
+    uid: "project-home",
+    name: "Home",
+    metadata: { area: "Personal", sidebar_order: 1 },
+    open_count: 1,
+  };
+  const workProject = {
+    id: 202,
+    uid: "project-work",
+    name: "Work",
+    metadata: { area: "Work", sidebar_order: 1 },
+    open_count: 1,
+  };
+  const home = await startKataBackend({
+    projects: [homeProject],
+    issues: [
+      issueSummary({
+        id: 1011,
+        uid: "issue-home",
+        project_id: homeProject.id,
+        project_uid: homeProject.uid,
+        project_name: homeProject.name,
+        short_id: "shared-1",
+        qualified_id: "Home#shared-1",
+        title: "Default daemon task",
+        body: "This task should not open from the bound docs folder.",
+        labels: ["home"],
+      }),
+    ],
+  });
+  const work = await startKataBackend({
+    projects: [workProject],
+    issues: [
+      issueSummary({
+        id: 2021,
+        uid: "issue-work",
+        project_id: workProject.id,
+        project_uid: workProject.uid,
+        project_name: workProject.name,
+        short_id: "shared-1",
+        qualified_id: "Work#shared-1",
+        title: "Bound daemon task",
+        body: "Opened through the folder daemon binding.",
+        labels: ["work"],
+      }),
+    ],
+  });
+  const kataHome = await configureKataHomeDaemons(
+    [
+      { name: "home", url: home.url },
+      { name: "work", url: work.url },
+    ],
+    "home",
+  );
+  const docsRoot = await createDocsFixture();
+  await writeFile(path.join(docsRoot, "bound-link.md"), ["# Bound Link", "", "Open #shared-1 here.", ""].join("\n"));
+  const server = await startIsolatedE2EServer();
+
+  try {
+    const res = await page.request.post(`${server.info.base_url}/api/v1/docs/folders`, {
+      data: {
+        id: "work-notes",
+        name: "Work Notes",
+        path: docsRoot,
+        daemon: "work",
+      },
+    });
+    expect(res.status()).toBe(201);
+    await expect(res.json()).resolves.toMatchObject({ folder: { daemon: "work" } });
+
+    await page.goto(`${server.info.base_url}/docs?folder=work-notes&doc=bound-link.md`);
+    await expect(page.getByRole("heading", { name: "Bound Link" })).toBeVisible();
+
+    await page.getByRole("link", { name: "#shared-1" }).click();
+
+    await expect(page).toHaveURL(/\/kata\?issue=issue-work/);
+    await expect(page.getByRole("region", { name: "Task detail" })).toContainText(
+      "Opened through the folder daemon binding.",
+    );
+    await expect.poll(() => work.state.seenPaths).toContain("GET /api/v1/issues?status=open");
+    await expect.poll(() => work.state.seenPaths).toContain("GET /api/v1/issues/issue-work");
+    expect(home.state.seenPaths).not.toContain("GET /api/v1/issues/issue-home");
   } finally {
     await server.stop();
     kataHome.restore();
@@ -6158,7 +6742,7 @@ test("kata detail title and description edit through the configured external dae
   }
 });
 
-test("kata complete dialog closes and reopens through the configured external daemon", async ({ page }) => {
+test("kata complete dialog closes through the configured external daemon", async ({ page }) => {
   const backend = await startKataBackend();
   const kataHome = await configureKataHome(backend.url);
   const server = await startIsolatedE2EServer();
@@ -6195,7 +6779,8 @@ test("kata complete dialog closes and reopens through the configured external da
     await dialog.getByPlaceholder(/What was done/).fill("Done via wire transfer");
     await dialog.getByRole("button", { name: "Complete" }).click();
 
-    await expect(detail.getByRole("button", { name: "Reopen" })).toBeVisible();
+    await expect(detail.getByText("Select a task")).toBeVisible();
+    await expect.poll(() => new URL(page.url()).searchParams.get("issue")).toBeNull();
     await expect(financeCount).toHaveText("0");
     await expect
       .poll(() => backend.state.seenPaths)
@@ -6206,14 +6791,53 @@ test("kata complete dialog closes and reopens through the configured external da
       closed_reason: "done",
       closed_message: "Done via wire transfer",
     });
+  } finally {
+    await server.stop();
+    kataHome.restore();
+    await backend.close();
+  }
+});
+
+test("kata closed task can be reopened from Logbook through the configured external daemon", async ({ page }) => {
+  const backend = await startKataBackend();
+  const kataHome = await configureKataHome(backend.url);
+  const server = await startIsolatedE2EServer();
+
+  try {
+    await page.goto(`${server.info.base_url}/kata?issue=issue-rent`);
+    const detail = page.getByRole("region", { name: "Task detail" });
+    await expect(detail.getByRole("heading", { name: "Pay rent" })).toBeVisible();
+
+    await detail.getByRole("button", { name: "Complete" }).click();
+    const dialog = page.getByRole("dialog", { name: "Complete task" });
+    await dialog.getByRole("button", { name: "Complete" }).click();
+    await expect(detail.getByText("Select a task")).toBeVisible();
+    await expect
+      .poll(
+        () =>
+          backend.state.seenPaths.filter((path) => path === "POST /api/v1/projects/1/issues/issue-rent/actions/close")
+            .length,
+      )
+      .toBe(1);
+
+    await page.getByRole("button", { name: "Logbook" }).click();
+    const taskList = page.locator(".kata-list");
+    await expect(page.getByRole("heading", { name: "Logbook" })).toBeVisible();
+    await taskList.getByRole("button", { name: /Pay rent/ }).click();
+    await expect(detail.getByRole("button", { name: "Reopen" })).toBeVisible();
 
     await detail.getByRole("button", { name: "Reopen" }).click();
-    await expect(detail.getByRole("button", { name: "Complete" })).toBeVisible();
-    await expect(financeCount).toHaveText("1");
+
+    await expect(detail.getByText("Select a task")).toBeVisible();
+    await expect(taskList.getByRole("button", { name: /Pay rent/ })).toHaveCount(0);
     await expect
-      .poll(() => backend.state.seenPaths)
-      .toContain("POST /api/v1/projects/1/issues/issue-rent/actions/reopen");
-    expect(issue?.status).toBe("open");
+      .poll(
+        () =>
+          backend.state.seenPaths.filter((path) => path === "POST /api/v1/projects/1/issues/issue-rent/actions/reopen")
+            .length,
+      )
+      .toBe(1);
+    expect(backend.state.issues.find((item) => item.uid === "issue-rent")?.status).toBe("open");
   } finally {
     await server.stop();
     kataHome.restore();
@@ -6239,7 +6863,8 @@ test("kata complete dialog submits alternate close reasons through the configure
     await dialog.getByPlaceholder(/What was done/).fill("  landlord switched autopay  ");
     await dialog.getByRole("button", { name: "Complete" }).click();
 
-    await expect(detail.getByRole("button", { name: "Reopen" })).toBeVisible();
+    await expect(detail.getByText("Select a task")).toBeVisible();
+    await expect.poll(() => new URL(page.url()).searchParams.get("issue")).toBeNull();
     const issue = backend.state.issues.find((item) => item.uid === "issue-rent");
     expect(issue?.metadata).toMatchObject({
       closed_reason: "wontfix",
@@ -6282,7 +6907,8 @@ test("kata overflow menu reveals checklist and deletes through the configured ex
     await expect(dialog.getByText("Email Susan re: Q3")).toBeVisible();
     await dialog.getByRole("button", { name: "Delete" }).click();
 
-    await expect(detail.getByRole("button", { name: "Reopen" })).toBeVisible();
+    await expect(detail.getByText("Select a task")).toBeVisible();
+    await expect.poll(() => new URL(page.url()).searchParams.get("issue")).toBeNull();
     await expect(kataCount).toHaveText("0");
     await expect.poll(() => backend.state.seenPaths).toContain("POST /api/v1/projects/2/issues/issue-q3/actions/close");
     const issue = backend.state.issues.find((item) => item.uid === "issue-q3");

--- a/frontend/tests/e2e-full/messages.spec.ts
+++ b/frontend/tests/e2e-full/messages.spec.ts
@@ -1410,19 +1410,39 @@ test("docs and messages keep local state while switching modes", async ({ page }
   }
 });
 
-test("messages browser back restores the selected Kata task", async ({ page }) => {
-  const fixture = await startConfiguredMessagesAndKataFixture(page, "kataback");
+test("Kata restoration preserves distinct browser history entries", async ({ page }) => {
+  const fixture = await startConfiguredMessagesAndKataFixture(page, "kataback", (kata) => {
+    const linkedIssue = kata.state.issues.find((issue) => issue.uid === "issue-q3");
+    expect(linkedIssue).toBeTruthy();
+    linkedIssue!.metadata = {
+      ...linkedIssue!.metadata,
+      mail_links: [
+        {
+          message_id: 101,
+          conversation_id: 501,
+          subject: "Project sync",
+          from: "sender-primary@example.com",
+          sent_at: "2026-05-15T10:00:00Z",
+          added_at: "2026-05-15T10:00:00Z",
+        },
+      ],
+    };
+  });
 
   try {
-    await page.goto(`${fixture.server.info.base_url}/kata?issue=issue-q3`);
+    await page.goto(`${fixture.server.info.base_url}/messages?q=project&message=101`);
+    await expect(page.getByRole("heading", { name: "Project sync", exact: true })).toBeVisible({ timeout: 8_000 });
+    const messagesURL = page.url();
+
+    const linkedTasks = page.getByRole("region", { name: "Linked tasks" });
+    await linkedTasks.getByRole("button", { name: /Kata#kat-7/ }).click();
+    await expect(page).toHaveURL(/\/kata\?issue=issue-q3$/);
     await expect(page.getByRole("region", { name: "Task detail" })).toContainText(
       "Confirm the Q3 project review agenda.",
-      { timeout: 8_000 },
     );
 
-    await appHeaderTab(page, "Messages").click();
-    await expect(page).toHaveURL(/\/messages$/);
-    await expect(page.getByRole("heading", { name: "Messages" })).toBeVisible();
+    await appHeaderTab(page, "Docs").click();
+    await expect(page).toHaveURL(/\/docs$/);
 
     await page.goBack();
     await expect(page).toHaveURL(/\/kata\?issue=issue-q3$/);
@@ -1430,9 +1450,17 @@ test("messages browser back restores the selected Kata task", async ({ page }) =
       "Confirm the Q3 project review agenda.",
     );
 
+    await page.goBack();
+    await expect(page).toHaveURL(messagesURL);
+    await expect(page.getByRole("heading", { name: "Project sync", exact: true })).toBeVisible();
+
     await page.goForward();
-    await expect(page).toHaveURL(/\/messages$/);
-    await expect(page.getByRole("heading", { name: "Messages" })).toBeVisible();
+    await expect(page).toHaveURL(/\/kata\?issue=issue-q3$/);
+    await expect(page.getByRole("region", { name: "Task detail" })).toContainText(
+      "Confirm the Q3 project review agenda.",
+    );
+    await page.goForward();
+    await expect(page).toHaveURL(/\/docs$/);
   } finally {
     await fixture.stop();
   }


### PR DESCRIPTION
- Preserve daemon-scoped Kata filters, view, and selected task when leaving and returning to Kata.
- Restore nested selections by revealing ancestors, expanding the hierarchy, and scrolling the task into view without stealing focus.
- Keep daemon switching and cursor catch-up transactional, with recoverable degraded-state handling.

<sup>generated by a clanker</sup>