### PR TITLE
fix: keep Kata federation menu available during loads

### DIFF
--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -151,6 +151,9 @@ Rows that contain buttons, links, or toggles need clear event ownership.
   close buttons or compact action affordances.
 - If a component claims menu-like behavior, it must honor the keyboard and focus
   contract of that role. Otherwise, use simpler semantics honestly.
+- Gate unavailable menu actions at the items when the menu remains safe to
+  inspect; native-disabled triggers swallow clicks and make pending work look
+  like broken UI (`frontend/src/lib/features/kata/KataDaemonSwitcher.svelte::choose`).
 
 ## Controlled Form Controls
 

--- a/frontend/src/lib/features/kata/KataDaemonSwitcher.svelte
+++ b/frontend/src/lib/features/kata/KataDaemonSwitcher.svelte
@@ -55,9 +55,8 @@
     title="Switch Kata daemon"
     aria-haspopup="menu"
     aria-expanded={open}
-    {disabled}
     onclick={() => {
-      if (!disabled) open = !open;
+      open = !open;
     }}
   >
     <ServerIcon class="chip-icon" size={13} strokeWidth={1.9} aria-hidden="true" />

--- a/frontend/src/lib/features/kata/KataDaemonSwitcher.test.ts
+++ b/frontend/src/lib/features/kata/KataDaemonSwitcher.test.ts
@@ -61,15 +61,17 @@ describe("KataDaemonSwitcher", () => {
     expect(onSelect).toHaveBeenCalledWith("work");
   });
 
