### PR TITLE
docs: route agent context by task

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,13 +74,6 @@ only routes to them.
 - Tests, docs, fixtures, commit messages, and PR text should use generic synthetic examples unless the user explicitly asks to preserve exact private project names, paths, prose, or domain details.
 - **Never use npm** — use `bun install` for frontend dependencies and invoke Vite+ directly via `./node_modules/.bin/vp ...` (or `../node_modules/.bin/vp ...` from `frontend/`). Never run `npm install` or `npm run` — this creates `package-lock.json` which conflicts with the bun lockfile
 - No emojis in code or output
-- For database schema changes, follow `context/db-migrations.md`; `internal/db/migrations/` is the source of truth for schema evolution.
-- For HTTP API error envelopes and frontend error branching, follow `context/error-handling.md`; branch on stable codes/details rather than prose.
-- For retries, backoff, and single-flight dedup against flaky upstreams, follow `context/retries-and-backoffs.md`.
-- For frontend UI and TypeScript/Svelte conventions, follow `context/ui-design-system.md`; prefer extending shared UI primitives over adding one-off local badge/chip/button styling, and name reused domain object shapes instead of repeating anonymous inline types.
-- For mobile, phone, narrow-viewport, touch, or `/m` route work, follow `context/mobile-ux.md`; mobile UX is a phone-first workflow, not desktop UI resized under mobile routes.
-- For Kata task authority, daemon integration, and workspace behavior, follow `context/workspace-apis.md`.
-- For Docs mode integration, follow `docs/superpowers/specs/2026-06-08-kata-docs-msgvault-modes-design.md` until dedicated context docs exist; its Messages/msgvault sections are historical (that mode was removed).
 - Datetimes are UTC across storage and API boundaries. Store timestamps in UTC, emit API timestamps as UTC RFC3339, and only convert to local time in the Svelte UI presentation layer.
 
 ## Roborev

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,8 +51,8 @@ only routes to them.
 | Workflow or terminal panel interaction models | `context/vscode-workflow-panel-interaction-spec.md` |
 | Workspace APIs, creation, or item identity | `context/workspace-apis.md` |
 | Workspace deletion, runtime sessions, tmux, or terminal UI | `context/workspace-runtime-lifecycle.md` |
-| Inline diff review comments | `context/inline-diff-review-comments-plan.md` |
-| Kata daemon integration, task UI, or Kata workspaces | `context/kata-mode.md`, `context/workspace-apis.md` |
+| Inline diff review comments | `context/inline-review-comments.md` |
+| Kata task authority, daemon integration, task UI, or Kata workspaces | `context/kata-mode.md`, `context/workspace-apis.md` |
 | Markdown folders, Docs APIs, or git publishing | `context/docs-mode.md` |
 
 ## Conventions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,14 +44,14 @@ only routes to them.
 | Test lanes, provider tests, API contracts, or HTTP tests | `context/testing.md` |
 | Agent hooks, session bootstrap, or dependency installation | `context/agent-bootstrap.md` |
 | User documentation, screenshots, or the Zensical site | `context/docs-authoring.md` |
-| Pushing, opening a pull request, or changing PR metadata | `context/pull-request-workflow.md` |
+| Pushing, opening a pull request, or changing PR metadata, comments, or review threads | `context/pull-request-workflow.md` |
 | Frontend visual design or component conventions | `context/ui-design-system.md` |
 | Frontend interaction, route state, persistence, or input semantics | `context/ui-interaction-contracts.md` |
 | Phone routes, narrow layouts, or touch UX | `context/mobile-ux.md` |
 | Workflow or terminal panel interaction models | `context/vscode-workflow-panel-interaction-spec.md` |
 | Workspace APIs, creation, or item identity | `context/workspace-apis.md` |
 | Workspace deletion, runtime sessions, tmux, or terminal UI | `context/workspace-runtime-lifecycle.md` |
-| Inline diff review comments | `context/inline-review-comments.md` |
+| Inline diff review drafts, comments, or threads | `context/inline-review-comments.md` |
 | Kata task authority, daemon integration, task UI, or Kata workspaces | `context/kata-mode.md`, `context/workspace-apis.md` |
 | Markdown folders, Docs APIs, or git publishing | `context/docs-mode.md` |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ only routes to them.
 | API failures or frontend error branching | `context/error-handling.md` |
 | Retries, rate limits, scheduling, or single-flight work | `context/retries-and-backoffs.md` |
 | Test design, test placement, or test helpers | `context/testing.md` |
+| User documentation, screenshots, or the Zensical site | `context/docs-authoring.md` |
 | Frontend visual design or component conventions | `context/ui-design-system.md` |
 | Frontend interaction, route state, persistence, or input semantics | `context/ui-interaction-contracts.md` |
 | Phone routes, narrow layouts, or touch UX | `context/mobile-ux.md` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,18 +38,19 @@ only routes to them.
 | Database schema migrations | `context/db-migrations.md` |
 | Deferred merge behavior | `context/deferred-merge.md` |
 | Embed routes or host bridges | `context/embeds.md` |
+| Daemon startup, discovery, host/origin validation, or SSE replay | `context/server-runtime.md` |
 | API failures or frontend error branching | `context/error-handling.md` |
 | Retries, rate limits, scheduling, or single-flight work | `context/retries-and-backoffs.md` |
 | Go test commands, assertions, fixtures, or shell tests | `context/testing-basics.md` |
 | Test lanes, provider tests, API contracts, or HTTP tests | `context/testing.md` |
-| Agent hooks, session bootstrap, or dependency installation | `context/agent-bootstrap.md` |
+| Repository-controlled session bootstrap or dependency installation | `context/agent-bootstrap.md` |
 | User documentation, screenshots, or the Zensical site | `context/docs-authoring.md` |
 | Pushing, opening a pull request, or changing PR metadata, comments, or review threads | `context/pull-request-workflow.md` |
 | Frontend visual design or component conventions | `context/ui-design-system.md` |
 | Frontend interaction, route state, persistence, or input semantics | `context/ui-interaction-contracts.md` |
 | Phone routes, narrow layouts, or touch UX | `context/mobile-ux.md` |
 | Workflow or terminal panel interaction models | `context/vscode-workflow-panel-interaction-spec.md` |
-| Workspace APIs, creation, or item identity | `context/workspace-apis.md` |
+| Workspace APIs, creation, item identity, lifecycle hooks, or generated launch context | `context/workspace-apis.md` |
 | Workspace deletion, runtime sessions, tmux, or terminal UI | `context/workspace-runtime-lifecycle.md` |
 | Inline diff review drafts, comments, or threads | `context/inline-review-comments.md` |
 | Kata task authority, daemon integration, task UI, or Kata workspaces | `context/kata-mode.md`, `context/workspace-apis.md` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,20 +11,11 @@ development commands.
 
 ## Provider Support
 
-kenn-forge supports GitHub, GitLab, Forgejo, and Gitea. The `gitealike` package is the shared Forgejo/Gitea adapter.
-
-This paragraph is the single place CLAUDE.md enumerates supported providers. Do not duplicate the list elsewhere in this file: not in the architecture diagram, env-var lists, project structure, key files, or test guidance. Adding or removing a provider updates this paragraph only. Mentioning a specific provider in context (for example, GitHub-only optimizations in `internal/github/`) is fine when it describes real artifacts, not when it restates the supported set.
-
-New features must work across every supported provider to the extent each provider's API allows. Concrete rules:
-
-- Provider-specific capability differences go behind the capability model in `internal/platform`. Declare capabilities in `Capabilities()`, check them before mutations, and return typed `unsupported_capability` errors when a provider can't satisfy an operation. Do not silently fall back to GitHub-only behavior for other providers.
-- A provider-verified repository is canonically identified by `(provider, platform_host, provider_repo_id)`; owner/repo is a mutable route. Route-only references still require provider and host, and must not be promoted or combined without a verified stable ID.
-- Never identify, route, cache, dedupe, query, persist, or compare repositories, pull requests, merge requests, issues, comments, checks, releases, workspaces, activity, or events by owner/repo/number alone. Every repo-scoped path and data structure must carry provider and host as well as owner and repo.
-- Repo-scoped routes use provider-aware paths like `/pulls/{provider}/{owner}/{name}/{number}`, with `/host/{platform_host}/...` for non-default or self-hosted instances.
-- GitHub-only optimizations (GraphQL bulk fetch, ETag recovery, detailed diff behavior) stay in `internal/github/` and remain optional around the neutral persistence path.
-- Frontend stores and components must thread the full provider ref (`provider`, `platformHost`, `owner`, `name`, `repoPath`) through the shared route helpers in `packages/ui/src/api/provider-routes.ts`. Do not hand-build `/api/v1` URLs or assume GitHub defaults inside components.
-
-For package layout and the new-provider checklist, see `context/provider-architecture.md`. For identity, tokens, freshness, and route shape, see `context/platform-sync-invariants.md`. For GitHub-only sync behavior, see `context/github-sync-invariants.md`.
+kenn-forge supports GitHub, GitLab, Forgejo, and Gitea. This is the single
+canonical provider list; `gitealike` is the shared Forgejo/Gitea adapter.
+Provider-backed features must work across every supported provider within its
+declared capabilities and preserve provider-verified stable repository identity;
+owner/name remains a mutable route. The routing table below owns the detailed rules.
 
 ## Non-Provider Modes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,33 @@ Kata and Docs are first-class kenn-forge modes, but they are not platform provid
 - Docs mode operates on explicitly configured local markdown folders. Treat folder reads, writes, deletes, browse, and git publish as local filesystem surfaces requiring explicit path safety, CSRF, and loopback-access decisions.
 - These modes may link to each other, but their data ownership remains separate: provider PR/MR data lives in kenn-forge's SQLite DB, Kata task data stays in external Kata daemons, and docs files stay on disk.
 
