### PR TITLE
Run only integration-tagged Go tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,7 +251,7 @@ jobs:
       - name: Run integration tests (git-dependent)
         run: |
           mkdir -p tmp
-          go tool gotestsum --format pkgname-and-test-fails --jsonfile=tmp/test-integration-output.json -- -tags integration ./... -shuffle=on -parallel=2
+          go tool gotestsum --format pkgname-and-test-fails --jsonfile=tmp/test-integration-output.json -- -tags integration ./... -run '^TestIntegration' -shuffle=on -parallel=2
 
       - name: Publish integration test report
         if: ${{ !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}

--- a/Makefile
+++ b/Makefile
@@ -283,7 +283,7 @@ test-short-precommit: ensure-embed-dir ensure-tmp-dir
 
 # Run integration tests that execute real git commands (excluded from test-short)
 test-integration: ensure-embed-dir ensure-tmp-dir
-	$(GOTESTSUM)=tmp/test-integration-output.json -- $(GO_TEST_P_FLAG) -tags integration ./... -shuffle=on
+	$(GOTESTSUM)=tmp/test-integration-output.json -- $(GO_TEST_P_FLAG) -tags integration ./... -run '^TestIntegration' -shuffle=on
 
 # Report per-package wall time for the slow race-test packages.
 race-times: ensure-embed-dir

--- a/context/testing.md
+++ b/context/testing.md
@@ -22,6 +22,10 @@ When changing structs, fields, aliases, fragments, pagination arguments, or nest
 
 CI runs the live GraphQL validation as a separate Go test step using the workflow `GITHUB_TOKEN` only in trusted contexts, such as pushes to `main`, manual `workflow_dispatch` runs, and same-repository pull requests. The general pull request Go test step does not receive a GitHub token.
 
+Integration-tagged top-level tests must use the `TestIntegration...` prefix;
+Go build tags are additive, so the dedicated lane relies on its matching run
+filter to avoid rerunning ordinary tests (`Makefile::test-integration`).
+
 ## CI path-gated test jobs
 
 The CI workflow classifies changed paths once in `.github/workflows/ci.yml::detect_changes`

--- a/docs/superpowers/plans/2026-07-22-integration-test-selection.md
+++ b/docs/superpowers/plans/2026-07-22-integration-test-selection.md
@@ -1,0 +1,120 @@
+# Integration Test Selection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the dedicated Go integration lane execute only tests from files guarded by the `integration` build tag.
+
+**Architecture:** Keep Go build tags responsible for compiling integration-only test files, and use a shared `TestIntegration...` naming convention plus `go test -run '^TestIntegration'` to select their top-level tests. Apply the same command shape in the Makefile and GitHub Actions so local and CI execution cannot drift.
+
+**Tech Stack:** Go test build tags and run filters, GNU Make, GitHub Actions, gotestsum
+
+## Global Constraints
+
+- Do not change production code, test assertions, fixtures, or subtest names.
+- Keep the ordinary Go test lane unchanged.
+- Use `-shuffle=on` for every direct `go test` invocation.
+- Do not add a test for Makefile or workflow configuration; verify these artifacts by enumerating tests and rendering the affected command.
+- Do not execute the integration test bodies during implementation verification; enumerate their names instead.
+- Do not push the rebased branch unless the user explicitly requests it.
+
+---
+
+### Task 1: Select Only Integration-Tagged Top-Level Tests
+
+**Files:**
+- Modify: `internal/gitclone/clone_test.go`
+- Modify: `internal/gitclone/diff_test.go`
+- Modify: `internal/docs/git_publish_integration_test.go`
+- Modify: `internal/docs/git_pull_integration_test.go`
+- Modify: `internal/github/merged_diff_test.go`
+- Modify: `Makefile`
+- Modify: `.github/workflows/ci.yml`
+
+**Interfaces:**
+- Consumes: Go's existing `integration` build constraint on the five test files.
+- Produces: Top-level test names matching `^TestIntegration` and equivalent local/CI integration commands.
+
+- [x] **Step 1: Record the failing pre-change selection behavior**
+
+Run:
+
+```bash
+go test -tags integration ./internal/gitclone -list . -shuffle=on
+```
+
+Expected before the fix: output includes ordinary tests such as
+`TestGitNetworkedResolvesTokenSourceForEachCall` as well as tagged tests such as
+`TestEnsureClone`; no listed test begins with `TestIntegration`.
+
+- [x] **Step 2: Prefix every tagged top-level test name**
+
+In each of the five integration-tagged files, change every top-level declaration
+from this form:
+
+```go
+func TestEnsureClone(t *testing.T) {
+```
+
+to this form, preserving the descriptive suffix and function body:
+
+```go
+func TestIntegrationEnsureClone(t *testing.T) {
+```
+
+Apply the same `Test` to `TestIntegration` prefix insertion to all 70 top-level
+tests in those files. Do not rename helpers or `t.Run` subtests.
+
+- [x] **Step 3: Add the same run filter to local and CI commands**
+
+Change the Makefile target to:
+
+```make
+test-integration: ensure-embed-dir ensure-tmp-dir
+	$(GOTESTSUM)=tmp/test-integration-output.json -- $(GO_TEST_P_FLAG) -tags integration ./... -run '^TestIntegration' -shuffle=on
+```
+
+Change the GitHub Actions command to:
+
+```yaml
+go tool gotestsum --format pkgname-and-test-fails --jsonfile=tmp/test-integration-output.json -- -tags integration ./... -run '^TestIntegration' -shuffle=on -parallel=2
+```
+
+- [x] **Step 4: Verify the focused selection**
+
+Run:
+
+```bash
+go test -tags integration ./internal/gitclone ./internal/docs ./internal/github -list '^TestIntegration' -shuffle=on
+```
+
+Expected: exactly 70 listed top-level tests, all beginning with
+`TestIntegration`, and no ordinary test names.
+
+- [x] **Step 5: Inspect the actual integration command without running it**
+
+Run:
+
+```bash
+make -n test-integration
+```
+
+Expected: the rendered gotestsum command contains both `-tags integration` and
+`-run '^TestIntegration'`.
+
+- [x] **Step 6: Confirm the ordinary lane is unchanged**
+
+Run:
+
+```bash
+git diff -- Makefile .github/workflows/ci.yml
+```
+
+Expected: only the dedicated integration commands gain the run filter; the
+ordinary Go test command remains unchanged.
+
+- [x] **Step 7: Review and commit**
+
+Run `git diff --check`, inspect the full diff, run the repository context-sync
+commit workflow, and create one conventional commit explaining that build tags
+are additive and therefore require an explicit test-name filter for the
+dedicated lane.

--- a/docs/superpowers/specs/2026-07-22-integration-test-selection-design.md
+++ b/docs/superpowers/specs/2026-07-22-integration-test-selection-design.md
@@ -1,0 +1,36 @@
+# Integration Test Selection
+
+## Problem
+
+The integration lane currently runs `go test -tags integration ./...`. Go build
+tags add the integration-tagged test files to each package, but they do not
+exclude ordinary test files. As a result, CI runs almost the full Go suite a
+second time before executing the tests that require real Git repositories.
+
+## Decision
+
+Integration-tagged top-level tests use the `TestIntegration...` naming prefix.
+Both `make test-integration` and the matching CI step keep the `integration`
+build tag and add `-run '^TestIntegration'`.
+
+The build tag remains responsible for compiling integration-only test files and
+helpers. The name filter is responsible for selecting only their top-level
+tests. The ordinary Go test lane remains unchanged and continues to exclude the
+tagged files.
+
+## Scope
+
+Rename the existing top-level tests in the five files guarded by
+`//go:build integration`. Do not change their assertions, fixtures, subtest
+names, or production code. Update both local and CI integration commands so
+they remain equivalent.
+
+## Verification
+
+- Before the change, demonstrate that a tagged package lists both ordinary and
+  integration tests.
+- After the change, list or run tests with `-tags integration -run
+  '^TestIntegration'` and confirm that only integration-prefixed tests are
+  selected.
+- Run `make test-integration` and the ordinary affected package tests to confirm
+  the two lanes remain distinct and passing.

--- a/internal/docs/git_publish_integration_test.go
+++ b/internal/docs/git_publish_integration_test.go
@@ -127,7 +127,7 @@ func gitOutput(t *testing.T, dir string, args ...string) string {
 	return strings.TrimSpace(runGit(t, dir, args...))
 }
 
-func TestGitChangesNotARepo(t *testing.T) {
+func TestIntegrationGitChangesNotARepo(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	dir := t.TempDir()
@@ -140,7 +140,7 @@ func TestGitChangesNotARepo(t *testing.T) {
 	assert.Empty(res.Changes)
 }
 
-func TestGitChangesEmptyRepo(t *testing.T) {
+func TestIntegrationGitChangesEmptyRepo(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
@@ -154,7 +154,7 @@ func TestGitChangesEmptyRepo(t *testing.T) {
 	assert.Equal("origin/main", res.Upstream)
 }
 
-func TestGitChangesIncludesUntrackedAndModifiedMarkdown(t *testing.T) {
+func TestIntegrationGitChangesIncludesUntrackedAndModifiedMarkdown(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
@@ -175,7 +175,7 @@ func TestGitChangesIncludesUntrackedAndModifiedMarkdown(t *testing.T) {
 	assert.Equal(suggestedCommitMessage(res.Changes), res.SuggestedMessage)
 }
 
-func TestGitChangesNoUpstream(t *testing.T) {
+func TestIntegrationGitChangesNoUpstream(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepoNoUpstream(t)
@@ -187,7 +187,7 @@ func TestGitChangesNoUpstream(t *testing.T) {
 	assert.Equal("main", res.Branch)
 }
 
-func TestGitPublishHappyPath(t *testing.T) {
+func TestIntegrationGitPublishHappyPath(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
@@ -208,7 +208,7 @@ func TestGitPublishHappyPath(t *testing.T) {
 	assert.Equal(res.Commit, head)
 }
 
-func TestGitPublishPushesConfiguredUpstreamDespitePushDefaults(t *testing.T) {
+func TestIntegrationGitPublishPushesConfiguredUpstreamDespitePushDefaults(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
@@ -230,7 +230,7 @@ func TestGitPublishPushesConfiguredUpstreamDespitePushDefaults(t *testing.T) {
 	assert.Equal(backupInitial, backupHead)
 }
 
-func TestGitPublishRefusesEmptyMessage(t *testing.T) {
+func TestIntegrationGitPublishRefusesEmptyMessage(t *testing.T) {
 	g := newGitRepo(t)
 	g.writeFile(t, "new.md", "# new\n")
 
@@ -239,7 +239,7 @@ func TestGitPublishRefusesEmptyMessage(t *testing.T) {
 	require.ErrorIs(t, err, ErrEmptyMessage)
 }
 
-func TestGitPublishRefusesNoMarkdownChanges(t *testing.T) {
+func TestIntegrationGitPublishRefusesNoMarkdownChanges(t *testing.T) {
 	g := newGitRepo(t)
 	g.writeFile(t, "code.go", "package x\n")
 
@@ -248,7 +248,7 @@ func TestGitPublishRefusesNoMarkdownChanges(t *testing.T) {
 	require.ErrorIs(t, err, ErrNoMarkdownChanges)
 }
 
-func TestGitPublishRefusesNotARepo(t *testing.T) {
+func TestIntegrationGitPublishRefusesNotARepo(t *testing.T) {
 	dir := t.TempDir()
 	reg := NewRegistry([]config.DocFolder{{ID: "f", Name: "F", Path: dir}})
 
@@ -257,7 +257,7 @@ func TestGitPublishRefusesNotARepo(t *testing.T) {
 	require.ErrorIs(t, err, ErrNotAGitRepo)
 }
 
-func TestGitPublishRefusesIndexNotCleanUnrelatedStaged(t *testing.T) {
+func TestIntegrationGitPublishRefusesIndexNotCleanUnrelatedStaged(t *testing.T) {
 	g := newGitRepo(t)
 	g.writeFile(t, "new.md", "# new\n")
 	g.writeFile(t, "code.go", "package x\n")
@@ -268,7 +268,7 @@ func TestGitPublishRefusesIndexNotCleanUnrelatedStaged(t *testing.T) {
 	require.ErrorIs(t, err, ErrIndexNotClean)
 }
 
-func TestGitPublishRefusesIndexNotCleanPartiallyStaged(t *testing.T) {
+func TestIntegrationGitPublishRefusesIndexNotCleanPartiallyStaged(t *testing.T) {
 	g := newGitRepo(t)
 	g.writeFile(t, "partial.md", "v1\n")
 	g.stage(t, "partial.md")
@@ -279,7 +279,7 @@ func TestGitPublishRefusesIndexNotCleanPartiallyStaged(t *testing.T) {
 	require.ErrorIs(t, err, ErrIndexNotClean)
 }
 
-func TestGitPublishRefusesConflict(t *testing.T) {
+func TestIntegrationGitPublishRefusesConflict(t *testing.T) {
 	g := newGitRepo(t)
 	runGit(t, g.dir, "checkout", "-b", "side")
 	g.writeFile(t, "seed.md", "side version\n")
@@ -298,7 +298,7 @@ func TestGitPublishRefusesConflict(t *testing.T) {
 	require.ErrorIs(t, err, ErrConflict)
 }
 
-func TestGitPublishRefusesNoUpstream(t *testing.T) {
+func TestIntegrationGitPublishRefusesNoUpstream(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepoNoUpstream(t)
@@ -312,7 +312,7 @@ func TestGitPublishRefusesNoUpstream(t *testing.T) {
 	assert.Equal("git push -u origin main", noUpstream.SuggestedCommand)
 }
 
-func TestGitPublishStagesRenamePair(t *testing.T) {
+func TestIntegrationGitPublishStagesRenamePair(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
@@ -326,7 +326,7 @@ func TestGitPublishStagesRenamePair(t *testing.T) {
 	assert.Contains(out, "renamed.md")
 }
 
-func TestGitPublishStagesWorktreeRename(t *testing.T) {
+func TestIntegrationGitPublishStagesWorktreeRename(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
@@ -342,7 +342,7 @@ func TestGitPublishStagesWorktreeRename(t *testing.T) {
 	assert.Contains(renames, "R")
 }
 
-func TestGitPublishPushFailedAfterCommit(t *testing.T) {
+func TestIntegrationGitPublishPushFailedAfterCommit(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
@@ -360,7 +360,7 @@ func TestGitPublishPushFailedAfterCommit(t *testing.T) {
 	assert.Equal(head, pushFailed.Commit)
 }
 
-func TestGitPublishDoesNotRunDocsRepoHooks(t *testing.T) {
+func TestIntegrationGitPublishDoesNotRunDocsRepoHooks(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
@@ -380,7 +380,7 @@ func TestGitPublishDoesNotRunDocsRepoHooks(t *testing.T) {
 	assert.NoFileExists(marker, "docs repo hook executed during publish")
 }
 
-func TestGitPublishIgnoresRepoHooksPathOverride(t *testing.T) {
+func TestIntegrationGitPublishIgnoresRepoHooksPathOverride(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
@@ -398,7 +398,7 @@ func TestGitPublishIgnoresRepoHooksPathOverride(t *testing.T) {
 	assert.NoFileExists(marker, "core.hooksPath hook executed during publish")
 }
 
-func TestGitPublishRejectsCommandBearingLocalConfig(t *testing.T) {
+func TestIntegrationGitPublishRejectsCommandBearingLocalConfig(t *testing.T) {
 	cases := []struct {
 		name  string
 		key   string
@@ -438,7 +438,7 @@ func TestGitPublishRejectsCommandBearingLocalConfig(t *testing.T) {
 	}
 }
 
-func TestGitPublishRejectsIncludedCommandBearingConfig(t *testing.T) {
+func TestIntegrationGitPublishRejectsIncludedCommandBearingConfig(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
@@ -457,7 +457,7 @@ func TestGitPublishRejectsIncludedCommandBearingConfig(t *testing.T) {
 	assert.NotEmpty(unsafe.Entries)
 }
 
-func TestGitPublishRejectsPushTargetInsideDocsFolder(t *testing.T) {
+func TestIntegrationGitPublishRejectsPushTargetInsideDocsFolder(t *testing.T) {
 	cases := []struct {
 		name string
 		url  func(g *gitRepo) string
@@ -497,7 +497,7 @@ func TestGitPublishRejectsPushTargetInsideDocsFolder(t *testing.T) {
 	}
 }
 
-func TestGitPublishRejectsPushInsteadOfRewriteIntoDocsFolder(t *testing.T) {
+func TestIntegrationGitPublishRejectsPushInsteadOfRewriteIntoDocsFolder(t *testing.T) {
 	require := require.New(t)
 	g := newGitRepo(t)
 	g.writeFile(t, "new.md", "# new\n")
@@ -513,7 +513,7 @@ func TestGitPublishRejectsPushInsteadOfRewriteIntoDocsFolder(t *testing.T) {
 	require.ErrorAs(err, &unsafe)
 }
 
-func TestGitPublishRejectsMixedLocalAndNetworkPushURLs(t *testing.T) {
+func TestIntegrationGitPublishRejectsMixedLocalAndNetworkPushURLs(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
@@ -533,7 +533,7 @@ func TestGitPublishRejectsMixedLocalAndNetworkPushURLs(t *testing.T) {
 		"publish committed before rejecting the mixed push urls")
 }
 
-func TestGitPublishRejectsRemoteHelperPushTarget(t *testing.T) {
+func TestIntegrationGitPublishRejectsRemoteHelperPushTarget(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
@@ -548,7 +548,7 @@ func TestGitPublishRejectsRemoteHelperPushTarget(t *testing.T) {
 	assert.NoFileExists(marker, "ext:: remote helper executed during publish")
 }
 
-func TestGitPublishNeutralizesLocalRemoteReceiveHooks(t *testing.T) {
+func TestIntegrationGitPublishNeutralizesLocalRemoteReceiveHooks(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
@@ -569,7 +569,7 @@ func TestGitPublishNeutralizesLocalRemoteReceiveHooks(t *testing.T) {
 	assert.Equal(res.Commit, gitOutput(t, g.remote, "rev-parse", "main"))
 }
 
-func TestGitPublishRejectsFilterAttributes(t *testing.T) {
+func TestIntegrationGitPublishRejectsFilterAttributes(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
@@ -585,7 +585,7 @@ func TestGitPublishRejectsFilterAttributes(t *testing.T) {
 	assert.NotEmpty(unsafe.Entries)
 }
 
-func TestGitPublishRejectsSubdirectoryFilterAttributes(t *testing.T) {
+func TestIntegrationGitPublishRejectsSubdirectoryFilterAttributes(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
@@ -601,7 +601,7 @@ func TestGitPublishRejectsSubdirectoryFilterAttributes(t *testing.T) {
 	assert.NotEmpty(unsafe.Entries)
 }
 
-func TestGitPublishGatesAttributesBeforeStatusRunsFilter(t *testing.T) {
+func TestIntegrationGitPublishGatesAttributesBeforeStatusRunsFilter(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
@@ -627,7 +627,7 @@ func TestGitPublishGatesAttributesBeforeStatusRunsFilter(t *testing.T) {
 	assert.NoFileExists(marker, "clean filter ran during status before the attribute gate")
 }
 
-func TestGitStatusRejectsFilterAttributes(t *testing.T) {
+func TestIntegrationGitStatusRejectsFilterAttributes(t *testing.T) {
 	require := require.New(t)
 	g := newGitRepo(t)
 	g.writeFile(t, ".gitattributes", "*.md filter=lfs\n")
@@ -638,7 +638,7 @@ func TestGitStatusRejectsFilterAttributes(t *testing.T) {
 	require.ErrorAs(err, &unsafe)
 }
 
-func TestGitChangesRejectsFilterAttributes(t *testing.T) {
+func TestIntegrationGitChangesRejectsFilterAttributes(t *testing.T) {
 	require := require.New(t)
 	g := newGitRepo(t)
 	g.writeFile(t, "sub/.gitattributes", "*.md diff=evil\n")
@@ -650,7 +650,7 @@ func TestGitChangesRejectsFilterAttributes(t *testing.T) {
 	require.ErrorAs(err, &unsafe)
 }
 
-func TestGitChangesRejectsCommandBearingLocalConfig(t *testing.T) {
+func TestIntegrationGitChangesRejectsCommandBearingLocalConfig(t *testing.T) {
 	require := require.New(t)
 	g := newGitRepo(t)
 	g.writeFile(t, "new.md", "# new\n")
@@ -665,7 +665,7 @@ func TestGitChangesRejectsCommandBearingLocalConfig(t *testing.T) {
 	require.ErrorAs(err, &unsafe)
 }
 
-func TestGitPublishAllowsBenignLocalConfig(t *testing.T) {
+func TestIntegrationGitPublishAllowsBenignLocalConfig(t *testing.T) {
 	require := require.New(t)
 	g := newGitRepo(t)
 	g.writeFile(t, "new.md", "# new\n")
@@ -680,7 +680,7 @@ func TestGitPublishAllowsBenignLocalConfig(t *testing.T) {
 	require.True(res.Pushed)
 }
 
-func TestGitStatusDoesNotRunRepoFsmonitor(t *testing.T) {
+func TestIntegrationGitStatusDoesNotRunRepoFsmonitor(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
@@ -697,7 +697,7 @@ func TestGitStatusDoesNotRunRepoFsmonitor(t *testing.T) {
 	assert.NoFileExists(marker, "core.fsmonitor program executed during git status")
 }
 
-func TestGitPublishBlocksExtRemoteHelperOnPush(t *testing.T) {
+func TestIntegrationGitPublishBlocksExtRemoteHelperOnPush(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
@@ -717,7 +717,7 @@ func TestGitPublishBlocksExtRemoteHelperOnPush(t *testing.T) {
 	assert.NoFileExists(marker, "ext:: remote helper executed during push")
 }
 
-func TestGitPublishCommitFailurePreservesStderr(t *testing.T) {
+func TestIntegrationGitPublishCommitFailurePreservesStderr(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
@@ -733,7 +733,7 @@ func TestGitPublishCommitFailurePreservesStderr(t *testing.T) {
 	assert.NotContains(commitFailed.Stderr, "exit status")
 }
 
-func TestGitPublishStagesLiteralPathspec(t *testing.T) {
+func TestIntegrationGitPublishStagesLiteralPathspec(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)

--- a/internal/docs/git_pull_integration_test.go
+++ b/internal/docs/git_pull_integration_test.go
@@ -34,7 +34,7 @@ func (g *gitRepo) remoteCommit(t *testing.T, rel, body string) string {
 	return gitOutput(t, clone, "rev-parse", "HEAD")
 }
 
-func TestGitPullFastForwards(t *testing.T) {
+func TestIntegrationGitPullFastForwards(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
@@ -58,7 +58,7 @@ func TestGitPullFastForwards(t *testing.T) {
 	assert.Equal("# remote\n", string(body))
 }
 
-func TestGitPullUpToDate(t *testing.T) {
+func TestIntegrationGitPullUpToDate(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
@@ -72,7 +72,7 @@ func TestGitPullUpToDate(t *testing.T) {
 	assert.Equal(head[:7], res.ShortCommit)
 }
 
-func TestGitPullRefusesDiverged(t *testing.T) {
+func TestIntegrationGitPullRefusesDiverged(t *testing.T) {
 	g := newGitRepo(t)
 	g.remoteCommit(t, "remote.md", "remote\n")
 	g.writeFile(t, "local.md", "local\n")
@@ -84,7 +84,7 @@ func TestGitPullRefusesDiverged(t *testing.T) {
 	require.ErrorIs(t, err, ErrDiverged)
 }
 
-func TestGitPullRefusesOverwritingDirtyWorktree(t *testing.T) {
+func TestIntegrationGitPullRefusesOverwritingDirtyWorktree(t *testing.T) {
 	g := newGitRepo(t)
 	g.remoteCommit(t, "seed.md", "remote seed\n")
 	g.writeFile(t, "seed.md", "local dirty\n")
@@ -100,7 +100,7 @@ func TestGitPullRefusesOverwritingDirtyWorktree(t *testing.T) {
 	assert.Equal(t, "local dirty\n", string(body))
 }
 
-func TestGitPullRefusesNoUpstream(t *testing.T) {
+func TestIntegrationGitPullRefusesNoUpstream(t *testing.T) {
 	g := newGitRepoNoUpstream(t)
 
 	_, err := g.registry.GitPull(context.Background(), g.folderID)
@@ -110,7 +110,7 @@ func TestGitPullRefusesNoUpstream(t *testing.T) {
 	assert.Contains(t, noUpstream.SuggestedCommand, "--set-upstream-to")
 }
 
-func TestGitPullRefusesNotARepo(t *testing.T) {
+func TestIntegrationGitPullRefusesNotARepo(t *testing.T) {
 	dir := t.TempDir()
 	reg := NewRegistry([]config.DocFolder{{ID: "f", Name: "F", Path: dir}})
 

--- a/internal/gitclone/clone_test.go
+++ b/internal/gitclone/clone_test.go
@@ -53,7 +53,7 @@ func run(t *testing.T, dir string, name string, args ...string) {
 	require.NoError(t, err, "command %s %v failed: %s%s", name, args, out, stderr)
 }
 
-func TestEnsureClone(t *testing.T) {
+func TestIntegrationEnsureClone(t *testing.T) {
 	remote, _ := setupTestRepo(t)
 	clonesDir := t.TempDir()
 	mgr := New(clonesDir, nil)
@@ -71,7 +71,7 @@ func TestEnsureClone(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestEnsureCloneInNamespacePartitionsStorage(t *testing.T) {
+func TestIntegrationEnsureCloneInNamespacePartitionsStorage(t *testing.T) {
 	remote, _ := setupTestRepo(t)
 	clonesDir := t.TempDir()
 	mgr := New(clonesDir, nil)
@@ -96,7 +96,7 @@ func TestEnsureCloneInNamespacePartitionsStorage(t *testing.T) {
 // with an already-canceled context does not start any clone work. The
 // pre-check exists so a canceled caller cannot trigger background
 // fetches that outlive the request it abandoned.
-func TestEnsureCloneShortCircuitsCanceledContext(t *testing.T) {
+func TestIntegrationEnsureCloneShortCircuitsCanceledContext(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -123,7 +123,7 @@ func TestEnsureCloneShortCircuitsCanceledContext(t *testing.T) {
 // git clone --bare. Without the sweep, git refuses to write into the
 // non-empty destination and every retry would fail with "destination
 // path already exists and is not an empty directory."
-func TestEnsureCloneSweepsPartialClone(t *testing.T) {
+func TestIntegrationEnsureCloneSweepsPartialClone(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -152,7 +152,7 @@ func TestEnsureCloneSweepsPartialClone(t *testing.T) {
 
 // TestEnsureCloneInstallsDefaultRefspecs verifies that a fresh clone gets the
 // bounded ref families workspace setup needs during background refresh.
-func TestEnsureCloneInstallsDefaultRefspecs(t *testing.T) {
+func TestIntegrationEnsureCloneInstallsDefaultRefspecs(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -175,7 +175,7 @@ func TestEnsureCloneInstallsDefaultRefspecs(t *testing.T) {
 // TestEnsureCloneFetchesNewBranchCommits is the regression test for the bug
 // where a merged PR's merge commit was never fetched into the bare clone
 // because git clone --bare sets no default fetch refspec.
-func TestEnsureCloneFetchesNewBranchCommits(t *testing.T) {
+func TestIntegrationEnsureCloneFetchesNewBranchCommits(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -199,7 +199,7 @@ func TestEnsureCloneFetchesNewBranchCommits(t *testing.T) {
 	assert.Equal(newSHA, got)
 }
 
-func TestEnsureCloneDoesNotRefreshMovedRemoteTags(t *testing.T) {
+func TestIntegrationEnsureCloneDoesNotRefreshMovedRemoteTags(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -228,7 +228,7 @@ func TestEnsureCloneDoesNotRefreshMovedRemoteTags(t *testing.T) {
 	require.NoError(err)
 }
 
-func TestEnsureCloneDoesNotFetchGitLabMergeRequestHeadsByDefault(t *testing.T) {
+func TestIntegrationEnsureCloneDoesNotFetchGitLabMergeRequestHeadsByDefault(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -266,7 +266,7 @@ func TestEnsureCloneDoesNotFetchGitLabMergeRequestHeadsByDefault(t *testing.T) {
 // previous version of cloneBare (only pull refspec, no remote-tracking
 // refspec) and verifies ensureRefspecs migrates it so branch fetches
 // work again.
-func TestEnsureCloneMigratesBrokenClone(t *testing.T) {
+func TestIntegrationEnsureCloneMigratesBrokenClone(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -313,7 +313,7 @@ func TestEnsureCloneMigratesBrokenClone(t *testing.T) {
 // TestEnsureCloneRemovesLegacyBranchRefspec verifies that legacy clones stop
 // fetching origin branches into refs/heads/*, which would collide with a
 // workspace checking out the PR branch name locally.
-func TestEnsureCloneRemovesLegacyBranchRefspec(t *testing.T) {
+func TestIntegrationEnsureCloneRemovesLegacyBranchRefspec(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -350,7 +350,7 @@ func TestEnsureCloneRemovesLegacyBranchRefspec(t *testing.T) {
 // before any middleman-specific refspec was added). In that case
 // `git config --get-all remote.origin.fetch` exits 1, which must not
 // short-circuit ensureRefspecs.
-func TestEnsureCloneMigratesCloneWithNoRefspec(t *testing.T) {
+func TestIntegrationEnsureCloneMigratesCloneWithNoRefspec(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -394,7 +394,7 @@ func TestEnsureCloneMigratesCloneWithNoRefspec(t *testing.T) {
 // remote default-branch symref available as refs/remotes/origin/HEAD.
 // Issue workspaces start from origin/HEAD, so older clones that lack that
 // symref would otherwise fail to create a worktree.
-func TestEnsureCloneRestoresOriginHead(t *testing.T) {
+func TestIntegrationEnsureCloneRestoresOriginHead(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -421,7 +421,7 @@ func TestEnsureCloneRestoresOriginHead(t *testing.T) {
 	assert.Equal("refs/remotes/origin/main", headRef)
 }
 
-func TestEnsureCloneRepairsStaleOriginHead(t *testing.T) {
+func TestIntegrationEnsureCloneRepairsStaleOriginHead(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -449,7 +449,7 @@ func TestEnsureCloneRepairsStaleOriginHead(t *testing.T) {
 	assert.Equal("refs/remotes/origin/main", headRef)
 }
 
-func TestEnsureCloneToleratesUnresolvedRemoteHead(t *testing.T) {
+func TestIntegrationEnsureCloneToleratesUnresolvedRemoteHead(t *testing.T) {
 	require := require.New(t)
 
 	remote, _ := setupTestRepo(t)
@@ -495,7 +495,7 @@ func gitSymbolicRef(t *testing.T, dir, ref string) string {
 	return strings.TrimSpace(string(out))
 }
 
-func TestEnsureCloneIgnoresInheritedGitEnv(t *testing.T) {
+func TestIntegrationEnsureCloneIgnoresInheritedGitEnv(t *testing.T) {
 	remote, _ := setupTestRepo(t)
 	clonesDir := t.TempDir()
 	mgr := New(clonesDir, nil)
@@ -522,7 +522,7 @@ func TestEnsureCloneIgnoresInheritedGitEnv(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestMergeBase(t *testing.T) {
+func TestIntegrationMergeBase(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 

--- a/internal/gitclone/diff_test.go
+++ b/internal/gitclone/diff_test.go
@@ -13,7 +13,7 @@ import (
 	gitcmd "go.kenn.io/kit/git/cmd"
 )
 
-func TestDiff(t *testing.T) {
+func TestIntegrationDiff(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -79,7 +79,7 @@ func TestDiff(t *testing.T) {
 	assert.Equal("added", result.Files[1].Status)
 }
 
-func TestDiffFiles(t *testing.T) {
+func TestIntegrationDiffFiles(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -144,7 +144,7 @@ func TestDiffFiles(t *testing.T) {
 	assert.Zero(files[1].Deletions)
 }
 
-func TestDiffFilesEmpty(t *testing.T) {
+func TestIntegrationDiffFilesEmpty(t *testing.T) {
 	assert := assert.New(t)
 
 	// Diffing a commit against itself yields no files.
@@ -183,7 +183,7 @@ func TestDiffFilesEmpty(t *testing.T) {
 	assert.Empty(result.Files)
 }
 
-func TestDiffArgumentBuildersTerminateOptionsBeforeRevisions(t *testing.T) {
+func TestIntegrationDiffArgumentBuildersTerminateOptionsBeforeRevisions(t *testing.T) {
 	assert := assert.New(t)
 
 	assert.Contains(

--- a/internal/github/merged_diff_test.go
+++ b/internal/github/merged_diff_test.go
@@ -94,7 +94,7 @@ func insertMergedPR(t *testing.T, ctx context.Context, d *db.DB, repoID int64, n
 	return mrID, revision
 }
 
-func TestComputeMergedPRDiffSHAs_MergeCommit(t *testing.T) {
+func TestIntegrationComputeMergedPRDiffSHAs_MergeCommit(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -136,7 +136,7 @@ func TestComputeMergedPRDiffSHAs_MergeCommit(t *testing.T) {
 	assert.NotEqual(prHead, shas.MergeBaseSHA, "diff should not be empty")
 }
 
-func TestComputeMergedPRDiffSHAs_ForceOverwritesIncorrectSHAs(t *testing.T) {
+func TestIntegrationComputeMergedPRDiffSHAs_ForceOverwritesIncorrectSHAs(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -182,7 +182,7 @@ func TestComputeMergedPRDiffSHAs_ForceOverwritesIncorrectSHAs(t *testing.T) {
 	assert.Equal(forkPoint, shas.MergeBaseSHA, "force=true should overwrite with correct merge base")
 }
 
-func TestComputeMergedPRDiffSHAs_SquashMerge(t *testing.T) {
+func TestIntegrationComputeMergedPRDiffSHAs_SquashMerge(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -222,7 +222,7 @@ func TestComputeMergedPRDiffSHAs_SquashMerge(t *testing.T) {
 	assert.NotEqual(prHead, shas.MergeBaseSHA)
 }
 
-func TestComputeMergedPRDiffSHAs_RebaseMerge(t *testing.T) {
+func TestIntegrationComputeMergedPRDiffSHAs_RebaseMerge(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -279,7 +279,7 @@ func TestComputeMergedPRDiffSHAs_RebaseMerge(t *testing.T) {
 // open -> merged transition through RunOnce. First sync inserts the PR as open
 // (before merge); second sync discovers it missing from ListOpenPullRequests,
 // calls fetchAndUpdateClosed, and computes diff SHAs via the merged-PR path.
-func TestSyncOpenToMergedTransition(t *testing.T) {
+func TestIntegrationSyncOpenToMergedTransition(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -414,7 +414,7 @@ func TestSyncOpenToMergedTransition(t *testing.T) {
 // RunOnce. The PR is inserted as open WITHOUT a clone manager (no diff SHAs
 // computed), then on the second sync (with clone manager) it transitions to
 // merged and computeMergedMRDiffSHAs must fill in the diff SHAs.
-func TestSyncFirstSeenMergedPR(t *testing.T) {
+func TestIntegrationSyncFirstSeenMergedPR(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -518,7 +518,7 @@ func TestSyncFirstSeenMergedPR(t *testing.T) {
 // merge commit), it still upserts the PR row, refreshes the timeline, and
 // returns the failure as a *DiffSyncError. The handler distinguishes this
 // from hard sync failures so the user sees a warning instead of a 502.
-func TestSyncMRWrapsDiffFailureAsDiffSyncError(t *testing.T) {
+func TestIntegrationSyncMRWrapsDiffFailureAsDiffSyncError(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
@@ -628,7 +628,7 @@ func TestSyncMRWrapsDiffFailureAsDiffSyncError(t *testing.T) {
 // the item type as "pr" so the resolve endpoint can route the user to the
 // PR detail view. The diff failure is preserved in the returned error so
 // the caller can surface it as a warning if it cares.
-func TestSyncItemByNumberReturnsTypeOnDiffSyncError(t *testing.T) {
+func TestIntegrationSyncItemByNumberReturnsTypeOnDiffSyncError(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 


### PR DESCRIPTION
- Stop the dedicated integration lane from rerunning the ordinary Go test suite
- Keep local and CI integration selection aligned through one tagged-test naming convention

<sup>generated by a clanker</sup>