### PR TITLE
Restore PR approval and gate browser E2E coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,6 +325,43 @@ jobs:
       - name: Build binary
         run: go build -o middleman ./cmd/middleman
 
+  e2e-mock:
+    runs-on: ubuntu-latest
+    needs: detect_changes
+    if: needs.detect_changes.outputs.frontend == 'true' || needs.detect_changes.outputs.e2e == 'true'
+    container: mcr.microsoft.com/playwright@sha256:5b8f294aff9041b7191c34a4bab3ac270157a28774d4b0660e9743297b697e48 # v1.61.1-noble
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chromium, firefox]
+    name: e2e mock (${{ matrix.browser }})
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup Vite+
+        uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
+        with:
+          node-version-file: package.json
+          cache: true
+          run-install: true
+
+      - name: Make $HOME owned by the current user for Firefox
+        if: matrix.browser == 'firefox'
+        run: chown "$(id -u):$(id -g)" "$HOME"
+
+      - name: Run mock E2E tests
+        run: cd frontend && vp exec -- playwright test --config=playwright.config.ts --project=${{ matrix.browser }}
+
+      - name: Upload mock Playwright report
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: e2e-mock-report-${{ matrix.browser }}
+          path: frontend/playwright-report/
+          retention-days: 7
+
   e2e:
     runs-on: ubuntu-latest
     needs: detect_changes

--- a/context/testing.md
+++ b/context/testing.md
@@ -134,6 +134,14 @@ Playwright waits must observe the rendered state consumed by the next assertion,
 not only the request completion or control value that triggered it; route refinement
 can leave new controls paired with old or loading content (`frontend/tests/e2e-full/kata.spec.ts:1625`, `frontend/tests/e2e-full/repo-browser.spec.ts:480`).
 
+CI executes `frontend/tests/e2e-full/`, not the local mock suite in
+`frontend/tests/e2e/`; Playwright regressions that must gate CI belong in the
+full-stack suite (`.github/workflows/ci.yml:395`, `frontend/playwright-e2e.config.ts:16`).
+
+A full-stack test claiming a user-triggered mutation works must drive the actual
+control and observe its request or visible result; `page.request` proves only the
+API contract (`frontend/tests/e2e-full/detail-action-buttons.spec.ts:925`).
+
 ## Huma API Contract
 
 Every public operation in `/api/v1/openapi.json` must have explicit OpenAPI

--- a/context/testing.md
+++ b/context/testing.md
@@ -134,9 +134,12 @@ Playwright waits must observe the rendered state consumed by the next assertion,
 not only the request completion or control value that triggered it; route refinement
 can leave new controls paired with old or loading content (`frontend/tests/e2e-full/kata.spec.ts:1625`, `frontend/tests/e2e-full/repo-browser.spec.ts:480`).
 
-CI executes `frontend/tests/e2e-full/`, not the local mock suite in
-`frontend/tests/e2e/`; Playwright regressions that must gate CI belong in the
-full-stack suite (`.github/workflows/ci.yml:395`, `frontend/playwright-e2e.config.ts:16`).
+CI executes both Playwright suites in Chromium and Firefox. Frontend-owned
+browser workflows using intercepted API responses belong in
+`frontend/tests/e2e/` (`frontend/playwright.config.ts`); workflows that must
+cross the built SPA, Go server, middleware, persistence, or provider fixture
+boundaries belong in `frontend/tests/e2e-full/`
+(`frontend/playwright-e2e.config.ts`).
 
 A full-stack test claiming a user-triggered mutation works must drive the actual
 control and observe its request or visible result; `page.request` proves only the

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -223,6 +223,9 @@ the same head pin, the same provider-side binding, the same post-success refresh
 handling. Do not give either action stronger client-side verification, staleness
 checks, or revocation behavior than the other
 (`internal/server/huma_routes.go::approvalReviewHeadSHA`).
+PR head mutations must not share an in-flight lock. Approve, request-changes,
+merge, and suggestion application keep local submission guards; only durable
+head-conflict state blocks the other actions (`packages/ui/src/components/detail/PullDetail.svelte::headActionsBlocked`).
 Once either provider mutation succeeds, close and clear its form before the
 follow-up refresh. A refresh failure may show a warning, but must not leave the
 successful mutation available for an accidental duplicate submission.

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { EmptyState, Spinner } from "@kenn-io/kit-ui";
-  import { tick } from "svelte";
+  import { onDestroy, tick } from "svelte";
   import { navigate } from "../../stores/router.svelte.ts";
   import { isNarrow } from "../../stores/container.svelte.js";
   import WorkspaceListSidebar from "./WorkspaceListSidebar.svelte";
@@ -207,6 +207,9 @@
   // remain blocked across A -> B -> A navigation, while a successful delete
   // still navigates away if the user returned to the destroyed workspace.
   let workspaceGen = 0;
+  onDestroy(() => {
+    workspaceGen += 1;
+  });
   let runtimeError = $state<string | null>(null);
   let pollTimer = $state<ReturnType<
     typeof setInterval
@@ -2232,11 +2235,14 @@
         : await client.DELETE("/workspaces/{id}", {
             params: { path: { id: targetId } },
           });
+      const responseFailed =
+        response.status === 409 ||
+        (!response.ok && response.status !== 204);
+      if (responseFailed && targetGen !== workspaceGen) return;
       // Different workspace now: the user has moved on and nothing
       // about this response applies.
       if (!isCurrentWorkspace(targetId, targetHostKey)) return;
       if (response.status === 409) {
-        if (targetGen !== workspaceGen) return;
         previouslyFocusedEl = triggerEl;
         forcePromptForId = targetId;
         forcePromptMessage = apiErrorMessage(
@@ -2246,7 +2252,6 @@
         return;
       }
       if (!response.ok && response.status !== 204) {
-        if (targetGen !== workspaceGen) return;
         showFlash(
           apiErrorMessage(error, `Delete failed (${response.status})`),
           { tone: "danger" },
@@ -2321,13 +2326,15 @@
               query: { force: true },
             },
           });
