### PR TITLE
fix: restore workspace ahead/behind arrows by configuring PR branch upstreams

### DIFF
--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -175,10 +175,15 @@ single source of truth for every sync-derived workspace surface:
 ahead/behind arrows, push, pull, and unpushed-commit flags. All of them
 silently report nothing when the upstream is missing, so every path that
 creates a workspace-owned branch must configure it — including the synthetic
-`middleman/pr-N` fallback, which tracks the PR's head branch on origin. The
-pushed-head observer pass rewires a missing upstream for same-repo open-PR
-workspaces (head-branch or synthetic checkouts only); fork heads stay
-untracked because origin has no ref for them.
+`middleman/pr-N` fallback, which tracks the PR's head branch on origin. Both
+wiring paths demand positive same-repo evidence before touching config: a nil
+`MRHeadRepo` is not proof (it is also nil when head-repo metadata was
+unavailable, and issue workspaces never set it). Creation binds only when
+`origin/<head>` resolves to the exact commit the worktree was materialized
+at; the pushed-head observer pass repairs a missing upstream only when the
+open MR row's `HeadRepoCloneURL` matches the base repository identity, the
+checked-out branch is the PR head or synthetic branch, and the
+remote-tracking ref exists. Everything else stays untracked.
 
 ## Sidebar Ordering
 

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -174,16 +174,13 @@ single source of truth for every sync-derived workspace surface:
 `commits_ahead`/`commits_behind` in the list response, the sidebar
 ahead/behind arrows, push, pull, and unpushed-commit flags. All of them
 silently report nothing when the upstream is missing, so every path that
-creates a workspace-owned branch must configure it — including the synthetic
-`middleman/pr-N` fallback, which tracks the PR's head branch on origin. Both
-wiring paths demand positive same-repo evidence before touching config: a nil
-`MRHeadRepo` is not proof (it is also nil when head-repo metadata was
-unavailable, and issue workspaces never set it). Creation binds only when
-`origin/<head>` resolves to the exact commit the worktree was materialized
-at; the pushed-head observer pass repairs a missing upstream only when the
-open MR row's `HeadRepoCloneURL` matches the base repository identity, the
-checked-out branch is the PR head or synthetic branch, and the
-remote-tracking ref exists. Everything else stays untracked.
+creates a workspace-owned branch should configure it when repository identity
+is known. Upstream wiring requires a non-empty head-repository identity that
+matches the base repository; matching commit SHAs are not identity evidence
+because forks preserve commit IDs. Unknown and fork heads stay untracked. The
+pushed-head observer may repair a missing upstream only when the current MR row
+proves the head is in the base repository, the checked-out branch is the PR
+head or synthetic branch, and the remote-tracking ref exists.
 
 ## Sidebar Ordering
 

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -175,8 +175,9 @@ single source of truth for every sync-derived workspace surface:
 ahead/behind arrows, push, pull, and unpushed-commit flags. All of them
 silently report nothing when the upstream is missing, so every path that
 creates a workspace-owned branch should configure it when repository identity
-is known. Upstream wiring requires a non-empty head-repository identity that
-matches the base repository; matching commit SHAs are not identity evidence
+is known. Upstream wiring requires a non-empty head-repository identity whose
+provider, host, and full repository path match the base repository; matching
+commit SHAs are not identity evidence
 because forks preserve commit IDs. Unknown and fork heads stay untracked. The
 pushed-head observer may repair a missing upstream only when the current MR row
 proves the head is in the base repository, the checked-out branch is the PR

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -167,6 +167,19 @@ response as expected rather than an error, and a future change should expose a
 resolved-merge-target signal on the workspace summary so the UI gate matches the
 server check exactly.
 
+## Branch Upstream
+
+The branch's git upstream config (`branch.<name>.remote`/`.merge`) is the
+single source of truth for every sync-derived workspace surface:
+`commits_ahead`/`commits_behind` in the list response, the sidebar
+ahead/behind arrows, push, pull, and unpushed-commit flags. All of them
+silently report nothing when the upstream is missing, so every path that
+creates a workspace-owned branch must configure it — including the synthetic
+`middleman/pr-N` fallback, which tracks the PR's head branch on origin. The
+pushed-head observer pass rewires a missing upstream for same-repo open-PR
+workspaces (head-branch or synthetic checkouts only); fork heads stay
+untracked because origin has no ref for them.
+
 ## Sidebar Ordering
 
 The workspace sidebar has two separate activity concepts:

--- a/docs/superpowers/plans/2026-07-15-workspace-upstream-repository-identity.md
+++ b/docs/superpowers/plans/2026-07-15-workspace-upstream-repository-identity.md
@@ -4,7 +4,7 @@
 
 **Goal:** Prevent workspace pushes from targeting a base-repository branch unless current clone metadata proves the PR head belongs to that repository, while preserving nested GitLab namespaces.
 
-**Architecture:** Encode the approved same/fork/unknown tri-state in the existing nullable `MRHeadRepo` field and refresh it from the current merge-request row before PR setup. Replace the GitHub-only clone-path parser with provider-neutral full-path normalization, then make observer healing trust the current MR row rather than the workspace snapshot.
+**Architecture:** Encode the approved same/fork/unknown tri-state in the existing nullable `MRHeadRepo` field and refresh it from the current merge-request row before PR setup and agent-context generation. Replace the GitHub-only clone-path parser with provider-aware full-path normalization, then make observer healing trust the current MR row rather than the workspace snapshot.
 
 **Tech Stack:** Go, SQLite-backed workspace fixtures, real temporary Git repositories, testify.
 
@@ -31,8 +31,8 @@
 - Modify: `internal/db/types.go`
 
 **Interfaces:**
-- Produces: `normalizeCloneRepoIdentity(cloneURL string) string`, preserving the full clone path.
-- Produces: `workspaceHeadRepo(platformHost, owner, name, cloneURL string) *string`, with the approved tri-state encoding.
+- Produces: `normalizeCloneRepoIdentity(provider, cloneURL string) string`, preserving provider and the full clone path.
+- Produces: `workspaceHeadRepo(provider, platformHost, owner, name, cloneURL string) *string`, with the approved tri-state encoding.
 - Consumes: existing `normalizeCloneURLHost` and `normalizePlatformHostIdentity` host rules.
 
 - [ ] **Step 1: Add failing nested-path and tri-state tests**
@@ -41,12 +41,12 @@ Extend `TestNormalizeCloneRepoIdentity` with:
 
 ```go
 assert.Equal(
-    "gitlab.com/group/subgroup/project",
-    normalizeCloneRepoIdentity("https://gitlab.com/Group/Subgroup/Project.git"),
+    "gitlab/gitlab.com/group/subgroup/project",
+    normalizeCloneRepoIdentity("gitlab", "https://gitlab.com/Group/Subgroup/Project.git"),
 )
 assert.Equal(
-    "gitlab.com/group/subgroup/project",
-    normalizeCloneRepoIdentity("git@gitlab.com:Group/Subgroup/Project.git"),
+    "gitlab/gitlab.com/group/subgroup/project",
+    normalizeCloneRepoIdentity("gitlab", "git@gitlab.com:Group/Subgroup/Project.git"),
 )
 ```
 
@@ -99,8 +99,9 @@ func cloneRepoPath(cloneURL string) string {
 }
 ```
 
-Have `normalizeCloneRepoIdentity` combine the normalized host with this entire
-path and lowercase only the comparison identity. Remove the now-unused
+Have `normalizeCloneRepoIdentity` combine the provider and normalized host with
+this entire path and lowercase only the comparison identity. Thread the
+provider through monitor candidate matching and remove the now-unused
 `internal/github` import.
 
 Change `workspaceHeadRepo` so empty or unparseable clone metadata returns a
@@ -133,6 +134,9 @@ git commit -m "fix: preserve explicit workspace head identity"
 **Files:**
 - Modify: `internal/workspace/manager.go`
 - Modify: `internal/workspace/manager_test.go`
+- Modify: `internal/workspace/agent_context.go`
+- Modify: `internal/workspace/agent_context_test.go`
+- Modify: `internal/server/api_test.go`
 
 **Interfaces:**
 - Produces: `(*Manager).refreshWorkspaceHeadRepo(ctx context.Context, ws *Workspace) error`.
@@ -144,6 +148,10 @@ Add a table test for `refreshWorkspaceHeadRepo` covering current same-repo,
 fork, and missing clone metadata. Seed a persisted PR workspace with the old
 `nil` representation, invoke the helper, and assert the refreshed pointer
 matches the current MR row.
+
+Add an agent-context test that persists the legacy `nil` representation while
+the current MR row has unknown metadata, then verifies launch context does not
+advertise an origin push target.
 
 Add `TestAddWorktreeUnknownHeadRepoDoesNotTrackMatchingOriginBranch`:
 
@@ -163,12 +171,18 @@ assert.Error(err, "unknown repository identity must leave the branch untracked")
 The fixture must configure `origin/<head>` and the provider merge-request ref
 at the same SHA to reproduce the reported attack precondition.
 
+Add `TestWorkspaceRetryLegacyUnknownHeadRepoLeavesBranchUntrackedE2E` in
+`internal/server/api_test.go`. Insert an errored legacy workspace with
+`MRHeadRepo == nil`, retry it through the generated HTTP client, wait for setup,
+and assert the real Git branch has no `branch.<name>.remote` configuration.
+
 - [ ] **Step 2: Run the focused tests and verify RED**
 
 Run:
 
 ```bash
 go test ./internal/workspace -run 'TestRefreshWorkspaceHeadRepo|TestAddWorktreeUnknownHeadRepoDoesNotTrackMatchingOriginBranch' -shuffle=on
+go test ./internal/server -run '^TestWorkspaceRetryLegacyUnknownHeadRepoLeavesBranchUntrackedE2E$' -shuffle=on
 ```
 
 Expected: the refresh helper is missing and current creation classifies empty
@@ -204,7 +218,7 @@ func (m *Manager) refreshWorkspaceHeadRepo(
         cloneURL = mr.HeadRepoCloneURL
     }
     ws.MRHeadRepo = workspaceHeadRepo(
-        ws.PlatformHost, ws.RepoOwner, ws.RepoName, cloneURL,
+        ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName, cloneURL,
     )
     return nil
 }
@@ -283,7 +297,7 @@ Remove the early `ws.MRHeadRepo != nil` rejection from
 
 ```go
 if strings.TrimSpace(mr.HeadRepoCloneURL) == "" || workspaceHeadRepo(
-    ws.PlatformHost, ws.RepoOwner, ws.RepoName, mr.HeadRepoCloneURL,
+    ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName, mr.HeadRepoCloneURL,
 ) != nil {
     return false, nil
 }

