### PR TITLE
Keep Kata project navigation stable during scope loads

### DIFF
--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -358,6 +358,9 @@ Rows that contain buttons, links, or toggles need clear event ownership.
   Kata snapshot loads are sequence- and intent-fenced; cross-authority changes
   clear prior authority instead of painting it under the new route
   (`frontend/src/lib/stores/kata-authority.svelte.ts::KataAuthorityStore.loadSnapshot`).
+- Keep Kata's daemon-scoped project navigation stable across same-daemon
+  authority changes; clearing scoped task authority must not clear shared chrome
+  (`frontend/src/lib/features/kata/KataWorkspace.svelte::sidebarCatalog`).
 - Kata route callbacks require both an accepted snapshot and the current navigation
   generation; daemon switches restore the target daemon's persisted authority, never
   source-daemon scope or selection (`frontend/src/lib/features/kata/KataWorkspace.svelte::switchKataDaemon`).

--- a/frontend/src/lib/features/kata/KataWorkspace.svelte
+++ b/frontend/src/lib/features/kata/KataWorkspace.svelte
@@ -194,6 +194,7 @@
   const taskAPI = untrack(() => api) ?? createKataTaskAPI();
   let connection = $state.raw<KataConnectionState>({ status: "offline" });
   let bootstrapDaemonId = $state<string | undefined>(undefined);
+  let sidebarCatalog = $state.raw<{ daemonID: string; projects: KataProjectSummary[] } | null>(null);
   let pendingCreatedProjectScope: PendingCreatedProjectScope | null = null;
   let supersededRouteSelectionUID: string | null = null;
   let rowNavigationSelection: PendingRecoveredSelection | null = null;
@@ -240,6 +241,10 @@
   const authorityController = createKataWorkspaceAuthorityController({
     resetIssueExpansion,
     onSnapshotAccepted: (snapshot) => {
+      sidebarCatalog = {
+        daemonID: snapshot.daemon_id,
+        projects: structuredClone(snapshot.projects) as KataProjectSummary[],
+      };
       const requestedIssueUID = selectedIssueUID?.trim() ?? "";
       const recoveredSelection = pendingRecoveredSelection?.uid === snapshot.selected_issue_uid
         ? pendingRecoveredSelection
@@ -357,7 +362,6 @@
   const acceptedProjects = $derived(
     acceptedSnapshot ? structuredClone(acceptedSnapshot.projects) as KataProjectSummary[] : [],
   );
-  const acceptedAreas = $derived(deriveKataAreas([...acceptedProjects]));
   const acceptedCurrentView = $derived.by(() => {
     if (!acceptedSnapshot) return { name: currentViewName, groups: [] };
     const projected = projectKataWorkspaceView({
@@ -416,8 +420,13 @@
   );
   // A daemon switch is transactional. Catalog data loaded while the target
   // is still provisional must not repaint either daemon's project controls.
-  const visibleProjects = $derived(switchingDaemon ? [] : acceptedProjects);
-  const visibleAreas = $derived(switchingDaemon ? [] : acceptedAreas);
+  const visibleProjects = $derived.by(() => {
+    if (switchingDaemon || routedDaemonError || authorityStore.state.phase === "abandoned") return [];
+    const requestedDaemonID = authorityStore.state.intent?.daemon_id ?? activeKataDaemonId;
+    if (!sidebarCatalog || (requestedDaemonID && requestedDaemonID !== sidebarCatalog.daemonID)) return [];
+    return sidebarCatalog.projects;
+  });
+  const visibleAreas = $derived(deriveKataAreas([...visibleProjects]));
 
   const systemViews = [
     { name: "inbox", label: "Inbox" },

--- a/frontend/src/lib/features/kata/KataWorkspaceRouting.test.ts
+++ b/frontend/src/lib/features/kata/KataWorkspaceRouting.test.ts
@@ -243,6 +243,38 @@ describe("KataWorkspace snapshot routing", () => {
     expect(onSelectedIssueChange).not.toHaveBeenCalledWith(initialIssues[0]!.uid);
   });
 
+  it("keeps the project sidebar stable while a project scope loads", async () => {
+    acceptHomeDaemon();
+    const pendingProject = deferred<KataWorkspaceSnapshotResponse>();
+    let requestCount = 0;
+    let projectSnapshot: KataWorkspaceSnapshotResponse | null = null;
+    const { api } = createWorkspaceAPI(initialIssues, {
+      snapshot: async (_request, snapshot) => {
+        requestCount += 1;
+        if (requestCount === 2) {
+          projectSnapshot = snapshot;
+          return pendingProject.promise;
+        }
+        return snapshot;
+      },
+    });
+
+    render(KataWorkspace, { props: { api } });
+    const finances = await screen.findByRole("button", { name: /^Finances\s+1$/ });
+
+    await fireEvent.click(finances);
+    await waitFor(() => expect(requestCount).toBe(2));
+
+    expect(screen.getByRole("button", { name: /^Kata\s+1$/ })).toBeTruthy();
+    expect(
+      screen
+        .getByRole("button", { name: /^Kata\s+1$/ })
+        .compareDocumentPosition(screen.getByRole("button", { name: "New project" })),
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+
+    pendingProject.resolve(projectSnapshot!);
+  });
+
   it("publishes only the latest route when project and system navigation loads finish out of order", async () => {
     acceptHomeDaemon();
     const pendingProject = deferred<KataWorkspaceSnapshotResponse>();


### PR DESCRIPTION
## Summary

- keep the Kata project list stable while same-daemon scope data refreshes
- prevent the New project action from jumping above the project list during navigation

<sup>generated by a clanker</sup>