### PR TITLE
Stop branch-name collisions from dead-ending workspace creation

### DIFF
--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -350,6 +350,15 @@ server check exactly.
   cancellable while hashing; cached diff membership never authorizes traversal
   (`internal/workspace/diff_snapshot.go::fingerprintWorktreePath`).
 
+## Worktree Branch Names
+
+An unavailable branch name must never fail workspace creation: an unusable PR
+head branch degrades to `middleman/pr-<n>`, then to a numbered variant of it,
+then to a detached checkout with no managed branch
+(`internal/workspace/manager.go::addFallbackWorktree`). Middleman owns the
+synthetic name and its numbered variants and may delete them during cleanup;
+any other pre-existing branch is user-owned and must keep pointing where it did.
+
 ## Branch Upstream
 
 The branch's git upstream config (`branch.<name>.remote`/`.merge`) is the

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -16,6 +16,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -977,7 +978,7 @@ func existingWorkspacePersistedBranch(
 	useMergeRequestHeadRef bool,
 ) (string, bool, error) {
 	if ws.ItemType == db.WorkspaceItemTypePullRequest &&
-		currentBranch == syntheticPRWorktreeBranch(ws.ItemNumber) {
+		isSyntheticPRWorktreeBranch(ws.ItemNumber, currentBranch) {
 		ok, err := existingWorkspaceHeadMatchesCurrentHead(
 			ctx, gitDir, ws, currentBranch, useMergeRequestHeadRef,
 		)
@@ -1503,25 +1504,89 @@ func (m *Manager) addWorktreeLocked(
 			ws.GitHeadRef, err, fallbackBranch, startRefErr,
 		)
 	}
-	fallbackErr := runGitWorktreeAdd(
-		ctx, cloneDir, ws.WorktreePath,
-		"-b", fallbackBranch, startRef,
+	branch, fallbackErr := m.addFallbackWorktree(
+		ctx, cloneDir, ws, fallbackBranch, startRef,
 	)
 	if fallbackErr == nil {
-		if upErr := configureFallbackBranchUpstream(
-			ctx, cloneDir, ws, fallbackBranch,
-		); upErr != nil {
-			cleanupWorktreeAddOnUpstreamFailure(
-				ctx, cloneDir, ws.WorktreePath, fallbackBranch,
-			)
-			return "", fmt.Errorf("configure branch upstream: %w", upErr)
-		}
-		return fallbackBranch, nil
+		return branch, nil
 	}
 	return "", fmt.Errorf(
 		"preferred branch %q failed: %w; fallback branch %q failed: %w",
 		ws.GitHeadRef, err, fallbackBranch, fallbackErr,
 	)
+}
+
+// addFallbackWorktree checks out the workspace head under a name other than the
+// PR head branch, which is where setup lands whenever the preferred name is
+// unusable (stale local branch, checked out elsewhere, or simply taken).
+//
+// Every failure reachable from here is a naming collision inside middleman's own
+// branch namespace, never a missing commit, so no collision may be terminal: a
+// taken synthetic name is uniquified, and if no branch can be created at all the
+// worktree is checked out detached. A workspace the maintainer can open and
+// rename by hand always beats a setup error with nothing to retry into.
+func (m *Manager) addFallbackWorktree(
+	ctx context.Context,
+	cloneDir string,
+	ws *Workspace,
+	fallbackBranch, startRef string,
+) (string, error) {
+	branch, err := m.addFallbackBranchWorktree(
+		ctx, cloneDir, ws, fallbackBranch, startRef,
+	)
+	if err == nil {
+		return branch, nil
+	}
+	fallbackErr := err
+
+	// Uniquifying leaves the colliding branch untouched: it may be a live
+	// workspace's checkout or a user branch middleman never created.
+	if uniqueBranch, nameErr := nextAvailableBranchName(
+		ctx, cloneDir, fallbackBranch,
+	); nameErr == nil {
+		branch, err = m.addFallbackBranchWorktree(
+			ctx, cloneDir, ws, uniqueBranch, startRef,
+		)
+		if err == nil {
+			return branch, nil
+		}
+	}
+
+	if detachErr := runGitWorktreeAdd(
+		ctx, cloneDir, ws.WorktreePath, "--detach", startRef,
+	); detachErr != nil {
+		return "", fmt.Errorf(
+			"%w; detached checkout failed: %w", fallbackErr, detachErr,
+		)
+	}
+	// An empty managed branch: middleman owns no branch here, so rollback and
+	// delete leave every existing branch in place.
+	slog.Warn("workspace worktree checked out detached",
+		"workspace_id", ws.ID, "path", ws.WorktreePath,
+		"branch", fallbackBranch, "err", fallbackErr)
+	return "", nil
+}
+
+func (m *Manager) addFallbackBranchWorktree(
+	ctx context.Context,
+	cloneDir string,
+	ws *Workspace,
+	branch, startRef string,
+) (string, error) {
+	if err := runGitWorktreeAdd(
+		ctx, cloneDir, ws.WorktreePath, "-b", branch, startRef,
+	); err != nil {
+		return "", err
+	}
+	if err := configureFallbackBranchUpstream(
+		ctx, cloneDir, ws, branch,
+	); err != nil {
+		cleanupWorktreeAddOnUpstreamFailure(
+			ctx, cloneDir, ws.WorktreePath, branch,
+		)
+		return "", fmt.Errorf("configure branch upstream: %w", err)
+	}
+	return branch, nil
 }
 
 func (m *Manager) addIssueWorktree(
@@ -1678,6 +1743,23 @@ func workspaceMergeRequestHeadRef(ws *Workspace) string {
 
 func syntheticPRWorktreeBranch(mrNumber int) string {
 	return fmt.Sprintf("middleman/pr-%d", mrNumber)
+}
+
+// isSyntheticPRWorktreeBranch reports whether branch is the synthetic PR branch
+// for this merge request or one of the numbered variants addFallbackWorktree
+// creates when that name is taken. Both are middleman-created names for the same
+// workspace head, so reuse and upstream repair must recognize either.
+func isSyntheticPRWorktreeBranch(mrNumber int, branch string) bool {
+	base := syntheticPRWorktreeBranch(mrNumber)
+	if branch == base {
+		return true
+	}
+	suffix, ok := strings.CutPrefix(branch, base+"-")
+	if !ok {
+		return false
+	}
+	_, err := strconv.Atoi(suffix)
+	return err == nil
 }
 
 // cleanupWorktreeAddOnUpstreamFailure rolls back a just-added worktree (and,

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -804,6 +804,44 @@ func TestSetupReusesExistingWorkspaceWorktree(t *testing.T) {
 	assert.Contains(argvs[0], ws.WorktreePath)
 }
 
+// A retried setup must recognize the uniquified synthetic branch as its own,
+// otherwise the workspace whose first attempt hit a name collision can never be
+// set up again.
+func TestSetupReusesExistingUniquifiedSyntheticPRWorktree(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	wtDir := t.TempDir()
+
+	localRepo, _, platformHost := setupHTTPWorktreeBaseForWorkspaceGitTest(
+		t, "feature/thing",
+	)
+	repoID := seedRepo(t, d, platformHost, "acme", "widget")
+	seedMR(t, d, repoID, 42, "feature/thing")
+
+	tmuxScript, _ := writeRecorderScript(t)
+
+	mgr := NewManager(d, wtDir)
+	mgr.SetTmuxCommand([]string{tmuxScript})
+	mgr.SetWorktreeBasePathResolver(staticBaseResolver(localRepo))
+
+	ws, err := mgr.Create(t.Context(), "github", platformHost, "acme", "widget", 42)
+	require.NoError(err)
+	existingBranch := syntheticPRWorktreeBranch(42) + "-2"
+	runWorkspaceTestGit(
+		t, localRepo,
+		"worktree", "add", ws.WorktreePath, "-b", existingBranch, "HEAD",
+	)
+
+	require.NoError(mgr.Setup(t.Context(), ws))
+
+	got, err := d.GetWorkspace(t.Context(), ws.ID)
+	require.NoError(err)
+	require.NotNil(got)
+	assert.Equal("ready", got.Status)
+	assert.Equal(existingBranch, got.WorkspaceBranch)
+}
+
 func TestSetupDoesNotReuseUnconfiguredMatchingOriginWorktree(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -2277,6 +2315,152 @@ func TestAddWorktreeFallbackBranchTracksPRHeadBranch(t *testing.T) {
 	require.True(ok, "divergence probe must resolve @{upstream}")
 	assert.Equal(0, div.Ahead)
 	assert.Equal(0, div.Behind)
+}
+
+// divergentCommitForWorkspaceGitTest creates a commit that is not the PR head so
+// a branch pointing at it makes addPreferredWorktree reject the preferred name.
+func divergentCommitForWorkspaceGitTest(
+	t *testing.T, cloneDir, parentSHA string,
+) string {
+	t.Helper()
+	treeOut, err := gitOutput(t.Context(), cloneDir, "rev-parse", "main^{tree}")
+	require.NoError(t, err)
+	sha, err := gitOutput(
+		t.Context(), cloneDir,
+		"commit-tree", strings.TrimSpace(treeOut),
+		"-p", parentSHA, "-m", "divergent local branch",
+	)
+	require.NoError(t, err)
+	require.NotEqual(t, parentSHA, strings.TrimSpace(sha))
+	return strings.TrimSpace(sha)
+}
+
+// A stale local branch with the PR head name plus a leftover synthetic branch
+// used to leave workspace creation with no usable branch name at all, and the
+// maintainer with a permanent error and nothing to retry into.
+func TestAddWorktreeUniquifiesFallbackBranchWhenSyntheticNameTaken(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	cloneDir := setupBareCloneForWorkspaceGitTest(t)
+	runWorkspaceTestGit(
+		t, cloneDir, "config", "remote.origin.fetch",
+		"+refs/heads/*:refs/remotes/origin/*",
+	)
+	const prNumber = 746
+	const headBranch = "fix/credential-rate-accounting"
+	headSHA := configureSameRepoPRRefs(t, cloneDir, headBranch, prNumber)
+
+	divergentSHA := divergentCommitForWorkspaceGitTest(t, cloneDir, headSHA)
+	runWorkspaceTestGit(
+		t, cloneDir, "update-ref", "refs/heads/"+headBranch, divergentSHA,
+	)
+	takenBranch := syntheticPRWorktreeBranch(prNumber)
+	runWorkspaceTestGit(
+		t, cloneDir, "update-ref", "refs/heads/"+takenBranch, divergentSHA,
+	)
+
+	ws := &Workspace{
+		ID:              "ws-uniquified-fallback",
+		Platform:        "github",
+		PlatformHost:    "github.com",
+		RepoOwner:       "acme",
+		RepoName:        "widget",
+		ItemType:        db.WorkspaceItemTypePullRequest,
+		ItemNumber:      prNumber,
+		GitHeadRef:      headBranch,
+		WorkspaceBranch: workspaceBranchUnknown,
+		WorktreePath:    filepath.Join(t.TempDir(), "worktree"),
+		TmuxSession:     "ws-uniquified-fallback",
+		Status:          "creating",
+	}
+	mgr := NewManager(openTestDB(t), t.TempDir())
+
+	branch, err := mgr.addWorktreeLocked(t.Context(), cloneDir, false, ws)
+
+	require.NoError(err)
+	assert.Equal(takenBranch+"-2", branch)
+	gotSHA, err := gitHeadSHA(t.Context(), ws.WorktreePath)
+	require.NoError(err)
+	assert.Equal(headSHA, gotSHA)
+	// Neither pre-existing branch may be moved or deleted to make room.
+	for _, existing := range []string{headBranch, takenBranch} {
+		sha, ok, err := gitRefSHA(t.Context(), cloneDir, "refs/heads/"+existing)
+		require.NoError(err)
+		require.True(ok, "pre-existing branch %q must survive", existing)
+		assert.Equal(divergentSHA, sha)
+	}
+	remote, err := gitConfigValue(
+		t.Context(), ws.WorktreePath, "branch."+branch+".remote",
+	)
+	require.NoError(err, "uniquified fallback branch must track the PR head branch")
+	assert.Equal("origin", remote)
+	mergeRef, err := gitConfigValue(
+		t.Context(), ws.WorktreePath, "branch."+branch+".merge",
+	)
+	require.NoError(err)
+	assert.Equal("refs/heads/"+headBranch, mergeRef)
+}
+
+// The guarantee behind the uniquified fallback: no branch-name state in the
+// repository can stop a workspace from being created. With every derived name
+// taken, the worktree is checked out detached rather than failing.
+func TestAddWorktreeFallsBackToDetachedWorktreeWhenBranchNamesExhausted(
+	t *testing.T,
+) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	cloneDir := setupBareCloneForWorkspaceGitTest(t)
+	const prNumber = 747
+	const headBranch = "fix/exhausted-branch-names"
+	headSHA := configureSameRepoPRRefs(t, cloneDir, headBranch, prNumber)
+	divergentSHA := divergentCommitForWorkspaceGitTest(t, cloneDir, headSHA)
+	runWorkspaceTestGit(
+		t, cloneDir, "update-ref", "refs/heads/"+headBranch, divergentSHA,
+	)
+
+	base := syntheticPRWorktreeBranch(prNumber)
+	var refUpdates strings.Builder
+	fmt.Fprintf(&refUpdates, "create refs/heads/%s %s\n", base, divergentSHA)
+	for i := 2; i < 1000; i++ {
+		fmt.Fprintf(
+			&refUpdates, "create refs/heads/%s-%d %s\n", base, i, divergentSHA,
+		)
+	}
+	_, stderr, err := gitcmd.New().Run(
+		t.Context(), cloneDir,
+		strings.NewReader(refUpdates.String()), "update-ref", "--stdin",
+	)
+	require.NoError(err, string(stderr))
+
+	ws := &Workspace{
+		ID:              "ws-detached-last-resort",
+		Platform:        "github",
+		PlatformHost:    "github.com",
+		RepoOwner:       "acme",
+		RepoName:        "widget",
+		ItemType:        db.WorkspaceItemTypePullRequest,
+		ItemNumber:      prNumber,
+		GitHeadRef:      headBranch,
+		WorkspaceBranch: workspaceBranchUnknown,
+		WorktreePath:    filepath.Join(t.TempDir(), "worktree"),
+		TmuxSession:     "ws-detached-last-resort",
+		Status:          "creating",
+	}
+	mgr := NewManager(openTestDB(t), t.TempDir())
+
+	branch, err := mgr.addWorktreeLocked(t.Context(), cloneDir, false, ws)
+
+	require.NoError(err)
+	// No managed branch: cleanup and delete must not remove anyone else's.
+	assert.Empty(branch)
+	gotSHA, err := gitHeadSHA(t.Context(), ws.WorktreePath)
+	require.NoError(err)
+	assert.Equal(headSHA, gotSHA)
+	current, err := worktreeCurrentBranch(t.Context(), ws.WorktreePath)
+	require.NoError(err)
+	assert.Empty(current, "last-resort worktree must be detached")
 }
 
 func TestAddWorktreeUnknownHeadRepoDoesNotTrackMatchingOriginBranch(t *testing.T) {

--- a/internal/workspace/pushed_head_observer.go
+++ b/internal/workspace/pushed_head_observer.go
@@ -470,7 +470,7 @@ func (o *PushedHeadObserver) configureMissingUpstream(
 		return false, nil
 	}
 	synthetic := ws.ItemType == db.WorkspaceItemTypePullRequest &&
-		branch == syntheticPRWorktreeBranch(ws.ItemNumber)
+		isSyntheticPRWorktreeBranch(ws.ItemNumber, branch)
 	if branch != head && !synthetic {
 		return false, nil
 	}


### PR DESCRIPTION
Opening a workspace could fail permanently when local branch state left no usable branch name: a stale local branch with the PR head name made the preferred checkout fail, and a leftover `middleman/pr-<n>` from an earlier workspace made the only fallback fail too. Retry and Delete both led back to the same error.

- Uniquify the synthetic fallback branch (`middleman/pr-<n>-2`) when the name is taken, still tracking the PR head branch
- Check the worktree out detached, with no managed branch, when no branch can be created at all
- Leave colliding branches exactly where they point; they may be another workspace's checkout or user-owned
- Recognize the numbered variants as middleman-owned during worktree reuse and pushed-head upstream repair, so a workspace that took one can still be set up again

Setup still fails when the PR head commit cannot be obtained at all; pointing a workspace at unrelated code would be worse.

<sup>generated by a clanker</sup>