+## Context Routing
+
+Read the smallest relevant set of topic documents before changing or reviewing
+the corresponding area. These documents own the detailed invariants; this file
+only routes to them.
+
+| When working on | Read |
+| --- | --- |
+| Provider interfaces or package boundaries | `context/provider-architecture.md` |
+| Provider identity, sync, import, routes, or settings | `context/platform-sync-invariants.md` |
+| GitHub-specific sync or notifications | `context/github-sync-invariants.md`, `context/notifications-in-activity.md` |
+| Config fields that persist to TOML | `context/config-persistence.md` |
+| Database schema migrations | `context/db-migrations.md` |
+| Deferred merge behavior | `context/deferred-merge.md` |
+| Embed routes or host bridges | `context/embeds.md` |
+| API failures or frontend error branching | `context/error-handling.md` |
+| Retries, rate limits, scheduling, or single-flight work | `context/retries-and-backoffs.md` |
+| Test design, test placement, or test helpers | `context/testing.md` |
+| Frontend visual design or component conventions | `context/ui-design-system.md` |
+| Frontend interaction, route state, persistence, or input semantics | `context/ui-interaction-contracts.md` |
+| Phone routes, narrow layouts, or touch UX | `context/mobile-ux.md` |
+| Workflow or terminal panel interaction models | `context/vscode-workflow-panel-interaction-spec.md` |
+| Workspace APIs, creation, or item identity | `context/workspace-apis.md` |
+| Workspace deletion, runtime sessions, tmux, or terminal UI | `context/workspace-runtime-lifecycle.md` |
+| Inline diff review comments | `context/inline-diff-review-comments-plan.md` |
+| Kata, Docs, or Messages/msgvault modes | `docs/superpowers/specs/2026-06-08-kata-docs-msgvault-modes-design.md` |
+
 ## Project Structure
 
 - `cmd/kenn-forge/` - Go server entrypoint

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ only routes to them.
 | Retries, rate limits, scheduling, or single-flight work | `context/retries-and-backoffs.md` |
 | Test design, test placement, or test helpers | `context/testing.md` |
 | User documentation, screenshots, or the Zensical site | `context/docs-authoring.md` |
+| Pushing, opening a pull request, or changing PR metadata | `context/pull-request-workflow.md` |
 | Frontend visual design or component conventions | `context/ui-design-system.md` |
 | Frontend interaction, route state, persistence, or input semantics | `context/ui-interaction-contracts.md` |
 | Phone routes, narrow layouts, or touch UX | `context/mobile-ux.md` |
@@ -234,16 +235,3 @@ Coverage of real behavior is non-negotiable; the lane is chosen by the behavior 
 - Run tests before committing when applicable
 - Before pushing any frontend change, you must have run the full affected suite locally after the final frontend/test edit — the full `vp test` Vitest run, plus the full affected Playwright e2e suite whenever the change touches Playwright specs or the shared mock fixtures they rely on; type checks and CI-only verification are not enough.
 - Never push new workstreams unless explicitly asked. When addressing review feedback or CI failures on an existing PR, an agent may push after the fix is implemented and relevant local validation has run.
-
-## Pull Requests
-
-- Treat this as a public repository: before pushing or opening a PR, run the scrub-private-data skill and remove unnecessary internal project names, hostnames, credentials, runner topology, and infrastructure details from the diff, commit messages, and PR metadata.
-- Do not watch or poll pull-request GitHub Actions checks unless the user explicitly asks, or the work is being performed through the `$kenn:refine-pr` skill.
-- This public repository runs same-repository pull requests through main-branch reusable workflows on organization-managed ephemeral self-hosted runners. Fork pull requests use GitHub-hosted runners, even when the author is an organization member; trust is determined by the head repository, not author association. Every external fork workflow run also requires explicit approval.
-- Never delete, minimize, hide, resolve, or otherwise remove PR comments, review comments, review threads, or CI/review bot comments unless the user explicitly asks for that exact action. If a comment is stale, false-positive, superseded, or contradicted by current evidence, leave it in place and explain the evidence in a reply or final report instead.
-- PR descriptions should be concise: summarize what changed, not how or why in detail
-- When a PR adds or changes visible UI, use the `capture-playwright` skill to capture a Playwright screenshot or short video and attach it with `gh image`
-- Do this before opening the PR so the description can include the visual artifact links
-- No test plans, implementation details, or checklists in PR descriptions
-- No marketing language (critical, robust, comprehensive, etc.)
-- A bulleted summary of user-visible changes is sufficient

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,28 +1,13 @@
-# Claude Code Instructions
+# Kenn Forge Agent Instructions
 
-## Project Overview
+## Project Model
 
-kenn-forge is a local-first maintainer console. Its original core is a dashboard for tracking pull and merge requests across a maintainer's fixed set of repositories on multiple platforms: it syncs PR/MR data into SQLite on a timer, serves a Svelte 5 SPA via an embedded Go HTTP server, and provides a focused workflow for triage, review, and merge from one place rather than each provider's notification UI. The product also includes first-class modes for external Kata task daemons and markdown docs without moving those domains into the provider registry.
-
-## Architecture
-
-```
-CLI (kenn-forge) → Config (TOML) → DB (SQLite)
-                    ↓                ↓
-               Sync Engine → Platform Registry → Provider Clients
-                    ↓                ↓
-               HTTP Server → REST API + Embedded SPA
-                    ↓
-          App Modes (PRs/issues, Kata, Docs)
-```
-
-- **Server**: Huma-based HTTP server on loopback (default 127.0.0.1:8091)
-- **Storage**: SQLite with WAL mode (pure Go driver: modernc.org/sqlite)
-- **Sync**: Periodic pull from each configured provider host (configurable, default 5m)
-- **Kata**: External daemon client mode; daemon catalog comes from Kata's own `$KATA_HOME/config.toml` and runtime records, not kenn-forge config
-- **Docs**: Configured markdown folders with filesystem-safe browse/read/write/search/git publish behavior
-- **Frontend**: Svelte 5 SPA embedded in the Go binary at build time
-- **Config**: TOML at `~/.kenn/forge/config.toml`; per-provider `KENN_FORGE_<PROVIDER>_TOKEN` env vars (with optional repo-level `token_env` overrides). Optional `[[github_apps]]` entries (written by the `kenn-forge-github-app` CLI) authenticate GitHub sync reads with app installation tokens ahead of PATs to relieve rate limits; mutations (merges, comments, state changes) stay on the user's PAT chain so they remain attributed to the user
+Kenn Forge is a local-first maintainer console. A Go/Huma server syncs
+provider-backed pull requests, issues, and activity into SQLite and serves an
+embedded Svelte 5 SPA. Kata and Docs are separate first-class modes whose data
+remains owned by their external or filesystem domains. The project builds
+without CGO; use the README and Makefile for discoverable setup, build, and
+development commands.
 
 ## Provider Support
 
@@ -77,64 +62,8 @@ only routes to them.
 | Workspace APIs, creation, or item identity | `context/workspace-apis.md` |
 | Workspace deletion, runtime sessions, tmux, or terminal UI | `context/workspace-runtime-lifecycle.md` |
 | Inline diff review comments | `context/inline-diff-review-comments-plan.md` |
-| Kata, Docs, or Messages/msgvault modes | `docs/superpowers/specs/2026-06-08-kata-docs-msgvault-modes-design.md` |
-
-## Project Structure
-
-- `cmd/kenn-forge/` - Go server entrypoint
-- `cmd/kenn-forge-github-app/` - CLI that creates and manages GitHub Apps (browser manifest flow) whose installation tokens kenn-forge uses instead of PATs
-- `internal/config/` - TOML config loading and validation
-- `internal/githubapp/` - GitHub App manifest flow, app JWT signing, installation token minting
-- `internal/db/` - SQLite schema, connection, queries, types
-- `internal/kata/` - Kata daemon catalog/runtime discovery, health, and proxy integration
-- `internal/docs/` - Markdown folder filesystem, search, and git-publish support
-- `internal/platform/` - Provider-neutral types, capability interfaces, registry, persistence helpers
-- `internal/platform/<provider>/` - Per-provider API transport and normalization
-- `internal/github/` - GitHub-only sync orchestration (GraphQL bulk fetch, ETag/rate-limit transports) consumed by the platform registry
-- `internal/server/` - HTTP handlers and routing
-- `internal/web/` - Embedded frontend (dist/ copied at build time)
-- `frontend/` - Svelte 5 SPA (Vite, TypeScript)
-
-## Key Files
-
-| Path                                         | Purpose                                                                                           |
-| -------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| `cmd/kenn-forge/main.go`                      | CLI entry point, server startup, signal handling                                                  |
-| `internal/config/config.go`                  | TOML config, validation, defaults                                                                 |
-| `internal/db/migrations/`                    | Numbered SQL migrations for schema changes                                                        |
-| `internal/db/db.go`                          | Database open, WAL, migration init                                                                |
-| `internal/db/queries.go`                     | All CRUD operations                                                                               |
-| `internal/db/types.go`                       | DB model types                                                                                    |
-| `internal/kata/`                             | External Kata daemon discovery, selection, health, and passthrough transport                      |
-| `internal/docs/`                             | Markdown folder registry, safe file operations, search, and git publish                           |
-| `internal/platform/types.go`                 | Provider-neutral domain types (Repository, MergeRequest, Issue, events, labels, releases, checks) |
-| `internal/platform/registry.go`              | `(platform, platform_host)` provider lookup and capability error types                            |
-| `internal/platform/metadata.go`              | Provider metadata (kind, label, default host, owner casing/nesting behavior)                      |
-| `internal/platform/persist.go`               | Conversion between neutral platform types and DB rows                                             |
-| `internal/platform/<provider>/`              | Per-provider client, normalization, and capability implementations                                |
-| `internal/github/client.go`                  | GitHub SDK transport used by `internal/platform/github`                                           |
-| `internal/github/sync.go`                    | Periodic sync engine (dispatches per-provider work through the platform registry)                 |
-| `internal/github/graphql.go`                 | GitHub-only GraphQL bulk-fetch optimization                                                       |
-| `internal/server/server.go`                  | HTTP router, SPA serving                                                                          |
-| `internal/server/huma_routes.go`             | Huma API registrations and handlers                                                               |
-| `internal/server/api_types.go`               | Shared API response types used by Huma                                                            |
-| `internal/apiclient/generated/client.gen.go` | Generated Go API client from the checked-in OpenAPI spec                                          |
-| `frontend/src/App.svelte`                    | Root component, view routing                                                                      |
-| `frontend/src/app.css`                       | Design tokens, theme, global styles                                                               |
-| `frontend/src/lib/stores/`                   | Svelte 5 rune-based stores                                                                        |
-| `frontend/src/lib/components/`               | UI components (sidebar, detail, app modes)                                                        |
-
-## Development
-
-```bash
-make build          # Build binary with embedded frontend
-make dev            # Run Go server in dev mode
-make frontend       # Build frontend SPA only
-make frontend-dev   # Run Vite dev server (use alongside make dev)
-make install        # Build and install to ~/.local/bin or GOPATH
-```
-
-For development, run `make dev` and `make frontend-dev` in parallel. Vite proxies `/api` to the Go server on :8091.
+| Kata daemon integration, task UI, or Kata workspaces | `context/kata-mode.md`, `context/workspace-apis.md` |
+| Markdown folders, Docs APIs, or git publishing | `context/docs-mode.md` |
 
 ## Testing
 
