### PR TITLE
Fix expanded workspace viewport layout

### DIFF
--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -241,6 +241,9 @@ Keyboard handlers must have one clear owner for each key press.
 - Expanded inline workspaces reuse the live hosted shell and fill the pane
   edge-to-edge; never add outer chrome or mutate the shell's workflow/terminal
   layout state (`packages/ui/src/components/workspace/WorkspaceDockPanel.svelte::expanded`).
+- The desktop `.app-main` clips overflow but must never become a scroll
+  container; focus-driven scrolling there shifts every mode rail and creates
+  matching chrome gaps (`frontend/src/App.svelte::.app-main`).
 - An expanded dock mode must not outlive its claim: WorkspaceDockPanel resets
   on inactive and on teardown, and the store resets `expanded` itself both
   when a claim is directly replaced by a different identity (`setClaim`) and

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -238,6 +238,9 @@ Keyboard handlers must have one clear owner for each key press.
   toolbar's explicit action. A collapsed dock also keeps its own reopen
   affordance at the bottom of the pane
   (`frontend/src/lib/stores/workspace-host.svelte.ts::focusTerminal`).
+- Expanded inline workspaces reuse the live hosted shell and fill the pane
+  edge-to-edge; never add outer chrome or mutate the shell's workflow/terminal
+  layout state (`packages/ui/src/components/workspace/WorkspaceDockPanel.svelte::expanded`).
 - An expanded dock mode must not outlive its claim: WorkspaceDockPanel resets
   on inactive and on teardown, and the store resets `expanded` itself both
   when a claim is directly replaced by a different identity (`setClaim`) and

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1694,7 +1694,8 @@
 
   .app-main {
     flex: 1;
-    overflow: hidden;
+    min-height: 0;
+    overflow: clip;
     display: flex;
     flex-direction: column;
     position: relative;

--- a/frontend/src/lib/components/terminal/WorkspaceDockPanel.browser.svelte.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceDockPanel.browser.svelte.ts
@@ -27,7 +27,6 @@ describe("WorkspaceDockPanel teardown", () => {
       props: {
         controller,
         active: true,
-        detailTitle: "#7 Fix the widget",
         children: detailChildren,
       },
     });
@@ -75,7 +74,6 @@ describe("WorkspaceDockPanel dock-close focus", () => {
       props: {
         controller,
         active: true,
-        detailTitle: "#7 Fix the widget",
         children: detailChildren,
       },
     });
@@ -112,7 +110,6 @@ describe("WorkspaceDockPanel dock-close focus", () => {
         get active() {
           return active;
         },
-        detailTitle: "#7 Fix the widget",
         children: detailChildren,
       },
     });
@@ -152,7 +149,6 @@ describe("WorkspaceDockPanel dock-close focus", () => {
       props: {
         controller,
         active: true,
-        detailTitle: "#7 Fix the widget",
         children: detailChildren,
       },
     });
@@ -183,7 +179,6 @@ describe("WorkspaceDockPanel dock-close focus", () => {
       props: {
         controller,
         active: true,
-        detailTitle: "#7 Fix the widget",
         children: detailChildren,
       },
     });
@@ -219,7 +214,6 @@ describe("WorkspaceDockPanel dock-close focus", () => {
       props: {
         controller,
         active: true,
-        detailTitle: "#7 Fix the widget",
         children: detailChildren,
       },
     });
@@ -253,7 +247,6 @@ describe("WorkspaceDockPanel collapsed reopen strip", () => {
       props: {
         controller,
         active: true,
-        detailTitle: "#7 Fix the widget",
         children: detailChildren,
       },
     });
@@ -288,7 +281,6 @@ describe("WorkspaceDockPanel collapsed reopen strip", () => {
         get active() {
           return active;
         },
-        detailTitle: "#7 Fix the widget",
         children: detailChildren,
       },
     });
