### PR TITLE
fix: docs and kata popovers rendered transparent from a phantom token

### DIFF
--- a/context/ui-design-system.md
+++ b/context/ui-design-system.md
@@ -256,6 +256,8 @@ Intent:
 
 Before placing an overlay inside a split view, compact sidebar, drawer, or scrollable region, verify that it can extend past its trigger container without being cut off.
 
+Popover surface chrome (background, border, radius, shadow) comes from `kit-popover-card`; do not re-declare it in component-scoped styles. Scoped rules outrank the kit class, and a `var()` referencing an undefined token (there is no `--bg-elevated`) computes to transparent with no build-time error.
+
 ### GitHubLabels
 
 Use `GitHubLabels` for actual GitHub labels.

--- a/frontend/src/lib/components/docs/DocMarkdownEditor.svelte
+++ b/frontend/src/lib/components/docs/DocMarkdownEditor.svelte
@@ -119,7 +119,7 @@
           },
           ".cm-tooltip.cm-tooltip-autocomplete": {
             border: "1px solid var(--border-default)",
-            background: "var(--bg-elevated)",
+            background: "var(--bg-surface)",
             color: "var(--text-primary)",
             borderRadius: "var(--radius-md)",
             boxShadow: "var(--shadow-md)",

--- a/frontend/src/lib/components/docs/DocsWorkspace.menu-surface.browser.svelte.ts
+++ b/frontend/src/lib/components/docs/DocsWorkspace.menu-surface.browser.svelte.ts
@@ -1,0 +1,67 @@
+// Regression guard for the phantom --bg-elevated token: the docs menus
+// carried kit-popover-card but a scoped background override referencing
+// an undefined custom property computed to transparent and outranked the
+// kit surface. The generic kit-popover-card contract test renders the
+// bare class and cannot see scoped overrides, so this mounts the real
+// menus with the real stylesheet chain and asserts their computed
+// backgrounds resolve to the opaque shared surface.
+
+import { describe, expect, it, vi } from "vite-plus/test";
+import { page } from "vite-plus/test/browser";
+import { render } from "vitest-browser-svelte";
+
+import "../../../app.css";
+import { defaultDocsRoute, type DocsRoute } from "../../api/docs/route";
+import DocsWorkspace from "./DocsWorkspace.svelte";
+import { createMockDocsBackend } from "./docsTestBackend";
+
+function renderWorkspace(overrides: Partial<DocsRoute> = {}) {
+  const route: DocsRoute = { ...defaultDocsRoute, ...overrides };
+  return render(DocsWorkspace, {
+    props: { route, onRouteChange: vi.fn(), api: createMockDocsBackend() },
+  });
+}
+
+// Resolve what var(--bg-surface) computes to in the loaded theme so the
+// assertions catch both a transparent fallthrough and a menu that drifts
+// off the shared surface token.
+function resolvedSurfaceColor(): string {
+  const probe = document.createElement("div");
+  probe.style.backgroundColor = "var(--bg-surface)";
+  document.body.appendChild(probe);
+  try {
+    return getComputedStyle(probe).backgroundColor;
+  } finally {
+    probe.remove();
+  }
+}
+
+describe("docs menu surfaces (browser)", () => {
+  it("folder switcher menu computes to the opaque shared popover surface", async () => {
+    renderWorkspace();
+
+    const trigger = page.getByRole("button", { name: "Switch folder" });
+    await expect.element(trigger).toBeEnabled();
+    await trigger.click();
+
+    const menu = page.getByRole("listbox", { name: "Folders" });
+    await expect.element(menu).toBeVisible();
+    const background = getComputedStyle(menu.element()).backgroundColor;
+    expect(background).toMatch(/^rgb\(/);
+    expect(background).toBe(resolvedSurfaceColor());
+  });
+
+  it("file actions menu computes to the opaque shared popover surface", async () => {
+    renderWorkspace({ folder: "notes", doc: "README.md" });
+
+    const trigger = page.getByRole("button", { name: "File actions" });
+    await expect.element(trigger).toBeVisible();
+    await trigger.click();
+
+    const menu = page.getByRole("menu", { name: "File actions" });
+    await expect.element(menu).toBeVisible();
+    const background = getComputedStyle(menu.element()).backgroundColor;
+    expect(background).toMatch(/^rgb\(/);
+    expect(background).toBe(resolvedSurfaceColor());
+  });
+});

--- a/frontend/src/lib/components/docs/DocsWorkspace.svelte
+++ b/frontend/src/lib/components/docs/DocsWorkspace.svelte
@@ -1546,7 +1546,6 @@
     list-style: none;
     margin: 0;
     padding: 4px;
-    background: var(--bg-elevated);
     max-height: 320px;
     overflow: auto;
   }
@@ -1859,7 +1858,6 @@
     margin: 0;
     padding: 4px;
     min-width: 160px;
-    background: var(--bg-elevated);
   }
 
   .file-menu-item {
@@ -1956,7 +1954,6 @@
     right: 16px;
     z-index: 50;
     padding: 8px 14px;
-    background: var(--bg-elevated);
     color: var(--text-primary);
     font-size: var(--font-size-sm);
   }

--- a/frontend/src/lib/components/docs/FolderTree.svelte
+++ b/frontend/src/lib/components/docs/FolderTree.svelte
@@ -255,7 +255,6 @@
   :global(.folder-tree-context-menu) {
     min-width: 140px;
     padding: 4px;
-    background: var(--bg-elevated);
     font-size: var(--font-size-sm);
   }
   :global(.folder-tree-context-menu-item) {

--- a/frontend/src/lib/components/docs/FolderTree.svelte
+++ b/frontend/src/lib/components/docs/FolderTree.svelte
@@ -243,6 +243,12 @@
 
     --trees-search-fg-override: var(--text-primary);
     --trees-search-bg-override: var(--bg-inset);
+    /* The library defaults to a 16px inline gutter; the rest of the
+       docs sidebar (folder chip header, folder dropdown) sits on the
+       app's 8px gutter. This variable drives both the search row and
+       the tree's scroll container, so they stay aligned with each
+       other while matching the header. */
+    --trees-padding-inline-override: 8px;
 
     --trees-selected-fg-override: var(--text-primary);
     --trees-selected-bg-override: var(--bg-surface-hover);

--- a/frontend/src/lib/components/kata/KataIssueList.svelte
+++ b/frontend/src/lib/components/kata/KataIssueList.svelte
@@ -834,7 +834,7 @@
     padding: 0 8px;
     border: 1px solid var(--border-default);
     border-radius: var(--radius-sm);
-    background: var(--bg-elevated);
+    background: var(--bg-surface);
     color: var(--text-secondary);
     font-size: var(--font-size-xs);
     font-weight: 500;


### PR DESCRIPTION
The docs file-actions "…" menu and folder switcher dropped their local popover chrome for the shared `kit-popover-card` class, but kept a scoped `background: var(--bg-elevated)` override — a token that has never been defined in this repo or in kit-ui. The invalid declaration computes to transparent and outranks the kit class's opaque surface, so the menus drew see-through over the tree and outline behind them.

- Docs file-actions menu, folder switcher, tree context menu, and publish toast now use the standard `kit-popover-card` surface unopposed.
- Kata tree-action buttons and the docs editor autocomplete tooltip swap the phantom token for `--bg-surface` (no kit class applies there).
- The docs sidebar tree search row now sits on the sidebar's 8px gutter instead of the @pierre/trees 16px default, aligning it with the folder chip header.

| File actions menu | Folder switcher | Sidebar search |
|---|---|---|
| ![docs-file-menu.png](https://github.com/user-attachments/assets/2995398e-436a-45e4-85f3-5f51d51acb1d) | ![docs-folder-menu.png](https://github.com/user-attachments/assets/0ac145d6-eda0-40c1-94f1-75c71462c0af) | ![docs-sidebar-search.png](https://github.com/user-attachments/assets/3029ba9a-9753-4284-b12e-cdf2f5740130) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)