@@ -175,12 +104,7 @@ Coverage of real behavior is non-negotiable; the lane is chosen by the behavior 
   tautological and should be replaced with real execution, parser/tool-native
   validation, or a documented manual release check.
 - Do not run tests with `-v` (especially `go test`) — default output has enough signal to debug failures, and verbose output wastes tokens. Only use `-v` if the user asks for it or a failure genuinely needs the extra detail
-- For provider-specific live or container test fixtures used when fake transports can't catch endpoint or auth drift, follow `context/testing.md` and `context/platform-sync-invariants.md`. The GitHub GraphQL gate is `KENN_FORGE_LIVE_GITHUB_TESTS=1`.
-
-## Build Requirements
-
-- **No CGO required** — uses modernc.org/sqlite (pure Go)
-- **Frontend**: Vite+ for Svelte build/test/check tooling with Bun used for dependency installation, embedded via `internal/web/dist/`
+- For provider-specific live or container test fixtures used when fake transports can't catch endpoint or auth drift, follow `context/testing.md` and `context/platform-sync-invariants.md`. The GitHub GraphQL gate is `MIDDLEMAN_LIVE_GITHUB_TESTS=1`.
 
 ## Conventions
 
@@ -203,13 +127,12 @@ Coverage of real behavior is non-negotiable; the lane is chosen by the behavior 
 - Tests should be fast and isolated
 - No emojis in code or output
 - For database schema changes, follow `context/db-migrations.md`; `internal/db/migrations/` is the source of truth for schema evolution.
-- For daemon startup, Host validation, and process-scoped SSE replay, follow `context/server-runtime.md`.
 - For HTTP API error envelopes and frontend error branching, follow `context/error-handling.md`; branch on stable codes/details rather than prose.
 - For retries, backoff, and single-flight dedup against flaky upstreams, follow `context/retries-and-backoffs.md`.
 - For frontend UI and TypeScript/Svelte conventions, follow `context/ui-design-system.md`; prefer extending shared UI primitives over adding one-off local badge/chip/button styling, and name reused domain object shapes instead of repeating anonymous inline types.
 - For mobile, phone, narrow-viewport, touch, or `/m` route work, follow `context/mobile-ux.md`; mobile UX is a phone-first workflow, not desktop UI resized under mobile routes.
-- For Kata daemon discovery and ownership boundaries, follow `context/kata-mode.md`; for task authority and workspace behavior, follow `context/workspace-apis.md`.
-- For Docs mode filesystem, access, config, and git-publish boundaries, follow `context/docs-mode.md`.
+- For Kata task authority, daemon integration, and workspace behavior, follow `context/workspace-apis.md`.
+- For Docs mode integration, follow `docs/superpowers/specs/2026-06-08-kata-docs-msgvault-modes-design.md` until dedicated context docs exist; its Messages/msgvault sections are historical (that mode was removed).
 - Datetimes are UTC across storage and API boundaries. Store timestamps in UTC, emit API timestamps as UTC RFC3339, and only convert to local time in the Svelte UI presentation layer.
 
 ## Roborev

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,11 +19,9 @@ owner/name remains a mutable route. The routing table below owns the detailed ru
 
 ## Non-Provider Modes
 
-Kata and Docs are first-class kenn-forge modes, but they are not platform providers and do not use provider-neutral repository identity. Do not force them through `internal/platform` or provider capability abstractions.
-
-- Kata mode talks to external Kata daemons. Kenn Forge reads the Kata daemon catalog from `$KATA_HOME/config.toml` (default `~/.kata/config.toml`) and resolves `local = true` daemon entries from Kata runtime records. Kenn Forge config must not become the source of truth for Kata daemon definitions.
-- Docs mode operates on explicitly configured local markdown folders. Treat folder reads, writes, deletes, browse, and git publish as local filesystem surfaces requiring explicit path safety, CSRF, and loopback-access decisions.
-- These modes may link to each other, but their data ownership remains separate: provider PR/MR data lives in kenn-forge's SQLite DB, Kata task data stays in external Kata daemons, and docs files stay on disk.
+Kata and Docs are first-class modes, not platform providers. Do not force them
+through `internal/platform`: their data remains owned respectively by Kata
+daemons and configured filesystem folders.
 
 ## Context Routing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ only routes to them.
 | API failures or frontend error branching | `context/error-handling.md` |
 | Retries, rate limits, scheduling, or single-flight work | `context/retries-and-backoffs.md` |
 | Test design, test placement, or test helpers | `context/testing.md` |
+| Agent hooks, session bootstrap, or dependency installation | `context/agent-bootstrap.md` |
 | User documentation, screenshots, or the Zensical site | `context/docs-authoring.md` |
 | Pushing, opening a pull request, or changing PR metadata | `context/pull-request-workflow.md` |
 | Frontend visual design or component conventions | `context/ui-design-system.md` |
@@ -199,7 +200,6 @@ Coverage of real behavior is non-negotiable; the lane is chosen by the behavior 
 - Zensical resolves `docs_dir`/`site_dir` relative to the config file's directory, so `uvx zensical build` cannot run in place against the checked-in `docs/zensical.toml`; stage a scratch project root containing a copy of the config beside a copy of `docs/`, then build there.
 - Tests, docs, fixtures, commit messages, and PR text should use generic synthetic examples unless the user explicitly asks to preserve exact private project names, paths, prose, or domain details.
 - **Never use npm** — use `bun install` for frontend dependencies and invoke Vite+ directly via `./node_modules/.bin/vp ...` (or `../node_modules/.bin/vp ...` from `frontend/`). Never run `npm install` or `npm run` — this creates `package-lock.json` which conflicts with the bun lockfile
-- Repo-controlled agent `SessionStart` hooks may bootstrap frontend deps as a hard prerequisite for local tooling, but this is reduced execution surface rather than complete untrusted-PR protection if a runner blindly trusts changed hook config. Keep the command self-contained in the hook definition, avoid branch-controlled helper scripts or `Makefile` targets, prefer an existing `node_modules/vite-plus/bin/vp`, and use frozen-lockfile installs with lifecycle scripts disabled (`--ignore-scripts`) plus a post-install check for the local Vite+ entrypoint when installation is needed.
 - Tests should be fast and isolated
 - No emojis in code or output
 - For database schema changes, follow `context/db-migrations.md`; `internal/db/migrations/` is the source of truth for schema evolution.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,8 @@ only routes to them.
 | Embed routes or host bridges | `context/embeds.md` |
 | API failures or frontend error branching | `context/error-handling.md` |
 | Retries, rate limits, scheduling, or single-flight work | `context/retries-and-backoffs.md` |
-| Test design, test placement, or test helpers | `context/testing.md` |
+| Go test commands, assertions, fixtures, or shell tests | `context/testing-basics.md` |
+| Test lanes, provider tests, API contracts, or HTTP tests | `context/testing.md` |
 | Agent hooks, session bootstrap, or dependency installation | `context/agent-bootstrap.md` |
 | User documentation, screenshots, or the Zensical site | `context/docs-authoring.md` |
 | Pushing, opening a pull request, or changing PR metadata | `context/pull-request-workflow.md` |
@@ -53,47 +54,6 @@ only routes to them.
 | Inline diff review comments | `context/inline-diff-review-comments-plan.md` |
 | Kata daemon integration, task UI, or Kata workspaces | `context/kata-mode.md`, `context/workspace-apis.md` |
 | Markdown folders, Docs APIs, or git publishing | `context/docs-mode.md` |
