### PR TITLE
Show live agent state in workspace rows

### DIFF
--- a/cmd/middleman/agent_hook_cli_test.go
+++ b/cmd/middleman/agent_hook_cli_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/middleman/internal/agentactivity"
+)
+
+func TestAgentHookRunReceivesLifecyclePayload(t *testing.T) {
+	require := require.New(t)
+	stateDir := t.TempDir()
+	workspace := t.TempDir()
+	t.Setenv(agentactivity.RuntimeSessionKeyEnv, "runtime-1")
+	payload, err := json.Marshal(map[string]string{
+		"session_id": "agent-1", "cwd": workspace,
+		"hook_event_name": "UserPromptSubmit",
+	})
+	require.NoError(err)
+
+	require.NoError(runAgentHookCLI([]string{
+		"run", "--state-dir", stateDir, "--source", "middleman-agent-activity",
+	}, strings.NewReader(string(payload)), io.Discard))
+
+	snapshot, ok := agentactivity.NewStore(stateDir).SnapshotForWorkspace(
+		workspace, []string{"runtime-1"},
+	)
+	require.True(ok)
+	assert.Equal(t, agentactivity.StateWorking, snapshot.State)
+}

--- a/cmd/middleman/agent_hook_cli_test.go
+++ b/cmd/middleman/agent_hook_cli_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"encoding/json"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -31,4 +33,25 @@ func TestAgentHookRunReceivesLifecyclePayload(t *testing.T) {
 	)
 	require.True(ok)
 	assert.Equal(t, agentactivity.StateWorking, snapshot.State)
+}
+
+func TestAgentHookInstallRejectsRelativeDataDirectory(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	require.NoError(os.WriteFile(configPath, []byte("data_dir = \"relative-data\"\n"), 0o600))
+	configDir := filepath.Join(dir, "codex")
+	t.Setenv("CODEX_HOME", configDir)
+
+	err := runAgentHookInstall("install", []string{
+		"--config", configPath,
+		"--agent", "codex",
+		"--binary", "/opt/middleman",
+	}, io.Discard)
+
+	require.Error(err)
+	assert.Contains(err.Error(), "absolute data_dir")
+	_, statErr := os.Stat(filepath.Join(configDir, "hooks.json"))
+	assert.ErrorIs(statErr, os.ErrNotExist)
 }

