### PR TITLE
fix: eliminate PR refresh judder and duplicate indicators

### DIFF
--- a/context/ui-design-system.md
+++ b/context/ui-design-system.md
@@ -15,6 +15,9 @@ Use this document as the intent-level guide for frontend UI work in `middleman`.
 - Layouts should feel compact, deliberate, and information-rich.
 - Visual emphasis should come from hierarchy and semantic color, not oversized controls or decorative effects.
 - Light and dark themes should express the same UI language through shared tokens.
+- PR detail background refresh has one progress surface: the metadata-row
+  `Syncing` indicator; do not add a second stale-data banner or spinner
+  (`packages/ui/src/components/detail/PullDetail.svelte`).
 
 ## Sources of truth
 

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -2907,7 +2907,7 @@ test.describe("diff view", () => {
     await expect.poll(() => renderedDiffFilePaths(page)).toEqual(expectedFileOrder);
   });
 
-  test("stale diff banner overlays without shifting diff content", async ({ page }) => {
+  test("stale diff warning stays clear of file controls without shifting diff content", async ({ page }) => {
     let fixture = staleDiff;
     await mockDiffApi(page, () => fixture);
     await navigateToDiff(page);
@@ -2920,44 +2920,22 @@ test.describe("diff view", () => {
     const firstContent = firstFile.locator(".file-content");
     await expect(banner).toBeVisible();
     await expect(banner).toContainText("outdated");
-    await expect(banner).toHaveCSS("pointer-events", "none");
     const staleBounds = await diffBody.boundingBox();
     expect(staleBounds).not.toBeNull();
 
     const bannerBounds = await visibleBoundingBox(banner);
     const headerBounds = await visibleBoundingBox(firstHeader);
-    const overlapLeft = Math.max(bannerBounds.x, headerBounds.x);
-    const overlapTop = Math.max(bannerBounds.y, headerBounds.y);
-    const overlapRight = Math.min(bannerBounds.x + bannerBounds.width, headerBounds.x + headerBounds.width);
-    const overlapBottom = Math.min(bannerBounds.y + bannerBounds.height, headerBounds.y + headerBounds.height);
-    expect(overlapRight).toBeGreaterThan(overlapLeft);
-    expect(overlapBottom).toBeGreaterThan(overlapTop);
-
-    const overlapCenter = {
-      x: (overlapLeft + overlapRight) / 2,
-      y: (overlapTop + overlapBottom) / 2,
-    };
-    const bannerPaintsOnTop = await banner.evaluate((node, point) => {
-      const previousPointerEvents = node.style.pointerEvents;
-      try {
-        node.style.pointerEvents = "auto";
-        const topElement = document.elementFromPoint(point.x, point.y);
-        return topElement !== null && node.contains(topElement);
-      } finally {
-        node.style.pointerEvents = previousPointerEvents;
-      }
-    }, overlapCenter);
-    expect(bannerPaintsOnTop).toBe(true);
-    await expect(banner).toHaveCSS("pointer-events", "none");
+    expect(headerBounds.y).toBeGreaterThanOrEqual(bannerBounds.y + bannerBounds.height);
 
     await expect(firstContent).toBeAttached();
-    await page.mouse.click(overlapCenter.x, overlapCenter.y);
+    await firstHeader.click();
     await expect(firstContent).not.toBeAttached();
 
     fixture = smallDiff;
     await openDiffFilterMenu(page);
     await page.getByRole("switch", { name: "Hide whitespace changes" }).click();
-    await expect(banner).not.toBeAttached();
+    await expect(banner).not.toBeVisible();
+    await expect(banner).toHaveAttribute("aria-hidden", "true");
 
     expect(await diffBody.boundingBox()).toEqual(staleBounds);
   });
@@ -4025,7 +4003,9 @@ test.describe("diff view (git-backed)", () => {
     await page.goto("/pulls/github/acme/widgets/1/files");
     await page.locator(".diff-file").first().waitFor({ state: "visible", timeout: 10_000 });
 
-    await expect(page.locator(".stale-banner")).not.toBeAttached();
+    const banner = page.locator(".stale-banner");
+    await expect(banner).not.toBeVisible();
+    await expect(banner).toHaveAttribute("aria-hidden", "true");
   });
 
   test("real diff loads and renders all changed files", async ({ page }) => {

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -2940,6 +2940,33 @@ test.describe("diff view", () => {
     expect(await diffBody.boundingBox()).toEqual(staleBounds);
   });
 
+  test("stale diff warning does not shift content when the initial diff loads", async ({ page }) => {
+    let releaseDiffResponse: () => void = () => {};
+    const diffResponseReleased = new Promise<void>((resolve) => {
+      releaseDiffResponse = resolve;
+    });
+    await mockDiffApi(page, staleDiff);
+    await page.route("**/api/v1/pulls/github/acme/widgets/1/diff*", async (route) => {
+      await diffResponseReleased;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(diffResponseFromFixture(staleDiff)),
+      });
+    });
+    await navigateToDiff(page);
+
+    const diffBody = page.locator(".diff-body");
+    await expect(page.locator(".diff-state-msg")).toHaveText("Loading diff");
+    const loadingBounds = await diffBody.boundingBox();
+    expect(loadingBounds).not.toBeNull();
+
+    releaseDiffResponse();
+    await waitForDiffLoaded(page);
+    await expect(page.locator(".stale-banner")).toBeVisible();
+    expect(await diffBody.boundingBox()).toEqual(loadingBounds);
+  });
+
   test("error state shown when diff API fails", async ({ page }) => {
     await mockDiffApiError(page, 404, "diff not available for this pull request");
     await navigateToDiff(page);

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -1386,20 +1386,24 @@ function diffResponseFromFixture(fixture: DiffResult | DiffFixture): DiffResult 
   };
 }
 
-async function mockDiffApi(page: Page, fixture: DiffResult | DiffFixture): Promise<void> {
-  const responseFixture = diffResponseFromFixture(fixture);
+async function mockDiffApi(
+  page: Page,
+  fixture: DiffResult | DiffFixture | (() => DiffResult | DiffFixture),
+): Promise<void> {
+  const currentFixture = (): DiffResult => diffResponseFromFixture(typeof fixture === "function" ? fixture() : fixture);
+
   await page.route("**/api/v1/pulls/github/acme/widgets/1/files", async (route) => {
     await route.fulfill({
       status: 200,
       contentType: "application/json",
-      body: JSON.stringify(filesFromDiff(responseFixture)),
+      body: JSON.stringify(filesFromDiff(currentFixture())),
     });
   });
   await page.route("**/api/v1/pulls/github/acme/widgets/1/diff*", async (route) => {
     await route.fulfill({
       status: 200,
       contentType: "application/json",
-      body: JSON.stringify(responseFixture),
+      body: JSON.stringify(currentFixture()),
     });
   });
 }
@@ -2903,13 +2907,59 @@ test.describe("diff view", () => {
     await expect.poll(() => renderedDiffFilePaths(page)).toEqual(expectedFileOrder);
   });
 
-  test("stale diff banner is shown when diff is stale", async ({ page }) => {
-    await mockDiffApi(page, staleDiff);
+  test("stale diff banner overlays without shifting diff content", async ({ page }) => {
+    let fixture = staleDiff;
+    await mockDiffApi(page, () => fixture);
     await navigateToDiff(page);
     await waitForDiffLoaded(page);
 
-    await expect(page.locator(".stale-banner")).toBeVisible();
-    await expect(page.locator(".stale-banner")).toContainText("outdated");
+    const banner = page.locator(".stale-banner");
+    const diffBody = page.locator(".diff-body");
+    const firstFile = page.locator(".diff-file").first();
+    const firstHeader = firstFile.locator(".file-header");
+    const firstContent = firstFile.locator(".file-content");
+    await expect(banner).toBeVisible();
+    await expect(banner).toContainText("outdated");
+    await expect(banner).toHaveCSS("pointer-events", "none");
+    const staleBounds = await diffBody.boundingBox();
+    expect(staleBounds).not.toBeNull();
+
+    const bannerBounds = await visibleBoundingBox(banner);
+    const headerBounds = await visibleBoundingBox(firstHeader);
+    const overlapLeft = Math.max(bannerBounds.x, headerBounds.x);
+    const overlapTop = Math.max(bannerBounds.y, headerBounds.y);
+    const overlapRight = Math.min(bannerBounds.x + bannerBounds.width, headerBounds.x + headerBounds.width);
+    const overlapBottom = Math.min(bannerBounds.y + bannerBounds.height, headerBounds.y + headerBounds.height);
+    expect(overlapRight).toBeGreaterThan(overlapLeft);
+    expect(overlapBottom).toBeGreaterThan(overlapTop);
+
+    const overlapCenter = {
+      x: (overlapLeft + overlapRight) / 2,
+      y: (overlapTop + overlapBottom) / 2,
+    };
+    const bannerPaintsOnTop = await banner.evaluate((node, point) => {
+      const previousPointerEvents = node.style.pointerEvents;
+      try {
+        node.style.pointerEvents = "auto";
+        const topElement = document.elementFromPoint(point.x, point.y);
+        return topElement !== null && node.contains(topElement);
+      } finally {
+        node.style.pointerEvents = previousPointerEvents;
+      }
+    }, overlapCenter);
+    expect(bannerPaintsOnTop).toBe(true);
+    await expect(banner).toHaveCSS("pointer-events", "none");
+
+    await expect(firstContent).toBeAttached();
+    await page.mouse.click(overlapCenter.x, overlapCenter.y);
+    await expect(firstContent).not.toBeAttached();
+
+    fixture = smallDiff;
+    await openDiffFilterMenu(page);
+    await page.getByRole("switch", { name: "Hide whitespace changes" }).click();
+    await expect(banner).not.toBeAttached();
+
+    expect(await diffBody.boundingBox()).toEqual(staleBounds);
   });
 
   test("error state shown when diff API fails", async ({ page }) => {

--- a/frontend/tests/e2e-full/pull-list.spec.ts
+++ b/frontend/tests/e2e-full/pull-list.spec.ts
@@ -218,7 +218,7 @@ test.describe("PR list view", () => {
     }
   });
 
-  test("PR detail refresh notification does not shift content", async ({ page }) => {
+  test("PR detail stale refresh uses the standard syncing indicator", async ({ page }) => {
     await page.route("**/api/v1/pulls/github/acme/widgets/1", async (route) => {
       const response = await route.fetch();
       const detail = (await response.json()) as {
@@ -232,23 +232,9 @@ test.describe("PR list view", () => {
 
     await page.goto("/pulls/github/acme/widgets/1");
 
-    const banner = page.locator(".pull-detail .refresh-banner");
-    const header = page.locator(".pull-detail .detail-header");
-    await expect(banner).toBeVisible();
-    await expect(header).toBeVisible();
-    const bannerBounds = await banner.boundingBox();
-    const refreshingBounds = await header.boundingBox();
-    expect(bannerBounds).not.toBeNull();
-    expect(refreshingBounds).not.toBeNull();
-    if (bannerBounds !== null && refreshingBounds !== null) {
-      expect(bannerBounds.y + bannerBounds.height).toBeLessThanOrEqual(refreshingBounds.y);
-    }
-
-    await banner.evaluate((node) => {
-      node.style.display = "none";
-    });
-
-    expect(await header.boundingBox()).toEqual(refreshingBounds);
+    await expect(page.locator(".pull-detail .sync-indicator")).toBeVisible();
+    await expect(page.locator(".pull-detail .refresh-banner")).toHaveCount(0);
+    await expect(page.getByText("Refreshing...", { exact: true })).toHaveCount(0);
   });
 });
 

--- a/frontend/tests/e2e-full/pull-list.spec.ts
+++ b/frontend/tests/e2e-full/pull-list.spec.ts
@@ -217,6 +217,39 @@ test.describe("PR list view", () => {
       expect(headerBox.width).toBeLessThanOrEqual(800);
     }
   });
+
+  test("PR detail refresh notification does not shift content", async ({ page }) => {
+    await page.route("**/api/v1/pulls/github/acme/widgets/1", async (route) => {
+      const response = await route.fetch();
+      const detail = (await response.json()) as {
+        detail_fetched_at: string;
+        merge_request: { UpdatedAt: string };
+      };
+      detail.detail_fetched_at = "2020-01-01T00:00:00Z";
+      detail.merge_request.UpdatedAt = "2026-01-01T00:00:00Z";
+      await route.fulfill({ response, json: detail });
+    });
+
+    await page.goto("/pulls/github/acme/widgets/1");
+
+    const banner = page.locator(".pull-detail .refresh-banner");
+    const header = page.locator(".pull-detail .detail-header");
+    await expect(banner).toBeVisible();
+    await expect(header).toBeVisible();
+    const bannerBounds = await banner.boundingBox();
+    const refreshingBounds = await header.boundingBox();
+    expect(bannerBounds).not.toBeNull();
+    expect(refreshingBounds).not.toBeNull();
+    if (bannerBounds !== null && refreshingBounds !== null) {
+      expect(bannerBounds.y + bannerBounds.height).toBeLessThanOrEqual(refreshingBounds.y);
+    }
+
+    await banner.evaluate((node) => {
+      node.style.display = "none";
+    });
+
+    expect(await header.boundingBox()).toEqual(refreshingBounds);
+  });
 });
 
 test.describe("PR list sidebar", () => {

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -2608,6 +2608,7 @@
 
   .pull-detail-content {
     container: pull-detail / inline-size;
+    position: relative;
     display: flex;
     flex-direction: column;
     gap: 16px;
@@ -3247,15 +3248,20 @@
   }
 
   .refresh-banner {
+    position: absolute;
+    top: 0;
+    right: 0;
+    z-index: 2;
+    transform: translateY(-100%);
     display: flex;
     align-items: center;
     gap: 6px;
-    padding: 4px 12px;
+    pointer-events: none;
+    padding: 1px 8px;
     background: var(--bg-inset);
     border-radius: var(--radius-sm);
     font-size: var(--font-size-xs);
     color: var(--text-secondary);
-    margin-bottom: 8px;
   }
 
 
@@ -3379,6 +3385,10 @@
     .pull-detail-content {
       gap: var(--detail-mobile-space-md);
       max-width: 100%;
+    }
+
+    .refresh-banner span {
+      display: none;
     }
 
     .detail-header,

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -29,7 +29,6 @@
     CopyButton,
     copyToClipboard,
     formatRelativeTime,
-    StatusDot,
   } from "@kenn-io/kit-ui";
   import EventTimeline from "./EventTimeline.svelte";
   import DetailActivityViewMenu from "./DetailActivityViewMenu.svelte";
@@ -1653,12 +1652,6 @@
               </Button>
             {/snippet}
 
-      {#if detailStore.isStaleRefreshing()}
-        <div class="refresh-banner">
-          <StatusDot status="working" label="Refreshing pull request details" size={5} />
-          <span aria-hidden="true">Refreshing...</span>
-        </div>
-      {/if}
       <!-- Header -->
       <div class="detail-header">
         {#if editingTitle}
@@ -2608,7 +2601,6 @@
 
   .pull-detail-content {
     container: pull-detail / inline-size;
-    position: relative;
     display: flex;
     flex-direction: column;
     gap: 16px;
@@ -3247,24 +3239,6 @@
     color: var(--accent-red);
   }
 
-  .refresh-banner {
-    position: absolute;
-    top: 0;
-    right: 0;
-    z-index: 2;
-    transform: translateY(-100%);
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    pointer-events: none;
-    padding: 1px 8px;
-    background: var(--bg-inset);
-    border-radius: var(--radius-sm);
-    font-size: var(--font-size-xs);
-    color: var(--text-secondary);
-  }
-
-
   .loading-placeholder {
     display: flex;
     align-items: center;
@@ -3387,10 +3361,6 @@
       max-width: 100%;
     }
 
-    .refresh-banner span {
-      display: none;
-    }
-
     .detail-header,
     .title-line {
       gap: var(--detail-mobile-space-sm);
@@ -3440,7 +3410,6 @@
     .files-stat,
     .merge-warnings,
     .action-error,
-    .refresh-banner,
     .loading-placeholder,
     .detail-tab {
       font-size: var(--font-size-sm);

--- a/packages/ui/src/components/detail/PullDetail.test.ts
+++ b/packages/ui/src/components/detail/PullDetail.test.ts
@@ -177,7 +177,7 @@ function renderPullDetail(
   options: {
     hideWorkspaceAction?: boolean;
     actions?: { pull: unknown[] };
-    staleRefreshing?: boolean;
+    detailSyncing?: boolean;
   } = {},
 ) {
   const actions = options.actions ?? { pull: [] };
@@ -188,8 +188,7 @@ function renderPullDetail(
     getDetail: () => detail,
     isDetailLoading: () => false,
     getDetailError: () => null,
-    isStaleRefreshing: () => options.staleRefreshing ?? false,
-    isDetailSyncing: () => false,
+    isDetailSyncing: () => options.detailSyncing ?? false,
     getDetailLoaded: () => true,
     updateKanbanState: vi.fn(),
     toggleDetailPRStar: vi.fn(),
@@ -377,11 +376,14 @@ describe("PullDetail approvals", () => {
     expect(document.querySelector(".approval-popup")).toBeNull();
   });
 
-  it("labels an active stale-detail refresh", () => {
-    renderPullDetail(pullDetail(), undefined, undefined, { staleRefreshing: true });
+  it("uses the standard syncing indicator without duplicate progress UI", () => {
+    renderPullDetail(pullDetail(), undefined, undefined, {
+      detailSyncing: true,
+    });
 
-    expect(screen.getByLabelText("Refreshing pull request details")).toBeTruthy();
-    expect(screen.getByText("Refreshing...")).toBeTruthy();
+    expect(document.querySelector(".sync-indicator")?.textContent).toContain("Syncing");
+    expect(document.querySelector(".refresh-banner")).toBeNull();
+    expect(screen.queryByText("Refreshing...")).toBeNull();
   });
 
   it("keeps task checkboxes disabled while highlighted markdown is pending", () => {

--- a/packages/ui/src/components/diff/DiffView.svelte
+++ b/packages/ui/src/components/diff/DiffView.svelte
@@ -581,11 +581,9 @@
 </script>
 
 <div class="diff-view">
-  {#if diff}
-    <div class={["stale-banner", { "stale-banner--hidden": !diff.stale }]} aria-hidden={!diff.stale}>
-      Diff may be outdated -- showing changes as of an earlier version of this PR.
-    </div>
-  {/if}
+  <div class={["stale-banner", { "stale-banner--hidden": !diff?.stale }]} aria-hidden={!diff?.stale}>
+    Diff may be outdated -- showing changes as of an earlier version of this PR.
+  </div>
 
   <div class="diff-body">
     {#if loading && !diff}

--- a/packages/ui/src/components/diff/DiffView.svelte
+++ b/packages/ui/src/components/diff/DiffView.svelte
@@ -581,8 +581,8 @@
 </script>
 
 <div class="diff-view">
-  {#if diff?.stale}
-    <div class="stale-banner">
+  {#if diff}
+    <div class={["stale-banner", { "stale-banner--hidden": !diff.stale }]} aria-hidden={!diff.stale}>
       Diff may be outdated -- showing changes as of an earlier version of this PR.
     </div>
   {/if}
@@ -649,7 +649,6 @@
 
 <style>
   .diff-view {
-    position: relative;
     display: flex;
     flex-direction: column;
     flex: 1;
@@ -658,15 +657,16 @@
   }
 
   .stale-banner {
-    position: absolute;
-    inset: 0 0 auto;
-    z-index: 3;
-    pointer-events: none;
+    flex-shrink: 0;
     padding: 6px 16px;
     background: var(--diff-stale-bg);
     color: var(--diff-stale-text);
     border-bottom: 1px solid var(--diff-stale-border);
     font-size: var(--font-size-sm);
+  }
+
+  .stale-banner--hidden {
+    visibility: hidden;
   }
 
   .review-warning {

--- a/packages/ui/src/components/diff/DiffView.svelte
+++ b/packages/ui/src/components/diff/DiffView.svelte
@@ -649,6 +649,7 @@
 
 <style>
   .diff-view {
+    position: relative;
     display: flex;
     flex-direction: column;
     flex: 1;
@@ -657,12 +658,15 @@
   }
 
   .stale-banner {
+    position: absolute;
+    inset: 0 0 auto;
+    z-index: 3;
+    pointer-events: none;
     padding: 6px 16px;
     background: var(--diff-stale-bg);
     color: var(--diff-stale-text);
     border-bottom: 1px solid var(--diff-stale-border);
     font-size: var(--font-size-sm);
-    flex-shrink: 0;
   }
 
   .review-warning {

--- a/packages/ui/src/stores/detail.svelte.ts
+++ b/packages/ui/src/stores/detail.svelte.ts
@@ -182,16 +182,6 @@ export function createDetailStore(opts: DetailStoreOptions) {
     return detailLoaded;
   }
 
-  function isStaleRefreshing(): boolean {
-    if (!detail || !syncing) return false;
-    const fetchedAt = detail.detail_fetched_at;
-    if (!fetchedAt) return false;
-    const fetchedMs = new Date(fetchedAt).getTime();
-    const updatedMs = new Date(detail.merge_request.UpdatedAt).getTime();
-    const hourAgo = Date.now() - 3_600_000;
-    return fetchedMs < hourAgo && updatedMs > fetchedMs;
-  }
-
   // --- internal helpers ---
 
   function prKey(ref: DetailRequestRef): string {
@@ -1387,7 +1377,6 @@ export function createDetailStore(opts: DetailStoreOptions) {
     isDetailSyncing,
     getDetailError,
     getDetailLoaded,
-    isStaleRefreshing,
     clearDetail,
     loadDetail,
     refreshDetailOnly,


### PR DESCRIPTION
Refresh state no longer moves PR review content or shows duplicate progress notices.

- Keep stale diff warnings clear of file controls while preserving the review layout during loading and refresh.
- Use the existing PR-detail "Syncing" indicator instead of a second "Refreshing..." banner.
- Add real-browser coverage for both refresh paths.