-
-## Testing
-
-```bash
-make test       # All Go tests
-make test-short # Fast tests only
-make lint       # golangci-lint
-make vet        # go vet
-```
-
-### End-to-End Tests
-
-Coverage of real behavior is non-negotiable; the lane is chosen by the behavior under test, not by a blanket "must have e2e" rule. Avoid the expensive lanes unless they add distinct confidence. Four independent axes:
-
-- **Component or app harness first.** UI-owned behavior such as filtering, sorting, hidden/disabled states, menu contents, route-derived view state, and store/component data flow should usually be covered in Vitest. Use **Vitest + jsdom** (`vp test`) when layout/browser primitives are not material; mount the real `App.svelte` via `frontend/src/test/appHarness.ts` when routing matters.
-- **Vitest browser before Playwright for real DOM needs.** Use `*.browser.svelte.ts` / `vitest-browser-svelte` (`vp test --project browser`) when the behavior needs a real browser DOM, native focus/keyboard semantics, localStorage/matchMedia, computed styles, or layout, but does not need an external HTTP server or multi-page Playwright workflow.
-- **Playwright/full-stack only for boundaries they uniquely prove.** Reserve Playwright for screenshots/video, `getBoundingClientRect`, scroll/sticky/overflow geometry, container queries, pointer drag, viewport emulation, canvas/xterm, computed CSS pixels, or workflows that must exercise browser navigation against a running app. Use `frontend/tests/e2e-full/` or `internal/server/` Go tests when the behavior depends on backend persistence, sync, capabilities, normalization, wire shape, or middleware. If a real-backend API/server test already proves the runtime path and a component/browser test proves the UI presentation, do not require duplicate full-stack e2e just to click through the same data.
-- **Mocking is the exception.** Do not assert backend-computed values through a hand-written fixture. Mock the API (`frontend/src/test/mockApiFetch.ts`, never fork the Playwright copy) only when the behavior is owned by the frontend or the seeded server cannot produce the state.
-
-### Test Guidelines
-
-- Always pass `-shuffle=on` when invoking `go test` directly (e.g. `go test ./internal/db -run TestFoo -shuffle=on`). The `make test` and `make test-short` targets already set it. Shuffled ordering catches hidden test-to-test coupling
-- Do not pass `-count=1` to `go test`. `-count=1` is the default and specifying it wastes tokens and disables the build cache unnecessarily. Omit the flag. If a genuine need to bypass cache arises, confirm with the user first
-- Only pass `-count=N` when `N > 1` (e.g. `-count=10` for flake hunting)
-- Table-driven tests for Go code
-- Use `testify` consistently in Go tests; prefer `require` for setup/preconditions and `assert` for non-blocking checks
-- When a test function has more than 3 assertions, create a local helper with `assert := assert.New(t)` and use the helper methods for the rest of the checks. Import `github.com/stretchr/testify/assert` without an alias; aliased assert imports are rejected by golangci-lint.
-- Do not use `t.Fatal`, `t.Fatalf`, `t.Error`, `t.Errorf`, `t.Fail`, or `t.FailNow` in tests; use testify assertions instead
-- Prefer the generated Go API client in `internal/apiclient` for integration-style API tests
-- For HTTP tests of user-visible behavior, follow the wire-level discipline in `context/testing.md`: route through `srv.ServeHTTP`, assert on what a client observes, and pick `internal/server/apitest/` or `internal/server/e2etest/` per the rules there.
-- Use `openTestDB(t)` helper for database tests
-- All tests use `t.TempDir()` for temp directories
-- Tests should be fast and isolated
-- Shell script tests must exercise observable behavior by running the script
-  against controlled inputs and asserting outputs, side effects, or exit
-  codes. Do not add bash tests that grep shell scripts, workflows, config
-  files, or docs for expected implementation text; those checks are usually
-  tautological and should be replaced with real execution, parser/tool-native
-  validation, or a documented manual release check.
-- Do not run tests with `-v` (especially `go test`) — default output has enough signal to debug failures, and verbose output wastes tokens. Only use `-v` if the user asks for it or a failure genuinely needs the extra detail
-- For provider-specific live or container test fixtures used when fake transports can't catch endpoint or auth drift, follow `context/testing.md` and `context/platform-sync-invariants.md`. The GitHub GraphQL gate is `MIDDLEMAN_LIVE_GITHUB_TESTS=1`.
 
 ## Conventions
 
@@ -113,7 +73,6 @@ Coverage of real behavior is non-negotiable; the lane is chosen by the behavior 
 - Zensical resolves `docs_dir`/`site_dir` relative to the config file's directory, so `uvx zensical build` cannot run in place against the checked-in `docs/zensical.toml`; stage a scratch project root containing a copy of the config beside a copy of `docs/`, then build there.
 - Tests, docs, fixtures, commit messages, and PR text should use generic synthetic examples unless the user explicitly asks to preserve exact private project names, paths, prose, or domain details.
 - **Never use npm** — use `bun install` for frontend dependencies and invoke Vite+ directly via `./node_modules/.bin/vp ...` (or `../node_modules/.bin/vp ...` from `frontend/`). Never run `npm install` or `npm run` — this creates `package-lock.json` which conflicts with the bun lockfile
-- Tests should be fast and isolated
 - No emojis in code or output
 - For database schema changes, follow `context/db-migrations.md`; `internal/db/migrations/` is the source of truth for schema evolution.
 - For HTTP API error envelopes and frontend error branching, follow `context/error-handling.md`; branch on stable codes/details rather than prose.

--- a/context/agent-bootstrap.md
+++ b/context/agent-bootstrap.md
@@ -1,0 +1,15 @@
+# Agent Bootstrap
+
+Use this document when changing repository-controlled agent hooks, session
+startup, or automatic frontend dependency installation.
+
+Repo-controlled `SessionStart` hooks may bootstrap frontend dependencies when
+local tooling cannot run without them. This reduces execution surface but does
+not fully protect a runner that blindly trusts changed hook configuration.
+
+- Keep the bootstrap command self-contained in the hook definition; do not
+  delegate to branch-controlled helper scripts or Makefile targets.
+- Prefer an existing `node_modules/vite-plus/bin/vp`.
+- When installation is required, use a frozen lockfile with lifecycle scripts
+  disabled through `--ignore-scripts`, then verify the local Vite+ entrypoint
+  exists.

--- a/context/agent-bootstrap.md
+++ b/context/agent-bootstrap.md
@@ -1,11 +1,13 @@
 # Agent Bootstrap
 
-Use this document when changing repository-controlled agent hooks, session
-startup, or automatic frontend dependency installation.
+Use this document only for committed repository hooks that bootstrap frontend
+dependencies at session start. For Kenn Forge's user-level lifecycle-hook relay
+or generated launch context, read [`workspace-apis.md`](./workspace-apis.md).
 
 Repo-controlled `SessionStart` hooks may bootstrap frontend dependencies when
 local tooling cannot run without them. This reduces execution surface but does
-not fully protect a runner that blindly trusts changed hook configuration.
+not fully protect a runner that blindly trusts changed hook configuration
+(`.claude/settings.json:8`, `.codex/hooks.json:8`).
 
 - Keep the bootstrap command self-contained in the hook definition; do not
   delegate to branch-controlled helper scripts or Makefile targets.

--- a/context/config-persistence.md
+++ b/context/config-persistence.md
@@ -1,6 +1,6 @@
 # Config Persistence Invariants
 
-Use this document when adding or changing config fields that Middleman saves
+Use this document when adding or changing config fields that Kenn Forge saves
 back to TOML.
 
 - `configFile` in `internal/config/config.go` is the hand-maintained subset of `Config` that `Save` writes to disk. A `Config` field absent from `configFile` (or from the `Save` initializer) loads from TOML fine but is silently dropped on the next save or restart.

--- a/context/config-persistence.md
+++ b/context/config-persistence.md
@@ -1,4 +1,7 @@
 # Config Persistence Invariants
 
+Use this document when adding or changing config fields that Middleman saves
+back to TOML.
+
 - `configFile` in `internal/config/config.go` is the hand-maintained subset of `Config` that `Save` writes to disk. A `Config` field absent from `configFile` (or from the `Save` initializer) loads from TOML fine but is silently dropped on the next save or restart.
 - Every new persisted config field or section must be wired in three places — `Config`, `configFile`, and the `Save` initializer — and covered by a save/load round-trip test with a non-default value (see `TestPullRequestsConfigRoundTrip` in `internal/config/config_test.go`).

--- a/context/db-migrations.md
+++ b/context/db-migrations.md
@@ -1,5 +1,8 @@
 # Database Migrations
 
+Use this document before creating, editing, reviewing, or validating database
+schema migrations.
+
 - **Shipped migrations are immutable.** A migration has shipped when it exists on `origin/main`, a tag or release branch, or a production database; correct it with a new forward migration.
 - **Each PR introduces at most one migration.** Amend a PR-local migration in place instead of stacking fix-ups.
 

--- a/context/deferred-merge.md
+++ b/context/deferred-merge.md
@@ -1,5 +1,8 @@
 # Deferred ("merge after CI") merge invariants
 
+Use this document for changes to deferred merge queueing, cancellation,
+supersession, completion events, or pending-state presentation.
+
 - Queued deferred merges live only in the server process (`deferredMergeInFlight`
   in `internal/server/pullapi/deferred_merge.go`); a restart drops them. Detail responses
   expose the state as `deferred_merge_pending`.

--- a/context/docs-authoring.md
+++ b/context/docs-authoring.md
@@ -1,0 +1,17 @@
+# Documentation Authoring
+
+Use this document for changes to user-facing documentation, workflow
+screenshots, or the Zensical site.
+
+- Keep user guidance concise and workflow-oriented: describe UI capabilities
+  and maintainer workflows without overexplaining internals. Treat the HTTP API
+  as an internal or thin-client concern rather than regular user guidance.
+- User-facing workflow screenshots are generated into a staged docs tree by the
+  docs build and must not be tracked in Git. Playwright captures in
+  `docs/screenshots/` use the real seeded e2e backend, not mocked API fixtures
+  or a developer daemon.
+- Verify screenshot asset-path findings against rendered `site/` output because
+  Zensical can rewrite raw HTML paths when `use_directory_urls` is enabled.
+- Zensical resolves `docs_dir` and `site_dir` relative to the config file. To
+  build `docs/zensical.toml`, stage a scratch project root containing the config
+  beside a copy of `docs/`, then run `uvx zensical build` there.

--- a/context/docs-mode.md
+++ b/context/docs-mode.md
@@ -22,9 +22,8 @@ filesystem operations, search, and git pull/publish behavior.
 
 ## Filesystem And HTTP Boundary
 
-- Every Docs API read, browse, mutation, and git operation requires a loopback
-  client even when the daemon is configured with a wider listener
-  (`internal/server/server.go::Server.isDocsReadAPIRequest`).
+- Docs browse, reads, mutations, and git operations require a loopback client
+  (`internal/server/server.go::Server.ServeHTTP`).
 - The registry accepts markdown files and an allowlist of raster image blobs,
   not arbitrary files. SVG stays excluded because same-origin SVG can execute
   script (`internal/docs/folder.go::imageExts`).
@@ -32,13 +31,11 @@ filesystem operations, search, and git pull/publish behavior.
   writes, renames, deletes, search, and blob serving must not escape the
   registered root or traverse ignored content
   (`internal/docs/folder.go::Registry.resolve`).
