### PR TITLE
Scope roborev counts to filtered reviews

### DIFF
--- a/frontend/src/lib/stores/roborev-jobs.test.ts
+++ b/frontend/src/lib/stores/roborev-jobs.test.ts
@@ -271,6 +271,55 @@ describe("createJobsStore auto-design filter", () => {
   });
 });
 
+describe("createJobsStore filtered status counts", () => {
+  it("counts the complete filtered result instead of the paginated rows", async () => {
+    const client = {
+      GET: vi.fn().mockImplementation((_path: string, opts: { params: { query: Record<string, unknown> } }) => {
+        if (opts.params.query.limit === 0) {
+          return Promise.resolve({
+            data: {
+              jobs: [
+                { ...makeJob(1), status: "queued" },
+                { ...makeJob(2), status: "running" },
+                makeJob(3),
+                makeJob(4),
+                { ...makeJob(5), status: "failed" },
+              ],
+              has_more: false,
+            },
+            error: undefined,
+          });
+        }
+        return Promise.resolve({
+          data: { jobs: [makeJob(4)], has_more: true },
+          error: undefined,
+        });
+      }),
+    };
+    const store = createJobsStore({ client: client as never, navigate: vi.fn() });
+
+    store.setFilter("repo", "/workspace/repo");
+    await vi.waitFor(() => {
+      expect(store.getFilteredStatusCounts()).toEqual({
+        queued: 1,
+        running: 1,
+        done: 2,
+        failed: 1,
+      });
+    });
+
+    expect(client.GET).toHaveBeenCalledWith("/api/jobs", {
+      params: {
+        query: expect.objectContaining({
+          repo: ["/workspace/repo"],
+          limit: 0,
+          omit_prompt: "true",
+        }),
+      },
+    });
+  });
+});
+
 describe("createJobsStore panel expansion", () => {
   function deferred<T>() {
     let resolve!: (value: T) => void;

--- a/frontend/src/lib/stores/roborev-jobs.test.ts
+++ b/frontend/src/lib/stores/roborev-jobs.test.ts
@@ -346,6 +346,90 @@ describe("createJobsStore filtered status counts", () => {
       },
     });
   });
