### PR TITLE
Remove the solo workspace drag marker

### DIFF
--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -362,10 +362,10 @@ Keyboard handlers must have one clear owner for each key press.
 - A leaf holding ONLY the workspace pane renders no outer tab strip at all
   (`TabbedPanelTree`'s `soloChromeTabKeys`, wired in `DetailPaneLayout`): the pane
   draws its own strip inside, and an outer row saying "Workspace" named the same
-  thing twice. Its strip contents float top-right of the leaf instead - a grip (the
-  tab's replacement as HTML5 drag source; without it a strip-less pane could never
-  be moved), the hide X, caller extras, and Maximize. A second tab in the leaf, or a
-  flattened surface, brings the strip back. The floating cluster must stack ABOVE
+  thing twice. Its remaining actions float top-right of the leaf instead: the hide
+  X, caller extras, and Maximize. A solo-chrome pane has no pointer drag source;
+  pane commands remain available, and a second tab or flattened surface brings the
+  draggable strip back. The floating cluster must stack ABOVE
   xterm's internal layers (its overlay scrollbar slider is z-index 11 and hugs the
   same right edge; nothing between the leaf and xterm's internals is a stacking
   context) - below that, the scrollbar silently swallows clicks on the rightmost

--- a/docs/superpowers/plans/2026-07-29-remove-solo-workspace-drag-grip.md
+++ b/docs/superpowers/plans/2026-07-29-remove-solo-workspace-drag-grip.md
@@ -1,0 +1,124 @@
+# Remove the Solo Workspace Drag Grip Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan directly in the current agent, task-by-task. Never use subagent-driven development. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the detached drag marker from the strip-less solo Workspace pane while preserving its other controls and normal multi-tab dragging.
+
+**Approved spec/design:** `docs/superpowers/specs/2026-07-29-remove-solo-workspace-drag-grip-design.md`
+
+**Architecture:** Keep `TabbedPanelTree`'s existing solo-chrome layout and pane action cluster, but stop creating a dedicated drag source when the outer tab strip is suppressed. Ordinary tab buttons retain the existing `startTabDrag` wiring whenever the strip is rendered.
+
+**Tech Stack:** Svelte 5, TypeScript, Vitest, Testing Library, Vite+
+
+## Global Constraints
+
+- Do not replace the grip with an invisible drag target or a draggable toolbar surface.
+- Preserve the hide, caller-provided leaf extras, and maximize controls.
+- Preserve ordinary draggable tab buttons in multi-tab leaves.
+- Use Vite+ commands, never npm.
+
+---
+
+### Task 1: Remove the Solo Workspace Drag Source
+
+**Files:**
+- Modify: `packages/ui/src/components/shared/DetailPaneLayout.test.ts`
+- Modify: `packages/ui/src/components/shared/TabbedPanelTree.svelte`
+
+**Interfaces:**
+- Consumes: `soloChromeTabKeys`, `tabActions`, and `leafActions` props already exposed by `TabbedPanelTree.svelte`.
+- Produces: A solo action cluster containing only `tabActions` and `leafActions`; ordinary rendered tabs continue to use `draggable={tabDragEnabled()}` and `startTabDrag(event, tab)`.
+
+- [x] **Step 1: Write the failing regression assertions**
+
+In the existing `drops the strip for a leaf that holds only the workspace, keeping its controls` test, replace the positive `Move Workspace` assertion with an absence assertion and keep the neighboring control assertions:
+
+```ts
+expect(within(cluster).queryByRole("button", { name: "Move Workspace" })).toBeNull();
+expect(within(cluster).getByTestId("pane-hide-workspace")).toBeTruthy();
+expect(within(cluster).getByTestId("pane-toggle-zoom")).toBeTruthy();
+expect(within(cluster).getByTestId("leaf-extra-leaf-workspace")).toBeTruthy();
+```
+
+In the existing `brings the strip back when a second tab lands in the workspace leaf` test, assert that the returned Workspace tab remains draggable:
+
+```ts
+const workspaceTab = screen.getByRole("tab", { name: "Workspace" });
+expect(workspaceTab.getAttribute("draggable")).toBe("true");
+```
+
+- [x] **Step 2: Run the focused test to verify the new absence assertion fails**
+
+Run:
+
+```bash
+cd frontend
+../node_modules/.bin/vp test run --project unit ../packages/ui/src/components/shared/DetailPaneLayout.test.ts
+```
+
+Expected: FAIL because the current solo action cluster still contains the accessible `Move Workspace` button. The existing multi-tab draggable assertion should already pass.
+
+- [x] **Step 3: Remove only the solo grip implementation**
+
+In `TabbedPanelTree.svelte`:
+
+- delete the `GripVerticalIcon` import;
+- remove the `tabbed-panel-solo-grip` button from `tabbed-panel-solo-actions`;
+- update the nearby comment so it describes the remaining actions without claiming a replacement drag source; and
+- delete the now-unused `.tabbed-panel-solo-grip` style.
+
+The solo cluster should reduce to:
+
+```svelte
+<div class="tabbed-panel-solo-actions" data-testid="tabbed-panel-solo-actions">
+  {@render tabActions?.(soloTab)}
+  {@render leafActions?.(node)}
+</div>
+```
+
+Do not change the ordinary tab button's existing drag attributes or handlers.
+
+- [x] **Step 4: Validate the edited Svelte component**
+
+Run:
+
+```bash
+./node_modules/.bin/vp exec -- svelte-mcp svelte-autofixer packages/ui/src/components/shared/TabbedPanelTree.svelte
+```
+
+Expected: no Svelte errors or actionable warnings caused by the edit.
+
+- [x] **Step 5: Run the focused component tests**
+
+Run:
+
+```bash
+cd frontend
+../node_modules/.bin/vp test run --project unit \
+  ../packages/ui/src/components/shared/DetailPaneLayout.test.ts \
+  ../packages/ui/src/components/shared/TabbedPanelTree.test.ts
+```
+
+Expected: PASS.
+
+- [x] **Step 6: Run the full frontend Vitest suite**
+
+Run:
+
+```bash
+cd frontend
+../node_modules/.bin/vp test
+```
+
+Expected: PASS.
+
+- [x] **Step 7: Commit the implementation**
+
+After running the repository `context-sync --commit` and mandatory commit skill workflows, stage only the plan, component, and test:
+
+```bash
+git add docs/superpowers/plans/2026-07-29-remove-solo-workspace-drag-grip.md \
+  packages/ui/src/components/shared/TabbedPanelTree.svelte \
+  packages/ui/src/components/shared/DetailPaneLayout.test.ts
+git commit -m "fix: remove the solo workspace drag marker"
+```

