### PR TITLE
fix: let Kata switches supersede background reads

### DIFF
--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -162,6 +162,9 @@ Rows that contain buttons, links, or toggles need clear event ownership.
   writes, initial ownership setup, or a context switch already in progress;
   background refresh counters are presentation state, not transaction locks
   (`frontend/src/lib/features/kata/KataWorkspace.svelte::daemonSwitchLocked`).
+- Treat event streams as cache invalidation, not render replay: batch cursor
+  catch-up into one view revalidation, and hydrate selected-item history off
+  the blocking view-load path (`frontend/src/lib/stores/kata-workspace.svelte.ts::syncEventCursor`).
 
 ## Controlled Form Controls
 

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -154,6 +154,14 @@ Rows that contain buttons, links, or toggles need clear event ownership.
 - Gate unavailable menu actions at the items when the menu remains safe to
   inspect; native-disabled triggers swallow clicks and make pending work look
   like broken UI (`frontend/src/lib/features/kata/KataDaemonSwitcher.svelte::choose`).
+- Keep navigation and context switches available during supersedable reads.
+  Start those reads with an `AbortSignal`, abort them when a newer navigation
+  begins, and retain stale-response generation checks as the application-state
+  backstop (`frontend/src/lib/stores/kata-workspace.svelte.ts::beginViewRequest`).
+- Reserve disabled navigation choices for exclusive transactions such as
+  writes, initial ownership setup, or a context switch already in progress;
+  background refresh counters are presentation state, not transaction locks
+  (`frontend/src/lib/features/kata/KataWorkspace.svelte::daemonSwitchLocked`).
 
 ## Controlled Form Controls
 

--- a/frontend/src/lib/api/kata/taskClient.test.ts
+++ b/frontend/src/lib/api/kata/taskClient.test.ts
@@ -1134,6 +1134,36 @@ describe("kata task HTTP client", () => {
     expect(signals.every((signal) => signal === controller.signal)).toBe(true);
   });
 
