### PR TITLE
test: isolate Git configuration per test binary

### DIFF
--- a/context/testing.md
+++ b/context/testing.md
@@ -291,6 +291,10 @@ Disable Git auto-GC and auto-maintenance in synthetic repositories under
 `t.TempDir`; detached maintenance can recreate files during fixture cleanup
 (`internal/gitclone/commits_test.go::commitTestRun`).
 
+Real-Git test packages use `gitsafe.RunIsolatedMain` in `TestMain`: one empty config per binary.
+Use `Runner` where code strips Git variables, and `MutableRunner` only for global config
+mutations (`internal/testutil/gitsafe/gitsafe.go::RunIsolatedMain`).
+
 Real tmux and PTY tests can still run in parallel when each test owns its
 session names, temp dirs, sockets, and cleanup. If the bottleneck is external
 resource pressure rather than correctness, keep `t.Parallel()` and gate the

--- a/internal/docs/folder.go
+++ b/internal/docs/folder.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync"
 
+	gitcmd "go.kenn.io/kit/git/cmd"
 	"go.kenn.io/middleman/internal/config"
 )
 
@@ -109,13 +110,23 @@ type Registry struct {
 	folders []config.DocFolder
 	byID    map[string]config.DocFolder
 	writeMu sync.Mutex
+	gitBase gitcmd.Runner
+}
+
+type RegistryOption func(*Registry)
+
+// WithGitRunner overrides the Git environment used by this registry.
+func WithGitRunner(runner gitcmd.Runner) RegistryOption {
+	return func(registry *Registry) {
+		registry.gitBase = runner
+	}
 }
 
 // NewRegistry returns a Registry over the given folders. Paths are
 // resolved through filepath.EvalSymlinks so that path-safety checks
 // compare apples to apples on platforms (macOS) where the TempDir and
 // real path differ via a top-level symlink.
