### PR TITLE
Reap Windows PTY test processes after runner exit

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,5 @@ packages/ui/src/api/generated/* linguist-generated=true
 packages/ui/src/api/roborev/generated/* linguist-generated=true
 internal/apiclient/spec/openapi.json linguist-generated=true
 internal/apiclient/generated/* linguist-generated=true
+*.sh text eol=lf
+scripts/context-sync text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,7 +338,7 @@ jobs:
         run: go test ./internal/workspace/localruntime -run TestManagerLaunchUsesPtyOwnerWhenConfigured -shuffle=on
 
       - name: Run Rust PTY manager server e2e tests
-        run: go test ./internal/server -run 'TestWorkspaceCreatesRustPtyManagerSessionE2E|TestWorkspaceRuntimeLaunchesRustPtyManagerSessionE2E' -shuffle=on
+        run: go test ./internal/server/workspacetest -run 'TestWorkspaceCreatesRustPtyManagerSessionE2E|TestWorkspaceRuntimeLaunchesRustPtyManagerSessionE2E' -shuffle=on
 
       - name: Run Rust PTY manager tests
         run: cargo test -p middleman-pty-manager

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,6 +331,9 @@ jobs:
           New-Item -ItemType Directory -Force internal/web/dist | Out-Null
           Set-Content -Path internal/web/dist/stub.html -Value ok
 
+      - name: Run Windows process cleanup tests
+        run: go test ./internal/testutil/processjob -shuffle=on
+
       - name: Run Go PTY owner tests
         run: go test ./internal/ptyowner/... -shuffle=on
 

--- a/context/testing.md
+++ b/context/testing.md
@@ -291,6 +291,10 @@ resource pressure rather than correctness, keep `t.Parallel()` and gate the
 expensive section with a package-level `golang.org/x/sync/semaphore.Weighted`
 instead of serializing the whole test.
 
+Windows test binaries that launch restart-durable PTY processes must contain
+their descendants in a kill-on-close Job Object; test timeouts bypass normal
+Go cleanup (`internal/testutil/processjob/processjob_windows.go::ContainCurrentProcessTree`).
+
 Keep splitting new high-volume tests into the existing black-box packages when
 they do not need unexported internals:
 

--- a/internal/ptyowner/process_job_test.go
+++ b/internal/ptyowner/process_job_test.go
@@ -1,0 +1,21 @@
+package ptyowner
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"go.kenn.io/middleman/internal/testutil/processjob"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("MIDDLEMAN_PTYOWNER_CLOSE_PTY_HELPER") == "1" ||
+		os.Getenv("MIDDLEMAN_PTYOWNER_TEST_HELPER") == "1" {
+		os.Exit(m.Run())
+	}
+	if err := processjob.ContainCurrentProcessTree(); err != nil {
+		fmt.Fprintf(os.Stderr, "contain pty owner test process tree: %v\n", err)
+		os.Exit(1)
+	}
+	os.Exit(m.Run())
+}

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -24532,138 +24532,6 @@ func TestWorkspacePtyOwnerTitleMarksWorkspaceWorkingE2E(t *testing.T) {
 	assert.Equal("⠴ t3code-b5014b03", *got.TmuxPaneTitle)
 }
 
-func TestWorkspaceCreatesRustPtyManagerSessionE2E(t *testing.T) {
-	if runtime.GOOS != "windows" {
-		requirePTYAvailable(t)
-	}
-	releasePTYSlot := acquirePTYE2ESlot(t)
-	t.Cleanup(releasePTYSlot)
-
-	require := require.New(t)
-	assert := assert.New(t)
-
-	managerPath := buildRustPtyManagerForTest(t)
-	ptyOwnerDir := longRustPtyOwnerDirForTest(t)
-	setLongUnixTempDirForTest(t)
-	cfg := &config.Config{
-		Tmux: config.Tmux{
-			Command: []string{filepath.Join(t.TempDir(), "missing-tmux")},
-		},
-		Shell: config.Shell{Command: rustPtyManagerShellCommandForTest(t)},
-	}
-	fixture := setupWorkspaceServerFixtureWithOptions(t, cfg, ServerOptions{
-		PtyOwnerDir:         ptyOwnerDir,
-		PtyOwnerManagerPath: managerPath,
-	})
-	ctx := context.Background()
-	ws := createReadyWorkspace(t, ctx, fixture.client)
-	cleanupPtyOwnerWorkspace(t, ptyOwnerDir, ws.TmuxSession)
-
-	stored, err := fixture.database.GetWorkspace(ctx, ws.Id)
-	require.NoError(err)
-	require.NotNil(stored)
-	assert.Equal(workspace.TerminalBackendPtyOwner, stored.TerminalBackend)
-
-	ts := httptest.NewServer(fixture.server)
-	t.Cleanup(ts.Close)
-	conn, _, err := workspaceTerminalDialWithQuery(
-		ctx, ts.URL, ws.Id, "cols=120&rows=30",
-	)
-	require.NoError(err)
-	defer conn.Close(websocket.StatusNormalClosure, "done")
-
-	if runtime.GOOS == "windows" {
-		workspaceTerminalConnWriteRead(
-			t, ctx, conn, "echo rust-owner-one\r", "rust-owner-one",
-		)
-	} else {
-		workspaceTerminalConnWriteRead(
-			t, ctx, conn, "printf 'rust-owner-one\n'\r", "rust-owner-one",
-		)
-		require.NoError(conn.Write(
-			ctx,
-			websocket.MessageText,
-			[]byte(`{"type":"resize","cols":133,"rows":37}`),
-		))
-		workspaceTerminalConnWriteRead(
-			t, ctx, conn, "printf 'size:'; stty size\r", "size:37 133",
-		)
-	}
-
-	require.NoError(conn.Close(websocket.StatusNormalClosure, "done"))
-	force := true
-	delResp, err := fixture.client.HTTP.DeleteWorkspaceWithResponse(
-		ctx, ws.Id, &generated.DeleteWorkspaceParams{Force: &force},
-	)
-	require.NoError(err)
-	require.Equal(http.StatusNoContent, delResp.StatusCode())
-
-	_, err = os.Stat(filepath.Join(ptyOwnerDir, ws.TmuxSession))
-	assert.True(os.IsNotExist(err))
-}
-
-func TestWorkspaceRuntimeLaunchesRustPtyManagerSessionE2E(t *testing.T) {
-	if runtime.GOOS != "windows" {
-		requirePTYAvailable(t)
-	}
-	releasePTYSlot := acquirePTYE2ESlot(t)
-	t.Cleanup(releasePTYSlot)
-
-	require := require.New(t)
-	assert := assert.New(t)
-
-	managerPath := buildRustPtyManagerForTest(t)
-	ptyOwnerDir := longRustPtyOwnerDirForTest(t)
-	setLongUnixTempDirForTest(t)
-	disableTmuxAgentSessions := false
-	cfg := &config.Config{
-		Agents: []config.Agent{{
-			Key:     "helper",
-			Label:   "Helper",
-			Command: serverRuntimeHelperCommand("echo"),
-		}},
-		Tmux: config.Tmux{
-			Command:       []string{filepath.Join(t.TempDir(), "missing-tmux")},
-			AgentSessions: &disableTmuxAgentSessions,
-		},
-	}
-	fixture := setupWorkspaceServerFixtureWithOptions(t, cfg, ServerOptions{
-		PtyOwnerDir:         ptyOwnerDir,
-		PtyOwnerManagerPath: managerPath,
-	})
-	ctx := context.Background()
-	ws := createReadyWorkspace(t, ctx, fixture.client)
-
-	launchResp, err := fixture.client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
-		ctx, ws.Id,
-		generated.LaunchWorkspaceRuntimeSessionInputBody{TargetKey: "helper"},
-	)
-	require.NoError(err)
-	require.Equal(http.StatusOK, launchResp.StatusCode(), string(launchResp.Body))
-	require.NotNil(launchResp.JSON200)
-	session := launchResp.JSON200
-	cleanupPtyOwnerWorkspace(t, ptyOwnerDir, session.Key)
-	assert.Equal("helper", session.TargetKey)
-	assert.Equal(string(localruntime.SessionStatusRunning), session.Status)
-
-	ts := httptest.NewServer(fixture.server)
-	t.Cleanup(ts.Close)
-	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") +
-		"/ws/v1/workspaces/" + ws.Id +
-		"/runtime/sessions/" + session.Key + "/terminal?cols=80&rows=24"
-	conn, _, err := websocket.Dial(ctx, wsURL, nil)
-	require.NoError(err)
-	defer conn.Close(websocket.StatusNormalClosure, "done")
-
-	workspaceTerminalConnWriteRead(t, ctx, conn, "ping\r", "echo:ping")
-
-	stopResp, err := fixture.client.HTTP.StopWorkspaceRuntimeSessionWithResponse(
-		ctx, ws.Id, session.Key,
-	)
-	require.NoError(err)
-	require.Equal(http.StatusNoContent, stopResp.StatusCode())
-}
-
 func TestWorkspaceRuntimePlainShellUsesPtyOwnerWhenTmuxUnavailableE2E(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test fixture uses /bin/sh")
@@ -25190,14 +25058,6 @@ func gitLocalRemoteURL(path string) string {
 	return (&url.URL{Scheme: "file", Path: slashPath}).String()
 }
 
-func rustPtyManagerShellCommandForTest(t *testing.T) []string {
-	t.Helper()
-	if runtime.GOOS == "windows" {
-		return serverRuntimeHelperCommand("echo")
-	}
-	return []string{"/bin/sh"}
-}
-
 func buildRustPtyManagerForTest(t *testing.T) string {
 	t.Helper()
 
@@ -25233,16 +25093,6 @@ func longRustPtyOwnerDirForTest(t *testing.T) string {
 	dir := filepath.Join(t.TempDir(), strings.Repeat("long-owner-root-", 8))
 	require.NoError(t, os.MkdirAll(dir, 0o755))
 	return dir
-}
-
-func setLongUnixTempDirForTest(t *testing.T) {
-	t.Helper()
-	if runtime.GOOS == "windows" {
-		return
-	}
-	dir := filepath.Join(t.TempDir(), strings.Repeat("long-temp-root-", 8))
-	require.NoError(t, os.MkdirAll(dir, 0o755))
-	t.Setenv("TMPDIR", dir)
 }
 
 func cleanupPtyOwnerWorkspace(

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -60,6 +60,7 @@ import (
 	"go.kenn.io/middleman/internal/testutil"
 	"go.kenn.io/middleman/internal/testutil/dbtest"
 	"go.kenn.io/middleman/internal/testutil/gitfake"
+	"go.kenn.io/middleman/internal/testutil/processjob"
 	"go.kenn.io/middleman/internal/tokenauth"
 	"go.kenn.io/middleman/internal/workspace"
 	"go.kenn.io/middleman/internal/workspace/localruntime"
@@ -79,6 +80,10 @@ var (
 func TestMain(m *testing.M) {
 	if isServerHelperProcess() {
 		os.Exit(m.Run())
+	}
+	if err := processjob.ContainCurrentProcessTree(); err != nil {
+		fmt.Fprintf(os.Stderr, "contain server test process tree: %v\n", err)
+		os.Exit(1)
 	}
 	envDir, envDirErr := os.MkdirTemp("", "middleman-server-tmux-env-*")
 	if envDirErr == nil {

--- a/internal/server/workspacetest/pty_owner_e2e_test.go
+++ b/internal/server/workspacetest/pty_owner_e2e_test.go
@@ -25,6 +25,7 @@ import (
 	"go.kenn.io/middleman/internal/procutil"
 	"go.kenn.io/middleman/internal/ptyowner"
 	"go.kenn.io/middleman/internal/server"
+	"go.kenn.io/middleman/internal/testutil/processjob"
 	"go.kenn.io/middleman/internal/workspace"
 	"go.kenn.io/middleman/internal/workspace/localruntime"
 )
@@ -36,6 +37,17 @@ var rustPtyManagerBuild struct {
 	path string
 	out  []byte
 	err  error
+}
+
+func TestMain(m *testing.M) {
+	if slices.Contains(os.Args, workspaceRuntimeHelperMarker) {
+		os.Exit(m.Run())
+	}
+	if err := processjob.ContainCurrentProcessTree(); err != nil {
+		fmt.Fprintf(os.Stderr, "contain workspace test process tree: %v\n", err)
+		os.Exit(1)
+	}
+	os.Exit(m.Run())
 }
 
 func TestWorkspaceCreatesRustPtyManagerSessionE2E(t *testing.T) {
@@ -55,7 +67,7 @@ func TestWorkspaceCreatesRustPtyManagerSessionE2E(t *testing.T) {
 	}
 	fixture := setupWorkspaceServerFixture(t, cfg, server.ServerOptions{
 		DisableWorkspaceBackgroundMonitors: true,
-		HostCheckAllowLoopbackAnyPort:       true,
+		HostCheckAllowLoopbackAnyPort:      true,
 		PtyOwnerDir:                        ptyOwnerDir,
 		PtyOwnerManagerPath:                managerPath,
 	})
@@ -124,7 +136,7 @@ func TestWorkspaceRuntimeLaunchesRustPtyManagerSessionE2E(t *testing.T) {
 	}
 	fixture := setupWorkspaceServerFixture(t, cfg, server.ServerOptions{
 		DisableWorkspaceBackgroundMonitors: true,
-		HostCheckAllowLoopbackAnyPort:       true,
+		HostCheckAllowLoopbackAnyPort:      true,
 		PtyOwnerDir:                        ptyOwnerDir,
 		PtyOwnerManagerPath:                managerPath,
 	})

--- a/internal/server/workspacetest/pty_owner_e2e_test.go
+++ b/internal/server/workspacetest/pty_owner_e2e_test.go
@@ -1,0 +1,339 @@
+package workspacetest
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/creack/pty/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/middleman/internal/apiclient/generated"
+	"go.kenn.io/middleman/internal/config"
+	"go.kenn.io/middleman/internal/procutil"
+	"go.kenn.io/middleman/internal/ptyowner"
+	"go.kenn.io/middleman/internal/server"
+	"go.kenn.io/middleman/internal/workspace"
+	"go.kenn.io/middleman/internal/workspace/localruntime"
+)
+
+const workspaceRuntimeHelperMarker = "middleman-workspace-runtime-helper"
+
+var rustPtyManagerBuild struct {
+	once sync.Once
+	path string
+	out  []byte
+	err  error
+}
+
+func TestWorkspaceCreatesRustPtyManagerSessionE2E(t *testing.T) {
+	requirePTYAvailable(t)
+
+	require := require.New(t)
+	assert := assert.New(t)
+
+	managerPath := buildRustPtyManagerForTest(t)
+	ptyOwnerDir := longRustPtyOwnerDirForTest(t)
+	setLongUnixTempDirForTest(t)
+	cfg := &config.Config{
+		Tmux: config.Tmux{
+			Command: []string{filepath.Join(t.TempDir(), "missing-tmux")},
+		},
+		Shell: config.Shell{Command: rustPtyManagerShellCommandForTest()},
+	}
+	fixture := setupWorkspaceServerFixture(t, cfg, server.ServerOptions{
+		DisableWorkspaceBackgroundMonitors: true,
+		HostCheckAllowLoopbackAnyPort:       true,
+		PtyOwnerDir:                        ptyOwnerDir,
+		PtyOwnerManagerPath:                managerPath,
+	})
+	ctx := t.Context()
+	ws := createReadyWorkspace(t, ctx, fixture.client)
+	cleanupPtyOwnerWorkspace(t, ptyOwnerDir, ws.TmuxSession)
+
+	stored, err := fixture.database.GetWorkspace(ctx, ws.Id)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.Equal(workspace.TerminalBackendPtyOwner, stored.TerminalBackend)
+
+	ts := httptest.NewServer(fixture.server)
+	t.Cleanup(ts.Close)
+	conn, _, err := workspaceTerminalDialWithQuery(
+		ctx, ts.URL, ws.Id, "cols=120&rows=30",
+	)
+	require.NoError(err)
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+
+	if runtime.GOOS == "windows" {
+		workspaceTerminalConnWriteRead(
+			t, ctx, conn, "echo rust-owner-one\r", "rust-owner-one",
+		)
+	} else {
+		workspaceTerminalConnWriteRead(
+			t, ctx, conn, "printf 'rust-owner-one\n'\r", "rust-owner-one",
+		)
+		require.NoError(conn.Write(
+			ctx,
+			websocket.MessageText,
+			[]byte(`{"type":"resize","cols":133,"rows":37}`),
+		))
+		workspaceTerminalConnWriteRead(
+			t, ctx, conn, "printf 'size:'; stty size\r", "size:37 133",
+		)
+	}
+
+	require.NoError(conn.Close(websocket.StatusNormalClosure, "done"))
+	deleteWorkspaceForPtyOwnerTest(t, ctx, fixture, ws.Id)
+
+	_, err = os.Stat(filepath.Join(ptyOwnerDir, ws.TmuxSession))
+	assert.True(os.IsNotExist(err))
+}
+
+func TestWorkspaceRuntimeLaunchesRustPtyManagerSessionE2E(t *testing.T) {
+	requirePTYAvailable(t)
+
+	require := require.New(t)
+	assert := assert.New(t)
+
+	managerPath := buildRustPtyManagerForTest(t)
+	ptyOwnerDir := longRustPtyOwnerDirForTest(t)
+	setLongUnixTempDirForTest(t)
+	disableTmuxAgentSessions := false
+	cfg := &config.Config{
+		Agents: []config.Agent{{
+			Key:     "helper",
+			Label:   "Helper",
+			Command: workspaceRuntimeHelperCommand("echo"),
+		}},
+		Tmux: config.Tmux{
+			Command:       []string{filepath.Join(t.TempDir(), "missing-tmux")},
+			AgentSessions: &disableTmuxAgentSessions,
+		},
+	}
+	fixture := setupWorkspaceServerFixture(t, cfg, server.ServerOptions{
+		DisableWorkspaceBackgroundMonitors: true,
+		HostCheckAllowLoopbackAnyPort:       true,
+		PtyOwnerDir:                        ptyOwnerDir,
+		PtyOwnerManagerPath:                managerPath,
+	})
+	ctx := t.Context()
+	ws := createReadyWorkspace(t, ctx, fixture.client)
+	cleanupPtyOwnerWorkspace(t, ptyOwnerDir, ws.TmuxSession)
+
+	launchResp, err := fixture.client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id,
+		generated.LaunchWorkspaceRuntimeSessionInputBody{TargetKey: "helper"},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, launchResp.StatusCode(), string(launchResp.Body))
+	require.NotNil(launchResp.JSON200)
+	session := launchResp.JSON200
+	cleanupPtyOwnerWorkspace(t, ptyOwnerDir, session.Key)
+	assert.Equal("helper", session.TargetKey)
+	assert.Equal(string(localruntime.SessionStatusRunning), session.Status)
+
+	ts := httptest.NewServer(fixture.server)
+	t.Cleanup(ts.Close)
+	wsURL := "ws" + strings.TrimPrefix(ts.URL, "http") +
+		"/ws/v1/workspaces/" + ws.Id +
+		"/runtime/sessions/" + session.Key + "/terminal?cols=80&rows=24"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	require.NoError(err)
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+
+	workspaceTerminalConnWriteRead(t, ctx, conn, "ping\r", "echo:ping")
+
+	stopResp, err := fixture.client.HTTP.StopWorkspaceRuntimeSessionWithResponse(
+		ctx, ws.Id, session.Key,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusNoContent, stopResp.StatusCode())
+	deleteWorkspaceForPtyOwnerTest(t, ctx, fixture, ws.Id)
+}
+
+func deleteWorkspaceForPtyOwnerTest(
+	t *testing.T,
+	ctx context.Context,
+	fixture workspaceServerFixture,
+	workspaceID string,
+) {
+	t.Helper()
+
+	force := true
+	resp, err := fixture.client.HTTP.DeleteWorkspaceWithResponse(
+		ctx, workspaceID, &generated.DeleteWorkspaceParams{Force: &force},
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode())
+}
+
+func requirePTYAvailable(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		return
+	}
+	ptmx, tty, err := pty.Open()
+	if err != nil {
+		t.Skipf("pty unavailable in this test environment: %v", err)
+	}
+	_ = ptmx.Close()
+	_ = tty.Close()
+}
+
+func rustPtyManagerShellCommandForTest() []string {
+	if runtime.GOOS == "windows" {
+		return workspaceRuntimeHelperCommand("echo")
+	}
+	return []string{"/bin/sh"}
+}
+
+func buildRustPtyManagerForTest(t *testing.T) string {
+	t.Helper()
+
+	cargo, err := exec.LookPath("cargo")
+	if err != nil {
+		t.Skip("cargo not available")
+	}
+	rustPtyManagerBuild.once.Do(func() {
+		root := repoRootForPtyOwnerTest(t)
+		cmd := procutil.Command(cargo, "build", "-p", "middleman-pty-manager")
+		cmd.Dir = root
+		rustPtyManagerBuild.out, rustPtyManagerBuild.err = cmd.CombinedOutput()
+		rustPtyManagerBuild.path = filepath.Join(
+			root, "target", "debug", "middleman-pty-manager",
+		)
+		if runtime.GOOS == "windows" {
+			rustPtyManagerBuild.path += ".exe"
+		}
+	})
+	require.NoError(t, rustPtyManagerBuild.err, string(rustPtyManagerBuild.out))
+	return rustPtyManagerBuild.path
+}
+
+func repoRootForPtyOwnerTest(t *testing.T) string {
+	t.Helper()
+
+	root, err := filepath.Abs(filepath.Join("..", "..", ".."))
+	require.NoError(t, err)
+	_, err = os.Stat(filepath.Join(root, "Cargo.toml"))
+	require.NoError(t, err)
+	return root
+}
+
+func longRustPtyOwnerDirForTest(t *testing.T) string {
+	t.Helper()
+
+	dir := filepath.Join(t.TempDir(), strings.Repeat("long-owner-root-", 8))
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	return dir
+}
+
+func setLongUnixTempDirForTest(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		return
+	}
+	dir := filepath.Join(t.TempDir(), strings.Repeat("long-temp-root-", 8))
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	t.Setenv("TMPDIR", dir)
+}
+
+func cleanupPtyOwnerWorkspace(
+	t *testing.T,
+	ptyOwnerDir string,
+	session string,
+) {
+	t.Helper()
+	t.Cleanup(func() {
+		_ = (&ptyowner.Client{Root: ptyOwnerDir}).Stop(
+			context.Background(), session,
+		)
+	})
+}
+
+func workspaceTerminalConnWriteRead(
+	t *testing.T,
+	ctx context.Context,
+	conn *websocket.Conn,
+	input string,
+	needle string,
+) {
+	t.Helper()
+
+	require.NoError(t, conn.Write(
+		ctx, websocket.MessageBinary, []byte(input),
+	))
+	readCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	var got strings.Builder
+	for {
+		typ, data, readErr := conn.Read(readCtx)
+		if readErr != nil {
+			break
+		}
+		if typ != websocket.MessageBinary {
+			continue
+		}
+		got.WriteString(string(data))
+		if strings.Contains(got.String(), needle) {
+			return
+		}
+	}
+	require.Contains(t, got.String(), needle)
+}
+
+func workspaceTerminalDialWithQuery(
+	ctx context.Context,
+	serverURL string,
+	workspaceID string,
+	query string,
+) (*websocket.Conn, *http.Response, error) {
+	wsURL := "ws" + strings.TrimPrefix(serverURL, "http") +
+		"/api/v1/workspaces/" + workspaceID + "/terminal"
+	if query != "" {
+		wsURL += "?" + query
+	}
+	return websocket.Dial(ctx, wsURL, nil)
+}
+
+func workspaceRuntimeHelperCommand(mode string) []string {
+	return []string{
+		os.Args[0],
+		"-test.run=TestWorkspaceRuntimeHelperProcess",
+		"--",
+		workspaceRuntimeHelperMarker,
+		mode,
+	}
+}
+
+func TestWorkspaceRuntimeHelperProcess(t *testing.T) {
+	args := os.Args
+	sep := slices.Index(args, "--")
+	if sep < 0 || len(args) <= sep+2 || args[sep+1] != workspaceRuntimeHelperMarker {
+		return
+	}
+	switch args[sep+2] {
+	case "echo":
+		line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+		if err == nil {
+			fmt.Print("echo:" + line)
+		}
+		for {
+			time.Sleep(time.Hour)
+		}
+	default:
+		require.Failf(t, "unknown helper mode", "mode %q", args[sep+2])
+	}
+}

--- a/internal/testutil/processjob/processjob_other.go
+++ b/internal/testutil/processjob/processjob_other.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package processjob
+
+// ContainCurrentProcessTree is a no-op outside Windows.
+func ContainCurrentProcessTree() error {
+	return nil
+}

--- a/internal/testutil/processjob/processjob_windows.go
+++ b/internal/testutil/processjob/processjob_windows.go
@@ -1,0 +1,55 @@
+//go:build windows
+
+package processjob
+
+import (
+	"fmt"
+	"sync"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+var (
+	containOnce sync.Once
+	containErr  error
+	jobHandle   windows.Handle
+)
+
+// ContainCurrentProcessTree assigns the current process to a Windows Job
+// Object whose descendants are terminated when this process exits. The job
+// handle intentionally remains open for the lifetime of the process: closing
+// it while the current process is still running would terminate the caller.
+func ContainCurrentProcessTree() error {
+	containOnce.Do(func() {
+		job, err := windows.CreateJobObject(nil, nil)
+		if err != nil {
+			containErr = fmt.Errorf("create process job: %w", err)
+			return
+		}
+
+		info := windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{}
+		info.BasicLimitInformation.LimitFlags =
+			windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+		_, err = windows.SetInformationJobObject(
+			job,
+			windows.JobObjectExtendedLimitInformation,
+			uintptr(unsafe.Pointer(&info)),
+			uint32(unsafe.Sizeof(info)),
+		)
+		if err != nil {
+			_ = windows.CloseHandle(job)
+			containErr = fmt.Errorf("configure process job: %w", err)
+			return
+		}
+		if err := windows.AssignProcessToJobObject(
+			job, windows.CurrentProcess(),
+		); err != nil {
+			_ = windows.CloseHandle(job)
+			containErr = fmt.Errorf("assign current process to job: %w", err)
+			return
+		}
+		jobHandle = job
+	})
+	return containErr
+}

--- a/internal/testutil/processjob/processjob_windows_test.go
+++ b/internal/testutil/processjob/processjob_windows_test.go
@@ -1,0 +1,109 @@
+//go:build windows
+
+package processjob
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+)
+
+const (
+	processJobOwnerHelper = "MIDDLEMAN_PROCESS_JOB_OWNER_HELPER"
+	processJobChildHelper = "MIDDLEMAN_PROCESS_JOB_CHILD_HELPER"
+)
+
+func TestContainCurrentProcessTreeStopsDetachedDescendant(t *testing.T) {
+	if os.Getenv(processJobChildHelper) == "1" {
+		time.Sleep(time.Hour)
+		return
+	}
+	if os.Getenv(processJobOwnerHelper) == "1" {
+		runProcessJobOwnerHelper()
+	}
+
+	require := require.New(t)
+	pidFile := filepath.Join(t.TempDir(), "child.pid")
+	owner := exec.Command(
+		os.Args[0],
+		"-test.run=^TestContainCurrentProcessTreeStopsDetachedDescendant$",
+	)
+	owner.Env = append(os.Environ(), processJobOwnerHelper+"=1")
+	owner.Args = append(owner.Args, "--", pidFile)
+	require.NoError(owner.Start())
+	t.Cleanup(func() {
+		if owner.ProcessState == nil {
+			_ = owner.Process.Kill()
+			_, _ = owner.Process.Wait()
+		}
+	})
+
+	var childPID int
+	require.Eventually(func() bool {
+		data, err := os.ReadFile(pidFile)
+		if err != nil {
+			return false
+		}
+		childPID, err = strconv.Atoi(strings.TrimSpace(string(data)))
+		return err == nil
+	}, 5*time.Second, 25*time.Millisecond)
+
+	require.NoError(owner.Process.Kill())
+	_ = owner.Wait()
+	require.Eventually(
+		func() bool { return windowsProcessExited(uint32(childPID)) },
+		5*time.Second,
+		25*time.Millisecond,
+	)
+}
+
+func runProcessJobOwnerHelper() {
+	if err := ContainCurrentProcessTree(); err != nil {
+		os.Exit(2)
+	}
+	args := os.Args
+	pidFile := args[len(args)-1]
+	child := exec.Command(
+		os.Args[0],
+		"-test.run=^TestContainCurrentProcessTreeStopsDetachedDescendant$",
+	)
+	child.Env = append(os.Environ(), processJobChildHelper+"=1")
+	child.SysProcAttr = &syscall.SysProcAttr{
+		HideWindow: true,
+		CreationFlags: windows.CREATE_NEW_PROCESS_GROUP |
+			windows.DETACHED_PROCESS |
+			windows.CREATE_NO_WINDOW,
+	}
+	if err := child.Start(); err != nil {
+		os.Exit(2)
+	}
+	if err := os.WriteFile(
+		pidFile, []byte(strconv.Itoa(child.Process.Pid)), 0o600,
+	); err != nil {
+		_ = child.Process.Kill()
+		os.Exit(2)
+	}
+	time.Sleep(time.Hour)
+}
+
+func windowsProcessExited(pid uint32) bool {
+	process, err := windows.OpenProcess(windows.SYNCHRONIZE, false, pid)
+	if errors.Is(err, windows.ERROR_INVALID_PARAMETER) {
+		return true
+	}
+	if err != nil {
+		return false
+	}
+	defer windows.CloseHandle(process)
+	status, err := windows.WaitForSingleObject(process, 0)
+	return err == nil && status == windows.WAIT_OBJECT_0
+}

--- a/internal/workspace/localruntime/manager_test.go
+++ b/internal/workspace/localruntime/manager_test.go
@@ -23,11 +23,16 @@ import (
 	"go.kenn.io/middleman/internal/procutil"
 	"go.kenn.io/middleman/internal/ptyowner"
 	ptyownerruntime "go.kenn.io/middleman/internal/ptyowner/runtime"
+	"go.kenn.io/middleman/internal/testutil/processjob"
 )
 
 func TestMain(m *testing.M) {
 	if os.Getenv("MIDDLEMAN_LOCALRUNTIME_HELPER") == "1" {
 		os.Exit(m.Run())
+	}
+	if err := processjob.ContainCurrentProcessTree(); err != nil {
+		fmt.Fprintf(os.Stderr, "contain local runtime test process tree: %v\n", err)
+		os.Exit(1)
 	}
 	envDir, err := os.MkdirTemp("", "middleman-localruntime-tmux-env-*")
 	if err == nil {


### PR DESCRIPTION
Windows PTY owners intentionally outlive server restarts, but a forcibly stopped Go test had no equivalent lifetime boundary. Detached test managers could therefore survive with their command trees and destabilize later Windows packages.

- Reap PTY-heavy Windows test descendants when their test binary exits.
- Run Rust PTY server coverage in the focused workspace test package instead of the monolithic server suite.
- Keep shell validation scripts LF-normalized in Windows checkouts.

Validated on Windows with the exact PTY CI lane and 20 forced-termination repetitions; no test-owned processes remained.