-- File writes are atomic and in-process mutations are serialized across folders;
-  create and rename never overwrite an existing destination
-  (`internal/docs/folder.go::Registry.WriteFile`).
-- Docs mutations retain the origin/CSRF boundary, and file writes stay JSON-wrapped
-  rather than bypassing the mutation content-type gate with raw markdown
-  (`internal/server/server.go::Server.isMutatingDocsAPIRequest`,
-  `internal/server/docsapi/routes.go::docsWriteFileInput`).
+- Writes use atomic sibling-temp renames; create and rename serialize their
+  no-clobber critical sections across folders and never overwrite a destination
+  (`internal/docs/folder.go::Registry`).
+- Docs mutations retain origin/CSRF; file writes stay JSON-wrapped, not raw markdown
+  (`internal/server/server.go::Server.isMutatingDocsAPIRequest`, `internal/server/docsapi/routes.go::docsWriteFileInput`).
 - Public operations use Huma and generated clients; blob responses remain binary
   rather than being modeled as JSON
   (`internal/server/docsapi/routes.go::docsBlobOutput`).
@@ -51,10 +48,9 @@ filesystem operations, search, and git pull/publish behavior.
 - Status rejects command-bearing worktree attributes; changes and publish also
   reject command-bearing local config before inspecting or staging content
   (`internal/docs/git.go::Registry.GitStatus`, `internal/docs/git_publish.go::Registry.GitChanges`).
-- Publish handles markdown changes only. Unrelated staged files, partial stages,
-  conflicts, missing upstreams, and diverged branches block the operation rather
-  than being folded into a Docs commit
-  (`internal/docs/git_publish.go::Registry.GitPublish`).
+- Publish stages markdown changes only. Unrelated or partial stages, conflicts,
+  and missing upstreams block before commit; rejected pushes can leave a local
+  commit for recovery (`internal/docs/git_publish.go::Registry.GitPublish`).
 - Push the branch's configured upstream; repository-wide `push.default` or
   `remote.pushDefault` must not redirect publication
   (`internal/docs/git_publish.go::Registry.currentUpstreamPushTarget`).

--- a/context/docs-mode.md
+++ b/context/docs-mode.md
@@ -6,7 +6,8 @@ filesystem operations, search, and git pull/publish behavior.
 ## Ownership And Configuration
 
 - Docs is a non-provider mode. Files remain on disk under explicitly configured
-  folder roots; Kenn Forge stores folder registration, not document content.
+  folder roots; Kenn Forge stores folder registration, not document content
+  (`internal/config/config.go::DocFolder`).
 - Folder IDs are stable URL-segment identities. Paths are normalized to absolute,
   symlink-resolved roots before entering the live registry
   (`internal/docs/folder.go::NewRegistry`).
@@ -34,6 +35,13 @@ filesystem operations, search, and git pull/publish behavior.
 - File writes are atomic and in-process mutations are serialized across folders;
   create and rename never overwrite an existing destination
   (`internal/docs/folder.go::Registry.WriteFile`).
+- Docs mutations retain the origin/CSRF boundary, and file writes stay JSON-wrapped
+  rather than bypassing the mutation content-type gate with raw markdown
+  (`internal/server/server.go::Server.isMutatingDocsAPIRequest`,
+  `internal/server/docsapi/routes.go::docsWriteFileInput`).
+- Public operations use Huma and generated clients; blob responses remain binary
+  rather than being modeled as JSON
+  (`internal/server/docsapi/routes.go::docsBlobOutput`).
 
 ## Git Pull And Publish
 

--- a/context/embeds.md
+++ b/context/embeds.md
@@ -1,5 +1,8 @@
 # Embeds
 
+Use this document for embed routes, host-owned panels, the workspace bridge, or
+embed-shell startup behavior.
+
 Kenn Forge embed routes are intended to run in an isolated browser context, such
 as an iframe, WebView, or host-owned panel that loads one Kenn Forge document per
 surface. They are not designed for multiple Kenn Forge instances mounted into the

--- a/context/inline-review-comments.md
+++ b/context/inline-review-comments.md
@@ -4,21 +4,30 @@ Use this document for inline pull-request diff comments, local review drafts,
 published review-thread ingestion, or review controls in shared diff UI.
 
 - Staged review comments are local Middleman data. Provider clients publish a
-  complete local draft; do not depend on provider-native pending drafts.
+  complete local draft; do not depend on provider-native pending drafts
+  (`internal/db/queries_review.go::DB.GetOrCreateMRReviewDraft`,
+  `internal/server/pullapi/diff_review_handlers.go::Handler.publishDiffReviewDraft`).
 - Provider support is capability-gated per action and operation. Missing draft
   mutation, thread-read, thread-resolution, or review-action support returns the
-  typed unsupported-capability path rather than enabling partial behavior.
+  typed unsupported-capability path rather than enabling partial behavior
+  (`internal/platform/types.go::Capabilities`).
 - Bind drafts to the full provider reference, pull request number, and diff head
-  SHA. Reject publish when the saved diff head is stale.
+  SHA. Reject publish when the saved diff head is stale
+  (`internal/server/pullapi/diff_review_handlers.go::Handler.publishDiffReviewDraft`).
 - Review ranges stay within one file and one diff side and are contiguous in
   rendered order. Full pull-request head diffs are reviewable; single-commit and
   arbitrary range diffs remain disabled until their coordinate mapping is
-  explicitly supported.
+  explicitly supported
+  (`internal/server/pullapi/diff_review_handlers.go::dbReviewLineRange`).
 - Public routes use provider-aware pull paths and internal draft/thread IDs.
   Provider review, thread, and comment IDs remain persistence metadata unless a
-  concrete public API need is introduced.
+  concrete public API need is introduced
+  (`internal/server/pullapi/handler.go::registerReviewDraftRoutes`).
 - Published review parts appear in the selected pull request timeline, not as
-  standalone global activity rows.
+  standalone global activity rows
+  (`internal/server/pullapi/diff_review_handlers.go::Handler.ingestDiffReviewThreads`).
 - Workspace diffs reuse the renderer with review mode disabled. They must not
   expose composers, draft trays, publish actions, or thread-resolution controls,
-  and replacing a pull-request diff with workspace state clears the draft store.
+  and replacing a pull-request diff with workspace state clears the draft store
+  (`packages/ui/src/components/workspace/WorkspaceDiffPanel.svelte::reviewMode`,
+  `packages/ui/src/components/diff/DiffView.svelte::reviewEnabled`).

--- a/context/inline-review-comments.md
+++ b/context/inline-review-comments.md
@@ -3,7 +3,7 @@
 Use this document for inline pull-request diff comments, local review drafts,
 published review-thread ingestion, or review controls in shared diff UI.
 
-- Staged review comments are local Middleman data. Provider clients publish a
+- Staged review comments are local Kenn Forge data. Provider clients publish a
   complete local draft; do not depend on provider-native pending drafts
   (`internal/db/queries_review.go::DB.GetOrCreateMRReviewDraft`,
   `internal/server/pullapi/diff_review_handlers.go::Handler.publishDiffReviewDraft`).

--- a/context/inline-review-comments.md
+++ b/context/inline-review-comments.md
@@ -7,10 +7,9 @@ published review-thread ingestion, or review controls in shared diff UI.
   complete local draft; do not depend on provider-native pending drafts
   (`internal/db/queries_review.go::DB.GetOrCreateMRReviewDraft`,
   `internal/server/pullapi/diff_review_handlers.go::Handler.publishDiffReviewDraft`).
-- Provider support is capability-gated per action and operation. Missing draft
-  mutation, thread-read, thread-resolution, or review-action support returns the
-  typed unsupported-capability path rather than enabling partial behavior
-  (`internal/platform/types.go::Capabilities`).
+- Unsupported draft mutations, thread resolutions, and review actions return
+  typed capability errors; thread ingestion is skipped when reads are unavailable
+  (`internal/server/pullapi/diff_review_handlers.go::Handler.publishDiffReviewDraft`).
 - Bind drafts to the full provider reference, pull request number, and diff head
   SHA. Reject publish when the saved diff head is stale
   (`internal/server/pullapi/diff_review_handlers.go::Handler.publishDiffReviewDraft`).

--- a/context/inline-review-comments.md
+++ b/context/inline-review-comments.md
@@ -1,0 +1,24 @@
+# Inline Review Comments
+
+Use this document for inline pull-request diff comments, local review drafts,
+published review-thread ingestion, or review controls in shared diff UI.
+
+- Staged review comments are local Middleman data. Provider clients publish a
+  complete local draft; do not depend on provider-native pending drafts.
+- Provider support is capability-gated per action and operation. Missing draft
+  mutation, thread-read, thread-resolution, or review-action support returns the
+  typed unsupported-capability path rather than enabling partial behavior.
+- Bind drafts to the full provider reference, pull request number, and diff head
+  SHA. Reject publish when the saved diff head is stale.
+- Review ranges stay within one file and one diff side and are contiguous in
+  rendered order. Full pull-request head diffs are reviewable; single-commit and
+  arbitrary range diffs remain disabled until their coordinate mapping is
+  explicitly supported.
+- Public routes use provider-aware pull paths and internal draft/thread IDs.
+  Provider review, thread, and comment IDs remain persistence metadata unless a
+  concrete public API need is introduced.
+- Published review parts appear in the selected pull request timeline, not as
+  standalone global activity rows.
+- Workspace diffs reuse the renderer with review mode disabled. They must not
+  expose composers, draft trays, publish actions, or thread-resolution controls,
+  and replacing a pull-request diff with workspace state clears the draft store.

--- a/context/pull-request-workflow.md
+++ b/context/pull-request-workflow.md
@@ -1,0 +1,25 @@
+# Pull Request Workflow
+
+Use this document before pushing, opening a pull request, or changing pull
+request metadata, comments, or review threads.
+
+- Treat this as a public repository. Before pushing or opening a pull request,
+  run the scrub-private-data skill and remove unnecessary internal project
+  names, hostnames, credentials, runner topology, and infrastructure details
+  from the diff, commits, and pull request metadata.
+- Do not watch or poll pull request GitHub Actions checks unless the user asks,
+  or the work is running through the `$kenn:refine-pr` skill.
+- Same-repository pull requests use main-branch reusable workflows on
+  organization-managed ephemeral self-hosted runners. Fork pull requests use
+  GitHub-hosted runners even for organization members; trust follows the head
+  repository, and external fork runs also require explicit approval.
+- Never delete, minimize, hide, or resolve pull request comments, review
+  comments, review threads, or CI/review-bot comments unless the user explicitly
+  asks for that exact action. Leave stale or contradicted comments in place and
+  explain the current evidence in a reply or report.
+- Keep pull request descriptions concise. A bulleted summary of user-visible
+  changes is sufficient; omit test plans, implementation details, checklists,
+  and marketing language.
+- For visible UI changes, use the `capture-playwright` skill before opening the
+  pull request and attach the screenshot or short video with `gh image` so the
+  description can include the resulting artifact links.