-  it("disables daemon choices while workspace work is in flight", async () => {
+  it("keeps the menu available while daemon choices are disabled", async () => {
     const onSelect = vi.fn();
     render(KataDaemonSwitcher, { props: { daemons, activeId: "home", disabled: true, onSelect } });
 
     const chip = screen.getByTestId("daemon-chip") as HTMLButtonElement;
-    expect(chip.disabled).toBe(true);
+    expect(chip.disabled).toBe(false);
     await fireEvent.click(chip);
 
-    expect(screen.queryByTestId("daemon-row-work")).toBeNull();
+    const workRow = screen.getByTestId("daemon-row-work") as HTMLButtonElement;
+    expect(workRow.disabled).toBe(true);
+    await fireEvent.click(workRow);
     expect(onSelect).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/lib/features/kata/KataWorkspace.test.ts
+++ b/frontend/src/lib/features/kata/KataWorkspace.test.ts
@@ -1017,7 +1017,9 @@ describe("KataWorkspace", () => {
       expect(screen.getByRole("button", { name: "Create workspace" })).toBeTruthy();
     });
     await fireEvent.click(screen.getByRole("button", { name: "Create workspace" }));
-    expect((screen.getByTestId("daemon-chip") as HTMLButtonElement).disabled).toBe(true);
+    await fireEvent.click(screen.getByTestId("daemon-chip"));
+    const workDaemonRow = screen.getByTestId("daemon-row-work") as HTMLButtonElement;
+    expect(workDaemonRow.disabled).toBe(true);
     workspaceCreate.resolve(createdWorkspace);
 
     await waitFor(() => {
@@ -1030,7 +1032,7 @@ describe("KataWorkspace", () => {
         }),
       );
       expect(mockNavigate).toHaveBeenCalledWith("/terminal/workspace-kata");
-      expect((screen.getByTestId("daemon-chip") as HTMLButtonElement).disabled).toBe(false);
+      expect(workDaemonRow.disabled).toBe(false);
     });
   });
 
@@ -1384,7 +1386,9 @@ describe("KataWorkspace", () => {
     await waitFor(() => expect(oldSearchSettled).toBe(true));
 
     expect(screen.queryByText("Loading snapshot")).toBeTruthy();
-    expect((screen.getByTestId("daemon-chip") as HTMLButtonElement).disabled).toBe(true);
+    await fireEvent.click(screen.getByTestId("daemon-chip"));
+    const homeDaemonRow = screen.getByTestId("daemon-row-home") as HTMLButtonElement;
+    expect(homeDaemonRow.disabled).toBe(true);
 
     newSearch.resolve({
       filters: { scope: { kind: "all" }, status: "open", owner: "", label: "", query: "new" },
@@ -1395,7 +1399,7 @@ describe("KataWorkspace", () => {
       expect(screen.queryByText("Loading snapshot")).toBeNull();
       expect(screen.getByRole("heading", { name: "Email Susan re: Q3" })).toBeTruthy();
     });
-    expect((screen.getByTestId("daemon-chip") as HTMLButtonElement).disabled).toBe(false);
+    expect(homeDaemonRow.disabled).toBe(false);
   });
 
   it("clears the loading announcement when the newest overlapping search finishes first", async () => {
@@ -1446,7 +1450,9 @@ describe("KataWorkspace", () => {
       expect(screen.queryByText("Loading snapshot")).toBeNull();
       expect(screen.getByRole("heading", { name: "Email Susan re: Q3" })).toBeTruthy();
     });
-    expect((screen.getByTestId("daemon-chip") as HTMLButtonElement).disabled).toBe(true);
+    await fireEvent.click(screen.getByTestId("daemon-chip"));
+    const homeDaemonRow = screen.getByTestId("daemon-row-home") as HTMLButtonElement;
+    expect(homeDaemonRow.disabled).toBe(true);
 
     oldSearch.resolve({
       filters: { scope: { kind: "all" }, status: "open", owner: "", label: "", query: "old" },
@@ -1457,7 +1463,7 @@ describe("KataWorkspace", () => {
 
     expect(screen.queryByText("Loading snapshot")).toBeNull();
     expect(screen.getByRole("heading", { name: "Email Susan re: Q3" })).toBeTruthy();
-    expect((screen.getByTestId("daemon-chip") as HTMLButtonElement).disabled).toBe(false);
+    expect(homeDaemonRow.disabled).toBe(false);
   });
 
   it("shows the normalized authentication message when bootstrap fails", async () => {

--- a/frontend/src/lib/features/kata/KataWorkspaceEventStream.test.ts
+++ b/frontend/src/lib/features/kata/KataWorkspaceEventStream.test.ts
@@ -587,12 +587,14 @@ describe("KataWorkspace", () => {
       ),
     );
     await oldStreamRefreshStarted.promise;
-    expect((screen.getByTestId("daemon-chip") as HTMLButtonElement).disabled).toBe(true);
+    await fireEvent.click(screen.getByTestId("daemon-chip"));
+    const homeDaemonRow = screen.getByTestId("daemon-row-home") as HTMLButtonElement;
+    expect(homeDaemonRow.disabled).toBe(true);
 
     releaseOldStreamRefresh.resolve();
     await waitFor(() => {
       expect(completedViewLoads).toBe(viewLoadsBeforeEvents + 2);
-      expect((screen.getByTestId("daemon-chip") as HTMLButtonElement).disabled).toBe(false);
+      expect(homeDaemonRow.disabled).toBe(false);
     });
 
     const viewLoadsAfterDrain = vi.mocked(api.issues).mock.calls.length;
@@ -646,13 +648,15 @@ describe("KataWorkspace", () => {
         `id: 6\nevent: sync.reset_required\ndata: ${JSON.stringify({ event_id: 6, reset_after_id: 6 })}\n\n`,
       ),
     );
+    await fireEvent.click(screen.getByTestId("daemon-chip"));
+    const homeDaemonRow = screen.getByTestId("daemon-row-home") as HTMLButtonElement;
     await waitFor(() => {
-      expect((screen.getByTestId("daemon-chip") as HTMLButtonElement).disabled).toBe(true);
+      expect(homeDaemonRow.disabled).toBe(true);
     });
 
     failedRefresh.reject(new Error("stream refresh failed"));
     await waitFor(() => {
-      expect((screen.getByTestId("daemon-chip") as HTMLButtonElement).disabled).toBe(false);
+      expect(homeDaemonRow.disabled).toBe(false);
       expect(streamControllers).toHaveLength(2);
     });
     expect(screen.getByRole("button", { name: /Pay rent/ })).toBeTruthy();

--- a/frontend/tests/e2e-full/kata.spec.ts
+++ b/frontend/tests/e2e-full/kata.spec.ts
@@ -2077,7 +2077,11 @@ test("kata daemon switch waits for an in-flight event stream refresh", async ({ 
       .poll(() => home.state.seenPaths.filter((path) => path === "GET /api/v1/issues?status=open").length)
       .toBeGreaterThan(homeIssueLoads);
 
-    await expect(page.getByTestId("daemon-chip")).toBeDisabled();
+    const daemonChip = page.getByTestId("daemon-chip");
+    await expect(daemonChip).toBeEnabled();
+    await daemonChip.click();
+    await expect(page.getByTestId("daemon-row-work")).toBeDisabled();
+    await daemonChip.click();
     await page.evaluate(() => {
       window.history.pushState({}, "", "/kata?view=all&issue=issue-q3&daemon=work");
       window.dispatchEvent(new PopStateEvent("popstate"));
@@ -2128,10 +2132,14 @@ test("kata stream refresh failure releases switching and reconnects", async ({ p
     await expect
       .poll(() => backend.state.seenPaths.filter((path) => path === "GET /api/v1/issues?status=open").length)
       .toBeGreaterThan(issueLoadsBefore);
-    await expect(page.getByTestId("daemon-chip")).toBeDisabled();
+    const daemonChip = page.getByTestId("daemon-chip");
+    await expect(daemonChip).toBeEnabled();
+    await daemonChip.click();
+    const daemonRow = page.getByTestId("daemon-row-e2e");
+    await expect(daemonRow).toBeDisabled();
 
     releaseIssues();
-    await expect(page.getByTestId("daemon-chip")).toBeEnabled();
+    await expect(daemonRow).toBeEnabled();
     await expect
       .poll(() => backend.state.seenPaths.filter((path) => path.startsWith("GET /api/v1/events/stream")).length)
       .toBeGreaterThan(streamsBefore);
@@ -3212,12 +3220,16 @@ test("kata daemon switch stays disabled until initial workspace bootstrap settle
   try {
     await page.goto(`${server.info.base_url}/kata?view=all`);
 
-    await expect(page.getByTestId("daemon-chip")).toBeVisible();
-    await expect(page.getByTestId("daemon-chip")).toBeDisabled();
+    const daemonChip = page.getByTestId("daemon-chip");
+    await expect(daemonChip).toBeVisible();
+    await expect(daemonChip).toBeEnabled();
+    await daemonChip.click();
+    const daemonRow = page.getByTestId("daemon-row-e2e");
+    await expect(daemonRow).toBeDisabled();
     releaseIssues();
 
     await expect(page.locator(".kata-list").getByRole("button", { name: /Pay rent/ })).toBeVisible();
-    await expect(page.getByTestId("daemon-chip")).toBeEnabled();
+    await expect(daemonRow).toBeEnabled();
   } finally {
     releaseIssues();
     await server.stop();
@@ -3620,13 +3632,16 @@ test("kata daemon switch waits for an in-flight mutation and its refresh", async
     await dialog.getByRole("button", { name: "Complete" }).click();
     await expect.poll(() => home.state.seenPaths).toContain("POST /api/v1/projects/1/issues/issue-rent/actions/close");
 
-    await expect(page.getByTestId("daemon-chip")).toBeDisabled();
+    const daemonChip = page.getByTestId("daemon-chip");
+    await expect(daemonChip).toBeEnabled();
     expect(work.state.seenPaths).not.toContain("POST /api/v1/projects/1/issues/issue-rent/actions/close");
 
     releaseClose();
-    await expect(page.getByTestId("daemon-chip")).toBeEnabled();
-    await page.getByTestId("daemon-chip").click();
-    await page.getByTestId("daemon-row-work").click();
+    await expect(dialog).toHaveCount(0);
+    await daemonChip.click();
+    const workDaemonRow = page.getByTestId("daemon-row-work");
+    await expect(workDaemonRow).toBeEnabled();
+    await workDaemonRow.click();
 
     await expect(page.getByTestId("daemon-chip")).toContainText("work");
     await expect(page.locator(".kata-list").getByRole("button", { name: /Pay rent/ })).toBeVisible();
@@ -3943,12 +3958,16 @@ test("kata project create submits inline input and switches scope", async ({ pag
     await input.press("Enter");
 
     await expect.poll(() => backend.state.seenPaths).toContain("POST /api/v1/projects");
-    await expect(page.getByTestId("daemon-chip")).toBeDisabled();
+    const daemonChip = page.getByTestId("daemon-chip");
+    await expect(daemonChip).toBeEnabled();
+    await daemonChip.click();
+    const daemonRow = page.getByTestId("daemon-row-e2e");
+    await expect(daemonRow).toBeDisabled();
     releaseCreate();
 
     await expect(page.getByRole("button", { name: /^Sabbatical\s+0$/ })).toBeVisible();
     await expect(page.getByRole("heading", { name: "Sabbatical", level: 2 })).toBeVisible();
-    await expect(page.getByTestId("daemon-chip")).toBeEnabled();
+    await expect(daemonRow).toBeEnabled();
   } finally {
     releaseCreate();
     await server.stop();


### PR DESCRIPTION
The Kata daemon selector could appear broken whenever workspace work was pending because its native trigger stopped accepting clicks.

- Keeps configured daemons inspectable during Kata loads and mutations.
- Keeps daemon changes disabled until in-flight work settles.
- Updates frontend and full-stack coverage for the interaction contract.

<sup>generated by a clanker</sup>