### PR TITLE
Make Kata repository mappings searchable

### DIFF
--- a/docs/superpowers/plans/2026-07-22-kata-repository-typeahead.md
+++ b/docs/superpowers/plans/2026-07-22-kata-repository-typeahead.md
@@ -34,13 +34,13 @@ Extend the `saves a Kata mapping to a selected known Middleman project` fixture 
 
 ```ts
 {
-  display_name: "Agentsview",
+  display_name: "Tools",
   repo: {
     provider: "github",
     platform_host: "github.com",
-    owner: "kenn-io",
-    name: "agentsview",
-    repo_path: "kenn-io/agentsview",
+    owner: "acme",
+    name: "tools",
+    repo_path: "acme/tools",
     capabilities: defaultProviderCapabilities,
   },
 },
@@ -55,7 +55,7 @@ const query = screen.getByRole("combobox", { name: pickerName });
 await fireEvent.input(query, { target: { value: "middle" } });
 
 expect(screen.getByRole("option", { name: "Middleman · kenn-io/middleman" })).toBeTruthy();
-expect(screen.queryByRole("option", { name: "Agentsview · kenn-io/agentsview" })).toBeNull();
+expect(screen.queryByRole("option", { name: "Tools · acme/tools" })).toBeNull();
 await fireEvent.mouseDown(screen.getByRole("option", { name: "Middleman · kenn-io/middleman" }));
 ```
 

