### PR TITLE
Stabilize frontend CI under runner contention

### DIFF
--- a/frontend/src/lib/dev/healthcheckPlugin.test.ts
+++ b/frontend/src/lib/dev/healthcheckPlugin.test.ts
@@ -72,12 +72,16 @@ describe("healthcheckPlugin", () => {
     return port;
   }
 
-  it.each(["/healthz", "/livez"])("serves %s", async (path) => {
-    const baseURL = await startServer();
+  it.each(["/healthz", "/livez"])(
+    "serves %s",
+    async (path) => {
+      const baseURL = await startServer();
 
-    const response = await fetch(baseURL + path);
+      const response = await fetch(baseURL + path);
 
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ status: "ok" });
-  });
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({ status: "ok" });
+    },
+    15_000,
+  );
 });

--- a/frontend/src/lib/dev/viteConfig.test.ts
+++ b/frontend/src/lib/dev/viteConfig.test.ts
@@ -20,6 +20,14 @@ describe("vite config", () => {
     expect(resolveUnitTestWorkers({ CI: "1" })).toBe(1);
   });
 
+  it("runs unit tests in worker threads", () => {
+    expect(config.test.projects?.[0]).toMatchObject({
+      test: {
+        pool: "threads",
+      },
+    });
+  });
+
   it("aliases @middleman/ui to the workspace source tree", () => {
     const aliases = Array.isArray(config.resolve?.alias) ? config.resolve.alias : [];
 

--- a/frontend/tests/e2e-full/stale-asset-recovery.spec.ts
+++ b/frontend/tests/e2e-full/stale-asset-recovery.spec.ts
@@ -8,8 +8,12 @@ function distAssetUrl(assetUrl: string): URL {
   return new URL(`../../dist/${pathname}`, import.meta.url);
 }
 
+function isNavigationContextReplacement(error: unknown): boolean {
+  return error instanceof Error && error.message.includes("Execution context was destroyed");
+}
+
 test("reloads an outdated frontend before rendering a Mermaid diagram", async ({ page }) => {
-  test.setTimeout(45_000);
+  test.setTimeout(90_000);
   await mockApi(page);
   const updatedEntrypointPath = "/assets/index-updated.js";
   const updatedMermaidCorePath = "/assets/mermaid.core-updated.js";
@@ -34,15 +38,18 @@ test("reloads an outdated frontend before rendering a Mermaid diagram", async ({
     }
 
     if (isVersionCheck) frontendVersionChecks += 1;
-    const response = await route.fetch();
-    const shell = await response.text();
+    const shell = await readFile(new URL("../../dist/index.html", import.meta.url), "utf8");
     const entrypointMatch = shell.match(/<script\b[^>]*\btype="module"[^>]*\bsrc="([^"]+)"[^>]*>/);
     const currentEntrypointPath = entrypointMatch?.[1];
     if (!entrypointMatch || !currentEntrypointPath) throw new Error("Frontend entrypoint not found in test shell");
 
     currentEntrypointUrl ||= new URL(currentEntrypointPath, route.request().url()).href;
     const updatedEntrypoint = entrypointMatch[0].replace(currentEntrypointPath, updatedEntrypointPath);
-    await route.fulfill({ response, body: shell.replace(entrypointMatch[0], updatedEntrypoint) });
+    await route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: shell.replace(entrypointMatch[0], updatedEntrypoint),
+    });
   });
   await page.route(updatedEntrypointPath, async (route) => {
     if (!currentEntrypointUrl) throw new Error("Current frontend entrypoint URL not captured");
@@ -108,23 +115,31 @@ test("reloads an outdated frontend before rendering a Mermaid diagram", async ({
         "```",
       ].join("\n"),
     );
+  const recoveryNavigation = page.waitForEvent("framenavigated", (frame) => frame === page.mainFrame());
   await page.locator(".body-edit .title-edit-save").click();
 
-  await expect.poll(() => mainFrameNavigations).toBeGreaterThanOrEqual(2);
+  await recoveryNavigation;
   await page.waitForLoadState("load");
+  await expect.poll(() => mainFrameNavigations).toBeGreaterThanOrEqual(2);
   await expect.poll(() => frontendVersionChecks).toBeGreaterThanOrEqual(1);
   await expect.poll(() => updatedSequenceRequests).toBeGreaterThanOrEqual(1);
-  await expect(page.locator(".markdown-body .kit-mermaid-viewer__pan svg").first()).toBeVisible({ timeout: 20_000 });
+  await expect(page.locator(".markdown-body .kit-mermaid-viewer__pan svg").first()).toBeVisible({ timeout: 60_000 });
   expect(oldSequenceRequests).toBeGreaterThanOrEqual(1);
   await expect(
     page.locator(".markdown-body pre.shiki").filter({ hasText: 'const ordinary = "code";' }).first(),
   ).toBeVisible();
   await expect
     .poll(
-      () =>
-        page.evaluate(() =>
-          Object.keys(window.sessionStorage).filter((key) => key.startsWith("middleman:vite-reload")),
-        ),
+      async () => {
+        try {
+          return await page.evaluate(() =>
+            Object.keys(window.sessionStorage).filter((key) => key.startsWith("middleman:vite-reload")),
+          );
+        } catch (error) {
+          if (isNavigationContextReplacement(error)) return null;
+          throw error;
+        }
+      },
       { timeout: 10_000 },
     )
     .toEqual([]);

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -167,6 +167,12 @@ const unitTestProject = {
   extends: true,
   test: {
     name: "unit",
+    // A single thread avoids both fork teardown failures and the memory
+    // pressure seen with concurrent workers on the current CI runner. Revisit
+    // process isolation after the runner memory upgrade. Node's global Web
+    // Storage must stay disabled in workers so jsdom owns localStorage.
+    pool: "threads",
+    execArgv: ["--no-experimental-webstorage"],
     ...(unitTestMaxWorkers ? { maxWorkers: unitTestMaxWorkers } : {}),
     environment: "jsdom",
     setupFiles: ["./src/test/setup.ts"],


### PR DESCRIPTION
Frontend CI intermittently lost Vitest workers and raced the intentional reload in the stale-asset recovery scenario on loaded runners.

- Run unit tests in worker threads and limit CI to one worker, avoiding the failing child-process lifecycle and concurrent memory pressure.
- Disable Node global Web Storage in test workers so jsdom remains the storage implementation.
- Give the Vite healthcheck integration cases a focused 15-second startup timeout.
- Synchronize the stale-asset scenario with its recovery navigation and tolerate execution-context replacement during the reload.
- Serve its synthetic updated shell from the built frontend instead of a cancelable routed response.
- Give only that loaded recovery scenario a larger render budget.