### PR TITLE
Warn only when workspace diff head moved

### DIFF
--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -199,6 +199,9 @@ server check exactly.
   publication. Only selected workspaces
   receive proactive refresh leases; ordinary entries validate on demand
   (`internal/server/server.go::streamEvents`).
+- A workspace response is user-visibly stale only for a confirmed mismatch
+  between its cached head and current Git HEAD; cache age and failed head
+  resolution do not raise the warning (`internal/server/workspace_diff_cache.go::workspaceDiffCache.Get`).
 - A local workspace becomes selected through its scoped SSE stream. The server
   subscribes that stream before acquiring the selection lease, then emits
   `workspace_diff_ready` only when cold/coalesced default-HEAD preparation

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -200,8 +200,8 @@ server check exactly.
   receive proactive refresh leases; ordinary entries validate on demand
   (`internal/server/server.go::streamEvents`).
 - A workspace response is user-visibly stale only for a confirmed mismatch
-  between its cached head and current Git HEAD; cache age and failed head
-  resolution do not raise the warning (`internal/server/workspace_diff_cache.go::workspaceDiffCache.Get`).
+  between its cached head and current Git HEAD, which queues immediate refresh;
+  cache age and failed head resolution do not warn (`internal/server/workspace_diff_cache.go::workspaceDiffCache.Get`).
 - A local workspace becomes selected through its scoped SSE stream. The server
   subscribes that stream before acquiring the selection lease, then emits
   `workspace_diff_ready` only when cold/coalesced default-HEAD preparation

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -199,9 +199,9 @@ server check exactly.
   publication. Only selected workspaces
   receive proactive refresh leases; ordinary entries validate on demand
   (`internal/server/server.go::streamEvents`).
-- A workspace response is user-visibly stale only for a confirmed mismatch
-  between its cached head and current Git HEAD, which queues immediate refresh;
-  cache age and failed head resolution do not warn (`internal/server/workspace_diff_cache.go::workspaceDiffCache.Get`).
+- A workspace response is user-visibly stale only when a bounded, coalesced
+  head-only probe confirms cached/current Git HEAD mismatch and queues refresh;
+  cache age, probe timeout, and resolution failure do not warn (`internal/server/workspace_diff_cache.go::workspaceDiffCache.Get`).
 - A local workspace becomes selected through its scoped SSE stream. The server
   subscribes that stream before acquiring the selection lease, then emits
   `workspace_diff_ready` only when cold/coalesced default-HEAD preparation

