### PR TITLE
Add current repository sync menu

### DIFF
--- a/context/platform-sync-invariants.md
+++ b/context/platform-sync-invariants.md
@@ -82,9 +82,9 @@ registry helpers return typed errors for missing providers or capabilities.
 
 - Missing optional capabilities should degrade that feature with a typed
   platform error, not break unrelated sync work.
-- `priority_repo` reorders a full run; `only_repo` restricts its repo set. Resolve
-  both by full provider/host/path identity, and reject invalid exclusive scope
-  instead of falling back to full sync. (`internal/server/huma_routes.go::triggerSync`)
+- `priority_repo` reorders a full run; `only_repo` restricts every repo-derived
+  phase and does not advance the full-run cooldown. Resolve both by full identity,
+  and never fall back from invalid exclusive scope. (`internal/github/sync.go::runOnce`)
 - Mutation routes must check provider capabilities before posting comments,
   changing state, merging, requesting review, or approving workflows.
   Server handlers translate these typed platform errors into the stable problem

--- a/context/platform-sync-invariants.md
+++ b/context/platform-sync-invariants.md
@@ -83,8 +83,8 @@ registry helpers return typed errors for missing providers or capabilities.
 - Missing optional capabilities should degrade that feature with a typed
   platform error, not break unrelated sync work.
 - `priority_repo` reorders a full run; `only_repo` restricts every repo-derived
-  phase and does not advance the full-run cooldown. Resolve both by full identity,
-  and never fall back from invalid exclusive scope. (`internal/github/sync.go::runOnce`)
+  phase and must not delay full-run cadence. Resolve both by full identity, and
+  never fall back from invalid exclusive scope. (`internal/github/sync.go::runOnce`)
 - Mutation routes must check provider capabilities before posting comments,
   changing state, merging, requesting review, or approving workflows.
   Server handlers translate these typed platform errors into the stable problem

--- a/context/platform-sync-invariants.md
+++ b/context/platform-sync-invariants.md
@@ -82,6 +82,9 @@ registry helpers return typed errors for missing providers or capabilities.
 
 - Missing optional capabilities should degrade that feature with a typed
   platform error, not break unrelated sync work.
+- `priority_repo` reorders a full run; `only_repo` restricts its repo set. Resolve
+  both by full provider/host/path identity, and reject invalid exclusive scope
+  instead of falling back to full sync. (`internal/server/huma_routes.go::triggerSync`)
 - Mutation routes must check provider capabilities before posting comments,
   changing state, merging, requesting review, or approving workflows.
   Server handlers translate these typed platform errors into the stable problem

