### PR TITLE
Align issue actions with PR detail flow

### DIFF
--- a/packages/ui/src/components/detail/IssueDetail.svelte
+++ b/packages/ui/src/components/detail/IssueDetail.svelte
@@ -1242,48 +1242,6 @@
         {/if}
       </div>
 
-
-      <!-- Issue body -->
-      {#if issue.Body}
-        <div class="section body-section">
-          <div class="section-header">
-            <span class="section-title-inline">Description</span>
-          </div>
-          <div class="inset-box-wrap">
-            <CopyButton
-              class={bodyCopied ? "body-copy body-copy--copied" : "body-copy"}
-              copied={bodyCopied}
-              onclick={() => copyBody(issue.Body)}
-              revealOnHover
-              ariaLabel="Copy to clipboard"
-              copiedAriaLabel="Copied!"
-              title="Copy to clipboard"
-              copiedTitle="Copied!"
-            />
-            <Card level="inset" padding="none" class="inset-box">
-              <!-- svelte-ignore a11y_click_events_have_key_events -->
-              <!-- svelte-ignore a11y_no_static_element_interactions -->
-              <div
-                class="inset-box__content markdown-body"
-                class:dragging={dragSourceIndex !== null}
-                onclick={onBodyClick}
-                ondragstart={onBodyDragStart}
-                ondragover={onBodyDragOver}
-                ondragleave={onBodyDragLeave}
-                ondrop={onBodyDrop}
-                ondragend={onBodyDragEnd}
-              >
-                {#await renderMarkdown(issue.Body, { provider, platformHost, owner, name, repoPath }, { interactiveTasks: capabilities.state_mutation && !contentGate.unavailable })}
-                  {@html renderMarkdownSync(issue.Body, { provider, platformHost, owner, name, repoPath })}
-                {:then html}
-                  {@html html}
-                {/await}
-              </div>
-            </Card>
-          </div>
-        </div>
-      {/if}
-
       <!-- Actions -->
       <div class="actions-row">
         {#if workspace}
@@ -1413,6 +1371,47 @@
           </Button>
         {/each}
       </div>
+
+      <!-- Issue body -->
+      {#if issue.Body}
+        <div class="section body-section">
+          <div class="section-header">
+            <span class="section-title-inline">Description</span>
+          </div>
+          <div class="inset-box-wrap">
+            <CopyButton
+              class={bodyCopied ? "body-copy body-copy--copied" : "body-copy"}
+              copied={bodyCopied}
+              onclick={() => copyBody(issue.Body)}
+              revealOnHover
+              ariaLabel="Copy to clipboard"
+              copiedAriaLabel="Copied!"
+              title="Copy to clipboard"
+              copiedTitle="Copied!"
+            />
+            <Card level="inset" padding="none" class="inset-box">
+              <!-- svelte-ignore a11y_click_events_have_key_events -->
+              <!-- svelte-ignore a11y_no_static_element_interactions -->
+              <div
+                class="inset-box__content markdown-body"
+                class:dragging={dragSourceIndex !== null}
+                onclick={onBodyClick}
+                ondragstart={onBodyDragStart}
+                ondragover={onBodyDragOver}
+                ondragleave={onBodyDragLeave}
+                ondrop={onBodyDrop}
+                ondragend={onBodyDragEnd}
+              >
+                {#await renderMarkdown(issue.Body, { provider, platformHost, owner, name, repoPath }, { interactiveTasks: capabilities.state_mutation && !contentGate.unavailable })}
+                  {@html renderMarkdownSync(issue.Body, { provider, platformHost, owner, name, repoPath })}
+                {:then html}
+                  {@html html}
+                {/await}
+              </div>
+            </Card>
+          </div>
+        </div>
+      {/if}
 
       <!-- Comment box -->
       <div class="section">

--- a/packages/ui/src/components/detail/IssueDetail.test.ts
+++ b/packages/ui/src/components/detail/IssueDetail.test.ts
@@ -11,6 +11,7 @@ import {
   recordWorkspaceCreated,
   resetWorkspaceCreatePendingForTest,
 } from "../../stores/workspace-create-pending.svelte.js";
+import type { ActionRegistry } from "../../types.js";
 import type { InlineWorkspaceController, WorkspaceItemIdentity } from "../../workspace-inline.js";
 import { openLabelPickerFor } from "./labelPickerCommand.js";
 import { createTestController } from "../workspace/inlineWorkspaceTestController.svelte.js";
@@ -159,7 +160,11 @@ function issueDetail(): IssueDetail {
 function renderIssueDetail(
   detail: IssueDetail,
   deleteIssueComment = vi.fn(async () => true),
-  options: { staleRefreshing?: boolean; inlineWorkspace?: InlineWorkspaceController | null } = {},
+  options: {
+    staleRefreshing?: boolean;
+    inlineWorkspace?: InlineWorkspaceController | null;
+    actions?: ActionRegistry;
+  } = {},
   apiClient: { GET: ReturnType<typeof vi.fn>; POST: ReturnType<typeof vi.fn> } = {
     GET: vi.fn(),
     POST: vi.fn(),
@@ -212,7 +217,7 @@ function renderIssueDetail(
           },
         },
       ],
-      [ACTIONS_KEY, { issue: [] }],
+      [ACTIONS_KEY, options.actions ?? { issue: [] }],
       [UI_CONFIG_KEY, { hideStar: true }],
       [NAVIGATE_KEY, navigate],
     ]),
@@ -264,6 +269,32 @@ describe("IssueDetail activity view", () => {
     expect(document.getElementById("issue-create-workspace-description")?.textContent).toContain(
       button.getAttribute("title"),
     );
+  });
+
+  it("places all issue actions before the description", () => {
+    const detail = issueDetail();
+    detail.issue.Body = "Action placement marker";
+
+    renderIssueDetail(detail, undefined, {
+      actions: {
+        issue: [
+          {
+            id: "extension-action",
+            label: "Extension action",
+            handler: vi.fn(),
+          },
+        ],
+      },
+    });
+
+    const description = screen.getByText("Description");
+    for (const action of [
+      screen.getByRole("button", { name: "Create Workspace" }),
+      screen.getByRole("button", { name: "Close issue" }),
+      screen.getByRole("button", { name: "Extension action" }),
+    ]) {
+      expect(action.compareDocumentPosition(description) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    }
   });
 
   it("labels an active stale-detail refresh", () => {


### PR DESCRIPTION
Issue workspace and state controls appeared below the description, making the Issue workflow inconsistent with pull request details.

- Place workspace, Close/Reopen, and extension actions together above the Issue description.
- Preserve action behavior and semantic keyboard order.

![Issue actions consolidated above the description](https://github.com/user-attachments/assets/03faac4d-4066-4ab4-915c-708739347b91)