--- a/docs/superpowers/plans/2026-07-20-workspace-diff-stale-warning.md
+++ b/docs/superpowers/plans/2026-07-20-workspace-diff-stale-warning.md
@@ -1,0 +1,171 @@
+# Workspace Diff Stale Warning Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make workspace diff responses set `stale: true` only when the cached snapshot head differs from the currently resolved Git HEAD.
+
+**Architecture:** Keep age-based stale-while-revalidate bookkeeping inside `workspaceDiffCache.Get`, but decouple it from the user-visible `gitclone.DiffResult.Stale` flag. On cache hits, resolve the current snapshot spec after releasing the cache mutex and compare its `HeadOID` with the cached snapshot's `Resolved.HeadOID`; resolution failure or unavailability is not a confirmed mismatch.
+
+**Tech Stack:** Go, `testify`, the existing workspace diff snapshot cache and server API tests.
+
+## Global Constraints
+
+- Cache age must continue to schedule asynchronous validation.
+- Only a confirmed cached/current `HeadOID` mismatch may set the workspace response's `stale` flag.
+- Failed or unavailable current-head resolution must serve the last-known-good snapshot without the warning.
+- Pull-request diff staleness is unchanged.
+- Run direct Go tests with `-shuffle=on`, without `-count=1` or `-v`.
+
+---
+
+### Task 1: Derive workspace warning state from Git HEAD
+
+**Files:**
+- Modify: `internal/server/workspace_diff_cache.go:171-197`
+- Test: `internal/server/workspace_diff_cache_test.go`
+- Verify: `internal/server/api_test.go`
+
+**Interfaces:**
+- Consumes: `workspaceDiffCacheDeps.resolve(context.Context, workspace.DiffSnapshotSpec) (workspace.ResolvedDiffSnapshotSpec, bool, error)` and `workspaceDiffSnapshot.Resolved.HeadOID`.
+- Produces: cache-hit `workspaceDiffSnapshot.Diff.Stale`, true only for a confirmed `HeadOID` mismatch; `workspaceDiffCacheState` continues to report age-based cache state for tracing and validation.
+
+- [ ] **Step 1: Write the failing cache regression test**
+
+Add a table-driven `TestWorkspaceDiffCacheWarningRequiresHeadMismatch` covering matching, changed, unavailable, and failed current-head resolution. Create a fresh cache per case, populate it, age its entry, prevent the unrelated async validator from racing the assertion with `retryAfter`, then change the resolver outcome before the second `Get`:
+
+```go
+func TestWorkspaceDiffCacheWarningRequiresHeadMismatch(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		currentHead string
+		resolveOK  bool
+		resolveErr error
+		wantStale  bool
+	}{
+		{name: "matching head", currentHead: "head", resolveOK: true},
+		{name: "changed head", currentHead: "new-head", resolveOK: true, wantStale: true},
+		{name: "head unavailable"},
+		{name: "head resolution failed", resolveErr: errors.New("resolve head")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require := require.New(t)
+			assert := assert.New(t)
+			now := time.Unix(100, 0)
+			resolved := workspaceDiffTestResolved()
+			resolveOK := true
+			var resolveErr error
+			cache := newWorkspaceDiffCache(t.Context(), workspaceDiffCacheDeps{
+				now: func() time.Time { return now },
+				resolve: func(context.Context, workspace.DiffSnapshotSpec) (workspace.ResolvedDiffSnapshotSpec, bool, error) {
+					return resolved, resolveOK, resolveErr
+				},
+				fingerprint: func(context.Context, workspace.ResolvedDiffSnapshotSpec) (workspace.DiffFingerprint, error) {
+					return "v1", nil
+				},
+				prepare: func(context.Context, workspace.ResolvedDiffSnapshotSpec) (*gitclone.DiffResult, error) {
+					return workspaceDiffTestResult("one.txt"), nil
+				},
+			})
+
+			_, _, err := cache.Get(t.Context(), workspaceDiffTestKey())
+			require.NoError(err)
+			now = now.Add(workspaceDiffCacheFreshFor + time.Second)
+			cache.mu.Lock()
+			cache.peekEntryLocked(workspaceDiffTestKey()).retryAfter = now.Add(time.Hour)
+			cache.mu.Unlock()
+			resolved.HeadOID = tt.currentHead
+			resolveOK = tt.resolveOK
+			resolveErr = tt.resolveErr
+
+			got, state, err := cache.Get(t.Context(), workspaceDiffTestKey())
+			require.NoError(err)
+			require.NotNil(got)
+			assert.Equal(workspaceDiffCacheStale, state)
+			assert.Equal(tt.wantStale, got.Diff.Stale)
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run the regression test and verify RED**
+
+Run:
+
+```bash
+go test ./internal/server -run TestWorkspaceDiffCacheWarningRequiresHeadMismatch -shuffle=on
+```
+
+Expected: FAIL because the current implementation sets `Diff.Stale` from cache age, making the matching, unavailable, and failed-resolution cases stale.
+
+- [ ] **Step 3: Implement the minimal cache-hit comparison**
+
+In `workspaceDiffCache.Get`, keep the cached snapshot and age state while holding the mutex, then release the mutex before calling `resolve`. Derive the cloned response's warning flag only from a successful, available head comparison:
+
+```go
+		fresh := now.Sub(updated.validatedAt) <= workspaceDiffCacheFreshFor
+		retryAllowed := !now.Before(updated.retryAfter)
+		cached := updated.snapshot
+		c.mu.Unlock()
+		resolved, ok, resolveErr := c.deps.resolve(ctx, key.Spec)
+		headMoved := resolveErr == nil && ok && cached.Resolved.HeadOID != resolved.HeadOID
+		snapshot := cloneWorkspaceDiffSnapshot(cached, headMoved)
+		state := workspaceDiffCacheHit
+		if !fresh {
+			state = workspaceDiffCacheStale
+			if retryAllowed {
+				c.validateAsync(key)
+			}
+		}
+```
+
+Do not change `refresh`, cache versions, event publication, PR SHA comparisons, or the frontend banner.
+
+- [ ] **Step 4: Run the regression test and verify GREEN**
+
+Run:
+
+```bash
+go test ./internal/server -run TestWorkspaceDiffCacheWarningRequiresHeadMismatch -shuffle=on
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Verify age-based validation still runs**
+
+Run the existing selected-validation tests:
+
+```bash
+go test ./internal/server -run 'TestWorkspaceDiffCache(SelectedValidationMeetsMaxAge|ReconnectRetainsActiveScopes)' -shuffle=on
+```
+
+Expected: PASS, proving the age threshold still schedules validation independently of the warning flag.
+
+- [ ] **Step 6: Verify the affected cache and HTTP boundary**
+
+Run:
+
+```bash
+go test ./internal/server -run 'TestWorkspaceDiff(Cache|EndpointsReportHeadAndPushed)' -shuffle=on
+```
+
+Then run:
+
+```bash
+go test ./internal/server -shuffle=on
+```
+
+Expected: both commands PASS.
+
+- [ ] **Step 7: Sync context and commit**
+
+Run the repository-local `context-sync` skill in `--commit` mode, review the final diff, then use the mandatory commit skill to create a conventional commit such as:
+
+```text
+fix: warn only when workspace diff head moved
+```
+
+The commit body should explain that cache age continues to drive background validation but no longer masquerades as confirmed Git revision drift.