--- a/docs/superpowers/plans/2026-07-15-workspace-upstream-repository-identity.md
+++ b/docs/superpowers/plans/2026-07-15-workspace-upstream-repository-identity.md
@@ -1,0 +1,361 @@
+# Workspace Upstream Repository Identity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent workspace pushes from targeting a base-repository branch unless current clone metadata proves the PR head belongs to that repository, while preserving nested GitLab namespaces.
+
+**Architecture:** Encode the approved same/fork/unknown tri-state in the existing nullable `MRHeadRepo` field and refresh it from the current merge-request row before PR setup. Replace the GitHub-only clone-path parser with provider-neutral full-path normalization, then make observer healing trust the current MR row rather than the workspace snapshot.
+
+**Tech Stack:** Go, SQLite-backed workspace fixtures, real temporary Git repositories, testify.
+
+## Global Constraints
+
+- Do not add a database migration or compatibility shim.
+- `nil` means confirmed same repository; non-nil empty means unknown; non-nil URL means confirmed fork.
+- Branch names and commit SHA equality never authorize an upstream.
+- Preserve the complete provider repository path, including GitLab nested namespaces.
+- Unknown and fork heads use provider merge-request refs and remain untracked.
+- Run direct `go test` commands with `-shuffle=on`, without `-v` or `-count=1`.
+- Use testify assertions and existing workspace Git fixtures.
+
+---
+
+### Task 1: Normalize Full Repository Identity And Encode The Tri-State
+
+**Files:**
+- Modify: `internal/workspace/monitor.go`
+- Modify: `internal/workspace/monitor_test.go`
+- Modify: `internal/workspace/manager.go`
+- Modify: `internal/workspace/manager_test.go`
+- Modify: `internal/workspace/agent_context.go`
+- Modify: `internal/db/types.go`
+
+**Interfaces:**
+- Produces: `normalizeCloneRepoIdentity(cloneURL string) string`, preserving the full clone path.
+- Produces: `workspaceHeadRepo(platformHost, owner, name, cloneURL string) *string`, with the approved tri-state encoding.
+- Consumes: existing `normalizeCloneURLHost` and `normalizePlatformHostIdentity` host rules.
+
+- [ ] **Step 1: Add failing nested-path and tri-state tests**
+
+Extend `TestNormalizeCloneRepoIdentity` with:
+
+```go
+assert.Equal(
+    "gitlab.com/group/subgroup/project",
+    normalizeCloneRepoIdentity("https://gitlab.com/Group/Subgroup/Project.git"),
+)
+assert.Equal(
+    "gitlab.com/group/subgroup/project",
+    normalizeCloneRepoIdentity("git@gitlab.com:Group/Subgroup/Project.git"),
+)
+```
+
+Extend `TestCreatePRHeadRepoClassification` with an `unknown` expectation and a
+nested GitLab same-repository case. The unknown assertion must require a
+non-nil pointer whose value is empty:
+
+```go
+require.NotNil(t, ws.MRHeadRepo)
+assert.Empty(*ws.MRHeadRepo)
+```
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run:
+
+```bash
+go test ./internal/workspace -run 'TestNormalizeCloneRepoIdentity|TestCreatePRHeadRepoClassification' -shuffle=on
+```
+
+Expected: nested GitLab identity is truncated to the final `owner/repo`, and
+missing metadata still produces `MRHeadRepo == nil`.
+
+- [ ] **Step 3: Implement full path parsing and tri-state classification**
+
+Replace the GitHub-only path parser with a local helper shaped as follows:
+
+```go
+func cloneRepoPath(cloneURL string) string {
+    var repoPath string
+    if strings.Contains(cloneURL, "://") {
+        parsed, err := url.Parse(cloneURL)
+        if err != nil {
+            return ""
+        }
+        repoPath = parsed.Path
+    } else {
+        beforePath, path, ok := strings.Cut(cloneURL, ":")
+        if !ok || !strings.Contains(beforePath, "@") {
+            return ""
+        }
+        repoPath = path
+    }
+    repoPath = strings.Trim(strings.TrimSpace(repoPath), "/")
+    repoPath = strings.TrimSuffix(repoPath, ".git")
+    if strings.Count(repoPath, "/") < 1 {
+        return ""
+    }
+    return repoPath
+}
+```
+
+Have `normalizeCloneRepoIdentity` combine the normalized host with this entire
+path and lowercase only the comparison identity. Remove the now-unused
+`internal/github` import.
+
+Change `workspaceHeadRepo` so empty or unparseable clone metadata returns a
+pointer to an empty string, an exact base match returns `nil`, and a different
+identity returns a pointer to the original clone URL.
+
+Update `db.Workspace.MRHeadRepo`'s comment with the three states. In
+`BuildAgentContext`, populate `ForkHeadRepo` only when the pointer is non-nil
+and its trimmed value is non-empty.
+
+- [ ] **Step 4: Run the focused tests and verify GREEN**
+
+Run:
+
+```bash
+go test ./internal/workspace -run 'TestNormalizeCloneRepoIdentity|TestCreatePRHeadRepoClassification|TestBuildAgentContext' -shuffle=on
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the identity model**
+
+```bash
+git add internal/workspace/monitor.go internal/workspace/monitor_test.go internal/workspace/manager.go internal/workspace/manager_test.go internal/workspace/agent_context.go internal/db/types.go
+git commit -m "fix: preserve explicit workspace head identity"
+```
+
+### Task 2: Reclassify Before Setup And Block Same-SHA Push Redirection
+
+**Files:**
+- Modify: `internal/workspace/manager.go`
+- Modify: `internal/workspace/manager_test.go`
+
+**Interfaces:**
+- Produces: `(*Manager).refreshWorkspaceHeadRepo(ctx context.Context, ws *Workspace) error`.
+- Consumes: `workspaceHeadRepo` from Task 1 and the current merge-request row.
+
+- [ ] **Step 1: Add failing setup and security regression tests**
+
+Add a table test for `refreshWorkspaceHeadRepo` covering current same-repo,
+fork, and missing clone metadata. Seed a persisted PR workspace with the old
+`nil` representation, invoke the helper, and assert the refreshed pointer
+matches the current MR row.
+
+Add `TestAddWorktreeUnknownHeadRepoDoesNotTrackMatchingOriginBranch`:
+
+```go
+repoID := seedRepo(t, d, "github.com", "acme", "widget")
+seedMRWithHeadRepo(t, d, repoID, prNumber, headBranch, "")
+ws, err := mgr.Create(t.Context(), "github", "github.com", "acme", "widget", prNumber)
+require.NoError(err)
+require.NotNil(ws.MRHeadRepo)
+
+branch, err := mgr.addWorktreeLocked(t.Context(), cloneDir, false, ws)
+require.NoError(err)
+_, err = gitConfigValue(t.Context(), ws.WorktreePath, "branch."+branch+".remote")
+assert.Error(err, "unknown repository identity must leave the branch untracked")
+```
+
+The fixture must configure `origin/<head>` and the provider merge-request ref
+at the same SHA to reproduce the reported attack precondition.
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run:
+
+```bash
+go test ./internal/workspace -run 'TestRefreshWorkspaceHeadRepo|TestAddWorktreeUnknownHeadRepoDoesNotTrackMatchingOriginBranch' -shuffle=on
+```
+
+Expected: the refresh helper is missing and current creation classifies empty
+metadata as same repository before Task 1 is applied; after Task 1, the helper
+test remains RED until setup refresh is wired.
+
+- [ ] **Step 3: Reclassify PR workspaces before Git mutation**
+
+Implement:
+
+```go
+func (m *Manager) refreshWorkspaceHeadRepo(
+    ctx context.Context, ws *Workspace,
+) error {
+    if ws.ItemType != db.WorkspaceItemTypePullRequest {
+        return nil
+    }
+    repo, err := m.workspaceRepo(ctx, ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName)
+    if err != nil {
+        return fmt.Errorf("look up workspace repo: %w", err)
+    }
+    if repo == nil {
+        unknown := ""
+        ws.MRHeadRepo = &unknown
+        return nil
+    }
+    mr, err := m.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, ws.ItemNumber)
+    if err != nil {
+        return fmt.Errorf("look up workspace merge request: %w", err)
+    }
+    cloneURL := ""
+    if mr != nil {
+        cloneURL = mr.HeadRepoCloneURL
+    }
+    ws.MRHeadRepo = workspaceHeadRepo(
+        ws.PlatformHost, ws.RepoOwner, ws.RepoName, cloneURL,
+    )
+    return nil
+}
+```
+
+Call it at the beginning of `SetupWithWorktreeBasePath`, before existing
+worktree provenance or clone selection. Unknown becomes fork-safe because the
+existing setup decision tree treats any non-nil `MRHeadRepo` as requiring the
+provider merge-request ref and disallowing local-base reuse.
+
+Update the fallback-upstream comment: confirmed same-repository identity is the
+authorization; SHA equality is only an additional checkout-consistency check.
+
+- [ ] **Step 4: Run the focused tests and verify GREEN**
+
+Run:
+
+```bash
+go test ./internal/workspace -run 'TestRefreshWorkspaceHeadRepo|TestAddWorktreeUnknownHeadRepoDoesNotTrackMatchingOriginBranch|TestAddWorktreeFallbackBranchTracksPRHeadBranch' -shuffle=on
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the safe setup routing**
+
+```bash
+git add internal/workspace/manager.go internal/workspace/manager_test.go
+git commit -m "fix: require repository identity before workspace tracking"
+```
+
+### Task 3: Heal From Current Nested Repository Metadata
+
+**Files:**
+- Modify: `internal/workspace/pushed_head_observer.go`
+- Modify: `internal/workspace/pushed_head_observer_test.go`
+
+**Interfaces:**
+- Consumes: provider-neutral full-path normalization from Task 1.
+- Produces: observer healing based solely on the current MR row's explicit same-repository evidence.
+
+- [ ] **Step 1: Add failing observer regression cases**
+
+Extend `TestPushedHeadObserverUpstreamHeal` so a workspace carrying an empty
+non-nil historical `MRHeadRepo` heals when the current MR row has a confirmed
+same-repository clone URL.
+
+Add a nested GitLab case with:
+
+```go
+platformHost := "gitlab.com"
+owner := "group/subgroup"
+name := "project"
+headRepoCloneURL := "https://gitlab.com/group/subgroup/project.git"
+```
+
+Assert one `SetBranchUpstream` call. Add a direct table test of
+`configureMissingUpstream` for provider-issue and Kata-task workspaces whose
+refresh-mapped associated PR has confirmed same-repository metadata.
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run:
+
+```bash
+go test ./internal/workspace -run 'TestPushedHeadObserverUpstreamHeal|TestConfigureMissingUpstreamForRefreshMappedWorkspaces' -shuffle=on
+```
+
+Expected: nested GitLab comparison fails with the truncated path, and a
+workspace's non-nil unknown snapshot blocks healing before current-row
+classification is evaluated.
+
+- [ ] **Step 3: Make the current MR row authoritative**
+
+Remove the early `ws.MRHeadRepo != nil` rejection from
+`configureMissingUpstream`. Retain the current-row gate:
+
+```go
+if strings.TrimSpace(mr.HeadRepoCloneURL) == "" || workspaceHeadRepo(
+    ws.PlatformHost, ws.RepoOwner, ws.RepoName, mr.HeadRepoCloneURL,
+) != nil {
+    return false, nil
+}
+```
+
+This permits historical unknown/fork snapshots to heal only after refresh
+proves the current head is in the base repository. Fork and unknown current
+rows remain untracked.
+
+- [ ] **Step 4: Run the focused tests and verify GREEN**
+
+Run:
+
+```bash
+go test ./internal/workspace -run 'TestPushedHeadObserverUpstreamHeal|TestConfigureMissingUpstreamForRefreshMappedWorkspaces' -shuffle=on
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit observer healing**
+
+```bash
+git add internal/workspace/pushed_head_observer.go internal/workspace/pushed_head_observer_test.go
+git commit -m "fix: heal workspace upstreams from current repo identity"
+```
+
+### Task 4: Verify The Complete Workspace Behavior
+
+**Files:**
+- Review: `context/workspace-apis.md`
+- Review: `docs/superpowers/specs/2026-07-15-workspace-upstream-repository-identity-design.md`
+- Review: all files modified by Tasks 1-3
+
+**Interfaces:**
+- Consumes: all preceding tasks.
+- Produces: verified security and nested-namespace behavior with no unrelated diff.
+
+- [ ] **Step 1: Format modified Go files**
+
+Run `gofmt -w` on the exact Go files changed by Tasks 1-3.
+
+- [ ] **Step 2: Run the full workspace package suite**
+
+```bash
+go test ./internal/workspace -shuffle=on
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run the short repository suite**
+
+```bash
+make test-short
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Review the final diff and context**
+
+Run:
+
+```bash
+git diff --check
+git status --short
+scripts/context-sync --check
+```
+
+Confirm the existing Branch Upstream context states that SHA equality is not
+repository identity evidence. Update it only if implementation changes the
+approved invariant.
+
+- [ ] **Step 5: Commit any verification-driven correction**
+
+If formatting or verification required a code correction, stage only those
+files and create a new conventional commit. Do not amend any prior commit.

--- a/docs/superpowers/specs/2026-07-15-workspace-upstream-repository-identity-design.md
+++ b/docs/superpowers/specs/2026-07-15-workspace-upstream-repository-identity-design.md
@@ -16,8 +16,8 @@ namespace so same-repository merge requests under paths such as
 PR head identity has three states:
 
 - **same repository**: a non-empty, parseable head clone URL resolves to the
-  workspace's normalized base repository identity;
-- **fork**: a non-empty, parseable head clone URL resolves to a different
+  workspace's provider, normalized host, and complete base repository path;
+- **fork**: that provider-aware identity differs from the workspace's base
   repository identity;
 - **unknown**: the clone URL is empty or cannot be normalized.
 
@@ -72,14 +72,14 @@ associated PR and supplies explicit same-repository metadata.
 
 ## Clone URL Normalization
 
-Repository identity normalization keeps the normalized host and the complete
-repository path. It supports URL clone forms and SCP-style SSH forms while
-trimming surrounding slashes and a final `.git` suffix.
+Repository identity normalization keeps the provider, normalized host, and the
+complete repository path. It supports URL clone forms and SCP-style SSH forms
+while trimming surrounding slashes and a final `.git` suffix.
 
 Examples:
 
-- `https://gitlab.com/group/subgroup/project.git` becomes
-  `gitlab.com/group/subgroup/project`;
+- provider `gitlab` plus `https://gitlab.com/group/subgroup/project.git`
+  becomes `gitlab/gitlab.com/group/subgroup/project`;
 - `git@gitlab.com:group/subgroup/project.git` becomes the same identity;
 - existing two-segment GitHub and self-hosted identities remain unchanged.
 
@@ -101,10 +101,12 @@ Regression coverage will prove:
   associated-PR metadata proves a same-repository head;
 - malformed or absent clone metadata remains untracked.
 
-Tests stay in the workspace package because they exercise its owned repository
-classification and Git branch behavior. No provider container is required: the
-defects are deterministic identity and local Git configuration logic rather
-than upstream API-shape drift.
+Workspace-package tests cover repository classification, Git branch behavior,
+observer healing, and refresh-mapped issue/Kata workspaces. A server e2e test
+uses the generated HTTP client, real SQLite, and real temporary Git repositories
+to retry a legacy unknown workspace and verify its branch remains untracked.
+No provider container is required because the defect is deterministic local
+identity and Git configuration logic rather than upstream API-shape drift.
 
 ## Scope
 

--- a/docs/superpowers/specs/2026-07-15-workspace-upstream-repository-identity-design.md
+++ b/docs/superpowers/specs/2026-07-15-workspace-upstream-repository-identity-design.md
@@ -1,0 +1,114 @@
+# Workspace Upstream Repository Identity
+
+## Purpose
+
+Workspace branches must never acquire a push upstream from branch names or
+commit equality alone. Forks preserve commit IDs, so an untrusted fork can have
+the same head branch name and commit as a base-repository branch without being
+authorized to push to that base branch.
+
+This change also makes repository comparison preserve GitLab's complete nested
+namespace so same-repository merge requests under paths such as
+`group/subgroup/project` can be classified and healed correctly.
+
+## Head Repository Identity
+
+PR head identity has three states:
+
+- **same repository**: a non-empty, parseable head clone URL resolves to the
+  workspace's normalized base repository identity;
+- **fork**: a non-empty, parseable head clone URL resolves to a different
+  repository identity;
+- **unknown**: the clone URL is empty or cannot be normalized.
+
+Unknown is a conservative safety state for historical workspace rows,
+temporarily incomplete provider payloads, or malformed clone metadata. Direct
+PR workspace creation is expected to receive usable head-repository metadata,
+but must remain safe if that expectation is violated. Kata-task and provider-
+issue workspaces may legitimately remain unknown until refresh maps an
+associated PR and supplies its head-repository evidence.
+
+The existing nullable `MRHeadRepo` field will encode the distinction without a
+schema migration:
+
+- `nil` means confirmed same repository;
+- a non-nil empty string means unknown;
+- a non-nil URL means confirmed fork.
+
+Code that presents fork information to users must require a non-empty value;
+non-nil alone is only the setup-routing signal for a fork-safe checkout.
+
+## Creation And Setup
+
+Workspace creation classifies the current merge-request row and persists the
+tri-state representation. Before setup or retry mutates Git state, the manager
+reclassifies from the current merge-request row so older rows that collapsed
+unknown into `nil` do not retain the unsafe assumption.
+
+Confirmed same-repository heads may use `origin/<head>` and configure it as the
+upstream. Confirmed forks and unknown heads use the provider's merge-request
+head ref, create a branch without an `origin/<head>` upstream, and never reuse a
+local-base checkout as proof of ownership.
+
+If a fork or unknown head cannot be materialized from the provider's
+merge-request ref, setup fails rather than falling back to a same-named base
+branch. Matching SHAs may confirm checkout content but never authorize a push
+target.
+
+## Observer Healing
+
+The pushed-head observer classifies repository identity from the current
+merge-request row rather than trusting the workspace's creation-time pointer.
+It configures a missing upstream only when all of these are true:
+
+- the current head clone URL proves the head is in the base repository;
+- the checked-out branch is the PR head branch or middleman's synthetic PR
+  branch;
+- `origin/<head>` exists.
+
+Fork and unknown states remain untracked. A historical workspace, Kata-task
+workspace, or provider-issue workspace may heal later when refresh maps its
+associated PR and supplies explicit same-repository metadata.
+
+## Clone URL Normalization
+
+Repository identity normalization keeps the normalized host and the complete
+repository path. It supports URL clone forms and SCP-style SSH forms while
+trimming surrounding slashes and a final `.git` suffix.
+
+Examples:
+
+- `https://gitlab.com/group/subgroup/project.git` becomes
+  `gitlab.com/group/subgroup/project`;
+- `git@gitlab.com:group/subgroup/project.git` becomes the same identity;
+- existing two-segment GitHub and self-hosted identities remain unchanged.
+
+Local filesystem paths and malformed clone strings remain unparseable and
+therefore classify as unknown.
+
+## Tests
+
+Regression coverage will prove:
+
+- missing head-repository metadata cannot configure an upstream even when a
+  same-named `origin` branch and the workspace have the same SHA;
+- confirmed same-repository workspaces continue to configure the correct
+  upstream;
+- confirmed forks remain fork-safe;
+- nested-group GitLab merge requests classify as same repository during
+  creation and can be healed by the observer;
+- Kata-task and provider-issue workspaces remain untracked until refreshed
+  associated-PR metadata proves a same-repository head;
+- malformed or absent clone metadata remains untracked.
+
+Tests stay in the workspace package because they exercise its owned repository
+classification and Git branch behavior. No provider container is required: the
+defects are deterministic identity and local Git configuration logic rather
+than upstream API-shape drift.
+
+## Scope
+
+This change does not add a migration, compatibility alias, alternate push path,
+or provider-specific fallback. It changes only workspace head-repository
+classification, clone URL normalization, upstream authorization, and focused
+regression coverage.

