### PR TITLE
Run Linux CI on self-hosted runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - kenn-linux-x64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
     name: Go tests
     runs-on: kenn-linux-x64
     # Bound package fan-out on high-core runners so concurrent test binaries
-    # stay within the job's memory budget.
+    # and in-package parallel tests stay within the job's memory budget.
     env:
       GOFLAGS: "-p=4"
     needs: detect_changes
@@ -136,7 +136,7 @@ jobs:
       - name: Run tests
         run: |
           mkdir -p tmp
-          go tool gotestsum --format pkgname-and-test-fails --jsonfile=tmp/test-output.json -- ./... -shuffle=on
+          go tool gotestsum --format pkgname-and-test-fails --jsonfile=tmp/test-output.json -- ./... -shuffle=on -parallel=2
 
       - name: Publish unit test report
         if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
@@ -168,7 +168,7 @@ jobs:
       - name: Run integration tests (git-dependent)
         run: |
           mkdir -p tmp
-          go tool gotestsum --format pkgname-and-test-fails --jsonfile=tmp/test-integration-output.json -- -tags integration ./... -shuffle=on
+          go tool gotestsum --format pkgname-and-test-fails --jsonfile=tmp/test-integration-output.json -- -tags integration ./... -shuffle=on -parallel=2
 
       - name: Publish integration test report
         if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
     # and in-package parallel tests stay within the job's memory budget.
     env:
       GOMAXPROCS: "4"
-      GOFLAGS: "-p=2"
+      GOFLAGS: "-p=1"
     needs: detect_changes
     if: needs.detect_changes.outputs.backend == 'true'
     steps:
@@ -239,7 +239,7 @@ jobs:
     # Race-instrumented packages are especially memory-intensive.
     env:
       GOMAXPROCS: "4"
-      GOFLAGS: "-p=2"
+      GOFLAGS: "-p=1"
     needs: detect_changes
     if: needs.detect_changes.outputs.backend == 'true'
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,7 @@ jobs:
     # Bound package fan-out on high-core runners so concurrent test binaries
     # and in-package parallel tests stay within the job's memory budget.
     env:
+      GOMAXPROCS: "4"
       GOFLAGS: "-p=4"
     needs: detect_changes
     if: needs.detect_changes.outputs.backend == 'true'
@@ -236,6 +237,7 @@ jobs:
     runs-on: kenn-linux-x64
     # Race-instrumented packages are especially memory-intensive.
     env:
+      GOMAXPROCS: "4"
       GOFLAGS: "-p=4"
     needs: detect_changes
     if: needs.detect_changes.outputs.backend == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,7 @@ jobs:
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Stub frontend embed dir
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   detect_changes:
     name: Detect changed paths
-    runs-on: ubuntu-latest
+    runs-on: kenn-linux-x64
     outputs:
       backend: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.backend == 'true' || steps.filter.outputs.ci == 'true' }}
       frontend: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.frontend == 'true' || steps.filter.outputs.ci == 'true' }}
@@ -68,7 +68,7 @@ jobs:
               - Makefile
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: kenn-linux-x64
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -77,6 +77,7 @@ jobs:
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Setup Vite+
         uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
@@ -110,7 +111,7 @@ jobs:
 
   test_go:
     name: Go tests
-    runs-on: ubuntu-latest
+    runs-on: kenn-linux-x64
     needs: detect_changes
     if: needs.detect_changes.outputs.backend == 'true'
     steps:
@@ -121,6 +122,7 @@ jobs:
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Stub frontend embed dir
         run: |
@@ -175,7 +177,7 @@ jobs:
 
   test_frontend:
     name: Frontend unit tests
-    runs-on: ubuntu-latest
+    runs-on: kenn-linux-x64
     needs: detect_changes
     if: needs.detect_changes.outputs.backend == 'true' || needs.detect_changes.outputs.frontend == 'true'
     steps:
@@ -227,7 +229,7 @@ jobs:
 
   race:
     name: go test -race
-    runs-on: ubuntu-latest
+    runs-on: kenn-linux-x64
     needs: detect_changes
     if: needs.detect_changes.outputs.backend == 'true'
     steps:
