### PR TITLE
Show rate-limit retry times in local time

### DIFF
--- a/context/testing.md
+++ b/context/testing.md
@@ -111,6 +111,10 @@ modules (`.github/workflows/ci.yml::e2e`). Keep CI unit tests serialized on
 memory-bounded self-hosted runners; assertions can finish before a pooled worker
 dies during teardown (`frontend/vite.config.ts::resolveUnitTestWorkers`).
 
+Timezone-sensitive Vitest tests must not mutate `process.env.TZ` after workers
+start; launch the test process with `TZ` or stub the locale formatter instead
+(`packages/ui/src/components/detail/operation-gates.test.ts:8`).
+
 Full-stack e2e serves the frontend embedded in the e2e-server binary
 (`internal/web/dist`), not live sources: run `make frontend` before building
 `cmd/e2e-server` locally, or the suite silently validates a stale bundle and

--- a/frontend/tests/e2e/inline-review.spec.ts
+++ b/frontend/tests/e2e/inline-review.spec.ts
@@ -662,7 +662,7 @@ test("a loaded draft becomes unpublishable when review_draft flips unavailable",
   // draft view clearing while gated is the store's designed behavior;
   // the draft itself persists server-side, so flipping back must
   // restore it.
-  const rateLimitedReason = "github.com rate-limited; retry at 14:35";
+  const rateLimitedReason = "github.com rate-limited";
   const publishCalls: string[] = [];
   page.on("request", (request) => {
     if (request.method() === "GET") return;
@@ -720,7 +720,7 @@ test("a loaded draft becomes unpublishable when review_draft flips unavailable",
   await page.clock.fastForward(61_000);
   await expect.poll(() => detailGets).toBeGreaterThan(getsBefore);
   await expect(page.getByRole("button", { name: "Publish review" })).toHaveCount(0);
-  await expect(page.locator(".review-warning")).toContainText(rateLimitedReason);
+  await expect(page.locator(".review-warning")).toContainText(/github\.com rate-limited; retry at \d{2}:\d{2}/);
 
   // Flip back: the server-side draft survived the gated window and
   // the view restores it, publishable again.

--- a/frontend/tests/e2e/write-credential-gating.spec.ts
+++ b/frontend/tests/e2e/write-credential-gating.spec.ts
@@ -287,7 +287,7 @@ test.describe("missing write credential gates non-merge mutations", () => {
     // gating: when only update_content is rate-limited, content edits
     // disable with the retry reason while unrelated mutations (close)
     // stay available.
-    const rateLimitedReason = "github.com rate-limited; retry at 14:35";
+    const rateLimitedReason = "github.com rate-limited";
     await mockApi(page);
     const rateLimitedOps = {
       ...Object.fromEntries(Object.keys(operations).map((k) => [k, { available: true }])),
@@ -317,7 +317,7 @@ test.describe("missing write credential gates non-merge mutations", () => {
 
     const editTitle = page.locator(".edit-title-btn");
     await expect(editTitle).toBeDisabled();
-    await expect(editTitle).toHaveAttribute("title", rateLimitedReason);
+    await expect(editTitle).toHaveAttribute("title", /github\.com rate-limited; retry at \d{2}:\d{2}/);
 
     const closeButton = page.locator(".btn--close").first();
     await expect(closeButton).toBeEnabled();

--- a/internal/server/e2etest/operation_availability_test.go
+++ b/internal/server/e2etest/operation_availability_test.go
@@ -1,0 +1,77 @@
+package e2etest
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/middleman/internal/apiclient"
+	"go.kenn.io/middleman/internal/db"
+	ghclient "go.kenn.io/middleman/internal/github"
+	"go.kenn.io/middleman/internal/server"
+	"go.kenn.io/middleman/internal/testutil/dbtest"
+	"go.kenn.io/middleman/internal/testutil/servertest"
+)
+
+func TestPullDetailReportsPausedRateTrackerE2E(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	database := dbtest.Open(t)
+	tracker := ghclient.NewRateTracker(database, "github.com", "rest")
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": &mockGH{}},
+		database,
+		nil,
+		[]ghclient.RepoRef{{Owner: "acme", Name: "widget", PlatformHost: "github.com"}},
+		time.Minute,
+		map[string]*ghclient.RateTracker{ghclient.RateBucketKey("github", "github.com"): tracker},
+		nil,
+	)
+	t.Cleanup(syncer.Stop)
+
+	repoID, err := database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
+	require.NoError(err)
+	_, err = database.UpsertMergeRequest(t.Context(), &db.MergeRequest{
+		RepoID:         repoID,
+		PlatformID:     7001,
+		Number:         7,
+		URL:            "https://github.com/acme/widget/pull/7",
+		Title:          "Update widget",
+		Author:         "ada",
+		State:          "open",
+		CreatedAt:      time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC),
+		UpdatedAt:      time.Date(2026, time.July, 22, 12, 5, 0, 0, time.UTC),
+		LastActivityAt: time.Date(2026, time.July, 22, 12, 5, 0, 0, time.UTC),
+	})
+	require.NoError(err)
+
+	resetAt := time.Now().UTC().Truncate(time.Second).Add(30 * time.Minute)
+	tracker.UpdateFromRate(ghclient.Rate{Limit: 5000, Remaining: 0, Reset: resetAt})
+
+	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{
+		HostCheckAllowLoopbackAnyPort: true,
+	})
+	middleman := httptest.NewServer(srv)
+	t.Cleanup(middleman.Close)
+
+	client, err := apiclient.NewWithHTTPClient(middleman.URL, middleman.Client())
+	require.NoError(err)
+	response, err := client.HTTP.GetPullWithResponse(t.Context(), "github", "acme", "widget", 7)
+	require.NoError(err)
+	require.Equal(http.StatusOK, response.StatusCode(), string(response.Body))
+	require.NotNil(response.JSON200)
+	require.NotNil(response.JSON200.Repo.Operations)
+
+	merge := response.JSON200.Repo.Operations.MergePr
+	assert.False(merge.Available)
+	require.NotNil(merge.Code)
+	assert.Equal("rate_limited", *merge.Code)
+	require.NotNil(merge.UnavailableReason)
+	assert.Equal("github.com rate-limited", *merge.UnavailableReason)
+	require.NotNil(merge.RetryAt)
+	assert.Equal(resetAt.Format(time.RFC3339), *merge.RetryAt)
+}

--- a/internal/server/operation_availability.go
+++ b/internal/server/operation_availability.go
@@ -619,15 +619,12 @@ func (s *Server) probeWriteCredential(
 }
 
 func formatRateLimit(host string, resetAt *time.Time) rateLimitAvailability {
-	res := rateLimitAvailability{limited: true}
+	res := rateLimitAvailability{
+		limited: true,
+		reason:  fmt.Sprintf("%s rate-limited", host),
+	}
 	if resetAt != nil {
 		res.retryAt = formatUTCRFC3339(*resetAt)
-		res.reason = fmt.Sprintf(
-			"%s rate-limited; retry at %s",
-			host, resetAt.UTC().Format("15:04"),
-		)
-		return res
 	}
-	res.reason = fmt.Sprintf("%s rate-limited", host)
 	return res
 }

--- a/internal/server/operation_availability_test.go
+++ b/internal/server/operation_availability_test.go
@@ -57,7 +57,7 @@ func TestDeriveOperationAvailability(t *testing.T) {
 	resetAt := time.Date(2026, 5, 19, 14, 35, 0, 0, time.UTC)
 	limitedRate := rateLimitAvailability{
 		limited: true,
-		reason:  "github.com rate-limited; retry at 14:35",
+		reason:  "github.com rate-limited",
 		retryAt: resetAt.UTC().Format(time.RFC3339),
 	}
 	repoCanMerge := db.Repo{ViewerCanMerge: true}
@@ -182,7 +182,7 @@ func TestDeriveOperationAvailability(t *testing.T) {
 			rate: limitedRate,
 			expected: OperationAvailability{
 				Code:              availabilityCodeRateLimited,
-				UnavailableReason: "github.com rate-limited; retry at 14:35",
+				UnavailableReason: "github.com rate-limited",
 				RetryAt:           resetAt.UTC().Format(time.RFC3339),
 			},
 		},
@@ -276,7 +276,7 @@ func TestFormatRateLimit(t *testing.T) {
 	resetAt := time.Date(2026, 5, 19, 14, 35, 0, 0, time.UTC)
 	got := formatRateLimit("github.com", &resetAt)
 	assert.True(got.limited)
-	assert.Equal("github.com rate-limited; retry at 14:35", got.reason)
+	assert.Equal("github.com rate-limited", got.reason)
 	assert.Equal(resetAt.UTC().Format(time.RFC3339), got.retryAt)
 
 	unknown := formatRateLimit("ghe.example.com", nil)

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -2034,7 +2034,8 @@
             />
           {/if}
           {@const mergeOp = repoOperations?.merge_pr}
-          {@const mergeOpUnavailable = mergeOp !== undefined && !mergeOp.available}
+          {@const mergeGate = operationGate(mergeOp)}
+          {@const mergeOpUnavailable = mergeGate.unavailable}
           {#if repoSettings && (mergeOp !== undefined
               || (capabilities.merge_mutation && repoSettings.viewerCanMerge))}
             {@const mergeSettings = repoSettings}
@@ -2048,7 +2049,7 @@
                 : headPinMissing
                 ? "The reviewed head commit has not been synced yet; merging is disabled until the next sync records it"
                 : mergeOpUnavailable
-                  ? mergeOp?.unavailable_reason ?? ""
+                  ? mergeGate.reason
                   : deferredMergePending
                     ? "A background merge is queued to run if its pending CI checks pass. Click to merge immediately; close the pull request to cancel."
                     : ""}

--- a/packages/ui/src/components/detail/PullDetail.test.ts
+++ b/packages/ui/src/components/detail/PullDetail.test.ts
@@ -876,6 +876,12 @@ describe("PullDetail approvals", () => {
   it("renders the merge button as disabled with reason when operations.merge_pr.available is false", async () => {
     const detail = pullDetail();
     detail.repo.capabilities.merge_mutation = true;
+    const retryAt = "2026-05-19T14:35:00Z";
+    const localRetryTime = new Date(retryAt).toLocaleTimeString(undefined, {
+      hour: "2-digit",
+      minute: "2-digit",
+      hourCycle: "h23",
+    });
 
     renderPullDetail(detail, {
       AllowSquashMerge: true,
@@ -886,8 +892,8 @@ describe("PullDetail approvals", () => {
         merge_pr: {
           available: false,
           code: "rate_limited",
-          unavailable_reason: "github.com rate-limited; retry at 14:35",
-          retry_at: "2026-05-19T14:35:00Z",
+          unavailable_reason: "github.com rate-limited",
+          retry_at: retryAt,
         },
       },
     });
@@ -898,7 +904,7 @@ describe("PullDetail approvals", () => {
       return found as HTMLButtonElement;
     });
     expect(button.disabled).toBe(true);
-    expect(button.title).toBe("github.com rate-limited; retry at 14:35");
+    expect(button.title).toBe(`github.com rate-limited; retry at ${localRetryTime}`);
   });
 
   it("disables ready-for-review with reason when its operation is unavailable", async () => {

--- a/packages/ui/src/components/detail/operation-gates.test.ts
+++ b/packages/ui/src/components/detail/operation-gates.test.ts
@@ -1,20 +1,14 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OperationAvailability } from "../../api/types.js";
 import { operationGate } from "./operation-gates.js";
 
-const originalTimeZone = process.env.TZ;
-
 afterEach(() => {
-  if (originalTimeZone === undefined) {
-    delete process.env.TZ;
-  } else {
-    process.env.TZ = originalTimeZone;
-  }
+  vi.restoreAllMocks();
 });
 
 describe("operationGate", () => {
   it("formats rate-limit retry times in the user's local timezone", () => {
-    process.env.TZ = "America/Chicago";
+    const toLocaleTimeString = vi.spyOn(Date.prototype, "toLocaleTimeString").mockReturnValue("09:35");
     const operation: OperationAvailability = {
       available: false,
       code: "rate_limited",
@@ -25,6 +19,11 @@ describe("operationGate", () => {
     expect(operationGate(operation)).toEqual({
       unavailable: true,
       reason: "github.com rate-limited; retry at 09:35",
+    });
+    expect(toLocaleTimeString).toHaveBeenCalledWith(undefined, {
+      hour: "2-digit",
+      minute: "2-digit",
+      hourCycle: "h23",
     });
   });
 

--- a/packages/ui/src/components/detail/operation-gates.test.ts
+++ b/packages/ui/src/components/detail/operation-gates.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { OperationAvailability } from "../../api/types.js";
+import { operationGate } from "./operation-gates.js";
+
+const originalTimeZone = process.env.TZ;
+
+afterEach(() => {
+  if (originalTimeZone === undefined) {
+    delete process.env.TZ;
+  } else {
+    process.env.TZ = originalTimeZone;
+  }
+});
+
+describe("operationGate", () => {
+  it("formats rate-limit retry times in the user's local timezone", () => {
+    process.env.TZ = "America/Chicago";
+    const operation: OperationAvailability = {
+      available: false,
+      code: "rate_limited",
+      unavailable_reason: "github.com rate-limited",
+      retry_at: "2026-05-19T14:35:00Z",
+    };
+
+    expect(operationGate(operation)).toEqual({
+      unavailable: true,
+      reason: "github.com rate-limited; retry at 09:35",
+    });
+  });
+
+  it("preserves non-rate-limit reasons", () => {
+    const operation: OperationAvailability = {
+      available: false,
+      code: "missing_write_credential",
+      unavailable_reason: "No user credential for writes on github.com",
+    };
+
+    expect(operationGate(operation)).toEqual({
+      unavailable: true,
+      reason: "No user credential for writes on github.com",
+    });
+  });
+});

--- a/packages/ui/src/components/detail/operation-gates.ts
+++ b/packages/ui/src/components/detail/operation-gates.ts
@@ -11,6 +11,21 @@ export type OperationGate = { unavailable: boolean; reason: string };
 
 const availableGate: OperationGate = { unavailable: false, reason: "" };
 
+function unavailableReason(op: OperationAvailability): string {
+  const reason = op.unavailable_reason ?? "";
+  if (op.code !== "rate_limited" || !op.retry_at) return reason;
+
+  const retryAt = new Date(op.retry_at);
+  if (Number.isNaN(retryAt.getTime())) return reason;
+
+  const localRetryTime = retryAt.toLocaleTimeString(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  });
+  return reason ? `${reason}; retry at ${localRetryTime}` : `Retry at ${localRetryTime}`;
+}
+
 /**
  * Gate for one operation.
  *
@@ -27,7 +42,7 @@ export function operationGate(op: OperationAvailability | undefined): OperationG
   if (op === undefined || op.available) {
     return availableGate;
   }
-  return { unavailable: true, reason: op.unavailable_reason ?? "" };
+  return { unavailable: true, reason: unavailableReason(op) };
 }
 
 /**

--- a/packages/ui/src/stores/detail.svelte.test.ts
+++ b/packages/ui/src/stores/detail.svelte.test.ts
@@ -76,6 +76,7 @@ describe("createDetailStore", () => {
   afterEach(() => {
     for (const item of getFlashes()) dismissFlash(item.id);
     localStorage.clear();
+    vi.restoreAllMocks();
     vi.useRealTimers();
   });
 
@@ -406,6 +407,47 @@ describe("createDetailStore", () => {
         }),
       }),
     );
+  });
+
+  it("shows rate-limit retry timing in local time when applying a suggestion", async () => {
+    const toLocaleTimeString = vi.spyOn(Date.prototype, "toLocaleTimeString").mockReturnValue("09:35");
+    const get = vi.fn().mockResolvedValue({ data: pullDetail("reviewed-head") });
+    const post = vi.fn(async (path: string) => {
+      if (path.endsWith("/review-suggestions/apply")) {
+        return {
+          error: {
+            code: ProblemCodes.rateLimited,
+            type: "about:blank",
+            title: "Too Many Requests",
+            detail: "github.com rate-limited",
+            details: { retryAfter: "2026-05-19T14:35:00Z" },
+          },
+        };
+      }
+      return { error: undefined };
+    });
+    const store = createDetailStore({ client: mockClient({ GET: get, POST: post }) });
+    await store.loadDetail("acme", "widget", 7, {
+      provider: "github",
+      platformHost: "github.com",
+      repoPath: "acme/widget",
+      sync: false,
+    });
+
+    const ok = await store.applyReviewSuggestions("acme", "widget", 7, {
+      suggestions: [{ threadID: "thread-1", replacement: "return publish();" }],
+    });
+
+    expect(ok).toBe(false);
+    expect(getFlash()).toMatchObject({
+      message: "github.com rate-limited; retry at 09:35",
+      tone: "danger",
+    });
+    expect(toLocaleTimeString).toHaveBeenCalledWith(undefined, {
+      hour: "2-digit",
+      minute: "2-digit",
+      hourCycle: "h23",
+    });
   });
 
   it("syncs detail before returning false for apply-suggestion state conflicts", async () => {

--- a/packages/ui/src/stores/detail.svelte.ts
+++ b/packages/ui/src/stores/detail.svelte.ts
@@ -4,6 +4,7 @@ import {
   isProblem,
   problemConflictContext,
   problemConflictReason,
+  problemRetryAfter,
   type ConflictReason,
   type ProblemBody,
 } from "../api/problems.js";
@@ -59,7 +60,18 @@ export interface ApplySuggestionConflict {
 }
 
 function apiErrorMessage(error: { detail?: string; title?: string }, fallback: string): string {
-  return error.detail ?? error.title ?? fallback;
+  const message = error.detail ?? error.title ?? fallback;
+  if (!isProblem(error)) return message;
+
+  const retryAt = problemRetryAfter(error);
+  if (!retryAt) return message;
+
+  const localRetryTime = retryAt.toLocaleTimeString(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  });
+  return `${message}; retry at ${localRetryTime}`;
 }
 
 function applySuggestionRefreshReason(problem: ProblemBody): Exclude<ConflictReason, "conflict"> | undefined {


### PR DESCRIPTION
Rate-limit retry guidance now uses the maintainer's local clock while preserving UTC instants at the API boundary.

- Show local retry times in disabled PR and review actions
- Include the same local retry time when a mutation reaches the rate limit