### PR TITLE
Keep completed agent status visible until opened

### DIFF
--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -301,8 +301,8 @@ Workspace create endpoints may return 202 with a pre-existing workspace
   never read from instruction files (`internal/workspace/agent_context.go::Manager.RenderAgentContextForWorktree`).
 - User-level hooks are single-target: install merges, uninstall preserves other
   handlers, and the last install wins (`internal/agentactivity/integration.go::Install`).
-- Matching live runtime/worktree reports use approval, input, working, idle priority;
-  latest state expires after 30 minutes or session exit, then tmux resumes (`internal/agentactivity/`, `internal/server/workspaceapi/lifecycle.go::Handler.HandleRuntimeSessionExit`).
+- Matching live runtime/worktree reports prioritize approval, input, working, done, then idle.
+  Stop/Interrupt stays `done` until row activation acknowledges that exact timestamp; reports expire after 30 minutes or session exit, then tmux resumes (`internal/agentactivity/store.go::statePriority`, `frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte::openWorkspace`).
 - Hook installs require absolute data roots and update symlink targets instead of replacing
   config links; report/worktree matching uses canonical filesystem paths (`cmd/middleman/main.go::runAgentHookInstall`,
   `internal/agentactivity/integration.go::writeJSONObject`, `internal/agentactivity/store.go::canonicalWorkspacePath`).

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -302,7 +302,7 @@ Workspace create endpoints may return 202 with a pre-existing workspace
 - User-level hooks are single-target: install merges, uninstall preserves other
   handlers, and the last install wins (`internal/agentactivity/integration.go::Install`).
 - Matching live runtime/worktree reports prioritize approval, input, working, done, then idle.
-  Stop/Interrupt stays `done` until row activation acknowledges that exact timestamp; reports expire after 30 minutes or session exit, then tmux resumes (`internal/agentactivity/store.go::statePriority`, `frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte::openWorkspace`).
+  Stop/Interrupt stays `done` for the 30-minute report window; row activation acknowledges a versioned completion for the browser-tab session, while a new timestamp resurfaces (`internal/agentactivity/store.go::statePriority`, `frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte::openWorkspace`).
 - Hook installs require absolute data roots and update symlink targets instead of replacing
   config links; report/worktree matching uses canonical filesystem paths (`cmd/middleman/main.go::runAgentHookInstall`,
   `internal/agentactivity/integration.go::writeJSONObject`, `internal/agentactivity/store.go::canonicalWorkspacePath`).

--- a/docs/superpowers/specs/2026-07-28-agent-activity-state-enum-design.md
+++ b/docs/superpowers/specs/2026-07-28-agent-activity-state-enum-design.md
@@ -6,9 +6,9 @@ Represent agent activity states as a real ordinal Go enum so priority is part of
 
 ## Design
 
-Change `agentactivity.State` from a string alias to an unsigned integer type. Declare the states with `iota` in ascending priority order: unknown, idle, done, working, input, approval. Valid state priority is therefore the enum's numeric value; unknown and out-of-range values have priority zero.
+Change `agentactivity.State` from a string alias to an unsigned integer type. Declare the states with `iota` in ascending priority order: unknown, idle, done, working, input, approval. `StateUnknown` is an internal-only zero-value sentinel; valid state priority is the enum's numeric value, while the sentinel and out-of-range values have priority zero.
 
-Keep the external representation stable. `String`, `MarshalJSON`, and `UnmarshalJSON` map valid enum values to the existing lowercase strings. Unknown strings and numeric JSON are rejected when reading reports. Workspace API responses continue converting the enum through `String`, so the OpenAPI contract remains unchanged.
+Keep the external representation stable. `String`, `MarshalJSON`, and `UnmarshalJSON` map the five externally valid states to the existing lowercase strings. `MarshalJSON` rejects the sentinel and out-of-range values; `UnmarshalJSON` rejects `"unknown"`, other unknown strings, and numeric JSON. Workspace API responses continue converting valid enum values through `String`, so the OpenAPI contract remains unchanged.
 
 ## Error Handling
 