@@ -238,6 +240,7 @@ jobs:
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Stub frontend embed dir
         run: |
@@ -297,7 +300,7 @@ jobs:
           retention-days: 7
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: kenn-linux-x64
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -306,6 +309,7 @@ jobs:
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Setup Vite+
         uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
@@ -326,7 +330,7 @@ jobs:
         run: go build -o middleman ./cmd/middleman
 
   e2e-mock:
-    runs-on: ubuntu-latest
+    runs-on: kenn-linux-x64
     needs: detect_changes
     if: needs.detect_changes.outputs.frontend == 'true' || needs.detect_changes.outputs.e2e == 'true'
     container: mcr.microsoft.com/playwright@sha256:5b8f294aff9041b7191c34a4bab3ac270157a28774d4b0660e9743297b697e48 # v1.61.1-noble
@@ -363,7 +367,7 @@ jobs:
           retention-days: 7
 
   e2e:
-    runs-on: ubuntu-latest
+    runs-on: kenn-linux-x64
     needs: detect_changes
     if: needs.detect_changes.outputs.backend == 'true' || needs.detect_changes.outputs.frontend == 'true' || needs.detect_changes.outputs.e2e == 'true'
     # Run inside the official Playwright image: browsers and their OS deps are
@@ -386,6 +390,7 @@ jobs:
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Setup Vite+
         uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
@@ -454,7 +459,7 @@ jobs:
           retention-days: 7
 
   e2e-roborev:
-    runs-on: ubuntu-latest
+    runs-on: kenn-linux-x64
     needs: detect_changes
     if: needs.detect_changes.outputs.backend == 'true' || needs.detect_changes.outputs.frontend == 'true' || needs.detect_changes.outputs.e2e == 'true'
     env:
@@ -476,6 +481,7 @@ jobs:
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Setup Vite+
         uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
@@ -499,7 +505,7 @@ jobs:
 
   test_browser:
     name: frontend browser tests
-    runs-on: ubuntu-latest
+    runs-on: kenn-linux-x64
     timeout-minutes: 15
     needs: detect_changes
     if: needs.detect_changes.outputs.backend == 'true' || needs.detect_changes.outputs.frontend == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,10 @@ jobs:
   test_go:
     name: Go tests
     runs-on: kenn-linux-x64
+    # Bound package fan-out on high-core runners so concurrent test binaries
+    # stay within the job's memory budget.
+    env:
+      GOFLAGS: "-p=4"
     needs: detect_changes
     if: needs.detect_changes.outputs.backend == 'true'
     steps:
@@ -230,6 +234,9 @@ jobs:
   race:
     name: go test -race
     runs-on: kenn-linux-x64
+    # Race-instrumented packages are especially memory-intensive.
+    env:
+      GOFLAGS: "-p=4"
     needs: detect_changes
     if: needs.detect_changes.outputs.backend == 'true'
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,7 @@ jobs:
     # and in-package parallel tests stay within the job's memory budget.
     env:
       GOMAXPROCS: "4"
+      GOMEMLIMIT: "4GiB"
       GOFLAGS: "-p=1"
     needs: detect_changes
     if: needs.detect_changes.outputs.backend == 'true'
@@ -239,6 +240,7 @@ jobs:
     # Race-instrumented packages are especially memory-intensive.
     env:
       GOMAXPROCS: "4"
+      GOMEMLIMIT: "4GiB"
       GOFLAGS: "-p=1"
     needs: detect_changes
     if: needs.detect_changes.outputs.backend == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
     # and in-package parallel tests stay within the job's memory budget.
     env:
       GOMAXPROCS: "4"
-      GOFLAGS: "-p=4"
+      GOFLAGS: "-p=2"
     needs: detect_changes
     if: needs.detect_changes.outputs.backend == 'true'
     steps:
@@ -239,7 +239,7 @@ jobs:
     # Race-instrumented packages are especially memory-intensive.
     env:
       GOMAXPROCS: "4"
