### PR TITLE
Align org-name visibility across sidebars

### DIFF
--- a/cmd/e2e-server/main.go
+++ b/cmd/e2e-server/main.go
@@ -632,6 +632,24 @@ func seedGiteaProviderCollisionFixture(
 	if err != nil {
 		return fmt.Errorf("upsert gitea collision repo: %w", err)
 	}
+	if _, err := database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:             repoID,
+		PlatformID:         9102,
+		PlatformExternalID: "gitea-acme-widgets-902",
+		Number:             902,
+		URL:                "https://github.com/acme/widgets/pulls/902",
+		Title:              "Gitea provider collision pull request",
+		Author:             "gina",
+		AuthorDisplayName:  "Gina",
+		State:              "open",
+		HeadBranch:         "provider-collision",
+		BaseBranch:         "main",
+		CreatedAt:          issue.CreatedAt,
+		UpdatedAt:          issue.UpdatedAt,
+		LastActivityAt:     issue.LastActivityAt,
+	}); err != nil {
+		return fmt.Errorf("upsert gitea collision pull request: %w", err)
+	}
 	if _, err := database.UpsertIssue(ctx, &db.Issue{
 		RepoID:             repoID,
 		PlatformID:         issue.PlatformID,

--- a/docs/superpowers/plans/2026-07-14-sidebar-org-name-visibility.md
+++ b/docs/superpowers/plans/2026-07-14-sidebar-org-name-visibility.md
@@ -13,6 +13,7 @@
 - Keep PR/issue/activity on `middleman:hideOrgName`.
 - Keep workspace display persistence independent.
 - Preserve provider/host disambiguation when organization names are hidden.
+- Keep repository chip color tied to full repository identity when display labels change.
 - Use existing shared filter and repository-label primitives.
 
 ---
@@ -41,6 +42,7 @@
 - Modify: `packages/ui/src/components/sidebar/IssueList.svelte`
 - Modify: `packages/ui/src/components/sidebar/PullItem.svelte`
 - Modify: `packages/ui/src/components/sidebar/IssueItem.svelte`
+- Modify: `packages/ui/src/views/FocusListView.svelte`
 
 **Interfaces:**
 
@@ -52,6 +54,8 @@
 - [x] Build a repository-label formatter from the visible PRs/issues and use it for grouped headers and flat/workflow row repo chips.
 - [x] Replace each item component's locally concatenated owner/repo label with its parent-provided collision-safe `repoLabel` prop.
 - [x] Run the focused browser test and confirm PR/issue assertions pass.
+- [x] Keep issue visibility reachable above and below its compact breakpoint, with full-stack responsive coverage.
+- [x] Cover compact badge/reset behavior and workspace active-state polarity.
 
 ### Task 3: Normalize the workspace menu wording
 

--- a/docs/superpowers/plans/2026-07-14-sidebar-org-name-visibility.md
+++ b/docs/superpowers/plans/2026-07-14-sidebar-org-name-visibility.md
@@ -56,6 +56,7 @@
 - [x] Run the focused browser test and confirm PR/issue assertions pass.
 - [x] Keep issue visibility reachable above and below its compact breakpoint, with full-stack responsive coverage.
 - [x] Cover compact badge/reset behavior and workspace active-state polarity.
+- [x] Apply the shared formatter to responsive focus/mobile lists and cover both item types in full-stack mobile tests.
 
 ### Task 3: Normalize the workspace menu wording
 

--- a/docs/superpowers/plans/2026-07-14-sidebar-org-name-visibility.md
+++ b/docs/superpowers/plans/2026-07-14-sidebar-org-name-visibility.md
@@ -1,0 +1,86 @@
+# Sidebar Organization-Name Visibility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose a consistently named **Hide org name** control in PR, issue, and workspace sidebar menus and make each sidebar render labels from its persisted preference.
+
+**Architecture:** PR and issue menus use the existing shared grouping preference and the shared collision-safe repository label formatter. The workspace menu keeps its independent display preference but presents the same positive “Hide org name” wording and active-state polarity.
+
+**Tech Stack:** Svelte 5, TypeScript, `@kenn-io/kit-ui` `FilterDropdown`, Vitest browser/jsdom, Playwright full-stack tests.
+
+## Global Constraints
+
+- Keep PR/issue/activity on `middleman:hideOrgName`.
+- Keep workspace display persistence independent.
+- Preserve provider/host disambiguation when organization names are hidden.
+- Use existing shared filter and repository-label primitives.
+
+---
+
+### Task 1: Pin the sidebar menu behavior with failing tests
+
+**Files:**
+
+- Modify: `frontend/src/App.grouping-toggle.browser.svelte.ts`
+- Modify: `frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts`
+
+**Interfaces:**
+
+- Consumes: existing app browser harness and `FilterDropdown` accessible button labels.
+- Produces: regression coverage for the shared PR/issue preference and workspace inverse-label behavior.
+
+- [x] Add browser assertions that PR and issue compact filter menus contain **Hide org name**, that selecting it hides the owner portion of visible repository labels, and that the state persists when moving between PR and issue routes.
+- [x] Update workspace tests to query **Hide org name**, assert it starts inactive when `showOrgNames` is true, and assert selection hides organization names.
+- [x] Run the focused browser and workspace tests from `frontend/` and confirm the new assertions fail because the controls or wording are absent.
+
+### Task 2: Implement shared PR and issue visibility controls
+
+**Files:**
+
+- Modify: `packages/ui/src/components/sidebar/PullList.svelte`
+- Modify: `packages/ui/src/components/sidebar/IssueList.svelte`
+- Modify: `packages/ui/src/components/sidebar/PullItem.svelte`
+- Modify: `packages/ui/src/components/sidebar/IssueItem.svelte`
+
+**Interfaces:**
+
+- Consumes: `grouping.getHideOrgName()`, `grouping.setHideOrgName(boolean)`, and `createRepoLabelFormatter(repos, { showOrgNames })`.
+- Produces: `repoLabel: string` props for PR/issue rows and collision-safe group labels.
+
+- [x] Add a Visibility section containing an item with `id: "hide-org-name"`, `label: "Hide org name"`, `active: grouping.getHideOrgName()`, and a selector that toggles the preference.
+- [x] Include this preference in compact-menu changed-state, count, and reset behavior.
+- [x] Build a repository-label formatter from the visible PRs/issues and use it for grouped headers and flat/workflow row repo chips.
+- [x] Replace each item component's locally concatenated owner/repo label with its parent-provided collision-safe `repoLabel` prop.
+- [x] Run the focused browser test and confirm PR/issue assertions pass.
+
+### Task 3: Normalize the workspace menu wording
+
+**Files:**
+
+- Modify: `frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte`
+- Modify: `frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts`
+
+**Interfaces:**
+
+- Consumes: existing `displayOptions.showOrgNames` boolean.
+- Produces: a checked **Hide org name** item when `showOrgNames` is false.
+
+- [x] Rename the item id to `hide-org-name`, label it **Hide org name**, describe the hidden state, and invert its `active` value while retaining the existing toggle callback.
+- [x] Run the focused workspace test and confirm its menu and rendering assertions pass.
+
+### Task 4: Validate and commit
+
+**Files:**
+
+- Modify: `docs/superpowers/specs/2026-07-14-sidebar-org-name-visibility-design.md` only if implementation disproves a factual assumption.
+- Modify: this plan to check completed steps.
+
+**Interfaces:**
+
+- Consumes: repository frontend validation commands.
+- Produces: a hook-verified implementation commit.
+
+- [x] Run `./node_modules/.bin/vp exec svelte-mcp svelte-autofixer` for every changed `.svelte` file and address actionable findings.
+- [x] Run the focused tests, then the full frontend `vp test` suite because frontend behavior changed.
+- [x] Run `make frontend-check-no-deps`.
+- [x] Review `git diff`, run the context-sync stop decision, and commit all scoped files with hooks enabled.

--- a/docs/superpowers/specs/2026-07-14-sidebar-org-name-visibility-design.md
+++ b/docs/superpowers/specs/2026-07-14-sidebar-org-name-visibility-design.md
@@ -12,6 +12,7 @@ Make organization-name visibility controllable from the PR, issue, and workspace
 - The workspace view menu labels its existing inverse control **Hide org name** and keeps using the workspace list's existing persisted display preference.
 - Selecting an item immediately updates repository labels in that sidebar.
 - PR and issue compact filter menus include the visibility item. Their changed-state indicator and reset behavior account for it.
+- The issue visibility item remains reachable in both compact and expanded sidebar layouts.
 - Existing sidebar layout, grouping, state filters, and workspace sort behavior remain unchanged.
 
 ## Components and data flow
@@ -19,6 +20,8 @@ Make organization-name visibility controllable from the PR, issue, and workspace
 `PullList.svelte` and `IssueList.svelte` add a Visibility section to their filter-section definitions. The item reads `grouping.getHideOrgName()` and toggles it through `grouping.setHideOrgName()`.
 
 PR and issue lists format their group headers and per-item repo chips through the shared collision-safe repository-label formatter, so no new store or persistence key is needed.
+
+Repository chip color remains keyed to the full provider, host, and repository identity rather than the shortened display label.
 
 `WorkspaceListSidebar.svelte` continues to use `displayOptions.showOrgNames`; only the menu-facing label, identifier, description, and active-state polarity change. This avoids coupling workspace display preferences to the global PR/issue/activity preference.
 

--- a/docs/superpowers/specs/2026-07-14-sidebar-org-name-visibility-design.md
+++ b/docs/superpowers/specs/2026-07-14-sidebar-org-name-visibility-design.md
@@ -1,0 +1,38 @@
+# Sidebar organization-name visibility
+
+## Goal
+
+Make organization-name visibility controllable from the PR, issue, and workspace sidebars so maintainers can adjust repository-label density where they are working.
+
+## Behavior
+
+- The PR filter menu includes a **Hide org name** visibility item.
+- The issue filter menu includes the same item.
+- Both items use the existing persisted `middleman:hideOrgName` preference already used by activity and provider-item rendering.
+- The workspace view menu labels its existing inverse control **Hide org name** and keeps using the workspace list's existing persisted display preference.
+- Selecting an item immediately updates repository labels in that sidebar.
+- PR and issue compact filter menus include the visibility item. Their changed-state indicator and reset behavior account for it.
+- Existing sidebar layout, grouping, state filters, and workspace sort behavior remain unchanged.
+
+## Components and data flow
+
+`PullList.svelte` and `IssueList.svelte` add a Visibility section to their filter-section definitions. The item reads `grouping.getHideOrgName()` and toggles it through `grouping.setHideOrgName()`.
+
+PR and issue label rendering already consumes the grouping preference through the shared repository-label path, so no new store or persistence key is needed.
+
+`WorkspaceListSidebar.svelte` continues to use `displayOptions.showOrgNames`; only the menu-facing label, identifier, description, and active-state polarity change. This avoids coupling workspace display preferences to the global PR/issue/activity preference.
+
+## Accessibility and interaction
+
+The existing `FilterDropdown` menu semantics, keyboard handling, focus behavior, and active checkmark remain the interaction contract. The active state means the stated action is enabled: a checked **Hide org name** item corresponds to hidden organization names.
+
+## Testing
+
+Focused component tests will verify that:
+
+- PR and issue filter menus expose **Hide org name**.
+- Selecting it toggles the shared preference and updates visible repository labels.
+- Workspace exposes the renamed control with the correct active polarity and still updates grouped and flat labels.
+- Compact-menu changed-state/reset behavior includes the PR and issue visibility preference.
+
+The affected frontend test suite and Svelte validation will run after the final edit.

--- a/docs/superpowers/specs/2026-07-14-sidebar-org-name-visibility-design.md
+++ b/docs/superpowers/specs/2026-07-14-sidebar-org-name-visibility-design.md
@@ -18,7 +18,7 @@ Make organization-name visibility controllable from the PR, issue, and workspace
 
 `PullList.svelte` and `IssueList.svelte` add a Visibility section to their filter-section definitions. The item reads `grouping.getHideOrgName()` and toggles it through `grouping.setHideOrgName()`.
 
-PR and issue label rendering already consumes the grouping preference through the shared repository-label path, so no new store or persistence key is needed.
+PR and issue lists format their group headers and per-item repo chips through the shared collision-safe repository-label formatter, so no new store or persistence key is needed.
 
 `WorkspaceListSidebar.svelte` continues to use `displayOptions.showOrgNames`; only the menu-facing label, identifier, description, and active-state polarity change. This avoids coupling workspace display preferences to the global PR/issue/activity preference.
 

--- a/docs/superpowers/specs/2026-07-14-sidebar-org-name-visibility-design.md
+++ b/docs/superpowers/specs/2026-07-14-sidebar-org-name-visibility-design.md
@@ -13,6 +13,7 @@ Make organization-name visibility controllable from the PR, issue, and workspace
 - Selecting an item immediately updates repository labels in that sidebar.
 - PR and issue compact filter menus include the visibility item. Their changed-state indicator and reset behavior account for it.
 - The issue visibility item remains reachable in both compact and expanded sidebar layouts.
+- Responsive focus and mobile PR/issue lists use the same preference and collision-safe labels.
 - Existing sidebar layout, grouping, state filters, and workspace sort behavior remain unchanged.
 
 ## Components and data flow

--- a/frontend/src/App.grouping-toggle.browser.svelte.ts
+++ b/frontend/src/App.grouping-toggle.browser.svelte.ts
@@ -228,6 +228,25 @@ async function selectPullGrouping(label: string): Promise<void> {
   await page.elementLocator(item!).click();
 }
 
+async function selectCompactFilterItem(label: string): Promise<void> {
+  await vi.waitFor(
+    () => expect(document.querySelector(".compact-filter-menu .kit-filter-dropdown__btn")).not.toBeNull(),
+    WAIT,
+  );
+  if (!document.querySelector(".compact-filter-menu .kit-filter-dropdown__panel")) {
+    await page.elementLocator(document.querySelector(".compact-filter-menu .kit-filter-dropdown__btn")!).click();
+  }
+  await vi.waitFor(
+    () => expect(document.querySelector(".compact-filter-menu .kit-filter-dropdown__panel")).not.toBeNull(),
+    WAIT,
+  );
+  const item = Array.from(document.querySelectorAll(".compact-filter-menu .kit-filter-dropdown__item")).find((el) =>
+    (el.textContent ?? "").includes(label),
+  );
+  expect(item).toBeDefined();
+  await page.elementLocator(item!).click();
+}
+
 function compactPullGroupingLabel(label: string): string {
   if (label === "Repo") return "By repo";
   if (label === "Status") return "By status";
@@ -329,6 +348,30 @@ describe("grouping toggle", () => {
     await vi.waitFor(() => expect(document.querySelector(".issue-item")).not.toBeNull(), WAIT);
     expect(count(".sidebar-group-header")).toBe(0);
     expect(document.querySelector(".repo-chip")).not.toBeNull();
+  });
+
+  it("PR and issue filters share the hide org name preference", async () => {
+    await mountPulls();
+    await selectPullGrouping("All");
+    await vi.waitFor(
+      () => expect(document.querySelector(".repo-chip")?.textContent?.trim()).toBe("acme/widgets"),
+      WAIT,
+    );
+
+    await selectCompactFilterItem("Hide org name");
+    await vi.waitFor(() => expect(document.querySelector(".repo-chip")?.textContent?.trim()).toBe("widgets"), WAIT);
+    expect(localStorage.getItem("middleman:hideOrgName")).toBe("1");
+
+    mounted?.unmount();
+    mounted = await mountBrowserApp("/issues", { overrides: overrides() });
+    await vi.waitFor(() => expect(document.querySelector(".issue-item")).not.toBeNull(), WAIT);
+    expect(document.querySelector(".repo-chip")?.textContent?.trim()).toBe("widgets");
+
+    await selectCompactFilterItem("Hide org name");
+    await vi.waitFor(
+      () => expect(document.querySelector(".repo-chip")?.textContent?.trim()).toBe("acme/widgets"),
+      WAIT,
+    );
   });
 
   it("toggle syncs into the threaded activity view", async () => {

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -222,10 +222,10 @@
       title: "Visibility",
       items: [
         {
-          id: "show-org-names",
-          label: "Show org names",
-          description: "Include owner or organization names in workspace repo labels.",
-          active: displayOptions.showOrgNames,
+          id: "hide-org-name",
+          label: "Hide org name",
+          description: "Hide owner or organization names in workspace repo labels.",
+          active: !displayOptions.showOrgNames,
           onSelect: () =>
             setDisplayOption(
               "showOrgNames",

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
@@ -942,7 +942,7 @@ describe("WorkspaceListSidebar", () => {
     expect(screen.getByRole("button", { name: "Created" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Activity" })).toBeTruthy();
     expect(screen.getByText("Visibility")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Show org names" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Hide org name" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Show PR diff stats" })).toBeTruthy();
   });
 
@@ -957,7 +957,7 @@ describe("WorkspaceListSidebar", () => {
     await screen.findByText("kenn-io/middleman");
 
     await fireEvent.click(screen.getByRole("button", { name: "View" }));
-    await fireEvent.click(screen.getByRole("button", { name: "Show org names" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Hide org name" }));
 
     expect(screen.queryByText("kenn-io/middleman")).toBeNull();
     expect(screen.getByText("middleman")).toBeTruthy();
@@ -1012,7 +1012,7 @@ describe("WorkspaceListSidebar", () => {
     await screen.findByText("GitHub acme widgets");
 
     await fireEvent.click(screen.getByRole("button", { name: "View" }));
-    await fireEvent.click(screen.getByRole("button", { name: "Show org names" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Hide org name" }));
 
     expect(
       Array.from(container.querySelectorAll(".sidebar-group-header__name")).map((el) => el.textContent?.trim()),

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
@@ -942,7 +942,7 @@ describe("WorkspaceListSidebar", () => {
     expect(screen.getByRole("button", { name: "Created" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Activity" })).toBeTruthy();
     expect(screen.getByText("Visibility")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Hide org name" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Hide org name" }).classList.contains("active")).toBe(false);
     expect(screen.getByRole("button", { name: "Show PR diff stats" })).toBeTruthy();
   });
 
@@ -957,7 +957,9 @@ describe("WorkspaceListSidebar", () => {
     await screen.findByText("kenn-io/middleman");
 
     await fireEvent.click(screen.getByRole("button", { name: "View" }));
-    await fireEvent.click(screen.getByRole("button", { name: "Hide org name" }));
+    const hideOrgName = screen.getByRole("button", { name: "Hide org name" });
+    await fireEvent.click(hideOrgName);
+    expect(hideOrgName.classList.contains("active")).toBe(true);
 
     expect(screen.queryByText("kenn-io/middleman")).toBeNull();
     expect(screen.getByText("middleman")).toBeTruthy();

--- a/frontend/tests/e2e-full/00-workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e-full/00-workspace-sidebar.spec.ts
@@ -385,7 +385,7 @@ test.describe("workspace sidebar full-stack", () => {
       // in a single pass before dismissing it.
       await viewTrigger.click();
       await page
-        .locator(".kit-filter-dropdown__panel .kit-filter-dropdown__item", { hasText: "Show org names" })
+        .locator(".kit-filter-dropdown__panel .kit-filter-dropdown__item", { hasText: "Hide org name" })
         .click();
       await page
         .locator(".kit-filter-dropdown__panel .kit-filter-dropdown__item", { hasText: "Show PR diff stats" })

--- a/frontend/tests/e2e-full/mobile-routes.spec.ts
+++ b/frontend/tests/e2e-full/mobile-routes.spec.ts
@@ -1,4 +1,5 @@
 import { devices, expect, test, type Page } from "@playwright/test";
+import { startIsolatedE2EServerWithOptions } from "./support/e2eServer.js";
 
 const iPhone13 = devices["iPhone 13"];
 test.use({
@@ -473,14 +474,24 @@ test.describe("phone routes", () => {
     await expectReadableFocusList(page, ".issue-item");
   });
 
-  test("mobile PR and issue lists respect the shared hide-org preference", async ({ page }) => {
-    await page.addInitScript(() => localStorage.setItem("middleman:hideOrgName", "1"));
+  test("mobile PR and issue lists respect hide-org while preserving provider collisions", async ({ browser }) => {
+    const server = await startIsolatedE2EServerWithOptions({ providerCollision: true });
+    const page = await browser.newPage();
+    try {
+      await page.addInitScript(() => localStorage.setItem("middleman:hideOrgName", "1"));
 
-    await page.goto("/m/pulls");
-    await expect(page.locator(".pull-item .repo-chip").first()).toHaveText("widgets");
+      await page.goto(`${server.info.base_url}/m/pulls`);
+      await expect(page.locator(".pull-item .repo-chip").first()).toHaveText("widgets");
 
-    await page.getByRole("link", { name: "Issues" }).click();
-    await expect(page.locator(".issue-item .repo-chip").first()).toHaveText("widgets");
+      await page.getByRole("link", { name: "Issues" }).click();
+      await expect(page.locator(".issue-item .repo-chip", { hasText: "github/github.com/acme/widgets" })).toHaveCount(
+        3,
+      );
+      await expect(page.locator(".issue-item .repo-chip", { hasText: "gitea/github.com/acme/widgets" })).toHaveCount(1);
+    } finally {
+      await page.close();
+      await server.stop();
+    }
   });
 });
 

--- a/frontend/tests/e2e-full/mobile-routes.spec.ts
+++ b/frontend/tests/e2e-full/mobile-routes.spec.ts
@@ -472,6 +472,16 @@ test.describe("phone routes", () => {
     await expect(page.locator(".focus-list")).toBeVisible();
     await expectReadableFocusList(page, ".issue-item");
   });
+
+  test("mobile PR and issue lists respect the shared hide-org preference", async ({ page }) => {
+    await page.addInitScript(() => localStorage.setItem("middleman:hideOrgName", "1"));
+
+    await page.goto("/m/pulls");
+    await expect(page.locator(".pull-item .repo-chip").first()).toHaveText("widgets");
+
+    await page.getByRole("link", { name: "Issues" }).click();
+    await expect(page.locator(".issue-item .repo-chip").first()).toHaveText("widgets");
+  });
 });
 
 test.describe("high-density phone routes", () => {

--- a/frontend/tests/e2e-full/mobile-routes.spec.ts
+++ b/frontend/tests/e2e-full/mobile-routes.spec.ts
@@ -481,13 +481,16 @@ test.describe("phone routes", () => {
       await page.addInitScript(() => localStorage.setItem("middleman:hideOrgName", "1"));
 
       await page.goto(`${server.info.base_url}/m/pulls`);
-      await expect(page.locator(".pull-item .repo-chip").first()).toHaveText("widgets");
+      await expect(page.locator(".pull-item .repo-chip", { hasText: "github/github.com/acme/widgets" })).toHaveCount(4);
+      await expect(page.locator(".pull-item .repo-chip", { hasText: "gitea/github.com/acme/widgets" })).toHaveCount(1);
+      await expect(page.locator(".pull-item .repo-chip", { hasText: /^tools$/ }).first()).toHaveText("tools");
 
       await page.getByRole("link", { name: "Issues" }).click();
       await expect(page.locator(".issue-item .repo-chip", { hasText: "github/github.com/acme/widgets" })).toHaveCount(
         3,
       );
       await expect(page.locator(".issue-item .repo-chip", { hasText: "gitea/github.com/acme/widgets" })).toHaveCount(1);
+      await expect(page.locator(".issue-item .repo-chip", { hasText: /^tools$/ }).first()).toHaveText("tools");
     } finally {
       await page.close();
       await server.stop();

--- a/frontend/tests/e2e-full/sidebar-collapse.spec.ts
+++ b/frontend/tests/e2e-full/sidebar-collapse.spec.ts
@@ -315,9 +315,23 @@ test.describe("collapsible sidebar", () => {
     await expectPullLocalFilterLabeled(await setPersistedSidebarWidth(page, "/pulls", 521, waitForPRList));
   });
 
-  test("issue filters switch at the buffered 373px fit point", async ({ page }) => {
-    await expectCompactFilterBar(await setPersistedSidebarWidth(page, "/issues", 372, waitForIssueList));
-    await expectExpandedFilterBar(await setPersistedSidebarWidth(page, "/issues", 373, waitForIssueList));
+  test("issue filters switch at the buffered 402px fit point", async ({ page }) => {
+    await expectCompactFilterBar(await setPersistedSidebarWidth(page, "/issues", 401, waitForIssueList));
+    await expectExpandedFilterBar(await setPersistedSidebarWidth(page, "/issues", 402, waitForIssueList));
+  });
+
+  test("issue org-name visibility remains accessible in the expanded filter bar", async ({ page }) => {
+    const filterBar = await setPersistedSidebarWidth(page, "/issues", 402, waitForIssueList);
+
+    const visibilityButton = filterBar.getByRole("button", { name: "Visibility" });
+    await expect(visibilityButton).toBeVisible();
+    await visibilityButton.click();
+    const hideOrgName = page.getByRole("button", { name: "Hide org name" });
+    await expect(hideOrgName).toBeVisible();
+    await hideOrgName.click();
+    await expect(page.locator(".sidebar-group-header__name").first()).toHaveText("widgets");
+    await page.getByRole("button", { name: "Reset visibility" }).click();
+    await expect(page.locator(".sidebar-group-header__name").first()).toHaveText("acme/widgets");
   });
 
   test("pull compact filters update state and grouping", async ({ page }) => {
@@ -337,6 +351,16 @@ test.describe("collapsible sidebar", () => {
       timeout: 5_000,
     });
     await expect(page.locator(".repo-chip").first()).toBeVisible();
+  });
+
+  test("pull compact filter badge counts org-name visibility", async ({ page }) => {
+    const filterBar = await setPersistedSidebarWidth(page, "/pulls", 395, waitForPRList);
+    const dropdown = await openCompactFilters(filterBar);
+
+    await dropdown.getByRole("button", { name: "Hide org name" }).click();
+    await expect(filterBar.locator(".compact-filter-menu .kit-filter-dropdown__badge")).toHaveText("1");
+    await dropdown.getByRole("button", { name: "Reset view" }).click();
+    await expect(filterBar.locator(".compact-filter-menu .kit-filter-dropdown__badge")).toHaveCount(0);
   });
 
   test("pull compact filters apply PR attributes and kanban status against the real API", async ({ page }) => {

--- a/frontend/tests/e2e/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar.spec.ts
@@ -3644,7 +3644,7 @@ test.describe("workspace list sorting", () => {
 
     const viewTrigger = page.getByTitle("View workspace options");
     await viewTrigger.click();
-    await page.locator(".kit-filter-dropdown__panel").getByRole("button", { name: "Show org names" }).click();
+    await page.locator(".kit-filter-dropdown__panel").getByRole("button", { name: "Hide org name" }).click();
 
     await expect(groupLabels).toHaveText([
       "github/github.com/acme/widgets",

--- a/packages/ui/src/components/sidebar/IssueItem.svelte
+++ b/packages/ui/src/components/sidebar/IssueItem.svelte
@@ -6,6 +6,7 @@
   import { Chip } from "@kenn-io/kit-ui";
   import LabelRow from "../shared/LabelRow.svelte";
   import WorkspaceIndicator from "../shared/WorkspaceIndicator.svelte";
+  import { repoIdentityKey } from "../../utils/repo-label.js";
 
   const { issues } = getStores();
 
@@ -43,6 +44,13 @@
   }
 
   const labels = $derived(issue.labels ?? []);
+  const repoColorKey = $derived(repoIdentityKey({
+    provider: issue.repo.provider,
+    platformHost: issue.repo.platform_host,
+    owner: issue.repo.owner,
+    name: issue.repo.name,
+    repoPath: issue.repo.repo_path,
+  }));
   const ago = $derived(formatRelativeTime(issue.LastActivityAt));
   const stateLabel = $derived(
     issue.State === "open" ? "Open" : "Closed",
@@ -59,7 +67,7 @@
         uppercase={false}
         title={repoLabel}
         tone="muted" class="repo-chip"
-        style={`color: ${hashColor(repoLabel)}; background: color-mix(in srgb, ${hashColor(repoLabel)} 15%, transparent);`}
+        style={`color: ${hashColor(repoColorKey)}; background: color-mix(in srgb, ${hashColor(repoColorKey)} 15%, transparent);`}
       >{repoLabel}</Chip>
     </div>
   {/if}

--- a/packages/ui/src/components/sidebar/IssueItem.svelte
+++ b/packages/ui/src/components/sidebar/IssueItem.svelte
@@ -13,14 +13,11 @@
     issue: Issue;
     selected: boolean;
     showRepo: boolean;
+    repoLabel: string;
     onclick: () => void;
   }
 
-  const { issue, selected, showRepo, onclick }: Props = $props();
-
-  const repoSlug = $derived(
-    `${issue.repo_owner ?? ""}/${issue.repo_name ?? ""}`,
-  );
+  const { issue, selected, showRepo, repoLabel, onclick }: Props = $props();
 
   let el: HTMLButtonElement;
 
@@ -60,10 +57,10 @@
       <Chip
         size="xs"
         uppercase={false}
-        title={repoSlug}
+        title={repoLabel}
         tone="muted" class="repo-chip"
-        style={`color: ${hashColor(repoSlug)}; background: color-mix(in srgb, ${hashColor(repoSlug)} 15%, transparent);`}
-      >{repoSlug}</Chip>
+        style={`color: ${hashColor(repoLabel)}; background: color-mix(in srgb, ${hashColor(repoLabel)} 15%, transparent);`}
+      >{repoLabel}</Chip>
     </div>
   {/if}
   <div class="meta-row">

--- a/packages/ui/src/components/sidebar/IssueItem.test.ts
+++ b/packages/ui/src/components/sidebar/IssueItem.test.ts
@@ -25,6 +25,7 @@ function renderItem(issue: Issue): void {
       issue,
       selected: false,
       showRepo: false,
+      repoLabel: "acme/widgets",
       onclick: () => {},
     },
     context: new Map<symbol, unknown>([[STORES_KEY, { issues: { toggleIssueStar: vi.fn() } }]]),

--- a/packages/ui/src/components/sidebar/IssueItem.test.ts
+++ b/packages/ui/src/components/sidebar/IssueItem.test.ts
@@ -14,6 +14,13 @@ const mkIssue = (overrides: Record<string, unknown>): Issue =>
     LastActivityAt: "2026-05-01T12:00:00Z",
     repo_owner: "acme",
     repo_name: "widgets",
+    repo: {
+      provider: "github",
+      platform_host: "github.com",
+      owner: "acme",
+      name: "widgets",
+      repo_path: "acme/widgets",
+    },
     Starred: false,
     labels: [],
     ...overrides,

--- a/packages/ui/src/components/sidebar/IssueList.svelte
+++ b/packages/ui/src/components/sidebar/IssueList.svelte
@@ -7,6 +7,7 @@
   import { FilterDropdown } from "@kenn-io/kit-ui";
   import { SidebarToggle } from "@kenn-io/kit-ui";
   import type { Issue } from "../../api/types.js";
+  import { createRepoLabelFormatter } from "../../utils/repo-label.js";
   import {
     buildIssueRoute,
     type IssueRouteRef,
@@ -34,6 +35,18 @@
   let searchInput = $state(issues.getIssueSearchQuery() ?? "");
   let debounceHandle: ReturnType<typeof setTimeout> | null = null;
   let refreshHandle: ReturnType<typeof setInterval> | null = null;
+  const repoLabelFormatter = $derived(
+    createRepoLabelFormatter(
+      issues.getIssues().map((issue) => ({
+        provider: issue.repo.provider,
+        platformHost: issue.repo.platform_host,
+        owner: issue.repo.owner,
+        name: issue.repo.name,
+        repoPath: issue.repo.repo_path,
+      })),
+      { showOrgNames: !grouping.getHideOrgName() },
+    ),
+  );
 
   $effect(() => {
     void issues.loadIssues();
@@ -72,6 +85,12 @@
     void issues.loadIssues();
   }
 
+  function resetCompactView(): void {
+    if (issues.getIssueFilterState() !== "open") setIssueState("open");
+    grouping.setGroupByRepo(true);
+    grouping.setHideOrgName(false);
+  }
+
   const compactFilterSections = $derived.by(() => [
     {
       title: "State",
@@ -91,10 +110,23 @@
         onSelect: () => grouping.setGroupByRepo(option.byRepo),
       })),
     },
+    {
+      title: "Visibility",
+      items: [
+        {
+          id: "hide-org-name",
+          label: "Hide org name",
+          active: grouping.getHideOrgName(),
+          onSelect: () => grouping.setHideOrgName(!grouping.getHideOrgName()),
+        },
+      ],
+    },
   ]);
 
   const hasCompactFilterChanges = $derived(
-    issues.getIssueFilterState() !== "open" || !grouping.getGroupByRepo(),
+    issues.getIssueFilterState() !== "open"
+      || !grouping.getGroupByRepo()
+      || grouping.getHideOrgName(),
   );
   const useCompactFilters = $derived(
     sidebarWidth <= COMPACT_FILTER_MAX_WIDTH,
@@ -165,6 +197,8 @@
         active={hasCompactFilterChanges}
         showBadge={false}
         sections={compactFilterSections}
+        resetLabel="Reset view"
+        onReset={resetCompactView}
         minWidth="160px"
       />
     </div>
@@ -230,7 +264,13 @@
       {#if grouping.getGroupByRepo()}
         {#each [...issues.issuesByRepo().entries()] as [repo, repoIssues] (repo)}
           {@const collapsed = collapsedRepos.isCollapsed("issues", repo)}
-          {@const repoLabel = repoIssues[0]?.repo.repo_path ?? repo}
+          {@const repoLabel = repoIssues[0] ? repoLabelFormatter.format({
+            provider: repoIssues[0].repo.provider,
+            platformHost: repoIssues[0].repo.platform_host,
+            owner: repoIssues[0].repo.owner,
+            name: repoIssues[0].repo.name,
+            repoPath: repoIssues[0].repo.repo_path,
+          }) : repo}
           <GroupedSidebarSection
             label={repoLabel}
             count={repoIssues.length}
@@ -241,6 +281,13 @@
                 {@const issueRef = routeRefForIssue(issue)}
                 <IssueItem
                   {issue}
+                  repoLabel={repoLabelFormatter.format({
+                    provider: issue.repo.provider,
+                    platformHost: issue.repo.platform_host,
+                    owner: issue.repo.owner,
+                    name: issue.repo.name,
+                    repoPath: issue.repo.repo_path,
+                  })}
                   showRepo={false}
                   selected={isSelected(issueRef)}
                   onclick={() => handleSelect(issueRef)}
@@ -253,6 +300,13 @@
           {@const issueRef = routeRefForIssue(issue)}
           <IssueItem
             {issue}
+            repoLabel={repoLabelFormatter.format({
+              provider: issue.repo.provider,
+              platformHost: issue.repo.platform_host,
+              owner: issue.repo.owner,
+              name: issue.repo.name,
+              repoPath: issue.repo.repo_path,
+            })}
             showRepo={true}
             selected={isSelected(issueRef)}
             onclick={() => handleSelect(issueRef)}

--- a/packages/ui/src/components/sidebar/IssueList.svelte
+++ b/packages/ui/src/components/sidebar/IssueList.svelte
@@ -28,9 +28,9 @@
     { byRepo: true, label: "By Repo" },
     { byRepo: false, label: "All" },
   ];
-  // Playwright-measured with a buffered "9999 issues" count label:
-  // the full issue filter row first fits at 373px.
-  const COMPACT_FILTER_MAX_WIDTH = 372;
+  // Playwright-measured with a buffered "9999 issues" count label and the
+  // icon-only visibility control: the full issue filter row first fits at 402px.
+  const COMPACT_FILTER_MAX_WIDTH = 401;
 
   let searchInput = $state(issues.getIssueSearchQuery() ?? "");
   let debounceHandle: ReturnType<typeof setTimeout> | null = null;
@@ -91,6 +91,18 @@
     grouping.setHideOrgName(false);
   }
 
+  const visibilityFilterSection = $derived({
+    title: "Visibility",
+    items: [
+      {
+        id: "hide-org-name",
+        label: "Hide org name",
+        active: grouping.getHideOrgName(),
+        onSelect: () => grouping.setHideOrgName(!grouping.getHideOrgName()),
+      },
+    ],
+  });
+
   const compactFilterSections = $derived.by(() => [
     {
       title: "State",
@@ -110,17 +122,7 @@
         onSelect: () => grouping.setGroupByRepo(option.byRepo),
       })),
     },
-    {
-      title: "Visibility",
-      items: [
-        {
-          id: "hide-org-name",
-          label: "Hide org name",
-          active: grouping.getHideOrgName(),
-          onSelect: () => grouping.setHideOrgName(!grouping.getHideOrgName()),
-        },
-      ],
-    },
+    visibilityFilterSection,
   ]);
 
   const hasCompactFilterChanges = $derived(
@@ -200,6 +202,18 @@
         resetLabel="Reset view"
         onReset={resetCompactView}
         minWidth="160px"
+      />
+    </div>
+    <div class="issue-visibility-menu">
+      <FilterDropdown
+        label="Visibility"
+        title="Issue visibility"
+        active={grouping.getHideOrgName()}
+        showBadge={false}
+        sections={[visibilityFilterSection]}
+        resetLabel="Reset visibility"
+        onReset={() => grouping.setHideOrgName(false)}
+        minWidth="180px"
       />
     </div>
     {#if isSidebarToggleEnabled()}
@@ -461,6 +475,21 @@
     transform-origin: left center;
   }
 
+  .issue-visibility-menu {
+    display: block;
+  }
+
+  .issue-visibility-menu :global(.kit-filter-dropdown__btn) {
+    width: 28px;
+    justify-content: center;
+    padding-inline: 0;
+  }
+
+  .issue-visibility-menu :global(.kit-filter-dropdown__trigger-label),
+  .issue-visibility-menu :global(.kit-filter-dropdown__trigger-detail) {
+    display: none;
+  }
+
   .compact-filter-menu :global(.kit-filter-dropdown__btn) {
     width: 26px;
     justify-content: center;
@@ -521,6 +550,10 @@
 
   .filter-bar--compact .state-toggle,
   .filter-bar--compact .group-toggle {
+    display: none;
+  }
+
+  .filter-bar--compact .issue-visibility-menu {
     display: none;
   }
 

--- a/packages/ui/src/components/sidebar/PullItem.svelte
+++ b/packages/ui/src/components/sidebar/PullItem.svelte
@@ -24,6 +24,7 @@
     pr: PullRequest;
     selected: boolean;
     showRepo: boolean;
+    repoLabel: string;
     onclick: () => void;
     importAction?: Action | undefined;
   }
@@ -32,13 +33,10 @@
     pr,
     selected,
     showRepo,
+    repoLabel,
     onclick,
     importAction,
   }: Props = $props();
-
-  const repoSlug = $derived(
-    `${pr.repo_owner ?? ""}/${pr.repo_name ?? ""}`,
-  );
 
   function handleStarClick(e: MouseEvent): void {
     e.stopPropagation();
@@ -176,10 +174,10 @@
       <Chip
         size="xs"
         uppercase={false}
-        title={repoSlug}
+        title={repoLabel}
         tone="muted" class="repo-chip"
-        style={`color: ${hashColor(repoSlug)}; background: color-mix(in srgb, ${hashColor(repoSlug)} 15%, transparent);`}
-      >{repoSlug}</Chip>
+        style={`color: ${hashColor(repoLabel)}; background: color-mix(in srgb, ${hashColor(repoLabel)} 15%, transparent);`}
+      >{repoLabel}</Chip>
     </div>
   {/if}
   <div class="meta-row">

--- a/packages/ui/src/components/sidebar/PullItem.svelte
+++ b/packages/ui/src/components/sidebar/PullItem.svelte
@@ -16,6 +16,7 @@
   import { Chip } from "@kenn-io/kit-ui";
   import LabelRow from "../shared/LabelRow.svelte";
   import WorkspaceIndicator from "../shared/WorkspaceIndicator.svelte";
+  import { repoIdentityKey } from "../../utils/repo-label.js";
 
   const { pulls } = getStores();
   const hostState = getHostState();
@@ -109,6 +110,13 @@
     pr.State === "open",
   );
   const labels = $derived(pr.labels ?? []);
+  const repoColorKey = $derived(repoIdentityKey({
+    provider: pr.repo.provider,
+    platformHost: pr.repo.platform_host,
+    owner: pr.repo.owner,
+    name: pr.repo.name,
+    repoPath: pr.repo.repo_path,
+  }));
   const reviewDecision = $derived(pr.ReviewDecision.trim().toUpperCase());
   const reviewIndicator = $derived.by(
     ():
@@ -176,7 +184,7 @@
         uppercase={false}
         title={repoLabel}
         tone="muted" class="repo-chip"
-        style={`color: ${hashColor(repoLabel)}; background: color-mix(in srgb, ${hashColor(repoLabel)} 15%, transparent);`}
+        style={`color: ${hashColor(repoColorKey)}; background: color-mix(in srgb, ${hashColor(repoColorKey)} 15%, transparent);`}
       >{repoLabel}</Chip>
     </div>
   {/if}

--- a/packages/ui/src/components/sidebar/PullItem.test.ts
+++ b/packages/ui/src/components/sidebar/PullItem.test.ts
@@ -33,6 +33,7 @@ function renderItem(pr: PullRequest): void {
       pr,
       selected: false,
       showRepo: false,
+      repoLabel: "o/n",
       onclick: () => {},
     },
     context: new Map<symbol, unknown>([

--- a/packages/ui/src/components/sidebar/PullItem.test.ts
+++ b/packages/ui/src/components/sidebar/PullItem.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test"
 import type { PullRequest } from "../../api/types.js";
 import { HOST_STATE_KEY, STORES_KEY } from "../../context.js";
 import { __resetCIWarnings } from "../../utils/ci-buckets-warn.js";
+import { hashColor } from "@kenn-io/kit-ui";
 import PullItem from "./PullItem.svelte";
 
 const mkPR = (overrides: Record<string, unknown>): PullRequest =>
@@ -22,6 +23,13 @@ const mkPR = (overrides: Record<string, unknown>): PullRequest =>
     PlatformExternalID: "ext-1",
     repo_owner: "o",
     repo_name: "n",
+    repo: {
+      provider: "github",
+      platform_host: "github.com",
+      owner: "o",
+      name: "n",
+      repo_path: "o/n",
+    },
     worktree_links: [],
     Starred: false,
     ...overrides,
@@ -203,6 +211,37 @@ describe("PullItem CI cluster", () => {
     expect(document.querySelector("[data-testid='ci-token-pending']")).toBeNull();
     expect(document.querySelector("[data-testid='ci-token-passed']")).toBeNull();
     expect(document.querySelector("[data-testid='ci-token-skipped']")).toBeNull();
+  });
+});
+
+describe("PullItem repository label", () => {
+  it("keeps chip color tied to repository identity when the display label changes", () => {
+    const pr = mkPR({
+      repo: {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "acme",
+        name: "widgets",
+        repo_path: "acme/widgets",
+      },
+    });
+    render(PullItem, {
+      props: {
+        pr,
+        selected: false,
+        showRepo: true,
+        repoLabel: "widgets",
+        onclick: () => {},
+      },
+      context: new Map<symbol, unknown>([
+        [STORES_KEY, { pulls: { togglePRStar: vi.fn() } }],
+        [HOST_STATE_KEY, {}],
+      ]),
+    });
+
+    expect(document.querySelector(".kit-chip.repo-chip")?.getAttribute("style")).toContain(
+      hashColor("github|github.com|acme/widgets"),
+    );
   });
 });
 

--- a/packages/ui/src/components/sidebar/PullList.svelte
+++ b/packages/ui/src/components/sidebar/PullList.svelte
@@ -11,6 +11,7 @@
   import type { KanbanStatus, PullRequest } from "../../api/types.js";
   import type { GroupingMode } from "../../stores/grouping.svelte.js";
   import type { PullAttributeFilter } from "../../stores/pulls.svelte.js";
+  import { createRepoLabelFormatter } from "../../utils/repo-label.js";
   import {
     buildPullRequestFilesRoute,
     buildPullRequestRoute,
@@ -87,6 +88,18 @@
   let debounceHandle: ReturnType<typeof setTimeout> | null = null;
   let refreshHandle: ReturnType<typeof setInterval> | null = null;
   const visiblePulls = $derived(pulls.getDisplayOrderPRs());
+  const repoLabelFormatter = $derived(
+    createRepoLabelFormatter(
+      visiblePulls.map((pr) => ({
+        provider: pr.repo.provider,
+        platformHost: pr.repo.platform_host,
+        owner: pr.repo.owner,
+        name: pr.repo.name,
+        repoPath: pr.repo.repo_path,
+      })),
+      { showOrgNames: !grouping.getHideOrgName() },
+    ),
+  );
 
   $effect(() => {
     void pulls.loadPulls();
@@ -140,9 +153,15 @@
   function resetCompactView(): void {
     pulls.clearLocalFilters();
     grouping.setGroupingMode("byRepo");
+    grouping.setHideOrgName(false);
     if (pulls.getFilterState() !== "open") {
       setPullState("open");
     }
+  }
+
+  function clearLocalViewFilters(): void {
+    pulls.clearLocalFilters();
+    grouping.setHideOrgName(false);
   }
 
   const toolbarFilterSections = $derived.by(() => [
@@ -185,6 +204,17 @@
         onSelect: () => pulls.toggleKanbanStatusFilter(option.value),
       })),
     },
+    {
+      title: "Visibility",
+      items: [
+        {
+          id: "hide-org-name",
+          label: "Hide org name",
+          active: grouping.getHideOrgName(),
+          onSelect: () => grouping.setHideOrgName(!grouping.getHideOrgName()),
+        },
+      ],
+    },
   ]);
   const compactFilterSections = $derived.by(() => [
     ...toolbarFilterSections,
@@ -193,7 +223,11 @@
   const hasCompactFilterChanges = $derived(
     pulls.getFilterState() !== "open"
       || groupingMode !== "byRepo"
-      || pulls.getLocalFilterCount() > 0,
+      || pulls.getLocalFilterCount() > 0
+      || grouping.getHideOrgName(),
+  );
+  const localViewFilterCount = $derived(
+    pulls.getLocalFilterCount() + Number(grouping.getHideOrgName()),
   );
   const useCompactFilters = $derived(
     sidebarWidth <= COMPACT_FILTER_MAX_WIDTH,
@@ -215,7 +249,13 @@
       return [...pulls.pullsByRepo().entries()].map(([repo, prs]) => ({
         key: `repo:${repo}`,
         collapseKey: repo,
-        label: prs[0]?.repo.repo_path ?? repo,
+        label: prs[0] ? repoLabelFormatter.format({
+          provider: prs[0].repo.provider,
+          platformHost: prs[0].repo.platform_host,
+          owner: prs[0].repo.owner,
+          name: prs[0].repo.name,
+          repoPath: prs[0].repo.repo_path,
+        }) : repo,
         showRepo: false,
         items: prs,
       }));
@@ -375,11 +415,11 @@
       <FilterDropdown
         label="PR filters"
         title="PR filters"
-        active={pulls.getLocalFilterCount() > 0}
-        badgeCount={pulls.getLocalFilterCount()}
+        active={localViewFilterCount > 0}
+        badgeCount={localViewFilterCount}
         sections={localFilterSections}
         resetLabel="Clear filters"
-        onReset={pulls.clearLocalFilters}
+        onReset={clearLocalViewFilters}
         minWidth="190px"
       />
     </div>
@@ -470,6 +510,13 @@
                 {@const prSelected = isSelected(prRef)}
                 <PullItem
                   {pr}
+                  repoLabel={repoLabelFormatter.format({
+                    provider: pr.repo.provider,
+                    platformHost: pr.repo.platform_host,
+                    owner: pr.repo.owner,
+                    name: pr.repo.name,
+                    repoPath: pr.repo.repo_path,
+                  })}
                   showRepo={group.showRepo}
                   selected={prSelected}
                   {importAction}
@@ -489,6 +536,13 @@
           {@const prSelected = isSelected(prRef)}
           <PullItem
             {pr}
+            repoLabel={repoLabelFormatter.format({
+              provider: pr.repo.provider,
+              platformHost: pr.repo.platform_host,
+              owner: pr.repo.owner,
+              name: pr.repo.name,
+              repoPath: pr.repo.repo_path,
+            })}
             showRepo={true}
             selected={prSelected}
             {importAction}

--- a/packages/ui/src/components/sidebar/PullList.svelte
+++ b/packages/ui/src/components/sidebar/PullList.svelte
@@ -401,7 +401,7 @@
         label="Filters"
         title="Filters"
         active={hasCompactFilterChanges}
-        badgeCount={pulls.getLocalFilterCount()}
+        badgeCount={localViewFilterCount}
         sections={compactFilterSections}
         resetLabel="Reset view"
         onReset={resetCompactView}

--- a/packages/ui/src/views/FocusListView.svelte
+++ b/packages/ui/src/views/FocusListView.svelte
@@ -266,6 +266,7 @@
               {@const prRef = routeRefForPull(pr)}
               <PullItem
                 {pr}
+                repoLabel={`${pr.repo_owner ?? ""}/${pr.repo_name ?? ""}`}
                 showRepo={!repo}
                 selected={false}
                 {importAction}
@@ -279,6 +280,7 @@
           {@const prRef = routeRefForPull(pr)}
           <PullItem
             {pr}
+            repoLabel={`${pr.repo_owner ?? ""}/${pr.repo_name ?? ""}`}
             showRepo={!repo}
             selected={false}
             {importAction}
@@ -307,6 +309,7 @@
           {@const issueRef = routeRefForIssue(issue)}
           <IssueItem
             {issue}
+            repoLabel={`${issue.repo_owner ?? ""}/${issue.repo_name ?? ""}`}
             showRepo={!repo}
             selected={false}
             onclick={() => handleIssueSelect(issueRef)}

--- a/packages/ui/src/views/FocusListView.svelte
+++ b/packages/ui/src/views/FocusListView.svelte
@@ -6,6 +6,7 @@
   import { ScrollBox } from "@kenn-io/kit-ui";
   import IssueItem from "../components/sidebar/IssueItem.svelte";
   import type { Issue, PullRequest } from "../api/types.js";
+  import { createRepoLabelFormatter } from "../utils/repo-label.js";
   import {
     buildFocusIssueRoute,
     buildFocusPullRequestRoute,
@@ -150,6 +151,31 @@
   const issueLoading = $derived(issues.isIssuesLoading());
   const issueError = $derived(issues.getIssuesError());
 
+  const prRepoLabelFormatter = $derived(
+    createRepoLabelFormatter(
+      prItems.map((pr) => ({
+        provider: pr.repo.provider,
+        platformHost: pr.repo.platform_host,
+        owner: pr.repo.owner,
+        name: pr.repo.name,
+        repoPath: pr.repo.repo_path,
+      })),
+      { showOrgNames: !grouping.getHideOrgName() },
+    ),
+  );
+  const issueRepoLabelFormatter = $derived(
+    createRepoLabelFormatter(
+      issueItems.map((issue) => ({
+        provider: issue.repo.provider,
+        platformHost: issue.repo.platform_host,
+        owner: issue.repo.owner,
+        name: issue.repo.name,
+        repoPath: issue.repo.repo_path,
+      })),
+      { showOrgNames: !grouping.getHideOrgName() },
+    ),
+  );
+
   const itemCount = $derived(
     listType === "mrs" ? prItems.length : issueItems.length,
   );
@@ -266,7 +292,13 @@
               {@const prRef = routeRefForPull(pr)}
               <PullItem
                 {pr}
-                repoLabel={`${pr.repo_owner ?? ""}/${pr.repo_name ?? ""}`}
+                repoLabel={prRepoLabelFormatter.format({
+                  provider: pr.repo.provider,
+                  platformHost: pr.repo.platform_host,
+                  owner: pr.repo.owner,
+                  name: pr.repo.name,
+                  repoPath: pr.repo.repo_path,
+                })}
                 showRepo={!repo}
                 selected={false}
                 {importAction}
@@ -280,7 +312,13 @@
           {@const prRef = routeRefForPull(pr)}
           <PullItem
             {pr}
-            repoLabel={`${pr.repo_owner ?? ""}/${pr.repo_name ?? ""}`}
+            repoLabel={prRepoLabelFormatter.format({
+              provider: pr.repo.provider,
+              platformHost: pr.repo.platform_host,
+              owner: pr.repo.owner,
+              name: pr.repo.name,
+              repoPath: pr.repo.repo_path,
+            })}
             showRepo={!repo}
             selected={false}
             {importAction}
@@ -309,7 +347,13 @@
           {@const issueRef = routeRefForIssue(issue)}
           <IssueItem
             {issue}
-            repoLabel={`${issue.repo_owner ?? ""}/${issue.repo_name ?? ""}`}
+            repoLabel={issueRepoLabelFormatter.format({
+              provider: issue.repo.provider,
+              platformHost: issue.repo.platform_host,
+              owner: issue.repo.owner,
+              name: issue.repo.name,
+              repoPath: issue.repo.repo_path,
+            })}
             showRepo={!repo}
             selected={false}
             onclick={() => handleIssueSelect(issueRef)}


### PR DESCRIPTION
Repository-label density could only be adjusted from activity and used inconsistent wording in workspaces, forcing maintainers out of the sidebar they were scanning.

- Adds **Hide org name** to PR and issue filter menus
- Keeps the preference synchronized across PRs, issues, and activity
- Uses the same wording in workspaces while preserving its independent preference
- Retains provider and host qualifiers when needed to avoid ambiguous repository labels

<sup>generated by a clanker</sup>