### PR TITLE
Fix Kata project identity

### DIFF
--- a/.kata.toml
+++ b/.kata.toml
@@ -1,5 +1,5 @@
 version = 1
 
 [project]
-identity = "github.com/wesm/middleman"
+identity = "github.com/kenn-io/middleman"
 name = "middleman"


### PR DESCRIPTION
- Point Kata project discovery at `github.com/kenn-io/middleman` after the repository ownership move.

<sup>generated by a clanker</sup>