### PR TITLE
Launch sessions from the workspace header

### DIFF
--- a/docs/superpowers/plans/2026-07-29-workspace-header-launch-session.md
+++ b/docs/superpowers/plans/2026-07-29-workspace-header-launch-session.md
@@ -1,0 +1,178 @@
+# Workspace Header Launch Session Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan directly in the current agent, task-by-task. Never use subagent-driven development. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a one-click Launch session shortcut beside Delete workspace in an embedded workspace pane header.
+
+**Approved spec/design:** `docs/superpowers/specs/2026-07-29-workspace-header-launch-session-design.md`
+
+**Architecture:** Reuse the existing `workspaceStripActions` snippet that publishes workspace-level actions into `WorkspacePaneControls`. Add a Play icon button that calls the existing `openLauncher` function, while retaining the popover action for promoted-session leaves that suppress strip actions.
+
+**Tech Stack:** Svelte 5, TypeScript, Lucide Svelte icons, kit-ui `IconButton`, Vitest with Testing Library, Playwright.
+
+## Global Constraints
+
+- The header shortcut is icon-only, appears immediately before Delete workspace, and has the accessible name and tooltip `Launch session`.
+- The shortcut is visible only under the same ready-workspace and strip-ownership conditions as Delete workspace.
+- The shortcut is disabled whenever other workspace actions are blocked.
+- Clicking the shortcut opens the existing `Launch a session` overlay; it does not launch a default target or add an API path.
+- Keep the existing Launch session action in the workspace controls popover for panes that omit strip actions.
+- Do not add dependencies or compatibility paths.
+
+---
+
+### Task 1: Add the workspace header launch shortcut
+
+**Files:**
+- Modify: `frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts`
+- Modify: `frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte`
+- Modify: `docs/superpowers/plans/2026-07-29-workspace-header-launch-session.md` (check off completed steps)
+
+**Interfaces:**
+- Consumes: `openLauncher(): void`, the existing `PlayIcon` import, `actionsBlocked`, and `workspaceStripActions()` in `WorkspaceTerminalView.svelte`.
+- Produces: A header `IconButton` with `ariaLabel="Launch session"`, `title="Launch session"`, and `onclick={openLauncher}` before the existing Delete workspace button.
+
+- [x] **Step 1: Write the failing component regression test**
+
+  In the existing embedded workspace controls test area of `WorkspaceTerminalView.test.ts`, add focused behavior tests. The production mutations they catch are removal of the direct strip action while the popover action remains available, omission of the `actionsBlocked` binding, and rendering the strip action for a non-ready workspace.
+
+  ```ts
+  it("opens the session launcher directly from the workspace pane header", async () => {
+    claimForPrs();
+
+    render(WorkspaceTerminalView, {
+      props: {
+        workspaceId: "ws-1",
+        paneSurface: "prs" as const,
+      },
+    });
+
+    await waitFor(() => expect(hostedWorkspaceControls()).not.toBeNull());
+    render(WorkspacePaneControls);
+
+    expect(screen.queryByRole("dialog", { name: "Workspace controls" })).toBeNull();
+    const launch = await screen.findByRole("button", { name: "Launch session" });
+    const deleteWorkspace = screen.getByRole("button", { name: /^Delete workspace / });
+    expect(launch.getAttribute("title")).toBe("Launch session");
+    expect(launch.compareDocumentPosition(deleteWorkspace) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
+
+    await fireEvent.click(launch);
+    expect(await screen.findByRole("dialog", { name: "Launch a session" })).toBeTruthy();
+  });
+  ```
+
+  Add a pending-delete test that keeps the current ready workspace rendered and verifies the live header shortcut becomes disabled while the delete request is unresolved:
+
+  ```ts
+  it("disables the header session launcher while workspace deletion is pending", async () => {
+    const deleteRequest = deferred<Response>();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((input: Request | URL | string, init?: RequestInit) => {
+        const method = init?.method ?? (input instanceof Request ? input.method : "GET");
+        const { pathname } = new URL(input instanceof Request ? input.url : String(input), "http://localhost");
+        if (method === "DELETE" && pathname.endsWith("/workspaces/ws-1")) return deleteRequest.promise;
+        if (pathname.endsWith("/workspaces/ws-1")) {
+          return Promise.resolve(Response.json(workspaceResponse));
+        }
+        if (pathname.endsWith("/api/v1/workspaces")) {
+          return Promise.resolve(Response.json({ workspaces: [workspaceResponse] }));
+        }
+        return Promise.resolve(Response.json({}));
+      }),
+    );
+    claimForPrs();
+
+    render(WorkspaceTerminalView, {
+      props: { workspaceId: "ws-1", paneSurface: "prs" as const },
+    });
+    await waitFor(() => expect(hostedWorkspaceControls()).not.toBeNull());
+    render(WorkspacePaneControls);
+    const launch = await screen.findByRole("button", { name: "Launch session" });
+    expect(launch.hasAttribute("disabled")).toBe(false);
+
+    await clickDeleteAndConfirm(screen.getByRole("button", { name: /^Delete workspace / }));
+    await waitFor(() => expect(launch.hasAttribute("disabled")).toBe(true));
+  });
+  ```
+
+  Rename the broken-workspace test to `leaves workspace strip actions off a broken workspace, whose error panel owns delete` and assert `Launch session` is absent too. Also mount `WorkspacePaneControls` in `stays away while a workspace is still being created` and assert the shortcut is absent there.
+
+- [x] **Step 2: Run the focused test and verify RED**
+
+  Run from `frontend/`:
+
+  ```bash
+  ../node_modules/.bin/vp test run --project unit WorkspaceTerminalView
+  ```
+
+  Expected: FAIL because no `Launch session` button is rendered until the workspace controls popover is opened.
+
+- [x] **Step 3: Add the minimal strip action**
+
+  In `workspaceStripActions()`, immediately before the existing danger-tone Delete workspace `IconButton`, add:
+
+  ```svelte
+  <IconButton
+    size="sm"
+    tone="neutral"
+    disabled={actionsBlocked}
+    ariaLabel="Launch session"
+    title="Launch session"
+    onclick={openLauncher}
+  >
+    <PlayIcon size="13" strokeWidth="2" aria-hidden="true" />
+  </IconButton>
+  ```
+
+  Update the adjacent comment so it describes both direct workspace actions and explains why Launch remains duplicated in the popover for panes that set `showStripActions={false}`.
+
+- [x] **Step 4: Run focused checks and verify GREEN**
+
+  Run from the repository root:
+
+  ```bash
+  vp exec -- svelte-mcp svelte-autofixer ./frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+  ```
+
+  Run from `frontend/`:
+
+  ```bash
+  ../node_modules/.bin/vp test run --project unit WorkspaceTerminalView
+  ```
+
+  Expected: Svelte analysis reports no actionable issue in the change and the WorkspaceTerminalView unit suite passes.
+
+- [x] **Step 5: Run the full affected frontend verification**
+
+  Run the full configured frontend unit suite from `frontend/`:
+
+  ```bash
+  ../node_modules/.bin/vp test run --project unit
+  ```
+
+  Then run the repository frontend check from the repository root:
+
+  ```bash
+  ./node_modules/.bin/vp run frontend-package-check
+  ```
+
+  Then run the affected Playwright suite from `frontend/`:
+
+  ```bash
+  ../node_modules/.bin/vp exec -- playwright test --config=playwright-e2e.config.ts tests/e2e-full/00-workspace-launcher.spec.ts --project=chromium
+  ```
+
+  Expected: all frontend tests and checks pass, and the Chromium workspace launcher suite passes.
+
+- [x] **Step 6: Review and commit the implementation**
+
+  Inspect `git diff`, confirm only the plan, component test, and component implementation changed, run the repository-local `context-sync` skill with `--commit`, then use the mandatory commit skill without amending or bypassing hooks:
+
+  ```bash
+  git add docs/superpowers/plans/2026-07-29-workspace-header-launch-session.md \
+    frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts \
+    frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+  git commit -m "feat: launch sessions from the workspace header" \
+    -m "Starting another workspace session currently requires opening the controls popover first. Keep the popover entry for promoted session panes while giving the workspace pane a direct shortcut beside Delete."
+  ```

