### PR TITLE
feat: filter Kata links and remember task columns

### DIFF
--- a/docs/superpowers/plans/2026-07-22-kata-link-filtering.md
+++ b/docs/superpowers/plans/2026-07-22-kata-link-filtering.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Make Kata issue links inherit the workspace task-status scope, expose relationship filters, and show peer state only when open and closed links are mixed.
+**Goal:** Make Kata issue links inherit the workspace task-status scope, expose relationship filters, and show peer state whenever both Open and Closed are enabled.
 
-**Architecture:** Add a small pure filter model for status and relationship classification. Keep the filter state in `KataWorkspace.svelte` so relationship choices survive selected-task navigation, pass it through `KataIssueDetail.svelte`, and let `KataIssueDiscussion.svelte` hydrate full peer summaries and apply the filters. A focused `KataLinkFilterMenu.svelte` owns the checkbox popover and reuses kit-ui positioning and dismissal utilities.
+**Architecture:** Add a small pure filter model for status, relationship classification, and peer-resolution state. Keep bounded peer hydration and row presentation in the existing `KataIssueDiscussion.svelte` Links section, while controlled filter state lives in `KataWorkspace.svelte` so choices survive selected-task navigation on one daemon and reset on daemon changes. Pass that state through `KataIssueDetail.svelte`; a focused `KataLinkFilterMenu.svelte` owns the checkbox popover and reuses kit-ui positioning and dismissal utilities.
 
 **Tech Stack:** Svelte 5 runes, TypeScript, `@kenn-io/kit-ui`, `@middleman/ui`, Testing Library, Vite+ Vitest.
 
@@ -13,10 +13,13 @@
 - Keep the change frontend-only; do not alter Kata or middleman HTTP contracts.
 - Default status visibility from the active top-level `open`, `closed`, or `all` filter.
 - Keep Parent, Child, Blocks, Blocked by, and Related as relationship filters; do not derive a blocked task status.
-- Render Open/Closed state chips only when both task states are enabled.
+- Render Open/Closed state chips whenever both task states are enabled, including all-open or all-closed result sets.
 - Keep the link creation form and link-row navigation behavior unchanged.
-- Preserve relationship filter choices across selected-task navigation in the current Kata workspace.
+- Preserve relationship filter choices across selected-task navigation on the same Kata daemon.
 - Reset only the link task-state choices when the top-level status scope changes.
+- Reset task-state and relationship choices when the active Kata daemon changes.
+- Keep failed peer rows discoverable with an unavailable marker whenever at least one task state is enabled.
+- Do not show resolving state for disabled relationships or when both task states are disabled.
 - Use shared checkbox, chip, positioning, and dismissable-overlay primitives.
 - Use Svelte 5 runes and keyed each blocks; do not add legacy Svelte event syntax.
 - Follow TDD: every production behavior starts with a focused failing test and an observed expected failure.
@@ -31,7 +34,7 @@
 
 **Interfaces:**
 - Consumes: `KataTaskLink`, `KataTaskStatusFilter`, and `KataTaskSummary` from `frontend/src/lib/api/kata/taskTypes.ts`.
-- Produces: `KataLinkRelation`, `KataLinkFilters`, `KATA_LINK_RELATIONS`, `createKataLinkFilters`, `applyKataLinkStatusScope`, `relationForKataLink`, and `kataLinkMatchesFilters`.
+- Produces: `KataLinkRelation`, `KataLinkFilters`, `KataLinkPeerResolution`, `KATA_LINK_RELATIONS`, `createKataLinkFilters`, `applyKataLinkStatusScope`, `relationForKataLink`, `kataLinkCouldAffectVisibleResults`, and `kataLinkMatchesFilters`.
 
 - [ ] **Step 1: Write failing tests for defaults, relationship direction, scope reset, and unresolved peers**
 
@@ -43,6 +46,7 @@ import type { KataTaskLink, KataTaskSummary } from "../../api/kata/taskTypes.js"
 import {
   applyKataLinkStatusScope,
   createKataLinkFilters,
+  kataLinkCouldAffectVisibleResults,
   kataLinkMatchesFilters,
   relationForKataLink,
 } from "./kataLinkFilters.js";
@@ -125,14 +129,25 @@ describe("kata link filters", () => {
     });
   });
 
-  it("matches resolved peers by state and unresolved peers only in a mixed-state view", () => {
+  it("matches resolved, pending, and failed peers without silently hiding failures", () => {
     const openOnly = createKataLinkFilters("open");
     const mixed = createKataLinkFilters("all");
 
-    expect(kataLinkMatchesFilters(link(), selectedUID, peer("open"), openOnly)).toBe(true);
-    expect(kataLinkMatchesFilters(link(), selectedUID, peer("closed"), openOnly)).toBe(false);
-    expect(kataLinkMatchesFilters(link(), selectedUID, undefined, openOnly)).toBe(false);
-    expect(kataLinkMatchesFilters(link(), selectedUID, undefined, mixed)).toBe(true);
+    expect(kataLinkMatchesFilters(link(), selectedUID, { kind: "resolved", peer: peer("open") }, openOnly)).toBe(true);
+    expect(kataLinkMatchesFilters(link(), selectedUID, { kind: "resolved", peer: peer("closed") }, openOnly)).toBe(false);
+    expect(kataLinkMatchesFilters(link(), selectedUID, { kind: "pending" }, openOnly)).toBe(false);
+    expect(kataLinkMatchesFilters(link(), selectedUID, { kind: "pending" }, mixed)).toBe(true);
+    expect(kataLinkMatchesFilters(link(), selectedUID, { kind: "failed" }, openOnly)).toBe(true);
+  });
+
+  it("ignores pending work that disabled filters cannot reveal", () => {
+    const filters = createKataLinkFilters("open");
+    filters.relations.related = false;
+    expect(kataLinkCouldAffectVisibleResults(link(), selectedUID, filters)).toBe(false);
+
+    filters.relations.related = true;
+    filters.statuses.open = false;
+    expect(kataLinkCouldAffectVisibleResults(link(), selectedUID, filters)).toBe(false);
   });
 });
 ```
@@ -166,6 +181,11 @@ export interface KataLinkFilters {
   statuses: Record<KataTaskSummary["status"], boolean>;
   relations: Record<KataLinkRelation, boolean>;
 }
+
+export type KataLinkPeerResolution =
+  | { kind: "pending" }
+  | { kind: "failed" }
+  | { kind: "resolved"; peer: KataTaskSummary };
 
 function statusesForScope(scope: KataTaskStatusFilter): KataLinkFilters["statuses"] {
   return {
@@ -203,16 +223,27 @@ export function relationForKataLink(link: KataTaskLink, selectedUID: string): Ka
   return "related";
 }
 
+export function kataLinkCouldAffectVisibleResults(
+  link: KataTaskLink,
+  selectedUID: string,
+  filters: KataLinkFilters,
+): boolean {
+  return (
+    filters.relations[relationForKataLink(link, selectedUID)] &&
+    (filters.statuses.open || filters.statuses.closed)
+  );
+}
+
 export function kataLinkMatchesFilters(
   link: KataTaskLink,
   selectedUID: string,
-  peer: KataTaskSummary | undefined,
+  resolution: KataLinkPeerResolution,
   filters: KataLinkFilters,
 ): boolean {
-  const relation = relationForKataLink(link, selectedUID);
-  if (!filters.relations[relation]) return false;
-  if (!peer) return filters.statuses.open && filters.statuses.closed;
-  return filters.statuses[peer.status];
+  if (!kataLinkCouldAffectVisibleResults(link, selectedUID, filters)) return false;
+  if (resolution.kind === "failed") return true;
+  if (resolution.kind === "pending") return filters.statuses.open && filters.statuses.closed;
+  return filters.statuses[resolution.peer.status];
 }
 ```
 
@@ -496,6 +527,8 @@ Create `frontend/src/lib/components/kata/KataLinkFilterMenu.svelte` with these e
 </style>
 ```
 
+The trigger remains an application-owned native button because the shared `Button` component does not expose the underlying `HTMLButtonElement` needed by `floatingPopoverStyle` and `dismissable` for geometry and focus restoration. Reuse the shared radius, border, focus-ring, and popover tokens shown above; do not introduce a new general button primitive.
+
 - [ ] **Step 4: Run the focused menu tests and confirm they pass**
 
 Run:
@@ -542,7 +575,7 @@ Expected: commit succeeds without bypassing hooks.
 - Modify: `frontend/tests/e2e-full/kata.spec.ts`
 
 **Interfaces:**
-- Consumes: `KataLinkFilters`, `applyKataLinkStatusScope`, `createKataLinkFilters`, `kataLinkMatchesFilters`, and `relationForKataLink` from Task 1; `KataLinkFilterMenu` from Task 2.
+- Consumes: `KataLinkFilters`, `KataLinkPeerResolution`, `KataLinkRelation`, `applyKataLinkStatusScope`, `createKataLinkFilters`, `kataLinkCouldAffectVisibleResults`, `kataLinkMatchesFilters`, and `relationForKataLink` from Task 1; `KataLinkFilterMenu` from Task 2.
 - Produces: controlled props `linkFilters: KataLinkFilters` and `onLinkFiltersChange: (next: KataLinkFilters) => void` threaded from `KataWorkspace` through `KataIssueDetail` to `KataIssueDiscussion`.
 
 - [ ] **Step 1: Write failing discussion tests for inherited state, relationship filtering, chips, counts, and empty states**
@@ -621,7 +654,7 @@ it("shows only open peers by default and reports the filtered count", async () =
   expect(screen.queryByText("Open", { selector: ".state-badge" })).toBeNull();
 });
 
-it("shows state chips only for mixed-state results", async () => {
+it("shows state chips when both task-state filters are enabled", async () => {
   const selected = makeIssue();
   selected.links = [
     taskLink(1, "issue-open", "open", "related"),
@@ -652,6 +685,33 @@ it("shows state chips only for mixed-state results", async () => {
   expect(within(links).getByRole("button", { name: /Closed peer closed/ })).toBeTruthy();
   expect(within(links).getByText("Open", { selector: ".state-badge" })).toBeTruthy();
   expect(within(links).getByText("Closed", { selector: ".state-badge" })).toBeTruthy();
+});
+
+it("shows state chips when both filters are enabled even if every peer is open", async () => {
+  const selected = makeIssue();
+  selected.links = [taskLink(1, "issue-open", "open", "related")];
+  render(KataIssueDiscussion, {
+    props: {
+      issue: selected,
+      events: [],
+      currentView: { groups: [] },
+      api: makeAPI({
+        issueDetails: {
+          "issue-open": makeIssue({ uid: "issue-open", short_id: "open", title: "Only open peer", status: "open" }),
+        },
+      }),
+      activeDaemonId: "home",
+      linkFilters: createKataLinkFilters("all"),
+      onLinkFiltersChange: vi.fn(),
+      onAddComment: vi.fn(async () => true),
+      onEditIssue: vi.fn(async () => true),
+      onSelectIssue: vi.fn(),
+    },
+  });
+
+  const links = screen.getByRole("region", { name: "Links" });
+  await waitFor(() => expect(within(links).getByRole("button", { name: /Only open peer open/ })).toBeTruthy());
+  expect(within(links).getByText("Open", { selector: ".state-badge" })).toBeTruthy();
 });
 
 it("filters directional relationship types and shows the filtered-empty message", async () => {
@@ -713,7 +773,60 @@ it("shows a resolving state while a single-state filter waits for peer status", 
   expect(within(screen.getByRole("region", { name: "Links" })).getByText("Resolving linked tasks...")).toBeTruthy();
 });
 
-it("marks failed peer state as unavailable in a mixed-state view", async () => {
+it("does not show resolving state for a pending disabled relationship", () => {
+  const selected = makeIssue();
+  selected.links = [taskLink(1, "issue-pending", "pending", "related")];
+  const api = makeAPI();
+  vi.mocked(api.issue).mockImplementation(() => new Promise<KataTaskDetail>(() => {}));
+  const filters = createKataLinkFilters("open");
+  filters.relations.related = false;
+
+  render(KataIssueDiscussion, {
+    props: {
+      issue: selected,
+      events: [],
+      currentView: { groups: [] },
+      api,
+      activeDaemonId: "home",
+      linkFilters: filters,
+      onLinkFiltersChange: vi.fn(),
+      onAddComment: vi.fn(async () => true),
+      onEditIssue: vi.fn(async () => true),
+      onSelectIssue: vi.fn(),
+    },
+  });
+
+  const links = screen.getByRole("region", { name: "Links" });
+  expect(within(links).getByText("No links match these filters.")).toBeTruthy();
+  expect(within(links).queryByText(/Resolving/)).toBeNull();
+});
+
+it("shows the filtered-empty state when both task states are disabled", () => {
+  const selected = makeIssue();
+  selected.links = [taskLink(1, "issue-open", "open", "related")];
+  const filters = createKataLinkFilters("all");
+  filters.statuses.open = false;
+  filters.statuses.closed = false;
+
+  render(KataIssueDiscussion, {
+    props: {
+      issue: selected,
+      events: [],
+      currentView: makeView(),
+      api: makeAPI(),
+      activeDaemonId: "home",
+      linkFilters: filters,
+      onLinkFiltersChange: vi.fn(),
+      onAddComment: vi.fn(async () => true),
+      onEditIssue: vi.fn(async () => true),
+      onSelectIssue: vi.fn(),
+    },
+  });
+
+  expect(within(screen.getByRole("region", { name: "Links" })).getByText("No links match these filters.")).toBeTruthy();
+});
+
+it("keeps failed peer state discoverable in a single-state view", async () => {
   const selected = makeIssue();
   selected.links = [taskLink(1, "issue-missing", "missing", "related")];
   const api = makeAPI();
@@ -726,7 +839,7 @@ it("marks failed peer state as unavailable in a mixed-state view", async () => {
       currentView: { groups: [] },
       api,
       activeDaemonId: "home",
-      linkFilters: createKataLinkFilters("all"),
+      linkFilters: createKataLinkFilters("open"),
       onLinkFiltersChange: vi.fn(),
       onAddComment: vi.fn(async () => true),
       onEditIssue: vi.fn(async () => true),
@@ -737,6 +850,30 @@ it("marks failed peer state as unavailable in a mixed-state view", async () => {
   const links = screen.getByRole("region", { name: "Links" });
   await waitFor(() => expect(within(links).getByTitle("Task state unavailable")).toBeTruthy());
   expect(within(links).getByRole("button", { name: /missing state unavailable/ })).toBeTruthy();
+});
+
+it("uses current-view peer summaries without redundant detail requests", () => {
+  const selected = makeIssue();
+  selected.links = [taskLink(1, "issue-2", "I-2", "related")];
+  const api = makeAPI();
+
+  render(KataIssueDiscussion, {
+    props: {
+      issue: selected,
+      events: [],
+      currentView: makeView(),
+      api,
+      activeDaemonId: "home",
+      linkFilters: createKataLinkFilters("open"),
+      onLinkFiltersChange: vi.fn(),
+      onAddComment: vi.fn(async () => true),
+      onEditIssue: vi.fn(async () => true),
+      onSelectIssue: vi.fn(),
+    },
+  });
+
+  expect(screen.getByRole("button", { name: /Linked task/ })).toBeTruthy();
+  expect(api.issue).not.toHaveBeenCalled();
 });
 
 it("retries failed peers when the same selected detail refreshes", async () => {
@@ -786,7 +923,7 @@ Expected: FAIL because the component does not accept controlled filters, hydrate
 
 In `KataIssueDiscussion.svelte`:
 
-1. Import `ItemStateChip` from `@middleman/ui`, `KataTaskSummary`, the filter helpers, and `KataLinkFilterMenu`.
+1. Import `ItemStateChip` from `@middleman/ui`, `KataTaskSummary`, `KataLinkPeerResolution`, `KataLinkRelation`, `kataLinkCouldAffectVisibleResults`, `kataLinkMatchesFilters`, `relationForKataLink`, and `KataLinkFilterMenu`.
 2. Add required props:
 
 ```ts
@@ -804,6 +941,19 @@ let lastSelectedDetail: KataTaskDetail | null = null;
 ```
 
 4. Preserve the existing signature and generation guard, but store `detail.issue` on success and `null` on failure.
+   Build hydration candidates only for peers not already available from `currentViewPeer(uid)`, not cached in `hydratedPeers`, and not present in `pendingPeerKeys`. Keep the existing one-request-per-peer concurrency and signature guards; do not serialize the requests or add a second cache.
+
+```ts
+const peerUIDs = issue.links
+  .map((link) => linkPeerUIDFor(link, issue.issue.uid))
+  .filter(
+    (uid) =>
+      uid &&
+      currentViewPeer(uid) === undefined &&
+      hydratedPeers[uid] === undefined &&
+      !pendingPeerKeys.has(`${signature}:${uid}`),
+  );
+```
 5. Add a same-task refresh effect that drops only failed entries, causing the existing hydration effect to retry them while preserving successful peer summaries:
 
 ```ts
