### PR TITLE
Keep keyboard focus in a pooled terminal across a pane move

### DIFF
--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -302,12 +302,15 @@ Keyboard handlers must have one clear owner for each key press.
   websocket (`frontend/src/lib/stores/session-host.svelte.ts`).
 - A pooled terminal constructs immediately, even in parking, so every mounted
   session keeps its websocket; it opts out of renderer autofocus. After
-  attachment the pool focuses explicit requests and restores focus-event-tracked
-  keyboard ownership: a real pane move rips the focused textarea out of the DOM
-  silently (slot teardown fires no focusout), so never sample activeElement at
-  park time. Ownership is revoked by any other element's focus claim, and a
-  restore fires only into unclaimed focus
-  (`frontend/src/lib/components/terminal/PooledSessionTerminal.svelte`).
+  attachment the pool honors queued focus requests — explicit ones always, soft
+  navigation-driven ones (a detail surface switched items) only when current
+  focus is not sacred — and restores focus-event-tracked keyboard ownership: a
+  real pane move rips the focused textarea out of the DOM silently (slot
+  teardown fires no focusout), so never sample activeElement at park time.
+  Ownership is revoked by any other element's focus claim, and by a park that
+  settles with no destination (the pane closed) — a cross-flush transfer's
+  transient no-destination park keeps it. A restore fires only into unclaimed
+  focus (`frontend/src/lib/components/terminal/PooledSessionTerminal.svelte`).
 - A promoted session is recorded ONCE, in the detail surface's stored pane tree.
   Containers mask it out of what they render (derived, not an effect) and never
   prune their own stored trees, so demoting restores the tab order, split, and

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -301,10 +301,12 @@ Keyboard handlers must have one clear owner for each key press.
   the pool only while it actually renders it, since a parked terminal keeps its
   websocket (`frontend/src/lib/stores/session-host.svelte.ts`).
 - A pooled terminal constructs immediately, even in parking, so every mounted
-  session keeps its websocket; it opts out of renderer autofocus and after
-  attachment the pool focuses explicit requests plus focus the reparent itself
-  took: parking blurs xterm's textarea, so a pane move restores focus a wrapper
-  held, while a park with no destination (pane closed) drops that intent
+  session keeps its websocket; it opts out of renderer autofocus. After
+  attachment the pool focuses explicit requests and restores focus-event-tracked
+  keyboard ownership: a real pane move rips the focused textarea out of the DOM
+  silently (slot teardown fires no focusout), so never sample activeElement at
+  park time. Ownership is revoked by any other element's focus claim, and a
+  restore fires only into unclaimed focus
   (`frontend/src/lib/components/terminal/PooledSessionTerminal.svelte`).
 - A promoted session is recorded ONCE, in the detail surface's stored pane tree.
   Containers mask it out of what they render (derived, not an effect) and never

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -301,8 +301,10 @@ Keyboard handlers must have one clear owner for each key press.
   the pool only while it actually renders it, since a parked terminal keeps its
   websocket (`frontend/src/lib/stores/session-host.svelte.ts`).
 - A pooled terminal constructs immediately, even in parking, so every mounted
-  session keeps its websocket; it opts out of renderer autofocus and the pool
-  focuses only explicit requests after attachment
+  session keeps its websocket; it opts out of renderer autofocus and after
+  attachment the pool focuses explicit requests plus focus the reparent itself
+  took: parking blurs xterm's textarea, so a pane move restores focus a wrapper
+  held, while a park with no destination (pane closed) drops that intent
   (`frontend/src/lib/components/terminal/PooledSessionTerminal.svelte`).
 - A promoted session is recorded ONCE, in the detail surface's stored pane tree.
   Containers mask it out of what they render (derived, not an effect) and never

--- a/frontend/src/lib/components/terminal/PooledSessionTerminal.svelte
+++ b/frontend/src/lib/components/terminal/PooledSessionTerminal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { tick } from "svelte";
   import TerminalPane from "./TerminalPane.svelte";
+  import { focusIsSacred } from "./terminal-focus.ts";
   import { consumeSessionFocus, type MountedSession } from "../../stores/session-host.svelte.ts";
 
   interface Props {
@@ -52,8 +53,26 @@
     if (!node || !park) return;
     attached = false;
     park.appendChild(node);
-    if (!destination || destination === park) return;
     let cancelled = false;
+    if (!destination || destination === park) {
+      // Parked with nowhere to go: the pane closed — unless this park is the
+      // transient first half of a cross-flush transfer whose destination
+      // registers a moment later (a promotion can do this). Settle on the
+      // same tick-then-frame cadence attachment uses before dropping
+      // ownership, so focus a close took is never replayed on some later,
+      // unrelated reveal, while a transfer mid-handoff keeps it.
+      void (async () => {
+        await tick();
+        if (cancelled) return;
+        requestAnimationFrame(() => {
+          if (cancelled) return;
+          ownsFocus = false;
+        });
+      })();
+      return () => {
+        cancelled = true;
+      };
+    }
     void (async () => {
       await tick();
       if (cancelled) return;
@@ -80,8 +99,13 @@
     const node = wrapper;
     if (!node) return;
     const requested = consumeSessionFocus(session.hostKey);
+    // A soft request is navigation asking, not the user: it loses to a sacred
+    // focus target (form fields, dialogs) but wins over a plain button, the
+    // same contract renderer autofocus follows at creation.
+    const granted =
+      requested === "explicit" || (requested === "soft" && !focusIsSacred(document.activeElement));
     const unclaimed = document.activeElement === null || document.activeElement === document.body;
-    if (!requested && !(ownsFocus && unclaimed)) return;
+    if (!granted && !(ownsFocus && unclaimed)) return;
     terminalPane?.focus();
     if (!node.contains(document.activeElement)) node.focus();
   });

--- a/frontend/src/lib/components/terminal/PooledSessionTerminal.svelte
+++ b/frontend/src/lib/components/terminal/PooledSessionTerminal.svelte
@@ -20,6 +20,13 @@
   // the parking node and resize the real tmux pane to one row.
   let attached = $state(false);
 
+  // Parking to move between slots blurs xterm's helper textarea (the wrapper
+  // passes through a display:none node and goes inert), so a pane move would
+  // silently take the keyboard away from a terminal the user was typing in.
+  // Remember that the wrapper held focus and give it back after attachment.
+  // Not $state: the focus effect below already reruns on `attached`.
+  let restoreFocus = false;
+
   // Placement, mirroring WorkspaceHost's: park first, attach after a tick.
   // Parking rather than leaving the wrapper in place matters because the
   // previous slot may be unmounting in this same flush.
@@ -35,8 +42,15 @@
     const park = parking;
     if (!node || !park) return;
     attached = false;
+    if (node.contains(document.activeElement)) restoreFocus = true;
     park.appendChild(node);
-    if (!destination || destination === park) return;
+    if (!destination || destination === park) {
+      // Parked with nowhere to go: the pane closed. Like the workspace host's
+      // clearPendingHostFocus, the intent must not fire on some later,
+      // unrelated reveal.
+      restoreFocus = false;
+      return;
+    }
     let cancelled = false;
     void (async () => {
       await tick();
@@ -52,14 +66,18 @@
     };
   });
 