--- a/docs/superpowers/specs/2026-07-29-workspace-header-launch-session-design.md
+++ b/docs/superpowers/specs/2026-07-29-workspace-header-launch-session-design.md
@@ -1,0 +1,24 @@
+# Workspace Header Launch Session Design
+
+## Goal
+
+Make launching another workspace session a one-click action from the workspace pane header, including when the terminal body or controls popover is closed.
+
+## Design
+
+Add a compact, icon-only Launch session action immediately before the existing Delete workspace action in the workspace pane header. Use the existing play icon, tooltip, and accessible name so the new shortcut matches the surrounding 24-pixel header controls without widening the action cluster.
+
+The existing Launch session action remains in the workspace controls popover. Promoted session panes intentionally omit the workspace-level header actions, so retaining the popover action preserves launch access from those panes while the workspace pane gains the requested shortcut.
+
+The shortcut uses the existing launcher-opening behavior. It does not launch a default target directly, change workspace or session identity, alter the controls popover, or add a new API path.
+
+## States and Errors
+
+- Show the header shortcut only when the workspace header already shows Delete workspace: the workspace is loaded, ready, and the pane owns workspace-level strip actions.
+- Disable the shortcut whenever other workspace actions are blocked.
+- Clicking it opens the existing Launch a session overlay. Existing launcher state and error handling remain authoritative.
+- Render Launch session before Delete workspace so the destructive action keeps its established position at the end of the workspace-specific action group.
+
+## Verification
+
+Add a component regression test that renders an embedded ready workspace, verifies the header exposes Launch session beside Delete workspace without opening the controls popover, and verifies clicking it opens the existing Launch a session dialog. Run the focused component test, the full frontend test suite, Svelte analysis, and the affected workspace launcher Playwright suite.

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -4382,16 +4382,25 @@
 {/snippet}
 
 <!-- Sits in the tab strip beside the controls trigger, not inside the popover.