--- a/docs/superpowers/plans/2026-07-20-current-repository-sync.md
+++ b/docs/superpowers/plans/2026-07-20-current-repository-sync.md
@@ -1,0 +1,428 @@
+# Current Repository Sync Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a split header sync control whose main segment keeps the existing full sync and whose menu can sync only the current repository.
+
+**Architecture:** `POST /sync` accepts a provider-qualified `only_repo` filter that resolves against tracked repositories and dispatches a restricted syncer run. The shared sync store exposes a separate scoped method. AppHeader resolves the route repository before a single global-selector value and renders a fixed-position, dismissable menu from the existing split control.
+
+**Tech Stack:** Go, Huma/OpenAPI, Svelte 5 runes, TypeScript, Vite+, Testing Library, testify.
+
+## Global Constraints
+
+- Repository identity is `provider|platform_host/repo_path`; owner/repo alone is invalid.
+- `triggerSync()` and `priority_repo` keep their current full-sync behavior.
+- `only_repo` never falls back to a full sync when resolution fails.
+- Notification sync stays attached only to the full-sync path.
+- Use shared kit-ui popover positioning, dismissal, and surface chrome.
+- Invoke direct Go tests with `-shuffle=on`; use Vite+ instead of npm.
+
+---
+
+### Task 1: Restrict a syncer run to selected repositories
+
+**Files:**
+- Modify: `internal/github/sync.go`
+- Test: `internal/github/syncertest/syncer_test.go`
+
+**Interfaces:**
+- Produces: `func (s *Syncer) TriggerRunForRepos(ctx context.Context, repos []RepoRef)`.
+- Preserves: `TriggerRunWithPriority(ctx, priorityRepos)` and `RunOnce(ctx)`.
+
+- [ ] **Step 1: Write the failing syncer test**
+
+Add a table-backed fake with three tracked repositories, set parallelism to one, call `TriggerRunForRepos` with the third repository, and assert that the upstream list call records only `o/third`:
+
+```go
+func TestSyncerTriggerRunForReposSyncsOnlySelectedRepos(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	var mu sync.Mutex
+	var calls []string
+	mock := &mockClient{
+		openPRs: []*gh.PullRequest{},
+		listOpenPRsFn: func(_ context.Context, owner, repo string) ([]*gh.PullRequest, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			calls = append(calls, owner+"/"+repo)
+			return []*gh.PullRequest{}, nil
+		},
+		getRepositoryFn: func(_ context.Context, owner, repo string) (*gh.Repository, error) {
+			ids := map[string]int64{"first": 1, "second": 2, "third": 3}
+			id := ids[repo]
+			nodeID := "repo-" + owner + "-" + repo
+			return &gh.Repository{
+				ID: &id, NodeID: &nodeID, Name: &repo,
+				Owner: &gh.User{Login: &owner}, Archived: new(bool),
+			}, nil
+		},
+	}
+	d := openTestDB(t)
+	s := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": mock}, d, nil,
+		[]ghclient.RepoRef{
+			{Owner: "o", Name: "first", PlatformHost: "github.com"},
+			{Owner: "o", Name: "second", PlatformHost: "github.com"},
+			{Owner: "o", Name: "third", PlatformHost: "github.com"},
+		},
+		time.Hour, nil, nil,
+	)
+	s.SetParallelism(1)
+	done := make(chan struct{}, 1)
+	s.SetOnStatusChange(func(status *ghclient.SyncStatus) {
+		if !status.Running {
+			select {
+			case done <- struct{}{}:
+			default:
+			}
+		}
+	})
+
+	s.TriggerRunForRepos(t.Context(), []ghclient.RepoRef{{
+		Owner: "o", Name: "third", PlatformHost: "github.com",
+	}})
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		require.FailNow("scoped TriggerRun did not complete within 1s")
+	}
+	s.Stop()
+
+	mu.Lock()
+	got := slices.Clone(calls)
+	mu.Unlock()
+	assert.Equal([]string{"o/third"}, got)
+}
+```
+
+Keep helpers local only when the existing priority test also uses them; otherwise inline the fixture to avoid one-test helpers.
+
+- [ ] **Step 2: Run the focused test and confirm RED**
+
+Run:
+
+```bash
+go test ./internal/github/syncertest -run TestSyncerTriggerRunForReposSyncsOnlySelectedRepos -shuffle=on
+```
+
+Expected: compile failure because `TriggerRunForRepos` does not exist.
+
+- [ ] **Step 3: Add the restricted trigger**
+
+Extend the internal run path with an optional repository override. Clone caller-owned input before starting the goroutine and preserve the existing single-flight and lifecycle behavior:
+
+```go
+func (s *Syncer) TriggerRunForRepos(ctx context.Context, repos []RepoRef) {
+	s.triggerRun(ctx, nil, slices.Clone(repos))
+}
+
+func (s *Syncer) TriggerRunWithPriority(ctx context.Context, priorityRepos []RepoRef) {
+	s.triggerRun(ctx, slices.Clone(priorityRepos), nil)
+}
+
+func (s *Syncer) triggerRun(ctx context.Context, priorityRepos, onlyRepos []RepoRef) {
+	s.lifecycleMu.Lock()
+	if s.stopped {
+		s.lifecycleMu.Unlock()
+		return
+	}
+	merged, cancel := s.mergeWithRunCtx(ctx)
+	s.wg.Add(1)
+	s.lifecycleMu.Unlock()
+
+	go func() {
+		defer s.wg.Done()
+		defer cancel()
+		s.runOnce(merged, true, priorityRepos, onlyRepos)
+	}()
+}
+```
+
+Update `RunOnce` and `runOnce` callers to pass `nil` for `onlyRepos`. After cloning tracked repositories inside `runOnce`, filter them by `repoPriorityKey` when `onlyRepos != nil`, then apply normal priority ordering:
+
+```go
+repos := slices.Clone(s.repos)
+if onlyRepos != nil {
+	repos = selectRepos(repos, onlyRepos)
+}
+repos = prioritizeRepos(repos, priorityRepos)
+```
+
+`selectRepos` keeps tracked-order output and matches on the existing provider/host/repo-path key.
+
+- [ ] **Step 4: Run syncer tests and confirm GREEN**
+
+Run:
+
+```bash
+go test ./internal/github/syncertest -run 'TestSyncerTriggerRun(WithPrioritySyncsSelectedReposFirst|ForReposSyncsOnlySelectedRepos)$' -shuffle=on
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the syncer slice**
+
+```bash
+git add internal/github/sync.go internal/github/syncertest/syncer_test.go
+git commit -m "feat: support repository-scoped sync runs"
+```
+
+### Task 2: Expose scoped sync through the API and UI store
+
+**Files:**
+- Modify: `internal/server/huma_routes.go`
+- Test: `internal/server/sync_routes_test.go`
+- Modify generated: `docs/openapi.json`
+- Modify generated: `internal/apiclient/generated/client.gen.go`
+- Modify generated: `packages/ui/src/api/generated/schema.ts`
+- Modify: `packages/ui/src/stores/sync.svelte.ts`
+- Test: `packages/ui/src/stores/sync.svelte.test.ts`
+
+**Interfaces:**
+- Consumes: `Syncer.TriggerRunForRepos(ctx, repos)` from Task 1.
+- Produces: repeated query parameter `only_repo` and `SyncStore.triggerRepoSync(repo: string): Promise<void>`.
+
+- [ ] **Step 1: Write failing server and store tests**
+
+Add a wire-level server test that posts:
+
+```text
+/api/v1/sync?only_repo=gitlab|gitlab.example.com/group/subgroup/project
+```
+
+Assert HTTP 202 and that the fake syncer receives only the matching full identity. Add a second case for an unknown identity and assert HTTP 400 with `code: "validationError"` and `details.field: "query.only_repo"`; assert no trigger ran.
+
+Add a store test:
+
+```ts
+it("passes one provider-qualified repository as the only sync scope", async () => {
+  const { store, post } = syncStoreFixture();
+  await store.triggerRepoSync("gitlab|gitlab.example.com/group/subgroup/project");
+  expect(post).toHaveBeenCalledWith("/sync", {
+    params: { query: { only_repo: ["gitlab|gitlab.example.com/group/subgroup/project"] } },
+  });
+});
+```
+
+Keep the existing priority test unchanged to guard full-sync behavior.
+
+- [ ] **Step 2: Run focused tests and confirm RED**
+
+Run:
+
+```bash
+go test ./internal/server -run 'TestTriggerSync(OnlyRepo|RejectsUnknownOnlyRepo)$' -shuffle=on
+./node_modules/.bin/vp test packages/ui/src/stores/sync.svelte.test.ts
+```
+
+Expected: the Go test cannot populate `only_repo`; the TypeScript test cannot find `triggerRepoSync`.
+
+- [ ] **Step 3: Implement server validation and dispatch**
+
+Extend input without changing `PriorityRepos`:
+
+```go
+type triggerSyncInput struct {
+	PriorityRepos []string `query:"priority_repo" doc:"Optional repository filters to sync first. Accepts repeated provider|platform_host/repo_path values or comma-separated values."`
+	OnlyRepos     []string `query:"only_repo" doc:"Optional repository filters to sync exclusively. Accepts repeated provider|platform_host/repo_path values or comma-separated values."`
+}
+```
+
+Resolve every `only_repo` value against `s.syncer.TrackedRepos()`. Reject malformed or unmatched values with:
+
+```go
+return nil, problemValidation("query.only_repo", "repository must match a configured provider|platform_host/repo_path")
+```
+
+When `OnlyRepos` is non-empty, call `TriggerRunForRepos(context.WithoutCancel(ctx), repos)` and skip notification sync. Otherwise preserve the current priority and notification path exactly.
+
+- [ ] **Step 4: Regenerate API artifacts**
+
+Run:
+
+```bash
+make api-generate
+```
+
+Expected: OpenAPI, Go client, and TypeScript schema expose `only_repo?: string[] | null`.
+
+- [ ] **Step 5: Implement the store method**
+
+Extract the optimistic status/error wrapper only if it removes duplication cleanly. Expose a scoped method that sends exactly one full identity:
+
+```ts
+async function triggerRepoSync(repo: string): Promise<void> {
+  await trigger({ params: { query: { only_repo: [repo] } } });
+}
+```
+
+`triggerSync()` continues to calculate `priority_repo` from `getPriorityRepos()` and calls the same internal trigger helper.
+
+- [ ] **Step 6: Run API and store tests and confirm GREEN**
+
+Run:
+
+```bash
+go test ./internal/server -run 'TestTriggerSync|TestMatchPriorityRepo' -shuffle=on
+./node_modules/.bin/vp test packages/ui/src/stores/sync.svelte.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit the contract slice**
+
+```bash
+git add internal/server/huma_routes.go internal/server/sync_routes_test.go docs/openapi.json internal/apiclient/generated/client.gen.go packages/ui/src/api/generated/schema.ts packages/ui/src/stores/sync.svelte.ts packages/ui/src/stores/sync.svelte.test.ts
+git commit -m "feat: expose repository-only sync requests"
+```
+
+### Task 3: Build the split sync control
+
+**Files:**
+- Modify: `frontend/src/lib/utils/repoSelectionSync.ts`
+- Test: `frontend/src/lib/utils/repoSelectionSync.test.ts`
+- Modify: `frontend/src/lib/components/layout/AppHeader.svelte`
+- Test: `frontend/src/lib/components/layout/AppHeader.test.ts`
+
+**Interfaces:**
+- Consumes: `sync.triggerRepoSync(repo)` from Task 2.
+- Produces: `syncRepoForRoute(route: Route): string | undefined` and the header split-menu interaction.
+
+- [ ] **Step 1: Write route-resolution and header interaction tests**
+
+Add table cases proving pull, issue, focus, and repo-browser routes return:
+
+```text
+provider|platformHost/repoPath
+```
+
+Add AppHeader tests with mocked `triggerSync` and `triggerRepoSync`:
+
+```ts
+it("keeps full sync on the primary segment", async () => {
+  render(AppHeader);
+  await fireEvent.click(screen.getByRole("button", { name: "Sync" }));
+  expect(triggerSync).toHaveBeenCalledOnce();
+  expect(triggerRepoSync).not.toHaveBeenCalled();
+});
+
+it("syncs the route repository from the chevron menu", async () => {
+  navigate("/host/ghe.example.com/pulls/github/acme/widget/7");
+  render(AppHeader);
+  await fireEvent.click(screen.getByRole("button", { name: "Sync options" }));
+  await fireEvent.click(screen.getByRole("menuitem", { name: "Sync current repo" }));
+  expect(triggerRepoSync).toHaveBeenCalledWith("github|ghe.example.com/acme/widget");
+});
+```
+
+Add cases for single selector fallback, disabled menu item for All repos/multi-select, Escape focus restoration, and shared running-state disabled controls.
+
+- [ ] **Step 2: Run focused frontend tests and confirm RED**
+
+Run:
+
+```bash
+./node_modules/.bin/vp test frontend/src/lib/utils/repoSelectionSync.test.ts frontend/src/lib/components/layout/AppHeader.test.ts
+```
+
+Expected: missing resolver, options button, and menu action failures.
+
+- [ ] **Step 3: Implement repository resolution**
+
+Add `syncRepoForRoute(route)` beside `globalRepoForSelectedRoute`. Reuse the selected-item resolution and add repo-browser identity. AppHeader derives:
+
+```ts
+const currentSyncRepo = $derived.by(() => {
+  const routeRepo = syncRepoForRoute(getRoute());
+  if (routeRepo) return routeRepo;
+  const selected = parseRepoFilterValue(getGlobalRepo());
+  return selected.length === 1 ? selected[0] : undefined;
+});
+```
+
+- [ ] **Step 4: Implement the fixed split-menu control**
+
+Import `autoReposition`, `dismissable`, and `floatingPopoverStyle` from kit-ui. Keep the primary button handler unchanged. Add a chevron button with `aria-label="Sync options"`, `aria-haspopup="menu"`, and `aria-expanded`. The open menu uses:
+
+```svelte
+<ul
+  class="sync-menu kit-popover-card"
+  role="menu"
+  aria-label="Sync options"
+  bind:this={syncMenu}
+  style={syncMenuStyle}
+>
+  <li>
+    <button
+      type="button"
+      role="menuitem"
+      disabled={!currentSyncRepo || syncing}
+      onclick={handleCurrentRepoSync}
+    >Sync current repo</button>
+  </li>
+</ul>
+```
+
+Position it with `floatingPopoverStyle({ align: "end", triggerGap: 2 })`. Wire `dismissable` and `autoReposition` in an open-state effect. Use `kit-popover-card` for chrome and local CSS only for split-button geometry and menu-item layout.
+
+- [ ] **Step 5: Run Svelte analysis and focused tests**
+
+Run:
+
+```bash
+./node_modules/.bin/vp exec -- svelte-mcp svelte-autofixer ./frontend/src/lib/components/layout/AppHeader.svelte
+./node_modules/.bin/vp test frontend/src/lib/utils/repoSelectionSync.test.ts frontend/src/lib/components/layout/AppHeader.test.ts
+```
+
+Expected: autofixer reports no actionable findings; tests PASS.
+
+- [ ] **Step 6: Commit the UI slice**
+
+```bash
+git add frontend/src/lib/utils/repoSelectionSync.ts frontend/src/lib/utils/repoSelectionSync.test.ts frontend/src/lib/components/layout/AppHeader.svelte frontend/src/lib/components/layout/AppHeader.test.ts
+git commit -m "feat: add current repository sync menu"
+```
+
+### Task 4: Final verification
+
+**Files:**
+- Review all files changed by Tasks 1 through 3.
+
+**Interfaces:**
+- Verifies the complete contract without adding new behavior.
+
+- [ ] **Step 1: Run Go verification**
+
+```bash
+go test ./internal/github/syncertest ./internal/server -shuffle=on
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run the complete frontend suite and checks**
+
+```bash
+./node_modules/.bin/vp test
+./node_modules/.bin/vp run check
+```
+
+Expected: PASS with no warnings attributable to this change.
+
+- [ ] **Step 3: Review generated and source diffs**
+
+```bash
+git status --short
+git diff HEAD~3 --stat
+git diff HEAD~3 -- docs/openapi.json packages/ui/src/api/generated/schema.ts internal/apiclient/generated/client.gen.go
+```
+
+Expected: generated changes only add `only_repo`; no unrelated files appear.
+
+- [ ] **Step 4: Run repository context sync before the final commit**
+
+```bash
+scripts/context-sync --check
+```
+
+Inspect the intended diff and update the smallest mapped context document only if the work introduced a durable rule not already captured by the design spec and existing provider/UI context.

--- a/docs/superpowers/specs/2026-07-20-current-repository-sync-design.md
+++ b/docs/superpowers/specs/2026-07-20-current-repository-sync-design.md
@@ -1,0 +1,84 @@
+# Current Repository Sync
+
+## Purpose
+
+Add a split sync control to the desktop app header. The primary segment keeps
+the existing full-sync behavior. The chevron segment exposes a separate action
+that syncs only the repository in the current UI context.
+
+## Interaction
+
+The control renders as one 28px button group:
+
+```text
+[ sync icon  Sync | chevron ]
+```
+
+- Clicking the icon or label triggers the existing full sync without changing
+  its request or priority behavior.
+- Clicking the chevron opens a compact popover menu with one item: `Sync current
+  repo`.
+- A route-specific repository wins for pull request, issue, focus, and repository
+  source routes. Otherwise, exactly one repository selected in the global repo
+  selector supplies the scope.
+- The menu item is disabled when neither source identifies one repository, such
+  as an all-repository or multi-repository selection on a non-repository route.
+- Both segments and the menu action are disabled while a sync is running. The
+  primary segment continues to show the existing spinner and `Syncing...` label.
+- The chevron exposes `aria-expanded` and `aria-haspopup="menu"`. Escape and an
+  outside press close the menu and restore focus to the chevron.
+
+The menu uses the shared popover surface and dismissal behavior so it is not
+clipped by the top bar or split-pane layout.
+
+## Repository Identity
+
+Scoped sync requests carry the full provider-qualified identity:
+
+```text
+provider|platform_host/repo_path
+```
+
+The server resolves this value against configured repositories. Owner, repo, or
+number alone must never select the sync target.
+
+## API And Syncer
+
+Extend `POST /sync` with an optional repeated `only_repo` query parameter. It
+uses the same provider-qualified syntax as `priority_repo`, but the two options
+have different behavior:
+
+- No `only_repo` retains the existing full sync.
+- `only_repo` runs the normal repository sync pipeline for only the resolved
+  repositories.
+- An unresolved or malformed `only_repo` value returns a stable client error and
+  must not fall back to a full sync.
+
+The sync store gains a scoped trigger method instead of changing `triggerSync`.
+The syncer gains a corresponding entry point that supplies the selected
+repository set to the existing bounded, single-flight run machinery. A scoped
+sync does not launch the separate notification sync because notifications are
+not repository-scoped.
+
+Sync status remains global. Starting either action sets the same running state,
+and completion refreshes the same status endpoint.
+
+## Error Handling
+
+Request failures flow through the existing sync-store status field. A rejected
+scoped request clears the optimistic running state and records the server error,
+matching full-sync failure behavior. The menu closes when the user selects its
+enabled action; it does not add a second toast or error surface.
+
+## Verification
+
+- A syncer test proves a scoped trigger visits only the requested repository.
+- A server test proves `only_repo` resolves provider, host, and nested repo path,
+  and that invalid scope cannot trigger a full sync.
+- A sync-store test proves full sync remains unchanged and scoped sync sends
+  `only_repo`.
+- AppHeader component tests prove the split interaction, route-first resolution,
+  single-selector fallback, ambiguous disabled state, dismissal behavior, and
+  loading state.
+- Svelte analysis, the full frontend test suite, and the affected Go packages run
+  after the final edits.

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -18152,6 +18152,17 @@ paths:
             type:
               - array
               - "null"
+        - description: Optional repository filters to sync exclusively. Accepts repeated provider|platform_host/repo_path values or comma-separated values.
+          explode: false
+          in: query
+          name: only_repo
+          schema:
+            description: Optional repository filters to sync exclusively. Accepts repeated provider|platform_host/repo_path values or comma-separated values.
+            items:
+              type: string
+            type:
+              - array
+              - "null"
       responses:
         "202":
           description: Accepted

--- a/frontend/src/lib/components/layout/AppHeader.svelte
+++ b/frontend/src/lib/components/layout/AppHeader.svelte
@@ -1,12 +1,20 @@
 <script lang="ts">
-  import { TopBar, type TopBarTab } from "@kenn-io/kit-ui";
+  import {
+    autoReposition,
+    dismissable,
+    floatingPopoverStyle,
+    TopBar,
+    type TopBarTab,
+  } from "@kenn-io/kit-ui";
   import { getStores, KbdBadge } from "@middleman/ui";
   import type { ModeVisibility } from "@middleman/ui/api/types";
+  import { tick } from "svelte";
   import { SvelteMap } from "svelte/reactivity";
   import {
     getBasePath,
     getLastActivityRoute,
     getPage,
+    getRoute,
     getView,
     navigate,
   } from "../../stores/router.svelte.ts";
@@ -18,13 +26,18 @@
   import HeaderIconButton from "./HeaderIconButton.svelte";
   import ThemeToggle from "./ThemeToggle.svelte";
   import {
+    ChevronDownIcon,
     SearchIcon,
     SettingsIcon,
     SidebarToggleIcon,
     SpinnerIcon,
     SyncIcon,
   } from "../../icons.ts";
-  import { getGlobalRepo, setGlobalRepo } from "../../stores/filter.svelte.js";
+  import {
+    getGlobalRepo,
+    parseRepoFilterValue,
+    setGlobalRepo,
+  } from "../../stores/filter.svelte.js";
   import { isEmbedded, getUIConfig } from "../../stores/embed-config.svelte.js";
   import { isThemeToggleVisible } from "../../stores/theme.svelte.js";
   import {
@@ -33,6 +46,7 @@
     isSidebarToggleEnabled,
   } from "../../stores/sidebar.svelte.js";
   import { openPalette } from "../../stores/keyboard/palette-state.svelte.js";
+  import { syncRepoForRoute } from "../../utils/repoSelectionSync.js";
 
   interface Props {
     onheightchange?: ((height: number) => void) | undefined;
@@ -101,6 +115,81 @@
   }
 
   const syncing = $derived(sync.getSyncState()?.running ?? false);
+  const currentSyncRepo = $derived.by(() => {
+    const routeRepo = syncRepoForRoute(getRoute());
+    if (routeRepo) return routeRepo;
+
+    const selectedRepos = parseRepoFilterValue(getGlobalRepo());
+    return selectedRepos.length === 1 ? selectedRepos[0] : undefined;
+  });
+  let syncMenuOpen = $state(false);
+  let syncControlEl = $state<HTMLDivElement>();
+  let syncMenuTriggerEl = $state<HTMLButtonElement>();
+  let syncMenuEl = $state<HTMLUListElement>();
+  let syncMenuItemEl = $state<HTMLButtonElement>();
+  let syncMenuStyle = $state("");
+
+  $effect(() => {
+    if (!syncMenuOpen) return;
+    const cleanups = [
+      dismissable({
+        owners: () => [syncControlEl],
+        dismiss: () => (syncMenuOpen = false),
+        escapeFocus: () => syncMenuTriggerEl,
+      }),
+      autoReposition(() => syncMenuEl, positionSyncMenu),
+    ];
+    return () => cleanups.forEach((cleanup) => cleanup());
+  });
+
+  function positionSyncMenu(): void {
+    if (!syncMenuTriggerEl || !syncMenuEl) return;
+    syncMenuStyle = floatingPopoverStyle({
+      trigger: syncMenuTriggerEl.getBoundingClientRect(),
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+      popoverWidth: syncMenuEl.offsetWidth,
+      popoverHeight: syncMenuEl.offsetHeight,
+      align: "end",
+      triggerGap: 2,
+    });
+  }
+
+  async function openSyncMenu(): Promise<void> {
+    if (syncing) return;
+    syncMenuOpen = true;
+    await tick();
+    positionSyncMenu();
+    if (currentSyncRepo) syncMenuItemEl?.focus();
+  }
+
+  async function toggleSyncMenu(): Promise<void> {
+    if (syncMenuOpen) {
+      syncMenuOpen = false;
+      return;
+    }
+    await openSyncMenu();
+  }
+
+  function handleSyncMenuTriggerKeydown(event: KeyboardEvent): void {
+    if (event.key !== "ArrowDown") return;
+    event.preventDefault();
+    void openSyncMenu();
+  }
+
+  function handleSyncMenuItemKeydown(event: KeyboardEvent): void {
+    if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) return;
+    event.preventDefault();
+    syncMenuItemEl?.focus();
+  }
+
+  async function handleCurrentRepoSync(): Promise<void> {
+    const repo = currentSyncRepo;
+    if (!repo || syncing) return;
+    syncMenuOpen = false;
+    await sync.triggerRepoSync(repo);
+  }
+
   const hideProviderRepoSelector = $derived(getUIConfig().hideRepoSelector);
   const isProviderRepoSelectorPage = $derived(
     getPage() === "activity" ||
@@ -296,32 +385,72 @@
       <KbdBadge binding={{ key: "K", ctrlOrMeta: true }} />
     </HeaderIconButton>
     {#if !getUIConfig().hideSync}
-      <button
-        class="action-btn sync-btn"
-        aria-label={syncing ? "Syncing" : "Sync"}
-        title={syncing ? "Syncing" : "Sync"}
-        onclick={handleSync}
-        disabled={syncing}
-      >
-        {#if syncing}
-          <span class="sync-icon sync-icon--spinning" aria-hidden="true">
-            <SpinnerIcon
-              size="14"
-              strokeWidth="2"
-            />
-          </span>
-        {:else}
-          <span class="sync-icon" aria-hidden="true">
-            <SyncIcon
-              size="14"
-              strokeWidth="1.75"
-            />
-          </span>
+      <div class="sync-split" bind:this={syncControlEl}>
+        <button
+          type="button"
+          class="action-btn sync-btn sync-primary"
+          aria-label={syncing ? "Syncing" : "Sync"}
+          title={syncing ? "Syncing" : "Sync"}
+          onclick={handleSync}
+          disabled={syncing}
+        >
+          {#if syncing}
+            <span class="sync-icon sync-icon--spinning" aria-hidden="true">
+              <SpinnerIcon
+                size="14"
+                strokeWidth="2"
+              />
+            </span>
+          {:else}
+            <span class="sync-icon" aria-hidden="true">
+              <SyncIcon
+                size="14"
+                strokeWidth="1.75"
+              />
+            </span>
+          {/if}
+          {#if !tabsCollapsed}
+            <span class="sync-label">{syncing ? "Syncing..." : "Sync"}</span>
+          {/if}
+        </button>
+        <button
+          bind:this={syncMenuTriggerEl}
+          type="button"
+          class="action-btn sync-menu-trigger"
+          aria-label="Sync options"
+          title="Sync options"
+          aria-haspopup="menu"
+          aria-expanded={syncMenuOpen}
+          onclick={toggleSyncMenu}
+          onkeydown={handleSyncMenuTriggerKeydown}
+          disabled={syncing}
+        >
+          <ChevronDownIcon size="12" strokeWidth="1.75" aria-hidden="true" />
+        </button>
+        {#if syncMenuOpen}
+          <ul
+            bind:this={syncMenuEl}
+            class="sync-menu kit-popover-card"
+            role="menu"
+            aria-label="Sync options"
+            style={syncMenuStyle}
+          >
+            <li>
+              <button
+                bind:this={syncMenuItemEl}
+                type="button"
+                role="menuitem"
+                title={currentSyncRepo ? "Sync current repo" : "Select one repository to sync"}
+                disabled={!currentSyncRepo || syncing}
+                onclick={handleCurrentRepoSync}
+                onkeydown={handleSyncMenuItemKeydown}
+              >
+                Sync current repo
+              </button>
+            </li>
+          </ul>
         {/if}
-        {#if !tabsCollapsed}
-          <span class="sync-label">{syncing ? "Syncing..." : "Sync"}</span>
-        {/if}
-      </button>
+      </div>
     {/if}
     {#if isThemeToggleVisible()}
       <ThemeToggle />
@@ -386,6 +515,58 @@
     min-width: 34px;
     min-height: 28px;
     line-height: 0;
+  }
+
+  .sync-split {
+    position: relative;
+    display: inline-flex;
+    flex-shrink: 0;
+  }
+
+  .sync-primary {
+    border-radius: var(--radius-sm) 0 0 var(--radius-sm);
+  }
+
+  .sync-menu-trigger {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 24px;
+    margin-left: -1px;
+    padding-inline: 6px;
+    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+    line-height: 0;
+  }
+
+  .sync-menu {
+    position: fixed;
+    z-index: var(--z-popover);
+    min-width: 168px;
+    margin: 0;
+    padding: var(--space-1);
+    list-style: none;
+  }
+
+  .sync-menu button {
+    width: 100%;
+    padding: var(--space-2) var(--space-3);
+    border: 0;
+    border-radius: var(--radius-sm);
+    color: var(--text-primary);
+    background: transparent;
+    font: inherit;
+    font-size: var(--font-size-md);
+    text-align: left;
+    white-space: nowrap;
+  }
+
+  .sync-menu button:hover:not(:disabled) {
+    background: var(--bg-surface-hover);
+  }
+
+  .sync-menu button:disabled {
+    color: var(--text-muted);
+    cursor: not-allowed;
   }
 
   .sync-icon {

--- a/frontend/src/lib/components/layout/AppHeader.test.ts
+++ b/frontend/src/lib/components/layout/AppHeader.test.ts
@@ -21,6 +21,12 @@ type ModeKey =
 
 const mockedReviewsDaemonAvailable = vi.hoisted(() => ({ value: true }));
 
+const mockedSync = vi.hoisted(() => ({
+  running: false,
+  triggerSync: vi.fn(() => Promise.resolve()),
+  triggerRepoSync: vi.fn((_repo: string) => Promise.resolve()),
+}));
+
 const mockedModeVisibility = vi.hoisted(() => ({
   value: {
     activity: true,
@@ -56,8 +62,9 @@ vi.mock("@middleman/ui", async (importOriginal) => {
     ...actual,
     getStores: () => ({
       sync: {
-        getSyncState: () => null,
-        triggerSync: () => Promise.resolve(),
+        getSyncState: () => (mockedSync.running ? { running: true } : null),
+        triggerSync: mockedSync.triggerSync,
+        triggerRepoSync: mockedSync.triggerRepoSync,
       },
       settings: {
         isModeVisible: (mode: ModeKey) => mockedModeVisibility.value[mode],
@@ -71,6 +78,7 @@ vi.mock("@middleman/ui", async (importOriginal) => {
 
 import AppHeader from "./AppHeader.svelte";
 import { initTheme, cleanupTheme } from "../../stores/theme.svelte.js";
+import { setGlobalRepo } from "../../stores/filter.svelte.js";
 import { setSidebarCollapsed } from "../../stores/sidebar.svelte.ts";
 import { navigate } from "../../stores/router.svelte.ts";
 import { isPaletteOpen, resetPaletteState } from "../../stores/keyboard/palette-state.svelte.js";
@@ -135,6 +143,10 @@ describe("AppHeader", () => {
     setSidebarCollapsed(false);
     mockedContainerSize.value = "wide";
     mockedReviewsDaemonAvailable.value = true;
+    mockedSync.running = false;
+    mockedSync.triggerSync.mockClear();
+    mockedSync.triggerRepoSync.mockClear();
+    setGlobalRepo(undefined);
     delete window.__middleman_config;
     window.__middleman_notify_config_changed?.();
     mockedModeVisibility.value = {
@@ -161,6 +173,8 @@ describe("AppHeader", () => {
     setSidebarCollapsed(false);
     mockedContainerSize.value = "wide";
     mockedReviewsDaemonAvailable.value = true;
+    mockedSync.running = false;
+    setGlobalRepo(undefined);
     delete window.__middleman_config;
     window.__middleman_notify_config_changed?.();
     mockedModeVisibility.value = {
@@ -176,6 +190,83 @@ describe("AppHeader", () => {
       workspaces: true,
     };
     resetPaletteState();
+  });
+
+  it("keeps the primary segment wired to the existing full sync", async () => {
+    initTheme();
+    render(AppHeader);
+
+    await fireEvent.click(screen.getByRole("button", { name: "Sync" }));
+
+    expect(mockedSync.triggerSync).toHaveBeenCalledOnce();
+    expect(mockedSync.triggerRepoSync).not.toHaveBeenCalled();
+  });
+
+  it("syncs the route repository before the global selector repository", async () => {
+    initTheme();
+    setGlobalRepo("gitlab|gitlab.com/other/project");
+    navigate("/pulls/github/acme/widgets/7");
+    render(AppHeader);
+
+    await fireEvent.click(screen.getByRole("button", { name: "Sync options" }));
+    const repoSyncAction = screen.getByRole("menuitem", { name: "Sync current repo" });
+    expect(document.activeElement).toBe(repoSyncAction);
+    await fireEvent.click(repoSyncAction);
+
+    expect(mockedSync.triggerRepoSync).toHaveBeenCalledWith("github|github.com/acme/widgets");
+    expect(mockedSync.triggerSync).not.toHaveBeenCalled();
+    expect(screen.queryByRole("menu", { name: "Sync options" })).toBeNull();
+  });
+
+  it("uses one globally selected repository when the route has no repository", async () => {
+    initTheme();
+    setGlobalRepo("gitlab|gitlab.example.com/team/infra");
+    navigate("/");
+    render(AppHeader);
+
+    await fireEvent.click(screen.getByRole("button", { name: "Sync options" }));
+    await fireEvent.click(screen.getByRole("menuitem", { name: "Sync current repo" }));
+
+    expect(mockedSync.triggerRepoSync).toHaveBeenCalledWith("gitlab|gitlab.example.com/team/infra");
+  });
+
+  it.each([
+    ["all repositories", undefined],
+    ["multiple repositories", "github|github.com/acme/widgets,gitlab|gitlab.com/team/infra"],
+  ])("disables repository sync for %s", async (_label, selection) => {
+    initTheme();
+    setGlobalRepo(selection);
+    navigate("/");
+    render(AppHeader);
+
+    await fireEvent.click(screen.getByRole("button", { name: "Sync options" }));
+
+    expect((screen.getByRole("menuitem", { name: "Sync current repo" }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("dismisses sync options outside and restores trigger focus after Escape", async () => {
+    initTheme();
+    setGlobalRepo("github|github.com/acme/widgets");
+    render(AppHeader);
+    const trigger = screen.getByRole("button", { name: "Sync options" });
+
+    await fireEvent.click(trigger);
+    await fireEvent.mouseDown(document.body);
+    expect(screen.queryByRole("menu", { name: "Sync options" })).toBeNull();
+
+    await fireEvent.click(trigger);
+    await fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("menu", { name: "Sync options" })).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("disables both sync segments while a sync is running", () => {
+    initTheme();
+    mockedSync.running = true;
+    render(AppHeader);
+
+    expect((screen.getByRole("button", { name: "Syncing" }) as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByRole("button", { name: "Sync options" }) as HTMLButtonElement).disabled).toBe(true);
   });
 
   it("toggles the root dark class when the theme button is clicked", async () => {

--- a/frontend/src/lib/utils/repoSelectionSync.test.ts
+++ b/frontend/src/lib/utils/repoSelectionSync.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
-import { globalRepoForSelectedRoute } from "./repoSelectionSync.js";
+import { globalRepoForSelectedRoute, syncRepoForRoute } from "./repoSelectionSync.js";
 import type { Route } from "../stores/router.svelte.ts";
 
 const prSelected = {
@@ -175,5 +175,34 @@ describe("globalRepoForSelectedRoute", () => {
       },
     } as unknown as Route;
     expect(() => globalRepoForSelectedRoute(route)).toThrow("selected route is missing provider");
+  });
+});
+
+describe("syncRepoForRoute", () => {
+  it("returns the selected item repository", () => {
+    const route: Route = {
+      page: "pulls",
+      view: "list",
+      selected: prSelected,
+    };
+
+    expect(syncRepoForRoute(route)).toBe("github|github.com/acme/tools");
+  });
+
+  it("returns the repository browser repository", () => {
+    const route: Route = {
+      page: "repo-browser",
+      provider: "gitlab",
+      platformHost: "gitlab.example.com",
+      repoPath: "Group/SubGroup/Project.Special",
+      owner: "Group/SubGroup",
+      name: "Project.Special",
+    };
+
+    expect(syncRepoForRoute(route)).toBe("gitlab|gitlab.example.com/Group/SubGroup/Project.Special");
+  });
+
+  it("returns undefined when the route does not identify one repository", () => {
+    expect(syncRepoForRoute({ page: "activity" })).toBeUndefined();
   });
 });

--- a/frontend/src/lib/utils/repoSelectionSync.ts
+++ b/frontend/src/lib/utils/repoSelectionSync.ts
@@ -13,6 +13,16 @@ function requireSelectedRouteRepoValue(value: string | undefined, field: string)
   return value;
 }
 
+function repoFilterValue(repo: SelectedRouteRepo, routeLabel = "selected route"): string {
+  const provider = requireSelectedRouteRepoValue(repo.provider, "provider");
+  const platformHost = repo.platformHost;
+  if (!platformHost) {
+    throw new Error(`${routeLabel} is missing platformHost`);
+  }
+  const repoPath = requireSelectedRouteRepoValue(repo.repoPath, "repoPath");
+  return `${provider}|${platformHost}/${repoPath}`;
+}
+
 // When the URL points at a specific PR or issue, returns the repo key
 // (`provider|platformHost/repoPath`) that the global repo filter and dropdown
 // should follow. Returns undefined for routes that don't nail down a single
@@ -29,8 +39,14 @@ export function globalRepoForSelectedRoute(route: Route): string | undefined {
   }
   if (!selected) return undefined;
 
-  const provider = requireSelectedRouteRepoValue(selected.provider, "provider");
-  const platformHost = requireSelectedRouteRepoValue(selected.platformHost, "platformHost");
-  const repoPath = requireSelectedRouteRepoValue(selected.repoPath, "repoPath");
-  return `${provider}|${platformHost}/${repoPath}`;
+  return repoFilterValue(selected);
+}
+
+// A scoped sync may also use the repository browser route, which identifies a
+// repository without selecting a pull request or issue.
+export function syncRepoForRoute(route: Route): string | undefined {
+  const selectedRepo = globalRepoForSelectedRoute(route);
+  if (selectedRepo || route.page !== "repo-browser") return selectedRepo;
+
+  return repoFilterValue(route, "repository browser route");
 }

--- a/frontend/tests/e2e-full/container-layout.spec.ts
+++ b/frontend/tests/e2e-full/container-layout.spec.ts
@@ -30,7 +30,7 @@ test.describe("container-aware layout", () => {
     await header.waitFor({ state: "visible", timeout: 10_000 });
 
     await expect(page.locator(".kit-top-bar__nav-select")).toBeVisible();
-    await expect(page.getByRole("button", { name: "Sync" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Sync", exact: true })).toBeVisible();
 
     const metrics = await page.evaluate(() => {
       const headerRect = document.querySelector(".app-top-bar")?.getBoundingClientRect();
@@ -56,7 +56,7 @@ test.describe("container-aware layout", () => {
       timeout: 20_000,
     });
     await expect(page.locator(".kit-top-bar__tabs")).not.toBeAttached();
-    await expect(page.getByRole("button", { name: "Sync" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Sync", exact: true })).toBeVisible();
     await expect(page.locator(".sync-btn .sync-label")).not.toBeVisible();
 
     await page.locator(".typeahead-trigger").click();

--- a/frontend/tests/e2e-full/container-layout.spec.ts
+++ b/frontend/tests/e2e-full/container-layout.spec.ts
@@ -8,6 +8,29 @@ test.setTimeout(60_000);
 // either side of where the full tab row fits so they assert the collapse
 // behavior rather than a magic pixel value.
 test.describe("container-aware layout", () => {
+  for (const viewport of [
+    { label: "narrow", width: 390, height: 700 },
+    { label: "medium", width: 1024, height: 768 },
+  ]) {
+    test(`sync options stay inside the ${viewport.label} viewport`, async ({ page }) => {
+      await page.setViewportSize({ width: viewport.width, height: viewport.height });
+      await page.goto("/pulls/github/acme/widgets/1?desktop=1");
+      await page.locator(".app-top-bar").waitFor({ state: "visible", timeout: 10_000 });
+
+      await page.getByRole("button", { name: "Sync options" }).click();
+      const menu = page.getByRole("menu", { name: "Sync options" });
+      await expect(menu).toBeVisible();
+      await expect(menu.getByRole("menuitem", { name: "Sync current repo" })).toBeVisible();
+
+      const box = await menu.boundingBox();
+      expect(box).not.toBeNull();
+      expect(box!.x).toBeGreaterThanOrEqual(0);
+      expect(box!.y).toBeGreaterThanOrEqual(0);
+      expect(box!.x + box!.width).toBeLessThanOrEqual(viewport.width);
+      expect(box!.y + box!.height).toBeLessThanOrEqual(viewport.height);
+    });
+  }
+
   test("narrow viewport shows dropdown and collapses sidebar", async ({ page }) => {
     await page.setViewportSize({ width: 400, height: 600 });
     await page.goto("/pulls?desktop=1");

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -4423,6 +4423,9 @@ type ListStacksParams struct {
 type TriggerSyncParams struct {
 	// PriorityRepo Optional repository filters to sync first. Accepts repeated provider|platform_host/repo_path values or comma-separated values.
 	PriorityRepo *[]string `form:"priority_repo,omitempty" json:"priority_repo,omitempty"`
+
+	// OnlyRepo Optional repository filters to sync exclusively. Accepts repeated provider|platform_host/repo_path values or comma-separated values.
+	OnlyRepo *[]string `form:"only_repo,omitempty" json:"only_repo,omitempty"`
 }
 
 // DeleteWorkspaceParams defines parameters for DeleteWorkspace.
@@ -27127,6 +27130,18 @@ func NewTriggerSyncRequest(server string, params *TriggerSyncParams) (*http.Requ
 		if params.PriorityRepo != nil {
 
 			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "priority_repo", *params.PriorityRepo, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "array", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.OnlyRepo != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "only_repo", *params.OnlyRepo, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "array", Format: ""}); err != nil {
 				return nil, err
 			} else {
 				for _, qp := range strings.Split(queryFrag, "&") {

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -2573,6 +2573,20 @@ func (s *Syncer) TriggerRunWithPriority(
 	ctx context.Context,
 	priorityRepos []RepoRef,
 ) {
+	s.triggerRun(ctx, slices.Clone(priorityRepos), nil)
+}
+
+// TriggerRunForRepos kicks off a non-blocking ad-hoc sync restricted to the
+// matching configured repositories.
+func (s *Syncer) TriggerRunForRepos(ctx context.Context, repos []RepoRef) {
+	s.triggerRun(ctx, nil, slices.Clone(repos))
+}
+
+func (s *Syncer) triggerRun(
+	ctx context.Context,
+	priorityRepos []RepoRef,
+	onlyRepos []RepoRef,
+) {
 	s.lifecycleMu.Lock()
 	if s.stopped {
 		s.lifecycleMu.Unlock()
@@ -2585,7 +2599,7 @@ func (s *Syncer) TriggerRunWithPriority(
 	go func() {
 		defer s.wg.Done()
 		defer cancel()
-		s.runOnce(merged, true, priorityRepos)
+		s.runOnce(merged, true, priorityRepos, onlyRepos)
 	}()
 }
 
@@ -3805,13 +3819,14 @@ func (s *Syncer) publishMonotonicProgress(
 // per-host GitHub rate limit and abuse-detection thresholds happy
 // while still capturing most of the wall-clock win on network I/O.
 func (s *Syncer) RunOnce(ctx context.Context) {
-	s.runOnce(ctx, false, nil)
+	s.runOnce(ctx, false, nil, nil)
 }
 
 func (s *Syncer) runOnce(
 	ctx context.Context,
 	bypassNextSyncAfter bool,
 	priorityRepos []RepoRef,
+	onlyRepos []RepoRef,
 ) {
 	if !s.running.CompareAndSwap(false, true) {
 		return
@@ -3828,6 +3843,9 @@ func (s *Syncer) runOnce(
 	s.reposMu.Lock()
 	repos := slices.Clone(s.repos)
 	s.reposMu.Unlock()
+	if onlyRepos != nil {
+		repos = selectRepos(repos, onlyRepos)
+	}
 	repos = prioritizeRepos(repos, priorityRepos)
 
 	total := len(repos)
@@ -4010,6 +4028,23 @@ func prioritizeRepos(repos, priorityRepos []RepoRef) []RepoRef {
 			return 0
 		}
 	})
+	return out
+}
+
+func selectRepos(repos, selectedRepos []RepoRef) []RepoRef {
+	selectedKeys := make(map[string]struct{}, len(selectedRepos))
+	for _, repo := range selectedRepos {
+		if key := repoPriorityKey(repo); key != "" {
+			selectedKeys[key] = struct{}{}
+		}
+	}
+
+	out := make([]RepoRef, 0, len(selectedKeys))
+	for _, repo := range repos {
+		if _, ok := selectedKeys[repoPriorityKey(repo)]; ok {
+			out = append(out, repo)
+		}
+	}
 	return out
 }
 

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -476,7 +476,10 @@ type Syncer struct {
 	branchActivityRetention  time.Duration
 	branchActivityMaxCommits int
 	parallelism              atomic.Int32
+	runMu                    sync.Mutex
 	running                  atomic.Bool
+	exclusiveRun             bool // guarded by runMu
+	scheduledFullPending     bool // guarded by runMu
 	providerWorkMu           sync.Mutex
 	providerWork             map[string]map[archive.WorkPriority]int
 	archiveProviderRequests  map[string]archiveProviderRequest
@@ -3828,10 +3831,31 @@ func (s *Syncer) runOnce(
 	priorityRepos []RepoRef,
 	onlyRepos []RepoRef,
 ) {
-	if !s.running.CompareAndSwap(false, true) {
+	s.runMu.Lock()
+	if s.running.Load() {
+		if !bypassNextSyncAfter && onlyRepos == nil && s.exclusiveRun {
+			s.scheduledFullPending = true
+		}
+		s.runMu.Unlock()
 		return
 	}
-	defer s.running.Store(false)
+	s.running.Store(true)
+	exclusive := onlyRepos != nil
+	s.exclusiveRun = exclusive
+	s.runMu.Unlock()
+	defer func() {
+		s.runMu.Lock()
+		s.running.Store(false)
+		s.exclusiveRun = false
+		retryScheduledFull := exclusive && s.scheduledFullPending
+		if retryScheduledFull {
+			s.scheduledFullPending = false
+		}
+		s.runMu.Unlock()
+		if retryScheduledFull {
+			s.TriggerRun(context.Background())
+		}
+	}()
 
 	rateLimitSnapshotCtx := ctx
 

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -3944,7 +3944,7 @@ dispatch:
 	// Detail drain: fetch full details for highest-priority items
 	// within the per-host budget. Runs after index scan completes.
 	if !canceled.Load() && ctx.Err() == nil {
-		s.drainDetailQueue(ctx, eligibleBuckets)
+		s.drainDetailQueue(ctx, eligibleBuckets, repos)
 	}
 
 	if !canceled.Load() && ctx.Err() == nil {
@@ -3977,9 +3977,11 @@ dispatch:
 	if rateLimitSnapshotCtx.Err() == nil {
 		s.RefreshRateLimitSnapshots(rateLimitSnapshotCtx)
 	}
-	s.advanceNextSync(
-		eligibleBuckets, s.nextSyncAfter, s.interval,
-	)
+	if onlyRepos == nil {
+		s.advanceNextSync(
+			eligibleBuckets, s.nextSyncAfter, s.interval,
+		)
+	}
 
 	slog.Info("sync complete", "repos", total)
 
@@ -8043,12 +8045,13 @@ func (s *Syncer) fetchAndUpdateClosedPlatformIssue(
 func (s *Syncer) drainDetailQueue(
 	ctx context.Context,
 	eligibleBuckets map[string]bool,
+	repos []RepoRef,
 ) {
 	if len(s.budgets) == 0 {
 		return
 	}
 
-	items := s.buildDetailQueueItems(ctx)
+	items := s.buildDetailQueueItems(ctx, repos)
 	if len(items) == 0 {
 		return
 	}
@@ -8157,15 +8160,15 @@ func (s *Syncer) drainDetailQueue(
 // state to build queue items for scoring.
 func (s *Syncer) buildDetailQueueItems(
 	ctx context.Context,
+	repos []RepoRef,
 ) []QueueItem {
-	// Build set of tracked repos to filter out stale DB rows
-	// from removed repos.
-	s.reposMu.Lock()
-	trackedRepos := make(map[string]bool, len(s.repos))
-	for _, r := range s.repos {
+	// Build the set of repos selected for this run. In addition to filtering
+	// stale DB rows from removed repos, this keeps repository-scoped runs from
+	// spending their detail budget on unrelated repositories on the same host.
+	trackedRepos := make(map[string]bool, len(repos))
+	for _, r := range repos {
 		trackedRepos[detailRepoKey(repoPlatform(r), repoHost(r), r.Owner, r.Name)] = true
 	}
-	s.reposMu.Unlock()
 
 	// Gather watched MR numbers for matching.
 	s.watchMu.Lock()

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -2590,6 +2590,15 @@ func (s *Syncer) triggerRun(
 	priorityRepos []RepoRef,
 	onlyRepos []RepoRef,
 ) {
+	s.triggerRunWithCadence(ctx, true, priorityRepos, onlyRepos)
+}
+
+func (s *Syncer) triggerRunWithCadence(
+	ctx context.Context,
+	bypassNextSyncAfter bool,
+	priorityRepos []RepoRef,
+	onlyRepos []RepoRef,
+) {
 	s.lifecycleMu.Lock()
 	if s.stopped {
 		s.lifecycleMu.Unlock()
@@ -2602,7 +2611,7 @@ func (s *Syncer) triggerRun(
 	go func() {
 		defer s.wg.Done()
 		defer cancel()
-		s.runOnce(merged, true, priorityRepos, onlyRepos)
+		s.runOnce(merged, bypassNextSyncAfter, priorityRepos, onlyRepos)
 	}()
 }
 
@@ -3853,7 +3862,7 @@ func (s *Syncer) runOnce(
 		}
 		s.runMu.Unlock()
 		if retryScheduledFull {
-			s.TriggerRun(context.Background())
+			s.triggerRunWithCadence(context.Background(), false, nil, nil)
 		}
 	}()
 

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -6079,7 +6079,7 @@ func TestDetailDrainUsesProviderCloneURLForNestedGitLabRepo(t *testing.T) {
 		rateKey: NewSyncBudget(100),
 	})
 
-	syncer.drainDetailQueue(ctx, map[string]bool{rateKey: true})
+	syncer.drainDetailQueue(ctx, map[string]bool{rateKey: true}, syncer.TrackedRepos())
 
 	assert.Equal(int32(1), provider.getMRCalls.Load())
 	clonePath, err := clones.ClonePath("gitlab.example.com", "group/subgroup", "project")
@@ -9513,7 +9513,7 @@ func TestDetailDrainUsesProviderReadersForNonGitHub(t *testing.T) {
 	})
 	syncer.clients = registry
 
-	syncer.drainDetailQueue(ctx, map[string]bool{rateKey: true})
+	syncer.drainDetailQueue(ctx, map[string]bool{rateKey: true}, syncer.TrackedRepos())
 
 	assert.Equal(int32(1), provider.getMRCalls.Load())
 	assert.Equal(int32(1), provider.getIssueCalls.Load())
@@ -9613,7 +9613,7 @@ func TestDetailDrainDisambiguatesSameHostOwnerNameAcrossProviders(t *testing.T) 
 	})
 	syncer.clients = registry
 
-	syncer.drainDetailQueue(ctx, map[string]bool{rateKey: true})
+	syncer.drainDetailQueue(ctx, map[string]bool{rateKey: true}, syncer.TrackedRepos())
 
 	assert.Equal(int32(1), gitlabProvider.getMRCalls.Load())
 	mr, err := d.GetMergeRequestByRepoIDAndNumber(ctx, gitlabRepoID, 7)
@@ -9674,7 +9674,7 @@ func TestDetailQueueWatchedKeyIncludesProviderIdentity(t *testing.T) {
 		Number:       7,
 	}})
 
-	items := syncer.buildDetailQueueItems(ctx)
+	items := syncer.buildDetailQueueItems(ctx, syncer.TrackedRepos())
 
 	require.Len(items, 2)
 	watchedByPlatform := map[platform.Kind]bool{}
@@ -9722,7 +9722,7 @@ func TestDetailQueueDerivesPendingCIFromCachedChecks(t *testing.T) {
 
 	syncer := NewSyncer(nil, d, nil, []RepoRef{repo}, time.Minute, nil, nil)
 
-	items := syncer.buildDetailQueueItems(ctx)
+	items := syncer.buildDetailQueueItems(ctx, syncer.TrackedRepos())
 	require.Len(items, 1)
 	assert.True(items[0].CIHadPending)
 	queue := BuildQueue(items, now)
@@ -9798,6 +9798,99 @@ func TestDetailDrainRespectsBudget(t *testing.T) {
 	require.NotNil(hostBudget)
 	assert.Positive(hostBudget.Spent(),
 		"budget should have been spent")
+}
+
+func TestScopedRunDrainsDetailsOnlyForSelectedRepos(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	now := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+	repos := []RepoRef{
+		{Owner: "owner", Name: "selected", PlatformHost: "github.com"},
+		{Owner: "owner", Name: "unrelated", PlatformHost: "github.com"},
+	}
+	for i, repo := range repos {
+		repoID, err := d.UpsertRepo(ctx, platform.DBRepoIdentity(platformRepoRef(repo)))
+		require.NoError(err)
+		_, err = d.UpsertMergeRequest(ctx, &db.MergeRequest{
+			RepoID:          repoID,
+			PlatformID:      int64(i + 1),
+			Number:          i + 1,
+			URL:             "https://github.com/owner/" + repo.Name + "/pull/1",
+			Title:           repo.Name,
+			Author:          "ada",
+			State:           "open",
+			HeadBranch:      "feature",
+			BaseBranch:      "main",
+			PlatformHeadSHA: "head",
+			PlatformBaseSHA: "base",
+			CreatedAt:       now,
+			UpdatedAt:       now,
+			LastActivityAt:  now,
+		})
+		require.NoError(err)
+	}
+
+	var detailRepos []string
+	mc := &detailTrackingClient{}
+	mc.budget = NewSyncBudget(100)
+	mc.listOpenPRsFn = func(_ context.Context, _, repo string) ([]*gh.PullRequest, error) {
+		if repo == "selected" {
+			return []*gh.PullRequest{buildOpenPR(1, now)}, nil
+		}
+		return []*gh.PullRequest{}, nil
+	}
+	mc.getPullRequestFn = func(_ context.Context, _, repo string, number int) (*gh.PullRequest, error) {
+		detailRepos = append(detailRepos, repo)
+		return buildOpenPR(number, now), nil
+	}
+	mc.comments = []*gh.IssueComment{}
+	mc.reviews = []*gh.PullRequestReview{}
+	mc.commits = []*gh.RepositoryCommit{}
+	mc.ciStatus = &gh.CombinedStatus{State: new("success")}
+
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc}, d, nil, repos,
+		time.Minute, nil,
+		map[string]*SyncBudget{"github.com": mc.budget},
+	)
+	syncer.runOnce(ctx, true, nil, repos[:1])
+
+	assert.Equal(t, []string{"selected"}, detailRepos)
+}
+
+func TestScopedRunDoesNotDelayNextFullRunOnSameHost(t *testing.T) {
+	ctx := t.Context()
+	d := openTestDB(t)
+	repos := []RepoRef{
+		{Owner: "owner", Name: "selected", PlatformHost: "github.com"},
+		{Owner: "owner", Name: "unrelated", PlatformHost: "github.com"},
+	}
+	var mu sync.Mutex
+	var indexRepos []string
+	mc := &mockClient{
+		listOpenPRsFn: func(_ context.Context, _, repo string) ([]*gh.PullRequest, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			indexRepos = append(indexRepos, repo)
+			return []*gh.PullRequest{}, nil
+		},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc}, d, nil, repos,
+		time.Hour,
+		map[string]*RateTracker{"github.com": NewRateTracker(d, "github.com", "rest")},
+		nil,
+	)
+	syncer.SetParallelism(1)
+
+	syncer.runOnce(ctx, true, nil, repos[:1])
+	syncer.RunOnce(ctx)
+
+	mu.Lock()
+	got := append([]string(nil), indexRepos...)
+	mu.Unlock()
+	assert.Equal(t, []string{"selected", "selected", "unrelated"}, got)
 }
 
 func TestBudgetResetOnRateWindowReset(t *testing.T) {
@@ -13591,7 +13684,7 @@ func TestDeferredCommentRefreshYieldsBudgetToDetailDrain(t *testing.T) {
 
 	syncer.queuePRCommentSync(repo, 1)
 	budget["github.com"].Spend(3)
-	syncer.drainDetailQueue(ctx, map[string]bool{"github.com": true})
+	syncer.drainDetailQueue(ctx, map[string]bool{"github.com": true}, syncer.TrackedRepos())
 	syncer.drainPendingCommentSyncs(ctx, map[string]bool{"github.com": true})
 
 	pr, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 2)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -9893,6 +9893,68 @@ func TestScopedRunDoesNotDelayNextFullRunOnSameHost(t *testing.T) {
 	assert.Equal(t, []string{"selected", "selected", "unrelated"}, got)
 }
 
+func TestScheduledFullRunRetriesAfterOverlappingScopedRun(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	repos := []RepoRef{
+		{Owner: "owner", Name: "selected", PlatformHost: "github.com"},
+		{Owner: "owner", Name: "unrelated", PlatformHost: "github.com"},
+	}
+	selectedEntered := make(chan struct{}, 1)
+	releaseSelected := make(chan struct{})
+	unrelatedSynced := make(chan struct{}, 1)
+	mc := &mockClient{
+		listOpenPRsFn: func(ctx context.Context, _, repo string) ([]*gh.PullRequest, error) {
+			switch repo {
+			case "selected":
+				select {
+				case selectedEntered <- struct{}{}:
+					select {
+					case <-releaseSelected:
+					case <-ctx.Done():
+						return nil, ctx.Err()
+					}
+				default:
+				}
+			case "unrelated":
+				select {
+				case unrelatedSynced <- struct{}{}:
+				default:
+				}
+			}
+			return []*gh.PullRequest{}, nil
+		},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc}, d, nil, repos,
+		time.Hour, nil, nil,
+	)
+	syncer.SetParallelism(1)
+	t.Cleanup(syncer.Stop)
+
+	scopedDone := make(chan struct{})
+	go func() {
+		defer close(scopedDone)
+		syncer.runOnce(ctx, true, nil, repos[:1])
+	}()
+
+	select {
+	case <-selectedEntered:
+	case <-time.After(time.Second):
+		require.FailNow("scoped run did not start within 1s")
+	}
+	syncer.RunOnce(ctx)
+	close(releaseSelected)
+
+	select {
+	case <-unrelatedSynced:
+	case <-time.After(time.Second):
+		require.FailNow("scheduled full run was not retried after scoped run")
+	}
+	<-scopedDone
+}
+
 func TestBudgetResetOnRateWindowReset(t *testing.T) {
 	assert := assert.New(t)
 	d := openTestDB(t)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -9894,65 +9894,93 @@ func TestScopedRunDoesNotDelayNextFullRunOnSameHost(t *testing.T) {
 }
 
 func TestScheduledFullRunRetriesAfterOverlappingScopedRun(t *testing.T) {
-	require := require.New(t)
-	ctx := t.Context()
-	d := openTestDB(t)
-	repos := []RepoRef{
-		{Owner: "owner", Name: "selected", PlatformHost: "github.com"},
-		{Owner: "owner", Name: "unrelated", PlatformHost: "github.com"},
+	tests := []struct {
+		name                string
+		cadenceGated        bool
+		wantUnrelatedSynced bool
+	}{
+		{name: "runs when host is due", wantUnrelatedSynced: true},
+		{name: "honors a future host cadence gate", cadenceGated: true},
 	}
-	selectedEntered := make(chan struct{}, 1)
-	releaseSelected := make(chan struct{})
-	unrelatedSynced := make(chan struct{}, 1)
-	mc := &mockClient{
-		listOpenPRsFn: func(ctx context.Context, _, repo string) ([]*gh.PullRequest, error) {
-			switch repo {
-			case "selected":
-				select {
-				case selectedEntered <- struct{}{}:
-					select {
-					case <-releaseSelected:
-					case <-ctx.Done():
-						return nil, ctx.Err()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			ctx := t.Context()
+			d := openTestDB(t)
+			repos := []RepoRef{
+				{Owner: "owner", Name: "selected", PlatformHost: "github.com"},
+				{Owner: "owner", Name: "unrelated", PlatformHost: "github.com"},
+			}
+			selectedEntered := make(chan struct{}, 1)
+			releaseSelected := make(chan struct{})
+			var unrelatedSynced atomic.Bool
+			mc := &mockClient{
+				listOpenPRsFn: func(ctx context.Context, _, repo string) ([]*gh.PullRequest, error) {
+					switch repo {
+					case "selected":
+						select {
+						case selectedEntered <- struct{}{}:
+							select {
+							case <-releaseSelected:
+							case <-ctx.Done():
+								return nil, ctx.Err()
+							}
+						default:
+						}
+					case "unrelated":
+						unrelatedSynced.Store(true)
 					}
-				default:
-				}
-			case "unrelated":
-				select {
-				case unrelatedSynced <- struct{}{}:
-				default:
+					return []*gh.PullRequest{}, nil
+				},
+			}
+			var rateTrackers map[string]*RateTracker
+			if tt.cadenceGated {
+				rateTrackers = map[string]*RateTracker{
+					"github.com": NewRateTracker(d, "github.com", "rest"),
 				}
 			}
-			return []*gh.PullRequest{}, nil
-		},
-	}
-	syncer := NewSyncer(
-		map[string]Client{"github.com": mc}, d, nil, repos,
-		time.Hour, nil, nil,
-	)
-	syncer.SetParallelism(1)
-	t.Cleanup(syncer.Stop)
+			syncer := NewSyncer(
+				map[string]Client{"github.com": mc}, d, nil, repos,
+				time.Hour, rateTrackers, nil,
+			)
+			if tt.cadenceGated {
+				syncer.nextSyncAfter["github.com"] = time.Now().Add(time.Hour)
+			}
+			syncer.SetParallelism(1)
+			t.Cleanup(syncer.Stop)
+			fullRunCompleted := make(chan struct{}, 1)
+			syncer.SetOnSyncCompleted(func(results []RepoSyncResult) {
+				if len(results) == len(repos) {
+					select {
+					case fullRunCompleted <- struct{}{}:
+					default:
+					}
+				}
+			})
 
-	scopedDone := make(chan struct{})
-	go func() {
-		defer close(scopedDone)
-		syncer.runOnce(ctx, true, nil, repos[:1])
-	}()
+			scopedDone := make(chan struct{})
+			go func() {
+				defer close(scopedDone)
+				syncer.runOnce(ctx, true, nil, repos[:1])
+			}()
 
-	select {
-	case <-selectedEntered:
-	case <-time.After(time.Second):
-		require.FailNow("scoped run did not start within 1s")
-	}
-	syncer.RunOnce(ctx)
-	close(releaseSelected)
+			select {
+			case <-selectedEntered:
+			case <-time.After(time.Second):
+				require.FailNow("scoped run did not start within 1s")
+			}
+			syncer.RunOnce(ctx)
+			close(releaseSelected)
 
-	select {
-	case <-unrelatedSynced:
-	case <-time.After(time.Second):
-		require.FailNow("scheduled full run was not retried after scoped run")
+			select {
+			case <-fullRunCompleted:
+			case <-time.After(time.Second):
+				require.FailNow("scheduled full run was not retried after scoped run")
+			}
+			assert.Equal(t, tt.wantUnrelatedSynced, unrelatedSynced.Load())
+			<-scopedDone
+		})
 	}
-	<-scopedDone
 }
 
 func TestBudgetResetOnRateWindowReset(t *testing.T) {

--- a/internal/github/syncertest/syncer_test.go
+++ b/internal/github/syncertest/syncer_test.go
@@ -715,6 +715,82 @@ func TestSyncerTriggerRunWithPrioritySyncsSelectedReposFirst(t *testing.T) {
 	assert.Equal([]string{"o/third", "o/first", "o/second"}, got)
 }
 
+func TestSyncerTriggerRunForReposSyncsOnlySelectedRepos(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	var mu sync.Mutex
+	var calls []string
+	mock := &mockClient{
+		openPRs: []*gh.PullRequest{},
+		listOpenPRsFn: func(
+			_ context.Context, owner, repo string,
+		) ([]*gh.PullRequest, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			calls = append(calls, owner+"/"+repo)
+			return []*gh.PullRequest{}, nil
+		},
+		getRepositoryFn: func(
+			_ context.Context, owner, repo string,
+		) (*gh.Repository, error) {
+			ids := map[string]int64{
+				"first":  1,
+				"second": 2,
+				"third":  3,
+			}
+			id := ids[repo]
+			nodeID := "repo-" + owner + "-" + repo
+			return &gh.Repository{
+				ID:       &id,
+				NodeID:   &nodeID,
+				Name:     &repo,
+				Owner:    &gh.User{Login: &owner},
+				Archived: new(bool),
+			}, nil
+		},
+	}
+	d := openTestDB(t)
+	repos := []ghclient.RepoRef{
+		{Owner: "o", Name: "first", PlatformHost: "github.com"},
+		{Owner: "o", Name: "second", PlatformHost: "github.com"},
+		{Owner: "o", Name: "third", PlatformHost: "github.com"},
+	}
+	s := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": mock},
+		d, nil, repos, time.Hour, nil, nil,
+	)
+	s.SetParallelism(1)
+
+	done := make(chan struct{}, 1)
+	s.SetOnStatusChange(func(status *ghclient.SyncStatus) {
+		if !status.Running {
+			select {
+			case done <- struct{}{}:
+			default:
+			}
+		}
+	})
+
+	s.TriggerRunForRepos(t.Context(), []ghclient.RepoRef{{
+		Owner:        "o",
+		Name:         "third",
+		PlatformHost: "github.com",
+	}})
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		require.FailNow("scoped TriggerRun did not complete within 1s")
+	}
+	s.Stop()
+
+	mu.Lock()
+	got := slices.Clone(calls)
+	mu.Unlock()
+	assert.Equal([]string{"o/third"}, got)
+}
+
 type blockingCtxMockClient struct {
 	mockClient
 	entered chan struct{}

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -7558,6 +7558,88 @@ func TestAPITriggerSyncIgnoresRequestCancellation(t *testing.T) {
 	assert.Equal(t, "widget", repos[0].Name)
 }
 
+func TestAPITriggerSyncOnlyRepoRestrictsRun(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	database := dbtest.Open(t)
+	var mu sync.Mutex
+	var calls []string
+	mock := &mockGH{
+		listOpenPullRequestsFn: func(
+			_ context.Context, owner, repo string,
+		) ([]*gh.PullRequest, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			calls = append(calls, owner+"/"+repo)
+			return nil, nil
+		},
+	}
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": mock},
+		database,
+		nil,
+		[]ghclient.RepoRef{
+			{Platform: platform.KindGitHub, Owner: "acme", Name: "first", PlatformHost: "github.com"},
+			{Platform: platform.KindGitHub, Owner: "acme", Name: "second", PlatformHost: "github.com"},
+		},
+		time.Minute,
+		nil,
+		nil,
+	)
+	done := make(chan struct{}, 1)
+	syncer.SetOnStatusChange(func(status *ghclient.SyncStatus) {
+		if !status.Running {
+			select {
+			case done <- struct{}{}:
+			default:
+			}
+		}
+	})
+	t.Cleanup(syncer.Stop)
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+
+	rr := doJSON(
+		t,
+		srv,
+		http.MethodPost,
+		"/api/v1/sync?only_repo=github|github.com/acme/second",
+		nil,
+	)
+	require.Equal(http.StatusAccepted, rr.Code, rr.Body.String())
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		require.Fail("expected repository-only sync to complete")
+	}
+
+	mu.Lock()
+	got := slices.Clone(calls)
+	mu.Unlock()
+	assert.Equal([]string{"acme/second"}, got)
+}
+
+func TestAPITriggerSyncRejectsUnknownOnlyRepo(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	srv, _ := setupTestServer(t)
+	rr := doJSON(
+		t,
+		srv,
+		http.MethodPost,
+		"/api/v1/sync?only_repo=github|github.com/acme/missing",
+		nil,
+	)
+	require.Equal(http.StatusBadRequest, rr.Code, rr.Body.String())
+
+	var problem ProblemError
+	require.NoError(json.NewDecoder(rr.Body).Decode(&problem))
+	assert.Equal(CodeValidationError, problem.Code)
+	assert.Equal("query.only_repo", problem.Details["field"])
+}
+
 func TestAPITriggerSyncBypassesNextSyncAfter(t *testing.T) {
 	require := require.New(t)
 
@@ -7662,6 +7744,12 @@ func TestMatchPriorityRepoRequiresProviderQualifiedRepoPaths(t *testing.T) {
 	assert.Equal(platform.KindGitHub, repo.Platform)
 	assert.Equal("github.com", repo.PlatformHost)
 	assert.Equal("acme/widget", repo.RepoPath)
+
+	repo, ok = matchPriorityRepo("gitlab|gitlab.com/group/subgroup/project", tracked)
+	assert.True(ok)
+	assert.Equal(platform.KindGitLab, repo.Platform)
+	assert.Equal("gitlab.com", repo.PlatformHost)
+	assert.Equal("group/subgroup/project", repo.RepoPath)
 }
 
 func TestAPIReadyForReview(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -7604,7 +7604,7 @@ func TestAPITriggerSyncOnlyRepoRestrictsRun(t *testing.T) {
 		t,
 		srv,
 		http.MethodPost,
-		"/api/v1/sync?only_repo=github|github.com/acme/second",
+		"/api/v1/sync?only_repo=gh|github.com/acme/second",
 		nil,
 	)
 	require.Equal(http.StatusAccepted, rr.Code, rr.Body.String())

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"log/slog"
 	"mime"
 	"net/http"
@@ -684,6 +685,7 @@ type listActivityInput struct {
 
 type triggerSyncInput struct {
 	PriorityRepos []string `query:"priority_repo" doc:"Optional repository filters to sync first. Accepts repeated provider|platform_host/repo_path values or comma-separated values."`
+	OnlyRepos     []string `query:"only_repo" doc:"Optional repository filters to sync exclusively. Accepts repeated provider|platform_host/repo_path values or comma-separated values."`
 }
 
 type listActivityOutput = bodyOutput[activityResponse]
@@ -4023,6 +4025,14 @@ func (s *Server) triggerSync(
 	if s.syncer == nil {
 		return nil, problemServiceUnavailable("syncer not configured")
 	}
+	if len(input.OnlyRepos) > 0 {
+		repos, err := s.onlyReposFromFilter(input.OnlyRepos)
+		if err != nil {
+			return nil, problemValidation("query.only_repo", err.Error())
+		}
+		s.syncer.TriggerRunForRepos(context.WithoutCancel(ctx), repos)
+		return &acceptedOutput{Status: http.StatusAccepted}, nil
+	}
 	s.syncer.TriggerRunWithPriority(
 		context.WithoutCancel(ctx),
 		s.priorityReposFromFilter(input.PriorityRepos),
@@ -4035,6 +4045,30 @@ func (s *Server) triggerSync(
 		})
 	}
 	return &acceptedOutput{Status: http.StatusAccepted}, nil
+}
+
+func (s *Server) onlyReposFromFilter(filters []string) ([]ghclient.RepoRef, error) {
+	values := splitRepoFilterValues(filters)
+	if len(values) == 0 {
+		return nil, fmt.Errorf("repository must match a configured provider|platform_host/repo_path")
+	}
+
+	tracked := s.syncer.TrackedRepos()
+	out := make([]ghclient.RepoRef, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		repo, ok := matchPriorityRepo(value, tracked)
+		if !ok {
+			return nil, fmt.Errorf("repository %q must match a configured provider|platform_host/repo_path", value)
+		}
+		key := priorityRepoIdentity(repo)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, repo)
+	}
+	return out, nil
 }
 
 func (s *Server) priorityReposFromFilter(filters []string) []ghclient.RepoRef {

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -4117,11 +4117,15 @@ func matchPriorityRepo(
 		if provider == "" || len(parts) < 3 {
 			return ghclient.RepoRef{}, false
 		}
+		kind, err := platform.NormalizeKind(provider)
+		if err != nil {
+			return ghclient.RepoRef{}, false
+		}
 
 		host := parts[0]
 		path := strings.Join(parts[1:], "/")
 		for _, repo := range tracked {
-			if strings.EqualFold(string(repoPlatformForPriority(repo)), provider) &&
+			if repoPlatformForPriority(repo) == kind &&
 				strings.EqualFold(repoHostForPriority(repo), host) &&
 				strings.EqualFold(repoPathForPriority(repo), path) {
 				return repo, true

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -16754,6 +16754,8 @@ export interface operations {
             query?: {
                 /** @description Optional repository filters to sync first. Accepts repeated provider|platform_host/repo_path values or comma-separated values. */
                 priority_repo?: string[] | null;
+                /** @description Optional repository filters to sync exclusively. Accepts repeated provider|platform_host/repo_path values or comma-separated values. */
+                only_repo?: string[] | null;
             };
             header?: never;
             path?: never;

--- a/packages/ui/src/stores/sync.svelte.test.ts
+++ b/packages/ui/src/stores/sync.svelte.test.ts
@@ -31,4 +31,32 @@ describe("sync store", () => {
       },
     });
   });
+
+  it("passes one provider-qualified repository as the only sync scope", async () => {
+    const post = vi.fn(async () => ({ error: undefined }));
+    const get = vi.fn(async (path: string) => {
+      if (path === "/sync/status") {
+        return {
+          data: { running: false, last_run_at: "", last_error: "" },
+        };
+      }
+      return { data: { hosts: {} } };
+    });
+    const store = createSyncStore({
+      client: {
+        GET: get,
+        POST: post,
+      } as unknown as MiddlemanClient,
+    });
+
+    await store.triggerRepoSync("gitlab|gitlab.example.com/group/subgroup/project");
+
+    expect(post).toHaveBeenCalledWith("/sync", {
+      params: {
+        query: {
+          only_repo: ["gitlab|gitlab.example.com/group/subgroup/project"],
+        },
+      },
+    });
+  });
 });

--- a/packages/ui/src/stores/sync.svelte.ts
+++ b/packages/ui/src/stores/sync.svelte.ts
@@ -95,7 +95,11 @@ export function createSyncStore(opts: SyncStoreOptions) {
     applySyncStatus(next);
   }
 
-  async function triggerSync(): Promise<void> {
+  type SyncRequest = () => Promise<{
+    error?: { detail?: string | undefined; title?: string | undefined } | undefined;
+  }>;
+
+  async function runTriggeredSync(request: SyncRequest): Promise<void> {
     const previous = status;
 
     status = {
@@ -107,9 +111,7 @@ export function createSyncStore(opts: SyncStoreOptions) {
     adjustPollingSpeed(true);
 
     try {
-      const priorityRepos = parsePriorityRepos(getPriorityRepos());
-      const syncOptions = priorityRepos.length > 0 ? { params: { query: { priority_repo: priorityRepos } } } : {};
-      const { error } = await apiClient.POST("/sync", syncOptions);
+      const { error } = await request();
       if (error) {
         throw new Error(error.detail ?? error.title ?? "failed to trigger sync");
       }
@@ -124,6 +126,20 @@ export function createSyncStore(opts: SyncStoreOptions) {
       adjustPollingSpeed(false);
       throw err;
     }
+  }
+
+  async function triggerSync(): Promise<void> {
+    const priorityRepos = parsePriorityRepos(getPriorityRepos());
+    const syncOptions = priorityRepos.length > 0 ? { params: { query: { priority_repo: priorityRepos } } } : {};
+    await runTriggeredSync(() => apiClient.POST("/sync", syncOptions));
+  }
+
+  async function triggerRepoSync(repo: string): Promise<void> {
+    await runTriggeredSync(() =>
+      apiClient.POST("/sync", {
+        params: { query: { only_repo: [repo] } },
+      }),
+    );
   }
 
   function parsePriorityRepos(value: string | undefined): string[] {
@@ -168,6 +184,7 @@ export function createSyncStore(opts: SyncStoreOptions) {
     refreshSyncStatus,
     setSyncStatus,
     triggerSync,
+    triggerRepoSync,
     startPolling,
     stopPolling,
   };


### PR DESCRIPTION
## Summary

- Keep the primary header Sync action on the existing full-sync path
- Add a segmented chevron menu for syncing only the repository in the current route or single-repository filter
- Disable repository-only sync for ambiguous scopes and validate the full provider-qualified repository identity

<sup>generated by a clanker</sup>