-      GOFLAGS: "-p=4"
+      GOFLAGS: "-p=2"
     needs: detect_changes
     if: needs.detect_changes.outputs.backend == 'true'
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
+          cache: false
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
@@ -97,6 +98,7 @@ jobs:
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
+          cache: false
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,6 +205,7 @@ Coverage of real behavior is non-negotiable; the lane is chosen by the behavior 
 
 ## Pull Requests
 
+- Treat this as a public repository: before pushing or opening a PR, run the scrub-private-data skill and remove unnecessary internal project names, hostnames, credentials, runner topology, and infrastructure details from the diff, commit messages, and PR metadata.
 - Never delete, minimize, hide, resolve, or otherwise remove PR comments, review comments, review threads, or CI/review bot comments unless the user explicitly asks for that exact action. If a comment is stale, false-positive, superseded, or contradicted by current evidence, leave it in place and explain the evidence in a reply or final report instead.
 - PR descriptions should be concise: summarize what changed, not how or why in detail
 - When a PR adds or changes visible UI, use the `capture-playwright` skill to capture a Playwright screenshot or short video and attach it with `gh image`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,6 +206,7 @@ Coverage of real behavior is non-negotiable; the lane is chosen by the behavior 
 ## Pull Requests
 
 - Treat this as a public repository: before pushing or opening a PR, run the scrub-private-data skill and remove unnecessary internal project names, hostnames, credentials, runner topology, and infrastructure details from the diff, commit messages, and PR metadata.