--- a/context/retries-and-backoffs.md
+++ b/context/retries-and-backoffs.md
@@ -1,5 +1,8 @@
 # Retries, Backoff, and Single-Flight Dedup
 
+Use this document for transient upstream retries, rate-limit gates, scheduling
+cadence, or single-flight request deduplication.
+
 kenn-forge has three distinct wait patterns. Keep them separate:
 
 - **Transient retry** — short bounded retries for flaky upstream failures.

--- a/context/server-runtime.md
+++ b/context/server-runtime.md
@@ -54,7 +54,7 @@ and the root event stream.
 - Loopback TCP is the required cross-platform transport; Unix sockets and
   named pipes are not lifecycle requirements. Background startup rejects
   non-loopback listeners before launching
-  (`cmd/middleman/start_background.go::validateBackgroundConfig`).
+  (`cmd/kenn-forge/start_background.go::validateBackgroundConfig`).
 - Only the startup-bound bearer with exact loopback authority/peer and no
   forwarding headers bypasses proxy Host interpretation; cookies never qualify,
   and the bearer remains available when general API auth is off

--- a/context/server-runtime.md
+++ b/context/server-runtime.md
@@ -6,7 +6,8 @@ and the root event stream.
 ## Startup Contracts
 
 - `kenn-forge` and `kenn-forge serve` are raw foreground commands; their
-  authoritative `data_dir` lock keeps duplicate startup as an error.
+  authoritative `data_dir` lock keeps duplicate startup as an error
+  (`cmd/kenn-forge/main.go::run`).
 - `kenn-forge start --background` is idempotent: reuse requires verified
   identity for the same resolved `data_dir`; starts serialize per data
   directory through the shared daemon manager without blocking unrelated
@@ -52,7 +53,8 @@ and the root event stream.
 
 - Loopback TCP is the required cross-platform transport; Unix sockets and
   named pipes are not lifecycle requirements. Background startup rejects
-  non-loopback listeners before launching.
+  non-loopback listeners before launching
+  (`cmd/middleman/start_background.go::validateBackgroundConfig`).
 - Only the startup-bound bearer with exact loopback authority/peer and no
   forwarding headers bypasses proxy Host interpretation; cookies never qualify,
   and the bearer remains available when general API auth is off

--- a/context/testing-basics.md
+++ b/context/testing-basics.md
@@ -3,11 +3,9 @@
 Use this document when writing or running Go tests, choosing common test
 fixtures, or changing shell-script coverage.
 
-Common commands are `make test`, `make test-short`, `make lint`, and `make vet`.
-
-- Pass `-shuffle=on` when invoking `go test` directly; the Make targets already
-  include it. Do not pass redundant `-count=1`. Use `-count=N` only when `N > 1`
-  for repeated runs.
+- Pass `-shuffle=on` when invoking `go test` directly; `make test` and
+  `make test-short` already include it. Do not pass redundant `-count=1`; use
+  `-count=N` only when `N > 1` for repeated runs.
 - Do not use `-v` unless the user requests it or a particular failure genuinely
   needs verbose output.
 - Prefer table-driven Go tests. Use testify `require` for preconditions and
@@ -17,9 +15,8 @@ Common commands are `make test`, `make test-short`, `make lint`, and `make vet`.
   more than three assertions, create `assert := assert.New(t)` and use the
   helper methods thereafter.
 - Prefer the generated Go API client for integration-style API tests.
-- Use the package's established database helper: `openTestDB(t)` inside
-  `internal/db` and the routed fixture guidance elsewhere. Give every test its
-  own `t.TempDir()` and keep tests fast and isolated.
+- Use established package fixtures instead of opening databases directly. Use
+  `t.TempDir()` when a test needs filesystem isolation.
 - Shell-script tests must execute the script against controlled inputs and
   assert observable output, side effects, or exit status. Do not grep scripts,
   workflows, config, or docs for expected implementation text.

--- a/context/testing-basics.md
+++ b/context/testing-basics.md
@@ -1,0 +1,28 @@
+# Test Basics
+
+Use this document when writing or running Go tests, choosing common test
+fixtures, or changing shell-script coverage.
+
+Common commands are `make test`, `make test-short`, `make lint`, and `make vet`.
+
+- Pass `-shuffle=on` when invoking `go test` directly; the Make targets already
+  include it. Do not pass redundant `-count=1`. Use `-count=N` only when `N > 1`
+  for repeated runs.
+- Do not use `-v` unless the user requests it or a particular failure genuinely
+  needs verbose output.
+- Prefer table-driven Go tests. Use testify `require` for preconditions and
+  `assert` for non-blocking checks; do not use `t.Fatal`, `t.Fatalf`, `t.Error`,
+  `t.Errorf`, `t.Fail`, or `t.FailNow`.
+- Import `github.com/stretchr/testify/assert` without an alias. When a test has
+  more than three assertions, create `assert := assert.New(t)` and use the
+  helper methods thereafter.
+- Prefer the generated Go API client for integration-style API tests.
+- Use the package's established database helper: `openTestDB(t)` inside
+  `internal/db` and the routed fixture guidance elsewhere. Give every test its
+  own `t.TempDir()` and keep tests fast and isolated.
+- Shell-script tests must execute the script against controlled inputs and
+  assert observable output, side effects, or exit status. Do not grep scripts,
+  workflows, config, or docs for expected implementation text.
+- Use provider live or container fixtures only when fake transports cannot
+  catch endpoint or authentication drift. GitHub GraphQL validation is gated by
+  `MIDDLEMAN_LIVE_GITHUB_TESTS=1`.

--- a/context/testing-basics.md
+++ b/context/testing-basics.md
@@ -22,4 +22,4 @@ fixtures, or changing shell-script coverage.
   workflows, config, or docs for expected implementation text.
 - Use provider live or container fixtures only when fake transports cannot
   catch endpoint or authentication drift. GitHub GraphQL validation is gated by
-  `MIDDLEMAN_LIVE_GITHUB_TESTS=1`.
+  `KENN_FORGE_LIVE_GITHUB_TESTS=1`.

--- a/context/testing.md
+++ b/context/testing.md
@@ -5,14 +5,6 @@ HTTP contract tests, or working on race and integration-test architecture. For
 everyday Go test construction and commands, also read
 [`context/testing-basics.md`](./testing-basics.md).
 
-## Go assertion style
-
-Go tests use `testify` consistently. Import
-`github.com/stretchr/testify/assert` without an alias and create local helpers
-as `assert := assert.New(t)` when a test has more than three assertions.
-Aliasing the `assert` package, including `Assert`, is not allowed and is
-enforced by golangci-lint's `importas` rule.
-
 Test server constructors that create a Workspace manager must apply their
 isolated test tmux command; they must never fall back to the host tmux server
 (`internal/server/kataapi/test_helpers_test.go::newKataTestServer`).

--- a/context/testing.md
+++ b/context/testing.md
@@ -131,6 +131,11 @@ owner:
   regressions; the delayed case must retain terminal DOM focus so `focusout` cannot mask a
   broken outside-pointerdown handler (`frontend/tests/e2e-full/00-tmux-browser-clipboard.spec.ts`).
 
+Mock the API only when the behavior is owned by the frontend or the seeded
+server cannot produce the state. Use `frontend/src/test/mockApiFetch.ts` rather
+than forking the Playwright fixture, and do not assert backend-computed values
+through hand-written frontend data.
+
 A UI regression can be sufficiently covered by a backend/server test for the
 real runtime path plus a component or Vitest browser test for presentation. Do
 not require a duplicate full-stack browser test when it would only replay data

--- a/context/testing.md
+++ b/context/testing.md
@@ -1,5 +1,10 @@
 # Testing
 
+Use this document when choosing test boundaries or lanes, changing provider or
+HTTP contract tests, or working on race and integration-test architecture. For
+everyday Go test construction and commands, also read
+[`context/testing-basics.md`](./testing-basics.md).
+
 ## Go assertion style
 
 Go tests use `testify` consistently. Import

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -136,6 +136,13 @@ Interactive surfaces must agree on which item is selected.
   action atomically from accepted snapshot enrichment; do not merge a prior
   action target or mutation response into a newly accepted snapshot
   (`frontend/src/lib/features/kata/KataWorkspace.svelte::acceptedSnapshot`).
+- Task selection, project scope, and graph source are snapshot request identity;
+  query, owner, and label remain presentation state
+  (`frontend/src/lib/features/kata/kataWorkspaceAuthority.ts::kataWorkspaceAuthorityRequest`).
+- Derive sidebar areas and ordering from project metadata, excluding inbox projects,
+  and render a reachable graph only for the accepted snapshot's current source
+  (`frontend/src/lib/features/kata/kataWorkspaceAuthority.ts::deriveKataAreas`,
+  `frontend/src/lib/features/kata/KataWorkspace.svelte::acceptedGraph`).
 - Cross-surface Kata navigation must carry daemon, project UID, and status authority;
   UID-only sources always resolve an isolated selected-detail read for routing —
   never a shared-snapshot row, which can be stale during invalidation reloads —

--- a/context/vscode-workflow-panel-interaction-spec.md
+++ b/context/vscode-workflow-panel-interaction-spec.md
@@ -1,6 +1,9 @@
 # VS Code Workflow Panel Interaction Spec
 
-Primary source: local VS Code checkout at `/Users/mariusvniekerk/src/microsoft/vscode`, revision `6b1e5513a8b`.
+Use this document when changing Middleman's workflow groups, workflow tabs,
+terminal groups, terminal splits, or related panel interaction semantics.
+
+Primary source: `microsoft/vscode` revision `6b1e5513a8b`.
 
 This spec describes the VS Code interaction model to mirror for kenn-forge's workflow and terminal panel work. It intentionally focuses on editor groups/tabs and integrated terminal tabs/splits, not VS Code implementation internals that do not map to kenn-forge.
 

