### PR TITLE
Bootstrap reusable CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_call:
   push:
     branches: [main]
   pull_request:
@@ -20,7 +21,7 @@ concurrency:
 jobs:
   detect_changes:
     name: Detect changed paths
-    runs-on: kenn-linux-x64
+    runs-on: ubuntu-latest
     outputs:
       backend: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.backend == 'true' || steps.filter.outputs.ci == 'true' }}
       frontend: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.frontend == 'true' || steps.filter.outputs.ci == 'true' }}
@@ -70,7 +71,7 @@ jobs:
 
   ensure_playwright_image:
     name: Ensure Playwright CI image
-    runs-on: kenn-linux-x64
+    runs-on: ubuntu-latest
     needs: detect_changes
     if: needs.detect_changes.outputs.backend == 'true' || needs.detect_changes.outputs.frontend == 'true' || needs.detect_changes.outputs.e2e == 'true'
     permissions:
@@ -146,7 +147,7 @@ jobs:
           echo "image=${PLAYWRIGHT_CI_IMAGE}@${manifest_digest}" >> "$GITHUB_OUTPUT"
 
   lint:
-    runs-on: kenn-linux-x64
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -198,11 +199,7 @@ jobs:
 
   test_go:
     name: Go tests
-    runs-on: kenn-linux-x64
-    # The runner guarantees 14 cores and can burst to 32. Seven four-thread
-    # package processes can use 28 burst cores while leaving headroom for the
-    # runner and compiler. The 28 GiB job does not need an artificial Go heap
-    # limit; package fan-out remains bounded by GOFLAGS.
+    runs-on: ubuntu-latest
     env:
       GOMAXPROCS: "4"
       GOFLAGS: "-p=7"
@@ -271,7 +268,7 @@ jobs:
 
   test_frontend:
     name: Frontend unit tests
-    runs-on: kenn-linux-x64
+    runs-on: ubuntu-latest
     needs: detect_changes
     if: needs.detect_changes.outputs.backend == 'true' || needs.detect_changes.outputs.frontend == 'true'
     steps:
@@ -330,7 +327,7 @@ jobs:
 
   race:
     name: go test -race
-    runs-on: kenn-linux-x64
+    runs-on: ubuntu-latest
     needs: detect_changes
     if: needs.detect_changes.outputs.backend == 'true'
     steps:
@@ -401,7 +398,7 @@ jobs:
           retention-days: 7
 
   build:
-    runs-on: kenn-linux-x64
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -437,7 +434,7 @@ jobs:
         run: go build -o middleman ./cmd/middleman
 
   e2e-mock:
-    runs-on: kenn-linux-x64
+    runs-on: ubuntu-latest
     needs: [detect_changes, ensure_playwright_image]
     if: needs.detect_changes.outputs.frontend == 'true' || needs.detect_changes.outputs.e2e == 'true'
     permissions:
@@ -485,7 +482,7 @@ jobs:
           retention-days: 7
 
   e2e:
-    runs-on: kenn-linux-x64
+    runs-on: ubuntu-latest
     needs: [detect_changes, ensure_playwright_image]
     if: needs.detect_changes.outputs.backend == 'true' || needs.detect_changes.outputs.frontend == 'true' || needs.detect_changes.outputs.e2e == 'true'
     permissions:
@@ -577,7 +574,7 @@ jobs:
           retention-days: 7
 
   e2e-roborev:
-    runs-on: kenn-linux-x64
+    runs-on: ubuntu-latest
     needs: detect_changes
     if: needs.detect_changes.outputs.backend == 'true' || needs.detect_changes.outputs.frontend == 'true' || needs.detect_changes.outputs.e2e == 'true'
     env:
@@ -629,7 +626,7 @@ jobs:
 
   test_browser:
     name: frontend browser tests
-    runs-on: kenn-linux-x64
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [detect_changes, ensure_playwright_image]
     if: needs.detect_changes.outputs.backend == 'true' || needs.detect_changes.outputs.frontend == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  MIDDLEMAN_CI_WORKERS: "2"
+
 permissions:
   checks: write
   contents: read
@@ -201,8 +204,8 @@ jobs:
     name: Go tests
     runs-on: ubuntu-latest
     env:
