### PR TITLE
Block TypeScript 7.0 Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,6 +29,10 @@
       "groupSlug": "javascript-dependencies"
     },
     {
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "!/^(7\\.0\\.)/"
+    },
+    {
       "matchManagers": ["github-actions"],
       "groupName": "GitHub Actions",
       "groupSlug": "github-actions"


### PR DESCRIPTION
Middleman's Svelte validation still depends on the compiler API that TypeScript 7.0 omits. Renovate should therefore skip the 7.0.x release line if TypeScript is surfaced as a managed dependency, rather than introducing an incompatible frontend toolchain through the grouped JavaScript update.

Other Bun and JavaScript dependency updates remain unaffected.

<sup>generated by a clanker</sup>