--- a/docs/superpowers/specs/2026-07-20-workspace-diff-stale-warning-design.md
+++ b/docs/superpowers/specs/2026-07-20-workspace-diff-stale-warning-design.md
@@ -1,0 +1,39 @@
+# Workspace Diff Stale Warning Design
+
+## Problem
+
+Workspace diff cache entries currently set the shared `stale` response flag
+when their validation timestamp is more than 15 seconds old. The shared diff
+view interprets that flag as proof that it is showing an earlier Git revision,
+so a normal stale-while-revalidate cache hit can display a warning even when
+the workspace has not changed.
+
+## Decision
+
+For workspace diffs, cache age remains an internal revalidation concern and
+must not set the user-visible `stale` flag. A cached workspace diff is stale
+only when its recorded Git `HeadOID` differs from the workspace's currently
+resolved `HeadOID`.
+
+The cache will resolve the current workspace snapshot specification on a cache
+hit, compare its head with the cached snapshot head, and set `stale` from that
+comparison. It will continue to schedule age-based background fingerprint
+validation exactly as before. If the current head cannot be resolved, the
+last-known-good snapshot is served without the warning; an unknown state is
+not a confirmed mismatch.
+
+Pull-request diff staleness remains unchanged because it is computed from the
+persisted platform and diff SHAs outside the workspace cache.
+
+## Verification
+
+Focused cache tests will prove that:
+
+- an old cache entry whose recorded head matches the current Git HEAD is not
+  marked stale;
+- a cache entry whose recorded head differs from the current Git HEAD is
+  marked stale;
+- age-based background validation is still requested for old entries.
+
+Existing server and UI tests cover propagation of the shared `stale` flag and
+the banner rendering, so no new browser-only duplicate is required.

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -25825,6 +25825,49 @@ func TestWorkspaceDiffEndpointsReportHeadAndPushedE2E(t *testing.T) {
 	assert.Equal(int64(1), pushedDiff.WhitespaceOnlyCount)
 }
 