+      const responseFailed =
+        !response.ok && response.status !== 204;
+      if (responseFailed && targetGen !== workspaceGen) return;
       // The force-delete on the server is destructive and runs to
       // completion either way; once the user has moved to a
       // different workspace we just drop the response on the
       // floor so navigate() doesn't pull them away.
       if (!isCurrentWorkspace(targetId, targetHostKey)) return;
       if (!response.ok && response.status !== 204) {
-        if (targetGen !== workspaceGen) return;
         showFlash(
           apiErrorMessage(error, `Delete failed (${response.status})`),
           { tone: "danger" },

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -202,10 +202,10 @@
   let renameInputValue = $state("");
   let renameSaving = $state(false);
   let renameInputEl = $state<HTMLInputElement | null>(null);
-  // Bumps on every workspace route change so non-delete async
-  // callbacks can detect stale responses for the previous route.
-  // Delete requests track their own target separately because the
-  // same workspace must stay blocked across A -> B -> A navigation.
+  // Bumps on every workspace route change so async callbacks can detect
+  // stale, non-destructive responses from a previous visit. Delete targets
+  // remain blocked across A -> B -> A navigation, while a successful delete
+  // still navigates away if the user returned to the destroyed workspace.
   let workspaceGen = 0;
   let runtimeError = $state<string | null>(null);
   let pollTimer = $state<ReturnType<
@@ -2213,6 +2213,7 @@
     if (actionsBlocked) return;
     const targetId = workspaceId;
     const targetHostKey = workspaceHostKey;
+    const targetGen = workspaceGen;
     // Capture the trigger synchronously: the click handler runs
     // before `inert` is applied to .terminal-view, so this is the
     // last point we can read the originating focused element. By
@@ -2235,6 +2236,7 @@
       // about this response applies.
       if (!isCurrentWorkspace(targetId, targetHostKey)) return;
       if (response.status === 409) {
+        if (targetGen !== workspaceGen) return;
         previouslyFocusedEl = triggerEl;
         forcePromptForId = targetId;
         forcePromptMessage = apiErrorMessage(
@@ -2244,6 +2246,7 @@
         return;
       }
       if (!response.ok && response.status !== 204) {
+        if (targetGen !== workspaceGen) return;
         showFlash(
           apiErrorMessage(error, `Delete failed (${response.status})`),
           { tone: "danger" },

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   mockOpen: vi.fn(),
   mockTerminalInstances: [] as Array<{ options: Record<string, unknown> }>,
   renameWorkspaceSession: vi.fn(),
+  showFlash: vi.fn(),
   stopWorkspaceSession: vi.fn(),
   terminalWrite: vi.fn(),
 }));
@@ -147,6 +148,10 @@ vi.mock("../../api/workspace-runtime.js", () => ({
   workspaceSessionWebSocketPath: (workspaceId: string, sessionKey: string) =>
     `/ws/v1/workspaces/${workspaceId}/runtime/sessions/${sessionKey}/terminal`,
   workspaceTmuxWebSocketPath: (workspaceId: string) => `/ws/v1/workspaces/${workspaceId}/terminal`,
+}));
+
+vi.mock("@middleman/ui/stores/flash", () => ({
+  showFlash: mocks.showFlash,
 }));
 
 import WorkspaceTerminalView from "./WorkspaceTerminalView.svelte";
@@ -327,6 +332,7 @@ describe("WorkspaceTerminalView", () => {
     mocks.getWorkspaceRuntime.mockResolvedValue(runtimeWithStaleSession());
     mocks.launchWorkspaceSession.mockReset();
     mocks.renameWorkspaceSession.mockReset();
+    mocks.showFlash.mockReset();
     mocks.renameWorkspaceSession.mockImplementation(
       async (_workspaceId: string, sessionKey: string, label: string) => ({
         ...(sessionKey === duplicateAgentSession.key ? duplicateAgentSession : runningSession),
@@ -1580,6 +1586,53 @@ describe("WorkspaceTerminalView", () => {
     otherDeleteRequest.resolve(new Response(null, { status: 204 }));
     deleteRequest.resolve(new Response(null, { status: 204 }));
     await waitFor(() => expect(window.location.pathname).toBe("/workspaces"));
+  });
+
+  it("drops a failed delete response after unmounting and remounting the workspace", async () => {
+    localStorage.setItem("middleman-workspace-active-tab:ws-1", "home");
+    const deleteRequest = deferred<Response>();
+    const fetchMock = vi.fn().mockImplementation((input: Request | URL | string, init?: RequestInit) => {
+      const url = input instanceof Request ? input.url : String(input);
+      const method = init?.method ?? (input instanceof Request ? input.method : "GET");
+      const { pathname } = new URL(url, "http://localhost");
+      if (method === "DELETE" && pathname.endsWith("/workspaces/ws-1")) {
+        return deleteRequest.promise;
+      }
+      if (pathname.endsWith("/workspaces/ws-1")) {
+        return Promise.resolve(Response.json(workspaceResponse));
+      }
+      if (pathname.endsWith("/api/v1/workspaces")) {
+        return Promise.resolve(Response.json({ workspaces: [workspaceResponse] }));
+      }
+      return Promise.resolve(Response.json({}));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    window.history.pushState({}, "", "/terminal/ws-1");
+
+    const firstVisit = render(WorkspaceTerminalView, {
+      props: {
+        workspaceId: "ws-1",
+      },
+    });
+
+    await screen.findByRole("button", { name: "Delete" });
+    await fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.some(([input]) => input instanceof Request && input.method === "DELETE")).toBe(true);
+    });
+
+    firstVisit.unmount();
+    render(WorkspaceTerminalView, {
+      props: {
+        workspaceId: "ws-1",
+      },
+    });
+    await screen.findByRole("button", { name: "Delete" });
+
+    deleteRequest.resolve(Response.json({ detail: "Old workspace delete failed." }, { status: 500 }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mocks.showFlash).not.toHaveBeenCalled();
   });
 
   it("disables active workflow terminal input while the selected workspace is deleting", async () => {

--- a/frontend/tests/e2e-full/detail-action-buttons.spec.ts
+++ b/frontend/tests/e2e-full/detail-action-buttons.spec.ts
@@ -922,28 +922,34 @@ test.describe("detail action buttons", () => {
     await expect(menu.locator(".btn--close")).toBeVisible();
   });
 
-  test("GitHub approve action is available in UI and API", async ({ page }) => {
+  test("GitHub approve action submits from the review popover", async ({ page }) => {
     let isolatedServer: IsolatedE2EServer | null = null;
     try {
       isolatedServer = await startIsolatedE2EServer();
 
       const baseURL = isolatedServer.info.base_url;
-      const detailURL = `${baseURL}/api/v1/pulls/github/acme/widgets/1`;
-
       await page.goto(`${baseURL}/pulls/github/acme/widgets/1`);
       await expect(page.locator(".pull-detail")).toBeVisible();
-      await expect(page.locator(".btn--approve")).toBeVisible();
+      await page.locator(".btn--approve").click();
 
-      const response = await page.request.post(`${detailURL}/approve`, {
-        data: {
-          body: "LGTM from approve e2e",
-          expected_head_sha: "head-sha",
-        },
+      const popover = page.getByRole("dialog", { name: "Submit pull request review" });
+      await expect(popover).toBeVisible();
+      await popover.getByRole("textbox").fill("LGTM from approve e2e");
+
+      const approvalResponse = page.waitForResponse((response) => {
+        return (
+          response.request().method() === "POST" &&
+          response.url() === `${baseURL}/api/v1/pulls/github/acme/widgets/1/approve`
+        );
       });
+      await popover.getByRole("button", { name: "Approve", exact: true }).click();
+
+      const response = await approvalResponse;
       expect(response.status()).toBe(200);
       expect((await response.json()) as { status?: string }).toMatchObject({
         status: "approved",
       });
+      await expect(popover).toHaveCount(0);
     } finally {
       await isolatedServer?.stop();
     }

--- a/frontend/tests/e2e/app-shell.spec.ts
+++ b/frontend/tests/e2e/app-shell.spec.ts
@@ -24,7 +24,7 @@ test("renders mocked frontend data", async ({ page }) => {
   await expect(
     page
       .getByRole("region", { name: "Pull requests" })
-      .getByRole("button", { name: /^acme\/widgets \d+$/ })
+      .getByRole("button", { name: /^github\.com\/acme\/widgets \d+$/ })
       .first(),
   ).toBeVisible();
   await expect(page.getByRole("contentinfo").getByText("3 PRs")).toBeVisible();

--- a/frontend/tests/e2e/head-pinned-actions.spec.ts
+++ b/frontend/tests/e2e/head-pinned-actions.spec.ts
@@ -158,10 +158,14 @@ async function openMergeModalAndConfirm(page: Page): Promise<void> {
 }
 
 async function submitApproval(page: Page): Promise<void> {
+  const approvalResponse = page.waitForResponse((response) => {
+    return response.request().method() === "POST" && /\/approve$/.test(new URL(response.url()).pathname);
+  });
   await page.locator(".btn--approve").first().click();
   const popover = page.locator(".approve-popover");
   await expect(popover).toBeVisible();
   await popover.getByRole("button", { name: "Approve", exact: true }).click();
+  await approvalResponse;
 }
 
 test.describe("head-pinned merge and approve", () => {
@@ -276,9 +280,13 @@ test.describe("head-pinned merge and approve", () => {
     await expect(page.getByRole("dialog", { name: "Merge Pull Request" })).toHaveCount(0);
     await expect(page.getByText(STALE_PROMPT)).toBeVisible();
     await refresh;
-    // The prompt asks for a re-review; the actions themselves stay
-    // available once the refreshed head is rendered.
-    await expect(page.locator(".btn--merge").first()).toBeEnabled();
+    // The refreshed detail stays blocked until the user re-reviews the
+    // moved head; rendering fresh data alone must not clear the conflict.
+    await expect(page.locator(".btn--merge").first()).toBeDisabled();
+    await expect(page.locator(".btn--merge").first()).toHaveAttribute(
+      "title",
+      "Refresh and re-review the pull request before merging",
+    );
   });
 
   test("generic merge conflict keeps the modal open and shows the provider message", async ({ page }) => {

--- a/frontend/tests/e2e/inline-review.spec.ts
+++ b/frontend/tests/e2e/inline-review.spec.ts
@@ -845,35 +845,33 @@ test("keeps split-mode inline composers on trailing right-side hunk lines", asyn
 
     await button.click();
     await expect(page.getByPlaceholder("Leave a comment")).toBeVisible();
-    await expect(
-      page
-        .locator(".pierre-diff")
-        .first()
-        .evaluate((host, lineNumber) => {
-          const root = host.shadowRoot;
-          const slot = root?.querySelector(`slot[name="annotation-additions-${lineNumber}"]`);
-          return slot ? pierreCodeSide(root, slot) : null;
+    const diff = page.locator(".pierre-diff").first();
+    const composerSide = () =>
+      diff.evaluate((host, lineNumber) => {
+        const root = host.shadowRoot;
+        const slot = root?.querySelector(`slot[name="annotation-additions-${lineNumber}"]`);
+        return slot ? pierreCodeSide(root, slot) : null;
 
-          function pierreCodeSide(
-            root: ShadowRoot | null | undefined,
-            element: Element,
-          ): "deletions" | "additions" | null {
-            const code = Array.from(root?.querySelectorAll<HTMLElement>("code") ?? []).find((candidate) =>
-              candidate.contains(element),
-            );
-            const pre = code?.parentElement;
-            if (!code || !pre) return null;
-            if (code.hasAttribute("data-additions")) return "additions";
-            if (code.hasAttribute("data-deletions")) return "deletions";
-            const index = Array.from(pre.children)
-              .filter((child) => child.tagName.toLowerCase() === "code")
-              .indexOf(code);
-            if (index === 0) return "deletions";
-            if (index === 1) return "additions";
-            return null;
-          }
-        }, line),
-    ).resolves.toBe("additions");
+        function pierreCodeSide(
+          root: ShadowRoot | null | undefined,
+          element: Element,
+        ): "deletions" | "additions" | null {
+          const code = Array.from(root?.querySelectorAll<HTMLElement>("code") ?? []).find((candidate) =>
+            candidate.contains(element),
+          );
+          const pre = code?.parentElement;
+          if (!code || !pre) return null;
+          if (code.hasAttribute("data-additions")) return "additions";
+          if (code.hasAttribute("data-deletions")) return "deletions";
+          const index = Array.from(pre.children)
+            .filter((child) => child.tagName.toLowerCase() === "code")
+            .indexOf(code);
+          if (index === 0) return "deletions";
+          if (index === 1) return "additions";
+          return null;
+        }
+      }, line);
+    await expect.poll(composerSide).toBe("additions");
     await page.getByRole("button", { name: "Cancel" }).click();
     await expect(page.getByPlaceholder("Leave a comment")).toHaveCount(0);
   }
@@ -895,10 +893,9 @@ test("keeps final added-file line visible when opening an inline composer", asyn
     await expect(page.getByPlaceholder("Leave a comment")).toBeVisible();
     await expect(page.getByText(lineText)).toBeVisible();
 
-    const layout = await page
-      .locator(".pierre-diff")
-      .first()
-      .evaluate(
+    const diff = page.locator(".pierre-diff").first();
+    const readLayout = () =>
+      diff.evaluate(
         (host, { lineNumber, lineText, followingText }) => {
           const root = host.shadowRoot;
           const line = Array.from(
@@ -926,11 +923,23 @@ test("keeps final added-file line visible when opening an inline composer", asyn
         },
         { lineNumber, lineText, followingText },
       );
-    expect(layout).not.toBeNull();
-    expect(layout!.assignedCount).toBeGreaterThan(0);
-    expect(layout!.slotInsideLine).toBe(false);
-    expect(layout!.composerTop).toBeGreaterThanOrEqual(layout!.lineBottom);
-    expect(layout!.followingTop).toBeGreaterThanOrEqual(layout!.composerBottom);
+    await expect
+      .poll(async () => {
+        const layout = await readLayout();
+        if (layout === null) return null;
+        return {
+          assigned: layout.assignedCount > 0,
+          composerAfterLine: layout.composerTop >= layout.lineBottom,
+          followingAfterComposer: layout.followingTop >= layout.composerBottom,
+          slotInsideLine: layout.slotInsideLine,
+        };
+      })
+      .toEqual({
+        assigned: true,
+        composerAfterLine: true,
+        followingAfterComposer: true,
+        slotInsideLine: false,
+      });
     await page.getByRole("button", { name: "Cancel" }).click();
     await expect(page.getByPlaceholder("Leave a comment")).toHaveCount(0);
   }
@@ -1393,9 +1402,12 @@ test("enables inline review on public Forgejo and Gitea files routes", async ({ 
 });
 
 test("does not create multiline draft ranges across separate PR diff hunks", async ({ page }) => {
-  let createdRange: Record<string, unknown> | undefined;
+  let resolveCreatedRange!: (range: Record<string, unknown>) => void;
+  const createdRangePromise = new Promise<Record<string, unknown>>((resolve) => {
+    resolveCreatedRange = resolve;
+  });
   await mockInlineReviewAPI(page, baseCapabilities, "github", "github.com", multiHunkDiffResponse, (body) => {
-    createdRange = body.range;
+    resolveCreatedRange(body.range);
   });
 
   await page.goto("/pulls/github/acme/widgets/42/files");
@@ -1411,6 +1423,7 @@ test("does not create multiline draft ranges across separate PR diff hunks", asy
   await page.getByPlaceholder("Leave a comment").fill("Only the second hunk.");
   await page.getByRole("button", { name: "Add comment" }).click();
 
+  const createdRange = await createdRangePromise;
   expect(createdRange).toMatchObject({
     path: "src/main.ts",
     side: "right",

--- a/frontend/tests/e2e/viewport-fit.spec.ts
+++ b/frontend/tests/e2e/viewport-fit.spec.ts
@@ -92,26 +92,28 @@ test("settings sidebar lists every panel in declaration order under group headin
   await page.goto("/settings");
 
   await expect(page.locator(".settings-page")).toBeVisible();
-  await expect(
-    page.evaluate(() =>
-      Array.from(document.querySelectorAll<HTMLElement>(".kit-settings__nav-label, .kit-settings__group-title")).map(
-        (item) => item.textContent?.trim() ?? "",
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        Array.from(document.querySelectorAll<HTMLElement>(".kit-settings__nav-label, .kit-settings__group-title")).map(
+          (item) => item.textContent?.trim() ?? "",
+        ),
       ),
-    ),
-  ).resolves.toEqual([
-    "Providers",
-    "Repositories",
-    "Workflow",
-    "Pull requests",
-    "Activity",
-    "Workspace",
-    "Terminal",
-    "Kata mappings",
-    "Workspace agents",
-    "Fleet federation",
-    "Navigation",
-    "Visible modes",
-  ]);
+    )
+    .toEqual([
+      "Providers",
+      "Repositories",
+      "Workflow",
+      "Pull requests",
+      "Activity",
+      "Workspace",
+      "Terminal",
+      "Kata mappings",
+      "Workspace agents",
+      "Fleet federation",
+      "Navigation",
+      "Visible modes",
+    ]);
 });
 
 test("settings navigation stacks on phone-width viewports", async ({ page }) => {

--- a/frontend/tests/e2e/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar.spec.ts
@@ -1004,7 +1004,7 @@ test.describe("terminal state icons", () => {
 
     await stateMessage.getByRole("button", { name: "Retry" }).click();
 
-    expect(retryCalls).toBe(1);
+    await expect.poll(() => retryCalls).toBe(1);
     await expect(page.locator(".header-name")).toContainText("Add auth middleware");
   });
 
@@ -1408,9 +1408,7 @@ test.describe("terminal state icons", () => {
       window.dispatchEvent(new PopStateEvent("popstate"));
     });
 
-    await expect(page).toHaveURL(/\/workspaces$/, {
-      timeout: 2000,
-    });
+    await expect(page).toHaveURL(/\/workspaces$/);
   });
 });
 
@@ -4471,7 +4469,7 @@ test.describe("issue workspace sidebar", () => {
 
     await page.addInitScript(() => {
       localStorage.setItem("middleman-workspace-sidebar-open", "true");
-      localStorage.setItem("middleman-workspace-sidebar-tab", "pr");
+      localStorage.setItem("middleman-workspace-sidebar-tab", "issue");
 
       const instances: Array<{
         listeners: Map<string, Set<(event: MessageEvent) => void>>;
@@ -4553,6 +4551,7 @@ test.describe("issue workspace sidebar", () => {
     const prButton = page.locator(".panel-toggle-btn", { hasText: "PR" });
     await expect(prButton).toBeVisible();
     await expect(issueButton).toBeVisible();
+    await expect(issueButton).toHaveClass(/active/);
 
     await prButton.click();
     await expect(prButton).toHaveClass(/active/);

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -22518,6 +22518,8 @@ func setupWorkspaceServerFixtureWithMockHostAndOptions(
 	runGit(t, tmpWork, "add", ".")
 	runGit(t, tmpWork, "commit", "-m", "feature commit")
 	runGit(t, tmpWork, "push", "origin", "feature")
+	featureSHA := gitOutput(t, tmpWork, "rev-parse", "HEAD")
+	runGit(t, remote, "update-ref", "refs/pull/1/head", featureSHA)
 
 	bareDir := filepath.Join(dir, "clones")
 	require.NoError(t, os.MkdirAll(bareDir, 0o755))
@@ -25641,10 +25643,9 @@ func TestWorkspaceListRestoresAheadBehindAfterUpstreamHealE2E(t *testing.T) {
 	ctx := context.Background()
 	ws := createReadyWorkspace(t, ctx, client)
 
-	// The observer only rewires an upstream when the merge-request row
-	// positively places the head branch in the base repository.
+	// Keep the missing-upstream state stable until the explicit observer pass.
 	seedPR(t, database, "acme", "widget", 1,
-		withSeedPRHeadRepoCloneURL("https://github.com/acme/widget.git"))
+		withSeedPRHeadRepoCloneURL("https://github.com/contributor/widget.git"))
 
 	runGit(t, ws.WorktreePath, "config", "user.email", "test@test.com")
 	runGit(t, ws.WorktreePath, "config", "user.name", "Test")
@@ -25660,6 +25661,7 @@ func TestWorkspaceListRestoresAheadBehindAfterUpstreamHealE2E(t *testing.T) {
 	branch := ws.GitHeadRef
 	runGit(t, ws.WorktreePath, "config", "--unset", "branch."+branch+".remote")
 	runGit(t, ws.WorktreePath, "config", "--unset", "branch."+branch+".merge")
+	clockNow.Store(now.Add(workspaceEnrichmentTTL + time.Second).UnixNano())
 
 	findWorkspace := func() *generated.WorkspaceResponse {
 		listResp, err := client.HTTP.ListWorkspacesWithResponse(ctx)
@@ -25677,7 +25679,6 @@ func TestWorkspaceListRestoresAheadBehindAfterUpstreamHealE2E(t *testing.T) {
 		return nil
 	}
 
-	clockNow.Store(now.Add(workspaceEnrichmentTTL + time.Second).UnixNano())
 	var broken *generated.WorkspaceResponse
 	require.Eventually(func() bool {
 		broken = findWorkspace()
@@ -25687,8 +25688,11 @@ func TestWorkspaceListRestoresAheadBehindAfterUpstreamHealE2E(t *testing.T) {
 	}, 2*time.Second, 10*time.Millisecond,
 		"counts must be omitted while the branch has no upstream")
 
+	// The observer only rewires an upstream when the merge-request row
+	// positively places the head branch in the base repository.
+	seedPR(t, database, "acme", "widget", 1,
+		withSeedPRHeadRepoCloneURL("https://github.com/acme/widget.git"))
 	srv.runWorkspacePushedHeadObserverPass(ctx)
-
 	clockNow.Store(now.Add(2 * (workspaceEnrichmentTTL + time.Second)).UnixNano())
 	var healed *generated.WorkspaceResponse
 	require.Eventually(func() bool {
@@ -28504,6 +28508,8 @@ func TestWorkspaceCreateFetchesCloneThroughAPI(t *testing.T) {
 	runGit(t, remoteWork, "add", ".")
 	runGit(t, remoteWork, "commit", "-m", "feature after fixture clone")
 	runGit(t, remoteWork, "push", "origin", "feature")
+	featureSHA := gitOutput(t, remoteWork, "rev-parse", "HEAD")
+	runGit(t, fixture.remote, "update-ref", "refs/pull/1/head", featureSHA)
 
 	createResp, err := fixture.client.HTTP.CreateWorkspaceWithResponse(
 		ctx,

--- a/internal/server/workspacetest/fixtures_test.go
+++ b/internal/server/workspacetest/fixtures_test.go
@@ -90,8 +90,9 @@ func setupWorkspaceServerFixture(
 	}
 	seedPROnHost(t, database, "github.com", "acme", "widget", 1)
 	srv := server.New(database, syncer, nil, basePath, cfg, server.ServerOptions{
-		Clones:      clones,
-		WorktreeDir: worktreeDir,
+		Clones:                             clones,
+		WorktreeDir:                        worktreeDir,
+		DisableWorkspaceBackgroundMonitors: true,
 		HostCheck: server.HostCheckOptions{
 			Bind:    config.HostKey{Host: "127.0.0.1", Port: "8091"},
 			Allowed: []config.HostKey{{Host: "middleman.test", Port: ""}},

--- a/packages/ui/src/components/detail/ApproveButton.svelte
+++ b/packages/ui/src/components/detail/ApproveButton.svelte
@@ -36,7 +36,6 @@
       number: number,
       routeGeneration: number,
     ) => void) | undefined;
-    onmutationchange?: ((active: boolean) => void) | undefined;
     oncompleted?: (() => void) | undefined;
     /** Tooltip override; pass the unavailable_reason when disabling. */
     title?: string | undefined;
@@ -57,7 +56,6 @@
     supportedReviewActions = [],
     routeGeneration = 0,
     onheadconflict,
-    onmutationchange,
     oncompleted,
     title = undefined,
   }: Props = $props();
@@ -145,7 +143,6 @@
     if (disabled || submitting) return;
     submitting = true;
     submittingAction = "approve";
-    onmutationchange?.(true);
     let handledHeadConflict = false;
     try {
       const approved = await submitApprovePR(buildInput(() => {
@@ -168,7 +165,6 @@
     } finally {
       submitting = false;
       submittingAction = null;
-      onmutationchange?.(false);
     }
   }
 
@@ -180,7 +176,6 @@
     if (disabled || submitting || body.trim() === "") return;
     submitting = true;
     submittingAction = "request_changes";
-    onmutationchange?.(true);
     let handledHeadConflict = false;
     try {
       const { error: requestError } = await client.POST(providerItemPath("pulls", {
@@ -222,7 +217,6 @@
     } finally {
       submitting = false;
       submittingAction = null;
-      onmutationchange?.(false);
     }
   }
 </script>

--- a/packages/ui/src/components/detail/EventTimeline.svelte
+++ b/packages/ui/src/components/detail/EventTimeline.svelte
@@ -913,7 +913,11 @@
   let applyingSuggestionKey = $state<string | null>(null);
   let suggestionErrors = $state<Record<string, string>>({});
   let batchedSuggestions = $state<BatchedSuggestion[]>([]);
+  let savingSuggestionBatch = $state(false);
   const batchedSuggestionKeys = $derived(batchedSuggestions.map((item) => item.key));
+  const suggestionSubmissionBusy = $derived(
+    applyingSuggestionKey !== null || savingSuggestionBatch,
+  );
   // Suggestions batched before the PR head moved (or while it is unknown)
   // must not reach batch submit; the server would reject the whole batch.
   // A stale cached diff context also withholds the batch, matching the
@@ -925,8 +929,6 @@
           (item) => currentHeadSHA !== "" && item.reviewedHeadSHA === currentHeadSHA,
         ),
   );
-  let savingSuggestionBatch = $state(false);
-
   $effect(() => {
     if (deleteTarget === null) return;
     return untrack(() => pushModalFrame("delete-timeline-comment", []));
@@ -1176,7 +1178,7 @@
     block: Extract<MarkdownSuggestionBlock, { type: "suggestion" }>,
     thread: ReviewThread,
   ): Promise<void> {
-    if (onApplySuggestion === undefined) return;
+    if (onApplySuggestion === undefined || suggestionSubmissionBusy) return;
     const key = suggestionKey(event, block);
     const { [key]: _discardedError, ...remainingErrors } = suggestionErrors;
     suggestionErrors = remainingErrors;
@@ -1219,7 +1221,7 @@
 
   async function commitSuggestionBatch(): Promise<void> {
     const eligible = eligibleBatchedSuggestions;
-    if (onApplySuggestion === undefined || eligible.length === 0) return;
+    if (onApplySuggestion === undefined || eligible.length === 0 || suggestionSubmissionBusy) return;
     const submittedKeys = eligible.map((item) => item.key);
     suggestionErrors = Object.fromEntries(
       Object.entries(suggestionErrors).filter(([key]) => !submittedKeys.includes(key)),
@@ -1525,6 +1527,7 @@
                       replacement={block.replacement}
                       {currentHeadSHA}
                       applying={applyingSuggestionKey === blockKey}
+                      submissionBusy={suggestionSubmissionBusy}
                       batched={batchedSuggestionKeys.includes(blockKey)}
                       error={suggestionErrors[blockKey] ?? null}
                       onCommit={onApplySuggestion !== undefined
@@ -1696,7 +1699,7 @@
         class="thread-toggle thread-reply-action"
         type="button"
         onclick={() => void commitSuggestionBatch()}
-        disabled={savingSuggestionBatch}
+        disabled={suggestionSubmissionBusy}
       >
         <CheckIcon size={14} />
         {savingSuggestionBatch ? "Committing..." : "Commit batch"}

--- a/packages/ui/src/components/detail/EventTimeline.test.ts
+++ b/packages/ui/src/components/detail/EventTimeline.test.ts
@@ -653,6 +653,80 @@ describe("EventTimeline", () => {
     });
   });
 
+  it("blocks concurrent individual and batch suggestion submissions", async () => {
+    let resolveApplication: ((value: boolean) => void) | undefined;
+    const applySuggestion = vi.fn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveApplication = resolve;
+        }),
+    );
+    const baseThread = makeReviewThreadEvent().diff_thread!;
+    const first = makeReviewThreadEvent({
+      ID: 1,
+      CreatedAt: "2024-06-01T12:01:00Z",
+      Body: ["First suggestion.", "", "```suggestion", "return firstSuggestion();", "```"].join("\n"),
+      diff_thread: { ...baseThread, id: "thread-1", diff_head_sha: "abc123" },
+    });
+    const second = makeReviewThreadEvent({
+      ID: 2,
+      CreatedAt: "2024-06-01T12:02:00Z",
+      Body: ["Second suggestion.", "", "```suggestion", "return secondSuggestion();", "```"].join("\n"),
+      diff_thread: { ...baseThread, id: "thread-2", diff_head_sha: "abc123" },
+    });
+    const { container } = render(EventTimeline, {
+      props: {
+        events: [first, second],
+        provider: "github",
+        platformHost: "github.com",
+        repoOwner: "acme",
+        repoName: "widget",
+        repoPath: "acme/widget",
+        number: 7,
+        currentHeadSHA: "abc123",
+        onApplySuggestion: applySuggestion,
+      },
+      context: new Map([
+        [
+          STORES_KEY,
+          {
+            diff: makeDiffStore(),
+            diffReviewDraft: {
+              setRouteContext: vi.fn(),
+              isSubmitting: () => false,
+            },
+          },
+        ],
+      ]),
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByRole("button", { name: "Add suggestion to batch" })).toHaveLength(2);
+    });
+    await fireEvent.click(screen.getAllByRole("button", { name: "Add suggestion to batch" })[1]!);
+    await fireEvent.click(screen.getAllByRole("button", { name: "Commit suggestion" })[0]!);
+    await waitFor(() => expect(applySuggestion).toHaveBeenCalledTimes(1));
+
+    const suggestionActions = Array.from(
+      container.querySelectorAll<HTMLButtonElement>(".review-suggestion__actions button"),
+    );
+    expect(suggestionActions.every((button) => button.disabled)).toBe(true);
+    expect((screen.getByRole("button", { name: "Commit batch" }) as HTMLButtonElement).disabled).toBe(true);
+
+    await fireEvent.click(suggestionActions[2]!);
+    await fireEvent.click(screen.getByRole("button", { name: "Commit batch" }));
+    expect(applySuggestion).toHaveBeenCalledTimes(1);
+
+    resolveApplication?.(true);
+    await waitFor(() => {
+      expect(
+        Array.from(container.querySelectorAll<HTMLButtonElement>(".review-suggestion__actions button")).every(
+          (button) => !button.disabled,
+        ),
+      ).toBe(true);
+    });
+  });
+
   it("shows an inline error only when suggestion application reports a durable conflict", async () => {
     const applySuggestion = vi.fn(async () => ({
       ok: false,

--- a/packages/ui/src/components/detail/MergeModal.svelte
+++ b/packages/ui/src/components/detail/MergeModal.svelte
@@ -58,8 +58,6 @@
       number: number,
       routeGeneration: number,
     ) => void) | undefined;
-    onmutationchange?: ((active: boolean) => void) | undefined;
-    mutationUnavailable?: boolean;
   }
 
   const {
@@ -69,8 +67,7 @@
     expectedHeadSha, requireHeadPin = false, routeGeneration = 0,
     deferUntilChecksPass = false,
     alreadyQueued = false, midStackWarning,
-    onclose, onmerged, onqueued, onstateconflict, onmutationchange,
-    mutationUnavailable = false,
+    onclose, onmerged, onqueued, onstateconflict,
   }: Props = $props();
 
   // Offer to queue a deferred merge only when none is queued yet.
@@ -173,9 +170,8 @@
   }
 
   async function submitMerge(deferred: boolean): Promise<void> {
-    if (headPinMissing || mutationUnavailable) return;
+    if (headPinMissing) return;
     activeMergeSubmission = deferred ? "deferred" : "immediate";
-    onmutationchange?.(true);
     error = null;
     try {
       // Pin the merge to the head the user reviewed; the server rejects
@@ -201,7 +197,6 @@
       showFlash(err instanceof Error ? err.message : String(err), { tone: "danger" });
     } finally {
       activeMergeSubmission = null;
-      onmutationchange?.(false);
     }
   }
 
@@ -330,7 +325,7 @@
     <Button
       class="btn btn--primary btn--green"
       onclick={handleMerge}
-      disabled={merging || headPinMissing || mutationUnavailable}
+      disabled={merging || headPinMissing}
       tone="success"
       surface="solid"
     >
@@ -340,7 +335,7 @@
       <Button
         class="btn btn--merge-anyway"
         onclick={handleMergeAnyway}
-        disabled={merging || headPinMissing || mutationUnavailable}
+        disabled={merging || headPinMissing}
         tone="success"
         surface="soft"
       >

--- a/packages/ui/src/components/detail/MergeModal.svelte.test.ts
+++ b/packages/ui/src/components/detail/MergeModal.svelte.test.ts
@@ -122,18 +122,6 @@ describe("MergeModal head pinning", () => {
     expect(init.body).not.toHaveProperty("expected_head_sha");
   });
 
-  it("blocks an already-open modal while another head mutation is active", async () => {
-    const post = vi.fn().mockResolvedValue({ data: {}, error: undefined, response: new Response("{}") });
-    const { rerender } = renderModal(post, { expectedHeadSha: "abc123" });
-
-    await rerender({ ...baseProps, expectedHeadSha: "abc123", mutationUnavailable: true });
-    const merge = screen.getByText("Squash and merge", { selector: ".kit-modal-footer button" });
-    expect((merge as HTMLButtonElement).disabled).toBe(true);
-    await fireEvent.click(merge);
-
-    expect(post).not.toHaveBeenCalled();
-  });
-
   it.each(["stale_state", "head_unknown", "not_open", "head_repo_unknown"] as const)(
     "closes and reports the %s conflict instead of leaving a stale retry open",
     async (reason) => {

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -292,32 +292,27 @@
   async function applyTimelineSuggestion(
     input: ApplySuggestionRequest,
   ): Promise<boolean | { ok: false; error: string }> {
-    if (stalePR || headActionsUnavailable || applySuggestionGate.unavailable) return false;
+    if (stalePR || headActionsBlocked || applySuggestionGate.unavailable) return false;
     if (currentPR()?.State !== "open") return false;
-    headMutationCount += 1;
     const requestGeneration = mutationRouteGeneration;
     let durableConflict = false;
-    try {
-      const ok = await detailStore.applyReviewSuggestions(owner, name, number, input, (conflict) => {
-        durableConflict = handleStateConflict(
-          conflict.reason,
-          conflict.context,
-          conflict.expectedHeadSha,
-          conflict.ref,
-          conflict.number,
-          requestGeneration,
-        );
-      });
-      if (!ok && durableConflict) {
-        return {
-          ok: false,
-          error: detailStore.getDetailError() ?? "Pull request state changed.",
-        };
-      }
-      return ok;
-    } finally {
-      headMutationCount = Math.max(0, headMutationCount - 1);
+    const ok = await detailStore.applyReviewSuggestions(owner, name, number, input, (conflict) => {
+      durableConflict = handleStateConflict(
+        conflict.reason,
+        conflict.context,
+        conflict.expectedHeadSha,
+        conflict.ref,
+        conflict.number,
+        requestGeneration,
+      );
+    });
+    if (!ok && durableConflict) {
+      return {
+        ok: false,
+        error: detailStore.getDetailError() ?? "Pull request state changed.",
+      };
     }
+    return ok;
   }
 
   function updateTimelineFilter(next: PRTimelineFilterState): void {
@@ -705,7 +700,6 @@
   // approve sends the latest synced provider head when known. A 409
   // typed merge or head-binding conflicts land here and force a refresh.
   let stateConflict = $state<Exclude<ConflictReason, "conflict"> | null>(null);
-  let headMutationCount = $state(0);
   // Provider side-effect context from the conflict response (an
   // approval that could not be revoked, posted review text a retry
   // would repeat); rendered with the stale banner so the consequence
@@ -725,12 +719,6 @@
   // head-bound action closed until route navigation or a successful state
   // mutation establishes a fresh workflow context.
   const headActionsBlocked = $derived(stateConflict !== null);
-  const headMutationInFlight = $derived(headMutationCount > 0);
-  const headActionsUnavailable = $derived(headActionsBlocked || headMutationInFlight);
-
-  function handleHeadMutationChange(active: boolean): void {
-    headMutationCount = Math.max(0, headMutationCount + (active ? 1 : -1));
-  }
   // Preflight guard for merge: a head-binding provider must never merge
   // against an unbound reviewed diff, so merge stays disabled until diff
   // sync proves the rendered code matches the current head — no request,
@@ -971,7 +959,7 @@
       repoSettings,
       // Treat a blocked head as stale for gating: the merge modal must
       // not open while the reviewed head is unknown.
-      stale: stalePR || headActionsUnavailable || midStackMergeBlocked,
+      stale: stalePR || headActionsBlocked || midStackMergeBlocked,
       stores: { detail: detailStore, pulls },
       client,
       requireHeadPin: capabilities.mutation_head_binding,
@@ -2039,7 +2027,7 @@
               {platformHost}
               {repoPath}
               size="sm"
-              disabled={stalePR || headActionsUnavailable || approveGate.unavailable}
+              disabled={stalePR || headActionsBlocked || approveGate.unavailable}
               expectedHeadSha={detailHeadSha}
               platformHeadSha={latestPlatformHeadSha}
               requireHeadPin={capabilities.mutation_head_binding}
@@ -2047,7 +2035,6 @@
               routeGeneration={mutationRouteGeneration}
               title={approveGate.unavailable ? approveGate.reason : undefined}
               onheadconflict={handleHeadConflict}
-              onmutationchange={handleHeadMutationChange}
               oncompleted={() => { stateConflict = null; headConflictContext = null; }}
             />
           {/if}
@@ -2088,10 +2075,10 @@
                     : ""}
             <Button
               class={deferredMergePending ? "btn--merge btn--merge-queued" : "btn--merge"}
-              disabled={stalePR || midStackMergeBlocked || mergeDisabledByConflicts || mergeOpUnavailable || headActionsUnavailable || headPinMissing}
+              disabled={stalePR || midStackMergeBlocked || mergeDisabledByConflicts || mergeOpUnavailable || headActionsBlocked || headPinMissing}
               title={mergeTitle}
               onclick={() => {
-                if (stalePR || midStackMergeBlocked || mergeOpUnavailable || headActionsUnavailable || headPinMissing) return;
+                if (stalePR || midStackMergeBlocked || mergeOpUnavailable || headActionsBlocked || headPinMissing) return;
                 runOpenMerge(buildOpenMergeInput(pr, capabilities));
               }}
               tone="success"
@@ -2377,8 +2364,6 @@
             ? `This is stack position ${d.stack?.position ?? "?"} of ${d.stack?.size ?? "?"}. Branch #${midStackBlocker.number} below it has not been merged.`
             : undefined}
           onstateconflict={handleStateConflict}
-          onmutationchange={handleHeadMutationChange}
-          mutationUnavailable={headActionsUnavailable}
           onclose={() => { showMergeModal = false; }}
           onqueued={() => {
             showMergeModal = false;
@@ -2541,7 +2526,7 @@
             onApplySuggestion={capabilities.review_suggestion_application
               && !stalePR
               && pr.State === "open"
-              && !headActionsUnavailable
+              && !headActionsBlocked
               && !applySuggestionGate.unavailable
                 ? applyTimelineSuggestion
                 : undefined}

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -672,8 +672,6 @@
         platformHost,
         repoPath,
       });
-      stateConflict = null;
-      headConflictContext = null;
       await refreshPulls();
       await activity.loadActivity();
     } catch (err) {
@@ -716,8 +714,8 @@
     detailStore.getDetail()?.platform_head_sha ?? "",
   );
   // A typed conflict invalidates the state the user reviewed. Keep every
-  // head-bound action closed until route navigation or a successful state
-  // mutation establishes a fresh workflow context.
+  // head-bound action closed until route navigation or explicit conflict
+  // recovery verifies a fresh workflow context.
   const headActionsBlocked = $derived(stateConflict !== null);
   // Preflight guard for merge: a head-binding provider must never merge
   // against an unbound reviewed diff, so merge stays disabled until diff
@@ -2035,7 +2033,6 @@
               routeGeneration={mutationRouteGeneration}
               title={approveGate.unavailable ? approveGate.reason : undefined}
               onheadconflict={handleHeadConflict}
-              oncompleted={() => { stateConflict = null; headConflictContext = null; }}
             />
           {/if}
           {#if capabilities.workflow_approval && workflowApproval?.checked && workflowApproval.required}
@@ -2377,8 +2374,6 @@
           }}
           onmerged={() => {
             showMergeModal = false;
-            stateConflict = null;
-            headConflictContext = null;
             void detailStore.loadDetail(owner, name, number, {
               provider,
               platformHost,

--- a/packages/ui/src/components/detail/PullDetail.test.ts
+++ b/packages/ui/src/components/detail/PullDetail.test.ts
@@ -1181,6 +1181,7 @@ describe("PullDetail approvals", () => {
   it("ignores a delayed merge conflict after an A-to-B-to-A route cycle", async () => {
     const detail = pullDetail();
     detail.repo.capabilities.merge_mutation = true;
+    detail.repo.capabilities.review_mutation = true;
     let resolveMerge: ((value: unknown) => void) | undefined;
     const apiClient = {
       GET: vi.fn(async () => ({
@@ -1215,7 +1216,7 @@ describe("PullDetail approvals", () => {
         name: "Squash and merge",
       }),
     );
-    expect((screen.getByRole("button", { name: "Approve" }) as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByRole("button", { name: "Approve" }) as HTMLButtonElement).disabled).toBe(false);
     await rerender({
       owner: "acme",
       name: "other-widget",

--- a/packages/ui/src/components/detail/PullDetail.test.ts
+++ b/packages/ui/src/components/detail/PullDetail.test.ts
@@ -1178,6 +1178,87 @@ describe("PullDetail approvals", () => {
     expect(screen.queryByRole("button", { name: "Merge after CI is complete" })).toBeNull();
   });
 
+  it("keeps a newer head conflict after an overlapping approval succeeds", async () => {
+    const detail = pullDetail();
+    detail.repo.capabilities.merge_mutation = true;
+    detail.repo.capabilities.review_mutation = true;
+    let resolveApprove!: (value: unknown) => void;
+    const approveRequest = new Promise((resolve) => {
+      resolveApprove = resolve;
+    });
+    let resolveMerge!: (value: unknown) => void;
+    const mergeRequest = new Promise((resolve) => {
+      resolveMerge = resolve;
+    });
+    const apiClient = {
+      GET: vi.fn(async () => ({
+        data: {
+          AllowSquashMerge: true,
+          AllowMergeCommit: false,
+          AllowRebaseMerge: false,
+          ViewerCanMerge: true,
+        },
+      })),
+      POST: vi.fn((path: string) => {
+        if (path.endsWith("/approve")) return approveRequest;
+        if (path.endsWith("/merge")) return mergeRequest;
+        return Promise.resolve({ data: {} });
+      }),
+    };
+    const { detailStore } = renderPullDetail(
+      detail,
+      {
+        AllowSquashMerge: true,
+        AllowMergeCommit: false,
+        AllowRebaseMerge: false,
+        ViewerCanMerge: true,
+      },
+      apiClient,
+    );
+
+    await fireEvent.click(await screen.findByRole("button", { name: "Approve" }));
+    await fireEvent.click(
+      within(screen.getByRole("dialog", { name: "Submit pull request review" })).getByRole("button", {
+        name: "Approve",
+      }),
+    );
+    await vi.waitFor(() => {
+      expect(apiClient.POST.mock.calls.some(([path]) => String(path).endsWith("/approve"))).toBe(true);
+    });
+    await fireEvent.click(await screen.findByRole("button", { name: "Squash and merge" }));
+    await fireEvent.click(
+      within(screen.getByRole("dialog", { name: "Merge Pull Request" })).getByRole("button", {
+        name: "Squash and merge",
+      }),
+    );
+
+    resolveMerge({
+      error: {
+        code: "conflict",
+        type: "about:blank",
+        status: 409,
+        detail: "head changed",
+        details: { reason: "stale_state" },
+      },
+    });
+    await vi.waitFor(() => {
+      expect(screen.getByText(/head commit changed since this pull request was reviewed/i)).toBeTruthy();
+    });
+
+    const detailLoadsBeforeApproval = detailStore.loadDetail.mock.calls.length;
+    resolveApprove({
+      data: { status: "approved" },
+      error: undefined,
+      response: new Response("{}"),
+    });
+    await vi.waitFor(() => {
+      expect(detailStore.loadDetail.mock.calls.length).toBeGreaterThan(detailLoadsBeforeApproval);
+    });
+
+    expect(screen.getByText(/head commit changed since this pull request was reviewed/i)).toBeTruthy();
+    expect((screen.getByRole("button", { name: "Approve" }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
   it("ignores a delayed merge conflict after an A-to-B-to-A route cycle", async () => {
     const detail = pullDetail();
     detail.repo.capabilities.merge_mutation = true;

--- a/packages/ui/src/components/detail/ReviewSuggestionBlock.svelte
+++ b/packages/ui/src/components/detail/ReviewSuggestionBlock.svelte
@@ -11,6 +11,7 @@
     replacement: string;
     currentHeadSHA?: string | undefined;
     applying?: boolean;
+    submissionBusy?: boolean;
     batched?: boolean;
     error?: string | null;
     onCommit?: (() => void) | undefined;
@@ -23,6 +24,7 @@
     replacement,
     currentHeadSHA = "",
     applying = false,
+    submissionBusy = false,
     batched = false,
     error = null,
     onCommit,
@@ -70,7 +72,7 @@
         class="review-suggestion__action review-suggestion__action--primary"
         type="button"
         onclick={onCommit}
-        disabled={!canApply || applying}
+        disabled={!canApply || submissionBusy}
         title={!canApply ? disabledReason : undefined}
       >
         <CheckIcon size={14} />
@@ -81,7 +83,7 @@
         class:review-suggestion__action--selected={batched}
         type="button"
         onclick={onToggleBatch}
-        disabled={(!canApply && !batched) || applying || onToggleBatch === undefined}
+        disabled={(!canApply && !batched) || submissionBusy || onToggleBatch === undefined}
         title={!canApply && !batched ? disabledReason : undefined}
       >
         <PlusIcon size={14} />


### PR DESCRIPTION
- Restores approval and request-changes submissions without a shared PR-wide mutation lock.
- Keeps suggestion applications serialized within their own review surface.
- Runs the mock Playwright suite in Chromium and Firefox CI and stabilizes its browser-visible waits.
- Prevents stale workspace-delete errors from affecting a later visit to the same workspace.