### PR TITLE
Refactor agent activity for maintainability

### DIFF
--- a/cmd/middleman/agent_hook_cli.go
+++ b/cmd/middleman/agent_hook_cli.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"go.kenn.io/middleman/internal/agentactivity"
+	"go.kenn.io/middleman/internal/config"
+)
+
+// The agent-hook command has two audiences: agents invoke `run` on every
+// lifecycle event, and maintainers run install/uninstall once to register that
+// receiver in the agent's own hook config.
+func runAgentHookCLI(args []string, stdin io.Reader, stdout io.Writer) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: middleman agent-hook <run|install|uninstall>")
+	}
+	switch args[0] {
+	case "run":
+		return runAgentHookReceiver(args[1:], stdin)
+	case "install":
+		return runAgentHookInstall(args[1:], stdout)
+	case "uninstall":
+		return runAgentHookUninstall(args[1:], stdout)
+	default:
+		return fmt.Errorf("unknown agent-hook subcommand %q", args[0])
+	}
+}
+
+// runAgentHookReceiver records one hook payload. It runs inside the agent's
+// critical path, so it fails open: bad flags, unreadable input, or an
+// unwritable state directory must never interrupt the session.
+func runAgentHookReceiver(args []string, stdin io.Reader) error {
+	fs := flag.NewFlagSet("middleman agent-hook run", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	stateDir := fs.String("state-dir", "", "agent activity state directory")
+	source := fs.String("source", "", "hook source marker")
+	if err := fs.Parse(args); err != nil {
+		return nil
+	}
+	if *source != agentactivity.HookSource {
+		return nil
+	}
+	_ = agentactivity.NewStore(*stateDir).HandleHook(
+		stdin, os.Getenv(agentactivity.RuntimeSessionKeyEnv),
+	)
+	return nil
+}
+
+func runAgentHookInstall(args []string, stdout io.Writer) error {
+	flags, err := parseAgentHookFlags("install", args)
+	if err != nil {
+		return err
+	}
+	stateDir, err := agentHookStateDir(flags.configPath)
+	if err != nil {
+		return err
+	}
+	executable, err := agentHookExecutable(flags.binary)
+	if err != nil {
+		return err
+	}
+	for _, integration := range flags.integrations {
+		result, err := agentactivity.Install(integration, executable, stateDir)
+		if err != nil {
+			return err
+		}
+		message := fmt.Sprintf(
+			"Installed middleman %s hooks in %s\n", integration, result.ConfigPath,
+		)
+		if integration == agentactivity.IntegrationCodex {
+			message += "Open /hooks in Codex once to review and trust the new hook commands.\n"
+		}
+		if _, err := io.WriteString(stdout, message); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func runAgentHookUninstall(args []string, stdout io.Writer) error {
+	flags, err := parseAgentHookFlags("uninstall", args)
+	if err != nil {
+		return err
+	}
+	for _, integration := range flags.integrations {
+		result, err := agentactivity.Uninstall(integration)
+		if err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(stdout,
+			"Removed middleman %s hooks from %s\n", integration, result.ConfigPath,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type agentHookFlags struct {
+	configPath   string
+	binary       string
+	integrations []agentactivity.Integration
+}
+
+// parseAgentHookFlags parses the flags shared by install and uninstall so both
+// subcommands accept the same arguments.
+func parseAgentHookFlags(action string, args []string) (agentHookFlags, error) {
+	fs := flag.NewFlagSet("middleman agent-hook "+action, flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	configPath := fs.String("config", config.DefaultConfigPath(), "middleman config path")
+	agent := fs.String("agent", "", "agent integration (claude or codex; empty applies to both)")
+	binary := fs.String("binary", "", "middleman binary path used by installed hooks")
+	if err := fs.Parse(args); err != nil {
+		return agentHookFlags{}, err
+	}
+	integrations := []agentactivity.Integration{
+		agentactivity.IntegrationClaude,
+		agentactivity.IntegrationCodex,
+	}
+	if strings.TrimSpace(*agent) != "" {
+		integration, err := agentactivity.ParseIntegration(*agent)
+		if err != nil {
+			return agentHookFlags{}, err
+		}
+		integrations = []agentactivity.Integration{integration}
+	}
+	return agentHookFlags{
+		configPath:   *configPath,
+		binary:       strings.TrimSpace(*binary),
+		integrations: integrations,
+	}, nil
+}
+
+// agentHookStateDir resolves where installed hooks write their reports. The
+// server derives the same directory from its own data dir, so an install that
+// pointed anywhere else would leave workspace rows without agent state.
+func agentHookStateDir(configPath string) (string, error) {
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		return "", err
+	}
+	// Hooks run from the agent's working directory, where a relative data dir
+	// would resolve differently for every session.
+	if !filepath.IsAbs(cfg.DataDir) {
+		return "", fmt.Errorf(
+			"agent hook install requires an absolute data_dir: %q", cfg.DataDir,
+		)
+	}
+	return agentactivity.StateDir(cfg.DataDir), nil
+}
+
+func agentHookExecutable(binary string) (string, error) {
+	if binary != "" {
+		return binary, nil
+	}
+	executable, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("resolve middleman executable: %w", err)
+	}
+	return executable, nil
+}

--- a/cmd/middleman/agent_hook_cli_test.go
+++ b/cmd/middleman/agent_hook_cli_test.go
@@ -44,7 +44,7 @@ func TestAgentHookInstallRejectsRelativeDataDirectory(t *testing.T) {
 	configDir := filepath.Join(dir, "codex")
 	t.Setenv("CODEX_HOME", configDir)
 
-	err := runAgentHookInstall("install", []string{
+	err := runAgentHookInstall([]string{
 		"--config", configPath,
 		"--agent", "codex",
 		"--binary", "/opt/middleman",

--- a/cmd/middleman/main.go
+++ b/cmd/middleman/main.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	oteltelemetry "go.kenn.io/kit/telemetry"
-	"go.kenn.io/middleman/internal/agentactivity"
 	"go.kenn.io/middleman/internal/archive"
 	"go.kenn.io/middleman/internal/cli/ctl"
 	"go.kenn.io/middleman/internal/cli/serve"
@@ -230,107 +229,6 @@ func runCLI(args []string, stdout io.Writer) error {
 	}
 
 	return serve.Run(args, runServer)
-}
-
-func runAgentHookCLI(args []string, stdin io.Reader, stdout io.Writer) error {
-	if len(args) == 0 {
-		return fmt.Errorf("usage: middleman agent-hook <run|install|uninstall>")
-	}
-	switch args[0] {
-	case "run":
-		return runAgentHookReceiver(args[1:], stdin)
-	case "install", "uninstall":
-		return runAgentHookInstall(args[0], args[1:], stdout)
-	default:
-		return fmt.Errorf("unknown agent-hook subcommand %q", args[0])
-	}
-}
-
-func runAgentHookReceiver(args []string, stdin io.Reader) error {
-	fs := flag.NewFlagSet("middleman agent-hook run", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	stateDir := fs.String("state-dir", "", "agent activity state directory")
-	source := fs.String("source", "", "hook source marker")
-	if err := fs.Parse(args); err != nil {
-		return nil
-	}
-	if *source != "middleman-agent-activity" {
-		return nil
-	}
-	store := agentactivity.NewStore(*stateDir)
-	_ = store.HandleHook(
-		stdin, os.Getenv(agentactivity.RuntimeSessionKeyEnv),
-	)
-	return nil
-}
-
-func runAgentHookInstall(action string, args []string, stdout io.Writer) error {
-	fs := flag.NewFlagSet("middleman agent-hook "+action, flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	configPath := fs.String("config", config.DefaultConfigPath(), "middleman config path")
-	agent := fs.String("agent", "", "agent integration (claude or codex; empty installs both)")
-	binary := fs.String("binary", "", "middleman binary path used by installed hooks")
-	if err := fs.Parse(args); err != nil {
-		return err
-	}
-	integrations := []agentactivity.Integration{
-		agentactivity.IntegrationClaude,
-		agentactivity.IntegrationCodex,
-	}
-	if strings.TrimSpace(*agent) != "" {
-		integration, err := agentactivity.ParseIntegration(*agent)
-		if err != nil {
-			return err
-		}
-		integrations = []agentactivity.Integration{integration}
-	}
-
-	if action == "uninstall" {
-		for _, integration := range integrations {
-			result, err := agentactivity.Uninstall(integration)
-			if err != nil {
-				return err
-			}
-			if _, err := fmt.Fprintf(stdout, "Removed middleman %s hooks from %s\n", integration, result.ConfigPath); err != nil {
-				return err
-			}
-		}
-		return nil
-	}
-
-	cfg, err := config.Load(*configPath)
-	if err != nil {
-		return err
-	}
-	if !filepath.IsAbs(cfg.DataDir) {
-		return fmt.Errorf("agent hook install requires an absolute data_dir: %q", cfg.DataDir)
-	}
-	executable := strings.TrimSpace(*binary)
-	if executable == "" {
-		executable, err = os.Executable()
-		if err != nil {
-			return fmt.Errorf("resolve middleman executable: %w", err)
-		}
-	}
-	for _, integration := range integrations {
-		result, err := agentactivity.Install(
-			integration,
-			executable,
-			filepath.Join(cfg.DataDir, "agent-activity"),
-		)
-		if err != nil {
-			return err
-		}
-		if _, err := fmt.Fprintf(stdout, "Installed middleman %s hooks in %s\n", integration, result.ConfigPath); err != nil {
-			return err
-		}
-		if integration == agentactivity.IntegrationCodex {
-			if _, err := fmt.Fprintln(stdout, "Open /hooks in Codex once to review and trust the new hook commands."); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
 }
 
 func runVersionCLI(args []string, stdout io.Writer) error {

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -240,9 +240,11 @@ visible to Git, the write fails.
 - Matching live runtime/worktree reports use approval, input, working, idle priority;
   latest state expires after 30 minutes or session exit, then tmux resumes (`internal/agentactivity/`, `internal/server/workspaceapi/lifecycle.go::Handler.HandleRuntimeSessionExit`).
 - Hook installs require absolute data roots and update symlink targets instead of replacing
-  config links; report/worktree matching uses canonical filesystem paths (`cmd/middleman/main.go::runAgentHookInstall`,
-  `internal/agentactivity/integration.go::writeJSONObject`, `internal/agentactivity/store.go::canonicalWorkspacePath`).
-- The active sidebar polls every five seconds, and hook receipt fails open (`frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte::onMount`, `cmd/middleman/main.go::runAgentHookReceiver`).
+  config links; report/worktree matching uses canonical filesystem paths (`cmd/middleman/agent_hook_cli.go::agentHookStateDir`,
+  `internal/agentactivity/integration.go::resolvedConfigWritePath`, `internal/agentactivity/store.go::canonicalWorkspacePath`).
+- Installed hooks and the server must resolve the same report directory, so both go
+  through `internal/agentactivity/store.go::StateDir`.
+- The active sidebar polls every five seconds, and hook receipt fails open (`frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte::onMount`, `cmd/middleman/agent_hook_cli.go::runAgentHookReceiver`).
 
 ## Diff Scopes
 

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -612,21 +612,31 @@
     return title || "Working";
   }
 
-  function agentStatePresentation(ws: Workspace): {
-    label: "Working" | "Approval" | "Input";
-    status: StatusDotStatus;
-    tone: "working" | "approval" | "input";
-  } | null {
-    switch (ws.agent_state) {
-      case "working":
-        return { label: "Working", status: "working", tone: "working" };
-      case "approval":
-        return { label: "Approval", status: "waiting", tone: "approval" };
-      case "input":
-        return { label: "Input", status: "waiting", tone: "input" };
-      default:
-        return null;
-    }
+  interface AgentStateBadge {
+    label: string;
+    dot: StatusDotStatus;
+    /** Suffixes the accessible description and picks the badge colour. */
+    tone: string;
+  }
+
+  // Idle has no badge on purpose: a hook report that the agent is idle means the
+  // row should stay quiet, which is what suppresses the tmux dot below.
+  const agentStateBadges: Partial<
+    Record<NonNullable<Workspace["agent_state"]>, AgentStateBadge>
+  > = {
+    working: { label: "Working", dot: "working", tone: "working" },
+    approval: { label: "Approval", dot: "waiting", tone: "approval" },
+    input: { label: "Input", dot: "waiting", tone: "input" },
+  };
+
+  function agentStateBadge(ws: Workspace): AgentStateBadge | null {
+    return (ws.agent_state && agentStateBadges[ws.agent_state]) || null;
+  }
+
+  // Hook reports are authoritative while they last, so tmux output only speaks
+  // for a workspace no agent session is reporting on.
+  function showsTmuxWorking(ws: Workspace): boolean {
+    return ws.tmux_working === true && ws.agent_state == null;
   }
 
   function itemStateClass(ws: Workspace): string {
@@ -1201,7 +1211,7 @@
           {@const ahead = ws.commits_ahead ?? 0}
           {@const behind = ws.commits_behind ?? 0}
           {@const showPush = ahead > 0 || behind > 0}
-          {@const agentState = agentStatePresentation(ws)}
+          {@const agentBadge = agentStateBadge(ws)}
           <div
             class={["ws-row", { selected: isSelectedWorkspace(ws) }]}
             onclick={(e) => {
@@ -1241,21 +1251,18 @@
                   size={6}
                 />
                 <span class="ws-name">{displayName(ws)}</span>
-                {#if agentState}
+                {#if agentBadge}
+                  {@const description = `Agent ${agentBadge.tone}`}
                   <span
-                    class={["agent-state", `agent-state--${agentState.tone}`]}
-                    title={`Agent ${agentState.label.toLowerCase()}`}
+                    class={["agent-state", `agent-state--${agentBadge.tone}`]}
+                    title={description}
                   >
-                    <StatusDot
-                      status={agentState.status}
-                      label={`Agent ${agentState.label.toLowerCase()}`}
-                      size={6}
-                    />
-                    <span>{agentState.label}</span>
+                    <StatusDot status={agentBadge.dot} label={description} size={6} />
+                    <span>{agentBadge.label}</span>
                   </span>
                 {:else if workspaceActionMatches(ws)}
                   <StatusDot status="working" label={workspaceBusyLabel(ws)} size={6} />
-                {:else if ws.agent_state == null && ws.tmux_working}
+                {:else if showsTmuxWorking(ws)}
                   <StatusDot status="working" label={workingTitle(ws)} size={6} />
                 {/if}
               </div>
@@ -1840,7 +1847,6 @@
     color: var(--accent-purple);
     --status-waiting: var(--accent-purple);
   }
-
 
   .repo-context {
     /* Flat sorts drop the per-repo group headers, so each row

--- a/internal/agentactivity/fileio.go
+++ b/internal/agentactivity/fileio.go
@@ -1,0 +1,34 @@
+package agentactivity
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// writeFileAtomic replaces path with data through a temporary file in the same
+// directory, so a hook firing while middleman reads the state never observes a
+// half-written file. tempPattern names the temporary file (see os.CreateTemp).
+func writeFileAtomic(path, tempPattern string, data []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, tempPattern)
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}

--- a/internal/agentactivity/integration.go
+++ b/internal/agentactivity/integration.go
@@ -1,6 +1,7 @@
 package agentactivity
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -20,7 +21,14 @@ const (
 	IntegrationCodex  Integration = "codex"
 )
 
-const hookCommandMarker = "--source middleman-agent-activity"
+// HookSource marks middleman's own hook invocations. The receiver refuses input
+// without it, and uninstall recognizes installed handlers by it.
+const HookSource = "middleman-agent-activity"
+
+const (
+	hookCommandMarker  = "--source " + HookSource
+	hookTimeoutSeconds = 2
+)
 
 var integrationHookEvents = map[Integration][]string{
 	IntegrationClaude: {
@@ -54,34 +62,17 @@ func Install(integration Integration, executable, stateDir string) (InstallResul
 	if err != nil {
 		return InstallResult{}, err
 	}
+	// Installing is idempotent: drop any handler from an earlier install, which
+	// may point at a stale binary path, before adding the current one.
 	removeMiddlemanHooks(hooks)
 
-	command := shellquote.Join(
-		executable, "agent-hook", "run", "--state-dir", stateDir,
-		"--source", "middleman-agent-activity",
-	)
-	commandWindows := windowsCommand(
-		executable, "agent-hook", "run", "--state-dir", stateDir,
-		"--source", "middleman-agent-activity",
-	)
-	if runtime.GOOS == "windows" {
-		command = commandWindows
-	}
+	command, commandWindows := hookCommands(executable, stateDir)
 	for _, event := range integrationHookEvents[integration] {
-		handler := map[string]any{
-			"type":    "command",
-			"command": command,
-			"timeout": 2,
-		}
-		if integration == IntegrationCodex {
-			handler["commandWindows"] = commandWindows
-		}
-		entry := map[string]any{"hooks": []any{handler}}
 		existing, err := arrayField(hooks, event, configPath)
 		if err != nil {
 			return InstallResult{}, err
 		}
-		hooks[event] = append(existing, entry)
+		hooks[event] = append(existing, hookEntry(integration, command, commandWindows))
 	}
 	if err := writeJSONObject(configPath, root); err != nil {
 		return InstallResult{}, err
@@ -124,32 +115,55 @@ func ParseIntegration(raw string) (Integration, error) {
 	return integration, nil
 }
 
+// hookCommands renders the receiver invocation for the running platform and,
+// separately, for Windows. Codex configs carry both.
+func hookCommands(executable, stateDir string) (command, commandWindows string) {
+	args := []string{
+		executable, "agent-hook", "run",
+		"--state-dir", stateDir,
+		"--source", HookSource,
+	}
+	commandWindows = windowsCommand(args...)
+	if runtime.GOOS == "windows" {
+		return commandWindows, commandWindows
+	}
+	return shellquote.Join(args...), commandWindows
+}
+
+// hookEntry builds one config entry that runs the middleman receiver.
+func hookEntry(integration Integration, command, commandWindows string) map[string]any {
+	handler := map[string]any{
+		"type":    "command",
+		"command": command,
+		"timeout": hookTimeoutSeconds,
+	}
+	if integration == IntegrationCodex {
+		handler["commandWindows"] = commandWindows
+	}
+	return map[string]any{"hooks": []any{handler}}
+}
+
 func integrationConfigPath(integration Integration) (string, error) {
-	dir := ""
 	switch integration {
 	case IntegrationClaude:
-		dir = strings.TrimSpace(os.Getenv("CLAUDE_CONFIG_DIR"))
-		if dir == "" {
-			home, err := os.UserHomeDir()
-			if err != nil {
-				return "", err
-			}
-			dir = filepath.Join(home, ".claude")
-		}
-		return filepath.Join(dir, "settings.json"), nil
+		return agentConfigPath("CLAUDE_CONFIG_DIR", ".claude", "settings.json")
 	case IntegrationCodex:
-		dir = strings.TrimSpace(os.Getenv("CODEX_HOME"))
-		if dir == "" {
-			home, err := os.UserHomeDir()
-			if err != nil {
-				return "", err
-			}
-			dir = filepath.Join(home, ".codex")
-		}
-		return filepath.Join(dir, "hooks.json"), nil
+		return agentConfigPath("CODEX_HOME", ".codex", "hooks.json")
 	default:
 		return "", fmt.Errorf("unsupported agent hook integration %q", integration)
 	}
+}
+
+func agentConfigPath(dirEnv, homeDirName, fileName string) (string, error) {
+	dir := strings.TrimSpace(os.Getenv(dirEnv))
+	if dir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		dir = filepath.Join(home, homeDirName)
+	}
+	return filepath.Join(dir, fileName), nil
 }
 
 func removeMiddlemanHooks(hooks map[string]any) {
@@ -160,37 +174,50 @@ func removeMiddlemanHooks(hooks map[string]any) {
 		}
 		keptEntries := make([]any, 0, len(entries))
 		for _, rawEntry := range entries {
-			entry, ok := rawEntry.(map[string]any)
-			if !ok {
-				keptEntries = append(keptEntries, rawEntry)
-				continue
+			if entry, keep := entryWithoutMiddlemanHandlers(rawEntry); keep {
+				keptEntries = append(keptEntries, entry)
 			}
-			rawHandlers, ok := entry["hooks"].([]any)
-			if !ok {
-				keptEntries = append(keptEntries, rawEntry)
-				continue
-			}
-			keptHandlers := make([]any, 0, len(rawHandlers))
-			for _, rawHandler := range rawHandlers {
-				handler, ok := rawHandler.(map[string]any)
-				command, _ := handler["command"].(string)
-				if ok && strings.Contains(command, hookCommandMarker) {
-					continue
-				}
-				keptHandlers = append(keptHandlers, rawHandler)
-			}
-			if len(keptHandlers) == 0 {
-				continue
-			}
-			entry["hooks"] = keptHandlers
-			keptEntries = append(keptEntries, entry)
 		}
 		if len(keptEntries) == 0 {
 			delete(hooks, event)
-		} else {
-			hooks[event] = keptEntries
+			continue
+		}
+		hooks[event] = keptEntries
+	}
+}
+
+// entryWithoutMiddlemanHandlers strips middleman handlers from one hook entry.
+// Entries middleman does not recognize are kept verbatim, and an entry that
+// held nothing but middleman handlers is dropped instead of left empty.
+func entryWithoutMiddlemanHandlers(rawEntry any) (any, bool) {
+	entry, ok := rawEntry.(map[string]any)
+	if !ok {
+		return rawEntry, true
+	}
+	handlers, ok := entry["hooks"].([]any)
+	if !ok {
+		return rawEntry, true
+	}
+	keptHandlers := make([]any, 0, len(handlers))
+	for _, handler := range handlers {
+		if !isMiddlemanHandler(handler) {
+			keptHandlers = append(keptHandlers, handler)
 		}
 	}
+	if len(keptHandlers) == 0 {
+		return nil, false
+	}
+	entry["hooks"] = keptHandlers
+	return entry, true
+}
+
+func isMiddlemanHandler(rawHandler any) bool {
+	handler, ok := rawHandler.(map[string]any)
+	if !ok {
+		return false
+	}
+	command, _ := handler["command"].(string)
+	return strings.Contains(command, hookCommandMarker)
 }
 
 func readJSONObject(path string) (map[string]any, error) {
@@ -202,7 +229,9 @@ func readJSONObject(path string) (map[string]any, error) {
 		return nil, err
 	}
 	var root map[string]any
-	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	// Agent configs may hold integers past float64 precision, and rewriting the
+	// file must not round values middleman does not own.
 	decoder.UseNumber()
 	if err := decoder.Decode(&root); err != nil {
 		return nil, fmt.Errorf("parse %s: %w", path, err)
@@ -258,18 +287,8 @@ func arrayField(root map[string]any, key, path string) ([]any, error) {
 }
 
 func writeJSONObject(path string, value map[string]any) error {
-	writePath := path
-	info, err := os.Lstat(path)
-	if err == nil && info.Mode()&os.ModeSymlink != 0 {
-		resolved, resolveErr := filepath.EvalSymlinks(path)
-		if resolveErr != nil {
-			return fmt.Errorf("resolve agent hook config symlink: %w", resolveErr)
-		}
-		writePath = resolved
-	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("inspect agent hook config path: %w", err)
-	}
-	if err := os.MkdirAll(filepath.Dir(writePath), 0o700); err != nil {
+	writePath, err := resolvedConfigWritePath(path)
+	if err != nil {
 		return err
 	}
 	data, err := json.MarshalIndent(value, "", "  ")
@@ -277,24 +296,27 @@ func writeJSONObject(path string, value map[string]any) error {
 		return err
 	}
 	data = append(data, '\n')
-	tmp, err := os.CreateTemp(filepath.Dir(writePath), ".middleman-hooks-*")
+	return writeFileAtomic(writePath, ".middleman-hooks-*", data)
+}
+
+// resolvedConfigWritePath follows a symlinked agent config to its target so an
+// install rewrites the file the user linked to instead of replacing the link.
+func resolvedConfigWritePath(path string) (string, error) {
+	info, err := os.Lstat(path)
 	if err != nil {
-		return err
+		if errors.Is(err, os.ErrNotExist) {
+			return path, nil
+		}
+		return "", fmt.Errorf("inspect agent hook config path: %w", err)
 	}
-	tmpPath := tmp.Name()
-	defer os.Remove(tmpPath)
-	if err := tmp.Chmod(0o600); err != nil {
-		tmp.Close()
-		return err
+	if info.Mode()&os.ModeSymlink == 0 {
+		return path, nil
 	}
-	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
-		return err
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve agent hook config symlink: %w", err)
 	}
-	if err := tmp.Close(); err != nil {
-		return err
-	}
-	return os.Rename(tmpPath, writePath)
+	return resolved, nil
 }
 
 func windowsCommand(args ...string) string {

--- a/internal/agentactivity/store.go
+++ b/internal/agentactivity/store.go
@@ -30,6 +30,11 @@ const RuntimeSessionKeyEnv = "MIDDLEMAN_RUNTIME_SESSION_KEY"
 // without another lifecycle event confirming it.
 const ReportFreshness = 30 * time.Minute
 
+const (
+	maxHookInputBytes = 1 << 20
+	maxReportBytes    = 64 << 10
+)
+
 type Report struct {
 	SessionID         string    `json:"session_id"`
 	RuntimeSessionKey string    `json:"runtime_session_key"`
@@ -66,66 +71,69 @@ func NewStore(root string) *Store {
 	return &Store{root: root, now: time.Now}
 }
 
+// StateDir names the report directory under a middleman data dir. Installed
+// hooks and the server must agree on it, so both derive it from here.
+func StateDir(dataDir string) string {
+	return filepath.Join(dataDir, "agent-activity")
+}
+
+// enabled reports whether the store has a state directory to read and write.
+// Callers hold a nil store when agent activity is not configured.
+func (s *Store) enabled() bool {
+	return s != nil && strings.TrimSpace(s.root) != ""
+}
+
 func (s *Store) HandleHook(input io.Reader, runtimeSessionKey string) error {
-	if s == nil || strings.TrimSpace(s.root) == "" {
+	if !s.enabled() {
 		return nil
 	}
 	var hook hookInput
-	if err := json.NewDecoder(io.LimitReader(input, 1<<20)).Decode(&hook); err != nil {
+	if err := json.NewDecoder(io.LimitReader(input, maxHookInputBytes)).Decode(&hook); err != nil {
 		return fmt.Errorf("decode agent hook: %w", err)
 	}
+	// Only the top-level session reports workspace state; subagent payloads
+	// carry an agent ID and would otherwise overwrite it.
 	if hook.AgentID != "" {
 		return nil
 	}
-	hook.SessionID = strings.TrimSpace(hook.SessionID)
+	sessionID := strings.TrimSpace(hook.SessionID)
 	runtimeSessionKey = strings.TrimSpace(runtimeSessionKey)
-	if hook.SessionID == "" || runtimeSessionKey == "" {
+	if sessionID == "" || runtimeSessionKey == "" {
 		return nil
 	}
 
-	state, remove, ok := stateForHook(hook)
-	if !ok {
+	outcome, state := hookEventOutcome(hook)
+	switch outcome {
+	case hookIgnored:
 		return nil
-	}
-	if remove {
-		err := os.Remove(s.reportPath(hook.SessionID))
-		if errors.Is(err, os.ErrNotExist) {
-			return nil
-		}
-		if err == nil {
-			s.invalidateCache()
-		}
-		return err
+	case hookEndsSession:
+		return s.removeReport(sessionID)
 	}
 
 	cwd, err := canonicalWorkspacePath(hook.CWD)
 	if err != nil {
 		return nil
 	}
-	report := Report{
-		SessionID:         hook.SessionID,
+	return s.writeReport(Report{
+		SessionID:         sessionID,
 		RuntimeSessionKey: runtimeSessionKey,
 		CWD:               cwd,
 		State:             state,
 		UpdatedAt:         s.now().UTC(),
-	}
-	return s.writeReport(report)
+	})
 }
 
+// SnapshotForWorkspace returns the most urgent state reported by any live
+// runtime session working in cwd.
 func (s *Store) SnapshotForWorkspace(cwd string, liveSessionKeys []string) (Snapshot, bool) {
-	if s == nil || strings.TrimSpace(s.root) == "" || len(liveSessionKeys) == 0 {
+	if !s.enabled() {
 		return Snapshot{}, false
 	}
 	target, err := canonicalWorkspacePath(cwd)
 	if err != nil {
 		return Snapshot{}, false
 	}
-	live := make(map[string]struct{}, len(liveSessionKeys))
-	for _, key := range liveSessionKeys {
-		if key = strings.TrimSpace(key); key != "" {
-			live[key] = struct{}{}
-		}
-	}
+	live := liveSessionKeySet(liveSessionKeys)
 	if len(live) == 0 {
 		return Snapshot{}, false
 	}
@@ -143,35 +151,14 @@ func (s *Store) SnapshotForWorkspace(cwd string, liveSessionKeys []string) (Snap
 	if len(reports) == 0 {
 		return Snapshot{}, false
 	}
-	slices.SortFunc(reports, func(a, b Report) int {
-		if priority := statePriority(b.State) - statePriority(a.State); priority != 0 {
-			return priority
-		}
-		return b.UpdatedAt.Compare(a.UpdatedAt)
-	})
-	return Snapshot{State: reports[0].State, UpdatedAt: reports[0].UpdatedAt}, true
-}
-
-func canonicalWorkspacePath(path string) (string, error) {
-	path = strings.TrimSpace(path)
-	if path == "" {
-		return "", errors.New("workspace path is required")
-	}
-	abs, err := filepath.Abs(path)
-	if err != nil {
-		return "", err
-	}
-	clean := filepath.Clean(abs)
-	if resolved, resolveErr := filepath.EvalSymlinks(clean); resolveErr == nil {
-		return filepath.Clean(resolved), nil
-	}
-	return clean, nil
+	best := slices.MaxFunc(reports, compareReportUrgency)
+	return Snapshot{State: best.State, UpdatedAt: best.UpdatedAt}, true
 }
 
 // RemoveRuntimeSession removes every agent report owned by one launched
 // runtime session.
 func (s *Store) RemoveRuntimeSession(runtimeSessionKey string) error {
-	if s == nil || strings.TrimSpace(s.root) == "" {
+	if !s.enabled() {
 		return nil
 	}
 	runtimeSessionKey = strings.TrimSpace(runtimeSessionKey)
@@ -192,68 +179,138 @@ func (s *Store) RemoveRuntimeSession(runtimeSessionKey string) error {
 	return errors.Join(errs...)
 }
 
+func liveSessionKeySet(keys []string) map[string]struct{} {
+	live := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		if key = strings.TrimSpace(key); key != "" {
+			live[key] = struct{}{}
+		}
+	}
+	return live
+}
+
+// compareReportUrgency orders reports by state priority, then by recency, so
+// an approval prompt outranks background work from another session.
+func compareReportUrgency(a, b Report) int {
+	if priority := statePriority(a.State) - statePriority(b.State); priority != 0 {
+		return priority
+	}
+	return a.UpdatedAt.Compare(b.UpdatedAt)
+}
+
+func canonicalWorkspacePath(path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", errors.New("workspace path is required")
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	clean := filepath.Clean(abs)
+	if resolved, resolveErr := filepath.EvalSymlinks(clean); resolveErr == nil {
+		return filepath.Clean(resolved), nil
+	}
+	return clean, nil
+}
+
+// reportDirListing is one view of the state directory: the report files to read
+// plus the metadata used to notice writes from other middleman processes.
+type reportDirListing struct {
+	names    []string
+	metadata map[string]os.FileInfo
+	// metadataComplete is false when a file's metadata could not be read, which
+	// makes the cache unusable because changes to it would go unnoticed.
+	metadataComplete bool
+}
+
+// reportScan is the result of reading every report file in one listing.
+type reportScan struct {
+	reports []Report
+	// validUntil is when the earliest-expiring report goes stale.
+	validUntil time.Time
+	// cleanupComplete is false when an expired report could not be deleted.
+	cleanupComplete bool
+}
+
 func (s *Store) reports() []Report {
 	s.cacheMu.Lock()
 	defer s.cacheMu.Unlock()
 
-	entries, err := os.ReadDir(s.root)
-	if err != nil {
+	listing, ok := s.listReportDir()
+	if !ok {
 		s.clearCacheLocked()
 		return nil
 	}
 	now := s.now().UTC()
-	files := make(map[string]os.FileInfo)
-	metadataComplete := true
-	for _, entry := range entries {
-		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
-			continue
-		}
-		info, infoErr := entry.Info()
-		if infoErr != nil {
-			metadataComplete = false
-			continue
-		}
-		files[entry.Name()] = info
-	}
-	if metadataComplete && sameReportFiles(files, s.cacheFiles) &&
+	if listing.metadataComplete && sameReportFiles(listing.metadata, s.cacheFiles) &&
 		(s.cacheValidUntil.IsZero() || now.Before(s.cacheValidUntil)) {
 		return slices.Clone(s.cacheReports)
 	}
 
-	reports := make([]Report, 0, len(entries))
-	validUntil := time.Time{}
-	cleanupPending := false
+	scan := s.scanReports(listing, now)
+	s.cacheFiles = listing.metadata
+	if !scan.cleanupComplete || !listing.metadataComplete {
+		s.cacheFiles = nil
+	}
+	s.cacheValidUntil = scan.validUntil
+	s.cacheReports = slices.Clone(scan.reports)
+	return scan.reports
+}
+
+func (s *Store) listReportDir() (reportDirListing, bool) {
+	entries, err := os.ReadDir(s.root)
+	if err != nil {
+		return reportDirListing{}, false
+	}
+	listing := reportDirListing{
+		metadata:         make(map[string]os.FileInfo),
+		metadataComplete: true,
+	}
 	for _, entry := range entries {
 		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
 			continue
 		}
-		path := filepath.Join(s.root, entry.Name())
+		listing.names = append(listing.names, entry.Name())
+		info, infoErr := entry.Info()
+		if infoErr != nil {
+			listing.metadataComplete = false
+			continue
+		}
+		listing.metadata[entry.Name()] = info
+	}
+	return listing, true
+}
+
+// scanReports reads every listed report, deleting the ones that have expired.
+// Deleted names are dropped from listing.metadata so it still describes the
+// directory once the scan finishes.
+func (s *Store) scanReports(listing reportDirListing, now time.Time) reportScan {
+	scan := reportScan{
+		reports:         make([]Report, 0, len(listing.names)),
+		cleanupComplete: true,
+	}
+	for _, name := range listing.names {
+		path := filepath.Join(s.root, name)
 		report, ok := s.readReport(path)
 		if !ok {
 			continue
 		}
 		expiresAt := report.UpdatedAt.Add(ReportFreshness)
 		if !now.Before(expiresAt) {
-			if removeErr := os.Remove(path); removeErr == nil ||
-				errors.Is(removeErr, os.ErrNotExist) {
-				delete(files, entry.Name())
+			if err := os.Remove(path); err == nil || errors.Is(err, os.ErrNotExist) {
+				delete(listing.metadata, name)
 			} else {
-				cleanupPending = true
+				scan.cleanupComplete = false
 			}
 			continue
 		}
-		if validUntil.IsZero() || expiresAt.Before(validUntil) {
-			validUntil = expiresAt
+		if scan.validUntil.IsZero() || expiresAt.Before(scan.validUntil) {
+			scan.validUntil = expiresAt
 		}
-		reports = append(reports, report)
+		scan.reports = append(scan.reports, report)
 	}
-	s.cacheFiles = files
-	if cleanupPending || !metadataComplete {
-		s.cacheFiles = nil
-	}
-	s.cacheValidUntil = validUntil
-	s.cacheReports = slices.Clone(reports)
-	return reports
+	return scan
 }
 
 func (s *Store) invalidateCache() {
@@ -283,37 +340,56 @@ func sameReportFiles(current, cached map[string]os.FileInfo) bool {
 	return true
 }
 
-func stateForHook(input hookInput) (State, bool, bool) {
+// hookOutcome says what a hook event means for the session's stored report.
+type hookOutcome int
+
+const (
+	// hookIgnored covers events that carry no state signal.
+	hookIgnored hookOutcome = iota
+	hookReportsState
+	hookEndsSession
+)
+
+// hookEventStates holds the events whose state does not depend on the payload.
+var hookEventStates = map[string]State{
+	"SessionStart":       StateIdle,
+	"UserPromptSubmit":   StateWorking,
+	"PostToolUse":        StateWorking,
+	"PostToolUseFailure": StateWorking,
+	"PreCompact":         StateWorking,
+	"PostCompact":        StateWorking,
+	"PermissionRequest":  StateApproval,
+	"Stop":               StateIdle,
+	"Interrupt":          StateIdle,
+}
+
+// notificationStates holds the notification kinds that mean the agent is
+// blocked on the user. Other notifications say nothing about the session.
+var notificationStates = map[string]State{
+	"permission_prompt":  StateApproval,
+	"idle_prompt":        StateInput,
+	"elicitation_dialog": StateInput,
+}
+
+func hookEventOutcome(input hookInput) (hookOutcome, State) {
 	switch input.HookEventName {
-	case "SessionStart":
-		return StateIdle, false, true
-	case "UserPromptSubmit":
-		return StateWorking, false, true
+	case "SessionEnd":
+		return hookEndsSession, ""
 	case "PreToolUse":
 		if isUserInputTool(input.ToolName) {
-			return StateInput, false, true
+			return hookReportsState, StateInput
 		}
-		return StateWorking, false, true
-	case "PostToolUse", "PostToolUseFailure", "PreCompact", "PostCompact":
-		return StateWorking, false, true
-	case "PermissionRequest":
-		return StateApproval, false, true
+		return hookReportsState, StateWorking
 	case "Notification":
-		switch input.NotificationType {
-		case "permission_prompt":
-			return StateApproval, false, true
-		case "idle_prompt", "elicitation_dialog":
-			return StateInput, false, true
-		default:
-			return "", false, false
+		if state, ok := notificationStates[input.NotificationType]; ok {
+			return hookReportsState, state
 		}
-	case "Stop", "Interrupt":
-		return StateIdle, false, true
-	case "SessionEnd":
-		return "", true, true
-	default:
-		return "", false, false
+		return hookIgnored, ""
 	}
+	if state, ok := hookEventStates[input.HookEventName]; ok {
+		return hookReportsState, state
+	}
+	return hookIgnored, ""
 }
 
 func isUserInputTool(tool string) bool {
@@ -341,35 +417,28 @@ func statePriority(state State) int {
 }
 
 func (s *Store) writeReport(report Report) error {
-	if err := os.MkdirAll(s.root, 0o700); err != nil {
-		return err
-	}
 	data, err := json.Marshal(report)
 	if err != nil {
 		return err
 	}
-	tmp, err := os.CreateTemp(s.root, ".agent-activity-*")
-	if err != nil {
-		return err
-	}
-	tmpPath := tmp.Name()
-	defer os.Remove(tmpPath)
-	if err := tmp.Chmod(0o600); err != nil {
-		tmp.Close()
-		return err
-	}
-	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		return err
-	}
-	if err := os.Rename(tmpPath, s.reportPath(report.SessionID)); err != nil {
+	if err := writeFileAtomic(
+		s.reportPath(report.SessionID), ".agent-activity-*", data,
+	); err != nil {
 		return err
 	}
 	s.invalidateCache()
 	return nil
+}
+
+func (s *Store) removeReport(sessionID string) error {
+	err := os.Remove(s.reportPath(sessionID))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err == nil {
+		s.invalidateCache()
+	}
+	return err
 }
 
 func (s *Store) readReport(path string) (Report, bool) {
@@ -379,7 +448,7 @@ func (s *Store) readReport(path string) (Report, bool) {
 	}
 	defer file.Close()
 	var report Report
-	if err := json.NewDecoder(io.LimitReader(file, 64<<10)).Decode(&report); err != nil {
+	if err := json.NewDecoder(io.LimitReader(file, maxReportBytes)).Decode(&report); err != nil {
 		return Report{}, false
 	}
 	if statePriority(report.State) == 0 || report.RuntimeSessionKey == "" ||

--- a/internal/procutil/env.go
+++ b/internal/procutil/env.go
@@ -1,0 +1,36 @@
+package procutil
+
+import (
+	"slices"
+	"strings"
+)
+
+// MergeEnv returns env with overrides applied, as an "KEY=value" slice suitable
+// for exec.Cmd.Env. Inherited entries for an overridden key are dropped rather
+// than shadowed, because not every consumer of an environment slice honors
+// last-wins duplicates. Overrides are appended in key order so callers can
+// compare rendered environments.
+func MergeEnv(env []string, overrides map[string]string) []string {
+	if len(overrides) == 0 {
+		return env
+	}
+	kept := env[:0]
+	for _, entry := range env {
+		key, _, found := strings.Cut(entry, "=")
+		if found {
+			if _, overridden := overrides[key]; overridden {
+				continue
+			}
+		}
+		kept = append(kept, entry)
+	}
+	keys := make([]string, 0, len(overrides))
+	for key := range overrides {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	for _, key := range keys {
+		kept = append(kept, key+"="+overrides[key])
+	}
+	return kept
+}

--- a/internal/ptyowner/client.go
+++ b/internal/ptyowner/client.go
@@ -11,7 +11,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 	"sync"
 	"syscall"
@@ -480,35 +479,9 @@ func ownerHelperEnvironment(env []string) []string {
 }
 
 func (c Client) ownerHelperEnvironment(env []string) []string {
-	return mergeEnvironment(
+	return procutil.MergeEnv(
 		sessionEnvironment(env, c.StripEnvVars), c.ExtraEnv,
 	)
-}
-
-func mergeEnvironment(env []string, extra map[string]string) []string {
-	if len(extra) == 0 {
-		return env
-	}
-	filtered := env[:0]
-	for _, value := range env {
-		key, _, found := strings.Cut(value, "=")
-		if found {
-			if _, replaced := extra[key]; replaced {
-				continue
-			}
-		}
-		filtered = append(filtered, value)
-	}
-	env = filtered
-	keys := make([]string, 0, len(extra))
-	for key := range extra {
-		keys = append(keys, key)
-	}
-	slices.Sort(keys)
-	for _, key := range keys {
-		env = append(env, key+"="+extra[key])
-	}
-	return env
 }
 
 func applyRPCDeadline(ctx context.Context, conn net.Conn) func() {

--- a/internal/ptyowner/owner.go
+++ b/internal/ptyowner/owner.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	gopty "github.com/aymanbagabas/go-pty"
+	"go.kenn.io/middleman/internal/procutil"
 )
 
 const maxOutputReplay = 64 * 1024
@@ -87,7 +88,7 @@ func RunOwner(ctx context.Context, opts Options) error {
 
 	cmd := p.Command(command[0], command[1:]...)
 	cmd.Dir = opts.Cwd
-	cmd.Env = mergeEnvironment(
+	cmd.Env = procutil.MergeEnv(
 		sessionEnvironment(os.Environ(), opts.StripEnvVars), opts.ExtraEnv,
 	)
 	configureOwnerCommand(cmd)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -938,9 +938,9 @@ func newServer(
 		Config:     workspaceConfigSnapshot(cfg, tmuxCmd),
 		Workspaces: s.workspaces,
 		Runtime:    s.runtime,
-		AgentActivity: agentactivity.NewStore(filepath.Join(
-			filepath.Dir(options.WorktreeDir), "agent-activity",
-		)),
+		AgentActivity: agentactivity.NewStore(
+			agentactivity.StateDir(filepath.Dir(options.WorktreeDir)),
+		),
 		TmuxCommand:        tmuxCmd,
 		Now:                workspaceNow,
 		EnrichmentDisabled: options.DisableWorkspaceEnrichment,

--- a/internal/server/workspaceapi/agent_activity.go
+++ b/internal/server/workspaceapi/agent_activity.go
@@ -1,0 +1,63 @@
+package workspaceapi
+
+import (
+	"log/slog"
+	"time"
+
+	"go.kenn.io/middleman/internal/db"
+	"go.kenn.io/middleman/internal/workspace/localruntime"
+)
+
+// withAgentActivity annotates a workspace response with the state agent hooks
+// last reported. Every response path funnels through here so a row shows the
+// same agent state whether it came from cached, refreshed, or live enrichment.
+func (s *Handler) withAgentActivity(
+	resp workspaceResponse,
+	summary *db.WorkspaceSummary,
+) workspaceResponse {
+	if s.agentActivity == nil || s.runtime == nil || summary == nil {
+		return resp
+	}
+	snapshot, ok := s.agentActivity.SnapshotForWorkspace(
+		summary.WorktreePath, s.liveAgentSessionKeys(summary.ID),
+	)
+	if !ok {
+		return resp
+	}
+	state := string(snapshot.State)
+	updatedAt := snapshot.UpdatedAt.UTC().Format(time.RFC3339)
+	resp.AgentState = &state
+	resp.AgentStateUpdatedAt = &updatedAt
+	return resp
+}
+
+// liveAgentSessionKeys lists the workspace's agent sessions that could still be
+// reporting. Reports from any other session describe work that already ended.
+func (s *Handler) liveAgentSessionKeys(workspaceID string) []string {
+	var keys []string
+	for _, session := range s.runtime.ListSessions(workspaceID) {
+		if session.Kind != localruntime.LaunchTargetAgent {
+			continue
+		}
+		if session.Status != localruntime.SessionStatusRunning &&
+			session.Status != localruntime.SessionStatusStarting {
+			continue
+		}
+		keys = append(keys, session.Key)
+	}
+	return keys
+}
+
+// removeAgentActivityRuntimeSession drops the reports a runtime session left
+// behind, so a stopped agent stops overriding tmux activity immediately instead
+// of waiting for the reports to expire.
+func (h *Handler) removeAgentActivityRuntimeSession(sessionKey string) {
+	if h == nil || h.agentActivity == nil || sessionKey == "" {
+		return
+	}
+	if err := h.agentActivity.RemoveRuntimeSession(sessionKey); err != nil {
+		slog.Warn("remove agent activity report",
+			"session_key", sessionKey,
+			"err", err)
+	}
+}

--- a/internal/server/workspaceapi/lifecycle.go
+++ b/internal/server/workspaceapi/lifecycle.go
@@ -175,14 +175,3 @@ func (h *Handler) HandleRuntimeSessionExit(info localruntime.SessionInfo) {
 		}
 	})
 }
-
-func (h *Handler) removeAgentActivityRuntimeSession(sessionKey string) {
-	if h == nil || h.agentActivity == nil || sessionKey == "" {
-		return
-	}
-	if err := h.agentActivity.RemoveRuntimeSession(sessionKey); err != nil {
-		slog.Warn("remove agent activity report",
-			"session_key", sessionKey,
-			"err", err)
-	}
-}

--- a/internal/server/workspaceapi/routes_handlers.go
+++ b/internal/server/workspaceapi/routes_handlers.go
@@ -1487,36 +1487,9 @@ func (s *Handler) toWorkspaceResponse(
 	ctx context.Context,
 	summary *db.WorkspaceSummary,
 ) workspaceResponse {
-	resp := s.workspaceResponseWithEnrichment(ctx, summary).response
-	s.applyAgentActivity(&resp, summary)
-	return resp
-}
-
-func (s *Handler) applyAgentActivity(
-	resp *workspaceResponse,
-	summary *db.WorkspaceSummary,
-) {
-	if s.agentActivity == nil || s.runtime == nil || resp == nil || summary == nil {
-		return
-	}
-	liveSessionKeys := make([]string, 0)
-	for _, session := range s.runtime.ListSessions(summary.ID) {
-		if session.Kind == localruntime.LaunchTargetAgent &&
-			(session.Status == localruntime.SessionStatusRunning ||
-				session.Status == localruntime.SessionStatusStarting) {
-			liveSessionKeys = append(liveSessionKeys, session.Key)
-		}
-	}
-	snapshot, ok := s.agentActivity.SnapshotForWorkspace(
-		summary.WorktreePath, liveSessionKeys,
+	return s.withAgentActivity(
+		s.workspaceResponseWithEnrichment(ctx, summary).response, summary,
 	)
-	if !ok {
-		return
-	}
-	state := string(snapshot.State)
-	updatedAt := snapshot.UpdatedAt.UTC().Format(time.RFC3339)
-	resp.AgentState = &state
-	resp.AgentStateUpdatedAt = &updatedAt
 }
 
 // Response returns the cached public DTO for a persisted workspace summary.

--- a/internal/server/workspaceapi/workspace_enrichment.go
+++ b/internal/server/workspaceapi/workspace_enrichment.go
@@ -49,17 +49,22 @@ type workspaceEnrichmentProbeResult struct {
 
 func (s *Handler) toCachedWorkspaceResponse(
 	summary *db.WorkspaceSummary,
-) (resp workspaceResponse) {
-	resp = toWorkspaceResponse(summary)
-	defer s.applyAgentActivity(&resp, summary)
+) workspaceResponse {
+	return s.withAgentActivity(s.cachedEnrichedResponse(summary), summary)
+}
+
+func (s *Handler) cachedEnrichedResponse(
+	summary *db.WorkspaceSummary,
+) workspaceResponse {
+	resp := toWorkspaceResponse(summary)
 	resp.Repo = s.repoRefFromParts(
 		summary.Platform, summary.PlatformHost, summary.RepoOwner, summary.RepoName,
 	)
 	if s.workspaceEnrichmentDisabled {
-		return
+		return resp
 	}
 	if s.workspaces == nil || summary.Status != "ready" {
-		return
+		return resp
 	}
 
 	entry, refreshDue := s.cachedWorkspaceEnrichment(summary.ID)
@@ -67,7 +72,7 @@ func (s *Handler) toCachedWorkspaceResponse(
 	if refreshDue {
 		s.scheduleWorkspaceEnrichment(*summary)
 	}
-	return
+	return resp
 }
 
 func (s *Handler) workspaceResponseFromEnrichmentCacheEntry(
@@ -164,21 +169,25 @@ func (s *Handler) cachedWorkspaceEnrichment(
 func (s *Handler) refreshWorkspaceResponse(
 	ctx context.Context,
 	summary *db.WorkspaceSummary,
-) (resp workspaceResponse) {
-	defer s.applyAgentActivity(&resp, summary)
+) workspaceResponse {
+	return s.withAgentActivity(s.refreshedEnrichedResponse(ctx, summary), summary)
+}
+
+func (s *Handler) refreshedEnrichedResponse(
+	ctx context.Context,
+	summary *db.WorkspaceSummary,
+) workspaceResponse {
 	generation := s.supersedeWorkspaceEnrichment(summary.ID)
 	result := s.workspaceResponseWithEnrichment(ctx, summary)
-	if summary.Status == "ready" {
-		entry, recorded, _ := s.recordWorkspaceEnrichmentResult(
-			summary.ID, generation, result,
-		)
-		resp = s.workspaceResponseAfterEnrichmentAttempt(
-			summary, result, entry, recorded,
-		)
-		return
+	if summary.Status != "ready" {
+		return result.response
 	}
-	resp = result.response
-	return
+	entry, recorded, _ := s.recordWorkspaceEnrichmentResult(
+		summary.ID, generation, result,
+	)
+	return s.workspaceResponseAfterEnrichmentAttempt(
+		summary, result, entry, recorded,
+	)
 }
 
 func (s *Handler) workspaceResponseAfterEnrichmentAttempt(

--- a/internal/workspace/localruntime/tmux_launcher.go
+++ b/internal/workspace/localruntime/tmux_launcher.go
@@ -48,27 +48,9 @@ func (p tmuxEnvPolicy) paneEnvironmentWithExtra(
 	extraStripVars []string,
 	extraEnv map[string]string,
 ) tmuxPaneEnvironment {
-	env := p.environment(baseEnv, extraStripVars)
-	filtered := env[:0]
-	for _, value := range env {
-		key, _, found := strings.Cut(value, "=")
-		if found {
-			if _, replaced := extraEnv[key]; replaced {
-				continue
-			}
-		}
-		filtered = append(filtered, value)
-	}
-	env = filtered
-	keys := make([]string, 0, len(extraEnv))
-	for key := range extraEnv {
-		keys = append(keys, key)
-	}
-	slices.Sort(keys)
-	for _, key := range keys {
-		env = append(env, key+"="+extraEnv[key])
-	}
-	return paneEnvironmentFromEnv(env, command)
+	return paneEnvironmentFromEnv(
+		procutil.MergeEnv(p.environment(baseEnv, extraStripVars), extraEnv), command,
+	)
 }
 
 func paneEnvironmentFromEnv(


### PR DESCRIPTION
Pure refactor of the agent activity code that landed in #756. No behavior, API, or UI change.

- Installed hooks and the server resolve the report directory through one function instead of deriving the same path separately
- Single home for the hook source marker, the atomic file write, and the environment override merge, each of which had been duplicated
- Hook lifecycle events resolve through a table and a named outcome instead of a `(State, bool, bool)` return
- Workspace responses attach agent state through one explicit call instead of named returns with deferred mutation
- Agent-hook CLI moved out of `main.go` into `cmd/middleman/agent_hook_cli.go`, and the workspaceapi agent-activity helpers now live in one file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sup>generated by a clanker</sup>
