### PR TITLE
Make diff file paths copyable

### DIFF
--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -350,8 +350,8 @@ Rows that contain buttons, links, or toggles need clear event ownership.
 - Focus-visible states matter for controls that are visually subtle, such as tab
   close buttons or compact action affordances.
 - Clipboard actions over provider- or repository-supplied text must refuse
-  concealed or default-ignorable characters, require full-value confirmation for
-  shell-unsafe text, and preserve safe text exactly (`packages/ui/src/components/diff/DiffFile.svelte::copyPath`).
+  concealed/default-ignorable characters and confirm shell-unsafe text, including option-
+  or assignment-shaped allowlisted values; show the full value, recommend explicit operand syntax, and preserve confirmed text exactly (`packages/ui/src/components/diff/DiffFile.svelte::copyPath`).
 - If a component claims menu-like behavior, it must honor the keyboard and focus
   contract of that role. Otherwise, use simpler semantics honestly.
 - Gate unavailable menu actions at the items when the menu remains safe to

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -349,9 +349,9 @@ Rows that contain buttons, links, or toggles need clear event ownership.
   surface is currently active.
 - Focus-visible states matter for controls that are visually subtle, such as tab
   close buttons or compact action affordances.
-- Clipboard actions over provider- or repository-supplied text must visibly
-  escape and refuse concealed control/format characters while preserving
-  ordinary text exactly (`packages/ui/src/components/diff/DiffFile.svelte::isConcealedCharacter`).
+- Clipboard actions over provider- or repository-supplied text must refuse
+  concealed control/format characters, require full-value confirmation for
+  shell-unsafe text, and preserve safe text exactly (`packages/ui/src/components/diff/DiffFile.svelte::copyPath`).
 - If a component claims menu-like behavior, it must honor the keyboard and focus
   contract of that role. Otherwise, use simpler semantics honestly.
 - Gate unavailable menu actions at the items when the menu remains safe to

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -350,7 +350,7 @@ Rows that contain buttons, links, or toggles need clear event ownership.
 - Focus-visible states matter for controls that are visually subtle, such as tab
   close buttons or compact action affordances.
 - Clipboard actions over provider- or repository-supplied text must refuse
-  concealed control/format characters, require full-value confirmation for
+  concealed or default-ignorable characters, require full-value confirmation for
   shell-unsafe text, and preserve safe text exactly (`packages/ui/src/components/diff/DiffFile.svelte::copyPath`).
 - If a component claims menu-like behavior, it must honor the keyboard and focus
   contract of that role. Otherwise, use simpler semantics honestly.

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -349,6 +349,9 @@ Rows that contain buttons, links, or toggles need clear event ownership.
   surface is currently active.
 - Focus-visible states matter for controls that are visually subtle, such as tab
   close buttons or compact action affordances.
+- Clipboard actions over provider- or repository-supplied text must visibly
+  escape and refuse concealed control/format characters while preserving
+  ordinary text exactly (`packages/ui/src/components/diff/DiffFile.svelte::isConcealedCharacter`).
 - If a component claims menu-like behavior, it must honor the keyboard and focus
   contract of that role. Otherwise, use simpler semantics honestly.
 - Gate unavailable menu actions at the items when the menu remains safe to

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -350,8 +350,7 @@ Rows that contain buttons, links, or toggles need clear event ownership.
 - Focus-visible states matter for controls that are visually subtle, such as tab
   close buttons or compact action affordances.
 - Clipboard actions over provider- or repository-supplied text must refuse
-  concealed/default-ignorable characters and confirm shell-unsafe text, including option-
-  or assignment-shaped allowlisted values; show the full value, recommend explicit operand syntax, and preserve confirmed text exactly (`packages/ui/src/components/diff/DiffFile.svelte::copyPath`).
+  concealed/default-ignorable characters and confirm shell-unsafe text, including option- or assignment-shaped allowlisted values; show the full value and tailor guidance to syntax, option, or command-position risk before preserving exact confirmed text (`packages/ui/src/components/diff/DiffFile.svelte::copyPath`).
 - If a component claims menu-like behavior, it must honor the keyboard and focus
   contract of that role. Otherwise, use simpler semantics honestly.
 - Gate unavailable menu actions at the items when the menu remains safe to

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -349,8 +349,9 @@ Rows that contain buttons, links, or toggles need clear event ownership.
   surface is currently active.
 - Focus-visible states matter for controls that are visually subtle, such as tab
   close buttons or compact action affordances.
-- Clipboard actions over provider- or repository-supplied text must refuse
-  concealed/default-ignorable characters and confirm shell-unsafe text, including option- or assignment-shaped allowlisted values; show the full value and tailor guidance to syntax, option, or command-position risk before preserving exact confirmed text (`packages/ui/src/components/diff/DiffFile.svelte::copyPath`).
+- Explicit clipboard controls copy provider/repository values exactly; copying is
+  not code execution or a shell security boundary, so source UI must not filter,
+  quote, escape, or add shell confirmation (`packages/ui/src/components/diff/DiffFile.svelte`).
 - If a component claims menu-like behavior, it must honor the keyboard and focus
   contract of that role. Otherwise, use simpler semantics honestly.
 - Gate unavailable menu actions at the items when the menu remains safe to

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -2202,7 +2202,11 @@ test.describe("diff view", () => {
     await expect(content).toBeVisible();
   });
 
