### PR TITLE
fix: hide GitHub app-authored issues

### DIFF
--- a/internal/github/graphql.go
+++ b/internal/github/graphql.go
@@ -300,7 +300,7 @@ type gqlIssue struct {
 	State      string
 	Body       string
 	URL        string `graphql:"url"`
-	Author     struct{ Login string }
+	Author     gqlIssueAuthor
 	CreatedAt  time.Time
 	UpdatedAt  time.Time
 	ClosedAt   *time.Time
@@ -319,6 +319,11 @@ type gqlIssue struct {
 		Nodes    []gqlIssueTimelineItem
 		PageInfo pageInfo
 	} `graphql:"timelineItems(itemTypes: [ASSIGNED_EVENT, UNASSIGNED_EVENT, CROSS_REFERENCED_EVENT, CLOSED_EVENT, REOPENED_EVENT], first: 100)"`
+}
+
+type gqlIssueAuthor struct {
+	Login    string
+	Typename string `graphql:"__typename"`
 }
 
 type gqlLabel struct {
@@ -418,6 +423,10 @@ func adaptPR(gql *gqlPR) *gh.PullRequest {
 
 func adaptIssue(gql *gqlIssue) *gh.Issue {
 	state := stateToREST(gql.State)
+	authorLogin := gql.Author.Login
+	if gql.Author.Typename == "Bot" && !strings.HasSuffix(authorLogin, "[bot]") {
+		authorLogin += "[bot]"
+	}
 	issue := &gh.Issue{
 		ID:       new(gql.DatabaseId),
 		Number:   new(gql.Number),
@@ -426,7 +435,7 @@ func adaptIssue(gql *gqlIssue) *gh.Issue {
 		Body:     new(gql.Body),
 		HTMLURL:  new(gql.URL),
 		Comments: new(gql.Comments.TotalCount),
-		User:     &gh.User{Login: new(gql.Author.Login)},
+		User:     &gh.User{Login: new(authorLogin)},
 	}
 
 	created := gh.Timestamp{Time: gql.CreatedAt}

--- a/internal/github/graphql_test.go
+++ b/internal/github/graphql_test.go
@@ -506,6 +506,43 @@ func TestGraphQLFetcherFetchRepoIssuesUsesIssueTimelineFragments(t *testing.T) {
 	assert.NotContains(string(requestBody), "BaseRefChangedEvent")
 }
 
+func TestGraphQLFetcherFetchRepoIssuesPreservesBotAuthor(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	now := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC).Format(time.RFC3339)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"repository":{"issues":{"nodes":[{
+			"databaseId":2001,
+			"number":3,
+			"title":"Dependency Dashboard",
+			"state":"OPEN",
+			"body":"",
+			"url":"https://github.com/example/project/issues/3",
+			"author":{"__typename":"Bot","login":"renovate"},
+			"createdAt":"` + now + `",
+			"updatedAt":"` + now + `",
+			"closedAt":null,
+			"labels":{"nodes":[]},
+			"comments":{"totalCount":0,"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}},
+			"assignees":{"nodes":[]},
+			"timelineItems":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":""}}
+		}],"pageInfo":{"hasNextPage":false,"endCursor":""}}}}}`))
+	}))
+	defer srv.Close()
+
+	fetcher := NewGraphQLFetcherWithClient(
+		githubv4.NewEnterpriseClient(srv.URL, srv.Client()), nil,
+	)
+
+	result, err := fetcher.FetchRepoIssues(t.Context(), "example", "project")
+	require.NoError(err)
+	require.NotNil(result)
+	require.Len(result.Issues, 1)
+	assert.Equal("renovate[bot]", result.Issues[0].Issue.GetUser().GetLogin())
+}
+
 func TestGraphQLFetcherFetchRepoIssuesLogsFetchProgressForPaginatedIssueSet(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -10196,7 +10196,7 @@ func TestE2EGraphQLIssueSyncThroughAPI(t *testing.T) {
 			"state":"OPEN",
 			"body":"Synced through the HTTP API",
 			"url":"https://github.com/acme/widget/issues/80",
-			"author":{"login":"ivy"},
+			"author":{"__typename":"Bot","login":"renovate"},
 			"createdAt":"` + now + `",
 			"updatedAt":"` + now + `",
 			"closedAt":null,
@@ -10257,7 +10257,7 @@ func TestE2EGraphQLIssueSyncThroughAPI(t *testing.T) {
 	apiIssue := (*listResp.JSON200)[0]
 	assert.Equal(int64(80), apiIssue.Number)
 	assert.Equal("Full stack GraphQL issue", apiIssue.Title)
-	assert.Equal("ivy", apiIssue.Author)
+	assert.Equal("renovate[bot]", apiIssue.Author)
 	assert.Equal("open", apiIssue.State)
 	require.NotNil(apiIssue.Labels)
 	require.Len(*apiIssue.Labels, 1)


### PR DESCRIPTION
GitHub GraphQL reports bot actors without the REST API bot suffix, so filtered issue queues could still show app-authored maintenance issues.

- Preserve GitHub bot identity during bulk issue sync
- Keep bot-authored issues out of filtered queues after the next sync