--- a/docs/superpowers/specs/2026-07-29-remove-solo-workspace-drag-grip-design.md
+++ b/docs/superpowers/specs/2026-07-29-remove-solo-workspace-drag-grip-design.md
@@ -1,0 +1,36 @@
+# Remove the Solo Workspace Drag Grip
+
+## Problem
+
+When the Workspace pane is alone in a leaf, middleman suppresses its redundant
+outer tab strip and floats the remaining pane actions over the Workspace header.
+The floating cluster currently begins with a six-dot drag grip. It looks detached
+from the Workspace controls and adds an unfamiliar affordance to an otherwise
+compact action row.
+
+## Design
+
+Remove the drag grip from the floating action cluster. Do not replace it with an
+invisible drag target or make the surrounding toolbar draggable, because either
+choice would create an undiscoverable or accidental interaction around adjacent
+buttons.
+
+This removes pointer-driven movement of the whole Workspace pane only while it is
+the sole tab in a strip-less leaf. Pane commands remain available, and the normal
+tab drag source returns whenever Workspace shares a leaf with another pane and the
+outer tab strip is visible.
+
+The hide, Workspace-specific, delete, settings, and maximize controls keep their
+current order and behavior.
+
+## Verification
+
+Update the focused component test for solo Workspace chrome to assert that:
+
+- the redundant outer tab strip remains absent;
+- no `Move Workspace` control is rendered;
+- the remaining hide, leaf-extra, and maximize controls remain present; and
+- multi-tab leaves still render their ordinary draggable tab strip.
+
+Run the Svelte autofixer on the edited component, the focused component tests, and
+the full frontend Vitest suite.

--- a/frontend/tests/e2e-full/00-inline-workspace-continuity.spec.ts
+++ b/frontend/tests/e2e-full/00-inline-workspace-continuity.spec.ts
@@ -1030,12 +1030,12 @@ test.describe("inline workspace pane continuity", () => {
       });
       const focusTerminal = page.getByRole("button", { name: "Focus Terminal" });
 
-      // 1. Tabbed behind a sibling: drag the workspace into the conversation's
-      //    leaf, then switch away from it. Neither hidden nor maximized. Alone in
-      //    its leaf the pane has no tab; the floating grip is its drag source.
-      await workspaceLeaf
-        .getByRole("button", { name: /^Move / })
-        .dragTo(conversationLeaf.getByRole("tab", { name: "Conversation" }));
+      // 1. Tabbed behind a sibling: move the ordinary Conversation tab into the
+      //    strip-less workspace leaf, then switch away from the workspace. This
+      //    leaves it neither hidden nor maximized without restoring a solo grip.
+      await conversationLeaf
+        .getByRole("tab", { name: "Conversation" })
+        .dragTo(workspaceLeaf.getByRole("group", { name: "Detail pane drop targets" }));
       await page.getByRole("tab", { name: "Conversation" }).click();
       await expect(page.locator(".detail-pane-workspace-slot")).toHaveCount(0);
 

