### PR TITLE
Simplify workspace launch cards

### DIFF
--- a/frontend/src/lib/components/terminal/LaunchMenu.svelte
+++ b/frontend/src/lib/components/terminal/LaunchMenu.svelte
@@ -40,12 +40,6 @@
     onLaunch?.(targetKey);
   }
 
-  function sourceLabel(target: LaunchTarget): string {
-    if (target.kind === "plain_shell") return "shell";
-    if (target.source === "config") return "configured";
-    return target.source;
-  }
-
   function targetLabel(target: LaunchTarget): string {
     return target.kind === "plain_shell" ? "Shell" : target.label;
   }
@@ -121,7 +115,6 @@
             {/if}
           </span>
           <span class="option-label">{targetLabel(target)}</span>
-          <span class="option-source">{sourceLabel(target)}</span>
         </button>
       {/each}
     </div>
@@ -198,7 +191,7 @@
 
   .launch-option {
     display: grid;
-    grid-template-columns: 16px 1fr auto;
+    grid-template-columns: 16px 1fr;
     align-items: center;
     gap: 8px;
     width: 100%;
@@ -250,15 +243,4 @@
     font-weight: 500;
   }
 
-  .option-source {
-    color: var(--text-muted);
-    font-size: var(--font-size-xs);
-    font-family: var(--font-mono);
-    text-transform: lowercase;
-    letter-spacing: 0;
-  }
-
-  .launch-option:hover:not(:disabled) .option-source {
-    color: color-mix(in srgb, var(--accent-blue) 80%, var(--text-muted));
-  }
 </style>

--- a/frontend/src/lib/components/terminal/LaunchMenu.test.ts
+++ b/frontend/src/lib/components/terminal/LaunchMenu.test.ts
@@ -49,12 +49,13 @@ describe("LaunchMenu", () => {
 
     await fireEvent.click(screen.getByRole("button", { name: "Launch" }));
 
-    expect(screen.getByRole("button", { name: /Codex/ })).toBeTruthy();
+    const codexOption = screen.getByRole("button", { name: /Codex/ });
+    expect(codexOption.textContent?.trim()).toBe("Codex");
     expect((screen.getByRole("button", { name: /Missing/ }) as HTMLButtonElement).disabled).toBe(true);
     expect(screen.queryByRole("button", { name: /Disabled config/ })).toBeNull();
-    expect(screen.getByRole("button", { name: /Shell/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Shell/ }).textContent?.trim()).toBe("Shell");
 
-    await fireEvent.click(screen.getByRole("button", { name: /Codex/ }));
+    await fireEvent.click(codexOption);
     expect(onLaunch).toHaveBeenCalledWith("codex");
   });
 });

--- a/frontend/src/lib/components/terminal/WorkspaceHome.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceHome.svelte
@@ -51,12 +51,6 @@
     return workspace?.mr_title ?? workspace?.git_head_ref ?? "Workspace";
   }
 
-  function sourceLabel(target: LaunchTarget): string {
-    if (target.source === "config") return "configured";
-    if (target.kind === "plain_shell") return "shell";
-    return "detected";
-  }
-
   function targetLabel(target: LaunchTarget): string {
     return target.kind === "plain_shell" ? "Shell" : target.label;
   }
@@ -127,7 +121,6 @@
             {/if}
           </span>
           <span class="card-label">{targetLabel(target)}</span>
-          <span class="card-source">{sourceLabel(target)}</span>
           {#if isLaunching}
             <span class="card-status">starting…</span>
           {/if}
@@ -290,7 +283,7 @@
 
   .launch-card {
     display: grid;
-    grid-template-columns: 16px 1fr auto;
+    grid-template-columns: 16px 1fr;
     align-items: center;
     gap: 4px 8px;
     /* min-height instead of fixed height: when a card flips into the
@@ -344,13 +337,6 @@
     white-space: nowrap;
     font-weight: 600;
     letter-spacing: 0.005em;
-  }
-
-  .card-source {
-    color: var(--text-muted);
-    font-size: var(--font-size-xs);
-    font-family: var(--font-mono);
-    letter-spacing: 0;
   }
 
   .card-status {

--- a/frontend/src/lib/components/terminal/WorkspaceHome.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceHome.test.ts
@@ -89,13 +89,11 @@ describe("WorkspaceHome", () => {
 
     expect(screen.getByText("Improve workspace UX")).toBeTruthy();
     expect(screen.getByText("/tmp/widget")).toBeTruthy();
-    expect(
-      (
-        screen.getByRole("button", {
-          name: "Codex",
-        }) as HTMLButtonElement
-      ).disabled,
-    ).toBe(false);
+    const codexLaunchButton = screen.getByRole("button", {
+      name: "Codex",
+    }) as HTMLButtonElement;
+    expect(codexLaunchButton.disabled).toBe(false);
+    expect(codexLaunchButton.textContent?.trim()).toBe("Codex");
     expect(
       (
         screen.getByRole("button", {
@@ -107,9 +105,14 @@ describe("WorkspaceHome", () => {
     expect(screen.queryByRole("button", { name: "Plain shell" })).toBeNull();
     expect(screen.queryByRole("button", { name: "shell" })).toBeNull();
 
-    await fireEvent.click(screen.getByRole("button", { name: "Codex" }));
+    const shellLaunchButton = screen.getByRole("button", {
+      name: "Shell",
+    }) as HTMLButtonElement;
+    expect(shellLaunchButton.textContent?.trim()).toBe("Shell");
+
+    await fireEvent.click(codexLaunchButton);
     expect(onLaunch).toHaveBeenCalledWith("codex");
-    await fireEvent.click(screen.getByRole("button", { name: "Shell" }));
+    await fireEvent.click(shellLaunchButton);
     expect(onLaunch).toHaveBeenCalledWith("plain_shell");
 
     await fireEvent.click(screen.getByRole("button", { name: /Codex\s+Running/ }));


### PR DESCRIPTION
Workspace launch options currently spend space on source labels that do not help maintainers choose a target.\n\n- Show only the target icon and name on workspace launch cards and toolbar options\n- Preserve disabled states, disabled-reason tooltips, and launch behavior\n\nValidation: focused component tests, the real-browser launch-target test, the seeded Chromium workspace test, and frontend checks pass. The full unit sweep reached 3,373 passing tests with one unrelated shared-flash assertion failing in frontend/src/App.test.ts.\n\n<sup>generated by a clanker</sup>