### PR TITLE
Fix detail timeline action alignment

### DIFF
--- a/frontend/src/App.pr-timeline-filters.browser.svelte.ts
+++ b/frontend/src/App.pr-timeline-filters.browser.svelte.ts
@@ -350,6 +350,22 @@ describe("PR timeline filters", () => {
     expect(contentGap).toBeCloseTo(8, 2);
   });
 
+  it("keeps detail timestamps right aligned with comment actions immediately before them", async () => {
+    await mountTimeline("/pulls/github/acme/widgets/1");
+    await vi.waitFor(() => expect(document.querySelector(".pull-detail .kit-comment-card")).not.toBeNull(), WAIT);
+
+    const commentCard = inDetail(".kit-comment-card").find((card) =>
+      (card.textContent ?? "").includes("Automated review summary"),
+    )!;
+    const commentActions = commentCard.querySelector<HTMLElement>(".kit-card__actions")!;
+    const commentTime = commentCard.querySelector<HTMLElement>(".kit-card__meta")!;
+    const commitRow = inDetail(".event-card--commit").find((card) => (card.textContent ?? "").includes("abc1111"))!;
+    const commitTime = commitRow.querySelector<HTMLElement>(".event-time")!;
+
+    expect(commentActions.getBoundingClientRect().right).toBeLessThanOrEqual(commentTime.getBoundingClientRect().left);
+    expect(commentTime.getBoundingClientRect().right).toBeCloseTo(commitTime.getBoundingClientRect().right, 2);
+  });
+
   it("renders merged lifecycle transitions as one purple row", async () => {
     await mountTimeline("/pulls/github/acme/tools/2");
     await vi.waitFor(() => expect(inDetail(".event--compact").length).toBeGreaterThan(0), WAIT);

--- a/frontend/src/App.pr-timeline-filters.browser.svelte.ts
+++ b/frontend/src/App.pr-timeline-filters.browser.svelte.ts
@@ -362,7 +362,7 @@ describe("PR timeline filters", () => {
     const commitRow = inDetail(".event-card--commit").find((card) => (card.textContent ?? "").includes("abc1111"))!;
     const commitTime = commitRow.querySelector<HTMLElement>(".event-time")!;
 
-    expect(commentActions.getBoundingClientRect().right).toBeLessThanOrEqual(commentTime.getBoundingClientRect().left);
+    expect(commentTime.getBoundingClientRect().left - commentActions.getBoundingClientRect().right).toBeCloseTo(6, 2);
     expect(commentTime.getBoundingClientRect().right).toBeCloseTo(commitTime.getBoundingClientRect().right, 2);
   });
 

--- a/frontend/tests/e2e/comment-editing.spec.ts
+++ b/frontend/tests/e2e/comment-editing.spec.ts
@@ -321,7 +321,6 @@ test("keeps the pre-kit commit SHA in the compact header before the timestamp", 
   expect(typeBox!.x + typeBox!.width).toBeLessThanOrEqual(authorBox!.x);
   expect(authorBox!.x + authorBox!.width).toBeLessThanOrEqual(shaBox!.x);
   expect(shaBox!.x + shaBox!.width).toBeLessThanOrEqual(timeBox!.x);
-  expect(timeBox!.x - (shaBox!.x + shaBox!.width)).toBeLessThanOrEqual(8);
   const headerCenters = [typeBox!, authorBox!, shaBox!, timeBox!].map((box) => box.y + box.height / 2);
   expect(Math.max(...headerCenters) - Math.min(...headerCenters)).toBeLessThanOrEqual(1);
   expect(subjectBox!.y).toBeGreaterThan(shaBox!.y + shaBox!.height);

--- a/packages/ui/src/components/detail/EventTimeline.svelte
+++ b/packages/ui/src/components/detail/EventTimeline.svelte
@@ -1986,10 +1986,6 @@
     flex-wrap: nowrap;
   }
 
-  .event-header--compact .event-time {
-    margin-left: 0;
-  }
-
   .event-card--compact-row {
     overflow: hidden;
   }
@@ -2125,9 +2121,14 @@
   }
 
   .event-timeline :global(.kit-comment-card:not(.event-card--commit) .kit-card__actions) {
+    order: 1;
     opacity: 0;
     pointer-events: none;
     transition: opacity 0.15s;
+  }
+
+  .event-timeline :global(.kit-comment-card:not(.event-card--commit) .kit-card__meta) {
+    order: 2;
   }
 
   .event-timeline :global(.kit-comment-card:not(.event-card--commit):hover .kit-card__actions),

--- a/packages/ui/src/components/detail/EventTimeline.svelte
+++ b/packages/ui/src/components/detail/EventTimeline.svelte
@@ -2122,6 +2122,7 @@
 
   .event-timeline :global(.kit-comment-card:not(.event-card--commit) .kit-card__actions) {
     order: 1;
+    margin-left: auto;
     opacity: 0;
     pointer-events: none;
     transition: opacity 0.15s;
@@ -2129,6 +2130,7 @@
 
   .event-timeline :global(.kit-comment-card:not(.event-card--commit) .kit-card__meta) {
     order: 2;
+    margin-left: 0;
   }
 
   .event-timeline :global(.kit-comment-card:not(.event-card--commit):hover .kit-card__actions),


### PR DESCRIPTION
Detail timeline headers lost their stable scan line when comment actions and relative timestamps competed for the trailing edge.

- Keep secondary comment actions quiet until hover or keyboard focus.
- Place the action group immediately before the right-aligned timestamp.
- Align compact commit timestamps to the same trailing edge.

The full frontend test and validation suites pass.

<sup>generated by a clanker</sup>