### PR TITLE
fix: recover Mermaid after frontend updates

### DIFF
--- a/frontend/src/lib/utils/frontendReloadGuard.test.ts
+++ b/frontend/src/lib/utils/frontendReloadGuard.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { prepareFrontendReload, retireFrontendReload } from "./frontendReloadGuard";
+
+describe("frontend reload guard", () => {
+  beforeEach(() => window.sessionStorage.clear());
+
+  it("prevents a repeated reload while the source frontend is still loaded", () => {
+    expect(prepareFrontendReload(window.sessionStorage, "/assets/index-a.js", "/assets/index-b.js")).toBe(true);
+    expect(prepareFrontendReload(window.sessionStorage, "/assets/index-a.js", "/assets/index-b.js")).toBe(false);
+
+    retireFrontendReload(window.sessionStorage, "/assets/index-a.js");
+
+    expect(prepareFrontendReload(window.sessionStorage, "/assets/index-a.js", "/assets/index-b.js")).toBe(false);
+  });
+
+  it("retires the guard after the destination frontend loads", () => {
+    expect(prepareFrontendReload(window.sessionStorage, "/assets/index-a.js", "/assets/index-b.js")).toBe(true);
+
+    retireFrontendReload(window.sessionStorage, "/assets/index-b.js");
+
+    expect(prepareFrontendReload(window.sessionStorage, "/assets/index-b.js", "/assets/index-a.js")).toBe(true);
+  });
+
+  it("retires the guard when the reload lands on a different frontend", () => {
+    expect(prepareFrontendReload(window.sessionStorage, "/assets/index-a.js", "/assets/index-b.js")).toBe(true);
+
+    retireFrontendReload(window.sessionStorage, "/assets/index-c.js");
+
+    expect(prepareFrontendReload(window.sessionStorage, "/assets/index-c.js", "/assets/index-b.js")).toBe(true);
+  });
+});

