### PR TITLE
Fix terminal keyboard and resize handling

### DIFF
--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -327,12 +327,16 @@ Keyboard handlers must have one clear owner for each key press.
 - Terminal SIZE is never gated on visibility, focus, or any "is this pane
   active" inference. A pane measures its own region through the fit addon and
   pushes the result whenever it differs from what the PTY was last told; resize
-  authority follows the same measurement. A container with no content box (a
+  authority follows the same measurement. Every pooled slot boundary must fill
+  its painted leaf in both axes; horizontal block stretch alone can leave the
+  xterm at a stale intrinsic height, so no vertical ResizeObserver result ever
+  reaches the PTY. A container with no content box (a
   parked terminal) measures nothing, which is what keeps it from resizing a live
   tmux pane to one row — the measurement IS the check. Record a size as sent
   only once the socket carried it, or a resize computed before the socket opened
   is suppressed forever and the PTY keeps its launch default
-  (`frontend/src/lib/components/terminal/XtermTerminalPane.svelte::terminalRegionSize`).
+  (`frontend/src/lib/components/terminal/TerminalSplitTree.svelte::terminal-leaf-body`,
+  `frontend/src/lib/components/terminal/XtermTerminalPane.svelte::terminalRegionSize`).
 - A promoted session is recorded ONCE, in the detail surface's stored pane tree.
   Containers mask it out of what they render (derived, not an effect) and never
   prune their own stored trees, so demoting restores the tab order, split, and

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -326,10 +326,9 @@ Keyboard handlers must have one clear owner for each key press.
   container that reports only its focused session makes the other halves of a
   split unclickable. Every leaf of a split shares the container's own visibility
   (`frontend/src/lib/components/terminal/TerminalSplitTree.svelte`).
-- Terminal SIZE is never gated on visibility, focus, or any "is this pane
-  active" inference. A pane measures its own region through the fit addon and
-  pushes the result whenever it differs from what the PTY was last told; resize
-  authority follows the same measurement. Every pooled slot boundary must fill
+- Terminal SIZE and resize authority require PAINTED state plus a valid fit
+  measurement, never focus: `visibility:hidden` retains geometry, while focus
+  gating strands unfocused split leaves. Every pooled slot boundary must fill
   its painted leaf in both axes; horizontal block stretch alone can leave the
   xterm at a stale intrinsic height, so no vertical ResizeObserver result ever
   reaches the PTY. A container with no content box (a
@@ -338,7 +337,7 @@ Keyboard handlers must have one clear owner for each key press.
   only once the socket carried it, or a resize computed before the socket opened
   is suppressed forever and the PTY keeps its launch default
   (`frontend/src/lib/components/terminal/TerminalSplitTree.svelte::terminal-leaf-body`,
-  `frontend/src/lib/components/terminal/XtermTerminalPane.svelte::terminalRegionSize`).
+  `frontend/src/lib/components/terminal/XtermTerminalPane.svelte::resizeAuthorityRegionSize`).
 - A promoted session is recorded ONCE, in the detail surface's stored pane tree.
   Containers mask it out of what they render (derived, not an effect) and never
   prune their own stored trees, so demoting restores the tab order, split, and

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -211,9 +211,15 @@ Whenever a control persists, document and test:
 
 Keyboard handlers must have one clear owner for each key press.
 
-- Input fields, textareas, contenteditable elements, and terminal surfaces own
-  printable keys while focused. Global shortcuts must not reinterpret those
-  keystrokes.
+- Input fields, textareas, and contenteditable elements own printable keys while
+  focused. Global shortcuts must not reinterpret those keystrokes, though
+  modified bindings still dispatch.
+- A focused TERMINAL owns every key, modified ones included, and the global
+  registry dispatches nothing: a TUI binds Escape, function keys, and Ctrl/Alt
+  chords, so any key the app reserves is a key the terminal loses. Ownership is
+  matched from the terminal surface, not from xterm's hidden textarea alone —
+  focus also rests on the session wrapper
+  (`frontend/src/lib/utils/keyboardShortcuts.ts::isTerminalKeyboardTarget`).
 - Modal frames outrank page-level shortcuts. When a modal, drawer, popover, or
   command surface is active, route and list navigation should run only through
   actions explicitly registered for that active surface.

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -214,11 +214,13 @@ Keyboard handlers must have one clear owner for each key press.
 - Input fields, textareas, and contenteditable elements own printable keys while
   focused. Global shortcuts must not reinterpret those keystrokes, though
   modified bindings still dispatch.
-- A focused TERMINAL owns every key, modified ones included, and the global
-  registry dispatches nothing: a TUI binds Escape, function keys, and Ctrl/Alt
-  chords, so any key the app reserves is a key the terminal loses. Ownership is
-  matched from the terminal surface, not from xterm's hidden textarea alone —
-  focus also rests on the session wrapper
+- A focused TERMINAL owns every key, modified ones included, and outranks even
+  the modal stack: a TUI binds Escape, function keys, and Ctrl/Cmd chords
+  (Cmd-K and Cmd-P included), so any key the app reserves is a key the terminal
+  loses. The dispatcher runs no handler and does not preventDefault. Ownership
+  is matched from the terminal surface, not from xterm's hidden textarea alone,
+  because focus also rests on the session wrapper. Popovers close from their own
+  window Escape listeners, not from the registry
   (`frontend/src/lib/utils/keyboardShortcuts.ts::isTerminalKeyboardTarget`).
 - Modal frames outrank page-level shortcuts. When a modal, drawer, popover, or
   command surface is active, route and list navigation should run only through

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -311,6 +311,12 @@ Keyboard handlers must have one clear owner for each key press.
   settles with no destination (the pane closed) — a cross-flush transfer's
   transient no-destination park keeps it. A restore fires only into unclaimed
   focus (`frontend/src/lib/components/terminal/PooledSessionTerminal.svelte`).
+- A slot's `visible` means PAINTED, never FOCUSED. Only a visible terminal pushes
+  its size (the pane suspends resize work and the server refuses resize authority
+  while inactive), so a container that reports only its focused session leaves the
+  other halves of a split at whatever size they last held — for a session never
+  focused, the tmux launch default. Every leaf of a split shares the container's
+  own visibility (`frontend/src/lib/components/terminal/TerminalSplitTree.svelte`).
 - A promoted session is recorded ONCE, in the detail surface's stored pane tree.
   Containers mask it out of what they render (derived, not an effect) and never
   prune their own stored trees, so demoting restores the tab order, split, and

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -335,9 +335,11 @@ Keyboard handlers must have one clear owner for each key press.
   parked terminal) measures nothing, which is what keeps it from resizing a live
   tmux pane to one row — the measurement IS the check. Record a size as sent
   only once the socket carried it, or a resize computed before the socket opened
-  is suppressed forever and the PTY keeps its launch default
+  is suppressed forever and the PTY keeps its launch default. Synchronize
+  authority on every measurement because geometry changes independently of
+  painted state; reclaiming authority must push even an unchanged size
   (`frontend/src/lib/components/terminal/TerminalSplitTree.svelte::terminal-leaf-body`,
-  `frontend/src/lib/components/terminal/XtermTerminalPane.svelte::resizeAuthorityRegionSize`).
+  `frontend/src/lib/components/terminal/XtermTerminalPane.svelte::resizeVisibleTerminal`).
 - A promoted session is recorded ONCE, in the detail surface's stored pane tree.
   Containers mask it out of what they render (derived, not an effect) and never
   prune their own stored trees, so demoting restores the tab order, split, and

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -217,7 +217,9 @@ Keyboard handlers must have one clear owner for each key press.
 - A focused TERMINAL owns every key, modified ones included, and outranks even
   the modal stack: a TUI binds Escape, function keys, and Ctrl/Cmd chords
   (Cmd-K and Cmd-P included), so any key the app reserves is a key the terminal
-  loses. The dispatcher runs no handler and does not preventDefault. Ownership
+  loses. Only `Ctrl/Cmd-Shift-K`, the documented command-palette escape hatch,
+  crosses this boundary; otherwise the dispatcher runs no handler and does not
+  preventDefault. Ownership
   is matched from the terminal surface, not from xterm's hidden textarea alone,
   because focus also rests on the session wrapper. Popovers close from their own
   window Escape listeners, not from the registry

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -319,12 +319,20 @@ Keyboard handlers must have one clear owner for each key press.
   settles with no destination (the pane closed) — a cross-flush transfer's
   transient no-destination park keeps it. A restore fires only into unclaimed
   focus (`frontend/src/lib/components/terminal/PooledSessionTerminal.svelte`).
-- A slot's `visible` means PAINTED, never FOCUSED. Only a visible terminal pushes
-  its size (the pane suspends resize work and the server refuses resize authority
-  while inactive), so a container that reports only its focused session leaves the
-  other halves of a split at whatever size they last held — for a session never
-  focused, the tmux launch default. Every leaf of a split shares the container's
-  own visibility (`frontend/src/lib/components/terminal/TerminalSplitTree.svelte`).
+- A slot's `visible` means PAINTED, never FOCUSED. It gates INTERACTIVITY — an
+  invisible slot's terminal is `inert`, dead to pointer and keyboard — so a
+  container that reports only its focused session makes the other halves of a
+  split unclickable. Every leaf of a split shares the container's own visibility
+  (`frontend/src/lib/components/terminal/TerminalSplitTree.svelte`).
+- Terminal SIZE is never gated on visibility, focus, or any "is this pane
+  active" inference. A pane measures its own region through the fit addon and
+  pushes the result whenever it differs from what the PTY was last told; resize
+  authority follows the same measurement. A container with no content box (a
+  parked terminal) measures nothing, which is what keeps it from resizing a live
+  tmux pane to one row — the measurement IS the check. Record a size as sent
+  only once the socket carried it, or a resize computed before the socket opened
+  is suppressed forever and the PTY keeps its launch default
+  (`frontend/src/lib/components/terminal/XtermTerminalPane.svelte::terminalRegionSize`).
 - A promoted session is recorded ONCE, in the detail surface's stored pane tree.
   Containers mask it out of what they render (derived, not an effect) and never
   prune their own stored trees, so demoting restores the tab order, split, and

--- a/docs/superpowers/plans/2026-07-29-hidden-terminal-resize-authority.md
+++ b/docs/superpowers/plans/2026-07-29-hidden-terminal-resize-authority.md
@@ -1,0 +1,197 @@
+# Hidden Terminal Resize Authority Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan directly in the current agent, task-by-task. Never use subagent-driven development. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent measurable but hidden terminal tabs from claiming or exercising PTY resize authority without disrupting resize delivery for painted split leaves.
+
+**Architecture:** Treat the existing `active` prop as painted state, not focus, and combine it with `terminalRegionSize()` at every resize-authority and resize/refresh send boundary. Keep websockets alive while hidden. Preserve the slot-level rule that every leaf in a painted split receives `active=true`.
+
+**Tech Stack:** TypeScript, Svelte 5, Vite+, Vitest, Playwright, xterm.js, WebSocket, tmux
+
+## Global Constraints
+
+- A hidden terminal keeps its websocket and continues receiving output.
+- Resize authority requires both `active=true` and valid measured geometry.
+- Unfocused leaves in a painted split remain resize-active.
+- Parked and hidden terminals emit no resize or refresh dimensions.
+- Use Vite+ directly; never use npm.
+- Run the real Chromium/tmux vertical-resize scenario before pushing.
+
+---
+
+### Task 1: Gate PTY resize authority without regressing painted terminals
+
+**Files:**
+- Modify: `frontend/src/lib/components/terminal/TerminalPane.test.ts:585-619`
+- Modify: `frontend/src/lib/components/terminal/XtermTerminalPane.svelte:266-277,353-364,431-475,515-520,700-707`
+- Verify: `frontend/src/lib/components/terminal/TerminalSplitTree.test.ts:100-137`
+- Modify: `context/ui-interaction-contracts.md:327-339`
+
+**Interfaces:**
+- Consumes: reactive `active: boolean`, where true means the terminal's slot is painted, and `terminalRegionSize(): { cols: number; rows: number } | null`.
+- Produces: `resizeAuthorityRegionSize(): { cols: number; rows: number } | null`, which returns a size only when both painted state and geometry permit PTY resize ownership.
+
+- [ ] **Step 1: Replace the contradictory inactive-pane test with hidden-tab regressions**
+
+Use a valid `fitDimensions` value while rendering with `active: false` so the test models `visibility:hidden`, not parking:
+
+```ts
+it("does not claim resize authority for a hidden but measurable region", async () => {
+  render(TerminalPane, { props: { workspaceId: "ws-123", active: false } });
+
+  await waitFor(() => expect(mockSockets).toHaveLength(1));
+  expect(mockSockets[0]!.url).toContain("resize_active=0");
+
+  mockSockets[0]!.onopen?.();
+  expect(mockSockets[0]!.sent).toContain(JSON.stringify({ type: "resize_active", active: false }));
+
+  mockSockets[0]!.sent = [];
+  fitDimensions = { cols: 100, rows: 40 };
+  resizeObserverCallbacks[0]!([], {} as ResizeObserver);
+
+  expect(mockSockets[0]!.sent).toHaveLength(0);
+});
+```
+
+Add the visible-to-hidden transition case:
+
+```ts
+it("revokes authority and ignores later measurements when its tab becomes hidden", async () => {
+  const { rerender } = render(TerminalPane, {
+    props: { workspaceId: "ws-123", active: true },
+  });
+  await waitFor(() => expect(mockSockets).toHaveLength(1));
+  mockSockets[0]!.onopen?.();
+  mockSockets[0]!.sent = [];
+
+  await rerender({ workspaceId: "ws-123", active: false });
+  expect(mockSockets[0]!.sent).toContain(JSON.stringify({ type: "resize_active", active: false }));
+
+  mockSockets[0]!.sent = [];
+  fitDimensions = { cols: 100, rows: 40 };
+  resizeObserverCallbacks[0]!([], {} as ResizeObserver);
+  expect(mockSockets[0]!.sent).toHaveLength(0);
+});
+```
+
+Keep a positive measurable-region case with `active: true`, proving a painted terminal still advertises authority and sends the measured resize:
+
+```ts
+it("claims resize authority for a painted measurable region", async () => {
+  render(TerminalPane, { props: { workspaceId: "ws-123", active: true } });
+
+  await waitFor(() => expect(mockSockets).toHaveLength(1));
+  expect(mockSockets[0]!.url).toContain("resize_active=1");
+  mockSockets[0]!.onopen?.();
+
+  mockSockets[0]!.sent = [];
+  fitDimensions = { cols: 100, rows: 40 };
+  resizeObserverCallbacks[0]!([], {} as ResizeObserver);
+
+  expect(resizeFramesOf(mockSockets[0]!)).toEqual([
+    JSON.stringify({ type: "resize", cols: 100, rows: 40 }),
+  ]);
+});
+```
+
+- [ ] **Step 2: Run the terminal tests and verify RED**
+
+Run from `frontend/`:
+
+```bash
+../node_modules/.bin/vp test src/lib/components/terminal/TerminalPane.test.ts src/lib/components/terminal/TerminalSplitTree.test.ts
+```
+
+Expected: the hidden measurable cases fail because the websocket URL advertises `resize_active=1`, the open socket sends `active: true`, and ResizeObserver still emits a resize.
+
+- [ ] **Step 3: Add one painted-and-measurable size helper**
+
+Keep `terminalRegionSize()` as geometry-only and add:
+
+```ts
+function resizeAuthorityRegionSize(): { cols: number; rows: number } | null {
+  if (!active) return null;
+  return terminalRegionSize();
+}
+```
+
+Use `resizeAuthorityRegionSize()` for the websocket query's `resize_active`, the socket-open authority frame, and the reactive authority frame:
+
+```ts
+const resizeActive = resizeAuthorityRegionSize() !== null ? "1" : "0";
+sendResizeActive(resizeAuthorityRegionSize() !== null);
+```
+
+- [ ] **Step 4: Gate both resize and refresh sends at execution time**
+
+In `resizeVisibleTerminal()`, obtain the size from `resizeAuthorityRegionSize()` before fitting or sending:
+
+```ts
+function resizeVisibleTerminal(): void {
+  const size = resizeAuthorityRegionSize();
+  if (!size || !terminal) return;
+
+  fitAddon?.fit();
+  terminal.refresh(0, Math.max(0, size.rows - 1));
+  if (size.cols === sentCols && size.rows === sentRows) return;
+  if (sendResize(size.cols, size.rows)) {
+    sentCols = size.cols;
+    sentRows = size.rows;
+  }
+}
+```
+
+In `refreshVisibleTerminal()`, obtain the same size first, then fit, refresh, and send that measured `{ cols, rows }`. This execution-time check prevents a queued animation frame from sending after `active` flips false:
+
+```ts
+function refreshVisibleTerminal(): void {
+  const size = resizeAuthorityRegionSize();
+  if (!size || !terminal) return;
+
+  fitAddon?.fit();
+  terminal.refresh(0, Math.max(0, size.rows - 1));
+  if (sendRefresh(size.cols, size.rows)) {
+    sentCols = size.cols;
+    sentRows = size.rows;
+  }
+}
+```
+
+- [ ] **Step 5: Update the durable interaction contract**
+
+Replace the claim that terminal size is never visibility-gated with the narrower invariant: size and authority require painted state plus valid geometry, painted state is never focus, and every visible split leaf receives it.
+
+- [ ] **Step 6: Run focused tests and Svelte analysis**
+
+Run the Step 2 command, then from the repository root:
+
+```bash
+./node_modules/.bin/vp exec -- svelte-mcp svelte-autofixer frontend/src/lib/components/terminal/XtermTerminalPane.svelte
+```
+
+Expected: focused tests pass, both visible split leaves remain registered as visible, and the autofixer reports no relevant issue.
+
+- [ ] **Step 7: Run the real tmux resize proof**
+
+Run from `frontend/`:
+
+```bash
+../node_modules/.bin/vp exec -- playwright test --config=playwright-e2e.config.ts tests/e2e-full/00-inline-workspace-continuity.spec.ts --project=chromium
+```
+
+Expected: the complete spec passes, including the dock-height test that verifies both rendered xterm height and `stty size` rows grow.
+
+- [ ] **Step 8: Run required full frontend verification**
+
+Run from the repository root:
+
+```bash
+make frontend-check-no-deps
+cd frontend && ../node_modules/.bin/vp test
+```
+
+Expected: formatting, lint, Svelte checks, and the complete Vitest suite pass.
+
+- [ ] **Step 9: Commit and push the review fix**
+
+Run `context-sync --commit`, inspect the public diff and commit metadata for private data, create a new hook-enforced conventional commit without amending, and push `t3code/fix-tmux-terminal-sizing`.

