### PR TITLE
Fix compact pull file controls

### DIFF
--- a/frontend/src/lib/components/RepoTypeahead.svelte
+++ b/frontend/src/lib/components/RepoTypeahead.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Card } from "@kenn-io/kit-ui";
+  import { Button } from "@kenn-io/kit-ui";
   import { onMount, tick } from "svelte";
   import {
     canonicalRepoFilterValue,
@@ -379,10 +379,9 @@
       {/each}
     </ul>
   {:else}
-    <Card
+    <Button
       class="typeahead-trigger"
-      level="inset"
-      padding="none"
+      size="sm"
       ariaLabel={`Select repository: ${displayValue}`}
       onclick={openDropdown}
     >
@@ -393,7 +392,7 @@
         strokeWidth="2"
         aria-hidden="true"
       />
-    </Card>
+    </Button>
   {/if}
 </div>
 
@@ -404,20 +403,13 @@
     max-width: 260px;
   }
 
-  :global(.typeahead-trigger.kit-card) {
+  :global(.typeahead-trigger.kit-button) {
     height: 26px;
     width: 100%;
-    gap: 4px;
-    padding: 0 8px;
+    justify-content: flex-start;
+    gap: var(--space-2);
+    padding: 0 var(--space-4);
     font-size: var(--font-size-xs);
-    color: var(--text-secondary);
-  }
-
-  :global(.typeahead-trigger .kit-card__body) {
-    display: flex;
-    width: 100%;
-    align-items: center;
-    gap: 4px;
   }
 
   .typeahead-value {

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -1645,6 +1645,39 @@ test.describe("diff view", () => {
     await expect(page.locator(".diff-file")).toHaveCount(4);
   });
 
+  test("keeps repository and commit scope controls in the compact button family", async ({ page }) => {
+    await navigateToDiff(page);
+
+    const repository = page.getByRole("button", { name: /^Select repository:/ });
+    const commitScope = page.getByRole("button", { name: /^Select commit range:/ });
+    await expect(repository).toBeVisible();
+    await expect(commitScope).toBeVisible();
+    await expect(repository).toHaveClass(/\bkit-button\b/);
+    await expect(commitScope).toHaveClass(/\bkit-button\b/);
+
+    const metrics = await page.evaluate(() => {
+      const inspect = (selector: string) => {
+        const element = document.querySelector<HTMLElement>(selector);
+        const style = element ? getComputedStyle(element) : null;
+        const rect = element?.getBoundingClientRect();
+        return {
+          height: rect?.height ?? 0,
+          background: style?.backgroundColor ?? "",
+          border: style?.border ?? "",
+          radius: style?.borderRadius ?? "",
+        };
+      };
+
+      return {
+        repository: inspect(".typeahead-trigger"),
+        commitScope: inspect(".diff-scope-picker__trigger"),
+      };
+    });
+
+    expect(metrics.repository).toEqual(metrics.commitScope);
+    expect(metrics.repository.height).toBe(26);
+  });
+
   test("resizes and remembers the changed-file tree width", async ({ page }) => {
     await mockDiffApi(page, smallDiff);
     await navigateToDiff(page);
@@ -3663,7 +3696,7 @@ test.describe("diff view", () => {
     await commitItems.first().click();
 
     await expect(page.locator(".diff-scope-picker .diff-scope-label")).toHaveText("abc1234");
-    await expect(page.locator(".diff-scope-picker__control .scope-pill")).toHaveCount(0);
+    await expect(page.locator(".diff-scope-picker__trigger .scope-pill")).toHaveCount(0);
     await expect(page.locator(".diff-file")).toHaveCount(1);
     await expect(page.locator(".diff-file").first()).toHaveAttribute("data-file-path", "frontend/src/scoped.ts");
 

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -1654,6 +1654,9 @@ test.describe("diff view", () => {
     await expect(commitScope).toBeVisible();
     await expect(repository).toHaveClass(/\bkit-button\b/);
     await expect(commitScope).toHaveClass(/\bkit-button\b/);
+    await expect(commitScope).toHaveText("HEAD");
+    await expect(commitScope.locator(".diff-scope-picker__chevron")).toBeVisible();
+    await expect(commitScope.locator("svg")).toHaveCount(2);
 
     const metrics = await page.evaluate(() => {
       const inspect = (selector: string) => {

--- a/packages/ui/src/components/diff/DiffScopePicker.svelte
+++ b/packages/ui/src/components/diff/DiffScopePicker.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { Button } from "@kenn-io/kit-ui";
+  import ChevronDownIcon from "@lucide/svelte/icons/chevron-down";
   import GitCommitHorizontalIcon from "@lucide/svelte/icons/git-commit-horizontal";
   import { getStores } from "../../context.js";
   import CommitListItem from "./CommitListItem.svelte";
@@ -85,13 +86,14 @@
     disabled={disabled}
     onclick={toggle}
   >
-    {#if compact}
-      <GitCommitHorizontalIcon size={16} strokeWidth={1.8} aria-hidden="true" />
-      <DiffScopeLabel {scope} />
-    {:else}
-      <span class="diff-scope-picker__label">Commits</span>
-      <DiffScopeLabel {scope} />
-    {/if}
+    <GitCommitHorizontalIcon size={14} strokeWidth={1.8} aria-hidden="true" />
+    <DiffScopeLabel {scope} />
+    <ChevronDownIcon
+      class="diff-scope-picker__chevron"
+      size={12}
+      strokeWidth={2}
+      aria-hidden="true"
+    />
   </Button>
 
   {#if open}
@@ -142,10 +144,19 @@
 
   :global(.diff-scope-picker__trigger.kit-button) {
     height: 26px;
-    gap: var(--space-4);
+    gap: var(--space-3);
     padding: 0 var(--space-3);
     font-size: inherit;
     line-height: 1;
+  }
+
+  :global(.diff-scope-picker__trigger .diff-scope-label) {
+    font-size: var(--font-size-xs);
+  }
+
+  :global(.diff-scope-picker__chevron) {
+    flex-shrink: 0;
+    opacity: 0.55;
   }
 
   .diff-scope-picker--compact :global(.diff-scope-picker__trigger.kit-button) {
@@ -154,15 +165,6 @@
     max-width: 130px;
     padding: 0 var(--space-4);
     overflow: hidden;
-  }
-
-  .diff-scope-picker__label {
-    display: inline-flex;
-    align-items: center;
-    font-size: var(--font-size-xs);
-    font-weight: 600;
-    line-height: 1;
-    white-space: nowrap;
   }
 
   .diff-scope-picker__menu {

--- a/packages/ui/src/components/diff/DiffScopePicker.svelte
+++ b/packages/ui/src/components/diff/DiffScopePicker.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { Button } from "@kenn-io/kit-ui";
   import GitCommitHorizontalIcon from "@lucide/svelte/icons/git-commit-horizontal";
   import { getStores } from "../../context.js";
   import CommitListItem from "./CommitListItem.svelte";
@@ -75,25 +76,23 @@
   class={["diff-scope-picker", compact && "diff-scope-picker--compact"]}
   bind:this={pickerRef}
 >
-  <div class="diff-scope-picker__control">
-    <button
-      class="diff-scope-picker__trigger"
-      type="button"
-      aria-label={`Select commit range: ${scopeLabel}`}
-      aria-expanded={open}
-      title="Commits"
-      disabled={disabled}
-      onclick={toggle}
-    >
-      {#if compact}
-        <GitCommitHorizontalIcon size={16} strokeWidth={1.8} aria-hidden="true" />
-        <DiffScopeLabel {scope} />
-      {:else}
-        <span class="diff-scope-picker__label">Commits</span>
-        <DiffScopeLabel {scope} />
-      {/if}
-    </button>
-  </div>
+  <Button
+    class="diff-scope-picker__trigger"
+    size="sm"
+    ariaLabel={`Select commit range: ${scopeLabel}`}
+    ariaExpanded={open}
+    title="Commits"
+    disabled={disabled}
+    onclick={toggle}
+  >
+    {#if compact}
+      <GitCommitHorizontalIcon size={16} strokeWidth={1.8} aria-hidden="true" />
+      <DiffScopeLabel {scope} />
+    {:else}
+      <span class="diff-scope-picker__label">Commits</span>
+      <DiffScopeLabel {scope} />
+    {/if}
+  </Button>
 
   {#if open}
     <div class="diff-scope-picker__menu">
@@ -141,49 +140,20 @@
     flex-shrink: 0;
   }
 
-  .diff-scope-picker__control {
-    display: inline-flex;
-    align-items: center;
-    box-sizing: border-box;
-    gap: 6px;
+  :global(.diff-scope-picker__trigger.kit-button) {
     height: 26px;
-    padding: 2px 6px;
-    border: 1px solid var(--border-muted);
-    border-radius: var(--radius-sm);
-    background: var(--bg-surface);
-    color: var(--text-secondary);
-  }
-
-  .diff-scope-picker__control:hover {
-    border-color: var(--accent-blue);
-    color: var(--text-primary);
-  }
-
-  .diff-scope-picker__trigger {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-    padding: 0;
-    border: 0;
-    background: transparent;
-    color: inherit;
-    font: inherit;
+    gap: var(--space-4);
+    padding: 0 var(--space-3);
+    font-size: inherit;
     line-height: 1;
   }
 
-  .diff-scope-picker--compact .diff-scope-picker__control {
-    gap: 0;
-    padding: 0;
+  .diff-scope-picker--compact :global(.diff-scope-picker__trigger.kit-button) {
+    gap: var(--space-3);
+    min-width: 80px;
+    max-width: 130px;
+    padding: 0 var(--space-4);
     overflow: hidden;
-  }
-
-  .diff-scope-picker--compact .diff-scope-picker__trigger {
-    gap: 6px;
-    min-width: 78px;
-    max-width: 128px;
-    height: 24px;
-    padding: 0 8px;
   }
 
   .diff-scope-picker__label {

--- a/packages/ui/src/components/diff/DiffScopePicker.test.ts
+++ b/packages/ui/src/components/diff/DiffScopePicker.test.ts
@@ -21,12 +21,11 @@ function compiledStyle(source: string, selector: string): CSSStyleDeclaration {
 describe("DiffScopePicker", () => {
   it("keeps toolbar labels vertically centered", () => {
     const trigger = compiledStyle(pickerSource, ".diff-scope-picker__trigger");
-    const label = compiledStyle(pickerSource, ".diff-scope-picker__label");
+    const pickerScope = compiledStyle(pickerSource, ".diff-scope-picker__trigger .diff-scope-label");
     const scope = compiledStyle(labelSource, ".diff-scope-label");
 
     expect(trigger.getPropertyValue("line-height")).toBe("1");
-    expect(label.getPropertyValue("display")).toBe("inline-flex");
-    expect(label.getPropertyValue("line-height")).toBe("1");
+    expect(pickerScope.getPropertyValue("font-size")).toBe("var(--font-size-xs)");
     expect(scope.getPropertyValue("display")).toBe("inline-flex");
     expect(scope.getPropertyValue("line-height")).toBe("1");
   });

--- a/packages/ui/src/stores/detail.svelte.ts
+++ b/packages/ui/src/stores/detail.svelte.ts
@@ -1292,7 +1292,7 @@ export function createDetailStore(opts: DetailStoreOptions) {
     const requestSelectionGeneration = selectionGeneration;
     const expectedHeadSHA = detail?.platform_head_sha ?? "";
     try {
-      const { data: applyResult, error: requestError } = await apiClient.POST(
+      const { error: requestError } = await apiClient.POST(
         providerItemPath("pulls", ref, "/review-suggestions/apply"),
         {
           params: {


### PR DESCRIPTION
- Render the repository selector and commit scope picker with the shared compact button treatment.
- Show the commit scope as an icon, current value, and dropdown chevron.
- Preserve existing interactions and responsive sizing, with browser regression coverage for the control geometry and picker affordance.

![ui-control-after-picker.png](https://github.com/user-attachments/assets/080ffd6c-53b5-4765-9931-bf66aec4cecb)
