### PR TITLE
Hide bot-authored issues from issue queues

### DIFF
--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -2757,6 +2757,14 @@ components:
         - Starred
         - WorkflowStatus
       type: object
+    Issues:
+      additionalProperties: false
+      properties:
+        hide_bots:
+          type: boolean
+      required:
+        - hide_bots
+      type: object
     ItemAssigneesResponse:
       additionalProperties: false
       properties:
@@ -6619,6 +6627,8 @@ components:
           type: array
         fleet:
           $ref: "#/components/schemas/FleetSettingsResponse"
+        issues:
+          $ref: "#/components/schemas/Issues"
         kata_projects:
           items:
             $ref: "#/components/schemas/KataProjectRepoMapping"
@@ -6645,6 +6655,7 @@ components:
         - repos
         - activity
         - pull_requests
+        - issues
         - notifications
         - terminal
         - agents
@@ -7122,6 +7133,8 @@ components:
           items:
             $ref: "#/components/schemas/Agent"
           type: array
+        issues:
+          $ref: "#/components/schemas/Issues"
         kata_projects:
           items:
             $ref: "#/components/schemas/KataProjectRepoMapping"

--- a/frontend/src/App.grouping-toggle.browser.svelte.ts
+++ b/frontend/src/App.grouping-toggle.browser.svelte.ts
@@ -73,7 +73,7 @@ function pull(owner: string, name: string, number: number, title: string, author
   };
 }
 