--- a/context/vscode-workflow-panel-interaction-spec.md
+++ b/context/vscode-workflow-panel-interaction-spec.md
@@ -1,6 +1,6 @@
 # VS Code Workflow Panel Interaction Spec
 
-Use this document when changing Middleman's workflow groups, workflow tabs,
+Use this document when changing Kenn Forge's workflow groups, workflow tabs,
 terminal groups, terminal splits, or related panel interaction semantics.
 
 Primary source: `microsoft/vscode` revision `6b1e5513a8b`.

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -1,5 +1,8 @@
 # Workspace APIs
 
+Use this document for changes to workspace creation, reuse, identity, routes,
+or item-to-workspace association.
+
 These APIs manage **kenn-forge-owned workspaces**: durable local execution
 contexts for tracked PRs, provider issues, mapped Kata tasks, and ad-hoc work in
 a tracked repository. They are not a generic Git worktree browser and not an

--- a/skills/context-sync/SKILL.md
+++ b/skills/context-sync/SKILL.md
@@ -64,8 +64,8 @@ knowledge that changes what future agents should do.
 | `server` | `context/server-runtime.md`, `context/workspace-apis.md`, `context/workspace-runtime-lifecycle.md` | `cmd/kenn-forge/`, `internal/daemonruntime/`, `internal/runtimelock/`, `internal/server/`, `internal/apiclient/generated/` |
 | `errors` | `context/error-handling.md` | error envelopes and frontend error branching |
 | `retries` | `context/retries-and-backoffs.md` | retry, backoff, and single-flight paths |
-| `testing` | `context/testing.md` | server API/E2E packages and test helpers |
-| `frontend` | `context/ui-design-system.md`, `context/ui-interaction-contracts.md` | `frontend/src/` |
+| `testing` | `context/testing-basics.md`, `context/testing.md` | server API/E2E packages and test helpers |
+| `frontend` | `context/ui-design-system.md`, `context/ui-interaction-contracts.md`, `context/vscode-workflow-panel-interaction-spec.md` | `frontend/src/` |
 | `mobile` | `context/mobile-ux.md` | frontend `/m` routes and phone-first components |
 | `kata` | `context/kata-mode.md`, `context/workspace-apis.md` | `internal/kata/`, `internal/server/kataapi/` |
 | `docs` | `context/docs-mode.md` | `internal/docs/`, `internal/server/docsapi/` |

--- a/skills/context-sync/SKILL.md
+++ b/skills/context-sync/SKILL.md
@@ -66,6 +66,7 @@ knowledge that changes what future agents should do.
 | `retries` | `context/retries-and-backoffs.md` | retry, backoff, and single-flight paths |
 | `testing` | `context/testing-basics.md`, `context/testing.md` | server API/E2E packages and test helpers |
 | `frontend` | `context/ui-design-system.md`, `context/ui-interaction-contracts.md`, `context/vscode-workflow-panel-interaction-spec.md` | `frontend/src/` |
+| `inline-review` | `context/inline-review-comments.md` | review draft/thread paths in `internal/platform/`, `internal/server/`, and `packages/ui/` |
 | `mobile` | `context/mobile-ux.md` | frontend `/m` routes and phone-first components |
 | `kata` | `context/kata-mode.md`, `context/workspace-apis.md` | `internal/kata/`, `internal/server/kataapi/` |
 | `docs` | `context/docs-mode.md` | `internal/docs/`, `internal/server/docsapi/` |

--- a/skills/context-sync/SKILL.md
+++ b/skills/context-sync/SKILL.md
@@ -62,6 +62,7 @@ knowledge that changes what future agents should do.
 | `config` | `context/config-persistence.md` | `internal/config/` save paths |
 | `platform` | `context/provider-architecture.md`, `context/platform-sync-invariants.md` | `internal/platform/` |
 | `github-sync` | `context/github-sync-invariants.md` | `internal/github/` |
+| `notifications` | `context/notifications-in-activity.md` | notification-owned paths in `internal/github/`, `internal/db/`, `internal/server/`, `frontend/`, and `packages/ui/` |
 | `db` | `context/db-migrations.md` | `internal/db/`, `internal/db/migrations/` |
 | `deferred-merge` | `context/deferred-merge.md` | deferred merge paths in `internal/server/` |
 | `embeds` | `context/embeds.md` | embed routes, shell, and host bridge paths |
@@ -72,14 +73,14 @@ knowledge that changes what future agents should do.
 | `docs-authoring` | `context/docs-authoring.md` | user docs, screenshots, and Zensical configuration |
 | `pull-requests` | `context/pull-request-workflow.md` | push and pull-request delivery workflow |
 | `frontend` | `context/ui-design-system.md`, `context/ui-interaction-contracts.md`, `context/vscode-workflow-panel-interaction-spec.md` | `frontend/src/` |
-| `inline-review` | `context/inline-review-comments.md` | review draft/thread paths in `internal/platform/`, `internal/server/`, and `packages/ui/` |
+| `inline-review` | `context/inline-review-comments.md` | review-owned paths in `internal/db/`, `internal/github/`, `internal/platform/`, `internal/server/`, and `packages/ui/` |
 | `mobile` | `context/mobile-ux.md` | frontend `/m` routes and phone-first components |
 | `kata` | `context/kata-mode.md`, `context/workspace-apis.md` | `internal/kata/`; Kata-owned paths in `internal/server/`, `internal/config/`, and `frontend/`, including shared app and configuration files |
 | `docs` | `context/docs-mode.md` | `internal/docs/`; Docs-owned paths in `internal/server/`, `internal/config/`, and `frontend/`, including shared app and configuration files |
 
-Mode scopes intentionally overlap the generic `server`, `config`, and `frontend` areas.
-For `--changed`, select every matching mode and generic area rather than choosing only
-the broadest or most specific row.
+Mode, notification, and inline-review scopes intentionally overlap generic areas. For
+`--changed`, select every matching focused and generic area rather than choosing only the
+broadest or most specific row.
 
 ## Audit Workflow
 

--- a/skills/context-sync/SKILL.md
+++ b/skills/context-sync/SKILL.md
@@ -58,13 +58,19 @@ knowledge that changes what future agents should do.
 
 | Area | Topic doc(s) | Code it tracks |
 |------|--------------|----------------|
+| `agent-bootstrap` | `context/agent-bootstrap.md` | repository-controlled agent hooks and dependency bootstrap |
+| `config` | `context/config-persistence.md` | `internal/config/` save paths |
 | `platform` | `context/provider-architecture.md`, `context/platform-sync-invariants.md` | `internal/platform/` |
 | `github-sync` | `context/github-sync-invariants.md` | `internal/github/` |
-| `db` | `context/db-migrations.md`, `context/embeds.md` | `internal/db/`, `internal/db/migrations/` |
+| `db` | `context/db-migrations.md` | `internal/db/`, `internal/db/migrations/` |
+| `deferred-merge` | `context/deferred-merge.md` | deferred merge paths in `internal/server/` |
+| `embeds` | `context/embeds.md` | embed routes, shell, and host bridge paths |
 | `server` | `context/server-runtime.md`, `context/workspace-apis.md`, `context/workspace-runtime-lifecycle.md` | `cmd/kenn-forge/`, `internal/daemonruntime/`, `internal/runtimelock/`, `internal/server/`, `internal/apiclient/generated/` |
 | `errors` | `context/error-handling.md` | error envelopes and frontend error branching |
 | `retries` | `context/retries-and-backoffs.md` | retry, backoff, and single-flight paths |
 | `testing` | `context/testing-basics.md`, `context/testing.md` | server API/E2E packages and test helpers |
+| `docs-authoring` | `context/docs-authoring.md` | user docs, screenshots, and Zensical configuration |
+| `pull-requests` | `context/pull-request-workflow.md` | push and pull-request delivery workflow |
 | `frontend` | `context/ui-design-system.md`, `context/ui-interaction-contracts.md`, `context/vscode-workflow-panel-interaction-spec.md` | `frontend/src/` |
 | `inline-review` | `context/inline-review-comments.md` | review draft/thread paths in `internal/platform/`, `internal/server/`, and `packages/ui/` |
 | `mobile` | `context/mobile-ux.md` | frontend `/m` routes and phone-first components |

--- a/skills/context-sync/SKILL.md
+++ b/skills/context-sync/SKILL.md
@@ -58,7 +58,7 @@ knowledge that changes what future agents should do.
 
 | Area | Topic doc(s) | Code it tracks |
 |------|--------------|----------------|
-| `agent-bootstrap` | `context/agent-bootstrap.md` | repository-controlled agent hooks and dependency bootstrap |
+| `agent-bootstrap` | `context/agent-bootstrap.md` | `.claude/settings.json`, `.codex/hooks.json` |
 | `config` | `context/config-persistence.md` | `internal/config/` save paths |
 | `platform` | `context/provider-architecture.md`, `context/platform-sync-invariants.md` | `internal/platform/` |
 | `github-sync` | `context/github-sync-invariants.md` | `internal/github/` |
@@ -66,13 +66,13 @@ knowledge that changes what future agents should do.
 | `db` | `context/db-migrations.md` | `internal/db/`, `internal/db/migrations/` |
 | `deferred-merge` | `context/deferred-merge.md` | deferred merge paths in `internal/server/` |
 | `embeds` | `context/embeds.md` | embed routes, shell, and host bridge paths |
-| `server` | `context/server-runtime.md`, `context/workspace-apis.md`, `context/workspace-runtime-lifecycle.md` | `cmd/kenn-forge/`, `internal/daemonruntime/`, `internal/runtimelock/`, `internal/server/`, `internal/apiclient/generated/` |
+| `server` | `context/server-runtime.md`, `context/workspace-apis.md`, `context/workspace-runtime-lifecycle.md` | `cmd/kenn-forge/`, `internal/daemonruntime/`, `internal/runtimelock/`; server/workspace-owned paths in `internal/config/`, `internal/workspace/`, `internal/agentactivity/`, `internal/server/`, `internal/apiclient/generated/`, `frontend/`, and `packages/ui/`, including shared app and configuration files |
 | `errors` | `context/error-handling.md` | error envelopes and frontend error branching |
 | `retries` | `context/retries-and-backoffs.md` | retry, backoff, and single-flight paths |