--- a/docs/superpowers/plans/2026-07-29-terminal-palette-chord.md
+++ b/docs/superpowers/plans/2026-07-29-terminal-palette-chord.md
@@ -83,10 +83,6 @@ if (isTerminalKeyboardTarget(event.target) && !isTerminalPaletteShortcut(event))
 
 Run the Step 2 command. Expected: PASS, including the existing terminal-ownership cases.
 
-- [ ] **Step 5: Commit the dispatcher boundary**
-
-Run `context-sync --commit`, then create a hook-enforced commit containing only the dispatcher and its test. Do not amend or bypass hooks.
-
 ### Task 2: Register and exercise the safe palette chord
 
 **Files:**
@@ -187,11 +183,11 @@ Expected: the full spec passes in both projects; the pane-move test opens the pa
 
 - [ ] **Step 7: Run the required full frontend verification**
 
-Run from `frontend/`:
+Run from the repository root:
 
 ```bash
-../node_modules/.bin/vp check
-../node_modules/.bin/vp test
+make frontend-check-no-deps
+cd frontend && ../node_modules/.bin/vp test
 ```
 
 Expected: checks and the complete Vitest suite pass.

--- a/docs/superpowers/plans/2026-07-29-terminal-palette-chord.md
+++ b/docs/superpowers/plans/2026-07-29-terminal-palette-chord.md
@@ -1,0 +1,201 @@
+# Terminal-safe Command Palette Chord Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan directly in the current agent, task-by-task. Never use subagent-driven development. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a focused terminal keep ordinary `Ctrl/Meta+K` while reserving `Ctrl/Meta+Shift+K` for opening and closing middleman's command palette.
+
+**Architecture:** Keep terminal ownership as the default at the global dispatcher boundary. Add one exact event-level exception for shifted `K`, then register the same chord on both the global palette action and the active palette modal frame. The real tmux-backed test continues to exercise palette teardown and terminal focus restoration with the safe chord.
+
+**Tech Stack:** TypeScript, Svelte 5, Vite+, Vitest, Playwright, xterm.js, tmux
+
+## Global Constraints
+
+- `Ctrl/Meta+K` remains terminal-owned.
+- Only `Ctrl/Meta+Shift+K` bypasses focused-terminal ownership.
+- Escape, function keys, `Ctrl/Meta+P`, and every other terminal keystroke remain terminal-owned.
+- Use Vite+ directly; never use npm.
+- Run the real-terminal Playwright spec in both Chromium and Firefox before pushing.
+
+---
+
+### Task 1: Reserve the shifted palette chord at the dispatcher
+
+**Files:**
+- Modify: `frontend/src/lib/stores/keyboard/dispatch.svelte.test.ts:249-301`
+- Modify: `frontend/src/lib/stores/keyboard/dispatch.svelte.ts:20-39`
+
+**Interfaces:**
+- Consumes: `dispatchKeydown(event: KeyboardEvent, contextProvider: () => Context): void`
+- Produces: terminal dispatch behavior where only `{ key: "k", ctrlOrMeta: true, shift: true }` reaches registered app actions.
+
+- [ ] **Step 1: Write the failing dispatcher tests**
+
+Extend the terminal ownership cases so unshifted `Meta+K` still does not dispatch, then add a focused case:
+
+```ts
+it("reserves Cmd-Shift-K for the palette while a terminal is focused", () => {
+  const palette = register("palette.open", { key: "k", ctrlOrMeta: true, shift: true });
+  const { textarea, wrapper } = terminalTargets();
+
+  for (const target of [textarea, wrapper]) {
+    const e = event({ key: "k", metaKey: true, shiftKey: true });
+    Object.defineProperty(e, "target", { value: target });
+    dispatchKeydown(e, () => ctx);
+    expect(e.preventDefault).toHaveBeenCalled();
+  }
+
+  expect(palette).toHaveBeenCalledTimes(2);
+});
+```
+
+- [ ] **Step 2: Run the dispatcher test and verify RED**
+
+Run from `frontend/`:
+
+```bash
+../node_modules/.bin/vp test src/lib/stores/keyboard/dispatch.svelte.test.ts
+```
+
+Expected: FAIL because terminal ownership returns before the shifted palette action can dispatch.
+
+- [ ] **Step 3: Add the exact event-level exception**
+
+Add a focused predicate beside `dispatchKeydown`:
+
+```ts
+function isTerminalPaletteShortcut(event: KeyboardEvent): boolean {
+  return (
+    event.key.toLowerCase() === "k" &&
+    (event.ctrlKey || event.metaKey) &&
+    event.shiftKey &&
+    !event.altKey
+  );
+}
+```
+
+Then narrow the early return:
+
+```ts
+if (isTerminalKeyboardTarget(event.target) && !isTerminalPaletteShortcut(event)) return;
+```
+
+- [ ] **Step 4: Run the dispatcher test and verify GREEN**
+
+Run the Step 2 command. Expected: PASS, including the existing terminal-ownership cases.
+
+- [ ] **Step 5: Commit the dispatcher boundary**
+
+Run `context-sync --commit`, then create a hook-enforced commit containing only the dispatcher and its test. Do not amend or bypass hooks.
+
+### Task 2: Register and exercise the safe palette chord
+
+**Files:**
+- Modify: `frontend/src/lib/stores/keyboard/actions.test.ts:142-150`
+- Modify: `frontend/src/lib/stores/keyboard/actions.ts:574-586`
+- Modify: `frontend/src/lib/components/keyboard/Palette.svelte.test.ts`
+- Modify: `frontend/src/lib/components/keyboard/Palette.svelte:427-440`
+- Modify: `frontend/tests/e2e-full/terminal-focus-pane-move.spec.ts:257-266`
+- Modify: `context/ui-interaction-contracts.md:212-224`
+
+**Interfaces:**
+- Consumes: the dispatcher exception from Task 1 and the existing `togglePalette()` / `closePalette()` handlers.
+- Produces: `Ctrl/Meta+Shift+K` in the binding arrays for `palette.open` and `palette.close`.
+
+- [ ] **Step 1: Write failing binding and modal tests**
+
+Update the `palette.open` binding expectation to include the shifted chord first:
+
+```ts
+expect(palette!.binding).toEqual([
+  { key: "k", ctrlOrMeta: true, shift: true },
+  { key: "k", ctrlOrMeta: true },
+  { key: "p", ctrlOrMeta: true },
+  { key: "p", ctrlOrMeta: true, shift: true },
+]);
+```
+
+Import `dispatchKeydown` and `Context`, then add a Palette component test that exercises the registered modal action:
+
+```ts
+it("closes with Cmd-Shift-K", async () => {
+  const { rerender } = render(Palette, { props: {} });
+  openPalette();
+  await rerender({});
+  const input = screen.getByRole("textbox", { name: "Search command palette" });
+  const event = new KeyboardEvent("keydown", {
+    key: "k",
+    metaKey: true,
+    shiftKey: true,
+    cancelable: true,
+  });
+  Object.defineProperty(event, "target", { value: input });
+
+  dispatchKeydown(event, () => ({}) as Context);
+
+  await waitFor(() => expect(screen.queryByRole("dialog", { name: "Command palette" })).toBeNull());
+});
+```
+
+- [ ] **Step 2: Run the binding/component tests and verify RED**
+
+Run from `frontend/`:
+
+```bash
+../node_modules/.bin/vp test src/lib/stores/keyboard/actions.test.ts src/lib/components/keyboard/Palette.svelte.test.ts
+```
+
+Expected: FAIL because neither palette binding array contains shifted `K`.
+
+- [ ] **Step 3: Add shifted K to both palette binding arrays**
+
+Insert this binding into `defaultActions` and `modalActions`:
+
+```ts
+{ key: "k", ctrlOrMeta: true, shift: true },
+```
+
+- [ ] **Step 4: Update the real terminal scenario and durable contract**
+
+Change the pane-move scenario to:
+
+```ts
+await page.keyboard.press("Meta+Shift+k");
+```
+
+Update the terminal keyboard ownership bullet in `context/ui-interaction-contracts.md` to name `Ctrl/Cmd-Shift-K` as the single documented palette exception while preserving ordinary `Cmd-K` and `Cmd-P` ownership.
+
+- [ ] **Step 5: Run focused tests and Svelte analysis**
+
+Run the Step 2 command, then from the repository root:
+
+```bash
+./node_modules/.bin/vp exec -- svelte-mcp svelte-autofixer frontend/src/lib/components/keyboard/Palette.svelte
+```
+
+Expected: tests PASS and the autofixer reports no relevant issue.
+
+- [ ] **Step 6: Run the real-terminal spec in both browsers**
+
+Run from `frontend/`:
+
+```bash
+../node_modules/.bin/vp exec -- playwright test --config=playwright-e2e.config.ts tests/e2e-full/terminal-focus-pane-move.spec.ts --project=chromium
+../node_modules/.bin/vp exec -- playwright test --config=playwright-e2e.config.ts tests/e2e-full/terminal-focus-pane-move.spec.ts --project=firefox
+```
+
+Expected: the full spec passes in both projects; the pane-move test opens the palette with the shifted chord and sends its post-move marker to the same tmux session without another click.
+
+- [ ] **Step 7: Run the required full frontend verification**
+
+Run from `frontend/`:
+
+```bash
+../node_modules/.bin/vp check
+../node_modules/.bin/vp test
+```
+
+Expected: checks and the complete Vitest suite pass.
+
+- [ ] **Step 8: Commit and push the focused CI fix**
+
+Run the repository-local `context-sync --commit` workflow, inspect the public diff and commit metadata for private data, create a new hook-enforced conventional commit without amending, and push `t3code/fix-tmux-terminal-sizing`.

