### PR TITLE
Make background daemon startup idempotent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,7 @@ Coverage of real behavior is non-negotiable; the lane is chosen by the behavior 
 - No emojis in code or output
 - For database schema changes, follow `context/db-migrations.md`; `internal/db/migrations/` is the source of truth for schema evolution.
 - For HTTP API error envelopes and frontend error branching, follow `context/error-handling.md`; branch on stable codes/details rather than prose.
+- For server discovery, background startup, and daemon identity, follow `context/daemon-lifecycle.md`.
 - For retries, backoff, and single-flight dedup against flaky upstreams, follow `context/retries-and-backoffs.md`.
 - For frontend UI and TypeScript/Svelte conventions, follow `context/ui-design-system.md`; prefer extending shared UI primitives over adding one-off local badge/chip/button styling, and name reused domain object shapes instead of repeating anonymous inline types.
 - For mobile, phone, narrow-viewport, touch, or `/m` route work, follow `context/mobile-ux.md`; mobile UX is a phone-first workflow, not desktop UI resized under mobile routes.

--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,10 @@ DEV_CLONE_FRONTEND_PORT ?= 5175
 # gotestsum prints package names on success and full output on failure,
 # while persisting raw `go test -json` events for downstream reporters.
 GOTESTSUM := go tool gotestsum --format pkgname-and-test-fails --jsonfile
-GO_TEST_P ?=
+GO_TEST_P ?= 7
+GO_TEST_PARALLEL ?= 4
 GO_TEST_P_FLAG := $(if $(GO_TEST_P),-p $(GO_TEST_P),)
+GO_TEST_PARALLEL_FLAG := $(if $(GO_TEST_PARALLEL),-parallel $(GO_TEST_PARALLEL),)
 
 # Ensure go:embed has at least one file (no-op if frontend is built)
 ensure-embed-dir:
@@ -269,22 +271,22 @@ dev-ephemeral-stop:
 
 # Run tests
 test: ensure-embed-dir ensure-tmp-dir
-	$(GOTESTSUM)=tmp/test-output.json -- $(GO_TEST_P_FLAG) ./... -shuffle=on
+	$(GOTESTSUM)=tmp/test-output.json -- $(GO_TEST_P_FLAG) $(GO_TEST_PARALLEL_FLAG) ./... -shuffle=on
 
 # Run fast tests only
 test-short: ensure-embed-dir ensure-tmp-dir
-	$(GOTESTSUM)=tmp/test-short-output.json -- $(GO_TEST_P_FLAG) ./... -short -shuffle=on
+	$(GOTESTSUM)=tmp/test-short-output.json -- $(GO_TEST_P_FLAG) $(GO_TEST_PARALLEL_FLAG) ./... -short -shuffle=on
 
 # Pre-commit lane for test-short. Deliberately no -shuffle=on: shuffle is not a
 # cacheable go-test flag, so it forces a full re-run of every package on every
 # commit. Unshuffled runs let unchanged packages hit the Go test result cache;
 # CI and make test/test-short keep shuffled ordering to catch test coupling.
 test-short-precommit: ensure-embed-dir ensure-tmp-dir
-	$(GOTESTSUM)=tmp/test-short-precommit-output.json -- $(GO_TEST_P_FLAG) ./... -short
+	$(GOTESTSUM)=tmp/test-short-precommit-output.json -- $(GO_TEST_P_FLAG) $(GO_TEST_PARALLEL_FLAG) ./... -short
 
 # Run integration tests that execute real git commands (excluded from test-short)
 test-integration: ensure-embed-dir ensure-tmp-dir
-	$(GOTESTSUM)=tmp/test-integration-output.json -- $(GO_TEST_P_FLAG) -tags integration ./... -run '^TestIntegration' -shuffle=on
+	$(GOTESTSUM)=tmp/test-integration-output.json -- $(GO_TEST_P_FLAG) $(GO_TEST_PARALLEL_FLAG) -tags integration ./... -run '^TestIntegration' -shuffle=on
 
 # Report per-package wall time for the slow race-test packages.
 race-times: ensure-embed-dir

--- a/Makefile
+++ b/Makefile
@@ -46,10 +46,8 @@ DEV_CLONE_FRONTEND_PORT ?= 5175
 # gotestsum prints package names on success and full output on failure,
 # while persisting raw `go test -json` events for downstream reporters.
 GOTESTSUM := go tool gotestsum --format pkgname-and-test-fails --jsonfile
-GO_TEST_P ?= 7
-GO_TEST_PARALLEL ?= 4
+GO_TEST_P ?=
 GO_TEST_P_FLAG := $(if $(GO_TEST_P),-p $(GO_TEST_P),)
-GO_TEST_PARALLEL_FLAG := $(if $(GO_TEST_PARALLEL),-parallel $(GO_TEST_PARALLEL),)
 
 # Ensure go:embed has at least one file (no-op if frontend is built)
 ensure-embed-dir:
@@ -271,22 +269,22 @@ dev-ephemeral-stop:
 
 # Run tests
 test: ensure-embed-dir ensure-tmp-dir
-	$(GOTESTSUM)=tmp/test-output.json -- $(GO_TEST_P_FLAG) $(GO_TEST_PARALLEL_FLAG) ./... -shuffle=on
+	$(GOTESTSUM)=tmp/test-output.json -- $(GO_TEST_P_FLAG) ./... -shuffle=on
 
 # Run fast tests only
 test-short: ensure-embed-dir ensure-tmp-dir
-	$(GOTESTSUM)=tmp/test-short-output.json -- $(GO_TEST_P_FLAG) $(GO_TEST_PARALLEL_FLAG) ./... -short -shuffle=on
+	$(GOTESTSUM)=tmp/test-short-output.json -- $(GO_TEST_P_FLAG) ./... -short -shuffle=on
 
 # Pre-commit lane for test-short. Deliberately no -shuffle=on: shuffle is not a
 # cacheable go-test flag, so it forces a full re-run of every package on every
 # commit. Unshuffled runs let unchanged packages hit the Go test result cache;
 # CI and make test/test-short keep shuffled ordering to catch test coupling.
 test-short-precommit: ensure-embed-dir ensure-tmp-dir
-	$(GOTESTSUM)=tmp/test-short-precommit-output.json -- $(GO_TEST_P_FLAG) $(GO_TEST_PARALLEL_FLAG) ./... -short
+	$(GOTESTSUM)=tmp/test-short-precommit-output.json -- $(GO_TEST_P_FLAG) ./... -short
 
 # Run integration tests that execute real git commands (excluded from test-short)
 test-integration: ensure-embed-dir ensure-tmp-dir
-	$(GOTESTSUM)=tmp/test-integration-output.json -- $(GO_TEST_P_FLAG) $(GO_TEST_PARALLEL_FLAG) -tags integration ./... -run '^TestIntegration' -shuffle=on
+	$(GOTESTSUM)=tmp/test-integration-output.json -- $(GO_TEST_P_FLAG) -tags integration ./... -run '^TestIntegration' -shuffle=on
 
 # Report per-package wall time for the slow race-test packages.
 race-times: ensure-embed-dir

