### PR TITLE
fix: preserve Unicode in service-hosted terminals

### DIFF
--- a/context/workspace-runtime-lifecycle.md
+++ b/context/workspace-runtime-lifecycle.md
@@ -86,6 +86,9 @@ still exists.
 - During middleman shutdown, detach/restart behavior is different: do not treat
   normal server shutdown as a natural user exit that should erase recoverable
   base runtime state.
+- Every tmux client attach must force UTF-8; service launchers may omit locale
+  variables, causing tmux to replace non-ASCII output before WebSocket transport
+  (`internal/workspace/localruntime/tmux_launcher.go::tmuxAttachSessionCommand`).
 
 ## UI Contract Rules
 

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -24910,6 +24910,7 @@ func TestWorkspaceRuntimeNaturalTmuxAgentExitForgetsStoredSessionE2E(
 	tmuxPath := filepath.Join(dir, "fake-tmux")
 	require.NoError(os.WriteFile(tmuxPath, []byte(`#!/bin/sh
 printf '%s\0' "$@" >> "$TMUX_RECORD"
+if [ "$1" = "-u" ]; then shift; fi
 case "$1" in
   has-session)
     echo "can't find session: $3" >&2
@@ -24972,6 +24973,7 @@ func TestWorkspaceRuntimeIncludesStoredRuntimeSessionsAfterReloadE2E(t *testing.
 	dir := t.TempDir()
 	tmuxPath := filepath.Join(dir, "fake-tmux")
 	require.NoError(os.WriteFile(tmuxPath, []byte(`#!/bin/sh
+if [ "$1" = "-u" ]; then shift; fi
 case "$1" in
   list-sessions)
     printf '%s\n' middleman-0000000000000001
@@ -25098,6 +25100,7 @@ if [ "$mode" = "capture-pane" ]; then
   printf 'stable\n'
   exit 0
 fi
+if [ "$1" = "-u" ]; then shift; fi
 if [ "$1" = "has-session" ]; then
   echo "can't find session: $3" >&2
   exit 1
@@ -25305,6 +25308,7 @@ for a in "$@"; do
   if [ "$a" = "capture-pane" ]; then mode="capture-pane"; fi
   prev="$a"
 done
+if [ "$1" = "-u" ]; then shift; fi
 case "$1" in
   list-sessions)
     printf '%s\n' 'middleman-0000000000000001-e81d3b0e9d82feaa'
@@ -25744,6 +25748,7 @@ for a in "$@"; do
   if [ "$prev" = "-t" ]; then target="$a"; fi
   prev="$a"
 done
+if [ "$1" = "-u" ]; then shift; fi
 if [ "$1" = "attach-session" ]; then
   cat >/dev/null
   exit 0
@@ -27563,6 +27568,10 @@ owner_arg() {
 }
 cmd="${1:-}"
 [ "$#" -gt 0 ] && shift || true
+if [ "$cmd" = "-u" ]; then
+  cmd="${1:-}"
+  [ "$#" -gt 0 ] && shift || true
+fi
 case "$cmd" in
   list-sessions)
     for session in "$state_dir"/*; do

--- a/internal/server/e2etest/settings_test.go
+++ b/internal/server/e2etest/settings_test.go
@@ -284,6 +284,7 @@ func TestSettingsAPIE2EHideTmuxStatusUpdateAffectsRuntimeSessions(t *testing.T) 
 	require.NoError(os.WriteFile(tmuxPath, fmt.Appendf(nil, `#!/bin/sh
 record=%q
 printf '%%s\0' "$#" "$@" >> "$record"
+if [ "$1" = "-u" ]; then shift; fi
 case "$1" in
   has-session)
     echo "can't find session: $3" >&2

--- a/internal/server/fleetapi/fleet_ssh_test.go
+++ b/internal/server/fleetapi/fleet_ssh_test.go
@@ -388,7 +388,7 @@ func TestSSHFleetAttachSpecWrapped(t *testing.T) {
 	assert := assert.New(t)
 
 	remoteSpec := `{"version":1,"kind":"tmux","session_key":"s1","target_key":"",` +
-		`"tmux_session":"mm-s1","command":["tmux","attach-session","-t","mm-s1"],` +
+		`"tmux_session":"mm-s1","command":["tmux","-u","attach-session","-t","mm-s1"],` +
 		`"requires_local_host":true}`
 	fake := &fakeSSHExec{routes: map[string]string{
 		"GET /api/v1/runtime/sessions/s1/attach-spec": framedJSON(200, remoteSpec),
@@ -419,7 +419,7 @@ func TestSSHFleetAttachSpecWrapped(t *testing.T) {
 	joined := strings.Join(spec.Command, " ")
 	assert.Contains(joined, "ControlPath="+srv.sshFleet.conns.SocketPath("epyc"))
 	assert.Contains(joined, "-t wes@epyc.local")
-	assert.Contains(joined, "tmux attach-session -t mm-s1")
+	assert.Contains(joined, "tmux -u attach-session -t mm-s1")
 	assert.False(spec.RequiresLocalHost,
 		"the wrapped spec runs from the hub host")
 	assert.Equal("mm-s1", spec.TmuxSession)

--- a/internal/server/projects_handlers_test.go
+++ b/internal/server/projects_handlers_test.go
@@ -242,7 +242,10 @@ func TestProjectWorktreeRuntimeAttachSpecUsesStoredTmuxSession(t *testing.T) {
 	assert.Equal("helper", spec.TargetKey)
 	assert.Equal("project-runtime-live", spec.TmuxSession)
 	assert.Equal(
-		[]string{tmuxScript, "--socket", "runtime", "attach-session", "-t", "project-runtime-live"},
+		[]string{
+			tmuxScript, "--socket", "runtime",
+			"-u", "attach-session", "-t", "project-runtime-live",
+		},
 		spec.Command,
 	)
 	assert.True(spec.RequiresLocalHost)

--- a/internal/server/projects_runtime_command_test.go
+++ b/internal/server/projects_runtime_command_test.go
@@ -36,6 +36,7 @@ func writeRuntimeCommandFakeTmux(t *testing.T) (tmuxPath, recordPath string) {
 	tmuxPath = filepath.Join(dir, "tmux")
 	script := fmt.Sprintf(`#!/bin/sh
 printf '%%s\0' "$#" "$@" >> %[1]s
+if [ "$1" = "-u" ]; then shift; fi
 case "$1" in
   has-session)
     if [ -f %[2]s ]; then exit 0; fi

--- a/internal/server/tmux_wrapper_test.go
+++ b/internal/server/tmux_wrapper_test.go
@@ -1101,17 +1101,20 @@ func TestTmuxWrapperAttachSession(t *testing.T) {
 	// with our "wrap" prefix.
 	var attach []string
 	for _, argv := range readTmuxRecord(t, record) {
-		if len(argv) >= 2 && argv[1] == "attach-session" {
+		if len(argv) >= 3 &&
+			argv[1] == "-u" &&
+			argv[2] == "attach-session" {
 			attach = argv
 			break
 		}
 	}
 	require.NotNil(attach, "attach-session argv not recorded")
-	require.Len(attach, 4)
+	require.Len(attach, 5)
 	assert.Equal("wrap", attach[0])
-	assert.Equal("attach-session", attach[1])
-	assert.Equal("-t", attach[2])
-	assert.NotEmpty(attach[3])
+	assert.Equal("-u", attach[1])
+	assert.Equal("attach-session", attach[2])
+	assert.Equal("-t", attach[3])
+	assert.NotEmpty(attach[4])
 }
 
 func TestTerminalRouteE2EPropagatesWorkspaceID(t *testing.T) {

--- a/internal/server/workspace_runtime_test_helpers_test.go
+++ b/internal/server/workspace_runtime_test_helpers_test.go
@@ -30,6 +30,7 @@ for a in "$@"; do
   if [ "$prev" = "-t" ]; then target="$a"; fi
   prev="$a"
 done
+if [ "$1" = "-u" ]; then shift; fi
 case "$1" in
   has-session)
     echo "can't find session: $target" >&2

--- a/internal/server/workspaceapi/runtime_attach_spec.go
+++ b/internal/server/workspaceapi/runtime_attach_spec.go
@@ -68,7 +68,9 @@ func runtimeAttachCommand(tmuxCommand []string, tmuxSession string) []string {
 	if len(command) == 0 {
 		command = []string{"tmux"}
 	}
-	return append(command, "attach-session", "-t", tmuxSession)
+	// Remote consumers may launch this command without locale variables.
+	// Force UTF-8 so tmux preserves non-ASCII terminal output.
+	return append(command, "-u", "attach-session", "-t", tmuxSession)
 }
 
 func attachSpecTmuxSessionExists(

--- a/internal/server/workspacetest/workspace_test.go
+++ b/internal/server/workspacetest/workspace_test.go
@@ -185,7 +185,10 @@ func TestWorkspaceRuntimeAttachSpecUsesStoredTmuxSessionE2E(t *testing.T) {
 	assert.Equal("codex", spec.TargetKey)
 	assert.Equal("workspace-runtime-live", spec.TmuxSession)
 	assert.Equal(
-		[]string{tmuxPath, "--socket", "workspace", "attach-session", "-t", "workspace-runtime-live"},
+		[]string{
+			tmuxPath, "--socket", "workspace",
+			"-u", "attach-session", "-t", "workspace-runtime-live",
+		},
 		spec.Command,
 	)
 	assert.True(spec.RequiresLocalHost)

--- a/internal/terminal/handler.go
+++ b/internal/terminal/handler.go
@@ -175,9 +175,7 @@ func (h *Handler) ServeHTTP(
 	if len(prefix) == 0 {
 		prefix = []string{"tmux"}
 	}
-	argv := make([]string, 0, len(prefix)+3)
-	argv = append(argv, prefix...)
-	argv = append(argv, "attach-session", "-t", ws.TmuxSession)
+	argv := tmuxAttachCommand(prefix, ws.TmuxSession)
 	cmd := procutil.CommandContext(ctx, argv[0], argv[1:]...)
 	cmd.Env = append(os.Environ(), "TERM=xterm-256color")
 	logWebsocketDebug(
@@ -311,6 +309,14 @@ func (h *Handler) ServeHTTP(
 		"workspace_id", id,
 		"exit_code", exitCode,
 	)
+}
+
+func tmuxAttachCommand(prefix []string, session string) []string {
+	argv := make([]string, 0, len(prefix)+4)
+	argv = append(argv, prefix...)
+	// Middleman may run as a service without locale variables. Force UTF-8 so
+	// tmux does not replace non-ASCII terminal output with underscores.
+	return append(argv, "-u", "attach-session", "-t", session)
 }
 
 func bridgePtyOwnerAttachment(

--- a/internal/terminal/handler_test.go
+++ b/internal/terminal/handler_test.go
@@ -130,6 +130,20 @@ func TestHandlerRejectsConcurrentWorkspaceTerminals(t *testing.T) {
 	release3()
 }
 
+func TestTmuxAttachCommandForcesUTF8(t *testing.T) {
+	assert.Equal(
+		t,
+		[]string{
+			"/usr/bin/env", "tmux", "-u",
+			"attach-session", "-t", "middleman-test",
+		},
+		tmuxAttachCommand(
+			[]string{"/usr/bin/env", "tmux"},
+			"middleman-test",
+		),
+	)
+}
+
 func TestHandlerAttachesPtyOwnerTerminal(t *testing.T) {
 	require := require.New(t)
 

--- a/internal/workspace/localruntime/command_session_test.go
+++ b/internal/workspace/localruntime/command_session_test.go
@@ -28,6 +28,7 @@ func writeCommandSessionFakeTmux(
 	tmuxPath = filepath.Join(dir, "tmux")
 	script := fmt.Sprintf(`#!/bin/sh
 printf '%%s\0' "$#" "$@" >> %s
+if [ "$1" = "-u" ]; then shift; fi
 case "$1" in
   has-session)
     if [ -f %s ]; then exit 0; fi

--- a/internal/workspace/localruntime/manager.go
+++ b/internal/workspace/localruntime/manager.go
@@ -623,7 +623,7 @@ func (m *Manager) restoredRuntimeCommand(
 	if len(command) == 0 {
 		command = []string{"tmux"}
 	}
-	return append(command, "attach-session", "-t", restored.TmuxSession), nil
+	return tmuxAttachSessionCommand(command, restored.TmuxSession), nil
 }
 
 func isTmuxCommandUnavailable(err error) bool {

--- a/internal/workspace/localruntime/manager_test.go
+++ b/internal/workspace/localruntime/manager_test.go
@@ -328,7 +328,10 @@ exit 0
 	require.NoError(err)
 	sessionName := tmuxSessionName("ws:alpha", "codex")
 
-	assert.Equal([]string{tmuxPath, "attach-session", "-t", sessionName}, launch.Command)
+	assert.Equal(
+		[]string{tmuxPath, "-u", "attach-session", "-t", sessionName},
+		launch.Command,
+	)
 	assert.Equal(sessionName, launch.TmuxSession)
 	records := readNullArgvRecord(t, record)
 	assert.Contains(records, []string{"has-session", "-t", sessionName})
@@ -388,7 +391,8 @@ exit 0
 	require.NoError(err)
 
 	assert.Equal(tmuxPath, launch.Command[0])
-	assert.Equal("attach-session", launch.Command[1])
+	assert.Equal("-u", launch.Command[1])
+	assert.Equal("attach-session", launch.Command[2])
 }
 
 func TestManagerLaunchCommandRejectsRelativeTmuxCommandWhenWrapped(t *testing.T) {
@@ -448,7 +452,10 @@ exit 0
 	require.NoError(err)
 	sessionName := tmuxSessionName("ws-1", "codex")
 
-	assert.Equal([]string{tmuxPath, "attach-session", "-t", sessionName}, launch.Command)
+	assert.Equal(
+		[]string{tmuxPath, "-u", "attach-session", "-t", sessionName},
+		launch.Command,
+	)
 	assert.Equal(sessionName, launch.TmuxSession)
 	records := readNullArgvRecord(t, record)
 	require.Len(records, 2)
@@ -471,6 +478,7 @@ func TestManagerLaunchPlainShellWrapsInTmuxWhenAvailable(t *testing.T) {
 	tmuxPath := filepath.Join(dir, "tmux")
 	require.NoError(os.WriteFile(tmuxPath, fmt.Appendf(nil, `#!/bin/sh
 printf '%%s\0' "$#" "$@" >> %s
+if [ "$1" = "-u" ]; then shift; fi
 if [ "$1" = "attach-session" ]; then
   trap 'exit 0' HUP INT TERM
   while :; do sleep 1; done
@@ -568,6 +576,26 @@ func TestManagerRestoreTmuxSessionRestoresPlainShellRuntimeSession(t *testing.T)
 	assert.Equal("Shell", shell.Label)
 	assert.Equal("middleman-ws-1-shell", shell.TmuxSession)
 	assert.Equal(createdAt, shell.CreatedAt)
+}
+
+func TestManagerRestoredRuntimeCommandForcesUTF8(t *testing.T) {
+	mgr := NewManager(Options{
+		TmuxCommand: []string{"/usr/bin/tmux", "-L", "middleman-test"},
+	})
+	t.Cleanup(mgr.Shutdown)
+
+	command, err := mgr.restoredRuntimeCommand(RestoredRuntimeSession{
+		TmuxSession: "middleman-ws-1-shell",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t,
+		[]string{
+			"/usr/bin/tmux", "-L", "middleman-test",
+			"-u", "attach-session", "-t", "middleman-ws-1-shell",
+		},
+		command,
+	)
 }
 
 func TestManagerRestoreTmuxSessionReusesExistingPlainShellRuntimeSession(t *testing.T) {
@@ -732,6 +760,7 @@ func TestManagerRestoreTmuxSessionAttachesStoredSessionWithoutOwnerValidation(t 
 	dir := t.TempDir()
 	tmuxPath := filepath.Join(dir, "tmux")
 	require.NoError(os.WriteFile(tmuxPath, []byte(`#!/bin/sh
+if [ "$1" = "-u" ]; then shift; fi
 if [ "$1" = "show-options" ]; then
   exit 99
 fi
@@ -1972,6 +2001,7 @@ func writeLongRunningAttachTmux(t *testing.T) string {
 	t.Helper()
 	tmuxPath := filepath.Join(t.TempDir(), "tmux")
 	require.NoError(t, os.WriteFile(tmuxPath, []byte(`#!/bin/sh
+if [ "$1" = "-u" ]; then shift; fi
 if [ "$1" = "attach-session" ]; then
   trap 'exit 0' HUP INT TERM
   while :; do sleep 1; done

--- a/internal/workspace/localruntime/tmux_launcher.go
+++ b/internal/workspace/localruntime/tmux_launcher.go
@@ -417,8 +417,15 @@ func (l tmuxLauncher) killSessionCommand() []string {
 }
 
 func (l tmuxLauncher) attachSessionCommand() []string {
+	return tmuxAttachSessionCommand(l.TmuxCommand, l.Session)
+}
+
+func tmuxAttachSessionCommand(command []string, session string) []string {
+	// Middleman may run as a service without locale variables. Force UTF-8 so
+	// tmux does not replace non-ASCII terminal output with underscores.
 	return append(
-		slices.Clone(l.TmuxCommand), "attach-session", "-t", l.Session,
+		slices.Clone(command),
+		"-u", "attach-session", "-t", session,
 	)
 }
 

--- a/internal/workspace/localruntime/tmux_launcher_test.go
+++ b/internal/workspace/localruntime/tmux_launcher_test.go
@@ -97,6 +97,21 @@ func TestTmuxLauncherCanHideStatusOnNewSessions(t *testing.T) {
 	assert.NotContains(launcher.attachSessionCommand(), "status")
 }
 
+func TestTmuxLauncherAttachForcesUTF8(t *testing.T) {
+	launcher := tmuxLauncher{
+		TmuxCommand: []string{"/usr/bin/tmux", "-L", "middleman-test"},
+		Session:     "middleman-test",
+	}
+
+	assert.Equal(t,
+		[]string{
+			"/usr/bin/tmux", "-L", "middleman-test",
+			"-u", "attach-session", "-t", "middleman-test",
+		},
+		launcher.attachSessionCommand(),
+	)
+}
+
 func TestTmuxLauncherCleansUpWhenHideStatusFails(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -172,7 +187,7 @@ exit 0
 		"kill-session", "-t", "middleman-test",
 	})
 	assert.NotContains(records, []string{
-		"attach-session", "-t", "middleman-test",
+		"-u", "attach-session", "-t", "middleman-test",
 	})
 	assert.NoFileExists(created)
 }
@@ -246,7 +261,7 @@ exit 0
 		"show-options", "-qv", "-t", "middleman-test", "@middleman_owner",
 	})
 	assert.NotContains(records, []string{
-		"attach-session", "-t", "middleman-test",
+		"-u", "attach-session", "-t", "middleman-test",
 	})
 	assert.NotContains(records, []string{
 		"new-session", "-e", "PATH", "-e", "TERM",


### PR DESCRIPTION
Service-managed middleman processes can start without locale variables. In that environment tmux rewrites non-ASCII output before it reaches browser terminals, so rebuilt xterm assets cannot correct the damaged byte stream.

- Force UTF-8 for base workspace, runtime, restored, project, and fleet tmux attachments.
- Preserve wrapped tmux command prefixes.
- Add regression coverage for the affected attach paths.

Validated with `make test-short`, focused non-short tmux server tests, and `make build-release`.