### PR TITLE
fix: restore compact PR comment spacing

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/state": "^6.6.0",
         "@codemirror/view": "^6.43.0",
-        "@kenn-io/kit-ui": "github:kenn-io/kit-ui#4d90fdf8a81424f53e92d45dc38fc24340894ee0",
+        "@kenn-io/kit-ui": "github:kenn-io/kit-ui#931f80c9d24444da531ece3fdcac359ec746fe62",
         "@lucide/svelte": "1.23.0",
         "@middleman/ui": "workspace:*",
         "@pierre/diffs": "1.2.12",
@@ -74,7 +74,7 @@
       "name": "@middleman/ui",
       "version": "0.0.1",
       "dependencies": {
-        "@kenn-io/kit-ui": "github:kenn-io/kit-ui#4d90fdf8a81424f53e92d45dc38fc24340894ee0",
+        "@kenn-io/kit-ui": "github:kenn-io/kit-ui#931f80c9d24444da531ece3fdcac359ec746fe62",
         "@lucide/svelte": "1.23.0",
         "@pierre/diffs": "1.2.12",
         "@pierre/trees": "1.0.0-beta.5",
@@ -232,7 +232,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@kenn-io/kit-ui": ["@kenn-io/kit-ui@github:kenn-io/kit-ui#4d90fdf", { "peerDependencies": { "@lucide/svelte": ">=1.0.0", "dompurify": "^3.2.0", "marked": "^18.0.0", "mermaid": ">=11.15.0 <12", "shiki": "^4.0.0", "svelte": "^5.29.0" }, "optionalPeers": ["mermaid"], "bin": { "kit-ui-check": "./bin/kit-ui-check.mjs" } }, "kenn-io-kit-ui-4d90fdf", "sha512-mgje8UnOPax2RrwALBE/+ZAcyQ866TeH/M6TLL+o1QDV2U7pkgXO1s8qHOU7Sx8iQKhWeDEnGLQZNcMsOK/8vA=="],
+    "@kenn-io/kit-ui": ["@kenn-io/kit-ui@github:kenn-io/kit-ui#931f80c", { "peerDependencies": { "@lucide/svelte": ">=1.0.0", "dompurify": "^3.2.0", "marked": "^18.0.0", "mermaid": ">=11.15.0 <12", "shiki": "^4.0.0", "svelte": "^5.29.0" }, "optionalPeers": ["mermaid"], "bin": { "kit-ui-check": "./bin/kit-ui-check.mjs" } }, "kenn-io-kit-ui-931f80c", "sha512-DZoCMAdaUg8wVUcEnaGPURN+rfqwdARd1IlakoS/MJ3YIiXCwTLR26qXGEjT5xFGJAZoM+htvMiM1X2Z6EFkzA=="],
 
     "@lezer/common": ["@lezer/common@1.5.2", "", {}, "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,7 +25,7 @@
     "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/state": "^6.6.0",
     "@codemirror/view": "^6.43.0",
-    "@kenn-io/kit-ui": "github:kenn-io/kit-ui#4d90fdf8a81424f53e92d45dc38fc24340894ee0",
+    "@kenn-io/kit-ui": "github:kenn-io/kit-ui#931f80c9d24444da531ece3fdcac359ec746fe62",
     "@lucide/svelte": "1.23.0",
     "@middleman/ui": "workspace:*",
     "@pierre/diffs": "1.2.12",

--- a/frontend/src/App.pr-timeline-filters.browser.svelte.ts
+++ b/frontend/src/App.pr-timeline-filters.browser.svelte.ts
@@ -88,7 +88,10 @@ function ev(mrID: number, eventType: string, fields: Record<string, unknown>) {
 function widgetsOneEvents() {
   const id = 1001;
   return [
-    ev(id, "issue_comment", { Author: "bob", Body: "Looks like a solid approach. Minor nit on naming." }),
+    ev(id, "issue_comment", {
+      Author: "review-bot[bot]",
+      Body: "## Automated review summary\n\nFollow-up findings belong close to the comment header.",
+    }),
     ev(id, "issue_comment", { Author: "carol", Body: "I agree, caching here will help a lot." }),
     ev(id, "review", { Author: "bob", Summary: "APPROVED", Body: "LGTM after addressing the naming nit." }),
     ev(id, "commit", {
@@ -333,6 +336,18 @@ describe("PR timeline filters", () => {
     expect(detailText(".kit-timeline")).toContain('"Add widget cache" -> "Add widget caching layer"');
     expect(detailText(".kit-timeline")).toContain("Base changed");
     expect(detailText(".kit-timeline")).toContain("develop -> main");
+  });
+
+  it("keeps heading-first comment content one spacing step below its header", async () => {
+    await mountTimeline("/pulls/github/acme/widgets/1");
+    await vi.waitFor(() => expect(document.querySelector(".pull-detail .event-body h2")).not.toBeNull(), WAIT);
+
+    const heading = document.querySelector<HTMLElement>(".pull-detail .event-body h2")!;
+    const card = heading.closest<HTMLElement>(".kit-comment-card")!;
+    const header = card.querySelector<HTMLElement>(".kit-card__header")!;
+    const contentGap = heading.getBoundingClientRect().top - header.getBoundingClientRect().bottom;
+
+    expect(contentGap).toBeCloseTo(8, 2);
   });
 
   it("renders merged lifecycle transitions as one purple row", async () => {

--- a/frontend/src/lib/components/kata/KataIssueProperties.test.ts
+++ b/frontend/src/lib/components/kata/KataIssueProperties.test.ts
@@ -246,6 +246,7 @@ describe("KataIssueProperties", () => {
     const ownerInput = screen.getByRole("combobox", { name: "Owner" });
     expect(ownerInput).toBe(document.activeElement);
     await fireEvent.input(ownerInput, { target: { value: "planner" } });
+    await fireEvent.keyDown(ownerInput, { key: "ArrowUp" });
     await fireEvent.keyDown(ownerInput, { key: "Enter" });
 
     expect(onAssignOwner).toHaveBeenCalledWith("issue-1", "agent:planner");

--- a/frontend/src/lib/components/settings/FleetSettings.test.ts
+++ b/frontend/src/lib/components/settings/FleetSettings.test.ts
@@ -109,6 +109,7 @@ describe("FleetSettings", () => {
     await fireEvent.click(screen.getByRole("button", { name: "SSH peer epyc platform: linux" }));
     const platformInput = screen.getByRole("combobox", { name: "SSH peer epyc platform" });
     await fireEvent.input(platformInput, { target: { value: "mac" } });
+    await fireEvent.keyDown(platformInput, { key: "ArrowUp" });
     await fireEvent.keyDown(platformInput, { key: "Enter" });
     await fireEvent.click(screen.getByRole("button", { name: "Save fleet federation" }));
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -123,7 +123,7 @@
     "typecheck": "cd ../.. && node node_modules/vite-plus/bin/vp run ui-package-typecheck"
   },
   "dependencies": {
-    "@kenn-io/kit-ui": "github:kenn-io/kit-ui#4d90fdf8a81424f53e92d45dc38fc24340894ee0",
+    "@kenn-io/kit-ui": "github:kenn-io/kit-ui#931f80c9d24444da531ece3fdcac359ec746fe62",
     "@lucide/svelte": "1.23.0",
     "@pierre/diffs": "1.2.12",
     "@pierre/trees": "1.0.0-beta.5",

--- a/packages/ui/src/components/detail/EventTimeline.svelte
+++ b/packages/ui/src/components/detail/EventTimeline.svelte
@@ -1847,6 +1847,7 @@
             tone={eventTimelineTone(event.EventType)}
             author={event.Author || undefined}
             time={formatRelativeTime(event.CreatedAt)}
+            bodyGap="none"
           >
             {#snippet actions()}
               {@render eventActions(event, undefined)}

--- a/packages/ui/src/components/detail/EventTimeline.svelte
+++ b/packages/ui/src/components/detail/EventTimeline.svelte
@@ -2365,7 +2365,7 @@
   .event-body {
     font-size: var(--font-size-sm);
     color: var(--text-primary);
-    padding: var(--focus-detail-space-sm, 8px) calc(var(--focus-detail-hit-target, 26px) + var(--focus-detail-space-sm, 8px)) var(--focus-detail-space-sm, 8px) var(--focus-detail-space-sm, 10px);
+    padding: 0 calc(var(--focus-detail-hit-target, 26px) + var(--focus-detail-space-sm, 8px)) var(--focus-detail-space-sm, 8px) var(--focus-detail-space-sm, 10px);
     white-space: pre-wrap;
     word-break: break-word;
     line-height: 1.6;
@@ -2382,6 +2382,10 @@
 
   .event-body.markdown-body {
     white-space: normal;
+  }
+
+  .event-body.markdown-body > :global(:first-child) {
+    margin-top: 0;
   }
 
   .event-body--nested {

--- a/packages/ui/src/components/detail/EventTimeline.test.ts
+++ b/packages/ui/src/components/detail/EventTimeline.test.ts
@@ -439,6 +439,7 @@ describe("EventTimeline", () => {
     expect(wrapper).toBeInstanceOf(HTMLElement);
     expect(body).toBeInstanceOf(HTMLElement);
     expect(bodyWrap).toBeInstanceOf(HTMLElement);
+    expect(wrapper!.classList.contains("kit-comment-card--body-gap-none")).toBe(true);
 
     expect(wrapper!.contains(bodyWrap)).toBe(true);
     expect(bodyWrap!.contains(body)).toBe(true);


### PR DESCRIPTION
Heading-first Markdown comments were stacking three separate top-spacing rules, so automated review comments still looked detached from their headers after the shared card gap was removed.

- Make the timeline wrapper the single owner of the 8px header-to-body interval
- Apply the spacing to heading-first Markdown while preserving compact and system cards
- Add real-browser geometry coverage for automated-review-shaped comments
- Keep canonical Typeahead selection tests aligned with the updated kit-ui dependency

![Corrected PR comment spacing](https://github.com/user-attachments/assets/a07f4b97-1533-4676-824e-e2c79d84bd55)