--- a/cmd/middleman/main.go
+++ b/cmd/middleman/main.go
@@ -302,6 +302,9 @@ func runAgentHookInstall(action string, args []string, stdout io.Writer) error {
 	if err != nil {
 		return err
 	}
+	if !filepath.IsAbs(cfg.DataDir) {
+		return fmt.Errorf("agent hook install requires an absolute data_dir: %q", cfg.DataDir)
+	}
 	executable := strings.TrimSpace(*binary)
 	if executable == "" {
 		executable, err = os.Executable()

--- a/cmd/middleman/main.go
+++ b/cmd/middleman/main.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	oteltelemetry "go.kenn.io/kit/telemetry"
+	"go.kenn.io/middleman/internal/agentactivity"
 	"go.kenn.io/middleman/internal/archive"
 	"go.kenn.io/middleman/internal/cli/ctl"
 	"go.kenn.io/middleman/internal/cli/serve"
@@ -214,6 +215,8 @@ func runCLI(args []string, stdout io.Writer) error {
 			return nil
 		case "archive":
 			return runArchiveCLI(args[1:], stdout)
+		case "agent-hook":
+			return runAgentHookCLI(args[1:], os.Stdin, stdout)
 		case "serve":
 			return serve.Run(args[1:], runServer)
 		}
@@ -227,6 +230,104 @@ func runCLI(args []string, stdout io.Writer) error {
 	}
 
 	return serve.Run(args, runServer)
+}
+
+func runAgentHookCLI(args []string, stdin io.Reader, stdout io.Writer) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: middleman agent-hook <run|install|uninstall>")
+	}
+	switch args[0] {
+	case "run":
+		return runAgentHookReceiver(args[1:], stdin)
+	case "install", "uninstall":
+		return runAgentHookInstall(args[0], args[1:], stdout)
+	default:
+		return fmt.Errorf("unknown agent-hook subcommand %q", args[0])
+	}
+}
+
+func runAgentHookReceiver(args []string, stdin io.Reader) error {
+	fs := flag.NewFlagSet("middleman agent-hook run", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	stateDir := fs.String("state-dir", "", "agent activity state directory")
+	source := fs.String("source", "", "hook source marker")
+	if err := fs.Parse(args); err != nil {
+		return nil
+	}
+	if *source != "middleman-agent-activity" {
+		return nil
+	}
+	store := agentactivity.NewStore(*stateDir)
+	_ = store.HandleHook(
+		stdin, os.Getenv(agentactivity.RuntimeSessionKeyEnv),
+	)
+	return nil
+}
+
+func runAgentHookInstall(action string, args []string, stdout io.Writer) error {
+	fs := flag.NewFlagSet("middleman agent-hook "+action, flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	configPath := fs.String("config", config.DefaultConfigPath(), "middleman config path")
+	agent := fs.String("agent", "", "agent integration (claude or codex; empty installs both)")
+	binary := fs.String("binary", "", "middleman binary path used by installed hooks")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	integrations := []agentactivity.Integration{
+		agentactivity.IntegrationClaude,
+		agentactivity.IntegrationCodex,
+	}
+	if strings.TrimSpace(*agent) != "" {
+		integration, err := agentactivity.ParseIntegration(*agent)
+		if err != nil {
+			return err
+		}
+		integrations = []agentactivity.Integration{integration}
+	}
+
+	if action == "uninstall" {
+		for _, integration := range integrations {
+			result, err := agentactivity.Uninstall(integration)
+			if err != nil {
+				return err
+			}
+			if _, err := fmt.Fprintf(stdout, "Removed middleman %s hooks from %s\n", integration, result.ConfigPath); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	cfg, err := config.Load(*configPath)
+	if err != nil {
+		return err
+	}
+	executable := strings.TrimSpace(*binary)
+	if executable == "" {
+		executable, err = os.Executable()
+		if err != nil {
+			return fmt.Errorf("resolve middleman executable: %w", err)
+		}
+	}
+	for _, integration := range integrations {
+		result, err := agentactivity.Install(
+			integration,
+			executable,
+			filepath.Join(cfg.DataDir, "agent-activity"),
+		)
+		if err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(stdout, "Installed middleman %s hooks in %s\n", integration, result.ConfigPath); err != nil {
+			return err
+		}
+		if integration == agentactivity.IntegrationCodex {
+			if _, err := fmt.Fprintln(stdout, "Open /hooks in Codex once to review and trust the new hook commands."); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func runVersionCLI(args []string, stdout io.Writer) error {

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -235,15 +235,11 @@ visible to Git, the write fails.
 
 ## Agent Activity Hooks
 
-- `middleman agent-hook install` merges user-level Claude/Codex hooks, and
-  uninstall removes only its handlers; Codex hook trust stays explicit
-  (`internal/agentactivity/integration.go::Install`).
-- Reports apply only when the runtime-session key and worktree match a live
-  agent. Priority is approval, input, working, idle; reported idle overrides
-  tmux inference, while missing reports retain it
-  (`internal/server/workspaceapi/routes_handlers.go::applyAgentActivity`).
-- Hook errors fail open, and session end removes its report
-  (`internal/agentactivity/store.go::Store.HandleHook`).
+- User-level hooks are single-target: install merges, uninstall preserves other
+  handlers, and the last install wins (`internal/agentactivity/integration.go::Install`).
+- Matching live runtime/worktree reports use approval, input, working, idle priority;
+  latest state expires after 30 minutes or session exit, then tmux resumes (`internal/agentactivity/`, `internal/server/workspaceapi/lifecycle.go::Handler.HandleRuntimeSessionExit`).
+- The active sidebar polls every five seconds, and hook receipt fails open (`frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte::onMount`, `cmd/middleman/main.go::runAgentHookReceiver`).
 
 ## Diff Scopes
 

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -233,6 +233,18 @@ Before writing, middleman ignores the generated path through the worktree's
 private exclude file, not tracked `.gitignore`. If the path would remain
 visible to Git, the write fails.
 
+## Agent Activity Hooks
+
+- `middleman agent-hook install` merges user-level Claude/Codex hooks, and
+  uninstall removes only its handlers; Codex hook trust stays explicit
+  (`internal/agentactivity/integration.go::Install`).
+- Reports apply only when the runtime-session key and worktree match a live
+  agent. Priority is approval, input, working, idle; reported idle overrides
+  tmux inference, while missing reports retain it
+  (`internal/server/workspaceapi/routes_handlers.go::applyAgentActivity`).
+- Hook errors fail open, and session end removes its report
+  (`internal/agentactivity/store.go::Store.HandleHook`).
+
 ## Diff Scopes
 
 Workspace diffs compare against local `HEAD`, the pushed branch, or a merge

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -239,6 +239,9 @@ visible to Git, the write fails.
   handlers, and the last install wins (`internal/agentactivity/integration.go::Install`).
 - Matching live runtime/worktree reports use approval, input, working, idle priority;
   latest state expires after 30 minutes or session exit, then tmux resumes (`internal/agentactivity/`, `internal/server/workspaceapi/lifecycle.go::Handler.HandleRuntimeSessionExit`).
+- Hook installs require absolute data roots and update symlink targets instead of replacing
+  config links; report/worktree matching uses canonical filesystem paths (`cmd/middleman/main.go::runAgentHookInstall`,
+  `internal/agentactivity/integration.go::writeJSONObject`, `internal/agentactivity/store.go::canonicalWorkspacePath`).
 - The active sidebar polls every five seconds, and hook receipt fails open (`frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte::onMount`, `cmd/middleman/main.go::runAgentHookReceiver`).
 
 ## Diff Scopes

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -87,7 +87,9 @@ branches from the repository's default branch.
 
 Run `middleman agent-hook install` once to show Claude and Codex activity in
 workspace rows. The rows distinguish active work, approval requests, and user
-input; Codex asks you to review the installed command through `/hooks` once.
+input, refreshing within five seconds while the sidebar is open. Reports expire
+after 30 minutes without another hook event and then fall back to tmux activity;
+Codex asks you to review the installed command through `/hooks` once.
 
 ## Use Kata tasks
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -85,6 +85,10 @@ picker preselects the repository you last started work in. Name the
 branch or leave it empty and middleman generates one; either way the worktree
 branches from the repository's default branch.
 
+Run `middleman agent-hook install` once to show Claude and Codex activity in
+workspace rows. The rows distinguish active work, approval requests, and user
+input; Codex asks you to review the installed command through `/hooks` once.
+
 ## Use Kata tasks
 
 Enable Kata mode when your work is tracked in Kata. middleman discovers Kata

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -7528,6 +7528,8 @@ components:
             - approval
           type: string
         agent_state_updated_at:
+          description: UTC timestamp of the hook report that produced agent_state.
+          format: date-time
           type: string
         associated_pr_number:
           format: int64

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -7519,6 +7519,16 @@ components:
           format: uri
           readOnly: true
           type: string
+        agent_state:
+          description: Hook-reported aggregate state for live agent sessions. Omitted when no live session has reported lifecycle state.
+          enum:
+            - idle
+            - working
+            - input
+            - approval
+          type: string
+        agent_state_updated_at:
+          type: string
         associated_pr_number:
           format: int64
           type: integer

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -74,6 +74,8 @@
       | "unknown"
       | null;
     tmux_last_output_at?: string | null;
+    agent_state?: "idle" | "working" | "input" | "approval" | null;
+    agent_state_updated_at?: string | null;
     status: string;
     error_message?: string | null;
     created_at: string;
@@ -608,6 +610,23 @@
       return `Working (${source})`;
     }
     return title || "Working";
+  }
+
+  function agentStatePresentation(ws: Workspace): {
+    label: "Working" | "Approval" | "Input";
+    status: StatusDotStatus;
+    tone: "working" | "approval" | "input";
+  } | null {
+    switch (ws.agent_state) {
+      case "working":
+        return { label: "Working", status: "working", tone: "working" };
+      case "approval":
+        return { label: "Approval", status: "waiting", tone: "approval" };
+      case "input":
+        return { label: "Input", status: "waiting", tone: "input" };
+      default:
+        return null;
+    }
   }
 
   function itemStateClass(ws: Workspace): string {
@@ -1182,6 +1201,7 @@
           {@const ahead = ws.commits_ahead ?? 0}
           {@const behind = ws.commits_behind ?? 0}
           {@const showPush = ahead > 0 || behind > 0}
+          {@const agentState = agentStatePresentation(ws)}
           <div
             class={["ws-row", { selected: isSelectedWorkspace(ws) }]}
             onclick={(e) => {
@@ -1221,10 +1241,22 @@
                   size={6}
                 />
                 <span class="ws-name">{displayName(ws)}</span>
-                {#if ws.tmux_working}
-                  <StatusDot status="working" label={workingTitle(ws)} size={6} />
+                {#if agentState}
+                  <span
+                    class={["agent-state", `agent-state--${agentState.tone}`]}
+                    title={`Agent ${agentState.label.toLowerCase()}`}
+                  >
+                    <StatusDot
+                      status={agentState.status}
+                      label={`Agent ${agentState.label.toLowerCase()}`}
+                      size={6}
+                    />
+                    <span>{agentState.label}</span>
+                  </span>
                 {:else if workspaceActionMatches(ws)}
                   <StatusDot status="working" label={workspaceBusyLabel(ws)} size={6} />
+                {:else if ws.agent_state == null && ws.tmux_working}
+                  <StatusDot status="working" label={workingTitle(ws)} size={6} />
                 {/if}
               </div>
               <div class="ws-row-meta">
@@ -1783,6 +1815,30 @@
 
   .ws-row.selected .ws-name {
     font-weight: 600;
+  }
+
+  .agent-state {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    flex-shrink: 0;
+    font-size: var(--font-size-xs);
+    font-weight: 600;
+    line-height: 1;
+  }
+
+  .agent-state--working {
+    color: var(--accent-green);
+  }
+
+  .agent-state--approval {
+    color: var(--accent-amber);
+    --status-waiting: var(--accent-amber);
+  }
+
+  .agent-state--input {
+    color: var(--accent-purple);
+    --status-waiting: var(--accent-purple);
   }
 
 

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
@@ -67,6 +67,7 @@ interface WorkspaceFixtureOptions {
   tmuxWorking?: boolean;
   tmuxPaneTitle?: string | null;
   tmuxActivitySource?: string;
+  agentState?: "idle" | "working" | "input" | "approval" | null;
   status?: string;
 }
 
@@ -93,6 +94,7 @@ function workspaceFixture({
   tmuxWorking = false,
   tmuxPaneTitle = null,
   tmuxActivitySource = "unknown",
+  agentState = null,
   status = "ready",
 }: WorkspaceFixtureOptions) {
   // Kata and ad-hoc workspaces carry no joined provider item metadata.
@@ -119,6 +121,7 @@ function workspaceFixture({
     tmux_working: tmuxWorking,
     tmux_pane_title: tmuxPaneTitle,
     tmux_activity_source: tmuxActivitySource,
+    agent_state: agentState,
     status,
     created_at: createdAt,
     tmux_last_output_at: tmuxLastOutputAt,
@@ -1443,6 +1446,59 @@ describe("WorkspaceListSidebar", () => {
     });
 
     expect(await screen.findByLabelText("Working (title): Running focused tests")).toBeTruthy();
+  });
+
+  it.each([
+    ["working", "Working", "Agent working"],
+    ["approval", "Approval", "Agent approval"],
+    ["input", "Input", "Agent input"],
+  ] as const)("shows hook-reported agent %s state", async (agentState, label, ariaLabel) => {
+    mockGet.mockResolvedValue({
+      data: {
+        workspaces: [
+          workspaceFixture({
+            id: `ws-${agentState}`,
+            provider: "github",
+            platformHost: "github.com",
+            owner: "acme",
+            name: "widget",
+            number: 9,
+            agentState,
+          }),
+        ],
+      },
+    });
+
+    render(WorkspaceListSidebar, { props: { selectedId: `ws-${agentState}` } });
+
+    expect(await screen.findByText(label)).toBeTruthy();
+    expect(screen.getByLabelText(ariaLabel)).toBeTruthy();
+  });
+
+  it("lets hook-reported idle override recent tmux output", async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        workspaces: [
+          workspaceFixture({
+            id: "ws-idle-agent",
+            provider: "github",
+            platformHost: "github.com",
+            owner: "acme",
+            name: "widget",
+            number: 9,
+            agentState: "idle",
+            tmuxWorking: true,
+            tmuxPaneTitle: "stale output",
+            tmuxActivitySource: "output",
+          }),
+        ],
+      },
+    });
+
+    render(WorkspaceListSidebar, { props: { selectedId: "ws-idle-agent" } });
+
+    await screen.findByText("PR 9");
+    expect(screen.queryByLabelText("Working (output): stale output")).toBeNull();
   });
 
   it("pushes an ahead workspace branch and shows a busy state while pending", async () => {

--- a/internal/agentactivity/integration.go
+++ b/internal/agentactivity/integration.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -201,7 +202,16 @@ func readJSONObject(path string) (map[string]any, error) {
 		return nil, err
 	}
 	var root map[string]any
-	if err := json.Unmarshal(data, &root); err != nil {
+	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	decoder.UseNumber()
+	if err := decoder.Decode(&root); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			err = errors.New("multiple JSON values")
+		}
 		return nil, fmt.Errorf("parse %s: %w", path, err)
 	}
 	if root == nil {
@@ -248,7 +258,18 @@ func arrayField(root map[string]any, key, path string) ([]any, error) {
 }
 
 func writeJSONObject(path string, value map[string]any) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+	writePath := path
+	info, err := os.Lstat(path)
+	if err == nil && info.Mode()&os.ModeSymlink != 0 {
+		resolved, resolveErr := filepath.EvalSymlinks(path)
+		if resolveErr != nil {
+			return fmt.Errorf("resolve agent hook config symlink: %w", resolveErr)
+		}
+		writePath = resolved
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("inspect agent hook config path: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(writePath), 0o700); err != nil {
 		return err
 	}
 	data, err := json.MarshalIndent(value, "", "  ")
@@ -256,7 +277,7 @@ func writeJSONObject(path string, value map[string]any) error {
 		return err
 	}
 	data = append(data, '\n')
-	tmp, err := os.CreateTemp(filepath.Dir(path), ".middleman-hooks-*")
+	tmp, err := os.CreateTemp(filepath.Dir(writePath), ".middleman-hooks-*")
 	if err != nil {
 		return err
 	}
@@ -273,7 +294,7 @@ func writeJSONObject(path string, value map[string]any) error {
 	if err := tmp.Close(); err != nil {
 		return err
 	}
-	return os.Rename(tmpPath, path)
+	return os.Rename(tmpPath, writePath)
 }
 
 func windowsCommand(args ...string) string {

--- a/internal/agentactivity/integration.go
+++ b/internal/agentactivity/integration.go
@@ -1,0 +1,289 @@
+package agentactivity
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	shellquote "github.com/kballard/go-shellquote"
+)
+
+type Integration string
+
+const (
+	IntegrationClaude Integration = "claude"
+	IntegrationCodex  Integration = "codex"
+)
+
+const hookCommandMarker = "--source middleman-agent-activity"
+
+var integrationHookEvents = map[Integration][]string{
+	IntegrationClaude: {
+		"SessionStart", "UserPromptSubmit", "PreToolUse", "PostToolUse",
+		"PostToolUseFailure", "PermissionRequest", "Notification", "Stop", "SessionEnd",
+	},
+	IntegrationCodex: {
+		"SessionStart", "UserPromptSubmit", "PreToolUse", "PostToolUse",
+		"PermissionRequest", "Stop", "SessionEnd",
+	},
+}
+
+type InstallResult struct {
+	Integration Integration
+	ConfigPath  string
+}
+
+func Install(integration Integration, executable, stateDir string) (InstallResult, error) {
+	configPath, err := integrationConfigPath(integration)
+	if err != nil {
+		return InstallResult{}, err
+	}
+	if strings.TrimSpace(executable) == "" || strings.TrimSpace(stateDir) == "" {
+		return InstallResult{}, errors.New("agent hook executable and state directory are required")
+	}
+	root, err := readJSONObject(configPath)
+	if err != nil {
+		return InstallResult{}, err
+	}
+	hooks, err := objectField(root, "hooks", configPath)
+	if err != nil {
+		return InstallResult{}, err
+	}
+	removeMiddlemanHooks(hooks)
+
+	command := shellquote.Join(
+		executable, "agent-hook", "run", "--state-dir", stateDir,
+		"--source", "middleman-agent-activity",
+	)
+	commandWindows := windowsCommand(
+		executable, "agent-hook", "run", "--state-dir", stateDir,
+		"--source", "middleman-agent-activity",
+	)
+	if runtime.GOOS == "windows" {
+		command = commandWindows
+	}
+	for _, event := range integrationHookEvents[integration] {
+		handler := map[string]any{
+			"type":    "command",
+			"command": command,
+			"timeout": 2,
+		}
+		if integration == IntegrationCodex {
+			handler["commandWindows"] = commandWindows
+		}
+		entry := map[string]any{"hooks": []any{handler}}
+		existing, err := arrayField(hooks, event, configPath)
+		if err != nil {
+			return InstallResult{}, err
+		}
+		hooks[event] = append(existing, entry)
+	}
+	if err := writeJSONObject(configPath, root); err != nil {
+		return InstallResult{}, err
+	}
+	return InstallResult{Integration: integration, ConfigPath: configPath}, nil
+}
+
+func Uninstall(integration Integration) (InstallResult, error) {
+	configPath, err := integrationConfigPath(integration)
+	if err != nil {
+		return InstallResult{}, err
+	}
+	if _, err := os.Stat(configPath); errors.Is(err, os.ErrNotExist) {
+		return InstallResult{Integration: integration, ConfigPath: configPath}, nil
+	} else if err != nil {
+		return InstallResult{}, err
+	}
+	root, err := readJSONObject(configPath)
+	if err != nil {
+		return InstallResult{}, err
+	}
+	hooks, err := existingObjectField(root, "hooks", configPath)
+	if err != nil {
+		return InstallResult{}, err
+	}
+	if hooks != nil {
+		removeMiddlemanHooks(hooks)
+	}
+	if err := writeJSONObject(configPath, root); err != nil {
+		return InstallResult{}, err
+	}
+	return InstallResult{Integration: integration, ConfigPath: configPath}, nil
+}
+
+func ParseIntegration(raw string) (Integration, error) {
+	integration := Integration(strings.ToLower(strings.TrimSpace(raw)))
+	if _, ok := integrationHookEvents[integration]; !ok {
+		return "", fmt.Errorf("unsupported agent hook integration %q (expected claude or codex)", raw)
+	}
+	return integration, nil
+}
+
+func integrationConfigPath(integration Integration) (string, error) {
+	dir := ""
+	switch integration {
+	case IntegrationClaude:
+		dir = strings.TrimSpace(os.Getenv("CLAUDE_CONFIG_DIR"))
+		if dir == "" {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return "", err
+			}
+			dir = filepath.Join(home, ".claude")
+		}
+		return filepath.Join(dir, "settings.json"), nil
+	case IntegrationCodex:
+		dir = strings.TrimSpace(os.Getenv("CODEX_HOME"))
+		if dir == "" {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return "", err
+			}
+			dir = filepath.Join(home, ".codex")
+		}
+		return filepath.Join(dir, "hooks.json"), nil
+	default:
+		return "", fmt.Errorf("unsupported agent hook integration %q", integration)
+	}
+}
+
+func removeMiddlemanHooks(hooks map[string]any) {
+	for event, rawEntries := range hooks {
+		entries, ok := rawEntries.([]any)
+		if !ok {
+			continue
+		}
+		keptEntries := make([]any, 0, len(entries))
+		for _, rawEntry := range entries {
+			entry, ok := rawEntry.(map[string]any)
+			if !ok {
+				keptEntries = append(keptEntries, rawEntry)
+				continue
+			}
+			rawHandlers, ok := entry["hooks"].([]any)
+			if !ok {
+				keptEntries = append(keptEntries, rawEntry)
+				continue
+			}
+			keptHandlers := make([]any, 0, len(rawHandlers))
+			for _, rawHandler := range rawHandlers {
+				handler, ok := rawHandler.(map[string]any)
+				command, _ := handler["command"].(string)
+				if ok && strings.Contains(command, hookCommandMarker) {
+					continue
+				}
+				keptHandlers = append(keptHandlers, rawHandler)
+			}
+			if len(keptHandlers) == 0 {
+				continue
+			}
+			entry["hooks"] = keptHandlers
+			keptEntries = append(keptEntries, entry)
+		}
+		if len(keptEntries) == 0 {
+			delete(hooks, event)
+		} else {
+			hooks[event] = keptEntries
+		}
+	}
+}
+
+func readJSONObject(path string) (map[string]any, error) {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return map[string]any{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var root map[string]any
+	if err := json.Unmarshal(data, &root); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if root == nil {
+		root = map[string]any{}
+	}
+	return root, nil
+}
+
+func objectField(root map[string]any, key, path string) (map[string]any, error) {
+	existing, err := existingObjectField(root, key, path)
+	if err != nil {
+		return nil, err
+	}
+	if existing != nil {
+		return existing, nil
+	}
+	value := map[string]any{}
+	root[key] = value
+	return value, nil
+}
+
+func existingObjectField(root map[string]any, key, path string) (map[string]any, error) {
+	raw, ok := root[key]
+	if !ok || raw == nil {
+		return nil, nil
+	}
+	value, ok := raw.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%s field %q must be an object", path, key)
+	}
+	return value, nil
+}
+
+func arrayField(root map[string]any, key, path string) ([]any, error) {
+	raw, ok := root[key]
+	if !ok || raw == nil {
+		return nil, nil
+	}
+	value, ok := raw.([]any)
+	if !ok {
+		return nil, fmt.Errorf("%s hook event %q must be an array", path, key)
+	}
+	return value, nil
+}
+
+func writeJSONObject(path string, value map[string]any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".middleman-hooks-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
+
+func windowsCommand(args ...string) string {
+	quoted := make([]string, 0, len(args))
+	for _, arg := range args {
+		if arg != "" && !strings.ContainsAny(arg, " \t\"") {
+			quoted = append(quoted, arg)
+			continue
+		}
+		quoted = append(quoted, `"`+strings.ReplaceAll(arg, `"`, `\"`)+`"`)
+	}
+	return strings.Join(quoted, " ")
+}

--- a/internal/agentactivity/store.go
+++ b/internal/agentactivity/store.go
@@ -1,0 +1,255 @@
+package agentactivity
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+)
+
+type State string
+
+const (
+	StateIdle     State = "idle"
+	StateWorking  State = "working"
+	StateInput    State = "input"
+	StateApproval State = "approval"
+)
+
+const RuntimeSessionKeyEnv = "MIDDLEMAN_RUNTIME_SESSION_KEY"
+
+type Report struct {
+	SessionID         string    `json:"session_id"`
+	RuntimeSessionKey string    `json:"runtime_session_key"`
+	CWD               string    `json:"cwd"`
+	State             State     `json:"state"`
+	UpdatedAt         time.Time `json:"updated_at"`
+}
+
+type Snapshot struct {
+	State     State
+	UpdatedAt time.Time
+}
+
+type hookInput struct {
+	SessionID        string `json:"session_id"`
+	CWD              string `json:"cwd"`
+	HookEventName    string `json:"hook_event_name"`
+	ToolName         string `json:"tool_name"`
+	NotificationType string `json:"notification_type"`
+	AgentID          string `json:"agent_id"`
+}
+
+type Store struct {
+	root string
+	now  func() time.Time
+}
+
+func NewStore(root string) *Store {
+	return &Store{root: root, now: time.Now}
+}
+
+func (s *Store) HandleHook(input io.Reader, runtimeSessionKey string) error {
+	if s == nil || strings.TrimSpace(s.root) == "" {
+		return nil
+	}
+	var hook hookInput
+	if err := json.NewDecoder(io.LimitReader(input, 1<<20)).Decode(&hook); err != nil {
+		return fmt.Errorf("decode agent hook: %w", err)
+	}
+	if hook.AgentID != "" {
+		return nil
+	}
+	hook.SessionID = strings.TrimSpace(hook.SessionID)
+	runtimeSessionKey = strings.TrimSpace(runtimeSessionKey)
+	if hook.SessionID == "" || runtimeSessionKey == "" {
+		return nil
+	}
+
+	state, remove, ok := stateForHook(hook)
+	if !ok {
+		return nil
+	}
+	if remove {
+		err := os.Remove(s.reportPath(hook.SessionID))
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+
+	cwd, err := filepath.Abs(strings.TrimSpace(hook.CWD))
+	if err != nil || strings.TrimSpace(hook.CWD) == "" {
+		return nil
+	}
+	report := Report{
+		SessionID:         hook.SessionID,
+		RuntimeSessionKey: runtimeSessionKey,
+		CWD:               filepath.Clean(cwd),
+		State:             state,
+		UpdatedAt:         s.now().UTC(),
+	}
+	return s.writeReport(report)
+}
+
+func (s *Store) SnapshotForWorkspace(cwd string, liveSessionKeys []string) (Snapshot, bool) {
+	if s == nil || strings.TrimSpace(s.root) == "" || len(liveSessionKeys) == 0 {
+		return Snapshot{}, false
+	}
+	absCWD, err := filepath.Abs(strings.TrimSpace(cwd))
+	if err != nil || strings.TrimSpace(cwd) == "" {
+		return Snapshot{}, false
+	}
+	live := make(map[string]struct{}, len(liveSessionKeys))
+	for _, key := range liveSessionKeys {
+		if key = strings.TrimSpace(key); key != "" {
+			live[key] = struct{}{}
+		}
+	}
+	if len(live) == 0 {
+		return Snapshot{}, false
+	}
+
+	entries, err := os.ReadDir(s.root)
+	if err != nil {
+		return Snapshot{}, false
+	}
+	target := filepath.Clean(absCWD)
+	var reports []Report
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		report, ok := s.readReport(filepath.Join(s.root, entry.Name()))
+		if !ok || filepath.Clean(report.CWD) != target {
+			continue
+		}
+		if _, ok := live[report.RuntimeSessionKey]; !ok {
+			continue
+		}
+		reports = append(reports, report)
+	}
+	if len(reports) == 0 {
+		return Snapshot{}, false
+	}
+	slices.SortFunc(reports, func(a, b Report) int {
+		if priority := statePriority(b.State) - statePriority(a.State); priority != 0 {
+			return priority
+		}
+		return b.UpdatedAt.Compare(a.UpdatedAt)
+	})
+	return Snapshot{State: reports[0].State, UpdatedAt: reports[0].UpdatedAt}, true
+}
+
+func stateForHook(input hookInput) (State, bool, bool) {
+	switch input.HookEventName {
+	case "SessionStart":
+		return StateIdle, false, true
+	case "UserPromptSubmit":
+		return StateWorking, false, true
+	case "PreToolUse":
+		if isUserInputTool(input.ToolName) {
+			return StateInput, false, true
+		}
+		return StateWorking, false, true
+	case "PostToolUse", "PostToolUseFailure", "PreCompact", "PostCompact":
+		return StateWorking, false, true
+	case "PermissionRequest":
+		return StateApproval, false, true
+	case "Notification":
+		switch input.NotificationType {
+		case "permission_prompt":
+			return StateApproval, false, true
+		case "idle_prompt", "elicitation_dialog":
+			return StateInput, false, true
+		default:
+			return "", false, false
+		}
+	case "Stop", "Interrupt":
+		return StateIdle, false, true
+	case "SessionEnd":
+		return "", true, true
+	default:
+		return "", false, false
+	}
+}
+
+func isUserInputTool(tool string) bool {
+	switch strings.ToLower(strings.TrimSpace(tool)) {
+	case "askuserquestion", "request_user_input", "tool_user_input":
+		return true
+	default:
+		return false
+	}
+}
+
+func statePriority(state State) int {
+	switch state {
+	case StateApproval:
+		return 4
+	case StateInput:
+		return 3
+	case StateWorking:
+		return 2
+	case StateIdle:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func (s *Store) writeReport(report Report) error {
+	if err := os.MkdirAll(s.root, 0o700); err != nil {
+		return err
+	}
+	data, err := json.Marshal(report)
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(s.root, ".agent-activity-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, s.reportPath(report.SessionID))
+}
+
+func (s *Store) readReport(path string) (Report, bool) {
+	file, err := os.Open(path)
+	if err != nil {
+		return Report{}, false
+	}
+	defer file.Close()
+	var report Report
+	if err := json.NewDecoder(io.LimitReader(file, 64<<10)).Decode(&report); err != nil {
+		return Report{}, false
+	}
+	if statePriority(report.State) == 0 || report.RuntimeSessionKey == "" || report.CWD == "" {
+		return Report{}, false
+	}
+	return report, true
+}
+
+func (s *Store) reportPath(sessionID string) string {
+	sum := sha256.Sum256([]byte(sessionID))
+	return filepath.Join(s.root, hex.EncodeToString(sum[:])+".json")
+}

--- a/internal/agentactivity/store.go
+++ b/internal/agentactivity/store.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -24,6 +25,10 @@ const (
 )
 
 const RuntimeSessionKeyEnv = "MIDDLEMAN_RUNTIME_SESSION_KEY"
+
+// ReportFreshness bounds how long a hook state can override tmux activity
+// without another lifecycle event confirming it.
+const ReportFreshness = 30 * time.Minute
 
 type Report struct {
 	SessionID         string    `json:"session_id"`
@@ -50,6 +55,11 @@ type hookInput struct {
 type Store struct {
 	root string
 	now  func() time.Time
+
+	cacheMu         sync.Mutex
+	cacheDirModTime time.Time
+	cacheValidUntil time.Time
+	cacheReports    []Report
 }
 
 func NewStore(root string) *Store {
@@ -81,6 +91,9 @@ func (s *Store) HandleHook(input io.Reader, runtimeSessionKey string) error {
 		err := os.Remove(s.reportPath(hook.SessionID))
 		if errors.Is(err, os.ErrNotExist) {
 			return nil
+		}
+		if err == nil {
+			s.invalidateCache()
 		}
 		return err
 	}
@@ -117,18 +130,10 @@ func (s *Store) SnapshotForWorkspace(cwd string, liveSessionKeys []string) (Snap
 		return Snapshot{}, false
 	}
 
-	entries, err := os.ReadDir(s.root)
-	if err != nil {
-		return Snapshot{}, false
-	}
 	target := filepath.Clean(absCWD)
 	var reports []Report
-	for _, entry := range entries {
-		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
-			continue
-		}
-		report, ok := s.readReport(filepath.Join(s.root, entry.Name()))
-		if !ok || filepath.Clean(report.CWD) != target {
+	for _, report := range s.reports() {
+		if filepath.Clean(report.CWD) != target {
 			continue
 		}
 		if _, ok := live[report.RuntimeSessionKey]; !ok {
@@ -146,6 +151,104 @@ func (s *Store) SnapshotForWorkspace(cwd string, liveSessionKeys []string) (Snap
 		return b.UpdatedAt.Compare(a.UpdatedAt)
 	})
 	return Snapshot{State: reports[0].State, UpdatedAt: reports[0].UpdatedAt}, true
+}
+
+// RemoveRuntimeSession removes every agent report owned by one launched
+// runtime session.
+func (s *Store) RemoveRuntimeSession(runtimeSessionKey string) error {
+	if s == nil || strings.TrimSpace(s.root) == "" {
+		return nil
+	}
+	runtimeSessionKey = strings.TrimSpace(runtimeSessionKey)
+	if runtimeSessionKey == "" {
+		return nil
+	}
+	var errs []error
+	for _, report := range s.reports() {
+		if report.RuntimeSessionKey != runtimeSessionKey {
+			continue
+		}
+		if err := os.Remove(s.reportPath(report.SessionID)); err != nil &&
+			!errors.Is(err, os.ErrNotExist) {
+			errs = append(errs, err)
+		}
+	}
+	s.invalidateCache()
+	return errors.Join(errs...)
+}
+
+func (s *Store) reports() []Report {
+	s.cacheMu.Lock()
+	defer s.cacheMu.Unlock()
+
+	info, err := os.Stat(s.root)
+	if err != nil {
+		s.clearCacheLocked()
+		return nil
+	}
+	now := s.now().UTC()
+	if info.ModTime().Equal(s.cacheDirModTime) &&
+		(s.cacheValidUntil.IsZero() || now.Before(s.cacheValidUntil)) {
+		return slices.Clone(s.cacheReports)
+	}
+
+	entries, err := os.ReadDir(s.root)
+	if err != nil {
+		s.clearCacheLocked()
+		return nil
+	}
+	reports := make([]Report, 0, len(entries))
+	validUntil := time.Time{}
+	removed := false
+	cleanupPending := false
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		path := filepath.Join(s.root, entry.Name())
+		report, ok := s.readReport(path)
+		if !ok {
+			continue
+		}
+		expiresAt := report.UpdatedAt.Add(ReportFreshness)
+		if !now.Before(expiresAt) {
+			if removeErr := os.Remove(path); removeErr == nil ||
+				errors.Is(removeErr, os.ErrNotExist) {
+				removed = true
+			} else {
+				cleanupPending = true
+			}
+			continue
+		}
+		if validUntil.IsZero() || expiresAt.Before(validUntil) {
+			validUntil = expiresAt
+		}
+		reports = append(reports, report)
+	}
+	if removed {
+		if refreshed, statErr := os.Stat(s.root); statErr == nil {
+			info = refreshed
+		}
+	}
+	s.cacheDirModTime = info.ModTime()
+	if cleanupPending {
+		s.cacheDirModTime = time.Time{}
+	}
+	s.cacheValidUntil = validUntil
+	s.cacheReports = slices.Clone(reports)
+	return reports
+}
+
+func (s *Store) invalidateCache() {
+	s.cacheMu.Lock()
+	defer s.cacheMu.Unlock()
+	s.clearCacheLocked()
+}
+
+func (s *Store) clearCacheLocked() {
+	s.cacheDirModTime = time.Time{}
+	s.cacheValidUntil = time.Time{}
+	s.cacheReports = nil
 }
 
 func stateForHook(input hookInput) (State, bool, bool) {
@@ -230,7 +333,11 @@ func (s *Store) writeReport(report Report) error {
 	if err := tmp.Close(); err != nil {
 		return err
 	}
-	return os.Rename(tmpPath, s.reportPath(report.SessionID))
+	if err := os.Rename(tmpPath, s.reportPath(report.SessionID)); err != nil {
+		return err
+	}
+	s.invalidateCache()
+	return nil
 }
 
 func (s *Store) readReport(path string) (Report, bool) {
@@ -243,7 +350,8 @@ func (s *Store) readReport(path string) (Report, bool) {
 	if err := json.NewDecoder(io.LimitReader(file, 64<<10)).Decode(&report); err != nil {
 		return Report{}, false
 	}
-	if statePriority(report.State) == 0 || report.RuntimeSessionKey == "" || report.CWD == "" {
+	if statePriority(report.State) == 0 || report.RuntimeSessionKey == "" ||
+		report.CWD == "" || report.UpdatedAt.IsZero() {
 		return Report{}, false
 	}
 	return report, true

--- a/internal/agentactivity/store.go
+++ b/internal/agentactivity/store.go
@@ -57,7 +57,7 @@ type Store struct {
 	now  func() time.Time
 
 	cacheMu         sync.Mutex
-	cacheDirModTime time.Time
+	cacheFiles      map[string]os.FileInfo
 	cacheValidUntil time.Time
 	cacheReports    []Report
 }
@@ -98,14 +98,14 @@ func (s *Store) HandleHook(input io.Reader, runtimeSessionKey string) error {
 		return err
 	}
 
-	cwd, err := filepath.Abs(strings.TrimSpace(hook.CWD))
-	if err != nil || strings.TrimSpace(hook.CWD) == "" {
+	cwd, err := canonicalWorkspacePath(hook.CWD)
+	if err != nil {
 		return nil
 	}
 	report := Report{
 		SessionID:         hook.SessionID,
 		RuntimeSessionKey: runtimeSessionKey,
-		CWD:               filepath.Clean(cwd),
+		CWD:               cwd,
 		State:             state,
 		UpdatedAt:         s.now().UTC(),
 	}
@@ -116,8 +116,8 @@ func (s *Store) SnapshotForWorkspace(cwd string, liveSessionKeys []string) (Snap
 	if s == nil || strings.TrimSpace(s.root) == "" || len(liveSessionKeys) == 0 {
 		return Snapshot{}, false
 	}
-	absCWD, err := filepath.Abs(strings.TrimSpace(cwd))
-	if err != nil || strings.TrimSpace(cwd) == "" {
+	target, err := canonicalWorkspacePath(cwd)
+	if err != nil {
 		return Snapshot{}, false
 	}
 	live := make(map[string]struct{}, len(liveSessionKeys))
@@ -130,10 +130,9 @@ func (s *Store) SnapshotForWorkspace(cwd string, liveSessionKeys []string) (Snap
 		return Snapshot{}, false
 	}
 
-	target := filepath.Clean(absCWD)
 	var reports []Report
 	for _, report := range s.reports() {
-		if filepath.Clean(report.CWD) != target {
+		if report.CWD != target {
 			continue
 		}
 		if _, ok := live[report.RuntimeSessionKey]; !ok {
@@ -151,6 +150,22 @@ func (s *Store) SnapshotForWorkspace(cwd string, liveSessionKeys []string) (Snap
 		return b.UpdatedAt.Compare(a.UpdatedAt)
 	})
 	return Snapshot{State: reports[0].State, UpdatedAt: reports[0].UpdatedAt}, true
+}
+
+func canonicalWorkspacePath(path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", errors.New("workspace path is required")
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	clean := filepath.Clean(abs)
+	if resolved, resolveErr := filepath.EvalSymlinks(clean); resolveErr == nil {
+		return filepath.Clean(resolved), nil
+	}
+	return clean, nil
 }
 
 // RemoveRuntimeSession removes every agent report owned by one launched
@@ -181,25 +196,32 @@ func (s *Store) reports() []Report {
 	s.cacheMu.Lock()
 	defer s.cacheMu.Unlock()
 
-	info, err := os.Stat(s.root)
-	if err != nil {
-		s.clearCacheLocked()
-		return nil
-	}
-	now := s.now().UTC()
-	if info.ModTime().Equal(s.cacheDirModTime) &&
-		(s.cacheValidUntil.IsZero() || now.Before(s.cacheValidUntil)) {
-		return slices.Clone(s.cacheReports)
-	}
-
 	entries, err := os.ReadDir(s.root)
 	if err != nil {
 		s.clearCacheLocked()
 		return nil
 	}
+	now := s.now().UTC()
+	files := make(map[string]os.FileInfo)
+	metadataComplete := true
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		info, infoErr := entry.Info()
+		if infoErr != nil {
+			metadataComplete = false
+			continue
+		}
+		files[entry.Name()] = info
+	}
+	if metadataComplete && sameReportFiles(files, s.cacheFiles) &&
+		(s.cacheValidUntil.IsZero() || now.Before(s.cacheValidUntil)) {
+		return slices.Clone(s.cacheReports)
+	}
+
 	reports := make([]Report, 0, len(entries))
 	validUntil := time.Time{}
-	removed := false
 	cleanupPending := false
 	for _, entry := range entries {
 		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
@@ -214,7 +236,7 @@ func (s *Store) reports() []Report {
 		if !now.Before(expiresAt) {
 			if removeErr := os.Remove(path); removeErr == nil ||
 				errors.Is(removeErr, os.ErrNotExist) {
-				removed = true
+				delete(files, entry.Name())
 			} else {
 				cleanupPending = true
 			}
@@ -225,14 +247,9 @@ func (s *Store) reports() []Report {
 		}
 		reports = append(reports, report)
 	}
-	if removed {
-		if refreshed, statErr := os.Stat(s.root); statErr == nil {
-			info = refreshed
-		}
-	}
-	s.cacheDirModTime = info.ModTime()
-	if cleanupPending {
-		s.cacheDirModTime = time.Time{}
+	s.cacheFiles = files
+	if cleanupPending || !metadataComplete {
+		s.cacheFiles = nil
 	}
 	s.cacheValidUntil = validUntil
 	s.cacheReports = slices.Clone(reports)
@@ -246,9 +263,24 @@ func (s *Store) invalidateCache() {
 }
 
 func (s *Store) clearCacheLocked() {
-	s.cacheDirModTime = time.Time{}
+	s.cacheFiles = nil
 	s.cacheValidUntil = time.Time{}
 	s.cacheReports = nil
+}
+
+func sameReportFiles(current, cached map[string]os.FileInfo) bool {
+	if cached == nil || len(current) != len(cached) {
+		return false
+	}
+	for name, currentInfo := range current {
+		cachedInfo, ok := cached[name]
+		if !ok || !os.SameFile(currentInfo, cachedInfo) ||
+			currentInfo.Size() != cachedInfo.Size() ||
+			!currentInfo.ModTime().Equal(cachedInfo.ModTime()) {
+			return false
+		}
+	}
+	return true
 }
 
 func stateForHook(input hookInput) (State, bool, bool) {
@@ -354,6 +386,11 @@ func (s *Store) readReport(path string) (Report, bool) {
 		report.CWD == "" || report.UpdatedAt.IsZero() {
 		return Report{}, false
 	}
+	cwd, err := canonicalWorkspacePath(report.CWD)
+	if err != nil {
+		return Report{}, false
+	}
+	report.CWD = cwd
 	return report, true
 }
 

--- a/internal/agentactivity/store_test.go
+++ b/internal/agentactivity/store_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -72,6 +73,25 @@ func TestStoreAggregatesOnlyLiveWorkspaceSessions(t *testing.T) {
 	assert.Equal(t, StateWorking, snapshot.State)
 }
 
+func TestStoreMatchesWorkspaceReachedThroughSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on Windows")
+	}
+	require := require.New(t)
+	workspace := t.TempDir()
+	workspaceLink := filepath.Join(t.TempDir(), "workspace-link")
+	require.NoError(os.Symlink(workspace, workspaceLink))
+	store := NewStore(t.TempDir())
+	reportHook(t, store, "runtime-live", map[string]any{
+		"session_id": "agent-live", "cwd": workspaceLink,
+		"hook_event_name": "UserPromptSubmit",
+	})
+
+	snapshot, ok := store.SnapshotForWorkspace(workspace, []string{"runtime-live"})
+	require.True(ok)
+	assert.Equal(t, StateWorking, snapshot.State)
+}
+
 func TestStoreExpiresAndRemovesStaleReports(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -108,11 +128,14 @@ func TestStoreCacheObservesReportsWrittenByAnotherProcess(t *testing.T) {
 	snapshot, ok := reader.SnapshotForWorkspace(workspace, []string{"runtime-live"})
 	require.True(ok)
 	require.Equal(StateWorking, snapshot.State)
+	dirInfo, err := os.Stat(root)
+	require.NoError(err)
 
 	reportHook(t, writer, "runtime-live", map[string]any{
 		"session_id": "agent-live", "cwd": workspace,
 		"hook_event_name": "PermissionRequest",
 	})
+	require.NoError(os.Chtimes(root, dirInfo.ModTime(), dirInfo.ModTime()))
 	snapshot, ok = reader.SnapshotForWorkspace(workspace, []string{"runtime-live"})
 	require.True(ok)
 	require.Equal(StateApproval, snapshot.State)
@@ -137,6 +160,7 @@ func TestInstallLifecyclePreservesOtherHooks(t *testing.T) {
 			configPath := filepath.Join(configDir, tt.configName)
 			require.NoError(os.WriteFile(configPath, []byte(`{
   "mode": "keep",
+  "sequence": 9007199254740993,
   "hooks": {
     "Stop": [{"hooks": [{"type": "command", "command": "keep-me"}]}],
     "SessionStart": [{"hooks": [{"type": "command", "command": "old agent-hook --source middleman-agent-activity"}]}]
@@ -151,6 +175,7 @@ func TestInstallLifecyclePreservesOtherHooks(t *testing.T) {
 
 			data, err := os.ReadFile(configPath)
 			require.NoError(err)
+			assert.Contains(string(data), `"sequence": 9007199254740993`)
 			var root map[string]any
 			require.NoError(json.Unmarshal(data, &root))
 			assert.Equal("keep", root["mode"])
@@ -179,6 +204,7 @@ func TestInstallLifecyclePreservesOtherHooks(t *testing.T) {
 			require.NoError(err)
 			data, err = os.ReadFile(configPath)
 			require.NoError(err)
+			assert.Contains(string(data), `"sequence": 9007199254740993`)
 			require.NoError(json.Unmarshal(data, &root))
 			assert.Equal("keep", root["mode"])
 			hooks = root["hooks"].(map[string]any)
@@ -191,6 +217,41 @@ func TestInstallLifecyclePreservesOtherHooks(t *testing.T) {
 			assert.NotContains(string(startJSON), hookCommandMarker)
 		})
 	}
+}
+
+func TestInstallLifecyclePreservesSymlinkedConfig(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on Windows")
+	}
+	assert := assert.New(t)
+	require := require.New(t)
+	configDir := t.TempDir()
+	t.Setenv("CODEX_HOME", configDir)
+	targetPath := filepath.Join(t.TempDir(), "hooks.json")
+	require.NoError(os.WriteFile(targetPath, []byte(`{
+  "hooks": {"Stop": [{"hooks": [{"type": "command", "command": "keep-me"}]}]}
+}`), 0o600))
+	configPath := filepath.Join(configDir, "hooks.json")
+	require.NoError(os.Symlink(targetPath, configPath))
+
+	_, err := Install(IntegrationCodex, "/opt/middleman", "/tmp/activity")
+	require.NoError(err)
+	info, err := os.Lstat(configPath)
+	require.NoError(err)
+	assert.NotZero(info.Mode() & os.ModeSymlink)
+	data, err := os.ReadFile(targetPath)
+	require.NoError(err)
+	assert.Contains(string(data), hookCommandMarker)
+
+	_, err = Uninstall(IntegrationCodex)
+	require.NoError(err)
+	info, err = os.Lstat(configPath)
+	require.NoError(err)
+	assert.NotZero(info.Mode() & os.ModeSymlink)
+	data, err = os.ReadFile(targetPath)
+	require.NoError(err)
+	assert.Contains(string(data), "keep-me")
+	assert.NotContains(string(data), hookCommandMarker)
 }
 
 func reportHook(t *testing.T, store *Store, runtimeKey string, input map[string]any) {

--- a/internal/agentactivity/store_test.go
+++ b/internal/agentactivity/store_test.go
@@ -72,37 +72,125 @@ func TestStoreAggregatesOnlyLiveWorkspaceSessions(t *testing.T) {
 	assert.Equal(t, StateWorking, snapshot.State)
 }
 
-func TestInstallPreservesOtherHooksAndReplacesMiddlemanHooks(t *testing.T) {
+func TestStoreExpiresAndRemovesStaleReports(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	configDir := t.TempDir()
-	t.Setenv("CODEX_HOME", configDir)
-	configPath := filepath.Join(configDir, "hooks.json")
-	require.NoError(os.WriteFile(configPath, []byte(`{
+	root := t.TempDir()
+	workspace := t.TempDir()
+	store := NewStore(root)
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	store.now = func() time.Time { return now }
+
+	reportHook(t, store, "runtime-stale", map[string]any{
+		"session_id": "agent-stale", "cwd": workspace,
+		"hook_event_name": "PermissionRequest",
+	})
+	now = now.Add(31 * time.Minute)
+
+	_, ok := store.SnapshotForWorkspace(workspace, []string{"runtime-stale"})
+	assert.False(ok)
+	entries, err := os.ReadDir(root)
+	require.NoError(err)
+	assert.Empty(entries)
+}
+
+func TestStoreCacheObservesReportsWrittenByAnotherProcess(t *testing.T) {
+	require := require.New(t)
+	root := t.TempDir()
+	workspace := t.TempDir()
+	reader := NewStore(root)
+	writer := NewStore(root)
+
+	reportHook(t, writer, "runtime-live", map[string]any{
+		"session_id": "agent-live", "cwd": workspace,
+		"hook_event_name": "UserPromptSubmit",
+	})
+	snapshot, ok := reader.SnapshotForWorkspace(workspace, []string{"runtime-live"})
+	require.True(ok)
+	require.Equal(StateWorking, snapshot.State)
+
+	reportHook(t, writer, "runtime-live", map[string]any{
+		"session_id": "agent-live", "cwd": workspace,
+		"hook_event_name": "PermissionRequest",
+	})
+	snapshot, ok = reader.SnapshotForWorkspace(workspace, []string{"runtime-live"})
+	require.True(ok)
+	require.Equal(StateApproval, snapshot.State)
+}
+
+func TestInstallLifecyclePreservesOtherHooks(t *testing.T) {
+	tests := []struct {
+		name        string
+		integration Integration
+		env         string
+		configName  string
+	}{
+		{name: "Claude", integration: IntegrationClaude, env: "CLAUDE_CONFIG_DIR", configName: "settings.json"},
+		{name: "Codex", integration: IntegrationCodex, env: "CODEX_HOME", configName: "hooks.json"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			configDir := t.TempDir()
+			t.Setenv(tt.env, configDir)
+			configPath := filepath.Join(configDir, tt.configName)
+			require.NoError(os.WriteFile(configPath, []byte(`{
+  "mode": "keep",
   "hooks": {
     "Stop": [{"hooks": [{"type": "command", "command": "keep-me"}]}],
     "SessionStart": [{"hooks": [{"type": "command", "command": "old agent-hook --source middleman-agent-activity"}]}]
   }
 }`), 0o600))
 
-	result, err := Install(IntegrationCodex, "/opt/middleman", "/tmp/activity")
-	require.NoError(err)
-	assert.Equal(configPath, result.ConfigPath)
+			for range 2 {
+				result, err := Install(tt.integration, "/opt/middleman", "/tmp/activity")
+				require.NoError(err)
+				assert.Equal(configPath, result.ConfigPath)
+			}
 
-	data, err := os.ReadFile(configPath)
-	require.NoError(err)
-	var root map[string]any
-	require.NoError(json.Unmarshal(data, &root))
-	hooks := root["hooks"].(map[string]any)
-	stopJSON, err := json.Marshal(hooks["Stop"])
-	require.NoError(err)
-	assert.Contains(string(stopJSON), "keep-me")
-	assert.Contains(string(stopJSON), hookCommandMarker)
-	startJSON, err := json.Marshal(hooks["SessionStart"])
-	require.NoError(err)
-	assert.NotContains(string(startJSON), "old agent-hook")
-	assert.Contains(string(startJSON), "/opt/middleman")
-	assert.Contains(string(startJSON), "agent-hook run")
+			data, err := os.ReadFile(configPath)
+			require.NoError(err)
+			var root map[string]any
+			require.NoError(json.Unmarshal(data, &root))
+			assert.Equal("keep", root["mode"])
+			hooks := root["hooks"].(map[string]any)
+			stopJSON, err := json.Marshal(hooks["Stop"])
+			require.NoError(err)
+			assert.Contains(string(stopJSON), "keep-me")
+			markerHandlers := 0
+			for _, rawEntry := range hooks["Stop"].([]any) {
+				entry := rawEntry.(map[string]any)
+				for _, rawHandler := range entry["hooks"].([]any) {
+					handler := rawHandler.(map[string]any)
+					command, _ := handler["command"].(string)
+					if strings.Contains(command, hookCommandMarker) {
+						markerHandlers++
+					}
+				}
+			}
+			assert.Equal(1, markerHandlers)
+			startJSON, err := json.Marshal(hooks["SessionStart"])
+			require.NoError(err)
+			assert.NotContains(string(startJSON), "old agent-hook")
+			assert.Contains(string(startJSON), "/opt/middleman")
+
+			_, err = Uninstall(tt.integration)
+			require.NoError(err)
+			data, err = os.ReadFile(configPath)
+			require.NoError(err)
+			require.NoError(json.Unmarshal(data, &root))
+			assert.Equal("keep", root["mode"])
+			hooks = root["hooks"].(map[string]any)
+			stopJSON, err = json.Marshal(hooks["Stop"])
+			require.NoError(err)
+			assert.Contains(string(stopJSON), "keep-me")
+			assert.NotContains(string(stopJSON), hookCommandMarker)
+			startJSON, err = json.Marshal(hooks["SessionStart"])
+			require.NoError(err)
+			assert.NotContains(string(startJSON), hookCommandMarker)
+		})
+	}
 }
 
 func reportHook(t *testing.T, store *Store, runtimeKey string, input map[string]any) {

--- a/internal/agentactivity/store_test.go
+++ b/internal/agentactivity/store_test.go
@@ -1,0 +1,113 @@
+package agentactivity
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStoreTracksHookLifecycleByRuntimeSession(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	root := t.TempDir()
+	workspace := t.TempDir()
+	store := NewStore(root)
+	now := time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC)
+	store.now = func() time.Time { return now }
+
+	reportHook(t, store, "runtime-a", map[string]any{
+		"session_id": "agent-a", "cwd": workspace,
+		"hook_event_name": "UserPromptSubmit",
+	})
+	snapshot, ok := store.SnapshotForWorkspace(workspace, []string{"runtime-a"})
+	require.True(ok)
+	assert.Equal(StateWorking, snapshot.State)
+	assert.Equal(now, snapshot.UpdatedAt)
+
+	now = now.Add(time.Minute)
+	reportHook(t, store, "runtime-a", map[string]any{
+		"session_id": "agent-a", "cwd": workspace,
+		"hook_event_name": "PreToolUse", "tool_name": "request_user_input",
+	})
+	snapshot, ok = store.SnapshotForWorkspace(workspace, []string{"runtime-a"})
+	require.True(ok)
+	assert.Equal(StateInput, snapshot.State)
+
+	reportHook(t, store, "runtime-a", map[string]any{
+		"session_id": "agent-a", "cwd": workspace,
+		"hook_event_name": "Stop",
+	})
+	snapshot, ok = store.SnapshotForWorkspace(workspace, []string{"runtime-a"})
+	require.True(ok)
+	assert.Equal(StateIdle, snapshot.State)
+
+	reportHook(t, store, "runtime-a", map[string]any{
+		"session_id": "agent-a", "cwd": workspace,
+		"hook_event_name": "SessionEnd",
+	})
+	_, ok = store.SnapshotForWorkspace(workspace, []string{"runtime-a"})
+	assert.False(ok)
+}
+
+func TestStoreAggregatesOnlyLiveWorkspaceSessions(t *testing.T) {
+	store := NewStore(t.TempDir())
+	workspace := t.TempDir()
+	reportHook(t, store, "runtime-stale", map[string]any{
+		"session_id": "agent-stale", "cwd": workspace,
+		"hook_event_name": "PermissionRequest",
+	})
+	reportHook(t, store, "runtime-live", map[string]any{
+		"session_id": "agent-live", "cwd": workspace,
+		"hook_event_name": "UserPromptSubmit",
+	})
+
+	snapshot, ok := store.SnapshotForWorkspace(workspace, []string{"runtime-live"})
+	require.True(t, ok)
+	assert.Equal(t, StateWorking, snapshot.State)
+}
+
+func TestInstallPreservesOtherHooksAndReplacesMiddlemanHooks(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	configDir := t.TempDir()
+	t.Setenv("CODEX_HOME", configDir)
+	configPath := filepath.Join(configDir, "hooks.json")
+	require.NoError(os.WriteFile(configPath, []byte(`{
+  "hooks": {
+    "Stop": [{"hooks": [{"type": "command", "command": "keep-me"}]}],
+    "SessionStart": [{"hooks": [{"type": "command", "command": "old agent-hook --source middleman-agent-activity"}]}]
+  }
+}`), 0o600))
+
+	result, err := Install(IntegrationCodex, "/opt/middleman", "/tmp/activity")
+	require.NoError(err)
+	assert.Equal(configPath, result.ConfigPath)
+
+	data, err := os.ReadFile(configPath)
+	require.NoError(err)
+	var root map[string]any
+	require.NoError(json.Unmarshal(data, &root))
+	hooks := root["hooks"].(map[string]any)
+	stopJSON, err := json.Marshal(hooks["Stop"])
+	require.NoError(err)
+	assert.Contains(string(stopJSON), "keep-me")
+	assert.Contains(string(stopJSON), hookCommandMarker)
+	startJSON, err := json.Marshal(hooks["SessionStart"])
+	require.NoError(err)
+	assert.NotContains(string(startJSON), "old agent-hook")
+	assert.Contains(string(startJSON), "/opt/middleman")
+	assert.Contains(string(startJSON), "agent-hook run")
+}
+
+func reportHook(t *testing.T, store *Store, runtimeKey string, input map[string]any) {
+	t.Helper()
+	data, err := json.Marshal(input)
+	require.NoError(t, err)
+	require.NoError(t, store.HandleHook(strings.NewReader(string(data)), runtimeKey))
+}

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -659,6 +659,30 @@ func (e WorkflowStateMetaResponseStatus) Valid() bool {
 	}
 }
 
+// Defines values for WorkspaceResponseAgentState.
+const (
+	Approval WorkspaceResponseAgentState = "approval"
+	Idle     WorkspaceResponseAgentState = "idle"
+	Input    WorkspaceResponseAgentState = "input"
+	Working  WorkspaceResponseAgentState = "working"
+)
+
+// Valid indicates whether the value is a known member of the WorkspaceResponseAgentState enum.
+func (e WorkspaceResponseAgentState) Valid() bool {
+	switch e {
+	case Approval:
+		return true
+	case Idle:
+		return true
+	case Input:
+		return true
+	case Working:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for WorkspaceResponseEnrichmentStatus.
 const (
 	Failed        WorkspaceResponseEnrichmentStatus = "failed"
@@ -3928,11 +3952,15 @@ type WorkspaceRef struct {
 // WorkspaceResponse defines model for WorkspaceResponse.
 type WorkspaceResponse struct {
 	// Schema A URL to the JSON Schema for this object.
-	Schema             *string `json:"$schema,omitempty"`
-	AssociatedPrNumber *int64  `json:"associated_pr_number,omitempty"`
-	CommitsAhead       *int64  `json:"commits_ahead,omitempty"`
-	CommitsBehind      *int64  `json:"commits_behind,omitempty"`
-	CreatedAt          string  `json:"created_at"`
+	Schema *string `json:"$schema,omitempty"`
+
+	// AgentState Hook-reported aggregate state for live agent sessions. Omitted when no live session has reported lifecycle state.
+	AgentState          *WorkspaceResponseAgentState `json:"agent_state,omitempty"`
+	AgentStateUpdatedAt *string                      `json:"agent_state_updated_at,omitempty"`
+	AssociatedPrNumber  *int64                       `json:"associated_pr_number,omitempty"`
+	CommitsAhead        *int64                       `json:"commits_ahead,omitempty"`
+	CommitsBehind       *int64                       `json:"commits_behind,omitempty"`
+	CreatedAt           string                       `json:"created_at"`
 
 	// EnrichmentError Combined error from the most recent reconciliation attempt; populated component fields may still contain last-known-good values.
 	EnrichmentError *string `json:"enrichment_error,omitempty"`
@@ -3969,6 +3997,9 @@ type WorkspaceResponse struct {
 	TmuxWorking        bool                              `json:"tmux_working"`
 	WorktreePath       string                            `json:"worktree_path"`
 }
+
+// WorkspaceResponseAgentState Hook-reported aggregate state for live agent sessions. Omitted when no live session has reported lifecycle state.
+type WorkspaceResponseAgentState string
 
 // WorkspaceResponseEnrichmentStatus Aggregate git-divergence and tmux-activity reconciliation status. Failed responses retain last-known-good component fields when available.
 type WorkspaceResponseEnrichmentStatus string

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -3955,12 +3955,14 @@ type WorkspaceResponse struct {
 	Schema *string `json:"$schema,omitempty"`
 
 	// AgentState Hook-reported aggregate state for live agent sessions. Omitted when no live session has reported lifecycle state.
-	AgentState          *WorkspaceResponseAgentState `json:"agent_state,omitempty"`
-	AgentStateUpdatedAt *string                      `json:"agent_state_updated_at,omitempty"`
-	AssociatedPrNumber  *int64                       `json:"associated_pr_number,omitempty"`
-	CommitsAhead        *int64                       `json:"commits_ahead,omitempty"`
-	CommitsBehind       *int64                       `json:"commits_behind,omitempty"`
-	CreatedAt           string                       `json:"created_at"`
+	AgentState *WorkspaceResponseAgentState `json:"agent_state,omitempty"`
+
+	// AgentStateUpdatedAt UTC timestamp of the hook report that produced agent_state.
+	AgentStateUpdatedAt *time.Time `json:"agent_state_updated_at,omitempty"`
+	AssociatedPrNumber  *int64     `json:"associated_pr_number,omitempty"`
+	CommitsAhead        *int64     `json:"commits_ahead,omitempty"`
+	CommitsBehind       *int64     `json:"commits_behind,omitempty"`
+	CreatedAt           string     `json:"created_at"`
 
 	// EnrichmentError Combined error from the most recent reconciliation attempt; populated component fields may still contain last-known-good values.
 	EnrichmentError *string `json:"enrichment_error,omitempty"`

--- a/internal/ptyowner/client.go
+++ b/internal/ptyowner/client.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"syscall"
@@ -26,6 +27,7 @@ type Client struct {
 	ManagerPath  string
 	Command      []string
 	StripEnvVars []string
+	ExtraEnv     map[string]string
 	InProcess    bool
 }
 
@@ -101,6 +103,7 @@ func (c *Client) Ensure(ctx context.Context, session, cwd string) error {
 				Cwd:          cwd,
 				Command:      command,
 				StripEnvVars: c.StripEnvVars,
+				ExtraEnv:     c.ExtraEnv,
 			})
 		}()
 		return c.waitReady(ctx, session, nil, nil, nil)
@@ -477,7 +480,35 @@ func ownerHelperEnvironment(env []string) []string {
 }
 
 func (c Client) ownerHelperEnvironment(env []string) []string {
-	return sessionEnvironment(env, c.StripEnvVars)
+	return mergeEnvironment(
+		sessionEnvironment(env, c.StripEnvVars), c.ExtraEnv,
+	)
+}
+
+func mergeEnvironment(env []string, extra map[string]string) []string {
+	if len(extra) == 0 {
+		return env
+	}
+	filtered := env[:0]
+	for _, value := range env {
+		key, _, found := strings.Cut(value, "=")
+		if found {
+			if _, replaced := extra[key]; replaced {
+				continue
+			}
+		}
+		filtered = append(filtered, value)
+	}
+	env = filtered
+	keys := make([]string, 0, len(extra))
+	for key := range extra {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	for _, key := range keys {
+		env = append(env, key+"="+extra[key])
+	}
+	return env
 }
 
 func applyRPCDeadline(ctx context.Context, conn net.Conn) func() {

--- a/internal/ptyowner/owner.go
+++ b/internal/ptyowner/owner.go
@@ -34,6 +34,7 @@ type Options struct {
 	Cwd          string
 	Command      []string
 	StripEnvVars []string
+	ExtraEnv     map[string]string
 }
 
 type owner struct {
@@ -86,7 +87,9 @@ func RunOwner(ctx context.Context, opts Options) error {
 
 	cmd := p.Command(command[0], command[1:]...)
 	cmd.Dir = opts.Cwd
-	cmd.Env = sessionEnvironment(os.Environ(), opts.StripEnvVars)
+	cmd.Env = mergeEnvironment(
+		sessionEnvironment(os.Environ(), opts.StripEnvVars), opts.ExtraEnv,
+	)
 	configureOwnerCommand(cmd)
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("start pty command: %w", err)

--- a/internal/ptyowner/owner_test.go
+++ b/internal/ptyowner/owner_test.go
@@ -396,17 +396,22 @@ func TestOwnerHelperEnvironmentStripsCredentials(t *testing.T) {
 	}, out)
 }
 
-func TestClientOwnerHelperEnvironmentStripsConfiguredVariables(t *testing.T) {
-	client := Client{StripEnvVars: []string{"WORKSPACE_TOKEN"}}
+func TestClientOwnerHelperEnvironmentAppliesSessionEnvironmentPolicy(t *testing.T) {
+	client := Client{
+		StripEnvVars: []string{"WORKSPACE_TOKEN"},
+		ExtraEnv:     map[string]string{"MIDDLEMAN_RUNTIME_SESSION_KEY": "runtime-1"},
+	}
 	out := client.ownerHelperEnvironment([]string{
 		"PATH=/usr/bin",
 		"WORKSPACE_TOKEN=secret",
+		"MIDDLEMAN_RUNTIME_SESSION_KEY=stale-runtime",
 		"KEEP=value",
 	})
 
 	require.ElementsMatch(t, []string{
 		"PATH=/usr/bin",
 		"KEEP=value",
+		"MIDDLEMAN_RUNTIME_SESSION_KEY=runtime-1",
 	}, out)
 }
 

--- a/internal/ptyowner/runtime/runtime.go
+++ b/internal/ptyowner/runtime/runtime.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"go.kenn.io/middleman/internal/agentactivity"
 	"go.kenn.io/middleman/internal/ptyowner"
 )
 
@@ -102,6 +103,9 @@ func (o owner) Start(
 	client := *o.client
 	client.ExeArgs = append([]string(nil), o.client.ExeArgs...)
 	client.Command = resolvedCommand
+	client.ExtraEnv = map[string]string{
+		agentactivity.RuntimeSessionKeyEnv: session,
+	}
 	client.StripEnvVars = append(
 		append([]string(nil), o.client.StripEnvVars...),
 		stripEnvVars...,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humago"
+	"go.kenn.io/middleman/internal/agentactivity"
 	"go.kenn.io/middleman/internal/archive"
 	"go.kenn.io/middleman/internal/config"
 	"go.kenn.io/middleman/internal/configwatch"
@@ -931,12 +932,15 @@ func newServer(
 		})
 	}
 	s.workspaceAPI = workspaceapi.New(workspaceapi.Deps{
-		DB:                 database,
-		Resolver:           repoResolver,
-		Syncer:             syncer,
-		Config:             workspaceConfigSnapshot(cfg, tmuxCmd),
-		Workspaces:         s.workspaces,
-		Runtime:            s.runtime,
+		DB:         database,
+		Resolver:   repoResolver,
+		Syncer:     syncer,
+		Config:     workspaceConfigSnapshot(cfg, tmuxCmd),
+		Workspaces: s.workspaces,
+		Runtime:    s.runtime,
+		AgentActivity: agentactivity.NewStore(filepath.Join(
+			filepath.Dir(options.WorktreeDir), "agent-activity",
+		)),
 		TmuxCommand:        tmuxCmd,
 		Now:                workspaceNow,
 		EnrichmentDisabled: options.DisableWorkspaceEnrichment,

--- a/internal/server/workspaceapi/handler.go
+++ b/internal/server/workspaceapi/handler.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
+	"go.kenn.io/middleman/internal/agentactivity"
 	"go.kenn.io/middleman/internal/db"
 	ghclient "go.kenn.io/middleman/internal/github"
 	"go.kenn.io/middleman/internal/server/httpapi"
@@ -78,6 +79,7 @@ type Deps struct {
 	Config             ConfigSnapshot
 	Workspaces         *workspace.Manager
 	Runtime            *localruntime.Manager
+	AgentActivity      *agentactivity.Store
 	TmuxCommand        []string
 	Now                func() time.Time
 	EnrichmentDisabled bool
@@ -97,18 +99,19 @@ type Deps struct {
 // Handler implements both the workspace and local-project services so their
 // Git-heavy tests and process limits remain in one package and test binary.
 type Handler struct {
-	db         *db.DB
-	resolver   *httpapi.RepositoryResolver
-	syncer     *ghclient.Syncer
-	configMu   sync.RWMutex
-	config     ConfigSnapshot
-	workspaces *workspace.Manager
-	runtime    *localruntime.Manager
-	tmuxCmd    []string
-	now        func() time.Time
-	broadcast  func(Event) uint64
-	subscribe  func(context.Context, bool) (<-chan RecordedEvent, <-chan struct{})
-	generation func() uint64
+	db            *db.DB
+	resolver      *httpapi.RepositoryResolver
+	syncer        *ghclient.Syncer
+	configMu      sync.RWMutex
+	config        ConfigSnapshot
+	workspaces    *workspace.Manager
+	runtime       *localruntime.Manager
+	agentActivity *agentactivity.Store
+	tmuxCmd       []string
+	now           func() time.Time
+	broadcast     func(Event) uint64
+	subscribe     func(context.Context, bool) (<-chan RecordedEvent, <-chan struct{})
+	generation    func() uint64
 
 	recomputeWorktreeLinks         func(context.Context)
 	refreshWorktreeStats           func(context.Context, string, string) error
@@ -154,6 +157,7 @@ func New(deps Deps) *Handler {
 		config:                         cloneConfigSnapshot(deps.Config),
 		workspaces:                     deps.Workspaces,
 		runtime:                        deps.Runtime,
+		agentActivity:                  deps.AgentActivity,
 		tmuxCmd:                        slices.Clone(deps.TmuxCommand),
 		now:                            now,
 		broadcast:                      deps.Broadcast,

--- a/internal/server/workspaceapi/lifecycle.go
+++ b/internal/server/workspaceapi/lifecycle.go
@@ -154,7 +154,11 @@ func (h *Handler) RestoreRuntimeSessions(ctx context.Context) error {
 // HandleRuntimeSessionExit reconciles a workspace runtime exit with persisted
 // session and enrichment state.
 func (h *Handler) HandleRuntimeSessionExit(info localruntime.SessionInfo) {
-	if h == nil || h.workspaces == nil {
+	if h == nil {
+		return
+	}
+	h.removeAgentActivityRuntimeSession(info.Key)
+	if h.workspaces == nil {
 		return
 	}
 	h.invalidateWorkspaceEnrichment(info.WorkspaceID)
@@ -170,4 +174,15 @@ func (h *Handler) HandleRuntimeSessionExit(info localruntime.SessionInfo) {
 				"err", err)
 		}
 	})
+}
+
+func (h *Handler) removeAgentActivityRuntimeSession(sessionKey string) {
+	if h == nil || h.agentActivity == nil || sessionKey == "" {
+		return
+	}
+	if err := h.agentActivity.RemoveRuntimeSession(sessionKey); err != nil {
+		slog.Warn("remove agent activity report",
+			"session_key", sessionKey,
+			"err", err)
+	}
 }

--- a/internal/server/workspaceapi/routes_handlers.go
+++ b/internal/server/workspaceapi/routes_handlers.go
@@ -2052,6 +2052,7 @@ func (s *Handler) stopWorkspaceRuntimeSession(
 				)
 			}
 			if stopped {
+				s.removeAgentActivityRuntimeSession(input.SessionKey)
 				s.invalidateWorkspaceEnrichment(summary.ID)
 				return nil, nil
 			}
@@ -2064,6 +2065,7 @@ func (s *Handler) stopWorkspaceRuntimeSession(
 	); err != nil {
 		return nil, httpapi.Internal("forget runtime session: " + err.Error())
 	}
+	s.removeAgentActivityRuntimeSession(input.SessionKey)
 	s.invalidateWorkspaceEnrichment(summary.ID)
 	return nil, nil
 }
@@ -2285,7 +2287,11 @@ func (s *Handler) deleteWorkspace(
 		ctx, input.ID, input.Force,
 		func(stopCtx context.Context) {
 			if s.runtime != nil {
+				sessions := s.runtime.ListSessions(input.ID)
 				s.runtime.StopWorkspace(stopCtx, input.ID)
+				for _, session := range sessions {
+					s.removeAgentActivityRuntimeSession(session.Key)
+				}
 			}
 		},
 	)

--- a/internal/server/workspaceapi/routes_handlers.go
+++ b/internal/server/workspaceapi/routes_handlers.go
@@ -1487,7 +1487,36 @@ func (s *Handler) toWorkspaceResponse(
 	ctx context.Context,
 	summary *db.WorkspaceSummary,
 ) workspaceResponse {
-	return s.workspaceResponseWithEnrichment(ctx, summary).response
+	resp := s.workspaceResponseWithEnrichment(ctx, summary).response
+	s.applyAgentActivity(&resp, summary)
+	return resp
+}
+
+func (s *Handler) applyAgentActivity(
+	resp *workspaceResponse,
+	summary *db.WorkspaceSummary,
+) {
+	if s.agentActivity == nil || s.runtime == nil || resp == nil || summary == nil {
+		return
+	}
+	liveSessionKeys := make([]string, 0)
+	for _, session := range s.runtime.ListSessions(summary.ID) {
+		if session.Kind == localruntime.LaunchTargetAgent &&
+			(session.Status == localruntime.SessionStatusRunning ||
+				session.Status == localruntime.SessionStatusStarting) {
+			liveSessionKeys = append(liveSessionKeys, session.Key)
+		}
+	}
+	snapshot, ok := s.agentActivity.SnapshotForWorkspace(
+		summary.WorktreePath, liveSessionKeys,
+	)
+	if !ok {
+		return
+	}
+	state := string(snapshot.State)
+	updatedAt := snapshot.UpdatedAt.UTC().Format(time.RFC3339)
+	resp.AgentState = &state
+	resp.AgentStateUpdatedAt = &updatedAt
 }
 
 // Response returns the cached public DTO for a persisted workspace summary.

--- a/internal/server/workspaceapi/types.go
+++ b/internal/server/workspaceapi/types.go
@@ -45,7 +45,7 @@ type workspaceResponse struct {
 	TmuxActivitySource    string                    `json:"tmux_activity_source"`
 	TmuxLastOutputAt      *string                   `json:"tmux_last_output_at"`
 	AgentState            *string                   `json:"agent_state,omitempty" enum:"idle,working,input,approval" doc:"Hook-reported aggregate state for live agent sessions. Omitted when no live session has reported lifecycle state."`
-	AgentStateUpdatedAt   *string                   `json:"agent_state_updated_at,omitempty"`
+	AgentStateUpdatedAt   *string                   `json:"agent_state_updated_at,omitempty" format:"date-time" doc:"UTC timestamp of the hook report that produced agent_state."`
 	Status                string                    `json:"status"`
 	ErrorMessage          *string                   `json:"error_message,omitempty"`
 	CreatedAt             string                    `json:"created_at"`

--- a/internal/server/workspaceapi/types.go
+++ b/internal/server/workspaceapi/types.go
@@ -44,6 +44,8 @@ type workspaceResponse struct {
 	TmuxWorking           bool                      `json:"tmux_working"`
 	TmuxActivitySource    string                    `json:"tmux_activity_source"`
 	TmuxLastOutputAt      *string                   `json:"tmux_last_output_at"`
+	AgentState            *string                   `json:"agent_state,omitempty" enum:"idle,working,input,approval" doc:"Hook-reported aggregate state for live agent sessions. Omitted when no live session has reported lifecycle state."`
+	AgentStateUpdatedAt   *string                   `json:"agent_state_updated_at,omitempty"`
 	Status                string                    `json:"status"`
 	ErrorMessage          *string                   `json:"error_message,omitempty"`
 	CreatedAt             string                    `json:"created_at"`

--- a/internal/server/workspaceapi/workspace_enrichment.go
+++ b/internal/server/workspaceapi/workspace_enrichment.go
@@ -49,16 +49,17 @@ type workspaceEnrichmentProbeResult struct {
 
 func (s *Handler) toCachedWorkspaceResponse(
 	summary *db.WorkspaceSummary,
-) workspaceResponse {
-	resp := toWorkspaceResponse(summary)
+) (resp workspaceResponse) {
+	resp = toWorkspaceResponse(summary)
+	defer s.applyAgentActivity(&resp, summary)
 	resp.Repo = s.repoRefFromParts(
 		summary.Platform, summary.PlatformHost, summary.RepoOwner, summary.RepoName,
 	)
 	if s.workspaceEnrichmentDisabled {
-		return resp
+		return
 	}
 	if s.workspaces == nil || summary.Status != "ready" {
-		return resp
+		return
 	}
 
 	entry, refreshDue := s.cachedWorkspaceEnrichment(summary.ID)
@@ -66,7 +67,7 @@ func (s *Handler) toCachedWorkspaceResponse(
 	if refreshDue {
 		s.scheduleWorkspaceEnrichment(*summary)
 	}
-	return resp
+	return
 }
 
 func (s *Handler) workspaceResponseFromEnrichmentCacheEntry(

--- a/internal/server/workspaceapi/workspace_enrichment.go
+++ b/internal/server/workspaceapi/workspace_enrichment.go
@@ -164,18 +164,21 @@ func (s *Handler) cachedWorkspaceEnrichment(
 func (s *Handler) refreshWorkspaceResponse(
 	ctx context.Context,
 	summary *db.WorkspaceSummary,
-) workspaceResponse {
+) (resp workspaceResponse) {
+	defer s.applyAgentActivity(&resp, summary)
 	generation := s.supersedeWorkspaceEnrichment(summary.ID)
 	result := s.workspaceResponseWithEnrichment(ctx, summary)
 	if summary.Status == "ready" {
 		entry, recorded, _ := s.recordWorkspaceEnrichmentResult(
 			summary.ID, generation, result,
 		)
-		return s.workspaceResponseAfterEnrichmentAttempt(
+		resp = s.workspaceResponseAfterEnrichmentAttempt(
 			summary, result, entry, recorded,
 		)
+		return
 	}
-	return result.response
+	resp = result.response
+	return
 }
 
 func (s *Handler) workspaceResponseAfterEnrichmentAttempt(

--- a/internal/server/workspaceapi/workspace_enrichment_test.go
+++ b/internal/server/workspaceapi/workspace_enrichment_test.go
@@ -1,7 +1,9 @@
 package workspaceapi
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -11,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	gitcmd "go.kenn.io/kit/git/cmd"
+	"go.kenn.io/middleman/internal/agentactivity"
 	"go.kenn.io/middleman/internal/db"
 	"go.kenn.io/middleman/internal/testutil/dbtest"
 	"go.kenn.io/middleman/internal/workspace"
@@ -571,7 +574,21 @@ func TestWorkspaceTmuxPruneUsesEnrichmentBackgroundCapacity(t *testing.T) {
 }
 
 func TestWorkspaceRuntimeExitInvalidatesCachedTmuxEnrichment(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
 	srv := newEnrichmentTestHandler(t, "")
+	activityRoot := t.TempDir()
+	workspace := t.TempDir()
+	srv.agentActivity = agentactivity.NewStore(activityRoot)
+	payload, err := json.Marshal(map[string]string{
+		"session_id":      "agent-session",
+		"cwd":             workspace,
+		"hook_event_name": "UserPromptSubmit",
+	})
+	require.NoError(err)
+	require.NoError(srv.agentActivity.HandleHook(
+		bytes.NewReader(payload), "agent-runtime",
+	))
 	srv.workspaceEnrichmentCache["ws-runtime"] = workspaceEnrichmentCacheEntry{
 		hasTmux:         true,
 		tmuxRefreshedAt: srv.now(),
@@ -579,9 +596,13 @@ func TestWorkspaceRuntimeExitInvalidatesCachedTmuxEnrichment(t *testing.T) {
 
 	srv.HandleRuntimeSessionExit(localruntime.SessionInfo{
 		WorkspaceID: "ws-runtime",
-		Key:         "agent",
+		Key:         "agent-runtime",
 		CreatedAt:   srv.now(),
 	})
 
-	assert.NotContains(t, srv.workspaceEnrichmentCache, "ws-runtime")
+	assert.NotContains(srv.workspaceEnrichmentCache, "ws-runtime")
+	_, ok := srv.agentActivity.SnapshotForWorkspace(
+		workspace, []string{"agent-runtime"},
+	)
+	assert.False(ok)
 }

--- a/internal/server/workspacetest/fixtures_test.go
+++ b/internal/server/workspacetest/fixtures_test.go
@@ -26,11 +26,12 @@ import (
 )
 
 type workspaceServerFixture struct {
-	server   *server.Server
-	client   *apiclient.Client
-	database *db.DB
-	bare     string
-	remote   string
+	server           *server.Server
+	client           *apiclient.Client
+	database         *db.DB
+	bare             string
+	remote           string
+	agentActivityDir string
 }
 
 func setupWorkspaceServerFixture(
@@ -117,11 +118,12 @@ func setupWorkspaceServerFixture(
 	}
 	client := setupTestClientWithBaseURL(t, srv, clientBaseURL)
 	return workspaceServerFixture{
-		server:   srv,
-		client:   client,
-		database: database,
-		bare:     bare,
-		remote:   remote,
+		server:           srv,
+		client:           client,
+		database:         database,
+		bare:             bare,
+		remote:           remote,
+		agentActivityDir: filepath.Join(dir, "agent-activity"),
 	}
 }
 

--- a/internal/server/workspacetest/workspace_agent_activity_test.go
+++ b/internal/server/workspacetest/workspace_agent_activity_test.go
@@ -72,6 +72,8 @@ func TestWorkspaceAgentActivityFlowsThroughHTTPResponsesE2E(t *testing.T) {
 	require.NoError(os.WriteFile(
 		filepath.Join(ws.WorktreePath, "activity.txt"), []byte("activity\n"), 0o644,
 	))
+	runGit(t, ws.WorktreePath, "config", "user.email", "agent-activity@example.invalid")
+	runGit(t, ws.WorktreePath, "config", "user.name", "Agent Activity Fixture")
 	runGit(t, ws.WorktreePath, "add", "activity.txt")
 	runGit(t, ws.WorktreePath, "commit", "-m", "add activity fixture")
 	pushResponse, err := fixture.client.HTTP.PushWorkspaceBranchWithResponse(ctx, ws.Id)

--- a/internal/server/workspacetest/workspace_agent_activity_test.go
+++ b/internal/server/workspacetest/workspace_agent_activity_test.go
@@ -1,0 +1,113 @@
+package workspacetest
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/middleman/internal/agentactivity"
+	"go.kenn.io/middleman/internal/apiclient/generated"
+	"go.kenn.io/middleman/internal/config"
+)
+
+func TestWorkspaceAgentActivityFlowsThroughHTTPResponsesE2E(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	cfg := &config.Config{Agents: []config.Agent{{
+		Key: "hook-agent", Label: "Hook agent",
+		Command: []string{"/bin/sh", "-c", "while :; do sleep 1; done"},
+	}}}
+	fixture := setupWorkspaceServerFixture(t, cfg)
+	ctx := t.Context()
+	ws := createReadyWorkspace(t, ctx, fixture.client)
+
+	launch, err := fixture.client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id,
+		generated.LaunchWorkspaceRuntimeSessionInputBody{TargetKey: "hook-agent"},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, launch.StatusCode())
+	require.NotNil(launch.JSON200)
+
+	store := agentactivity.NewStore(fixture.agentActivityDir)
+	for _, report := range []struct {
+		sessionID  string
+		runtimeKey string
+		event      string
+	}{
+		{sessionID: "wrong-agent", runtimeKey: "wrong-runtime", event: "PermissionRequest"},
+		{sessionID: "wrong-worktree", runtimeKey: launch.JSON200.Key, event: "PermissionRequest"},
+		{sessionID: "live-agent", runtimeKey: launch.JSON200.Key, event: "UserPromptSubmit"},
+	} {
+		cwd := ws.WorktreePath
+		if report.sessionID == "wrong-worktree" {
+			cwd = t.TempDir()
+		}
+		payload, marshalErr := json.Marshal(map[string]string{
+			"session_id":      report.sessionID,
+			"cwd":             cwd,
+			"hook_event_name": report.event,
+		})
+		require.NoError(marshalErr)
+		require.NoError(store.HandleHook(
+			strings.NewReader(string(payload)), report.runtimeKey,
+		))
+	}
+
+	getResponse, err := fixture.client.HTTP.GetWorkspaceWithResponse(ctx, ws.Id)
+	require.NoError(err)
+	require.Equal(http.StatusOK, getResponse.StatusCode())
+	require.NotNil(getResponse.JSON200)
+	require.NotNil(getResponse.JSON200.AgentState)
+	require.NotNil(getResponse.JSON200.AgentStateUpdatedAt)
+	assert.Equal(generated.Working, *getResponse.JSON200.AgentState)
+	assert.Equal(time.UTC, getResponse.JSON200.AgentStateUpdatedAt.Location())
+
+	require.NoError(os.WriteFile(
+		filepath.Join(ws.WorktreePath, "activity.txt"), []byte("activity\n"), 0o644,
+	))
+	runGit(t, ws.WorktreePath, "add", "activity.txt")
+	runGit(t, ws.WorktreePath, "commit", "-m", "add activity fixture")
+	pushResponse, err := fixture.client.HTTP.PushWorkspaceBranchWithResponse(ctx, ws.Id)
+	require.NoError(err)
+	require.Equal(http.StatusOK, pushResponse.StatusCode(), string(pushResponse.Body))
+	require.NotNil(pushResponse.JSON200)
+	require.NotNil(pushResponse.JSON200.AgentState)
+	assert.Equal(generated.Working, *pushResponse.JSON200.AgentState)
+
+	payload, err := json.Marshal(map[string]string{
+		"session_id":      "live-agent",
+		"cwd":             ws.WorktreePath,
+		"hook_event_name": "Stop",
+	})
+	require.NoError(err)
+	require.NoError(store.HandleHook(
+		strings.NewReader(string(payload)), launch.JSON200.Key,
+	))
+	getResponse, err = fixture.client.HTTP.GetWorkspaceWithResponse(ctx, ws.Id)
+	require.NoError(err)
+	require.Equal(http.StatusOK, getResponse.StatusCode())
+	require.NotNil(getResponse.JSON200)
+	require.NotNil(getResponse.JSON200.AgentState)
+	assert.Equal(generated.Idle, *getResponse.JSON200.AgentState)
+
+	stopResponse, err := fixture.client.HTTP.StopWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id, launch.JSON200.Key,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusNoContent, stopResponse.StatusCode())
+	_, ok := store.SnapshotForWorkspace(ws.WorktreePath, []string{launch.JSON200.Key})
+	assert.False(ok)
+
+	getResponse, err = fixture.client.HTTP.GetWorkspaceWithResponse(ctx, ws.Id)
+	require.NoError(err)
+	require.Equal(http.StatusOK, getResponse.StatusCode())
+	require.NotNil(getResponse.JSON200)
+	assert.Nil(getResponse.JSON200.AgentState)
+}

--- a/internal/workspace/localruntime/manager.go
+++ b/internal/workspace/localruntime/manager.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/creack/pty/v2"
 
+	"go.kenn.io/middleman/internal/agentactivity"
 	"go.kenn.io/middleman/internal/procutil"
 	ptyownerruntime "go.kenn.io/middleman/internal/ptyowner/runtime"
 )
@@ -1467,8 +1468,10 @@ func (m *Manager) launchCommand(
 
 	tmuxSession := tmuxSessionName(workspaceID, sessionKey)
 
-	paneEnv := tmuxAgentEnvPolicy.paneEnvironment(
-		os.Environ(), resolvedAgentCommand, m.currentStripEnvVars(),
+	paneEnv := tmuxAgentEnvPolicy.paneEnvironmentWithExtra(
+		os.Environ(), resolvedAgentCommand, m.currentStripEnvVars(), map[string]string{
+			agentactivity.RuntimeSessionKeyEnv: sessionKey,
+		},
 	)
 	prepared, err := tmuxLauncher{
 		TmuxCommand: tmuxCommand,

--- a/internal/workspace/localruntime/tmux_launcher.go
+++ b/internal/workspace/localruntime/tmux_launcher.go
@@ -49,6 +49,17 @@ func (p tmuxEnvPolicy) paneEnvironmentWithExtra(
 	extraEnv map[string]string,
 ) tmuxPaneEnvironment {
 	env := p.environment(baseEnv, extraStripVars)
+	filtered := env[:0]
+	for _, value := range env {
+		key, _, found := strings.Cut(value, "=")
+		if found {
+			if _, replaced := extraEnv[key]; replaced {
+				continue
+			}
+		}
+		filtered = append(filtered, value)
+	}
+	env = filtered
 	keys := make([]string, 0, len(extraEnv))
 	for key := range extraEnv {
 		keys = append(keys, key)

--- a/internal/workspace/localruntime/tmux_launcher_test.go
+++ b/internal/workspace/localruntime/tmux_launcher_test.go
@@ -67,6 +67,17 @@ func TestTmuxLauncherAgentOperationsKeepEnvValuesOutOfArgv(t *testing.T) {
 	assert.NotContains(scriptText, "secret-value")
 }
 
+func TestTmuxPaneEnvironmentExtraReplacesInheritedValue(t *testing.T) {
+	pane := tmuxAgentEnvPolicy.paneEnvironmentWithExtra(
+		[]string{"PATH=/usr/bin", "MIDDLEMAN_RUNTIME_SESSION_KEY=parent"},
+		[]string{"/bin/sh"}, nil,
+		map[string]string{"MIDDLEMAN_RUNTIME_SESSION_KEY": "child"},
+	)
+
+	assert.Contains(t, pane.commandEnv, "MIDDLEMAN_RUNTIME_SESSION_KEY=child")
+	assert.NotContains(t, pane.commandEnv, "MIDDLEMAN_RUNTIME_SESSION_KEY=parent")
+}
+
 func TestTmuxLauncherCanHideStatusOnNewSessions(t *testing.T) {
 	assert := assert.New(t)
 

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -7654,6 +7654,12 @@ export interface components {
              * @example /api/v1/schemas/WorkspaceResponse.json
              */
             readonly $schema?: string;
+            /**
+             * @description Hook-reported aggregate state for live agent sessions. Omitted when no live session has reported lifecycle state.
+             * @enum {string}
+             */
+            agent_state?: "idle" | "working" | "input" | "approval";
+            agent_state_updated_at?: string;
             /** Format: int64 */
             associated_pr_number?: number;
             /** Format: int64 */
@@ -17600,4 +17606,5 @@ export const mergeRequestResponseStateValues: ReadonlyArray<FlattenedDeepRequire
 export const problemErrorCodeValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["ProblemError"]["code"]> = ["badRequest", "branchConflict", "branchInUse", "branchProtected", "commentNotFound", "conflict", "destinationExists", "forbidden", "hookFailed", "internalError", "issueNotFound", "notFound", "payloadTooLarge", "projectNotFound", "pullNotFound", "rateLimited", "repoNotFound", "serviceUnavailable", "settingsUnavailable", "toolMissing", "toolUnauthenticated", "unauthorized", "unsupportedCapability", "upstreamError", "validationError", "workspaceNotFound", "worktreeDirty"];
 export const terminalRendererValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["Terminal"]["renderer"]> = ["xterm", "ghostty-web"];
 export const workflowStateMetaResponseStatusValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["WorkflowStateMetaResponse"]["status"]> = ["new", "reviewing", "waiting", "awaiting_merge"];
+export const workspaceResponseAgent_stateValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["WorkspaceResponse"]["agent_state"]> = ["idle", "working", "input", "approval"];
 export const workspaceResponseEnrichment_statusValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["WorkspaceResponse"]["enrichment_status"]> = ["not_applicable", "pending", "fresh", "stale", "failed"];

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -7659,6 +7659,10 @@ export interface components {
              * @enum {string}
              */
             agent_state?: "idle" | "working" | "input" | "approval";
+            /**
+             * Format: date-time
+             * @description UTC timestamp of the hook report that produced agent_state.
+             */
             agent_state_updated_at?: string;
             /** Format: int64 */
             associated_pr_number?: number;


### PR DESCRIPTION
## Summary

- receive Claude and Codex lifecycle hooks through a small middleman CLI subcommand
- distinguish working, idle, input, and approval states for live workspace sessions
- show quiet agent-state indicators in workspace sidebar rows while retaining tmux fallback

## Screenshot

![Workspace sidebar showing Working, Input, and Approval agent states](https://github.com/user-attachments/assets/78ae8607-1c94-47ff-8cf0-b7cf7d5091b1)

<sup>generated by a clanker</sup>