### PR TITLE
fix: stop endlessly re-syncing workspace PRs whose local tracking ref is stale

### DIFF
--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -200,6 +200,17 @@ Test fixtures that seed PR rows must either carry a same-repo
 unknown-provenance setup resolves heads exclusively through the fork-safe ref
 and fails outright when the remote does not serve it.
 
+## Pushed-Head Refresh Convergence
+
+A tracking-ref/provider-head mismatch is not proof of a local push: when the
+PR advanced from another checkout, the local tracking ref is the stale side
+and a provider sync can never converge. The observer therefore enqueues a PR
+sync on mismatch, retries on failure after `pushedHeadRefreshRetryInterval`,
+but must stop once a refresh for the same observed SHA succeeded and the
+provider head still differs (`LastRefreshSucceededAt >= LastRefreshEnqueuedAt`)
+— otherwise the visible PR is re-synced and re-rendered forever. A tracking-ref
+move restarts the cycle.
+
 ## Sidebar Ordering
 
 The workspace sidebar has two separate activity concepts:

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -60,8 +60,12 @@ state.
 - Overlapping tmux probes wait for the active sample within the caller budget;
   fallback carries an error only when waiting or sample production fails
   (`internal/server/huma_routes.go::probeOneTmuxSession`).
-- Background completion emits `workspace_status` so clients refetch promptly
-  (`internal/server/workspace_enrichment.go::runWorkspaceEnrichmentJob`).
+- Background completion emits `workspace_status` only for durable changes:
+  first completion, divergence movement, or error-state change — never for
+  tmux-activity-only movement, and tmux prune broadcasts only when it pruned.
+  Unconditional broadcasts made every client refetch schedule the next
+  enrichment, a permanent refresh loop
+  (`internal/server/workspace_enrichment.go::workspaceEnrichmentBroadcastWorthy`).
 - `DELETE /workspaces/{id}`: tear down a middleman-managed workspace and its
   local resources.
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -809,7 +809,7 @@ func newServer(
 			if err := s.workspaces.ReapOrphanTmuxSessions(cleanupCtx); err != nil {
 				slog.Warn("reap orphan tmux sessions", "err", err)
 			}
-			if err := s.workspaces.PruneMissingTmuxSessions(cleanupCtx); err != nil {
+			if _, err := s.workspaces.PruneMissingTmuxSessions(cleanupCtx); err != nil {
 				slog.Warn("prune missing tmux sessions", "err", err)
 			}
 			cleanupCancel()

--- a/internal/server/workspace_enrichment.go
+++ b/internal/server/workspace_enrichment.go
@@ -161,7 +161,7 @@ func (s *Server) refreshWorkspaceResponse(
 	generation := s.supersedeWorkspaceEnrichment(summary.ID)
 	result := s.workspaceResponseWithEnrichment(ctx, summary)
 	if summary.Status == "ready" {
-		entry, recorded := s.recordWorkspaceEnrichmentResult(
+		entry, recorded, _ := s.recordWorkspaceEnrichmentResult(
 			summary.ID, generation, result,
 		)
 		return s.workspaceResponseAfterEnrichmentAttempt(
@@ -286,9 +286,9 @@ func (s *Server) runWorkspaceEnrichmentJob(
 	)
 	defer cancel()
 	result := s.workspaceResponseWithEnrichment(probeCtx, &job.summary)
-	if _, recorded := s.recordWorkspaceEnrichmentResult(
+	if _, recorded, changed := s.recordWorkspaceEnrichmentResult(
 		job.summary.ID, job.generation, result,
-	); recorded {
+	); recorded && changed {
 		s.broadcastWorkspaceStatus(job.summary.ID)
 	}
 }
@@ -328,15 +328,16 @@ func (s *Server) recordWorkspaceEnrichmentResult(
 	workspaceID string,
 	generation uint64,
 	result workspaceEnrichmentProbeResult,
-) (workspaceEnrichmentCacheEntry, bool) {
+) (workspaceEnrichmentCacheEntry, bool, bool) {
 	s.workspaceEnrichmentMu.Lock()
 	defer s.workspaceEnrichmentMu.Unlock()
 	currentGeneration, ok := s.workspaceEnrichmentGenerations[workspaceID]
 	if !ok || currentGeneration != generation {
-		return s.workspaceEnrichmentCache[workspaceID], false
+		return s.workspaceEnrichmentCache[workspaceID], false, false
 	}
 	now := s.now()
-	entry := s.workspaceEnrichmentCache[workspaceID]
+	prior := s.workspaceEnrichmentCache[workspaceID]
+	entry := prior
 	if result.divergenceComplete {
 		entry.response.CommitsAhead = result.response.CommitsAhead
 		entry.response.CommitsBehind = result.response.CommitsBehind
@@ -354,7 +355,34 @@ func (s *Server) recordWorkspaceEnrichmentResult(
 		entry.lastError = result.err.Error()
 	}
 	s.workspaceEnrichmentCache[workspaceID] = entry
-	return entry, true
+	return entry, true, workspaceEnrichmentBroadcastWorthy(prior, entry)
+}
+
+// workspaceEnrichmentBroadcastWorthy reports whether a recorded enrichment
+// result should notify SSE clients. Completion of the first probe (the
+// pending → fresh transition clients wait on), a divergence change, and an
+// error-state change are notification-worthy. Tmux-activity-only changes are
+// not: an active agent moves the activity timestamp on every probe, and
+// broadcasting those turned each completion into a client refetch that
+// scheduled the next enrichment — a permanent refresh loop. The workspace
+// list's own polling still picks activity changes up.
+func workspaceEnrichmentBroadcastWorthy(prior, next workspaceEnrichmentCacheEntry) bool {
+	if prior.hasDivergence != next.hasDivergence || prior.hasTmux != next.hasTmux {
+		return true
+	}
+	if prior.lastError != next.lastError {
+		return true
+	}
+	return next.hasDivergence &&
+		(!intPointerEqual(prior.response.CommitsAhead, next.response.CommitsAhead) ||
+			!intPointerEqual(prior.response.CommitsBehind, next.response.CommitsBehind))
+}
+
+func intPointerEqual(a, b *int) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
 }
 
 func (s *Server) finishWorkspaceEnrichment(
@@ -426,9 +454,15 @@ func (s *Server) runWorkspaceTmuxPrune(ctx context.Context) {
 		ctx, workspaceEnrichmentRefreshTimeout,
 	)
 	defer cancel()
-	if err := s.workspaces.PruneMissingTmuxSessions(pruneCtx); err != nil {
+	pruned, err := s.workspaces.PruneMissingTmuxSessions(pruneCtx)
+	if err != nil {
 		slog.Debug("prune missing tmux sessions", "err", err)
 		return
 	}
-	s.hub.Broadcast(Event{Type: "workspace_status", Data: map[string]string{}})
+	// Broadcast only when the pass changed state. The unconditional
+	// broadcast made every open view refetch its workspace every prune
+	// interval even though nothing happened.
+	if pruned {
+		s.hub.Broadcast(Event{Type: "workspace_status", Data: map[string]string{}})
+	}
 }

--- a/internal/server/workspace_enrichment_test.go
+++ b/internal/server/workspace_enrichment_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -34,7 +35,7 @@ func TestWorkspaceEnrichmentSupersedeRejectsOlderRefreshAndPreservesCache(t *tes
 		divergenceRefreshedAt: now,
 	}
 	srv.supersedeWorkspaceEnrichment("ws-1")
-	entry, recorded := srv.recordWorkspaceEnrichmentResult(
+	entry, recorded, _ := srv.recordWorkspaceEnrichmentResult(
 		"ws-1",
 		oldGeneration,
 		workspaceEnrichmentProbeResult{
@@ -58,7 +59,7 @@ func TestWorkspaceEnrichmentRejectsResultAfterGenerationIsTrimmed(t *testing.T) 
 	}
 	ahead := 1
 
-	_, recorded := srv.recordWorkspaceEnrichmentResult(
+	_, recorded, _ := srv.recordWorkspaceEnrichmentResult(
 		"deleted-workspace",
 		0,
 		workspaceEnrichmentProbeResult{
@@ -372,6 +373,65 @@ func TestWorkspaceEnrichmentCompletionBroadcastsWorkspaceStatusE2E(t *testing.T)
 			got.JSON200 != nil &&
 			string(got.JSON200.EnrichmentStatus) == workspaceEnrichmentFresh
 	}, 2*time.Second, 10*time.Millisecond)
+}
+
+func TestWorkspaceEnrichmentBroadcastsOnlyDurableChanges(t *testing.T) {
+	assert := assert.New(t)
+	srv := &Server{
+		workspaceEnrichmentCache:       make(map[string]workspaceEnrichmentCacheEntry),
+		workspaceEnrichmentGenerations: map[string]uint64{"ws-1": 1},
+		now: func() time.Time {
+			return time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+		},
+	}
+	ahead := 1
+	behind := 0
+	title := "pane"
+	record := func(result workspaceEnrichmentProbeResult) bool {
+		_, recorded, changed := srv.recordWorkspaceEnrichmentResult("ws-1", 1, result)
+		assert.True(recorded)
+		return changed
+	}
+
+	// First completion is the pending -> fresh transition clients wait on.
+	assert.True(record(workspaceEnrichmentProbeResult{
+		response:           workspaceResponse{CommitsAhead: &ahead, CommitsBehind: &behind, TmuxPaneTitle: &title},
+		divergenceComplete: true,
+		tmuxComplete:       true,
+	}))
+
+	// Tmux-activity-only movement (a busy agent changes it every probe)
+	// must not notify: broadcasting it re-poked every open view forever.
+	spinnerTitle := "pane *"
+	assert.False(record(workspaceEnrichmentProbeResult{
+		response: workspaceResponse{
+			CommitsAhead:  &ahead,
+			CommitsBehind: &behind,
+			TmuxPaneTitle: &spinnerTitle,
+			TmuxWorking:   true,
+		},
+		divergenceComplete: true,
+		tmuxComplete:       true,
+	}))
+
+	// Divergence movement notifies.
+	newBehind := 3
+	assert.True(record(workspaceEnrichmentProbeResult{
+		response:           workspaceResponse{CommitsAhead: &ahead, CommitsBehind: &newBehind, TmuxPaneTitle: &spinnerTitle},
+		divergenceComplete: true,
+		tmuxComplete:       true,
+	}))
+
+	// A new failure notifies once; the same repeated failure stays silent.
+	assert.True(record(workspaceEnrichmentProbeResult{err: errors.New("boom")}))
+	assert.False(record(workspaceEnrichmentProbeResult{err: errors.New("boom")}))
+
+	// Recovery notifies.
+	assert.True(record(workspaceEnrichmentProbeResult{
+		response:           workspaceResponse{CommitsAhead: &ahead, CommitsBehind: &newBehind, TmuxPaneTitle: &spinnerTitle},
+		divergenceComplete: true,
+		tmuxComplete:       true,
+	}))
 }
 
 func TestWorkspaceEnrichmentUsesBoundedWorkersPastBackgroundCapacity(t *testing.T) {

--- a/internal/server/workspace_pushed_head_e2e_test.go
+++ b/internal/server/workspace_pushed_head_e2e_test.go
@@ -175,6 +175,99 @@ func TestWorkspacePushedHeadObserverE2ELocalOnlyCommitTriggersNothing(t *testing
 	assert.Equal(pushedHead, stored.PlatformHeadSHA)
 }
 
+func TestWorkspacePushedHeadObserverE2EStopsAfterNonConvergingRefresh(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	// The provider authoritatively reports a head the local worktree has
+	// never seen: the PR advanced from another checkout, so the local
+	// tracking ref is the stale side and no amount of re-syncing converges.
+	providerHead := "e2e0000000000000000000000000000000000000"
+	newTitle := "Moved elsewhere"
+	var detailSyncCalls atomic.Int64
+	mock := &mockGH{
+		getPullRequestFn: func(_ context.Context, _, _ string, _ int) (*gh.PullRequest, error) {
+			detailSyncCalls.Add(1)
+			state := "open"
+			body := "updated body"
+			url := "https://github.com/acme/widget/pull/1"
+			now := gh.Timestamp{Time: time.Date(2026, 5, 20, 14, 15, 0, 0, time.UTC)}
+			return &gh.PullRequest{
+				ID:        new(int64(1001)),
+				Number:    new(1),
+				Title:     &newTitle,
+				Body:      &body,
+				State:     &state,
+				HTMLURL:   &url,
+				User:      &gh.User{Login: new("octocat")},
+				CreatedAt: &now,
+				UpdatedAt: &now,
+				Head:      &gh.PullRequestBranch{Ref: new("feature"), SHA: &providerHead},
+				Base:      &gh.PullRequestBranch{Ref: new("main"), SHA: new("base-sha")},
+			}, nil
+		},
+	}
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": mock},
+		database,
+		nil,
+		[]ghclient.RepoRef{{Owner: "acme", Name: "widget", PlatformHost: "github.com"}},
+		time.Minute,
+		nil,
+		nil,
+	)
+	t.Cleanup(syncer.Stop)
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{WorktreeDir: t.TempDir()})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+
+	worktreePath, _ := setupPushedHeadE2EWorktree(t)
+	seedPushedHeadE2ERepoAndPR(t, database, providerHead)
+	insertPushedHeadE2EWorkspace(t, database, worktreePath)
+
+	httpServer := httptest.NewServer(srv)
+	defer httpServer.Close()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, httpServer.URL+"/api/v1/events", nil)
+	require.NoError(err)
+	resp, err := httpServer.Client().Do(req)
+	require.NoError(err)
+	defer resp.Body.Close()
+	require.Equal(http.StatusOK, resp.StatusCode)
+	require.Eventually(func() bool {
+		return srv.SubscriberCount() == 1
+	}, 2*time.Second, 5*time.Millisecond)
+	scanner := bufio.NewScanner(resp.Body)
+
+	// First pass refreshes once: enqueue, provider sync, completion.
+	srv.runWorkspacePushedHeadObserverPass(ctx)
+	assert.Equal("workspace_pushed_head_changed", readSSEFrameWithin(t, scanner, 5*time.Second, nil).Event)
+	assert.Equal("workspace_pr_refresh_queued", readSSEFrameWithin(t, scanner, 5*time.Second, nil).Event)
+	assert.Equal("pr_detail_refreshed", readSSEFrameWithin(t, scanner, 5*time.Second, nil).Event)
+	assert.Equal("data_changed", readSSEFrameWithin(t, scanner, 5*time.Second, nil).Event)
+	require.Equal(int64(1), detailSyncCalls.Load())
+
+	// Well past the failure-retry interval, the succeeded-but-still-
+	// different refresh must not be repeated.
+	srv.workspacePushedHeadObserver.SetNowForTest(func() time.Time {
+		return time.Now().Add(time.Minute)
+	})
+	srv.runWorkspacePushedHeadObserverPass(ctx)
+	srv.Hub().Broadcast(Event{Type: "sentinel_after_pass", Data: map[string]any{}})
+	frame := readSSEFrameWithin(t, scanner, 5*time.Second, nil)
+	assert.Equal("sentinel_after_pass", frame.Event)
+	assert.Equal(int64(1), detailSyncCalls.Load(), "non-converging refresh must not be re-enqueued")
+
+	// A real local push moves the tracking ref and refreshes again.
+	pushNewPushedHeadE2ECommit(t, worktreePath)
+	srv.runWorkspacePushedHeadObserverPass(ctx)
+	assert.Equal("workspace_pushed_head_changed", readSSEFrameWithin(t, scanner, 5*time.Second, nil).Event)
+	assert.Equal("workspace_pr_refresh_queued", readSSEFrameWithin(t, scanner, 5*time.Second, nil).Event)
+	assert.Equal("pr_detail_refreshed", readSSEFrameWithin(t, scanner, 5*time.Second, nil).Event)
+	require.Eventually(func() bool {
+		return detailSyncCalls.Load() == 2
+	}, 2*time.Second, 5*time.Millisecond)
+}
+
 func seedPushedHeadE2ERepoAndPR(t *testing.T, database *db.DB, oldHead string) int64 {
 	t.Helper()
 	repoID, err := database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -2511,11 +2511,13 @@ func (m *Manager) ReapOrphanTmuxSessions(ctx context.Context) error {
 // the host tmux server. Runtime-session rows whose tmux session was killed
 // outside middleman are removed. Ready workspaces whose primary tmux session is
 // missing are marked errored so list responses stop probing dead session names
-// and the UI can offer retry/delete.
-func (m *Manager) PruneMissingTmuxSessions(ctx context.Context) error {
+// and the UI can offer retry/delete. It reports whether anything was pruned so
+// callers only notify clients about passes that changed state.
+func (m *Manager) PruneMissingTmuxSessions(ctx context.Context) (bool, error) {
+	changed := false
 	sessions, err := m.listTmuxSessions(ctx)
 	if err != nil {
-		return err
+		return false, err
 	}
 	live := make(map[string]bool, len(sessions))
 	for _, session := range sessions {
@@ -2524,7 +2526,7 @@ func (m *Manager) PruneMissingTmuxSessions(ctx context.Context) error {
 
 	storedSessions, err := m.db.ListAllWorkspaceRuntimeTmuxSessions(ctx)
 	if err != nil {
-		return err
+		return false, err
 	}
 	for _, stored := range storedSessions {
 		if stored.TmuxSession == "" {
@@ -2539,16 +2541,18 @@ func (m *Manager) PruneMissingTmuxSessions(ctx context.Context) error {
 			"target_key", stored.TargetKey,
 			"tmux_session", stored.TmuxSession,
 		)
-		if _, err := m.db.DeleteWorkspaceRuntimeSessionCreatedAt(
+		deleted, err := m.db.DeleteWorkspaceRuntimeSessionCreatedAt(
 			ctx, stored.WorkspaceID, stored.SessionKey, stored.CreatedAt,
-		); err != nil {
-			return err
+		)
+		if err != nil {
+			return changed, err
 		}
+		changed = changed || deleted
 	}
 
 	workspaces, err := m.db.ListWorkspaces(ctx)
 	if err != nil {
-		return fmt.Errorf("list workspaces: %w", err)
+		return changed, fmt.Errorf("list workspaces: %w", err)
 	}
 	for _, ws := range workspaces {
 		if ws.Status != "ready" ||
@@ -2571,10 +2575,11 @@ func (m *Manager) PruneMissingTmuxSessions(ctx context.Context) error {
 		if err := m.db.UpdateWorkspaceStatus(
 			ctx, ws.ID, "error", &msg,
 		); err != nil {
-			return err
+			return changed, err
 		}
+		changed = true
 	}
-	return nil
+	return changed, nil
 }
 
 func isWorkspaceTmuxSessionName(session string) bool {

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -3825,7 +3825,9 @@ func TestManagerPruneMissingTmuxSessionsRemovesStaleRecords(
 		time.Time{},
 	)
 
-	require.NoError(mgr.PruneMissingTmuxSessions(ctx))
+	pruned, pruneErr := mgr.PruneMissingTmuxSessions(ctx)
+	require.NoError(pruneErr)
+	assert.True(pruned)
 
 	stored, err := d.ListWorkspaceRuntimeTmuxSessions(ctx, "0000000000000001")
 	require.NoError(err)
@@ -3910,7 +3912,9 @@ func TestManagerTmuxSessionListSurvivesTmux36Sanitization(t *testing.T) {
 		Status:       "ready",
 	}))
 
-	require.NoError(mgr.PruneMissingTmuxSessions(ctx))
+	pruned, pruneErr := mgr.PruneMissingTmuxSessions(ctx)
+	require.NoError(pruneErr)
+	assert.False(pruned, "no-op prune must report no change so callers stay silent")
 	live, err := d.GetWorkspace(ctx, "0000000000000001")
 	require.NoError(err)
 	require.NotNil(live)

--- a/internal/workspace/pushed_head_observer.go
+++ b/internal/workspace/pushed_head_observer.go
@@ -389,6 +389,15 @@ func (o *PushedHeadObserver) observeWorkspacePR(ctx context.Context, ws *Workspa
 		if providerSHA == "" || strings.EqualFold(providerSHA, lookup.sha) {
 			return PushedHeadUpdate{}, false, nil
 		}
+		// A refresh enqueued for this same observed SHA already completed:
+		// the provider authoritatively answered with a head that still
+		// differs, meaning the local tracking ref is stale (the PR moved
+		// somewhere else), not that the provider lags a local push.
+		// Re-syncing cannot converge, so stop until the local ref moves;
+		// retries stay reserved for refreshes that failed outright.
+		if !prior.LastRefreshSucceededAt.IsZero() && !prior.LastRefreshSucceededAt.Before(prior.LastRefreshEnqueuedAt) {
+			return PushedHeadUpdate{}, false, nil
+		}
 		if !prior.LastRefreshEnqueuedAt.IsZero() && observedAt.Sub(prior.LastRefreshEnqueuedAt) < pushedHeadRefreshRetryInterval {
 			return PushedHeadUpdate{}, false, nil
 		}

--- a/internal/workspace/pushed_head_observer.go
+++ b/internal/workspace/pushed_head_observer.go
@@ -136,12 +136,19 @@ func (o *PushedHeadObserver) SetNowForTest(now func() time.Time) {
 	o.now = now
 }
 
+// MarkRefreshEnqueued and MarkRefreshSucceeded stamp the observation only
+// while it still tracks the SHA the refresh was enqueued for. A refresh
+// completing after the tracking ref moved on must not stamp the new SHA's
+// cycle: its timestamps would satisfy the stop-retrying gate and suppress
+// the refresh the new SHA still needs.
 func (o *PushedHeadObserver) MarkRefreshEnqueued(update PushedHeadUpdate, at time.Time) {
 	key := update.remoteHeadKey()
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	obs := o.observed[key]
-	obs.SHA = update.NewSHA
+	if !strings.EqualFold(obs.SHA, update.NewSHA) {
+		return
+	}
 	obs.LastRefreshEnqueuedAt = at
 	o.observed[key] = obs
 }
@@ -151,7 +158,9 @@ func (o *PushedHeadObserver) MarkRefreshSucceeded(update PushedHeadUpdate, at ti
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	obs := o.observed[key]
-	obs.SHA = update.NewSHA
+	if !strings.EqualFold(obs.SHA, update.NewSHA) {
+		return
+	}
 	obs.LastRefreshSucceededAt = at
 	o.observed[key] = obs
 }
@@ -405,8 +414,12 @@ func (o *PushedHeadObserver) observeWorkspacePR(ctx context.Context, ws *Workspa
 		return update, true, nil
 	}
 	update.OldSHA = prior.SHA
-	prior.SHA = lookup.sha
-	prior.ObservedAt = observedAt
+	// The refresh timestamps belong to the previously observed SHA. If they
+	// survived a SHA change and the enqueue for the new SHA is dropped (a
+	// same-key detail sync already in flight), the old success stamp would
+	// satisfy the stop-retrying gate above and permanently suppress the new
+	// SHA's refresh.
+	prior = remoteHeadObservation{SHA: lookup.sha, ObservedAt: observedAt}
 	o.observed[key] = prior
 	return update, true, nil
 }

--- a/internal/workspace/pushed_head_observer_test.go
+++ b/internal/workspace/pushed_head_observer_test.go
@@ -251,6 +251,53 @@ func TestPushedHeadObserverDoesNotRetryAfterRefreshSucceeds(t *testing.T) {
 	assert.Empty(retry.HeadChanges)
 }
 
+func TestPushedHeadObserverStopsRetryingAfterSuccessfulRefreshStillDiffers(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
+	seedMRWithPlatformHead(t, d, repoID, 42, "feature/remote-head", "1111111", "")
+	insertPushedHeadWorkspace(t, d, "ws-pr", db.WorkspaceItemTypePullRequest, 42, nil)
+	reader := &fakeRemoteHeadReader{
+		branch:      "feature/remote-head",
+		upstream:    upstreamState{hasTracking: true, remoteName: "origin", branchName: "feature/remote-head"},
+		trackingSHA: "2222222",
+		trackingRef: "refs/remotes/origin/feature/remote-head",
+		trackingOK:  true,
+	}
+	now := time.Date(2026, 5, 20, 14, 15, 0, 0, time.UTC)
+	observer := NewPushedHeadObserver(d)
+	observer.SetGitReaderForTest(reader)
+	observer.SetNowForTest(func() time.Time { return now })
+
+	first, err := observer.RunOnce(context.Background())
+	require.NoError(err)
+	require.Len(first.HeadChanges, 1)
+	observer.MarkRefreshEnqueued(first.HeadChanges[0], now)
+	// The enqueued provider sync completed and authoritatively reported a
+	// head that still differs from the local tracking ref: the local ref
+	// is stale, so another sync cannot converge.
+	observer.MarkRefreshSucceeded(first.HeadChanges[0], now.Add(2*time.Second))
+
+	now = now.Add(pushedHeadRefreshRetryInterval + time.Second)
+	steady, err := observer.RunOnce(context.Background())
+	require.NoError(err)
+	assert.Empty(steady.HeadChanges)
+
+	now = now.Add(pushedHeadRefreshRetryInterval + time.Second)
+	later, err := observer.RunOnce(context.Background())
+	require.NoError(err)
+	assert.Empty(later.HeadChanges)
+
+	// A real local push moves the tracking ref and restarts the cycle.
+	reader.trackingSHA = "3333333"
+	pushed, err := observer.RunOnce(context.Background())
+	require.NoError(err)
+	require.Len(pushed.HeadChanges, 1)
+	assert.Equal("2222222", pushed.HeadChanges[0].OldSHA)
+	assert.Equal("3333333", pushed.HeadChanges[0].NewSHA)
+}
+
 func TestPushedHeadObserverDetectsSubsequentTrackingRefMove(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/workspace/pushed_head_observer_test.go
+++ b/internal/workspace/pushed_head_observer_test.go
@@ -298,6 +298,94 @@ func TestPushedHeadObserverStopsRetryingAfterSuccessfulRefreshStillDiffers(t *te
 	assert.Equal("3333333", pushed.HeadChanges[0].NewSHA)
 }
 
+func TestPushedHeadObserverRetriesNewSHAWhenEnqueueWasDropped(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
+	seedMRWithPlatformHead(t, d, repoID, 42, "feature/remote-head", "1111111", "")
+	insertPushedHeadWorkspace(t, d, "ws-pr", db.WorkspaceItemTypePullRequest, 42, nil)
+	reader := &fakeRemoteHeadReader{
+		branch:      "feature/remote-head",
+		upstream:    upstreamState{hasTracking: true, remoteName: "origin", branchName: "feature/remote-head"},
+		trackingSHA: "2222222",
+		trackingRef: "refs/remotes/origin/feature/remote-head",
+		trackingOK:  true,
+	}
+	now := time.Date(2026, 5, 20, 14, 15, 0, 0, time.UTC)
+	observer := NewPushedHeadObserver(d)
+	observer.SetGitReaderForTest(reader)
+	observer.SetNowForTest(func() time.Time { return now })
+
+	// Suppressed steady state for the first SHA: refresh enqueued and
+	// succeeded, provider still reports a different head.
+	first, err := observer.RunOnce(context.Background())
+	require.NoError(err)
+	require.Len(first.HeadChanges, 1)
+	observer.MarkRefreshEnqueued(first.HeadChanges[0], now)
+	observer.MarkRefreshSucceeded(first.HeadChanges[0], now.Add(2*time.Second))
+
+	// A push moves the tracking ref, but the server drops the enqueue
+	// (same-key detail sync already in flight), so neither marker runs.
+	reader.trackingSHA = "3333333"
+	now = now.Add(time.Minute)
+	moved, err := observer.RunOnce(context.Background())
+	require.NoError(err)
+	require.Len(moved.HeadChanges, 1)
+
+	// The new SHA must keep retrying: the old SHA's refresh stamps do not
+	// belong to it and must not satisfy the stop-retrying gate.
+	now = now.Add(time.Minute)
+	retry, err := observer.RunOnce(context.Background())
+	require.NoError(err)
+	require.Len(retry.HeadChanges, 1)
+	assert.Equal("3333333", retry.HeadChanges[0].NewSHA)
+}
+
+func TestPushedHeadObserverLateSuccessForOldSHADoesNotDisturbNewCycle(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
+	seedMRWithPlatformHead(t, d, repoID, 42, "feature/remote-head", "1111111", "")
+	insertPushedHeadWorkspace(t, d, "ws-pr", db.WorkspaceItemTypePullRequest, 42, nil)
+	reader := &fakeRemoteHeadReader{
+		branch:      "feature/remote-head",
+		upstream:    upstreamState{hasTracking: true, remoteName: "origin", branchName: "feature/remote-head"},
+		trackingSHA: "2222222",
+		trackingRef: "refs/remotes/origin/feature/remote-head",
+		trackingOK:  true,
+	}
+	now := time.Date(2026, 5, 20, 14, 15, 0, 0, time.UTC)
+	observer := NewPushedHeadObserver(d)
+	observer.SetGitReaderForTest(reader)
+	observer.SetNowForTest(func() time.Time { return now })
+
+	first, err := observer.RunOnce(context.Background())
+	require.NoError(err)
+	require.Len(first.HeadChanges, 1)
+	observer.MarkRefreshEnqueued(first.HeadChanges[0], now)
+
+	// Push moves the ref; the new SHA's refresh is enqueued normally.
+	reader.trackingSHA = "3333333"
+	now = now.Add(time.Minute)
+	moved, err := observer.RunOnce(context.Background())
+	require.NoError(err)
+	require.Len(moved.HeadChanges, 1)
+	observer.MarkRefreshEnqueued(moved.HeadChanges[0], now)
+
+	// The first SHA's refresh completes only now. It must not rebind the
+	// observation to the old SHA: doing so re-routed the next pass through
+	// the SHA-changed branch and re-emitted the same head change inside
+	// the new refresh's retry window.
+	observer.MarkRefreshSucceeded(first.HeadChanges[0], now.Add(time.Second))
+
+	now = now.Add(5 * time.Second)
+	within, err := observer.RunOnce(context.Background())
+	require.NoError(err)
+	assert.Empty(within.HeadChanges)
+}
+
 func TestPushedHeadObserverDetectsSubsequentTrackingRefMove(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)


### PR DESCRIPTION
A PR shown in the workspace view was refreshed continuously, restarting as soon as each refresh finished. Two independent loops caused it.

**Pushed-head sync loop.** The pushed-head observer treats any mismatch between a workspace's local remote-tracking SHA and the provider head SHA as "the provider lags a local push" and re-enqueued a full PR provider sync every retry interval. When the PR advanced from another checkout, the local tracking ref is the stale side and never converges, so the same PR was re-synced forever, each completion making the frontend reload the visible PR detail. A successful sync is an authoritative provider answer: if the head still differs afterwards, another sync cannot converge, so the observer now stops re-enqueueing until the local tracking ref moves. Refresh timestamps reset when the observed SHA changes so a dropped enqueue cannot suppress a later push; failed refreshes keep the retry interval.

**Workspace-status broadcast loop.** Every enrichment completion and every tmux prune pass broadcast `workspace_status` unconditionally (~40 events/min observed live with one open workspace). A busy agent moves the tmux-activity timestamp on every 5s probe, so each broadcast made clients refetch and each refetch scheduled the next enrichment past the 5s TTL. Completions now notify only for durable changes (first completion, divergence movement, error-state change) and prune broadcasts only when it pruned; activity ordering still flows through the workspace list's own polling.

- Workspace-view PRs with stale local tracking refs are no longer re-synced and re-rendered in a loop
- Open workspace views no longer refetch every few seconds while idle or while an agent is streaming output
- Push-triggered refresh, failure retries, and the pending-to-fresh enrichment transition behave as before
- Convergence and broadcast rules are recorded in `context/workspace-apis.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sup>generated by a clanker</sup>