--- a/cmd/middleman/agent_hook.go
+++ b/cmd/middleman/agent_hook.go
@@ -229,8 +229,8 @@ func installAgentHooks(action, configPath, rawAgent, binary string, stdout io.Wr
 	if err != nil {
 		return err
 	}
-	if !filepath.IsAbs(cfg.DataDir) {
-		return fmt.Errorf("agent hook install requires an absolute data_dir: %q", cfg.DataDir)
+	if cfg.DataDirWasRelative() {
+		return fmt.Errorf("agent hook install requires an absolute data_dir")
 	}
 	absoluteConfigPath, err := filepath.Abs(configPath)
 	if err != nil {

--- a/cmd/middleman/cli.go
+++ b/cmd/middleman/cli.go
@@ -13,10 +13,11 @@ import (
 )
 
 type cliOptions struct {
-	Stdin     io.Reader
-	Stdout    io.Writer
-	Stderr    io.Writer
-	RunServer serve.Runner
+	Stdin           io.Reader
+	Stdout          io.Writer
+	Stderr          io.Writer
+	RunServer       serve.Runner
+	StartBackground backgroundRunner
 }
 
 func newRootCommand(opts cliOptions) *cobra.Command {
@@ -31,6 +32,9 @@ func newRootCommand(opts cliOptions) *cobra.Command {
 	}
 	if opts.RunServer == nil {
 		opts.RunServer = runServer
+	}
+	if opts.StartBackground == nil {
+		opts.StartBackground = startBackground
 	}
 
 	serveOptions := serve.Options{}
@@ -72,6 +76,7 @@ func newRootCommand(opts cliOptions) *cobra.Command {
 		newArchiveCommand(opts.Stdout, time.Now),
 		newAgentHookCommand(opts.Stdin, opts.Stdout),
 		newStatusCommand(opts.Stdout),
+		newStartCommand(opts.StartBackground, opts.Stdout),
 		newPtyOwnerCommand(),
 		serve.NewCommand(opts.RunServer),
 	)

--- a/cmd/middleman/daemon_client.go
+++ b/cmd/middleman/daemon_client.go
@@ -42,7 +42,7 @@ func discoverDaemonHTTP(configPath string, timeout time.Duration) (daemonHTTPCli
 	baseURL := fmt.Sprintf("http://%s%s", status.Metadata.ListenAddr, prefix)
 	transport := daemonOriginTransport{
 		token: token, origin: "http://" + status.Metadata.ListenAddr,
-		forwardedHost: status.Metadata.ListenAddr, base: http.DefaultTransport,
+		base: http.DefaultTransport,
 	}
 	return daemonHTTPClient{
 		BaseURL: baseURL,
@@ -51,10 +51,9 @@ func discoverDaemonHTTP(configPath string, timeout time.Duration) (daemonHTTPCli
 }
 
 type daemonOriginTransport struct {
-	token         string
-	origin        string
-	forwardedHost string
-	base          http.RoundTripper
+	token  string
+	origin string
+	base   http.RoundTripper
 }
 
 func (t daemonOriginTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -64,9 +63,6 @@ func (t daemonOriginTransport) RoundTrip(req *http.Request) (*http.Response, err
 	if strings.EqualFold(requestOrigin, t.origin) {
 		if t.token != "" {
 			request.Header.Set("Authorization", "Bearer "+t.token)
-		}
-		if t.forwardedHost != "" {
-			request.Header.Set("X-Forwarded-Host", t.forwardedHost)
 		}
 	} else {
 		request.Header.Del("Authorization")

--- a/cmd/middleman/daemon_client_test.go
+++ b/cmd/middleman/daemon_client_test.go
@@ -31,13 +31,13 @@ func TestDaemonOriginTransportScopesHeadersToDaemonOrigin(t *testing.T) {
 
 	client := &http.Client{Transport: daemonOriginTransport{
 		token: "daemon-secret", origin: origin.URL,
-		forwardedHost: "127.0.0.1:8091", base: http.DefaultTransport,
+		base: http.DefaultTransport,
 	}}
 	resp, err := client.Get(origin.URL)
 	require.NoError(err)
 	require.NoError(resp.Body.Close())
 	assert.Equal("Bearer daemon-secret", originAuthorization)
-	assert.Equal("127.0.0.1:8091", originForwardedHost)
+	assert.Empty(originForwardedHost)
 	assert.Empty(redirectedAuthorization)
 	assert.Empty(redirectedForwardedHost)
 }

--- a/cmd/middleman/lock_e2e_test.go
+++ b/cmd/middleman/lock_e2e_test.go
@@ -9,12 +9,10 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
-	"sync"
 	"syscall"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kit/daemon"
 
@@ -36,54 +34,11 @@ func buildMiddleman(t *testing.T) string {
 	return binPath
 }
 
-func installMissingGitHubCLI(t *testing.T) {
-	t.Helper()
-	binDir := t.TempDir()
-	ghName := "gh"
-	ghBody := "#!/bin/sh\nexit 1\n"
-	if runtime.GOOS == "windows" {
-		ghName = "gh.bat"
-		ghBody = "@exit /b 1\r\n"
-	}
-	require.NoError(t, os.WriteFile(
-		filepath.Join(binDir, ghName), []byte(ghBody), 0o700,
-	))
-	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
-}
-
-func writeBackgroundStartConfig(
-	t *testing.T, configPath, dataDir string, port int,
-) {
-	t.Helper()
-	installMissingGitHubCLI(t)
-	t.Setenv("MIDDLEMAN_GITHUB_TOKEN_UNSET_FOR_BACKGROUND_E2E", "")
-	body := fmt.Sprintf(`host = "127.0.0.1"
-port = %d
-data_dir = %q
-sync_interval = "5m"
-github_token_env = "MIDDLEMAN_GITHUB_TOKEN_UNSET_FOR_BACKGROUND_E2E"
-allowed_hosts = ["middleman.example.test"]
-trust_reverse_proxy = true
-
-[api]
-require_auth = true
-
-[activity]
-view_mode = "threaded"
-time_range = "7d"
-
-[terminal]
-`, port, dataDir)
-	require.NoError(t, os.WriteFile(configPath, []byte(body), 0o600))
-}
-
 // TestStartBackgroundSerializesAndReusesCompatibleRuntime protects the
-// process-level lifecycle contract. If serialization breaks, simultaneous
-// callers can launch competing children; if discovery trusts a file without
-// the authenticated ping, a stale or unrelated runtime can be reported as
-// success.
+// process-level lifecycle contract. If serialization or rediscovery breaks,
+// simultaneous callers can launch competing children or a later call can
+// replace the verified runtime instead of reusing it.
 func TestStartBackgroundSerializesAndReusesCompatibleRuntime(t *testing.T) {
-	assert := assert.New(t)
 	require := require.New(t)
 	bin := buildMiddleman(t)
 	root := t.TempDir()
@@ -93,41 +48,33 @@ func TestStartBackgroundSerializesAndReusesCompatibleRuntime(t *testing.T) {
 	require.NoError(os.MkdirAll(runtimeDir, 0o700))
 	t.Setenv("MIDDLEMAN_HOME", runtimeDir)
 	configPath := filepath.Join(runtimeDir, "config.toml")
-	writeBackgroundStartConfig(t, configPath, "./data", reserveFreePort(t))
+	writeMinimalConfig(t, configPath, "./data", reserveFreePort(t))
 
 	type commandResult struct {
-		stdout string
 		stderr string
 		err    error
 	}
-	runStart := func(gate <-chan struct{}) commandResult {
-		<-gate
+	runStart := func() commandResult {
 		cmd := procutil.Command(bin, "start", "--background", "--config", configPath)
 		cmd.Dir = root
-		var stdout, stderr bytes.Buffer
-		cmd.Stdout = &stdout
+		var stderr bytes.Buffer
 		cmd.Stderr = &stderr
 		cmd.Env = append(os.Environ(), "MIDDLEMAN_LOG_LEVEL=warn")
-		err := cmd.Run()
-		return commandResult{stdout: stdout.String(), stderr: stderr.String(), err: err}
+		return commandResult{stderr: stderr.String(), err: cmd.Run()}
 	}
 
 	gate := make(chan struct{})
 	results := make(chan commandResult, 2)
-	var callers sync.WaitGroup
-	callers.Add(2)
 	for range 2 {
 		go func() {
-			defer callers.Done()
-			results <- runStart(gate)
+			<-gate
+			results <- runStart()
 		}()
 	}
 	close(gate)
-	callers.Wait()
-	close(results)
-	for result := range results {
+	for range 2 {
+		result := <-results
 		require.NoError(result.err, result.stderr)
-		assert.Contains(result.stdout, "middleman running")
 	}
 
 	store := daemon.RuntimeStore{Dir: runtimeDir}
@@ -140,29 +87,18 @@ func TestStartBackgroundSerializesAndReusesCompatibleRuntime(t *testing.T) {
 			_ = process.Kill()
 		}
 	})
-	assert.Equal("middleman", record.Service)
-	assert.Equal("dev", record.Version)
-	assert.Equal(daemon.NetworkTCP, record.Network)
-	assert.Equal("127.0.0.1", record.Metadata["host"])
-	assert.NotEmpty(record.Metadata["port"])
-	assert.Equal("false", record.Metadata["read_only"])
-	assert.Equal("true", record.Metadata["require_auth"])
+	require.Equal("middleman", record.Service)
+	require.Equal(daemon.NetworkTCP, record.Network)
 	canonicalDir, err := filepath.EvalSymlinks(dataDir)
 	require.NoError(err)
-	assert.Equal(canonicalDir, record.Metadata["data_dir"])
-	assert.Equal(runtimelock.AuthTokenPath(canonicalDir), record.Metadata["auth_token_path"])
+	require.Equal(canonicalDir, record.Metadata["data_dir"])
 
-	again := procutil.Command(bin, "start", "--background", "--config", configPath)
-	again.Dir = root
-	var againOut, againErr bytes.Buffer
-	again.Stdout = &againOut
-	again.Stderr = &againErr
-	require.NoError(again.Run(), againErr.String())
-	assert.Contains(againOut.String(), "middleman running")
+	again := runStart()
+	require.NoError(again.err, again.stderr)
 	recordsAfter, err := store.List()
 	require.NoError(err)
 	require.Len(recordsAfter, 1)
-	assert.Equal(record.PID, recordsAfter[0].PID)
+	require.Equal(record.PID, recordsAfter[0].PID)
 }
 
 // reserveFreePort opens a listener on 127.0.0.1:0, closes it, and
@@ -183,7 +119,17 @@ func reserveFreePort(t *testing.T) int {
 // with the developer's real ~/.config/middleman.
 func writeMinimalConfig(t *testing.T, configPath, dataDir string, port int) {
 	t.Helper()
-	installMissingGitHubCLI(t)
+	binDir := t.TempDir()
+	ghName := "gh"
+	ghBody := "#!/bin/sh\nexit 1\n"
+	if runtime.GOOS == "windows" {
+		ghName = "gh.bat"
+		ghBody = "@exit /b 1\r\n"
+	}
+	require.NoError(t, os.WriteFile(
+		filepath.Join(binDir, ghName), []byte(ghBody), 0o700,
+	))
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Setenv("MIDDLEMAN_GITHUB_TOKEN_UNSET_FOR_LOCK_E2E", "")
 	body := fmt.Sprintf(`host = "127.0.0.1"
 port = %d

--- a/cmd/middleman/lock_e2e_test.go
+++ b/cmd/middleman/lock_e2e_test.go
@@ -3,12 +3,15 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"net"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -108,6 +111,7 @@ func TestStartBackgroundSerializesAndReusesCompatibleRuntime(t *testing.T) {
 // has multiple winners, discovery cannot authenticate the runtime that won the
 // authoritative data-directory lock.
 func TestForegroundAndBackgroundStartShareAuthToken(t *testing.T) {
+	assert := assert.New(t)
 	require := require.New(t)
 	bin := buildMiddleman(t)
 	root := t.TempDir()
@@ -169,7 +173,61 @@ func TestForegroundAndBackgroundStartShareAuthToken(t *testing.T) {
 		Path: daemonruntime.ProofPingPath,
 	})
 	require.NoError(err)
-	assert.Equal(t, record.PID, ping.PID)
+	assert.Equal(record.PID, ping.PID)
+}
+
+// TestStartBackgroundReportsConfiguredBasePath protects the operator-facing
+// URL. If discovery drops the startup-bound prefix, the reported location
+// points at an unmounted route and returns 404.
+func TestStartBackgroundReportsConfiguredBasePath(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	bin := buildMiddleman(t)
+	root := t.TempDir()
+	dataDir := filepath.Join(root, "data")
+	runtimeDir := filepath.Join(root, "config-home")
+	require.NoError(os.MkdirAll(runtimeDir, 0o700))
+	t.Setenv("MIDDLEMAN_HOME", runtimeDir)
+	configPath := filepath.Join(runtimeDir, "config.toml")
+	port := reserveFreePort(t)
+	writeMinimalConfigWithBasePath(
+		t, configPath, dataDir, port, "/console/",
+	)
+	store := daemon.RuntimeStore{Dir: runtimeDir}
+	t.Cleanup(func() {
+		records, _ := store.List()
+		for _, record := range records {
+			if process, findErr := os.FindProcess(record.PID); findErr == nil {
+				_ = process.Kill()
+			}
+		}
+	})
+
+	cmd := procutil.Command(
+		bin, "start", "--background", "--config", configPath,
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	cmd.Env = append(os.Environ(), "MIDDLEMAN_LOG_LEVEL=warn")
+	require.NoError(cmd.Run(), stderr.String())
+
+	records, err := store.List()
+	require.NoError(err)
+	require.Len(records, 1)
+	wantURL := fmt.Sprintf("http://127.0.0.1:%d/console", port)
+	require.Contains(strings.TrimSpace(stdout.String()), wantURL+" (pid ")
+	client := &http.Client{Timeout: 5 * time.Second}
+	request, err := http.NewRequestWithContext(
+		t.Context(), http.MethodGet, wantURL, nil,
+	)
+	require.NoError(err)
+	response, err := client.Do(request)
+	require.NoError(err)
+	t.Cleanup(func() { require.NoError(response.Body.Close()) })
+	_, err = io.Copy(io.Discard, response.Body)
+	require.NoError(err)
+	assert.Equal(http.StatusOK, response.StatusCode)
 }
 
 // reserveFreePort opens a listener on 127.0.0.1:0, closes it, and
@@ -190,6 +248,13 @@ func reserveFreePort(t *testing.T) int {
 // with the developer's real ~/.config/middleman.
 func writeMinimalConfig(t *testing.T, configPath, dataDir string, port int) {
 	t.Helper()
+	writeMinimalConfigWithBasePath(t, configPath, dataDir, port, "/")
+}
+
+func writeMinimalConfigWithBasePath(
+	t *testing.T, configPath, dataDir string, port int, basePath string,
+) {
+	t.Helper()
 	binDir := t.TempDir()
 	ghName := "gh"
 	ghBody := "#!/bin/sh\nexit 1\n"
@@ -205,6 +270,7 @@ func writeMinimalConfig(t *testing.T, configPath, dataDir string, port int) {
 	body := fmt.Sprintf(`host = "127.0.0.1"
 port = %d
 data_dir = %q
+base_path = %q
 sync_interval = "5m"
 github_token_env = "MIDDLEMAN_GITHUB_TOKEN_UNSET_FOR_LOCK_E2E"
 
@@ -213,7 +279,7 @@ view_mode = "threaded"
 time_range = "7d"
 
 [terminal]
-`, port, dataDir)
+`, port, dataDir, basePath)
 	require.NoError(t, os.WriteFile(configPath, []byte(body), 0o600))
 }
 

--- a/cmd/middleman/lock_e2e_test.go
+++ b/cmd/middleman/lock_e2e_test.go
@@ -36,9 +36,7 @@ func buildMiddleman(t *testing.T) string {
 	return binPath
 }
 
-func writeBackgroundStartConfig(
-	t *testing.T, configPath, dataDir string, port int,
-) {
+func installMissingGitHubCLI(t *testing.T) {
 	t.Helper()
 	binDir := t.TempDir()
 	ghName := "gh"
@@ -51,6 +49,13 @@ func writeBackgroundStartConfig(
 		filepath.Join(binDir, ghName), []byte(ghBody), 0o700,
 	))
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func writeBackgroundStartConfig(
+	t *testing.T, configPath, dataDir string, port int,
+) {
+	t.Helper()
+	installMissingGitHubCLI(t)
 	t.Setenv("MIDDLEMAN_GITHUB_TOKEN_UNSET_FOR_BACKGROUND_E2E", "")
 	body := fmt.Sprintf(`host = "127.0.0.1"
 port = %d
@@ -178,17 +183,7 @@ func reserveFreePort(t *testing.T) int {
 // with the developer's real ~/.config/middleman.
 func writeMinimalConfig(t *testing.T, configPath, dataDir string, port int) {
 	t.Helper()
-	binDir := t.TempDir()
-	ghName := "gh"
-	ghBody := "#!/bin/sh\nexit 1\n"
-	if runtime.GOOS == "windows" {
-		ghName = "gh.bat"
-		ghBody = "@exit /b 1\r\n"
-	}
-	require.NoError(t, os.WriteFile(
-		filepath.Join(binDir, ghName), []byte(ghBody), 0o700,
-	))
-	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	installMissingGitHubCLI(t)
 	t.Setenv("MIDDLEMAN_GITHUB_TOKEN_UNSET_FOR_LOCK_E2E", "")
 	body := fmt.Sprintf(`host = "127.0.0.1"
 port = %d

--- a/cmd/middleman/lock_e2e_test.go
+++ b/cmd/middleman/lock_e2e_test.go
@@ -9,11 +9,14 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kit/daemon"
 
 	"go.kenn.io/middleman/internal/procutil"
 	"go.kenn.io/middleman/internal/runtimelock"
@@ -31,6 +34,130 @@ func buildMiddleman(t *testing.T) string {
 	cmd.Stderr = os.Stderr
 	require.NoError(t, cmd.Run(), "go build ./cmd/middleman")
 	return binPath
+}
+
+func writeBackgroundStartConfig(
+	t *testing.T, configPath, dataDir string, port int,
+) {
+	t.Helper()
+	binDir := t.TempDir()
+	ghName := "gh"
+	ghBody := "#!/bin/sh\nexit 1\n"
+	if runtime.GOOS == "windows" {
+		ghName = "gh.bat"
+		ghBody = "@exit /b 1\r\n"
+	}
+	require.NoError(t, os.WriteFile(
+		filepath.Join(binDir, ghName), []byte(ghBody), 0o700,
+	))
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("MIDDLEMAN_GITHUB_TOKEN_UNSET_FOR_BACKGROUND_E2E", "")
+	body := fmt.Sprintf(`host = "127.0.0.1"
+port = %d
+data_dir = %q
+sync_interval = "5m"
+github_token_env = "MIDDLEMAN_GITHUB_TOKEN_UNSET_FOR_BACKGROUND_E2E"
+allowed_hosts = ["middleman.example.test"]
+trust_reverse_proxy = true
+
+[api]
+require_auth = true
+
+[activity]
+view_mode = "threaded"
+time_range = "7d"
+
+[terminal]
+`, port, dataDir)
+	require.NoError(t, os.WriteFile(configPath, []byte(body), 0o600))
+}
+
+// TestStartBackgroundSerializesAndReusesCompatibleRuntime protects the
+// process-level lifecycle contract. If serialization breaks, simultaneous
+// callers can launch competing children; if discovery trusts a file without
+// the authenticated ping, a stale or unrelated runtime can be reported as
+// success.
+func TestStartBackgroundSerializesAndReusesCompatibleRuntime(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	bin := buildMiddleman(t)
+	root := t.TempDir()
+	dataDir := filepath.Join(root, "data")
+	require.NoError(os.MkdirAll(dataDir, 0o700))
+	runtimeDir := filepath.Join(root, "config-home")
+	require.NoError(os.MkdirAll(runtimeDir, 0o700))
+	t.Setenv("MIDDLEMAN_HOME", runtimeDir)
+	configPath := filepath.Join(runtimeDir, "config.toml")
+	writeBackgroundStartConfig(t, configPath, "./data", reserveFreePort(t))
+
+	type commandResult struct {
+		stdout string
+		stderr string
+		err    error
+	}
+	runStart := func(gate <-chan struct{}) commandResult {
+		<-gate
+		cmd := procutil.Command(bin, "start", "--background", "--config", configPath)
+		cmd.Dir = root
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		cmd.Env = append(os.Environ(), "MIDDLEMAN_LOG_LEVEL=warn")
+		err := cmd.Run()
+		return commandResult{stdout: stdout.String(), stderr: stderr.String(), err: err}
+	}
+
+	gate := make(chan struct{})
+	results := make(chan commandResult, 2)
+	var callers sync.WaitGroup
+	callers.Add(2)
+	for range 2 {
+		go func() {
+			defer callers.Done()
+			results <- runStart(gate)
+		}()
+	}
+	close(gate)
+	callers.Wait()
+	close(results)
+	for result := range results {
+		require.NoError(result.err, result.stderr)
+		assert.Contains(result.stdout, "middleman running")
+	}
+
+	store := daemon.RuntimeStore{Dir: runtimeDir}
+	records, err := store.List()
+	require.NoError(err)
+	require.Len(records, 1)
+	record := records[0]
+	t.Cleanup(func() {
+		if process, findErr := os.FindProcess(record.PID); findErr == nil {
+			_ = process.Kill()
+		}
+	})
+	assert.Equal("middleman", record.Service)
+	assert.Equal("dev", record.Version)
+	assert.Equal(daemon.NetworkTCP, record.Network)
+	assert.Equal("127.0.0.1", record.Metadata["host"])
+	assert.NotEmpty(record.Metadata["port"])
+	assert.Equal("false", record.Metadata["read_only"])
+	assert.Equal("true", record.Metadata["require_auth"])
+	canonicalDir, err := filepath.EvalSymlinks(dataDir)
+	require.NoError(err)
+	assert.Equal(canonicalDir, record.Metadata["data_dir"])
+	assert.Equal(runtimelock.AuthTokenPath(canonicalDir), record.Metadata["auth_token_path"])
+
+	again := procutil.Command(bin, "start", "--background", "--config", configPath)
+	again.Dir = root
+	var againOut, againErr bytes.Buffer
+	again.Stdout = &againOut
+	again.Stderr = &againErr
+	require.NoError(again.Run(), againErr.String())
+	assert.Contains(againOut.String(), "middleman running")
+	recordsAfter, err := store.List()
+	require.NoError(err)
+	require.Len(recordsAfter, 1)
+	assert.Equal(record.PID, recordsAfter[0].PID)
 }
 
 // reserveFreePort opens a listener on 127.0.0.1:0, closes it, and

--- a/cmd/middleman/lock_e2e_test.go
+++ b/cmd/middleman/lock_e2e_test.go
@@ -248,7 +248,7 @@ func reserveFreePort(t *testing.T) int {
 // with the developer's real ~/.config/middleman.
 func writeMinimalConfig(t *testing.T, configPath, dataDir string, port int) {
 	t.Helper()
-	writeMinimalConfigWithBasePath(t, configPath, dataDir, port, "/")
+	writeMinimalConfigWithBasePath(t, configPath, dataDir, port, "")
 }
 
 func writeMinimalConfigWithBasePath(
@@ -267,11 +267,14 @@ func writeMinimalConfigWithBasePath(
 	))
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Setenv("MIDDLEMAN_GITHUB_TOKEN_UNSET_FOR_LOCK_E2E", "")
+	basePathConfig := ""
+	if basePath != "" {
+		basePathConfig = fmt.Sprintf("base_path = %q\n", basePath)
+	}
 	body := fmt.Sprintf(`host = "127.0.0.1"
 port = %d
 data_dir = %q
-base_path = %q
-sync_interval = "5m"
+%ssync_interval = "5m"
 github_token_env = "MIDDLEMAN_GITHUB_TOKEN_UNSET_FOR_LOCK_E2E"
 
 [activity]
@@ -279,7 +282,7 @@ view_mode = "threaded"
 time_range = "7d"
 
 [terminal]
-`, port, dataDir, basePath)
+`, port, dataDir, basePathConfig)
 	require.NoError(t, os.WriteFile(configPath, []byte(body), 0o600))
 }
 

--- a/cmd/middleman/lock_e2e_test.go
+++ b/cmd/middleman/lock_e2e_test.go
@@ -212,6 +212,8 @@ func TestStartupLockCollisionAndStatus(t *testing.T) {
 	root := t.TempDir()
 	dataDir := filepath.Join(root, "data")
 	require.NoError(os.MkdirAll(dataDir, 0o700))
+	canonicalDataDir, err := filepath.EvalSymlinks(dataDir)
+	require.NoError(err)
 	cfgPath := filepath.Join(root, "config.toml")
 
 	port := reserveFreePort(t)
@@ -244,7 +246,7 @@ func TestStartupLockCollisionAndStatus(t *testing.T) {
 	startupJSONCmd.Stderr = os.Stderr
 	require.NoError(startupJSONCmd.Run())
 	require.Contains(startupJSONOut.String(), "\"running\": true")
-	require.Contains(startupJSONOut.String(), "\"data_dir\": \""+dataDir+"\"")
+	require.Contains(startupJSONOut.String(), "\"data_dir\": \""+canonicalDataDir+"\"")
 	require.Contains(startupJSONOut.String(), "\"metadata\": null")
 	require.Contains(startupJSONOut.String(), "\"metadata_error\": \"missing\"")
 
@@ -310,7 +312,7 @@ func TestStartupLockCollisionAndStatus(t *testing.T) {
 	jsonCmd.Stderr = os.Stderr
 	require.NoError(jsonCmd.Run())
 	require.Contains(jsonOut.String(), "\"running\": true")
-	require.Contains(jsonOut.String(), "\"data_dir\": \""+dataDir+"\"")
+	require.Contains(jsonOut.String(), "\"data_dir\": \""+canonicalDataDir+"\"")
 	require.Contains(jsonOut.String(), "\"port\": "+strconv.Itoa(port))
 
 	// Shut down the first process gracefully so the deferred Release

--- a/cmd/middleman/lock_e2e_test.go
+++ b/cmd/middleman/lock_e2e_test.go
@@ -13,9 +13,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kit/daemon"
 
+	"go.kenn.io/middleman/internal/daemonruntime"
 	"go.kenn.io/middleman/internal/procutil"
 	"go.kenn.io/middleman/internal/runtimelock"
 )
@@ -99,6 +101,75 @@ func TestStartBackgroundSerializesAndReusesCompatibleRuntime(t *testing.T) {
 	require.NoError(err)
 	require.Len(recordsAfter, 1)
 	require.Equal(record.PID, recordsAfter[0].PID)
+}
+
+// TestForegroundAndBackgroundStartShareAuthToken protects a fresh data
+// directory started through both lifecycle paths at once. If token creation
+// has multiple winners, discovery cannot authenticate the runtime that won the
+// authoritative data-directory lock.
+func TestForegroundAndBackgroundStartShareAuthToken(t *testing.T) {
+	require := require.New(t)
+	bin := buildMiddleman(t)
+	root := t.TempDir()
+	dataDir := filepath.Join(root, "data")
+	runtimeDir := filepath.Join(root, "config-home")
+	require.NoError(os.MkdirAll(runtimeDir, 0o700))
+	t.Setenv("MIDDLEMAN_HOME", runtimeDir)
+	configPath := filepath.Join(runtimeDir, "config.toml")
+	writeMinimalConfig(t, configPath, dataDir, reserveFreePort(t))
+	store := daemon.RuntimeStore{Dir: runtimeDir}
+
+	foreground := procutil.Command(bin, "serve", "--config", configPath)
+	var foregroundStderr bytes.Buffer
+	foreground.Stderr = &foregroundStderr
+	foreground.Env = append(os.Environ(), "MIDDLEMAN_LOG_LEVEL=warn")
+	background := procutil.Command(
+		bin, "start", "--background", "--config", configPath,
+	)
+	var backgroundStderr bytes.Buffer
+	background.Stderr = &backgroundStderr
+	background.Env = append(os.Environ(), "MIDDLEMAN_LOG_LEVEL=warn")
+	t.Cleanup(func() {
+		records, _ := store.List()
+		for _, record := range records {
+			if process, findErr := os.FindProcess(record.PID); findErr == nil {
+				_ = process.Kill()
+			}
+		}
+		if foreground.Process != nil {
+			_ = foreground.Process.Kill()
+			_ = foreground.Wait()
+		}
+	})
+
+	gate := make(chan struct{})
+	foregroundStarted := make(chan error, 1)
+	backgroundDone := make(chan error, 1)
+	go func() {
+		<-gate
+		foregroundStarted <- foreground.Start()
+	}()
+	go func() {
+		<-gate
+		backgroundDone <- background.Run()
+	}()
+	close(gate)
+	require.NoError(<-foregroundStarted)
+	require.NoError(<-backgroundDone, backgroundStderr.String())
+
+	records, err := store.List()
+	require.NoError(err)
+	require.Len(records, 1)
+	record := records[0]
+	token, err := runtimelock.ReadAuthToken(dataDir)
+	require.NoError(err)
+	proof, err := daemon.NewProof([]byte(token))
+	require.NoError(err)
+	ping, err := proof.Probe(t.Context(), record, daemon.ProbeOptions{
+		Path: daemonruntime.ProofPingPath,
+	})
+	require.NoError(err)
+	assert.Equal(t, record.PID, ping.PID)
 }
 
 // reserveFreePort opens a listener on 127.0.0.1:0, closes it, and

--- a/cmd/middleman/main.go
+++ b/cmd/middleman/main.go
@@ -13,17 +13,16 @@ import (
 	"os/signal"
 	"path"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync"
 	"syscall"
 	"time"
 
-	"go.kenn.io/kit/daemon"
 	oteltelemetry "go.kenn.io/kit/telemetry"
 	"go.kenn.io/middleman/internal/archive"
 	"go.kenn.io/middleman/internal/cli/serve"
 	"go.kenn.io/middleman/internal/config"
+	"go.kenn.io/middleman/internal/daemonruntime"
 	"go.kenn.io/middleman/internal/db"
 	"go.kenn.io/middleman/internal/gitclone"
 	ghclient "go.kenn.io/middleman/internal/github"
@@ -305,11 +304,6 @@ func run(opts serve.Options) error {
 			"create data directory %s: %w", cfg.DataDir, err,
 		)
 	}
-	canonicalDir, err := config.CanonicalDataDir(cfg.DataDir)
-	if err != nil {
-		return err
-	}
-	cfg.DataDir = canonicalDir
 
 	lockHandle, err := runtimelock.Acquire(cfg.DataDir)
 	if err != nil {
@@ -375,7 +369,12 @@ func run(opts serve.Options) error {
 	); err != nil {
 		slog.Warn("write runtime metadata", "err", err)
 	}
-	runtimePath, err := writeDaemonRuntimeRecord(ln, cfg)
+	runtimePath, err := daemonruntime.Publish(daemonruntime.PublishOptions{
+		Address:     ln.Addr().String(),
+		Version:     version,
+		DataDir:     cfg.DataDir,
+		RequireAuth: cfg.API.RequireAuth,
+	})
 	if err != nil {
 		_ = ln.Close()
 		return fmt.Errorf("write daemon runtime record: %w", err)
@@ -760,42 +759,6 @@ func writeRuntimeMetadata(
 		BasePath:    canonicalBasePath(basePath),
 		RequireAuth: requireAuth,
 	})
-}
-
-func writeDaemonRuntimeRecord(
-	ln net.Listener, cfg *config.Config,
-) (string, error) {
-	host, portText, err := net.SplitHostPort(ln.Addr().String())
-	if err != nil {
-		return "", fmt.Errorf("listener address is not TCP: %w", err)
-	}
-	port, err := strconv.Atoi(portText)
-	if err != nil {
-		return "", fmt.Errorf("parse listener port: %w", err)
-	}
-	runtimeDir, err := filepath.Abs(config.DefaultDataDir())
-	if err != nil {
-		return "", fmt.Errorf("resolve runtime directory: %w", err)
-	}
-	store := daemon.RuntimeStore{Dir: runtimeDir}
-	if _, err := store.CleanupDead(); err != nil {
-		return "", fmt.Errorf("clean stale daemon runtime records: %w", err)
-	}
-	record := daemon.NewRuntimeRecord(
-		daemonServiceName, version,
-		daemon.Endpoint{Network: daemon.NetworkTCP, Address: ln.Addr().String()},
-	)
-	record.Metadata = map[string]string{
-		"host":         host,
-		"port":         strconv.Itoa(port),
-		"read_only":    "false",
-		"require_auth": strconv.FormatBool(cfg.API.RequireAuth),
-		"data_dir":     cfg.DataDir,
-	}
-	if cfg.API.RequireAuth {
-		record.Metadata["auth_token_path"] = runtimelock.AuthTokenPath(cfg.DataDir)
-	}
-	return store.Write(record)
 }
 
 // canonicalBasePath publishes the prefix form clients join paths

--- a/cmd/middleman/main.go
+++ b/cmd/middleman/main.go
@@ -18,6 +18,7 @@ import (
 	"syscall"
 	"time"
 
+	"go.kenn.io/kit/daemon"
 	oteltelemetry "go.kenn.io/kit/telemetry"
 	"go.kenn.io/middleman/internal/archive"
 	"go.kenn.io/middleman/internal/cli/serve"
@@ -369,7 +370,7 @@ func run(opts serve.Options) error {
 	); err != nil {
 		slog.Warn("write runtime metadata", "err", err)
 	}
-	runtimePath, err := daemonruntime.Publish(daemonruntime.PublishOptions{
+	runtimeRecord, runtimePath, err := daemonruntime.Publish(daemonruntime.PublishOptions{
 		Address:     ln.Addr().String(),
 		Version:     version,
 		DataDir:     cfg.DataDir,
@@ -384,6 +385,16 @@ func run(opts serve.Options) error {
 			slog.Warn("remove daemon runtime record", "err", err)
 		}
 	}()
+	proof, err := daemon.NewProof([]byte(authToken))
+	if err != nil {
+		_ = ln.Close()
+		return fmt.Errorf("initialize daemon proof: %w", err)
+	}
+	daemonProofHandler, err := proof.NewPingHandler(runtimeRecord)
+	if err != nil {
+		_ = ln.Close()
+		return fmt.Errorf("initialize daemon ping: %w", err)
+	}
 
 	startupHandler := server.NewStartupHandler(
 		assets, cfg, server.ServerOptions{}, ln,
@@ -572,6 +583,8 @@ func run(opts serve.Options) error {
 		database, syncer, cloneMgr, assets,
 		cfg, configPath, server.ServerOptions{
 			APIAuthToken:        enforcedToken,
+			DirectClientToken:   authToken,
+			DaemonProofHandler:  daemonProofHandler,
 			WorktreeDir:         filepath.Join(cfg.DataDir, "worktrees"),
 			PtyOwnerManagerPath: os.Getenv("MIDDLEMAN_PTY_MANAGER"),
 			Telemetry:           telemetryReporter,

--- a/cmd/middleman/main.go
+++ b/cmd/middleman/main.go
@@ -13,11 +13,13 @@ import (
 	"os/signal"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
 	"time"
 
+	"go.kenn.io/kit/daemon"
 	oteltelemetry "go.kenn.io/kit/telemetry"
 	"go.kenn.io/middleman/internal/archive"
 	"go.kenn.io/middleman/internal/cli/serve"
@@ -303,6 +305,11 @@ func run(opts serve.Options) error {
 			"create data directory %s: %w", cfg.DataDir, err,
 		)
 	}
+	canonicalDir, err := config.CanonicalDataDir(cfg.DataDir)
+	if err != nil {
+		return err
+	}
+	cfg.DataDir = canonicalDir
 
 	lockHandle, err := runtimelock.Acquire(cfg.DataDir)
 	if err != nil {
@@ -368,6 +375,16 @@ func run(opts serve.Options) error {
 	); err != nil {
 		slog.Warn("write runtime metadata", "err", err)
 	}
+	runtimePath, err := writeDaemonRuntimeRecord(ln, cfg)
+	if err != nil {
+		_ = ln.Close()
+		return fmt.Errorf("write daemon runtime record: %w", err)
+	}
+	defer func() {
+		if err := os.Remove(runtimePath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			slog.Warn("remove daemon runtime record", "err", err)
+		}
+	}()
 
 	startupHandler := server.NewStartupHandler(
 		assets, cfg, server.ServerOptions{}, ln,
@@ -743,6 +760,42 @@ func writeRuntimeMetadata(
 		BasePath:    canonicalBasePath(basePath),
 		RequireAuth: requireAuth,
 	})
+}
+
+func writeDaemonRuntimeRecord(
+	ln net.Listener, cfg *config.Config,
+) (string, error) {
+	host, portText, err := net.SplitHostPort(ln.Addr().String())
+	if err != nil {
+		return "", fmt.Errorf("listener address is not TCP: %w", err)
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		return "", fmt.Errorf("parse listener port: %w", err)
+	}
+	runtimeDir, err := filepath.Abs(config.DefaultDataDir())
+	if err != nil {
+		return "", fmt.Errorf("resolve runtime directory: %w", err)
+	}
+	store := daemon.RuntimeStore{Dir: runtimeDir}
+	if _, err := store.CleanupDead(); err != nil {
+		return "", fmt.Errorf("clean stale daemon runtime records: %w", err)
+	}
+	record := daemon.NewRuntimeRecord(
+		daemonServiceName, version,
+		daemon.Endpoint{Network: daemon.NetworkTCP, Address: ln.Addr().String()},
+	)
+	record.Metadata = map[string]string{
+		"host":         host,
+		"port":         strconv.Itoa(port),
+		"read_only":    "false",
+		"require_auth": strconv.FormatBool(cfg.API.RequireAuth),
+		"data_dir":     cfg.DataDir,
+	}
+	if cfg.API.RequireAuth {
+		record.Metadata["auth_token_path"] = runtimelock.AuthTokenPath(cfg.DataDir)
+	}
+	return store.Write(record)
 }
 
 // canonicalBasePath publishes the prefix form clients join paths

--- a/cmd/middleman/main.go
+++ b/cmd/middleman/main.go
@@ -365,17 +365,18 @@ func run(opts serve.Options) error {
 		)
 	}
 
-	if err := writeRuntimeMetadata(
-		lockHandle, ln, cfg.DataDir, cfg.BasePath, cfg.API.RequireAuth,
-	); err != nil {
+	runtimeIdentity, err := daemonruntime.NewIdentity(ln.Addr(), daemonruntime.IdentityOptions{
+		Version: version, Commit: commit, DataDir: cfg.DataDir,
+		BasePath: cfg.BasePath, RequireAuth: cfg.API.RequireAuth,
+	})
+	if err != nil {
+		_ = ln.Close()
+		return fmt.Errorf("build daemon runtime identity: %w", err)
+	}
+	if err := lockHandle.WriteMetadata(runtimeIdentity.LockMetadata); err != nil {
 		slog.Warn("write runtime metadata", "err", err)
 	}
-	runtimeRecord, runtimePath, err := daemonruntime.Publish(daemonruntime.PublishOptions{
-		Address:     ln.Addr().String(),
-		Version:     version,
-		DataDir:     cfg.DataDir,
-		RequireAuth: cfg.API.RequireAuth,
-	})
+	runtimePath, err := daemonruntime.Publish(runtimeIdentity.Record)
 	if err != nil {
 		_ = ln.Close()
 		return fmt.Errorf("write daemon runtime record: %w", err)
@@ -390,7 +391,7 @@ func run(opts serve.Options) error {
 		_ = ln.Close()
 		return fmt.Errorf("initialize daemon proof: %w", err)
 	}
-	daemonProofHandler, err := proof.NewPingHandler(runtimeRecord)
+	daemonProofHandler, err := proof.NewPingHandler(runtimeIdentity.Record)
 	if err != nil {
 		_ = ln.Close()
 		return fmt.Errorf("initialize daemon ping: %w", err)
@@ -746,44 +747,6 @@ func profilerSrvDone(srv *profiler.Server) <-chan error {
 		return nil
 	}
 	return srv.Done()
-}
-
-// writeRuntimeMetadata snapshots the bound listener and process state
-// into the runtime metadata file. The recorded port comes from
-// ln.Addr() (not cfg.Port) so it matches the kernel-assigned value if
-// they ever diverge.
-func writeRuntimeMetadata(
-	h *runtimelock.Handle, ln net.Listener,
-	dataDir, basePath string, requireAuth bool,
-) error {
-	tcpAddr, ok := ln.Addr().(*net.TCPAddr)
-	if !ok {
-		return fmt.Errorf("listener returned non-TCP address %T", ln.Addr())
-	}
-	return h.WriteMetadata(runtimelock.Metadata{
-		PID:         os.Getpid(),
-		Host:        tcpAddr.IP.String(),
-		Port:        tcpAddr.Port,
-		ListenAddr:  ln.Addr().String(),
-		StartedAt:   time.Now().UTC().Format(time.RFC3339),
-		Version:     version,
-		Commit:      commit,
-		TokenPath:   runtimelock.AuthTokenPath(dataDir),
-		BasePath:    canonicalBasePath(basePath),
-		RequireAuth: requireAuth,
-	})
-}
-
-// canonicalBasePath publishes the prefix form clients join paths
-// onto: no trailing slash, except the bare root.
-func canonicalBasePath(basePath string) string {
-	if basePath == "" {
-		return "/"
-	}
-	if trimmed := strings.TrimSuffix(basePath, "/"); trimmed != "" {
-		return trimmed
-	}
-	return "/"
 }
 
 func resolveStartupRepos(

--- a/cmd/middleman/main.go
+++ b/cmd/middleman/main.go
@@ -346,11 +346,6 @@ func run(opts serve.Options) error {
 	if err != nil {
 		return fmt.Errorf("ensure auth token: %w", err)
 	}
-	enforcedToken := ""
-	if cfg.API.RequireAuth {
-		enforcedToken = authToken
-	}
-
 	addr := cfg.ListenAddr()
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
@@ -583,9 +578,10 @@ func run(opts serve.Options) error {
 	srv = server.NewWithConfig(
 		database, syncer, cloneMgr, assets,
 		cfg, configPath, server.ServerOptions{
-			APIAuthToken:        enforcedToken,
-			DirectClientToken:   authToken,
-			DaemonProofHandler:  daemonProofHandler,
+			DaemonAccess: server.DaemonAccessOptions{
+				Token: authToken, RequireAPIAuth: cfg.API.RequireAuth,
+				ProofHandler: daemonProofHandler,
+			},
 			WorktreeDir:         filepath.Join(cfg.DataDir, "worktrees"),
 			PtyOwnerManagerPath: os.Getenv("MIDDLEMAN_PTY_MANAGER"),
 			Telemetry:           telemetryReporter,

--- a/cmd/middleman/main_test.go
+++ b/cmd/middleman/main_test.go
@@ -25,7 +25,6 @@ import (
 	"go.kenn.io/middleman/internal/db"
 	ghclient "go.kenn.io/middleman/internal/github"
 	"go.kenn.io/middleman/internal/platform"
-	"go.kenn.io/middleman/internal/runtimelock"
 	"go.kenn.io/middleman/internal/server"
 	"go.kenn.io/middleman/internal/testutil"
 	"go.kenn.io/middleman/internal/testutil/dbtest"
@@ -130,49 +129,6 @@ func mainTestTokenSource(
 			EnvName: envName,
 		}},
 	}, tokenauth.Options{})
-}
-
-func TestWriteRuntimeMetadataRecordsBoundTCPPort(t *testing.T) {
-	require := require.New(t)
-	assert := assert.New(t)
-	dataDir := t.TempDir()
-	lockHandle, err := runtimelock.Acquire(dataDir)
-	require.NoError(err)
-	t.Cleanup(func() {
-		require.NoError(lockHandle.Release())
-	})
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(err)
-	t.Cleanup(func() {
-		require.NoError(ln.Close())
-	})
-
-	require.NoError(writeRuntimeMetadata(lockHandle, ln, dataDir, "/", false))
-
-	data, err := os.ReadFile(runtimelock.MetadataPath(dataDir))
-	require.NoError(err)
-	var meta runtimelock.Metadata
-	require.NoError(json.Unmarshal(data, &meta))
-	tcpAddr := ln.Addr().(*net.TCPAddr)
-	assert.Equal(tcpAddr.Port, meta.Port)
-	assert.Equal("127.0.0.1", meta.Host)
-	assert.Equal(ln.Addr().String(), meta.ListenAddr)
-}
-
-func TestWriteRuntimeMetadataRejectsNonTCPListener(t *testing.T) {
-	dataDir := t.TempDir()
-	lockHandle, err := runtimelock.Acquire(dataDir)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, lockHandle.Release())
-	})
-
-	err = writeRuntimeMetadata(
-		lockHandle, fakeListener{addr: fakeAddr("not-an-address")},
-		dataDir, "/", false,
-	)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "non-TCP")
 }
 
 func TestRunMainShutdownStopsSignalsBeforeLongCleanup(t *testing.T) {
@@ -281,22 +237,6 @@ func TestResolveStartupReposExpandsConfiguredGlobs(t *testing.T) {
 		RepoPath:     "roborev-dev/middleman",
 	}}, repos)
 }
-
-type fakeAddr string
-
-func (a fakeAddr) Network() string { return "fake" }
-
-func (a fakeAddr) String() string { return string(a) }
-
-type fakeListener struct {
-	addr net.Addr
-}
-
-func (l fakeListener) Accept() (net.Conn, error) { return nil, errors.New("not implemented") }
-
-func (l fakeListener) Close() error { return nil }
-
-func (l fakeListener) Addr() net.Addr { return l.addr }
 
 func TestResolveStartupReposKeepsExactReposWhenResolutionFails(t *testing.T) {
 	assert := assert.New(t)

--- a/cmd/middleman/main_test.go
+++ b/cmd/middleman/main_test.go
@@ -38,7 +38,18 @@ func TestMain(m *testing.M) {
 			panic(err)
 		}
 	}
-	os.Exit(m.Run())
+	runtimeDir, err := os.MkdirTemp("", "middleman-test-home-")
+	if err != nil {
+		panic(err)
+	}
+	if err := os.Setenv("MIDDLEMAN_HOME", runtimeDir); err != nil {
+		panic(err)
+	}
+	code := m.Run()
+	if err := os.RemoveAll(runtimeDir); err != nil {
+		panic(err)
+	}
+	os.Exit(code)
 }
 
 func TestConfigureLoggingRedactsTokens(t *testing.T) {
@@ -773,7 +784,7 @@ func TestRootHelpListsEveryPublicCommandWithoutStartingServer(t *testing.T) {
 	for _, name := range []string{
 		"activity", "agent-hook", "api", "archive", "config", "docs",
 		"issues", "pulls", "quickstart", "rate-limits", "repo-summaries",
-		"repos", "serve", "stacks", "status", "sync", "version", "workspaces",
+		"repos", "serve", "stacks", "start", "status", "sync", "version", "workspaces",
 	} {
 		assert.Contains(stdout.String(), name)
 	}
@@ -814,6 +825,7 @@ func TestRootNestedHelpExposesCommandFlags(t *testing.T) {
 		{name: "archive report", args: []string{"archive", "report", "--help"}, want: []string{"--days", "--start", "--end", "--format", "--repo"}},
 		{name: "agent hook run", args: []string{"agent-hook", "run", "--help"}, want: []string{"--agent", "--config", "--source"}},
 		{name: "status", args: []string{"status", "--help"}, want: []string{"--config", "--json"}},
+		{name: "start", args: []string{"start", "--help"}, want: []string{"--background", "--config"}},
 		{name: "serve", args: []string{"serve", "--help"}, want: []string{"--config", "--pprof-addr"}},
 		{name: "api", args: []string{"api", "--help"}, want: []string{"list", "--config", "-d", "-i", "--timeout"}},
 	}

--- a/cmd/middleman/start_background.go
+++ b/cmd/middleman/start_background.go
@@ -92,11 +92,6 @@ func validateBackgroundConfig(cfg *config.Config) error {
 			cfg.Host,
 		)
 	}
-	if cfg.TrustReverseProxy && !cfg.API.RequireAuth {
-		return errors.New(
-			"background start with trust_reverse_proxy=true requires api.require_auth=true",
-		)
-	}
 	return nil
 }
 
@@ -158,6 +153,9 @@ func (d backgroundDiscovery) find(
 	if err != nil {
 		return daemon.RuntimeRecord{}, daemon.PingInfo{}, false, err
 	}
+	if token == "" {
+		return daemon.RuntimeRecord{}, daemon.PingInfo{}, false, nil
+	}
 	records, err := d.store.List()
 	if err != nil {
 		return daemon.RuntimeRecord{}, daemon.PingInfo{}, false, err
@@ -184,17 +182,13 @@ func (d backgroundDiscovery) probe(
 		return daemon.PingInfo{}, false, nil
 	}
 
-	endpoint := record.Endpoint()
-	client := endpoint.HTTPClient(daemon.HTTPClientOptions{
-		Timeout:           backgroundProbeTimeout,
-		DisableKeepAlives: true,
-	})
-	client.Transport = daemonOriginTransport{
-		token: token, origin: endpoint.BaseURL(), base: client.Transport,
+	proof, err := daemon.NewProof([]byte(token))
+	if err != nil {
+		return daemon.PingInfo{}, false, fmt.Errorf("initialize daemon proof: %w", err)
 	}
-	ping, err := daemon.ProbeHTTP(
-		ctx, client, endpoint.BaseURL(), daemon.ProbeOptions{
-			Path:            "/api/ping",
+	ping, err := proof.Probe(
+		ctx, record, daemon.ProbeOptions{
+			Path:            daemonruntime.ProofPingPath,
 			ExpectedService: daemonruntime.Service,
 			Timeout:         backgroundProbeTimeout,
 		},

--- a/cmd/middleman/start_background.go
+++ b/cmd/middleman/start_background.go
@@ -13,21 +13,11 @@ import (
 	"go.kenn.io/kit/daemon"
 	"go.kenn.io/middleman/internal/config"
 	"go.kenn.io/middleman/internal/daemonruntime"
-	"go.kenn.io/middleman/internal/runtimelock"
 )
 
-const (
-	backgroundStartTimeout = 90 * time.Second
-	backgroundProbeTimeout = 750 * time.Millisecond
-)
+const backgroundStartTimeout = 90 * time.Second
 
 type backgroundRunner func(context.Context, string, io.Writer) error
-
-type backgroundDiscovery struct {
-	store   daemon.RuntimeStore
-	dataDir string
-	version string
-}
 
 func newStartCommand(run backgroundRunner, stdout io.Writer) *cobra.Command {
 	var background bool
@@ -68,7 +58,7 @@ func startBackground(
 	if err != nil {
 		return err
 	}
-	manager := newBackgroundManager(
+	manager := daemonruntime.NewManager(
 		store, cfg.DataDir, version,
 		func(ctx context.Context) error {
 			return startBackgroundProcess(ctx, configPath, cfg.DataDir)
@@ -118,95 +108,4 @@ func startBackgroundProcess(
 		Stderr:          logFile,
 		RefuseEphemeral: true,
 	})
-}
-
-func newBackgroundManager(
-	discoveryStore daemon.RuntimeStore,
-	dataDir, expectedVersion string,
-	start daemon.StartFunc,
-) daemon.Manager {
-	discovery := backgroundDiscovery{
-		store: discoveryStore, dataDir: dataDir, version: expectedVersion,
-	}
-	return daemon.Manager{
-		Store:    daemonruntime.StartLockStore(discoveryStore, dataDir),
-		FindFunc: discovery.find,
-		Start: func(ctx context.Context) error {
-			if _, err := runtimelock.EnsureAuthToken(dataDir); err != nil {
-				return fmt.Errorf("ensure auth token: %w", err)
-			}
-			if start == nil {
-				return errors.New("middleman daemon is not running")
-			}
-			if err := start(ctx); err != nil {
-				return fmt.Errorf("start middleman daemon: %w", err)
-			}
-			return nil
-		},
-	}
-}
-
-func (d backgroundDiscovery) find(
-	ctx context.Context,
-) (daemon.RuntimeRecord, daemon.PingInfo, bool, error) {
-	token, err := runtimelock.ReadAuthToken(d.dataDir)
-	if err != nil {
-		return daemon.RuntimeRecord{}, daemon.PingInfo{}, false, err
-	}
-	if token == "" {
-		return daemon.RuntimeRecord{}, daemon.PingInfo{}, false, nil
-	}
-	records, err := d.store.List()
-	if err != nil {
-		return daemon.RuntimeRecord{}, daemon.PingInfo{}, false, err
-	}
-	for _, record := range records {
-		ping, compatible, err := d.probe(ctx, record, token)
-		if err != nil {
-			return daemon.RuntimeRecord{}, daemon.PingInfo{}, false, err
-		}
-		if compatible {
-			return record, ping, true, nil
-		}
-	}
-	return daemon.RuntimeRecord{}, daemon.PingInfo{}, false, nil
-}
-
-func (d backgroundDiscovery) probe(
-	ctx context.Context, record daemon.RuntimeRecord, token string,
-) (daemon.PingInfo, bool, error) {
-	if !daemonruntime.Compatible(record, daemonruntime.MatchOptions{
-		DataDir:        d.dataDir,
-		TokenAvailable: token != "",
-	}) {
-		return daemon.PingInfo{}, false, nil
-	}
-
-	proof, err := daemon.NewProof([]byte(token))
-	if err != nil {
-		return daemon.PingInfo{}, false, fmt.Errorf("initialize daemon proof: %w", err)
-	}
-	ping, err := proof.Probe(
-		ctx, record, daemon.ProbeOptions{
-			Path:            daemonruntime.ProofPingPath,
-			ExpectedService: daemonruntime.Service,
-			Timeout:         backgroundProbeTimeout,
-		},
-	)
-	if err != nil {
-		if ctx.Err() != nil {
-			return daemon.PingInfo{}, false, ctx.Err()
-		}
-		return daemon.PingInfo{}, false, nil
-	}
-	if ping.PID != record.PID {
-		return daemon.PingInfo{}, false, nil
-	}
-	if record.Version != d.version || ping.Version != d.version {
-		return daemon.PingInfo{}, false, fmt.Errorf(
-			"running middleman version %q is incompatible with %q",
-			ping.Version, d.version,
-		)
-	}
-	return ping, true, nil
 }

--- a/cmd/middleman/start_background.go
+++ b/cmd/middleman/start_background.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/gofrs/flock"
 	"github.com/spf13/cobra"
 	"go.kenn.io/kit/daemon"
 	"go.kenn.io/middleman/internal/config"
@@ -20,17 +19,14 @@ import (
 const (
 	backgroundStartTimeout = 90 * time.Second
 	backgroundProbeTimeout = 750 * time.Millisecond
-	backgroundProbeTick    = 50 * time.Millisecond
 )
 
 type backgroundRunner func(context.Context, string, io.Writer) error
 
-type backgroundLifecycle struct {
+type backgroundDiscovery struct {
 	store   daemon.RuntimeStore
 	dataDir string
-	token   string
 	version string
-	start   daemon.StartFunc
 }
 
 func newStartCommand(run backgroundRunner, stdout io.Writer) *cobra.Command {
@@ -68,24 +64,17 @@ func startBackground(
 	if err := os.MkdirAll(cfg.DataDir, 0o700); err != nil {
 		return fmt.Errorf("create data directory %s: %w", cfg.DataDir, err)
 	}
-	token, err := runtimelock.ReadAuthToken(cfg.DataDir)
-	if err != nil {
-		return fmt.Errorf("read auth token: %w", err)
-	}
 	store, err := daemonruntime.Store()
 	if err != nil {
 		return err
 	}
-	lifecycle := backgroundLifecycle{
-		store:   store,
-		dataDir: cfg.DataDir,
-		token:   token,
-		version: version,
-		start: func(ctx context.Context) error {
+	manager := newBackgroundManager(
+		store, cfg.DataDir, version,
+		func(ctx context.Context) error {
 			return startBackgroundProcess(ctx, configPath, cfg.DataDir)
 		},
-	}
-	record, _, err := lifecycle.Ensure(ctx, backgroundStartTimeout)
+	)
+	record, _, err := manager.Ensure(ctx, backgroundStartTimeout)
 	if err != nil {
 		return err
 	}
@@ -136,80 +125,45 @@ func startBackgroundProcess(
 	})
 }
 
-func (l backgroundLifecycle) Ensure(
-	ctx context.Context, timeout time.Duration,
-) (daemon.RuntimeRecord, daemon.PingInfo, error) {
-	if timeout <= 0 {
-		timeout = backgroundStartTimeout
+func newBackgroundManager(
+	discoveryStore daemon.RuntimeStore,
+	dataDir, expectedVersion string,
+	start daemon.StartFunc,
+) daemon.Manager {
+	discovery := backgroundDiscovery{
+		store: discoveryStore, dataDir: dataDir, version: expectedVersion,
 	}
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
-	if record, ping, ok, err := l.find(ctx); err != nil || ok {
-		return record, ping, err
-	}
-	lockPath, err := daemonruntime.StartLockStore(l.store, l.dataDir).LockPath()
-	if err != nil {
-		return daemon.RuntimeRecord{}, daemon.PingInfo{}, err
-	}
-	lock := flock.New(lockPath)
-	locked, err := lock.TryLockContext(ctx, backgroundProbeTick)
-	if err != nil {
-		return daemon.RuntimeRecord{}, daemon.PingInfo{}, fmt.Errorf(
-			"acquire daemon start lock: %w", err,
-		)
-	}
-	if !locked {
-		return daemon.RuntimeRecord{}, daemon.PingInfo{}, ctx.Err()
-	}
-	defer func() { _ = lock.Unlock() }()
-
-	token, err := runtimelock.EnsureAuthToken(l.dataDir)
-	if err != nil {
-		return daemon.RuntimeRecord{}, daemon.PingInfo{}, fmt.Errorf(
-			"ensure auth token: %w", err,
-		)
-	}
-	l.token = token
-	if record, ping, ok, err := l.find(ctx); err != nil || ok {
-		return record, ping, err
-	}
-	if l.start == nil {
-		return daemon.RuntimeRecord{}, daemon.PingInfo{}, errors.New("middleman daemon is not running")
-	}
-	if err := l.start(ctx); err != nil {
-		return daemon.RuntimeRecord{}, daemon.PingInfo{}, fmt.Errorf("start middleman daemon: %w", err)
-	}
-
-	ticker := time.NewTicker(backgroundProbeTick)
-	defer ticker.Stop()
-	for {
-		record, ping, ok, err := l.find(ctx)
-		if err != nil {
-			return daemon.RuntimeRecord{}, daemon.PingInfo{}, err
-		}
-		if ok {
-			return record, ping, nil
-		}
-		select {
-		case <-ctx.Done():
-			return daemon.RuntimeRecord{}, daemon.PingInfo{}, fmt.Errorf(
-				"middleman failed to start within %s: %w", timeout, ctx.Err(),
-			)
-		case <-ticker.C:
-		}
+	return daemon.Manager{
+		Store:    daemonruntime.StartLockStore(discoveryStore, dataDir),
+		FindFunc: discovery.find,
+		Start: func(ctx context.Context) error {
+			if _, err := runtimelock.EnsureAuthToken(dataDir); err != nil {
+				return fmt.Errorf("ensure auth token: %w", err)
+			}
+			if start == nil {
+				return errors.New("middleman daemon is not running")
+			}
+			if err := start(ctx); err != nil {
+				return fmt.Errorf("start middleman daemon: %w", err)
+			}
+			return nil
+		},
 	}
 }
 
-func (l backgroundLifecycle) find(
+func (d backgroundDiscovery) find(
 	ctx context.Context,
 ) (daemon.RuntimeRecord, daemon.PingInfo, bool, error) {
-	records, err := l.store.List()
+	token, err := runtimelock.ReadAuthToken(d.dataDir)
+	if err != nil {
+		return daemon.RuntimeRecord{}, daemon.PingInfo{}, false, err
+	}
+	records, err := d.store.List()
 	if err != nil {
 		return daemon.RuntimeRecord{}, daemon.PingInfo{}, false, err
 	}
 	for _, record := range records {
-		ping, compatible, err := l.probe(ctx, record)
+		ping, compatible, err := d.probe(ctx, record, token)
 		if err != nil {
 			return daemon.RuntimeRecord{}, daemon.PingInfo{}, false, err
 		}
@@ -220,12 +174,12 @@ func (l backgroundLifecycle) find(
 	return daemon.RuntimeRecord{}, daemon.PingInfo{}, false, nil
 }
 
-func (l backgroundLifecycle) probe(
-	ctx context.Context, record daemon.RuntimeRecord,
+func (d backgroundDiscovery) probe(
+	ctx context.Context, record daemon.RuntimeRecord, token string,
 ) (daemon.PingInfo, bool, error) {
 	if !daemonruntime.Compatible(record, daemonruntime.MatchOptions{
-		DataDir:        l.dataDir,
-		TokenAvailable: l.token != "",
+		DataDir:        d.dataDir,
+		TokenAvailable: token != "",
 	}) {
 		return daemon.PingInfo{}, false, nil
 	}
@@ -236,7 +190,7 @@ func (l backgroundLifecycle) probe(
 		DisableKeepAlives: true,
 	})
 	client.Transport = daemonOriginTransport{
-		token: l.token, origin: endpoint.BaseURL(), base: client.Transport,
+		token: token, origin: endpoint.BaseURL(), base: client.Transport,
 	}
 	ping, err := daemon.ProbeHTTP(
 		ctx, client, endpoint.BaseURL(), daemon.ProbeOptions{
@@ -254,10 +208,10 @@ func (l backgroundLifecycle) probe(
 	if ping.PID != record.PID {
 		return daemon.PingInfo{}, false, nil
 	}
-	if record.Version != l.version || ping.Version != l.version {
+	if record.Version != d.version || ping.Version != d.version {
 		return daemon.PingInfo{}, false, fmt.Errorf(
 			"running middleman version %q is incompatible with %q",
-			ping.Version, l.version,
+			ping.Version, d.version,
 		)
 	}
 	return ping, true, nil

--- a/cmd/middleman/start_background.go
+++ b/cmd/middleman/start_background.go
@@ -68,9 +68,13 @@ func startBackground(
 	if err != nil {
 		return err
 	}
+	runtimeURL, err := daemonruntime.URL(record)
+	if err != nil {
+		return err
+	}
 	_, err = fmt.Fprintf(
 		stdout, "middleman running at %s (pid %d)\n",
-		record.Endpoint().BaseURL(), record.PID,
+		runtimeURL, record.PID,
 	)
 	return err
 }

--- a/cmd/middleman/start_background.go
+++ b/cmd/middleman/start_background.go
@@ -5,21 +5,19 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"os"
 	"path/filepath"
-	"strconv"
 	"time"
 
 	"github.com/gofrs/flock"
 	"github.com/spf13/cobra"
 	"go.kenn.io/kit/daemon"
 	"go.kenn.io/middleman/internal/config"
+	"go.kenn.io/middleman/internal/daemonruntime"
 	"go.kenn.io/middleman/internal/runtimelock"
 )
 
 const (
-	daemonServiceName      = "middleman"
 	backgroundStartTimeout = 90 * time.Second
 	backgroundProbeTimeout = 750 * time.Millisecond
 	backgroundProbeTick    = 50 * time.Millisecond
@@ -28,13 +26,11 @@ const (
 type backgroundRunner func(context.Context, string, io.Writer) error
 
 type backgroundLifecycle struct {
-	store         daemon.RuntimeStore
-	dataDir       string
-	token         string
-	authTokenPath string
-	version       string
-	prepare       func(*backgroundLifecycle) error
-	start         daemon.StartFunc
+	store   daemon.RuntimeStore
+	dataDir string
+	token   string
+	version string
+	start   daemon.StartFunc
 }
 
 func newStartCommand(run backgroundRunner, stdout io.Writer) *cobra.Command {
@@ -72,33 +68,19 @@ func startBackground(
 	if err := os.MkdirAll(cfg.DataDir, 0o700); err != nil {
 		return fmt.Errorf("create data directory %s: %w", cfg.DataDir, err)
 	}
-	dataDir, err := config.CanonicalDataDir(cfg.DataDir)
-	if err != nil {
-		return err
-	}
-	cfg.DataDir = dataDir
 	token, err := runtimelock.ReadAuthToken(cfg.DataDir)
 	if err != nil {
 		return fmt.Errorf("read auth token: %w", err)
 	}
-	runtimeDir, err := filepath.Abs(config.DefaultDataDir())
+	store, err := daemonruntime.Store()
 	if err != nil {
-		return fmt.Errorf("resolve runtime directory: %w", err)
+		return err
 	}
 	lifecycle := backgroundLifecycle{
-		store:         daemon.RuntimeStore{Dir: runtimeDir},
-		dataDir:       cfg.DataDir,
-		token:         token,
-		authTokenPath: runtimelock.AuthTokenPath(cfg.DataDir),
-		version:       version,
-		prepare: func(l *backgroundLifecycle) error {
-			token, err := runtimelock.EnsureAuthToken(cfg.DataDir)
-			if err != nil {
-				return fmt.Errorf("ensure auth token: %w", err)
-			}
-			l.token = token
-			return nil
-		},
+		store:   store,
+		dataDir: cfg.DataDir,
+		token:   token,
+		version: version,
 		start: func(ctx context.Context) error {
 			return startBackgroundProcess(ctx, configPath, cfg.DataDir)
 		},
@@ -166,7 +148,7 @@ func (l backgroundLifecycle) Ensure(
 	if record, ping, ok, err := l.find(ctx); err != nil || ok {
 		return record, ping, err
 	}
-	lockPath, err := l.store.LockPath()
+	lockPath, err := daemonruntime.StartLockStore(l.store, l.dataDir).LockPath()
 	if err != nil {
 		return daemon.RuntimeRecord{}, daemon.PingInfo{}, err
 	}
@@ -182,11 +164,13 @@ func (l backgroundLifecycle) Ensure(
 	}
 	defer func() { _ = lock.Unlock() }()
 
-	if l.prepare != nil {
-		if err := l.prepare(&l); err != nil {
-			return daemon.RuntimeRecord{}, daemon.PingInfo{}, err
-		}
+	token, err := runtimelock.EnsureAuthToken(l.dataDir)
+	if err != nil {
+		return daemon.RuntimeRecord{}, daemon.PingInfo{}, fmt.Errorf(
+			"ensure auth token: %w", err,
+		)
 	}
+	l.token = token
 	if record, ping, ok, err := l.find(ctx); err != nil || ok {
 		return record, ping, err
 	}
@@ -239,29 +223,10 @@ func (l backgroundLifecycle) find(
 func (l backgroundLifecycle) probe(
 	ctx context.Context, record daemon.RuntimeRecord,
 ) (daemon.PingInfo, bool, error) {
-	if record.Service != daemonServiceName || record.Network != daemon.NetworkTCP ||
-		record.Metadata["data_dir"] != l.dataDir || !daemon.ProcessAlive(record.PID) {
-		return daemon.PingInfo{}, false, nil
-	}
-	if err := daemon.RequireLoopback(record.Address); err != nil {
-		return daemon.PingInfo{}, false, nil
-	}
-	host, port, err := net.SplitHostPort(record.Address)
-	if err != nil || record.Metadata["host"] != host || record.Metadata["port"] != port {
-		return daemon.PingInfo{}, false, nil
-	}
-	readOnly, err := strconv.ParseBool(record.Metadata["read_only"])
-	if err != nil || readOnly {
-		return daemon.PingInfo{}, false, nil
-	}
-	requireAuth, err := strconv.ParseBool(record.Metadata["require_auth"])
-	if err != nil {
-		return daemon.PingInfo{}, false, nil
-	}
-	if requireAuth && (l.token == "" || record.Metadata["auth_token_path"] != l.authTokenPath) {
-		return daemon.PingInfo{}, false, nil
-	}
-	if !requireAuth && record.Metadata["auth_token_path"] != "" {
+	if !daemonruntime.Compatible(record, daemonruntime.MatchOptions{
+		DataDir:        l.dataDir,
+		TokenAvailable: l.token != "",
+	}) {
 		return daemon.PingInfo{}, false, nil
 	}
 
@@ -276,7 +241,7 @@ func (l backgroundLifecycle) probe(
 	ping, err := daemon.ProbeHTTP(
 		ctx, client, endpoint.BaseURL(), daemon.ProbeOptions{
 			Path:            "/api/ping",
-			ExpectedService: daemonServiceName,
+			ExpectedService: daemonruntime.Service,
 			Timeout:         backgroundProbeTimeout,
 		},
 	)

--- a/cmd/middleman/start_background.go
+++ b/cmd/middleman/start_background.go
@@ -1,0 +1,299 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/gofrs/flock"
+	"github.com/spf13/cobra"
+	"go.kenn.io/kit/daemon"
+	"go.kenn.io/middleman/internal/config"
+	"go.kenn.io/middleman/internal/runtimelock"
+)
+
+const (
+	daemonServiceName      = "middleman"
+	backgroundStartTimeout = 90 * time.Second
+	backgroundProbeTimeout = 750 * time.Millisecond
+	backgroundProbeTick    = 50 * time.Millisecond
+)
+
+type backgroundRunner func(context.Context, string, io.Writer) error
+
+type backgroundLifecycle struct {
+	store         daemon.RuntimeStore
+	dataDir       string
+	token         string
+	authTokenPath string
+	version       string
+	prepare       func(*backgroundLifecycle) error
+	start         daemon.StartFunc
+}
+
+func newStartCommand(run backgroundRunner, stdout io.Writer) *cobra.Command {
+	var background bool
+	var configPath string
+	cmd := &cobra.Command{
+		Use:   "start",
+		Short: "Ensure the middleman daemon is running",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if !background {
+				return errors.New("start requires --background")
+			}
+			return run(cmd.Context(), configPath, stdout)
+		},
+	}
+	cmd.Flags().BoolVar(&background, "background", false, "start in the background")
+	cmd.Flags().StringVar(&configPath, "config", config.DefaultConfigPath(), "path to config file")
+	return cmd
+}
+
+func startBackground(
+	ctx context.Context, configPath string, stdout io.Writer,
+) error {
+	if err := config.EnsureDefault(configPath); err != nil {
+		return fmt.Errorf("ensure config: %w", err)
+	}
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	if err := validateBackgroundConfig(cfg); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(cfg.DataDir, 0o700); err != nil {
+		return fmt.Errorf("create data directory %s: %w", cfg.DataDir, err)
+	}
+	dataDir, err := config.CanonicalDataDir(cfg.DataDir)
+	if err != nil {
+		return err
+	}
+	cfg.DataDir = dataDir
+	token, err := runtimelock.ReadAuthToken(cfg.DataDir)
+	if err != nil {
+		return fmt.Errorf("read auth token: %w", err)
+	}
+	runtimeDir, err := filepath.Abs(config.DefaultDataDir())
+	if err != nil {
+		return fmt.Errorf("resolve runtime directory: %w", err)
+	}
+	lifecycle := backgroundLifecycle{
+		store:         daemon.RuntimeStore{Dir: runtimeDir},
+		dataDir:       cfg.DataDir,
+		token:         token,
+		authTokenPath: runtimelock.AuthTokenPath(cfg.DataDir),
+		version:       version,
+		prepare: func(l *backgroundLifecycle) error {
+			token, err := runtimelock.EnsureAuthToken(cfg.DataDir)
+			if err != nil {
+				return fmt.Errorf("ensure auth token: %w", err)
+			}
+			l.token = token
+			return nil
+		},
+		start: func(ctx context.Context) error {
+			return startBackgroundProcess(ctx, configPath, cfg.DataDir)
+		},
+	}
+	record, _, err := lifecycle.Ensure(ctx, backgroundStartTimeout)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(
+		stdout, "middleman running at %s (pid %d)\n",
+		record.Endpoint().BaseURL(), record.PID,
+	)
+	return err
+}
+
+func validateBackgroundConfig(cfg *config.Config) error {
+	if !config.IsLoopbackHostname(cfg.Host) {
+		return fmt.Errorf(
+			"background start requires a loopback TCP listener, got %q",
+			cfg.Host,
+		)
+	}
+	if cfg.TrustReverseProxy && !cfg.API.RequireAuth {
+		return errors.New(
+			"background start with trust_reverse_proxy=true requires api.require_auth=true",
+		)
+	}
+	return nil
+}
+
+func startBackgroundProcess(
+	ctx context.Context, configPath, dataDir string,
+) error {
+	executable, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve middleman executable: %w", err)
+	}
+	logFile, err := os.OpenFile(
+		filepath.Join(dataDir, "middleman.background.log"),
+		os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600,
+	)
+	if err != nil {
+		return fmt.Errorf("open background log: %w", err)
+	}
+	defer func() { _ = logFile.Close() }()
+	return daemon.StartDetached(ctx, daemon.StartDetachedOptions{
+		Executable:      executable,
+		Args:            []string{"serve", "--config", configPath},
+		Env:             os.Environ(),
+		Stdout:          logFile,
+		Stderr:          logFile,
+		RefuseEphemeral: true,
+	})
+}
+
+func (l backgroundLifecycle) Ensure(
+	ctx context.Context, timeout time.Duration,
+) (daemon.RuntimeRecord, daemon.PingInfo, error) {
+	if timeout <= 0 {
+		timeout = backgroundStartTimeout
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	if record, ping, ok, err := l.find(ctx); err != nil || ok {
+		return record, ping, err
+	}
+	lockPath, err := l.store.LockPath()
+	if err != nil {
+		return daemon.RuntimeRecord{}, daemon.PingInfo{}, err
+	}
+	lock := flock.New(lockPath)
+	locked, err := lock.TryLockContext(ctx, backgroundProbeTick)
+	if err != nil {
+		return daemon.RuntimeRecord{}, daemon.PingInfo{}, fmt.Errorf(
+			"acquire daemon start lock: %w", err,
+		)
+	}
+	if !locked {
+		return daemon.RuntimeRecord{}, daemon.PingInfo{}, ctx.Err()
+	}
+	defer func() { _ = lock.Unlock() }()
+
+	if l.prepare != nil {
+		if err := l.prepare(&l); err != nil {
+			return daemon.RuntimeRecord{}, daemon.PingInfo{}, err
+		}
+	}
+	if record, ping, ok, err := l.find(ctx); err != nil || ok {
+		return record, ping, err
+	}
+	if l.start == nil {
+		return daemon.RuntimeRecord{}, daemon.PingInfo{}, errors.New("middleman daemon is not running")
+	}
+	if err := l.start(ctx); err != nil {
+		return daemon.RuntimeRecord{}, daemon.PingInfo{}, fmt.Errorf("start middleman daemon: %w", err)
+	}
+
+	ticker := time.NewTicker(backgroundProbeTick)
+	defer ticker.Stop()
+	for {
+		record, ping, ok, err := l.find(ctx)
+		if err != nil {
+			return daemon.RuntimeRecord{}, daemon.PingInfo{}, err
+		}
+		if ok {
+			return record, ping, nil
+		}
+		select {
+		case <-ctx.Done():
+			return daemon.RuntimeRecord{}, daemon.PingInfo{}, fmt.Errorf(
+				"middleman failed to start within %s: %w", timeout, ctx.Err(),
+			)
+		case <-ticker.C:
+		}
+	}
+}
+
+func (l backgroundLifecycle) find(
+	ctx context.Context,
+) (daemon.RuntimeRecord, daemon.PingInfo, bool, error) {
+	records, err := l.store.List()
+	if err != nil {
+		return daemon.RuntimeRecord{}, daemon.PingInfo{}, false, err
+	}
+	for _, record := range records {
+		ping, compatible, err := l.probe(ctx, record)
+		if err != nil {
+			return daemon.RuntimeRecord{}, daemon.PingInfo{}, false, err
+		}
+		if compatible {
+			return record, ping, true, nil
+		}
+	}
+	return daemon.RuntimeRecord{}, daemon.PingInfo{}, false, nil
+}
+
+func (l backgroundLifecycle) probe(
+	ctx context.Context, record daemon.RuntimeRecord,
+) (daemon.PingInfo, bool, error) {
+	if record.Service != daemonServiceName || record.Network != daemon.NetworkTCP ||
+		record.Metadata["data_dir"] != l.dataDir || !daemon.ProcessAlive(record.PID) {
+		return daemon.PingInfo{}, false, nil
+	}
+	if err := daemon.RequireLoopback(record.Address); err != nil {
+		return daemon.PingInfo{}, false, nil
+	}
+	host, port, err := net.SplitHostPort(record.Address)
+	if err != nil || record.Metadata["host"] != host || record.Metadata["port"] != port {
+		return daemon.PingInfo{}, false, nil
+	}
+	readOnly, err := strconv.ParseBool(record.Metadata["read_only"])
+	if err != nil || readOnly {
+		return daemon.PingInfo{}, false, nil
+	}
+	requireAuth, err := strconv.ParseBool(record.Metadata["require_auth"])
+	if err != nil {
+		return daemon.PingInfo{}, false, nil
+	}
+	if requireAuth && (l.token == "" || record.Metadata["auth_token_path"] != l.authTokenPath) {
+		return daemon.PingInfo{}, false, nil
+	}
+	if !requireAuth && record.Metadata["auth_token_path"] != "" {
+		return daemon.PingInfo{}, false, nil
+	}
+
+	endpoint := record.Endpoint()
+	client := endpoint.HTTPClient(daemon.HTTPClientOptions{
+		Timeout:           backgroundProbeTimeout,
+		DisableKeepAlives: true,
+	})
+	client.Transport = daemonOriginTransport{
+		token: l.token, origin: endpoint.BaseURL(), base: client.Transport,
+	}
+	ping, err := daemon.ProbeHTTP(
+		ctx, client, endpoint.BaseURL(), daemon.ProbeOptions{
+			Path:            "/api/ping",
+			ExpectedService: daemonServiceName,
+			Timeout:         backgroundProbeTimeout,
+		},
+	)
+	if err != nil {
+		if ctx.Err() != nil {
+			return daemon.PingInfo{}, false, ctx.Err()
+		}
+		return daemon.PingInfo{}, false, nil
+	}
+	if ping.PID != record.PID {
+		return daemon.PingInfo{}, false, nil
+	}
+	if record.Version != l.version || ping.Version != l.version {
+		return daemon.PingInfo{}, false, fmt.Errorf(
+			"running middleman version %q is incompatible with %q",
+			ping.Version, l.version,
+		)
+	}
+	return ping, true, nil
+}

--- a/cmd/middleman/start_background_test.go
+++ b/cmd/middleman/start_background_test.go
@@ -7,8 +7,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"path/filepath"
-	"runtime"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -19,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kit/daemon"
 	"go.kenn.io/middleman/internal/config"
+	"go.kenn.io/middleman/internal/runtimelock"
 )
 
 func TestValidateBackgroundConfigRejectsUnsafeDirectVerification(t *testing.T) {
@@ -51,30 +50,6 @@ func TestValidateBackgroundConfigRejectsUnsafeDirectVerification(t *testing.T) {
 	}
 }
 
-func TestCanonicalDataDirUsesOneFilesystemIdentity(t *testing.T) {
-	root := t.TempDir()
-	realDir := filepath.Join(root, "state")
-	require.NoError(t, os.Mkdir(realDir, 0o700))
-	t.Chdir(root)
-
-	relative, err := config.CanonicalDataDir("./state")
-	require.NoError(t, err)
-	absolute, err := config.CanonicalDataDir(realDir)
-	require.NoError(t, err)
-
-	assert.Equal(t, absolute, relative)
-	link := filepath.Join(root, "state-link")
-	if err := os.Symlink(realDir, link); err != nil {
-		if runtime.GOOS == "windows" {
-			return
-		}
-		require.NoError(t, err)
-	}
-	linked, err := config.CanonicalDataDir(link)
-	require.NoError(t, err)
-	assert.Equal(t, absolute, linked)
-}
-
 // TestBackgroundLifecycleSerializesConcurrentStarts protects the launch
 // owner invariant. If the shared start lock is removed or discovery is not
 // repeated under it, concurrent callers invoke the detached starter twice.
@@ -97,17 +72,19 @@ func TestBackgroundLifecycleSerializesConcurrentStarts(t *testing.T) {
 
 	runtimeDir := t.TempDir()
 	dataDir := t.TempDir()
+	require.NoError(os.WriteFile(
+		runtimelock.AuthTokenPath(dataDir), []byte(token+"\n"), 0o600,
+	))
 	store := daemon.RuntimeStore{Dir: runtimeDir}
 	startEntered := make(chan struct{})
 	releaseStart := make(chan struct{})
 	var enteredOnce sync.Once
 	var starts atomic.Int32
 	lifecycle := backgroundLifecycle{
-		store:         store,
-		dataDir:       dataDir,
-		token:         token,
-		authTokenPath: dataDir + "/auth_token",
-		version:       "v-test",
+		store:   store,
+		dataDir: dataDir,
+		token:   token,
+		version: "v-test",
 		start: func(context.Context) error {
 			starts.Add(1)
 			enteredOnce.Do(func() { close(startEntered) })
@@ -154,6 +131,58 @@ func TestBackgroundLifecycleSerializesConcurrentStarts(t *testing.T) {
 	assert.Equal(first.record.PID, second.record.PID)
 }
 
+// TestBackgroundLifecycleAllowsIndependentDataDirectoryStarts protects the
+// lock scope. A stalled launch for one data directory must not block an
+// unrelated instance that shares the config-home discovery directory.
+func TestBackgroundLifecycleAllowsIndependentDataDirectoryStarts(t *testing.T) {
+	store := daemon.RuntimeStore{Dir: t.TempDir()}
+	firstStarted := make(chan struct{})
+	secondStarted := make(chan struct{})
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	first := backgroundLifecycle{
+		store: store, dataDir: t.TempDir(), version: "v-test",
+		start: func(ctx context.Context) error {
+			close(firstStarted)
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	}
+	second := backgroundLifecycle{
+		store: store, dataDir: t.TempDir(), version: "v-test",
+		start: func(ctx context.Context) error {
+			close(secondStarted)
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	}
+
+	go func() {
+		_, _, _ = first.Ensure(ctx, 2*time.Second)
+	}()
+	require.Eventually(t, func() bool {
+		select {
+		case <-firstStarted:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+	go func() {
+		_, _, _ = second.Ensure(ctx, 2*time.Second)
+	}()
+
+	require.Eventually(t, func() bool {
+		select {
+		case <-secondStarted:
+			return true
+		default:
+			return false
+		}
+	}, 500*time.Millisecond, 10*time.Millisecond)
+}
+
 // TestBackgroundLifecycleRejectsUnverifiedLiveRecord protects the boundary
 // between process discovery and daemon identity. A live PID and plausible
 // metadata are insufficient until the authenticated ping succeeds.
@@ -192,7 +221,7 @@ func TestBackgroundLifecycleRejectsUnverifiedLiveRecord(t *testing.T) {
 	var starts atomic.Int32
 	lifecycle := backgroundLifecycle{
 		store: store, dataDir: dataDir, token: "daemon-secret",
-		authTokenPath: dataDir + "/auth_token", version: "v-test",
+		version: "v-test",
 		start: func(context.Context) error {
 			starts.Add(1)
 			allowPing.Store(true)

--- a/cmd/middleman/start_background_test.go
+++ b/cmd/middleman/start_background_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -17,32 +16,8 @@ import (
 )
 
 func TestValidateBackgroundConfigRejectsUnsafeDirectVerification(t *testing.T) {
-	tests := []struct {
-		name string
-		cfg  config.Config
-		want string
-	}{
-		{
-			name: "non-loopback listener",
-			cfg: config.Config{
-				Host: "192.0.2.1", API: config.API{RequireAuth: true},
-			},
-			want: "loopback TCP listener",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := validateBackgroundConfig(&tt.cfg)
-			require.ErrorContains(t, err, tt.want)
-		})
-	}
-}
-
-func TestValidateBackgroundConfigAllowsUnauthenticatedReverseProxy(t *testing.T) {
-	cfg := config.Config{Host: "127.0.0.1", TrustReverseProxy: true}
-
-	require.NoError(t, validateBackgroundConfig(&cfg))
+	err := validateBackgroundConfig(&config.Config{Host: "192.0.2.1"})
+	require.ErrorContains(t, err, "loopback TCP listener")
 }
 
 // TestBackgroundManagerRejectsMismatchedPingIdentity protects the attachment
@@ -53,15 +28,9 @@ func TestBackgroundManagerRejectsMismatchedPingIdentity(t *testing.T) {
 	require := require.New(t)
 	dataDir := t.TempDir()
 	token := "daemon-secret"
-	_, record := newBackgroundProofServer(t, dataDir, token, "v-real")
-	require.NoError(os.WriteFile(
-		runtimelock.AuthTokenPath(dataDir), []byte(token+"\n"), 0o600,
-	))
+	record := newBackgroundProofRecord(t, dataDir, token, "v-real")
 	record.Version = "v-claimed"
-	store := daemon.RuntimeStore{Dir: t.TempDir()}
-	_, err := store.Write(record)
-	require.NoError(err)
-	manager := daemonruntime.NewManager(store, dataDir, "v-claimed", nil)
+	manager := newDiscoveryManager(t, dataDir, token, record, "v-claimed")
 
 	_, _, found, err := manager.Find(t.Context())
 
@@ -79,11 +48,9 @@ func TestBackgroundDiscoveryDoesNotDiscloseBearerBeforeProof(t *testing.T) {
 	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests.Add(1)
 		receivedAuthorization.Store(r.Header.Get("Authorization"))
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprintf(w,
-			`{"ok":true,"service":"middleman","version":"v-test","pid":%d}`,
-			os.Getpid(),
-		)
+		daemon.NewPingHandler(daemon.PingHandlerOptions{
+			Service: daemonruntime.Service, Version: "v-test", PID: os.Getpid(),
+		}).ServeHTTP(w, r)
 	}))
 	t.Cleanup(attacker.Close)
 
@@ -94,14 +61,9 @@ func TestBackgroundDiscoveryDoesNotDiscloseBearerBeforeProof(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	record := identity.Record
-	require.NoError(t, os.WriteFile(
-		runtimelock.AuthTokenPath(dataDir), []byte("daemon-secret\n"), 0o600,
-	))
-	store := daemon.RuntimeStore{Dir: t.TempDir()}
-	_, err = store.Write(record)
-	require.NoError(t, err)
-	manager := daemonruntime.NewManager(store, dataDir, "v-test", nil)
+	manager := newDiscoveryManager(
+		t, dataDir, "daemon-secret", identity.Record, "v-test",
+	)
 
 	_, _, compatible, err := manager.Find(t.Context())
 
@@ -111,10 +73,26 @@ func TestBackgroundDiscoveryDoesNotDiscloseBearerBeforeProof(t *testing.T) {
 	assert.Empty(t, receivedAuthorization.Load())
 }
 
-func newBackgroundProofServer(
+func newDiscoveryManager(
+	t *testing.T,
+	dataDir, token string,
+	record daemon.RuntimeRecord,
+	version string,
+) daemon.Manager {
+	t.Helper()
+	require.NoError(t, os.WriteFile(
+		runtimelock.AuthTokenPath(dataDir), []byte(token+"\n"), 0o600,
+	))
+	store := daemon.RuntimeStore{Dir: t.TempDir()}
+	_, err := store.Write(record)
+	require.NoError(t, err)
+	return daemonruntime.NewManager(store, dataDir, version, nil)
+}
+
+func newBackgroundProofRecord(
 	t *testing.T,
 	dataDir, token, version string,
-) (*httptest.Server, daemon.RuntimeRecord) {
+) daemon.RuntimeRecord {
 	t.Helper()
 	server := httptest.NewUnstartedServer(nil)
 	identity, err := daemonruntime.NewIdentity(
@@ -131,5 +109,5 @@ func newBackgroundProofServer(
 	server.Config.Handler = ping
 	server.Start()
 	t.Cleanup(server.Close)
-	return server, record
+	return record
 }

--- a/cmd/middleman/start_background_test.go
+++ b/cmd/middleman/start_background_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kit/daemon"
 	"go.kenn.io/middleman/internal/config"
+	"go.kenn.io/middleman/internal/daemonruntime"
 	"go.kenn.io/middleman/internal/runtimelock"
 )
 
@@ -67,7 +68,7 @@ func TestBackgroundManagerSerializesConcurrentStarts(t *testing.T) {
 	releaseStart := make(chan struct{})
 	var enteredOnce sync.Once
 	var starts atomic.Int32
-	manager := newBackgroundManager(
+	manager := daemonruntime.NewManager(
 		store, dataDir, "v-test",
 		func(context.Context) error {
 			starts.Add(1)
@@ -112,7 +113,7 @@ func TestBackgroundManagerAllowsIndependentDataDirectoryStarts(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	t.Cleanup(cancel)
 
-	first := newBackgroundManager(
+	first := daemonruntime.NewManager(
 		store, t.TempDir(), "v-test",
 		func(ctx context.Context) error {
 			close(firstStarted)
@@ -120,7 +121,7 @@ func TestBackgroundManagerAllowsIndependentDataDirectoryStarts(t *testing.T) {
 			return ctx.Err()
 		},
 	)
-	second := newBackgroundManager(
+	second := daemonruntime.NewManager(
 		store, t.TempDir(), "v-test",
 		func(ctx context.Context) error {
 			close(secondStarted)
@@ -173,7 +174,7 @@ func TestBackgroundManagerRejectsUnverifiedLiveRecord(t *testing.T) {
 	_, err := store.Write(record)
 	require.NoError(err)
 	var starts atomic.Int32
-	manager := newBackgroundManager(
+	manager := daemonruntime.NewManager(
 		store, dataDir, "v-test",
 		func(context.Context) error {
 			starts.Add(1)
@@ -186,6 +187,30 @@ func TestBackgroundManagerRejectsUnverifiedLiveRecord(t *testing.T) {
 
 	require.NoError(err)
 	assert.Equal(t, int32(1), starts.Load())
+}
+
+// TestBackgroundManagerRejectsMismatchedPingIdentity protects the attachment
+// boundary rather than a particular implementation of the proof check. If all
+// identity validation is removed, a record for one runtime can claim another
+// live endpoint and background start will report the wrong daemon as success.
+func TestBackgroundManagerRejectsMismatchedPingIdentity(t *testing.T) {
+	require := require.New(t)
+	dataDir := t.TempDir()
+	token := "daemon-secret"
+	_, record := newBackgroundProofServer(t, dataDir, token, "v-real", nil)
+	require.NoError(os.WriteFile(
+		runtimelock.AuthTokenPath(dataDir), []byte(token+"\n"), 0o600,
+	))
+	record.Version = "v-claimed"
+	store := daemon.RuntimeStore{Dir: t.TempDir()}
+	_, err := store.Write(record)
+	require.NoError(err)
+	manager := daemonruntime.NewManager(store, dataDir, "v-claimed", nil)
+
+	_, _, found, err := manager.Find(t.Context())
+
+	require.NoError(err)
+	assert.False(t, found)
 }
 
 // TestBackgroundDiscoveryDoesNotDiscloseBearerBeforeProof protects the
@@ -221,9 +246,15 @@ func TestBackgroundDiscoveryDoesNotDiscloseBearerBeforeProof(t *testing.T) {
 			"auth_token_path": runtimelock.AuthTokenPath(dataDir),
 		},
 	}
-	discovery := backgroundDiscovery{dataDir: dataDir, version: "v-test"}
+	require.NoError(t, os.WriteFile(
+		runtimelock.AuthTokenPath(dataDir), []byte("daemon-secret\n"), 0o600,
+	))
+	store := daemon.RuntimeStore{Dir: t.TempDir()}
+	_, err := store.Write(record)
+	require.NoError(t, err)
+	manager := daemonruntime.NewManager(store, dataDir, "v-test", nil)
 
-	_, compatible, err := discovery.probe(t.Context(), record, "daemon-secret")
+	_, _, compatible, err := manager.Find(t.Context())
 
 	require.NoError(t, err)
 	assert.False(t, compatible)

--- a/cmd/middleman/start_background_test.go
+++ b/cmd/middleman/start_background_test.go
@@ -33,13 +33,6 @@ func TestValidateBackgroundConfigRejectsUnsafeDirectVerification(t *testing.T) {
 			},
 			want: "loopback TCP listener",
 		},
-		{
-			name: "unauthenticated reverse proxy",
-			cfg: config.Config{
-				Host: "127.0.0.1", TrustReverseProxy: true,
-			},
-			want: "require_auth=true",
-		},
 	}
 
 	for _, tt := range tests {
@@ -50,6 +43,12 @@ func TestValidateBackgroundConfigRejectsUnsafeDirectVerification(t *testing.T) {
 	}
 }
 
+func TestValidateBackgroundConfigAllowsUnauthenticatedReverseProxy(t *testing.T) {
+	cfg := config.Config{Host: "127.0.0.1", TrustReverseProxy: true}
+
+	require.NoError(t, validateBackgroundConfig(&cfg))
+}
+
 // TestBackgroundManagerSerializesConcurrentStarts protects the launch
 // owner invariant. If the shared start lock is removed or discovery is not
 // repeated under it, concurrent callers invoke the detached starter twice.
@@ -57,21 +56,9 @@ func TestBackgroundManagerSerializesConcurrentStarts(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	token := "daemon-secret"
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("Authorization") != "Bearer "+token {
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprintf(w,
-			`{"ok":true,"service":"middleman","version":"v-test","pid":%d}`,
-			os.Getpid(),
-		)
-	}))
-	t.Cleanup(server.Close)
-
 	runtimeDir := t.TempDir()
 	dataDir := t.TempDir()
+	_, record := newBackgroundProofServer(t, dataDir, token, "v-test", nil)
 	require.NoError(os.WriteFile(
 		runtimelock.AuthTokenPath(dataDir), []byte(token+"\n"), 0o600,
 	))
@@ -86,20 +73,7 @@ func TestBackgroundManagerSerializesConcurrentStarts(t *testing.T) {
 			starts.Add(1)
 			enteredOnce.Do(func() { close(startEntered) })
 			<-releaseStart
-			_, err := store.Write(daemon.RuntimeRecord{
-				PID: os.Getpid(), Network: daemon.NetworkTCP,
-				Address: server.Listener.Addr().String(),
-				Service: "middleman", Version: "v-test",
-				StartedAt: time.Now().UTC(),
-				Metadata: map[string]string{
-					"host":            "127.0.0.1",
-					"port":            strconv.Itoa(server.Listener.Addr().(*net.TCPAddr).Port),
-					"read_only":       "false",
-					"require_auth":    "true",
-					"data_dir":        dataDir,
-					"auth_token_path": dataDir + "/auth_token",
-				},
-			})
+			_, err := store.Write(record)
 			return err
 		},
 	)
@@ -186,34 +160,17 @@ func TestBackgroundManagerAllowsIndependentDataDirectoryStarts(t *testing.T) {
 func TestBackgroundManagerRejectsUnverifiedLiveRecord(t *testing.T) {
 	require := require.New(t)
 	var allowPing atomic.Bool
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		if !allowPing.Load() {
-			http.Error(w, "not ready", http.StatusServiceUnavailable)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprintf(w,
-			`{"ok":true,"service":"middleman","version":"v-test","pid":%d}`,
-			os.Getpid(),
-		)
-	}))
-	t.Cleanup(server.Close)
-
 	runtimeDir := t.TempDir()
 	dataDir := t.TempDir()
+	token := "daemon-secret"
+	_, record := newBackgroundProofServer(
+		t, dataDir, token, "v-test", allowPing.Load,
+	)
+	require.NoError(os.WriteFile(
+		runtimelock.AuthTokenPath(dataDir), []byte(token+"\n"), 0o600,
+	))
 	store := daemon.RuntimeStore{Dir: runtimeDir}
-	address := server.Listener.Addr().String()
-	host, port, err := net.SplitHostPort(address)
-	require.NoError(err)
-	_, err = store.Write(daemon.RuntimeRecord{
-		PID: os.Getpid(), Network: daemon.NetworkTCP, Address: address,
-		Service: "middleman", Version: "v-test", StartedAt: time.Now().UTC(),
-		Metadata: map[string]string{
-			"host": host, "port": port, "read_only": "false",
-			"require_auth": "true", "data_dir": dataDir,
-			"auth_token_path": dataDir + "/auth_token",
-		},
-	})
+	_, err := store.Write(record)
 	require.NoError(err)
 	var starts atomic.Int32
 	manager := newBackgroundManager(
@@ -229,4 +186,82 @@ func TestBackgroundManagerRejectsUnverifiedLiveRecord(t *testing.T) {
 
 	require.NoError(err)
 	assert.Equal(t, int32(1), starts.Load())
+}
+
+// TestBackgroundDiscoveryDoesNotDiscloseBearerBeforeProof protects the
+// credential boundary for stale runtime records. If discovery attaches the
+// bearer before the endpoint proves possession of the daemon token, a process
+// that inherits the recorded loopback port can steal the persistent token.
+func TestBackgroundDiscoveryDoesNotDiscloseBearerBeforeProof(t *testing.T) {
+	var receivedAuthorization atomic.Value
+	var requests atomic.Int32
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		receivedAuthorization.Store(r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w,
+			`{"ok":true,"service":"middleman","version":"v-test","pid":%d}`,
+			os.Getpid(),
+		)
+	}))
+	t.Cleanup(attacker.Close)
+
+	dataDir := t.TempDir()
+	record := daemon.RuntimeRecord{
+		PID: os.Getpid(), Network: daemon.NetworkTCP,
+		Address: attacker.Listener.Addr().String(),
+		Service: "middleman", Version: "v-test",
+		StartedAt: time.Now().UTC(),
+		Metadata: map[string]string{
+			"host":            attacker.Listener.Addr().(*net.TCPAddr).IP.String(),
+			"port":            strconv.Itoa(attacker.Listener.Addr().(*net.TCPAddr).Port),
+			"read_only":       "false",
+			"require_auth":    "true",
+			"data_dir":        dataDir,
+			"auth_token_path": runtimelock.AuthTokenPath(dataDir),
+		},
+	}
+	discovery := backgroundDiscovery{dataDir: dataDir, version: "v-test"}
+
+	_, compatible, err := discovery.probe(t.Context(), record, "daemon-secret")
+
+	require.NoError(t, err)
+	assert.False(t, compatible)
+	assert.NotZero(t, requests.Load())
+	assert.Empty(t, receivedAuthorization.Load())
+}
+
+func newBackgroundProofServer(
+	t *testing.T,
+	dataDir, token, version string,
+	ready func() bool,
+) (*httptest.Server, daemon.RuntimeRecord) {
+	t.Helper()
+	server := httptest.NewUnstartedServer(nil)
+	address := server.Listener.Addr().String()
+	host, port, err := net.SplitHostPort(address)
+	require.NoError(t, err)
+	record := daemon.RuntimeRecord{
+		PID: os.Getpid(), Network: daemon.NetworkTCP, Address: address,
+		Service: "middleman", Version: version, StartedAt: time.Now().UTC(),
+		Metadata: map[string]string{
+			"host": host, "port": port, "read_only": "false",
+			"require_auth": "true", "data_dir": dataDir,
+			"auth_token_path": runtimelock.AuthTokenPath(dataDir),
+		},
+	}
+	proof, err := daemon.NewProof([]byte(token))
+	require.NoError(t, err)
+	ping, err := proof.NewPingHandler(record)
+	require.NoError(t, err)
+	server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if ready != nil && !ready() {
+			http.Error(w, "not ready", http.StatusServiceUnavailable)
+			return
+		}
+		ping.ServeHTTP(w, r)
+	})
+	server.Start()
+	t.Cleanup(server.Close)
+	return server, record
 }

--- a/cmd/middleman/start_background_test.go
+++ b/cmd/middleman/start_background_test.go
@@ -1,0 +1,207 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/kit/daemon"
+	"go.kenn.io/middleman/internal/config"
+)
+
+func TestValidateBackgroundConfigRejectsUnsafeDirectVerification(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  config.Config
+		want string
+	}{
+		{
+			name: "non-loopback listener",
+			cfg: config.Config{
+				Host: "192.0.2.1", API: config.API{RequireAuth: true},
+			},
+			want: "loopback TCP listener",
+		},
+		{
+			name: "unauthenticated reverse proxy",
+			cfg: config.Config{
+				Host: "127.0.0.1", TrustReverseProxy: true,
+			},
+			want: "require_auth=true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateBackgroundConfig(&tt.cfg)
+			require.ErrorContains(t, err, tt.want)
+		})
+	}
+}
+
+func TestCanonicalDataDirUsesOneFilesystemIdentity(t *testing.T) {
+	root := t.TempDir()
+	realDir := filepath.Join(root, "state")
+	require.NoError(t, os.Mkdir(realDir, 0o700))
+	t.Chdir(root)
+
+	relative, err := config.CanonicalDataDir("./state")
+	require.NoError(t, err)
+	absolute, err := config.CanonicalDataDir(realDir)
+	require.NoError(t, err)
+
+	assert.Equal(t, absolute, relative)
+	link := filepath.Join(root, "state-link")
+	if err := os.Symlink(realDir, link); err != nil {
+		if runtime.GOOS == "windows" {
+			return
+		}
+		require.NoError(t, err)
+	}
+	linked, err := config.CanonicalDataDir(link)
+	require.NoError(t, err)
+	assert.Equal(t, absolute, linked)
+}
+
+// TestBackgroundLifecycleSerializesConcurrentStarts protects the launch
+// owner invariant. If the shared start lock is removed or discovery is not
+// repeated under it, concurrent callers invoke the detached starter twice.
+func TestBackgroundLifecycleSerializesConcurrentStarts(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	token := "daemon-secret"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+token {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w,
+			`{"ok":true,"service":"middleman","version":"v-test","pid":%d}`,
+			os.Getpid(),
+		)
+	}))
+	t.Cleanup(server.Close)
+
+	runtimeDir := t.TempDir()
+	dataDir := t.TempDir()
+	store := daemon.RuntimeStore{Dir: runtimeDir}
+	startEntered := make(chan struct{})
+	releaseStart := make(chan struct{})
+	var enteredOnce sync.Once
+	var starts atomic.Int32
+	lifecycle := backgroundLifecycle{
+		store:         store,
+		dataDir:       dataDir,
+		token:         token,
+		authTokenPath: dataDir + "/auth_token",
+		version:       "v-test",
+		start: func(context.Context) error {
+			starts.Add(1)
+			enteredOnce.Do(func() { close(startEntered) })
+			<-releaseStart
+			_, err := store.Write(daemon.RuntimeRecord{
+				PID: os.Getpid(), Network: daemon.NetworkTCP,
+				Address: server.Listener.Addr().String(),
+				Service: "middleman", Version: "v-test",
+				StartedAt: time.Now().UTC(),
+				Metadata: map[string]string{
+					"host":            "127.0.0.1",
+					"port":            strconv.Itoa(server.Listener.Addr().(*net.TCPAddr).Port),
+					"read_only":       "false",
+					"require_auth":    "true",
+					"data_dir":        dataDir,
+					"auth_token_path": dataDir + "/auth_token",
+				},
+			})
+			return err
+		},
+	}
+
+	type result struct {
+		record daemon.RuntimeRecord
+		err    error
+	}
+	results := make(chan result, 2)
+	go func() {
+		record, _, err := lifecycle.Ensure(t.Context(), time.Second)
+		results <- result{record: record, err: err}
+	}()
+	<-startEntered
+	go func() {
+		record, _, err := lifecycle.Ensure(t.Context(), time.Second)
+		results <- result{record: record, err: err}
+	}()
+	close(releaseStart)
+
+	first := <-results
+	second := <-results
+	require.NoError(first.err)
+	require.NoError(second.err)
+	assert.Equal(int32(1), starts.Load())
+	assert.Equal(first.record.PID, second.record.PID)
+}
+
+// TestBackgroundLifecycleRejectsUnverifiedLiveRecord protects the boundary
+// between process discovery and daemon identity. A live PID and plausible
+// metadata are insufficient until the authenticated ping succeeds.
+func TestBackgroundLifecycleRejectsUnverifiedLiveRecord(t *testing.T) {
+	require := require.New(t)
+	var allowPing atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if !allowPing.Load() {
+			http.Error(w, "not ready", http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w,
+			`{"ok":true,"service":"middleman","version":"v-test","pid":%d}`,
+			os.Getpid(),
+		)
+	}))
+	t.Cleanup(server.Close)
+
+	runtimeDir := t.TempDir()
+	dataDir := t.TempDir()
+	store := daemon.RuntimeStore{Dir: runtimeDir}
+	address := server.Listener.Addr().String()
+	host, port, err := net.SplitHostPort(address)
+	require.NoError(err)
+	_, err = store.Write(daemon.RuntimeRecord{
+		PID: os.Getpid(), Network: daemon.NetworkTCP, Address: address,
+		Service: "middleman", Version: "v-test", StartedAt: time.Now().UTC(),
+		Metadata: map[string]string{
+			"host": host, "port": port, "read_only": "false",
+			"require_auth": "true", "data_dir": dataDir,
+			"auth_token_path": dataDir + "/auth_token",
+		},
+	})
+	require.NoError(err)
+	var starts atomic.Int32
+	lifecycle := backgroundLifecycle{
+		store: store, dataDir: dataDir, token: "daemon-secret",
+		authTokenPath: dataDir + "/auth_token", version: "v-test",
+		start: func(context.Context) error {
+			starts.Add(1)
+			allowPing.Store(true)
+			return nil
+		},
+	}
+
+	_, _, err = lifecycle.Ensure(t.Context(), time.Second)
+
+	require.NoError(err)
+	assert.Equal(t, int32(1), starts.Load())
+}

--- a/cmd/middleman/start_background_test.go
+++ b/cmd/middleman/start_background_test.go
@@ -50,10 +50,10 @@ func TestValidateBackgroundConfigRejectsUnsafeDirectVerification(t *testing.T) {
 	}
 }
 
-// TestBackgroundLifecycleSerializesConcurrentStarts protects the launch
+// TestBackgroundManagerSerializesConcurrentStarts protects the launch
 // owner invariant. If the shared start lock is removed or discovery is not
 // repeated under it, concurrent callers invoke the detached starter twice.
-func TestBackgroundLifecycleSerializesConcurrentStarts(t *testing.T) {
+func TestBackgroundManagerSerializesConcurrentStarts(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	token := "daemon-secret"
@@ -80,12 +80,9 @@ func TestBackgroundLifecycleSerializesConcurrentStarts(t *testing.T) {
 	releaseStart := make(chan struct{})
 	var enteredOnce sync.Once
 	var starts atomic.Int32
-	lifecycle := backgroundLifecycle{
-		store:   store,
-		dataDir: dataDir,
-		token:   token,
-		version: "v-test",
-		start: func(context.Context) error {
+	manager := newBackgroundManager(
+		store, dataDir, "v-test",
+		func(context.Context) error {
 			starts.Add(1)
 			enteredOnce.Do(func() { close(startEntered) })
 			<-releaseStart
@@ -105,7 +102,7 @@ func TestBackgroundLifecycleSerializesConcurrentStarts(t *testing.T) {
 			})
 			return err
 		},
-	}
+	)
 
 	type result struct {
 		record daemon.RuntimeRecord
@@ -113,12 +110,12 @@ func TestBackgroundLifecycleSerializesConcurrentStarts(t *testing.T) {
 	}
 	results := make(chan result, 2)
 	go func() {
-		record, _, err := lifecycle.Ensure(t.Context(), time.Second)
+		record, _, err := manager.Ensure(t.Context(), time.Second)
 		results <- result{record: record, err: err}
 	}()
 	<-startEntered
 	go func() {
-		record, _, err := lifecycle.Ensure(t.Context(), time.Second)
+		record, _, err := manager.Ensure(t.Context(), time.Second)
 		results <- result{record: record, err: err}
 	}()
 	close(releaseStart)
@@ -131,32 +128,32 @@ func TestBackgroundLifecycleSerializesConcurrentStarts(t *testing.T) {
 	assert.Equal(first.record.PID, second.record.PID)
 }
 
-// TestBackgroundLifecycleAllowsIndependentDataDirectoryStarts protects the
+// TestBackgroundManagerAllowsIndependentDataDirectoryStarts protects the
 // lock scope. A stalled launch for one data directory must not block an
 // unrelated instance that shares the config-home discovery directory.
-func TestBackgroundLifecycleAllowsIndependentDataDirectoryStarts(t *testing.T) {
+func TestBackgroundManagerAllowsIndependentDataDirectoryStarts(t *testing.T) {
 	store := daemon.RuntimeStore{Dir: t.TempDir()}
 	firstStarted := make(chan struct{})
 	secondStarted := make(chan struct{})
 	ctx, cancel := context.WithCancel(t.Context())
 	t.Cleanup(cancel)
 
-	first := backgroundLifecycle{
-		store: store, dataDir: t.TempDir(), version: "v-test",
-		start: func(ctx context.Context) error {
+	first := newBackgroundManager(
+		store, t.TempDir(), "v-test",
+		func(ctx context.Context) error {
 			close(firstStarted)
 			<-ctx.Done()
 			return ctx.Err()
 		},
-	}
-	second := backgroundLifecycle{
-		store: store, dataDir: t.TempDir(), version: "v-test",
-		start: func(ctx context.Context) error {
+	)
+	second := newBackgroundManager(
+		store, t.TempDir(), "v-test",
+		func(ctx context.Context) error {
 			close(secondStarted)
 			<-ctx.Done()
 			return ctx.Err()
 		},
-	}
+	)
 
 	go func() {
 		_, _, _ = first.Ensure(ctx, 2*time.Second)
@@ -183,10 +180,10 @@ func TestBackgroundLifecycleAllowsIndependentDataDirectoryStarts(t *testing.T) {
 	}, 500*time.Millisecond, 10*time.Millisecond)
 }
 
-// TestBackgroundLifecycleRejectsUnverifiedLiveRecord protects the boundary
+// TestBackgroundManagerRejectsUnverifiedLiveRecord protects the boundary
 // between process discovery and daemon identity. A live PID and plausible
 // metadata are insufficient until the authenticated ping succeeds.
-func TestBackgroundLifecycleRejectsUnverifiedLiveRecord(t *testing.T) {
+func TestBackgroundManagerRejectsUnverifiedLiveRecord(t *testing.T) {
 	require := require.New(t)
 	var allowPing atomic.Bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -219,17 +216,16 @@ func TestBackgroundLifecycleRejectsUnverifiedLiveRecord(t *testing.T) {
 	})
 	require.NoError(err)
 	var starts atomic.Int32
-	lifecycle := backgroundLifecycle{
-		store: store, dataDir: dataDir, token: "daemon-secret",
-		version: "v-test",
-		start: func(context.Context) error {
+	manager := newBackgroundManager(
+		store, dataDir, "v-test",
+		func(context.Context) error {
 			starts.Add(1)
 			allowPing.Store(true)
 			return nil
 		},
-	}
+	)
 
-	_, _, err = lifecycle.Ensure(t.Context(), time.Second)
+	_, _, err = manager.Ensure(t.Context(), time.Second)
 
 	require.NoError(err)
 	assert.Equal(t, int32(1), starts.Load())

--- a/cmd/middleman/start_background_test.go
+++ b/cmd/middleman/start_background_test.go
@@ -1,17 +1,12 @@
 package main
 
 import (
-	"context"
 	"fmt"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"strconv"
-	"sync"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -50,145 +45,6 @@ func TestValidateBackgroundConfigAllowsUnauthenticatedReverseProxy(t *testing.T)
 	require.NoError(t, validateBackgroundConfig(&cfg))
 }
 
-// TestBackgroundManagerSerializesConcurrentStarts protects the launch
-// owner invariant. If the shared start lock is removed or discovery is not
-// repeated under it, concurrent callers invoke the detached starter twice.
-func TestBackgroundManagerSerializesConcurrentStarts(t *testing.T) {
-	assert := assert.New(t)
-	require := require.New(t)
-	token := "daemon-secret"
-	runtimeDir := t.TempDir()
-	dataDir := t.TempDir()
-	_, record := newBackgroundProofServer(t, dataDir, token, "v-test", nil)
-	require.NoError(os.WriteFile(
-		runtimelock.AuthTokenPath(dataDir), []byte(token+"\n"), 0o600,
-	))
-	store := daemon.RuntimeStore{Dir: runtimeDir}
-	startEntered := make(chan struct{})
-	releaseStart := make(chan struct{})
-	var enteredOnce sync.Once
-	var starts atomic.Int32
-	manager := daemonruntime.NewManager(
-		store, dataDir, "v-test",
-		func(context.Context) error {
-			starts.Add(1)
-			enteredOnce.Do(func() { close(startEntered) })
-			<-releaseStart
-			_, err := store.Write(record)
-			return err
-		},
-	)
-
-	type result struct {
-		record daemon.RuntimeRecord
-		err    error
-	}
-	results := make(chan result, 2)
-	go func() {
-		record, _, err := manager.Ensure(t.Context(), time.Second)
-		results <- result{record: record, err: err}
-	}()
-	<-startEntered
-	go func() {
-		record, _, err := manager.Ensure(t.Context(), time.Second)
-		results <- result{record: record, err: err}
-	}()
-	close(releaseStart)
-
-	first := <-results
-	second := <-results
-	require.NoError(first.err)
-	require.NoError(second.err)
-	assert.Equal(int32(1), starts.Load())
-	assert.Equal(first.record.PID, second.record.PID)
-}
-
-// TestBackgroundManagerAllowsIndependentDataDirectoryStarts protects the
-// lock scope. A stalled launch for one data directory must not block an
-// unrelated instance that shares the config-home discovery directory.
-func TestBackgroundManagerAllowsIndependentDataDirectoryStarts(t *testing.T) {
-	store := daemon.RuntimeStore{Dir: t.TempDir()}
-	firstStarted := make(chan struct{})
-	secondStarted := make(chan struct{})
-	ctx, cancel := context.WithCancel(t.Context())
-	t.Cleanup(cancel)
-
-	first := daemonruntime.NewManager(
-		store, t.TempDir(), "v-test",
-		func(ctx context.Context) error {
-			close(firstStarted)
-			<-ctx.Done()
-			return ctx.Err()
-		},
-	)
-	second := daemonruntime.NewManager(
-		store, t.TempDir(), "v-test",
-		func(ctx context.Context) error {
-			close(secondStarted)
-			<-ctx.Done()
-			return ctx.Err()
-		},
-	)
-
-	go func() {
-		_, _, _ = first.Ensure(ctx, 2*time.Second)
-	}()
-	require.Eventually(t, func() bool {
-		select {
-		case <-firstStarted:
-			return true
-		default:
-			return false
-		}
-	}, time.Second, 10*time.Millisecond)
-	go func() {
-		_, _, _ = second.Ensure(ctx, 2*time.Second)
-	}()
-
-	require.Eventually(t, func() bool {
-		select {
-		case <-secondStarted:
-			return true
-		default:
-			return false
-		}
-	}, 500*time.Millisecond, 10*time.Millisecond)
-}
-
-// TestBackgroundManagerRejectsUnverifiedLiveRecord protects the boundary
-// between process discovery and daemon identity. A live PID and plausible
-// metadata are insufficient until the authenticated ping succeeds.
-func TestBackgroundManagerRejectsUnverifiedLiveRecord(t *testing.T) {
-	require := require.New(t)
-	var allowPing atomic.Bool
-	runtimeDir := t.TempDir()
-	dataDir := t.TempDir()
-	token := "daemon-secret"
-	_, record := newBackgroundProofServer(
-		t, dataDir, token, "v-test", allowPing.Load,
-	)
-	require.NoError(os.WriteFile(
-		runtimelock.AuthTokenPath(dataDir), []byte(token+"\n"), 0o600,
-	))
-	store := daemon.RuntimeStore{Dir: runtimeDir}
-	_, err := store.Write(record)
-	require.NoError(err)
-	var starts atomic.Int32
-	manager := daemonruntime.NewManager(
-		store, dataDir, "v-test",
-		func(context.Context) error {
-			starts.Add(1)
-			allowPing.Store(true)
-			return nil
-		},
-	)
-
-	_, _, err = manager.Ensure(t.Context(), time.Second)
-
-	require.NoError(err)
-	assert.Equal(t, int32(1), starts.Load())
-}
-
 // TestBackgroundManagerRejectsMismatchedPingIdentity protects the attachment
 // boundary rather than a particular implementation of the proof check. If all
 // identity validation is removed, a record for one runtime can claim another
@@ -197,7 +53,7 @@ func TestBackgroundManagerRejectsMismatchedPingIdentity(t *testing.T) {
 	require := require.New(t)
 	dataDir := t.TempDir()
 	token := "daemon-secret"
-	_, record := newBackgroundProofServer(t, dataDir, token, "v-real", nil)
+	_, record := newBackgroundProofServer(t, dataDir, token, "v-real")
 	require.NoError(os.WriteFile(
 		runtimelock.AuthTokenPath(dataDir), []byte(token+"\n"), 0o600,
 	))
@@ -232,25 +88,18 @@ func TestBackgroundDiscoveryDoesNotDiscloseBearerBeforeProof(t *testing.T) {
 	t.Cleanup(attacker.Close)
 
 	dataDir := t.TempDir()
-	record := daemon.RuntimeRecord{
-		PID: os.Getpid(), Network: daemon.NetworkTCP,
-		Address: attacker.Listener.Addr().String(),
-		Service: "middleman", Version: "v-test",
-		StartedAt: time.Now().UTC(),
-		Metadata: map[string]string{
-			"host":            attacker.Listener.Addr().(*net.TCPAddr).IP.String(),
-			"port":            strconv.Itoa(attacker.Listener.Addr().(*net.TCPAddr).Port),
-			"read_only":       "false",
-			"require_auth":    "true",
-			"data_dir":        dataDir,
-			"auth_token_path": runtimelock.AuthTokenPath(dataDir),
+	identity, err := daemonruntime.NewIdentity(
+		attacker.Listener.Addr(), daemonruntime.IdentityOptions{
+			Version: "v-test", DataDir: dataDir, RequireAuth: true,
 		},
-	}
+	)
+	require.NoError(t, err)
+	record := identity.Record
 	require.NoError(t, os.WriteFile(
 		runtimelock.AuthTokenPath(dataDir), []byte("daemon-secret\n"), 0o600,
 	))
 	store := daemon.RuntimeStore{Dir: t.TempDir()}
-	_, err := store.Write(record)
+	_, err = store.Write(record)
 	require.NoError(t, err)
 	manager := daemonruntime.NewManager(store, dataDir, "v-test", nil)
 
@@ -265,33 +114,21 @@ func TestBackgroundDiscoveryDoesNotDiscloseBearerBeforeProof(t *testing.T) {
 func newBackgroundProofServer(
 	t *testing.T,
 	dataDir, token, version string,
-	ready func() bool,
 ) (*httptest.Server, daemon.RuntimeRecord) {
 	t.Helper()
 	server := httptest.NewUnstartedServer(nil)
-	address := server.Listener.Addr().String()
-	host, port, err := net.SplitHostPort(address)
-	require.NoError(t, err)
-	record := daemon.RuntimeRecord{
-		PID: os.Getpid(), Network: daemon.NetworkTCP, Address: address,
-		Service: "middleman", Version: version, StartedAt: time.Now().UTC(),
-		Metadata: map[string]string{
-			"host": host, "port": port, "read_only": "false",
-			"require_auth": "true", "data_dir": dataDir,
-			"auth_token_path": runtimelock.AuthTokenPath(dataDir),
+	identity, err := daemonruntime.NewIdentity(
+		server.Listener.Addr(), daemonruntime.IdentityOptions{
+			Version: version, DataDir: dataDir, RequireAuth: true,
 		},
-	}
+	)
+	require.NoError(t, err)
+	record := identity.Record
 	proof, err := daemon.NewProof([]byte(token))
 	require.NoError(t, err)
 	ping, err := proof.NewPingHandler(record)
 	require.NoError(t, err)
-	server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if ready != nil && !ready() {
-			http.Error(w, "not ready", http.StatusServiceUnavailable)
-			return
-		}
-		ping.ServeHTTP(w, r)
-	})
+	server.Config.Handler = ping
 	server.Start()
 	t.Cleanup(server.Close)
 	return server, record

--- a/context/daemon-lifecycle.md
+++ b/context/daemon-lifecycle.md
@@ -7,7 +7,7 @@
 - `middleman start --background` is idempotent: reuse requires verified
   identity for the same resolved `data_dir`; starts serialize per data
   directory through the shared daemon manager without blocking unrelated
-  instances (`cmd/middleman/start_background.go::newBackgroundManager`).
+  instances (`internal/daemonruntime/lifecycle.go::NewManager`).
 - Config loading establishes the canonical `data_dir` identity used by startup
   and reload comparisons (`internal/config/config.go::load`).
 
@@ -38,4 +38,5 @@
   (`internal/server/daemon_access.go::daemonRequestPolicy.admit`).
 - Discovery sends only a random challenge until the endpoint proves the daemon
   token and full runtime identity; the proof route requires the exact direct
-  loopback authority without forwarding headers (`cmd/middleman/start_background.go::backgroundDiscovery.probe`).
+  loopback authority without forwarding headers
+  (`internal/daemonruntime/lifecycle.go::discovery.probe`).

--- a/context/daemon-lifecycle.md
+++ b/context/daemon-lifecycle.md
@@ -1,0 +1,34 @@
+# Daemon lifecycle
+
+## Startup contracts
+
+- `middleman` and `middleman serve` are raw foreground commands; their
+  authoritative `data_dir` lock keeps duplicate startup as an error.
+- `middleman start --background` is idempotent: reuse requires verified
+  identity for the same resolved `data_dir`, and concurrent starts serialize
+  token creation and launch (`cmd/middleman/start_background.go::Ensure`).
+
+## Discovery and readiness
+
+- Every ready server publishes the standard `daemon.<pid>.json` record in
+  config home, even when `config.toml` changes `data_dir`; the record is a
+  discovery surface and does not replace the authoritative data-directory
+  lock/status (`cmd/middleman/main.go::writeDaemonRuntimeRecord`).
+- Record metadata is string-valued `host`, `port`, `read_only=false`,
+  `require_auth`, and `data_dir`; `auth_token_path` is present only when auth is
+  enabled. Discovery still requires a live PID and authenticated ping.
+- `GET /api/ping` is registered only on the ready application handler and
+  returns the standard service, version, and PID identity
+  (`internal/server/daemon_ping.go::registerDaemonPing`).
+
+## Transport trust boundary
+
+- Loopback TCP is the required cross-platform transport; Unix sockets and
+  named pipes are not lifecycle requirements. Background startup rejects
+  non-loopback listeners before launching; proxy-trusting configurations also
+  require API authentication.
+- A direct request bypasses proxy Host interpretation only with the valid API
+  bearer, exact loopback listener authority, loopback peer, and no
+  `Forwarded` or `X-Forwarded-*` headers. Cookies never qualify, and requests
+  with forwarding metadata stay on the proxy path
+  (`internal/server/api_auth.go::isDirectDaemonBearerRequest`).

--- a/context/daemon-lifecycle.md
+++ b/context/daemon-lifecycle.md
@@ -21,8 +21,8 @@
   discovery surface and does not replace the authoritative data-directory
   lock/status (`internal/daemonruntime/runtime.go::Publish`).
 - Record metadata is string-valued `host`, `port`, `read_only=false`,
-  `require_auth`, and `data_dir`; `auth_token_path` is present only when auth is
-  enabled. Its producer and compatibility checks share one typed owner;
+  `require_auth`, `data_dir`, and canonical `base_path`; `auth_token_path` is
+  present only when auth is enabled. One typed owner builds and validates it;
   discovery still requires a live PID and a token-derived proof bound to the
   record's service, version, PID, network, and address
   (`internal/daemonruntime/runtime.go::Compatible`).

--- a/context/daemon-lifecycle.md
+++ b/context/daemon-lifecycle.md
@@ -5,18 +5,23 @@
 - `middleman` and `middleman serve` are raw foreground commands; their
   authoritative `data_dir` lock keeps duplicate startup as an error.
 - `middleman start --background` is idempotent: reuse requires verified
-  identity for the same resolved `data_dir`, and concurrent starts serialize
-  token creation and launch (`cmd/middleman/start_background.go::Ensure`).
+  identity for the same resolved `data_dir`; starts serialize per data
+  directory without blocking unrelated instances
+  (`cmd/middleman/start_background.go::Ensure`).
+- Config loading establishes the canonical `data_dir` identity used by startup
+  and reload comparisons (`internal/config/config.go::load`).
 
 ## Discovery and readiness
 
 - Every ready server publishes the standard `daemon.<pid>.json` record in
   config home, even when `config.toml` changes `data_dir`; the record is a
   discovery surface and does not replace the authoritative data-directory
-  lock/status (`cmd/middleman/main.go::writeDaemonRuntimeRecord`).
+  lock/status (`internal/daemonruntime/runtime.go::Publish`).
 - Record metadata is string-valued `host`, `port`, `read_only=false`,
   `require_auth`, and `data_dir`; `auth_token_path` is present only when auth is
-  enabled. Discovery still requires a live PID and authenticated ping.
+  enabled. Its producer and compatibility checks share one typed owner;
+  discovery still requires a live PID and authenticated ping
+  (`internal/daemonruntime/runtime.go::Compatible`).
 - `GET /api/ping` is registered only on the ready application handler and
   returns the standard service, version, and PID identity
   (`internal/server/daemon_ping.go::registerDaemonPing`).

--- a/context/daemon-lifecycle.md
+++ b/context/daemon-lifecycle.md
@@ -8,6 +8,9 @@
   identity for the same resolved `data_dir`; starts serialize per data
   directory through the shared daemon manager without blocking unrelated
   instances (`internal/daemonruntime/lifecycle.go::NewManager`).
+- Lifecycle startup mints the API token under the authoritative data-directory
+  lock; atomic serialized publication makes concurrent paths retain one
+  credential (`internal/runtimelock/token.go::EnsureAuthToken`).
 - Config loading establishes the canonical `data_dir` identity used by startup
   and reload comparisons (`internal/config/config.go::load`).
 

--- a/context/daemon-lifecycle.md
+++ b/context/daemon-lifecycle.md
@@ -25,7 +25,7 @@
   (`internal/daemonruntime/runtime.go::Compatible`).
 - The ready handler exposes standard identity at `GET /api/ping`; its private
   proof path binds the same identity to the published record and only accepts
-  direct loopback requests (`internal/server/daemon_ping.go::registerDaemonPing`).
+  direct loopback requests (`internal/server/daemon_access.go::daemonRequestPolicy.admit`).
 
 ## Transport trust boundary
 
@@ -34,7 +34,8 @@
   non-loopback listeners before launching.
 - Only the startup-bound bearer with exact loopback authority/peer and no
   forwarding headers bypasses proxy Host interpretation; cookies never qualify,
-  and the bearer remains available when general API auth is off (`internal/server/api_auth.go::isDirectDaemonBearerRequest`).
+  and the bearer remains available when general API auth is off
+  (`internal/server/daemon_access.go::daemonRequestPolicy.admit`).
 - Discovery sends only a random challenge until the endpoint proves the daemon
   token and full runtime identity; the proof route requires the exact direct
   loopback authority without forwarding headers (`cmd/middleman/start_background.go::backgroundDiscovery.probe`).

--- a/context/daemon-lifecycle.md
+++ b/context/daemon-lifecycle.md
@@ -20,20 +20,21 @@
 - Record metadata is string-valued `host`, `port`, `read_only=false`,
   `require_auth`, and `data_dir`; `auth_token_path` is present only when auth is
   enabled. Its producer and compatibility checks share one typed owner;
-  discovery still requires a live PID and authenticated ping
+  discovery still requires a live PID and a token-derived proof bound to the
+  record's service, version, PID, network, and address
   (`internal/daemonruntime/runtime.go::Compatible`).
-- `GET /api/ping` is registered only on the ready application handler and
-  returns the standard service, version, and PID identity
-  (`internal/server/daemon_ping.go::registerDaemonPing`).
+- The ready handler exposes standard identity at `GET /api/ping`; its private
+  proof path binds the same identity to the published record and only accepts
+  direct loopback requests (`internal/server/daemon_ping.go::registerDaemonPing`).
 
 ## Transport trust boundary
 
 - Loopback TCP is the required cross-platform transport; Unix sockets and
   named pipes are not lifecycle requirements. Background startup rejects
-  non-loopback listeners before launching; proxy-trusting configurations also
-  require API authentication.
-- A direct request bypasses proxy Host interpretation only with the valid API
-  bearer, exact loopback listener authority, loopback peer, and no
-  `Forwarded` or `X-Forwarded-*` headers. Cookies never qualify, and requests
-  with forwarding metadata stay on the proxy path
-  (`internal/server/api_auth.go::isDirectDaemonBearerRequest`).
+  non-loopback listeners before launching.
+- Only the startup-bound bearer with exact loopback authority/peer and no
+  forwarding headers bypasses proxy Host interpretation; cookies never qualify,
+  and the bearer remains available when general API auth is off (`internal/server/api_auth.go::isDirectDaemonBearerRequest`).
+- Discovery sends only a random challenge until the endpoint proves the daemon
+  token and full runtime identity; the proof route requires the exact direct
+  loopback authority without forwarding headers (`cmd/middleman/start_background.go::backgroundDiscovery.probe`).

--- a/context/daemon-lifecycle.md
+++ b/context/daemon-lifecycle.md
@@ -6,8 +6,8 @@
   authoritative `data_dir` lock keeps duplicate startup as an error.
 - `middleman start --background` is idempotent: reuse requires verified
   identity for the same resolved `data_dir`; starts serialize per data
-  directory without blocking unrelated instances
-  (`cmd/middleman/start_background.go::Ensure`).
+  directory through the shared daemon manager without blocking unrelated
+  instances (`cmd/middleman/start_background.go::newBackgroundManager`).
 - Config loading establishes the canonical `data_dir` identity used by startup
   and reload comparisons (`internal/config/config.go::load`).
 

--- a/context/testing.md
+++ b/context/testing.md
@@ -1,5 +1,11 @@
 # Testing
 
+## Local Go suite concurrency
+
+Run the full local suite through `make test`; its bounded package and test
+concurrency mirrors CI and avoids process-launch exhaustion on high-core hosts
+without serializing the suite (`Makefile::test`).
+
 ## Go assertion style
 
 Go tests use `testify` consistently. Import

--- a/context/testing.md
+++ b/context/testing.md
@@ -1,11 +1,5 @@
 # Testing
 
-## Local Go suite concurrency
-
-Run the full local suite through `make test`; its bounded package and test
-concurrency mirrors CI and avoids process-launch exhaustion on high-core hosts
-without serializing the suite (`Makefile::test`).
-
 ## Go assertion style
 
 Go tests use `testify` consistently. Import

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -20,9 +20,9 @@ middleman start --background --config /path/to/config.toml
 
 The command waits for the ready daemon identity before returning. Direct
 foreground starts retain their duplicate-process error behavior. Background
-startup requires a loopback listener; when `trust_reverse_proxy=true`, API
-authentication must also be enabled so direct readiness verification stays
-authenticated.
+startup requires a loopback listener. It verifies the recorded endpoint with a
+credential-free challenge before reusing the process, including when general
+API authentication is disabled.
 
 ## Version
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -10,6 +10,20 @@ middleman serve -config /path/to/config.toml
 
 Without a subcommand, `middleman` starts the daemon and web UI.
 
+Use the idempotent background lifecycle when a caller needs to ensure the app
+is available without treating an existing compatible process as an error:
+
+```sh
+middleman start --background
+middleman start --background --config /path/to/config.toml
+```
+
+The command waits for the ready daemon identity before returning. Direct
+foreground starts retain their duplicate-process error behavior. Background
+startup requires a loopback listener; when `trust_reverse_proxy=true`, API
+authentication must also be enabled so direct readiness verification stays
+authenticated.
+
 ## Version
 
 ```sh

--- a/docs/superpowers/specs/2026-05-19-host-origin-middleware-design.md
+++ b/docs/superpowers/specs/2026-05-19-host-origin-middleware-design.md
@@ -101,13 +101,20 @@ can drive both `GET` (read-out) and `POST` (write) attacks.
 
 One narrowly authenticated request class does not require a forwarded-host
 header when `trust_reverse_proxy=true`: a gated API request with the valid
-daemon `Authorization: Bearer` credential, no `Forwarded` header and no
-`X-Forwarded-*` header, the exact configured loopback listener authority in
-`Host`, and a loopback peer address. Session cookies do not qualify. This lets
-native local clients address the listener directly without claiming to be a
-reverse proxy. Every request that misses any condition follows the validation
-steps below unchanged; in particular, a request carrying forwarding metadata
-always stays on the reverse-proxy path.
+startup-bound daemon `Authorization: Bearer` credential, no `Forwarded` header
+and no `X-Forwarded-*` header, the exact configured loopback listener authority
+in `Host`, and a loopback peer address. The daemon token exists independently
+of the optional general API-authentication policy. Session cookies do not
+qualify. This lets native local clients address the listener directly without
+claiming to be a reverse proxy. Every request that misses any condition follows
+the validation steps below unchanged; in particular, a request carrying
+forwarding metadata always stays on the reverse-proxy path.
+
+Lifecycle discovery uses a narrower credential-free exception on the private
+ping-proof path. It requires the exact loopback listener authority, a loopback
+peer, and no forwarding headers. The endpoint answers a random challenge with
+an HMAC bound to the complete published runtime identity, so discovery can
+reject stale or redirected records before any bearer token is transmitted.
 
 Canonicalization: parse a host header value into a `hostKey` of
 `(lowercase_host, port_string_or_empty)`. IPv6 literals are wrapped

--- a/docs/superpowers/specs/2026-05-19-host-origin-middleware-design.md
+++ b/docs/superpowers/specs/2026-05-19-host-origin-middleware-design.md
@@ -94,11 +94,20 @@ listed.
 
 ## Validation flow
 
-The middleware runs FIRST on every request (before `checkCSRF`,
-before the `basePath` stripper, before any handler). Validation is
-identical for safe and unsafe methods — DNS rebinding can drive
-both `GET` (read-out) and `POST` (write) attacks, and the cost of
-validating GETs is negligible.
+Request classification runs before the Host decision, and Host validation
+still runs before `checkCSRF`, the `basePath` stripper, or any application
+handler. Validation is identical for safe and unsafe methods — DNS rebinding
+can drive both `GET` (read-out) and `POST` (write) attacks.
+
+One narrowly authenticated request class does not require a forwarded-host
+header when `trust_reverse_proxy=true`: a gated API request with the valid
+daemon `Authorization: Bearer` credential, no `Forwarded` header and no
+`X-Forwarded-*` header, the exact configured loopback listener authority in
+`Host`, and a loopback peer address. Session cookies do not qualify. This lets
+native local clients address the listener directly without claiming to be a
+reverse proxy. Every request that misses any condition follows the validation
+steps below unchanged; in particular, a request carrying forwarding metadata
+always stays on the reverse-proxy path.
 
 Canonicalization: parse a host header value into a `hostKey` of
 `(lowercase_host, port_string_or_empty)`. IPv6 literals are wrapped

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/yuin/goldmark v1.7.17
 	gitlab.com/gitlab-org/api/client-go/v2 v2.44.0
 	go.kenn.io/kata v0.11.1
-	go.kenn.io/kit v0.15.0
+	go.kenn.io/kit v0.16.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/yuin/goldmark v1.7.17
 	gitlab.com/gitlab-org/api/client-go/v2 v2.44.0
 	go.kenn.io/kata v0.11.1
-	go.kenn.io/kit v0.14.0
+	go.kenn.io/kit v0.15.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0

--- a/go.sum
+++ b/go.sum
@@ -599,8 +599,8 @@ gitlab.com/gitlab-org/api/client-go/v2 v2.44.0 h1:Vtv2WKC8p9BAygu5VCZlZUwDhTQ7UM
 gitlab.com/gitlab-org/api/client-go/v2 v2.44.0/go.mod h1:pTbeBowtVA+0/ZExWEZYUGOrpu5qlRN5ZyOUf27BnVY=
 go.kenn.io/kata v0.11.1 h1:eOyaHjdhjwwOKJfP45XL0/dmxR6j4NdEThZqbqZDTnw=
 go.kenn.io/kata v0.11.1/go.mod h1:ZC6PtwN1CiOXWcBYlBb4s2JX6N/v57TsgzoGcAwE7Uk=
-go.kenn.io/kit v0.14.0 h1:SYuPI4j+XDAlYBUGm7DbXtiycBPy7sOIkhT7r6pZgVs=
-go.kenn.io/kit v0.14.0/go.mod h1:VOdYooAwKWo4gRE3Uo4Qor21hjnye8oNKPZrs2DLfzQ=
+go.kenn.io/kit v0.15.0 h1:GaP0SO8Gd3yLzJ4w4F8w3JpOb9JCanQQlCwQXrvLaOg=
+go.kenn.io/kit v0.15.0/go.mod h1:VOdYooAwKWo4gRE3Uo4Qor21hjnye8oNKPZrs2DLfzQ=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/go.sum
+++ b/go.sum
@@ -599,8 +599,8 @@ gitlab.com/gitlab-org/api/client-go/v2 v2.44.0 h1:Vtv2WKC8p9BAygu5VCZlZUwDhTQ7UM
 gitlab.com/gitlab-org/api/client-go/v2 v2.44.0/go.mod h1:pTbeBowtVA+0/ZExWEZYUGOrpu5qlRN5ZyOUf27BnVY=
 go.kenn.io/kata v0.11.1 h1:eOyaHjdhjwwOKJfP45XL0/dmxR6j4NdEThZqbqZDTnw=
 go.kenn.io/kata v0.11.1/go.mod h1:ZC6PtwN1CiOXWcBYlBb4s2JX6N/v57TsgzoGcAwE7Uk=
-go.kenn.io/kit v0.15.0 h1:GaP0SO8Gd3yLzJ4w4F8w3JpOb9JCanQQlCwQXrvLaOg=
-go.kenn.io/kit v0.15.0/go.mod h1:VOdYooAwKWo4gRE3Uo4Qor21hjnye8oNKPZrs2DLfzQ=
+go.kenn.io/kit v0.16.0 h1:V7W6TroOV8vue/2Zow1EnW6/YN0W2UfrSgrhHN0jO0k=
+go.kenn.io/kit v0.16.0/go.mod h1:VOdYooAwKWo4gRE3Uo4Qor21hjnye8oNKPZrs2DLfzQ=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -807,7 +807,8 @@ type Config struct {
 	parsedAllowedHosts []HostKey
 	// parsedBindKey is the canonical (Host, Port) key for the bind
 	// address, populated by Validate.
-	parsedBindKey HostKey
+	parsedBindKey      HostKey
+	dataDirWasRelative bool
 }
 
 // API configures the HTTP API surface.
@@ -1139,6 +1140,12 @@ func load(path string) (*Config, error) {
 	if cfg.DataDir == "" {
 		cfg.DataDir = DefaultDataDir()
 	}
+	cfg.dataDirWasRelative = !filepath.IsAbs(cfg.DataDir)
+	canonicalDir, err := canonicalDataDir(cfg.DataDir)
+	if err != nil {
+		return nil, err
+	}
+	cfg.DataDir = canonicalDir
 
 	if cfg.Activity.ViewMode == "" {
 		cfg.Activity.ViewMode = defaultViewMode
@@ -1209,6 +1216,12 @@ func rejectDeprecatedConfigKeys(meta toml.MetaData) error {
 
 func (c *Config) Validate() error {
 	return c.validate()
+}
+
+// DataDirWasRelative reports whether data_dir was relative before loading
+// established its canonical runtime identity.
+func (c *Config) DataDirWasRelative() bool {
+	return c.dataDirWasRelative
 }
 
 // validate runs every config rule.

--- a/internal/config/data_dir.go
+++ b/internal/config/data_dir.go
@@ -1,0 +1,25 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// CanonicalDataDir returns one stable identity for a configured data directory.
+// Existing symlink aliases resolve to their target; a not-yet-created path is
+// still made absolute so reload comparisons do not depend on process cwd.
+func CanonicalDataDir(dataDir string) (string, error) {
+	absolute, err := filepath.Abs(dataDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve data directory: %w", err)
+	}
+	resolved, err := filepath.EvalSymlinks(absolute)
+	if err == nil {
+		return filepath.Clean(resolved), nil
+	}
+	if os.IsNotExist(err) {
+		return filepath.Clean(absolute), nil
+	}
+	return "", fmt.Errorf("resolve data directory symlinks: %w", err)
+}

--- a/internal/config/data_dir.go
+++ b/internal/config/data_dir.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 )
 
 // canonicalDataDir returns one stable identity for a configured data directory.
@@ -18,8 +19,28 @@ func canonicalDataDir(dataDir string) (string, error) {
 	if err == nil {
 		return filepath.Clean(resolved), nil
 	}
-	if os.IsNotExist(err) {
-		return filepath.Clean(absolute), nil
+	if !os.IsNotExist(err) {
+		return "", fmt.Errorf("resolve data directory symlinks: %w", err)
 	}
-	return "", fmt.Errorf("resolve data directory symlinks: %w", err)
+
+	missing := make([]string, 0, 2)
+	ancestor := absolute
+	for {
+		parent := filepath.Dir(ancestor)
+		if parent == ancestor {
+			return filepath.Clean(absolute), nil
+		}
+		missing = append(missing, filepath.Base(ancestor))
+		ancestor = parent
+		resolved, err = filepath.EvalSymlinks(ancestor)
+		if err == nil {
+			for _, component := range slices.Backward(missing) {
+				resolved = filepath.Join(resolved, component)
+			}
+			return filepath.Clean(resolved), nil
+		}
+		if !os.IsNotExist(err) {
+			return "", fmt.Errorf("resolve data directory symlinks: %w", err)
+		}
+	}
 }

--- a/internal/config/data_dir.go
+++ b/internal/config/data_dir.go
@@ -6,10 +6,10 @@ import (
 	"path/filepath"
 )
 
-// CanonicalDataDir returns one stable identity for a configured data directory.
+// canonicalDataDir returns one stable identity for a configured data directory.
 // Existing symlink aliases resolve to their target; a not-yet-created path is
 // still made absolute so reload comparisons do not depend on process cwd.
-func CanonicalDataDir(dataDir string) (string, error) {
+func canonicalDataDir(dataDir string) (string, error) {
 	absolute, err := filepath.Abs(dataDir)
 	if err != nil {
 		return "", fmt.Errorf("resolve data directory: %w", err)

--- a/internal/config/data_dir_test.go
+++ b/internal/config/data_dir_test.go
@@ -1,0 +1,31 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLoadCanonicalizesDataDir protects config identity at its owner. If
+// loading leaves a relative path untouched, startup and reload can compare the
+// same directory as two different instances after the working directory moves.
+func TestLoadCanonicalizesDataDir(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(root, "state"), 0o700))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "config.toml"),
+		[]byte("data_dir = \"./state\"\n"),
+		0o600,
+	))
+	t.Chdir(root)
+
+	cfg, err := Load(filepath.Join(root, "config.toml"))
+	require.NoError(t, err)
+	expected, err := filepath.EvalSymlinks(filepath.Join(root, "state"))
+	require.NoError(t, err)
+
+	assert.Equal(t, expected, cfg.DataDir)
+}

--- a/internal/config/data_dir_test.go
+++ b/internal/config/data_dir_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -28,4 +29,36 @@ func TestLoadCanonicalizesDataDir(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, expected, cfg.DataDir)
+}
+
+// TestLoadCanonicalizesMissingDataDirUnderSymlink protects startup identity.
+// If loading resolves the same configured directory differently before and
+// after creation, a background parent cannot discover the child it started.
+func TestLoadCanonicalizesMissingDataDirUnderSymlink(t *testing.T) {
+	require := require.New(t)
+	root := t.TempDir()
+	target := filepath.Join(root, "target")
+	alias := filepath.Join(root, "alias")
+	require.NoError(os.Mkdir(target, 0o700))
+	if err := os.Symlink(target, alias); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	resolvedTarget, err := filepath.EvalSymlinks(target)
+	require.NoError(err)
+	configured := filepath.Join(alias, "missing", "state")
+	configPath := filepath.Join(root, "config.toml")
+	require.NoError(os.WriteFile(
+		configPath,
+		fmt.Appendf(nil, "data_dir = %q\n", configured),
+		0o600,
+	))
+
+	before, err := Load(configPath)
+	require.NoError(err)
+	require.NoError(os.MkdirAll(before.DataDir, 0o700))
+	after, err := Load(configPath)
+	require.NoError(err)
+
+	require.Equal(filepath.Join(resolvedTarget, "missing", "state"), before.DataDir)
+	require.Equal(before.DataDir, after.DataDir)
 }

--- a/internal/daemonruntime/lifecycle.go
+++ b/internal/daemonruntime/lifecycle.go
@@ -1,0 +1,102 @@
+package daemonruntime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.kenn.io/kit/daemon"
+	"go.kenn.io/middleman/internal/runtimelock"
+)
+
+const probeTimeout = 750 * time.Millisecond
+
+type discovery struct {
+	store   daemon.RuntimeStore
+	dataDir string
+	version string
+}
+
+// NewManager returns the shared lifecycle manager with Middleman's discovery
+// identity and per-data-directory start lock.
+func NewManager(
+	store daemon.RuntimeStore,
+	dataDir, expectedVersion string,
+	start daemon.StartFunc,
+) daemon.Manager {
+	discovery := discovery{store: store, dataDir: dataDir, version: expectedVersion}
+	return daemon.Manager{
+		Store:    StartLockStore(store, dataDir),
+		FindFunc: discovery.find,
+		Start: func(ctx context.Context) error {
+			if _, err := runtimelock.EnsureAuthToken(dataDir); err != nil {
+				return fmt.Errorf("ensure auth token: %w", err)
+			}
+			if start == nil {
+				return errors.New("middleman daemon is not running")
+			}
+			if err := start(ctx); err != nil {
+				return fmt.Errorf("start middleman daemon: %w", err)
+			}
+			return nil
+		},
+	}
+}
+
+func (d discovery) find(
+	ctx context.Context,
+) (daemon.RuntimeRecord, daemon.PingInfo, bool, error) {
+	token, err := runtimelock.ReadAuthToken(d.dataDir)
+	if err != nil {
+		return daemon.RuntimeRecord{}, daemon.PingInfo{}, false, err
+	}
+	if token == "" {
+		return daemon.RuntimeRecord{}, daemon.PingInfo{}, false, nil
+	}
+	proof, err := daemon.NewProof([]byte(token))
+	if err != nil {
+		return daemon.RuntimeRecord{}, daemon.PingInfo{}, false,
+			fmt.Errorf("initialize daemon proof: %w", err)
+	}
+	records, err := d.store.List()
+	if err != nil {
+		return daemon.RuntimeRecord{}, daemon.PingInfo{}, false, err
+	}
+	for _, record := range records {
+		ping, compatible, err := d.probe(ctx, proof, record)
+		if err != nil {
+			return daemon.RuntimeRecord{}, daemon.PingInfo{}, false, err
+		}
+		if compatible {
+			return record, ping, true, nil
+		}
+	}
+	return daemon.RuntimeRecord{}, daemon.PingInfo{}, false, nil
+}
+
+func (d discovery) probe(
+	ctx context.Context,
+	proof *daemon.Proof,
+	record daemon.RuntimeRecord,
+) (daemon.PingInfo, bool, error) {
+	if !Compatible(record, d.dataDir) {
+		return daemon.PingInfo{}, false, nil
+	}
+	ping, err := proof.Probe(ctx, record, daemon.ProbeOptions{
+		Path: ProofPingPath, Timeout: probeTimeout,
+	})
+	if err != nil {
+		if ctx.Err() != nil {
+			return daemon.PingInfo{}, false, ctx.Err()
+		}
+		return daemon.PingInfo{}, false, nil
+	}
+	if record.Version != d.version {
+		return daemon.PingInfo{}, false, fmt.Errorf(
+			"running middleman version %q is incompatible with %q",
+			record.Version, d.version,
+		)
+	}
+	return ping, true, nil
+}

--- a/internal/daemonruntime/lifecycle.go
+++ b/internal/daemonruntime/lifecycle.go
@@ -30,9 +30,6 @@ func NewManager(
 		Store:    StartLockStore(store, dataDir),
 		FindFunc: discovery.find,
 		Start: func(ctx context.Context) error {
-			if _, err := runtimelock.EnsureAuthToken(dataDir); err != nil {
-				return fmt.Errorf("ensure auth token: %w", err)
-			}
 			if start == nil {
 				return errors.New("middleman daemon is not running")
 			}

--- a/internal/daemonruntime/runtime.go
+++ b/internal/daemonruntime/runtime.go
@@ -1,0 +1,120 @@
+// Package daemonruntime owns Middleman's standard kit daemon discovery record.
+package daemonruntime
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"net"
+	"path/filepath"
+	"strconv"
+
+	"go.kenn.io/kit/daemon"
+	"go.kenn.io/middleman/internal/config"
+	"go.kenn.io/middleman/internal/runtimelock"
+)
+
+const (
+	Service = "middleman"
+
+	metadataHost          = "host"
+	metadataPort          = "port"
+	metadataReadOnly      = "read_only"
+	metadataRequireAuth   = "require_auth"
+	metadataDataDir       = "data_dir"
+	metadataAuthTokenPath = "auth_token_path"
+)
+
+// PublishOptions contains the startup-bound identity written for discovery.
+type PublishOptions struct {
+	Address     string
+	Version     string
+	DataDir     string
+	RequireAuth bool
+}
+
+// MatchOptions contains the local identity required to attach to a record.
+type MatchOptions struct {
+	DataDir        string
+	TokenAvailable bool
+}
+
+// Store returns the predictable config-home discovery store.
+func Store() (daemon.RuntimeStore, error) {
+	runtimeDir, err := filepath.Abs(config.DefaultDataDir())
+	if err != nil {
+		return daemon.RuntimeStore{}, fmt.Errorf("resolve runtime directory: %w", err)
+	}
+	return daemon.RuntimeStore{Dir: runtimeDir}, nil
+}
+
+// StartLockStore returns the kit lock identity for one resolved data directory.
+// The digest avoids exposing filesystem paths in config-home filenames.
+func StartLockStore(discoveryStore daemon.RuntimeStore, dataDir string) daemon.RuntimeStore {
+	digest := sha256.Sum256([]byte(dataDir))
+	return daemon.RuntimeStore{
+		Dir:    discoveryStore.Dir,
+		Prefix: fmt.Sprintf("%s-start-%x", Service, digest[:16]),
+	}
+}
+
+// Publish writes the standard discovery record after the listener is bound.
+func Publish(opts PublishOptions) (string, error) {
+	host, port, err := net.SplitHostPort(opts.Address)
+	if err != nil {
+		return "", fmt.Errorf("listener address is not TCP: %w", err)
+	}
+	store, err := Store()
+	if err != nil {
+		return "", err
+	}
+	if _, err := store.CleanupDead(); err != nil {
+		return "", fmt.Errorf("clean stale daemon runtime records: %w", err)
+	}
+	record := daemon.NewRuntimeRecord(
+		Service,
+		opts.Version,
+		daemon.Endpoint{Network: daemon.NetworkTCP, Address: opts.Address},
+	)
+	record.Metadata = map[string]string{
+		metadataHost:        host,
+		metadataPort:        port,
+		metadataReadOnly:    strconv.FormatBool(false),
+		metadataRequireAuth: strconv.FormatBool(opts.RequireAuth),
+		metadataDataDir:     opts.DataDir,
+	}
+	if opts.RequireAuth {
+		record.Metadata[metadataAuthTokenPath] = runtimelock.AuthTokenPath(opts.DataDir)
+	}
+	return store.Write(record)
+}
+
+// Compatible reports whether a discovery record can represent the expected
+// local instance before the caller performs its authenticated readiness probe.
+func Compatible(record daemon.RuntimeRecord, opts MatchOptions) bool {
+	if record.Service != Service || record.Network != daemon.NetworkTCP ||
+		record.Metadata[metadataDataDir] != opts.DataDir ||
+		!daemon.ProcessAlive(record.PID) {
+		return false
+	}
+	if err := daemon.RequireLoopback(record.Address); err != nil {
+		return false
+	}
+	host, port, err := net.SplitHostPort(record.Address)
+	if err != nil || record.Metadata[metadataHost] != host ||
+		record.Metadata[metadataPort] != port {
+		return false
+	}
+	readOnly, err := strconv.ParseBool(record.Metadata[metadataReadOnly])
+	if err != nil || readOnly {
+		return false
+	}
+	requireAuth, err := strconv.ParseBool(record.Metadata[metadataRequireAuth])
+	if err != nil {
+		return false
+	}
+	if requireAuth {
+		return opts.TokenAvailable &&
+			record.Metadata[metadataAuthTokenPath] == runtimelock.AuthTokenPath(opts.DataDir)
+	}
+	return record.Metadata[metadataAuthTokenPath] == ""
+}

--- a/internal/daemonruntime/runtime.go
+++ b/internal/daemonruntime/runtime.go
@@ -14,7 +14,8 @@ import (
 )
 
 const (
-	Service = "middleman"
+	Service       = "middleman"
+	ProofPingPath = "/api/ping/proof"
 
 	metadataHost          = "host"
 	metadataPort          = "port"
@@ -57,18 +58,19 @@ func StartLockStore(discoveryStore daemon.RuntimeStore, dataDir string) daemon.R
 	}
 }
 
-// Publish writes the standard discovery record after the listener is bound.
-func Publish(opts PublishOptions) (string, error) {
+// Publish writes the standard discovery record after the listener is bound and
+// returns the exact identity that credential-free endpoint proof must bind.
+func Publish(opts PublishOptions) (daemon.RuntimeRecord, string, error) {
 	host, port, err := net.SplitHostPort(opts.Address)
 	if err != nil {
-		return "", fmt.Errorf("listener address is not TCP: %w", err)
+		return daemon.RuntimeRecord{}, "", fmt.Errorf("listener address is not TCP: %w", err)
 	}
 	store, err := Store()
 	if err != nil {
-		return "", err
+		return daemon.RuntimeRecord{}, "", err
 	}
 	if _, err := store.CleanupDead(); err != nil {
-		return "", fmt.Errorf("clean stale daemon runtime records: %w", err)
+		return daemon.RuntimeRecord{}, "", fmt.Errorf("clean stale daemon runtime records: %w", err)
 	}
 	record := daemon.NewRuntimeRecord(
 		Service,
@@ -85,7 +87,8 @@ func Publish(opts PublishOptions) (string, error) {
 	if opts.RequireAuth {
 		record.Metadata[metadataAuthTokenPath] = runtimelock.AuthTokenPath(opts.DataDir)
 	}
-	return store.Write(record)
+	path, err := store.Write(record)
+	return record, path, err
 }
 
 // Compatible reports whether a discovery record can represent the expected

--- a/internal/daemonruntime/runtime.go
+++ b/internal/daemonruntime/runtime.go
@@ -33,12 +33,6 @@ type PublishOptions struct {
 	RequireAuth bool
 }
 
-// MatchOptions contains the local identity required to attach to a record.
-type MatchOptions struct {
-	DataDir        string
-	TokenAvailable bool
-}
-
 // Store returns the predictable config-home discovery store.
 func Store() (daemon.RuntimeStore, error) {
 	runtimeDir, err := filepath.Abs(config.DefaultDataDir())
@@ -93,9 +87,9 @@ func Publish(opts PublishOptions) (daemon.RuntimeRecord, string, error) {
 
 // Compatible reports whether a discovery record can represent the expected
 // local instance before the caller performs its authenticated readiness probe.
-func Compatible(record daemon.RuntimeRecord, opts MatchOptions) bool {
+func Compatible(record daemon.RuntimeRecord, dataDir string) bool {
 	if record.Service != Service || record.Network != daemon.NetworkTCP ||
-		record.Metadata[metadataDataDir] != opts.DataDir ||
+		record.Metadata[metadataDataDir] != dataDir ||
 		!daemon.ProcessAlive(record.PID) {
 		return false
 	}
@@ -116,8 +110,7 @@ func Compatible(record daemon.RuntimeRecord, opts MatchOptions) bool {
 		return false
 	}
 	if requireAuth {
-		return opts.TokenAvailable &&
-			record.Metadata[metadataAuthTokenPath] == runtimelock.AuthTokenPath(opts.DataDir)
+		return record.Metadata[metadataAuthTokenPath] == runtimelock.AuthTokenPath(dataDir)
 	}
 	return record.Metadata[metadataAuthTokenPath] == ""
 }

--- a/internal/daemonruntime/runtime.go
+++ b/internal/daemonruntime/runtime.go
@@ -7,6 +7,8 @@ import (
 	"net"
 	"path/filepath"
 	"strconv"
+	"strings"
+	"time"
 
 	"go.kenn.io/kit/daemon"
 	"go.kenn.io/middleman/internal/config"
@@ -25,12 +27,21 @@ const (
 	metadataAuthTokenPath = "auth_token_path"
 )
 
-// PublishOptions contains the startup-bound identity written for discovery.
-type PublishOptions struct {
-	Address     string
+// IdentityOptions contains the startup-bound values shared by both runtime
+// discovery surfaces.
+type IdentityOptions struct {
 	Version     string
+	Commit      string
 	DataDir     string
+	BasePath    string
 	RequireAuth bool
+}
+
+// Identity is the single startup identity serialized to the authoritative
+// data-directory status and the generic kit discovery store.
+type Identity struct {
+	Record       daemon.RuntimeRecord
+	LockMetadata runtimelock.Metadata
 }
 
 // Store returns the predictable config-home discovery store.
@@ -52,24 +63,19 @@ func StartLockStore(discoveryStore daemon.RuntimeStore, dataDir string) daemon.R
 	}
 }
 
-// Publish writes the standard discovery record after the listener is bound and
-// returns the exact identity that credential-free endpoint proof must bind.
-func Publish(opts PublishOptions) (daemon.RuntimeRecord, string, error) {
-	host, port, err := net.SplitHostPort(opts.Address)
-	if err != nil {
-		return daemon.RuntimeRecord{}, "", fmt.Errorf("listener address is not TCP: %w", err)
+// NewIdentity derives both discovery representations from one bound TCP
+// listener address and process snapshot.
+func NewIdentity(address net.Addr, opts IdentityOptions) (Identity, error) {
+	tcpAddress, ok := address.(*net.TCPAddr)
+	if !ok {
+		return Identity{}, fmt.Errorf("listener returned non-TCP address %T", address)
 	}
-	store, err := Store()
-	if err != nil {
-		return daemon.RuntimeRecord{}, "", err
-	}
-	if _, err := store.CleanupDead(); err != nil {
-		return daemon.RuntimeRecord{}, "", fmt.Errorf("clean stale daemon runtime records: %w", err)
-	}
+	host := tcpAddress.IP.String()
+	port := strconv.Itoa(tcpAddress.Port)
 	record := daemon.NewRuntimeRecord(
 		Service,
 		opts.Version,
-		daemon.Endpoint{Network: daemon.NetworkTCP, Address: opts.Address},
+		daemon.Endpoint{Network: daemon.NetworkTCP, Address: address.String()},
 	)
 	record.Metadata = map[string]string{
 		metadataHost:        host,
@@ -78,11 +84,49 @@ func Publish(opts PublishOptions) (daemon.RuntimeRecord, string, error) {
 		metadataRequireAuth: strconv.FormatBool(opts.RequireAuth),
 		metadataDataDir:     opts.DataDir,
 	}
+	tokenPath := runtimelock.AuthTokenPath(opts.DataDir)
 	if opts.RequireAuth {
-		record.Metadata[metadataAuthTokenPath] = runtimelock.AuthTokenPath(opts.DataDir)
+		record.Metadata[metadataAuthTokenPath] = tokenPath
+	}
+	return Identity{
+		Record: record,
+		LockMetadata: runtimelock.Metadata{
+			PID:         record.PID,
+			Host:        host,
+			Port:        tcpAddress.Port,
+			ListenAddr:  record.Address,
+			StartedAt:   record.StartedAt.UTC().Format(time.RFC3339),
+			Version:     record.Version,
+			Commit:      opts.Commit,
+			TokenPath:   tokenPath,
+			BasePath:    canonicalBasePath(opts.BasePath),
+			RequireAuth: opts.RequireAuth,
+		},
+	}, nil
+}
+
+// Publish writes identity's standard discovery record and returns its exact
+// path for cleanup when the server exits.
+func Publish(record daemon.RuntimeRecord) (string, error) {
+	store, err := Store()
+	if err != nil {
+		return "", err
+	}
+	if _, err := store.CleanupDead(); err != nil {
+		return "", fmt.Errorf("clean stale daemon runtime records: %w", err)
 	}
 	path, err := store.Write(record)
-	return record, path, err
+	return path, err
+}
+
+func canonicalBasePath(basePath string) string {
+	if basePath == "" {
+		return "/"
+	}
+	if trimmed := strings.TrimSuffix(basePath, "/"); trimmed != "" {
+		return trimmed
+	}
+	return "/"
 }
 
 // Compatible reports whether a discovery record can represent the expected

--- a/internal/daemonruntime/runtime.go
+++ b/internal/daemonruntime/runtime.go
@@ -25,6 +25,7 @@ const (
 	metadataRequireAuth   = "require_auth"
 	metadataDataDir       = "data_dir"
 	metadataAuthTokenPath = "auth_token_path"
+	metadataBasePath      = "base_path"
 )
 
 // IdentityOptions contains the startup-bound values shared by both runtime
@@ -72,6 +73,7 @@ func NewIdentity(address net.Addr, opts IdentityOptions) (Identity, error) {
 	}
 	host := tcpAddress.IP.String()
 	port := strconv.Itoa(tcpAddress.Port)
+	basePath := canonicalBasePath(opts.BasePath)
 	record := daemon.NewRuntimeRecord(
 		Service,
 		opts.Version,
@@ -83,6 +85,7 @@ func NewIdentity(address net.Addr, opts IdentityOptions) (Identity, error) {
 		metadataReadOnly:    strconv.FormatBool(false),
 		metadataRequireAuth: strconv.FormatBool(opts.RequireAuth),
 		metadataDataDir:     opts.DataDir,
+		metadataBasePath:    basePath,
 	}
 	tokenPath := runtimelock.AuthTokenPath(opts.DataDir)
 	if opts.RequireAuth {
@@ -99,10 +102,25 @@ func NewIdentity(address net.Addr, opts IdentityOptions) (Identity, error) {
 			Version:     record.Version,
 			Commit:      opts.Commit,
 			TokenPath:   tokenPath,
-			BasePath:    canonicalBasePath(opts.BasePath),
+			BasePath:    basePath,
 			RequireAuth: opts.RequireAuth,
 		},
 	}, nil
+}
+
+// URL returns the browser location advertised by a verified runtime record.
+func URL(record daemon.RuntimeRecord) (string, error) {
+	basePath := record.Metadata[metadataBasePath]
+	if basePath == "" || !strings.HasPrefix(basePath, "/") ||
+		strings.HasPrefix(basePath, "//") || strings.ContainsAny(basePath, "?#") ||
+		canonicalBasePath(basePath) != basePath {
+		return "", fmt.Errorf("daemon runtime record has invalid base_path %q", basePath)
+	}
+	baseURL := record.Endpoint().BaseURL()
+	if basePath == "/" {
+		return baseURL, nil
+	}
+	return baseURL + basePath, nil
 }
 
 // Publish writes identity's standard discovery record and returns its exact
@@ -151,6 +169,9 @@ func Compatible(record daemon.RuntimeRecord, dataDir string) bool {
 	}
 	requireAuth, err := strconv.ParseBool(record.Metadata[metadataRequireAuth])
 	if err != nil {
+		return false
+	}
+	if _, err := URL(record); err != nil {
 		return false
 	}
 	if requireAuth {

--- a/internal/daemonruntime/runtime_test.go
+++ b/internal/daemonruntime/runtime_test.go
@@ -41,6 +41,7 @@ func TestNewIdentityKeepsDiscoverySurfacesAligned(t *testing.T) {
 	assert.Equal(runtimelock.AuthTokenPath(dataDir), metadata.TokenPath)
 	assert.Equal(metadata.TokenPath, record.Metadata[metadataAuthTokenPath])
 	assert.Equal("/middleman", metadata.BasePath)
+	assert.Equal(metadata.BasePath, record.Metadata[metadataBasePath])
 	assert.True(metadata.RequireAuth)
 }
 

--- a/internal/daemonruntime/runtime_test.go
+++ b/internal/daemonruntime/runtime_test.go
@@ -1,0 +1,55 @@
+package daemonruntime
+
+import (
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/middleman/internal/runtimelock"
+)
+
+// TestNewIdentityKeepsDiscoverySurfacesAligned protects clients of both the
+// authoritative lock metadata and generic daemon record. If either surface is
+// built independently again, they can advertise different process or listener
+// identities and attach clients to the wrong runtime.
+func TestNewIdentityKeepsDiscoverySurfacesAligned(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(err)
+	t.Cleanup(func() { require.NoError(listener.Close()) })
+	dataDir := t.TempDir()
+
+	identity, err := NewIdentity(listener.Addr(), IdentityOptions{
+		Version: "v-test", Commit: "commit-test", DataDir: dataDir,
+		BasePath: "/middleman/", RequireAuth: true,
+	})
+
+	require.NoError(err)
+	record := identity.Record
+	metadata := identity.LockMetadata
+	assert.Equal(record.PID, metadata.PID)
+	assert.Equal(record.Address, metadata.ListenAddr)
+	assert.Equal(record.Version, metadata.Version)
+	assert.Equal(record.StartedAt.Format(time.RFC3339), metadata.StartedAt)
+	assert.Equal(record.Metadata[metadataHost], metadata.Host)
+	assert.Equal(strconv.Itoa(listener.Addr().(*net.TCPAddr).Port), record.Metadata[metadataPort])
+	assert.Equal(runtimelock.AuthTokenPath(dataDir), metadata.TokenPath)
+	assert.Equal(metadata.TokenPath, record.Metadata[metadataAuthTokenPath])
+	assert.Equal("/middleman", metadata.BasePath)
+	assert.True(metadata.RequireAuth)
+}
+
+func TestNewIdentityRejectsNonTCPAddress(t *testing.T) {
+	_, err := NewIdentity(fakeAddress("not-tcp"), IdentityOptions{})
+
+	require.ErrorContains(t, err, "non-TCP")
+}
+
+type fakeAddress string
+
+func (a fakeAddress) Network() string { return "fake" }
+func (a fakeAddress) String() string  { return string(a) }

--- a/internal/daemonruntime/runtime_test.go
+++ b/internal/daemonruntime/runtime_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kit/daemon"
 	"go.kenn.io/middleman/internal/runtimelock"
 )
 
@@ -47,6 +48,19 @@ func TestNewIdentityRejectsNonTCPAddress(t *testing.T) {
 	_, err := NewIdentity(fakeAddress("not-tcp"), IdentityOptions{})
 
 	require.ErrorContains(t, err, "non-TCP")
+}
+
+// TestStartLockStoreScopesLocksByDataDirectory protects independent daemon
+// instances that share the config-home runtime store. If the data directory is
+// dropped from lock identity, a stalled start blocks unrelated instances.
+func TestStartLockStoreScopesLocksByDataDirectory(t *testing.T) {
+	store := daemon.RuntimeStore{Dir: t.TempDir()}
+
+	first := StartLockStore(store, "/data/first")
+	second := StartLockStore(store, "/data/second")
+
+	assert.Equal(t, first.Dir, second.Dir)
+	assert.NotEqual(t, first.Prefix, second.Prefix)
 }
 
 type fakeAddress string

--- a/internal/runtimelock/paths.go
+++ b/internal/runtimelock/paths.go
@@ -7,6 +7,7 @@ const (
 	lockFileName     = "middleman.lock"
 	metadataFileName = "middleman.run.json"
 	metadataTmpFile  = ".middleman.run.json.tmp"
+	authTokenLock    = ".auth_token.lock"
 )
 
 // LockPath returns the absolute path of the lock file under dataDir.
@@ -14,6 +15,10 @@ const (
 // existence implies nothing about liveness.
 func LockPath(dataDir string) string {
 	return filepath.Join(dataDir, lockFileName)
+}
+
+func authTokenLockPath(dataDir string) string {
+	return filepath.Join(dataDir, authTokenLock)
 }
 
 // MetadataPath returns the absolute path of the runtime metadata file

--- a/internal/runtimelock/token.go
+++ b/internal/runtimelock/token.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/gofrs/flock"
 )
 
 // authTokenFileName is the well-known name of the API auth token under
@@ -24,7 +26,21 @@ func AuthTokenPath(dataDir string) string {
 // EnsureAuthToken returns the API auth token under dataDir, minting a
 // new random token (0600) when none exists. An existing token is
 // reused so restarts do not invalidate connected clients.
-func EnsureAuthToken(dataDir string) (string, error) {
+func EnsureAuthToken(dataDir string) (token string, returnErr error) {
+	creationLock := flock.New(authTokenLockPath(dataDir))
+	if err := creationLock.Lock(); err != nil {
+		return "", fmt.Errorf("lock auth token creation: %w", err)
+	}
+	defer func() {
+		if err := creationLock.Unlock(); err != nil && returnErr == nil {
+			returnErr = fmt.Errorf("unlock auth token creation: %w", err)
+		}
+	}()
+
+	return ensureAuthTokenLocked(dataDir)
+}
+
+func ensureAuthTokenLocked(dataDir string) (string, error) {
 	path := AuthTokenPath(dataDir)
 	existing, err := os.ReadFile(path)
 	if err == nil {
@@ -37,11 +53,6 @@ func EnsureAuthToken(dataDir string) (string, error) {
 			}
 			return token, nil
 		}
-		// An empty file is replaced below; remove it first so the
-		// fresh write applies the restricted mode.
-		if err := os.Remove(path); err != nil {
-			return "", fmt.Errorf("replace empty auth token: %w", err)
-		}
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return "", fmt.Errorf("read auth token: %w", err)
 	}
@@ -51,10 +62,47 @@ func EnsureAuthToken(dataDir string) (string, error) {
 		return "", fmt.Errorf("generate auth token: %w", err)
 	}
 	token := hex.EncodeToString(raw)
-	if err := os.WriteFile(path, []byte(token+"\n"), 0o600); err != nil {
-		return "", fmt.Errorf("write auth token: %w", err)
+	if err := writeAuthToken(dataDir, path, token); err != nil {
+		return "", err
 	}
 	return token, nil
+}
+
+func writeAuthToken(dataDir, path, token string) error {
+	tmp, err := os.CreateTemp(dataDir, ".auth_token.*.tmp")
+	if err != nil {
+		return fmt.Errorf("create auth token temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("restrict auth token temp file: %w", err)
+	}
+	if _, err := tmp.WriteString(token + "\n"); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write auth token temp file: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync auth token temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close auth token temp file: %w", err)
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("replace empty auth token: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("publish auth token: %w", err)
+	}
+	committed = true
+	return nil
 }
 
 // ReadAuthToken returns the token under dataDir, or "" when absent.

--- a/internal/runtimelock/token_test.go
+++ b/internal/runtimelock/token_test.go
@@ -2,11 +2,52 @@ package runtimelock
 
 import (
 	"os"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestEnsureAuthTokenConcurrentCallersReuseWinner protects startup callers
+// that reach a fresh data directory together. If creation is a read-then-write
+// race, callers can retain different tokens from the one left on disk.
+func TestEnsureAuthTokenConcurrentCallersReuseWinner(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	const callers = 32
+	dir := t.TempDir()
+	gate := make(chan struct{})
+	tokens := make(chan string, callers)
+	errs := make(chan error, callers)
+	var ready sync.WaitGroup
+	ready.Add(callers)
+
+	for range callers {
+		go func() {
+			ready.Done()
+			<-gate
+			token, err := EnsureAuthToken(dir)
+			tokens <- token
+			errs <- err
+		}()
+	}
+	ready.Wait()
+	close(gate)
+
+	winner := ""
+	for range callers {
+		require.NoError(<-errs)
+		token := <-tokens
+		if winner == "" {
+			winner = token
+		}
+		assert.Equal(winner, token)
+	}
+	onDisk, err := ReadAuthToken(dir)
+	require.NoError(err)
+	assert.Equal(winner, onDisk)
+}
 
 // TestEnsureAuthToken pins the token contract thin clients rely on:
 // minted once with user-only permissions, stable across restarts.

--- a/internal/server/api_auth.go
+++ b/internal/server/api_auth.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"strings"
 
+	"go.kenn.io/middleman/internal/config"
 	"go.kenn.io/middleman/internal/server/httpapi"
 )
 
@@ -29,6 +30,15 @@ const authBootstrapParam = "auth_token"
 
 func tokenEqual(a, b string) bool {
 	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}
+
+func (s *Server) hasValidDaemonBearer(r *http.Request) bool {
+	if s.apiAuthToken == "" {
+		return false
+	}
+	header := r.Header.Get("Authorization")
+	token, ok := strings.CutPrefix(header, "Bearer ")
+	return ok && tokenEqual(strings.TrimSpace(token), s.apiAuthToken)
 }
 
 // handleAuthBootstrap converts a valid ?auth_token= query into the
@@ -69,11 +79,8 @@ func (s *Server) handleAuthBootstrap(
 func (s *Server) authorizeAPIRequest(
 	w http.ResponseWriter, r *http.Request,
 ) bool {
-	header := r.Header.Get("Authorization")
-	if token, ok := strings.CutPrefix(header, "Bearer "); ok {
-		if tokenEqual(strings.TrimSpace(token), s.apiAuthToken) {
-			return true
-		}
+	if s.hasValidDaemonBearer(r) {
+		return true
 	}
 	if cookie, err := r.Cookie(authCookieName); err == nil {
 		if tokenEqual(cookie.Value, s.apiAuthToken) {
@@ -88,6 +95,18 @@ func (s *Server) authorizeAPIRequest(
 		nil,
 	))
 	return false
+}
+
+func (s *Server) isDirectDaemonBearerRequest(
+	r *http.Request, opts HostCheckOptions,
+) bool {
+	if !s.isGatedAPIRequest(r) || !s.hasValidDaemonBearer(r) ||
+		hasForwardingHeaders(r.Header) || !isLoopbackRemoteAddr(r.RemoteAddr) ||
+		!config.IsLoopbackHostname(strings.Trim(opts.Bind.Host, "[]")) {
+		return false
+	}
+	key, err := config.ParseHostKey(r.Host)
+	return err == nil && key.Equal(opts.Bind)
 }
 
 // isGatedAPIRequest reports whether the path is a route subject to

--- a/internal/server/api_auth.go
+++ b/internal/server/api_auth.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"go.kenn.io/middleman/internal/config"
+	"go.kenn.io/middleman/internal/daemonruntime"
 	"go.kenn.io/middleman/internal/server/httpapi"
 )
 
@@ -32,13 +33,13 @@ func tokenEqual(a, b string) bool {
 	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
 }
 
-func (s *Server) hasValidDaemonBearer(r *http.Request) bool {
-	if s.apiAuthToken == "" {
+func hasValidBearer(r *http.Request, expected string) bool {
+	if expected == "" {
 		return false
 	}
 	header := r.Header.Get("Authorization")
 	token, ok := strings.CutPrefix(header, "Bearer ")
-	return ok && tokenEqual(strings.TrimSpace(token), s.apiAuthToken)
+	return ok && tokenEqual(strings.TrimSpace(token), expected)
 }
 
 // handleAuthBootstrap converts a valid ?auth_token= query into the
@@ -79,7 +80,7 @@ func (s *Server) handleAuthBootstrap(
 func (s *Server) authorizeAPIRequest(
 	w http.ResponseWriter, r *http.Request,
 ) bool {
-	if s.hasValidDaemonBearer(r) {
+	if hasValidBearer(r, s.apiAuthToken) {
 		return true
 	}
 	if cookie, err := r.Cookie(authCookieName); err == nil {
@@ -100,8 +101,18 @@ func (s *Server) authorizeAPIRequest(
 func (s *Server) isDirectDaemonBearerRequest(
 	r *http.Request, opts HostCheckOptions,
 ) bool {
-	if !s.isGatedAPIRequest(r) || !s.hasValidDaemonBearer(r) ||
-		hasForwardingHeaders(r.Header) || !isLoopbackRemoteAddr(r.RemoteAddr) ||
+	return s.isGatedAPIRequest(r) &&
+		hasValidBearer(r, s.directClientToken) &&
+		isDirectLoopbackListenerRequest(r, opts)
+}
+
+func isDirectDaemonProofRequest(r *http.Request, opts HostCheckOptions) bool {
+	return r.Method == http.MethodGet && r.URL.Path == daemonruntime.ProofPingPath &&
+		isDirectLoopbackListenerRequest(r, opts)
+}
+
+func isDirectLoopbackListenerRequest(r *http.Request, opts HostCheckOptions) bool {
+	if hasForwardingHeaders(r.Header) || !isLoopbackRemoteAddr(r.RemoteAddr) ||
 		!config.IsLoopbackHostname(strings.Trim(opts.Bind.Host, "[]")) {
 		return false
 	}

--- a/internal/server/api_auth.go
+++ b/internal/server/api_auth.go
@@ -10,7 +10,7 @@ import (
 )
 
 // API auth gates /api and /ws routes behind the daemon's bearer token
-// when the server is constructed with one (ServerOptions.APIAuthToken,
+// when the server is configured to require it (ServerOptions.DaemonAccess,
 // minted under data_dir at serve start). Two credentials are
 // accepted: an `Authorization: Bearer <token>` header (CLI, native
 // thin clients, SSE over plain HTTP clients) and the session cookie a
@@ -50,7 +50,7 @@ func (s *Server) handleAuthBootstrap(
 	if token == "" {
 		return false
 	}
-	if !tokenEqual(token, s.apiAuthToken) {
+	if !tokenEqual(token, s.daemonRequests.token) {
 		http.Error(w, "invalid auth token", http.StatusForbidden)
 		return true
 	}
@@ -78,11 +78,11 @@ func (s *Server) handleAuthBootstrap(
 func (s *Server) authorizeAPIRequest(
 	w http.ResponseWriter, r *http.Request,
 ) bool {
-	if hasValidBearer(r, s.apiAuthToken) {
+	if hasValidBearer(r, s.daemonRequests.token) {
 		return true
 	}
 	if cookie, err := r.Cookie(authCookieName); err == nil {
-		if tokenEqual(cookie.Value, s.apiAuthToken) {
+		if tokenEqual(cookie.Value, s.daemonRequests.token) {
 			return true
 		}
 	}

--- a/internal/server/api_auth.go
+++ b/internal/server/api_auth.go
@@ -6,8 +6,6 @@ import (
 	"net/url"
 	"strings"
 
-	"go.kenn.io/middleman/internal/config"
-	"go.kenn.io/middleman/internal/daemonruntime"
 	"go.kenn.io/middleman/internal/server/httpapi"
 )
 
@@ -96,28 +94,6 @@ func (s *Server) authorizeAPIRequest(
 		nil,
 	))
 	return false
-}
-
-func (s *Server) isDirectDaemonBearerRequest(
-	r *http.Request, opts HostCheckOptions,
-) bool {
-	return s.isGatedAPIRequest(r) &&
-		hasValidBearer(r, s.directClientToken) &&
-		isDirectLoopbackListenerRequest(r, opts)
-}
-
-func isDirectDaemonProofRequest(r *http.Request, opts HostCheckOptions) bool {
-	return r.Method == http.MethodGet && r.URL.Path == daemonruntime.ProofPingPath &&
-		isDirectLoopbackListenerRequest(r, opts)
-}
-
-func isDirectLoopbackListenerRequest(r *http.Request, opts HostCheckOptions) bool {
-	if hasForwardingHeaders(r.Header) || !isLoopbackRemoteAddr(r.RemoteAddr) ||
-		!config.IsLoopbackHostname(strings.Trim(opts.Bind.Host, "[]")) {
-		return false
-	}
-	key, err := config.ParseHostKey(r.Host)
-	return err == nil && key.Equal(opts.Bind)
 }
 
 // isGatedAPIRequest reports whether the path is a route subject to

--- a/internal/server/api_auth_test.go
+++ b/internal/server/api_auth_test.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"encoding/json"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -30,55 +29,23 @@ func newAuthTestServer(t *testing.T, token string) *httptest.Server {
 	return ts
 }
 
-// TestDaemonPingRequiresBearerAndReportsReadyIdentity protects the generic
-// kit-daemon attachment contract. If the route becomes public or stops
-// reporting the live service/version/PID tuple, a launcher can attach to the
-// wrong process or treat an unready app as usable.
-func TestDaemonPingRequiresBearerAndReportsReadyIdentity(t *testing.T) {
+// TestDaemonPingContract protects authenticated readiness and the private
+// identity proof used before lifecycle discovery trusts a recorded endpoint.
+func TestDaemonPingContract(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	srv := New(dbtest.Open(t), nil, nil, "/middleman", nil, ServerOptions{
-		DaemonAccess: DaemonAccessOptions{
-			Token: "secret-token", RequireAPIAuth: true,
-		},
-	})
-	srv.SetBuildInfo(BuildInfo{Name: "middleman", Version: "v-test"})
-	ts := httptest.NewServer(srv)
-	t.Cleanup(ts.Close)
-
-	unauthorized := authGet(t, ts, "/api/ping", nil)
-	assert.Equal(http.StatusUnauthorized, unauthorized.StatusCode)
-
-	response := authGet(t, ts, "/api/ping", func(r *http.Request) {
-		r.Header.Set("Authorization", "Bearer secret-token")
-	})
-	require.Equal(http.StatusOK, response.StatusCode)
-	var ping daemon.PingInfo
-	require.NoError(json.NewDecoder(response.Body).Decode(&ping))
-	assert.True(ping.OK)
-	assert.Equal("middleman", ping.Service)
-	assert.Equal("v-test", ping.Version)
-	assert.Equal(os.Getpid(), ping.PID)
-}
-
-// TestDaemonProofUsesThePublishedIdentity protects the proof route that
-// lifecycle discovery reaches before sending credentials. The proof must bind
-// the exact runtime record and remain unavailable through proxy-shaped or
-// wrong-authority requests.
-func TestDaemonProofUsesThePublishedIdentity(t *testing.T) {
-	require := require.New(t)
 	ts := httptest.NewUnstartedServer(nil)
-	address := ts.Listener.Addr().String()
-	bind, err := config.ParseHostKey(address)
+	bind, err := config.ParseHostKey(ts.Listener.Addr().String())
 	require.NoError(err)
-	record := daemon.NewRuntimeRecord(
-		daemonruntime.Service,
-		"v-test",
-		daemon.Endpoint{Network: daemon.NetworkTCP, Address: address},
+	identity, err := daemonruntime.NewIdentity(
+		ts.Listener.Addr(), daemonruntime.IdentityOptions{
+			Version: "v-test", DataDir: t.TempDir(), RequireAuth: true,
+		},
 	)
+	require.NoError(err)
 	proof, err := daemon.NewProof([]byte("secret-token"))
 	require.NoError(err)
-	proofHandler, err := proof.NewPingHandler(record)
+	proofHandler, err := proof.NewPingHandler(identity.Record)
 	require.NoError(err)
 	srv := New(dbtest.Open(t), nil, nil, "/", nil, ServerOptions{
 		DaemonAccess: DaemonAccessOptions{
@@ -86,35 +53,39 @@ func TestDaemonProofUsesThePublishedIdentity(t *testing.T) {
 			ProofHandler: proofHandler,
 		},
 		HostCheck: HostCheckOptions{
-			Bind: bind, TrustReverseProxy: true,
+			Bind: bind, Allowed: []config.HostKey{{Host: "middleman.example.test"}},
+			TrustReverseProxy: true,
 		},
 	})
+	srv.SetBuildInfo(BuildInfo{Name: "middleman", Version: "v-test"})
 	ts.Config.Handler = srv
 	ts.Start()
 	t.Cleanup(ts.Close)
 
-	ping, err := proof.Probe(t.Context(), record, daemon.ProbeOptions{
-		Path: daemonruntime.ProofPingPath,
+	unauthorized := authGet(t, ts, "/api/ping", func(r *http.Request) {
+		r.Header.Set("X-Forwarded-Host", "middleman.example.test")
 	})
-	require.NoError(err)
-	assert.Equal(t, record.PID, ping.PID)
+	assert.Equal(http.StatusUnauthorized, unauthorized.StatusCode)
+	response := authGet(t, ts, "/api/ping", func(r *http.Request) {
+		r.Header.Set("Authorization", "Bearer secret-token")
+	})
+	require.Equal(http.StatusOK, response.StatusCode)
+	var ping daemon.PingInfo
+	require.NoError(json.NewDecoder(response.Body).Decode(&ping))
+	assert.Equal(daemon.PingInfo{
+		OK: true, Service: daemonruntime.Service,
+		Version: "v-test", PID: os.Getpid(),
+	}, ping)
 
-	wrongProof, err := daemon.NewProof([]byte("wrong-token"))
-	require.NoError(err)
-	_, err = wrongProof.Probe(t.Context(), record, daemon.ProbeOptions{
+	_, err = proof.Probe(t.Context(), identity.Record, daemon.ProbeOptions{
 		Path: daemonruntime.ProofPingPath,
 	})
-	require.Error(err)
+	require.NoError(err)
 
 	forwarded := authGet(t, ts, daemonruntime.ProofPingPath, func(r *http.Request) {
-		r.Header.Set("X-Forwarded-Host", r.Host)
+		r.Header.Set("X-Forwarded-Host", "middleman.example.test")
 	})
-	assert.Equal(t, http.StatusForbidden, forwarded.StatusCode)
-
-	wrongHost := authGet(t, ts, daemonruntime.ProofPingPath, func(r *http.Request) {
-		r.Host = net.JoinHostPort("localhost", bind.Port)
-	})
-	assert.Equal(t, http.StatusForbidden, wrongHost.StatusCode)
+	assert.Equal(http.StatusForbidden, forwarded.StatusCode)
 }
 
 func authGet(

--- a/internal/server/api_auth_test.go
+++ b/internal/server/api_auth_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -12,6 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/kit/daemon"
 
+	"go.kenn.io/middleman/internal/config"
+	"go.kenn.io/middleman/internal/daemonruntime"
 	"go.kenn.io/middleman/internal/testutil/dbtest"
 )
 
@@ -52,6 +55,61 @@ func TestDaemonPingRequiresBearerAndReportsReadyIdentity(t *testing.T) {
 	assert.Equal("middleman", ping.Service)
 	assert.Equal("v-test", ping.Version)
 	assert.Equal(os.Getpid(), ping.PID)
+}
+
+// TestDaemonProofUsesThePublishedIdentity protects the proof route that
+// lifecycle discovery reaches before sending credentials. The proof must bind
+// the exact runtime record and remain unavailable through proxy-shaped or
+// wrong-authority requests.
+func TestDaemonProofUsesThePublishedIdentity(t *testing.T) {
+	require := require.New(t)
+	ts := httptest.NewUnstartedServer(nil)
+	address := ts.Listener.Addr().String()
+	bind, err := config.ParseHostKey(address)
+	require.NoError(err)
+	record := daemon.NewRuntimeRecord(
+		daemonruntime.Service,
+		"v-test",
+		daemon.Endpoint{Network: daemon.NetworkTCP, Address: address},
+	)
+	proof, err := daemon.NewProof([]byte("secret-token"))
+	require.NoError(err)
+	proofHandler, err := proof.NewPingHandler(record)
+	require.NoError(err)
+	srv := New(dbtest.Open(t), nil, nil, "/", nil, ServerOptions{
+		APIAuthToken:       "secret-token",
+		DirectClientToken:  "secret-token",
+		DaemonProofHandler: proofHandler,
+		HostCheck: HostCheckOptions{
+			Bind: bind, TrustReverseProxy: true,
+		},
+	})
+	ts.Config.Handler = srv
+	ts.Start()
+	t.Cleanup(ts.Close)
+
+	ping, err := proof.Probe(t.Context(), record, daemon.ProbeOptions{
+		Path: daemonruntime.ProofPingPath,
+	})
+	require.NoError(err)
+	assert.Equal(t, record.PID, ping.PID)
+
+	wrongProof, err := daemon.NewProof([]byte("wrong-token"))
+	require.NoError(err)
+	_, err = wrongProof.Probe(t.Context(), record, daemon.ProbeOptions{
+		Path: daemonruntime.ProofPingPath,
+	})
+	require.Error(err)
+
+	forwarded := authGet(t, ts, daemonruntime.ProofPingPath, func(r *http.Request) {
+		r.Header.Set("X-Forwarded-Host", r.Host)
+	})
+	assert.Equal(t, http.StatusForbidden, forwarded.StatusCode)
+
+	wrongHost := authGet(t, ts, daemonruntime.ProofPingPath, func(r *http.Request) {
+		r.Host = net.JoinHostPort("localhost", bind.Port)
+	})
+	assert.Equal(t, http.StatusForbidden, wrongHost.StatusCode)
 }
 
 func authGet(

--- a/internal/server/api_auth_test.go
+++ b/internal/server/api_auth_test.go
@@ -21,7 +21,9 @@ import (
 func newAuthTestServer(t *testing.T, token string) *httptest.Server {
 	t.Helper()
 	srv := New(dbtest.Open(t), nil, nil, "/", nil, ServerOptions{
-		APIAuthToken: token,
+		DaemonAccess: DaemonAccessOptions{
+			Token: token, RequireAPIAuth: token != "",
+		},
 	})
 	ts := httptest.NewServer(srv)
 	t.Cleanup(ts.Close)
@@ -36,7 +38,9 @@ func TestDaemonPingRequiresBearerAndReportsReadyIdentity(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	srv := New(dbtest.Open(t), nil, nil, "/middleman", nil, ServerOptions{
-		APIAuthToken: "secret-token",
+		DaemonAccess: DaemonAccessOptions{
+			Token: "secret-token", RequireAPIAuth: true,
+		},
 	})
 	srv.SetBuildInfo(BuildInfo{Name: "middleman", Version: "v-test"})
 	ts := httptest.NewServer(srv)
@@ -77,9 +81,10 @@ func TestDaemonProofUsesThePublishedIdentity(t *testing.T) {
 	proofHandler, err := proof.NewPingHandler(record)
 	require.NoError(err)
 	srv := New(dbtest.Open(t), nil, nil, "/", nil, ServerOptions{
-		APIAuthToken:       "secret-token",
-		DirectClientToken:  "secret-token",
-		DaemonProofHandler: proofHandler,
+		DaemonAccess: DaemonAccessOptions{
+			Token: "secret-token", RequireAPIAuth: true,
+			ProofHandler: proofHandler,
+		},
 		HostCheck: HostCheckOptions{
 			Bind: bind, TrustReverseProxy: true,
 		},

--- a/internal/server/api_auth_test.go
+++ b/internal/server/api_auth_test.go
@@ -5,10 +5,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/kit/daemon"
 
 	"go.kenn.io/middleman/internal/testutil/dbtest"
 )
@@ -21,6 +23,35 @@ func newAuthTestServer(t *testing.T, token string) *httptest.Server {
 	ts := httptest.NewServer(srv)
 	t.Cleanup(ts.Close)
 	return ts
+}
+
+// TestDaemonPingRequiresBearerAndReportsReadyIdentity protects the generic
+// kit-daemon attachment contract. If the route becomes public or stops
+// reporting the live service/version/PID tuple, a launcher can attach to the
+// wrong process or treat an unready app as usable.
+func TestDaemonPingRequiresBearerAndReportsReadyIdentity(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	srv := New(dbtest.Open(t), nil, nil, "/middleman", nil, ServerOptions{
+		APIAuthToken: "secret-token",
+	})
+	srv.SetBuildInfo(BuildInfo{Name: "middleman", Version: "v-test"})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	unauthorized := authGet(t, ts, "/api/ping", nil)
+	assert.Equal(http.StatusUnauthorized, unauthorized.StatusCode)
+
+	response := authGet(t, ts, "/api/ping", func(r *http.Request) {
+		r.Header.Set("Authorization", "Bearer secret-token")
+	})
+	require.Equal(http.StatusOK, response.StatusCode)
+	var ping daemon.PingInfo
+	require.NoError(json.NewDecoder(response.Body).Decode(&ping))
+	assert.True(ping.OK)
+	assert.Equal("middleman", ping.Service)
+	assert.Equal("v-test", ping.Version)
+	assert.Equal(os.Getpid(), ping.PID)
 }
 
 func authGet(

--- a/internal/server/apitest/archive_test.go
+++ b/internal/server/apitest/archive_test.go
@@ -296,7 +296,10 @@ func TestAPIArchiveRoutesObeyHostAuthAndCSRFGuards(t *testing.T) {
 	syncer := ghclient.NewSyncer(nil, database, nil, nil, time.Minute, nil, nil)
 	t.Cleanup(syncer.Stop)
 	authServer := server.New(database, syncer, nil, "/", nil, server.ServerOptions{
-		APIAuthToken: "archive-test-token", Archive: archiveStatusController{},
+		DaemonAccess: server.DaemonAccessOptions{
+			Token: "archive-test-token", RequireAPIAuth: true,
+		},
+		Archive: archiveStatusController{},
 	})
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/internal/server/config_reload.go
+++ b/internal/server/config_reload.go
@@ -343,6 +343,19 @@ func (s *Server) applyConfigChange(ctx context.Context) configChangedEvent {
 			Error: sanitizeConfigError(err, s.cfgPath),
 		}
 	}
+	canonicalDir, err := config.CanonicalDataDir(newCfg.DataDir)
+	if err != nil {
+		slog.Warn(
+			"config reload failed data directory resolution; keeping last-known-good",
+			"path", s.cfgPath,
+			"err", err,
+		)
+		return configChangedEvent{
+			Valid: false,
+			Error: sanitizeConfigError(err, s.cfgPath),
+		}
+	}
+	newCfg.DataDir = canonicalDir
 	if err := validateReloadCloneTokenSources(newCfg); err != nil {
 		slog.Warn(
 			"config reload failed clone token validation; keeping last-known-good",

--- a/internal/server/config_reload.go
+++ b/internal/server/config_reload.go
@@ -343,19 +343,6 @@ func (s *Server) applyConfigChange(ctx context.Context) configChangedEvent {
 			Error: sanitizeConfigError(err, s.cfgPath),
 		}
 	}
-	canonicalDir, err := config.CanonicalDataDir(newCfg.DataDir)
-	if err != nil {
-		slog.Warn(
-			"config reload failed data directory resolution; keeping last-known-good",
-			"path", s.cfgPath,
-			"err", err,
-		)
-		return configChangedEvent{
-			Valid: false,
-			Error: sanitizeConfigError(err, s.cfgPath),
-		}
-	}
-	newCfg.DataDir = canonicalDir
 	if err := validateReloadCloneTokenSources(newCfg); err != nil {
 		slog.Warn(
 			"config reload failed clone token validation; keeping last-known-good",

--- a/internal/server/config_reload_test.go
+++ b/internal/server/config_reload_test.go
@@ -443,6 +443,35 @@ func TestConfigReload_NilSyncerAppliesHotReloadWithoutPanic(t *testing.T) {
 	assert.Equal("30d", gotActivity.TimeRange)
 }
 
+func TestConfigReloadPreservesCanonicalDataDirIdentity(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	root := t.TempDir()
+	realDir := filepath.Join(root, "state")
+	require.NoError(os.Mkdir(realDir, 0o700))
+	link := filepath.Join(root, "state-link")
+	if err := os.Symlink(realDir, link); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	content := fmt.Sprintf("data_dir = %q\n", link) + validReloadConfig
+	srv, _, cfgPath := setupTestServerWithConfigContent(t, content, &mockGH{})
+	canonicalDir, err := filepath.EvalSymlinks(realDir)
+	require.NoError(err)
+	srv.cfgMu.Lock()
+	srv.cfg.DataDir = canonicalDir
+	srv.bootCfgSnapshot.DataDir = canonicalDir
+	srv.cfgMu.Unlock()
+
+	writeConfigToml(t, cfgPath, content)
+	event := srv.applyConfigChange(t.Context())
+
+	require.True(event.Valid, event.Error)
+	assert.False(event.RestartRequired)
+	srv.cfgMu.Lock()
+	assert.Equal(canonicalDir, srv.cfg.DataDir)
+	srv.cfgMu.Unlock()
+}
+
 func TestConfigReload_UpdatesBranchActivityLimits(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/server/config_reload_test.go
+++ b/internal/server/config_reload_test.go
@@ -457,10 +457,6 @@ func TestConfigReloadPreservesCanonicalDataDirIdentity(t *testing.T) {
 	srv, _, cfgPath := setupTestServerWithConfigContent(t, content, &mockGH{})
 	canonicalDir, err := filepath.EvalSymlinks(realDir)
 	require.NoError(err)
-	srv.cfgMu.Lock()
-	srv.cfg.DataDir = canonicalDir
-	srv.bootCfgSnapshot.DataDir = canonicalDir
-	srv.cfgMu.Unlock()
 
 	writeConfigToml(t, cfgPath, content)
 	event := srv.applyConfigChange(t.Context())

--- a/internal/server/daemon_access.go
+++ b/internal/server/daemon_access.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"net/http"
+	"strings"
+
+	"go.kenn.io/middleman/internal/config"
+	"go.kenn.io/middleman/internal/daemonruntime"
+)
+
+type daemonRequestPolicy struct {
+	directToken string
+	proof       http.Handler
+}
+
+type daemonRequestAdmission struct {
+	bypassProxyHostCheck bool
+	handled              bool
+}
+
+func (p daemonRequestPolicy) admit(
+	w http.ResponseWriter,
+	r *http.Request,
+	hostOpts HostCheckOptions,
+	gatedAPIRequest bool,
+) daemonRequestAdmission {
+	direct := isDirectLoopbackListenerRequest(r, hostOpts)
+	if r.URL.Path == daemonruntime.ProofPingPath {
+		if r.Method != http.MethodGet || !direct {
+			rejectHost(w, r, "daemon_proof_not_direct", r.Host, "")
+			return daemonRequestAdmission{handled: true}
+		}
+		if p.proof != nil {
+			p.proof.ServeHTTP(w, r)
+			return daemonRequestAdmission{handled: true}
+		}
+		return daemonRequestAdmission{bypassProxyHostCheck: true}
+	}
+	return daemonRequestAdmission{
+		bypassProxyHostCheck: gatedAPIRequest &&
+			hasValidBearer(r, p.directToken) && direct,
+	}
+}
+
+func isDirectLoopbackListenerRequest(r *http.Request, opts HostCheckOptions) bool {
+	if hasForwardingHeaders(r.Header) || !isLoopbackRemoteAddr(r.RemoteAddr) ||
+		!config.IsLoopbackHostname(strings.Trim(opts.Bind.Host, "[]")) {
+		return false
+	}
+	key, err := config.ParseHostKey(r.Host)
+	return err == nil && key.Equal(opts.Bind)
+}

--- a/internal/server/daemon_access.go
+++ b/internal/server/daemon_access.go
@@ -8,9 +8,17 @@ import (
 	"go.kenn.io/middleman/internal/daemonruntime"
 )
 
+// DaemonAccessOptions configures startup-bound daemon authentication and proof.
+type DaemonAccessOptions struct {
+	Token          string
+	RequireAPIAuth bool
+	ProofHandler   http.Handler
+}
+
 type daemonRequestPolicy struct {
-	directToken string
-	proof       http.Handler
+	token          string
+	requireAPIAuth bool
+	proof          http.Handler
 }
 
 type daemonRequestAdmission struct {
@@ -38,7 +46,7 @@ func (p daemonRequestPolicy) admit(
 	}
 	return daemonRequestAdmission{
 		bypassProxyHostCheck: gatedAPIRequest &&
-			hasValidBearer(r, p.directToken) && direct,
+			hasValidBearer(r, p.token) && direct,
 	}
 }
 

--- a/internal/server/daemon_ping.go
+++ b/internal/server/daemon_ping.go
@@ -8,6 +8,7 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humago"
 	"go.kenn.io/kit/daemon"
+	"go.kenn.io/middleman/internal/daemonruntime"
 	"go.kenn.io/middleman/internal/server/httpapi"
 )
 
@@ -34,7 +35,7 @@ func (s *Server) daemonPing(
 ) (*daemonPingOutput, error) {
 	return &daemonPingOutput{Body: daemon.PingInfo{
 		OK:      true,
-		Service: "middleman",
+		Service: daemonruntime.Service,
 		Version: s.buildInfo.Version,
 		PID:     os.Getpid(),
 	}}, nil

--- a/internal/server/daemon_ping.go
+++ b/internal/server/daemon_ping.go
@@ -24,6 +24,9 @@ func daemonPingAPIConfig() huma.Config {
 }
 
 func (s *Server) registerDaemonPing(mux *http.ServeMux) {
+	if s.options.DaemonProofHandler != nil {
+		mux.Handle(daemonruntime.ProofPingPath, s.options.DaemonProofHandler)
+	}
 	api := humago.New(mux, daemonPingAPIConfig())
 	api.UseMiddleware(otelSpanMiddleware)
 	huma.Get(api, "/api/ping", s.daemonPing,

--- a/internal/server/daemon_ping.go
+++ b/internal/server/daemon_ping.go
@@ -24,9 +24,6 @@ func daemonPingAPIConfig() huma.Config {
 }
 
 func (s *Server) registerDaemonPing(mux *http.ServeMux) {
-	if s.options.DaemonProofHandler != nil {
-		mux.Handle(daemonruntime.ProofPingPath, s.options.DaemonProofHandler)
-	}
 	api := humago.New(mux, daemonPingAPIConfig())
 	api.UseMiddleware(otelSpanMiddleware)
 	huma.Get(api, "/api/ping", s.daemonPing,

--- a/internal/server/daemon_ping.go
+++ b/internal/server/daemon_ping.go
@@ -1,0 +1,41 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"os"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/adapters/humago"
+	"go.kenn.io/kit/daemon"
+	"go.kenn.io/middleman/internal/server/httpapi"
+)
+
+type daemonPingOutput = httpapi.BodyOutput[daemon.PingInfo]
+
+func daemonPingAPIConfig() huma.Config {
+	config := huma.DefaultConfig("middleman daemon", "0.1.0")
+	config.OpenAPIPath = ""
+	config.DocsPath = ""
+	config.SchemasPath = ""
+	config.Servers = nil
+	return config
+}
+
+func (s *Server) registerDaemonPing(mux *http.ServeMux) {
+	api := humago.New(mux, daemonPingAPIConfig())
+	api.UseMiddleware(otelSpanMiddleware)
+	huma.Get(api, "/api/ping", s.daemonPing,
+		httpapi.DocumentOperation("get-daemon-ping", "Get daemon readiness", "System"))
+}
+
+func (s *Server) daemonPing(
+	_ context.Context, _ *struct{},
+) (*daemonPingOutput, error) {
+	return &daemonPingOutput{Body: daemon.PingInfo{
+		OK:      true,
+		Service: "middleman",
+		Version: s.buildInfo.Version,
+		PID:     os.Getpid(),
+	}}, nil
+}

--- a/internal/server/host_check.go
+++ b/internal/server/host_check.go
@@ -50,6 +50,25 @@ func (o HostCheckOptions) Valid() bool {
 	return o.Bind.Valid()
 }
 
+func hasForwardingHeaders(header http.Header) bool {
+	for name := range header {
+		if strings.EqualFold(name, "Forwarded") ||
+			strings.HasPrefix(strings.ToLower(name), "x-forwarded-") {
+			return true
+		}
+	}
+	return false
+}
+
+func listenerHostKey(ln net.Listener) (config.HostKey, bool) {
+	host, port, err := net.SplitHostPort(ln.Addr().String())
+	if err != nil {
+		return config.HostKey{}, false
+	}
+	key, err := config.ParseHostKey(net.JoinHostPort(host, port))
+	return key, err == nil
+}
+
 // checkHost runs the Host validation steps from the design spec.
 // Returns true when the request may proceed; returns false (and
 // writes the 403) when it must be rejected. Panics when opts is

--- a/internal/server/host_check_test.go
+++ b/internal/server/host_check_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"maps"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -53,133 +54,133 @@ type fixedAddrListener struct {
 
 func (l fixedAddrListener) Addr() net.Addr { return l.addr }
 
+func newDirectDaemonRequest(bearer string, headers http.Header) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/snapshot", nil)
+	req.Host = "127.0.0.1:8091"
+	req.RemoteAddr = "127.0.0.1:1234"
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	maps.Copy(req.Header, headers)
+	return req
+}
+
+func serveDirectDaemonRequest(
+	srv *Server, bearer string, headers http.Header,
+) *httptest.ResponseRecorder {
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, newDirectDaemonRequest(bearer, headers))
+	return rr
+}
+
 // TestDirectDaemonBearerClassification protects the native-client trust
-// boundary. If bearer classification moves after proxy Host validation,
-// authenticated CLI requests fail whenever trust_reverse_proxy is enabled. If
-// the classifier is widened, cookies, listener aliases, configured public
-// hosts, or forwarded requests can bypass the proxy checks.
+// boundary without constructing the full application. If the classifier is
+// widened, cookies, listener aliases, non-loopback peers, or forwarded
+// requests can bypass reverse-proxy Host validation.
 func TestDirectDaemonBearerClassification(t *testing.T) {
 	tests := []struct {
-		name            string
-		configuredToken string
-		host            string
-		bearer          string
-		cookie          string
-		headers         http.Header
-		remoteAddr      string
-		wantStatus      int
+		name                     string
+		bearer, host, remoteAddr string
+		missingBearer, noToken   bool
+		cookie, forwarded, ipv6  bool
+		wantBypass               bool
 	}{
-		{
-			name:            "valid bearer and exact listener authority",
-			configuredToken: "daemon-secret",
-			host:            "127.0.0.1:8091", bearer: "daemon-secret",
-			wantStatus: http.StatusOK,
-		},
-		{
-			name:            "missing bearer",
-			configuredToken: "daemon-secret",
-			host:            "127.0.0.1:8091", wantStatus: http.StatusForbidden,
-		},
-		{
-			name:            "invalid bearer",
-			configuredToken: "daemon-secret",
-			host:            "127.0.0.1:8091", bearer: "wrong",
-			wantStatus: http.StatusForbidden,
-		},
-		{
-			name:            "session cookie does not qualify",
-			configuredToken: "daemon-secret",
-			host:            "127.0.0.1:8091", cookie: "daemon-secret",
-			wantStatus: http.StatusForbidden,
-		},
-		{
-			name:            "loopback alias is not the exact listener authority",
-			configuredToken: "daemon-secret",
-			host:            "localhost:8091", bearer: "daemon-secret",
-			wantStatus: http.StatusForbidden,
-		},
-		{
-			name:            "non-loopback peer is not a direct client",
-			configuredToken: "daemon-secret",
-			host:            "127.0.0.1:8091", bearer: "daemon-secret",
-			remoteAddr: "192.0.2.1:1234", wantStatus: http.StatusForbidden,
-		},
-		{
-			name:            "allowed public host is not the listener authority",
-			configuredToken: "daemon-secret",
-			host:            "mm.example.com", bearer: "daemon-secret",
-			wantStatus: http.StatusForbidden,
-		},
-		{
-			name:            "X-Forwarded-For stays on proxy path",
-			configuredToken: "daemon-secret",
-			host:            "127.0.0.1:8091", bearer: "daemon-secret",
-			headers:    http.Header{"X-Forwarded-For": {"127.0.0.1"}},
-			wantStatus: http.StatusForbidden,
-		},
-		{
-			name:            "valid forwarded host stays on proxy path",
-			configuredToken: "daemon-secret",
-			host:            "127.0.0.1:8091", bearer: "daemon-secret",
-			headers:    http.Header{"X-Forwarded-Host": {"mm.example.com"}},
-			wantStatus: http.StatusOK,
-		},
-		{
-			name:            "malformed forwarded header stays rejected",
-			configuredToken: "daemon-secret",
-			host:            "127.0.0.1:8091", bearer: "daemon-secret",
-			headers:    http.Header{"Forwarded": {"wat"}},
-			wantStatus: http.StatusForbidden,
-		},
-		{
-			name:            "conflicting forwarded headers stay rejected",
-			configuredToken: "daemon-secret",
-			host:            "127.0.0.1:8091", bearer: "daemon-secret",
-			headers: http.Header{
-				"Forwarded":        {"host=other.example.com"},
-				"X-Forwarded-Host": {"mm.example.com"},
-			},
-			wantStatus: http.StatusForbidden,
-		},
-		{
-			name: "authentication disabled",
-			host: "127.0.0.1:8091", bearer: "daemon-secret",
-			wantStatus: http.StatusForbidden,
-		},
+		{name: "valid exact listener authority", wantBypass: true},
+		{name: "missing bearer", missingBearer: true},
+		{name: "invalid bearer", bearer: "wrong"},
+		{name: "session cookie does not qualify", missingBearer: true, cookie: true},
+		{name: "loopback alias is not exact", host: "localhost:8091"},
+		{name: "non-loopback peer", remoteAddr: "192.0.2.1:1234"},
+		{name: "public host", host: "mm.example.com"},
+		{name: "forwarded request", forwarded: true},
+		{name: "missing configured token", noToken: true},
+		{name: "IPv6 listener authority", ipv6: true, wantBypass: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			srv := setupHostCheckServerWithToken(t, HostCheckOptions{
-				Bind: bindLoopback8091(),
-				Allowed: []config.HostKey{
-					{Host: "mm.example.com", Port: ""},
-					{Host: "other.example.com", Port: ""},
-				},
-				TrustReverseProxy: true,
-			}, tt.configuredToken)
-			req := httptest.NewRequest(http.MethodGet, "/api/v1/snapshot", nil)
-			req.Host = tt.host
-			req.RemoteAddr = tt.remoteAddr
-			if req.RemoteAddr == "" {
-				req.RemoteAddr = "127.0.0.1:1234"
+			token := "daemon-secret"
+			if tt.noToken {
+				token = ""
 			}
-			for name, values := range tt.headers {
-				for _, value := range values {
-					req.Header.Add(name, value)
-				}
+			bind := bindLoopback8091()
+			req := newDirectDaemonRequest("daemon-secret", nil)
+			if tt.ipv6 {
+				bind = config.HostKey{Host: "[::1]", Port: "8091"}
+				req.Host = "[::1]:8091"
+				req.RemoteAddr = "[::1]:1234"
 			}
-			if tt.bearer != "" {
+			if tt.host != "" {
+				req.Host = tt.host
+			}
+			if tt.remoteAddr != "" {
+				req.RemoteAddr = tt.remoteAddr
+			}
+			if tt.forwarded {
+				req.Header.Set("X-Forwarded-For", "127.0.0.1")
+			}
+			if tt.missingBearer {
+				req.Header.Del("Authorization")
+			} else if tt.bearer != "" {
 				req.Header.Set("Authorization", "Bearer "+tt.bearer)
 			}
-			if tt.cookie != "" {
-				req.AddCookie(&http.Cookie{Name: authCookieName, Value: tt.cookie})
+			if tt.cookie {
+				req.AddCookie(&http.Cookie{Name: authCookieName, Value: "daemon-secret"})
 			}
 			rr := httptest.NewRecorder()
 
-			srv.ServeHTTP(rr, req)
+			admission := (daemonRequestPolicy{token: token}).admit(
+				rr, req, HostCheckOptions{Bind: bind}, true,
+			)
 
-			assert.Equal(t, tt.wantStatus, rr.Code, rr.Body.String())
+			assert.False(t, admission.handled)
+			assert.Equal(t, tt.wantBypass, admission.bypassProxyHostCheck)
+		})
+	}
+}
+
+// TestDirectDaemonBearerHostIntegration protects middleware ordering. Direct
+// bearer requests bypass proxy Host interpretation, while any forwarded shape
+// remains subject to the existing proxy validation and rejection rules.
+func TestDirectDaemonBearerHostIntegration(t *testing.T) {
+	srv := setupHostCheckServerWithToken(t, HostCheckOptions{
+		Bind: bindLoopback8091(),
+		Allowed: []config.HostKey{
+			{Host: "mm.example.com"}, {Host: "other.example.com"},
+		},
+		TrustReverseProxy: true,
+	}, "daemon-secret")
+	tests := []struct {
+		name    string
+		bearer  string
+		headers http.Header
+		status  int
+	}{
+		{name: "direct bearer", bearer: "daemon-secret", status: http.StatusOK},
+		{name: "missing bearer", status: http.StatusForbidden},
+		{
+			name: "valid forwarded host", bearer: "daemon-secret",
+			headers: http.Header{"X-Forwarded-Host": {"mm.example.com"}},
+			status:  http.StatusOK,
+		},
+		{
+			name: "malformed forwarded header", bearer: "daemon-secret",
+			headers: http.Header{"Forwarded": {"wat"}}, status: http.StatusForbidden,
+		},
+		{
+			name: "conflicting forwarded headers", bearer: "daemon-secret",
+			headers: http.Header{
+				"Forwarded":        {"host=other.example.com"},
+				"X-Forwarded-Host": {"mm.example.com"},
+			},
+			status: http.StatusForbidden,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rr := serveDirectDaemonRequest(srv, tt.bearer, tt.headers)
+
+			assert.Equal(t, tt.status, rr.Code, rr.Body.String())
 		})
 	}
 }
@@ -221,41 +222,13 @@ func TestDirectDaemonBearerClassificationWithoutGeneralAPIAuth(t *testing.T) {
 		},
 		DaemonAccess: DaemonAccessOptions{Token: "daemon-secret"},
 	})
-	tests := []struct {
-		name    string
-		bearer  string
-		headers http.Header
-		status  int
-	}{
-		{name: "valid direct credential", bearer: "daemon-secret", status: http.StatusOK},
-		{name: "missing direct credential", status: http.StatusForbidden},
-		{name: "invalid direct credential", bearer: "wrong", status: http.StatusForbidden},
-		{
-			name:    "unauthenticated proxy request retains configured policy",
-			headers: http.Header{"X-Forwarded-Host": {"mm.example.com"}},
-			status:  http.StatusOK,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodGet, "/api/v1/snapshot", nil)
-			req.Host = "127.0.0.1:8091"
-			req.RemoteAddr = "127.0.0.1:1234"
-			if tt.bearer != "" {
-				req.Header.Set("Authorization", "Bearer "+tt.bearer)
-			}
-			for name, values := range tt.headers {
-				for _, value := range values {
-					req.Header.Add(name, value)
-				}
-			}
-			rr := httptest.NewRecorder()
+	direct := serveDirectDaemonRequest(srv, "daemon-secret", nil)
+	assert.Equal(t, http.StatusOK, direct.Code, direct.Body.String())
 
-			srv.ServeHTTP(rr, req)
-
-			assert.Equal(t, tt.status, rr.Code, rr.Body.String())
-		})
-	}
+	proxied := serveDirectDaemonRequest(srv, "", http.Header{
+		"X-Forwarded-Host": {"mm.example.com"},
+	})
+	assert.Equal(t, http.StatusOK, proxied.Code, proxied.Body.String())
 }
 
 // TestHostCheckBackendHost exercises Step 1+2 of the spec: parse

--- a/internal/server/host_check_test.go
+++ b/internal/server/host_check_test.go
@@ -35,9 +35,10 @@ func setupHostCheckServerWithToken(
 	syncer := ghclient.NewSyncer(nil, database, nil, nil, time.Minute, nil, nil)
 	t.Cleanup(syncer.Stop)
 	return New(database, syncer, emptyFrontend(), "/", nil, ServerOptions{
-		HostCheck:         opts,
-		APIAuthToken:      token,
-		DirectClientToken: token,
+		HostCheck: opts,
+		DaemonAccess: DaemonAccessOptions{
+			Token: token, RequireAPIAuth: token != "",
+		},
 	})
 }
 
@@ -218,7 +219,7 @@ func TestDirectDaemonBearerClassificationWithoutGeneralAPIAuth(t *testing.T) {
 			Allowed:           []config.HostKey{{Host: "mm.example.com"}},
 			TrustReverseProxy: true,
 		},
-		DirectClientToken: "daemon-secret",
+		DaemonAccess: DaemonAccessOptions{Token: "daemon-secret"},
 	})
 	tests := []struct {
 		name    string

--- a/internal/server/host_check_test.go
+++ b/internal/server/host_check_test.go
@@ -24,17 +24,183 @@ import (
 // resolveHostCheckOptions over both the cfg=nil fallback and the
 // test-friendly AllowLoopbackAnyPort relaxation.
 func setupHostCheckServer(t *testing.T, opts HostCheckOptions) *Server {
+	return setupHostCheckServerWithToken(t, opts, "")
+}
+
+func setupHostCheckServerWithToken(
+	t *testing.T, opts HostCheckOptions, token string,
+) *Server {
 	t.Helper()
 	database := dbtest.Open(t)
 	syncer := ghclient.NewSyncer(nil, database, nil, nil, time.Minute, nil, nil)
 	t.Cleanup(syncer.Stop)
 	return New(database, syncer, emptyFrontend(), "/", nil, ServerOptions{
-		HostCheck: opts,
+		HostCheck:    opts,
+		APIAuthToken: token,
 	})
 }
 
 func bindLoopback8091() config.HostKey {
 	return config.HostKey{Host: "127.0.0.1", Port: "8091"}
+}
+
+type fixedAddrListener struct {
+	net.Listener
+	addr net.Addr
+}
+
+func (l fixedAddrListener) Addr() net.Addr { return l.addr }
+
+// TestDirectDaemonBearerClassification protects the native-client trust
+// boundary. If bearer classification moves after proxy Host validation,
+// authenticated CLI requests fail whenever trust_reverse_proxy is enabled. If
+// the classifier is widened, cookies, listener aliases, configured public
+// hosts, or forwarded requests can bypass the proxy checks.
+func TestDirectDaemonBearerClassification(t *testing.T) {
+	tests := []struct {
+		name            string
+		configuredToken string
+		host            string
+		bearer          string
+		cookie          string
+		headers         http.Header
+		remoteAddr      string
+		wantStatus      int
+	}{
+		{
+			name:            "valid bearer and exact listener authority",
+			configuredToken: "daemon-secret",
+			host:            "127.0.0.1:8091", bearer: "daemon-secret",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:            "missing bearer",
+			configuredToken: "daemon-secret",
+			host:            "127.0.0.1:8091", wantStatus: http.StatusForbidden,
+		},
+		{
+			name:            "invalid bearer",
+			configuredToken: "daemon-secret",
+			host:            "127.0.0.1:8091", bearer: "wrong",
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:            "session cookie does not qualify",
+			configuredToken: "daemon-secret",
+			host:            "127.0.0.1:8091", cookie: "daemon-secret",
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:            "loopback alias is not the exact listener authority",
+			configuredToken: "daemon-secret",
+			host:            "localhost:8091", bearer: "daemon-secret",
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:            "non-loopback peer is not a direct client",
+			configuredToken: "daemon-secret",
+			host:            "127.0.0.1:8091", bearer: "daemon-secret",
+			remoteAddr: "192.0.2.1:1234", wantStatus: http.StatusForbidden,
+		},
+		{
+			name:            "allowed public host is not the listener authority",
+			configuredToken: "daemon-secret",
+			host:            "mm.example.com", bearer: "daemon-secret",
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:            "X-Forwarded-For stays on proxy path",
+			configuredToken: "daemon-secret",
+			host:            "127.0.0.1:8091", bearer: "daemon-secret",
+			headers:    http.Header{"X-Forwarded-For": {"127.0.0.1"}},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:            "valid forwarded host stays on proxy path",
+			configuredToken: "daemon-secret",
+			host:            "127.0.0.1:8091", bearer: "daemon-secret",
+			headers:    http.Header{"X-Forwarded-Host": {"mm.example.com"}},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:            "malformed forwarded header stays rejected",
+			configuredToken: "daemon-secret",
+			host:            "127.0.0.1:8091", bearer: "daemon-secret",
+			headers:    http.Header{"Forwarded": {"wat"}},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:            "conflicting forwarded headers stay rejected",
+			configuredToken: "daemon-secret",
+			host:            "127.0.0.1:8091", bearer: "daemon-secret",
+			headers: http.Header{
+				"Forwarded":        {"host=other.example.com"},
+				"X-Forwarded-Host": {"mm.example.com"},
+			},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name: "authentication disabled",
+			host: "127.0.0.1:8091", bearer: "daemon-secret",
+			wantStatus: http.StatusForbidden,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := setupHostCheckServerWithToken(t, HostCheckOptions{
+				Bind: bindLoopback8091(),
+				Allowed: []config.HostKey{
+					{Host: "mm.example.com", Port: ""},
+					{Host: "other.example.com", Port: ""},
+				},
+				TrustReverseProxy: true,
+			}, tt.configuredToken)
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/snapshot", nil)
+			req.Host = tt.host
+			req.RemoteAddr = tt.remoteAddr
+			if req.RemoteAddr == "" {
+				req.RemoteAddr = "127.0.0.1:1234"
+			}
+			for name, values := range tt.headers {
+				for _, value := range values {
+					req.Header.Add(name, value)
+				}
+			}
+			if tt.bearer != "" {
+				req.Header.Set("Authorization", "Bearer "+tt.bearer)
+			}
+			if tt.cookie != "" {
+				req.AddCookie(&http.Cookie{Name: authCookieName, Value: tt.cookie})
+			}
+			rr := httptest.NewRecorder()
+
+			srv.ServeHTTP(rr, req)
+
+			assert.Equal(t, tt.wantStatus, rr.Code, rr.Body.String())
+		})
+	}
+}
+
+func TestDirectDaemonBearerUsesActualIPv6ListenerAuthority(t *testing.T) {
+	srv := setupHostCheckServerWithToken(t, HostCheckOptions{
+		Bind: config.HostKey{
+			Host: "[0:0:0:0:0:0:0:1]", Port: "8091",
+		},
+		TrustReverseProxy: true,
+	}, "daemon-secret")
+	srv.adoptListenerHostPort(fixedAddrListener{addr: &net.TCPAddr{
+		IP: net.IPv6loopback, Port: 8091,
+	}})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/snapshot", nil)
+	req.Host = "[::1]:8091"
+	req.RemoteAddr = "[::1]:1234"
+	req.Header.Set("Authorization", "Bearer daemon-secret")
+	rr := httptest.NewRecorder()
+
+	srv.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
 }
 
 // TestHostCheckBackendHost exercises Step 1+2 of the spec: parse

--- a/internal/server/host_check_test.go
+++ b/internal/server/host_check_test.go
@@ -35,8 +35,9 @@ func setupHostCheckServerWithToken(
 	syncer := ghclient.NewSyncer(nil, database, nil, nil, time.Minute, nil, nil)
 	t.Cleanup(syncer.Stop)
 	return New(database, syncer, emptyFrontend(), "/", nil, ServerOptions{
-		HostCheck:    opts,
-		APIAuthToken: token,
+		HostCheck:         opts,
+		APIAuthToken:      token,
+		DirectClientToken: token,
 	})
 }
 
@@ -201,6 +202,59 @@ func TestDirectDaemonBearerUsesActualIPv6ListenerAuthority(t *testing.T) {
 	srv.ServeHTTP(rr, req)
 
 	assert.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+}
+
+// TestDirectDaemonBearerClassificationWithoutGeneralAPIAuth protects the
+// distinction between the direct-listener credential and optional API auth.
+// A native client must still bypass proxy Host interpretation without forcing
+// proxied browser/API traffic to authenticate.
+func TestDirectDaemonBearerClassificationWithoutGeneralAPIAuth(t *testing.T) {
+	database := dbtest.Open(t)
+	syncer := ghclient.NewSyncer(nil, database, nil, nil, time.Minute, nil, nil)
+	t.Cleanup(syncer.Stop)
+	srv := New(database, syncer, emptyFrontend(), "/", nil, ServerOptions{
+		HostCheck: HostCheckOptions{
+			Bind:              bindLoopback8091(),
+			Allowed:           []config.HostKey{{Host: "mm.example.com"}},
+			TrustReverseProxy: true,
+		},
+		DirectClientToken: "daemon-secret",
+	})
+	tests := []struct {
+		name    string
+		bearer  string
+		headers http.Header
+		status  int
+	}{
+		{name: "valid direct credential", bearer: "daemon-secret", status: http.StatusOK},
+		{name: "missing direct credential", status: http.StatusForbidden},
+		{name: "invalid direct credential", bearer: "wrong", status: http.StatusForbidden},
+		{
+			name:    "unauthenticated proxy request retains configured policy",
+			headers: http.Header{"X-Forwarded-Host": {"mm.example.com"}},
+			status:  http.StatusOK,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/snapshot", nil)
+			req.Host = "127.0.0.1:8091"
+			req.RemoteAddr = "127.0.0.1:1234"
+			if tt.bearer != "" {
+				req.Header.Set("Authorization", "Bearer "+tt.bearer)
+			}
+			for name, values := range tt.headers {
+				for _, value := range values {
+					req.Header.Add(name, value)
+				}
+			}
+			rr := httptest.NewRecorder()
+
+			srv.ServeHTTP(rr, req)
+
+			assert.Equal(t, tt.status, rr.Code, rr.Body.String())
+		})
+	}
 }
 
 // TestHostCheckBackendHost exercises Step 1+2 of the spec: parse

--- a/internal/server/host_check_test.go
+++ b/internal/server/host_check_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"maps"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -47,30 +46,23 @@ func bindLoopback8091() config.HostKey {
 	return config.HostKey{Host: "127.0.0.1", Port: "8091"}
 }
 
-type fixedAddrListener struct {
-	net.Listener
-	addr net.Addr
-}
-
-func (l fixedAddrListener) Addr() net.Addr { return l.addr }
-
-func newDirectDaemonRequest(bearer string, headers http.Header) *http.Request {
+func directDaemonRequest(bearer string, headers http.Header) *http.Request {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/snapshot", nil)
 	req.Host = "127.0.0.1:8091"
 	req.RemoteAddr = "127.0.0.1:1234"
+	if headers != nil {
+		req.Header = headers.Clone()
+	}
 	if bearer != "" {
 		req.Header.Set("Authorization", "Bearer "+bearer)
 	}
-	maps.Copy(req.Header, headers)
 	return req
 }
 
-func serveDirectDaemonRequest(
-	srv *Server, bearer string, headers http.Header,
-) *httptest.ResponseRecorder {
+func serveDirectDaemonRequest(srv *Server, bearer string, headers http.Header) int {
 	rr := httptest.NewRecorder()
-	srv.ServeHTTP(rr, newDirectDaemonRequest(bearer, headers))
-	return rr
+	srv.ServeHTTP(rr, directDaemonRequest(bearer, headers))
+	return rr.Code
 }
 
 // TestDirectDaemonBearerClassification protects the native-client trust
@@ -79,57 +71,37 @@ func serveDirectDaemonRequest(
 // requests can bypass reverse-proxy Host validation.
 func TestDirectDaemonBearerClassification(t *testing.T) {
 	tests := []struct {
-		name                     string
-		bearer, host, remoteAddr string
-		missingBearer, noToken   bool
-		cookie, forwarded, ipv6  bool
-		wantBypass               bool
+		name, token, host, remoteAddr, bearer string
+		headers                               http.Header
+		cookie, wantBypass                    bool
+		bind                                  config.HostKey
 	}{
-		{name: "valid exact listener authority", wantBypass: true},
-		{name: "missing bearer", missingBearer: true},
-		{name: "invalid bearer", bearer: "wrong"},
-		{name: "session cookie does not qualify", missingBearer: true, cookie: true},
-		{name: "loopback alias is not exact", host: "localhost:8091"},
-		{name: "non-loopback peer", remoteAddr: "192.0.2.1:1234"},
-		{name: "public host", host: "mm.example.com"},
-		{name: "forwarded request", forwarded: true},
-		{name: "missing configured token", noToken: true},
-		{name: "IPv6 listener authority", ipv6: true, wantBypass: true},
+		{name: "valid", token: "secret", host: "127.0.0.1:8091", remoteAddr: "127.0.0.1:1", bearer: "secret", wantBypass: true},
+		{name: "missing bearer", token: "secret", host: "127.0.0.1:8091", remoteAddr: "127.0.0.1:1"},
+		{name: "invalid bearer", token: "secret", host: "127.0.0.1:8091", remoteAddr: "127.0.0.1:1", bearer: "wrong"},
+		{name: "cookie", token: "secret", host: "127.0.0.1:8091", remoteAddr: "127.0.0.1:1", cookie: true},
+		{name: "listener alias", token: "secret", host: "localhost:8091", remoteAddr: "127.0.0.1:1", bearer: "secret"},
+		{name: "non-loopback peer", token: "secret", host: "127.0.0.1:8091", remoteAddr: "192.0.2.1:1", bearer: "secret"},
+		{name: "public host", token: "secret", host: "mm.example.com", remoteAddr: "127.0.0.1:1", bearer: "secret"},
+		{name: "forwarded", token: "secret", host: "127.0.0.1:8091", remoteAddr: "127.0.0.1:1", bearer: "secret", headers: http.Header{"Forwarded": {"host=mm.example.com"}}},
+		{name: "missing token", host: "127.0.0.1:8091", remoteAddr: "127.0.0.1:1", bearer: "secret"},
+		{name: "IPv6", token: "secret", bind: config.HostKey{Host: "[::1]", Port: "8091"}, host: "[::1]:8091", remoteAddr: "[::1]:1", bearer: "secret", wantBypass: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			token := "daemon-secret"
-			if tt.noToken {
-				token = ""
-			}
 			bind := bindLoopback8091()
-			req := newDirectDaemonRequest("daemon-secret", nil)
-			if tt.ipv6 {
-				bind = config.HostKey{Host: "[::1]", Port: "8091"}
-				req.Host = "[::1]:8091"
-				req.RemoteAddr = "[::1]:1234"
+			if tt.bind.Host != "" {
+				bind = tt.bind
 			}
-			if tt.host != "" {
-				req.Host = tt.host
-			}
-			if tt.remoteAddr != "" {
-				req.RemoteAddr = tt.remoteAddr
-			}
-			if tt.forwarded {
-				req.Header.Set("X-Forwarded-For", "127.0.0.1")
-			}
-			if tt.missingBearer {
-				req.Header.Del("Authorization")
-			} else if tt.bearer != "" {
-				req.Header.Set("Authorization", "Bearer "+tt.bearer)
-			}
+			req := directDaemonRequest(tt.bearer, tt.headers)
+			req.Host, req.RemoteAddr = tt.host, tt.remoteAddr
 			if tt.cookie {
-				req.AddCookie(&http.Cookie{Name: authCookieName, Value: "daemon-secret"})
+				req.AddCookie(&http.Cookie{Name: authCookieName, Value: "secret"})
 			}
 			rr := httptest.NewRecorder()
 
-			admission := (daemonRequestPolicy{token: token}).admit(
+			admission := (daemonRequestPolicy{token: tt.token}).admit(
 				rr, req, HostCheckOptions{Bind: bind}, true,
 			)
 
@@ -144,66 +116,12 @@ func TestDirectDaemonBearerClassification(t *testing.T) {
 // remains subject to the existing proxy validation and rejection rules.
 func TestDirectDaemonBearerHostIntegration(t *testing.T) {
 	srv := setupHostCheckServerWithToken(t, HostCheckOptions{
-		Bind: bindLoopback8091(),
-		Allowed: []config.HostKey{
-			{Host: "mm.example.com"}, {Host: "other.example.com"},
-		},
+		Bind:              bindLoopback8091(),
 		TrustReverseProxy: true,
 	}, "daemon-secret")
-	tests := []struct {
-		name    string
-		bearer  string
-		headers http.Header
-		status  int
-	}{
-		{name: "direct bearer", bearer: "daemon-secret", status: http.StatusOK},
-		{name: "missing bearer", status: http.StatusForbidden},
-		{
-			name: "valid forwarded host", bearer: "daemon-secret",
-			headers: http.Header{"X-Forwarded-Host": {"mm.example.com"}},
-			status:  http.StatusOK,
-		},
-		{
-			name: "malformed forwarded header", bearer: "daemon-secret",
-			headers: http.Header{"Forwarded": {"wat"}}, status: http.StatusForbidden,
-		},
-		{
-			name: "conflicting forwarded headers", bearer: "daemon-secret",
-			headers: http.Header{
-				"Forwarded":        {"host=other.example.com"},
-				"X-Forwarded-Host": {"mm.example.com"},
-			},
-			status: http.StatusForbidden,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			rr := serveDirectDaemonRequest(srv, tt.bearer, tt.headers)
-
-			assert.Equal(t, tt.status, rr.Code, rr.Body.String())
-		})
-	}
-}
-
-func TestDirectDaemonBearerUsesActualIPv6ListenerAuthority(t *testing.T) {
-	srv := setupHostCheckServerWithToken(t, HostCheckOptions{
-		Bind: config.HostKey{
-			Host: "[0:0:0:0:0:0:0:1]", Port: "8091",
-		},
-		TrustReverseProxy: true,
-	}, "daemon-secret")
-	srv.adoptListenerHostPort(fixedAddrListener{addr: &net.TCPAddr{
-		IP: net.IPv6loopback, Port: 8091,
-	}})
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/snapshot", nil)
-	req.Host = "[::1]:8091"
-	req.RemoteAddr = "[::1]:1234"
-	req.Header.Set("Authorization", "Bearer daemon-secret")
-	rr := httptest.NewRecorder()
-
-	srv.ServeHTTP(rr, req)
-
-	assert.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	assert.Equal(t, http.StatusOK, serveDirectDaemonRequest(srv, "daemon-secret", nil))
+	assert.Equal(t, http.StatusForbidden, serveDirectDaemonRequest(srv, "", nil))
+	assert.Equal(t, http.StatusForbidden, serveDirectDaemonRequest(srv, "wrong", nil))
 }
 
 // TestDirectDaemonBearerClassificationWithoutGeneralAPIAuth protects the
@@ -222,13 +140,10 @@ func TestDirectDaemonBearerClassificationWithoutGeneralAPIAuth(t *testing.T) {
 		},
 		DaemonAccess: DaemonAccessOptions{Token: "daemon-secret"},
 	})
-	direct := serveDirectDaemonRequest(srv, "daemon-secret", nil)
-	assert.Equal(t, http.StatusOK, direct.Code, direct.Body.String())
-
-	proxied := serveDirectDaemonRequest(srv, "", http.Header{
+	assert.Equal(t, http.StatusOK, serveDirectDaemonRequest(srv, "daemon-secret", nil))
+	assert.Equal(t, http.StatusOK, serveDirectDaemonRequest(srv, "", http.Header{
 		"X-Forwarded-Host": {"mm.example.com"},
-	})
-	assert.Equal(t, http.StatusOK, proxied.Code, proxied.Body.String())
+	}))
 }
 
 // TestHostCheckBackendHost exercises Step 1+2 of the spec: parse

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -26,7 +26,6 @@ import (
 	"go.kenn.io/middleman/internal/archive"
 	"go.kenn.io/middleman/internal/config"
 	"go.kenn.io/middleman/internal/configwatch"
-	"go.kenn.io/middleman/internal/daemonruntime"
 	"go.kenn.io/middleman/internal/db"
 	"go.kenn.io/middleman/internal/docs"
 	"go.kenn.io/middleman/internal/gitclone"
@@ -231,10 +230,8 @@ type Server struct {
 	toolingRun    toolingRunner
 
 	// apiAuthToken gates /api routes when non-empty (api_auth.go).
-	apiAuthToken string
-	// directClientToken classifies native direct-listener requests even when
-	// general API authentication is disabled.
-	directClientToken string
+	apiAuthToken   string
+	daemonRequests daemonRequestPolicy
 
 	// bg tracks short-lived goroutines that HTTP handlers spawn
 	// outside of the Syncer's own wait group (e.g. mergePR's
@@ -761,21 +758,24 @@ func newServer(
 	})
 
 	s := &Server{
-		db:                     database,
-		repoResolver:           repoResolver,
-		basePath:               basePath,
-		syncer:                 syncer,
-		archive:                options.Archive,
-		clones:                 clones,
-		telemetry:              options.Telemetry,
-		cfg:                    cfg,
-		cfgPath:                cfgPath,
-		tokenSources:           options.TokenSources,
-		bootCfgSnapshot:        snapshotStartupConfig(cfg),
-		runtimeStripEnvVars:    initialRuntimeStripEnvNames(cfg),
-		options:                options,
-		apiAuthToken:           options.APIAuthToken,
-		directClientToken:      options.DirectClientToken,
+		db:                  database,
+		repoResolver:        repoResolver,
+		basePath:            basePath,
+		syncer:              syncer,
+		archive:             options.Archive,
+		clones:              clones,
+		telemetry:           options.Telemetry,
+		cfg:                 cfg,
+		cfgPath:             cfgPath,
+		tokenSources:        options.TokenSources,
+		bootCfgSnapshot:     snapshotStartupConfig(cfg),
+		runtimeStripEnvVars: initialRuntimeStripEnvNames(cfg),
+		options:             options,
+		apiAuthToken:        options.APIAuthToken,
+		daemonRequests: daemonRequestPolicy{
+			directToken: options.DirectClientToken,
+			proof:       options.DaemonProofHandler,
+		},
 		now:                    time.Now,
 		hub:                    NewEventHubWithCapacity(cfg.SSEBufferSizeOrDefault()),
 		labelCatalogRefreshIDs: make(map[int64]struct{}),
@@ -1295,20 +1295,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 	hostOpts := *s.hostOpts.Load()
-	directDaemonBearer := s.isDirectDaemonBearerRequest(r, hostOpts)
-	directDaemonProof := isDirectDaemonProofRequest(r, hostOpts)
-	if r.URL.Path == daemonruntime.ProofPingPath && !directDaemonProof {
-		rejectHost(w, r, "daemon_proof_not_direct", r.Host, "")
+	admission := s.daemonRequests.admit(
+		w, r, hostOpts, s.isGatedAPIRequest(r),
+	)
+	if admission.handled {
 		return
 	}
-	if !directDaemonBearer && !directDaemonProof && !checkHost(w, r, hostOpts) {
+	if !admission.bypassProxyHostCheck && !checkHost(w, r, hostOpts) {
 		return
 	}
 	if !s.checkHost(w, r) {
-		return
-	}
-	if directDaemonProof {
-		s.handler.ServeHTTP(w, r)
 		return
 	}
 	if s.apiAuthToken != "" {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1128,9 +1128,11 @@ func newServer(
 		prefix := strings.TrimSuffix(basePath, "/")
 		outer.Handle("/healthz", mux)
 		outer.Handle("/livez", mux)
+		s.registerDaemonPing(outer)
 		outer.Handle(basePath, stripPrefixPreservingPattern(prefix, mux))
 		assembled = outer
 	} else {
+		s.registerDaemonPing(mux)
 		assembled = mux
 	}
 	s.handler = otelhttp.NewHandler(assembled, "middleman.http",
@@ -1281,7 +1283,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 	hostOpts := *s.hostOpts.Load()
-	if !checkHost(w, r, hostOpts) {
+	directDaemonBearer := s.isDirectDaemonBearerRequest(r, hostOpts)
+	if !directDaemonBearer && !checkHost(w, r, hostOpts) {
 		return
 	}
 	if !s.checkHost(w, r) {
@@ -1534,20 +1537,16 @@ func (s *Server) AttachHTTPServer(srv *http.Server, ln net.Listener) {
 	s.bgMu.Unlock()
 }
 
-// adoptListenerHostPort repoints the Host-check bind at the actual
-// bound port when the configured bind asked for a kernel-assigned
-// one (port 0) - otherwise every request to an ephemeral-port daemon
-// would be rejected, since no Host header can match port "0".
+// adoptListenerHostPort repoints the Host-check bind at the listener's actual
+// authority. Besides kernel-assigned ports, this normalizes IP literals to the
+// form net/http places in direct request Host headers.
 func (s *Server) adoptListenerHostPort(ln net.Listener) {
 	opts := *s.hostOpts.Load()
-	if opts.Bind.Port != "0" {
+	bind, ok := listenerHostKey(ln)
+	if !ok {
 		return
 	}
-	_, port, err := net.SplitHostPort(ln.Addr().String())
-	if err != nil {
-		return
-	}
-	opts.Bind.Port = port
+	opts.Bind = bind
 	s.hostOpts.Store(&opts)
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -26,6 +26,7 @@ import (
 	"go.kenn.io/middleman/internal/archive"
 	"go.kenn.io/middleman/internal/config"
 	"go.kenn.io/middleman/internal/configwatch"
+	"go.kenn.io/middleman/internal/daemonruntime"
 	"go.kenn.io/middleman/internal/db"
 	"go.kenn.io/middleman/internal/docs"
 	"go.kenn.io/middleman/internal/gitclone"
@@ -67,7 +68,14 @@ type ServerOptions struct {
 	// or session-cookie auth (see api_auth.go). Health probes stay
 	// open. Minted under data_dir by the serve entrypoint when
 	// [api].require_auth is set.
-	APIAuthToken                       string
+	APIAuthToken string
+	// DirectClientToken authenticates native clients addressing the exact
+	// loopback listener without forwarding headers. It is startup-bound and
+	// independent of whether general API authentication is enabled.
+	DirectClientToken string
+	// DaemonProofHandler serves the private credential-free proof route.
+	// Production supplies kit's proof handler bound to the published record.
+	DaemonProofHandler                 http.Handler
 	Clones                             *gitclone.Manager // optional clone manager for diff view
 	WorktreeDir                        string            // base dir for workspace worktrees
 	DisableWorkspaceBackgroundMonitors bool
@@ -224,6 +232,9 @@ type Server struct {
 
 	// apiAuthToken gates /api routes when non-empty (api_auth.go).
 	apiAuthToken string
+	// directClientToken classifies native direct-listener requests even when
+	// general API authentication is disabled.
+	directClientToken string
 
 	// bg tracks short-lived goroutines that HTTP handlers spawn
 	// outside of the Syncer's own wait group (e.g. mergePR's
@@ -764,6 +775,7 @@ func newServer(
 		runtimeStripEnvVars:    initialRuntimeStripEnvNames(cfg),
 		options:                options,
 		apiAuthToken:           options.APIAuthToken,
+		directClientToken:      options.DirectClientToken,
 		now:                    time.Now,
 		hub:                    NewEventHubWithCapacity(cfg.SSEBufferSizeOrDefault()),
 		labelCatalogRefreshIDs: make(map[int64]struct{}),
@@ -1284,10 +1296,19 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}()
 	hostOpts := *s.hostOpts.Load()
 	directDaemonBearer := s.isDirectDaemonBearerRequest(r, hostOpts)
-	if !directDaemonBearer && !checkHost(w, r, hostOpts) {
+	directDaemonProof := isDirectDaemonProofRequest(r, hostOpts)
+	if r.URL.Path == daemonruntime.ProofPingPath && !directDaemonProof {
+		rejectHost(w, r, "daemon_proof_not_direct", r.Host, "")
+		return
+	}
+	if !directDaemonBearer && !directDaemonProof && !checkHost(w, r, hostOpts) {
 		return
 	}
 	if !s.checkHost(w, r) {
+		return
+	}
+	if directDaemonProof {
+		s.handler.ServeHTTP(w, r)
 		return
 	}
 	if s.apiAuthToken != "" {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -63,18 +63,7 @@ type versionOutputBody BuildInfo
 type versionOutput = httpapi.BodyOutput[versionOutputBody]
 
 type ServerOptions struct {
-	// APIAuthToken, when non-empty, gates /api routes behind bearer
-	// or session-cookie auth (see api_auth.go). Health probes stay
-	// open. Minted under data_dir by the serve entrypoint when
-	// [api].require_auth is set.
-	APIAuthToken string
-	// DirectClientToken authenticates native clients addressing the exact
-	// loopback listener without forwarding headers. It is startup-bound and
-	// independent of whether general API authentication is enabled.
-	DirectClientToken string
-	// DaemonProofHandler serves the private credential-free proof route.
-	// Production supplies kit's proof handler bound to the published record.
-	DaemonProofHandler                 http.Handler
+	DaemonAccess                       DaemonAccessOptions
 	Clones                             *gitclone.Manager // optional clone manager for diff view
 	WorktreeDir                        string            // base dir for workspace worktrees
 	DisableWorkspaceBackgroundMonitors bool
@@ -229,8 +218,6 @@ type Server struct {
 	toolingStatus toolingStatusCache
 	toolingRun    toolingRunner
 
-	// apiAuthToken gates /api routes when non-empty (api_auth.go).
-	apiAuthToken   string
 	daemonRequests daemonRequestPolicy
 
 	// bg tracks short-lived goroutines that HTTP handlers spawn
@@ -771,10 +758,10 @@ func newServer(
 		bootCfgSnapshot:     snapshotStartupConfig(cfg),
 		runtimeStripEnvVars: initialRuntimeStripEnvNames(cfg),
 		options:             options,
-		apiAuthToken:        options.APIAuthToken,
 		daemonRequests: daemonRequestPolicy{
-			directToken: options.DirectClientToken,
-			proof:       options.DaemonProofHandler,
+			token:          options.DaemonAccess.Token,
+			requireAPIAuth: options.DaemonAccess.RequireAPIAuth,
+			proof:          options.DaemonAccess.ProofHandler,
 		},
 		now:                    time.Now,
 		hub:                    NewEventHubWithCapacity(cfg.SSEBufferSizeOrDefault()),
@@ -1307,7 +1294,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if !s.checkHost(w, r) {
 		return
 	}
-	if s.apiAuthToken != "" {
+	if s.daemonRequests.requireAPIAuth {
 		if s.handleAuthBootstrap(w, r) {
 			return
 		}

--- a/internal/server/startup_handler.go
+++ b/internal/server/startup_handler.go
@@ -66,6 +66,9 @@ func NewStartupHandler(
 		options.HostCheck,
 		options.HostCheckAllowLoopbackAnyPort,
 	)
+	if bind, ok := listenerHostKey(ln); ok {
+		hostOpts.Bind = bind
+	}
 
 	var spa http.Handler
 	if frontend != nil {

--- a/skills/context-sync/SKILL.md
+++ b/skills/context-sync/SKILL.md
@@ -61,7 +61,7 @@ knowledge that changes what future agents should do.
 | `platform` | `context/provider-architecture.md`, `context/platform-sync-invariants.md` | `internal/platform/` |
 | `github-sync` | `context/github-sync-invariants.md` | `internal/github/` |
 | `db` | `context/db-migrations.md`, `context/embeds.md` | `internal/db/`, `internal/db/migrations/` |
-| `server` | `context/workspace-apis.md`, `context/workspace-runtime-lifecycle.md` | `internal/server/`, `internal/apiclient/generated/` |
+| `server` | `context/daemon-lifecycle.md`, `context/workspace-apis.md`, `context/workspace-runtime-lifecycle.md` | `cmd/middleman/`, `internal/server/`, `internal/apiclient/generated/` |
 | `errors` | `context/error-handling.md` | error envelopes and frontend error branching |
 | `retries` | `context/retries-and-backoffs.md` | retry, backoff, and single-flight paths |
 | `testing` | `context/testing.md` | server API/E2E packages and test helpers |

--- a/tools/devephemeral/main_test.go
+++ b/tools/devephemeral/main_test.go
@@ -54,8 +54,10 @@ func TestPrepareEphemeralConfigOverridesPortAndDataDir(t *testing.T) {
 
 	reloaded, err := config.Load(prepared.configPath)
 	require.NoError(err)
+	expectedDataDir, err := filepath.EvalSymlinks(filepath.Join(workDir, "data"))
+	require.NoError(err)
 	assert.Equal(39101, reloaded.Port)
-	assert.Equal(filepath.Join(workDir, "data"), reloaded.DataDir)
+	assert.Equal(expectedDataDir, reloaded.DataDir)
 	assert.Equal(filepath.Join(workDir, "dev-ephemeral.json"), prepared.statusPath)
 	assert.Equal("http://127.0.0.1:39101", prepared.backendURL)
 	assert.Equal("http://127.0.0.1:39102", prepared.frontendURL)


### PR DESCRIPTION
- Add `middleman start --background`, reusing a compatible proof-verified runtime or starting and verifying one.
- Publish standard daemon discovery and readiness identity from config home, including resolved runtime metadata.
- Prove the recorded endpoint owns the startup token before sending bearer credentials.
- Allow direct loopback clients with the startup-bound bearer while preserving reverse-proxy Host validation and optional API authentication.
- Keep raw foreground duplicate-start behavior unchanged and use loopback TCP across platforms.