+- This public repository intentionally runs pull-request CI on organization-managed ephemeral self-hosted runners. Repository policy permits only collaborators to create pull requests, and every external fork workflow run requires explicit approval. Treat collaborators and explicitly approved runs as trusted principals; do not flag self-hosted `pull_request` execution on its own.
 - Never delete, minimize, hide, resolve, or otherwise remove PR comments, review comments, review threads, or CI/review bot comments unless the user explicitly asks for that exact action. If a comment is stale, false-positive, superseded, or contradicted by current evidence, leave it in place and explain the evidence in a reply or final report instead.
 - PR descriptions should be concise: summarize what changed, not how or why in detail
 - When a PR adds or changes visible UI, use the `capture-playwright` skill to capture a Playwright screenshot or short video and attach it with `gh image`

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -9,6 +9,7 @@ const baseURL = `http://${host}:${port}`;
 export default defineConfig({
   testDir: "./tests/e2e",
   fullyParallel: true,
+  ...(process.env.CI ? { workers: 2 } : {}),
   timeout: 30_000,
   retries: process.env.CI ? 2 : 0,
   expect: {

--- a/frontend/src/lib/dev/viteConfig.test.ts
+++ b/frontend/src/lib/dev/viteConfig.test.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { describe, expect, it } from "vite-plus/test";
 import config, {
+  resolveBrowserTestWorkers,
   resolveViteAllowedHosts,
   resolveViteHmr,
   resolveViteServerPort,
@@ -8,6 +9,11 @@ import config, {
 } from "../../../vite.config";
 
 describe("vite config", () => {
+  it("bounds browser test concurrency in CI", () => {
+    expect(resolveBrowserTestWorkers({})).toBeUndefined();
+    expect(resolveBrowserTestWorkers({ CI: "1" })).toBe(2);
+  });
+
   it("aliases @middleman/ui to the workspace source tree", () => {
     const aliases = Array.isArray(config.resolve?.alias) ? config.resolve.alias : [];
 

--- a/frontend/src/lib/dev/viteConfig.test.ts
+++ b/frontend/src/lib/dev/viteConfig.test.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { describe, expect, it } from "vite-plus/test";
 import config, {
   resolveBrowserTestWorkers,
+  resolveUnitTestWorkers,
   resolveViteAllowedHosts,
   resolveViteHmr,
   resolveViteServerPort,
@@ -12,6 +13,11 @@ describe("vite config", () => {
   it("bounds browser test concurrency in CI", () => {
     expect(resolveBrowserTestWorkers({})).toBeUndefined();
     expect(resolveBrowserTestWorkers({ CI: "1" })).toBe(2);
+  });
+
+  it("bounds unit test concurrency in CI", () => {
+    expect(resolveUnitTestWorkers({})).toBeUndefined();
+    expect(resolveUnitTestWorkers({ CI: "1" })).toBe(2);
   });
 
   it("aliases @middleman/ui to the workspace source tree", () => {

--- a/frontend/tests/e2e-full/messages.spec.ts
+++ b/frontend/tests/e2e-full/messages.spec.ts
@@ -1100,48 +1100,48 @@ test.describe("messages HTML viewer", () => {
   });
 });
 
-test("messages header tab stays available across setup and health states", async ({ page }) => {
-  {
-    const savedSearches = await configureIsolatedSavedSearches("header-unconfigured");
-    const server = await startIsolatedE2EServer();
-    try {
-      await page.goto(server.info.base_url);
-      await expectMessagesTabOpens(page);
-      await expect(page.getByRole("button", { name: "Set up Messages" })).toBeVisible();
-      await expectMessagesWorkspaceUnavailable(page);
-    } finally {
-      await server.stop();
-      savedSearches.restore();
-    }
+test("messages header tab stays available while unconfigured", async ({ page }) => {
+  const savedSearches = await configureIsolatedSavedSearches("header-unconfigured");
+  const server = await startIsolatedE2EServer();
+  try {
+    await page.goto(server.info.base_url);
+    await expectMessagesTabOpens(page);
+    await expect(page.getByRole("button", { name: "Set up Messages" })).toBeVisible();
+    await expectMessagesWorkspaceUnavailable(page);
+  } finally {
+    await server.stop();
+    savedSearches.restore();
   }
+});
 
-  for (const scenario of [
-    {
-      name: "misconfigured",
-      envValue: undefined,
-      configureBackend: (backend: BackendHandle) => {
-        backend.state.authorized = true;
-      },
-      banner: "Messages are misconfigured",
+for (const scenario of [
+  {
+    name: "misconfigured",
+    envValue: undefined,
+    configureBackend: (backend: BackendHandle) => {
+      backend.state.authorized = true;
     },
-    {
-      name: "down",
-      envValue: "secret-key",
-      configureBackend: (backend: BackendHandle) => {
-        backend.state.authorized = true;
-        backend.state.available = false;
-      },
-      banner: "Messages unavailable - retrying on next refresh.",
+    banner: "Messages are misconfigured",
+  },
+  {
+    name: "down",
+    envValue: "secret-key",
+    configureBackend: (backend: BackendHandle) => {
+      backend.state.authorized = true;
+      backend.state.available = false;
     },
-    {
-      name: "unauthorized",
-      envValue: "secret-key",
-      configureBackend: (backend: BackendHandle) => {
-        backend.state.authorized = false;
-      },
-      banner: "Messages key rejected - check `api_key_env`.",
+    banner: "Messages unavailable - retrying on next refresh.",
+  },
+  {
+    name: "unauthorized",
+    envValue: "secret-key",
+    configureBackend: (backend: BackendHandle) => {
+      backend.state.authorized = false;
     },
-  ]) {
+    banner: "Messages key rejected - check `api_key_env`.",
+  },
+]) {
+  test(`messages header tab stays available when ${scenario.name}`, async ({ page }) => {
     const backend = await startMsgvaultBackend();
     scenario.configureBackend(backend);
     const savedSearches = await configureIsolatedSavedSearches(`header-${scenario.name}`);
@@ -1173,18 +1173,18 @@ test("messages header tab stays available across setup and health states", async
       }
       savedSearches.restore();
     }
-  }
+  });
+}
 
-  {
-    const fixture = await startConfiguredMessagesFixture(page, "headerok");
-    try {
-      await page.goto(fixture.server.info.base_url);
-      await expectMessagesTabOpens(page);
-      await expect(page.getByPlaceholder("Search messages...")).toBeVisible();
-      await expect(page.getByRole("navigation", { name: "Messages facets" })).toBeVisible();
-    } finally {
-      await fixture.stop();
-    }
+test("messages header tab stays available when configured", async ({ page }) => {
+  const fixture = await startConfiguredMessagesFixture(page, "headerok");
+  try {
+    await page.goto(fixture.server.info.base_url);
+    await expectMessagesTabOpens(page);
+    await expect(page.getByPlaceholder("Search messages...")).toBeVisible();
+    await expect(page.getByRole("navigation", { name: "Messages facets" })).toBeVisible();
+  } finally {
+    await fixture.stop();
   }
 });
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -143,6 +143,10 @@ export function resolveBrowserTestWorkers(env: Record<string, string | undefined
   return env.CI ? 2 : undefined;
 }
 
+export function resolveUnitTestWorkers(env: Record<string, string | undefined> = process.env): number | undefined {
+  return env.CI ? 2 : undefined;
+}
+
 function terminalWebSocketProxy(url: string): ProxyOptions {
   const proxy: ProxyOptions = {
     target: url,
@@ -158,10 +162,12 @@ function terminalWebSocketProxy(url: string): ProxyOptions {
 // The "unit" project preserves the prior flat test config: jsdom plus the
 // localStorage/elementFromPoint shims in setup.ts. The browser glob exclude
 // keeps *.browser.svelte.ts files off this project so they never double-run.
+const unitTestMaxWorkers = resolveUnitTestWorkers();
 const unitTestProject = {
   extends: true,
   test: {
     name: "unit",
+    ...(unitTestMaxWorkers ? { maxWorkers: unitTestMaxWorkers } : {}),
     environment: "jsdom",
     setupFiles: ["./src/test/setup.ts"],
     include: ["src/**/*.{test,spec}.?(c|m)[jt]s?(x)", "../packages/ui/src/**/*.{test,spec}.?(c|m)[jt]s?(x)"],

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -139,6 +139,10 @@ export function webSocketDebugEnabled(env: Record<string, string | undefined> = 
   }
 }
 
+export function resolveBrowserTestWorkers(env: Record<string, string | undefined> = process.env): number | undefined {
+  return env.CI ? 2 : undefined;
+}
+
 function terminalWebSocketProxy(url: string): ProxyOptions {
   const proxy: ProxyOptions = {
     target: url,
@@ -188,6 +192,7 @@ const unitTestProject = {
 // keeps the standard "module"/"development|production" placeholders intact.
 const browserTestProject = defineProject(async () => {
   const { playwright } = await import("vite-plus/test/browser-playwright");
+  const maxWorkers = resolveBrowserTestWorkers();
   return {
     extends: true,
     resolve: {
@@ -196,6 +201,7 @@ const browserTestProject = defineProject(async () => {
     test: {
       name: "browser",
       include: ["src/**/*.browser.svelte.ts"],
+      ...(maxWorkers ? { maxWorkers } : {}),
       browser: {
         enabled: true,
         provider: playwright() as never,

--- a/internal/server/workspacetest/fixtures_test.go
+++ b/internal/server/workspacetest/fixtures_test.go
@@ -94,6 +94,7 @@ func setupWorkspaceServerFixture(
 		Clones:                             clones,
 		WorktreeDir:                        worktreeDir,
 		DisableWorkspaceBackgroundMonitors: true,
+		PtyOwnerInProcess:                  true,
 		HostCheck: server.HostCheckOptions{
 			Bind:    config.HostKey{Host: "127.0.0.1", Port: "8091"},
 			Allowed: []config.HostKey{{Host: "middleman.test", Port: ""}},


### PR DESCRIPTION
Linux CI repeatedly pays hosted-runner setup and dependency transfer costs. Organization-managed ephemeral runners can reuse warm local state while Windows and release jobs remain hosted.

- Move Linux CI jobs to the self-hosted runner group while keeping Windows and release jobs hosted.
- Disable redundant setup-go cache transfers across CI and release workflows.
- Bound frontend worker counts and Go package, runtime, and memory concurrency for high-core, memory-bounded jobs.
- Make workspace test fixtures independent of tmux availability by using the in-process PTY owner.
- Give independently provisioned E2E states separate timeout budgets.
- Record the trusted-collaborator and approved-run boundary for public pull-request CI.