### PR TITLE
fix: accept an embedded WebSocket base

### DIFF
--- a/frontend/src/lib/components/terminal/GhosttyTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/GhosttyTerminalPane.svelte
@@ -20,6 +20,7 @@
     isMultilinePaste,
     sanitizeTerminalPasteText,
   } from "./bracketedPaste.js";
+  import { embeddedWebSocketUrl } from "./embeddedWebSocket.js";
   import { buildTerminalFontFamily } from "./terminalFontFamily.js";
   import { createTmuxMouseDragFilter } from "./tmuxMouseDragFilter.js";
 
@@ -129,6 +130,8 @@
     if (/^wss?:\/\//.test(withSize)) {
       return withSize;
     }
+    const embeddedUrl = embeddedWebSocketUrl(withBasePath(withSize));
+    if (embeddedUrl) return embeddedUrl;
     const devUrl = buildDevApiWsUrl(withSize);
     if (devUrl) return devUrl;
     const proto = location.protocol === "https:" ? "wss" : "ws";

--- a/frontend/src/lib/components/terminal/GhosttyTerminalPane.test.ts
+++ b/frontend/src/lib/components/terminal/GhosttyTerminalPane.test.ts
@@ -87,6 +87,7 @@ describe("GhosttyTerminalPane", () => {
     configuredScrollback = 1000;
     configuredCursorBlink = true;
     delete window.__BASE_PATH__;
+    delete window.__KENN_EMBEDDED_WEBSOCKET_BASE_URL__;
     window.__MIDDLEMAN_DEV_API_URL__ = "http://127.0.0.1:8091";
     terminalCtor.mockReset();
     mockFit.mockReset();
@@ -166,6 +167,29 @@ describe("GhosttyTerminalPane", () => {
     const url = new URL(socketAt(0).url);
     expect(url.origin).toBe("ws://localhost:3000");
     expect(url.pathname).toBe("/ws/v1/workspaces/ws-123/terminal");
+  });
+
+  it("uses the embedding host websocket base for terminal routes", async () => {
+    window.__KENN_EMBEDDED_WEBSOCKET_BASE_URL__ = "ws://127.0.0.1:19443/lease-capability/";
+
+    await renderStarted({ workspaceId: "ws-123" });
+
+    expect(sockets).toHaveLength(1);
+    const url = new URL(socketAt(0).url);
+    expect(url.origin).toBe("ws://127.0.0.1:19443");
+    expect(url.pathname).toBe("/lease-capability/ws/v1/workspaces/ws-123/terminal");
+    expect(url.searchParams.get("cols")).toBe("80");
+    expect(url.searchParams.get("rows")).toBe("24");
+  });
+
+  it("preserves the Middleman base path through the embedding host socket", async () => {
+    window.__BASE_PATH__ = "/middleman/";
+    window.__KENN_EMBEDDED_WEBSOCKET_BASE_URL__ = "ws://127.0.0.1:19443/lease-capability/";
+
+    await renderStarted({ workspaceId: "ws-123" });
+
+    const url = new URL(socketAt(0).url);
+    expect(url.pathname).toBe("/lease-capability/middleman/ws/v1/workspaces/ws-123/terminal");
   });
 
   it("applies the base path to the default workspace socket", async () => {

--- a/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
@@ -13,6 +13,7 @@
     createTerminalPastePayload,
     isMultilinePaste,
   } from "./bracketedPaste.js";
+  import { embeddedWebSocketUrl } from "./embeddedWebSocket.js";
   import {
     buildTerminalFontFamily,
     primaryTerminalFontFamily,
@@ -144,6 +145,8 @@
     if (/^wss?:\/\//.test(withSize)) {
       return withSize;
     }
+    const embeddedUrl = embeddedWebSocketUrl(withBasePath(withSize));
+    if (embeddedUrl) return embeddedUrl;
     const devUrl = buildDevApiWsUrl(withSize);
     if (devUrl) return devUrl;
     const proto = location.protocol === "https:" ? "wss" : "ws";

--- a/frontend/src/lib/components/terminal/embeddedWebSocket.ts
+++ b/frontend/src/lib/components/terminal/embeddedWebSocket.ts
@@ -1,0 +1,17 @@
+export function embeddedWebSocketUrl(path: string): string | null {
+  const raw = window.__KENN_EMBEDDED_WEBSOCKET_BASE_URL__?.trim();
+  if (!raw) return null;
+
+  try {
+    const base = new URL(raw);
+    if (base.protocol !== "ws:" && base.protocol !== "wss:") return null;
+    const requested = new URL(path, "http://middleman.local");
+    const basePath = base.pathname.replace(/\/$/, "");
+    base.pathname = `${basePath}${requested.pathname}`;
+    base.search = requested.search;
+    base.hash = "";
+    return base.toString();
+  } catch {
+    return null;
+  }
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -268,6 +268,7 @@ interface MiddlemanNavigateEvent {
 interface Window {
   __BASE_PATH__?: string;
   __MIDDLEMAN_DEV_API_URL__?: string;
+  __KENN_EMBEDDED_WEBSOCKET_BASE_URL__?: string;
   __MIDDLEMAN_FORCE_MOBILE_ROUTES__?: boolean;
   __middleman_config?: MiddlemanConfig;
   __middleman_event_source_counts?: () => {


### PR DESCRIPTION
Kenn Console embeds Middleman behind a stable `https://middleman.kenn.invalid` browser origin so Chromium profile state survives endpoint and view changes. Electron's intercepted HTTPS protocol does not receive WebSocket upgrades, however, so deriving terminal sockets from `location.host` leaves embedded Ghostty and Xterm sessions targeting an unreachable `.invalid` endpoint.

This adds an optional embedding contract for a host-provided WebSocket base. Both terminal renderers prefer that endpoint while preserving Middleman's base path and terminal query parameters. Standalone and normal development behavior remain unchanged when an embedding host does not provide the value.

The endpoint is deliberately supplied by the embedding host rather than inferred by Middleman: Console can bind it to the currently verified loopback route generation and revoke it when that route changes.

A hidden real-Electron characterization verified that Chromium permits the stable HTTPS `.invalid` page to connect to the literal-loopback plaintext WebSocket endpoint. Focused frontend tests cover the capability-scoped endpoint and nested Middleman base path.