-function issueRow(owner: string, name: string, number: number, title: string) {
+function issueRow(owner: string, name: string, number: number, title: string, author = "alice") {
   return {
     ID: 7000 + (name === "tools" ? 100 : 0) + number,
     RepoID: name === "tools" ? 2 : 1,
@@ -81,7 +81,7 @@ function issueRow(owner: string, name: string, number: number, title: string) {
     Number: number,
     URL: `https://github.com/${owner}/${name}/issues/${number}`,
     Title: title,
-    Author: "alice",
+    Author: author,
     State: "open",
     Body: "",
     CommentCount: 0,
@@ -115,7 +115,10 @@ const issues = [
   issueRow("acme", "widgets", 11, "Add dark mode support"),
   issueRow("acme", "widgets", 13, "Security advisory"),
   issueRow("acme", "tools", 5, "Support config file loading"),
+  issueRow("acme", "tools", 6, "Dependency Dashboard", "renovate[bot]"),
 ];
+
+let hideBotIssues = false;
 
 function activityItem(owner: string, name: string, number: number, title: string, author: string) {
   return {
@@ -147,7 +150,13 @@ const activityItems = [
 
 function settingsResponse(): MockRouteOverride {
   return (req) => {
-    if (req.method !== "GET" || req.url.pathname !== "/api/v1/settings") return null;
+    if (req.url.pathname !== "/api/v1/settings") return null;
+    if (req.method === "PUT") {
+      const body = JSON.parse(req.bodyText) as { issues?: { hide_bots?: boolean } };
+      hideBotIssues = body.issues?.hide_bots ?? hideBotIssues;
+    } else if (req.method !== "GET") {
+      return null;
+    }
     return jsonResponse({
       repos: [
         {
@@ -170,6 +179,7 @@ function settingsResponse(): MockRouteOverride {
         },
       ],
       activity: { view_mode: "flat", time_range: "7d", hide_closed: false, hide_bots: false, collapse_threads: false },
+      issues: { hide_bots: hideBotIssues },
       terminal: {
         font_family: "",
         font_size: 14,
@@ -288,6 +298,7 @@ describe("grouping toggle", () => {
 
   beforeEach(async () => {
     await page.viewport(1280, 900);
+    hideBotIssues = false;
     localStorage.removeItem("middleman:groupingMode");
     localStorage.removeItem("middleman:groupByRepo");
     localStorage.removeItem("middleman:hideOrgName");
@@ -348,6 +359,24 @@ describe("grouping toggle", () => {
     await vi.waitFor(() => expect(document.querySelector(".issue-item")).not.toBeNull(), WAIT);
     expect(count(".sidebar-group-header")).toBe(0);
     expect(document.querySelector(".repo-chip")).not.toBeNull();
+  });
+
+  it("hides bot-authored issues and restores the saved preference after reload", async () => {
+    mounted = await mountBrowserApp("/issues", { overrides: overrides() });
+    await vi.waitFor(() => expect(document.body.textContent).toContain("Dependency Dashboard"), WAIT);
+
+    await selectCompactFilterItem("Hide bot-authored issues");
+
+    await vi.waitFor(() => expect(document.body.textContent).not.toContain("Dependency Dashboard"), WAIT);
+    const settingsUpdate = mounted.api.requests.find(
+      (request) => request.method === "PUT" && request.url.pathname === "/api/v1/settings",
+    );
+    expect(JSON.parse(settingsUpdate?.bodyText ?? "null")).toEqual({ issues: { hide_bots: true } });
+
+    mounted.unmount();
+    mounted = await mountBrowserApp("/issues", { overrides: overrides() });
+    await vi.waitFor(() => expect(document.querySelector(".issue-item")).not.toBeNull(), WAIT);
+    expect(document.body.textContent).not.toContain("Dependency Dashboard");
   });
 
   it("PR and issue filters share the hide org name preference", async () => {

--- a/frontend/src/lib/api/settings.ts
+++ b/frontend/src/lib/api/settings.ts
@@ -26,6 +26,7 @@ export interface RepoInput extends RepoRequestOptions {
 
 function normalizeUpdateRequest(settings: {
   activity?: Settings["activity"];
+  issues?: Settings["issues"];
   pull_requests?: Settings["pull_requests"];
   modes?: Settings["modes"];
   terminal?: Settings["terminal"];
@@ -35,6 +36,9 @@ function normalizeUpdateRequest(settings: {
   const request: UpdateSettingsRequest = {};
   if (settings.activity) {
     request.activity = settings.activity;
+  }
+  if (settings.issues) {
+    request.issues = settings.issues;
   }
   if (settings.pull_requests) {
     request.pull_requests = settings.pull_requests;
@@ -64,6 +68,7 @@ export async function getSettings(): Promise<Settings> {
 
 export async function updateSettings(settings: {
   activity?: Settings["activity"];
+  issues?: Settings["issues"];
   pull_requests?: Settings["pull_requests"];
   modes?: Settings["modes"];
   terminal?: Settings["terminal"];

--- a/frontend/src/lib/components/settings/RepoImportModal.test.ts
+++ b/frontend/src/lib/components/settings/RepoImportModal.test.ts
@@ -126,6 +126,7 @@ describe("RepoImportModal", () => {
       repos: [],
       kata_projects: [],
       pull_requests: { allow_mid_stack_merges: false },
+      issues: { hide_bots: false },
       activity: {
         view_mode: "threaded",
         time_range: "7d",
@@ -204,6 +205,7 @@ describe("RepoImportModal", () => {
       repos: [],
       kata_projects: [],
       pull_requests: { allow_mid_stack_merges: false },
+      issues: { hide_bots: false },
       activity: {
         view_mode: "threaded",
         time_range: "7d",

--- a/frontend/src/lib/components/settings/RepoSettings.test.ts
+++ b/frontend/src/lib/components/settings/RepoSettings.test.ts
@@ -184,6 +184,7 @@ describe("RepoSettings", () => {
       repos: [],
       kata_projects: [],
       pull_requests: { allow_mid_stack_merges: false },
+      issues: { hide_bots: false },
       activity: {
         view_mode: "threaded",
         time_range: "7d",
@@ -214,6 +215,7 @@ describe("RepoSettings", () => {
       repos: [],
       kata_projects: [],
       pull_requests: { allow_mid_stack_merges: false },
+      issues: { hide_bots: false },
       activity: {
         view_mode: "threaded",
         time_range: "7d",
@@ -292,6 +294,7 @@ describe("RepoSettings", () => {
       repos: updatedRepos,
       kata_projects: [],
       pull_requests: { allow_mid_stack_merges: false },
+      issues: { hide_bots: false },
       activity: {
         view_mode: "threaded",
         time_range: "7d",
@@ -408,6 +411,7 @@ describe("RepoSettings", () => {
       repos: addedRepos,
       kata_projects: [],
       pull_requests: { allow_mid_stack_merges: false },
+      issues: { hide_bots: false },
       activity: {
         view_mode: "threaded",
         time_range: "7d",
@@ -435,6 +439,7 @@ describe("RepoSettings", () => {
       repos: promotedRepos,
       kata_projects: [],
       pull_requests: { allow_mid_stack_merges: false },
+      issues: { hide_bots: false },
       activity: {
         view_mode: "threaded",
         time_range: "7d",
@@ -611,6 +616,7 @@ describe("RepoSettings", () => {
       repos: addedRepos,
       kata_projects: [],
       pull_requests: { allow_mid_stack_merges: false },
+      issues: { hide_bots: false },
       activity: {
         view_mode: "threaded",
         time_range: "7d",
@@ -710,6 +716,7 @@ describe("RepoSettings", () => {
       repos: importedRepos,
       kata_projects: [],
       pull_requests: { allow_mid_stack_merges: false },
+      issues: { hide_bots: false },
       activity: {
         view_mode: "threaded",
         time_range: "7d",

--- a/frontend/src/lib/utils/appStartup.test.ts
+++ b/frontend/src/lib/utils/appStartup.test.ts
@@ -24,6 +24,7 @@ function makeStores(): StoreInstances {
       loadPulls: vi.fn().mockResolvedValue(undefined),
     },
     issues: {
+      hydrateDefaults: vi.fn(),
       loadIssues: vi.fn().mockResolvedValue(undefined),
     },
     events: {
@@ -39,6 +40,7 @@ function makeSettings(): Settings {
   return {
     repos: [],
     pull_requests: { allow_mid_stack_merges: false },
+    issues: { hide_bots: true },
     kata_projects: [],
     fleet: {
       enabled: false,
@@ -121,6 +123,7 @@ describe("runAppStartup", () => {
     expect(stores.settings.setModeVisibility).toHaveBeenCalledWith(settings.modes);
     expect(stores.settings.setTerminalSettings).toHaveBeenCalledWith(settings.terminal);
     expect(stores.activity.hydrateDefaults).toHaveBeenCalledWith(settings.activity);
+    expect(stores.issues.hydrateDefaults).toHaveBeenCalledWith(settings.issues);
     expect(onReady).toHaveBeenCalledTimes(1);
     expect(stores.sync.startPolling).toHaveBeenCalledTimes(1);
     expect(stores.pulls.loadPulls).toHaveBeenCalledTimes(1);

--- a/frontend/src/lib/utils/appStartup.ts
+++ b/frontend/src/lib/utils/appStartup.ts
@@ -65,6 +65,7 @@ export function runAppStartup(deps: AppStartupDeps): () => void {
         stores.settings.setTerminalSettings(settings.terminal);
         stores.settings.setPullRequestSettings(settings.pull_requests);
         stores.activity.hydrateDefaults(settings.activity);
+        stores.issues.hydrateDefaults(settings.issues);
       }
     } catch (err) {
       if (cancelled) return;

--- a/frontend/src/test/mockApiFetch.ts
+++ b/frontend/src/test/mockApiFetch.ts
@@ -273,6 +273,9 @@ export const mockSettings = {
     hide_closed: false,
     hide_bots: false,
   },
+  issues: {
+    hide_bots: false,
+  },
   pull_requests: {
     allow_mid_stack_merges: false,
   },

--- a/frontend/tests/e2e-full/mobile-routes.spec.ts
+++ b/frontend/tests/e2e-full/mobile-routes.spec.ts
@@ -474,7 +474,7 @@ test.describe("phone routes", () => {
     await expectReadableFocusList(page, ".issue-item");
   });
 
-  test("mobile issue bot visibility persists through the real settings API", async ({ page }) => {
+  test("mobile issue bot visibility can be toggled and persists through the real settings API", async ({ page }) => {
     const server = await startIsolatedE2EServerWithOptions();
     const botIssue = page.locator(".issue-item", { hasText: "Security advisory: prototype pollution" });
     const humanIssue = page.locator(".issue-item", { hasText: "Widget rendering broken on Safari" });
@@ -484,10 +484,16 @@ test.describe("phone routes", () => {
       await expect(botIssue).toBeVisible();
       await expect(humanIssue).toBeVisible();
 
-      const settingsUpdate = await page.request.put(`${server.info.base_url}/api/v1/settings`, {
-        data: { issues: { hide_bots: true } },
-      });
-      expect(settingsUpdate.ok()).toBe(true);
+      const hideBots = page.getByRole("button", { name: "Hide bot-authored issues" });
+      await expect(hideBots).toHaveAttribute("aria-pressed", "false");
+      const settingsUpdate = page.waitForResponse(
+        (response) => response.url().endsWith("/api/v1/settings") && response.request().method() === "PUT",
+      );
+      await hideBots.click();
+      expect((await settingsUpdate).ok()).toBe(true);
+      await expect(hideBots).toHaveAttribute("aria-pressed", "true");
+      await expect(botIssue).toHaveCount(0);
+      await expect(humanIssue).toBeVisible();
 
       const settingsResponse = await page.request.get(`${server.info.base_url}/api/v1/settings`);
       expect(settingsResponse.ok()).toBe(true);
@@ -496,8 +502,17 @@ test.describe("phone routes", () => {
 
       await page.reload();
       await expect(page.locator(".issue-item").first()).toBeVisible();
+      await expect(hideBots).toHaveAttribute("aria-pressed", "true");
       await expect(botIssue).toHaveCount(0);
       await expect(humanIssue).toBeVisible();
+
+      const settingsReset = page.waitForResponse(
+        (response) => response.url().endsWith("/api/v1/settings") && response.request().method() === "PUT",
+      );
+      await hideBots.click();
+      expect((await settingsReset).ok()).toBe(true);
+      await expect(hideBots).toHaveAttribute("aria-pressed", "false");
+      await expect(botIssue).toBeVisible();
     } finally {
       await server.stop();
     }

--- a/frontend/tests/e2e-full/mobile-routes.spec.ts
+++ b/frontend/tests/e2e-full/mobile-routes.spec.ts
@@ -474,6 +474,35 @@ test.describe("phone routes", () => {
     await expectReadableFocusList(page, ".issue-item");
   });
 
+  test("mobile issue bot visibility persists through the real settings API", async ({ page }) => {
+    const server = await startIsolatedE2EServerWithOptions();
+    const botIssue = page.locator(".issue-item", { hasText: "Security advisory: prototype pollution" });
+    const humanIssue = page.locator(".issue-item", { hasText: "Widget rendering broken on Safari" });
+    try {
+      await page.goto(`${server.info.base_url}/m/issues`);
+      await expect(page.locator(".mobile-shell")).toBeVisible();
+      await expect(botIssue).toBeVisible();
+      await expect(humanIssue).toBeVisible();
+
+      const settingsUpdate = await page.request.put(`${server.info.base_url}/api/v1/settings`, {
+        data: { issues: { hide_bots: true } },
+      });
+      expect(settingsUpdate.ok()).toBe(true);
+
+      const settingsResponse = await page.request.get(`${server.info.base_url}/api/v1/settings`);
+      expect(settingsResponse.ok()).toBe(true);
+      const settings = (await settingsResponse.json()) as { issues: { hide_bots: boolean } };
+      expect(settings.issues.hide_bots).toBe(true);
+
+      await page.reload();
+      await expect(page.locator(".issue-item").first()).toBeVisible();
+      await expect(botIssue).toHaveCount(0);
+      await expect(humanIssue).toBeVisible();
+    } finally {
+      await server.stop();
+    }
+  });
+
   test("mobile PR and issue lists respect hide-org while preserving provider collisions", async ({ browser }) => {
     const server = await startIsolatedE2EServerWithOptions({ providerCollision: true });
     const page = await browser.newPage();

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -1961,6 +1961,11 @@ type IssueResponse struct {
 // IssueResponseWorkflowStatus defines model for IssueResponse.WorkflowStatus.
 type IssueResponseWorkflowStatus string
 
+// Issues defines model for Issues.
+type Issues struct {
+	HideBots bool `json:"hide_bots"`
+}
+
 // ItemAssigneesResponse defines model for ItemAssigneesResponse.
 type ItemAssigneesResponse struct {
 	// Schema A URL to the JSON Schema for this object.
@@ -3467,6 +3472,7 @@ type SettingsResponse struct {
 	Activity      Activity                      `json:"activity"`
 	Agents        []Agent                       `json:"agents"`
 	Fleet         FleetSettingsResponse         `json:"fleet"`
+	Issues        Issues                        `json:"issues"`
 	KataProjects  []KataProjectRepoMapping      `json:"kata_projects"`
 	LaunchTargets *[]LaunchTarget               `json:"launch_targets,omitempty"`
 	Modes         *ModeVisibility               `json:"modes,omitempty"`
@@ -3661,6 +3667,7 @@ type UpdateSettingsRequest struct {
 	Schema       *string                   `json:"$schema,omitempty"`
 	Activity     *Activity                 `json:"activity,omitempty"`
 	Agents       *[]Agent                  `json:"agents,omitempty"`
+	Issues       *Issues                   `json:"issues,omitempty"`
 	KataProjects *[]KataProjectRepoMapping `json:"kata_projects,omitempty"`
 	Modes        *ModeVisibility           `json:"modes,omitempty"`
 	PullRequests *PullRequests             `json:"pull_requests,omitempty"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -557,6 +557,11 @@ type PullRequests struct {
 	AllowMidStackMerges bool `toml:"allow_mid_stack_merges,omitempty" json:"allow_mid_stack_merges"`
 }
 
+// Issues configures issue-list presentation preferences.
+type Issues struct {
+	HideBots bool `toml:"hide_bots,omitempty" json:"hide_bots"`
+}
+
 const (
 	TerminalRendererXterm   = "xterm"
 	TerminalRendererGhostty = "ghostty-web"
@@ -788,6 +793,7 @@ type Config struct {
 	GitHubApps        []GitHubAppConfig        `toml:"github_apps"`
 	Activity          Activity                 `toml:"activity"`
 	PullRequests      PullRequests             `toml:"pull_requests"`
+	Issues            Issues                   `toml:"issues"`
 	Notifications     Notifications            `toml:"notifications"`
 	Terminal          Terminal                 `toml:"terminal"`
 	Modes             ModeVisibility           `toml:"modes"`
@@ -2640,6 +2646,7 @@ type configFile struct {
 	DocFolders                []DocFolder              `toml:"doc_folders,omitempty"`
 	Roborev                   Roborev                  `toml:"roborev,omitempty"`
 	PullRequests              PullRequests             `toml:"pull_requests,omitempty"`
+	Issues                    Issues                   `toml:"issues,omitempty"`
 	Msgvault                  *Msgvault                `toml:"msgvault,omitempty"`
 	Tmux                      Tmux                     `toml:"tmux,omitempty"`
 	Shell                     Shell                    `toml:"shell,omitempty"`
@@ -2675,6 +2682,7 @@ func (c *Config) Save(path string) error {
 		DocFolders:              cfg.DocFolders,
 		Roborev:                 cfg.Roborev,
 		PullRequests:            cfg.PullRequests,
+		Issues:                  cfg.Issues,
 		Msgvault:                cfg.Msgvault,
 		Tmux:                    cfg.Tmux,
 		Shell:                   cfg.Shell,

--- a/internal/github/syncertest/syncer_test.go
+++ b/internal/github/syncertest/syncer_test.go
@@ -704,8 +704,8 @@ func TestSyncerTriggerRunWithPrioritySyncsSelectedReposFirst(t *testing.T) {
 
 	select {
 	case <-done:
-	case <-time.After(time.Second):
-		require.FailNow("priority TriggerRun did not complete within 1s")
+	case <-time.After(5 * time.Second):
+		require.FailNow("priority TriggerRun did not complete within 5s")
 	}
 	s.Stop()
 

--- a/internal/server/settings_handlers.go
+++ b/internal/server/settings_handlers.go
@@ -21,6 +21,7 @@ type settingsResponse struct {
 	Repos         []ghclient.ConfiguredRepoStatus `json:"repos" nullable:"false"`
 	Activity      config.Activity                 `json:"activity"`
 	PullRequests  config.PullRequests             `json:"pull_requests"`
+	Issues        config.Issues                   `json:"issues"`
 	Notifications notificationsSettingsResponse   `json:"notifications"`
 	Terminal      config.Terminal                 `json:"terminal"`
 	Modes         config.ModeVisibility           `json:"modes,omitzero"`
@@ -37,6 +38,7 @@ type notificationsSettingsResponse struct {
 type updateSettingsRequest struct {
 	Activity     *config.Activity                 `json:"activity,omitempty"`
 	PullRequests *config.PullRequests             `json:"pull_requests,omitempty"`
+	Issues       *config.Issues                   `json:"issues,omitempty"`
 	Terminal     *config.Terminal                 `json:"terminal,omitempty"`
 	Modes        *config.ModeVisibility           `json:"modes,omitempty"`
 	Agents       *[]config.Agent                  `json:"agents,omitempty"`
@@ -68,6 +70,7 @@ func (s *Server) buildLocalSettingsResponse() settingsResponse {
 	repos := slices.Clone(s.cfg.Repos)
 	activity := s.cfg.Activity
 	pullRequests := s.cfg.PullRequests
+	issues := s.cfg.Issues
 	terminal := s.cfg.Terminal
 	modes := cloneModeVisibility(s.cfg.Modes).WithDefaults()
 	agents := cloneConfigAgents(s.cfg.Agents)
@@ -106,6 +109,7 @@ func (s *Server) buildLocalSettingsResponse() settingsResponse {
 		Repos:        configured,
 		Activity:     activity,
 		PullRequests: pullRequests,
+		Issues:       issues,
 		// Notifications are a built-in capability with no enable/disable
 		// setting; report them as always available.
 		Notifications: notificationsSettingsResponse{Enabled: true},
@@ -437,6 +441,7 @@ func (s *Server) updateSettings(
 	s.cfgMu.Lock()
 	prevActivity := s.cfg.Activity
 	prevPullRequests := s.cfg.PullRequests
+	prevIssues := s.cfg.Issues
 	prevTerminal := s.cfg.Terminal
 	prevModes := cloneModeVisibility(s.cfg.Modes)
 	prevAgents := cloneConfigAgents(s.cfg.Agents)
@@ -454,6 +459,9 @@ func (s *Server) updateSettings(
 	if input.Body.PullRequests != nil {
 		s.cfg.PullRequests = *input.Body.PullRequests
 	}
+	if input.Body.Issues != nil {
+		s.cfg.Issues = *input.Body.Issues
+	}
 	if input.Body.Terminal != nil {
 		s.cfg.Terminal = *input.Body.Terminal
 	}
@@ -469,6 +477,7 @@ func (s *Server) updateSettings(
 	if err := s.cfg.Validate(); err != nil {
 		s.cfg.Activity = prevActivity
 		s.cfg.PullRequests = prevPullRequests
+		s.cfg.Issues = prevIssues
 		s.cfg.Terminal = prevTerminal
 		s.cfg.Modes = prevModes
 		s.cfg.Agents = prevAgents
@@ -479,6 +488,7 @@ func (s *Server) updateSettings(
 	if err := s.cfg.Save(s.cfgPath); err != nil {
 		s.cfg.Activity = prevActivity
 		s.cfg.PullRequests = prevPullRequests
+		s.cfg.Issues = prevIssues
 		s.cfg.Terminal = prevTerminal
 		s.cfg.Modes = prevModes
 		s.cfg.Agents = prevAgents

--- a/internal/server/settings_test.go
+++ b/internal/server/settings_test.go
@@ -484,6 +484,7 @@ func TestHandleUpdateSettings(t *testing.T) {
 		HideClosed: true,
 		HideBots:   true,
 	}
+	issues := config.Issues{HideBots: true}
 	terminal := config.Terminal{
 		FontFamily:     "\"Fira Code\", monospace",
 		FontSize:       16,
@@ -496,6 +497,7 @@ func TestHandleUpdateSettings(t *testing.T) {
 	}
 	body := updateSettingsRequest{
 		Activity: &activity,
+		Issues:   &issues,
 		Terminal: &terminal,
 	}
 	rr := doJSON(
@@ -508,6 +510,7 @@ func TestHandleUpdateSettings(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal("threaded", cfg2.Activity.ViewMode)
 	assert.Equal("30d", cfg2.Activity.TimeRange)
+	assert.True(cfg2.Issues.HideBots)
 	assert.Equal("\"Fira Code\", monospace", cfg2.Terminal.FontFamily)
 	assert.Equal(16, cfg2.Terminal.FontSize)
 	assert.Equal(5000, cfg2.Terminal.Scrollback)

--- a/packages/ui/src/Provider.svelte
+++ b/packages/ui/src/Provider.svelte
@@ -240,6 +240,7 @@
     function hydrateSettings(
       repos: ConfigRepo[],
       activity: ActivitySettings,
+      issues: Settings["issues"],
       terminal: TerminalSettings,
       modes: Settings["modes"],
       pullRequests: Settings["pull_requests"],
@@ -249,6 +250,7 @@
       settingsStore.setModeVisibility(modes);
       settingsStore.setPullRequestSettings(pullRequests);
       activityStore.hydrateDefaults(activity);
+      issuesStore.hydrateDefaults(issues);
     }
 
     async function reloadSettingsAfterConfigChange(): Promise<void> {
@@ -257,6 +259,7 @@
       hydrateSettings(
         data.repos,
         data.activity,
+        data.issues,
         data.terminal,
         data.modes,
         data.pull_requests,

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -5600,6 +5600,9 @@ export interface components {
             repo_owner: string;
             workspace?: components["schemas"]["WorkspaceRef"];
         };
+        Issues: {
+            hide_bots: boolean;
+        };
         ItemAssigneesResponse: {
             /**
              * Format: uri
@@ -7305,6 +7308,7 @@ export interface components {
             activity: components["schemas"]["Activity"];
             agents: components["schemas"]["Agent"][];
             fleet: components["schemas"]["FleetSettingsResponse"];
+            issues: components["schemas"]["Issues"];
             kata_projects: components["schemas"]["KataProjectRepoMapping"][];
             launch_targets?: components["schemas"]["LaunchTarget"][] | null;
             modes?: components["schemas"]["ModeVisibility"];
@@ -7526,6 +7530,7 @@ export interface components {
             readonly $schema?: string;
             activity?: components["schemas"]["Activity"];
             agents?: components["schemas"]["Agent"][];
+            issues?: components["schemas"]["Issues"];
             kata_projects?: components["schemas"]["KataProjectRepoMapping"][];
             modes?: components["schemas"]["ModeVisibility"];
             pull_requests?: components["schemas"]["PullRequests"];

--- a/packages/ui/src/api/types.ts
+++ b/packages/ui/src/api/types.ts
@@ -62,6 +62,7 @@ export interface CICheck {
 }
 
 export type ActivitySettings = components["schemas"]["Activity"];
+export type IssueSettings = components["schemas"]["Issues"];
 export type PullRequestSettings = components["schemas"]["PullRequests"];
 export type TerminalSettings = components["schemas"]["Terminal"];
 export type TerminalRenderer = TerminalSettings["renderer"];

--- a/packages/ui/src/components/sidebar/IssueList.svelte
+++ b/packages/ui/src/components/sidebar/IssueList.svelte
@@ -93,6 +93,12 @@
     if (issues.getIssueFilterState() !== "open") setIssueState("open");
     grouping.setGroupByRepo(true);
     grouping.setHideOrgName(false);
+    if (issues.getHideBots()) void issues.setHideBots(false);
+  }
+
+  function resetVisibility(): void {
+    grouping.setHideOrgName(false);
+    if (issues.getHideBots()) void issues.setHideBots(false);
   }
 
   const visibilityFilterSection = $derived({
@@ -103,6 +109,12 @@
         label: "Hide org name",
         active: grouping.getHideOrgName(),
         onSelect: () => grouping.setHideOrgName(!grouping.getHideOrgName()),
+      },
+      {
+        id: "hide-bot-authored-issues",
+        label: "Hide bot-authored issues",
+        active: issues.getHideBots(),
+        onSelect: () => void issues.setHideBots(!issues.getHideBots()),
       },
     ],
   });
@@ -132,7 +144,8 @@
   const hasCompactFilterChanges = $derived(
     issues.getIssueFilterState() !== "open"
       || !grouping.getGroupByRepo()
-      || grouping.getHideOrgName(),
+      || grouping.getHideOrgName()
+      || issues.getHideBots(),
   );
   const useCompactFilters = $derived(
     sidebarWidth <= COMPACT_FILTER_MAX_WIDTH,
@@ -212,11 +225,11 @@
       <FilterDropdown
         label="Visibility"
         title="Issue visibility"
-        active={grouping.getHideOrgName()}
+        active={grouping.getHideOrgName() || issues.getHideBots()}
         showBadge={false}
         sections={[visibilityFilterSection]}
         resetLabel="Reset visibility"
-        onReset={() => grouping.setHideOrgName(false)}
+        onReset={resetVisibility}
         minWidth="180px"
       />
     </div>

--- a/packages/ui/src/stores/issues.svelte.test.ts
+++ b/packages/ui/src/stores/issues.svelte.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import type { Issue } from "../api/types.js";
+import type { MiddlemanClient } from "../types.js";
+import { dismissFlash, getFlash, getFlashes } from "./flash.svelte.js";
+import { createIssuesStore } from "./issues.svelte.js";
+
+afterEach(() => {
+  for (const item of getFlashes()) dismissFlash(item.id);
+});
+
+function issue(id: number, author: string): Issue {
+  return {
+    ID: id,
+    Number: id,
+    Title: `Issue ${id}`,
+    Author: author,
+    State: "open",
+    repo_owner: "acme",
+    repo_name: "widgets",
+    platform_host: "github.com",
+    repo: {
+      provider: "github",
+      platform_host: "github.com",
+      owner: "acme",
+      name: "widgets",
+      repo_path: "acme/widgets",
+    },
+  } as Issue;
+}
+
+describe("issues store bot visibility", () => {
+  it("hydrates the persisted preference and hides bot-authored issues", async () => {
+    const client = {
+      GET: vi.fn(async () => ({
+        data: [issue(1, "alice"), issue(2, "renovate[bot]"), issue(3, "release-bot")],
+        error: undefined,
+      })),
+    } as unknown as MiddlemanClient;
+    const store = createIssuesStore({ client });
+
+    await store.loadIssues();
+    store.hydrateDefaults({ hide_bots: true });
+
+    expect(store.getHideBots()).toBe(true);
+    expect(store.getIssues().map((item) => item.Author)).toEqual(["alice"]);
+  });
+
+  it("persists visibility changes and adopts the saved response", async () => {
+    const put = vi.fn(async () => ({
+      data: { issues: { hide_bots: true } },
+      error: undefined,
+    }));
+    const store = createIssuesStore({
+      client: { PUT: put } as unknown as MiddlemanClient,
+    });
+
+    await store.setHideBots(true);
+
+    expect(put).toHaveBeenCalledWith("/settings", {
+      body: { issues: { hide_bots: true } },
+    });
+    expect(store.getHideBots()).toBe(true);
+  });
+
+  it("restores the previous preference when persistence fails", async () => {
+    const store = createIssuesStore({
+      client: {
+        PUT: vi.fn(async () => ({
+          data: undefined,
+          error: { detail: "settings unavailable" },
+        })),
+      } as unknown as MiddlemanClient,
+    });
+
+    await store.setHideBots(true);
+
+    expect(store.getHideBots()).toBe(false);
+    expect(getFlash()).toMatchObject({ message: "settings unavailable", tone: "danger" });
+  });
+
+  it("restores the previous preference when the settings request throws", async () => {
+    const store = createIssuesStore({
+      client: {
+        PUT: vi.fn(async () => {
+          throw new Error("network unavailable");
+        }),
+      } as unknown as MiddlemanClient,
+    });
+
+    await store.setHideBots(true);
+
+    expect(store.getHideBots()).toBe(false);
+    expect(getFlash()).toMatchObject({ message: "network unavailable", tone: "danger" });
+  });
+});

--- a/packages/ui/src/stores/issues.svelte.test.ts
+++ b/packages/ui/src/stores/issues.svelte.test.ts
@@ -32,7 +32,13 @@ describe("issues store bot visibility", () => {
   it("hydrates the persisted preference and hides bot-authored issues", async () => {
     const client = {
       GET: vi.fn(async () => ({
-        data: [issue(1, "alice"), issue(2, "renovate[bot]"), issue(3, "release-bot")],
+        data: [
+          issue(1, "alice"),
+          issue(2, "renovate[bot]"),
+          issue(3, "release-bot"),
+          issue(4, "Talbot"),
+          issue(5, "Abbot"),
+        ],
         error: undefined,
       })),
     } as unknown as MiddlemanClient;
@@ -42,7 +48,7 @@ describe("issues store bot visibility", () => {
     store.hydrateDefaults({ hide_bots: true });
 
     expect(store.getHideBots()).toBe(true);
-    expect(store.getIssues().map((item) => item.Author)).toEqual(["alice"]);
+    expect(store.getIssues().map((item) => item.Author)).toEqual(["alice", "Talbot", "Abbot"]);
   });
 
   it("persists visibility changes and adopts the saved response", async () => {

--- a/packages/ui/src/stores/issues.svelte.test.ts
+++ b/packages/ui/src/stores/issues.svelte.test.ts
@@ -8,7 +8,7 @@ afterEach(() => {
   for (const item of getFlashes()) dismissFlash(item.id);
 });
 
-function issue(id: number, author: string): Issue {
+function issue(id: number, author: string, provider = "github"): Issue {
   return {
     ID: id,
     Number: id,
@@ -19,7 +19,7 @@ function issue(id: number, author: string): Issue {
     repo_name: "widgets",
     platform_host: "github.com",
     repo: {
-      provider: "github",
+      provider,
       platform_host: "github.com",
       owner: "acme",
       name: "widgets",
@@ -34,10 +34,14 @@ describe("issues store bot visibility", () => {
       GET: vi.fn(async () => ({
         data: [
           issue(1, "alice"),
-          issue(2, "renovate[bot]"),
-          issue(3, "release-bot"),
-          issue(4, "Talbot"),
-          issue(5, "Abbot"),
+          issue(2, "renovate[bot]", "github"),
+          issue(3, "project_123_bot_4ffca233d8298ea1", "gitlab"),
+          issue(4, "group_456_bot_8ea14ffca233d829", "gitlab"),
+          issue(5, "release-bot", "forgejo"),
+          issue(6, "renovate-bot", "gitea"),
+          issue(7, "Talbot", "github"),
+          issue(8, "Abbot", "gitea"),
+          issue(9, "project_alpha_bot_build", "gitlab"),
         ],
         error: undefined,
       })),
@@ -48,7 +52,12 @@ describe("issues store bot visibility", () => {
     store.hydrateDefaults({ hide_bots: true });
 
     expect(store.getHideBots()).toBe(true);
-    expect(store.getIssues().map((item) => item.Author)).toEqual(["alice", "Talbot", "Abbot"]);
+    expect(store.getIssues().map((item) => item.Author)).toEqual([
+      "alice",
+      "Talbot",
+      "Abbot",
+      "project_alpha_bot_build",
+    ]);
   });
 
   it("persists visibility changes and adopts the saved response", async () => {

--- a/packages/ui/src/stores/issues.svelte.test.ts
+++ b/packages/ui/src/stores/issues.svelte.test.ts
@@ -77,6 +77,43 @@ describe("issues store bot visibility", () => {
     expect(store.getHideBots()).toBe(true);
   });
 
+  it("prevents out-of-order responses by serializing rapid visibility changes", async () => {
+    let resolveFirst!: (response: { data: { issues: { hide_bots: boolean } }; error: undefined }) => void;
+    const firstResponse = new Promise<{
+      data: { issues: { hide_bots: boolean } };
+      error: undefined;
+    }>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const put = vi
+      .fn()
+      .mockImplementationOnce(async () => firstResponse)
+      .mockResolvedValueOnce({
+        data: { issues: { hide_bots: false } },
+        error: undefined,
+      });
+    const store = createIssuesStore({
+      client: { PUT: put } as unknown as MiddlemanClient,
+    });
+
+    const hide = store.setHideBots(true);
+    const show = store.setHideBots(false);
+
+    expect(store.getHideBots()).toBe(false);
+    expect(put).toHaveBeenCalledTimes(1);
+
+    resolveFirst({
+      data: { issues: { hide_bots: true } },
+      error: undefined,
+    });
+    await vi.waitFor(() => expect(put).toHaveBeenCalledTimes(2));
+    expect(store.getHideBots()).toBe(false);
+
+    await Promise.all([hide, show]);
+    expect(put.mock.calls.map(([, options]) => options.body.issues.hide_bots)).toEqual([true, false]);
+    expect(store.getHideBots()).toBe(false);
+  });
+
   it("restores the previous preference when persistence fails", async () => {
     const store = createIssuesStore({
       client: {

--- a/packages/ui/src/stores/issues.svelte.ts
+++ b/packages/ui/src/stores/issues.svelte.ts
@@ -63,11 +63,14 @@ function strongerSyncMode(a: IssueDetailSyncMode, b: IssueDetailSyncMode): Issue
   return syncIntentRank(b) > syncIntentRank(a) ? b : a;
 }
 
-const BOT_SUFFIXES = ["[bot]", "-bot"];
+const GITLAB_RESOURCE_BOT_USERNAME = /^(?:project|group)_\d+_bot_[a-z0-9]+$/;
 
-function isBotAuthor(author: string): boolean {
-  const lower = author.toLowerCase();
-  return BOT_SUFFIXES.some((suffix) => lower.endsWith(suffix));
+function isBotAuthor(issue: Issue): boolean {
+  const author = issue.Author.toLowerCase();
+  if (author.endsWith("-bot")) return true;
+  if (issue.repo.provider === "github") return author.endsWith("[bot]");
+  if (issue.repo.provider === "gitlab") return GITLAB_RESOURCE_BOT_USERNAME.test(author);
+  return false;
 }
 
 export function createIssuesStore(opts: IssuesStoreOptions) {
@@ -129,7 +132,7 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
 
   function getIssues(): Issue[] {
     if (!hideBots) return issues;
-    return issues.filter((issue) => !isBotAuthor(issue.Author));
+    return issues.filter((issue) => !isBotAuthor(issue));
   }
 
   function getHideBots(): boolean {

--- a/packages/ui/src/stores/issues.svelte.ts
+++ b/packages/ui/src/stores/issues.svelte.ts
@@ -63,7 +63,7 @@ function strongerSyncMode(a: IssueDetailSyncMode, b: IssueDetailSyncMode): Issue
   return syncIntentRank(b) > syncIntentRank(a) ? b : a;
 }
 
-const BOT_SUFFIXES = ["[bot]", "-bot", "bot"];
+const BOT_SUFFIXES = ["[bot]", "-bot"];
 
 function isBotAuthor(author: string): boolean {
   const lower = author.toLowerCase();

--- a/packages/ui/src/stores/issues.svelte.ts
+++ b/packages/ui/src/stores/issues.svelte.ts
@@ -1,4 +1,4 @@
-import type { Issue, IssueDetail, IssuesParams, Label } from "../api/types.js";
+import type { Issue, IssueDetail, IssuesParams, IssueSettings, Label } from "../api/types.js";
 import {
   providerDefaultHost,
   providerItemPath,
@@ -63,6 +63,13 @@ function strongerSyncMode(a: IssueDetailSyncMode, b: IssueDetailSyncMode): Issue
   return syncIntentRank(b) > syncIntentRank(a) ? b : a;
 }
 
+const BOT_SUFFIXES = ["[bot]", "-bot", "bot"];
+
+function isBotAuthor(author: string): boolean {
+  const lower = author.toLowerCase();
+  return BOT_SUFFIXES.some((suffix) => lower.endsWith(suffix));
+}
+
 export function createIssuesStore(opts: IssuesStoreOptions) {
   const apiClient = opts.client;
   const getGlobalRepo = opts.getGlobalRepo ?? (() => undefined);
@@ -79,6 +86,7 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
   // --- list state ---
 
   let issues = $state<Issue[]>([]);
+  let hideBots = $state(false);
   let loading = $state(false);
   let storeError = $state<string | null>(null);
   let filterStarred = $state(false);
@@ -120,7 +128,12 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
   // --- list reads ---
 
   function getIssues(): Issue[] {
-    return issues;
+    if (!hideBots) return issues;
+    return issues.filter((issue) => !isBotAuthor(issue.Author));
+  }
+
+  function getHideBots(): boolean {
+    return hideBots;
   }
   function isIssuesLoading(): boolean {
     return loading;
@@ -140,7 +153,7 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
 
   function issuesByRepo(): Map<string, Issue[]> {
     const map = new Map<string, Issue[]>();
-    for (const issue of issues) {
+    for (const issue of getIssues()) {
       const key = issueIdentityKey(issueRef(issue));
       const existing = map.get(key);
       if (existing) existing.push(issue);
@@ -222,6 +235,27 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
   }
   function setIssueFilterState(s: string): void {
     filterState = s;
+  }
+
+  function hydrateDefaults(settings: IssueSettings): void {
+    hideBots = settings.hide_bots;
+  }
+
+  async function setHideBots(value: boolean): Promise<void> {
+    const previous = hideBots;
+    hideBots = value;
+    try {
+      const { data, error: requestError } = await apiClient.PUT("/settings", {
+        body: { issues: { hide_bots: value } },
+      });
+      if (!data) {
+        throw new Error(apiErrorMessage(requestError ?? {}, "failed to save issue visibility"));
+      }
+      hideBots = data.issues.hide_bots;
+    } catch (err) {
+      hideBots = previous;
+      showFlash(err instanceof Error ? err.message : "failed to save issue visibility", { tone: "danger" });
+    }
   }
 
   function selectIssue(
@@ -977,7 +1011,7 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
       }
       return ordered;
     }
-    return issues;
+    return getIssues();
   }
 
   function selectNextIssue(): void {
@@ -1048,6 +1082,7 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
 
   return {
     getIssues,
+    getHideBots,
     isIssuesLoading,
     getIssuesError,
     getSelectedIssue,
@@ -1057,6 +1092,8 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
     setIssueSearchQuery,
     getIssueFilterState,
     setIssueFilterState,
+    hydrateDefaults,
+    setHideBots,
     issuesByRepo,
     selectIssue,
     clearIssueSelection,

--- a/packages/ui/src/stores/issues.svelte.ts
+++ b/packages/ui/src/stores/issues.svelte.ts
@@ -90,6 +90,9 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
 
   let issues = $state<Issue[]>([]);
   let hideBots = $state(false);
+  let confirmedHideBots = false;
+  let hideBotsMutationGeneration = 0;
+  let hideBotsSave: Promise<void> | null = null;
   let loading = $state(false);
   let storeError = $state<string | null>(null);
   let filterStarred = $state(false);
@@ -242,23 +245,40 @@ export function createIssuesStore(opts: IssuesStoreOptions) {
 
   function hydrateDefaults(settings: IssueSettings): void {
     hideBots = settings.hide_bots;
+    confirmedHideBots = settings.hide_bots;
+  }
+
+  async function persistHideBots(): Promise<void> {
+    for (;;) {
+      const generation = hideBotsMutationGeneration;
+      const value = hideBots;
+      try {
+        const { data, error: requestError } = await apiClient.PUT("/settings", {
+          body: { issues: { hide_bots: value } },
+        });
+        if (!data) {
+          throw new Error(apiErrorMessage(requestError ?? {}, "failed to save issue visibility"));
+        }
+        confirmedHideBots = data.issues.hide_bots;
+        if (generation !== hideBotsMutationGeneration) continue;
+        hideBots = confirmedHideBots;
+        return;
+      } catch (err) {
+        if (generation !== hideBotsMutationGeneration) continue;
+        hideBots = confirmedHideBots;
+        showFlash(err instanceof Error ? err.message : "failed to save issue visibility", { tone: "danger" });
+        return;
+      }
+    }
   }
 
   async function setHideBots(value: boolean): Promise<void> {
-    const previous = hideBots;
     hideBots = value;
-    try {
-      const { data, error: requestError } = await apiClient.PUT("/settings", {
-        body: { issues: { hide_bots: value } },
-      });
-      if (!data) {
-        throw new Error(apiErrorMessage(requestError ?? {}, "failed to save issue visibility"));
-      }
-      hideBots = data.issues.hide_bots;
-    } catch (err) {
-      hideBots = previous;
-      showFlash(err instanceof Error ? err.message : "failed to save issue visibility", { tone: "danger" });
-    }
+    hideBotsMutationGeneration += 1;
+    hideBotsSave ??= persistHideBots().finally(() => {
+      hideBotsSave = null;
+    });
+    await hideBotsSave;
   }
 
   function selectIssue(

--- a/packages/ui/src/views/FocusListView.svelte
+++ b/packages/ui/src/views/FocusListView.svelte
@@ -239,6 +239,15 @@
           onclick={() => grouping.setGroupingMode("flat")}
         >All</button>
       </div>
+    {:else}
+      <button
+        type="button"
+        class="visibility-btn"
+        class:visibility-btn--active={issues.getHideBots()}
+        aria-label="Hide bot-authored issues"
+        aria-pressed={issues.getHideBots()}
+        onclick={() => void issues.setHideBots(!issues.getHideBots())}
+      >Hide bots</button>
     {/if}
   </div>
   <div class="search-bar">
@@ -422,7 +431,8 @@
     margin-left: auto;
   }
 
-  .group-btn {
+  .group-btn,
+  .visibility-btn {
     font-size: var(--font-size-xs);
     padding: 2px 8px;
     border: none;
@@ -433,10 +443,23 @@
     white-space: nowrap;
   }
 
+  .visibility-btn {
+    margin-left: auto;
+    border: 1px solid var(--border-default);
+    background: var(--bg-inset);
+    font-weight: 600;
+  }
+
   .group-btn--active {
     background: var(--bg-surface);
     color: var(--text-primary);
     box-shadow: var(--shadow-sm);
+  }
+
+  .visibility-btn--active {
+    color: var(--accent-blue);
+    background: color-mix(in srgb, var(--accent-blue) 12%, transparent);
+    border-color: color-mix(in srgb, var(--accent-blue) 34%, transparent);
   }
 
   .workflow-group {
@@ -577,7 +600,8 @@
   }
 
   :global(.mobile-main) .state-btn,
-  :global(.mobile-main) .group-btn {
+  :global(.mobile-main) .group-btn,
+  :global(.mobile-main) .visibility-btn {
     min-height: var(--focus-mobile-hit-target);
     border-radius: var(--focus-mobile-radius-sm);
     padding: var(--focus-mobile-space-xs) var(--focus-mobile-space-sm);


### PR DESCRIPTION
Bot-created maintenance issues can permanently occupy the open issue queue even though maintainers rarely need them in daily triage.

- Add a persisted **Hide bot-authored issues** visibility preference to issue lists.
- Apply the preference across issue counts and list consumers while retaining synced data and direct links.