### PR TITLE
Speed up selected workspace diff loading

### DIFF
--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -271,6 +271,13 @@ server check exactly.
   captured load token and generation still own the store; stale preview work
   fails without mutation
   (`packages/ui/src/stores/diff.svelte.ts::loadWorkspaceFilePreview`).
+- Preserving refreshes publish only a fresh coherent files/diff pair; stale
+  responses retain the visible pair and retry because same-fingerprint
+  validation emits no change event
+  (`packages/ui/src/stores/diff.svelte.ts::loadWorkspaceDiff`).
+- Workspace diff and preview paths identify the current path first. Old paths
+  are fallback aliases only, since a rename source can coexist with a new file
+  at that path (`internal/server/huma_routes.go::filterWorkspaceDiffSnapshotPath`).
 - Live worktree reads use Go's `os.Root` containment. Final symlinks are read as
   links, regular files are identity-checked across the open, and intermediate
   symlinks may resolve only within the worktree. Untracked patch reads and

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -233,6 +233,10 @@ server check exactly.
   bounded queue is not a hard completion deadline
   (`internal/server/server.go::notifyWorktreeStatsChanged`). One background worker
   serializes proactive validation; foreground cold reads bypass that queue.
+  Entryless cold failures stay with selection prewarm's five-second retry;
+  periodic validation handles only published entries, so its one-second cadence
+  cannot bypass cold backoff
+  (`internal/server/workspace_diff_cache.go::validateSelected`).
 - The 128 MiB inactive-cache budget evicts least-recently-used inactive
   entries, never active snapshots. A newly published snapshot has a one-minute
   files/diff revision lease so an oversized `/files` response cannot evict

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -187,6 +187,22 @@ response as expected rather than an error, and a future change should expose a
 resolved-merge-target signal on the workspace summary so the UI gate matches the
 server check exactly.
 
+## Diff Snapshot Coherence
+
+- Files, patches, and previews must project from one immutable snapshot; clients
+  pin `/diff` to the `/files` revision and retry a revision conflict atomically
+  (`internal/server/workspace_diff_cache.go::workspaceDiffCache`).
+- Cache entries are stale-while-revalidate with last-known-good fallback. Only
+  selected workspaces receive proactive refresh leases; ordinary entries validate
+  on demand so background Git work scales with active UI use
+  (`internal/server/server.go::streamEvents`).
+- Publishing a dirty-worktree snapshot requires matching before/after resolved
+  refs and fingerprints; repository-local attributes are fingerprint inputs
+  (`internal/workspace/diff_snapshot.go::PrepareDiffSnapshot`).
+- Whitespace-only classification is post-processing over aggregate Git output;
+  raw mode/type changes remain substantive even when content differs only in
+  whitespace (`internal/workspace/diff_whitespace.go::classifyWhitespaceOnly`).
+
 ## Branch Upstream
 
 The branch's git upstream config (`branch.<name>.remote`/`.merge`) is the

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -222,9 +222,11 @@ server check exactly.
 - Manual workspace refresh schedules asynchronous validation for every cached
   key belonging to that workspace, whether or not the workspace currently has
   a local selection lease, even when provider refresh later fails. Workspace
-  responses and runtime readiness never wait on Git. Failure preserves the last-known-good snapshot;
-  preserving browser refreshes retry with capped, cancelable backoff while initial
-  loads still expose blocking errors (`packages/ui/src/stores/diff.svelte.ts::loadWorkspaceDiff`).
+  responses and runtime readiness never wait on Git. Failure preserves the
+  last-known-good snapshot; preserving browser refreshes retry with capped,
+  cancelable backoff only when retained files and diff share a snapshot version,
+  while cold loads expose blocking errors
+  (`packages/ui/src/stores/diff.svelte.ts::loadWorkspaceDiff`).
   A changed fingerprint publishes through `workspace_diff_changed` when ready.
   Watcher hints validate selected keys even inside the freshness interval;
   periodic validation makes stale snapshots eligible for refresh, while the
@@ -261,7 +263,10 @@ server check exactly.
 - Snapshot versions are opaque equality tokens. Clients may compare only for
   equality; ordering and replay position come from SSE event IDs, not from
   parsing the version or revision fields. A typed `snapshot_changed` preview
-  conflict reloads the coherent files/diff pair once and retries the preview.
+  conflict reloads the coherent files/diff pair once only while the preview's
+  captured load token and generation still own the store; stale preview work
+  fails without mutation
+  (`packages/ui/src/stores/diff.svelte.ts::loadWorkspaceFilePreview`).
 - Live worktree reads use Go's `os.Root` containment. Final symlinks are read as
   links, regular files are identity-checked across the open, and intermediate
   symlinks may resolve only within the worktree. Untracked patch reads and

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -223,10 +223,12 @@ server check exactly.
   key belonging to that workspace, whether or not the workspace currently has
   a local selection lease, even when provider refresh later fails. Workspace
   responses and runtime readiness never wait on Git. Failure preserves the last-known-good snapshot;
-  a later request or signal retries, and a changed fingerprint publishes through
-  `workspace_diff_changed` when ready. Watcher hints validate selected keys even
-  inside the freshness interval; periodic validation makes stale snapshots
-  eligible for refresh, while the bounded queue is not a hard completion deadline
+  preserving browser refreshes retry with capped, cancelable backoff while initial
+  loads still expose blocking errors (`packages/ui/src/stores/diff.svelte.ts::loadWorkspaceDiff`).
+  A changed fingerprint publishes through `workspace_diff_changed` when ready.
+  Watcher hints validate selected keys even inside the freshness interval;
+  periodic validation makes stale snapshots eligible for refresh, while the
+  bounded queue is not a hard completion deadline
   (`internal/server/server.go::notifyWorktreeStatsChanged`). One background worker
   serializes proactive validation; foreground cold reads bypass that queue.
 - The 128 MiB inactive-cache budget evicts least-recently-used inactive

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -189,19 +189,83 @@ server check exactly.
 
 ## Diff Snapshot Coherence
 
-- Files, patches, and previews must project from one immutable snapshot; clients
-  pin `/diff` to the `/files` revision and retry a revision conflict atomically
+- Files and patches project from one immutable snapshot. Preview membership is
+  revision-pinned too, but new-side bytes remain live and may move afterward
   (`internal/server/workspace_diff_cache.go::workspaceDiffCache`).
-- Cache entries are stale-while-revalidate with last-known-good fallback. Only
-  selected workspaces receive proactive refresh leases; ordinary entries validate
-  on demand so background Git work scales with active UI use
+- Cache entries are stale-while-revalidate with last-known-good fallback.
+  `jellydator/ttlcache/v3` owns entry storage, TTL expiration, and inactive-entry
+  cost pressure through separate protected and cost-limited pools; middleman's
+  wrapper owns snapshot coherence, bounded validation, selection leases, and
+  publication. Only selected workspaces
+  receive proactive refresh leases; ordinary entries validate on demand
   (`internal/server/server.go::streamEvents`).
+- A local workspace becomes selected through its scoped SSE stream. The server
+  subscribes that stream before acquiring the selection lease, then emits
+  `workspace_diff_ready` only when cold/coalesced default-HEAD preparation
+  completes; a warm cache hit needs no readiness event. This ordering prevents
+  fast preparation from racing ahead of the selecting browser.
+- Fleet selection uses `/workspaces/{id}/diff/watch` through the fleet proxy to
+  hold the remote lease, prewarm HEAD, and relay opaque versions. Switching
+  aborts and replaces the watch, so only the selected remote workspace refreshes
+  (`internal/server/huma_routes.go::watchWorkspaceDiff`). Empty or foreign
+  tokens return `changed=true`; matches wait 25 seconds and timeout unchanged.
+  A `409` while the workspace is still being created is transient and the client
+  retries it with the normal watch backoff; unsupported watch responses remain
+  terminal and fall back to request-driven diff loading.
+- Workspace switching keeps runtime and shell reads on their own critical path.
+  The previous sidebar is replaced immediately by a neutral placeholder. The
+  new diff panel mounts after matching workspace metadata and either matching
+  runtime state or a terminal runtime error, so a runtime API failure cannot
+  leave workspace details hidden forever. Panel cancellation uses a per-load
+  token in addition to workspace identity: cleanup from an older same-workspace
+  load must not abort its replacement.
+- Manual workspace refresh schedules asynchronous validation for every cached
+  key belonging to that workspace, whether or not the workspace currently has
+  a local selection lease, even when provider refresh later fails. Workspace
+  responses and runtime readiness never wait on Git. Failure preserves the last-known-good snapshot;
+  a later request or signal retries, and a changed fingerprint publishes through
+  `workspace_diff_changed` when ready. Watcher hints validate selected keys even
+  inside the freshness interval; periodic validation makes stale snapshots
+  eligible for refresh, while the bounded queue is not a hard completion deadline
+  (`internal/server/server.go::notifyWorktreeStatsChanged`). One background worker
+  serializes proactive validation; foreground cold reads bypass that queue.
+- The 128 MiB inactive-cache budget evicts least-recently-used inactive
+  entries, never active snapshots. A newly published snapshot has a one-minute
+  files/diff revision lease so an oversized `/files` response cannot evict
+  itself before its pinned `/diff` read. Selected keys stop being protected
+  after 10 minutes without access. Selected and pair-retained snapshots have
+  zero eviction cost and may temporarily put the total working set above the
+  inactive-cache budget
+  (`internal/server/workspace_diff_cache.go::maintainLocked`).
 - Publishing a dirty-worktree snapshot requires matching before/after resolved
-  refs and fingerprints; repository-local attributes are fingerprint inputs
-  (`internal/workspace/diff_snapshot.go::PrepareDiffSnapshot`).
+  refs and fingerprints; repository-local attributes are fingerprint inputs.
+  Commit/range generated-file checks use the resolved head commit as the Git
+  attribute source, while live worktree snapshots intentionally use worktree
+  attributes (`internal/workspace/diff_snapshot.go::PrepareDiffSnapshot`).
 - Whitespace-only classification is post-processing over aggregate Git output;
   raw mode/type changes remain substantive even when content differs only in
-  whitespace (`internal/workspace/diff_whitespace.go::classifyWhitespaceOnly`).
+  whitespace. Ambiguous multi-hunk files compare complete old/new record
+  sequences in Go. One batch Git process streams old blobs into ordered
+  whitespace-normalized record digests, keeping memory bounded without per-file
+  subprocesses (`internal/workspace/diff_whitespace.go::readWhitespaceBlobDigests`).
+- Untracked-file content is required for binary detection, line totals, and
+  synthetic patches, but snapshot preparation does not read an unbounded path
+  list serially. Tracked/untracked fingerprint hashing and untracked patch
+  construction share one file-read budget sized from the Go runtime's host
+  parallelism at process start, so cache validation cannot multiply I/O
+  concurrency. Results retain path order and cancellation propagates between
+  files and read chunks
+  (`internal/workspace/diff.go::untrackedReadPool.run`).
+- Snapshot versions are opaque equality tokens. Clients may compare only for
+  equality; ordering and replay position come from SSE event IDs, not from
+  parsing the version or revision fields. A typed `snapshot_changed` preview
+  conflict reloads the coherent files/diff pair once and retries the preview.
+- Live worktree reads use Go's `os.Root` containment. Final symlinks are read as
+  links, regular files are identity-checked across the open, and intermediate
+  symlinks may resolve only within the worktree. Untracked patch reads and
+  fingerprints use the same rooted opens, reject non-regular files, and remain
+  cancellable while hashing; cached diff membership never authorizes traversal
+  (`internal/workspace/diff_snapshot.go::fingerprintWorktreePath`).
 
 ## Branch Upstream
 

--- a/docs/superpowers/plans/2026-07-17-selected-workspace-diff-loading.md
+++ b/docs/superpowers/plans/2026-07-17-selected-workspace-diff-loading.md
@@ -6,7 +6,7 @@
 
 **Architecture:** Resolve each request into a logical key plus a Git/content fingerprint. The logical key carries workspace/path/base/scope/whitespace identity; the physical cache revision adds resolved base/head OIDs and the dirty-content digest, satisfying the resolved-base key invariant without forcing fresh validation on every warm read. A server-owned stale-while-revalidate cache stores the complete gitclone.DiffResult and a patch-free file projection, coalesces preparation, and validates only workspaces leased by the terminal SSE connection. Ordinary whitespace-only classification moves from one git diff -w subprocess per path to a Go implementation of Git xdiff record equivalence; explicit hide-whitespace patches remain aggregate Git -w output.
 
-**Tech Stack:** Go 1.25, Git CLI through go.kenn.io/kit/git/cmd, golang.org/x/sync/singleflight, OpenTelemetry, Huma/OpenAPI, Svelte 5 runes, Vite+ Vitest.
+**Tech Stack:** Go 1.26, Git CLI through go.kenn.io/kit/git/cmd, golang.org/x/sync/singleflight, OpenTelemetry, Huma/OpenAPI, Svelte 5 runes, Vite+ Vitest.
 
 ## Global Constraints
 
@@ -15,7 +15,9 @@
 - Use Git xdiff's ASCII C-locale whitespace set: space, tab, newline, vertical tab, form feed, and carriage return.
 - Keep file previews as separate bounded reads; never store preview contents in the snapshot cache.
 - Use a 15-second selected validation interval, a 10-minute inactivity TTL, and a 128 MiB approximate-byte ceiling. These are internal constants, not new configuration.
+- Treat 15 seconds as the validation max-age for every entry. Unselected entries validate on demand after that age; selected entries also validate proactively.
 - Replace a cached value only when fingerprints taken before and after preparation match. A failure never replaces the last-known-good snapshot.
+- Return an opaque cache-generation/revision token from both projections and let `/diff` require the `/files` token so replacements between requests cannot mix revisions.
 - Do not add go-git or another cache dependency; use the hardened Git wrapper, stdlib, and the existing x/sync/singleflight dependency.
 - Apply kenn-test-scope-discipline:test-scope-discipline before tests. Test middleman-owned logic, not Git/Go/Svelte library behavior.
 - Apply svelte-code-writer and svelte-core-bestpractices before Svelte edits. Run vp exec svelte-mcp svelte-autofixer on every changed Svelte file.
@@ -204,7 +206,7 @@ Normalize WorktreePath with filepath.Abs and filepath.Clean. Commit/range uses F
 
 - [ ] **Step 4: Implement the content fingerprint**
 
-Hash a versioned stream containing normalized path, resolved OIDs, mode flags, aggregate git diff --raw -z --no-renames metadata, and git ls-files --others --exclude-standard -z when untracked files participate. For each current worktree path in those sets, append lstat mode plus symlink target or streamed regular-file bytes. Encode missing/deleted state explicitly. Commit/range snapshots use immutable resolved OIDs.
+Hash a versioned stream containing normalized path, freshly resolved OIDs, mode flags, aggregate git diff --raw -z --no-renames metadata, repository-local `.git/info/attributes`, and git ls-files --others --exclude-standard -z when untracked files participate. For each current worktree path in those sets, append lstat mode plus symlink target or a content digest. Cache content digests by strong stat identity so unchanged large files are not reread on every validation. Encode missing/deleted state explicitly. Commit/range snapshots use immutable resolved OIDs.
 
 Do not use addition/deletion totals as identity.
 
@@ -214,7 +216,7 @@ PrepareDiffSnapshot calls the aggregate ref preparer from Task 1. ReadDiffSnapsh
 
 - [ ] **Step 6: Test movement during preparation**
 
-Use a narrow unexported test hook restored with t.Cleanup to edit a file between before/after fingerprints. Assert the fingerprints differ so the server can reject publication. Do not add retry machinery to the workspace package.
+Use a narrow unexported test hook restored with t.Cleanup to edit a file or move a ref between before/after fingerprints. Re-resolve the logical spec after preparation and assert the resolved OIDs or fingerprints differ so the server can reject publication. Document boundary comparison as best-effort movement detection, not a transactional filesystem snapshot. Do not add retry machinery to the workspace package.
 
 - [ ] **Step 7: Run and commit**
 
@@ -283,13 +285,15 @@ Build Files by copying each DiffFile, clearing Patch, and replacing Hunks with a
 
 Fresh returns synchronously. Expired last-known-good returns a clone marked stale and schedules validation. A cold miss waits. Shared work runs under the cache root context and callers wait via singleflight.DoChan so one canceled request does not cancel other waiters.
 
-Stable publication is:
+Stable publication re-resolves the logical spec on both sides of preparation:
 
 ~~~go
-before := fingerprint(resolved)
-result := prepare(resolved)
-after := fingerprint(resolved)
-if before != after {
+beforeResolved := resolve(logicalSpec)
+before := fingerprint(beforeResolved)
+result := prepare(beforeResolved) // exclusively from resolved OIDs
+afterResolved := resolve(logicalSpec)
+after := fingerprint(afterResolved)
+if beforeResolved.OIDs != afterResolved.OIDs || before != after {
 	return errWorkspaceDiffMovedDuringPreparation
 }
 publish(result, after)
@@ -299,9 +303,9 @@ Preparation errors or movement never replace last-known-good or emit an event.
 
 - [ ] **Step 5: Implement selected-only validation and eviction**
 
-Select refcounts workspace IDs. First lease resolves/prewarms default HEAD and starts one 15-second loop. MarkActive changes the selected workspace's validated key to the latest requested base/scope/whitespace key. Final release cancels the loop but retains entries.
+Select refcounts workspace IDs. First lease resolves/prewarms default HEAD and starts one 15-second loop. MarkActive retains every recently requested base/scope/whitespace key for a selected workspace, so concurrent tabs cannot overwrite each other's validation target. Final release cancels the loop but retains entries.
 
-ValidateSelected debounces prompt validation for selected active keys. After publish/access, evict entries idle for 10 minutes, then LRU inactive entries until at most 128 MiB. Selected entries are last-resort eviction candidates.
+ValidateSelected debounces prompt validation for selected active keys and backs off repeated failures. After publish/access, evict entries idle for 10 minutes, then LRU inactive entries until at most 128 MiB. Actively leased keys are pinned and never eviction candidates.
 
 - [ ] **Step 6: Add trace data**
 
@@ -341,7 +345,7 @@ Through httptest.Server, open a scoped stream, wait for one lease/default HEAD p
 {"workspace_id":"ws-1","revision":2}
 ~~~
 
-Using existing workspace API fixtures plus an injected counting preparer, request /files then /diff and assert one preparation with identical file/count identity. Concurrent requests coalesce. A path request after whole-snapshot preparation filters without preparation. Retain existing preview/path-safety tests.
+Using existing workspace API fixtures plus an injected counting preparer, request /files then /diff and assert one preparation with identical file/count identity. Concurrent requests coalesce. A path request after whole-snapshot preparation filters without preparation. Retain existing preview/path-safety tests. Add one real HTTP + SQLite + temporary-Git-worktree e2e scenario that makes a same-size edit, validates it, observes `workspace_diff_changed`, and reads the replacement.
 
 - [ ] **Step 2: Prove the tests fail**
 
@@ -357,7 +361,7 @@ Add workspaceDiffCache *workspaceDiffCache. Construct it after bgCtx/workspace m
 
 - [ ] **Step 4: Route all workspace reads through the snapshot**
 
-Convert workspaceDiffRequest to workspaceDiffLogicalKey after current scope validation. /files returns snapshot.Files; /diff returns snapshot.Diff.Files; both use the same whitespace count/stale state. Path-scoped /diff filters an exact Path or OldPath match from a copy. /file-preview selects membership from the snapshot then calls workspace.ReadDiffSnapshotFile.
+Convert workspaceDiffRequest to workspaceDiffLogicalKey after current scope validation. /files returns snapshot.Files; /diff returns snapshot.Diff.Files; both use the same whitespace count/stale state and opaque generation/revision token. `/diff?revision=` rejects a token mismatch so the client restarts both reads instead of publishing mixed revisions. Path-scoped /diff filters an exact Path or OldPath match from a copy. /file-preview selects membership from the snapshot then calls workspace.ReadDiffSnapshotFile.
 
 Preserve workspaceDiffBaseUnavailable and current cold-failure problem envelopes.
 
@@ -416,7 +420,7 @@ The body explains that /files prepares the whole snapshot, /diff is a projection
 
 - [ ] **Step 1: Add failing stale-visible store tests**
 
-Load snapshot A. Start a preserving refresh with deferred files/diff. Assert A remains visible. Resolve files B only and assert A remains coherent. Resolve diff B and assert both projections switch together. Reject refresh and assert A remains while getDiffError records failure.
+Load snapshot A. Start a preserving refresh with deferred files/diff. Assert A remains visible. Resolve files B only and assert A remains coherent. Resolve diff B with the pinned revision and assert both projections switch together. Simulate a revision mismatch and assert the pair retries rather than mixing. Reject refresh and assert A remains while getDiffError records failure.
 
 ~~~ts
 const refresh = store.loadWorkspaceDiff("ws-1", "head", false, {
@@ -444,7 +448,7 @@ Capture EventSource URLs/listeners. Assert local ws-1 opens events?workspace_id=
 
 - [ ] **Step 5: Thread a diff-only revision**
 
-Add diffSnapshotRevision state in WorkspaceTerminalView. Defensively parse the event, require the matching local ID and a newer numeric revision, then assign it. Pass it separately from sidebarRefreshToken so PR/issue/review panels do not redraw.
+Add diffSnapshotRevision state in WorkspaceTerminalView. Defensively parse the event, require the matching local ID and a changed opaque generation/revision token, then assign it. On `reconnect.stale`, trigger the same preserving diff refresh. Pass it separately from sidebarRefreshToken so PR/issue/review panels do not redraw.
 
 Add the prop through WorkspaceRightSidebar to WorkspaceDiffPanel. The panel key includes general refresh and diff revision. preserveVisible is true only when workspace/base identity is unchanged and the diff revision advanced. refreshCommits remains tied to manual/general refresh, not background diff replacement.
 
@@ -520,7 +524,7 @@ Expected: PASS with only intentional generated artifacts.
 
 - [ ] **Step 5: Measure the profiled live workspace**
 
-For workspace 539fb58f99084088, record cold/warm HEAD and merge-target /files then /diff spans. Verify cold preparation uses constant aggregate Git commands; following /diff is a hit with no Git work; unchanged selected validation fingerprints only; a real edit produces one replacement/event; warm latency is transfer/serialization rather than Git.
+For workspace 539fb58f99084088 and a checked-in synthetic 128-file benchmark fixture, record cold/warm HEAD and merge-target /files then /diff spans. Verify cold preparation uses constant aggregate Git commands; following /diff is a hit with no Git work; unchanged selected validation fingerprints only; a real edit produces one replacement/event; warm latency is transfer/serialization rather than Git. Record cold latency, warm lookup latency, validation duration, subprocess count, and bytes hashed so future runs are comparable.
 
 If any named cold phase remains multi-second, investigate/fix it before completion instead of hiding it with cache warmth.
 

--- a/docs/superpowers/plans/2026-07-17-selected-workspace-diff-loading.md
+++ b/docs/superpowers/plans/2026-07-17-selected-workspace-diff-loading.md
@@ -6,11 +6,13 @@
 
 **Architecture:** Resolve each request into a logical key plus a Git/content fingerprint. The logical key carries workspace/path/base/scope/whitespace identity; the physical cache revision adds resolved base/head OIDs and the dirty-content digest, satisfying the resolved-base key invariant without forcing fresh validation on every warm read. A server-owned stale-while-revalidate cache stores the complete gitclone.DiffResult and a patch-free file projection, coalesces preparation, and validates only workspaces leased by the terminal SSE connection. Ordinary whitespace-only classification moves from one git diff -w subprocess per path to a Go implementation of Git xdiff record equivalence; explicit hide-whitespace patches remain aggregate Git -w output.
 
-**Tech Stack:** Go 1.26, Git CLI through go.kenn.io/kit/git/cmd, golang.org/x/sync/singleflight, OpenTelemetry, Huma/OpenAPI, Svelte 5 runes, Vite+ Vitest.
+**Tech Stack:** Go 1.26, Git CLI through go.kenn.io/kit/git/cmd, jellydator/ttlcache/v3, golang.org/x/sync/singleflight, OpenTelemetry, Huma/OpenAPI, Svelte 5 runes, Vite+ Vitest.
 
 ## Global Constraints
 
-- Proactively prepare and validate only a local workspace selected through the terminal view's scoped SSE connection; fleet workspaces remain request-driven.
+- Proactively prepare and validate only a terminal-selected workspace: local
+  selection uses scoped SSE and fleet selection holds a long-poll lease on the
+  owning member.
 - Preserve current /files, /diff, and /file-preview response shapes, base/scope semantics, rename/copy detection, --find-copies-harder, untracked files, generated attributes, path safety, and explicit Git -w hunk behavior.
 - Use Git xdiff's ASCII C-locale whitespace set: space, tab, newline, vertical tab, form feed, and carriage return.
 - Keep file previews as separate bounded reads; never store preview contents in the snapshot cache.
@@ -18,7 +20,9 @@
 - Treat 15 seconds as the validation max-age for every entry. Unselected entries validate on demand after that age; selected entries also validate proactively.
 - Replace a cached value only when fingerprints taken before and after preparation match. A failure never replaces the last-known-good snapshot.
 - Return an opaque cache-generation/revision token from both projections and let `/diff` require the `/files` token so replacements between requests cannot mix revisions.
-- Do not add go-git or another cache dependency; use the hardened Git wrapper, stdlib, and the existing x/sync/singleflight dependency.
+- Do not add go-git. Use the hardened Git wrapper for Git behavior,
+  `jellydator/ttlcache/v3` for TTL/LRU/cost lifecycle, and the existing
+  x/sync/singleflight dependency for cancellable error-returning preparation.
 - Apply kenn-test-scope-discipline:test-scope-discipline before tests. Test middleman-owned logic, not Git/Go/Svelte library behavior.
 - Apply svelte-code-writer and svelte-core-bestpractices before Svelte edits. Run vp exec svelte-mcp svelte-autofixer on every changed Svelte file.
 - Apply the mandatory commit-push-pr:commit skill before every commit. Never amend and never bypass hooks.
@@ -277,13 +281,17 @@ Expected: FAIL because workspaceDiffCache is undefined.
 
 - [ ] **Step 3: Implement storage and projections**
 
-Use a mutex-protected logical-entry map, physical fingerprint/revision per entry, monotonic revision counter, timestamps, and singleflight.Group. Approximate bytes by summing patch/path/status/hunk/line strings; never JSON-marshal on the request path.
+Use `jellydator/ttlcache/v3` for logical-entry storage and TTL expiration. Keep
+protected-entry cost pressure, physical fingerprint/revision state,
+selected/pair-retention protection, stable publication, and
+`singleflight.Group` in the workspace coordinator. Approximate bytes by summing
+patch/path/status/hunk/line strings; never JSON-marshal on the request path.
 
 Build Files by copying each DiffFile, clearing Patch, and replacing Hunks with an empty non-nil slice.
 
 - [ ] **Step 4: Implement hit/stale/miss and stable replacement**
 
-Fresh returns synchronously. Expired last-known-good returns a clone marked stale and schedules validation. A cold miss waits. Shared work runs under the cache root context and callers wait via singleflight.DoChan so one canceled request does not cancel other waiters.
+Fresh returns synchronously. Expired last-known-good returns a clone marked stale and schedules validation. A cold miss waits. Shared work runs under a cache-owned 30-second context and callers wait via singleflight.DoChan, so a five-second validator or canceled request does not cancel other waiters.
 
 Stable publication re-resolves the logical spec on both sides of preparation:
 
@@ -305,7 +313,12 @@ Preparation errors or movement never replace last-known-good or emit an event.
 
 Select refcounts workspace IDs. First lease resolves/prewarms default HEAD and starts one 15-second loop. MarkActive retains every recently requested base/scope/whitespace key for a selected workspace, so concurrent tabs cannot overwrite each other's validation target. Final release cancels the loop but retains entries.
 
-ValidateSelected debounces prompt validation for selected active keys and backs off repeated failures. After publish/access, evict entries idle for 10 minutes, then LRU inactive entries until at most 128 MiB. Actively leased keys are pinned and never eviction candidates.
+ValidateSelected debounces prompt validation for selected active keys and queues
+it through one background worker; that worker remains attached until
+cache-owned preparation completes. A failed initial prewarm retries every five
+seconds for the life of the selection. Preserve active scopes across watch
+reconnects, prune them after 10 idle minutes, then evict inactive entries by LRU
+toward 128 MiB while skipping active and one-minute pair-retained snapshots.
 
 - [ ] **Step 6: Add trace data**
 
@@ -381,7 +394,7 @@ notifyWorktreeStatsChanged calls workspaceDiffCache.ValidateSelected before broa
 
 - [ ] **Step 6: Broadcast only stable replacements**
 
-On a changed stable replacement broadcast workspace_diff_changed with WorkspaceID and Revision. Emit nothing for equal validation, initial cold population, failure, or concurrent movement.
+On a changed stable replacement broadcast workspace_diff_changed with WorkspaceID and Revision. This replacement callback emits nothing for equal validation, initial cold population, failure, or concurrent movement; Task 7 adds a separate selected-prewarm readiness event.
 
 - [ ] **Step 7: Regenerate and verify**
 
@@ -444,7 +457,7 @@ Do not add shared reactive pending payloads; one invocation and existing generat
 
 - [ ] **Step 4: Add failing terminal selection/event tests**
 
-Capture EventSource URLs/listeners. Assert local ws-1 opens events?workspace_id=ws-1; fleet member/ws-1 remains unscoped; another workspace event does nothing; a strictly newer matching revision triggers only diff refresh; replaying the same revision does not duplicate work.
+Capture EventSource URLs/listeners. Assert local ws-1 opens events?workspace_id=ws-1; fleet member/ws-1 remains unscoped; another workspace event does nothing; a different matching opaque version triggers only diff refresh; replaying the same version does not duplicate work. SSE event IDs, not revision values, own ordering.
 
 - [ ] **Step 5: Thread a diff-only revision**
 
@@ -548,6 +561,91 @@ The body explains why selected-only validation and last-known-good publication m
 
 ---
 
+### Task 7: Give workspace runtime priority over sidebar diff work
+
+**Files:**
+- Modify: `frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte`
+- Modify: `frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts`
+- Modify: `frontend/tests/e2e-full/00-workspace-tab-persistence.spec.ts`
+- Modify: `packages/ui/src/components/workspace/WorkspaceDiffPanel.svelte`
+- Modify: `packages/ui/src/stores/diff.svelte.ts`
+- Modify: `frontend/src/lib/stores/diff.svelte.test.ts`
+- Modify: `internal/server/workspace_diff_cache.go`
+- Modify: `internal/server/workspace_diff_cache_test.go`
+- Modify: `internal/server/server.go`
+- Modify: `internal/server/api_test.go`
+
+**Interfaces:**
+- Consumes: current route identity, `runtimeLive`, and the diff store's current workspace identity.
+- Produces: `cancelWorkspaceDiff(workspaceID, workspaceHostKey?, loadToken?)`, an identity- and invocation-scoped abort that cannot cancel a newer same-workspace load.
+- Produces: a monotonic workspace-load generation checked after every await, including commit refresh.
+- Produces: selected-prewarm `workspace_diff_ready` SSE payload `{workspace_id, revision, version}`.
+
+- [ ] **Step 1: Add failing transition and cancellation tests**
+
+In `WorkspaceTerminalView.test.ts`, keep workspace A unresolved after selecting B and assert A's PR/diff content is absent, a `Loading workspace details...` placeholder is visible, and the B diff request does not start until both B workspace and runtime responses apply. Also reject B's runtime request and assert matching B workspace details become usable instead of leaving the sidebar spinner forever. Deliver `workspace_diff_ready` before runtime resolves and assert it is retained without starting a browser diff request. In `diff.svelte.test.ts`, start A, start B, then call `cancelWorkspaceDiff("A")`; assert B is not aborted or cleared. Start two same-workspace loads and prove cleanup from the first token cannot abort the second. Also cancel A while its commit refresh is unresolved, resolve that request, and assert the stale invocation cannot start files/diff requests afterward.
+
+- [ ] **Step 2: Run focused tests to verify they fail**
+
+~~~bash
+./node_modules/.bin/vp test frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts frontend/src/lib/stores/diff.svelte.test.ts
+~~~
+
+Expected: FAIL because stale sidebar content remains mounted and no identity-scoped cancellation API exists.
+
+- [ ] **Step 3: Implement shell-first sidebar lifecycle**
+
+Render the right-sidebar frame whenever it is open, but render `WorkspaceRightSidebar` only when the loaded workspace identity matches the route and runtime loading has either produced matching state or settled with an error. Render a neutral spinner with `Loading workspace details...` during the transition. Do not clear the previous workspace/runtime objects because the workflow pane intentionally remains stable.
+
+Add a monotonic workspace-load generation and an invocation token to the diff store and capture them at the start of every load. `cancelWorkspaceDiff(workspaceID, workspaceHostKey?, loadToken?)` returns without mutation unless the supplied identity and, when present, token equal the current load; on a match it advances the generation, aborts both controllers, and clears only workspace diff loading state. Check identity and generation after every await and in every rejection path, including `loadCommits`, and before starting each request. Track the active invocation outside the reactive load key and cancel it explicitly on identity change, deactivation, or component destroy. Do not return cancellation directly from the load effect: that effect updates `loadedKey`, so its own rerun would abort the request it just started.
+
+- [ ] **Step 4: Emit readiness after selected server prewarm**
+
+Add a selected-prewarm callback distinct from ordinary cache replacement. Register the event-hub subscriber synchronously before acquiring the selection lease and starting prewarm; only then enter the SSE serve loop. In `workspaceDiffCache.Select`, when the first lease's `Get` publishes or coalesces a cold default-HEAD snapshot, invoke the callback with its revision/version. `Server` broadcasts `workspace_diff_ready`; cached hits, failures, unselected cold requests, and normal validation do not emit it. Keep `workspace_diff_changed` for replacement of an existing fingerprint. The client treats versions as opaque equality tokens; SSE event IDs, not version strings, own event ordering and replay.
+
+Add cache and wire-level SSE tests proving one ready event follows successful first-selection cold preparation, no event follows failure/hit, and the payload is scoped to the selected workspace. The wire test must let prewarm complete immediately and prove the first selecting client receives readiness, guarding subscriber-before-lease ordering.
+
+- [ ] **Step 5: Run Svelte analysis and focused tests**
+
+~~~bash
+./node_modules/.bin/vp exec svelte-mcp svelte-autofixer frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte --svelte-version 5
+./node_modules/.bin/vp exec svelte-mcp svelte-autofixer packages/ui/src/components/workspace/WorkspaceDiffPanel.svelte --svelte-version 5
+(cd frontend && ../node_modules/.bin/vp test src/lib/components/terminal/WorkspaceTerminalView.test.ts src/lib/stores/diff.svelte.test.ts)
+~~~
+
+Expected: no new actionable autofixer issue; tests PASS.
+
+- [ ] **Step 6: Run backend tests**
+
+~~~bash
+go test ./internal/server -run 'TestWorkspaceDiffCache|TestWorkspaceDiffSelectionLease' -shuffle=on
+~~~
+
+Expected: PASS.
+
+- [ ] **Step 7: Run the complete frontend suite and capture the transition**
+
+~~~bash
+(cd frontend && ../node_modules/.bin/vp test)
+make frontend-check
+make frontend
+(cd frontend && node ./scripts/run-e2e-to-file.ts 00-workspace-tab-persistence.spec.ts --project=chromium)
+~~~
+
+Add a seeded full-stack scenario that opens workspace A, switches to B while B's workspace/runtime responses are gated, and observes the real EventSource. Assert A's sidebar disappears immediately, early B readiness does not start a browser diff, and B's diff request starts only after matching workspace/runtime data apply. Expected: PASS. Capture the same neutral transition from this scenario without exposing a live workspace.
+
+- [ ] **Step 8: Commit and update the existing PR**
+
+~~~bash
+git add frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts frontend/tests/e2e-full/00-workspace-tab-persistence.spec.ts packages/ui/src/components/workspace/WorkspaceDiffPanel.svelte packages/ui/src/stores/diff.svelte.ts frontend/src/lib/stores/diff.svelte.test.ts internal/server/workspace_diff_cache.go internal/server/workspace_diff_cache_test.go internal/server/server.go internal/server/api_test.go
+git commit -m "fix: prioritize workspace runtime during switches"
+git push
+~~~
+
+The body records that old diff response parsing must never compete with readiness of the newly selected workspace shell.
+
+---
+
 ## Final Acceptance Checklist
 
 - [ ] A 128-file merge-target cold load performs no per-file Git subprocess loop.
@@ -555,7 +653,9 @@ The body explains why selected-only validation and last-known-good publication m
 - [ ] Warm selected-workspace requests perform no Git diff work.
 - [ ] Unchanged validation performs no recomputation and emits no event.
 - [ ] Same-total content edits are detected; concurrent edits cannot publish a torn snapshot.
-- [ ] Only local terminal selections receive proactive work; inactive/fleet workspaces stay request-driven.
-- [ ] Cache is bounded by 10-minute inactivity and 128 MiB approximate bytes with last-known-good after failures.
+- [ ] Only terminal selections receive proactive work; fleet selection is leased on the owning member and inactive workspaces stay request-driven.
+- [ ] Cache prunes active keys after 10 minutes without access and evicts inactive entries toward a 128 MiB approximate-byte target while preserving last-known-good after failures.
 - [ ] Matching workspace_diff_changed refreshes only the diff panel without blanking.
+- [ ] Switching workspace identity removes the old sidebar immediately, aborts its diff load, and starts the new diff only after runtime readiness.
+- [ ] Selected default-HEAD preparation begins immediately and emits one readiness event without putting browser diff parsing on the shell critical path.
 - [ ] Focused, full affected, race, Svelte analysis, generated-contract, lint, build, and context-sync checks pass.

--- a/docs/superpowers/plans/2026-07-17-selected-workspace-diff-loading.md
+++ b/docs/superpowers/plans/2026-07-17-selected-workspace-diff-loading.md
@@ -1,0 +1,557 @@
+# Selected Workspace Diff Loading Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make selected local workspace diffs load from a prepared, bounded snapshot while reducing the cold path to aggregate Git work and recomputing only after resolved refs or changed contents move.
+
+**Architecture:** Resolve each request into a logical key plus a Git/content fingerprint. The logical key carries workspace/path/base/scope/whitespace identity; the physical cache revision adds resolved base/head OIDs and the dirty-content digest, satisfying the resolved-base key invariant without forcing fresh validation on every warm read. A server-owned stale-while-revalidate cache stores the complete gitclone.DiffResult and a patch-free file projection, coalesces preparation, and validates only workspaces leased by the terminal SSE connection. Ordinary whitespace-only classification moves from one git diff -w subprocess per path to a Go implementation of Git xdiff record equivalence; explicit hide-whitespace patches remain aggregate Git -w output.
+
+**Tech Stack:** Go 1.25, Git CLI through go.kenn.io/kit/git/cmd, golang.org/x/sync/singleflight, OpenTelemetry, Huma/OpenAPI, Svelte 5 runes, Vite+ Vitest.
+
+## Global Constraints
+
+- Proactively prepare and validate only a local workspace selected through the terminal view's scoped SSE connection; fleet workspaces remain request-driven.
+- Preserve current /files, /diff, and /file-preview response shapes, base/scope semantics, rename/copy detection, --find-copies-harder, untracked files, generated attributes, path safety, and explicit Git -w hunk behavior.
+- Use Git xdiff's ASCII C-locale whitespace set: space, tab, newline, vertical tab, form feed, and carriage return.
+- Keep file previews as separate bounded reads; never store preview contents in the snapshot cache.
+- Use a 15-second selected validation interval, a 10-minute inactivity TTL, and a 128 MiB approximate-byte ceiling. These are internal constants, not new configuration.
+- Replace a cached value only when fingerprints taken before and after preparation match. A failure never replaces the last-known-good snapshot.
+- Do not add go-git or another cache dependency; use the hardened Git wrapper, stdlib, and the existing x/sync/singleflight dependency.
+- Apply kenn-test-scope-discipline:test-scope-discipline before tests. Test middleman-owned logic, not Git/Go/Svelte library behavior.
+- Apply svelte-code-writer and svelte-core-bestpractices before Svelte edits. Run vp exec svelte-mcp svelte-autofixer on every changed Svelte file.
+- Apply the mandatory commit-push-pr:commit skill before every commit. Never amend and never bypass hooks.
+
+---
+
+## File Structure
+
+- Create internal/workspace/diff_whitespace.go and diff_whitespace_test.go for Git-compatible record comparison and parsed-diff classification.
+- Create internal/workspace/diff_snapshot.go and diff_snapshot_test.go for resolved inputs, ref/content fingerprinting, stable full preparation, and direct preview reads.
+- Modify internal/workspace/diff.go so public workspace diff entry points share aggregate preparation and never classify with one subprocess per path.
+- Create internal/server/workspace_diff_cache.go and workspace_diff_cache_test.go for bounded SWR storage, single-flight work, selection leases, and validators.
+- Modify internal/server/server.go, huma_routes.go, and fleet_worktree_links.go to own the cache, route APIs through it, lease selection through SSE, and consume stats-change hints.
+- Modify internal/server/server_test.go and api_test.go for wire/API behavior.
+- Regenerate Huma OpenAPI and generated clients with make api-generate.
+- Modify packages/ui/src/stores/diff.svelte.ts and its frontend test for stale-visible atomic replacement.
+- Modify WorkspaceTerminalView.svelte, WorkspaceRightSidebar.svelte, WorkspaceDiffPanel.svelte, and focused tests for scoped selection and diff-only refresh.
+- Modify context/workspace-apis.md with the final invariants.
+
+---
+
+### Task 1: Port Git xdiff whitespace equivalence and remove the per-file subprocess loop
+
+**Files:**
+- Create: internal/workspace/diff_whitespace.go
+- Create: internal/workspace/diff_whitespace_test.go
+- Modify: internal/workspace/diff.go:95-168,240-352,889-943
+- Test: internal/workspace/diff_test.go
+
+**Interfaces:**
+- Consumes: parsed gitclone.DiffFile, Hunk, and Line values from one ordinary aggregate patch.
+- Produces: classifyWhitespaceOnly(files []gitclone.DiffFile) int and gitWhitespaceRecordEqual(left, right string) bool.
+
+- [ ] **Step 1: Write failing record and file classification tests**
+
+Create table-driven tests for indentation, tabs, CR, vertical-tab/form-feed, blank-line insertion, missing final newline, repeated lines, mixed edits, multiple hunks, and status/binary guards.
+
+~~~go
+func TestGitWhitespaceRecordEqual(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name        string
+		left, right string
+		want        bool
+	}{
+		{name: "indentation", left: "\treturn value", right: "  return value", want: true},
+		{name: "vertical and form feed", left: "a\vb\fc", right: "abc", want: true},
+		{name: "substantive", left: "return old", right: "return new", want: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, gitWhitespaceRecordEqual(tt.left, tt.right))
+		})
+	}
+}
+~~~
+
+For file classification, construct modified parsed hunks and assert added, deleted, renamed, copied, and binary files remain non-whitespace-only.
+
+- [ ] **Step 2: Prove the new tests fail**
+
+Run:
+
+~~~bash
+go test ./internal/workspace -run 'TestGitWhitespaceRecordEqual|TestClassifyWhitespaceOnly' -shuffle=on
+~~~
+
+Expected: FAIL because both functions are undefined.
+
+- [ ] **Step 3: Implement exact byte-level record comparison**
+
+~~~go
+func isGitWhitespace(b byte) bool {
+	switch b {
+	case ' ', '\t', '\n', '\v', '\f', '\r':
+		return true
+	default:
+		return false
+	}
+}
+
+func gitWhitespaceRecordEqual(left, right string) bool {
+	i, j := 0, 0
+	for {
+		for i < len(left) && isGitWhitespace(left[i]) { i++ }
+		for j < len(right) && isGitWhitespace(right[j]) { j++ }
+		if i == len(left) || j == len(right) {
+			for i < len(left) && isGitWhitespace(left[i]) { i++ }
+			for j < len(right) && isGitWhitespace(right[j]) { j++ }
+			return i == len(left) && j == len(right)
+		}
+		if left[i] != right[j] { return false }
+		i++
+		j++
+	}
+}
+~~~
+
+hunkWhitespaceOnly rebuilds old/new records: context enters both sides, delete only old, add only new. It requires equal record counts and pairwise equality. Ignore NoNewline because -w compares record contents. classifyWhitespaceOnly considers only modified non-binary files, requires every changed hunk to pass, mutates only IsWhitespaceOnly, and returns the count.
+
+- [ ] **Step 4: Add Git-oracle parity cases**
+
+For each old/new byte fixture, create a temp repo, commit old, write new, parse the ordinary WorktreeDiff, and compare the Go flag with whether git diff --quiet -w -- path exits zero. Include CRLF, repeated lines, blank-line insertion, missing-final-newline, and mixed whitespace/substantive edits.
+
+If ordinary hunk reconstruction fails an oracle case, compare complete old/new record sequences obtained with one git cat-file --batch invocation plus Go worktree reads. Never add per-file Git calls.
+
+- [ ] **Step 5: Route aggregate preparation through the classifier**
+
+In worktreeDiffFromRefsPath, run raw, numstat, and patch once, parse the result, call classifyWhitespaceOnly in ordinary mode, and use its count. Explicit hide mode keeps aggregate Git -w raw/numstat/patch output and uses ordinary classification only for the count.
+
+Make WorktreeDiffFiles variants project metadata from the same full preparation by copying entries, setting Patch to empty, and setting Hunks to []gitclone.Hunk{}. Remove the production call path through worktreeWhitespaceOnlyFiles.
+
+Wrap the cold preparation phases in child spans named workspace.diff.git.raw, workspace.diff.git.numstat, workspace.diff.git.patch, workspace.diff.whitespace, workspace.diff.untracked, workspace.diff.generated_attributes, and workspace.diff.assemble. Spans carry counts/bytes only, never file paths or contents.
+
+- [ ] **Step 6: Run workspace regressions**
+
+~~~bash
+go test ./internal/workspace -run 'TestGitWhitespace|TestClassifyWhitespaceOnly|TestWorktreeDiff' -shuffle=on
+~~~
+
+Expected: PASS, including existing rename/copy, generated, untracked, preview, and hide-whitespace coverage selected by the pattern.
+
+- [ ] **Step 7: Commit**
+
+~~~bash
+git add internal/workspace/diff.go internal/workspace/diff_test.go internal/workspace/diff_whitespace.go internal/workspace/diff_whitespace_test.go
+git commit -m "perf: eliminate per-file workspace whitespace diffs"
+~~~
+
+The body explains that Git remains the aggregate patch authority while Go applies xdiff-compatible record equivalence, eliminating subprocess growth with file count.
+
+---
+
+### Task 2: Resolve, fingerprint, and stably prepare one complete workspace snapshot
+
+**Files:**
+- Create: internal/workspace/diff_snapshot.go
+- Create: internal/workspace/diff_snapshot_test.go
+- Modify: internal/workspace/diff.go
+
+**Interfaces:**
+
+~~~go
+type DiffSnapshotSpec struct {
+	WorktreePath      string
+	Base              WorktreeDiffBase
+	MergeTargetBranch string
+	FromSHA           string
+	ToSHA             string
+	HideWhitespace    bool
+}
+
+type ResolvedDiffSnapshotSpec struct {
+	DiffSnapshotSpec
+	BaseRef          string
+	HeadRef          string
+	BaseOID          string
+	HeadOID          string
+	IncludeUntracked bool
+}
+
+type DiffFingerprint string
+
+func ResolveDiffSnapshotSpec(context.Context, DiffSnapshotSpec) (ResolvedDiffSnapshotSpec, bool, error)
+func FingerprintDiffSnapshot(context.Context, ResolvedDiffSnapshotSpec) (DiffFingerprint, error)
+func PrepareDiffSnapshot(context.Context, ResolvedDiffSnapshotSpec) (*gitclone.DiffResult, error)
+func ReadDiffSnapshotFile(context.Context, ResolvedDiffSnapshotSpec, gitclone.DiffFile, string, int64) (*gitclone.FileContent, error)
+~~~
+
+- [ ] **Step 1: Write failing resolution/fingerprint tests**
+
+Test HEAD, pushed, merge-target, commit, and range resolution; stable unchanged fingerprints; same-size/same-line-count dirty edits; untracked content edits; and commit/range fingerprints that ignore unrelated dirty files.
+
+- [ ] **Step 2: Prove the tests fail**
+
+~~~bash
+go test ./internal/workspace -run 'TestResolveDiffSnapshotSpec|TestFingerprintDiffSnapshot' -shuffle=on
+~~~
+
+Expected: FAIL because the snapshot types/functions do not exist.
+
+- [ ] **Step 3: Implement verified ref resolution**
+
+Normalize WorktreePath with filepath.Abs and filepath.Clean. Commit/range uses FromSHA/ToSHA with IncludeUntracked=false. Other scopes reuse worktreeDiffBaseRef or worktreeMergeTargetBaseRef, use the worktree as the head, and IncludeUntracked=true. Resolve every non-empty ref through hardened git rev-parse --verify ref^{commit}.
+
+- [ ] **Step 4: Implement the content fingerprint**
+
+Hash a versioned stream containing normalized path, resolved OIDs, mode flags, aggregate git diff --raw -z --no-renames metadata, and git ls-files --others --exclude-standard -z when untracked files participate. For each current worktree path in those sets, append lstat mode plus symlink target or streamed regular-file bytes. Encode missing/deleted state explicitly. Commit/range snapshots use immutable resolved OIDs.
+
+Do not use addition/deletion totals as identity.
+
+- [ ] **Step 5: Implement preparation and direct preview**
+
+PrepareDiffSnapshot calls the aggregate ref preparer from Task 1. ReadDiffSnapshotFile accepts already-selected DiffFile metadata and reads old/new content directly through existing blob/worktree safety and byte limits; it must not run a diff to rediscover membership.
+
+- [ ] **Step 6: Test movement during preparation**
+
+Use a narrow unexported test hook restored with t.Cleanup to edit a file between before/after fingerprints. Assert the fingerprints differ so the server can reject publication. Do not add retry machinery to the workspace package.
+
+- [ ] **Step 7: Run and commit**
+
+~~~bash
+go test ./internal/workspace -shuffle=on
+git add internal/workspace/diff.go internal/workspace/diff_snapshot.go internal/workspace/diff_snapshot_test.go
+git commit -m "feat: prepare stable workspace diff snapshots"
+~~~
+
+The body explains that immutable refs plus dirty-content hashing separate cheap validation from recomputation and let previews reuse resolved membership.
+
+---
+
+### Task 3: Add the bounded stale-while-revalidate cache and selection leases
+
+**Files:**
+- Create: internal/server/workspace_diff_cache.go
+- Create: internal/server/workspace_diff_cache_test.go
+
+**Interfaces:**
+
+~~~go
+type workspaceDiffLogicalKey struct {
+	WorkspaceID string
+	Spec        workspace.DiffSnapshotSpec
+}
+
+type workspaceDiffSnapshot struct {
+	Resolved    workspace.ResolvedDiffSnapshotSpec
+	Fingerprint workspace.DiffFingerprint
+	Revision    uint64
+	Diff        *gitclone.DiffResult
+	Files       []gitclone.DiffFile
+	SizeBytes   int64
+}
+
+type workspaceDiffCacheState string
+
+func (c *workspaceDiffCache) Get(context.Context, workspaceDiffLogicalKey) (*workspaceDiffSnapshot, workspaceDiffCacheState, error)
+func (c *workspaceDiffCache) Select(string, func(context.Context) (workspaceDiffLogicalKey, error)) func()
+func (c *workspaceDiffCache) MarkActive(workspaceDiffLogicalKey)
+func (c *workspaceDiffCache) ValidateSelected()
+~~~
+
+- [ ] **Step 1: Write failing cache tests with fake time/dependencies**
+
+Inject now, resolve, fingerprint, prepare, and onChanged. Cover first miss/fresh hit; concurrent coalescing; immediate stale return; equal validation without prepare/event; changed stable replacement; movement during prepare; last-known-good after failure; byte/TTL eviction with inactive-first LRU; first-selection HEAD prewarm; tab refcounting; final-disconnect validator stop.
+
+Use channels only for coalescing and immediate-stale contracts. Use fake-clock advancement for TTL.
+
+- [ ] **Step 2: Prove the tests fail**
+
+~~~bash
+go test ./internal/server -run 'TestWorkspaceDiffCache' -shuffle=on
+~~~
+
+Expected: FAIL because workspaceDiffCache is undefined.
+
+- [ ] **Step 3: Implement storage and projections**
+
+Use a mutex-protected logical-entry map, physical fingerprint/revision per entry, monotonic revision counter, timestamps, and singleflight.Group. Approximate bytes by summing patch/path/status/hunk/line strings; never JSON-marshal on the request path.
+
+Build Files by copying each DiffFile, clearing Patch, and replacing Hunks with an empty non-nil slice.
+
+- [ ] **Step 4: Implement hit/stale/miss and stable replacement**
+
+Fresh returns synchronously. Expired last-known-good returns a clone marked stale and schedules validation. A cold miss waits. Shared work runs under the cache root context and callers wait via singleflight.DoChan so one canceled request does not cancel other waiters.
+
+Stable publication is:
+
+~~~go
+before := fingerprint(resolved)
+result := prepare(resolved)
+after := fingerprint(resolved)
+if before != after {
+	return errWorkspaceDiffMovedDuringPreparation
+}
+publish(result, after)
+~~~
+
+Preparation errors or movement never replace last-known-good or emit an event.
+
+- [ ] **Step 5: Implement selected-only validation and eviction**
+
+Select refcounts workspace IDs. First lease resolves/prewarms default HEAD and starts one 15-second loop. MarkActive changes the selected workspace's validated key to the latest requested base/scope/whitespace key. Final release cancels the loop but retains entries.
+
+ValidateSelected debounces prompt validation for selected active keys. After publish/access, evict entries idle for 10 minutes, then LRU inactive entries until at most 128 MiB. Selected entries are last-resort eviction candidates.
+
+- [ ] **Step 6: Add trace data**
+
+Set request-span attributes workspace.diff.cache_result, workspace.diff.snapshot_bytes, workspace.diff.revision, and workspace.id. cache_result is exactly hit, stale, miss, or coalesced; use singleflight's shared result plus the cache's pre-call state to distinguish miss from coalesced. Add child spans workspace.diff.resolve, workspace.diff.fingerprint, and workspace.diff.prepare around the granular preparation spans from Task 1; record errors and concurrent movement. Never attach paths or content.
+
+- [ ] **Step 7: Run normal/race tests and commit**
+
+~~~bash
+go test ./internal/server -run 'TestWorkspaceDiffCache' -shuffle=on
+go test -race ./internal/server -run 'TestWorkspaceDiffCache' -shuffle=on
+git add internal/server/workspace_diff_cache.go internal/server/workspace_diff_cache_test.go
+git commit -m "feat: cache selected workspace diff snapshots"
+~~~
+
+The body records selected-only cost, stale-while-revalidate behavior, and stable publication.
+
+---
+
+### Task 4: Wire the cache into APIs, worktree signals, SSE, and shutdown
+
+**Files:**
+- Modify: internal/server/server.go:130-255,675-840,1458-1605
+- Modify: internal/server/huma_routes.go:557-585,657-665,850-880,5808-6250
+- Modify: internal/server/fleet_worktree_links.go:283-291
+- Modify: internal/server/server_test.go
+- Modify: internal/server/api_test.go:25713-26630
+- Modify: generated files from make api-generate
+
+**Interfaces:**
+- Produces: GET /api/v1/events?workspace_id={local-id} selection lease and workspace_diff_changed payload with workspace_id and revision.
+
+- [ ] **Step 1: Add failing wire/API tests**
+
+Through httptest.Server, open a scoped stream, wait for one lease/default HEAD preparation, open a second and assert one validator/two refs, close both, and assert final release. An unscoped stream creates no lease. Parse a replacement frame:
+
+~~~json
+{"workspace_id":"ws-1","revision":2}
+~~~
+
+Using existing workspace API fixtures plus an injected counting preparer, request /files then /diff and assert one preparation with identical file/count identity. Concurrent requests coalesce. A path request after whole-snapshot preparation filters without preparation. Retain existing preview/path-safety tests.
+
+- [ ] **Step 2: Prove the tests fail**
+
+~~~bash
+go test ./internal/server -run 'TestWorkspaceDiffSelection|TestWorkspaceDiffEndpointsShareSnapshot|TestWorkspaceDiffEndpointScopesPatchByPathE2E|TestWorkspaceFilePreviewEndpointReturnsRequestedDiffSideContentE2E' -shuffle=on
+~~~
+
+Expected: FAIL in new lease/cache assertions.
+
+- [ ] **Step 3: Own cache lifecycle in Server**
+
+Add workspaceDiffCache *workspaceDiffCache. Construct it after bgCtx/workspace manager dependencies exist. Use s.bgCtx as root so existing shutdown cancellation and background drain stop validators/in-flight work; do not create an untracked shutdown path.
+
+- [ ] **Step 4: Route all workspace reads through the snapshot**
+
+Convert workspaceDiffRequest to workspaceDiffLogicalKey after current scope validation. /files returns snapshot.Files; /diff returns snapshot.Diff.Files; both use the same whitespace count/stale state. Path-scoped /diff filters an exact Path or OldPath match from a copy. /file-preview selects membership from the snapshot then calls workspace.ReadDiffSnapshotFile.
+
+Preserve workspaceDiffBaseUnavailable and current cold-failure problem envelopes.
+
+- [ ] **Step 5: Register SSE selection and stats hints**
+
+Add a Huma query input:
+
+~~~go
+type streamEventsInput struct {
+	WorkspaceID string
+}
+~~~
+
+Tag WorkspaceID as query workspace_id with documentation. Capture it in streamEvents, acquire before serveSSE, and defer release. Invalid/not-ready IDs log background prewarm failure without breaking the general event stream.
+
+notifyWorktreeStatsChanged calls workspaceDiffCache.ValidateSelected before broadcasting the existing stats event. It never scans every workspace.
+
+- [ ] **Step 6: Broadcast only stable replacements**
+
+On a changed stable replacement broadcast workspace_diff_changed with WorkspaceID and Revision. Emit nothing for equal validation, initial cold population, failure, or concurrent movement.
+
+- [ ] **Step 7: Regenerate and verify**
+
+~~~bash
+make api-generate
+go test ./internal/server -run 'TestHumaContractMetadata|TestHumaConvenienceRoutesUseDocumentOperation|TestRouteMetadataWalker|TestWorkspaceDiffSelection|TestWorkspaceDiffEndpoint' -shuffle=on
+~~~
+
+Expected: PASS with intentional generated changes.
+
+- [ ] **Step 8: Commit**
+
+Stage server code, tests, and generated artifacts, then:
+
+~~~bash
+git commit -m "perf: serve workspace diff views from shared snapshots"
+~~~
+
+The body explains that /files prepares the whole snapshot, /diff is a projection, and SSE lifetime owns local selection.
+
+---
+
+### Task 5: Preserve stale UI data and refresh only the matching workspace diff
+
+**Files:**
+- Modify: packages/ui/src/stores/diff.svelte.ts:16-25,640-865
+- Modify: frontend/src/lib/stores/diff.svelte.test.ts
+- Modify: frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte:180-225,2460-2600,3055-3080
+- Modify: frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+- Modify: packages/ui/src/components/workspace/WorkspaceRightSidebar.svelte:41-78,297-310
+- Modify: packages/ui/src/components/workspace/WorkspaceDiffPanel.svelte:8-55
+
+**Interfaces:**
+- Consumes workspace_diff_changed data {workspace_id, revision}.
+- Produces LoadWorkspaceDiffOptions.preserveVisible, diffSnapshotRevision props, and atomic background replacement.
+
+- [ ] **Step 1: Add failing stale-visible store tests**
+
+Load snapshot A. Start a preserving refresh with deferred files/diff. Assert A remains visible. Resolve files B only and assert A remains coherent. Resolve diff B and assert both projections switch together. Reject refresh and assert A remains while getDiffError records failure.
+
+~~~ts
+const refresh = store.loadWorkspaceDiff("ws-1", "head", false, {
+  preserveVisible: true,
+});
+~~~
+
+- [ ] **Step 2: Prove current clearing behavior fails**
+
+~~~bash
+./node_modules/.bin/vp test frontend/src/lib/stores/diff.svelte.test.ts
+~~~
+
+Expected: FAIL in the new test because startDiffLoad clears current state.
+
+- [ ] **Step 3: Implement atomic preserving refresh**
+
+Add preserveVisible to LoadWorkspaceDiffOptions. Preserving loads retain reactive state, keep the new files response in a local non-reactive variable, and apply files+diff only after both succeed. Failure retains old values and sets the error. Initial/base/scope/whitespace loads keep current progressive files-then-diff behavior.
+
+Do not add shared reactive pending payloads; one invocation and existing generation guards own them.
+
+- [ ] **Step 4: Add failing terminal selection/event tests**
+
+Capture EventSource URLs/listeners. Assert local ws-1 opens events?workspace_id=ws-1; fleet member/ws-1 remains unscoped; another workspace event does nothing; a strictly newer matching revision triggers only diff refresh; replaying the same revision does not duplicate work.
+
+- [ ] **Step 5: Thread a diff-only revision**
+
+Add diffSnapshotRevision state in WorkspaceTerminalView. Defensively parse the event, require the matching local ID and a newer numeric revision, then assign it. Pass it separately from sidebarRefreshToken so PR/issue/review panels do not redraw.
+
+Add the prop through WorkspaceRightSidebar to WorkspaceDiffPanel. The panel key includes general refresh and diff revision. preserveVisible is true only when workspace/base identity is unchanged and the diff revision advanced. refreshCommits remains tied to manual/general refresh, not background diff replacement.
+
+- [ ] **Step 6: Scope only local SSE**
+
+Within the existing route effect:
+
+~~~ts
+const evtURL = new URL(basePath + "/api/v1/events", window.location.origin);
+if (!hostKey) evtURL.searchParams.set("workspace_id", id);
+const source = new EventSource(evtURL.pathname + evtURL.search);
+~~~
+
+Existing teardown closes the source, ending the server lease on navigation/destruction.
+
+- [ ] **Step 7: Run Svelte analysis and focused tests**
+
+~~~bash
+./node_modules/.bin/vp exec svelte-mcp svelte-autofixer ./frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte --svelte-version 5
+./node_modules/.bin/vp exec svelte-mcp svelte-autofixer ./packages/ui/src/components/workspace/WorkspaceRightSidebar.svelte --svelte-version 5
+./node_modules/.bin/vp exec svelte-mcp svelte-autofixer ./packages/ui/src/components/workspace/WorkspaceDiffPanel.svelte --svelte-version 5
+./node_modules/.bin/vp test frontend/src/lib/stores/diff.svelte.test.ts frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+~~~
+
+Expected: no new actionable autofixer issue from edits; tests PASS.
+
+- [ ] **Step 8: Commit**
+
+~~~bash
+git add packages/ui/src/stores/diff.svelte.ts packages/ui/src/components/workspace/WorkspaceRightSidebar.svelte packages/ui/src/components/workspace/WorkspaceDiffPanel.svelte frontend/src/lib/stores/diff.svelte.test.ts frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+git commit -m "perf: refresh selected workspace diffs without blanking"
+~~~
+
+The body explains that scoped SSE owns local selection and the last coherent snapshot stays visible during replacement.
+
+---
+
+### Task 6: Document invariants and verify cold/warm traces
+
+**Files:**
+- Modify: context/workspace-apis.md:170-195
+- Modify the design spec only if final names materially differ.
+
+- [ ] **Step 1: Record durable invariants**
+
+Add a Diff snapshot lifecycle subsection stating: /files and /diff project one complete snapshot; ordinary whitespace classification is Go xdiff-equivalent while explicit hide uses aggregate Git -w; only events?workspace_id creates proactive local selection; stats change is a selected validation hint; equal fingerprints do not recompute/event; stable replacement emits workspace_diff_changed; last-known-good survives failures. Anchor claims to final functions.
+
+- [ ] **Step 2: Run complete affected backend suites**
+
+~~~bash
+go test ./internal/workspace ./internal/server -shuffle=on
+~~~
+
+Expected: PASS.
+
+- [ ] **Step 3: Run complete frontend unit suite**
+
+~~~bash
+./node_modules/.bin/vp test
+~~~
+
+Expected: PASS. Reproduce any claimed unrelated scheduling failure on the base commit rather than weakening/skipping tests.
+
+- [ ] **Step 4: Run static/build checks**
+
+~~~bash
+make lint
+make frontend
+git diff --check
+~~~
+
+Expected: PASS with only intentional generated artifacts.
+
+- [ ] **Step 5: Measure the profiled live workspace**
+
+For workspace 539fb58f99084088, record cold/warm HEAD and merge-target /files then /diff spans. Verify cold preparation uses constant aggregate Git commands; following /diff is a hit with no Git work; unchanged selected validation fingerprints only; a real edit produces one replacement/event; warm latency is transfer/serialization rather than Git.
+
+If any named cold phase remains multi-second, investigate/fix it before completion instead of hiding it with cache warmth.
+
+- [ ] **Step 6: Run context-sync**
+
+~~~bash
+scripts/context-sync --check
+scripts/hooks/context-sync-stop.sh mark "updated context/workspace-apis.md for selected workspace diff snapshot lifecycle"
+~~~
+
+Address drift before marking.
+
+- [ ] **Step 7: Commit**
+
+~~~bash
+git add context/workspace-apis.md
+git commit -m "docs: record workspace diff cache invariants"
+~~~
+
+The body explains why selected-only validation and last-known-good publication must survive refactors.
+
+---
+
+## Final Acceptance Checklist
+
+- [ ] A 128-file merge-target cold load performs no per-file Git subprocess loop.
+- [ ] /files followed by /diff prepares once; the second request is a projection.
+- [ ] Warm selected-workspace requests perform no Git diff work.
+- [ ] Unchanged validation performs no recomputation and emits no event.
+- [ ] Same-total content edits are detected; concurrent edits cannot publish a torn snapshot.
+- [ ] Only local terminal selections receive proactive work; inactive/fleet workspaces stay request-driven.
+- [ ] Cache is bounded by 10-minute inactivity and 128 MiB approximate bytes with last-known-good after failures.
+- [ ] Matching workspace_diff_changed refreshes only the diff panel without blanking.
+- [ ] Focused, full affected, race, Svelte analysis, generated-contract, lint, build, and context-sync checks pass.

--- a/docs/superpowers/specs/2026-07-17-selected-workspace-diff-loading-design.md
+++ b/docs/superpowers/specs/2026-07-17-selected-workspace-diff-loading-design.md
@@ -27,9 +27,9 @@ handling, copy/rename detection, path safety, and explicit hide-whitespace
 behavior.
 
 Provider pull-request diffs and repository-browser diffs are not cache clients
-in this change. Fleet-proxied workspaces receive the cold-path improvement when
-the member computes their local diff; proactive selection refresh remains owned
-by the server that owns the worktree.
+in this change. A fleet long-poll holds the selection lease on the member that
+owns the worktree; the hub relays only opaque HEAD versions and never performs
+the member's Git work.
 
 ## Git and Go responsibilities
 
@@ -109,14 +109,19 @@ carries `workspace_id`. Its lifetime is the selection lease. The server
 reference-counts concurrent tabs, prepares the default HEAD snapshot on the
 first selection, and stops proactive work when the final selection disconnects.
 Previously prepared entries may remain available until eviction, but inactive
-entries are not refreshed. Fleet selections keep request-driven caching and the
-cold-path improvement; they do not create a proactive lease on the remote
-member in this change.
+entries are not refreshed. Fleet selections use a 25-second `/diff/watch`
+long-poll through HTTP or SSH proxying. Empty or foreign tokens return the
+current HEAD version with `changed=true`; matching tokens return that same
+version with `changed=false` on timeout. Events only trigger a reread of the
+watched HEAD key, so versions never cross diff scopes. Cancellation releases
+the remote lease, while recently active scopes survive immediate reconnects.
 
 Every base/scope/whitespace key requested by a currently selected workspace is
 active until its access lease ages out. This keeps concurrent tabs with different
 diff scopes independent. Active keys are pinned against eviction; older inactive
-keys remain read-only cache entries until eviction.
+keys remain read-only cache entries until eviction. Expired active-key records
+are pruned even while their workspace remains selected, so a scope that has not
+been read for 10 minutes cannot stay pinned forever.
 
 Validation is cheaper than recomputation. Each validation re-resolves the logical
 specification, then fingerprints the resolved Git refs and changed-path state.
@@ -124,7 +129,9 @@ Unchanged strong stat identities reuse per-file content digests; changed metadat
 is confirmed from file contents so same-size edits are not missed without
 re-reading unchanged large files every 15 seconds. The fingerprint also includes
 the repository-local attribute input (`.git/info/attributes`); the hardened Git
-runner already excludes user and system configuration. Preparation uses resolved
+runner already excludes user and system configuration. Commit/range generated
+file classification uses the resolved head commit as `git check-attr --source`;
+only live worktree snapshots consult worktree `.gitattributes`. Preparation uses resolved
 OIDs, then re-resolves and fingerprints again before publication. Equal boundary
 fingerprints are best-effort movement detection rather than a filesystem
 transaction: an A-to-B-to-A mutation can evade them. A mismatch leaves the
@@ -133,27 +140,54 @@ previous snapshot in place and schedules a throttled retry.
 The existing worktree-stats change signal requests prompt validation for the
 selected worktree. A bounded selected-workspace validation interval is the
 fallback for changes that do not alter aggregate stats. Concurrent validation
-or preparation for one key is single-flight.
+or preparation for one key is single-flight. One background validation worker
+serializes proactive Git preparation and remains occupied until the shared
+cache-owned preparation completes, with a 30-second ceiling so one caller cannot
+cancel another while its Git work continues. Foreground cold reads do not wait
+behind the background queue. If the first selected-workspace prewarm
+cannot resolve or prepare, it retries every five seconds while the selection
+lease remains open.
 
-All entries have a 15-second validation max-age. Selected entries validate
-proactively; an older unselected entry returns its last-known-good value as stale
-and schedules request-driven validation, so frequent fleet reads cannot keep a
-snapshot fresh indefinitely. When validation finds the same fingerprint, it performs no diff recomputation
-and emits no event. When a stable recomputation produces a changed snapshot,
+All entries become eligible for validation after 15 seconds. This is a freshness
+threshold, not a completion SLA when the bounded worker queue is backlogged.
+Selected entries validate proactively; an older unselected entry returns its
+last-known-good value as stale and schedules request-driven validation, so
+frequent fleet reads cannot keep a snapshot fresh indefinitely. A one-second
+scheduler begins validation during
+the final second of that window so timer phase cannot stretch the bound toward
+30 seconds. When validation finds the same fingerprint, it
+performs no diff recomputation, does not renew foreground access time, and emits
+no event. Manual workspace refresh schedules best-effort validation for every
+cached key for that workspace, including unselected and fleet-owned entries; it
+is queued before provider refresh and does not wait for preparation. Provider or
+preparation failures leave the last-known-good snapshot visible and retry on a
+later signal or read. When a stable recomputation produces
+a changed snapshot,
 the server atomically replaces the entry and broadcasts
 `workspace_diff_changed` with workspace/host identity and snapshot revision.
 The terminal filters that event to its selected workspace and reloads only the
 currently visible diff scope. The stale snapshot remains visible until the
-replacement request completes. Revision identity includes a per-process cache
-generation, and `reconnect.stale` always triggers a preserving diff refresh, so
-restart, eviction, and replay-ring loss cannot strand an old display.
+replacement request completes. Versions are opaque equality tokens; clients do
+not infer ordering from version or revision values because SSE event IDs own
+ordering and replay. Revision identity includes a per-process cache generation,
+and `reconnect.stale` always triggers a preserving diff refresh, so restart,
+eviction, and replay-ring loss cannot strand an old display.
 
 ## Cache bounds and failures
 
-Snapshots use an in-memory TTL cache bounded by both inactivity and approximate
-serialized bytes. Eviction removes least-recently-used inactive entries; actively
-leased entries are never eviction candidates. Cache loss or eviction is never an API failure; the next read
-uses the cold path.
+Snapshots use `jellydator/ttlcache/v3` for entry storage and TTL expiration.
+Middleman's coordinator applies the 128 MiB inactive-entry target so pressure
+cannot evict selected or pair-retained snapshots, and retains ownership of
+coherent projections, stable publication, and single-flight preparation.
+New snapshots receive a one-minute pair-retention lease so an oversized
+`/files` projection survives long enough for its revision-pinned `/diff` read.
+The target may therefore be exceeded temporarily by pair-retained snapshots or
+the active working set. Active protection expires after 10 minutes without
+foreground access, at which point normal cost eviction can recover memory.
+Cache loss or eviction is never an API failure; the next read uses the cold path.
+Mixed-version fleet members are not given a compatibility fallback for revision
+pinning: hub and member must run a version that supports snapshot versions and
+typed `snapshot_changed` conflicts.
 
 Preparation errors do not replace a last-known-good snapshot and do not emit a
 change event. A cold request with no usable snapshot preserves the current API
@@ -175,6 +209,32 @@ sidebar before the frontend starts its `/diff` request. The cold `/files`
 preparation completes the shared snapshot, so the following `/diff` is a cache
 projection and performs no Git work.
 
+Workspace switching gives the shell/runtime critical-path priority over diff
+work. As soon as route identity differs from the loaded workspace, the old
+right sidebar is unmounted, its identity-scoped files/diff requests are aborted,
+and a neutral sidebar placeholder replaces it. The new sidebar mounts after
+workspace metadata and either matching runtime state or a terminal runtime error
+belong to the selected route, so runtime failure cannot strand the placeholder.
+A monotonic load generation is checked after every await and rejection path.
+Each invocation also has a token, so cleanup from an older same-workspace load
+cannot abort its replacement. Same-workspace background snapshot replacement
+continues to preserve the visible diff. A typed `snapshot_changed` file-preview
+conflict reloads the coherent files/diff pair once and retries the preview.
+
+This browser-side deferral does not defer server preparation. The scoped SSE
+selection lease starts default-HEAD prewarming immediately alongside workspace
+and runtime reads. The event subscriber is registered before that lease starts,
+so even immediate prewarm completion reaches the selecting client. Initial selected prewarm publication emits
+`workspace_diff_ready` with the snapshot version; the client records it without
+mounting the diff panel, then uses it to request the already-prepared snapshot
+after runtime readiness. Preparation failure emits no ready event and never
+delays or fails the shell.
+
+Fleet selection starts its watch at route selection, independently of metadata,
+runtime, and sidebar mounting. The watch keeps its own HEAD token, aborts through
+the proxy on switch, and retries failures with capped exponential jitter; only a
+changed HEAD token triggers a preserving diff reload.
+
 ## Verification
 
 - Go unit tests pin the xdiff-compatible whitespace record comparison and
@@ -187,11 +247,19 @@ projection and performs no Git work.
   single-flight behavior, byte/TTL eviction, disconnect handling, and
   last-known-good behavior after failure.
 - Wire-level SSE tests prove selection registration and matching
-  `workspace_diff_changed` delivery.
+  `workspace_diff_ready`/`workspace_diff_changed` delivery.
 - Frontend tests prove workspace-qualified event filtering and stale-visible
-  refresh.
+  refresh, and prove a route switch aborts the previous diff before the new
+  sidebar mounts after runtime readiness.
+- A seeded full-stack browser test proves EventSource delivery and workspace,
+  runtime, and diff-request ordering across a real workspace switch.
 - Before/after live traces record cold and warm HEAD/merge-target loads for the
-  profiled workspace. The acceptance condition is that the cold path has no
-  per-file Git subprocess growth and warm requests perform no Git diff work;
-  any remaining multi-second cold phase is investigated rather than hidden by
-  the cache.
+  profiled workspace. The measured acceptance budgets are a default-HEAD cold
+  preparation below 500 ms and warm `/files` and `/diff` server spans below
+  5 ms each. Subprocess count must have zero slope as changed-file count grows
+  from 1 to 128, and an unchanged validation must perform no preparation. Any
+  regression beyond those budgets is investigated rather than hidden by cache
+  warmth.
+- The measured selected HEAD cache-hit server spans were 0.25 ms for `/files`
+  and 0.35 ms for `/diff`. A concurrent cold merge-target preparation left the
+  runtime endpoint at 0.675 ms server time, confirming Git work is off readiness.

--- a/docs/superpowers/specs/2026-07-17-selected-workspace-diff-loading-design.md
+++ b/docs/superpowers/specs/2026-07-17-selected-workspace-diff-loading-design.md
@@ -85,14 +85,18 @@ The key includes:
 
 Path-scoped diff reads select the requested file from a prepared whole-diff
 snapshot when the matching snapshot exists. File-content previews remain
-separate bounded reads and are not stored in the snapshot cache.
+separate bounded reads and are not stored in the snapshot cache. A new-side
+worktree preview is intentionally live and can move ahead of the cached patch;
+blob-backed old/range sides remain pinned to resolved OIDs.
 
 Preparation records trace phases for base resolution, revision validation, Git
 raw metadata, numstat, patch generation, Go whitespace classification,
 untracked-file loading, generated-attribute lookup, and response assembly. The
 request span records cache result (`hit`, `stale`, `miss`, or `coalesced`) and
 snapshot size so the live trace shows whether latency is Git, Go processing,
-serialization, or cache waiting.
+serialization, or cache waiting. Both projections carry an opaque cache-generation
+plus revision token. `/diff` can require the revision returned by `/files`; a
+mismatch asks the client to restart the pair rather than combining revisions.
 
 ## Selection, validation, and refresh
 
@@ -109,36 +113,46 @@ entries are not refreshed. Fleet selections keep request-driven caching and the
 cold-path improvement; they do not create a proactive lease on the remote
 member in this change.
 
-The last requested base/scope/whitespace key becomes the selected workspace's
-active snapshot. Changing scope prepares that key; older keys remain read-only
-cache entries until eviction.
+Every base/scope/whitespace key requested by a currently selected workspace is
+active until its access lease ages out. This keeps concurrent tabs with different
+diff scopes independent. Active keys are pinned against eviction; older inactive
+keys remain read-only cache entries until eviction.
 
-Validation is cheaper than recomputation. A revision fingerprint includes the
-resolved Git refs and the selected worktree's changed-path state. Unchanged
-metadata extends freshness without running the aggregate patch. Changed
-metadata is confirmed from changed file contents so edits that retain the same
-add/delete totals are not missed. Fingerprints taken before and after
-preparation must match before the result is published; a concurrent edit leaves
-the previous snapshot in place and schedules another debounced validation.
+Validation is cheaper than recomputation. Each validation re-resolves the logical
+specification, then fingerprints the resolved Git refs and changed-path state.
+Unchanged strong stat identities reuse per-file content digests; changed metadata
+is confirmed from file contents so same-size edits are not missed without
+re-reading unchanged large files every 15 seconds. The fingerprint also includes
+the repository-local attribute input (`.git/info/attributes`); the hardened Git
+runner already excludes user and system configuration. Preparation uses resolved
+OIDs, then re-resolves and fingerprints again before publication. Equal boundary
+fingerprints are best-effort movement detection rather than a filesystem
+transaction: an A-to-B-to-A mutation can evade them. A mismatch leaves the
+previous snapshot in place and schedules a throttled retry.
 
 The existing worktree-stats change signal requests prompt validation for the
 selected worktree. A bounded selected-workspace validation interval is the
 fallback for changes that do not alter aggregate stats. Concurrent validation
 or preparation for one key is single-flight.
 
-When validation finds the same fingerprint, it performs no diff recomputation
+All entries have a 15-second validation max-age. Selected entries validate
+proactively; an older unselected entry returns its last-known-good value as stale
+and schedules request-driven validation, so frequent fleet reads cannot keep a
+snapshot fresh indefinitely. When validation finds the same fingerprint, it performs no diff recomputation
 and emits no event. When a stable recomputation produces a changed snapshot,
 the server atomically replaces the entry and broadcasts
 `workspace_diff_changed` with workspace/host identity and snapshot revision.
 The terminal filters that event to its selected workspace and reloads only the
 currently visible diff scope. The stale snapshot remains visible until the
-replacement request completes.
+replacement request completes. Revision identity includes a per-process cache
+generation, and `reconnect.stale` always triggers a preserving diff refresh, so
+restart, eviction, and replay-ring loss cannot strand an old display.
 
 ## Cache bounds and failures
 
 Snapshots use an in-memory TTL cache bounded by both inactivity and approximate
-serialized bytes. Eviction removes least-recently-used inactive entries before
-selected entries. Cache loss or eviction is never an API failure; the next read
+serialized bytes. Eviction removes least-recently-used inactive entries; actively
+leased entries are never eviction candidates. Cache loss or eviction is never an API failure; the next read
 uses the cold path.
 
 Preparation errors do not replace a last-known-good snapshot and do not emit a

--- a/docs/superpowers/specs/2026-07-17-selected-workspace-diff-loading-design.md
+++ b/docs/superpowers/specs/2026-07-17-selected-workspace-diff-loading-design.md
@@ -1,0 +1,183 @@
+# Selected workspace diff loading
+
+## Goal
+
+Make workspace diff views feel immediate after a workspace is selected, while
+also fixing the cold path so a cache miss is proportional to one aggregate Git
+diff rather than to the number of changed files.
+
+The live baseline for workspace `539fb58f99084088` was:
+
+- HEAD: `/files` 1.38s followed by `/diff` 1.90s;
+- merge target: `/files` 8.84s followed by `/diff` 16.13s;
+- merge-target response: 128 files and about 4 MB of JSON;
+- the aggregate Git patch command itself: about 240ms.
+
+The dominant avoidable cost is workspace whitespace-only classification, which
+currently invokes `git diff --numstat -w` once per changed path. The frontend
+then pays another independent Git walk because it requests `/files` and `/diff`
+sequentially.
+
+## Scope
+
+This change covers local workspace diff files, patches, and their selected-view
+refresh lifecycle. It retains the current workspace bases, commit/range scopes,
+file previews, response shapes, generated-file attributes, untracked-file
+handling, copy/rename detection, path safety, and explicit hide-whitespace
+behavior.
+
+Provider pull-request diffs and repository-browser diffs are not cache clients
+in this change. Fleet-proxied workspaces receive the cold-path improvement when
+the member computes their local diff; proactive selection refresh remains owned
+by the server that owns the worktree.
+
+## Git and Go responsibilities
+
+Git remains authoritative for:
+
+- base, upstream, and merge-base resolution;
+- the ordinary aggregate raw metadata, numstat, and patch;
+- rename/copy detection, including `--find-copies-harder`;
+- binary patch decisions and `check-attr` generated-file metadata;
+- the explicit hide-whitespace patch, where `-w` can change hunk alignment in a
+  file that contains both whitespace and substantive edits.
+
+Go owns whitespace-only classification for the ordinary diff. This is a small
+port of Git xdiff's `XDF_IGNORE_WHITESPACE` record equivalence, not a new diff
+engine. Git's current implementation splits input into line records, ignores C
+`isspace` bytes while hashing and comparing each record, and preserves record
+count and order. The Go equivalent uses the ASCII whitespace set recognized by
+Git in the C locale (`space`, tab, newline, vertical tab, form feed, carriage
+return), preserves line boundaries, and ignores final-newline differences in
+the same way.
+
+For every modified non-binary file, the classifier reconstructs the old and new
+line sequences represented by each ordinary patch hunk. A hunk is
+whitespace-only only when its old and new record counts match and corresponding
+records match after Git-compatible whitespace removal. A file is
+whitespace-only only when every changed hunk is whitespace-only. Added,
+deleted, renamed, copied, type-changed, and binary files are never classified
+as whitespace-only, matching the current `--no-renames -w` classification
+contract.
+
+Git remains the test oracle. Table-driven and generated parity cases compare
+the Go classifier with `git diff --quiet -w` for indentation, tabs, blank-line
+insertion, CRLF, missing final newlines, repeated lines, mixed substantive and
+whitespace edits, binary files, renames, and copies. If ordinary hunks cannot
+reproduce Git parity for an edge case, the implementation must use complete
+old/new record sequences for that file rather than weaken the contract or add
+per-file Git calls.
+
+## Shared workspace snapshot
+
+A workspace diff snapshot contains the complete `gitclone.DiffResult` plus the
+file-list projection derived from it. `/files` and `/diff` use the same
+preparation and concurrent requests for the same key share one in-flight
+computation. `/files` never starts a second raw/numstat/whitespace scan after a
+full snapshot has been prepared.
+
+The key includes:
+
+- workspace ID and normalized worktree path;
+- base (`head`, `pushed`, or `merge-target`) and resolved base identity;
+- commit/range scope;
+- ordinary or explicit hide-whitespace mode.
+
+Path-scoped diff reads select the requested file from a prepared whole-diff
+snapshot when the matching snapshot exists. File-content previews remain
+separate bounded reads and are not stored in the snapshot cache.
+
+Preparation records trace phases for base resolution, revision validation, Git
+raw metadata, numstat, patch generation, Go whitespace classification,
+untracked-file loading, generated-attribute lookup, and response assembly. The
+request span records cache result (`hit`, `stale`, `miss`, or `coalesced`) and
+snapshot size so the live trace shows whether latency is Git, Go processing,
+serialization, or cache waiting.
+
+## Selection, validation, and refresh
+
+Only a workspace selected in a terminal view receives proactive preparation or
+background validation. Workspace list rows and inactive workspaces do not start
+diff work.
+
+For a local workspace, the terminal view's existing dedicated SSE connection
+carries `workspace_id`. Its lifetime is the selection lease. The server
+reference-counts concurrent tabs, prepares the default HEAD snapshot on the
+first selection, and stops proactive work when the final selection disconnects.
+Previously prepared entries may remain available until eviction, but inactive
+entries are not refreshed. Fleet selections keep request-driven caching and the
+cold-path improvement; they do not create a proactive lease on the remote
+member in this change.
+
+The last requested base/scope/whitespace key becomes the selected workspace's
+active snapshot. Changing scope prepares that key; older keys remain read-only
+cache entries until eviction.
+
+Validation is cheaper than recomputation. A revision fingerprint includes the
+resolved Git refs and the selected worktree's changed-path state. Unchanged
+metadata extends freshness without running the aggregate patch. Changed
+metadata is confirmed from changed file contents so edits that retain the same
+add/delete totals are not missed. Fingerprints taken before and after
+preparation must match before the result is published; a concurrent edit leaves
+the previous snapshot in place and schedules another debounced validation.
+
+The existing worktree-stats change signal requests prompt validation for the
+selected worktree. A bounded selected-workspace validation interval is the
+fallback for changes that do not alter aggregate stats. Concurrent validation
+or preparation for one key is single-flight.
+
+When validation finds the same fingerprint, it performs no diff recomputation
+and emits no event. When a stable recomputation produces a changed snapshot,
+the server atomically replaces the entry and broadcasts
+`workspace_diff_changed` with workspace/host identity and snapshot revision.
+The terminal filters that event to its selected workspace and reloads only the
+currently visible diff scope. The stale snapshot remains visible until the
+replacement request completes.
+
+## Cache bounds and failures
+
+Snapshots use an in-memory TTL cache bounded by both inactivity and approximate
+serialized bytes. Eviction removes least-recently-used inactive entries before
+selected entries. Cache loss or eviction is never an API failure; the next read
+uses the cold path.
+
+Preparation errors do not replace a last-known-good snapshot and do not emit a
+change event. A cold request with no usable snapshot preserves the current API
+problem response. A stale response is allowed only when a last-known-good
+snapshot exists; background failure is recorded on the preparation span and a
+later validation retries. Server shutdown cancels validators and in-flight
+preparation through the existing background lifecycle.
+
+## Frontend behavior
+
+The selected local terminal workspace identifies itself on the scoped SSE
+connection. `workspace_diff_changed` increments a diff-specific refresh token
+only for the matching workspace. The diff store retains its current files and
+patch during background replacement instead of clearing them to a loading
+screen.
+
+The current progressive file-list presentation remains: `/files` populates the
+sidebar before the frontend starts its `/diff` request. The cold `/files`
+preparation completes the shared snapshot, so the following `/diff` is a cache
+projection and performs no Git work.
+
+## Verification
+
+- Go unit tests pin the xdiff-compatible whitespace record comparison and
+  file-classification rules against Git oracle cases.
+- Workspace diff tests prove `/files` and `/diff` share preparation, concurrent
+  requests coalesce, explicit hide-whitespace retains Git hunk semantics, and
+  path/preview behavior remains safe.
+- Cache tests use a fake clock and preparer to prove selected-only prewarming,
+  unchanged validation without recomputation, stable changed replacement,
+  single-flight behavior, byte/TTL eviction, disconnect handling, and
+  last-known-good behavior after failure.
+- Wire-level SSE tests prove selection registration and matching
+  `workspace_diff_changed` delivery.
+- Frontend tests prove workspace-qualified event filtering and stale-visible
+  refresh.
+- Before/after live traces record cold and warm HEAD/merge-target loads for the
+  profiled workspace. The acceptance condition is that the cold path has no
+  per-file Git subprocess growth and warm requests perform no Git diff work;
+  any remaining multi-second cold phase is investigated rather than hidden by
+  the cache.

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -950,6 +950,9 @@ components:
           type:
             - array
             - "null"
+        snapshot_version:
+          description: Opaque workspace diff snapshot version used to keep files and patches coherent.
+          type: string
         stale:
           type: boolean
         whitespace_only_count:
@@ -1599,6 +1602,9 @@ components:
           type:
             - array
             - "null"
+        snapshot_version:
+          description: Opaque workspace diff snapshot version to pin on the following workspace diff request.
+          type: string
         stale:
           type: boolean
         whitespace_only_count:
@@ -7780,6 +7786,14 @@ paths:
   /events:
     get:
       operationId: stream-events
+      parameters:
+        - description: Optional selected local workspace to prewarm and validate while this stream is connected
+          explode: false
+          in: query
+          name: workspace_id
+          schema:
+            description: Optional selected local workspace to prewarm and validate while this stream is connected
+            type: string
       responses:
         "200":
           content:
@@ -17843,6 +17857,13 @@ paths:
           name: to
           schema:
             description: End SHA for range diff (inclusive)
+            type: string
+        - description: Optional snapshot_version returned by the workspace files endpoint
+          explode: false
+          in: query
+          name: revision
+          schema:
+            description: Optional snapshot_version returned by the workspace files endpoint
             type: string
       responses:
         "200":

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -6836,6 +6836,26 @@ components:
       required:
         - status
       type: object
+    WorkspaceDiffWatchResponse:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - /api/v1/schemas/WorkspaceDiffWatchResponse.json
+          format: uri
+          readOnly: true
+          type: string
+        changed:
+          description: True when the caller must reload the watched default-HEAD snapshot.
+          type: boolean
+        version:
+          description: Opaque version of the current default-HEAD snapshot; never a version from another diff scope.
+          type: string
+      required:
+        - changed
+        - version
+      type: object
     WorkspaceKataMetadata:
       additionalProperties: false
       properties:
@@ -8908,6 +8928,11 @@ paths:
           name: to
           schema:
             type: string
+        - description: Pinned workspace snapshot version.
+          in: query
+          name: revision
+          schema:
+            type: string
       responses:
         default:
           content:
@@ -8920,6 +8945,39 @@ paths:
                 $ref: "#/components/schemas/ProblemError"
           description: Response returned by the owning fleet host.
       summary: Get workspace diff on fleet host
+      tags:
+        - Fleet
+  /fleet/hosts/{host_key}/workspaces/{id}/diff/watch:
+    get:
+      operationId: watch-fleet-workspace-diff
+      parameters:
+        - in: path
+          name: host_key
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - description: Last observed workspace diff snapshot version.
+          in: query
+          name: version
+          schema:
+            type: string
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Response returned by the owning fleet host.
+      summary: Watch selected workspace diff on fleet host
       tags:
         - Fleet
   /fleet/hosts/{host_key}/workspaces/{id}/file-preview:
@@ -8959,6 +9017,11 @@ paths:
         - description: Newer range commit SHA.
           in: query
           name: to
+          schema:
+            type: string
+        - description: Pinned workspace snapshot version.
+          in: query
+          name: revision
           schema:
             type: string
         - description: Workspace file path to preview.
@@ -17881,6 +17944,38 @@ paths:
       summary: Get workspace diff
       tags:
         - Workspaces
+  /workspaces/{id}/diff/watch:
+    get:
+      operationId: watch-workspace-diff
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - description: Last observed opaque workspace diff snapshot version
+          explode: false
+          in: query
+          name: version
+          schema:
+            description: Last observed opaque workspace diff snapshot version
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkspaceDiffWatchResponse"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Error
+      summary: Watch selected workspace diff
+      tags:
+        - Workspaces
   /workspaces/{id}/file-preview:
     get:
       operationId: get-workspace-file-preview
@@ -17947,6 +18042,13 @@ paths:
           name: to
           schema:
             description: End SHA for range diff (inclusive)
+            type: string
+        - description: Optional snapshot_version returned by the workspace files endpoint
+          explode: false
+          in: query
+          name: revision
+          schema:
+            description: Optional snapshot_version returned by the workspace files endpoint
             type: string
       responses:
         "200":

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -190,6 +190,8 @@
   };
   let deletingWorkspaceTargets = $state<DeletingWorkspaceTarget[]>([]);
   let sidebarRefreshToken = $state(0);
+  let diffRefreshToken = $state(0);
+  let lastDiffSnapshotVersion = "";
   let forcePromptMessage = $state<string | null>(null);
   let forcePromptForId = $state<string | null>(null);
   let forceDeleting = $state(false);
@@ -2513,8 +2515,11 @@
       return;
     }
 
-    const evtUrl = `${basePath}/api/v1/events`;
-    const source = new EventSource(evtUrl);
+    const evtUrl = new URL(`${basePath}/api/v1/events`, window.location.origin);
+    if (!hostKey) {
+      evtUrl.searchParams.set("workspace_id", id);
+    }
+    const source = new EventSource(`${evtUrl.pathname}${evtUrl.search}`);
     eventSource = source;
     const workspaceRequest = fetchWorkspace();
     void fetchRuntime();
@@ -2565,7 +2570,30 @@
     source.addEventListener("reconnect.stale", () => {
       void fetchWorkspace();
       void fetchRuntime();
+      diffRefreshToken += 1;
     });
+    source.addEventListener(
+      "workspace_diff_changed",
+      (e: MessageEvent) => {
+        try {
+          const data = JSON.parse(e.data as string) as {
+            workspace_id?: string;
+            version?: string;
+          };
+          if (
+            data.workspace_id === id &&
+            typeof data.version === "string" &&
+            data.version !== "" &&
+            data.version !== lastDiffSnapshotVersion
+          ) {
+            lastDiffSnapshotVersion = data.version;
+            diffRefreshToken += 1;
+          }
+        } catch {
+          // Malformed SSE data; ignore.
+        }
+      },
+    );
 
     void workspaceRequest.then(() => {
       if (workspace?.status === "creating") {
@@ -3071,6 +3099,7 @@
                 branch={workspace.git_head_ref}
                 roborevBaseUrl={basePath + "/api/roborev"}
                 refreshToken={sidebarRefreshToken}
+                {diffRefreshToken}
                 disabled={actionsBlocked}
                 {kataTaskPanel}
               />

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -75,6 +75,7 @@
     clearActiveTerminalDrag,
     readRuntimeSessionDrag,
   } from "./terminal-drag";
+  import { shouldRetryFleetDiffWatch } from "./fleet-diff-watch.js";
   import { Button, CollapsibleSidebar,
     SplitResizeHandle,
     WorkspaceRightSidebar,
@@ -364,13 +365,13 @@
   // workspace.id check, a runtime that lands first for the new
   // workspace can render its sessions/launch targets next to the
   // previous workspace's still-cached header/home data.
-  const runtimeLive = $derived(
-    runtime !== null &&
-      runtimeForId === workspaceId &&
-      runtimeForHostKey === workspaceHostKey &&
-      workspace?.id === workspaceId &&
-      selectedWorkspaceHostKey(workspace) === workspaceHostKey,
+  const workspaceLive = $derived(
+    workspace?.id === workspaceId && selectedWorkspaceHostKey(workspace) === workspaceHostKey,
   );
+  const runtimeLive = $derived(
+    runtime !== null && runtimeForId === workspaceId && runtimeForHostKey === workspaceHostKey && workspaceLive,
+  );
+  const workspaceDetailsReady = $derived(workspaceLive && (runtimeLive || runtimeError !== null));
 
   function hasAppliedRuntimeFor(
     id: string,
@@ -2392,6 +2393,67 @@
     forcePromptForId = null;
   }
 
+  async function watchFleetWorkspaceDiff(
+    id: string,
+    hostKey: string,
+    signal: AbortSignal,
+  ): Promise<void> {
+    let version = "";
+    let retryDelay = 1_000;
+    while (!signal.aborted && isCurrentWorkspace(id, hostKey)) {
+      try {
+        const { data, response } = await client.GET(
+          "/fleet/hosts/{host_key}/workspaces/{id}/diff/watch",
+          {
+            params: {
+              path: { host_key: hostKey, id },
+              query: version ? { version } : {},
+            },
+            signal,
+          },
+        );
+        if (signal.aborted || !isCurrentWorkspace(id, hostKey)) return;
+        const update = data as
+          | { changed?: boolean; version?: string }
+          | undefined;
+        if (!response.ok) {
+          if (!shouldRetryFleetDiffWatch(response.status)) return;
+          await waitForFleetDiffWatchRetry(signal, retryDelay);
+          retryDelay = Math.min(retryDelay * 2, 30_000);
+          continue;
+        }
+        // A successful but incompatible response will not become valid by
+        // retrying forever. Leave request-driven diff loading in place for
+        // older fleet members that do not implement the watch contract.
+        if (typeof update?.version !== "string" || update.version === "") return;
+        retryDelay = 1_000;
+        version = update.version;
+        if (update.changed && version !== lastDiffSnapshotVersion) {
+          lastDiffSnapshotVersion = version;
+          diffRefreshToken += 1;
+        }
+      } catch {
+        if (signal.aborted || !isCurrentWorkspace(id, hostKey)) return;
+        await waitForFleetDiffWatchRetry(signal, retryDelay);
+        retryDelay = Math.min(retryDelay * 2, 30_000);
+      }
+    }
+  }
+
+  function waitForFleetDiffWatchRetry(signal: AbortSignal, delay: number): Promise<void> {
+    if (signal.aborted) return Promise.resolve();
+    const jitteredDelay = Math.round(delay * (0.8 + Math.random() * 0.4));
+    return new Promise((resolve) => {
+      const done = () => {
+        window.clearTimeout(timeout);
+        signal.removeEventListener("abort", done);
+        resolve();
+      };
+      const timeout = window.setTimeout(done, jitteredDelay);
+      signal.addEventListener("abort", done, { once: true });
+    });
+  }
+
   let previouslyFocusedEl: HTMLElement | null = null;
 
   $effect(() => {
@@ -2424,14 +2486,10 @@
   // App.svelte means the lifecycle is now driven entirely by this
   // effect.
   //
-  // Critically, this effect must NOT null out `workspace` or
-  // `runtime` between switches: the right sidebar and stage area
-  // both gate on those values being non-null, so clearing them
-  // would unmount the right sidebar and replace the stage with the
-  // "Setting up workspace…" spinner — the flash the user is trying
-  // to avoid. Instead we let the previous workspace's data stay on
-  // screen until the new fetchWorkspace() resolves and overwrites
-  // it in place.
+  // Keep the previous workspace and runtime available to the workflow
+  // stage until their replacements arrive. The right sidebar gates on
+  // runtimeLive separately, so it cannot mix those retained values with
+  // the newly selected route.
   $effect(() => {
     const id = workspaceId;
     const hostKey = workspaceHostKey;
@@ -2480,6 +2538,7 @@
     // leave these flags stuck true on the next workspace.
     retryingSetup = false;
     refreshingWorkspace = false;
+    lastDiffSnapshotVersion = "";
 
     // Errors/transient flags from the prior workspace should not
     // bleed across — clear them but don't touch workspace/runtime.
@@ -2513,6 +2572,11 @@
       runtimeForHostKey = undefined;
       stopRuntimePolling();
       return;
+    }
+
+    const fleetDiffWatchAbort = hostKey ? new AbortController() : null;
+    if (hostKey && fleetDiffWatchAbort) {
+      void watchFleetWorkspaceDiff(id, hostKey, fleetDiffWatchAbort.signal);
     }
 
     const evtUrl = new URL(`${basePath}/api/v1/events`, window.location.origin);
@@ -2572,28 +2636,27 @@
       void fetchRuntime();
       diffRefreshToken += 1;
     });
-    source.addEventListener(
-      "workspace_diff_changed",
-      (e: MessageEvent) => {
-        try {
-          const data = JSON.parse(e.data as string) as {
-            workspace_id?: string;
-            version?: string;
-          };
-          if (
-            data.workspace_id === id &&
-            typeof data.version === "string" &&
-            data.version !== "" &&
-            data.version !== lastDiffSnapshotVersion
-          ) {
-            lastDiffSnapshotVersion = data.version;
-            diffRefreshToken += 1;
-          }
-        } catch {
-          // Malformed SSE data; ignore.
+    const refreshPreparedDiff = (e: MessageEvent) => {
+      try {
+        const data = JSON.parse(e.data as string) as {
+          workspace_id?: string;
+          version?: string;
+        };
+        if (
+          data.workspace_id === id &&
+          typeof data.version === "string" &&
+          data.version !== "" &&
+          data.version !== lastDiffSnapshotVersion
+        ) {
+          lastDiffSnapshotVersion = data.version;
+          diffRefreshToken += 1;
         }
-      },
-    );
+      } catch {
+        // Malformed SSE data; ignore.
+      }
+    };
+    source.addEventListener("workspace_diff_ready", refreshPreparedDiff);
+    source.addEventListener("workspace_diff_changed", refreshPreparedDiff);
 
     void workspaceRequest.then(() => {
       if (workspace?.status === "creating") {
@@ -2606,6 +2669,7 @@
     return () => {
       stopPolling();
       stopRuntimePolling();
+      fleetDiffWatchAbort?.abort();
       source.close();
       if (eventSource === source) {
         eventSource = null;
@@ -3058,7 +3122,7 @@
               {/if}
             </div>
           </div>
-          {#if sidebarOpen && workspace && !hideRightSidebar}
+          {#if sidebarOpen && !hideRightSidebar}
             <SplitResizeHandle
               class="sidebar-resize-handle"
               ariaLabel="Resize workspace details"
@@ -3073,36 +3137,43 @@
               class="right-sidebar"
               style="width: {sidebarWidth}px"
             >
-              {#snippet kataTaskPanel()}
-                {@const sidebarWorkspace = workspace}
-                {#if sidebarWorkspace?.kata}
-                  <KataWorkspaceSidebarPane
-                    kata={sidebarWorkspace.kata}
-                    disabled={actionsBlocked}
-                  />
-                {:else}
-                  <EmptyState title="No linked Kata task" />
-                {/if}
-              {/snippet}
-              <WorkspaceRightSidebar
-                activeTab={sidebarTab}
-                workspaceID={workspace.id}
-                workspaceHostKey={selectedWorkspaceHostKey(workspace)}
-                provider={workspace.repo.provider}
-                platformHost={workspace.repo.platform_host}
-                repoOwner={workspace.repo.owner}
-                repoName={workspace.repo.name}
-                repoPath={workspace.repo.repo_path}
-                ownerItemType={workspace.item_type}
-                ownerItemNumber={workspace.item_number}
-                associatedPRNumber={getWorkspacePRNumber(workspace)}
-                branch={workspace.git_head_ref}
-                roborevBaseUrl={basePath + "/api/roborev"}
-                refreshToken={sidebarRefreshToken}
-                {diffRefreshToken}
-                disabled={actionsBlocked}
-                {kataTaskPanel}
-              />
+              {#if workspaceDetailsReady && workspace}
+                {#snippet kataTaskPanel()}
+                  {@const sidebarWorkspace = workspace}
+                  {#if sidebarWorkspace?.kata}
+                    <KataWorkspaceSidebarPane
+                      kata={sidebarWorkspace.kata}
+                      disabled={actionsBlocked}
+                    />
+                  {:else}
+                    <EmptyState title="No linked Kata task" />
+                  {/if}
+                {/snippet}
+                <WorkspaceRightSidebar
+                  activeTab={sidebarTab}
+                  workspaceID={workspace.id}
+                  workspaceHostKey={selectedWorkspaceHostKey(workspace)}
+                  provider={workspace.repo.provider}
+                  platformHost={workspace.repo.platform_host}
+                  repoOwner={workspace.repo.owner}
+                  repoName={workspace.repo.name}
+                  repoPath={workspace.repo.repo_path}
+                  ownerItemType={workspace.item_type}
+                  ownerItemNumber={workspace.item_number}
+                  associatedPRNumber={getWorkspacePRNumber(workspace)}
+                  branch={workspace.git_head_ref}
+                  roborevBaseUrl={basePath + "/api/roborev"}
+                  refreshToken={sidebarRefreshToken}
+                  {diffRefreshToken}
+                  disabled={actionsBlocked}
+                  {kataTaskPanel}
+                />
+              {:else}
+                <div class="state-message">
+                  <Spinner size={18} />
+                  <span>Loading workspace details...</span>
+                </div>
+              {/if}
             </div>
           {/if}
         </div>

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -885,6 +885,26 @@ describe("WorkspaceTerminalView", () => {
     });
   });
 
+  it("scopes only local workspace event streams for diff prewarming", async () => {
+    const urls: string[] = [];
+    vi.stubGlobal(
+      "EventSource",
+      class {
+        constructor(url: string) {
+          urls.push(url);
+        }
+        addEventListener(): void {}
+        close(): void {}
+      },
+    );
+
+    const { rerender } = render(WorkspaceTerminalView, { props: { workspaceId: "ws-1" } });
+    await waitFor(() => expect(urls).toContain("/api/v1/events?workspace_id=ws-1"));
+
+    await rerender({ workspaceId: "ws-1", workspaceHostKey: "member" });
+    await waitFor(() => expect(urls.at(-1)).toBe("/api/v1/events"));
+  });
+
   it("treats id-less workspace status events as global invalidation", async () => {
     const eventListeners: Record<string, (event: MessageEvent) => void> = {};
     const fetchMock = vi.fn().mockImplementation((input: Request | URL | string) => {

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -1,5 +1,7 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/svelte";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { createDiffStore } from "@middleman/ui/stores/diff";
+import { STORES_KEY } from "../../../../../packages/ui/src/context.js";
 
 const mocks = vi.hoisted(() => ({
   getWorkspaceRuntime: vi.fn(),
@@ -14,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   showFlash: vi.fn(),
   stopWorkspaceSession: vi.fn(),
   terminalWrite: vi.fn(),
+  diffStore: null as unknown as ReturnType<typeof createDiffStore>,
 }));
 
 let sockets: MockWebSocket[] = [];
@@ -136,6 +139,7 @@ vi.mock("@middleman/ui", async (importOriginal) => {
         getTerminalFontLigatures: () => false,
         getTerminalRenderer: () => "ghostty-web",
       },
+      diff: mocks.diffStore,
     }),
   };
 });
@@ -328,6 +332,7 @@ describe("WorkspaceTerminalView", () => {
     localStorage.clear();
     localStorage.setItem("middleman-workspace-active-tab:ws-1", "session:ws-1:helper");
     sockets = [];
+    mocks.diffStore = createDiffStore();
     mocks.getWorkspaceRuntime.mockReset();
     mocks.getWorkspaceRuntime.mockResolvedValue(runtimeWithStaleSession());
     mocks.launchWorkspaceSession.mockReset();
@@ -903,6 +908,209 @@ describe("WorkspaceTerminalView", () => {
 
     await rerender({ workspaceId: "ws-1", workspaceHostKey: "member" });
     await waitFor(() => expect(urls.at(-1)).toBe("/api/v1/events"));
+  });
+
+  it("prewarms a selected fleet diff and reloads it when the remote watch advances", async () => {
+    window.__BASE_PATH__ = window.location.origin;
+    localStorage.setItem("middleman-workspace-sidebar-open", "true");
+    localStorage.setItem("middleman-workspace-sidebar-tab", "diff");
+    const changed = deferred<Response>();
+    let watchCalls = 0;
+    const fetchMock = vi.fn().mockImplementation((input: Request | URL | string) => {
+      const raw = input instanceof Request ? input.url : String(input);
+      const url = new URL(raw, "http://localhost");
+      if (url.pathname.endsWith("/fleet/hosts/member/workspaces/ws-1/diff/watch")) {
+        watchCalls += 1;
+        if (watchCalls === 1) {
+          return Promise.resolve(Response.json({ changed: true, version: "fleet:1" }));
+        }
+        if (watchCalls === 2) return changed.promise;
+        return new Promise<Response>(() => {});
+      }
+      if (url.pathname.endsWith("/fleet/hosts/member/workspaces/ws-1")) {
+        return Promise.resolve(Response.json({ ...workspaceResponse, fleet_host_key: "member" }));
+      }
+      if (url.pathname.endsWith("/api/v1/workspaces")) {
+        return Promise.resolve(Response.json({ workspaces: [] }));
+      }
+      return Promise.resolve(Response.json({}));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const loadWorkspaceDiff = vi.spyOn(mocks.diffStore, "loadWorkspaceDiff").mockResolvedValue();
+
+    render(WorkspaceTerminalView, {
+      props: { workspaceId: "ws-1", workspaceHostKey: "member" },
+      context: new Map([[STORES_KEY, { diff: mocks.diffStore }]]),
+    });
+
+    await waitFor(() => expect(watchCalls).toBe(2));
+    await waitFor(() => expect(loadWorkspaceDiff).toHaveBeenCalled());
+    const beforeChange = loadWorkspaceDiff.mock.calls.length;
+
+    changed.resolve(Response.json({ changed: true, version: "fleet:2" }));
+
+    await waitFor(() => expect(loadWorkspaceDiff.mock.calls.length).toBeGreaterThan(beforeChange));
+    expect(loadWorkspaceDiff).toHaveBeenLastCalledWith(
+      "ws-1",
+      "head",
+      false,
+      expect.objectContaining({ workspaceHostKey: "member", preserveVisible: true }),
+    );
+  });
+
+  it("retries a fleet diff watch while the workspace transitions from creating to ready", async () => {
+    window.__BASE_PATH__ = window.location.origin;
+    localStorage.setItem("middleman-workspace-sidebar-open", "true");
+    localStorage.setItem("middleman-workspace-sidebar-tab", "diff");
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    let watchCalls = 0;
+    const fetchMock = vi.fn().mockImplementation((input: Request | URL | string) => {
+      const raw = input instanceof Request ? input.url : String(input);
+      const url = new URL(raw, "http://localhost");
+      if (url.pathname.endsWith("/fleet/hosts/member/workspaces/ws-1/diff/watch")) {
+        watchCalls += 1;
+        if (watchCalls === 1) {
+          return Promise.resolve(Response.json({ detail: "workspace is not ready" }, { status: 409 }));
+        }
+        if (watchCalls === 2) {
+          return Promise.resolve(Response.json({ changed: true, version: "fleet:ready" }));
+        }
+        return new Promise<Response>(() => {});
+      }
+      if (url.pathname.endsWith("/fleet/hosts/member/workspaces/ws-1")) {
+        return Promise.resolve(Response.json({ ...workspaceResponse, fleet_host_key: "member" }));
+      }
+      if (url.pathname.endsWith("/api/v1/workspaces")) {
+        return Promise.resolve(Response.json({ workspaces: [] }));
+      }
+      return Promise.resolve(Response.json({}));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const loadWorkspaceDiff = vi.spyOn(mocks.diffStore, "loadWorkspaceDiff").mockResolvedValue();
+
+    render(WorkspaceTerminalView, {
+      props: { workspaceId: "ws-1", workspaceHostKey: "member" },
+      context: new Map([[STORES_KEY, { diff: mocks.diffStore }]]),
+    });
+
+    await waitFor(() => expect(watchCalls).toBe(3), { timeout: 2_000 });
+    expect(
+      fetchMock.mock.calls.some(([input]) => {
+        const raw = input instanceof Request ? input.url : String(input);
+        return new URL(raw, "http://localhost").searchParams.get("version") === "fleet:ready";
+      }),
+    ).toBe(true);
+    await waitFor(() => {
+      expect(loadWorkspaceDiff).toHaveBeenLastCalledWith(
+        "ws-1",
+        "head",
+        false,
+        expect.objectContaining({ workspaceHostKey: "member", preserveVisible: true }),
+      );
+    });
+  });
+
+  it("removes the old sidebar and waits for matching runtime before loading the new diff", async () => {
+    window.__BASE_PATH__ = window.location.origin;
+    localStorage.setItem("middleman-workspace-sidebar-open", "true");
+    localStorage.setItem("middleman-workspace-sidebar-tab", "diff");
+    const workspaceB = { ...workspaceResponse, id: "ws-2", git_head_ref: "feature/two" };
+    const workspaceBGate = deferred<typeof workspaceB>();
+    const runtimeBGate = deferred<ReturnType<typeof runtimeWithStaleSession>>();
+    const eventListeners: Array<Record<string, (event: MessageEvent) => void>> = [];
+    const loadWorkspaceDiff = vi.spyOn(mocks.diffStore, "loadWorkspaceDiff").mockResolvedValue();
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((input: Request | URL | string) => {
+        const path = fetchPath(input);
+        if (path.endsWith("/workspaces/ws-1")) return Promise.resolve(Response.json(workspaceResponse));
+        if (path.endsWith("/workspaces/ws-2")) {
+          return workspaceBGate.promise.then((workspace) => Response.json(workspace));
+        }
+        if (path.endsWith("/api/v1/workspaces")) {
+          return Promise.resolve(Response.json({ workspaces: [workspaceResponse, workspaceB] }));
+        }
+        return Promise.resolve(Response.json({}));
+      }),
+    );
+    vi.stubGlobal(
+      "EventSource",
+      class {
+        private listeners: Record<string, (event: MessageEvent) => void> = {};
+        constructor() {
+          eventListeners.push(this.listeners);
+        }
+        addEventListener(type: string, callback: (event: MessageEvent) => void): void {
+          this.listeners[type] = callback;
+        }
+        close(): void {}
+      },
+    );
+    mocks.getWorkspaceRuntime
+      .mockResolvedValueOnce(runtimeWithStaleSession())
+      .mockReturnValueOnce(runtimeBGate.promise);
+
+    const { rerender } = render(WorkspaceTerminalView, {
+      props: { workspaceId: "ws-1" },
+      context: new Map([[STORES_KEY, { diff: mocks.diffStore }]]),
+    });
+    await waitFor(() => expect(loadWorkspaceDiff).toHaveBeenCalledWith("ws-1", "head", false, expect.anything()));
+
+    await rerender({ workspaceId: "ws-2" });
+
+    expect(await screen.findByText("Loading workspace details...")).toBeTruthy();
+    expect(screen.queryByRole("region", { name: "Workspace Diff" })).toBeNull();
+    expect(loadWorkspaceDiff).toHaveBeenCalledTimes(1);
+
+    eventListeners.at(-1)?.workspace_diff_ready?.(
+      new MessageEvent("workspace_diff_ready", {
+        data: JSON.stringify({ workspace_id: "ws-2", version: "generation:2" }),
+      }),
+    );
+    workspaceBGate.resolve(workspaceB);
+    await Promise.resolve();
+    expect(loadWorkspaceDiff).toHaveBeenCalledTimes(1);
+
+    runtimeBGate.resolve(runtimeWithStaleSession());
+    await waitFor(() => expect(loadWorkspaceDiff).toHaveBeenCalledWith("ws-2", "head", false, expect.anything()));
+    expect(screen.queryByText("Loading workspace details...")).toBeNull();
+  });
+
+  it("renders matching workspace details when runtime loading fails", async () => {
+    window.__BASE_PATH__ = window.location.origin;
+    localStorage.setItem("middleman-workspace-sidebar-open", "true");
+    localStorage.setItem("middleman-workspace-sidebar-tab", "diff");
+    const loadWorkspaceDiff = vi.spyOn(mocks.diffStore, "loadWorkspaceDiff").mockResolvedValue();
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((input: Request | URL | string) => {
+        const path = fetchPath(input);
+        if (path.endsWith("/workspaces/ws-1")) return Promise.resolve(Response.json(workspaceResponse));
+        if (path.endsWith("/api/v1/workspaces")) {
+          return Promise.resolve(Response.json({ workspaces: [workspaceResponse] }));
+        }
+        return Promise.resolve(Response.json({}));
+      }),
+    );
+    vi.stubGlobal(
+      "EventSource",
+      class {
+        addEventListener(): void {}
+        close(): void {}
+      },
+    );
+    mocks.getWorkspaceRuntime.mockRejectedValue(new Error("runtime unavailable"));
+
+    render(WorkspaceTerminalView, {
+      props: { workspaceId: "ws-1" },
+      context: new Map([[STORES_KEY, { diff: mocks.diffStore }]]),
+    });
+
+    expect(await screen.findByText("runtime unavailable")).toBeTruthy();
+    await waitFor(() => expect(loadWorkspaceDiff).toHaveBeenCalledWith("ws-1", "head", false, expect.anything()));
+    expect(screen.queryByText("Loading workspace details...")).toBeNull();
   });
 
   it("treats id-less workspace status events as global invalidation", async () => {

--- a/frontend/src/lib/components/terminal/fleet-diff-watch.test.ts
+++ b/frontend/src/lib/components/terminal/fleet-diff-watch.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vite-plus/test";
+import { shouldRetryFleetDiffWatch } from "./fleet-diff-watch.js";
+
+describe("shouldRetryFleetDiffWatch", () => {
+  it.each([
+    { status: 404, retry: false },
+    { status: 405, retry: false },
+    { status: 408, retry: true },
+    { status: 409, retry: true },
+    { status: 425, retry: true },
+    { status: 429, retry: true },
+    { status: 500, retry: true },
+    { status: 501, retry: false },
+    { status: 503, retry: true },
+  ])("returns $retry for HTTP $status", ({ status, retry }) => {
+    expect(shouldRetryFleetDiffWatch(status)).toBe(retry);
+  });
+});

--- a/frontend/src/lib/components/terminal/fleet-diff-watch.ts
+++ b/frontend/src/lib/components/terminal/fleet-diff-watch.ts
@@ -1,0 +1,4 @@
+export function shouldRetryFleetDiffWatch(status: number): boolean {
+  if (status === 501) return false;
+  return status === 408 || status === 409 || status === 425 || status === 429 || status >= 500;
+}

--- a/frontend/src/lib/stores/diff.svelte.test.ts
+++ b/frontend/src/lib/stores/diff.svelte.test.ts
@@ -410,6 +410,62 @@ describe("createDiffStore loadDiff", () => {
     expect(filesCalls).toBe(2);
   });
 
+  it("rejects preview recovery superseded while its workspace reload is pending", async () => {
+    let filesCalls = 0;
+    let previewCalls = 0;
+    let releaseRecovery: () => void = () => {};
+    let signalRecoveryStarted: () => void = () => {};
+    const recoveryStarted = new Promise<void>((resolve) => {
+      signalRecoveryStarted = resolve;
+    });
+    const recoveryGate = new Promise<void>((resolve) => {
+      releaseRecovery = resolve;
+    });
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (url.includes("/workspaces/ws-1/files")) {
+        filesCalls += 1;
+        if (filesCalls === 2) {
+          signalRecoveryStarted();
+          await recoveryGate;
+        }
+        return Response.json(makeFilesResult(["original.ts"], { snapshot_version: `generation:${filesCalls}` }));
+      }
+      if (url.includes("/workspaces/ws-1/diff")) {
+        return Response.json({
+          ...makeDiffResult(["original.ts"]),
+          snapshot_version: `generation:${filesCalls}`,
+        });
+      }
+      if (url.includes("/workspaces/ws-1/file-preview")) {
+        previewCalls += 1;
+        if (previewCalls === 1) {
+          return Response.json(
+            { code: "conflict", detail: "snapshot changed", details: { reason: "snapshot_changed" } },
+            { status: 409 },
+          );
+        }
+        return Response.json({ path: "original.ts", content: "superseded retry" });
+      }
+      return Response.json({}, { status: 404 });
+    });
+
+    const store = createDiffStore({ client: testClient() });
+    const initialToken = {};
+    const replacementToken = {};
+    await store.loadWorkspaceDiff("ws-1", "head", false, { loadToken: initialToken });
+    const preview = store.loadFilePreview("owner", "repo", 1, "original.ts", "new");
+    await recoveryStarted;
+
+    await store.loadWorkspaceDiff("ws-1", "head", false, { loadToken: replacementToken });
+    releaseRecovery();
+
+    await expect(preview).rejects.toThrow("Workspace changed while refreshing file preview");
+    expect(previewCalls).toBe(1);
+    expect(store.getDiff()?.snapshot_version).toBe("generation:3");
+  });
+
   it("loads workspace diffs against the merge target", async () => {
     const calls: string[] = [];
     const files = makeFilesResult(["src/app.go"]);

--- a/frontend/src/lib/stores/diff.svelte.test.ts
+++ b/frontend/src/lib/stores/diff.svelte.test.ts
@@ -232,6 +232,56 @@ describe("createDiffStore loadDiff", () => {
     expect(store.getDiff()?.files[0]?.path).toBe("b.ts");
   });
 
+  it("keeps retrying a preserving workspace refresh until both responses are fresh", async () => {
+    vi.useFakeTimers();
+    try {
+      let filesCalls = 0;
+      let diffCalls = 0;
+      let signalStalePair: () => void = () => {};
+      const stalePairSeen = new Promise<void>((resolve) => {
+        signalStalePair = resolve;
+      });
+
+      vi.spyOn(globalThis, "fetch").mockImplementation(async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+        if (url.includes("/workspaces/ws-1/files")) {
+          filesCalls += 1;
+          return Response.json(
+            makeFilesResult(["a.ts"], {
+              stale: filesCalls === 2,
+              snapshot_version: "generation:1",
+            }),
+          );
+        }
+        if (url.includes("/workspaces/ws-1/diff")) {
+          diffCalls += 1;
+          if (diffCalls === 2) signalStalePair();
+          return Response.json({
+            ...makeDiffResult(["a.ts"]),
+            stale: diffCalls === 2,
+            snapshot_version: "generation:1",
+          });
+        }
+        return Response.json({}, { status: 404 });
+      });
+
+      const store = createDiffStore({ client: testClient() });
+      await store.loadWorkspaceDiff("ws-1", "head");
+      const refresh = store.loadWorkspaceDiff("ws-1", "head", false, { preserveVisible: true });
+      await stalePairSeen;
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(store.getDiff()?.stale).toBe(false);
+
+      await vi.runOnlyPendingTimersAsync();
+      await refresh;
+      expect(store.getDiff()?.stale).toBe(false);
+      expect(filesCalls).toBe(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("retries a workspace diff pair when its pinned revision changes", async () => {
     const calls: string[] = [];
     let filesCalls = 0;

--- a/frontend/src/lib/stores/diff.svelte.test.ts
+++ b/frontend/src/lib/stores/diff.svelte.test.ts
@@ -185,6 +185,87 @@ describe("createDiffStore loadDiff", () => {
     });
   });
 
+  it("keeps a coherent workspace diff visible during a preserving refresh", async () => {
+    const filesA = makeFilesResult(["a.ts"], { snapshot_version: "generation:1" });
+    const diffA = { ...makeDiffResult(["a.ts"]), snapshot_version: "generation:1" };
+    const filesB = makeFilesResult(["b.ts"], { snapshot_version: "generation:2" });
+    const diffB = { ...makeDiffResult(["b.ts"]), snapshot_version: "generation:2" };
+    let filesCalls = 0;
+    let diffCalls = 0;
+    let signalDiffStarted: () => void = () => {};
+    let releaseDiff: () => void = () => {};
+    const diffStarted = new Promise<void>((resolve) => {
+      signalDiffStarted = resolve;
+    });
+    const diffGate = new Promise<void>((resolve) => {
+      releaseDiff = resolve;
+    });
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (url.includes("/workspaces/ws-1/files")) {
+        filesCalls += 1;
+        return Response.json(filesCalls === 1 ? filesA : filesB);
+      }
+      if (url.includes("/workspaces/ws-1/diff")) {
+        diffCalls += 1;
+        if (diffCalls === 2) {
+          signalDiffStarted();
+          await diffGate;
+        }
+        return Response.json(diffCalls === 1 ? diffA : diffB);
+      }
+      return Response.json({}, { status: 404 });
+    });
+
+    const store = createDiffStore({ client: testClient() });
+    await store.loadWorkspaceDiff("ws-1", "head");
+
+    const refresh = store.loadWorkspaceDiff("ws-1", "head", false, { preserveVisible: true });
+    await diffStarted;
+    expect(store.getFileList()?.files[0]?.path).toBe("a.ts");
+    expect(store.getDiff()?.files[0]?.path).toBe("a.ts");
+
+    releaseDiff();
+    await refresh;
+    expect(store.getFileList()?.files[0]?.path).toBe("b.ts");
+    expect(store.getDiff()?.files[0]?.path).toBe("b.ts");
+  });
+
+  it("retries a workspace diff pair when its pinned revision changes", async () => {
+    const calls: string[] = [];
+    let filesCalls = 0;
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      calls.push(url);
+      if (url.includes("/workspaces/ws-1/files")) {
+        filesCalls += 1;
+        return Response.json(
+          makeFilesResult([filesCalls === 1 ? "old.ts" : "new.ts"], {
+            snapshot_version: `generation:${filesCalls}`,
+          }),
+        );
+      }
+      if (url.includes("revision=generation%3A1")) {
+        return Response.json({ detail: "snapshot changed" }, { status: 409 });
+      }
+      if (url.includes("revision=generation%3A2")) {
+        return Response.json({ ...makeDiffResult(["new.ts"]), snapshot_version: "generation:2" });
+      }
+      return Response.json({}, { status: 404 });
+    });
+
+    const store = createDiffStore({ client: testClient() });
+    await store.loadWorkspaceDiff("ws-1", "head");
+
+    expect(filesCalls).toBe(2);
+    expect(store.getFileList()?.files[0]?.path).toBe("new.ts");
+    expect(store.getDiff()?.files[0]?.path).toBe("new.ts");
+    expect(calls).toContain("/api/v1/workspaces/ws-1/diff?base=head&revision=generation%3A1");
+    expect(calls).toContain("/api/v1/workspaces/ws-1/diff?base=head&revision=generation%3A2");
+  });
+
   it("loads remote workspace files, diff, commits, and previews through the fleet host route", async () => {
     const calls: string[] = [];
     const files = makeFilesResult(["src/remote.go"]);

--- a/frontend/src/lib/stores/diff.svelte.test.ts
+++ b/frontend/src/lib/stores/diff.svelte.test.ts
@@ -362,6 +362,54 @@ describe("createDiffStore loadDiff", () => {
     );
   });
 
+  it("rejects stale preview recovery after a newer same-workspace load takes ownership", async () => {
+    let filesCalls = 0;
+    let releasePreview: () => void = () => {};
+    let signalPreviewStarted: () => void = () => {};
+    const previewStarted = new Promise<void>((resolve) => {
+      signalPreviewStarted = resolve;
+    });
+    const previewGate = new Promise<void>((resolve) => {
+      releasePreview = resolve;
+    });
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (url.includes("/workspaces/ws-1/files")) {
+        filesCalls += 1;
+        const path = filesCalls === 1 ? "original.ts" : filesCalls === 2 ? "replacement.ts" : "stale.ts";
+        return Response.json(makeFilesResult([path], { snapshot_version: `generation:${filesCalls}` }));
+      }
+      if (url.includes("/workspaces/ws-1/diff")) {
+        const path = filesCalls === 1 ? "original.ts" : filesCalls === 2 ? "replacement.ts" : "stale.ts";
+        return Response.json({ ...makeDiffResult([path]), snapshot_version: `generation:${filesCalls}` });
+      }
+      if (url.includes("/workspaces/ws-1/file-preview")) {
+        signalPreviewStarted();
+        await previewGate;
+        return Response.json(
+          { code: "conflict", detail: "snapshot changed", details: { reason: "snapshot_changed" } },
+          { status: 409 },
+        );
+      }
+      return Response.json({}, { status: 404 });
+    });
+
+    const store = createDiffStore({ client: testClient() });
+    const initialToken = {};
+    const replacementToken = {};
+    await store.loadWorkspaceDiff("ws-1", "head", false, { loadToken: initialToken });
+    const preview = store.loadFilePreview("owner", "repo", 1, "original.ts", "new");
+    await previewStarted;
+
+    await store.loadWorkspaceDiff("ws-1", "head", false, { loadToken: replacementToken });
+    releasePreview();
+
+    await expect(preview).rejects.toThrow("Workspace changed while refreshing file preview");
+    expect(store.getDiff()?.files[0]?.path).toBe("replacement.ts");
+    expect(filesCalls).toBe(2);
+  });
+
   it("loads workspace diffs against the merge target", async () => {
     const calls: string[] = [];
     const files = makeFilesResult(["src/app.go"]);

--- a/frontend/src/lib/stores/diff.svelte.test.ts
+++ b/frontend/src/lib/stores/diff.svelte.test.ts
@@ -248,7 +248,10 @@ describe("createDiffStore loadDiff", () => {
         );
       }
       if (url.includes("revision=generation%3A1")) {
-        return Response.json({ detail: "snapshot changed" }, { status: 409 });
+        return Response.json(
+          { code: "conflict", detail: "snapshot changed", details: { reason: "snapshot_changed" } },
+          { status: 409 },
+        );
       }
       if (url.includes("revision=generation%3A2")) {
         return Response.json({ ...makeDiffResult(["new.ts"]), snapshot_version: "generation:2" });
@@ -268,8 +271,8 @@ describe("createDiffStore loadDiff", () => {
 
   it("loads remote workspace files, diff, commits, and previews through the fleet host route", async () => {
     const calls: string[] = [];
-    const files = makeFilesResult(["src/remote.go"]);
-    const diff = makeDiffResult(["src/remote.go"]);
+    const files = makeFilesResult(["src/remote.go"], { snapshot_version: "generation:1" });
+    const diff = { ...makeDiffResult(["src/remote.go"]), snapshot_version: "generation:1" };
 
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input: RequestInfo | URL) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
@@ -308,12 +311,55 @@ describe("createDiffStore loadDiff", () => {
     await store.loadFilePreview("owner", "repo", 1, "src/remote.go", "new");
 
     expect(calls).toContain("/api/v1/fleet/hosts/member/workspaces/ws-1/files?base=merge-target");
-    expect(calls).toContain("/api/v1/fleet/hosts/member/workspaces/ws-1/diff?base=merge-target");
+    expect(calls).toContain(
+      "/api/v1/fleet/hosts/member/workspaces/ws-1/diff?base=merge-target&revision=generation%3A1",
+    );
     expect(calls).toContain("/api/v1/fleet/hosts/member/workspaces/ws-1/commits");
     expect(calls).toContain(
-      "/api/v1/fleet/hosts/member/workspaces/ws-1/file-preview?base=merge-target&path=src%2Fremote.go&side=new",
+      "/api/v1/fleet/hosts/member/workspaces/ws-1/file-preview?base=merge-target&path=src%2Fremote.go&side=new&revision=generation%3A1",
     );
     expect(calls.some((url) => url.includes("/api/v1/workspaces/ws-1/"))).toBe(false);
+  });
+
+  it("reloads the coherent workspace snapshot and retries a conflicted preview once", async () => {
+    const calls: string[] = [];
+    let filesCalls = 0;
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      calls.push(url);
+      if (url.includes("/workspaces/ws-1/files")) {
+        filesCalls += 1;
+        return Response.json(makeFilesResult(["src/app.go"], { snapshot_version: `generation:${filesCalls}` }));
+      }
+      if (url.includes("/workspaces/ws-1/diff")) {
+        return Response.json({ ...makeDiffResult(["src/app.go"]), snapshot_version: `generation:${filesCalls}` });
+      }
+      if (url.includes("revision=generation%3A1")) {
+        return Response.json(
+          { code: "conflict", detail: "snapshot changed", details: { reason: "snapshot_changed" } },
+          { status: 409 },
+        );
+      }
+      if (url.includes("revision=generation%3A2")) {
+        return Response.json({ path: "src/app.go", content: "package refreshed" });
+      }
+      return Response.json({}, { status: 404 });
+    });
+
+    const store = createDiffStore({ client: testClient() });
+    await store.loadWorkspaceDiff("ws-1", "head");
+
+    const preview = await store.loadFilePreview("owner", "repo", 1, "src/app.go", "new");
+
+    expect(preview.content).toBe("package refreshed");
+    expect(filesCalls).toBe(2);
+    expect(calls).toContain(
+      "/api/v1/workspaces/ws-1/file-preview?base=head&path=src%2Fapp.go&side=new&revision=generation%3A1",
+    );
+    expect(calls).toContain(
+      "/api/v1/workspaces/ws-1/file-preview?base=head&path=src%2Fapp.go&side=new&revision=generation%3A2",
+    );
   });
 
   it("loads workspace diffs against the merge target", async () => {
@@ -681,6 +727,143 @@ describe("createDiffStore loadDiff", () => {
     expect(calls).not.toContain("/api/v1/fleet/hosts/member-a/workspaces/ws-1/files?base=merge-target");
     expect(calls).not.toContain("/api/v1/fleet/hosts/member-a/workspaces/ws-1/diff?base=merge-target");
     expect(store.getDiff()?.files[0]?.path).toBe("member-b.ts");
+  });
+
+  it("does not resume a canceled workspace load after commit refresh", async () => {
+    const calls: string[] = [];
+    let commitCalls = 0;
+    let releaseRefresh: () => void = () => {};
+    let signalRefresh: () => void = () => {};
+    const refreshStarted = new Promise<void>((resolve) => {
+      signalRefresh = resolve;
+    });
+    const refreshGate = new Promise<void>((resolve) => {
+      releaseRefresh = resolve;
+    });
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      calls.push(url);
+      if (url.includes("/workspaces/ws-1/commits")) {
+        commitCalls += 1;
+        if (commitCalls === 2) {
+          signalRefresh();
+          await refreshGate;
+        }
+        return Response.json({ commits: [] });
+      }
+      if (url.includes("/workspaces/ws-1/files")) {
+        return Response.json(makeFilesResult(["a.ts"]));
+      }
+      if (url.includes("/workspaces/ws-1/diff")) {
+        return Response.json(makeDiffResult(["a.ts"]));
+      }
+      return Response.json({}, { status: 404 });
+    });
+
+    const store = createDiffStore({ client: testClient() });
+    await store.loadWorkspaceDiff("ws-1", "head");
+    await store.loadCommits();
+    calls.length = 0;
+
+    const refresh = store.loadWorkspaceDiff("ws-1", "head", false, { refreshCommits: true });
+    await refreshStarted;
+    store.cancelWorkspaceDiff("ws-1");
+    releaseRefresh();
+    await refresh;
+
+    expect(calls).toEqual(["/api/v1/workspaces/ws-1/commits"]);
+    expect(store.isDiffLoading()).toBe(false);
+  });
+
+  it("does not let a superseded same-workspace owner cancel the replacement load", async () => {
+    const tokenA = {};
+    const tokenB = {};
+    let commitCalls = 0;
+    let filesCalls = 0;
+    let releaseCommitRefresh: () => void = () => {};
+    let signalCommitRefresh: () => void = () => {};
+    const commitRefreshStarted = new Promise<void>((resolve) => {
+      signalCommitRefresh = resolve;
+    });
+    const commitRefreshGate = new Promise<void>((resolve) => {
+      releaseCommitRefresh = resolve;
+    });
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (url.includes("/workspaces/ws-1/commits")) {
+        commitCalls += 1;
+        if (commitCalls === 2) {
+          signalCommitRefresh();
+          await commitRefreshGate;
+        }
+        return Response.json({ commits: [] });
+      }
+      if (url.includes("/workspaces/ws-1/files")) {
+        filesCalls += 1;
+        return Response.json(makeFilesResult([filesCalls === 1 ? "original.ts" : "replacement.ts"]));
+      }
+      if (url.includes("/workspaces/ws-1/diff")) {
+        return Response.json(makeDiffResult([filesCalls === 1 ? "original.ts" : "replacement.ts"]));
+      }
+      return Response.json({}, { status: 404 });
+    });
+
+    const store = createDiffStore({ client: testClient() });
+    await store.loadWorkspaceDiff("ws-1", "head", false, { loadToken: tokenA });
+    await store.loadCommits();
+
+    const replacement = store.loadWorkspaceDiff("ws-1", "head", false, {
+      loadToken: tokenB,
+      refreshCommits: true,
+    });
+    await commitRefreshStarted;
+    store.cancelWorkspaceDiff("ws-1", undefined, tokenA);
+    releaseCommitRefresh();
+    await replacement;
+
+    expect(store.getDiff()?.files[0]?.path).toBe("replacement.ts");
+    expect(store.getDiffError()).toBeNull();
+  });
+
+  it("keeps the workspace owner token through a commit-scope reload", async () => {
+    const token = {};
+    let scopeSignal: AbortSignal | undefined;
+    let signalScopeRequest: () => void = () => {};
+    const scopeRequestStarted = new Promise<void>((resolve) => {
+      signalScopeRequest = resolve;
+    });
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (url.includes("/workspaces/ws-1/commits")) {
+        return Response.json({
+          commits: [{ sha: "sha2", message: "second", author_name: "Alice" }],
+        });
+      }
+      if (url.includes("commit=sha2")) {
+        scopeSignal = init?.signal ?? undefined;
+        signalScopeRequest();
+        return new Promise<Response>(() => {});
+      }
+      if (url.includes("/workspaces/ws-1/files")) {
+        return Response.json(makeFilesResult(["original.ts"]));
+      }
+      if (url.includes("/workspaces/ws-1/diff")) {
+        return Response.json(makeDiffResult(["original.ts"]));
+      }
+      return Response.json({}, { status: 404 });
+    });
+
+    const store = createDiffStore({ client: testClient() });
+    await store.loadWorkspaceDiff("ws-1", "head", false, { loadToken: token });
+    await store.loadCommits();
+    store.selectCommit("sha2");
+    await scopeRequestStarted;
+
+    store.cancelWorkspaceDiff("ws-1", undefined, token);
+
+    expect(scopeSignal?.aborted).toBe(true);
   });
 
   it("resets workspace commit scope when refresh removes the selected commit", async () => {

--- a/frontend/tests/e2e-full/00-workspace-tab-persistence.spec.ts
+++ b/frontend/tests/e2e-full/00-workspace-tab-persistence.spec.ts
@@ -394,6 +394,123 @@ test.describe("workspace tab persistence", () => {
     }
   });
 
+  test("prepares the selected diff before workspace details finish switching", async ({ page }) => {
+    test.skip(
+      !hasCommand("git") || !hasCommand("tmux", ["-V"]),
+      "git and tmux are required for the real workspace flow",
+    );
+
+    let isolatedServer: IsolatedE2EServer | null = null;
+    let api: APIRequestContext | null = null;
+    try {
+      isolatedServer = await startIsolatedWorkspaceE2EServer();
+      api = await playwrightRequest.newContext({
+        baseURL: isolatedServer.info.base_url,
+      });
+
+      const workspaceA = await createIssueWorkspace(api, 10);
+      const workspaceB = await createIssueWorkspace(api, 11);
+      const [workspaceAResponse, workspaceBResponse] = await Promise.all([
+        api.get(`/api/v1/workspaces/${workspaceA.id}`),
+        api.get(`/api/v1/workspaces/${workspaceB.id}`),
+      ]);
+      expect(workspaceAResponse.ok()).toBe(true);
+      expect(workspaceBResponse.ok()).toBe(true);
+      const workspaceADetail = (await workspaceAResponse.json()) as WorkspaceStatusResponse;
+      const workspaceBDetail = (await workspaceBResponse.json()) as WorkspaceStatusResponse;
+      expect(workspaceADetail.worktree_path).toBeTruthy();
+      expect(workspaceBDetail.worktree_path).toBeTruthy();
+      await writeFile(join(workspaceADetail.worktree_path!, "workspace-a.txt"), "workspace a\n");
+      await writeFile(join(workspaceBDetail.worktree_path!, "workspace-b.txt"), "workspace b\n");
+
+      await page.addInitScript(() => {
+        const NativeEventSource = window.EventSource;
+        const readyWorkspaceIDs: string[] = [];
+        (
+          window as Window & {
+            __workspaceDiffReadyIDs?: string[];
+          }
+        ).__workspaceDiffReadyIDs = readyWorkspaceIDs;
+        window.EventSource = class extends NativeEventSource {
+          constructor(url: string | URL, eventSourceInitDict?: EventSourceInit) {
+            super(url, eventSourceInitDict);
+            this.addEventListener("workspace_diff_ready", (event) => {
+              const data = JSON.parse((event as MessageEvent).data as string) as {
+                workspace_id?: string;
+              };
+              if (data.workspace_id) readyWorkspaceIDs.push(data.workspace_id);
+            });
+          }
+        };
+      });
+
+      let releaseWorkspaceDetail!: () => void;
+      const workspaceDetailMayContinue = new Promise<void>((resolve) => {
+        releaseWorkspaceDetail = resolve;
+      });
+      let releaseRuntime!: () => void;
+      const runtimeMayContinue = new Promise<void>((resolve) => {
+        releaseRuntime = resolve;
+      });
+      await page.route(
+        (url) => url.pathname === `/api/v1/workspaces/${workspaceB.id}`,
+        async (route) => {
+          await workspaceDetailMayContinue;
+          await route.continue();
+        },
+      );
+      await page.route(
+        (url) => url.pathname === `/api/v1/workspaces/${workspaceB.id}/runtime`,
+        async (route) => {
+          await runtimeMayContinue;
+          await route.continue();
+        },
+      );
+
+      const workspaceBDiffRequests: string[] = [];
+      page.on("request", (request) => {
+        const path = new URL(request.url()).pathname;
+        if (
+          path === `/api/v1/workspaces/${workspaceB.id}/files` ||
+          path === `/api/v1/workspaces/${workspaceB.id}/diff`
+        ) {
+          workspaceBDiffRequests.push(path);
+        }
+      });
+
+      await page.goto(`${isolatedServer.info.base_url}/terminal/${workspaceA.id}`);
+      await page.locator(".panel-toggle-group .panel-toggle-btn", { hasText: "Diff" }).click();
+      await expect(page.getByRole("region", { name: "Workspace Diff" })).toBeVisible();
+
+      await page.locator(".workspace-list-sidebar .ws-row", { hasText: "Add dark mode support" }).click();
+      await expect(page).toHaveURL(new RegExp(`/terminal/${workspaceB.id}$`));
+      await expect(page.getByText("Loading workspace details...")).toBeVisible();
+      await expect(page.getByRole("region", { name: "Workspace Diff" })).toHaveCount(0);
+
+      await page.waitForFunction(
+        (workspaceID) =>
+          (
+            window as Window & {
+              __workspaceDiffReadyIDs?: string[];
+            }
+          ).__workspaceDiffReadyIDs?.includes(workspaceID),
+        workspaceB.id,
+      );
+      expect(workspaceBDiffRequests).toEqual([]);
+
+      releaseWorkspaceDetail();
+      await expect(page.getByText("Loading workspace details...")).toBeVisible();
+      expect(workspaceBDiffRequests).toEqual([]);
+
+      releaseRuntime();
+      await expect(page.getByRole("region", { name: "Workspace Diff" })).toBeVisible();
+      await expect.poll(() => workspaceBDiffRequests).toContain(`/api/v1/workspaces/${workspaceB.id}/files`);
+    } finally {
+      await api?.dispose();
+      await isolatedServer?.stop();
+    }
+  });
+
   test("workspace diff context expansion renders text from the real preview API", async ({ page }) => {
     test.skip(
       !hasCommand("git") || !hasCommand("tmux", ["-V"]),

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/go-github/v88 v88.0.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
+	github.com/jellydator/ttlcache/v3 v3.4.1
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/klauspost/compress v1.18.6
 	github.com/microcosm-cc/bluemonday v1.0.27

--- a/go.sum
+++ b/go.sum
@@ -317,6 +317,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/inhies/go-bytesize v0.0.0-20220417184213-4913239db9cf h1:FtEj8sfIcaaBfAKrE1Cwb61YDtYq9JxChK1c7AKce7s=
 github.com/inhies/go-bytesize v0.0.0-20220417184213-4913239db9cf/go.mod h1:yrqSXGoD/4EKfF26AOGzscPOgTTJcyAwM2rpixWT+t4=
+github.com/jellydator/ttlcache/v3 v3.4.1 h1:bOdXmXiycyK6E6Qjyuj5vl+/vU3SCOoDs8a86NbHjAQ=
+github.com/jellydator/ttlcache/v3 v3.4.1/go.mod h1:j7LO12PNghFg5+0v9budMAT4rDK4JY969jb9vOdOBBk=
 github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -903,10 +903,13 @@ type DiffResponse struct {
 	Schema *string `json:"$schema,omitempty"`
 
 	// DiffHeadSha Synced PR diff snapshot head this diff was computed from. Always set for pull request diffs (the endpoint fails when no snapshot head is synced); empty for commit and workspace diffs. Compare with the pull detail's platform_head_sha to detect stale cached diff context; unrelated to 'stale', which reports clone-refresh staleness.
-	DiffHeadSha         *string     `json:"diff_head_sha,omitempty"`
-	Files               *[]DiffFile `json:"files"`
-	Stale               bool        `json:"stale"`
-	WhitespaceOnlyCount int64       `json:"whitespace_only_count"`
+	DiffHeadSha *string     `json:"diff_head_sha,omitempty"`
+	Files       *[]DiffFile `json:"files"`
+
+	// SnapshotVersion Opaque workspace diff snapshot version used to keep files and patches coherent.
+	SnapshotVersion     *string `json:"snapshot_version,omitempty"`
+	Stale               bool    `json:"stale"`
+	WhitespaceOnlyCount int64   `json:"whitespace_only_count"`
 }
 
 // DiffReviewDraftComment defines model for DiffReviewDraftComment.
@@ -1191,10 +1194,13 @@ type FilePreviewResponse struct {
 // FilesResponse defines model for FilesResponse.
 type FilesResponse struct {
 	// Schema A URL to the JSON Schema for this object.
-	Schema              *string     `json:"$schema,omitempty"`
-	Files               *[]DiffFile `json:"files"`
-	Stale               bool        `json:"stale"`
-	WhitespaceOnlyCount int64       `json:"whitespace_only_count"`
+	Schema *string     `json:"$schema,omitempty"`
+	Files  *[]DiffFile `json:"files"`
+
+	// SnapshotVersion Opaque workspace diff snapshot version to pin on the following workspace diff request.
+	SnapshotVersion     *string `json:"snapshot_version,omitempty"`
+	Stale               bool    `json:"stale"`
+	WhitespaceOnlyCount int64   `json:"whitespace_only_count"`
 }
 
 // FilesystemCompleteOutputBody defines model for FilesystemCompleteOutputBody.
@@ -3426,6 +3432,12 @@ type SearchDocsParams struct {
 	Limit *int64  `form:"limit,omitempty" json:"limit,omitempty"`
 }
 
+// StreamEventsParams defines parameters for StreamEvents.
+type StreamEventsParams struct {
+	// WorkspaceId Optional selected local workspace to prewarm and validate while this stream is connected
+	WorkspaceId *string `form:"workspace_id,omitempty" json:"workspace_id,omitempty"`
+}
+
 // CompleteFilesystemPathParams defines parameters for CompleteFilesystemPath.
 type CompleteFilesystemPathParams struct {
 	Path string `form:"path" json:"path"`
@@ -3923,6 +3935,9 @@ type GetWorkspaceDiffParams struct {
 
 	// To End SHA for range diff (inclusive)
 	To *string `form:"to,omitempty" json:"to,omitempty"`
+
+	// Revision Optional snapshot_version returned by the workspace files endpoint
+	Revision *string `form:"revision,omitempty" json:"revision,omitempty"`
 }
 
 // GetWorkspaceFilePreviewParams defines parameters for GetWorkspaceFilePreview.
@@ -4431,7 +4446,7 @@ type ClientInterface interface {
 	SearchDocs(ctx context.Context, params *SearchDocsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// StreamEvents request
-	StreamEvents(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+	StreamEvents(ctx context.Context, params *StreamEventsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// CompleteFilesystemPath request
 	CompleteFilesystemPath(ctx context.Context, params *CompleteFilesystemPathParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -5719,8 +5734,8 @@ func (c *Client) SearchDocs(ctx context.Context, params *SearchDocsParams, reqEd
 	return c.Client.Do(req)
 }
 
-func (c *Client) StreamEvents(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewStreamEventsRequest(c.Server)
+func (c *Client) StreamEvents(ctx context.Context, params *StreamEventsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewStreamEventsRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -11068,7 +11083,7 @@ func NewSearchDocsRequest(server string, params *SearchDocsParams) (*http.Reques
 }
 
 // NewStreamEventsRequest generates requests for StreamEvents
-func NewStreamEventsRequest(server string) (*http.Request, error) {
+func NewStreamEventsRequest(server string, params *StreamEventsParams) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -11084,6 +11099,33 @@ func NewStreamEventsRequest(server string) (*http.Request, error) {
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if params.WorkspaceId != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "workspace_id", *params.WorkspaceId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
 	}
 
 	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
@@ -26608,6 +26650,18 @@ func NewGetWorkspaceDiffRequest(server string, id string, params *GetWorkspaceDi
 		if params.To != nil {
 
 			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "to", *params.To, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.Revision != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "revision", *params.Revision, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
 				return nil, err
 			} else {
 				for _, qp := range strings.Split(queryFrag, "&") {

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -3232,6 +3232,18 @@ type WorkflowStateMetaResponse struct {
 // WorkflowStateMetaResponseStatus defines model for WorkflowStateMetaResponse.Status.
 type WorkflowStateMetaResponseStatus string
 
+// WorkspaceDiffWatchResponse defines model for WorkspaceDiffWatchResponse.
+type WorkspaceDiffWatchResponse struct {
+	// Schema A URL to the JSON Schema for this object.
+	Schema *string `json:"$schema,omitempty"`
+
+	// Changed True when the caller must reload the watched default-HEAD snapshot.
+	Changed bool `json:"changed"`
+
+	// Version Opaque version of the current default-HEAD snapshot; never a version from another diff scope.
+	Version string `json:"version"`
+}
+
 // WorkspaceKataMetadata defines model for WorkspaceKataMetadata.
 type WorkspaceKataMetadata struct {
 	DaemonId    string  `json:"daemon_id"`
@@ -3518,6 +3530,15 @@ type GetFleetWorkspaceDiffParams struct {
 
 	// To Newer range commit SHA.
 	To *string `form:"to,omitempty" json:"to,omitempty"`
+
+	// Revision Pinned workspace snapshot version.
+	Revision *string `form:"revision,omitempty" json:"revision,omitempty"`
+}
+
+// WatchFleetWorkspaceDiffParams defines parameters for WatchFleetWorkspaceDiff.
+type WatchFleetWorkspaceDiffParams struct {
+	// Version Last observed workspace diff snapshot version.
+	Version *string `form:"version,omitempty" json:"version,omitempty"`
 }
 
 // GetFleetWorkspaceFilePreviewParams defines parameters for GetFleetWorkspaceFilePreview.
@@ -3536,6 +3557,9 @@ type GetFleetWorkspaceFilePreviewParams struct {
 
 	// To Newer range commit SHA.
 	To *string `form:"to,omitempty" json:"to,omitempty"`
+
+	// Revision Pinned workspace snapshot version.
+	Revision *string `form:"revision,omitempty" json:"revision,omitempty"`
 
 	// Path Workspace file path to preview.
 	Path *string `form:"path,omitempty" json:"path,omitempty"`
@@ -3940,6 +3964,12 @@ type GetWorkspaceDiffParams struct {
 	Revision *string `form:"revision,omitempty" json:"revision,omitempty"`
 }
 
+// WatchWorkspaceDiffParams defines parameters for WatchWorkspaceDiff.
+type WatchWorkspaceDiffParams struct {
+	// Version Last observed opaque workspace diff snapshot version
+	Version *string `form:"version,omitempty" json:"version,omitempty"`
+}
+
 // GetWorkspaceFilePreviewParams defines parameters for GetWorkspaceFilePreview.
 type GetWorkspaceFilePreviewParams struct {
 	// Base Diff base: head, pushed, or merge-target
@@ -3962,6 +3992,9 @@ type GetWorkspaceFilePreviewParams struct {
 
 	// To End SHA for range diff (inclusive)
 	To *string `form:"to,omitempty" json:"to,omitempty"`
+
+	// Revision Optional snapshot_version returned by the workspace files endpoint
+	Revision *string `form:"revision,omitempty" json:"revision,omitempty"`
 }
 
 // GetWorkspaceFilePreviewParamsBase defines parameters for GetWorkspaceFilePreview.
@@ -4570,6 +4603,9 @@ type ClientInterface interface {
 
 	// GetFleetWorkspaceDiff request
 	GetFleetWorkspaceDiff(ctx context.Context, hostKey string, id string, params *GetFleetWorkspaceDiffParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// WatchFleetWorkspaceDiff request
+	WatchFleetWorkspaceDiff(ctx context.Context, hostKey string, id string, params *WatchFleetWorkspaceDiffParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetFleetWorkspaceFilePreview request
 	GetFleetWorkspaceFilePreview(ctx context.Context, hostKey string, id string, params *GetFleetWorkspaceFilePreviewParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -5387,6 +5423,9 @@ type ClientInterface interface {
 
 	// GetWorkspaceDiff request
 	GetWorkspaceDiff(ctx context.Context, id string, params *GetWorkspaceDiffParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// WatchWorkspaceDiff request
+	WatchWorkspaceDiff(ctx context.Context, id string, params *WatchWorkspaceDiffParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetWorkspaceFilePreview request
 	GetWorkspaceFilePreview(ctx context.Context, id string, params *GetWorkspaceFilePreviewParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -6276,6 +6315,18 @@ func (c *Client) GetFleetWorkspaceCommits(ctx context.Context, hostKey string, i
 
 func (c *Client) GetFleetWorkspaceDiff(ctx context.Context, hostKey string, id string, params *GetFleetWorkspaceDiffParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetFleetWorkspaceDiffRequest(c.Server, hostKey, id, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) WatchFleetWorkspaceDiff(ctx context.Context, hostKey string, id string, params *WatchFleetWorkspaceDiffParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewWatchFleetWorkspaceDiffRequest(c.Server, hostKey, id, params)
 	if err != nil {
 		return nil, err
 	}
@@ -9886,6 +9937,18 @@ func (c *Client) GetWorkspaceDiff(ctx context.Context, id string, params *GetWor
 	return c.Client.Do(req)
 }
 
+func (c *Client) WatchWorkspaceDiff(ctx context.Context, id string, params *WatchWorkspaceDiffParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewWatchWorkspaceDiffRequest(c.Server, id, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) GetWorkspaceFilePreview(ctx context.Context, id string, params *GetWorkspaceFilePreviewParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetWorkspaceFilePreviewRequest(c.Server, id, params)
 	if err != nil {
@@ -12881,6 +12944,86 @@ func NewGetFleetWorkspaceDiffRequest(server string, hostKey string, id string, p
 
 		}
 
+		if params.Revision != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "revision", *params.Revision, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewWatchFleetWorkspaceDiffRequest generates requests for WatchFleetWorkspaceDiff
+func NewWatchFleetWorkspaceDiffRequest(server string, hostKey string, id string, params *WatchFleetWorkspaceDiffParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "host_key", hostKey, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/fleet/hosts/%s/workspaces/%s/diff/watch", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if params.Version != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "version", *params.Version, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
 		if encoded := queryValues.Encode(); encoded != "" {
 			rawQueryFragments = append(rawQueryFragments, encoded)
 		}
@@ -12988,6 +13131,18 @@ func NewGetFleetWorkspaceFilePreviewRequest(server string, hostKey string, id st
 		if params.To != nil {
 
 			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "to", *params.To, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.Revision != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "revision", *params.Revision, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
 				return nil, err
 			} else {
 				for _, qp := range strings.Split(queryFrag, "&") {
@@ -26685,6 +26840,67 @@ func NewGetWorkspaceDiffRequest(server string, id string, params *GetWorkspaceDi
 	return req, nil
 }
 
+// NewWatchWorkspaceDiffRequest generates requests for WatchWorkspaceDiff
+func NewWatchWorkspaceDiffRequest(server string, id string, params *WatchWorkspaceDiffParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "id", id, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/workspaces/%s/diff/watch", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if params.Version != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "version", *params.Version, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewGetWorkspaceFilePreviewRequest generates requests for GetWorkspaceFilePreview
 func NewGetWorkspaceFilePreviewRequest(server string, id string, params *GetWorkspaceFilePreviewParams) (*http.Request, error) {
 	var err error
@@ -26795,6 +27011,18 @@ func NewGetWorkspaceFilePreviewRequest(server string, id string, params *GetWork
 		if params.To != nil {
 
 			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "to", *params.To, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.Revision != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "revision", *params.Revision, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
 				return nil, err
 			} else {
 				for _, qp := range strings.Split(queryFrag, "&") {
@@ -27588,6 +27816,9 @@ type ClientWithResponsesInterface interface {
 
 	// GetFleetWorkspaceDiffWithResponse request
 	GetFleetWorkspaceDiffWithResponse(ctx context.Context, hostKey string, id string, params *GetFleetWorkspaceDiffParams, reqEditors ...RequestEditorFn) (*GetFleetWorkspaceDiffResponse, error)
+
+	// WatchFleetWorkspaceDiffWithResponse request
+	WatchFleetWorkspaceDiffWithResponse(ctx context.Context, hostKey string, id string, params *WatchFleetWorkspaceDiffParams, reqEditors ...RequestEditorFn) (*WatchFleetWorkspaceDiffResponse, error)
 
 	// GetFleetWorkspaceFilePreviewWithResponse request
 	GetFleetWorkspaceFilePreviewWithResponse(ctx context.Context, hostKey string, id string, params *GetFleetWorkspaceFilePreviewParams, reqEditors ...RequestEditorFn) (*GetFleetWorkspaceFilePreviewResponse, error)
@@ -28405,6 +28636,9 @@ type ClientWithResponsesInterface interface {
 
 	// GetWorkspaceDiffWithResponse request
 	GetWorkspaceDiffWithResponse(ctx context.Context, id string, params *GetWorkspaceDiffParams, reqEditors ...RequestEditorFn) (*GetWorkspaceDiffResponse, error)
+
+	// WatchWorkspaceDiffWithResponse request
+	WatchWorkspaceDiffWithResponse(ctx context.Context, id string, params *WatchWorkspaceDiffParams, reqEditors ...RequestEditorFn) (*WatchWorkspaceDiffResponse, error)
 
 	// GetWorkspaceFilePreviewWithResponse request
 	GetWorkspaceFilePreviewWithResponse(ctx context.Context, id string, params *GetWorkspaceFilePreviewParams, reqEditors ...RequestEditorFn) (*GetWorkspaceFilePreviewResponse, error)
@@ -29639,6 +29873,29 @@ func (r GetFleetWorkspaceDiffResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r GetFleetWorkspaceDiffResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type WatchFleetWorkspaceDiffResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSONDefault                   *map[string]interface{}
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r WatchFleetWorkspaceDiffResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r WatchFleetWorkspaceDiffResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -34599,6 +34856,29 @@ func (r GetWorkspaceDiffResponse) StatusCode() int {
 	return 0
 }
 
+type WatchWorkspaceDiffResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *WorkspaceDiffWatchResponse
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r WatchWorkspaceDiffResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r WatchWorkspaceDiffResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type GetWorkspaceFilePreviewResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
@@ -35506,6 +35786,15 @@ func (c *ClientWithResponses) GetFleetWorkspaceDiffWithResponse(ctx context.Cont
 		return nil, err
 	}
 	return ParseGetFleetWorkspaceDiffResponse(rsp)
+}
+
+// WatchFleetWorkspaceDiffWithResponse request returning *WatchFleetWorkspaceDiffResponse
+func (c *ClientWithResponses) WatchFleetWorkspaceDiffWithResponse(ctx context.Context, hostKey string, id string, params *WatchFleetWorkspaceDiffParams, reqEditors ...RequestEditorFn) (*WatchFleetWorkspaceDiffResponse, error) {
+	rsp, err := c.WatchFleetWorkspaceDiff(ctx, hostKey, id, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseWatchFleetWorkspaceDiffResponse(rsp)
 }
 
 // GetFleetWorkspaceFilePreviewWithResponse request returning *GetFleetWorkspaceFilePreviewResponse
@@ -38125,6 +38414,15 @@ func (c *ClientWithResponses) GetWorkspaceDiffWithResponse(ctx context.Context, 
 	return ParseGetWorkspaceDiffResponse(rsp)
 }
 
+// WatchWorkspaceDiffWithResponse request returning *WatchWorkspaceDiffResponse
+func (c *ClientWithResponses) WatchWorkspaceDiffWithResponse(ctx context.Context, id string, params *WatchWorkspaceDiffParams, reqEditors ...RequestEditorFn) (*WatchWorkspaceDiffResponse, error) {
+	rsp, err := c.WatchWorkspaceDiff(ctx, id, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseWatchWorkspaceDiffResponse(rsp)
+}
+
 // GetWorkspaceFilePreviewWithResponse request returning *GetWorkspaceFilePreviewResponse
 func (c *ClientWithResponses) GetWorkspaceFilePreviewWithResponse(ctx context.Context, id string, params *GetWorkspaceFilePreviewParams, reqEditors ...RequestEditorFn) (*GetWorkspaceFilePreviewResponse, error) {
 	rsp, err := c.GetWorkspaceFilePreview(ctx, id, params, reqEditors...)
@@ -39937,6 +40235,39 @@ func ParseGetFleetWorkspaceDiffResponse(rsp *http.Response) (*GetFleetWorkspaceD
 	}
 
 	response := &GetFleetWorkspaceDiffResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case rsp.Header.Get("Content-Type") == "application/json" && true:
+		var dest map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	case rsp.Header.Get("Content-Type") == "application/problem+json" && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseWatchFleetWorkspaceDiffResponse parses an HTTP response from a WatchFleetWorkspaceDiffWithResponse call
+func ParseWatchFleetWorkspaceDiffResponse(rsp *http.Response) (*WatchFleetWorkspaceDiffResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &WatchFleetWorkspaceDiffResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -46846,6 +47177,39 @@ func ParseGetWorkspaceDiffResponse(rsp *http.Response) (*GetWorkspaceDiffRespons
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest DiffResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseWatchWorkspaceDiffResponse parses an HTTP response from a WatchWorkspaceDiffWithResponse call
+func ParseWatchWorkspaceDiffResponse(rsp *http.Response) (*WatchWorkspaceDiffResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &WatchWorkspaceDiffResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest WorkspaceDiffWatchResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/internal/apiclient/generated/client_stream_test.go
+++ b/internal/apiclient/generated/client_stream_test.go
@@ -39,7 +39,7 @@ func TestStreamEventsReturnsLiveEventStream(t *testing.T) {
 		err  error
 	}, 1)
 	go func() {
-		resp, err := client.StreamEvents(context.Background())
+		resp, err := client.StreamEvents(context.Background(), nil)
 		done <- struct {
 			resp *http.Response
 			err  error

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -26248,6 +26248,99 @@ func TestWorkspaceDiffEndpointMarksGeneratedFilesE2E(t *testing.T) {
 	assert.False(requireWorkspaceDiffFile(t, *diff.Files, "src.ts").IsGenerated)
 }
 
+func TestWorkspaceDiffSnapshotRefreshesSameSizeEditAndPinsRevisionE2E(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	assert := assert.New(t)
+
+	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, nil)
+	ws := createReadyWorkspace(t, context.Background(), client)
+	path := filepath.Join(ws.WorktreePath, "same-size.txt")
+	require.NoError(os.WriteFile(path, []byte("a1\n"), 0o644))
+
+	firstFiles := requestWorkspaceFiles(t, srv, ws.Id, "head")
+	require.NotNil(firstFiles.SnapshotVersion)
+	firstVersion := *firstFiles.SnapshotVersion
+	firstDiff := requestWorkspaceDiffQuery(
+		t, srv, ws.Id,
+		"base=head&revision="+url.QueryEscape(firstVersion),
+	)
+	require.NotNil(firstDiff.SnapshotVersion)
+	assert.Equal(firstVersion, *firstDiff.SnapshotVersion)
+
+	events, _ := srv.hub.Subscribe(t.Context(), false)
+	require.NoError(os.WriteFile(path, []byte("b1\n"), 0o644))
+	key := workspaceDiffLogicalKey{
+		WorkspaceID: ws.Id,
+		Spec: workspace.DiffSnapshotSpec{
+			WorktreePath: ws.WorktreePath,
+			Base:         workspace.WorktreeDiffBaseHead,
+		},
+	}
+	require.NoError(srv.workspaceDiffCache.validate(t.Context(), key))
+
+	select {
+	case event := <-events:
+		assert.Equal("workspace_diff_changed", event.Event.Type)
+	case <-time.After(time.Second):
+		require.Fail("workspace diff change event not received")
+	}
+
+	staleReq := newWorkspaceFixtureRequest(
+		http.MethodGet,
+		"/api/v1/workspaces/"+ws.Id+"/diff?base=head&revision="+url.QueryEscape(firstVersion),
+		nil,
+	)
+	staleRR := httptest.NewRecorder()
+	srv.ServeHTTP(staleRR, staleReq)
+	assert.Equal(http.StatusConflict, staleRR.Code)
+
+	secondFiles := requestWorkspaceFiles(t, srv, ws.Id, "head")
+	require.NotNil(secondFiles.SnapshotVersion)
+	assert.NotEqual(firstVersion, *secondFiles.SnapshotVersion)
+	secondDiff := requestWorkspaceDiffQuery(
+		t, srv, ws.Id,
+		"base=head&revision="+url.QueryEscape(*secondFiles.SnapshotVersion),
+	)
+	file := requireWorkspaceDiffFile(t, *secondDiff.Files, "same-size.txt")
+	assert.Contains(file.Patch, "+b1\n")
+}
+
+func TestWorkspaceDiffSelectionLeaseFollowsScopedEventStreamE2E(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	assert := assert.New(t)
+
+	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, nil)
+	ws := createReadyWorkspace(t, context.Background(), client)
+	httpServer := httptest.NewServer(srv)
+	t.Cleanup(httpServer.Close)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		httpServer.URL+"/api/v1/events?workspace_id="+url.QueryEscape(ws.Id),
+		nil,
+	)
+	require.NoError(err)
+	response, err := http.DefaultClient.Do(request)
+	require.NoError(err)
+	require.Equal(http.StatusOK, response.StatusCode)
+
+	srv.workspaceDiffCache.mu.Lock()
+	assert.Equal(1, srv.workspaceDiffCache.selected[ws.Id])
+	srv.workspaceDiffCache.mu.Unlock()
+
+	cancel()
+	require.NoError(response.Body.Close())
+	require.Eventually(func() bool {
+		srv.workspaceDiffCache.mu.Lock()
+		defer srv.workspaceDiffCache.mu.Unlock()
+		return srv.workspaceDiffCache.selected[ws.Id] == 0
+	}, time.Second, 10*time.Millisecond)
+}
+
 func TestWorkspaceDiffEndpointScopesPatchByPathE2E(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -26774,6 +26774,35 @@ func TestWorkspaceDiffEndpointScopesPatchByPathE2E(t *testing.T) {
 	assert.NotContains(workspaceDiffPaths(*diff.Files), "second.go")
 }
 
+func TestWorkspaceDiffPathPrefersCurrentPathOverEarlierRenameE2E(t *testing.T) {
+	t.Parallel()
+
+	require := require.New(t)
+	assert := assert.New(t)
+	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, nil)
+	ws := createReadyWorkspace(t, context.Background(), client)
+	runGit(t, ws.WorktreePath, "config", "user.email", "test@test.com")
+	runGit(t, ws.WorktreePath, "config", "user.name", "Test")
+	require.NoError(os.WriteFile(filepath.Join(ws.WorktreePath, "z.txt"), []byte("renamed content\n"), 0o644))
+	runGit(t, ws.WorktreePath, "add", "z.txt")
+	runGit(t, ws.WorktreePath, "commit", "-m", "add rename source")
+	require.NoError(os.Rename(filepath.Join(ws.WorktreePath, "z.txt"), filepath.Join(ws.WorktreePath, "a.txt")))
+	runGit(t, ws.WorktreePath, "add", "-A")
+	require.NoError(os.WriteFile(filepath.Join(ws.WorktreePath, "z.txt"), []byte("new current path\n"), 0o644))
+
+	diff := requestWorkspaceDiffForPath(t, srv, ws.Id, "head", "z.txt")
+	require.NotNil(diff.Files)
+	require.Len(*diff.Files, 1)
+	assert.Equal("z.txt", (*diff.Files)[0].Path)
+	assert.Equal("added", (*diff.Files)[0].Status)
+
+	preview := requestWorkspaceFilePreview(t, srv, ws.Id, "head", "z.txt", "new")
+	content, err := base64.StdEncoding.DecodeString(preview.Content)
+	require.NoError(err)
+	assert.Equal("z.txt", preview.Path)
+	assert.Equal("new current path\n", string(content))
+}
+
 func TestWorkspaceDiffEndpointKeepsModifiedSourcePatchSeparateFromCopyE2E(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -26294,6 +26294,21 @@ func TestWorkspaceDiffSnapshotRefreshesSameSizeEditAndPinsRevisionE2E(t *testing
 	staleRR := httptest.NewRecorder()
 	srv.ServeHTTP(staleRR, staleReq)
 	assert.Equal(http.StatusConflict, staleRR.Code)
+	var staleProblem rawProblemDetail
+	require.NoError(json.Unmarshal(staleRR.Body.Bytes(), &staleProblem))
+	assert.Equal("conflict", staleProblem.Code)
+	assert.Equal("snapshot_changed", staleProblem.Details["reason"])
+	stalePreviewReq := newWorkspaceFixtureRequest(
+		http.MethodGet,
+		"/api/v1/workspaces/"+ws.Id+"/file-preview?base=head&path=same-size.txt&revision="+url.QueryEscape(firstVersion),
+		nil,
+	)
+	stalePreviewRR := httptest.NewRecorder()
+	srv.ServeHTTP(stalePreviewRR, stalePreviewReq)
+	assert.Equal(http.StatusConflict, stalePreviewRR.Code)
+	var stalePreviewProblem rawProblemDetail
+	require.NoError(json.Unmarshal(stalePreviewRR.Body.Bytes(), &stalePreviewProblem))
+	assert.Equal("snapshot_changed", stalePreviewProblem.Details["reason"])
 
 	secondFiles := requestWorkspaceFiles(t, srv, ws.Id, "head")
 	require.NotNil(secondFiles.SnapshotVersion)
@@ -26306,6 +26321,40 @@ func TestWorkspaceDiffSnapshotRefreshesSameSizeEditAndPinsRevisionE2E(t *testing
 	assert.Contains(file.Patch, "+b1\n")
 }
 
+func TestWorkspaceDiffPairLeaseSurvivesCostPressureE2E(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, nil)
+	ws := createReadyWorkspace(t, context.Background(), client)
+	require.NoError(os.WriteFile(filepath.Join(ws.WorktreePath, "pair.txt"), []byte("pair\n"), 0o644))
+	files := requestWorkspaceFiles(t, srv, ws.Id, "head")
+	require.NotNil(files.SnapshotVersion)
+
+	now := time.Now()
+	entry := func() *workspaceDiffCacheEntry {
+		return &workspaceDiffCacheEntry{
+			snapshot:   &workspaceDiffSnapshot{SizeBytes: workspaceDiffCacheMaxBytes},
+			lastAccess: now,
+		}
+	}
+	first := workspaceDiffLogicalKey{WorkspaceID: "pressure-1"}
+	second := workspaceDiffLogicalKey{WorkspaceID: "pressure-2"}
+	srv.workspaceDiffCache.mu.Lock()
+	storedFirst := srv.workspaceDiffCache.storeEntryLocked(first, entry(), now)
+	storedSecond := srv.workspaceDiffCache.storeEntryLocked(second, entry(), now)
+	srv.workspaceDiffCache.mu.Unlock()
+	require.True(storedFirst)
+	require.True(storedSecond)
+
+	diff := requestWorkspaceDiffQuery(
+		t, srv, ws.Id,
+		"base=head&revision="+url.QueryEscape(*files.SnapshotVersion),
+	)
+	require.NotNil(diff.SnapshotVersion)
+	require.Equal(*files.SnapshotVersion, *diff.SnapshotVersion)
+}
+
 func TestWorkspaceDiffSelectionLeaseFollowsScopedEventStreamE2E(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
@@ -26313,6 +26362,26 @@ func TestWorkspaceDiffSelectionLeaseFollowsScopedEventStreamE2E(t *testing.T) {
 
 	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, nil)
 	ws := createReadyWorkspace(t, context.Background(), client)
+	srv.workspaceDiffCache.deps.resolve = func(
+		_ context.Context, spec workspace.DiffSnapshotSpec,
+	) (workspace.ResolvedDiffSnapshotSpec, bool, error) {
+		return workspace.ResolvedDiffSnapshotSpec{
+			DiffSnapshotSpec: spec,
+			BaseRef:          "HEAD",
+			BaseOID:          "base",
+			HeadOID:          "head",
+		}, true, nil
+	}
+	srv.workspaceDiffCache.deps.fingerprint = func(
+		context.Context, workspace.ResolvedDiffSnapshotSpec,
+	) (workspace.DiffFingerprint, error) {
+		return "ready", nil
+	}
+	srv.workspaceDiffCache.deps.prepare = func(
+		context.Context, workspace.ResolvedDiffSnapshotSpec,
+	) (*gitclone.DiffResult, error) {
+		return workspaceDiffTestResult("ready.txt"), nil
+	}
 	httpServer := httptest.NewServer(srv)
 	t.Cleanup(httpServer.Close)
 
@@ -26327,6 +26396,18 @@ func TestWorkspaceDiffSelectionLeaseFollowsScopedEventStreamE2E(t *testing.T) {
 	response, err := http.DefaultClient.Do(request)
 	require.NoError(err)
 	require.Equal(http.StatusOK, response.StatusCode)
+	scanner := bufio.NewScanner(response.Body)
+	ready := readSSEFrameWithin(t, scanner, 5*time.Second, cancel)
+	for ready.Event != "workspace_diff_ready" {
+		ready = readSSEFrameWithin(t, scanner, 5*time.Second, cancel)
+	}
+	var readyData struct {
+		WorkspaceID string `json:"workspace_id"`
+		Version     string `json:"version"`
+	}
+	require.NoError(json.Unmarshal([]byte(ready.Data), &readyData))
+	assert.Equal(ws.Id, readyData.WorkspaceID)
+	assert.NotEmpty(readyData.Version)
 
 	srv.workspaceDiffCache.mu.Lock()
 	assert.Equal(1, srv.workspaceDiffCache.selected[ws.Id])
@@ -26339,6 +26420,325 @@ func TestWorkspaceDiffSelectionLeaseFollowsScopedEventStreamE2E(t *testing.T) {
 		defer srv.workspaceDiffCache.mu.Unlock()
 		return srv.workspaceDiffCache.selected[ws.Id] == 0
 	}, time.Second, 10*time.Millisecond)
+}
+
+func TestWorkspaceDiffWatchPrewarmsAndPushesSelectedChangesE2E(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	assert := assert.New(t)
+
+	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, nil)
+	ws := createReadyWorkspace(t, context.Background(), client)
+	path := filepath.Join(ws.WorktreePath, "watched.txt")
+	require.NoError(os.WriteFile(path, []byte("a1\n"), 0o644))
+	httpServer := httptest.NewServer(srv)
+	t.Cleanup(httpServer.Close)
+
+	firstResponse, err := http.Get(
+		httpServer.URL + "/api/v1/workspaces/" + ws.Id + "/diff/watch",
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, firstResponse.StatusCode)
+	var first struct {
+		Changed bool   `json:"changed"`
+		Version string `json:"version"`
+	}
+	require.NoError(json.NewDecoder(firstResponse.Body).Decode(&first))
+	require.NoError(firstResponse.Body.Close())
+	assert.True(first.Changed)
+	require.NotEmpty(first.Version)
+
+	pushedRequest, err := srv.workspaceDiffRequest(
+		t.Context(), ws.Id, string(workspace.WorktreeDiffBasePushed),
+	)
+	require.NoError(err)
+	pushed, _, err := srv.workspaceDiffCache.Get(
+		t.Context(), srv.workspaceDiffCacheKey(pushedRequest, false),
+	)
+	require.NoError(err)
+	require.NotEqual(first.Version, pushed.Version)
+	foreignClient := &http.Client{Timeout: time.Second}
+	foreignResponse, err := foreignClient.Get(
+		httpServer.URL + "/api/v1/workspaces/" + ws.Id +
+			"/diff/watch?version=" + url.QueryEscape(pushed.Version),
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, foreignResponse.StatusCode)
+	var resetToHead struct {
+		Changed bool   `json:"changed"`
+		Version string `json:"version"`
+	}
+	require.NoError(json.NewDecoder(foreignResponse.Body).Decode(&resetToHead))
+	require.NoError(foreignResponse.Body.Close())
+	assert.True(resetToHead.Changed)
+	assert.Equal(first.Version, resetToHead.Version)
+
+	type watchResult struct {
+		status int
+		body   struct {
+			Changed bool   `json:"changed"`
+			Version string `json:"version"`
+		}
+		err error
+	}
+	result := make(chan watchResult, 1)
+	go func() {
+		response, requestErr := http.Get(
+			httpServer.URL + "/api/v1/workspaces/" + ws.Id +
+				"/diff/watch?version=" + url.QueryEscape(first.Version),
+		)
+		got := watchResult{err: requestErr}
+		if requestErr == nil {
+			got.status = response.StatusCode
+			got.err = json.NewDecoder(response.Body).Decode(&got.body)
+			closeErr := response.Body.Close()
+			if got.err == nil {
+				got.err = closeErr
+			}
+		}
+		result <- got
+	}()
+
+	require.Eventually(func() bool {
+		srv.workspaceDiffCache.mu.Lock()
+		defer srv.workspaceDiffCache.mu.Unlock()
+		return srv.workspaceDiffCache.selected[ws.Id] == 1
+	}, time.Second, 10*time.Millisecond)
+	srv.hub.Broadcast(Event{Type: "workspace_diff_changed", Data: workspaceDiffEventData{
+		WorkspaceID: ws.Id,
+		Revision:    pushed.Revision,
+		Version:     pushed.Version,
+	}})
+	select {
+	case got := <-result:
+		require.Fail(
+			"workspace diff watch returned an unrelated scope",
+			"version=%q error=%v", got.body.Version, got.err,
+		)
+	case <-time.After(100 * time.Millisecond):
+	}
+	require.NoError(os.WriteFile(path, []byte("b1\n"), 0o644))
+	srv.notifyWorktreeStatsChanged()
+
+	select {
+	case got := <-result:
+		require.NoError(got.err)
+		require.Equal(http.StatusOK, got.status)
+		assert.True(got.body.Changed)
+		assert.NotEqual(first.Version, got.body.Version)
+	case <-time.After(5 * time.Second):
+		require.Fail("workspace diff watch did not return the changed snapshot")
+	}
+}
+
+func TestFleetWorkspaceDiffWatchCancellationReleasesRemoteSelectionE2E(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+
+	client, _, _, _, peerServer := setupTestServerWithWorkspacesServer(t, nil)
+	ws := createReadyWorkspace(t, context.Background(), client)
+	peerHTTP := httptest.NewServer(peerServer)
+	t.Cleanup(peerHTTP.Close)
+
+	hub := &Server{cfg: &config.Config{Fleet: config.Fleet{
+		Enabled: true,
+		Key:     "hub",
+		Peers: []config.FleetPeer{
+			{Key: "member", BaseURL: peerHTTP.URL},
+		},
+	}}}
+	hubAPI := newFleetTestAPI()
+	hub.registerFleetRoutes(hubAPI)
+	hubHTTP := httptest.NewServer(hubAPI.Adapter())
+	t.Cleanup(hubHTTP.Close)
+
+	watchURL := hubHTTP.URL + "/fleet/hosts/member/workspaces/" + ws.Id + "/diff/watch"
+	firstResponse, err := http.Get(watchURL)
+	require.NoError(err)
+	require.Equal(http.StatusOK, firstResponse.StatusCode)
+	var first workspaceDiffWatchResponse
+	require.NoError(json.NewDecoder(firstResponse.Body).Decode(&first))
+	require.NoError(firstResponse.Body.Close())
+	require.NotEmpty(first.Version)
+	require.Eventually(func() bool {
+		peerServer.workspaceDiffCache.mu.Lock()
+		defer peerServer.workspaceDiffCache.mu.Unlock()
+		return peerServer.workspaceDiffCache.selected[ws.Id] == 0
+	}, time.Second, 10*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		watchURL+"?version="+url.QueryEscape(first.Version),
+		nil,
+	)
+	require.NoError(err)
+	requestDone := make(chan error, 1)
+	go func() {
+		response, requestErr := http.DefaultClient.Do(request)
+		if response != nil {
+			requestErr = errors.Join(requestErr, response.Body.Close())
+		}
+		requestDone <- requestErr
+	}()
+	require.Eventually(func() bool {
+		peerServer.workspaceDiffCache.mu.Lock()
+		defer peerServer.workspaceDiffCache.mu.Unlock()
+		return peerServer.workspaceDiffCache.selected[ws.Id] == 1
+	}, time.Second, 10*time.Millisecond)
+
+	cancel()
+	select {
+	case requestErr := <-requestDone:
+		require.ErrorIs(requestErr, context.Canceled)
+	case <-time.After(time.Second):
+		require.Fail("fleet diff watch cancellation did not reach the proxy client")
+	}
+	require.Eventually(func() bool {
+		peerServer.workspaceDiffCache.mu.Lock()
+		defer peerServer.workspaceDiffCache.mu.Unlock()
+		return peerServer.workspaceDiffCache.selected[ws.Id] == 0
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestFleetWorkspaceDiffWatchTransitionsFromCreatingToReadyE2E(t *testing.T) {
+	t.Parallel()
+
+	client, database, _, _, peerServer := setupTestServerWithWorkspacesServer(t, nil)
+	ws := createReadyWorkspace(t, context.Background(), client)
+	peerHTTP := httptest.NewServer(peerServer)
+	t.Cleanup(peerHTTP.Close)
+
+	hub := &Server{cfg: &config.Config{Fleet: config.Fleet{
+		Enabled: true,
+		Key:     "hub",
+		Peers: []config.FleetPeer{
+			{Key: "member", BaseURL: peerHTTP.URL},
+		},
+	}}}
+	hubAPI := newFleetTestAPI()
+	hub.registerFleetRoutes(hubAPI)
+	hubHTTP := httptest.NewServer(hubAPI.Adapter())
+	t.Cleanup(hubHTTP.Close)
+
+	watchURL := hubHTTP.URL + "/fleet/hosts/member/workspaces/" + ws.Id + "/diff/watch"
+	tests := []struct {
+		name       string
+		status     string
+		wantStatus int
+		wantReady  bool
+	}{
+		{name: "creating", status: "creating", wantStatus: http.StatusConflict},
+		{name: "ready", status: "ready", wantStatus: http.StatusOK, wantReady: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			require.NoError(database.UpdateWorkspaceStatus(t.Context(), ws.Id, tt.status, nil))
+
+			response, err := http.Get(watchURL)
+			require.NoError(err)
+			require.Equal(tt.wantStatus, response.StatusCode)
+			defer response.Body.Close()
+			if !tt.wantReady {
+				return
+			}
+
+			var body workspaceDiffWatchResponse
+			require.NoError(json.NewDecoder(response.Body).Decode(&body))
+			assert.True(body.Changed)
+			assert.NotEmpty(body.Version)
+		})
+	}
+}
+
+func TestWorkspaceManualRefreshRevalidatesCachedDiffWhenProviderRefreshFailsE2E(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	assert := assert.New(t)
+
+	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, nil)
+	ws := createReadyWorkspace(t, context.Background(), client)
+	path := filepath.Join(ws.WorktreePath, "manual-refresh.txt")
+	require.NoError(os.WriteFile(path, []byte("before\n"), 0o644))
+	first := requestWorkspaceFiles(t, srv, ws.Id, "head")
+	require.NotNil(first.SnapshotVersion)
+	firstVersion := *first.SnapshotVersion
+
+	events, _ := srv.hub.Subscribe(t.Context(), false)
+	require.NoError(os.WriteFile(path, []byte("after\n"), 0o644))
+	originalPrepare := srv.workspaceDiffCache.deps.prepare
+	prepareStarted := make(chan struct{})
+	releasePrepare := make(chan struct{})
+	var signalPrepare sync.Once
+	srv.workspaceDiffCache.deps.prepare = func(
+		ctx context.Context,
+		resolved workspace.ResolvedDiffSnapshotSpec,
+	) (*gitclone.DiffResult, error) {
+		signalPrepare.Do(func() { close(prepareStarted) })
+		select {
+		case <-releasePrepare:
+			return originalPrepare(ctx, resolved)
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
+	request := newWorkspaceFixtureRequest(
+		http.MethodPost,
+		"/api/v1/workspaces/"+ws.Id+"/refresh",
+		strings.NewReader("{}"),
+	)
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+	responseDone := make(chan struct{})
+	go func() {
+		srv.ServeHTTP(response, request)
+		close(responseDone)
+	}()
+	select {
+	case <-responseDone:
+		require.Equal(http.StatusBadGateway, response.Code, response.Body.String())
+	case <-time.After(5 * time.Second):
+		require.Fail("workspace refresh waited for diff preparation")
+	}
+	select {
+	case <-prepareStarted:
+	case <-time.After(5 * time.Second):
+		require.Fail("workspace refresh did not schedule diff preparation")
+	}
+	close(releasePrepare)
+
+	var changed workspaceDiffEventData
+	select {
+	case event := <-events:
+		for event.Event.Type != "workspace_diff_changed" {
+			select {
+			case event = <-events:
+			case <-time.After(5 * time.Second):
+				require.Fail("workspace diff change event not received")
+			}
+		}
+		var ok bool
+		changed, ok = event.Event.Data.(workspaceDiffEventData)
+		require.True(ok)
+	case <-time.After(5 * time.Second):
+		require.Fail("workspace diff change event not received")
+	}
+	assert.Equal(ws.Id, changed.WorkspaceID)
+	assert.NotEqual(firstVersion, changed.Version)
+
+	second := requestWorkspaceFiles(t, srv, ws.Id, "head")
+	require.NotNil(second.SnapshotVersion)
+	assert.Equal(changed.Version, *second.SnapshotVersion)
+	diff := requestWorkspaceDiffQuery(
+		t, srv, ws.Id,
+		"base=head&revision="+url.QueryEscape(changed.Version),
+	)
+	file := requireWorkspaceDiffFile(t, *diff.Files, "manual-refresh.txt")
+	assert.Contains(file.Patch, "+after\n")
 }
 
 func TestWorkspaceDiffEndpointScopesPatchByPathE2E(t *testing.T) {

--- a/internal/server/api_types.go
+++ b/internal/server/api_types.go
@@ -361,6 +361,11 @@ type filesResponse struct {
 	SnapshotVersion     string              `json:"snapshot_version,omitempty" doc:"Opaque workspace diff snapshot version to pin on the following workspace diff request."`
 }
 
+type workspaceDiffWatchResponse struct {
+	Changed bool   `json:"changed" doc:"True when the caller must reload the watched default-HEAD snapshot."`
+	Version string `json:"version" doc:"Opaque version of the current default-HEAD snapshot; never a version from another diff scope."`
+}
+
 type diffReviewLineRange struct {
 	Path        string `json:"path"`
 	OldPath     string `json:"old_path,omitempty"`

--- a/internal/server/api_types.go
+++ b/internal/server/api_types.go
@@ -347,6 +347,7 @@ type diffResponse struct {
 	Stale               bool                `json:"stale"`
 	WhitespaceOnlyCount int                 `json:"whitespace_only_count"`
 	Files               []gitclone.DiffFile `json:"files"`
+	SnapshotVersion     string              `json:"snapshot_version,omitempty" doc:"Opaque workspace diff snapshot version used to keep files and patches coherent."`
 	// DiffHeadSHA is the synced PR diff snapshot head this diff was
 	// computed from; clients compare it against platform_head_sha to
 	// detect stale cached diff context. Empty for non-PR diffs.
@@ -357,6 +358,7 @@ type filesResponse struct {
 	Stale               bool                `json:"stale"`
 	WhitespaceOnlyCount int                 `json:"whitespace_only_count"`
 	Files               []gitclone.DiffFile `json:"files"`
+	SnapshotVersion     string              `json:"snapshot_version,omitempty" doc:"Opaque workspace diff snapshot version to pin on the following workspace diff request."`
 }
 
 type diffReviewLineRange struct {

--- a/internal/server/fleet_proxy.go
+++ b/internal/server/fleet_proxy.go
@@ -204,9 +204,22 @@ func (s *Server) registerFleetOperationRoutes(api huma.API) {
 			path:        "/fleet/hosts/{host_key}/workspaces/{id}/files",
 			summary:     "Get workspace files on fleet host",
 			pathParams:  []string{"host_key", "id"},
-			queryParams: fleetWorkspaceDiffQueryParams(),
+			queryParams: fleetWorkspaceDiffScopeQueryParams(),
 			targetPath: func(r *http.Request) string {
 				return "/api/v1/workspaces/" + escapePath(r.PathValue("id")) + "/files"
+			},
+		},
+		{
+			operationID: "watch-fleet-workspace-diff",
+			method:      http.MethodGet,
+			path:        "/fleet/hosts/{host_key}/workspaces/{id}/diff/watch",
+			summary:     "Watch selected workspace diff on fleet host",
+			pathParams:  []string{"host_key", "id"},
+			queryParams: []*huma.Param{
+				fleetStringQueryParam("version", "Last observed workspace diff snapshot version."),
+			},
+			targetPath: func(r *http.Request) string {
+				return "/api/v1/workspaces/" + escapePath(r.PathValue("id")) + "/diff/watch"
 			},
 		},
 		{
@@ -617,6 +630,13 @@ func fleetForceQueryParam() *huma.Param {
 }
 
 func fleetWorkspaceDiffQueryParams() []*huma.Param {
+	return append(
+		fleetWorkspaceDiffScopeQueryParams(),
+		fleetStringQueryParam("revision", "Pinned workspace snapshot version."),
+	)
+}
+
+func fleetWorkspaceDiffScopeQueryParams() []*huma.Param {
 	return []*huma.Param{
 		fleetStringQueryParam("base", "Workspace diff base."),
 		fleetStringQueryParam("whitespace", "Whitespace filtering mode."),

--- a/internal/server/fleet_routes_test.go
+++ b/internal/server/fleet_routes_test.go
@@ -85,6 +85,18 @@ func TestSnapshotRoutesRegistered(t *testing.T) {
 	require.NotNil(spec.Paths["/fleet/hosts/{host_key}/projects/{project_id}/worktrees/{worktree_id}/session-backend"].Put, "PUT fleet worktree session backend not registered")
 	require.NotNil(spec.Paths["/fleet/hosts/{host_key}/projects/{project_id}/worktrees/{worktree_id}/linked-issues"].Put, "PUT fleet worktree linked issues not registered")
 	require.NotNil(spec.Paths["/fleet/hosts/{host_key}/projects/{project_id}/worktrees/{worktree_id}/refresh-stats"].Post, "POST fleet worktree stats refresh not registered")
+	for _, path := range []string{
+		"/fleet/hosts/{host_key}/workspaces/{id}/diff",
+		"/fleet/hosts/{host_key}/workspaces/{id}/file-preview",
+	} {
+		queryParams := make([]string, 0)
+		for _, param := range spec.Paths[path].Get.Parameters {
+			if param.In == "query" {
+				queryParams = append(queryParams, param.Name)
+			}
+		}
+		assert.Contains(queryParams, "revision", path)
+	}
 
 	gotProjectRegister := spec.Paths["/fleet/hosts/{host_key}/projects"].Post
 	assert.Equal("register-fleet-project", gotProjectRegister.OperationID)

--- a/internal/server/fleet_ssh_test.go
+++ b/internal/server/fleet_ssh_test.go
@@ -63,6 +63,16 @@ func (f *fakeSSHExec) exec(
 func newSSHTestTransport(
 	t *testing.T, fake *fakeSSHExec, peers ...config.FleetSSHPeer,
 ) *sshFleetTransport {
+	return newSSHTestTransportWithExec(t, fake.exec, peers...)
+}
+
+func newSSHTestTransportWithExec(
+	t *testing.T,
+	exec func(
+		context.Context, []string, []byte,
+	) ([]byte, []byte, int, error),
+	peers ...config.FleetSSHPeer,
+) *sshFleetTransport {
 	t.Helper()
 	conns := sshfleet.NewConnectionManager(t.TempDir(), sshfleet.Config{
 		RunSSH: func(args []string) (int, error) {
@@ -79,7 +89,7 @@ func newSSHTestTransport(
 	})
 	return &sshFleetTransport{
 		conns:  conns,
-		runner: sshfleet.NewRunnerWithExec(conns, fake.exec),
+		runner: sshfleet.NewRunnerWithExec(conns, exec),
 		peers:  peers,
 	}
 }
@@ -228,9 +238,21 @@ func TestSSHFleetProxyRelaysWorkspaceDiffReads(t *testing.T) {
 	assert := assert.New(t)
 
 	fake := &fakeSSHExec{routes: map[string]string{
-		"GET /api/v1/workspaces/ws_1/diff?base=merge-target&whitespace=hide": framedJSON(
+		"GET /api/v1/workspaces/ws_1/diff/watch?version=snapshot-7": framedJSON(
+			http.StatusOK,
+			`{"changed":true,"version":"snapshot-8"}`,
+		),
+		"GET /api/v1/workspaces/ws_1/diff?base=merge-target&revision=snapshot-7&whitespace=hide": framedJSON(
 			http.StatusOK,
 			`{"stale":false,"files":[{"path":"remote.go","status":"modified"}]}`,
+		),
+		"GET /api/v1/workspaces/ws_1/file-preview?base=merge-target&path=remote.go&revision=snapshot-7": framedJSON(
+			http.StatusOK,
+			`{"path":"remote.go","content":"package remote"}`,
+		),
+		"GET /api/v1/workspaces/ws_1/diff?base=merge-target&revision=stale": framedJSON(
+			http.StatusConflict,
+			`{"code":"conflict","detail":"snapshot changed","details":{"reason":"snapshot_changed"}}`,
 		),
 	}}
 	srv, _ := setupTestServer(t)
@@ -244,7 +266,7 @@ func TestSSHFleetProxyRelaysWorkspaceDiffReads(t *testing.T) {
 	defer ts.Close()
 
 	resp := httpDo(t, ts, http.MethodGet,
-		"/api/v1/fleet/hosts/epyc/workspaces/ws_1/diff?base=merge-target&whitespace=hide", nil)
+		"/api/v1/fleet/hosts/epyc/workspaces/ws_1/diff?base=merge-target&revision=snapshot-7&whitespace=hide", nil)
 	if resp.StatusCode != http.StatusOK {
 		raw, _ := io.ReadAll(resp.Body)
 		require.Failf("unexpected relay status",
@@ -261,7 +283,90 @@ func TestSSHFleetProxyRelaysWorkspaceDiffReads(t *testing.T) {
 	require.Len(diff.Files, 1)
 	assert.Equal("remote.go", diff.Files[0].Path)
 	assert.Contains(fake.calls,
-		"GET /api/v1/workspaces/ws_1/diff?base=merge-target&whitespace=hide")
+		"GET /api/v1/workspaces/ws_1/diff?base=merge-target&revision=snapshot-7&whitespace=hide")
+
+	previewResp := httpDo(t, ts, http.MethodGet,
+		"/api/v1/fleet/hosts/epyc/workspaces/ws_1/file-preview?base=merge-target&path=remote.go&revision=snapshot-7", nil)
+	require.Equal(http.StatusOK, previewResp.StatusCode)
+	previewResp.Body.Close()
+	assert.Contains(fake.calls,
+		"GET /api/v1/workspaces/ws_1/file-preview?base=merge-target&path=remote.go&revision=snapshot-7")
+
+	staleResp := httpDo(t, ts, http.MethodGet,
+		"/api/v1/fleet/hosts/epyc/workspaces/ws_1/diff?base=merge-target&revision=stale", nil)
+	assert.Equal(http.StatusConflict, staleResp.StatusCode)
+	staleBody, err := io.ReadAll(staleResp.Body)
+	require.NoError(err)
+	staleResp.Body.Close()
+	assert.Contains(string(staleBody), `"reason":"snapshot_changed"`)
+
+	watchResp := httpDo(t, ts, http.MethodGet,
+		"/api/v1/fleet/hosts/epyc/workspaces/ws_1/diff/watch?version=snapshot-7", nil)
+	require.Equal(http.StatusOK, watchResp.StatusCode)
+	var watch struct {
+		Changed bool   `json:"changed"`
+		Version string `json:"version"`
+	}
+	require.NoError(json.NewDecoder(watchResp.Body).Decode(&watch))
+	require.NoError(watchResp.Body.Close())
+	assert.True(watch.Changed)
+	assert.Equal("snapshot-8", watch.Version)
+	assert.Contains(fake.calls,
+		"GET /api/v1/workspaces/ws_1/diff/watch?version=snapshot-7")
+}
+
+func TestSSHFleetDiffWatchCancellationReachesRemoteRelay(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	started := make(chan struct{})
+	canceled := make(chan struct{})
+	exec := func(
+		ctx context.Context, _ []string, _ []byte,
+	) ([]byte, []byte, int, error) {
+		close(started)
+		<-ctx.Done()
+		close(canceled)
+		return nil, nil, 0, ctx.Err()
+	}
+
+	srv, _ := setupTestServer(t)
+	setTestFleetConfig(srv, func(cfg *config.Config) {
+		cfg.Fleet.Enabled = true
+	})
+	srv.sshFleet = newSSHTestTransportWithExec(t, exec, config.FleetSSHPeer{
+		Key: "epyc", Destination: "wes@epyc.local",
+	})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		ts.URL+"/api/v1/fleet/hosts/epyc/workspaces/ws_1/diff/watch",
+		nil,
+	)
+	require.NoError(err)
+	done := make(chan error, 1)
+	go func() {
+		response, requestErr := http.DefaultClient.Do(request)
+		if response != nil {
+			_ = response.Body.Close()
+		}
+		done <- requestErr
+	}()
+
+	<-started
+	cancel()
+	assert.Eventually(func() bool {
+		select {
+		case <-canceled:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+	require.ErrorIs(<-done, context.Canceled)
 }
 
 // TestSSHFleetAttachSpecWrapped pins the attach contract: a peer's

--- a/internal/server/fleet_worktree_links.go
+++ b/internal/server/fleet_worktree_links.go
@@ -282,7 +282,7 @@ func (s *Server) NotifyWorktreeLinksChanged() {
 // broadcasts a payload-free worktree_stats_changed refetch hint.
 func (s *Server) notifyWorktreeStatsChanged() {
 	if s.workspaceDiffCache != nil {
-		s.workspaceDiffCache.ValidateSelected()
+		s.workspaceDiffCache.RevalidateSelected()
 	}
 	if s.hub != nil {
 		s.hub.Broadcast(Event{

--- a/internal/server/fleet_worktree_links.go
+++ b/internal/server/fleet_worktree_links.go
@@ -281,6 +281,9 @@ func (s *Server) NotifyWorktreeLinksChanged() {
 // notifyWorktreeStatsChanged is the stats-sampler callback: it
 // broadcasts a payload-free worktree_stats_changed refetch hint.
 func (s *Server) notifyWorktreeStatsChanged() {
+	if s.workspaceDiffCache != nil {
+		s.workspaceDiffCache.ValidateSelected()
+	}
 	if s.hub != nil {
 		s.hub.Broadcast(Event{
 			Type: "worktree_stats_changed", Data: struct{}{},

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -567,6 +567,11 @@ type getWorkspaceFilesInput struct {
 	To         string `query:"to"     doc:"End SHA for range diff (inclusive)"`
 }
 
+type watchWorkspaceDiffInput struct {
+	ID      string `path:"id"`
+	Version string `query:"version" doc:"Last observed opaque workspace diff snapshot version"`
+}
+
 type getWorkspaceDiffInput struct {
 	ID         string `path:"id"`
 	Base       string `query:"base"      doc:"Diff base: head, pushed, or merge-target"`
@@ -587,6 +592,7 @@ type getWorkspaceFilePreviewInput struct {
 	Commit     string `query:"commit" doc:"Scope to a single commit SHA"`
 	From       string `query:"from"   doc:"Start SHA for range diff (inclusive)"`
 	To         string `query:"to"     doc:"End SHA for range diff (inclusive)"`
+	Revision   string `query:"revision" doc:"Optional snapshot_version returned by the workspace files endpoint"`
 }
 
 type getWorkspaceCommitsInput struct {
@@ -647,6 +653,7 @@ type getWorkspaceOutput = bodyOutput[workspaceResponse]
 type getWorkspaceDiffOutput = bodyOutput[diffResponse]
 type getWorkspaceFilePreviewOutput = bodyOutput[filePreviewResponse]
 type getWorkspaceFilesOutput = bodyOutput[filesResponse]
+type watchWorkspaceDiffOutput = bodyOutput[workspaceDiffWatchResponse]
 type getWorkspaceCommitsOutput = bodyOutput[commitsResponse]
 
 type getWorkspaceRuntimeOutput = bodyOutput[workspaceRuntimeResponse]
@@ -921,6 +928,8 @@ func (s *Server) registerAPI(api huma.API) {
 		documentOperation("get-workspace-file-preview", "Get workspace file preview", "Workspaces"))
 	huma.Get(api, "/workspaces/{id}/files", s.getWorkspaceFiles,
 		documentOperation("get-workspace-files", "Get workspace files", "Workspaces"))
+	huma.Get(api, "/workspaces/{id}/diff/watch", s.watchWorkspaceDiff,
+		documentOperation("watch-workspace-diff", "Watch selected workspace diff", "Workspaces"))
 	huma.Register(api, huma.Operation{
 		OperationID:   "retry-workspace",
 		Method:        http.MethodPost,
@@ -5595,6 +5604,9 @@ func (s *Server) refreshWorkspace(
 			CodeWorkspaceNotFound, "workspace not found", nil,
 		)
 	}
+	if s.workspaceDiffCache != nil {
+		s.workspaceDiffCache.RevalidateWorkspace(input.ID)
+	}
 
 	provider := strings.TrimSpace(summary.Platform)
 	if provider == "" {
@@ -5847,6 +5859,82 @@ func (s *Server) getWorkspaceFiles(
 	}}, nil
 }
 
+const workspaceDiffWatchTimeout = 25 * time.Second
+
+func (s *Server) watchWorkspaceDiff(
+	ctx context.Context,
+	input *watchWorkspaceDiffInput,
+) (*watchWorkspaceDiffOutput, error) {
+	req, err := s.workspaceDiffRequest(ctx, input.ID, string(workspace.WorktreeDiffBaseHead))
+	if err != nil {
+		return nil, err
+	}
+	key := s.workspaceDiffCacheKey(req, false)
+	events, hubDone := s.hub.Subscribe(ctx, false)
+	releaseSelection := s.workspaceDiffCache.Select(
+		input.ID,
+		func(context.Context) (workspaceDiffLogicalKey, error) {
+			return key, nil
+		},
+	)
+	defer releaseSelection()
+
+	snapshot, _, err := s.workspaceDiffCache.Get(ctx, key)
+	if err != nil {
+		if errors.Is(err, errWorkspaceDiffBaseUnavailable) {
+			return nil, workspaceDiffBaseUnavailable(req.Base)
+		}
+		return nil, problemUpstream("failed to prepare selected workspace diff", "", "")
+	}
+	if input.Version == "" || input.Version != snapshot.Version {
+		return &watchWorkspaceDiffOutput{Body: workspaceDiffWatchResponse{
+			Changed: true,
+			Version: snapshot.Version,
+		}}, nil
+	}
+
+	timer := time.NewTimer(workspaceDiffWatchTimeout)
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-hubDone:
+			return &watchWorkspaceDiffOutput{Body: workspaceDiffWatchResponse{
+				Version: snapshot.Version,
+			}}, nil
+		case <-timer.C:
+			return &watchWorkspaceDiffOutput{Body: workspaceDiffWatchResponse{
+				Version: snapshot.Version,
+			}}, nil
+		case event, ok := <-events:
+			if !ok {
+				return &watchWorkspaceDiffOutput{Body: workspaceDiffWatchResponse{
+					Version: snapshot.Version,
+				}}, nil
+			}
+			if event.Event.Type != "workspace_diff_ready" && event.Event.Type != "workspace_diff_changed" {
+				continue
+			}
+			data, ok := event.Event.Data.(workspaceDiffEventData)
+			if !ok || data.WorkspaceID != input.ID {
+				continue
+			}
+			current, _, getErr := s.workspaceDiffCache.Get(ctx, key)
+			if getErr != nil {
+				return nil, problemUpstream("failed to read selected workspace diff", "", "")
+			}
+			if current.Version == input.Version {
+				continue
+			}
+			return &watchWorkspaceDiffOutput{Body: workspaceDiffWatchResponse{
+				Changed: true,
+				Version: current.Version,
+			}}, nil
+		}
+	}
+}
+
 func (s *Server) getWorkspaceDiff(
 	ctx context.Context, input *getWorkspaceDiffInput,
 ) (*getWorkspaceDiffOutput, error) {
@@ -5880,7 +5968,7 @@ func (s *Server) getWorkspaceDiff(
 		return nil, problemConflict(
 			CodeConflict,
 			"workspace diff snapshot changed; reload the file list",
-			map[string]any{"snapshot_version": snapshot.Version},
+			map[string]any{"reason": "snapshot_changed", "snapshot_version": snapshot.Version},
 		)
 	}
 	files := snapshot.Diff.Files
@@ -5923,6 +6011,13 @@ func (s *Server) getWorkspaceFilePreview(
 	)
 	var content *gitclone.FileContent
 	if err == nil {
+		if input.Revision != "" && input.Revision != snapshot.Version {
+			return nil, problemConflict(
+				CodeConflict,
+				"workspace diff snapshot changed; reload the file list",
+				map[string]any{"reason": "snapshot_changed", "snapshot_version": snapshot.Version},
+			)
+		}
 		matching := filterWorkspaceDiffSnapshotPath(snapshot.Diff.Files, input.Path)
 		if len(matching) == 0 {
 			err = gitclone.ErrNotFound
@@ -5949,6 +6044,9 @@ func (s *Server) getWorkspaceFilePreview(
 			"path", input.Path,
 			"err", err,
 		)
+		return nil, problemUpstream("failed to read workspace file preview", "", "")
+	}
+	if content == nil {
 		return nil, problemUpstream("failed to read workspace file preview", "", "")
 	}
 	return &getWorkspaceFilePreviewOutput{Body: filePreviewResponse{

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -6135,7 +6135,12 @@ func filterWorkspaceDiffSnapshotPath(
 	path string,
 ) []gitclone.DiffFile {
 	for i := range files {
-		if files[i].Path == path || files[i].OldPath == path {
+		if files[i].Path == path {
+			return []gitclone.DiffFile{files[i]}
+		}
+	}
+	for i := range files {
+		if files[i].OldPath == path {
 			return []gitclone.DiffFile{files[i]}
 		}
 	}

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -554,6 +554,10 @@ type getWorkspaceInput struct {
 	ID string `path:"id"`
 }
 
+type streamEventsInput struct {
+	WorkspaceID string `query:"workspace_id" doc:"Optional selected local workspace to prewarm and validate while this stream is connected"`
+}
+
 type getWorkspaceFilesInput struct {
 	ID         string `path:"id"`
 	Base       string `query:"base"      doc:"Diff base: head, pushed, or merge-target"`
@@ -571,6 +575,7 @@ type getWorkspaceDiffInput struct {
 	Commit     string `query:"commit" doc:"Scope to a single commit SHA"`
 	From       string `query:"from"   doc:"Start SHA for range diff (inclusive)"`
 	To         string `query:"to"     doc:"End SHA for range diff (inclusive)"`
+	Revision   string `query:"revision" doc:"Optional snapshot_version returned by the workspace files endpoint"`
 }
 
 type getWorkspaceFilePreviewInput struct {
@@ -5819,10 +5824,13 @@ func (s *Server) getWorkspaceFiles(
 	}
 
 	hideWhitespace := input.Whitespace == "hide"
-	files, ok, diffErr := s.workspaceDiffFiles(
-		ctx, req, hideWhitespace,
+	snapshot, _, diffErr := s.workspaceDiffCache.Get(
+		ctx, s.workspaceDiffCacheKey(req, hideWhitespace),
 	)
 	if diffErr != nil {
+		if errors.Is(diffErr, errWorkspaceDiffBaseUnavailable) {
+			return nil, workspaceDiffBaseUnavailable(req.Base)
+		}
 		slog.Error(
 			"failed to list workspace diff files",
 			"workspace_id", input.ID,
@@ -5831,27 +5839,11 @@ func (s *Server) getWorkspaceFiles(
 		)
 		return nil, problemUpstream("failed to list workspace files", "", "")
 	}
-	if !ok {
-		return nil, workspaceDiffBaseUnavailable(req.Base)
-	}
-	whitespaceOnlyCount, countOK, countErr := s.workspaceDiffWhitespaceOnlyCount(
-		ctx, req,
-	)
-	if countErr != nil {
-		slog.Warn(
-			"failed to count workspace whitespace-only diff files",
-			"workspace_id", input.ID,
-			"base", req.Base,
-			"err", countErr,
-		)
-	}
-	if !countOK {
-		return nil, workspaceDiffBaseUnavailable(req.Base)
-	}
 	return &getWorkspaceFilesOutput{Body: filesResponse{
-		Stale:               false,
-		WhitespaceOnlyCount: whitespaceOnlyCount,
-		Files:               files,
+		Stale:               snapshot.Diff.Stale,
+		WhitespaceOnlyCount: snapshot.Diff.WhitespaceOnlyCount,
+		Files:               snapshot.Files,
+		SnapshotVersion:     snapshot.Version,
 	}}, nil
 }
 
@@ -5869,10 +5861,13 @@ func (s *Server) getWorkspaceDiff(
 	}
 
 	hideWhitespace := input.Whitespace == "hide"
-	result, ok, diffErr := s.workspaceDiff(
-		ctx, req, hideWhitespace, input.Path,
+	snapshot, _, diffErr := s.workspaceDiffCache.Get(
+		ctx, s.workspaceDiffCacheKey(req, hideWhitespace),
 	)
 	if diffErr != nil {
+		if errors.Is(diffErr, errWorkspaceDiffBaseUnavailable) {
+			return nil, workspaceDiffBaseUnavailable(req.Base)
+		}
 		slog.Error(
 			"failed to compute workspace diff",
 			"workspace_id", input.ID,
@@ -5881,13 +5876,22 @@ func (s *Server) getWorkspaceDiff(
 		)
 		return nil, problemUpstream("failed to compute workspace diff", "", "")
 	}
-	if !ok {
-		return nil, workspaceDiffBaseUnavailable(req.Base)
+	if input.Revision != "" && input.Revision != snapshot.Version {
+		return nil, problemConflict(
+			CodeConflict,
+			"workspace diff snapshot changed; reload the file list",
+			map[string]any{"snapshot_version": snapshot.Version},
+		)
+	}
+	files := snapshot.Diff.Files
+	if input.Path != "" {
+		files = filterWorkspaceDiffSnapshotPath(files, input.Path)
 	}
 	return &getWorkspaceDiffOutput{Body: diffResponse{
-		Stale:               false,
-		WhitespaceOnlyCount: result.WhitespaceOnlyCount,
-		Files:               result.Files,
+		Stale:               snapshot.Diff.Stale,
+		WhitespaceOnlyCount: snapshot.Diff.WhitespaceOnlyCount,
+		Files:               files,
+		SnapshotVersion:     snapshot.Version,
 	}}, nil
 }
 
@@ -5914,10 +5918,24 @@ func (s *Server) getWorkspaceFilePreview(
 	}
 
 	hideWhitespace := input.Whitespace == "hide"
-	content, ok, err := s.workspaceFilePreview(
-		ctx, req, hideWhitespace, input.Path, side,
+	snapshot, _, err := s.workspaceDiffCache.Get(
+		ctx, s.workspaceDiffCacheKey(req, hideWhitespace),
 	)
+	var content *gitclone.FileContent
+	if err == nil {
+		matching := filterWorkspaceDiffSnapshotPath(snapshot.Diff.Files, input.Path)
+		if len(matching) == 0 {
+			err = gitclone.ErrNotFound
+		} else {
+			content, err = workspace.ReadDiffSnapshotFile(
+				ctx, snapshot.Resolved, matching[0], side, maxFilePreviewBytes,
+			)
+		}
+	}
 	if err != nil {
+		if errors.Is(err, errWorkspaceDiffBaseUnavailable) {
+			return nil, workspaceDiffBaseUnavailable(req.Base)
+		}
 		if errors.Is(err, gitclone.ErrNotFound) {
 			return nil, problemNotFound(CodeNotFound, "workspace file preview not available: file is not changed in this diff", nil)
 		}
@@ -5933,10 +5951,6 @@ func (s *Server) getWorkspaceFilePreview(
 		)
 		return nil, problemUpstream("failed to read workspace file preview", "", "")
 	}
-	if !ok {
-		return nil, workspaceDiffBaseUnavailable(req.Base)
-	}
-
 	return &getWorkspaceFilePreviewOutput{Body: filePreviewResponse{
 		Path:      content.Path,
 		MediaType: previewMediaType(content.Path, content.Data),
@@ -5999,6 +6013,35 @@ func (s *Server) workspaceDiffRequest(
 			"head", "pushed", "merge-target",
 		)
 	}
+}
+
+func (s *Server) workspaceDiffCacheKey(
+	req workspaceDiffRequest,
+	hideWhitespace bool,
+) workspaceDiffLogicalKey {
+	return workspaceDiffLogicalKey{
+		WorkspaceID: req.Summary.ID,
+		Spec: workspace.DiffSnapshotSpec{
+			WorktreePath:      req.Summary.WorktreePath,
+			Base:              req.Base,
+			MergeTargetBranch: req.MergeTargetBranch,
+			FromSHA:           req.FromSHA,
+			ToSHA:             req.ToSHA,
+			HideWhitespace:    hideWhitespace,
+		},
+	}
+}
+
+func filterWorkspaceDiffSnapshotPath(
+	files []gitclone.DiffFile,
+	path string,
+) []gitclone.DiffFile {
+	for i := range files {
+		if files[i].Path == path || files[i].OldPath == path {
+			return []gitclone.DiffFile{files[i]}
+		}
+	}
+	return []gitclone.DiffFile{}
 }
 
 func (s *Server) workspaceCommits(
@@ -6099,150 +6142,6 @@ func (s *Server) validateWorkspaceSHAs(
 		}
 	}
 	return indexMap, nil
-}
-
-func (s *Server) workspaceDiffFiles(
-	ctx context.Context,
-	req workspaceDiffRequest,
-	hideWhitespace bool,
-) ([]gitclone.DiffFile, bool, error) {
-	if req.FromSHA != "" && req.ToSHA != "" {
-		return workspace.WorktreeDiffFilesBetween(
-			ctx,
-			req.Summary.WorktreePath,
-			req.FromSHA,
-			req.ToSHA,
-			hideWhitespace,
-		)
-	}
-	if req.Base == workspace.WorktreeDiffBaseMergeTarget {
-		return workspace.WorktreeDiffFilesAgainstMergeTarget(
-			ctx,
-			req.Summary.WorktreePath,
-			req.MergeTargetBranch,
-			hideWhitespace,
-		)
-	}
-	return workspace.WorktreeDiffFiles(
-		ctx, req.Summary.WorktreePath, req.Base, hideWhitespace,
-	)
-}
-
-func (s *Server) workspaceDiff(
-	ctx context.Context,
-	req workspaceDiffRequest,
-	hideWhitespace bool,
-	path string,
-) (*gitclone.DiffResult, bool, error) {
-	if req.FromSHA != "" && req.ToSHA != "" {
-		if path != "" {
-			return workspace.WorktreeFileDiffBetween(
-				ctx,
-				req.Summary.WorktreePath,
-				req.FromSHA,
-				req.ToSHA,
-				hideWhitespace,
-				path,
-			)
-		}
-		return workspace.WorktreeDiffBetween(
-			ctx,
-			req.Summary.WorktreePath,
-			req.FromSHA,
-			req.ToSHA,
-			hideWhitespace,
-		)
-	}
-	if req.Base == workspace.WorktreeDiffBaseMergeTarget {
-		if path != "" {
-			return workspace.WorktreeFileDiffAgainstMergeTarget(
-				ctx,
-				req.Summary.WorktreePath,
-				req.MergeTargetBranch,
-				hideWhitespace,
-				path,
-			)
-		}
-		return workspace.WorktreeDiffAgainstMergeTarget(
-			ctx,
-			req.Summary.WorktreePath,
-			req.MergeTargetBranch,
-			hideWhitespace,
-		)
-	}
-	if path != "" {
-		return workspace.WorktreeFileDiff(
-			ctx, req.Summary.WorktreePath, req.Base, hideWhitespace, path,
-		)
-	}
-	return workspace.WorktreeDiff(
-		ctx, req.Summary.WorktreePath, req.Base, hideWhitespace,
-	)
-}
-
-func (s *Server) workspaceFilePreview(
-	ctx context.Context,
-	req workspaceDiffRequest,
-	hideWhitespace bool,
-	path string,
-	side string,
-) (*gitclone.FileContent, bool, error) {
-	if req.FromSHA != "" && req.ToSHA != "" {
-		return workspace.WorktreeFileContentBetween(
-			ctx,
-			req.Summary.WorktreePath,
-			req.FromSHA,
-			req.ToSHA,
-			hideWhitespace,
-			path,
-			side,
-			maxFilePreviewBytes,
-		)
-	}
-	if req.Base == workspace.WorktreeDiffBaseMergeTarget {
-		return workspace.WorktreeFileContentAgainstMergeTarget(
-			ctx,
-			req.Summary.WorktreePath,
-			req.MergeTargetBranch,
-			hideWhitespace,
-			path,
-			side,
-			maxFilePreviewBytes,
-		)
-	}
-	return workspace.WorktreeFileContent(
-		ctx,
-		req.Summary.WorktreePath,
-		req.Base,
-		hideWhitespace,
-		path,
-		side,
-		maxFilePreviewBytes,
-	)
-}
-
-func (s *Server) workspaceDiffWhitespaceOnlyCount(
-	ctx context.Context,
-	req workspaceDiffRequest,
-) (int, bool, error) {
-	if req.FromSHA != "" && req.ToSHA != "" {
-		return workspace.WorktreeDiffWhitespaceOnlyCountBetween(
-			ctx,
-			req.Summary.WorktreePath,
-			req.FromSHA,
-			req.ToSHA,
-		)
-	}
-	if req.Base == workspace.WorktreeDiffBaseMergeTarget {
-		return workspace.WorktreeDiffWhitespaceOnlyCountAgainstMergeTarget(
-			ctx,
-			req.Summary.WorktreePath,
-			req.MergeTargetBranch,
-		)
-	}
-	return workspace.WorktreeDiffWhitespaceOnlyCount(
-		ctx, req.Summary.WorktreePath, req.Base,
-	)
 }
 
 func (s *Server) workspaceMergeTargetBranch(

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -251,6 +251,12 @@ type Server struct {
 	connWG sync.WaitGroup
 }
 
+type workspaceDiffEventData struct {
+	WorkspaceID string `json:"workspace_id"`
+	Revision    uint64 `json:"revision"`
+	Version     string `json:"version"`
+}
+
 // trackHTTPConn is installed as http.Server.ConnState by Serve so
 // Shutdown can wait for per-connection goroutines to fully unwind.
 func (s *Server) trackHTTPConn(_ net.Conn, state http.ConnState) {
@@ -732,12 +738,19 @@ func newServer(
 	s.docsRegistry = docs.NewRegistry(docFolders)
 	warnDocFolderDaemonBindings(docFolders)
 	s.workspaceDiffCache = newWorkspaceDiffCache(s.bgCtx, workspaceDiffCacheDeps{
+		onReady: func(workspaceID string, revision uint64, version string) {
+			s.hub.Broadcast(Event{Type: "workspace_diff_ready", Data: workspaceDiffEventData{
+				WorkspaceID: workspaceID,
+				Revision:    revision,
+				Version:     version,
+			}})
+		},
 		onChanged: func(workspaceID string, revision uint64, version string) {
-			s.hub.Broadcast(Event{Type: "workspace_diff_changed", Data: struct {
-				WorkspaceID string `json:"workspace_id"`
-				Revision    uint64 `json:"revision"`
-				Version     string `json:"version"`
-			}{WorkspaceID: workspaceID, Revision: revision, Version: version}})
+			s.hub.Broadcast(Event{Type: "workspace_diff_changed", Data: workspaceDiffEventData{
+				WorkspaceID: workspaceID,
+				Revision:    revision,
+				Version:     version,
+			}})
 		},
 	})
 	s.runBackground(func(ctx context.Context) {
@@ -1497,6 +1510,10 @@ func (s *Server) streamEvents(
 			ctx.SetHeader("Connection", "keep-alive")
 
 			r, w := humago.Unwrap(ctx)
+			rc := http.NewResponseController(w)
+			_ = rc.SetWriteDeadline(time.Time{})
+			cursor, hasCursor := parseLastEventID(r)
+			ch, done := s.hub.Subscribe(ctx.Context(), !hasCursor)
 			releaseSelection := func() {}
 			if input.WorkspaceID != "" && s.workspaceDiffCache != nil {
 				releaseSelection = s.workspaceDiffCache.Select(
@@ -1513,10 +1530,7 @@ func (s *Server) streamEvents(
 				)
 			}
 			defer releaseSelection()
-			rc := http.NewResponseController(w)
-			_ = rc.SetWriteDeadline(time.Time{})
-			cursor, hasCursor := parseLastEventID(r)
-			s.serveSSE(ctx.Context(), w, rc, cursor, hasCursor)
+			s.serveSSESubscribed(ctx.Context(), w, rc, cursor, hasCursor, ch, done)
 		},
 	}, nil
 }
@@ -1566,6 +1580,18 @@ func (s *Server) serveSSE(
 	// supplied the handler replays the ring directly, so cached
 	// sync_status injection by Subscribe would duplicate; pass false.
 	ch, done := s.hub.Subscribe(ctx, !hasCursor)
+	s.serveSSESubscribed(ctx, w, rc, cursor, hasCursor, ch, done)
+}
+
+func (s *Server) serveSSESubscribed(
+	ctx context.Context,
+	w io.Writer,
+	rc sseController,
+	cursor uint64,
+	hasCursor bool,
+	ch <-chan RecordedEvent,
+	done <-chan struct{},
+) {
 
 	if err := rc.Flush(); err != nil {
 		return

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -138,6 +138,7 @@ type Server struct {
 	workspaces                  *workspace.Manager
 	workspacePRMonitor          *workspace.PRMonitor
 	workspacePushedHeadObserver *workspace.PushedHeadObserver
+	workspaceDiffCache          *workspaceDiffCache
 	tmuxActivity                *tmuxActivityTracker
 	fleetTmuxMonitor            *fleetTmuxMonitor
 	fleetWorktreeDiscoverer     *fleetWorktreeDiscoverer
@@ -730,6 +731,19 @@ func newServer(
 	}
 	s.docsRegistry = docs.NewRegistry(docFolders)
 	warnDocFolderDaemonBindings(docFolders)
+	s.workspaceDiffCache = newWorkspaceDiffCache(s.bgCtx, workspaceDiffCacheDeps{
+		onChanged: func(workspaceID string, revision uint64, version string) {
+			s.hub.Broadcast(Event{Type: "workspace_diff_changed", Data: struct {
+				WorkspaceID string `json:"workspace_id"`
+				Revision    uint64 `json:"revision"`
+				Version     string `json:"version"`
+			}{WorkspaceID: workspaceID, Revision: revision, Version: version}})
+		},
+	})
+	s.runBackground(func(ctx context.Context) {
+		<-ctx.Done()
+		s.workspaceDiffCache.Wait()
+	})
 
 	s.hostOpts.Store(&hostOpts)
 	if hostOpts.TrustReverseProxy && len(hostOpts.Allowed) == 0 {
@@ -1474,7 +1488,7 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) streamEvents(
-	_ context.Context, _ *struct{},
+	_ context.Context, input *streamEventsInput,
 ) (*huma.StreamResponse, error) {
 	return &huma.StreamResponse{
 		Body: func(ctx huma.Context) {
@@ -1483,6 +1497,22 @@ func (s *Server) streamEvents(
 			ctx.SetHeader("Connection", "keep-alive")
 
 			r, w := humago.Unwrap(ctx)
+			releaseSelection := func() {}
+			if input.WorkspaceID != "" && s.workspaceDiffCache != nil {
+				releaseSelection = s.workspaceDiffCache.Select(
+					input.WorkspaceID,
+					func(resolveCtx context.Context) (workspaceDiffLogicalKey, error) {
+						req, err := s.workspaceDiffRequest(
+							resolveCtx, input.WorkspaceID, string(workspace.WorktreeDiffBaseHead),
+						)
+						if err != nil {
+							return workspaceDiffLogicalKey{}, err
+						}
+						return s.workspaceDiffCacheKey(req, false), nil
+					},
+				)
+			}
+			defer releaseSelection()
 			rc := http.NewResponseController(w)
 			_ = rc.SetWriteDeadline(time.Time{})
 			cursor, hasCursor := parseLastEventID(r)

--- a/internal/server/workspace_diff_cache.go
+++ b/internal/server/workspace_diff_cache.go
@@ -603,11 +603,13 @@ func (c *workspaceDiffCache) validateSelected(force bool) {
 			continue
 		}
 		for key := range active {
-			if entry := c.peekEntryLocked(key); entry != nil {
-				if (!force && now.Sub(entry.validatedAt) < workspaceDiffCacheFreshFor-workspaceDiffValidationPoll) ||
-					now.Before(entry.retryAfter) {
-					continue
-				}
+			entry := c.peekEntryLocked(key)
+			if entry == nil {
+				continue
+			}
+			if (!force && now.Sub(entry.validatedAt) < workspaceDiffCacheFreshFor-workspaceDiffValidationPoll) ||
+				now.Before(entry.retryAfter) {
+				continue
 			}
 			keys = append(keys, key)
 		}

--- a/internal/server/workspace_diff_cache.go
+++ b/internal/server/workspace_diff_cache.go
@@ -1,0 +1,506 @@
+package server
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"go.kenn.io/middleman/internal/gitclone"
+	"go.kenn.io/middleman/internal/workspace"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/sync/singleflight"
+)
+
+const (
+	workspaceDiffCacheFreshFor  = 15 * time.Second
+	workspaceDiffCacheIdleTTL   = 10 * time.Minute
+	workspaceDiffCacheRetryWait = 5 * time.Second
+	workspaceDiffCacheMaxBytes  = int64(128 << 20)
+)
+
+var errWorkspaceDiffMovedDuringPreparation = errors.New("workspace diff moved during preparation")
+var errWorkspaceDiffBaseUnavailable = errors.New("workspace diff base is unavailable")
+
+type workspaceDiffLogicalKey struct {
+	WorkspaceID string
+	Spec        workspace.DiffSnapshotSpec
+}
+
+type workspaceDiffSnapshot struct {
+	Resolved    workspace.ResolvedDiffSnapshotSpec
+	Fingerprint workspace.DiffFingerprint
+	Revision    uint64
+	Version     string
+	Diff        *gitclone.DiffResult
+	Files       []gitclone.DiffFile
+	SizeBytes   int64
+}
+
+type workspaceDiffCacheState string
+
+const (
+	workspaceDiffCacheHit       workspaceDiffCacheState = "hit"
+	workspaceDiffCacheStale     workspaceDiffCacheState = "stale"
+	workspaceDiffCacheMiss      workspaceDiffCacheState = "miss"
+	workspaceDiffCacheCoalesced workspaceDiffCacheState = "coalesced"
+)
+
+type workspaceDiffCacheDeps struct {
+	now         func() time.Time
+	resolve     func(context.Context, workspace.DiffSnapshotSpec) (workspace.ResolvedDiffSnapshotSpec, bool, error)
+	fingerprint func(context.Context, workspace.ResolvedDiffSnapshotSpec) (workspace.DiffFingerprint, error)
+	prepare     func(context.Context, workspace.ResolvedDiffSnapshotSpec) (*gitclone.DiffResult, error)
+	onChanged   func(workspaceID string, revision uint64, version string)
+	onColdWait  func()
+}
+
+type workspaceDiffCacheEntry struct {
+	snapshot    *workspaceDiffSnapshot
+	validatedAt time.Time
+	lastAccess  time.Time
+	retryAfter  time.Time
+}
+
+type workspaceDiffCache struct {
+	root       context.Context
+	deps       workspaceDiffCacheDeps
+	generation string
+
+	mu         sync.Mutex
+	entries    map[workspaceDiffLogicalKey]*workspaceDiffCacheEntry
+	inFlight   map[workspaceDiffLogicalKey]bool
+	selected   map[string]int
+	active     map[string]map[workspaceDiffLogicalKey]time.Time
+	nextRev    uint64
+	totalBytes int64
+	group      singleflight.Group
+	wg         sync.WaitGroup
+}
+
+func newWorkspaceDiffCache(
+	root context.Context,
+	deps workspaceDiffCacheDeps,
+) *workspaceDiffCache {
+	if deps.now == nil {
+		deps.now = time.Now
+	}
+	if deps.resolve == nil {
+		deps.resolve = workspace.ResolveDiffSnapshotSpec
+	}
+	if deps.fingerprint == nil {
+		deps.fingerprint = workspace.FingerprintDiffSnapshot
+	}
+	if deps.prepare == nil {
+		deps.prepare = workspace.PrepareDiffSnapshot
+	}
+	c := &workspaceDiffCache{
+		root:       root,
+		deps:       deps,
+		generation: newWorkspaceDiffCacheGeneration(),
+		entries:    make(map[workspaceDiffLogicalKey]*workspaceDiffCacheEntry),
+		inFlight:   make(map[workspaceDiffLogicalKey]bool),
+		selected:   make(map[string]int),
+		active:     make(map[string]map[workspaceDiffLogicalKey]time.Time),
+	}
+	c.wg.Add(1)
+	go c.validationLoop()
+	return c
+}
+
+func newWorkspaceDiffCacheGeneration() string {
+	var data [8]byte
+	if _, err := rand.Read(data[:]); err == nil {
+		return hex.EncodeToString(data[:])
+	}
+	return fmt.Sprintf("%x", time.Now().UnixNano())
+}
+
+func (c *workspaceDiffCache) Get(
+	ctx context.Context,
+	key workspaceDiffLogicalKey,
+) (*workspaceDiffSnapshot, workspaceDiffCacheState, error) {
+	now := c.deps.now()
+	c.mu.Lock()
+	if entry := c.entries[key]; entry != nil {
+		entry.lastAccess = now
+		c.markActiveLocked(key, now)
+		fresh := now.Sub(entry.validatedAt) <= workspaceDiffCacheFreshFor
+		retryAllowed := !now.Before(entry.retryAfter)
+		snapshot := cloneWorkspaceDiffSnapshot(entry.snapshot, !fresh)
+		c.mu.Unlock()
+		state := workspaceDiffCacheHit
+		if !fresh {
+			state = workspaceDiffCacheStale
+			if retryAllowed {
+				c.validateAsync(key)
+			}
+		}
+		c.setSpanAttributes(ctx, key, snapshot, state)
+		return snapshot, state, nil
+	}
+	leader := !c.inFlight[key]
+	if leader {
+		c.inFlight[key] = true
+	}
+	c.mu.Unlock()
+
+	resultCh := c.group.DoChan(c.singleflightKey(key), func() (any, error) {
+		defer func() {
+			c.mu.Lock()
+			delete(c.inFlight, key)
+			c.mu.Unlock()
+		}()
+		return c.refresh(c.root, key)
+	})
+	if c.deps.onColdWait != nil {
+		c.deps.onColdWait()
+	}
+	select {
+	case <-ctx.Done():
+		return nil, workspaceDiffCacheMiss, ctx.Err()
+	case result := <-resultCh:
+		if result.Err != nil {
+			return nil, workspaceDiffCacheMiss, result.Err
+		}
+		snapshot := cloneWorkspaceDiffSnapshot(result.Val.(*workspaceDiffSnapshot), false)
+		state := workspaceDiffCacheMiss
+		if !leader {
+			state = workspaceDiffCacheCoalesced
+		}
+		c.setSpanAttributes(ctx, key, snapshot, state)
+		return snapshot, state, nil
+	}
+}
+
+func (c *workspaceDiffCache) validate(
+	ctx context.Context,
+	key workspaceDiffLogicalKey,
+) error {
+	resultCh := c.group.DoChan(c.singleflightKey(key), func() (any, error) {
+		return c.refresh(c.root, key)
+	})
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case result := <-resultCh:
+		return result.Err
+	}
+}
+
+func (c *workspaceDiffCache) refresh(
+	ctx context.Context,
+	key workspaceDiffLogicalKey,
+) (*workspaceDiffSnapshot, error) {
+	resolved, ok, err := c.deps.resolve(ctx, key.Spec)
+	if err != nil {
+		c.recordFailure(key)
+		return nil, err
+	}
+	if !ok {
+		err = errWorkspaceDiffBaseUnavailable
+		c.recordFailure(key)
+		return nil, err
+	}
+	before, err := c.deps.fingerprint(ctx, resolved)
+	if err != nil {
+		c.recordFailure(key)
+		return nil, err
+	}
+
+	now := c.deps.now()
+	c.mu.Lock()
+	entry := c.entries[key]
+	if entry != nil && entry.snapshot.Fingerprint == before {
+		entry.validatedAt = now
+		entry.retryAfter = time.Time{}
+		entry.lastAccess = now
+		snapshot := entry.snapshot
+		c.mu.Unlock()
+		return snapshot, nil
+	}
+	c.mu.Unlock()
+
+	diff, err := c.deps.prepare(ctx, resolved)
+	if err != nil {
+		c.recordFailure(key)
+		return nil, err
+	}
+	afterResolved, ok, err := c.deps.resolve(ctx, key.Spec)
+	if err != nil || !ok {
+		if err == nil {
+			err = errWorkspaceDiffMovedDuringPreparation
+		}
+		c.recordFailure(key)
+		return nil, err
+	}
+	after, err := c.deps.fingerprint(ctx, afterResolved)
+	if err != nil {
+		c.recordFailure(key)
+		return nil, err
+	}
+	if before != after || resolved.BaseOID != afterResolved.BaseOID || resolved.HeadOID != afterResolved.HeadOID {
+		c.recordFailure(key)
+		return nil, errWorkspaceDiffMovedDuringPreparation
+	}
+
+	files := workspaceDiffFilesProjection(diff.Files)
+	sizeBytes := approximateWorkspaceDiffBytes(diff, files)
+	c.mu.Lock()
+	previous := c.entries[key]
+	c.nextRev++
+	snapshot := &workspaceDiffSnapshot{
+		Resolved:    afterResolved,
+		Fingerprint: after,
+		Revision:    c.nextRev,
+		Version:     fmt.Sprintf("%s:%d", c.generation, c.nextRev),
+		Diff:        diff,
+		Files:       files,
+		SizeBytes:   sizeBytes,
+	}
+	if previous != nil {
+		c.totalBytes -= previous.snapshot.SizeBytes
+	}
+	c.entries[key] = &workspaceDiffCacheEntry{
+		snapshot:    snapshot,
+		validatedAt: now,
+		lastAccess:  now,
+	}
+	c.totalBytes += sizeBytes
+	c.markActiveLocked(key, now)
+	changed := previous != nil && previous.snapshot.Fingerprint != after
+	c.evictLocked(now)
+	c.mu.Unlock()
+	if changed && c.deps.onChanged != nil {
+		c.deps.onChanged(key.WorkspaceID, snapshot.Revision, snapshot.Version)
+	}
+	return snapshot, nil
+}
+
+func (c *workspaceDiffCache) recordFailure(key workspaceDiffLogicalKey) {
+	c.mu.Lock()
+	if entry := c.entries[key]; entry != nil {
+		entry.retryAfter = c.deps.now().Add(workspaceDiffCacheRetryWait)
+	}
+	c.mu.Unlock()
+}
+
+func (c *workspaceDiffCache) validateAsync(key workspaceDiffLogicalKey) {
+	c.wg.Go(func() {
+		_ = c.validate(c.root, key)
+	})
+}
+
+func (c *workspaceDiffCache) Select(
+	workspaceID string,
+	resolveKey func(context.Context) (workspaceDiffLogicalKey, error),
+) func() {
+	c.mu.Lock()
+	first := c.selected[workspaceID] == 0
+	c.selected[workspaceID]++
+	c.mu.Unlock()
+	if first && resolveKey != nil {
+		c.wg.Go(func() {
+			key, err := resolveKey(c.root)
+			if err != nil {
+				return
+			}
+			c.MarkActive(key)
+			_, _, _ = c.Get(c.root, key)
+		})
+	}
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			c.mu.Lock()
+			if c.selected[workspaceID] <= 1 {
+				delete(c.selected, workspaceID)
+				delete(c.active, workspaceID)
+			} else {
+				c.selected[workspaceID]--
+			}
+			c.mu.Unlock()
+		})
+	}
+}
+
+func (c *workspaceDiffCache) MarkActive(key workspaceDiffLogicalKey) {
+	c.mu.Lock()
+	c.markActiveLocked(key, c.deps.now())
+	c.mu.Unlock()
+}
+
+func (c *workspaceDiffCache) markActiveLocked(key workspaceDiffLogicalKey, now time.Time) {
+	if c.selected[key.WorkspaceID] == 0 {
+		return
+	}
+	keys := c.active[key.WorkspaceID]
+	if keys == nil {
+		keys = make(map[workspaceDiffLogicalKey]time.Time)
+		c.active[key.WorkspaceID] = keys
+	}
+	keys[key] = now
+}
+
+func (c *workspaceDiffCache) ValidateSelected() {
+	now := c.deps.now()
+	c.mu.Lock()
+	keys := make([]workspaceDiffLogicalKey, 0)
+	for workspaceID, active := range c.active {
+		if c.selected[workspaceID] == 0 {
+			continue
+		}
+		for key, accessed := range active {
+			if now.Sub(accessed) > workspaceDiffCacheIdleTTL {
+				continue
+			}
+			if entry := c.entries[key]; entry != nil && now.Before(entry.retryAfter) {
+				continue
+			}
+			keys = append(keys, key)
+		}
+	}
+	c.mu.Unlock()
+	for _, key := range keys {
+		c.validateAsync(key)
+	}
+}
+
+func (c *workspaceDiffCache) validationLoop() {
+	defer c.wg.Done()
+	ticker := time.NewTicker(workspaceDiffCacheFreshFor)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-c.root.Done():
+			return
+		case <-ticker.C:
+			c.ValidateSelected()
+		}
+	}
+}
+
+func (c *workspaceDiffCache) Wait() {
+	c.wg.Wait()
+}
+
+func (c *workspaceDiffCache) singleflightKey(key workspaceDiffLogicalKey) string {
+	return fmt.Sprintf("%s\x00%s\x00%s\x00%s\x00%s\x00%s\x00%t",
+		key.WorkspaceID,
+		key.Spec.WorktreePath,
+		key.Spec.Base,
+		key.Spec.MergeTargetBranch,
+		key.Spec.FromSHA,
+		key.Spec.ToSHA,
+		key.Spec.HideWhitespace,
+	)
+}
+
+func (c *workspaceDiffCache) setSpanAttributes(
+	ctx context.Context,
+	key workspaceDiffLogicalKey,
+	snapshot *workspaceDiffSnapshot,
+	state workspaceDiffCacheState,
+) {
+	span := trace.SpanFromContext(ctx)
+	span.SetAttributes(
+		attribute.String("workspace.id", key.WorkspaceID),
+		attribute.String("workspace.diff.cache_result", string(state)),
+		attribute.Int64("workspace.diff.snapshot_bytes", snapshot.SizeBytes),
+		attribute.Int64("workspace.diff.revision", int64(snapshot.Revision)),
+	)
+}
+
+func (c *workspaceDiffCache) evictLocked(now time.Time) {
+	for key, entry := range c.entries {
+		if c.activeKeyLocked(key) || now.Sub(entry.lastAccess) <= workspaceDiffCacheIdleTTL {
+			continue
+		}
+		c.removeEntryLocked(key, entry)
+	}
+	if c.totalBytes <= workspaceDiffCacheMaxBytes {
+		return
+	}
+	type candidate struct {
+		key   workspaceDiffLogicalKey
+		entry *workspaceDiffCacheEntry
+	}
+	candidates := make([]candidate, 0, len(c.entries))
+	for key, entry := range c.entries {
+		if !c.activeKeyLocked(key) {
+			candidates = append(candidates, candidate{key: key, entry: entry})
+		}
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].entry.lastAccess.Before(candidates[j].entry.lastAccess)
+	})
+	for _, candidate := range candidates {
+		if c.totalBytes <= workspaceDiffCacheMaxBytes {
+			break
+		}
+		c.removeEntryLocked(candidate.key, candidate.entry)
+	}
+}
+
+func (c *workspaceDiffCache) activeKeyLocked(key workspaceDiffLogicalKey) bool {
+	if c.selected[key.WorkspaceID] == 0 {
+		return false
+	}
+	_, ok := c.active[key.WorkspaceID][key]
+	return ok
+}
+
+func (c *workspaceDiffCache) removeEntryLocked(
+	key workspaceDiffLogicalKey,
+	entry *workspaceDiffCacheEntry,
+) {
+	delete(c.entries, key)
+	c.totalBytes -= entry.snapshot.SizeBytes
+}
+
+func workspaceDiffFilesProjection(files []gitclone.DiffFile) []gitclone.DiffFile {
+	projection := make([]gitclone.DiffFile, len(files))
+	copy(projection, files)
+	for i := range projection {
+		projection[i].Patch = ""
+		projection[i].Hunks = []gitclone.Hunk{}
+	}
+	return projection
+}
+
+func cloneWorkspaceDiffSnapshot(
+	snapshot *workspaceDiffSnapshot,
+	stale bool,
+) *workspaceDiffSnapshot {
+	clone := *snapshot
+	diff := *snapshot.Diff
+	diff.Stale = stale
+	diff.Files = append([]gitclone.DiffFile(nil), snapshot.Diff.Files...)
+	clone.Diff = &diff
+	clone.Files = append([]gitclone.DiffFile(nil), snapshot.Files...)
+	return &clone
+}
+
+func approximateWorkspaceDiffBytes(
+	diff *gitclone.DiffResult,
+	files []gitclone.DiffFile,
+) int64 {
+	size := int64(64)
+	for _, list := range [][]gitclone.DiffFile{diff.Files, files} {
+		for _, file := range list {
+			size += int64(len(file.Path) + len(file.OldPath) + len(file.Status) + len(file.Patch) + 96)
+			for _, hunk := range file.Hunks {
+				size += int64(len(hunk.Section) + 48)
+				for _, line := range hunk.Lines {
+					size += int64(len(line.Type) + len(line.Content) + 32)
+				}
+			}
+		}
+	}
+	return size
+}

--- a/internal/server/workspace_diff_cache.go
+++ b/internal/server/workspace_diff_cache.go
@@ -6,26 +6,33 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"sort"
+	"maps"
 	"sync"
 	"time"
 
+	"github.com/jellydator/ttlcache/v3"
 	"go.kenn.io/middleman/internal/gitclone"
 	"go.kenn.io/middleman/internal/workspace"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/singleflight"
 )
 
 const (
-	workspaceDiffCacheFreshFor  = 15 * time.Second
-	workspaceDiffCacheIdleTTL   = 10 * time.Minute
-	workspaceDiffCacheRetryWait = 5 * time.Second
-	workspaceDiffCacheMaxBytes  = int64(128 << 20)
+	workspaceDiffCacheFreshFor      = 15 * time.Second
+	workspaceDiffCacheIdleTTL       = 10 * time.Minute
+	workspaceDiffCacheRetryWait     = 5 * time.Second
+	workspaceDiffPreparationTimeout = 30 * time.Second
+	workspaceDiffValidationPoll     = time.Second
+	workspaceDiffCacheMaxBytes      = int64(128 << 20)
+	workspaceDiffCachePairRetention = time.Minute
 )
 
 var errWorkspaceDiffMovedDuringPreparation = errors.New("workspace diff moved during preparation")
 var errWorkspaceDiffBaseUnavailable = errors.New("workspace diff base is unavailable")
+
+var workspaceDiffCacheTracer = otel.Tracer("go.kenn.io/middleman/internal/server/workspace-diff-cache")
 
 type workspaceDiffLogicalKey struct {
 	WorkspaceID string
@@ -53,18 +60,23 @@ const (
 
 type workspaceDiffCacheDeps struct {
 	now         func() time.Time
+	after       func(time.Duration) <-chan time.Time
 	resolve     func(context.Context, workspace.DiffSnapshotSpec) (workspace.ResolvedDiffSnapshotSpec, bool, error)
 	fingerprint func(context.Context, workspace.ResolvedDiffSnapshotSpec) (workspace.DiffFingerprint, error)
 	prepare     func(context.Context, workspace.ResolvedDiffSnapshotSpec) (*gitclone.DiffResult, error)
 	onChanged   func(workspaceID string, revision uint64, version string)
+	onReady     func(workspaceID string, revision uint64, version string)
 	onColdWait  func()
+	maxBytes    int64
 }
 
 type workspaceDiffCacheEntry struct {
-	snapshot    *workspaceDiffSnapshot
-	validatedAt time.Time
-	lastAccess  time.Time
-	retryAfter  time.Time
+	snapshot      *workspaceDiffSnapshot
+	validatedAt   time.Time
+	lastAccess    time.Time
+	retryAfter    time.Time
+	retainedUntil time.Time
+	costExempt    bool
 }
 
 type workspaceDiffCache struct {
@@ -72,15 +84,22 @@ type workspaceDiffCache struct {
 	deps       workspaceDiffCacheDeps
 	generation string
 
-	mu         sync.Mutex
-	entries    map[workspaceDiffLogicalKey]*workspaceDiffCacheEntry
-	inFlight   map[workspaceDiffLogicalKey]bool
-	selected   map[string]int
-	active     map[string]map[workspaceDiffLogicalKey]time.Time
-	nextRev    uint64
-	totalBytes int64
-	group      singleflight.Group
-	wg         sync.WaitGroup
+	mu               sync.Mutex
+	protectedEntries *ttlcache.Cache[workspaceDiffLogicalKey, *workspaceDiffCacheEntry]
+	inactiveEntries  *ttlcache.Cache[workspaceDiffLogicalKey, *workspaceDiffCacheEntry]
+	inFlight         map[workspaceDiffLogicalKey]bool
+	selected         map[string]int
+	active           map[string]map[workspaceDiffLogicalKey]time.Time
+	selectionCancel  map[string]context.CancelFunc
+	nextRev          uint64
+	group            singleflight.Group
+	wg               sync.WaitGroup
+
+	validationMu      sync.Mutex
+	validationCond    *sync.Cond
+	validationQueue   []workspaceDiffLogicalKey
+	validationQueued  map[workspaceDiffLogicalKey]struct{}
+	validationStopped bool
 }
 
 func newWorkspaceDiffCache(
@@ -89,6 +108,9 @@ func newWorkspaceDiffCache(
 ) *workspaceDiffCache {
 	if deps.now == nil {
 		deps.now = time.Now
+	}
+	if deps.after == nil {
+		deps.after = time.After
 	}
 	if deps.resolve == nil {
 		deps.resolve = workspace.ResolveDiffSnapshotSpec
@@ -99,15 +121,40 @@ func newWorkspaceDiffCache(
 	if deps.prepare == nil {
 		deps.prepare = workspace.PrepareDiffSnapshot
 	}
-	c := &workspaceDiffCache{
-		root:       root,
-		deps:       deps,
-		generation: newWorkspaceDiffCacheGeneration(),
-		entries:    make(map[workspaceDiffLogicalKey]*workspaceDiffCacheEntry),
-		inFlight:   make(map[workspaceDiffLogicalKey]bool),
-		selected:   make(map[string]int),
-		active:     make(map[string]map[workspaceDiffLogicalKey]time.Time),
+	if deps.maxBytes == 0 {
+		deps.maxBytes = workspaceDiffCacheMaxBytes
 	}
+	protectedEntries := ttlcache.New(
+		ttlcache.WithTTL[workspaceDiffLogicalKey, *workspaceDiffCacheEntry](workspaceDiffCacheIdleTTL),
+		ttlcache.WithDisableTouchOnHit[workspaceDiffLogicalKey, *workspaceDiffCacheEntry](),
+	)
+	inactiveEntries := ttlcache.New(
+		ttlcache.WithTTL[workspaceDiffLogicalKey, *workspaceDiffCacheEntry](workspaceDiffCacheIdleTTL),
+		ttlcache.WithDisableTouchOnHit[workspaceDiffLogicalKey, *workspaceDiffCacheEntry](),
+		ttlcache.WithMaxCost(uint64(deps.maxBytes), workspaceDiffCacheEntryCost),
+	)
+	c := &workspaceDiffCache{
+		root:             root,
+		deps:             deps,
+		generation:       newWorkspaceDiffCacheGeneration(),
+		protectedEntries: protectedEntries,
+		inactiveEntries:  inactiveEntries,
+		inFlight:         make(map[workspaceDiffLogicalKey]bool),
+		selected:         make(map[string]int),
+		active:           make(map[string]map[workspaceDiffLogicalKey]time.Time),
+		selectionCancel:  make(map[string]context.CancelFunc),
+		validationQueued: make(map[workspaceDiffLogicalKey]struct{}),
+	}
+	c.validationCond = sync.NewCond(&c.validationMu)
+	c.wg.Add(1)
+	go c.validationWorker()
+	c.wg.Go(func() {
+		<-root.Done()
+		c.validationMu.Lock()
+		c.validationStopped = true
+		c.validationCond.Broadcast()
+		c.validationMu.Unlock()
+	})
 	c.wg.Add(1)
 	go c.validationLoop()
 	return c
@@ -127,12 +174,16 @@ func (c *workspaceDiffCache) Get(
 ) (*workspaceDiffSnapshot, workspaceDiffCacheState, error) {
 	now := c.deps.now()
 	c.mu.Lock()
-	if entry := c.entries[key]; entry != nil {
-		entry.lastAccess = now
+	if entry := c.getEntryLocked(key); entry != nil {
+		updated := *entry
+		updated.lastAccess = now
+		updated.retainedUntil = now.Add(workspaceDiffCachePairRetention)
+		updated.costExempt = true
 		c.markActiveLocked(key, now)
-		fresh := now.Sub(entry.validatedAt) <= workspaceDiffCacheFreshFor
-		retryAllowed := !now.Before(entry.retryAfter)
-		snapshot := cloneWorkspaceDiffSnapshot(entry.snapshot, !fresh)
+		c.storeEntryLocked(key, &updated, now)
+		fresh := now.Sub(updated.validatedAt) <= workspaceDiffCacheFreshFor
+		retryAllowed := !now.Before(updated.retryAfter)
+		snapshot := cloneWorkspaceDiffSnapshot(updated.snapshot, !fresh)
 		c.mu.Unlock()
 		state := workspaceDiffCacheHit
 		if !fresh {
@@ -148,6 +199,7 @@ func (c *workspaceDiffCache) Get(
 	if leader {
 		c.inFlight[key] = true
 	}
+	c.markActiveLocked(key, now)
 	c.mu.Unlock()
 
 	resultCh := c.group.DoChan(c.singleflightKey(key), func() (any, error) {
@@ -156,7 +208,7 @@ func (c *workspaceDiffCache) Get(
 			delete(c.inFlight, key)
 			c.mu.Unlock()
 		}()
-		return c.refresh(c.root, key)
+		return c.refreshShared(key)
 	})
 	if c.deps.onColdWait != nil {
 		c.deps.onColdWait()
@@ -168,7 +220,11 @@ func (c *workspaceDiffCache) Get(
 		if result.Err != nil {
 			return nil, workspaceDiffCacheMiss, result.Err
 		}
-		snapshot := cloneWorkspaceDiffSnapshot(result.Val.(*workspaceDiffSnapshot), false)
+		snapshot := result.Val.(*workspaceDiffSnapshot)
+		if entry := c.touchEntry(key, now); entry != nil {
+			snapshot = entry.snapshot
+		}
+		snapshot = cloneWorkspaceDiffSnapshot(snapshot, false)
 		state := workspaceDiffCacheMiss
 		if !leader {
 			state = workspaceDiffCacheCoalesced
@@ -182,15 +238,29 @@ func (c *workspaceDiffCache) validate(
 	ctx context.Context,
 	key workspaceDiffLogicalKey,
 ) error {
-	resultCh := c.group.DoChan(c.singleflightKey(key), func() (any, error) {
-		return c.refresh(c.root, key)
-	})
+	resultCh := c.validationResult(key)
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
 	case result := <-resultCh:
 		return result.Err
 	}
+}
+
+func (c *workspaceDiffCache) validationResult(
+	key workspaceDiffLogicalKey,
+) <-chan singleflight.Result {
+	return c.group.DoChan(c.singleflightKey(key), func() (any, error) {
+		return c.refreshShared(key)
+	})
+}
+
+func (c *workspaceDiffCache) refreshShared(
+	key workspaceDiffLogicalKey,
+) (*workspaceDiffSnapshot, error) {
+	ctx, cancel := context.WithTimeout(c.root, workspaceDiffPreparationTimeout)
+	defer cancel()
+	return c.refresh(ctx, key)
 }
 
 func (c *workspaceDiffCache) refresh(
@@ -215,11 +285,10 @@ func (c *workspaceDiffCache) refresh(
 
 	now := c.deps.now()
 	c.mu.Lock()
-	entry := c.entries[key]
+	entry := c.peekEntryLocked(key)
 	if entry != nil && entry.snapshot.Fingerprint == before {
 		entry.validatedAt = now
 		entry.retryAfter = time.Time{}
-		entry.lastAccess = now
 		snapshot := entry.snapshot
 		c.mu.Unlock()
 		return snapshot, nil
@@ -252,7 +321,7 @@ func (c *workspaceDiffCache) refresh(
 	files := workspaceDiffFilesProjection(diff.Files)
 	sizeBytes := approximateWorkspaceDiffBytes(diff, files)
 	c.mu.Lock()
-	previous := c.entries[key]
+	previous := c.peekEntryLocked(key)
 	c.nextRev++
 	snapshot := &workspaceDiffSnapshot{
 		Resolved:    afterResolved,
@@ -263,18 +332,19 @@ func (c *workspaceDiffCache) refresh(
 		Files:       files,
 		SizeBytes:   sizeBytes,
 	}
+	lastAccess := now
 	if previous != nil {
-		c.totalBytes -= previous.snapshot.SizeBytes
+		lastAccess = previous.lastAccess
 	}
-	c.entries[key] = &workspaceDiffCacheEntry{
-		snapshot:    snapshot,
-		validatedAt: now,
-		lastAccess:  now,
+	entry = &workspaceDiffCacheEntry{
+		snapshot:      snapshot,
+		validatedAt:   now,
+		lastAccess:    lastAccess,
+		retainedUntil: now.Add(workspaceDiffCachePairRetention),
+		costExempt:    true,
 	}
-	c.totalBytes += sizeBytes
-	c.markActiveLocked(key, now)
+	c.storeEntryLocked(key, entry, now)
 	changed := previous != nil && previous.snapshot.Fingerprint != after
-	c.evictLocked(now)
 	c.mu.Unlock()
 	if changed && c.deps.onChanged != nil {
 		c.deps.onChanged(key.WorkspaceID, snapshot.Revision, snapshot.Version)
@@ -284,16 +354,142 @@ func (c *workspaceDiffCache) refresh(
 
 func (c *workspaceDiffCache) recordFailure(key workspaceDiffLogicalKey) {
 	c.mu.Lock()
-	if entry := c.entries[key]; entry != nil {
+	if entry := c.peekEntryLocked(key); entry != nil {
 		entry.retryAfter = c.deps.now().Add(workspaceDiffCacheRetryWait)
 	}
 	c.mu.Unlock()
 }
 
+func (c *workspaceDiffCache) peekEntry(key workspaceDiffLogicalKey) *workspaceDiffCacheEntry {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.peekEntryLocked(key)
+}
+
+func (c *workspaceDiffCache) peekEntryLocked(key workspaceDiffLogicalKey) *workspaceDiffCacheEntry {
+	return c.getEntryLocked(key)
+}
+
+func (c *workspaceDiffCache) touchEntry(
+	key workspaceDiffLogicalKey,
+	now time.Time,
+) *workspaceDiffCacheEntry {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry := c.getEntryLocked(key)
+	if entry == nil {
+		return nil
+	}
+	updated := *entry
+	updated.lastAccess = now
+	updated.retainedUntil = now.Add(workspaceDiffCachePairRetention)
+	updated.costExempt = true
+	c.markActiveLocked(key, now)
+	if !c.storeEntryLocked(key, &updated, now) {
+		return nil
+	}
+	return &updated
+}
+
+func (c *workspaceDiffCache) storeEntryLocked(
+	key workspaceDiffLogicalKey,
+	entry *workspaceDiffCacheEntry,
+	now time.Time,
+) bool {
+	ttl := workspaceDiffCacheIdleTTL - now.Sub(entry.lastAccess)
+	active := c.activeKeyLocked(key)
+	if active {
+		ttl = ttlcache.NoTTL
+	} else if ttl <= 0 {
+		c.deleteEntryLocked(key)
+		return false
+	}
+	if entry.costExempt || active {
+		c.inactiveEntries.Delete(key)
+		c.protectedEntries.Set(key, entry, ttl)
+		return c.protectedEntries.Has(key)
+	}
+	c.protectedEntries.Delete(key)
+	c.inactiveEntries.Set(key, entry, ttl)
+	return c.inactiveEntries.Has(key)
+}
+
+func (c *workspaceDiffCache) getEntryLocked(key workspaceDiffLogicalKey) *workspaceDiffCacheEntry {
+	item := c.protectedEntries.Get(key)
+	if item == nil {
+		item = c.inactiveEntries.Get(key)
+	}
+	if item == nil {
+		return nil
+	}
+	return item.Value()
+}
+
+func (c *workspaceDiffCache) deleteEntryLocked(key workspaceDiffLogicalKey) {
+	c.protectedEntries.Delete(key)
+	c.inactiveEntries.Delete(key)
+}
+
+func (c *workspaceDiffCache) allEntriesLocked() map[workspaceDiffLogicalKey]*ttlcache.Item[workspaceDiffLogicalKey, *workspaceDiffCacheEntry] {
+	entries := c.inactiveEntries.Items()
+	maps.Copy(entries, c.protectedEntries.Items())
+	return entries
+}
+
+func workspaceDiffCacheEntryCost(
+	item ttlcache.CostItem[workspaceDiffLogicalKey, *workspaceDiffCacheEntry],
+) uint64 {
+	entry := item.Value
+	if entry == nil || entry.snapshot == nil || entry.snapshot.SizeBytes <= 0 {
+		return 0
+	}
+	return uint64(entry.snapshot.SizeBytes)
+}
+
 func (c *workspaceDiffCache) validateAsync(key workspaceDiffLogicalKey) {
-	c.wg.Go(func() {
-		_ = c.validate(c.root, key)
-	})
+	c.validationMu.Lock()
+	defer c.validationMu.Unlock()
+	if c.validationStopped {
+		return
+	}
+	if _, exists := c.validationQueued[key]; exists {
+		return
+	}
+	c.validationQueued[key] = struct{}{}
+	c.validationQueue = append(c.validationQueue, key)
+	c.validationCond.Signal()
+}
+
+func (c *workspaceDiffCache) validationWorker() {
+	defer c.wg.Done()
+	for {
+		c.validationMu.Lock()
+		for len(c.validationQueue) == 0 && !c.validationStopped {
+			c.validationCond.Wait()
+		}
+		if c.validationStopped {
+			c.validationMu.Unlock()
+			return
+		}
+		key := c.validationQueue[0]
+		c.validationQueue = c.validationQueue[1:]
+		c.validationMu.Unlock()
+
+		ctx, span := workspaceDiffCacheTracer.Start(c.root, "workspace.diff.validate.background",
+			trace.WithAttributes(
+				attribute.String("workspace.id", key.WorkspaceID),
+				attribute.String("workspace.diff.base", string(key.Spec.Base)),
+			),
+		)
+		if err := c.validate(ctx, key); err != nil {
+			span.RecordError(err)
+		}
+		span.End()
+
+		c.validationMu.Lock()
+		delete(c.validationQueued, key)
+		c.validationMu.Unlock()
+	}
 }
 
 func (c *workspaceDiffCache) Select(
@@ -303,35 +499,77 @@ func (c *workspaceDiffCache) Select(
 	c.mu.Lock()
 	first := c.selected[workspaceID] == 0
 	c.selected[workspaceID]++
+	var selectionCtx context.Context
+	if first && resolveKey != nil {
+		var cancel context.CancelFunc
+		selectionCtx, cancel = context.WithCancel(c.root)
+		c.selectionCancel[workspaceID] = cancel
+	}
 	c.mu.Unlock()
 	if first && resolveKey != nil {
 		c.wg.Go(func() {
-			key, err := resolveKey(c.root)
-			if err != nil {
-				return
-			}
-			c.MarkActive(key)
-			_, _, _ = c.Get(c.root, key)
+			c.prewarmSelected(selectionCtx, resolveKey)
 		})
 	}
 	var once sync.Once
 	return func() {
 		once.Do(func() {
 			c.mu.Lock()
+			var cancel context.CancelFunc
 			if c.selected[workspaceID] <= 1 {
+				cancel = c.selectionCancel[workspaceID]
+				delete(c.selectionCancel, workspaceID)
 				delete(c.selected, workspaceID)
-				delete(c.active, workspaceID)
 			} else {
 				c.selected[workspaceID]--
 			}
+			c.maintainLocked(c.deps.now())
 			c.mu.Unlock()
+			if cancel != nil {
+				cancel()
+			}
 		})
+	}
+}
+
+func (c *workspaceDiffCache) prewarmSelected(
+	ctx context.Context,
+	resolveKey func(context.Context) (workspaceDiffLogicalKey, error),
+) {
+	for {
+		key, err := resolveKey(ctx)
+		if err == nil {
+			c.MarkActive(key)
+			var snapshot *workspaceDiffSnapshot
+			var state workspaceDiffCacheState
+			snapshot, state, err = c.Get(ctx, key)
+			if err == nil &&
+				(state == workspaceDiffCacheMiss || state == workspaceDiffCacheCoalesced) &&
+				c.deps.onReady != nil {
+				c.deps.onReady(key.WorkspaceID, snapshot.Revision, snapshot.Version)
+			}
+		}
+		if err == nil {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-c.deps.after(workspaceDiffCacheRetryWait):
+		}
 	}
 }
 
 func (c *workspaceDiffCache) MarkActive(key workspaceDiffLogicalKey) {
 	c.mu.Lock()
-	c.markActiveLocked(key, c.deps.now())
+	now := c.deps.now()
+	c.markActiveLocked(key, now)
+	if entry := c.getEntryLocked(key); entry != nil {
+		updated := *entry
+		updated.retainedUntil = now.Add(workspaceDiffCachePairRetention)
+		updated.costExempt = true
+		c.storeEntryLocked(key, &updated, now)
+	}
 	c.mu.Unlock()
 }
 
@@ -348,20 +586,44 @@ func (c *workspaceDiffCache) markActiveLocked(key workspaceDiffLogicalKey, now t
 }
 
 func (c *workspaceDiffCache) ValidateSelected() {
+	c.validateSelected(false)
+}
+
+func (c *workspaceDiffCache) RevalidateSelected() {
+	c.validateSelected(true)
+}
+
+func (c *workspaceDiffCache) validateSelected(force bool) {
 	now := c.deps.now()
 	c.mu.Lock()
+	c.maintainLocked(now)
 	keys := make([]workspaceDiffLogicalKey, 0)
 	for workspaceID, active := range c.active {
 		if c.selected[workspaceID] == 0 {
 			continue
 		}
-		for key, accessed := range active {
-			if now.Sub(accessed) > workspaceDiffCacheIdleTTL {
-				continue
+		for key := range active {
+			if entry := c.peekEntryLocked(key); entry != nil {
+				if (!force && now.Sub(entry.validatedAt) < workspaceDiffCacheFreshFor-workspaceDiffValidationPoll) ||
+					now.Before(entry.retryAfter) {
+					continue
+				}
 			}
-			if entry := c.entries[key]; entry != nil && now.Before(entry.retryAfter) {
-				continue
-			}
+			keys = append(keys, key)
+		}
+	}
+	c.mu.Unlock()
+	for _, key := range keys {
+		c.validateAsync(key)
+	}
+}
+
+func (c *workspaceDiffCache) RevalidateWorkspace(workspaceID string) {
+	c.mu.Lock()
+	items := c.allEntriesLocked()
+	keys := make([]workspaceDiffLogicalKey, 0)
+	for key := range items {
+		if key.WorkspaceID == workspaceID {
 			keys = append(keys, key)
 		}
 	}
@@ -373,7 +635,7 @@ func (c *workspaceDiffCache) ValidateSelected() {
 
 func (c *workspaceDiffCache) validationLoop() {
 	defer c.wg.Done()
-	ticker := time.NewTicker(workspaceDiffCacheFreshFor)
+	ticker := time.NewTicker(workspaceDiffValidationPoll)
 	defer ticker.Stop()
 	for {
 		select {
@@ -416,34 +678,40 @@ func (c *workspaceDiffCache) setSpanAttributes(
 	)
 }
 
-func (c *workspaceDiffCache) evictLocked(now time.Time) {
-	for key, entry := range c.entries {
-		if c.activeKeyLocked(key) || now.Sub(entry.lastAccess) <= workspaceDiffCacheIdleTTL {
+func (c *workspaceDiffCache) maintain(now time.Time) {
+	c.mu.Lock()
+	c.maintainLocked(now)
+	c.mu.Unlock()
+	c.protectedEntries.DeleteExpired()
+	c.inactiveEntries.DeleteExpired()
+}
+
+func (c *workspaceDiffCache) maintainLocked(now time.Time) {
+	for workspaceID, keys := range c.active {
+		for key, accessed := range keys {
+			if now.Sub(accessed) > workspaceDiffCacheIdleTTL {
+				delete(keys, key)
+				c.deleteEntryLocked(key)
+			}
+		}
+		if len(keys) == 0 {
+			delete(c.active, workspaceID)
+		}
+	}
+	for key, item := range c.allEntriesLocked() {
+		entry := item.Value()
+		if c.activeKeyLocked(key) {
 			continue
 		}
-		c.removeEntryLocked(key, entry)
-	}
-	if c.totalBytes <= workspaceDiffCacheMaxBytes {
-		return
-	}
-	type candidate struct {
-		key   workspaceDiffLogicalKey
-		entry *workspaceDiffCacheEntry
-	}
-	candidates := make([]candidate, 0, len(c.entries))
-	for key, entry := range c.entries {
-		if !c.activeKeyLocked(key) {
-			candidates = append(candidates, candidate{key: key, entry: entry})
+		if now.Sub(entry.lastAccess) > workspaceDiffCacheIdleTTL {
+			c.deleteEntryLocked(key)
+			continue
 		}
-	}
-	sort.Slice(candidates, func(i, j int) bool {
-		return candidates[i].entry.lastAccess.Before(candidates[j].entry.lastAccess)
-	})
-	for _, candidate := range candidates {
-		if c.totalBytes <= workspaceDiffCacheMaxBytes {
-			break
+		if entry.costExempt && !now.Before(entry.retainedUntil) {
+			updated := *entry
+			updated.costExempt = false
+			c.storeEntryLocked(key, &updated, now)
 		}
-		c.removeEntryLocked(candidate.key, candidate.entry)
 	}
 }
 
@@ -453,14 +721,6 @@ func (c *workspaceDiffCache) activeKeyLocked(key workspaceDiffLogicalKey) bool {
 	}
 	_, ok := c.active[key.WorkspaceID][key]
 	return ok
-}
-
-func (c *workspaceDiffCache) removeEntryLocked(
-	key workspaceDiffLogicalKey,
-	entry *workspaceDiffCacheEntry,
-) {
-	delete(c.entries, key)
-	c.totalBytes -= entry.snapshot.SizeBytes
 }
 
 func workspaceDiffFilesProjection(files []gitclone.DiffFile) []gitclone.DiffFile {

--- a/internal/server/workspace_diff_cache_test.go
+++ b/internal/server/workspace_diff_cache_test.go
@@ -1,0 +1,170 @@
+package server
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/middleman/internal/gitclone"
+	"go.kenn.io/middleman/internal/workspace"
+)
+
+func TestWorkspaceDiffCacheMissThenHitPreparesOnce(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	now := time.Unix(100, 0)
+	prepareCalls := 0
+	key := workspaceDiffTestKey()
+	cache := newWorkspaceDiffCache(t.Context(), workspaceDiffCacheDeps{
+		now: func() time.Time { return now },
+		resolve: func(context.Context, workspace.DiffSnapshotSpec) (workspace.ResolvedDiffSnapshotSpec, bool, error) {
+			return workspaceDiffTestResolved(), true, nil
+		},
+		fingerprint: func(context.Context, workspace.ResolvedDiffSnapshotSpec) (workspace.DiffFingerprint, error) {
+			return "v1", nil
+		},
+		prepare: func(context.Context, workspace.ResolvedDiffSnapshotSpec) (*gitclone.DiffResult, error) {
+			prepareCalls++
+			return workspaceDiffTestResult("one.txt"), nil
+		},
+	})
+
+	first, state, err := cache.Get(t.Context(), key)
+	require.NoError(err)
+	require.NotNil(first)
+	assert.Equal(workspaceDiffCacheMiss, state)
+	assert.False(first.Diff.Stale)
+
+	second, state, err := cache.Get(t.Context(), key)
+	require.NoError(err)
+	require.NotNil(second)
+	assert.Equal(workspaceDiffCacheHit, state)
+	assert.Equal(uint64(1), second.Revision)
+	assert.Equal(1, prepareCalls)
+	assert.Empty(second.Files[0].Patch)
+	assert.Empty(second.Files[0].Hunks)
+}
+
+func TestWorkspaceDiffCacheChangedValidationReplacesStableSnapshot(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	now := time.Unix(100, 0)
+	fingerprint := workspace.DiffFingerprint("v1")
+	preparePath := "one.txt"
+	var changes []uint64
+	key := workspaceDiffTestKey()
+	cache := newWorkspaceDiffCache(t.Context(), workspaceDiffCacheDeps{
+		now: func() time.Time { return now },
+		resolve: func(context.Context, workspace.DiffSnapshotSpec) (workspace.ResolvedDiffSnapshotSpec, bool, error) {
+			return workspaceDiffTestResolved(), true, nil
+		},
+		fingerprint: func(context.Context, workspace.ResolvedDiffSnapshotSpec) (workspace.DiffFingerprint, error) {
+			return fingerprint, nil
+		},
+		prepare: func(context.Context, workspace.ResolvedDiffSnapshotSpec) (*gitclone.DiffResult, error) {
+			return workspaceDiffTestResult(preparePath), nil
+		},
+		onChanged: func(_ string, revision uint64, _ string) { changes = append(changes, revision) },
+	})
+
+	_, _, err := cache.Get(t.Context(), key)
+	require.NoError(err)
+	fingerprint = "v2"
+	preparePath = "two.txt"
+	now = now.Add(workspaceDiffCacheFreshFor + time.Second)
+	require.NoError(cache.validate(t.Context(), key))
+
+	got, state, err := cache.Get(t.Context(), key)
+	require.NoError(err)
+	assert.Equal(workspaceDiffCacheHit, state)
+	assert.Equal("two.txt", got.Diff.Files[0].Path)
+	assert.Equal(uint64(2), got.Revision)
+	assert.Equal([]uint64{2}, changes)
+}
+
+func TestWorkspaceDiffCacheConcurrentMissesCoalesce(t *testing.T) {
+	require := require.New(t)
+	key := workspaceDiffTestKey()
+	started := make(chan struct{})
+	release := make(chan struct{})
+	waiting := make(chan struct{}, 2)
+	prepareCalls := 0
+	cache := newWorkspaceDiffCache(t.Context(), workspaceDiffCacheDeps{
+		resolve: func(context.Context, workspace.DiffSnapshotSpec) (workspace.ResolvedDiffSnapshotSpec, bool, error) {
+			return workspaceDiffTestResolved(), true, nil
+		},
+		fingerprint: func(context.Context, workspace.ResolvedDiffSnapshotSpec) (workspace.DiffFingerprint, error) {
+			return "v1", nil
+		},
+		prepare: func(context.Context, workspace.ResolvedDiffSnapshotSpec) (*gitclone.DiffResult, error) {
+			prepareCalls++
+			if prepareCalls == 1 {
+				close(started)
+			}
+			<-release
+			return workspaceDiffTestResult("one.txt"), nil
+		},
+		onColdWait: func() { waiting <- struct{}{} },
+	})
+
+	type result struct {
+		state workspaceDiffCacheState
+		err   error
+	}
+	results := make(chan result, 2)
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Go(func() {
+			_, state, err := cache.Get(t.Context(), key)
+			results <- result{state: state, err: err}
+		})
+	}
+	<-started
+	<-waiting
+	<-waiting
+	close(release)
+	wg.Wait()
+	close(results)
+
+	states := map[workspaceDiffCacheState]int{}
+	for result := range results {
+		require.NoError(result.err)
+		states[result.state]++
+	}
+	assert.Equal(t, 1, prepareCalls)
+	assert.Equal(t, 2, states[workspaceDiffCacheMiss]+states[workspaceDiffCacheCoalesced])
+}
+
+func workspaceDiffTestKey() workspaceDiffLogicalKey {
+	return workspaceDiffLogicalKey{
+		WorkspaceID: "ws-1",
+		Spec: workspace.DiffSnapshotSpec{
+			WorktreePath: "/tmp/worktree",
+			Base:         workspace.WorktreeDiffBaseHead,
+		},
+	}
+}
+
+func workspaceDiffTestResolved() workspace.ResolvedDiffSnapshotSpec {
+	return workspace.ResolvedDiffSnapshotSpec{
+		DiffSnapshotSpec: workspaceDiffTestKey().Spec,
+		BaseRef:          "HEAD",
+		BaseOID:          "base",
+		HeadOID:          "head",
+		IncludeUntracked: true,
+	}
+}
+
+func workspaceDiffTestResult(path string) *gitclone.DiffResult {
+	return &gitclone.DiffResult{Files: []gitclone.DiffFile{{
+		Path:   path,
+		Status: "modified",
+		Patch:  "patch",
+		Hunks: []gitclone.Hunk{{Lines: []gitclone.Line{{
+			Type: "add", Content: "line",
+		}}}},
+	}}}
+}

--- a/internal/server/workspace_diff_cache_test.go
+++ b/internal/server/workspace_diff_cache_test.go
@@ -2,7 +2,9 @@ package server
 
 import (
 	"context"
+	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -48,6 +50,116 @@ func TestWorkspaceDiffCacheMissThenHitPreparesOnce(t *testing.T) {
 	assert.Empty(second.Files[0].Hunks)
 }
 
+func TestWorkspaceDiffCacheProtectedEntriesDoNotConsumeCostBudget(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		selected bool
+	}{
+		{name: "pair-retained snapshot"},
+		{name: "selected snapshot", selected: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require := require.New(t)
+			now := time.Unix(100, 0)
+			cache := newWorkspaceDiffCache(t.Context(), workspaceDiffCacheDeps{
+				now:      func() time.Time { return now },
+				maxBytes: 3,
+			})
+			protectedKey := workspaceDiffTestKey()
+			inactiveKey := protectedKey
+			inactiveKey.Spec.Base = workspace.WorktreeDiffBasePushed
+			newestInactiveKey := inactiveKey
+			newestInactiveKey.Spec.HideWhitespace = true
+			entry := func(version string, costExempt bool) *workspaceDiffCacheEntry {
+				return &workspaceDiffCacheEntry{
+					snapshot: &workspaceDiffSnapshot{
+						Version:   version,
+						SizeBytes: 2,
+					},
+					validatedAt:   now,
+					lastAccess:    now,
+					retainedUntil: now.Add(workspaceDiffCachePairRetention),
+					costExempt:    costExempt,
+				}
+			}
+
+			protectedEntry := entry("protected", true)
+			if tt.selected {
+				protectedEntry.retainedUntil = now
+			}
+
+			cache.mu.Lock()
+			require.True(cache.storeEntryLocked(protectedKey, protectedEntry, now))
+			require.True(cache.storeEntryLocked(inactiveKey, entry("inactive", false), now))
+			require.True(cache.storeEntryLocked(newestInactiveKey, entry("newest", false), now))
+			if tt.selected {
+				cache.selected[protectedKey.WorkspaceID] = 1
+				cache.active[protectedKey.WorkspaceID] = map[workspaceDiffLogicalKey]time.Time{
+					protectedKey: now,
+				}
+			}
+			cache.maintainLocked(now)
+			cache.mu.Unlock()
+
+			require.NotNil(cache.peekEntry(protectedKey))
+			require.Nil(cache.peekEntry(inactiveKey))
+			require.NotNil(cache.peekEntry(newestInactiveKey))
+		})
+	}
+}
+
+func TestWorkspaceDiffCacheReconnectRetainsActiveScopes(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	assert := assert.New(t)
+	now := time.Unix(100, 0)
+	var fingerprintCalls atomic.Int64
+	cache := newWorkspaceDiffCache(t.Context(), workspaceDiffCacheDeps{
+		now: func() time.Time { return now },
+		resolve: func(_ context.Context, spec workspace.DiffSnapshotSpec) (workspace.ResolvedDiffSnapshotSpec, bool, error) {
+			resolved := workspaceDiffTestResolved()
+			resolved.DiffSnapshotSpec = spec
+			return resolved, true, nil
+		},
+		fingerprint: func(_ context.Context, resolved workspace.ResolvedDiffSnapshotSpec) (workspace.DiffFingerprint, error) {
+			fingerprintCalls.Add(1)
+			return workspace.DiffFingerprint(resolved.Base), nil
+		},
+		prepare: func(_ context.Context, resolved workspace.ResolvedDiffSnapshotSpec) (*gitclone.DiffResult, error) {
+			return workspaceDiffTestResult(string(resolved.Base) + ".txt"), nil
+		},
+	})
+	headKey := workspaceDiffTestKey()
+	pushedKey := headKey
+	pushedKey.Spec.Base = workspace.WorktreeDiffBasePushed
+	release := cache.Select(headKey.WorkspaceID, nil)
+	_, _, err := cache.Get(t.Context(), headKey)
+	require.NoError(err)
+	_, _, err = cache.Get(t.Context(), pushedKey)
+	require.NoError(err)
+	release()
+
+	cache.mu.Lock()
+	_, retained := cache.active[headKey.WorkspaceID][pushedKey]
+	cache.mu.Unlock()
+	require.True(retained)
+	baseline := fingerprintCalls.Load()
+	now = now.Add(workspaceDiffCacheFreshFor)
+	release = cache.Select(headKey.WorkspaceID, nil)
+	defer release()
+	cache.ValidateSelected()
+
+	assert.Eventually(
+		func() bool { return fingerprintCalls.Load() >= baseline+2 },
+		time.Second,
+		time.Millisecond,
+	)
+}
+
 func TestWorkspaceDiffCacheChangedValidationReplacesStableSnapshot(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -74,7 +186,7 @@ func TestWorkspaceDiffCacheChangedValidationReplacesStableSnapshot(t *testing.T)
 	require.NoError(err)
 	fingerprint = "v2"
 	preparePath = "two.txt"
-	now = now.Add(workspaceDiffCacheFreshFor + time.Second)
+	now = now.Add(workspaceDiffCachePairRetention + time.Second)
 	require.NoError(cache.validate(t.Context(), key))
 
 	got, state, err := cache.Get(t.Context(), key)
@@ -146,6 +258,333 @@ func workspaceDiffTestKey() workspaceDiffLogicalKey {
 			Base:         workspace.WorktreeDiffBaseHead,
 		},
 	}
+}
+
+func TestWorkspaceDiffCacheExpiredActiveEntryCanBeEvicted(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+	now := time.Now()
+	key := workspaceDiffTestKey()
+	entry := &workspaceDiffCacheEntry{
+		snapshot:   &workspaceDiffSnapshot{SizeBytes: workspaceDiffCacheMaxBytes + 1},
+		lastAccess: now.Add(-workspaceDiffCacheIdleTTL - time.Second),
+		costExempt: true,
+	}
+	cache := newWorkspaceDiffCache(t.Context(), workspaceDiffCacheDeps{now: func() time.Time { return now }})
+	cache.mu.Lock()
+	cache.selected[key.WorkspaceID] = 1
+	cache.active[key.WorkspaceID] = map[workspaceDiffLogicalKey]time.Time{key: entry.lastAccess}
+	cache.storeEntryLocked(key, entry, now)
+	cache.mu.Unlock()
+
+	cache.maintain(now)
+
+	assert.Nil(cache.peekEntry(key))
+	assert.NotContains(cache.active, key.WorkspaceID)
+}
+
+func TestWorkspaceDiffCacheSelectionRetriesFailedPrewarm(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	retry := make(chan time.Time)
+	firstAttempt := make(chan struct{})
+	ready := make(chan struct{})
+	resolveCalls := 0
+	cache := newWorkspaceDiffCache(t.Context(), workspaceDiffCacheDeps{
+		after: func(time.Duration) <-chan time.Time { return retry },
+		resolve: func(context.Context, workspace.DiffSnapshotSpec) (workspace.ResolvedDiffSnapshotSpec, bool, error) {
+			return workspaceDiffTestResolved(), true, nil
+		},
+		fingerprint: func(context.Context, workspace.ResolvedDiffSnapshotSpec) (workspace.DiffFingerprint, error) {
+			return "v1", nil
+		},
+		prepare: func(context.Context, workspace.ResolvedDiffSnapshotSpec) (*gitclone.DiffResult, error) {
+			return workspaceDiffTestResult("one.txt"), nil
+		},
+		onReady: func(string, uint64, string) { close(ready) },
+	})
+
+	release := cache.Select("ws-1", func(context.Context) (workspaceDiffLogicalKey, error) {
+		resolveCalls++
+		if resolveCalls == 1 {
+			close(firstAttempt)
+			return workspaceDiffLogicalKey{}, errors.New("temporarily unavailable")
+		}
+		return workspaceDiffTestKey(), nil
+	})
+	t.Cleanup(release)
+	<-firstAttempt
+	retry <- time.Now()
+	<-ready
+
+	assert.NotNil(cache.peekEntry(workspaceDiffTestKey()))
+	assert.Equal(2, resolveCalls)
+	require.NotNil(cache.selectionCancel["ws-1"])
+}
+
+func TestWorkspaceDiffCacheSelectedColdPrewarmSignalsReady(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+	var readyWorkspaceID string
+	var readyVersion string
+	cache := newWorkspaceDiffCache(t.Context(), workspaceDiffCacheDeps{
+		resolve: func(context.Context, workspace.DiffSnapshotSpec) (workspace.ResolvedDiffSnapshotSpec, bool, error) {
+			return workspaceDiffTestResolved(), true, nil
+		},
+		fingerprint: func(context.Context, workspace.ResolvedDiffSnapshotSpec) (workspace.DiffFingerprint, error) {
+			return "v1", nil
+		},
+		prepare: func(context.Context, workspace.ResolvedDiffSnapshotSpec) (*gitclone.DiffResult, error) {
+			return workspaceDiffTestResult("one.txt"), nil
+		},
+		onReady: func(workspaceID string, _ uint64, version string) {
+			readyWorkspaceID = workspaceID
+			readyVersion = version
+		},
+	})
+	cache.selected["ws-1"] = 1
+
+	cache.prewarmSelected(t.Context(), func(context.Context) (workspaceDiffLogicalKey, error) {
+		return workspaceDiffTestKey(), nil
+	})
+
+	assert.Equal("ws-1", readyWorkspaceID)
+	assert.NotEmpty(readyVersion)
+}
+
+func TestWorkspaceDiffCacheSelectedWarmPrewarmDoesNotSignalReady(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	assert := assert.New(t)
+	readyCalls := 0
+	cache := newWorkspaceDiffCache(t.Context(), workspaceDiffCacheDeps{
+		resolve: func(context.Context, workspace.DiffSnapshotSpec) (workspace.ResolvedDiffSnapshotSpec, bool, error) {
+			return workspaceDiffTestResolved(), true, nil
+		},
+		fingerprint: func(context.Context, workspace.ResolvedDiffSnapshotSpec) (workspace.DiffFingerprint, error) {
+			return "v1", nil
+		},
+		prepare: func(context.Context, workspace.ResolvedDiffSnapshotSpec) (*gitclone.DiffResult, error) {
+			return workspaceDiffTestResult("one.txt"), nil
+		},
+		onReady: func(string, uint64, string) { readyCalls++ },
+	})
+	_, _, err := cache.Get(t.Context(), workspaceDiffTestKey())
+	require.NoError(err)
+	cache.selected["ws-1"] = 1
+
+	cache.prewarmSelected(t.Context(), func(context.Context) (workspaceDiffLogicalKey, error) {
+		return workspaceDiffTestKey(), nil
+	})
+
+	assert.Zero(readyCalls)
+}
+
+func TestWorkspaceDiffCacheRevalidateWorkspaceChecksCachedSnapshots(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name     string
+		selected bool
+	}{
+		{name: "selected", selected: true},
+		{name: "unselected", selected: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require := require.New(t)
+			assert := assert.New(t)
+			key := workspaceDiffTestKey()
+			var fingerprint atomic.Value
+			fingerprint.Store(workspace.DiffFingerprint("v1"))
+			var prepareCalls atomic.Int64
+			changed := make(chan string, 1)
+			cache := newWorkspaceDiffCache(t.Context(), workspaceDiffCacheDeps{
+				resolve: func(context.Context, workspace.DiffSnapshotSpec) (workspace.ResolvedDiffSnapshotSpec, bool, error) {
+					return workspaceDiffTestResolved(), true, nil
+				},
+				fingerprint: func(context.Context, workspace.ResolvedDiffSnapshotSpec) (workspace.DiffFingerprint, error) {
+					return fingerprint.Load().(workspace.DiffFingerprint), nil
+				},
+				prepare: func(context.Context, workspace.ResolvedDiffSnapshotSpec) (*gitclone.DiffResult, error) {
+					prepareCalls.Add(1)
+					return workspaceDiffTestResult("one.txt"), nil
+				},
+				onChanged: func(_ string, _ uint64, version string) { changed <- version },
+			})
+			_, _, err := cache.Get(t.Context(), key)
+			require.NoError(err)
+			if tc.selected {
+				cache.mu.Lock()
+				cache.selected[key.WorkspaceID] = 1
+				cache.active[key.WorkspaceID] = map[workspaceDiffLogicalKey]time.Time{key: time.Now()}
+				cache.mu.Unlock()
+			}
+
+			fingerprint.Store(workspace.DiffFingerprint("v2"))
+			cache.RevalidateWorkspace(key.WorkspaceID)
+
+			select {
+			case version := <-changed:
+				assert.NotEmpty(version)
+			case <-time.After(time.Second):
+				require.Fail("cached snapshot was not revalidated")
+			}
+			assert.Equal(int64(2), prepareCalls.Load())
+		})
+	}
+}
+
+func TestWorkspaceDiffCacheValidationTimeoutDoesNotPoisonForegroundWaiter(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	key := workspaceDiffTestKey()
+	prepareStarted := make(chan struct{})
+	releasePrepare := make(chan struct{})
+	cache := newWorkspaceDiffCache(t.Context(), workspaceDiffCacheDeps{
+		resolve: func(context.Context, workspace.DiffSnapshotSpec) (workspace.ResolvedDiffSnapshotSpec, bool, error) {
+			return workspaceDiffTestResolved(), true, nil
+		},
+		fingerprint: func(context.Context, workspace.ResolvedDiffSnapshotSpec) (workspace.DiffFingerprint, error) {
+			return "v1", nil
+		},
+		prepare: func(ctx context.Context, _ workspace.ResolvedDiffSnapshotSpec) (*gitclone.DiffResult, error) {
+			close(prepareStarted)
+			select {
+			case <-releasePrepare:
+				return workspaceDiffTestResult("one.txt"), nil
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		},
+	})
+
+	validationCtx, cancel := context.WithTimeout(t.Context(), 25*time.Millisecond)
+	defer cancel()
+	validationDone := make(chan error, 1)
+	go func() { validationDone <- cache.validate(validationCtx, key) }()
+	<-prepareStarted
+	type getResult struct {
+		err error
+	}
+	getDone := make(chan getResult, 1)
+	go func() {
+		_, _, err := cache.Get(t.Context(), key)
+		getDone <- getResult{err: err}
+	}()
+	require.ErrorIs(<-validationDone, context.DeadlineExceeded)
+
+	select {
+	case result := <-getDone:
+		require.Fail("foreground waiter inherited validation cancellation", "error=%v", result.err)
+	case <-time.After(25 * time.Millisecond):
+	}
+	close(releasePrepare)
+	require.NoError((<-getDone).err)
+}
+
+func TestWorkspaceDiffCacheBackgroundValidationDoesNotRenewAccess(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	assert := assert.New(t)
+	now := time.Unix(100, 0)
+	key := workspaceDiffTestKey()
+	fingerprint := workspace.DiffFingerprint("v1")
+	cache := newWorkspaceDiffCache(t.Context(), workspaceDiffCacheDeps{
+		now: func() time.Time { return now },
+		resolve: func(context.Context, workspace.DiffSnapshotSpec) (workspace.ResolvedDiffSnapshotSpec, bool, error) {
+			return workspaceDiffTestResolved(), true, nil
+		},
+		fingerprint: func(context.Context, workspace.ResolvedDiffSnapshotSpec) (workspace.DiffFingerprint, error) {
+			return fingerprint, nil
+		},
+		prepare: func(context.Context, workspace.ResolvedDiffSnapshotSpec) (*gitclone.DiffResult, error) {
+			return workspaceDiffTestResult("one.txt"), nil
+		},
+	})
+	_, _, err := cache.Get(t.Context(), key)
+	require.NoError(err)
+	initialAccess := cache.peekEntry(key).lastAccess
+	fingerprint = "v2"
+	now = now.Add(time.Minute)
+
+	require.NoError(cache.validate(t.Context(), key))
+
+	assert.Equal(initialAccess, cache.peekEntry(key).lastAccess)
+}
+
+func TestWorkspaceDiffCacheSelectedValidationMeetsMaxAge(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	assert := assert.New(t)
+	now := time.Unix(100, 0)
+	key := workspaceDiffTestKey()
+	var fingerprint atomic.Value
+	fingerprint.Store(workspace.DiffFingerprint("v1"))
+	var fingerprintCalls atomic.Int64
+	cache := newWorkspaceDiffCache(t.Context(), workspaceDiffCacheDeps{
+		now: func() time.Time { return now },
+		resolve: func(context.Context, workspace.DiffSnapshotSpec) (workspace.ResolvedDiffSnapshotSpec, bool, error) {
+			return workspaceDiffTestResolved(), true, nil
+		},
+		fingerprint: func(context.Context, workspace.ResolvedDiffSnapshotSpec) (workspace.DiffFingerprint, error) {
+			fingerprintCalls.Add(1)
+			return fingerprint.Load().(workspace.DiffFingerprint), nil
+		},
+		prepare: func(context.Context, workspace.ResolvedDiffSnapshotSpec) (*gitclone.DiffResult, error) {
+			return workspaceDiffTestResult("one.txt"), nil
+		},
+	})
+	_, _, err := cache.Get(t.Context(), key)
+	require.NoError(err)
+	initialCalls := fingerprintCalls.Load()
+	cache.mu.Lock()
+	cache.selected[key.WorkspaceID] = 1
+	cache.active[key.WorkspaceID] = map[workspaceDiffLogicalKey]time.Time{key: now}
+	cache.mu.Unlock()
+	fingerprint.Store(workspace.DiffFingerprint("v2"))
+
+	now = now.Add(workspaceDiffCacheFreshFor - workspaceDiffValidationPoll - time.Nanosecond)
+	cache.ValidateSelected()
+	assert.Equal(initialCalls, fingerprintCalls.Load())
+
+	now = now.Add(time.Nanosecond)
+	cache.ValidateSelected()
+	assert.Eventually(func() bool { return fingerprintCalls.Load() > initialCalls }, time.Second, time.Millisecond)
+}
+
+func TestWorkspaceDiffCacheRetainsOversizedSnapshotForCoherentPair(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	assert := assert.New(t)
+	now := time.Unix(100, 0)
+	key := workspaceDiffTestKey()
+	prepareCalls := 0
+	cache := newWorkspaceDiffCache(t.Context(), workspaceDiffCacheDeps{
+		now:      func() time.Time { return now },
+		maxBytes: 1,
+		resolve: func(context.Context, workspace.DiffSnapshotSpec) (workspace.ResolvedDiffSnapshotSpec, bool, error) {
+			return workspaceDiffTestResolved(), true, nil
+		},
+		fingerprint: func(context.Context, workspace.ResolvedDiffSnapshotSpec) (workspace.DiffFingerprint, error) {
+			return "v1", nil
+		},
+		prepare: func(context.Context, workspace.ResolvedDiffSnapshotSpec) (*gitclone.DiffResult, error) {
+			prepareCalls++
+			return workspaceDiffTestResult("one.txt"), nil
+		},
+	})
+	first, _, err := cache.Get(t.Context(), key)
+	require.NoError(err)
+
+	second, state, err := cache.Get(t.Context(), key)
+	require.NoError(err)
+	assert.Equal(workspaceDiffCacheHit, state)
+	assert.Equal(first.Version, second.Version)
+	assert.Equal(1, prepareCalls)
+
+	now = now.Add(workspaceDiffCachePairRetention + time.Second)
+	cache.maintain(now)
+	assert.Nil(cache.peekEntry(key))
 }
 
 func workspaceDiffTestResolved() workspace.ResolvedDiffSnapshotSpec {

--- a/internal/server/workspace_diff_cache_test.go
+++ b/internal/server/workspace_diff_cache_test.go
@@ -322,6 +322,52 @@ func TestWorkspaceDiffCacheSelectionRetriesFailedPrewarm(t *testing.T) {
 	require.NotNil(cache.selectionCancel["ws-1"])
 }
 
+func TestWorkspaceDiffCacheSelectedColdFailureWaitsForPrewarmBackoff(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	retry := make(chan time.Time)
+	attempts := make(chan int64, 2)
+	var prepareCalls atomic.Int64
+	cache := newWorkspaceDiffCache(t.Context(), workspaceDiffCacheDeps{
+		after: func(time.Duration) <-chan time.Time { return retry },
+		resolve: func(context.Context, workspace.DiffSnapshotSpec) (workspace.ResolvedDiffSnapshotSpec, bool, error) {
+			return workspaceDiffTestResolved(), true, nil
+		},
+		fingerprint: func(context.Context, workspace.ResolvedDiffSnapshotSpec) (workspace.DiffFingerprint, error) {
+			return "v1", nil
+		},
+		prepare: func(context.Context, workspace.ResolvedDiffSnapshotSpec) (*gitclone.DiffResult, error) {
+			call := prepareCalls.Add(1)
+			attempts <- call
+			if call == 1 {
+				return nil, errors.New("temporarily unavailable")
+			}
+			return workspaceDiffTestResult("one.txt"), nil
+		},
+	})
+
+	release := cache.Select("ws-1", func(context.Context) (workspaceDiffLogicalKey, error) {
+		return workspaceDiffTestKey(), nil
+	})
+	t.Cleanup(release)
+	require.Equal(int64(1), <-attempts)
+
+	cache.ValidateSelected()
+	earlyAttempt := false
+	select {
+	case attempt := <-attempts:
+		earlyAttempt = true
+		assert.Fail("periodic validation bypassed cold retry backoff", "attempt=%d", attempt)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	retry <- time.Now()
+	if !earlyAttempt {
+		require.Equal(int64(2), <-attempts)
+	}
+	assert.Equal(int64(2), prepareCalls.Load())
+}
+
 func TestWorkspaceDiffCacheSelectedColdPrewarmSignalsReady(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)

--- a/internal/server/workspace_diff_cache_test.go
+++ b/internal/server/workspace_diff_cache_test.go
@@ -327,9 +327,13 @@ func TestWorkspaceDiffCacheSelectedColdFailureWaitsForPrewarmBackoff(t *testing.
 	assert := assert.New(t)
 	retry := make(chan time.Time)
 	attempts := make(chan int64, 2)
+	backoffStarted := make(chan struct{})
 	var prepareCalls atomic.Int64
 	cache := newWorkspaceDiffCache(t.Context(), workspaceDiffCacheDeps{
-		after: func(time.Duration) <-chan time.Time { return retry },
+		after: func(time.Duration) <-chan time.Time {
+			close(backoffStarted)
+			return retry
+		},
 		resolve: func(context.Context, workspace.DiffSnapshotSpec) (workspace.ResolvedDiffSnapshotSpec, bool, error) {
 			return workspaceDiffTestResolved(), true, nil
 		},
@@ -351,6 +355,7 @@ func TestWorkspaceDiffCacheSelectedColdFailureWaitsForPrewarmBackoff(t *testing.
 	})
 	t.Cleanup(release)
 	require.Equal(int64(1), <-attempts)
+	<-backoffStarted
 
 	cache.ValidateSelected()
 	earlyAttempt := false

--- a/internal/workspace/diff.go
+++ b/internal/workspace/diff.go
@@ -6,8 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -16,6 +16,8 @@ import (
 	"go.kenn.io/middleman/internal/procutil"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/semaphore"
 )
 
 type WorktreeDiffBase string
@@ -29,6 +31,21 @@ const (
 const maxUntrackedTextFileBytes = 1 << 20
 
 var workspaceDiffTracer = otel.Tracer("go.kenn.io/middleman/internal/workspace/diff")
+
+var untrackedFileReads = newUntrackedReadPool(runtime.GOMAXPROCS(0))
+
+type untrackedReadPool struct {
+	limit int
+	sem   *semaphore.Weighted
+}
+
+func newUntrackedReadPool(limit int) *untrackedReadPool {
+	limit = max(limit, 1)
+	return &untrackedReadPool{
+		limit: limit,
+		sem:   semaphore.NewWeighted(int64(limit)),
+	}
+}
 
 func WorktreeDiffFiles(
 	ctx context.Context,
@@ -172,9 +189,17 @@ func worktreeDiffFilesFromRefs(
 		files = filtered
 	}
 	if includeUntracked {
-		files = append(files, worktreeUntrackedFiles(ctx, dir, false, hideWhitespace)...)
+		untracked, untrackedErr := worktreeUntrackedFiles(ctx, dir, false, hideWhitespace)
+		if untrackedErr != nil {
+			return nil, fmt.Errorf("untracked files: %w", untrackedErr)
+		}
+		files = append(files, untracked...)
 	}
-	markWorktreeGeneratedFiles(ctx, dir, files)
+	attributeSource := ""
+	if !includeUntracked {
+		attributeSource = headRef
+	}
+	markWorktreeGeneratedFiles(ctx, dir, attributeSource, files)
 	gitclone.SortDiffFiles(files)
 	return files, nil
 }
@@ -489,7 +514,20 @@ func worktreeDiffFromRefsPath(
 			return nil, fmt.Errorf("whitespace count: %w", err)
 		}
 	} else {
-		wsCount = classifyWhitespaceOnly(files, worktreeRawModeChanges(rawOut))
+		wsCount, err = classifyWorkspaceWhitespaceOnly(
+			whitespaceCtx,
+			dir,
+			baseRef,
+			headRef,
+			includeUntracked,
+			files,
+			worktreeRawModeChanges(rawOut),
+		)
+		if err != nil {
+			whitespaceSpan.RecordError(err)
+			whitespaceSpan.End()
+			return nil, fmt.Errorf("classify whitespace-only files: %w", err)
+		}
 	}
 	whitespaceSpan.SetAttributes(attribute.Int("workspace.diff.whitespace_only_files", wsCount))
 	whitespaceSpan.End()
@@ -497,11 +535,25 @@ func worktreeDiffFromRefsPath(
 		assembleCtx, "workspace.diff.untracked",
 	)
 	if includeUntracked && path == "" {
-		files = append(files, worktreeUntrackedFiles(untrackedCtx, dir, true, hideWhitespace)...)
+		untracked, untrackedErr := worktreeUntrackedFiles(
+			untrackedCtx, dir, true, hideWhitespace,
+		)
+		if untrackedErr != nil {
+			untrackedSpan.RecordError(untrackedErr)
+			untrackedSpan.End()
+			return nil, fmt.Errorf("untracked files: %w", untrackedErr)
+		}
+		files = append(files, untracked...)
 	} else if includeUntracked {
-		if file, ok := worktreeUntrackedFile(
+		file, ok, untrackedErr := worktreeUntrackedFile(
 			untrackedCtx, dir, path, true, hideWhitespace,
-		); ok {
+		)
+		if untrackedErr != nil {
+			untrackedSpan.RecordError(untrackedErr)
+			untrackedSpan.End()
+			return nil, fmt.Errorf("untracked file: %w", untrackedErr)
+		}
+		if ok {
 			files = append(files, file)
 		}
 	}
@@ -509,7 +561,11 @@ func worktreeDiffFromRefsPath(
 	generatedCtx, generatedSpan := workspaceDiffTracer.Start(
 		assembleCtx, "workspace.diff.generated_attributes",
 	)
-	markWorktreeGeneratedFiles(generatedCtx, dir, files)
+	attributeSource := ""
+	if !includeUntracked {
+		attributeSource = headRef
+	}
+	markWorktreeGeneratedFiles(generatedCtx, dir, attributeSource, files)
 	generatedSpan.End()
 	gitclone.SortDiffFiles(files)
 	assembleSpan.SetAttributes(attribute.Int("workspace.diff.file_count", len(files)))
@@ -551,51 +607,39 @@ func readWorktreeFileContent(
 	path string,
 	maxBytes int64,
 ) (*gitclone.FileContent, error) {
-	fullPath := filepath.Join(dir, path)
-	info, err := os.Lstat(fullPath)
+	opened, err := openWorktreePath(dir, path)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", gitclone.ErrNotFound, err)
 	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		target, err := os.Readlink(fullPath)
-		if err != nil {
-			return nil, fmt.Errorf("%w: %v", gitclone.ErrNotFound, err)
-		}
-		data := []byte(target)
+	if opened.file == nil {
+		data := []byte(opened.symlinkTarget)
 		if maxBytes > 0 && int64(len(data)) > maxBytes {
 			return nil, fmt.Errorf("%w: %d bytes", gitclone.ErrTooLarge, len(data))
 		}
 		return &gitclone.FileContent{Path: path, Data: data, Size: int64(len(data))}, nil
 	}
-	if !info.Mode().IsRegular() {
-		return nil, gitclone.ErrNotFound
+	defer opened.file.Close()
+	if maxBytes > 0 && opened.info.Size() > maxBytes {
+		return nil, fmt.Errorf("%w: %d bytes", gitclone.ErrTooLarge, opened.info.Size())
 	}
-
-	file, info, err := openRegularUntrackedFile(fullPath)
-	if err != nil {
-		return nil, fmt.Errorf("%w: %v", gitclone.ErrNotFound, err)
-	}
-	defer file.Close()
-	if maxBytes > 0 && info.Size() > maxBytes {
-		return nil, fmt.Errorf("%w: %d bytes", gitclone.ErrTooLarge, info.Size())
-	}
-	limit := info.Size()
+	limit := opened.info.Size()
 	if maxBytes > 0 {
 		limit = maxBytes + 1
 	}
-	data, err := io.ReadAll(io.LimitReader(file, limit))
+	data, err := io.ReadAll(io.LimitReader(opened.file, limit))
 	if err != nil {
 		return nil, err
 	}
 	if maxBytes > 0 && int64(len(data)) > maxBytes {
 		return nil, fmt.Errorf("%w: %d bytes", gitclone.ErrTooLarge, len(data))
 	}
-	return &gitclone.FileContent{Path: path, Data: data, Size: info.Size()}, nil
+	return &gitclone.FileContent{Path: path, Data: data, Size: opened.info.Size()}, nil
 }
 
 func markWorktreeGeneratedFiles(
 	ctx context.Context,
 	dir string,
+	attributeSource string,
 	files []gitclone.DiffFile,
 ) {
 	if len(files) == 0 {
@@ -604,10 +648,12 @@ func markWorktreeGeneratedFiles(
 	generated := map[string]bool{}
 	input := gitclone.GeneratedAttributeInput(files)
 	if len(input) > 0 {
-		out, err := worktreeGitOutputWithInput(
-			ctx, dir, input,
-			"check-attr", "-z", "--stdin", "linguist-generated",
-		)
+		args := []string{"check-attr", "-z", "--stdin"}
+		if attributeSource != "" {
+			args = append(args, "--source", attributeSource)
+		}
+		args = append(args, "linguist-generated")
+		out, err := worktreeGitOutputWithInput(ctx, dir, input, args...)
 		if err == nil {
 			generated = gitclone.ParseLinguistGeneratedAttributes(out)
 		}
@@ -691,12 +737,15 @@ func worktreeUntrackedFiles(
 	dir string,
 	withHunks bool,
 	hideWhitespace bool,
-) []gitclone.DiffFile {
+) ([]gitclone.DiffFile, error) {
 	out, err := worktreeGitOutput(
 		ctx, dir, "ls-files", "--others", "--exclude-standard", "-z",
 	)
 	if err != nil {
-		return nil
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		return nil, nil
 	}
 	parts := bytes.Split(out, []byte{0})
 	paths := make([]string, 0, len(parts))
@@ -708,7 +757,7 @@ func worktreeUntrackedFiles(
 		paths = append(paths, path)
 	}
 	return worktreeUntrackedFilesFromPaths(
-		dir, paths, withHunks, hideWhitespace,
+		ctx, dir, paths, withHunks, hideWhitespace,
 	)
 }
 
@@ -718,107 +767,227 @@ func worktreeUntrackedFile(
 	path string,
 	withHunks bool,
 	hideWhitespace bool,
-) (gitclone.DiffFile, bool) {
+) (gitclone.DiffFile, bool, error) {
 	out, err := worktreeGitOutput(
 		ctx, dir, "ls-files", "--others", "--exclude-standard", "-z",
 		"--", path,
 	)
 	if err != nil {
-		return gitclone.DiffFile{}, false
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return gitclone.DiffFile{}, false, ctxErr
+		}
+		return gitclone.DiffFile{}, false, nil
 	}
 	for part := range bytes.SplitSeq(out, []byte{0}) {
 		if string(part) != path {
 			continue
 		}
-		files := worktreeUntrackedFilesFromPaths(
-			dir, []string{path}, withHunks, hideWhitespace,
+		files, filesErr := worktreeUntrackedFilesFromPaths(
+			ctx, dir, []string{path}, withHunks, hideWhitespace,
 		)
-		if len(files) == 0 {
-			return gitclone.DiffFile{}, false
+		if filesErr != nil {
+			return gitclone.DiffFile{}, false, filesErr
 		}
-		return files[0], true
+		if len(files) == 0 {
+			return gitclone.DiffFile{}, false, nil
+		}
+		return files[0], true, nil
 	}
-	return gitclone.DiffFile{}, false
+	return gitclone.DiffFile{}, false, nil
 }
 
 func worktreeUntrackedFilesFromPaths(
+	ctx context.Context,
 	dir string,
 	paths []string,
 	withHunks bool,
 	hideWhitespace bool,
-) []gitclone.DiffFile {
-	files := make([]gitclone.DiffFile, 0, len(paths))
-	for _, path := range paths {
-		if path == "" {
-			continue
-		}
-		file := gitclone.DiffFile{
-			Path:    filepath.ToSlash(path),
-			OldPath: filepath.ToSlash(path),
-			Status:  "added",
-			Hunks:   []gitclone.Hunk{},
-		}
-		content, ok := readUntrackedFileContent(
-			filepath.Join(dir, path),
-		)
-		if !ok {
-			continue
-		}
-		if content == nil {
-			file.IsBinary = true
-			files = append(files, file)
-			continue
-		}
-		if hideWhitespace && len(content) > 0 &&
-			!bytes.Contains(content, []byte{0}) &&
-			len(bytes.TrimSpace(content)) == 0 {
-			continue
-		}
-		file.Additions = countAddedLines(content)
-		if bytes.Contains(content, []byte{0}) {
-			file.IsBinary = true
-		} else if withHunks {
-			file.Hunks = []gitclone.Hunk{
-				untrackedFileHunk(content),
-			}
-			file.Patch = gitclone.BuildPatch(file)
-		}
-		files = append(files, file)
+) ([]gitclone.DiffFile, error) {
+	type result struct {
+		file gitclone.DiffFile
+		ok   bool
 	}
-	return files
+	results := make([]result, len(paths))
+	err := untrackedFileReads.run(ctx, paths, func(
+		readCtx context.Context, index int, path string,
+	) error {
+		file, ok, readErr := buildUntrackedDiffFile(
+			readCtx, dir, path, withHunks, hideWhitespace,
+		)
+		if readErr != nil {
+			return readErr
+		}
+		results[index] = result{file: file, ok: ok}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	files := make([]gitclone.DiffFile, 0, len(results))
+	for _, result := range results {
+		if result.ok {
+			files = append(files, result.file)
+		}
+	}
+	return files, nil
 }
 
-func readUntrackedFileContent(path string) ([]byte, bool) {
-	info, err := os.Lstat(path)
-	if err != nil {
-		return nil, false
+func (p *untrackedReadPool) run(
+	ctx context.Context,
+	paths []string,
+	read func(context.Context, int, string) error,
+) error {
+	type job struct {
+		index int
+		path  string
 	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		target, err := os.Readlink(path)
-		if err != nil {
-			return nil, false
+	group, groupCtx := errgroup.WithContext(ctx)
+	jobs := make(chan job)
+	workerCount := min(p.limit, len(paths))
+	for range workerCount {
+		group.Go(func() error {
+			for {
+				select {
+				case <-groupCtx.Done():
+					return groupCtx.Err()
+				case item, ok := <-jobs:
+					if !ok {
+						return nil
+					}
+					if err := p.sem.Acquire(groupCtx, 1); err != nil {
+						return err
+					}
+					readErr := read(groupCtx, item.index, item.path)
+					p.sem.Release(1)
+					if readErr != nil {
+						return readErr
+					}
+				}
+			}
+		})
+	}
+
+	for index, path := range paths {
+		select {
+		case jobs <- job{index: index, path: path}:
+		case <-groupCtx.Done():
+			close(jobs)
+			if err := group.Wait(); err != nil {
+				return err
+			}
+			return ctx.Err()
 		}
-		return []byte(target), true
 	}
-	if !info.Mode().IsRegular() {
-		return nil, false
+	close(jobs)
+	if err := group.Wait(); err != nil {
+		return err
 	}
-	file, info, err := openRegularUntrackedFile(path)
+	return ctx.Err()
+}
+
+func buildUntrackedDiffFile(
+	ctx context.Context,
+	dir string,
+	path string,
+	withHunks bool,
+	hideWhitespace bool,
+) (gitclone.DiffFile, bool, error) {
+	if path == "" {
+		return gitclone.DiffFile{}, false, nil
+	}
+	file := gitclone.DiffFile{
+		Path:    filepath.ToSlash(path),
+		OldPath: filepath.ToSlash(path),
+		Status:  "added",
+		Hunks:   []gitclone.Hunk{},
+	}
+	content, ok, err := readUntrackedFileContent(ctx, dir, path)
+	if err != nil || !ok {
+		return gitclone.DiffFile{}, false, err
+	}
+	if content == nil {
+		file.IsBinary = true
+		return file, true, nil
+	}
+	if hideWhitespace && len(content) > 0 &&
+		!bytes.Contains(content, []byte{0}) &&
+		len(bytes.TrimSpace(content)) == 0 {
+		return gitclone.DiffFile{}, false, nil
+	}
+	file.Additions = countAddedLines(content)
+	if bytes.Contains(content, []byte{0}) {
+		file.IsBinary = true
+	} else if withHunks {
+		file.Hunks = []gitclone.Hunk{
+			untrackedFileHunk(content),
+		}
+		file.Patch = gitclone.BuildPatch(file)
+	}
+	return file, true, nil
+}
+
+func readUntrackedFileContent(
+	ctx context.Context,
+	root string,
+	relative string,
+) ([]byte, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, false, err
+	}
+	clean, err := cleanWorktreeDiffPath(relative)
 	if err != nil {
-		return nil, false
+		return nil, false, err
 	}
-	defer file.Close()
-	if info.Size() > maxUntrackedTextFileBytes {
-		return nil, true
-	}
-	content, err := io.ReadAll(io.LimitReader(file, maxUntrackedTextFileBytes+1))
+	opened, err := openWorktreePath(root, clean)
 	if err != nil {
-		return nil, false
+		if err := ctx.Err(); err != nil {
+			return nil, false, err
+		}
+		return nil, false, nil
+	}
+	if opened.file == nil {
+		return []byte(opened.symlinkTarget), true, nil
+	}
+	defer opened.file.Close()
+	if opened.info.Size() > maxUntrackedTextFileBytes {
+		return nil, true, nil
+	}
+	content, err := readAllWithContext(ctx, opened.file, maxUntrackedTextFileBytes+1)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, false, ctxErr
+		}
+		return nil, false, nil
 	}
 	if len(content) > maxUntrackedTextFileBytes {
-		return nil, true
+		return nil, true, nil
 	}
-	return content, true
+	return content, true, nil
+}
+
+func readAllWithContext(ctx context.Context, reader io.Reader, limit int64) ([]byte, error) {
+	limited := io.LimitReader(reader, limit)
+	buffer := bytes.NewBuffer(nil)
+	chunk := make([]byte, 32*1024)
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		read, err := limited.Read(chunk)
+		if read > 0 {
+			_, _ = buffer.Write(chunk[:read])
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		if errors.Is(err, io.EOF) {
+			return buffer.Bytes(), nil
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
 }
 
 func countAddedLines(content []byte) int {

--- a/internal/workspace/diff.go
+++ b/internal/workspace/diff.go
@@ -129,18 +129,53 @@ func worktreeDiffFilesFromRefs(
 	hideWhitespace bool,
 	includeUntracked bool,
 ) ([]gitclone.DiffFile, error) {
-	result, err := worktreeDiffFromRefsPath(
-		ctx, dir, baseRef, headRef, hideWhitespace, "", includeUntracked,
+	rawArgs := appendWorktreeHeadRef(gitclone.AddDiffWhitespaceFlag(gitclone.DiffArgs(
+		"--raw", "-z", "-M", "-C", "--find-copies-harder", baseRef,
+	), hideWhitespace), headRef)
+	rawOut, err := worktreeDiffGitPhase(ctx, "workspace.diff.git.raw", dir, rawArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("git diff --raw: %w", err)
+	}
+	files := gitclone.ParseRawZ(rawOut)
+	if files == nil {
+		files = []gitclone.DiffFile{}
+	}
+
+	numstatArgs := appendWorktreeHeadRef(gitclone.AddDiffWhitespaceFlag(gitclone.DiffArgs(
+		"--numstat", "-z", "-M", "-C", "--find-copies-harder", baseRef,
+	), hideWhitespace), headRef)
+	numstatOut, err := worktreeDiffGitPhase(
+		ctx, "workspace.diff.git.numstat", dir, numstatArgs...,
 	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("git diff --numstat: %w", err)
 	}
-	files := make([]gitclone.DiffFile, len(result.Files))
-	copy(files, result.Files)
+	counts := parseWorktreeNumstatZ(numstatOut)
+	applyWorktreeNumstat(files, counts)
+	whitespaceFiles, err := worktreeWhitespaceOnlyFilesAggregate(
+		ctx, dir, baseRef, headRef, "",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("whitespace files: %w", err)
+	}
 	for i := range files {
-		files[i].Patch = ""
-		files[i].Hunks = []gitclone.Hunk{}
+		files[i].IsWhitespaceOnly = whitespaceFiles[files[i].Path]
 	}
+	if hideWhitespace {
+		filtered := files[:0]
+		for i := range files {
+			if files[i].Status == "modified" && whitespaceFiles[files[i].Path] {
+				continue
+			}
+			filtered = append(filtered, files[i])
+		}
+		files = filtered
+	}
+	if includeUntracked {
+		files = append(files, worktreeUntrackedFiles(ctx, dir, false, hideWhitespace)...)
+	}
+	markWorktreeGeneratedFiles(ctx, dir, files)
+	gitclone.SortDiffFiles(files)
 	return files, nil
 }
 
@@ -454,7 +489,7 @@ func worktreeDiffFromRefsPath(
 			return nil, fmt.Errorf("whitespace count: %w", err)
 		}
 	} else {
-		wsCount = classifyWhitespaceOnly(files)
+		wsCount = classifyWhitespaceOnly(files, worktreeRawModeChanges(rawOut))
 	}
 	whitespaceSpan.SetAttributes(attribute.Int("workspace.diff.whitespace_only_files", wsCount))
 	whitespaceSpan.End()
@@ -872,7 +907,41 @@ func parseWorktreeNumstatInt(value string) int {
 func worktreeWhitespaceOnlyCount(
 	ctx context.Context, dir string, baseRef string, headRef string, path string,
 ) (int, error) {
-	return worktreeWhitespaceOnlyCountFromPatch(ctx, dir, baseRef, headRef, path)
+	files, err := worktreeWhitespaceOnlyFilesAggregate(ctx, dir, baseRef, headRef, path)
+	return len(files), err
+}
+
+func worktreeWhitespaceOnlyFilesAggregate(
+	ctx context.Context, dir string, baseRef string, headRef string, path string,
+) (map[string]bool, error) {
+	rawArgs := appendWorktreePathspec(appendWorktreeHeadRef(gitclone.DiffArgs(
+		"--raw", "-z", "--no-renames", baseRef,
+	), headRef), path)
+	rawOut, err := worktreeDiffGitPhase(ctx, "workspace.diff.git.raw", dir, rawArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("git diff --raw: %w", err)
+	}
+	numstatArgs := appendWorktreePathspec(appendWorktreeHeadRef(gitclone.DiffArgs(
+		"--numstat", "-z", "--no-renames", "-w", baseRef,
+	), headRef), path)
+	numstatOut, err := worktreeDiffGitPhase(
+		ctx, "workspace.diff.git.numstat", dir, numstatArgs...,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("git diff --numstat -w: %w", err)
+	}
+	nonWhitespace := parseWorktreeNumstatZ(numstatOut)
+	modeChanges := worktreeRawModeChanges(rawOut)
+	result := make(map[string]bool)
+	for _, file := range gitclone.ParseRawZ(rawOut) {
+		if file.Status != "modified" || modeChanges[file.Path] {
+			continue
+		}
+		if _, ok := nonWhitespace[file.Path]; !ok {
+			result[file.Path] = true
+		}
+	}
+	return result, nil
 }
 
 func worktreeWhitespaceOnlyCountFromPatch(
@@ -896,7 +965,39 @@ func worktreeWhitespaceOnlyCountFromPatch(
 	if files == nil {
 		files = []gitclone.DiffFile{}
 	}
-	return classifyWhitespaceOnly(files), nil
+	return classifyWhitespaceOnly(files, worktreeRawModeChanges(rawOut)), nil
+}
+
+func worktreeRawModeChanges(data []byte) map[string]bool {
+	parts := bytes.Split(data, []byte{0})
+	changed := make(map[string]bool)
+	for i := 0; i < len(parts); i++ {
+		header := string(parts[i])
+		if !strings.HasPrefix(header, ":") {
+			continue
+		}
+		fields := strings.Fields(header)
+		if len(fields) < 5 {
+			continue
+		}
+		i++
+		if i >= len(parts) {
+			break
+		}
+		path := string(parts[i])
+		status := fields[4]
+		if strings.HasPrefix(status, "R") || strings.HasPrefix(status, "C") {
+			i++
+			if i >= len(parts) {
+				break
+			}
+			path = string(parts[i])
+		}
+		if fields[0] != ":"+fields[1] && path != "" {
+			changed[path] = true
+		}
+	}
+	return changed
 }
 
 func worktreeDiffBaseRef(

--- a/internal/workspace/diff.go
+++ b/internal/workspace/diff.go
@@ -14,6 +14,8 @@ import (
 	gitcmd "go.kenn.io/kit/git/cmd"
 	"go.kenn.io/middleman/internal/gitclone"
 	"go.kenn.io/middleman/internal/procutil"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 type WorktreeDiffBase string
@@ -25,6 +27,8 @@ const (
 )
 
 const maxUntrackedTextFileBytes = 1 << 20
+
+var workspaceDiffTracer = otel.Tracer("go.kenn.io/middleman/internal/workspace/diff")
 
 func WorktreeDiffFiles(
 	ctx context.Context,
@@ -125,44 +129,18 @@ func worktreeDiffFilesFromRefs(
 	hideWhitespace bool,
 	includeUntracked bool,
 ) ([]gitclone.DiffFile, error) {
-	rawArgs := appendWorktreeHeadRef(gitclone.AddDiffWhitespaceFlag(gitclone.DiffArgs(
-		"--raw", "-z", "-M", "-C", "--find-copies-harder",
-		baseRef,
-	), hideWhitespace), headRef)
-	rawOut, err := worktreeGitOutput(ctx, dir, rawArgs...)
+	result, err := worktreeDiffFromRefsPath(
+		ctx, dir, baseRef, headRef, hideWhitespace, "", includeUntracked,
+	)
 	if err != nil {
-		return nil, fmt.Errorf("git diff --raw: %w", err)
+		return nil, err
 	}
-	files := gitclone.ParseRawZ(rawOut)
-	if files == nil {
-		files = []gitclone.DiffFile{}
+	files := make([]gitclone.DiffFile, len(result.Files))
+	copy(files, result.Files)
+	for i := range files {
+		files[i].Patch = ""
+		files[i].Hunks = []gitclone.Hunk{}
 	}
-	if hideWhitespace {
-		wsFiles, err := worktreeWhitespaceOnlyFiles(ctx, dir, baseRef, headRef, "")
-		if err != nil {
-			return nil, fmt.Errorf("whitespace files: %w", err)
-		}
-		files = filterWorktreeWhitespaceOnlyFiles(files, wsFiles)
-	}
-
-	numstatArgs := appendWorktreeHeadRef(gitclone.AddDiffWhitespaceFlag(gitclone.DiffArgs(
-		"--numstat", "-z", "-M", "-C", "--find-copies-harder",
-		baseRef,
-	), hideWhitespace), headRef)
-	numstatOut, err := worktreeGitOutput(ctx, dir, numstatArgs...)
-	if err != nil {
-		return nil, fmt.Errorf("git diff --numstat: %w", err)
-	}
-	counts := parseWorktreeNumstatZ(numstatOut)
-	applyWorktreeNumstat(files, counts)
-	if hideWhitespace {
-		files = dropWhitespaceOnlyModifications(files, counts)
-	}
-	if includeUntracked {
-		files = append(files, worktreeUntrackedFiles(ctx, dir, false, hideWhitespace)...)
-	}
-	markWorktreeGeneratedFiles(ctx, dir, files)
-	gitclone.SortDiffFiles(files)
 	return files, nil
 }
 
@@ -421,17 +399,12 @@ func worktreeDiffFromRefsPath(
 		return nil, err
 	}
 
-	wsCount, err := worktreeWhitespaceOnlyCount(ctx, dir, baseRef, headRef, path)
-	if err != nil {
-		return nil, fmt.Errorf("whitespace count: %w", err)
-	}
-
 	rawArgs := appendWorktreeHeadRef(gitclone.AddDiffWhitespaceFlag(gitclone.DiffArgs(
 		"--raw", "-z", "-M", "-C", "--find-copies-harder",
 		baseRef,
 	), hideWhitespace), headRef)
 	rawArgs = appendWorktreePathspec(rawArgs, path)
-	rawOut, err := worktreeGitOutput(ctx, dir, rawArgs...)
+	rawOut, err := worktreeDiffGitPhase(ctx, "workspace.diff.git.raw", dir, rawArgs...)
 	if err != nil {
 		return nil, fmt.Errorf("git diff --raw: %w", err)
 	}
@@ -442,7 +415,7 @@ func worktreeDiffFromRefsPath(
 		baseRef,
 	), hideWhitespace), headRef)
 	numstatArgs = appendWorktreePathspec(numstatArgs, path)
-	numstatOut, err := worktreeGitOutput(ctx, dir, numstatArgs...)
+	numstatOut, err := worktreeDiffGitPhase(ctx, "workspace.diff.git.numstat", dir, numstatArgs...)
 	if err != nil {
 		return nil, fmt.Errorf("git diff --numstat: %w", err)
 	}
@@ -451,10 +424,12 @@ func worktreeDiffFromRefsPath(
 		"-M", "-C", "--find-copies-harder", "-U3", baseRef,
 	), hideWhitespace), headRef)
 	patchArgs = appendWorktreePathspec(patchArgs, path)
-	patchOut, err := worktreeGitOutput(ctx, dir, patchArgs...)
+	patchOut, err := worktreeDiffGitPhase(ctx, "workspace.diff.git.patch", dir, patchArgs...)
 	if err != nil {
 		return nil, fmt.Errorf("git diff patch: %w", err)
 	}
+	assembleCtx, assembleSpan := workspaceDiffTracer.Start(ctx, "workspace.diff.assemble")
+	defer assembleSpan.End()
 	files = gitclone.ParsePatch(patchOut, files)
 	if files == nil {
 		files = []gitclone.DiffFile{}
@@ -465,25 +440,44 @@ func worktreeDiffFromRefsPath(
 		files = dropWhitespaceOnlyModifications(files, counts)
 	}
 
-	if !hideWhitespace {
-		wsFiles, err := worktreeWhitespaceOnlyFiles(ctx, dir, baseRef, headRef, path)
-		if err == nil {
-			for i := range files {
-				files[i].IsWhitespaceOnly = wsFiles[files[i].Path]
-			}
+	wsCount := 0
+	whitespaceCtx, whitespaceSpan := workspaceDiffTracer.Start(
+		assembleCtx, "workspace.diff.whitespace",
+	)
+	if hideWhitespace {
+		wsCount, err = worktreeWhitespaceOnlyCountFromPatch(
+			whitespaceCtx, dir, baseRef, headRef, path,
+		)
+		if err != nil {
+			whitespaceSpan.RecordError(err)
+			whitespaceSpan.End()
+			return nil, fmt.Errorf("whitespace count: %w", err)
 		}
+	} else {
+		wsCount = classifyWhitespaceOnly(files)
 	}
+	whitespaceSpan.SetAttributes(attribute.Int("workspace.diff.whitespace_only_files", wsCount))
+	whitespaceSpan.End()
+	untrackedCtx, untrackedSpan := workspaceDiffTracer.Start(
+		assembleCtx, "workspace.diff.untracked",
+	)
 	if includeUntracked && path == "" {
-		files = append(files, worktreeUntrackedFiles(ctx, dir, true, hideWhitespace)...)
+		files = append(files, worktreeUntrackedFiles(untrackedCtx, dir, true, hideWhitespace)...)
 	} else if includeUntracked {
 		if file, ok := worktreeUntrackedFile(
-			ctx, dir, path, true, hideWhitespace,
+			untrackedCtx, dir, path, true, hideWhitespace,
 		); ok {
 			files = append(files, file)
 		}
 	}
-	markWorktreeGeneratedFiles(ctx, dir, files)
+	untrackedSpan.End()
+	generatedCtx, generatedSpan := workspaceDiffTracer.Start(
+		assembleCtx, "workspace.diff.generated_attributes",
+	)
+	markWorktreeGeneratedFiles(generatedCtx, dir, files)
+	generatedSpan.End()
 	gitclone.SortDiffFiles(files)
+	assembleSpan.SetAttributes(attribute.Int("workspace.diff.file_count", len(files)))
 
 	return &gitclone.DiffResult{
 		WhitespaceOnlyCount: wsCount,
@@ -621,23 +615,6 @@ func dropWhitespaceOnlyModifications(
 		out = append(out, files[i])
 	}
 	return out
-}
-
-func filterWorktreeWhitespaceOnlyFiles(
-	files []gitclone.DiffFile,
-	wsFiles map[string]bool,
-) []gitclone.DiffFile {
-	if len(files) == 0 || len(wsFiles) == 0 {
-		return files
-	}
-	filtered := files[:0]
-	for _, file := range files {
-		if wsFiles[file.Path] {
-			continue
-		}
-		filtered = append(filtered, file)
-	}
-	return filtered
 }
 
 func appendWorktreePathspec(args []string, path string) []string {
@@ -895,50 +872,31 @@ func parseWorktreeNumstatInt(value string) int {
 func worktreeWhitespaceOnlyCount(
 	ctx context.Context, dir string, baseRef string, headRef string, path string,
 ) (int, error) {
-	files, err := worktreeWhitespaceOnlyFiles(ctx, dir, baseRef, headRef, path)
-	if err != nil {
-		return 0, err
-	}
-	return len(files), nil
+	return worktreeWhitespaceOnlyCountFromPatch(ctx, dir, baseRef, headRef, path)
 }
 
-func worktreeWhitespaceOnlyFiles(
+func worktreeWhitespaceOnlyCountFromPatch(
 	ctx context.Context, dir string, baseRef string, headRef string, path string,
-) (map[string]bool, error) {
-	allArgs := appendWorktreePathspec(appendWorktreeHeadRef(gitclone.DiffArgs(
-		"--raw", "-z", "--no-renames", baseRef,
+) (int, error) {
+	rawArgs := appendWorktreePathspec(appendWorktreeHeadRef(gitclone.DiffArgs(
+		"--raw", "-z", "-M", "-C", "--find-copies-harder", baseRef,
 	), headRef), path)
-	outAll, err := worktreeGitOutput(ctx, dir, allArgs...)
+	rawOut, err := worktreeDiffGitPhase(ctx, "workspace.diff.git.raw", dir, rawArgs...)
 	if err != nil {
-		return nil, err
+		return 0, fmt.Errorf("git diff --raw: %w", err)
 	}
-
-	allFiles := worktreeRawPaths(outAll)
-	result := make(map[string]bool)
-	for file := range allFiles {
-		args := appendWorktreeHeadRef(gitclone.DiffArgs(
-			"--numstat", "-z", "--no-renames", "-w", baseRef,
-		), headRef)
-		outNoWhitespace, err := worktreeGitOutput(
-			ctx, dir, appendWorktreePathspec(args, file)...,
-		)
-		if err != nil {
-			return nil, err
-		}
-		if len(outNoWhitespace) == 0 {
-			result[file] = true
-		}
+	patchArgs := appendWorktreePathspec(appendWorktreeHeadRef(gitclone.DiffArgs(
+		"-M", "-C", "--find-copies-harder", "-U3", baseRef,
+	), headRef), path)
+	patchOut, err := worktreeDiffGitPhase(ctx, "workspace.diff.git.patch", dir, patchArgs...)
+	if err != nil {
+		return 0, fmt.Errorf("git diff patch: %w", err)
 	}
-	return result, nil
-}
-
-func worktreeRawPaths(data []byte) map[string]bool {
-	files := gitclone.ParseRawZ(data)
-	paths := make(map[string]bool, len(files))
-	for _, file := range files {
-		paths[file.Path] = true
+	files := gitclone.ParsePatch(patchOut, gitclone.ParseRawZ(rawOut))
+	if files == nil {
+		files = []gitclone.DiffFile{}
 	}
-	return paths
+	return classifyWhitespaceOnly(files), nil
 }
 
 func worktreeDiffBaseRef(
@@ -1001,6 +959,22 @@ func worktreeGitOutput(
 	args ...string,
 ) ([]byte, error) {
 	return worktreeGitOutputWithInput(ctx, dir, nil, args...)
+}
+
+func worktreeDiffGitPhase(
+	ctx context.Context,
+	name string,
+	dir string,
+	args ...string,
+) ([]byte, error) {
+	phaseCtx, span := workspaceDiffTracer.Start(ctx, name)
+	defer span.End()
+	out, err := worktreeGitOutput(phaseCtx, dir, args...)
+	span.SetAttributes(attribute.Int("workspace.diff.output_bytes", len(out)))
+	if err != nil {
+		span.RecordError(err)
+	}
+	return out, err
 }
 
 func worktreeGitOutputWithInput(

--- a/internal/workspace/diff_nonunix.go
+++ b/internal/workspace/diff_nonunix.go
@@ -30,3 +30,7 @@ func openRegularUntrackedFile(path string) (*os.File, os.FileInfo, error) {
 	}
 	return file, info, nil
 }
+
+func openWorktreeFile(root *os.Root, path string) (*os.File, error) {
+	return root.Open(path)
+}

--- a/internal/workspace/diff_portable.go
+++ b/internal/workspace/diff_portable.go
@@ -1,0 +1,50 @@
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+)
+
+type openedWorktreePath struct {
+	file          *os.File
+	info          os.FileInfo
+	symlinkTarget string
+}
+
+func openWorktreePath(root, relative string) (*openedWorktreePath, error) {
+	rooted, err := os.OpenRoot(root)
+	if err != nil {
+		return nil, err
+	}
+	defer rooted.Close()
+
+	path := filepath.FromSlash(relative)
+	info, err := rooted.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		target, readErr := rooted.Readlink(path)
+		if readErr != nil {
+			return nil, readErr
+		}
+		return &openedWorktreePath{symlinkTarget: target}, nil
+	}
+	if !info.Mode().IsRegular() {
+		return nil, errWorktreePathNotRegular
+	}
+	file, err := openWorktreeFile(rooted, path)
+	if err != nil {
+		return nil, err
+	}
+	openedInfo, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	if !openedInfo.Mode().IsRegular() || !os.SameFile(info, openedInfo) {
+		_ = file.Close()
+		return nil, errWorktreePathNotRegular
+	}
+	return &openedWorktreePath{file: file, info: openedInfo}, nil
+}

--- a/internal/workspace/diff_snapshot.go
+++ b/internal/workspace/diff_snapshot.go
@@ -42,6 +42,8 @@ type DiffFingerprint string
 
 const maxDiffContentDigestEntries = 4096
 
+var errWorktreePathNotRegular = errors.New("worktree path is not a regular file or symlink")
+
 var diffContentDigests = struct {
 	sync.Mutex
 	entries map[string]diffContentDigestEntry
@@ -155,6 +157,10 @@ func FingerprintDiffSnapshot(
 	} else {
 		writeDiffFingerprintField(h, []byte{0})
 	}
+	if err := fingerprintRepositoryAttributes(ctx, h, current.WorktreePath); err != nil {
+		span.RecordError(err)
+		return "", err
+	}
 	if !current.IncludeUntracked {
 		return DiffFingerprint(fmt.Sprintf("%x", h.Sum(nil))), nil
 	}
@@ -177,11 +183,6 @@ func FingerprintDiffSnapshot(
 	}
 	writeDiffFingerprintField(h, rawOut)
 	writeDiffFingerprintField(h, untrackedOut)
-	if err := fingerprintRepositoryAttributes(ctx, h, current.WorktreePath); err != nil {
-		span.RecordError(err)
-		return "", err
-	}
-
 	paths := make(map[string]struct{})
 	for _, file := range gitclone.ParseRawZ(rawOut) {
 		paths[file.Path] = struct{}{}
@@ -196,14 +197,31 @@ func FingerprintDiffSnapshot(
 		orderedPaths = append(orderedPaths, path)
 	}
 	sort.Strings(orderedPaths)
-	var bytesRead int64
-	for _, path := range orderedPaths {
-		read, err := fingerprintWorktreePath(h, current.WorktreePath, path)
-		if err != nil {
-			span.RecordError(err)
-			return "", err
+	type pathFingerprint struct {
+		encoded   []byte
+		bytesRead int64
+	}
+	pathFingerprints := make([]pathFingerprint, len(orderedPaths))
+	err = untrackedFileReads.run(ctx, orderedPaths, func(
+		readCtx context.Context, index int, path string,
+	) error {
+		encoded, read, readErr := fingerprintWorktreePath(
+			readCtx, current.WorktreePath, path,
+		)
+		if readErr != nil {
+			return readErr
 		}
-		bytesRead += read
+		pathFingerprints[index] = pathFingerprint{encoded: encoded, bytesRead: read}
+		return nil
+	})
+	if err != nil {
+		span.RecordError(err)
+		return "", err
+	}
+	var bytesRead int64
+	for _, fingerprint := range pathFingerprints {
+		_, _ = h.Write(fingerprint.encoded)
+		bytesRead += fingerprint.bytesRead
 	}
 	span.SetAttributes(
 		attribute.Int("workspace.diff.fingerprint_paths", len(orderedPaths)),
@@ -237,63 +255,72 @@ func fingerprintRepositoryAttributes(
 	return nil
 }
 
-func fingerprintWorktreePath(h hash.Hash, dir, path string) (int64, error) {
+func fingerprintWorktreePath(ctx context.Context, dir, path string) ([]byte, int64, error) {
 	clean, err := cleanWorktreeDiffPath(path)
 	if err != nil {
-		return 0, err
+		return nil, 0, err
 	}
-	writeDiffFingerprintField(h, []byte(clean))
+	var encoded bytes.Buffer
+	writeDiffFingerprintField(&encoded, []byte(clean))
 	fullPath := filepath.Join(dir, filepath.FromSlash(clean))
-	info, err := os.Lstat(fullPath)
+	opened, err := openWorktreePath(dir, clean)
 	if errors.Is(err, os.ErrNotExist) {
-		writeDiffFingerprintField(h, []byte("missing"))
-		return 0, nil
+		writeDiffFingerprintField(&encoded, []byte("missing"))
+		return encoded.Bytes(), 0, nil
+	}
+	if errors.Is(err, errWorktreePathNotRegular) {
+		writeDiffFingerprintField(&encoded, []byte("nonregular"))
+		return encoded.Bytes(), 0, nil
 	}
 	if err != nil {
-		return 0, err
+		return nil, 0, err
 	}
-	writeDiffFingerprintField(h, []byte(info.Mode().String()))
-	if info.Mode()&os.ModeSymlink != 0 {
-		target, err := os.Readlink(fullPath)
-		if err != nil {
-			return 0, err
-		}
-		writeDiffFingerprintField(h, []byte(target))
-		return 0, nil
+	if opened.file == nil {
+		writeDiffFingerprintField(&encoded, []byte("symlink"))
+		writeDiffFingerprintField(&encoded, []byte(opened.symlinkTarget))
+		return encoded.Bytes(), 0, nil
 	}
-	if !info.Mode().IsRegular() {
-		return 0, nil
-	}
-	digest, bytesRead, err := diffContentDigest(fullPath, info)
+	defer opened.file.Close()
+	writeDiffFingerprintField(&encoded, []byte(opened.info.Mode().String()))
+	digest, bytesRead, err := diffContentDigestFile(ctx, fullPath, opened.file, opened.info)
 	if err != nil {
-		return 0, err
+		return nil, 0, err
 	}
-	writeDiffFingerprintField(h, digest[:])
-	return bytesRead, nil
+	writeDiffFingerprintField(&encoded, digest[:])
+	return encoded.Bytes(), bytesRead, nil
 }
 
-func diffContentDigest(path string, info os.FileInfo) ([sha256.Size]byte, int64, error) {
+func diffContentDigest(ctx context.Context, path string) ([sha256.Size]byte, int64, error) {
+	file, info, err := openRegularUntrackedFile(path)
+	if err != nil {
+		return [sha256.Size]byte{}, 0, err
+	}
+	defer file.Close()
+	return diffContentDigestFile(ctx, path, file, info)
+}
+
+func diffContentDigestFile(
+	ctx context.Context,
+	cacheKey string,
+	file *os.File,
+	info os.FileInfo,
+) ([sha256.Size]byte, int64, error) {
 	identity := fmt.Sprintf(
 		"%d|%d|%s|%#v",
 		info.Size(), info.ModTime().UnixNano(), info.Mode(), info.Sys(),
 	)
 	now := time.Now()
 	diffContentDigests.Lock()
-	if cached, ok := diffContentDigests.entries[path]; ok && cached.identity == identity {
+	if cached, ok := diffContentDigests.entries[cacheKey]; ok && cached.identity == identity {
 		cached.usedAt = now
-		diffContentDigests.entries[path] = cached
+		diffContentDigests.entries[cacheKey] = cached
 		diffContentDigests.Unlock()
 		return cached.digest, 0, nil
 	}
 	diffContentDigests.Unlock()
 
-	file, err := os.Open(path)
-	if err != nil {
-		return [sha256.Size]byte{}, 0, err
-	}
-	defer file.Close()
 	digestHash := sha256.New()
-	bytesRead, err := io.Copy(digestHash, file)
+	bytesRead, err := hashDiffContent(ctx, digestHash, file)
 	if err != nil {
 		return [sha256.Size]byte{}, bytesRead, err
 	}
@@ -301,7 +328,7 @@ func diffContentDigest(path string, info os.FileInfo) ([sha256.Size]byte, int64,
 	copy(digest[:], digestHash.Sum(nil))
 
 	diffContentDigests.Lock()
-	diffContentDigests.entries[path] = diffContentDigestEntry{
+	diffContentDigests.entries[cacheKey] = diffContentDigestEntry{
 		identity: identity,
 		digest:   digest,
 		usedAt:   now,
@@ -321,11 +348,38 @@ func diffContentDigest(path string, info os.FileInfo) ([sha256.Size]byte, int64,
 	return digest, bytesRead, nil
 }
 
-func writeDiffFingerprintField(h hash.Hash, value []byte) {
+func hashDiffContent(ctx context.Context, destination hash.Hash, file *os.File) (int64, error) {
+	buffer := make([]byte, 128<<10)
+	var total int64
+	for {
+		if err := ctx.Err(); err != nil {
+			return total, err
+		}
+		read, err := file.Read(buffer)
+		if read > 0 {
+			written, writeErr := destination.Write(buffer[:read])
+			total += int64(written)
+			if writeErr != nil {
+				return total, writeErr
+			}
+			if written != read {
+				return total, errors.New("short diff fingerprint hash write")
+			}
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return total, nil
+			}
+			return total, err
+		}
+	}
+}
+
+func writeDiffFingerprintField(w io.Writer, value []byte) {
 	var size [8]byte
 	binary.LittleEndian.PutUint64(size[:], uint64(len(value)))
-	_, _ = h.Write(size[:])
-	_, _ = h.Write(value)
+	_, _ = w.Write(size[:])
+	_, _ = w.Write(value)
 }
 
 func PrepareDiffSnapshot(

--- a/internal/workspace/diff_snapshot.go
+++ b/internal/workspace/diff_snapshot.go
@@ -1,0 +1,404 @@
+package workspace
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"hash"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"go.kenn.io/middleman/internal/gitclone"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+type DiffSnapshotSpec struct {
+	WorktreePath      string
+	Base              WorktreeDiffBase
+	MergeTargetBranch string
+	FromSHA           string
+	ToSHA             string
+	HideWhitespace    bool
+}
+
+type ResolvedDiffSnapshotSpec struct {
+	DiffSnapshotSpec
+	BaseRef          string
+	HeadRef          string
+	BaseOID          string
+	HeadOID          string
+	IncludeUntracked bool
+}
+
+type DiffFingerprint string
+
+const maxDiffContentDigestEntries = 4096
+
+var diffContentDigests = struct {
+	sync.Mutex
+	entries map[string]diffContentDigestEntry
+}{entries: make(map[string]diffContentDigestEntry)}
+
+type diffContentDigestEntry struct {
+	identity string
+	digest   [sha256.Size]byte
+	usedAt   time.Time
+}
+
+func ResolveDiffSnapshotSpec(
+	ctx context.Context,
+	spec DiffSnapshotSpec,
+) (ResolvedDiffSnapshotSpec, bool, error) {
+	ctx, span := workspaceDiffTracer.Start(ctx, "workspace.diff.resolve")
+	defer span.End()
+
+	absPath, err := filepath.Abs(spec.WorktreePath)
+	if err != nil {
+		span.RecordError(err)
+		return ResolvedDiffSnapshotSpec{}, false, err
+	}
+	spec.WorktreePath = filepath.Clean(absPath)
+
+	resolved := ResolvedDiffSnapshotSpec{DiffSnapshotSpec: spec}
+	if spec.FromSHA != "" || spec.ToSHA != "" {
+		if spec.FromSHA == "" || spec.ToSHA == "" {
+			return ResolvedDiffSnapshotSpec{}, false, errors.New("both diff range refs are required")
+		}
+		resolved.BaseRef = spec.FromSHA
+		resolved.HeadRef = spec.ToSHA
+	} else {
+		if resolved.Base == "" {
+			resolved.Base = WorktreeDiffBaseHead
+		}
+		var ok bool
+		switch resolved.Base {
+		case WorktreeDiffBaseMergeTarget:
+			resolved.BaseRef, ok, err = worktreeMergeTargetBaseRef(
+				ctx, resolved.WorktreePath, resolved.MergeTargetBranch,
+			)
+		default:
+			resolved.BaseRef, ok, err = worktreeDiffBaseRef(
+				ctx, resolved.WorktreePath, resolved.Base,
+			)
+		}
+		if err != nil || !ok {
+			if err != nil {
+				span.RecordError(err)
+			}
+			return ResolvedDiffSnapshotSpec{}, ok, err
+		}
+		resolved.IncludeUntracked = true
+	}
+
+	resolved.BaseOID, err = resolveDiffOID(ctx, resolved.WorktreePath, resolved.BaseRef, "object")
+	if err != nil {
+		span.RecordError(err)
+		return ResolvedDiffSnapshotSpec{}, false, err
+	}
+	headRef := resolved.HeadRef
+	if headRef == "" {
+		headRef = "HEAD"
+	}
+	resolved.HeadOID, err = resolveDiffOID(ctx, resolved.WorktreePath, headRef, "commit")
+	if err != nil {
+		span.RecordError(err)
+		return ResolvedDiffSnapshotSpec{}, false, err
+	}
+	return resolved, true, nil
+}
+
+func resolveDiffOID(ctx context.Context, dir, ref, objectType string) (string, error) {
+	out, err := worktreeGitOutput(ctx, dir, "rev-parse", "--verify", ref+"^{"+objectType+"}")
+	if err != nil {
+		return "", fmt.Errorf("resolve diff ref %q: %w", ref, err)
+	}
+	oid := strings.TrimSpace(string(out))
+	if oid == "" {
+		return "", fmt.Errorf("resolve diff ref %q: empty object id", ref)
+	}
+	return oid, nil
+}
+
+func FingerprintDiffSnapshot(
+	ctx context.Context,
+	resolved ResolvedDiffSnapshotSpec,
+) (DiffFingerprint, error) {
+	ctx, span := workspaceDiffTracer.Start(ctx, "workspace.diff.fingerprint")
+	defer span.End()
+
+	current, ok, err := ResolveDiffSnapshotSpec(ctx, resolved.DiffSnapshotSpec)
+	if err != nil {
+		span.RecordError(err)
+		return "", err
+	}
+	if !ok {
+		return "", errors.New("diff base is no longer available")
+	}
+
+	h := sha256.New()
+	writeDiffFingerprintField(h, []byte("middleman-workspace-diff-v1"))
+	writeDiffFingerprintField(h, []byte(current.WorktreePath))
+	writeDiffFingerprintField(h, []byte(current.BaseOID))
+	writeDiffFingerprintField(h, []byte(current.HeadOID))
+	writeDiffFingerprintField(h, []byte(current.Base))
+	writeDiffFingerprintField(h, []byte(current.MergeTargetBranch))
+	if current.HideWhitespace {
+		writeDiffFingerprintField(h, []byte{1})
+	} else {
+		writeDiffFingerprintField(h, []byte{0})
+	}
+	if !current.IncludeUntracked {
+		return DiffFingerprint(fmt.Sprintf("%x", h.Sum(nil))), nil
+	}
+
+	rawOut, err := worktreeGitOutput(
+		ctx, current.WorktreePath,
+		gitclone.DiffArgs("--raw", "-z", "--no-renames", current.BaseOID)...,
+	)
+	if err != nil {
+		span.RecordError(err)
+		return "", fmt.Errorf("fingerprint tracked changes: %w", err)
+	}
+	untrackedOut, err := worktreeGitOutput(
+		ctx, current.WorktreePath,
+		"ls-files", "--others", "--exclude-standard", "-z",
+	)
+	if err != nil {
+		span.RecordError(err)
+		return "", fmt.Errorf("fingerprint untracked changes: %w", err)
+	}
+	writeDiffFingerprintField(h, rawOut)
+	writeDiffFingerprintField(h, untrackedOut)
+	if err := fingerprintRepositoryAttributes(ctx, h, current.WorktreePath); err != nil {
+		span.RecordError(err)
+		return "", err
+	}
+
+	paths := make(map[string]struct{})
+	for _, file := range gitclone.ParseRawZ(rawOut) {
+		paths[file.Path] = struct{}{}
+	}
+	for part := range bytes.SplitSeq(untrackedOut, []byte{0}) {
+		if len(part) > 0 {
+			paths[string(part)] = struct{}{}
+		}
+	}
+	orderedPaths := make([]string, 0, len(paths))
+	for path := range paths {
+		orderedPaths = append(orderedPaths, path)
+	}
+	sort.Strings(orderedPaths)
+	var bytesRead int64
+	for _, path := range orderedPaths {
+		read, err := fingerprintWorktreePath(h, current.WorktreePath, path)
+		if err != nil {
+			span.RecordError(err)
+			return "", err
+		}
+		bytesRead += read
+	}
+	span.SetAttributes(
+		attribute.Int("workspace.diff.fingerprint_paths", len(orderedPaths)),
+		attribute.Int64("workspace.diff.fingerprint_bytes_read", bytesRead),
+	)
+	return DiffFingerprint(fmt.Sprintf("%x", h.Sum(nil))), nil
+}
+
+func fingerprintRepositoryAttributes(
+	ctx context.Context,
+	h hash.Hash,
+	dir string,
+) error {
+	out, err := worktreeGitOutput(ctx, dir, "rev-parse", "--git-path", "info/attributes")
+	if err != nil {
+		return fmt.Errorf("resolve repository attributes: %w", err)
+	}
+	path := strings.TrimSpace(string(out))
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(dir, path)
+	}
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		writeDiffFingerprintField(h, []byte("attributes-missing"))
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read repository attributes: %w", err)
+	}
+	writeDiffFingerprintField(h, data)
+	return nil
+}
+
+func fingerprintWorktreePath(h hash.Hash, dir, path string) (int64, error) {
+	clean, err := cleanWorktreeDiffPath(path)
+	if err != nil {
+		return 0, err
+	}
+	writeDiffFingerprintField(h, []byte(clean))
+	fullPath := filepath.Join(dir, filepath.FromSlash(clean))
+	info, err := os.Lstat(fullPath)
+	if errors.Is(err, os.ErrNotExist) {
+		writeDiffFingerprintField(h, []byte("missing"))
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	writeDiffFingerprintField(h, []byte(info.Mode().String()))
+	if info.Mode()&os.ModeSymlink != 0 {
+		target, err := os.Readlink(fullPath)
+		if err != nil {
+			return 0, err
+		}
+		writeDiffFingerprintField(h, []byte(target))
+		return 0, nil
+	}
+	if !info.Mode().IsRegular() {
+		return 0, nil
+	}
+	digest, bytesRead, err := diffContentDigest(fullPath, info)
+	if err != nil {
+		return 0, err
+	}
+	writeDiffFingerprintField(h, digest[:])
+	return bytesRead, nil
+}
+
+func diffContentDigest(path string, info os.FileInfo) ([sha256.Size]byte, int64, error) {
+	identity := fmt.Sprintf(
+		"%d|%d|%s|%#v",
+		info.Size(), info.ModTime().UnixNano(), info.Mode(), info.Sys(),
+	)
+	now := time.Now()
+	diffContentDigests.Lock()
+	if cached, ok := diffContentDigests.entries[path]; ok && cached.identity == identity {
+		cached.usedAt = now
+		diffContentDigests.entries[path] = cached
+		diffContentDigests.Unlock()
+		return cached.digest, 0, nil
+	}
+	diffContentDigests.Unlock()
+
+	file, err := os.Open(path)
+	if err != nil {
+		return [sha256.Size]byte{}, 0, err
+	}
+	defer file.Close()
+	digestHash := sha256.New()
+	bytesRead, err := io.Copy(digestHash, file)
+	if err != nil {
+		return [sha256.Size]byte{}, bytesRead, err
+	}
+	var digest [sha256.Size]byte
+	copy(digest[:], digestHash.Sum(nil))
+
+	diffContentDigests.Lock()
+	diffContentDigests.entries[path] = diffContentDigestEntry{
+		identity: identity,
+		digest:   digest,
+		usedAt:   now,
+	}
+	if len(diffContentDigests.entries) > maxDiffContentDigestEntries {
+		var oldestPath string
+		var oldest time.Time
+		for candidatePath, candidate := range diffContentDigests.entries {
+			if oldestPath == "" || candidate.usedAt.Before(oldest) {
+				oldestPath = candidatePath
+				oldest = candidate.usedAt
+			}
+		}
+		delete(diffContentDigests.entries, oldestPath)
+	}
+	diffContentDigests.Unlock()
+	return digest, bytesRead, nil
+}
+
+func writeDiffFingerprintField(h hash.Hash, value []byte) {
+	var size [8]byte
+	binary.LittleEndian.PutUint64(size[:], uint64(len(value)))
+	_, _ = h.Write(size[:])
+	_, _ = h.Write(value)
+}
+
+func PrepareDiffSnapshot(
+	ctx context.Context,
+	resolved ResolvedDiffSnapshotSpec,
+) (*gitclone.DiffResult, error) {
+	ctx, span := workspaceDiffTracer.Start(ctx, "workspace.diff.prepare")
+	defer span.End()
+	headRef := ""
+	if !resolved.IncludeUntracked {
+		headRef = resolved.HeadOID
+	}
+	result, err := worktreeDiffFromRefsPath(
+		ctx,
+		resolved.WorktreePath,
+		resolved.BaseOID,
+		headRef,
+		resolved.HideWhitespace,
+		"",
+		resolved.IncludeUntracked,
+	)
+	if err != nil {
+		span.RecordError(err)
+		return nil, err
+	}
+	span.SetAttributes(attribute.Int("workspace.diff.file_count", len(result.Files)))
+	return result, nil
+}
+
+func ReadDiffSnapshotFile(
+	ctx context.Context,
+	resolved ResolvedDiffSnapshotSpec,
+	file gitclone.DiffFile,
+	side string,
+	maxBytes int64,
+) (*gitclone.FileContent, error) {
+	ref := resolved.HeadOID
+	previewPath := file.Path
+	useWorktree := resolved.IncludeUntracked
+	switch side {
+	case "old":
+		if file.Status == "added" {
+			return nil, gitclone.ErrNotFound
+		}
+		ref = resolved.BaseOID
+		previewPath = file.OldPath
+		if previewPath == "" {
+			previewPath = file.Path
+		}
+		useWorktree = false
+	case "new":
+		if file.Status == "deleted" {
+			return nil, gitclone.ErrNotFound
+		}
+	case "":
+		if file.Status == "deleted" {
+			ref = resolved.BaseOID
+			previewPath = file.OldPath
+			if previewPath == "" {
+				previewPath = file.Path
+			}
+			useWorktree = false
+		}
+	default:
+		return nil, errors.New("side must be old or new")
+	}
+
+	previewPath, err := cleanWorktreeDiffPath(previewPath)
+	if err != nil {
+		return nil, err
+	}
+	if useWorktree {
+		return readWorktreeFileContent(resolved.WorktreePath, previewPath, maxBytes)
+	}
+	return worktreeBlobContent(ctx, resolved.WorktreePath, ref, previewPath, maxBytes)
+}

--- a/internal/workspace/diff_snapshot_test.go
+++ b/internal/workspace/diff_snapshot_test.go
@@ -1,6 +1,7 @@
 package workspace
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/middleman/internal/gitclone"
 )
 
 func TestResolveDiffSnapshotSpec(t *testing.T) {
@@ -53,6 +55,18 @@ func TestFingerprintDiffSnapshotDetectsDirtyContentWithoutSizeChange(t *testing.
 	assert.NotEqual(t, first, second)
 }
 
+func TestDiffContentDigestHonorsCancellation(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "large.txt")
+	require.NoError(t, os.WriteFile(path, make([]byte, 1<<20), 0o600))
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, _, err := diffContentDigest(ctx, path)
+
+	require.ErrorIs(t, err, context.Canceled)
+}
+
 func TestFingerprintDiffSnapshotDetectsUntrackedContentChange(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
@@ -73,6 +87,35 @@ func TestFingerprintDiffSnapshotDetectsUntrackedContentChange(t *testing.T) {
 	second, err := FingerprintDiffSnapshot(t.Context(), resolved)
 	require.NoError(err)
 	assert.NotEqual(t, first, second)
+}
+
+func TestFingerprintDiffSnapshotRejectsIntermediateSymlink(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	work := t.TempDir()
+	outside := t.TempDir()
+
+	runWorkspaceTestGit(t, work, "init", "--initial-branch=main")
+	runWorkspaceTestGit(t, work, "config", "user.email", "t@test.com")
+	runWorkspaceTestGit(t, work, "config", "user.name", "Test")
+	require.NoError(os.MkdirAll(filepath.Join(work, "nested"), 0o755))
+	require.NoError(os.WriteFile(filepath.Join(work, "nested", "tracked.txt"), []byte("inside\n"), 0o644))
+	runWorkspaceTestGit(t, work, "add", "nested/tracked.txt")
+	runWorkspaceTestGit(t, work, "commit", "-m", "fixture")
+
+	require.NoError(os.WriteFile(filepath.Join(outside, "tracked.txt"), []byte("outside\n"), 0o600))
+	require.NoError(os.RemoveAll(filepath.Join(work, "nested")))
+	require.NoError(os.Symlink(outside, filepath.Join(work, "nested")))
+
+	resolved, ok, err := ResolveDiffSnapshotSpec(t.Context(), DiffSnapshotSpec{
+		WorktreePath: work,
+		Base:         WorktreeDiffBaseHead,
+	})
+	require.NoError(err)
+	require.True(ok)
+
+	_, err = FingerprintDiffSnapshot(t.Context(), resolved)
+	require.Error(err)
 }
 
 func TestFingerprintDiffSnapshotDetectsRepositoryAttributeChange(t *testing.T) {
@@ -126,6 +169,80 @@ func TestFingerprintDiffSnapshotRangeIgnoresWorktree(t *testing.T) {
 	second, err := FingerprintDiffSnapshot(t.Context(), resolved)
 	require.NoError(err)
 	assert.Equal(t, first, second)
+}
+
+func TestFingerprintDiffSnapshotRangeDetectsRepositoryAttributeChange(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	assert := assert.New(t)
+	work := setupDivergenceWorktree(t)
+	from := strings.TrimSpace(string(runWorkspaceTestGit(t, work, "rev-parse", "HEAD^")))
+	to := strings.TrimSpace(string(runWorkspaceTestGit(t, work, "rev-parse", "HEAD")))
+
+	resolved, ok, err := ResolveDiffSnapshotSpec(t.Context(), DiffSnapshotSpec{
+		WorktreePath: work,
+		FromSHA:      from,
+		ToSHA:        to,
+	})
+	require.NoError(err)
+	require.True(ok)
+	first, err := FingerprintDiffSnapshot(t.Context(), resolved)
+	require.NoError(err)
+
+	gitDir := strings.TrimSpace(string(runWorkspaceTestGit(t, work, "rev-parse", "--git-dir")))
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(work, gitDir)
+	}
+	require.NoError(os.MkdirAll(filepath.Join(gitDir, "info"), 0o755))
+	require.NoError(os.WriteFile(filepath.Join(gitDir, "info", "attributes"), []byte("*.txt linguist-generated\n"), 0o644))
+	second, err := FingerprintDiffSnapshot(t.Context(), resolved)
+	require.NoError(err)
+	assert.NotEqual(first, second)
+}
+
+func TestPrepareDiffSnapshotRangeUsesCommittedAttributes(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	work := setupDivergenceWorktree(t)
+	from := strings.TrimSpace(string(runWorkspaceTestGit(t, work, "rev-parse", "HEAD^")))
+	to := strings.TrimSpace(string(runWorkspaceTestGit(t, work, "rev-parse", "HEAD")))
+	require.NoError(os.WriteFile(
+		filepath.Join(work, ".gitattributes"),
+		[]byte("*.txt linguist-generated\n"),
+		0o644,
+	))
+
+	resolved, ok, err := ResolveDiffSnapshotSpec(t.Context(), DiffSnapshotSpec{
+		WorktreePath: work,
+		FromSHA:      from,
+		ToSHA:        to,
+	})
+	require.NoError(err)
+	require.True(ok)
+	diff, err := PrepareDiffSnapshot(t.Context(), resolved)
+	require.NoError(err)
+	require.Len(diff.Files, 1)
+	assert.False(t, diff.Files[0].IsGenerated)
+}
+
+func TestReadDiffSnapshotFileRejectsIntermediateSymlink(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	worktree := t.TempDir()
+	outside := t.TempDir()
+	require.NoError(os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("secret\n"), 0o600))
+	require.NoError(os.Symlink(outside, filepath.Join(worktree, "nested")))
+	resolved := ResolvedDiffSnapshotSpec{
+		DiffSnapshotSpec: DiffSnapshotSpec{WorktreePath: worktree},
+		IncludeUntracked: true,
+	}
+
+	content, err := ReadDiffSnapshotFile(
+		t.Context(), resolved, gitclone.DiffFile{Path: "nested/secret.txt", Status: "modified"}, "new", 1024,
+	)
+
+	require.Error(err)
+	assert.Nil(t, content)
 }
 
 func TestPrepareDiffSnapshotUsesResolvedInputs(t *testing.T) {

--- a/internal/workspace/diff_snapshot_test.go
+++ b/internal/workspace/diff_snapshot_test.go
@@ -1,0 +1,150 @@
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveDiffSnapshotSpec(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	assert := assert.New(t)
+	work := setupDivergenceWorktree(t)
+
+	resolved, ok, err := ResolveDiffSnapshotSpec(t.Context(), DiffSnapshotSpec{
+		WorktreePath: work,
+		Base:         WorktreeDiffBaseHead,
+	})
+
+	require.NoError(err)
+	require.True(ok)
+	assert.Equal(WorktreeDiffBaseHead, resolved.Base)
+	assert.Equal("HEAD", resolved.BaseRef)
+	assert.Len(resolved.BaseOID, 40)
+	assert.Len(resolved.HeadOID, 40)
+	assert.True(resolved.IncludeUntracked)
+	assert.Equal(filepath.Clean(work), resolved.WorktreePath)
+}
+
+func TestFingerprintDiffSnapshotDetectsDirtyContentWithoutSizeChange(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	work := setupDivergenceWorktree(t)
+	path := filepath.Join(work, "f.txt")
+
+	require.NoError(os.WriteFile(path, []byte("a1\n"), 0o644))
+	resolved, ok, err := ResolveDiffSnapshotSpec(t.Context(), DiffSnapshotSpec{
+		WorktreePath: work,
+		Base:         WorktreeDiffBaseHead,
+	})
+	require.NoError(err)
+	require.True(ok)
+	first, err := FingerprintDiffSnapshot(t.Context(), resolved)
+	require.NoError(err)
+
+	require.NoError(os.WriteFile(path, []byte("b1\n"), 0o644))
+	second, err := FingerprintDiffSnapshot(t.Context(), resolved)
+	require.NoError(err)
+	assert.NotEqual(t, first, second)
+}
+
+func TestFingerprintDiffSnapshotDetectsUntrackedContentChange(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	work := setupDivergenceWorktree(t)
+	path := filepath.Join(work, "new.txt")
+
+	require.NoError(os.WriteFile(path, []byte("a1\n"), 0o644))
+	resolved, ok, err := ResolveDiffSnapshotSpec(t.Context(), DiffSnapshotSpec{
+		WorktreePath: work,
+		Base:         WorktreeDiffBaseHead,
+	})
+	require.NoError(err)
+	require.True(ok)
+	first, err := FingerprintDiffSnapshot(t.Context(), resolved)
+	require.NoError(err)
+
+	require.NoError(os.WriteFile(path, []byte("b1\n"), 0o644))
+	second, err := FingerprintDiffSnapshot(t.Context(), resolved)
+	require.NoError(err)
+	assert.NotEqual(t, first, second)
+}
+
+func TestFingerprintDiffSnapshotDetectsRepositoryAttributeChange(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	work := setupDivergenceWorktree(t)
+	require.NoError(os.WriteFile(filepath.Join(work, "f.txt"), []byte("dirty\n"), 0o644))
+
+	resolved, ok, err := ResolveDiffSnapshotSpec(t.Context(), DiffSnapshotSpec{
+		WorktreePath: work,
+		Base:         WorktreeDiffBaseHead,
+	})
+	require.NoError(err)
+	require.True(ok)
+	first, err := FingerprintDiffSnapshot(t.Context(), resolved)
+	require.NoError(err)
+
+	gitDir := strings.TrimSpace(string(runWorkspaceTestGit(t, work, "rev-parse", "--git-dir")))
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(work, gitDir)
+	}
+	require.NoError(os.MkdirAll(filepath.Join(gitDir, "info"), 0o755))
+	require.NoError(os.WriteFile(
+		filepath.Join(gitDir, "info", "attributes"),
+		[]byte("*.txt linguist-generated\n"),
+		0o644,
+	))
+	second, err := FingerprintDiffSnapshot(t.Context(), resolved)
+	require.NoError(err)
+	assert.NotEqual(t, first, second)
+}
+
+func TestFingerprintDiffSnapshotRangeIgnoresWorktree(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	work := setupDivergenceWorktree(t)
+	from := strings.TrimSpace(string(runWorkspaceTestGit(t, work, "rev-parse", "HEAD^")))
+	to := strings.TrimSpace(string(runWorkspaceTestGit(t, work, "rev-parse", "HEAD")))
+
+	resolved, ok, err := ResolveDiffSnapshotSpec(t.Context(), DiffSnapshotSpec{
+		WorktreePath: work,
+		FromSHA:      from,
+		ToSHA:        to,
+	})
+	require.NoError(err)
+	require.True(ok)
+	first, err := FingerprintDiffSnapshot(t.Context(), resolved)
+	require.NoError(err)
+
+	require.NoError(os.WriteFile(filepath.Join(work, "unrelated.txt"), []byte("dirty\n"), 0o644))
+	second, err := FingerprintDiffSnapshot(t.Context(), resolved)
+	require.NoError(err)
+	assert.Equal(t, first, second)
+}
+
+func TestPrepareDiffSnapshotUsesResolvedInputs(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	assert := assert.New(t)
+	work := setupDivergenceWorktree(t)
+	require.NoError(os.WriteFile(filepath.Join(work, "f.txt"), []byte("f1  \n"), 0o644))
+
+	resolved, ok, err := ResolveDiffSnapshotSpec(t.Context(), DiffSnapshotSpec{
+		WorktreePath: work,
+		Base:         WorktreeDiffBaseHead,
+	})
+	require.NoError(err)
+	require.True(ok)
+	diff, err := PrepareDiffSnapshot(t.Context(), resolved)
+	require.NoError(err)
+	require.Len(diff.Files, 1)
+	assert.Equal("f.txt", diff.Files[0].Path)
+	assert.True(diff.Files[0].IsWhitespaceOnly)
+	assert.Equal(1, diff.WhitespaceOnlyCount)
+}

--- a/internal/workspace/diff_snapshot_unix_test.go
+++ b/internal/workspace/diff_snapshot_unix_test.go
@@ -1,0 +1,21 @@
+//go:build unix
+
+package workspace
+
+import (
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiffContentDigestRejectsFIFOWithoutBlocking(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "changed.fifo")
+	require.NoError(t, syscall.Mkfifo(path, 0o600))
+
+	_, _, err := diffContentDigest(t.Context(), path)
+
+	require.ErrorContains(t, err, "not a regular file")
+}

--- a/internal/workspace/diff_test.go
+++ b/internal/workspace/diff_test.go
@@ -2,14 +2,146 @@ package workspace
 
 import (
 	"bytes"
+	"context"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"testing/synctest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestRunUntrackedPathReadsDoesNotSerializeFiles(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name           string
+		limit          int
+		runCount       int
+		pathCount      int
+		wantConcurrent int
+	}{
+		{name: "paths below budget", limit: 4, runCount: 1, pathCount: 2, wantConcurrent: 2},
+		{name: "concurrent runs share budget", limit: 3, runCount: 2, pathCount: 5, wantConcurrent: 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			synctest.Test(t, func(t *testing.T) {
+				pool := newUntrackedReadPool(tt.limit)
+				paths := make([]string, tt.pathCount)
+				for i := range paths {
+					paths[i] = fmt.Sprintf("file-%d", i)
+				}
+				started := make(chan struct{}, tt.runCount*tt.pathCount)
+				release := make(chan struct{})
+				done := make(chan error, tt.runCount)
+				for range tt.runCount {
+					go func() {
+						done <- pool.run(t.Context(), paths, func(_ context.Context, _ int, _ string) error {
+							started <- struct{}{}
+							<-release
+							return nil
+						})
+					}()
+				}
+
+				synctest.Wait()
+				assert.Len(t, started, tt.wantConcurrent)
+				close(release)
+				synctest.Wait()
+				for range tt.runCount {
+					require.NoError(t, <-done)
+				}
+			})
+		})
+	}
+}
+
+func TestUntrackedFileReadsRespectCancellation(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "file.txt"), []byte("content\n"), 0o600))
+
+	tests := []struct {
+		name string
+		read func(context.Context) error
+	}{
+		{
+			name: "path enumeration",
+			read: func(ctx context.Context) error {
+				_, err := worktreeUntrackedFilesFromPaths(ctx, root, []string{"file.txt"}, true, false)
+				return err
+			},
+		},
+		{
+			name: "file content",
+			read: func(ctx context.Context) error {
+				_, _, err := readUntrackedFileContent(ctx, root, "file.txt")
+				return err
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, cancel := context.WithCancel(t.Context())
+			cancel()
+			require.ErrorIs(t, tt.read(ctx), context.Canceled)
+		})
+	}
+}
+
+func TestReadAllWithContextStopsBetweenReads(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(t.Context())
+	reader, writer := io.Pipe()
+	t.Cleanup(func() {
+		_ = reader.Close()
+		_ = writer.Close()
+	})
+	go func() {
+		_, _ = writer.Write([]byte("first"))
+		cancel()
+		_ = writer.Close()
+	}()
+
+	_, err := readAllWithContext(ctx, reader, 1024)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestReadUntrackedFileContentRejectsIntermediateSymlink(t *testing.T) {
+	t.Parallel()
+	requirements := require.New(t)
+	worktree := t.TempDir()
+	outside := t.TempDir()
+	requirements.NoError(os.Mkdir(filepath.Join(worktree, "safe"), 0o700))
+	requirements.NoError(os.WriteFile(filepath.Join(worktree, "safe", "file.txt"), []byte("safe\n"), 0o600))
+	requirements.NoError(os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("secret\n"), 0o600))
+	requirements.NoError(os.Symlink(outside, filepath.Join(worktree, "linked")))
+
+	tests := []struct {
+		name     string
+		path     string
+		wantOK   bool
+		wantData string
+	}{
+		{name: "nested regular file", path: "safe/file.txt", wantOK: true, wantData: "safe\n"},
+		{name: "intermediate symlink", path: "linked/secret.txt"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			content, ok, err := readUntrackedFileContent(t.Context(), worktree, tt.path)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantData, string(content))
+		})
+	}
+}
 
 func TestWorktreeDiffFilesAgainstHead(t *testing.T) {
 	require := require.New(t)

--- a/internal/workspace/diff_totals.go
+++ b/internal/workspace/diff_totals.go
@@ -35,7 +35,11 @@ func WorktreeDiffTotals(
 	if err != nil || !ok {
 		return 0, 0, ok, err
 	}
-	return added + worktreeUntrackedAdditions(ctx, dir), removed, true, nil
+	untracked, err := worktreeUntrackedAdditions(ctx, dir)
+	if err != nil {
+		return 0, 0, false, err
+	}
+	return added + untracked, removed, true, nil
 }
 
 // worktreeTrackedDiffTotals sums the tracked-file diff against the first base
@@ -166,12 +170,16 @@ func worktreeNumstatAgainst(
 
 // worktreeUntrackedAdditions sums the line counts of untracked text files,
 // reusing the sidebar's untracked-file path so binary files contribute zero.
-func worktreeUntrackedAdditions(ctx context.Context, dir string) int {
+func worktreeUntrackedAdditions(ctx context.Context, dir string) (int, error) {
+	files, err := worktreeUntrackedFiles(ctx, dir, false, false)
+	if err != nil {
+		return 0, err
+	}
 	total := 0
-	for _, file := range worktreeUntrackedFiles(ctx, dir, false, false) {
+	for _, file := range files {
 		total += file.Additions
 	}
-	return total
+	return total, nil
 }
 
 // sumWorktreeNumstatZ totals the added/removed counts across all files in a

--- a/internal/workspace/diff_unix.go
+++ b/internal/workspace/diff_unix.go
@@ -9,7 +9,7 @@ import (
 )
 
 func openRegularUntrackedFile(path string) (*os.File, os.FileInfo, error) {
-	file, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
+	file, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW|syscall.O_NONBLOCK, 0)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -23,4 +23,8 @@ func openRegularUntrackedFile(path string) (*os.File, os.FileInfo, error) {
 		return nil, nil, errors.New("untracked path is not a regular file")
 	}
 	return file, info, nil
+}
+
+func openWorktreeFile(root *os.Root, path string) (*os.File, error) {
+	return root.OpenFile(path, os.O_RDONLY|syscall.O_NONBLOCK, 0)
 }

--- a/internal/workspace/diff_whitespace.go
+++ b/internal/workspace/diff_whitespace.go
@@ -1,0 +1,88 @@
+package workspace
+
+import "go.kenn.io/middleman/internal/gitclone"
+
+func isGitWhitespace(b byte) bool {
+	switch b {
+	case ' ', '\t', '\n', '\v', '\f', '\r':
+		return true
+	default:
+		return false
+	}
+}
+
+// gitWhitespaceRecordEqual matches xdiff's XDF_IGNORE_WHITESPACE record
+// comparison: ASCII C-locale whitespace is discarded while line records keep
+// their order and cardinality.
+func gitWhitespaceRecordEqual(left, right string) bool {
+	i, j := 0, 0
+	for {
+		for i < len(left) && isGitWhitespace(left[i]) {
+			i++
+		}
+		for j < len(right) && isGitWhitespace(right[j]) {
+			j++
+		}
+		if i == len(left) || j == len(right) {
+			for i < len(left) && isGitWhitespace(left[i]) {
+				i++
+			}
+			for j < len(right) && isGitWhitespace(right[j]) {
+				j++
+			}
+			return i == len(left) && j == len(right)
+		}
+		if left[i] != right[j] {
+			return false
+		}
+		i++
+		j++
+	}
+}
+
+func classifyWhitespaceOnly(files []gitclone.DiffFile) int {
+	count := 0
+	for i := range files {
+		file := &files[i]
+		if file.Status != "modified" || file.IsBinary || len(file.Hunks) == 0 {
+			continue
+		}
+		whitespaceOnly := true
+		for _, hunk := range file.Hunks {
+			if !hunkWhitespaceOnly(hunk) {
+				whitespaceOnly = false
+				break
+			}
+		}
+		file.IsWhitespaceOnly = whitespaceOnly
+		if whitespaceOnly {
+			count++
+		}
+	}
+	return count
+}
+
+func hunkWhitespaceOnly(hunk gitclone.Hunk) bool {
+	oldRecords := make([]string, 0, hunk.OldCount)
+	newRecords := make([]string, 0, hunk.NewCount)
+	for _, line := range hunk.Lines {
+		switch line.Type {
+		case "context":
+			oldRecords = append(oldRecords, line.Content)
+			newRecords = append(newRecords, line.Content)
+		case "delete":
+			oldRecords = append(oldRecords, line.Content)
+		case "add":
+			newRecords = append(newRecords, line.Content)
+		}
+	}
+	if len(oldRecords) != len(newRecords) {
+		return false
+	}
+	for i := range oldRecords {
+		if !gitWhitespaceRecordEqual(oldRecords[i], newRecords[i]) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/workspace/diff_whitespace.go
+++ b/internal/workspace/diff_whitespace.go
@@ -1,6 +1,21 @@
 package workspace
 
-import "go.kenn.io/middleman/internal/gitclone"
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"hash"
+	"io"
+	"strconv"
+	"strings"
+
+	gitcmd "go.kenn.io/kit/git/cmd"
+	"go.kenn.io/middleman/internal/gitclone"
+	"go.kenn.io/middleman/internal/procutil"
+)
 
 func isGitWhitespace(b byte) bool {
 	switch b {
@@ -44,7 +59,86 @@ func classifyWhitespaceOnly(
 	files []gitclone.DiffFile,
 	modeChanged map[string]bool,
 ) int {
+	count, _ := classifyWhitespaceOnlyCandidates(files, modeChanged)
+	return count
+}
+
+func classifyWorkspaceWhitespaceOnly(
+	ctx context.Context,
+	dir string,
+	baseRef string,
+	headRef string,
+	includeUntracked bool,
+	files []gitclone.DiffFile,
+	modeChanged map[string]bool,
+) (int, error) {
+	if len(files) == 0 {
+		return 0, nil
+	}
+	count, candidates := classifyWhitespaceOnlyCandidates(files, modeChanged)
+	if len(candidates) == 0 {
+		return count, nil
+	}
+
+	type candidateContent struct {
+		index   int
+		oldSpec string
+		newSpec string
+	}
+	candidateContents := make([]candidateContent, 0, len(candidates))
+	objectSpecs := make([]string, 0, len(candidates)*2)
+	for _, index := range candidates {
+		file := files[index]
+		oldPath := file.OldPath
+		if oldPath == "" {
+			oldPath = file.Path
+		}
+		if strings.ContainsAny(oldPath, "\r\n") || strings.ContainsAny(file.Path, "\r\n") {
+			continue
+		}
+		candidate := candidateContent{
+			index:   index,
+			oldSpec: baseRef + ":" + oldPath,
+		}
+		objectSpecs = append(objectSpecs, candidate.oldSpec)
+		if !includeUntracked {
+			candidate.newSpec = headRef + ":" + file.Path
+			objectSpecs = append(objectSpecs, candidate.newSpec)
+		}
+		candidateContents = append(candidateContents, candidate)
+	}
+	blobs, err := readWhitespaceBlobDigests(ctx, dir, objectSpecs)
+	if err != nil {
+		return 0, err
+	}
+	for _, candidate := range candidateContents {
+		oldDigest := blobs[candidate.oldSpec]
+		var newDigest [sha256.Size]byte
+		if candidate.newSpec != "" {
+			newDigest = blobs[candidate.newSpec]
+		} else {
+			var readErr error
+			newDigest, readErr = readWorktreeWhitespaceDigest(
+				ctx, dir, files[candidate.index].Path,
+			)
+			if readErr != nil {
+				return 0, fmt.Errorf("read whitespace candidate %q: %w", files[candidate.index].Path, readErr)
+			}
+		}
+		if oldDigest == newDigest {
+			files[candidate.index].IsWhitespaceOnly = true
+			count++
+		}
+	}
+	return count, nil
+}
+
+func classifyWhitespaceOnlyCandidates(
+	files []gitclone.DiffFile,
+	modeChanged map[string]bool,
+) (int, []int) {
 	count := 0
+	candidates := make([]int, 0)
 	for i := range files {
 		file := &files[i]
 		if file.Status != "modified" || file.IsBinary || modeChanged[file.Path] || len(file.Hunks) == 0 {
@@ -57,12 +151,16 @@ func classifyWhitespaceOnly(
 				break
 			}
 		}
-		file.IsWhitespaceOnly = whitespaceOnly
 		if whitespaceOnly {
+			file.IsWhitespaceOnly = true
 			count++
+			continue
+		}
+		if hunksWhitespaceRecordsEqual(file.Hunks) {
+			candidates = append(candidates, i)
 		}
 	}
-	return count
+	return count, candidates
 }
 
 func hunkWhitespaceOnly(hunk gitclone.Hunk) bool {
@@ -79,13 +177,227 @@ func hunkWhitespaceOnly(hunk gitclone.Hunk) bool {
 			newRecords = append(newRecords, line.Content)
 		}
 	}
-	if len(oldRecords) != len(newRecords) {
+	return gitWhitespaceRecordsEqual(oldRecords, newRecords)
+}
+
+func hunksWhitespaceRecordsEqual(hunks []gitclone.Hunk) bool {
+	oldRecords := make([]string, 0)
+	newRecords := make([]string, 0)
+	for _, hunk := range hunks {
+		for _, line := range hunk.Lines {
+			switch line.Type {
+			case "context":
+				oldRecords = append(oldRecords, line.Content)
+				newRecords = append(newRecords, line.Content)
+			case "delete":
+				oldRecords = append(oldRecords, line.Content)
+			case "add":
+				newRecords = append(newRecords, line.Content)
+			}
+		}
+	}
+	return gitWhitespaceRecordsEqual(oldRecords, newRecords)
+}
+
+func gitWhitespaceRecordsEqual(left, right []string) bool {
+	if len(left) != len(right) {
 		return false
 	}
-	for i := range oldRecords {
-		if !gitWhitespaceRecordEqual(oldRecords[i], newRecords[i]) {
+	for i := range left {
+		if !gitWhitespaceRecordEqual(left[i], right[i]) {
 			return false
 		}
 	}
 	return true
+}
+
+type gitWhitespaceDigestWriter struct {
+	ctx        context.Context
+	fileHash   hash.Hash
+	recordHash hash.Hash
+	finished   bool
+}
+
+func newGitWhitespaceDigestWriter(ctx context.Context) *gitWhitespaceDigestWriter {
+	return &gitWhitespaceDigestWriter{
+		ctx:        ctx,
+		fileHash:   sha256.New(),
+		recordHash: sha256.New(),
+	}
+}
+
+func (w *gitWhitespaceDigestWriter) Write(data []byte) (int, error) {
+	if err := w.ctx.Err(); err != nil {
+		return 0, err
+	}
+	normalized := make([]byte, 0, len(data))
+	flush := func() {
+		if len(normalized) == 0 {
+			return
+		}
+		_, _ = w.recordHash.Write(normalized)
+		normalized = normalized[:0]
+	}
+	for _, b := range data {
+		if b == '\n' {
+			flush()
+			w.finishRecord()
+			continue
+		}
+		if !isGitWhitespace(b) {
+			normalized = append(normalized, b)
+		}
+	}
+	flush()
+	return len(data), nil
+}
+
+func (w *gitWhitespaceDigestWriter) finishRecord() {
+	_, _ = w.fileHash.Write(w.recordHash.Sum(nil))
+	w.recordHash.Reset()
+}
+
+func (w *gitWhitespaceDigestWriter) sum() [sha256.Size]byte {
+	if !w.finished {
+		w.finishRecord()
+		w.finished = true
+	}
+	var digest [sha256.Size]byte
+	copy(digest[:], w.fileHash.Sum(nil))
+	return digest
+}
+
+func gitWhitespaceDigest(reader io.Reader, size int64) ([sha256.Size]byte, error) {
+	return gitWhitespaceDigestContext(context.Background(), reader, size)
+}
+
+func gitWhitespaceDigestContext(
+	ctx context.Context,
+	reader io.Reader,
+	size int64,
+) ([sha256.Size]byte, error) {
+	if size < 0 {
+		return [sha256.Size]byte{}, errors.New("negative whitespace content size")
+	}
+	destination := newGitWhitespaceDigestWriter(ctx)
+	if _, err := io.CopyN(destination, reader, size); err != nil {
+		return [sha256.Size]byte{}, err
+	}
+	return destination.sum(), nil
+}
+
+func readWorktreeWhitespaceDigest(
+	ctx context.Context,
+	dir string,
+	path string,
+) ([sha256.Size]byte, error) {
+	clean, err := cleanWorktreeDiffPath(path)
+	if err != nil {
+		return [sha256.Size]byte{}, err
+	}
+	opened, err := openWorktreePath(dir, clean)
+	if err != nil {
+		return [sha256.Size]byte{}, err
+	}
+	if opened.file == nil {
+		data := []byte(opened.symlinkTarget)
+		return gitWhitespaceDigest(bytes.NewReader(data), int64(len(data)))
+	}
+	defer opened.file.Close()
+	return gitWhitespaceDigestContext(ctx, opened.file, opened.info.Size())
+}
+
+func readWhitespaceBlobDigests(
+	ctx context.Context,
+	dir string,
+	objectSpecs []string,
+) (map[string][sha256.Size]byte, error) {
+	unique := make([]string, 0, len(objectSpecs))
+	seen := make(map[string]struct{}, len(objectSpecs))
+	for _, spec := range objectSpecs {
+		if _, ok := seen[spec]; ok {
+			continue
+		}
+		seen[spec] = struct{}{}
+		unique = append(unique, spec)
+	}
+	if len(unique) == 0 {
+		return map[string][sha256.Size]byte{}, nil
+	}
+	if dir == "" {
+		return nil, errors.New("empty worktree dir")
+	}
+	cmd := gitcmd.New().Command(ctx, dir, "cat-file", "--batch")
+	cmd.Stdin = strings.NewReader(strings.Join(unique, "\n") + "\n")
+	reader, writer := io.Pipe()
+	cmd.Stdout = writer
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	type parseResult struct {
+		digests map[string][sha256.Size]byte
+		err     error
+	}
+	parsed := make(chan parseResult, 1)
+	go func() {
+		digests, err := parseWhitespaceBlobDigests(ctx, reader, unique)
+		parsed <- parseResult{digests: digests, err: err}
+		if err != nil {
+			_ = reader.CloseWithError(err)
+		}
+	}()
+	runErr := procutil.Run(ctx, cmd, "git workspace diff subprocess capacity")
+	_ = writer.Close()
+	parse := <-parsed
+	_ = reader.Close()
+	if parse.err != nil {
+		if runErr != nil {
+			return nil, fmt.Errorf(
+				"parse whitespace candidate blobs: %v; git cat-file: %w: %s",
+				parse.err,
+				runErr,
+				strings.TrimSpace(stderr.String()),
+			)
+		}
+		return nil, parse.err
+	}
+	if runErr != nil {
+		return nil, fmt.Errorf(
+			"read whitespace candidate blobs: %w: %s",
+			runErr, strings.TrimSpace(stderr.String()),
+		)
+	}
+	return parse.digests, nil
+}
+
+func parseWhitespaceBlobDigests(
+	ctx context.Context,
+	input io.Reader,
+	specs []string,
+) (map[string][sha256.Size]byte, error) {
+	reader := bufio.NewReader(input)
+	result := make(map[string][sha256.Size]byte, len(specs))
+	for _, spec := range specs {
+		header, readErr := reader.ReadString('\n')
+		if readErr != nil {
+			return nil, fmt.Errorf("read blob header for %q: %w", spec, readErr)
+		}
+		fields := strings.Fields(header)
+		if len(fields) != 3 || fields[1] != "blob" {
+			return nil, fmt.Errorf("read blob %q: unexpected header %q", spec, strings.TrimSpace(header))
+		}
+		size, parseErr := strconv.ParseInt(fields[2], 10, 64)
+		if parseErr != nil || size < 0 {
+			return nil, fmt.Errorf("read blob %q: invalid size %q", spec, fields[2])
+		}
+		digest, readErr := gitWhitespaceDigestContext(ctx, reader, size)
+		if readErr != nil {
+			return nil, fmt.Errorf("read blob %q content: %w", spec, readErr)
+		}
+		terminator, readErr := reader.ReadByte()
+		if readErr != nil || terminator != '\n' {
+			return nil, fmt.Errorf("read blob %q terminator", spec)
+		}
+		result[spec] = digest
+	}
+	return result, nil
 }

--- a/internal/workspace/diff_whitespace.go
+++ b/internal/workspace/diff_whitespace.go
@@ -40,11 +40,14 @@ func gitWhitespaceRecordEqual(left, right string) bool {
 	}
 }
 
-func classifyWhitespaceOnly(files []gitclone.DiffFile) int {
+func classifyWhitespaceOnly(
+	files []gitclone.DiffFile,
+	modeChanged map[string]bool,
+) int {
 	count := 0
 	for i := range files {
 		file := &files[i]
-		if file.Status != "modified" || file.IsBinary || len(file.Hunks) == 0 {
+		if file.Status != "modified" || file.IsBinary || modeChanged[file.Path] || len(file.Hunks) == 0 {
 			continue
 		}
 		whitespaceOnly := true

--- a/internal/workspace/diff_whitespace_test.go
+++ b/internal/workspace/diff_whitespace_test.go
@@ -1,0 +1,117 @@
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	gitcmd "go.kenn.io/kit/git/cmd"
+	"go.kenn.io/middleman/internal/gitclone"
+)
+
+func TestGitWhitespaceRecordEqual(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name  string
+		left  string
+		right string
+		want  bool
+	}{
+		{name: "indentation", left: "\treturn value", right: "  return value", want: true},
+		{name: "vertical tab and form feed", left: "a\vb\fc", right: "abc", want: true},
+		{name: "carriage return", left: "value\r", right: "value", want: true},
+		{name: "substantive", left: "return old", right: "return new", want: false},
+		{name: "non ascii space", left: "a\u00a0b", right: "ab", want: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, gitWhitespaceRecordEqual(tt.left, tt.right))
+		})
+	}
+}
+
+func TestClassifyWhitespaceOnly(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	whitespaceHunk := gitclone.Hunk{Lines: []gitclone.Line{
+		{Type: "context", Content: "func example() {"},
+		{Type: "delete", Content: "\treturn"},
+		{Type: "add", Content: "  return"},
+		{Type: "context", Content: "}"},
+	}}
+	substantiveHunk := gitclone.Hunk{Lines: []gitclone.Line{
+		{Type: "delete", Content: "old"},
+		{Type: "add", Content: "new"},
+	}}
+	blankLineInsertion := gitclone.Hunk{Lines: []gitclone.Line{
+		{Type: "context", Content: "first"},
+		{Type: "add", Content: "  "},
+		{Type: "context", Content: "second"},
+	}}
+
+	files := []gitclone.DiffFile{
+		{Path: "whitespace.go", Status: "modified", Hunks: []gitclone.Hunk{whitespaceHunk}},
+		{Path: "mixed.go", Status: "modified", Hunks: []gitclone.Hunk{whitespaceHunk, substantiveHunk}},
+		{Path: "blank.go", Status: "modified", Hunks: []gitclone.Hunk{blankLineInsertion}},
+		{Path: "binary.dat", Status: "modified", IsBinary: true, Hunks: []gitclone.Hunk{whitespaceHunk}},
+		{Path: "renamed.go", Status: "renamed", Hunks: []gitclone.Hunk{whitespaceHunk}},
+	}
+
+	count := classifyWhitespaceOnly(files)
+
+	assert.Equal(1, count)
+	assert.True(files[0].IsWhitespaceOnly)
+	assert.False(files[1].IsWhitespaceOnly)
+	assert.False(files[2].IsWhitespaceOnly)
+	assert.False(files[3].IsWhitespaceOnly)
+	assert.False(files[4].IsWhitespaceOnly)
+}
+
+func TestClassifyWhitespaceOnlyMatchesGit(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name string
+		old  string
+		new  string
+	}{
+		{name: "indentation", old: "first\n\tvalue\nlast\n", new: "first\n  value\nlast\n"},
+		{name: "crlf", old: "first\r\nsecond\r\n", new: "first\nsecond\n"},
+		{name: "blank line insertion", old: "first\nsecond\n", new: "first\n \nsecond\n"},
+		{name: "missing final newline", old: "first\nsecond\n", new: "first\nsecond"},
+		{name: "repeated lines", old: "same\n value\nsame\n", new: "same\n\tvalue\nsame\n"},
+		{name: "mixed edit", old: "first\n old\nlast\n", new: "first\n new\nlast\n"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require := require.New(t)
+			assert := assert.New(t)
+			work := t.TempDir()
+			path := filepath.Join(work, "fixture.txt")
+
+			runWorkspaceTestGit(t, work, "init", "--initial-branch=main")
+			runWorkspaceTestGit(t, work, "config", "user.email", "t@test.com")
+			runWorkspaceTestGit(t, work, "config", "user.name", "Test")
+			require.NoError(os.WriteFile(path, []byte(tt.old), 0o644))
+			runWorkspaceTestGit(t, work, "add", "fixture.txt")
+			runWorkspaceTestGit(t, work, "commit", "-m", "fixture")
+			require.NoError(os.WriteFile(path, []byte(tt.new), 0o644))
+
+			_, _, gitErr := gitcmd.New().Run(
+				t.Context(), work, nil,
+				"diff", "--quiet", "-w", "HEAD", "--", "fixture.txt",
+			)
+			diff, ok, err := WorktreeDiff(
+				t.Context(), work, WorktreeDiffBaseHead, false,
+			)
+			require.NoError(err)
+			require.True(ok)
+			require.Len(diff.Files, 1)
+			assert.Equal(gitErr == nil, diff.Files[0].IsWhitespaceOnly)
+		})
+	}
+}

--- a/internal/workspace/diff_whitespace_test.go
+++ b/internal/workspace/diff_whitespace_test.go
@@ -1,6 +1,7 @@
 package workspace
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,6 +11,31 @@ import (
 	gitcmd "go.kenn.io/kit/git/cmd"
 	"go.kenn.io/middleman/internal/gitclone"
 )
+
+func TestGitWhitespaceDigestMatchesFileSemantics(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name  string
+		left  string
+		right string
+		want  bool
+	}{
+		{name: "indentation", left: "first\n\tvalue\n", right: "first\n  value\n", want: true},
+		{name: "blank record", left: "first\nsecond\n", right: "first\n \nsecond\n", want: false},
+		{name: "final newline", left: "first\n", right: "first", want: false},
+		{name: "substantive", left: "old\n", right: "new\n", want: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			left, err := gitWhitespaceDigest(bytes.NewBufferString(tt.left), int64(len(tt.left)))
+			require.NoError(t, err)
+			right, err := gitWhitespaceDigest(bytes.NewBufferString(tt.right), int64(len(tt.right)))
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, left == right)
+		})
+	}
+}
 
 func TestGitWhitespaceRecordEqual(t *testing.T) {
 	t.Parallel()
@@ -86,6 +112,11 @@ func TestClassifyWhitespaceOnlyMatchesGit(t *testing.T) {
 		{name: "blank line insertion", old: "first\nsecond\n", new: "first\n \nsecond\n"},
 		{name: "missing final newline", old: "first\nsecond\n", new: "first\nsecond"},
 		{name: "repeated lines", old: "same\n value\nsame\n", new: "same\n\tvalue\nsame\n"},
+		{
+			name: "distant repeated lines",
+			old:  "start\n value\nsame\none\ntwo\nthree\nfour\nfive\nsix\nseven\nsame\nvalue\nend\n",
+			new:  "start\nvalue\nsame\none\ntwo\nthree\nfour\nfive\nsix\nseven\nsame\n value\nend\n",
+		},
 		{name: "mixed edit", old: "first\n old\nlast\n", new: "first\n new\nlast\n"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -102,7 +133,6 @@ func TestClassifyWhitespaceOnlyMatchesGit(t *testing.T) {
 			runWorkspaceTestGit(t, work, "add", "fixture.txt")
 			runWorkspaceTestGit(t, work, "commit", "-m", "fixture")
 			require.NoError(os.WriteFile(path, []byte(tt.new), 0o644))
-
 			_, _, gitErr := gitcmd.New().Run(
 				t.Context(), work, nil,
 				"diff", "--quiet", "-w", "HEAD", "--", "fixture.txt",
@@ -116,6 +146,42 @@ func TestClassifyWhitespaceOnlyMatchesGit(t *testing.T) {
 			assert.Equal(gitErr == nil, diff.Files[0].IsWhitespaceOnly)
 		})
 	}
+}
+
+func TestClassifyWorkspaceWhitespaceOnlyChecksWholeFileAcrossHunks(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	assert := assert.New(t)
+	work := t.TempDir()
+	path := filepath.Join(work, "fixture.txt")
+	oldContent := "first\n value\nmiddle\nlast\n"
+	newContent := "first\n\tvalue\nmiddle\nlast\n"
+	runWorkspaceTestGit(t, work, "init", "--initial-branch=main")
+	runWorkspaceTestGit(t, work, "config", "user.email", "t@test.com")
+	runWorkspaceTestGit(t, work, "config", "user.name", "Test")
+	require.NoError(os.WriteFile(path, []byte(oldContent), 0o644))
+	runWorkspaceTestGit(t, work, "add", "fixture.txt")
+	runWorkspaceTestGit(t, work, "commit", "-m", "fixture")
+	require.NoError(os.WriteFile(path, []byte(newContent), 0o644))
+	files := []gitclone.DiffFile{{
+		Path: "fixture.txt", Status: "modified",
+		Hunks: []gitclone.Hunk{
+			{OldCount: 1, Lines: []gitclone.Line{{Type: "delete", Content: " value"}}},
+			{NewCount: 1, Lines: []gitclone.Line{{Type: "add", Content: "\tvalue"}}},
+		},
+	}}
+
+	count, err := classifyWorkspaceWhitespaceOnly(
+		t.Context(), work, "HEAD", "", true, files, nil,
+	)
+	require.NoError(err)
+	_, _, gitErr := gitcmd.New().Run(
+		t.Context(), work, nil, "diff", "--quiet", "-w", "HEAD", "--", "fixture.txt",
+	)
+
+	require.NoError(gitErr)
+	assert.Equal(1, count)
+	assert.True(files[0].IsWhitespaceOnly)
 }
 
 func TestWorktreeDiffDoesNotClassifyModeChangeAsWhitespaceOnly(t *testing.T) {

--- a/internal/workspace/diff_whitespace_test.go
+++ b/internal/workspace/diff_whitespace_test.go
@@ -59,9 +59,10 @@ func TestClassifyWhitespaceOnly(t *testing.T) {
 		{Path: "blank.go", Status: "modified", Hunks: []gitclone.Hunk{blankLineInsertion}},
 		{Path: "binary.dat", Status: "modified", IsBinary: true, Hunks: []gitclone.Hunk{whitespaceHunk}},
 		{Path: "renamed.go", Status: "renamed", Hunks: []gitclone.Hunk{whitespaceHunk}},
+		{Path: "mode.go", Status: "modified", Hunks: []gitclone.Hunk{whitespaceHunk}},
 	}
 
-	count := classifyWhitespaceOnly(files)
+	count := classifyWhitespaceOnly(files, map[string]bool{"mode.go": true})
 
 	assert.Equal(1, count)
 	assert.True(files[0].IsWhitespaceOnly)
@@ -69,6 +70,7 @@ func TestClassifyWhitespaceOnly(t *testing.T) {
 	assert.False(files[2].IsWhitespaceOnly)
 	assert.False(files[3].IsWhitespaceOnly)
 	assert.False(files[4].IsWhitespaceOnly)
+	assert.False(files[5].IsWhitespaceOnly)
 }
 
 func TestClassifyWhitespaceOnlyMatchesGit(t *testing.T) {
@@ -114,4 +116,21 @@ func TestClassifyWhitespaceOnlyMatchesGit(t *testing.T) {
 			assert.Equal(gitErr == nil, diff.Files[0].IsWhitespaceOnly)
 		})
 	}
+}
+
+func TestWorktreeDiffDoesNotClassifyModeChangeAsWhitespaceOnly(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	work := setupDivergenceWorktree(t)
+	path := filepath.Join(work, "f.txt")
+
+	require.NoError(os.WriteFile(path, []byte("f1  \n"), 0o755))
+	require.NoError(os.Chmod(path, 0o755))
+	diff, ok, err := WorktreeDiff(t.Context(), work, WorktreeDiffBaseHead, false)
+
+	require.NoError(err)
+	require.True(ok)
+	require.Len(diff.Files, 1)
+	assert.False(t, diff.Files[0].IsWhitespaceOnly)
+	assert.Equal(t, 0, diff.WhitespaceOnlyCount)
 }

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -4680,6 +4680,8 @@ export interface components {
             /** @description Synced PR diff snapshot head this diff was computed from. Always set for pull request diffs (the endpoint fails when no snapshot head is synced); empty for commit and workspace diffs. Compare with the pull detail's platform_head_sha to detect stale cached diff context; unrelated to 'stale', which reports clone-refresh staleness. */
             diff_head_sha?: string;
             files: components["schemas"]["DiffFile"][] | null;
+            /** @description Opaque workspace diff snapshot version used to keep files and patches coherent. */
+            snapshot_version?: string;
             stale: boolean;
             /** Format: int64 */
             whitespace_only_count: number;
@@ -5019,6 +5021,8 @@ export interface components {
              */
             readonly $schema?: string;
             files: components["schemas"]["DiffFile"][] | null;
+            /** @description Opaque workspace diff snapshot version to pin on the following workspace diff request. */
+            snapshot_version?: string;
             stale: boolean;
             /** Format: int64 */
             whitespace_only_count: number;
@@ -8118,7 +8122,10 @@ export interface operations {
     };
     "stream-events": {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Optional selected local workspace to prewarm and validate while this stream is connected */
+                workspace_id?: string;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -16671,6 +16678,8 @@ export interface operations {
                 from?: string;
                 /** @description End SHA for range diff (inclusive) */
                 to?: string;
+                /** @description Optional snapshot_version returned by the workspace files endpoint */
+                revision?: string;
             };
             header?: never;
             path: {

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -761,6 +761,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/fleet/hosts/{host_key}/workspaces/{id}/diff/watch": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Watch selected workspace diff on fleet host */
+        get: operations["watch-fleet-workspace-diff"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/fleet/hosts/{host_key}/workspaces/{id}/file-preview": {
         parameters: {
             query?: never;
@@ -4016,6 +4033,23 @@ export interface paths {
         };
         /** Get workspace diff */
         get: operations["get-workspace-diff"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/workspaces/{id}/diff/watch": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Watch selected workspace diff */
+        get: operations["watch-workspace-diff"];
         put?: never;
         post?: never;
         delete?: never;
@@ -7321,6 +7355,18 @@ export interface components {
             updated_reason?: string;
             updated_source?: string;
         };
+        WorkspaceDiffWatchResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example /api/v1/schemas/WorkspaceDiffWatchResponse.json
+             */
+            readonly $schema?: string;
+            /** @description True when the caller must reload the watched default-HEAD snapshot. */
+            changed: boolean;
+            /** @description Opaque version of the current default-HEAD snapshot; never a version from another diff scope. */
+            version: string;
+        };
         WorkspaceKataMetadata: {
             daemon_id: string;
             issue_uid: string;
@@ -9112,6 +9158,37 @@ export interface operations {
                 from?: string;
                 /** @description Newer range commit SHA. */
                 to?: string;
+                /** @description Pinned workspace snapshot version. */
+                revision?: string;
+            };
+            header?: never;
+            path: {
+                host_key: string;
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Response returned by the owning fleet host. */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
+    "watch-fleet-workspace-diff": {
+        parameters: {
+            query?: {
+                /** @description Last observed workspace diff snapshot version. */
+                version?: string;
             };
             header?: never;
             path: {
@@ -9149,6 +9226,8 @@ export interface operations {
                 from?: string;
                 /** @description Newer range commit SHA. */
                 to?: string;
+                /** @description Pinned workspace snapshot version. */
+                revision?: string;
                 /** @description Workspace file path to preview. */
                 path?: string;
                 /** @description Preview side. */
@@ -16709,6 +16788,40 @@ export interface operations {
             };
         };
     };
+    "watch-workspace-diff": {
+        parameters: {
+            query?: {
+                /** @description Last observed opaque workspace diff snapshot version */
+                version?: string;
+            };
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkspaceDiffWatchResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
     "get-workspace-file-preview": {
         parameters: {
             query?: {
@@ -16726,6 +16839,8 @@ export interface operations {
                 from?: string;
                 /** @description End SHA for range diff (inclusive) */
                 to?: string;
+                /** @description Optional snapshot_version returned by the workspace files endpoint */
+                revision?: string;
             };
             header?: never;
             path: {

--- a/packages/ui/src/api/types.ts
+++ b/packages/ui/src/api/types.ts
@@ -115,12 +115,14 @@ export interface DiffResult {
   files: DiffFile[];
   /** Synced PR diff snapshot head; compare with platform_head_sha to detect stale cached context. */
   diff_head_sha?: string;
+  snapshot_version?: string;
 }
 
 export interface FilesResult {
   stale: boolean;
   whitespace_only_count?: number;
   files: DiffFile[];
+  snapshot_version?: string;
 }
 
 export type FilePreview = components["schemas"]["FilePreviewResponse"];

--- a/packages/ui/src/components/diff/DiffView.test.ts
+++ b/packages/ui/src/components/diff/DiffView.test.ts
@@ -2,7 +2,12 @@ import { cleanup, fireEvent, render, waitFor } from "@testing-library/svelte";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import type { DiffFile, DiffResult, FilesResult } from "../../api/types.js";
 import { STORES_KEY } from "../../context.js";
-import type { DiffScrollTarget, DiffStore } from "../../stores/diff.svelte.js";
+import {
+  createDiffStore,
+  type DiffScrollTarget,
+  type DiffStore,
+  type DiffStoreOptions,
+} from "../../stores/diff.svelte.js";
 
 vi.mock("./DiffFile.svelte", async () => ({
   default: (await import("./DiffViewTestFile.svelte")).default,
@@ -126,6 +131,37 @@ describe("DiffView", () => {
     await fireEvent.keyDown(window, { key: "j" });
 
     expect(requestScrollToFile).toHaveBeenCalledWith("b.ts");
+  });
+
+  it("keeps the previous diff rendered when a preserving refresh fails", async () => {
+    let refreshFails = false;
+    const file = makeFile("a.ts");
+    const client = {
+      GET: vi.fn(async (path: string) => {
+        if (refreshFails) {
+          const response = Response.json({ detail: "refresh failed" }, { status: 500 });
+          return { error: await response.clone().json(), response };
+        }
+        const response = Response.json({});
+        if (path.endsWith("/files")) {
+          return { data: { stale: false, files: [file] }, response };
+        }
+        return {
+          data: { stale: false, whitespace_only_count: 0, files: [file] },
+          response,
+        };
+      }),
+    } as unknown as NonNullable<DiffStoreOptions["client"]>;
+    const diff = createDiffStore({ client });
+    await diff.loadWorkspaceDiff("ws-1", "head");
+    const { getByText, queryByText } = renderDiffView(diff);
+    expect(getByText("a.ts")).toBeTruthy();
+
+    refreshFails = true;
+    await diff.loadWorkspaceDiff("ws-1", "head", false, { preserveVisible: true });
+
+    expect(getByText("a.ts")).toBeTruthy();
+    expect(queryByText("refresh failed")).toBeNull();
   });
 
   it("pages the diff area with PageDown even when focus is outside the diff pane", async () => {

--- a/packages/ui/src/components/diff/DiffView.test.ts
+++ b/packages/ui/src/components/diff/DiffView.test.ts
@@ -153,10 +153,22 @@ describe("DiffView", () => {
             const failed = Response.json({ detail: "refresh failed" }, { status: 500 });
             return { error: await failed.clone().json(), response: failed };
           }
-          return { data: { stale: false, files: [filesCalls === 1 ? oldFile : newFile] }, response };
+          return {
+            data: {
+              stale: false,
+              files: [filesCalls === 1 ? oldFile : newFile],
+              snapshot_version: `generation:${filesCalls}`,
+            },
+            response,
+          };
         }
         return {
-          data: { stale: false, whitespace_only_count: 0, files: [filesCalls === 1 ? oldFile : newFile] },
+          data: {
+            stale: false,
+            whitespace_only_count: 0,
+            files: [filesCalls === 1 ? oldFile : newFile],
+            snapshot_version: `generation:${filesCalls}`,
+          },
           response,
         };
       }),
@@ -175,6 +187,63 @@ describe("DiffView", () => {
     await vi.runOnlyPendingTimersAsync();
     await refresh;
     expect(getByText("b.ts")).toBeTruthy();
+  });
+
+  it("surfaces refresh errors when the initial workspace snapshot is not yet visible", async () => {
+    const file = makeFile("a.ts");
+    let filesCalls = 0;
+    let releaseInitial: () => void = () => {};
+    let signalInitialStarted: () => void = () => {};
+    let signalFailure: () => void = () => {};
+    const initialStarted = new Promise<void>((resolve) => {
+      signalInitialStarted = resolve;
+    });
+    const initialGate = new Promise<void>((resolve) => {
+      releaseInitial = resolve;
+    });
+    const failureSeen = new Promise<void>((resolve) => {
+      signalFailure = resolve;
+    });
+    const client = {
+      GET: vi.fn(async (path: string) => {
+        if (path.endsWith("/files")) {
+          filesCalls += 1;
+          if (filesCalls === 1) {
+            signalInitialStarted();
+            await initialGate;
+            const response = Response.json({});
+            return {
+              data: { stale: false, files: [file], snapshot_version: "generation:1" },
+              response,
+            };
+          }
+          signalFailure();
+          const response = Response.json({ detail: "cold refresh failed" }, { status: 500 });
+          return { error: await response.clone().json(), response };
+        }
+        const response = Response.json({});
+        return {
+          data: {
+            stale: false,
+            whitespace_only_count: 0,
+            files: [file],
+            snapshot_version: "generation:1",
+          },
+          response,
+        };
+      }),
+    } as unknown as NonNullable<DiffStoreOptions["client"]>;
+    const diff = createDiffStore({ client });
+    const { getByText, queryByText } = renderDiffView(diff);
+    const initialLoad = diff.loadWorkspaceDiff("ws-1", "head");
+    await initialStarted;
+    const refresh = diff.loadWorkspaceDiff("ws-1", "head", false, { preserveVisible: true });
+    await failureSeen;
+    releaseInitial();
+    await Promise.all([initialLoad, refresh]);
+
+    await waitFor(() => expect(getByText("cold refresh failed")).toBeTruthy());
+    expect(queryByText("a.ts")).toBeNull();
   });
 
   it("shows an error when an initial snapshot retry fails", async () => {

--- a/packages/ui/src/components/diff/DiffView.test.ts
+++ b/packages/ui/src/components/diff/DiffView.test.ts
@@ -120,6 +120,7 @@ function renderDiffView(
 
 describe("DiffView", () => {
   afterEach(() => {
+    vi.useRealTimers();
     cleanup();
   });
 
@@ -133,21 +134,29 @@ describe("DiffView", () => {
     expect(requestScrollToFile).toHaveBeenCalledWith("b.ts");
   });
 
-  it("keeps the previous diff rendered when a preserving refresh fails", async () => {
-    let refreshFails = false;
-    const file = makeFile("a.ts");
+  it("keeps the previous diff rendered while a preserving refresh retries", async () => {
+    vi.useFakeTimers();
+    const oldFile = makeFile("a.ts");
+    const newFile = makeFile("b.ts");
+    let filesCalls = 0;
+    let signalFailure: () => void = () => {};
+    const failureSeen = new Promise<void>((resolve) => {
+      signalFailure = resolve;
+    });
     const client = {
       GET: vi.fn(async (path: string) => {
-        if (refreshFails) {
-          const response = Response.json({ detail: "refresh failed" }, { status: 500 });
-          return { error: await response.clone().json(), response };
-        }
         const response = Response.json({});
         if (path.endsWith("/files")) {
-          return { data: { stale: false, files: [file] }, response };
+          filesCalls += 1;
+          if (filesCalls === 2) {
+            signalFailure();
+            const failed = Response.json({ detail: "refresh failed" }, { status: 500 });
+            return { error: await failed.clone().json(), response: failed };
+          }
+          return { data: { stale: false, files: [filesCalls === 1 ? oldFile : newFile] }, response };
         }
         return {
-          data: { stale: false, whitespace_only_count: 0, files: [file] },
+          data: { stale: false, whitespace_only_count: 0, files: [filesCalls === 1 ? oldFile : newFile] },
           response,
         };
       }),
@@ -157,11 +166,48 @@ describe("DiffView", () => {
     const { getByText, queryByText } = renderDiffView(diff);
     expect(getByText("a.ts")).toBeTruthy();
 
-    refreshFails = true;
-    await diff.loadWorkspaceDiff("ws-1", "head", false, { preserveVisible: true });
+    const refresh = diff.loadWorkspaceDiff("ws-1", "head", false, { preserveVisible: true });
+    await failureSeen;
 
     expect(getByText("a.ts")).toBeTruthy();
     expect(queryByText("refresh failed")).toBeNull();
+
+    await vi.runOnlyPendingTimersAsync();
+    await refresh;
+    expect(getByText("b.ts")).toBeTruthy();
+  });
+
+  it("shows an error when an initial snapshot retry fails", async () => {
+    let filesCalls = 0;
+    let diffCalls = 0;
+    const file = makeFile("a.ts");
+    const client = {
+      GET: vi.fn(async (path: string) => {
+        if (path.endsWith("/files")) {
+          filesCalls += 1;
+          if (filesCalls === 2) {
+            const response = Response.json({ detail: "refresh failed" }, { status: 500 });
+            return { error: await response.clone().json(), response };
+          }
+          const response = Response.json({});
+          return { data: { stale: false, files: [file], snapshot_version: "generation:1" }, response };
+        }
+        diffCalls += 1;
+        const response = Response.json(
+          { code: "conflict", detail: "snapshot changed", details: { reason: "snapshot_changed" } },
+          { status: 409 },
+        );
+        return { error: await response.clone().json(), response };
+      }),
+    } as unknown as NonNullable<DiffStoreOptions["client"]>;
+    const diff = createDiffStore({ client });
+
+    await diff.loadWorkspaceDiff("ws-1", "head");
+    const { getByText, queryByText } = renderDiffView(diff);
+
+    expect(getByText("refresh failed")).toBeTruthy();
+    expect(queryByText("a.ts")).toBeNull();
+    expect(diffCalls).toBe(1);
   });
 
   it("pages the diff area with PageDown even when focus is outside the diff pane", async () => {

--- a/packages/ui/src/components/workspace/WorkspaceDiffPanel.svelte
+++ b/packages/ui/src/components/workspace/WorkspaceDiffPanel.svelte
@@ -16,6 +16,7 @@
     itemNumber: number;
     active?: boolean;
     refreshToken?: number;
+    diffRefreshToken?: number;
     disabled?: boolean;
     showMergeTarget?: boolean;
   }
@@ -31,6 +32,7 @@
     itemNumber,
     active = false,
     refreshToken = 0,
+    diffRefreshToken = 0,
     disabled = false,
     showMergeTarget = true,
   }: Props = $props();
@@ -41,15 +43,22 @@
     !showMergeTarget && selectedBase === "merge-target" ? "head" : selectedBase
   );
   let loadedKey = "";
+  let loadedIdentity = "";
+  let loadedDiffRefreshToken = 0;
 
   $effect(() => {
     if (!active) return;
-    const key = `${workspaceHostKey ?? "self"}:${workspaceID}:${base}:${refreshToken}`;
+    const identity = `${workspaceHostKey ?? "self"}:${workspaceID}:${base}`;
+    const key = `${identity}:${refreshToken}:${diffRefreshToken}`;
     if (loadedKey === key) return;
+    const preserveVisible = loadedIdentity === identity && diffRefreshToken !== loadedDiffRefreshToken;
     loadedKey = key;
+    loadedIdentity = identity;
+    loadedDiffRefreshToken = diffRefreshToken;
     void diff.loadWorkspaceDiff(workspaceID, base, false, {
-      refreshCommits: refreshToken > 0,
+      refreshCommits: refreshToken > 0 && !preserveVisible,
       workspaceHostKey,
+      preserveVisible,
     });
   });
 

--- a/packages/ui/src/components/workspace/WorkspaceDiffPanel.svelte
+++ b/packages/ui/src/components/workspace/WorkspaceDiffPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onDestroy } from "svelte";
   import DiffScopePicker from "../diff/DiffScopePicker.svelte";
   import DiffToolbar from "../diff/DiffToolbar.svelte";
   import DiffView from "../diff/DiffView.svelte";
@@ -45,13 +46,33 @@
   let loadedKey = "";
   let loadedIdentity = "";
   let loadedDiffRefreshToken = 0;
+  let activeLoad: {
+    workspaceID: string;
+    workspaceHostKey?: string | undefined;
+    token: object;
+  } | null = null;
+
+  function cancelActiveLoad(): void {
+    if (!activeLoad) return;
+    diff.cancelWorkspaceDiff(activeLoad.workspaceID, activeLoad.workspaceHostKey, activeLoad.token);
+    activeLoad = null;
+  }
+
+  onDestroy(cancelActiveLoad);
 
   $effect(() => {
-    if (!active) return;
+    if (!active) {
+      cancelActiveLoad();
+      loadedKey = "";
+      return;
+    }
     const identity = `${workspaceHostKey ?? "self"}:${workspaceID}:${base}`;
     const key = `${identity}:${refreshToken}:${diffRefreshToken}`;
     if (loadedKey === key) return;
     const preserveVisible = loadedIdentity === identity && diffRefreshToken !== loadedDiffRefreshToken;
+    cancelActiveLoad();
+    const loadToken = {};
+    activeLoad = { workspaceID, workspaceHostKey, token: loadToken };
     loadedKey = key;
     loadedIdentity = identity;
     loadedDiffRefreshToken = diffRefreshToken;
@@ -59,6 +80,7 @@
       refreshCommits: refreshToken > 0 && !preserveVisible,
       workspaceHostKey,
       preserveVisible,
+      loadToken,
     });
   });
 

--- a/packages/ui/src/components/workspace/WorkspaceRightSidebar.svelte
+++ b/packages/ui/src/components/workspace/WorkspaceRightSidebar.svelte
@@ -53,6 +53,7 @@
     branch: string;
     roborevBaseUrl: string;
     refreshToken?: number;
+    diffRefreshToken?: number;
     disabled?: boolean;
     kataTaskPanel?: Snippet | undefined;
   }
@@ -72,6 +73,7 @@
     branch,
     roborevBaseUrl,
     refreshToken = 0,
+    diffRefreshToken = 0,
     disabled = false,
     kataTaskPanel = undefined,
   }: Props = $props();
@@ -305,6 +307,7 @@
         itemNumber={ownerItemNumber}
         active={activeTab === "diff"}
         {refreshToken}
+        {diffRefreshToken}
         {disabled}
         showMergeTarget={hasMergeTarget}
       />

--- a/packages/ui/src/components/workspace/WorkspaceRightSidebar.test.ts
+++ b/packages/ui/src/components/workspace/WorkspaceRightSidebar.test.ts
@@ -156,6 +156,15 @@ describe("WorkspaceRightSidebar", () => {
     expect(calls.some((url) => url.endsWith("/api/v1/workspaces/ws-1/commits"))).toBe(true);
     expect(screen.getByRole("button", { name: "Compare with merge target" }).getAttribute("aria-pressed")).toBe("true");
     expect(calls.some((url) => url.endsWith("/api/v1/workspaces/ws-1/diff?base=head"))).toBe(false);
+
+    calls.length = 0;
+    await rerender({ diffRefreshToken: 1 });
+    await waitFor(() => {
+      expect(calls.some((url) => url.endsWith("/api/v1/workspaces/ws-1/diff?base=merge-target&commit=sha2"))).toBe(
+        true,
+      );
+    });
+    expect(calls.some((url) => url.endsWith("/api/v1/workspaces/ws-1/commits"))).toBe(false);
   });
 
   it("disables diff controls while the workspace is deleting", async () => {

--- a/packages/ui/src/stores/diff.svelte.ts
+++ b/packages/ui/src/stores/diff.svelte.ts
@@ -579,6 +579,7 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     const workspaceBase = currentWorkspaceBase;
     const workspaceStacked = currentWorkspaceStacked;
     const workspaceLoadToken = currentWorkspaceLoadToken;
+    const workspaceGeneration = workspaceLoadGeneration;
     const revision = fileList?.snapshot_version ?? diff?.snapshot_version;
     const key =
       `workspace:${workspaceHostKey ?? "self"}:${workspaceID}:` +
@@ -617,7 +618,9 @@ export function createDiffStore(opts?: DiffStoreOptions) {
         if (
           currentWorkspaceID !== workspaceID ||
           currentWorkspaceHostKey !== workspaceHostKey ||
-          currentWorkspaceBase !== workspaceBase
+          currentWorkspaceBase !== workspaceBase ||
+          currentWorkspaceLoadToken !== workspaceLoadToken ||
+          workspaceLoadGeneration !== workspaceGeneration
         ) {
           throw new Error("Workspace changed while refreshing file preview");
         }
@@ -869,7 +872,12 @@ export function createDiffStore(opts?: DiffStoreOptions) {
 
     if (!workspaceLoadIsCurrent(generation, workspaceID, workspaceHostKey, base)) return;
     clearFilePreviewCache();
-    const preserveVisible = options.preserveVisible === true && !workspaceScopeChanged;
+    const visibleSnapshotVersion = diff?.snapshot_version;
+    const preserveVisible =
+      options.preserveVisible === true &&
+      !workspaceScopeChanged &&
+      visibleSnapshotVersion !== undefined &&
+      fileList?.snapshot_version === visibleSnapshotVersion;
     let retryDelay = workspaceDiffRetryInitialDelay;
     while (workspaceLoadIsCurrent(generation, workspaceID, workspaceHostKey, base)) {
       let retrySignal: AbortSignal | null = null;

--- a/packages/ui/src/stores/diff.svelte.ts
+++ b/packages/ui/src/stores/diff.svelte.ts
@@ -8,6 +8,7 @@ import {
 } from "../api/provider-routes.js";
 import type { components } from "../api/generated/schema.js";
 import type { MiddlemanClient } from "../types.js";
+import { isProblem, ProblemCodes } from "../api/problems.js";
 import {
   countDiffFilesByCategory,
   filterDiffFilesByCategory,
@@ -27,6 +28,7 @@ export interface LoadWorkspaceDiffOptions {
   refreshCommits?: boolean;
   workspaceHostKey?: string | undefined;
   preserveVisible?: boolean;
+  loadToken?: object | undefined;
 }
 
 interface LoadCommitsOptions {
@@ -46,6 +48,10 @@ export interface DiffStoreOptions {
 
 function apiErrorMessage(error: { detail?: string; title?: string } | undefined, fallback: string): string {
   return error?.detail ?? error?.title ?? fallback;
+}
+
+function isSnapshotChanged(error: unknown): boolean {
+  return isProblem(error) && error.code === ProblemCodes.conflict && error.details?.["reason"] === "snapshot_changed";
 }
 
 type DiffResponse = components["schemas"]["DiffResponse"];
@@ -163,6 +169,8 @@ export function createDiffStore(opts?: DiffStoreOptions) {
   let commitsLoading = $state(false);
   let commitsError = $state<string | null>(null);
   let commitsGeneration = 0;
+  let workspaceLoadGeneration = 0;
+  let currentWorkspaceLoadToken: object | undefined;
   let scope = $state<DiffScope>({ kind: "head" });
   let filePreviewGeneration = $state(0);
   const filePreviewCache = new Map<string, Promise<FilePreview>>();
@@ -551,37 +559,63 @@ export function createDiffStore(opts?: DiffStoreOptions) {
   }
 
   async function loadWorkspaceFilePreview(path: string, side?: "old" | "new"): Promise<FilePreview> {
+    const workspaceID = currentWorkspaceID;
+    const workspaceHostKey = currentWorkspaceHostKey;
+    const workspaceBase = currentWorkspaceBase;
+    const workspaceStacked = currentWorkspaceStacked;
+    const workspaceLoadToken = currentWorkspaceLoadToken;
+    const revision = fileList?.snapshot_version ?? diff?.snapshot_version;
     const key =
-      `workspace:${currentWorkspaceHostKey ?? "self"}:${currentWorkspaceID}:` +
-      `${currentWorkspaceBase}:${scopeCacheKey()}:${path}:${side ?? "preview"}`;
+      `workspace:${workspaceHostKey ?? "self"}:${workspaceID}:` +
+      `${workspaceBase}:${scopeCacheKey()}:${revision ?? "latest"}:${path}:${side ?? "preview"}`;
     const cached = filePreviewCache.get(key);
     if (cached) return cached;
 
     const request = (async () => {
-      const params = {
-        query: {
-          ...workspaceDiffQuery(currentWorkspaceBase),
-          path,
-          ...(side && { side }),
-        },
-      };
-      const { data, error, response } = currentWorkspaceHostKey
-        ? await apiClient.GET("/fleet/hosts/{host_key}/workspaces/{id}/file-preview", {
-            params: {
-              ...params,
-              path: { host_key: currentWorkspaceHostKey, id: currentWorkspaceID },
-            },
-          })
-        : await apiClient.GET("/workspaces/{id}/file-preview", {
-            params: {
-              ...params,
-              path: { id: currentWorkspaceID },
-            },
-          });
-      if (!data) {
-        throw new Error(apiErrorMessage(error, `HTTP ${response.status}`));
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        const currentRevision = fileList?.snapshot_version ?? diff?.snapshot_version;
+        const params = {
+          query: {
+            ...workspaceDiffQuery(workspaceBase),
+            path,
+            ...(side && { side }),
+            ...(currentRevision && { revision: currentRevision }),
+          },
+        };
+        const { data, error, response } = workspaceHostKey
+          ? await apiClient.GET("/fleet/hosts/{host_key}/workspaces/{id}/file-preview", {
+              params: {
+                ...params,
+                path: { host_key: workspaceHostKey, id: workspaceID },
+              },
+            })
+          : await apiClient.GET("/workspaces/{id}/file-preview", {
+              params: {
+                ...params,
+                path: { id: workspaceID },
+              },
+            });
+        if (data) return data as FilePreview;
+        if (!isSnapshotChanged(error) || attempt > 0) {
+          throw new Error(apiErrorMessage(error, `HTTP ${response.status}`));
+        }
+        if (
+          currentWorkspaceID !== workspaceID ||
+          currentWorkspaceHostKey !== workspaceHostKey ||
+          currentWorkspaceBase !== workspaceBase
+        ) {
+          throw new Error("Workspace changed while refreshing file preview");
+        }
+        await loadWorkspaceDiff(workspaceID, workspaceBase, workspaceStacked, {
+          workspaceHostKey,
+          preserveVisible: true,
+          loadToken: workspaceLoadToken,
+        });
+        if (!getVisibleFileList()?.files.some((file) => file.path === path)) {
+          throw new Error("File is no longer present in the workspace diff");
+        }
       }
-      return data as FilePreview;
+      throw new Error("Workspace file preview could not be refreshed");
     })();
 
     filePreviewCache.set(key, request);
@@ -621,7 +655,10 @@ export function createDiffStore(opts?: DiffStoreOptions) {
   }
 
   function currentWorkspaceOptions(): LoadWorkspaceDiffOptions {
-    return currentWorkspaceHostKey ? { workspaceHostKey: currentWorkspaceHostKey } : {};
+    return {
+      ...(currentWorkspaceHostKey ? { workspaceHostKey: currentWorkspaceHostKey } : {}),
+      ...(currentWorkspaceLoadToken ? { loadToken: currentWorkspaceLoadToken } : {}),
+    };
   }
 
   function resetScopeIfMissingFromLoadedCommits(): void {
@@ -661,6 +698,20 @@ export function createDiffStore(opts?: DiffStoreOptions) {
 
   function diffLoadIsCurrent(diffAc: AbortController): boolean {
     return abortController === diffAc;
+  }
+
+  function workspaceLoadIsCurrent(
+    generation: number,
+    workspaceID: string,
+    workspaceHostKey: string | undefined,
+    base: WorkspaceDiffBase,
+  ): boolean {
+    return (
+      generation === workspaceLoadGeneration &&
+      currentWorkspaceID === workspaceID &&
+      currentWorkspaceHostKey === workspaceHostKey &&
+      currentWorkspaceBase === base
+    );
   }
 
   function finishFilesLoad(filesAc: AbortController): void {
@@ -705,6 +756,8 @@ export function createDiffStore(opts?: DiffStoreOptions) {
   }
 
   async function loadDiff(owner: string, name: string, number: number, identity: ProviderRouteRef): Promise<void> {
+    workspaceLoadGeneration += 1;
+    currentWorkspaceLoadToken = undefined;
     const prChanged = owner !== currentOwner || name !== currentName || number !== currentNumber;
     currentOwner = owner;
     currentName = name;
@@ -771,7 +824,9 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     stacked = false,
     options: LoadWorkspaceDiffOptions = {},
   ): Promise<void> {
+    const generation = ++workspaceLoadGeneration;
     const workspaceHostKey = options.workspaceHostKey;
+    currentWorkspaceLoadToken = options.loadToken;
     const workspaceScopeChanged =
       workspaceID !== currentWorkspaceID ||
       base !== currentWorkspaceBase ||
@@ -793,16 +848,11 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     }
     if (shouldRefreshCommits) {
       await loadCommits({ force: true });
-      if (
-        currentWorkspaceID !== workspaceID ||
-        currentWorkspaceHostKey !== workspaceHostKey ||
-        currentWorkspaceBase !== base
-      ) {
-        return;
-      }
+      if (!workspaceLoadIsCurrent(generation, workspaceID, workspaceHostKey, base)) return;
       resetScopeIfMissingFromLoadedCommits();
     }
 
+    if (!workspaceLoadIsCurrent(generation, workspaceID, workspaceHostKey, base)) return;
     clearFilePreviewCache();
     const preserveVisible = options.preserveVisible === true && !workspaceScopeChanged;
     for (let attempt = 0; attempt < 2; attempt += 1) {
@@ -811,6 +861,7 @@ export function createDiffStore(opts?: DiffStoreOptions) {
       let pendingFiles: FilesResponse | null = null;
 
       try {
+        if (!workspaceLoadIsCurrent(generation, workspaceID, workspaceHostKey, base)) return;
         const { data, error, response } = workspaceHostKey
           ? await apiClient.GET("/fleet/hosts/{host_key}/workspaces/{id}/files", {
               params: {
@@ -826,7 +877,8 @@ export function createDiffStore(opts?: DiffStoreOptions) {
               },
               signal: filesAc.signal,
             });
-        if (!filesLoadIsCurrent(filesAc)) return;
+        if (!filesLoadIsCurrent(filesAc) || !workspaceLoadIsCurrent(generation, workspaceID, workspaceHostKey, base))
+          return;
         if (!data) {
           throw new Error(apiErrorMessage(error, `HTTP ${response.status}`));
         }
@@ -835,7 +887,12 @@ export function createDiffStore(opts?: DiffStoreOptions) {
           applyFilesResult(data);
         }
       } catch (_err) {
-        if (filesAc.signal.aborted || !filesLoadIsCurrent(filesAc)) return;
+        if (
+          filesAc.signal.aborted ||
+          !filesLoadIsCurrent(filesAc) ||
+          !workspaceLoadIsCurrent(generation, workspaceID, workspaceHostKey, base)
+        )
+          return;
         failDiffLoad(_err, diffAc, filesAc, preserveAttempt);
         return;
       } finally {
@@ -843,6 +900,7 @@ export function createDiffStore(opts?: DiffStoreOptions) {
       }
 
       try {
+        if (!workspaceLoadIsCurrent(generation, workspaceID, workspaceHostKey, base)) return;
         const query = {
           ...workspaceDiffQuery(base),
           ...(pendingFiles?.snapshot_version && { revision: pendingFiles.snapshot_version }),
@@ -862,9 +920,10 @@ export function createDiffStore(opts?: DiffStoreOptions) {
               },
               signal: diffAc.signal,
             });
-        if (!diffLoadIsCurrent(diffAc)) return;
+        if (!diffLoadIsCurrent(diffAc) || !workspaceLoadIsCurrent(generation, workspaceID, workspaceHostKey, base))
+          return;
         if (!data) {
-          if (response.status === 409 && attempt === 0) {
+          if (isSnapshotChanged(error) && attempt === 0) {
             continue;
           }
           throw new Error(apiErrorMessage(error, `HTTP ${response.status}`));
@@ -878,6 +937,7 @@ export function createDiffStore(opts?: DiffStoreOptions) {
         }
         return;
       } catch (_err) {
+        if (!workspaceLoadIsCurrent(generation, workspaceID, workspaceHostKey, base)) return;
         failDiffLoad(_err, diffAc, filesAc, preserveAttempt);
         return;
       } finally {
@@ -887,6 +947,8 @@ export function createDiffStore(opts?: DiffStoreOptions) {
   }
 
   async function loadCommitDiff(identity: ProviderRouteRef, sha: string): Promise<void> {
+    workspaceLoadGeneration += 1;
+    currentWorkspaceLoadToken = undefined;
     const commitChanged = identity.owner !== currentOwner || identity.name !== currentName || sha !== currentCommitSHA;
     currentOwner = identity.owner;
     currentName = identity.name;
@@ -943,6 +1005,9 @@ export function createDiffStore(opts?: DiffStoreOptions) {
   }
 
   function clearDiff(): void {
+    workspaceLoadGeneration += 1;
+    currentWorkspaceLoadToken = undefined;
+    commitsGeneration += 1;
     abortController?.abort();
     abortController = null;
     fileListAbortController?.abort();
@@ -972,6 +1037,24 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     currentProvider = "";
     currentPlatformHost = undefined;
     currentRepoPath = "";
+  }
+
+  function cancelWorkspaceDiff(workspaceID: string, workspaceHostKey?: string, loadToken?: object): void {
+    if (workspaceID !== currentWorkspaceID || workspaceHostKey !== currentWorkspaceHostKey) return;
+    if (loadToken !== undefined && loadToken !== currentWorkspaceLoadToken) return;
+
+    workspaceLoadGeneration += 1;
+    currentWorkspaceLoadToken = undefined;
+    commitsGeneration += 1;
+    abortController?.abort();
+    abortController = null;
+    fileListAbortController?.abort();
+    fileListAbortController = null;
+    loading = false;
+    fileListLoading = false;
+    commitsLoading = false;
+    storeError = null;
+    clearFilePreviewCache();
   }
 
   async function loadCommits(options: LoadCommitsOptions = {}): Promise<void> {
@@ -1199,6 +1282,7 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     loadCommitDiff,
     loadFilePreview,
     loadWorkspaceDiff,
+    cancelWorkspaceDiff,
     clearDiff,
     getScope,
     getCommits,

--- a/packages/ui/src/stores/diff.svelte.ts
+++ b/packages/ui/src/stores/diff.svelte.ts
@@ -104,6 +104,21 @@ function safeSetItem(key: string, value: string): void {
 
 const VALID_TAB_WIDTHS = [1, 2, 4, 8];
 const VALID_DIFF_VIEW_MODES: DiffViewMode[] = ["unified", "split"];
+const workspaceDiffRetryInitialDelay = 1_000;
+const workspaceDiffRetryMaxDelay = 30_000;
+
+function waitForWorkspaceDiffRetry(signal: AbortSignal, delay: number): Promise<void> {
+  if (signal.aborted) return Promise.resolve();
+  return new Promise((resolve) => {
+    const done = () => {
+      clearTimeout(timeout);
+      signal.removeEventListener("abort", done);
+      resolve();
+    };
+    const timeout = setTimeout(done, delay);
+    signal.addEventListener("abort", done, { once: true });
+  });
+}
 
 function loadTabWidth(): number {
   const raw = parseInt(safeGetItem("diff-tab-width") ?? "4", 10);
@@ -855,94 +870,107 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     if (!workspaceLoadIsCurrent(generation, workspaceID, workspaceHostKey, base)) return;
     clearFilePreviewCache();
     const preserveVisible = options.preserveVisible === true && !workspaceScopeChanged;
-    for (let attempt = 0; attempt < 2; attempt += 1) {
-      const preserveAttempt = preserveVisible || attempt > 0;
-      const { diffAc, filesAc } = startDiffLoad(preserveAttempt);
-      let pendingFiles: FilesResponse | null = null;
+    let retryDelay = workspaceDiffRetryInitialDelay;
+    while (workspaceLoadIsCurrent(generation, workspaceID, workspaceHostKey, base)) {
+      let retrySignal: AbortSignal | null = null;
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        const preserveAttempt = preserveVisible || attempt > 0;
+        const { diffAc, filesAc } = startDiffLoad(preserveAttempt);
+        let pendingFiles: FilesResponse | null = null;
 
-      try {
-        if (!workspaceLoadIsCurrent(generation, workspaceID, workspaceHostKey, base)) return;
-        const { data, error, response } = workspaceHostKey
-          ? await apiClient.GET("/fleet/hosts/{host_key}/workspaces/{id}/files", {
-              params: {
-                path: { host_key: workspaceHostKey, id: workspaceID },
-                query: workspaceDiffQuery(base),
-              },
-              signal: filesAc.signal,
-            })
-          : await apiClient.GET("/workspaces/{id}/files", {
-              params: {
-                path: { id: workspaceID },
-                query: workspaceDiffQuery(base),
-              },
-              signal: filesAc.signal,
-            });
-        if (!filesLoadIsCurrent(filesAc) || !workspaceLoadIsCurrent(generation, workspaceID, workspaceHostKey, base))
-          return;
-        if (!data) {
-          throw new Error(apiErrorMessage(error, `HTTP ${response.status}`));
-        }
-        pendingFiles = data;
-        if (!preserveAttempt) {
-          applyFilesResult(data);
-        }
-      } catch (_err) {
-        if (
-          filesAc.signal.aborted ||
-          !filesLoadIsCurrent(filesAc) ||
-          !workspaceLoadIsCurrent(generation, workspaceID, workspaceHostKey, base)
-        )
-          return;
-        failDiffLoad(_err, diffAc, filesAc, preserveAttempt);
-        return;
-      } finally {
-        finishFilesLoad(filesAc);
-      }
-
-      try {
-        if (!workspaceLoadIsCurrent(generation, workspaceID, workspaceHostKey, base)) return;
-        const query = {
-          ...workspaceDiffQuery(base),
-          ...(pendingFiles?.snapshot_version && { revision: pendingFiles.snapshot_version }),
-        };
-        const { data, error, response } = workspaceHostKey
-          ? await apiClient.GET("/fleet/hosts/{host_key}/workspaces/{id}/diff", {
-              params: {
-                path: { host_key: workspaceHostKey, id: workspaceID },
-                query,
-              },
-              signal: diffAc.signal,
-            })
-          : await apiClient.GET("/workspaces/{id}/diff", {
-              params: {
-                path: { id: workspaceID },
-                query,
-              },
-              signal: diffAc.signal,
-            });
-        if (!diffLoadIsCurrent(diffAc) || !workspaceLoadIsCurrent(generation, workspaceID, workspaceHostKey, base))
-          return;
-        if (!data) {
-          if (isSnapshotChanged(error) && attempt === 0) {
-            continue;
+        try {
+          if (!workspaceLoadIsCurrent(generation, workspaceID, workspaceHostKey, base)) return;
+          const { data, error, response } = workspaceHostKey
+            ? await apiClient.GET("/fleet/hosts/{host_key}/workspaces/{id}/files", {
+                params: {
+                  path: { host_key: workspaceHostKey, id: workspaceID },
+                  query: workspaceDiffQuery(base),
+                },
+                signal: filesAc.signal,
+              })
+            : await apiClient.GET("/workspaces/{id}/files", {
+                params: {
+                  path: { id: workspaceID },
+                  query: workspaceDiffQuery(base),
+                },
+                signal: filesAc.signal,
+              });
+          if (!filesLoadIsCurrent(filesAc) || !workspaceLoadIsCurrent(generation, workspaceID, workspaceHostKey, base))
+            return;
+          if (!data) {
+            throw new Error(apiErrorMessage(error, `HTTP ${response.status}`));
           }
-          throw new Error(apiErrorMessage(error, `HTTP ${response.status}`));
+          pendingFiles = data;
+          if (!preserveAttempt) {
+            applyFilesResult(data);
+          }
+        } catch (_err) {
+          if (
+            filesAc.signal.aborted ||
+            !filesLoadIsCurrent(filesAc) ||
+            !workspaceLoadIsCurrent(generation, workspaceID, workspaceHostKey, base)
+          )
+            return;
+          failDiffLoad(_err, diffAc, filesAc, preserveVisible);
+          if (!preserveVisible) return;
+          retrySignal = diffAc.signal;
+          break;
+        } finally {
+          finishFilesLoad(filesAc);
         }
-        if (preserveAttempt && pendingFiles) {
-          fileList = normalizeFilesResult(pendingFiles);
-          diff = normalizeDiffResult(data);
-          setActiveIfNeeded(getVisibleDiffFiles());
-        } else {
-          applyDiffResult(data);
+
+        try {
+          if (!workspaceLoadIsCurrent(generation, workspaceID, workspaceHostKey, base)) return;
+          const query = {
+            ...workspaceDiffQuery(base),
+            ...(pendingFiles?.snapshot_version && { revision: pendingFiles.snapshot_version }),
+          };
+          const { data, error, response } = workspaceHostKey
+            ? await apiClient.GET("/fleet/hosts/{host_key}/workspaces/{id}/diff", {
+                params: {
+                  path: { host_key: workspaceHostKey, id: workspaceID },
+                  query,
+                },
+                signal: diffAc.signal,
+              })
+            : await apiClient.GET("/workspaces/{id}/diff", {
+                params: {
+                  path: { id: workspaceID },
+                  query,
+                },
+                signal: diffAc.signal,
+              });
+          if (!diffLoadIsCurrent(diffAc) || !workspaceLoadIsCurrent(generation, workspaceID, workspaceHostKey, base))
+            return;
+          if (!data) {
+            if (isSnapshotChanged(error) && attempt === 0) {
+              continue;
+            }
+            throw new Error(apiErrorMessage(error, `HTTP ${response.status}`));
+          }
+          if (preserveAttempt && pendingFiles) {
+            fileList = normalizeFilesResult(pendingFiles);
+            diff = normalizeDiffResult(data);
+            setActiveIfNeeded(getVisibleDiffFiles());
+          } else {
+            applyDiffResult(data);
+          }
+          return;
+        } catch (_err) {
+          if (!workspaceLoadIsCurrent(generation, workspaceID, workspaceHostKey, base)) return;
+          failDiffLoad(_err, diffAc, filesAc, preserveVisible);
+          if (!preserveVisible) return;
+          retrySignal = diffAc.signal;
+          break;
+        } finally {
+          finishDiffLoad(diffAc);
         }
-        return;
-      } catch (_err) {
-        if (!workspaceLoadIsCurrent(generation, workspaceID, workspaceHostKey, base)) return;
-        failDiffLoad(_err, diffAc, filesAc, preserveAttempt);
-        return;
-      } finally {
-        finishDiffLoad(diffAc);
       }
+
+      if (!retrySignal) return;
+      await waitForWorkspaceDiffRetry(retrySignal, retryDelay);
+      if (retrySignal.aborted || !workspaceLoadIsCurrent(generation, workspaceID, workspaceHostKey, base)) return;
+      retryDelay = Math.min(retryDelay * 2, workspaceDiffRetryMaxDelay);
     }
   }
 

--- a/packages/ui/src/stores/diff.svelte.ts
+++ b/packages/ui/src/stores/diff.svelte.ts
@@ -967,6 +967,10 @@ export function createDiffStore(opts?: DiffStoreOptions) {
             }
             throw new Error(apiErrorMessage(error, `HTTP ${response.status}`));
           }
+          if (preserveVisible && (pendingFiles?.stale || data.stale)) {
+            retrySignal = diffAc.signal;
+            break;
+          }
           if (preserveAttempt && pendingFiles) {
             fileList = normalizeFilesResult(pendingFiles);
             diff = normalizeDiffResult(data);

--- a/packages/ui/src/stores/diff.svelte.ts
+++ b/packages/ui/src/stores/diff.svelte.ts
@@ -744,8 +744,8 @@ export function createDiffStore(opts?: DiffStoreOptions) {
   ): void {
     if (diffAc.signal.aborted || !diffLoadIsCurrent(diffAc)) return;
 
-    storeError = err instanceof Error ? err.message : String(err);
     if (!preserveVisible) {
+      storeError = err instanceof Error ? err.message : String(err);
       diff = null;
       fileList = null;
     }

--- a/packages/ui/src/stores/diff.svelte.ts
+++ b/packages/ui/src/stores/diff.svelte.ts
@@ -624,11 +624,22 @@ export function createDiffStore(opts?: DiffStoreOptions) {
         ) {
           throw new Error("Workspace changed while refreshing file preview");
         }
-        await loadWorkspaceDiff(workspaceID, workspaceBase, workspaceStacked, {
+        const recovery = loadWorkspaceDiff(workspaceID, workspaceBase, workspaceStacked, {
           workspaceHostKey,
           preserveVisible: true,
           loadToken: workspaceLoadToken,
         });
+        const recoveryGeneration = workspaceLoadGeneration;
+        await recovery;
+        if (
+          currentWorkspaceID !== workspaceID ||
+          currentWorkspaceHostKey !== workspaceHostKey ||
+          currentWorkspaceBase !== workspaceBase ||
+          currentWorkspaceLoadToken !== workspaceLoadToken ||
+          workspaceLoadGeneration !== recoveryGeneration
+        ) {
+          throw new Error("Workspace changed while refreshing file preview");
+        }
         if (!getVisibleFileList()?.files.some((file) => file.path === path)) {
           throw new Error("File is no longer present in the workspace diff");
         }

--- a/packages/ui/src/stores/diff.svelte.ts
+++ b/packages/ui/src/stores/diff.svelte.ts
@@ -26,6 +26,7 @@ export type DiffViewMode = "unified" | "split";
 export interface LoadWorkspaceDiffOptions {
   refreshCommits?: boolean;
   workspaceHostKey?: string | undefined;
+  preserveVisible?: boolean;
 }
 
 interface LoadCommitsOptions {
@@ -632,7 +633,7 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     scope = { kind: "head" };
   }
 
-  function startDiffLoad(): {
+  function startDiffLoad(preserveVisible = false): {
     diffAc: AbortController;
     filesAc: AbortController;
   } {
@@ -643,8 +644,10 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     abortController = diffAc;
     fileListAbortController = filesAc;
 
-    diff = null;
-    fileList = null;
+    if (!preserveVisible) {
+      diff = null;
+      fileList = null;
+    }
     loading = true;
     fileListLoading = true;
     storeError = null;
@@ -682,12 +685,19 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     setActiveIfNeeded(getVisibleDiffFiles());
   }
 
-  function failDiffLoad(err: unknown, diffAc: AbortController, filesAc: AbortController): void {
+  function failDiffLoad(
+    err: unknown,
+    diffAc: AbortController,
+    filesAc: AbortController,
+    preserveVisible = false,
+  ): void {
     if (diffAc.signal.aborted || !diffLoadIsCurrent(diffAc)) return;
 
     storeError = err instanceof Error ? err.message : String(err);
-    diff = null;
-    fileList = null;
+    if (!preserveVisible) {
+      diff = null;
+      fileList = null;
+    }
     fileListAbortController = null;
     filesAc.abort();
     fileListLoading = false;
@@ -794,62 +804,85 @@ export function createDiffStore(opts?: DiffStoreOptions) {
     }
 
     clearFilePreviewCache();
-    const { diffAc, filesAc } = startDiffLoad();
+    const preserveVisible = options.preserveVisible === true && !workspaceScopeChanged;
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const preserveAttempt = preserveVisible || attempt > 0;
+      const { diffAc, filesAc } = startDiffLoad(preserveAttempt);
+      let pendingFiles: FilesResponse | null = null;
 
-    try {
-      const { data, error, response } = workspaceHostKey
-        ? await apiClient.GET("/fleet/hosts/{host_key}/workspaces/{id}/files", {
-            params: {
-              path: { host_key: workspaceHostKey, id: workspaceID },
-              query: workspaceDiffQuery(base),
-            },
-            signal: filesAc.signal,
-          })
-        : await apiClient.GET("/workspaces/{id}/files", {
-            params: {
-              path: { id: workspaceID },
-              query: workspaceDiffQuery(base),
-            },
-            signal: filesAc.signal,
-          });
-      if (!filesLoadIsCurrent(filesAc)) return;
-      if (!data) {
-        throw new Error(apiErrorMessage(error, `HTTP ${response.status}`));
+      try {
+        const { data, error, response } = workspaceHostKey
+          ? await apiClient.GET("/fleet/hosts/{host_key}/workspaces/{id}/files", {
+              params: {
+                path: { host_key: workspaceHostKey, id: workspaceID },
+                query: workspaceDiffQuery(base),
+              },
+              signal: filesAc.signal,
+            })
+          : await apiClient.GET("/workspaces/{id}/files", {
+              params: {
+                path: { id: workspaceID },
+                query: workspaceDiffQuery(base),
+              },
+              signal: filesAc.signal,
+            });
+        if (!filesLoadIsCurrent(filesAc)) return;
+        if (!data) {
+          throw new Error(apiErrorMessage(error, `HTTP ${response.status}`));
+        }
+        pendingFiles = data;
+        if (!preserveAttempt) {
+          applyFilesResult(data);
+        }
+      } catch (_err) {
+        if (filesAc.signal.aborted || !filesLoadIsCurrent(filesAc)) return;
+        failDiffLoad(_err, diffAc, filesAc, preserveAttempt);
+        return;
+      } finally {
+        finishFilesLoad(filesAc);
       }
-      applyFilesResult(data);
-    } catch (_err) {
-      if (filesAc.signal.aborted || !filesLoadIsCurrent(filesAc)) return;
-      failDiffLoad(_err, diffAc, filesAc);
-      return;
-    } finally {
-      finishFilesLoad(filesAc);
-    }
 
-    try {
-      const { data, error, response } = workspaceHostKey
-        ? await apiClient.GET("/fleet/hosts/{host_key}/workspaces/{id}/diff", {
-            params: {
-              path: { host_key: workspaceHostKey, id: workspaceID },
-              query: workspaceDiffQuery(base),
-            },
-            signal: diffAc.signal,
-          })
-        : await apiClient.GET("/workspaces/{id}/diff", {
-            params: {
-              path: { id: workspaceID },
-              query: workspaceDiffQuery(base),
-            },
-            signal: diffAc.signal,
-          });
-      if (!diffLoadIsCurrent(diffAc)) return;
-      if (!data) {
-        throw new Error(apiErrorMessage(error, `HTTP ${response.status}`));
+      try {
+        const query = {
+          ...workspaceDiffQuery(base),
+          ...(pendingFiles?.snapshot_version && { revision: pendingFiles.snapshot_version }),
+        };
+        const { data, error, response } = workspaceHostKey
+          ? await apiClient.GET("/fleet/hosts/{host_key}/workspaces/{id}/diff", {
+              params: {
+                path: { host_key: workspaceHostKey, id: workspaceID },
+                query,
+              },
+              signal: diffAc.signal,
+            })
+          : await apiClient.GET("/workspaces/{id}/diff", {
+              params: {
+                path: { id: workspaceID },
+                query,
+              },
+              signal: diffAc.signal,
+            });
+        if (!diffLoadIsCurrent(diffAc)) return;
+        if (!data) {
+          if (response.status === 409 && attempt === 0) {
+            continue;
+          }
+          throw new Error(apiErrorMessage(error, `HTTP ${response.status}`));
+        }
+        if (preserveAttempt && pendingFiles) {
+          fileList = normalizeFilesResult(pendingFiles);
+          diff = normalizeDiffResult(data);
+          setActiveIfNeeded(getVisibleDiffFiles());
+        } else {
+          applyDiffResult(data);
+        }
+        return;
+      } catch (_err) {
+        failDiffLoad(_err, diffAc, filesAc, preserveAttempt);
+        return;
+      } finally {
+        finishDiffLoad(diffAc);
       }
-      applyDiffResult(data);
-    } catch (_err) {
-      failDiffLoad(_err, diffAc, filesAc);
-    } finally {
-      finishDiffLoad(diffAc);
     }
   }
 


### PR DESCRIPTION
Workspace diff views were repeating expensive Git work and could keep the prior workspace's sidebar visible while a new selection loaded.

- Prepare and cache diff data only for the selected workspace.
- Keep shell and runtime readiness independent from diff preparation and browser parsing.
- Replace stale sidebar content immediately, then mount the selected diff when its runtime is ready.
- Revalidate selected diff data asynchronously on manual refresh and notify the browser when it is ready.
- Reduce the reported workspace's warm server loads to 0.25ms for files and 0.35ms for diff after a 90.8ms cold preparation.

<sup>generated by a clanker</sup>