### PR TITLE
fix: drain server fixtures before test teardown

### DIFF
--- a/context/testing.md
+++ b/context/testing.md
@@ -209,6 +209,10 @@ clones its own bare repo and worktree root. Keep tests serial when they call
 resources, or intentionally verify ordering against another test-visible shared
 resource.
 
+Tests that construct a `server.Server` must register graceful shutdown before
+database fixture cleanup; closing only an `httptest.Server` leaves background
+monitors able to race SQLite `t.TempDir` removal (`internal/server/server.go::Shutdown`).
+
 Disable Git auto-GC and auto-maintenance in synthetic repositories under
 `t.TempDir`; detached maintenance can recreate files during fixture cleanup
 (`internal/gitclone/commits_test.go::commitTestRun`).

--- a/context/testing.md
+++ b/context/testing.md
@@ -209,9 +209,9 @@ clones its own bare repo and worktree root. Keep tests serial when they call
 resources, or intentionally verify ordering against another test-visible shared
 resource.
 
-Tests that construct a `server.Server` must register graceful shutdown before
-database fixture cleanup; closing only an `httptest.Server` leaves background
-monitors able to race SQLite `t.TempDir` removal (`internal/server/server.go::Shutdown`).
+Black-box tests should construct servers through `internal/testutil/servertest`;
+closing only an `httptest.Server` leaves background monitors able to race SQLite
+`t.TempDir` removal (`internal/testutil/servertest/servertest.go::New`).
 
 Disable Git auto-GC and auto-maintenance in synthetic repositories under
 `t.TempDir`; detached maintenance can recreate files during fixture cleanup

--- a/internal/server/apitest/activity_notifications_test.go
+++ b/internal/server/apitest/activity_notifications_test.go
@@ -14,6 +14,7 @@ import (
 	ghclient "go.kenn.io/middleman/internal/github"
 	"go.kenn.io/middleman/internal/server"
 	"go.kenn.io/middleman/internal/testutil/dbtest"
+	"go.kenn.io/middleman/internal/testutil/servertest"
 )
 
 // setupNotificationsAPIServer builds an API server with a non-nil config so