-  // Focus an explicitly requested terminal whether the request arrived before
-  // attachment or after it was already visible. The renderer queues the request
-  // through its async construction; the wrapper is an immediate fallback while
-  // that work finishes.
+  // Focus the terminal on an explicit request (whether it arrived before
+  // attachment or after it was already visible) or to give back focus a
+  // reparent took. The renderer queues the request through its async
+  // construction; the wrapper is an immediate fallback while that work
+  // finishes.
   $effect(() => {
     if (!attached || !active) return;
     const node = wrapper;
-    if (!node || !consumeSessionFocus(session.hostKey)) return;
+    if (!node) return;
+    const requested = consumeSessionFocus(session.hostKey);
+    if (!requested && !restoreFocus) return;
+    restoreFocus = false;
     terminalPane?.focus();
     if (!node.contains(document.activeElement)) node.focus();
   });

--- a/frontend/src/lib/components/terminal/PooledSessionTerminal.svelte
+++ b/frontend/src/lib/components/terminal/PooledSessionTerminal.svelte
@@ -20,12 +20,21 @@
   // the parking node and resize the real tmux pane to one row.
   let attached = $state(false);
 
-  // Parking to move between slots blurs xterm's helper textarea (the wrapper
-  // passes through a display:none node and goes inert), so a pane move would
-  // silently take the keyboard away from a terminal the user was typing in.
-  // Remember that the wrapper held focus and give it back after attachment.
-  // Not $state: the focus effect below already reruns on `attached`.
-  let restoreFocus = false;
+  // The wrapper owns the keyboard when the last focus event landed inside it.
+  // Focus events are the only reliable signal: a real pane move tears down the
+  // source slot, which rips the focused textarea out of the DOM (no focusout
+  // fires on removal) before this component's effects run, so sampling
+  // document.activeElement at park time never sees the focus it must restore.
+  // Ownership survives that silent loss and is revoked only when another
+  // element actually claims focus. Not $state: decisions are made when
+  // `attached`/`active` flip, which the focus effect already tracks.
+  let ownsFocus = false;
+
+  function handleDocumentFocusIn(event: FocusEvent): void {
+    const node = wrapper;
+    if (!node) return;
+    ownsFocus = event.target instanceof Node && node.contains(event.target);
+  }
 
   // Placement, mirroring WorkspaceHost's: park first, attach after a tick.
   // Parking rather than leaving the wrapper in place matters because the
@@ -42,15 +51,8 @@
     const park = parking;
     if (!node || !park) return;
     attached = false;
-    if (node.contains(document.activeElement)) restoreFocus = true;
     park.appendChild(node);
-    if (!destination || destination === park) {
-      // Parked with nowhere to go: the pane closed. Like the workspace host's
-      // clearPendingHostFocus, the intent must not fire on some later,
-      // unrelated reveal.
-      restoreFocus = false;
-      return;
-    }
+    if (!destination || destination === park) return;
     let cancelled = false;
     void (async () => {
       await tick();
@@ -67,17 +69,19 @@
   });
 
   // Focus the terminal on an explicit request (whether it arrived before
-  // attachment or after it was already visible) or to give back focus a
-  // reparent took. The renderer queues the request through its async
-  // construction; the wrapper is an immediate fallback while that work
-  // finishes.
+  // attachment or after it was already visible), or to give back focus a
+  // reparent took. Restoration is decided here, at attachment, and only into
+  // unclaimed focus: anything else that took the keyboard since the reparent
+  // keeps it, and an intent that was not honored now never fires later. The
+  // renderer queues explicit requests through its async construction; the
+  // wrapper is an immediate fallback while that work finishes.
   $effect(() => {
     if (!attached || !active) return;
     const node = wrapper;
     if (!node) return;
     const requested = consumeSessionFocus(session.hostKey);
-    if (!requested && !restoreFocus) return;
-    restoreFocus = false;
+    const unclaimed = document.activeElement === null || document.activeElement === document.body;
+    if (!requested && !(ownsFocus && unclaimed)) return;
     terminalPane?.focus();
     if (!node.contains(document.activeElement)) node.focus();
   });