@@ -16,4 +16,4 @@ Invalid enum values cannot be written as valid reports. Invalid JSON state value
 
 ## Testing
 
-Add focused coverage that pins enum ordering, string conversion, JSON string round trips, and invalid JSON rejection. Existing agent lifecycle and workspace HTTP tests continue to prove that hook events and API responses retain their current values.
+Add focused coverage that pins enum ordering, string conversion, JSON string round trips, sentinel and out-of-range serialization rejection, and invalid JSON rejection. Existing agent lifecycle and workspace HTTP tests continue to prove that hook events and API responses retain their current values.

--- a/docs/superpowers/specs/2026-07-28-agent-activity-state-enum-design.md
+++ b/docs/superpowers/specs/2026-07-28-agent-activity-state-enum-design.md
@@ -1,0 +1,19 @@
+# Agent Activity State Enum Design
+
+## Goal
+
+Represent agent activity states as a real ordinal Go enum so priority is part of the type definition instead of a separate switch, without changing persisted reports or API values.
+
+## Design
+
+Change `agentactivity.State` from a string alias to an unsigned integer type. Declare the states with `iota` in ascending priority order: unknown, idle, done, working, input, approval. Valid state priority is therefore the enum's numeric value; unknown and out-of-range values have priority zero.
+
+Keep the external representation stable. `String`, `MarshalJSON`, and `UnmarshalJSON` map valid enum values to the existing lowercase strings. Unknown strings and numeric JSON are rejected when reading reports. Workspace API responses continue converting the enum through `String`, so the OpenAPI contract remains unchanged.
+
+## Error Handling
+
+Invalid enum values cannot be written as valid reports. Invalid JSON state values cause report decoding to fail, preserving the current behavior of ignoring malformed report files.
+
+## Testing
+
+Add focused coverage that pins enum ordering, string conversion, JSON string round trips, and invalid JSON rejection. Existing agent lifecycle and workspace HTTP tests continue to prove that hook events and API responses retain their current values.

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -7666,6 +7666,7 @@ components:
             - working
             - input
             - approval
+            - done
           type: string
         agent_state_updated_at:
           description: UTC timestamp of the hook report that produced agent_state.

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -149,6 +149,8 @@
   const basePath = (
     window.__BASE_PATH__ ?? "/"
   ).replace(/\/$/, "");
+  const doneAcknowledgementsStorageKey =
+    "middleman:workspace-agent-done-acknowledgements/v1";
 
   let workspaces = $state.raw<Workspace[]>([]);
   let fleetHosts = $state.raw<HostSummary[]>([]);
@@ -172,7 +174,9 @@
   } | null>(null);
   let contextMenuEl = $state<HTMLDivElement | null>(null);
   let contextMenuStyle = $state("");
-  let acknowledgedDoneStates = $state<string[]>([]);
+  let acknowledgedDoneStates = $state.raw<Record<string, string>>(
+    loadDoneAcknowledgements(),
+  );
 
   const workspaceListLoadTimeoutMs = 10_000;
   let displayOptions = $state<WorkspaceListDisplayOptions>(
@@ -416,10 +420,12 @@
       const remote = fleetLoaded && !fleetError && hasRemoteFleetHosts
         ? await fetchPeerWorkspaces(abortController.signal)
         : [];
-      workspaces = [
+      const nextWorkspaces = [
         ...local,
         ...(hasRemoteFleetHosts ? remote : []),
       ];
+      reconcileDoneAcknowledgements(nextWorkspaces);
+      workspaces = nextWorkspaces;
       workspaceListStatus = "loaded";
     } catch {
       // Network error; keep stale list.
@@ -625,24 +631,77 @@
         return { label: "Approval", status: "waiting", tone: "approval" };
       case "input":
         return { label: "Input", status: "waiting", tone: "input" };
-      case "done":
-        if (acknowledgedDoneStates.includes(doneStateKey(ws))) return null;
+      case "done": {
+        const version = doneStateVersion(ws);
+        if (version !== null && acknowledgedDoneStates[workspaceRowKey(ws)] === version) {
+          return null;
+        }
         return { label: "Done", status: "idle", tone: "done" };
+      }
       default:
         return null;
     }
   }
 
