### PR TITLE
Filter pull requests by workspace presence

### DIFF
--- a/frontend/tests/e2e/pull-list-filters.spec.ts
+++ b/frontend/tests/e2e/pull-list-filters.spec.ts
@@ -102,24 +102,29 @@ test("PR filters stack attributes and allow multiple kanban statuses", async ({ 
   await expect(rows).toHaveCount(4);
 
   await openPrFilters(page);
-  await page.locator(".kit-filter-dropdown__panel").getByRole("button", { name: "Has workspace" }).click();
+  const filterPanel = page.locator(".kit-filter-dropdown__panel");
+  const workspaceGrouping = (
+    await filterPanel.locator(".kit-filter-dropdown__section-title, .kit-filter-dropdown__item").allTextContents()
+  )
+    .map((text) => text.trim())
+    .filter((text) => ["Status", "Has workspace", "Visibility"].includes(text));
+  expect(workspaceGrouping).toEqual(["Status", "Has workspace", "Visibility"]);
+
+  await filterPanel.getByRole("button", { name: "Has workspace" }).click();
   await expect(rows).toHaveText([/Approved review queue/, /Ready failed workflow/]);
-  await page.locator(".kit-filter-dropdown__panel").getByRole("button", { name: "Has workspace" }).click();
+  await filterPanel.getByRole("button", { name: "Has workspace" }).click();
 
-  await page.locator(".kit-filter-dropdown__panel").getByRole("button", { name: "Ready for review" }).click();
-  await page.locator(".kit-filter-dropdown__panel").getByRole("button", { name: "Reviewing" }).click();
-  await page.locator(".kit-filter-dropdown__panel").getByRole("button", { name: "Awaiting merge" }).click();
+  await filterPanel.getByRole("button", { name: "Ready for review" }).click();
+  await filterPanel.getByRole("button", { name: "Reviewing" }).click();
+  await filterPanel.getByRole("button", { name: "Awaiting merge" }).click();
 
   await expect(rows).toHaveText([/Approved review queue/, /Ready failed workflow/]);
 
-  await page.locator(".kit-filter-dropdown__panel").getByRole("button", { name: "Failed CI" }).click();
+  await filterPanel.getByRole("button", { name: "Failed CI" }).click();
   await expect(rows).toHaveText([/Ready failed workflow/]);
 
-  await page
-    .locator(".kit-filter-dropdown__panel")
-    .getByRole("button", { name: /^(Clear filters|Reset view)$/ })
-    .click();
-  await page.locator(".kit-filter-dropdown__panel").getByRole("button", { name: "Merge conflicts" }).click();
+  await filterPanel.getByRole("button", { name: /^(Clear filters|Reset view)$/ }).click();
+  await filterPanel.getByRole("button", { name: "Merge conflicts" }).click();
 
   await expect(rows).toHaveText([/Ready conflict resolver/]);
 });

--- a/frontend/tests/e2e/pull-list-filters.spec.ts
+++ b/frontend/tests/e2e/pull-list-filters.spec.ts
@@ -64,6 +64,7 @@ async function mockPulls(page: Page) {
         pull(10, "Approved review queue", {
           ReviewDecision: "APPROVED",
           KanbanStatus: "reviewing",
+          workspace: { id: "ws-10", status: "ready" },
         }),
         pull(11, "Draft parser cleanup", {
           IsDraft: true,
@@ -72,6 +73,7 @@ async function mockPulls(page: Page) {
         pull(12, "Ready failed workflow", {
           CIStatus: "failure",
           KanbanStatus: "awaiting_merge",
+          workspace: { id: "ws-12", status: "ready" },
         }),
         pull(13, "Ready conflict resolver", {
           MergeableState: "dirty",
@@ -100,6 +102,10 @@ test("PR filters stack attributes and allow multiple kanban statuses", async ({ 
   await expect(rows).toHaveCount(4);
 
   await openPrFilters(page);
+  await page.locator(".kit-filter-dropdown__panel").getByRole("button", { name: "Has workspace" }).click();
+  await expect(rows).toHaveText([/Approved review queue/, /Ready failed workflow/]);
+  await page.locator(".kit-filter-dropdown__panel").getByRole("button", { name: "Has workspace" }).click();
+
   await page.locator(".kit-filter-dropdown__panel").getByRole("button", { name: "Ready for review" }).click();
   await page.locator(".kit-filter-dropdown__panel").getByRole("button", { name: "Reviewing" }).click();
   await page.locator(".kit-filter-dropdown__panel").getByRole("button", { name: "Awaiting merge" }).click();

--- a/packages/ui/src/components/sidebar/PullList.svelte
+++ b/packages/ui/src/components/sidebar/PullList.svelte
@@ -201,22 +201,24 @@
     },
     {
       title: "Status",
-      items: kanbanFilterOptions.map((option) => ({
-        id: `kanban-${option.value}`,
-        label: option.label,
-        active: pulls.getKanbanStatusFilters().includes(option.value),
-        onSelect: () => pulls.toggleKanbanStatusFilter(option.value),
-      })),
-    },
-    {
-      title: "Visibility",
       items: [
+        ...kanbanFilterOptions.map((option) => ({
+          id: `kanban-${option.value}`,
+          label: option.label,
+          active: pulls.getKanbanStatusFilters().includes(option.value),
+          onSelect: () => pulls.toggleKanbanStatusFilter(option.value),
+        })),
         {
           id: "has-workspace",
           label: "Has workspace",
           active: pulls.getAttributeFilters().includes("has_workspace"),
           onSelect: () => pulls.toggleAttributeFilter("has_workspace"),
         },
+      ],
+    },
+    {
+      title: "Visibility",
+      items: [
         {
           id: "hide-org-name",
           label: "Hide org name",

--- a/packages/ui/src/components/sidebar/PullList.svelte
+++ b/packages/ui/src/components/sidebar/PullList.svelte
@@ -212,6 +212,12 @@
       title: "Visibility",
       items: [
         {
+          id: "has-workspace",
+          label: "Has workspace",
+          active: pulls.getAttributeFilters().includes("has_workspace"),
+          onSelect: () => pulls.toggleAttributeFilter("has_workspace"),
+        },
+        {
           id: "hide-org-name",
           label: "Hide org name",
           active: grouping.getHideOrgName(),

--- a/packages/ui/src/stores/pulls.svelte.test.ts
+++ b/packages/ui/src/stores/pulls.svelte.test.ts
@@ -136,6 +136,20 @@ describe("pulls store display order", () => {
     expect(store.getDisplayOrderPRs().map((pr) => pr.ID)).toEqual([4]);
   });
 
+  it("filters pull requests to entries with a workspace", async () => {
+    const store = createPullsStore({
+      client: clientWithPulls([
+        pull(1, "api", "2026-05-20T15:00:00Z", { workspace: { id: "ws-1", status: "ready" } }),
+        pull(2, "web", "2026-05-20T14:00:00Z"),
+      ]),
+    });
+
+    await store.loadPulls();
+    store.toggleAttributeFilter("has_workspace");
+
+    expect(store.getDisplayOrderPRs().map((pr) => pr.ID)).toEqual([1]);
+  });
+
   it("matches empty, missing, and unknown kanban statuses as New", async () => {
     const store = createPullsStore({
       client: clientWithPulls([

--- a/packages/ui/src/stores/pulls.svelte.ts
+++ b/packages/ui/src/stores/pulls.svelte.ts
@@ -36,7 +36,7 @@ type PullsParams = {
   offset?: number;
 };
 
-export type PullAttributeFilter = "approved" | "draft" | "ready" | "merge_conflicts" | "failed_ci";
+export type PullAttributeFilter = "approved" | "draft" | "ready" | "merge_conflicts" | "failed_ci" | "has_workspace";
 
 export interface PullsStoreOptions {
   client: MiddlemanClient;
@@ -422,7 +422,10 @@ export function createPullsStore(opts: PullsStoreOptions) {
     if (filter === "merge_conflicts") {
       return pr.MergeableState === "dirty";
     }
-    return hasFailedCI(pr);
+    if (filter === "failed_ci") {
+      return hasFailedCI(pr);
+    }
+    return pr.workspace !== undefined;
   }
 
   function hasFailedCI(pr: PullRequest): boolean {


### PR DESCRIPTION
## Summary

- add a Has workspace option to the PR filter visibility menu
- compose workspace presence with existing PR and status filters
- clear the workspace filter through the existing reset actions

<sup>generated by a clanker</sup>