### PR TITLE
Fix private Markdown image previews

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
         "@playwright/test": "1.61.1",
         "@sveltejs/mcp": "0.1.25",
         "svelte-check": "4.7.1",
+        "typescript": "5.9.3",
         "vite-plus": "0.2.3",
       },
     },

--- a/context/error-handling.md
+++ b/context/error-handling.md
@@ -99,8 +99,9 @@ Translate `internal/platform` typed errors at the server boundary:
 | `provider_not_configured`, `missing_token`, `invalid_repo_ref`, `invalid_argument` | `400 badRequest` |
 | Unknown provider/platform failures | `502 upstreamError` |
 
-Context cancellation and deadline errors should pass through cancellation paths
-instead of being wrapped as provider failures.
+Cancellation and deadline errors pass through only when the request context is
+done; a provider child-context deadline while the request remains active is a
+`502 upstreamError` (`internal/server/markdown_images.go::markdownImageError`).
 
 ## Frontend Handling
 

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -178,6 +178,9 @@ owner actually resolves to an app installation. Gating it on whether the host ha
 any active app sends a PAT-backed owner that shares the host with another owner's
 app to an endpoint its credential cannot use, which fails even though the token
 chain "correctly" falls back to the PAT.
+- Private `user-attachments` reads are the exception to app-token-first reads:
+  GitHub returns 404 to installation tokens, so the repo-scoped image proxy must
+  use the user's PAT/`gh` chain (`internal/github/client.go::GetMarkdownImage`).
 Config may carry multiple `[[github_apps]]` rows for one host, but those rows
 represent distinct app credentials. Management commands must target one row by
 app owner/installation account or app id, and duplicate installation accounts on

--- a/context/platform-sync-invariants.md
+++ b/context/platform-sync-invariants.md
@@ -192,6 +192,10 @@ GitLab API calls address projects by numeric id or URL-escaped path with
 slashes. Middleman should prefer the stored provider id after resolution and
 preserve `path_with_namespace` as `repo_path`.
 
+GitLab private Markdown upload web URLs do not accept API-token authentication.
+Translate only repo-scoped upload URLs to the authenticated project-upload API;
+never proxy arbitrary provider URLs. (`internal/platform/gitlab/markdown_images.go::GetMarkdownImage`)
+
 GitLab merge request and issue `iid` values are repo-scoped numbers. Persist
 provider object ids separately from user-visible numbers, and scope events by
 provider identity so equal GitHub/GitLab ids do not collide.

--- a/context/platform-sync-invariants.md
+++ b/context/platform-sync-invariants.md
@@ -82,6 +82,10 @@ registry helpers return typed errors for missing providers or capabilities.
 
 - Missing optional capabilities should degrade that feature with a typed
   platform error, not break unrelated sync work.
+- Never put foreground deadlines on a shared provider HTTP client; scope them to
+  the operation context (`internal/platform/gitlab/client.go::NewClient`).
+- Resolve opaque provider repo IDs by `repo_path` before numeric-only operations
+  (`internal/platform/gitlab/client.go::projectScopedArg`).
 - `priority_repo` reorders a full run; `only_repo` restricts every repo-derived
   phase and must not delay full-run cadence. Resolve both by full identity, and
   never fall back from invalid exclusive scope. (`internal/github/sync.go::runOnce`)

--- a/context/provider-architecture.md
+++ b/context/provider-architecture.md
@@ -243,7 +243,8 @@ Frontend state should keep a reusable provider ref:
 Use `providerRouteParams()` and `providerItemPath()` or `providerRepoPath()` for
 repo-scoped requests. Do not hand-build `/api/v1` URLs or assume GitHub defaults
 inside components/stores. Host defaults may be omitted from URLs only by the
-shared route helper.
+shared route helper; browser resource URLs must use the configured API base so
+non-root deployments retain their `base_path` (`frontend/src/lib/api/runtime.ts::apiBaseURL`).
 
 ## Notification Identity
 

--- a/docs/superpowers/specs/2026-07-24-frontend-api-client-lint-design.md
+++ b/docs/superpowers/specs/2026-07-24-frontend-api-client-lint-design.md
@@ -1,0 +1,70 @@
+# Frontend API Client Lint Design
+
+## Problem
+
+Middleman already runs `frontend-api-client-check`, but the checker only looks
+for the contiguous text `/api/v1`. A production helper assembled the same
+prefix as `"/api" + "/v1"`, then built a browser image URL from it. The guard
+passed even though the URL bypassed the configured API base and broke
+deployments mounted below a non-root `base_path`.
+
+The guard must enforce the API access policy rather than one spelling of the
+forbidden string. Its diagnostic must also identify the approved replacement.
+
+## Considered Approaches
+
+1. Expand the text scanner with regular expressions for concatenated strings.
+   This is a small patch, but every new expression shape creates another escape.
+2. Parse frontend source and evaluate statically resolvable string expressions.
+   This catches literals, concatenation, template strings, and constant aliases
+   while retaining precise file and line diagnostics. This is the selected
+   approach.
+3. Replace the script with a custom general-purpose linter plugin. That offers
+   deeper data-flow analysis, but adds integration and maintenance cost beyond
+   the narrow policy being enforced.
+
+## Design
+
+The existing guardrail command and CI integration remain unchanged. The
+checker will parse production JavaScript, TypeScript, JSX, TSX, and Svelte
+script content and resolve constant string expressions far enough to recognize
+the Middleman REST prefix even when it is split or passed through aliases.
+
+Production REST requests must use the generated client. Provider-aware route
+parameters continue to come from `providerItemPath`, `providerRepoPath`, and
+the related typed helpers; those helpers return OpenAPI paths without an
+`/api/v1` mount prefix.
+
+Browser-owned resource navigation, such as an `<img src>`, cannot be performed
+by `openapi-fetch`. It must use a shared resource-URL helper derived from the
+same configured API base URL as the generated client. The Markdown image proxy
+will use that helper, so non-root `base_path` deployments resolve correctly.
+
+SSE, WebSocket, and NDJSON transports remain explicit exceptions because the
+generated REST client does not implement their connection semantics. Each
+exception stays narrowly associated with its existing transport rather than
+becoming a general file or directory exemption.
+
+## Diagnostics
+
+Each violation will identify the approved replacement:
+
+- REST request: use the generated runtime client or the injected typed UI
+  client.
+- Browser resource URL: use the configured API resource-URL helper.
+- Streaming connection: use the named, allowlisted transport helper.
+
+The message will not merely report that a URL is forbidden.
+
+## Verification
+
+Script tests will first reproduce the missed split-literal and constant-alias
+case, then cover template construction, allowed generated-client base setup,
+browser resource URLs, test/generated-file exclusions, and the existing
+streaming exceptions. The production scan must flag the current Markdown image
+URL before its fix and pass afterward.
+
+Markdown rendering tests will cover both root and prefixed API bases. The normal
+frontend guardrail, script-test, formatting, lint, type-check, and relevant UI
+test lanes will run before completion. No OpenAPI operation changes are
+expected; `make api-generate` must remain clean.

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -5198,6 +5198,8 @@ components:
           type: boolean
         read_labels:
           type: boolean
+        read_markdown_images:
+          type: boolean
         read_merge_requests:
           type: boolean
         read_releases:
@@ -5240,6 +5242,7 @@ components:
         - read_releases
         - read_ci
         - read_labels
+        - read_markdown_images
         - comment_mutation
         - state_mutation
         - merge_mutation
@@ -13619,6 +13622,91 @@ paths:
       summary: List repository labels
       tags:
         - Repositories
+  /host/{platform_host}/repo/{provider}/{owner}/{name}/markdown-image:
+    get:
+      operationId: get-markdown-image-on-host
+      parameters:
+        - in: path
+          name: provider
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: platform_host
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: owner
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: source
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            image/avif:
+              schema:
+                contentMediaType: application/octet-stream
+                format: binary
+                type: string
+            image/bmp:
+              schema:
+                contentMediaType: application/octet-stream
+                format: binary
+                type: string
+            image/gif:
+              schema:
+                contentMediaType: application/octet-stream
+                format: binary
+                type: string
+            image/jpeg:
+              schema:
+                contentMediaType: application/octet-stream
+                format: binary
+                type: string
+            image/png:
+              schema:
+                contentMediaType: application/octet-stream
+                format: binary
+                type: string
+            image/webp:
+              schema:
+                contentMediaType: application/octet-stream
+                format: binary
+                type: string
+          description: Image response
+          headers:
+            Cache-Control:
+              schema:
+                type: string
+            Content-Length:
+              schema:
+                type: string
+            Content-Type:
+              schema:
+                type: string
+            X-Content-Type-Options:
+              schema:
+                type: string
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Error
+      summary: Get markdown image
+      tags:
+        - Repositories
   /host/{platform_host}/repo/{provider}/{owner}/{name}/refresh:
     post:
       operationId: refresh-repo-on-host
@@ -18183,6 +18271,86 @@ paths:
                 $ref: "#/components/schemas/ProblemError"
           description: Error
       summary: List repository labels
+      tags:
+        - Repositories
+  /repo/{provider}/{owner}/{name}/markdown-image:
+    get:
+      operationId: get-markdown-image
+      parameters:
+        - in: path
+          name: provider
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: owner
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: source
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            image/avif:
+              schema:
+                contentMediaType: application/octet-stream
+                format: binary
+                type: string
+            image/bmp:
+              schema:
+                contentMediaType: application/octet-stream
+                format: binary
+                type: string
+            image/gif:
+              schema:
+                contentMediaType: application/octet-stream
+                format: binary
+                type: string
+            image/jpeg:
+              schema:
+                contentMediaType: application/octet-stream
+                format: binary
+                type: string
+            image/png:
+              schema:
+                contentMediaType: application/octet-stream
+                format: binary
+                type: string
+            image/webp:
+              schema:
+                contentMediaType: application/octet-stream
+                format: binary
+                type: string
+          description: Image response
+          headers:
+            Cache-Control:
+              schema:
+                type: string
+            Content-Length:
+              schema:
+                type: string
+            Content-Type:
+              schema:
+                type: string
+            X-Content-Type-Options:
+              schema:
+                type: string
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Error
+      summary: Get markdown image
       tags:
         - Repositories
   /repo/{provider}/{owner}/{name}/refresh:

--- a/frontend/src/lib/api/docs/api.ts
+++ b/frontend/src/lib/api/docs/api.ts
@@ -1,4 +1,5 @@
 import type { components } from "@middleman/ui/api/schema";