--- a/frontend/src/lib/utils/frontendReloadGuard.ts
+++ b/frontend/src/lib/utils/frontendReloadGuard.ts
@@ -1,0 +1,48 @@
+const storageKey = "middleman:vite-reload";
+
+interface FrontendReload {
+  source: string;
+  target: string;
+}
+
+function readFrontendReload(storage: Storage): FrontendReload | null {
+  const raw = storage.getItem(storageKey);
+  if (!raw) return null;
+
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    storage.removeItem(storageKey);
+    return null;
+  }
+
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("source" in value) ||
+    typeof value.source !== "string" ||
+    !("target" in value) ||
+    typeof value.target !== "string"
+  ) {
+    storage.removeItem(storageKey);
+    return null;
+  }
+
+  return { source: value.source, target: value.target };
+}
+
+export function prepareFrontendReload(storage: Storage, source: string, target: string): boolean {
+  const pending = readFrontendReload(storage);
+  if (pending?.source === source && pending.target === target) return false;
+
+  storage.setItem(storageKey, JSON.stringify({ source, target } satisfies FrontendReload));
+  return true;
+}
+
+export function retireFrontendReload(storage: Storage, loadedEntrypoint: string): void {
+  const pending = readFrontendReload(storage);
+  if (!pending || loadedEntrypoint === pending.source) return;
+
+  storage.removeItem(storageKey);
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -3,9 +3,9 @@ import { pushModalFrame } from "@middleman/ui/stores/keyboard/modal-stack";
 import { mount } from "svelte";
 import App from "./App.svelte";
 import "./app.css";
+import { prepareFrontendReload, retireFrontendReload } from "./lib/utils/frontendReloadGuard.js";
 import { initMarkdownImageExpansion } from "./lib/utils/markdownImages.js";
 
-const viteReloadKey = "middleman:vite-reload";
 const currentFrontendEntrypoint = new URL(import.meta.url);
 
 function frontendEntrypoints(document: Document, baseUrl: string): URL[] {
@@ -29,9 +29,9 @@ async function reloadIfFrontendChanged(): Promise<void> {
     const latestEntrypoint = latestEntrypoints.at(-1);
     if (!latestEntrypoint) return;
 
-    if (window.sessionStorage.getItem(viteReloadKey) === latestEntrypoint.pathname) return;
+    if (!prepareFrontendReload(window.sessionStorage, currentFrontendEntrypoint.pathname, latestEntrypoint.pathname))
+      return;
 
-    window.sessionStorage.setItem(viteReloadKey, latestEntrypoint.pathname);
     window.location.reload();
   } catch (error) {
     console.warn("Could not check for a frontend update", error);
@@ -39,9 +39,7 @@ async function reloadIfFrontendChanged(): Promise<void> {
 }
 
 try {
-  if (window.sessionStorage.getItem(viteReloadKey) === currentFrontendEntrypoint.pathname) {
-    window.sessionStorage.removeItem(viteReloadKey);
-  }
+  retireFrontendReload(window.sessionStorage, currentFrontendEntrypoint.pathname);
 } catch (error) {
   console.warn("Could not clear completed frontend reload", error);
 }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -5,6 +5,14 @@ import App from "./App.svelte";
 import "./app.css";
 import { initMarkdownImageExpansion } from "./lib/utils/markdownImages.js";
 
+// A browser tab can outlive a server update and request a content-hashed
+// lazy chunk that the new binary no longer embeds. Reload the uncached SPA
+// entrypoint so the tab binds to the current asset graph.
+window.addEventListener("vite:preloadError", (event) => {
+  event.preventDefault();
+  window.location.reload();
+});
+
 const target = document.getElementById("app");
 
 if (!target) {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -5,43 +5,45 @@ import App from "./App.svelte";
 import "./app.css";
 import { initMarkdownImageExpansion } from "./lib/utils/markdownImages.js";
 
-const viteProbeParam = "_middleman_vite_probe";
 const viteReloadKeyPrefix = "middleman:vite-reload:";
+const currentFrontendEntrypoint = new URL(import.meta.url);
 
-function viteAssetUrl(payload: unknown): URL | null {
-  if (!(payload instanceof Error)) return null;
-  const match = payload.message.match(/https?:\/\/[^\s'")]+/);
-  if (!match) return null;
-
-  const url = new URL(match[0]);
-  if (url.origin !== window.location.origin || !url.pathname.startsWith("/assets/")) return null;
-  return url;
+function frontendEntrypoints(document: Document, baseUrl: string): URL[] {
+  return Array.from(document.querySelectorAll<HTMLScriptElement>('script[type="module"][src]'), (script) => {
+    return new URL(script.src, baseUrl);
+  });
 }
 
-async function reloadIfViteAssetIsMissing(payload: unknown): Promise<void> {
-  const assetUrl = viteAssetUrl(payload);
-  if (!assetUrl) return;
-
-  const reloadKey = `${viteReloadKeyPrefix}${assetUrl.pathname}`;
+async function reloadIfFrontendChanged(): Promise<void> {
   try {
-    if (window.sessionStorage.getItem(reloadKey)) return;
+    const response = await window.fetch(window.location.href, {
+      cache: "no-store",
+      headers: { Accept: "text/html" },
+    });
+    if (!response.ok) return;
 
-    assetUrl.searchParams.set(viteProbeParam, Date.now().toString());
-    const response = await window.fetch(assetUrl, { method: "HEAD", cache: "no-store" });
-    if (response.status !== 404 && response.status !== 410) return;
+    const latestDocument = new DOMParser().parseFromString(await response.text(), "text/html");
+    const latestEntrypoints = frontendEntrypoints(latestDocument, response.url);
+    if (latestEntrypoints.some((entrypoint) => entrypoint.pathname === currentFrontendEntrypoint.pathname)) return;
+
+    const latestEntrypoint = latestEntrypoints.at(-1);
+    if (!latestEntrypoint) return;
+
+    const reloadKey = `${viteReloadKeyPrefix}${currentFrontendEntrypoint.pathname}:${latestEntrypoint.pathname}`;
+    if (window.sessionStorage.getItem(reloadKey)) return;
 
     window.sessionStorage.setItem(reloadKey, "1");
     window.location.reload();
   } catch (error) {
-    console.warn("Could not verify failed frontend asset", error);
+    console.warn("Could not check for a frontend update", error);
   }
 }
 
 // A browser tab can outlive a server update and request a content-hashed lazy
-// chunk that the new binary no longer embeds. Vite emits the same event for
-// transient failures, so confirm that the asset is gone before reloading.
-window.addEventListener("vite:preloadError", (event) => {
-  void reloadIfViteAssetIsMissing((event as Event & { payload?: unknown }).payload);
+// chunk that the new binary no longer embeds. Reload only when the server's
+// current HTML points to a different frontend, preserving transient retries.
+window.addEventListener("vite:preloadError", () => {
+  void reloadIfFrontendChanged();
 });
 
 const target = document.getElementById("app");

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -5,12 +5,43 @@ import App from "./App.svelte";
 import "./app.css";
 import { initMarkdownImageExpansion } from "./lib/utils/markdownImages.js";
 
-// A browser tab can outlive a server update and request a content-hashed
-// lazy chunk that the new binary no longer embeds. Reload the uncached SPA
-// entrypoint so the tab binds to the current asset graph.
+const viteProbeParam = "_middleman_vite_probe";
+const viteReloadKeyPrefix = "middleman:vite-reload:";
+
+function viteAssetUrl(payload: unknown): URL | null {
+  if (!(payload instanceof Error)) return null;
+  const match = payload.message.match(/https?:\/\/[^\s'")]+/);
+  if (!match) return null;
+
+  const url = new URL(match[0]);
+  if (url.origin !== window.location.origin || !url.pathname.startsWith("/assets/")) return null;
+  return url;
+}
+
+async function reloadIfViteAssetIsMissing(payload: unknown): Promise<void> {
+  const assetUrl = viteAssetUrl(payload);
+  if (!assetUrl) return;
+
+  const reloadKey = `${viteReloadKeyPrefix}${assetUrl.pathname}`;
+  try {
+    if (window.sessionStorage.getItem(reloadKey)) return;
+
+    assetUrl.searchParams.set(viteProbeParam, Date.now().toString());
+    const response = await window.fetch(assetUrl, { method: "HEAD", cache: "no-store" });
+    if (response.status !== 404 && response.status !== 410) return;
+
+    window.sessionStorage.setItem(reloadKey, "1");
+    window.location.reload();
+  } catch (error) {
+    console.warn("Could not verify failed frontend asset", error);
+  }
+}
+
+// A browser tab can outlive a server update and request a content-hashed lazy
+// chunk that the new binary no longer embeds. Vite emits the same event for
+// transient failures, so confirm that the asset is gone before reloading.
 window.addEventListener("vite:preloadError", (event) => {
-  event.preventDefault();
-  window.location.reload();
+  void reloadIfViteAssetIsMissing((event as Event & { payload?: unknown }).payload);
 });
 
 const target = document.getElementById("app");

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -5,7 +5,7 @@ import App from "./App.svelte";
 import "./app.css";
 import { initMarkdownImageExpansion } from "./lib/utils/markdownImages.js";
 
-const viteReloadKeyPrefix = "middleman:vite-reload:";
+const viteReloadKey = "middleman:vite-reload";
 const currentFrontendEntrypoint = new URL(import.meta.url);
 
 function frontendEntrypoints(document: Document, baseUrl: string): URL[] {
@@ -29,14 +29,21 @@ async function reloadIfFrontendChanged(): Promise<void> {
     const latestEntrypoint = latestEntrypoints.at(-1);
     if (!latestEntrypoint) return;
 
-    const reloadKey = `${viteReloadKeyPrefix}${currentFrontendEntrypoint.pathname}:${latestEntrypoint.pathname}`;
-    if (window.sessionStorage.getItem(reloadKey)) return;
+    if (window.sessionStorage.getItem(viteReloadKey) === latestEntrypoint.pathname) return;
 
-    window.sessionStorage.setItem(reloadKey, "1");
+    window.sessionStorage.setItem(viteReloadKey, latestEntrypoint.pathname);
     window.location.reload();
   } catch (error) {
     console.warn("Could not check for a frontend update", error);
   }
+}
+
+try {
+  if (window.sessionStorage.getItem(viteReloadKey) === currentFrontendEntrypoint.pathname) {
+    window.sessionStorage.removeItem(viteReloadKey);
+  }
+} catch (error) {
+  console.warn("Could not clear completed frontend reload", error);
 }
 
 // A browser tab can outlive a server update and request a content-hashed lazy

--- a/frontend/tests/e2e-full/stale-asset-recovery.spec.ts
+++ b/frontend/tests/e2e-full/stale-asset-recovery.spec.ts
@@ -1,41 +1,91 @@
 import { expect, test } from "@playwright/test";
+import { readFile } from "node:fs/promises";
 
 import { mockApi } from "../e2e/support/mockApi";
 
+function distAssetUrl(assetUrl: string): URL {
+  const pathname = new URL(assetUrl).pathname.replace(/^\//, "");
+  return new URL(`../../dist/${pathname}`, import.meta.url);
+}
+
 test("reloads an outdated frontend before rendering a Mermaid diagram", async ({ page }) => {
   await mockApi(page);
+  const updatedEntrypointPath = "/assets/index-updated.js";
+  const updatedMermaidCorePath = "/assets/mermaid.core-updated.js";
+  const updatedSequencePath = "/assets/sequenceDiagram-updated.js";
   let mainFrameNavigations = 0;
   let frontendVersionChecks = 0;
-  let sequenceChunkRequests = 0;
+  let oldSequenceRequests = 0;
+  let updatedSequenceRequests = 0;
+  let currentEntrypointUrl = "";
+  let currentMermaidCoreUrl = "";
+  let currentSequenceUrl = "";
   page.on("framenavigated", (frame) => {
     if (frame === page.mainFrame()) mainFrameNavigations += 1;
   });
   await page.route(/\/pulls\/github\/acme\/widgets\/42$/, async (route) => {
     const accept = await route.request().headerValue("accept");
-    if (route.request().resourceType() !== "fetch" || !accept?.includes("text/html")) {
+    const isVersionCheck = route.request().resourceType() === "fetch" && accept?.includes("text/html");
+    const isUpdatedNavigation = route.request().resourceType() === "document" && mainFrameNavigations > 0;
+    if (!isVersionCheck && !isUpdatedNavigation) {
       await route.fallback();
       return;
     }
 
-    frontendVersionChecks += 1;
+    if (isVersionCheck) frontendVersionChecks += 1;
+    const response = await route.fetch();
+    const shell = await response.text();
+    const entrypointMatch = shell.match(/<script\b[^>]*\btype="module"[^>]*\bsrc="([^"]+)"[^>]*>/);
+    const currentEntrypointPath = entrypointMatch?.[1];
+    if (!entrypointMatch || !currentEntrypointPath) throw new Error("Frontend entrypoint not found in test shell");
+
+    currentEntrypointUrl ||= new URL(currentEntrypointPath, route.request().url()).href;
+    const updatedEntrypoint = entrypointMatch[0].replace(currentEntrypointPath, updatedEntrypointPath);
+    await route.fulfill({ response, body: shell.replace(entrypointMatch[0], updatedEntrypoint) });
+  });
+  await page.route(updatedEntrypointPath, async (route) => {
+    if (!currentEntrypointUrl) throw new Error("Current frontend entrypoint URL not captured");
+
+    const body = await readFile(distAssetUrl(currentEntrypointUrl), "utf8");
+    const mermaidCoreFilename = body.match(/mermaid\.core-[A-Za-z0-9_-]+\.js/)?.[0];
+    if (!mermaidCoreFilename) throw new Error("Mermaid core chunk not found in frontend entrypoint");
+
+    currentMermaidCoreUrl = new URL(mermaidCoreFilename, currentEntrypointUrl).href;
     await route.fulfill({
       status: 200,
-      contentType: "text/html",
-      body: [
-        "<!doctype html>",
-        '<html><body><div id="app"></div>',
-        '<script type="module" src="/assets/index-updated.js"></script>',
-        "</body></html>",
-      ].join(""),
+      contentType: "application/javascript",
+      body: body.replaceAll(mermaidCoreFilename, "mermaid.core-updated.js"),
+    });
+  });
+  await page.route(updatedMermaidCorePath, async (route) => {
+    if (!currentMermaidCoreUrl) throw new Error("Current Mermaid core URL not captured");
+
+    const body = await readFile(distAssetUrl(currentMermaidCoreUrl), "utf8");
+    const sequenceFilename = body.match(/sequenceDiagram-[A-Za-z0-9_-]+\.js/)?.[0];
+    if (!sequenceFilename) throw new Error("Sequence diagram chunk not found in Mermaid core");
+
+    currentSequenceUrl ||= new URL(sequenceFilename, currentMermaidCoreUrl).href;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/javascript",
+      body: body.replaceAll(sequenceFilename, "sequenceDiagram-updated.js"),
     });
   });
   await page.route(/\/assets\/sequenceDiagram-[^/?]+\.js$/, async (route) => {
-    sequenceChunkRequests += 1;
-    if (sequenceChunkRequests === 1) {
-      await route.fulfill({ status: 404, contentType: "text/plain", body: "missing stale chunk" });
+    if (new URL(route.request().url()).pathname === updatedSequencePath) {
+      if (!currentSequenceUrl) throw new Error("Current sequence diagram URL not captured");
+
+      updatedSequenceRequests += 1;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/javascript",
+        body: await readFile(distAssetUrl(currentSequenceUrl), "utf8"),
+      });
       return;
     }
-    await route.fallback();
+
+    oldSequenceRequests += 1;
+    await route.fulfill({ status: 404, contentType: "text/plain", body: "missing stale chunk" });
   });
 
   await page.goto("/pulls/github/acme/widgets/42");
@@ -60,8 +110,14 @@ test("reloads an outdated frontend before rendering a Mermaid diagram", async ({
   await page.locator(".body-edit .title-edit-save").click();
 
   await expect.poll(() => mainFrameNavigations).toBeGreaterThanOrEqual(2);
+  await page.waitForLoadState("load");
   await expect.poll(() => frontendVersionChecks).toBeGreaterThanOrEqual(1);
-  await expect.poll(() => sequenceChunkRequests).toBeGreaterThanOrEqual(2);
-  await expect(page.locator(".markdown-body .kit-mermaid-viewer__pan svg")).toBeVisible();
-  await expect(page.locator(".markdown-body pre.shiki")).toContainText('const ordinary = "code";');
+  await expect.poll(() => updatedSequenceRequests).toBeGreaterThanOrEqual(1);
+  await expect(page.locator(".markdown-body .kit-mermaid-viewer__pan svg").first()).toBeVisible({ timeout: 10_000 });
+  expect(oldSequenceRequests).toBeGreaterThanOrEqual(1);
+  await expect(page.locator(".markdown-body pre.shiki").filter({ hasText: 'const ordinary = "code";' })).toBeVisible();
+  const reloadGuardKeys = await page.evaluate(() =>
+    Object.keys(window.sessionStorage).filter((key) => key.startsWith("middleman:vite-reload")),
+  );
+  expect(reloadGuardKeys).toEqual([]);
 });

--- a/frontend/tests/e2e-full/stale-asset-recovery.spec.ts
+++ b/frontend/tests/e2e-full/stale-asset-recovery.spec.ts
@@ -2,14 +2,22 @@ import { expect, test } from "@playwright/test";
 
 import { mockApi } from "../e2e/support/mockApi";
 
-test("reloads stale assets before rendering a Mermaid diagram", async ({ page }) => {
+test("reloads a confirmed stale asset before rendering a Mermaid diagram", async ({ page }) => {
   await mockApi(page);
   let mainFrameNavigations = 0;
+  let missingAssetProbes = 0;
   let sequenceChunkRequests = 0;
   page.on("framenavigated", (frame) => {
     if (frame === page.mainFrame()) mainFrameNavigations += 1;
   });
-  await page.route(/\/assets\/sequenceDiagram-[^/]+\.js$/, async (route) => {
+  await page.route(/\/assets\/sequenceDiagram-[^/?]+\.js(?:\?.*)?$/, async (route) => {
+    const requestUrl = new URL(route.request().url());
+    if (requestUrl.searchParams.has("_middleman_vite_probe")) {
+      missingAssetProbes += 1;
+      await route.fulfill({ status: 404, contentType: "text/plain", body: "missing stale chunk" });
+      return;
+    }
+
     sequenceChunkRequests += 1;
     if (sequenceChunkRequests === 1) {
       await route.fulfill({ status: 404, contentType: "text/plain", body: "missing stale chunk" });
@@ -40,6 +48,7 @@ test("reloads stale assets before rendering a Mermaid diagram", async ({ page })
   await page.locator(".body-edit .title-edit-save").click();
 
   await expect.poll(() => mainFrameNavigations).toBeGreaterThanOrEqual(2);
+  await expect.poll(() => missingAssetProbes).toBeGreaterThanOrEqual(1);
   await expect.poll(() => sequenceChunkRequests).toBeGreaterThanOrEqual(2);
   await expect(page.locator(".markdown-body .kit-mermaid-viewer__pan svg")).toBeVisible();
   await expect(page.locator(".markdown-body pre.shiki")).toContainText('const ordinary = "code";');

--- a/frontend/tests/e2e-full/stale-asset-recovery.spec.ts
+++ b/frontend/tests/e2e-full/stale-asset-recovery.spec.ts
@@ -2,22 +2,34 @@ import { expect, test } from "@playwright/test";
 
 import { mockApi } from "../e2e/support/mockApi";
 
-test("reloads a confirmed stale asset before rendering a Mermaid diagram", async ({ page }) => {
+test("reloads an outdated frontend before rendering a Mermaid diagram", async ({ page }) => {
   await mockApi(page);
   let mainFrameNavigations = 0;
-  let missingAssetProbes = 0;
+  let frontendVersionChecks = 0;
   let sequenceChunkRequests = 0;
   page.on("framenavigated", (frame) => {
     if (frame === page.mainFrame()) mainFrameNavigations += 1;
   });
-  await page.route(/\/assets\/sequenceDiagram-[^/?]+\.js(?:\?.*)?$/, async (route) => {
-    const requestUrl = new URL(route.request().url());
-    if (requestUrl.searchParams.has("_middleman_vite_probe")) {
-      missingAssetProbes += 1;
-      await route.fulfill({ status: 404, contentType: "text/plain", body: "missing stale chunk" });
+  await page.route(/\/pulls\/github\/acme\/widgets\/42$/, async (route) => {
+    const accept = await route.request().headerValue("accept");
+    if (route.request().resourceType() !== "fetch" || !accept?.includes("text/html")) {
+      await route.fallback();
       return;
     }
 
+    frontendVersionChecks += 1;
+    await route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: [
+        "<!doctype html>",
+        '<html><body><div id="app"></div>',
+        '<script type="module" src="/assets/index-updated.js"></script>',
+        "</body></html>",
+      ].join(""),
+    });
+  });
+  await page.route(/\/assets\/sequenceDiagram-[^/?]+\.js$/, async (route) => {
     sequenceChunkRequests += 1;
     if (sequenceChunkRequests === 1) {
       await route.fulfill({ status: 404, contentType: "text/plain", body: "missing stale chunk" });
@@ -48,7 +60,7 @@ test("reloads a confirmed stale asset before rendering a Mermaid diagram", async
   await page.locator(".body-edit .title-edit-save").click();
 
   await expect.poll(() => mainFrameNavigations).toBeGreaterThanOrEqual(2);
-  await expect.poll(() => missingAssetProbes).toBeGreaterThanOrEqual(1);
+  await expect.poll(() => frontendVersionChecks).toBeGreaterThanOrEqual(1);
   await expect.poll(() => sequenceChunkRequests).toBeGreaterThanOrEqual(2);
   await expect(page.locator(".markdown-body .kit-mermaid-viewer__pan svg")).toBeVisible();
   await expect(page.locator(".markdown-body pre.shiki")).toContainText('const ordinary = "code";');

--- a/frontend/tests/e2e-full/stale-asset-recovery.spec.ts
+++ b/frontend/tests/e2e-full/stale-asset-recovery.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "@playwright/test";
+
+import { mockApi } from "../e2e/support/mockApi";
+
+test("reloads stale assets before rendering a Mermaid diagram", async ({ page }) => {
+  await mockApi(page);
+  let mainFrameNavigations = 0;
+  let sequenceChunkRequests = 0;
+  page.on("framenavigated", (frame) => {
+    if (frame === page.mainFrame()) mainFrameNavigations += 1;
+  });
+  await page.route(/\/assets\/sequenceDiagram-[^/]+\.js$/, async (route) => {
+    sequenceChunkRequests += 1;
+    if (sequenceChunkRequests === 1) {
+      await route.fulfill({ status: 404, contentType: "text/plain", body: "missing stale chunk" });
+      return;
+    }
+    await route.fallback();
+  });
+
+  await page.goto("/pulls/github/acme/widgets/42");
+  await page.locator(".edit-body-btn").click();
+  await page
+    .locator(".body-edit-textarea")
+    .fill(
+      [
+        "```mermaid",
+        "sequenceDiagram",
+        "  participant Client",
+        "  participant Server",
+        "  Client->>Server: Send request",
+        "  Server-->>Client: Return response",
+        "```",
+        "",
+        "```ts",
+        'const ordinary = "code";',
+        "```",
+      ].join("\n"),
+    );
+  await page.locator(".body-edit .title-edit-save").click();
+
+  await expect.poll(() => mainFrameNavigations).toBeGreaterThanOrEqual(2);
+  await expect.poll(() => sequenceChunkRequests).toBeGreaterThanOrEqual(2);
+  await expect(page.locator(".markdown-body .kit-mermaid-viewer__pan svg")).toBeVisible();
+  await expect(page.locator(".markdown-body pre.shiki")).toContainText('const ordinary = "code";');
+});

--- a/frontend/tests/e2e-full/stale-asset-recovery.spec.ts
+++ b/frontend/tests/e2e-full/stale-asset-recovery.spec.ts
@@ -9,6 +9,7 @@ function distAssetUrl(assetUrl: string): URL {
 }
 
 test("reloads an outdated frontend before rendering a Mermaid diagram", async ({ page }) => {
+  test.setTimeout(45_000);
   await mockApi(page);
   const updatedEntrypointPath = "/assets/index-updated.js";
   const updatedMermaidCorePath = "/assets/mermaid.core-updated.js";
@@ -113,11 +114,18 @@ test("reloads an outdated frontend before rendering a Mermaid diagram", async ({
   await page.waitForLoadState("load");
   await expect.poll(() => frontendVersionChecks).toBeGreaterThanOrEqual(1);
   await expect.poll(() => updatedSequenceRequests).toBeGreaterThanOrEqual(1);
-  await expect(page.locator(".markdown-body .kit-mermaid-viewer__pan svg").first()).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator(".markdown-body .kit-mermaid-viewer__pan svg").first()).toBeVisible({ timeout: 20_000 });
   expect(oldSequenceRequests).toBeGreaterThanOrEqual(1);
-  await expect(page.locator(".markdown-body pre.shiki").filter({ hasText: 'const ordinary = "code";' })).toBeVisible();
-  const reloadGuardKeys = await page.evaluate(() =>
-    Object.keys(window.sessionStorage).filter((key) => key.startsWith("middleman:vite-reload")),
-  );
-  expect(reloadGuardKeys).toEqual([]);
+  await expect(
+    page.locator(".markdown-body pre.shiki").filter({ hasText: 'const ordinary = "code";' }).first(),
+  ).toBeVisible();
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() =>
+          Object.keys(window.sessionStorage).filter((key) => key.startsWith("middleman:vite-reload")),
+        ),
+      { timeout: 10_000 },
+    )
+    .toEqual([]);
 });

--- a/frontend/tests/e2e/edit-pr-content.spec.ts
+++ b/frontend/tests/e2e/edit-pr-content.spec.ts
@@ -133,13 +133,30 @@ test("markdown mermaid fences render as diagrams", async ({ page }) => {
   await page.goto("/pulls/github/acme/widgets/42");
   await page.locator(".edit-body-btn").click();
 
-  await page.locator(".body-edit-textarea").fill("```mermaid\ngraph TD\n  A --> B\n```");
+  await page
+    .locator(".body-edit-textarea")
+    .fill(
+      [
+        "```mermaid",
+        "sequenceDiagram",
+        "  participant Client",
+        "  participant Server",
+        "  Client->>Server: Send request",
+        "  Server-->>Client: Return response",
+        "```",
+        "",
+        "```ts",
+        'const ordinary = "code";',
+        "```",
+      ].join("\n"),
+    );
   await page.locator(".body-edit .title-edit-save").click();
 
   await expect(page.locator(".markdown-body code.language-mermaid")).toHaveCount(0);
   await expect(
     page.locator(".markdown-body pre.mermaid.kit-mermaid-viewer .kit-mermaid-viewer__pan svg"),
   ).toBeVisible();
+  await expect(page.locator(".markdown-body pre.shiki")).toContainText('const ordinary = "code";');
   await expect(page.getByRole("button", { name: "Zoom in diagram" })).toHaveCount(0);
   await expect(page.getByRole("button", { name: "Zoom out diagram" })).toHaveCount(0);
   await expect(page.getByRole("button", { name: "Copy Mermaid source" })).toBeVisible();


### PR DESCRIPTION
An already-open Middleman tab can outlive a binary update. When that tab later encounters its first Mermaid diagram, Vite can request an obsolete content-hashed sequence-diagram chunk from the new server. The server correctly returns 404 for the stale asset, and Kit restores the escaped Mermaid source after the infrastructure failure, matching the reported plain-code rendering.

Middleman now handles Vite's `vite:preloadError` event at the application deployment boundary. It fetches the server's current HTML without cache and reloads only when that document points to a different frontend entrypoint, while transient failures continue into the existing feature-level retry paths. A source-and-target session marker prevents repeated reloads while a deployment is incomplete and is retired after loading either the target or a newer frontend, allowing later rollback and redeploy cycles to recover. The reusable Kit renderer remains unchanged.

Browser coverage exercises the reported `sequenceDiagram` beside an ordinary TypeScript fence, keeps the stale sequence chunk permanently unavailable, and requires the reload to boot a distinct updated asset graph. Focused state-transition coverage protects rollback after a reload lands on an intervening deployment, while existing coverage preserves the repeated-failure retry flow for other lazy features.
