### PR TITLE
Fix cleanup when linked worktree metadata disappears

### DIFF
--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -25895,6 +25895,51 @@ func TestWorkspaceForceDeleteToleratesCorruptWorktreeGitfileE2E(t *testing.T) {
 	assert.Nil(got)
 }
 
+func TestWorkspaceForceDeleteToleratesMissingWorktreeCommonDirE2E(
+	t *testing.T,
+) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	client, database, _, _ := setupTestServerWithWorkspaces(t)
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, client)
+	installGitCommonDirReadFailure(t)
+
+	force := true
+	delResp, err := client.HTTP.DeleteWorkspaceWithResponse(
+		ctx, ws.Id, &generated.DeleteWorkspaceParams{Force: &force},
+	)
+	require.NoError(err)
+	require.Equal(
+		http.StatusNoContent, delResp.StatusCode(), string(delResp.Body),
+	)
+
+	got, err := database.GetWorkspace(ctx, ws.Id)
+	require.NoError(err)
+	assert.Nil(got)
+}
+
+func installGitCommonDirReadFailure(t *testing.T) {
+	t.Helper()
+
+	realGit, err := exec.LookPath("git")
+	require.NoError(t, err)
+	wrapperDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(wrapperDir, "git"), []byte(`#!/bin/sh
+set -eu
+case " $* " in
+	*" rev-parse --path-format=absolute --git-common-dir "*)
+		echo "fatal: failed to read worktrees/pr-1/commondir: Success" >&2
+		exit 128
+		;;
+esac
+exec "$MIDDLEMAN_TEST_REAL_GIT" "$@"
+`), 0o755))
+	t.Setenv("PATH", wrapperDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("MIDDLEMAN_TEST_REAL_GIT", realGit)
+}
+
 // TestWorkspaceDeleteDirtyKeepsRuntimeSessionsE2E covers the case where the
 // workspace is dirty and delete is rejected with 409. Runtime sessions must
 // survive — killing them on a delete that didn't actually happen would leave

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -3632,7 +3632,12 @@ func isGitWorktreeAbsent(err error) bool {
 		// reports "is not a .git file". Treat both as absent so
 		// cleanup skips the dead worktree instead of failing.
 		strings.Contains(msg, "invalid gitfile format") ||
-		strings.Contains(msg, "is not a .git file")
+		strings.Contains(msg, "is not a .git file") ||
+		// A linked worktree can disappear between Git opening its
+		// metadata directory and reading commondir. Git reports this
+		// race with a misleading "Success" suffix.
+		(strings.Contains(msg, "failed to read worktrees/") &&
+			strings.Contains(msg, "/commondir: success"))
 }
 
 func isGitBranchAbsent(err error) bool {

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -5144,6 +5144,14 @@ func TestIsGitWorktreeAbsentClassifiesCorruptGitfile(t *testing.T) {
 			errors.New("fatal: '/tmp/wt' is not a working tree"),
 			true,
 		},
+		{
+			"missing linked-worktree metadata",
+			fmt.Errorf(
+				"%w: %s", errors.New("exit status 128"),
+				"fatal: failed to read worktrees/pr-1/commondir: Success",
+			),
+			true,
+		},
 		{"nil error", nil, false},
 		{
 			"unrelated git failure",


### PR DESCRIPTION
Workspace teardown can race with removal of Git linked-worktree metadata, causing cleanup to fail on a misleading `commondir` read error even though the worktree is already unusable.

- Treat only that dead-metadata error as an absent worktree during cleanup.
- Exercise the HTTP force-delete workflow and confirm the persisted workspace record is removed.