+import { configuredAPIBaseURL } from "@middleman/ui/api/runtime-base";
 import type {
   AddFolderInput,
   BrowseResponse,
@@ -204,8 +205,7 @@ function resourceURLFor(baseURL: string | undefined, path: string): URL {
 }
 
 function defaultAPIBaseURL(): string {
-  const basePath = typeof window !== "undefined" ? (window.__BASE_PATH__ ?? "/") : "/";
-  return new URL(`${basePath.replace(/\/$/, "")}/api/v1`, runtimeOrigin()).toString();
+  return configuredAPIBaseURL();
 }
 
 function runtimeOrigin(): string {

--- a/frontend/src/lib/api/kata/daemons.test.ts
+++ b/frontend/src/lib/api/kata/daemons.test.ts
@@ -129,9 +129,7 @@ describe("kata api helpers", () => {
 
     expect(seenURL?.pathname).toBe("/middleman/api/v1/kata/daemons");
     expect(daemons.map((d) => d.id)).toEqual(["home"]);
-    expect(kataProxyPath("/api/v1/projects?include=stats")).toBe(
-      "/middleman/api/v1/kata/proxy/api/v1/projects?include=stats",
-    );
+    expect(kataProxyPath("/projects?include=stats")).toBe("/middleman/api/v1/kata/proxy/api/v1/projects?include=stats");
   });
 
   it("returns an empty roster when the control endpoint is absent", async () => {

--- a/frontend/src/lib/api/kata/daemons.ts
+++ b/frontend/src/lib/api/kata/daemons.ts
@@ -1,3 +1,4 @@
+import { configuredAPIBaseURL, configuredAPIPath } from "@middleman/ui/api/runtime-base";
 import type { components } from "@middleman/ui/api/schema";
 
 import { createRuntimeClient } from "../runtime.js";
@@ -6,23 +7,15 @@ export const KATA_DAEMON_HEADER = "X-Middleman-Kata-Daemon";
 
 export type KataDaemonInfo = components["schemas"]["KataDaemonResponse"];
 
-const API_PREFIX = "/api" + "/v1";
-const KATA_PROXY_ROUTE = `${API_PREFIX}/kata/proxy`;
-
-function appPath(path: string): string {
-  const basePath = typeof window !== "undefined" ? (window.__BASE_PATH__ ?? "/") : "/";
-  const prefix = basePath === "/" ? "" : basePath.replace(/\/$/, "");
-  return `${prefix}${path}`;
-}
+const KATA_PROXY_ROUTE = "/kata/proxy";
 
 function apiBaseURL(): string {
-  const origin = typeof window !== "undefined" ? window.location.origin : "http://localhost";
-  return new URL(appPath(API_PREFIX), origin).toString();
+  return configuredAPIBaseURL();
 }
 
 export function kataProxyPath(path: string): string {
   const normalized = path.startsWith("/") ? path : `/${path}`;
-  return appPath(`${KATA_PROXY_ROUTE}${normalized}`);
+  return configuredAPIPath(`${KATA_PROXY_ROUTE}${normalized}`);
 }
 
 export async function fetchKataDaemons(fetchImpl: typeof fetch = fetch): Promise<KataDaemonInfo[]> {

--- a/frontend/src/lib/api/kata/daemons.ts
+++ b/frontend/src/lib/api/kata/daemons.ts
@@ -14,8 +14,9 @@ function apiBaseURL(): string {
 }
 
 export function kataProxyPath(path: string): string {
+  const kataUpstreamAPIRoute = "/api/v1";
   const normalized = path.startsWith("/") ? path : `/${path}`;
-  return configuredAPIPath(`${KATA_PROXY_ROUTE}${normalized}`);
+  return configuredAPIPath(`${KATA_PROXY_ROUTE}${kataUpstreamAPIRoute}${normalized}`);
 }
 
 export async function fetchKataDaemons(fetchImpl: typeof fetch = fetch): Promise<KataDaemonInfo[]> {

--- a/frontend/src/lib/api/kata/taskClient.test.ts
+++ b/frontend/src/lib/api/kata/taskClient.test.ts
@@ -164,6 +164,29 @@ describe("kata mutation and recurrence HTTP client", () => {
     expect(calls.map((call) => [proxyPath(call.url), call.method])).toEqual([["/api/v1/projects", "POST"]]);
   });
 
+  test("keeps the Kata API path independent of Middleman's configured base path", async () => {
+    const previousBasePath = window.__BASE_PATH__;
+    window.__BASE_PATH__ = "/middleman/";
+    try {
+      const { calls, fetchImpl } = createFetchStub({
+        "/api/v1/projects": { body: { project: project("project-new", "New") } },
+      });
+      const api = createKataTaskAPI({ fetchImpl });
+
+      await api.createProject("New", { daemonId: "home" });
+
+      const requestURL = calls[0]?.url;
+      if (requestURL === undefined) throw new Error("expected a Kata proxy request");
+      expect(new URL(requestURL, window.location.origin).pathname).toBe("/middleman/api/v1/kata/proxy/api/v1/projects");
+    } finally {
+      if (previousBasePath === undefined) {
+        delete window.__BASE_PATH__;
+      } else {
+        window.__BASE_PATH__ = previousBasePath;
+      }
+    }
+  });
+
   test("creates tasks with metadata on one explicitly pinned daemon", async () => {
     const { calls, fetchImpl } = createFetchStub({
       "/api/v1/projects/7/issues": {

--- a/frontend/src/lib/api/kata/taskClient.ts
+++ b/frontend/src/lib/api/kata/taskClient.ts
@@ -1,5 +1,3 @@
-import { configuredAPIPath } from "@middleman/ui/api/runtime-base";
-
 import { KATA_DAEMON_HEADER, kataProxyPath } from "./daemons.js";
 import { normalizeKataRecurrenceResponse, normalizeKataRecurrences } from "./taskNormalizers.js";
 import type {
@@ -58,7 +56,7 @@ function parseErrorEnvelope(body: unknown, status: number): ErrorEnvelope {
 }
 
 function taskPath(path: string): string {
-  return configuredAPIPath(path);
+  return path.startsWith("/") ? path : `/${path}`;
 }
 
 interface KataCreateProtocolResponse extends KataTaskMutationResponse {

--- a/frontend/src/lib/api/kata/taskClient.ts
+++ b/frontend/src/lib/api/kata/taskClient.ts
@@ -1,3 +1,5 @@
+import { configuredAPIPath } from "@middleman/ui/api/runtime-base";
+
 import { KATA_DAEMON_HEADER, kataProxyPath } from "./daemons.js";
 import { normalizeKataRecurrenceResponse, normalizeKataRecurrences } from "./taskNormalizers.js";
 import type {
@@ -34,8 +36,6 @@ interface ErrorEnvelope {
   details?: unknown;
 }
 
-const KATA_TASK_API_PREFIX = "/api" + "/v1";
-
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -58,7 +58,7 @@ function parseErrorEnvelope(body: unknown, status: number): ErrorEnvelope {
 }
 
 function taskPath(path: string): string {
-  return `${KATA_TASK_API_PREFIX}${path}`;
+  return configuredAPIPath(path);
 }
 
 interface KataCreateProtocolResponse extends KataTaskMutationResponse {

--- a/frontend/src/lib/api/messages/api.ts
+++ b/frontend/src/lib/api/messages/api.ts
@@ -1,4 +1,5 @@
 import type { components } from "@middleman/ui/api/schema";
+import { configuredAPIBaseURL } from "@middleman/ui/api/runtime-base";
 
 import { apiErrorMessage, createRuntimeClient } from "../runtime.js";
 import type {
@@ -77,9 +78,7 @@ function resourceURLFor(baseURL: string | undefined, path: string, query: Record
 }
 
 function defaultAPIBaseURL(): string {
-  const basePath = typeof window !== "undefined" ? (window.__BASE_PATH__ ?? "/") : "/";
-  const origin = typeof window !== "undefined" ? window.location.origin : "http://localhost";
-  return new URL(`${basePath.replace(/\/$/, "")}/api/v1`, origin).toString();
+  return configuredAPIBaseURL();
 }
 
 function serializeHideDeleted(value: boolean | undefined): string | undefined {

--- a/frontend/src/lib/api/runtime.ts
+++ b/frontend/src/lib/api/runtime.ts
@@ -1,16 +1,13 @@
 import type { QuerySerializerOptions } from "openapi-fetch";
 
 import { createAPIClient } from "@middleman/ui/api/client";
+import { configuredAPIBaseURL } from "@middleman/ui/api/runtime-base";
 import type { components } from "@middleman/ui/api/schema";
 import { csrfFetch, type FetchFn } from "@middleman/ui/api/csrf";
 
 import { traceHeadersForRequest } from "../instrumentation/traceContext.js";
 
-const basePath = typeof window !== "undefined" ? (window.__BASE_PATH__ ?? "/") : "/";
-const baseUrl =
-  typeof window !== "undefined"
-    ? new URL(`${basePath.replace(/\/$/, "")}/api/v1`, window.location.origin).toString()
-    : "http://localhost/api/v1";
+const baseUrl = configuredAPIBaseURL();
 
 export const apiBaseURL = baseUrl;
 

--- a/frontend/src/lib/api/workspace-runtime.test.ts
+++ b/frontend/src/lib/api/workspace-runtime.test.ts
@@ -11,6 +11,11 @@ import {
 } from "./workspace-runtime.js";
 import { beginInteractionTrace, endInteractionTrace } from "../instrumentation/traceContext.js";
 
+function capturedRequest(call: Parameters<RuntimeFetch> | undefined): Request {
+  if (!call) throw new Error("expected a runtime request");
+  return new Request(call[0], call[1]);
+}
+
 describe("workspace-runtime api", () => {
   afterEach(() => {
     delete window.__BASE_PATH__;
@@ -34,7 +39,7 @@ describe("workspace-runtime api", () => {
 
     const runtime = await getWorkspaceRuntime("ws-1", fetchMock);
 
-    expect(fetchMock.mock.calls[0]?.[0]).toBe("/api/v1/workspaces/ws-1/runtime");
+    expect(new URL(capturedRequest(fetchMock.mock.calls[0]).url).pathname).toBe("/api/v1/workspaces/ws-1/runtime");
     expect(runtime.launch_targets).toEqual([]);
     expect(runtime.sessions).toEqual([]);
   });
@@ -82,23 +87,22 @@ describe("workspace-runtime api", () => {
     await renameWorkspaceSession("ws-1", "ws-1:helper", "Review helper", fetchMock);
     await stopWorkspaceSession("ws-1", "ws-1:helper", fetchMock);
 
-    expect(fetchMock.mock.calls[0]?.[0]).toBe("/api/v1/workspaces/ws-1/runtime/sessions");
-    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
-      method: "POST",
-      body: JSON.stringify({ target_key: "helper" }),
-    });
-    expect(new Headers(fetchMock.mock.calls[0]?.[1]?.headers).get("Content-Type")).toBe("application/json");
-    expect(fetchMock.mock.calls[1]?.[0]).toBe("/api/v1/workspaces/ws-1/runtime/sessions/ws-1%3Ahelper");
-    expect(fetchMock.mock.calls[1]?.[1]).toMatchObject({
-      method: "PATCH",
-      body: JSON.stringify({ label: "Review helper" }),
-    });
-    expect(new Headers(fetchMock.mock.calls[1]?.[1]?.headers).get("Content-Type")).toBe("application/json");
-    expect(fetchMock.mock.calls[2]?.[0]).toBe("/api/v1/workspaces/ws-1/runtime/sessions/ws-1%3Ahelper");
-    expect(fetchMock.mock.calls[2]?.[1]).toMatchObject({
-      method: "DELETE",
-    });
-    expect(new Headers(fetchMock.mock.calls[2]?.[1]?.headers).get("Content-Type")).toBe("application/json");
+    const launchRequest = capturedRequest(fetchMock.mock.calls[0]);
+    expect(new URL(launchRequest.url).pathname).toBe("/api/v1/workspaces/ws-1/runtime/sessions");
+    expect(launchRequest.method).toBe("POST");
+    await expect(launchRequest.clone().json()).resolves.toEqual({ target_key: "helper" });
+    expect(launchRequest.headers.get("Content-Type")).toBe("application/json");
+
+    const renameRequest = capturedRequest(fetchMock.mock.calls[1]);
+    expect(new URL(renameRequest.url).pathname).toBe("/api/v1/workspaces/ws-1/runtime/sessions/ws-1%3Ahelper");
+    expect(renameRequest.method).toBe("PATCH");
+    await expect(renameRequest.clone().json()).resolves.toEqual({ label: "Review helper" });
+    expect(renameRequest.headers.get("Content-Type")).toBe("application/json");
+
+    const stopRequest = capturedRequest(fetchMock.mock.calls[2]);
+    expect(new URL(stopRequest.url).pathname).toBe("/api/v1/workspaces/ws-1/runtime/sessions/ws-1%3Ahelper");
+    expect(stopRequest.method).toBe("DELETE");
+    expect(stopRequest.headers.get("Content-Type")).toBe("application/json");
   });
 
   it("includes display region when launching a workspace session", async () => {
@@ -124,15 +128,14 @@ describe("workspace-runtime api", () => {
 
     await launchWorkspaceSession("ws-1", "plain_shell", undefined, "workflow", fetchMock);
 
-    expect(fetchMock.mock.calls[0]?.[0]).toBe("/api/v1/workspaces/ws-1/runtime/sessions");
-    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
-      method: "POST",
-      body: JSON.stringify({
-        target_key: "plain_shell",
-        display_region: "workflow",
-      }),
+    const request = capturedRequest(fetchMock.mock.calls[0]);
+    expect(new URL(request.url).pathname).toBe("/api/v1/workspaces/ws-1/runtime/sessions");
+    expect(request.method).toBe("POST");
+    await expect(request.clone().json()).resolves.toEqual({
+      target_key: "plain_shell",
+      display_region: "workflow",
     });
-    expect(new Headers(fetchMock.mock.calls[0]?.[1]?.headers).get("Content-Type")).toBe("application/json");
+    expect(request.headers.get("Content-Type")).toBe("application/json");
   });
 
   it("adds W3C trace headers to runtime reads and mutations", async () => {
@@ -164,9 +167,7 @@ describe("workspace-runtime api", () => {
     await renameWorkspaceSession("ws-1", "ws-1:helper", "Review helper", fetchMock);
     await stopWorkspaceSession("ws-1", "ws-1:helper", fetchMock);
 
-    const requests = fetchMock.mock.calls.map(([input, init]) =>
-      input instanceof Request ? input : new Request(new URL(String(input), "http://localhost"), init),
-    );
+    const requests = fetchMock.mock.calls.map((call) => capturedRequest(call));
     expect(requests).toHaveLength(4);
     for (const request of requests) {
       expect(request.headers.get("traceparent")).toMatch(new RegExp(`^00-${traceId}-[0-9a-f]{16}-01$`));
@@ -199,7 +200,9 @@ describe("workspace-runtime api", () => {
 
     await getWorkspaceRuntime("ws-1", fetchMock);
 
-    expect(fetchMock.mock.calls[0]?.[0]).toBe("/middleman/api/v1/workspaces/ws-1/runtime");
+    expect(new URL(capturedRequest(fetchMock.mock.calls[0]).url).pathname).toBe(
+      "/middleman/api/v1/workspaces/ws-1/runtime",
+    );
     expect(workspaceSessionWebSocketPath("ws-1", "ws-1:helper")).toBe(
       "/middleman/ws/v1/workspaces/ws-1/runtime/sessions/ws-1%3Ahelper/terminal",
     );

--- a/frontend/src/lib/api/workspace-runtime.ts
+++ b/frontend/src/lib/api/workspace-runtime.ts
@@ -1,6 +1,7 @@
 import type { LaunchTarget, RuntimeSession, WorkspaceRuntime } from "@middleman/ui/api/types";
+import { configuredAPIBaseURL } from "@middleman/ui/api/runtime-base";
 
-import { tracedFetch } from "./runtime.js";
+import { createRuntimeClient } from "./runtime.js";
 
 export type WorkspaceRuntimeState = Omit<WorkspaceRuntime, "launch_targets" | "sessions"> & {
   launch_targets: LaunchTarget[];
@@ -14,10 +15,6 @@ function basePath(): string {
   return path.replace(/\/$/, "");
 }
 
-function apiBaseUrl(): string {
-  return `${basePath()}/api/v1`;
-}
-
 function wsBaseUrl(): string {
   return `${basePath()}/ws/v1`;
 }
@@ -26,19 +23,26 @@ function hostPrefix(hostKey?: string): string {
   return hostKey ? `/fleet/hosts/${encodeURIComponent(hostKey)}` : "";
 }
 
-function workspaceRuntimeURL(workspaceId: string, hostKey?: string): string {
-  return `${apiBaseUrl()}${hostPrefix(hostKey)}/workspaces/${encodeURIComponent(workspaceId)}/runtime`;
+function problemMessage(error: unknown): string | undefined {
+  if (typeof error !== "object" || error === null) return undefined;
+  if ("detail" in error && typeof error.detail === "string") return error.detail;
+  if ("title" in error && typeof error.title === "string") return error.title;
+  return undefined;
 }
 
-async function readJSON<T>(response: Response, fallback: string): Promise<T> {
-  if (response.ok) {
-    return (await response.json()) as T;
+function runtimeResult<T>(data: unknown, error: unknown, response: Response, fallback: string): T {
+  if (response.ok && data !== undefined) {
+    return data as T;
   }
-  const body = (await response.json().catch(() => ({}))) as {
-    detail?: string;
-    title?: string;
-  };
-  throw new Error(body.detail ?? body.title ?? fallback);
+  throw new Error(problemMessage(error) ?? fallback);
+}
+
+function runtimeFetch(hostKeyOrFetch: string | RuntimeFetch | undefined, fallback: RuntimeFetch): RuntimeFetch {
+  return typeof hostKeyOrFetch === "function" ? hostKeyOrFetch : fallback;
+}
+
+function workspaceRuntimeClient(fetchImpl: RuntimeFetch) {
+  return createRuntimeClient(fetchImpl, configuredAPIBaseURL());
 }
 
 export async function getWorkspaceRuntime(
@@ -47,9 +51,20 @@ export async function getWorkspaceRuntime(
   fetchFn: RuntimeFetch = fetch,
 ): Promise<WorkspaceRuntimeState> {
   const hostKey = typeof hostKeyOrFetch === "string" ? hostKeyOrFetch : undefined;
-  const runtimeFetch = tracedFetch(typeof hostKeyOrFetch === "function" ? hostKeyOrFetch : fetchFn);
-  const response = await runtimeFetch(workspaceRuntimeURL(workspaceId, hostKey));
-  const runtime = await readJSON<WorkspaceRuntime>(response, `GET workspace runtime failed (${response.status})`);
+  const client = workspaceRuntimeClient(runtimeFetch(hostKeyOrFetch, fetchFn));
+  const result = hostKey
+    ? await client.GET("/fleet/hosts/{host_key}/workspaces/{id}/runtime", {
+        params: { path: { host_key: hostKey, id: workspaceId } },
+      })
+    : await client.GET("/workspaces/{id}/runtime", {
+        params: { path: { id: workspaceId } },
+      });
+  const runtime = runtimeResult<WorkspaceRuntime>(
+    result.data,
+    result.error,
+    result.response,
+    `GET workspace runtime failed (${result.response.status})`,
+  );
   return {
     ...runtime,
     launch_targets: runtime.launch_targets ?? [],
@@ -66,22 +81,32 @@ export async function launchWorkspaceSession(
 ): Promise<RuntimeSession> {
   const hostKey = typeof hostKeyOrRegionOrFetch === "string" ? hostKeyOrRegionOrFetch : undefined;
   const displayRegion = regionOrFetch === "workflow" || regionOrFetch === "terminal" ? regionOrFetch : undefined;
-  const runtimeFetch = tracedFetch(
+  const fetchImpl =
     typeof hostKeyOrRegionOrFetch === "function"
       ? hostKeyOrRegionOrFetch
       : typeof regionOrFetch === "function"
         ? regionOrFetch
-        : fetchFn,
+        : fetchFn;
+  const client = workspaceRuntimeClient(fetchImpl);
+  const body = {
+    target_key: targetKey,
+    ...(displayRegion ? { display_region: displayRegion } : {}),
+  };
+  const result = hostKey
+    ? await client.POST("/fleet/hosts/{host_key}/workspaces/{id}/runtime/sessions", {
+        params: { path: { host_key: hostKey, id: workspaceId } },
+        body,
+      })
+    : await client.POST("/workspaces/{id}/runtime/sessions", {
+        params: { path: { id: workspaceId } },
+        body,
+      });
+  return runtimeResult<RuntimeSession>(
+    result.data,
+    result.error,
+    result.response,
+    `Launch session failed (${result.response.status})`,
   );
-  const response = await runtimeFetch(`${workspaceRuntimeURL(workspaceId, hostKey)}/sessions`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      target_key: targetKey,
-      ...(displayRegion ? { display_region: displayRegion } : {}),
-    }),
-  });
-  return readJSON<RuntimeSession>(response, `Launch session failed (${response.status})`);
 }
 
 export async function stopWorkspaceSession(
@@ -91,16 +116,18 @@ export async function stopWorkspaceSession(
   fetchFn: RuntimeFetch = fetch,
 ): Promise<void> {
   const hostKey = typeof hostKeyOrFetch === "string" ? hostKeyOrFetch : undefined;
-  const runtimeFetch = tracedFetch(typeof hostKeyOrFetch === "function" ? hostKeyOrFetch : fetchFn);
-  const response = await runtimeFetch(
-    `${workspaceRuntimeURL(workspaceId, hostKey)}/sessions/${encodeURIComponent(sessionKey)}`,
-    {
-      method: "DELETE",
-      headers: { "Content-Type": "application/json" },
-    },
-  );
-  if (!response.ok && response.status !== 204) {
-    await readJSON<unknown>(response, `Stop session failed (${response.status})`);
+  const client = workspaceRuntimeClient(runtimeFetch(hostKeyOrFetch, fetchFn));
+  const result = hostKey
+    ? await client.DELETE("/fleet/hosts/{host_key}/workspaces/{id}/runtime/sessions/{session_key}", {
+        params: { path: { host_key: hostKey, id: workspaceId, session_key: sessionKey } },
+        headers: { "Content-Type": "application/json" },
+      })
+    : await client.DELETE("/workspaces/{id}/runtime/sessions/{session_key}", {
+        params: { path: { id: workspaceId, session_key: sessionKey } },
+        headers: { "Content-Type": "application/json" },
+      });
+  if (!result.response.ok && result.response.status !== 204) {
+    throw new Error(problemMessage(result.error) ?? `Stop session failed (${result.response.status})`);
   }
 }
 
@@ -112,16 +139,22 @@ export async function renameWorkspaceSession(
   fetchFn: RuntimeFetch = fetch,
 ): Promise<RuntimeSession> {
   const hostKey = typeof hostKeyOrFetch === "string" ? hostKeyOrFetch : undefined;
-  const runtimeFetch = tracedFetch(typeof hostKeyOrFetch === "function" ? hostKeyOrFetch : fetchFn);
-  const response = await runtimeFetch(
-    `${workspaceRuntimeURL(workspaceId, hostKey)}/sessions/${encodeURIComponent(sessionKey)}`,
-    {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ label }),
-    },
+  const client = workspaceRuntimeClient(runtimeFetch(hostKeyOrFetch, fetchFn));
+  const result = hostKey
+    ? await client.PATCH("/fleet/hosts/{host_key}/workspaces/{id}/runtime/sessions/{session_key}", {
+        params: { path: { host_key: hostKey, id: workspaceId, session_key: sessionKey } },
+        body: { label },
+      })
+    : await client.PATCH("/workspaces/{id}/runtime/sessions/{session_key}", {
+        params: { path: { id: workspaceId, session_key: sessionKey } },
+        body: { label },
+      });
+  return runtimeResult<RuntimeSession>(
+    result.data,
+    result.error,
+    result.response,
+    `Rename session failed (${result.response.status})`,
   );
-  return readJSON<RuntimeSession>(response, `Rename session failed (${response.status})`);
 }
 
 export function workspaceSessionWebSocketPath(workspaceId: string, sessionKey: string, hostKey?: string): string {

--- a/frontend/src/lib/components/repositories/repoSummary.ts
+++ b/frontend/src/lib/components/repositories/repoSummary.ts
@@ -34,6 +34,7 @@ export const defaultProviderCapabilities: ProviderCapabilities = {
   read_releases: true,
   read_ci: true,
   read_labels: false,
+  read_markdown_images: false,
   comment_mutation: true,
   state_mutation: true,
   merge_mutation: true,

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -2946,6 +2946,7 @@ type ProviderCapabilitiesResponse struct {
 	ReadComments                bool      `json:"read_comments"`
 	ReadIssues                  bool      `json:"read_issues"`
 	ReadLabels                  bool      `json:"read_labels"`
+	ReadMarkdownImages          bool      `json:"read_markdown_images"`
 	ReadMergeRequests           bool      `json:"read_merge_requests"`
 	ReadReleases                bool      `json:"read_releases"`
 	ReadRepositories            bool      `json:"read_repositories"`
@@ -4471,6 +4472,11 @@ type GetRepoCommitDiffOnHostParams struct {
 	Whitespace *string `form:"whitespace,omitempty" json:"whitespace,omitempty"`
 }
 
+// GetMarkdownImageOnHostParams defines parameters for GetMarkdownImageOnHost.
+type GetMarkdownImageOnHostParams struct {
+	Source *string `form:"source,omitempty" json:"source,omitempty"`
+}
+
 // ResolveRepoItemOnHostParams defines parameters for ResolveRepoItemOnHost.
 type ResolveRepoItemOnHostParams struct {
 	// ItemType Optional item type hint for providers whose issues and merge requests have separate number spaces.
@@ -4711,6 +4717,11 @@ type GetCommentAutocompleteParams struct {
 // GetRepoCommitDiffParams defines parameters for GetRepoCommitDiff.
 type GetRepoCommitDiffParams struct {
 	Whitespace *string `form:"whitespace,omitempty" json:"whitespace,omitempty"`
+}
+
+// GetMarkdownImageParams defines parameters for GetMarkdownImage.
+type GetMarkdownImageParams struct {
+	Source *string `form:"source,omitempty" json:"source,omitempty"`
 }
 
 // ResolveRepoItemParams defines parameters for ResolveRepoItem.
@@ -5708,6 +5719,9 @@ type ClientInterface interface {
 	// ListRepoLabelsOnHost request
 	ListRepoLabelsOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// GetMarkdownImageOnHost request
+	GetMarkdownImageOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, params *GetMarkdownImageOnHostParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// RefreshRepoOnHost request
 	RefreshRepoOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -6121,6 +6135,9 @@ type ClientInterface interface {
 
 	// ListRepoLabels request
 	ListRepoLabels(ctx context.Context, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetMarkdownImage request
+	GetMarkdownImage(ctx context.Context, provider string, owner string, name string, params *GetMarkdownImageParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// RefreshRepo request
 	RefreshRepo(ctx context.Context, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -8444,6 +8461,18 @@ func (c *Client) ListRepoLabelsOnHost(ctx context.Context, platformHost string, 
 	return c.Client.Do(req)
 }
 
+func (c *Client) GetMarkdownImageOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, params *GetMarkdownImageOnHostParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetMarkdownImageOnHostRequest(c.Server, platformHost, provider, owner, name, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) RefreshRepoOnHost(ctx context.Context, platformHost string, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewRefreshRepoOnHostRequest(c.Server, platformHost, provider, owner, name)
 	if err != nil {
@@ -10258,6 +10287,18 @@ func (c *Client) GetRepoCommitDiff(ctx context.Context, provider string, owner s
 
 func (c *Client) ListRepoLabels(ctx context.Context, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewListRepoLabelsRequest(c.Server, provider, owner, name)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetMarkdownImage(ctx context.Context, provider string, owner string, name string, params *GetMarkdownImageParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetMarkdownImageRequest(c.Server, provider, owner, name, params)
 	if err != nil {
 		return nil, err
 	}
@@ -19647,6 +19688,88 @@ func NewListRepoLabelsOnHostRequest(server string, platformHost string, provider
 	return req, nil
 }
 
+// NewGetMarkdownImageOnHostRequest generates requests for GetMarkdownImageOnHost
+func NewGetMarkdownImageOnHostRequest(server string, platformHost string, provider string, owner string, name string, params *GetMarkdownImageOnHostParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "platform_host", platformHost, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "provider", provider, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "owner", owner, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam3 string
+
+	pathParam3, err = runtime.StyleParamWithOptions("simple", false, "name", name, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/host/%s/repo/%s/%s/%s/markdown-image", pathParam0, pathParam1, pathParam2, pathParam3)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if params.Source != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "source", *params.Source, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewRefreshRepoOnHostRequest generates requests for RefreshRepoOnHost
 func NewRefreshRepoOnHostRequest(server string, platformHost string, provider string, owner string, name string) (*http.Request, error) {
 	var err error
@@ -26676,6 +26799,81 @@ func NewListRepoLabelsRequest(server string, provider string, owner string, name
 	return req, nil
 }
 
+// NewGetMarkdownImageRequest generates requests for GetMarkdownImage
+func NewGetMarkdownImageRequest(server string, provider string, owner string, name string, params *GetMarkdownImageParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "provider", provider, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithOptions("simple", false, "owner", owner, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam2 string
+
+	pathParam2, err = runtime.StyleParamWithOptions("simple", false, "name", name, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/repo/%s/%s/%s/markdown-image", pathParam0, pathParam1, pathParam2)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if params.Source != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "source", *params.Source, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewRefreshRepoRequest generates requests for RefreshRepo
 func NewRefreshRepoRequest(server string, provider string, owner string, name string) (*http.Request, error) {
 	var err error
@@ -29470,6 +29668,9 @@ type ClientWithResponsesInterface interface {
 	// ListRepoLabelsOnHostWithResponse request
 	ListRepoLabelsOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*ListRepoLabelsOnHostResponse, error)
 
+	// GetMarkdownImageOnHostWithResponse request
+	GetMarkdownImageOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, params *GetMarkdownImageOnHostParams, reqEditors ...RequestEditorFn) (*GetMarkdownImageOnHostResponse, error)
+
 	// RefreshRepoOnHostWithResponse request
 	RefreshRepoOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*RefreshRepoOnHostResponse, error)
 
@@ -29880,6 +30081,9 @@ type ClientWithResponsesInterface interface {
 
 	// ListRepoLabelsWithResponse request
 	ListRepoLabelsWithResponse(ctx context.Context, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*ListRepoLabelsResponse, error)
+
+	// GetMarkdownImageWithResponse request
+	GetMarkdownImageWithResponse(ctx context.Context, provider string, owner string, name string, params *GetMarkdownImageParams, reqEditors ...RequestEditorFn) (*GetMarkdownImageResponse, error)
 
 	// RefreshRepoWithResponse request
 	RefreshRepoWithResponse(ctx context.Context, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*RefreshRepoResponse, error)
@@ -33019,6 +33223,28 @@ func (r ListRepoLabelsOnHostResponse) StatusCode() int {
 	return 0
 }
 
+type GetMarkdownImageOnHostResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r GetMarkdownImageOnHostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetMarkdownImageOnHostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type RefreshRepoOnHostResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
@@ -35501,6 +35727,28 @@ func (r ListRepoLabelsResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r ListRepoLabelsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetMarkdownImageResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r GetMarkdownImageResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetMarkdownImageResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -38217,6 +38465,15 @@ func (c *ClientWithResponses) ListRepoLabelsOnHostWithResponse(ctx context.Conte
 	return ParseListRepoLabelsOnHostResponse(rsp)
 }
 
+// GetMarkdownImageOnHostWithResponse request returning *GetMarkdownImageOnHostResponse
+func (c *ClientWithResponses) GetMarkdownImageOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, params *GetMarkdownImageOnHostParams, reqEditors ...RequestEditorFn) (*GetMarkdownImageOnHostResponse, error) {
+	rsp, err := c.GetMarkdownImageOnHost(ctx, platformHost, provider, owner, name, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetMarkdownImageOnHostResponse(rsp)
+}
+
 // RefreshRepoOnHostWithResponse request returning *RefreshRepoOnHostResponse
 func (c *ClientWithResponses) RefreshRepoOnHostWithResponse(ctx context.Context, platformHost string, provider string, owner string, name string, reqEditors ...RequestEditorFn) (*RefreshRepoOnHostResponse, error) {
 	rsp, err := c.RefreshRepoOnHost(ctx, platformHost, provider, owner, name, reqEditors...)
@@ -39532,6 +39789,15 @@ func (c *ClientWithResponses) ListRepoLabelsWithResponse(ctx context.Context, pr
 		return nil, err
 	}
 	return ParseListRepoLabelsResponse(rsp)
+}
+
+// GetMarkdownImageWithResponse request returning *GetMarkdownImageResponse
+func (c *ClientWithResponses) GetMarkdownImageWithResponse(ctx context.Context, provider string, owner string, name string, params *GetMarkdownImageParams, reqEditors ...RequestEditorFn) (*GetMarkdownImageResponse, error) {
+	rsp, err := c.GetMarkdownImage(ctx, provider, owner, name, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetMarkdownImageResponse(rsp)
 }
 
 // RefreshRepoWithResponse request returning *RefreshRepoResponse
@@ -44273,6 +44539,32 @@ func ParseListRepoLabelsOnHostResponse(rsp *http.Response) (*ListRepoLabelsOnHos
 	return response, nil
 }
 
+// ParseGetMarkdownImageOnHostResponse parses an HTTP response from a GetMarkdownImageOnHostWithResponse call
+func ParseGetMarkdownImageOnHostResponse(rsp *http.Response) (*GetMarkdownImageOnHostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetMarkdownImageOnHostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseRefreshRepoOnHostResponse parses an HTTP response from a RefreshRepoOnHostWithResponse call
 func ParseRefreshRepoOnHostResponse(rsp *http.Response) (*RefreshRepoOnHostResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -47725,6 +48017,32 @@ func ParseListRepoLabelsResponse(rsp *http.Response) (*ListRepoLabelsResponse, e
 		}
 		response.JSON200 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetMarkdownImageResponse parses an HTTP response from a GetMarkdownImageWithResponse call
+func ParseGetMarkdownImageResponse(rsp *http.Response) (*GetMarkdownImageResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetMarkdownImageResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
 		var dest ProblemError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -7,8 +7,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
+	"mime"
 	"net/http"
+	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -167,6 +170,90 @@ type Client interface {
 	InvalidateListETagsForRepo(owner, repo string, endpoints ...string)
 }
 
+type markdownImageClient interface {
+	GetMarkdownImage(ctx context.Context, owner, sourceURL string) (platform.MarkdownImage, error)
+}
+
+const maxMarkdownImageBytes = 25 << 20
+
+var allowedMarkdownImageTypes = map[string]struct{}{
+	"image/avif": {},
+	"image/bmp":  {},
+	"image/gif":  {},
+	"image/jpeg": {},
+	"image/png":  {},
+	"image/webp": {},
+}
+
+func (c *liveClient) GetMarkdownImage(
+	ctx context.Context,
+	owner, sourceURL string,
+) (platform.MarkdownImage, error) {
+	parsed, err := url.Parse(sourceURL)
+	if err != nil || parsed.Scheme != "https" || parsed.User != nil ||
+		!strings.EqualFold(parsed.Host, c.platformHost) ||
+		!strings.HasPrefix(parsed.EscapedPath(), "/user-attachments/assets/") {
+		return platform.MarkdownImage{}, &platform.Error{
+			Code: platform.ErrCodeInvalidArgument, Provider: platform.KindGitHub,
+			PlatformHost: c.platformHost, Field: "source", Err: errors.New("unsupported markdown image URL"),
+		}
+	}
+
+	// github.com/user-attachments accepts the user's credential but returns
+	// 404 for installation tokens, even when the app can read the repository.
+	authCtx := tokenauth.WithMutationAuth(tokenauth.WithGitHubOwner(ctx, owner))
+	if c.source == nil {
+		return platform.MarkdownImage{}, errors.New("GitHub markdown image token source is unavailable")
+	}
+	token, err := c.source.Token(authCtx)
+	if err != nil {
+		return platform.MarkdownImage{}, err
+	}
+	req, err := http.NewRequestWithContext(authCtx, http.MethodGet, parsed.String(), nil)
+	if err != nil {
+		return platform.MarkdownImage{}, err
+	}
+	req.Header.Set("Accept", "application/octet-stream")
+	req.Header.Set("Authorization", "Bearer "+token)
+	client := c.markdownImageHTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return platform.MarkdownImage{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return platform.MarkdownImage{}, platform.PermissionDenied(platform.KindGitHub, c.platformHost, errors.New(resp.Status))
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		return platform.MarkdownImage{}, &platform.Error{Code: platform.ErrCodeNotFound, Provider: platform.KindGitHub, PlatformHost: c.platformHost}
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return platform.MarkdownImage{}, fmt.Errorf("fetch GitHub markdown image: %s", resp.Status)
+	}
+
+	contentType, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+	if err != nil {
+		return platform.MarkdownImage{}, fmt.Errorf("parse GitHub markdown image content type: %w", err)
+	}
+	if _, ok := allowedMarkdownImageTypes[contentType]; !ok {
+		return platform.MarkdownImage{}, &platform.Error{
+			Code: platform.ErrCodeInvalidArgument, Provider: platform.KindGitHub,
+			PlatformHost: c.platformHost, Field: "source", Err: fmt.Errorf("unsupported image content type %q", contentType),
+		}
+	}
+	content, err := io.ReadAll(io.LimitReader(resp.Body, maxMarkdownImageBytes+1))
+	if err != nil {
+		return platform.MarkdownImage{}, err
+	}
+	if len(content) > maxMarkdownImageBytes {
+		return platform.MarkdownImage{}, fmt.Errorf("GitHub markdown image exceeds %d bytes", maxMarkdownImageBytes)
+	}
+	return platform.MarkdownImage{Content: content, ContentType: contentType}, nil
+}
+
 type conditionalPullRequestGetter interface {
 	GetPullRequestIfChanged(
 		ctx context.Context,
@@ -306,17 +393,18 @@ func NewClient(
 		graphQLEndpoint = options.baseURLOverride + "/api/graphql"
 	}
 	return &liveClient{
-		gh:                     ghClient,
-		ghWrite:                ghWriteClient,
-		ghNotifications:        ghNotificationClient,
-		source:                 source,
-		httpClient:             httpClient,
-		httpWriteClient:        writeHTTPClient,
-		httpNotificationClient: notificationHTTPClient,
-		rateTracker:            rateTracker,
-		platformHost:           normalizedPlatformHost(platformHost),
-		graphQLEndpoint:        graphQLEndpoint,
-		etag:                   et,
+		gh:                      ghClient,
+		ghWrite:                 ghWriteClient,
+		ghNotifications:         ghNotificationClient,
+		source:                  source,
+		httpClient:              httpClient,
+		httpWriteClient:         writeHTTPClient,
+		httpNotificationClient:  notificationHTTPClient,
+		markdownImageHTTPClient: &http.Client{Transport: wrapPublicGitHubAPIGuard(http.DefaultTransport)},
+		rateTracker:             rateTracker,
+		platformHost:            normalizedPlatformHost(platformHost),
+		graphQLEndpoint:         graphQLEndpoint,
+		etag:                    et,
 	}, nil
 }
 
@@ -406,6 +494,7 @@ type liveClient struct {
 	httpClient              *http.Client
 	httpWriteClient         *http.Client
 	httpNotificationClient  *http.Client
+	markdownImageHTTPClient *http.Client
 	rateTracker             *RateTracker
 	writeRateTracker        *RateTracker
 	graphQLRateTracker      *RateTracker

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -1120,6 +1120,7 @@ func (p *gitHubClientProvider) Capabilities() platform.Capabilities {
 	_, assignees := p.client.(githubAssigneeClient)
 	_, reviewers := p.client.(githubReviewerClient)
 	_, archivePages := p.client.(pageClient)
+	_, markdownImages := p.client.(markdownImageClient)
 	return platform.Capabilities{
 		ReadRepositories:            true,
 		ReadMergeRequests:           true,
@@ -1128,6 +1129,7 @@ func (p *gitHubClientProvider) Capabilities() platform.Capabilities {
 		ReadReleases:                true,
 		ReadCI:                      true,
 		ReadLabels:                  labels,
+		ReadMarkdownImages:          markdownImages,
 		ReadNotifications:           true,
 		CommentMutation:             true,
 		StateMutation:               true,
@@ -1160,6 +1162,18 @@ func (p *gitHubClientProvider) Capabilities() platform.Capabilities {
 			platform.ReviewActionRequestChanges,
 		},
 	}
+}
+
+func (p *gitHubClientProvider) GetMarkdownImage(
+	ctx context.Context,
+	ref platform.RepoRef,
+	sourceURL string,
+) (platform.MarkdownImage, error) {
+	reader, ok := p.client.(markdownImageClient)
+	if !ok {
+		return platform.MarkdownImage{}, platform.UnsupportedCapability(platform.KindGitHub, p.host, "read_markdown_images")
+	}
+	return reader.GetMarkdownImage(ctx, ref.Owner, sourceURL)
 }
 
 func (p *gitHubClientProvider) OperationRateLimitBuckets(

--- a/internal/platform/client.go
+++ b/internal/platform/client.go
@@ -39,6 +39,18 @@ type RepositoryReader interface {
 	) ([]Repository, error)
 }
 
+type MarkdownImage struct {
+	Content     []byte
+	ContentType string
+}
+
+// MarkdownImageReader fetches provider-hosted images embedded in repository
+// Markdown. Providers should accept only their own trusted attachment URLs;
+// callers must not be able to turn this into a general-purpose URL fetcher.
+type MarkdownImageReader interface {
+	GetMarkdownImage(ctx context.Context, ref RepoRef, sourceURL string) (MarkdownImage, error)
+}
+
 type MergeRequestReader interface {
 	ListOpenMergeRequests(ctx context.Context, ref RepoRef) ([]MergeRequest, error)
 	GetMergeRequest(ctx context.Context, ref RepoRef, number int) (MergeRequest, error)

--- a/internal/platform/gitlab/client.go
+++ b/internal/platform/gitlab/client.go
@@ -131,7 +131,6 @@ func NewClient(host string, source tokenauth.Source, options ...ClientOption) (*
 		AllowedOrigin:       opts.baseURL,
 	}
 	httpClient := &http.Client{
-		Timeout:   opts.foregroundTimeout,
 		Transport: authRT,
 	}
 	clientOptions = append(clientOptions, gitlab.WithHTTPClient(httpClient))

--- a/internal/platform/gitlab/client.go
+++ b/internal/platform/gitlab/client.go
@@ -37,6 +37,7 @@ type Client struct {
 	host              string
 	baseURL           string
 	api               *gitlab.Client
+	httpClient        *http.Client
 	foregroundTimeout time.Duration
 
 	// userIDMu guards userIDs, a username -> user ID cache for
@@ -129,9 +130,11 @@ func NewClient(host string, source tokenauth.Source, options ...ClientOption) (*
 		RetryOnUnauthorized: true,
 		AllowedOrigin:       opts.baseURL,
 	}
-	clientOptions = append(clientOptions, gitlab.WithHTTPClient(&http.Client{
+	httpClient := &http.Client{
+		Timeout:   opts.foregroundTimeout,
 		Transport: authRT,
-	}))
+	}
+	clientOptions = append(clientOptions, gitlab.WithHTTPClient(httpClient))
 
 	api, err := gitlab.NewClient("", clientOptions...)
 	if err != nil {
@@ -141,6 +144,7 @@ func NewClient(host string, source tokenauth.Source, options ...ClientOption) (*
 		host:              host,
 		baseURL:           opts.baseURL,
 		api:               api,
+		httpClient:        httpClient,
 		foregroundTimeout: opts.foregroundTimeout,
 		userIDs:           make(map[string]int64),
 		projectCloneURLs:  make(map[int64]string),
@@ -257,6 +261,7 @@ func (c *Client) Capabilities() platform.Capabilities {
 		ReadReleases:           true,
 		ReadCI:                 true,
 		ReadLabels:             true,
+		ReadMarkdownImages:     true,
 		CommentMutation:        true,
 		StateMutation:          true,
 		MergeMutation:          true,

--- a/internal/platform/gitlab/client_test.go
+++ b/internal/platform/gitlab/client_test.go
@@ -89,6 +89,23 @@ func TestClientTestHelperDisablesRetries(t *testing.T) {
 	assert.Equal(1, requests)
 }
 
+func TestForegroundTimeoutDoesNotApplyToRepositoryReads(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, `{
+			"id": 42,
+			"path": "project",
+			"path_with_namespace": "group/project",
+			"name": "Project"
+		}`)
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL, WithForegroundTimeoutForTesting(time.Nanosecond))
+	_, err := client.GetRepository(t.Context(), platform.RepoRef{RepoPath: "group/project"})
+
+	require.NoError(t, err)
+}
+
 func TestClientListOpenMergeRequestsPopulatesForkHeadRepoCloneURL(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/platform/gitlab/markdown_images.go
+++ b/internal/platform/gitlab/markdown_images.go
@@ -60,14 +60,18 @@ func (c *Client) GetMarkdownImage(
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		code := platform.ErrCodeInvalidRepoRef
+		var code platform.PlatformErrorCode
 		switch resp.StatusCode {
+		case http.StatusBadRequest:
+			code = platform.ErrCodeInvalidRepoRef
 		case http.StatusUnauthorized, http.StatusForbidden:
 			code = platform.ErrCodePermissionDenied
 		case http.StatusNotFound:
 			code = platform.ErrCodeNotFound
 		case http.StatusTooManyRequests:
 			code = platform.ErrCodeRateLimited
+		default:
+			return platform.MarkdownImage{}, fmt.Errorf("GitLab markdown image request failed: %s", resp.Status)
 		}
 		return platform.MarkdownImage{}, &platform.Error{
 			Code: code, Provider: platform.KindGitLab, PlatformHost: c.host,

--- a/internal/platform/gitlab/markdown_images.go
+++ b/internal/platform/gitlab/markdown_images.go
@@ -1,0 +1,152 @@
+package gitlab
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"go.kenn.io/middleman/internal/platform"
+)
+
+const maxMarkdownImageBytes = 25 << 20
+
+var allowedMarkdownImageTypes = map[string]struct{}{
+	"image/avif": {},
+	"image/bmp":  {},
+	"image/gif":  {},
+	"image/jpeg": {},
+	"image/png":  {},
+	"image/webp": {},
+}
+
+func (c *Client) GetMarkdownImage(
+	ctx context.Context,
+	ref platform.RepoRef,
+	sourceURL string,
+) (platform.MarkdownImage, error) {
+	secret, filename, err := c.markdownUploadParts(ref, sourceURL)
+	if err != nil {
+		return platform.MarkdownImage{}, err
+	}
+	if ref.PlatformID <= 0 {
+		return platform.MarkdownImage{}, &platform.Error{
+			Code: platform.ErrCodeInvalidRepoRef, Provider: platform.KindGitLab,
+			PlatformHost: c.host, Field: "platform_id", Err: errors.New("missing GitLab project ID"),
+		}
+	}
+
+	endpoint := strings.TrimRight(c.baseURL, "/") + "/projects/" +
+		strconv.FormatInt(ref.PlatformID, 10) + "/uploads/" +
+		url.PathEscape(secret) + "/" + url.PathEscape(filename)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return platform.MarkdownImage{}, err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return platform.MarkdownImage{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		code := platform.ErrCodeInvalidRepoRef
+		switch resp.StatusCode {
+		case http.StatusUnauthorized, http.StatusForbidden:
+			code = platform.ErrCodePermissionDenied
+		case http.StatusNotFound:
+			code = platform.ErrCodeNotFound
+		case http.StatusTooManyRequests:
+			code = platform.ErrCodeRateLimited
+		}
+		return platform.MarkdownImage{}, &platform.Error{
+			Code: code, Provider: platform.KindGitLab, PlatformHost: c.host,
+			Capability: "read_markdown_images", Err: errors.New(resp.Status),
+		}
+	}
+	if resp.ContentLength > maxMarkdownImageBytes {
+		return platform.MarkdownImage{}, fmt.Errorf("GitLab markdown image exceeds %d bytes", maxMarkdownImageBytes)
+	}
+	content, err := io.ReadAll(io.LimitReader(resp.Body, maxMarkdownImageBytes+1))
+	if err != nil {
+		return platform.MarkdownImage{}, err
+	}
+	if len(content) > maxMarkdownImageBytes {
+		return platform.MarkdownImage{}, fmt.Errorf("GitLab markdown image exceeds %d bytes", maxMarkdownImageBytes)
+	}
+	contentType := markdownImageContentType(resp.Header.Get("Content-Type"), content)
+	if _, ok := allowedMarkdownImageTypes[contentType]; !ok {
+		return platform.MarkdownImage{}, &platform.Error{
+			Code: platform.ErrCodeInvalidArgument, Provider: platform.KindGitLab,
+			PlatformHost: c.host, Field: "source", Err: fmt.Errorf("unsupported markdown image content type %q", contentType),
+		}
+	}
+	return platform.MarkdownImage{Content: content, ContentType: contentType}, nil
+}
+
+func (c *Client) markdownUploadParts(ref platform.RepoRef, source string) (string, string, error) {
+	parsed, err := url.Parse(source)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" || parsed.User != nil ||
+		parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", "", c.invalidMarkdownImageSource()
+	}
+	apiURL, err := url.Parse(c.baseURL)
+	if err != nil || !strings.EqualFold(parsed.Scheme, apiURL.Scheme) ||
+		!strings.EqualFold(parsed.Host, apiURL.Host) {
+		return "", "", c.invalidMarkdownImageSource()
+	}
+	prefixes := []string{"/" + escapePath(ref.RepoPath) + "/uploads/"}
+	if ref.PlatformID > 0 {
+		prefixes = append(prefixes, "/-/project/"+strconv.FormatInt(ref.PlatformID, 10)+"/uploads/")
+	}
+	prefix := ""
+	for _, candidate := range prefixes {
+		if strings.HasPrefix(parsed.EscapedPath(), candidate) {
+			prefix = candidate
+			break
+		}
+	}
+	if ref.RepoPath == "" || prefix == "" {
+		return "", "", c.invalidMarkdownImageSource()
+	}
+	parts := strings.Split(strings.TrimPrefix(parsed.EscapedPath(), prefix), "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", c.invalidMarkdownImageSource()
+	}
+	secret, err := url.PathUnescape(parts[0])
+	if err != nil || strings.ContainsAny(secret, "/\\") {
+		return "", "", c.invalidMarkdownImageSource()
+	}
+	filename, err := url.PathUnescape(parts[1])
+	if err != nil || strings.ContainsAny(filename, "/\\") {
+		return "", "", c.invalidMarkdownImageSource()
+	}
+	return secret, filename, nil
+}
+
+func (c *Client) invalidMarkdownImageSource() error {
+	return &platform.Error{
+		Code: platform.ErrCodeInvalidArgument, Provider: platform.KindGitLab,
+		PlatformHost: c.host, Field: "source", Err: errors.New("unsupported markdown image URL"),
+	}
+}
+
+func escapePath(path string) string {
+	parts := strings.Split(path, "/")
+	for index, part := range parts {
+		parts[index] = url.PathEscape(part)
+	}
+	return strings.Join(parts, "/")
+}
+
+func markdownImageContentType(header string, content []byte) string {
+	contentType, _, err := mime.ParseMediaType(header)
+	if err == nil && contentType != "" && contentType != "application/octet-stream" {
+		return contentType
+	}
+	return http.DetectContentType(content)
+}

--- a/internal/platform/gitlab/markdown_images.go
+++ b/internal/platform/gitlab/markdown_images.go
@@ -30,6 +30,12 @@ func (c *Client) GetMarkdownImage(
 	ref platform.RepoRef,
 	sourceURL string,
 ) (platform.MarkdownImage, error) {
+	ctx, cancel := c.withForegroundTimeout(ctx)
+	defer cancel()
+	_, ref, err := c.projectScopedArg(ctx, ref)
+	if err != nil {
+		return platform.MarkdownImage{}, err
+	}
 	secret, filename, err := c.markdownUploadParts(ref, sourceURL)
 	if err != nil {
 		return platform.MarkdownImage{}, err

--- a/internal/platform/gitlab/markdown_images_test.go
+++ b/internal/platform/gitlab/markdown_images_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -36,6 +37,27 @@ func TestGetMarkdownImageUsesAuthenticatedProjectUploadAPI(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal("image/png", image.ContentType)
 	assert.Equal(imageBytes, image.Content)
+}
+
+func TestGetMarkdownImageUsesForegroundTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write([]byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a})
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewClient(
+		server.Listener.Addr().String(),
+		testTokenSource("gitlab-token"),
+		WithBaseURLForTesting(server.URL+"/api/v4"),
+		WithForegroundTimeoutForTesting(time.Nanosecond),
+	)
+	require.NoError(t, err)
+	_, err = client.GetMarkdownImage(t.Context(), platform.RepoRef{
+		Platform: platform.KindGitLab, RepoPath: "group/project", PlatformID: 42,
+	}, server.URL+"/group/project/uploads/secret/private.png")
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
 func TestGetMarkdownImageRejectsUntrustedSourcesAndActiveContent(t *testing.T) {

--- a/internal/platform/gitlab/markdown_images_test.go
+++ b/internal/platform/gitlab/markdown_images_test.go
@@ -1,0 +1,74 @@
+package gitlab
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/middleman/internal/platform"
+)
+
+func TestGetMarkdownImageUsesAuthenticatedProjectUploadAPI(t *testing.T) {
+	assert := assert.New(t)
+	imageBytes := []byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("/api/v4/projects/42/uploads/0123456789abcdef/private-image.png", r.URL.Path)
+		assert.Equal("gitlab-token", r.Header.Get("PRIVATE-TOKEN"))
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, err := w.Write(imageBytes)
+		assert.NoError(err)
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewClient(
+		server.Listener.Addr().String(),
+		testTokenSource("gitlab-token"),
+		WithBaseURLForTesting(server.URL+"/api/v4"),
+	)
+	require.NoError(t, err)
+	image, err := client.GetMarkdownImage(t.Context(), platform.RepoRef{
+		Platform: platform.KindGitLab, Host: server.Listener.Addr().String(),
+		RepoPath: "group/project", PlatformID: 42,
+	}, server.URL+"/-/project/42/uploads/0123456789abcdef/private-image.png")
+	require.NoError(t, err)
+	assert.Equal("image/png", image.ContentType)
+	assert.Equal(imageBytes, image.Content)
+}
+
+func TestGetMarkdownImageRejectsUntrustedSourcesAndActiveContent(t *testing.T) {
+	tests := []struct {
+		name        string
+		source      string
+		contentType string
+	}{
+		{name: "different repository", source: "/other/project/uploads/secret/image.png", contentType: "image/png"},
+		{name: "active content", source: "/group/project/uploads/secret/image.svg", contentType: "image/svg+xml"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", tc.contentType)
+				_, err := w.Write([]byte("<svg></svg>"))
+				assert.NoError(err)
+			}))
+			t.Cleanup(server.Close)
+			client, err := NewClient(
+				server.Listener.Addr().String(), testTokenSource("token"),
+				WithBaseURLForTesting(server.URL+"/api/v4"),
+			)
+			require.NoError(err)
+			_, err = client.GetMarkdownImage(context.Background(), platform.RepoRef{
+				Platform: platform.KindGitLab, RepoPath: "group/project", PlatformID: 42,
+			}, server.URL+tc.source)
+			require.Error(err)
+			var platformErr *platform.Error
+			require.ErrorAs(err, &platformErr)
+			assert.Equal(platform.ErrCodeInvalidArgument, platformErr.Code)
+		})
+	}
+}

--- a/internal/platform/registry.go
+++ b/internal/platform/registry.go
@@ -79,6 +79,19 @@ func (r *Registry) RepositoryReader(kind Kind, host string) (RepositoryReader, e
 	return reader, nil
 }
 
+func (r *Registry) MarkdownImageReader(kind Kind, host string) (MarkdownImageReader, error) {
+	provider, err := r.Provider(kind, host)
+	if err != nil {
+		return nil, err
+	}
+
+	reader, ok := provider.(MarkdownImageReader)
+	if !ok || !provider.Capabilities().ReadMarkdownImages {
+		return nil, UnsupportedCapability(kind, host, "read_markdown_images")
+	}
+	return reader, nil
+}
+
 func (r *Registry) MergeRequestReader(kind Kind, host string) (MergeRequestReader, error) {
 	provider, err := r.Provider(kind, host)
 	if err != nil {

--- a/internal/platform/types.go
+++ b/internal/platform/types.go
@@ -478,15 +478,16 @@ func archiveContractError(kind Kind, host, field, format string, args ...any) er
 }
 
 type Capabilities struct {
-	ReadRepositories  bool
-	ReadMergeRequests bool
-	ReadIssues        bool
-	ReadComments      bool
-	ReadReleases      bool
-	ReadCI            bool
-	ReadLabels        bool
-	ReadNotifications bool
-	CommentMutation   bool
+	ReadRepositories   bool
+	ReadMergeRequests  bool
+	ReadIssues         bool
+	ReadComments       bool
+	ReadReleases       bool
+	ReadCI             bool
+	ReadLabels         bool
+	ReadMarkdownImages bool
+	ReadNotifications  bool
+	CommentMutation    bool
 	// StateMutation means the provider can PATCH the item itself:
 	// open/close state transitions AND title/body/content updates.
 	// Every provider implements both through the same mutator, and

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -245,6 +245,7 @@ type mockGH struct {
 	listIssueCommentsErr       error
 	listNotificationsFn        func(context.Context, ghclient.NotificationListOptions) ([]ghclient.NotificationThread, bool, error)
 	markNotificationReadFn     func(context.Context, string) error
+	getMarkdownImageFn         func(context.Context, string, string) (platform.MarkdownImage, error)
 }
 
 func (m *mockGH) ListOpenPullRequests(ctx context.Context, owner, repo string) ([]*gh.PullRequest, error) {
@@ -707,6 +708,16 @@ func (m *mockGH) MarkNotificationThreadRead(ctx context.Context, threadID string
 		return m.markNotificationReadFn(ctx, threadID)
 	}
 	return nil
+}
+
+func (m *mockGH) GetMarkdownImage(
+	ctx context.Context,
+	owner, sourceURL string,
+) (platform.MarkdownImage, error) {
+	if m.getMarkdownImageFn != nil {
+		return m.getMarkdownImageFn(ctx, owner, sourceURL)
+	}
+	return platform.MarkdownImage{}, nil
 }
 
 // InvalidateListETagsForRepo is a no-op for the server test mock,

--- a/internal/server/gitlab_container_e2e_test.go
+++ b/internal/server/gitlab_container_e2e_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net"
 	"net/http"
 	"net/url"
@@ -129,6 +130,49 @@ func TestGitLabContainerE2E(t *testing.T) {
 		platformgitlab.WithForegroundTimeoutForTesting(time.Minute),
 	)
 	require.NoError(err)
+
+	imageBytes := []byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a}
+	var uploadBody bytes.Buffer
+	uploadWriter := multipart.NewWriter(&uploadBody)
+	uploadPart, err := uploadWriter.CreateFormFile("file", "private-markdown-image.png")
+	require.NoError(err)
+	_, err = uploadPart.Write(imageBytes)
+	require.NoError(err)
+	require.NoError(uploadWriter.Close())
+	uploadReq, err := http.NewRequestWithContext(
+		ctx, http.MethodPost,
+		fmt.Sprintf("%s/projects/%d/uploads", manifest.APIURL, manifest.ProjectID),
+		&uploadBody,
+	)
+	require.NoError(err)
+	uploadReq.Header.Set("PRIVATE-TOKEN", manifest.Token)
+	uploadReq.Header.Set("Content-Type", uploadWriter.FormDataContentType())
+	uploadResp, err := http.DefaultClient.Do(uploadReq)
+	require.NoError(err)
+	uploadRaw, err := io.ReadAll(io.LimitReader(uploadResp.Body, 1<<20))
+	uploadResp.Body.Close()
+	require.NoError(err)
+	require.Less(uploadResp.StatusCode, 300, string(uploadRaw))
+	var upload struct {
+		FullPath string `json:"full_path"`
+	}
+	require.NoError(json.Unmarshal(uploadRaw, &upload), string(uploadRaw))
+	require.NotEmpty(upload.FullPath)
+	attachmentURL := manifest.BaseURL + upload.FullPath
+	anonymousReq, err := http.NewRequestWithContext(ctx, http.MethodGet, attachmentURL, nil)
+	require.NoError(err)
+	anonymousResp, err := http.DefaultClient.Do(anonymousReq)
+	require.NoError(err)
+	anonymousResp.Body.Close()
+	assert.GreaterOrEqual(anonymousResp.StatusCode, 400)
+	markdownImage, err := client.GetMarkdownImage(ctx, platform.RepoRef{
+		Platform: platform.KindGitLab, Host: manifest.Host,
+		RepoPath: manifest.RepoPath, PlatformID: manifest.ProjectID,
+	}, attachmentURL)
+	require.NoError(err)
+	assert.Equal("image/png", markdownImage.ContentType)
+	assert.Equal(imageBytes, markdownImage.Content)
+
 	registry, err := platform.NewRegistry(client)
 	require.NoError(err)
 

--- a/internal/server/httpapi/repository_resolver.go
+++ b/internal/server/httpapi/repository_resolver.go
@@ -124,6 +124,8 @@ func CapabilityEnabled(caps ProviderCapabilitiesResponse, capability string) boo
 		return caps.IssueMutation
 	case "read_labels":
 		return caps.ReadLabels
+	case "read_markdown_images":
+		return caps.ReadMarkdownImages
 	case "label_mutation":
 		return caps.LabelMutation
 	case "assignee_mutation":
@@ -292,6 +294,7 @@ func ProviderCapabilitiesFromPlatform(caps platform.Capabilities) ProviderCapabi
 		ReadReleases:                caps.ReadReleases,
 		ReadCI:                      caps.ReadCI,
 		ReadLabels:                  caps.ReadLabels,
+		ReadMarkdownImages:          caps.ReadMarkdownImages,
 		CommentMutation:             caps.CommentMutation,
 		StateMutation:               caps.StateMutation,
 		MergeMutation:               caps.MergeMutation,

--- a/internal/server/httpapi/repository_types.go
+++ b/internal/server/httpapi/repository_types.go
@@ -8,6 +8,7 @@ type ProviderCapabilitiesResponse struct {
 	ReadReleases                bool     `json:"read_releases"`
 	ReadCI                      bool     `json:"read_ci"`
 	ReadLabels                  bool     `json:"read_labels"`
+	ReadMarkdownImages          bool     `json:"read_markdown_images"`
 	CommentMutation             bool     `json:"comment_mutation"`
 	StateMutation               bool     `json:"state_mutation"`
 	MergeMutation               bool     `json:"merge_mutation"`

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -399,6 +399,16 @@ func (s *Server) registerProviderRepoAPI(api huma.API) {
 		httpapi.DocumentOperation("get-repo", "Get repository", "Repositories"))
 	huma.Get(api, hostRepoPath, s.getRepoOnHost,
 		httpapi.DocumentOperation("get-repo-on-host", "Get repository", "Repositories"))
+	huma.Register(api, huma.Operation{
+		OperationID: "get-markdown-image", Method: http.MethodGet, Path: repoPath + "/markdown-image",
+		DefaultStatus: http.StatusOK, Summary: "Get markdown image", Tags: []string{"Repositories"},
+		Responses: markdownImageResponses(),
+	}, s.getMarkdownImage)
+	huma.Register(api, huma.Operation{
+		OperationID: "get-markdown-image-on-host", Method: http.MethodGet, Path: hostRepoPath + "/markdown-image",
+		DefaultStatus: http.StatusOK, Summary: "Get markdown image", Tags: []string{"Repositories"},
+		Responses: markdownImageResponses(),
+	}, s.getMarkdownImageOnHost)
 	huma.Get(api, repoPath+"/commits/{sha}/diff", s.getRepoCommitDiff,
 		httpapi.DocumentOperation("get-repo-commit-diff", "Get repository commit diff", "Repositories"))
 	huma.Get(api, hostRepoPath+"/commits/{sha}/diff", s.getRepoCommitDiffOnHost,

--- a/internal/server/markdown_image_cache.go
+++ b/internal/server/markdown_image_cache.go
@@ -1,0 +1,184 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"go.kenn.io/middleman/internal/platform"
+	"golang.org/x/sync/singleflight"
+)
+
+const (
+	markdownImageCacheTTL      = 14 * 24 * time.Hour
+	markdownImageFetchTimeout  = 30 * time.Second
+	markdownImageCacheMaxBytes = int64(512 << 20)
+	markdownImageCacheMagic    = "middleman-markdown-image-v1\n"
+)
+
+type markdownImageCache struct {
+	root  string
+	mu    sync.Mutex
+	group singleflight.Group
+}
+
+func newMarkdownImageCache(root string) *markdownImageCache {
+	return &markdownImageCache{root: root}
+}
+
+func markdownImageCacheRoot(dataDir string) string {
+	if strings.TrimSpace(dataDir) == "" {
+		return ""
+	}
+	return filepath.Join(dataDir, "cache", "markdown-images")
+}
+
+func (c *markdownImageCache) path(key string) string {
+	sum := sha256.Sum256([]byte(key))
+	return filepath.Join(c.root, hex.EncodeToString(sum[:])+".cache")
+}
+
+func (c *markdownImageCache) get(key string) (platform.MarkdownImage, bool) {
+	if c == nil || c.root == "" {
+		return platform.MarkdownImage{}, false
+	}
+	path := c.path(key)
+	info, err := os.Stat(path)
+	if err != nil || time.Since(info.ModTime()) > markdownImageCacheTTL {
+		if err == nil {
+			_ = os.Remove(path)
+		}
+		return platform.MarkdownImage{}, false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil || !bytes.HasPrefix(data, []byte(markdownImageCacheMagic)) {
+		return platform.MarkdownImage{}, false
+	}
+	payload := data[len(markdownImageCacheMagic):]
+	separator := bytes.IndexByte(payload, '\n')
+	if separator <= 0 {
+		return platform.MarkdownImage{}, false
+	}
+	return platform.MarkdownImage{
+		ContentType: string(payload[:separator]),
+		Content:     payload[separator+1:],
+	}, true
+}
+
+func (c *markdownImageCache) load(
+	ctx context.Context,
+	key string,
+	fetch func(context.Context) (platform.MarkdownImage, error),
+) (platform.MarkdownImage, error) {
+	if image, ok := c.get(key); ok {
+		return image, nil
+	}
+	resultCh := c.group.DoChan(key, func() (any, error) {
+		if image, ok := c.get(key); ok {
+			return image, nil
+		}
+		fetchCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), markdownImageFetchTimeout)
+		defer cancel()
+		image, err := fetch(fetchCtx)
+		if err != nil {
+			return platform.MarkdownImage{}, err
+		}
+		if err := c.set(key, image); err != nil {
+			slog.Warn("cache markdown image", "err", err)
+		}
+		return image, nil
+	})
+	select {
+	case <-ctx.Done():
+		return platform.MarkdownImage{}, ctx.Err()
+	case result := <-resultCh:
+		if result.Err != nil {
+			return platform.MarkdownImage{}, result.Err
+		}
+		return result.Val.(platform.MarkdownImage), nil
+	}
+}
+
+func (c *markdownImageCache) set(key string, image platform.MarkdownImage) error {
+	if c == nil || c.root == "" {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if err := os.MkdirAll(c.root, 0o700); err != nil {
+		return err
+	}
+	temp, err := os.CreateTemp(c.root, ".markdown-image-*")
+	if err != nil {
+		return err
+	}
+	tempPath := temp.Name()
+	defer func() { _ = os.Remove(tempPath) }()
+	if _, err = temp.WriteString(markdownImageCacheMagic + image.ContentType + "\n"); err == nil {
+		_, err = temp.Write(image.Content)
+	}
+	closeErr := temp.Close()
+	if err != nil {
+		return err
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	if err := os.Rename(tempPath, c.path(key)); err != nil {
+		return err
+	}
+	return c.evictLocked(time.Now())
+}
+
+type markdownImageCacheFile struct {
+	path    string
+	size    int64
+	modTime time.Time
+}
+
+func (c *markdownImageCache) evictLocked(now time.Time) error {
+	entries, err := os.ReadDir(c.root)
+	if err != nil {
+		return err
+	}
+	files := make([]markdownImageCacheFile, 0, len(entries))
+	var total int64
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".cache") {
+			continue
+		}
+		info, infoErr := entry.Info()
+		if infoErr != nil {
+			continue
+		}
+		path := filepath.Join(c.root, entry.Name())
+		if now.Sub(info.ModTime()) > markdownImageCacheTTL {
+			if removeErr := os.Remove(path); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+				return removeErr
+			}
+			continue
+		}
+		files = append(files, markdownImageCacheFile{path: path, size: info.Size(), modTime: info.ModTime()})
+		total += info.Size()
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].modTime.Before(files[j].modTime) })
+	for _, file := range files {
+		if total <= markdownImageCacheMaxBytes {
+			break
+		}
+		if err := os.Remove(file.path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		total -= file.size
+	}
+	return nil
+}

--- a/internal/server/markdown_images.go
+++ b/internal/server/markdown_images.go
@@ -55,7 +55,7 @@ func (s *Server) getMarkdownImageFor(
 	host := httpapi.ProviderHost(*repo)
 	reader, err := s.syncer.Registry().MarkdownImageReader(kind, host)
 	if err != nil {
-		return nil, httpapi.MapPlatformError(err)
+		return nil, markdownImageError(ctx, err, kind, host)
 	}
 	ref := httpapi.PlatformRepoRef(*repo)
 	cacheKey := string(ref.Platform) + "\x00" + ref.Host + "\x00" + ref.RepoPath + "\x00" + source
@@ -63,7 +63,7 @@ func (s *Server) getMarkdownImageFor(
 		return reader.GetMarkdownImage(fetchCtx, ref, source)
 	})
 	if err != nil {
-		return nil, httpapi.MapPlatformError(err)
+		return nil, markdownImageError(ctx, err, kind, host)
 	}
 	return &markdownImageOutput{
 		ContentType:        image.ContentType,
@@ -72,6 +72,13 @@ func (s *Server) getMarkdownImageFor(
 		ContentTypeOptions: "nosniff",
 		Body:               image.Content,
 	}, nil
+}
+
+func markdownImageError(ctx context.Context, err error, kind platform.Kind, host string) error {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
+	}
+	return httpapi.ProviderCallProblem(err, string(kind), host)
 }
 
 func markdownImageResponses() map[string]*huma.Response {

--- a/internal/server/markdown_images.go
+++ b/internal/server/markdown_images.go
@@ -1,0 +1,91 @@
+package server
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/danielgtaylor/huma/v2"
+	"go.kenn.io/middleman/internal/platform"
+	"go.kenn.io/middleman/internal/server/httpapi"
+)
+
+type markdownImageOutput struct {
+	ContentType        string `header:"Content-Type"`
+	CacheControl       string `header:"Cache-Control"`
+	ContentLength      string `header:"Content-Length"`
+	ContentTypeOptions string `header:"X-Content-Type-Options"`
+	Body               []byte
+}
+
+type markdownImageInput struct {
+	Provider     string `path:"provider"`
+	PlatformHost string
+	Owner        string `path:"owner"`
+	Name         string `path:"name"`
+	Source       string `query:"source"`
+}
+
+type markdownImageHostInput struct {
+	Provider     string `path:"provider"`
+	PlatformHost string `path:"platform_host"`
+	Owner        string `path:"owner"`
+	Name         string `path:"name"`
+	Source       string `query:"source"`
+}
+
+func (s *Server) getMarkdownImage(ctx context.Context, input *markdownImageInput) (*markdownImageOutput, error) {
+	return s.getMarkdownImageFor(ctx, input.Provider, input.PlatformHost, input.Owner, input.Name, input.Source)
+}
+
+func (s *Server) getMarkdownImageOnHost(ctx context.Context, input *markdownImageHostInput) (*markdownImageOutput, error) {
+	return s.getMarkdownImageFor(ctx, input.Provider, input.PlatformHost, input.Owner, input.Name, input.Source)
+}
+
+func (s *Server) getMarkdownImageFor(
+	ctx context.Context,
+	provider, platformHost, owner, name, source string,
+) (*markdownImageOutput, error) {
+	repo, err := s.repoResolver.RequireRouteCapability(
+		ctx, provider, platformHost, owner, name, capabilityReadMarkdownImages,
+	)
+	if err != nil {
+		return nil, err
+	}
+	kind := httpapi.ProviderKind(*repo)
+	host := httpapi.ProviderHost(*repo)
+	reader, err := s.syncer.Registry().MarkdownImageReader(kind, host)
+	if err != nil {
+		return nil, httpapi.MapPlatformError(err)
+	}
+	ref := httpapi.PlatformRepoRef(*repo)
+	cacheKey := string(ref.Platform) + "\x00" + ref.Host + "\x00" + ref.RepoPath + "\x00" + source
+	image, err := s.markdownImages.load(ctx, cacheKey, func(fetchCtx context.Context) (platform.MarkdownImage, error) {
+		return reader.GetMarkdownImage(fetchCtx, ref, source)
+	})
+	if err != nil {
+		return nil, httpapi.MapPlatformError(err)
+	}
+	return &markdownImageOutput{
+		ContentType:        image.ContentType,
+		CacheControl:       "private, max-age=31536000, immutable",
+		ContentLength:      strconv.Itoa(len(image.Content)),
+		ContentTypeOptions: "nosniff",
+		Body:               image.Content,
+	}, nil
+}
+
+func markdownImageResponses() map[string]*huma.Response {
+	return map[string]*huma.Response{
+		"200": {
+			Description: "Image response",
+			Content: map[string]*huma.MediaType{
+				"image/avif": {Schema: &huma.Schema{Type: "string", Format: "binary"}},
+				"image/bmp":  {Schema: &huma.Schema{Type: "string", Format: "binary"}},
+				"image/gif":  {Schema: &huma.Schema{Type: "string", Format: "binary"}},
+				"image/jpeg": {Schema: &huma.Schema{Type: "string", Format: "binary"}},
+				"image/png":  {Schema: &huma.Schema{Type: "string", Format: "binary"}},
+				"image/webp": {Schema: &huma.Schema{Type: "string", Format: "binary"}},
+			},
+		},
+	}
+}

--- a/internal/server/markdown_images_test.go
+++ b/internal/server/markdown_images_test.go
@@ -7,11 +7,15 @@ import (
 	"net/url"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/middleman/internal/db"
+	ghclient "go.kenn.io/middleman/internal/github"
 	"go.kenn.io/middleman/internal/platform"
+	platformgitlab "go.kenn.io/middleman/internal/platform/gitlab"
+	"go.kenn.io/middleman/internal/testutil/dbtest"
 )
 
 func repoBrowserRequest(
@@ -66,4 +70,74 @@ func TestMarkdownImageRouteFetchesThroughProvider(t *testing.T) {
 	entries, err := os.ReadDir(srv.markdownImages.root)
 	require.NoError(err)
 	assert.Len(entries, 1)
+}
+
+func TestMarkdownImageRouteResolvesOpaqueGitLabProjectID(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	imageBytes := []byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a}
+	var paths []string
+	gitlabServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.EscapedPath())
+		assert.Equal("gitlab-token", r.Header.Get("PRIVATE-TOKEN"))
+		switch r.URL.EscapedPath() {
+		case "/api/v4/projects/group%2Fproject":
+			w.Header().Set("Content-Type", "application/json")
+			_, err := w.Write([]byte(`{
+				"id": 42,
+				"path": "project",
+				"path_with_namespace": "group/project",
+				"name": "Project"
+			}`))
+			assert.NoError(err)
+		case "/api/v4/projects/42/uploads/secret/private.png":
+			w.Header().Set("Content-Type", "image/png")
+			_, err := w.Write(imageBytes)
+			assert.NoError(err)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(gitlabServer.Close)
+
+	provider, err := platformgitlab.NewClient(
+		"gitlab.example.com",
+		testTokenSource("gitlab-token"),
+		platformgitlab.WithBaseURLForTesting(gitlabServer.URL+"/api/v4"),
+		platformgitlab.WithoutRetriesForTesting(),
+	)
+	require.NoError(err)
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+	database := dbtest.Open(t)
+	_, err = database.UpsertRepo(t.Context(), db.RepoIdentity{
+		Platform:       "gitlab",
+		PlatformHost:   "gitlab.example.com",
+		PlatformRepoID: "gid://gitlab/Project/4242",
+		Owner:          "group",
+		Name:           "project",
+		RepoPath:       "group/project",
+	})
+	require.NoError(err)
+	syncer := ghclient.NewSyncerWithRegistry(registry, database, nil, nil, time.Minute, nil, nil)
+	t.Cleanup(syncer.Stop)
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	srv.markdownImages = newMarkdownImageCache(t.TempDir())
+	source := gitlabServer.URL + "/group/project/uploads/secret/private.png"
+
+	rr := repoBrowserRequest(
+		t,
+		srv,
+		http.MethodGet,
+		"/api/v1/host/gitlab.example.com/repo/gitlab/group/project/markdown-image?source="+url.QueryEscape(source),
+	)
+
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+	assert.Equal("image/png", rr.Header().Get("Content-Type"))
+	assert.Equal(imageBytes, rr.Body.Bytes())
+	assert.Equal([]string{
+		"/api/v4/projects/group%2Fproject",
+		"/api/v4/projects/42/uploads/secret/private.png",
+	}, paths)
 }

--- a/internal/server/markdown_images_test.go
+++ b/internal/server/markdown_images_test.go
@@ -96,6 +96,51 @@ func TestMarkdownImageRouteMapsProviderDeadlineToUpstreamError(t *testing.T) {
 	require.Equal(t, http.StatusBadGateway, rr.Code, rr.Body.String())
 }
 
+func TestMarkdownImageRouteMapsGitLabServerErrorToUpstreamError(t *testing.T) {
+	require := require.New(t)
+	gitlabServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v4/projects/42/uploads/secret/private.png", r.URL.EscapedPath())
+		assert.Equal(t, "gitlab-token", r.Header.Get("PRIVATE-TOKEN"))
+		http.Error(w, "unavailable", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(gitlabServer.Close)
+
+	provider, err := platformgitlab.NewClient(
+		"gitlab.example.com",
+		testTokenSource("gitlab-token"),
+		platformgitlab.WithBaseURLForTesting(gitlabServer.URL+"/api/v4"),
+		platformgitlab.WithoutRetriesForTesting(),
+	)
+	require.NoError(err)
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+	database := dbtest.Open(t)
+	_, err = database.UpsertRepo(t.Context(), db.RepoIdentity{
+		Platform:       "gitlab",
+		PlatformHost:   "gitlab.example.com",
+		PlatformRepoID: "42",
+		Owner:          "group",
+		Name:           "project",
+		RepoPath:       "group/project",
+	})
+	require.NoError(err)
+	syncer := ghclient.NewSyncerWithRegistry(registry, database, nil, nil, time.Minute, nil, nil)
+	t.Cleanup(syncer.Stop)
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	srv.markdownImages = newMarkdownImageCache(t.TempDir())
+
+	rr := repoBrowserRequest(
+		t,
+		srv,
+		http.MethodGet,
+		"/api/v1/host/gitlab.example.com/repo/gitlab/group/project/markdown-image?source="+
+			url.QueryEscape(gitlabServer.URL+"/group/project/uploads/secret/private.png"),
+	)
+
+	require.Equal(http.StatusBadGateway, rr.Code, rr.Body.String())
+}
+
 func TestMarkdownImageRouteResolvesOpaqueGitLabProjectID(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/server/markdown_images_test.go
+++ b/internal/server/markdown_images_test.go
@@ -72,6 +72,30 @@ func TestMarkdownImageRouteFetchesThroughProvider(t *testing.T) {
 	assert.Len(entries, 1)
 }
 
+func TestMarkdownImageRouteMapsProviderDeadlineToUpstreamError(t *testing.T) {
+	mock := &mockGH{getMarkdownImageFn: func(
+		context.Context,
+		string,
+		string,
+	) (platform.MarkdownImage, error) {
+		return platform.MarkdownImage{}, context.DeadlineExceeded
+	}}
+	srv, database := setupTestServerWithMock(t, mock)
+	srv.markdownImages = newMarkdownImageCache(t.TempDir())
+	_, err := database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
+	require.NoError(t, err)
+
+	rr := repoBrowserRequest(
+		t,
+		srv,
+		http.MethodGet,
+		"/api/v1/repo/github/acme/widget/markdown-image?source="+
+			url.QueryEscape("https://github.com/user-attachments/assets/11111111-2222-3333-4444-555555555555"),
+	)
+
+	require.Equal(t, http.StatusBadGateway, rr.Code, rr.Body.String())
+}
+
 func TestMarkdownImageRouteResolvesOpaqueGitLabProjectID(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/server/markdown_images_test.go
+++ b/internal/server/markdown_images_test.go
@@ -1,0 +1,69 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/middleman/internal/db"
+	"go.kenn.io/middleman/internal/platform"
+)
+
+func repoBrowserRequest(
+	t *testing.T,
+	srv *Server,
+	method, target string,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, target, nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	return rr
+}
+
+func TestMarkdownImageRouteFetchesThroughProvider(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	const source = "https://github.com/user-attachments/assets/11111111-2222-3333-4444-555555555555"
+	var gotOwner, gotSource string
+	fetches := 0
+	mock := &mockGH{getMarkdownImageFn: func(
+		_ context.Context,
+		owner, sourceURL string,
+	) (platform.MarkdownImage, error) {
+		fetches++
+		gotOwner, gotSource = owner, sourceURL
+		return platform.MarkdownImage{Content: []byte("png-bytes"), ContentType: "image/png"}, nil
+	}}
+	srv, database := setupTestServerWithMock(t, mock)
+	srv.markdownImages = newMarkdownImageCache(t.TempDir())
+	_, err := database.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
+	require.NoError(err)
+
+	rr := repoBrowserRequest(t, srv, http.MethodGet,
+		"/api/v1/repo/github/acme/widget/markdown-image?source="+url.QueryEscape(source),
+	)
+
+	require.Equal(http.StatusOK, rr.Code)
+	assert.Equal("image/png", rr.Header().Get("Content-Type"))
+	assert.Equal("private, max-age=31536000, immutable", rr.Header().Get("Cache-Control"))
+	assert.Equal("nosniff", rr.Header().Get("X-Content-Type-Options"))
+	assert.Equal("png-bytes", rr.Body.String())
+	assert.Equal("acme", gotOwner)
+	assert.Equal(source, gotSource)
+
+	cached := repoBrowserRequest(t, srv, http.MethodGet,
+		"/api/v1/repo/github/acme/widget/markdown-image?source="+url.QueryEscape(source),
+	)
+	require.Equal(http.StatusOK, cached.Code)
+	assert.Equal("png-bytes", cached.Body.String())
+	assert.Equal(1, fetches)
+	entries, err := os.ReadDir(srv.markdownImages.root)
+	require.NoError(err)
+	assert.Len(entries, 1)
+}

--- a/internal/server/operation_availability.go
+++ b/internal/server/operation_availability.go
@@ -23,6 +23,7 @@ const (
 	capabilityDraftMutation               = "draft_mutation"
 	capabilityIssueMutation               = "issue_mutation"
 	capabilityReadLabels                  = "read_labels"
+	capabilityReadMarkdownImages          = "read_markdown_images"
 	capabilityLabelMutation               = "label_mutation"
 	capabilityAssigneeMutation            = "assignee_mutation"
 	capabilityReviewerMutation            = "reviewer_mutation"

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -212,6 +212,7 @@ type Server struct {
 	issueAPI               *issueapi.Handler
 	pullLifecycle          pullLifecycle
 	workspaceAPI           *workspaceapi.Handler
+	markdownImages         *markdownImageCache
 
 	// toolingStatus caches the assembled CLI tooling probe;
 	// toolingRun overrides the probe subprocess runner in tests.
@@ -720,6 +721,10 @@ func newServer(
 		options.HostCheckAllowLoopbackAnyPort,
 	)
 	deferredMergeMaxWait := options.deferredMergeMaxWait
+	markdownImageDataDir := ""
+	if cfg != nil {
+		markdownImageDataDir = cfg.DataDir
+	}
 	repoResolver := httpapi.NewRepositoryResolver(httpapi.RepositoryResolverDeps{
 		DB: database,
 		ProviderCapabilities: func(kind platform.Kind, host string) (platform.Capabilities, error) {
@@ -748,6 +753,7 @@ func newServer(
 		now:                    time.Now,
 		hub:                    NewEventHubWithCapacity(cfg.SSEBufferSizeOrDefault()),
 		labelCatalogRefreshIDs: make(map[int64]struct{}),
+		markdownImages:         newMarkdownImageCache(markdownImageCacheRoot(markdownImageDataDir)),
 		bgCtx: shutdownAwareContext{
 			parent:   bgBaseCtx,
 			deadline: bgDeadline,

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@playwright/test": "1.61.1",
     "@sveltejs/mcp": "0.1.25",
     "svelte-check": "4.7.1",
+    "typescript": "5.9.3",
     "vite-plus": "0.2.3"
   },
   "overrides": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -32,6 +32,9 @@
     "./api/provider-labels": {
       "default": "./src/api/provider-labels.ts"
     },
+    "./api/runtime-base": {
+      "default": "./src/api/runtime-base.ts"
+    },
     "./utils/time": {
       "default": "./src/utils/time.ts"
     },

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -1945,6 +1945,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/host/{platform_host}/repo/{provider}/{owner}/{name}/markdown-image": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get markdown image */
+        get: operations["get-markdown-image-on-host"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/host/{platform_host}/repo/{provider}/{owner}/{name}/refresh": {
         parameters: {
             query?: never;
@@ -3634,6 +3651,23 @@ export interface paths {
         };
         /** List repository labels */
         get: operations["list-repo-labels"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/repo/{provider}/{owner}/{name}/markdown-image": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get markdown image */
+        get: operations["get-markdown-image"];
         put?: never;
         post?: never;
         delete?: never;
@@ -6668,6 +6702,7 @@ export interface components {
             read_comments: boolean;
             read_issues: boolean;
             read_labels: boolean;
+            read_markdown_images: boolean;
             read_merge_requests: boolean;
             read_releases: boolean;
             read_repositories: boolean;
@@ -12426,6 +12461,51 @@ export interface operations {
             };
         };
     };
+    "get-markdown-image-on-host": {
+        parameters: {
+            query?: {
+                source?: string;
+            };
+            header?: never;
+            path: {
+                provider: string;
+                platform_host: string;
+                owner: string;
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Image response */
+            200: {
+                headers: {
+                    "Cache-Control"?: string;
+                    "Content-Length"?: string;
+                    "Content-Type"?: string;
+                    "X-Content-Type-Options"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "image/avif": string;
+                    "image/bmp": string;
+                    "image/gif": string;
+                    "image/jpeg": string;
+                    "image/png": string;
+                    "image/webp": string;
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
     "refresh-repo-on-host": {
         parameters: {
             query?: never;
@@ -16285,6 +16365,50 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["RepoLabelsResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
+    "get-markdown-image": {
+        parameters: {
+            query?: {
+                source?: string;
+            };
+            header?: never;
+            path: {
+                provider: string;
+                owner: string;
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Image response */
+            200: {
+                headers: {
+                    "Cache-Control"?: string;
+                    "Content-Length"?: string;
+                    "Content-Type"?: string;
+                    "X-Content-Type-Options"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "image/avif": string;
+                    "image/bmp": string;
+                    "image/gif": string;
+                    "image/jpeg": string;
+                    "image/png": string;
+                    "image/webp": string;
                 };
             };
             /** @description Error */

--- a/packages/ui/src/api/provider-routes.ts
+++ b/packages/ui/src/api/provider-routes.ts
@@ -18,6 +18,8 @@ const defaultHosts: Record<string, string> = {
   gitea: "gitea.com",
 };
 
+const API_PREFIX = "/api" + "/v1";
+
 export function canonicalProvider(provider: string): string {
   const normalized = provider.toLowerCase();
   if (normalized === "gh") return "github";
@@ -137,6 +139,7 @@ type RepoSuffix =
   | "/comment-autocomplete"
   | "/commits/{sha}/diff"
   | "/labels"
+  | "/markdown-image"
   | "/refresh"
   | "/worktree-base"
   | "/resolve/{number}";
@@ -152,6 +155,20 @@ export function providerRepoPath(ref: ProviderRouteRef, suffix = ""): string {
     return `/host/{platform_host}/repo/{provider}/{owner}/{name}${suffix}`;
   }
   return `/repo/{provider}/{owner}/{name}${suffix}`;
+}
+
+export function providerRepoResourceURL(
+  ref: ProviderRouteRef,
+  suffix: RepoSuffix,
+  query: Record<string, string> = {},
+): string {
+  const params = providerRouteParams(ref);
+  const provider = encodeURIComponent(params.provider);
+  const owner = encodeURIComponent(params.owner);
+  const name = encodeURIComponent(params.name);
+  const hostPrefix = params.platform_host ? `/host/${encodeURIComponent(params.platform_host)}` : "";
+  const search = new URLSearchParams(query).toString();
+  return `${API_PREFIX}${hostPrefix}/repo/${provider}/${owner}/${name}${suffix}${search ? `?${search}` : ""}`;
 }
 
 type CollectionKind = Exclude<RouteKind, "repo">;

--- a/packages/ui/src/api/provider-routes.ts
+++ b/packages/ui/src/api/provider-routes.ts
@@ -1,3 +1,5 @@
+import { configuredAPIPath } from "./runtime-base.js";
+
 export type ProviderRouteRef = {
   provider: string;
   platformHost?: string | undefined;
@@ -17,8 +19,6 @@ const defaultHosts: Record<string, string> = {
   fj: "codeberg.org",
   gitea: "gitea.com",
 };
-
-const API_PREFIX = "/api" + "/v1";
 
 export function canonicalProvider(provider: string): string {
   const normalized = provider.toLowerCase();
@@ -168,7 +168,7 @@ export function providerRepoResourceURL(
   const name = encodeURIComponent(params.name);
   const hostPrefix = params.platform_host ? `/host/${encodeURIComponent(params.platform_host)}` : "";
   const search = new URLSearchParams(query).toString();
-  return `${API_PREFIX}${hostPrefix}/repo/${provider}/${owner}/${name}${suffix}${search ? `?${search}` : ""}`;
+  return configuredAPIPath(`${hostPrefix}/repo/${provider}/${owner}/${name}${suffix}${search ? `?${search}` : ""}`);
 }
 
 type CollectionKind = Exclude<RouteKind, "repo">;

--- a/packages/ui/src/api/runtime-base.ts
+++ b/packages/ui/src/api/runtime-base.ts
@@ -1,0 +1,19 @@
+type RuntimeWindow = Window & { __BASE_PATH__?: string };
+
+function runtimeBasePath(): string {
+  return typeof window === "undefined" ? "/" : ((window as RuntimeWindow).__BASE_PATH__ ?? "/");
+}
+
+export function configuredAPIBasePath(basePath = runtimeBasePath()): string {
+  const prefix = basePath === "/" ? "" : basePath.replace(/\/+$/, "");
+  return `${prefix}/api/v1`;
+}
+
+export function configuredAPIBaseURL(basePath = runtimeBasePath()): string {
+  const origin = typeof window === "undefined" ? "http://localhost" : window.location.origin;
+  return new URL(configuredAPIBasePath(basePath), origin).toString();
+}
+
+export function configuredAPIPath(path: string, basePath = runtimeBasePath()): string {
+  return `${configuredAPIBasePath(basePath)}${path.startsWith("/") ? path : `/${path}`}`;
+}

--- a/packages/ui/src/api/runtime-base.ts
+++ b/packages/ui/src/api/runtime-base.ts
@@ -5,7 +5,9 @@ function runtimeBasePath(): string {
 }
 
 export function configuredAPIBasePath(basePath = runtimeBasePath()): string {
-  const prefix = basePath === "/" ? "" : basePath.replace(/\/+$/, "");
+  let end = basePath.length;
+  while (end > 0 && basePath[end - 1] === "/") end -= 1;
+  const prefix = basePath.slice(0, end);
   return `${prefix}/api/v1`;
 }
 

--- a/packages/ui/src/components/detail/IssueDetail.svelte
+++ b/packages/ui/src/components/detail/IssueDetail.svelte
@@ -70,6 +70,7 @@
     read_releases: true,
     read_ci: true,
     read_labels: false,
+    read_markdown_images: false,
     comment_mutation: true,
     state_mutation: true,
     merge_mutation: true,

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -129,6 +129,7 @@
     read_releases: true,
     read_ci: true,
     read_labels: false,
+    read_markdown_images: false,
     comment_mutation: true,
     state_mutation: true,
     merge_mutation: true,

--- a/packages/ui/src/stores/diff.svelte.ts
+++ b/packages/ui/src/stores/diff.svelte.ts
@@ -1,5 +1,6 @@
 import type { DiffResult, FilePreview, FilesResult, CommitInfo } from "../api/types.js";
 import { createAPIClient } from "../api/generated/client.js";
+import { configuredAPIBaseURL } from "../api/runtime-base.js";
 import {
   providerItemPath,
   providerRepoPath,
@@ -79,11 +80,7 @@ function withVisibleFiles<T extends DiffResult | FilesResult>(result: T, files: 
 }
 
 function apiBaseURL(basePath: string): string {
-  const path = `${basePath.replace(/\/$/, "")}/api/v1`;
-  if (typeof window !== "undefined") {
-    return new URL(path, window.location.origin).toString();
-  }
-  return `http://localhost${path}`;
+  return configuredAPIBaseURL(basePath);
 }
 
 function safeGetItem(key: string): string | null {

--- a/packages/ui/src/utils/markdown.test.ts
+++ b/packages/ui/src/utils/markdown.test.ts
@@ -20,6 +20,29 @@ describe("renderMarkdown task lists", () => {
     expect(html).toContain('height="1000"');
   });
 
+  it("keeps the configured base path in proxied image URLs", async () => {
+    const previousBasePath = window.__BASE_PATH__;
+    window.__BASE_PATH__ = "/middleman/";
+    const source = "https://github.com/user-attachments/assets/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+    try {
+      const html = await renderMarkdown(`![Private image](${source})`, {
+        provider: "github",
+        platformHost: "github.com",
+        owner: "acme",
+        name: "widgets",
+        repoPath: "acme/widgets",
+      });
+
+      expect(html).toContain(
+        `src="/middleman/api/v1/repo/github/acme/widgets/markdown-image?source=${encodeURIComponent(source)}"`,
+      );
+    } finally {
+      if (previousBasePath === undefined) delete window.__BASE_PATH__;
+      else window.__BASE_PATH__ = previousBasePath;
+    }
+  });
+
   it("proxies private GitLab upload images through the repo-scoped API", async () => {
     const source = "/uploads/0123456789abcdef/private-image.png";
     const canonicalSource = "https://gitlab.example.com/group/project/uploads/0123456789abcdef/private-image.png";

--- a/packages/ui/src/utils/markdown.test.ts
+++ b/packages/ui/src/utils/markdown.test.ts
@@ -20,6 +20,34 @@ describe("renderMarkdown task lists", () => {
     expect(html).toContain('height="1000"');
   });
 
+  it("proxies private GitLab upload images through the repo-scoped API", async () => {
+    const source = "/uploads/0123456789abcdef/private-image.png";
+    const canonicalSource = "https://gitlab.example.com/group/project/uploads/0123456789abcdef/private-image.png";
+    const html = await renderMarkdown(`![Private image](${source})`, {
+      provider: "gitlab",
+      platformHost: "gitlab.example.com",
+      owner: "group",
+      name: "project",
+      repoPath: "group/project",
+    });
+
+    expect(html).toContain(
+      `src="/api/v1/host/gitlab.example.com/repo/gitlab/group/project/markdown-image?source=${encodeURIComponent(canonicalSource)}"`,
+    );
+
+    const fullSource = "https://gitlab.example.com/-/project/42/uploads/0123456789abcdef/private-image.png";
+    const fullPathHtml = await renderMarkdown(`![Private image](${fullSource})`, {
+      provider: "gitlab",
+      platformHost: "gitlab.example.com",
+      owner: "group",
+      name: "project",
+      repoPath: "group/project",
+    });
+    expect(fullPathHtml).toContain(
+      `src="/api/v1/host/gitlab.example.com/repo/gitlab/group/project/markdown-image?source=${encodeURIComponent(fullSource)}"`,
+    );
+  });
+
   it("renders item references with the shared internal route and data attributes", async () => {
     const html = await renderMarkdown("See #12 and acme/tools#13", {
       provider: "github",

--- a/packages/ui/src/utils/markdown.test.ts
+++ b/packages/ui/src/utils/markdown.test.ts
@@ -3,6 +3,23 @@ import { buildCanonicalProviderItemURL } from "./item-reference.js";
 import { renderMarkdown, renderMarkdownBlocks } from "./markdown.js";
 
 describe("renderMarkdown task lists", () => {
+  it("proxies private GitHub attachment images through the repo-scoped API", async () => {
+    const source = "https://github.com/user-attachments/assets/11111111-2222-3333-4444-555555555555";
+    const html = await renderMarkdown(`<img width="1440" height="1000" alt="Project list" src="${source}" />`, {
+      provider: "github",
+      platformHost: "github.com",
+      owner: "acme",
+      name: "widgets",
+      repoPath: "acme/widgets",
+    });
+
+    expect(html).toContain(
+      `src="/api/v1/repo/github/acme/widgets/markdown-image?source=${encodeURIComponent(source)}"`,
+    );
+    expect(html).toContain('width="1440"');
+    expect(html).toContain('height="1000"');
+  });
+
   it("renders item references with the shared internal route and data attributes", async () => {
     const html = await renderMarkdown("See #12 and acme/tools#13", {
       provider: "github",

--- a/packages/ui/src/utils/markdown.ts
+++ b/packages/ui/src/utils/markdown.ts
@@ -17,7 +17,7 @@ import type { UponSanitizeAttributeHook } from "dompurify";
 import { codeFenceLanguage, codeHighlightPlan, escapeHtml, shikiStyleIsAllowed } from "@kenn-io/kit-ui/utils/markdown";
 import { mermaidCodeFence } from "@kenn-io/kit-ui/utils/markdown-mermaid";
 import { getSingletonHighlighter, type BundledLanguage, type Highlighter } from "shiki";
-import { canonicalProvider } from "../api/provider-routes.js";
+import { canonicalProvider, providerRepoResourceURL } from "../api/provider-routes.js";
 import { itemReferenceAnchorAttributes } from "./item-reference.js";
 import type { ItemReferenceType } from "./item-reference.js";
 
@@ -181,6 +181,7 @@ let renderState: {
   // otherwise data-task-index values would drift from the source
   // and clicks would mutate the wrong line.
   blockquoteDepth: number;
+  repo?: RepoContext | undefined;
 } = {
   taskIndex: 0,
   interactiveTasks: false,
@@ -189,6 +190,7 @@ let renderState: {
   shikiNonce: "",
   itemStack: [],
   blockquoteDepth: 0,
+  repo: undefined,
 };
 
 const htmlCache = new Map<string, Promise<string>>();
@@ -357,6 +359,7 @@ export interface RenderedMarkdownBlock {
 
 function resetRenderState(
   opts: RenderMarkdownOpts,
+  repo?: RepoContext,
   highlightCode = true,
   highlightedCodeTokens?: WeakSet<Tokens.Code>,
 ): void {
@@ -368,11 +371,13 @@ function resetRenderState(
     shikiNonce: shikiNonce(),
     itemStack: [],
     blockquoteDepth: 0,
+    repo,
   };
 }
 
 function sanitizeMarkdownHtml(html: string): string {
   DOMPurify.addHook("uponSanitizeAttribute", shikiStyleSanitizer);
+  DOMPurify.addHook("uponSanitizeAttribute", markdownImageSourceSanitizer);
   try {
     const sanitized = DOMPurify.sanitize(html, {
       ADD_ATTR: MARKDOWN_ALLOWED_ATTRS,
@@ -380,6 +385,26 @@ function sanitizeMarkdownHtml(html: string): string {
     return sanitized.replaceAll(new RegExp(`\\s${SHIKI_GENERATED_ATTR}="[^"]*"`, "g"), "");
   } finally {
     DOMPurify.removeHook("uponSanitizeAttribute", shikiStyleSanitizer);
+    DOMPurify.removeHook("uponSanitizeAttribute", markdownImageSourceSanitizer);
+  }
+}
+
+const markdownImageSourceSanitizer: UponSanitizeAttributeHook = (node, data) => {
+  if (data.attrName !== "src" || node.tagName.toLowerCase() !== "img" || !renderState.repo) return;
+  const source = proxiedMarkdownImageSource(data.attrValue, renderState.repo);
+  if (source) data.attrValue = source;
+};
+
+function proxiedMarkdownImageSource(source: string, repo: RepoContext): string | null {
+  if (canonicalProvider(repo.provider) !== "github") return null;
+  try {
+    const url = new URL(source);
+    const host = repo.platformHost?.trim() || "github.com";
+    if (url.protocol !== "https:" || url.host.toLowerCase() !== host.toLowerCase()) return null;
+    if (!url.pathname.startsWith("/user-attachments/assets/")) return null;
+    return providerRepoResourceURL(repo, "/markdown-image", { source: url.toString() });
+  } catch {
+    return null;
   }
 }
 
@@ -467,7 +492,7 @@ export function renderMarkdownBlocks(
   const tokens = marked.lexer(raw) as Tokens.Generic[];
   // Rich-preview block slicing is synchronous by design; keep code fences
   // plain here instead of making output depend on prior async Shiki loads.
-  resetRenderState(opts, false);
+  resetRenderState(opts, repo, false);
   const blocks: RenderedMarkdownBlock[] = [];
   let line = 1;
   for (let i = 0; i < tokens.length; i++) {
@@ -549,23 +574,24 @@ async function renderMarkdownUncached(
   // shared highlight budget.
   const highlightPlan = codeHighlightPlan(marked, tokens, (_code, lang) => lang === "mermaid");
   await loadCodeFenceLanguages(highlightPlan.languages);
-  return renderMarkdownTokens(marked, tokens, opts, true, highlightPlan.tokens);
+  return renderMarkdownTokens(marked, tokens, opts, repo, true, highlightPlan.tokens);
 }
 
 export function renderMarkdownSync(raw: string, repo?: RepoContext, opts: RenderMarkdownOpts = {}): string {
   if (!raw) return "";
   const marked = getMarked(repo);
   const tokens = marked.lexer(raw) as Tokens.Generic[];
-  return renderMarkdownTokens(marked, tokens, opts, false);
+  return renderMarkdownTokens(marked, tokens, opts, repo, false);
 }
 
 function renderMarkdownTokens(
   marked: Marked,
   tokens: Tokens.Generic[],
   opts: RenderMarkdownOpts,
+  repo?: RepoContext,
   highlightCode = true,
   highlightedCodeTokens?: WeakSet<Tokens.Code>,
 ): string {
-  resetRenderState(opts, highlightCode, highlightedCodeTokens);
+  resetRenderState(opts, repo, highlightCode, highlightedCodeTokens);
   return sanitizeMarkdownHtml(marked.parser(tokens) as string);
 }

--- a/packages/ui/src/utils/markdown.ts
+++ b/packages/ui/src/utils/markdown.ts
@@ -396,16 +396,34 @@ const markdownImageSourceSanitizer: UponSanitizeAttributeHook = (node, data) => 
 };
 
 function proxiedMarkdownImageSource(source: string, repo: RepoContext): string | null {
-  if (canonicalProvider(repo.provider) !== "github") return null;
+  const provider = canonicalProvider(repo.provider);
+  if (provider !== "github" && provider !== "gitlab") return null;
   try {
-    const url = new URL(source);
-    const host = repo.platformHost?.trim() || "github.com";
+    const host = repo.platformHost?.trim() || (provider === "github" ? "github.com" : "gitlab.com");
+    const normalizedSource =
+      provider === "gitlab" ? normalizedGitLabMarkdownImageSource(source, host, repo.repoPath) : source;
+    if (!normalizedSource) return null;
+    const url = new URL(normalizedSource);
     if (url.protocol !== "https:" || url.host.toLowerCase() !== host.toLowerCase()) return null;
-    if (!url.pathname.startsWith("/user-attachments/assets/")) return null;
+    if (provider === "github" && !url.pathname.startsWith("/user-attachments/assets/")) return null;
+    if (
+      provider === "gitlab" &&
+      !url.pathname.startsWith(`/${repo.repoPath}/uploads/`) &&
+      !/^\/-\/project\/\d+\/uploads\//.test(url.pathname)
+    )
+      return null;
     return providerRepoResourceURL(repo, "/markdown-image", { source: url.toString() });
   } catch {
     return null;
   }
+}
+
+function normalizedGitLabMarkdownImageSource(source: string, host: string, repoPath: string): string | null {
+  if (/^https:\/\//i.test(source)) return source;
+  const uploadPath = source.replace(/^\//, "");
+  if (uploadPath.startsWith("uploads/")) return `https://${host}/${repoPath}/${uploadPath}`;
+  if (uploadPath.startsWith(`${repoPath}/uploads/`)) return `https://${host}/${uploadPath}`;
+  return null;
 }
 
 function shikiNonce(): string {

--- a/packages/ui/src/views/PRListView.svelte
+++ b/packages/ui/src/views/PRListView.svelte
@@ -47,6 +47,7 @@
     read_comments: true,
     read_releases: true,
     read_labels: true,
+    read_markdown_images: false,
     read_ci: true,
     comment_mutation: true,
     thread_reply: false,

--- a/scripts/lint-api-urls.mjs
+++ b/scripts/lint-api-urls.mjs
@@ -3,13 +3,20 @@
 import { readdir, readFile, stat } from "node:fs/promises";
 import { relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
+import ts from "typescript";
 
 const API_MARKER = "/api/v1";
 const SOURCE_EXTENSIONS = new Set([".js", ".jsx", ".svelte", ".ts", ".tsx"]);
 
 const DEFAULT_SCAN_PATHS = ["frontend/src", "packages/ui/src"];
 
-const GENERATED_CLIENT_RUNTIME_FILES = new Set(["frontend/src/lib/api/runtime.ts"]);
+const API_URL_MESSAGE =
+  "Manual Middleman API URL in production frontend code. Use the generated client through the frontend runtime (or injected typed UI client) for REST requests; use the configured API base helper for browser resource URLs. Only scoped streaming transport helpers are exempt.";
+
+const GENERATED_CLIENT_RUNTIME_FILES = new Set([
+  "frontend/src/lib/api/runtime.ts",
+  "packages/ui/src/api/runtime-base.ts",
+]);
 
 function toPosix(path) {
   return path.split(sep).join("/");
@@ -77,6 +84,162 @@ function isApiBasePathOnly(line, column) {
   return next === undefined || next === "`" || next === "'" || next === '"';
 }
 
+function lineNumberAt(content, offset) {
+  return content.slice(0, offset).split(/\r?\n/).length;
+}
+
+function svelteScriptRegions(content, path) {
+  if (!path.endsWith(".svelte")) return [{ content, offset: 0 }];
+
+  const regions = [];
+  const scriptPattern = /<script(?:\s[^>]*)?>([\s\S]*?)<\/script>/gi;
+  for (const match of content.matchAll(scriptPattern)) {
+    const script = match[1] ?? "";
+    const matchOffset = match.index ?? 0;
+    const contentOffset = match[0].indexOf(script);
+    regions.push({ content: script, offset: matchOffset + contentOffset });
+  }
+  return regions;
+}
+
+function unwrapExpression(node) {
+  while (
+    ts.isParenthesizedExpression(node) ||
+    ts.isAsExpression(node) ||
+    ts.isSatisfiesExpression(node) ||
+    ts.isTypeAssertionExpression(node)
+  ) {
+    node = node.expression;
+  }
+  return node;
+}
+
+function staticString(node, declarations, seen = new Set()) {
+  node = unwrapExpression(node);
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) return node.text;
+
+  if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.PlusToken) {
+    const left = staticString(node.left, declarations, seen);
+    const right = staticString(node.right, declarations, seen);
+    return left === null || right === null ? null : left + right;
+  }
+
+  if (ts.isTemplateExpression(node)) {
+    let value = node.head.text;
+    for (const span of node.templateSpans) {
+      const expression = staticString(span.expression, declarations, seen);
+      if (expression === null) return null;
+      value += expression + span.literal.text;
+    }
+    return value;
+  }
+
+  if (ts.isIdentifier(node)) {
+    if (seen.has(node.text)) return null;
+    const declaration = declarations.get(node.text);
+    if (!declaration) return null;
+    const nextSeen = new Set(seen);
+    nextSeen.add(node.text);
+    return staticString(declaration, declarations, nextSeen);
+  }
+
+  return null;
+}
+
+function constDeclarations(sourceFile) {
+  const declarations = new Map();
+
+  function visit(node) {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.initializer &&
+      ts.isVariableDeclarationList(node.parent) &&
+      (node.parent.flags & ts.NodeFlags.Const) !== 0
+    ) {
+      declarations.set(node.name.text, node.initializer);
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return declarations;
+}
+
+function referencesForbiddenConstant(node, declarations) {
+  let found = false;
+
+  function visit(child) {
+    if (found) return;
+    if (ts.isIdentifier(child)) {
+      const initializer = declarations.get(child.text);
+      if (initializer && staticString(initializer, declarations)?.includes(API_MARKER)) {
+        found = true;
+        return;
+      }
+    }
+    ts.forEachChild(child, visit);
+  }
+
+  visit(node);
+  return found;
+}
+
+function structuralFindings(content, path) {
+  const findings = [];
+
+  for (const region of svelteScriptRegions(content, path)) {
+    const sourceFile = ts.createSourceFile(path, region.content, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+    const declarations = constDeclarations(sourceFile);
+
+    function addFinding(node) {
+      const offset = region.offset + node.getStart(sourceFile);
+      const line = lineNumberAt(content, offset);
+      const lineText = content.split(/\r?\n/)[line - 1] ?? "";
+      const column = offset - content.lastIndexOf("\n", offset - 1);
+      const context = contextFor(content.split(/\r?\n/), line - 1);
+      if (isAllowedStreamingTransport(lineText, context)) return;
+      findings.push({ file: path, line, column, message: API_URL_MESSAGE });
+    }
+
+    function visit(node) {
+      if (ts.isVariableDeclaration(node) && node.initializer) {
+        const value = staticString(node.initializer, declarations);
+        if (
+          value?.includes(API_MARKER) &&
+          (!node.initializer.getText(sourceFile).includes(API_MARKER) || value === API_MARKER) &&
+          !referencesForbiddenConstant(node.initializer, declarations)
+        ) {
+          addFinding(node.initializer);
+        }
+        return;
+      }
+
+      if (
+        ts.isBinaryExpression(node) ||
+        ts.isTemplateExpression(node) ||
+        ts.isStringLiteral(node) ||
+        ts.isNoSubstitutionTemplateLiteral(node)
+      ) {
+        const value = staticString(node, declarations);
+        if (
+          value?.includes(API_MARKER) &&
+          (!node.getText(sourceFile).includes(API_MARKER) || value === API_MARKER) &&
+          !referencesForbiddenConstant(node, declarations)
+        ) {
+          addFinding(node);
+          return;
+        }
+      }
+      ts.forEachChild(node, visit);
+    }
+
+    visit(sourceFile);
+  }
+
+  return findings;
+}
+
 async function collectFiles(path) {
   const info = await stat(path).catch(() => null);
   if (!info) return [];
@@ -120,6 +283,8 @@ export async function lintApiUrls({ root = process.cwd(), paths = DEFAULT_SCAN_P
     const content = await readFile(file, "utf8");
     const lines = content.split(/\r?\n/);
 
+    findings.push(...structuralFindings(content, relPath));
+
     lines.forEach((line, index) => {
       const column = line.indexOf(API_MARKER);
       if (column === -1 || isCommentOnly(line)) return;
@@ -132,8 +297,7 @@ export async function lintApiUrls({ root = process.cwd(), paths = DEFAULT_SCAN_P
         file: relPath,
         line: index + 1,
         column: column + 1,
-        message:
-          "Hardcoded /api/v1 endpoint in production frontend code. Use the generated client instead; only scoped streaming transports are allowed.",
+        message: API_URL_MESSAGE,
       });
     });
   }

--- a/scripts/lint-api-urls.mjs
+++ b/scripts/lint-api-urls.mjs
@@ -92,12 +92,31 @@ function svelteScriptRegions(content, path) {
   if (!path.endsWith(".svelte")) return [{ content, offset: 0 }];
 
   const regions = [];
-  const scriptPattern = /<script(?:\s[^>]*)?>([\s\S]*?)<\/script>/gi;
-  for (const match of content.matchAll(scriptPattern)) {
-    const script = match[1] ?? "";
-    const matchOffset = match.index ?? 0;
-    const contentOffset = match[0].indexOf(script);
-    regions.push({ content: script, offset: matchOffset + contentOffset });
+  const lower = content.toLowerCase();
+  let cursor = 0;
+  while (cursor < content.length) {
+    const open = lower.indexOf("<script", cursor);
+    if (open === -1) break;
+    const boundary = lower[open + "<script".length];
+    if (boundary !== ">" && boundary?.trim() !== "") {
+      cursor = open + "<script".length;
+      continue;
+    }
+    const openEnd = lower.indexOf(">", open + "<script".length);
+    if (openEnd === -1) break;
+
+    let close = lower.indexOf("</script", openEnd + 1);
+    let closeEnd = -1;
+    while (close !== -1) {
+      closeEnd = lower.indexOf(">", close + "</script".length);
+      if (closeEnd === -1 || lower.slice(close + "</script".length, closeEnd).trim() === "") break;
+      close = lower.indexOf("</script", close + "</script".length);
+    }
+    if (close === -1 || closeEnd === -1) break;
+
+    const offset = openEnd + 1;
+    regions.push({ content: content.slice(offset, close), offset });
+    cursor = closeEnd + 1;
   }
   return regions;
 }

--- a/scripts/lint-api-urls.mjs
+++ b/scripts/lint-api-urls.mjs
@@ -11,12 +11,20 @@ const SOURCE_EXTENSIONS = new Set([".js", ".jsx", ".svelte", ".ts", ".tsx"]);
 const DEFAULT_SCAN_PATHS = ["frontend/src", "packages/ui/src"];
 
 const API_URL_MESSAGE =
-  "Manual Middleman API URL in production frontend code. Use the generated client through the frontend runtime (or injected typed UI client) for REST requests; use the configured API base helper for browser resource URLs. Only scoped streaming transport helpers are exempt.";
+  "Manual Middleman API URL in production frontend code. Use the generated client through the frontend runtime (or injected typed UI client) for REST requests; use the configured API base helper for browser resource URLs. Only explicit scoped transport helpers are exempt.";
 
 const GENERATED_CLIENT_RUNTIME_FILES = new Set([
   "frontend/src/lib/api/runtime.ts",
   "packages/ui/src/api/runtime-base.ts",
 ]);
+
+// This helper builds a Middleman proxy URL whose nested /api/v1 belongs to
+// Kata, not Middleman. Keep the exception tied to the proxy boundary itself;
+// callers and neighboring files remain subject to the normal API-client rule.
+const SCOPED_UPSTREAM_PROXY_HELPERS = new Map([
+  ["frontend/src/lib/api/kata/daemons.ts", new Set(["kataProxyPath"])],
+]);
+const GENERATED_CLIENT_FACTORIES = new Set(["createAPIClient", "createRuntimeClient"]);
 
 function toPosix(path) {
   return path.split(sep).join("/");
@@ -64,10 +72,14 @@ function isAllowedStreamingTransport(line, context) {
     return true;
   }
 
+  if (context.includes("EventSource") && context.includes("/api/v1/events")) {
+    return true;
+  }
+
   if (
     (context.includes("WebSocket") || context.includes("buildWsUrl")) &&
     context.includes("/terminal") &&
-    line.includes("/api/v1/workspaces/")
+    context.includes("/api/v1/workspaces/")
   ) {
     return true;
   }
@@ -79,13 +91,41 @@ function isAllowedStreamingTransport(line, context) {
   return false;
 }
 
-function isApiBasePathOnly(line, column) {
-  const next = line[column + API_MARKER.length];
-  return next === undefined || next === "`" || next === "'" || next === '"';
-}
-
 function lineNumberAt(content, offset) {
   return content.slice(0, offset).split(/\r?\n/).length;
+}
+
+function lineStartOffsets(content) {
+  const offsets = [0];
+  const newline = /\r?\n/g;
+  let match;
+  while ((match = newline.exec(content)) !== null) {
+    offsets.push(match.index + match[0].length);
+  }
+  return offsets;
+}
+
+function scopedUpstreamProxyRanges(content, path) {
+  const helperNames = SCOPED_UPSTREAM_PROXY_HELPERS.get(path);
+  if (!helperNames) return [];
+
+  const sourceFile = ts.createSourceFile(path, content, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  const ranges = [];
+
+  function visit(node) {
+    if (ts.isFunctionDeclaration(node) && node.name && helperNames.has(node.name.text)) {
+      ranges.push([node.getStart(sourceFile), node.end]);
+      return;
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return ranges;
+}
+
+function isInScopedUpstreamProxy(offset, ranges) {
+  return ranges.some(([start, end]) => offset >= start && offset < end);
 }
 
 function svelteScriptRegions(content, path) {
@@ -204,15 +244,88 @@ function referencesForbiddenConstant(node, declarations) {
   return found;
 }
 
-function structuralFindings(content, path) {
+function nearestAliasScope(node) {
+  let current = node.parent;
+  while (current) {
+    if (ts.isSourceFile(current) || ts.isFunctionLike(current)) return current;
+    current = current.parent;
+  }
+  return undefined;
+}
+
+function referencesAlias(node, aliasesByScope) {
+  let found = false;
+
+  function visit(child) {
+    if (found) return;
+    if (ts.isIdentifier(child)) {
+      let scope = nearestAliasScope(child);
+      while (scope) {
+        if (aliasesByScope.get(scope)?.has(child.text)) {
+          found = true;
+          return;
+        }
+        scope = nearestAliasScope(scope);
+      }
+    }
+    ts.forEachChild(child, visit);
+  }
+
+  visit(node);
+  return found;
+}
+
+function isGeneratedClientFactoryCall(node) {
+  node = unwrapExpression(node);
+  return ts.isCallExpression(node) && ts.isIdentifier(node.expression) && GENERATED_CLIENT_FACTORIES.has(node.expression.text);
+}
+
+function apiPathAliases(sourceFile) {
+  const declarations = [];
+  function collect(node) {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.initializer &&
+      ts.isVariableDeclarationList(node.parent) &&
+      (node.parent.flags & ts.NodeFlags.Const) !== 0
+    ) {
+      declarations.push({ name: node.name.text, initializer: node.initializer, scope: nearestAliasScope(node) });
+    }
+    ts.forEachChild(node, collect);
+  }
+  collect(sourceFile);
+
+  const aliasesByScope = new Map();
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const { name, initializer, scope } of declarations) {
+      if (!scope) continue;
+      const aliases = aliasesByScope.get(scope) ?? new Set();
+      if (aliases.has(name)) continue;
+      if (isGeneratedClientFactoryCall(initializer)) continue;
+      if (initializer.getText(sourceFile).includes(API_MARKER) || referencesAlias(initializer, aliasesByScope)) {
+        aliases.add(name);
+        aliasesByScope.set(scope, aliases);
+        changed = true;
+      }
+    }
+  }
+  return aliasesByScope;
+}
+
+function structuralFindings(content, path, scopedProxyRanges) {
   const findings = [];
 
   for (const region of svelteScriptRegions(content, path)) {
     const sourceFile = ts.createSourceFile(path, region.content, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
     const declarations = constDeclarations(sourceFile);
+    const pathAliases = apiPathAliases(sourceFile);
 
     function addFinding(node) {
       const offset = region.offset + node.getStart(sourceFile);
+      if (isInScopedUpstreamProxy(offset, scopedProxyRanges)) return;
       const line = lineNumberAt(content, offset);
       const lineText = content.split(/\r?\n/)[line - 1] ?? "";
       const column = offset - content.lastIndexOf("\n", offset - 1);
@@ -225,9 +338,10 @@ function structuralFindings(content, path) {
       if (ts.isVariableDeclaration(node) && node.initializer) {
         const value = staticString(node.initializer, declarations);
         if (
-          value?.includes(API_MARKER) &&
-          (!node.initializer.getText(sourceFile).includes(API_MARKER) || value === API_MARKER) &&
-          !referencesForbiddenConstant(node.initializer, declarations)
+          (value?.includes(API_MARKER) &&
+            !node.initializer.getText(sourceFile).includes(API_MARKER) &&
+            !referencesForbiddenConstant(node.initializer, declarations)) ||
+          (referencesAlias(node.initializer, pathAliases) && !isGeneratedClientFactoryCall(node.initializer))
         ) {
           addFinding(node.initializer);
         }
@@ -243,7 +357,7 @@ function structuralFindings(content, path) {
         const value = staticString(node, declarations);
         if (
           value?.includes(API_MARKER) &&
-          (!node.getText(sourceFile).includes(API_MARKER) || value === API_MARKER) &&
+          !node.getText(sourceFile).includes(API_MARKER) &&
           !referencesForbiddenConstant(node, declarations)
         ) {
           addFinding(node);
@@ -301,13 +415,15 @@ export async function lintApiUrls({ root = process.cwd(), paths = DEFAULT_SCAN_P
 
     const content = await readFile(file, "utf8");
     const lines = content.split(/\r?\n/);
+    const lineStarts = lineStartOffsets(content);
+    const scopedProxyRanges = scopedUpstreamProxyRanges(content, relPath);
 
-    findings.push(...structuralFindings(content, relPath));
+    findings.push(...structuralFindings(content, relPath, scopedProxyRanges));
 
     lines.forEach((line, index) => {
       const column = line.indexOf(API_MARKER);
       if (column === -1 || isCommentOnly(line)) return;
-      if (isApiBasePathOnly(line, column)) return;
+      if (isInScopedUpstreamProxy(lineStarts[index] + column, scopedProxyRanges)) return;
 
       const context = contextFor(lines, index);
       if (isAllowedStreamingTransport(line, context)) return;
@@ -321,7 +437,7 @@ export async function lintApiUrls({ root = process.cwd(), paths = DEFAULT_SCAN_P
     });
   }
 
-  return findings;
+  return findings.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line || a.column - b.column);
 }
 
 function parseArgs(argv) {
@@ -357,7 +473,7 @@ function printHelp() {
 
 Detect hardcoded Middleman /api/v1 URLs in production frontend TypeScript
 and Svelte code. Test files, generated code, and scoped streaming
-transports are ignored.
+or upstream-proxy transports are ignored.
 `);
 }
 

--- a/scripts/lint-api-urls.test.mjs
+++ b/scripts/lint-api-urls.test.mjs
@@ -88,13 +88,58 @@ test("allows generated client base path helpers", async () => {
   const root = await makeRoot();
   await write(
     root,
-    "packages/ui/src/stores/diff.svelte.ts",
+    "packages/ui/src/api/runtime-base.ts",
     ["function apiBaseURL(basePath) {", '  return `${basePath.replace(/\\/$/, "")}/api/v1`;', "}", ""].join("\n"),
   );
 
   const findings = await lintApiUrls({ root });
 
   assert.deepEqual(findings, []);
+});
+
+test("flags dynamic API-base aliases and their endpoint consumers", async () => {
+  const root = await makeRoot();
+  await write(
+    root,
+    "frontend/src/lib/api/manual.ts",
+    [
+      "const base = `${basePath}/api/v1`;",
+      "const settingsURL = `${base}/settings`;",
+      "export const loadSettings = () => fetch(settingsURL);",
+      "",
+    ].join("\n"),
+  );
+
+  const findings = await lintApiUrls({ root });
+
+  assert.deepEqual(
+    findings.map((finding) => finding.line),
+    [1, 2, 3],
+  );
+  assert.ok(findings.every((finding) => /generated client/.test(finding.message)));
+});
+
+test("allows the Kata upstream API prefix only inside its proxy path helper", async () => {
+  const root = await makeRoot();
+  await write(
+    root,
+    "frontend/src/lib/api/kata/daemons.ts",
+    [
+      "export function kataProxyPath(path) {",
+      '  return configuredAPIPath(`/kata/proxy/api/v1${path}`);',
+      "}",
+      "export function directKataPath(path) {",
+      '  return `/api/v1${path}`;',
+      "}",
+      "",
+    ].join("\n"),
+  );
+
+  const findings = await lintApiUrls({ root });
+
+  assert.equal(findings.length, 1);
+  assert.match(findings[0].file, /daemons\.ts$/);
+  assert.equal(findings[0].line, 5);
 });
 
 test("allows scoped streaming transports", async () => {

--- a/scripts/lint-api-urls.test.mjs
+++ b/scripts/lint-api-urls.test.mjs
@@ -54,6 +54,20 @@ test("flags API prefixes assembled through constants", async () => {
   assert.match(findings[0].message, /configured API base/);
 });
 
+test("flags assembled API prefixes in Svelte script tags with spaced closing syntax", async () => {
+  const root = await makeRoot();
+  await write(
+    root,
+    "frontend/src/lib/components/Example.svelte",
+    ["<script>", 'const API_PREFIX = "/api" + "/v1";', "</script >", "<p>Example</p>", ""].join("\n"),
+  );
+
+  const findings = await lintApiUrls({ root });
+
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].line, 2);
+});
+
 test("ignores tests, generated code, and OpenAPI schema files", async () => {
   const root = await makeRoot();
   await write(root, "frontend/src/lib/api/settings.test.ts", 'expect(url).toBe("/api/v1/settings");\n');

--- a/scripts/lint-api-urls.test.mjs
+++ b/scripts/lint-api-urls.test.mjs
@@ -33,6 +33,27 @@ test("flags hardcoded production /api/v1 endpoint calls", async () => {
   assert.match(findings[0].message, /generated client/);
 });
 
+test("flags API prefixes assembled through constants", async () => {
+  const root = await makeRoot();
+  await write(
+    root,
+    "packages/ui/src/api/provider-routes.ts",
+    [
+      'const API_PREFIX = "/api" + "/v1";',
+      "const MARKDOWN_IMAGE_URL = `${API_PREFIX}/repo/github/acme/widgets/markdown-image`;",
+      "export { MARKDOWN_IMAGE_URL };",
+      "",
+    ].join("\n"),
+  );
+
+  const findings = await lintApiUrls({ root });
+
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].line, 1);
+  assert.match(findings[0].message, /generated client/);
+  assert.match(findings[0].message, /configured API base/);
+});
+
 test("ignores tests, generated code, and OpenAPI schema files", async () => {
   const root = await makeRoot();
   await write(root, "frontend/src/lib/api/settings.test.ts", 'expect(url).toBe("/api/v1/settings");\n');


### PR DESCRIPTION
Private provider-hosted images could appear as broken fixed-size previews because browser image requests cannot carry repository credentials.

- Render private GitHub and GitLab Markdown images through repo-scoped authenticated requests
- Cache successful image responses on disk for 14 days within a 512 MiB budget
- Leave browser-readable Forgejo and Gitea attachment URLs on direct loading

<sup>generated by a clanker</sup>