--- a/frontend/tests/e2e-full/00-workspace-launcher.spec.ts
+++ b/frontend/tests/e2e-full/00-workspace-launcher.spec.ts
@@ -195,14 +195,12 @@ test.describe("embedded workspace launcher", () => {
       await page.keyboard.press("Escape");
 
       // 3. Tabbed behind a sibling, which leaves it neither hidden nor maximized.
-      //    Alone in its leaf the workspace pane has no tab to drag - the floating
-      //    grip is its drag source - and dropping on the conversation strip files
-      //    it as a tab behind Conversation.
-      await page
-        .locator(".tabbed-panel-leaf")
-        .filter({ has: slot })
-        .getByRole("button", { name: "Move Workspace" })
-        .dragTo(conversationLeaf.getByRole("tab", { name: "Conversation" }));
+      //    The strip-less workspace pane deliberately has no drag target, so move
+      //    the ordinary Conversation tab into its leaf and then select Conversation.
+      const workspaceLeaf = page.locator(".tabbed-panel-leaf").filter({ has: slot });
+      await conversationLeaf
+        .getByRole("tab", { name: "Conversation" })
+        .dragTo(workspaceLeaf.getByRole("group", { name: "Detail pane drop targets" }));
       await page.getByRole("tab", { name: "Conversation" }).click();
       await expect(slot).toHaveCount(0);
       await runPaletteCommand(page, "Launch a workspace session");
@@ -244,10 +242,6 @@ test.describe("embedded workspace launcher", () => {
       const terminal = page.locator(".detail-pane-workspace-slot .terminal-container");
       await expect(terminal).toBeVisible();
       await typeMarkerCommand(page, terminal, workspace.worktree_path, "sole-session-marker");
-      // Alone in its leaf the pane draws no tab; the floating grip carries the
-      // session's name instead, so it is where a rename has to show up.
-      await expect(page.getByRole("button", { name: "Move Shell", exact: true })).toBeVisible();
-
       await page.getByRole("button", { name: "Rename Shell", exact: true }).click();
       const rename = page.getByRole("dialog", { name: "Rename tab" });
       await expect(rename).toBeVisible();
@@ -255,19 +249,23 @@ test.describe("embedded workspace launcher", () => {
       await rename.getByRole("button", { name: "Save" }).click();
       await expect(rename).toBeHidden();
 
-      // The pane's grip is named after the session, so a rename has to reach it.
-      await expect(page.getByRole("button", { name: "Move Reviewer shell", exact: true })).toBeVisible();
+      // The remaining session controls take the runtime's new label.
+      const closeSession = page.getByRole("button", { name: "Close Reviewer shell", exact: true });
+      await expect(closeSession).toBeVisible();
       await typeMarkerCommand(page, terminal, workspace.worktree_path, "sole-session-marker-renamed");
 
-      await page.getByRole("button", { name: "Close Reviewer shell", exact: true }).click();
+      await closeSession.click();
       const confirm = page.getByRole("dialog", { name: /Stop Reviewer shell/ });
       await expect(confirm).toBeVisible();
       await confirm.getByRole("button", { name: "Stop session" }).click();
 
-      // Nothing running: the pane goes back to offering a launch rather than a
-      // terminal, which is the only state left that a workspace can be in.
-      await expect(page.getByRole("button", { name: "Move Workspace" })).toBeVisible();
+      // Nothing running: the pane keeps its ordinary controls, whose Launch action
+      // is the way back after the one-time automatic launcher has already appeared.
       await expect(page.locator(".detail-pane-workspace-slot .terminal-container")).toHaveCount(0);
+      await page.getByRole("button", { name: "Workspace controls" }).first().click();
+      await expect(
+        page.getByRole("dialog", { name: "Workspace controls" }).getByRole("button", { name: "Launch" }),
+      ).toBeVisible();
     } finally {
       await api?.dispose();
       await isolatedServer?.stop();

--- a/frontend/tests/e2e-full/terminal-focus-pane-move.spec.ts
+++ b/frontend/tests/e2e-full/terminal-focus-pane-move.spec.ts
@@ -205,7 +205,7 @@ test("terminal keeps keyboard focus across a pane move without a click", async (
     await movedTerminal.evaluate((element) => {
       element
         .closest(".tabbed-panel-leaf")
-        ?.querySelector<HTMLElement>(".tabbed-panel-solo-grip, .tabbed-panel-tab-button")
+        ?.querySelector<HTMLElement>(".tabbed-panel-tab-button")
         ?.setAttribute("data-focus-drag-source", "true");
     });
     await page

--- a/packages/ui/src/components/shared/DetailPaneLayout.test.ts
+++ b/packages/ui/src/components/shared/DetailPaneLayout.test.ts
@@ -317,8 +317,8 @@ describe("detail pane layout", () => {
   it("drops the strip for a leaf that holds only the workspace, keeping its controls", () => {
     // The workspace pane draws its own strip inside - one tab per session, plus the
     // dock - so a leaf holding it alone stacked two rows to name one thing, and the
-    // outer one said only "Workspace". The controls move onto the pane instead, with
-    // a grip standing in for the tab as the drag source.
+    // outer one said only "Workspace". The remaining controls move onto the pane
+    // instead without inventing a separate drag affordance.
     render(DetailPaneLayoutTestHarness, { layout: store(splitTree()), withLeafExtras: true });
 
     const workspaceBody = screen.getByTestId("pane-workspace").closest(".tabbed-panel-body")!;
@@ -329,7 +329,7 @@ describe("detail pane layout", () => {
     const cluster = screen.getByTestId("tabbed-panel-solo-actions");
     expect(workspaceBody.contains(cluster)).toBe(false);
     expect(workspaceBody.closest(".tabbed-panel-leaf")?.contains(cluster)).toBe(true);
-    expect(within(cluster).getByRole("button", { name: "Move Workspace" })).toBeTruthy();
+    expect(within(cluster).queryByRole("button", { name: "Move Workspace" })).toBeNull();
     expect(within(cluster).getByTestId("pane-hide-workspace")).toBeTruthy();
     expect(within(cluster).getByTestId("pane-toggle-zoom")).toBeTruthy();
     expect(within(cluster).getByTestId("leaf-extra-leaf-workspace")).toBeTruthy();
@@ -348,7 +348,8 @@ describe("detail pane layout", () => {
 
     flushSync(() => layout.appendTabToLeaf("files", "leaf-workspace"));
 
-    expect(screen.getByRole("tab", { name: "Workspace" })).toBeTruthy();
+    const workspaceTab = screen.getByRole("tab", { name: "Workspace" });
+    expect(workspaceTab.getAttribute("draggable")).toBe("true");
     expect(screen.queryByTestId("tabbed-panel-solo-actions")).toBeNull();
   });
 

--- a/packages/ui/src/components/shared/TabbedPanelTree.svelte
+++ b/packages/ui/src/components/shared/TabbedPanelTree.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import GripVerticalIcon from "@lucide/svelte/icons/grip-vertical";
   import { SplitResizeHandle, StatusDot, type SplitResizeEvent } from "@kenn-io/kit-ui";
   import { untrack, type Snippet } from "svelte";
   import Self from "./TabbedPanelTree.svelte";
@@ -654,23 +653,10 @@
     {#if soloChrome}
       {@const soloTab = tabForKey(node.tabs[0]!)}
       {#if soloTab}
-        <!-- The strip's contents with the strip taken away: they float at the top
-             right of the body, which is where the pane's own strip ends, so the two
-             read as one bar. The grip is the drag source the tab button used to be -
-             without it a pane with no strip could never be moved. -->
+        <!-- The strip's remaining actions with the strip taken away: they float at
+             the top right of the body, which is where the pane's own strip ends, so
+             the two read as one bar. -->
         <div class="tabbed-panel-solo-actions" data-testid="tabbed-panel-solo-actions">
-          <button
-            class="tabbed-panel-tab-tool tabbed-panel-solo-grip"
-            type="button"
-            draggable={tabDragEnabled()}
-            disabled={disabled}
-            title={`Move ${soloTab.label}`}
-            aria-label={`Move ${soloTab.label}`}
-            ondragstart={(event) => startTabDrag(event, soloTab)}
-            ondragend={finishTabDrag}
-          >
-            <GripVerticalIcon size="12" strokeWidth="2.2" aria-hidden="true" />
-          </button>
           {@render tabActions?.(soloTab)}
           {@render leafActions?.(node)}
         </div>
@@ -939,10 +925,6 @@
   .tabbed-panel-solo-actions :global(.tabbed-panel-tab-tool:disabled) {
     cursor: default;
     opacity: 0.3;
-  }
-
-  .tabbed-panel-solo-grip {
-    cursor: grab;
   }
 
   .tabbed-panel-tabs {


### PR DESCRIPTION
- Remove the detached drag marker from solo Workspace panes.
- Keep pane commands and ordinary tab dragging available when a tab strip is present.

<sup>generated by a clanker</sup>