### PR TITLE
fix: restore native scrollbar behavior

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/state": "^6.6.0",
         "@codemirror/view": "^6.43.0",
-        "@kenn-io/kit-ui": "github:kenn-io/kit-ui#727473d47a3bb224eac90849e0a2532ef3bac8e7",
+        "@kenn-io/kit-ui": "github:kenn-io/kit-ui#c5e81a4f1f1bffac06d37406344fde0926bf4189",
         "@lucide/svelte": "1.23.0",
         "@middleman/ui": "workspace:*",
         "@pierre/diffs": "1.2.12",
@@ -74,7 +74,7 @@
       "name": "@middleman/ui",
       "version": "0.0.1",
       "dependencies": {
-        "@kenn-io/kit-ui": "github:kenn-io/kit-ui#727473d47a3bb224eac90849e0a2532ef3bac8e7",
+        "@kenn-io/kit-ui": "github:kenn-io/kit-ui#c5e81a4f1f1bffac06d37406344fde0926bf4189",
         "@lucide/svelte": "1.23.0",
         "@pierre/diffs": "1.2.12",
         "@pierre/trees": "1.0.0-beta.5",
@@ -232,7 +232,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@kenn-io/kit-ui": ["@kenn-io/kit-ui@github:kenn-io/kit-ui#727473d", { "peerDependencies": { "@lucide/svelte": ">=1.0.0", "dompurify": "^3.2.0", "marked": "^18.0.0", "mermaid": ">=11.15.0 <12", "shiki": "^4.0.0", "svelte": "^5.29.0" }, "optionalPeers": ["mermaid"], "bin": { "kit-ui-check": "./bin/kit-ui-check.mjs" } }, "kenn-io-kit-ui-727473d", "sha512-y/sNoD8TeKof2i1bCa/vMA7xUVlZMmJRtR2iSVqNNQLxJedBAsTtAjJ4qCHLNr9vEP0jNAHcljcMbttznQA5tg=="],
+    "@kenn-io/kit-ui": ["@kenn-io/kit-ui@github:kenn-io/kit-ui#c5e81a4", { "peerDependencies": { "@lucide/svelte": ">=1.0.0", "dompurify": "^3.2.0", "marked": "^18.0.0", "mermaid": ">=11.15.0 <12", "shiki": "^4.0.0", "svelte": "^5.29.0" }, "optionalPeers": ["mermaid"], "bin": { "kit-ui-check": "./bin/kit-ui-check.mjs" } }, "kenn-io-kit-ui-c5e81a4", "sha512-+f+EHoyPJk+nemnyEE0R2daVuL96oJVO0CqJXNq2fybL6h/rdMVeLg9fsLIF5/pHX0/WMcFG9aQ8++Pl6C2tGg=="],
 
     "@lezer/common": ["@lezer/common@1.5.2", "", {}, "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,7 +25,7 @@
     "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/state": "^6.6.0",
     "@codemirror/view": "^6.43.0",
-    "@kenn-io/kit-ui": "github:kenn-io/kit-ui#727473d47a3bb224eac90849e0a2532ef3bac8e7",
+    "@kenn-io/kit-ui": "github:kenn-io/kit-ui#c5e81a4f1f1bffac06d37406344fde0926bf4189",
     "@lucide/svelte": "1.23.0",
     "@middleman/ui": "workspace:*",
     "@pierre/diffs": "1.2.12",

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -14,11 +14,6 @@
   padding: 0;
 }
 
-* {
-  scrollbar-color: var(--border-default) transparent;
-  scrollbar-width: thin;
-}
-
 /* App-specific tokens — light theme */
 :root {
   --chrome-border-width: 1px;
@@ -152,25 +147,6 @@ body {
 /* Action failures must remain visible while their retryable modal stays open. */
 #app .kit-flash-stack {
   z-index: var(--z-flash);
-}
-
-/* Scrollbars */
-::-webkit-scrollbar {
-  width: 6px;
-  height: 6px;
-}
-
-::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-::-webkit-scrollbar-thumb {
-  background: var(--border-default);
-  border-radius: 3px;
-}
-
-::-webkit-scrollbar-thumb:hover {
-  background: var(--text-muted);
 }
 
 /* Element resets */

--- a/frontend/tests/e2e-full/sidebar-scroll-indicator.spec.ts
+++ b/frontend/tests/e2e-full/sidebar-scroll-indicator.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test, type Locator } from "@playwright/test";
 
+import { authoredScrollbarWidths } from "../support/scrollbarStyles";
+
 async function constrainScrollArea(scrollArea: Locator): Promise<void> {
   await scrollArea.locator("..").evaluate((node) => {
     const root = node as HTMLElement;
@@ -25,8 +27,9 @@ test("grouped rail uses native scrollbars with sticky content", async ({ page, b
   }));
   expect(initialGeometry.scrollHeight).toBeGreaterThan(initialGeometry.clientHeight);
   expect(initialGeometry.scrollbarColor).toBe("auto");
-  expect(initialGeometry.scrollbarWidth).toBe("auto");
+  expect(await authoredScrollbarWidths(scrollArea)).toEqual([]);
   if (browserName === "chromium") {
+    expect(initialGeometry.scrollbarWidth).toBe("auto");
     expect(initialGeometry.webkitWidth).toBe("auto");
   }
   await expect(stickyHeader).toBeVisible();
@@ -36,7 +39,7 @@ test("grouped rail uses native scrollbars with sticky content", async ({ page, b
   await expect.poll(() => scrollArea.evaluate((node) => node.scrollTop)).toBeGreaterThan(0);
 });
 
-test("grouped rails share labeled native scroll regions", async ({ page }) => {
+test("grouped rails share labeled native scroll regions", async ({ page, browserName }) => {
   const rails = [
     { path: "/pulls", label: "Pull requests" },
     { path: "/issues", label: "Issues" },
@@ -56,12 +59,13 @@ test("grouped rails share labeled native scroll regions", async ({ page }) => {
     await expect(scrollArea).toBeVisible();
     await expect(scrollArea).toHaveAttribute("tabindex", "0");
     await expect(scrollArea.locator("..").locator(".kit-scrollbox__indicator")).toHaveCount(0);
-    await expect(
-      scrollArea.evaluate((node) => ({
-        color: getComputedStyle(node).scrollbarColor,
-        width: getComputedStyle(node).scrollbarWidth,
-      })),
-    ).resolves.toEqual({ color: "auto", width: "auto" });
+    const scrollbarStyles = await scrollArea.evaluate((node) => ({
+      color: getComputedStyle(node).scrollbarColor,
+      width: getComputedStyle(node).scrollbarWidth,
+    }));
+    expect(scrollbarStyles.color).toBe("auto");
+    expect(await authoredScrollbarWidths(scrollArea)).toEqual([]);
+    if (browserName === "chromium") expect(scrollbarStyles.width).toBe("auto");
   }
 });
 

--- a/frontend/tests/e2e-full/sidebar-scroll-indicator.spec.ts
+++ b/frontend/tests/e2e-full/sidebar-scroll-indicator.spec.ts
@@ -8,60 +8,35 @@ async function constrainScrollArea(scrollArea: Locator): Promise<void> {
   });
 }
 
-test("grouped rail scroll indicator floats above sticky headers", async ({ page }) => {
+test("grouped rail uses native scrollbars with sticky content", async ({ page, browserName }) => {
   await page.goto("/pulls");
   await expect(page.locator(".pull-item").first()).toBeVisible();
 
   const scrollArea = page.getByRole("region", { name: "Pull requests" });
-  const scrollRoot = scrollArea.locator("..");
-  const indicator = scrollRoot.locator(".kit-scrollbox__indicator");
-  const thumb = indicator.locator(".kit-scrollbox__thumb");
   const stickyHeader = scrollArea.locator(".sidebar-group-header").first();
   await constrainScrollArea(scrollArea);
 
   const initialGeometry = await scrollArea.evaluate((node) => ({
-    clientWidth: node.clientWidth,
-    offsetWidth: (node as HTMLElement).offsetWidth,
     clientHeight: node.clientHeight,
     scrollHeight: node.scrollHeight,
+    scrollbarColor: getComputedStyle(node).scrollbarColor,
+    scrollbarWidth: getComputedStyle(node).scrollbarWidth,
+    webkitWidth: getComputedStyle(node, "::-webkit-scrollbar").width,
   }));
   expect(initialGeometry.scrollHeight).toBeGreaterThan(initialGeometry.clientHeight);
-  expect(initialGeometry.clientWidth).toBe(initialGeometry.offsetWidth);
-  await expect(indicator).toHaveCSS("opacity", "0");
-
-  await scrollArea.evaluate((node) => {
-    node.scrollTop = 20;
-  });
-  await expect(indicator).toHaveCSS("opacity", "1");
-
-  const stacking = await scrollArea.evaluate((node) => {
-    const root = node.parentElement;
-    const header = node.querySelector(".sidebar-group-header");
-    const overlay = root?.querySelector(".kit-scrollbox__indicator");
-    return {
-      header: Number.parseInt(getComputedStyle(header!).zIndex, 10),
-      overlay: Number.parseInt(getComputedStyle(overlay!).zIndex, 10),
-    };
-  });
-  expect(stacking.overlay).toBeGreaterThan(stacking.header);
-
-  const headerBox = await stickyHeader.boundingBox();
-  const thumbBox = await thumb.boundingBox();
-  expect(headerBox).not.toBeNull();
-  expect(thumbBox).not.toBeNull();
-  if (headerBox !== null && thumbBox !== null) {
-    expect(thumbBox.y).toBeLessThan(headerBox.y + headerBox.height);
-    expect(thumbBox.x).toBeGreaterThan(headerBox.x);
+  expect(initialGeometry.scrollbarColor).toBe("auto");
+  expect(initialGeometry.scrollbarWidth).toBe("auto");
+  if (browserName === "chromium") {
+    expect(initialGeometry.webkitWidth).toBe("auto");
   }
+  await expect(stickyHeader).toBeVisible();
 
   await scrollArea.focus();
   await page.keyboard.press("End");
-  await expect.poll(() => scrollArea.evaluate((node) => node.scrollTop)).toBeGreaterThan(20);
-  await expect(indicator).toHaveCSS("opacity", "1");
-  await expect(indicator).toHaveCSS("opacity", "0", { timeout: 1_500 });
+  await expect.poll(() => scrollArea.evaluate((node) => node.scrollTop)).toBeGreaterThan(0);
 });
 
-test("grouped rails share labeled overlay scroll regions", async ({ page }) => {
+test("grouped rails share labeled native scroll regions", async ({ page }) => {
   const rails = [
     { path: "/pulls", label: "Pull requests" },
     { path: "/issues", label: "Issues" },
@@ -80,7 +55,13 @@ test("grouped rails share labeled overlay scroll regions", async ({ page }) => {
     const scrollArea = scope.getByRole("region", { name: rail.label, exact: true });
     await expect(scrollArea).toBeVisible();
     await expect(scrollArea).toHaveAttribute("tabindex", "0");
-    await expect(scrollArea.locator("..").locator(".kit-scrollbox__indicator")).toHaveCount(1);
+    await expect(scrollArea.locator("..").locator(".kit-scrollbox__indicator")).toHaveCount(0);
+    await expect(
+      scrollArea.evaluate((node) => ({
+        color: getComputedStyle(node).scrollbarColor,
+        width: getComputedStyle(node).scrollbarWidth,
+      })),
+    ).resolves.toEqual({ color: "auto", width: "auto" });
   }
 });
 

--- a/frontend/tests/e2e/viewport-fit.spec.ts
+++ b/frontend/tests/e2e/viewport-fit.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 import { mockApi } from "./support/mockApi";
+import { authoredScrollbarWidths } from "../support/scrollbarStyles";
 
 test.beforeEach(async ({ page }) => {
   await mockApi(page);
@@ -166,8 +167,9 @@ test("app scroll panes use browser-native scrollbar styling", async ({ page, bro
   }));
 
   expect(scrollbarStyles.color).toBe("auto");
-  expect(scrollbarStyles.width).toBe("auto");
+  expect(await authoredScrollbarWidths(pane)).toEqual([]);
   if (browserName === "chromium") {
+    expect(scrollbarStyles.width).toBe("auto");
     expect(scrollbarStyles.webkitWidth).toBe("auto");
   }
 

--- a/frontend/tests/e2e/viewport-fit.spec.ts
+++ b/frontend/tests/e2e/viewport-fit.spec.ts
@@ -149,9 +149,7 @@ test("settings navigation stacks on phone-width viewports", async ({ page }) => 
     });
 });
 
-test("Firefox receives compact scrollbar styling for app scroll panes", async ({ page, browserName }) => {
-  test.skip(browserName !== "firefox", "Firefox-specific scrollbar regression");
-
+test("app scroll panes use browser-native scrollbar styling", async ({ page, browserName }) => {
   // Short viewport plus the tall Terminal panel so the settings panel
   // overflows its scroll pane.
   await page.setViewportSize({ width: 1280, height: 420 });
@@ -161,36 +159,40 @@ test("Firefox receives compact scrollbar styling for app scroll panes", async ({
   const pane = page.locator(".kit-settings__scroll");
   await expect(pane).toBeVisible();
   await expect.poll(() => pane.evaluate((el) => el.scrollHeight > el.clientHeight)).toBe(true);
-  await expect(
-    page.evaluate(() => {
-      const settingsPane = document.querySelector(".kit-settings__scroll");
-      const appRules = Array.from(document.styleSheets)
-        .flatMap((sheet) => {
-          try {
-            return Array.from(sheet.cssRules);
-          } catch {
-            return [];
-          }
-        })
-        .filter((rule): rule is CSSStyleRule => "selectorText" in rule);
+  const scrollbarStyles = await pane.evaluate((element) => ({
+    color: getComputedStyle(element).scrollbarColor,
+    width: getComputedStyle(element).scrollbarWidth,
+    webkitWidth: getComputedStyle(element, "::-webkit-scrollbar").width,
+  }));
 
-      return appRules.some(
-        (rule) =>
-          settingsPane?.matches(rule.selectorText) === true &&
-          rule.style.scrollbarWidth === "thin" &&
-          rule.style.scrollbarColor.includes("transparent"),
-      );
-    }),
-  ).resolves.toBe(true);
+  expect(scrollbarStyles.color).toBe("auto");
+  expect(scrollbarStyles.width).toBe("auto");
+  if (browserName === "chromium") {
+    expect(scrollbarStyles.webkitWidth).toBe("auto");
+  }
 
   await expect(
     page.evaluate(() => {
-      const appRect = document.querySelector("#app")?.getBoundingClientRect();
+      const scrollPane = document.querySelector<HTMLElement>(".kit-settings__scroll");
+      const content = document.querySelector<HTMLElement>(".kit-settings__content");
+      if (!scrollPane || !content) return null;
+
+      const scrollPaneRect = scrollPane.getBoundingClientRect();
+      const contentRect = content.getBoundingClientRect();
 
       return {
-        heightFits: appRect?.height === window.innerHeight,
-        widthFits: appRect?.width === window.innerWidth,
+        documentFitsViewport: document.documentElement.scrollWidth <= window.innerWidth,
+        scrollPaneDoesNotOverflowHorizontally: scrollPane.scrollWidth <= scrollPane.clientWidth,
+        scrollPaneFitsContent:
+          Math.round(scrollPaneRect.left) >= Math.round(contentRect.left) &&
+          Math.round(scrollPaneRect.right) <= Math.round(contentRect.right),
+        contentFitsViewport: Math.round(contentRect.left) >= 0 && Math.round(contentRect.right) <= window.innerWidth,
       };
     }),
-  ).resolves.toEqual({ heightFits: true, widthFits: true });
+  ).resolves.toEqual({
+    documentFitsViewport: true,
+    scrollPaneDoesNotOverflowHorizontally: true,
+    scrollPaneFitsContent: true,
+    contentFitsViewport: true,
+  });
 });

--- a/frontend/tests/support/scrollbarStyles.ts
+++ b/frontend/tests/support/scrollbarStyles.ts
@@ -1,0 +1,54 @@
+import type { Locator } from "@playwright/test";
+
+export interface AuthoredScrollbarWidth {
+  selector: string;
+  value: string;
+}
+
+export async function authoredScrollbarWidths(locator: Locator): Promise<AuthoredScrollbarWidth[]> {
+  return locator.evaluate((element) => {
+    const declarations: AuthoredScrollbarWidth[] = [];
+
+    const collect = (rules: CSSRuleList): void => {
+      for (const rule of rules) {
+        if (rule instanceof CSSMediaRule && !matchMedia(rule.conditionText).matches) continue;
+        if (rule instanceof CSSSupportsRule && !CSS.supports(rule.conditionText)) continue;
+
+        if (rule instanceof CSSStyleRule) {
+          const value = rule.style.getPropertyValue("scrollbar-width").trim();
+          if (value) {
+            try {
+              if (element.matches(rule.selectorText)) {
+                declarations.push({ selector: rule.selectorText, value });
+              }
+            } catch {
+              // Selectors for another browser engine cannot match here.
+            }
+          }
+        }
+
+        if ("cssRules" in rule) {
+          try {
+            const nestedRules = rule.cssRules;
+            if (nestedRules instanceof CSSRuleList) collect(nestedRules);
+          } catch {
+            // Cross-origin stylesheets are not inspectable.
+          }
+        }
+      }
+    };
+
+    for (const sheet of document.styleSheets) {
+      try {
+        collect(sheet.cssRules);
+      } catch {
+        // Cross-origin stylesheets are not inspectable.
+      }
+    }
+
+    const inlineValue = (element as HTMLElement).style.getPropertyValue("scrollbar-width").trim();
+    if (inlineValue) declarations.push({ selector: "<inline>", value: inlineValue });
+
+    return declarations;
+  });
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -123,7 +123,7 @@
     "typecheck": "cd ../.. && node node_modules/vite-plus/bin/vp run ui-package-typecheck"
   },
   "dependencies": {
-    "@kenn-io/kit-ui": "github:kenn-io/kit-ui#727473d47a3bb224eac90849e0a2532ef3bac8e7",
+    "@kenn-io/kit-ui": "github:kenn-io/kit-ui#c5e81a4f1f1bffac06d37406344fde0926bf4189",
     "@lucide/svelte": "1.23.0",
     "@pierre/diffs": "1.2.12",
     "@pierre/trees": "1.0.0-beta.5",


### PR DESCRIPTION
## Summary

- Restore browser-native scrollbars so platform settings control their width, visibility, and interaction.
- Adopt the merged [`kit-ui` ScrollBox fix](https://github.com/kenn-io/kit-ui/pull/36) across pull, issue, workspace, and Kata rails.
- Preserve viewport fit, sticky content, and keyboard scrolling with updated regression coverage.
