### PR TITLE
fix: avoid endpoint scans for Git credentials

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/compose v0.43.0
 	github.com/yuin/goldmark v1.7.17
 	gitlab.com/gitlab-org/api/client-go/v2 v2.44.0
-	go.kenn.io/kit v0.9.3
+	go.kenn.io/kit v0.10.1
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0

--- a/go.sum
+++ b/go.sum
@@ -589,8 +589,8 @@ github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 gitlab.com/gitlab-org/api/client-go/v2 v2.44.0 h1:Vtv2WKC8p9BAygu5VCZlZUwDhTQ7UMlS3PErXyjUmeY=
 gitlab.com/gitlab-org/api/client-go/v2 v2.44.0/go.mod h1:pTbeBowtVA+0/ZExWEZYUGOrpu5qlRN5ZyOUf27BnVY=
-go.kenn.io/kit v0.9.3 h1:fyDE2r+P3SjVgTity1LgjL8RqTAY8CRPDy221t6geUE=
-go.kenn.io/kit v0.9.3/go.mod h1:dComZhFNb4LR+Tj4ZD0slEDMkPJk0gGd8q/HEHXTGSM=
+go.kenn.io/kit v0.10.1 h1:xywCqiz+qP8FOjurIlY/RLpHkdLSTLiRYCaiKGHpV+8=
+go.kenn.io/kit v0.10.1/go.mod h1:dComZhFNb4LR+Tj4ZD0slEDMkPJk0gGd8q/HEHXTGSM=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/internal/gitclone/auth_test.go
+++ b/internal/gitclone/auth_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/middleman/internal/testutil/gitfake"
 	"go.kenn.io/middleman/internal/tokenauth"
 )
 
