### PR TITLE
fix: keep the PR panel still when a background refresh changes nothing

### DIFF
--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -66,6 +66,10 @@ state.
   Unconditional broadcasts made every client refetch schedule the next
   enrichment, a permanent refresh loop
   (`internal/server/workspace_enrichment.go::workspaceEnrichmentBroadcastWorthy`).
+- Client detail stores mirror this: a background poll or sync whose payload is
+  content-identical (ignoring fetch timestamps) must not replace displayed
+  store state — equal-but-new objects re-render the whole panel every cycle
+  (`packages/ui/src/stores/detail.svelte.ts::applyRefreshedDetail`).
 - `DELETE /workspaces/{id}`: tear down a middleman-managed workspace and its
   local resources.
 

--- a/packages/ui/src/stores/detail.svelte.test.ts
+++ b/packages/ui/src/stores/detail.svelte.test.ts
@@ -90,6 +90,70 @@ describe("createDetailStore", () => {
     expect(store.getDetail()?.platform_head_sha).toBe("new-head");
   });
 
+  it("applies a warnings-only change since the panel renders warnings", async () => {
+    const routeIdentity = {
+      provider: "github",
+      platformHost: "github.com",
+      repoPath: "acme/widget",
+    };
+    const get = vi
+      .fn()
+      .mockResolvedValueOnce({ data: { ...pullDetail("head"), detail_fetched_at: "2026-07-15T10:00:00Z" } })
+      .mockResolvedValueOnce({
+        data: { ...pullDetail("head"), warnings: ["diff unavailable"], detail_fetched_at: "2026-07-15T10:01:00Z" },
+      })
+      .mockResolvedValueOnce({
+        data: { ...pullDetail("head"), warnings: ["diff unavailable"], detail_fetched_at: "2026-07-15T10:02:00Z" },
+      });
+    const store = createDetailStore({
+      client: mockClient({ GET: get }),
+      getPage: () => "pulls",
+    });
+    await store.loadDetail("acme", "widget", 7, { ...routeIdentity, sync: false });
+
+    await store.refreshDetailOnly("acme", "widget", 7, routeIdentity);
+    expect((store.getDetail() as { warnings?: string[] } | null)?.warnings).toEqual(["diff unavailable"]);
+
+    // The same warnings again are not a change.
+    const displayed = store.getDetail();
+    await store.refreshDetailOnly("acme", "widget", 7, routeIdentity);
+    expect(store.getDetail()).toBe(displayed);
+  });
+
+  it("baselines polling convergence on the latest observed timestamp, not the frozen store one", async () => {
+    vi.useFakeTimers();
+    const routeIdentity = {
+      provider: "github",
+      platformHost: "github.com",
+      repoPath: "acme/widget",
+    };
+    const get = vi
+      .fn()
+      .mockResolvedValueOnce({ data: { ...pullDetail("head"), detail_fetched_at: "2026-07-15T10:00:00Z" } })
+      .mockResolvedValueOnce({ data: { ...pullDetail("head"), detail_fetched_at: "2026-07-15T10:01:00Z" } })
+      .mockResolvedValueOnce({ data: { ...pullDetail("head"), detail_fetched_at: "2026-07-15T10:01:00Z" } })
+      .mockResolvedValue({ data: { ...pullDetail("new-head"), detail_fetched_at: "2026-07-15T10:02:00Z" } });
+    const post = vi.fn().mockResolvedValue({ error: undefined });
+    const store = createDetailStore({
+      client: mockClient({ GET: get, POST: post }),
+      getPage: () => "pulls",
+    });
+    await store.loadDetail("acme", "widget", 7, { ...routeIdentity, sync: false });
+    // Content-identical refresh: the store timestamp freezes at 10:00
+    // while the server clock is at 10:01.
+    await store.refreshDetailOnly("acme", "widget", 7, routeIdentity);
+
+    // The next polling cycle's first re-GET still returns 10:01. Judged
+    // against the frozen store timestamp that would look like completion
+    // and drop the real change; against the observed baseline the loop
+    // keeps going and applies the new head from the finished sync.
+    store.startDetailPolling("acme", "widget", 7, routeIdentity);
+    await vi.advanceTimersByTimeAsync(60_000 + 300 + 700 + 100);
+
+    expect(store.getDetail()?.platform_head_sha).toBe("new-head");
+    store.stopDetailPolling();
+  });
+
   it("flashes failed optimistic state changes without poisoning detail load state", async () => {
     const optimisticKanbanUpdate = vi.fn();
     const store = createDetailStore({

--- a/packages/ui/src/stores/detail.svelte.test.ts
+++ b/packages/ui/src/stores/detail.svelte.test.ts
@@ -60,6 +60,36 @@ describe("createDetailStore", () => {
     vi.useRealTimers();
   });
 
+  it("keeps the displayed detail object when a refresh returns identical content", async () => {
+    const routeIdentity = {
+      provider: "github",
+      platformHost: "github.com",
+      repoPath: "acme/widget",
+    };
+    const get = vi
+      .fn()
+      .mockResolvedValueOnce({ data: { ...pullDetail("head"), detail_fetched_at: "2026-07-15T10:00:00Z" } })
+      .mockResolvedValueOnce({ data: { ...pullDetail("head"), detail_fetched_at: "2026-07-15T10:01:00Z" } })
+      .mockResolvedValueOnce({ data: { ...pullDetail("new-head"), detail_fetched_at: "2026-07-15T10:02:00Z" } });
+    const store = createDetailStore({
+      client: mockClient({ GET: get }),
+      getPage: () => "pulls",
+    });
+    await store.loadDetail("acme", "widget", 7, { ...routeIdentity, sync: false });
+    const displayed = store.getDetail();
+
+    // Only the sync timestamp moved: the polling refresh must not swap
+    // in an equal-but-new object, or the PR panel re-renders every cycle.
+    await store.refreshDetailOnly("acme", "widget", 7, routeIdentity);
+    expect(store.getDetail()).toBe(displayed);
+    expect(store.getDetail()?.detail_fetched_at).toBe("2026-07-15T10:00:00Z");
+
+    // Real content changes still apply.
+    await store.refreshDetailOnly("acme", "widget", 7, routeIdentity);
+    expect(store.getDetail()).not.toBe(displayed);
+    expect(store.getDetail()?.platform_head_sha).toBe("new-head");
+  });
+
   it("flashes failed optimistic state changes without poisoning detail load state", async () => {
     const optimisticKanbanUpdate = vi.fn();
     const store = createDetailStore({

--- a/packages/ui/src/stores/detail.svelte.ts
+++ b/packages/ui/src/stores/detail.svelte.ts
@@ -314,13 +314,34 @@ export function createDetailStore(opts: DetailStoreOptions) {
     }
   }
 
+  // A refreshed payload whose content matches the displayed detail must
+  // not replace it: the sync timestamp moves on every background poll,
+  // and swapping in an equal-but-new object re-rendered the whole PR
+  // panel (and re-ran the scroll-restore effect) every polling cycle
+  // even though nothing about the PR changed.
+  function detailContentUnchanged(next: PullDetail): boolean {
+    if (detail === null) return false;
+    const strip = (d: PullDetail): string => {
+      // warnings are advisory (surfaced via flash on arrival, never
+      // rendered from the store), so they don't make content "new".
+      const { detail_fetched_at: _fetchedAt, warnings: _warnings, ...rest } = d as PullDetail & { warnings?: string[] };
+      return JSON.stringify(rest);
+    };
+    return strip(detail) === strip(next);
+  }
+
+  function applyRefreshedDetail(next: PullDetail): void {
+    if (detailContentUnchanged(next)) return;
+    detail = next;
+  }
+
   async function refreshDetail(
     owner: string,
     name: string,
     number: number,
     expectedGen: number = syncGeneration,
     identity: DetailRequestRef,
-  ): Promise<{ ok: boolean; error?: string }> {
+  ): Promise<{ ok: boolean; error?: string; fetchedAt?: string }> {
     const ref = detailRequestRef(owner, name, number, identity);
     try {
       const { data, error: requestError } = await apiClient.GET(providerItemPath("pulls", ref, ""), {
@@ -336,12 +357,14 @@ export function createDetailStore(opts: DetailStoreOptions) {
         return { ok: false, error: apiErrorMessage(requestError, "failed to refresh pull request") };
       }
       if (data !== undefined) {
-        detail = withPreservedLocalBody({
-          ...data,
-          events: data.events ?? [],
-        } as PullDetail);
+        applyRefreshedDetail(
+          withPreservedLocalBody({
+            ...data,
+            events: data.events ?? [],
+          } as PullDetail),
+        );
         detailLoaded = data.detail_loaded ?? detailLoaded;
-        return { ok: true };
+        return { ok: true, ...(data.detail_fetched_at != null && { fetchedAt: data.detail_fetched_at }) };
       }
       return { ok: false, error: "Pull request refresh returned no detail" };
     } catch (err) {
@@ -371,10 +394,12 @@ export function createDetailStore(opts: DetailStoreOptions) {
       }
       if (data) {
         storeError = null;
-        detail = withPreservedLocalBody({
-          ...data,
-          events: data.events ?? [],
-        } as PullDetail);
+        applyRefreshedDetail(
+          withPreservedLocalBody({
+            ...data,
+            events: data.events ?? [],
+          } as PullDetail),
+        );
         detailLoaded = data.detail_loaded ?? detailLoaded;
         refreshed = true;
       }
@@ -548,9 +573,12 @@ export function createDetailStore(opts: DetailStoreOptions) {
     for (const ms of [300, 700, 1_500, 3_000, 5_000]) {
       await delay(ms);
       if (gen !== syncGeneration) return;
-      await refreshDetail(owner, name, number, gen, identity);
+      // Convergence is judged on the response's fetch timestamp, not the
+      // store's: content-identical refreshes intentionally leave the
+      // store untouched, so the store timestamp can stay frozen while
+      // the background sync has in fact completed.
+      const { fetchedAt } = await refreshDetail(owner, name, number, gen, identity);
       if (gen !== syncGeneration) return;
-      const fetchedAt = detail?.detail_fetched_at;
       if (fetchedAt && fetchedAt !== previousFetchedAt) {
         return;
       }
@@ -607,10 +635,12 @@ export function createDetailStore(opts: DetailStoreOptions) {
         }
         if (data) {
           storeError = null;
-          detail = withPreservedLocalBody({
-            ...data,
-            events: data.events ?? [],
-          } as PullDetail);
+          applyRefreshedDetail(
+            withPreservedLocalBody({
+              ...data,
+              events: data.events ?? [],
+            } as PullDetail),
+          );
           detailLoaded = data.detail_loaded ?? detailLoaded;
           const warning = data.warnings?.[0];
           if (warning) {

--- a/packages/ui/src/stores/detail.svelte.ts
+++ b/packages/ui/src/stores/detail.svelte.ts
@@ -138,6 +138,13 @@ export function createDetailStore(opts: DetailStoreOptions) {
     key: string;
     promise: Promise<void>;
   } | null = null;
+  // Latest detail_fetched_at seen in any server payload for the current
+  // selection. The store's own detail_fetched_at intentionally freezes
+  // while refreshes are content-identical, so background-sync convergence
+  // must baseline against this value — the frozen store timestamp would
+  // make the previous cycle's sync look like this cycle's completion and
+  // end the convergence loop before the new sync has landed.
+  let lastObservedFetchedAt: string | undefined;
   // Provider synchronization is eventually complete. Keep a successfully
   // deleted comment hidden locally until an ordinary sync no longer returns it.
   const hiddenDeletedCommentIDs: Record<string, number[]> = {};
@@ -321,10 +328,10 @@ export function createDetailStore(opts: DetailStoreOptions) {
   // even though nothing about the PR changed.
   function detailContentUnchanged(next: PullDetail): boolean {
     if (detail === null) return false;
+    // Only the fetch timestamp is volatile-by-design; everything else —
+    // including warnings, which the PR panel renders — is content.
     const strip = (d: PullDetail): string => {
-      // warnings are advisory (surfaced via flash on arrival, never
-      // rendered from the store), so they don't make content "new".
-      const { detail_fetched_at: _fetchedAt, warnings: _warnings, ...rest } = d as PullDetail & { warnings?: string[] };
+      const { detail_fetched_at: _fetchedAt, ...rest } = d;
       return JSON.stringify(rest);
     };
     return strip(detail) === strip(next);
@@ -333,6 +340,14 @@ export function createDetailStore(opts: DetailStoreOptions) {
   function applyRefreshedDetail(next: PullDetail): void {
     if (detailContentUnchanged(next)) return;
     detail = next;
+  }
+
+  function noteObservedFetchedAt(fetchedAt: string | null | undefined): void {
+    if (fetchedAt != null) lastObservedFetchedAt = fetchedAt;
+  }
+
+  function observedFetchedAtBaseline(): string | undefined {
+    return lastObservedFetchedAt ?? detail?.detail_fetched_at;
   }
 
   async function refreshDetail(
@@ -363,6 +378,7 @@ export function createDetailStore(opts: DetailStoreOptions) {
             events: data.events ?? [],
           } as PullDetail),
         );
+        noteObservedFetchedAt(data.detail_fetched_at);
         detailLoaded = data.detail_loaded ?? detailLoaded;
         return { ok: true, ...(data.detail_fetched_at != null && { fetchedAt: data.detail_fetched_at }) };
       }
@@ -400,6 +416,7 @@ export function createDetailStore(opts: DetailStoreOptions) {
             events: data.events ?? [],
           } as PullDetail),
         );
+        noteObservedFetchedAt(data.detail_fetched_at);
         detailLoaded = data.detail_loaded ?? detailLoaded;
         refreshed = true;
       }
@@ -448,6 +465,7 @@ export function createDetailStore(opts: DetailStoreOptions) {
     storeError = null;
     detailLoaded = false;
     unsavedLocalBody = null;
+    lastObservedFetchedAt = undefined;
   }
 
   async function loadDetail(owner: string, name: string, number: number, options: DetailRequestOptions): Promise<void> {
@@ -460,6 +478,9 @@ export function createDetailStore(opts: DetailStoreOptions) {
     if (activeSelectionKey !== key) {
       activeSelectionKey = key;
       ++selectionGeneration;
+      // The observed-timestamp baseline belongs to the previous selection;
+      // carrying it over would let another PR's sync clock gate this one.
+      lastObservedFetchedAt = undefined;
     }
     if (loading && activeLoad?.key === key && activeLoad.promise !== null) {
       activeLoad.syncMode = strongerSyncMode(activeLoad.syncMode, syncMode);
@@ -512,6 +533,7 @@ export function createDetailStore(opts: DetailStoreOptions) {
               events: data.events ?? [],
             } as PullDetail)
           : null;
+        noteObservedFetchedAt(data?.detail_fetched_at);
         detailLoaded = data?.detail_loaded ?? false;
       } catch (err) {
         if (gen !== syncGeneration) return;
@@ -531,7 +553,7 @@ export function createDetailStore(opts: DetailStoreOptions) {
           void syncDetail(owner, name, number, gen, requestRef);
           return;
         }
-        void enqueueBackgroundDetailSync(owner, name, number, gen, detail?.detail_fetched_at, requestRef);
+        void enqueueBackgroundDetailSync(owner, name, number, gen, observedFetchedAtBaseline(), requestRef);
       }
     })();
     currentLoad.promise = promise;
@@ -641,6 +663,7 @@ export function createDetailStore(opts: DetailStoreOptions) {
               events: data.events ?? [],
             } as PullDetail),
           );
+          noteObservedFetchedAt(data.detail_fetched_at);
           detailLoaded = data.detail_loaded ?? detailLoaded;
           const warning = data.warnings?.[0];
           if (warning) {
@@ -1050,7 +1073,7 @@ export function createDetailStore(opts: DetailStoreOptions) {
     const ref = detailRequestRef(owner, name, number, identity);
     stopDetailPolling();
     detailPollHandle = setInterval(() => {
-      void enqueueBackgroundDetailSync(owner, name, number, syncGeneration, detail?.detail_fetched_at, ref);
+      void enqueueBackgroundDetailSync(owner, name, number, syncGeneration, observedFetchedAtBaseline(), ref);
     }, 60_000);
     if (syncDep) {
       unsubSyncComplete = syncDep.subscribeSyncComplete(() => {


### PR DESCRIPTION
Follow-up to #685. With the workspace_status broadcast storm fixed server-side, the open workspace's PR panel still visibly refreshed every 60 seconds — verified against the live instance after #685 deployed: SSE stream quiet, workspace and runtime payloads byte-stable, panel still redrawing.

The remaining driver is the detail store's own background polling: it POSTs a provider sync and re-GETs the detail until `detail_fetched_at` moves, and the sync always moves it, so the store swapped in an equal-but-new object every cycle. That re-rendered the whole panel and re-ran the scroll-restore effect with nothing to show. The user-facing rule this enforces: if nothing about the PR changed, nothing should refresh.

Refreshed payloads that are content-identical to the displayed detail (ignoring only the fetch timestamp) now leave the store untouched. The background-sync convergence loop judges completion from the response's fetch timestamp instead of the store's, since the store timestamp intentionally freezes while content is unchanged. Real changes, optimistic mutations, and initial loads replace state exactly as before.

- The workspace-view PR panel (and the pulls-page detail) only redraws when the PR actually changed
- Background freshness polling, CI auto-refresh, and sync-complete refreshes still run — they just stop repainting identical content
- The client-side invariant is recorded in `context/workspace-apis.md` alongside the server-side broadcast rule

Note for reviewers: three unrelated unit tests (App feature-route lazy shells, one PierreFileDiff case) fail locally in full-suite runs on this machine after the first run in a fresh worktree — reproduced identically on unmodified main in the same conditions, so they are a local scheduling artifact, not from this change. The unit project alone and all changed-area tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sup>generated by a clanker</sup>