@@ -87,6 +91,8 @@
   // terminal sitting in whatever slot last held it.
   $effect(() => () => wrapper?.remove());
 </script>
+
+<svelte:document onfocusin={handleDocumentFocusIn} />
 
 <!-- tabindex, like the workspace host's own wrapper: Focus Terminal on a session
      the user promoted has to put the keyboard somewhere inside its terminal, and

--- a/frontend/src/lib/components/terminal/SessionTerminalPool.browser.svelte.ts
+++ b/frontend/src/lib/components/terminal/SessionTerminalPool.browser.svelte.ts
@@ -215,6 +215,95 @@ describe("SessionTerminalPool", () => {
     }, WAIT);
   });
 
+  // The production path, unlike the registry-driven move above: a real pane
+  // move unmounts the source SessionTerminalSlot, whose cleanup parks the
+  // wrapper — silently blurring xterm, with no focusout — before the pool's
+  // placement effect runs. Focus must survive that ordering too.
+  for (const order of ["source-first", "destination-first"] as const) {
+    it(`keeps keyboard focus across a real slot transfer (${order})`, async () => {
+      mountSession(agent);
+      mountPool();
+      const harnessTarget = document.createElement("div");
+      document.body.append(harnessTarget);
+      const props = $state({ hostKey: agent, showSource: true, showDestination: false, order });
+      const harness = mount(SessionTerminalSlotTransferHarness, { target: harnessTarget, props });
+      await waitForReparent();
+
+      requestSessionFocus(agent);
+      await vi.waitFor(() => {
+        expect(document.activeElement?.closest(".terminal-container")).not.toBeNull();
+      }, WAIT);
+
+      flushSync(() => {
+        props.showSource = false;
+        props.showDestination = true;
+      });
+      await waitForReparent();
+
+      const wrapper = wrapperFor(agent) as HTMLElement;
+      expect(wrapper.parentElement?.parentElement?.dataset.slot).toBe("destination");
+      await vi.waitFor(() => {
+        expect(document.activeElement?.closest(".terminal-container")).not.toBeNull();
+      }, WAIT);
+
+      flushSync(() => unmount(harness as never));
+      harnessTarget.remove();
+    });
+  }
+
+  it("does not steal focus another element claimed during the move", async () => {
+    mountSession(agent);
+    mountPool();
+    showIn(agent, slotA);
+    await waitForReparent();
+
+    requestSessionFocus(agent);
+    await vi.waitFor(() => {
+      expect(document.activeElement?.closest(".terminal-container")).not.toBeNull();
+    }, WAIT);
+
+    const input = document.createElement("input");
+    document.body.append(input);
+
+    showIn(agent, slotB);
+    // Claimed between parking and attachment: the keyboard went somewhere on
+    // purpose, and the restore must not take it back.
+    input.focus();
+
+    const wrapper = wrapperFor(agent) as HTMLElement;
+    await vi.waitFor(() => expect(wrapper.inert).toBe(false), WAIT);
+    expect(document.activeElement).toBe(input);
+    input.remove();
+  });
+
+  it("drops the restore intent once focus was claimed elsewhere while parked", async () => {
+    mountSession(agent);
+    mountPool();
+    showIn(agent, slotA);
+    await waitForReparent();
+
+    requestSessionFocus(agent);
+    await vi.waitFor(() => {
+      expect(document.activeElement?.closest(".terminal-container")).not.toBeNull();
+    }, WAIT);
+
+    showIn(agent, null);
+    await waitForReparent();
+
+    // The user worked somewhere else while the pane was closed and left focus
+    // on nothing. A much later reveal must not replay the stale intent.
+    const input = document.createElement("input");
+    document.body.append(input);
+    input.focus();
+    input.blur();
+
+    showIn(agent, slotB);
+    const wrapper = wrapperFor(agent) as HTMLElement;
+    await vi.waitFor(() => expect(wrapper.inert).toBe(false), WAIT);
+    expect(document.activeElement?.closest(".terminal-container")).toBeNull();
+    input.remove();
+  });
+
   it("keeps two sessions live at once", async () => {
     mountSession(agent);
     mountSession(shell);

--- a/frontend/src/lib/components/terminal/SessionTerminalPool.browser.svelte.ts
+++ b/frontend/src/lib/components/terminal/SessionTerminalPool.browser.svelte.ts
@@ -191,6 +191,30 @@ describe("SessionTerminalPool", () => {
     button.remove();
   });
 
+  it("keeps keyboard focus inside the terminal across a pane move", async () => {
+    mountSession(agent);
+    mountPool();
+    showIn(agent, slotA);
+    await waitForReparent();
+
+    requestSessionFocus(agent);
+    await vi.waitFor(() => {
+      expect(document.activeElement?.closest(".terminal-container")).not.toBeNull();
+    }, WAIT);
+
+    // A pane move: the slot changes and nothing queues a focus request. The
+    // reparent through the display:none parking node blurs xterm's helper
+    // textarea, so unless the pool restores what it took, tmux copy/paste
+    // keys land on <body> until the user clicks the terminal again.
+    showIn(agent, slotB);
+    await waitForReparent();
+
+    expect(wrapperFor(agent)?.parentElement).toBe(slotB);
+    await vi.waitFor(() => {
+      expect(document.activeElement?.closest(".terminal-container")).not.toBeNull();
+    }, WAIT);
+  });
+
   it("keeps two sessions live at once", async () => {
     mountSession(agent);
     mountSession(shell);

--- a/frontend/src/lib/components/terminal/SessionTerminalPool.browser.svelte.ts
+++ b/frontend/src/lib/components/terminal/SessionTerminalPool.browser.svelte.ts
@@ -4,6 +4,7 @@ import { DEFAULT_TERMINAL_SETTINGS } from "@middleman/ui";
 
 import { STORES_KEY } from "../../../../../packages/ui/src/context.js";
 import {
+  consumeSessionFocus,
   noteSessionMounted,
   noteSessionUnmounted,
   registerSessionSlot,
@@ -276,6 +277,52 @@ describe("SessionTerminalPool", () => {
     input.remove();
   });
 
+  it("drops ownership when its pane closes, even with no focus claim after", async () => {
+    mountSession(agent);
+    mountPool();
+    showIn(agent, slotA);
+    await waitForReparent();
+
+    requestSessionFocus(agent);
+    await vi.waitFor(() => {
+      expect(document.activeElement?.closest(".terminal-container")).not.toBeNull();
+    }, WAIT);
+
+    // The pane closes while the terminal holds focus, and the user touches
+    // nothing focusable afterwards: focus sits on <body>. A later, unrelated
+    // reveal must not replay ownership the close already took away.
+    showIn(agent, null);
+    await waitForReparent();
+
+    showIn(agent, slotB);
+    const wrapper = wrapperFor(agent) as HTMLElement;
+    await vi.waitFor(() => expect(wrapper.inert).toBe(false), WAIT);
+    expect(document.activeElement?.closest(".terminal-container")).toBeNull();
+  });
+
+  it("keeps ownership through a cross-flush transfer's transient park", async () => {
+    mountSession(agent);
+    mountPool();
+    showIn(agent, slotA);
+    await waitForReparent();
+
+    requestSessionFocus(agent);
+    await vi.waitFor(() => {
+      expect(document.activeElement?.closest(".terminal-container")).not.toBeNull();
+    }, WAIT);
+
+    // A promotion can unregister the source slot in one flush and register the
+    // destination in the next: the terminal passes through a no-destination
+    // park. That transient must not be mistaken for the pane closing.
+    showIn(agent, null);
+    showIn(agent, slotB);
+    await waitForReparent();
+
+    await vi.waitFor(() => {
+      expect(document.activeElement?.closest(".terminal-container")).not.toBeNull();
+    }, WAIT);
+  });
+
   it("drops the restore intent once focus was claimed elsewhere while parked", async () => {
     mountSession(agent);
     mountPool();
@@ -301,6 +348,49 @@ describe("SessionTerminalPool", () => {
     const wrapper = wrapperFor(agent) as HTMLElement;
     await vi.waitFor(() => expect(wrapper.inert).toBe(false), WAIT);
     expect(document.activeElement?.closest(".terminal-container")).toBeNull();
+    input.remove();
+  });
+
+  it("honors a soft focus request over a plain button's focus", async () => {
+    mountSession(agent);
+    mountPool();
+    showIn(agent, slotA);
+    await waitForReparent();
+    const wrapper = wrapperFor(agent) as HTMLElement;
+    await vi.waitFor(() => expect(wrapper.inert).toBe(false), WAIT);
+
+    // A PR list row is a plain button: like a launch tile, it is not a focus
+    // target the terminal must defer to when navigation asks for acquisition.
+    const button = document.createElement("button");
+    document.body.append(button);
+    button.focus();
+
+    requestSessionFocus(agent, { soft: true });
+    await vi.waitFor(() => {
+      expect(document.activeElement?.closest(".terminal-container")).not.toBeNull();
+    }, WAIT);
+    button.remove();
+  });
+
+  it("declines a soft focus request while a sacred element holds focus", async () => {
+    mountSession(agent);
+    mountPool();
+    showIn(agent, slotA);
+    await waitForReparent();
+    const wrapper = wrapperFor(agent) as HTMLElement;
+    await vi.waitFor(() => expect(wrapper.inert).toBe(false), WAIT);
+
+    const input = document.createElement("input");
+    document.body.append(input);
+    input.focus();
+
+    requestSessionFocus(agent, { soft: true });
+    flushSync();
+
+    // The user is typing somewhere: navigation-driven acquisition must lose,
+    // and the declined request must not stay armed for a later reveal.
+    expect(document.activeElement).toBe(input);
+    expect(consumeSessionFocus(agent)).toBe(false);
     input.remove();
   });
 

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -37,6 +37,7 @@
   import {
     mountedSessions,
     noteSessionMounted,
+    isSessionSlotVisible,
     noteSessionUnmounted,
     onSessionExited,
     requestSessionFocus,
@@ -810,6 +811,29 @@
       sessionKeyFromWorkflowTab(activeTabKey) ??
       (terminalLayout.open ? terminalLayout.activeSessionKey : null),
   );
+
+  // Entering a detail item that hosts a live terminal asks for the keyboard,
+  // softly: the pool declines while focus is somewhere sacred, so navigation
+  // never pulls the user out of a form field or dialog. Without this, only a
+  // terminal the user had personally focused ever re-acquired focus (the
+  // pool's ownership restore), which made acquisition look random across PRs.
+  // Fires once per claim while the surface stays visible; leaving and coming
+  // back — another item, another tab — arms it again.
+  let acquiredFocusClaim: string | null = null;
+  $effect(() => {
+    if (paneSurface === undefined || !hostVisible) {
+      acquiredFocusClaim = null;
+      return;
+    }
+    const session = runtimeSessions.find((candidate) => candidate.key === currentSessionKey);
+    if (session === undefined) return;
+    const sessionHost = sessionHostKeyFor(session);
+    if (!isSessionSlotVisible(sessionHost)) return;
+    const claim = `${workspaceId} ${workspaceHostKey ?? ""}`;
+    if (acquiredFocusClaim === claim) return;
+    acquiredFocusClaim = claim;
+    requestSessionFocus(sessionHost, { soft: true });
+  });
 
   // Promotion implies mounted. Demotion hands the session back to the workflow
   // region, whose slot only renders for a mounted session, so a session promoted

--- a/frontend/src/lib/stores/session-host.svelte.ts
+++ b/frontend/src/lib/stores/session-host.svelte.ts
@@ -176,7 +176,10 @@ export function noteSessionUnmounted(key: SessionHostKey): void {
   // waits for a subtree under the same key to mount - a revisit, or the pane being
   // reopened for its own reasons - and steals focus for a Focus Terminal the user
   // pressed long before, somewhere else.
-  if (pendingFocusKey === key) pendingFocusKey = null;
+  if (pendingFocusKey === key) {
+    pendingFocusKey = null;
+    pendingFocusSoft = false;
+  }
   mounted = mounted.filter((session) => session.hostKey !== key);
   registerSessionSlot(key, null);
 }
@@ -206,21 +209,36 @@ export function noteSessionExited(key: SessionHostKey, code: number): void {
 // request to. Deliberately a single slot: only one focus request can be
 // outstanding, and a newer one supersedes it.
 let pendingFocusKey = $state<SessionHostKey | null>(null);
+let pendingFocusSoft = false;
 
-export function requestSessionFocus(key: SessionHostKey): void {
+/**
+ * Queue a focus request for a session's terminal. Explicit requests (Focus
+ * Terminal, a fresh launch) always land. Soft requests come from navigation —
+ * a detail surface switched to another item — and the pool declines them when
+ * focus is somewhere sacred, so switching PRs never pulls the keyboard out of
+ * a form field or dialog.
+ */
+export function requestSessionFocus(key: SessionHostKey, opts?: { soft?: boolean }): void {
   pendingFocusKey = key;
+  pendingFocusSoft = opts?.soft === true;
 }
 
 /** Drop an outstanding request, for when focus moves somewhere else entirely. */
 export function clearSessionFocusRequest(): void {
   pendingFocusKey = null;
+  pendingFocusSoft = false;
 }
 
-/** True when this session owns the outstanding focus request, which it consumes. */
-export function consumeSessionFocus(key: SessionHostKey): boolean {
+/**
+ * The outstanding request's flavor when this session owns it, which it
+ * consumes; false otherwise.
+ */
+export function consumeSessionFocus(key: SessionHostKey): "explicit" | "soft" | false {
   if (pendingFocusKey !== key) return false;
   pendingFocusKey = null;
-  return true;
+  const soft = pendingFocusSoft;
+  pendingFocusSoft = false;
+  return soft ? "soft" : "explicit";
 }
 
 export function resetSessionHostForTest(): void {
@@ -229,5 +247,6 @@ export function resetSessionHostForTest(): void {
   for (const key of Object.keys(slotVisible)) delete slotVisible[key];
   mounted = [];
   pendingFocusKey = null;
+  pendingFocusSoft = false;
   exitListeners.clear();
 }

--- a/frontend/src/lib/stores/session-host.test.ts
+++ b/frontend/src/lib/stores/session-host.test.ts
@@ -49,6 +49,26 @@ describe("session host registry", () => {
     expect(consumeSessionFocus(agentOnA)).toBe(false);
   });
 
+  it("distinguishes soft focus requests from explicit ones", () => {
+    // Soft requests come from navigation (a detail surface switched items), and
+    // the pool must be able to decline them when focus is somewhere sacred.
+    requestSessionFocus(agentOnA, { soft: true });
+    expect(consumeSessionFocus(agentOnA)).toBe("soft");
+    expect(consumeSessionFocus(agentOnA)).toBe(false);
+
+    requestSessionFocus(agentOnA);
+    expect(consumeSessionFocus(agentOnA)).toBe("explicit");
+  });
+
+  it("supersedes a soft request's flavor along with its key", () => {
+    const shellOnA = sessionHostKey("ws-1", undefined, "shell", "2026-01-01T00:00:00Z");
+    requestSessionFocus(agentOnA, { soft: true });
+    requestSessionFocus(shellOnA);
+    // A stale soft flavor on a newer explicit request would let a sacred
+    // element veto a focus the user explicitly asked for.
+    expect(consumeSessionFocus(shellOnA)).toBe("explicit");
+  });
+
   it("registers and clears one slot per session key", () => {
     const el = document.createElement("div");
     registerSessionSlot(agentOnA, el);

--- a/frontend/tests/e2e-full/terminal-focus-pane-move.spec.ts
+++ b/frontend/tests/e2e-full/terminal-focus-pane-move.spec.ts
@@ -49,21 +49,37 @@ async function waitForWorkspaceReady(api: APIRequestContext, workspaceId: string
   throw new Error(`workspace ${workspaceId} did not become ready`);
 }
 
-async function createIssueWorkspace(api: APIRequestContext): Promise<WorkspaceStatusResponse> {
-  const response = await api.post("/api/v1/issues/github/acme/widgets/10/workspace", { data: {} });
+async function createIssueWorkspace(api: APIRequestContext, issueNumber = 10): Promise<WorkspaceStatusResponse> {
+  const response = await api.post(`/api/v1/issues/github/acme/widgets/${issueNumber}/workspace`, {
+    data: {},
+  });
   expect(response.status()).toBe(202);
   const workspace = (await response.json()) as WorkspaceStatusResponse;
   return waitForWorkspaceReady(api, workspace.id);
 }
 
-async function launchDockedShell(api: APIRequestContext, workspaceId: string): Promise<void> {
+async function launchShell(
+  api: APIRequestContext,
+  workspaceId: string,
+  region: "terminal" | "workflow",
+): Promise<void> {
   const response = await api.post(`/api/v1/workspaces/${workspaceId}/runtime/sessions`, {
     data: {
       target_key: "plain_shell",
-      display_region: "terminal",
+      display_region: region,
     },
   });
   expect(response.status(), await response.text()).toBe(200);
+}
+
+async function launchDockedShell(api: APIRequestContext, workspaceId: string): Promise<void> {
+  await launchShell(api, workspaceId, "terminal");
+}
+
+async function focusedSessionHost(page: Page): Promise<string | null> {
+  return page.evaluate(
+    () => document.activeElement?.closest("[data-session-host]")?.getAttribute("data-session-host") ?? null,
+  );
 }
 
 async function openTerminalPanel(page: Page): Promise<Locator> {
@@ -266,6 +282,49 @@ test("terminal keeps keyboard focus across a pane move without a click", async (
         timeout: 15_000,
       })
       .toBe(true);
+  } finally {
+    await api?.dispose();
+    await isolatedServer?.stop();
+  }
+});
+
+test("terminal acquires keyboard focus on every item switch, not just the first", async ({ page }) => {
+  test.skip(!hasCommand("git") || !hasCommand("tmux", ["-V"]), "git and tmux are required for the real workspace flow");
+  await page.setViewportSize({ width: 1440, height: 900 });
+
+  let isolatedServer: IsolatedE2EServer | null = null;
+  let api: APIRequestContext | null = null;
+  try {
+    isolatedServer = await startIsolatedWorkspaceE2EServer();
+    api = await playwrightRequest.newContext({
+      baseURL: isolatedServer.info.base_url,
+    });
+    // Two items, each with its own workspace and a live tmux shell filling the
+    // workspace pane, so switching items swaps the whole terminal under the
+    // detail surface.
+    const first = await createIssueWorkspace(api, 10);
+    const second = await createIssueWorkspace(api, 13);
+    await launchShell(api, first.id, "workflow");
+    await launchShell(api, second.id, "workflow");
+
+    // Entering an item with a live terminal must hand it the keyboard without
+    // any click: the only prior focus is the page body.
+    await page.goto(`${isolatedServer.info.base_url}/issues/github/acme/widgets/10`);
+    await expect(page.locator(".detail-pane-workspace-slot .workspace-host-wrapper")).toBeVisible();
+    await expect.poll(() => activeElementDescription(page), { timeout: 15_000 }).toContain("xterm-helper-textarea");
+    expect(await focusedSessionHost(page)).toContain(first.id);
+
+    // Switching to another item with a workspace must acquire again — the bug
+    // was that only the first terminal ever did. The sidebar row is a plain
+    // button, exactly the focus a soft request is allowed to take.
+    await page.locator("aside button", { hasText: "#13" }).first().click();
+    await expect.poll(() => focusedSessionHost(page), { timeout: 15_000 }).toContain(second.id);
+    await expect.poll(() => activeElementDescription(page)).toContain("xterm-helper-textarea");
+
+    // And back: re-entry is an acquisition too, not a one-shot.
+    await page.locator("aside button", { hasText: "#10" }).first().click();
+    await expect.poll(() => focusedSessionHost(page), { timeout: 15_000 }).toContain(first.id);
+    await expect.poll(() => activeElementDescription(page)).toContain("xterm-helper-textarea");
   } finally {
     await api?.dispose();
     await isolatedServer?.stop();

--- a/frontend/tests/e2e-full/terminal-focus-pane-move.spec.ts
+++ b/frontend/tests/e2e-full/terminal-focus-pane-move.spec.ts
@@ -1,0 +1,273 @@
+import { execFileSync } from "node:child_process";
+import {
+  expect,
+  request as playwrightRequest,
+  test,
+  type APIRequestContext,
+  type Locator,
+  type Page,
+} from "@playwright/test";
+import { startIsolatedWorkspaceE2EServer, type IsolatedE2EServer } from "./support/e2eServer";
+
+// Regression for the pane-move focus loss shipped with the rearrangeable
+// detail panes: moving a pooled session terminal reparents its DOM subtree
+// through a display:none parking node, silently blurring xterm's helper
+// textarea. Keyboard input and keyboard-driven tmux copy/paste must keep
+// working after the move WITHOUT clicking the terminal again — the existing
+// clipboard spec clicks before every operation, which masks exactly this.
+
+type WorkspaceStatusResponse = {
+  id: string;
+  status: string;
+  error_message?: string | null;
+};
+
+const preMarker = "TERM_FOCUS_PRE_MOVE";
+const postMarker = "TERM_FOCUS_POST_MOVE";
+const clipboardMarker = "TERM_FOCUS_TMUX_CLIP";
+
+function hasCommand(command: string, args: string[] = ["--version"]): boolean {
+  try {
+    execFileSync(command, args, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForWorkspaceReady(api: APIRequestContext, workspaceId: string): Promise<WorkspaceStatusResponse> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const response = await api.get(`/api/v1/workspaces/${workspaceId}`);
+    expect(response.ok()).toBe(true);
+    const workspace = (await response.json()) as WorkspaceStatusResponse;
+    if (workspace.status === "ready") return workspace;
+    if (workspace.status === "error") {
+      throw new Error(workspace.error_message ?? `workspace ${workspaceId} failed to become ready`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`workspace ${workspaceId} did not become ready`);
+}
+
+async function createIssueWorkspace(api: APIRequestContext): Promise<WorkspaceStatusResponse> {
+  const response = await api.post("/api/v1/issues/github/acme/widgets/10/workspace", { data: {} });
+  expect(response.status()).toBe(202);
+  const workspace = (await response.json()) as WorkspaceStatusResponse;
+  return waitForWorkspaceReady(api, workspace.id);
+}
+
+async function launchDockedShell(api: APIRequestContext, workspaceId: string): Promise<void> {
+  const response = await api.post(`/api/v1/workspaces/${workspaceId}/runtime/sessions`, {
+    data: {
+      target_key: "plain_shell",
+      display_region: "terminal",
+    },
+  });
+  expect(response.status(), await response.text()).toBe(200);
+}
+
+async function openTerminalPanel(page: Page): Promise<Locator> {
+  const open = page.getByRole("button", { name: "Open terminal panel" });
+  await expect(open).toBeVisible({ timeout: 15_000 });
+  await open.click();
+  const panel = page.locator(".terminal-panel.open");
+  await expect(panel).toBeVisible();
+  return panel;
+}
+
+function observeTerminal(page: Page): {
+  received(text: string): boolean;
+  sent(text: string): boolean;
+} {
+  const streams: Array<{ received: string; sent: string }> = [];
+  page.on("websocket", (socket) => {
+    const stream = { received: "", sent: "" };
+    streams.push(stream);
+    const receivedDecoder = new TextDecoder();
+    const sentDecoder = new TextDecoder();
+    socket.on("framereceived", ({ payload }) => {
+      const chunk = typeof payload === "string" ? payload : receivedDecoder.decode(payload, { stream: true });
+      stream.received = (stream.received + chunk).slice(-64 * 1024);
+    });
+    socket.on("framesent", ({ payload }) => {
+      const chunk = typeof payload === "string" ? payload : sentDecoder.decode(payload, { stream: true });
+      stream.sent = (stream.sent + chunk).slice(-64 * 1024);
+    });
+  });
+  return {
+    received: (text) => streams.some((stream) => stream.received.includes(text)),
+    sent: (text) => streams.some((stream) => stream.sent.includes(text)),
+  };
+}
+
+async function activeElementDescription(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    const element = document.activeElement;
+    if (!(element instanceof HTMLElement)) return String(element);
+    return [
+      element.tagName.toLowerCase(),
+      element.id ? `#${element.id}` : "",
+      ...Array.from(element.classList, (name) => `.${name}`),
+    ].join("");
+  });
+}
+
+// Deny the async clipboard API so the OSC 52 write is observable through the
+// HTTP fallback in every browser, the same boundary the clipboard spec uses.
+async function interceptClipboardFallback(page: Page): Promise<string[]> {
+  await page.addInitScript(() => {
+    const denied = () => Promise.reject(new DOMException("denied", "NotAllowedError"));
+    Object.defineProperties(navigator.clipboard, {
+      write: { configurable: true, value: denied },
+      writeText: { configurable: true, value: denied },
+    });
+  });
+  const writes: string[] = [];
+  await page.route("**/api/v1/terminal/clipboard", async (route) => {
+    const body = route.request().postDataJSON() as { text?: string };
+    writes.push(body.text ?? "");
+    await route.fulfill({ status: 204 });
+  });
+  return writes;
+}
+
+async function typeMarker(page: Page, marker: string): Promise<void> {
+  await page.keyboard.type(`printf '${marker}\\n'`);
+  await page.keyboard.press("Enter");
+}
+
+async function runTmuxCommand(page: Page, command: string): Promise<void> {
+  await page.keyboard.press("Control+b");
+  await page.keyboard.press(":");
+  await page.keyboard.type(command);
+  await page.keyboard.press("Enter");
+}
+
+test.describe.configure({ mode: "serial", timeout: 120_000 });
+
+test("terminal keeps keyboard focus across a pane move without a click", async ({ page }) => {
+  test.skip(!hasCommand("git") || !hasCommand("tmux", ["-V"]), "git and tmux are required for the real workspace flow");
+  await page.setViewportSize({ width: 1440, height: 900 });
+
+  const fallbackWrites = await interceptClipboardFallback(page);
+  const terminal = observeTerminal(page);
+  let isolatedServer: IsolatedE2EServer | null = null;
+  let api: APIRequestContext | null = null;
+  try {
+    isolatedServer = await startIsolatedWorkspaceE2EServer();
+    api = await playwrightRequest.newContext({
+      baseURL: isolatedServer.info.base_url,
+    });
+    const workspace = await createIssueWorkspace(api);
+    // Two real tmux shells in the bottom dock: with two sessions each dock leaf
+    // keeps its own "Move ... to a pane" control, so the promotion below runs
+    // through the real handler without focusing a palette or button first.
+    await launchDockedShell(api, workspace.id);
+    await launchDockedShell(api, workspace.id);
+
+    await page.goto(`${isolatedServer.info.base_url}/issues/github/acme/widgets/10`);
+    await expect(page.locator(".detail-pane-workspace-slot .workspace-host-wrapper")).toBeVisible();
+    const panel = await openTerminalPanel(page);
+    const chosenLeaf = panel.locator('.terminal-leaf:has(button[aria-label$=" to a pane"])').first();
+    const inlineTerminal = chosenLeaf.locator(".terminal-container");
+    await expect(inlineTerminal).toBeVisible();
+    await expect(inlineTerminal.locator("canvas, .xterm-screen").first()).toBeVisible();
+    const promote = chosenLeaf.getByRole("button", { name: /^Move .+ to a pane$/ });
+    await expect(promote).toBeVisible();
+
+    // Promotion is setup for the pane-move scenario. Stamp the exact live
+    // xterm node first, so the assertions below prove the pane move carried,
+    // rather than rebuilt, the same real tmux terminal.
+    await inlineTerminal.evaluate((element) => {
+      element.setAttribute("data-focus-reparent-witness", "live-terminal");
+    });
+    await promote.click();
+    const movedTerminal = page.locator('.session-terminal-slot [data-focus-reparent-witness="live-terminal"]');
+    await expect(page.locator('.terminal-panel [data-focus-reparent-witness="live-terminal"]')).toHaveCount(0);
+    await expect(movedTerminal).toBeVisible();
+
+    await movedTerminal.evaluate((element) => {
+      element
+        .closest(".tabbed-panel-leaf")
+        ?.querySelector<HTMLElement>(".tabbed-panel-solo-grip, .tabbed-panel-tab-button")
+        ?.setAttribute("data-focus-drag-source", "true");
+    });
+    await page
+      .locator('[data-pane-key="conversation"]')
+      .first()
+      .evaluate((element) => {
+        element.parentElement?.setAttribute("data-focus-drop-target", "true");
+      });
+
+    // Setup only: join the promoted tab into the conversation leaf so the
+    // palette's "Split pane right" command has a real structural edit to make.
+    await page.evaluate(() => {
+      const source = document.querySelector<HTMLElement>('[data-focus-drag-source="true"]');
+      const target = document.querySelector<HTMLElement>('[data-focus-drop-target="true"]');
+      if (!source || !target) {
+        throw new Error("pane drag source or conversation drop target missing");
+      }
+      const transfer = new DataTransfer();
+      const targetRect = target.getBoundingClientRect();
+      const sourceRect = source.getBoundingClientRect();
+      const dispatch = (type: string, element: HTMLElement, x: number, y: number) =>
+        element.dispatchEvent(
+          new DragEvent(type, {
+            bubbles: true,
+            cancelable: true,
+            dataTransfer: transfer,
+            clientX: x,
+            clientY: y,
+          }),
+        );
+      dispatch("dragstart", source, sourceRect.left + sourceRect.width / 2, sourceRect.top + sourceRect.height / 2);
+      dispatch("dragover", target, targetRect.left + targetRect.width / 2, targetRect.top + targetRect.height / 2);
+      dispatch("drop", target, targetRect.left + targetRect.width / 2, targetRect.top + targetRect.height / 2);
+      dispatch("dragend", source, targetRect.left + targetRect.width / 2, targetRect.top + targetRect.height / 2);
+    });
+    await expect(movedTerminal).toBeVisible();
+    await movedTerminal.evaluate((element) => {
+      element.closest(".session-terminal-slot")?.setAttribute("data-focus-source-slot", "true");
+    });
+
+    // The only terminal click in the scenario under test.
+    await movedTerminal.click({ position: { x: 10, y: 10 } });
+    await expect.poll(() => activeElementDescription(page)).toContain("xterm-helper-textarea");
+    await typeMarker(page, preMarker);
+    await expect.poll(() => terminal.sent(preMarker), { timeout: 15_000 }).toBe(true);
+    await expect.poll(() => terminal.received(preMarker), { timeout: 15_000 }).toBe(true);
+    expect(await activeElementDescription(page)).toContain("xterm-helper-textarea");
+
+    // The real pane command, entirely by keyboard. Palette teardown restores
+    // the terminal focus it saved before the handler splits this tab into a
+    // new leaf, and the split reparents the terminal through the parking node.
+    await page.keyboard.press("Meta+k");
+    const palette = page.getByRole("dialog", { name: "Command palette" });
+    await expect(palette).toBeVisible();
+    await page.getByRole("textbox", { name: "Search command palette" }).fill("Split pane right");
+    await expect(palette.getByRole("button", { name: /Split pane right/ })).toBeVisible();
+    await page.keyboard.press("Enter");
+    await expect(palette).not.toBeVisible();
+    await expect(page.locator('[data-focus-source-slot="true"]')).toHaveCount(0);
+    await expect(movedTerminal).toBeVisible();
+
+    // The regression: focus must come back to xterm on its own, and keystrokes
+    // must reach the live tmux session with no further click.
+    await expect.poll(() => activeElementDescription(page)).toContain("xterm-helper-textarea");
+    await typeMarker(page, postMarker);
+    await expect.poll(() => terminal.sent(postMarker), { timeout: 15_000 }).toBe(true);
+    await expect.poll(() => terminal.received(postMarker), { timeout: 15_000 }).toBe(true);
+
+    // Keyboard-only tmux clipboard after the move, through the same OSC 52
+    // fallback boundary the clipboard spec proves.
+    await runTmuxCommand(page, `set-buffer -w '${clipboardMarker}'`);
+    await expect
+      .poll(() => fallbackWrites.some((write) => write.includes(clipboardMarker)), {
+        timeout: 15_000,
+      })
+      .toBe(true);
+  } finally {
+    await api?.dispose();
+    await isolatedServer?.stop();
+  }
+});


### PR DESCRIPTION
Since #766, moving a session pane (drag, split, or join) reparents its live terminal through the pool's `display:none` parking node, which blurs xterm's helper textarea; focus came back only for an explicit Focus Terminal request. Keyboard-driven tmux copy/paste stopped reaching the terminal after any pane move until the user clicked it — easy to misread as an OSC 52 clipboard failure, and invisible to the Firefox clipboard e2e tests because they click the terminal before every operation.

- The terminal pool now restores focus it took during a reparent when the wrapper held it; closing a pane still drops that intent.
- Regression test covers focus staying in the terminal across a slot move with no extra click.

🤖 Generated with Claude Code (claude-fable-5)

<sup>generated by a clanker</sup>