-  test("clicking a file path writes the exact path to the clipboard", async ({ page, context, browserName }) => {
+  test("clicking a file path copy icon writes the exact path to the clipboard", async ({
+    page,
+    context,
+    browserName,
+  }) => {
     test.skip(browserName !== "chromium", "Clipboard read assertions require Chromium permissions");
     await context.grantPermissions(["clipboard-read", "clipboard-write"]);
     await mockDiffApi(page, smallDiff);
@@ -2210,182 +2214,22 @@ test.describe("diff view", () => {
     await waitForDiffLoaded(page);
 
     const path = "internal/server/handler.go";
-    const pathButton = page.locator(`.diff-file[data-file-path="${path}"] .file-path`);
-    await pathButton.click();
+    const copyButton = page.locator(`.diff-file[data-file-path="${path}"] .file-path-copy`);
+    await copyButton.click();
 
     await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe(path);
-    await expect(pathButton).toHaveAttribute("title", "Copied!");
-    await expect(page.locator(".file-path-copy-status")).toHaveText("Copied");
+    await expect(copyButton).toHaveAttribute("title", "Copied!");
   });
 
-  test("confirms a truncated shell-unsafe path before copying it", async ({ page, context, browserName }) => {
-    test.skip(browserName !== "chromium", "Clipboard read assertions require Chromium permissions");
-    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
-    const path = `src/${"a".repeat(240)};$(hidden-command).ts`;
-    const unsafeDiff: DiffResult = {
-      ...smallDiff,
-      files: smallDiff.files.map((file, index) => (index === 0 ? { ...file, path, old_path: path } : file)),
-    };
-    await mockDiffApi(page, unsafeDiff);
-    await navigateToDiff(page);
-    await waitForDiffLoaded(page);
-    await page.evaluate(() => navigator.clipboard.writeText("unchanged"));
-
-    const pathButton = page.locator(`.diff-file[data-file-path="${path}"] .file-path`);
-    await expect
-      .poll(() =>
-        pathButton.evaluate((element) => {
-          const style = getComputedStyle(element);
-          return {
-            overflowing: element.scrollWidth > element.clientWidth,
-            overflow: style.overflow,
-            textOverflow: style.textOverflow,
-            whiteSpace: style.whiteSpace,
-          };
-        }),
-      )
-      .toEqual({
-        overflowing: true,
-        overflow: "hidden",
-        textOverflow: "ellipsis",
-        whiteSpace: "nowrap",
-      });
-
-    let confirmationMessage = "";
-    page.once("dialog", async (dialog) => {
-      confirmationMessage = dialog.message();
-      await dialog.dismiss();
-    });
-    await pathButton.click();
-
-    expect(confirmationMessage).toContain(path);
-    expect(confirmationMessage).toContain("Quote or escape the entire path for your shell");
-    expect(confirmationMessage).not.toContain("place -- before it");
-    await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe("unchanged");
-
-    page.once("dialog", async (dialog) => {
-      await dialog.accept();
-    });
-    await pathButton.click();
-
-    await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe(path);
-  });
-
-  test("confirms an option-shaped path before preserving it on the clipboard", async ({
-    page,
-    context,
-    browserName,
-  }) => {
-    test.skip(browserName !== "chromium", "Clipboard read assertions require Chromium permissions");
-    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
-    const path = "--output=.git/config";
-    const optionShapedDiff: DiffResult = {
-      ...smallDiff,
-      files: smallDiff.files.map((file, index) => (index === 0 ? { ...file, path, old_path: path } : file)),
-    };
-    await mockDiffApi(page, optionShapedDiff);
-    await navigateToDiff(page);
-    await waitForDiffLoaded(page);
-    await page.evaluate(() => navigator.clipboard.writeText("unchanged"));
-
-    const pathButton = page.locator(`.diff-file[data-file-path="${path}"] .file-path`);
-    let confirmationMessage = "";
-    page.once("dialog", async (dialog) => {
-      confirmationMessage = dialog.message();
-      await dialog.dismiss();
-    });
-
-    await pathButton.click();
-
-    expect(confirmationMessage).toContain(path);
-    expect(confirmationMessage).toContain("place -- before it or prefix it with ./");
-    await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe("unchanged");
-
-    page.once("dialog", async (dialog) => {
-      await dialog.accept();
-    });
-    await pathButton.click();
-
-    await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe(path);
-  });
-
-  test("confirms an augmented assignment-shaped path before copying it", async ({ page, context, browserName }) => {
-    test.skip(browserName !== "chromium", "Clipboard read assertions require Chromium permissions");
-    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
-    const path = "PROMPT_COMMAND+=src/payload";
-    const assignmentShapedDiff: DiffResult = {
-      ...smallDiff,
-      files: smallDiff.files.map((file, index) => (index === 0 ? { ...file, path, old_path: path } : file)),
-    };
-    await mockDiffApi(page, assignmentShapedDiff);
-    await navigateToDiff(page);
-    await waitForDiffLoaded(page);
-    await page.evaluate(() => navigator.clipboard.writeText("unchanged"));
-
-    const pathButton = page.locator(`.diff-file[data-file-path="${path}"] .file-path`);
-    let confirmationMessage = "";
-    page.once("dialog", async (dialog) => {
-      confirmationMessage = dialog.message();
-      await dialog.dismiss();
-    });
-
-    await pathButton.click();
-
-    expect(confirmationMessage).toContain(path);
-    expect(confirmationMessage).toContain("pass it as an argument after the command");
-    expect(confirmationMessage).not.toContain("place -- before it");
-    await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe("unchanged");
-
-    page.once("dialog", async (dialog) => {
-      await dialog.accept();
-    });
-    await pathButton.click();
-
-    await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe(path);
-  });
-
-  test("concealed path characters remain escaped and cannot reach the clipboard", async ({
-    page,
-    context,
-    browserName,
-  }) => {
-    test.skip(browserName !== "chromium", "Clipboard read assertions require Chromium permissions");
-    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
-    const path = "src/safe\ufe0fpayload.ts";
-    const concealedDiff: DiffResult = {
-      ...smallDiff,
-      files: smallDiff.files.map((file, index) => (index === 0 ? { ...file, path, old_path: path } : file)),
-    };
-    await mockDiffApi(page, concealedDiff);
-    await navigateToDiff(page);
-    await waitForDiffLoaded(page);
-    await page.evaluate(() => navigator.clipboard.writeText("unchanged"));
-
-    const pathButton = page.locator(`.diff-file[data-file-path="${path}"] .file-path`);
-    await expect(pathButton).toHaveText("src/safe\\ufe0fpayload.ts");
-    await expect(pathButton).toHaveAttribute("aria-disabled", "true");
-
-    await pathButton.click({ force: true });
-
-    await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe("unchanged");
-  });
-
-  test("deleted file paths retain line-through while hovered and focused", async ({ page }) => {
+  test("deleted file paths retain line-through", async ({ page }) => {
     await mockDiffApi(page, smallDiff);
     await navigateToDiff(page);
     await waitForDiffLoaded(page);
 
-    const pathButton = page.locator('.diff-file[data-file-path="internal/legacy/old_handler.go"] .file-path');
-    const decorations = () => pathButton.evaluate((element) => getComputedStyle(element).textDecorationLine.split(" "));
+    const pathLabel = page.locator('.diff-file[data-file-path="internal/legacy/old_handler.go"] .file-path');
+    const decorations = () => pathLabel.evaluate((element) => getComputedStyle(element).textDecorationLine.split(" "));
 
-    await pathButton.hover();
     await expect.poll(decorations).toContain("line-through");
-    await expect.poll(decorations).toContain("underline");
-
-    await page.mouse.move(0, 0);
-    await pathButton.focus();
-    await expect.poll(decorations).toContain("line-through");
-    await expect.poll(decorations).toContain("underline");
   });
 
   test("more menu collapses and expands all visible diffs", async ({ page }) => {

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -2259,6 +2259,8 @@ test.describe("diff view", () => {
     await pathButton.click();
 
     expect(confirmationMessage).toContain(path);
+    expect(confirmationMessage).toContain("Quote or escape the entire path for your shell");
+    expect(confirmationMessage).not.toContain("place -- before it");
     await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe("unchanged");
 
     page.once("dialog", async (dialog) => {
@@ -2296,7 +2298,42 @@ test.describe("diff view", () => {
     await pathButton.click();
 
     expect(confirmationMessage).toContain(path);
-    expect(confirmationMessage).toContain("pass -- before the path or prefix it with ./");
+    expect(confirmationMessage).toContain("place -- before it or prefix it with ./");
+    await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe("unchanged");
+
+    page.once("dialog", async (dialog) => {
+      await dialog.accept();
+    });
+    await pathButton.click();
+
+    await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe(path);
+  });
+
+  test("confirms an augmented assignment-shaped path before copying it", async ({ page, context, browserName }) => {
+    test.skip(browserName !== "chromium", "Clipboard read assertions require Chromium permissions");
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+    const path = "PROMPT_COMMAND+=src/payload";
+    const assignmentShapedDiff: DiffResult = {
+      ...smallDiff,
+      files: smallDiff.files.map((file, index) => (index === 0 ? { ...file, path, old_path: path } : file)),
+    };
+    await mockDiffApi(page, assignmentShapedDiff);
+    await navigateToDiff(page);
+    await waitForDiffLoaded(page);
+    await page.evaluate(() => navigator.clipboard.writeText("unchanged"));
+
+    const pathButton = page.locator(`.diff-file[data-file-path="${path}"] .file-path`);
+    let confirmationMessage = "";
+    page.once("dialog", async (dialog) => {
+      confirmationMessage = dialog.message();
+      await dialog.dismiss();
+    });
+
+    await pathButton.click();
+
+    expect(confirmationMessage).toContain(path);
+    expect(confirmationMessage).toContain("pass it as an argument after the command");
+    expect(confirmationMessage).not.toContain("place -- before it");
     await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe("unchanged");
 
     page.once("dialog", async (dialog) => {

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -2269,6 +2269,50 @@ test.describe("diff view", () => {
     await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe(path);
   });
 
+  test("concealed path characters remain escaped and cannot reach the clipboard", async ({
+    page,
+    context,
+    browserName,
+  }) => {
+    test.skip(browserName !== "chromium", "Clipboard read assertions require Chromium permissions");
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+    const path = "src/safe\ufe0fpayload.ts";
+    const concealedDiff: DiffResult = {
+      ...smallDiff,
+      files: smallDiff.files.map((file, index) => (index === 0 ? { ...file, path, old_path: path } : file)),
+    };
+    await mockDiffApi(page, concealedDiff);
+    await navigateToDiff(page);
+    await waitForDiffLoaded(page);
+    await page.evaluate(() => navigator.clipboard.writeText("unchanged"));
+
+    const pathButton = page.locator(`.diff-file[data-file-path="${path}"] .file-path`);
+    await expect(pathButton).toHaveText("src/safe\\ufe0fpayload.ts");
+    await expect(pathButton).toHaveAttribute("aria-disabled", "true");
+
+    await pathButton.click({ force: true });
+
+    await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe("unchanged");
+  });
+
+  test("deleted file paths retain line-through while hovered and focused", async ({ page }) => {
+    await mockDiffApi(page, smallDiff);
+    await navigateToDiff(page);
+    await waitForDiffLoaded(page);
+
+    const pathButton = page.locator('.diff-file[data-file-path="internal/legacy/old_handler.go"] .file-path');
+    const decorations = () => pathButton.evaluate((element) => getComputedStyle(element).textDecorationLine.split(" "));
+
+    await pathButton.hover();
+    await expect.poll(decorations).toContain("line-through");
+    await expect.poll(decorations).toContain("underline");
+
+    await page.mouse.move(0, 0);
+    await pathButton.focus();
+    await expect.poll(decorations).toContain("line-through");
+    await expect.poll(decorations).toContain("underline");
+  });
+
   test("more menu collapses and expands all visible diffs", async ({ page }) => {
     await mockDiffApi(page, smallDiff);
     await navigateToDiff(page);

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -2094,7 +2094,7 @@ test.describe("diff view", () => {
     await expect(page.locator('[data-file-path="src/pkg9/file_49.go"]')).toBeVisible();
 
     const earlierFile = page.locator('[data-file-path="src/pkg5/file_25.go"]');
-    await expect(earlierFile.locator(".file-header")).toHaveAttribute("title", "Collapse file");
+    await expect(earlierFile.locator(".file-collapse-toggle")).toHaveAttribute("title", "Collapse file");
     await expect(earlierFile.locator(".file-content")).toBeAttached();
     await expect
       .poll(async () =>
@@ -2175,26 +2175,30 @@ test.describe("diff view", () => {
     await expect(page).toHaveURL(/\/pulls\/github\/acme\/widgets\/1$/);
   });
 
-  test("clicking a file header collapses and expands its content", async ({ page }) => {
+  test("clicking a file collapse control hides and restores its content", async ({ page }) => {
     await mockDiffApi(page, smallDiff);
     await navigateToDiff(page);
     await waitForDiffLoaded(page);
 
     const firstFile = page.locator(".diff-file").first();
     const header = firstFile.locator(".file-header");
+    const collapseToggle = firstFile.locator(".file-collapse-toggle");
     const content = firstFile.locator(".file-content");
 
     await expect(header.locator(".kit-diff-stats")).toHaveCount(1);
+    const collapseBounds = await collapseToggle.boundingBox();
+    expect(collapseBounds?.width).toBeGreaterThanOrEqual(24);
+    expect(collapseBounds?.height).toBeGreaterThanOrEqual(24);
 
     // Content is initially visible.
     await expect(content).toBeVisible();
 
     // Collapse.
-    await header.click();
+    await collapseToggle.click();
     await expect(content).not.toBeAttached();
 
     // Expand.
-    await header.click();
+    await collapseToggle.click();
     await expect(content).toBeVisible();
   });
 
@@ -2209,13 +2213,13 @@ test.describe("diff view", () => {
     await page.getByRole("button", { name: "Collapse all diffs" }).click();
 
     await expect(page.locator(".diff-file .file-content")).toHaveCount(0);
-    await expect(page.locator(".diff-file .file-header[title='Expand file']")).toHaveCount(4);
+    await expect(page.locator(".diff-file .file-collapse-toggle[title='Expand file']")).toHaveCount(4);
     await expect(page.getByRole("button", { name: "Expand all diffs" })).toBeVisible();
 
     await page.getByRole("button", { name: "Expand all diffs" }).click();
 
     await expect(page.locator(".diff-file .file-content")).toHaveCount(4);
-    await expect(page.locator(".diff-file .file-header[title='Collapse file']")).toHaveCount(4);
+    await expect(page.locator(".diff-file .file-collapse-toggle[title='Collapse file']")).toHaveCount(4);
   });
 
   test("toolbar keeps file filters inline and moves display settings into the menu", async ({ page }) => {
@@ -2928,7 +2932,7 @@ test.describe("diff view", () => {
     expect(headerBounds.y).toBeGreaterThanOrEqual(bannerBounds.y + bannerBounds.height);
 
     await expect(firstContent).toBeAttached();
-    await firstHeader.click();
+    await firstFile.locator(".file-collapse-toggle").click();
     await expect(firstContent).not.toBeAttached();
 
     fixture = smallDiff;
@@ -3948,7 +3952,7 @@ test.describe("diff view performance", () => {
     await expect(firstFile.locator(".file-content")).toBeAttached();
 
     // Collapse.
-    await firstFile.locator(".file-header").click();
+    await firstFile.locator(".file-collapse-toggle").click();
     await expect(firstFile.locator(".file-content")).not.toBeAttached();
 
     // Other files still have their content.

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -2218,6 +2218,57 @@ test.describe("diff view", () => {
     await expect(page.locator(".file-path-copy-status")).toHaveText("Copied");
   });
 
+  test("confirms a truncated shell-unsafe path before copying it", async ({ page, context, browserName }) => {
+    test.skip(browserName !== "chromium", "Clipboard read assertions require Chromium permissions");
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+    const path = `src/${"a".repeat(240)};$(hidden-command).ts`;
+    const unsafeDiff: DiffResult = {
+      ...smallDiff,
+      files: smallDiff.files.map((file, index) => (index === 0 ? { ...file, path, old_path: path } : file)),
+    };
+    await mockDiffApi(page, unsafeDiff);
+    await navigateToDiff(page);
+    await waitForDiffLoaded(page);
+    await page.evaluate(() => navigator.clipboard.writeText("unchanged"));
+
+    const pathButton = page.locator(`.diff-file[data-file-path="${path}"] .file-path`);
+    await expect
+      .poll(() =>
+        pathButton.evaluate((element) => {
+          const style = getComputedStyle(element);
+          return {
+            overflowing: element.scrollWidth > element.clientWidth,
+            overflow: style.overflow,
+            textOverflow: style.textOverflow,
+            whiteSpace: style.whiteSpace,
+          };
+        }),
+      )
+      .toEqual({
+        overflowing: true,
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+        whiteSpace: "nowrap",
+      });
+
+    let confirmationMessage = "";
+    page.once("dialog", async (dialog) => {
+      confirmationMessage = dialog.message();
+      await dialog.dismiss();
+    });
+    await pathButton.click();
+
+    expect(confirmationMessage).toContain(path);
+    await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe("unchanged");
+
+    page.once("dialog", async (dialog) => {
+      await dialog.accept();
+    });
+    await pathButton.click();
+
+    await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe(path);
+  });
+
   test("more menu collapses and expands all visible diffs", async ({ page }) => {
     await mockDiffApi(page, smallDiff);
     await navigateToDiff(page);

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -2269,6 +2269,44 @@ test.describe("diff view", () => {
     await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe(path);
   });
 
+  test("confirms an option-shaped path before preserving it on the clipboard", async ({
+    page,
+    context,
+    browserName,
+  }) => {
+    test.skip(browserName !== "chromium", "Clipboard read assertions require Chromium permissions");
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+    const path = "--output=.git/config";
+    const optionShapedDiff: DiffResult = {
+      ...smallDiff,
+      files: smallDiff.files.map((file, index) => (index === 0 ? { ...file, path, old_path: path } : file)),
+    };
+    await mockDiffApi(page, optionShapedDiff);
+    await navigateToDiff(page);
+    await waitForDiffLoaded(page);
+    await page.evaluate(() => navigator.clipboard.writeText("unchanged"));
+
+    const pathButton = page.locator(`.diff-file[data-file-path="${path}"] .file-path`);
+    let confirmationMessage = "";
+    page.once("dialog", async (dialog) => {
+      confirmationMessage = dialog.message();
+      await dialog.dismiss();
+    });
+
+    await pathButton.click();
+
+    expect(confirmationMessage).toContain(path);
+    expect(confirmationMessage).toContain("pass -- before the path or prefix it with ./");
+    await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe("unchanged");
+
+    page.once("dialog", async (dialog) => {
+      await dialog.accept();
+    });
+    await pathButton.click();
+
+    await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe(path);
+  });
+
   test("concealed path characters remain escaped and cannot reach the clipboard", async ({
     page,
     context,

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -2202,6 +2202,22 @@ test.describe("diff view", () => {
     await expect(content).toBeVisible();
   });
 
+  test("clicking a file path writes the exact path to the clipboard", async ({ page, context, browserName }) => {
+    test.skip(browserName !== "chromium", "Clipboard read assertions require Chromium permissions");
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+    await mockDiffApi(page, smallDiff);
+    await navigateToDiff(page);
+    await waitForDiffLoaded(page);
+
+    const path = "internal/server/handler.go";
+    const pathButton = page.locator(`.diff-file[data-file-path="${path}"] .file-path`);
+    await pathButton.click();
+
+    await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe(path);
+    await expect(pathButton).toHaveAttribute("title", "Copied!");
+    await expect(page.locator(".file-path-copy-status")).toHaveText("Copied");
+  });
+
   test("more menu collapses and expands all visible diffs", async ({ page }) => {
     await mockDiffApi(page, smallDiff);
     await navigateToDiff(page);

--- a/packages/ui/src/components/diff/DiffFile.svelte
+++ b/packages/ui/src/components/diff/DiffFile.svelte
@@ -268,7 +268,7 @@
   }
 
   function isConcealedCharacter(character: string): boolean {
-    return /[\p{Cc}\p{Cf}\p{Cs}\u2028\u2029]/u.test(character);
+    return /[\p{Cc}\p{Cf}\p{Cs}\p{Default_Ignorable_Code_Point}\u2028\u2029]/u.test(character);
   }
 
   function supportsRichPreview(path: string): boolean {
@@ -775,6 +775,11 @@
 
   .file-path--deleted {
     text-decoration: line-through;
+  }
+
+  .file-path--deleted:hover,
+  .file-path--deleted:focus-visible {
+    text-decoration: line-through underline;
   }
 
   .file-stats {

--- a/packages/ui/src/components/diff/DiffFile.svelte
+++ b/packages/ui/src/components/diff/DiffFile.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { DiffLineAnnotation, SelectedLineRange, Virtualizer } from "@pierre/diffs";
-  import { mount, onDestroy, onMount, unmount } from "svelte";
+  import { mount, onMount, unmount } from "svelte";
   import type { DiffFile as DiffFileType } from "../../api/types.js";
   import type { DiffReviewDraftComment } from "../../stores/diff-review-draft.svelte.js";
   import type { DiffReviewLineRange } from "../../stores/diff-review-draft.svelte.js";
@@ -9,7 +9,7 @@
   import DiffReviewDraftInlineComment from "./DiffReviewDraftInlineComment.svelte";
   import DiffReviewThreadInlineComment from "./DiffReviewThreadInlineComment.svelte";
   import DiffRichPreview from "./DiffRichPreview.svelte";
-  import { copyToClipboard, DiffStats } from "@kenn-io/kit-ui";
+  import { CopyButton, DiffStats } from "@kenn-io/kit-ui";
   import {
     reviewThreadTargetLine,
     reviewThreadTargetSide,
@@ -83,10 +83,6 @@
   // fires synchronously for on-screen files.
   let fileEl: HTMLDivElement | undefined = $state();
   let inViewport = $state(false);
-  let copiedPath = $state(false);
-  let copiedPathTimeout: ReturnType<typeof setTimeout> | undefined;
-  const pathContainsConcealedCharacters = $derived(containsConcealedCharacters(file.path));
-  const displayedPath = $derived(displayPath(file));
   type MountedAnnotation = {
     component?: object;
     observer?: MutationObserver;
@@ -186,24 +182,8 @@
     };
   });
 
-  onDestroy(() => {
-    if (copiedPathTimeout !== undefined) clearTimeout(copiedPathTimeout);
-  });
-
   function toggle(): void {
     diffStore.toggleFileCollapsed(owner, name, number, file.path);
-  }
-
-  async function copyPath(): Promise<void> {
-    if (pathContainsConcealedCharacters) return;
-    if (pathContainsShellUnsafeCharacters(file.path) && !confirmShellUnsafePathCopy(file.path)) return;
-    if (!(await copyToClipboard(file.path))) return;
-    copiedPath = true;
-    if (copiedPathTimeout !== undefined) clearTimeout(copiedPathTimeout);
-    copiedPathTimeout = setTimeout(() => {
-      copiedPath = false;
-      copiedPathTimeout = undefined;
-    }, 1500);
   }
 
   async function loadDiffText(side: "old" | "new"): Promise<string> {
@@ -221,76 +201,10 @@
   }
 
   function displayPath(f: DiffFileType): string {
-    const path = escapeConcealedCharacters(f.path);
     if (f.status === "renamed" && f.old_path !== f.path) {
-      return `${escapeConcealedCharacters(f.old_path)} -> ${path}`;
+      return `${f.old_path} -> ${f.path}`;
     }
-    return path;
-  }
-
-  function containsConcealedCharacters(path: string): boolean {
-    return Array.from(path).some((character) => isConcealedCharacter(character));
-  }
-
-  function pathContainsShellUnsafeCharacters(path: string): boolean {
-    return path.startsWith("-") || pathLooksLikeShellAssignment(path) || pathContainsShellSyntaxCharacters(path);
-  }
-
-  function pathLooksLikeShellAssignment(path: string): boolean {
-    return /^[\p{L}_][\p{L}\p{M}\p{N}_]*(?:\+)?=/u.test(path);
-  }
-
-  function pathContainsShellSyntaxCharacters(path: string): boolean {
-    return /[^\p{L}\p{M}\p{N}._@:+,=/-]/u.test(path);
-  }
-
-  function confirmShellUnsafePathCopy(path: string): boolean {
-    const guidance: string[] = [];
-    if (pathContainsShellSyntaxCharacters(path)) {
-      guidance.push("Quote or escape the entire path for your shell before using it in a terminal.");
-    }
-    if (path.startsWith("-")) {
-      guidance.push(
-        "When passing this path to a command, place -- before it or prefix it with ./ so it is treated as a file operand.",
-      );
-    }
-    if (pathLooksLikeShellAssignment(path)) {
-      guidance.push(
-        "Do not paste this path before a command name; pass it as an argument after the command instead.",
-      );
-    }
-    return window.confirm(
-      `This file path contains characters that may be unsafe to paste into a terminal.\n\nReview the full path before copying:\n${escapeConcealedCharacters(path)}\n\n${guidance.join("\n\n")}\n\nCopy it anyway?`,
-    );
-  }
-
-  function escapeConcealedCharacters(path: string): string {
-    return Array.from(path, (character) => {
-      if (!isConcealedCharacter(character)) return character;
-      switch (character) {
-        case "\0":
-          return "\\0";
-        case "\b":
-          return "\\b";
-        case "\t":
-          return "\\t";
-        case "\n":
-          return "\\n";
-        case "\v":
-          return "\\v";
-        case "\f":
-          return "\\f";
-        case "\r":
-          return "\\r";
-      }
-      const codePoint = character.codePointAt(0) ?? 0;
-      const hex = codePoint.toString(16).padStart(4, "0");
-      return codePoint <= 0xffff ? `\\u${hex}` : `\\u{${hex}}`;
-    }).join("");
-  }
-
-  function isConcealedCharacter(character: string): boolean {
-    return /[\p{Cc}\p{Cf}\p{Cs}\p{Default_Ignorable_Code_Point}\u2028\u2029]/u.test(character);
+    return f.path;
   }
 
   function supportsRichPreview(path: string): boolean {
@@ -613,30 +527,26 @@
         <path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
       </svg>
     </button>
-    <button
-      type="button"
+    <span
       class="file-path"
-      class:file-path--copied={copiedPath}
       class:file-path--deleted={file.status === "deleted"}
-      class:file-path--unsafe={pathContainsConcealedCharacters}
-      onclick={copyPath}
-      aria-disabled={pathContainsConcealedCharacters}
-      aria-label={pathContainsConcealedCharacters
-        ? `Cannot copy file path containing concealed characters: ${displayedPath}`
-        : copiedPath
-          ? `Copied file path ${file.path}`
-          : `Copy file path ${file.path}`}
-      title={pathContainsConcealedCharacters
-        ? "Cannot copy a path containing concealed characters"
-        : copiedPath
-          ? "Copied!"
-          : "Copy file path"}
     >
-      {displayedPath}
-    </button>
-    {#if copiedPath}
-      <span class="file-path-copy-status" role="status" aria-live="polite">Copied</span>
-    {/if}
+      {displayPath(file)}
+    </span>
+    <!--
+      Copying repository metadata is not code execution or a security boundary.
+      Preserve the provider's filename exactly; interpretation after paste belongs
+      to the destination explicitly chosen by the user. Do not filter, quote,
+      escape, or add shell-specific confirmation here.
+    -->
+    <CopyButton
+      class="file-path-copy"
+      text={file.path}
+      ariaLabel={`Copy file path ${file.path}`}
+      copiedAriaLabel={`Copied file path ${file.path}`}
+      title="Copy file path"
+      copiedTitle="Copied!"
+    />
     <span class="file-stats">
       <DiffStats
         additions={file.additions}
@@ -752,15 +662,9 @@
   }
 
   .file-path {
-    appearance: none;
-    padding: 0;
-    border: 0;
-    background: transparent;
     font-family: var(--font-mono);
     font-size: var(--font-size-sm);
     color: var(--diff-text);
-    text-align: left;
-    cursor: copy;
     flex: 1;
     min-width: 0;
     overflow: hidden;
@@ -768,40 +672,8 @@
     white-space: nowrap;
   }
 
-  .file-path:hover,
-  .file-path:focus-visible {
-    text-decoration: underline;
-    text-underline-offset: 2px;
-  }
-
-  .file-path:focus-visible {
-    outline: 1px solid var(--border-strong);
-    outline-offset: 2px;
-    border-radius: var(--radius-sm);
-  }
-
-  .file-path--copied {
-    color: var(--accent-green);
-  }
-
-  .file-path--unsafe {
-    color: var(--text-muted);
-    cursor: not-allowed;
-  }
-
-  .file-path-copy-status {
-    flex-shrink: 0;
-    color: var(--accent-green);
-    font-size: var(--font-size-xs);
-  }
-
   .file-path--deleted {
     text-decoration: line-through;
-  }
-
-  .file-path--deleted:hover,
-  .file-path--deleted:focus-visible {
-    text-decoration: line-through underline;
   }
 
   .file-stats {

--- a/packages/ui/src/components/diff/DiffFile.svelte
+++ b/packages/ui/src/components/diff/DiffFile.svelte
@@ -85,6 +85,8 @@
   let inViewport = $state(false);
   let copiedPath = $state(false);
   let copiedPathTimeout: ReturnType<typeof setTimeout> | undefined;
+  const pathContainsConcealedCharacters = $derived(containsConcealedCharacters(file.path));
+  const displayedPath = $derived(displayPath(file));
   type MountedAnnotation = {
     component?: object;
     observer?: MutationObserver;
@@ -193,6 +195,7 @@
   }
 
   async function copyPath(): Promise<void> {
+    if (pathContainsConcealedCharacters) return;
     if (!(await copyToClipboard(file.path))) return;
     copiedPath = true;
     if (copiedPathTimeout !== undefined) clearTimeout(copiedPathTimeout);
@@ -217,10 +220,44 @@
   }
 
   function displayPath(f: DiffFileType): string {
+    const path = escapeConcealedCharacters(f.path);
     if (f.status === "renamed" && f.old_path !== f.path) {
-      return `${f.old_path} -> ${f.path}`;
+      return `${escapeConcealedCharacters(f.old_path)} -> ${path}`;
     }
-    return f.path;
+    return path;
+  }
+
+  function containsConcealedCharacters(path: string): boolean {
+    return Array.from(path).some((character) => isConcealedCharacter(character));
+  }
+
+  function escapeConcealedCharacters(path: string): string {
+    return Array.from(path, (character) => {
+      if (!isConcealedCharacter(character)) return character;
+      switch (character) {
+        case "\0":
+          return "\\0";
+        case "\b":
+          return "\\b";
+        case "\t":
+          return "\\t";
+        case "\n":
+          return "\\n";
+        case "\v":
+          return "\\v";
+        case "\f":
+          return "\\f";
+        case "\r":
+          return "\\r";
+      }
+      const codePoint = character.codePointAt(0) ?? 0;
+      const hex = codePoint.toString(16).padStart(4, "0");
+      return codePoint <= 0xffff ? `\\u${hex}` : `\\u{${hex}}`;
+    }).join("");
+  }
+
+  function isConcealedCharacter(character: string): boolean {
+    return /[\p{Cc}\p{Cf}\p{Cs}\u2028\u2029]/u.test(character);
   }
 
   function supportsRichPreview(path: string): boolean {
@@ -548,12 +585,25 @@
       class="file-path"
       class:file-path--copied={copiedPath}
       class:file-path--deleted={file.status === "deleted"}
+      class:file-path--unsafe={pathContainsConcealedCharacters}
       onclick={copyPath}
-      aria-label={copiedPath ? `Copied file path ${file.path}` : `Copy file path ${file.path}`}
-      title={copiedPath ? "Copied!" : "Copy file path"}
+      aria-disabled={pathContainsConcealedCharacters}
+      aria-label={pathContainsConcealedCharacters
+        ? `Cannot copy file path containing concealed characters: ${displayedPath}`
+        : copiedPath
+          ? `Copied file path ${file.path}`
+          : `Copy file path ${file.path}`}
+      title={pathContainsConcealedCharacters
+        ? "Cannot copy a path containing concealed characters"
+        : copiedPath
+          ? "Copied!"
+          : "Copy file path"}
     >
-      {displayPath(file)}
+      {displayedPath}
     </button>
+    {#if copiedPath}
+      <span class="file-path-copy-status" role="status" aria-live="polite">Copied</span>
+    {/if}
     <span class="file-stats">
       <DiffStats
         additions={file.additions}
@@ -699,6 +749,17 @@
 
   .file-path--copied {
     color: var(--accent-green);
+  }
+
+  .file-path--unsafe {
+    color: var(--text-muted);
+    cursor: not-allowed;
+  }
+
+  .file-path-copy-status {
+    flex-shrink: 0;
+    color: var(--accent-green);
+    font-size: var(--font-size-xs);
   }
 
   .file-path--deleted {

--- a/packages/ui/src/components/diff/DiffFile.svelte
+++ b/packages/ui/src/components/diff/DiffFile.svelte
@@ -233,16 +233,34 @@
   }
 
   function pathContainsShellUnsafeCharacters(path: string): boolean {
-    return (
-      path.startsWith("-") ||
-      /^[\p{L}_][\p{L}\p{M}\p{N}_]*=/u.test(path) ||
-      /[^\p{L}\p{M}\p{N}._@:+,=/-]/u.test(path)
-    );
+    return path.startsWith("-") || pathLooksLikeShellAssignment(path) || pathContainsShellSyntaxCharacters(path);
+  }
+
+  function pathLooksLikeShellAssignment(path: string): boolean {
+    return /^[\p{L}_][\p{L}\p{M}\p{N}_]*(?:\+)?=/u.test(path);
+  }
+
+  function pathContainsShellSyntaxCharacters(path: string): boolean {
+    return /[^\p{L}\p{M}\p{N}._@:+,=/-]/u.test(path);
   }
 
   function confirmShellUnsafePathCopy(path: string): boolean {
+    const guidance: string[] = [];
+    if (pathContainsShellSyntaxCharacters(path)) {
+      guidance.push("Quote or escape the entire path for your shell before using it in a terminal.");
+    }
+    if (path.startsWith("-")) {
+      guidance.push(
+        "When passing this path to a command, place -- before it or prefix it with ./ so it is treated as a file operand.",
+      );
+    }
+    if (pathLooksLikeShellAssignment(path)) {
+      guidance.push(
+        "Do not paste this path before a command name; pass it as an argument after the command instead.",
+      );
+    }
     return window.confirm(
-      `This file path contains characters that may be unsafe to paste into a terminal.\n\nReview the full path before copying:\n${escapeConcealedCharacters(path)}\n\nWhen using a terminal, pass -- before the path or prefix it with ./ so it is treated as a file operand.\n\nCopy it anyway?`,
+      `This file path contains characters that may be unsafe to paste into a terminal.\n\nReview the full path before copying:\n${escapeConcealedCharacters(path)}\n\n${guidance.join("\n\n")}\n\nCopy it anyway?`,
     );
   }
 

--- a/packages/ui/src/components/diff/DiffFile.svelte
+++ b/packages/ui/src/components/diff/DiffFile.svelte
@@ -196,6 +196,7 @@
 
   async function copyPath(): Promise<void> {
     if (pathContainsConcealedCharacters) return;
+    if (pathContainsShellUnsafeCharacters(file.path) && !confirmShellUnsafePathCopy(file.path)) return;
     if (!(await copyToClipboard(file.path))) return;
     copiedPath = true;
     if (copiedPathTimeout !== undefined) clearTimeout(copiedPathTimeout);
@@ -229,6 +230,16 @@
 
   function containsConcealedCharacters(path: string): boolean {
     return Array.from(path).some((character) => isConcealedCharacter(character));
+  }
+
+  function pathContainsShellUnsafeCharacters(path: string): boolean {
+    return /[^\p{L}\p{M}\p{N}._@:+,=/-]/u.test(path);
+  }
+
+  function confirmShellUnsafePathCopy(path: string): boolean {
+    return window.confirm(
+      `This file path contains characters that may be unsafe to paste into a terminal.\n\nReview the full path before copying:\n${escapeConcealedCharacters(path)}\n\nCopy it anyway?`,
+    );
   }
 
   function escapeConcealedCharacters(path: string): string {

--- a/packages/ui/src/components/diff/DiffFile.svelte
+++ b/packages/ui/src/components/diff/DiffFile.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { DiffLineAnnotation, SelectedLineRange, Virtualizer } from "@pierre/diffs";
-  import { mount, onMount, unmount } from "svelte";
+  import { mount, onDestroy, onMount, unmount } from "svelte";
   import type { DiffFile as DiffFileType } from "../../api/types.js";
   import type { DiffReviewDraftComment } from "../../stores/diff-review-draft.svelte.js";
   import type { DiffReviewLineRange } from "../../stores/diff-review-draft.svelte.js";
@@ -9,7 +9,7 @@
   import DiffReviewDraftInlineComment from "./DiffReviewDraftInlineComment.svelte";
   import DiffReviewThreadInlineComment from "./DiffReviewThreadInlineComment.svelte";
   import DiffRichPreview from "./DiffRichPreview.svelte";
-  import { DiffStats } from "@kenn-io/kit-ui";
+  import { copyToClipboard, DiffStats } from "@kenn-io/kit-ui";
   import {
     reviewThreadTargetLine,
     reviewThreadTargetSide,
@@ -83,6 +83,8 @@
   // fires synchronously for on-screen files.
   let fileEl: HTMLDivElement | undefined = $state();
   let inViewport = $state(false);
+  let copiedPath = $state(false);
+  let copiedPathTimeout: ReturnType<typeof setTimeout> | undefined;
   type MountedAnnotation = {
     component?: object;
     observer?: MutationObserver;
@@ -182,8 +184,22 @@
     };
   });
 
+  onDestroy(() => {
+    if (copiedPathTimeout !== undefined) clearTimeout(copiedPathTimeout);
+  });
+
   function toggle(): void {
     diffStore.toggleFileCollapsed(owner, name, number, file.path);
+  }
+
+  async function copyPath(): Promise<void> {
+    if (!(await copyToClipboard(file.path))) return;
+    copiedPath = true;
+    if (copiedPathTimeout !== undefined) clearTimeout(copiedPathTimeout);
+    copiedPathTimeout = setTimeout(() => {
+      copiedPath = false;
+      copiedPathTimeout = undefined;
+    }, 1500);
   }
 
   async function loadDiffText(side: "old" | "new"): Promise<string> {
@@ -514,13 +530,30 @@
 </script>
 
 <div class="diff-file" data-file-path={file.path} bind:this={fileEl}>
-  <button class="file-header" onclick={toggle} title={collapsed ? "Expand file" : "Collapse file"}>
-    <svg class="collapse-chevron" class:collapse-chevron--collapsed={collapsed} width="12" height="12" viewBox="0 0 12 12" fill="none">
-      <path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    </svg>
-    <span class="file-path" class:file-path--deleted={file.status === "deleted"}>
+  <div class="file-header">
+    <button
+      type="button"
+      class="file-collapse-toggle"
+      onclick={toggle}
+      aria-label={collapsed ? "Expand file" : "Collapse file"}
+      aria-expanded={!collapsed}
+      title={collapsed ? "Expand file" : "Collapse file"}
+    >
+      <svg class="collapse-chevron" class:collapse-chevron--collapsed={collapsed} width="12" height="12" viewBox="0 0 12 12" fill="none">
+        <path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+    </button>
+    <button
+      type="button"
+      class="file-path"
+      class:file-path--copied={copiedPath}
+      class:file-path--deleted={file.status === "deleted"}
+      onclick={copyPath}
+      aria-label={copiedPath ? `Copied file path ${file.path}` : `Copy file path ${file.path}`}
+      title={copiedPath ? "Copied!" : "Copy file path"}
+    >
       {displayPath(file)}
-    </span>
+    </button>
     <span class="file-stats">
       <DiffStats
         additions={file.additions}
@@ -528,7 +561,7 @@
         dimZeros
       />
     </span>
-  </button>
+  </div>
   {#if !collapsed}
     <div class="file-content">
       {#if showRichPreview}
@@ -598,12 +631,32 @@
     border-bottom: 1px solid var(--diff-border);
     font-size: var(--font-size-sm);
     text-align: left;
-    cursor: pointer;
     color: var(--diff-text);
   }
 
   .file-header:hover {
     background: var(--bg-surface-hover);
+  }
+
+  .file-collapse-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    margin: -4px -6px;
+    flex: 0 0 24px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+  }
+
+  .file-collapse-toggle:focus-visible {
+    outline: 1px solid var(--border-strong);
+    outline-offset: 2px;
+    border-radius: var(--radius-sm);
   }
 
   .collapse-chevron {
@@ -616,14 +669,36 @@
   }
 
   .file-path {
+    appearance: none;
+    padding: 0;
+    border: 0;
+    background: transparent;
     font-family: var(--font-mono);
     font-size: var(--font-size-sm);
     color: var(--diff-text);
+    text-align: left;
+    cursor: copy;
     flex: 1;
     min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  .file-path:hover,
+  .file-path:focus-visible {
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+
+  .file-path:focus-visible {
+    outline: 1px solid var(--border-strong);
+    outline-offset: 2px;
+    border-radius: var(--radius-sm);
+  }
+
+  .file-path--copied {
+    color: var(--accent-green);
   }
 
   .file-path--deleted {

--- a/packages/ui/src/components/diff/DiffFile.svelte
+++ b/packages/ui/src/components/diff/DiffFile.svelte
@@ -233,12 +233,16 @@
   }
 
   function pathContainsShellUnsafeCharacters(path: string): boolean {
-    return /[^\p{L}\p{M}\p{N}._@:+,=/-]/u.test(path);
+    return (
+      path.startsWith("-") ||
+      /^[\p{L}_][\p{L}\p{M}\p{N}_]*=/u.test(path) ||
+      /[^\p{L}\p{M}\p{N}._@:+,=/-]/u.test(path)
+    );
   }
 
   function confirmShellUnsafePathCopy(path: string): boolean {
     return window.confirm(
-      `This file path contains characters that may be unsafe to paste into a terminal.\n\nReview the full path before copying:\n${escapeConcealedCharacters(path)}\n\nCopy it anyway?`,
+      `This file path contains characters that may be unsafe to paste into a terminal.\n\nReview the full path before copying:\n${escapeConcealedCharacters(path)}\n\nWhen using a terminal, pass -- before the path or prefix it with ./ so it is treated as a file operand.\n\nCopy it anyway?`,
     );
   }
 

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -90,12 +90,18 @@ afterAll(() => {
 
 import DiffFile from "./DiffFile.svelte";
 import diffRichPreviewSource from "./DiffRichPreview.svelte?raw";
+import { copyToClipboard } from "@kenn-io/kit-ui";
 import type { DiffFile as DiffFileType, FilePreview } from "../../api/types.js";
 import { STORES_KEY } from "../../context.js";
 import type { DiffReviewDraftComment, DiffReviewLineRange } from "../../stores/diff-review-draft.svelte.js";
 import { createDiffStore } from "../../stores/diff.svelte.js";
 import { renderedCodeSide } from "./pierre-dom.js";
 import type { ReviewThread } from "./review-thread-context.js";
+
+vi.mock("@kenn-io/kit-ui", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@kenn-io/kit-ui")>()),
+  copyToClipboard: vi.fn(() => Promise.resolve(true)),
+}));
 
 type LoadFilePreview = (
   owner: string,
@@ -343,6 +349,7 @@ function textPreview(path: string, text: string): FilePreview {
 
 describe("DiffFile", () => {
   afterEach(() => {
+    vi.mocked(copyToClipboard).mockClear();
     cleanup();
     localStorage.removeItem("diff-rich-preview");
     localStorage.removeItem("diff-view-mode");
@@ -360,6 +367,15 @@ describe("DiffFile", () => {
 
     expect(screen.getByText("src/foo.ts")).toBeTruthy();
     await expectPierreDiffText(/old linenew line/);
+  });
+
+  it("copies the title-bar file path without collapsing the diff", async () => {
+    renderDiffFile(makeFile());
+
+    await fireEvent.click(screen.getByRole("button", { name: "Copy file path src/foo.ts" }));
+
+    expect(copyToClipboard).toHaveBeenCalledWith("src/foo.ts");
+    expect(document.querySelector(".file-content")).toBeTruthy();
   });
 
   it("exposes stable line targets inside the Pierre shadow root", async () => {
@@ -566,9 +582,11 @@ describe("DiffFile", () => {
     renderDiffFile(makeFile());
 
     const header = screen.getByTitle("Collapse file");
+    expect(header.getAttribute("aria-expanded")).toBe("true");
     await fireEvent.click(header);
 
     expect(document.querySelector(".file-content")).toBeNull();
+    expect(header.getAttribute("aria-expanded")).toBe("false");
   });
 
   it("shows content again after toggling collapse twice", async () => {

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -392,7 +392,7 @@ describe("DiffFile", () => {
       await fireEvent.click(pathButton);
 
       expect(confirmSpy).toHaveBeenCalledWith(
-        `This file path contains characters that may be unsafe to paste into a terminal.\n\nReview the full path before copying:\n${path}\n\nCopy it anyway?`,
+        `This file path contains characters that may be unsafe to paste into a terminal.\n\nReview the full path before copying:\n${path}\n\nWhen using a terminal, pass -- before the path or prefix it with ./ so it is treated as a file operand.\n\nCopy it anyway?`,
       );
       expect(copyToClipboard).not.toHaveBeenCalled();
 
@@ -404,6 +404,26 @@ describe("DiffFile", () => {
       confirmSpy.mockRestore();
     }
   });
+
+  it.each(["-rf", "--output=.git/config", "CONFIG=payload"])(
+    "requires confirmation before copying an option- or assignment-shaped path: %s",
+    async (path) => {
+      const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+      try {
+        renderDiffFile(makeFile({ path, old_path: path }));
+        const pathButton = screen.getByRole("button", { name: `Copy file path ${path}` });
+
+        await fireEvent.click(pathButton);
+
+        expect(confirmSpy).toHaveBeenCalledWith(
+          `This file path contains characters that may be unsafe to paste into a terminal.\n\nReview the full path before copying:\n${path}\n\nWhen using a terminal, pass -- before the path or prefix it with ./ so it is treated as a file operand.\n\nCopy it anyway?`,
+        );
+        expect(copyToClipboard).not.toHaveBeenCalled();
+      } finally {
+        confirmSpy.mockRestore();
+      }
+    },
+  );
 
   it.each([
     ["control character", "\n", "\\n"],

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -409,6 +409,8 @@ describe("DiffFile", () => {
     ["control character", "\n", "\\n"],
     ["format character", "\u202e", "\\u202e"],
     ["unpaired surrogate", "\ud800", "\\ud800"],
+    ["variation selector", "\ufe0f", "\\ufe0f"],
+    ["supplementary variation selector", "\u{e0100}", "\\u{e0100}"],
     ["line separator", "\u2028", "\\u2028"],
     ["paragraph separator", "\u2029", "\\u2029"],
   ])("refuses to copy paths with a concealed %s", async (_description, character, escapedCharacter) => {

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -392,7 +392,7 @@ describe("DiffFile", () => {
       await fireEvent.click(pathButton);
 
       expect(confirmSpy).toHaveBeenCalledWith(
-        `This file path contains characters that may be unsafe to paste into a terminal.\n\nReview the full path before copying:\n${path}\n\nWhen using a terminal, pass -- before the path or prefix it with ./ so it is treated as a file operand.\n\nCopy it anyway?`,
+        `This file path contains characters that may be unsafe to paste into a terminal.\n\nReview the full path before copying:\n${path}\n\nQuote or escape the entire path for your shell before using it in a terminal.\n\nCopy it anyway?`,
       );
       expect(copyToClipboard).not.toHaveBeenCalled();
 
@@ -405,8 +405,8 @@ describe("DiffFile", () => {
     }
   });
 
-  it.each(["-rf", "--output=.git/config", "CONFIG=payload"])(
-    "requires confirmation before copying an option- or assignment-shaped path: %s",
+  it.each(["-rf", "--output=.git/config"])(
+    "requires confirmation before copying an option-shaped path: %s",
     async (path) => {
       const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
       try {
@@ -416,7 +416,27 @@ describe("DiffFile", () => {
         await fireEvent.click(pathButton);
 
         expect(confirmSpy).toHaveBeenCalledWith(
-          `This file path contains characters that may be unsafe to paste into a terminal.\n\nReview the full path before copying:\n${path}\n\nWhen using a terminal, pass -- before the path or prefix it with ./ so it is treated as a file operand.\n\nCopy it anyway?`,
+          `This file path contains characters that may be unsafe to paste into a terminal.\n\nReview the full path before copying:\n${path}\n\nWhen passing this path to a command, place -- before it or prefix it with ./ so it is treated as a file operand.\n\nCopy it anyway?`,
+        );
+        expect(copyToClipboard).not.toHaveBeenCalled();
+      } finally {
+        confirmSpy.mockRestore();
+      }
+    },
+  );
+
+  it.each(["CONFIG=payload", "PROMPT_COMMAND+=src/payload"])(
+    "requires confirmation before copying an assignment-shaped path: %s",
+    async (path) => {
+      const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+      try {
+        renderDiffFile(makeFile({ path, old_path: path }));
+        const pathButton = screen.getByRole("button", { name: `Copy file path ${path}` });
+
+        await fireEvent.click(pathButton);
+
+        expect(confirmSpy).toHaveBeenCalledWith(
+          `This file path contains characters that may be unsafe to paste into a terminal.\n\nReview the full path before copying:\n${path}\n\nDo not paste this path before a command name; pass it as an argument after the command instead.\n\nCopy it anyway?`,
         );
         expect(copyToClipboard).not.toHaveBeenCalled();
       } finally {

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -375,7 +375,31 @@ describe("DiffFile", () => {
     await fireEvent.click(screen.getByRole("button", { name: "Copy file path src/foo.ts" }));
 
     expect(copyToClipboard).toHaveBeenCalledWith("src/foo.ts");
+    const copyStatus = document.querySelector(".file-path-copy-status");
+    expect(copyStatus?.textContent).toBe("Copied");
+    expect(copyStatus?.getAttribute("role")).toBe("status");
+    expect(copyStatus?.getAttribute("aria-live")).toBe("polite");
     expect(document.querySelector(".file-content")).toBeTruthy();
+  });
+
+  it.each([
+    ["control character", "\n", "\\n"],
+    ["format character", "\u202e", "\\u202e"],
+    ["unpaired surrogate", "\ud800", "\\ud800"],
+    ["line separator", "\u2028", "\\u2028"],
+    ["paragraph separator", "\u2029", "\\u2029"],
+  ])("refuses to copy paths with a concealed %s", async (_description, character, escapedCharacter) => {
+    const path = `src/safe.ts${character}payload`;
+    renderDiffFile(makeFile({ path, old_path: path }));
+
+    const pathButton = screen.getByRole("button", {
+      name: `Cannot copy file path containing concealed characters: src/safe.ts${escapedCharacter}payload`,
+    });
+    await fireEvent.click(pathButton);
+
+    expect(pathButton.textContent?.trim()).toBe(`src/safe.ts${escapedCharacter}payload`);
+    expect(pathButton.getAttribute("aria-disabled")).toBe("true");
+    expect(copyToClipboard).not.toHaveBeenCalled();
   });
 
   it("exposes stable line targets inside the Pierre shadow root", async () => {

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -382,6 +382,29 @@ describe("DiffFile", () => {
     expect(document.querySelector(".file-content")).toBeTruthy();
   });
 
+  it("requires confirmation before copying a shell-unsafe path", async () => {
+    const path = `src/${"a".repeat(180)};$(hidden-command).ts`;
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+    try {
+      renderDiffFile(makeFile({ path, old_path: path }));
+      const pathButton = screen.getByRole("button", { name: `Copy file path ${path}` });
+
+      await fireEvent.click(pathButton);
+
+      expect(confirmSpy).toHaveBeenCalledWith(
+        `This file path contains characters that may be unsafe to paste into a terminal.\n\nReview the full path before copying:\n${path}\n\nCopy it anyway?`,
+      );
+      expect(copyToClipboard).not.toHaveBeenCalled();
+
+      confirmSpy.mockReturnValue(true);
+      await fireEvent.click(pathButton);
+
+      expect(copyToClipboard).toHaveBeenCalledWith(path);
+    } finally {
+      confirmSpy.mockRestore();
+    }
+  });
+
   it.each([
     ["control character", "\n", "\\n"],
     ["format character", "\u202e", "\\u202e"],

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -90,18 +90,12 @@ afterAll(() => {
 
 import DiffFile from "./DiffFile.svelte";
 import diffRichPreviewSource from "./DiffRichPreview.svelte?raw";
-import { copyToClipboard } from "@kenn-io/kit-ui";
 import type { DiffFile as DiffFileType, FilePreview } from "../../api/types.js";
 import { STORES_KEY } from "../../context.js";
 import type { DiffReviewDraftComment, DiffReviewLineRange } from "../../stores/diff-review-draft.svelte.js";
 import { createDiffStore } from "../../stores/diff.svelte.js";
 import { renderedCodeSide } from "./pierre-dom.js";
 import type { ReviewThread } from "./review-thread-context.js";
-
-vi.mock("@kenn-io/kit-ui", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@kenn-io/kit-ui")>()),
-  copyToClipboard: vi.fn(() => Promise.resolve(true)),
-}));
 
 type LoadFilePreview = (
   owner: string,
@@ -349,7 +343,6 @@ function textPreview(path: string, text: string): FilePreview {
 
 describe("DiffFile", () => {
   afterEach(() => {
-    vi.mocked(copyToClipboard).mockClear();
     cleanup();
     localStorage.removeItem("diff-rich-preview");
     localStorage.removeItem("diff-view-mode");
@@ -369,102 +362,31 @@ describe("DiffFile", () => {
     await expectPierreDiffText(/old linenew line/);
   });
 
-  it("copies the title-bar file path without collapsing the diff", async () => {
-    renderDiffFile(makeFile());
+  it("copies the exact title-bar file path from a dedicated copy button", async () => {
+    const path = "PROMPT_COMMAND+=src/payload;$(hidden-command).ts";
+    const originalClipboard = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+    const writeText = vi.fn(() => Promise.resolve());
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
 
-    await fireEvent.click(screen.getByRole("button", { name: "Copy file path src/foo.ts" }));
-
-    expect(copyToClipboard).toHaveBeenCalledWith("src/foo.ts");
-    const copyStatus = document.querySelector(".file-path-copy-status");
-    expect(copyStatus?.textContent).toBe("Copied");
-    expect(copyStatus?.getAttribute("role")).toBe("status");
-    expect(copyStatus?.getAttribute("aria-live")).toBe("polite");
-    expect(document.querySelector(".file-content")).toBeTruthy();
-  });
-
-  it("requires confirmation before copying a shell-unsafe path", async () => {
-    const path = `src/${"a".repeat(180)};$(hidden-command).ts`;
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
     try {
       renderDiffFile(makeFile({ path, old_path: path }));
-      const pathButton = screen.getByRole("button", { name: `Copy file path ${path}` });
 
-      await fireEvent.click(pathButton);
+      const pathLabel = screen.getByText(path);
+      expect(pathLabel.tagName).toBe("SPAN");
+      await fireEvent.click(screen.getByRole("button", { name: `Copy file path ${path}` }));
 
-      expect(confirmSpy).toHaveBeenCalledWith(
-        `This file path contains characters that may be unsafe to paste into a terminal.\n\nReview the full path before copying:\n${path}\n\nQuote or escape the entire path for your shell before using it in a terminal.\n\nCopy it anyway?`,
-      );
-      expect(copyToClipboard).not.toHaveBeenCalled();
-
-      confirmSpy.mockReturnValue(true);
-      await fireEvent.click(pathButton);
-
-      expect(copyToClipboard).toHaveBeenCalledWith(path);
+      expect(writeText).toHaveBeenCalledWith(path);
+      expect(document.querySelector(".file-content")).toBeTruthy();
     } finally {
-      confirmSpy.mockRestore();
+      if (originalClipboard) {
+        Object.defineProperty(navigator, "clipboard", originalClipboard);
+      } else {
+        delete (navigator as Navigator & { clipboard?: Clipboard }).clipboard;
+      }
     }
-  });
-
-  it.each(["-rf", "--output=.git/config"])(
-    "requires confirmation before copying an option-shaped path: %s",
-    async (path) => {
-      const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
-      try {
-        renderDiffFile(makeFile({ path, old_path: path }));
-        const pathButton = screen.getByRole("button", { name: `Copy file path ${path}` });
-
-        await fireEvent.click(pathButton);
-
-        expect(confirmSpy).toHaveBeenCalledWith(
-          `This file path contains characters that may be unsafe to paste into a terminal.\n\nReview the full path before copying:\n${path}\n\nWhen passing this path to a command, place -- before it or prefix it with ./ so it is treated as a file operand.\n\nCopy it anyway?`,
-        );
-        expect(copyToClipboard).not.toHaveBeenCalled();
-      } finally {
-        confirmSpy.mockRestore();
-      }
-    },
-  );
-
-  it.each(["CONFIG=payload", "PROMPT_COMMAND+=src/payload"])(
-    "requires confirmation before copying an assignment-shaped path: %s",
-    async (path) => {
-      const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
-      try {
-        renderDiffFile(makeFile({ path, old_path: path }));
-        const pathButton = screen.getByRole("button", { name: `Copy file path ${path}` });
-
-        await fireEvent.click(pathButton);
-
-        expect(confirmSpy).toHaveBeenCalledWith(
-          `This file path contains characters that may be unsafe to paste into a terminal.\n\nReview the full path before copying:\n${path}\n\nDo not paste this path before a command name; pass it as an argument after the command instead.\n\nCopy it anyway?`,
-        );
-        expect(copyToClipboard).not.toHaveBeenCalled();
-      } finally {
-        confirmSpy.mockRestore();
-      }
-    },
-  );
-
-  it.each([
-    ["control character", "\n", "\\n"],
-    ["format character", "\u202e", "\\u202e"],
-    ["unpaired surrogate", "\ud800", "\\ud800"],
-    ["variation selector", "\ufe0f", "\\ufe0f"],
-    ["supplementary variation selector", "\u{e0100}", "\\u{e0100}"],
-    ["line separator", "\u2028", "\\u2028"],
-    ["paragraph separator", "\u2029", "\\u2029"],
-  ])("refuses to copy paths with a concealed %s", async (_description, character, escapedCharacter) => {
-    const path = `src/safe.ts${character}payload`;
-    renderDiffFile(makeFile({ path, old_path: path }));
-
-    const pathButton = screen.getByRole("button", {
-      name: `Cannot copy file path containing concealed characters: src/safe.ts${escapedCharacter}payload`,
-    });
-    await fireEvent.click(pathButton);
-
-    expect(pathButton.textContent?.trim()).toBe(`src/safe.ts${escapedCharacter}payload`);
-    expect(pathButton.getAttribute("aria-disabled")).toBe("true");
-    expect(copyToClipboard).not.toHaveBeenCalled();
   });
 
   it("exposes stable line targets inside the Pierre shadow root", async () => {


### PR DESCRIPTION
Diff file paths in the main viewer were display-only, making it cumbersome to reuse a path while reviewing a change.

- Click a file path in the diff title bar to copy the exact current path with transient feedback.
- Keep collapse and expand as a separate accessible control with explicit state and a practical hit target.