+  test("threads abort signals through view and search fetches", async () => {
+    const { fetchImpl } = createFetchStub({
+      "/api/v1/projects?include=stats": {
+        body: { projects: [project("project-work", "Work")] },
+      },
+      "/api/v1/projects/1/issues?status=open": {
+        body: { issues: [issue("issue-1", "Shown issue", "project-work")] },
+      },
+      "/api/v1/issues?status=open": {
+        body: { issues: [issue("issue-1", "Shown issue", "project-work")] },
+      },
+    });
+    const signals: (AbortSignal | null | undefined)[] = [];
+    const recordingFetch: typeof fetch = (input, init) => {
+      signals.push(init?.signal);
+      return fetchImpl(input, init);
+    };
+    const api = createKataTaskAPI({ fetchImpl: recordingFetch });
+    const controller = new AbortController();
+
+    await api.issues({ view: "all", project_uid: "project-work" }, { signal: controller.signal });
+    await api.search(
+      { scope: { kind: "all" }, status: "open", owner: "", label: "", query: "" },
+      { signal: controller.signal },
+    );
+
+    expect(signals).toHaveLength(3);
+    expect(signals.every((signal) => signal === controller.signal)).toBe(true);
+  });
+
   test("fetches events with supported server params and filters issue_uid client-side", async () => {
     const { calls, fetchImpl } = createFetchStub({
       "/api/v1/events?project_id=2&after_id=4": {

--- a/frontend/src/lib/api/kata/taskClient.ts
+++ b/frontend/src/lib/api/kata/taskClient.ts
@@ -375,9 +375,10 @@ export function createKataTaskAPI(options: CreateKataTaskAPIOptions = {}): KataT
     });
   }
 
-  async function fetchProjects(daemonId?: string, pinned = false) {
+  async function fetchProjects(daemonId?: string, pinned = false, signal?: AbortSignal) {
     const result = await request<unknown>(taskPath("/projects?include=stats"), {
       headers: pinned ? pinnedDaemonHeaders(daemonId) : daemonHeaders(daemonId),
+      signal,
     });
     return normalizeKataProjectList(result.body);
   }
@@ -387,6 +388,7 @@ export function createKataTaskAPI(options: CreateKataTaskAPIOptions = {}): KataT
     daemonId?: string,
     project?: KataProjectSummary,
     pinned = false,
+    signal?: AbortSignal,
   ): Promise<KataTaskSummary[]> {
     const params = new URLSearchParams();
     params.set("status", status);
@@ -395,6 +397,7 @@ export function createKataTaskAPI(options: CreateKataTaskAPIOptions = {}): KataT
     const path = taskPath(`${basePath}?${params.toString()}`);
     const result = await request<unknown>(path, {
       headers: pinned ? pinnedDaemonHeaders(daemonId) : daemonHeaders(daemonId),
+      signal,
     });
     return normalizeKataTaskList(result.body)
       .groups.flatMap((group) => group.issues)
@@ -434,15 +437,16 @@ export function createKataTaskAPI(options: CreateKataTaskAPIOptions = {}): KataT
     filters: KataTaskSearchFilters,
     daemonId?: string,
     pinned = false,
+    signal?: AbortSignal,
   ): Promise<KataTaskSummary[]> {
     if (filters.status === "all") {
       const [open, closed] = await Promise.all([
-        fetchIssuesByStatus("open", daemonId, undefined, pinned),
-        fetchIssuesByStatus("closed", daemonId, undefined, pinned),
+        fetchIssuesByStatus("open", daemonId, undefined, pinned, signal),
+        fetchIssuesByStatus("closed", daemonId, undefined, pinned, signal),
       ]);
       return filterSearchIssues([...open, ...closed], filters);
     }
-    return filterSearchIssues(await fetchIssuesByStatus(filters.status, daemonId, undefined, pinned), filters);
+    return filterSearchIssues(await fetchIssuesByStatus(filters.status, daemonId, undefined, pinned, signal), filters);
   }
 
   async function searchProjectIssueList(
@@ -450,15 +454,16 @@ export function createKataTaskAPI(options: CreateKataTaskAPIOptions = {}): KataT
     project: KataProjectSummary,
     daemonId?: string,
     pinned = false,
+    signal?: AbortSignal,
   ): Promise<KataTaskSummary[]> {
     if (filters.status === "all") {
       const [open, closed] = await Promise.all([
-        fetchIssuesByStatus("open", daemonId, project, pinned),
-        fetchIssuesByStatus("closed", daemonId, project, pinned),
+        fetchIssuesByStatus("open", daemonId, project, pinned, signal),
+        fetchIssuesByStatus("closed", daemonId, project, pinned, signal),
       ]);
       return filterSearchIssues([...open, ...closed], filters);
     }
-    return filterSearchIssues(await fetchIssuesByStatus(filters.status, daemonId, project, pinned), filters);
+    return filterSearchIssues(await fetchIssuesByStatus(filters.status, daemonId, project, pinned, signal), filters);
   }
 
   async function hydrateProjectSearchRows(
@@ -467,6 +472,7 @@ export function createKataTaskAPI(options: CreateKataTaskAPIOptions = {}): KataT
     project: KataProjectSummary,
     daemonId?: string,
     pinned = false,
+    signal?: AbortSignal,
   ): Promise<KataTaskSummary[]> {
     if (filters.label.trim() === "" || issues.length === 0) return issues;
     const rows = await searchProjectIssueList(
@@ -478,6 +484,7 @@ export function createKataTaskAPI(options: CreateKataTaskAPIOptions = {}): KataT
       project,
       daemonId,
       pinned,
+      signal,
     );
     const byUID = new Map(rows.map((issue) => [issue.uid, issue]));
     return issues.map((issue) => ({
@@ -490,19 +497,21 @@ export function createKataTaskAPI(options: CreateKataTaskAPIOptions = {}): KataT
     filters: KataTaskSearchFilters & { scope: { kind: "project"; project_uid: string } },
     daemonId?: string,
     pinned = false,
+    signal?: AbortSignal,
   ) {
-    const projects = await fetchProjects(daemonId, pinned);
+    const projects = await fetchProjects(daemonId, pinned, signal);
     const project = projects.projects.find((item) => item.uid === filters.scope.project_uid);
     if (!project) {
       return filterSearchIssues([], filters);
     }
     if (filters.query.trim() === "") {
-      return searchProjectIssueList(filters, project, daemonId, pinned);
+      return searchProjectIssueList(filters, project, daemonId, pinned, signal);
     }
     const params = new URLSearchParams();
     params.set("q", filters.query);
     const result = await request<unknown>(taskPath(`/projects/${project.id}/search?${params.toString()}`), {
       headers: pinned ? pinnedDaemonHeaders(daemonId) : daemonHeaders(daemonId),
+      signal,
     });
     const issues = await hydrateProjectSearchRows(
       normalizeSearchResults(result.body, project),
@@ -510,6 +519,7 @@ export function createKataTaskAPI(options: CreateKataTaskAPIOptions = {}): KataT
       project,
       daemonId,
       pinned,
+      signal,
     );
     return filterSearchIssues(issues, filters, { applyQuery: false });
   }
@@ -519,13 +529,13 @@ export function createKataTaskAPI(options: CreateKataTaskAPIOptions = {}): KataT
       workflowDaemonId = daemonId?.trim() || undefined;
     },
 
-    async instance() {
-      const result = await request<unknown>(taskPath("/instance"));
+    async instance(opts) {
+      const result = await request<unknown>(taskPath("/instance"), { signal: opts?.signal });
       return normalizeKataInstance(result.body);
     },
 
-    projects() {
-      return fetchProjects();
+    projects(opts) {
+      return fetchProjects(undefined, false, opts?.signal);
     },
 
     async createProject(name) {
@@ -621,13 +631,15 @@ export function createKataTaskAPI(options: CreateKataTaskAPIOptions = {}): KataT
       const daemonId = await resolveOperationDaemonId(opts?.daemonId);
       const status = query.view === "logbook" ? "closed" : "open";
       const genericIssuesPromise =
-        query.project_uid === undefined ? fetchIssuesByStatus(status, daemonId, undefined, true) : undefined;
-      const projectsPromise = fetchProjects(daemonId, true);
+        query.project_uid === undefined
+          ? fetchIssuesByStatus(status, daemonId, undefined, true, opts?.signal)
+          : undefined;
+      const projectsPromise = fetchProjects(daemonId, true, opts?.signal);
       const issuesPromise =
         genericIssuesPromise ??
         projectsPromise.then((projects) => {
           const project = projects.projects.find((item) => item.uid === query.project_uid);
-          return project ? fetchIssuesByStatus(status, daemonId, project, true) : [];
+          return project ? fetchIssuesByStatus(status, daemonId, project, true, opts?.signal) : [];
         });
       const [issues, projects] = await Promise.all([issuesPromise, projectsPromise]);
       const projectMap = new Map(projects.projects.map((project) => [project.uid, project]));
@@ -650,8 +662,9 @@ export function createKataTaskAPI(options: CreateKataTaskAPIOptions = {}): KataT
               filters as KataTaskSearchFilters & { scope: { kind: "project"; project_uid: string } },
               daemonId,
               true,
+              opts?.signal,
             )
-          : await searchAllProjects(filters, daemonId, true);
+          : await searchAllProjects(filters, daemonId, true, opts?.signal);
       const response = {
         filters,
         issues,

--- a/frontend/src/lib/api/kata/taskTypes.ts
+++ b/frontend/src/lib/api/kata/taskTypes.ts
@@ -383,8 +383,8 @@ export interface KataTaskIssuesQuery {
 
 export interface KataTaskAPI {
   bindWorkflowDaemon?(daemonId?: string): void;
-  instance(): Promise<KataInstanceResponse>;
-  projects(): Promise<KataProjectsResponse>;
+  instance(opts?: { signal?: AbortSignal }): Promise<KataInstanceResponse>;
+  projects(opts?: { signal?: AbortSignal }): Promise<KataProjectsResponse>;
   createProject(name: string): Promise<KataProjectSummary>;
   renameProject(projectID: number, name: string): Promise<KataProjectSummary>;
   patchProjectMetadata(
@@ -399,8 +399,11 @@ export interface KataTaskAPI {
     draft: KataTaskCreateDraft,
     idempotencyKey?: string | undefined,
   ): Promise<KataTaskMutationResponse>;
-  issues(query: KataTaskIssuesQuery, opts?: { daemonId?: string }): Promise<KataTaskViewResponse>;
-  search(filters: KataTaskSearchFilters, opts?: { daemonId?: string }): Promise<KataTaskSearchResponse>;
+  issues(query: KataTaskIssuesQuery, opts?: { daemonId?: string; signal?: AbortSignal }): Promise<KataTaskViewResponse>;
+  search(
+    filters: KataTaskSearchFilters,
+    opts?: { daemonId?: string; signal?: AbortSignal },
+  ): Promise<KataTaskSearchResponse>;
   issue(uid: string, opts?: { daemonId?: string; pinned?: boolean; signal?: AbortSignal }): Promise<KataTaskDetail>;
   reachableGraph(
     projectID: number,

--- a/frontend/src/lib/features/kata/KataDaemonSwitcher.svelte
+++ b/frontend/src/lib/features/kata/KataDaemonSwitcher.svelte
@@ -198,8 +198,14 @@
     cursor: pointer;
   }
 
-  .daemon-row:hover {
+  .daemon-row:hover:not(:disabled) {
     background: var(--bg-surface-hover);
+  }
+
+  .daemon-row:disabled {
+    color: var(--text-muted);
+    cursor: not-allowed;
+    opacity: 0.6;
   }
 
   .daemon-row.selected {

--- a/frontend/src/lib/features/kata/KataWorkspace.svelte
+++ b/frontend/src/lib/features/kata/KataWorkspace.svelte
@@ -414,19 +414,17 @@
 
   type RouteMismatch = "daemon" | "viewScope" | "select" | "clear" | null;
 
-  // A daemon switch is transactional and refuses while other work is in
-  // flight. The reconciler must check the same gates before attempting
-  // it: an attempt that would refuse must be a no-op evaluation, not a
-  // reconcile pass, or the effect re-fires itself in a busy loop.
-  function daemonSwitchGated(): boolean {
-    return viewWorkCount > 0 || store.hasPendingMutations || workspaceActionBusy;
+  // Read-only view work is intentionally absent: a daemon switch advances
+  // the navigation generation and invalidates pending loads, so stale read
+  // completions cannot repaint the new daemon. Only ownership setup, another
+  // switch transaction, or non-supersedable writes hold the exclusive lock.
+  function daemonSwitchLocked(): boolean {
+    return loading || switchingDaemon || store.hasPendingMutations || workspaceActionBusy;
   }
 
-  // Route list loads are not abortable, so the reconciler starts them
-  // without awaiting: a stalled fetch must not block converging to a
-  // newer route (the store's request guards drop the late result). This
-  // records which route's list load is in flight so re-evaluations do
-  // not start a duplicate.
+  // The reconciler starts route list loads without awaiting so a newer
+  // route can supersede and abort them. This records which route's list
+  // load is in flight so re-evaluations do not start a duplicate.
   let viewScopeLoadSignature = $state<string | null>(null);
 
   function startViewScopeLoad(signature: string): void {
@@ -509,7 +507,7 @@
           return;
         }
         if (mismatch === "daemon") {
-          if (daemonSwitchGated()) return;
+          if (daemonSwitchLocked()) return;
           await switchKataDaemon(requestedDaemonId!);
           if (requestedDaemonId !== null && requestedDaemonId !== store.daemonId) {
             // The switch refused or failed; the effect re-fires when its
@@ -616,7 +614,7 @@
       }
       return;
     }
-    if (mismatch === "daemon" && daemonSwitchGated()) return;
+    if (mismatch === "daemon" && daemonSwitchLocked()) return;
     // A project route load applies its scope before its optional view load
     // finishes. That intermediate state can leave only the issue selection
     // mismatched, but selecting now would be aborted when the remaining view
@@ -862,7 +860,7 @@
   }
 
   async function switchKataDaemon(id: string): Promise<void> {
-    if (loading || switchingDaemon || viewWorkCount > 0 || store.hasPendingMutations || workspaceActionBusy) return;
+    if (daemonSwitchLocked()) return;
     const previousExplicitDaemon = getActiveKataDaemon();
     const previousDaemon = store.daemonId ?? activeKataDaemonId;
     if (id === store.daemonId) return;
@@ -1163,7 +1161,7 @@
           activeId={activeKataDaemonId}
           activeStatusLabel={activeDaemonStatusLabel()}
           activeStatusTone={activeDaemonStatusLabel() ? "error" : undefined}
-          disabled={loading || switchingDaemon || viewWorkCount > 0 || store.hasPendingMutations || workspaceActionBusy}
+          disabled={daemonSwitchLocked()}
           onSelect={(id) => {
             void switchKataDaemon(id);
           }}

--- a/frontend/src/lib/features/kata/KataWorkspace.test.ts
+++ b/frontend/src/lib/features/kata/KataWorkspace.test.ts
@@ -953,6 +953,7 @@ describe("KataWorkspace", () => {
     expect(screen.getByText("Email Susan re: Q3 body")).toBeTruthy();
     expect(search).toHaveBeenCalledWith(
       expect.objectContaining({ scope: { kind: "project", project_uid: "project-kata" } }),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
   });
 
@@ -1259,13 +1260,16 @@ describe("KataWorkspace", () => {
     await fireEvent.keyDown(projectInput, { key: "Enter" });
 
     await waitFor(() => {
-      expect(search).toHaveBeenLastCalledWith({
-        scope: { kind: "project", project_uid: "project-kata" },
-        status: "all",
-        owner: "fixture-user",
-        label: "work",
-        query: "q3",
-      });
+      expect(search).toHaveBeenLastCalledWith(
+        {
+          scope: { kind: "project", project_uid: "project-kata" },
+          status: "all",
+          owner: "fixture-user",
+          label: "work",
+          query: "q3",
+        },
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
     });
   });
 
@@ -1374,9 +1378,19 @@ describe("KataWorkspace", () => {
       expect(screen.getByRole("heading", { name: "All Open" })).toBeTruthy();
     });
     await fireEvent.input(screen.getByLabelText("Search tasks"), { target: { value: "old" } });
-    await waitFor(() => expect(search).toHaveBeenCalledWith(expect.objectContaining({ query: "old" })));
+    await waitFor(() =>
+      expect(search).toHaveBeenCalledWith(
+        expect.objectContaining({ query: "old" }),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      ),
+    );
     await fireEvent.input(screen.getByLabelText("Search tasks"), { target: { value: "new" } });
-    await waitFor(() => expect(search).toHaveBeenCalledWith(expect.objectContaining({ query: "new" })));
+    await waitFor(() =>
+      expect(search).toHaveBeenCalledWith(
+        expect.objectContaining({ query: "new" }),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      ),
+    );
 
     oldSearch.resolve({
       filters: { scope: { kind: "all" }, status: "open", owner: "", label: "", query: "old" },
@@ -1388,7 +1402,7 @@ describe("KataWorkspace", () => {
     expect(screen.queryByText("Loading snapshot")).toBeTruthy();
     await fireEvent.click(screen.getByTestId("daemon-chip"));
     const homeDaemonRow = screen.getByTestId("daemon-row-home") as HTMLButtonElement;
-    expect(homeDaemonRow.disabled).toBe(true);
+    expect(homeDaemonRow.disabled).toBe(false);
 
     newSearch.resolve({
       filters: { scope: { kind: "all" }, status: "open", owner: "", label: "", query: "new" },
@@ -1436,9 +1450,19 @@ describe("KataWorkspace", () => {
       expect(screen.getByRole("heading", { name: "All Open" })).toBeTruthy();
     });
     await fireEvent.input(screen.getByLabelText("Search tasks"), { target: { value: "old" } });
-    await waitFor(() => expect(search).toHaveBeenCalledWith(expect.objectContaining({ query: "old" })));
+    await waitFor(() =>
+      expect(search).toHaveBeenCalledWith(
+        expect.objectContaining({ query: "old" }),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      ),
+    );
     await fireEvent.input(screen.getByLabelText("Search tasks"), { target: { value: "new" } });
-    await waitFor(() => expect(search).toHaveBeenCalledWith(expect.objectContaining({ query: "new" })));
+    await waitFor(() =>
+      expect(search).toHaveBeenCalledWith(
+        expect.objectContaining({ query: "new" }),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      ),
+    );
 
     newSearch.resolve({
       filters: { scope: { kind: "all" }, status: "open", owner: "", label: "", query: "new" },
@@ -1452,7 +1476,7 @@ describe("KataWorkspace", () => {
     });
     await fireEvent.click(screen.getByTestId("daemon-chip"));
     const homeDaemonRow = screen.getByTestId("daemon-row-home") as HTMLButtonElement;
-    expect(homeDaemonRow.disabled).toBe(true);
+    expect(homeDaemonRow.disabled).toBe(false);
 
     oldSearch.resolve({
       filters: { scope: { kind: "all" }, status: "open", owner: "", label: "", query: "old" },

--- a/frontend/src/lib/features/kata/KataWorkspaceEventStream.test.ts
+++ b/frontend/src/lib/features/kata/KataWorkspaceEventStream.test.ts
@@ -508,7 +508,7 @@ describe("KataWorkspace", () => {
     expect(streamHeaders[2]?.get("Last-Event-ID")).toBe("6");
   });
 
-  it("drains queued old-stream messages before enabling a daemon switch", async () => {
+  it("keeps daemon switching available while draining queued old-stream messages", async () => {
     const streamControllers: ReadableStreamDefaultController<Uint8Array>[] = [];
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
       const url = new URL(input instanceof Request ? input.url : String(input), window.location.origin);
@@ -589,7 +589,7 @@ describe("KataWorkspace", () => {
     await oldStreamRefreshStarted.promise;
     await fireEvent.click(screen.getByTestId("daemon-chip"));
     const homeDaemonRow = screen.getByTestId("daemon-row-home") as HTMLButtonElement;
-    expect(homeDaemonRow.disabled).toBe(true);
+    expect(homeDaemonRow.disabled).toBe(false);
 
     releaseOldStreamRefresh.resolve();
     await waitFor(() => {
@@ -604,7 +604,7 @@ describe("KataWorkspace", () => {
     expect(api.issues).toHaveBeenCalledTimes(viewLoadsAfterDrain);
   });
 
-  it("releases the daemon switch gate and reconnects when a stream refresh fails", async () => {
+  it("keeps daemon switching available and reconnects when a stream refresh fails", async () => {
     const streamControllers: ReadableStreamDefaultController<Uint8Array>[] = [];
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
       const url = new URL(input instanceof Request ? input.url : String(input), window.location.origin);
@@ -651,7 +651,7 @@ describe("KataWorkspace", () => {
     await fireEvent.click(screen.getByTestId("daemon-chip"));
     const homeDaemonRow = screen.getByTestId("daemon-row-home") as HTMLButtonElement;
     await waitFor(() => {
-      expect(homeDaemonRow.disabled).toBe(true);
+      expect(homeDaemonRow.disabled).toBe(false);
     });
 
     failedRefresh.reject(new Error("stream refresh failed"));

--- a/frontend/src/lib/features/kata/KataWorkspaceRouting.test.ts
+++ b/frontend/src/lib/features/kata/KataWorkspaceRouting.test.ts
@@ -127,7 +127,12 @@ describe("KataWorkspace", () => {
     await Promise.resolve();
     vi.mocked(api.issues).mockImplementationOnce(async (_query: KataTaskIssuesQuery) => stalledView.promise);
     await rerender({ api, routeViewName: "inbox", selectedIssueUID: "issue-email-susan" });
-    await waitFor(() => expect(api.issues).toHaveBeenCalledWith({ view: "inbox" }));
+    await waitFor(() =>
+      expect(api.issues).toHaveBeenCalledWith(
+        { view: "inbox" },
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      ),
+    );
 
     await rerender({ api, routeViewName: null, selectedIssueUID: null });
     await waitFor(() => {

--- a/frontend/src/lib/stores/kata-workspace.svelte.test.ts
+++ b/frontend/src/lib/stores/kata-workspace.svelte.test.ts
@@ -1795,6 +1795,37 @@ describe("kata workspace store", () => {
     expect(store.eventCursor).toBe(99);
   });
 
+  test("an unrelated remote event preserves the cached selected detail", async () => {
+    const api = createFakeKataTaskAPI();
+    const store = createKataWorkspaceStore({ api });
+    await store.bootstrap();
+    expect(store.selectedIssue?.issue.uid).toBe("issue-pay-rent");
+    api.mocks.issue.mockClear();
+
+    await store.applyRemoteEvent({ ...events[1]!, event_id: 99 });
+
+    expect(store.selectedIssue?.issue.uid).toBe("issue-pay-rent");
+    expect(api.mocks.issue).not.toHaveBeenCalled();
+  });
+
+  test("view loads do not wait for selected issue history", async () => {
+    const api = createFakeKataTaskAPI();
+    const slowEvents = deferred<KataTaskEventsResponse>();
+    api.mocks.events.mockImplementationOnce(() => slowEvents.promise);
+    const store = createKataWorkspaceStore({ api });
+
+    const bootstrap = store.bootstrap();
+    try {
+      await vi.waitFor(() => {
+        expect(store.selectedIssue?.issue.uid).toBe("issue-pay-rent");
+      });
+      await bootstrap;
+    } finally {
+      slowEvents.resolve({ reset_required: false, events: [], next_after_id: 0 });
+      await bootstrap;
+    }
+  });
+
   test("syncs event cursor through paged event reads", async () => {
     const api = createFakeKataTaskAPI();
     api.mocks.events.mockImplementation(async (query: KataTaskEventsQuery = {}) => {
@@ -1820,6 +1851,30 @@ describe("kata workspace store", () => {
     expect(cursorReads.map(([query]) => query?.after_id)).toEqual([0, 1, 2]);
   });
 
+  test("syncing a multi-page event backlog revalidates the view once", async () => {
+    const api = createFakeKataTaskAPI();
+    api.mocks.events
+      .mockResolvedValueOnce({
+        reset_required: false,
+        events: [{ ...events[0]!, event_id: 100 }],
+        next_after_id: 100,
+      })
+      .mockResolvedValueOnce({
+        reset_required: false,
+        events: [{ ...events[1]!, event_id: 101 }],
+        next_after_id: 101,
+      })
+      .mockResolvedValueOnce({ reset_required: false, events: [], next_after_id: 101 });
+    const store = createKataWorkspaceStore({ api });
+    await store.bootstrap("all", null, { selectFirst: false });
+    api.mocks.issues.mockClear();
+
+    await store.syncEventCursor();
+
+    expect(store.eventCursor).toBe(101);
+    expect(api.mocks.issues).toHaveBeenCalledOnce();
+  });
+
   test("syncing the event cursor applies observed events before advancing", async () => {
     const api = createFakeKataTaskAPI();
     const store = createKataWorkspaceStore({ api });
@@ -1836,7 +1891,7 @@ describe("kata workspace store", () => {
     expect(store.selectedIssue?.issue.uid).toBe("issue-renew-passport");
   });
 
-  test("syncing the event cursor stops after an unapplied event in a multi-event page", async () => {
+  test("syncing the event cursor does not advance when batched revalidation is unapplied", async () => {
     const api = createFakeKataTaskAPI();
     const store = createKataWorkspaceStore({ api });
     await store.bootstrap("all");
@@ -1862,7 +1917,7 @@ describe("kata workspace store", () => {
     expect(store.eventCursor).toBe(0);
     expect(api.mocks.search).toHaveBeenCalledTimes(2);
     const cursorReads = api.mocks.events.mock.calls.filter(([query]) => query?.after_id !== undefined);
-    expect(cursorReads.map(([query]) => query?.after_id)).toEqual([0]);
+    expect(cursorReads.map(([query]) => query?.after_id)).toEqual([0, 101]);
   });
 
   test("resetEventCursor lets lower-id events from a new daemon apply", async () => {

--- a/frontend/src/lib/stores/kata-workspace.svelte.test.ts
+++ b/frontend/src/lib/stores/kata-workspace.svelte.test.ts
@@ -852,7 +852,10 @@ describe("kata workspace store", () => {
       label: "",
       query: "",
     });
-    expect(api.mocks.issues).toHaveBeenLastCalledWith({ view: "inbox" }, { daemonId: "home" });
+    expect(api.mocks.issues).toHaveBeenLastCalledWith(
+      { view: "inbox" },
+      expect.objectContaining({ daemonId: "home", signal: expect.any(AbortSignal) }),
+    );
   });
 
   test("normalizes duplicate candidates from tolerant task error details", () => {
@@ -1126,6 +1129,32 @@ describe("kata workspace store", () => {
     expect(store.pendingSelectionUID).toBeNull();
   });
 
+  test("invalidating pending loads aborts the in-flight view load", async () => {
+    const api = createFakeKataTaskAPI();
+    const response = deferred<KataTaskViewResponse>();
+    api.mocks.issues.mockImplementationOnce(() => response.promise);
+    const store = createKataWorkspaceStore({ api });
+
+    const pending = store.openView("all");
+    await vi.waitFor(() => expect(api.mocks.issues).toHaveBeenCalledOnce());
+    const signal = api.mocks.issues.mock.calls[0]?.[1]?.signal as AbortSignal | undefined;
+    store.invalidatePendingLoads();
+    response.resolve({
+      ...buildKataTaskView({
+        view: "all",
+        issues,
+        projects,
+        today: "2026-05-15",
+        fetched_at: fetchedAt,
+      }),
+      daemon_id: "home",
+    });
+
+    await pending;
+    expect(signal).toBeInstanceOf(AbortSignal);
+    expect(signal?.aborted).toBe(true);
+  });
+
   test("explicit empty relationship fields clear stale cached graph links", () => {
     const store = createKataWorkspaceStore({ api: createFakeKataTaskAPI() });
     const stale = {
@@ -1291,7 +1320,7 @@ describe("kata workspace store", () => {
     expect(api.mocks.search).not.toHaveBeenCalled();
     expect(api.mocks.issues).toHaveBeenCalledWith(
       { view: "upcoming", project_uid: "project-kata" },
-      { daemonId: "home" },
+      expect.objectContaining({ daemonId: "home", signal: expect.any(AbortSignal) }),
     );
     expect(store.currentView.name).toBe("upcoming");
   });
@@ -1316,7 +1345,7 @@ describe("kata workspace store", () => {
     expect(api.mocks.search).not.toHaveBeenCalled();
     expect(api.mocks.issues).toHaveBeenCalledWith(
       { view: "upcoming", project_uid: "project-kata" },
-      { daemonId: "home" },
+      expect.objectContaining({ daemonId: "home", signal: expect.any(AbortSignal) }),
     );
     expect(store.currentView.name).toBe("upcoming");
     expect(store.selectedIssue?.issue.uid).toBe("issue-read-design-notes");
@@ -1800,7 +1829,10 @@ describe("kata workspace store", () => {
     await store.syncEventCursor();
 
     expect(store.eventCursor).toBe(2);
-    expect(api.mocks.issues).toHaveBeenCalledWith({ view: "inbox" }, { daemonId: "home" });
+    expect(api.mocks.issues).toHaveBeenCalledWith(
+      { view: "inbox" },
+      expect.objectContaining({ daemonId: "home", signal: expect.any(AbortSignal) }),
+    );
     expect(store.selectedIssue?.issue.uid).toBe("issue-renew-passport");
   });
 
@@ -1853,7 +1885,10 @@ describe("kata workspace store", () => {
     });
 
     expect(store.eventCursor).toBe(lowID);
-    expect(api.mocks.issues).toHaveBeenCalledWith({ view: "today" }, { daemonId: "home" });
+    expect(api.mocks.issues).toHaveBeenCalledWith(
+      { view: "today" },
+      expect.objectContaining({ daemonId: "home", signal: expect.any(AbortSignal) }),
+    );
   });
 
   test("remote events do not advance the cursor when refreshing the view fails", async () => {
@@ -1907,7 +1942,10 @@ describe("kata workspace store", () => {
     });
 
     expect(store.eventCursor).toBe(77);
-    expect(api.mocks.issues).toHaveBeenCalledWith({ view: "today" }, { daemonId: "home" });
+    expect(api.mocks.issues).toHaveBeenCalledWith(
+      { view: "today" },
+      expect.objectContaining({ daemonId: "home", signal: expect.any(AbortSignal) }),
+    );
     expect(api.mocks.issue).toHaveBeenCalledWith("issue-pay-rent", { signal: expect.any(AbortSignal) });
     expect(store.selectedIssue?.comments.map((comment) => comment.body)).toContain("Remote note.");
   });
@@ -1940,7 +1978,10 @@ describe("kata workspace store", () => {
     });
 
     expect(store.eventCursor).toBe(77);
-    expect(api.mocks.issues).toHaveBeenCalledWith({ view: "today" }, { daemonId: "home" });
+    expect(api.mocks.issues).toHaveBeenCalledWith(
+      { view: "today" },
+      expect.objectContaining({ daemonId: "home", signal: expect.any(AbortSignal) }),
+    );
     expect(store.selectedIssue?.issue.metadata).toMatchObject({
       scheduled_on: "2026-05-20",
       someday: true,
@@ -2040,7 +2081,10 @@ describe("kata workspace store", () => {
 
     await store.syncEventCursor();
 
-    expect(api.mocks.issues).toHaveBeenCalledWith({ view: "inbox" }, { daemonId: "home" });
+    expect(api.mocks.issues).toHaveBeenCalledWith(
+      { view: "inbox" },
+      expect.objectContaining({ daemonId: "home", signal: expect.any(AbortSignal) }),
+    );
     expect(store.eventCursor).toBe(25);
   });
 
@@ -2057,7 +2101,10 @@ describe("kata workspace store", () => {
     });
 
     expect(store.eventCursor).toBe(100);
-    expect(api.mocks.issues).toHaveBeenLastCalledWith({ view: "inbox" }, { daemonId: "home" });
+    expect(api.mocks.issues).toHaveBeenLastCalledWith(
+      { view: "inbox" },
+      expect.objectContaining({ daemonId: "home", signal: expect.any(AbortSignal) }),
+    );
     expect(store.currentView.name).toBe("inbox");
     expect(store.connection.status).toBe("online");
   });
@@ -2087,7 +2134,10 @@ describe("kata workspace store", () => {
       owner: "agent:planner",
       query: "design",
     });
-    expect(api.mocks.search).toHaveBeenLastCalledWith(store.searchFilters, { daemonId: "home" });
+    expect(api.mocks.search).toHaveBeenLastCalledWith(
+      store.searchFilters,
+      expect.objectContaining({ daemonId: "home", signal: expect.any(AbortSignal) }),
+    );
     expect(store.selectedIssue?.issue.uid).toBe("issue-read-design-notes");
   });
 
@@ -2177,7 +2227,10 @@ describe("kata workspace store", () => {
       lastEventID: 100,
     });
     await vi.waitFor(() => {
-      expect(api.mocks.issues).toHaveBeenCalledWith({ view: "today" });
+      expect(api.mocks.issues).toHaveBeenCalledWith(
+        { view: "today" },
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
     });
 
     await store.openView("inbox");

--- a/frontend/src/lib/stores/kata-workspace.svelte.ts
+++ b/frontend/src/lib/stores/kata-workspace.svelte.ts
@@ -302,6 +302,7 @@ export class KataWorkspaceStore {
   cachedTasks = $derived([...this.taskCache.values()]);
 
   private viewRequestID = 0;
+  private viewAbort: AbortController | null = null;
   private detailRequestID = 0;
   private detailAbort: AbortController | null = null;
   private unscopedViewName: KataTaskViewName = "today";
@@ -310,6 +311,13 @@ export class KataWorkspaceStore {
 
   constructor(options: CreateKataWorkspaceStoreOptions = {}) {
     this.api = options.api ?? createKataTaskAPI();
+  }
+
+  private beginViewRequest(): { requestID: number; signal: AbortSignal } {
+    this.viewAbort?.abort();
+    const controller = new AbortController();
+    this.viewAbort = controller;
+    return { requestID: ++this.viewRequestID, signal: controller.signal };
   }
 
   clearDaemonBinding(): void {
@@ -339,11 +347,14 @@ export class KataWorkspaceStore {
     preferredIssueUID?: string | null,
     options: KataBootstrapOptions = {},
   ): Promise<void> {
-    const requestID = ++this.viewRequestID;
+    const { requestID, signal } = this.beginViewRequest();
     this.connection = { status: "connecting" };
     try {
-      await this.api.instance();
-      const [projects, view] = await Promise.all([this.api.projects(), this.loadIssues({ view: viewName })]);
+      await this.api.instance({ signal });
+      const [projects, view] = await Promise.all([
+        this.api.projects({ signal }),
+        this.loadIssues({ view: viewName }, signal),
+      ]);
       if (requestID !== this.viewRequestID) {
         this.connection = { status: "online" };
         return;
@@ -380,8 +391,14 @@ export class KataWorkspaceStore {
 
   async openView(viewName: KataTaskViewName, options: KataLoadOptions = {}): Promise<void> {
     if (!shouldApplyLoad(options)) return;
-    const requestID = ++this.viewRequestID;
-    const view = await this.loadIssues({ view: viewName, ...scopedIssueQuery(this.searchFilters) });
+    const { requestID, signal } = this.beginViewRequest();
+    let view: KataTaskViewResponse;
+    try {
+      view = await this.loadIssues({ view: viewName, ...scopedIssueQuery(this.searchFilters) }, signal);
+    } catch (error) {
+      if (requestID !== this.viewRequestID) return;
+      throw error;
+    }
     if (requestID !== this.viewRequestID || !shouldApplyLoad(options)) return;
     this.acceptWorkflowResult(view);
     this.cacheView(view);
@@ -419,9 +436,9 @@ export class KataWorkspaceStore {
       return;
     }
 
-    const requestID = ++this.viewRequestID;
+    const { requestID, signal } = this.beginViewRequest();
     try {
-      const results = await this.searchIssues(this.searchFilters);
+      const results = await this.searchIssues(this.searchFilters, signal);
       if (requestID !== this.viewRequestID || !shouldApplyLoad(options)) return;
       this.acceptWorkflowResult(results);
       this.duplicateCandidates = [];
@@ -452,8 +469,14 @@ export class KataWorkspaceStore {
         : this.unscopedViewName;
 
     if (!hasActiveSearchFilters(nextFilters)) {
-      const requestID = ++this.viewRequestID;
-      const view = await this.loadIssues({ view: nextUnscopedViewName });
+      const { requestID, signal } = this.beginViewRequest();
+      let view: KataTaskViewResponse;
+      try {
+        view = await this.loadIssues({ view: nextUnscopedViewName }, signal);
+      } catch (error) {
+        if (requestID !== this.viewRequestID || !shouldApplyLoad(options)) return;
+        throw error;
+      }
       if (requestID !== this.viewRequestID || !shouldApplyLoad(options)) return;
       this.acceptWorkflowResult(view);
       this.searchFilters = nextFilters;
@@ -472,9 +495,9 @@ export class KataWorkspaceStore {
       return;
     }
 
-    const requestID = ++this.viewRequestID;
+    const { requestID, signal } = this.beginViewRequest();
     try {
-      const results = await this.searchIssues(nextFilters);
+      const results = await this.searchIssues(nextFilters, signal);
       if (requestID !== this.viewRequestID || !shouldApplyLoad(options)) return;
       this.acceptWorkflowResult(results);
       if (previousFilters.scope.kind === "all" && nextFilters.scope.kind === "project") {
@@ -500,41 +523,47 @@ export class KataWorkspaceStore {
   }
 
   async createProject(name: string): Promise<KataProjectSummary> {
-    const project = await this.api.createProject(name);
-    await this.reloadProjects();
-    return project;
+    return this.withMutation(async () => {
+      const project = await this.api.createProject(name);
+      await this.reloadProjects();
+      return project;
+    });
   }
 
   async captureIssue(actor: string, draft: KataTaskCreateDraft, idempotencyKey = createULID()): Promise<void> {
-    const inbox =
-      this.projects.find(isTaskInboxProject) ??
-      (await this.api.projects()).projects.find((project) => isTaskInboxProject(project));
-    if (!inbox) throw new Error("task inbox project is not available");
+    await this.withMutation(async () => {
+      const inbox =
+        this.projects.find(isTaskInboxProject) ??
+        (await this.api.projects()).projects.find((project) => isTaskInboxProject(project));
+      if (!inbox) throw new Error("task inbox project is not available");
 
-    const result = await this.api.createIssue(inbox.id, actor, draft, idempotencyKey);
-    this.captureMutationETag(result);
-    await this.reloadProjects();
+      const result = await this.api.createIssue(inbox.id, actor, draft, idempotencyKey);
+      this.captureMutationETag(result);
+      await this.reloadProjects();
 
-    const requestID = ++this.viewRequestID;
-    this.searchFilters = defaultKataTaskSearchFilters();
-    this.duplicateCandidates = [];
-    const view = await this.loadIssues({ view: "inbox" });
-    if (requestID !== this.viewRequestID) return;
-    this.acceptWorkflowResult(view);
-    this.cacheView(view);
-    this.currentView = {
-      name: "inbox",
-      groups: view.groups,
-      fetched_at: view.fetched_at,
-    };
-    this.unscopedViewName = "inbox";
-    await this.loadSelectedIssue(result.issue?.uid ?? null, requestID, ++this.detailRequestID);
+      const { requestID, signal } = this.beginViewRequest();
+      this.searchFilters = defaultKataTaskSearchFilters();
+      this.duplicateCandidates = [];
+      const view = await this.loadIssues({ view: "inbox" }, signal);
+      if (requestID !== this.viewRequestID) return;
+      this.acceptWorkflowResult(view);
+      this.cacheView(view);
+      this.currentView = {
+        name: "inbox",
+        groups: view.groups,
+        fetched_at: view.fetched_at,
+      };
+      this.unscopedViewName = "inbox";
+      await this.loadSelectedIssue(result.issue?.uid ?? null, requestID, ++this.detailRequestID);
+    });
   }
 
   async renameProject(projectID: number, name: string): Promise<void> {
-    await this.api.renameProject(projectID, name);
-    await this.reloadProjects();
-    await this.refreshCurrentView(this.selectedIssue?.issue.uid);
+    await this.withMutation(async () => {
+      await this.api.renameProject(projectID, name);
+      await this.reloadProjects();
+      await this.refreshCurrentView(this.selectedIssue?.issue.uid);
+    });
   }
 
   async selectIssue(uid: string): Promise<boolean> {
@@ -585,13 +614,17 @@ export class KataWorkspaceStore {
   }
 
   async closeIssue(uid: string, actor: string, options: KataTaskCloseOptions = {}): Promise<void> {
-    await this.mutateIssue(uid, (target) => this.api.closeIssue(target, actor, options));
-    await this.reloadProjects();
+    await this.withMutation(async () => {
+      await this.mutateIssue(uid, (target) => this.api.closeIssue(target, actor, options));
+      await this.reloadProjects();
+    });
   }
 
   async reopenIssue(uid: string, actor: string): Promise<void> {
-    await this.mutateIssue(uid, (target) => this.api.reopenIssue(target, actor));
-    await this.reloadProjects();
+    await this.withMutation(async () => {
+      await this.mutateIssue(uid, (target) => this.api.reopenIssue(target, actor));
+      await this.reloadProjects();
+    });
   }
 
   async editIssue(uid: string, actor: string, patch: KataTaskEditPatch): Promise<void> {
@@ -612,20 +645,24 @@ export class KataWorkspaceStore {
   }
 
   async moveIssue(uid: string, actor: string, toProjectUID: string): Promise<void> {
-    const issue = this.issueForMutation(uid);
-    const selectedETag = this.selectedIssue?.issue.uid === uid ? this.selectedIssue.etag : undefined;
-    const ifMatch = this.issueETags.get(uid) ?? selectedETag ?? `"rev-${issue.revision}"`;
-    await this.mutateIssue(uid, (target) => this.api.moveIssue(target, actor, toProjectUID, ifMatch));
-    await this.reloadProjects();
+    await this.withMutation(async () => {
+      const issue = this.issueForMutation(uid);
+      const selectedETag = this.selectedIssue?.issue.uid === uid ? this.selectedIssue.etag : undefined;
+      const ifMatch = this.issueETags.get(uid) ?? selectedETag ?? `"rev-${issue.revision}"`;
+      await this.mutateIssue(uid, (target) => this.api.moveIssue(target, actor, toProjectUID, ifMatch));
+      await this.reloadProjects();
+    });
   }
 
   async createRecurrence(
     projectID: number,
     input: KataCreateRecurrenceInput,
   ): Promise<KataRecurrenceResponse["recurrence"]> {
-    const response = await this.api.createRecurrence(projectID, input);
-    await this.refreshSelectedRecurrences();
-    return response.recurrence;
+    return this.withMutation(async () => {
+      const response = await this.api.createRecurrence(projectID, input);
+      await this.refreshSelectedRecurrences();
+      return response.recurrence;
+    });
   }
 
   async patchRecurrence(
@@ -633,31 +670,35 @@ export class KataWorkspaceStore {
     input: KataPatchRecurrenceInput,
     ifMatch: string,
   ): Promise<KataRecurrenceResponse["recurrence"]> {
-    const target = this.recurrenceTarget(id);
-    try {
-      const response = await this.api.patchRecurrence(target.projectID, target.uid, input, ifMatch);
-      await this.refreshSelectedRecurrences();
-      return response.recurrence;
-    } catch (error) {
-      if (error && typeof error === "object" && (error as { status?: number }).status === 412) {
-        const latest = await this.api.showRecurrence(target.projectID, target.uid);
-        throw Object.assign(error, { response: latest });
+    return this.withMutation(async () => {
+      const target = this.recurrenceTarget(id);
+      try {
+        const response = await this.api.patchRecurrence(target.projectID, target.uid, input, ifMatch);
+        await this.refreshSelectedRecurrences();
+        return response.recurrence;
+      } catch (error) {
+        if (error && typeof error === "object" && (error as { status?: number }).status === 412) {
+          const latest = await this.api.showRecurrence(target.projectID, target.uid);
+          throw Object.assign(error, { response: latest });
+        }
+        throw error;
       }
-      throw error;
-    }
+    });
   }
 
   async deleteRecurrence(id: number, actor: string): Promise<void> {
-    const target = this.recurrenceTarget(id);
-    try {
-      await this.api.deleteRecurrence(target.projectID, target.uid, actor, target.ifMatch);
-      await this.refreshSelectedRecurrences();
-    } catch (error) {
-      if (error && typeof error === "object" && (error as { status?: number }).status === 412) {
+    await this.withMutation(async () => {
+      const target = this.recurrenceTarget(id);
+      try {
+        await this.api.deleteRecurrence(target.projectID, target.uid, actor, target.ifMatch);
         await this.refreshSelectedRecurrences();
+      } catch (error) {
+        if (error && typeof error === "object" && (error as { status?: number }).status === 412) {
+          await this.refreshSelectedRecurrences();
+        }
+        throw error;
       }
-      throw error;
-    }
+    });
   }
 
   resetSearchFilters(): void {
@@ -670,6 +711,8 @@ export class KataWorkspaceStore {
   }
 
   invalidatePendingLoads(): void {
+    this.viewAbort?.abort();
+    this.viewAbort = null;
     this.viewRequestID++;
     this.detailRequestID++;
     this.abortPendingDetail();
@@ -781,17 +824,21 @@ export class KataWorkspaceStore {
     this.api.bindWorkflowDaemon?.(daemonId);
   }
 
-  private workflowRequestOptions(): { daemonId: string } | undefined {
-    return this.daemonId ? { daemonId: this.daemonId } : undefined;
+  private workflowRequestOptions(signal?: AbortSignal): { daemonId?: string; signal?: AbortSignal } | undefined {
+    if (!this.daemonId && !signal) return undefined;
+    return {
+      ...(this.daemonId ? { daemonId: this.daemonId } : {}),
+      ...(signal ? { signal } : {}),
+    };
   }
 
-  private loadIssues(query: KataTaskIssuesQuery): Promise<KataTaskViewResponse> {
-    const options = this.workflowRequestOptions();
+  private loadIssues(query: KataTaskIssuesQuery, signal?: AbortSignal): Promise<KataTaskViewResponse> {
+    const options = this.workflowRequestOptions(signal);
     return options ? this.api.issues(query, options) : this.api.issues(query);
   }
 
-  private searchIssues(filters: KataTaskSearchFilters): Promise<KataTaskSearchResponse> {
-    const options = this.workflowRequestOptions();
+  private searchIssues(filters: KataTaskSearchFilters, signal?: AbortSignal): Promise<KataTaskSearchResponse> {
+    const options = this.workflowRequestOptions(signal);
     return options ? this.api.search(filters, options) : this.api.search(filters);
   }
 
@@ -908,13 +955,21 @@ export class KataWorkspaceStore {
     await this.mutateIssue(uid, (target) => this.api.patchIssueMetadata(target, actor, patch, ifMatch));
   }
 
+  private async withMutation<T>(task: () => Promise<T>): Promise<T> {
+    this.pendingMutationCount += 1;
+    try {
+      return await task();
+    } finally {
+      this.pendingMutationCount -= 1;
+    }
+  }
+
   private async mutateIssue(
     uid: string,
     operation: (target: KataTaskMutationTarget) => Promise<KataTaskMutationResponse>,
     options: { preserveSelection?: boolean } = {},
   ): Promise<void> {
-    this.pendingMutationCount += 1;
-    try {
+    await this.withMutation(async () => {
       const preserveSelection = options.preserveSelection ?? true;
       const target = this.targetForIssue(uid);
       const selectionBeforeMutation = this.detailRequestID;
@@ -927,9 +982,7 @@ export class KataWorkspaceStore {
           : currentSelectedUID
         : undefined;
       await this.refreshCurrentView(preferredUID);
-    } finally {
-      this.pendingMutationCount -= 1;
-    }
+    });
   }
 
   private targetForIssue(uid: string): KataTaskMutationTarget {
@@ -960,7 +1013,7 @@ export class KataWorkspaceStore {
   }
 
   private async refreshCurrentView(preferredUID?: string | null): Promise<boolean> {
-    const requestID = ++this.viewRequestID;
+    const { requestID, signal } = this.beginViewRequest();
     // Selection epoch at refresh start: any selection or clear that lands
     // while the view fetch below is in flight bumps detailRequestID,
     // which makes the preferredUID captured by the caller stale.
@@ -970,7 +1023,7 @@ export class KataWorkspaceStore {
     if (shouldRefreshViaSearch(this.searchFilters, this.currentView.name)) {
       let results: KataTaskSearchResponse;
       try {
-        results = await this.searchIssues(this.searchFilters);
+        results = await this.searchIssues(this.searchFilters, signal);
       } catch (error) {
         if (requestID !== this.viewRequestID) return false;
         this.duplicateCandidates = duplicateCandidatesFromError(error);
@@ -991,7 +1044,7 @@ export class KataWorkspaceStore {
     } else {
       let view: KataTaskViewResponse;
       try {
-        view = await this.loadIssues({ view: this.currentView.name, ...scopedIssueQuery(this.searchFilters) });
+        view = await this.loadIssues({ view: this.currentView.name, ...scopedIssueQuery(this.searchFilters) }, signal);
       } catch (error) {
         if (requestID !== this.viewRequestID) return false;
         this.duplicateCandidates = duplicateCandidatesFromError(error);

--- a/frontend/src/lib/stores/kata-workspace.svelte.ts
+++ b/frontend/src/lib/stores/kata-workspace.svelte.ts
@@ -738,6 +738,7 @@ export class KataWorkspaceStore {
 
   async syncEventCursor(): Promise<void> {
     let afterID = this.eventCursor;
+    const pendingEvents: KataTaskEvent[] = [];
     for (;;) {
       const response = await this.api.events({ after_id: afterID, limit: 100 });
       const nextAfterID = Math.max(afterID, response.next_after_id, ...response.events.map((event) => event.event_id));
@@ -748,27 +749,26 @@ export class KataWorkspaceStore {
           reset_after_id: response.reset_after_id ?? nextAfterID,
           lastEventID: nextAfterID,
         });
-      } else {
-        for (const event of response.events) {
-          const refreshed = await this.applyRemoteEvent(event);
-          if (!refreshed) return;
-        }
-        this.eventCursor = Math.max(this.eventCursor, nextAfterID);
+        return;
       }
-      if (response.events.length === 0 || nextAfterID === afterID) return;
+      pendingEvents.push(...response.events.filter((event) => event.event_id > this.eventCursor));
+      const reachedEnd = response.events.length === 0 || nextAfterID === afterID;
       afterID = nextAfterID;
+      if (reachedEnd) break;
     }
+    if (pendingEvents.length === 0) {
+      this.eventCursor = Math.max(this.eventCursor, afterID);
+      return;
+    }
+    const refreshed = await this.refreshForRemoteEvents(pendingEvents);
+    if (!refreshed) return;
+    this.eventCursor = Math.max(this.eventCursor, afterID);
   }
 
   async applyRemoteEvent(event: KataTaskEvent): Promise<boolean> {
     if (event.event_id <= this.eventCursor) return true;
-    if (event.type.startsWith("project.")) {
-      await this.reloadProjects();
-    }
-    const preferredUID = this.pendingSelectionUID ?? this.selectedIssue?.issue.uid ?? null;
-    const refreshed = await this.refreshCurrentView(preferredUID);
+    const refreshed = await this.refreshForRemoteEvents([event]);
     if (!refreshed) return false;
-    this.applyTrivialMetadataEvent(event);
     this.eventCursor = event.event_id;
     return true;
   }
@@ -790,6 +790,26 @@ export class KataWorkspaceStore {
     const projects = await this.api.projects();
     this.projects = projects.projects;
     this.areas = deriveKataAreas(projects.projects);
+  }
+
+  private async refreshForRemoteEvents(events: readonly KataTaskEvent[]): Promise<boolean> {
+    if (events.some((event) => event.type.startsWith("project."))) {
+      await this.reloadProjects();
+    }
+    const preferredUID = this.pendingSelectionUID ?? this.selectedIssue?.issue.uid ?? null;
+    const selectedProjectID = this.selectedIssue?.issue.project_id;
+    const refreshSelectedDetail = events.some(
+      (event) =>
+        event.issue_uid === preferredUID ||
+        event.related_issue_uid === preferredUID ||
+        (event.type.startsWith("project.") && event.project_id === selectedProjectID),
+    );
+    const refreshed = await this.refreshCurrentView(preferredUID, { refreshSelectedDetail });
+    if (!refreshed) return false;
+    for (const event of events) {
+      this.applyTrivialMetadataEvent(event);
+    }
+    return true;
   }
 
   private clearTaskCache(): void {
@@ -1012,7 +1032,10 @@ export class KataWorkspaceStore {
     }
   }
 
-  private async refreshCurrentView(preferredUID?: string | null): Promise<boolean> {
+  private async refreshCurrentView(
+    preferredUID?: string | null,
+    options: { refreshSelectedDetail?: boolean } = {},
+  ): Promise<boolean> {
     const { requestID, signal } = this.beginViewRequest();
     // Selection epoch at refresh start: any selection or clear that lands
     // while the view fetch below is in flight bumps detailRequestID,
@@ -1063,6 +1086,7 @@ export class KataWorkspaceStore {
       issues = selectableViewIssues(view.groups);
     }
     this.currentView = nextView;
+    if (options.refreshSelectedDetail === false) return true;
     let resolvedUID = preferredUID;
     if (this.detailRequestID !== selectionEpoch) {
       // The selection changed while the view fetch was in flight, so the
@@ -1155,50 +1179,15 @@ export class KataWorkspaceStore {
       clearInteraction(KATA_SELECT_ISSUE_INTERACTION, timingToken);
       return false;
     }
-    // Direct selections render the pane and resolve as soon as the detail
-    // lands: callers sync the route from this promise, so it must not wait
-    // on (or fail with) the event-log walk, which finishes in a guarded
-    // background continuation. View loads keep the original atomic apply:
-    // their callers update route bookkeeping only after this promise
-    // settles, and an intermediate reactive flush would let the workspace
-    // route-sync effect stomp the fresh selection with the stale route
-    // issue.
-    if (viewRequestID === undefined) {
-      applyDetail();
-      void this.finishSelectedEvents(eventsPromise, abort, uid, detailRequestID, timingToken);
-      return true;
-    }
-
-    let events: KataTaskEventsResponse;
-    try {
-      events = await eventsPromise;
-    } catch (error) {
-      clearInteraction(KATA_SELECT_ISSUE_INTERACTION, timingToken);
-      if (abort.signal.aborted) return false;
-      throw error;
-    } finally {
-      if (this.detailAbort === abort) this.detailAbort = null;
-    }
-    if (viewRequestID !== this.viewRequestID) {
-      this.observeGraphStore("detail-load-stale", { uid, detailRequestID, viewRequestID });
-      clearInteraction(KATA_SELECT_ISSUE_INTERACTION, timingToken);
-      return false;
-    }
-    if (detailRequestID !== this.detailRequestID) {
-      clearInteraction(KATA_SELECT_ISSUE_INTERACTION, timingToken);
-      return false;
-    }
+    // Issue history may require a client-side walk of the daemon's whole
+    // event log. The selected detail is already usable, so history fills in
+    // as a guarded continuation instead of extending list/view loading.
     applyDetail();
-    this.selectedEvents = events.events;
-    measureInteraction(KATA_SELECT_ISSUE_INTERACTION, "events-loaded", timingToken, {
-      uid,
-      count: events.events.length,
-    });
-    clearInteraction(KATA_SELECT_ISSUE_INTERACTION, timingToken);
+    void this.finishSelectedEvents(eventsPromise, abort, uid, detailRequestID, timingToken);
     return true;
   }
 
-  // Completes a direct selection's best-effort event-log read after the
+  // Completes a selection's best-effort event-log read after the
   // detail has already been applied and the selection promise resolved. A
   // failed or superseded read leaves the rendered detail in place with an
   // empty event log instead of failing the selection.

--- a/frontend/tests/e2e-full/kata.spec.ts
+++ b/frontend/tests/e2e-full/kata.spec.ts
@@ -2049,7 +2049,7 @@ test("kata workspace reloads from reset frames on the configured daemon stream",
   }
 });
 
-test("kata daemon switch waits for an in-flight event stream refresh", async ({ page }) => {
+test("kata daemon switch supersedes an in-flight event stream refresh", async ({ page }) => {
   let releaseIssues!: () => void;
   const issuesBarrier = new Promise<void>((resolve) => {
     releaseIssues = resolve;
@@ -2080,25 +2080,15 @@ test("kata daemon switch waits for an in-flight event stream refresh", async ({ 
     const daemonChip = page.getByTestId("daemon-chip");
     await expect(daemonChip).toBeEnabled();
     await daemonChip.click();
-    await expect(page.getByTestId("daemon-row-work")).toBeDisabled();
-    await daemonChip.click();
-    await page.evaluate(() => {
-      window.history.pushState({}, "", "/kata?view=all&issue=issue-q3&daemon=work");
-      window.dispatchEvent(new PopStateEvent("popstate"));
-    });
-    await expect(page).toHaveURL(/daemon=work/);
-    await page.evaluate(
-      () => new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve()))),
-    );
-    expect(work.state.seenPaths).not.toContain("GET /api/v1/issues?status=open");
+    const workDaemonRow = page.getByTestId("daemon-row-work");
+    await expect(workDaemonRow).toBeEnabled();
+    await workDaemonRow.click();
+    await expect(page.getByTestId("daemon-chip")).toContainText("work");
+    await expect.poll(() => work.state.seenPaths).toContain("GET /api/v1/issues?status=open");
+    await expect(page.locator(".kata-list").getByRole("button", { name: /Email Susan re: Q3/ })).toBeVisible();
 
     releaseIssues();
 
-    await expect(page.getByTestId("daemon-chip")).toContainText("work");
-    await expect(page.locator(".kata-list").getByRole("button", { name: /Email Susan re: Q3/ })).toBeVisible();
-    await expect(page.getByRole("region", { name: "Task detail" })).toContainText(
-      "Confirm the Q3 project review agenda.",
-    );
     await expect(page.locator(".kata-list").getByRole("button", { name: /Pay rent/ })).toHaveCount(0);
   } finally {
     releaseIssues();
@@ -2109,7 +2099,7 @@ test("kata daemon switch waits for an in-flight event stream refresh", async ({ 
   }
 });
 
-test("kata stream refresh failure releases switching and reconnects", async ({ page }) => {
+test("kata stream refresh failure does not block switching and reconnects", async ({ page }) => {
   let releaseIssues!: () => void;
   const issuesBarrier = new Promise<void>((resolve) => {
     releaseIssues = resolve;
@@ -2136,7 +2126,7 @@ test("kata stream refresh failure releases switching and reconnects", async ({ p
     await expect(daemonChip).toBeEnabled();
     await daemonChip.click();
     const daemonRow = page.getByTestId("daemon-row-e2e");
-    await expect(daemonRow).toBeDisabled();
+    await expect(daemonRow).toBeEnabled();
 
     releaseIssues();
     await expect(daemonRow).toBeEnabled();


### PR DESCRIPTION
Background Kata reads were treated as exclusive switch transactions, and event catch-up amplified the delay by revalidating the same view once per event while waiting on selected-task history scans.

- Keeps daemon switching available during supersedable reads and aborts stale requests.
- Collapses cursor catch-up into one view revalidation.
- Reuses cached selected detail for unrelated events and hydrates task history in the background.
- Locks switching only for setup, an active switch, or non-supersedable writes.

<sup>generated by a clanker</sup>