@@ -39,6 +40,7 @@ func TestGitNetworkedResolvesTokenSourceForEachCall(t *testing.T) {
 	gitPath := filepath.Join(dir, "git")
 	require.NoError(os.WriteFile(gitPath, []byte(`#!/bin/sh
 set -eu
+`+gitfake.CredentialHelperRunner+`
 out="${MIDDLEMAN_TEST_GIT_CAPTURE:?}"
 i=0
 count="${GIT_CONFIG_COUNT:-0}"
@@ -46,7 +48,7 @@ while [ "$i" -lt "$count" ]; do
 	eval "key=\${GIT_CONFIG_KEY_$i:-}"
 	eval "value=\${GIT_CONFIG_VALUE_$i:-}"
 	if [ "$key" = "credential.helper" ]; then
-		"$value" get >> "$out"
+		run_credential_helper "$value" get >> "$out"
 		echo "---" >> "$out"
 	fi
 	i=$((i + 1))
@@ -87,6 +89,7 @@ func TestGitNetworkedResolvesTokenFileSourceForEachCall(t *testing.T) {
 	gitPath := filepath.Join(dir, "git")
 	require.NoError(os.WriteFile(gitPath, []byte(`#!/bin/sh
 set -eu
+`+gitfake.CredentialHelperRunner+`
 out="${MIDDLEMAN_TEST_GIT_CAPTURE:?}"
 i=0
 count="${GIT_CONFIG_COUNT:-0}"
@@ -94,7 +97,7 @@ while [ "$i" -lt "$count" ]; do
 	eval "key=\${GIT_CONFIG_KEY_$i:-}"
 	eval "value=\${GIT_CONFIG_VALUE_$i:-}"
 	if [ "$key" = "credential.helper" ]; then
-		"$value" get >> "$out"
+		run_credential_helper "$value" get >> "$out"
 		echo "---" >> "$out"
 	fi
 	i=$((i + 1))
@@ -141,6 +144,7 @@ func TestGitRetriesAuthFailureAfterInvalidatingTokenSource(t *testing.T) {
 	gitPath := filepath.Join(dir, "git")
 	require.NoError(os.WriteFile(gitPath, []byte(`#!/bin/sh
 set -eu
+`+gitfake.CredentialHelperRunner+`
 out="${MIDDLEMAN_TEST_GIT_CAPTURE:?}"
 tmp="$out.current"
 helper=""
@@ -154,7 +158,7 @@ while [ "$i" -lt "$count" ]; do
 	fi
 	i=$((i + 1))
 done
-"$helper" get > "$tmp"
+run_credential_helper "$helper" get > "$tmp"
 cat "$tmp" >> "$out"
 echo "---" >> "$out"
 password="$(sed -n 's/^password=//p' "$tmp")"
@@ -195,6 +199,7 @@ func TestCloneBareRetriesAuthFailureAfterCleaningPartialClone(t *testing.T) {
 	gitPath := filepath.Join(dir, "git")
 	require.NoError(os.WriteFile(gitPath, []byte(`#!/bin/sh
 set -eu
+`+gitfake.CredentialHelperRunner+`
 if [ "${1:-}" != "clone" ]; then
 	exit 0
 fi
@@ -219,7 +224,7 @@ while [ "$i" -lt "$count" ]; do
 done
 
 tmp="$out.current"
-"$helper" get > "$tmp"
+run_credential_helper "$helper" get > "$tmp"
 cat "$tmp" >> "$out"
 echo "---" >> "$out"
 password="$(sed -n 's/^password=//p' "$tmp")"

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -55,6 +55,7 @@ import (
 	"go.kenn.io/middleman/internal/stacks"
 	"go.kenn.io/middleman/internal/testutil"
 	"go.kenn.io/middleman/internal/testutil/dbtest"
+	"go.kenn.io/middleman/internal/testutil/gitfake"
 	"go.kenn.io/middleman/internal/tokenauth"
 	"go.kenn.io/middleman/internal/workspace"
 	"go.kenn.io/middleman/internal/workspace/localruntime"
@@ -4979,6 +4980,7 @@ func installCredentialCapturingGit(t *testing.T, dir string) string {
 	require.NoError(t, os.MkdirAll(gitWrapperDir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(gitWrapperDir, "git"), []byte(`#!/bin/sh
 set -eu
+`+gitfake.CredentialHelperRunner+`
 out="${MIDDLEMAN_TEST_GIT_CAPTURE:?}"
 helper=""
 i=0
@@ -4992,7 +4994,7 @@ while [ "$i" -lt "$count" ]; do
 	i=$((i + 1))
 done
 if [ -n "$helper" ]; then
-	"$helper" get >> "$out"
+	run_credential_helper "$helper" get >> "$out"
 	echo "---" >> "$out"
 fi
 exec "$MIDDLEMAN_TEST_REAL_GIT" "$@"

--- a/internal/testutil/gitfake/credential.go
+++ b/internal/testutil/gitfake/credential.go
@@ -1,0 +1,16 @@
+// Package gitfake provides shell fragments for fake git executables used by
+// tests.
+package gitfake
+
+// CredentialHelperRunner defines run_credential_helper, which follows Git's
+// credential.helper dispatch rules for inline shell snippets and executable
+// paths. The operation and any later arguments are appended to the helper.
+const CredentialHelperRunner = `run_credential_helper() {
+	helper="$1"
+	shift
+	case "$helper" in
+		!*) /bin/sh -c "${helper#?} \"\$@\"" "$helper" "$@" ;;
+		*) "$helper" "$@" ;;
+	esac
+}
+`

--- a/internal/testutil/gitfake/credential_test.go
+++ b/internal/testutil/gitfake/credential_test.go
@@ -1,0 +1,56 @@
+package gitfake
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/middleman/internal/procutil"
+)
+
+func TestCredentialHelperRunner(t *testing.T) {
+	dir := t.TempDir()
+	executableHelper := filepath.Join(dir, "credential-helper")
+	require.NoError(t, os.WriteFile(
+		executableHelper,
+		[]byte("#!/bin/sh\nprintf 'password=executable\\n'\n"),
+		0o755,
+	))
+
+	tests := []struct {
+		name   string
+		helper string
+		want   string
+	}{
+		{
+			name:   "inline shell snippet",
+			helper: `!f() { [ "$1" = get ] && printf 'password=inline\n'; }; f`,
+			want:   "password=inline\n",
+		},
+		{
+			name:   "executable path",
+			helper: executableHelper,
+			want:   "password=executable\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			script := filepath.Join(t.TempDir(), "run-helper")
+			require.NoError(os.WriteFile(
+				script,
+				[]byte("#!/bin/sh\nset -eu\n"+CredentialHelperRunner+`run_credential_helper "$HELPER" get
+`),
+				0o755,
+			))
+			cmd := procutil.Command("sh", script)
+			cmd.Env = append(os.Environ(), "HELPER="+tt.helper)
+			got, err := cmd.Output()
+			require.NoError(err)
+			assert.Equal(tt.want, string(got))
+		})
+	}
+}

--- a/internal/workspace/branch_sync_test.go
+++ b/internal/workspace/branch_sync_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/middleman/internal/gitclone"
+	"go.kenn.io/middleman/internal/testutil/gitfake"
 	"go.kenn.io/middleman/internal/tokenauth"
 )
 
@@ -143,6 +144,7 @@ func TestPushWorktreeBranchUsesAuthenticatedRunnerAndMutationAuth(t *testing.T) 
 	capturePath := filepath.Join(fakeDir, "credentials.txt")
 	require.NoError(os.WriteFile(filepath.Join(fakeDir, "git"), []byte(`#!/bin/sh
 set -eu
+`+gitfake.CredentialHelperRunner+`
 real="${MIDDLEMAN_TEST_REAL_GIT:?}"
 capture="${MIDDLEMAN_TEST_GIT_CAPTURE:?}"
 op="${1:-}"
@@ -163,7 +165,7 @@ push|fetch)
 		echo "fatal: Authentication failed: no credential helper" >&2
 		exit 128
 	fi
-	password="$("$helper" get | sed -n 's/^password=//p')"
+	password="$(run_credential_helper "$helper" get | sed -n 's/^password=//p')"
 	if [ -z "$password" ]; then
 		echo "fatal: Authentication failed: empty credential" >&2
 		exit 128


### PR DESCRIPTION
Authenticated Git operations currently create a new temporary executable helper for each command through the older Kit release, which causes macOS endpoint security to reassess every helper.

This upgrades Middleman to Kit v0.10.1's non-executable credential response files. The fake Git fixtures now model both supported helper forms so the token-rotation, retry, and authenticated-push tests keep exercising the same boundary.