### PR TITLE
Tolerate race-detector scheduling in sync trigger tests

### DIFF
--- a/context/testing.md
+++ b/context/testing.md
@@ -338,9 +338,10 @@ fixture.
 ### Sleep And Timer Tests
 
 Do not add sleeps as a synchronization mechanism. Prefer a channel closed by
-the fake or callback that observed the exact event under test. If the behavior
-is inherently observable only by polling, check once immediately, then poll with
-a short ticker bounded by a context deadline.
+the fake or callback that observed the exact event, then await it with
+`require.Eventually` and scheduling headroom under `-race`. If the behavior is
+inherently observable only by polling, check immediately, then use a short ticker
+bounded by a context deadline. (`internal/github/syncertest/syncer_test.go::TestSyncerTriggerRunRunsRunOnce`)
 
 When server e2e tests chain `POST /api/v1/sync` with another ad-hoc sync
 trigger, treat the HTTP 202 and DB row timestamps as intermediate observations.

--- a/internal/github/syncertest/syncer_test.go
+++ b/internal/github/syncertest/syncer_test.go
@@ -628,12 +628,15 @@ func TestSyncerTriggerRunRunsRunOnce(t *testing.T) {
 
 	s.TriggerRun(t.Context())
 
-	select {
-	case <-done:
-	case <-time.After(time.Second):
-		require.FailNow(t,
-			"TriggerRun did not complete RunOnce within 1s")
-	}
+	require.Eventually(t, func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, 5*time.Second, 10*time.Millisecond,
+		"TriggerRun did not complete RunOnce")
 	s.Stop()
 	assert.True(mock.listOpenPRsCalled,
 		"TriggerRun should invoke ListOpenPullRequests")
@@ -778,11 +781,15 @@ func TestSyncerTriggerRunForReposSyncsOnlySelectedRepos(t *testing.T) {
 		PlatformHost: "github.com",
 	}})
 
-	select {
-	case <-done:
-	case <-time.After(time.Second):
-		require.FailNow("scoped TriggerRun did not complete within 1s")
-	}
+	require.Eventually(func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, 5*time.Second, 10*time.Millisecond,
+		"scoped TriggerRun did not complete")
 	s.Stop()
 
 	mu.Lock()


### PR DESCRIPTION
- Let asynchronous sync-trigger tests await their completion signal with race-detector scheduling headroom.
- Document the condition-based waiting convention for asynchronous Go tests.

<sup>generated by a clanker</sup>