### PR TITLE
Collapse long PR and issue descriptions

### DIFF
--- a/docs/superpowers/plans/2026-07-29-collapsible-long-descriptions.md
+++ b/docs/superpowers/plans/2026-07-29-collapsible-long-descriptions.md
@@ -1,0 +1,322 @@
+# Collapsible Long Descriptions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan directly in the current agent, task-by-task. Never use subagent-driven development. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an expanded-by-default collapse control to provider PR and issue descriptions whose Markdown source exceeds 1,500 characters.
+
+**Approved spec/design:** `docs/superpowers/specs/2026-07-29-collapsible-long-descriptions-design.md`
+
+**Architecture:** Introduce one shared `CollapsibleDescription` Svelte component that owns threshold detection, transient per-item collapse state, the description header, copy control, and compact card styling. Pull and issue detail components retain their existing Markdown rendering and interaction handlers and pass that content to the shared component as a snippet.
+
+**Tech Stack:** Svelte 5 runes and snippets, TypeScript, `@kenn-io/kit-ui`, Testing Library, Vite+ unit and browser projects.
+
+## Global Constraints
+
+- Provider PR and issue descriptions only; Kata task descriptions remain unchanged.
+- A description is long only when its Markdown source length is greater than 1,500 characters.
+- Long descriptions start expanded; compact descriptions have a 320px maximum height and vertical scrolling.
+- Collapse state is transient, per item, and resets when the full provider-aware item identity changes.
+- Existing edit, copy, Markdown, task-list, and drag behavior must remain intact.
+- Do not add persistence, API changes, or dependencies.
+
+---
+
+### Task 1: Shared collapse behavior in pull request details
+
+**Files:**
+- Create: `packages/ui/src/components/detail/CollapsibleDescription.svelte`
+- Modify: `packages/ui/src/components/detail/PullDetail.svelte:2714-2802`
+- Test: `packages/ui/src/components/detail/PullDetail.test.ts`
+
+**Interfaces:**
+- Produces: `CollapsibleDescription` with props `source: string`, `itemKey: string`, `copied: boolean`, `oncopy: () => void`, optional `headerActions?: Snippet`, and `children: Snippet`.
+- Produces: visible `Collapse` / `Expand` control with accessible names `Collapse description` / `Expand description` and `aria-expanded` state.
+- Consumes: the existing `CopyButton`, `Card`, PR body copy callback, edit callback, Markdown renderer, and body drag handlers.
+
+- [ ] **Step 1: Write the failing expanded-default test**
+
+Add this focused behavior test near `PullDetail body copy feedback`:
+
+```ts
+it("offers an expanded collapse control for a long pull description", () => {
+  const detail = pullDetail();
+  detail.merge_request.Body = "x".repeat(1_501);
+  renderPullDetail(detail);
+
+  const collapse = screen.getByRole("button", { name: "Collapse description" });
+  expect(collapse.getAttribute("aria-expanded")).toBe("true");
+});
+```
+
+The production mutation caught by this test is omitting the long-description control or defaulting it to compact.
+
+- [ ] **Step 2: Run the test and verify the missing behavior**
+
+Run:
+
+```bash
+cd frontend && ../node_modules/.bin/vp test run --project unit ../packages/ui/src/components/detail/PullDetail.test.ts -t "offers an expanded collapse control"
+```
+
+Expected: FAIL because no button named `Collapse description` exists.
+
+- [ ] **Step 3: Add the minimal shared component and use it for PR bodies**
+
+Create the component with this public shape and initial state:
+
+```svelte
+<script lang="ts">
+  import { Card, CopyButton } from "@kenn-io/kit-ui";
+  import type { Snippet } from "svelte";
+
+  interface Props {
+    source: string;
+    itemKey: string;
+    copied: boolean;
+    oncopy: () => void;
+    headerActions?: Snippet;
+    children: Snippet;
+  }
+
+  const { source, itemKey, copied, oncopy, headerActions, children }: Props = $props();
+  let collapsed = $state(false);
+  const isLong = true;
+
+  function toggleCollapsed(): void {
+    collapsed = !collapsed;
+  }
+</script>
+```
+
+Render the `Description` header, the conditional text button, the existing copy button contract, a `Card level="inset" padding="none"`, and `{@render children()}`. The toggle uses `aria-expanded={!collapsed}`, the visible label is `Collapse` or `Expand`, and its `aria-label` adds `description`.
+
+In `PullDetail.svelte`, replace only the non-editing `pr.Body` header/card branch with `CollapsibleDescription`. Pass a provider-aware `itemKey` containing `provider`, `platformHost`, `owner`, `name`, `number`, and the `pull` kind. Pass the existing Edit button as `headerActions`; keep the textarea/add-description branches in `PullDetail`.
+
+- [ ] **Step 4: Run the focused test and verify it passes**
+
+Run the Step 2 command.
+
+Expected: PASS.
+
+- [ ] **Step 5: Write failing threshold and identity-reset tests**
+
+Add two tests:
+
+```ts
+it("does not offer collapse at the long-description threshold", () => {
+  const detail = pullDetail();
+  detail.merge_request.Body = "x".repeat(1_500);
+  renderPullDetail(detail);
+
+  expect(screen.queryByRole("button", { name: "Collapse description" })).toBeNull();
+});
+
+it("expands a collapsed description after pull navigation", async () => {
+  const detail = pullDetail();
+  detail.merge_request.Body = "x".repeat(1_501);
+  const { rerender } = renderPullDetail(detail);
+
+  await fireEvent.click(screen.getByRole("button", { name: "Collapse description" }));
+  expect(screen.getByRole("button", { name: "Expand description" }).getAttribute("aria-expanded")).toBe("false");
+
+  detail.merge_request.Number = 2;
+  await rerender({ number: 2 });
+
+  expect(screen.getByRole("button", { name: "Collapse description" }).getAttribute("aria-expanded")).toBe("true");
+});
+```
+
+The first test catches an off-by-one threshold. The second catches collapse state leaking between provider item identities.
+
+- [ ] **Step 6: Run the new tests and verify the expected failures**
+
+Run:
+
+```bash
+cd frontend && ../node_modules/.bin/vp test run --project unit ../packages/ui/src/components/detail/PullDetail.test.ts -t "long-description threshold|after pull navigation"
+```
+
+Expected: both tests FAIL because the minimal implementation shows the control unconditionally and stores collapse as a plain boolean.
+
+- [ ] **Step 7: Complete threshold and per-item state behavior**
+
+Replace the minimal state with the final threshold and per-item derivations:
+
+```ts
+let collapsedItemKey = $state<string | null>(null);
+const isLong = $derived(source.length > 1_500);
+const collapsed = $derived(isLong && collapsedItemKey === itemKey);
+
+function toggleCollapsed(): void {
+  collapsedItemKey = collapsed ? null : itemKey;
+}
+```
+
+Do not use `$effect` or persistence: changing `itemKey` makes `collapsed` false without an imperative reset.
+
+- [ ] **Step 8: Run the entire PullDetail unit file**
+
+Run:
+
+```bash
+cd frontend && ../node_modules/.bin/vp test run --project unit ../packages/ui/src/components/detail/PullDetail.test.ts
+```
+
+Expected: PASS, including existing copy and editing behavior.
+
+- [ ] **Step 9: Commit Task 1**
+
+Before committing, run the repository-local `context-sync` skill with `--commit`, then the mandatory commit skill. Stage only these files and create a conventional commit explaining why long descriptions need an opt-in compact state.
+
+---
+
+### Task 2: Compact scrolling in a real browser
+
+**Files:**
+- Modify: `packages/ui/src/components/detail/CollapsibleDescription.svelte`
+- Create: `frontend/src/test/CollapsibleDescriptionBrowserFixture.svelte`
+- Create: `frontend/src/CollapsibleDescription.browser.svelte.ts`
+
+**Interfaces:**
+- Consumes: `CollapsibleDescription` from Task 1.
+- Produces: `.detail-description-card--compact` with computed `max-height: 320px` and `overflow-y: auto`.
+
+- [ ] **Step 1: Write the browser fixture and failing layout test**
+
+The fixture renders `CollapsibleDescription` with a 1,501-character source, a stable item key, and content tall enough to overflow:
+
+```svelte
+<CollapsibleDescription source={"x".repeat(1_501)} itemKey="github:github.com:acme/widget:pull:1" copied={false} oncopy={() => {}}>
+  <div style="height: 640px">Long rendered description</div>
+</CollapsibleDescription>
+```
+
+The browser test mounts the fixture, clicks `Collapse description`, selects `.detail-description-card--compact`, and asserts:
+
+```ts
+expect(getComputedStyle(card).maxHeight).toBe("320px");
+expect(getComputedStyle(card).overflowY).toBe("auto");
+```
+
+The production mutation caught by this test is toggling the label/state without creating the requested bounded scrolling surface.
+
+- [ ] **Step 2: Run the browser test and verify it fails**
+
+Run:
+
+```bash
+cd frontend && ../node_modules/.bin/vp test run --project browser src/CollapsibleDescription.browser.svelte.ts
+```
+
+Expected: FAIL because the compact card does not yet compute to a 320px scroll container.
+
+- [ ] **Step 3: Add compact card styling**
+
+In `CollapsibleDescription.svelte`, apply the compact modifier only when `collapsed` is true:
+
+```css
+:global(.detail-description-card) {
+  overflow: hidden;
+}
+
+:global(.detail-description-card--compact) {
+  max-height: 320px;
+  overflow-y: auto;
+}
+```
+
+Keep the copy button outside the scrolling `Card` so it remains reachable while the description scrolls. Use the existing spacing tokens for new gaps and padding.
+
+- [ ] **Step 4: Run the browser test and verify it passes**
+
+Run the Step 2 command.
+
+Expected: PASS.
+
+- [ ] **Step 5: Validate the new Svelte component**
+
+Run:
+
+```bash
+node node_modules/vite-plus/bin/vp exec -- svelte-mcp svelte-autofixer packages/ui/src/components/detail/CollapsibleDescription.svelte --svelte-version 5
+node node_modules/vite-plus/bin/vp exec -- svelte-check --tsconfig packages/ui/tsconfig.json --fail-on-warnings
+```
+
+Expected: no actionable autofixer findings and no Svelte errors or warnings.
+
+- [ ] **Step 6: Commit Task 2**
+
+Before committing, run `context-sync --commit` and the mandatory commit skill. Stage the shared component and browser test/fixture only.
+
+---
+
+### Task 3: Reuse the collapse surface for issue details
+
+**Files:**
+- Modify: `packages/ui/src/components/detail/IssueDetail.svelte:1375-1418`
+- Test: `packages/ui/src/components/detail/IssueDetail.test.ts`
+
+**Interfaces:**
+- Consumes: the `CollapsibleDescription` props and behavior completed in Tasks 1-2.
+- Preserves: existing issue body copy callback, rendered Markdown, interactive tasks, and body drag handlers.
+
+- [ ] **Step 1: Write the failing issue integration test**
+
+Add:
+
+```ts
+it("collapses and expands a long issue description", async () => {
+  const detail = issueDetail();
+  detail.issue.Body = "x".repeat(1_501);
+  renderIssueDetail(detail);
+
+  await fireEvent.click(screen.getByRole("button", { name: "Collapse description" }));
+  const expand = screen.getByRole("button", { name: "Expand description" });
+  expect(expand.getAttribute("aria-expanded")).toBe("false");
+
+  await fireEvent.click(expand);
+  expect(screen.getByRole("button", { name: "Collapse description" }).getAttribute("aria-expanded")).toBe("true");
+});
+```
+
+The production mutation caught by this test is wiring the shared behavior only into pull requests.
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run:
+
+```bash
+cd frontend && ../node_modules/.bin/vp test run --project unit ../packages/ui/src/components/detail/IssueDetail.test.ts -t "collapses and expands a long issue description"
+```
+
+Expected: FAIL because IssueDetail does not yet render the shared control.
+
+- [ ] **Step 3: Replace the issue description wrapper**
+
+Import `CollapsibleDescription` in `IssueDetail.svelte` and replace the existing `section-header` / `inset-box-wrap` / `Card` shell for non-empty issue bodies. Pass `issue.Body`, the existing copy state and callback, and an item key containing `provider`, `platformHost`, `owner`, `name`, `number`, and the `issue` kind. Keep the existing `.inset-box__content markdown-body` div and every click/drag/drop handler as the child snippet.
+
+- [ ] **Step 4: Run the issue test file and verify it passes**
+
+Run:
+
+```bash
+cd frontend && ../node_modules/.bin/vp test run --project unit ../packages/ui/src/components/detail/IssueDetail.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run final affected verification**
+
+Run:
+
+```bash
+cd frontend && ../node_modules/.bin/vp test run --project unit ../packages/ui/src/components/detail/PullDetail.test.ts ../packages/ui/src/components/detail/IssueDetail.test.ts
+cd frontend && ../node_modules/.bin/vp test run --project browser src/CollapsibleDescription.browser.svelte.ts
+node node_modules/vite-plus/bin/vp run ui-package-check
+```
+
+Expected: all commands pass. Playwright/full-stack testing is intentionally omitted because the interaction is component-owned and the only layout-sensitive contract is covered in the real-browser Vitest test.
+
+- [ ] **Step 6: Commit Task 3**
+
+Run `context-sync --commit`, load the mandatory commit skill, review the complete diff, and commit the issue integration and any final scoped fixes. Do not amend earlier commits.

--- a/docs/superpowers/plans/2026-07-29-collapsible-long-descriptions.md
+++ b/docs/superpowers/plans/2026-07-29-collapsible-long-descriptions.md
@@ -6,7 +6,7 @@
 
 **Approved spec/design:** `docs/superpowers/specs/2026-07-29-collapsible-long-descriptions-design.md`
 
-**Architecture:** Introduce one shared `CollapsibleDescription` Svelte component that owns threshold detection, transient per-item collapse state, the description header, copy control, and compact card styling. Pull and issue detail components retain their existing Markdown rendering and interaction handlers and pass that content to the shared component as a snippet.
+**Architecture:** Introduce one shared `CollapsibleDescription` Svelte component that owns threshold detection, transient collapse state, the description header, copy control, and compact card styling. Pull and issue detail components retain their existing Markdown rendering and interaction handlers, key the shared component by normalized provider-aware identity, and pass rendered content as a snippet.
 
 **Tech Stack:** Svelte 5 runes and snippets, TypeScript, `@kenn-io/kit-ui`, Testing Library, Vite+ unit and browser projects.
 
@@ -29,7 +29,7 @@
 - Test: `packages/ui/src/components/detail/PullDetail.test.ts`
 
 **Interfaces:**
-- Produces: `CollapsibleDescription` with props `source: string`, `itemKey: string`, `copied: boolean`, `oncopy: () => void`, optional `headerActions?: Snippet`, and `children: Snippet`.
+- Produces: `CollapsibleDescription` with props `source: string`, `copied: boolean`, `oncopy: () => void`, optional `headerActions?: Snippet`, and `children: Snippet`.
 - Produces: visible `Collapse` / `Expand` control with accessible names `Collapse description` / `Expand description` and `aria-expanded` state.
 - Consumes: the existing `CopyButton`, `Card`, PR body copy callback, edit callback, Markdown renderer, and body drag handlers.
 
@@ -71,14 +71,13 @@ Create the component with this public shape and initial state:
 
   interface Props {
     source: string;
-    itemKey: string;
     copied: boolean;
     oncopy: () => void;
     headerActions?: Snippet;
     children: Snippet;
   }
 
-  const { source, itemKey, copied, oncopy, headerActions, children }: Props = $props();
+  const { source, copied, oncopy, headerActions, children }: Props = $props();
   let collapsed = $state(false);
   const isLong = true;
 
@@ -90,7 +89,7 @@ Create the component with this public shape and initial state:
 
 Render the `Description` header, the conditional text button, the existing copy button contract, a `Card level="inset" padding="none"`, and `{@render children()}`. The toggle uses `aria-expanded={!collapsed}`, the visible label is `Collapse` or `Expand`, and its `aria-label` adds `description`.
 
-In `PullDetail.svelte`, replace only the non-editing `pr.Body` header/card branch with `CollapsibleDescription`. Pass a provider-aware `itemKey` containing `provider`, `platformHost`, `owner`, `name`, `number`, and the `pull` kind. Pass the existing Edit button as `headerActions`; keep the textarea/add-description branches in `PullDetail`.
+In `PullDetail.svelte`, replace only the non-editing `pr.Body` header/card branch with `CollapsibleDescription`. Derive a normalized provider-aware key containing `canonicalProvider(provider)`, `resolvedPlatformHost(provider, platformHost)`, `owner`, `name`, `number`, and the `pull` kind, then wrap the shared component in a Svelte `{#key}` block. Pass the existing Edit button as `headerActions`; keep the textarea/add-description branches in `PullDetail`.
 
 - [ ] **Step 4: Run the focused test and verify it passes**
 
@@ -123,6 +122,11 @@ it("expands a collapsed description after pull navigation", async () => {
   await rerender({ number: 2 });
 
   expect(screen.getByRole("button", { name: "Collapse description" }).getAttribute("aria-expanded")).toBe("true");
+
+  detail.merge_request.Number = 1;
+  await rerender({ number: 1 });
+
+  expect(screen.getByRole("button", { name: "Collapse description" }).getAttribute("aria-expanded")).toBe("true");
 });
 ```
 
@@ -140,19 +144,20 @@ Expected: both tests FAIL because the minimal implementation shows the control u
 
 - [ ] **Step 7: Complete threshold and per-item state behavior**
 
-Replace the minimal state with the final threshold and per-item derivations:
+Replace the unconditional threshold with the final source-length derivation:
 
 ```ts
-let collapsedItemKey = $state<string | null>(null);
+let collapsed = $state(false);
 const isLong = $derived(source.length > 1_500);
-const collapsed = $derived(isLong && collapsedItemKey === itemKey);
 
 function toggleCollapsed(): void {
-  collapsedItemKey = collapsed ? null : itemKey;
+  collapsed = !collapsed;
 }
 ```
 
-Do not use `$effect` or persistence: changing `itemKey` makes `collapsed` false without an imperative reset.
+In each provider detail parent, derive `descriptionItemKey` from canonical provider, resolved host, owner, name, item kind, and number. Wrap the complete existing `CollapsibleDescription` call in `{#key descriptionItemKey}` / `{/key}` without changing its rendered Markdown child.
+
+Do not use `$effect` or persistence: Svelte recreates the transient component state whenever navigation changes normalized identity, including an A → B → A round trip.
 
 - [ ] **Step 8: Run the entire PullDetail unit file**
 
@@ -186,7 +191,7 @@ Before committing, run the repository-local `context-sync` skill with `--commit`
 The fixture renders `CollapsibleDescription` with a 1,501-character source, a stable item key, and content tall enough to overflow:
 
 ```svelte
-<CollapsibleDescription source={"x".repeat(1_501)} itemKey="github:github.com:acme/widget:pull:1" copied={false} oncopy={() => {}}>
+<CollapsibleDescription source={"x".repeat(1_501)} copied={false} oncopy={() => {}}>
   <div style="height: 640px">Long rendered description</div>
 </CollapsibleDescription>
 ```
@@ -293,7 +298,7 @@ Expected: FAIL because IssueDetail does not yet render the shared control.
 
 - [ ] **Step 3: Replace the issue description wrapper**
 
-Import `CollapsibleDescription` in `IssueDetail.svelte` and replace the existing `section-header` / `inset-box-wrap` / `Card` shell for non-empty issue bodies. Pass `issue.Body`, the existing copy state and callback, and an item key containing `provider`, `platformHost`, `owner`, `name`, `number`, and the `issue` kind. Keep the existing `.inset-box__content markdown-body` div and every click/drag/drop handler as the child snippet.
+Import `CollapsibleDescription` in `IssueDetail.svelte` and replace the existing `section-header` / `inset-box-wrap` / `Card` shell for non-empty issue bodies. Pass `issue.Body` plus the existing copy state and callback, and key the component by the normalized provider/host/owner/name/number identity with the `issue` kind. Keep the existing `.inset-box__content markdown-body` div and every click/drag/drop handler as the child snippet.
 
 - [ ] **Step 4: Run the issue test file and verify it passes**
 

--- a/docs/superpowers/specs/2026-07-29-collapsible-long-descriptions-design.md
+++ b/docs/superpowers/specs/2026-07-29-collapsible-long-descriptions-design.md
@@ -1,0 +1,37 @@
+# Collapsible Long Descriptions
+
+## Goal
+
+Keep unusually long pull request and issue descriptions from dominating the detail view while preserving the full description as the default presentation.
+
+## Scope
+
+This change applies to provider pull request and issue detail descriptions. Kata task descriptions are a separate mode and are not part of this change.
+
+## Behavior
+
+- A description is considered long when its Markdown source exceeds 1,500 characters.
+- Short descriptions keep their current presentation and do not show a collapse control.
+- Long descriptions render fully expanded by default.
+- The description header shows `Collapse` while expanded and `Expand` while compact.
+- The control exposes the current state with `aria-expanded`.
+- The compact state limits the description card to 320px and gives the card its own vertical scrollbar.
+- Navigating to a different pull request or issue resets the description to expanded.
+- Editing, copying, rendered Markdown, interactive task lists, and drag behavior remain unchanged.
+
+## Component Design
+
+A shared detail-description wrapper owns the long-description threshold, expanded state, header control, and compact scrolling styles. Pull and issue detail views continue to own their existing Markdown rendering and provider-specific interactions, passing the Markdown source and rendered content into the wrapper.
+
+The wrapper keeps the threshold and compact height identical across both detail types without coupling their mutation or drag handlers. Its state is transient and per rendered item; it is not written to local storage or the URL.
+
+## Verification
+
+Component tests cover both pull request and issue descriptions:
+
+- source at or below the threshold has no collapse control;
+- source above the threshold has a control and starts expanded;
+- collapse and expand update the accessible state and compact styling;
+- changing item identity restores the expanded state.
+
+The affected frontend test suite and Svelte checks run after the final edit.

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1584,6 +1584,7 @@
   .focus-layout--phone :global(.copy-icon-btn),
   .focus-layout--phone :global(.copy-number-btn),
   .focus-layout--phone :global(.pull-detail-content .meta-row .copy-number-btn),
+  .focus-layout--phone :global(.detail-description__toggle),
   .focus-layout--phone :global(.kit-button),
   .focus-layout--phone :global(.detail-tab),
   .focus-layout--phone :global(.add-description-btn) {

--- a/frontend/src/CollapsibleDescription.browser.svelte.ts
+++ b/frontend/src/CollapsibleDescription.browser.svelte.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vite-plus/test";
+import { page } from "vite-plus/test/browser";
+import { render } from "vitest-browser-svelte";
+
+import "./app.css";
+import CollapsibleDescriptionBrowserFixture from "./test/CollapsibleDescriptionBrowserFixture.svelte";
+
+describe("collapsible description browser layout", () => {
+  it("creates a 320px vertical scroll container when collapsed", async () => {
+    const { container, unmount } = render(CollapsibleDescriptionBrowserFixture);
+
+    try {
+      await page.getByRole("button", { name: "Collapse description" }).click();
+
+      const card = container.querySelector(".detail-description-card--compact");
+      expect(card).not.toBeNull();
+
+      const style = getComputedStyle(card as Element);
+      expect(style.maxHeight).toBe("320px");
+      expect(style.overflowY).toBe("auto");
+    } finally {
+      unmount();
+    }
+  });
+});

--- a/frontend/src/CollapsibleDescription.browser.svelte.ts
+++ b/frontend/src/CollapsibleDescription.browser.svelte.ts
@@ -10,6 +10,10 @@ describe("collapsible description browser layout", () => {
     const { container, unmount } = render(CollapsibleDescriptionBrowserFixture);
 
     try {
+      const expandedCard = container.querySelector(".detail-description-card");
+      expect(expandedCard).not.toBeNull();
+      const expandedHeight = (expandedCard as Element).clientHeight;
+
       await page.getByRole("button", { name: "Collapse description" }).click();
 
       const card = container.querySelector(".detail-description-card--compact");
@@ -18,6 +22,18 @@ describe("collapsible description browser layout", () => {
       const style = getComputedStyle(card as Element);
       expect(style.maxHeight).toBe("320px");
       expect(style.overflowY).toBe("auto");
+      expect((card as Element).scrollHeight).toBeGreaterThan((card as Element).clientHeight);
+
+      (card as Element).scrollTop = 100;
+      expect((card as Element).scrollTop).toBeGreaterThan(0);
+
+      const collapsedHeight = (card as Element).clientHeight;
+      await page.getByRole("button", { name: "Expand description" }).click();
+
+      const restoredCard = container.querySelector(".detail-description-card");
+      expect(restoredCard).not.toBeNull();
+      expect((restoredCard as Element).clientHeight).toBe(expandedHeight);
+      expect((restoredCard as Element).clientHeight).toBeGreaterThan(collapsedHeight);
     } finally {
       unmount();
     }

--- a/frontend/src/test/CollapsibleDescriptionBrowserFixture.svelte
+++ b/frontend/src/test/CollapsibleDescriptionBrowserFixture.svelte
@@ -4,7 +4,6 @@
 
 <CollapsibleDescription
   source={"x".repeat(1_501)}
-  itemKey="github:github.com:acme/widget:pull:1"
   copied={false}
   oncopy={() => {}}
 >

--- a/frontend/src/test/CollapsibleDescriptionBrowserFixture.svelte
+++ b/frontend/src/test/CollapsibleDescriptionBrowserFixture.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import CollapsibleDescription from "../../../packages/ui/src/components/detail/CollapsibleDescription.svelte";
+</script>
+
+<CollapsibleDescription
+  source={"x".repeat(1_501)}
+  itemKey="github:github.com:acme/widget:pull:1"
+  copied={false}
+  oncopy={() => {}}
+>
+  <div style="height: 640px">Long rendered description</div>
+</CollapsibleDescription>

--- a/frontend/tests/e2e-full/mobile-routes.spec.ts
+++ b/frontend/tests/e2e-full/mobile-routes.spec.ts
@@ -427,6 +427,28 @@ test.describe("phone routes", () => {
     await expect(page.locator(".mobile-shell")).toHaveCount(0);
   });
 
+  test("long description collapse toggle has a phone-sized hit target", async ({ page }) => {
+    const server = await startIsolatedE2EServerWithOptions();
+    try {
+      await page.goto(`${server.info.base_url}/pulls/github/acme/widgets/1`);
+      await expect(page.locator(".focus-layout .pull-detail .detail-title")).toBeVisible();
+      await expect(page.locator(".pull-detail .sync-indicator")).toHaveCount(0, { timeout: 15_000 });
+
+      await page.locator(".edit-body-btn").click();
+      await page.locator(".body-edit-textarea").fill(["Long phone description", "", "Details ".repeat(200)].join("\n"));
+      await page.locator(".body-edit .title-edit-save").click();
+
+      const collapseToggle = page.getByRole("button", { name: "Collapse description" });
+      await expect(collapseToggle).toBeVisible();
+      const bounds = await collapseToggle.boundingBox();
+
+      expect(bounds?.width ?? 0).toBeGreaterThanOrEqual(49);
+      expect(bounds?.height ?? 0).toBeGreaterThanOrEqual(49);
+    } finally {
+      await server.stop();
+    }
+  });
+
   test("phone canonical PR files deep link renders focus presentation without changing URL", async ({ page }) => {
     await page.goto("/pulls/github/acme/widgets/1/files");
 

--- a/packages/ui/src/components/detail/CollapsibleDescription.svelte
+++ b/packages/ui/src/components/detail/CollapsibleDescription.svelte
@@ -122,6 +122,16 @@
   }
 
   @media (max-width: 640px) {
+    .detail-description__toggle {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: var(--detail-mobile-hit-target, 37px);
+      min-height: var(--detail-mobile-hit-target, 37px);
+      padding: var(--detail-mobile-space-xs, var(--space-3));
+      font-size: var(--detail-mobile-type-sm, var(--font-size-sm));
+    }
+
     .detail-description__card-wrap :global(.kit-copy-btn.body-copy) {
       position: static;
       min-width: var(--detail-mobile-hit-target, 37px);

--- a/packages/ui/src/components/detail/CollapsibleDescription.svelte
+++ b/packages/ui/src/components/detail/CollapsibleDescription.svelte
@@ -1,0 +1,130 @@
+<script lang="ts">
+  import { Card, CopyButton } from "@kenn-io/kit-ui";
+  import type { Snippet } from "svelte";
+
+  interface Props {
+    source: string;
+    itemKey: string;
+    copied: boolean;
+    oncopy: () => void;
+    headerActions?: Snippet;
+    children: Snippet;
+  }
+
+  const { source, itemKey, copied, oncopy, headerActions, children }: Props = $props();
+
+  let collapsedItemKey = $state<string | null>(null);
+  const isLong = $derived(source.length > 1_500);
+  const collapsed = $derived(isLong && collapsedItemKey === itemKey);
+
+  function toggleCollapsed(): void {
+    collapsedItemKey = collapsed ? null : itemKey;
+  }
+</script>
+
+<div class="detail-description__header">
+  <span class="detail-description__title">Description</span>
+  <div class="detail-description__actions">
+    {#if headerActions}
+      {@render headerActions()}
+    {/if}
+    {#if isLong}
+      <button
+        type="button"
+        class="detail-description__toggle"
+        aria-label={collapsed ? "Expand description" : "Collapse description"}
+        aria-expanded={!collapsed}
+        onclick={toggleCollapsed}
+      >
+        {collapsed ? "Expand" : "Collapse"}
+      </button>
+    {/if}
+  </div>
+</div>
+<div class="detail-description__card-wrap">
+  <CopyButton
+    class={copied ? "body-copy body-copy--copied" : "body-copy"}
+    {copied}
+    onclick={oncopy}
+    revealOnHover
+    ariaLabel="Copy to clipboard"
+    copiedAriaLabel="Copied!"
+    title="Copy to clipboard"
+    copiedTitle="Copied!"
+  />
+  <Card
+    level="inset"
+    padding="none"
+    class={collapsed
+      ? "detail-description-card detail-description-card--compact"
+      : "detail-description-card"}
+  >
+    {@render children()}
+  </Card>
+</div>
+
+<style>
+  .detail-description__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .detail-description__title {
+    color: var(--text-muted);
+    font-size: var(--font-size-sm);
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+  }
+
+  .detail-description__actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-4);
+  }
+
+  .detail-description__toggle {
+    padding: 0;
+    border: 0;
+    background: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    font-family: inherit;
+    font-size: var(--font-size-2xs);
+  }
+
+  .detail-description__toggle:hover {
+    color: var(--accent-blue);
+  }
+
+  .detail-description__card-wrap {
+    position: relative;
+  }
+
+  .detail-description__card-wrap :global(.kit-copy-btn.body-copy) {
+    position: absolute;
+    top: var(--space-3);
+    right: var(--space-3);
+    z-index: 1;
+  }
+
+  .detail-description__card-wrap:hover :global(.kit-copy-btn.body-copy),
+  .detail-description__card-wrap :global(.kit-copy-btn.body-copy--copied) {
+    opacity: 1;
+  }
+
+  :global(.detail-description-card) {
+    overflow: hidden;
+  }
+
+  @media (max-width: 640px) {
+    .detail-description__card-wrap :global(.kit-copy-btn.body-copy) {
+      position: static;
+      min-width: var(--detail-mobile-hit-target, 37px);
+      min-height: var(--detail-mobile-hit-target, 37px);
+      padding: var(--detail-mobile-space-xs, var(--space-3));
+      opacity: 1;
+    }
+  }
+</style>

--- a/packages/ui/src/components/detail/CollapsibleDescription.svelte
+++ b/packages/ui/src/components/detail/CollapsibleDescription.svelte
@@ -118,6 +118,11 @@
     overflow: hidden;
   }
 
+  :global(.detail-description-card--compact) {
+    max-height: 320px;
+    overflow-y: auto;
+  }
+
   @media (max-width: 640px) {
     .detail-description__card-wrap :global(.kit-copy-btn.body-copy) {
       position: static;

--- a/packages/ui/src/components/detail/CollapsibleDescription.svelte
+++ b/packages/ui/src/components/detail/CollapsibleDescription.svelte
@@ -4,21 +4,19 @@
 
   interface Props {
     source: string;
-    itemKey: string;
     copied: boolean;
     oncopy: () => void;
     headerActions?: Snippet;
     children: Snippet;
   }
 
-  const { source, itemKey, copied, oncopy, headerActions, children }: Props = $props();
+  const { source, copied, oncopy, headerActions, children }: Props = $props();
 
-  let collapsedItemKey = $state<string | null>(null);
+  let collapsed = $state(false);
   const isLong = $derived(source.length > 1_500);
-  const collapsed = $derived(isLong && collapsedItemKey === itemKey);
 
   function toggleCollapsed(): void {
-    collapsedItemKey = collapsed ? null : itemKey;
+    collapsed = !collapsed;
   }
 </script>
 
@@ -32,11 +30,11 @@
       <button
         type="button"
         class="detail-description__toggle"
-        aria-label={collapsed ? "Expand description" : "Collapse description"}
-        aria-expanded={!collapsed}
+        aria-label={isLong && collapsed ? "Expand description" : "Collapse description"}
+        aria-expanded={!(isLong && collapsed)}
         onclick={toggleCollapsed}
       >
-        {collapsed ? "Expand" : "Collapse"}
+        {isLong && collapsed ? "Expand" : "Collapse"}
       </button>
     {/if}
   </div>
@@ -55,7 +53,7 @@
   <Card
     level="inset"
     padding="none"
-    class={collapsed
+    class={isLong && collapsed
       ? "detail-description-card detail-description-card--compact"
       : "detail-description-card"}
   >

--- a/packages/ui/src/components/detail/IssueDetail.svelte
+++ b/packages/ui/src/components/detail/IssueDetail.svelte
@@ -12,14 +12,9 @@
   import { renderMarkdown, renderMarkdownSync } from "../../utils/markdown.js";
   import { moveTaskListItem, toggleTaskListItem } from "../../utils/task-list.js";
   import { firstUnavailableGate, operationGate } from "./operation-gates.js";
-  import {
-    Card,
-    CopyButton,
-    copyToClipboard,
-    formatRelativeTime,
-    StatusDot,
-  } from "@kenn-io/kit-ui";
+  import { copyToClipboard, formatRelativeTime, StatusDot } from "@kenn-io/kit-ui";
   import EventTimeline from "./EventTimeline.svelte";
+  import CollapsibleDescription from "./CollapsibleDescription.svelte";
   import DetailActivityViewMenu from "./DetailActivityViewMenu.svelte";
   import IssueCommentBox from "./IssueCommentBox.svelte";
   import WorkspaceCreateSplitButton from "../workspace/WorkspaceCreateSplitButton.svelte";
@@ -1375,41 +1370,31 @@
       <!-- Issue body -->
       {#if issue.Body}
         <div class="section body-section">
-          <div class="section-header">
-            <span class="section-title-inline">Description</span>
-          </div>
-          <div class="inset-box-wrap">
-            <CopyButton
-              class={bodyCopied ? "body-copy body-copy--copied" : "body-copy"}
-              copied={bodyCopied}
-              onclick={() => copyBody(issue.Body)}
-              revealOnHover
-              ariaLabel="Copy to clipboard"
-              copiedAriaLabel="Copied!"
-              title="Copy to clipboard"
-              copiedTitle="Copied!"
-            />
-            <Card level="inset" padding="none" class="inset-box">
-              <!-- svelte-ignore a11y_click_events_have_key_events -->
-              <!-- svelte-ignore a11y_no_static_element_interactions -->
-              <div
-                class="inset-box__content markdown-body"
-                class:dragging={dragSourceIndex !== null}
-                onclick={onBodyClick}
-                ondragstart={onBodyDragStart}
-                ondragover={onBodyDragOver}
-                ondragleave={onBodyDragLeave}
-                ondrop={onBodyDrop}
-                ondragend={onBodyDragEnd}
-              >
-                {#await renderMarkdown(issue.Body, { provider, platformHost, owner, name, repoPath }, { interactiveTasks: capabilities.state_mutation && !contentGate.unavailable })}
-                  {@html renderMarkdownSync(issue.Body, { provider, platformHost, owner, name, repoPath })}
-                {:then html}
-                  {@html html}
-                {/await}
-              </div>
-            </Card>
-          </div>
+          <CollapsibleDescription
+            source={issue.Body}
+            itemKey={`${provider}:${platformHost ?? ""}:${owner}/${name}:issue:${number}`}
+            copied={bodyCopied}
+            oncopy={() => copyBody(issue.Body)}
+          >
+            <!-- svelte-ignore a11y_click_events_have_key_events -->
+            <!-- svelte-ignore a11y_no_static_element_interactions -->
+            <div
+              class="inset-box__content markdown-body"
+              class:dragging={dragSourceIndex !== null}
+              onclick={onBodyClick}
+              ondragstart={onBodyDragStart}
+              ondragover={onBodyDragOver}
+              ondragleave={onBodyDragLeave}
+              ondrop={onBodyDrop}
+              ondragend={onBodyDragEnd}
+            >
+              {#await renderMarkdown(issue.Body, { provider, platformHost, owner, name, repoPath }, { interactiveTasks: capabilities.state_mutation && !contentGate.unavailable })}
+                {@html renderMarkdownSync(issue.Body, { provider, platformHost, owner, name, repoPath })}
+              {:then html}
+                {@html html}
+              {/await}
+            </div>
+          </CollapsibleDescription>
         </div>
       {/if}
 
@@ -1754,12 +1739,6 @@
     gap: 8px;
   }
 
-  .section-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-  }
-
   .section-title-row {
     display: flex;
     align-items: center;
@@ -1773,37 +1752,6 @@
     text-transform: uppercase;
     letter-spacing: 0.05em;
     color: var(--text-muted);
-  }
-
-  .section-title-inline {
-    font-size: var(--font-size-sm);
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: var(--text-muted);
-  }
-
-  .inset-box-wrap {
-    position: relative;
-  }
-
-  /* Kit CopyButton owns size, hover, active, copied icon, and the
-     touch always-visible rule; the wrap positions it and reveals it on
-     hover (kit's --reveal only self-reveals on focus-visible). */
-  .inset-box-wrap :global(.kit-copy-btn.body-copy) {
-    position: absolute;
-    top: 6px;
-    right: 6px;
-    z-index: 1;
-  }
-
-  .inset-box-wrap:hover :global(.kit-copy-btn.body-copy),
-  .inset-box-wrap :global(.kit-copy-btn.body-copy--copied) {
-    opacity: 1;
-  }
-
-  :global(.inset-box) {
-    overflow: hidden;
   }
 
   .inset-box__content {
@@ -1954,7 +1902,6 @@
 
     .star-btn,
     .gh-link,
-    .inset-box-wrap :global(.kit-copy-btn.body-copy),
     .meta-row :global(.copy-number-btn) {
       min-width: var(--detail-mobile-hit-target);
       min-height: var(--detail-mobile-hit-target);
@@ -1971,7 +1918,6 @@
     .meta-sep,
     .sync-indicator,
     .section-title,
-    .section-title-inline,
     .refresh-banner,
     .loading-placeholder {
       font-size: var(--font-size-sm);
@@ -2028,9 +1974,5 @@
       font-size: var(--font-size-sm);
     }
 
-    .inset-box-wrap :global(.kit-copy-btn.body-copy) {
-      position: static;
-      opacity: 1;
-    }
   }
 </style>

--- a/packages/ui/src/components/detail/IssueDetail.svelte
+++ b/packages/ui/src/components/detail/IssueDetail.svelte
@@ -144,6 +144,9 @@
     number,
     itemType: "issue",
   });
+  const descriptionItemKey = $derived(
+    `${canonicalProvider(provider)}:${resolvedPlatformHost(provider, platformHost)}:${owner}/${name}:issue:${number}`,
+  );
 
   // See PullDetail.svelte: while a route change is in flight, the
   // displayed issue may briefly belong to the previous route. Mutating
@@ -1370,31 +1373,32 @@
       <!-- Issue body -->
       {#if issue.Body}
         <div class="section body-section">
-          <CollapsibleDescription
-            source={issue.Body}
-            itemKey={`${provider}:${platformHost ?? ""}:${owner}/${name}:issue:${number}`}
-            copied={bodyCopied}
-            oncopy={() => copyBody(issue.Body)}
-          >
-            <!-- svelte-ignore a11y_click_events_have_key_events -->
-            <!-- svelte-ignore a11y_no_static_element_interactions -->
-            <div
-              class="inset-box__content markdown-body"
-              class:dragging={dragSourceIndex !== null}
-              onclick={onBodyClick}
-              ondragstart={onBodyDragStart}
-              ondragover={onBodyDragOver}
-              ondragleave={onBodyDragLeave}
-              ondrop={onBodyDrop}
-              ondragend={onBodyDragEnd}
+          {#key descriptionItemKey}
+            <CollapsibleDescription
+              source={issue.Body}
+              copied={bodyCopied}
+              oncopy={() => copyBody(issue.Body)}
             >
-              {#await renderMarkdown(issue.Body, { provider, platformHost, owner, name, repoPath }, { interactiveTasks: capabilities.state_mutation && !contentGate.unavailable })}
-                {@html renderMarkdownSync(issue.Body, { provider, platformHost, owner, name, repoPath })}
-              {:then html}
-                {@html html}
-              {/await}
-            </div>
-          </CollapsibleDescription>
+              <!-- svelte-ignore a11y_click_events_have_key_events -->
+              <!-- svelte-ignore a11y_no_static_element_interactions -->
+              <div
+                class="inset-box__content markdown-body"
+                class:dragging={dragSourceIndex !== null}
+                onclick={onBodyClick}
+                ondragstart={onBodyDragStart}
+                ondragover={onBodyDragOver}
+                ondragleave={onBodyDragLeave}
+                ondrop={onBodyDrop}
+                ondragend={onBodyDragEnd}
+              >
+                {#await renderMarkdown(issue.Body, { provider, platformHost, owner, name, repoPath }, { interactiveTasks: capabilities.state_mutation && !contentGate.unavailable })}
+                  {@html renderMarkdownSync(issue.Body, { provider, platformHost, owner, name, repoPath })}
+                {:then html}
+                  {@html html}
+                {/await}
+              </div>
+            </CollapsibleDescription>
+          {/key}
         </div>
       {/if}
 

--- a/packages/ui/src/components/detail/IssueDetail.test.ts
+++ b/packages/ui/src/components/detail/IssueDetail.test.ts
@@ -999,6 +999,29 @@ describe("IssueDetail inline workspace handoff", () => {
   });
 });
 
+describe("IssueDetail description collapse", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("collapses and expands a long issue description", async () => {
+    const detail = issueDetail();
+    detail.issue.Body = "x".repeat(1_501);
+    renderIssueDetail(detail);
+
+    await fireEvent.click(screen.getByRole("button", { name: "Collapse description" }));
+    const expand = screen.getByRole("button", { name: "Expand description" });
+    expect(expand.getAttribute("aria-expanded")).toBe("false");
+
+    await fireEvent.click(expand);
+    expect(screen.getByRole("button", { name: "Collapse description" }).getAttribute("aria-expanded")).toBe("true");
+  });
+});
+
 describe("IssueDetail body copy feedback", () => {
   beforeEach(() => {
     localStorage.clear();

--- a/packages/ui/src/components/detail/IssueDetail.test.ts
+++ b/packages/ui/src/components/detail/IssueDetail.test.ts
@@ -1020,6 +1020,22 @@ describe("IssueDetail description collapse", () => {
     await fireEvent.click(expand);
     expect(screen.getByRole("button", { name: "Collapse description" }).getAttribute("aria-expanded")).toBe("true");
   });
+
+  it("expands a collapsed description after issue navigation", async () => {
+    const detail = issueDetail();
+    detail.issue.Body = "x".repeat(1_501);
+    const { rerender } = renderIssueDetail(detail);
+
+    await fireEvent.click(screen.getByRole("button", { name: "Collapse description" }));
+
+    detail.issue.Number = 8;
+    await rerender({ number: 8 });
+    expect(screen.getByRole("button", { name: "Collapse description" }).getAttribute("aria-expanded")).toBe("true");
+
+    detail.issue.Number = 7;
+    await rerender({ number: 7 });
+    expect(screen.getByRole("button", { name: "Collapse description" }).getAttribute("aria-expanded")).toBe("true");
+  });
 });
 
 describe("IssueDetail body copy feedback", () => {

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -25,14 +25,9 @@
   import { moveTaskListItem, toggleTaskListItem } from "../../utils/task-list.js";
   import type { ApplySuggestionRequest } from "../../utils/markdown-suggestions.js";
   import { firstUnavailableGate, operationGate } from "./operation-gates.js";
-  import {
-    Card,
-    CopyButton,
-    FitStages,
-    copyToClipboard,
-    formatRelativeTime,
-  } from "@kenn-io/kit-ui";
+  import { FitStages, copyToClipboard, formatRelativeTime } from "@kenn-io/kit-ui";
   import EventTimeline from "./EventTimeline.svelte";
+  import CollapsibleDescription from "./CollapsibleDescription.svelte";
   import DetailActivityViewMenu from "./DetailActivityViewMenu.svelte";
   import CommentBox from "./CommentBox.svelte";
   import ApproveButton from "./ApproveButton.svelte";
@@ -2715,20 +2710,10 @@
 
       <!-- PR body -->
       <div class="section body-section">
-        <div class="section-header">
-          <span class="section-title-inline">Description</span>
-          {#if !editingBody && capabilities.state_mutation && !stalePR}
-            <button
-              class="edit-body-btn"
-              onclick={startEditBody}
-              disabled={contentGate.unavailable}
-              title={contentGate.unavailable ? contentGate.reason : undefined}
-            >
-              Edit
-            </button>
-          {/if}
-        </div>
         {#if editingBody}
+          <div class="section-header">
+            <span class="section-title-inline">Description</span>
+          </div>
           <div class="body-edit">
             <!-- svelte-ignore a11y_autofocus -->
             <textarea
@@ -2757,47 +2742,67 @@
             </div>
           </div>
         {:else if pr.Body}
-          <div class="inset-box-wrap">
-            <CopyButton
-              class={bodyCopied ? "body-copy body-copy--copied" : "body-copy"}
-              copied={bodyCopied}
-              onclick={() => copyBody(pr.Body)}
-              revealOnHover
-              ariaLabel="Copy to clipboard"
-              copiedAriaLabel="Copied!"
-              title="Copy to clipboard"
-              copiedTitle="Copied!"
-            />
-            <Card level="inset" padding="none" class="inset-box">
-              <!-- svelte-ignore a11y_click_events_have_key_events -->
-              <!-- svelte-ignore a11y_no_static_element_interactions -->
-              <div
-                class="inset-box__content markdown-body"
-                class:dragging={dragSourceIndex !== null}
-                onclick={onBodyClick}
-                ondragstart={onBodyDragStart}
-                ondragover={onBodyDragOver}
-                ondragleave={onBodyDragLeave}
-                ondrop={onBodyDrop}
-                ondragend={onBodyDragEnd}
-              >
-                {#await renderMarkdown(pr.Body, { provider, platformHost, owner, name, repoPath }, { interactiveTasks: capabilities.state_mutation && !contentGate.unavailable })}
-                  {@html renderMarkdownSync(pr.Body, { provider, platformHost, owner, name, repoPath })}
-                {:then html}
-                  {@html html}
-                {/await}
-              </div>
-            </Card>
-          </div>
-        {:else if capabilities.state_mutation && !stalePR}
-          <button
-            class="add-description-btn"
-            onclick={startEditBody}
-            disabled={contentGate.unavailable}
-            title={contentGate.unavailable ? contentGate.reason : undefined}
+          <CollapsibleDescription
+            source={pr.Body}
+            itemKey={`${provider}:${platformHost ?? ""}:${owner}/${name}:pull:${number}`}
+            copied={bodyCopied}
+            oncopy={() => copyBody(pr.Body)}
           >
-            Add a description
-          </button>
+            {#snippet headerActions()}
+              {#if capabilities.state_mutation && !stalePR}
+                <button
+                  class="edit-body-btn"
+                  onclick={startEditBody}
+                  disabled={contentGate.unavailable}
+                  title={contentGate.unavailable ? contentGate.reason : undefined}
+                >
+                  Edit
+                </button>
+              {/if}
+            {/snippet}
+            <!-- svelte-ignore a11y_click_events_have_key_events -->
+            <!-- svelte-ignore a11y_no_static_element_interactions -->
+            <div
+              class="inset-box__content markdown-body"
+              class:dragging={dragSourceIndex !== null}
+              onclick={onBodyClick}
+              ondragstart={onBodyDragStart}
+              ondragover={onBodyDragOver}
+              ondragleave={onBodyDragLeave}
+              ondrop={onBodyDrop}
+              ondragend={onBodyDragEnd}
+            >
+              {#await renderMarkdown(pr.Body, { provider, platformHost, owner, name, repoPath }, { interactiveTasks: capabilities.state_mutation && !contentGate.unavailable })}
+                {@html renderMarkdownSync(pr.Body, { provider, platformHost, owner, name, repoPath })}
+              {:then html}
+                {@html html}
+              {/await}
+            </div>
+          </CollapsibleDescription>
+        {:else}
+          <div class="section-header">
+            <span class="section-title-inline">Description</span>
+            {#if capabilities.state_mutation && !stalePR}
+              <button
+                class="edit-body-btn"
+                onclick={startEditBody}
+                disabled={contentGate.unavailable}
+                title={contentGate.unavailable ? contentGate.reason : undefined}
+              >
+                Edit
+              </button>
+            {/if}
+          </div>
+          {#if capabilities.state_mutation && !stalePR}
+            <button
+              class="add-description-btn"
+              onclick={startEditBody}
+              disabled={contentGate.unavailable}
+              title={contentGate.unavailable ? contentGate.reason : undefined}
+            >
+              Add a description
+            </button>
+          {/if}
         {/if}
       </div>
 
@@ -3493,29 +3498,6 @@
     color: var(--text-muted);
   }
 
-  .inset-box-wrap {
-    position: relative;
-  }
-
-  /* Kit CopyButton owns size, hover, active, copied icon, and the
-     touch always-visible rule; the wrap positions it and reveals it on
-     hover (kit's --reveal only self-reveals on focus-visible). */
-  .inset-box-wrap :global(.kit-copy-btn.body-copy) {
-    position: absolute;
-    top: 6px;
-    right: 6px;
-    z-index: 1;
-  }
-
-  .inset-box-wrap:hover :global(.kit-copy-btn.body-copy),
-  .inset-box-wrap :global(.kit-copy-btn.body-copy--copied) {
-    opacity: 1;
-  }
-
-  :global(.inset-box) {
-    overflow: hidden;
-  }
-
   .inset-box__content {
     padding: 10px 12px;
     font-size: var(--font-size-root);
@@ -3673,8 +3655,7 @@
     .edit-title-btn,
     .edit-body-btn,
     .star-btn,
-    .gh-link,
-    .inset-box-wrap :global(.kit-copy-btn.body-copy) {
+    .gh-link {
       min-width: var(--detail-mobile-hit-target);
       min-height: var(--detail-mobile-hit-target);
       justify-content: center;
@@ -3766,9 +3747,5 @@
       min-height: var(--detail-mobile-hit-target);
     }
 
-    .inset-box-wrap :global(.kit-copy-btn.body-copy) {
-      position: static;
-      opacity: 1;
-    }
   }
 </style>

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -217,6 +217,9 @@
     number,
     itemType: "pull",
   });
+  const descriptionItemKey = $derived(
+    `${canonicalProvider(provider)}:${resolvedPlatformHost(provider, platformHost)}:${owner}/${name}:pull:${number}`,
+  );
 
   let activeTab = $state<"conversation" | "files">("conversation");
   let expandedPanel = $state<"ci" | "stack" | "merge" | null>(null);
@@ -2742,43 +2745,44 @@
             </div>
           </div>
         {:else if pr.Body}
-          <CollapsibleDescription
-            source={pr.Body}
-            itemKey={`${provider}:${platformHost ?? ""}:${owner}/${name}:pull:${number}`}
-            copied={bodyCopied}
-            oncopy={() => copyBody(pr.Body)}
-          >
-            {#snippet headerActions()}
-              {#if capabilities.state_mutation && !stalePR}
-                <button
-                  class="edit-body-btn"
-                  onclick={startEditBody}
-                  disabled={contentGate.unavailable}
-                  title={contentGate.unavailable ? contentGate.reason : undefined}
-                >
-                  Edit
-                </button>
-              {/if}
-            {/snippet}
-            <!-- svelte-ignore a11y_click_events_have_key_events -->
-            <!-- svelte-ignore a11y_no_static_element_interactions -->
-            <div
-              class="inset-box__content markdown-body"
-              class:dragging={dragSourceIndex !== null}
-              onclick={onBodyClick}
-              ondragstart={onBodyDragStart}
-              ondragover={onBodyDragOver}
-              ondragleave={onBodyDragLeave}
-              ondrop={onBodyDrop}
-              ondragend={onBodyDragEnd}
+          {#key descriptionItemKey}
+            <CollapsibleDescription
+              source={pr.Body}
+              copied={bodyCopied}
+              oncopy={() => copyBody(pr.Body)}
             >
-              {#await renderMarkdown(pr.Body, { provider, platformHost, owner, name, repoPath }, { interactiveTasks: capabilities.state_mutation && !contentGate.unavailable })}
-                {@html renderMarkdownSync(pr.Body, { provider, platformHost, owner, name, repoPath })}
-              {:then html}
-                {@html html}
-              {/await}
-            </div>
-          </CollapsibleDescription>
+              {#snippet headerActions()}
+                {#if capabilities.state_mutation && !stalePR}
+                  <button
+                    class="edit-body-btn"
+                    onclick={startEditBody}
+                    disabled={contentGate.unavailable}
+                    title={contentGate.unavailable ? contentGate.reason : undefined}
+                  >
+                    Edit
+                  </button>
+                {/if}
+              {/snippet}
+              <!-- svelte-ignore a11y_click_events_have_key_events -->
+              <!-- svelte-ignore a11y_no_static_element_interactions -->
+              <div
+                class="inset-box__content markdown-body"
+                class:dragging={dragSourceIndex !== null}
+                onclick={onBodyClick}
+                ondragstart={onBodyDragStart}
+                ondragover={onBodyDragOver}
+                ondragleave={onBodyDragLeave}
+                ondrop={onBodyDrop}
+                ondragend={onBodyDragEnd}
+              >
+                {#await renderMarkdown(pr.Body, { provider, platformHost, owner, name, repoPath }, { interactiveTasks: capabilities.state_mutation && !contentGate.unavailable })}
+                  {@html renderMarkdownSync(pr.Body, { provider, platformHost, owner, name, repoPath })}
+                {:then html}
+                  {@html html}
+                {/await}
+              </div>
+            </CollapsibleDescription>
+          {/key}
         {:else}
           <div class="section-header">
             <span class="section-title-inline">Description</span>

--- a/packages/ui/src/components/detail/PullDetail.test.ts
+++ b/packages/ui/src/components/detail/PullDetail.test.ts
@@ -2045,6 +2045,11 @@ describe("PullDetail description collapse", () => {
     await rerender({ number: 2 });
 
     expect(screen.getByRole("button", { name: "Collapse description" }).getAttribute("aria-expanded")).toBe("true");
+
+    detail.merge_request.Number = 1;
+    await rerender({ number: 1 });
+
+    expect(screen.getByRole("button", { name: "Collapse description" }).getAttribute("aria-expanded")).toBe("true");
   });
 });
 

--- a/packages/ui/src/components/detail/PullDetail.test.ts
+++ b/packages/ui/src/components/detail/PullDetail.test.ts
@@ -2007,6 +2007,47 @@ describe("PullDetail inline workspace handoff", () => {
   });
 });
 
+describe("PullDetail description collapse", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("offers an expanded collapse control for a long pull description", () => {
+    const detail = pullDetail();
+    detail.merge_request.Body = "x".repeat(1_501);
+    renderPullDetail(detail);
+
+    const collapse = screen.getByRole("button", { name: "Collapse description" });
+    expect(collapse.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("does not offer collapse at the long-description threshold", () => {
+    const detail = pullDetail();
+    detail.merge_request.Body = "x".repeat(1_500);
+    renderPullDetail(detail);
+
+    expect(screen.queryByRole("button", { name: "Collapse description" })).toBeNull();
+  });
+
+  it("expands a collapsed description after pull navigation", async () => {
+    const detail = pullDetail();
+    detail.merge_request.Body = "x".repeat(1_501);
+    const { rerender } = renderPullDetail(detail);
+
+    await fireEvent.click(screen.getByRole("button", { name: "Collapse description" }));
+    expect(screen.getByRole("button", { name: "Expand description" }).getAttribute("aria-expanded")).toBe("false");
+
+    detail.merge_request.Number = 2;
+    await rerender({ number: 2 });
+
+    expect(screen.getByRole("button", { name: "Collapse description" }).getAttribute("aria-expanded")).toBe("true");
+  });
+});
+
 describe("PullDetail body copy feedback", () => {
   beforeEach(() => {
     localStorage.clear();


### PR DESCRIPTION
- Add expanded-by-default collapse controls to long pull request and issue descriptions.
- Keep compact descriptions scrollable and reset them when navigating between items.

<sup>generated by a clanker</sup>