+func TestWorkspaceDiffEndpointWarnsOnlyAfterGitHeadMovesE2E(t *testing.T) {
+	t.Parallel()
+
+	require := require.New(t)
+	assert := assert.New(t)
+
+	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, nil)
+	ws := createReadyWorkspace(t, context.Background(), client)
+	runGit(t, ws.WorktreePath, "config", "user.email", "test@test.com")
+	runGit(t, ws.WorktreePath, "config", "user.name", "Test")
+
+	initial := requestWorkspaceDiff(t, srv, ws.Id, "head")
+	assert.False(initial.Stale)
+	key := workspaceDiffLogicalKey{
+		WorkspaceID: ws.Id,
+		Spec: workspace.DiffSnapshotSpec{
+			WorktreePath: ws.WorktreePath,
+			Base:         workspace.WorktreeDiffBaseHead,
+		},
+	}
+	srv.workspaceDiffCache.mu.Lock()
+	entry := srv.workspaceDiffCache.peekEntryLocked(key)
+	if entry != nil {
+		entry.validatedAt = time.Now().Add(-workspaceDiffCacheFreshFor - time.Second)
+		entry.retryAfter = time.Now().Add(time.Hour)
+	}
+	srv.workspaceDiffCache.mu.Unlock()
+	require.NotNil(entry)
+
+	unchanged := requestWorkspaceDiff(t, srv, ws.Id, "head")
+	assert.False(unchanged.Stale)
+	require.NoError(os.WriteFile(
+		filepath.Join(ws.WorktreePath, "head-moved.txt"),
+		[]byte("head moved\n"),
+		0o644,
+	))
+	runGit(t, ws.WorktreePath, "add", "head-moved.txt")
+	runGit(t, ws.WorktreePath, "commit", "-m", "move workspace head")
+
+	moved := requestWorkspaceDiff(t, srv, ws.Id, "head")
+	assert.True(moved.Stale)
+}
+
 func TestWorkspaceFilePreviewEndpointReturnsRequestedDiffSideContentE2E(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -25825,7 +25825,7 @@ func TestWorkspaceDiffEndpointsReportHeadAndPushedE2E(t *testing.T) {
 	assert.Equal(int64(1), pushedDiff.WhitespaceOnlyCount)
 }
 
-func TestWorkspaceDiffEndpointWarnsOnlyAfterGitHeadMovesE2E(t *testing.T) {
+func TestWorkspaceDiffEndpointWarnsAndRefreshesOnlyAfterGitHeadMovesE2E(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
@@ -25838,6 +25838,8 @@ func TestWorkspaceDiffEndpointWarnsOnlyAfterGitHeadMovesE2E(t *testing.T) {
 
 	initial := requestWorkspaceDiff(t, srv, ws.Id, "head")
 	assert.False(initial.Stale)
+	require.NotNil(initial.SnapshotVersion)
+	initialVersion := *initial.SnapshotVersion
 	key := workspaceDiffLogicalKey{
 		WorkspaceID: ws.Id,
 		Spec: workspace.DiffSnapshotSpec{
@@ -25856,16 +25858,55 @@ func TestWorkspaceDiffEndpointWarnsOnlyAfterGitHeadMovesE2E(t *testing.T) {
 
 	unchanged := requestWorkspaceDiff(t, srv, ws.Id, "head")
 	assert.False(unchanged.Stale)
+	srv.workspaceDiffCache.mu.Lock()
+	entry = srv.workspaceDiffCache.peekEntryLocked(key)
+	if entry != nil {
+		entry.retryAfter = time.Time{}
+	}
+	srv.workspaceDiffCache.mu.Unlock()
+	require.NotNil(entry)
+	require.NoError(srv.workspaceDiffCache.validate(t.Context(), key))
 	require.NoError(os.WriteFile(
 		filepath.Join(ws.WorktreePath, "head-moved.txt"),
-		[]byte("head moved\n"),
+		[]byte("committed\n"),
 		0o644,
 	))
 	runGit(t, ws.WorktreePath, "add", "head-moved.txt")
 	runGit(t, ws.WorktreePath, "commit", "-m", "move workspace head")
+	require.NoError(os.WriteFile(
+		filepath.Join(ws.WorktreePath, "head-moved.txt"),
+		[]byte("worktree change\n"),
+		0o644,
+	))
 
 	moved := requestWorkspaceDiff(t, srv, ws.Id, "head")
 	assert.True(moved.Stale)
+	require.NotNil(moved.SnapshotVersion)
+	assert.Equal(initialVersion, *moved.SnapshotVersion)
+
+	var refreshed generated.DiffResponse
+	assert.Eventually(func() bool {
+		req := newWorkspaceFixtureRequest(
+			http.MethodGet,
+			"/api/v1/workspaces/"+ws.Id+"/diff?base=head",
+			nil,
+		)
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			return false
+		}
+		var candidate generated.DiffResponse
+		if err := json.Unmarshal(rr.Body.Bytes(), &candidate); err != nil ||
+			candidate.Stale || candidate.SnapshotVersion == nil ||
+			*candidate.SnapshotVersion == initialVersion {
+			return false
+		}
+		refreshed = candidate
+		return true
+	}, 2*time.Second, 10*time.Millisecond)
+	require.NotNil(refreshed.Files)
+	assert.Contains(workspaceDiffPaths(*refreshed.Files), "head-moved.txt")
 }
 
 func TestWorkspaceFilePreviewEndpointReturnsRequestedDiffSideContentE2E(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -25909,6 +25909,34 @@ func TestWorkspaceDiffEndpointWarnsAndRefreshesOnlyAfterGitHeadMovesE2E(t *testi
 	assert.Contains(workspaceDiffPaths(*refreshed.Files), "head-moved.txt")
 }
 
+func TestWorkspaceDiffCacheHitReturnsWhileGitCapacityIsHeldE2E(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	restoreLimiter := procutil.SetDefaultLimiterForTest(
+		procutil.NewLimiterWithAcquireTimeout(1, 500*time.Millisecond),
+	)
+	t.Cleanup(restoreLimiter)
+
+	client, _, _, _, srv := setupTestServerWithWorkspacesServer(t, nil)
+	ws := createReadyWorkspace(t, context.Background(), client)
+	initial := requestWorkspaceDiff(t, srv, ws.Id, "head")
+	assert.False(initial.Stale)
+
+	releaseHeld, err := procutil.TryAcquire(
+		context.Background(), "test-held workspace diff capacity",
+	)
+	require.NoError(err)
+	defer releaseHeld()
+
+	started := time.Now()
+	cached := requestWorkspaceDiff(t, srv, ws.Id, "head")
+	elapsed := time.Since(started)
+	releaseHeld()
+
+	assert.False(cached.Stale)
+	assert.Less(elapsed, 200*time.Millisecond)
+}
+
 func TestWorkspaceFilePreviewEndpointReturnsRequestedDiffSideContentE2E(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/workspace_diff_cache.go
+++ b/internal/server/workspace_diff_cache.go
@@ -183,8 +183,11 @@ func (c *workspaceDiffCache) Get(
 		c.storeEntryLocked(key, &updated, now)
 		fresh := now.Sub(updated.validatedAt) <= workspaceDiffCacheFreshFor
 		retryAllowed := !now.Before(updated.retryAfter)
-		snapshot := cloneWorkspaceDiffSnapshot(updated.snapshot, !fresh)
+		cached := updated.snapshot
 		c.mu.Unlock()
+		resolved, ok, resolveErr := c.deps.resolve(ctx, key.Spec)
+		headMoved := resolveErr == nil && ok && cached.Resolved.HeadOID != resolved.HeadOID
+		snapshot := cloneWorkspaceDiffSnapshot(cached, headMoved)
 		state := workspaceDiffCacheHit
 		if !fresh {
 			state = workspaceDiffCacheStale

--- a/internal/server/workspace_diff_cache.go
+++ b/internal/server/workspace_diff_cache.go
@@ -191,9 +191,9 @@ func (c *workspaceDiffCache) Get(
 		state := workspaceDiffCacheHit
 		if !fresh {
 			state = workspaceDiffCacheStale
-			if retryAllowed {
-				c.validateAsync(key)
-			}
+		}
+		if retryAllowed && (!fresh || headMoved) {
+			c.validateAsync(key)
 		}
 		c.setSpanAttributes(ctx, key, snapshot, state)
 		return snapshot, state, nil

--- a/internal/server/workspace_diff_cache.go
+++ b/internal/server/workspace_diff_cache.go
@@ -24,6 +24,7 @@ const (
 	workspaceDiffCacheIdleTTL       = 10 * time.Minute
 	workspaceDiffCacheRetryWait     = 5 * time.Second
 	workspaceDiffPreparationTimeout = 30 * time.Second
+	workspaceDiffHeadProbeTimeout   = 50 * time.Millisecond
 	workspaceDiffValidationPoll     = time.Second
 	workspaceDiffCacheMaxBytes      = int64(128 << 20)
 	workspaceDiffCachePairRetention = time.Minute
@@ -62,6 +63,7 @@ type workspaceDiffCacheDeps struct {
 	now         func() time.Time
 	after       func(time.Duration) <-chan time.Time
 	resolve     func(context.Context, workspace.DiffSnapshotSpec) (workspace.ResolvedDiffSnapshotSpec, bool, error)
+	resolveHead func(context.Context, workspace.DiffSnapshotSpec) (string, error)
 	fingerprint func(context.Context, workspace.ResolvedDiffSnapshotSpec) (workspace.DiffFingerprint, error)
 	prepare     func(context.Context, workspace.ResolvedDiffSnapshotSpec) (*gitclone.DiffResult, error)
 	onChanged   func(workspaceID string, revision uint64, version string)
@@ -93,6 +95,7 @@ type workspaceDiffCache struct {
 	selectionCancel  map[string]context.CancelFunc
 	nextRev          uint64
 	group            singleflight.Group
+	headGroup        singleflight.Group
 	wg               sync.WaitGroup
 
 	validationMu      sync.Mutex
@@ -114,6 +117,9 @@ func newWorkspaceDiffCache(
 	}
 	if deps.resolve == nil {
 		deps.resolve = workspace.ResolveDiffSnapshotSpec
+	}
+	if deps.resolveHead == nil {
+		deps.resolveHead = workspace.ResolveDiffSnapshotHeadOID
 	}
 	if deps.fingerprint == nil {
 		deps.fingerprint = workspace.FingerprintDiffSnapshot
@@ -185,8 +191,7 @@ func (c *workspaceDiffCache) Get(
 		retryAllowed := !now.Before(updated.retryAfter)
 		cached := updated.snapshot
 		c.mu.Unlock()
-		resolved, ok, resolveErr := c.deps.resolve(ctx, key.Spec)
-		headMoved := resolveErr == nil && ok && cached.Resolved.HeadOID != resolved.HeadOID
+		headMoved := c.cachedHeadMoved(ctx, key, cached)
 		snapshot := cloneWorkspaceDiffSnapshot(cached, headMoved)
 		state := workspaceDiffCacheHit
 		if !fresh {
@@ -234,6 +239,28 @@ func (c *workspaceDiffCache) Get(
 		}
 		c.setSpanAttributes(ctx, key, snapshot, state)
 		return snapshot, state, nil
+	}
+}
+
+func (c *workspaceDiffCache) cachedHeadMoved(
+	ctx context.Context,
+	key workspaceDiffLogicalKey,
+	cached *workspaceDiffSnapshot,
+) bool {
+	resultCh := c.headGroup.DoChan(c.singleflightKey(key), func() (any, error) {
+		probeCtx, cancel := context.WithTimeout(c.root, workspaceDiffHeadProbeTimeout)
+		defer cancel()
+		return c.deps.resolveHead(probeCtx, key.Spec)
+	})
+	select {
+	case <-ctx.Done():
+		return false
+	case result := <-resultCh:
+		if result.Err != nil {
+			return false
+		}
+		headOID, ok := result.Val.(string)
+		return ok && headOID != "" && cached.Resolved.HeadOID != headOID
 	}
 }
 

--- a/internal/server/workspace_diff_cache_test.go
+++ b/internal/server/workspace_diff_cache_test.go
@@ -50,6 +50,62 @@ func TestWorkspaceDiffCacheMissThenHitPreparesOnce(t *testing.T) {
 	assert.Empty(second.Files[0].Hunks)
 }
 
+func TestWorkspaceDiffCacheWarningRequiresHeadMismatch(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		currentHead string
+		resolveOK   bool
+		resolveErr  error
+		wantStale   bool
+	}{
+		{name: "matching head", currentHead: "head", resolveOK: true},
+		{name: "changed head", currentHead: "new-head", resolveOK: true, wantStale: true},
+		{name: "head unavailable"},
+		{name: "head resolution failed", resolveErr: errors.New("resolve head")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require := require.New(t)
+			assert := assert.New(t)
+			now := time.Unix(100, 0)
+			resolved := workspaceDiffTestResolved()
+			resolveOK := true
+			var resolveErr error
+			cache := newWorkspaceDiffCache(t.Context(), workspaceDiffCacheDeps{
+				now: func() time.Time { return now },
+				resolve: func(context.Context, workspace.DiffSnapshotSpec) (workspace.ResolvedDiffSnapshotSpec, bool, error) {
+					return resolved, resolveOK, resolveErr
+				},
+				fingerprint: func(context.Context, workspace.ResolvedDiffSnapshotSpec) (workspace.DiffFingerprint, error) {
+					return "v1", nil
+				},
+				prepare: func(context.Context, workspace.ResolvedDiffSnapshotSpec) (*gitclone.DiffResult, error) {
+					return workspaceDiffTestResult("one.txt"), nil
+				},
+			})
+
+			_, _, err := cache.Get(t.Context(), workspaceDiffTestKey())
+			require.NoError(err)
+			now = now.Add(workspaceDiffCacheFreshFor + time.Second)
+			cache.mu.Lock()
+			cache.peekEntryLocked(workspaceDiffTestKey()).retryAfter = now.Add(time.Hour)
+			cache.mu.Unlock()
+			resolved.HeadOID = tt.currentHead
+			resolveOK = tt.resolveOK
+			resolveErr = tt.resolveErr
+
+			got, state, err := cache.Get(t.Context(), workspaceDiffTestKey())
+			require.NoError(err)
+			require.NotNil(got)
+			assert.Equal(workspaceDiffCacheStale, state)
+			assert.Equal(tt.wantStale, got.Diff.Stale)
+		})
+	}
+}
+
 func TestWorkspaceDiffCacheProtectedEntriesDoNotConsumeCostBudget(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/server/workspace_diff_cache_test.go
+++ b/internal/server/workspace_diff_cache_test.go
@@ -55,14 +55,13 @@ func TestWorkspaceDiffCacheWarningRequiresHeadMismatch(t *testing.T) {
 	tests := []struct {
 		name        string
 		currentHead string
-		resolveOK   bool
-		resolveErr  error
+		headErr     error
 		wantStale   bool
 	}{
-		{name: "matching head", currentHead: "head", resolveOK: true},
-		{name: "changed head", currentHead: "new-head", resolveOK: true, wantStale: true},
-		{name: "head unavailable"},
-		{name: "head resolution failed", resolveErr: errors.New("resolve head")},
+		{name: "matching head", currentHead: "head"},
+		{name: "changed head", currentHead: "new-head", wantStale: true},
+		{name: "head unavailable", headErr: errors.New("head unavailable")},
+		{name: "head resolution failed", headErr: errors.New("resolve head")},
 	}
 
 	for _, tt := range tests {
@@ -71,13 +70,13 @@ func TestWorkspaceDiffCacheWarningRequiresHeadMismatch(t *testing.T) {
 			require := require.New(t)
 			assert := assert.New(t)
 			now := time.Unix(100, 0)
-			resolved := workspaceDiffTestResolved()
-			resolveOK := true
-			var resolveErr error
 			cache := newWorkspaceDiffCache(t.Context(), workspaceDiffCacheDeps{
 				now: func() time.Time { return now },
 				resolve: func(context.Context, workspace.DiffSnapshotSpec) (workspace.ResolvedDiffSnapshotSpec, bool, error) {
-					return resolved, resolveOK, resolveErr
+					return workspaceDiffTestResolved(), true, nil
+				},
+				resolveHead: func(context.Context, workspace.DiffSnapshotSpec) (string, error) {
+					return tt.currentHead, tt.headErr
 				},
 				fingerprint: func(context.Context, workspace.ResolvedDiffSnapshotSpec) (workspace.DiffFingerprint, error) {
 					return "v1", nil
@@ -93,10 +92,6 @@ func TestWorkspaceDiffCacheWarningRequiresHeadMismatch(t *testing.T) {
 			cache.mu.Lock()
 			cache.peekEntryLocked(workspaceDiffTestKey()).retryAfter = now.Add(time.Hour)
 			cache.mu.Unlock()
-			resolved.HeadOID = tt.currentHead
-			resolveOK = tt.resolveOK
-			resolveErr = tt.resolveErr
-
 			got, state, err := cache.Get(t.Context(), workspaceDiffTestKey())
 			require.NoError(err)
 			require.NotNil(got)
@@ -104,6 +99,36 @@ func TestWorkspaceDiffCacheWarningRequiresHeadMismatch(t *testing.T) {
 			assert.Equal(tt.wantStale, got.Diff.Stale)
 		})
 	}
+}
+
+func TestWorkspaceDiffCacheHitDoesNotRepeatFullSnapshotResolution(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	assert := assert.New(t)
+	resolveCalls := 0
+	cache := newWorkspaceDiffCache(t.Context(), workspaceDiffCacheDeps{
+		resolve: func(context.Context, workspace.DiffSnapshotSpec) (workspace.ResolvedDiffSnapshotSpec, bool, error) {
+			resolveCalls++
+			return workspaceDiffTestResolved(), true, nil
+		},
+		resolveHead: func(context.Context, workspace.DiffSnapshotSpec) (string, error) {
+			return "head", nil
+		},
+		fingerprint: func(context.Context, workspace.ResolvedDiffSnapshotSpec) (workspace.DiffFingerprint, error) {
+			return "v1", nil
+		},
+		prepare: func(context.Context, workspace.ResolvedDiffSnapshotSpec) (*gitclone.DiffResult, error) {
+			return workspaceDiffTestResult("one.txt"), nil
+		},
+	})
+
+	_, _, err := cache.Get(t.Context(), workspaceDiffTestKey())
+	require.NoError(err)
+	_, state, err := cache.Get(t.Context(), workspaceDiffTestKey())
+	require.NoError(err)
+
+	assert.Equal(workspaceDiffCacheHit, state)
+	assert.Equal(2, resolveCalls)
 }
 
 func TestWorkspaceDiffCacheHeadMismatchQueuesImmediateValidation(t *testing.T) {
@@ -120,6 +145,9 @@ func TestWorkspaceDiffCacheHeadMismatchQueuesImmediateValidation(t *testing.T) {
 		},
 		resolve: func(context.Context, workspace.DiffSnapshotSpec) (workspace.ResolvedDiffSnapshotSpec, bool, error) {
 			return resolved, true, nil
+		},
+		resolveHead: func(context.Context, workspace.DiffSnapshotSpec) (string, error) {
+			return resolved.HeadOID, nil
 		},
 		fingerprint: func(context.Context, workspace.ResolvedDiffSnapshotSpec) (workspace.DiffFingerprint, error) {
 			return workspace.DiffFingerprint(resolved.HeadOID), nil

--- a/internal/server/workspace_diff_cache_test.go
+++ b/internal/server/workspace_diff_cache_test.go
@@ -106,6 +106,44 @@ func TestWorkspaceDiffCacheWarningRequiresHeadMismatch(t *testing.T) {
 	}
 }
 
+func TestWorkspaceDiffCacheHeadMismatchQueuesImmediateValidation(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	assert := assert.New(t)
+	now := time.Unix(100, 0)
+	resolved := workspaceDiffTestResolved()
+	key := workspaceDiffTestKey()
+	cache := newWorkspaceDiffCache(t.Context(), workspaceDiffCacheDeps{
+		now: func() time.Time { return now },
+		after: func(time.Duration) <-chan time.Time {
+			return make(chan time.Time)
+		},
+		resolve: func(context.Context, workspace.DiffSnapshotSpec) (workspace.ResolvedDiffSnapshotSpec, bool, error) {
+			return resolved, true, nil
+		},
+		fingerprint: func(context.Context, workspace.ResolvedDiffSnapshotSpec) (workspace.DiffFingerprint, error) {
+			return workspace.DiffFingerprint(resolved.HeadOID), nil
+		},
+		prepare: func(context.Context, workspace.ResolvedDiffSnapshotSpec) (*gitclone.DiffResult, error) {
+			return workspaceDiffTestResult(resolved.HeadOID + ".txt"), nil
+		},
+	})
+
+	_, _, err := cache.Get(t.Context(), key)
+	require.NoError(err)
+	resolved.HeadOID = "new-head"
+
+	got, state, err := cache.Get(t.Context(), key)
+	require.NoError(err)
+	require.NotNil(got)
+	assert.Equal(workspaceDiffCacheHit, state)
+	assert.True(got.Diff.Stale)
+	assert.Eventually(func() bool {
+		entry := cache.peekEntry(key)
+		return entry != nil && entry.snapshot.Resolved.HeadOID == "new-head"
+	}, time.Second, time.Millisecond)
+}
+
 func TestWorkspaceDiffCacheProtectedEntriesDoNotConsumeCostBudget(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/workspace/diff_snapshot.go
+++ b/internal/workspace/diff_snapshot.go
@@ -55,6 +55,22 @@ type diffContentDigestEntry struct {
 	usedAt   time.Time
 }
 
+// ResolveDiffSnapshotHeadOID resolves only the head ref needed to compare a cached snapshot.
+func ResolveDiffSnapshotHeadOID(
+	ctx context.Context,
+	spec DiffSnapshotSpec,
+) (string, error) {
+	absPath, err := filepath.Abs(spec.WorktreePath)
+	if err != nil {
+		return "", err
+	}
+	headRef := spec.ToSHA
+	if headRef == "" {
+		headRef = "HEAD"
+	}
+	return resolveDiffOID(ctx, filepath.Clean(absPath), headRef, "commit")
+}
+
 func ResolveDiffSnapshotSpec(
 	ctx context.Context,
 	spec DiffSnapshotSpec,


### PR DESCRIPTION
Workspace diff cache age was surfacing through the shared stale flag as if it proved revision drift, so unchanged workspaces frequently showed an outdated-diff warning.

- Raise the warning only when the cached snapshot head differs from current Git HEAD.
- Keep age-based background validation without turning validation age or HEAD-resolution failures into user-visible warnings.
- Cover matching, moved, unavailable, and failed HEAD resolution.

Validated with the focused cache and HTTP boundary tests plus the full short test suite.

<sup>generated by a clanker</sup>