@@ -322,7 +314,6 @@ describe("WorkspaceDockPanel resize handle", () => {
       props: {
         controller,
         active: true,
-        detailTitle: "#7 Fix the widget",
         children: detailChildren,
       },
     });
@@ -363,7 +354,6 @@ describe("WorkspaceDockPanel resize handle", () => {
       props: {
         controller,
         active: true,
-        detailTitle: "#7 Fix the widget",
         children: detailChildren,
       },
     });

--- a/frontend/src/lib/components/terminal/WorkspaceHost.browser.svelte.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceHost.browser.svelte.ts
@@ -1,5 +1,5 @@
 import { page } from "vite-plus/test/browser";
-import { flushSync, mount, unmount } from "svelte";
+import { createRawSnippet, flushSync, mount, unmount } from "svelte";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vite-plus/test";
 import { DEFAULT_TERMINAL_SETTINGS } from "@middleman/ui";
 import { createDiffStore } from "@middleman/ui/stores/diff";
@@ -14,6 +14,7 @@ import {
   resetWorkspaceHostForTest,
 } from "../../stores/workspace-host.svelte.ts";
 import WorkspaceHost from "./WorkspaceHost.svelte";
+import WorkspaceDockPanel from "../../../../../packages/ui/src/components/workspace/WorkspaceDockPanel.svelte";
 
 const WAIT = 10_000;
 
@@ -50,6 +51,10 @@ const workspace = {
 };
 
 const emptyRuntime = { launch_targets: [], sessions: [] };