-  function doneStateKey(ws: Workspace): string {
-    return `${workspaceRowKey(ws)}:${ws.agent_state_updated_at ?? "unknown"}`;
+  function loadDoneAcknowledgements(): Record<string, string> {
+    try {
+      const stored = window.sessionStorage.getItem(doneAcknowledgementsStorageKey);
+      if (!stored) return {};
+      const parsed: unknown = JSON.parse(stored);
+      if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+        return {};
+      }
+      const acknowledgements: Record<string, string> = {};
+      for (const [workspaceKey, version] of Object.entries(parsed)) {
+        if (typeof version === "string" && version.trim()) {
+          acknowledgements[workspaceKey] = version;
+        }
+      }
+      return acknowledgements;
+    } catch {
+      return {};
+    }
+  }
+
+  function saveDoneAcknowledgements(value: Record<string, string>): void {
+    try {
+      if (Object.keys(value).length === 0) {
+        window.sessionStorage.removeItem(doneAcknowledgementsStorageKey);
+      } else {
+        window.sessionStorage.setItem(doneAcknowledgementsStorageKey, JSON.stringify(value));
+      }
+    } catch {
+      // Storage is optional; the in-memory acknowledgement still applies.
+    }
+  }
+
+  function doneStateVersion(ws: Workspace): string | null {
+    if (ws.agent_state !== "done") return null;
+    return ws.agent_state_updated_at?.trim() || null;
+  }
+
+  function reconcileDoneAcknowledgements(items: Workspace[]): void {
+    let next = acknowledgedDoneStates;
+    for (const ws of items) {
+      const workspaceKey = workspaceRowKey(ws);
+      const acknowledgedVersion = next[workspaceKey];
+      if (!acknowledgedVersion || acknowledgedVersion === doneStateVersion(ws)) continue;
+      if (next === acknowledgedDoneStates) next = { ...acknowledgedDoneStates };
+      delete next[workspaceKey];
+    }
+    if (next === acknowledgedDoneStates) return;
+    acknowledgedDoneStates = next;
+    saveDoneAcknowledgements(next);
   }
 
   function openWorkspace(ws: Workspace): void {
-    if (ws.agent_state === "done") {
-      const stateKey = doneStateKey(ws);
-      if (!acknowledgedDoneStates.includes(stateKey)) {
-        acknowledgedDoneStates = [...acknowledgedDoneStates, stateKey];
-      }
+    const doneVersion = doneStateVersion(ws);
+    if (doneVersion !== null) {
+      acknowledgedDoneStates = {
+        ...acknowledgedDoneStates,
+        [workspaceRowKey(ws)]: doneVersion,
+      };
+      saveDoneAcknowledgements(acknowledgedDoneStates);
     }
     navigate(workspaceRoute(ws));
   }

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.svelte
@@ -74,7 +74,7 @@
       | "unknown"
       | null;
     tmux_last_output_at?: string | null;
-    agent_state?: "idle" | "working" | "input" | "approval" | null;
+    agent_state?: "idle" | "working" | "input" | "approval" | "done" | null;
     agent_state_updated_at?: string | null;
     status: string;
     error_message?: string | null;
@@ -172,6 +172,7 @@
   } | null>(null);
   let contextMenuEl = $state<HTMLDivElement | null>(null);
   let contextMenuStyle = $state("");