--- a/internal/db/types.go
+++ b/internal/db/types.go
@@ -732,7 +732,9 @@ type Workspace struct {
 	ItemKey            string
 	AssociatedPRNumber *int
 	GitHeadRef         string
-	MRHeadRepo         *string // nil for same-repo PRs
+	// MRHeadRepo is nil for confirmed same-repo PRs, non-nil empty when
+	// repository identity is unknown, and non-nil with a clone URL for forks.
+	MRHeadRepo *string
 	// WorkspaceBranch is the exact branch name checked out in the
 	// worktree after setup. Before setup completes it may contain the
 	// requested branch name or workspaceBranchUnknown.

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -25583,9 +25583,14 @@ func TestWorkspaceListRestoresAheadBehindAfterUpstreamHealE2E(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
-	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, nil)
+	client, database, _, _, srv := setupTestServerWithWorkspacesServer(t, nil)
 	ctx := context.Background()
 	ws := createReadyWorkspace(t, ctx, client)
+
+	// The observer only rewires an upstream when the merge-request row
+	// positively places the head branch in the base repository.
+	seedPR(t, database, "acme", "widget", 1,
+		withSeedPRHeadRepoCloneURL("https://github.com/acme/widget.git"))
 
 	runGit(t, ws.WorktreePath, "config", "user.email", "test@test.com")
 	runGit(t, ws.WorktreePath, "config", "user.name", "Test")

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -1216,25 +1216,26 @@ func seedPR(t *testing.T, database *db.DB, owner, name string, number int, opts 
 	numberText := strconv.Itoa(number)
 	now := time.Now().UTC().Truncate(time.Second)
 	pr := &db.MergeRequest{
-		RepoID:         repoID,
-		PlatformID:     int64(number) * 1000,
-		Number:         number,
-		URL:            "https://github.com/" + owner + "/" + name + "/pull/" + numberText,
-		Title:          "Test PR #" + numberText,
-		Author:         "testuser",
-		State:          "open",
-		IsDraft:        false,
-		Body:           "test body",
-		HeadBranch:     "feature",
-		BaseBranch:     "main",
-		Additions:      5,
-		Deletions:      2,
-		CommentCount:   0,
-		ReviewDecision: "",
-		CIStatus:       "",
-		CreatedAt:      now,
-		UpdatedAt:      now,
-		LastActivityAt: now,
+		RepoID:           repoID,
+		PlatformID:       int64(number) * 1000,
+		Number:           number,
+		URL:              "https://github.com/" + owner + "/" + name + "/pull/" + numberText,
+		Title:            "Test PR #" + numberText,
+		Author:           "testuser",
+		State:            "open",
+		IsDraft:          false,
+		Body:             "test body",
+		HeadBranch:       "feature",
+		HeadRepoCloneURL: "https://github.com/" + owner + "/" + name + ".git",
+		BaseBranch:       "main",
+		Additions:        5,
+		Deletions:        2,
+		CommentCount:     0,
+		ReviewDecision:   "",
+		CIStatus:         "",
+		CreatedAt:        now,
+		UpdatedAt:        now,
+		LastActivityAt:   now,
 	}
 	for _, opt := range opts {
 		opt(pr)
@@ -29797,6 +29798,61 @@ func TestWorkspaceCreateSameRepoHeadCloneURLTracksOriginBranchE2E(t *testing.T) 
 			t, ws.WorktreePath,
 			"config", "--get", "branch.feature.merge",
 		),
+	)
+}
+
+func TestWorkspaceRetryLegacyUnknownHeadRepoLeavesBranchUntrackedE2E(t *testing.T) {
+	t.Parallel()
+
+	assert := assert.New(t)
+	require := require.New(t)
+	fixture := setupWorkspaceServerFixture(t, nil)
+	ctx := t.Context()
+
+	headSHA := testGitSHA(t, fixture.remote, "refs/heads/feature")
+	runGit(t, fixture.remote, "update-ref", "refs/pull/2/head", headSHA)
+	seedPR(
+		t, fixture.database, "acme", "widget", 2,
+		withSeedPRHeadRepoCloneURL(""),
+	)
+	errMessage := "retry legacy workspace"
+	const workspaceID = "legacy-unknown-head-repo"
+	require.NoError(fixture.database.InsertWorkspace(ctx, &db.Workspace{
+		ID:              workspaceID,
+		Platform:        "github",
+		PlatformHost:    "github.com",
+		RepoOwner:       "acme",
+		RepoName:        "widget",
+		ItemType:        db.WorkspaceItemTypePullRequest,
+		ItemNumber:      2,
+		GitHeadRef:      "feature",
+		MRHeadRepo:      nil,
+		WorkspaceBranch: "__middleman_unknown__",
+		WorktreePath:    filepath.Join(fixture.worktrees, workspaceID),
+		TmuxSession:     "middleman-" + workspaceID,
+		Status:          "error",
+		ErrorMessage:    &errMessage,
+	}))
+
+	retryResp, err := fixture.client.HTTP.RetryWorkspaceWithResponse(ctx, workspaceID)
+	require.NoError(err)
+	require.Equal(http.StatusAccepted, retryResp.StatusCode())
+
+	ready := waitForWorkspaceReady(t, ctx, fixture.client, workspaceID)
+	assert.Equal(headSHA, testGitSHA(t, ready.WorktreePath, "HEAD"))
+	branch := gitOutput(t, ready.WorktreePath, "branch", "--show-current")
+	remoteOut, remoteErrOut, upstreamErr := gitcmd.New().Run(
+		ctx, ready.WorktreePath, nil,
+		"config", "--get", "branch."+branch+".remote",
+	)
+	mergeOut, _, _ := gitcmd.New().Run(
+		ctx, ready.WorktreePath, nil,
+		"config", "--get", "branch."+branch+".merge",
+	)
+	assert.Error(
+		upstreamErr,
+		"legacy unknown workspace must remain untracked after retry; branch=%q remote=%q merge=%q stderr=%q",
+		branch, strings.TrimSpace(string(remoteOut)), strings.TrimSpace(string(mergeOut)), strings.TrimSpace(string(remoteErrOut)),
 	)
 }
 

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -25570,6 +25570,69 @@ func TestWorkspaceListReportsCommitsAheadBehindE2E(t *testing.T) {
 	assert.Equal(int64(0), *found.CommitsBehind)
 }
 