-| `testing` | `context/testing-basics.md`, `context/testing.md` | server API/E2E packages and test helpers |
+| `testing` | `context/testing-basics.md`, `context/testing.md` | repository test files; `Makefile`, `.golangci.yml`, CI/test tooling, and helpers under `.github/workflows/`, `tools/`, `scripts/`, `internal/testutil/`, `frontend/`, and `packages/ui/` |
 | `docs-authoring` | `context/docs-authoring.md` | user docs, screenshots, and Zensical configuration |
 | `pull-requests` | `context/pull-request-workflow.md` | push and pull-request delivery workflow |
-| `frontend` | `context/ui-design-system.md`, `context/ui-interaction-contracts.md`, `context/vscode-workflow-panel-interaction-spec.md` | `frontend/src/` |
+| `frontend` | `context/ui-design-system.md`, `context/ui-interaction-contracts.md`, `context/vscode-workflow-panel-interaction-spec.md` | `frontend/src/`, `packages/ui/src/` |
 | `inline-review` | `context/inline-review-comments.md` | review-owned paths in `internal/db/`, `internal/github/`, `internal/platform/`, `internal/server/`, and `packages/ui/` |
 | `mobile` | `context/mobile-ux.md` | frontend `/m` routes and phone-first components |
 | `kata` | `context/kata-mode.md`, `context/workspace-apis.md` | `internal/kata/`; Kata-owned paths in `internal/server/`, `internal/config/`, and `frontend/`, including shared app and configuration files |

--- a/skills/context-sync/SKILL.md
+++ b/skills/context-sync/SKILL.md
@@ -74,8 +74,12 @@ knowledge that changes what future agents should do.
 | `frontend` | `context/ui-design-system.md`, `context/ui-interaction-contracts.md`, `context/vscode-workflow-panel-interaction-spec.md` | `frontend/src/` |
 | `inline-review` | `context/inline-review-comments.md` | review draft/thread paths in `internal/platform/`, `internal/server/`, and `packages/ui/` |
 | `mobile` | `context/mobile-ux.md` | frontend `/m` routes and phone-first components |
-| `kata` | `context/kata-mode.md`, `context/workspace-apis.md` | `internal/kata/`, `internal/server/kataapi/` |
-| `docs` | `context/docs-mode.md` | `internal/docs/`, `internal/server/docsapi/` |
+| `kata` | `context/kata-mode.md`, `context/workspace-apis.md` | `internal/kata/`; Kata-owned paths in `internal/server/`, `internal/config/`, and `frontend/`, including shared app and configuration files |
+| `docs` | `context/docs-mode.md` | `internal/docs/`; Docs-owned paths in `internal/server/`, `internal/config/`, and `frontend/`, including shared app and configuration files |
+
+Mode scopes intentionally overlap the generic `server`, `config`, and `frontend` areas.
+For `--changed`, select every matching mode and generic area rather than choosing only
+the broadest or most specific row.
 
 ## Audit Workflow
 

--- a/skills/context-sync/context-guide.md
+++ b/skills/context-sync/context-guide.md
@@ -144,6 +144,7 @@ Silencing a failing guard without recording the decision is forbidden.
 | Test commands and common Go conventions | `context/testing-basics.md` | Everyday test construction |
 | Test lanes and HTTP discipline | `context/testing.md` | Boundary and integration testing |
 | UI/TS/Svelte conventions, interaction contracts | `context/ui-design-system.md`, `context/ui-interaction-contracts.md` | Frontend consistency |
+| Inline review draft and thread contracts | `context/inline-review-comments.md` | Provider-aware review behavior |
 | Phone-first mobile workflow | `context/mobile-ux.md` | `/m` is its own UX |
 | Kata daemon integration | `context/kata-mode.md`, `context/workspace-apis.md` | External authority and workspace contracts |
 | Docs mode integration | `context/docs-mode.md` | Local filesystem and git-publish boundary |

--- a/skills/context-sync/context-guide.md
+++ b/skills/context-sync/context-guide.md
@@ -142,6 +142,7 @@ Silencing a failing guard without recording the decision is forbidden.
 | Provider-neutral sync identity, tokens, freshness, route shape | `context/platform-sync-invariants.md` | Cross-provider invariants |
 | New-provider checklist, package layout | `context/provider-architecture.md` | Onboarding a provider |
 | GitHub-only sync behavior (GraphQL, ETag) | `context/github-sync-invariants.md` | Isolated optimization |
+| Activity notification sync, persistence, and presentation | `context/notifications-in-activity.md` | User-scoped notification state |
 | Schema evolution rules | `context/db-migrations.md` | Migrations are the source of truth |
 | Daemon startup, Host validation, SSE replay | `context/server-runtime.md` | Root server lifecycle and request boundary |
 | API error envelopes + frontend branching | `context/error-handling.md` | Stable contract |

--- a/skills/context-sync/context-guide.md
+++ b/skills/context-sync/context-guide.md
@@ -141,7 +141,8 @@ Silencing a failing guard without recording the decision is forbidden.
 | Daemon startup, Host validation, SSE replay | `context/server-runtime.md` | Root server lifecycle and request boundary |
 | API error envelopes + frontend branching | `context/error-handling.md` | Stable contract |
 | Retry/backoff/single-flight | `context/retries-and-backoffs.md` | Upstream flakiness |
-| HTTP test discipline (apitest vs e2etest) | `context/testing.md` | Wire-level testing |
+| Test commands and common Go conventions | `context/testing-basics.md` | Everyday test construction |
+| Test lanes and HTTP discipline | `context/testing.md` | Boundary and integration testing |
 | UI/TS/Svelte conventions, interaction contracts | `context/ui-design-system.md`, `context/ui-interaction-contracts.md` | Frontend consistency |
 | Phone-first mobile workflow | `context/mobile-ux.md` | `/m` is its own UX |
 | Kata daemon integration | `context/kata-mode.md`, `context/workspace-apis.md` | External authority and workspace contracts |

--- a/skills/context-sync/context-guide.md
+++ b/skills/context-sync/context-guide.md
@@ -50,12 +50,15 @@ The size ceilings below are per-doc; these are per-change:
 
 kenn-forge's durable agent context lives in two places:
 
-- **Root `CLAUDE.md`** — the hub. Project overview, architecture, the single canonical
-  provider list, non-provider modes, project structure, key files, dev/test commands,
-  conventions, git/PR workflow, and routing references into `context/`.
+- **Root `CLAUDE.md`** — the hub. A compact project model, the single canonical provider
+  list, non-provider ownership boundary, universal conventions, Git workflow, and
+  trigger-oriented routing references into `context/`.
 - **`context/*.md`** — topic docs. One concern each (provider sync invariants, error
   handling, db migrations, retries, testing discipline, UI design system, mobile UX,
   etc.). Deep enough to hold real rationale; narrow enough to load only when relevant.
+
+The README, Makefile, and source tree own discoverable inventories, key-file lists, and
+development commands. Do not copy them into the always-loaded hub.
 
 Specs and plans live under `docs/superpowers/specs/` and `docs/superpowers/plans/`;
 durable, dated decisions live under `docs/adr/`.
@@ -133,7 +136,9 @@ Silencing a failing guard without recording the decision is forbidden.
 
 | Content type | Store in | Why |
 |--------------|----------|-----|
-| Project shape, canonical provider list, modes, key files, workflow | root `CLAUDE.md` | The always-loaded hub |
+| Compact project model, canonical provider list, universal workflow | root `CLAUDE.md` | The always-loaded hub |
+| Agent hook and dependency bootstrap constraints | `context/agent-bootstrap.md` | Session startup safety |
+| TOML config save invariants | `context/config-persistence.md` | Whole-file persistence |
 | Provider-neutral sync identity, tokens, freshness, route shape | `context/platform-sync-invariants.md` | Cross-provider invariants |
 | New-provider checklist, package layout | `context/provider-architecture.md` | Onboarding a provider |
 | GitHub-only sync behavior (GraphQL, ETag) | `context/github-sync-invariants.md` | Isolated optimization |
@@ -143,6 +148,8 @@ Silencing a failing guard without recording the decision is forbidden.
 | Retry/backoff/single-flight | `context/retries-and-backoffs.md` | Upstream flakiness |
 | Test commands and common Go conventions | `context/testing-basics.md` | Everyday test construction |
 | Test lanes and HTTP discipline | `context/testing.md` | Boundary and integration testing |
+| User docs, screenshots, and Zensical workflow | `context/docs-authoring.md` | Documentation delivery |
+| Push and pull-request metadata policy | `context/pull-request-workflow.md` | Public delivery workflow |
 | UI/TS/Svelte conventions, interaction contracts | `context/ui-design-system.md`, `context/ui-interaction-contracts.md` | Frontend consistency |
 | Inline review draft and thread contracts | `context/inline-review-comments.md` | Provider-aware review behavior |
 | Phone-first mobile workflow | `context/mobile-ux.md` | `/m` is its own UX |
@@ -165,9 +172,9 @@ deleting substance. They are not a mandate to shrink today's docs.
 | `docs/adr/*` entry | ~80 | One decision |
 | `docs/superpowers/specs/*` | as needed | Design surface, archived after landing |
 
-The root `CLAUDE.md` is the hub and is allowed to be long, but it should stay a router
-and a conventions list — push any concern that grows rationale into a `context/` doc and
-reference it.
+The root `CLAUDE.md` should remain near 100 lines and behave as a router plus a concise
+universal conventions list. Push conditional procedures or rationale into a topic doc
+and route them by task trigger.
 
 ## When to Update Context
 


### PR DESCRIPTION
- Reduce the always-loaded agent instructions to a compact project model, universal rules, and trigger-oriented routes.
- Move conditional workflow and implemented-mode guidance into focused context documents.
- Reclassify the historical inline-review rollout plan and align the context-sync ownership map.

<sup>generated by a clanker</sup>