+  let acknowledgedDoneStates = $state<string[]>([]);
 
   const workspaceListLoadTimeoutMs = 10_000;
   let displayOptions = $state<WorkspaceListDisplayOptions>(
@@ -613,9 +614,9 @@
   }
 
   function agentStatePresentation(ws: Workspace): {
-    label: "Working" | "Approval" | "Input";
+    label: "Working" | "Approval" | "Input" | "Done";
     status: StatusDotStatus;
-    tone: "working" | "approval" | "input";
+    tone: "working" | "approval" | "input" | "done";
   } | null {
     switch (ws.agent_state) {
       case "working":
@@ -624,9 +625,26 @@
         return { label: "Approval", status: "waiting", tone: "approval" };
       case "input":
         return { label: "Input", status: "waiting", tone: "input" };
+      case "done":
+        if (acknowledgedDoneStates.includes(doneStateKey(ws))) return null;
+        return { label: "Done", status: "idle", tone: "done" };
       default:
         return null;
     }
+  }
+
+  function doneStateKey(ws: Workspace): string {
+    return `${workspaceRowKey(ws)}:${ws.agent_state_updated_at ?? "unknown"}`;
+  }
+
+  function openWorkspace(ws: Workspace): void {
+    if (ws.agent_state === "done") {
+      const stateKey = doneStateKey(ws);
+      if (!acknowledgedDoneStates.includes(stateKey)) {
+        acknowledgedDoneStates = [...acknowledgedDoneStates, stateKey];
+      }
+    }
+    navigate(workspaceRoute(ws));
   }
 
   function itemStateClass(ws: Workspace): string {
@@ -1213,7 +1231,7 @@
                 e.target.closest(".item-bubble")) {
                 return;
               }