-     Deleting the worktree is the action a maintainer reaches for most once a PR is
-     done, and behind a menu it costs a click to open, a target to find, and a second
-     click. It is the only strip action for that reason: everything else here is
-     either rare or lives with the thing it acts on. -->
+     Launching and deleting are the workspace actions a maintainer reaches for often
+     enough that opening a menu first is a click too many. Launch remains in the
+     popover as well because promoted session panes intentionally suppress these
+     workspace-level strip actions. -->
 {#snippet workspaceStripActions()}
-  <!-- Ready only. A workspace whose setup failed renders its own Delete beside the
+  <!-- Ready only. A workspace whose setup failed renders its own actions beside the
        Retry in the error panel, which is where the user is already looking, and one
-       still being created has nothing to delete yet - the strip action there would
-       be the second owner this snippet exists to avoid. -->
+       still being created cannot launch or be deleted yet. -->
   {#if workspaceLive && workspace?.status === "ready"}
+    <IconButton
+      size="sm"
+      tone="neutral"
+      disabled={actionsBlocked}
+      ariaLabel="Launch session"
+      title="Launch session"
+      onclick={openLauncher}
+    >
+      <PlayIcon size="13" strokeWidth="2" aria-hidden="true" />
+    </IconButton>
     <IconButton
       size="sm"
       tone="danger"

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -2845,12 +2845,64 @@ describe("WorkspaceTerminalView", () => {
     expect(controls.queryByRole("button", { name: "Delete" })).toBeNull();
   });
 
-  it("leaves the strip Delete off a broken workspace, whose error panel owns one", async () => {
-    // The strip action is the single owner only while the workspace is ready. A
-    // failed setup renders its own Delete beside the Retry the user is already
-    // looking at, so a second one in the strip would be two Deletes with their own
-    // disabled and pending states -- exactly what moving it out of the popover
-    // avoided.
+  it("opens the session launcher directly from the workspace pane header", async () => {
+    claimForPrs();
+
+    render(WorkspaceTerminalView, {
+      props: {
+        workspaceId: "ws-1",
+        paneSurface: "prs" as const,
+      },
+    });
+
+    await waitFor(() => expect(hostedWorkspaceControls()).not.toBeNull());
+    render(WorkspacePaneControls);
+
+    expect(screen.queryByRole("dialog", { name: "Workspace controls" })).toBeNull();
+    const launch = await screen.findByRole("button", { name: "Launch session" });
+    const deleteWorkspace = screen.getByRole("button", { name: /^Delete workspace / });
+    expect(launch.getAttribute("title")).toBe("Launch session");
+    expect(launch.compareDocumentPosition(deleteWorkspace) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
+
+    await fireEvent.click(launch);
+    expect(await screen.findByRole("dialog", { name: "Launch a session" })).toBeTruthy();
+  });
+
+  it("disables the header session launcher while workspace deletion is pending", async () => {
+    const deleteRequest = deferred<Response>();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((input: Request | URL | string, init?: RequestInit) => {
+        const method = init?.method ?? (input instanceof Request ? input.method : "GET");
+        const { pathname } = new URL(input instanceof Request ? input.url : String(input), "http://localhost");
+        if (method === "DELETE" && pathname.endsWith("/workspaces/ws-1")) return deleteRequest.promise;
+        if (pathname.endsWith("/workspaces/ws-1")) {
+          return Promise.resolve(Response.json(workspaceResponse));
+        }
+        if (pathname.endsWith("/api/v1/workspaces")) {
+          return Promise.resolve(Response.json({ workspaces: [workspaceResponse] }));
+        }
+        return Promise.resolve(Response.json({}));
+      }),
+    );
+    claimForPrs();
+
+    render(WorkspaceTerminalView, {
+      props: { workspaceId: "ws-1", paneSurface: "prs" as const },
+    });
+    await waitFor(() => expect(hostedWorkspaceControls()).not.toBeNull());
+    render(WorkspacePaneControls);
+    const launch = await screen.findByRole("button", { name: "Launch session" });
+    expect(launch.hasAttribute("disabled")).toBe(false);
+
+    await clickDeleteAndConfirm(screen.getByRole("button", { name: /^Delete workspace / }));
+    await waitFor(() => expect(launch.hasAttribute("disabled")).toBe(true));
+  });
+
+  it("leaves workspace strip actions off a broken workspace, whose error panel owns delete", async () => {
+    // The strip actions only apply while the workspace is ready. A failed setup
+    // cannot launch a session and renders its own Delete beside the Retry the user
+    // is already looking at, so the header must offer neither shortcut.
     vi.stubGlobal(
       "fetch",
       vi.fn().mockImplementation((input: Request | URL | string) => {
@@ -2881,6 +2933,7 @@ describe("WorkspaceTerminalView", () => {
     await waitFor(() => expect(screen.getByText(/tmux session is no longer running/)).toBeTruthy());
     expect(screen.getByRole("button", { name: "Delete" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: /^Delete workspace / })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Launch session" })).toBeNull();
   });
 
   it("carries the dock modes into the pane controls, since the header that held them is gone", async () => {
@@ -3102,9 +3155,11 @@ describe("WorkspaceTerminalView", () => {
       render(WorkspaceTerminalView, {
         props: { workspaceId: "ws-1", paneSurface: "prs" as const },
       });
+      render(WorkspacePaneControls);
 
       await waitFor(() => expect(mocks.getWorkspaceRuntime).toHaveBeenCalled());
       await waitFor(() => expect(screen.queryByRole("dialog", { name: /Launch a session/ })).toBeNull());
+      expect(screen.queryByRole("button", { name: "Launch session" })).toBeNull();
     });
 
     it("gives a recovered workspace its launcher back", async () => {

--- a/frontend/tests/e2e-full/00-workspace-launcher.spec.ts
+++ b/frontend/tests/e2e-full/00-workspace-launcher.spec.ts
@@ -90,7 +90,7 @@ test.describe("embedded workspace launcher", () => {
     });
   });
 
-  test("launches a first session from the overlay and reopens it from the pane controls", async ({ page }) => {
+  test("launches a first session from the overlay and another from the pane header", async ({ page }) => {
     test.skip(
       !hasCommand("git") || !hasCommand("tmux", ["-V"]),
       "git and tmux are required for the real workspace flow",
@@ -119,26 +119,29 @@ test.describe("embedded workspace launcher", () => {
       await expect(container).toBeVisible();
       await typeMarkerCommand(page, container, workspace.worktree_path, "launcher-marker");
 
-      // And it is reachable again afterwards: the workspace's controls moved into
-      // the pane's own popover, which is the only launch affordance left in a pane.
-      await page.getByRole("button", { name: "Workspace controls" }).first().click();
-      const controls = page.getByRole("dialog", { name: "Workspace controls" });
-      await expect(controls).toBeVisible();
-      await controls.getByRole("button", { name: "Launch" }).click();
+      // The direct pane-header action must reach the same launcher after a session is
+      // already running, without opening the workspace controls popover first.
+      const headerLaunch = page.getByRole("button", { name: "Launch session" });
+      await expect(headerLaunch).toBeVisible();
+      await headerLaunch.click();
       await expect(launcher).toBeVisible();
-
-      // Dismissed by hand this time, which must leave the live terminal behind it
-      // untouched rather than reopening over it.
-      await page.keyboard.press("Escape");
+      await launcher.getByRole("button", { name: "Shell", exact: true }).click();
       await expect(launcher).toBeHidden();
 
-      // The popover deliberately stays open under a dialog it opened, and it floats
-      // over the terminal, so it has to come down before the keystrokes below can
-      // reach it. Its own trigger, not Escape: with the launcher gone Escape belongs
-      // to the detail view, which would deselect the issue and take the pane with it.
-      await page.getByRole("button", { name: "Workspace controls" }).first().click();
-      await expect(controls).toBeHidden();
-      await typeMarkerCommand(page, container, workspace.worktree_path, "launcher-marker-after-dismiss");
+      // The e2e-only endpoint reads SQLite directly, so two persisted shell targets
+      // prove the header-opened launch completed across the HTTP/runtime boundary.
+      await expect
+        .poll(async () => {
+          const response = await api!.get(`/__e2e/workspaces/${workspace.id}/persisted-runtime-sessions`);
+          expect(response.ok()).toBe(true);
+          const body = (await response.json()) as { target_keys: string[] };
+          return body.target_keys;
+        })
+        .toEqual(["plain_shell", "plain_shell"]);
+      const activeContainer = page.locator(
+        ".detail-pane-workspace-slot .tabbed-panel-tab-panel.active .terminal-container",
+      );
+      await typeMarkerCommand(page, activeContainer, workspace.worktree_path, "launcher-marker-after-header-launch");
     } finally {
       await api?.dispose();
       await isolatedServer?.stop();


### PR DESCRIPTION
Launching another session from an embedded workspace currently requires an extra trip through the controls popover, which is especially awkward when the terminal is collapsed.

- Put a direct Launch session action beside Delete for ready workspaces.
- Keep the popover entry for promoted session panes and preserve blocked and non-ready states.

![Workspace header with Launch session beside Delete](https://github.com/user-attachments/assets/d1ff28b2-8607-4af3-a1ec-bade95ebd2fb)

<sup>generated by a clanker</sup>