--- a/docs/superpowers/plans/2026-07-29-terminal-vertical-resize.md
+++ b/docs/superpowers/plans/2026-07-29-terminal-vertical-resize.md
@@ -1,0 +1,171 @@
+# Terminal Vertical Resize Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a pooled docked terminal grow vertically with its leaf and propagate the resulting row count through xterm, the websocket, tmux, and the PTY.
+
+**Architecture:** Keep geometry ownership at the terminal leaf. Activate the existing flex-growth contract on `SessionTerminalSlot` by making its immediate leaf body a flex container; leave terminal pooling, resize measurement, resize authority, and keyboard dispatch unchanged. Prove the user-visible boundary with the existing isolated full-stack browser harness and a real `stty size` command.
+
+**Tech Stack:** Svelte 5, xterm.js, Playwright, Vite+, Go-backed isolated workspace server, tmux.
+
+## Global Constraints
+
+- Do not add another Escape or keyboard-dispatch workaround; Chrome already sends `0x1b` through the terminal websocket.
+- Keep the change UI-only. Do not change session creation, resize arbitration, provider behavior, or server APIs.
+- Use the real tmux-backed Playwright workspace flow for the row-count regression.
+- Use Vite+ directly; never use npm.
+- Run the repository-local Svelte autofixer before finalizing the component.
+- Before committing, run the repository-local `context-sync` skill in `--commit` mode and the mandatory commit skill.
+
+---
+
+### Task 1: Stretch the pooled terminal through the dock leaf
+
+**Files:**
+
+- Modify: `frontend/tests/e2e-full/00-inline-workspace-continuity.spec.ts`
+- Modify: `frontend/src/lib/components/terminal/TerminalSplitTree.svelte:594`
+
+**Interfaces:**
+
+- Consumes: `openTerminalPanel(page)`, `readPtyGeometry(page, container, worktreePath, name)`, the `Resize terminal panel` separator, and `SessionTerminalSlot`'s existing `flex: 1 1 auto` contract.
+- Produces: a dock leaf whose immediate session slot fills the leaf in both axes; no new functions, props, events, or API types.
+
+- [ ] **Step 1: Add the failing real-browser regression**
+
+Add this test near the start of the existing `inline workspace pane continuity` describe block, after its `beforeEach`:
+
+```ts
+test("a dock resize grows both the pooled terminal and its PTY rows", async ({ page }) => {
+  test.skip(
+    !hasCommand("git") || !hasCommand("tmux", ["-V"]),
+    "git and tmux are required for the real workspace flow",
+  );
+  await page.setViewportSize({ width: 1440, height: 900 });
+
+  let isolatedServer: IsolatedE2EServer | null = null;
+  let api: APIRequestContext | null = null;
+  try {
+    isolatedServer = await startIsolatedWorkspaceE2EServer();
+    api = await playwrightRequest.newContext({ baseURL: isolatedServer.info.base_url });
+    const workspace = await createIssueWorkspace(api, 10);
+    for (let index = 0; index < 2; index += 1) {
+      const launch = await api.post(`/api/v1/workspaces/${workspace.id}/runtime/sessions`, {
+        data: { target_key: "plain_shell", display_region: "terminal" },
+      });
+      expect(launch.status(), await launch.text()).toBe(200);
+    }
+
+    await page.goto(`${isolatedServer.info.base_url}/issues/github/acme/widgets/10`);
+    const terminal = await openTerminalPanel(page);
+    const panel = page.locator(".terminal-panel.open");
+    const handle = panel.getByRole("separator", { name: "Resize terminal panel" });
+    const leafBody = panel.locator(".terminal-leaf").filter({ has: terminal }).locator(".terminal-leaf-body");
+
+    const beforeHeight = await terminal.evaluate((element) => element.getBoundingClientRect().height);
+    const beforePty = await readPtyGeometry(page, terminal, workspace.worktree_path, "dock-resize-before");
+
+    await handle.press("ArrowUp");
+    await handle.press("ArrowUp");
+
+    await expect
+      .poll(() => terminal.evaluate((element) => element.getBoundingClientRect().height))
+      .toBeGreaterThan(beforeHeight + 20);
+    const afterLeafHeight = await leafBody.evaluate((element) => element.getBoundingClientRect().height);
+    const afterHeight = await terminal.evaluate((element) => element.getBoundingClientRect().height);
+    expect(Math.abs(afterLeafHeight - afterHeight)).toBeLessThan(2);
+
+    const afterPty = await readPtyGeometry(page, terminal, workspace.worktree_path, "dock-resize-after");
+    expect(afterPty.rows).toBeGreaterThan(beforePty.rows);
+  } finally {
+    await api?.dispose();
+    await isolatedServer?.stop();
+  }
+});
+```
+
+The production regression this catches is removing the terminal leaf's vertical flex participation: the panel and leaf body grow, but the xterm height and `stty` row count remain unchanged.
+
+- [ ] **Step 2: Run the focused test and verify the expected failure**
+
+Run from `frontend/`:
+
+```bash
+../node_modules/.bin/vp exec -- playwright test --config=playwright-e2e.config.ts tests/e2e-full/00-inline-workspace-continuity.spec.ts --project=chromium --grep "a dock resize grows both the pooled terminal and its PTY rows"
+```
+
+Expected: FAIL at the polled terminal-height assertion because `.terminal-leaf-body` grows while `.terminal-container` remains at its previous height; the PTY consequently keeps its previous row count.
+
+- [ ] **Step 3: Apply the minimal leaf-boundary fix**
+
+In `TerminalSplitTree.svelte`, change the existing leaf-body rule to participate in flex layout:
+
+```css
+.terminal-leaf-body {
+  position: relative;
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+```
+
+Do not add height declarations to `SessionTerminalSlot`, `PooledSessionTerminal`, or `XtermTerminalPane`; those layers already express the correct growth contract.
+
+- [ ] **Step 4: Run the Svelte analyzer**
+
+Run from the repository root:
+
+```bash
+./node_modules/.bin/vp exec -- svelte-mcp svelte-autofixer frontend/src/lib/components/terminal/TerminalSplitTree.svelte
+```
+
+Expected: no actionable Svelte errors caused by the change.
+
+- [ ] **Step 5: Re-run the focused browser test**
+
+Run from `frontend/`:
+
+```bash
+../node_modules/.bin/vp exec -- playwright test --config=playwright-e2e.config.ts tests/e2e-full/00-inline-workspace-continuity.spec.ts --project=chromium --grep "a dock resize grows both the pooled terminal and its PTY rows"
+```
+
+Expected: PASS. The xterm fills the resized leaf and `stty size` reports more rows.
+
+- [ ] **Step 6: Run the complete affected frontend verification**
+
+Run from the repository root:
+
+```bash
+make webui-verify
+```
+
+Then run the complete affected Playwright spec from `frontend/`:
+
+```bash
+../node_modules/.bin/vp exec -- playwright test --config=playwright-e2e.config.ts tests/e2e-full/00-inline-workspace-continuity.spec.ts --project=chromium
+```
+
+Expected: all checks and tests pass without new warnings.
+
+- [ ] **Step 7: Re-prove the live browser boundary**
+
+In the existing local Chrome page, enlarge and shrink the terminal dock. Confirm that the xterm fills the leaf after both changes, inspect the outgoing websocket resize frame, and run this inside the active shell:
+
+```python
+import shutil
+shutil.get_terminal_size()
+```
+
+Expected: both `columns` and `lines` follow the visible terminal dimensions; `lines` is no longer stuck at six in a tall dock.
+
+- [ ] **Step 8: Commit the implementation**
+
+Run the repository-local context-sync commit workflow, then stage only the implementation and regression:
+
+```bash
+git add frontend/src/lib/components/terminal/TerminalSplitTree.svelte frontend/tests/e2e-full/00-inline-workspace-continuity.spec.ts
+git commit -m "fix: let docked terminals grow vertically"
+```
+
+The commit body should record that pooled terminal slots already carried the correct flex-growth contract, but their block parent prevented vertical geometry from reaching xterm and the PTY.

--- a/docs/superpowers/plans/2026-07-29-terminal-vertical-resize.md
+++ b/docs/superpowers/plans/2026-07-29-terminal-vertical-resize.md
@@ -137,7 +137,8 @@ Expected: PASS. The xterm fills the resized leaf and `stty size` reports more ro
 Run from the repository root:
 
 ```bash
-make webui-verify
+make frontend-check-no-deps
+cd frontend && ../node_modules/.bin/vp test run --project unit
 ```
 
 Then run the complete affected Playwright spec from `frontend/`:

--- a/docs/superpowers/specs/2026-07-29-hidden-terminal-resize-authority-design.md
+++ b/docs/superpowers/specs/2026-07-29-hidden-terminal-resize-authority-design.md
@@ -1,0 +1,19 @@
+# Hidden terminal resize authority
+
+## Problem
+
+Inactive workflow tabs remain mounted under `visibility: hidden`, so their terminal regions retain measurable dimensions. Geometry alone therefore cannot distinguish a painted terminal from a hidden one: a hidden terminal can claim PTY resize authority and continue sending resize or refresh dimensions.
+
+## Design
+
+Resize authority requires both the pane's painted-state signal and valid measured geometry. A hidden terminal keeps its websocket and continues receiving output, but it advertises `resize_active=0`, sends `resize_active: false` when hidden, and emits no resize or refresh frames until painted again.
+
+The painted-state signal is not focus. Every leaf in a visible terminal split receives `active=true`, including unfocused leaves, so all painted terminals continue fitting and sizing their own PTYs. Parked terminals and hidden workflow tabs receive `active=false`; valid geometry cannot override that state.
+
+## Verification
+
+- A hidden but measurable terminal neither claims authority nor emits resize or refresh frames.
+- A visible terminal that becomes hidden revokes authority before later measurements can resize the PTY.
+- Existing unmeasurable-region coverage continues protecting parked terminals.
+- Split-tree coverage proves every painted leaf remains active regardless of focus.
+- The real Chromium/tmux dock-resize scenario proves vertical resize events still reach the PTY.

--- a/docs/superpowers/specs/2026-07-29-terminal-palette-chord-design.md
+++ b/docs/superpowers/specs/2026-07-29-terminal-palette-chord-design.md
@@ -1,0 +1,18 @@
+# Terminal-safe command palette chord
+
+## Problem
+
+A focused terminal must receive ordinary `Ctrl/Meta+K`, because terminal applications use that chord. The current terminal ownership rule correctly keeps the chord inside xterm, but the pane-move end-to-end test still expects it to open middleman's command palette.
+
+## Design
+
+Keep `Ctrl/Meta+K` terminal-owned. Add `Ctrl/Meta+Shift+K` as an explicit cross-platform command palette chord that middleman may reserve even when the keyboard event originates inside a focused terminal.
+
+The exception is limited to this exact chord. Escape, function keys, unshifted `Ctrl/Meta+K`, and every other terminal keystroke continue to bypass the global keyboard registry. When the palette is open, the same shifted chord closes it, matching the existing palette-toggle bindings.
+
+## Verification
+
+- Unit tests prove unshifted `Ctrl/Meta+K` stays terminal-owned while shifted `Ctrl/Meta+Shift+K` invokes the palette action.
+- Palette tests prove the shifted chord is registered for both opening and closing.
+- The real tmux-backed pane-move test uses the shifted chord and proves that palette teardown restores focus to the same live terminal after it is reparented.
+- The affected Chromium and Firefox Playwright lanes run before the fix is pushed.

--- a/docs/superpowers/specs/2026-07-29-terminal-vertical-resize-design.md
+++ b/docs/superpowers/specs/2026-07-29-terminal-vertical-resize-design.md
@@ -1,0 +1,53 @@
+# Terminal Vertical Resize Design
+
+## Problem
+
+The bottom terminal dock can grow vertically without growing its pooled xterm.
+The dock body receives the new height, but the terminal remains at its previous
+row count. Width changes still propagate because normal block layout stretches
+the terminal slot horizontally.
+
+Live inspection showed the dock leaf body at 529 pixels while the pooled xterm
+remained 90 pixels tall. No resize frame was sent for that terminal, and a
+command inside the PTY still reported six rows. The immediate cause is that
+`.terminal-leaf-body` is a block container, so the slot's existing `flex: 1`
+does not participate in vertical layout.
+
+Escape handling is not part of this change. With the terminal focused, Chrome
+sent the exact `0x1b` byte on the terminal websocket, matching Escape injected
+directly into the same tmux pane. The branch's terminal keyboard ownership path
+therefore needs no additional workaround for this defect.
+
+## Design
+
+Make `.terminal-leaf-body` a flex container. `SessionTerminalSlot` already
+declares flexible growth with zero minimum dimensions, and the pooled wrapper
+and terminal container already use full height. Activating that existing flex
+contract at the leaf boundary lets the reparented terminal fill both axes while
+preserving the split-preview overlay and pane-move lifecycle.
+
+Do not add height declarations through each pooled wrapper and do not
+absolute-position the terminal slot. Both alternatives duplicate ownership of
+the leaf's geometry and create more coupling between the split tree and the
+pooling implementation.
+
+## Verification
+
+Add a real-browser regression around a docked shell. The test will:
+
+1. Open a workspace with a real tmux-backed terminal.
+2. Record the terminal's rendered height and PTY row count.
+3. Enlarge the bottom terminal dock through its resize handle.
+4. Assert that the pooled xterm fills the enlarged leaf.
+5. Run `stty size` inside the terminal and assert that the PTY row count grew.
+
+The browser/PTY boundary is intentional: a component-only test could verify a
+CSS value while missing the ResizeObserver, websocket, resize-authority, or tmux
+application path that the user actually depends on.
+
+## Scope
+
+This change is UI-only; the likely regression surface is terminal geometry
+after dock resizing and pooled-terminal reparenting. It does not change session
+creation, resize arbitration, keyboard dispatch, provider behavior, or server
+APIs.