-func NewRegistry(folders []config.DocFolder) *Registry {
+func NewRegistry(folders []config.DocFolder, options ...RegistryOption) *Registry {
 	resolved := make([]config.DocFolder, 0, len(folders))
 	byID := make(map[string]config.DocFolder, len(folders))
 	for _, v := range folders {
@@ -125,14 +136,22 @@ func NewRegistry(folders []config.DocFolder) *Registry {
 		resolved = append(resolved, v)
 		byID[v.ID] = v
 	}
-	return &Registry{folders: resolved, byID: byID}
+	registry := &Registry{
+		folders: resolved,
+		byID:    byID,
+		gitBase: docsGitBase(),
+	}
+	for _, option := range options {
+		option(registry)
+	}
+	return registry
 }
 
 // Replace swaps the registered folder snapshot in place. Readers keep a
 // consistent view through the registry mutex, and ongoing file operations
 // that already resolved a folder continue against that resolved path.
 func (r *Registry) Replace(folders []config.DocFolder) {
-	next := NewRegistry(folders)
+	next := NewRegistry(folders, WithGitRunner(r.gitBase))
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.folders = next.folders

--- a/internal/docs/git.go
+++ b/internal/docs/git.go
@@ -26,9 +26,12 @@ import (
 // supported customization surface is gitconfig (core.sshCommand,
 // user.name/user.email, credential.helper). Unlike gitcmd.New(), global
 // and system config stay readable: docs commits rely on the maintainer's
-// identity, filters, and credential helpers. A package variable so tests
-// can substitute fully isolated config.
-var docsGitBase = gitcmd.Runner{Env: stripDocsSecretEnv(os.Environ()), StripEnv: true}
+// identity, filters, and credential helpers. Build it when a command runs so
+// package TestMain isolation is visible instead of snapshotting the host
+// environment during package initialization.
+func docsGitBase() gitcmd.Runner {
+	return gitcmd.Runner{Env: stripDocsSecretEnv(os.Environ()), StripEnv: true}
+}
 
 // emptyHooksDir is an empty directory used as core.hooksPath so that
 // hooks shipped inside a docs folder's .git/hooks (or pointed to by a
@@ -58,12 +61,12 @@ var emptyHooksDir = sync.OnceValues(func() (string, error) {
 // gpg.program for signed commits, credential.helper, core.sshCommand) is
 // left intact because disabling it would break real workflows; treat
 // such repos as trusted before registering them as docs folders.
-func docsGitRunner() (gitcmd.Runner, error) {
+func docsGitRunner(base gitcmd.Runner) (gitcmd.Runner, error) {
 	hooksDir, err := emptyHooksDir()
 	if err != nil {
 		return gitcmd.Runner{}, fmt.Errorf("creating empty git hooks dir: %w", err)
 	}
-	return docsGitBase.
+	return base.
 		WithConfig("core.hooksPath", hooksDir).
 		WithConfig("core.fsmonitor", "false").
 		WithConfig("protocol.allow", "never").
@@ -77,8 +80,10 @@ func docsGitRunner() (gitcmd.Runner, error) {
 // runDocsGit runs one git command against a docs folder root under the
 // shared subprocess limiter. Failures unwrap to *gitcmd.GitError, whose
 // message and Stderr field carry git's trimmed stderr.
-func runDocsGit(ctx context.Context, root string, stdin io.Reader, args ...string) ([]byte, error) {
-	runner, err := docsGitRunner()
+func (r *Registry) runGit(
+	ctx context.Context, root string, stdin io.Reader, args ...string,
+) ([]byte, error) {
+	runner, err := docsGitRunner(r.gitBase)
 	if err != nil {
 		return nil, err
 	}
@@ -170,10 +175,10 @@ func (r *Registry) GitStatus(ctx context.Context, folderID string) (GitStatusRes
 	if !isGitRepo(v.Path) {
 		return GitStatusResponse{IsRepo: false, Entries: []GitStatusEntry{}}, nil
 	}
-	if err := assertWorktreeAttributesSafe(ctx, v.Path); err != nil {
+	if err := r.assertWorktreeAttributesSafe(ctx, v.Path); err != nil {
 		return GitStatusResponse{}, err
 	}
-	entries, err := runGitStatus(ctx, v.Path)
+	entries, err := r.runGitStatus(ctx, v.Path)
 	if err != nil {
 		return GitStatusResponse{}, err
 	}
@@ -185,8 +190,8 @@ func isGitRepo(root string) bool {
 	return err == nil
 }
 
-func runGitStatus(ctx context.Context, root string) ([]GitStatusEntry, error) {
-	out, err := runDocsGit(ctx, root, nil,
+func (r *Registry) runGitStatus(ctx context.Context, root string) ([]GitStatusEntry, error) {
+	out, err := r.runGit(ctx, root, nil,
 		"-c", "color.status=false",
 		"status", "--porcelain=v1", "-z",
 		"--untracked-files=all",

--- a/internal/docs/git_publish.go
+++ b/internal/docs/git_publish.go
@@ -207,18 +207,18 @@ func (r *Registry) GitChanges(ctx context.Context, folderID string) (GitChangesR
 	// once the user submits. Command-bearing config does not execute
 	// during the status read itself (unlike filter attributes), so this
 	// gate is for signal parity, not read-time safety.
-	if err := assertSafeToPublish(ctx, v.Path); err != nil {
+	if err := r.assertSafeToPublish(ctx, v.Path); err != nil {
 		return GitChangesResponse{}, err
 	}
-	branch, err := currentBranch(ctx, v.Path)
+	branch, err := r.currentBranch(ctx, v.Path)
 	if err != nil {
 		return GitChangesResponse{}, err
 	}
-	upstream, _ := currentUpstream(ctx, v.Path, branch)
-	if err := assertWorktreeAttributesSafe(ctx, v.Path); err != nil {
+	upstream, _ := r.currentUpstream(ctx, v.Path, branch)
+	if err := r.assertWorktreeAttributesSafe(ctx, v.Path); err != nil {
 		return GitChangesResponse{}, err
 	}
-	records, err := readPorcelain(ctx, v.Path)
+	records, err := r.readPorcelain(ctx, v.Path)
 	if err != nil {
 		return GitChangesResponse{}, err
 	}
@@ -237,36 +237,36 @@ func (r *Registry) GitChanges(ctx context.Context, folderID string) (GitChangesR
 	}, nil
 }
 
-func currentBranch(ctx context.Context, root string) (string, error) {
-	out, err := runDocsGit(ctx, root, nil, "symbolic-ref", "--short", "HEAD")
+func (r *Registry) currentBranch(ctx context.Context, root string) (string, error) {
+	out, err := r.runGit(ctx, root, nil, "symbolic-ref", "--short", "HEAD")
 	if err != nil {
 		return "", fmt.Errorf("git symbolic-ref: %w", err)
 	}
 	return strings.TrimSpace(string(out)), nil
 }
 
-func currentUpstream(ctx context.Context, root, branch string) (string, error) {
-	out, err := runDocsGit(ctx, root, nil, "rev-parse", "--abbrev-ref", branch+"@{upstream}")
+func (r *Registry) currentUpstream(ctx context.Context, root, branch string) (string, error) {
+	out, err := r.runGit(ctx, root, nil, "rev-parse", "--abbrev-ref", branch+"@{upstream}")
 	if err != nil {
 		return "", err
 	}
 	return strings.TrimSpace(string(out)), nil
 }
 
-func currentUpstreamPushTarget(ctx context.Context, root, branch string) (remote, mergeRef string, err error) {
-	remoteOut, err := runDocsGit(ctx, root, nil, "config", "--get", "branch."+branch+".remote")
+func (r *Registry) currentUpstreamPushTarget(ctx context.Context, root, branch string) (remote, mergeRef string, err error) {
+	remoteOut, err := r.runGit(ctx, root, nil, "config", "--get", "branch."+branch+".remote")
 	if err != nil {
 		return "", "", err
 	}
-	mergeOut, err := runDocsGit(ctx, root, nil, "config", "--get", "branch."+branch+".merge")
+	mergeOut, err := r.runGit(ctx, root, nil, "config", "--get", "branch."+branch+".merge")
 	if err != nil {
 		return "", "", err
 	}
 	return strings.TrimSpace(string(remoteOut)), strings.TrimSpace(string(mergeOut)), nil
 }
 
-func readPorcelain(ctx context.Context, root string) ([]PorcelainRecord, error) {
-	out, err := runDocsGit(ctx, root, nil,
+func (r *Registry) readPorcelain(ctx context.Context, root string) ([]PorcelainRecord, error) {
+	out, err := r.runGit(ctx, root, nil,
 		"-c", "color.status=false",
 		"status", "--porcelain=v1", "-z",
 		"--untracked-files=all",
@@ -331,16 +331,16 @@ func (r *Registry) GitPublish(ctx context.Context, folderID, message string) (Pu
 	if strings.TrimSpace(message) == "" {
 		return PublishResponse{}, ErrEmptyMessage
 	}
-	if err := assertSafeToPublish(ctx, v.Path); err != nil {
+	if err := r.assertSafeToPublish(ctx, v.Path); err != nil {
 		return PublishResponse{}, err
 	}
 	// Gate attributes before git status: status rehashes modified tracked
 	// files through any configured filter, so a repo-controlled filter
 	// attribute must be rejected before status runs, not after.
-	if err := assertWorktreeAttributesSafe(ctx, v.Path); err != nil {
+	if err := r.assertWorktreeAttributesSafe(ctx, v.Path); err != nil {
 		return PublishResponse{}, err
 	}
-	records, err := readPorcelain(ctx, v.Path)
+	records, err := r.readPorcelain(ctx, v.Path)
 	if err != nil {
 		return PublishResponse{}, err
 	}
@@ -355,18 +355,18 @@ func (r *Registry) GitPublish(ctx context.Context, folderID, message string) (Pu
 	if len(publishable) == 0 {
 		return PublishResponse{}, ErrNoMarkdownChanges
 	}
-	branch, err := currentBranch(ctx, v.Path)
+	branch, err := r.currentBranch(ctx, v.Path)
 	if err != nil {
 		return PublishResponse{}, err
 	}
-	upstream, err := currentUpstream(ctx, v.Path, branch)
+	upstream, err := r.currentUpstream(ctx, v.Path, branch)
 	if err != nil || upstream == "" {
 		return PublishResponse{}, &NoUpstreamError{
 			Branch:           branch,
 			SuggestedCommand: fmt.Sprintf("git push -u origin %s", branch),
 		}
 	}
-	upstreamRemote, upstreamMergeRef, err := currentUpstreamPushTarget(ctx, v.Path, branch)
+	upstreamRemote, upstreamMergeRef, err := r.currentUpstreamPushTarget(ctx, v.Path, branch)
 	if err != nil || upstreamRemote == "" || upstreamMergeRef == "" {
 		return PublishResponse{}, &NoUpstreamError{
 			Branch:           branch,
@@ -376,18 +376,18 @@ func (r *Registry) GitPublish(ctx context.Context, folderID, message string) (Pu
 	// Validate where the push will land before staging or committing, so
 	// an unsafe push target cannot leave a half-finished publish (commit
 	// created, push refused) behind.
-	pushTarget, err := assertPushTargetSafe(ctx, v.Path, upstreamRemote)
+	pushTarget, err := r.assertPushTargetSafe(ctx, v.Path, upstreamRemote)
 	if err != nil {
 		return PublishResponse{}, err
 	}
-	if err := stagePublishSet(ctx, v.Path, publishable); err != nil {
+	if err := r.stagePublishSet(ctx, v.Path, publishable); err != nil {
 		return PublishResponse{}, fmt.Errorf("git add: %w", err)
 	}
-	commitSHA, err := runCommit(ctx, v.Path, message)
+	commitSHA, err := r.runCommit(ctx, v.Path, message)
 	if err != nil {
 		return PublishResponse{}, err
 	}
-	if stderr, err := runPush(ctx, v.Path, upstreamRemote, upstreamMergeRef, pushTarget); err != nil {
+	if stderr, err := r.runPush(ctx, v.Path, upstreamRemote, upstreamMergeRef, pushTarget); err != nil {
 		return PublishResponse{}, &PushFailedAfterCommitError{
 			Commit: commitSHA,
 			Stderr: stderr,
@@ -421,7 +421,7 @@ func filterPublishable(changes []PublishChange, unmerged []string) []PublishChan
 	return out
 }
 
-func stagePublishSet(ctx context.Context, root string, changes []PublishChange) error {
+func (r *Registry) stagePublishSet(ctx context.Context, root string, changes []PublishChange) error {
 	args := []string{"--literal-pathspecs", "add", "-A", "--"}
 	for _, c := range changes {
 		args = append(args, c.Path)
@@ -439,13 +439,13 @@ func stagePublishSet(ctx context.Context, root string, changes []PublishChange) 
 			return fmt.Errorf("stat old path %s: %w", c.OldPath, statErr)
 		}
 	}
-	if _, err := runDocsGit(ctx, root, nil, args...); err != nil {
+	if _, err := r.runGit(ctx, root, nil, args...); err != nil {
 		return err
 	}
 	return nil
 }
 
-func runCommit(ctx context.Context, root, message string) (string, error) {
+func (r *Registry) runCommit(ctx context.Context, root, message string) (string, error) {
 	messageFile, err := os.CreateTemp("", "middleman-docs-commit-message-*")
 	if err != nil {
 		return "", err
@@ -460,17 +460,17 @@ func runCommit(ctx context.Context, root, message string) (string, error) {
 		return "", err
 	}
 
-	if _, err := runDocsGit(ctx, root, nil, "commit", "-F", messagePath); err != nil {
+	if _, err := r.runGit(ctx, root, nil, "commit", "-F", messagePath); err != nil {
 		return "", &CommitFailedError{Stderr: gitStderr(err)}
 	}
-	headOut, err := runDocsGit(ctx, root, nil, "rev-parse", "HEAD")
+	headOut, err := r.runGit(ctx, root, nil, "rev-parse", "HEAD")
 	if err != nil {
 		return "", err
 	}
 	return strings.TrimSpace(string(headOut)), nil
 }
 
-func runPush(ctx context.Context, root, remote, mergeRef string, target pushTargetClass) (string, error) {
+func (r *Registry) runPush(ctx context.Context, root, remote, mergeRef string, target pushTargetClass) (string, error) {
 	args := []string{"push"}
 	if target == pushTargetLocal {
 		receivePack, err := localReceivePack()
@@ -480,7 +480,7 @@ func runPush(ctx context.Context, root, remote, mergeRef string, target pushTarg
 		args = append(args, "--receive-pack="+receivePack)
 	}
 	args = append(args, remote, "HEAD:"+mergeRef)
-	if _, err := runDocsGit(ctx, root, nil, args...); err != nil {
+	if _, err := r.runGit(ctx, root, nil, args...); err != nil {
 		return gitStderr(err), err
 	}
 	return "", nil

--- a/internal/docs/git_publish_integration_test.go
+++ b/internal/docs/git_publish_integration_test.go
@@ -12,10 +12,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	gitcmd "go.kenn.io/kit/git/cmd"
-	"go.kenn.io/kit/git/env"
 	"go.kenn.io/middleman/internal/config"
 	"go.kenn.io/middleman/internal/procutil"
+	"go.kenn.io/middleman/internal/testutil/gitsafe"
 )
 
 type gitRepo struct {
@@ -27,7 +26,6 @@ type gitRepo struct {
 
 func newGitRepo(t *testing.T) *gitRepo {
 	t.Helper()
-	useIsolatedGitEnv(t)
 	if err := procutil.Command("git", "--version").Run(); err != nil {
 		t.Skip("git binary unavailable")
 	}
@@ -44,13 +42,12 @@ func newGitRepo(t *testing.T) *gitRepo {
 	runGit(t, dir, "push", "-u", "origin", "main")
 	reg := NewRegistry([]config.DocFolder{
 		{ID: "f", Name: "F", Path: dir},
-	})
+	}, WithGitRunner(gitsafe.Runner()))
 	return &gitRepo{dir: dir, remote: remote, registry: reg, folderID: "f"}
 }
 
 func newGitRepoNoUpstream(t *testing.T) *gitRepo {
 	t.Helper()
-	useIsolatedGitEnv(t)
 	if err := procutil.Command("git", "--version").Run(); err != nil {
 		t.Skip("git binary unavailable")
 	}
@@ -63,7 +60,7 @@ func newGitRepoNoUpstream(t *testing.T) *gitRepo {
 	runGit(t, dir, "commit", "-m", "seed")
 	reg := NewRegistry([]config.DocFolder{
 		{ID: "f", Name: "F", Path: dir},
-	})
+	}, WithGitRunner(gitsafe.Runner()))
 	return &gitRepo{dir: dir, registry: reg, folderID: "f"}
 }
 
@@ -84,42 +81,9 @@ func runGit(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 	cmd := procutil.Command("git", args...)
 	cmd.Dir = dir
-	cmd.Env = fixtureGitEnv
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "git %s: %s", strings.Join(args, " "), string(out))
 	return string(out)
-}
-
-// fixtureGitEnv is the environment for git commands run directly by test
-// fixtures (repo setup, out-of-band asserts). useIsolatedGitEnv replaces it
-// alongside the production runner so fixtures and code under test share the
-// same isolated global/system config.
-var fixtureGitEnv = append(gitenv.StripAll(os.Environ()), "GIT_CONFIG_NOSYSTEM=1")
-
-func useIsolatedGitEnv(t *testing.T) {
-	t.Helper()
-	oldBase := docsGitBase
-	oldFixture := fixtureGitEnv
-	home := t.TempDir()
-	xdgConfig := t.TempDir()
-	env := append(gitenv.StripAll(os.Environ()),
-		"HOME="+home,
-		"XDG_CONFIG_HOME="+xdgConfig,
-	)
-	docsGitBase = gitcmd.Runner{
-		Env:              env,
-		StripEnv:         true,
-		NullGlobalConfig: true,
-		NoSystemConfig:   true,
-	}
-	fixtureGitEnv = append(append([]string(nil), env...),
-		"GIT_CONFIG_NOSYSTEM=1",
-		"GIT_CONFIG_GLOBAL="+filepath.Join(home, ".gitconfig"),
-	)
-	t.Cleanup(func() {
-		docsGitBase = oldBase
-		fixtureGitEnv = oldFixture
-	})
 }
 
 func gitOutput(t *testing.T, dir string, args ...string) string {
@@ -131,7 +95,10 @@ func TestIntegrationGitChangesNotARepo(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	dir := t.TempDir()
-	reg := NewRegistry([]config.DocFolder{{ID: "f", Name: "F", Path: dir}})
+	reg := NewRegistry(
+		[]config.DocFolder{{ID: "f", Name: "F", Path: dir}},
+		WithGitRunner(gitsafe.Runner()),
+	)
 
 	res, err := reg.GitChanges(context.Background(), "f")
 
@@ -289,7 +256,6 @@ func TestIntegrationGitPublishRefusesConflict(t *testing.T) {
 	runGit(t, g.dir, "commit", "-am", "main")
 	cmd := procutil.Command("git", "merge", "side")
 	cmd.Dir = g.dir
-	cmd.Env = fixtureGitEnv
 	out, mergeErr := cmd.CombinedOutput()
 	require.Error(t, mergeErr, "expected merge conflict, got clean merge: %s", out)
 
@@ -605,12 +571,23 @@ func TestIntegrationGitPublishGatesAttributesBeforeStatusRunsFilter(t *testing.T
 	assert := assert.New(t)
 	require := require.New(t)
 	g := newGitRepo(t)
+	runner := gitsafe.MutableRunner(t)
+	g.registry = NewRegistry(
+		[]config.DocFolder{{ID: g.folderID, Name: "F", Path: g.dir}},
+		WithGitRunner(runner),
+	)
 	marker := filepath.Join(t.TempDir(), "filter-ran")
 	// Simulate a globally-installed clean filter, as git-lfs would be on a
 	// victim's machine. The repo only chooses to route paths through it.
-	runGit(t, g.dir, "config", "--global", "filter.evil.clean",
-		"sh -c 'echo ran > \""+marker+"\"; cat'")
-	runGit(t, g.dir, "config", "--global", "filter.evil.smudge", "cat")
+	_, stderr, err := runner.Run(
+		t.Context(), g.dir, nil, "config", "--global", "filter.evil.clean",
+		"sh -c 'echo ran > \""+marker+"\"; cat'",
+	)
+	require.NoError(err, string(stderr))
+	_, stderr, err = runner.Run(
+		t.Context(), g.dir, nil, "config", "--global", "filter.evil.smudge", "cat",
+	)
+	require.NoError(err, string(stderr))
 	// Attacker-controlled repo attributes opt markdown into that filter.
 	g.writeFile(t, ".gitattributes", "*.md filter=evil\n")
 	// Modify a tracked markdown to the same byte length as the committed
@@ -620,7 +597,7 @@ func TestIntegrationGitPublishGatesAttributesBeforeStatusRunsFilter(t *testing.T
 	old := time.Unix(1_000_000_000, 0)
 	require.NoError(os.Chtimes(filepath.Join(g.dir, "seed.md"), old, old))
 
-	_, err := g.registry.GitPublish(context.Background(), g.folderID, "docs: x")
+	_, err = g.registry.GitPublish(context.Background(), g.folderID, "docs: x")
 
 	var unsafe *UnsafeGitConfigError
 	require.ErrorAs(err, &unsafe)

--- a/internal/docs/git_pull.go
+++ b/internal/docs/git_pull.go
@@ -65,7 +65,7 @@ func (r *Registry) GitPull(ctx context.Context, folderID string) (PullResponse, 
 	if !isGitRepo(v.Path) {
 		return PullResponse{}, ErrNotAGitRepo
 	}
-	branch, err := currentBranch(ctx, v.Path)
+	branch, err := r.currentBranch(ctx, v.Path)
 	if err != nil {
 		return PullResponse{}, err
 	}
@@ -73,11 +73,11 @@ func (r *Registry) GitPull(ctx context.Context, folderID string) (PullResponse, 
 		Branch:           branch,
 		SuggestedCommand: fmt.Sprintf("git branch --set-upstream-to=origin/%s %s", branch, branch),
 	}
-	upstream, err := currentUpstream(ctx, v.Path, branch)
+	upstream, err := r.currentUpstream(ctx, v.Path, branch)
 	if err != nil || upstream == "" {
 		return PullResponse{}, noUpstream
 	}
-	remote, mergeRef, err := currentUpstreamPushTarget(ctx, v.Path, branch)
+	remote, mergeRef, err := r.currentUpstreamPushTarget(ctx, v.Path, branch)
 	if err != nil || remote == "" || mergeRef == "" {
 		return PullResponse{}, noUpstream
 	}
@@ -85,19 +85,19 @@ func (r *Registry) GitPull(ctx context.Context, folderID string) (PullResponse, 
 	// opportunistically writes refs/remotes/<remote>/<branch> whenever the
 	// command-line ref matches the configured fetch refspec, so origin/main
 	// does not go stale after this fetch (asserted in the integration test).
-	if _, err := runDocsGit(ctx, v.Path, nil, "fetch", remote, mergeRef); err != nil {
+	if _, err := r.runGit(ctx, v.Path, nil, "fetch", remote, mergeRef); err != nil {
 		return PullResponse{}, &PullFailedError{Stderr: gitStderr(err)}
 	}
-	head, err := revParse(ctx, v.Path, "HEAD")
+	head, err := r.revParse(ctx, v.Path, "HEAD")
 	if err != nil {
 		return PullResponse{}, err
 	}
-	fetchHead, err := revParse(ctx, v.Path, "FETCH_HEAD")
+	fetchHead, err := r.revParse(ctx, v.Path, "FETCH_HEAD")
 	if err != nil {
 		return PullResponse{}, err
 	}
 	res := PullResponse{Branch: branch, Upstream: upstream}
-	upToDate, err := isAncestor(ctx, v.Path, fetchHead, head)
+	upToDate, err := r.isAncestor(ctx, v.Path, fetchHead, head)
 	if err != nil {
 		return PullResponse{}, err
 	}
@@ -107,14 +107,14 @@ func (r *Registry) GitPull(ctx context.Context, folderID string) (PullResponse, 
 		res.ShortCommit = head[:7]
 		return res, nil
 	}
-	canFastForward, err := isAncestor(ctx, v.Path, head, fetchHead)
+	canFastForward, err := r.isAncestor(ctx, v.Path, head, fetchHead)
 	if err != nil {
 		return PullResponse{}, err
 	}
 	if !canFastForward {
 		return PullResponse{}, ErrDiverged
 	}
-	if _, err := runDocsGit(ctx, v.Path, nil, "merge", "--ff-only", "FETCH_HEAD"); err != nil {
+	if _, err := r.runGit(ctx, v.Path, nil, "merge", "--ff-only", "FETCH_HEAD"); err != nil {
 		return PullResponse{}, &PullFailedError{Stderr: gitStderr(err)}
 	}
 	res.Commit = fetchHead
@@ -122,8 +122,8 @@ func (r *Registry) GitPull(ctx context.Context, folderID string) (PullResponse, 
 	return res, nil
 }
 
-func revParse(ctx context.Context, root, rev string) (string, error) {
-	out, err := runDocsGit(ctx, root, nil, "rev-parse", rev)
+func (r *Registry) revParse(ctx context.Context, root, rev string) (string, error) {
+	out, err := r.runGit(ctx, root, nil, "rev-parse", rev)
 	if err != nil {
 		return "", fmt.Errorf("git rev-parse %s: %w", rev, err)
 	}
@@ -133,8 +133,8 @@ func revParse(ctx context.Context, root, rev string) (string, error) {
 // isAncestor reports whether ancestor is reachable from descendant. git
 // merge-base --is-ancestor signals its answer through the exit code: 0 for
 // yes, 1 for no, anything else is a real failure.
-func isAncestor(ctx context.Context, root, ancestor, descendant string) (bool, error) {
-	_, err := runDocsGit(ctx, root, nil, "merge-base", "--is-ancestor", ancestor, descendant)
+func (r *Registry) isAncestor(ctx context.Context, root, ancestor, descendant string) (bool, error) {
+	_, err := r.runGit(ctx, root, nil, "merge-base", "--is-ancestor", ancestor, descendant)
 	if err == nil {
 		return true, nil
 	}

--- a/internal/docs/git_push_safety.go
+++ b/internal/docs/git_push_safety.go
@@ -39,8 +39,8 @@ const (
 // Local paths outside the folder stay allowed — pushing to a personal
 // bare mirror is a real workflow — because runPush neutralizes the
 // target's command surfaces with localReceivePack.
-func assertPushTargetSafe(ctx context.Context, root, remote string) (pushTargetClass, error) {
-	urls, err := remotePushURLs(ctx, root, remote)
+func (r *Registry) assertPushTargetSafe(ctx context.Context, root, remote string) (pushTargetClass, error) {
+	urls, err := r.remotePushURLs(ctx, root, remote)
 	if err != nil {
 		return 0, err
 	}
@@ -78,8 +78,8 @@ func assertPushTargetSafe(ctx context.Context, root, remote string) (pushTargetC
 // upstream may also name a bare URL or path instead of a configured
 // remote; get-url fails for those and the string itself is the one push
 // target.
-func remotePushURLs(ctx context.Context, root, remote string) ([]string, error) {
-	out, err := runDocsGit(ctx, root, nil, "remote", "get-url", "--push", "--all", remote)
+func (r *Registry) remotePushURLs(ctx context.Context, root, remote string) ([]string, error) {
+	out, err := r.runGit(ctx, root, nil, "remote", "get-url", "--push", "--all", remote)
 	if err != nil {
 		return []string{remote}, nil
 	}

--- a/internal/docs/git_safety.go
+++ b/internal/docs/git_safety.go
@@ -33,8 +33,8 @@ func (e *UnsafeGitConfigError) Error() string {
 // untrusted repo never reaches an executing git command. Attribute-driven
 // filter/diff drivers are checked separately, before git status runs, by
 // assertWorktreeAttributesSafe.
-func assertSafeToPublish(ctx context.Context, root string) error {
-	entries, err := unsafeGitConfigEntries(ctx, root)
+func (r *Registry) assertSafeToPublish(ctx context.Context, root string) error {
+	entries, err := r.unsafeGitConfigEntries(ctx, root)
 	if err != nil {
 		return err
 	}
@@ -52,19 +52,19 @@ func assertSafeToPublish(ctx context.Context, root string) error {
 // the publish set computed from git status output. Path enumeration (git
 // ls-files) and attribute resolution (git check-attr) never run a filter
 // program, so the gate itself is safe to call first.
-func assertWorktreeAttributesSafe(ctx context.Context, root string) error {
-	paths, err := worktreePaths(ctx, root)
+func (r *Registry) assertWorktreeAttributesSafe(ctx context.Context, root string) error {
+	paths, err := r.worktreePaths(ctx, root)
 	if err != nil {
 		return err
 	}
-	return assertPathsAttributesSafe(ctx, root, paths)
+	return r.assertPathsAttributesSafe(ctx, root, paths)
 }
 
 // worktreePaths lists every tracked and untracked (non-ignored) path in the
 // docs repo. git ls-files reads the index and directory listing only; it
 // never runs a filter, so it is safe to call before the attribute gate.
-func worktreePaths(ctx context.Context, root string) ([]string, error) {
-	out, err := runDocsGit(ctx, root, nil, "ls-files", "-z", "--cached", "--others", "--exclude-standard")
+func (r *Registry) worktreePaths(ctx context.Context, root string) ([]string, error) {
+	out, err := r.runGit(ctx, root, nil, "ls-files", "-z", "--cached", "--others", "--exclude-standard")
 	if err != nil {
 		return nil, fmt.Errorf("listing docs worktree paths: %w", err)
 	}
@@ -83,12 +83,12 @@ func worktreePaths(ctx context.Context, root string) ([]string, error) {
 // .gitattributes, .git/info/attributes, core.attributesFile) and runs no
 // filter program. Paths are fed on stdin so a large worktree cannot blow
 // the command-line argument limit.
-func assertPathsAttributesSafe(ctx context.Context, root string, paths []string) error {
+func (r *Registry) assertPathsAttributesSafe(ctx context.Context, root string, paths []string) error {
 	if len(paths) == 0 {
 		return nil
 	}
 	stdin := strings.NewReader(strings.Join(paths, "\x00") + "\x00")
-	out, err := runDocsGit(ctx, root, stdin, "check-attr", "-z", "--stdin", "filter", "diff")
+	out, err := r.runGit(ctx, root, stdin, "check-attr", "-z", "--stdin", "filter", "diff")
 	if err != nil {
 		return fmt.Errorf("checking docs git attributes: %w", err)
 	}
@@ -118,8 +118,8 @@ func attributeValueIsDriver(value string) bool {
 	}
 }
 
-func unsafeGitConfigEntries(ctx context.Context, root string) ([]string, error) {
-	out, err := runDocsGit(ctx, root, nil, "config", "--local", "--list", "-z")
+func (r *Registry) unsafeGitConfigEntries(ctx context.Context, root string) ([]string, error) {
+	out, err := r.runGit(ctx, root, nil, "config", "--local", "--list", "-z")
 	if err != nil {
 		// A repo with no local config still exits 0 with empty output, so a
 		// non-zero exit is a real failure worth surfacing.

--- a/internal/docs/testmain_test.go
+++ b/internal/docs/testmain_test.go
@@ -1,0 +1,12 @@
+package docs
+
+import (
+	"os"
+	"testing"
+
+	"go.kenn.io/middleman/internal/testutil/gitsafe"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(gitsafe.RunIsolatedMain(m))
+}

--- a/internal/projects/identity.go
+++ b/internal/projects/identity.go
@@ -41,6 +41,17 @@ func ResolveIdentityFromPathWithKnownPlatforms(
 	path string,
 	known []KnownPlatformHost,
 ) (*db.PlatformIdentity, error) {
+	return resolveIdentityFromPathWithGitEnv(
+		ctx, path, known, gitenv.StripAll(os.Environ()),
+	)
+}
+
+func resolveIdentityFromPathWithGitEnv(
+	ctx context.Context,
+	path string,
+	known []KnownPlatformHost,
+	gitEnv []string,
+) (*db.PlatformIdentity, error) {
 	if strings.TrimSpace(path) == "" {
 		return nil, fmt.Errorf("path is required")
 	}
@@ -50,7 +61,7 @@ func ResolveIdentityFromPathWithKnownPlatforms(
 	}
 	cmd := procutil.CommandContext(ctx, "git", "remote", "get-url", "origin")
 	cmd.Dir = abs
-	cmd.Env = gitenv.StripAll(os.Environ())
+	cmd.Env = gitEnv
 	out, err := cmd.Output()
 	if err != nil {
 		var exitErr *exec.ExitError

--- a/internal/projects/identity_test.go
+++ b/internal/projects/identity_test.go
@@ -1,7 +1,6 @@
 package projects
 
 import (
-	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -10,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	gitcmd "go.kenn.io/kit/git/cmd"
+	"go.kenn.io/middleman/internal/testutil/gitsafe"
 )
 
 func TestParseRemoteURL_GitHubFormats(t *testing.T) {
@@ -144,7 +144,9 @@ func TestResolveIdentityFromPath_NoOriginRemote(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(runGit(t, dir, "init", "-q"))
 
-	identity, err := ResolveIdentityFromPath(context.Background(), dir)
+	identity, err := resolveIdentityFromPathWithGitEnv(
+		t.Context(), dir, nil, gitsafe.Runner().Env,
+	)
 	require.NoError(err)
 	assert.Nil(identity)
 }
@@ -160,7 +162,9 @@ func TestResolveIdentityFromPath_UnrecognizableRemote(t *testing.T) {
 	require.NoError(runGit(t, dir, "init", "-q"))
 	require.NoError(runGit(t, dir, "remote", "add", "origin", "/local/only/repo"))
 
-	identity, err := ResolveIdentityFromPath(context.Background(), dir)
+	identity, err := resolveIdentityFromPathWithGitEnv(
+		t.Context(), dir, nil, gitsafe.Runner().Env,
+	)
 	require.NoError(err)
 	assert.Nil(identity)
 }
@@ -176,7 +180,9 @@ func TestResolveIdentityFromPath_RecognizedRemote(t *testing.T) {
 	require.NoError(runGit(t, dir, "init", "-q"))
 	require.NoError(runGit(t, dir, "remote", "add", "origin", "git@github.com:wesm/examplerepo.git"))
 
-	identity, err := ResolveIdentityFromPath(context.Background(), dir)
+	identity, err := resolveIdentityFromPathWithGitEnv(
+		t.Context(), dir, nil, gitsafe.Runner().Env,
+	)
 	require.NoError(err)
 	require.NotNil(identity)
 	assert.Equal("github.com", identity.Host)
@@ -196,14 +202,16 @@ func TestResolveIdentityFromPath_NotAGitRepoIsTreatedAsNoIdentity(t *testing.T) 
 	// returns (nil, nil) and lets registration validation reject the
 	// non-repo separately.
 	dir := t.TempDir()
-	identity, err := ResolveIdentityFromPath(context.Background(), dir)
+	identity, err := resolveIdentityFromPathWithGitEnv(
+		t.Context(), dir, nil, gitsafe.Runner().Env,
+	)
 	require.NoError(err)
 	assert.Nil(identity)
 }
 
 func TestResolveIdentityFromPath_RequiresPath(t *testing.T) {
 	require := require.New(t)
-	_, err := ResolveIdentityFromPath(context.Background(), "")
+	_, err := ResolveIdentityFromPath(t.Context(), "")
 	require.Error(err)
 }
 
@@ -236,7 +244,9 @@ func TestResolveIdentityFromPath_ResolvesRelativePaths(t *testing.T) {
 
 	rel, err := filepath.Rel(cwd, dir)
 	require.NoError(err)
-	identity, err := ResolveIdentityFromPath(context.Background(), filepath.Join(cwd, rel))
+	identity, err := resolveIdentityFromPathWithGitEnv(
+		t.Context(), filepath.Join(cwd, rel), nil, gitsafe.Runner().Env,
+	)
 	require.NoError(err)
 	require.NotNil(identity)
 	assert.Equal("github.com", identity.Host)

--- a/internal/projects/testmain_test.go
+++ b/internal/projects/testmain_test.go
@@ -1,0 +1,12 @@
+package projects
+
+import (
+	"os"
+	"testing"
+
+	"go.kenn.io/middleman/internal/testutil/gitsafe"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(gitsafe.RunIsolatedMain(m))
+}

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -60,6 +60,7 @@ import (
 	"go.kenn.io/middleman/internal/testutil"
 	"go.kenn.io/middleman/internal/testutil/dbtest"
 	"go.kenn.io/middleman/internal/testutil/gitfake"
+	"go.kenn.io/middleman/internal/testutil/gitsafe"
 	"go.kenn.io/middleman/internal/testutil/processjob"
 	"go.kenn.io/middleman/internal/tokenauth"
 	"go.kenn.io/middleman/internal/workspace"
@@ -89,7 +90,7 @@ func TestMain(m *testing.M) {
 	if envDirErr == nil {
 		_ = os.Setenv("MIDDLEMAN_TMUX_ENV_DIR", envDir)
 	}
-	code := m.Run()
+	code := gitsafe.RunIsolatedMain(m)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	if err := cleanupMiddlemanTestTmuxSessionsWithContext(ctx); err != nil {
 		fmt.Fprintf(os.Stderr, "cleanup middleman test tmux sessions: %v\n", err)

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -23863,11 +23863,16 @@ func cleanupMiddlemanTestTmuxSessionsWithContext(ctx context.Context) error {
 		var stderr bytes.Buffer
 		cmd.Stderr = &stderr
 		if err := procutil.Run(ctx, cmd, "test tmux cleanup"); err != nil {
+			msg := strings.TrimSpace(stderr.String())
+			if strings.Contains(msg, "can't find session") ||
+				isTmuxServerAbsentMessage(msg) {
+				continue
+			}
 			errs = append(
 				errs,
 				fmt.Errorf(
 					"kill leaked tmux session %s: %w: %s",
-					session, err, strings.TrimSpace(stderr.String()),
+					session, err, msg,
 				),
 			)
 		}
@@ -24325,6 +24330,37 @@ func TestMiddlemanTmuxSessionsTreatsMissingTmuxSocketAsEmpty(t *testing.T) {
 
 	require.NoError(err)
 	require.Empty(sessions)
+}
+
+func TestCleanupMiddlemanTestTmuxSessionsIgnoresConcurrentRemoval(t *testing.T) {
+	require := require.New(t)
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, "removed")
+	tmuxPath := filepath.Join(dir, "tmux")
+	body := `#!/bin/sh
+if [ "$1" = "list-sessions" ]; then
+  if [ ! -f "$TMUX_REMOVED_STATE" ]; then
+    echo "middleman-concurrent:$TMUX_SESSION_PATH"
+  fi
+  exit 0
+fi
+if [ "$1" = "kill-session" ]; then
+  : > "$TMUX_REMOVED_STATE"
+  echo "can't find session: $3" >&2
+  exit 1
+fi
+exit 2
+`
+	require.NoError(os.WriteFile(tmuxPath, []byte(body), 0o755))
+	t.Setenv("PATH", dir)
+	t.Setenv("TMUX_REMOVED_STATE", statePath)
+	t.Setenv("TMUX_SESSION_PATH", dir)
+
+	err := cleanupMiddlemanTestTmuxSessionsWithContext(
+		context.Background(),
+	)
+
+	require.NoError(err)
 }
 
 func TestWorkspaceRuntimeTargetsRefreshAfterSettingsUpdateE2E(t *testing.T) {

--- a/internal/server/docs_git_routes_test.go
+++ b/internal/server/docs_git_routes_test.go
@@ -14,11 +14,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	gitenv "go.kenn.io/kit/git/env"
+	gitcmd "go.kenn.io/kit/git/cmd"
 	"go.kenn.io/middleman/internal/config"
 	"go.kenn.io/middleman/internal/docs"
-	"go.kenn.io/middleman/internal/procutil"
 	"go.kenn.io/middleman/internal/server/httpapi"
+	"go.kenn.io/middleman/internal/testutil/gitsafe"
 )
 
 type docsGitRepo struct {
@@ -28,7 +28,7 @@ type docsGitRepo struct {
 
 func newDocsGitRepo(t *testing.T, upstream bool) docsGitRepo {
 	t.Helper()
-	if err := procutil.Command("git", "--version").Run(); err != nil {
+	if _, err := gitcmd.New().Output(t.Context(), "", "--version"); err != nil {
 		t.Skip("git binary unavailable")
 	}
 	dir := t.TempDir()
@@ -52,36 +52,9 @@ func newDocsGitRepo(t *testing.T, upstream bool) docsGitRepo {
 
 func runDocsGit(t *testing.T, dir string, args ...string) string {
 	t.Helper()
-	cmd := procutil.Command("git", args...)
-	cmd.Dir = dir
-	cmd.Env = cleanDocsGitEnv(os.Environ())
-	out, err := cmd.CombinedOutput()
-	require.NoError(t, err, "git %v: %s", args, string(out))
+	out, stderr, err := gitcmd.New().Run(t.Context(), dir, nil, args...)
+	require.NoError(t, err, "git %v: %s", args, string(stderr))
 	return string(out)
-}
-
-func cleanDocsGitEnv(env []string) []string {
-	return gitenv.StripAll(env)
-}
-
-func TestDocsGitFixtureDoesNotLeakIntoInheritedGitConfig(t *testing.T) {
-	require := require.New(t)
-
-	host := t.TempDir()
-	runDocsGit(t, host, "init", "-q", "-b", "main")
-	hostConfig := filepath.Join(host, ".git", "config")
-	before, err := os.ReadFile(hostConfig)
-	require.NoError(err)
-
-	t.Setenv("GIT_CONFIG", hostConfig)
-	t.Setenv("GIT_DIR", filepath.Join(host, ".git"))
-	t.Setenv("GIT_WORK_TREE", host)
-
-	_ = newDocsGitRepo(t, false)
-
-	after, err := os.ReadFile(hostConfig)
-	require.NoError(err)
-	require.Equal(string(before), string(after))
 }
 
 func (g docsGitRepo) write(t *testing.T, rel, body string) {
@@ -96,7 +69,8 @@ func setupDocsGitRouteServer(t *testing.T, root string) *Server {
 	cfg := &config.Config{
 		DocFolders: []config.DocFolder{{ID: "f", Name: "F", Path: root}},
 	}
-	srv := New(openTestDB(t), nil, nil, "/", cfg, ServerOptions{})
+	registry := docs.NewRegistry(cfg.DocFolders, docs.WithGitRunner(gitsafe.Runner()))
+	srv := New(openTestDB(t), nil, nil, "/", cfg, ServerOptions{DocsRegistry: registry})
 	t.Cleanup(func() { gracefulShutdown(t, srv) })
 	return srv
 }
@@ -473,10 +447,9 @@ func TestDocsGitPublishEndpointProblemMappings(t *testing.T) {
 				runDocsGit(t, repo.dir, "checkout", "main")
 				repo.write(t, "seed.md", "main version\n")
 				runDocsGit(t, repo.dir, "commit", "-am", "main")
-				cmd := procutil.Command("git", "merge", "side")
-				cmd.Dir = repo.dir
-				cmd.Env = cleanDocsGitEnv(os.Environ())
-				out, mergeErr := cmd.CombinedOutput()
+				out, _, mergeErr := gitcmd.New().Run(
+					t.Context(), repo.dir, nil, "merge", "side",
+				)
 				require.Error(t, mergeErr, "expected merge conflict, got clean merge: %s", out)
 				return setupDocsGitRouteServer(t, repo.dir)
 			},
@@ -534,12 +507,14 @@ func TestDocsGitPublishEndpointRejectsConcurrentInFlightPublish(t *testing.T) {
 	require := require.New(t)
 	repo := newDocsGitRepo(t, true)
 	repo.write(t, "blocked.md", "# blocked\n")
-	srv := New(openTestDB(t), nil, nil, "/", &config.Config{
+	cfg := &config.Config{
 		DocFolders: []config.DocFolder{
 			{ID: "f", Name: "F", Path: repo.dir},
 			{ID: "alias", Name: "Alias", Path: repo.dir},
 		},
-	}, ServerOptions{})
+	}
+	registry := docs.NewRegistry(cfg.DocFolders, docs.WithGitRunner(gitsafe.Runner()))
+	srv := New(openTestDB(t), nil, nil, "/", cfg, ServerOptions{DocsRegistry: registry})
 	t.Cleanup(func() { gracefulShutdown(t, srv) })
 
 	// The publish safety gate forbids command-bearing config, so hold the

--- a/internal/server/docsapi/routes.go
+++ b/internal/server/docsapi/routes.go
@@ -25,6 +25,7 @@ type Deps struct {
 	Config              *config.Config
 	BeginConfigMutation func() func()
 	SaveFolders         func([]config.DocFolder) error
+	Registry            *docs.Registry
 }
 
 type Handler struct {
@@ -40,10 +41,14 @@ func New(deps Deps) *Handler {
 	if deps.Config != nil {
 		folders = deps.Config.DocFolders
 	}
+	registry := deps.Registry
+	if registry == nil {
+		registry = docs.NewRegistry(folders)
+	}
 	return &Handler{
 		beginConfigMutation: deps.BeginConfigMutation,
 		saveFolders:         deps.SaveFolders,
-		docsRegistry:        docs.NewRegistry(folders),
+		docsRegistry:        registry,
 		docsPublishLocks:    NewPublishLockSet(),
 	}
 }

--- a/internal/server/e2etest/fleet_primary_worktree_test.go
+++ b/internal/server/e2etest/fleet_primary_worktree_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/middleman/internal/fleet"
-	"go.kenn.io/middleman/internal/procutil"
+	"go.kenn.io/middleman/internal/testutil/gitsafe"
 )
 
 // gitInitRepoWithWorktree creates a real git repo with one empty commit and a
@@ -34,9 +34,8 @@ func gitInitRepoWithWorktree(t *testing.T, worktreeName string) (string, string)
 
 func gitRun(t *testing.T, dir string, args ...string) {
 	t.Helper()
-	cmd := procutil.Command("git", append([]string{"-C", dir}, args...)...)
-	out, err := cmd.CombinedOutput()
-	require.NoError(t, err, "git %v: %s", args, out)
+	_, stderr, err := gitsafe.Runner().Run(t.Context(), dir, nil, args...)
+	require.NoError(t, err, "git %v: %s", args, stderr)
 }
 
 // registerProjectE2E registers a local checkout over HTTP and returns its

--- a/internal/server/e2etest/testmain_test.go
+++ b/internal/server/e2etest/testmain_test.go
@@ -1,0 +1,12 @@
+package e2etest
+
+import (
+	"os"
+	"testing"
+
+	"go.kenn.io/middleman/internal/testutil/gitsafe"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(gitsafe.RunIsolatedMain(m))
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -27,6 +27,7 @@ import (
 	"go.kenn.io/middleman/internal/config"
 	"go.kenn.io/middleman/internal/configwatch"
 	"go.kenn.io/middleman/internal/db"
+	"go.kenn.io/middleman/internal/docs"
 	"go.kenn.io/middleman/internal/gitclone"
 	ghclient "go.kenn.io/middleman/internal/github"
 	"go.kenn.io/middleman/internal/platform"
@@ -81,6 +82,7 @@ type ServerOptions struct {
 	Telemetry                          telemetry.Client
 	TokenSources                       *tokenauth.SourceSet
 	Archive                            archive.Controller
+	DocsRegistry                       *docs.Registry
 	// TerminalClipboard overrides native clipboard integration in tests.
 	TerminalClipboard systemclipboard.Writer
 	// HostCheck overrides the Host validation middleware options.
@@ -782,7 +784,8 @@ func newServer(
 		workspaceNow = options.WorkspaceNow
 	}
 	s.docsAPI = docsapi.New(docsapi.Deps{
-		Config: cfg,
+		Config:   cfg,
+		Registry: options.DocsRegistry,
 		BeginConfigMutation: func() func() {
 			s.configReloadMu.Lock()
 			return s.configReloadMu.Unlock

--- a/internal/server/workspacetest/fixtures_test.go
+++ b/internal/server/workspacetest/fixtures_test.go
@@ -45,6 +45,15 @@ func setupWorkspaceServerFixture(
 	if testing.Short() {
 		t.Skip("workspace e2e tests skipped in short mode")
 	}
+	if cfg == nil {
+		cfg = &config.Config{}
+	} else {
+		clone := *cfg
+		cfg = &clone
+	}
+	if len(cfg.Tmux.Command) == 0 {
+		cfg.Tmux.Command = append([]string(nil), workspaceTestTmuxCommand...)
+	}
 
 	dir := t.TempDir()
 	database := dbtest.Open(t)

--- a/internal/server/workspacetest/project_worktree_from_mr_test.go
+++ b/internal/server/workspacetest/project_worktree_from_mr_test.go
@@ -15,15 +15,14 @@ import (
 	gh "github.com/google/go-github/v89/github"
 	"github.com/stretchr/testify/assert"
 	Require "github.com/stretchr/testify/require"
-	gitenv "go.kenn.io/kit/git/env"
 
 	"go.kenn.io/middleman/internal/db"
 	ghclient "go.kenn.io/middleman/internal/github"
-	"go.kenn.io/middleman/internal/procutil"
 	"go.kenn.io/middleman/internal/server"
 	"go.kenn.io/middleman/internal/server/httpapi"
 	"go.kenn.io/middleman/internal/testutil"
 	"go.kenn.io/middleman/internal/testutil/dbtest"
+	"go.kenn.io/middleman/internal/testutil/gitsafe"
 	"go.kenn.io/middleman/internal/testutil/servertest"
 )
 
@@ -301,10 +300,7 @@ func TestCreateWorktreeFromRelativeForkRoutePersistsAbsoluteTracking(t *testing.
 
 func worktreeConfigForRoute(t *testing.T, dir, key string) string {
 	t.Helper()
-	cmd := procutil.Command("git", "config", "--get", key)
-	cmd.Dir = dir
-	cmd.Env = gitenv.StripAll(os.Environ())
-	out, err := cmd.Output()
+	out, err := gitsafe.Runner().Output(t.Context(), dir, "config", "--get", key)
 	if err != nil {
 		return ""
 	}

--- a/internal/server/workspacetest/project_worktree_lifecycle_test.go
+++ b/internal/server/workspacetest/project_worktree_lifecycle_test.go
@@ -14,17 +14,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	Require "github.com/stretchr/testify/require"
 
-	gitenv "go.kenn.io/kit/git/env"
-	"go.kenn.io/middleman/internal/procutil"
+	"go.kenn.io/middleman/internal/testutil/gitsafe"
 )
 
 func lifecycleRouteGit(t *testing.T, dir string, args ...string) string {
 	t.Helper()
-	cmd := procutil.Command("git", args...)
-	cmd.Dir = dir
-	cmd.Env = gitenv.StripAll(os.Environ())
-	out, err := cmd.CombinedOutput()
-	Require.NoError(t, err, "git %v: %s", args, out)
+	out, stderr, err := gitsafe.Runner().Run(t.Context(), dir, nil, args...)
+	Require.NoError(t, err, "git %v: %s", args, stderr)
 	return strings.TrimSpace(string(out))
 }
 
@@ -242,11 +238,11 @@ func TestWorktreeDeleteFromDiskRoute(t *testing.T) {
 
 	_, statErr := os.Stat(created.Path)
 	assert.True(os.IsNotExist(statErr))
-	cmd := procutil.Command(
-		"git", "show-ref", "--verify", "--quiet", "refs/heads/feature")
-	cmd.Dir = repo
-	cmd.Env = gitenv.StripAll(os.Environ())
-	require.Error(cmd.Run(), "branch deleted with remove_branch")
+	_, err := gitsafe.Runner().Output(
+		t.Context(), repo,
+		"show-ref", "--verify", "--quiet", "refs/heads/feature",
+	)
+	require.Error(err, "branch deleted with remove_branch")
 	rows := listWorktreeRows(t, ts, projectID)
 	require.Len(rows, 1, "only the root checkout row remains")
 	assert.Nil(worktreeRowByBranch(rows, "feature"),

--- a/internal/server/workspacetest/pty_owner_e2e_test.go
+++ b/internal/server/workspacetest/pty_owner_e2e_test.go
@@ -25,8 +25,6 @@ import (
 	"go.kenn.io/middleman/internal/procutil"
 	"go.kenn.io/middleman/internal/ptyowner"
 	"go.kenn.io/middleman/internal/server"
-	"go.kenn.io/middleman/internal/testutil/gitsafe"
-	"go.kenn.io/middleman/internal/testutil/processjob"
 	"go.kenn.io/middleman/internal/workspace"
 	"go.kenn.io/middleman/internal/workspace/localruntime"
 )
@@ -38,17 +36,6 @@ var rustPtyManagerBuild struct {
 	path string
 	out  []byte
 	err  error
-}
-
-func TestMain(m *testing.M) {
-	if slices.Contains(os.Args, workspaceRuntimeHelperMarker) {
-		os.Exit(m.Run())
-	}
-	if err := processjob.ContainCurrentProcessTree(); err != nil {
-		fmt.Fprintf(os.Stderr, "contain workspace test process tree: %v\n", err)
-		os.Exit(1)
-	}
-	os.Exit(gitsafe.RunIsolatedMain(m))
 }
 
 func TestWorkspaceCreatesRustPtyManagerSessionE2E(t *testing.T) {

--- a/internal/server/workspacetest/pty_owner_e2e_test.go
+++ b/internal/server/workspacetest/pty_owner_e2e_test.go
@@ -25,6 +25,7 @@ import (
 	"go.kenn.io/middleman/internal/procutil"
 	"go.kenn.io/middleman/internal/ptyowner"
 	"go.kenn.io/middleman/internal/server"
+	"go.kenn.io/middleman/internal/testutil/gitsafe"
 	"go.kenn.io/middleman/internal/testutil/processjob"
 	"go.kenn.io/middleman/internal/workspace"
 	"go.kenn.io/middleman/internal/workspace/localruntime"
@@ -47,7 +48,7 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "contain workspace test process tree: %v\n", err)
 		os.Exit(1)
 	}
-	os.Exit(m.Run())
+	os.Exit(gitsafe.RunIsolatedMain(m))
 }
 
 func TestWorkspaceCreatesRustPtyManagerSessionE2E(t *testing.T) {

--- a/internal/server/workspacetest/testmain_test.go
+++ b/internal/server/workspacetest/testmain_test.go
@@ -1,0 +1,99 @@
+package workspacetest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"go.kenn.io/middleman/internal/procutil"
+	"go.kenn.io/middleman/internal/testutil/gitsafe"
+	"go.kenn.io/middleman/internal/testutil/processjob"
+)
+
+var workspaceTestTmuxCommand []string
+
+func TestMain(m *testing.M) {
+	if slices.Contains(os.Args, workspaceRuntimeHelperMarker) {
+		os.Exit(m.Run())
+	}
+	if err := processjob.ContainCurrentProcessTree(); err != nil {
+		fmt.Fprintf(os.Stderr, "contain workspace test process tree: %v\n", err)
+		os.Exit(1)
+	}
+	cleanupTmux, err := configureWorkspaceTestTmux()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "configure isolated workspace test tmux: %v\n", err)
+		os.Exit(1)
+	}
+	code := gitsafe.RunIsolatedMain(m)
+	if err := cleanupTmux(); err != nil {
+		fmt.Fprintf(os.Stderr, "cleanup isolated workspace test tmux: %v\n", err)
+		if code == 0 {
+			code = 1
+		}
+	}
+	os.Exit(code)
+}
+
+func configureWorkspaceTestTmux() (func() error, error) {
+	tmuxPath, err := exec.LookPath("tmux")
+	if errors.Is(err, exec.ErrNotFound) {
+		return func() error { return nil }, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("find tmux: %w", err)
+	}
+
+	tmuxDir, err := os.MkdirTemp("/tmp", "middleman-workspacetest-tmux-*")
+	if err != nil {
+		return nil, fmt.Errorf("create tmux socket directory: %w", err)
+	}
+	socket := filepath.Join(tmuxDir, "tmux.sock")
+	workspaceTestTmuxCommand = []string{
+		tmuxPath, "-f", "/dev/null", "-S", socket,
+	}
+
+	return func() error {
+		var errs []error
+		if _, statErr := os.Stat(socket); statErr == nil {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			out, killErr := procutil.CombinedOutput(
+				ctx,
+				procutil.CommandContext(
+					ctx, tmuxPath, "-f", "/dev/null", "-S", socket,
+					"kill-server",
+				),
+				"workspace test tmux cleanup",
+			)
+			cancel()
+			msg := strings.TrimSpace(string(out))
+			if killErr != nil && !workspaceTestTmuxServerAbsent(msg) {
+				errs = append(errs, fmt.Errorf(
+					"kill private tmux server: %w: %s",
+					killErr, msg,
+				))
+			}
+		} else if !errors.Is(statErr, os.ErrNotExist) {
+			errs = append(errs, fmt.Errorf("inspect tmux socket: %w", statErr))
+		}
+		if removeErr := os.RemoveAll(tmuxDir); removeErr != nil {
+			errs = append(errs, fmt.Errorf(
+				"remove tmux socket directory: %w", removeErr,
+			))
+		}
+		return errors.Join(errs...)
+	}, nil
+}
+
+func workspaceTestTmuxServerAbsent(msg string) bool {
+	return strings.Contains(msg, "no server running") ||
+		(strings.Contains(msg, "error connecting to") &&
+			strings.Contains(msg, "No such file or directory"))
+}

--- a/internal/server/workspacetest/workspace_test.go
+++ b/internal/server/workspacetest/workspace_test.go
@@ -1,10 +1,12 @@
 package workspacetest
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -16,8 +18,36 @@ import (
 	"go.kenn.io/middleman/internal/apiclient/generated"
 	"go.kenn.io/middleman/internal/config"
 	"go.kenn.io/middleman/internal/db"
+	"go.kenn.io/middleman/internal/procutil"
 	"go.kenn.io/middleman/internal/workspace/localruntime"
 )
+
+func TestWorkspaceFixtureUsesIsolatedTmuxServer(t *testing.T) {
+	tmuxPath, err := exec.LookPath("tmux")
+	if err != nil {
+		t.Skip("tmux not available")
+	}
+
+	fixture := setupWorkspaceServerFixture(t, nil)
+	ctx := t.Context()
+	ws := createReadyWorkspace(t, ctx, fixture.client)
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(
+			context.WithoutCancel(ctx), 5*time.Second,
+		)
+		defer cancel()
+		deleteWorkspaceForPtyOwnerTest(t, cleanupCtx, fixture, ws.Id)
+	})
+
+	err = procutil.Run(
+		ctx,
+		procutil.CommandContext(
+			ctx, tmuxPath, "has-session", "-t", ws.TmuxSession,
+		),
+		"inspect default test tmux server",
+	)
+	assert.Error(t, err, "workspace session leaked into the default tmux server")
+}
 
 func TestWorkspaceRuntimeTargetsE2E(t *testing.T) {
 	require := require.New(t)

--- a/internal/testutil/dbtest/dbtest.go
+++ b/internal/testutil/dbtest/dbtest.go
@@ -9,15 +9,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/middleman/internal/db"
-
-	// gitsafe's init() strips inherited GIT_DIR/GIT_WORK_TREE from the
-	// test process. Every server-side test binary that builds git
-	// fixtures already imports dbtest for its SQLite setup, so routing
-	// the scrub through this regular import protects every fixture
-	// (SetupDiffRepo, the provider clone fixtures, ...) from
-	// re-initializing the host repo under the pre-commit hook — no
-	// per-package guard import needed.
-	_ "go.kenn.io/middleman/internal/testutil/gitsafe"
 )
 
 var templateCache = &templateState{}

--- a/internal/testutil/gitsafe/gitsafe.go
+++ b/internal/testutil/gitsafe/gitsafe.go
@@ -1,49 +1,137 @@
-// Package gitsafe strips inherited git location/identity environment
-// variables (GIT_DIR, GIT_WORK_TREE, GIT_CONFIG*, GIT_AUTHOR_*, ...)
-// from the current process the moment it is imported.
-//
-// The repository's pre-commit hook runs `go test` with GIT_DIR and
-// GIT_WORK_TREE set, pointing at the host repository. Git gives those
-// variables precedence over a child command's working directory, so a
-// test fixture that shells out to bare `git init` / `git config` /
-// `git clone` re-initializes and reconfigures the REAL repo — writing
-// core.worktree and a fixture identity into its config and corrupting
-// how Git resolves the user's working tree.
-//
-// Per-command wrappers like gitcmd.New() already strip these, but a raw
-// exec/procutil git call does not. This package neutralizes the entire
-// class at the process level, before any test or fixture runs, so it is
-// safe even if a fixture forgets the wrapper. Blank-import it from every
-// test package that runs git:
-//
-//	import _ "go.kenn.io/middleman/internal/testutil/gitsafe"
+// Package gitsafe isolates test binaries from developer and system Git state.
 package gitsafe
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
+	"testing"
 
+	"github.com/stretchr/testify/require"
+	gitcmd "go.kenn.io/kit/git/cmd"
 	gitenv "go.kenn.io/kit/git/env"
 )
 
-func init() {
-	UnsetInheritedGitEnv()
+// RunIsolatedMain runs a package's tests with one portable, empty Git config.
+// The setup is shared by the test binary so Git-heavy suites do not create a
+// new config directory for every test or command, which is costly on Windows.
+func RunIsolatedMain(m *testing.M) int {
+	root, err := os.MkdirTemp("", "middleman-git-test-*")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "create isolated Git test directory: %v\n", err)
+		return 1
+	}
+	defer func() { _ = os.RemoveAll(root) }()
+
+	if err := configureGitForTests(root); err != nil {
+		fmt.Fprintf(os.Stderr, "configure isolated Git test environment: %v\n", err)
+		return 1
+	}
+	return m.Run()
 }
 
-// UnsetInheritedGitEnv removes from the live process environment every
-// variable that gitenv.StripInherited filters — the canonical set that
-// can bind a child git process to an inherited parent repository,
-// config, or identity. Reusing gitenv keeps that list in one place.
-func UnsetInheritedGitEnv() {
+func configureGitForTests(root string) error {
+	unsetInheritedGitEnv()
+
+	// Git for Windows cannot reliably use NUL as GIT_CONFIG_GLOBAL. A regular,
+	// empty file is a valid no-op config on every platform.
+	globalConfig := filepath.Join(root, "global.gitconfig")
+	if err := os.WriteFile(globalConfig, nil, 0o600); err != nil {
+		return fmt.Errorf("create empty global config: %w", err)
+	}
+	xdgConfigHome := filepath.Join(root, "xdg")
+	if err := os.MkdirAll(xdgConfigHome, 0o755); err != nil {
+		return fmt.Errorf("create XDG config directory: %w", err)
+	}
+
+	for key, value := range map[string]string{
+		"GIT_CONFIG_GLOBAL":   globalConfig,
+		"GIT_CONFIG_NOSYSTEM": "1",
+		"GIT_TERMINAL_PROMPT": "0",
+		"HOME":                root,
+		"XDG_CONFIG_HOME":     xdgConfigHome,
+	} {
+		if err := os.Setenv(key, value); err != nil {
+			return fmt.Errorf("set %s: %w", key, err)
+		}
+	}
+	return nil
+}
+
+// Runner returns a real Git runner bound to the test binary's shared isolated
+// config. It creates no files or directories; RunIsolatedMain owns that setup.
+func Runner() gitcmd.Runner {
+	return gitcmd.Runner{
+		Env:                         isolatedCommandEnv(os.Environ()),
+		DisableSafeDirectoryForward: true,
+	}
+}
+
+// MutableRunner returns a runner with a per-test writable global config. Use
+// it only when the behavior under test intentionally changes global config;
+// ordinary Git tests should use the package-shared Runner.
+func MutableRunner(t testing.TB) gitcmd.Runner {
+	t.Helper()
+	root := t.TempDir()
+	globalConfig := filepath.Join(root, "global.gitconfig")
+	require.NoError(t, os.WriteFile(globalConfig, nil, 0o600))
+	xdgConfigHome := filepath.Join(root, "xdg")
+	require.NoError(t, os.Mkdir(xdgConfigHome, 0o755))
+
+	return gitcmd.Runner{
+		Env: replaceEnvValues(gitenv.StripAll(os.Environ()), map[string]string{
+			"GIT_CONFIG_GLOBAL":   globalConfig,
+			"GIT_CONFIG_NOSYSTEM": "1",
+			"GIT_TERMINAL_PROMPT": "0",
+			"HOME":                root,
+			"XDG_CONFIG_HOME":     xdgConfigHome,
+		}),
+		DisableSafeDirectoryForward: true,
+	}
+}
+
+func isolatedCommandEnv(base []string) []string {
+	replacements := make(map[string]string)
+	for _, key := range []string{
+		"GIT_CONFIG_GLOBAL",
+		"GIT_CONFIG_NOSYSTEM",
+		"GIT_TERMINAL_PROMPT",
+		"HOME",
+		"XDG_CONFIG_HOME",
+	} {
+		if value, ok := os.LookupEnv(key); ok {
+			replacements[key] = value
+		}
+	}
+	return replaceEnvValues(gitenv.StripAll(base), replacements)
+}
+
+func replaceEnvValues(base []string, replacements map[string]string) []string {
+	out := make([]string, 0, len(base)+len(replacements))
+	for _, entry := range base {
+		key, _, _ := strings.Cut(entry, "=")
+		if _, replaced := replacements[strings.ToUpper(key)]; replaced {
+			continue
+		}
+		out = append(out, entry)
+	}
+	for key, value := range replacements {
+		out = append(out, key+"="+value)
+	}
+	return out
+}
+
+func unsetInheritedGitEnv() {
 	full := os.Environ()
 	kept := make(map[string]struct{}, len(full))
-	for _, kv := range gitenv.StripInherited(full) {
-		if name, _, ok := strings.Cut(kv, "="); ok {
+	for _, entry := range gitenv.StripAll(full) {
+		if name, _, ok := strings.Cut(entry, "="); ok {
 			kept[name] = struct{}{}
 		}
 	}
-	for _, kv := range full {
-		name, _, ok := strings.Cut(kv, "=")
+	for _, entry := range full {
+		name, _, ok := strings.Cut(entry, "=")
 		if !ok {
 			continue
 		}

--- a/internal/testutil/gitsafe/gitsafe_test.go
+++ b/internal/testutil/gitsafe/gitsafe_test.go
@@ -2,34 +2,93 @@ package gitsafe
 
 import (
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/middleman/internal/procutil"
 )
 
-func TestUnsetInheritedGitEnvRemovesRepoBindingVars(t *testing.T) {
+func TestMain(m *testing.M) {
+	os.Exit(RunIsolatedMain(m))
+}
+
+// If package-level Git isolation stops running, real Git can read a developer's
+// identity or system settings and inherited repository bindings during tests.
+func TestRunIsolatedMainProtectsRealGitWithPortableConfig(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	// t.Setenv restores these after the test; it also fails if the test
-	// is marked parallel, which keeps the process-global mutation safe.
-	t.Setenv("GIT_DIR", "/some/host/.git")
-	t.Setenv("GIT_WORK_TREE", "/some/host")
-	t.Setenv("GIT_CONFIG_GLOBAL", "/some/host/.gitconfig")
-	t.Setenv("GIT_AUTHOR_NAME", "Inherited Author")
-	t.Setenv("GITSAFE_TEST_KEEPME", "keep")
+	globalConfig := os.Getenv("GIT_CONFIG_GLOBAL")
+	require.NotEmpty(globalConfig)
+	info, err := os.Stat(globalConfig)
+	require.NoError(err)
+	assert.True(info.Mode().IsRegular(), "global config must be a regular file")
+	assert.Zero(info.Size(), "shared test config must stay empty")
+	assert.Equal("1", os.Getenv("GIT_CONFIG_NOSYSTEM"))
+	assert.Equal("0", os.Getenv("GIT_TERMINAL_PROMPT"))
+	require.DirExists(os.Getenv("XDG_CONFIG_HOME"))
 
-	UnsetInheritedGitEnv()
-
-	for _, name := range []string{
-		"GIT_DIR", "GIT_WORK_TREE", "GIT_CONFIG_GLOBAL", "GIT_AUTHOR_NAME",
-	} {
-		_, present := os.LookupEnv(name)
-		assert.Falsef(present, "%s must be unset so fixtures cannot reach the host repo", name)
+	for _, key := range []string{"GIT_DIR", "GIT_WORK_TREE", "GIT_CONFIG_SYSTEM"} {
+		_, present := os.LookupEnv(key)
+		assert.False(present, "%s leaked into the test process", key)
 	}
 
-	value, present := os.LookupEnv("GITSAFE_TEST_KEEPME")
-	require.True(present, "non-git env must be preserved")
-	assert.Equal("keep", value)
+	externalHome := t.TempDir()
+	externalHomeConfig := filepath.Join(externalHome, ".gitconfig")
+	externalContents := []byte("[user]\n\tname = External User\n")
+	require.NoError(os.WriteFile(externalHomeConfig, externalContents, 0o600))
+	externalSystemConfig := filepath.Join(t.TempDir(), "system.gitconfig")
+	require.NoError(os.WriteFile(externalSystemConfig, externalContents, 0o600))
+
+	cmd := procutil.Command("git", "config", "--get", "user.name")
+	cmd.Env = replaceEnv(os.Environ(), map[string]string{
+		"HOME":              externalHome,
+		"GIT_CONFIG_SYSTEM": externalSystemConfig,
+	})
+	_, err = cmd.Output()
+	require.Error(err, "Git unexpectedly read external home or system config")
+
+	homeContents, err := os.ReadFile(externalHomeConfig)
+	require.NoError(err)
+	assert.Equal(externalContents, homeContents)
+	systemContents, err := os.ReadFile(externalSystemConfig)
+	require.NoError(err)
+	assert.Equal(externalContents, systemContents)
+}
+
+// If a test that writes global Git config shares the package config, parallel
+// tests can observe or overwrite that setting.
+func TestMutableRunnerKeepsGlobalWritesPrivate(t *testing.T) {
+	require := require.New(t)
+
+	runner := MutableRunner(t)
+	_, _, err := runner.Run(
+		t.Context(), "", nil, "config", "--global", "user.name", "Private Test User",
+	)
+	require.NoError(err)
+
+	out, err := runner.Output(t.Context(), "", "config", "--global", "--get", "user.name")
+	require.NoError(err)
+	assert.Equal(t, "Private Test User", strings.TrimSpace(string(out)))
+
+	_, err = Runner().Output(t.Context(), "", "config", "--global", "--get", "user.name")
+	require.Error(err, "private global config leaked into the package config")
+}
+
+func replaceEnv(base []string, replacements map[string]string) []string {
+	out := make([]string, 0, len(base)+len(replacements))
+	for _, entry := range base {
+		key, _, _ := strings.Cut(entry, "=")
+		if _, replaced := replacements[strings.ToUpper(key)]; replaced {
+			continue
+		}
+		out = append(out, entry)
+	}
+	for key, value := range replacements {
+		out = append(out, key+"="+value)
+	}
+	return out
 }


### PR DESCRIPTION
- Isolate real Git tests from inherited global and system configuration through package-level test setup.
- Keep Git-heavy suites fast on Windows by sharing one portable empty config per test binary, while tests that modify global config receive private runners.
- Keep parallel workspace test packages independent with a private tmux server per test binary and race-safe cleanup.