+// TestWorkspaceListRestoresAheadBehindAfterUpstreamHealE2E covers the repair
+// path for workspaces whose branch lost (or never received) an upstream —
+// the state every synthetic middleman/pr-N fallback branch was created in
+// before upstreams were configured at worktree add. The list must omit the
+// counts while the upstream is missing, and a pushed-head observer pass must
+// rewire the branch to the PR head branch so the counts come back without
+// recreating the workspace.
+func TestWorkspaceListRestoresAheadBehindAfterUpstreamHealE2E(t *testing.T) {
+	t.Parallel()
+
+	require := require.New(t)
+	assert := assert.New(t)
+
+	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, nil)
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+
+	runGit(t, ws.WorktreePath, "config", "user.email", "test@test.com")
+	runGit(t, ws.WorktreePath, "config", "user.name", "Test")
+	require.NoError(os.WriteFile(
+		filepath.Join(ws.WorktreePath, "ahead-1.txt"),
+		[]byte("a1\n"), 0o644,
+	))
+	runGit(t, ws.WorktreePath, "add", ".")
+	runGit(t, ws.WorktreePath, "commit", "-m", "ahead 1")
+
+	// Strip the branch's upstream configuration to reproduce a workspace
+	// created by the fallback path.
+	branch := ws.GitHeadRef
+	runGit(t, ws.WorktreePath, "config", "--unset", "branch."+branch+".remote")
+	runGit(t, ws.WorktreePath, "config", "--unset", "branch."+branch+".merge")
+
+	findWorkspace := func() *generated.WorkspaceResponse {
+		listResp, err := client.HTTP.ListWorkspacesWithResponse(ctx)
+		require.NoError(err)
+		require.Equal(http.StatusOK, listResp.StatusCode())
+		require.NotNil(listResp.JSON200)
+		require.NotNil(listResp.JSON200.Workspaces)
+		for i := range *listResp.JSON200.Workspaces {
+			entry := &(*listResp.JSON200.Workspaces)[i]
+			if entry.Id == ws.Id {
+				return entry
+			}
+		}
+		require.Fail("workspace missing from list", ws.Id)
+		return nil
+	}
+
+	broken := findWorkspace()
+	require.Nil(broken.CommitsAhead,
+		"counts must be omitted while the branch has no upstream")
+	require.Nil(broken.CommitsBehind)
+
+	srv.runWorkspacePushedHeadObserverPass(ctx)
+
+	healed := findWorkspace()
+	require.NotNil(healed.CommitsAhead,
+		"observer pass must restore the branch upstream")
+	require.NotNil(healed.CommitsBehind)
+	assert.Equal(int64(1), *healed.CommitsAhead)
+	assert.Equal(int64(0), *healed.CommitsBehind)
+}
+
 func TestWorkspaceDiffEndpointsReportHeadAndPushedE2E(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/e2etest/settings_test.go
+++ b/internal/server/e2etest/settings_test.go
@@ -1144,19 +1144,23 @@ func seedSettingsWorkspaceMR(
 	repoID int64, number int, headBranch string,
 ) {
 	t.Helper()
+	repo, err := database.GetRepoByID(t.Context(), repoID)
+	require.NoError(t, err)
+	require.NotNil(t, repo)
 	now := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
-	_, err := database.UpsertMergeRequest(t.Context(), &db.MergeRequest{
-		RepoID:         repoID,
-		PlatformID:     repoID*10000 + int64(number),
-		Number:         number,
-		Title:          "Test PR",
-		Author:         "author",
-		State:          db.MergeRequestStateOpen,
-		HeadBranch:     headBranch,
-		BaseBranch:     "main",
-		CreatedAt:      now,
-		UpdatedAt:      now,
-		LastActivityAt: now,
+	_, err = database.UpsertMergeRequest(t.Context(), &db.MergeRequest{
+		RepoID:           repoID,
+		PlatformID:       repoID*10000 + int64(number),
+		Number:           number,
+		Title:            "Test PR",
+		Author:           "author",
+		State:            db.MergeRequestStateOpen,
+		HeadBranch:       headBranch,
+		HeadRepoCloneURL: "https://" + repo.PlatformHost + "/" + repo.Owner + "/" + repo.Name + ".git",
+		BaseBranch:       "main",
+		CreatedAt:        now,
+		UpdatedAt:        now,
+		LastActivityAt:   now,
 	})
 	require.NoError(t, err)
 }

--- a/internal/workspace/agent_context.go
+++ b/internal/workspace/agent_context.go
@@ -192,6 +192,9 @@ func (m *Manager) PrepareAgentLaunchContext(
 	if summary == nil {
 		return ErrWorkspaceNotFound
 	}
+	if err := m.refreshWorkspaceHeadRepo(ctx, &summary.Workspace); err != nil {
+		return fmt.Errorf("refresh workspace head repository: %w", err)
+	}
 
 	writable, err := generatedFileWritable(filepath.Join(summary.WorktreePath, relPath))
 	if err != nil {

--- a/internal/workspace/agent_context.go
+++ b/internal/workspace/agent_context.go
@@ -45,6 +45,9 @@ type AgentContext struct {
 	// push must target to update the PR. It is forge-side state, unlike the
 	// locally discoverable checked-out branch.
 	HeadBranch string
+	// HeadRepoUnknown means the PR head repository identity was unavailable,
+	// so no origin push target is authorized.
+	HeadRepoUnknown bool
 	// ForkHeadRepo is set when the PR head lives in a fork, where pushing
 	// to origin does not update the PR.
 	ForkHeadRepo string
@@ -110,7 +113,9 @@ func BuildAgentContext(ws WorkspaceSummary) AgentContext {
 		// Prefer the currently synced PR head branch: the creation-time
 		// GitHeadRef snapshot goes stale when the head branch is renamed.
 		ctx.HeadBranch = firstNonEmpty(stringPtrValue(ws.MRHeadBranch), ws.GitHeadRef)
-		if ws.MRHeadRepo != nil {
+		if ws.MRHeadRepo != nil && strings.TrimSpace(*ws.MRHeadRepo) == "" {
+			ctx.HeadRepoUnknown = true
+		} else if ws.MRHeadRepo != nil {
 			ctx.ForkHeadRepo = *ws.MRHeadRepo
 		}
 	}
@@ -147,6 +152,9 @@ func RenderAgentContext(ctx AgentContext) string {
 	default:
 		writeMarkdownLine(&b, "PR", itemNumberLabel(ctx.ItemNumber))
 		switch {
+		case ctx.HeadRepoUnknown:
+			writeMarkdownLine(&b, "PR head",
+				ctx.HeadBranch+"; repository identity unavailable; no push upstream configured")
 		case ctx.ForkHeadRepo != "":
 			writeMarkdownLine(&b, "PR head",
 				forkHeadLabel(ctx.HeadBranch, ctx.ForkHeadRepo)+"; pushing to origin does not update this PR")

--- a/internal/workspace/agent_context_test.go
+++ b/internal/workspace/agent_context_test.go
@@ -345,6 +345,41 @@ func TestPrepareAgentLaunchContextUsesSyncedHeadBranchForPushTarget(t *testing.T
 	assert.NotContains(string(content), "Working branch")
 }
 
+func TestPrepareAgentLaunchContextRefreshesLegacyUnknownHeadRepo(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
+	seedMRWithHeadRepo(t, d, repoID, 42, "feature/widgets", "")
+	mgr := NewManager(d, t.TempDir())
+	ws, err := mgr.Create(t.Context(), "github", "github.com", "acme", "widget", 42)
+	require.NoError(err)
+	worktree := ws.WorktreePath
+	initWorkspaceGitRepoAt(t, worktree)
+	require.NoError(d.UpdateWorkspaceBranch(t.Context(), ws.ID, "feature/widgets"))
+	require.NoError(d.UpdateWorkspaceStatus(t.Context(), ws.ID, "ready", nil))
+	_, err = d.WriteDB().ExecContext(
+		t.Context(),
+		`UPDATE middleman_workspaces SET mr_head_repo = NULL WHERE id = ?`,
+		ws.ID,
+	)
+	require.NoError(err)
+
+	require.NoError(mgr.PrepareAgentLaunchContext(t.Context(), PrepareAgentLaunchContextOptions{
+		WorkspaceID: ws.ID,
+		TargetKey:   "codex",
+	}))
+
+	content, err := os.ReadFile(filepath.Join(worktree, "AGENTS.local.md"))
+	require.NoError(err)
+	assert.Contains(
+		string(content),
+		"PR head: feature/widgets; repository identity unavailable; no push upstream configured",
+	)
+}
+
 func TestPrepareAgentLaunchContextPreservesUserFileAndRefreshesMarkedFile(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)

--- a/internal/workspace/agent_context_test.go
+++ b/internal/workspace/agent_context_test.go
@@ -59,6 +59,22 @@ func TestBuildAgentContext(t *testing.T) {
 			},
 		},
 		{
+			name: "pull request with unknown head repo has no push target",
+			ws: WorkspaceSummary{
+				Workspace: db.Workspace{
+					ID: "ws-unknown-pr", Platform: "github", PlatformHost: "github.com",
+					RepoOwner: "acme", RepoName: "widget", ItemType: db.WorkspaceItemTypePullRequest,
+					ItemNumber: 44, GitHeadRef: "feature/unknown",
+					MRHeadRepo: ptr(""),
+				},
+			},
+			want: []string{
+				"Source kind: pull request",
+				"PR: #44",
+				"PR head: feature/unknown; repository identity unavailable; no push upstream configured",
+			},
+		},
+		{
 			name: "provider issue",
 			ws: WorkspaceSummary{
 				Workspace: db.Workspace{

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -609,19 +609,20 @@ func issueWorkspaceBranchConflict(
 }
 
 func workspaceHeadRepo(platformHost, owner, name, cloneURL string) *string {
-	if cloneURL == "" {
-		return nil
-	}
 	// MRHeadRepo means "this PR head must be resolved through fork-safe refs"
 	// in setup. GitHub also fills head.repo.clone_url for same-repo PRs, so
 	// compare clone identities before treating a non-empty URL as fork metadata.
 	headRepo := normalizeCloneRepoIdentity(cloneURL)
+	if headRepo == "" {
+		unknown := ""
+		return &unknown
+	}
 	baseRepo := strings.ToLower(strings.Join([]string{
 		normalizePlatformHostIdentity(platformHost),
 		strings.TrimSpace(owner),
 		strings.TrimSpace(name),
 	}, "/"))
-	if headRepo != "" && headRepo == baseRepo {
+	if headRepo == baseRepo {
 		return nil
 	}
 	s := cloneURL

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -288,15 +288,17 @@ func (m *Manager) Create(
 	}
 
 	ws := &Workspace{
-		ID:              id,
-		Platform:        repo.Platform,
-		PlatformHost:    platformHost,
-		RepoOwner:       owner,
-		RepoName:        name,
-		ItemType:        db.WorkspaceItemTypePullRequest,
-		ItemNumber:      mrNumber,
-		GitHeadRef:      mr.HeadBranch,
-		MRHeadRepo:      workspaceHeadRepo(platformHost, owner, name, mr.HeadRepoCloneURL),
+		ID:           id,
+		Platform:     repo.Platform,
+		PlatformHost: platformHost,
+		RepoOwner:    owner,
+		RepoName:     name,
+		ItemType:     db.WorkspaceItemTypePullRequest,
+		ItemNumber:   mrNumber,
+		GitHeadRef:   mr.HeadBranch,
+		MRHeadRepo: workspaceHeadRepo(
+			repo.Platform, platformHost, owner, name, mr.HeadRepoCloneURL,
+		),
 		WorkspaceBranch: workspaceBranchUnknown,
 		WorktreePath: filepath.Join(
 			m.worktreeDir, repo.Platform, platformHost, owner, name,
@@ -608,16 +610,17 @@ func issueWorkspaceBranchConflict(
 	}
 }
 
-func workspaceHeadRepo(platformHost, owner, name, cloneURL string) *string {
+func workspaceHeadRepo(provider, platformHost, owner, name, cloneURL string) *string {
 	// MRHeadRepo means "this PR head must be resolved through fork-safe refs"
 	// in setup. GitHub also fills head.repo.clone_url for same-repo PRs, so
 	// compare clone identities before treating a non-empty URL as fork metadata.
-	headRepo := normalizeCloneRepoIdentity(cloneURL)
+	headRepo := normalizeCloneRepoIdentity(provider, cloneURL)
 	if headRepo == "" {
 		unknown := ""
 		return &unknown
 	}
 	baseRepo := strings.ToLower(strings.Join([]string{
+		strings.TrimSpace(provider),
 		normalizePlatformHostIdentity(platformHost),
 		strings.TrimSpace(owner),
 		strings.TrimSpace(name),
@@ -649,6 +652,12 @@ func (m *Manager) SetupWithWorktreeBasePath(
 		ws.ID, workspaceSetupStageSetup, "started",
 		"starting workspace setup",
 	)
+	if err := m.refreshWorkspaceHeadRepo(ctx, ws); err != nil {
+		return m.failSetup(
+			ctx, ws.ID, workspaceSetupStageSetup,
+			fmt.Errorf("refresh workspace head repository: %w", err),
+		)
+	}
 
 	branch, reusedWorktree, err := m.reuseExistingWorkspaceWorktree(ctx, ws)
 	var gitDir string
@@ -670,6 +679,21 @@ func (m *Manager) SetupWithWorktreeBasePath(
 			return m.failSetup(
 				ctx,
 				ws.ID, workspaceSetupStageWorktree, err,
+			)
+		}
+	}
+	if ws.ItemType == db.WorkspaceItemTypePullRequest && ws.MRHeadRepo != nil {
+		currentBranch, branchErr := worktreeCurrentBranch(ctx, ws.WorktreePath)
+		if branchErr == nil && currentBranch != "" {
+			branchErr = clearBranchUpstream(ctx, ws.WorktreePath, currentBranch)
+		}
+		if branchErr != nil {
+			if !reusedWorktree {
+				m.rollbackWorktree(ctx, gitDir, ws, branch)
+			}
+			return m.failSetup(
+				ctx, ws.ID, workspaceSetupStageWorktree,
+				fmt.Errorf("clear untrusted branch upstream: %w", branchErr),
 			)
 		}
 	}
@@ -725,6 +749,36 @@ func (m *Manager) SetupWithWorktreeBasePath(
 			fmt.Errorf("update status to ready: %w", err),
 		)
 	}
+	return nil
+}
+
+func (m *Manager) refreshWorkspaceHeadRepo(
+	ctx context.Context, ws *Workspace,
+) error {
+	if ws.ItemType != db.WorkspaceItemTypePullRequest {
+		return nil
+	}
+	repo, err := m.workspaceRepo(
+		ctx, ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
+	)
+	if err != nil {
+		return fmt.Errorf("look up workspace repo: %w", err)
+	}
+	cloneURL := ""
+	if repo != nil {
+		mr, lookupErr := m.db.GetMergeRequestByRepoIDAndNumber(
+			ctx, repo.ID, ws.ItemNumber,
+		)
+		if lookupErr != nil {
+			return fmt.Errorf("look up workspace merge request: %w", lookupErr)
+		}
+		if mr != nil {
+			cloneURL = mr.HeadRepoCloneURL
+		}
+	}
+	ws.MRHeadRepo = workspaceHeadRepo(
+		ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName, cloneURL,
+	)
 	return nil
 }
 
@@ -1651,13 +1705,11 @@ func cleanupWorktreeAddOnUpstreamFailure(
 // configureFallbackBranchUpstream points the synthetic PR fallback branch at
 // the PR's head branch on origin, so divergence counts, push, and pull treat
 // the remote PR branch as the sync target exactly like a preferred-name
-// checkout would. A nil MRHeadRepo alone cannot prove the head lives in the
-// base repository (it is also nil when head-repo metadata was unavailable),
-// so the binding additionally requires origin/<head> to resolve to the exact
-// commit this worktree was just materialized at. Fork heads, deleted head
-// branches, and same-named base branches with different content all fail that
-// check and are left without an upstream; the pushed-head observer can wire
-// them later with merge-request-row evidence.
+// checkout would. Setup classifies MRHeadRepo from the current merge-request
+// row before reaching this path, so nil is explicit same-repository evidence.
+// The SHA check is an additional checkout-consistency check, not repository
+// identity evidence: forks preserve commit IDs. Fork and unknown heads take
+// the merge-request-ref path and remain without an origin upstream.
 func configureFallbackBranchUpstream(
 	ctx context.Context,
 	cloneDir string,
@@ -1703,6 +1755,21 @@ func setBranchUpstream(
 		ctx, worktreePath,
 		"config", "branch."+branch+".merge", mergeRef,
 	)
+}
+
+func clearBranchUpstream(ctx context.Context, worktreePath, branch string) error {
+	for _, suffix := range []string{"remote", "merge"} {
+		key := "branch." + branch + "." + suffix
+		if _, err := gitConfigValue(ctx, worktreePath, key); err != nil {
+			continue
+		}
+		if err := runGitWithoutHooks(
+			ctx, worktreePath, "config", "--unset-all", key,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func validateLocalBranchName(

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -1650,8 +1650,13 @@ func cleanupWorktreeAddOnUpstreamFailure(
 // configureFallbackBranchUpstream points the synthetic PR fallback branch at
 // the PR's head branch on origin, so divergence counts, push, and pull treat
 // the remote PR branch as the sync target exactly like a preferred-name
-// checkout would. Fork heads and deleted head branches have no origin
-// tracking ref to bind to and are left without an upstream.
+// checkout would. A nil MRHeadRepo alone cannot prove the head lives in the
+// base repository (it is also nil when head-repo metadata was unavailable),
+// so the binding additionally requires origin/<head> to resolve to the exact
+// commit this worktree was just materialized at. Fork heads, deleted head
+// branches, and same-named base branches with different content all fail that
+// check and are left without an upstream; the pushed-head observer can wire
+// them later with merge-request-row evidence.
 func configureFallbackBranchUpstream(
 	ctx context.Context,
 	cloneDir string,
@@ -1661,7 +1666,20 @@ func configureFallbackBranchUpstream(
 	if ws.MRHeadRepo != nil {
 		return nil
 	}
-	if !gitRefExists(ctx, cloneDir, "refs/remotes/origin/"+ws.GitHeadRef) {
+	trackingSHA, ok, err := gitRefSHA(
+		ctx, cloneDir, "refs/remotes/origin/"+ws.GitHeadRef,
+	)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	headSHA, err := gitHeadSHA(ctx, ws.WorktreePath)
+	if err != nil {
+		return err
+	}
+	if trackingSHA != headSHA {
 		return nil
 	}
 	return setBranchUpstream(

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -1453,6 +1453,14 @@ func (m *Manager) addWorktreeLocked(
 		"-b", fallbackBranch, startRef,
 	)
 	if fallbackErr == nil {
+		if upErr := configureFallbackBranchUpstream(
+			ctx, cloneDir, ws, fallbackBranch,
+		); upErr != nil {
+			cleanupWorktreeAddOnUpstreamFailure(
+				ctx, cloneDir, ws.WorktreePath, fallbackBranch,
+			)
+			return "", fmt.Errorf("configure branch upstream: %w", upErr)
+		}
 		return fallbackBranch, nil
 	}
 	return "", fmt.Errorf(
@@ -1531,15 +1539,8 @@ func (m *Manager) addPreferredWorktree(
 			ctx, ws.WorktreePath, ws.GitHeadRef,
 			"origin", "refs/heads/"+ws.GitHeadRef,
 		); err != nil {
-			cleanupCtx, cancel := cleanupContext(ctx)
-			defer cancel()
-			_ = runGitWithoutHooks(
-				cleanupCtx, cloneDir,
-				"worktree", "remove", "--force", ws.WorktreePath,
-			)
-			_ = runGitWithoutHooks(
-				cleanupCtx, cloneDir,
-				"branch", "-D", "--", ws.GitHeadRef,
+			cleanupWorktreeAddOnUpstreamFailure(
+				ctx, cloneDir, ws.WorktreePath, ws.GitHeadRef,
 			)
 			return "", fmt.Errorf("configure branch upstream: %w", err)
 		}
@@ -1575,11 +1576,10 @@ func (m *Manager) addPreferredWorktree(
 			ctx, ws.WorktreePath, ws.GitHeadRef,
 			"origin", "refs/heads/"+ws.GitHeadRef,
 		); err != nil {
-			cleanupCtx, cancel := cleanupContext(ctx)
-			defer cancel()
-			_ = runGitWithoutHooks(
-				cleanupCtx, cloneDir,
-				"worktree", "remove", "--force", ws.WorktreePath,
+			// Empty branch: the branch pre-existed this workspace and
+			// stays in place; only the worktree is rolled back.
+			cleanupWorktreeAddOnUpstreamFailure(
+				ctx, cloneDir, ws.WorktreePath, "",
 			)
 			return "", fmt.Errorf("configure branch upstream: %w", err)
 		}
@@ -1623,6 +1623,51 @@ func workspaceMergeRequestHeadRef(ws *Workspace) string {
 
 func syntheticPRWorktreeBranch(mrNumber int) string {
 	return fmt.Sprintf("middleman/pr-%d", mrNumber)
+}
+
+// cleanupWorktreeAddOnUpstreamFailure rolls back a just-added worktree (and,
+// when middleman created it, its branch) after configuring the branch
+// upstream failed. Callers must already hold the per-repo lock for cloneDir.
+// An empty branch leaves a pre-existing user-owned branch in place.
+func cleanupWorktreeAddOnUpstreamFailure(
+	ctx context.Context, cloneDir, worktreePath, branch string,
+) {
+	cleanupCtx, cancel := cleanupContext(ctx)
+	defer cancel()
+	_ = runGitWithoutHooks(
+		cleanupCtx, cloneDir,
+		"worktree", "remove", "--force", worktreePath,
+	)
+	if branch == "" {
+		return
+	}
+	_ = runGitWithoutHooks(
+		cleanupCtx, cloneDir,
+		"branch", "-D", "--", branch,
+	)
+}
+
+// configureFallbackBranchUpstream points the synthetic PR fallback branch at
+// the PR's head branch on origin, so divergence counts, push, and pull treat
+// the remote PR branch as the sync target exactly like a preferred-name
+// checkout would. Fork heads and deleted head branches have no origin
+// tracking ref to bind to and are left without an upstream.
+func configureFallbackBranchUpstream(
+	ctx context.Context,
+	cloneDir string,
+	ws *Workspace,
+	fallbackBranch string,
+) error {
+	if ws.MRHeadRepo != nil {
+		return nil
+	}
+	if !gitRefExists(ctx, cloneDir, "refs/remotes/origin/"+ws.GitHeadRef) {
+		return nil
+	}
+	return setBranchUpstream(
+		ctx, ws.WorktreePath, fallbackBranch,
+		"origin", "refs/heads/"+ws.GitHeadRef,
+	)
 }
 
 func setBranchUpstream(

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -336,6 +336,63 @@ func TestCreatePRHeadRepoClassification(t *testing.T) {
 	}
 }
 
+func TestRefreshWorkspaceHeadRepo(t *testing.T) {
+	tests := []struct {
+		name        string
+		cloneURL    string
+		wantUnknown bool
+		wantFork    string
+	}{
+		{
+			name:     "current same-repo metadata",
+			cloneURL: "https://github.com/acme/widget.git",
+		},
+		{
+			name:        "missing current metadata",
+			wantUnknown: true,
+		},
+		{
+			name:     "current fork metadata",
+			cloneURL: "https://github.com/contributor/widget.git",
+			wantFork: "https://github.com/contributor/widget.git",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			d := openTestDB(t)
+			repoID := seedRepo(t, d, "github.com", "acme", "widget")
+			seedMRWithHeadRepo(t, d, repoID, 42, "feature/thing", tt.cloneURL)
+			ws := &Workspace{
+				Platform:     "github",
+				PlatformHost: "github.com",
+				RepoOwner:    "acme",
+				RepoName:     "widget",
+				ItemType:     db.WorkspaceItemTypePullRequest,
+				ItemNumber:   42,
+				GitHeadRef:   "feature/thing",
+			}
+			mgr := NewManager(d, t.TempDir())
+
+			err := mgr.refreshWorkspaceHeadRepo(t.Context(), ws)
+
+			require.NoError(err)
+			switch {
+			case tt.wantUnknown:
+				require.NotNil(ws.MRHeadRepo)
+				assert.Empty(*ws.MRHeadRepo)
+			case tt.wantFork != "":
+				require.NotNil(ws.MRHeadRepo)
+				assert.Equal(tt.wantFork, *ws.MRHeadRepo)
+			default:
+				assert.Nil(ws.MRHeadRepo)
+			}
+		})
+	}
+}
+
 func TestCreateIssueDefaultBranchSluggified(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -637,14 +694,14 @@ func TestSetupFailurePersistsStatusWhenContextCanceled(t *testing.T) {
 
 	err = mgr.Setup(ctx, ws)
 	require.Error(err)
-	require.Contains(err.Error(), "clone manager not set")
+	require.ErrorIs(err, context.Canceled)
 
 	got, err := d.GetWorkspace(t.Context(), ws.ID)
 	require.NoError(err)
 	require.NotNil(got)
 	assert.Equal("error", got.Status)
 	require.NotNil(got.ErrorMessage)
-	assert.Contains(*got.ErrorMessage, "clone manager not set")
+	assert.Contains(*got.ErrorMessage, "context canceled")
 
 	events, err := d.ListWorkspaceSetupEvents(
 		t.Context(), ws.ID,
@@ -653,9 +710,9 @@ func TestSetupFailurePersistsStatusWhenContextCanceled(t *testing.T) {
 	require.Len(events, 2)
 	assert.Equal("setup", events[0].Stage)
 	assert.Equal("started", events[0].Outcome)
-	assert.Equal("clone", events[1].Stage)
+	assert.Equal("setup", events[1].Stage)
 	assert.Equal("failure", events[1].Outcome)
-	assert.Contains(events[1].Message, "clone manager not set")
+	assert.Contains(events[1].Message, "context canceled")
 }
 
 func TestSetupUsesConfiguredWorktreeBasePath(t *testing.T) {
@@ -2220,6 +2277,49 @@ func TestAddWorktreeFallbackBranchTracksPRHeadBranch(t *testing.T) {
 	require.True(ok, "divergence probe must resolve @{upstream}")
 	assert.Equal(0, div.Ahead)
 	assert.Equal(0, div.Behind)
+}
+
+func TestAddWorktreeUnknownHeadRepoDoesNotTrackMatchingOriginBranch(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	cloneDir := setupBareCloneForWorkspaceGitTest(t)
+	const prNumber = 45
+	const headBranch = "feature/unknown-head-repo"
+	headSHA := strings.TrimSpace(string(runWorkspaceTestGit(
+		t, cloneDir, "rev-parse", "main",
+	)))
+	runWorkspaceTestGit(
+		t, cloneDir, "push", "origin",
+		headSHA+":refs/heads/"+headBranch,
+	)
+	runWorkspaceTestGit(
+		t, cloneDir, "push", "origin",
+		fmt.Sprintf("%s:refs/pull/%d/head", headSHA, prNumber),
+	)
+	runWorkspaceTestGit(
+		t, cloneDir, "fetch", "origin",
+		"+refs/heads/"+headBranch+":refs/remotes/origin/"+headBranch,
+	)
+
+	d := openTestDB(t)
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
+	seedMRWithHeadRepo(t, d, repoID, prNumber, headBranch, "")
+	mgr := NewManager(d, t.TempDir())
+	ws, err := mgr.Create(
+		t.Context(), "github", "github.com", "acme", "widget", prNumber,
+	)
+	require.NoError(err)
+
+	branch, err := mgr.addWorktreeLocked(t.Context(), cloneDir, false, ws)
+	require.NoError(err)
+	gotSHA, err := gitHeadSHA(t.Context(), ws.WorktreePath)
+	require.NoError(err)
+	assert.Equal(headSHA, gotSHA)
+	_, err = gitConfigValue(
+		t.Context(), ws.WorktreePath, "branch."+branch+".remote",
+	)
+	assert.Error(err, "unknown repository identity must leave the branch untracked")
 }
 
 func TestAddWorktreeLocalBaseFetchesPullRefWhenHeadBranchDeleted(t *testing.T) {

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -2106,6 +2106,75 @@ func TestAddWorktreeUsesFallbackWhenLocalBasePreferredBranchCheckedOut(t *testin
 	assert.Equal(originSHA, headSHA)
 }
 
+func TestAddWorktreeFallbackBranchTracksPRHeadBranch(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	cloneDir := setupBareCloneForWorkspaceGitTest(t)
+	// Managed clones always carry the remote-tracking refspec (gitclone
+	// EnsureRefspecs); without it git cannot resolve `@{upstream}` from
+	// the branch config this test asserts on.
+	runWorkspaceTestGit(
+		t, cloneDir, "config", "remote.origin.fetch",
+		"+refs/heads/*:refs/remotes/origin/*",
+	)
+	prNumber := 44
+	headBranch := "feature/tracked-fallback"
+	headSHA := configureSameRepoPRRefs(t, cloneDir, headBranch, prNumber)
+
+	// Point the local branch with the preferred name at a divergent
+	// commit so addPreferredWorktree rejects it and the synthetic
+	// fallback branch is used instead.
+	treeOut, err := gitOutput(t.Context(), cloneDir, "rev-parse", "main^{tree}")
+	require.NoError(err)
+	divergentSHA, err := gitOutput(
+		t.Context(), cloneDir,
+		"commit-tree", strings.TrimSpace(treeOut),
+		"-p", headSHA, "-m", "divergent local branch",
+	)
+	require.NoError(err)
+	runWorkspaceTestGit(
+		t, cloneDir, "update-ref",
+		"refs/heads/"+headBranch, strings.TrimSpace(divergentSHA),
+	)
+
+	ws := &Workspace{
+		ID:              "ws-fallback-tracks-head",
+		Platform:        "github",
+		PlatformHost:    "github.com",
+		RepoOwner:       "acme",
+		RepoName:        "widget",
+		ItemType:        db.WorkspaceItemTypePullRequest,
+		ItemNumber:      prNumber,
+		GitHeadRef:      headBranch,
+		WorkspaceBranch: workspaceBranchUnknown,
+		WorktreePath:    filepath.Join(t.TempDir(), "worktree"),
+		TmuxSession:     "ws-fallback-tracks-head",
+		Status:          "creating",
+	}
+	mgr := NewManager(openTestDB(t), t.TempDir())
+
+	branch, err := mgr.addWorktreeLocked(t.Context(), cloneDir, false, ws)
+
+	require.NoError(err)
+	require.Equal(syntheticPRWorktreeBranch(prNumber), branch)
+	remote, err := gitConfigValue(
+		t.Context(), ws.WorktreePath, "branch."+branch+".remote",
+	)
+	require.NoError(err, "fallback branch must track the PR head branch")
+	assert.Equal("origin", remote)
+	mergeRef, err := gitConfigValue(
+		t.Context(), ws.WorktreePath, "branch."+branch+".merge",
+	)
+	require.NoError(err)
+	assert.Equal("refs/heads/"+headBranch, mergeRef)
+	div, ok, err := WorktreeDivergence(t.Context(), ws.WorktreePath)
+	require.NoError(err)
+	require.True(ok, "divergence probe must resolve @{upstream}")
+	assert.Equal(0, div.Ahead)
+	assert.Equal(0, div.Behind)
+}
+
 func TestAddWorktreeLocalBaseFetchesPullRefWhenHeadBranchDeleted(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -2472,6 +2541,12 @@ func TestAddWorktreeMergedSameRepoPRUsesPullRefWhenHeadBranchDeleted(
 	gotSHA, err := gitHeadSHA(t.Context(), ws.WorktreePath)
 	require.NoError(err)
 	assert.Equal(headSHA, gotSHA)
+	// The head branch no longer exists on origin, so there is nothing
+	// for the fallback branch to track.
+	_, err = gitConfigValue(
+		t.Context(), ws.WorktreePath, "branch."+branch+".remote",
+	)
+	assert.Error(err, "deleted head branch must not be configured as upstream")
 }
 
 func TestAddWorktreeGitLabMRUsesMergeRequestRefWhenHeadBranchDeleted(

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -62,21 +62,25 @@ func seedMR(
 	repoID int64, number int, headBranch string,
 ) {
 	t.Helper()
+	repo, err := d.GetRepoByID(t.Context(), repoID)
+	require.NoError(t, err)
+	require.NotNil(t, repo)
 	now := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
 	mr := &db.MergeRequest{
-		RepoID:         repoID,
-		PlatformID:     repoID*10000 + int64(number),
-		Number:         number,
-		Title:          "Test PR",
-		Author:         "author",
-		State:          "open",
-		HeadBranch:     headBranch,
-		BaseBranch:     "main",
-		CreatedAt:      now,
-		UpdatedAt:      now,
-		LastActivityAt: now,
+		RepoID:           repoID,
+		PlatformID:       repoID*10000 + int64(number),
+		Number:           number,
+		Title:            "Test PR",
+		Author:           "author",
+		State:            "open",
+		HeadBranch:       headBranch,
+		HeadRepoCloneURL: "https://" + repo.PlatformHost + "/" + repo.Owner + "/" + repo.Name + ".git",
+		BaseBranch:       "main",
+		CreatedAt:        now,
+		UpdatedAt:        now,
+		LastActivityAt:   now,
 	}
-	_, err := d.UpsertMergeRequest(t.Context(), mr)
+	_, err = d.UpsertMergeRequest(t.Context(), mr)
 	require.NoError(t, err)
 }
 
@@ -225,11 +229,15 @@ func TestWorkspaceSummaryCacheDoesNotResurrectDeletedWorkspace(t *testing.T) {
 func TestCreatePRHeadRepoClassification(t *testing.T) {
 	tests := []struct {
 		name           string
+		provider       string
 		platformHost   string
+		owner          string
+		repoName       string
 		number         int
 		headBranch     string
 		headRepoURL    string
 		wantMRHeadRepo string
+		wantUnknown    bool
 	}{
 		{
 			name:           "fork PR keeps head repo",
@@ -251,30 +259,69 @@ func TestCreatePRHeadRepoClassification(t *testing.T) {
 			headBranch:   "feature/enterprise",
 			headRepoURL:  "https://GHE.example.com:8443/Acme/Widget.git",
 		},
+		{
+			name:        "missing head repo metadata is unknown",
+			number:      247,
+			headBranch:  "feature/unknown",
+			wantUnknown: true,
+		},
+		{
+			name:         "same-repo GitLab nested group is not fork",
+			provider:     "gitlab",
+			platformHost: "gitlab.com",
+			owner:        "group/subgroup",
+			repoName:     "project",
+			number:       248,
+			headBranch:   "feature/nested",
+			headRepoURL:  "https://gitlab.com/group/subgroup/project.git",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
+			require := require.New(t)
 			d := openTestDB(t)
+			provider := tt.provider
+			if provider == "" {
+				provider = "github"
+			}
 			platformHost := tt.platformHost
 			if platformHost == "" {
 				platformHost = "github.com"
 			}
-			repoID := seedRepo(
-				t, d, platformHost, "acme", "widget",
-			)
+			owner := tt.owner
+			if owner == "" {
+				owner = "acme"
+			}
+			repoName := tt.repoName
+			if repoName == "" {
+				repoName = "widget"
+			}
+			repoID, err := d.UpsertRepo(t.Context(), db.RepoIdentity{
+				Platform:     provider,
+				PlatformHost: platformHost,
+				Owner:        owner,
+				Name:         repoName,
+				RepoPath:     owner + "/" + repoName,
+			})
+			require.NoError(err)
 			seedMRWithHeadRepo(
 				t, d, repoID, tt.number, tt.headBranch, tt.headRepoURL,
 			)
 
 			mgr := NewManager(d, t.TempDir())
 			ws, err := mgr.Create(
-				t.Context(), "github", platformHost, "acme", "widget", tt.number,
+				t.Context(), provider, platformHost, owner, repoName, tt.number,
 			)
-			require.NoError(t, err)
-			require.NotNil(t, ws)
+			require.NoError(err)
+			require.NotNil(ws)
 
+			if tt.wantUnknown {
+				require.NotNil(ws.MRHeadRepo)
+				assert.Empty(*ws.MRHeadRepo)
+				return
+			}
 			if tt.wantMRHeadRepo == "" {
 				// Same-repo PRs still have head repo clone URLs in GitHub
 				// payloads. Keeping MRHeadRepo nil sends workspace setup down
@@ -283,7 +330,7 @@ func TestCreatePRHeadRepoClassification(t *testing.T) {
 				assert.Nil(ws.MRHeadRepo)
 				return
 			}
-			require.NotNil(t, ws.MRHeadRepo)
+			require.NotNil(ws.MRHeadRepo)
 			assert.Equal(tt.wantMRHeadRepo, *ws.MRHeadRepo)
 		})
 	}

--- a/internal/workspace/monitor.go
+++ b/internal/workspace/monitor.go
@@ -163,7 +163,7 @@ func (m *PRMonitor) detectAssociatedPR(
 		return 0, false, err
 	}
 	if upstream.hasTracking {
-		if prNumber, ok := selectPRByUpstream(candidates, upstream); ok {
+		if prNumber, ok := selectPRByUpstream(ws.Platform, candidates, upstream); ok {
 			return prNumber, true, nil
 		}
 	}
@@ -173,7 +173,7 @@ func (m *PRMonitor) detectAssociatedPR(
 		return 0, false, err
 	}
 	if prNumber, ok := selectPRByLocalBranch(
-		candidates, currentBranch, headSHA, upstream,
+		ws.Platform, candidates, currentBranch, headSHA, upstream,
 	); ok {
 		return prNumber, true, nil
 	}
@@ -181,6 +181,7 @@ func (m *PRMonitor) detectAssociatedPR(
 }
 
 func selectPRByUpstream(
+	provider string,
 	candidates []db.MergeRequest,
 	upstream upstreamState,
 ) (int, bool) {
@@ -188,7 +189,7 @@ func selectPRByUpstream(
 		return 0, false
 	}
 
-	remoteRepo := normalizeCloneRepoIdentity(upstream.remoteURL)
+	remoteRepo := normalizeCloneRepoIdentity(provider, upstream.remoteURL)
 	if strings.TrimSpace(upstream.remoteURL) != "" && remoteRepo == "" {
 		return 0, false
 	}
@@ -198,7 +199,7 @@ func selectPRByUpstream(
 		if candidate.HeadBranch != upstream.branchName {
 			continue
 		}
-		candidateRepo := normalizeCloneRepoIdentity(candidate.HeadRepoCloneURL)
+		candidateRepo := normalizeCloneRepoIdentity(provider, candidate.HeadRepoCloneURL)
 		if remoteRepo != "" {
 			if candidateRepo == "" || candidateRepo != remoteRepo {
 				continue
@@ -213,6 +214,7 @@ func selectPRByUpstream(
 }
 
 func selectPRByLocalBranch(
+	provider string,
 	candidates []db.MergeRequest,
 	currentBranch, currentHeadSHA string,
 	upstream upstreamState,
@@ -227,7 +229,7 @@ func selectPRByLocalBranch(
 		candidate := candidates[i]
 		if candidate.HeadBranch == currentBranch &&
 			strings.EqualFold(candidate.PlatformHeadSHA, currentHeadSHA) &&
-			localBranchCandidateMatchesUpstream(candidate, upstream) {
+			localBranchCandidateMatchesUpstream(provider, candidate, upstream) {
 			matches = append(matches, candidate)
 		}
 	}
@@ -238,14 +240,15 @@ func selectPRByLocalBranch(
 }
 
 func localBranchCandidateMatchesUpstream(
+	provider string,
 	candidate db.MergeRequest,
 	upstream upstreamState,
 ) bool {
 	if !upstream.hasTracking {
 		return true
 	}
-	remoteRepo := normalizeCloneRepoIdentity(upstream.remoteURL)
-	candidateRepo := normalizeCloneRepoIdentity(candidate.HeadRepoCloneURL)
+	remoteRepo := normalizeCloneRepoIdentity(provider, upstream.remoteURL)
+	candidateRepo := normalizeCloneRepoIdentity(provider, candidate.HeadRepoCloneURL)
 	return remoteRepo == "" ||
 		candidateRepo == "" ||
 		candidateRepo == remoteRepo
@@ -334,9 +337,10 @@ func gitOutput(
 	return string(out), nil
 }
 
-func normalizeCloneRepoIdentity(cloneURL string) string {
+func normalizeCloneRepoIdentity(provider, cloneURL string) string {
+	provider = strings.ToLower(strings.TrimSpace(provider))
 	cloneURL = strings.TrimSpace(cloneURL)
-	if cloneURL == "" {
+	if provider == "" || cloneURL == "" {
 		return ""
 	}
 	if !strings.Contains(cloneURL, "://") && !strings.Contains(cloneURL, "@") {
@@ -350,7 +354,7 @@ func normalizeCloneRepoIdentity(cloneURL string) string {
 	if repoPath == "" {
 		return ""
 	}
-	return strings.ToLower(host + "/" + repoPath)
+	return strings.ToLower(provider + "/" + host + "/" + repoPath)
 }
 
 func cloneRepoPath(cloneURL string) string {

--- a/internal/workspace/monitor.go
+++ b/internal/workspace/monitor.go
@@ -10,7 +10,6 @@ import (
 
 	gitcmd "go.kenn.io/kit/git/cmd"
 	"go.kenn.io/middleman/internal/db"
-	ghclient "go.kenn.io/middleman/internal/github"
 )
 
 type PRAssociationUpdate struct {
@@ -347,11 +346,38 @@ func normalizeCloneRepoIdentity(cloneURL string) string {
 	if host == "" {
 		return ""
 	}
-	fullName := ghclient.ParseHeadRepoFullName(cloneURL)
-	if fullName == "" {
+	repoPath := cloneRepoPath(cloneURL)
+	if repoPath == "" {
 		return ""
 	}
-	return strings.ToLower(host + "/" + fullName)
+	return strings.ToLower(host + "/" + repoPath)
+}
+
+func cloneRepoPath(cloneURL string) string {
+	var repoPath string
+	if strings.Contains(cloneURL, "://") {
+		parsed, err := url.Parse(cloneURL)
+		if err != nil {
+			return ""
+		}
+		repoPath = parsed.Path
+	} else {
+		beforePath, path, ok := strings.Cut(cloneURL, ":")
+		if !ok || !strings.Contains(beforePath, "@") {
+			return ""
+		}
+		repoPath = path
+	}
+	unescaped, err := url.PathUnescape(repoPath)
+	if err != nil {
+		return ""
+	}
+	repoPath = strings.Trim(strings.TrimSpace(unescaped), "/")
+	repoPath = strings.TrimSuffix(repoPath, ".git")
+	if strings.Count(repoPath, "/") < 1 {
+		return ""
+	}
+	return repoPath
 }
 
 func normalizeCloneURLHost(cloneURL string) string {

--- a/internal/workspace/monitor_test.go
+++ b/internal/workspace/monitor_test.go
@@ -656,14 +656,14 @@ func TestSelectPRByUpstream(t *testing.T) {
 		},
 	}
 
-	number, ok := selectPRByUpstream(candidates, upstreamState{
+	number, ok := selectPRByUpstream("github", candidates, upstreamState{
 		branchName: "shared-branch",
 		remoteURL:  "git@github.com:Fork-Two/Widget.git",
 	})
 	assert.True(ok)
 	assert.Equal(42, number)
 
-	number, ok = selectPRByUpstream([]db.MergeRequest{{
+	number, ok = selectPRByUpstream("github", []db.MergeRequest{{
 		Number:           44,
 		HeadBranch:       "shared-branch",
 		HeadRepoCloneURL: "https://ghe.example.com/fork-two/widget.git",
@@ -679,7 +679,7 @@ func TestSelectPRByUpstream(t *testing.T) {
 		{branchName: "missing", remoteURL: "git@github.com:Fork-Two/Widget.git"},
 		{branchName: ""},
 	} {
-		number, ok = selectPRByUpstream(candidates, upstream)
+		number, ok = selectPRByUpstream("github", candidates, upstream)
 		assert.False(ok)
 		assert.Zero(number)
 	}
@@ -695,19 +695,19 @@ func TestSelectPRByBranchRejectsAmbiguousMatches(t *testing.T) {
 	}
 
 	number, ok := selectPRByLocalBranch(
-		candidates, "single-local", "abc123", upstreamState{},
+		"github", candidates, "single-local", "abc123", upstreamState{},
 	)
 	assert.True(ok)
 	assert.Equal(43, number)
 
 	number, ok = selectPRByLocalBranch(
-		candidates, "shared-local", "abc123", upstreamState{},
+		"github", candidates, "shared-local", "abc123", upstreamState{},
 	)
 	assert.False(ok)
 	assert.Zero(number)
 
 	number, ok = selectPRByLocalBranch(
-		candidates, "wrong-head", "abc123", upstreamState{},
+		"github", candidates, "wrong-head", "abc123", upstreamState{},
 	)
 	assert.False(ok)
 	assert.Zero(number)
@@ -776,31 +776,35 @@ func TestNormalizeCloneRepoIdentity(t *testing.T) {
 	assert := assert.New(t)
 
 	assert.Equal(
-		"github.com/fork/widget",
-		normalizeCloneRepoIdentity(" git@GitHub.com:Fork/Widget.git "),
+		"github/github.com/fork/widget",
+		normalizeCloneRepoIdentity("github", " git@GitHub.com:Fork/Widget.git "),
 	)
 	assert.Equal(
-		"github.com/fork/widget",
-		normalizeCloneRepoIdentity("https://token@github.com/Fork/Widget/"),
+		"github/github.com/fork/widget",
+		normalizeCloneRepoIdentity("github", "https://token@github.com/Fork/Widget/"),
 	)
 	assert.Equal(
-		"github.com/fork/widget",
-		normalizeCloneRepoIdentity("ssh://git@github.com:22/Fork/Widget.git"),
+		"github/github.com/fork/widget",
+		normalizeCloneRepoIdentity("github", "ssh://git@github.com:22/Fork/Widget.git"),
 	)
 	assert.Equal(
-		"ghe.example.com:8443/fork/widget",
-		normalizeCloneRepoIdentity("https://ghe.example.com:8443/Fork/Widget.git"),
+		"github/ghe.example.com:8443/fork/widget",
+		normalizeCloneRepoIdentity("github", "https://ghe.example.com:8443/Fork/Widget.git"),
 	)
 	assert.Equal(
-		"gitlab.com/group/subgroup/project",
-		normalizeCloneRepoIdentity("https://gitlab.com/Group/Subgroup/Project.git"),
+		"gitlab/gitlab.com/group/subgroup/project",
+		normalizeCloneRepoIdentity("gitlab", "https://gitlab.com/Group/Subgroup/Project.git"),
 	)
 	assert.Equal(
-		"gitlab.com/group/subgroup/project",
-		normalizeCloneRepoIdentity("git@gitlab.com:Group/Subgroup/Project.git"),
+		"gitlab/gitlab.com/group/subgroup/project",
+		normalizeCloneRepoIdentity("gitlab", "git@gitlab.com:Group/Subgroup/Project.git"),
 	)
-	assert.Empty(normalizeCloneRepoIdentity("/tmp/workspace/remote.git"))
-	assert.Empty(normalizeCloneRepoIdentity("not a clone url"))
+	assert.NotEqual(
+		normalizeCloneRepoIdentity("github", "https://forge.example/acme/widget.git"),
+		normalizeCloneRepoIdentity("gitlab", "https://forge.example/acme/widget.git"),
+	)
+	assert.Empty(normalizeCloneRepoIdentity("github", "/tmp/workspace/remote.git"))
+	assert.Empty(normalizeCloneRepoIdentity("github", "not a clone url"))
 }
 
 func TestNormalizePlatformHostIdentity(t *testing.T) {

--- a/internal/workspace/monitor_test.go
+++ b/internal/workspace/monitor_test.go
@@ -791,6 +791,14 @@ func TestNormalizeCloneRepoIdentity(t *testing.T) {
 		"ghe.example.com:8443/fork/widget",
 		normalizeCloneRepoIdentity("https://ghe.example.com:8443/Fork/Widget.git"),
 	)
+	assert.Equal(
+		"gitlab.com/group/subgroup/project",
+		normalizeCloneRepoIdentity("https://gitlab.com/Group/Subgroup/Project.git"),
+	)
+	assert.Equal(
+		"gitlab.com/group/subgroup/project",
+		normalizeCloneRepoIdentity("git@gitlab.com:Group/Subgroup/Project.git"),
+	)
 	assert.Empty(normalizeCloneRepoIdentity("/tmp/workspace/remote.git"))
 	assert.Empty(normalizeCloneRepoIdentity("not a clone url"))
 }

--- a/internal/workspace/monitor_test.go
+++ b/internal/workspace/monitor_test.go
@@ -203,7 +203,7 @@ func TestPRMonitorRefreshWorkspaceAssociationAssociatesKataTask(t *testing.T) {
 	runWorkspaceTestGit(t, worktreePath, "checkout", "-b", "feature/kata-task")
 	headSHA, err := gitHeadSHA(ctx, worktreePath)
 	require.NoError(err)
-	seedMRWithPlatformHead(t, d, repoID, 42, "feature/kata-task", headSHA)
+	seedMRWithPlatformHead(t, d, repoID, 42, "feature/kata-task", headSHA, "")
 	kataMetadata := db.WorkspaceKataMetadata{
 		DaemonID:   "local",
 		ProjectUID: "project-1",
@@ -268,7 +268,7 @@ func TestPRMonitorRunOnceFallsBackToLocalHeadSHAWhenUpstreamRepoMetadataMissing(
 	)
 	headSHA, err := gitHeadSHA(ctx, worktreePath)
 	require.NoError(err)
-	seedMRWithPlatformHead(t, d, repoID, 42, "feature/gitlab", headSHA)
+	seedMRWithPlatformHead(t, d, repoID, 42, "feature/gitlab", headSHA, "")
 	workspaceID := insertMonitorWorkspaceWithIdentity(
 		t, d, "ws-gitlab", "gitlab", "gitlab.com",
 		"Group/SubGroup", "Project", worktreePath,
@@ -594,7 +594,7 @@ func TestPRMonitorRunOnceScopesCandidatesByWorkspaceProvider(t *testing.T) {
 	headSHA, err := gitHeadSHA(ctx, worktreePath)
 	require.NoError(err)
 	seedMRWithPlatformHead(
-		t, d, githubRepoID, 42, "feature/provider-scope", headSHA,
+		t, d, githubRepoID, 42, "feature/provider-scope", headSHA, "",
 	)
 	workspaceID := insertMonitorWorkspaceWithIdentity(
 		t, d, "ws-gitlab-provider-scope", "gitlab", "git.example.com",

--- a/internal/workspace/pushed_head_observer.go
+++ b/internal/workspace/pushed_head_observer.go
@@ -216,7 +216,9 @@ func pushedHeadWorkspaceEligible(ws *Workspace) bool {
 	if strings.TrimSpace(ws.PlatformHost) == "" || strings.TrimSpace(ws.RepoOwner) == "" || strings.TrimSpace(ws.RepoName) == "" {
 		return false
 	}
-	return ws.ItemType == db.WorkspaceItemTypePullRequest || ws.ItemType == db.WorkspaceItemTypeIssue
+	return ws.ItemType == db.WorkspaceItemTypePullRequest ||
+		ws.ItemType == db.WorkspaceItemTypeIssue ||
+		ws.ItemType == db.WorkspaceItemTypeKataTask
 }
 
 func (o *PushedHeadObserver) resolveWorkspacePR(ctx context.Context, ws *Workspace) (*WorkspacePRAssociation, *db.Repo, *db.MergeRequest, bool, error) {
@@ -238,9 +240,11 @@ func (o *PushedHeadObserver) resolveWorkspacePR(ctx context.Context, ws *Workspa
 	switch ws.ItemType {
 	case db.WorkspaceItemTypePullRequest:
 		prNumber = ws.ItemNumber
-	case db.WorkspaceItemTypeIssue:
+	case db.WorkspaceItemTypeIssue, db.WorkspaceItemTypeKataTask:
 		if ws.AssociatedPRNumber != nil {
 			prNumber = *ws.AssociatedPRNumber
+		} else if ws.ItemType == db.WorkspaceItemTypeKataTask {
+			return nil, repo, nil, false, nil
 		} else {
 			detected, ok, err := o.monitor.detectAssociatedPR(ctx, ws)
 			if err != nil {

--- a/internal/workspace/pushed_head_observer.go
+++ b/internal/workspace/pushed_head_observer.go
@@ -434,15 +434,12 @@ func (o *PushedHeadObserver) configureMissingUpstream(
 	ctx context.Context, ws *Workspace, mr db.MergeRequest, branch string,
 	trackingCache map[string]trackingLookup,
 ) (bool, error) {
-	if ws.MRHeadRepo != nil {
-		return false, nil
-	}
 	head := strings.TrimSpace(mr.HeadBranch)
 	if head == "" {
 		return false, nil
 	}
 	if strings.TrimSpace(mr.HeadRepoCloneURL) == "" || workspaceHeadRepo(
-		ws.PlatformHost, ws.RepoOwner, ws.RepoName, mr.HeadRepoCloneURL,
+		ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName, mr.HeadRepoCloneURL,
 	) != nil {
 		return false, nil
 	}

--- a/internal/workspace/pushed_head_observer.go
+++ b/internal/workspace/pushed_head_observer.go
@@ -307,7 +307,7 @@ func (o *PushedHeadObserver) observeWorkspacePR(ctx context.Context, ws *Workspa
 		return PushedHeadUpdate{}, false, err
 	}
 	if !upstream.hasTracking || upstream.remoteName == "" || upstream.branchName == "" {
-		healed, healErr := o.configureMissingUpstream(ctx, ws, mr, branch)
+		healed, healErr := o.configureMissingUpstream(ctx, ws, mr, branch, trackingCache)
 		if healErr != nil {
 			return PushedHeadUpdate{}, false, healErr
 		}
@@ -325,13 +325,10 @@ func (o *PushedHeadObserver) observeWorkspacePR(ctx context.Context, ws *Workspa
 		return PushedHeadUpdate{}, false, nil
 	}
 
-	cacheKey := ws.WorktreePath + "\x00" + upstream.remoteName + "\x00" + upstream.branchName
-	lookup, cached := trackingCache[cacheKey]
-	if !cached {
-		sha, ref, ok, err := o.git.RemoteTrackingSHA(ctx, ws.WorktreePath, upstream.remoteName, upstream.branchName)
-		lookup = trackingLookup{sha: strings.TrimSpace(sha), ref: ref, ok: ok, err: err}
-		trackingCache[cacheKey] = lookup
-	}
+	lookup := o.lookupRemoteTrackingSHA(
+		ctx, ws.WorktreePath, upstream.remoteName, upstream.branchName,
+		trackingCache,
+	)
 	if lookup.err != nil {
 		return PushedHeadUpdate{}, false, lookup.err
 	}
@@ -401,17 +398,41 @@ func (o *PushedHeadObserver) observeWorkspacePR(ctx context.Context, ws *Workspa
 	return update, true, nil
 }
 
+// lookupRemoteTrackingSHA resolves a remote-tracking ref through the pass's
+// per-worktree cache so the heal probe and the observation share one git call.
+func (o *PushedHeadObserver) lookupRemoteTrackingSHA(
+	ctx context.Context, dir, remote, branch string,
+	trackingCache map[string]trackingLookup,
+) trackingLookup {
+	cacheKey := dir + "\x00" + remote + "\x00" + branch
+	lookup, cached := trackingCache[cacheKey]
+	if !cached {
+		sha, ref, ok, err := o.git.RemoteTrackingSHA(ctx, dir, remote, branch)
+		lookup = trackingLookup{sha: strings.TrimSpace(sha), ref: ref, ok: ok, err: err}
+		trackingCache[cacheKey] = lookup
+	}
+	return lookup
+}
+
 // configureMissingUpstream restores tracking configuration for a workspace
 // branch that should follow the open PR's head branch but has no upstream —
 // the state every synthetic fallback branch was created in before upstreams
 // were configured at worktree add. Without an upstream, every derived surface
 // (sidebar ahead/behind counts, push, pull, unpushed-commit flags) silently
-// reports nothing. Only same-repo heads are wired, and only when the checked
-// out branch is the PR head branch or middleman's synthetic PR branch: origin
-// cannot track a fork's head branch, and an unrelated user branch must not be
-// rewired.
+// reports nothing.
+//
+// The rewiring demands positive evidence before touching config. A nil
+// workspace MRHeadRepo is not proof of a same-repo head: it is also nil when
+// head-repo metadata was unavailable at creation, and issue workspaces never
+// set it even when their associated PR is fork-backed. The merge-request row
+// must place the head branch in the base repository, the checked-out branch
+// must be the PR head branch or middleman's synthetic PR branch (an unrelated
+// user branch must not be rewired), and the remote-tracking ref must already
+// exist — mirroring worktree creation — so the branch never ends up tracking
+// a ref that resolves to nothing.
 func (o *PushedHeadObserver) configureMissingUpstream(
 	ctx context.Context, ws *Workspace, mr db.MergeRequest, branch string,
+	trackingCache map[string]trackingLookup,
 ) (bool, error) {
 	if ws.MRHeadRepo != nil {
 		return false, nil
@@ -420,9 +441,23 @@ func (o *PushedHeadObserver) configureMissingUpstream(
 	if head == "" {
 		return false, nil
 	}
+	if strings.TrimSpace(mr.HeadRepoCloneURL) == "" || workspaceHeadRepo(
+		ws.PlatformHost, ws.RepoOwner, ws.RepoName, mr.HeadRepoCloneURL,
+	) != nil {
+		return false, nil
+	}
 	synthetic := ws.ItemType == db.WorkspaceItemTypePullRequest &&
 		branch == syntheticPRWorktreeBranch(ws.ItemNumber)
 	if branch != head && !synthetic {
+		return false, nil
+	}
+	lookup := o.lookupRemoteTrackingSHA(
+		ctx, ws.WorktreePath, "origin", head, trackingCache,
+	)
+	if lookup.err != nil {
+		return false, lookup.err
+	}
+	if !lookup.ok || lookup.sha == "" {
 		return false, nil
 	}
 	if err := o.git.SetBranchUpstream(

--- a/internal/workspace/pushed_head_observer.go
+++ b/internal/workspace/pushed_head_observer.go
@@ -68,6 +68,7 @@ type remoteHeadGitReader interface {
 	BranchName(ctx context.Context, dir string) (string, error)
 	UpstreamState(ctx context.Context, dir, branch string) (upstreamState, error)
 	RemoteTrackingSHA(ctx context.Context, dir, remote, branch string) (string, string, bool, error)
+	SetBranchUpstream(ctx context.Context, dir, branch, remote, mergeRef string) error
 }
 
 const (
@@ -87,6 +88,12 @@ func (gitRemoteHeadReader) UpstreamState(ctx context.Context, dir, branch string
 	gitCtx, cancel := context.WithTimeout(ctx, pushedHeadGitTimeout)
 	defer cancel()
 	return gitUpstreamState(gitCtx, dir, branch)
+}
+
+func (gitRemoteHeadReader) SetBranchUpstream(ctx context.Context, dir, branch, remote, mergeRef string) error {
+	gitCtx, cancel := context.WithTimeout(ctx, pushedHeadGitTimeout)
+	defer cancel()
+	return setBranchUpstream(gitCtx, dir, branch, remote, mergeRef)
 }
 
 func (gitRemoteHeadReader) RemoteTrackingSHA(ctx context.Context, dir, remote, branch string) (string, string, bool, error) {
@@ -300,8 +307,19 @@ func (o *PushedHeadObserver) observeWorkspacePR(ctx context.Context, ws *Workspa
 		return PushedHeadUpdate{}, false, err
 	}
 	if !upstream.hasTracking || upstream.remoteName == "" || upstream.branchName == "" {
-		slog.Debug("workspace pushed-head observer missing upstream", "workspace_id", ws.ID, "branch", branch)
-		return PushedHeadUpdate{}, false, nil
+		healed, healErr := o.configureMissingUpstream(ctx, ws, mr, branch)
+		if healErr != nil {
+			return PushedHeadUpdate{}, false, healErr
+		}
+		if !healed {
+			slog.Debug("workspace pushed-head observer missing upstream", "workspace_id", ws.ID, "branch", branch)
+			return PushedHeadUpdate{}, false, nil
+		}
+		upstream = upstreamState{
+			hasTracking: true,
+			remoteName:  "origin",
+			branchName:  mr.HeadBranch,
+		}
 	}
 	if upstream.branchName != mr.HeadBranch {
 		return PushedHeadUpdate{}, false, nil
@@ -381,6 +399,40 @@ func (o *PushedHeadObserver) observeWorkspacePR(ctx context.Context, ws *Workspa
 	prior.ObservedAt = observedAt
 	o.observed[key] = prior
 	return update, true, nil
+}
+
+// configureMissingUpstream restores tracking configuration for a workspace
+// branch that should follow the open PR's head branch but has no upstream —
+// the state every synthetic fallback branch was created in before upstreams
+// were configured at worktree add. Without an upstream, every derived surface
+// (sidebar ahead/behind counts, push, pull, unpushed-commit flags) silently
+// reports nothing. Only same-repo heads are wired, and only when the checked
+// out branch is the PR head branch or middleman's synthetic PR branch: origin
+// cannot track a fork's head branch, and an unrelated user branch must not be
+// rewired.
+func (o *PushedHeadObserver) configureMissingUpstream(
+	ctx context.Context, ws *Workspace, mr db.MergeRequest, branch string,
+) (bool, error) {
+	if ws.MRHeadRepo != nil {
+		return false, nil
+	}
+	head := strings.TrimSpace(mr.HeadBranch)
+	if head == "" {
+		return false, nil
+	}
+	synthetic := ws.ItemType == db.WorkspaceItemTypePullRequest &&
+		branch == syntheticPRWorktreeBranch(ws.ItemNumber)
+	if branch != head && !synthetic {
+		return false, nil
+	}
+	if err := o.git.SetBranchUpstream(
+		ctx, ws.WorktreePath, branch, "origin", "refs/heads/"+head,
+	); err != nil {
+		return false, fmt.Errorf("configure branch upstream: %w", err)
+	}
+	slog.Info("configured missing workspace branch upstream",
+		"workspace_id", ws.ID, "branch", branch, "head_branch", head)
+	return true, nil
 }
 
 func (o *PushedHeadObserver) recordFailure(workspaceID string, err error) {

--- a/internal/workspace/pushed_head_observer_test.go
+++ b/internal/workspace/pushed_head_observer_test.go
@@ -13,15 +13,24 @@ import (
 )
 
 type fakeRemoteHeadReader struct {
-	branchCalls   int
-	upstreamCalls int
-	trackingCalls int
-	branch        string
-	upstream      upstreamState
-	trackingSHA   string
-	trackingRef   string
-	trackingOK    bool
-	trackingErr   error
+	branchCalls      int
+	upstreamCalls    int
+	trackingCalls    int
+	branch           string
+	upstream         upstreamState
+	trackingSHA      string
+	trackingRef      string
+	trackingOK       bool
+	trackingErr      error
+	setUpstreamCalls []fakeSetUpstreamCall
+	setUpstreamErr   error
+}
+
+type fakeSetUpstreamCall struct {
+	dir      string
+	branch   string
+	remote   string
+	mergeRef string
 }
 
 func (r *fakeRemoteHeadReader) BranchName(context.Context, string) (string, error) {
@@ -37,6 +46,16 @@ func (r *fakeRemoteHeadReader) UpstreamState(context.Context, string, string) (u
 func (r *fakeRemoteHeadReader) RemoteTrackingSHA(context.Context, string, string, string) (string, string, bool, error) {
 	r.trackingCalls++
 	return r.trackingSHA, r.trackingRef, r.trackingOK, r.trackingErr
+}
+
+func (r *fakeRemoteHeadReader) SetBranchUpstream(_ context.Context, dir, branch, remote, mergeRef string) error {
+	r.setUpstreamCalls = append(r.setUpstreamCalls, fakeSetUpstreamCall{
+		dir:      dir,
+		branch:   branch,
+		remote:   remote,
+		mergeRef: mergeRef,
+	})
+	return r.setUpstreamErr
 }
 
 func insertPushedHeadWorkspace(
@@ -335,4 +354,85 @@ func TestPushedHeadObserverMissingRefAndTransientErrorKeepObservationState(t *te
 	require.Len(recovered.HeadChanges, 1)
 	assert.Equal("1111111", recovered.HeadChanges[0].OldSHA)
 	assert.Equal("2222222", recovered.HeadChanges[0].NewSHA)
+}
+
+func TestPushedHeadObserverUpstreamHeal(t *testing.T) {
+	forkHeadRepo := "https://github.com/contributor/widget.git"
+	cases := []struct {
+		name       string
+		branch     string
+		mrHeadRepo *string
+		wantHeal   bool
+	}{
+		{
+			name:     "synthetic PR branch is rewired to the PR head",
+			branch:   "middleman/pr-42",
+			wantHeal: true,
+		},
+		{
+			name:     "head-branch checkout is rewired to itself",
+			branch:   "feature/remote-head",
+			wantHeal: true,
+		},
+		{
+			name:   "unrelated branch is left alone",
+			branch: "scratch/unrelated",
+		},
+		{
+			name:       "fork PR head cannot be tracked by origin",
+			branch:     "feature/remote-head",
+			mrHeadRepo: &forkHeadRepo,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			d := openTestDB(t)
+			repoID := seedRepo(t, d, "github.com", "acme", "widget")
+			seedMRWithPlatformHead(t, d, repoID, 42, "feature/remote-head", "2222222")
+			require.NoError(d.InsertWorkspace(t.Context(), &db.Workspace{
+				ID:              "ws-pr",
+				Platform:        "github",
+				PlatformHost:    "github.com",
+				RepoOwner:       "acme",
+				RepoName:        "widget",
+				ItemType:        db.WorkspaceItemTypePullRequest,
+				ItemNumber:      42,
+				GitHeadRef:      "feature/remote-head",
+				MRHeadRepo:      tc.mrHeadRepo,
+				WorkspaceBranch: tc.branch,
+				WorktreePath:    "/tmp/worktree",
+				TmuxSession:     "middleman-ws-pr",
+				Status:          "ready",
+			}))
+			reader := &fakeRemoteHeadReader{
+				branch:      tc.branch,
+				upstream:    upstreamState{},
+				trackingSHA: "2222222",
+				trackingRef: "refs/remotes/origin/feature/remote-head",
+				trackingOK:  true,
+			}
+			observer := newPushedHeadObserverForTest(t, d, reader)
+
+			result, err := observer.RunOnce(context.Background())
+			require.NoError(err)
+			assert.Empty(result.HeadChanges)
+			if !tc.wantHeal {
+				assert.Empty(reader.setUpstreamCalls,
+					"branch must not be rewired")
+				assert.Zero(reader.trackingCalls)
+				return
+			}
+			require.Len(reader.setUpstreamCalls, 1,
+				"missing upstream must be configured")
+			call := reader.setUpstreamCalls[0]
+			assert.Equal("/tmp/worktree", call.dir)
+			assert.Equal(tc.branch, call.branch)
+			assert.Equal("origin", call.remote)
+			assert.Equal("refs/heads/feature/remote-head", call.mergeRef)
+			assert.Equal(1, reader.trackingCalls,
+				"observation must continue against the healed upstream")
+		})
+	}
 }

--- a/internal/workspace/pushed_head_observer_test.go
+++ b/internal/workspace/pushed_head_observer_test.go
@@ -88,23 +88,24 @@ func seedMRWithPlatformHead(
 	d *db.DB,
 	repoID int64,
 	number int,
-	branch, sha string,
+	branch, sha, headRepoCloneURL string,
 ) {
 	t.Helper()
 	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
 	_, err := d.UpsertMergeRequest(t.Context(), &db.MergeRequest{
-		RepoID:          repoID,
-		PlatformID:      repoID*10000 + int64(number),
-		Number:          number,
-		Title:           "Refresh me",
-		Author:          "author",
-		State:           db.MergeRequestStateOpen,
-		HeadBranch:      branch,
-		PlatformHeadSHA: sha,
-		BaseBranch:      "main",
-		CreatedAt:       now,
-		UpdatedAt:       now,
-		LastActivityAt:  now,
+		RepoID:           repoID,
+		PlatformID:       repoID*10000 + int64(number),
+		Number:           number,
+		Title:            "Refresh me",
+		Author:           "author",
+		State:            db.MergeRequestStateOpen,
+		HeadBranch:       branch,
+		PlatformHeadSHA:  sha,
+		HeadRepoCloneURL: headRepoCloneURL,
+		BaseBranch:       "main",
+		CreatedAt:        now,
+		UpdatedAt:        now,
+		LastActivityAt:   now,
 	})
 	require.NoError(t, err)
 }
@@ -128,7 +129,7 @@ func TestPushedHeadObserverFirstObservationSkipsWhenProviderHeadMatches(t *testi
 	require := require.New(t)
 	d := openTestDB(t)
 	repoID := seedRepo(t, d, "github.com", "acme", "widget")
-	seedMRWithPlatformHead(t, d, repoID, 42, "feature/remote-head", "2222222")
+	seedMRWithPlatformHead(t, d, repoID, 42, "feature/remote-head", "2222222", "")
 	insertPushedHeadWorkspace(t, d, "ws-pr", db.WorkspaceItemTypePullRequest, 42, nil)
 	reader := &fakeRemoteHeadReader{
 		branch: "feature/remote-head",
@@ -155,7 +156,7 @@ func TestPushedHeadObserverFirstObservationEnqueuesWhenProviderHeadDiffers(t *te
 	require := require.New(t)
 	d := openTestDB(t)
 	repoID := seedRepo(t, d, "github.com", "acme", "widget")
-	seedMRWithPlatformHead(t, d, repoID, 42, "feature/remote-head", "1111111")
+	seedMRWithPlatformHead(t, d, repoID, 42, "feature/remote-head", "1111111", "")
 	insertPushedHeadWorkspace(t, d, "ws-pr", db.WorkspaceItemTypePullRequest, 42, nil)
 	reader := &fakeRemoteHeadReader{
 		branch: "feature/remote-head",
@@ -191,7 +192,7 @@ func TestPushedHeadObserverRetriesObservedSHAUntilProviderHeadMatches(t *testing
 	require := require.New(t)
 	d := openTestDB(t)
 	repoID := seedRepo(t, d, "github.com", "acme", "widget")
-	seedMRWithPlatformHead(t, d, repoID, 42, "feature/remote-head", "1111111")
+	seedMRWithPlatformHead(t, d, repoID, 42, "feature/remote-head", "1111111", "")
 	insertPushedHeadWorkspace(t, d, "ws-pr", db.WorkspaceItemTypePullRequest, 42, nil)
 	reader := &fakeRemoteHeadReader{
 		branch:      "feature/remote-head",
@@ -227,7 +228,7 @@ func TestPushedHeadObserverDoesNotRetryAfterRefreshSucceeds(t *testing.T) {
 	require := require.New(t)
 	d := openTestDB(t)
 	repoID := seedRepo(t, d, "github.com", "acme", "widget")
-	seedMRWithPlatformHead(t, d, repoID, 42, "feature/remote-head", "1111111")
+	seedMRWithPlatformHead(t, d, repoID, 42, "feature/remote-head", "1111111", "")
 	insertPushedHeadWorkspace(t, d, "ws-pr", db.WorkspaceItemTypePullRequest, 42, nil)
 	reader := &fakeRemoteHeadReader{
 		branch:      "feature/remote-head",
@@ -243,7 +244,7 @@ func TestPushedHeadObserverDoesNotRetryAfterRefreshSucceeds(t *testing.T) {
 	require.Len(first.HeadChanges, 1)
 	now := time.Date(2026, 5, 20, 14, 15, 0, 0, time.UTC)
 	observer.MarkRefreshSucceeded(first.HeadChanges[0], now)
-	seedMRWithPlatformHead(t, d, repoID, 42, "feature/remote-head", "2222222")
+	seedMRWithPlatformHead(t, d, repoID, 42, "feature/remote-head", "2222222", "")
 
 	retry, err := observer.RunOnce(context.Background())
 	require.NoError(err)
@@ -255,7 +256,7 @@ func TestPushedHeadObserverDetectsSubsequentTrackingRefMove(t *testing.T) {
 	require := require.New(t)
 	d := openTestDB(t)
 	repoID := seedRepo(t, d, "github.com", "acme", "widget")
-	seedMRWithPlatformHead(t, d, repoID, 42, "feature/remote-head", "1111111")
+	seedMRWithPlatformHead(t, d, repoID, 42, "feature/remote-head", "1111111", "")
 	insertPushedHeadWorkspace(t, d, "ws-pr", db.WorkspaceItemTypePullRequest, 42, nil)
 	reader := &fakeRemoteHeadReader{
 		branch: "feature/remote-head",
@@ -322,7 +323,7 @@ func TestPushedHeadObserverMissingRefAndTransientErrorKeepObservationState(t *te
 	require := require.New(t)
 	d := openTestDB(t)
 	repoID := seedRepo(t, d, "github.com", "acme", "widget")
-	seedMRWithPlatformHead(t, d, repoID, 42, "feature/remote-head", "1111111")
+	seedMRWithPlatformHead(t, d, repoID, 42, "feature/remote-head", "1111111", "")
 	insertPushedHeadWorkspace(t, d, "ws-pr", db.WorkspaceItemTypePullRequest, 42, nil)
 	reader := &fakeRemoteHeadReader{
 		branch:      "feature/remote-head",
@@ -358,30 +359,59 @@ func TestPushedHeadObserverMissingRefAndTransientErrorKeepObservationState(t *te
 
 func TestPushedHeadObserverUpstreamHeal(t *testing.T) {
 	forkHeadRepo := "https://github.com/contributor/widget.git"
+	sameRepoURL := "https://github.com/acme/widget.git"
 	cases := []struct {
-		name       string
-		branch     string
-		mrHeadRepo *string
-		wantHeal   bool
+		name             string
+		branch           string
+		mrHeadRepo       *string
+		headRepoCloneURL string
+		trackingOK       bool
+		wantHeal         bool
 	}{
 		{
-			name:     "synthetic PR branch is rewired to the PR head",
-			branch:   "middleman/pr-42",
-			wantHeal: true,
+			name:             "synthetic PR branch is rewired to the PR head",
+			branch:           "middleman/pr-42",
+			headRepoCloneURL: sameRepoURL,
+			trackingOK:       true,
+			wantHeal:         true,
 		},
 		{
-			name:     "head-branch checkout is rewired to itself",
-			branch:   "feature/remote-head",
-			wantHeal: true,
+			name:             "head-branch checkout is rewired to itself",
+			branch:           "feature/remote-head",
+			headRepoCloneURL: sameRepoURL,
+			trackingOK:       true,
+			wantHeal:         true,
 		},
 		{
-			name:   "unrelated branch is left alone",
-			branch: "scratch/unrelated",
+			name:             "unrelated branch is left alone",
+			branch:           "scratch/unrelated",
+			headRepoCloneURL: sameRepoURL,
+			trackingOK:       true,
 		},
 		{
-			name:       "fork PR head cannot be tracked by origin",
-			branch:     "feature/remote-head",
-			mrHeadRepo: &forkHeadRepo,
+			name:             "fork PR head cannot be tracked by origin",
+			branch:           "feature/remote-head",
+			mrHeadRepo:       &forkHeadRepo,
+			headRepoCloneURL: forkHeadRepo,
+			trackingOK:       true,
+		},
+		{
+			name:             "MR row without head-repo metadata is not trusted",
+			branch:           "feature/remote-head",
+			headRepoCloneURL: "",
+			trackingOK:       true,
+		},
+		{
+			name:             "fork-backed MR row blocks heal even with nil workspace head repo",
+			branch:           "feature/remote-head",
+			headRepoCloneURL: forkHeadRepo,
+			trackingOK:       true,
+		},
+		{
+			name:             "missing remote-tracking ref blocks heal",
+			branch:           "middleman/pr-42",
+			headRepoCloneURL: sameRepoURL,
+			trackingOK:       false,
 		},
 	}
 	for _, tc := range cases {
@@ -390,7 +420,10 @@ func TestPushedHeadObserverUpstreamHeal(t *testing.T) {
 			require := require.New(t)
 			d := openTestDB(t)
 			repoID := seedRepo(t, d, "github.com", "acme", "widget")
-			seedMRWithPlatformHead(t, d, repoID, 42, "feature/remote-head", "2222222")
+			seedMRWithPlatformHead(
+				t, d, repoID, 42, "feature/remote-head", "2222222",
+				tc.headRepoCloneURL,
+			)
 			require.NoError(d.InsertWorkspace(t.Context(), &db.Workspace{
 				ID:              "ws-pr",
 				Platform:        "github",
@@ -411,7 +444,10 @@ func TestPushedHeadObserverUpstreamHeal(t *testing.T) {
 				upstream:    upstreamState{},
 				trackingSHA: "2222222",
 				trackingRef: "refs/remotes/origin/feature/remote-head",
-				trackingOK:  true,
+				trackingOK:  tc.trackingOK,
+			}
+			if !tc.trackingOK {
+				reader.trackingSHA = ""
 			}
 			observer := newPushedHeadObserverForTest(t, d, reader)
 
@@ -420,8 +456,7 @@ func TestPushedHeadObserverUpstreamHeal(t *testing.T) {
 			assert.Empty(result.HeadChanges)
 			if !tc.wantHeal {
 				assert.Empty(reader.setUpstreamCalls,
-					"branch must not be rewired")
-				assert.Zero(reader.trackingCalls)
+					"branch must not be rewired without positive same-repo evidence")
 				return
 			}
 			require.Len(reader.setUpstreamCalls, 1,
@@ -432,7 +467,7 @@ func TestPushedHeadObserverUpstreamHeal(t *testing.T) {
 			assert.Equal("origin", call.remote)
 			assert.Equal("refs/heads/feature/remote-head", call.mergeRef)
 			assert.Equal(1, reader.trackingCalls,
-				"observation must continue against the healed upstream")
+				"heal probe and observation must share one tracking lookup")
 		})
 	}
 }

--- a/internal/workspace/pushed_head_observer_test.go
+++ b/internal/workspace/pushed_head_observer_test.go
@@ -318,6 +318,61 @@ func TestPushedHeadObserverAssociatesIssueWorkspaceAndObservesHead(t *testing.T)
 	assert.Equal(42, *ws.AssociatedPRNumber)
 }
 
+func TestPushedHeadObserverRunOnceHealsAssociatedKataWorkspace(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
+	worktreePath := setupMonitorRepo(t)
+	runWorkspaceTestGit(t, worktreePath, "checkout", "-b", "feature/kata-task")
+	runWorkspaceTestGit(t, worktreePath, "push", "origin", "feature/kata-task")
+	headSHA, err := gitHeadSHA(ctx, worktreePath)
+	require.NoError(err)
+	seedMRWithPlatformHead(
+		t, d, repoID, 42, "feature/kata-task", headSHA,
+		"https://github.com/acme/widget.git",
+	)
+	associatedPRNumber := 42
+	kataMetadata := db.WorkspaceKataMetadata{
+		DaemonID:   "local",
+		ProjectUID: "project-1",
+		IssueUID:   "issue-1",
+	}
+	require.NoError(d.InsertWorkspace(ctx, &db.Workspace{
+		ID:                 "ws-kata",
+		Platform:           "github",
+		PlatformHost:       "github.com",
+		RepoOwner:          "acme",
+		RepoName:           "widget",
+		ItemType:           db.WorkspaceItemTypeKataTask,
+		ItemKey:            db.KataWorkspaceItemKey(kataMetadata),
+		AssociatedPRNumber: &associatedPRNumber,
+		GitHeadRef:         "feature/kata-task",
+		WorkspaceBranch:    "feature/kata-task",
+		WorktreePath:       worktreePath,
+		TmuxSession:        "middleman-ws-kata",
+		Status:             "ready",
+		KataMetadata:       &kataMetadata,
+	}))
+
+	before, err := gitUpstreamState(ctx, worktreePath, "feature/kata-task")
+	require.NoError(err)
+	assert.False(before.hasTracking)
+
+	observer := NewPushedHeadObserver(d)
+	result, err := observer.RunOnce(ctx)
+	require.NoError(err)
+	assert.Empty(result.Associations)
+	assert.Empty(result.HeadChanges)
+
+	after, err := gitUpstreamState(ctx, worktreePath, "feature/kata-task")
+	require.NoError(err)
+	assert.True(after.hasTracking)
+	assert.Equal("origin", after.remoteName)
+	assert.Equal("feature/kata-task", after.branchName)
+}
+
 func TestPushedHeadObserverMissingRefAndTransientErrorKeepObservationState(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/workspace/pushed_head_observer_test.go
+++ b/internal/workspace/pushed_head_observer_test.go
@@ -360,6 +360,7 @@ func TestPushedHeadObserverMissingRefAndTransientErrorKeepObservationState(t *te
 func TestPushedHeadObserverUpstreamHeal(t *testing.T) {
 	forkHeadRepo := "https://github.com/contributor/widget.git"
 	sameRepoURL := "https://github.com/acme/widget.git"
+	unknownHeadRepo := ""
 	cases := []struct {
 		name             string
 		branch           string
@@ -378,6 +379,14 @@ func TestPushedHeadObserverUpstreamHeal(t *testing.T) {
 		{
 			name:             "head-branch checkout is rewired to itself",
 			branch:           "feature/remote-head",
+			headRepoCloneURL: sameRepoURL,
+			trackingOK:       true,
+			wantHeal:         true,
+		},
+		{
+			name:             "legacy unknown snapshot heals from current same-repo metadata",
+			branch:           "feature/remote-head",
+			mrHeadRepo:       &unknownHeadRepo,
 			headRepoCloneURL: sameRepoURL,
 			trackingOK:       true,
 			wantHeal:         true,
@@ -468,6 +477,86 @@ func TestPushedHeadObserverUpstreamHeal(t *testing.T) {
 			assert.Equal("refs/heads/feature/remote-head", call.mergeRef)
 			assert.Equal(1, reader.trackingCalls,
 				"heal probe and observation must share one tracking lookup")
+		})
+	}
+}
+
+func TestConfigureMissingUpstreamForRefreshMappedWorkspaces(t *testing.T) {
+	tests := []struct {
+		name         string
+		platform     string
+		platformHost string
+		owner        string
+		repoName     string
+		itemType     string
+		cloneURL     string
+	}{
+		{
+			name:         "provider issue associated during refresh",
+			platform:     "github",
+			platformHost: "github.com",
+			owner:        "acme",
+			repoName:     "widget",
+			itemType:     db.WorkspaceItemTypeIssue,
+			cloneURL:     "https://github.com/acme/widget.git",
+		},
+		{
+			name:         "Kata task associated during refresh",
+			platform:     "github",
+			platformHost: "github.com",
+			owner:        "acme",
+			repoName:     "widget",
+			itemType:     db.WorkspaceItemTypeKataTask,
+			cloneURL:     "https://github.com/acme/widget.git",
+		},
+		{
+			name:         "GitLab nested group",
+			platform:     "gitlab",
+			platformHost: "gitlab.com",
+			owner:        "group/subgroup",
+			repoName:     "project",
+			itemType:     db.WorkspaceItemTypePullRequest,
+			cloneURL:     "https://gitlab.com/group/subgroup/project.git",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			reader := &fakeRemoteHeadReader{
+				branch:      "feature/remote-head",
+				trackingSHA: "2222222",
+				trackingRef: "refs/remotes/origin/feature/remote-head",
+				trackingOK:  true,
+			}
+			observer := newPushedHeadObserverForTest(t, openTestDB(t), reader)
+			ws := &Workspace{
+				ID:           "ws-refresh-mapped",
+				Platform:     tt.platform,
+				PlatformHost: tt.platformHost,
+				RepoOwner:    tt.owner,
+				RepoName:     tt.repoName,
+				ItemType:     tt.itemType,
+				ItemNumber:   42,
+				WorktreePath: "/tmp/worktree",
+			}
+			mr := db.MergeRequest{
+				Number:           42,
+				HeadBranch:       "feature/remote-head",
+				HeadRepoCloneURL: tt.cloneURL,
+			}
+
+			healed, err := observer.configureMissingUpstream(
+				t.Context(), ws, mr, "feature/remote-head",
+				map[string]trackingLookup{},
+			)
+
+			require.NoError(err)
+			assert.True(healed)
+			require.Len(reader.setUpstreamCalls, 1)
+			assert.Equal("origin", reader.setUpstreamCalls[0].remote)
+			assert.Equal("refs/heads/feature/remote-head", reader.setUpstreamCalls[0].mergeRef)
 		})
 	}
 }


### PR DESCRIPTION
Workspaces that took the synthetic `middleman/pr-N` fallback branch (used whenever the PR's real branch name is already checked out or points elsewhere) never got an upstream configured, so every upstream-derived surface silently reported nothing: no sidebar ahead/behind arrows, no push/pull, no unpushed-commit flags — even for a workspace dozens of commits ahead of its PR. #670 fixed the +/- diff chips (a default-branch problem) but never touched this separate divergence path.

The branch upstream config stays the single source of truth rather than adding per-surface fallbacks; both the creation path and a periodic repair now guarantee it exists. Fork PR heads are deliberately left untracked — origin has no ref for them.

- Workspace rows for PR workspaces on the fallback branch now show ahead/behind arrows, and push/pull target the actual PR head branch
- Existing workspaces with a missing upstream self-heal within one pushed-head observer pass (same-repo open PRs; head-branch or synthetic checkouts only), no recreation needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sup>generated by a clanker</sup>