--- a/frontend/src/lib/components/keyboard/Palette.svelte
+++ b/frontend/src/lib/components/keyboard/Palette.svelte
@@ -429,6 +429,7 @@
       id: "palette.close",
       label: "Close palette",
       binding: [
+        { key: "k", ctrlOrMeta: true, shift: true },
         { key: "k", ctrlOrMeta: true },
         { key: "p", ctrlOrMeta: true },
         { key: "p", ctrlOrMeta: true, shift: true },

--- a/frontend/src/lib/components/keyboard/Palette.svelte.test.ts
+++ b/frontend/src/lib/components/keyboard/Palette.svelte.test.ts
@@ -2,11 +2,12 @@ import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-li
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import Palette from "./Palette.svelte";
+import { dispatchKeydown } from "../../stores/keyboard/dispatch.svelte.js";
 import { closePalette, openPalette, resetPaletteState } from "../../stores/keyboard/palette-state.svelte.js";
 import { registerScopedActions, resetRegistry } from "../../stores/keyboard/registry.svelte.js";
 import { RECENTS_KEY } from "../../stores/keyboard/recents.svelte.js";
 import type { ModePaletteResults } from "../../stores/keyboard/mode-palette-search.js";
-import type { Action } from "../../stores/keyboard/types.js";
+import type { Action, Context } from "../../stores/keyboard/types.js";
 import { resetModalStack } from "@middleman/ui/stores/keyboard/modal-stack";
 
 const noop = (): void => {};
@@ -52,6 +53,24 @@ describe("Palette", () => {
     closePalette();
     await rerender({});
     expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("closes with Cmd-Shift-K", async () => {
+    const { rerender } = render(Palette, { props: {} });
+    openPalette();
+    await rerender({});
+    const input = screen.getByRole("textbox", { name: "Search command palette" });
+    const event = new KeyboardEvent("keydown", {
+      key: "k",
+      metaKey: true,
+      shiftKey: true,
+      cancelable: true,
+    });
+    Object.defineProperty(event, "target", { value: input });
+
+    dispatchKeydown(event, () => ({}) as Context);
+
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "Command palette" })).toBeNull());
   });
 
   it("renders preview placeholder when no results", async () => {

--- a/frontend/src/lib/components/terminal/DockedTerminalPanel.svelte
+++ b/frontend/src/lib/components/terminal/DockedTerminalPanel.svelte
@@ -44,8 +44,10 @@
     height: number;
     loading?: boolean;
     disabled?: boolean;
-    // False while the owning WorkspaceTerminalView is parked in a hidden
-    // host: forwarded to TerminalSplitTree so its TerminalPanes deactivate.
+    // Whether this dock is painted: false while the owning
+    // WorkspaceTerminalView is parked in a hidden host, and false for the
+    // workflow-tab placement while another tab is selected. Forwarded to
+    // TerminalSplitTree, which makes it every leaf's visibility.
     hostVisible?: boolean;
     /** Shared detail-surface scope when terminal sessions may become top-level panes. */
     dragScope?: string | undefined;

--- a/frontend/src/lib/components/terminal/TerminalPane.test.ts
+++ b/frontend/src/lib/components/terminal/TerminalPane.test.ts
@@ -32,7 +32,7 @@ const {
   mouseDragObserveTerminalData: vi.fn(),
   mouseDragReset: vi.fn(),
   resizeObserverCallbacks: [] as ResizeObserverCallback[],
-  xtermFitAddons: [] as Array<{ fit: ReturnType<typeof vi.fn> }>,
+  xtermFitAddons: [] as Array<{ fit: ReturnType<typeof vi.fn>; proposeDimensions: ReturnType<typeof vi.fn> }>,
   xtermInstances: [] as Array<{
     clearTextureAtlas: ReturnType<typeof vi.fn>;
     cols: number;
@@ -56,6 +56,9 @@ let configuredLetterSpacing = 0;
 let configuredCursorBlink = true;
 let configuredFontLigatures = false;
 let mockSockets: MockWebSocket[] = [];
+// What the fit addon measures the region as. undefined models a container with
+// no content box (a parked terminal), for which the real addon proposes nothing.
+let fitDimensions: { cols: number; rows: number } | undefined = { cols: 80, rows: 24 };
 const originalDocumentFonts = Object.getOwnPropertyDescriptor(document, "fonts");
 const originalNavigatorClipboard = Object.getOwnPropertyDescriptor(navigator, "clipboard");
 
@@ -178,7 +181,10 @@ vi.mock("@xterm/xterm", () => ({
 
 vi.mock("@xterm/addon-fit", () => ({
   FitAddon: vi.fn().mockImplementation(function () {
-    const addon = { fit: vi.fn() };
+    // proposeDimensions is the pane's measurement of its own region: the real
+    // addon returns undefined, or a zero, for a container with no content box
+    // (a parked terminal), and the pane only pushes a size when it gets one.
+    const addon = { fit: vi.fn(), proposeDimensions: vi.fn(() => fitDimensions) };
     xtermFitAddons.push(addon);
     return addon;
   }),
@@ -205,6 +211,10 @@ vi.mock("@xterm/xterm/css/xterm.css", () => ({}));
 
 import TerminalPane from "./TerminalPane.svelte";
 
+function resizeFramesOf(socket: MockWebSocket): string[] {
+  return socket.sent.map(String).filter((frame) => frame.includes('"type":"resize"'));
+}
+
 describe("TerminalPane", () => {
   beforeEach(() => {
     configuredFontFamily = "";
@@ -214,6 +224,7 @@ describe("TerminalPane", () => {
     configuredLetterSpacing = 0;
     configuredCursorBlink = true;
     configuredFontLigatures = false;
+    fitDimensions = { cols: 80, rows: 24 };
     ligaturesAddonCtor.mockReset();
     clipboardWriteText.mockReset();
     clipboardWriterCancelPointerGesture.mockReset();
@@ -504,7 +515,7 @@ describe("TerminalPane", () => {
     expect(mockSockets[0]!.sent).toContain(JSON.stringify({ type: "resize", cols: 80, rows: 24 }));
   });
 
-  it("does not claim resize authority when a selected font resolves in an inactive pane", async () => {
+  it("pushes the re-measured size when a font resolves late in an unfocused pane", async () => {
     vi.useFakeTimers();
     const fontLoad = deferred<FontFace[]>();
     stubFontLoad(fontLoad.promise);
@@ -516,17 +527,17 @@ describe("TerminalPane", () => {
     const terminal = xtermInstances[0]!;
     const fitAddon = xtermFitAddons[0]!;
     terminal.clearTextureAtlas.mockClear();
-    terminal.refresh.mockClear();
     fitAddon.fit.mockClear();
     mockSockets[0]!.sent = [];
+    // Different metrics, so the region works out to a different size.
+    fitDimensions = { cols: 70, rows: 20 };
 
     fontLoad.resolve([]);
     await vi.advanceTimersByTimeAsync(0);
 
     expect(terminal.clearTextureAtlas).toHaveBeenCalledTimes(1);
     expect(fitAddon.fit).toHaveBeenCalledTimes(1);
-    expect(terminal.refresh).toHaveBeenCalledTimes(1);
-    expect(mockSockets[0]!.sent).toHaveLength(0);
+    expect(resizeFramesOf(mockSockets[0]!)).toEqual([JSON.stringify({ type: "resize", cols: 70, rows: 20 })]);
   });
 
   it("does not rebuild a disposed xterm when the selected font resolves late", async () => {
@@ -571,23 +582,75 @@ describe("TerminalPane", () => {
     expect(xtermInstances[0]!.clearTextureAtlas).not.toHaveBeenCalled();
   });
 
-  it("only lets active panes claim terminal resize authority", async () => {
-    const { rerender } = render(TerminalPane, {
-      props: { workspaceId: "ws-123", active: false },
-    });
+  it("claims resize authority for a measurable region even while unfocused", async () => {
+    // Authority follows the region, not focus. An unfocused pane that is
+    // painted still owns its own PTY's size — gating this on `active` is what
+    // left the other halves of a split at the tmux launch default.
+    render(TerminalPane, { props: { workspaceId: "ws-123", active: false } });
+
+    await waitFor(() => expect(mockSockets).toHaveLength(1));
+    expect(mockSockets[0]!.url).toContain("resize_active=1");
+
+    mockSockets[0]!.onopen?.();
+    expect(mockSockets[0]!.sent).toContain(JSON.stringify({ type: "resize_active", active: true }));
+
+    mockSockets[0]!.sent = [];
+    fitDimensions = { cols: 100, rows: 40 };
+    resizeObserverCallbacks[0]!([], {} as ResizeObserver);
+
+    expect(mockSockets[0]!.sent).toContain(JSON.stringify({ type: "resize", cols: 100, rows: 40 }));
+  });
+
+  it("neither claims authority nor pushes a size for an unmeasurable region", async () => {
+    // A parked terminal sits in a display:none node: the fit addon proposes
+    // nothing for it, and measuring it anyway is what used to resize a live
+    // tmux pane to one row.
+    fitDimensions = undefined;
+    render(TerminalPane, { props: { workspaceId: "ws-123" } });
 
     await waitFor(() => expect(mockSockets).toHaveLength(1));
     expect(mockSockets[0]!.url).toContain("resize_active=0");
 
     mockSockets[0]!.onopen?.();
-    expect(mockSockets[0]!.sent).toContain(JSON.stringify({ type: "resize_active", active: false }));
-
     mockSockets[0]!.sent = [];
     resizeObserverCallbacks[0]!([], {} as ResizeObserver);
-    expect(mockSockets[0]!.sent).toHaveLength(0);
 
-    await rerender({ workspaceId: "ws-123", active: true });
-    expect(mockSockets[0]!.sent).toContain(JSON.stringify({ type: "resize_active", active: true }));
+    expect(resizeFramesOf(mockSockets[0]!)).toHaveLength(0);
+  });
+
+  it("sends nothing more for a burst that measures the same size", async () => {
+    render(TerminalPane, { props: { workspaceId: "ws-123" } });
+
+    await waitFor(() => expect(resizeObserverCallbacks).toHaveLength(1));
+    mockSockets[0]!.onopen?.();
+
+    mockSockets[0]!.sent = [];
+    fitDimensions = { cols: 120, rows: 50 };
+    resizeObserverCallbacks[0]!([], {} as ResizeObserver);
+    resizeObserverCallbacks[0]!([], {} as ResizeObserver);
+    resizeObserverCallbacks[0]!([], {} as ResizeObserver);
+
+    expect(resizeFramesOf(mockSockets[0]!)).toEqual([JSON.stringify({ type: "resize", cols: 120, rows: 50 })]);
+  });
+
+  it("re-sends a size the socket was not open to carry", async () => {
+    // The first measurement lands before the socket opens. Recording it as sent
+    // anyway would let the dedupe suppress it forever, leaving the PTY at the
+    // size it launched with.
+    render(TerminalPane, { props: { workspaceId: "ws-123" } });
+
+    await waitFor(() => expect(resizeObserverCallbacks).toHaveLength(1));
+    mockSockets[0]!.readyState = 0;
+    fitDimensions = { cols: 90, rows: 30 };
+    resizeObserverCallbacks[0]!([], {} as ResizeObserver);
+    expect(resizeFramesOf(mockSockets[0]!)).toHaveLength(0);
+
+    mockSockets[0]!.readyState = 1;
+    mockSockets[0]!.onopen?.();
+    mockSockets[0]!.sent = [];
+    resizeObserverCallbacks[0]!([], {} as ResizeObserver);
+
+    expect(resizeFramesOf(mockSockets[0]!)).toEqual([JSON.stringify({ type: "resize", cols: 90, rows: 30 })]);
   });
 
   it("focuses the xterm terminal once it initializes while active", async () => {
@@ -630,12 +693,12 @@ describe("TerminalPane", () => {
     fitAddon.fit.mockClear();
     mockSockets[0]!.sent = [];
 
+    fitDimensions = { cols: 80, rows: 24 };
     resizeObserverCallbacks[0]!([], {} as ResizeObserver);
 
     expect(fitAddon.fit).toHaveBeenCalled();
     expect(terminal.clearTextureAtlas).not.toHaveBeenCalled();
     expect(terminal.refresh).toHaveBeenCalledWith(0, 23);
-    expect(mockSockets[0]!.sent).toContain(JSON.stringify({ type: "resize", cols: 80, rows: 24 }));
   });
 
   it("forwards complete tmux mouse drags without a local threshold", async () => {

--- a/frontend/src/lib/components/terminal/TerminalPane.test.ts
+++ b/frontend/src/lib/components/terminal/TerminalPane.test.ts
@@ -647,6 +647,47 @@ describe("TerminalPane", () => {
     expect(resizeFramesOf(mockSockets[0]!)).toHaveLength(0);
   });
 
+  it("claims authority before resizing when an active region gains geometry", async () => {
+    fitDimensions = undefined;
+    render(TerminalPane, { props: { workspaceId: "ws-123", active: true } });
+
+    await waitFor(() => expect(mockSockets).toHaveLength(1));
+    expect(mockSockets[0]!.url).toContain("resize_active=0");
+    mockSockets[0]!.onopen?.();
+    mockSockets[0]!.sent = [];
+
+    fitDimensions = { cols: 100, rows: 40 };
+    resizeObserverCallbacks[0]!([], {} as ResizeObserver);
+    resizeObserverCallbacks[0]!([], {} as ResizeObserver);
+
+    expect(mockSockets[0]!.sent.map(String)).toEqual([
+      JSON.stringify({ type: "resize_active", active: true }),
+      JSON.stringify({ type: "resize", cols: 100, rows: 40 }),
+    ]);
+  });
+
+  it("revokes and reclaims authority as active region geometry changes", async () => {
+    render(TerminalPane, { props: { workspaceId: "ws-123", active: true } });
+
+    await waitFor(() => expect(mockSockets).toHaveLength(1));
+    mockSockets[0]!.onopen?.();
+    mockSockets[0]!.sent = [];
+
+    fitDimensions = undefined;
+    resizeObserverCallbacks[0]!([], {} as ResizeObserver);
+    resizeObserverCallbacks[0]!([], {} as ResizeObserver);
+
+    fitDimensions = { cols: 80, rows: 24 };
+    resizeObserverCallbacks[0]!([], {} as ResizeObserver);
+    resizeObserverCallbacks[0]!([], {} as ResizeObserver);
+
+    expect(mockSockets[0]!.sent.map(String)).toEqual([
+      JSON.stringify({ type: "resize_active", active: false }),
+      JSON.stringify({ type: "resize_active", active: true }),
+      JSON.stringify({ type: "resize", cols: 80, rows: 24 }),
+    ]);
+  });
+
   it("sends nothing more for a burst that measures the same size", async () => {
     render(TerminalPane, { props: { workspaceId: "ws-123" } });
 

--- a/frontend/src/lib/components/terminal/TerminalPane.test.ts
+++ b/frontend/src/lib/components/terminal/TerminalPane.test.ts
@@ -515,12 +515,12 @@ describe("TerminalPane", () => {
     expect(mockSockets[0]!.sent).toContain(JSON.stringify({ type: "resize", cols: 80, rows: 24 }));
   });
 
-  it("pushes the re-measured size when a font resolves late in an unfocused pane", async () => {
+  it("pushes the re-measured size when a font resolves late in a painted pane", async () => {
     vi.useFakeTimers();
     const fontLoad = deferred<FontFace[]>();
     stubFontLoad(fontLoad.promise);
 
-    render(TerminalPane, { props: { workspaceId: "ws-123", active: false } });
+    render(TerminalPane, { props: { workspaceId: "ws-123", active: true } });
     await tick();
     await vi.advanceTimersByTimeAsync(300);
 
@@ -582,23 +582,52 @@ describe("TerminalPane", () => {
     expect(xtermInstances[0]!.clearTextureAtlas).not.toHaveBeenCalled();
   });
 
-  it("claims resize authority for a measurable region even while unfocused", async () => {
-    // Authority follows the region, not focus. An unfocused pane that is
-    // painted still owns its own PTY's size — gating this on `active` is what
-    // left the other halves of a split at the tmux launch default.
-    render(TerminalPane, { props: { workspaceId: "ws-123", active: false } });
+  it("claims resize authority for a painted measurable region", async () => {
+    render(TerminalPane, { props: { workspaceId: "ws-123", active: true } });
 
     await waitFor(() => expect(mockSockets).toHaveLength(1));
     expect(mockSockets[0]!.url).toContain("resize_active=1");
 
     mockSockets[0]!.onopen?.();
-    expect(mockSockets[0]!.sent).toContain(JSON.stringify({ type: "resize_active", active: true }));
+    mockSockets[0]!.sent = [];
+    fitDimensions = { cols: 100, rows: 40 };
+    resizeObserverCallbacks[0]!([], {} as ResizeObserver);
+
+    expect(resizeFramesOf(mockSockets[0]!)).toEqual([JSON.stringify({ type: "resize", cols: 100, rows: 40 })]);
+  });
+
+  it("does not claim resize authority for a hidden but measurable region", async () => {
+    render(TerminalPane, { props: { workspaceId: "ws-123", active: false } });
+
+    await waitFor(() => expect(mockSockets).toHaveLength(1));
+    expect(mockSockets[0]!.url).toContain("resize_active=0");
+
+    mockSockets[0]!.onopen?.();
+    expect(mockSockets[0]!.sent).toContain(JSON.stringify({ type: "resize_active", active: false }));
 
     mockSockets[0]!.sent = [];
     fitDimensions = { cols: 100, rows: 40 };
     resizeObserverCallbacks[0]!([], {} as ResizeObserver);
 
-    expect(mockSockets[0]!.sent).toContain(JSON.stringify({ type: "resize", cols: 100, rows: 40 }));
+    expect(mockSockets[0]!.sent).toHaveLength(0);
+  });
+
+  it("revokes authority and ignores later measurements when its tab becomes hidden", async () => {
+    const { rerender } = render(TerminalPane, {
+      props: { workspaceId: "ws-123", active: true },
+    });
+    await waitFor(() => expect(mockSockets).toHaveLength(1));
+    mockSockets[0]!.onopen?.();
+    mockSockets[0]!.sent = [];
+
+    await rerender({ workspaceId: "ws-123", active: false });
+    expect(mockSockets[0]!.sent).toContain(JSON.stringify({ type: "resize_active", active: false }));
+
+    mockSockets[0]!.sent = [];
+    fitDimensions = { cols: 100, rows: 40 };
+    resizeObserverCallbacks[0]!([], {} as ResizeObserver);
+
+    expect(mockSockets[0]!.sent).toHaveLength(0);
   });
 
   it("neither claims authority nor pushes a size for an unmeasurable region", async () => {
@@ -633,7 +662,7 @@ describe("TerminalPane", () => {
     expect(resizeFramesOf(mockSockets[0]!)).toEqual([JSON.stringify({ type: "resize", cols: 120, rows: 50 })]);
   });
 
-  it("re-sends a size the socket was not open to carry", async () => {
+  it("sends a size measured before socket open once the connection opens", async () => {
     // The first measurement lands before the socket opens. Recording it as sent
     // anyway would let the dedupe suppress it forever, leaving the PTY at the
     // size it launched with.
@@ -647,10 +676,8 @@ describe("TerminalPane", () => {
 
     mockSockets[0]!.readyState = 1;
     mockSockets[0]!.onopen?.();
-    mockSockets[0]!.sent = [];
-    resizeObserverCallbacks[0]!([], {} as ResizeObserver);
 
-    expect(resizeFramesOf(mockSockets[0]!)).toEqual([JSON.stringify({ type: "resize", cols: 90, rows: 30 })]);
+    expect(mockSockets[0]!.sent).toContain(JSON.stringify({ type: "refresh", cols: 90, rows: 30 }));
   });
 
   it("focuses the xterm terminal once it initializes while active", async () => {

--- a/frontend/src/lib/components/terminal/TerminalSplitTree.svelte
+++ b/frontend/src/lib/components/terminal/TerminalSplitTree.svelte
@@ -593,6 +593,7 @@
 
   .terminal-leaf-body {
     position: relative;
+    display: flex;
     flex: 1;
     min-height: 0;
     overflow: hidden;

--- a/frontend/src/lib/components/terminal/TerminalSplitTree.svelte
+++ b/frontend/src/lib/components/terminal/TerminalSplitTree.svelte
@@ -43,9 +43,13 @@
     activeSessionKey: string | null;
     borderTrim?: BorderTrim | undefined;
     disabled?: boolean;
-    // False while the owning WorkspaceTerminalView is parked in a hidden
-    // host: ANDed into every TerminalPane's `active` prop so ResizeObserver-
-    // driven refresh/resize work in the pane suspends while hidden.
+    // Whether this tree is painted at all: false while the owning
+    // WorkspaceTerminalView is parked in a hidden host, or while the dock
+    // holding it sits behind another workflow tab. It is every leaf's whole
+    // visibility, because a split paints all of its leaves at once — gating a
+    // leaf on `activeSessionKey` instead would leave the unfocused halves of a
+    // split inert, so their ResizeObserver never pushed a size and their tmux
+    // pane kept the launch default until the user clicked into them.
     hostVisible?: boolean;
     /** Shared detail-surface scope when terminal sessions may become top-level panes. */
     dragScope?: string | undefined;
@@ -400,7 +404,7 @@
               session.key,
               session.created_at,
             )}
-            visible={activeSessionKey === session.key && hostVisible}
+            visible={hostVisible}
           />
           <div
             class={[

--- a/frontend/src/lib/components/terminal/TerminalSplitTree.test.ts
+++ b/frontend/src/lib/components/terminal/TerminalSplitTree.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test"
 import TerminalSplitTree from "./TerminalSplitTree.svelte";
 import type { PaneNode } from "./terminal-layout";
 import { clearActiveTerminalDrag, readRuntimeSessionDrag } from "./terminal-drag";
+import { isSessionSlotVisible, resetSessionHostForTest, sessionHostKey } from "../../stores/session-host.svelte.ts";
 
 vi.mock("./TerminalPane.svelte", async () => ({
   default: (await import("./TerminalSplitTreeTestPane.svelte")).default,
@@ -87,8 +88,47 @@ describe("TerminalSplitTree", () => {
     cleanup();
     clearActiveTerminalDrag();
     clearActiveTabbedPanelDrag();
+    resetSessionHostForTest();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+  });
+
+  it("keeps every leaf of a split on screen, not only the focused one", async () => {
+    render(TerminalSplitTree, {
+      props: {
+        workspaceId: "ws-1",
+        node: split(),
+        sessions,
+        displayLabels: {},
+        activeSessionKey: sessions[0]!.key,
+      },
+    });
+
+    // Both leaves of a split are painted side by side, so both terminals have
+    // to size themselves to their own pane. Only the focused one reporting as
+    // visible leaves the other inert at whatever size it last held.
+    for (const session of sessions.slice(0, 2)) {
+      const key = sessionHostKey("ws-1", undefined, session.key, session.created_at);
+      expect(isSessionSlotVisible(key), session.label).toBe(true);
+    }
+  });
+
+  it("hides every leaf while the host is parked", async () => {
+    render(TerminalSplitTree, {
+      props: {
+        workspaceId: "ws-1",
+        node: split(),
+        sessions,
+        displayLabels: {},
+        activeSessionKey: sessions[0]!.key,
+        hostVisible: false,
+      },
+    });
+
+    for (const session of sessions.slice(0, 2)) {
+      const key = sessionHostKey("ws-1", undefined, session.key, session.created_at);
+      expect(isSessionSlotVisible(key), session.label).toBe(false);
+    }
   });
 
   it("publishes and clears a detail-pane payload from a terminal leaf drag", async () => {

--- a/frontend/src/lib/components/terminal/TerminalZoomControl.svelte
+++ b/frontend/src/lib/components/terminal/TerminalZoomControl.svelte
@@ -27,7 +27,7 @@
   <button
     type="button"
     aria-label="Decrease terminal font size"
-    title="Decrease terminal font size (Cmd/Ctrl+-)"
+    title="Decrease terminal font size"
     disabled={disabled || fontSize <= MIN_TERMINAL_FONT_SIZE}
     onclick={onDecrease}
   >
@@ -37,7 +37,7 @@
     class="font-size"
     type="button"
     aria-label="Reset terminal font size"
-    title="Reset terminal font size (Cmd/Ctrl+0)"
+    title="Reset terminal font size"
     {disabled}
     onclick={onReset}
   >
@@ -46,7 +46,7 @@
   <button
     type="button"
     aria-label="Increase terminal font size"
-    title="Increase terminal font size (Cmd/Ctrl++)"
+    title="Increase terminal font size"
     disabled={disabled || fontSize >= MAX_TERMINAL_FONT_SIZE}
     onclick={onIncrease}
   >

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -3548,11 +3548,6 @@
 <div
   class="terminal-view"
   inert={modalOpen}
-  onkeydowncapture={(event) => {
-    if (terminalSettingsReady && !terminalOptionsSaving) {
-      terminalZoom.handleKeydown(event);
-    }
-  }}
 >
   {#snippet inlineCollapseControl()}
     <!-- Collapsing the inline dock is pure local UI and must stay

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -3955,7 +3955,7 @@
                             height={terminalLayout.height}
                             loading={terminalLaunching}
                             disabled={actionsBlocked}
-                            {hostVisible}
+                            hostVisible={active && hostVisible}
                             onToggle={() => void toggleTerminalPanel()}
                             onNewTerminal={() => void launchTerminalSession()}
                             onSplit={(direction) => void splitTerminal(direction)}

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -84,6 +84,9 @@ vi.mock("@xterm/addon-fit", () => ({
   FitAddon: vi.fn().mockImplementation(function () {
     return {
       fit: mocks.mockFit,
+      // The pane measures its own region through the addon; a real one
+      // proposes nothing for a container with no content box.
+      proposeDimensions: () => ({ cols: 80, rows: 24 }),
     };
   }),
 }));

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -698,8 +698,8 @@ describe("WorkspaceTerminalView", () => {
     expect(screen.getByLabelText("Helper running").classList.contains("kit-status-dot--idle")).toBe(true);
   });
 
-  it("persists toolbar and focused-terminal font zoom through shared settings", async () => {
-    const { container } = render(WorkspaceTerminalView, {
+  it("persists toolbar font zoom through shared settings", async () => {
+    render(WorkspaceTerminalView, {
       props: {
         workspaceId: "ws-1",
       },
@@ -716,20 +716,33 @@ describe("WorkspaceTerminalView", () => {
       });
     });
     expect(mocks.mockSetTerminalSettings).toHaveBeenCalledWith(expect.objectContaining({ font_size: 15 }));
+  });
 
-    mocks.mockUpdateSettings.mockClear();
+  it.each([
+    ["Meta+=", { key: "=", metaKey: true }],
+    ["Ctrl+-", { key: "-", ctrlKey: true }],
+    ["Meta+0", { key: "0", metaKey: true }],
+  ] as const)("leaves %s untouched while a terminal is focused", async (_label, init) => {
+    const { container } = render(WorkspaceTerminalView, {
+      props: {
+        workspaceId: "ws-1",
+      },
+    });
+
+    await screen.findByRole("button", { name: "Increase terminal font size" });
     const terminalInput = document.createElement("textarea");
     container.querySelector(".terminal-container")?.append(terminalInput);
     terminalInput.focus();
-    await fireEvent.keyDown(terminalInput, {
-      key: "=",
-      metaKey: true,
+    const event = new KeyboardEvent("keydown", {
+      ...init,
+      bubbles: true,
+      cancelable: true,
     });
-    await waitFor(() => {
-      expect(mocks.mockUpdateSettings).toHaveBeenCalledWith({
-        terminal: expect.objectContaining({ font_size: 15 }),
-      });
-    });
+    terminalInput.dispatchEvent(event);
+    await Promise.resolve();
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(mocks.mockUpdateSettings).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalViewEmbed.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalViewEmbed.test.ts
@@ -66,7 +66,9 @@ vi.mock("@xterm/xterm", () => ({
 
 vi.mock("@xterm/addon-fit", () => ({
   FitAddon: vi.fn().mockImplementation(function () {
-    return { fit: vi.fn() };
+    // The pane measures its own region through the addon; a real one proposes
+    // nothing for a container with no content box.
+    return { fit: vi.fn(), proposeDimensions: () => ({ cols: 80, rows: 24 }) };
   }),
 }));
 

--- a/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
@@ -269,7 +269,7 @@
     rows: number,
   ): string {
     const sep = url.includes("?") ? "&" : "?";
-    const resizeActive = terminalRegionSize() !== null ? "1" : "0";
+    const resizeActive = resizeAuthorityRegionSize() !== null ? "1" : "0";
     const { traceparent, baggage } = traceHeadersForRequest();
     let result = `${url}${sep}cols=${cols}&rows=${rows}&resize_active=${resizeActive}&traceparent=${encodeURIComponent(traceparent)}`;
     if (baggage !== null) result += `&baggage=${encodeURIComponent(baggage)}`;
@@ -351,15 +351,16 @@
   }
 
   function refreshVisibleTerminal(): void {
-    if (!terminal) return;
+    const size = resizeAuthorityRegionSize();
+    if (!size || !terminal) return;
 
     fitAddon?.fit();
-    terminal.refresh(0, Math.max(0, terminal.rows - 1));
+    terminal.refresh(0, Math.max(0, size.rows - 1));
     // The server resizes on a refresh's dimensions too, so a delivered refresh
     // counts as the size the PTY now has.
-    if (sendRefresh(terminal.cols, terminal.rows)) {
-      sentCols = terminal.cols;
-      sentRows = terminal.rows;
+    if (sendRefresh(size.cols, size.rows)) {
+      sentCols = size.cols;
+      sentRows = size.rows;
     }
   }
 
@@ -434,8 +435,8 @@
    * A parked terminal sits in a `display:none` node, whose content box is zero,
    * so the fit addon proposes nothing usable for it — measuring that is what
    * used to resize a live tmux pane to one row. The measurement itself is the
-   * check; nothing here infers whether some container believes the pane is on
-   * screen.
+   * geometry check. Painted state is applied separately because
+   * `visibility:hidden` retains dimensions.
    */
   function terminalRegionSize(): { cols: number; rows: number } | null {
     if (!fitAddon || !terminal || !containerEl.isConnected) return null;
@@ -448,17 +449,21 @@
     return { cols: proposed.cols, rows: proposed.rows };
   }
 
+  function resizeAuthorityRegionSize(): { cols: number; rows: number } | null {
+    if (!active) return null;
+    return terminalRegionSize();
+  }
+
   /**
    * Push the region's size whenever it differs from what the PTY was last told.
    *
-   * Deliberately not gated on the pane being focused or "active": every painted
-   * terminal owns its own size, and a container that reports only its focused
-   * session used to leave the other halves of a split at whatever size they
-   * last held. Sending only on a real change keeps a ResizeObserver burst from
-   * turning into a burst of resize frames.
+   * Painted state is not focus: every visible split leaf is active and owns its
+   * own size. Requiring it here prevents a visibility-hidden tab, whose geometry
+   * remains measurable, from resizing the PTY. Sending only on a real change
+   * keeps a ResizeObserver burst from turning into a burst of resize frames.
    */
   function resizeVisibleTerminal(): void {
-    const size = terminalRegionSize();
+    const size = resizeAuthorityRegionSize();
     if (!size || !terminal) return;
 
     fitAddon?.fit();
@@ -515,7 +520,7 @@
     socket.onopen = () => {
       switchTimer.record("socket-open");
       reconnectDelay = 1000;
-      sendResizeActive(terminalRegionSize() !== null);
+      sendResizeActive(resizeAuthorityRegionSize() !== null);
       if (active) scheduleTerminalRefresh();
     };
 
@@ -699,10 +704,10 @@
 
   $effect(() => {
     if (!terminal) return;
-    // Authority follows the rendered region, not focus: a painted split leaf
-    // must be allowed to size its own PTY, while a parked terminal (no region)
-    // must not dictate a size for the pane the user is actually looking at.
-    sendResizeActive(terminalRegionSize() !== null);
+    // Authority requires painted state plus geometry, never focus: every
+    // painted split leaf stays eligible, while hidden and parked terminals do
+    // not dictate a size for the pane the user is actually looking at.
+    sendResizeActive(resizeAuthorityRegionSize() !== null);
     if (active) scheduleTerminalRefresh();
   });
 

--- a/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
@@ -67,6 +67,10 @@
   let resizeObserver: ResizeObserver | null = null;
   let refreshFrame: number | null = null;
   let resizeFrame: number | null = null;
+  // What the PTY was last told. Resends are skipped against this, so a
+  // ResizeObserver burst costs one frame, not one per callback.
+  let sentCols = 0;
+  let sentRows = 0;
   let appliedTerminalFontFamily = "";
   let appliedFontSize = 0;
   let appliedScrollback = 0;
@@ -265,7 +269,7 @@
     rows: number,
   ): string {
     const sep = url.includes("?") ? "&" : "?";
-    const resizeActive = active ? "1" : "0";
+    const resizeActive = terminalRegionSize() !== null ? "1" : "0";
     const { traceparent, baggage } = traceHeadersForRequest();
     let result = `${url}${sep}cols=${cols}&rows=${rows}&resize_active=${resizeActive}&traceparent=${encodeURIComponent(traceparent)}`;
     if (baggage !== null) result += `&baggage=${encodeURIComponent(baggage)}`;
@@ -322,12 +326,12 @@
     }
   }
 
-  function sendResize(cols: number, rows: number): void {
-    sendControl("resize", cols, rows);
+  function sendResize(cols: number, rows: number): boolean {
+    return sendControl("resize", cols, rows);
   }
 
-  function sendRefresh(cols: number, rows: number): void {
-    sendControl("refresh", cols, rows);
+  function sendRefresh(cols: number, rows: number): boolean {
+    return sendControl("refresh", cols, rows);
   }
 
   function sendResizeActive(nextActive: boolean): void {
@@ -340,10 +344,10 @@
     type: "resize" | "refresh",
     cols: number,
     rows: number,
-  ): void {
-    if (ws?.readyState === WebSocket.OPEN) {
-      ws.send(JSON.stringify({ type, cols, rows }));
-    }
+  ): boolean {
+    if (ws?.readyState !== WebSocket.OPEN) return false;
+    ws.send(JSON.stringify({ type, cols, rows }));
+    return true;
   }
 
   function refreshVisibleTerminal(): void {
@@ -351,7 +355,12 @@
 
     fitAddon?.fit();
     terminal.refresh(0, Math.max(0, terminal.rows - 1));
-    sendRefresh(terminal.cols, terminal.rows);
+    // The server resizes on a refresh's dimensions too, so a delivered refresh
+    // counts as the size the PTY now has.
+    if (sendRefresh(terminal.cols, terminal.rows)) {
+      sentCols = terminal.cols;
+      sentRows = terminal.rows;
+    }
   }
 
   function redrawTerminalTextureAtlas(): void {
@@ -419,12 +428,50 @@
     });
   }
 
-  function resizeVisibleTerminal(): void {
-    if (!fitAddon || !terminal || !active) return;
+  /**
+   * The size this terminal's region actually is, or null when it has none.
+   *
+   * A parked terminal sits in a `display:none` node, whose content box is zero,
+   * so the fit addon proposes nothing usable for it — measuring that is what
+   * used to resize a live tmux pane to one row. The measurement itself is the
+   * check; nothing here infers whether some container believes the pane is on
+   * screen.
+   */
+  function terminalRegionSize(): { cols: number; rows: number } | null {
+    if (!fitAddon || !terminal || !containerEl.isConnected) return null;
 
-    fitAddon.fit();
-    terminal.refresh(0, Math.max(0, terminal.rows - 1));
-    sendResize(terminal.cols, terminal.rows);
+    const proposed = fitAddon.proposeDimensions();
+    if (!proposed) return null;
+    if (!Number.isFinite(proposed.cols) || !Number.isFinite(proposed.rows)) return null;
+    if (proposed.cols < 1 || proposed.rows < 1) return null;
+
+    return { cols: proposed.cols, rows: proposed.rows };
+  }
+
+  /**
+   * Push the region's size whenever it differs from what the PTY was last told.
+   *
+   * Deliberately not gated on the pane being focused or "active": every painted
+   * terminal owns its own size, and a container that reports only its focused
+   * session used to leave the other halves of a split at whatever size they
+   * last held. Sending only on a real change keeps a ResizeObserver burst from
+   * turning into a burst of resize frames.
+   */
+  function resizeVisibleTerminal(): void {
+    const size = terminalRegionSize();
+    if (!size || !terminal) return;
+
+    fitAddon?.fit();
+    terminal.refresh(0, Math.max(0, size.rows - 1));
+    // Compare the MEASUREMENT, not a read-back of terminal.cols: fit() applies
+    // these same numbers, and the measurement is what the size should be.
+    if (size.cols === sentCols && size.rows === sentRows) return;
+    // Recorded only once the socket carried it — a resize computed before the
+    // socket opened would otherwise be suppressed forever as already sent.
+    if (sendResize(size.cols, size.rows)) {
+      sentCols = size.cols;
+      sentRows = size.rows;
+    }
   }
 
   function handleTerminalPaste(event: ClipboardEvent): void {
@@ -468,7 +515,7 @@
     socket.onopen = () => {
       switchTimer.record("socket-open");
       reconnectDelay = 1000;
-      sendResizeActive(active);
+      sendResizeActive(terminalRegionSize() !== null);
       if (active) scheduleTerminalRefresh();
     };
 
@@ -652,7 +699,10 @@
 
   $effect(() => {
     if (!terminal) return;
-    sendResizeActive(active);
+    // Authority follows the rendered region, not focus: a painted split leaf
+    // must be allowed to size its own PTY, while a parked terminal (no region)
+    // must not dictate a size for the pane the user is actually looking at.
+    sendResizeActive(terminalRegionSize() !== null);
     if (active) scheduleTerminalRefresh();
   });
 
@@ -799,9 +849,10 @@
 
         lateFontRebuilt = true;
         terminal.clearTextureAtlas();
-        fitAddon?.fit();
-        terminal.refresh(0, Math.max(0, terminal.rows - 1));
-        if (active) sendResize(terminal.cols, terminal.rows);
+        // New metrics mean a new measurement; resizeVisibleTerminal re-fits,
+        // repaints, and pushes the size only if the region now works out
+        // differently.
+        resizeVisibleTerminal();
       },
       () => finishInitialFontWait({ error: true }),
     );

--- a/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
@@ -71,6 +71,7 @@
   // ResizeObserver burst costs one frame, not one per callback.
   let sentCols = 0;
   let sentRows = 0;
+  let sentResizeActive: boolean | null = null;
   let appliedTerminalFontFamily = "";
   let appliedFontSize = 0;
   let appliedScrollback = 0;
@@ -334,10 +335,14 @@
     return sendControl("refresh", cols, rows);
   }
 
-  function sendResizeActive(nextActive: boolean): void {
+  function sendResizeActive(nextActive: boolean): boolean {
+    if (sentResizeActive === nextActive) return false;
     if (ws?.readyState === WebSocket.OPEN) {
       ws.send(JSON.stringify({ type: "resize_active", active: nextActive }));
+      sentResizeActive = nextActive;
+      return true;
     }
+    return false;
   }
 
   function sendControl(
@@ -463,14 +468,18 @@
    * keeps a ResizeObserver burst from turning into a burst of resize frames.
    */
   function resizeVisibleTerminal(): void {
-    const size = resizeAuthorityRegionSize();
-    if (!size || !terminal) return;
+    const size = terminalRegionSize();
+    const resizeActive = active && size !== null;
+    const authorityChanged = sendResizeActive(resizeActive);
+    if (!resizeActive || !size || !terminal) return;
 
     fitAddon?.fit();
     terminal.refresh(0, Math.max(0, size.rows - 1));
     // Compare the MEASUREMENT, not a read-back of terminal.cols: fit() applies
     // these same numbers, and the measurement is what the size should be.
-    if (size.cols === sentCols && size.rows === sentRows) return;
+    // Re-send unchanged dimensions when reclaiming authority because another
+    // attachment may have resized the PTY while this region had no geometry.
+    if (!authorityChanged && size.cols === sentCols && size.rows === sentRows) return;
     // Recorded only once the socket carried it — a resize computed before the
     // socket opened would otherwise be suppressed forever as already sent.
     if (sendResize(size.cols, size.rows)) {
@@ -515,6 +524,7 @@
     if (!url) return;
     const socket = new WebSocket(url);
     socket.binaryType = "arraybuffer";
+    sentResizeActive = null;
     ws = socket;
 
     socket.onopen = () => {

--- a/frontend/src/lib/components/terminal/terminalZoom.test.ts
+++ b/frontend/src/lib/components/terminal/terminalZoom.test.ts
@@ -98,43 +98,4 @@ describe("terminal zoom controller", () => {
     expect(harness.getSettings().font_size).toBe(RESET_TERMINAL_FONT_SIZE);
     expect(harness.reportError).toHaveBeenCalledWith(expect.objectContaining({ message: "settings unavailable" }));
   });
-
-  it("handles browser zoom shortcuts only from a focused terminal", async () => {
-    const harness = createHarness();
-    const terminal = document.createElement("div");
-    terminal.className = "terminal-container";
-    const input = document.createElement("textarea");
-    terminal.append(input);
-    const outside = document.createElement("button");
-
-    const outsideEvent = new KeyboardEvent("keydown", { key: "+", metaKey: true, cancelable: true });
-    Object.defineProperty(outsideEvent, "target", { value: outside });
-    expect(harness.controller.handleKeydown(outsideEvent)).toBe(false);
-    expect(outsideEvent.defaultPrevented).toBe(false);
-
-    const increaseEvent = new KeyboardEvent("keydown", { key: "=", metaKey: true, cancelable: true });
-    Object.defineProperty(increaseEvent, "target", { value: input });
-    expect(harness.controller.handleKeydown(increaseEvent)).toBe(true);
-    expect(increaseEvent.defaultPrevented).toBe(true);
-    expect(harness.getSettings().font_size).toBe(13);
-
-    const browserSpecificIncreaseEvent = new KeyboardEvent("keydown", {
-      code: "Equal",
-      ctrlKey: true,
-      key: "Unidentified",
-      cancelable: true,
-    });
-    Object.defineProperty(browserSpecificIncreaseEvent, "target", {
-      value: input,
-    });
-    expect(harness.controller.handleKeydown(browserSpecificIncreaseEvent)).toBe(true);
-    expect(harness.getSettings().font_size).toBe(14);
-
-    const resetEvent = new KeyboardEvent("keydown", { key: "0", ctrlKey: true, cancelable: true });
-    Object.defineProperty(resetEvent, "target", { value: input });
-    expect(harness.controller.handleKeydown(resetEvent)).toBe(true);
-    expect(harness.getSettings().font_size).toBe(RESET_TERMINAL_FONT_SIZE);
-
-    await harness.controller.whenIdle();
-  });
 });

--- a/frontend/src/lib/components/terminal/terminalZoom.ts
+++ b/frontend/src/lib/components/terminal/terminalZoom.ts
@@ -14,7 +14,6 @@ interface TerminalZoomControllerOptions {
 
 export interface TerminalZoomController {
   decrease: () => void;
-  handleKeydown: (event: KeyboardEvent) => boolean;
   increase: () => void;
   reset: () => void;
   setFontSize: (fontSize: number) => void;
@@ -23,21 +22,6 @@ export interface TerminalZoomController {
 
 function clampFontSize(fontSize: number): number {
   return Math.min(MAX_TERMINAL_FONT_SIZE, Math.max(MIN_TERMINAL_FONT_SIZE, Math.round(fontSize)));
-}
-
-type TerminalZoomAction = "decrease" | "increase" | "reset";
-
-function terminalShortcutAction(event: KeyboardEvent): TerminalZoomAction | null {
-  if ((!event.metaKey && !event.ctrlKey) || event.altKey) return null;
-  if (!(event.target instanceof Element) || !event.target.closest(".terminal-container")) return null;
-  if (event.key === "0" || event.code === "Digit0" || event.code === "Numpad0") return "reset";
-  if (event.key === "+" || event.key === "=" || event.code === "Equal" || event.code === "NumpadAdd") {
-    return "increase";
-  }
-  if (event.key === "-" || event.key === "_" || event.code === "Minus" || event.code === "NumpadSubtract") {
-    return "decrease";
-  }
-  return null;
 }
 
 export function createTerminalZoomController({
@@ -87,25 +71,8 @@ export function createTerminalZoomController({
     setFontSize(RESET_TERMINAL_FONT_SIZE);
   }
 
-  function handleKeydown(event: KeyboardEvent): boolean {
-    const action = terminalShortcutAction(event);
-    if (!action) return false;
-    event.preventDefault();
-    event.stopPropagation();
-
-    if (action === "reset") {
-      reset();
-    } else if (action === "increase") {
-      increase();
-    } else {
-      decrease();
-    }
-    return true;
-  }
-
   return {
     decrease,
-    handleKeydown,
     increase,
     reset,
     setFontSize,

--- a/frontend/src/lib/stores/keyboard/actions.test.ts
+++ b/frontend/src/lib/stores/keyboard/actions.test.ts
@@ -139,10 +139,11 @@ describe("defaultActions", () => {
     expect(ids).not.toContain("nav.pulls.board");
   });
 
-  it("palette.open binds Cmd/Ctrl+K, Cmd/Ctrl+P, and Cmd/Ctrl+Shift+P", () => {
+  it("palette.open binds the terminal-safe shifted K chord and the existing palette chords", () => {
     const palette = defaultActions.find((a) => a.id === "palette.open");
     expect(palette).toBeDefined();
     expect(palette!.binding).toEqual([
+      { key: "k", ctrlOrMeta: true, shift: true },
       { key: "k", ctrlOrMeta: true },
       { key: "p", ctrlOrMeta: true },
       { key: "p", ctrlOrMeta: true, shift: true },

--- a/frontend/src/lib/stores/keyboard/actions.ts
+++ b/frontend/src/lib/stores/keyboard/actions.ts
@@ -576,6 +576,7 @@ export const defaultActions: Action[] = [
     label: "Open command palette",
     scope: "global",
     binding: [
+      { key: "k", ctrlOrMeta: true, shift: true },
       { key: "k", ctrlOrMeta: true },
       { key: "p", ctrlOrMeta: true },
       { key: "p", ctrlOrMeta: true, shift: true },

--- a/frontend/src/lib/stores/keyboard/dispatch.svelte.test.ts
+++ b/frontend/src/lib/stores/keyboard/dispatch.svelte.test.ts
@@ -280,6 +280,22 @@ describe("dispatchKeydown — a focused terminal owns the keyboard", () => {
     expect(palette).not.toHaveBeenCalled();
   });
 
+  it("reserves Ctrl/Cmd-Shift-K for the palette while a terminal is focused", () => {
+    const palette = register("palette.open", { key: "k", ctrlOrMeta: true, shift: true });
+    const { textarea, wrapper } = terminalTargets();
+
+    for (const modifier of [{ metaKey: true }, { ctrlKey: true }]) {
+      for (const target of [textarea, wrapper]) {
+        const e = event({ key: "k", shiftKey: true, ...modifier });
+        Object.defineProperty(e, "target", { value: target });
+        dispatchKeydown(e, () => ctx);
+        expect(e.preventDefault).toHaveBeenCalled();
+      }
+    }
+
+    expect(palette).toHaveBeenCalledTimes(4);
+  });
+
   it("keeps terminal ownership while a modal frame is open", () => {
     // RESERVED_WHILE_MODAL_OPEN preventDefaults the palette keys for any frame
     // on the stack. A frame that never trapped focus cannot own the keyboard

--- a/frontend/src/lib/stores/keyboard/dispatch.svelte.test.ts
+++ b/frontend/src/lib/stores/keyboard/dispatch.svelte.test.ts
@@ -266,6 +266,40 @@ describe("dispatchKeydown — a focused terminal owns the keyboard", () => {
     expect(chord).not.toHaveBeenCalled();
   });
 
+  it("lets Cmd-K and Cmd-P through to a TUI that binds them", () => {
+    const palette = register("palette.open", { key: "k", ctrlOrMeta: true });
+    const { textarea } = terminalTargets();
+
+    for (const key of ["k", "p"]) {
+      const e = event({ key, metaKey: true });
+      Object.defineProperty(e, "target", { value: textarea });
+      dispatchKeydown(e, () => ctx);
+      expect(e.preventDefault, `Cmd-${key}`).not.toHaveBeenCalled();
+    }
+
+    expect(palette).not.toHaveBeenCalled();
+  });
+
+  it("keeps terminal ownership while a modal frame is open", () => {
+    // RESERVED_WHILE_MODAL_OPEN preventDefaults the palette keys for any frame
+    // on the stack. A frame that never trapped focus cannot own the keyboard
+    // the user is typing into, so the terminal still wins.
+    const framed = vi.fn();
+    pushModalFrame("modal", [
+      { id: "modal.esc", label: "Close", binding: { key: "Escape" }, priority: 100, when: () => true, handler: framed },
+    ]);
+    const { textarea } = terminalTargets();
+
+    for (const init of [{ key: "Escape" }, { key: "k", metaKey: true }]) {
+      const e = event(init);
+      Object.defineProperty(e, "target", { value: textarea });
+      dispatchKeydown(e, () => ctx);
+      expect(e.preventDefault, init.key).not.toHaveBeenCalled();
+    }
+
+    expect(framed).not.toHaveBeenCalled();
+  });
+
   it("still dispatches the same keys away from a terminal", () => {
     const escape = register("escape.list", { key: "Escape" });
     const chord = register("palette", { key: "p", ctrlOrMeta: true });

--- a/frontend/src/lib/stores/keyboard/dispatch.svelte.test.ts
+++ b/frontend/src/lib/stores/keyboard/dispatch.svelte.test.ts
@@ -209,3 +209,76 @@ describe("dispatchKeydown — in-flight de-dup", () => {
     expect(handler).toHaveBeenCalledTimes(2);
   });
 });
+
+describe("dispatchKeydown — a focused terminal owns the keyboard", () => {
+  beforeEach(() => {
+    resetRegistry();
+    resetModalStack();
+    document.body.replaceChildren();
+  });
+
+  afterEach(() => {
+    document.body.replaceChildren();
+  });
+
+  // The real chain, and both places focus actually lands: xterm parks it in a
+  // hidden textarea, but a pane focused without a click into the grid holds it
+  // on the session wrapper — which no editable selector matches.
+  function terminalTargets(): { textarea: HTMLElement; wrapper: HTMLElement } {
+    const wrapper = document.createElement("div");
+    wrapper.dataset.sessionHost = "ws-1/agent";
+    const container = document.createElement("div");
+    container.className = "terminal-container";
+    const xterm = document.createElement("div");
+    xterm.className = "xterm";
+    const textarea = document.createElement("textarea");
+    textarea.className = "xterm-helper-textarea";
+    xterm.append(textarea);
+    container.append(xterm);
+    wrapper.append(container);
+    document.body.append(wrapper);
+    return { textarea, wrapper };
+  }
+
+  function register(id: string, binding: Action["binding"]): ReturnType<typeof vi.fn> {
+    const handler = vi.fn();
+    registerScopedActions(id, [{ id, label: id, scope: "global", binding, priority: 0, when: () => true, handler }]);
+    return handler;
+  }
+
+  it("leaves Escape, function keys, and Ctrl chords to the terminal", () => {
+    const escape = register("escape.list", { key: "Escape" });
+    const fnKey = register("help", { key: "F1" });
+    const chord = register("palette", { key: "p", ctrlOrMeta: true });
+    const { textarea, wrapper } = terminalTargets();
+
+    for (const target of [textarea, wrapper]) {
+      for (const init of [{ key: "Escape" }, { key: "F1" }, { key: "p", ctrlKey: true }]) {
+        const e = event(init);
+        Object.defineProperty(e, "target", { value: target });
+        dispatchKeydown(e, () => ctx);
+        expect(e.preventDefault, `${init.key} on ${target.tagName}`).not.toHaveBeenCalled();
+      }
+    }
+
+    expect(escape).not.toHaveBeenCalled();
+    expect(fnKey).not.toHaveBeenCalled();
+    expect(chord).not.toHaveBeenCalled();
+  });
+
+  it("still dispatches the same keys away from a terminal", () => {
+    const escape = register("escape.list", { key: "Escape" });
+    const chord = register("palette", { key: "p", ctrlOrMeta: true });
+    const outside = document.createElement("div");
+    document.body.append(outside);
+
+    for (const init of [{ key: "Escape" }, { key: "p", ctrlKey: true }]) {
+      const e = event(init);
+      Object.defineProperty(e, "target", { value: outside });
+      dispatchKeydown(e, () => ctx);
+    }
+
+    expect(escape).toHaveBeenCalled();
+    expect(chord).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/stores/keyboard/dispatch.svelte.test.ts
+++ b/frontend/src/lib/stores/keyboard/dispatch.svelte.test.ts
@@ -300,6 +300,43 @@ describe("dispatchKeydown — a focused terminal owns the keyboard", () => {
     expect(framed).not.toHaveBeenCalled();
   });
 
+  it("owns the keyboard when Focus Terminal parked focus on the workspace wrapper", () => {
+    // The unpromoted workspace terminal's Focus Terminal path focuses
+    // `.workspace-host-wrapper` itself, which sits ABOVE the terminal —
+    // closest() walks up, so a subtree selector never sees it.
+    const escape = register("escape.list", { key: "Escape" });
+    const host = document.createElement("div");
+    host.className = "workspace-host-wrapper";
+    host.tabIndex = -1;
+    host.append(document.createElement("div"));
+    document.body.append(host);
+
+    const e = event({ key: "Escape" });
+    Object.defineProperty(e, "target", { value: host });
+    dispatchKeydown(e, () => ctx);
+
+    expect(escape).not.toHaveBeenCalled();
+    expect(e.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("leaves the workspace's own controls to the app", () => {
+    // The wrapper also contains the workspace sidebar, dock header, and
+    // dialogs. Matching it as an ancestor would swallow every shortcut typed
+    // anywhere in the workspace, so only the wrapper ITSELF counts.
+    const escape = register("escape.list", { key: "Escape" });
+    const host = document.createElement("div");
+    host.className = "workspace-host-wrapper";
+    const control = document.createElement("button");
+    host.append(control);
+    document.body.append(host);
+
+    const e = event({ key: "Escape" });
+    Object.defineProperty(e, "target", { value: control });
+    dispatchKeydown(e, () => ctx);
+
+    expect(escape).toHaveBeenCalled();
+  });
+
   it("still dispatches the same keys away from a terminal", () => {
     const escape = register("escape.list", { key: "Escape" });
     const chord = register("palette", { key: "p", ctrlOrMeta: true });

--- a/frontend/src/lib/stores/keyboard/dispatch.svelte.ts
+++ b/frontend/src/lib/stores/keyboard/dispatch.svelte.ts
@@ -1,7 +1,7 @@
 import { getStack } from "@middleman/ui/stores/keyboard/modal-stack";
 import { showFlash } from "@middleman/ui/stores/flash";
 import { getAllActions } from "./registry.svelte.js";
-import { shouldIgnoreGlobalShortcutTarget } from "../../utils/keyboardShortcuts.js";
+import { isTerminalKeyboardTarget, shouldIgnoreGlobalShortcutTarget } from "../../utils/keyboardShortcuts.js";
 import type { Action, Context, KeySpec } from "./types.js";
 
 const RESERVED_WHILE_MODAL_OPEN: KeySpec[] = [
@@ -38,6 +38,13 @@ export function dispatchKeydown(event: KeyboardEvent, contextProvider: () => Con
     }
     return;
   }
+
+  // A focused terminal owns EVERY key, modified ones included. Anything less
+  // and the app quietly steals whatever the TUI inside it binds — Escape, the
+  // function keys, Ctrl chords — and the terminal is only as usable as the set
+  // of keys this app happens not to want. No preventDefault: the keystroke is
+  // xterm's, and stopping the default is how it would fail to arrive.
+  if (isTerminalKeyboardTarget(event.target)) return;
 
   const editable = shouldIgnoreGlobalShortcutTarget(event.target);
   const ctx = contextProvider();

--- a/frontend/src/lib/stores/keyboard/dispatch.svelte.ts
+++ b/frontend/src/lib/stores/keyboard/dispatch.svelte.ts
@@ -20,6 +20,16 @@ const SCOPE_SPECIFICITY: Record<Action["scope"], number> = {
 };
 
 export function dispatchKeydown(event: KeyboardEvent, contextProvider: () => Context): void {
+  // A focused terminal owns EVERY key, modified ones included, and it outranks
+  // the modal stack too: a frame that did not trap focus cannot be holding the
+  // keyboard the user is typing into. Anything less and the app quietly steals
+  // whatever the TUI binds — Escape, the function keys, Ctrl/Cmd chords — and
+  // the terminal is only as usable as the set of keys this app happens not to
+  // want. Not even preventDefault: the keystroke is xterm's, and suppressing
+  // the default is how it would fail to arrive. Popovers keep their own window
+  // Escape listeners, so they still close from here.
+  if (isTerminalKeyboardTarget(event.target)) return;
+
   const stack = getStack();
   if (stack.length > 0) {
     const modalCtx = contextProvider();
@@ -38,13 +48,6 @@ export function dispatchKeydown(event: KeyboardEvent, contextProvider: () => Con
     }
     return;
   }
-
-  // A focused terminal owns EVERY key, modified ones included. Anything less
-  // and the app quietly steals whatever the TUI inside it binds — Escape, the
-  // function keys, Ctrl chords — and the terminal is only as usable as the set
-  // of keys this app happens not to want. No preventDefault: the keystroke is
-  // xterm's, and stopping the default is how it would fail to arrive.
-  if (isTerminalKeyboardTarget(event.target)) return;
 
   const editable = shouldIgnoreGlobalShortcutTarget(event.target);
   const ctx = contextProvider();

--- a/frontend/src/lib/stores/keyboard/dispatch.svelte.ts
+++ b/frontend/src/lib/stores/keyboard/dispatch.svelte.ts
@@ -20,15 +20,12 @@ const SCOPE_SPECIFICITY: Record<Action["scope"], number> = {
 };
 
 export function dispatchKeydown(event: KeyboardEvent, contextProvider: () => Context): void {
-  // A focused terminal owns EVERY key, modified ones included, and it outranks
-  // the modal stack too: a frame that did not trap focus cannot be holding the
-  // keyboard the user is typing into. Anything less and the app quietly steals
-  // whatever the TUI binds — Escape, the function keys, Ctrl/Cmd chords — and
-  // the terminal is only as usable as the set of keys this app happens not to
-  // want. Not even preventDefault: the keystroke is xterm's, and suppressing
-  // the default is how it would fail to arrive. Popovers keep their own window
-  // Escape listeners, so they still close from here.
-  if (isTerminalKeyboardTarget(event.target)) return;
+  // A focused terminal owns every key except the explicit shifted palette
+  // chord, and it otherwise outranks the modal stack too: a frame that did not
+  // trap focus cannot be holding the keyboard the user is typing into. Not even
+  // preventDefault: the keystroke is xterm's, and suppressing the default is how
+  // it would fail to arrive. Popovers keep their own window Escape listeners.
+  if (isTerminalKeyboardTarget(event.target) && !isTerminalPaletteShortcut(event)) return;
 
   const stack = getStack();
   if (stack.length > 0) {
@@ -64,6 +61,10 @@ export function dispatchKeydown(event: KeyboardEvent, contextProvider: () => Con
 
   event.preventDefault();
   runHandler(matchingActions[0]!, ctx);
+}
+
+function isTerminalPaletteShortcut(event: KeyboardEvent): boolean {
+  return event.key.toLowerCase() === "k" && (event.ctrlKey || event.metaKey) && event.shiftKey && !event.altKey;
 }
 
 interface RunnableAction {

--- a/frontend/src/lib/utils/keyboardShortcuts.ts
+++ b/frontend/src/lib/utils/keyboardShortcuts.ts
@@ -1,11 +1,35 @@
 const EDITABLE_SELECTOR = "input, textarea, select, [contenteditable='true']";
 
+// A live terminal, by any of the wrappers a keydown can land on: xterm's own
+// root and hidden helper textarea, the pane container, and the session wrapper
+// (which is what holds focus when a pane is focused without clicking into the
+// grid itself).
+const TERMINAL_SELECTOR = ".terminal-container, .xterm, [data-session-host]";
+
 export function shouldIgnoreGlobalShortcutTarget(target: EventTarget | null): boolean {
+  return closestMatch(target, EDITABLE_SELECTOR);
+}
+
+/**
+ * Whether a focused terminal owns this keystroke outright.
+ *
+ * A terminal is a whole second keyboard consumer, not a text field: TUIs bind
+ * Escape, function keys, and Ctrl/Alt chords, and every one of those is a key
+ * the app would otherwise claim. The editable guard is not enough on its own —
+ * it lets modified bindings through, and it only matches a terminal at all by
+ * way of xterm's hidden textarea, so focus resting on the session wrapper
+ * leaks the keystroke to the global registry.
+ */
+export function isTerminalKeyboardTarget(target: EventTarget | null): boolean {
+  return closestMatch(target, TERMINAL_SELECTOR);
+}
+
+function closestMatch(target: EventTarget | null, selector: string): boolean {
   if (!(target instanceof Node)) {
     return false;
   }
 
   const element = target instanceof Element ? target : target.parentElement;
 
-  return element?.closest(EDITABLE_SELECTOR) !== null;
+  return element?.closest(selector) != null;
 }

--- a/frontend/src/lib/utils/keyboardShortcuts.ts
+++ b/frontend/src/lib/utils/keyboardShortcuts.ts
@@ -1,10 +1,16 @@
 const EDITABLE_SELECTOR = "input, textarea, select, [contenteditable='true']";
 
-// A live terminal, by any of the wrappers a keydown can land on: xterm's own
-// root and hidden helper textarea, the pane container, and the session wrapper
-// (which is what holds focus when a pane is focused without clicking into the
-// grid itself).
-const TERMINAL_SELECTOR = ".terminal-container, .xterm, [data-session-host]";
+// Subtrees that hold nothing but a terminal, so anything inside one is the
+// terminal's: xterm's root and hidden helper textarea, the pane container, and
+// the pooled session wrapper (whose only child is the terminal pane).
+const TERMINAL_SUBTREE_SELECTOR = ".terminal-container, .xterm, [data-session-host]";
+
+// The unpromoted workspace's Focus Terminal path parks focus on this wrapper
+// itself. It is NOT a terminal-only subtree — the workspace sidebar, dock
+// header, launcher, and dialogs all live under it — so it counts only when it
+// is the event target. Matching it as an ancestor would hand the terminal every
+// shortcut typed into the workspace's own controls.
+const TERMINAL_FOCUS_HOLDER_SELECTOR = ".workspace-host-wrapper";
 
 export function shouldIgnoreGlobalShortcutTarget(target: EventTarget | null): boolean {
   return closestMatch(target, EDITABLE_SELECTOR);
@@ -17,19 +23,26 @@ export function shouldIgnoreGlobalShortcutTarget(target: EventTarget | null): bo
  * Escape, function keys, and Ctrl/Alt chords, and every one of those is a key
  * the app would otherwise claim. The editable guard is not enough on its own —
  * it lets modified bindings through, and it only matches a terminal at all by
- * way of xterm's hidden textarea, so focus resting on the session wrapper
- * leaks the keystroke to the global registry.
+ * way of xterm's hidden textarea, so focus resting on either wrapper leaks the
+ * keystroke to the global registry.
  */
 export function isTerminalKeyboardTarget(target: EventTarget | null): boolean {
-  return closestMatch(target, TERMINAL_SELECTOR);
-}
-
-function closestMatch(target: EventTarget | null, selector: string): boolean {
-  if (!(target instanceof Node)) {
+  const element = elementFor(target);
+  if (element === null) {
     return false;
   }
 
-  const element = target instanceof Element ? target : target.parentElement;
+  return element.closest(TERMINAL_SUBTREE_SELECTOR) != null || element.matches(TERMINAL_FOCUS_HOLDER_SELECTOR);
+}
 
-  return element?.closest(selector) != null;
+function closestMatch(target: EventTarget | null, selector: string): boolean {
+  return elementFor(target)?.closest(selector) != null;
+}
+
+function elementFor(target: EventTarget | null): Element | null {
+  if (!(target instanceof Node)) {
+    return null;
+  }
+
+  return target instanceof Element ? target : target.parentElement;
 }

--- a/frontend/tests/e2e-full/00-inline-workspace-continuity.spec.ts
+++ b/frontend/tests/e2e-full/00-inline-workspace-continuity.spec.ts
@@ -237,6 +237,59 @@ test.describe("inline workspace pane continuity", () => {
     });
   });
 
+  test("a dock resize grows both the pooled terminal and its PTY rows", async ({ page }) => {
+    test.skip(
+      !hasCommand("git") || !hasCommand("tmux", ["-V"]),
+      "git and tmux are required for the real workspace flow",
+    );
+    await page.setViewportSize({ width: 1440, height: 900 });
+
+    let isolatedServer: IsolatedE2EServer | null = null;
+    let api: APIRequestContext | null = null;
+    try {
+      isolatedServer = await startIsolatedWorkspaceE2EServer();
+      api = await playwrightRequest.newContext({ baseURL: isolatedServer.info.base_url });
+      const workspace = await createIssueWorkspace(api, 10);
+      for (let index = 0; index < 2; index += 1) {
+        const launch = await api.post(`/api/v1/workspaces/${workspace.id}/runtime/sessions`, {
+          data: { target_key: "plain_shell", display_region: "terminal" },
+        });
+        expect(launch.status(), await launch.text()).toBe(200);
+      }
+
+      await page.goto(`${isolatedServer.info.base_url}/issues/github/acme/widgets/10`);
+      const terminal = await openTerminalPanel(page);
+      const panel = page.locator(".terminal-panel.open");
+      const handle = panel.getByRole("separator", { name: "Resize terminal panel" });
+
+      const beforeHeight = await terminal.evaluate((element) => element.getBoundingClientRect().height);
+      const beforePty = await readPtyGeometry(page, terminal, workspace.worktree_path, "dock-resize-before");
+
+      await handle.press("ArrowUp");
+      await handle.press("ArrowUp");
+
+      await expect
+        .poll(() => terminal.evaluate((element) => element.getBoundingClientRect().height))
+        .toBeGreaterThan(beforeHeight + 20);
+      const afterGeometry = await terminal.evaluate((element) => {
+        const leafBody = element.closest(".terminal-leaf-body");
+        if (!(leafBody instanceof HTMLElement)) return null;
+        return {
+          leafHeight: leafBody.getBoundingClientRect().height,
+          terminalHeight: element.getBoundingClientRect().height,
+        };
+      });
+      expect(afterGeometry).not.toBeNull();
+      expect(Math.abs(afterGeometry!.leafHeight - afterGeometry!.terminalHeight)).toBeLessThan(2);
+
+      const afterPty = await readPtyGeometry(page, terminal, workspace.worktree_path, "dock-resize-after");
+      expect(afterPty.rows).toBeGreaterThan(beforePty.rows);
+    } finally {
+      await api?.dispose();
+      await isolatedServer?.stop();
+    }
+  });
+
   test("maximizing an inline workspace keeps the app frame fixed and its controls reachable", async ({ page }) => {
     test.skip(
       !hasCommand("git") || !hasCommand("tmux", ["-V"]),

--- a/frontend/tests/e2e-full/00-inline-workspace-continuity.spec.ts
+++ b/frontend/tests/e2e-full/00-inline-workspace-continuity.spec.ts
@@ -38,9 +38,11 @@ type WorkspaceStatusResponse = {
   error_message?: string | null;
 };
 
-type TerminalGeometryFrame = {
-  cols: number;
-  rows: number;
+type TerminalControlFrame = {
+  active: boolean | undefined;
+  cols: number | undefined;
+  rows: number | undefined;
+  type: "refresh" | "resize" | "resize_active";
 };
 
 const lockedWorkspaceTestTimeoutMs = 120_000;
@@ -57,19 +59,25 @@ function hasCommand(command: string, args: string[] = ["--version"]): boolean {
   }
 }
 
-function observeTerminalRefreshFrames(page: Page): TerminalGeometryFrame[] {
-  const frames: TerminalGeometryFrame[] = [];
+function observeTerminalControlFrames(page: Page): TerminalControlFrame[] {
+  const frames: TerminalControlFrame[] = [];
   page.on("websocket", (socket) => {
     socket.on("framesent", ({ payload }) => {
       if (typeof payload !== "string") return;
       try {
         const message = JSON.parse(payload) as {
           type?: string;
+          active?: boolean;
           cols?: number;
           rows?: number;
         };
-        if (message.type !== "refresh" || message.cols === undefined || message.rows === undefined) return;
-        frames.push({ cols: message.cols, rows: message.rows });
+        if (message.type !== "refresh" && message.type !== "resize" && message.type !== "resize_active") return;
+        frames.push({
+          active: message.active,
+          cols: message.cols,
+          rows: message.rows,
+          type: message.type,
+        });
       } catch {
         // Terminal input uses binary frames; ignore non-control payloads.
       }
@@ -237,7 +245,7 @@ test.describe("inline workspace pane continuity", () => {
     });
   });
 
-  test("a dock resize grows both the pooled terminal and its PTY rows", async ({ page }) => {
+  test("a dock resize grows both split terminals and their PTY rows", async ({ page }) => {
     test.skip(
       !hasCommand("git") || !hasCommand("tmux", ["-V"]),
       "git and tmux are required for the real workspace flow",
@@ -258,32 +266,109 @@ test.describe("inline workspace pane continuity", () => {
       }
 
       await page.goto(`${isolatedServer.info.base_url}/issues/github/acme/widgets/10`);
-      const terminal = await openTerminalPanel(page);
+      await openTerminalPanel(page);
       const panel = page.locator(".terminal-panel.open");
       const handle = panel.getByRole("separator", { name: "Resize terminal panel" });
+      await panel.getByRole("button", { name: "Split terminal right" }).click();
+      const terminals = panel.locator(".terminal-container");
+      await expect(terminals).toHaveCount(2);
 
-      const beforeHeight = await terminal.evaluate((element) => element.getBoundingClientRect().height);
-      const beforePty = await readPtyGeometry(page, terminal, workspace.worktree_path, "dock-resize-before");
+      const beforeHeights = await terminals.evaluateAll((elements) =>
+        elements.map((element) => element.getBoundingClientRect().height),
+      );
+      const beforePtys: Array<{ rows: number; cols: number }> = [];
+      for (const index of [0, 1]) {
+        beforePtys.push(
+          await readPtyGeometry(page, terminals.nth(index), workspace.worktree_path, `dock-resize-before-${index}`),
+        );
+      }
 
       await handle.press("ArrowUp");
       await handle.press("ArrowUp");
 
+      for (const index of [0, 1]) {
+        await expect
+          .poll(() => terminals.nth(index).evaluate((element) => element.getBoundingClientRect().height))
+          .toBeGreaterThan(beforeHeights[index]! + 20);
+        const afterGeometry = await terminals.nth(index).evaluate((element) => {
+          const leafBody = element.closest(".terminal-leaf-body");
+          if (!(leafBody instanceof HTMLElement)) return null;
+          return {
+            leafHeight: leafBody.getBoundingClientRect().height,
+            terminalHeight: element.getBoundingClientRect().height,
+          };
+        });
+        expect(afterGeometry).not.toBeNull();
+        expect(Math.abs(afterGeometry!.leafHeight - afterGeometry!.terminalHeight)).toBeLessThan(2);
+
+        const afterPty = await readPtyGeometry(
+          page,
+          terminals.nth(index),
+          workspace.worktree_path,
+          `dock-resize-after-${index}`,
+        );
+        expect(afterPty.rows).toBeGreaterThan(beforePtys[index]!.rows);
+      }
+    } finally {
+      await api?.dispose();
+      await isolatedServer?.stop();
+    }
+  });
+
+  test("a hidden workflow terminal revokes authority and sends no geometry frames", async ({ page }) => {
+    test.skip(
+      !hasCommand("git") || !hasCommand("tmux", ["-V"]),
+      "git and tmux are required for the real workspace flow",
+    );
+    await page.setViewportSize({ width: 1440, height: 900 });
+
+    let isolatedServer: IsolatedE2EServer | null = null;
+    let api: APIRequestContext | null = null;
+    try {
+      const controlFrames = observeTerminalControlFrames(page);
+      isolatedServer = await startIsolatedWorkspaceE2EServer();
+      api = await playwrightRequest.newContext({ baseURL: isolatedServer.info.base_url });
+      const workspace = await createIssueWorkspace(api, 10);
+
+      await page.goto(`${isolatedServer.info.base_url}/terminal/${workspace.id}`);
+      const terminalPanel = page.getByRole("region", { name: "Terminal panel" });
+      await terminalPanel.getByRole("button", { name: "New terminal" }).click();
+      const moveToWorkflow = terminalPanel.getByRole("button", { name: "Move terminal panel to workflow" });
+      await expect(moveToWorkflow).toBeVisible();
+      await moveToWorkflow.click();
+
+      const workflow = page.getByRole("region", { name: "Workflow panes" });
+      const homeTab = workflow.getByRole("tab", { name: "Home" });
+      const terminalTab = workflow.getByRole("tab", { name: "Terminal" });
+      await expect(terminalTab).toHaveAttribute("aria-selected", "true");
+      const revocationsBeforeHide = controlFrames.filter(
+        (frame) => frame.type === "resize_active" && frame.active === false,
+      ).length;
+
+      await homeTab.click();
+      await expect(homeTab).toHaveAttribute("aria-selected", "true");
       await expect
-        .poll(() => terminal.evaluate((element) => element.getBoundingClientRect().height))
-        .toBeGreaterThan(beforeHeight + 20);
-      const afterGeometry = await terminal.evaluate((element) => {
-        const leafBody = element.closest(".terminal-leaf-body");
-        if (!(leafBody instanceof HTMLElement)) return null;
-        return {
-          leafHeight: leafBody.getBoundingClientRect().height,
-          terminalHeight: element.getBoundingClientRect().height,
-        };
-      });
-      expect(afterGeometry).not.toBeNull();
-      expect(Math.abs(afterGeometry!.leafHeight - afterGeometry!.terminalHeight)).toBeLessThan(2);
+        .poll(() => controlFrames.filter((frame) => frame.type === "resize_active" && frame.active === false).length)
+        .toBe(revocationsBeforeHide + 1);
+      const geometryFramesAfterHide = controlFrames.filter(
+        (frame) => frame.type === "resize" || frame.type === "refresh",
+      ).length;
+      const widthBeforeResize = await workflow.evaluate((element) => element.getBoundingClientRect().width);
 
-      const afterPty = await readPtyGeometry(page, terminal, workspace.worktree_path, "dock-resize-after");
-      expect(afterPty.rows).toBeGreaterThan(beforePty.rows);
+      await page.setViewportSize({ width: 1200, height: 760 });
+      await expect
+        .poll(() => workflow.evaluate((element) => element.getBoundingClientRect().width))
+        .toBeLessThan(widthBeforeResize - 100);
+      await page.evaluate(
+        () =>
+          new Promise<void>((resolve) => {
+            requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+          }),
+      );
+
+      expect(controlFrames.filter((frame) => frame.type === "resize" || frame.type === "refresh")).toHaveLength(
+        geometryFramesAfterHide,
+      );
     } finally {
       await api?.dispose();
       await isolatedServer?.stop();
@@ -989,7 +1074,8 @@ test.describe("inline workspace pane continuity", () => {
     let isolatedServer: IsolatedE2EServer | null = null;
     let api: APIRequestContext | null = null;
     try {
-      const refreshFrames = observeTerminalRefreshFrames(page);
+      const controlFrames = observeTerminalControlFrames(page);
+      const refreshFrames = () => controlFrames.filter((frame) => frame.type === "refresh");
       isolatedServer = await startIsolatedWorkspaceE2EServer();
       api = await playwrightRequest.newContext({ baseURL: isolatedServer.info.base_url });
 
@@ -1023,14 +1109,14 @@ test.describe("inline workspace pane continuity", () => {
         name: "Reset terminal font size",
       });
       await expect(resetZoom).toHaveText("12px");
-      const refreshCountBeforeZoom = refreshFrames.length;
+      const refreshCountBeforeZoom = refreshFrames().length;
       for (let fontSize = 13; fontSize <= ZOOMED_TERMINAL_FONT_SIZE; fontSize += 1) {
         await page.getByRole("button", { name: "Increase terminal font size" }).click();
         await expect(resetZoom).toHaveText(`${fontSize}px`);
       }
       await expectPersistedTerminalFontSize(api, ZOOMED_TERMINAL_FONT_SIZE);
-      await expect.poll(() => refreshFrames.length).toBeGreaterThan(refreshCountBeforeZoom);
-      await expect.poll(() => refreshFrames.at(-1)?.cols).toBeLessThan(beforeZoom.cols);
+      await expect.poll(() => refreshFrames().length).toBeGreaterThan(refreshCountBeforeZoom);
+      await expect.poll(() => refreshFrames().at(-1)?.cols).toBeLessThan(beforeZoom.cols);
       await waitForPtyColumnsBelow(
         page,
         tabContainer,

--- a/frontend/tests/e2e-full/terminal-focus-pane-move.spec.ts
+++ b/frontend/tests/e2e-full/terminal-focus-pane-move.spec.ts
@@ -257,7 +257,7 @@ test("terminal keeps keyboard focus across a pane move without a click", async (
     // The real pane command, entirely by keyboard. Palette teardown restores
     // the terminal focus it saved before the handler splits this tab into a
     // new leaf, and the split reparents the terminal through the parking node.
-    await page.keyboard.press("Meta+k");
+    await page.keyboard.press("Meta+Shift+k");
     const palette = page.getByRole("dialog", { name: "Command palette" });
     await expect(palette).toBeVisible();
     await page.getByRole("textbox", { name: "Search command palette" }).fill("Split pane right");


### PR DESCRIPTION
- Keep Escape, function keys, and modified shortcuts inside focused terminals instead of triggering app-level commands.
- Resize every painted terminal from its own region, including unfocused split leaves and vertically resized dock panes.
- Keep parked terminals from overriding the size of the visible tmux pane.

[Terminal resize video](https://github.com/user-attachments/assets/627c1607-e994-47b2-85b3-a6ad7b969266)