### PR TITLE
test: give PR fixtures head-repo identity so setup takes the branch path

### DIFF
--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -195,6 +195,11 @@ pushed-head observer may repair a missing upstream only when the current MR row
 proves the head is in the base repository, the checked-out branch is the PR
 head or synthetic branch, and the remote-tracking ref exists.
 
+Test fixtures that seed PR rows must either carry a same-repo
+`HeadRepoCloneURL` or publish `refs/pull/<n>/head` on the fixture remote:
+unknown-provenance setup resolves heads exclusively through the fork-safe ref
+and fails outright when the remote does not serve it.
+
 ## Sidebar Ordering
 
 The workspace sidebar has two separate activity concepts:

--- a/internal/server/workspace_concurrent_e2e_test.go
+++ b/internal/server/workspace_concurrent_e2e_test.go
@@ -33,7 +33,8 @@ func TestWorkspaceConcurrentSameRepoOperationsE2E(t *testing.T) {
 
 	// Fixture already seeded PR #1; add PR #2 in the same repo so both
 	// concurrent creates target the same bare clone but different
-	// worktree paths.
+	// worktree paths. Same-repo head evidence keeps setup on the branch
+	// path; without it the fixture remote would need refs/pull/2/head.
 	seedPROnHost(
 		t, fixture.database, "github.com", "acme", "widget", 2,
 		withSeedPRHeadRepoCloneURL("https://github.com/acme/widget.git"),

--- a/internal/server/workspacetest/fixtures_test.go
+++ b/internal/server/workspacetest/fixtures_test.go
@@ -179,6 +179,33 @@ func seedPROnHost(
 	host, owner, name string, number int,
 ) int64 {
 	t.Helper()
+	// Same-repo head evidence: without it the workspace classifies as
+	// unknown provenance and setup requires refs/pull/<n>/head from the
+	// fixture remote.
+	return seedPRWithHeadRepo(
+		t, database, host, owner, name, number,
+		fmt.Sprintf("https://%s/%s/%s.git", host, owner, name),
+	)
+}
+
+// seedPRWithoutHeadRepo seeds a merge request whose head-repo identity is
+// unknown (legacy rows synced before HeadRepoCloneURL existed, or providers
+// that omit it). Workspaces for it take the fork-safe ref path and stay
+// untracked.
+func seedPRWithoutHeadRepo(
+	t *testing.T, database *db.DB,
+	host, owner, name string, number int,
+) int64 {
+	t.Helper()
+	return seedPRWithHeadRepo(t, database, host, owner, name, number, "")
+}
+
+func seedPRWithHeadRepo(
+	t *testing.T, database *db.DB,
+	host, owner, name string, number int,
+	headRepoCloneURL string,
+) int64 {
+	t.Helper()
 	ctx := t.Context()
 
 	repoID, err := database.UpsertRepo(ctx, db.GitHubRepoIdentity(host, owner, name))
@@ -196,7 +223,7 @@ func seedPROnHost(
 		IsDraft:          false,
 		Body:             "test body",
 		HeadBranch:       "feature",
-		HeadRepoCloneURL: fmt.Sprintf("https://%s/%s/%s.git", host, owner, name),
+		HeadRepoCloneURL: headRepoCloneURL,
 		BaseBranch:       "main",
 		Additions:        5,
 		Deletions:        2,

--- a/internal/server/workspacetest/workspace_test.go
+++ b/internal/server/workspacetest/workspace_test.go
@@ -232,26 +232,32 @@ func TestWorkspaceCommitsOmitsPushStatusWithoutUpstreamE2E(t *testing.T) {
 
 	fixture := setupWorkspaceServerFixture(t, nil)
 	ctx := t.Context()
-	runGit(t, fixture.remote,
-		"update-ref", "refs/pull/1/head", "refs/heads/feature")
-	repo, err := fixture.database.GetRepoByIdentity(
-		ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"),
+
+	// A PR whose merge-request row carries no head-repo identity classifies
+	// as unknown provenance: setup resolves it through the fork-safe
+	// refs/pull/<n>/head path and leaves the branch untracked. @{upstream}
+	// never resolves, so push status is unknowable and the endpoint must omit
+	// it rather than report every commit as unpushed (the false "Not pushed
+	// to remote" regression roborev flagged).
+	headSHA := testGitSHA(t, fixture.remote, "refs/heads/feature")
+	runGit(t, fixture.remote, "update-ref", "refs/pull/2/head", headSHA)
+	seedPRWithoutHeadRepo(t, fixture.database, "github.com", "acme", "widget", 2)
+
+	createResp, err := fixture.client.HTTP.CreateWorkspaceWithResponse(
+		ctx,
+		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
+			PlatformHost: "github.com",
+			Owner:        "acme",
+			Name:         "widget",
+			MrNumber:     2,
+		},
 	)
 	require.NoError(err)
-	require.NotNil(repo)
-	mr, err := fixture.database.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, 1)
-	require.NoError(err)
-	require.NotNil(mr)
-	mr.HeadRepoCloneURL = "https://github.com/contributor/widget.git"
-	_, err = fixture.database.UpsertMergeRequest(ctx, mr)
-	require.NoError(err)
-	ws := createReadyWorkspace(t, ctx, fixture.client)
+	require.Equal(http.StatusAccepted, createResp.StatusCode())
+	require.NotNil(createResp.JSON202)
+	ws := waitForWorkspaceReady(t, ctx, fixture.client, createResp.JSON202.Id)
 	require.NotEmpty(ws.WorktreePath)
-	require.NotEmpty(ws.GitHeadRef)
-
-	// Fork PR heads have no origin upstream. Push status is therefore
-	// unknowable, so the endpoint must omit it rather than report every commit
-	// as unpushed (the false "Not pushed to remote" regression roborev flagged).
 
 	resp, err := fixture.client.HTTP.GetWorkspaceCommitsWithResponse(ctx, ws.Id)
 	require.NoError(err)


### PR DESCRIPTION
#678 made workspace setup classify a merge request with no `HeadRepoCloneURL` as unknown provenance, which resolves the head exclusively through `refs/pull/<n>/head` and fails outright when the remote does not serve that ref. The `workspacetest` fixture and the concurrent same-repo test seed exactly such rows against plain local remotes, so every workspace they create dies at the fetch — these are the Go test failures on #678's final CI run, which merged red. `api_test`'s own fixtures were already migrated; these two were missed.

- `workspacetest` fixture PRs now carry same-repo head evidence by default, matching the `api_test` seeding
- The commits push-status test wanted the opposite state, so instead of unsetting the upstream by hand (which the observer heal races) it seeds a PR without head-repo identity and publishes the fork-safe ref — the untracked branch now comes from the real unknown-provenance setup path
- The fixture requirement is recorded in `context/workspace-apis.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sup>generated by a clanker</sup>