### PR TITLE
fix: persist GitHub repo default branch so worktree diff stats have a base

### DIFF
--- a/context/platform-sync-invariants.md
+++ b/context/platform-sync-invariants.md
@@ -137,7 +137,12 @@ registry helpers return typed errors for missing providers or capabilities.
   path.
 - Provider-supplied web URLs, clone URLs, default branches, platform ids, and
   external ids should be persisted when available instead of reconstructed from
-  host/owner/name.
+  host/owner/name. Every settings-refresh branch must write this metadata:
+  repo resolution pre-fills the platform repo id, so the identity sync never
+  re-resolves the repository and whichever refresh branch runs is the row's
+  only metadata writer. A branch that skips the write leaves default_branch
+  empty forever, which silently degrades the worktree diff sampler to a bare
+  HEAD diff (0/0 sidebar stats).
 
 ## Label Catalogs And Mutations
 

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -3772,6 +3772,21 @@ func (s *Syncer) refreshRepoSettings(
 			)
 			return
 		}
+		// This branch is the only settings refresh most GitHub repos ever
+		// take (resolution pre-fills the platform repo id, so resolvedRepo
+		// is nil), so it must persist provider metadata too — otherwise a
+		// newly discovered repo keeps an empty default branch and the
+		// worktree diff sampler degrades to a bare HEAD diff.
+		if err := s.db.UpdateRepoProviderMetadata(ctx, repoID, db.RepoProviderMetadata{
+			PlatformRepoID: ghRepo.GetNodeID(),
+			WebURL:         ghRepo.GetHTMLURL(),
+			CloneURL:       ghRepo.GetCloneURL(),
+			DefaultBranch:  ghRepo.GetDefaultBranch(),
+		}); err != nil {
+			slog.Warn("update repo provider metadata failed",
+				"repo", repo.Owner+"/"+repo.Name, "err", err,
+			)
+		}
 		if canMerge := gitHubViewerCanMerge(ghRepo); canMerge != nil {
 			_ = s.db.UpdateRepoSettings(ctx, repoID,
 				ghRepo.GetAllowSquashMerge(),

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -5543,6 +5543,58 @@ func TestSyncRepoUpdatesViewerCanMergeWithoutMergeSettings(t *testing.T) {
 	assert.False(repos[0].ViewerCanMerge)
 }
 
+func TestRefreshRepoSettingsPersistsGitHubProviderMetadata(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	// The modern resolution path pre-fills the platform repo id, so
+	// syncRepoIdentity never resolves the repository itself and
+	// refreshRepoSettings receives resolvedRepo == nil. Provider metadata
+	// must still be persisted from the GitHub settings fetch, or the row
+	// keeps an empty default branch forever and downstream consumers (the
+	// worktree diff sampler) fall back to a bare HEAD diff.
+	repoID, err := d.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "R_kgDOexample",
+		Owner:          "acme",
+		Name:           "widgets",
+		RepoPath:       "acme/widgets",
+	})
+	require.NoError(err)
+	client := &mockClient{getRepositoryFn: func(
+		context.Context,
+		string,
+		string,
+	) (*gh.Repository, error) {
+		return &gh.Repository{
+			Name:          new("widgets"),
+			NodeID:        new("R_kgDOexample"),
+			HTMLURL:       new("https://github.com/acme/widgets"),
+			CloneURL:      new("https://github.com/acme/widgets.git"),
+			DefaultBranch: new("main"),
+		}, nil
+	}}
+	syncer := NewSyncer(map[string]Client{"github.com": client}, d, nil, []RepoRef{{
+		Platform:     platform.KindGitHub,
+		PlatformHost: "github.com",
+		Owner:        "acme",
+		Name:         "widgets",
+		RepoPath:     "acme/widgets",
+	}}, time.Minute, nil, nil)
+
+	syncer.refreshRepoSettings(ctx, syncer.repos[0], repoID, nil)
+
+	repos, err := d.ListRepos(ctx)
+	require.NoError(err)
+	require.Len(repos, 1)
+	assert.Equal("main", repos[0].DefaultBranch)
+	assert.Equal("https://github.com/acme/widgets", repos[0].WebURL)
+	assert.Equal("https://github.com/acme/widgets.git", repos[0].CloneURL)
+	assert.Equal("R_kgDOexample", repos[0].PlatformRepoID)
+}
+
 func TestRefreshRepoSettingsPreservesViewerCanMergeWhenGitHubOmitsPermissions(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -5543,26 +5543,25 @@ func TestSyncRepoUpdatesViewerCanMergeWithoutMergeSettings(t *testing.T) {
 	assert.False(repos[0].ViewerCanMerge)
 }
 
-func TestRefreshRepoSettingsPersistsGitHubProviderMetadata(t *testing.T) {
+func TestSyncRepoPersistsGitHubProviderMetadataWhenIdentityPrefilled(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	ctx := t.Context()
 	d := openTestDB(t)
-	// The modern resolution path pre-fills the platform repo id, so
-	// syncRepoIdentity never resolves the repository itself and
-	// refreshRepoSettings receives resolvedRepo == nil. Provider metadata
-	// must still be persisted from the GitHub settings fetch, or the row
-	// keeps an empty default branch forever and downstream consumers (the
-	// worktree diff sampler) fall back to a bare HEAD diff.
-	repoID, err := d.UpsertRepoByProviderID(ctx, db.RepoIdentity{
-		Platform:       "github",
-		PlatformHost:   "github.com",
-		PlatformRepoID: "R_kgDOexample",
-		Owner:          "acme",
-		Name:           "widgets",
-		RepoPath:       "acme/widgets",
-	})
-	require.NoError(err)
+	// Repo resolution (glob listing and explicit lookup) pre-fills the
+	// platform repo id, so syncRepoIdentity never resolves the repository
+	// itself and the GitHub settings-refresh branch is the row's only
+	// metadata writer. It must persist provider metadata from its own
+	// settings fetch, or the row keeps an empty default branch forever and
+	// the worktree diff sampler degrades to a bare HEAD diff.
+	repo := RepoRef{
+		Platform:           platform.KindGitHub,
+		PlatformHost:       "github.com",
+		Owner:              "acme",
+		Name:               "widgets",
+		RepoPath:           "acme/widgets",
+		PlatformExternalID: "R_kgDOexample",
+	}
 	client := &mockClient{getRepositoryFn: func(
 		context.Context,
 		string,
@@ -5576,15 +5575,10 @@ func TestRefreshRepoSettingsPersistsGitHubProviderMetadata(t *testing.T) {
 			DefaultBranch: new("main"),
 		}, nil
 	}}
-	syncer := NewSyncer(map[string]Client{"github.com": client}, d, nil, []RepoRef{{
-		Platform:     platform.KindGitHub,
-		PlatformHost: "github.com",
-		Owner:        "acme",
-		Name:         "widgets",
-		RepoPath:     "acme/widgets",
-	}}, time.Minute, nil, nil)
+	syncer := NewSyncer(map[string]Client{"github.com": client}, d, nil,
+		[]RepoRef{repo}, time.Minute, nil, nil)
 
-	syncer.refreshRepoSettings(ctx, syncer.repos[0], repoID, nil)
+	require.NoError(syncer.syncRepo(ctx, repo))
 
 	repos, err := d.ListRepos(ctx)
 	require.NoError(err)

--- a/internal/server/e2etest/fleet_snapshot_diff_stats_test.go
+++ b/internal/server/e2etest/fleet_snapshot_diff_stats_test.go
@@ -1,0 +1,158 @@
+package e2etest
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	gh "github.com/google/go-github/v88/github"
+	"github.com/stretchr/testify/require"
+	gitcmd "go.kenn.io/kit/git/cmd"
+
+	"go.kenn.io/middleman/internal/config"
+	dbpkg "go.kenn.io/middleman/internal/db"
+	"go.kenn.io/middleman/internal/fleet"
+	ghclient "go.kenn.io/middleman/internal/github"
+	"go.kenn.io/middleman/internal/platform"
+	"go.kenn.io/middleman/internal/server"
+	"go.kenn.io/middleman/internal/testutil"
+	"go.kenn.io/middleman/internal/testutil/dbtest"
+)
+
+// repoMetadataClient wraps the fixture client so GetRepository reports the
+// provider metadata a real GitHub response carries. Local to this test so the
+// shared fixture client's seeded e2e behavior is unchanged.
+type repoMetadataClient struct {
+	ghclient.Client
+}
+
+func (c repoMetadataClient) GetRepository(
+	ctx context.Context, owner, repo string,
+) (*gh.Repository, error) {
+	r, err := c.Client.GetRepository(ctx, owner, repo)
+	if err != nil {
+		return nil, err
+	}
+	r.DefaultBranch = new("main")
+	r.HTMLURL = new("https://github.com/" + owner + "/" + repo)
+	r.CloneURL = new("https://github.com/" + owner + "/" + repo + ".git")
+	return r, nil
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	runner := gitcmd.New().WithConfig("init.defaultBranch", "main")
+	out, stderr, err := runner.Run(t.Context(), dir, nil, args...)
+	require.NoError(t, err, "git %v failed: %s%s", args, out, stderr)
+}
+
+// TestFleetSnapshotBranchDiffForSyncedRepoE2E covers the full chain behind the
+// workspace sidebar's +/- chips: a GitHub sync with a pre-resolved repo
+// identity persists the provider default branch, the worktree stats sampler
+// resolves an orphan workspace's diff base from that synced row, and the
+// snapshot API reports the branch-relative diff counts. A regression anywhere
+// in that wiring reproduces the user-visible failure where committed work
+// sampled 0/0 because the repo row had no default branch.
+func TestFleetSnapshotBranchDiffForSyncedRepoE2E(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	require := require.New(t)
+	ctx := context.Background()
+
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init", "-q")
+	runGit(t, repoDir, "config", "user.email", "t@e.st")
+	runGit(t, repoDir, "config", "user.name", "Tester")
+	require.NoError(os.WriteFile(
+		filepath.Join(repoDir, "base.txt"), []byte("base\n"), 0o644,
+	))
+	runGit(t, repoDir, "add", ".")
+	runGit(t, repoDir, "commit", "-m", "base")
+
+	featDir := filepath.Join(t.TempDir(), "feat")
+	runGit(t, repoDir, "worktree", "add", "-b", "feature", featDir)
+	require.NoError(os.WriteFile(
+		filepath.Join(featDir, "feature.txt"), []byte("x\ny\n"), 0o644,
+	))
+	runGit(t, featDir, "add", ".")
+	runGit(t, featDir, "commit", "-m", "feature work")
+
+	database := dbtest.Open(t)
+	// The pre-filled external id reproduces the modern resolution shape:
+	// syncRepoIdentity short-circuits and the settings refresh is the only
+	// path that can persist the default branch.
+	repoRef := ghclient.RepoRef{
+		Platform:           platform.KindGitHub,
+		PlatformHost:       "github.com",
+		Owner:              "acme",
+		Name:               "widgets",
+		RepoPath:           "acme/widgets",
+		PlatformExternalID: "repo-acme-widgets",
+	}
+	client := repoMetadataClient{Client: testutil.NewFixtureClient()}
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": client}, database, nil,
+		[]ghclient.RepoRef{repoRef}, time.Minute, nil, nil,
+	)
+	t.Cleanup(syncer.Stop)
+	syncer.RunOnce(ctx)
+
+	repoRow, err := database.GetRepoByIdentity(
+		ctx, dbpkg.GitHubRepoIdentity("github.com", "acme", "widgets"),
+	)
+	require.NoError(err)
+	require.NotNil(repoRow)
+	require.Equal("main", repoRow.DefaultBranch,
+		"sync must persist the provider default branch for a pre-resolved repo")
+
+	// Orphan workspace: no registered project, so the sampler's diff base
+	// comes from the synced repo row alone.
+	require.NoError(database.InsertWorkspace(ctx, &dbpkg.Workspace{
+		ID: "ws-diff", Platform: "github", PlatformHost: "github.com",
+		RepoOwner: "acme", RepoName: "widgets",
+		ItemType: dbpkg.WorkspaceItemTypePullRequest, ItemNumber: 7,
+		GitHeadRef: "feature", WorktreePath: featDir, Status: "ready",
+	}))
+
+	cfg := &config.Config{BasePath: "/"}
+	cfg.Tmux.Command = []string{"middleman-no-such-tmux"}
+	srv := server.New(database, syncer, nil, "/", cfg, server.ServerOptions{
+		WorktreeDir:                        t.TempDir(),
+		DisableWorkspaceBackgroundMonitors: true,
+		HostCheck: server.HostCheckOptions{
+			Bind:                 config.HostKey{Host: "127.0.0.1", Port: "8091"},
+			AllowLoopbackAnyPort: true,
+		},
+	})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	status, body := postJSON(
+		t, ts.Client(), ts.URL+"/api/v1/snapshot/refresh-stats", nil,
+	)
+	require.Equal(http.StatusOK, status, "refresh-stats: %s", body)
+
+	var snap fleet.Snapshot
+	getJSON(t, ts, "/api/v1/snapshot", &snap)
+	var wt *fleet.WorktreeSummary
+	for i := range snap.Worktrees {
+		if snap.Worktrees[i].LinkedPRNumber != nil &&
+			*snap.Worktrees[i].LinkedPRNumber == 7 {
+			wt = &snap.Worktrees[i]
+			break
+		}
+	}
+	require.NotNil(wt, "orphan workspace worktree present in snapshot")
+	require.NotNil(wt.DiffAdded, "sampled worktree surfaces diff counts")
+	require.Equal(2, *wt.DiffAdded,
+		"diff must be measured against the synced default branch, not HEAD")
+	require.NotNil(wt.DiffRemoved)
+	require.Equal(0, *wt.DiffRemoved)
+}


### PR DESCRIPTION
Workspace sidebar +/- diff chips showed 0/0 for any workspace on a recently discovered repo, no matter how many commits its branch carried. Every GitHub repo row created since early July had an empty `default_branch` (also `web_url`/`clone_url`), because repo resolution now pre-fills the platform repo id: `syncRepoIdentity` never re-resolves the repository, so the GitHub branch of `refreshRepoSettings` is the only settings refresh those repos ever take — and it persisted merge settings while dropping the provider metadata already present in the fetched response. With no default branch, the worktree stats sampler's merge-base cascade degrades to a bare `HEAD` diff and stores a confident 0/0 sample for a clean worktree.

- GitHub settings refresh now persists provider metadata (default branch, web/clone URLs, platform repo id) from the response it already fetches — no extra API spend
- Existing empty repo rows self-heal on the next sync pass; diff chips recover on the following sampler pass
- Context doc records why every settings-refresh branch must write this metadata

Verified against a live database: a workspace whose real whole-branch diff was +456 had a stored 0/0 sample and an empty repo `default_branch`; the new regression test reproduces the pre-filled-identity flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sup>generated by a clanker</sup>