@@ -823,7 +973,7 @@ $effect(() => {
 ```
 
 This effect keys recovery on a new selected-detail object, not revision or link signature, because a refresh may replace the detail snapshot without changing either value.
-6. Resolve current-view peers without an API call:
+6. Resolve current-view peers without an API call and replace the existing independent `linkLabel` branching with formatting based on `relationForKataLink`:
 
 ```ts
 function currentViewPeer(uid: string): KataTaskSummary | undefined {
@@ -834,13 +984,26 @@ function currentViewPeer(uid: string): KataTaskSummary | undefined {
   return undefined;
 }
 
-function peerFor(link: KataTaskLink): KataTaskSummary | undefined {
+function peerResolution(link: KataTaskLink): KataLinkPeerResolution {
   const uid = linkPeerUID(link);
-  return currentViewPeer(uid) ?? hydratedPeers[uid] ?? undefined;
+  const current = currentViewPeer(uid);
+  if (current) return { kind: "resolved", peer: current };
+  const hydrated = hydratedPeers[uid];
+  if (hydrated === null) return { kind: "failed" };
+  if (hydrated !== undefined) return { kind: "resolved", peer: hydrated };
+  return { kind: "pending" };
 }
 
-function peerHydrationFailed(link: KataTaskLink): boolean {
-  return hydratedPeers[linkPeerUID(link)] === null;
+const relationLabels: Record<KataLinkRelation, string> = {
+  parent: "parent",
+  child: "child",
+  blocks: "blocks",
+  blocked_by: "blocked_by",
+  related: "related",
+};
+
+function linkLabel(link: KataTaskLink): string {
+  return relationLabels[relationForKataLink(link, issue.issue.uid)];
 }
 ```
 
@@ -849,15 +1012,16 @@ function peerHydrationFailed(link: KataTaskLink): boolean {
 ```ts
 const visibleLinks = $derived(
   issue.links.filter((link) =>
-    kataLinkMatchesFilters(link, issue.issue.uid, peerFor(link), linkFilters),
+    kataLinkMatchesFilters(link, issue.issue.uid, peerResolution(link), linkFilters),
   ),
 );
 const showStateChips = $derived(linkFilters.statuses.open && linkFilters.statuses.closed);
 const unresolvedPeerCount = $derived(
-  issue.links.filter((link) => {
-    const uid = linkPeerUID(link);
-    return currentViewPeer(uid) === undefined && hydratedPeers[uid] === undefined;
-  }).length,
+  issue.links.filter(
+    (link) =>
+      peerResolution(link).kind === "pending" &&
+      kataLinkCouldAffectVisibleResults(link, issue.issue.uid, linkFilters),
+  ).length,
 );
 ```
 
@@ -883,12 +1047,13 @@ Replace the Links header and list body with this structure:
 {:else}
   <div class="link-list" aria-busy={unresolvedPeerCount > 0}>
     {#each visibleLinks as link (link.id)}
-      {@const peer = peerFor(link)}
+      {@const resolution = peerResolution(link)}
+      {@const peer = resolution.kind === "resolved" ? resolution.peer : undefined}
       <button
         type="button"
         class="link-row"
         class:link-row--with-state={showStateChips}
-        aria-label={`${linkLabel(link)} ${linkPeerShortID(link)} ${peer?.title ?? ""}${showStateChips && peer ? ` ${peer.status}` : ""}${showStateChips && peerHydrationFailed(link) ? " state unavailable" : ""}`.trim()}
+        aria-label={`${linkLabel(link)} ${linkPeerShortID(link)} ${peer?.title ?? ""}${showStateChips && peer ? ` ${peer.status}` : ""}${resolution.kind === "failed" ? " state unavailable" : ""}`.trim()}
         onclick={() => void onSelectIssue(linkPeerUID(link))}
       >
         <span class="link-kind">{linkLabel(link)}</span>
@@ -896,7 +1061,7 @@ Replace the Links header and list body with this structure:
         {#if peer?.title}<span class="link-title">{peer.title}</span>{/if}
         {#if showStateChips && peer}
           <ItemStateChip state={peer.status} size="xs" />
-        {:else if showStateChips && peerHydrationFailed(link)}
+        {:else if resolution.kind === "failed"}
           <ItemStateChip state="unknown" size="xs" title="Task state unavailable" />
         {/if}
       </button>
@@ -917,45 +1082,7 @@ node ../node_modules/vite-plus/bin/vp test run --project unit src/lib/components
 
 Expected: PASS.
 
-- [ ] **Step 6: Thread controlled filter state through detail and workspace**
-
-In `KataIssueDetail.svelte`, add `linkFilters` and `onLinkFiltersChange` to `Props`, destructuring, and the `KataIssueDiscussion` call. Import `createKataLinkFilters` in `KataIssueDetail.test.ts` and update `renderDetail` with:
-
-```ts
-linkFilters: createKataLinkFilters("open"),
-onLinkFiltersChange: vi.fn(),
-```
-
-In `KataWorkspace.svelte`, import the filter model and add state beside the other workspace-owned UI state:
-
-```ts
-let linkFilters = $state<KataLinkFilters>(createKataLinkFilters("open"));
-let lastLinkStatusScope = $state<KataTaskSearchFilters["status"]>("open");
-```
-
-After `listStatusFilter` is defined, synchronize only task state:
-
-```ts
-$effect(() => {
-  const nextScope = listStatusFilter;
-  if (nextScope === lastLinkStatusScope) return;
-  lastLinkStatusScope = nextScope;
-  linkFilters = applyKataLinkStatusScope(linkFilters, nextScope);
-});
-```
-
-Pass the controlled state to `KataIssueDetail`:
-
-```svelte
-linkFilters={linkFilters}
-onLinkFiltersChange={(next) => {
-  linkFilters = next;
-}}
-```
-
-Do not key or reset `linkFilters` on selected issue changes. This is what preserves relationship choices while navigating tasks.
-
-- [ ] **Step 7: Add a workspace-level regression test for status reset and relationship persistence**
+- [ ] **Step 6: Write failing workspace regressions before controlled-state wiring**
 
 Add this test to `KataWorkspace.test.ts`:
 
@@ -1025,9 +1152,114 @@ it("keeps relationship filters across task navigation and resets state filters w
   expect((screen.getByRole("checkbox", { name: "Closed" }) as HTMLInputElement).checked).toBe(true);
   expect((screen.getByRole("checkbox", { name: "Related" }) as HTMLInputElement).checked).toBe(false);
 });
+
+it("resets the complete link-filter scope when switching daemons", async () => {
+  vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+    Response.json({
+      daemons: [
+        { id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" },
+        { id: "work", url: "http://127.0.0.1:8888", default: false, auth: "none", health: "connected" },
+      ],
+    }),
+  );
+  setActiveKataDaemon("home");
+  const homeRoot = issue("issue-home-root", "Home root", "project-kata");
+  const homePeer = issue("issue-home-peer", "Home peer", "project-kata");
+  const workRoot = issue("issue-work-root", "Work root", "project-kata");
+  const api = createDaemonWorkspaceAPI({ home: [homeRoot, homePeer], work: [workRoot] });
+  vi.mocked(api.issue).mockImplementation(async (uid: string) => {
+    const rows = [homeRoot, homePeer, workRoot];
+    const taskDetail = detail(uid, rows);
+    if (uid !== homeRoot.uid) return taskDetail;
+    return {
+      ...taskDetail,
+      links: [
+        {
+          id: 1,
+          project_id: homeRoot.project_id,
+          from: { uid: homeRoot.uid, short_id: homeRoot.short_id },
+          to: { uid: homePeer.uid, short_id: homePeer.short_id },
+          type: "related",
+          author: "fixture-user",
+          created_at: fetchedAt,
+        },
+      ],
+    };
+  });
+
+  render(KataWorkspaceRouteHost, { props: { api, initialIssue: homeRoot.uid } });
+  await waitFor(() => expect(screen.getByRole("heading", { name: "Home root" })).toBeTruthy());
+  await fireEvent.click(screen.getByRole("button", { name: "Filter links" }));
+  await fireEvent.click(screen.getByRole("checkbox", { name: "Related" }));
+  await fireEvent.keyDown(document, { key: "Escape" });
+
+  await fireEvent.click(screen.getByTestId("daemon-chip"));
+  const workDaemonRow = await screen.findByTestId("daemon-row-work");
+  await waitFor(() => expect((workDaemonRow as HTMLButtonElement).disabled).toBe(false));
+  await fireEvent.click(workDaemonRow);
+  await waitFor(() => expect(screen.getByRole("heading", { name: "Work root" })).toBeTruthy());
+
+  await fireEvent.click(screen.getByRole("button", { name: "Filter links" }));
+  expect((screen.getByRole("checkbox", { name: "Open" }) as HTMLInputElement).checked).toBe(true);
+  expect((screen.getByRole("checkbox", { name: "Closed" }) as HTMLInputElement).checked).toBe(false);
+  expect((screen.getByRole("checkbox", { name: "Related" }) as HTMLInputElement).checked).toBe(true);
+});
 ```
 
 This test uses role-based queries and asserts only the interaction contract. Do not add API-call-count assertions unrelated to link filtering.
+
+Run the workspace test now:
+
+```bash
+node ../node_modules/vite-plus/bin/vp test run --project unit src/lib/features/kata/KataWorkspace.test.ts
+```
+
+Expected: FAIL because filter state is not owned by the workspace and no daemon-scoped reset exists.
+
+- [ ] **Step 7: Thread daemon-scoped controlled filter state through detail and workspace**
+
+In `KataIssueDetail.svelte`, add `linkFilters` and `onLinkFiltersChange` to `Props`, destructuring, and the `KataIssueDiscussion` call. Import `createKataLinkFilters` in `KataIssueDetail.test.ts` and update `renderDetail` with:
+
+```ts
+linkFilters: createKataLinkFilters("open"),
+onLinkFiltersChange: vi.fn(),
+```
+
+In `KataWorkspace.svelte`, import the filter model and add state beside the other workspace-owned UI state:
+
+```ts
+let linkFilters = $state<KataLinkFilters>(createKataLinkFilters("open"));
+let lastLinkFilterScope = $state<{
+  daemonID: string | undefined;
+  status: KataTaskSearchFilters["status"];
+}>({ daemonID: undefined, status: "open" });
+```
+
+After `activeKataDaemonId` and `listStatusFilter` are defined, synchronize the daemon and status scopes together:
+
+```ts
+$effect(() => {
+  const daemonID = activeKataDaemonId;
+  const status = listStatusFilter;
+  if (daemonID !== lastLinkFilterScope.daemonID) {
+    linkFilters = createKataLinkFilters(status);
+  } else if (status !== lastLinkFilterScope.status) {
+    linkFilters = applyKataLinkStatusScope(linkFilters, status);
+  }
+  lastLinkFilterScope = { daemonID, status };
+});
+```
+
+Pass the controlled state to `KataIssueDetail`:
+
+```svelte
+linkFilters={linkFilters}
+onLinkFiltersChange={(next) => {
+  linkFilters = next;
+}}
+```
+
+Do not key or reset `linkFilters` on selected issue changes. Task navigation on one daemon preserves the state; daemon changes reset both status and relationship choices.
 
 - [ ] **Step 8: Run all affected component and workspace tests**
 
@@ -1105,6 +1337,17 @@ await expect(links.getByText("Closed", { exact: true })).toBeVisible();
 await filterPanel.getByRole("checkbox", { name: "Parent" }).click();
 await expect(links).not.toContainText("Quarterly budget review with a long title");
 await expect(links).toContainText("1 / 2");
+await filterPanel.getByRole("checkbox", { name: "Parent" }).click();
+await filterPanel.getByRole("checkbox", { name: "Related" }).click();
+await page.keyboard.press("Escape");
+```
+
+Keep the existing navigation into the parent task and back to Pay rent. After returning, reopen **Filter links**, assert **Related** is still unchecked, then re-enable it before the existing add-related-link assertions:
+
+```ts
+await links.getByRole("button", { name: "Filter links" }).click();
+await expect(filterPanel.getByRole("checkbox", { name: "Related" })).not.toBeChecked();
+await filterPanel.getByRole("checkbox", { name: "Related" }).click();
 await page.keyboard.press("Escape");
 ```
 
@@ -1121,10 +1364,9 @@ Expected: PASS against the real middleman server and seeded external Kata daemon
 From the repository root:
 
 ```bash
-./node_modules/.bin/vp test run --project unit
+(cd frontend && node ../node_modules/vite-plus/bin/vp test run --project unit)
 ./node_modules/.bin/vp run frontend-check
-cd frontend
-node ./scripts/run-e2e-to-file.ts tests/e2e-full/kata.spec.ts --grep "kata task links render"
+(cd frontend && node ./scripts/run-e2e-to-file.ts tests/e2e-full/kata.spec.ts --grep "kata task links render")
 ```
 
 Expected: all commands exit 0. The component and workspace tests own filtering and state lifetime; the focused Playwright scenario owns fixed positioning, stacking, and clipping in the real split-pane layout.

--- a/docs/superpowers/plans/2026-07-22-kata-link-filtering.md
+++ b/docs/superpowers/plans/2026-07-22-kata-link-filtering.md
@@ -466,7 +466,12 @@ Create `frontend/src/lib/components/kata/KataLinkFilterMenu.svelte` with these e
   }
 
   .link-filter-panel {
+    position: fixed;
+    z-index: var(--z-popover);
     width: 220px;
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 16px);
+    overflow-y: auto;
     padding: 10px;
     display: grid;
     gap: 10px;
@@ -534,6 +539,7 @@ Expected: commit succeeds without bypassing hooks.
 - Modify: `frontend/src/lib/components/kata/KataIssueDetail.test.ts:1-145`
 - Modify: `frontend/src/lib/features/kata/KataWorkspace.svelte:1-270,2720-2770`
 - Modify: `frontend/src/lib/features/kata/KataWorkspace.test.ts`
+- Modify: `frontend/tests/e2e-full/kata.spec.ts`
 
 **Interfaces:**
 - Consumes: `KataLinkFilters`, `applyKataLinkStatusScope`, `createKataLinkFilters`, `kataLinkMatchesFilters`, and `relationForKataLink` from Task 1; `KataLinkFilterMenu` from Task 2.
@@ -732,6 +738,38 @@ it("marks failed peer state as unavailable in a mixed-state view", async () => {
   await waitFor(() => expect(within(links).getByTitle("Task state unavailable")).toBeTruthy());
   expect(within(links).getByRole("button", { name: /missing state unavailable/ })).toBeTruthy();
 });
+
+it("retries failed peers when the same selected detail refreshes", async () => {
+  const selected = makeIssue();
+  selected.links = [taskLink(1, "issue-retry", "retry", "related")];
+  const api = makeAPI();
+  vi.mocked(api.issue)
+    .mockRejectedValueOnce(new Error("temporary"))
+    .mockResolvedValueOnce(makeIssue({ uid: "issue-retry", short_id: "retry", title: "Recovered peer" }));
+  const props = {
+    issue: selected,
+    events: [],
+    currentView: { groups: [] },
+    api,
+    activeDaemonId: "home",
+    linkFilters: createKataLinkFilters("all"),
+    onLinkFiltersChange: vi.fn(),
+    onAddComment: vi.fn(async () => true),
+    onEditIssue: vi.fn(async () => true),
+    onSelectIssue: vi.fn(),
+  };
+  const { rerender } = render(KataIssueDiscussion, { props });
+  const links = screen.getByRole("region", { name: "Links" });
+  await waitFor(() => expect(within(links).getByTitle("Task state unavailable")).toBeTruthy());
+
+  await rerender({
+    ...props,
+    issue: { ...selected, issue: { ...selected.issue } },
+  });
+
+  await waitFor(() => expect(within(links).getByRole("button", { name: /Recovered peer open/ })).toBeTruthy());
+  expect(api.issue).toHaveBeenCalledTimes(2);
+});
 ```
 
 - [ ] **Step 2: Run the discussion test and verify the new assertions fail for missing props and unfiltered rows**
@@ -762,10 +800,30 @@ onLinkFiltersChange: (next: KataLinkFilters) => void;
 let hydratedPeers = $state<Record<string, KataTaskSummary | null>>({});
 let peerHydrationSignature = $state("");
 let pendingPeerKeys = $state<ReadonlySet<string>>(new Set());
+let lastSelectedDetail: KataTaskDetail | null = null;
 ```
 
 4. Preserve the existing signature and generation guard, but store `detail.issue` on success and `null` on failure.
-5. Resolve current-view peers without an API call:
+5. Add a same-task refresh effect that drops only failed entries, causing the existing hydration effect to retry them while preserving successful peer summaries:
+
+```ts
+$effect(() => {
+  const current = issue;
+  if (
+    lastSelectedDetail !== null &&
+    current !== lastSelectedDetail &&
+    current.issue.uid === lastSelectedDetail.issue.uid
+  ) {
+    hydratedPeers = Object.fromEntries(
+      Object.entries(hydratedPeers).filter(([, peer]) => peer !== null),
+    );
+  }
+  lastSelectedDetail = current;
+});
+```
+
+This effect keys recovery on a new selected-detail object, not revision or link signature, because a refresh may replace the detail snapshot without changing either value.
+6. Resolve current-view peers without an API call:
 
 ```ts
 function currentViewPeer(uid: string): KataTaskSummary | undefined {
@@ -786,7 +844,7 @@ function peerHydrationFailed(link: KataTaskLink): boolean {
 }
 ```
 
-6. Derive visible rows and loading state:
+7. Derive visible rows and loading state:
 
 ```ts
 const visibleLinks = $derived(
@@ -999,18 +1057,79 @@ From the repository root:
 
 Expected: no unresolved Svelte correctness findings.
 
-- [ ] **Step 10: Run the full affected frontend verification**
+- [ ] **Step 10: Extend the seeded Kata Playwright link workflow**
+
+Extend `test("kata task links render, navigate, and add related links through the configured external daemon", ...)` in `frontend/tests/e2e-full/kata.spec.ts`:
+
+1. Add a closed peer:
+
+```ts
+const closedPeer = {
+  ...issueSummary({
+    id: 34,
+    uid: "issue-closed-link",
+    project_id: 1,
+    project_uid: "project-finance",
+    project_name: "Finances",
+    short_id: "closed-link",
+    qualified_id: "Finances#closed-link",
+    title: "Completed linked task",
+    body: "Closed peer body.",
+    labels: ["home"],
+  }),
+  status: "closed" as const,
+  closed_reason: "done" as const,
+  closed_at: now,
+};
+```
+
+2. Include `closedPeer` in the backend issues and add a Related link from `issues[0]!` to it.
+3. After opening `issue-rent`, add these assertions before navigating through the existing parent link:
+
+```ts
+await expect(links).toContainText("Quarterly budget review with a long title");
+await expect(links).not.toContainText("Completed linked task");
+await expect(links).toContainText("1 / 2");
+
+await links.getByRole("button", { name: "Filter links" }).click();
+const filterPanel = page.locator(".link-filter-panel");
+await expect(filterPanel).toBeVisible();
+expect(await filterPanel.evaluate((element) => getComputedStyle(element).position)).toBe("fixed");
+expect(Number(await filterPanel.evaluate((element) => getComputedStyle(element).zIndex))).toBeGreaterThan(0);
+await filterPanel.getByRole("checkbox", { name: "Closed" }).click();
+
+await expect(links).toContainText("Completed linked task");
+await expect(links.getByText("Open", { exact: true })).toBeVisible();
+await expect(links.getByText("Closed", { exact: true })).toBeVisible();
+
+await filterPanel.getByRole("checkbox", { name: "Parent" }).click();
+await expect(links).not.toContainText("Quarterly budget review with a long title");
+await expect(links).toContainText("1 / 2");
+await page.keyboard.press("Escape");
+```
+
+Run from `frontend/`:
+
+```bash
+node ./scripts/run-e2e-to-file.ts tests/e2e-full/kata.spec.ts --grep "kata task links render"
+```
+
+Expected: PASS against the real middleman server and seeded external Kata daemon.
+
+- [ ] **Step 11: Run the full affected frontend verification**
 
 From the repository root:
 
 ```bash
 ./node_modules/.bin/vp test run --project unit
 ./node_modules/.bin/vp run frontend-check
+cd frontend
+node ./scripts/run-e2e-to-file.ts tests/e2e-full/kata.spec.ts --grep "kata task links render"
 ```
 
-Expected: both commands exit 0. Do not add Playwright solely to repeat checkbox visibility; the component and workspace tests own this workflow, and no browser-only geometry is changing beyond the already-shared floating-position utilities.
+Expected: all commands exit 0. The component and workspace tests own filtering and state lifetime; the focused Playwright scenario owns fixed positioning, stacking, and clipping in the real split-pane layout.
 
-- [ ] **Step 11: Review the final diff and commit the integrated behavior**
+- [ ] **Step 12: Review the final diff and commit the integrated behavior**
 
 Review:
 
@@ -1029,7 +1148,8 @@ git add \
   frontend/src/lib/components/kata/KataIssueDetail.svelte \
   frontend/src/lib/components/kata/KataIssueDetail.test.ts \
   frontend/src/lib/features/kata/KataWorkspace.svelte \
-  frontend/src/lib/features/kata/KataWorkspace.test.ts
+  frontend/src/lib/features/kata/KataWorkspace.test.ts \
+  frontend/tests/e2e-full/kata.spec.ts
 git commit -m "feat: filter Kata links by task state and relation" \
   -m "Kata detail links should follow the maintainer's active task scope while still allowing local relationship filtering. Mixed-state results retain explicit state labels without repeating redundant chips in single-state views."
 ```

--- a/docs/superpowers/plans/2026-07-22-kata-link-filtering.md
+++ b/docs/superpowers/plans/2026-07-22-kata-link-filtering.md
@@ -1328,6 +1328,24 @@ const filterPanel = page.locator(".link-filter-panel");
 await expect(filterPanel).toBeVisible();
 expect(await filterPanel.evaluate((element) => getComputedStyle(element).position)).toBe("fixed");
 expect(Number(await filterPanel.evaluate((element) => getComputedStyle(element).zIndex))).toBeGreaterThan(0);
+const filterTriggerBox = await links.getByRole("button", { name: "Filter links" }).boundingBox();
+const filterPanelBox = await filterPanel.boundingBox();
+expect(filterTriggerBox).not.toBeNull();
+expect(filterPanelBox).not.toBeNull();
+expect(Math.abs(filterPanelBox!.x + filterPanelBox!.width - (filterTriggerBox!.x + filterTriggerBox!.width))).toBeLessThanOrEqual(2);
+expect(filterPanelBox!.x).toBeGreaterThanOrEqual(0);
+expect(filterPanelBox!.y).toBeGreaterThanOrEqual(0);
+expect(filterPanelBox!.x + filterPanelBox!.width).toBeLessThanOrEqual((page.viewportSize()?.width ?? 0) + 1);
+expect(filterPanelBox!.y + filterPanelBox!.height).toBeLessThanOrEqual((page.viewportSize()?.height ?? 0) + 1);
+
+await page.setViewportSize({ width: 720, height: 540 });
+const constrainedFilterPanelBox = await filterPanel.boundingBox();
+expect(constrainedFilterPanelBox).not.toBeNull();
+expect(constrainedFilterPanelBox!.x).toBeGreaterThanOrEqual(0);
+expect(constrainedFilterPanelBox!.y).toBeGreaterThanOrEqual(0);
+expect(constrainedFilterPanelBox!.x + constrainedFilterPanelBox!.width).toBeLessThanOrEqual(721);
+expect(constrainedFilterPanelBox!.y + constrainedFilterPanelBox!.height).toBeLessThanOrEqual(541);
+await page.setViewportSize({ width: 1280, height: 720 });
 await filterPanel.getByRole("checkbox", { name: "Closed" }).click();
 
 await expect(links).toContainText("Completed linked task");
@@ -1366,10 +1384,10 @@ From the repository root:
 ```bash
 (cd frontend && node ../node_modules/vite-plus/bin/vp test run --project unit)
 ./node_modules/.bin/vp run frontend-check
-(cd frontend && node ./scripts/run-e2e-to-file.ts tests/e2e-full/kata.spec.ts --grep "kata task links render")
+(cd frontend && node ./scripts/run-e2e-to-file.ts tests/e2e-full/kata.spec.ts)
 ```
 
-Expected: all commands exit 0. The component and workspace tests own filtering and state lifetime; the focused Playwright scenario owns fixed positioning, stacking, and clipping in the real split-pane layout.
+Expected: all commands exit 0. The component and workspace tests own filtering and state lifetime; the complete affected Kata Playwright file verifies fixed positioning, trigger anchoring, viewport containment, clipping, and the real maintainer workflow after the final spec edit.
 
 - [ ] **Step 12: Review the final diff and commit the integrated behavior**
 

--- a/docs/superpowers/plans/2026-07-22-kata-link-filtering.md
+++ b/docs/superpowers/plans/2026-07-22-kata-link-filtering.md
@@ -1,0 +1,1037 @@
+# Kata Link Filtering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Kata issue links inherit the workspace task-status scope, expose relationship filters, and show peer state only when open and closed links are mixed.
+
+**Architecture:** Add a small pure filter model for status and relationship classification. Keep the filter state in `KataWorkspace.svelte` so relationship choices survive selected-task navigation, pass it through `KataIssueDetail.svelte`, and let `KataIssueDiscussion.svelte` hydrate full peer summaries and apply the filters. A focused `KataLinkFilterMenu.svelte` owns the checkbox popover and reuses kit-ui positioning and dismissal utilities.
+
+**Tech Stack:** Svelte 5 runes, TypeScript, `@kenn-io/kit-ui`, `@middleman/ui`, Testing Library, Vite+ Vitest.
+
+## Global Constraints
+
+- Keep the change frontend-only; do not alter Kata or middleman HTTP contracts.
+- Default status visibility from the active top-level `open`, `closed`, or `all` filter.
+- Keep Parent, Child, Blocks, Blocked by, and Related as relationship filters; do not derive a blocked task status.
+- Render Open/Closed state chips only when both task states are enabled.
+- Keep the link creation form and link-row navigation behavior unchanged.
+- Preserve relationship filter choices across selected-task navigation in the current Kata workspace.
+- Reset only the link task-state choices when the top-level status scope changes.
+- Use shared checkbox, chip, positioning, and dismissable-overlay primitives.
+- Use Svelte 5 runes and keyed each blocks; do not add legacy Svelte event syntax.
+- Follow TDD: every production behavior starts with a focused failing test and an observed expected failure.
+
+---
+
+### Task 1: Define the Kata link filter contract
+
+**Files:**
+- Create: `frontend/src/lib/features/kata/kataLinkFilters.ts`
+- Create: `frontend/src/lib/features/kata/kataLinkFilters.test.ts`
+
+**Interfaces:**
+- Consumes: `KataTaskLink`, `KataTaskStatusFilter`, and `KataTaskSummary` from `frontend/src/lib/api/kata/taskTypes.ts`.
+- Produces: `KataLinkRelation`, `KataLinkFilters`, `KATA_LINK_RELATIONS`, `createKataLinkFilters`, `applyKataLinkStatusScope`, `relationForKataLink`, and `kataLinkMatchesFilters`.
+
+- [ ] **Step 1: Write failing tests for defaults, relationship direction, scope reset, and unresolved peers**
+
+Create `frontend/src/lib/features/kata/kataLinkFilters.test.ts`:
+
+```ts
+import { describe, expect, it } from "vite-plus/test";
+import type { KataTaskLink, KataTaskSummary } from "../../api/kata/taskTypes.js";
+import {
+  applyKataLinkStatusScope,
+  createKataLinkFilters,
+  kataLinkMatchesFilters,
+  relationForKataLink,
+} from "./kataLinkFilters.js";
+
+const selectedUID = "issue-selected";
+
+function link(overrides: Partial<KataTaskLink> = {}): KataTaskLink {
+  return {
+    id: 1,
+    project_id: 1,
+    from: { uid: selectedUID, short_id: "selected" },
+    to: { uid: "issue-peer", short_id: "peer" },
+    type: "related",
+    author: "maintainer",
+    created_at: "2026-07-22T12:00:00Z",
+    ...overrides,
+  };
+}
+
+function peer(status: KataTaskSummary["status"]): KataTaskSummary {
+  return {
+    id: 2,
+    uid: "issue-peer",
+    project_id: 1,
+    project_uid: "project-1",
+    project_name: "Inbox",
+    short_id: "peer",
+    qualified_id: "Inbox#peer",
+    title: "Peer task",
+    status,
+    metadata: {},
+    revision: 1,
+    author: "maintainer",
+    created_at: "2026-07-22T12:00:00Z",
+    updated_at: "2026-07-22T12:00:00Z",
+  };
+}
+
+describe("kata link filters", () => {
+  it.each([
+    ["open", { open: true, closed: false }],
+    ["closed", { open: false, closed: true }],
+    ["all", { open: true, closed: true }],
+  ] as const)("defaults task states from the %s scope", (scope, statuses) => {
+    expect(createKataLinkFilters(scope).statuses).toEqual(statuses);
+  });
+
+  it("classifies relationship direction from the selected task", () => {
+    expect(relationForKataLink(link({ type: "parent" }), selectedUID)).toBe("child");
+    expect(
+      relationForKataLink(
+        link({
+          type: "parent",
+          from: { uid: "issue-parent", short_id: "parent" },
+          to: { uid: selectedUID, short_id: "selected" },
+        }),
+        selectedUID,
+      ),
+    ).toBe("parent");
+    expect(relationForKataLink(link({ type: "blocks" }), selectedUID)).toBe("blocks");
+    expect(
+      relationForKataLink(
+        link({
+          type: "blocks",
+          from: { uid: "issue-blocker", short_id: "blocker" },
+          to: { uid: selectedUID, short_id: "selected" },
+        }),
+        selectedUID,
+      ),
+    ).toBe("blocked_by");
+  });
+
+  it("resets task states without changing relationship choices", () => {
+    const current = createKataLinkFilters("all");
+    current.relations.related = false;
+
+    expect(applyKataLinkStatusScope(current, "closed")).toEqual({
+      statuses: { open: false, closed: true },
+      relations: { ...current.relations, related: false },
+    });
+  });
+
+  it("matches resolved peers by state and unresolved peers only in a mixed-state view", () => {
+    const openOnly = createKataLinkFilters("open");
+    const mixed = createKataLinkFilters("all");
+
+    expect(kataLinkMatchesFilters(link(), selectedUID, peer("open"), openOnly)).toBe(true);
+    expect(kataLinkMatchesFilters(link(), selectedUID, peer("closed"), openOnly)).toBe(false);
+    expect(kataLinkMatchesFilters(link(), selectedUID, undefined, openOnly)).toBe(false);
+    expect(kataLinkMatchesFilters(link(), selectedUID, undefined, mixed)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run the new test and confirm the expected missing-module failure**
+
+Run from `frontend/`:
+
+```bash
+node ../node_modules/vite-plus/bin/vp test run --project unit src/lib/features/kata/kataLinkFilters.test.ts
+```
+
+Expected: FAIL because `./kataLinkFilters.js` does not exist.
+
+- [ ] **Step 3: Implement the filter model**
+
+Create `frontend/src/lib/features/kata/kataLinkFilters.ts`:
+
+```ts
+import type {
+  KataTaskLink,
+  KataTaskStatusFilter,
+  KataTaskSummary,
+} from "../../api/kata/taskTypes.js";
+
+export const KATA_LINK_RELATIONS = ["parent", "child", "blocks", "blocked_by", "related"] as const;
+
+export type KataLinkRelation = (typeof KATA_LINK_RELATIONS)[number];
+
+export interface KataLinkFilters {
+  statuses: Record<KataTaskSummary["status"], boolean>;
+  relations: Record<KataLinkRelation, boolean>;
+}
+
+function statusesForScope(scope: KataTaskStatusFilter): KataLinkFilters["statuses"] {
+  return {
+    open: scope !== "closed",
+    closed: scope !== "open",
+  };
+}
+
+export function createKataLinkFilters(scope: KataTaskStatusFilter): KataLinkFilters {
+  return {
+    statuses: statusesForScope(scope),
+    relations: {
+      parent: true,
+      child: true,
+      blocks: true,
+      blocked_by: true,
+      related: true,
+    },
+  };
+}
+
+export function applyKataLinkStatusScope(
+  current: KataLinkFilters,
+  scope: KataTaskStatusFilter,
+): KataLinkFilters {
+  return {
+    statuses: statusesForScope(scope),
+    relations: { ...current.relations },
+  };
+}
+
+export function relationForKataLink(link: KataTaskLink, selectedUID: string): KataLinkRelation {
+  if (link.type === "parent") return link.to.uid === selectedUID ? "parent" : "child";
+  if (link.type === "blocks") return link.to.uid === selectedUID ? "blocked_by" : "blocks";
+  return "related";
+}
+
+export function kataLinkMatchesFilters(
+  link: KataTaskLink,
+  selectedUID: string,
+  peer: KataTaskSummary | undefined,
+  filters: KataLinkFilters,
+): boolean {
+  const relation = relationForKataLink(link, selectedUID);
+  if (!filters.relations[relation]) return false;
+  if (!peer) return filters.statuses.open && filters.statuses.closed;
+  return filters.statuses[peer.status];
+}
+```
+
+- [ ] **Step 4: Run the focused test and confirm it passes**
+
+Run:
+
+```bash
+node ../node_modules/vite-plus/bin/vp test run --project unit src/lib/features/kata/kataLinkFilters.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Context-check and commit the filter contract**
+
+From the repository root, invoke the repository-local `context-sync` skill with `--commit`. Then invoke the mandatory commit skill and create a normal hook-verified commit:
+
+```bash
+git add frontend/src/lib/features/kata/kataLinkFilters.ts frontend/src/lib/features/kata/kataLinkFilters.test.ts
+git commit -m "feat: define Kata link filter semantics" \
+  -m "Kata link visibility needs one explicit contract for status inheritance and directional relationship names before the detail UI can apply user-controlled filters."
+```
+
+Expected: commit succeeds without `--no-verify`.
+
+---
+
+### Task 2: Build the accessible link-filter popover
+
+**Files:**
+- Create: `frontend/src/lib/components/kata/KataLinkFilterMenu.svelte`
+- Create: `frontend/src/lib/components/kata/KataLinkFilterMenu.test.ts`
+
+**Interfaces:**
+- Consumes: `KataLinkFilters`, `KataLinkRelation`, and `KATA_LINK_RELATIONS` from Task 1.
+- Produces: `KataLinkFilterMenu` with props `filters: KataLinkFilters` and `onChange: (next: KataLinkFilters) => void`.
+
+- [ ] **Step 1: Write failing interaction tests for the checkbox menu**
+
+Create `frontend/src/lib/components/kata/KataLinkFilterMenu.test.ts`:
+
+```ts
+import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { createKataLinkFilters } from "../../features/kata/kataLinkFilters.js";
+import KataLinkFilterMenu from "./KataLinkFilterMenu.svelte";
+
+describe("KataLinkFilterMenu", () => {
+  afterEach(cleanup);
+
+  it("emits independent task-state and relationship changes", async () => {
+    const filters = createKataLinkFilters("open");
+    const onChange = vi.fn();
+    render(KataLinkFilterMenu, { props: { filters, onChange } });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Filter links" }));
+    await fireEvent.click(screen.getByRole("checkbox", { name: "Closed" }));
+    expect(onChange).toHaveBeenLastCalledWith({
+      ...filters,
+      statuses: { open: true, closed: true },
+    });
+
+    await fireEvent.click(screen.getByRole("checkbox", { name: "Blocked by" }));
+    expect(onChange).toHaveBeenLastCalledWith({
+      ...filters,
+      relations: { ...filters.relations, blocked_by: false },
+    });
+  });
+
+  it("closes on Escape and returns focus to the trigger", async () => {
+    render(KataLinkFilterMenu, {
+      props: { filters: createKataLinkFilters("all"), onChange: vi.fn() },
+    });
+
+    const trigger = screen.getByRole("button", { name: "Filter links" });
+    await fireEvent.click(trigger);
+    await fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(screen.queryByRole("group", { name: "Link filters" })).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests and confirm the expected missing-component failure**
+
+Run from `frontend/`:
+
+```bash
+node ../node_modules/vite-plus/bin/vp test run --project unit src/lib/components/kata/KataLinkFilterMenu.test.ts
+```
+
+Expected: FAIL because `KataLinkFilterMenu.svelte` does not exist.
+
+- [ ] **Step 3: Implement the floating checkbox menu**
+
+Create `frontend/src/lib/components/kata/KataLinkFilterMenu.svelte` with these exact behaviors:
+
+```svelte
+<script lang="ts">
+  import { autoReposition, Checkbox, dismissable, floatingPopoverStyle } from "@kenn-io/kit-ui";
+  import FunnelIcon from "@lucide/svelte/icons/funnel";
+  import { tick } from "svelte";
+  import {
+    KATA_LINK_RELATIONS,
+    type KataLinkFilters,
+    type KataLinkRelation,
+  } from "../../features/kata/kataLinkFilters.js";
+
+  interface Props {
+    filters: KataLinkFilters;
+    onChange: (next: KataLinkFilters) => void;
+  }
+
+  let { filters, onChange }: Props = $props();
+  let open = $state(false);
+  let trigger: HTMLButtonElement | undefined = $state();
+  let panel: HTMLDivElement | undefined = $state();
+  let panelStyle = $state("");
+
+  const relationLabels: Record<KataLinkRelation, string> = {
+    parent: "Parent",
+    child: "Child",
+    blocks: "Blocks",
+    blocked_by: "Blocked by",
+    related: "Related",
+  };
+
+  $effect(() => {
+    if (!open) return;
+    const cleanups = [
+      dismissable({
+        owners: () => [panel, trigger],
+        dismiss: close,
+        escapeFocus: () => trigger,
+      }),
+      autoReposition(() => panel, position),
+    ];
+    return () => cleanups.forEach((cleanup) => cleanup());
+  });
+
+  function position(): void {
+    if (!trigger || !panel) return;
+    panelStyle = floatingPopoverStyle({
+      trigger: trigger.getBoundingClientRect(),
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+      popoverWidth: panel.offsetWidth,
+      popoverHeight: panel.offsetHeight,
+      align: "end",
+    });
+  }
+
+  function close(): void {
+    open = false;
+  }
+
+  async function toggle(): Promise<void> {
+    open = !open;
+    if (!open) return;
+    await tick();
+    position();
+  }
+
+  function changeStatus(status: "open" | "closed", checked: boolean): void {
+    onChange({ ...filters, statuses: { ...filters.statuses, [status]: checked } });
+  }
+
+  function changeRelation(relation: KataLinkRelation, checked: boolean): void {
+    onChange({ ...filters, relations: { ...filters.relations, [relation]: checked } });
+  }
+</script>
+
+<div class="link-filter-menu">
+  <button
+    bind:this={trigger}
+    type="button"
+    class="link-filter-trigger"
+    aria-label="Filter links"
+    aria-expanded={open}
+    onclick={toggle}
+  >
+    <FunnelIcon size={12} strokeWidth={2} aria-hidden="true" />
+    <span>Filters</span>
+  </button>
+
+  {#if open}
+    <div
+      bind:this={panel}
+      class="link-filter-panel kit-popover-card"
+      style={panelStyle}
+      role="group"
+      aria-label="Link filters"
+    >
+      <fieldset>
+        <legend>Task state</legend>
+        <Checkbox
+          label="Open"
+          checked={filters.statuses.open}
+          onchange={(checked) => changeStatus("open", checked)}
+        />
+        <Checkbox
+          label="Closed"
+          checked={filters.statuses.closed}
+          onchange={(checked) => changeStatus("closed", checked)}
+        />
+      </fieldset>
+      <fieldset>
+        <legend>Relationship</legend>
+        {#each KATA_LINK_RELATIONS as relation (relation)}
+          <Checkbox
+            label={relationLabels[relation]}
+            checked={filters.relations[relation]}
+            onchange={(checked) => changeRelation(relation, checked)}
+          />
+        {/each}
+      </fieldset>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .link-filter-menu {
+    position: relative;
+  }
+
+  .link-filter-trigger {
+    min-height: 26px;
+    border: 1px solid var(--border-muted);
+    border-radius: var(--radius-sm);
+    background: var(--bg-inset);
+    color: var(--text-muted);
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 3px 8px;
+    font: inherit;
+    font-size: var(--font-size-xs);
+    cursor: pointer;
+  }
+
+  .link-filter-trigger:hover,
+  .link-filter-trigger[aria-expanded="true"] {
+    border-color: var(--accent-blue);
+    color: var(--text-primary);
+  }
+
+  .link-filter-trigger:focus-visible {
+    outline: var(--focus-ring);
+    outline-offset: 2px;
+  }
+
+  .link-filter-panel {
+    width: 220px;
+    padding: 10px;
+    display: grid;
+    gap: 10px;
+  }
+
+  fieldset {
+    min-width: 0;
+    border: 0;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 7px;
+  }
+
+  legend {
+    margin: 0 0 3px;
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    font-weight: 650;
+    text-transform: uppercase;
+  }
+</style>
+```
+
+- [ ] **Step 4: Run the focused menu tests and confirm they pass**
+
+Run:
+
+```bash
+node ../node_modules/vite-plus/bin/vp test run --project unit src/lib/components/kata/KataLinkFilterMenu.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the Svelte autofixer before committing**
+
+From the repository root:
+
+```bash
+./node_modules/.bin/vp exec -- svelte-mcp svelte-autofixer ./frontend/src/lib/components/kata/KataLinkFilterMenu.svelte
+```
+
+Expected: no unresolved Svelte correctness findings. Apply any clear suggestions, then rerun the focused test.
+
+- [ ] **Step 6: Context-check and commit the filter menu**
+
+Invoke `context-sync --commit`, then the mandatory commit skill, and commit through hooks:
+
+```bash
+git add frontend/src/lib/components/kata/KataLinkFilterMenu.svelte frontend/src/lib/components/kata/KataLinkFilterMenu.test.ts
+git commit -m "feat: add Kata link filter controls" \
+  -m "Maintainers need compact keyboard-accessible controls for task state and directional relationship visibility without adding permanent toolbar clutter to every link row."
+```
+
+Expected: commit succeeds without bypassing hooks.
+
+---
+
+### Task 3: Filter hydrated link rows and connect workspace scope
+
+**Files:**
+- Modify: `frontend/src/lib/components/kata/KataIssueDiscussion.svelte:1-205,294-370`
+- Modify: `frontend/src/lib/components/kata/KataIssueDiscussion.test.ts:1-430`
+- Modify: `frontend/src/lib/components/kata/KataIssueDetail.svelte:1-110,378-388`
+- Modify: `frontend/src/lib/components/kata/KataIssueDetail.test.ts:1-145`
+- Modify: `frontend/src/lib/features/kata/KataWorkspace.svelte:1-270,2720-2770`
+- Modify: `frontend/src/lib/features/kata/KataWorkspace.test.ts`
+
+**Interfaces:**
+- Consumes: `KataLinkFilters`, `applyKataLinkStatusScope`, `createKataLinkFilters`, `kataLinkMatchesFilters`, and `relationForKataLink` from Task 1; `KataLinkFilterMenu` from Task 2.
+- Produces: controlled props `linkFilters: KataLinkFilters` and `onLinkFiltersChange: (next: KataLinkFilters) => void` threaded from `KataWorkspace` through `KataIssueDetail` to `KataIssueDiscussion`.
+
+- [ ] **Step 1: Write failing discussion tests for inherited state, relationship filtering, chips, counts, and empty states**
+
+Extend `KataIssueDiscussion.test.ts` so `makeAPI` can resolve details by UID:
+
+```ts
+function makeAPI(
+  options: {
+    searchIssues?: KataTaskSummary[];
+    issueDetails?: Record<string, KataTaskDetail>;
+  } = {},
+): KataTaskAPI {
+  return {
+    search: vi.fn(async () => ({
+      filters: { scope: { kind: "all" }, status: "open", owner: "", label: "", query: "" },
+      issues: options.searchIssues ?? [],
+      fetched_at: "2026-06-01T12:00:00Z",
+    })),
+    issue: vi.fn(async (uid: string) =>
+      options.issueDetails?.[uid] ?? makeIssue({ uid, short_id: uid, title: "Hydrated task" }),
+    ),
+  } as unknown as KataTaskAPI;
+}
+```
+
+Import `KataTaskLink` and `createKataLinkFilters`, and add required `linkFilters` / `onLinkFiltersChange` props to every existing render. Update the existing off-view hydration test from `makeAPI({ issueDetail: peerDetail })` to `makeAPI({ issueDetails: { "issue-peer": peerDetail } })`. Then add these focused tests:
+
+```ts
+function taskLink(
+  id: number,
+  peerUID: string,
+  peerShortID: string,
+  type: KataTaskLink["type"],
+): KataTaskLink {
+  return {
+    id,
+    project_id: 1,
+    from: { uid: "issue-1", short_id: "I-1" },
+    to: { uid: peerUID, short_id: peerShortID },
+    type,
+    author: "wes",
+    created_at: "2026-06-01T12:20:00Z",
+  };
+}
+
+it("shows only open peers by default and reports the filtered count", async () => {
+  const selected = makeIssue();
+  selected.links = [
+    taskLink(1, "issue-open", "open", "related"),
+    taskLink(2, "issue-closed", "closed", "blocks"),
+  ];
+  render(KataIssueDiscussion, {
+    props: {
+      issue: selected,
+      events: [],
+      currentView: { groups: [] },
+      api: makeAPI({
+        issueDetails: {
+          "issue-open": makeIssue({ uid: "issue-open", short_id: "open", title: "Open peer", status: "open" }),
+          "issue-closed": makeIssue({ uid: "issue-closed", short_id: "closed", title: "Closed peer", status: "closed" }),
+        },
+      }),
+      activeDaemonId: "home",
+      linkFilters: createKataLinkFilters("open"),
+      onLinkFiltersChange: vi.fn(),
+      onAddComment: vi.fn(async () => true),
+      onEditIssue: vi.fn(async () => true),
+      onSelectIssue: vi.fn(),
+    },
+  });
+
+  await waitFor(() => expect(screen.getByRole("button", { name: /Open peer/ })).toBeTruthy());
+  expect(screen.queryByRole("button", { name: /Closed peer/ })).toBeNull();
+  expect(within(screen.getByRole("region", { name: "Links" })).getByText("1 / 2")).toBeTruthy();
+  expect(screen.queryByText("Open", { selector: ".state-badge" })).toBeNull();
+});
+
+it("shows state chips only for mixed-state results", async () => {
+  const selected = makeIssue();
+  selected.links = [
+    taskLink(1, "issue-open", "open", "related"),
+    taskLink(2, "issue-closed", "closed", "blocks"),
+  ];
+  render(KataIssueDiscussion, {
+    props: {
+      issue: selected,
+      events: [],
+      currentView: { groups: [] },
+      api: makeAPI({
+        issueDetails: {
+          "issue-open": makeIssue({ uid: "issue-open", short_id: "open", title: "Open peer", status: "open" }),
+          "issue-closed": makeIssue({ uid: "issue-closed", short_id: "closed", title: "Closed peer", status: "closed" }),
+        },
+      }),
+      activeDaemonId: "home",
+      linkFilters: createKataLinkFilters("all"),
+      onLinkFiltersChange: vi.fn(),
+      onAddComment: vi.fn(async () => true),
+      onEditIssue: vi.fn(async () => true),
+      onSelectIssue: vi.fn(),
+    },
+  });
+
+  const links = screen.getByRole("region", { name: "Links" });
+  await waitFor(() => expect(within(links).getByRole("button", { name: /Open peer open/ })).toBeTruthy());
+  expect(within(links).getByRole("button", { name: /Closed peer closed/ })).toBeTruthy();
+  expect(within(links).getByText("Open", { selector: ".state-badge" })).toBeTruthy();
+  expect(within(links).getByText("Closed", { selector: ".state-badge" })).toBeTruthy();
+});
+
+it("filters directional relationship types and shows the filtered-empty message", async () => {
+  const selected = makeIssue();
+  selected.links = [
+    taskLink(1, "issue-related", "related", "related"),
+    taskLink(2, "issue-blocked", "blocked", "blocks"),
+  ];
+  const filters = createKataLinkFilters("all");
+  filters.relations.related = false;
+  filters.relations.blocks = false;
+  render(KataIssueDiscussion, {
+    props: {
+      issue: selected,
+      events: [],
+      currentView: { groups: [] },
+      api: makeAPI({
+        issueDetails: {
+          "issue-related": makeIssue({ uid: "issue-related", short_id: "related", title: "Related peer" }),
+          "issue-blocked": makeIssue({ uid: "issue-blocked", short_id: "blocked", title: "Blocked peer" }),
+        },
+      }),
+      activeDaemonId: "home",
+      linkFilters: filters,
+      onLinkFiltersChange: vi.fn(),
+      onAddComment: vi.fn(async () => true),
+      onEditIssue: vi.fn(async () => true),
+      onSelectIssue: vi.fn(),
+    },
+  });
+
+  const links = screen.getByRole("region", { name: "Links" });
+  await waitFor(() => expect(within(links).getByText("No links match these filters.")).toBeTruthy());
+  expect(within(links).queryByText("No links.")).toBeNull();
+  expect(within(links).getByText("0 / 2")).toBeTruthy();
+});
+
+it("shows a resolving state while a single-state filter waits for peer status", () => {
+  const selected = makeIssue();
+  selected.links = [taskLink(1, "issue-pending", "pending", "related")];
+  const api = makeAPI();
+  vi.mocked(api.issue).mockImplementation(() => new Promise<KataTaskDetail>(() => {}));
+
+  render(KataIssueDiscussion, {
+    props: {
+      issue: selected,
+      events: [],
+      currentView: { groups: [] },
+      api,
+      activeDaemonId: "home",
+      linkFilters: createKataLinkFilters("open"),
+      onLinkFiltersChange: vi.fn(),
+      onAddComment: vi.fn(async () => true),
+      onEditIssue: vi.fn(async () => true),
+      onSelectIssue: vi.fn(),
+    },
+  });
+
+  expect(within(screen.getByRole("region", { name: "Links" })).getByText("Resolving linked tasks...")).toBeTruthy();
+});
+
+it("marks failed peer state as unavailable in a mixed-state view", async () => {
+  const selected = makeIssue();
+  selected.links = [taskLink(1, "issue-missing", "missing", "related")];
+  const api = makeAPI();
+  vi.mocked(api.issue).mockRejectedValue(new Error("unavailable"));
+
+  render(KataIssueDiscussion, {
+    props: {
+      issue: selected,
+      events: [],
+      currentView: { groups: [] },
+      api,
+      activeDaemonId: "home",
+      linkFilters: createKataLinkFilters("all"),
+      onLinkFiltersChange: vi.fn(),
+      onAddComment: vi.fn(async () => true),
+      onEditIssue: vi.fn(async () => true),
+      onSelectIssue: vi.fn(),
+    },
+  });
+
+  const links = screen.getByRole("region", { name: "Links" });
+  await waitFor(() => expect(within(links).getByTitle("Task state unavailable")).toBeTruthy());
+  expect(within(links).getByRole("button", { name: /missing state unavailable/ })).toBeTruthy();
+});
+```
+
+- [ ] **Step 2: Run the discussion test and verify the new assertions fail for missing props and unfiltered rows**
+
+Run from `frontend/`:
+
+```bash
+node ../node_modules/vite-plus/bin/vp test run --project unit src/lib/components/kata/KataIssueDiscussion.test.ts
+```
+
+Expected: FAIL because the component does not accept controlled filters, hydrates only titles, renders all links, and has no mixed-state chip behavior.
+
+- [ ] **Step 3: Replace title-only hydration with peer-summary hydration**
+
+In `KataIssueDiscussion.svelte`:
+
+1. Import `ItemStateChip` from `@middleman/ui`, `KataTaskSummary`, the filter helpers, and `KataLinkFilterMenu`.
+2. Add required props:
+
+```ts
+linkFilters: KataLinkFilters;
+onLinkFiltersChange: (next: KataLinkFilters) => void;
+```
+
+3. Replace `linkTitles` with:
+
+```ts
+let hydratedPeers = $state<Record<string, KataTaskSummary | null>>({});
+let peerHydrationSignature = $state("");
+let pendingPeerKeys = $state<ReadonlySet<string>>(new Set());
+```
+
+4. Preserve the existing signature and generation guard, but store `detail.issue` on success and `null` on failure.
+5. Resolve current-view peers without an API call:
+
+```ts
+function currentViewPeer(uid: string): KataTaskSummary | undefined {
+  for (const group of currentView.groups) {
+    const found = group.issues.find((candidate) => candidate.uid === uid);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+function peerFor(link: KataTaskLink): KataTaskSummary | undefined {
+  const uid = linkPeerUID(link);
+  return currentViewPeer(uid) ?? hydratedPeers[uid] ?? undefined;
+}
+
+function peerHydrationFailed(link: KataTaskLink): boolean {
+  return hydratedPeers[linkPeerUID(link)] === null;
+}
+```
+
+6. Derive visible rows and loading state:
+
+```ts
+const visibleLinks = $derived(
+  issue.links.filter((link) =>
+    kataLinkMatchesFilters(link, issue.issue.uid, peerFor(link), linkFilters),
+  ),
+);
+const showStateChips = $derived(linkFilters.statuses.open && linkFilters.statuses.closed);
+const unresolvedPeerCount = $derived(
+  issue.links.filter((link) => {
+    const uid = linkPeerUID(link);
+    return currentViewPeer(uid) === undefined && hydratedPeers[uid] === undefined;
+  }).length,
+);
+```
+
+- [ ] **Step 4: Render the menu, visible count, filtered states, and conditional chips**
+
+Replace the Links header and list body with this structure:
+
+```svelte
+<div class="section-header link-section-header">
+  <h3>Links</h3>
+  <div class="link-header-actions">
+    <span>{visibleLinks.length === issue.links.length ? issue.links.length : `${visibleLinks.length} / ${issue.links.length}`}</span>
+    {#if unresolvedPeerCount > 0}<span class="link-loading">Resolving {unresolvedPeerCount}</span>{/if}
+    <KataLinkFilterMenu filters={linkFilters} onChange={onLinkFiltersChange} />
+  </div>
+</div>
+{#if issue.links.length === 0}
+  <p class="link-empty">No links.</p>
+{:else if visibleLinks.length === 0 && unresolvedPeerCount > 0}
+  <p class="link-empty">Resolving linked tasks...</p>
+{:else if visibleLinks.length === 0}
+  <p class="link-empty">No links match these filters.</p>
+{:else}
+  <div class="link-list" aria-busy={unresolvedPeerCount > 0}>
+    {#each visibleLinks as link (link.id)}
+      {@const peer = peerFor(link)}
+      <button
+        type="button"
+        class="link-row"
+        class:link-row--with-state={showStateChips}
+        aria-label={`${linkLabel(link)} ${linkPeerShortID(link)} ${peer?.title ?? ""}${showStateChips && peer ? ` ${peer.status}` : ""}${showStateChips && peerHydrationFailed(link) ? " state unavailable" : ""}`.trim()}
+        onclick={() => void onSelectIssue(linkPeerUID(link))}
+      >
+        <span class="link-kind">{linkLabel(link)}</span>
+        <span class="link-peer">{linkPeerShortID(link)}</span>
+        {#if peer?.title}<span class="link-title">{peer.title}</span>{/if}
+        {#if showStateChips && peer}
+          <ItemStateChip state={peer.status} size="xs" />
+        {:else if showStateChips && peerHydrationFailed(link)}
+          <ItemStateChip state="unknown" size="xs" title="Task state unavailable" />
+        {/if}
+      </button>
+    {/each}
+  </div>
+{/if}
+```
+
+Update the row grid so `.link-row` keeps the current three columns and `.link-row--with-state` adds a final max-content column. Add compact header-action and muted `.link-loading` styling; do not duplicate chip geometry locally.
+
+- [ ] **Step 5: Run the discussion tests and confirm they pass**
+
+Run:
+
+```bash
+node ../node_modules/vite-plus/bin/vp test run --project unit src/lib/components/kata/KataIssueDiscussion.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Thread controlled filter state through detail and workspace**
+
+In `KataIssueDetail.svelte`, add `linkFilters` and `onLinkFiltersChange` to `Props`, destructuring, and the `KataIssueDiscussion` call. Import `createKataLinkFilters` in `KataIssueDetail.test.ts` and update `renderDetail` with:
+
+```ts
+linkFilters: createKataLinkFilters("open"),
+onLinkFiltersChange: vi.fn(),
+```
+
+In `KataWorkspace.svelte`, import the filter model and add state beside the other workspace-owned UI state:
+
+```ts
+let linkFilters = $state<KataLinkFilters>(createKataLinkFilters("open"));
+let lastLinkStatusScope = $state<KataTaskSearchFilters["status"]>("open");
+```
+
+After `listStatusFilter` is defined, synchronize only task state:
+
+```ts
+$effect(() => {
+  const nextScope = listStatusFilter;
+  if (nextScope === lastLinkStatusScope) return;
+  lastLinkStatusScope = nextScope;
+  linkFilters = applyKataLinkStatusScope(linkFilters, nextScope);
+});
+```
+
+Pass the controlled state to `KataIssueDetail`:
+
+```svelte
+linkFilters={linkFilters}
+onLinkFiltersChange={(next) => {
+  linkFilters = next;
+}}
+```
+
+Do not key or reset `linkFilters` on selected issue changes. This is what preserves relationship choices while navigating tasks.
+
+- [ ] **Step 7: Add a workspace-level regression test for status reset and relationship persistence**
+
+Add this test to `KataWorkspace.test.ts`:
+
+```ts
+it("keeps relationship filters across task navigation and resets state filters with the workspace scope", async () => {
+  const root = issue("issue-root", "Root task", "project-kata");
+  const next = issue("issue-next", "Next task", "project-kata");
+  const related = issue("issue-related", "Related task", "project-kata");
+  const blocked = issue("issue-blocked", "Blocked task", "project-kata");
+  const closed = {
+    ...issue("issue-closed", "Closed task", "project-kata"),
+    status: "closed" as const,
+    closed_reason: "done" as const,
+    closed_at: fetchedAt,
+  };
+  const rows = [root, next, related, blocked, closed];
+  const links: KataTaskLink[] = [
+    {
+      id: 1,
+      project_id: root.project_id,
+      from: { uid: root.uid, short_id: root.short_id },
+      to: { uid: related.uid, short_id: related.short_id },
+      type: "related",
+      author: "fixture-user",
+      created_at: fetchedAt,
+    },
+    {
+      id: 2,
+      project_id: root.project_id,
+      from: { uid: root.uid, short_id: root.short_id },
+      to: { uid: blocked.uid, short_id: blocked.short_id },
+      type: "blocks",
+      author: "fixture-user",
+      created_at: fetchedAt,
+    },
+  ];
+  const { api } = createWorkspaceAPI(rows);
+  vi.mocked(api.issue).mockImplementation(async (uid: string) => {
+    const taskDetail = detail(uid, rows);
+    return uid === root.uid ? { ...taskDetail, links } : taskDetail;
+  });
+
+  render(KataWorkspaceRouteHost, { props: { api, initialIssue: root.uid } });
+
+  await waitFor(() => expect(screen.getByRole("heading", { name: "Root task" })).toBeTruthy());
+  await fireEvent.click(screen.getByRole("button", { name: "Filter links" }));
+  await fireEvent.click(screen.getByRole("checkbox", { name: "Related" }));
+
+  const issues = screen.getByRole("main", { name: "Issues" });
+  await fireEvent.click(within(issues).getByRole("button", { name: /Next task/ }));
+  await waitFor(() => expect(screen.getByRole("heading", { name: "Next task" })).toBeTruthy());
+  await fireEvent.click(within(issues).getByRole("button", { name: /Root task/ }));
+  await waitFor(() => expect(screen.getByRole("heading", { name: "Root task" })).toBeTruthy());
+
+  await fireEvent.click(screen.getByRole("button", { name: "Filter links" }));
+  expect((screen.getByRole("checkbox", { name: "Related" }) as HTMLInputElement).checked).toBe(false);
+  await fireEvent.keyDown(document, { key: "Escape" });
+
+  await fireEvent.click(screen.getByRole("combobox", { name: "Status: Open" }));
+  await fireEvent.click(screen.getByRole("option", { name: "Closed" }));
+  await waitFor(() => expect(within(issues).getByRole("button", { name: /Closed task/ })).toBeTruthy());
+  await fireEvent.click(within(issues).getByRole("button", { name: /Closed task/ }));
+  await waitFor(() => expect(screen.getByRole("heading", { name: "Closed task" })).toBeTruthy());
+
+  await fireEvent.click(screen.getByRole("button", { name: "Filter links" }));
+  expect((screen.getByRole("checkbox", { name: "Open" }) as HTMLInputElement).checked).toBe(false);
+  expect((screen.getByRole("checkbox", { name: "Closed" }) as HTMLInputElement).checked).toBe(true);
+  expect((screen.getByRole("checkbox", { name: "Related" }) as HTMLInputElement).checked).toBe(false);
+});
+```
+
+This test uses role-based queries and asserts only the interaction contract. Do not add API-call-count assertions unrelated to link filtering.
+
+- [ ] **Step 8: Run all affected component and workspace tests**
+
+Run from `frontend/`:
+
+```bash
+node ../node_modules/vite-plus/bin/vp test run --project unit \
+  src/lib/features/kata/kataLinkFilters.test.ts \
+  src/lib/components/kata/KataLinkFilterMenu.test.ts \
+  src/lib/components/kata/KataIssueDiscussion.test.ts \
+  src/lib/components/kata/KataIssueDetail.test.ts \
+  src/lib/features/kata/KataWorkspace.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Run Svelte analysis on every changed component**
+
+From the repository root:
+
+```bash
+./node_modules/.bin/vp exec -- svelte-mcp svelte-autofixer ./frontend/src/lib/components/kata/KataLinkFilterMenu.svelte
+./node_modules/.bin/vp exec -- svelte-mcp svelte-autofixer ./frontend/src/lib/components/kata/KataIssueDiscussion.svelte
+./node_modules/.bin/vp exec -- svelte-mcp svelte-autofixer ./frontend/src/lib/components/kata/KataIssueDetail.svelte
+./node_modules/.bin/vp exec -- svelte-mcp svelte-autofixer ./frontend/src/lib/features/kata/KataWorkspace.svelte
+```
+
+Expected: no unresolved Svelte correctness findings.
+
+- [ ] **Step 10: Run the full affected frontend verification**
+
+From the repository root:
+
+```bash
+./node_modules/.bin/vp test run --project unit
+./node_modules/.bin/vp run frontend-check
+```
+
+Expected: both commands exit 0. Do not add Playwright solely to repeat checkbox visibility; the component and workspace tests own this workflow, and no browser-only geometry is changing beyond the already-shared floating-position utilities.
+
+- [ ] **Step 11: Review the final diff and commit the integrated behavior**
+
+Review:
+
+```bash
+git status --short
+git diff --stat HEAD
+git diff HEAD -- frontend/src/lib/components/kata frontend/src/lib/features/kata/KataWorkspace.svelte frontend/src/lib/features/kata/KataWorkspace.test.ts
+```
+
+Invoke `context-sync --commit`, then the mandatory commit skill. Commit through hooks:
+
+```bash
+git add \
+  frontend/src/lib/components/kata/KataIssueDiscussion.svelte \
+  frontend/src/lib/components/kata/KataIssueDiscussion.test.ts \
+  frontend/src/lib/components/kata/KataIssueDetail.svelte \
+  frontend/src/lib/components/kata/KataIssueDetail.test.ts \
+  frontend/src/lib/features/kata/KataWorkspace.svelte \
+  frontend/src/lib/features/kata/KataWorkspace.test.ts
+git commit -m "feat: filter Kata links by task state and relation" \
+  -m "Kata detail links should follow the maintainer's active task scope while still allowing local relationship filtering. Mixed-state results retain explicit state labels without repeating redundant chips in single-state views."
+```
+
+Expected: commit succeeds without `--no-verify`, and `git status --short` is clean afterward.

--- a/docs/superpowers/plans/2026-07-22-kata-link-filtering.md
+++ b/docs/superpowers/plans/2026-07-22-kata-link-filtering.md
@@ -29,10 +29,12 @@
 ### Task 1: Define the Kata link filter contract
 
 **Files:**
+
 - Create: `frontend/src/lib/features/kata/kataLinkFilters.ts`
 - Create: `frontend/src/lib/features/kata/kataLinkFilters.test.ts`
 
 **Interfaces:**
+
 - Consumes: `KataTaskLink`, `KataTaskStatusFilter`, and `KataTaskSummary` from `frontend/src/lib/api/kata/taskTypes.ts`.
 - Produces: `KataLinkRelation`, `KataLinkFilters`, `KataLinkPeerResolution`, `KATA_LINK_RELATIONS`, `createKataLinkFilters`, `applyKataLinkStatusScope`, `relationForKataLink`, `kataLinkCouldAffectVisibleResults`, and `kataLinkMatchesFilters`.
 
@@ -134,7 +136,9 @@ describe("kata link filters", () => {
     const mixed = createKataLinkFilters("all");
 
     expect(kataLinkMatchesFilters(link(), selectedUID, { kind: "resolved", peer: peer("open") }, openOnly)).toBe(true);
-    expect(kataLinkMatchesFilters(link(), selectedUID, { kind: "resolved", peer: peer("closed") }, openOnly)).toBe(false);
+    expect(kataLinkMatchesFilters(link(), selectedUID, { kind: "resolved", peer: peer("closed") }, openOnly)).toBe(
+      false,
+    );
     expect(kataLinkMatchesFilters(link(), selectedUID, { kind: "pending" }, openOnly)).toBe(false);
     expect(kataLinkMatchesFilters(link(), selectedUID, { kind: "pending" }, mixed)).toBe(true);
     expect(kataLinkMatchesFilters(link(), selectedUID, { kind: "failed" }, openOnly)).toBe(true);
@@ -167,11 +171,7 @@ Expected: FAIL because `./kataLinkFilters.js` does not exist.
 Create `frontend/src/lib/features/kata/kataLinkFilters.ts`:
 
 ```ts
-import type {
-  KataTaskLink,
-  KataTaskStatusFilter,
-  KataTaskSummary,
-} from "../../api/kata/taskTypes.js";
+import type { KataTaskLink, KataTaskStatusFilter, KataTaskSummary } from "../../api/kata/taskTypes.js";
 
 export const KATA_LINK_RELATIONS = ["parent", "child", "blocks", "blocked_by", "related"] as const;
 
@@ -207,10 +207,7 @@ export function createKataLinkFilters(scope: KataTaskStatusFilter): KataLinkFilt
   };
 }
 
-export function applyKataLinkStatusScope(
-  current: KataLinkFilters,
-  scope: KataTaskStatusFilter,
-): KataLinkFilters {
+export function applyKataLinkStatusScope(current: KataLinkFilters, scope: KataTaskStatusFilter): KataLinkFilters {
   return {
     statuses: statusesForScope(scope),
     relations: { ...current.relations },
@@ -229,8 +226,7 @@ export function kataLinkCouldAffectVisibleResults(
   filters: KataLinkFilters,
 ): boolean {
   return (
-    filters.relations[relationForKataLink(link, selectedUID)] &&
-    (filters.statuses.open || filters.statuses.closed)
+    filters.relations[relationForKataLink(link, selectedUID)] && (filters.statuses.open || filters.statuses.closed)
   );
 }
 
@@ -274,10 +270,12 @@ Expected: commit succeeds without `--no-verify`.
 ### Task 2: Build the accessible link-filter popover
 
 **Files:**
+
 - Create: `frontend/src/lib/components/kata/KataLinkFilterMenu.svelte`
 - Create: `frontend/src/lib/components/kata/KataLinkFilterMenu.test.ts`
 
 **Interfaces:**
+
 - Consumes: `KataLinkFilters`, `KataLinkRelation`, and `KATA_LINK_RELATIONS` from Task 1.
 - Produces: `KataLinkFilterMenu` with props `filters: KataLinkFilters` and `onChange: (next: KataLinkFilters) => void`.
 
@@ -566,6 +564,7 @@ Expected: commit succeeds without bypassing hooks.
 ### Task 3: Filter hydrated link rows and connect workspace scope
 
 **Files:**
+
 - Modify: `frontend/src/lib/components/kata/KataIssueDiscussion.svelte:1-205,294-370`
 - Modify: `frontend/src/lib/components/kata/KataIssueDiscussion.test.ts:1-430`
 - Modify: `frontend/src/lib/components/kata/KataIssueDetail.svelte:1-110,378-388`
@@ -575,6 +574,7 @@ Expected: commit succeeds without bypassing hooks.
 - Modify: `frontend/tests/e2e-full/kata.spec.ts`
 
 **Interfaces:**
+
 - Consumes: `KataLinkFilters`, `KataLinkPeerResolution`, `KataLinkRelation`, `applyKataLinkStatusScope`, `createKataLinkFilters`, `kataLinkCouldAffectVisibleResults`, `kataLinkMatchesFilters`, and `relationForKataLink` from Task 1; `KataLinkFilterMenu` from Task 2.
 - Produces: controlled props `linkFilters: KataLinkFilters` and `onLinkFiltersChange: (next: KataLinkFilters) => void` threaded from `KataWorkspace` through `KataIssueDetail` to `KataIssueDiscussion`.
 
@@ -595,8 +595,8 @@ function makeAPI(
       issues: options.searchIssues ?? [],
       fetched_at: "2026-06-01T12:00:00Z",
     })),
-    issue: vi.fn(async (uid: string) =>
-      options.issueDetails?.[uid] ?? makeIssue({ uid, short_id: uid, title: "Hydrated task" }),
+    issue: vi.fn(
+      async (uid: string) => options.issueDetails?.[uid] ?? makeIssue({ uid, short_id: uid, title: "Hydrated task" }),
     ),
   } as unknown as KataTaskAPI;
 }
@@ -605,12 +605,7 @@ function makeAPI(
 Import `KataTaskLink` and `createKataLinkFilters`, and add required `linkFilters` / `onLinkFiltersChange` props to every existing render. Update the existing off-view hydration test from `makeAPI({ issueDetail: peerDetail })` to `makeAPI({ issueDetails: { "issue-peer": peerDetail } })`. Then add these focused tests:
 
 ```ts
-function taskLink(
-  id: number,
-  peerUID: string,
-  peerShortID: string,
-  type: KataTaskLink["type"],
-): KataTaskLink {
+function taskLink(id: number, peerUID: string, peerShortID: string, type: KataTaskLink["type"]): KataTaskLink {
   return {
     id,
     project_id: 1,
@@ -624,10 +619,7 @@ function taskLink(
 
 it("shows only open peers by default and reports the filtered count", async () => {
   const selected = makeIssue();
-  selected.links = [
-    taskLink(1, "issue-open", "open", "related"),
-    taskLink(2, "issue-closed", "closed", "blocks"),
-  ];
+  selected.links = [taskLink(1, "issue-open", "open", "related"), taskLink(2, "issue-closed", "closed", "blocks")];
   render(KataIssueDiscussion, {
     props: {
       issue: selected,
@@ -636,7 +628,12 @@ it("shows only open peers by default and reports the filtered count", async () =
       api: makeAPI({
         issueDetails: {
           "issue-open": makeIssue({ uid: "issue-open", short_id: "open", title: "Open peer", status: "open" }),
-          "issue-closed": makeIssue({ uid: "issue-closed", short_id: "closed", title: "Closed peer", status: "closed" }),
+          "issue-closed": makeIssue({
+            uid: "issue-closed",
+            short_id: "closed",
+            title: "Closed peer",
+            status: "closed",
+          }),
         },
       }),
       activeDaemonId: "home",
@@ -656,10 +653,7 @@ it("shows only open peers by default and reports the filtered count", async () =
 
 it("shows state chips when both task-state filters are enabled", async () => {
   const selected = makeIssue();
-  selected.links = [
-    taskLink(1, "issue-open", "open", "related"),
-    taskLink(2, "issue-closed", "closed", "blocks"),
-  ];
+  selected.links = [taskLink(1, "issue-open", "open", "related"), taskLink(2, "issue-closed", "closed", "blocks")];
   render(KataIssueDiscussion, {
     props: {
       issue: selected,
@@ -668,7 +662,12 @@ it("shows state chips when both task-state filters are enabled", async () => {
       api: makeAPI({
         issueDetails: {
           "issue-open": makeIssue({ uid: "issue-open", short_id: "open", title: "Open peer", status: "open" }),
-          "issue-closed": makeIssue({ uid: "issue-closed", short_id: "closed", title: "Closed peer", status: "closed" }),
+          "issue-closed": makeIssue({
+            uid: "issue-closed",
+            short_id: "closed",
+            title: "Closed peer",
+            status: "closed",
+          }),
         },
       }),
       activeDaemonId: "home",
@@ -940,7 +939,7 @@ let pendingPeerKeys = $state<ReadonlySet<string>>(new Set());
 let lastSelectedDetail: KataTaskDetail | null = null;
 ```
 
-4. Preserve the existing signature and generation guard, but store `detail.issue` on success and `null` on failure.
+4. Preserve the existing generation guard, but remove `issue.issue.revision` from the hydration signature. The cache-reset identity is daemon, selected task UID, and link identity; a same-task revision change must not discard successful peer summaries. Store `detail.issue` on success and `null` on failure.
    Build hydration candidates only for peers not already available from `currentViewPeer(uid)`, not cached in `hydratedPeers`, and not present in `pendingPeerKeys`. Keep the existing one-request-per-peer concurrency and signature guards; do not serialize the requests or add a second cache.
 
 ```ts
@@ -954,6 +953,7 @@ const peerUIDs = issue.links
       !pendingPeerKeys.has(`${signature}:${uid}`),
   );
 ```
+
 5. Add a same-task refresh effect that drops only failed entries, causing the existing hydration effect to retry them while preserving successful peer summaries:
 
 ```ts
@@ -964,16 +964,13 @@ $effect(() => {
     current !== lastSelectedDetail &&
     current.issue.uid === lastSelectedDetail.issue.uid
   ) {
-    hydratedPeers = Object.fromEntries(
-      Object.entries(hydratedPeers).filter(([, peer]) => peer !== null),
-    );
+    hydratedPeers = Object.fromEntries(Object.entries(hydratedPeers).filter(([, peer]) => peer !== null));
   }
   lastSelectedDetail = current;
 });
 ```
 
-This effect keys recovery on a new selected-detail object, not revision or link signature, because a refresh may replace the detail snapshot without changing either value.
-6. Resolve current-view peers without an API call and replace the existing independent `linkLabel` branching with formatting based on `relationForKataLink`:
+This effect keys recovery on a new selected-detail object, not revision or link signature, because a refresh may replace the detail snapshot without changing either value. Cover a refresh with an incremented revision and assert that successful peers remain cached while failed peers retry. 6. Resolve current-view peers without an API call and replace the existing independent `linkLabel` branching with formatting based on `relationForKataLink`:
 
 ```ts
 function currentViewPeer(uid: string): KataTaskSummary | undefined {
@@ -1011,16 +1008,13 @@ function linkLabel(link: KataTaskLink): string {
 
 ```ts
 const visibleLinks = $derived(
-  issue.links.filter((link) =>
-    kataLinkMatchesFilters(link, issue.issue.uid, peerResolution(link), linkFilters),
-  ),
+  issue.links.filter((link) => kataLinkMatchesFilters(link, issue.issue.uid, peerResolution(link), linkFilters)),
 );
 const showStateChips = $derived(linkFilters.statuses.open && linkFilters.statuses.closed);
 const unresolvedPeerCount = $derived(
   issue.links.filter(
     (link) =>
-      peerResolution(link).kind === "pending" &&
-      kataLinkCouldAffectVisibleResults(link, issue.issue.uid, linkFilters),
+      peerResolution(link).kind === "pending" && kataLinkCouldAffectVisibleResults(link, issue.issue.uid, linkFilters),
   ).length,
 );
 ```
@@ -1332,19 +1326,44 @@ const filterTriggerBox = await links.getByRole("button", { name: "Filter links" 
 const filterPanelBox = await filterPanel.boundingBox();
 expect(filterTriggerBox).not.toBeNull();
 expect(filterPanelBox).not.toBeNull();
-expect(Math.abs(filterPanelBox!.x + filterPanelBox!.width - (filterTriggerBox!.x + filterTriggerBox!.width))).toBeLessThanOrEqual(2);
+expect(
+  Math.abs(filterPanelBox!.x + filterPanelBox!.width - (filterTriggerBox!.x + filterTriggerBox!.width)),
+).toBeLessThanOrEqual(2);
+expect(
+  Math.min(
+    Math.abs(filterPanelBox!.y - (filterTriggerBox!.y + filterTriggerBox!.height)),
+    Math.abs(filterPanelBox!.y + filterPanelBox!.height - filterTriggerBox!.y),
+  ),
+).toBeLessThanOrEqual(5);
 expect(filterPanelBox!.x).toBeGreaterThanOrEqual(0);
 expect(filterPanelBox!.y).toBeGreaterThanOrEqual(0);
 expect(filterPanelBox!.x + filterPanelBox!.width).toBeLessThanOrEqual((page.viewportSize()?.width ?? 0) + 1);
 expect(filterPanelBox!.y + filterPanelBox!.height).toBeLessThanOrEqual((page.viewportSize()?.height ?? 0) + 1);
 
 await page.setViewportSize({ width: 720, height: 540 });
+const filterTrigger = links.getByRole("button", { name: "Filter links" });
+await filterTrigger.scrollIntoViewIfNeeded();
+const constrainedFilterTriggerBox = await filterTrigger.boundingBox();
 const constrainedFilterPanelBox = await filterPanel.boundingBox();
+expect(constrainedFilterTriggerBox).not.toBeNull();
 expect(constrainedFilterPanelBox).not.toBeNull();
 expect(constrainedFilterPanelBox!.x).toBeGreaterThanOrEqual(0);
 expect(constrainedFilterPanelBox!.y).toBeGreaterThanOrEqual(0);
 expect(constrainedFilterPanelBox!.x + constrainedFilterPanelBox!.width).toBeLessThanOrEqual(721);
 expect(constrainedFilterPanelBox!.y + constrainedFilterPanelBox!.height).toBeLessThanOrEqual(541);
+expect(
+  Math.abs(
+    constrainedFilterPanelBox!.x +
+      constrainedFilterPanelBox!.width -
+      (constrainedFilterTriggerBox!.x + constrainedFilterTriggerBox!.width),
+  ),
+).toBeLessThanOrEqual(2);
+expect(
+  Math.min(
+    Math.abs(constrainedFilterPanelBox!.y - (constrainedFilterTriggerBox!.y + constrainedFilterTriggerBox!.height)),
+    Math.abs(constrainedFilterPanelBox!.y + constrainedFilterPanelBox!.height - constrainedFilterTriggerBox!.y),
+  ),
+).toBeLessThanOrEqual(5);
 await page.setViewportSize({ width: 1280, height: 720 });
 await filterPanel.getByRole("checkbox", { name: "Closed" }).click();
 
@@ -1359,6 +1378,8 @@ await filterPanel.getByRole("checkbox", { name: "Parent" }).click();
 await filterPanel.getByRole("checkbox", { name: "Related" }).click();
 await page.keyboard.press("Escape");
 ```
+
+At both viewport sizes, re-read the trigger and panel boxes and assert the panel is still right-edge aligned and vertically adjacent using the helper's 4px trigger gap: either immediately below the trigger or flipped immediately above it. Containment alone is insufficient.
 
 Keep the existing navigation into the parent task and back to Pay rent. After returning, reopen **Filter links**, assert **Related** is still unchecked, then re-enable it before the existing add-related-link assertions:
 

--- a/docs/superpowers/plans/2026-07-22-kata-task-column-visibility.md
+++ b/docs/superpowers/plans/2026-07-22-kata-task-column-visibility.md
@@ -1,0 +1,751 @@
+# Kata Task Column Visibility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Kata task-list column picker that hides optional metadata columns immediately and restores the browser-local choice after reload.
+
+**Architecture:** A focused TypeScript helper owns the allowlisted column model and best-effort `localStorage` serialization. A small Svelte popover component owns checkbox interaction and focus-safe dismissal. `KataIssueList.svelte` owns the active visibility state, conditionally renders headers and cells, and derives wide and responsive grid templates from the same state.
+
+**Tech Stack:** Svelte 5 runes, TypeScript, `@kenn-io/kit-ui` popover utilities and Checkbox, Testing Library, Vite+ unit tests.
+
+## Global Constraints
+
+- ID and Title remain permanently visible.
+- Updated, Priority, Due, Owner, and Tags are independently hideable.
+- One browser-local preference applies across every Kata view, project scope, and daemon.
+- Enabled columns may still auto-hide at the existing pane-width breakpoints; disabled columns never appear.
+- Sorting, row selection, tree expansion, task detail behavior, and backend contracts remain unchanged.
+- Storage failures are non-fatal and malformed values fall back to all optional columns visible.
+- Use Bun and Vite+ tooling. Never use npm.
+- Run the Svelte autofixer on every changed `.svelte` file before completion.
+
+---
+
+## File Map
+
+- Create `frontend/src/lib/components/kata/kataTaskColumns.ts`: column identifiers, labels, defaults, parsing, loading, and persistence.
+- Create `frontend/src/lib/components/kata/kataTaskColumns.test.ts`: pure persistence and normalization coverage.
+- Create `frontend/src/lib/components/kata/KataColumnPicker.svelte`: trigger, checkbox popover, Show all action, dismissal, and focus restoration.
+- Modify `frontend/src/lib/components/kata/KataIssueList.svelte`: state ownership, conditional cells, responsive grid tracks, and header composition.
+- Modify `frontend/src/lib/components/kata/KataIssueList.test.ts`: user-visible toggle, restore, reset, fixed-column, and storage-failure coverage.
+
+### Task 1: Define and test the persisted column model
+
+**Files:**
+- Create: `frontend/src/lib/components/kata/kataTaskColumns.ts`
+- Create: `frontend/src/lib/components/kata/kataTaskColumns.test.ts`
+
+**Interfaces:**
+- Produces: `KataOptionalTaskColumn`, `KataTaskColumnVisibility`, `KATA_OPTIONAL_TASK_COLUMNS`, `KATA_TASK_COLUMNS_STORAGE_KEY`, `defaultKataTaskColumnVisibility()`, `loadKataTaskColumnVisibility()`, and `persistKataTaskColumnVisibility()`.
+- Consumes: browser `localStorage` through the narrow `Pick<Storage, "getItem" | "setItem">` interface.
+
+- [ ] **Step 1: Write failing persistence tests**
+
+Create `kataTaskColumns.test.ts` with these cases:
+
+```ts
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import {
+  KATA_OPTIONAL_TASK_COLUMNS,
+  KATA_TASK_COLUMNS_STORAGE_KEY,
+  defaultKataTaskColumnVisibility,
+  loadKataTaskColumnVisibility,
+  persistKataTaskColumnVisibility,
+} from "./kataTaskColumns.js";
+
+describe("Kata task column visibility", () => {
+  it("defaults every optional column to visible", () => {
+    expect(defaultKataTaskColumnVisibility()).toEqual({
+      updated: true,
+      priority: true,
+      due: true,
+      owner: true,
+      tags: true,
+    });
+  });
+
+  it("restores known columns in canonical order and ignores unknown keys", () => {
+    const storage = {
+      getItem: vi.fn(() => JSON.stringify(["tags", "future-column", "updated", "tags"])),
+      setItem: vi.fn(),
+    };
+
+    expect(loadKataTaskColumnVisibility(storage)).toEqual({
+      updated: true,
+      priority: false,
+      due: false,
+      owner: false,
+      tags: true,
+    });
+  });
+
+  it.each(["not-json", JSON.stringify({ visible: ["updated"] }), JSON.stringify(["updated", 3])])(
+    "falls back for malformed storage: %s",
+    (raw) => {
+      const storage = { getItem: vi.fn(() => raw), setItem: vi.fn() };
+      expect(loadKataTaskColumnVisibility(storage)).toEqual(defaultKataTaskColumnVisibility());
+    },
+  );
+
+  it("falls back when storage reads throw", () => {
+    const storage = {
+      getItem: vi.fn(() => {
+        throw new Error("blocked");
+      }),
+      setItem: vi.fn(),
+    };
+    expect(loadKataTaskColumnVisibility(storage)).toEqual(defaultKataTaskColumnVisibility());
+  });
+
+  it("persists visible keys and tolerates write failures", () => {
+    const setItem = vi.fn();
+    persistKataTaskColumnVisibility(
+      { updated: true, priority: false, due: true, owner: false, tags: false },
+      { getItem: vi.fn(), setItem },
+    );
+    expect(setItem).toHaveBeenCalledWith(KATA_TASK_COLUMNS_STORAGE_KEY, JSON.stringify(["updated", "due"]));
+
+    expect(() =>
+      persistKataTaskColumnVisibility(defaultKataTaskColumnVisibility(), {
+        getItem: vi.fn(),
+        setItem: vi.fn(() => {
+          throw new Error("quota");
+        }),
+      }),
+    ).not.toThrow();
+    expect(KATA_OPTIONAL_TASK_COLUMNS.map((column) => column.id)).toEqual([
+      "updated",
+      "priority",
+      "due",
+      "owner",
+      "tags",
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the new test and verify the red state**
+
+Run from `frontend/`:
+
+```bash
+node ../node_modules/vite-plus/bin/vp test run --project unit src/lib/components/kata/kataTaskColumns.test.ts
+```
+
+Expected: FAIL because `./kataTaskColumns.js` does not exist.
+
+- [ ] **Step 3: Implement the column model and storage boundary**
+
+Create `kataTaskColumns.ts`:
+
+```ts
+export const KATA_TASK_COLUMNS_STORAGE_KEY = "middleman:kata:issue-columns/v1";
+
+export const KATA_OPTIONAL_TASK_COLUMNS = [
+  { id: "updated", label: "Updated" },
+  { id: "priority", label: "Priority" },
+  { id: "due", label: "Due" },
+  { id: "owner", label: "Owner" },
+  { id: "tags", label: "Tags" },
+] as const;
+
+export type KataOptionalTaskColumn = (typeof KATA_OPTIONAL_TASK_COLUMNS)[number]["id"];
+export type KataTaskColumnVisibility = Record<KataOptionalTaskColumn, boolean>;
+type ColumnStorage = Pick<Storage, "getItem" | "setItem">;
+
+const knownColumns = new Set<string>(KATA_OPTIONAL_TASK_COLUMNS.map((column) => column.id));
+
+export function defaultKataTaskColumnVisibility(): KataTaskColumnVisibility {
+  return { updated: true, priority: true, due: true, owner: true, tags: true };
+}
+
+function browserStorage(): ColumnStorage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function loadKataTaskColumnVisibility(
+  storage: ColumnStorage | null = browserStorage(),
+): KataTaskColumnVisibility {
+  if (!storage) return defaultKataTaskColumnVisibility();
+  try {
+    const raw = storage.getItem(KATA_TASK_COLUMNS_STORAGE_KEY);
+    if (raw === null) return defaultKataTaskColumnVisibility();
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed) || !parsed.every((value) => typeof value === "string")) {
+      return defaultKataTaskColumnVisibility();
+    }
+    const visible = new Set(parsed.filter((value) => knownColumns.has(value)));
+    return Object.fromEntries(
+      KATA_OPTIONAL_TASK_COLUMNS.map((column) => [column.id, visible.has(column.id)]),
+    ) as KataTaskColumnVisibility;
+  } catch {
+    return defaultKataTaskColumnVisibility();
+  }
+}
+
+export function persistKataTaskColumnVisibility(
+  visibility: KataTaskColumnVisibility,
+  storage: ColumnStorage | null = browserStorage(),
+): void {
+  if (!storage) return;
+  try {
+    const visible = KATA_OPTIONAL_TASK_COLUMNS
+      .filter((column) => visibility[column.id])
+      .map((column) => column.id);
+    storage.setItem(KATA_TASK_COLUMNS_STORAGE_KEY, JSON.stringify(visible));
+  } catch {
+    // Browser storage is best-effort. Keep the in-memory preference usable.
+  }
+}
+```
+
+- [ ] **Step 4: Run the focused test and verify green**
+
+Run the Task 1 test command again.
+
+Expected: PASS with seven test cases, including the three malformed-value table entries.
+
+- [ ] **Step 5: Commit the persisted model**
+
+Invoke the repository-local `context-sync` skill with `--commit`, then invoke the mandatory commit skill and create a commit with subject:
+
+```text
+feat: remember Kata task column choices
+```
+
+Stage only the two Task 1 files.
+
+### Task 2: Add the column picker and integrate visible grid tracks
+
+**Files:**
+- Create: `frontend/src/lib/components/kata/KataColumnPicker.svelte`
+- Modify: `frontend/src/lib/components/kata/KataIssueList.svelte:1-168`
+- Modify: `frontend/src/lib/components/kata/KataIssueList.svelte:623-846`
+- Modify: `frontend/src/lib/components/kata/KataIssueList.svelte:861-1379`
+- Modify: `frontend/src/lib/components/kata/KataIssueList.test.ts:66-210`
+
+**Interfaces:**
+- Consumes: the Task 1 column constants, visibility type, default factory, loader, and persister.
+- Produces: `KataColumnPicker` props `{ visibility, onchange, onShowAll }` and responsive `--table-cols-*` custom properties used by both header and rows.
+
+- [ ] **Step 1: Write failing task-list interaction tests**
+
+Import `KATA_TASK_COLUMNS_STORAGE_KEY` into `KataIssueList.test.ts`, then append these focused cases inside the existing `describe("KataIssueList", ...)` block:
+
+```ts
+it("hides an optional column while keeping ID and Title visible", async () => {
+  render(KataIssueList, {
+    props: { currentView, selectedIssueUID: null, loading: false, onSelect: () => {} },
+  });
+
+  const header = screen.getByRole("row");
+  const row = screen.getByText("Pay rent").closest("button");
+  const table = document.querySelector<HTMLElement>(".table");
+  expect(row).not.toBeNull();
+  expect(table).not.toBeNull();
+  expect(table!.style.getPropertyValue("--table-cols-wide")).toContain("minmax(96px, 200px)");
+
+  await fireEvent.click(screen.getByRole("button", { name: "Columns" }));
+  await fireEvent.click(screen.getByRole("checkbox", { name: "Tags" }));
+
+  expect(within(header).getByText("ID")).toBeTruthy();
+  expect(within(header).getByText("Title")).toBeTruthy();
+  expect(within(header).queryByText("Tags")).toBeNull();
+  expect(within(row!).queryByText("home · monthly")).toBeNull();
+  expect(table!.style.getPropertyValue("--table-cols-wide")).not.toContain("minmax(96px, 200px)");
+  expect(JSON.parse(localStorage.getItem(KATA_TASK_COLUMNS_STORAGE_KEY)!)).toEqual([
+    "updated",
+    "priority",
+    "due",
+    "owner",
+  ]);
+});
+
+it("restores hidden columns and Show all resets the preference", async () => {
+  const first = render(KataIssueList, {
+    props: { currentView, selectedIssueUID: null, loading: false, onSelect: () => {} },
+  });
+
+  await fireEvent.click(screen.getByRole("button", { name: "Columns" }));
+  for (const name of ["Priority", "Due", "Owner", "Tags"]) {
+    await fireEvent.click(screen.getByRole("checkbox", { name }));
+  }
+  first.unmount();
+
+  render(KataIssueList, {
+    props: { currentView, selectedIssueUID: null, loading: false, onSelect: () => {} },
+  });
+
+  const header = screen.getByRole("row");
+  expect(within(header).getByText("Updated")).toBeTruthy();
+  expect(within(header).queryByText("Priority")).toBeNull();
+  expect(within(header).queryByText("Due")).toBeNull();
+  expect(within(header).queryByText("Owner")).toBeNull();
+  expect(within(header).queryByText("Tags")).toBeNull();
+
+  await fireEvent.click(screen.getByRole("button", { name: "Columns" }));
+  await fireEvent.click(screen.getByRole("button", { name: "Show all" }));
+
+  expect(within(header).getByText("Priority")).toBeTruthy();
+  expect(within(header).getByText("Due")).toBeTruthy();
+  expect(within(header).getByText("Owner")).toBeTruthy();
+  expect(within(header).getByText("Tags")).toBeTruthy();
+  expect(JSON.parse(localStorage.getItem(KATA_TASK_COLUMNS_STORAGE_KEY)!)).toEqual([
+    "updated",
+    "priority",
+    "due",
+    "owner",
+    "tags",
+  ]);
+});
+
+it("keeps column toggles usable when localStorage writes fail", async () => {
+  vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+    throw new Error("quota");
+  });
+  render(KataIssueList, {
+    props: { currentView, selectedIssueUID: null, loading: false, onSelect: () => {} },
+  });
+
+  await fireEvent.click(screen.getByRole("button", { name: "Columns" }));
+  await fireEvent.click(screen.getByRole("checkbox", { name: "Owner" }));
+
+  expect(within(screen.getByRole("row")).queryByText("Owner")).toBeNull();
+});
+
+it("falls back to all columns for malformed saved data", () => {
+  localStorage.setItem(KATA_TASK_COLUMNS_STORAGE_KEY, JSON.stringify({ visible: ["updated"] }));
+  render(KataIssueList, {
+    props: { currentView, selectedIssueUID: null, loading: false, onSelect: () => {} },
+  });
+
+  const header = screen.getByRole("row");
+  for (const name of ["Updated", "Priority", "Due", "Owner", "Tags"]) {
+    expect(within(header).getByText(name)).toBeTruthy();
+  }
+});
+
+it("closes the column picker with Escape and restores trigger focus", async () => {
+  render(KataIssueList, {
+    props: { currentView, selectedIssueUID: null, loading: false, onSelect: () => {} },
+  });
+
+  const trigger = screen.getByRole("button", { name: "Columns" });
+  await fireEvent.click(trigger);
+  expect(screen.getByRole("checkbox", { name: "Updated" })).toBeTruthy();
+
+  await fireEvent.keyDown(document, { key: "Escape" });
+
+  expect(screen.queryByRole("checkbox", { name: "Updated" })).toBeNull();
+  expect(document.activeElement).toBe(trigger);
+});
+```
+
+- [ ] **Step 2: Run the Kata issue-list test and verify red**
+
+Run from `frontend/`:
+
+```bash
+node ../node_modules/vite-plus/bin/vp test run --project unit src/lib/components/kata/KataIssueList.test.ts
+```
+
+Expected: FAIL because the Columns trigger and conditional rendering do not exist.
+
+- [ ] **Step 3: Create the checkbox popover component**
+
+Create `KataColumnPicker.svelte` using:
+
+```svelte
+<script lang="ts">
+  import Columns3Icon from "@lucide/svelte/icons/columns-3";
+  import { Checkbox, autoReposition, dismissable, floatingPopoverStyle } from "@kenn-io/kit-ui";
+  import { tick } from "svelte";
+  import {
+    KATA_OPTIONAL_TASK_COLUMNS,
+    type KataTaskColumnVisibility,
+  } from "./kataTaskColumns.js";
+
+  interface Props {
+    visibility: KataTaskColumnVisibility;
+    onchange: (visibility: KataTaskColumnVisibility) => void;
+    onShowAll: () => void;
+  }
+
+  let { visibility, onchange, onShowAll }: Props = $props();
+  let open = $state(false);
+  let trigger = $state<HTMLButtonElement>();
+  let panel = $state<HTMLDivElement>();
+  let panelStyle = $state("");
+
+  const allVisible = $derived(KATA_OPTIONAL_TASK_COLUMNS.every((column) => visibility[column.id]));
+
+  $effect(() => {
+    if (!open) return;
+    const cleanups = [
+      dismissable({ owners: () => [trigger, panel], dismiss: close, escapeFocus: () => trigger }),
+      autoReposition(() => panel, position),
+    ];
+    return () => cleanups.forEach((cleanup) => cleanup());
+  });
+
+  function close(): void {
+    open = false;
+  }
+
+  function position(): void {
+    if (!trigger || !panel) return;
+    panelStyle = floatingPopoverStyle({
+      trigger: trigger.getBoundingClientRect(),
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+      popoverWidth: panel.offsetWidth,
+      popoverHeight: panel.offsetHeight,
+      align: "end",
+    });
+  }
+
+  async function toggle(): Promise<void> {
+    open = !open;
+    if (!open) return;
+    await tick();
+    position();
+  }
+</script>
+
+<div class="column-picker">
+  <button bind:this={trigger} type="button" aria-expanded={open} onclick={() => void toggle()}>
+    <Columns3Icon size={13} strokeWidth={2} aria-hidden="true" />
+    <span>Columns</span>
+  </button>
+  {#if open}
+    <div bind:this={panel} class="column-picker__panel kit-popover-card" style={panelStyle}>
+      <div class="column-picker__title">Visible columns</div>
+      {#each KATA_OPTIONAL_TASK_COLUMNS as column (column.id)}
+        <Checkbox
+          checked={visibility[column.id]}
+          label={column.label}
+          onchange={(checked) => onchange({ ...visibility, [column.id]: checked })}
+        />
+      {/each}
+      <button type="button" class="column-picker__reset" disabled={allVisible} onclick={onShowAll}>
+        Show all
+      </button>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .column-picker {
+    position: relative;
+    flex-shrink: 0;
+  }
+
+  .column-picker > button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-2);
+    min-height: 26px;
+    padding: 0 var(--space-4);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    background: var(--bg-surface);
+    color: var(--text-secondary);
+    font: inherit;
+    font-size: var(--font-size-xs);
+    font-weight: 500;
+    white-space: nowrap;
+    cursor: pointer;
+  }
+
+  .column-picker > button:hover,
+  .column-picker > button:focus-visible,
+  .column-picker > button[aria-expanded="true"] {
+    border-color: var(--border-strong);
+    color: var(--text-primary);
+  }
+
+  .column-picker__panel {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+    min-width: 180px;
+    padding: var(--space-5);
+  }
+
+  .column-picker__title {
+    color: var(--text-faint);
+    font-size: var(--font-size-3xs);
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .column-picker__reset {
+    margin-top: var(--space-2);
+    padding: var(--space-3) var(--space-4) 0;
+    border: 0;
+    border-top: 1px solid var(--border-muted);
+    background: transparent;
+    color: var(--accent-blue);
+    font: inherit;
+    font-size: var(--font-size-xs);
+    text-align: left;
+    cursor: pointer;
+  }
+
+  .column-picker__reset:disabled {
+    color: var(--text-faint);
+    cursor: default;
+  }
+</style>
+```
+
+Use `kit-popover-card` for shared surface chrome. Do not add a modal or a second overlay implementation.
+
+- [ ] **Step 4: Integrate visibility state and conditional DOM**
+
+In `KataIssueList.svelte`:
+
+1. Import `KataColumnPicker` and the Task 1 helper.
+2. Initialize `let columnVisibility = $state(loadKataTaskColumnVisibility());`.
+3. Add `setColumnVisibility(next)` and `showAllColumns()` functions that update state first and then persist it.
+4. Add a `.header-actions` wrapper that always renders `KataColumnPicker`; keep `.tree-actions` conditional inside it.
+5. Wrap each optional header and matching row cell in `{#if columnVisibility.<id>}` blocks. Leave ID and Title unconditional.
+
+Use these state transitions:
+
+```ts
+let columnVisibility = $state(loadKataTaskColumnVisibility());
+
+function setColumnVisibility(next: KataTaskColumnVisibility): void {
+  columnVisibility = next;
+  persistKataTaskColumnVisibility(next);
+}
+
+function showAllColumns(): void {
+  setColumnVisibility(defaultKataTaskColumnVisibility());
+}
+```
+
+Replace the conditional top-right action block with this composition:
+
+```svelte
+<div class="header-actions">
+  <KataColumnPicker
+    visibility={columnVisibility}
+    onchange={setColumnVisibility}
+    onShowAll={showAllColumns}
+  />
+  {#if hasExpandableVisibleRows || hasAnyExpandedRows || bulkExpanding}
+    <div class="tree-actions" aria-label="Task tree controls">
+      <button
+        class="tree-action"
+        type="button"
+        disabled={bulkExpanding || allKnownExpandableRowsExpanded}
+        aria-busy={bulkExpanding ? "true" : undefined}
+        onclick={() => void expandAllVisible()}
+      >
+        <ListChevronsUpDownIcon size={13} strokeWidth={2} />
+        <span>{bulkExpanding ? "Expanding" : "Expand all"}</span>
+      </button>
+      <button
+        class="tree-action"
+        type="button"
+        disabled={!hasAnyExpandedRows}
+        onclick={collapseAllVisible}
+      >
+        <ListChevronsDownUpIcon size={13} strokeWidth={2} />
+        <span>Collapse all</span>
+      </button>
+    </div>
+  {/if}
+</div>
+```
+
+Use this responsive grid derivation in the script:
+
+```ts
+type TaskGridLayout = "wide" | "medium" | "compact" | "narrow";
+
+const TASK_COLUMN_TRACKS: Record<
+  TaskGridLayout,
+  Record<KataOptionalTaskColumn, string | null>
+> = {
+  wide: {
+    updated: "minmax(64px, 80px)",
+    priority: "minmax(68px, 80px)",
+    due: "minmax(56px, 70px)",
+    owner: "minmax(72px, 110px)",
+    tags: "minmax(96px, 200px)",
+  },
+  medium: {
+    updated: "minmax(64px, 80px)",
+    priority: "minmax(68px, 80px)",
+    due: "minmax(56px, 70px)",
+    owner: "minmax(72px, 110px)",
+    tags: null,
+  },
+  compact: {
+    updated: "minmax(60px, 76px)",
+    priority: "minmax(64px, 78px)",
+    due: "minmax(54px, 68px)",
+    owner: null,
+    tags: null,
+  },
+  narrow: {
+    updated: "minmax(58px, 72px)",
+    priority: "minmax(62px, 74px)",
+    due: null,
+    owner: null,
+    tags: null,
+  },
+};
+
+const TASK_TITLE_TRACKS: Record<TaskGridLayout, string> = {
+  wide: "minmax(220px, 1fr)",
+  medium: "minmax(220px, 1fr)",
+  compact: "minmax(180px, 1fr)",
+  narrow: "minmax(140px, 1fr)",
+};
+
+function taskGridColumns(layout: TaskGridLayout): string {
+  return [
+    "var(--table-id-col)",
+    TASK_TITLE_TRACKS[layout],
+    ...KATA_OPTIONAL_TASK_COLUMNS.flatMap((column) => {
+      const track = TASK_COLUMN_TRACKS[layout][column.id];
+      return columnVisibility[column.id] && track ? [track] : [];
+    }),
+  ].join(" ");
+}
+
+let wideGridColumns = $derived(taskGridColumns("wide"));
+let mediumGridColumns = $derived(taskGridColumns("medium"));
+let compactGridColumns = $derived(taskGridColumns("compact"));
+let narrowGridColumns = $derived(taskGridColumns("narrow"));
+```
+
+Publish the four strings on `.table` with Svelte style directives, set `--table-cols: var(--table-cols-wide)` in the base rule, and replace the three hard-coded container-query templates with `var(--table-cols-medium)`, `var(--table-cols-compact)`, and `var(--table-cols-narrow)`. Keep the existing auto-hide selectors so enabled DOM cells disappear at the same breakpoints as their omitted tracks.
+
+```svelte
+<div
+  class="table"
+  class:table--project-scoped={isProjectScoped}
+  style:--table-cols-wide={wideGridColumns}
+  style:--table-cols-medium={mediumGridColumns}
+  style:--table-cols-compact={compactGridColumns}
+  style:--table-cols-narrow={narrowGridColumns}
+>
+```
+
+```css
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-shrink: 0;
+}
+
+.table {
+  --table-cols: var(--table-cols-wide);
+}
+
+@container list (max-width: 880px) {
+  .table { --table-cols: var(--table-cols-medium); }
+}
+
+@container list (max-width: 680px) {
+  .table { --table-cols: var(--table-cols-compact); }
+}
+
+@container list (max-width: 520px) {
+  .table { --table-cols: var(--table-cols-narrow); }
+}
+```
+
+- [ ] **Step 5: Run the Svelte autofixer on both changed components**
+
+Run from the repository root:
+
+```bash
+cd frontend && ../node_modules/.bin/vp exec -- svelte-mcp svelte-autofixer src/lib/components/kata/KataColumnPicker.svelte
+cd frontend && ../node_modules/.bin/vp exec -- svelte-mcp svelte-autofixer src/lib/components/kata/KataIssueList.svelte
+```
+
+Expected: no unresolved Svelte findings. Apply any safe suggested corrections with `apply_patch`, then rerun until clean.
+
+- [ ] **Step 6: Run the focused tests and verify green**
+
+Run from `frontend/`:
+
+```bash
+node ../node_modules/vite-plus/bin/vp test run --project unit \
+  src/lib/components/kata/kataTaskColumns.test.ts \
+  src/lib/components/kata/KataIssueList.test.ts
+```
+
+Expected: PASS for both files with no warnings.
+
+- [ ] **Step 7: Commit the complete user-visible interaction**
+
+Invoke `context-sync --commit`, then invoke the mandatory commit skill and create a commit with subject:
+
+```text
+feat: let maintainers hide Kata task columns
+```
+
+Stage only the picker, issue-list component, issue-list tests, and any Task 1 files changed during integration.
+
+### Task 3: Run final frontend verification
+
+**Files:**
+- Verify only; no production file should be added in this task.
+
+**Interfaces:**
+- Consumes: the complete Tasks 1 and 2 implementation.
+- Produces: evidence that the focused behavior and affected frontend suite pass without a Playwright-only boundary.
+
+- [ ] **Step 1: Run the full unit suite**
+
+Run from `frontend/`:
+
+```bash
+node ../node_modules/vite-plus/bin/vp test run --project unit
+```
+
+Expected: PASS. Investigate any failure before continuing.
+
+- [ ] **Step 2: Run frontend formatting, lint, kit, and Svelte checks**
+
+Run from the repository root:
+
+```bash
+make frontend-check
+```
+
+Expected: PASS for formatting, lint, `kit-ui-check`, and `svelte-check`.
+
+- [ ] **Step 3: Confirm the final diff and persistence scope**
+
+Run:
+
+```bash
+git status --short
+git diff --stat HEAD~2..HEAD
+git diff HEAD~2..HEAD -- frontend/src/lib/components/kata
+```
+
+Expected: only the approved Kata column preference, picker, list integration, and tests are present. No API, backend, route, migration, or Playwright files change.
+
+- [ ] **Step 4: Apply any verification fixes as a new commit**
+
+If verification required edits, rerun the focused tests, full unit suite, Svelte autofixer for changed `.svelte` files, and `make frontend-check`. Then invoke `context-sync --commit` and the mandatory commit skill. Create a new commit rather than amending, with a subject that states the corrected user-visible outcome.
+
+If no edits were required, do not create an empty commit.

--- a/docs/superpowers/plans/2026-07-22-kata-task-column-visibility.md
+++ b/docs/superpowers/plans/2026-07-22-kata-task-column-visibility.md
@@ -13,11 +13,12 @@
 - ID and Title remain permanently visible.
 - Updated, Priority, Due, Owner, and Tags are independently hideable.
 - One browser-local preference applies across every Kata view, project scope, and daemon.
-- Enabled columns may still auto-hide at the existing pane-width breakpoints; disabled columns never appear.
-- Hiding the active Updated, Priority, or Owner sort resets sorting to Title ascending; other sorting, row selection, tree expansion, task detail behavior, and backend contracts remain unchanged.
+- Effective visibility is `user-enabled ∩ layout-supported`; the picker labels enabled choices as columns shown when space allows, disabled columns never appear, and the active user-enabled sort column remains layout-supported so its control cannot disappear.
+- Hiding the active Updated, Priority, or Owner sort resets sorting to Title ascending, including reconciliation of inconsistent saved preferences before first render. Responsive auto-hiding is temporary and does not reset sorting; keep the active Owner column rendered at compact widths, allowing horizontal overflow if necessary. Other sorting, row selection, tree expansion, task detail behavior, and backend contracts remain unchanged.
 - Storage failures are non-fatal and malformed values fall back to all optional columns visible.
 - Compact panes keep header actions on one line by visually hiding action labels while retaining icons, titles, and accessible names.
 - Browser-tab synchronization is out of scope.
+- The browser-local preference is global across Kata views, project scopes, and daemons.
 - Use Bun and Vite+ tooling. Never use npm.
 - Run the Svelte autofixer on every changed `.svelte` file before completion.
 
@@ -36,10 +37,12 @@
 ### Task 1: Define and test the persisted column model
 
 **Files:**
+
 - Create: `frontend/src/lib/components/kata/kataTaskColumns.ts`
 - Create: `frontend/src/lib/components/kata/kataTaskColumns.test.ts`
 
 **Interfaces:**
+
 - Produces: `KataOptionalTaskColumn`, `KataTaskColumnVisibility`, `KATA_OPTIONAL_TASK_COLUMNS`, `KATA_TASK_COLUMNS_STORAGE_KEY`, `defaultKataTaskColumnVisibility()`, `loadKataTaskColumnVisibility()`, and `persistKataTaskColumnVisibility()`.
 - Consumes: browser `localStorage` through the narrow `Pick<Storage, "getItem" | "setItem">` interface.
 
@@ -199,9 +202,7 @@ export function persistKataTaskColumnVisibility(
 ): void {
   if (!storage) return;
   try {
-    const visible = KATA_OPTIONAL_TASK_COLUMNS
-      .filter((column) => visibility[column.id])
-      .map((column) => column.id);
+    const visible = KATA_OPTIONAL_TASK_COLUMNS.filter((column) => visibility[column.id]).map((column) => column.id);
     storage.setItem(KATA_TASK_COLUMNS_STORAGE_KEY, JSON.stringify(visible));
   } catch {
     // Browser storage is best-effort. Keep the in-memory preference usable.
@@ -228,6 +229,7 @@ Stage only the two Task 1 files.
 ### Task 2: Add the column picker and integrate visible grid tracks
 
 **Files:**
+
 - Create: `frontend/src/lib/components/kata/KataColumnPicker.svelte`
 - Modify: `frontend/src/lib/components/kata/KataIssueList.svelte:1-168`
 - Modify: `frontend/src/lib/components/kata/KataIssueList.svelte:623-846`
@@ -235,6 +237,7 @@ Stage only the two Task 1 files.
 - Modify: `frontend/src/lib/components/kata/KataIssueList.test.ts:66-210`
 
 **Interfaces:**
+
 - Consumes: the Task 1 column constants, visibility type, default factory, loader, and persister.
 - Produces: `KataColumnPicker` props `{ visibility, onchange, onShowAll }` and responsive `--table-cols-*` custom properties used by both header and rows.
 
@@ -356,13 +359,19 @@ it("resets an invisible active sort to Title ascending", async () => {
   });
 
   await fireEvent.click(screen.getByRole("button", { name: "Sort by Priority" }));
-  expect(screen.getByRole("button", { name: "Sort by Priority, currently ascending" })).toHaveAttribute("aria-pressed", "true");
+  expect(screen.getByRole("button", { name: "Sort by Priority, currently ascending" })).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
 
   await fireEvent.click(screen.getByRole("button", { name: "Columns" }));
   await fireEvent.click(screen.getByRole("checkbox", { name: "Priority" }));
 
   expect(screen.queryByRole("button", { name: /Sort by Priority/ })).toBeNull();
-  expect(screen.getByRole("button", { name: "Sort by Title, currently ascending" })).toHaveAttribute("aria-pressed", "true");
+  expect(screen.getByRole("button", { name: "Sort by Title, currently ascending" })).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
   expect(JSON.parse(localStorage.getItem("middleman:kata:issue-sort/v1")!)).toEqual({
     key: "title",
     direction: "asc",
@@ -446,7 +455,7 @@ Create `KataColumnPicker.svelte` using:
     bind:this={trigger}
     type="button"
     aria-label="Columns"
-    title="Choose visible columns"
+    title="Choose columns shown when space allows"
     aria-expanded={open}
     onclick={() => void toggle()}
   >
@@ -455,7 +464,7 @@ Create `KataColumnPicker.svelte` using:
   </button>
   {#if open}
     <div bind:this={panel} class="column-picker__panel kit-popover-card" style={panelStyle}>
-      <div class="column-picker__title">Visible columns</div>
+      <div class="column-picker__title">Shown when space allows</div>
       {#each KATA_OPTIONAL_TASK_COLUMNS as column (column.id)}
         <Checkbox
           checked={visibility[column.id]}
@@ -549,7 +558,7 @@ Use `kit-popover-card` for shared surface chrome. Do not add a modal or a second
 In `KataIssueList.svelte`:
 
 1. Import `KataColumnPicker` and the Task 1 helper.
-2. Initialize `let columnVisibility = $state(loadKataTaskColumnVisibility());`.
+2. Load visibility before sort state, reconcile an optional sort whose column is disabled, and persist Title ascending when reconciliation changes it.
 3. Add `setColumnVisibility(next)` and `showAllColumns()` functions that update state first and then persist it.
 4. Add a `.header-actions` wrapper that always renders `KataColumnPicker`; keep `.tree-actions` conditional inside it.
 5. Wrap each optional header and matching row cell in `{#if columnVisibility.<id>}` blocks. Leave ID and Title unconditional.
@@ -557,17 +566,27 @@ In `KataIssueList.svelte`:
 Use these state transitions so an optional sort cannot remain active after its control disappears:
 
 ```ts
-let columnVisibility = $state(loadKataTaskColumnVisibility());
+const restoredColumnVisibility = loadKataTaskColumnVisibility();
+const restoredSort = loadSort();
+const initialSort = sortForColumnVisibility(restoredSort, restoredColumnVisibility);
+let sort: KataTaskSort = $state(initialSort);
+let columnVisibility = $state(restoredColumnVisibility);
+if (initialSort !== restoredSort) persistSort(initialSort);
 
 function optionalColumnForSort(key: KataTaskSortKey): KataOptionalTaskColumn | null {
   if (key === "updated" || key === "priority" || key === "owner") return key;
   return null;
 }
 
+function sortForColumnVisibility(current: KataTaskSort, visibility: KataTaskColumnVisibility): KataTaskSort {
+  const activeSortColumn = optionalColumnForSort(current.key);
+  return activeSortColumn && !visibility[activeSortColumn] ? { key: "title", direction: "asc" } : current;
+}
+
 function setColumnVisibility(next: KataTaskColumnVisibility): void {
-  const activeSortColumn = optionalColumnForSort(sort.key);
-  if (activeSortColumn && !next[activeSortColumn]) {
-    sort = { key: "title", direction: "asc" };
+  const nextSort = sortForColumnVisibility(sort, next);
+  if (nextSort !== sort) {
+    sort = nextSort;
     persistSort(sort);
   }
   columnVisibility = next;
@@ -623,10 +642,7 @@ Use this responsive grid derivation in the script:
 ```ts
 type TaskGridLayout = "wide" | "medium" | "compact" | "narrow";
 
-const TASK_COLUMN_TRACKS: Record<
-  TaskGridLayout,
-  Record<KataOptionalTaskColumn, string | null>
-> = {
+const TASK_COLUMN_TRACKS: Record<TaskGridLayout, Record<KataOptionalTaskColumn, string | null>> = {
   wide: {
     updated: "minmax(64px, 80px)",
     priority: "minmax(68px, 80px)",
@@ -669,10 +685,16 @@ function taskGridColumns(layout: TaskGridLayout): string {
     "var(--table-id-col)",
     TASK_TITLE_TRACKS[layout],
     ...KATA_OPTIONAL_TASK_COLUMNS.flatMap((column) => {
-      const track = TASK_COLUMN_TRACKS[layout][column.id];
+      const track = taskColumnTrack(layout, column.id);
       return columnVisibility[column.id] && track ? [track] : [];
     }),
   ].join(" ");
+}
+
+function taskColumnTrack(layout: TaskGridLayout, column: KataOptionalTaskColumn): string | null {
+  const track = TASK_COLUMN_TRACKS[layout][column];
+  if (track || column !== "owner" || sort.key !== "owner") return track;
+  return TASK_COLUMN_TRACKS.medium.owner;
 }
 
 let wideGridColumns = $derived(taskGridColumns("wide"));
@@ -681,7 +703,7 @@ let compactGridColumns = $derived(taskGridColumns("compact"));
 let narrowGridColumns = $derived(taskGridColumns("narrow"));
 ```
 
-Publish the four strings on `.table` with Svelte style directives, set `--table-cols: var(--table-cols-wide)` in the base rule, and replace the three hard-coded container-query templates with `var(--table-cols-medium)`, `var(--table-cols-compact)`, and `var(--table-cols-narrow)`. Keep the existing auto-hide selectors so enabled DOM cells disappear at the same breakpoints as their omitted tracks.
+Publish the four strings on `.table` with Svelte style directives, set `--table-cols: var(--table-cols-wide)` in the base rule, and replace the three hard-coded container-query templates with `var(--table-cols-medium)`, `var(--table-cols-compact)`, and `var(--table-cols-narrow)`. Keep the existing auto-hide selectors so enabled DOM cells disappear at the same breakpoints as their omitted tracks, except when Owner is the active user-enabled sort: retain its track and cells so the sort indicator remains visible.
 
 ```svelte
 <div
@@ -708,11 +730,15 @@ Publish the four strings on `.table` with Svelte style directives, set `--table-
 }
 
 @container list (max-width: 880px) {
-  .table { --table-cols: var(--table-cols-medium); }
+  .table {
+    --table-cols: var(--table-cols-medium);
+  }
 }
 
 @container list (max-width: 680px) {
-  .table { --table-cols: var(--table-cols-compact); }
+  .table {
+    --table-cols: var(--table-cols-compact);
+  }
   .header-actions :global(.action-label) {
     position: absolute;
     width: 1px;
@@ -725,7 +751,9 @@ Publish the four strings on `.table` with Svelte style directives, set `--table-
 }
 
 @container list (max-width: 520px) {
-  .table { --table-cols: var(--table-cols-narrow); }
+  .table {
+    --table-cols: var(--table-cols-narrow);
+  }
 }
 ```
 
@@ -826,6 +854,12 @@ test("kata task columns float and preserve responsive grid alignment", async ({ 
     expect(triggerBox).not.toBeNull();
     expect(panelBox).not.toBeNull();
     expect(Math.abs(panelBox!.x + panelBox!.width - (triggerBox!.x + triggerBox!.width))).toBeLessThanOrEqual(2);
+    expect(
+      Math.min(
+        Math.abs(panelBox!.y - (triggerBox!.y + triggerBox!.height)),
+        Math.abs(panelBox!.y + panelBox!.height - triggerBox!.y),
+      ),
+    ).toBeLessThanOrEqual(5);
     expect(panelBox!.y).toBeGreaterThanOrEqual(0);
     expect(panelBox!.x).toBeGreaterThanOrEqual(0);
     expect(panelBox!.x + panelBox!.width).toBeLessThanOrEqual((page.viewportSize()?.width ?? 0) + 1);
@@ -847,12 +881,25 @@ test("kata task columns float and preserve responsive grid alignment", async ({ 
     await expect(page.locator(".table-header .col-tags")).toHaveCount(0);
 
     await page.setViewportSize({ width: 720, height: 540 });
+    const constrainedTriggerBox = await page.getByRole("button", { name: "Columns" }).boundingBox();
     const constrainedPanelBox = await panel.boundingBox();
+    expect(constrainedTriggerBox).not.toBeNull();
     expect(constrainedPanelBox).not.toBeNull();
     expect(constrainedPanelBox!.x).toBeGreaterThanOrEqual(0);
     expect(constrainedPanelBox!.y).toBeGreaterThanOrEqual(0);
     expect(constrainedPanelBox!.x + constrainedPanelBox!.width).toBeLessThanOrEqual(721);
     expect(constrainedPanelBox!.y + constrainedPanelBox!.height).toBeLessThanOrEqual(541);
+    expect(
+      Math.abs(
+        constrainedPanelBox!.x + constrainedPanelBox!.width - (constrainedTriggerBox!.x + constrainedTriggerBox!.width),
+      ),
+    ).toBeLessThanOrEqual(2);
+    expect(
+      Math.min(
+        Math.abs(constrainedPanelBox!.y - (constrainedTriggerBox!.y + constrainedTriggerBox!.height)),
+        Math.abs(constrainedPanelBox!.y + constrainedPanelBox!.height - constrainedTriggerBox!.y),
+      ),
+    ).toBeLessThanOrEqual(5);
 
     for (const column of ["id", "title", "updated", "priority", "due", "owner"]) {
       const headerBox = await page.locator(`.table-header .col-${column}`).boundingBox();
@@ -869,6 +916,8 @@ test("kata task columns float and preserve responsive grid alignment", async ({ 
   }
 });
 ```
+
+At the initial and constrained viewport sizes, re-read both trigger and panel boxes and assert horizontal alignment plus vertical adjacency with the 4px trigger gap, accepting either the below placement or the helper's immediate above flip. Also measure header/row alignment while the list is compact, not only after widening it again.
 
 Run from `frontend/`:
 
@@ -891,9 +940,11 @@ Stage only the picker, issue-list component, unit/browser tests, the focused Kat
 ### Task 3: Run final frontend verification
 
 **Files:**
+
 - Verify only; no production file should be added in this task.
 
 **Interfaces:**
+
 - Consumes: the complete Tasks 1 and 2 implementation.
 - Produces: evidence that unit logic, real-browser focus behavior, responsive geometry, and the affected frontend checks pass.
 

--- a/docs/superpowers/plans/2026-07-22-kata-task-column-visibility.md
+++ b/docs/superpowers/plans/2026-07-22-kata-task-column-visibility.md
@@ -6,7 +6,7 @@
 
 **Architecture:** A focused TypeScript helper owns the allowlisted column model and best-effort `localStorage` serialization. A small Svelte popover component owns checkbox interaction and focus-safe dismissal. `KataIssueList.svelte` owns the active visibility state, conditionally renders headers and cells, and derives wide and responsive grid templates from the same state.
 
-**Tech Stack:** Svelte 5 runes, TypeScript, `@kenn-io/kit-ui` popover utilities and Checkbox, Testing Library, Vite+ unit tests.
+**Tech Stack:** Svelte 5 runes, TypeScript, `@kenn-io/kit-ui` popover utilities and Checkbox, Testing Library, Vite+ unit/browser tests, Playwright full-stack tests.
 
 ## Global Constraints
 
@@ -14,8 +14,10 @@
 - Updated, Priority, Due, Owner, and Tags are independently hideable.
 - One browser-local preference applies across every Kata view, project scope, and daemon.
 - Enabled columns may still auto-hide at the existing pane-width breakpoints; disabled columns never appear.
-- Sorting, row selection, tree expansion, task detail behavior, and backend contracts remain unchanged.
+- Hiding the active Updated, Priority, or Owner sort resets sorting to Title ascending; other sorting, row selection, tree expansion, task detail behavior, and backend contracts remain unchanged.
 - Storage failures are non-fatal and malformed values fall back to all optional columns visible.
+- Compact panes keep header actions on one line by visually hiding action labels while retaining icons, titles, and accessible names.
+- Browser-tab synchronization is out of scope.
 - Use Bun and Vite+ tooling. Never use npm.
 - Run the Svelte autofixer on every changed `.svelte` file before completion.
 
@@ -28,6 +30,8 @@
 - Create `frontend/src/lib/components/kata/KataColumnPicker.svelte`: trigger, checkbox popover, Show all action, dismissal, and focus restoration.
 - Modify `frontend/src/lib/components/kata/KataIssueList.svelte`: state ownership, conditional cells, responsive grid tracks, and header composition.
 - Modify `frontend/src/lib/components/kata/KataIssueList.test.ts`: user-visible toggle, restore, reset, fixed-column, and storage-failure coverage.
+- Modify `frontend/src/lib/components/kata/KataIssueList.browser.svelte.ts`: keyboard/focus semantics in a real browser.
+- Modify `frontend/tests/e2e-full/kata.spec.ts`: floating placement and responsive grid geometry against the seeded backend.
 
 ### Task 1: Define and test the persisted column model
 
@@ -345,6 +349,25 @@ it("closes the column picker with Escape and restores trigger focus", async () =
   expect(screen.queryByRole("checkbox", { name: "Updated" })).toBeNull();
   expect(document.activeElement).toBe(trigger);
 });
+
+it("resets an invisible active sort to Title ascending", async () => {
+  render(KataIssueList, {
+    props: { currentView, selectedIssueUID: null, loading: false, onSelect: () => {} },
+  });
+
+  await fireEvent.click(screen.getByRole("button", { name: "Sort by Priority" }));
+  expect(screen.getByRole("button", { name: "Sort by Priority, currently ascending" })).toHaveAttribute("aria-pressed", "true");
+
+  await fireEvent.click(screen.getByRole("button", { name: "Columns" }));
+  await fireEvent.click(screen.getByRole("checkbox", { name: "Priority" }));
+
+  expect(screen.queryByRole("button", { name: /Sort by Priority/ })).toBeNull();
+  expect(screen.getByRole("button", { name: "Sort by Title, currently ascending" })).toHaveAttribute("aria-pressed", "true");
+  expect(JSON.parse(localStorage.getItem("middleman:kata:issue-sort/v1")!)).toEqual({
+    key: "title",
+    direction: "asc",
+  });
+});
 ```
 
 - [ ] **Step 2: Run the Kata issue-list test and verify red**
@@ -419,9 +442,16 @@ Create `KataColumnPicker.svelte` using:
 </script>
 
 <div class="column-picker">
-  <button bind:this={trigger} type="button" aria-expanded={open} onclick={() => void toggle()}>
+  <button
+    bind:this={trigger}
+    type="button"
+    aria-label="Columns"
+    title="Choose visible columns"
+    aria-expanded={open}
+    onclick={() => void toggle()}
+  >
     <Columns3Icon size={13} strokeWidth={2} aria-hidden="true" />
-    <span>Columns</span>
+    <span class="action-label">Columns</span>
   </button>
   {#if open}
     <div bind:this={panel} class="column-picker__panel kit-popover-card" style={panelStyle}>
@@ -472,10 +502,15 @@ Create `KataColumnPicker.svelte` using:
   }
 
   .column-picker__panel {
+    position: fixed;
+    z-index: var(--z-popover);
     display: flex;
     flex-direction: column;
     gap: var(--space-4);
     min-width: 180px;
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 16px);
+    overflow-y: auto;
     padding: var(--space-5);
   }
 
@@ -519,12 +554,22 @@ In `KataIssueList.svelte`:
 4. Add a `.header-actions` wrapper that always renders `KataColumnPicker`; keep `.tree-actions` conditional inside it.
 5. Wrap each optional header and matching row cell in `{#if columnVisibility.<id>}` blocks. Leave ID and Title unconditional.
 
-Use these state transitions:
+Use these state transitions so an optional sort cannot remain active after its control disappears:
 
 ```ts
 let columnVisibility = $state(loadKataTaskColumnVisibility());
 
+function optionalColumnForSort(key: KataTaskSortKey): KataOptionalTaskColumn | null {
+  if (key === "updated" || key === "priority" || key === "owner") return key;
+  return null;
+}
+
 function setColumnVisibility(next: KataTaskColumnVisibility): void {
+  const activeSortColumn = optionalColumnForSort(sort.key);
+  if (activeSortColumn && !next[activeSortColumn]) {
+    sort = { key: "title", direction: "asc" };
+    persistSort(sort);
+  }
   columnVisibility = next;
   persistKataTaskColumnVisibility(next);
 }
@@ -548,21 +593,25 @@ Replace the conditional top-right action block with this composition:
       <button
         class="tree-action"
         type="button"
+        aria-label={bulkExpanding ? "Expanding tasks" : "Expand all tasks"}
+        title={bulkExpanding ? "Expanding tasks" : "Expand all tasks"}
         disabled={bulkExpanding || allKnownExpandableRowsExpanded}
         aria-busy={bulkExpanding ? "true" : undefined}
         onclick={() => void expandAllVisible()}
       >
         <ListChevronsUpDownIcon size={13} strokeWidth={2} />
-        <span>{bulkExpanding ? "Expanding" : "Expand all"}</span>
+        <span class="action-label">{bulkExpanding ? "Expanding" : "Expand all"}</span>
       </button>
       <button
         class="tree-action"
         type="button"
+        aria-label="Collapse all tasks"
+        title="Collapse all tasks"
         disabled={!hasAnyExpandedRows}
         onclick={collapseAllVisible}
       >
         <ListChevronsDownUpIcon size={13} strokeWidth={2} />
-        <span>Collapse all</span>
+        <span class="action-label">Collapse all</span>
       </button>
     </div>
   {/if}
@@ -651,6 +700,7 @@ Publish the four strings on `.table` with Svelte style directives, set `--table-
   align-items: center;
   gap: var(--space-3);
   flex-shrink: 0;
+  white-space: nowrap;
 }
 
 .table {
@@ -663,6 +713,15 @@ Publish the four strings on `.table` with Svelte style directives, set `--table-
 
 @container list (max-width: 680px) {
   .table { --table-cols: var(--table-cols-compact); }
+  .header-actions :global(.action-label) {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+    clip-path: inset(50%);
+  }
 }
 
 @container list (max-width: 520px) {
@@ -675,8 +734,9 @@ Publish the four strings on `.table` with Svelte style directives, set `--table-
 Run from the repository root:
 
 ```bash
-cd frontend && ../node_modules/.bin/vp exec -- svelte-mcp svelte-autofixer src/lib/components/kata/KataColumnPicker.svelte
-cd frontend && ../node_modules/.bin/vp exec -- svelte-mcp svelte-autofixer src/lib/components/kata/KataIssueList.svelte
+cd frontend
+../node_modules/.bin/vp exec -- svelte-mcp svelte-autofixer src/lib/components/kata/KataColumnPicker.svelte
+../node_modules/.bin/vp exec -- svelte-mcp svelte-autofixer src/lib/components/kata/KataIssueList.svelte
 ```
 
 Expected: no unresolved Svelte findings. Apply any safe suggested corrections with `apply_patch`, then rerun until clean.
@@ -693,7 +753,115 @@ node ../node_modules/vite-plus/bin/vp test run --project unit \
 
 Expected: PASS for both files with no warnings.
 
-- [ ] **Step 7: Commit the complete user-visible interaction**
+- [ ] **Step 7: Extend real-browser keyboard and focus coverage**
+
+Add this case to `KataIssueList.browser.svelte.ts`:
+
+```ts
+it("opens the column picker from the keyboard and restores focus on Escape", async () => {
+  await page.viewport(980, 620);
+  const issue = task();
+  render(KataIssueList, {
+    props: {
+      currentView: currentView(issue),
+      selectedIssueUID: issue.uid,
+      loading: false,
+      onSelect: () => {},
+    },
+  });
+
+  const trigger = page.getByRole("button", { name: "Columns" });
+  await trigger.focus();
+  await trigger.press("Enter");
+  await expect.element(trigger).toHaveAttribute("aria-expanded", "true");
+  const updated = page.getByRole("checkbox", { name: "Updated" });
+  await expect.element(updated).toBeVisible();
+
+  await updated.press("Escape");
+
+  await expect.element(trigger).toHaveAttribute("aria-expanded", "false");
+  await expect.element(trigger).toHaveFocus();
+});
+```
+
+Run from `frontend/`:
+
+```bash
+node ../node_modules/vite-plus/bin/vp test run --project browser src/lib/components/kata/KataIssueList.browser.svelte.ts
+```
+
+Expected: PASS in Chromium.
+
+- [ ] **Step 8: Add full-stack Playwright geometry coverage**
+
+Add a focused test near the existing Kata task-list sorting tests in `frontend/tests/e2e-full/kata.spec.ts`. Use `startKataBackend`, `configureKataHome`, and `startIsolatedE2EServer`, then assert this sequence:
+
+```ts
+test("kata task columns float and preserve responsive grid alignment", async ({ page }) => {
+  const backend = await startKataBackend();
+  const kataHome = await configureKataHome(backend.url);
+  const server = await startIsolatedE2EServer();
+
+  try {
+    await page.goto(`${server.info.base_url}/kata`);
+    await expectKataDaemonSwitcherReady(page);
+    const list = page.locator(".issue-list");
+    await list.evaluate((element) => {
+      element.style.width = "940px";
+      element.style.flex = "none";
+    });
+
+    const titleHeader = page.locator(".table-header .col-title");
+    const titleRow = page.locator(".issue-row .col-title").first();
+    const titleWidthBefore = await titleRow.evaluate((element) => element.getBoundingClientRect().width);
+    expect(Math.abs((await titleHeader.boundingBox())!.x - (await titleRow.boundingBox())!.x)).toBeLessThanOrEqual(1);
+
+    await page.getByRole("button", { name: "Columns" }).click();
+    const panel = page.locator(".column-picker__panel");
+    await expect(panel).toBeVisible();
+    expect(await panel.evaluate((element) => getComputedStyle(element).position)).toBe("fixed");
+    expect(Number(await panel.evaluate((element) => getComputedStyle(element).zIndex))).toBeGreaterThan(0);
+    await page.getByRole("checkbox", { name: "Tags" }).click();
+    await expect(page.locator(".table-header .col-tags")).toHaveCount(0);
+    await expect(page.locator(".issue-row .col-tags")).toHaveCount(0);
+    const titleWidthAfter = await titleRow.evaluate((element) => element.getBoundingClientRect().width);
+    expect(titleWidthAfter).toBeGreaterThan(titleWidthBefore);
+
+    await list.evaluate((element) => {
+      element.style.width = "640px";
+    });
+    await expect(page.locator(".table-header .col-owner")).toBeHidden();
+    await list.evaluate((element) => {
+      element.style.width = "940px";
+    });
+    await expect(page.locator(".table-header .col-owner")).toBeVisible();
+    await expect(page.locator(".table-header .col-tags")).toHaveCount(0);
+
+    for (const column of ["id", "title", "updated", "priority", "due", "owner"]) {
+      const headerBox = await page.locator(`.table-header .col-${column}`).boundingBox();
+      const rowBox = await page.locator(`.issue-row .col-${column}`).first().boundingBox();
+      expect(headerBox).not.toBeNull();
+      expect(rowBox).not.toBeNull();
+      expect(Math.abs(headerBox!.x - rowBox!.x)).toBeLessThanOrEqual(1);
+      expect(Math.abs(headerBox!.width - rowBox!.width)).toBeLessThanOrEqual(1);
+    }
+  } finally {
+    await server.stop();
+    kataHome.restore();
+    await backend.close();
+  }
+});
+```
+
+Run from `frontend/`:
+
+```bash
+node ./scripts/run-e2e-to-file.ts tests/e2e-full/kata.spec.ts --grep "kata task columns float"
+```
+
+Expected: PASS with output recorded in the normal e2e log file.
+
+- [ ] **Step 9: Commit the complete user-visible interaction**
 
 Invoke `context-sync --commit`, then invoke the mandatory commit skill and create a commit with subject:
 
@@ -701,7 +869,7 @@ Invoke `context-sync --commit`, then invoke the mandatory commit skill and creat
 feat: let maintainers hide Kata task columns
 ```
 
-Stage only the picker, issue-list component, issue-list tests, and any Task 1 files changed during integration.
+Stage only the picker, issue-list component, unit/browser tests, the focused Kata Playwright test, and any Task 1 files changed during integration.
 
 ### Task 3: Run final frontend verification
 
@@ -710,7 +878,7 @@ Stage only the picker, issue-list component, issue-list tests, and any Task 1 fi
 
 **Interfaces:**
 - Consumes: the complete Tasks 1 and 2 implementation.
-- Produces: evidence that the focused behavior and affected frontend suite pass without a Playwright-only boundary.
+- Produces: evidence that unit logic, real-browser focus behavior, responsive geometry, and the affected frontend checks pass.
 
 - [ ] **Step 1: Run the full unit suite**
 
@@ -722,7 +890,18 @@ node ../node_modules/vite-plus/bin/vp test run --project unit
 
 Expected: PASS. Investigate any failure before continuing.
 
-- [ ] **Step 2: Run frontend formatting, lint, kit, and Svelte checks**
+- [ ] **Step 2: Run the full affected browser suite**
+
+Run from `frontend/`:
+
+```bash
+node ../node_modules/vite-plus/bin/vp test run --project browser src/lib/components/kata/KataIssueList.browser.svelte.ts
+node ./scripts/run-e2e-to-file.ts tests/e2e-full/kata.spec.ts --grep "kata task columns float"
+```
+
+Expected: both commands pass.
+
+- [ ] **Step 3: Run frontend formatting, lint, kit, and Svelte checks**
 
 Run from the repository root:
 
@@ -732,7 +911,7 @@ make frontend-check
 
 Expected: PASS for formatting, lint, `kit-ui-check`, and `svelte-check`.
 
-- [ ] **Step 3: Confirm the final diff and persistence scope**
+- [ ] **Step 4: Confirm the final diff and persistence scope**
 
 Run:
 
@@ -742,9 +921,9 @@ git diff --stat HEAD~2..HEAD
 git diff HEAD~2..HEAD -- frontend/src/lib/components/kata
 ```
 
-Expected: only the approved Kata column preference, picker, list integration, and tests are present. No API, backend, route, migration, or Playwright files change.
+Expected: only the approved Kata column preference, picker, list integration, unit/browser tests, and focused Kata Playwright coverage are present. No API, backend, route, or migration files change.
 
-- [ ] **Step 4: Apply any verification fixes as a new commit**
+- [ ] **Step 5: Apply any verification fixes as a new commit**
 
 If verification required edits, rerun the focused tests, full unit suite, Svelte autofixer for changed `.svelte` files, and `make frontend-check`. Then invoke `context-sync --commit` and the mandatory commit skill. Create a new commit rather than amending, with a subject that states the corrected user-visible outcome.
 

--- a/docs/superpowers/plans/2026-07-22-kata-task-column-visibility.md
+++ b/docs/superpowers/plans/2026-07-22-kata-task-column-visibility.md
@@ -821,6 +821,15 @@ test("kata task columns float and preserve responsive grid alignment", async ({ 
     await expect(panel).toBeVisible();
     expect(await panel.evaluate((element) => getComputedStyle(element).position)).toBe("fixed");
     expect(Number(await panel.evaluate((element) => getComputedStyle(element).zIndex))).toBeGreaterThan(0);
+    const triggerBox = await page.getByRole("button", { name: "Columns" }).boundingBox();
+    const panelBox = await panel.boundingBox();
+    expect(triggerBox).not.toBeNull();
+    expect(panelBox).not.toBeNull();
+    expect(Math.abs(panelBox!.x + panelBox!.width - (triggerBox!.x + triggerBox!.width))).toBeLessThanOrEqual(2);
+    expect(panelBox!.y).toBeGreaterThanOrEqual(0);
+    expect(panelBox!.x).toBeGreaterThanOrEqual(0);
+    expect(panelBox!.x + panelBox!.width).toBeLessThanOrEqual((page.viewportSize()?.width ?? 0) + 1);
+    expect(panelBox!.y + panelBox!.height).toBeLessThanOrEqual((page.viewportSize()?.height ?? 0) + 1);
     await page.getByRole("checkbox", { name: "Tags" }).click();
     await expect(page.locator(".table-header .col-tags")).toHaveCount(0);
     await expect(page.locator(".issue-row .col-tags")).toHaveCount(0);
@@ -836,6 +845,14 @@ test("kata task columns float and preserve responsive grid alignment", async ({ 
     });
     await expect(page.locator(".table-header .col-owner")).toBeVisible();
     await expect(page.locator(".table-header .col-tags")).toHaveCount(0);
+
+    await page.setViewportSize({ width: 720, height: 540 });
+    const constrainedPanelBox = await panel.boundingBox();
+    expect(constrainedPanelBox).not.toBeNull();
+    expect(constrainedPanelBox!.x).toBeGreaterThanOrEqual(0);
+    expect(constrainedPanelBox!.y).toBeGreaterThanOrEqual(0);
+    expect(constrainedPanelBox!.x + constrainedPanelBox!.width).toBeLessThanOrEqual(721);
+    expect(constrainedPanelBox!.y + constrainedPanelBox!.height).toBeLessThanOrEqual(541);
 
     for (const column of ["id", "title", "updated", "priority", "due", "owner"]) {
       const headerBox = await page.locator(`.table-header .col-${column}`).boundingBox();
@@ -896,10 +913,10 @@ Run from `frontend/`:
 
 ```bash
 node ../node_modules/vite-plus/bin/vp test run --project browser src/lib/components/kata/KataIssueList.browser.svelte.ts
-node ./scripts/run-e2e-to-file.ts tests/e2e-full/kata.spec.ts --grep "kata task columns float"
+node ./scripts/run-e2e-to-file.ts tests/e2e-full/kata.spec.ts
 ```
 
-Expected: both commands pass.
+Expected: the browser test and the complete affected Kata Playwright file pass.
 
 - [ ] **Step 3: Run frontend formatting, lint, kit, and Svelte checks**
 

--- a/docs/superpowers/specs/2026-07-22-kata-link-filtering-design.md
+++ b/docs/superpowers/specs/2026-07-22-kata-link-filtering-design.md
@@ -47,7 +47,7 @@ Use any matching peer already present in the current view immediately. Resolve r
 
 Until a peer resolves, retain its row as pending rather than guessing its status. Pending rows do not count as an Open or Closed match. The section should keep a quiet loading indication while unresolved peers remain so the user can distinguish incomplete hydration from an empty filter result.
 
-If a peer read fails, keep the existing short ID navigation affordance and mark its state unavailable. Failed peers remain visible only when the task-state filter includes both states, since their status cannot be classified safely. A later selected-task refresh retries hydration through the existing component lifecycle.
+If a peer read fails, keep the existing short ID navigation affordance and mark its state unavailable. Failed peers remain visible only when the task-state filter includes both states, since their status cannot be classified safely. When the selected detail is refreshed, even if its UID, revision, and link signature are unchanged, clear only failed peer entries and retry them. Successful peer summaries remain cached so a refresh does not restart every link request.
 
 ## Accessibility
 
@@ -68,5 +68,7 @@ Add focused component tests that prove:
 - A filtered-empty state differs from a task with no links.
 - Off-view peer hydration supplies title and status without changing link navigation.
 - Failed or pending peer hydration follows the documented visibility behavior.
+- A transient peer-read failure recovers after a same-task selected-detail refresh.
+- Relationship selections survive task-to-task navigation, while a later top-level status change resets only the Open/Closed choices.
 
-This is a UI-owned behavior change. Component tests cover the filtering and presentation contract. Add or update one affected Kata browser workflow only if the popover interaction or shared overlay behavior cannot be proved reliably in jsdom; no backend or API-contract test is required.
+This is a UI-owned behavior change. Component and workspace tests cover filtering, hydration, and state lifetime. Add one focused Kata Playwright workflow for the browser-only popover placement and clipping contract; use the real seeded Kata backend rather than a handwritten frontend fixture. No API-contract test is required.

--- a/docs/superpowers/specs/2026-07-22-kata-link-filtering-design.md
+++ b/docs/superpowers/specs/2026-07-22-kata-link-filtering-design.md
@@ -1,0 +1,72 @@
+# Kata Link Filtering Design
+
+**Date:** 2026-07-22
+**Status:** Approved for implementation
+
+## Goal
+
+Make linked Kata tasks reflect the active task-status scope, expose relationship filters, and communicate peer task state only when the visible set mixes open and closed tasks.
+
+## Scope
+
+- Filter linked peers by task status: **Open**, **Closed**, or both.
+- Default the link status selection from the top-level Kata status filter.
+- Filter links by their displayed relationship: **Parent**, **Child**, **Blocks**, **Blocked by**, and **Related**.
+- Keep link navigation and link creation behavior unchanged.
+- Do not derive a separate blocked task state. `Blocks` and `Blocked by` remain explicit relationship types.
+- Keep this change in the frontend. The existing Kata detail API already provides the peer task data needed to resolve status.
+
+## Interaction
+
+Add a compact **Filters** control beside the Links count. It opens a popover with two groups of checkboxes:
+
+- **Task state:** Open and Closed.
+- **Relationship:** Parent, Child, Blocks, Blocked by, and Related.
+
+All relationship types are enabled by default. Task-state defaults follow the active top-level filter:
+
+- top-level **Open** enables only Open links;
+- top-level **Closed** enables only Closed links;
+- top-level **All** enables both.
+
+Changing either group updates the visible rows immediately. The local filter state remains active while navigating between selected tasks in the current Kata workspace. A later top-level status change resets the local task-state selection to that new scope. Relationship choices remain unchanged because they are independent of task status.
+
+The section count shows the visible and total counts when filtering removes rows, for example `8 / 29`. With no active reduction, it shows the existing total count. If links exist but none match, show `No links match these filters.` The existing `No links.` message remains for tasks with no relationships.
+
+## Link Rows
+
+Each row keeps the existing relationship label, peer short ID, and title. Peer task hydration retains the full task summary instead of only the title so the row can be filtered by `status`.
+
+Render an **Open** or **Closed** state chip only when both states are enabled and the visible list can contain a mixture. When the filter shows only Open or only Closed, omit the chip because the filter already communicates that state. Status remains available to assistive technology through the row's accessible name when the chip is rendered.
+
+Relationship labels remain plain compact text. They already describe direction relative to the selected task, including the existing conversion from `parent` to `child` and from `blocks` to `blocked_by` when the selected task is on the opposite side of the edge.
+
+## Loading and Failure Behavior
+
+Use any matching peer already present in the current view immediately. Resolve remaining peers through the existing task-detail reads that currently hydrate off-screen link titles.
+
+Until a peer resolves, retain its row as pending rather than guessing its status. Pending rows do not count as an Open or Closed match. The section should keep a quiet loading indication while unresolved peers remain so the user can distinguish incomplete hydration from an empty filter result.
+
+If a peer read fails, keep the existing short ID navigation affordance and mark its state unavailable. Failed peers remain visible only when the task-state filter includes both states, since their status cannot be classified safely. A later selected-task refresh retries hydration through the existing component lifecycle.
+
+## Accessibility
+
+- The Filters trigger exposes its expanded state and has a clear accessible name.
+- Filter options use real labeled checkboxes.
+- Escape and outside interaction close the popover through the shared overlay behavior and restore focus to the trigger.
+- Visible state is not communicated by color alone: mixed-state rows use text-bearing chips, and single-state views are named by the active checkbox selection.
+- Link rows remain keyboard-focusable buttons with a complete accessible name.
+
+## Testing
+
+Add focused component tests that prove:
+
+- Open, Closed, and All top-level scopes produce the matching default link-status selection.
+- Relationship checkboxes independently hide and restore Parent, Child, Blocks, Blocked by, and Related rows.
+- Mixed Open and Closed results render state chips, while single-state results do not.
+- The count distinguishes visible links from the total when filters hide rows.
+- A filtered-empty state differs from a task with no links.
+- Off-view peer hydration supplies title and status without changing link navigation.
+- Failed or pending peer hydration follows the documented visibility behavior.
+
+This is a UI-owned behavior change. Component tests cover the filtering and presentation contract. Add or update one affected Kata browser workflow only if the popover interaction or shared overlay behavior cannot be proved reliably in jsdom; no backend or API-contract test is required.

--- a/docs/superpowers/specs/2026-07-22-kata-link-filtering-design.md
+++ b/docs/superpowers/specs/2026-07-22-kata-link-filtering-design.md
@@ -5,7 +5,7 @@
 
 ## Goal
 
-Make linked Kata tasks reflect the active task-status scope, expose relationship filters, and communicate peer task state only when the visible set mixes open and closed tasks.
+Make linked Kata tasks reflect the active task-status scope, expose relationship filters, and communicate peer task state whenever both Open and Closed are enabled.
 
 ## Scope
 
@@ -29,7 +29,9 @@ All relationship types are enabled by default. Task-state defaults follow the ac
 - top-level **Closed** enables only Closed links;
 - top-level **All** enables both.
 
-Changing either group updates the visible rows immediately. The local filter state remains active while navigating between selected tasks in the current Kata workspace. A later top-level status change resets the local task-state selection to that new scope. Relationship choices remain unchanged because they are independent of task status.
+Changing either group updates the visible rows immediately. The local filter state remains active while navigating between selected tasks on the same Kata daemon. A later top-level status change resets the local task-state selection to that new scope while retaining relationship choices. Switching daemons starts a new link-filter scope: task states follow the target daemon's top-level filter and all relationship types return to visible.
+
+If both task-state checkboxes are disabled, no resolved, pending, or failed rows are visible. If every relationship is disabled, the section shows the filtered-empty state immediately and does not show a resolving indicator for hidden relationships.
 
 The section count shows the visible and total counts when filtering removes rows, for example `8 / 29`. With no active reduction, it shows the existing total count. If links exist but none match, show `No links match these filters.` The existing `No links.` message remains for tasks with no relationships.
 
@@ -37,7 +39,7 @@ The section count shows the visible and total counts when filtering removes rows
 
 Each row keeps the existing relationship label, peer short ID, and title. Peer task hydration retains the full task summary instead of only the title so the row can be filtered by `status`.
 
-Render an **Open** or **Closed** state chip only when both states are enabled and the visible list can contain a mixture. When the filter shows only Open or only Closed, omit the chip because the filter already communicates that state. Status remains available to assistive technology through the row's accessible name when the chip is rendered.
+Render an **Open** or **Closed** state chip whenever both states are enabled, even if the current result happens to contain only one state. The filter no longer makes any individual row's state apparent in that mode. When the filter shows only Open or only Closed, omit the chip because the filter already communicates that state. Status remains available to assistive technology through the row's accessible name when the chip is rendered.
 
 Relationship labels remain plain compact text. They already describe direction relative to the selected task, including the existing conversion from `parent` to `child` and from `blocks` to `blocked_by` when the selected task is on the opposite side of the edge.
 
@@ -45,9 +47,9 @@ Relationship labels remain plain compact text. They already describe direction r
 
 Use any matching peer already present in the current view immediately. Resolve remaining peers through the existing task-detail reads that currently hydrate off-screen link titles.
 
-Until a peer resolves, retain its row as pending rather than guessing its status. Pending rows do not count as an Open or Closed match. The section should keep a quiet loading indication while unresolved peers remain so the user can distinguish incomplete hydration from an empty filter result.
+Until a peer resolves, retain its row as pending rather than guessing its status. Pending rows appear only when both task states are enabled. With a single active state they remain hidden, but the section keeps a quiet loading indication when their relationship is enabled and hydration could change the visible result. Pending peers behind disabled relationships, or with both task states disabled, do not contribute to loading state.
 
-If a peer read fails, keep the existing short ID navigation affordance and mark its state unavailable. Failed peers remain visible only when the task-state filter includes both states, since their status cannot be classified safely. When the selected detail is refreshed, even if its UID, revision, and link signature are unchanged, clear only failed peer entries and retry them. Successful peer summaries remain cached so a refresh does not restart every link request.
+If a peer read fails, keep the existing short ID navigation affordance visible under any non-empty task-state selection and mark its state unavailable. This prevents transient hydration failures from silently concealing relationships in the default Open view. When the selected detail is refreshed, even if its UID, revision, and link signature are unchanged, clear only failed peer entries and retry them. Successful peer summaries remain cached so a refresh does not restart every link request. Current-view peers are used directly and never receive redundant detail requests; remaining peers retain the existing bounded one-request-per-peer behavior within the selected-detail lifecycle.
 
 ## Accessibility
 
@@ -63,12 +65,14 @@ Add focused component tests that prove:
 
 - Open, Closed, and All top-level scopes produce the matching default link-status selection.
 - Relationship checkboxes independently hide and restore Parent, Child, Blocks, Blocked by, and Related rows.
-- Mixed Open and Closed results render state chips, while single-state results do not.
+- Both-state filters render state chips, while Open-only and Closed-only filters do not.
+- An All filter containing only Open peers still renders Open state chips.
 - The count distinguishes visible links from the total when filters hide rows.
 - A filtered-empty state differs from a task with no links.
 - Off-view peer hydration supplies title and status without changing link navigation.
 - Failed or pending peer hydration follows the documented visibility behavior.
+- Disabled relationships do not keep the section in a resolving state, and disabling both task states produces the filtered-empty state.
 - A transient peer-read failure recovers after a same-task selected-detail refresh.
-- Relationship selections survive task-to-task navigation, while a later top-level status change resets only the Open/Closed choices.
+- Relationship selections survive task-to-task navigation on one daemon, a later top-level status change resets only the Open/Closed choices, and a daemon switch resets the complete local link-filter scope.
 
 This is a UI-owned behavior change. Component and workspace tests cover filtering, hydration, and state lifetime. Add one focused Kata Playwright workflow for the browser-only popover placement and clipping contract; use the real seeded Kata backend rather than a handwritten frontend fixture. No API-contract test is required.

--- a/docs/superpowers/specs/2026-07-22-kata-task-column-visibility-design.md
+++ b/docs/superpowers/specs/2026-07-22-kata-task-column-visibility-design.md
@@ -12,7 +12,7 @@ Let maintainers hide low-value metadata columns in the Kata task list and rememb
 - Keep **ID** and **Title** permanently visible.
 - Let users independently show or hide **Updated**, **Priority**, **Due**, **Owner**, and **Tags**.
 - Apply one browser-local preference across every Kata task view, project scope, and daemon.
-- Keep sorting, row selection, tree expansion, and task detail behavior unchanged.
+- Keep row selection, tree expansion, and task detail behavior unchanged. Sorting changes only when the active optional sort column is hidden, as defined below.
 - Do not add server settings, URL state, or per-view overrides.
 
 ## Interaction
@@ -22,6 +22,8 @@ Add an always-available **Columns** button to the task-list header beside the tr
 Checkbox changes apply immediately while the popover remains open. Escape and outside interaction close the popover using the application's existing overlay and focus conventions. The control remains available when the current task set has no expandable rows, unlike the conditional tree controls.
 
 ID and Title do not appear as toggleable options. Keeping them fixed prevents users from hiding task identity or leaving a list that cannot be scanned meaningfully.
+
+If the user hides the currently active optional sort column (Updated, Priority, or Owner), sorting resets immediately to Title ascending and persists through the existing sort preference. This avoids ordering the list by an invisible criterion. Hiding Due or Tags does not affect sorting because those columns are not sort controls. Showing columns again does not change the current sort.
 
 ## State and Persistence
 
@@ -36,6 +38,8 @@ Persist the set in `localStorage` under a versioned Kata-specific key. On restor
 
 The preference is intentionally global within one browser. Navigating between Kata views, project scopes, or daemons retains the same column layout. Reloading or remounting the application restores it.
 
+Synchronization between simultaneously open browser tabs is out of scope. Each tab reads the preference when the task list mounts and writes its own later changes.
+
 ## Layout and Responsive Behavior
 
 Hidden columns are removed from both the header and every task row. Their grid tracks are also removed so the Title column receives the freed width instead of leaving empty gaps.
@@ -43,6 +47,8 @@ Hidden columns are removed from both the header and every task row. Their grid t
 The existing container-width rules remain an additional visibility constraint. A user-enabled column may still auto-hide when the task pane is narrow; a user-disabled column never appears at any width. Expanding the pane restores only columns that are enabled in the saved preference.
 
 Group headings, empty states, nested task indentation, row action placement, and the horizontal scroll container continue to span the resulting grid without changing their behavior.
+
+The header actions remain on one line. At compact container widths, the Columns, Expand all, and Collapse all labels become visually hidden while their icons, accessible names, and titles remain available. This prevents the always-visible Columns control from forcing the task heading or count out of the pane.
 
 ## Accessibility
 
@@ -61,5 +67,6 @@ Add focused component tests that prove:
 - Show all restores every optional column and updates storage;
 - malformed or wrong-shaped stored data falls back safely, while unknown column keys are ignored;
 - storage failures do not break the interaction.
+- hiding the active Updated, Priority, or Owner sort resets sorting to Title ascending and persists it.
 
-The behavior is component-owned and does not cross an HTTP or backend boundary. A full-stack Playwright test would duplicate the component contract without adding distinct confidence, so verification should use the Kata issue-list tests plus the affected frontend test and check suites.
+Add a Vitest browser test for keyboard opening, `aria-expanded`, Escape dismissal, and trigger focus restoration. Extend the Kata full-stack Playwright coverage for the browser-only layout contract: the picker floats above the header, header and row cells stay aligned, enabled columns auto-hide and return across representative container widths, disabled columns remain absent after widening, and the Title track receives freed width. The Playwright test exercises the real seeded Kata backend because the existing Kata full-stack fixture already owns this visible workflow.

--- a/docs/superpowers/specs/2026-07-22-kata-task-column-visibility-design.md
+++ b/docs/superpowers/specs/2026-07-22-kata-task-column-visibility-design.md
@@ -1,0 +1,65 @@
+# Kata Task Column Visibility Design
+
+**Date:** 2026-07-22
+**Status:** Approved for implementation
+
+## Goal
+
+Let maintainers hide low-value metadata columns in the Kata task list and remember that choice in the current browser. The interaction should preserve the table's compact scan line, keyboard behavior, and responsive layout.
+
+## Scope
+
+- Keep **ID** and **Title** permanently visible.
+- Let users independently show or hide **Updated**, **Priority**, **Due**, **Owner**, and **Tags**.
+- Apply one browser-local preference across every Kata task view, project scope, and daemon.
+- Keep sorting, row selection, tree expansion, and task detail behavior unchanged.
+- Do not add server settings, URL state, or per-view overrides.
+
+## Interaction
+
+Add an always-available **Columns** button to the task-list header beside the tree controls. It opens a compact popover containing one checkbox for each optional column and a **Show all** reset action.
+
+Checkbox changes apply immediately while the popover remains open. Escape and outside interaction close the popover using the application's existing overlay and focus conventions. The control remains available when the current task set has no expandable rows, unlike the conditional tree controls.
+
+ID and Title do not appear as toggleable options. Keeping them fixed prevents users from hiding task identity or leaving a list that cannot be scanned meaningfully.
+
+## State and Persistence
+
+The task-list component owns a small allowlisted set of visible optional-column keys. Its default contains all five optional columns.
+
+Persist the set in `localStorage` under a versioned Kata-specific key. On restore:
+
+- accept only known column keys;
+- ignore duplicates and unknown keys;
+- fall back to all optional columns when the stored value is missing, malformed, or not the expected shape;
+- treat storage read and write failures as non-fatal so the table remains usable.
+
+The preference is intentionally global within one browser. Navigating between Kata views, project scopes, or daemons retains the same column layout. Reloading or remounting the application restores it.
+
+## Layout and Responsive Behavior
+
+Hidden columns are removed from both the header and every task row. Their grid tracks are also removed so the Title column receives the freed width instead of leaving empty gaps.
+
+The existing container-width rules remain an additional visibility constraint. A user-enabled column may still auto-hide when the task pane is narrow; a user-disabled column never appears at any width. Expanding the pane restores only columns that are enabled in the saved preference.
+
+Group headings, empty states, nested task indentation, row action placement, and the horizontal scroll container continue to span the resulting grid without changing their behavior.
+
+## Accessibility
+
+- The Columns trigger exposes its expanded state and has a clear accessible name.
+- Each optional column uses a real labeled checkbox.
+- Keyboard users can open the popover, change options, close it with Escape, and regain focus on the trigger.
+- Visual column choices do not remove task identity or disrupt row keyboard navigation.
+
+## Testing
+
+Add focused component tests that prove:
+
+- ID and Title stay visible while an optional column can be hidden;
+- hiding a column removes both its header and its row cells;
+- the saved preference is restored after remounting;
+- Show all restores every optional column and updates storage;
+- malformed or wrong-shaped stored data falls back safely, while unknown column keys are ignored;
+- storage failures do not break the interaction.
+
+The behavior is component-owned and does not cross an HTTP or backend boundary. A full-stack Playwright test would duplicate the component contract without adding distinct confidence, so verification should use the Kata issue-list tests plus the affected frontend test and check suites.

--- a/docs/superpowers/specs/2026-07-22-kata-task-column-visibility-design.md
+++ b/docs/superpowers/specs/2026-07-22-kata-task-column-visibility-design.md
@@ -17,13 +17,13 @@ Let maintainers hide low-value metadata columns in the Kata task list and rememb
 
 ## Interaction
 
-Add an always-available **Columns** button to the task-list header beside the tree controls. It opens a compact popover containing one checkbox for each optional column and a **Show all** reset action.
+Add an always-available **Columns** button to the task-list header beside the tree controls. It opens a compact popover labeled **Shown when space allows**, containing one checkbox for each optional column and a **Show all** reset action. A checked box means user-enabled; actual rendering is the intersection of that preference and the columns supported by the current responsive layout.
 
 Checkbox changes apply immediately while the popover remains open. Escape and outside interaction close the popover using the application's existing overlay and focus conventions. The control remains available when the current task set has no expandable rows, unlike the conditional tree controls.
 
 ID and Title do not appear as toggleable options. Keeping them fixed prevents users from hiding task identity or leaving a list that cannot be scanned meaningfully.
 
-If the user hides the currently active optional sort column (Updated, Priority, or Owner), sorting resets immediately to Title ascending and persists through the existing sort preference. This avoids ordering the list by an invisible criterion. Hiding Due or Tags does not affect sorting because those columns are not sort controls. Showing columns again does not change the current sort.
+If the user hides the currently active optional sort column (Updated, Priority, or Owner), sorting resets immediately to Title ascending and persists through the existing sort preference. Restoring a saved visibility preference also reconciles an independently saved sort before first render. Responsive auto-hiding is temporary and does not change sorting; a user-enabled active sort column remains rendered, with horizontal overflow if necessary, so its indicator and control never disappear. Hiding Due or Tags does not affect sorting because those columns are not sort controls. Showing columns again does not change the current sort.
 
 ## State and Persistence
 
@@ -44,7 +44,7 @@ Synchronization between simultaneously open browser tabs is out of scope. Each t
 
 Hidden columns are removed from both the header and every task row. Their grid tracks are also removed so the Title column receives the freed width instead of leaving empty gaps.
 
-The existing container-width rules remain an additional visibility constraint. A user-enabled column may still auto-hide when the task pane is narrow; a user-disabled column never appears at any width. Expanding the pane restores only columns that are enabled in the saved preference.
+The existing container-width rules remain an additional visibility constraint. Effective visibility is `user-enabled ∩ layout-supported`, except that the active user-enabled sort column is always layout-supported so the ordering remains visible and controllable. Other user-enabled columns may auto-hide when the task pane is narrow, while a user-disabled column never appears at any width. Expanding the pane restores only columns that are enabled in the saved preference.
 
 Group headings, empty states, nested task indentation, row action placement, and the horizontal scroll container continue to span the resulting grid without changing their behavior.
 
@@ -65,8 +65,11 @@ Add focused component tests that prove:
 - hiding a column removes both its header and its row cells;
 - the saved preference is restored after remounting;
 - Show all restores every optional column and updates storage;
+- all optional columns can be disabled while ID and Title remain usable;
 - malformed or wrong-shaped stored data falls back safely, while unknown column keys are ignored;
 - storage failures do not break the interaction.
 - hiding the active Updated, Priority, or Owner sort resets sorting to Title ascending and persists it.
+- restoring inconsistent saved visibility and sort preferences reconciles to Title ascending before first render;
+- responsive auto-hiding leaves the saved sort unchanged and compact-layout header/row tracks remain aligned.
 
 Add a Vitest browser test for keyboard opening, `aria-expanded`, Escape dismissal, and trigger focus restoration. Extend the Kata full-stack Playwright coverage for the browser-only layout contract: the picker floats above the header, header and row cells stay aligned, enabled columns auto-hide and return across representative container widths, disabled columns remain absent after widening, and the Title track receives freed width. The Playwright test exercises the real seeded Kata backend because the existing Kata full-stack fixture already owns this visible workflow.

--- a/frontend/src/lib/components/kata/KataColumnPicker.svelte
+++ b/frontend/src/lib/components/kata/KataColumnPicker.svelte
@@ -51,6 +51,8 @@
     if (!open) return;
     await tick();
     position();
+    await tick();
+    position();
   }
 </script>
 
@@ -59,7 +61,7 @@
     bind:this={trigger}
     type="button"
     aria-label="Columns"
-    title="Choose visible columns"
+    title="Choose columns shown when space allows"
     aria-expanded={open}
     onclick={() => void toggle()}
   >
@@ -68,7 +70,7 @@
   </button>
   {#if open}
     <div bind:this={panel} class="column-picker__panel kit-popover-card" style={panelStyle}>
-      <div class="column-picker__title">Visible columns</div>
+      <div class="column-picker__title">Shown when space allows</div>
       {#each KATA_OPTIONAL_TASK_COLUMNS as column (column.id)}
         <Checkbox
           checked={visibility[column.id]}

--- a/frontend/src/lib/components/kata/KataColumnPicker.svelte
+++ b/frontend/src/lib/components/kata/KataColumnPicker.svelte
@@ -1,0 +1,155 @@
+<script lang="ts">
+  import Columns3Icon from "@lucide/svelte/icons/columns-3";
+  import { Checkbox, autoReposition, dismissable, floatingPopoverStyle } from "@kenn-io/kit-ui";
+  import { tick } from "svelte";
+  import {
+    KATA_OPTIONAL_TASK_COLUMNS,
+    type KataTaskColumnVisibility,
+  } from "./kataTaskColumns.js";
+
+  interface Props {
+    visibility: KataTaskColumnVisibility;
+    onchange: (visibility: KataTaskColumnVisibility) => void;
+    onShowAll: () => void;
+  }
+
+  let { visibility, onchange, onShowAll }: Props = $props();
+  let open = $state(false);
+  let trigger = $state<HTMLButtonElement>();
+  let panel = $state<HTMLDivElement>();
+  let panelStyle = $state("");
+
+  const allVisible = $derived(KATA_OPTIONAL_TASK_COLUMNS.every((column) => visibility[column.id]));
+
+  $effect(() => {
+    if (!open) return;
+    const cleanups = [
+      dismissable({ owners: () => [trigger, panel], dismiss: close, escapeFocus: () => trigger }),
+      autoReposition(() => panel, position),
+    ];
+    return () => cleanups.forEach((cleanup) => cleanup());
+  });
+
+  function close(): void {
+    open = false;
+  }
+
+  function position(): void {
+    if (!trigger || !panel) return;
+    panelStyle = floatingPopoverStyle({
+      trigger: trigger.getBoundingClientRect(),
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+      popoverWidth: panel.offsetWidth,
+      popoverHeight: panel.offsetHeight,
+      align: "end",
+    });
+  }
+
+  async function toggle(): Promise<void> {
+    open = !open;
+    if (!open) return;
+    await tick();
+    position();
+  }
+</script>
+
+<div class="column-picker">
+  <button
+    bind:this={trigger}
+    type="button"
+    aria-label="Columns"
+    title="Choose visible columns"
+    aria-expanded={open}
+    onclick={() => void toggle()}
+  >
+    <Columns3Icon size={13} strokeWidth={2} aria-hidden="true" />
+    <span class="action-label">Columns</span>
+  </button>
+  {#if open}
+    <div bind:this={panel} class="column-picker__panel kit-popover-card" style={panelStyle}>
+      <div class="column-picker__title">Visible columns</div>
+      {#each KATA_OPTIONAL_TASK_COLUMNS as column (column.id)}
+        <Checkbox
+          checked={visibility[column.id]}
+          label={column.label}
+          onchange={(checked) => onchange({ ...visibility, [column.id]: checked })}
+        />
+      {/each}
+      <button type="button" class="column-picker__reset" disabled={allVisible} onclick={onShowAll}>
+        Show all
+      </button>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .column-picker {
+    position: relative;
+    flex-shrink: 0;
+  }
+
+  .column-picker > button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-2);
+    min-height: 26px;
+    padding: 0 var(--space-4);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    background: var(--bg-surface);
+    color: var(--text-secondary);
+    font: inherit;
+    font-size: var(--font-size-xs);
+    font-weight: 500;
+    white-space: nowrap;
+    cursor: pointer;
+  }
+
+  .column-picker > button:hover,
+  .column-picker > button:focus-visible,
+  .column-picker > button[aria-expanded="true"] {
+    border-color: var(--border-strong);
+    color: var(--text-primary);
+  }
+
+  .column-picker__panel {
+    position: fixed;
+    z-index: var(--z-popover);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+    min-width: 180px;
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 16px);
+    overflow-y: auto;
+    padding: var(--space-5);
+  }
+
+  .column-picker__title {
+    color: var(--text-faint);
+    font-size: var(--font-size-3xs);
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .column-picker__reset {
+    margin-top: var(--space-2);
+    padding: var(--space-3) var(--space-4) 0;
+    border: 0;
+    border-top: 1px solid var(--border-muted);
+    background: transparent;
+    color: var(--accent-blue);
+    font: inherit;
+    font-size: var(--font-size-xs);
+    text-align: left;
+    cursor: pointer;
+  }
+
+  .column-picker__reset:disabled {
+    color: var(--text-faint);
+    cursor: default;
+  }
+</style>

--- a/frontend/src/lib/components/kata/KataIssueDetail.svelte
+++ b/frontend/src/lib/components/kata/KataIssueDetail.svelte
@@ -14,6 +14,7 @@
     KataTaskEvent,
     KataTaskGroup,
   } from "../../api/kata/taskTypes.js";
+  import type { KataLinkFilters } from "../../features/kata/kataLinkFilters.js";
   import type { MessageLinkRef } from "../../messages/types";
   import IssueMessageLinks from "../../features/kata/IssueMessageLinks.svelte";
   import RecurrencePanel from "../recurrence/RecurrencePanel.svelte";
@@ -36,6 +37,8 @@
     currentView: { groups: KataTaskGroup[] };
     api: KataTaskAPI;
     activeDaemonId?: string | undefined;
+    linkFilters: KataLinkFilters;
+    onLinkFiltersChange: (next: KataLinkFilters) => void;
     projects: KataProjectSummary[];
     ownerOptions: TypeaheadOption[];
     messageLinks: MessageLinkRef[];
@@ -75,6 +78,8 @@
     currentView,
     api,
     activeDaemonId = undefined,
+    linkFilters,
+    onLinkFiltersChange,
     projects,
     ownerOptions,
     messageLinks,
@@ -381,6 +386,8 @@
       {currentView}
       {api}
       {activeDaemonId}
+      {linkFilters}
+      {onLinkFiltersChange}
       onAddComment={onAddComment}
       onEditIssue={onEditIssue}
       onSelectIssue={onSelectIssue}

--- a/frontend/src/lib/components/kata/KataIssueDetail.test.ts
+++ b/frontend/src/lib/components/kata/KataIssueDetail.test.ts
@@ -8,6 +8,7 @@ import type {
   KataTaskDetail,
   KataTaskViewResponse,
 } from "../../api/kata/taskTypes.js";
+import { createKataLinkFilters } from "../../features/kata/kataLinkFilters.js";
 import type { MessageLinkRef } from "../../messages/types";
 
 import KataIssueDetail from "./KataIssueDetail.svelte";
@@ -111,6 +112,8 @@ function renderDetail(props: Partial<KataIssueDetailProps> = {}) {
       currentView: makeView(),
       api: makeAPI(),
       activeDaemonId: "home",
+      linkFilters: createKataLinkFilters("open"),
+      onLinkFiltersChange: vi.fn(),
       projects: [makeProject("project-1", "Inbox", "inbox"), makeProject("project-2", "Roadmap")],
       ownerOptions: [],
       messageLinks: [],

--- a/frontend/src/lib/components/kata/KataIssueDiscussion.svelte
+++ b/frontend/src/lib/components/kata/KataIssueDiscussion.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { MentionTextarea, type MentionOption } from "@kenn-io/kit-ui";
-  import { Button } from "@middleman/ui";
+  import { Button, ItemStateChip } from "@middleman/ui";
   import { renderMarkdown, renderMarkdownSync } from "@middleman/ui/utils/markdown";
   import { localDateTimeLabel, timeAgo } from "@middleman/ui/utils/time";
 
@@ -11,8 +11,18 @@
     KataTaskEvent,
     KataTaskGroup,
     KataTaskLink,
+    KataTaskSummary,
   } from "../../api/kata/taskTypes.js";
   import { describeKataEvent } from "../../features/kata/eventFormatter";
+  import {
+    kataLinkCouldAffectVisibleResults,
+    kataLinkMatchesFilters,
+    relationForKataLink,
+    type KataLinkFilters,
+    type KataLinkPeerResolution,
+    type KataLinkRelation,
+  } from "../../features/kata/kataLinkFilters.js";
+  import KataLinkFilterMenu from "./KataLinkFilterMenu.svelte";
 
   interface Props {
     issue: KataTaskDetail;
@@ -20,6 +30,8 @@
     currentView: { groups: KataTaskGroup[] };
     api: KataTaskAPI;
     activeDaemonId?: string | undefined;
+    linkFilters: KataLinkFilters;
+    onLinkFiltersChange: (next: KataLinkFilters) => void;
     onAddComment: (uid: string, body: string) => boolean | Promise<boolean>;
     onEditIssue: (uid: string, patch: KataTaskEditPatch) => boolean | Promise<boolean>;
     onSelectIssue: (uid: string) => void | Promise<void>;
@@ -31,6 +43,8 @@
     currentView,
     api,
     activeDaemonId = undefined,
+    linkFilters,
+    onLinkFiltersChange,
     onAddComment,
     onEditIssue,
     onSelectIssue,
@@ -38,9 +52,10 @@
 
   let commentDraft = $state("");
   let relatedDraft = $state("");
-  let linkTitles = $state<Record<string, string>>({});
-  let linkTitleSignature = $state("");
-  let pendingLinkTitleKeys = $state<ReadonlySet<string>>(new Set());
+  let hydratedPeers = $state<Record<string, KataTaskSummary | null>>({});
+  let peerHydrationSignature = $state("");
+  let pendingPeerKeys = $state<ReadonlySet<string>>(new Set());
+  let lastSelectedDetail: KataTaskDetail | null = null;
 
   const sortedComments = $derived.by(() => {
     const comments = issue.comments ?? [];
@@ -53,34 +68,62 @@
   });
 
   $effect(() => {
+    const current = issue;
+    if (lastSelectedDetail !== null && current !== lastSelectedDetail && current.issue.uid === lastSelectedDetail.issue.uid) {
+      hydratedPeers = Object.fromEntries(Object.entries(hydratedPeers).filter(([, peer]) => peer !== null));
+    }
+    lastSelectedDetail = current;
+  });
+
+  $effect(() => {
     const signature = linkHydrationSignature();
-    if (signature !== linkTitleSignature) {
-      linkTitleSignature = signature;
-      linkTitles = {};
-      pendingLinkTitleKeys = new Set();
+    if (signature !== peerHydrationSignature) {
+      peerHydrationSignature = signature;
+      hydratedPeers = {};
+      pendingPeerKeys = new Set();
     }
     const peerUIDs = issue.links
       .map((link) => linkPeerUIDFor(link, issue.issue.uid))
-      .filter((uid) => uid && linkTitles[uid] === undefined && !pendingLinkTitleKeys.has(`${signature}:${uid}`));
+      .filter(
+        (uid) =>
+          uid &&
+          currentViewPeer(uid) === undefined &&
+          hydratedPeers[uid] === undefined &&
+          !pendingPeerKeys.has(`${signature}:${uid}`),
+      );
     if (peerUIDs.length === 0) return;
     for (const uid of new Set(peerUIDs)) {
       const key = `${signature}:${uid}`;
-      pendingLinkTitleKeys = new Set([...pendingLinkTitleKeys, key]);
+      pendingPeerKeys = new Set([...pendingPeerKeys, key]);
       void api
         .issue(uid)
         .then((detail) => {
           if (signature !== linkHydrationSignature()) return;
-          linkTitles = { ...linkTitles, [uid]: detail.issue.title };
+          hydratedPeers = { ...hydratedPeers, [uid]: detail.issue };
         })
         .catch(() => {
           if (signature !== linkHydrationSignature()) return;
-          linkTitles = { ...linkTitles, [uid]: "" };
+          hydratedPeers = { ...hydratedPeers, [uid]: null };
         })
         .finally(() => {
-          pendingLinkTitleKeys = new Set([...pendingLinkTitleKeys].filter((candidate) => candidate !== key));
+          pendingPeerKeys = new Set([...pendingPeerKeys].filter((candidate) => candidate !== key));
         });
     }
   });
+
+  const visibleLinks = $derived(
+    issue.links.filter((link) =>
+      kataLinkMatchesFilters(link, issue.issue.uid, peerResolution(link), linkFilters),
+    ),
+  );
+  const showStateChips = $derived(linkFilters.statuses.open && linkFilters.statuses.closed);
+  const unresolvedPeerCount = $derived(
+    issue.links.filter(
+      (link) =>
+        peerResolution(link).kind === "pending" &&
+        kataLinkCouldAffectVisibleResults(link, issue.issue.uid, linkFilters),
+    ).length,
+  );
 
   async function submitComment(): Promise<void> {
     const body = commentDraft.trim();
@@ -91,18 +134,17 @@
     }
   }
 
-  function currentIssueTitle(uid: string): string {
-    if (issue.issue.uid === uid) return issue.issue.title;
+  function currentViewPeer(uid: string): KataTaskSummary | undefined {
     for (const group of currentView.groups) {
-      const found = group.issues.find((item) => item.uid === uid);
-      if (found) return found.title;
+      const found = group.issues.find((candidate) => candidate.uid === uid);
+      if (found) return found;
     }
-    return linkTitles[uid] ?? "";
+    return undefined;
   }
 
   function linkHydrationSignature(): string {
     const links = issue.links.map((link) => `${link.id}:${linkPeerUIDFor(link, issue.issue.uid)}:${link.type}`).join("|");
-    return `${activeDaemonId ?? ""}:${issue.issue.uid}:${issue.issue.revision}:${links}`;
+    return `${activeDaemonId ?? ""}:${issue.issue.uid}:${links}`;
   }
 
   function linkPeerUIDFor(link: KataTaskLink, selectedUID: string | undefined): string {
@@ -117,14 +159,26 @@
     return link.from.uid === issue.issue.uid ? link.to.short_id : link.from.short_id;
   }
 
-  function linkPeerTitle(link: KataTaskLink): string {
-    return currentIssueTitle(linkPeerUID(link));
+  function peerResolution(link: KataTaskLink): KataLinkPeerResolution {
+    const uid = linkPeerUID(link);
+    const current = currentViewPeer(uid);
+    if (current) return { kind: "resolved", peer: current };
+    const hydrated = hydratedPeers[uid];
+    if (hydrated === null) return { kind: "failed" };
+    if (hydrated !== undefined) return { kind: "resolved", peer: hydrated };
+    return { kind: "pending" };
   }
 
+  const relationLabels: Record<KataLinkRelation, string> = {
+    parent: "parent",
+    child: "child",
+    blocks: "blocks",
+    blocked_by: "blocked_by",
+    related: "related",
+  };
+
   function linkLabel(link: KataTaskLink): string {
-    if (link.type === "blocks" && link.to.uid === issue.issue.uid) return "blocked_by";
-    if (link.type === "parent") return link.to.uid === issue.issue.uid ? "parent" : "child";
-    return link.type;
+    return relationLabels[relationForKataLink(link, issue.issue.uid)];
   }
 
   async function submitRelatedLink(): Promise<void> {
@@ -167,26 +221,44 @@
 </script>
 
 <section class="task-links" aria-label="Links">
-  <div class="section-header">
+  <div class="section-header link-section-header">
     <h3>Links</h3>
-    <span>{issue.links.length}</span>
+    <div class="link-header-actions">
+      <span>
+        {visibleLinks.length === issue.links.length
+          ? issue.links.length
+          : `${visibleLinks.length} / ${issue.links.length}`}
+      </span>
+      {#if unresolvedPeerCount > 0}<span class="link-loading">Resolving {unresolvedPeerCount}</span>{/if}
+      <KataLinkFilterMenu filters={linkFilters} onChange={onLinkFiltersChange} />
+    </div>
   </div>
   {#if issue.links.length === 0}
     <p class="link-empty">No links.</p>
+  {:else if visibleLinks.length === 0 && unresolvedPeerCount > 0}
+    <p class="link-empty">Resolving linked tasks...</p>
+  {:else if visibleLinks.length === 0}
+    <p class="link-empty">No links match these filters.</p>
   {:else}
-    <div class="link-list">
-      {#each issue.links as link (link.id)}
+    <div class="link-list" aria-busy={unresolvedPeerCount > 0}>
+      {#each visibleLinks as link (link.id)}
+        {@const resolution = peerResolution(link)}
+        {@const peer = resolution.kind === "resolved" ? resolution.peer : undefined}
         <button
           type="button"
-          class="link-row"
+          class={["link-row", (showStateChips || resolution.kind === "failed") && "link-row--with-state"]}
+          aria-label={`${linkLabel(link)} ${linkPeerShortID(link)} ${peer?.title ?? ""}${showStateChips && peer ? ` ${peer.status}` : ""}${resolution.kind === "failed" ? " state unavailable" : ""}`.trim()}
           onclick={() => {
             void onSelectIssue(linkPeerUID(link));
           }}
         >
           <span class="link-kind">{linkLabel(link)}</span>
           <span class="link-peer">{linkPeerShortID(link)}</span>
-          {#if linkPeerTitle(link)}
-            <span class="link-title">{linkPeerTitle(link)}</span>
+          {#if peer?.title}<span class="link-title">{peer.title}</span>{/if}
+          {#if showStateChips && peer}
+            <ItemStateChip state={peer.status} size="xs" />
+          {:else if resolution.kind === "failed"}
+            <ItemStateChip state="unknown" size="xs" title="Task state unavailable" />
           {/if}
         </button>
       {/each}
@@ -319,9 +391,19 @@
     margin: 0;
   }
 
-  .section-header > span {
+  .link-header-actions {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-3);
+  }
+
+  .link-header-actions > span {
     color: var(--text-muted);
     font-size: var(--font-size-xs);
+  }
+
+  .link-header-actions > .link-loading {
+    color: var(--text-faint);
   }
 
   .link-empty,
@@ -352,6 +434,10 @@
     font-size: var(--font-size-sm);
     text-align: left;
     cursor: pointer;
+  }
+
+  .link-row--with-state {
+    grid-template-columns: minmax(72px, max-content) minmax(54px, max-content) minmax(0, 1fr) max-content;
   }
 
   .link-row:hover {

--- a/frontend/src/lib/components/kata/KataIssueDiscussion.svelte
+++ b/frontend/src/lib/components/kata/KataIssueDiscussion.svelte
@@ -426,7 +426,7 @@
     background: transparent;
     color: var(--text-primary);
     display: grid;
-    grid-template-columns: minmax(72px, max-content) minmax(54px, max-content) minmax(0, 1fr);
+    grid-template-columns: max-content max-content minmax(0, 1fr);
     align-items: center;
     gap: 8px;
     padding: 4px 6px;
@@ -437,7 +437,7 @@
   }
 
   .link-row--with-state {
-    grid-template-columns: minmax(72px, max-content) minmax(54px, max-content) minmax(0, 1fr) max-content;
+    grid-template-columns: max-content max-content minmax(0, 1fr) max-content;
   }
 
   .link-row:hover {

--- a/frontend/src/lib/components/kata/KataIssueDiscussion.test.ts
+++ b/frontend/src/lib/components/kata/KataIssueDiscussion.test.ts
@@ -4,9 +4,11 @@ import type {
   KataTaskAPI,
   KataTaskDetail,
   KataTaskEvent,
+  KataTaskLink,
   KataTaskSummary,
   KataTaskViewResponse,
 } from "../../api/kata/taskTypes.js";
+import { createKataLinkFilters } from "../../features/kata/kataLinkFilters.js";
 
 import KataIssueDiscussion from "./KataIssueDiscussion.svelte";
 
@@ -102,7 +104,12 @@ function makeView(): KataTaskViewResponse {
   };
 }
 
-function makeAPI(options: { searchIssues?: KataTaskSummary[]; issueDetail?: KataTaskDetail } = {}): KataTaskAPI {
+function makeAPI(
+  options: {
+    searchIssues?: KataTaskSummary[];
+    issueDetails?: Record<string, KataTaskDetail>;
+  } = {},
+): KataTaskAPI {
   return {
     search: vi.fn(async () => ({
       filters: { scope: { kind: "all" }, status: "open", owner: "", label: "", query: "" },
@@ -110,9 +117,21 @@ function makeAPI(options: { searchIssues?: KataTaskSummary[]; issueDetail?: Kata
       fetched_at: "2026-06-01T12:00:00Z",
     })),
     issue: vi.fn(
-      async () => options.issueDetail ?? makeIssue({ uid: "issue-2", short_id: "I-2", title: "Hydrated task" }),
+      async (uid: string) => options.issueDetails?.[uid] ?? makeIssue({ uid, short_id: uid, title: "Hydrated task" }),
     ),
   } as unknown as KataTaskAPI;
+}
+
+function taskLink(id: number, peerUID: string, peerShortID: string, type: KataTaskLink["type"]): KataTaskLink {
+  return {
+    id,
+    project_id: 1,
+    from: { uid: "issue-1", short_id: "I-1" },
+    to: { uid: peerUID, short_id: peerShortID },
+    type,
+    author: "wes",
+    created_at: "2026-06-01T12:20:00Z",
+  };
 }
 
 function searchTask(overrides: Partial<KataTaskSummary> = {}): KataTaskSummary {
@@ -152,6 +171,8 @@ describe("KataIssueDiscussion", () => {
         currentView: makeView(),
         api: makeAPI(),
         activeDaemonId: "home",
+        linkFilters: createKataLinkFilters("open"),
+        onLinkFiltersChange: vi.fn(),
         onAddComment,
         onEditIssue,
         onSelectIssue: vi.fn(),
@@ -185,6 +206,8 @@ describe("KataIssueDiscussion", () => {
         currentView: makeView(),
         api: makeAPI(),
         activeDaemonId: "home",
+        linkFilters: createKataLinkFilters("open"),
+        onLinkFiltersChange: vi.fn(),
         onAddComment: vi.fn(async () => true),
         onEditIssue: vi.fn(async () => true),
         onSelectIssue,
@@ -213,6 +236,8 @@ describe("KataIssueDiscussion", () => {
         currentView: makeView(),
         api: makeAPI(),
         activeDaemonId: "home",
+        linkFilters: createKataLinkFilters("open"),
+        onLinkFiltersChange: vi.fn(),
         onAddComment: vi.fn(async () => false),
         onEditIssue: vi.fn(async () => true),
         onSelectIssue: vi.fn(),
@@ -236,6 +261,8 @@ describe("KataIssueDiscussion", () => {
         currentView: makeView(),
         api,
         activeDaemonId: "home",
+        linkFilters: createKataLinkFilters("open"),
+        onLinkFiltersChange: vi.fn(),
         onAddComment: vi.fn(async () => true),
         onEditIssue: vi.fn(async () => true),
         onSelectIssue: vi.fn(),
@@ -292,6 +319,8 @@ describe("KataIssueDiscussion", () => {
         currentView: makeView(),
         api: makeAPI({ searchIssues: [sharedHome, ...filler, sharedWork] }),
         activeDaemonId: "home",
+        linkFilters: createKataLinkFilters("open"),
+        onLinkFiltersChange: vi.fn(),
         onAddComment: vi.fn(async () => true),
         onEditIssue: vi.fn(async () => true),
         onSelectIssue: vi.fn(),
@@ -321,6 +350,8 @@ describe("KataIssueDiscussion", () => {
         currentView: makeView(),
         api: makeAPI({ searchIssues: [searchTask({ short_id: "rent", title: "Rent" })] }),
         activeDaemonId: "home",
+        linkFilters: createKataLinkFilters("open"),
+        onLinkFiltersChange: vi.fn(),
         onAddComment: vi.fn(async () => true),
         onEditIssue: vi.fn(async () => true),
         onSelectIssue: vi.fn(),
@@ -357,6 +388,8 @@ describe("KataIssueDiscussion", () => {
         currentView: makeView(),
         api: makeAPI(),
         activeDaemonId: "home",
+        linkFilters: createKataLinkFilters("open"),
+        onLinkFiltersChange: vi.fn(),
         onAddComment: vi.fn(async () => true),
         onEditIssue: vi.fn(async () => true),
         onSelectIssue: vi.fn(),
@@ -384,11 +417,13 @@ describe("KataIssueDiscussion", () => {
       },
     ];
     const api = makeAPI({
-      issueDetail: makeIssue({
-        uid: "issue-peer",
-        short_id: "P-1",
-        title: "Hydrated peer task",
-      }),
+      issueDetails: {
+        "issue-peer": makeIssue({
+          uid: "issue-peer",
+          short_id: "P-1",
+          title: "Hydrated peer task",
+        }),
+      },
     });
     render(KataIssueDiscussion, {
       props: {
@@ -397,6 +432,8 @@ describe("KataIssueDiscussion", () => {
         currentView: { groups: [] },
         api,
         activeDaemonId: "home",
+        linkFilters: createKataLinkFilters("open"),
+        onLinkFiltersChange: vi.fn(),
         onAddComment: vi.fn(async () => true),
         onEditIssue: vi.fn(async () => true),
         onSelectIssue: vi.fn(),
@@ -408,5 +445,307 @@ describe("KataIssueDiscussion", () => {
       expect(within(links).getByText("Hydrated peer task")).toBeTruthy();
     });
     expect(api.issue).toHaveBeenCalledWith("issue-peer");
+  });
+
+  it("shows only open peers by default and reports the filtered count", async () => {
+    const selected = makeIssue();
+    selected.links = [taskLink(1, "issue-open", "open", "related"), taskLink(2, "issue-closed", "closed", "blocks")];
+    render(KataIssueDiscussion, {
+      props: {
+        issue: selected,
+        events: [],
+        currentView: { groups: [] },
+        api: makeAPI({
+          issueDetails: {
+            "issue-open": makeIssue({ uid: "issue-open", short_id: "open", title: "Open peer", status: "open" }),
+            "issue-closed": makeIssue({
+              uid: "issue-closed",
+              short_id: "closed",
+              title: "Closed peer",
+              status: "closed",
+            }),
+          },
+        }),
+        activeDaemonId: "home",
+        linkFilters: createKataLinkFilters("open"),
+        onLinkFiltersChange: vi.fn(),
+        onAddComment: vi.fn(async () => true),
+        onEditIssue: vi.fn(async () => true),
+        onSelectIssue: vi.fn(),
+      },
+    });
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /Open peer/ })).toBeTruthy());
+    expect(screen.queryByRole("button", { name: /Closed peer/ })).toBeNull();
+    const links = screen.getByRole("region", { name: "Links" });
+    expect(within(links).getByText("1 / 2")).toBeTruthy();
+    expect(links.querySelector(".state-badge")).toBeNull();
+  });
+
+  it("shows state chips when both task-state filters are enabled", async () => {
+    const selected = makeIssue();
+    selected.links = [taskLink(1, "issue-open", "open", "related"), taskLink(2, "issue-closed", "closed", "blocks")];
+    render(KataIssueDiscussion, {
+      props: {
+        issue: selected,
+        events: [],
+        currentView: { groups: [] },
+        api: makeAPI({
+          issueDetails: {
+            "issue-open": makeIssue({ uid: "issue-open", short_id: "open", title: "Open peer", status: "open" }),
+            "issue-closed": makeIssue({
+              uid: "issue-closed",
+              short_id: "closed",
+              title: "Closed peer",
+              status: "closed",
+            }),
+          },
+        }),
+        activeDaemonId: "home",
+        linkFilters: createKataLinkFilters("all"),
+        onLinkFiltersChange: vi.fn(),
+        onAddComment: vi.fn(async () => true),
+        onEditIssue: vi.fn(async () => true),
+        onSelectIssue: vi.fn(),
+      },
+    });
+
+    const links = screen.getByRole("region", { name: "Links" });
+    await waitFor(() => expect(within(links).getByRole("button", { name: /Open peer open/ })).toBeTruthy());
+    expect(within(links).getByRole("button", { name: /Closed peer closed/ })).toBeTruthy();
+    expect(within(links).getByText("Open").closest(".state-badge")).toBeTruthy();
+    expect(within(links).getByText("Closed").closest(".state-badge")).toBeTruthy();
+  });
+
+  it("shows state chips when both filters are enabled even if every peer is open", async () => {
+    const selected = makeIssue();
+    selected.links = [taskLink(1, "issue-open", "open", "related")];
+    render(KataIssueDiscussion, {
+      props: {
+        issue: selected,
+        events: [],
+        currentView: { groups: [] },
+        api: makeAPI({
+          issueDetails: {
+            "issue-open": makeIssue({ uid: "issue-open", short_id: "open", title: "Only open peer", status: "open" }),
+          },
+        }),
+        activeDaemonId: "home",
+        linkFilters: createKataLinkFilters("all"),
+        onLinkFiltersChange: vi.fn(),
+        onAddComment: vi.fn(async () => true),
+        onEditIssue: vi.fn(async () => true),
+        onSelectIssue: vi.fn(),
+      },
+    });
+
+    const links = screen.getByRole("region", { name: "Links" });
+    await waitFor(() => expect(within(links).getByRole("button", { name: /Only open peer open/ })).toBeTruthy());
+    expect(within(links).getByText("Open").closest(".state-badge")).toBeTruthy();
+  });
+
+  it("filters directional relationship types and shows the filtered-empty message", async () => {
+    const selected = makeIssue();
+    selected.links = [
+      taskLink(1, "issue-related", "related", "related"),
+      taskLink(2, "issue-blocked", "blocked", "blocks"),
+    ];
+    const filters = createKataLinkFilters("all");
+    filters.relations.related = false;
+    filters.relations.blocks = false;
+    render(KataIssueDiscussion, {
+      props: {
+        issue: selected,
+        events: [],
+        currentView: { groups: [] },
+        api: makeAPI({
+          issueDetails: {
+            "issue-related": makeIssue({ uid: "issue-related", short_id: "related", title: "Related peer" }),
+            "issue-blocked": makeIssue({ uid: "issue-blocked", short_id: "blocked", title: "Blocked peer" }),
+          },
+        }),
+        activeDaemonId: "home",
+        linkFilters: filters,
+        onLinkFiltersChange: vi.fn(),
+        onAddComment: vi.fn(async () => true),
+        onEditIssue: vi.fn(async () => true),
+        onSelectIssue: vi.fn(),
+      },
+    });
+
+    const links = screen.getByRole("region", { name: "Links" });
+    await waitFor(() => expect(within(links).getByText("No links match these filters.")).toBeTruthy());
+    expect(within(links).queryByText("No links.")).toBeNull();
+    expect(within(links).getByText("0 / 2")).toBeTruthy();
+  });
+
+  it("shows a resolving state while a single-state filter waits for peer status", () => {
+    const selected = makeIssue();
+    selected.links = [taskLink(1, "issue-pending", "pending", "related")];
+    const api = makeAPI();
+    vi.mocked(api.issue).mockImplementation(() => new Promise<KataTaskDetail>(() => {}));
+
+    render(KataIssueDiscussion, {
+      props: {
+        issue: selected,
+        events: [],
+        currentView: { groups: [] },
+        api,
+        activeDaemonId: "home",
+        linkFilters: createKataLinkFilters("open"),
+        onLinkFiltersChange: vi.fn(),
+        onAddComment: vi.fn(async () => true),
+        onEditIssue: vi.fn(async () => true),
+        onSelectIssue: vi.fn(),
+      },
+    });
+
+    expect(within(screen.getByRole("region", { name: "Links" })).getByText("Resolving linked tasks...")).toBeTruthy();
+  });
+
+  it("does not show resolving state for a pending disabled relationship", () => {
+    const selected = makeIssue();
+    selected.links = [taskLink(1, "issue-pending", "pending", "related")];
+    const api = makeAPI();
+    vi.mocked(api.issue).mockImplementation(() => new Promise<KataTaskDetail>(() => {}));
+    const filters = createKataLinkFilters("open");
+    filters.relations.related = false;
+
+    render(KataIssueDiscussion, {
+      props: {
+        issue: selected,
+        events: [],
+        currentView: { groups: [] },
+        api,
+        activeDaemonId: "home",
+        linkFilters: filters,
+        onLinkFiltersChange: vi.fn(),
+        onAddComment: vi.fn(async () => true),
+        onEditIssue: vi.fn(async () => true),
+        onSelectIssue: vi.fn(),
+      },
+    });
+
+    const links = screen.getByRole("region", { name: "Links" });
+    expect(within(links).getByText("No links match these filters.")).toBeTruthy();
+    expect(within(links).queryByText(/Resolving/)).toBeNull();
+  });
+
+  it("shows the filtered-empty state when both task states are disabled", () => {
+    const selected = makeIssue();
+    selected.links = [taskLink(1, "issue-open", "open", "related")];
+    const filters = createKataLinkFilters("all");
+    filters.statuses.open = false;
+    filters.statuses.closed = false;
+
+    render(KataIssueDiscussion, {
+      props: {
+        issue: selected,
+        events: [],
+        currentView: makeView(),
+        api: makeAPI(),
+        activeDaemonId: "home",
+        linkFilters: filters,
+        onLinkFiltersChange: vi.fn(),
+        onAddComment: vi.fn(async () => true),
+        onEditIssue: vi.fn(async () => true),
+        onSelectIssue: vi.fn(),
+      },
+    });
+
+    expect(
+      within(screen.getByRole("region", { name: "Links" })).getByText("No links match these filters."),
+    ).toBeTruthy();
+  });
+
+  it("keeps failed peer state discoverable in a single-state view", async () => {
+    const selected = makeIssue();
+    selected.links = [taskLink(1, "issue-missing", "missing", "related")];
+    const api = makeAPI();
+    vi.mocked(api.issue).mockRejectedValue(new Error("unavailable"));
+
+    render(KataIssueDiscussion, {
+      props: {
+        issue: selected,
+        events: [],
+        currentView: { groups: [] },
+        api,
+        activeDaemonId: "home",
+        linkFilters: createKataLinkFilters("open"),
+        onLinkFiltersChange: vi.fn(),
+        onAddComment: vi.fn(async () => true),
+        onEditIssue: vi.fn(async () => true),
+        onSelectIssue: vi.fn(),
+      },
+    });
+
+    const links = screen.getByRole("region", { name: "Links" });
+    await waitFor(() => expect(within(links).getByTitle("Task state unavailable")).toBeTruthy());
+    expect(within(links).getByRole("button", { name: /missing state unavailable/ })).toBeTruthy();
+  });
+
+  it("uses current-view peer summaries without redundant detail requests", () => {
+    const selected = makeIssue();
+    selected.links = [taskLink(1, "issue-2", "I-2", "related")];
+    const api = makeAPI();
+
+    render(KataIssueDiscussion, {
+      props: {
+        issue: selected,
+        events: [],
+        currentView: makeView(),
+        api,
+        activeDaemonId: "home",
+        linkFilters: createKataLinkFilters("open"),
+        onLinkFiltersChange: vi.fn(),
+        onAddComment: vi.fn(async () => true),
+        onEditIssue: vi.fn(async () => true),
+        onSelectIssue: vi.fn(),
+      },
+    });
+
+    expect(screen.getByRole("button", { name: /Linked task/ })).toBeTruthy();
+    expect(api.issue).not.toHaveBeenCalled();
+  });
+
+  it("retries only failed peers when a revised selected detail refreshes", async () => {
+    const selected = makeIssue();
+    selected.links = [taskLink(1, "issue-stable", "stable", "related"), taskLink(2, "issue-retry", "retry", "related")];
+    const api = makeAPI();
+    let retryCalls = 0;
+    vi.mocked(api.issue).mockImplementation(async (uid: string) => {
+      if (uid === "issue-stable") {
+        return makeIssue({ uid, short_id: "stable", title: "Stable peer" });
+      }
+      retryCalls += 1;
+      if (retryCalls === 1) throw new Error("temporary");
+      return makeIssue({ uid, short_id: "retry", title: "Recovered peer" });
+    });
+    const props = {
+      issue: selected,
+      events: [],
+      currentView: { groups: [] },
+      api,
+      activeDaemonId: "home",
+      linkFilters: createKataLinkFilters("all"),
+      onLinkFiltersChange: vi.fn(),
+      onAddComment: vi.fn(async () => true),
+      onEditIssue: vi.fn(async () => true),
+      onSelectIssue: vi.fn(),
+    };
+    const { rerender } = render(KataIssueDiscussion, { props });
+    const links = screen.getByRole("region", { name: "Links" });
+    await waitFor(() => expect(within(links).getByRole("button", { name: /Stable peer open/ })).toBeTruthy());
+    await waitFor(() => expect(within(links).getByTitle("Task state unavailable")).toBeTruthy());
+
+    await rerender({
+      ...props,
+      issue: { ...selected, issue: { ...selected.issue, revision: selected.issue.revision + 1 } },
+    });
+
+    await waitFor(() => expect(within(links).getByRole("button", { name: /Recovered peer open/ })).toBeTruthy());
+    expect(api.issue).toHaveBeenCalledTimes(3);
+    expect(vi.mocked(api.issue).mock.calls.filter(([uid]) => uid === "issue-stable")).toHaveLength(1);
+    expect(vi.mocked(api.issue).mock.calls.filter(([uid]) => uid === "issue-retry")).toHaveLength(2);
   });
 });

--- a/frontend/src/lib/components/kata/KataIssueList.browser.svelte.ts
+++ b/frontend/src/lib/components/kata/KataIssueList.browser.svelte.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
-import { page } from "vite-plus/test/browser";
+import { page, userEvent } from "vite-plus/test/browser";
 import { render } from "vitest-browser-svelte";
 
 import "../../../app.css";
@@ -40,6 +40,31 @@ function currentView(issue: KataTaskSummary): KataCurrentView {
 }
 
 describe("KataIssueList table geometry (browser)", () => {
+  it("opens the column picker from the keyboard and restores focus on Escape", async () => {
+    await page.viewport(980, 620);
+    const issue = task();
+    render(KataIssueList, {
+      props: {
+        currentView: currentView(issue),
+        selectedIssueUID: issue.uid,
+        loading: false,
+        onSelect: () => {},
+      },
+    });
+
+    const trigger = page.getByRole("button", { name: "Columns" });
+    (trigger.element() as HTMLButtonElement).focus();
+    await userEvent.keyboard("{Enter}");
+    await expect.element(trigger).toHaveAttribute("aria-expanded", "true");
+    const updated = page.getByRole("checkbox", { name: "Updated" });
+    await expect.element(updated).toBeVisible();
+
+    await userEvent.keyboard("{Escape}");
+
+    await expect.element(trigger).toHaveAttribute("aria-expanded", "false");
+    await expect.element(trigger).toHaveFocus();
+  });
+
   it("paints the header and selected row flush with the table pane", async () => {
     await page.viewport(980, 620);
 

--- a/frontend/src/lib/components/kata/KataIssueList.svelte
+++ b/frontend/src/lib/components/kata/KataIssueList.svelte
@@ -65,8 +65,12 @@
   }: Props = $props();
 
   const SORT_STORAGE_KEY = "middleman:kata:issue-sort/v1";
-  let sort: KataTaskSort = $state(loadSort());
-  let columnVisibility = $state(loadKataTaskColumnVisibility());
+  const restoredColumnVisibility = loadKataTaskColumnVisibility();
+  const restoredSort = loadSort();
+  const initialSort = sortForColumnVisibility(restoredSort, restoredColumnVisibility);
+  let sort: KataTaskSort = $state(initialSort);
+  let columnVisibility = $state(restoredColumnVisibility);
+  if (initialSort !== restoredSort) persistSort(initialSort);
 
   type TaskGridLayout = "wide" | "medium" | "compact" | "narrow";
 
@@ -116,10 +120,16 @@
       "var(--table-id-col)",
       TASK_TITLE_TRACKS[layout],
       ...KATA_OPTIONAL_TASK_COLUMNS.flatMap((column) => {
-        const track = TASK_COLUMN_TRACKS[layout][column.id];
+        const track = taskColumnTrack(layout, column.id);
         return columnVisibility[column.id] && track ? [track] : [];
       }),
     ].join(" ");
+  }
+
+  function taskColumnTrack(layout: TaskGridLayout, column: KataOptionalTaskColumn): string | null {
+    const track = TASK_COLUMN_TRACKS[layout][column];
+    if (track || column !== "owner" || sort.key !== "owner") return track;
+    return TASK_COLUMN_TRACKS.medium.owner;
   }
 
   let wideGridColumns = $derived(taskGridColumns("wide"));
@@ -241,10 +251,20 @@
     return null;
   }
 
+  function sortForColumnVisibility(
+    current: KataTaskSort,
+    visibility: KataTaskColumnVisibility,
+  ): KataTaskSort {
+    const activeSortColumn = optionalColumnForSort(current.key);
+    return activeSortColumn && !visibility[activeSortColumn]
+      ? { key: "title", direction: "asc" }
+      : current;
+  }
+
   function setColumnVisibility(next: KataTaskColumnVisibility): void {
-    const activeSortColumn = optionalColumnForSort(sort.key);
-    if (activeSortColumn && !next[activeSortColumn]) {
-      sort = { key: "title", direction: "asc" };
+    const nextSort = sortForColumnVisibility(sort, next);
+    if (nextSort !== sort) {
+      sort = nextSort;
       persistSort(sort);
     }
     columnVisibility = next;
@@ -758,6 +778,7 @@
   <div
     class="table"
     class:table--project-scoped={isProjectScoped}
+    class:table--keep-owner-sort={sort.key === "owner" && columnVisibility.owner}
     style:--table-cols-wide={wideGridColumns}
     style:--table-cols-medium={mediumGridColumns}
     style:--table-cols-compact={compactGridColumns}
@@ -1083,15 +1104,16 @@
     overflow: hidden;
     /* Shared grid template — header and rows live in the same scroll
        plane and inherit this template, so horizontal movement stays
-       aligned in split views. The ID column uses a fixed ch-based
-       width per scope so every row (and the header) start the title
-       at the same x; max-content was being re-evaluated per row,
-       which let different IDs leave different gaps. The two widths
-       are tight enough for short_ids at top level / qualified_ids in
-       a project to fit without truncation. The title takes the
+       aligned in split views. The ID column uses a fixed absolute
+       width per scope so the header and rows do not resolve `ch`
+       against their different font sizes. This keeps every title at
+       the same x; max-content also let different IDs leave different
+       gaps. The two widths are tight enough for qualified ids at the
+       top level / short ids in a project to fit without truncation.
+       The title takes the
        leftover via `1fr` so the metadata cluster anchors at the
        right edge with no whitespace pocket. */
-    --table-id-col: 13ch;         /* room for "Finances#rent" + badge padding */
+    --table-id-col: 112px;        /* room for "Finances#rent" + badge padding */
     --table-cols: var(--table-cols-wide);
     --table-gap: 14px;
     --table-min-width: 720px;
@@ -1103,7 +1125,7 @@
        around each id adds 7px of padding on both sides, so include
        14px here — otherwise a 6-char id clips against the badge
        background. */
-    --table-id-col: calc(6ch + 14px);
+    --table-id-col: 60px;
   }
 
   .table-header {
@@ -1457,8 +1479,8 @@
   }
 
   @container list (max-width: 680px) {
-    .col-owner,
-    .cell-owner {
+    .table:not(.table--keep-owner-sort) .col-owner,
+    .table:not(.table--keep-owner-sort) .cell-owner {
       display: none;
     }
 
@@ -1466,6 +1488,10 @@
       --table-cols: var(--table-cols-compact);
       --table-gap: 12px;
       --table-min-width: 460px;
+    }
+
+    .table.table--keep-owner-sort {
+      --table-min-width: 560px;
     }
 
     .header-actions :global(.action-label) {

--- a/frontend/src/lib/components/kata/KataIssueList.svelte
+++ b/frontend/src/lib/components/kata/KataIssueList.svelte
@@ -16,6 +16,15 @@
     type KataTaskSort,
     type KataTaskSortKey,
   } from "../../features/kata/taskSort.js";
+  import KataColumnPicker from "./KataColumnPicker.svelte";
+  import {
+    KATA_OPTIONAL_TASK_COLUMNS,
+    defaultKataTaskColumnVisibility,
+    loadKataTaskColumnVisibility,
+    persistKataTaskColumnVisibility,
+    type KataOptionalTaskColumn,
+    type KataTaskColumnVisibility,
+  } from "./kataTaskColumns.js";
 
   export interface KataIssueRevealRequest {
     uid: string;
@@ -57,6 +66,66 @@
 
   const SORT_STORAGE_KEY = "middleman:kata:issue-sort/v1";
   let sort: KataTaskSort = $state(loadSort());
+  let columnVisibility = $state(loadKataTaskColumnVisibility());
+
+  type TaskGridLayout = "wide" | "medium" | "compact" | "narrow";
+
+  const TASK_COLUMN_TRACKS: Record<
+    TaskGridLayout,
+    Record<KataOptionalTaskColumn, string | null>
+  > = {
+    wide: {
+      updated: "minmax(64px, 80px)",
+      priority: "minmax(68px, 80px)",
+      due: "minmax(56px, 70px)",
+      owner: "minmax(72px, 110px)",
+      tags: "minmax(96px, 200px)",
+    },
+    medium: {
+      updated: "minmax(64px, 80px)",
+      priority: "minmax(68px, 80px)",
+      due: "minmax(56px, 70px)",
+      owner: "minmax(72px, 110px)",
+      tags: null,
+    },
+    compact: {
+      updated: "minmax(60px, 76px)",
+      priority: "minmax(64px, 78px)",
+      due: "minmax(54px, 68px)",
+      owner: null,
+      tags: null,
+    },
+    narrow: {
+      updated: "minmax(58px, 72px)",
+      priority: "minmax(62px, 74px)",
+      due: null,
+      owner: null,
+      tags: null,
+    },
+  };
+
+  const TASK_TITLE_TRACKS: Record<TaskGridLayout, string> = {
+    wide: "minmax(220px, 1fr)",
+    medium: "minmax(220px, 1fr)",
+    compact: "minmax(180px, 1fr)",
+    narrow: "minmax(140px, 1fr)",
+  };
+
+  function taskGridColumns(layout: TaskGridLayout): string {
+    return [
+      "var(--table-id-col)",
+      TASK_TITLE_TRACKS[layout],
+      ...KATA_OPTIONAL_TASK_COLUMNS.flatMap((column) => {
+        const track = TASK_COLUMN_TRACKS[layout][column.id];
+        return columnVisibility[column.id] && track ? [track] : [];
+      }),
+    ].join(" ");
+  }
+
+  let wideGridColumns = $derived(taskGridColumns("wide"));
+  let mediumGridColumns = $derived(taskGridColumns("medium"));
+  let compactGridColumns = $derived(taskGridColumns("compact"));
+  let narrowGridColumns = $derived(taskGridColumns("narrow"));
 
   let expanded: Record<string, boolean> = $state({});
   let childrenByUID: Record<string, KataTaskSummary[]> = $state({});
@@ -165,6 +234,25 @@
   function handleSortClick(key: KataTaskSortKey) {
     sort = toggleKataTaskSort(sort, key);
     persistSort(sort);
+  }
+
+  function optionalColumnForSort(key: KataTaskSortKey): KataOptionalTaskColumn | null {
+    if (key === "updated" || key === "priority" || key === "owner") return key;
+    return null;
+  }
+
+  function setColumnVisibility(next: KataTaskColumnVisibility): void {
+    const activeSortColumn = optionalColumnForSort(sort.key);
+    if (activeSortColumn && !next[activeSortColumn]) {
+      sort = { key: "title", direction: "asc" };
+      persistSort(sort);
+    }
+    columnVisibility = next;
+    persistKataTaskColumnVisibility(next);
+  }
+
+  function showAllColumns(): void {
+    setColumnVisibility(defaultKataTaskColumnVisibility());
   }
 
   function viewTitle(view: KataCurrentView): string {
@@ -627,36 +715,54 @@
         <h2>{viewTitle(currentView)}</h2>
         <span class="count">{totalFilteredIssues()} {totalFilteredIssues() === 1 ? "task" : "tasks"}</span>
       </div>
-      {#if hasExpandableVisibleRows || hasAnyExpandedRows || bulkExpanding}
-        <div class="tree-actions" aria-label="Task tree controls">
-          <button
-            class="tree-action"
-            type="button"
-            disabled={bulkExpanding || allKnownExpandableRowsExpanded}
-            aria-busy={bulkExpanding ? "true" : undefined}
-            onclick={() => void expandAllVisible()}
-          >
-            <ListChevronsUpDownIcon size={13} strokeWidth={2} />
-            <span>{bulkExpanding ? "Expanding" : "Expand all"}</span>
-          </button>
-          <button
-            class="tree-action"
-            type="button"
-            disabled={!hasAnyExpandedRows}
-            onclick={collapseAllVisible}
-          >
-            <ListChevronsDownUpIcon size={13} strokeWidth={2} />
-            <span>Collapse all</span>
-          </button>
-        </div>
-      {/if}
+      <div class="header-actions">
+        <KataColumnPicker
+          visibility={columnVisibility}
+          onchange={setColumnVisibility}
+          onShowAll={showAllColumns}
+        />
+        {#if hasExpandableVisibleRows || hasAnyExpandedRows || bulkExpanding}
+          <div class="tree-actions" aria-label="Task tree controls">
+            <button
+              class="tree-action"
+              type="button"
+              aria-label={bulkExpanding ? "Expanding tasks" : "Expand all tasks"}
+              title={bulkExpanding ? "Expanding tasks" : "Expand all tasks"}
+              disabled={bulkExpanding || allKnownExpandableRowsExpanded}
+              aria-busy={bulkExpanding ? "true" : undefined}
+              onclick={() => void expandAllVisible()}
+            >
+              <ListChevronsUpDownIcon size={13} strokeWidth={2} />
+              <span class="action-label">{bulkExpanding ? "Expanding" : "Expand all"}</span>
+            </button>
+            <button
+              class="tree-action"
+              type="button"
+              aria-label="Collapse all tasks"
+              title="Collapse all tasks"
+              disabled={!hasAnyExpandedRows}
+              onclick={collapseAllVisible}
+            >
+              <ListChevronsDownUpIcon size={13} strokeWidth={2} />
+              <span class="action-label">Collapse all</span>
+            </button>
+          </div>
+        {/if}
+      </div>
     </div>
     {#if loading}
       <span class="kit-sr-only" aria-live="polite">Loading snapshot</span>
     {/if}
   </div>
 
-  <div class="table" class:table--project-scoped={isProjectScoped}>
+  <div
+    class="table"
+    class:table--project-scoped={isProjectScoped}
+    style:--table-cols-wide={wideGridColumns}
+    style:--table-cols-medium={mediumGridColumns}
+    style:--table-cols-compact={compactGridColumns}
+    style:--table-cols-narrow={narrowGridColumns}
+  >
     <!-- The table-body is the keyboard-nav root: any row inside this
          container is reachable via ↓/↑ (j/k), Home/End (g/G), and
          ↔ to expand or collapse subtasks. -->
@@ -694,50 +800,56 @@
             <ChevronDownIcon size={11} strokeWidth={2} />
           {/if}
         </button>
-        <button
-          class="col col-updated"
-          type="button"
-          aria-label={sortLabel("updated", "Updated")}
-          aria-pressed={sortIndicator("updated") !== null}
-          onclick={() => handleSortClick("updated")}
-        >
-          <span>Updated</span>
-          {#if sortIndicator("updated") === "asc"}
-            <ChevronUpIcon size={11} strokeWidth={2} />
-          {:else if sortIndicator("updated") === "desc"}
-            <ChevronDownIcon size={11} strokeWidth={2} />
-          {/if}
-        </button>
-        <button
-          class="col col-priority"
-          type="button"
-          aria-label={sortLabel("priority", "Priority")}
-          aria-pressed={sortIndicator("priority") !== null}
-          onclick={() => handleSortClick("priority")}
-        >
-          <span>Priority</span>
-          {#if sortIndicator("priority") === "asc"}
-            <ChevronUpIcon size={11} strokeWidth={2} />
-          {:else if sortIndicator("priority") === "desc"}
-            <ChevronDownIcon size={11} strokeWidth={2} />
-          {/if}
-        </button>
-        <span class="col col-due col-static">Due</span>
-        <button
-          class="col col-owner"
-          type="button"
-          aria-label={sortLabel("owner", "Owner")}
-          aria-pressed={sortIndicator("owner") !== null}
-          onclick={() => handleSortClick("owner")}
-        >
-          <span>Owner</span>
-          {#if sortIndicator("owner") === "asc"}
-            <ChevronUpIcon size={11} strokeWidth={2} />
-          {:else if sortIndicator("owner") === "desc"}
-            <ChevronDownIcon size={11} strokeWidth={2} />
-          {/if}
-        </button>
-        <span class="col col-tags col-static">Tags</span>
+        {#if columnVisibility.updated}
+          <button
+            class="col col-updated"
+            type="button"
+            aria-label={sortLabel("updated", "Updated")}
+            aria-pressed={sortIndicator("updated") !== null}
+            onclick={() => handleSortClick("updated")}
+          >
+            <span>Updated</span>
+            {#if sortIndicator("updated") === "asc"}
+              <ChevronUpIcon size={11} strokeWidth={2} />
+            {:else if sortIndicator("updated") === "desc"}
+              <ChevronDownIcon size={11} strokeWidth={2} />
+            {/if}
+          </button>
+        {/if}
+        {#if columnVisibility.priority}
+          <button
+            class="col col-priority"
+            type="button"
+            aria-label={sortLabel("priority", "Priority")}
+            aria-pressed={sortIndicator("priority") !== null}
+            onclick={() => handleSortClick("priority")}
+          >
+            <span>Priority</span>
+            {#if sortIndicator("priority") === "asc"}
+              <ChevronUpIcon size={11} strokeWidth={2} />
+            {:else if sortIndicator("priority") === "desc"}
+              <ChevronDownIcon size={11} strokeWidth={2} />
+            {/if}
+          </button>
+        {/if}
+        {#if columnVisibility.due}<span class="col col-due col-static">Due</span>{/if}
+        {#if columnVisibility.owner}
+          <button
+            class="col col-owner"
+            type="button"
+            aria-label={sortLabel("owner", "Owner")}
+            aria-pressed={sortIndicator("owner") !== null}
+            onclick={() => handleSortClick("owner")}
+          >
+            <span>Owner</span>
+            {#if sortIndicator("owner") === "asc"}
+              <ChevronUpIcon size={11} strokeWidth={2} />
+            {:else if sortIndicator("owner") === "desc"}
+              <ChevronDownIcon size={11} strokeWidth={2} />
+            {/if}
+          </button>
+        {/if}
+        {#if columnVisibility.tags}<span class="col col-tags col-static">Tags</span>{/if}
       </div>
 
       {#if visibleRootIssues.length === 0}
@@ -809,21 +921,29 @@
         {/if}
         <span class="title-text" id={titleId}>{issue.title}</span>
       </span>
-      <span class="cell cell-updated" title={issue.updated_at}>
-        {relativeTime(issue.updated_at)}
-      </span>
-      <span class="cell cell-priority">
-        {#if priority}
-          <span class={`pri-pill priority-${issue.priority}`}>{priority}</span>
-        {/if}
-      </span>
-      <span class="cell cell-due" title={issue.metadata.deadline_on ?? ""}>
-        {#if issue.metadata.deadline_on}{shortDate(issue.metadata.deadline_on)}{/if}
-      </span>
-      <span class="cell cell-owner">{issue.owner ?? ""}</span>
-      <span class="cell cell-tags" title={labels}>
-        {#if labels}{labels}{/if}
-      </span>
+      {#if columnVisibility.updated}
+        <span class="cell cell-updated" title={issue.updated_at}>
+          {relativeTime(issue.updated_at)}
+        </span>
+      {/if}
+      {#if columnVisibility.priority}
+        <span class="cell cell-priority">
+          {#if priority}
+            <span class={`pri-pill priority-${issue.priority}`}>{priority}</span>
+          {/if}
+        </span>
+      {/if}
+      {#if columnVisibility.due}
+        <span class="cell cell-due" title={issue.metadata.deadline_on ?? ""}>
+          {#if issue.metadata.deadline_on}{shortDate(issue.metadata.deadline_on)}{/if}
+        </span>
+      {/if}
+      {#if columnVisibility.owner}<span class="cell cell-owner">{issue.owner ?? ""}</span>{/if}
+      {#if columnVisibility.tags}
+        <span class="cell cell-tags" title={labels}>
+          {#if labels}{labels}{/if}
+        </span>
+      {/if}
       <span class="kit-sr-only">
         <span>project: {issue.project_name}</span>
         {#if issue.metadata.deadline_on}<span> · Due {shortDate(issue.metadata.deadline_on)}</span>{/if}
@@ -899,6 +1019,14 @@
     min-width: 0;
   }
 
+  .header-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    flex-shrink: 0;
+    white-space: nowrap;
+  }
+
   .pane-header h2 {
     font-size: var(--font-size-xl);
     line-height: 1.1;
@@ -964,16 +1092,7 @@
        leftover via `1fr` so the metadata cluster anchors at the
        right edge with no whitespace pocket. */
     --table-id-col: 13ch;         /* room for "Finances#rent" + badge padding */
-    --table-cols:
-      var(--table-id-col)         /* id badge */
-      minmax(220px, 1fr)          /* title — absorbs leftover space */
-      minmax(64px, 80px)          /* updated */
-      minmax(68px, 80px)          /* priority — wide enough that the
-                                     uppercase header doesn't overflow
-                                     into UPDATED's sort chevron */
-      minmax(56px, 70px)          /* due */
-      minmax(72px, 110px)         /* owner */
-      minmax(96px, 200px);        /* tags */
+    --table-cols: var(--table-cols-wide);
     --table-gap: 14px;
     --table-min-width: 720px;
   }
@@ -1332,13 +1451,7 @@
     }
 
     .table {
-      --table-cols:
-        var(--table-id-col)
-        minmax(220px, 1fr)
-        minmax(64px, 80px)
-        minmax(68px, 80px)
-        minmax(56px, 70px)
-        minmax(72px, 110px);
+      --table-cols: var(--table-cols-medium);
       --table-min-width: 580px;
     }
   }
@@ -1350,14 +1463,13 @@
     }
 
     .table {
-      --table-cols:
-        var(--table-id-col)
-        minmax(180px, 1fr)
-        minmax(60px, 76px)
-        minmax(64px, 78px)
-        minmax(54px, 68px);
+      --table-cols: var(--table-cols-compact);
       --table-gap: 12px;
       --table-min-width: 460px;
+    }
+
+    .header-actions :global(.action-label) {
+      display: none;
     }
   }
 
@@ -1368,11 +1480,7 @@
     }
 
     .table {
-      --table-cols:
-        var(--table-id-col)
-        minmax(140px, 1fr)
-        minmax(58px, 72px)
-        minmax(62px, 74px);
+      --table-cols: var(--table-cols-narrow);
       --table-gap: 10px;
       --table-min-width: 320px;
     }

--- a/frontend/src/lib/components/kata/KataIssueList.test.ts
+++ b/frontend/src/lib/components/kata/KataIssueList.test.ts
@@ -204,7 +204,7 @@ describe("KataIssueList", () => {
     });
 
     await fireEvent.click(screen.getByRole("button", { name: "Columns" }));
-    for (const name of ["Priority", "Due", "Owner", "Tags"]) {
+    for (const name of ["Updated", "Priority", "Due", "Owner", "Tags"]) {
       await fireEvent.click(screen.getByRole("checkbox", { name }));
     }
     first.unmount();
@@ -219,7 +219,7 @@ describe("KataIssueList", () => {
     });
 
     const header = screen.getByRole("row");
-    expect(within(header).getByText("Updated")).toBeTruthy();
+    expect(within(header).queryByText("Updated")).toBeNull();
     expect(within(header).queryByText("Priority")).toBeNull();
     expect(within(header).queryByText("Due")).toBeNull();
     expect(within(header).queryByText("Owner")).toBeNull();
@@ -239,6 +239,29 @@ describe("KataIssueList", () => {
       "owner",
       "tags",
     ]);
+  });
+
+  it("reconciles a restored sort whose optional column is disabled", () => {
+    localStorage.setItem(KATA_TASK_COLUMNS_STORAGE_KEY, JSON.stringify(["updated", "priority", "due", "tags"]));
+    localStorage.setItem("middleman:kata:issue-sort/v1", JSON.stringify({ key: "owner", direction: "desc" }));
+
+    render(KataIssueList, {
+      props: {
+        currentView,
+        selectedIssueUID: null,
+        loading: false,
+        onSelect: () => {},
+      },
+    });
+
+    expect(screen.queryByRole("button", { name: /Sort by Owner/ })).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Sort by Title, currently ascending" }).getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(JSON.parse(localStorage.getItem("middleman:kata:issue-sort/v1")!)).toEqual({
+      key: "title",
+      direction: "asc",
+    });
   });
 
   it("keeps column toggles usable when localStorage writes fail", async () => {

--- a/frontend/src/lib/components/kata/KataIssueList.test.ts
+++ b/frontend/src/lib/components/kata/KataIssueList.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import type { KataTaskAPI, KataTaskDetail, KataTaskSummary } from "../../api/kata/taskTypes.js";
 import type { KataCurrentView } from "../../stores/kata-workspace.svelte.js";
 import KataIssueList from "./KataIssueList.svelte";
+import { KATA_TASK_COLUMNS_STORAGE_KEY } from "./kataTaskColumns.js";
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -157,6 +158,151 @@ describe("KataIssueList", () => {
 
     const labels = Array.from(tableHeader?.querySelectorAll(".col") ?? []).map((el) => el.textContent?.trim());
     expect(labels.slice(0, 3)).toEqual(["ID", "Title", "Updated"]);
+  });
+
+  it("hides an optional column while keeping ID and Title visible", async () => {
+    const { container } = render(KataIssueList, {
+      props: {
+        currentView,
+        selectedIssueUID: null,
+        loading: false,
+        onSelect: () => {},
+      },
+    });
+
+    const header = screen.getByRole("row");
+    const row = screen.getByText("Pay rent").closest("button");
+    const table = container.querySelector<HTMLElement>(".table");
+    expect(row).not.toBeNull();
+    expect(table).not.toBeNull();
+    expect(table!.style.getPropertyValue("--table-cols-wide")).toContain("minmax(96px, 200px)");
+
+    await fireEvent.click(screen.getByRole("button", { name: "Columns" }));
+    await fireEvent.click(screen.getByRole("checkbox", { name: "Tags" }));
+
+    expect(within(header).getByText("ID")).toBeTruthy();
+    expect(within(header).getByText("Title")).toBeTruthy();
+    expect(within(header).queryByText("Tags")).toBeNull();
+    expect(within(row!).queryByText("home · monthly")).toBeNull();
+    expect(table!.style.getPropertyValue("--table-cols-wide")).not.toContain("minmax(96px, 200px)");
+    expect(JSON.parse(localStorage.getItem(KATA_TASK_COLUMNS_STORAGE_KEY)!)).toEqual([
+      "updated",
+      "priority",
+      "due",
+      "owner",
+    ]);
+  });
+
+  it("restores hidden columns after remount and Show all resets the preference", async () => {
+    const first = render(KataIssueList, {
+      props: {
+        currentView,
+        selectedIssueUID: null,
+        loading: false,
+        onSelect: () => {},
+      },
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Columns" }));
+    for (const name of ["Priority", "Due", "Owner", "Tags"]) {
+      await fireEvent.click(screen.getByRole("checkbox", { name }));
+    }
+    first.unmount();
+
+    render(KataIssueList, {
+      props: {
+        currentView,
+        selectedIssueUID: null,
+        loading: false,
+        onSelect: () => {},
+      },
+    });
+
+    const header = screen.getByRole("row");
+    expect(within(header).getByText("Updated")).toBeTruthy();
+    expect(within(header).queryByText("Priority")).toBeNull();
+    expect(within(header).queryByText("Due")).toBeNull();
+    expect(within(header).queryByText("Owner")).toBeNull();
+    expect(within(header).queryByText("Tags")).toBeNull();
+
+    await fireEvent.click(screen.getByRole("button", { name: "Columns" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Show all" }));
+
+    expect(within(header).getByText("Priority")).toBeTruthy();
+    expect(within(header).getByText("Due")).toBeTruthy();
+    expect(within(header).getByText("Owner")).toBeTruthy();
+    expect(within(header).getByText("Tags")).toBeTruthy();
+    expect(JSON.parse(localStorage.getItem(KATA_TASK_COLUMNS_STORAGE_KEY)!)).toEqual([
+      "updated",
+      "priority",
+      "due",
+      "owner",
+      "tags",
+    ]);
+  });
+
+  it("keeps column toggles usable when localStorage writes fail", async () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("quota");
+    });
+    render(KataIssueList, {
+      props: {
+        currentView,
+        selectedIssueUID: null,
+        loading: false,
+        onSelect: () => {},
+      },
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Columns" }));
+    await fireEvent.click(screen.getByRole("checkbox", { name: "Owner" }));
+
+    expect(within(screen.getByRole("row")).queryByText("Owner")).toBeNull();
+  });
+
+  it("falls back to all columns for malformed saved data", () => {
+    localStorage.setItem(KATA_TASK_COLUMNS_STORAGE_KEY, JSON.stringify({ visible: ["updated"] }));
+    render(KataIssueList, {
+      props: {
+        currentView,
+        selectedIssueUID: null,
+        loading: false,
+        onSelect: () => {},
+      },
+    });
+
+    const header = screen.getByRole("row");
+    for (const name of ["Updated", "Priority", "Due", "Owner", "Tags"]) {
+      expect(within(header).getByText(name)).toBeTruthy();
+    }
+  });
+
+  it("resets an invisible active sort to Title ascending", async () => {
+    render(KataIssueList, {
+      props: {
+        currentView,
+        selectedIssueUID: null,
+        loading: false,
+        onSelect: () => {},
+      },
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Sort by Priority" }));
+    expect(
+      screen.getByRole("button", { name: "Sort by Priority, currently ascending" }).getAttribute("aria-pressed"),
+    ).toBe("true");
+
+    await fireEvent.click(screen.getByRole("button", { name: "Columns" }));
+    await fireEvent.click(screen.getByRole("checkbox", { name: "Priority" }));
+
+    expect(screen.queryByRole("button", { name: /Sort by Priority/ })).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Sort by Title, currently ascending" }).getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(JSON.parse(localStorage.getItem("middleman:kata:issue-sort/v1")!)).toEqual({
+      key: "title",
+      direction: "asc",
+    });
   });
 
   it("defaults flat lists to recently updated first", () => {
@@ -448,8 +594,8 @@ describe("KataIssueList", () => {
       },
     });
 
-    const expandAll = screen.getByRole("button", { name: "Expand all" });
-    const collapseAll = screen.getByRole("button", { name: "Collapse all" });
+    const expandAll = screen.getByRole("button", { name: "Expand all tasks" });
+    const collapseAll = screen.getByRole("button", { name: "Collapse all tasks" });
     expect(collapseAll.hasAttribute("disabled")).toBe(true);
 
     await fireEvent.click(expandAll);
@@ -823,7 +969,7 @@ describe("KataIssueList", () => {
     expect(screen.getAllByRole("button", { name: /Restored child/ })).toHaveLength(1);
     expect(api.issue).toHaveBeenCalledWith(root.uid);
 
-    await fireEvent.click(screen.getByRole("button", { name: "Expand all" }));
+    await fireEvent.click(screen.getByRole("button", { name: "Expand all tasks" }));
 
     expect(await screen.findByRole("button", { name: /Sibling grandchild/ })).toBeTruthy();
     expect(await screen.findByRole("button", { name: /Restored grandchild/ })).toBeTruthy();

--- a/frontend/src/lib/components/kata/KataLinkFilterMenu.svelte
+++ b/frontend/src/lib/components/kata/KataLinkFilterMenu.svelte
@@ -1,0 +1,182 @@
+<script lang="ts">
+  import { autoReposition, Checkbox, dismissable, floatingPopoverStyle } from "@kenn-io/kit-ui";
+  import FunnelIcon from "@lucide/svelte/icons/funnel";
+  import { tick } from "svelte";
+  import {
+    KATA_LINK_RELATIONS,
+    type KataLinkFilters,
+    type KataLinkRelation,
+  } from "../../features/kata/kataLinkFilters.js";
+
+  interface Props {
+    filters: KataLinkFilters;
+    onChange: (next: KataLinkFilters) => void;
+  }
+
+  let { filters, onChange }: Props = $props();
+  let open = $state(false);
+  let trigger = $state<HTMLButtonElement>();
+  let panel = $state<HTMLDivElement>();
+  let panelStyle = $state("");
+
+  const relationLabels: Record<KataLinkRelation, string> = {
+    parent: "Parent",
+    child: "Child",
+    blocks: "Blocks",
+    blocked_by: "Blocked by",
+    related: "Related",
+  };
+
+  $effect(() => {
+    if (!open) return;
+    const cleanups = [
+      dismissable({
+        owners: () => [panel, trigger],
+        dismiss: close,
+        escapeFocus: () => trigger,
+      }),
+      autoReposition(() => panel, position),
+    ];
+    return () => cleanups.forEach((cleanup) => cleanup());
+  });
+
+  function position(): void {
+    if (!trigger || !panel) return;
+    panelStyle = floatingPopoverStyle({
+      trigger: trigger.getBoundingClientRect(),
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+      popoverWidth: panel.offsetWidth,
+      popoverHeight: panel.offsetHeight,
+      align: "end",
+    });
+  }
+
+  function close(): void {
+    open = false;
+  }
+
+  async function toggle(): Promise<void> {
+    open = !open;
+    if (!open) return;
+    await tick();
+    position();
+  }
+
+  function changeStatus(status: "open" | "closed", checked: boolean): void {
+    onChange({ ...filters, statuses: { ...filters.statuses, [status]: checked } });
+  }
+
+  function changeRelation(relation: KataLinkRelation, checked: boolean): void {
+    onChange({ ...filters, relations: { ...filters.relations, [relation]: checked } });
+  }
+</script>
+
+<div class="link-filter-menu">
+  <button
+    bind:this={trigger}
+    type="button"
+    class="link-filter-trigger"
+    aria-label="Filter links"
+    aria-expanded={open}
+    onclick={toggle}
+  >
+    <FunnelIcon size={12} strokeWidth={2} aria-hidden="true" />
+    <span>Filters</span>
+  </button>
+
+  {#if open}
+    <div
+      bind:this={panel}
+      class="link-filter-panel kit-popover-card"
+      style={panelStyle}
+      role="group"
+      aria-label="Link filters"
+    >
+      <fieldset>
+        <legend>Task state</legend>
+        <Checkbox
+          label="Open"
+          checked={filters.statuses.open}
+          onchange={(checked) => changeStatus("open", checked)}
+        />
+        <Checkbox
+          label="Closed"
+          checked={filters.statuses.closed}
+          onchange={(checked) => changeStatus("closed", checked)}
+        />
+      </fieldset>
+      <fieldset>
+        <legend>Relationship</legend>
+        {#each KATA_LINK_RELATIONS as relation (relation)}
+          <Checkbox
+            label={relationLabels[relation]}
+            checked={filters.relations[relation]}
+            onchange={(checked) => changeRelation(relation, checked)}
+          />
+        {/each}
+      </fieldset>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .link-filter-menu {
+    position: relative;
+  }
+
+  .link-filter-trigger {
+    min-height: 26px;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    background: var(--bg-surface);
+    color: var(--text-muted);
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: 3px 8px;
+    font: inherit;
+    font-size: var(--font-size-xs);
+    cursor: pointer;
+  }
+
+  .link-filter-trigger:hover,
+  .link-filter-trigger[aria-expanded="true"] {
+    border-color: var(--accent-blue);
+    color: var(--text-primary);
+  }
+
+  .link-filter-trigger:focus-visible {
+    outline: var(--focus-ring);
+    outline-offset: 2px;
+  }
+
+  .link-filter-panel {
+    position: fixed;
+    z-index: var(--z-popover);
+    width: 220px;
+    max-width: calc(100vw - 16px);
+    max-height: calc(100vh - 16px);
+    overflow-y: auto;
+    padding: 10px;
+    display: grid;
+    gap: var(--space-4);
+  }
+
+  fieldset {
+    min-width: 0;
+    border: 0;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: var(--space-3);
+  }
+
+  legend {
+    margin: 0 0 3px;
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    font-weight: 650;
+    text-transform: uppercase;
+  }
+</style>

--- a/frontend/src/lib/components/kata/KataLinkFilterMenu.svelte
+++ b/frontend/src/lib/components/kata/KataLinkFilterMenu.svelte
@@ -61,6 +61,8 @@
     if (!open) return;
     await tick();
     position();
+    await tick();
+    position();
   }
 
   function changeStatus(status: "open" | "closed", checked: boolean): void {

--- a/frontend/src/lib/components/kata/KataLinkFilterMenu.test.ts
+++ b/frontend/src/lib/components/kata/KataLinkFilterMenu.test.ts
@@ -1,0 +1,40 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { createKataLinkFilters } from "../../features/kata/kataLinkFilters.js";
+import KataLinkFilterMenu from "./KataLinkFilterMenu.svelte";
+
+describe("KataLinkFilterMenu", () => {
+  afterEach(cleanup);
+
+  it("emits independent task-state and relationship changes", async () => {
+    const filters = createKataLinkFilters("open");
+    const onChange = vi.fn();
+    render(KataLinkFilterMenu, { props: { filters, onChange } });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Filter links" }));
+    await fireEvent.click(screen.getByRole("checkbox", { name: "Closed" }));
+    expect(onChange).toHaveBeenLastCalledWith({
+      ...filters,
+      statuses: { open: true, closed: true },
+    });
+
+    await fireEvent.click(screen.getByRole("checkbox", { name: "Blocked by" }));
+    expect(onChange).toHaveBeenLastCalledWith({
+      ...filters,
+      relations: { ...filters.relations, blocked_by: false },
+    });
+  });
+
+  it("closes on Escape and returns focus to the trigger", async () => {
+    render(KataLinkFilterMenu, {
+      props: { filters: createKataLinkFilters("all"), onChange: vi.fn() },
+    });
+
+    const trigger = screen.getByRole("button", { name: "Filter links" });
+    await fireEvent.click(trigger);
+    await fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(screen.queryByRole("group", { name: "Link filters" })).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+  });
+});

--- a/frontend/src/lib/components/kata/kataTaskColumns.test.ts
+++ b/frontend/src/lib/components/kata/kataTaskColumns.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import {
+  KATA_OPTIONAL_TASK_COLUMNS,
+  KATA_TASK_COLUMNS_STORAGE_KEY,
+  defaultKataTaskColumnVisibility,
+  loadKataTaskColumnVisibility,
+  persistKataTaskColumnVisibility,
+} from "./kataTaskColumns.js";
+
+describe("Kata task column visibility", () => {
+  it("defaults every optional column to visible", () => {
+    expect(defaultKataTaskColumnVisibility()).toEqual({
+      updated: true,
+      priority: true,
+      due: true,
+      owner: true,
+      tags: true,
+    });
+  });
+
+  it("restores known columns and ignores duplicate or unknown keys", () => {
+    const storage = {
+      getItem: vi.fn(() => JSON.stringify(["tags", "future-column", "updated", "tags"])),
+      setItem: vi.fn(),
+    };
+
+    expect(loadKataTaskColumnVisibility(storage)).toEqual({
+      updated: true,
+      priority: false,
+      due: false,
+      owner: false,
+      tags: true,
+    });
+  });
+
+  it.each(["not-json", JSON.stringify({ visible: ["updated"] }), JSON.stringify(["updated", 3])])(
+    "falls back for malformed storage: %s",
+    (raw) => {
+      const storage = { getItem: vi.fn(() => raw), setItem: vi.fn() };
+      expect(loadKataTaskColumnVisibility(storage)).toEqual(defaultKataTaskColumnVisibility());
+    },
+  );
+
+  it("falls back when storage reads throw", () => {
+    const storage = {
+      getItem: vi.fn(() => {
+        throw new Error("blocked");
+      }),
+      setItem: vi.fn(),
+    };
+
+    expect(loadKataTaskColumnVisibility(storage)).toEqual(defaultKataTaskColumnVisibility());
+  });
+
+  it("persists visible keys and tolerates write failures", () => {
+    const setItem = vi.fn();
+    persistKataTaskColumnVisibility(
+      { updated: true, priority: false, due: true, owner: false, tags: false },
+      { getItem: vi.fn(), setItem },
+    );
+    expect(setItem).toHaveBeenCalledWith(KATA_TASK_COLUMNS_STORAGE_KEY, JSON.stringify(["updated", "due"]));
+
+    expect(() =>
+      persistKataTaskColumnVisibility(defaultKataTaskColumnVisibility(), {
+        getItem: vi.fn(),
+        setItem: vi.fn(() => {
+          throw new Error("quota");
+        }),
+      }),
+    ).not.toThrow();
+    expect(KATA_OPTIONAL_TASK_COLUMNS.map((column) => column.id)).toEqual([
+      "updated",
+      "priority",
+      "due",
+      "owner",
+      "tags",
+    ]);
+  });
+});

--- a/frontend/src/lib/components/kata/kataTaskColumns.ts
+++ b/frontend/src/lib/components/kata/kataTaskColumns.ts
@@ -1,0 +1,62 @@
+export const KATA_TASK_COLUMNS_STORAGE_KEY = "middleman:kata:issue-columns/v1";
+
+export const KATA_OPTIONAL_TASK_COLUMNS = [
+  { id: "updated", label: "Updated" },
+  { id: "priority", label: "Priority" },
+  { id: "due", label: "Due" },
+  { id: "owner", label: "Owner" },
+  { id: "tags", label: "Tags" },
+] as const;
+
+export type KataOptionalTaskColumn = (typeof KATA_OPTIONAL_TASK_COLUMNS)[number]["id"];
+export type KataTaskColumnVisibility = Record<KataOptionalTaskColumn, boolean>;
+
+type ColumnStorage = Pick<Storage, "getItem" | "setItem">;
+
+const knownColumns = new Set<string>(KATA_OPTIONAL_TASK_COLUMNS.map((column) => column.id));
+
+export function defaultKataTaskColumnVisibility(): KataTaskColumnVisibility {
+  return { updated: true, priority: true, due: true, owner: true, tags: true };
+}
+
+function browserStorage(): ColumnStorage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function loadKataTaskColumnVisibility(
+  storage: ColumnStorage | null = browserStorage(),
+): KataTaskColumnVisibility {
+  if (!storage) return defaultKataTaskColumnVisibility();
+  try {
+    const raw = storage.getItem(KATA_TASK_COLUMNS_STORAGE_KEY);
+    if (raw === null) return defaultKataTaskColumnVisibility();
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed) || !parsed.every((value) => typeof value === "string")) {
+      return defaultKataTaskColumnVisibility();
+    }
+    const visible = new Set(parsed.filter((value) => knownColumns.has(value)));
+    return Object.fromEntries(
+      KATA_OPTIONAL_TASK_COLUMNS.map((column) => [column.id, visible.has(column.id)]),
+    ) as KataTaskColumnVisibility;
+  } catch {
+    return defaultKataTaskColumnVisibility();
+  }
+}
+
+export function persistKataTaskColumnVisibility(
+  visibility: KataTaskColumnVisibility,
+  storage: ColumnStorage | null = browserStorage(),
+): void {
+  if (!storage) return;
+  try {
+    const visible = KATA_OPTIONAL_TASK_COLUMNS.filter((column) => visibility[column.id]).map((column) => column.id);
+    storage.setItem(KATA_TASK_COLUMNS_STORAGE_KEY, JSON.stringify(visible));
+  } catch {
+    // Browser storage is best-effort. Keep the in-memory preference usable.
+  }
+}

--- a/frontend/src/lib/components/terminal/KataWorkspaceSidebarPane.svelte
+++ b/frontend/src/lib/components/terminal/KataWorkspaceSidebarPane.svelte
@@ -14,6 +14,7 @@
   import { computeRemoveMessageLinkPatch, readMessageLinks } from "../../messages/messageLinks.js";
   import type { MessageLinkRef } from "../../messages/types";
   import KataRecurrenceDialogs from "../../features/kata/KataRecurrenceDialogs.svelte";
+  import { createKataLinkFilters, type KataLinkFilters } from "../../features/kata/kataLinkFilters.js";
   import { createKataWorkspaceStore } from "../../stores/kata-workspace.svelte.js";
 
   interface Props {
@@ -30,6 +31,7 @@
   let loading = $state(true);
   let loadError = $state<string | null>(null);
   let checklistRevealed = $state(false);
+  let linkFilters = $state<KataLinkFilters>(createKataLinkFilters("all"));
   let pendingMoveIssueUIDs = $state.raw<ReadonlySet<string>>(new Set());
   let unlinkBusyIds = $state<ReadonlySet<number>>(new Set());
   let loadRequestID = 0;
@@ -48,6 +50,7 @@
     loading = true;
     loadError = null;
     checklistRevealed = false;
+    linkFilters = createKataLinkFilters("all");
     void store
       .bootstrap("all", issueUID, { selectFirst: false })
       .catch((err) => {
@@ -228,6 +231,10 @@
       currentView={store.currentView}
       api={store.api}
       activeDaemonId={kata.daemon_id}
+      {linkFilters}
+      onLinkFiltersChange={(next) => {
+        linkFilters = next;
+      }}
       projects={store.projects}
       ownerOptions={ownerOptions()}
       messageLinks={selectedMessageLinks()}

--- a/frontend/src/lib/components/terminal/KataWorkspaceSidebarPane.test.ts
+++ b/frontend/src/lib/components/terminal/KataWorkspaceSidebarPane.test.ts
@@ -107,6 +107,7 @@ describe("KataWorkspaceSidebarPane", () => {
     render(KataWorkspaceSidebarPane, { props: { kata } });
 
     await screen.findByRole("heading", { name: "Ship the thing" });
+    expect(screen.getByRole("button", { name: "Filter links" })).toBeTruthy();
     await fireEvent.click(screen.getByRole("button", { name: "More actions" }));
     await fireEvent.click(screen.getByRole("menuitem", { name: "Move to another project" }));
     await fireEvent.click(screen.getByRole("button", { name: /Roadmap/ }));

--- a/frontend/src/lib/features/kata/KataWorkspace.svelte
+++ b/frontend/src/lib/features/kata/KataWorkspace.svelte
@@ -55,6 +55,11 @@
   import KataRecurrenceDialogs from "./KataRecurrenceDialogs.svelte";
   import KataSearchPanel from "./KataSearchPanel.svelte";
   import { createKataEventStreamController } from "./kataEventStreamController.js";
+  import {
+    applyKataLinkStatusScope,
+    createKataLinkFilters,
+    type KataLinkFilters,
+  } from "./kataLinkFilters.js";
   import type { KataGraphLayoutDirection } from "./kataReachableGraph.js";
 
   interface Props {
@@ -160,6 +165,11 @@
   let unknownRoutedBootstrapPending = $state(false);
   let listMode = $state<ListMode>("tasks");
   let graphSourceIssue = $state.raw<KataTaskSummary | null>(null);
+  let linkFilters = $state<KataLinkFilters>(createKataLinkFilters("open"));
+  let lastLinkFilterScope: {
+    daemonID: string | undefined;
+    status: KataTaskSearchFilters["status"];
+  } = { daemonID: undefined, status: "open" };
   const store = createKataWorkspaceStore({ api: untrack(() => api) });
   const actor = "middleman";
   // Route synchronization is level-triggered: the URL is the source of
@@ -244,6 +254,16 @@
   const listStatusFilter = $derived<KataTaskSearchFilters["status"]>(
     store.currentView.name === "logbook" ? "all" : store.searchFilters.status,
   );
+  $effect(() => {
+    const daemonID = activeKataDaemonId;
+    const status = listStatusFilter;
+    if (daemonID !== lastLinkFilterScope.daemonID) {
+      linkFilters = createKataLinkFilters(status);
+    } else if (status !== lastLinkFilterScope.status) {
+      linkFilters = applyKataLinkStatusScope(untrack(() => linkFilters), status);
+    }
+    lastLinkFilterScope = { daemonID, status };
+  });
   const eventStream = createKataEventStreamController({
     getDaemonId: () => requestKataDaemonId,
     getLastEventID: () => store.eventCursor,
@@ -2727,6 +2747,10 @@
       currentView={store.currentView}
       api={store.api}
       activeDaemonId={activeKataDaemonId}
+      {linkFilters}
+      onLinkFiltersChange={(next) => {
+        linkFilters = next;
+      }}
       projects={store.projects}
       ownerOptions={ownerOptions()}
       messageLinks={selectedMessageLinks()}

--- a/frontend/src/lib/features/kata/KataWorkspace.test.ts
+++ b/frontend/src/lib/features/kata/KataWorkspace.test.ts
@@ -4695,4 +4695,121 @@ describe("KataWorkspace", () => {
     await waitFor(() => expect(screen.queryByText("Lease renewal")).toBeNull());
     expect(loadKataWorkspaceState("home")).toEqual(persisted);
   });
+
+  it("keeps relationship filters across task navigation and resets state filters with the workspace scope", async () => {
+    const root = issue("issue-root", "Root task", "project-kata");
+    const next = issue("issue-next", "Next task", "project-kata");
+    const related = issue("issue-related", "Related task", "project-kata");
+    const blocked = issue("issue-blocked", "Blocked task", "project-kata");
+    const closed = {
+      ...issue("issue-closed", "Closed task", "project-kata"),
+      status: "closed" as const,
+      closed_reason: "done" as const,
+      closed_at: fetchedAt,
+    };
+    const rows = [root, next, related, blocked, closed];
+    const links: KataTaskLink[] = [
+      {
+        id: 1,
+        project_id: root.project_id,
+        from: { uid: root.uid, short_id: root.short_id },
+        to: { uid: related.uid, short_id: related.short_id },
+        type: "related",
+        author: "fixture-user",
+        created_at: fetchedAt,
+      },
+      {
+        id: 2,
+        project_id: root.project_id,
+        from: { uid: root.uid, short_id: root.short_id },
+        to: { uid: blocked.uid, short_id: blocked.short_id },
+        type: "blocks",
+        author: "fixture-user",
+        created_at: fetchedAt,
+      },
+    ];
+    const { api } = createWorkspaceAPI(rows);
+    vi.mocked(api.issue).mockImplementation(async (uid: string) => {
+      const taskDetail = detail(uid, rows);
+      return uid === root.uid ? { ...taskDetail, links } : taskDetail;
+    });
+
+    render(KataWorkspaceRouteHost, { props: { api, initialIssue: root.uid } });
+
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Root task" })).toBeTruthy());
+    await fireEvent.click(screen.getByRole("button", { name: "Filter links" }));
+    await fireEvent.click(screen.getByRole("checkbox", { name: "Related" }));
+
+    const issues = screen.getByRole("main", { name: "Issues" });
+    await fireEvent.click(within(issues).getByRole("button", { name: /Next task/ }));
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Next task" })).toBeTruthy());
+    await fireEvent.click(within(issues).getByRole("button", { name: /Root task/ }));
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Root task" })).toBeTruthy());
+
+    await fireEvent.click(screen.getByRole("button", { name: "Filter links" }));
+    expect((screen.getByRole("checkbox", { name: "Related" }) as HTMLInputElement).checked).toBe(false);
+    await fireEvent.keyDown(document, { key: "Escape" });
+
+    await fireEvent.click(screen.getByRole("combobox", { name: "Status: Open" }));
+    await fireEvent.click(screen.getByRole("option", { name: "All" }));
+    await waitFor(() => expect(screen.getByRole("combobox", { name: "Status: All" })).toBeTruthy());
+    expect(screen.getByRole("heading", { name: "Root task" })).toBeTruthy();
+
+    await fireEvent.click(screen.getByRole("button", { name: "Filter links" }));
+    expect((screen.getByRole("checkbox", { name: "Open" }) as HTMLInputElement).checked).toBe(true);
+    expect((screen.getByRole("checkbox", { name: "Closed" }) as HTMLInputElement).checked).toBe(true);
+    expect((screen.getByRole("checkbox", { name: "Related" }) as HTMLInputElement).checked).toBe(false);
+  });
+
+  it("resets the complete link-filter scope when switching daemons", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({
+        daemons: [
+          { id: "home", url: "http://127.0.0.1:7777", default: true, auth: "none", health: "connected" },
+          { id: "work", url: "http://127.0.0.1:8888", default: false, auth: "none", health: "connected" },
+        ],
+      }),
+    );
+    setActiveKataDaemon("home");
+    const homeRoot = issue("issue-home-root", "Home root", "project-kata");
+    const homePeer = issue("issue-home-peer", "Home peer", "project-kata");
+    const workRoot = issue("issue-work-root", "Work root", "project-kata");
+    const api = createDaemonWorkspaceAPI({ home: [homeRoot, homePeer], work: [workRoot] });
+    vi.mocked(api.issue).mockImplementation(async (uid: string) => {
+      const rows = [homeRoot, homePeer, workRoot];
+      const taskDetail = detail(uid, rows);
+      if (uid !== homeRoot.uid) return taskDetail;
+      return {
+        ...taskDetail,
+        links: [
+          {
+            id: 1,
+            project_id: homeRoot.project_id,
+            from: { uid: homeRoot.uid, short_id: homeRoot.short_id },
+            to: { uid: homePeer.uid, short_id: homePeer.short_id },
+            type: "related",
+            author: "fixture-user",
+            created_at: fetchedAt,
+          },
+        ],
+      };
+    });
+
+    render(KataWorkspaceRouteHost, { props: { api, initialIssue: homeRoot.uid } });
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Home root" })).toBeTruthy());
+    await fireEvent.click(screen.getByRole("button", { name: "Filter links" }));
+    await fireEvent.click(screen.getByRole("checkbox", { name: "Related" }));
+    await fireEvent.keyDown(document, { key: "Escape" });
+
+    await fireEvent.click(screen.getByTestId("daemon-chip"));
+    const workDaemonRow = await screen.findByTestId("daemon-row-work");
+    await waitFor(() => expect((workDaemonRow as HTMLButtonElement).disabled).toBe(false));
+    await fireEvent.click(workDaemonRow);
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Work root" })).toBeTruthy());
+
+    await fireEvent.click(screen.getByRole("button", { name: "Filter links" }));
+    expect((screen.getByRole("checkbox", { name: "Open" }) as HTMLInputElement).checked).toBe(true);
+    expect((screen.getByRole("checkbox", { name: "Closed" }) as HTMLInputElement).checked).toBe(false);
+    expect((screen.getByRole("checkbox", { name: "Related" }) as HTMLInputElement).checked).toBe(true);
+  });
 });

--- a/frontend/src/lib/features/kata/kataLinkFilters.test.ts
+++ b/frontend/src/lib/features/kata/kataLinkFilters.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vite-plus/test";
+import type { KataTaskLink, KataTaskSummary } from "../../api/kata/taskTypes.js";
+import {
+  applyKataLinkStatusScope,
+  createKataLinkFilters,
+  kataLinkCouldAffectVisibleResults,
+  kataLinkMatchesFilters,
+  relationForKataLink,
+} from "./kataLinkFilters.js";
+
+const selectedUID = "issue-selected";
+
+function link(overrides: Partial<KataTaskLink> = {}): KataTaskLink {
+  return {
+    id: 1,
+    project_id: 1,
+    from: { uid: selectedUID, short_id: "selected" },
+    to: { uid: "issue-peer", short_id: "peer" },
+    type: "related",
+    author: "maintainer",
+    created_at: "2026-07-22T12:00:00Z",
+    ...overrides,
+  };
+}
+
+function peer(status: KataTaskSummary["status"]): KataTaskSummary {
+  return {
+    id: 2,
+    uid: "issue-peer",
+    project_id: 1,
+    project_uid: "project-1",
+    project_name: "Inbox",
+    short_id: "peer",
+    qualified_id: "Inbox#peer",
+    title: "Peer task",
+    status,
+    metadata: {},
+    revision: 1,
+    author: "maintainer",
+    created_at: "2026-07-22T12:00:00Z",
+    updated_at: "2026-07-22T12:00:00Z",
+  };
+}
+
+describe("kata link filters", () => {
+  it.each([
+    ["open", { open: true, closed: false }],
+    ["closed", { open: false, closed: true }],
+    ["all", { open: true, closed: true }],
+  ] as const)("defaults task states from the %s scope", (scope, statuses) => {
+    expect(createKataLinkFilters(scope).statuses).toEqual(statuses);
+  });
+
+  it("classifies relationship direction from the selected task", () => {
+    expect(relationForKataLink(link({ type: "parent" }), selectedUID)).toBe("child");
+    expect(
+      relationForKataLink(
+        link({
+          type: "parent",
+          from: { uid: "issue-parent", short_id: "parent" },
+          to: { uid: selectedUID, short_id: "selected" },
+        }),
+        selectedUID,
+      ),
+    ).toBe("parent");
+    expect(relationForKataLink(link({ type: "blocks" }), selectedUID)).toBe("blocks");
+    expect(
+      relationForKataLink(
+        link({
+          type: "blocks",
+          from: { uid: "issue-blocker", short_id: "blocker" },
+          to: { uid: selectedUID, short_id: "selected" },
+        }),
+        selectedUID,
+      ),
+    ).toBe("blocked_by");
+  });
+
+  it("resets task states without changing relationship choices", () => {
+    const current = createKataLinkFilters("all");
+    current.relations.related = false;
+
+    expect(applyKataLinkStatusScope(current, "closed")).toEqual({
+      statuses: { open: false, closed: true },
+      relations: { ...current.relations, related: false },
+    });
+  });
+
+  it("matches resolved, pending, and failed peers without silently hiding failures", () => {
+    const openOnly = createKataLinkFilters("open");
+    const mixed = createKataLinkFilters("all");
+
+    expect(kataLinkMatchesFilters(link(), selectedUID, { kind: "resolved", peer: peer("open") }, openOnly)).toBe(true);
+    expect(kataLinkMatchesFilters(link(), selectedUID, { kind: "resolved", peer: peer("closed") }, openOnly)).toBe(
+      false,
+    );
+    expect(kataLinkMatchesFilters(link(), selectedUID, { kind: "pending" }, openOnly)).toBe(false);
+    expect(kataLinkMatchesFilters(link(), selectedUID, { kind: "pending" }, mixed)).toBe(true);
+    expect(kataLinkMatchesFilters(link(), selectedUID, { kind: "failed" }, openOnly)).toBe(true);
+  });
+
+  it("ignores pending work that disabled filters cannot reveal", () => {
+    const filters = createKataLinkFilters("open");
+    filters.relations.related = false;
+    expect(kataLinkCouldAffectVisibleResults(link(), selectedUID, filters)).toBe(false);
+
+    filters.relations.related = true;
+    filters.statuses.open = false;
+    expect(kataLinkCouldAffectVisibleResults(link(), selectedUID, filters)).toBe(false);
+  });
+});

--- a/frontend/src/lib/features/kata/kataLinkFilters.ts
+++ b/frontend/src/lib/features/kata/kataLinkFilters.ts
@@ -1,0 +1,70 @@
+import type { KataTaskLink, KataTaskStatusFilter, KataTaskSummary } from "../../api/kata/taskTypes.js";
+
+export const KATA_LINK_RELATIONS = ["parent", "child", "blocks", "blocked_by", "related"] as const;
+
+export type KataLinkRelation = (typeof KATA_LINK_RELATIONS)[number];
+
+export interface KataLinkFilters {
+  statuses: Record<KataTaskSummary["status"], boolean>;
+  relations: Record<KataLinkRelation, boolean>;
+}
+
+export type KataLinkPeerResolution =
+  | { kind: "pending" }
+  | { kind: "failed" }
+  | { kind: "resolved"; peer: KataTaskSummary };
+
+function statusesForScope(scope: KataTaskStatusFilter): KataLinkFilters["statuses"] {
+  return {
+    open: scope !== "closed",
+    closed: scope !== "open",
+  };
+}
+
+export function createKataLinkFilters(scope: KataTaskStatusFilter): KataLinkFilters {
+  return {
+    statuses: statusesForScope(scope),
+    relations: {
+      parent: true,
+      child: true,
+      blocks: true,
+      blocked_by: true,
+      related: true,
+    },
+  };
+}
+
+export function applyKataLinkStatusScope(current: KataLinkFilters, scope: KataTaskStatusFilter): KataLinkFilters {
+  return {
+    statuses: statusesForScope(scope),
+    relations: { ...current.relations },
+  };
+}
+
+export function relationForKataLink(link: KataTaskLink, selectedUID: string): KataLinkRelation {
+  if (link.type === "parent") return link.to.uid === selectedUID ? "parent" : "child";
+  if (link.type === "blocks") return link.to.uid === selectedUID ? "blocked_by" : "blocks";
+  return "related";
+}
+
+export function kataLinkCouldAffectVisibleResults(
+  link: KataTaskLink,
+  selectedUID: string,
+  filters: KataLinkFilters,
+): boolean {
+  return (
+    filters.relations[relationForKataLink(link, selectedUID)] && (filters.statuses.open || filters.statuses.closed)
+  );
+}
+
+export function kataLinkMatchesFilters(
+  link: KataTaskLink,
+  selectedUID: string,
+  resolution: KataLinkPeerResolution,
+  filters: KataLinkFilters,
+): boolean {
+  if (!kataLinkCouldAffectVisibleResults(link, selectedUID, filters)) return false;
+  if (resolution.kind === "failed") return true;
+  if (resolution.kind === "pending") return filters.statuses.open && filters.statuses.closed;
+  return filters.statuses[resolution.peer.status];
+}

--- a/frontend/tests/e2e-full/kata.spec.ts
+++ b/frontend/tests/e2e-full/kata.spec.ts
@@ -100,6 +100,51 @@ async function selectGraphFilterItem(graph: Locator, id: string): Promise<void> 
   await expect(item).toHaveClass(/(^|\s)active(\s|$)/);
 }
 
+type ElementBox = { x: number; y: number; width: number; height: number };
+
+function expectFloatingPanelAnchored(trigger: ElementBox, panel: ElementBox): void {
+  expect(Math.abs(panel.x + panel.width - (trigger.x + trigger.width))).toBeLessThanOrEqual(2);
+  const belowGap = Math.abs(panel.y - (trigger.y + trigger.height + 4));
+  const aboveGap = Math.abs(trigger.y - (panel.y + panel.height + 4));
+  expect(Math.min(belowGap, aboveGap)).toBeLessThanOrEqual(2);
+}
+
+async function expectTaskColumnsAligned(page: Page, columns: readonly string[]): Promise<void> {
+  for (const column of columns) {
+    await expect(page.locator(`.table-header .col-${column}`)).toBeVisible();
+    await expect(page.locator(`.issue-row .cell-${column}`).first()).toHaveCount(1);
+  }
+
+  const header = page.locator(".table-header");
+  const row = page.locator(".issue-row").first();
+  const headerGrid = await header.evaluate((element) => {
+    const style = getComputedStyle(element);
+    return {
+      columns: style.gridTemplateColumns,
+      gap: style.columnGap,
+      paddingLeft: style.paddingLeft,
+      paddingRight: style.paddingRight,
+    };
+  });
+  const rowGrid = await row.evaluate((element) => {
+    const style = getComputedStyle(element);
+    return {
+      columns: style.gridTemplateColumns,
+      gap: style.columnGap,
+      paddingLeft: style.paddingLeft,
+      paddingRight: style.paddingRight,
+    };
+  });
+  expect(rowGrid).toEqual(headerGrid);
+
+  const headerBox = await header.boundingBox();
+  const rowBox = await row.boundingBox();
+  expect(headerBox).not.toBeNull();
+  expect(rowBox).not.toBeNull();
+  expect(Math.abs(headerBox!.x - rowBox!.x)).toBeLessThanOrEqual(1);
+  expect(Math.abs(headerBox!.width - rowBox!.width)).toBeLessThanOrEqual(1);
+}
+
 type BackendState = {
   commentsByUID: Map<string, CommentRow[]>;
   duplicateIssueListResponses: DuplicateIssueListResponse[];
@@ -3178,16 +3223,9 @@ test("kata task columns float and preserve responsive grid alignment", async ({ 
       element.style.flex = "none";
     });
 
-    const titleHeader = page.locator(".table-header .col-title");
-    const titleHeaderLabel = titleHeader.locator("span").nth(1);
     const titleCell = page.locator(".issue-row .cell-title").first();
-    const titleText = titleCell.locator(".title-text");
     const titleWidthBefore = await titleCell.evaluate((element) => element.getBoundingClientRect().width);
-    const titleHeaderBox = await titleHeaderLabel.boundingBox();
-    const titleCellBox = await titleText.boundingBox();
-    expect(titleHeaderBox).not.toBeNull();
-    expect(titleCellBox).not.toBeNull();
-    expect(Math.abs(titleHeaderBox!.x - titleCellBox!.x)).toBeLessThanOrEqual(3);
+    await expectTaskColumnsAligned(page, ["id", "title", "updated", "priority", "due", "owner", "tags"]);
 
     const trigger = page.getByRole("button", { name: "Columns" });
     await trigger.click();
@@ -3199,7 +3237,7 @@ test("kata task columns float and preserve responsive grid alignment", async ({ 
     const panelBox = await panel.boundingBox();
     expect(triggerBox).not.toBeNull();
     expect(panelBox).not.toBeNull();
-    expect(Math.abs(panelBox!.x + panelBox!.width - (triggerBox!.x + triggerBox!.width))).toBeLessThanOrEqual(2);
+    expectFloatingPanelAnchored(triggerBox!, panelBox!);
     expect(panelBox!.x).toBeGreaterThanOrEqual(0);
     expect(panelBox!.y).toBeGreaterThanOrEqual(0);
     expect(panelBox!.x + panelBox!.width).toBeLessThanOrEqual(1181);
@@ -3210,19 +3248,36 @@ test("kata task columns float and preserve responsive grid alignment", async ({ 
     await expect(page.locator(".issue-row .cell-tags")).toHaveCount(0);
     const titleWidthAfter = await titleCell.evaluate((element) => element.getBoundingClientRect().width);
     expect(titleWidthAfter).toBeGreaterThan(titleWidthBefore);
+    await page.keyboard.press("Escape");
 
     await list.evaluate((element) => {
       element.style.width = "640px";
     });
     await expect(trigger.locator(".action-label")).toBeHidden();
     await expect(page.locator(".table-header .col-owner")).toBeHidden();
+    await expectTaskColumnsAligned(page, ["id", "title", "updated", "priority", "due"]);
     await list.evaluate((element) => {
       element.style.width = "940px";
     });
     await expect(page.locator(".table-header .col-owner")).toBeVisible();
     await expect(page.locator(".table-header .col-tags")).toHaveCount(0);
 
+    await page.getByRole("button", { name: /Sort by Owner/ }).click();
+    await list.evaluate((element) => {
+      element.style.width = "640px";
+    });
+    await expect(page.getByRole("button", { name: "Sort by Owner, currently ascending" })).toBeVisible();
+    await expectTaskColumnsAligned(page, ["id", "title", "updated", "priority", "due", "owner"]);
+    await trigger.click();
+
+    await page.keyboard.press("Escape");
     await page.setViewportSize({ width: 720, height: 540 });
+    expect(await page.evaluate(() => ({ width: window.innerWidth, height: window.innerHeight }))).toEqual({
+      width: 720,
+      height: 540,
+    });
+    await trigger.scrollIntoViewIfNeeded();
+    await trigger.click();
     await expect
       .poll(async () => {
         const box = await panel.boundingBox();
@@ -3236,25 +3291,12 @@ test("kata task columns float and preserve responsive grid alignment", async ({ 
       })
       .toBeLessThanOrEqual(541);
     const constrainedPanelBox = await panel.boundingBox();
+    const constrainedTriggerBox = await trigger.boundingBox();
     expect(constrainedPanelBox).not.toBeNull();
+    expect(constrainedTriggerBox).not.toBeNull();
     expect(constrainedPanelBox!.x).toBeGreaterThanOrEqual(0);
     expect(constrainedPanelBox!.y).toBeGreaterThanOrEqual(0);
-
-    for (const column of ["id", "title", "updated", "priority", "due", "owner"]) {
-      const headerLocator =
-        column === "title"
-          ? page.locator(".table-header .col-title span").nth(1)
-          : page.locator(`.table-header .col-${column}`);
-      const rowLocator =
-        column === "title"
-          ? page.locator(".issue-row .title-text").first()
-          : page.locator(`.issue-row .cell-${column}`).first();
-      const headerBox = await headerLocator.boundingBox();
-      const rowBox = await rowLocator.boundingBox();
-      expect(headerBox).not.toBeNull();
-      expect(rowBox).not.toBeNull();
-      expect(Math.abs(headerBox!.x - rowBox!.x)).toBeLessThanOrEqual(column === "title" ? 3 : 1);
-    }
+    expectFloatingPanelAnchored(constrainedTriggerBox!, constrainedPanelBox!);
   } finally {
     await server.stop();
     kataHome.restore();
@@ -6512,8 +6554,25 @@ test("kata task links render, navigate, and add related links through the config
     body: "Parent budgeting task.",
     labels: ["home"],
   });
+  const closedPeer = {
+    ...issueSummary({
+      id: 34,
+      uid: "issue-closed-link",
+      project_id: 1,
+      project_uid: "project-finance",
+      project_name: "Finances",
+      short_id: "closed-link",
+      qualified_id: "Finances#closed-link",
+      title: "Completed linked task",
+      body: "Closed peer body.",
+      labels: ["home"],
+    }),
+    status: "closed" as const,
+    closed_reason: "done" as const,
+    closed_at: now,
+  };
   const backend = await startKataBackend({
-    issues: [...issues, budget],
+    issues: [...issues, budget, closedPeer],
     links: [
       linkRow({
         id: 1,
@@ -6522,19 +6581,87 @@ test("kata task links render, navigate, and add related links through the config
         to: issues[0]!,
         type: "parent",
       }),
+      linkRow({
+        id: 2,
+        project_id: 1,
+        from: issues[0]!,
+        to: closedPeer,
+        type: "related",
+      }),
     ],
   });
   const kataHome = await configureKataHome(backend.url);
   const server = await startIsolatedE2EServer();
 
   try {
+    await page.setViewportSize({ width: 720, height: 540 });
     await page.goto(`${server.info.base_url}/kata?issue=issue-rent`);
+    await page.getByRole("button", { name: "Switch to side-by-side layout" }).click();
 
     const detail = page.getByRole("region", { name: "Task detail" });
     const links = detail.getByRole("region", { name: "Links" });
     await expect(links.getByRole("heading", { name: "Links" })).toBeVisible();
     await expect(links).toContainText("Quarterly budget review with a long title");
-    await expect.poll(() => backend.state.seenPaths).toContain("GET /api/v1/issues/issue-budget");
+    await expect(links).not.toContainText("Completed linked task");
+    await expect(links).toContainText("1 / 2");
+    expect(backend.state.seenPaths).not.toContain("GET /api/v1/issues/issue-budget");
+    await expect.poll(() => backend.state.seenPaths).toContain("GET /api/v1/issues/issue-closed-link");
+
+    const filterTrigger = links.getByRole("button", { name: "Filter links" });
+    await filterTrigger.click();
+    const filterPanel = page.locator(".link-filter-panel");
+    await expect(filterPanel).toBeVisible();
+    expect(await filterPanel.evaluate((element) => getComputedStyle(element).position)).toBe("fixed");
+    expect(Number(await filterPanel.evaluate((element) => getComputedStyle(element).zIndex))).toBeGreaterThan(0);
+    const filterTriggerBox = await filterTrigger.boundingBox();
+    const filterPanelBox = await filterPanel.boundingBox();
+    expect(filterTriggerBox).not.toBeNull();
+    expect(filterPanelBox).not.toBeNull();
+    expectFloatingPanelAnchored(filterTriggerBox!, filterPanelBox!);
+    expect(filterPanelBox!.x).toBeGreaterThanOrEqual(0);
+    expect(filterPanelBox!.y).toBeGreaterThanOrEqual(0);
+    expect(filterPanelBox!.x + filterPanelBox!.width).toBeLessThanOrEqual(721);
+    expect(filterPanelBox!.y + filterPanelBox!.height).toBeLessThanOrEqual(541);
+
+    await page.keyboard.press("Escape");
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await filterTrigger.focus();
+    await page.keyboard.press("Enter");
+    await expect(filterPanel).toBeVisible();
+    await expect
+      .poll(async () => {
+        const box = await filterPanel.boundingBox();
+        return box ? box.x + box.width : Number.POSITIVE_INFINITY;
+      })
+      .toBeLessThanOrEqual(1281);
+    await expect
+      .poll(async () => {
+        const box = await filterPanel.boundingBox();
+        return box ? box.y + box.height : Number.POSITIVE_INFINITY;
+      })
+      .toBeLessThanOrEqual(721);
+    const wideFilterPanelBox = await filterPanel.boundingBox();
+    const wideFilterTriggerBox = await filterTrigger.boundingBox();
+    expect(wideFilterPanelBox).not.toBeNull();
+    expect(wideFilterTriggerBox).not.toBeNull();
+    expect(wideFilterPanelBox!.x).toBeGreaterThanOrEqual(0);
+    expect(wideFilterPanelBox!.y).toBeGreaterThanOrEqual(0);
+    expect(wideFilterPanelBox!.x + wideFilterPanelBox!.width).toBeLessThanOrEqual(1281);
+    expect(wideFilterPanelBox!.y + wideFilterPanelBox!.height).toBeLessThanOrEqual(721);
+    expectFloatingPanelAnchored(wideFilterTriggerBox!, wideFilterPanelBox!);
+    await filterPanel.getByRole("checkbox", { name: "Closed" }).click();
+
+    await expect(links).toContainText("Completed linked task");
+    const linkList = links.locator(".link-list");
+    await expect(linkList.getByText("Open", { exact: true })).toBeVisible();
+    await expect(linkList.getByText("Closed", { exact: true })).toBeVisible();
+
+    await filterPanel.getByRole("checkbox", { name: "Parent" }).click();
+    await expect(links).not.toContainText("Quarterly budget review with a long title");
+    await expect(links).toContainText("1 / 2");
+    await filterPanel.getByRole("checkbox", { name: "Parent" }).click();
+    await filterPanel.getByRole("checkbox", { name: "Related" }).click();
+    await page.keyboard.press("Escape");
 
     await links.getByRole("button", { name: /parent\s+budget/ }).click();
     await expect(detail.getByRole("heading", { name: "Quarterly budget review with a long title" })).toBeVisible();
@@ -6544,8 +6671,13 @@ test("kata task links render, navigate, and add related links through the config
       .locator(".kata-list")
       .getByRole("button", { name: /Pay rent/ })
       .click();
+    await filterTrigger.focus();
+    await page.keyboard.press("Enter");
+    await expect(filterPanel.getByRole("checkbox", { name: "Related" })).not.toBeChecked();
+    await filterPanel.getByRole("checkbox", { name: "Related" }).click();
+    await page.keyboard.press("Escape");
     await links.getByLabel("Related issue", { exact: true }).fill("kat-7");
-    await links.getByRole("button", { name: "Link" }).click();
+    await links.getByRole("button", { name: "Link", exact: true }).click();
 
     await expect(links.getByRole("button", { name: /related\s+kat-7/ })).toBeVisible();
     await expect.poll(() => backend.state.seenPaths).toContain("PATCH /api/v1/projects/1/issues/issue-rent");

--- a/frontend/tests/e2e-full/kata.spec.ts
+++ b/frontend/tests/e2e-full/kata.spec.ts
@@ -6655,6 +6655,24 @@ test("kata task links render, navigate, and add related links through the config
     const linkList = links.locator(".link-list");
     await expect(linkList.getByText("Open", { exact: true })).toBeVisible();
     await expect(linkList.getByText("Closed", { exact: true })).toBeVisible();
+    const linkTextGaps = await linkList.getByRole("button", { name: /parent\s+budget/ }).evaluate((row) => {
+      const textBox = (selector: string): DOMRect => {
+        const element = row.querySelector(selector);
+        if (!element) throw new Error(`Missing ${selector}`);
+        const range = document.createRange();
+        range.selectNodeContents(element);
+        return range.getBoundingClientRect();
+      };
+      const kind = textBox(".link-kind");
+      const peer = textBox(".link-peer");
+      const title = textBox(".link-title");
+      return {
+        kindToPeer: peer.x - kind.right,
+        peerToTitle: title.x - peer.right,
+      };
+    });
+    expect(linkTextGaps.kindToPeer).toBeLessThanOrEqual(16);
+    expect(linkTextGaps.peerToTitle).toBeLessThanOrEqual(16);
 
     await filterPanel.getByRole("checkbox", { name: "Parent" }).click();
     await expect(links).not.toContainText("Quarterly budget review with a long title");

--- a/frontend/tests/e2e-full/kata.spec.ts
+++ b/frontend/tests/e2e-full/kata.spec.ts
@@ -3163,6 +3163,105 @@ test("kata task list sorting preserves visible groups", async ({ page }) => {
   }
 });
 
+test("kata task columns float and preserve responsive grid alignment", async ({ page }) => {
+  await page.setViewportSize({ width: 1180, height: 760 });
+  const backend = await startKataBackend();
+  const kataHome = await configureKataHome(backend.url);
+  const server = await startIsolatedE2EServer();
+
+  try {
+    await page.goto(`${server.info.base_url}/kata`);
+    await expectKataDaemonSwitcherReady(page);
+    const list = page.locator(".issue-list");
+    await list.evaluate((element) => {
+      element.style.width = "940px";
+      element.style.flex = "none";
+    });
+
+    const titleHeader = page.locator(".table-header .col-title");
+    const titleHeaderLabel = titleHeader.locator("span").nth(1);
+    const titleCell = page.locator(".issue-row .cell-title").first();
+    const titleText = titleCell.locator(".title-text");
+    const titleWidthBefore = await titleCell.evaluate((element) => element.getBoundingClientRect().width);
+    const titleHeaderBox = await titleHeaderLabel.boundingBox();
+    const titleCellBox = await titleText.boundingBox();
+    expect(titleHeaderBox).not.toBeNull();
+    expect(titleCellBox).not.toBeNull();
+    expect(Math.abs(titleHeaderBox!.x - titleCellBox!.x)).toBeLessThanOrEqual(3);
+
+    const trigger = page.getByRole("button", { name: "Columns" });
+    await trigger.click();
+    const panel = page.locator(".column-picker__panel");
+    await expect(panel).toBeVisible();
+    expect(await panel.evaluate((element) => getComputedStyle(element).position)).toBe("fixed");
+    expect(Number(await panel.evaluate((element) => getComputedStyle(element).zIndex))).toBeGreaterThan(0);
+    const triggerBox = await trigger.boundingBox();
+    const panelBox = await panel.boundingBox();
+    expect(triggerBox).not.toBeNull();
+    expect(panelBox).not.toBeNull();
+    expect(Math.abs(panelBox!.x + panelBox!.width - (triggerBox!.x + triggerBox!.width))).toBeLessThanOrEqual(2);
+    expect(panelBox!.x).toBeGreaterThanOrEqual(0);
+    expect(panelBox!.y).toBeGreaterThanOrEqual(0);
+    expect(panelBox!.x + panelBox!.width).toBeLessThanOrEqual(1181);
+    expect(panelBox!.y + panelBox!.height).toBeLessThanOrEqual(761);
+
+    await page.getByRole("checkbox", { name: "Tags" }).click();
+    await expect(page.locator(".table-header .col-tags")).toHaveCount(0);
+    await expect(page.locator(".issue-row .cell-tags")).toHaveCount(0);
+    const titleWidthAfter = await titleCell.evaluate((element) => element.getBoundingClientRect().width);
+    expect(titleWidthAfter).toBeGreaterThan(titleWidthBefore);
+
+    await list.evaluate((element) => {
+      element.style.width = "640px";
+    });
+    await expect(trigger.locator(".action-label")).toBeHidden();
+    await expect(page.locator(".table-header .col-owner")).toBeHidden();
+    await list.evaluate((element) => {
+      element.style.width = "940px";
+    });
+    await expect(page.locator(".table-header .col-owner")).toBeVisible();
+    await expect(page.locator(".table-header .col-tags")).toHaveCount(0);
+
+    await page.setViewportSize({ width: 720, height: 540 });
+    await expect
+      .poll(async () => {
+        const box = await panel.boundingBox();
+        return box ? box.x + box.width : Number.POSITIVE_INFINITY;
+      })
+      .toBeLessThanOrEqual(721);
+    await expect
+      .poll(async () => {
+        const box = await panel.boundingBox();
+        return box ? box.y + box.height : Number.POSITIVE_INFINITY;
+      })
+      .toBeLessThanOrEqual(541);
+    const constrainedPanelBox = await panel.boundingBox();
+    expect(constrainedPanelBox).not.toBeNull();
+    expect(constrainedPanelBox!.x).toBeGreaterThanOrEqual(0);
+    expect(constrainedPanelBox!.y).toBeGreaterThanOrEqual(0);
+
+    for (const column of ["id", "title", "updated", "priority", "due", "owner"]) {
+      const headerLocator =
+        column === "title"
+          ? page.locator(".table-header .col-title span").nth(1)
+          : page.locator(`.table-header .col-${column}`);
+      const rowLocator =
+        column === "title"
+          ? page.locator(".issue-row .title-text").first()
+          : page.locator(`.issue-row .cell-${column}`).first();
+      const headerBox = await headerLocator.boundingBox();
+      const rowBox = await rowLocator.boundingBox();
+      expect(headerBox).not.toBeNull();
+      expect(rowBox).not.toBeNull();
+      expect(Math.abs(headerBox!.x - rowBox!.x)).toBeLessThanOrEqual(column === "title" ? 3 : 1);
+    }
+  } finally {
+    await server.stop();
+    kataHome.restore();
+    await backend.close();
+  }
+});
+
 test("kata task list keyboard navigation moves focus and selection", async ({ page }) => {
   const backend = await startKataBackend();
   const kataHome = await configureKataHome(backend.url);


### PR DESCRIPTION
Linked Kata tasks previously ignored the active status scope, so completed relationships appeared alongside open work without a clear state or a way to narrow link types. Task-list density choices also disappeared between visits, while compact layouts could hide the active sort indicator.

- Make linked tasks follow Open, Closed, or All while allowing explicit task-state and relationship filters.
- Show state chips only when both states are enabled and keep unavailable peers navigable.
- Remember optional task-column choices and preserve aligned, visible sort controls at compact widths.

Validated with the frontend unit suite, frontend checks, and the full Kata Playwright suite in Chromium and Firefox.

<sup>generated by a clanker</sup>