### PR TITLE
Keep Save/Reset readable in the terminal options popover

### DIFF
--- a/context/ui-design-system.md
+++ b/context/ui-design-system.md
@@ -340,6 +340,8 @@ Before placing an overlay inside a split view, compact sidebar, drawer, or scrol
 
 Popover surface chrome (background, border, radius, shadow) comes from `kit-popover-card`; do not re-declare it in component-scoped styles. Scoped rules outrank the kit class, and a `var()` referencing an undefined token (there is no `--bg-elevated`) computes to transparent with no build-time error.
 
+A popover that lowers its own min-content width (`overflow-wrap: anywhere`, so an unbreakable branch name cannot stretch `WorkspacePaneControls` past its max-width) leaks that to every surface nested inside it, where flex rows then shrink buttons below their labels and break them mid-word. Reset `overflow-wrap`/`word-break` at the nested popover's root instead of hardening each child (`frontend/src/lib/components/terminal/TerminalOptionsMenu.svelte`).
+
 ### GitHubLabels
 
 Use `GitHubLabels` for actual GitHub labels.

--- a/frontend/src/lib/components/settings/TerminalSettings.svelte
+++ b/frontend/src/lib/components/settings/TerminalSettings.svelte
@@ -557,18 +557,26 @@
 
   .setting-actions {
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     justify-content: space-between;
     gap: 12px;
   }
 
+  /* The help paragraph is the only flexible item here: without this the
+     buttons shrink below their label width and "Save"/"Reset" wrap
+     mid-word inside the narrow compact popover. */
   .button-row {
     display: flex;
+    flex: 0 0 auto;
+    margin-left: auto;
     align-items: center;
     gap: 8px;
   }
 
   .setting-help {
+    flex: 1 1 180px;
+    min-width: 0;
     margin: 0;
     font-size: var(--font-size-xs);
     color: var(--text-muted);
@@ -581,6 +589,7 @@
   .retry-fonts-btn {
     height: 28px;
     padding: 0 10px;
+    white-space: nowrap;
     font-size: var(--font-size-sm);
     font-weight: 600;
     border-radius: var(--radius-sm);

--- a/frontend/src/lib/components/terminal/TerminalOptionsMenu.svelte
+++ b/frontend/src/lib/components/terminal/TerminalOptionsMenu.svelte
@@ -138,6 +138,13 @@
     position: absolute;
     right: 0;
     top: calc(100% + 4px);
+    /* The pane-controls popover that hosts this trigger sets
+       `overflow-wrap: anywhere` so a long branch name cannot set its
+       min-content width. That inherits in here, where it has no business:
+       it let the settings form shrink its Save/Reset buttons below their
+       labels, which then broke mid-word ("Sa/ve"). */
+    overflow-wrap: normal;
+    word-break: normal;
     z-index: 25;
     width: 372px;
     padding: 10px;


### PR DESCRIPTION
The Save and Reset buttons in the terminal options popover shrank below their labels and broke mid-word ("Sa/ve", "Re/set") whenever the popover was opened from the workspace pane controls. That popover sets `overflow-wrap: anywhere` so a long branch name cannot stretch it, and the rule inherited into the settings form.

- Save and Reset keep their full labels on one line in the terminal options popover.
- The help text wraps instead of the buttons when space is tight.

<sup>generated by a clanker</sup>