@@ -30,7 +31,7 @@ func setupNotificationsAPIServer(t *testing.T) (*server.Server, *db.DB) {
 	// A non-nil config enables notifications; the explicit HostCheck override
 	// (which short-circuits config-derived host options) keeps the apitest
 	// "middleman.test" base URL accepted.
-	srv := server.New(database, syncer, nil, "/", &config.Config{}, server.ServerOptions{
+	srv := servertest.New(t, database, syncer, nil, "/", &config.Config{}, server.ServerOptions{
 		HostCheck: server.HostCheckOptions{
 			Bind: config.HostKey{Host: "127.0.0.1", Port: "8091"},
 			Allowed: []config.HostKey{

--- a/internal/server/apitest/assignees_reviewers_test.go
+++ b/internal/server/apitest/assignees_reviewers_test.go
@@ -16,6 +16,7 @@ import (
 	"go.kenn.io/middleman/internal/server"
 	"go.kenn.io/middleman/internal/testutil"
 	"go.kenn.io/middleman/internal/testutil/dbtest"
+	"go.kenn.io/middleman/internal/testutil/servertest"
 )
 
 type assigneesAPIResponse struct {
@@ -62,7 +63,7 @@ func setupAssigneeTestServer(t *testing.T) (*server.Server, *db.DB, *testutil.Fi
 		database, nil, defaultTestRepos, time.Minute, nil, nil,
 	)
 	t.Cleanup(syncer.Stop)
-	srv := server.New(database, syncer, nil, "/", nil, server.ServerOptions{})
+	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{})
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
@@ -355,7 +356,7 @@ func TestAPIAssigneeAndReviewerMutationsAreCapabilityGated(t *testing.T) {
 	require.NoError(err)
 	syncer := ghclient.NewSyncerWithRegistry(registry, database, nil, nil, time.Minute, nil, nil)
 	t.Cleanup(syncer.Stop)
-	srv := server.New(database, syncer, nil, "/", nil, server.ServerOptions{})
+	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{})
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()

--- a/internal/server/apitest/fixtures_test.go
+++ b/internal/server/apitest/fixtures_test.go
@@ -18,6 +18,7 @@ import (
 	"go.kenn.io/middleman/internal/server"
 	"go.kenn.io/middleman/internal/testutil"
 	"go.kenn.io/middleman/internal/testutil/dbtest"
+	"go.kenn.io/middleman/internal/testutil/servertest"
 )
 
 var defaultTestRepos = []ghclient.RepoRef{
@@ -32,7 +33,7 @@ func setupTestServer(t *testing.T) (*server.Server, *db.DB) {
 	syncer := ghclient.NewSyncer(nil, database, nil, defaultTestRepos, time.Minute, nil, nil)
 	t.Cleanup(syncer.Stop)
 
-	srv := server.New(database, syncer, nil, "/", nil, server.ServerOptions{})
+	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{})
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
@@ -55,7 +56,7 @@ func setupTestServerWithFixtureClient(
 	)
 	t.Cleanup(syncer.Stop)
 
-	srv := server.New(database, syncer, nil, "/", nil, server.ServerOptions{})
+	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{})
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()

--- a/internal/server/apitest/fleet_ssh_peers_test.go
+++ b/internal/server/apitest/fleet_ssh_peers_test.go
@@ -12,6 +12,7 @@ import (
 	ghclient "go.kenn.io/middleman/internal/github"
 	"go.kenn.io/middleman/internal/server"
 	"go.kenn.io/middleman/internal/testutil/dbtest"
+	"go.kenn.io/middleman/internal/testutil/servertest"
 )
 
 func setupFleetSettingsServer(t *testing.T) (*server.Server, string) {
@@ -33,7 +34,7 @@ allowed_hosts = ["middleman.test"]
 	)
 	t.Cleanup(syncer.Stop)
 
-	srv := server.NewWithConfig(
+	srv := servertest.NewWithConfig(t,
 		database, syncer, nil, nil, cfg, cfgPath,
 		server.ServerOptions{},
 	)

--- a/internal/server/apitest/host_check_test.go
+++ b/internal/server/apitest/host_check_test.go
@@ -20,6 +20,7 @@ import (
 	ghclient "go.kenn.io/middleman/internal/github"
 	"go.kenn.io/middleman/internal/server"
 	"go.kenn.io/middleman/internal/testutil/dbtest"
+	"go.kenn.io/middleman/internal/testutil/servertest"
 )
 
 // TestHostValidationE2E exercises the Host validation middleware
@@ -165,7 +166,7 @@ func setupHostValidationServer(t *testing.T, opts ...server.HostCheckOptions) (*
 	if len(opts) > 0 {
 		hostCheck = opts[0]
 	}
-	srv := server.New(database, syncer, nil, "/", nil, server.ServerOptions{
+	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{
 		HostCheck: hostCheck,
 	})
 	return srv, database
@@ -181,7 +182,7 @@ func setupHostValidationServerFromConfig(t *testing.T, content string) (*server.
 	syncer := ghclient.NewSyncer(nil, database, nil, defaultTestRepos, time.Minute, nil, nil)
 	t.Cleanup(syncer.Stop)
 
-	srv := server.NewWithConfig(database, syncer, nil, nil, cfg, cfgPath, server.ServerOptions{})
+	srv := servertest.NewWithConfig(t, database, syncer, nil, nil, cfg, cfgPath, server.ServerOptions{})
 	return srv, database
 }
 

--- a/internal/server/apitest/labels_test.go
+++ b/internal/server/apitest/labels_test.go
@@ -17,6 +17,7 @@ import (
 	"go.kenn.io/middleman/internal/server"
 	"go.kenn.io/middleman/internal/testutil"
 	"go.kenn.io/middleman/internal/testutil/dbtest"
+	"go.kenn.io/middleman/internal/testutil/servertest"
 )
 
 type labelAPIResponse struct {
@@ -73,7 +74,7 @@ func setupLabelTestServer(t *testing.T) (*server.Server, *db.DB, *testutil.Fixtu
 	*client.Issues["acme/widget"][0].Number = 7
 	syncer := ghclient.NewSyncer(map[string]ghclient.Client{"github.com": client}, database, nil, defaultTestRepos, time.Minute, nil, nil)
 	t.Cleanup(syncer.Stop)
-	srv := server.New(database, syncer, nil, "/", nil, server.ServerOptions{})
+	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{})
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
@@ -155,7 +156,7 @@ func TestAPIListRepoLabelsReturnsCachedCatalogWhileRefreshRuns(t *testing.T) {
 	defer close(client.release)
 	syncer := ghclient.NewSyncer(map[string]ghclient.Client{"github.com": client}, database, nil, defaultTestRepos, time.Minute, nil, nil)
 	t.Cleanup(syncer.Stop)
-	srv := server.New(database, syncer, nil, "/", nil, server.ServerOptions{})
+	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{})
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()

--- a/internal/server/e2etest/fixtures_test.go
+++ b/internal/server/e2etest/fixtures_test.go
@@ -15,6 +15,7 @@ import (
 	"go.kenn.io/middleman/internal/platform"
 	"go.kenn.io/middleman/internal/server"
 	"go.kenn.io/middleman/internal/testutil/dbtest"
+	"go.kenn.io/middleman/internal/testutil/servertest"
 )
 
 type localHealthResponse struct {
@@ -28,7 +29,7 @@ func setupTestServer(t *testing.T) (*server.Server, *db.DB) {
 	syncer := ghclient.NewSyncer(nil, database, nil, nil, time.Minute, nil, nil)
 	t.Cleanup(syncer.Stop)
 
-	srv := server.New(database, syncer, nil, "/", nil, server.ServerOptions{
+	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{
 		HostCheckAllowLoopbackAnyPort: true,
 	})
 	return srv, database
@@ -52,7 +53,7 @@ func setupTestServerWithSSEBufferSize(
 		BasePath:      "/",
 		SSEBufferSize: size,
 	}
-	srv := server.New(database, syncer, nil, "/", cfg, server.ServerOptions{
+	srv := servertest.New(t, database, syncer, nil, "/", cfg, server.ServerOptions{
 		HostCheck: server.HostCheckOptions{
 			Bind:                 config.HostKey{Host: "127.0.0.1", Port: "8091"},
 			AllowLoopbackAnyPort: true,
@@ -70,7 +71,7 @@ func setupWithBasePath(t *testing.T, basePath string, _ any) *server.Server {
 		database, nil, nil, time.Minute, nil, nil,
 	)
 	t.Cleanup(syncer.Stop)
-	return server.New(database, syncer, nil, basePath, nil, server.ServerOptions{
+	return servertest.New(t, database, syncer, nil, basePath, nil, server.ServerOptions{
 		HostCheckAllowLoopbackAnyPort: true,
 	})
 }
@@ -122,8 +123,8 @@ func setupTestServerWithConfigContentAndSyncer(
 	)
 	t.Cleanup(syncer.Stop)
 
-	srv := server.NewWithConfig(
-		database, syncer, nil, nil, cfg, cfgPath, server.ServerOptions{
+	srv := servertest.NewWithConfig(
+		t, database, syncer, nil, nil, cfg, cfgPath, server.ServerOptions{
 			HostCheckAllowLoopbackAnyPort: true,
 		},
 	)

--- a/internal/server/e2etest/fleet_snapshot_diff_stats_test.go
+++ b/internal/server/e2etest/fleet_snapshot_diff_stats_test.go
@@ -22,6 +22,7 @@ import (
 	"go.kenn.io/middleman/internal/server"
 	"go.kenn.io/middleman/internal/testutil"
 	"go.kenn.io/middleman/internal/testutil/dbtest"
+	"go.kenn.io/middleman/internal/testutil/servertest"
 )
 
 // repoMetadataClient wraps the fixture client so GetRepository reports the
@@ -122,7 +123,7 @@ func TestFleetSnapshotBranchDiffForSyncedRepoE2E(t *testing.T) {
 
 	cfg := &config.Config{BasePath: "/"}
 	cfg.Tmux.Command = []string{"middleman-no-such-tmux"}
-	srv := server.New(database, syncer, nil, "/", cfg, server.ServerOptions{
+	srv := servertest.New(t, database, syncer, nil, "/", cfg, server.ServerOptions{
 		WorktreeDir:                        t.TempDir(),
 		DisableWorkspaceBackgroundMonitors: true,
 		HostCheck: server.HostCheckOptions{

--- a/internal/server/e2etest/fleet_snapshot_test.go
+++ b/internal/server/e2etest/fleet_snapshot_test.go
@@ -29,6 +29,7 @@ import (
 	ghclient "go.kenn.io/middleman/internal/github"
 	"go.kenn.io/middleman/internal/server"
 	"go.kenn.io/middleman/internal/testutil/dbtest"
+	"go.kenn.io/middleman/internal/testutil/servertest"
 )
 
 func bootFleetServer(t *testing.T, cfg *config.Config) (*httptest.Server, *dbpkg.DB) {
@@ -42,7 +43,7 @@ func bootFleetServer(t *testing.T, cfg *config.Config) (*httptest.Server, *dbpkg
 	if cfg.Tmux.Command == nil {
 		cfg.Tmux.Command = []string{"middleman-no-such-tmux"}
 	}
-	srv := server.New(database, syncer, nil, "/", cfg, server.ServerOptions{
+	srv := servertest.New(t, database, syncer, nil, "/", cfg, server.ServerOptions{
 		WorktreeDir:                        t.TempDir(),
 		DisableWorkspaceBackgroundMonitors: true,
 		HostCheck: server.HostCheckOptions{

--- a/internal/server/e2etest/github_app_split_auth_test.go
+++ b/internal/server/e2etest/github_app_split_auth_test.go
@@ -24,6 +24,7 @@ import (
 	"go.kenn.io/middleman/internal/platform"
 	"go.kenn.io/middleman/internal/server"
 	"go.kenn.io/middleman/internal/testutil/dbtest"
+	"go.kenn.io/middleman/internal/testutil/servertest"
 	"go.kenn.io/middleman/internal/tokenauth"
 )
 
@@ -257,7 +258,7 @@ repository_selection = "all"
 		registry, database, nil, []ghclient.RepoRef{ref}, time.Minute, nil, nil,
 	)
 	t.Cleanup(syncer.Stop)
-	srv := server.NewWithConfig(
+	srv := servertest.NewWithConfig(t,
 		database, syncer, nil, nil, cfg, cfgPath,
 		server.ServerOptions{
 			TokenSources: sourceSet,
@@ -541,7 +542,7 @@ repository_selection = "all"
 		registry, database, nil, resolved.Expanded, time.Minute, nil, nil,
 	)
 	t.Cleanup(syncer.Stop)
-	srv := server.NewWithConfig(
+	srv := servertest.NewWithConfig(t,
 		database, syncer, nil, nil, cfg, cfgPath,
 		server.ServerOptions{HostCheckAllowLoopbackAnyPort: true},
 	)
@@ -738,7 +739,7 @@ repository_selection = "all"
 		registry, database, nil, []ghclient.RepoRef{ref}, time.Minute, nil, nil,
 	)
 	t.Cleanup(syncer.Stop)
-	srv := server.NewWithConfig(
+	srv := servertest.NewWithConfig(t,
 		database, syncer, nil, nil, cfg, cfgPath,
 		server.ServerOptions{
 			TokenSources: sourceSet,

--- a/internal/server/e2etest/github_head_pin_test.go
+++ b/internal/server/e2etest/github_head_pin_test.go
@@ -21,6 +21,7 @@ import (
 	"go.kenn.io/middleman/internal/platform"
 	"go.kenn.io/middleman/internal/server"
 	"go.kenn.io/middleman/internal/testutil/dbtest"
+	"go.kenn.io/middleman/internal/testutil/servertest"
 )
 
 // setupGitHubHeadPinServer boots the HTTP API with real SQLite against
@@ -91,7 +92,7 @@ func setupGitHubHeadPinServerWithDiff(
 	)
 	t.Cleanup(syncer.Stop)
 
-	srv := server.New(database, syncer, nil, "/", nil, server.ServerOptions{})
+	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{})
 	return srv, database, repoID
 }
 

--- a/internal/server/e2etest/gitlab_discussions_test.go
+++ b/internal/server/e2etest/gitlab_discussions_test.go
@@ -17,6 +17,7 @@ import (
 	"go.kenn.io/middleman/internal/platform"
 	"go.kenn.io/middleman/internal/server"
 	"go.kenn.io/middleman/internal/testutil/dbtest"
+	"go.kenn.io/middleman/internal/testutil/servertest"
 )
 
 func TestGetPRDetailIncludesThreadID(t *testing.T) {
@@ -199,7 +200,7 @@ func TestGitLabDiscussionMetadataSyncsToDetailAPI(t *testing.T) {
 	require.NoError(syncer.SyncMROnProvider(ctx, platform.KindGitLab, "gitlab.com", "acme", "widget", 7))
 	require.NoError(syncer.SyncIssueOnProvider(ctx, platform.KindGitLab, "gitlab.com", "acme", "widget", 11))
 
-	srv := server.New(database, syncer, nil, "/", nil, server.ServerOptions{})
+	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{})
 
 	prReq := httptest.NewRequest(http.MethodGet, "/api/v1/pulls/gitlab/acme/widget/7", nil)
 	prRR := httptest.NewRecorder()
@@ -447,7 +448,7 @@ func TestGitLabRepoCapabilitiesIncludeDiscussions(t *testing.T) {
 	)
 	t.Cleanup(syncer.Stop)
 
-	srv := server.New(database, syncer, nil, "/", nil, server.ServerOptions{})
+	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{})
 	syncer.RunOnce(ctx)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/repo/gitlab/acme/widget", nil)
@@ -511,7 +512,7 @@ func TestReplyToDiscussionE2E(t *testing.T) {
 	)
 	t.Cleanup(syncer.Stop)
 
-	srv := server.New(database, syncer, nil, "/", nil, server.ServerOptions{})
+	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{})
 	syncer.RunOnce(ctx)
 
 	// Create an MR to reply to
@@ -697,7 +698,7 @@ func TestReplyToDiscussionRejectsInvalidThreadID(t *testing.T) {
 	)
 	t.Cleanup(syncer.Stop)
 
-	srv := server.New(database, syncer, nil, "/", nil, server.ServerOptions{})
+	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{})
 	syncer.RunOnce(ctx)
 
 	dbRepo2, err := database.GetRepoByIdentity(ctx, db.RepoIdentity{
@@ -795,7 +796,7 @@ func TestResolveDiscussionE2E(t *testing.T) {
 	)
 	t.Cleanup(syncer.Stop)
 
-	srv := server.New(database, syncer, nil, "/", nil, server.ServerOptions{})
+	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{})
 	syncer.RunOnce(ctx)
 
 	dbRepo3, err := database.GetRepoByIdentity(ctx, db.RepoIdentity{
@@ -946,7 +947,7 @@ func TestDiscussionEndpointsRejectNonExistentMR(t *testing.T) {
 	)
 	t.Cleanup(syncer.Stop)
 
-	srv := server.New(database, syncer, nil, "/", nil, server.ServerOptions{})
+	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{})
 	syncer.RunOnce(ctx)
 
 	// Note: We do NOT create an MR in the database, so MR #999 does not exist locally.
@@ -1023,7 +1024,7 @@ func TestResolveDiscussionUpdatesLocalState(t *testing.T) {
 	)
 	t.Cleanup(syncer.Stop)
 
-	srv := server.New(database, syncer, nil, "/", nil, server.ServerOptions{})
+	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{})
 	syncer.RunOnce(ctx)
 
 	dbRepo, err := database.GetRepoByIdentity(ctx, db.RepoIdentity{

--- a/internal/server/e2etest/gitlab_mutations_test.go
+++ b/internal/server/e2etest/gitlab_mutations_test.go
@@ -19,6 +19,7 @@ import (
 	platformgitlab "go.kenn.io/middleman/internal/platform/gitlab"
 	"go.kenn.io/middleman/internal/server"
 	"go.kenn.io/middleman/internal/testutil/dbtest"
+	"go.kenn.io/middleman/internal/testutil/servertest"
 	"go.kenn.io/middleman/internal/tokenauth"
 )
 
@@ -357,7 +358,7 @@ func setupGitLabMutationServer(
 	)
 	t.Cleanup(syncer.Stop)
 
-	srv := server.New(database, syncer, nil, "/", nil, server.ServerOptions{})
+	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{})
 	t.Cleanup(func() { gracefulShutdown(t, srv) })
 	return srv, database, recorder, repoID
 }
@@ -1003,7 +1004,7 @@ func TestGitLabSquashAlwaysProjectDisallowsMergeCommitE2E(t *testing.T) {
 		registry, database, nil, []ghclient.RepoRef{repo}, time.Minute, nil, nil,
 	)
 	t.Cleanup(syncer.Stop)
-	srv := server.New(database, syncer, nil, "/", nil, server.ServerOptions{})
+	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{})
 
 	syncer.RunOnce(ctx)
 

--- a/internal/server/e2etest/gitlab_sync_pin_test.go
+++ b/internal/server/e2etest/gitlab_sync_pin_test.go
@@ -27,6 +27,7 @@ import (
 	platformgitlab "go.kenn.io/middleman/internal/platform/gitlab"
 	"go.kenn.io/middleman/internal/server"
 	"go.kenn.io/middleman/internal/testutil/dbtest"
+	"go.kenn.io/middleman/internal/testutil/servertest"
 )
 
 // setupGitLabCloneFixture builds a local git history (base commit on
@@ -124,7 +125,7 @@ func TestGitLabSyncPRSurfacesTransientForkSourceProjectLookupAsUpstream(t *testi
 		registry, database, gitclone.New(t.TempDir(), nil), []ghclient.RepoRef{repo}, time.Minute, nil, nil,
 	)
 	t.Cleanup(syncer.Stop)
-	srv := server.New(database, syncer, nil, "/", nil, server.ServerOptions{})
+	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{})
 
 	rr := doGitLabJSON(t, srv, http.MethodPost, "/api/v1/pulls/gitlab/acme/widget/7/sync", `{}`)
 	require.Equal(http.StatusBadGateway, rr.Code, rr.Body.String())
@@ -240,7 +241,7 @@ func TestGitLabNormalSyncEnablesHeadBoundMutations(t *testing.T) {
 		registry, database, clones, []ghclient.RepoRef{repo}, time.Minute, nil, nil,
 	)
 	t.Cleanup(syncer.Stop)
-	srv := server.New(database, syncer, nil, "/", nil, server.ServerOptions{})
+	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{})
 
 	// A normal periodic sync discovers the MR; the detail sync — the
 	// same one a detail view or post-conflict reload performs — fills

--- a/internal/server/e2etest/labels_provider_test.go
+++ b/internal/server/e2etest/labels_provider_test.go
@@ -23,6 +23,7 @@ import (
 	gitlabprovider "go.kenn.io/middleman/internal/platform/gitlab"
 	"go.kenn.io/middleman/internal/server"
 	"go.kenn.io/middleman/internal/testutil/dbtest"
+	"go.kenn.io/middleman/internal/testutil/servertest"
 	"go.kenn.io/middleman/internal/tokenauth"
 )
 
@@ -155,7 +156,7 @@ func newLabelTestServer(
 		time.Minute, nil, nil,
 	)
 	t.Cleanup(syncer.Stop)
-	srv := server.New(database, syncer, nil, "/", nil, server.ServerOptions{})
+	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{})
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()

--- a/internal/server/e2etest/settings_test.go
+++ b/internal/server/e2etest/settings_test.go
@@ -25,6 +25,7 @@ import (
 	"go.kenn.io/middleman/internal/github"
 	"go.kenn.io/middleman/internal/server"
 	"go.kenn.io/middleman/internal/testutil/dbtest"
+	"go.kenn.io/middleman/internal/testutil/servertest"
 )
 
 func doServerJSON(
@@ -222,7 +223,7 @@ name = "widget"
 	seedReadyRuntimeWorkspace(t, database, workspacePath)
 	syncer := github.NewSyncer(nil, database, nil, nil, time.Minute, nil, nil)
 	t.Cleanup(syncer.Stop)
-	srv := server.NewWithConfig(
+	srv := servertest.NewWithConfig(t,
 		database, syncer, nil, nil, cfg, cfgPath,
 		server.ServerOptions{
 			WorktreeDir:                        filepath.Join(dir, "worktrees"),
@@ -771,7 +772,7 @@ name = "widget"
 	)
 	t.Cleanup(syncer.Stop)
 
-	srv := server.NewWithConfig(
+	srv := servertest.NewWithConfig(t,
 		database, syncer, nil, nil, cfg, cfgPath,
 		server.ServerOptions{WorktreeDir: filepath.Join(dir, "workspaces")},
 	)
@@ -926,7 +927,7 @@ func TestWorkspaceAPIE2ERejectsEmptyProviderForAmbiguousRepo(t *testing.T) {
 	database := dbtest.Open(t)
 	syncer := github.NewSyncer(nil, database, nil, nil, time.Minute, nil, nil)
 	t.Cleanup(syncer.Stop)
-	srv := server.New(
+	srv := servertest.New(t,
 		database, syncer, nil, "/", nil,
 		server.ServerOptions{WorktreeDir: filepath.Join(t.TempDir(), "workspaces")},
 	)

--- a/internal/server/e2etest/sync_cooldown_test.go
+++ b/internal/server/e2etest/sync_cooldown_test.go
@@ -22,6 +22,7 @@ import (
 	"go.kenn.io/middleman/internal/platform"
 	"go.kenn.io/middleman/internal/server"
 	"go.kenn.io/middleman/internal/testutil/dbtest"
+	"go.kenn.io/middleman/internal/testutil/servertest"
 )
 
 func TestTriggerSyncE2EBypassesCooldown(t *testing.T) {
@@ -474,7 +475,7 @@ func startSyncCooldownE2EServerWithSyncer(
 	)
 	t.Cleanup(syncer.Stop)
 
-	srv := server.NewWithConfig(
+	srv := servertest.NewWithConfig(t,
 		database, syncer, nil, nil, cfg, cfgPath,
 		server.ServerOptions{HostCheckAllowLoopbackAnyPort: true},
 	)

--- a/internal/server/e2etest/sync_routes_test.go
+++ b/internal/server/e2etest/sync_routes_test.go
@@ -18,6 +18,7 @@ import (
 	platformgithub "go.kenn.io/middleman/internal/platform/github"
 	"go.kenn.io/middleman/internal/server"
 	"go.kenn.io/middleman/internal/testutil/dbtest"
+	"go.kenn.io/middleman/internal/testutil/servertest"
 )
 
 func TestSyncRoutesWithoutProviderSyncerE2E(t *testing.T) {
@@ -25,7 +26,7 @@ func TestSyncRoutesWithoutProviderSyncerE2E(t *testing.T) {
 	require := require.New(t)
 
 	database := dbtest.Open(t)
-	srv := server.New(database, nil, nil, "/", nil, server.ServerOptions{
+	srv := servertest.New(t, database, nil, nil, "/", nil, server.ServerOptions{
 		HostCheckAllowLoopbackAnyPort: true,
 	})
 	ts := httptest.NewServer(srv)
@@ -114,7 +115,7 @@ func TestSyncListNotModifiedDoesNotChangeRateLimitBudgetE2E(t *testing.T) {
 	)
 	t.Cleanup(syncer.Stop)
 
-	srv := server.New(database, syncer, nil, "/", nil, server.ServerOptions{
+	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{
 		HostCheckAllowLoopbackAnyPort: true,
 	})
 	middleman := httptest.NewServer(srv)

--- a/internal/server/e2etest/token_rotation_test.go
+++ b/internal/server/e2etest/token_rotation_test.go
@@ -25,6 +25,7 @@ import (
 	platformgitlab "go.kenn.io/middleman/internal/platform/gitlab"
 	"go.kenn.io/middleman/internal/server"
 	"go.kenn.io/middleman/internal/testutil/dbtest"
+	"go.kenn.io/middleman/internal/testutil/servertest"
 	"go.kenn.io/middleman/internal/tokenauth"
 )
 
@@ -124,7 +125,7 @@ token_file = %q
 		registry, database, nil, []ghclient.RepoRef{ref}, time.Minute, nil, nil,
 	)
 	t.Cleanup(syncer.Stop)
-	srv := server.NewWithConfig(
+	srv := servertest.NewWithConfig(t,
 		database, syncer, nil, nil, cfg, cfgPath,
 		server.ServerOptions{TokenSources: sourceSet},
 	)
@@ -476,7 +477,7 @@ func TestRuntimeLaunchStripsReloadedAndImplicitTokenEnvsE2E(t *testing.T) {
 	database := dbtest.Open(t)
 	syncer := ghclient.NewSyncer(nil, database, nil, nil, time.Minute, nil, nil)
 	t.Cleanup(syncer.Stop)
-	srv := server.NewWithConfig(
+	srv := servertest.NewWithConfig(t,
 		database, syncer, nil, nil, cfg, cfgPath,
 		server.ServerOptions{
 			WorktreeDir:                        filepath.Join(dir, "worktrees"),
@@ -572,7 +573,7 @@ name = "widget"
 		database, nil, nil, time.Minute, nil, nil,
 	)
 	t.Cleanup(syncer.Stop)
-	srv := server.NewWithConfig(
+	srv := servertest.NewWithConfig(t,
 		database, syncer, nil, nil, cfg, cfgPath, server.ServerOptions{},
 	)
 	t.Cleanup(func() { gracefulShutdown(t, srv) })
@@ -655,7 +656,7 @@ func TestSharedHostCloneAuthFollowsSurvivingProviderTokenE2E(t *testing.T) {
 		registry, database, nil, nil, time.Minute, nil, nil,
 	)
 	t.Cleanup(syncer.Stop)
-	srv := server.NewWithConfig(
+	srv := servertest.NewWithConfig(t,
 		database, syncer, nil, nil, cfg, cfgPath,
 		server.ServerOptions{TokenSources: sourceSet},
 	)
@@ -773,7 +774,7 @@ func startGitLabTokenSyncServer(
 		registry, database, nil, []ghclient.RepoRef{ref}, time.Minute, nil, nil,
 	)
 	t.Cleanup(syncer.Stop)
-	srv := server.NewWithConfig(
+	srv := servertest.NewWithConfig(t,
 		database, syncer, nil, nil, cfg, cfgPath,
 		server.ServerOptions{TokenSources: sourceSet},
 	)

--- a/internal/server/e2etest/worktree_events_test.go
+++ b/internal/server/e2etest/worktree_events_test.go
@@ -17,6 +17,7 @@ import (
 	ghclient "go.kenn.io/middleman/internal/github"
 	"go.kenn.io/middleman/internal/server"
 	"go.kenn.io/middleman/internal/testutil/dbtest"
+	"go.kenn.io/middleman/internal/testutil/servertest"
 )
 
 // TestE2E_WorktreeLinkChangeReachesSSE drives the sync-completed path
@@ -36,7 +37,7 @@ func TestE2E_WorktreeLinkChangeReachesSSE(t *testing.T) {
 	t.Cleanup(syncer.Stop)
 	cfg := &config.Config{BasePath: "/"}
 	cfg.Tmux.Command = []string{"middleman-no-such-tmux"}
-	srv := server.New(database, syncer, nil, "/", cfg, server.ServerOptions{
+	srv := servertest.New(t, database, syncer, nil, "/", cfg, server.ServerOptions{
 		WorktreeDir:                        t.TempDir(),
 		DisableWorkspaceBackgroundMonitors: true,
 		HostCheck: server.HostCheckOptions{

--- a/internal/server/workspacetest/fixtures_test.go
+++ b/internal/server/workspacetest/fixtures_test.go
@@ -22,6 +22,7 @@ import (
 	ghclient "go.kenn.io/middleman/internal/github"
 	"go.kenn.io/middleman/internal/server"
 	"go.kenn.io/middleman/internal/testutil/dbtest"
+	"go.kenn.io/middleman/internal/testutil/servertest"
 )
 
 type workspaceServerFixture struct {
@@ -89,7 +90,7 @@ func setupWorkspaceServerFixture(
 		basePath = cfg.BasePath
 	}
 	seedPROnHost(t, database, "github.com", "acme", "widget", 1)
-	srv := server.New(database, syncer, nil, basePath, cfg, server.ServerOptions{
+	srv := servertest.New(t, database, syncer, nil, basePath, cfg, server.ServerOptions{
 		Clones:                             clones,
 		WorktreeDir:                        worktreeDir,
 		DisableWorkspaceBackgroundMonitors: true,

--- a/internal/testutil/servertest/servertest.go
+++ b/internal/testutil/servertest/servertest.go
@@ -1,0 +1,60 @@
+package servertest
+
+import (
+	"context"
+	"io/fs"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/middleman/internal/config"
+	"go.kenn.io/middleman/internal/db"
+	"go.kenn.io/middleman/internal/gitclone"
+	ghclient "go.kenn.io/middleman/internal/github"
+	"go.kenn.io/middleman/internal/server"
+)
+
+const shutdownTimeout = 5 * time.Second
+
+// New constructs a server and registers graceful shutdown with t.
+func New(
+	t testing.TB,
+	database *db.DB,
+	syncer *ghclient.Syncer,
+	frontend fs.FS,
+	basePath string,
+	cfg *config.Config,
+	opts server.ServerOptions,
+) *server.Server {
+	t.Helper()
+	return registerCleanup(t, server.New(
+		database, syncer, frontend, basePath, cfg, opts,
+	))
+}
+
+// NewWithConfig constructs a configured server and registers graceful shutdown with t.
+func NewWithConfig(
+	t testing.TB,
+	database *db.DB,
+	syncer *ghclient.Syncer,
+	clones *gitclone.Manager,
+	frontend fs.FS,
+	cfg *config.Config,
+	cfgPath string,
+	opts server.ServerOptions,
+) *server.Server {
+	t.Helper()
+	return registerCleanup(t, server.NewWithConfig(
+		database, syncer, clones, frontend, cfg, cfgPath, opts,
+	))
+}
+
+func registerCleanup(t testing.TB, srv *server.Server) *server.Server {
+	t.Helper()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer cancel()
+		require.NoError(t, srv.Shutdown(ctx))
+	})
+	return srv
+}


### PR DESCRIPTION
## Summary

- Prevent intermittent SQLite temp-directory cleanup failures in black-box server tests.
- Make graceful server teardown the default across API, e2e, and workspace test fixtures.
- Record the lifecycle requirement in the testing context.

<sup>generated by a clanker</sup>