-      GOMAXPROCS: "4"
-      GOFLAGS: "-p=7"
+      GOMAXPROCS: "2"
+      GOFLAGS: "-p=2"
     needs: detect_changes
     if: needs.detect_changes.outputs.backend == 'true'
     steps:

--- a/frontend/playwright-e2e.config.ts
+++ b/frontend/playwright-e2e.config.ts
@@ -3,14 +3,17 @@ import { ensureE2EServer } from "./tests/e2e-full/support/e2eServer";
 
 const serverInfo = await ensureE2EServer();
 
-// Chromium can use 28 of the runner's 32 burst cores. Firefox's heavier
-// per-worker processes degrade past about 50% of available cores (measured
-// locally: 9 workers beat both 6 and 13), so CI caps it at the guaranteed
-// 14-core baseline.
+// Chromium can use twice the configured CI baseline. Firefox's heavier
+// per-worker processes stay at the baseline so both managed and hosted
+// runners can select concurrency that matches their available resources.
 function configuredWorkers(): number | string {
   const args = process.argv.join(" ");
   const firefox = /--project[= ]firefox/.test(args);
-  if (process.env.CI) return firefox ? 14 : 28;
+  if (process.env.CI) {
+    const configured = Number.parseInt(process.env.MIDDLEMAN_CI_WORKERS ?? "", 10);
+    const baseline = configured > 0 ? configured : 14;
+    return firefox ? baseline : baseline * 2;
+  }
   return firefox ? "50%" : "75%";
 }
 

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -7,10 +7,9 @@ process.env.PLAYWRIGHT_PORT = String(port);
 const baseURL = `http://${host}:${port}`;
 
 function ciWorkers(): number | undefined {
-  // Mock tests share one Vite dev server. At 28 Chromium workers, concurrent
-  // navigation and reload bursts can starve that server past the 30s test
-  // timeout; the runner's guaranteed 14 cores complete the suite cleanly.
-  return process.env.CI ? 14 : undefined;
+  if (!process.env.CI) return undefined;
+  const configured = Number.parseInt(process.env.MIDDLEMAN_CI_WORKERS ?? "", 10);
+  return configured > 0 ? configured : 14;
 }
 
 const workers = ciWorkers();

--- a/frontend/src/lib/dev/viteConfig.test.ts
+++ b/frontend/src/lib/dev/viteConfig.test.ts
@@ -18,6 +18,7 @@ describe("vite config", () => {
   it("uses the guaranteed CI cores for unit tests", () => {
     expect(resolveUnitTestWorkers({})).toBeUndefined();
     expect(resolveUnitTestWorkers({ CI: "1" })).toBe(14);
+    expect(resolveUnitTestWorkers({ CI: "1", MIDDLEMAN_CI_WORKERS: "2" })).toBe(2);
   });
 
   it("runs unit tests in worker threads", () => {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -144,7 +144,9 @@ export function resolveBrowserTestWorkers(env: Record<string, string | undefined
 }
 
 export function resolveUnitTestWorkers(env: Record<string, string | undefined> = process.env): number | undefined {
-  return env.CI ? 14 : undefined;
+  if (!env.CI) return undefined;
+  const configured = Number.parseInt(env.MIDDLEMAN_CI_WORKERS ?? "", 10);
+  return configured > 0 ? configured : 14;
 }
 
 function terminalWebSocketProxy(url: string): ProxyOptions {
@@ -167,9 +169,8 @@ const unitTestProject = {
   extends: true,
   test: {
     name: "unit",
-    // Match the runner's guaranteed cores now that CI has enough memory for
-    // concurrent jsdom workers. Node's global Web Storage must stay disabled
-    // in workers so jsdom owns localStorage.
+    // Match the workflow-selected runner profile. Node's global Web Storage
+    // must stay disabled in workers so jsdom owns localStorage.
     pool: "threads",
     execArgv: ["--no-experimental-webstorage"],
     ...(unitTestMaxWorkers ? { maxWorkers: unitTestMaxWorkers } : {}),


### PR DESCRIPTION
## Summary

- make the existing CI workflow callable from a later main-pinned dispatcher
- retain the current pull-request trigger
- use GitHub-hosted runners during the bootstrap phase because the legacy managed label no longer admits this public repository
- select a conservative browser and Go worker profile for the smaller hosted runner

This restores full pull-request validation while the replacement runner-routing change is reviewed and landed separately.