+
+const detailChildren = createRawSnippet(() => ({
+  render: () => `<div>PR detail</div>`,
+}));
 
 function workspaceRoutes(): MockRouteOverride {
   return (req) => {
@@ -355,6 +360,57 @@ describe("WorkspaceHost", () => {
     const parkedScope = page.elementLocator(host);
     expect(parkedScope.getByRole("button", { name: "Expand Terminal" }).query()).toBeNull();
     expect(parkedScope.getByRole("button", { name: "Collapse Terminal" }).query()).toBeNull();
+  });
+
+  it("fills the expanded PR pane with the existing hosted workspace shell", async () => {
+    const prs = getInlineWorkspaceController("prs");
+    prs.setDockMode("split");
+
+    const panelTarget = document.createElement("div");
+    panelTarget.style.cssText = "display: flex; width: 800px; height: 600px;";
+    document.body.appendChild(panelTarget);
+    const panel = mount(WorkspaceDockPanel, {
+      target: panelTarget,
+      props: {
+        controller: prs,
+        active: true,
+        children: detailChildren,
+      },
+    });
+
+    try {
+      instance = mount(WorkspaceHost, {
+        target: hostContainer,
+        context: new Map([[STORES_KEY, { settings: settingsStore }]]),
+      });
+
+      prs.claim(identityA, { id: "ws-1", status: "ready" });
+      navigate("/pulls");
+      flushSync();
+      await waitForReparent();
+
+      const panelElement = panelTarget.querySelector<HTMLElement>(".workspace-dock-panel");
+      const host = panelTarget.querySelector<HTMLElement>(".workspace-host-wrapper");
+      expect(panelElement).not.toBeNull();
+      expect(host).not.toBeNull();
+      await vi.waitFor(() => expect(host?.inert).toBe(false), WAIT);
+      const existingStage = host!.querySelector(".workspace-stage");
+      expect(existingStage).not.toBeNull();
+
+      flushSync(() => prs.setDockMode("expanded"));
+
+      const panelRect = panelElement!.getBoundingClientRect();
+      const hostRect = host!.getBoundingClientRect();
+      expect(host!.querySelector(".workspace-stage")).toBe(existingStage);
+      expect({
+        top: Math.round(hostRect.top - panelRect.top),
+        bottom: Math.round(panelRect.bottom - hostRect.bottom),
+        height: Math.round(hostRect.height),
+      }).toEqual({ top: 0, bottom: 0, height: 600 });
+    } finally {
+      flushSync(() => unmount(panel));
+      panelTarget.remove();
+    }
   });
 
   it("unmounts the right sidebar while parked and restores it on reveal", async () => {

--- a/frontend/tests/e2e-full/00-inline-workspace-continuity.spec.ts
+++ b/frontend/tests/e2e-full/00-inline-workspace-continuity.spec.ts
@@ -208,6 +208,77 @@ async function expectPersistedTerminalFontSize(api: APIRequestContext, fontSize:
 test.describe("inline workspace dock continuity", () => {
   test.describe.configure({ mode: "serial", timeout: lockedWorkspaceTestTimeoutMs });
 
+  test("expanding an inline workspace keeps the app frame fixed and its controls reachable", async ({ page }) => {
+    test.skip(
+      !hasCommand("git") || !hasCommand("tmux", ["-V"]),
+      "git and tmux are required for the real workspace flow",
+    );
+
+    let isolatedServer: IsolatedE2EServer | null = null;
+    let api: APIRequestContext | null = null;
+    try {
+      isolatedServer = await startIsolatedWorkspaceE2EServer();
+      api = await playwrightRequest.newContext({ baseURL: isolatedServer.info.base_url });
+      await createIssueWorkspace(api, 10);
+
+      await page.goto(`${isolatedServer.info.base_url}/issues/github/acme/widgets/10`);
+      const appMain = page.locator(".app-main");
+      const itemRail = page.locator(".issue-list");
+      const expand = page.getByRole("button", { name: "Expand Terminal" });
+      await expect(expand).toBeVisible();
+      const overflowMetrics = await appMain.evaluate((element) => {
+        const overflowProbe = document.createElement("div");
+        overflowProbe.dataset.testOverflowProbe = "true";
+        overflowProbe.style.cssText = "flex: 0 0 2000px; width: 1px;";
+        element.appendChild(overflowProbe);
+        element.scrollTop = 40;
+        return { clientHeight: element.clientHeight, scrollHeight: element.scrollHeight };
+      });
+      expect(overflowMetrics.scrollHeight).toBeGreaterThan(overflowMetrics.clientHeight);
+      await expect(appMain).toHaveJSProperty("scrollTop", 0);
+      await appMain.locator("[data-test-overflow-probe]").evaluate((element) => element.remove());
+
+      await expand.click();
+
+      const collapse = page.getByRole("button", { name: "Collapse Terminal" });
+      const showDetails = page.getByRole("button", { name: "Show Details" });
+      await expect(showDetails).toBeVisible();
+      await expect(collapse).toBeVisible();
+      await showDetails.click();
+      await expect(expand).toBeVisible();
+      await expand.click();
+      await expect(showDetails).toBeVisible();
+      await expect(appMain).toHaveJSProperty("scrollTop", 0);
+      await expect
+        .poll(async () => {
+          const [mainBox, railBox, panelBox] = await Promise.all([
+            appMain.boundingBox(),
+            itemRail.boundingBox(),
+            page.locator(".workspace-dock-panel").boundingBox(),
+          ]);
+          return {
+            railTopDelta: railBox && mainBox ? railBox.y - mainBox.y : undefined,
+            railBottomDelta: railBox && mainBox ? railBox.y + railBox.height - (mainBox.y + mainBox.height) : undefined,
+            panelTopDelta: panelBox && mainBox ? panelBox.y - mainBox.y : undefined,
+            panelBottomDelta:
+              panelBox && mainBox ? panelBox.y + panelBox.height - (mainBox.y + mainBox.height) : undefined,
+          };
+        })
+        .toEqual({
+          railTopDelta: 0,
+          railBottomDelta: 0,
+          panelTopDelta: 0,
+          panelBottomDelta: 0,
+        });
+
+      await collapse.click();
+      await expect(page.locator(".workspace-dock-slot")).toHaveCount(0);
+    } finally {
+      await api?.dispose();
+      await isolatedServer?.stop();
+    }
+  });
+
   test("tab flip preserves the live terminal (xterm)", async ({ browserName, page }) => {
     test.skip(
       !hasCommand("git") || !hasCommand("tmux", ["-V"]),

--- a/packages/ui/src/components/workspace/WorkspaceDockPanel.svelte
+++ b/packages/ui/src/components/workspace/WorkspaceDockPanel.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-  import { flushSync, tick, untrack, type Snippet } from "svelte";
+  import { tick, untrack, type Snippet } from "svelte";
   import { BottomDock, Button } from "@kenn-io/kit-ui";
-  import ChevronsDownIcon from "@lucide/svelte/icons/chevrons-down";
   import ChevronsUpIcon from "@lucide/svelte/icons/chevrons-up";
   import type { InlineDockMode, InlineWorkspaceController } from "../../workspace-inline.js";
 
@@ -9,13 +8,11 @@
     controller: InlineWorkspaceController;
     /** True while the surface's claim is active — gates the dock entirely. */
     active: boolean;
-    /** Title strip text while the terminal is expanded (e.g. "#7 Fix the widget"). */
-    detailTitle: string;
     /** The detail subtree; stays mounted (hidden + inert) while expanded. */
     children: Snippet;
   }
 
-  let { controller, active, detailTitle, children }: Props = $props();
+  let { controller, active, children }: Props = $props();
 
   const MIN_DOCK_PX = 160;
   const MAX_DOCK_RATIO = 0.8;
@@ -85,32 +82,12 @@
     return dockSlotEl?.contains(focused) ?? false;
   }
 
-  // Focus policy: terminal gets focus when revealed via
-  // controller.focusTerminal (which reopens a collapsed dock in split, never
-  // expanded); the detail pane gets it back on collapse-from-expanded. `expanded`
-  // (and the wrapper's hidden/inert attributes) is a $derived that only
-  // recomputes on the next reactive flush, so focusing synchronously right
-  // after setDockMode would target an element that is still hidden/inert —
-  // a silent no-op when a real browser enforces it. `collapseToDetail` is
-  // invoked from a DOM event handler, outside any active Svelte flush, so
-  // the write is deferred to a microtask by default; flushSync forces that
-  // flush to complete before we focus.
-  function collapseToDetail(): void {
-    flushSync(() => {
-      controller.setDockMode("split");
-    });
-    detailWrapper?.focus();
-  }
-
   // The expand/collapse controls live in the embedded WorkspaceTerminalView's
-  // own toolbar now, outside this panel, so an expanded -> split transition
-  // can land here without collapseToDetail ever running (e.g. its "Show
-  // Details" button). Track the previous mode and apply the same focus
-  // contract for any such transition while active. Like the reset-on-inactive
-  // effect below, this runs inside an already-active flush, so the mode
-  // write that drove it has already resolved by the time this body runs;
-  // tick() is kept for defensive consistency with collapseToDetail rather
-  // than relying on that scheduling detail.
+  // own toolbar, so track an expanded -> split transition and return focus
+  // to the detail after it becomes visible. Like the reset-on-inactive effect
+  // below, this runs inside an already-active flush, so the mode write that
+  // drove it has resolved by the time this body runs; tick() keeps the focus
+  // after the DOM update without relying on that scheduling detail.
   let lastObservedMode: InlineDockMode = untrack(() => mode);
   $effect(() => {
     const current = mode;
@@ -175,15 +152,6 @@
 </script>
 
 <div class="workspace-dock-panel" class:workspace-dock-panel--expanded={expanded}>
-  {#if expanded}
-    <div class="workspace-dock-titlestrip">
-      <span class="workspace-dock-title" title={detailTitle}>{detailTitle}</span>
-      <Button size="sm" surface="soft" tone="neutral" label="Show details" onclick={collapseToDetail}>
-        <ChevronsDownIcon size="14" strokeWidth="2.2" aria-hidden="true" />
-      </Button>
-    </div>
-  {/if}
-
   <div
     class="workspace-dock-detail"
     bind:this={detailWrapper}
@@ -252,15 +220,6 @@
     min-height: 0;
     min-width: 0;
     height: 100%;
-  }
-  .workspace-dock-titlestrip {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 8px;
-    padding: 6px 12px;
-    border-bottom: 1px solid var(--border-muted);
-    background: var(--bg-inset);
   }
   .workspace-dock-reopenstrip {
     display: flex;

--- a/packages/ui/src/components/workspace/WorkspaceDockPanel.test.ts
+++ b/packages/ui/src/components/workspace/WorkspaceDockPanel.test.ts
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/svelte";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/svelte";
 import { createRawSnippet, tick } from "svelte";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { resetModalStack } from "../../stores/keyboard/modal-stack.svelte.js";
@@ -15,9 +15,9 @@ const detailChildren = createRawSnippet(() => ({
   render: () => `<div data-testid="detail-marker">detail alive</div>`,
 }));
 
-function renderPanel(controller: InlineWorkspaceController, active: boolean, detailTitle = "#7 Fix the widget") {
+function renderPanel(controller: InlineWorkspaceController, active: boolean) {
   return render(WorkspaceDockPanel, {
-    props: { controller, active, detailTitle, children: detailChildren },
+    props: { controller, active, children: detailChildren },
   });
 }
 
@@ -116,7 +116,7 @@ describe("WorkspaceDockPanel", () => {
 
   it("expanded mode hides the detail but keeps it mounted with state", () => {
     const controller = createTestController("expanded");
-    renderPanel(controller, true, "#7 Fix the widget");
+    renderPanel(controller, true);
 
     const detail = screen.getByTestId("detail-marker").closest<HTMLElement>(".workspace-dock-detail");
     expect(detail?.hasAttribute("hidden")).toBe(true);
@@ -125,14 +125,6 @@ describe("WorkspaceDockPanel", () => {
     // check here.
     expect(detail?.inert).toBe(true);
     expect(screen.getByTestId("detail-marker")).toBeTruthy();
-
-    const titlestrip = document.querySelector<HTMLElement>(".workspace-dock-titlestrip");
-    expect(titlestrip?.textContent).toContain("#7 Fix the widget");
-    // The title strip's own "Show details" button is now the only one in
-    // this panel: the dock header that used to offer a second, identically
-    // labeled control is gone (moved to the WTV toolbar as "Show Details").
-    expect(titlestrip && within(titlestrip).getByRole("button", { name: "Show details" })).toBeTruthy();
-    expect(screen.getAllByRole("button", { name: "Show details" })).toHaveLength(1);
   });
 
   it("persists height per surface and clamps on restore", async () => {
@@ -200,43 +192,12 @@ describe("WorkspaceDockPanel", () => {
 
     expect(controller.setDockMode).not.toHaveBeenCalled();
 
-    await rerender({ controller, active: false, detailTitle: "#7 Fix the widget", children: detailChildren });
+    await rerender({ controller, active: false, children: detailChildren });
     await tick();
 
     expect(controller.setDockMode).toHaveBeenCalledWith("split");
     const detail = screen.getByTestId("detail-marker").closest(".workspace-dock-detail");
     expect(detail?.hasAttribute("hidden")).toBe(false);
-  });
-
-  it("returns focus to the detail pane, only once it is visible, when collapsing via the control", async () => {
-    const controller = createTestController("expanded");
-    renderPanel(controller, true);
-    const detail = screen.getByTestId("detail-marker").closest<HTMLElement>(".workspace-dock-detail");
-    expect(detail).toBeTruthy();
-
-    // Capture whether the detail pane still carried hidden/inert at the
-    // exact moment .focus() was invoked on it — a real browser silently
-    // ignores focus() on a hidden/inert element, so this is the load-bearing
-    // assertion (document.activeElement alone is not: jsdom does not
-    // enforce that restriction and would report success either way).
-    let hiddenAtFocusTime: boolean | undefined;
-    let inertAtFocusTime: boolean | undefined;
-    const originalFocus = HTMLElement.prototype.focus;
-    vi.spyOn(HTMLElement.prototype, "focus").mockImplementation(function (this: HTMLElement) {
-      if (this === detail) {
-        hiddenAtFocusTime = this.hidden;
-        inertAtFocusTime = this.inert;
-      }
-      return originalFocus.call(this);
-    });
-
-    const titlestrip = document.querySelector<HTMLElement>(".workspace-dock-titlestrip");
-    expect(titlestrip).toBeTruthy();
-    await fireEvent.click(within(titlestrip as HTMLElement).getByRole("button", { name: "Show details" }));
-
-    expect(hiddenAtFocusTime).toBe(false);
-    expect(inertAtFocusTime).toBe(false);
-    expect(document.activeElement).toBe(detail);
   });
 
   it("returns focus to the detail pane, only once it is visible, when the claim goes away while expanded", async () => {
@@ -262,7 +223,7 @@ describe("WorkspaceDockPanel", () => {
       return originalFocus.call(this);
     });
 
-    await rerender({ controller, active: false, detailTitle: "#7 Fix the widget", children: detailChildren });
+    await rerender({ controller, active: false, children: detailChildren });
 
     await waitFor(() => expect(document.activeElement).toBe(detail));
     expect(hiddenAtFocusTime).toBe(false);
@@ -272,9 +233,7 @@ describe("WorkspaceDockPanel", () => {
     // The expand/collapse controls now live in the embedded
     // WorkspaceTerminalView's toolbar, outside this panel, so this drives
     // the same expanded -> split transition the way that toolbar's "Show
-    // Details" button does: directly through the controller, never through
-    // this panel's own collapseToDetail (which only the title strip's
-    // button still calls).
+    // Details" button does: directly through the controller.
     const controller = createTestController("expanded");
     renderPanel(controller, true);
     const detail = screen.getByTestId("detail-marker").closest<HTMLElement>(".workspace-dock-detail");

--- a/packages/ui/src/views/ActivityFeedView.svelte
+++ b/packages/ui/src/views/ActivityFeedView.svelte
@@ -440,7 +440,6 @@
           <WorkspaceDockPanel
             controller={inlineWorkspace}
             active={claimIdentity !== null && inlineWorkspace.isClaimedFor(claimIdentity)}
-            detailTitle={activeDrawer ? `#${activeDrawer.number} ${activeDrawer.owner}/${activeDrawer.name}` : ""}
           >
             {@render activityEmbed()}
           </WorkspaceDockPanel>

--- a/packages/ui/src/views/IssueListView.svelte
+++ b/packages/ui/src/views/IssueListView.svelte
@@ -150,7 +150,6 @@
         <WorkspaceDockPanel
           controller={inlineWorkspace}
           active={claimIdentity !== null && inlineWorkspace.isClaimedFor(claimIdentity)}
-          detailTitle={`#${selectedIssue.number} ${selectedIssue.owner}/${selectedIssue.name}`}
         >
           {@render detailContent()}
         </WorkspaceDockPanel>

--- a/packages/ui/src/views/PRListView.svelte
+++ b/packages/ui/src/views/PRListView.svelte
@@ -478,7 +478,6 @@
         <WorkspaceDockPanel
           controller={inlineWorkspace}
           active={claimIdentity !== null && inlineWorkspace.isClaimedFor(claimIdentity)}
-          detailTitle={`#${selectedPR.number} ${selectedPR.owner}/${selectedPR.name}`}
         >
           {@render detailContent()}
         </WorkspaceDockPanel>


### PR DESCRIPTION
Expanded inline workspaces could move their controls under the app header and shift the list/detail panes, leaving blank space below the page.

- Preserve the live workspace shell and its internal terminal state while it fills the pane.
- Keep app chrome fixed with Show Details and Collapse Terminal reachable after repeated expansion cycles.