--- a/docs/superpowers/plans/2026-07-22-kata-repository-typeahead.md
+++ b/docs/superpowers/plans/2026-07-22-kata-repository-typeahead.md
@@ -1,0 +1,177 @@
+# Kata Repository Typeahead Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the manual Kata project repository picker searchable by replacing its non-filterable dropdown with kit-ui's existing `Typeahead`.
+
+**Architecture:** Keep mapping identity and persistence unchanged. Adapt the existing `RepoOption` list to kit-ui's `TypeaheadOption` shape in `KataProjectMappingsSettings`, then bind `onselect` to the existing draft repository key.
+
+**Tech Stack:** Svelte 5, TypeScript, kit-ui `Typeahead`, Testing Library, Vite+ Vitest
+
+## Global Constraints
+
+- Reuse kit-ui's existing `Typeahead`; do not change kit-ui or add another picker implementation.
+- Search locally across the current display-name and repository-path label.
+- Preserve the provider-qualified repository key used by `repoOptionsByKey` and mapping persistence.
+- Leave daemon and other short enumerated controls on `SelectDropdown`.
+- Use Vite+ commands, never npm.
+
+---
+
+### Task 1: Replace the repository dropdown with the existing typeahead
+
+**Files:**
+- Modify: `frontend/src/lib/components/settings/KataProjectMappingsSettings.svelte:1-92,434-441,572-585`
+- Test: `frontend/src/lib/components/settings/KataProjectMappingsSettings.test.ts:80-208`
+
+**Interfaces:**
+- Consumes: kit-ui `Typeahead` and `TypeaheadOption`; existing `RepoOption.key`, `RepoOption.label`, `draft.repoKey`, and `repoOptionsByKey`.
+- Produces: `repoTypeaheadOptions: TypeaheadOption[]`, where `name` is the existing provider-qualified repository key and `label` is the existing display-name plus repository-path label.
+
+- [ ] **Step 1: Write the failing interaction test**
+
+Extend the `saves a Kata mapping to a selected known Middleman project` fixture with a second repository target:
+
+```ts
+{
+  display_name: "Agentsview",
+  repo: {
+    provider: "github",
+    platform_host: "github.com",
+    owner: "kenn-io",
+    name: "agentsview",
+    repo_path: "kenn-io/agentsview",
+    capabilities: defaultProviderCapabilities,
+  },
+},
+```
+
+Replace the dropdown interaction with the typeahead contract:
+
+```ts
+const pickerName = "Kata project project-kata repository target";
+await fireEvent.click(screen.getByRole("button", { name: pickerName }));
+const query = screen.getByRole("combobox", { name: pickerName });
+await fireEvent.input(query, { target: { value: "middle" } });
+
+expect(screen.getByRole("option", { name: "Middleman · kenn-io/middleman" })).toBeTruthy();
+expect(screen.queryByRole("option", { name: "Agentsview · kenn-io/agentsview" })).toBeNull();
+await fireEvent.mouseDown(screen.getByRole("option", { name: "Middleman · kenn-io/middleman" }));
+```
+
+Update the two closed-control assertions to use the typeahead trigger's button role:
+
+```ts
+expect(screen.getByRole("button", { name: /project-kata repository target/ }).textContent).toContain("Middleman");
+expect(screen.getByRole("button", { name: /project-unmapped repository target/ }).textContent).toContain(
+  "Select a repository",
+);
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails for the missing typeahead**
+
+Run:
+
+```bash
+cd frontend && ../node_modules/.bin/vp test run --project unit src/lib/components/settings/KataProjectMappingsSettings.test.ts
+```
+
+Expected: FAIL because the closed repository control is still a `combobox` rather than the expected typeahead trigger button.
+
+- [ ] **Step 3: Implement the minimal Typeahead adapter and control replacement**
+
+Import the existing kit primitive:
+
+```ts
+import { Typeahead, type TypeaheadOption } from "@kenn-io/kit-ui";
+```
+
+Replace `repoSelectOptions` with a typeahead-shaped derived value:
+
+```ts
+const repoTypeaheadOptions = $derived<TypeaheadOption[]>(
+  repoOptions.map((option) => ({ name: option.key, label: option.label })),
+);
+```
+
+Replace only the repository-target control:
+
+```svelte
+<Typeahead
+  value={draft.repoKey}
+  options={repoTypeaheadOptions}
+  fallbackLabel="Select a repository"
+  placeholder={`Kata project ${label} repository target`}
+  emptyLabel="No matching repositories"
+  onselect={(value) => {
+    draft.repoKey = value;
+  }}
+  disabled={embedded || saving}
+/>
+```
+
+Replace the table's old SelectDropdown layout overrides with public Typeahead sizing knobs:
+
+```css
+.mapping-table :global(.kit-typeahead) {
+  width: 100%;
+  min-width: 0;
+  max-width: none;
+  --typeahead-control-height: 30px;
+  --typeahead-control-font-size: var(--font-size-sm);
+}
+```
+
+- [ ] **Step 4: Run the focused test and verify it passes**
+
+Run:
+
+```bash
+cd frontend && ../node_modules/.bin/vp test run --project unit src/lib/components/settings/KataProjectMappingsSettings.test.ts
+```
+
+Expected: PASS with the filter assertion and existing mapping-save assertion both satisfied.
+
+- [ ] **Step 5: Validate the Svelte component**
+
+Run:
+
+```bash
+vp exec -- svelte-mcp svelte-autofixer ./frontend/src/lib/components/settings/KataProjectMappingsSettings.svelte --svelte-version 5
+```
+
+Expected: no Svelte errors or required fixes.
+
+Run:
+
+```bash
+make frontend-check
+```
+
+Expected: formatting, lint, type, Svelte, and kit-ui checks pass.
+
+- [ ] **Step 6: Run the full affected frontend suite**
+
+Run:
+
+```bash
+cd frontend && ../node_modules/.bin/vp test run --project unit
+```
+
+Expected: all frontend unit tests pass.
+
+- [ ] **Step 7: Sync context and commit the implementation**
+
+Run `scripts/context-sync --check`, inspect the intended diff under the repository-local `context-sync --commit` workflow, then stage only:
+
+```text
+docs/superpowers/plans/2026-07-22-kata-repository-typeahead.md
+frontend/src/lib/components/settings/KataProjectMappingsSettings.svelte
+frontend/src/lib/components/settings/KataProjectMappingsSettings.test.ts
+```
+
+Create a normal hook-verified commit using the mandatory commit skill with subject:
+
+```text
+fix: make Kata repository mappings searchable
+```

--- a/docs/superpowers/specs/2026-07-22-kata-repository-typeahead-design.md
+++ b/docs/superpowers/specs/2026-07-22-kata-repository-typeahead-design.md
@@ -1,0 +1,54 @@
+# Kata Repository Typeahead
+
+## Problem
+
+The manual Kata project-mapping table uses `SelectDropdown` for repository
+targets. The repository list can be long, but this control only supports
+scrolling through the full list. Middleman already depends on kit-ui's
+`Typeahead`, which provides filtering, keyboard navigation, match highlighting,
+and popover positioning for this interaction.
+
+## Decision
+
+Replace only the repository-target `SelectDropdown` in
+`KataProjectMappingsSettings` with the existing kit-ui `Typeahead`. Daemon and
+other short enumerated pickers remain `SelectDropdown` controls.
+
+Each typeahead option uses the existing provider-qualified repository key as its
+stable `name`. Its searchable label includes both the configured display name
+and `repo_path`, preserving the current visible option text and allowing either
+form to match. The closed trigger shows the same full label so repositories with
+similar display names remain distinguishable.
+
+An empty mapping shows `Select a repository`. Opening the control focuses its
+query input; typing filters locally, Arrow keys move through matches, Enter
+selects the highlighted repository, and Escape closes the list. The control is
+disabled under the same embedded and saving conditions as today.
+
+## Data And Errors
+
+Selection continues to write the repository key into `draft.repoKey`.
+`buildPendingMappings` resolves that key through the existing
+`repoOptionsByKey` map, so the saved provider, platform host, and repository path
+are unchanged. Unavailable configured mappings remain selectable and removable.
+
+The option source is already loaded with the mapping diagnostics, so filtering
+is local and introduces no new loading, remote-search, or error state.
+
+## Verification
+
+A focused component test will open a new mapping's repository picker, type a
+repository query, prove non-matching options are removed, select the remaining
+option, and verify the existing save request still contains the full repository
+identity. Existing tests continue to cover inferred selections, empty
+selections, and unavailable configured mappings.
+
+After the final edit, run Svelte analysis on the component, the focused
+component test, and the full frontend test suite.
+
+## Non-goals
+
+- Changing kit-ui or adding another typeahead implementation.
+- Adding remote repository search.
+- Changing mapping persistence or API contracts.
+- Converting short enumerated dropdowns that do not need filtering.

--- a/frontend/src/lib/components/settings/KataProjectMappingsSettings.svelte
+++ b/frontend/src/lib/components/settings/KataProjectMappingsSettings.svelte
@@ -2,6 +2,7 @@
   import PlusIcon from "@lucide/svelte/icons/plus";
   import RotateCcwIcon from "@lucide/svelte/icons/rotate-ccw";
   import TrashIcon from "@lucide/svelte/icons/trash-2";
+  import { Typeahead, type TypeaheadOption } from "@kenn-io/kit-ui";
   import { onMount, untrack } from "svelte";
   import { Button, Chip, SelectDropdown } from "@middleman/ui";
   import type { KataProjectRepoMapping } from "@middleman/ui/api/types";
@@ -84,8 +85,8 @@
       .sort((left, right) => left.label.localeCompare(right.label));
   });
   const repoOptionsByKey = $derived.by(() => new Map(repoOptions.map((option) => [option.key, option])));
-  const repoSelectOptions = $derived(
-    repoOptions.map((option) => ({ value: option.key, label: option.label })),
+  const repoTypeaheadOptions = $derived<TypeaheadOption[]>(
+    repoOptions.map((option) => ({ name: option.key, label: option.label })),
   );
   const pendingMappings = $derived(buildPendingMappings());
   const isDirty = $derived(
@@ -432,11 +433,15 @@
                   />
                 </td>
                 <td>
-                  <SelectDropdown
-                    title={`Kata project ${label} repository target`}
+                  <Typeahead
                     value={draft.repoKey}
-                    options={[{ value: "", label: "Select a repository" }, ...repoSelectOptions]}
-                    onchange={(value) => { draft.repoKey = value; }}
+                    options={repoTypeaheadOptions}
+                    fallbackLabel="Select a repository"
+                    placeholder={`Kata project ${label} repository target`}
+                    emptyLabel="No matching repositories"
+                    onselect={(value) => {
+                      draft.repoKey = value;
+                    }}
                     disabled={embedded || saving}
                   />
                 </td>
@@ -601,15 +606,12 @@
     min-width: 160px;
   }
 
-  .mapping-table :global(.kit-select-dropdown) {
+  .mapping-table :global(.kit-typeahead) {
     width: 100%;
     min-width: 0;
-  }
-
-  .mapping-table :global(.kit-select-dropdown__trigger) {
-    height: 30px;
-    font-size: var(--font-size-sm);
-    font-weight: 400;
+    max-width: none;
+    --typeahead-control-height: 30px;
+    --typeahead-control-font-size: var(--font-size-sm);
   }
 
   .daemon-col {

--- a/frontend/src/lib/components/settings/KataProjectMappingsSettings.test.ts
+++ b/frontend/src/lib/components/settings/KataProjectMappingsSettings.test.ts
@@ -109,7 +109,7 @@ describe("KataProjectMappingsSettings", () => {
 
     expect((screen.getByLabelText("Kata project project-kata daemon ID") as HTMLInputElement).value).toBe("work");
     expect((screen.getByLabelText("Kata project project-kata UID") as HTMLInputElement).value).toBe("project-kata");
-    expect(screen.getByRole("combobox", { name: /project-kata repository target/ }).textContent).toContain("Middleman");
+    expect(screen.getByRole("button", { name: /project-kata repository target/ }).textContent).toContain("Middleman");
   });
 
   it("saves a Kata mapping to a selected known Middleman project", async () => {
@@ -138,6 +138,17 @@ describe("KataProjectMappingsSettings", () => {
             capabilities: defaultProviderCapabilities,
           },
         },
+        {
+          display_name: "Agentsview",
+          repo: {
+            provider: "github",
+            platform_host: "github.com",
+            owner: "kenn-io",
+            name: "agentsview",
+            repo_path: "kenn-io/agentsview",
+            capabilities: defaultProviderCapabilities,
+          },
+        },
       ],
     });
     const onUpdate = vi.fn();
@@ -160,10 +171,14 @@ describe("KataProjectMappingsSettings", () => {
       target: { value: "project-kata" },
     });
 
-    await fireEvent.click(screen.getByRole("combobox", { name: /repository target/ }));
-    const option = screen.getByRole("option", { name: "Middleman · kenn-io/middleman" });
-    expect(option).toBeTruthy();
-    await fireEvent.click(option);
+    const pickerName = "Kata project project-kata repository target";
+    await fireEvent.click(screen.getByRole("button", { name: pickerName }));
+    const query = screen.getByRole("combobox", { name: pickerName });
+    await fireEvent.input(query, { target: { value: "middle" } });
+
+    expect(screen.getByRole("option", { name: "Middleman · kenn-io/middleman" })).toBeTruthy();
+    expect(screen.queryByRole("option", { name: "Agentsview · kenn-io/agentsview" })).toBeNull();
+    await fireEvent.mouseDown(screen.getByRole("option", { name: "Middleman · kenn-io/middleman" }));
 
     await fireEvent.click(screen.getByRole("button", { name: "Save Kata mappings" }));
 
@@ -202,7 +217,7 @@ describe("KataProjectMappingsSettings", () => {
     render(KataProjectMappingsSettings, { props: { mappings: [], onUpdate: vi.fn() } });
     await fireEvent.click(await screen.findByRole("button", { name: "Add override" }));
 
-    expect(screen.getByRole("combobox", { name: /project-unmapped repository target/ }).textContent).toContain(
+    expect(screen.getByRole("button", { name: /project-unmapped repository target/ }).textContent).toContain(
       "Select a repository",
     );
     expect((screen.getByRole("button", { name: "Save Kata mappings" }) as HTMLButtonElement).disabled).toBe(true);

--- a/frontend/src/lib/components/settings/KataProjectMappingsSettings.test.ts
+++ b/frontend/src/lib/components/settings/KataProjectMappingsSettings.test.ts
@@ -139,13 +139,13 @@ describe("KataProjectMappingsSettings", () => {
           },
         },
         {
-          display_name: "Agentsview",
+          display_name: "Tools",
           repo: {
             provider: "github",
             platform_host: "github.com",
-            owner: "kenn-io",
-            name: "agentsview",
-            repo_path: "kenn-io/agentsview",
+            owner: "acme",
+            name: "tools",
+            repo_path: "acme/tools",
             capabilities: defaultProviderCapabilities,
           },
         },
@@ -177,7 +177,7 @@ describe("KataProjectMappingsSettings", () => {
     await fireEvent.input(query, { target: { value: "middle" } });
 
     expect(screen.getByRole("option", { name: "Middleman · kenn-io/middleman" })).toBeTruthy();
-    expect(screen.queryByRole("option", { name: "Agentsview · kenn-io/agentsview" })).toBeNull();
+    expect(screen.queryByRole("option", { name: "Tools · acme/tools" })).toBeNull();
     await fireEvent.mouseDown(screen.getByRole("option", { name: "Middleman · kenn-io/middleman" }));
 
     await fireEvent.click(screen.getByRole("button", { name: "Save Kata mappings" }));


### PR DESCRIPTION
Large repository catalogs make manual Kata mappings slow to configure when the target picker can only be scrolled.

- Filter repository targets by display name or repository path
- Preserve provider-qualified identity and existing mapping saves

Validated with the full frontend unit suite (3,180 tests) and frontend checks.

<sup>generated by a clanker</sup>