-              navigate(workspaceRoute(ws));
+              openWorkspace(ws);
             }}
             onkeydown={(e) => {
               // Ignore keydowns that originate inside a nested
@@ -1224,7 +1242,7 @@
               if (e.target !== e.currentTarget) return;
               if (e.key === "Enter" || e.key === " ") {
                 e.preventDefault();
-                navigate(workspaceRoute(ws));
+                openWorkspace(ws);
               }
             }}
             oncontextmenu={(e) => {
@@ -1839,6 +1857,10 @@
   .agent-state--input {
     color: var(--accent-purple);
     --status-waiting: var(--accent-purple);
+  }
+
+  .agent-state--done {
+    color: var(--accent-green);
   }
 
 

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
@@ -67,7 +67,8 @@ interface WorkspaceFixtureOptions {
   tmuxWorking?: boolean;
   tmuxPaneTitle?: string | null;
   tmuxActivitySource?: string;
-  agentState?: "idle" | "working" | "input" | "approval" | null;
+  agentState?: "idle" | "working" | "input" | "approval" | "done" | null;
+  agentStateUpdatedAt?: string | null;
   status?: string;
 }
 
@@ -95,6 +96,7 @@ function workspaceFixture({
   tmuxPaneTitle = null,
   tmuxActivitySource = "unknown",
   agentState = null,
+  agentStateUpdatedAt = null,
   status = "ready",
 }: WorkspaceFixtureOptions) {
   // Kata and ad-hoc workspaces carry no joined provider item metadata.
@@ -122,6 +124,7 @@ function workspaceFixture({
     tmux_pane_title: tmuxPaneTitle,
     tmux_activity_source: tmuxActivitySource,
     agent_state: agentState,
+    agent_state_updated_at: agentStateUpdatedAt,
     status,
     created_at: createdAt,
     tmux_last_output_at: tmuxLastOutputAt,
@@ -1473,6 +1476,39 @@ describe("WorkspaceListSidebar", () => {
 
     expect(await screen.findByText(label)).toBeTruthy();
     expect(screen.getByLabelText(ariaLabel)).toBeTruthy();
+  });
+
+  it("keeps a completed agent visible until its workspace row is opened", async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        workspaces: [
+          workspaceFixture({
+            id: "ws-done",
+            provider: "github",
+            platformHost: "github.com",
+            owner: "acme",
+            name: "widget",
+            number: 9,
+            agentState: "done",
+            agentStateUpdatedAt: "2026-07-28T12:00:00Z",
+          }),
+        ],
+      },
+    });
+
+    const { container } = render(WorkspaceListSidebar, {
+      props: { selectedId: "" },
+    });
+
+    expect(await screen.findByText("Done")).toBeTruthy();
+    expect(screen.getByLabelText("Agent done")).toBeTruthy();
+
+    const row = container.querySelector<HTMLElement>(".ws-row");
+    expect(row).toBeTruthy();
+    await fireEvent.click(row!);
+
+    expect(screen.queryByText("Done")).toBeNull();
+    expect(mockNavigate).toHaveBeenCalledWith("/terminal/ws-done");
   });
 
   it("lets hook-reported idle override recent tmux output", async () => {

--- a/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceListSidebar.test.ts
@@ -201,6 +201,7 @@ describe("WorkspaceListSidebar", () => {
     MockEventSource.instances.length = 0;
     resetNewWorkspaceDialogState();
     localStorage.clear();
+    sessionStorage.clear();
     vi.stubGlobal("EventSource", MockEventSource);
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
@@ -1479,36 +1480,77 @@ describe("WorkspaceListSidebar", () => {
   });
 
   it("keeps a completed agent visible until its workspace row is opened", async () => {
-    mockGet.mockResolvedValue({
-      data: {
-        workspaces: [
-          workspaceFixture({
-            id: "ws-done",
-            provider: "github",
-            platformHost: "github.com",
-            owner: "acme",
-            name: "widget",
-            number: 9,
-            agentState: "done",
-            agentStateUpdatedAt: "2026-07-28T12:00:00Z",
-          }),
-        ],
-      },
-    });
+    let agentStateUpdatedAt = "2026-07-28T12:00:00.000000001Z";
+    mockGet.mockImplementation(() =>
+      Promise.resolve({
+        data: {
+          workspaces: [
+            workspaceFixture({
+              id: "ws-done",
+              provider: "github",
+              platformHost: "github.com",
+              owner: "acme",
+              name: "widget",
+              number: 9,
+              agentState: "done",
+              agentStateUpdatedAt,
+            }),
+          ],
+        },
+      }),
+    );
 
-    const { container } = render(WorkspaceListSidebar, {
+    const first = render(WorkspaceListSidebar, {
       props: { selectedId: "" },
     });
 
     expect(await screen.findByText("Done")).toBeTruthy();
     expect(screen.getByLabelText("Agent done")).toBeTruthy();
 
-    const row = container.querySelector<HTMLElement>(".ws-row");
+    const row = first.container.querySelector<HTMLElement>(".ws-row");
     expect(row).toBeTruthy();
     await fireEvent.click(row!);
 
     expect(screen.queryByText("Done")).toBeNull();
     expect(mockNavigate).toHaveBeenCalledWith("/terminal/ws-done");
+
+    first.unmount();
+    const remounted = render(WorkspaceListSidebar, { props: { selectedId: "" } });
+    await screen.findByText("PR 9");
+    expect(screen.queryByText("Done")).toBeNull();
+
+    remounted.unmount();
+    agentStateUpdatedAt = "2026-07-28T12:00:00.000000002Z";
+    render(WorkspaceListSidebar, { props: { selectedId: "" } });
+    expect(await screen.findByText("Done")).toBeTruthy();
+  });
+
+  it("does not dismiss an unversioned completed agent state", async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        workspaces: [
+          workspaceFixture({
+            id: "ws-unversioned-done",
+            provider: "github",
+            platformHost: "github.com",
+            owner: "acme",
+            name: "widget",
+            number: 10,
+            agentState: "done",
+          }),
+        ],
+      },
+    });
+
+    const { container } = render(WorkspaceListSidebar, { props: { selectedId: "" } });
+    expect(await screen.findByText("Done")).toBeTruthy();
+
+    const row = container.querySelector<HTMLElement>(".ws-row");
+    expect(row).toBeTruthy();
+    await fireEvent.click(row!);
+
+    expect(screen.getByText("Done")).toBeTruthy();
+    expect(mockNavigate).toHaveBeenCalledWith("/terminal/ws-unversioned-done");
   });
 
   it("lets hook-reported idle override recent tmux output", async () => {

--- a/internal/agentactivity/store.go
+++ b/internal/agentactivity/store.go
@@ -22,6 +22,7 @@ const (
 	StateWorking  State = "working"
 	StateInput    State = "input"
 	StateApproval State = "approval"
+	StateDone     State = "done"
 )
 
 const RuntimeSessionKeyEnv = "MIDDLEMAN_RUNTIME_SESSION_KEY"
@@ -320,7 +321,7 @@ func stateForHook(input HookEvent) (State, bool, bool) {
 			return "", false, false
 		}
 	case "Stop", "Interrupt":
-		return StateIdle, false, true
+		return StateDone, false, true
 	case "SessionEnd":
 		return "", true, true
 	default:
@@ -340,10 +341,12 @@ func isUserInputTool(tool string) bool {
 func statePriority(state State) int {
 	switch state {
 	case StateApproval:
-		return 4
+		return 5
 	case StateInput:
-		return 3
+		return 4
 	case StateWorking:
+		return 3
+	case StateDone:
 		return 2
 	case StateIdle:
 		return 1

--- a/internal/agentactivity/store_test.go
+++ b/internal/agentactivity/store_test.go
@@ -46,7 +46,7 @@ func TestStoreTracksHookLifecycleByRuntimeSession(t *testing.T) {
 	})
 	snapshot, ok = store.SnapshotForWorkspace(workspace, []string{"runtime-a"})
 	require.True(ok)
-	assert.Equal(StateIdle, snapshot.State)
+	assert.Equal(StateDone, snapshot.State)
 
 	reportHook(t, store, "runtime-a", map[string]any{
 		"session_id": "agent-a", "cwd": workspace,

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -755,6 +755,7 @@ func (e WorkflowStateMetaResponseStatus) Valid() bool {
 // Defines values for WorkspaceResponseAgentState.
 const (
 	Approval WorkspaceResponseAgentState = "approval"
+	Done     WorkspaceResponseAgentState = "done"
 	Idle     WorkspaceResponseAgentState = "idle"
 	Input    WorkspaceResponseAgentState = "input"
 	Working  WorkspaceResponseAgentState = "working"
@@ -764,6 +765,8 @@ const (
 func (e WorkspaceResponseAgentState) Valid() bool {
 	switch e {
 	case Approval:
+		return true
+	case Done:
 		return true
 	case Idle:
 		return true

--- a/internal/server/workspaceapi/routes_handlers.go
+++ b/internal/server/workspaceapi/routes_handlers.go
@@ -1546,9 +1546,13 @@ func (s *Handler) applyAgentActivity(
 		return
 	}
 	state := string(snapshot.State)
-	updatedAt := snapshot.UpdatedAt.UTC().Format(time.RFC3339)
+	updatedAt := formatAgentActivityUpdatedAt(snapshot.UpdatedAt)
 	resp.AgentState = &state
 	resp.AgentStateUpdatedAt = &updatedAt
+}
+
+func formatAgentActivityUpdatedAt(value time.Time) string {
+	return value.UTC().Format(time.RFC3339Nano)
 }
 
 // Response returns the cached public DTO for a persisted workspace summary.

--- a/internal/server/workspaceapi/types.go
+++ b/internal/server/workspaceapi/types.go
@@ -44,7 +44,7 @@ type workspaceResponse struct {
 	TmuxWorking           bool                      `json:"tmux_working"`
 	TmuxActivitySource    string                    `json:"tmux_activity_source"`
 	TmuxLastOutputAt      *string                   `json:"tmux_last_output_at"`
-	AgentState            *string                   `json:"agent_state,omitempty" enum:"idle,working,input,approval" doc:"Hook-reported aggregate state for live agent sessions. Omitted when no live session has reported lifecycle state."`
+	AgentState            *string                   `json:"agent_state,omitempty" enum:"idle,working,input,approval,done" doc:"Hook-reported aggregate state for live agent sessions. Omitted when no live session has reported lifecycle state."`
 	AgentStateUpdatedAt   *string                   `json:"agent_state_updated_at,omitempty" format:"date-time" doc:"UTC timestamp of the hook report that produced agent_state."`
 	Status                string                    `json:"status"`
 	ErrorMessage          *string                   `json:"error_message,omitempty"`

--- a/internal/server/workspaceapi/workspace_enrichment_test.go
+++ b/internal/server/workspaceapi/workspace_enrichment_test.go
@@ -50,6 +50,13 @@ func runGit(t *testing.T, dir string, args ...string) {
 	require.NoError(t, err, "git %v failed: %s", args, stderr)
 }
 
+func TestFormatAgentActivityUpdatedAtPreservesSubsecondPrecision(t *testing.T) {
+	t.Parallel()
+	updatedAt := time.Date(2026, 7, 28, 12, 0, 0, 123456789, time.UTC)
+
+	assert.Equal(t, "2026-07-28T12:00:00.123456789Z", formatAgentActivityUpdatedAt(updatedAt))
+}
+
 func TestWorkspaceEnrichmentRestoresDivergenceAfterObserverHealsUpstream(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/server/workspacetest/workspace_agent_activity_test.go
+++ b/internal/server/workspacetest/workspace_agent_activity_test.go
@@ -97,7 +97,7 @@ func TestWorkspaceAgentActivityFlowsThroughHTTPResponsesE2E(t *testing.T) {
 	require.Equal(http.StatusOK, getResponse.StatusCode())
 	require.NotNil(getResponse.JSON200)
 	require.NotNil(getResponse.JSON200.AgentState)
-	assert.Equal(generated.Idle, *getResponse.JSON200.AgentState)
+	assert.Equal(generated.Done, *getResponse.JSON200.AgentState)
 
 	stopResponse, err := fixture.client.HTTP.StopWorkspaceRuntimeSessionWithResponse(
 		ctx, ws.Id, launch.JSON200.Key,

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -7738,7 +7738,7 @@ export interface components {
              * @description Hook-reported aggregate state for live agent sessions. Omitted when no live session has reported lifecycle state.
              * @enum {string}
              */
-            agent_state?: "idle" | "working" | "input" | "approval";
+            agent_state?: "idle" | "working" | "input" | "approval" | "done";
             /**
              * Format: date-time
              * @description UTC timestamp of the hook report that produced agent_state.
@@ -17738,6 +17738,6 @@ export const mergeRequestResponseStateValues: ReadonlyArray<FlattenedDeepRequire
 export const problemErrorCodeValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["ProblemError"]["code"]> = ["badRequest", "branchConflict", "branchInUse", "branchProtected", "commentNotFound", "conflict", "destinationExists", "forbidden", "hookFailed", "internalError", "issueNotFound", "notFound", "payloadTooLarge", "projectNotFound", "pullNotFound", "rateLimited", "repoNotFound", "serviceUnavailable", "settingsUnavailable", "toolMissing", "toolUnauthenticated", "unauthorized", "unsupportedCapability", "upstreamError", "validationError", "workspaceDirectoryNotReusable", "workspaceNotFound", "worktreeDirty"];
 export const terminalRendererValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["Terminal"]["renderer"]> = ["xterm", "ghostty-web"];
 export const workflowStateMetaResponseStatusValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["WorkflowStateMetaResponse"]["status"]> = ["new", "reviewing", "waiting", "awaiting_merge"];
-export const workspaceResponseAgent_stateValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["WorkspaceResponse"]["agent_state"]> = ["idle", "working", "input", "approval"];
+export const workspaceResponseAgent_stateValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["WorkspaceResponse"]["agent_state"]> = ["idle", "working", "input", "approval", "done"];
 export const workspaceResponseEnrichment_statusValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["WorkspaceResponse"]["enrichment_status"]> = ["not_applicable", "pending", "fresh", "stale", "failed"];
 export const workspaceResponseMr_head_repo_kindValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["WorkspaceResponse"]["mr_head_repo_kind"]> = ["same_repo", "fork", "unknown"];


### PR DESCRIPTION
- Show a Done status when an agent run finishes instead of clearing immediately
- Keep completion acknowledgement across workspace navigation for the browser tab
- Resurface later completions with distinct timestamps

<sup>generated by a clanker</sup>