+
+  it("preserves the previous scoped counts while a filtered reload is pending", async () => {
+    let resolveReloadCounts!: (result: { data: { jobs: ReviewJob[]; has_more: boolean }; error: undefined }) => void;
+    const reloadCounts = new Promise<{
+      data: { jobs: ReviewJob[]; has_more: boolean };
+      error: undefined;
+    }>((resolve) => {
+      resolveReloadCounts = resolve;
+    });
+    let countRequests = 0;
+    const client = {
+      GET: vi.fn().mockImplementation((_path: string, opts: { params: { query: Record<string, unknown> } }) => {
+        if (opts.params.query.limit === 0 && ++countRequests === 2) return reloadCounts;
+        return Promise.resolve({
+          data: { jobs: [makeJob(1)], has_more: false },
+          error: undefined,
+        });
+      }),
+    };
+    const store = createJobsStore({ client: client as never, navigate: vi.fn() });
+    await store.loadJobs();
+    expect(store.getFilteredStatusCounts()?.done).toBe(1);
+
+    const reload = store.loadJobs();
+    try {
+      expect(store.getFilteredStatusCounts()?.done).toBe(1);
+    } finally {
+      resolveReloadCounts({
+        data: { jobs: [makeJob(2), makeJob(3)], has_more: false },
+        error: undefined,
+      });
+    }
+    await reload;
+    expect(store.getFilteredStatusCounts()?.done).toBe(2);
+  });
+
+  it("does not reuse scoped counts after the filters change", async () => {
+    let resolveNextCounts!: (result: { data: { jobs: ReviewJob[]; has_more: boolean }; error: undefined }) => void;
+    const nextCounts = new Promise<{
+      data: { jobs: ReviewJob[]; has_more: boolean };
+      error: undefined;
+    }>((resolve) => {
+      resolveNextCounts = resolve;
+    });
+    const client = {
+      GET: vi.fn().mockImplementation((_path: string, opts: { params: { query: Record<string, unknown> } }) => {
+        if (opts.params.query.limit === 0 && opts.params.query.git_ref === "next") return nextCounts;
+        return Promise.resolve({
+          data: { jobs: [makeJob(1)], has_more: false },
+          error: undefined,
+        });
+      }),
+    };
+    const store = createJobsStore({ client: client as never, navigate: vi.fn() });
+    await store.loadJobs();
+
+    store.setFilter("search", "next");
+    try {
+      expect(store.getFilteredStatusCounts()).toBeUndefined();
+    } finally {
+      resolveNextCounts({
+        data: { jobs: [makeJob(2)], has_more: false },
+        error: undefined,
+      });
+    }
+  });
+
+  it("keeps successful rows when the scoped count request rejects", async () => {
+    const client = {
+      GET: vi.fn().mockImplementation((_path: string, opts: { params: { query: Record<string, unknown> } }) => {
+        if (opts.params.query.limit === 0) return Promise.reject(new Error("count unavailable"));
+        return Promise.resolve({
+          data: { jobs: [makeJob(7)], has_more: false },
+          error: undefined,
+        });
+      }),
+    };
+    const store = createJobsStore({ client: client as never, navigate: vi.fn() });
+
+    await store.loadJobs();
+
+    expect(store.getJobs().map((job) => job.id)).toEqual([7]);
+    expect(store.getError()).toBeNull();
+  });
 });
 
 describe("createJobsStore panel expansion", () => {

--- a/frontend/src/lib/stores/roborev-jobs.test.ts
+++ b/frontend/src/lib/stores/roborev-jobs.test.ts
@@ -180,7 +180,7 @@ describe("createJobsStore event stream", () => {
     bodyController?.enqueue(encoder.encode('{"type":"review.com'));
     bodyController?.enqueue(encoder.encode('pleted","job_id":42}\n'));
 
-    await vi.waitFor(() => expect(client.GET).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(client.GET).toHaveBeenCalledTimes(2));
     store.disconnectEventStream();
 
     await vi.waitFor(() => expect(bodyCancelled).toBe(true));
@@ -272,6 +272,34 @@ describe("createJobsStore auto-design filter", () => {
 });
 
 describe("createJobsStore filtered status counts", () => {
+  it("uses filtered counts while auto-design classifier jobs are hidden by default", async () => {
+    const client = {
+      GET: vi.fn().mockResolvedValue({
+        data: { jobs: [makeJob(1)], has_more: false },
+        error: undefined,
+      }),
+    };
+    const store = createJobsStore({ client: client as never, navigate: vi.fn() });
+
+    await store.loadJobs();
+
+    expect(store.getFilteredStatusCounts()).toEqual({
+      queued: 0,
+      running: 0,
+      done: 1,
+      failed: 0,
+    });
+    expect(client.GET).toHaveBeenCalledWith("/api/jobs", {
+      params: {
+        query: expect.objectContaining({
+          hide_classify_jobs: "true",
+          limit: 0,
+          omit_prompt: "true",
+        }),
+      },
+    });
+  });
+
   it("counts the complete filtered result instead of the paginated rows", async () => {
     const client = {
       GET: vi.fn().mockImplementation((_path: string, opts: { params: { query: Record<string, unknown> } }) => {

--- a/frontend/tests/e2e-full/roborev-e2e.spec.ts
+++ b/frontend/tests/e2e-full/roborev-e2e.spec.ts
@@ -639,6 +639,53 @@ test.describe.serial("Roborev", () => {
       await expect(autoDesignClassifyRow.locator(".col-type")).toHaveText("classify");
     });
 
+    test("status counts follow the default auto-design visibility", async ({ page }) => {
+      await page.route("**/api/roborev/api/stream/events", (route) => route.abort());
+      await waitForReviewsReady(page);
+      await waitForJobRows(page, 10);
+
+      await page.locator(".picker-button").click();
+      const visibleJobsResponse = page.waitForResponse((response) => {
+        const url = new URL(response.url());
+        return (
+          response.ok() &&
+          url.pathname.endsWith("/api/roborev/api/jobs") &&
+          url.searchParams.get("limit") === "0" &&
+          url.searchParams.get("hide_classify_jobs") === "true" &&
+          url.searchParams.getAll("repo").some((repo) => repo.includes("test-repo-alpha"))
+        );
+      });
+      await page.locator(".dropdown-item.repo-item", { hasText: "test-repo-alpha" }).click();
+      const visibleJobsBody = (await (await visibleJobsResponse).json()) as {
+        jobs: Array<{ id: number; status: string }>;
+      };
+      const visibleFailed = visibleJobsBody.jobs.filter((job) => job.status === "failed").length;
+      expect(visibleJobsBody.jobs.some((job) => job.id === 76)).toBe(false);
+
+      await expect(page.locator('.status-counts [title="Failed"]')).toHaveText(`${visibleFailed} failed`);
+
+      const allJobsResponse = page.waitForResponse((response) => {
+        const url = new URL(response.url());
+        return (
+          response.ok() &&
+          url.pathname.endsWith("/api/roborev/api/jobs") &&
+          url.searchParams.get("limit") === "0" &&
+          url.searchParams.get("hide_classify_jobs") === null &&
+          url.searchParams.getAll("repo").some((repo) => repo.includes("test-repo-alpha"))
+        );
+      });
+      await page.getByLabel("Show auto-design").check();
+
+      const allJobsBody = (await (await allJobsResponse).json()) as {
+        jobs: Array<{ id: number; status: string }>;
+      };
+      const allFailed = allJobsBody.jobs.filter((job) => job.status === "failed").length;
+      expect(allJobsBody.jobs.some((job) => job.id === 76)).toBe(true);
+      expect(allFailed).toBeGreaterThan(visibleFailed);
+      await expect(page.locator(".git-ref[title='auto-design-classify']")).toBeVisible();
+      await expect(page.locator('.status-counts [title="Failed"]')).toHaveText(`${allFailed} failed`);
+    });
+
     test("reset each filter to default restores full list", async ({ page }) => {
       await waitForReviewsReady(page);
       await waitForJobRows(page, 10);

--- a/packages/ui/src/components/roborev/DaemonStatus.svelte
+++ b/packages/ui/src/components/roborev/DaemonStatus.svelte
@@ -5,6 +5,11 @@
   const daemon = stores.roborevDaemon;
 
   const counts = $derived(stores.roborevJobs?.getFilteredStatusCounts());
+  const filteredCounts = $derived(stores.roborevJobs?.usesFilteredStatusCounts() ?? false);
+
+  function displayCount(filtered: number | undefined, daemonTotal: number): number | string {
+    return filteredCounts ? (filtered ?? "--") : daemonTotal;
+  }
 
   function formatVersion(version: string): string {
     if (version.startsWith("v")) return version;
@@ -42,16 +47,16 @@
 
       <span class="status-counts">
         <span class="count count-queued" title="Queued">
-          {counts?.queued ?? daemon.getQueuedJobs()} queued
+          {displayCount(counts?.queued, daemon.getQueuedJobs())} queued
         </span>
         <span class="count count-running" title="Running">
-          {counts?.running ?? daemon.getRunningJobs()} running
+          {displayCount(counts?.running, daemon.getRunningJobs())} running
         </span>
         <span class="count count-done" title="Done">
-          {counts?.done ?? daemon.getCompletedJobs()} done
+          {displayCount(counts?.done, daemon.getCompletedJobs())} done
         </span>
         <span class="count count-failed" title="Failed">
-          {counts?.failed ?? daemon.getFailedJobs()} failed
+          {displayCount(counts?.failed, daemon.getFailedJobs())} failed
         </span>
       </span>
     {:else}

--- a/packages/ui/src/components/roborev/DaemonStatus.svelte
+++ b/packages/ui/src/components/roborev/DaemonStatus.svelte
@@ -4,6 +4,8 @@
   const stores = getStores();
   const daemon = stores.roborevDaemon;
 
+  const counts = $derived(stores.roborevJobs?.getFilteredStatusCounts());
+
   function formatVersion(version: string): string {
     if (version.startsWith("v")) return version;
     return `v${version}`;
@@ -40,16 +42,16 @@
 
       <span class="status-counts">
         <span class="count count-queued" title="Queued">
-          {daemon.getQueuedJobs()} queued
+          {counts?.queued ?? daemon.getQueuedJobs()} queued
         </span>
         <span class="count count-running" title="Running">
-          {daemon.getRunningJobs()} running
+          {counts?.running ?? daemon.getRunningJobs()} running
         </span>
         <span class="count count-done" title="Done">
-          {daemon.getCompletedJobs()} done
+          {counts?.done ?? daemon.getCompletedJobs()} done
         </span>
         <span class="count count-failed" title="Failed">
-          {daemon.getFailedJobs()} failed
+          {counts?.failed ?? daemon.getFailedJobs()} failed
         </span>
       </span>
     {:else}

--- a/packages/ui/src/components/roborev/DaemonStatus.test.ts
+++ b/packages/ui/src/components/roborev/DaemonStatus.test.ts
@@ -18,6 +18,7 @@ type DaemonStoreStub = {
 const state = {
   daemon: null as DaemonStoreStub | null,
   filteredCounts: undefined as { queued: number; running: number; done: number; failed: number } | undefined,
+  filteredScope: false,
 };
 
 vi.mock("../../context.js", () => ({
@@ -25,6 +26,7 @@ vi.mock("../../context.js", () => ({
     roborevDaemon: state.daemon,
     roborevJobs: {
       getFilteredStatusCounts: () => state.filteredCounts,
+      usesFilteredStatusCounts: () => state.filteredScope,
     },
   }),
 }));
@@ -52,6 +54,7 @@ describe("DaemonStatus", () => {
     cleanup();
     state.daemon = null;
     state.filteredCounts = undefined;
+    state.filteredScope = false;
   });
 
   it("does not prepend another v when the daemon version already has one", () => {
@@ -69,6 +72,7 @@ describe("DaemonStatus", () => {
   });
 
   it("shows counts from the filtered jobs view when available", () => {
+    state.filteredScope = true;
     state.filteredCounts = { queued: 1, running: 0, done: 3, failed: 2 };
 
     render(DaemonStatus);
@@ -77,5 +81,17 @@ describe("DaemonStatus", () => {
     expect(screen.getByTitle("Running").textContent?.trim()).toBe("0 running");
     expect(screen.getByTitle("Done").textContent?.trim()).toBe("3 done");
     expect(screen.getByTitle("Failed").textContent?.trim()).toBe("2 failed");
+  });
+
+  it("does not fall back to daemon totals before scoped counts are available", () => {
+    state.filteredScope = true;
+    state.daemon = {
+      ...createDaemonStore("v0.52.0"),
+      getFailedJobs: () => 9,
+    };
+
+    render(DaemonStatus);
+
+    expect(screen.getByTitle("Failed").textContent?.trim()).toBe("-- failed");
   });
 });

--- a/packages/ui/src/components/roborev/DaemonStatus.test.ts
+++ b/packages/ui/src/components/roborev/DaemonStatus.test.ts
@@ -17,11 +17,15 @@ type DaemonStoreStub = {
 
 const state = {
   daemon: null as DaemonStoreStub | null,
+  filteredCounts: undefined as { queued: number; running: number; done: number; failed: number } | undefined,
 };
 
 vi.mock("../../context.js", () => ({
   getStores: () => ({
     roborevDaemon: state.daemon,
+    roborevJobs: {
+      getFilteredStatusCounts: () => state.filteredCounts,
+    },
   }),
 }));
 
@@ -47,6 +51,7 @@ describe("DaemonStatus", () => {
   afterEach(() => {
     cleanup();
     state.daemon = null;
+    state.filteredCounts = undefined;
   });
 
   it("does not prepend another v when the daemon version already has one", () => {
@@ -61,5 +66,16 @@ describe("DaemonStatus", () => {
     render(DaemonStatus);
 
     expect(screen.getByTitle("Daemon version").textContent).toBe("v0.52.0");
+  });
+
+  it("shows counts from the filtered jobs view when available", () => {
+    state.filteredCounts = { queued: 1, running: 0, done: 3, failed: 2 };
+
+    render(DaemonStatus);
+
+    expect(screen.getByTitle("Queued").textContent?.trim()).toBe("1 queued");
+    expect(screen.getByTitle("Running").textContent?.trim()).toBe("0 running");
+    expect(screen.getByTitle("Done").textContent?.trim()).toBe("3 done");
+    expect(screen.getByTitle("Failed").textContent?.trim()).toBe("2 failed");
   });
 });

--- a/packages/ui/src/stores/roborev/jobs.svelte.ts
+++ b/packages/ui/src/stores/roborev/jobs.svelte.ts
@@ -12,6 +12,13 @@ export interface JobsStoreOptions {
   onError?: (msg: string) => void;
 }
 
+export interface JobStatusCounts {
+  queued: number;
+  running: number;
+  done: number;
+  failed: number;
+}
+
 type SortColumn = "id" | "status" | "verdict" | "agent" | "elapsed" | "cost" | "job_type" | "enqueued_at";
 type SortDirection = "asc" | "desc";
 
@@ -31,6 +38,7 @@ export function createJobsStore(opts: JobsStoreOptions) {
   let loading = $state(false);
   let hasMore = $state(false);
   let stats = $state<JobStats>({ done: 0, closed: 0, open: 0 });
+  let filteredStatusCounts = $state<JobStatusCounts | undefined>(undefined);
   let storeError = $state<string | null>(null);
   let selectedJobId = $state<number | undefined>(undefined);
   let highlightedJobId = $state<number | undefined>(undefined);
@@ -80,6 +88,29 @@ export function createJobsStore(opts: JobsStoreOptions) {
     if (filterJobType) q.job_type = filterJobType;
     if (!filterShowAutoDesign) q.hide_classify_jobs = "true";
     return q;
+  }
+
+  function hasActiveFilters(): boolean {
+    return Boolean(
+      filterRepo ||
+      filterBranch ||
+      filterStatus ||
+      filterSearch ||
+      filterHideClosed ||
+      filterJobType ||
+      filterShowAutoDesign,
+    );
+  }
+
+  function countJobsByStatus(filteredJobs: ReviewJob[]): JobStatusCounts {
+    const counts: JobStatusCounts = { queued: 0, running: 0, done: 0, failed: 0 };
+    for (const job of filteredJobs) {
+      if (job.status === "queued") counts.queued += 1;
+      else if (job.status === "running") counts.running += 1;
+      else if (job.status === "done") counts.done += 1;
+      else if (job.status === "failed") counts.failed += 1;
+    }
+    return counts;
   }
 
   function getElapsedSeconds(job: ReviewJob): number {
@@ -146,17 +177,31 @@ export function createJobsStore(opts: JobsStoreOptions) {
 
   async function loadJobs(): Promise<void> {
     const version = ++requestVersion;
+    const filtered = hasActiveFilters();
     loading = true;
     storeError = null;
+    filteredStatusCounts = undefined;
     try {
-      const { data, error } = await client.GET("/api/jobs", {
-        params: { query: buildQuery() },
-      });
+      const query = buildQuery();
+      const [listResult, countResult] = await Promise.all([
+        client.GET("/api/jobs", { params: { query } }),
+        filtered
+          ? client.GET("/api/jobs", {
+              params: {
+                query: { ...query, limit: 0, omit_prompt: "true" },
+              },
+            })
+          : Promise.resolve(undefined),
+      ]);
+      const { data, error } = listResult;
       if (error) throw new Error("Failed to load jobs");
       if (version !== requestVersion) return;
       jobs = sortJobs(data?.jobs ?? []);
       hasMore = data?.has_more ?? false;
       stats = data?.stats ?? { done: 0, closed: 0, open: 0 };
+      if (filtered && countResult && !countResult.error) {
+        filteredStatusCounts = countJobsByStatus(countResult.data?.jobs ?? []);
+      }
       const expandedRuns: Record<string, true> = {};
       for (const job of jobs) {
         const runUuid = job.panel_run_uuid;
@@ -586,6 +631,9 @@ export function createJobsStore(opts: JobsStoreOptions) {
   function getStats(): JobStats {
     return stats;
   }
+  function getFilteredStatusCounts(): JobStatusCounts | undefined {
+    return filteredStatusCounts;
+  }
   function getError(): string | null {
     return storeError;
   }
@@ -632,6 +680,7 @@ export function createJobsStore(opts: JobsStoreOptions) {
     isLoading,
     getHasMore,
     getStats,
+    getFilteredStatusCounts,
     getError,
     getSelectedJobId,
     getHighlightedJobId,

--- a/packages/ui/src/stores/roborev/jobs.svelte.ts
+++ b/packages/ui/src/stores/roborev/jobs.svelte.ts
@@ -98,7 +98,7 @@ export function createJobsStore(opts: JobsStoreOptions) {
       filterSearch ||
       filterHideClosed ||
       filterJobType ||
-      filterShowAutoDesign,
+      !filterShowAutoDesign,
     );
   }
 

--- a/packages/ui/src/stores/roborev/jobs.svelte.ts
+++ b/packages/ui/src/stores/roborev/jobs.svelte.ts
@@ -39,6 +39,7 @@ export function createJobsStore(opts: JobsStoreOptions) {
   let hasMore = $state(false);
   let stats = $state<JobStats>({ done: 0, closed: 0, open: 0 });
   let filteredStatusCounts = $state<JobStatusCounts | undefined>(undefined);
+  let filteredStatusCountsScope: string | undefined;
   let storeError = $state<string | null>(null);
   let selectedJobId = $state<number | undefined>(undefined);
   let highlightedJobId = $state<number | undefined>(undefined);
@@ -180,17 +181,23 @@ export function createJobsStore(opts: JobsStoreOptions) {
     const filtered = hasActiveFilters();
     loading = true;
     storeError = null;
-    filteredStatusCounts = undefined;
     try {
       const query = buildQuery();
+      const countQuery = { ...query, limit: 0, omit_prompt: "true" as const };
+      const countScope = JSON.stringify(countQuery);
+      if (filtered && filteredStatusCountsScope !== countScope) {
+        filteredStatusCounts = undefined;
+      }
       const [listResult, countResult] = await Promise.all([
         client.GET("/api/jobs", { params: { query } }),
         filtered
-          ? client.GET("/api/jobs", {
-              params: {
-                query: { ...query, limit: 0, omit_prompt: "true" },
-              },
-            })
+          ? client
+              .GET("/api/jobs", {
+                params: {
+                  query: countQuery,
+                },
+              })
+              .catch(() => undefined)
           : Promise.resolve(undefined),
       ]);
       const { data, error } = listResult;
@@ -201,6 +208,7 @@ export function createJobsStore(opts: JobsStoreOptions) {
       stats = data?.stats ?? { done: 0, closed: 0, open: 0 };
       if (filtered && countResult && !countResult.error) {
         filteredStatusCounts = countJobsByStatus(countResult.data?.jobs ?? []);
+        filteredStatusCountsScope = countScope;
       }
       const expandedRuns: Record<string, true> = {};
       for (const job of jobs) {
@@ -634,6 +642,9 @@ export function createJobsStore(opts: JobsStoreOptions) {
   function getFilteredStatusCounts(): JobStatusCounts | undefined {
     return filteredStatusCounts;
   }
+  function usesFilteredStatusCounts(): boolean {
+    return hasActiveFilters();
+  }
   function getError(): string | null {
     return storeError;
   }
@@ -681,6 +692,7 @@ export function createJobsStore(opts: JobsStoreOptions) {
     getHasMore,
     getStats,
     getFilteredStatusCounts,
+    usesFilteredStatusCounts,
     getError,
     getSelectedJobId,
     getHighlightedJobId,


### PR DESCRIPTION
- Make review status counts follow the active repository, branch, status, search, and visibility filters.
- Count the complete filtered result while keeping the review table paginated.

![Filtered roborev counts scoped to test-repo-beta](https://github.com/user-attachments/assets/bcfa9db9-6a54-45da-9e5b-0f2996032fa6)

<sup>generated by a clanker</sup>