### PR TITLE
Preserve repository history across path reuse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,6 +260,7 @@ jobs:
           fail-on-error: false
 
       - name: Run integration tests (git-dependent)
+        if: ${{ !cancelled() }}
         run: |
           mkdir -p tmp
           go tool gotestsum --format pkgname-and-test-fails --jsonfile=tmp/test-integration-output.json -- -tags integration ./... -run '^TestIntegration' -shuffle=on -parallel=4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,8 +33,18 @@ This paragraph is the single place CLAUDE.md enumerates supported providers. Do 
 New features must work across every supported provider to the extent each provider's API allows. Concrete rules:
 
 - Provider-specific capability differences go behind the capability model in `internal/platform`. Declare capabilities in `Capabilities()`, check them before mutations, and return typed `unsupported_capability` errors when a provider can't satisfy an operation. Do not silently fall back to GitHub-only behavior for other providers.
-- Repository identity is always the quad `(provider, platform_host, owner, repo)`. In code and schema this same quad is always represented as `(platform, platform_host, owner, name)`. There is no repository identity without both provider and host. The host may be omitted from a user-facing route only when the route helper is intentionally using the provider's default host; the logical identity still includes the normalized host.
-- Never identify, route, cache, dedupe, query, persist, or compare repositories, pull requests, merge requests, issues, comments, checks, releases, workspaces, activity, or events by owner/repo/number alone. Every repo-scoped path and data structure must carry provider and host as well as owner and repo.
+- Repository data identity is the provider's stable repository ID, scoped by
+  `(provider, platform_host)`, and persisted as one immutable internal
+  repository ID. `(owner, repo)` and `repo_path` are mutable display and routing
+  coordinates. A provider ID change at an occupied route creates a new local
+  incarnation and retires the old one; a route change with the same provider ID
+  preserves the local incarnation.
+- Never identify, cache, dedupe, persist, or compare repository-owned pull
+  requests, merge requests, issues, comments, checks, releases, workspaces,
+  activity, archives, notifications, or Git clones by owner/repo/number alone.
+  Persisted ownership uses the internal repository ID. Provider calls and routes
+  still carry provider, host, owner, and repo because those coordinates select
+  an endpoint and credential.
 - Repo-scoped routes use provider-aware paths like `/pulls/{provider}/{owner}/{name}/{number}`, with `/host/{platform_host}/...` for non-default or self-hosted instances.
 - GitHub-only optimizations (GraphQL bulk fetch, ETag recovery, detailed diff behavior) stay in `internal/github/` and remain optional around the neutral persistence path.
 - Frontend stores and components must thread the full provider ref (`provider`, `platformHost`, `owner`, `name`, `repoPath`) through the shared route helpers in `packages/ui/src/api/provider-routes.ts`. Do not hand-build `/api/v1` URLs or assume GitHub defaults inside components.

--- a/cmd/e2e-server/main.go
+++ b/cmd/e2e-server/main.go
@@ -1457,9 +1457,10 @@ func buildAppState(
 	rootHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost &&
 			r.URL.Path == "/__e2e/issue-workspace/reused-branch" {
-			clonePath, err := diffRepo.Manager.ClonePath(
+			clonePath, err := diffRepo.Manager.RepositoryClone(
+				diffRepo.RepositoryID,
 				"github", "github.com", "acme", "widgets",
-			)
+			).ClonePath()
 			if err != nil {
 				http.Error(w, "resolve fixture clone", http.StatusInternalServerError)
 				return
@@ -1496,9 +1497,10 @@ func buildAppState(
 			forkSnapshot := *mr
 			forkSnapshot.HeadRepoCloneURL = "https://github.com/forker/widgets.git"
 			forkSnapshot.UpdatedAt = time.Now().UTC()
-			clonePath, err := diffRepo.Manager.ClonePath(
+			clonePath, err := diffRepo.Manager.RepositoryClone(
+				diffRepo.RepositoryID,
 				"github", "github.com", "acme", "widgets",
-			)
+			).ClonePath()
 			if err != nil {
 				http.Error(w, "resolve fixture clone", http.StatusInternalServerError)
 				return

--- a/cmd/kenn-forge/archive_cli.go
+++ b/cmd/kenn-forge/archive_cli.go
@@ -129,21 +129,26 @@ func runArchiveMutation(command string, daemonFlags archiveDaemonFlags, all bool
 func newArchiveStatusCommand(stdout io.Writer) *cobra.Command {
 	flags := archiveDaemonFlags{}
 	var repositories archiveStringList
+	var repositoryIDs []int64
 	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "Show repository archive status",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runArchiveStatus(flags, repositories, stdout)
+			return runArchiveStatus(flags, repositories, repositoryIDs, stdout)
 		},
 	}
 	addArchiveDaemonFlags(cmd, &flags)
 	cmd.Flags().Bool("json", false, "emit JSON (status output is always JSON)")
 	cmd.Flags().Var(&repositories, "repo", "provider|host/repo_path; repeat for multiple repositories")
+	cmd.Flags().Int64SliceVar(&repositoryIDs, "repo-id", nil, "immutable repository incarnation ID; repeat for multiple repositories")
 	return cmd
 }
 
-func runArchiveStatus(daemonFlags archiveDaemonFlags, repositories []string, stdout io.Writer) error {
+func runArchiveStatus(daemonFlags archiveDaemonFlags, repositories []string, repositoryIDs []int64, stdout io.Writer) error {
+	if len(repositories) > 0 && len(repositoryIDs) > 0 {
+		return errors.New("--repo and --repo-id are mutually exclusive")
+	}
 	refs, err := parseArchiveRepositoryRefs(repositories)
 	if err != nil {
 		return err
@@ -156,6 +161,9 @@ func runArchiveStatus(daemonFlags archiveDaemonFlags, repositories []string, std
 	if len(refs) > 0 {
 		values := archiveRepositoryFilters(refs)
 		params.Repo = &values
+	}
+	if len(repositoryIDs) > 0 {
+		params.RepoId = &repositoryIDs
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), daemonFlags.timeout)
 	defer cancel()
@@ -170,14 +178,15 @@ func runArchiveStatus(daemonFlags archiveDaemonFlags, repositories []string, std
 }
 
 type archiveReportOptions struct {
-	daemonFlags  archiveDaemonFlags
-	days         int
-	startValue   string
-	endValue     string
-	format       string
-	verbose      bool
-	output       string
-	repositories archiveStringList
+	daemonFlags   archiveDaemonFlags
+	days          int
+	startValue    string
+	endValue      string
+	format        string
+	verbose       bool
+	output        string
+	repositories  archiveStringList
+	repositoryIDs []int64
 }
 
 func newArchiveReportCommand(stdout io.Writer, now func() time.Time) *cobra.Command {
@@ -198,10 +207,14 @@ func newArchiveReportCommand(stdout io.Writer, now func() time.Time) *cobra.Comm
 	cmd.Flags().BoolVar(&opts.verbose, "verbose", false, "include bounded activity details")
 	cmd.Flags().StringVar(&opts.output, "output", "", "write output atomically to this file")
 	cmd.Flags().Var(&opts.repositories, "repo", "provider|host/repo_path; repeat for multiple repositories")
+	cmd.Flags().Int64SliceVar(&opts.repositoryIDs, "repo-id", nil, "immutable repository incarnation ID; repeat for multiple repositories")
 	return cmd
 }
 
 func runArchiveReport(opts archiveReportOptions, daysSet bool, stdout io.Writer, now func() time.Time) error {
+	if len(opts.repositories) > 0 && len(opts.repositoryIDs) > 0 {
+		return errors.New("--repo and --repo-id are mutually exclusive")
+	}
 	if daysSet && opts.days <= 0 {
 		return errors.New("--days must be positive")
 	}
@@ -226,6 +239,9 @@ func runArchiveReport(opts archiveReportOptions, daysSet bool, stdout io.Writer,
 	if len(refs) > 0 {
 		values := archiveRepositoryFilters(refs)
 		params.Repo = &values
+	}
+	if len(opts.repositoryIDs) > 0 {
+		params.RepoId = &opts.repositoryIDs
 	}
 	if opts.verbose {
 		params.Verbose = &opts.verbose
@@ -435,8 +451,13 @@ func archiveOptionalIntPointer(value *int64) *int {
 }
 
 func archiveReportRepositoryRefFromAPI(input generated.ArchiveRepositoryRef) report.RepositoryRef {
+	repositoryID := int64(0)
+	if input.RepositoryId != nil {
+		repositoryID = *input.RepositoryId
+	}
 	return report.RepositoryRef{
-		Provider: input.Provider, PlatformHost: input.PlatformHost, Owner: input.Owner,
+		RepositoryID: repositoryID,
+		Provider:     input.Provider, PlatformHost: input.PlatformHost, Owner: input.Owner,
 		Name: input.Name, RepoPath: input.RepoPath,
 	}
 }

--- a/cmd/kenn-forge/archive_cli_test.go
+++ b/cmd/kenn-forge/archive_cli_test.go
@@ -304,12 +304,28 @@ func TestArchiveCLISubcommandsUseGeneratedDaemonContract(t *testing.T) {
 			wantOut:   "[]",
 		},
 		{
+			name: "status incarnation filters", args: []string{"status", "--config", cfgPath,
+				"--repo-id", "41", "--repo-id", "42"},
+			wantMethod: http.MethodGet, wantPath: "/base/api/v1/archive/status",
+			wantQuery: url.Values{"repo_id": {"41", "42"}}, wantOut: "[]",
+		},
+		{
 			name: "report days json", args: []string{"report", "--config", cfgPath, "--days", "2", "--format", "json", "--verbose"},
 			wantMethod: http.MethodGet, wantPath: "/base/api/v1/archive/report",
 			wantQuery: url.Values{
 				"start": {"2026-07-11T15:30:00Z"}, "end": {"2026-07-13T15:30:00Z"}, "verbose": {"true"},
 			},
 			wantOut: `"merge_commit_sha": "abc123"`,
+		},
+		{
+			name: "report incarnation filter", args: []string{"report", "--config", cfgPath,
+				"--days", "2", "--format", "json", "--repo-id", "42"},
+			wantMethod: http.MethodGet, wantPath: "/base/api/v1/archive/report",
+			wantQuery: url.Values{
+				"start": {"2026-07-11T15:30:00Z"}, "end": {"2026-07-13T15:30:00Z"},
+				"repo_id": {"42"},
+			},
+			wantOut: `"merge_requests_merged": 1`,
 		},
 	}
 	for _, tt := range tests {

--- a/cmd/kenn-forge/main.go
+++ b/cmd/kenn-forge/main.go
@@ -747,7 +747,11 @@ func resolveStartupRepos(
 	registry *platform.Registry,
 	database *db.DB,
 ) []ghclient.RepoRef {
-	seen := make(map[string]struct{})
+	type resolvedCandidate struct {
+		index  int
+		isGlob bool
+	}
+	seen := make(map[string]resolvedCandidate)
 	repos := make([]ghclient.RepoRef, 0, len(cfg.Repos))
 	for _, raw := range cfg.Repos {
 		_, expanded, err := ghclient.ResolveConfiguredRepoWithRegistry(
@@ -760,7 +764,9 @@ func resolveStartupRepos(
 					ctx, database, raw,
 				)
 			} else {
-				expanded = ghclient.FallbackConfiguredRepoRefs(nil, raw)
+				expanded = fallbackExactFromDB(
+					ctx, database, raw,
+				)
 			}
 		}
 		for _, repo := range expanded {
@@ -768,14 +774,65 @@ func resolveStartupRepos(
 				strings.ToLower(repoHost(repo)) + "\x00" +
 				strings.ToLower(repo.Owner) + "\x00" +
 				strings.ToLower(repo.Name)
-			if _, ok := seen[key]; ok {
+			if current, ok := seen[key]; ok {
+				merged, mergedIsGlob := ghclient.MergeConfiguredRepoCandidate(
+					repos[current.index],
+					current.isGlob,
+					repo,
+					raw.HasNameGlob(),
+				)
+				repos[current.index] = merged
+				current.isGlob = mergedIsGlob
+				seen[key] = current
 				continue
 			}
-			seen[key] = struct{}{}
+			seen[key] = resolvedCandidate{
+				index:  len(repos),
+				isGlob: raw.HasNameGlob(),
+			}
 			repos = append(repos, repo)
 		}
 	}
 	return repos
+}
+
+func fallbackExactFromDB(
+	ctx context.Context,
+	database *db.DB,
+	raw config.Repo,
+) []ghclient.RepoRef {
+	if database != nil {
+		repoPath := strings.TrimSpace(raw.RepoPath)
+		if repoPath == "" {
+			repoPath = strings.Trim(raw.Owner+"/"+raw.Name, "/")
+		}
+		stored, err := database.GetRepoByConfiguredRoute(ctx, db.RepoIdentity{
+			Platform:     raw.PlatformOrDefault(),
+			PlatformHost: raw.PlatformHostOrDefault(),
+			Owner:        raw.Owner,
+			Name:         raw.Name,
+			RepoPath:     repoPath,
+		})
+		if err != nil {
+			slog.Warn("fallback exact repo from db", "err", err)
+		} else if stored != nil {
+			return []ghclient.RepoRef{{
+				Platform:           platform.Kind(stored.Platform),
+				RepoID:             stored.ID,
+				Owner:              stored.Owner,
+				Name:               stored.Name,
+				CredentialOwner:    raw.Owner,
+				CredentialName:     raw.Name,
+				PlatformHost:       stored.PlatformHost,
+				RepoPath:           stored.RepoPath,
+				PlatformExternalID: stored.PlatformRepoID,
+				WebURL:             stored.WebURL,
+				CloneURL:           stored.CloneURL,
+				DefaultBranch:      stored.DefaultBranch,
+			}}
+		}
+	}
+	return ghclient.FallbackConfiguredRepoRefs(nil, raw)
 }
 
 func providerHostKey(platformName, host string) string {

--- a/cmd/kenn-forge/main.go
+++ b/cmd/kenn-forge/main.go
@@ -903,10 +903,11 @@ func fallbackGlobFromDB(
 		)
 		if matched {
 			repo := ghclient.RepoRef{
-				Platform:     rawPlatform,
-				Owner:        r.Owner,
-				Name:         r.Name,
-				PlatformHost: dbHost,
+				Platform:        rawPlatform,
+				Owner:           r.Owner,
+				Name:            r.Name,
+				ConfiguredGlobs: []ghclient.ConfiguredRepoGlob{{Owner: raw.Owner, Name: raw.Name}},
+				PlatformHost:    dbHost,
 			}
 			matches = append(matches, repo)
 		}

--- a/cmd/kenn-forge/main_test.go
+++ b/cmd/kenn-forge/main_test.go
@@ -260,6 +260,169 @@ func TestResolveStartupReposKeepsExactReposWhenResolutionFails(t *testing.T) {
 	}}, repos)
 }
 
+func TestResolveStartupReposRestoresRenamedExactRepoWhenOffline(t *testing.T) {
+	require := require.New(t)
+	database := dbtest.Open(t)
+	ctx := t.Context()
+	repoID, err := database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "R_42",
+		Owner:          "acme-tools",
+		Name:           "current-widget",
+		RepoPath:       "acme-tools/current-widget",
+	})
+	require.NoError(err)
+	require.NoError(database.SaveRepoConfiguredRoute(ctx, repoID, db.RepoIdentity{
+		Platform:     "github",
+		PlatformHost: "github.com",
+		Owner:        "acme",
+		Name:         "legacy-widget",
+		RepoPath:     "acme/legacy-widget",
+	}))
+	cfg := &config.Config{Repos: []config.Repo{{
+		Owner: "acme",
+		Name:  "legacy-widget",
+	}}}
+
+	repos := resolveStartupRepos(
+		ctx,
+		cfg,
+		mustProviderRegistry(t, nil),
+		database,
+	)
+
+	require.Equal([]ghclient.RepoRef{{
+		Platform:           platform.KindGitHub,
+		RepoID:             repoID,
+		Owner:              "acme-tools",
+		Name:               "current-widget",
+		CredentialOwner:    "acme",
+		CredentialName:     "legacy-widget",
+		PlatformHost:       "github.com",
+		RepoPath:           "acme-tools/current-widget",
+		PlatformExternalID: "R_42",
+	}}, repos)
+}
+
+func TestResolveStartupReposPrefersDirectRouteOverRenameAlias(t *testing.T) {
+	require := require.New(t)
+	reader := mainTestRepositoryReader{
+		kind: platform.KindGitLab,
+		host: "gitlab.example.com",
+		getRepository: func(platform.RepoRef) (platform.Repository, error) {
+			return platform.Repository{
+				Ref: platform.RepoRef{
+					Platform: platform.KindGitLab,
+					Host:     "gitlab.example.com",
+					Owner:    "acme-tools",
+					Name:     "current-widget",
+					RepoPath: "acme-tools/current-widget",
+				},
+				PlatformExternalID: "project-42",
+			}, nil
+		},
+	}
+	cfg := &config.Config{Repos: []config.Repo{
+		{
+			Platform:     "gitlab",
+			PlatformHost: "gitlab.example.com",
+			Owner:        "acme",
+			Name:         "legacy-widget",
+			TokenEnv:     "LEGACY_ROUTE_TOKEN",
+		},
+		{
+			Platform:     "gitlab",
+			PlatformHost: "gitlab.example.com",
+			Owner:        "acme-tools",
+			Name:         "current-widget",
+			TokenEnv:     "CURRENT_ROUTE_TOKEN",
+		},
+	}}
+
+	repos := resolveStartupRepos(
+		t.Context(), cfg, mustProviderRegistry(t, nil, reader), nil,
+	)
+
+	require.Equal([]ghclient.RepoRef{{
+		Platform:     platform.KindGitLab,
+		PlatformHost: "gitlab.example.com",
+		Owner:        "acme-tools",
+		Name:         "current-widget",
+		ConfiguredRoutes: []ghclient.ConfiguredRepoRoute{
+			{Owner: "acme", Name: "legacy-widget", RepoPath: "acme/legacy-widget"},
+			{Owner: "acme-tools", Name: "current-widget", RepoPath: "acme-tools/current-widget"},
+		},
+		RepoPath:           "acme-tools/current-widget",
+		PlatformExternalID: "project-42",
+	}}, repos)
+}
+
+func TestResolveStartupReposPrefersRenamedExactRouteOverGlob(t *testing.T) {
+	canonical := platform.Repository{
+		Ref: platform.RepoRef{
+			Platform: platform.KindGitLab,
+			Host:     "gitlab.example.com",
+			Owner:    "acme-tools",
+			Name:     "current-widget",
+			RepoPath: "acme-tools/current-widget",
+		},
+		PlatformExternalID: "project-42",
+	}
+	reader := mainTestRepositoryReader{
+		kind: platform.KindGitLab,
+		host: "gitlab.example.com",
+		getRepository: func(platform.RepoRef) (platform.Repository, error) {
+			return canonical, nil
+		},
+		listRepositories: func(string) ([]platform.Repository, error) {
+			return []platform.Repository{canonical}, nil
+		},
+	}
+	exact := config.Repo{
+		Platform:     "gitlab",
+		PlatformHost: "gitlab.example.com",
+		Owner:        "acme",
+		Name:         "legacy-widget",
+		TokenEnv:     "EXACT_ROUTE_TOKEN",
+	}
+	glob := config.Repo{
+		Platform:     "gitlab",
+		PlatformHost: "gitlab.example.com",
+		Owner:        "acme-tools",
+		Name:         "*",
+	}
+
+	for _, test := range []struct {
+		name  string
+		repos []config.Repo
+	}{
+		{name: "exact first", repos: []config.Repo{exact, glob}},
+		{name: "glob first", repos: []config.Repo{glob, exact}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			require := require.New(t)
+			repos := resolveStartupRepos(
+				t.Context(),
+				&config.Config{Repos: test.repos},
+				mustProviderRegistry(t, nil, reader),
+				nil,
+			)
+
+			require.Equal([]ghclient.RepoRef{{
+				Platform:           platform.KindGitLab,
+				PlatformHost:       "gitlab.example.com",
+				Owner:              "acme-tools",
+				Name:               "current-widget",
+				CredentialOwner:    "acme",
+				CredentialName:     "legacy-widget",
+				RepoPath:           "acme-tools/current-widget",
+				PlatformExternalID: "project-42",
+			}}, repos)
+		})
+	}
+}
+
 func TestResolveStartupReposFallsBackToDBForOfflineGlobs(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -650,8 +813,10 @@ func mustProviderRegistry(
 }
 
 type mainTestRepositoryReader struct {
-	kind platform.Kind
-	host string
+	kind             platform.Kind
+	host             string
+	getRepository    func(platform.RepoRef) (platform.Repository, error)
+	listRepositories func(string) ([]platform.Repository, error)
 }
 
 func (r mainTestRepositoryReader) Platform() platform.Kind {
@@ -670,6 +835,9 @@ func (r mainTestRepositoryReader) GetRepository(
 	_ context.Context,
 	ref platform.RepoRef,
 ) (platform.Repository, error) {
+	if r.getRepository != nil {
+		return r.getRepository(ref)
+	}
 	return platform.Repository{Ref: ref}, nil
 }
 
@@ -678,6 +846,9 @@ func (r mainTestRepositoryReader) ListRepositories(
 	owner string,
 	_ platform.RepositoryListOptions,
 ) ([]platform.Repository, error) {
+	if r.listRepositories != nil {
+		return r.listRepositories(owner)
+	}
 	return []platform.Repository{{
 		Ref: platform.RepoRef{
 			Platform: r.kind,
@@ -762,7 +933,7 @@ func TestRootNestedHelpExposesCommandFlags(t *testing.T) {
 		{name: "version", args: []string{"version", "--help"}, want: []string{"--json"}},
 		{name: "config read", args: []string{"config", "read", "--help"}, want: []string{"--config"}},
 		{name: "docs add", args: []string{"docs", "add-folder", "--help"}, want: []string{"--config", "--id", "--name", "--daemon"}},
-		{name: "archive report", args: []string{"archive", "report", "--help"}, want: []string{"--days", "--start", "--end", "--format", "--repo"}},
+		{name: "archive report", args: []string{"archive", "report", "--help"}, want: []string{"--days", "--start", "--end", "--format", "--repo", "--repo-id"}},
 		{name: "agent hook run", args: []string{"agent-hook", "run", "--help"}, want: []string{"--agent", "--config", "--source"}},
 		{name: "status", args: []string{"status", "--help"}, want: []string{"--config", "--json"}},
 		{name: "start", args: []string{"start", "--help"}, want: []string{"--background", "--config"}},

--- a/cmd/kenn-forge/main_test.go
+++ b/cmd/kenn-forge/main_test.go
@@ -230,11 +230,12 @@ func TestResolveStartupReposExpandsConfiguredGlobs(t *testing.T) {
 	)
 
 	assert.Equal([]ghclient.RepoRef{{
-		Platform:     "github",
-		Owner:        "roborev-dev",
-		Name:         "kenn-forge",
-		PlatformHost: "github.com",
-		RepoPath:     "roborev-dev/kenn-forge",
+		Platform:        "github",
+		Owner:           "roborev-dev",
+		Name:            "kenn-forge",
+		ConfiguredGlobs: []ghclient.ConfiguredRepoGlob{{Owner: "roborev-dev", Name: "*"}},
+		PlatformHost:    "github.com",
+		RepoPath:        "roborev-dev/kenn-forge",
 	}}, repos)
 }
 
@@ -410,12 +411,18 @@ func TestResolveStartupReposPrefersRenamedExactRouteOverGlob(t *testing.T) {
 			)
 
 			require.Equal([]ghclient.RepoRef{{
-				Platform:           platform.KindGitLab,
-				PlatformHost:       "gitlab.example.com",
-				Owner:              "acme-tools",
-				Name:               "current-widget",
-				CredentialOwner:    "acme",
-				CredentialName:     "legacy-widget",
+				Platform:        platform.KindGitLab,
+				PlatformHost:    "gitlab.example.com",
+				Owner:           "acme-tools",
+				Name:            "current-widget",
+				CredentialOwner: "acme",
+				CredentialName:  "legacy-widget",
+				ConfiguredRoutes: []ghclient.ConfiguredRepoRoute{{
+					Owner: "acme", Name: "legacy-widget", RepoPath: "acme/legacy-widget",
+				}},
+				ConfiguredGlobs: []ghclient.ConfiguredRepoGlob{{
+					Owner: "acme-tools", Name: "*",
+				}},
 				RepoPath:           "acme-tools/current-widget",
 				PlatformExternalID: "project-42",
 			}}, repos)
@@ -445,16 +452,18 @@ func TestResolveStartupReposFallsBackToDBForOfflineGlobs(t *testing.T) {
 
 	assert.ElementsMatch([]ghclient.RepoRef{
 		{
-			Platform:     platform.KindGitHub,
-			Owner:        "acme",
-			Name:         "widgets",
-			PlatformHost: "github.com",
+			Platform:        platform.KindGitHub,
+			Owner:           "acme",
+			Name:            "widgets",
+			ConfiguredGlobs: []ghclient.ConfiguredRepoGlob{{Owner: "acme", Name: "*"}},
+			PlatformHost:    "github.com",
 		},
 		{
-			Platform:     platform.KindGitHub,
-			Owner:        "acme",
-			Name:         "tools",
-			PlatformHost: "github.com",
+			Platform:        platform.KindGitHub,
+			Owner:           "acme",
+			Name:            "tools",
+			ConfiguredGlobs: []ghclient.ConfiguredRepoGlob{{Owner: "acme", Name: "*"}},
+			PlatformHost:    "github.com",
 		},
 	}, repos)
 }

--- a/cmd/kenn-forge/profiler_e2e_test.go
+++ b/cmd/kenn-forge/profiler_e2e_test.go
@@ -58,7 +58,7 @@ func TestServeStartsProfilerListenerE2E(t *testing.T) {
 	waitForFile(t, runtimelock.MetadataPath(dataDir), 10*time.Second)
 	healthBody := waitForHTTPBody(
 		t,
-		fmt.Sprintf("http://127.0.0.1:%d/healthz", appPort),
+		fmt.Sprintf("http://127.0.0.1:%d/livez", appPort),
 		10*time.Second,
 	)
 	profilerBody := waitForHTTPBody(

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -18,20 +18,35 @@ and provider capability rules, start with
 ## Identity Rules
 
 GitHub entities in kenn-forge are not identified by owner/name/number alone.
-The provider-neutral identity is `(platform, platform_host, owner, name)`;
-this document focuses on GitHub-specific default-host behavior and GitHub-only
-sync optimizations.
+The stable GitHub repository ID, scoped by host, owns one immutable internal
+repository ID. Owner/name are mutable routing and display coordinates; this
+document focuses on GitHub-specific default-host behavior and GitHub-only sync
+optimizations.
 
-- Repository identity is `(github, platform_host, owner, name)`.
-- PR and issue identity is `(github, platform_host, owner, name, number)`.
+- Repository data identity is `(github, platform_host, platform_repo_id)`.
+- Persisted PR and issue identity is `(internal_repo_id, number)`.
+- Provider API routing remains `(github, platform_host, owner, name, number)`.
 - Workspace association repair and list filtering must preserve that
-  provider/host-aware identity.
+  internal repository incarnation.
 - GitHub owner/name are case-folded lookup keys; do not apply that rule to
   providers whose metadata preserves nested or mixed-case paths.
 
 Rules:
 
-- Treat `platform_host` as part of every persisted GitHub object identity.
+- Treat `platform_host` and the stable provider repository ID as the upstream
+  repository identity; never overwrite a stored stable ID from metadata.
+- A new stable ID at the same route creates a fresh local repository
+  incarnation. Retired activity remains stored but is hidden from default
+  lists, and the new incarnation receives clean archive, notification, ETag,
+  workspace, and managed-clone state.
+- A route change with the same stable ID preserves the internal repository ID
+  and repository-owned history. Keep the configured lookup route as a
+  credential/identity alias while provider reads use the current resolved
+  route; if both routes are configured, tracked-ref deduplication prefers the
+  direct current route. (`internal/github/sync.go::compactTrackedRepositoriesByID`)
+- Tracked `RepoRef` lists are concurrent snapshots; constructors and publishers
+  must copy their slices before mutation.
+  (`internal/github/sync.go::publishResolvedRepository`)
 - When a caller explicitly supplies `platform_host`, honor it all the way
   through query, sync, and response shaping.
 - Only fall back to the default host when the request truly omits host and the
@@ -41,6 +56,11 @@ Rules:
   compatibility paths.
 - Do not constrain repo-scoped listing queries to one host unless the caller
   asked for that host.
+- GitHub issue-list clients must continue filtering payloads with
+  `PullRequestLinks` before page normalization. `NormalizeIssue` also rejects
+  those payloads as a persistence backstop, but it is not a list filter: letting
+  a pull request reach it would fail the entire issue page.
+  (`internal/github/client.go`, `internal/platform/github/normalize.go`)
 
 ## Freshness Rules
 
@@ -55,6 +75,9 @@ what "current" means.
 - Budgeted detail drain treats each queue item's worst-case cost as soft admission;
   provider pagination and child hydration may exceed it because the transport counts
   actual wire attempts (`internal/github/sync.go::drainDetailQueue`).
+- Detail-queue work is bound to the repository ID selected during index sync
+  and holds that incarnation stable through provider, clone, and persistence
+  work (`internal/github/sync.go::drainDetailQueueItems`).
 
 For pull requests, that means:
 
@@ -296,6 +319,10 @@ has a tracked repository. Ownerless APIs may use only the host fallback; never
 borrow an arbitrary owner PAT. Repository notifications use the user/write
 identity. App-only routes may read, but notifications and mutations remain
 disabled until restart establishes a stable user identity.
+After a repository rename, notification list options carry the current
+owner/name for provider filtering separately from the configured owner/name
+used to select an exact credential route.
+(`internal/github/auth_router.go::RoutedClient.ListNotifications`)
 
 Notification sync watermarks are per repository identity, never host-wide: a
 repository whose credential route is unavailable or exhausted reports its error
@@ -344,7 +371,8 @@ Managed Git uses exact-repository or owner PAT routes with mutation context and
 must never expose an App installation token to smart HTTP. Thread full provider,
 host, owner, and repository identity through clone/fetch and local reads, passing
 the normalized platform (`repoPlatform(repo)`) so an unqualified GitHub ref still
-picks its credential route instead of none;
+picks its credential route instead of none; a same-ID rename changes the remote
+endpoint but retains the configured exact credential route;
 partition non-GitHub clone storage by provider on shared hosts. Before injecting
 a PAT into workspace fetch or push, require the branch upstream to be `origin`,
 reject repository-local URL rewrites, and validate every origin fetch/push URL.
@@ -354,6 +382,12 @@ run git with no credential, which succeeds against any public repository and
 spends no identity's budget. A route resolver that cannot serve a repository must
 return a source whose `Token` reports the missing route
 (`cmd/kenn-forge/provider_startup.go::missingRouteTokenSource`).
+
+Repository-browser refreshes hold the active repository lease until shared
+singleflight Git work has actually stopped, including caller cancellation.
+Restart seeding may repoint an incarnation-scoped clone to a same-ID renamed
+origin locally, but network refresh belongs to the retrying background loop.
+(`internal/gitclone/repo_browser.go::Manager.RefreshRepoBrowserClones`)
 
 Token-file rotation within the same GitHub user is hot-reloadable. Changing the
 authenticated user, adding a write identity to an App-only route, or adding or

--- a/context/notifications-in-activity.md
+++ b/context/notifications-in-activity.md
@@ -131,6 +131,9 @@ Rules:
 - Newer unread GitHub activity clears queued/synced/error propagation fields and reactivates row.
 - Failure updates must be guarded by queued generation just like success updates.
 - Rate-limit/secondary-limit errors should pause retry without burning normal per-row attempts across batch.
+- Credential-bucket rate-limit deferral selects queued rows by internal
+  repository ID, never by mutable owner/name routes.
+  (`internal/db/queries_notifications.go::DB.DeferQueuedNotificationAcksForRepos`)
 - Retry cap failures should stop automatic retries, clear `source_ack_next_attempt_at`, and preserve local done/read state.
 
 ## Sync Behavior
@@ -146,7 +149,9 @@ Rules:
 - Notification sync failures should update notification sync status so UI can surface them.
 - Top-level manual sync also triggers notification sync.
 - `/notifications/sync` triggers only notification sync and returns `202` once accepted.
-- Sync watermark identity is per repository: `(platform, platform_host, repo_owner, repo_name)`, with owner/name lowercased to match `notificationRepoKey`. One repository's failing or unroutable credential route must not hold back watermark advancement for healthy repositories on the same host.
+- Sync watermark identity is the internal repository ID. One repository's
+  failing or unroutable credential route must not hold back watermark
+  advancement for healthy repositories on the same host.
 - A repository with no watermark yet full-syncs (GitHub `All: true`) without resetting siblings; later syncs use its persisted watermark/overlap to avoid full backlog scans.
 - GitHub notification pagination must run until the provider reports no next page; do not use a fixed page cap for either the primary repo notification list or the participating-only annotation scan. A fixed cap can pin the watermark forever on large backlogs. The guardrail is the shared sync budget/rate reserve (`internal/github/notifications_sync.go::ensureNotificationPageBudget`), which should stop sync explicitly when upstream budget is exhausted (`internal/github/sync_test.go::TestSyncNotificationsReadsAllRepositoryNotificationPages`, `internal/github/sync_test.go::TestSyncNotificationsReadsAllParticipatingNotificationPages`).
 - Notification sync and read propagation should stop with server lifecycle before shared services are torn down.

--- a/context/notifications-in-activity.md
+++ b/context/notifications-in-activity.md
@@ -37,12 +37,19 @@ Notifications are user-scoped at provider level but repo-scoped in kenn-forge.
 Rules:
 
 - Persist notification item identity as `(platform, platform_host, platform_notification_id)`.
-- Treat repository identity as `(platform, platform_host, repo_owner, repo_name)` everywhere notifications are filtered, joined, or summarized.
+- Bind each notification to the active internal repository ID when its provider
+  route is known. Keep provider/host/owner/name as routing and display fields,
+  not repository ownership.
 - `platform` is required. Blank provider/platform values are errors, not implicit GitHub defaults.
 - Show notifications only for current monitored repo set from config/syncer repo refs.
 - Historical notifications for removed repos may stay in SQLite but must not appear in `unread`, `active`, `read`, `done`, or `all` unless future explicit `include_unmonitored` contract exists.
-- `repo_id` is enrichment/optimization, not visibility authority.
-- Sync watermarks are keyed by full repository identity `(platform, platform_host, repo_owner, repo_name)`, never by host alone.
+- `repo_id` is the visibility authority. Notifications without a resolved
+  repository ID remain hidden until an active repository adopts them.
+- Sync watermarks are keyed by internal repository ID, never by host or mutable
+  route alone.
+- After a same-ID repository rename, provider notification filters use the
+  current owner/name while exact credential selection retains the configured
+  pre-rename owner/name until configuration adopts the new route.
 - Repo facets and filters must be host-qualified when host ambiguity is possible, e.g. `github.com/acme/widget`.
 
 ## Persistence Shape
@@ -67,7 +74,14 @@ Rules:
 
 - `done_at` and `done_reason` remain kenn-forge-local triage state.
 - `source_*` fields track provider-side activity and acknowledgement propagation state.
-- The notification schema ships as a single migration, `000035_notifications.*`; do not split future assumptions across deleted branch-only migrations. Branch databases that already applied the abandoned notification migration at version 34 are repaired at startup by ensuring the current `000034_fleet_integration` artifacts exist before the database is accepted. Migration `000040` rebuilt the watermark table to per-repository identity and retired the host-wide `sync_cursor`/`tracked_repos_key` columns; old host-wide rows are dropped because they cannot be attributed to a repository.
+- The notification schema ships as a single migration,
+  `000035_notifications.*`; do not split future assumptions across deleted
+  branch-only migrations. Branch databases that already applied the abandoned
+  notification migration at version 34 are repaired at startup by ensuring the
+  current `000034_fleet_integration` artifacts exist before the database is
+  accepted. Migration `000040` retired the host-wide
+  `sync_cursor`/`tracked_repos_key` columns. Migration `000045` keys watermarks
+  by internal repository ID and discards the prior path-keyed cache.
 
 ## Triage State Model
 
@@ -109,6 +123,9 @@ Rules:
 - The registry's `NotificationReader`/`NotificationMutator` accessors gate on the declared capability flags, not interface satisfaction, because stubs satisfy the interfaces.
 - The sync engine intentionally requires BOTH `ReadNotifications` and `NotificationMutation` to select a provider: listing and read-ack propagation are treated as one feature today. A future read-only provider (list without upstream mark-read) would split this — select listing on `ReadNotifications` and propagation on `NotificationMutation` separately. Until such a provider exists the coupling keeps the path simple.
 - Propagation workers must revalidate queued generation before calling provider.
+- Propagation resolves the active repository by queued `repo_id` and holds its
+  incarnation stable through refetch, mark-read, and local persistence.
+  (`internal/github/notifications_sync.go::Syncer.ProcessQueuedNotificationReads`)
 - Stale queued work must not mark newer provider activity read.
 - After successful propagation, stale GitHub sync payloads with `unread=true` and `source_updated_at <= source_ack_generation_at` must preserve local read state.
 - Newer unread GitHub activity clears queued/synced/error propagation fields and reactivates row.

--- a/context/platform-sync-invariants.md
+++ b/context/platform-sync-invariants.md
@@ -7,17 +7,44 @@ provider interfaces, and the checklist for adding a new provider, read
 
 ## Identity
 
-Repository identity is `(platform, platform_host, owner, name)`, with
-`repo_path` as the provider-canonical full path and provider IDs used for
-reconciliation when available.
+Repository data identity is the provider's stable repository ID scoped by
+`(platform, platform_host)`. Kenn Forge assigns each such identity one immutable
+internal repository ID. `(owner, name)` and `repo_path` are mutable provider
+routing and display coordinates.
 
 - `platform` is the provider kind named in the canonical provider list in
   `CLAUDE.md`.
 - `platform_host` is the normalized host for that provider. Preserve ports.
 - `owner` and `name` are provider-canonical display/config fields.
 - `repo_path` carries the full provider path when `owner/name` is not enough.
-- `platform_repo_id` / provider external IDs are stable provider identities;
-  prefer them for rename reconciliation, but never drop human-readable fields.
+- `platform_repo_id` / provider external IDs are stable provider identities.
+  Provider-owned children, archive state, notification progress, conditional
+  request state, workspaces, and managed Git storage are scoped by the internal
+  repository ID.
+- A stable provider ID follows a rename while preserving the internal
+  repository ID and all repository-owned history. A different stable provider
+  ID observed at an occupied route creates a fresh internal repository
+  incarnation; the prior incarnation and its history are retained but retired
+  from default lists. (`internal/db/queries.go::UpsertRepoByProviderID`)
+- Keep configured lookup coordinates separate from resolved display/routing
+  coordinates; live identity verification always queries the configured route
+  so later path reuse becomes a new incarnation. (`internal/github/sync.go::syncRepoIdentity`)
+- Persist every exact configured-to-resolved route binding across restarts and
+  reconcile aliases from the complete configuration snapshot. Exact settings
+  match configured coordinates; globs match resolved coordinates.
+  (`internal/db/queries.go::ReconcileRepoConfiguredRoutes`)
+- When resolved configuration entries overlap, exact entries beat globs; among
+  exact entries, the current direct route beats a rename alias.
+  (`internal/github/repo_config_resolver.go::PreferConfiguredRepoCandidate`)
+- Publish resolved tracked routes and reconcile archive configuration as one
+  generation-fenced transition; delayed reads cannot restore superseded routes.
+  (`internal/github/sync.go::resolveActiveRepository`)
+- Renaming a stable provider ID into an occupied route retires the destination
+  incarnation without merging its provider-owned data into the source.
+- Every non-empty provider ID written to an existing repository row, including
+  ordinary upserts and provider-metadata refreshes, must pass the same conflict
+  check. Metadata updates may fill an empty stable ID but never replace one.
+  (`internal/db/queries.go::validateRepoProviderIDWriteTx`)
 
 GitLab nested namespaces make `repo_path` mandatory for reliable addressing:
 `group/subgroup/project` has owner `group/subgroup` and name `project`.
@@ -29,10 +56,18 @@ provider-canonical owner/name casing; do not lowercase them like GitLab.
 `repo_path` is normally `owner/name` and is primarily a canonicalization aid for
 URL-parsed config or provider responses.
 
-Do not identify repos, merge requests, issues, events, stars, workspaces, or
-activity rows by owner/name/number alone. Thread the full provider ref through
-requests, sync queues, persistence, and responses. Dedupe keys for items and
-events must be scoped by persisted repo ID or full provider identity.
+Do not identify repositories or repository-owned rows by owner/name/number.
+Thread the full provider route through requests and sync queues, but scope
+persistence, caches, archives, notifications, workspaces, and item/event dedupe
+by the persisted internal repository ID.
+Background work retaining a mutable route must reauthorize its active internal ID
+and hold authorization through provider/Git access and persistence; queued routes
+can outlive ownership. (`internal/db/db.go::LockRepositoryReconciliationRead`)
+Provider mutations hold a capability-aware active-repository lease through the
+provider write and direct local persistence, releasing it before any nested sync
+acquires its own lease. (`internal/server/httpapi/repository_resolver.go::RepositoryResolver.LeaseRouteCapability`)
+Provider-owned parent and mutation-result writes must reject a retired internal
+repository ID. (`internal/db/queries.go::requireActiveRepoTx`)
 
 ## Provider Hosts And Tokens
 
@@ -86,9 +121,14 @@ Managed Git authorization is selected by full `(platform, platform_host, owner,
 name)` identity. GitHub smart HTTP uses mutation/user candidates and never an
 App installation token. Exact repository routes beat owner routes, which beat
 the unscoped host fallback. Non-GitHub providers use their provider-host
-fallback. Clone storage and singleflight keys must partition providers sharing a
-host, and authenticated workspace operations must validate the effective origin
-fetch and push destinations before resolving a credential.
+fallback. Repository-owned clone storage is selected by internal repository ID
+through an immutable handle; mutable routes select only the remote and
+credential. (`internal/gitclone/clone.go::Manager.RepositoryClone`)
+Do not adopt route-keyed legacy clones into repository-owned storage without an
+explicit association to the same internal repository ID; path identity alone
+cannot distinguish a rename from route reuse.
+Authenticated workspace operations must validate the effective origin fetch and
+push destinations before resolving a credential.
 
 Minimum read scope should cover repository metadata, merge requests or pull
 requests, issues, comments, commits, tags, releases, and CI/status data. Write
@@ -109,6 +149,13 @@ registry helpers return typed errors for missing providers or capabilities.
   the operation context (`internal/platform/gitlab/client.go::NewClient`).
 - Resolve opaque provider repo IDs by `repo_path` before numeric-only operations
   (`internal/platform/gitlab/client.go::projectScopedArg`).
+- A full repository sync must use the live stable ID when the provider supports
+  repository reads, even when configuration already carries an ID. Providers
+  that explicitly do not support repository reads may use a configured stable
+  ID; a claimed repository read that returns no stable ID fails closed.
+  Repositories whose index sync fails are excluded from that run's detail drain.
+  (`internal/github/sync.go::syncRepoIdentity`,
+  `internal/github/sync.go::reposWithSuccessfulIndexSync`)
 - `priority_repo` reorders a full run; `only_repo` restricts every repo-derived
   phase and must not delay full-run cadence. Resolve both by full identity, and
   never fall back from invalid exclusive scope. (`internal/github/sync.go::runOnce`)
@@ -179,17 +226,18 @@ registry helpers return typed errors for missing providers or capabilities.
   path.
 - Provider-supplied web URLs, clone URLs, default branches, platform ids, and
   external ids should be persisted when available instead of reconstructed from
-  host/owner/name. Every settings-refresh branch must write this metadata:
-  repo resolution pre-fills the platform repo id, so the identity sync never
-  re-resolves the repository and whichever refresh branch runs is the row's
-  only metadata writer. A branch that skips the write leaves default_branch
-  empty forever, which silently degrades the worktree diff sampler to a bare
-  HEAD diff (0/0 sidebar stats).
+  host/owner/name. Every settings-refresh branch must write this metadata; a
+  branch that skips the write leaves `default_branch` empty and silently
+  degrades branch activity. (`internal/github/sync.go::refreshRepoSettings`)
 - Child datasets and detail/CI/diff freshness writes are fenced to the parent snapshot revision. Complete comments and inline review sets replace; submitted reviews remain additive. (`internal/db/queries_snapshot_children.go::CommitMergeRequestChildSnapshot`)
 
 ## Historical Archive
 
-- Archive is a scheduling and progress mode over normal sync, not a second sync engine; completeness is repository and item progress scoped by full repository identity. (`internal/db/queries_archive.go::GetArchiveProgress`)
+- Archive is a scheduling and progress mode over normal sync, not a second sync
+  engine; completeness is repository and item progress scoped by internal
+  repository ID. A replacement incarnation starts fresh discovery while the
+  retired archive remains available for explicit historical inspection.
+  (`internal/db/queries_archive.go::GetArchiveProgress`)
 - Created-order inventory calls require the historical capability; updated-order maintenance traversal does not. Each returns one bounded identity page with an advancing opaque cursor or explicit exhaustion. (`internal/platform/reader_validation.go::pageReaderValidation.prepare`)
 - Hydration admits one item and invokes canonical item sync; only a successful complete sync records an archive outcome. Do not add archive-specific content paths. (`internal/archive/hydrate.go::hydrateItem`)
 - Only parent lookups explicitly classified as removed, moved, or inaccessible are terminal. Generic and child-dataset not-found responses remain retries; a successful non-GitHub feature-metadata confirmation doubles as repository-accessibility evidence and must not be repeated before marking the parent absent. Canonical item content stays untouched. (`internal/archive/hydrate.go::archiveTerminalSyncOutcome`, `internal/platform/gitealike/feature_disabled.go::Provider.repositoryItemLookupError`,
@@ -314,6 +362,9 @@ partial review dataset or report an incomplete explicit sync as successful
 Repository import requests and route/query shapes should carry
 `provider`, `platform_host`, and either `repo_path` or exact `owner/name`.
 
+- Repository imports must serialize read-modify-save with config reload
+  publication; an older watcher snapshot must not overwrite a later import.
+  (`internal/server/repo_import_handlers.go::Server.applyBulkExactRepos`)
 - Provider-aware item routes use `/pulls/{provider}/{owner}/{name}/{number}`,
   `/issues/{provider}/{owner}/{name}/{number}`, and `/repo/{provider}/{owner}/{name}`.
 - Non-default hosts use the `/host/{platform_host}/...` route prefix.

--- a/context/platform-sync-invariants.md
+++ b/context/platform-sync-invariants.md
@@ -33,6 +33,9 @@ routing and display coordinates.
   reconcile aliases from the complete configuration snapshot. Exact settings
   match configured coordinates; globs match resolved coordinates.
   (`internal/db/queries.go::ReconcileRepoConfiguredRoutes`)
+- Glob discovery grants membership only while the resolved route matches an
+  originating pattern; globs never become durable route aliases.
+  (`internal/github/sync.go::repoMatchesConfiguredGlobs`)
 - When resolved configuration entries overlap, exact entries beat globs; among
   exact entries, the current direct route beats a rename alias.
   (`internal/github/repo_config_resolver.go::PreferConfiguredRepoCandidate`)

--- a/context/provider-architecture.md
+++ b/context/provider-architecture.md
@@ -249,11 +249,10 @@ implemented notification source today.
 Rules:
 
 - Notification item identity is `(platform, platform_host, platform_notification_id)`.
-- Notification repo scope is `(platform, platform_host, repo_owner, repo_name)`.
-- Sync watermarks are keyed by full repository identity
-  `(platform, platform_host, repo_owner, repo_name)`, never by host alone; one
-  repository's sync failure must not block watermark advancement for healthy
-  repositories on the same host.
+- Notification repo ownership and sync watermarks are keyed by internal
+  repository ID. Provider/host/owner/name remain routing and display fields;
+  one repository incarnation's sync failure must not block watermark
+  advancement for healthy repositories on the same host.
 - Blank provider values are invalid in notification paths. Do not add fallback
   behavior that silently treats missing provider as GitHub.
 - If server/API keeps GitHub-shaped response fields for compatibility, contain

--- a/context/testing.md
+++ b/context/testing.md
@@ -321,6 +321,10 @@ Real-Git test packages use `gitsafe.RunIsolatedMain` in `TestMain`: one empty co
 Use `Runner` where code strips Git variables, and `MutableRunner` only for global config
 mutations (`internal/testutil/gitsafe/gitsafe.go::RunIsolatedMain`).
 
+Managed-clone fixtures must bind the persisted repository ID before resolving
+their clone path; route-keyed fixture storage is abandoned once runtime setup
+binds the incarnation (`internal/testutil/diff_repo.go::SetupDiffRepo`).
+
 Real tmux and PTY tests can still run in parallel when each test owns its
 session names, temp dirs, sockets, and cleanup. If the bottleneck is external
 resource pressure rather than correctness, keep `t.Parallel()` and gate the

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -35,9 +35,9 @@ embedder protocol for arbitrary host state.
   - Directory recovery accepts no path and applies only when the workspace row
     is absent; an occupied deterministic path conflicts with its actual branch,
     and choosing another branch cannot relocate it (`internal/workspace/manager.go::Manager.CreateIssue`).
-  - Recovery validates repository provenance before persistence and again during
-    setup; the managed clone's deterministic path is not identity without a
-    matching origin (`internal/workspace/manager.go::Manager.existingWorktreeUsesManagedClone`).
+  - Recovery accepts incarnation-scoped and pre-incarnation managed clones only
+    after validating the repository ID, Git common directory, origin, linked
+    worktree, and branch (`internal/workspace/manager.go::Manager.existingWorkspaceWorktreeProvenance`).
   - Pending recovery uses a Git-invalid branch marker and must adopt that
     directory without create/cleanup fallback; retry/delete preserve it until setup
     publishes the real branch and ready status (`internal/workspace/manager.go::workspaceRequiresExistingDirectory`).
@@ -206,6 +206,12 @@ Persisted workspace `worktree_path` values should be absolute. Workspace setup
 runs `git worktree add` from the managed clone or configured base checkout, so
 relative paths would be interpreted relative to that Git directory while later
 API reads interpret them relative to the kenn-forge server process.
+Workspace setup authorizes the workspace's stored repository ID and holds that
+incarnation stable through clone, worktree, terminal, and persistence side
+effects (`internal/workspace/manager.go::Manager.SetupWithWorktreeBasePath`).
+Networked workspace branch actions likewise lease the stored repository ID;
+retired workspaces remain available only for local inspection and cleanup
+(`internal/server/workspaceapi/workspace_branch_actions.go::Handler.runWorkspaceBranchAction`).
 
 Keep Git worktree and merge-request lifecycle semantics in
 `go.kenn.io/kit/git/managed`; Kenn Forge supplies application policy instead of

--- a/docs/archive.md
+++ b/docs/archive.md
@@ -24,7 +24,9 @@ There is no manual cursor-reset command. Invalid cursors, provider page limits, 
 
 ## Status and coverage
 
-`kenn-forge archive status` reports repository-scoped progress using the full provider identity. Common states are:
+`kenn-forge archive status` reports repository-scoped progress using the full
+provider identity. Use `--repo-id` to inspect a retained historical repository
+incarnation that no longer owns its former route. Common states are:
 
 - **current** — supported inventory and item hydration are complete;
 - **partial** — one or more inventory scopes or items are unsupported or terminally blocked;
@@ -37,7 +39,12 @@ Error details are sanitized. Removing a repository from configuration pauses its
 
 ## Reports
 
-`kenn-forge archive report` reads SQLite for a UTC time range and optional repository filters. Summary output aggregates activity and contributors. Verbose output includes individual records. JSON output is available for automation.
+`kenn-forge archive report` reads SQLite for a UTC time range and optional
+repository filters. Route filters select the current repository at a path;
+`--repo-id` selects one immutable repository incarnation, including retained
+history after route reuse. Summary output aggregates activity and contributors.
+Verbose output includes individual records. JSON output is available for
+automation.
 
 Reports reflect supported coverage. Check archive status before treating a report as complete.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -74,9 +74,11 @@ response body.
 kenn-forge archive start --all
 kenn-forge archive start --repo 'github|github.com/owner/repo'
 kenn-forge archive status --json
+kenn-forge archive status --repo-id 42
 kenn-forge archive pause --all
 kenn-forge archive report --days 7
 kenn-forge archive report --start 2026-07-01 --end 2026-07-07 --verbose
+kenn-forge archive report --days 7 --repo-id 42
 ```
 
 Archive collection runs in the background within each provider host's normal
@@ -88,7 +90,8 @@ Reports use only kenn-forge's local archive, so they make no provider requests,
 but the kenn-forge daemon must be running. `--days` uses rolling 24-hour UTC
 periods. Date-only ranges include both named dates; RFC3339 ranges use an
 inclusive start and exclusive end. Reports default to Markdown; use
-`--format json`, `--output PATH`, and repeated fully qualified `--repo` filters
+`--format json`, `--output PATH`, repeated fully qualified `--repo` filters,
+and repeated immutable `--repo-id` filters
 as needed.
 
 Starting from an existing kenn-forge database discovers historical issues, pull

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -712,6 +712,9 @@ components:
           type: string
         repo_path:
           type: string
+        repository_id:
+          format: int64
+          type: integer
       required:
         - provider
         - platform_host
@@ -8196,6 +8199,18 @@ paths:
             type:
               - array
               - "null"
+        - description: Repeated immutable repository incarnation IDs.
+          explode: true
+          in: query
+          name: repo_id
+          schema:
+            description: Repeated immutable repository incarnation IDs.
+            items:
+              format: int64
+              type: integer
+            type:
+              - array
+              - "null"
         - explode: false
           in: query
           name: verbose
@@ -8258,6 +8273,18 @@ paths:
             description: Repeated provider|platform_host/repo_path filters.
             items:
               type: string
+            type:
+              - array
+              - "null"
+        - description: Repeated immutable repository incarnation IDs.
+          explode: true
+          in: query
+          name: repo_id
+          schema:
+            description: Repeated immutable repository incarnation IDs.
+            items:
+              format: int64
+              type: integer
             type:
               - array
               - "null"

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -1306,6 +1306,7 @@ type ArchiveRepositoryRef struct {
 	PlatformHost string `json:"platform_host"`
 	Provider     string `json:"provider"`
 	RepoPath     string `json:"repo_path"`
+	RepositoryId *int64 `json:"repository_id,omitempty"`
 }
 
 // ArchiveStatusResponse defines model for ArchiveStatusResponse.
@@ -4295,14 +4296,20 @@ type GetArchiveReportParams struct {
 	End string `form:"end" json:"end"`
 
 	// Repo Repeated provider|platform_host/repo_path filters.
-	Repo    *[]string `form:"repo,omitempty" json:"repo,omitempty"`
-	Verbose *bool     `form:"verbose,omitempty" json:"verbose,omitempty"`
+	Repo *[]string `form:"repo,omitempty" json:"repo,omitempty"`
+
+	// RepoId Repeated immutable repository incarnation IDs.
+	RepoId  *[]int64 `form:"repo_id,omitempty" json:"repo_id,omitempty"`
+	Verbose *bool    `form:"verbose,omitempty" json:"verbose,omitempty"`
 }
 
 // ListArchiveStatusParams defines parameters for ListArchiveStatus.
 type ListArchiveStatusParams struct {
 	// Repo Repeated provider|platform_host/repo_path filters.
 	Repo *[]string `form:"repo,omitempty" json:"repo,omitempty"`
+
+	// RepoId Repeated immutable repository incarnation IDs.
+	RepoId *[]int64 `form:"repo_id,omitempty" json:"repo_id,omitempty"`
 }
 
 // BrowseDocsFoldersParams defines parameters for BrowseDocsFolders.
@@ -11537,6 +11544,18 @@ func NewGetArchiveReportRequest(server string, params *GetArchiveReportParams) (
 
 		}
 
+		if params.RepoId != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "repo_id", *params.RepoId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "array", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
 		if params.Verbose != nil {
 
 			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "verbose", *params.Verbose, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "boolean", Format: ""}); err != nil {
@@ -11634,6 +11653,18 @@ func NewListArchiveStatusRequest(server string, params *ListArchiveStatusParams)
 		if params.Repo != nil {
 
 			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "repo", *params.Repo, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "array", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.RepoId != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "repo_id", *params.RepoId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "array", Format: ""}); err != nil {
 				return nil, err
 			} else {
 				for _, qp := range strings.Split(queryFrag, "&") {

--- a/internal/archive/controller.go
+++ b/internal/archive/controller.go
@@ -13,5 +13,6 @@ type Controller interface {
 	Pause(context.Context, []platform.RepoRef) ([]Status, error)
 	PauseAll(context.Context) ([]Status, error)
 	Status(context.Context, []platform.RepoRef) ([]Status, error)
+	StatusByRepositoryIDs(context.Context, []int64) ([]Status, error)
 	Report(context.Context, ReportOptions) (report.Model, error)
 }

--- a/internal/archive/report.go
+++ b/internal/archive/report.go
@@ -17,10 +17,11 @@ import (
 var ErrEmptyReportScope = errors.New("archive report repository scope is empty")
 
 type ReportOptions struct {
-	Start        time.Time
-	End          time.Time
-	Repositories []platform.RepoRef
-	Detailed     bool
+	Start         time.Time
+	End           time.Time
+	Repositories  []platform.RepoRef
+	RepositoryIDs []int64
+	Detailed      bool
 }
 
 func (s *Service) Report(ctx context.Context, opts ReportOptions) (report.Model, error) {
@@ -38,7 +39,13 @@ func (s *Service) report(
 	opts.Start = opts.Start.UTC()
 	opts.End = opts.End.UTC()
 
-	var requestedIDs []int64
+	if len(opts.Repositories) > 0 && len(opts.RepositoryIDs) > 0 {
+		return report.Model{}, errors.New("archive report repository routes and IDs are mutually exclusive")
+	}
+	if err := validateRepositoryIDs(opts.RepositoryIDs); err != nil {
+		return report.Model{}, err
+	}
+	requestedIDs := normalizeRepositoryIDs(opts.RepositoryIDs)
 	if len(opts.Repositories) > 0 {
 		resolved, err := s.resolveRepositories(ctx, opts.Repositories, false)
 		if err != nil {
@@ -111,7 +118,7 @@ func buildArchiveReport(
 		repoIndexes[row.RepoID] = i
 		model.Repositories[i] = report.Repository{
 			Repository: reportRepositoryRef(
-				row.Platform, row.PlatformHost, row.Owner, row.Name, row.RepoPath,
+				row.RepoID, row.Platform, row.PlatformHost, row.Owner, row.Name, row.RepoPath,
 			),
 			Coverage: reportCoverage(row),
 		}
@@ -151,7 +158,7 @@ func buildArchiveReport(
 		for i, row := range activityRows {
 			model.Activity[i] = report.Activity{
 				Repository: reportRepositoryRef(
-					row.Platform, row.PlatformHost, row.Owner, row.Name, row.RepoPath,
+					row.RepoID, row.Platform, row.PlatformHost, row.Owner, row.Name, row.RepoPath,
 				),
 				Kind: report.ActivityKind(row.Kind), ItemNumber: row.ItemNumber,
 				ProviderExternalID: row.ProviderExternalID, Title: row.Title,
@@ -185,9 +192,10 @@ func reportCoverage(row db.ArchiveReportRepositoryRow) report.Coverage {
 	}
 }
 
-func reportRepositoryRef(provider, host, owner, name, repoPath string) report.RepositoryRef {
+func reportRepositoryRef(repoID int64, provider, host, owner, name, repoPath string) report.RepositoryRef {
 	return report.RepositoryRef{
-		Provider: provider, PlatformHost: host, Owner: owner, Name: name, RepoPath: repoPath,
+		RepositoryID: repoID, Provider: provider, PlatformHost: host,
+		Owner: owner, Name: name, RepoPath: repoPath,
 	}
 }
 

--- a/internal/archive/report/model.go
+++ b/internal/archive/report/model.go
@@ -24,6 +24,7 @@ const (
 )
 
 type RepositoryRef struct {
+	RepositoryID int64  `json:"repository_id"`
 	Provider     string `json:"provider"`
 	PlatformHost string `json:"platform_host"`
 	Owner        string `json:"owner"`

--- a/internal/archive/report_service_test.go
+++ b/internal/archive/report_service_test.go
@@ -102,6 +102,51 @@ func TestArchiveServiceReportFiltersFullRepositoryIdentityAndRejectsEmptyScope(t
 	assert.ErrorIs(err, ErrEmptyReportScope)
 }
 
+func TestArchiveServiceReadsRetiredHistoryByRepositoryID(t *testing.T) {
+	require := require.New(t)
+	database := dbtest.Open(t)
+	ctx := t.Context()
+	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	ref := archiveServiceRef(platform.KindGitHub, "github.test", "repo")
+	ref.PlatformExternalID = "R_old"
+	oldID, err := database.UpsertRepoByProviderID(ctx, platform.DBRepoIdentity(ref))
+	require.NoError(err)
+	provider := newArchiveServiceProvider(ref.Platform, ref.Host)
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+	service := newArchiveTestService(t, database, registry, []platform.RepoRef{ref}, nil, now)
+	require.NoError(service.EnsureConfigured(ctx, []platform.RepoRef{ref}))
+	_, err = database.UpsertIssue(ctx, &db.Issue{
+		RepoID: oldID, Number: 1, Title: "Historical issue", Author: "sam",
+		State: "open", CreatedAt: archiveTestTime(), UpdatedAt: archiveTestTime(),
+	})
+	require.NoError(err)
+
+	replacement := ref
+	replacement.PlatformExternalID = "R_new"
+	newID, err := database.UpsertRepoByProviderID(ctx, platform.DBRepoIdentity(replacement))
+	require.NoError(err)
+	require.NotEqual(oldID, newID)
+
+	statuses, err := service.StatusByRepositoryIDs(ctx, []int64{oldID})
+	require.NoError(err)
+	require.Len(statuses, 1)
+	require.Equal(oldID, statuses[0].RepoID)
+	require.Equal("owner", statuses[0].Repo.Owner)
+	require.Equal("repo", statuses[0].Repo.Name)
+
+	model, err := service.Report(ctx, ReportOptions{
+		Start: archiveTestTime().Add(-time.Hour), End: archiveTestTime().Add(time.Hour),
+		RepositoryIDs: []int64{oldID}, Detailed: true,
+	})
+	require.NoError(err)
+	require.Len(model.Repositories, 1)
+	require.Equal(oldID, model.Repositories[0].Repository.RepositoryID)
+	require.Equal("owner/repo", model.Repositories[0].Repository.RepoPath)
+	require.Len(model.Activity, 1)
+	require.Equal(oldID, model.Activity[0].Repository.RepositoryID)
+}
+
 func TestArchiveServiceReportUsesRangeEndAsDeterministicStatusTime(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/archive/service.go
+++ b/internal/archive/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -229,6 +230,45 @@ func (s *Service) Status(ctx context.Context, refs []platform.RepoRef) ([]Status
 	return s.statusResolved(ctx, resolved)
 }
 
+// StatusByRepositoryIDs reads archive state for immutable repository
+// incarnations, including retired history that is no longer route-addressable.
+func (s *Service) StatusByRepositoryIDs(ctx context.Context, repoIDs []int64) ([]Status, error) {
+	if err := validateRepositoryIDs(repoIDs); err != nil {
+		return nil, err
+	}
+	repoIDs = normalizeRepositoryIDs(repoIDs)
+	if len(repoIDs) == 0 {
+		return []Status{}, nil
+	}
+	return s.statusByIDs(ctx, repoIDs)
+}
+
+func validateRepositoryIDs(repoIDs []int64) error {
+	for _, repoID := range repoIDs {
+		if repoID <= 0 {
+			return errors.New("repository IDs must be positive")
+		}
+	}
+	return nil
+}
+
+func normalizeRepositoryIDs(repoIDs []int64) []int64 {
+	seen := make(map[int64]struct{}, len(repoIDs))
+	result := make([]int64, 0, len(repoIDs))
+	for _, repoID := range repoIDs {
+		if repoID <= 0 {
+			continue
+		}
+		if _, ok := seen[repoID]; ok {
+			continue
+		}
+		seen[repoID] = struct{}{}
+		result = append(result, repoID)
+	}
+	slices.Sort(result)
+	return result
+}
+
 func (s *Service) configuredRepositories(ctx context.Context) ([]platform.RepoRef, error) {
 	if s.configured == nil {
 		return nil, errors.New("archive configured repository source is required")
@@ -248,6 +288,27 @@ func (s *Service) statusAll(ctx context.Context) ([]Status, error) {
 	ids := make([]int64, len(states))
 	for i := range states {
 		ids[i] = states[i].RepoID
+	}
+	return s.statusByIDs(ctx, ids)
+}
+
+func (s *Service) statusByIDs(ctx context.Context, ids []int64) ([]Status, error) {
+	states, err := s.db.ListArchiveRepoStates(ctx, ids)
+	if err != nil {
+		return nil, err
+	}
+	if len(states) != len(ids) {
+		found := make(map[int64]struct{}, len(states))
+		for _, state := range states {
+			found[state.RepoID] = struct{}{}
+		}
+		missing := make([]int64, 0, len(ids)-len(states))
+		for _, id := range ids {
+			if _, ok := found[id]; !ok {
+				missing = append(missing, id)
+			}
+		}
+		return nil, &db.ArchiveRepoStateNotFoundError{RepoIDs: missing}
 	}
 	progress, err := s.db.GetArchiveProgress(ctx, db.ArchiveProgressOpts{RepoIDs: ids, Now: s.now()})
 	if err != nil {

--- a/internal/archive/service_test.go
+++ b/internal/archive/service_test.go
@@ -119,7 +119,7 @@ func TestArchiveServiceEnsureConfiguredSeedsFreshRepository(t *testing.T) {
 	assert.Equal(db.ArchiveOperatorStateActive, states[0].OperatorState)
 }
 
-func TestArchiveServiceEnsureConfiguredMergesRenamedRepositoryAtExistingDestination(t *testing.T) {
+func TestArchiveServiceEnsureConfiguredKeepsArchiveWithStableRepositoryID(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	database := dbtest.Open(t)
@@ -133,21 +133,139 @@ func TestArchiveServiceEnsureConfiguredMergesRenamedRepositoryAtExistingDestinat
 
 	sourceID, err := database.UpsertRepoByProviderID(t.Context(), platform.DBRepoIdentity(previous))
 	require.NoError(err)
-	destinationID, err := database.UpsertRepo(t.Context(), platform.DBRepoIdentity(staleDestination))
+	destinationID, err := database.UpsertRepoByProviderID(
+		t.Context(),
+		platform.DBRepoIdentity(staleDestination),
+	)
 	require.NoError(err)
+	require.NoError(database.EnsureDiscoveryArchives(
+		t.Context(),
+		[]int64{sourceID, destinationID},
+		now,
+	))
+	require.NoError(database.StartFullArchives(
+		t.Context(),
+		[]int64{sourceID},
+		now,
+	))
 	provider := newArchiveServiceProvider(current.Platform, current.Host)
 	registry, err := platform.NewRegistry(provider)
 	require.NoError(err)
 	service := newArchiveTestService(t, database, registry, []platform.RepoRef{current}, nil, now)
 
-	require.NoError(service.EnsureConfigured(t.Context(), []platform.RepoRef{current}))
+	require.NoError(service.EnsureConfigured(
+		t.Context(),
+		[]platform.RepoRef{current},
+	))
+
 	repos, err := database.ListRepos(t.Context())
 	require.NoError(err)
 	require.Len(repos, 1)
-	assert.Equal(destinationID, repos[0].ID)
+	assert.Equal(sourceID, repos[0].ID)
 	assert.Equal("repo-current", repos[0].PlatformRepoID)
 	assert.Equal("current", repos[0].Name)
-	assert.NotEqual(sourceID, destinationID)
+
+	destination, err := database.GetRepoByID(
+		t.Context(),
+		destinationID,
+	)
+	require.NoError(err)
+	require.NotNil(destination)
+	require.NotNil(destination.RetiredAt)
+	require.NotNil(destination.RetiredReplacementID)
+	assert.Equal(sourceID, *destination.RetiredReplacementID)
+	assert.Equal("repo-obsolete", destination.PlatformRepoID)
+
+	states, err := database.ListArchiveRepoStates(
+		t.Context(),
+		[]int64{sourceID, destinationID},
+	)
+	require.NoError(err)
+	require.Len(states, 2)
+	assert.Equal(sourceID, states[0].RepoID)
+	assert.Equal(db.ArchiveCollectionModeFull, states[0].CollectionMode)
+	assert.Equal(db.ArchiveOperatorStateActive, states[0].OperatorState)
+	assert.Equal(destinationID, states[1].RepoID)
+	assert.Equal(db.ArchiveOperatorStatePaused, states[1].OperatorState)
+	require.NotNil(states[1].LastErrorCode)
+	assert.Equal(
+		string(db.ArchiveErrorCodeConfigurationRemoved),
+		*states[1].LastErrorCode,
+	)
+}
+
+func TestArchiveServiceEnsureConfiguredStartsFreshReplacementArchive(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	database := dbtest.Open(t)
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	oldRef := archiveServiceRef(platform.KindGitHub, "github.test", "project")
+	oldRef.PlatformExternalID = "repo-old"
+	newRef := oldRef
+	newRef.PlatformExternalID = "repo-new"
+
+	provider := newArchiveServiceProvider(oldRef.Platform, oldRef.Host)
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+	service := newArchiveTestService(
+		t,
+		database,
+		registry,
+		[]platform.RepoRef{newRef},
+		nil,
+		now,
+	)
+
+	require.NoError(service.EnsureConfigured(
+		t.Context(),
+		[]platform.RepoRef{oldRef},
+	))
+	oldRepo, err := database.GetRepoByIdentity(
+		t.Context(),
+		platform.DBRepoIdentity(oldRef),
+	)
+	require.NoError(err)
+	require.NotNil(oldRepo)
+	require.NoError(database.StartFullArchives(
+		t.Context(),
+		[]int64{oldRepo.ID},
+		now,
+	))
+
+	require.NoError(service.EnsureConfigured(
+		t.Context(),
+		[]platform.RepoRef{newRef},
+	))
+	newRepo, err := database.GetRepoByIdentity(
+		t.Context(),
+		platform.DBRepoIdentity(newRef),
+	)
+	require.NoError(err)
+	require.NotNil(newRepo)
+	assert.NotEqual(oldRepo.ID, newRepo.ID)
+	assert.Equal("repo-new", newRepo.PlatformRepoID)
+
+	states, err := database.ListArchiveRepoStates(
+		t.Context(),
+		[]int64{oldRepo.ID, newRepo.ID},
+	)
+	require.NoError(err)
+	require.Len(states, 2)
+	assert.Equal(oldRepo.ID, states[0].RepoID)
+	assert.Equal(db.ArchiveCollectionModeFull, states[0].CollectionMode)
+	assert.Equal(db.ArchiveOperatorStatePaused, states[0].OperatorState)
+	assert.Equal(newRepo.ID, states[1].RepoID)
+	assert.Equal(db.ArchiveCollectionModeDiscovery, states[1].CollectionMode)
+	assert.Equal(db.ArchiveOperatorStateActive, states[1].OperatorState)
+	assert.Nil(states[1].InitialStartedAt)
+	assert.Nil(states[1].InitialCompletedAt)
+	assert.Equal(db.ArchiveCoverageUnknown, states[1].IssuesCoverage)
+	assert.Equal(db.ArchiveCoverageUnknown, states[1].MergeRequestsCoverage)
+
+	statuses, err := service.Status(t.Context(), nil)
+	require.NoError(err)
+	require.Len(statuses, 1)
+	assert.Equal(newRepo.ID, statuses[0].RepoID)
 }
 
 func TestArchiveServiceAllScopeAndWakeLifecycle(t *testing.T) {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"sync"
+	"sync/atomic"
 
 	"go.kenn.io/forge/internal/db/dbupgrade"
 	_ "modernc.org/sqlite"
@@ -30,6 +31,13 @@ type mergeRequestSnapshotLockKey struct {
 type mergeRequestSnapshotLock struct {
 	token chan struct{}
 	refs  int
+}
+
+type repositoryReconciliationReadLeaseContextKey struct{}
+
+type repositoryReconciliationReadLease struct {
+	db     *DB
+	active atomic.Bool
 }
 
 // Open opens (or creates) a SQLite database at path, enables WAL mode, and
@@ -108,21 +116,48 @@ func (d *DB) WriteDB() *sql.DB { return d.rw }
 func (d *DB) LockRepositoryReconciliationRead(
 	ctx context.Context,
 ) (func(), error) {
+	_, release, err := d.LeaseRepositoryReconciliationRead(ctx)
+	return release, err
+}
+
+// LeaseRepositoryReconciliationRead returns a context that identifies the
+// active lease to nested repository-aware helpers. A nested acquisition on the
+// same DB becomes a no-op, avoiding RWMutex read recursion when a writer has
+// already closed admission to new readers.
+func (d *DB) LeaseRepositoryReconciliationRead(
+	ctx context.Context,
+) (context.Context, func(), error) {
 	if err := ctx.Err(); err != nil {
-		return nil, err
+		return nil, nil, err
+	}
+	if existing, ok := ctx.Value(
+		repositoryReconciliationReadLeaseContextKey{},
+	).(*repositoryReconciliationReadLease); ok &&
+		existing.db == d && existing.active.Load() {
+		return ctx, func() {}, nil
 	}
 	d.mrReconcileGate.Lock()
 	d.mrReconcileMu.RLock()
 	d.mrReconcileGate.Unlock()
 	if err := ctx.Err(); err != nil {
 		d.mrReconcileMu.RUnlock()
-		return nil, err
+		return nil, nil, err
 	}
 
+	lease := &repositoryReconciliationReadLease{db: d}
+	lease.active.Store(true)
 	var once sync.Once
-	return func() {
-		once.Do(d.mrReconcileMu.RUnlock)
-	}, nil
+	release := func() {
+		once.Do(func() {
+			lease.active.Store(false)
+			d.mrReconcileMu.RUnlock()
+		})
+	}
+	return context.WithValue(
+		ctx,
+		repositoryReconciliationReadLeaseContextKey{},
+		lease,
+	), release, nil
 }
 
 func (d *DB) lockRepositoryReconciliationWrite() func() {

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -666,10 +666,151 @@ func TestOpenMigratesRateLimitsToPrincipals(t *testing.T) {
 	require.NoError(err)
 	require.Zero(watermarkRows,
 		"host-wide watermarks cannot be attributed to repositories and are dropped")
+	repoID, err := database.UpsertRepoByProviderID(t.Context(), RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repo-widget",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	require.NoError(err)
 	require.NoError(database.UpdateNotificationSyncWatermark(
-		t.Context(), "github", "github.com", "acme", "widget",
-		time.Now().UTC(), nil,
+		t.Context(), repoID, time.Now().UTC(), nil,
 	))
+
+	var integrity string
+	require.NoError(database.ReadDB().QueryRow(`PRAGMA integrity_check`).Scan(&integrity))
+	require.Equal("ok", integrity)
+	rows, err := database.ReadDB().Query(`PRAGMA foreign_key_check`)
+	require.NoError(err)
+	defer rows.Close()
+	require.False(rows.Next())
+}
+
+func TestOpenMigratesRepositoryOwnedStateToIncarnationIDs(t *testing.T) {
+	require := require.New(t)
+	path := filepath.Join(t.TempDir(), "repository-incarnation-v43.db")
+	openAtVersionForTest(t, path, 43, func(raw *sql.DB) {
+		_, err := raw.Exec(`
+			INSERT INTO middleman_repos (
+				id, platform, platform_host, platform_repo_id,
+				owner, name, repo_path, owner_key, name_key, repo_path_key
+			) VALUES (
+				1, 'github', 'github.com', 'repository-1',
+				'acme', 'widget', 'acme/widget',
+				'acme', 'widget', 'acme/widget'
+			)`)
+		require.NoError(err)
+		_, err = raw.Exec(`
+			INSERT INTO middleman_workspaces (
+				id, platform, platform_host, repo_owner, repo_name,
+				repo_owner_key, repo_name_key, repo_path_key,
+				item_type, item_number, item_key, git_head_ref,
+				worktree_path, tmux_session, status
+			) VALUES (
+				'workspace-1', 'github', 'github.com', 'acme', 'widget',
+				'acme', 'widget', 'acme/widget',
+				'pull_request', 7, '7', 'feature/example',
+				'/tmp/workspace-1', 'workspace-1', 'ready'
+			)`)
+		require.NoError(err)
+		_, err = raw.Exec(`
+			INSERT INTO middleman_notification_items (
+				platform, platform_host, platform_notification_id,
+				repo_owner, repo_name, subject_type, subject_title,
+				item_type, reason, source_updated_at, synced_at
+			) VALUES (
+				'github', 'github.com', 'notification-1',
+				'acme', 'widget', 'PullRequest', 'Review requested',
+				'pr', 'review_requested',
+				'2026-07-30T10:00:00Z', '2026-07-30T10:00:00Z'
+			)`)
+		require.NoError(err)
+		_, err = raw.Exec(`
+			INSERT INTO middleman_notification_items (
+				platform, platform_host, platform_notification_id,
+				repo_owner, repo_name, subject_type, subject_title,
+				item_type, reason, source_updated_at, synced_at
+			) VALUES (
+				'github', 'github.com', 'notification-unscoped',
+				'acme', 'unconfigured', 'Issue', 'Unconfigured repository',
+				'issue', 'subscribed',
+				'2026-07-30T10:00:00Z', '2026-07-30T10:00:00Z'
+			)`)
+		require.NoError(err)
+		_, err = raw.Exec(`
+			INSERT INTO middleman_http_etags (
+				platform, platform_host, owner_key, name_key,
+				resource_type, resource_number, etag
+			) VALUES (
+				'github', 'github.com', 'acme', 'widget',
+				'pull_request', 7, '"etag-v1"'
+			)`)
+		require.NoError(err)
+		_, err = raw.Exec(`
+			INSERT INTO middleman_notification_sync_watermarks (
+				platform, platform_host, repo_owner, repo_name,
+				last_successful_sync_at
+			) VALUES (
+				'github', 'github.com', 'acme', 'widget',
+				'2026-07-30T10:00:00Z'
+			)`)
+		require.NoError(err)
+	})
+
+	database, err := Open(path)
+	require.NoError(err)
+	t.Cleanup(func() { require.NoError(database.Close()) })
+
+	var workspaceRepoID int64
+	var workspacePath, legacyCloneOwner, legacyCloneName string
+	require.NoError(database.ReadDB().QueryRow(`
+		SELECT repo_id, worktree_path,
+		       legacy_clone_owner, legacy_clone_name
+		FROM forge_workspaces
+		WHERE id = 'workspace-1'
+	`).Scan(
+		&workspaceRepoID,
+		&workspacePath,
+		&legacyCloneOwner,
+		&legacyCloneName,
+	))
+	require.Equal(int64(1), workspaceRepoID)
+	require.Equal("/tmp/workspace-1", workspacePath)
+	require.Equal("acme", legacyCloneOwner)
+	require.Equal("widget", legacyCloneName)
+	workspace, err := database.GetWorkspace(t.Context(), "workspace-1")
+	require.NoError(err)
+	require.NotNil(workspace)
+	require.Equal("acme", workspace.LegacyCloneOwner)
+	require.Equal("widget", workspace.LegacyCloneName)
+
+	var notificationRepoID int64
+	require.NoError(database.ReadDB().QueryRow(`
+		SELECT repo_id
+		FROM forge_notification_items
+		WHERE platform_notification_id = 'notification-1'
+	`).Scan(&notificationRepoID))
+	require.Equal(int64(1), notificationRepoID)
+
+	var unscopedRepoID sql.NullInt64
+	require.NoError(database.ReadDB().QueryRow(`
+		SELECT repo_id
+		FROM forge_notification_items
+		WHERE platform_notification_id = 'notification-unscoped'
+	`).Scan(&unscopedRepoID))
+	require.False(unscopedRepoID.Valid)
+
+	for _, table := range []string{
+		"forge_http_etags",
+		"forge_notification_sync_watermarks",
+	} {
+		var count int
+		require.NoError(database.ReadDB().QueryRow(
+			"SELECT COUNT(*) FROM " + table,
+		).Scan(&count))
+		require.Zero(count)
+	}
 
 	var integrity string
 	require.NoError(database.ReadDB().QueryRow(`PRAGMA integrity_check`).Scan(&integrity))

--- a/internal/db/migrations/000045_repository_incarnations.down.sql
+++ b/internal/db/migrations/000045_repository_incarnations.down.sql
@@ -1,0 +1,72 @@
+DROP TABLE forge_notification_sync_watermarks;
+
+CREATE TABLE forge_notification_sync_watermarks (
+    platform TEXT NOT NULL,
+    platform_host TEXT NOT NULL,
+    repo_owner TEXT NOT NULL,
+    repo_name TEXT NOT NULL,
+    last_successful_sync_at TEXT NOT NULL,
+    last_full_sync_at TEXT,
+    PRIMARY KEY (platform, platform_host, repo_owner, repo_name)
+);
+
+DROP TABLE forge_http_etags;
+
+CREATE TABLE forge_http_etags (
+    platform TEXT NOT NULL,
+    platform_host TEXT NOT NULL,
+    owner_key TEXT NOT NULL,
+    name_key TEXT NOT NULL,
+    resource_type TEXT NOT NULL,
+    resource_number INTEGER NOT NULL,
+    etag TEXT NOT NULL,
+    fetched_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (
+        platform,
+        platform_host,
+        owner_key,
+        name_key,
+        resource_type,
+        resource_number
+    )
+);
+
+DROP TABLE forge_repository_config_routes;
+
+DELETE FROM forge_workspaces
+WHERE repo_id IN (
+    SELECT id
+    FROM forge_repos
+    WHERE retired_at IS NOT NULL
+);
+
+DELETE FROM forge_repos
+WHERE retired_at IS NOT NULL;
+
+DROP INDEX idx_workspaces_external_item_key;
+DROP INDEX idx_workspaces_repository_item_key;
+
+CREATE UNIQUE INDEX idx_workspaces_provider_item_key
+    ON forge_workspaces(
+        platform,
+        platform_host,
+        repo_path_key,
+        item_type,
+        item_key
+    );
+
+ALTER TABLE forge_workspaces DROP COLUMN repo_id;
+ALTER TABLE forge_workspaces DROP COLUMN legacy_clone_name;
+ALTER TABLE forge_workspaces DROP COLUMN legacy_clone_owner;
+
+DROP INDEX idx_repos_retired_replacement;
+DROP INDEX idx_repos_provider_path_key;
+
+CREATE UNIQUE INDEX idx_repos_provider_path_key
+    ON forge_repos(platform, platform_host, repo_path_key)
+    WHERE repo_path_key <> '';
+
+ALTER TABLE forge_repos DROP COLUMN retired_name;
+ALTER TABLE forge_repos DROP COLUMN retired_owner;
+ALTER TABLE forge_repos DROP COLUMN retired_replacement_id;
+ALTER TABLE forge_repos DROP COLUMN retired_at;

--- a/internal/db/migrations/000045_repository_incarnations.up.sql
+++ b/internal/db/migrations/000045_repository_incarnations.up.sql
@@ -1,0 +1,122 @@
+ALTER TABLE forge_repos
+    ADD COLUMN retired_at DATETIME;
+
+ALTER TABLE forge_repos
+    ADD COLUMN retired_replacement_id INTEGER
+        REFERENCES forge_repos(id);
+
+ALTER TABLE forge_repos
+    ADD COLUMN retired_owner TEXT;
+
+ALTER TABLE forge_repos
+    ADD COLUMN retired_name TEXT;
+
+DROP INDEX idx_repos_provider_path_key;
+
+CREATE UNIQUE INDEX idx_repos_provider_path_key
+    ON forge_repos(platform, platform_host, repo_path_key)
+    WHERE repo_path_key <> '' AND retired_at IS NULL;
+
+CREATE INDEX idx_repos_retired_replacement
+    ON forge_repos(retired_replacement_id)
+    WHERE retired_replacement_id IS NOT NULL;
+
+-- Exact configuration routes remain stable when the provider reports a
+-- renamed display path. Persist that binding so an offline restart can seed
+-- the same active repository incarnation without inventing a path-only row.
+CREATE TABLE forge_repository_config_routes (
+    repo_id INTEGER NOT NULL
+        REFERENCES forge_repos(id) ON DELETE CASCADE,
+    platform TEXT NOT NULL,
+    platform_host TEXT NOT NULL,
+    owner TEXT NOT NULL,
+    name TEXT NOT NULL,
+    repo_path TEXT NOT NULL,
+    repo_path_key TEXT NOT NULL,
+    PRIMARY KEY (platform, platform_host, repo_path_key)
+);
+
+CREATE INDEX idx_repository_config_routes_repo
+    ON forge_repository_config_routes(repo_id);
+
+ALTER TABLE forge_workspaces
+    ADD COLUMN repo_id INTEGER
+        REFERENCES forge_repos(id);
+
+-- Preserve the route used by pre-incarnation managed clones. Workspace route
+-- fields continue to follow repository renames, while these coordinates stay
+-- fixed so recovery can identify the existing route-keyed Git directory.
+ALTER TABLE forge_workspaces
+    ADD COLUMN legacy_clone_owner TEXT;
+
+ALTER TABLE forge_workspaces
+    ADD COLUMN legacy_clone_name TEXT;
+
+UPDATE forge_workspaces AS workspace
+SET repo_id = (
+    SELECT repo.id
+    FROM forge_repos AS repo
+    WHERE repo.platform = workspace.platform
+      AND repo.platform_host = workspace.platform_host
+      AND repo.repo_path_key = workspace.repo_path_key
+      AND repo.retired_at IS NULL
+);
+
+UPDATE forge_workspaces
+SET legacy_clone_owner = repo_owner,
+    legacy_clone_name = repo_name
+WHERE repo_id IS NOT NULL;
+
+DROP INDEX idx_workspaces_provider_item_key;
+
+CREATE UNIQUE INDEX idx_workspaces_repository_item_key
+    ON forge_workspaces(repo_id, item_type, item_key)
+    WHERE repo_id IS NOT NULL;
+
+CREATE UNIQUE INDEX idx_workspaces_external_item_key
+    ON forge_workspaces(
+        platform,
+        platform_host,
+        repo_path_key,
+        item_type,
+        item_key
+    )
+    WHERE repo_id IS NULL;
+
+-- Conditional-request state belongs to a repository incarnation, not to a
+-- mutable provider route. These rows are caches, so the clean migration is to
+-- discard them and let active repositories repopulate them.
+DROP TABLE forge_http_etags;
+
+CREATE TABLE forge_http_etags (
+    repo_id INTEGER NOT NULL
+        REFERENCES forge_repos(id) ON DELETE CASCADE,
+    resource_type TEXT NOT NULL,
+    resource_number INTEGER NOT NULL,
+    etag TEXT NOT NULL,
+    fetched_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (repo_id, resource_type, resource_number)
+);
+
+-- Notification progress is likewise incarnation-owned. Dropping prior
+-- path-keyed watermarks forces one full notification pass after migration.
+DROP TABLE forge_notification_sync_watermarks;
+
+CREATE TABLE forge_notification_sync_watermarks (
+    repo_id INTEGER PRIMARY KEY
+        REFERENCES forge_repos(id) ON DELETE CASCADE,
+    last_successful_sync_at TEXT NOT NULL,
+    last_full_sync_at TEXT
+);
+
+UPDATE forge_notification_items AS notification
+SET repo_id = (
+    SELECT repo.id
+    FROM forge_repos AS repo
+    WHERE repo.platform = notification.platform
+      AND repo.platform_host = notification.platform_host
+      AND repo.owner_key = lower(notification.repo_owner)
+      AND repo.name_key = lower(notification.repo_name)
+      AND repo.retired_at IS NULL
+)
+WHERE repo_id IS NULL;

--- a/internal/db/projecttest/project_test.go
+++ b/internal/db/projecttest/project_test.go
@@ -74,6 +74,42 @@ func TestCreateProjectLinkedToRepo(t *testing.T) {
 	assert.Equal("github.com", roundTrip.PlatformIdentity.Host)
 }
 
+func TestProjectLinkedToRetiredRepositoryHasNoPlatformIdentity(t *testing.T) {
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	oldRepoID, err := d.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repository-old",
+		Owner:          "acme",
+		Name:           "widget",
+		RepoPath:       "acme/widget",
+	})
+	require.NoError(err)
+	project, err := d.CreateProject(ctx, db.CreateProjectInput{
+		DisplayName: "widget",
+		LocalPath:   "/tmp/widget",
+		RepoID:      sql.NullInt64{Int64: oldRepoID, Valid: true},
+	})
+	require.NoError(err)
+	require.NotNil(project.PlatformIdentity)
+
+	_, err = d.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repository-replacement",
+		Owner:          "acme",
+		Name:           "widget",
+		RepoPath:       "acme/widget",
+	})
+	require.NoError(err)
+
+	after, err := d.GetProjectByID(ctx, project.ID)
+	require.NoError(err)
+	assert.Nil(t, after.PlatformIdentity)
+}
+
 func TestCreateProjectFKSetNullOnRepoDelete(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -822,13 +822,13 @@ func (d *DB) MarkRepoLabelCatalogSynced(ctx context.Context, repoID int64, synce
 }
 
 func (d *DB) ReplaceIssueLabels(ctx context.Context, repoID, issueID int64, labels []Label) error {
-	return d.Tx(ctx, func(tx *sql.Tx) error {
+	return d.withActiveRepositoryTx(ctx, repoID, func(tx *sql.Tx) error {
 		return replaceIssueLabelsTx(ctx, tx, repoID, issueID, labels)
 	})
 }
 
 func (d *DB) ReplaceMergeRequestLabels(ctx context.Context, repoID, mrID int64, labels []Label) error {
-	return d.Tx(ctx, func(tx *sql.Tx) error {
+	return d.withActiveRepositoryTx(ctx, repoID, func(tx *sql.Tx) error {
 		return replaceMergeRequestLabelsTx(ctx, tx, repoID, mrID, labels)
 	})
 }
@@ -917,6 +917,7 @@ func (d *DB) PurgeOtherHosts(ctx context.Context, keepHost string) error {
 	return d.Tx(ctx, func(tx *sql.Tx) error {
 		queries := []string{
 			`DELETE FROM forge_starred_items WHERE repo_id IN (SELECT id FROM forge_repos WHERE platform_host != ?)`,
+			`DELETE FROM forge_workspaces WHERE repo_id IN (SELECT id FROM forge_repos WHERE platform_host != ?)`,
 			`DELETE FROM forge_mr_worktree_links WHERE merge_request_id IN (SELECT id FROM forge_merge_requests WHERE repo_id IN (SELECT id FROM forge_repos WHERE platform_host != ?))`,
 			`DELETE FROM forge_item_workflow_state WHERE repo_id IN (SELECT id FROM forge_repos WHERE platform_host != ?)`,
 			`DELETE FROM forge_mr_events WHERE merge_request_id IN (SELECT id FROM forge_merge_requests WHERE repo_id IN (SELECT id FROM forge_repos WHERE platform_host != ?))`,
@@ -969,17 +970,7 @@ func upsertRepoIdentityTx(ctx context.Context, tx *sql.Tx, identity RepoIdentity
 		     owner, name, repo_path,
 		     owner_key, name_key, repo_path_key
 		 )
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-		 ON CONFLICT(platform, platform_host, owner, name) DO UPDATE SET
-		     repo_path = excluded.repo_path,
-		     owner_key = excluded.owner_key,
-		     name_key = excluded.name_key,
-		     repo_path_key = excluded.repo_path_key,
-		     platform_repo_id = CASE
-		         WHEN forge_repos.platform_repo_id = ''
-		         THEN excluded.platform_repo_id
-		         ELSE forge_repos.platform_repo_id
-		     END`,
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		identity.Platform, identity.PlatformHost, identity.PlatformRepoID,
 		identity.Owner, identity.Name, identity.RepoPath,
 		identity.OwnerKey, identity.NameKey, identity.RepoPathKey,
@@ -991,11 +982,15 @@ func upsertRepoIdentityTx(ctx context.Context, tx *sql.Tx, identity RepoIdentity
 	err = tx.QueryRowContext(ctx,
 		`SELECT id FROM forge_repos
 		 WHERE platform = ? AND platform_host = ?
-		   AND owner_key = ? AND name_key = ?`,
+		   AND owner_key = ? AND name_key = ?
+		   AND retired_at IS NULL`,
 		identity.Platform, identity.PlatformHost, identity.OwnerKey, identity.NameKey,
 	).Scan(&id)
 	if err != nil {
 		return 0, fmt.Errorf("get repo id after upsert: %w", err)
+	}
+	if err := adoptUnscopedNotificationsTx(ctx, tx, id, identity); err != nil {
+		return 0, err
 	}
 	return id, nil
 }
@@ -1031,23 +1026,33 @@ func (d *DB) UpsertRepoByProviderID(ctx context.Context, identity RepoIdentity) 
 			if err != nil {
 				return err
 			}
-			targetIdentity, err := lookupRepoIdentityByIDTx(ctx, tx, targetID)
-			if err != nil {
+			if err := retireRepoTx(ctx, tx, targetID); err != nil {
 				return err
 			}
-			if err := mergeRepoRowsTx(ctx, tx, sourceID, targetID); err != nil {
+			if err := updateRepoIdentityTx(ctx, tx, sourceID, identity); err != nil {
 				return err
 			}
-			if err := updateRepoIdentityTx(ctx, tx, targetID, identity); err != nil {
+			if err := activateRepoTx(ctx, tx, sourceID); err != nil {
 				return err
 			}
-			if err := updateWorkspaceRepoIdentityTx(ctx, tx, sourceIdentity, identity); err != nil {
+			if err := updateWorkspaceRepoIdentityTx(
+				ctx,
+				tx,
+				sourceID,
+				sourceIdentity,
+				identity,
+			); err != nil {
 				return err
 			}
-			if err := updateWorkspaceRepoIdentityTx(ctx, tx, targetIdentity, identity); err != nil {
+			if err := setRepoRetiredReplacementTx(
+				ctx,
+				tx,
+				targetID,
+				sourceID,
+			); err != nil {
 				return err
 			}
-			id = targetID
+			id = sourceID
 			return nil
 		}
 
@@ -1059,7 +1064,12 @@ func (d *DB) UpsertRepoByProviderID(ctx context.Context, identity RepoIdentity) 
 			if err := updateRepoIdentityTx(ctx, tx, sourceID, identity); err != nil {
 				return err
 			}
-			if err := updateWorkspaceRepoIdentityTx(ctx, tx, sourceIdentity, identity); err != nil {
+			if err := activateRepoTx(ctx, tx, sourceID); err != nil {
+				return err
+			}
+			if err := updateWorkspaceRepoIdentityTx(
+				ctx, tx, sourceID, sourceIdentity, identity,
+			); err != nil {
 				return err
 			}
 			id = sourceID
@@ -1071,10 +1081,34 @@ func (d *DB) UpsertRepoByProviderID(ctx context.Context, identity RepoIdentity) 
 			if err != nil {
 				return err
 			}
+			if conflictErr := repositoryIdentityConflict(
+				targetID,
+				targetIdentity,
+				identity,
+			); conflictErr != nil {
+				if err := retireRepoTx(ctx, tx, targetID); err != nil {
+					return err
+				}
+				id, err = upsertRepoIdentityTx(ctx, tx, identity)
+				if err != nil {
+					return err
+				}
+				if err := setRepoRetiredReplacementTx(
+					ctx,
+					tx,
+					targetID,
+					id,
+				); err != nil {
+					return err
+				}
+				return nil
+			}
 			if err := updateRepoIdentityTx(ctx, tx, targetID, identity); err != nil {
 				return err
 			}
-			if err := updateWorkspaceRepoIdentityTx(ctx, tx, targetIdentity, identity); err != nil {
+			if err := updateWorkspaceRepoIdentityTx(
+				ctx, tx, targetID, targetIdentity, identity,
+			); err != nil {
 				return err
 			}
 			id = targetID
@@ -1088,6 +1122,142 @@ func (d *DB) UpsertRepoByProviderID(ctx context.Context, identity RepoIdentity) 
 		return 0, err
 	}
 	return id, nil
+}
+
+func retireRepoTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	repoID int64,
+) error {
+	result, err := tx.ExecContext(ctx, `
+		UPDATE forge_repos
+		SET retired_at = CURRENT_TIMESTAMP,
+		    retired_replacement_id = NULL,
+		    retired_owner = owner,
+		    retired_name = name,
+		    owner = '',
+		    name = printf('__retired_repository_%d__', id),
+		    owner_key = '',
+		    name_key = lower(printf('__retired_repository_%d__', id))
+		WHERE id = ? AND retired_at IS NULL`,
+		repoID,
+	)
+	if err != nil {
+		return fmt.Errorf("retire repository incarnation: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("read retired repository result: %w", err)
+	}
+	if affected != 1 {
+		return fmt.Errorf("retire repository incarnation %d: active row not found", repoID)
+	}
+	return nil
+}
+
+func activateRepoTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	repoID int64,
+) error {
+	_, err := tx.ExecContext(ctx, `
+		UPDATE forge_repos
+		SET retired_at = NULL,
+		    retired_replacement_id = NULL,
+		    retired_owner = NULL,
+		    retired_name = NULL
+		WHERE id = ?`,
+		repoID,
+	)
+	if err != nil {
+		return fmt.Errorf("activate repository incarnation: %w", err)
+	}
+	return nil
+}
+
+func setRepoRetiredReplacementTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	retiredRepoID int64,
+	replacementRepoID int64,
+) error {
+	_, err := tx.ExecContext(ctx, `
+		UPDATE forge_repos
+		SET retired_replacement_id = ?
+		WHERE id = ? AND retired_at IS NOT NULL`,
+		replacementRepoID,
+		retiredRepoID,
+	)
+	if err != nil {
+		return fmt.Errorf("link retired repository replacement: %w", err)
+	}
+	return nil
+}
+
+func requireActiveRepoTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	repoID int64,
+	expectedProviderID string,
+) error {
+	var storedProviderID string
+	var retiredAt sql.NullTime
+	err := tx.QueryRowContext(ctx, `
+		SELECT platform_repo_id, retired_at
+		FROM forge_repos
+		WHERE id = ?`,
+		repoID,
+	).Scan(&storedProviderID, &retiredAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("repository incarnation %d not found", repoID)
+	}
+	if err != nil {
+		return fmt.Errorf("load repository incarnation %d: %w", repoID, err)
+	}
+	if retiredAt.Valid {
+		return fmt.Errorf("%w: repository %d", ErrRepositoryRetired, repoID)
+	}
+	if expectedProviderID != "" &&
+		storedProviderID != "" &&
+		storedProviderID != expectedProviderID {
+		return fmt.Errorf(
+			"repository incarnation %d provider id is %q, not %q",
+			repoID,
+			storedProviderID,
+			expectedProviderID,
+		)
+	}
+	return nil
+}
+
+func (d *DB) withActiveRepositoryTx(
+	ctx context.Context,
+	repoID int64,
+	write func(*sql.Tx) error,
+) error {
+	return d.Tx(ctx, func(tx *sql.Tx) error {
+		if err := requireActiveRepoTx(ctx, tx, repoID, ""); err != nil {
+			return err
+		}
+		return write(tx)
+	})
+}
+
+func repositoryIdentityConflict(
+	repoID int64,
+	existing RepoIdentity,
+	incoming RepoIdentity,
+) error {
+	if incoming.PlatformRepoID == "" ||
+		existing.PlatformRepoID == "" ||
+		existing.PlatformRepoID == incoming.PlatformRepoID {
+		return nil
+	}
+	return &RepoIdentityConflictError{
+		ExistingRepoID: repoID,
+		Existing:       existing,
+		Incoming:       incoming,
+	}
 }
 
 func lookupRepoIDByProviderIDTx(
@@ -1125,7 +1295,8 @@ func lookupRepoIDByIdentityTx(
 		 WHERE platform = ?
 		   AND platform_host = ?
 		   AND owner_key = ?
-		   AND name_key = ?`,
+		   AND name_key = ?
+		   AND retired_at IS NULL`,
 		identity.Platform, identity.PlatformHost, identity.OwnerKey, identity.NameKey,
 	).Scan(&id)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -1145,7 +1316,9 @@ func lookupRepoIdentityByIDTx(
 	var identity RepoIdentity
 	err := tx.QueryRowContext(ctx,
 		`SELECT platform, platform_host, platform_repo_id,
-		        owner, name, repo_path,
+		        COALESCE(retired_owner, owner),
+		        COALESCE(retired_name, name),
+		        repo_path,
 		        owner_key, name_key, repo_path_key
 		 FROM forge_repos
 		 WHERE id = ?`,
@@ -1168,6 +1341,14 @@ func updateRepoIdentityTx(
 	identity RepoIdentity,
 ) error {
 	identity = canonicalRepoIdentity(identity)
+	if err := validateRepoProviderIDWriteTx(
+		ctx,
+		tx,
+		repoID,
+		identity.PlatformRepoID,
+	); err != nil {
+		return err
+	}
 	if _, err := tx.ExecContext(ctx, `
 		UPDATE forge_merge_requests
 		SET head_repo_identity_stale = 1,
@@ -1218,12 +1399,67 @@ func updateRepoIdentityTx(
 	if err != nil {
 		return fmt.Errorf("update repo identity: %w", err)
 	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE forge_notification_items
+		SET repo_owner = ?, repo_name = ?
+		WHERE repo_id = ?`,
+		identity.OwnerKey,
+		identity.NameKey,
+		repoID,
+	); err != nil {
+		return fmt.Errorf("update renamed repository notification route: %w", err)
+	}
+	return adoptUnscopedNotificationsTx(ctx, tx, repoID, identity)
+}
+
+func adoptUnscopedNotificationsTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	repoID int64,
+	identity RepoIdentity,
+) error {
+	identity = canonicalRepoIdentity(identity)
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE forge_notification_items
+		SET repo_id = ?
+		WHERE repo_id IS NULL
+		  AND platform = ?
+		  AND platform_host = ?
+		  AND repo_owner = ?
+		  AND repo_name = ?`,
+		repoID,
+		identity.Platform,
+		identity.PlatformHost,
+		identity.OwnerKey,
+		identity.NameKey,
+	); err != nil {
+		return fmt.Errorf("associate notifications with repository incarnation: %w", err)
+	}
 	return nil
+}
+
+func validateRepoProviderIDWriteTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	repoID int64,
+	incomingProviderID string,
+) error {
+	if incomingProviderID == "" {
+		return nil
+	}
+	existing, err := lookupRepoIdentityByIDTx(ctx, tx, repoID)
+	if err != nil {
+		return err
+	}
+	incoming := existing
+	incoming.PlatformRepoID = incomingProviderID
+	return repositoryIdentityConflict(repoID, existing, incoming)
 }
 
 func updateWorkspaceRepoIdentityTx(
 	ctx context.Context,
 	tx *sql.Tx,
+	repoID int64,
 	from, to RepoIdentity,
 ) error {
 	from = canonicalRepoIdentity(from)
@@ -1237,10 +1473,6 @@ func updateWorkspaceRepoIdentityTx(
 		return nil
 	}
 
-	if err := mergeWorkspaceRowsForIdentityChangeTx(ctx, tx, from, to); err != nil {
-		return err
-	}
-
 	_, err := tx.ExecContext(ctx,
 		`UPDATE forge_workspaces
 		 SET platform_host = ?,
@@ -1249,982 +1481,17 @@ func updateWorkspaceRepoIdentityTx(
 		     repo_owner_key = ?,
 		     repo_name_key = ?,
 		     repo_path_key = ?
-		 WHERE platform_host = ?
-		   AND repo_path_key = ?`,
+		 WHERE repo_id = ?`,
 		to.PlatformHost,
 		to.Owner,
 		to.Name,
 		to.OwnerKey,
 		to.NameKey,
 		to.RepoPathKey,
-		from.PlatformHost,
-		from.RepoPathKey,
+		repoID,
 	)
 	if err != nil {
 		return fmt.Errorf("update workspace repo identity: %w", err)
-	}
-	return nil
-}
-
-func mergeWorkspaceRowsForIdentityChangeTx(
-	ctx context.Context,
-	tx *sql.Tx,
-	from, to RepoIdentity,
-) error {
-	rows, err := tx.QueryContext(ctx,
-		`SELECT source.id, target.id
-		 FROM forge_workspaces AS source
-		 JOIN forge_workspaces AS target
-		   ON target.platform_host = ?
-		  AND target.repo_path_key = ?
-		  AND target.item_type = source.item_type
-		  AND target.item_key = source.item_key
-		 WHERE source.platform_host = ?
-		   AND source.repo_path_key = ?
-		   AND source.id <> target.id`,
-		to.PlatformHost,
-		to.RepoPathKey,
-		from.PlatformHost,
-		from.RepoPathKey,
-	)
-	if err != nil {
-		return fmt.Errorf("list workspace identity merge targets: %w", err)
-	}
-
-	type workspaceMerge struct {
-		sourceID string
-		targetID string
-	}
-	var merges []workspaceMerge
-	for rows.Next() {
-		var merge workspaceMerge
-		if err := rows.Scan(&merge.sourceID, &merge.targetID); err != nil {
-			_ = rows.Close()
-			return fmt.Errorf("scan workspace identity merge target: %w", err)
-		}
-		merges = append(merges, merge)
-	}
-	if err := rows.Close(); err != nil {
-		return fmt.Errorf("close workspace identity merge targets: %w", err)
-	}
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("iterate workspace identity merge targets: %w", err)
-	}
-
-	for _, merge := range merges {
-		if _, err := tx.ExecContext(ctx,
-			`UPDATE forge_workspace_setup_events
-			 SET workspace_id = ?
-			 WHERE workspace_id = ?`,
-			merge.targetID,
-			merge.sourceID,
-		); err != nil {
-			return fmt.Errorf("move workspace setup events: %w", err)
-		}
-		if _, err := tx.ExecContext(ctx,
-			`UPDATE forge_workspace_runtime_sessions
-			 SET workspace_id = ?
-			 WHERE workspace_id = ?`,
-			merge.targetID,
-			merge.sourceID,
-		); err != nil {
-			return fmt.Errorf("move workspace runtime sessions: %w", err)
-		}
-		if _, err := tx.ExecContext(ctx,
-			`DELETE FROM forge_workspaces
-			 WHERE id = ?`,
-			merge.sourceID,
-		); err != nil {
-			return fmt.Errorf("delete merged workspace row: %w", err)
-		}
-	}
-
-	return nil
-}
-
-func mergeRepoLabelNameConflictsTx(ctx context.Context, tx *sql.Tx, fromRepoID, toRepoID int64) error {
-	rows, err := tx.QueryContext(ctx, `
-		SELECT conflict.id, target.id
-		FROM forge_labels AS source
-		JOIN forge_labels AS target
-		  ON target.repo_id = ?
-		 AND (
-		     source.platform_id IS NOT NULL
-		     AND target.platform_id IS NOT NULL
-		     AND source.platform_id = target.platform_id
-		     OR (
-		         source.platform_external_id <> ''
-		         AND target.platform_external_id <> ''
-		         AND source.platform_external_id = target.platform_external_id
-		     )
-		 )
-		JOIN forge_labels AS conflict
-		  ON conflict.repo_id = ?
-		 AND conflict.name = source.name
-		 AND conflict.id <> target.id
-		WHERE source.repo_id = ?
-		  AND source.catalog_present = 1`,
-		toRepoID, toRepoID, fromRepoID,
-	)
-	if err != nil {
-		return fmt.Errorf("list label name conflicts: %w", err)
-	}
-	defer rows.Close()
-
-	type mergePair struct {
-		fromID int64
-		toID   int64
-	}
-	pairs := []mergePair{}
-	for rows.Next() {
-		var pair mergePair
-		if err := rows.Scan(&pair.fromID, &pair.toID); err != nil {
-			return fmt.Errorf("scan label name conflict: %w", err)
-		}
-		pairs = append(pairs, pair)
-	}
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("iterate label name conflicts: %w", err)
-	}
-	for _, pair := range pairs {
-		if err := mergeLabelRowAssociationsTx(ctx, tx, pair.fromID, pair.toID); err != nil {
-			return fmt.Errorf("merge destination label name conflict: %w", err)
-		}
-	}
-	return nil
-}
-
-func mergeRepoMergeRequestDraftsTx(
-	ctx context.Context,
-	tx *sql.Tx,
-	sourceMRID, targetMRID int64,
-) error {
-	var sourceDraftID int64
-	var sourceUpdatedAt string
-	err := tx.QueryRowContext(ctx, `
-		SELECT id, updated_at
-		FROM forge_mr_review_drafts
-		WHERE merge_request_id = ?`,
-		sourceMRID,
-	).Scan(&sourceDraftID, &sourceUpdatedAt)
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("look up source review draft: %w", err)
-	}
-
-	var targetDraftID int64
-	var targetUpdatedAt string
-	err = tx.QueryRowContext(ctx, `
-		SELECT id, updated_at
-		FROM forge_mr_review_drafts
-		WHERE merge_request_id = ?`,
-		targetMRID,
-	).Scan(&targetDraftID, &targetUpdatedAt)
-	if errors.Is(err, sql.ErrNoRows) {
-		if _, err := tx.ExecContext(ctx, `
-			UPDATE forge_mr_review_drafts
-			SET merge_request_id = ?
-			WHERE id = ?`,
-			targetMRID, sourceDraftID,
-		); err != nil {
-			return fmt.Errorf("move source review draft: %w", err)
-		}
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("look up target review draft: %w", err)
-	}
-
-	if _, err := tx.ExecContext(ctx, `
-		UPDATE forge_mr_review_draft_comments
-		SET draft_id = ?
-		WHERE draft_id = ?`,
-		targetDraftID, sourceDraftID,
-	); err != nil {
-		return fmt.Errorf("merge source review draft comments: %w", err)
-	}
-	if sourceUpdatedAt > targetUpdatedAt {
-		if _, err := tx.ExecContext(ctx, `
-			UPDATE forge_mr_review_drafts
-			SET body = source.body,
-			    action = source.action,
-			    updated_at = source.updated_at
-			FROM forge_mr_review_drafts AS source
-			WHERE forge_mr_review_drafts.id = ?
-			  AND source.id = ?`,
-			targetDraftID, sourceDraftID,
-		); err != nil {
-			return fmt.Errorf("copy newer source review draft: %w", err)
-		}
-	}
-	if _, err := tx.ExecContext(ctx,
-		`DELETE FROM forge_mr_review_drafts WHERE id = ?`,
-		sourceDraftID,
-	); err != nil {
-		return fmt.Errorf("delete merged source review draft: %w", err)
-	}
-	return nil
-}
-
-func mergeRepoMergeRequestChildrenTx(
-	ctx context.Context,
-	tx *sql.Tx,
-	sourceMRID, targetMRID int64,
-) error {
-	if err := mergeRepoMergeRequestDraftsTx(
-		ctx, tx, sourceMRID, targetMRID,
-	); err != nil {
-		return err
-	}
-
-	steps := []struct {
-		name string
-		sql  string
-		args []any
-	}{
-		{
-			name: "merge merge request labels",
-			sql: `INSERT OR IGNORE INTO forge_merge_request_labels (
-			          merge_request_id, label_id
-			      )
-			      SELECT ?, label_id
-			      FROM forge_merge_request_labels
-			      WHERE merge_request_id = ?`,
-			args: []any{targetMRID, sourceMRID},
-		},
-		{
-			name: "drop duplicate source merge request events",
-			sql: `DELETE FROM forge_mr_events AS source
-			      WHERE source.merge_request_id = ?
-			        AND EXISTS (
-			            SELECT 1
-			            FROM forge_mr_events AS target
-			            WHERE target.merge_request_id = ?
-			              AND (
-			                  target.dedupe_key = source.dedupe_key
-			                  OR (
-			                      source.platform_external_id <> ''
-			                      AND target.event_type = source.event_type
-			                      AND target.platform_external_id = source.platform_external_id
-			                  )
-			              )
-			        )`,
-			args: []any{sourceMRID, targetMRID},
-		},
-		{
-			name: "move merge request events",
-			sql:  `UPDATE forge_mr_events SET merge_request_id = ? WHERE merge_request_id = ?`,
-			args: []any{targetMRID, sourceMRID},
-		},
-		{
-			name: "move merge request worktree links",
-			sql:  `UPDATE forge_mr_worktree_links SET merge_request_id = ? WHERE merge_request_id = ?`,
-			args: []any{targetMRID, sourceMRID},
-		},
-		{
-			name: "drop source stack membership when target is already stacked",
-			sql: `DELETE FROM forge_stack_members
-			      WHERE merge_request_id = ?
-			        AND EXISTS (
-			            SELECT 1
-			            FROM forge_stack_members
-			            WHERE merge_request_id = ?
-			        )`,
-			args: []any{sourceMRID, targetMRID},
-		},
-		{
-			name: "move merge request stack membership",
-			sql:  `UPDATE forge_stack_members SET merge_request_id = ? WHERE merge_request_id = ?`,
-			args: []any{targetMRID, sourceMRID},
-		},
-		{
-			name: "copy newer duplicate review threads",
-			sql: `UPDATE forge_mr_review_threads AS target
-			      SET provider_review_id = source.provider_review_id,
-			          provider_comment_id = source.provider_comment_id,
-			          path = source.path,
-			          old_path = source.old_path,
-			          side = source.side,
-			          start_side = source.start_side,
-			          start_line = source.start_line,
-			          line = source.line,
-			          old_line = source.old_line,
-			          new_line = source.new_line,
-			          line_type = source.line_type,
-			          diff_head_sha = source.diff_head_sha,
-			          commit_sha = source.commit_sha,
-			          body = source.body,
-			          author_login = source.author_login,
-			          resolved = source.resolved,
-			          created_at = source.created_at,
-			          updated_at = source.updated_at,
-			          resolved_at = source.resolved_at,
-			          metadata_json = source.metadata_json
-			      FROM forge_mr_review_threads AS source
-			      WHERE target.merge_request_id = ?
-			        AND source.merge_request_id = ?
-			        AND target.provider_thread_id = source.provider_thread_id
-			        AND source.updated_at >= target.updated_at`,
-			args: []any{targetMRID, sourceMRID},
-		},
-		{
-			name: "drop duplicate source review threads",
-			sql: `DELETE FROM forge_mr_review_threads AS source
-			      WHERE source.merge_request_id = ?
-			        AND EXISTS (
-			            SELECT 1
-			            FROM forge_mr_review_threads AS target
-			            WHERE target.merge_request_id = ?
-			              AND target.provider_thread_id = source.provider_thread_id
-			        )`,
-			args: []any{sourceMRID, targetMRID},
-		},
-		{
-			name: "move merge request review threads",
-			sql:  `UPDATE forge_mr_review_threads SET merge_request_id = ? WHERE merge_request_id = ?`,
-			args: []any{targetMRID, sourceMRID},
-		},
-	}
-	for _, step := range steps {
-		if _, err := tx.ExecContext(ctx, step.sql, step.args...); err != nil {
-			return fmt.Errorf("%s: %w", step.name, err)
-		}
-	}
-	return nil
-}
-
-func copyMergeRequestSnapshotTx(
-	ctx context.Context,
-	tx *sql.Tx,
-	sourceMRID, targetMRID int64,
-) error {
-	_, err := tx.ExecContext(ctx, `
-		UPDATE forge_merge_requests AS target
-		SET (
-		    platform_id, platform_external_id, number, url, title, author,
-		    author_display_name, state, is_draft, is_locked, body,
-		    head_branch, base_branch, additions, deletions, files_changed,
-		    merge_commit_sha, comment_count,
-		    review_decision, ci_status, ci_checks_json, platform_head_sha,
-		    platform_base_sha, diff_head_sha, diff_base_sha, merge_base_sha,
-		    head_repo_clone_url, mergeable_state, created_at, updated_at,
-		    last_activity_at, merged_at, closed_at, detail_fetched_at,
-		    ci_had_pending, workflow_approval_checked_at,
-		    workflow_approval_head_sha, workflow_approval_required,
-		    workflow_approval_count, assignees_json, reviewers_json,
-		    head_repo_identity_stale, snapshot_revision
-		) = (
-		    SELECT
-		        platform_id, platform_external_id, number, url, title, author,
-		        author_display_name, state, is_draft, is_locked, body,
-		        head_branch, base_branch, additions, deletions, files_changed,
-		        merge_commit_sha, comment_count,
-		        review_decision, ci_status, ci_checks_json, platform_head_sha,
-		        platform_base_sha, diff_head_sha, diff_base_sha, merge_base_sha,
-		        head_repo_clone_url, mergeable_state, created_at, updated_at,
-		        last_activity_at, merged_at, closed_at, detail_fetched_at,
-		        ci_had_pending, workflow_approval_checked_at,
-		        workflow_approval_head_sha, workflow_approval_required,
-		        workflow_approval_count, assignees_json, reviewers_json,
-		        1, MAX(source.snapshot_revision, target.snapshot_revision) + 1
-		    FROM forge_merge_requests AS source
-		    WHERE source.id = ?
-		)
-		WHERE target.id = ?`,
-		sourceMRID, targetMRID,
-	)
-	if err != nil {
-		return fmt.Errorf("copy winning merge request snapshot: %w", err)
-	}
-	return nil
-}
-
-func mergeRepoMergeRequestCollisionsTx(
-	ctx context.Context,
-	tx *sql.Tx,
-	fromRepoID, toRepoID int64,
-) error {
-	rows, err := tx.QueryContext(ctx, `
-		SELECT source.id, target.id, source.updated_at >= target.updated_at
-		FROM forge_merge_requests AS source
-		JOIN forge_merge_requests AS target
-		  ON target.repo_id = ?
-		 AND (
-		     target.number = source.number
-		     OR target.platform_id = source.platform_id
-		 )
-		WHERE source.repo_id = ?
-		ORDER BY source.id, target.id`,
-		toRepoID, fromRepoID,
-	)
-	if err != nil {
-		return fmt.Errorf("list merge request reconciliation collisions: %w", err)
-	}
-	type collision struct {
-		sourceID   int64
-		targetID   int64
-		sourceWins bool
-	}
-	var collisions []collision
-	sourceTargets := make(map[int64]int64)
-	targetSources := make(map[int64]int64)
-	for rows.Next() {
-		var c collision
-		if err := rows.Scan(&c.sourceID, &c.targetID, &c.sourceWins); err != nil {
-			_ = rows.Close()
-			return fmt.Errorf("scan merge request reconciliation collision: %w", err)
-		}
-		if prior, ok := sourceTargets[c.sourceID]; ok && prior != c.targetID {
-			_ = rows.Close()
-			return fmt.Errorf(
-				"ambiguous merge request reconciliation: source %d matches targets %d and %d",
-				c.sourceID, prior, c.targetID,
-			)
-		}
-		if prior, ok := targetSources[c.targetID]; ok && prior != c.sourceID {
-			_ = rows.Close()
-			return fmt.Errorf(
-				"ambiguous merge request reconciliation: target %d matches sources %d and %d",
-				c.targetID, prior, c.sourceID,
-			)
-		}
-		sourceTargets[c.sourceID] = c.targetID
-		targetSources[c.targetID] = c.sourceID
-		collisions = append(collisions, c)
-	}
-	if err := rows.Close(); err != nil {
-		return fmt.Errorf("close merge request reconciliation collisions: %w", err)
-	}
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("iterate merge request reconciliation collisions: %w", err)
-	}
-
-	for _, c := range collisions {
-		if err := mergeRepoMergeRequestChildrenTx(
-			ctx, tx, c.sourceID, c.targetID,
-		); err != nil {
-			return err
-		}
-		if c.sourceWins {
-			if err := copyMergeRequestSnapshotTx(
-				ctx, tx, c.sourceID, c.targetID,
-			); err != nil {
-				return err
-			}
-		}
-		if _, err := tx.ExecContext(ctx,
-			`DELETE FROM forge_merge_requests WHERE id = ?`,
-			c.sourceID,
-		); err != nil {
-			return fmt.Errorf("delete merged source merge request: %w", err)
-		}
-	}
-	return nil
-}
-
-func mergeRepoRowsTx(ctx context.Context, tx *sql.Tx, fromRepoID, toRepoID int64) error {
-	if fromRepoID == toRepoID {
-		return nil
-	}
-	if err := mergeRepoMergeRequestCollisionsTx(
-		ctx, tx, fromRepoID, toRepoID,
-	); err != nil {
-		return err
-	}
-
-	steps := []struct {
-		name string
-		sql  string
-		args []any
-	}{
-		{
-			name: "clear stale source label catalog membership",
-			sql: `UPDATE forge_labels
-			      SET catalog_present = 0
-			      WHERE repo_id = ?
-			        AND COALESCE((SELECT label_catalog_synced_at FROM forge_repos WHERE id = ?), '') <=
-			            COALESCE((SELECT label_catalog_synced_at FROM forge_repos WHERE id = ?), '')`,
-			args: []any{fromRepoID, fromRepoID, toRepoID},
-		},
-		{
-			name: "clear stale destination label catalog membership",
-			sql: `UPDATE forge_labels
-			      SET catalog_present = 0
-			      WHERE repo_id = ?
-			        AND COALESCE((SELECT label_catalog_synced_at FROM forge_repos WHERE id = ?), '') >
-			            COALESCE((SELECT label_catalog_synced_at FROM forge_repos WHERE id = ?), '')`,
-			args: []any{toRepoID, fromRepoID, toRepoID},
-		},
-		{
-			name: "copy source repo metadata",
-			sql: `UPDATE forge_repos
-			      SET web_url = CASE
-			              WHEN web_url = ''
-			              THEN (SELECT web_url FROM forge_repos WHERE id = ?)
-			              ELSE web_url
-			          END,
-			          clone_url = CASE
-			              WHEN clone_url = ''
-			              THEN (SELECT clone_url FROM forge_repos WHERE id = ?)
-			              ELSE clone_url
-			          END,
-			          default_branch = CASE
-			              WHEN default_branch = ''
-			              THEN (SELECT default_branch FROM forge_repos WHERE id = ?)
-			              ELSE default_branch
-			          END,
-			          label_catalog_synced_at = CASE
-			              WHEN (SELECT label_catalog_synced_at FROM forge_repos WHERE id = ?) > COALESCE(label_catalog_synced_at, '')
-			              THEN (SELECT label_catalog_synced_at FROM forge_repos WHERE id = ?)
-			              ELSE label_catalog_synced_at
-			          END,
-			          label_catalog_checked_at = CASE
-			              WHEN (SELECT label_catalog_checked_at FROM forge_repos WHERE id = ?) > COALESCE(label_catalog_checked_at, '')
-			              THEN (SELECT label_catalog_checked_at FROM forge_repos WHERE id = ?)
-			              ELSE label_catalog_checked_at
-			          END,
-			          label_catalog_sync_error = CASE
-			              WHEN (SELECT label_catalog_checked_at FROM forge_repos WHERE id = ?) > COALESCE(label_catalog_checked_at, '')
-			              THEN (SELECT label_catalog_sync_error FROM forge_repos WHERE id = ?)
-			              ELSE label_catalog_sync_error
-			          END
-			      WHERE id = ?`,
-			args: []any{fromRepoID, fromRepoID, fromRepoID, fromRepoID, fromRepoID, fromRepoID, fromRepoID, fromRepoID, fromRepoID, toRepoID},
-		},
-		{
-			name: "move merge requests",
-			sql: `UPDATE forge_merge_requests
-			      SET repo_id = ?,
-			          head_repo_identity_stale = 1,
-			          snapshot_revision = snapshot_revision + 1
-			      WHERE repo_id = ?`,
-			args: []any{toRepoID, fromRepoID},
-		},
-		{
-			name: "move issues",
-			sql: `UPDATE forge_issues
-			      SET repo_id = ?
-			      WHERE repo_id = ?
-			        AND NOT EXISTS (
-			            SELECT 1
-			            FROM forge_issues AS target
-			            WHERE target.repo_id = ?
-			              AND (
-			                  target.number = forge_issues.number
-			                  OR target.platform_id = forge_issues.platform_id
-			              )
-			        )`,
-			args: []any{toRepoID, fromRepoID, toRepoID},
-		},
-		{
-			name: "drop duplicate issues",
-			sql:  `DELETE FROM forge_issues WHERE repo_id = ?`,
-			args: []any{fromRepoID},
-		},
-		{
-			name: "move labels",
-			sql: `UPDATE forge_labels
-			      SET repo_id = ?
-			      WHERE repo_id = ?
-			        AND NOT EXISTS (
-			            SELECT 1
-			            FROM forge_labels AS target
-			            WHERE target.repo_id = ?
-			              AND (
-			                  target.name = forge_labels.name
-			                  OR (
-			                      target.platform_id IS NOT NULL
-			                      AND forge_labels.platform_id IS NOT NULL
-			                      AND target.platform_id = forge_labels.platform_id
-			                  )
-			                  OR (
-			                      target.platform_external_id <> ''
-			                      AND forge_labels.platform_external_id <> ''
-			                      AND target.platform_external_id = forge_labels.platform_external_id
-			                  )
-			              )
-			        )`,
-			args: []any{toRepoID, fromRepoID, toRepoID},
-		},
-		{
-			name: "copy duplicate label catalog metadata",
-			sql: `UPDATE forge_labels AS target
-			      SET name = COALESCE((
-			              SELECT source.name
-			              FROM forge_labels AS source
-			              WHERE source.repo_id = ?
-			                AND source.catalog_present = 1
-			                AND (
-			                    source.name = target.name
-			                    OR (
-			                        source.platform_id IS NOT NULL
-			                        AND target.platform_id IS NOT NULL
-			                        AND source.platform_id = target.platform_id
-			                    )
-			                    OR (
-			                        source.platform_external_id <> ''
-			                        AND target.platform_external_id <> ''
-			                        AND source.platform_external_id = target.platform_external_id
-			                    )
-			                )
-			              ORDER BY source.catalog_seen_at DESC
-			              LIMIT 1
-			          ), name),
-			          description = COALESCE((
-			              SELECT source.description
-			              FROM forge_labels AS source
-			              WHERE source.repo_id = ?
-			                AND source.catalog_present = 1
-			                AND (
-			                    source.name = target.name
-			                    OR (
-			                        source.platform_id IS NOT NULL
-			                        AND target.platform_id IS NOT NULL
-			                        AND source.platform_id = target.platform_id
-			                    )
-			                    OR (
-			                        source.platform_external_id <> ''
-			                        AND target.platform_external_id <> ''
-			                        AND source.platform_external_id = target.platform_external_id
-			                    )
-			                )
-			              ORDER BY source.catalog_seen_at DESC
-			              LIMIT 1
-			          ), description),
-			          color = COALESCE((
-			              SELECT source.color
-			              FROM forge_labels AS source
-			              WHERE source.repo_id = ?
-			                AND source.catalog_present = 1
-			                AND (
-			                    source.name = target.name
-			                    OR (
-			                        source.platform_id IS NOT NULL
-			                        AND target.platform_id IS NOT NULL
-			                        AND source.platform_id = target.platform_id
-			                    )
-			                    OR (
-			                        source.platform_external_id <> ''
-			                        AND target.platform_external_id <> ''
-			                        AND source.platform_external_id = target.platform_external_id
-			                    )
-			                )
-			              ORDER BY source.catalog_seen_at DESC
-			              LIMIT 1
-			          ), color),
-			          is_default = COALESCE((
-			              SELECT source.is_default
-			              FROM forge_labels AS source
-			              WHERE source.repo_id = ?
-			                AND source.catalog_present = 1
-			                AND (
-			                    source.name = target.name
-			                    OR (
-			                        source.platform_id IS NOT NULL
-			                        AND target.platform_id IS NOT NULL
-			                        AND source.platform_id = target.platform_id
-			                    )
-			                    OR (
-			                        source.platform_external_id <> ''
-			                        AND target.platform_external_id <> ''
-			                        AND source.platform_external_id = target.platform_external_id
-			                    )
-			                )
-			              ORDER BY source.catalog_seen_at DESC
-			              LIMIT 1
-			          ), is_default),
-			          updated_at = COALESCE((
-			              SELECT source.updated_at
-			              FROM forge_labels AS source
-			              WHERE source.repo_id = ?
-			                AND source.catalog_present = 1
-			                AND (
-			                    source.name = target.name
-			                    OR (
-			                        source.platform_id IS NOT NULL
-			                        AND target.platform_id IS NOT NULL
-			                        AND source.platform_id = target.platform_id
-			                    )
-			                    OR (
-			                        source.platform_external_id <> ''
-			                        AND target.platform_external_id <> ''
-			                        AND source.platform_external_id = target.platform_external_id
-			                    )
-			                )
-			              ORDER BY source.catalog_seen_at DESC
-			              LIMIT 1
-			          ), updated_at),
-			          catalog_present = CASE
-			              WHEN catalog_present = 1 OR EXISTS (
-			                  SELECT 1
-			                  FROM forge_labels AS source
-			                  WHERE source.repo_id = ?
-			                    AND source.catalog_present = 1
-			                    AND (
-			                        source.name = target.name
-			                        OR (
-			                            source.platform_id IS NOT NULL
-			                            AND target.platform_id IS NOT NULL
-			                            AND source.platform_id = target.platform_id
-			                        )
-			                        OR (
-			                            source.platform_external_id <> ''
-			                            AND target.platform_external_id <> ''
-			                            AND source.platform_external_id = target.platform_external_id
-			                        )
-			                    )
-			              )
-			              THEN 1
-			              ELSE catalog_present
-			          END,
-			          catalog_seen_at = CASE
-			              WHEN catalog_seen_at IS NULL
-			              THEN (
-			                  SELECT MAX(source.catalog_seen_at)
-			                  FROM forge_labels AS source
-			                  WHERE source.repo_id = ?
-			                    AND (
-			                        source.name = target.name
-			                        OR (
-			                            source.platform_id IS NOT NULL
-			                            AND target.platform_id IS NOT NULL
-			                            AND source.platform_id = target.platform_id
-			                        )
-			                        OR (
-			                            source.platform_external_id <> ''
-			                            AND target.platform_external_id <> ''
-			                            AND source.platform_external_id = target.platform_external_id
-			                        )
-			                    )
-			              )
-			              WHEN (
-			                  SELECT MAX(source.catalog_seen_at)
-			                  FROM forge_labels AS source
-			                  WHERE source.repo_id = ?
-			                    AND (
-			                        source.name = target.name
-			                        OR (
-			                            source.platform_id IS NOT NULL
-			                            AND target.platform_id IS NOT NULL
-			                            AND source.platform_id = target.platform_id
-			                        )
-			                        OR (
-			                            source.platform_external_id <> ''
-			                            AND target.platform_external_id <> ''
-			                            AND source.platform_external_id = target.platform_external_id
-			                        )
-			                    )
-			              ) > catalog_seen_at
-			              THEN (
-			                  SELECT MAX(source.catalog_seen_at)
-			                  FROM forge_labels AS source
-			                  WHERE source.repo_id = ?
-			                    AND (
-			                        source.name = target.name
-			                        OR (
-			                            source.platform_id IS NOT NULL
-			                            AND target.platform_id IS NOT NULL
-			                            AND source.platform_id = target.platform_id
-			                        )
-			                        OR (
-			                            source.platform_external_id <> ''
-			                            AND target.platform_external_id <> ''
-			                            AND source.platform_external_id = target.platform_external_id
-			                        )
-			                    )
-			              )
-			              ELSE catalog_seen_at
-			          END
-			      WHERE target.repo_id = ?
-			        AND EXISTS (
-			            SELECT 1
-			            FROM forge_labels AS source
-			            WHERE source.repo_id = ?
-			              AND (
-			                  source.name = target.name
-			                  OR (
-			                      source.platform_id IS NOT NULL
-			                      AND target.platform_id IS NOT NULL
-			                      AND source.platform_id = target.platform_id
-			                  )
-			                  OR (
-			                      source.platform_external_id <> ''
-			                      AND target.platform_external_id <> ''
-			                      AND source.platform_external_id = target.platform_external_id
-			                  )
-			              )
-			        )`,
-			args: []any{fromRepoID, fromRepoID, fromRepoID, fromRepoID, fromRepoID, fromRepoID, fromRepoID, fromRepoID, fromRepoID, toRepoID, fromRepoID},
-		},
-		{
-			name: "copy issue label associations to duplicate labels",
-			sql: `WITH source_label_targets AS (
-			          SELECT source.id AS source_label_id,
-			                 target.id AS target_label_id,
-			                 ROW_NUMBER() OVER (
-			                     PARTITION BY source.id
-			                     ORDER BY
-			                         CASE
-			                             WHEN target.platform_id IS NOT NULL
-			                                  AND source.platform_id IS NOT NULL
-			                                  AND target.platform_id = source.platform_id
-			                             THEN 0
-			                             WHEN target.platform_external_id <> ''
-			                                  AND source.platform_external_id <> ''
-			                                  AND target.platform_external_id = source.platform_external_id
-			                             THEN 1
-			                             ELSE 2
-			                         END,
-			                         target.id
-			                 ) AS target_rank
-			          FROM forge_labels AS source
-			          JOIN forge_labels AS target
-			              ON target.repo_id = ?
-			             AND (
-			                 target.name = source.name
-			                 OR (
-			                     target.platform_id IS NOT NULL
-			                     AND source.platform_id IS NOT NULL
-			                     AND target.platform_id = source.platform_id
-			                 )
-			                 OR (
-			                     target.platform_external_id <> ''
-			                     AND source.platform_external_id <> ''
-			                     AND target.platform_external_id = source.platform_external_id
-			                 )
-			             )
-			          WHERE source.repo_id = ?
-			      )
-			      INSERT INTO forge_issue_labels (issue_id, label_id)
-			      SELECT il.issue_id, slt.target_label_id
-			      FROM forge_issue_labels AS il
-			      JOIN source_label_targets AS slt
-			          ON slt.source_label_id = il.label_id
-			         AND slt.target_rank = 1
-			      ON CONFLICT(issue_id, label_id) DO NOTHING`,
-			args: []any{toRepoID, fromRepoID},
-		},
-		{
-			name: "copy merge request label associations to duplicate labels",
-			sql: `WITH source_label_targets AS (
-			          SELECT source.id AS source_label_id,
-			                 target.id AS target_label_id,
-			                 ROW_NUMBER() OVER (
-			                     PARTITION BY source.id
-			                     ORDER BY
-			                         CASE
-			                             WHEN target.platform_id IS NOT NULL
-			                                  AND source.platform_id IS NOT NULL
-			                                  AND target.platform_id = source.platform_id
-			                             THEN 0
-			                             WHEN target.platform_external_id <> ''
-			                                  AND source.platform_external_id <> ''
-			                                  AND target.platform_external_id = source.platform_external_id
-			                             THEN 1
-			                             ELSE 2
-			                         END,
-			                         target.id
-			                 ) AS target_rank
-			          FROM forge_labels AS source
-			          JOIN forge_labels AS target
-			              ON target.repo_id = ?
-			             AND (
-			                 target.name = source.name
-			                 OR (
-			                     target.platform_id IS NOT NULL
-			                     AND source.platform_id IS NOT NULL
-			                     AND target.platform_id = source.platform_id
-			                 )
-			                 OR (
-			                     target.platform_external_id <> ''
-			                     AND source.platform_external_id <> ''
-			                     AND target.platform_external_id = source.platform_external_id
-			                 )
-			             )
-			          WHERE source.repo_id = ?
-			      )
-			      INSERT INTO forge_merge_request_labels (merge_request_id, label_id)
-			      SELECT mrl.merge_request_id, slt.target_label_id
-			      FROM forge_merge_request_labels AS mrl
-			      JOIN source_label_targets AS slt
-			          ON slt.source_label_id = mrl.label_id
-			         AND slt.target_rank = 1
-			      ON CONFLICT(merge_request_id, label_id) DO NOTHING`,
-			args: []any{toRepoID, fromRepoID},
-		},
-		{
-			name: "drop duplicate labels",
-			sql:  `DELETE FROM forge_labels WHERE repo_id = ?`,
-			args: []any{fromRepoID},
-		},
-		{
-			name: "copy starred items",
-			sql: `INSERT OR IGNORE INTO forge_starred_items (
-			          item_type, repo_id, number, starred_at
-			      )
-			      SELECT item_type, ?, number, starred_at
-			      FROM forge_starred_items
-			      WHERE repo_id = ?`,
-			args: []any{toRepoID, fromRepoID},
-		},
-		{
-			name: "delete source starred items",
-			sql:  `DELETE FROM forge_starred_items WHERE repo_id = ?`,
-			args: []any{fromRepoID},
-		},
-		{
-			name: "move stacks",
-			sql: `UPDATE forge_stacks
-			      SET repo_id = ?
-			      WHERE repo_id = ?
-			        AND NOT EXISTS (
-			            SELECT 1
-			            FROM forge_stacks AS target
-			            WHERE target.repo_id = ?
-			              AND target.base_number = forge_stacks.base_number
-			        )`,
-			args: []any{toRepoID, fromRepoID, toRepoID},
-		},
-		{
-			name: "drop duplicate stacks",
-			sql:  `DELETE FROM forge_stacks WHERE repo_id = ?`,
-			args: []any{fromRepoID},
-		},
-		{
-			name: "move repo overview",
-			sql: `UPDATE forge_repo_overviews
-			      SET repo_id = ?
-			      WHERE repo_id = ?
-			        AND NOT EXISTS (
-			            SELECT 1
-			            FROM forge_repo_overviews AS target
-			            WHERE target.repo_id = ?
-			        )`,
-			args: []any{toRepoID, fromRepoID, toRepoID},
-		},
-		{
-			name: "drop duplicate repo overview",
-			sql:  `DELETE FROM forge_repo_overviews WHERE repo_id = ?`,
-			args: []any{fromRepoID},
-		},
-		{
-			name: "delete source repo",
-			sql:  `DELETE FROM forge_repos WHERE id = ?`,
-			args: []any{fromRepoID},
-		},
-	}
-
-	for _, step := range steps {
-		if step.name == "copy duplicate label catalog metadata" {
-			if err := mergeRepoLabelNameConflictsTx(ctx, tx, fromRepoID, toRepoID); err != nil {
-				return err
-			}
-		}
-		if _, err := tx.ExecContext(ctx, step.sql, step.args...); err != nil {
-			return fmt.Errorf("%s: %w", step.name, err)
-		}
 	}
 	return nil
 }
@@ -2233,7 +1500,9 @@ func mergeRepoRowsTx(ctx context.Context, tx *sql.Tx, fromRepoID, toRepoID int64
 func (d *DB) ListRepos(ctx context.Context) ([]Repo, error) {
 	rows, err := d.ro.QueryContext(ctx,
 		`SELECT id, platform, platform_host, platform_repo_id,
-		        owner, name, repo_path,
+		        COALESCE(retired_owner, owner),
+		        COALESCE(retired_name, name),
+		        repo_path,
 		        owner_key, name_key, repo_path_key,
 		        web_url, clone_url, default_branch,
 		        last_sync_started_at, last_sync_completed_at,
@@ -2242,7 +1511,9 @@ func (d *DB) ListRepos(ctx context.Context) ([]Repo, error) {
 		        label_catalog_synced_at, label_catalog_checked_at,
 		        label_catalog_sync_error,
 		        created_at
-		 FROM forge_repos ORDER BY owner, name, platform, platform_host`,
+		 FROM forge_repos
+		 WHERE retired_at IS NULL
+		 ORDER BY owner, name, platform, platform_host`,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("list repos: %w", err)
@@ -2303,23 +1574,38 @@ func (d *DB) UpdateRepoProviderMetadata(
 	repoID int64,
 	metadata RepoProviderMetadata,
 ) error {
-	_, err := d.rw.ExecContext(ctx,
-		`UPDATE forge_repos
-		 SET platform_repo_id = ?,
-		     web_url = ?,
-		     clone_url = ?,
-		     default_branch = ?
-		 WHERE id = ?`,
-		metadata.PlatformRepoID,
-		metadata.WebURL,
-		metadata.CloneURL,
-		metadata.DefaultBranch,
-		repoID,
-	)
-	if err != nil {
-		return fmt.Errorf("update repo provider metadata: %w", err)
-	}
-	return nil
+	return d.Tx(ctx, func(tx *sql.Tx) error {
+		if err := validateRepoProviderIDWriteTx(
+			ctx,
+			tx,
+			repoID,
+			metadata.PlatformRepoID,
+		); err != nil {
+			return err
+		}
+		_, err := tx.ExecContext(ctx,
+			`UPDATE forge_repos
+			 SET platform_repo_id = CASE
+			         WHEN ? <> ''
+			         THEN ?
+			         ELSE platform_repo_id
+			     END,
+			     web_url = ?,
+			     clone_url = ?,
+			     default_branch = ?
+			 WHERE id = ?`,
+			metadata.PlatformRepoID,
+			metadata.PlatformRepoID,
+			metadata.WebURL,
+			metadata.CloneURL,
+			metadata.DefaultBranch,
+			repoID,
+		)
+		if err != nil {
+			return fmt.Errorf("update repo provider metadata: %w", err)
+		}
+		return nil
+	})
 }
 
 // GetRepoByIdentity returns the repo for the provider-qualified identity,
@@ -2341,7 +1627,8 @@ func (d *DB) GetRepoByIdentity(ctx context.Context, identity RepoIdentity) (*Rep
 		 FROM forge_repos
 		 WHERE platform = ?
 		   AND platform_host = ?
-		   AND repo_path_key = ?`,
+		   AND repo_path_key = ?
+		   AND retired_at IS NULL`,
 		identity.Platform, identity.PlatformHost, identity.RepoPathKey,
 	).Scan(
 		&r.ID, &r.Platform, &r.PlatformHost, &r.PlatformRepoID,
@@ -2366,21 +1653,35 @@ func (d *DB) GetRepoByIdentity(ctx context.Context, identity RepoIdentity) (*Rep
 	return &r, nil
 }
 
-// GetRepoByID returns the repo with the given ID, or nil if not found.
-func (d *DB) GetRepoByID(ctx context.Context, id int64) (*Repo, error) {
+// GetRepoByConfiguredRoute returns the active repository previously resolved
+// from an exact configuration route, or nil when the route has no saved alias.
+func (d *DB) GetRepoByConfiguredRoute(
+	ctx context.Context,
+	identity RepoIdentity,
+) (*Repo, error) {
+	identity = canonicalRepoIdentity(identity)
 	var r Repo
-	err := d.ro.QueryRowContext(ctx,
-		`SELECT id, platform, platform_host, platform_repo_id,
-		        owner, name, repo_path,
-		        owner_key, name_key, repo_path_key,
-		        web_url, clone_url, default_branch,
-		        last_sync_started_at, last_sync_completed_at,
-		        last_sync_error, allow_squash_merge, allow_merge_commit,
-		        allow_rebase_merge, viewer_can_merge,
-		        label_catalog_synced_at, label_catalog_checked_at,
-		        label_catalog_sync_error,
-		        created_at
-		 FROM forge_repos WHERE id = ?`, id,
+	err := d.ro.QueryRowContext(ctx, `
+		SELECT repo.id, repo.platform, repo.platform_host, repo.platform_repo_id,
+		       repo.owner, repo.name, repo.repo_path,
+		       repo.owner_key, repo.name_key, repo.repo_path_key,
+		       repo.web_url, repo.clone_url, repo.default_branch,
+		       repo.last_sync_started_at, repo.last_sync_completed_at,
+		       repo.last_sync_error,
+		       repo.allow_squash_merge, repo.allow_merge_commit,
+		       repo.allow_rebase_merge, repo.viewer_can_merge,
+		       repo.label_catalog_synced_at, repo.label_catalog_checked_at,
+		       repo.label_catalog_sync_error,
+		       repo.created_at
+		FROM forge_repository_config_routes AS configured
+		JOIN forge_repos AS repo ON repo.id = configured.repo_id
+		WHERE configured.platform = ?
+		  AND configured.platform_host = ?
+		  AND configured.repo_path_key = ?
+		  AND repo.retired_at IS NULL`,
+		identity.Platform,
+		identity.PlatformHost,
+		identity.RepoPathKey,
 	).Scan(
 		&r.ID, &r.Platform, &r.PlatformHost, &r.PlatformRepoID,
 		&r.Owner, &r.Name, &r.RepoPath,
@@ -2398,10 +1699,177 @@ func (d *DB) GetRepoByID(ctx context.Context, id int64) (*Repo, error) {
 		return nil, nil
 	}
 	if err != nil {
+		return nil, fmt.Errorf("get repo by configured route: %w", err)
+	}
+	normalizeRepoTimestamps(&r)
+	return &r, nil
+}
+
+// GetRepoByID returns the repo with the given ID, or nil if not found.
+func (d *DB) GetRepoByID(ctx context.Context, id int64) (*Repo, error) {
+	var r Repo
+	err := d.ro.QueryRowContext(ctx,
+		`SELECT id, platform, platform_host, platform_repo_id,
+		        COALESCE(retired_owner, owner),
+		        COALESCE(retired_name, name),
+		        repo_path,
+		        owner_key, name_key, repo_path_key,
+		        web_url, clone_url, default_branch,
+		        last_sync_started_at, last_sync_completed_at,
+		        last_sync_error, allow_squash_merge, allow_merge_commit,
+		        allow_rebase_merge, viewer_can_merge,
+		        label_catalog_synced_at, label_catalog_checked_at,
+		        label_catalog_sync_error,
+		        retired_at, retired_replacement_id,
+		        created_at
+		 FROM forge_repos WHERE id = ?`, id,
+	).Scan(
+		&r.ID, &r.Platform, &r.PlatformHost, &r.PlatformRepoID,
+		&r.Owner, &r.Name, &r.RepoPath,
+		&r.OwnerKey, &r.NameKey, &r.RepoPathKey,
+		&r.WebURL, &r.CloneURL, &r.DefaultBranch,
+		&r.LastSyncStartedAt, &r.LastSyncCompletedAt,
+		&r.LastSyncError,
+		&r.AllowSquashMerge, &r.AllowMergeCommit, &r.AllowRebaseMerge,
+		&r.ViewerCanMerge,
+		&r.LabelCatalogSyncedAt, &r.LabelCatalogCheckedAt,
+		&r.LabelCatalogSyncError,
+		&r.RetiredAt, &r.RetiredReplacementID,
+		&r.CreatedAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
 		return nil, fmt.Errorf("get repo by id: %w", err)
 	}
 	normalizeRepoTimestamps(&r)
 	return &r, nil
+}
+
+// SaveRepoConfiguredRoute records the exact configuration route that selected
+// an active repository whose provider path has changed. Matching routes need
+// no alias and remove only that route's stale binding; a repository may have
+// several exact configured routes.
+func (d *DB) SaveRepoConfiguredRoute(
+	ctx context.Context,
+	repoID int64,
+	configured RepoIdentity,
+) error {
+	configured = canonicalRepoIdentity(configured)
+	return d.Tx(ctx, func(tx *sql.Tx) error {
+		var current RepoIdentity
+		err := tx.QueryRowContext(ctx, `
+			SELECT platform, platform_host, platform_repo_id,
+			       owner, name, repo_path,
+			       owner_key, name_key, repo_path_key
+			FROM forge_repos
+			WHERE id = ? AND retired_at IS NULL`, repoID,
+		).Scan(
+			&current.Platform, &current.PlatformHost, &current.PlatformRepoID,
+			&current.Owner, &current.Name, &current.RepoPath,
+			&current.OwnerKey, &current.NameKey, &current.RepoPathKey,
+		)
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrRepositoryRetired
+		}
+		if err != nil {
+			return fmt.Errorf("get repo for configured route: %w", err)
+		}
+		current = canonicalRepoIdentity(current)
+		if current.Platform != configured.Platform ||
+			current.PlatformHost != configured.PlatformHost {
+			return fmt.Errorf("configured route provider does not match repository")
+		}
+
+		if _, err := tx.ExecContext(ctx, `
+			DELETE FROM forge_repository_config_routes
+			WHERE platform = ? AND platform_host = ? AND repo_path_key = ?`,
+			configured.Platform,
+			configured.PlatformHost,
+			configured.RepoPathKey,
+		); err != nil {
+			return fmt.Errorf("clear configured repository route: %w", err)
+		}
+		if current.RepoPathKey == configured.RepoPathKey {
+			return nil
+		}
+
+		_, err = tx.ExecContext(ctx, `
+			INSERT INTO forge_repository_config_routes (
+				repo_id, platform, platform_host,
+				owner, name, repo_path, repo_path_key
+			) VALUES (?, ?, ?, ?, ?, ?, ?)
+			ON CONFLICT(platform, platform_host, repo_path_key) DO UPDATE SET
+				repo_id = excluded.repo_id,
+				owner = excluded.owner,
+				name = excluded.name,
+				repo_path = excluded.repo_path`,
+			repoID,
+			configured.Platform,
+			configured.PlatformHost,
+			configured.Owner,
+			configured.Name,
+			configured.RepoPath,
+			configured.RepoPathKey,
+		)
+		if err != nil {
+			return fmt.Errorf("save configured repository route: %w", err)
+		}
+		return nil
+	})
+}
+
+type RepoConfiguredRouteBinding struct {
+	RepoID int64
+	Route  RepoIdentity
+}
+
+// ReconcileRepoConfiguredRoutes atomically replaces durable aliases with the
+// complete exact-route configuration. Direct current routes need no alias.
+func (d *DB) ReconcileRepoConfiguredRoutes(
+	ctx context.Context,
+	bindings []RepoConfiguredRouteBinding,
+) error {
+	return d.Tx(ctx, func(tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM forge_repository_config_routes`); err != nil {
+			return fmt.Errorf("clear configured repository routes: %w", err)
+		}
+		for _, binding := range bindings {
+			configured := canonicalRepoIdentity(binding.Route)
+			var platformName, platformHost, currentPathKey string
+			err := tx.QueryRowContext(ctx, `
+				SELECT platform, platform_host, repo_path_key
+				FROM forge_repos
+				WHERE id = ? AND retired_at IS NULL`, binding.RepoID,
+			).Scan(&platformName, &platformHost, &currentPathKey)
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrRepositoryRetired
+			}
+			if err != nil {
+				return fmt.Errorf("get repo for configured route reconciliation: %w", err)
+			}
+			if platformName != configured.Platform || platformHost != configured.PlatformHost {
+				return fmt.Errorf("configured route provider does not match repository")
+			}
+			if currentPathKey == configured.RepoPathKey {
+				continue
+			}
+			_, err = tx.ExecContext(ctx, `
+				INSERT INTO forge_repository_config_routes (
+					repo_id, platform, platform_host,
+					owner, name, repo_path, repo_path_key
+				) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+				binding.RepoID, configured.Platform, configured.PlatformHost,
+				configured.Owner, configured.Name, configured.RepoPath,
+				configured.RepoPathKey,
+			)
+			if err != nil {
+				return fmt.Errorf("save configured repository route: %w", err)
+			}
+		}
+		return nil
+	})
 }
 
 func normalizeRepoTimestamps(r *Repo) {
@@ -2424,6 +1892,10 @@ func normalizeRepoTimestamps(r *Repo) {
 	if r.LabelCatalogCheckedAt != nil {
 		t := r.LabelCatalogCheckedAt.UTC()
 		r.LabelCatalogCheckedAt = &t
+	}
+	if r.RetiredAt != nil {
+		t := r.RetiredAt.UTC()
+		r.RetiredAt = &t
 	}
 }
 
@@ -2500,40 +1972,46 @@ func marshalUserNamesJSON(names []string) string {
 // UpdateMergeRequestAssignees persists a provider-confirmed assignee set
 // after a mutation so the next sync does not revert the edit.
 func (d *DB) UpdateMergeRequestAssignees(ctx context.Context, repoID, mrID int64, assignees []string) error {
-	_, err := d.rw.ExecContext(ctx,
-		`UPDATE forge_merge_requests SET assignees_json = ? WHERE id = ? AND repo_id = ?`,
-		marshalUserNamesJSON(assignees), mrID, repoID,
-	)
-	if err != nil {
-		return fmt.Errorf("update merge request assignees: %w", err)
-	}
-	return nil
+	return d.withActiveRepositoryTx(ctx, repoID, func(tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx,
+			`UPDATE forge_merge_requests SET assignees_json = ? WHERE id = ? AND repo_id = ?`,
+			marshalUserNamesJSON(assignees), mrID, repoID,
+		)
+		if err != nil {
+			return fmt.Errorf("update merge request assignees: %w", err)
+		}
+		return nil
+	})
 }
 
 // UpdateMergeRequestReviewers persists a provider-confirmed
 // requested-reviewer set after a mutation.
 func (d *DB) UpdateMergeRequestReviewers(ctx context.Context, repoID, mrID int64, reviewers []string) error {
-	_, err := d.rw.ExecContext(ctx,
-		`UPDATE forge_merge_requests SET reviewers_json = ? WHERE id = ? AND repo_id = ?`,
-		marshalUserNamesJSON(reviewers), mrID, repoID,
-	)
-	if err != nil {
-		return fmt.Errorf("update merge request reviewers: %w", err)
-	}
-	return nil
+	return d.withActiveRepositoryTx(ctx, repoID, func(tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx,
+			`UPDATE forge_merge_requests SET reviewers_json = ? WHERE id = ? AND repo_id = ?`,
+			marshalUserNamesJSON(reviewers), mrID, repoID,
+		)
+		if err != nil {
+			return fmt.Errorf("update merge request reviewers: %w", err)
+		}
+		return nil
+	})
 }
 
 // UpdateIssueAssignees persists a provider-confirmed assignee set on an
 // issue after a mutation.
 func (d *DB) UpdateIssueAssignees(ctx context.Context, repoID, issueID int64, assignees []string) error {
-	_, err := d.rw.ExecContext(ctx,
-		`UPDATE forge_issues SET assignees_json = ? WHERE id = ? AND repo_id = ?`,
-		marshalUserNamesJSON(assignees), issueID, repoID,
-	)
-	if err != nil {
-		return fmt.Errorf("update issue assignees: %w", err)
-	}
-	return nil
+	return d.withActiveRepositoryTx(ctx, repoID, func(tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx,
+			`UPDATE forge_issues SET assignees_json = ? WHERE id = ? AND repo_id = ?`,
+			marshalUserNamesJSON(assignees), issueID, repoID,
+		)
+		if err != nil {
+			return fmt.Errorf("update issue assignees: %w", err)
+		}
+		return nil
+	})
 }
 
 func (d *DB) UpsertMergeRequest(ctx context.Context, mr *MergeRequest) (int64, error) {
@@ -2721,6 +2199,9 @@ func upsertMergeRequestParentTx(
 	tx *sql.Tx,
 	mr *MergeRequest,
 ) (int64, int64, bool, error) {
+	if err := requireActiveRepoTx(ctx, tx, mr.RepoID, ""); err != nil {
+		return 0, 0, false, err
+	}
 	canonicalizeMergeRequestTimestamps(mr)
 	id, revision, accepted, err := upsertMergeRequestSnapshot(ctx, tx, mr)
 	return id, revision, accepted, err
@@ -2796,6 +2277,7 @@ func (d *DB) GetMergeRequest(
 		    ON s.item_type = 'pr' AND s.repo_id = p.repo_id AND s.number = p.number
 		WHERE r.platform = ? AND r.platform_host = ?
 		  AND r.owner_key = ? AND r.name_key = ?
+		  AND r.retired_at IS NULL
 		  AND p.number = ?`,
 		platform, platformHost, owner, name, number,
 	).Scan(
@@ -2899,7 +2381,7 @@ func (d *DB) ListMergeRequests(ctx context.Context, opts ListMergeRequestsOpts) 
 	if state == "" {
 		state = "open"
 	}
-	var conds []string
+	conds := []string{"r.retired_at IS NULL"}
 	var args []any
 
 	switch state {
@@ -3363,21 +2845,24 @@ type IssueDerivedFields struct {
 // Derived fields (CommentCount, CIStatus, etc.) are untouched.
 func (d *DB) UpdateMRTitleBody(
 	ctx context.Context,
+	repoID int64,
 	id int64,
 	title, body string,
 	updatedAt time.Time,
 ) error {
-	_, err := d.rw.ExecContext(ctx, `
-		UPDATE forge_merge_requests
-		SET title = ?, body = ?, updated_at = ?,
-		    last_activity_at = MAX(last_activity_at, ?)
-		WHERE id = ? AND updated_at <= ?`,
-		title, body, updatedAt, updatedAt, id, updatedAt,
-	)
-	if err != nil {
-		return fmt.Errorf("update mr title/body: %w", err)
-	}
-	return nil
+	return d.withActiveRepositoryTx(ctx, repoID, func(tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+			UPDATE forge_merge_requests
+			SET title = ?, body = ?, updated_at = ?,
+			    last_activity_at = MAX(last_activity_at, ?)
+			WHERE id = ? AND repo_id = ? AND updated_at <= ?`,
+			title, body, updatedAt, updatedAt, id, repoID, updatedAt,
+		)
+		if err != nil {
+			return fmt.Errorf("update mr title/body: %w", err)
+		}
+		return nil
+	})
 }
 
 // UpdateIssueTitleBody updates only the title, body, updated_at, and
@@ -3385,21 +2870,24 @@ func (d *DB) UpdateMRTitleBody(
 // MAX(existing, updatedAt) so list ordering reflects the edit.
 func (d *DB) UpdateIssueTitleBody(
 	ctx context.Context,
+	repoID int64,
 	id int64,
 	title, body string,
 	updatedAt time.Time,
 ) error {
-	_, err := d.rw.ExecContext(ctx, `
-		UPDATE forge_issues
-		SET title = ?, body = ?, updated_at = ?,
-		    last_activity_at = MAX(last_activity_at, ?)
-		WHERE id = ? AND updated_at <= ?`,
-		title, body, updatedAt, updatedAt, id, updatedAt,
-	)
-	if err != nil {
-		return fmt.Errorf("update issue title/body: %w", err)
-	}
-	return nil
+	return d.withActiveRepositoryTx(ctx, repoID, func(tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+			UPDATE forge_issues
+			SET title = ?, body = ?, updated_at = ?,
+			    last_activity_at = MAX(last_activity_at, ?)
+			WHERE id = ? AND repo_id = ? AND updated_at <= ?`,
+			title, body, updatedAt, updatedAt, id, repoID, updatedAt,
+		)
+		if err != nil {
+			return fmt.Errorf("update issue title/body: %w", err)
+		}
+		return nil
+	})
 }
 
 // UpdateMRDerivedFields writes computed fields back to the merge_requests row.
@@ -3659,17 +3147,19 @@ func (d *DB) UpdateMRState(
 	mergedAt, closedAt *time.Time,
 ) error {
 	now := time.Now().UTC()
-	_, err := d.rw.ExecContext(ctx, `
-		UPDATE forge_merge_requests
-		SET state = ?, merged_at = ?, closed_at = ?,
-		    updated_at = ?, last_activity_at = ?
-		WHERE repo_id = ? AND number = ?`,
-		state, mergedAt, closedAt, now, now, repoID, number,
-	)
-	if err != nil {
-		return fmt.Errorf("update mr state: %w", err)
-	}
-	return nil
+	return d.withActiveRepositoryTx(ctx, repoID, func(tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+			UPDATE forge_merge_requests
+			SET state = ?, merged_at = ?, closed_at = ?,
+			    updated_at = ?, last_activity_at = ?
+			WHERE repo_id = ? AND number = ?`,
+			state, mergedAt, closedAt, now, now, repoID, number,
+		)
+		if err != nil {
+			return fmt.Errorf("update mr state: %w", err)
+		}
+		return nil
+	})
 }
 
 // UpdateMRDraftState records a provider-confirmed draft flag without
@@ -3680,6 +3170,9 @@ func (d *DB) UpdateMRDraftState(ctx context.Context, repoID int64, number int, i
 		return fmt.Errorf("begin update mr draft state: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
+	if err := requireActiveRepoTx(ctx, tx, repoID, ""); err != nil {
+		return err
+	}
 
 	var updatedAt time.Time
 	var lastActivityAt time.Time
@@ -3760,6 +3253,9 @@ func upsertIssueParentTx(
 	tx *sql.Tx,
 	issue *Issue,
 ) (int64, int64, bool, error) {
+	if err := requireActiveRepoTx(ctx, tx, issue.RepoID, ""); err != nil {
+		return 0, 0, false, err
+	}
 	canonicalizeIssueTimestamps(issue)
 	var issueID, revision int64
 	err := tx.QueryRowContext(ctx, `
@@ -3832,6 +3328,7 @@ func (d *DB) GetIssue(
 		    ON w.repo_id = i.repo_id AND w.item_type = 'issue' AND w.item_number = i.number
 		WHERE r.platform = ? AND r.platform_host = ?
 		  AND r.owner_key = ? AND r.name_key = ?
+		  AND r.retired_at IS NULL
 		  AND i.number = ?`,
 		platform, platformHost, owner, name, number,
 	).Scan(
@@ -3915,7 +3412,7 @@ func (d *DB) ListIssues(
 	if state == "" {
 		state = "open"
 	}
-	var conds []string
+	conds := []string{"r.retired_at IS NULL"}
 	var args []any
 
 	switch state {
@@ -4100,16 +3597,18 @@ func (d *DB) UpdateIssueState(
 	closedAt *time.Time,
 ) error {
 	now := time.Now().UTC()
-	_, err := d.rw.ExecContext(ctx, `
-		UPDATE forge_issues SET state = ?, closed_at = ?,
-		    updated_at = ?, last_activity_at = ?
-		WHERE repo_id = ? AND number = ?`,
-		state, closedAt, now, now, repoID, number,
-	)
-	if err != nil {
-		return fmt.Errorf("update issue state: %w", err)
-	}
-	return nil
+	return d.withActiveRepositoryTx(ctx, repoID, func(tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+			UPDATE forge_issues SET state = ?, closed_at = ?,
+			    updated_at = ?, last_activity_at = ?
+			WHERE repo_id = ? AND number = ?`,
+			state, closedAt, now, now, repoID, number,
+		)
+		if err != nil {
+			return fmt.Errorf("update issue state: %w", err)
+		}
+		return nil
+	})
 }
 
 // GetPreviouslyOpenIssueNumbers returns issue numbers that are open in the DB
@@ -4157,20 +3656,17 @@ func (d *DB) CountOpenIssuesForRepo(ctx context.Context, repoID int64) (int, err
 
 func (d *DB) GetHTTPEtag(
 	ctx context.Context,
-	platform, platformHost, owner, name, resourceType string,
+	repoID int64,
+	resourceType string,
 	resourceNumber int,
 ) (string, error) {
-	platformHost, owner, name = canonicalRepoLookupIdentifier(platformHost, owner, name)
 	var etag string
 	err := d.ro.QueryRowContext(ctx,
 		`SELECT etag FROM forge_http_etags
-		WHERE platform = ?
-		  AND platform_host = ?
-		  AND owner_key = ?
-		  AND name_key = ?
+		WHERE repo_id = ?
 		  AND resource_type = ?
 		  AND resource_number = ?`,
-		platform, platformHost, owner, name, resourceType, resourceNumber,
+		repoID, resourceType, resourceNumber,
 	).Scan(&etag)
 	if errors.Is(err, sql.ErrNoRows) {
 		return "", nil
@@ -4183,27 +3679,23 @@ func (d *DB) GetHTTPEtag(
 
 func (d *DB) UpsertHTTPEtag(
 	ctx context.Context,
-	platform, platformHost, owner, name, resourceType string,
+	repoID int64,
+	resourceType string,
 	resourceNumber int,
 	etag string,
 ) error {
 	if etag == "" {
 		return nil
 	}
-	platformHost, owner, name = canonicalRepoLookupIdentifier(platformHost, owner, name)
 	_, err := d.rw.ExecContext(ctx,
 		`INSERT INTO forge_http_etags (
-			platform, platform_host, owner_key, name_key,
-			resource_type, resource_number, etag, fetched_at
+			repo_id, resource_type, resource_number, etag, fetched_at
 		)
-		VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))
-		ON CONFLICT (
-			platform, platform_host, owner_key, name_key,
-			resource_type, resource_number
-		) DO UPDATE SET
+		VALUES (?, ?, ?, ?, datetime('now'))
+		ON CONFLICT (repo_id, resource_type, resource_number) DO UPDATE SET
 			etag = excluded.etag,
 			fetched_at = excluded.fetched_at`,
-		platform, platformHost, owner, name, resourceType, resourceNumber, etag,
+		repoID, resourceType, resourceNumber, etag,
 	)
 	if err != nil {
 		return fmt.Errorf("upsert http etag: %w", err)
@@ -4495,6 +3987,7 @@ func (d *DB) ListCommentAutocompleteUsers(
 			SELECT id
 			FROM forge_repos
 			WHERE platform = ? AND platform_host = ? AND owner_key = ? AND name_key = ?
+			  AND retired_at IS NULL
 		), candidates AS (
 			SELECT mr.author AS login, mr.last_activity_at AS last_seen
 			FROM forge_merge_requests mr
@@ -4572,6 +4065,7 @@ func (d *DB) ListCommentAutocompleteReferences(
 			SELECT id
 			FROM forge_repos
 			WHERE platform = ? AND platform_host = ? AND owner_key = ? AND name_key = ?
+			  AND retired_at IS NULL
 		), candidates AS (
 			SELECT 'pull' AS kind, mr.number, mr.title, mr.state, mr.last_activity_at
 			FROM forge_merge_requests mr
@@ -4898,31 +4392,64 @@ func canonicalWorkspacePlatform(provider string) string {
 	return provider
 }
 
-func (d *DB) canonicalizeWorkspaceRepo(
+func canonicalizeWorkspaceRepo(
 	ctx context.Context,
+	queryer interface {
+		QueryRowContext(context.Context, string, ...any) *sql.Row
+	},
+	expectedRepoID *int64,
 	provider, platformHost, owner, name string,
-) (string, string, string, string, string, string, string, error) {
+) (*int64, string, string, string, string, string, string, string, error) {
 	provider = strings.ToLower(strings.TrimSpace(provider))
 	host, ownerKey, nameKey := canonicalRepoLookupIdentifier(platformHost, owner, name)
 	pathKey := ownerKey + "/" + nameKey
 
+	var matchedRepoID int64
 	var matchedProvider, displayOwner, displayName, repoOwnerKey, repoNameKey, repoPathKey string
-	err := d.ro.QueryRowContext(ctx, `
-		SELECT platform, owner, name, owner_key, name_key, repo_path_key
-		FROM forge_repos
-		WHERE platform_host = ? AND repo_path_key = ?
-		  AND (? = '' OR platform = ?)
-		ORDER BY CASE WHEN platform <> 'github' THEN 0 ELSE 1 END, id
-		LIMIT 1`,
-		host, pathKey, provider, provider,
-	).Scan(&matchedProvider, &displayOwner, &displayName, &repoOwnerKey, &repoNameKey, &repoPathKey)
+	var row *sql.Row
+	if expectedRepoID != nil {
+		row = queryer.QueryRowContext(ctx, `
+			SELECT id, platform, owner, name, owner_key, name_key, repo_path_key
+			FROM forge_repos
+			WHERE id = ? AND retired_at IS NULL`,
+			*expectedRepoID,
+		)
+	} else {
+		row = queryer.QueryRowContext(ctx, `
+			SELECT id, platform, owner, name, owner_key, name_key, repo_path_key
+			FROM forge_repos
+			WHERE platform_host = ? AND repo_path_key = ?
+			  AND retired_at IS NULL
+			  AND (? = '' OR platform = ?)
+			ORDER BY CASE WHEN platform <> 'github' THEN 0 ELSE 1 END, id
+			LIMIT 1`,
+			host, pathKey, provider, provider,
+		)
+	}
+	err := row.Scan(
+		&matchedRepoID,
+		&matchedProvider,
+		&displayOwner,
+		&displayName,
+		&repoOwnerKey,
+		&repoNameKey,
+		&repoPathKey,
+	)
 	if errors.Is(err, sql.ErrNoRows) {
-		return canonicalWorkspacePlatform(provider), host, ownerKey, nameKey, ownerKey, nameKey, pathKey, nil
+		if expectedRepoID != nil {
+			return nil, "", "", "", "", "", "", "", ErrRepositoryRetired
+		}
+		return nil, canonicalWorkspacePlatform(provider), host, ownerKey, nameKey,
+			ownerKey, nameKey, pathKey, nil
 	}
 	if err != nil {
-		return "", "", "", "", "", "", "", fmt.Errorf("lookup workspace repo identity: %w", err)
+		return nil, "", "", "", "", "", "", "", fmt.Errorf(
+			"lookup workspace repo identity: %w",
+			err,
+		)
 	}
-	return matchedProvider, host, displayOwner, displayName, repoOwnerKey, repoNameKey, repoPathKey, nil
+	return &matchedRepoID, matchedProvider, host, displayOwner, displayName,
+		repoOwnerKey, repoNameKey, repoPathKey, nil
 }
 
 func workspaceItemKeyForInsert(ws *Workspace) (string, error) {
@@ -4965,7 +4492,9 @@ func scanWorkspace(scanner interface{ Scan(...any) error }) (*Workspace, error) 
 	var ws Workspace
 	var kataMetadataJSON string
 	err := scanner.Scan(
-		&ws.ID, &ws.Platform, &ws.PlatformHost, &ws.RepoOwner, &ws.RepoName,
+		&ws.ID, &ws.RepoID,
+		&ws.Platform, &ws.PlatformHost, &ws.RepoOwner, &ws.RepoName,
+		&ws.LegacyCloneOwner, &ws.LegacyCloneName,
 		&ws.ItemType, &ws.ItemNumber, &ws.ItemKey, &ws.AssociatedPRNumber,
 		&ws.GitHeadRef, &ws.MRHeadRepo, &ws.WorkspaceBranch,
 		&ws.WorktreePath, &ws.TmuxSession, &ws.TerminalBackend, &ws.Status,
@@ -4992,11 +4521,20 @@ func scanWorkspace(scanner interface{ Scan(...any) error }) (*Workspace, error) 
 func (d *DB) InsertWorkspace(
 	ctx context.Context, ws *Workspace,
 ) error {
+	tx, err := d.rw.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin insert workspace: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+
 	var repoOwnerKey, repoNameKey, repoPathKey string
-	var err error
-	ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
-		repoOwnerKey, repoNameKey, repoPathKey, err = d.canonicalizeWorkspaceRepo(
+	ws.RepoID, ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
+		repoOwnerKey, repoNameKey, repoPathKey, err = canonicalizeWorkspaceRepo(
 		ctx,
+		tx,
+		ws.RepoID,
 		ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
 	)
 	if err != nil {
@@ -5013,16 +4551,16 @@ func (d *DB) InsertWorkspace(
 	if err != nil {
 		return fmt.Errorf("encode workspace kata metadata: %w", err)
 	}
-	_, err = d.rw.ExecContext(ctx, `
+	_, err = tx.ExecContext(ctx, `
 		INSERT INTO forge_workspaces
-		    (id, platform, platform_host, repo_owner, repo_name,
+		    (id, repo_id, platform, platform_host, repo_owner, repo_name,
 		     repo_owner_key, repo_name_key, repo_path_key,
 		     item_type, item_number, item_key, associated_pr_number,
 		     git_head_ref, mr_head_repo, workspace_branch,
 		     worktree_path, tmux_session, terminal_backend, status,
 		     error_message, kata_metadata)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		ws.ID, ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		ws.ID, ws.RepoID, ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
 		repoOwnerKey, repoNameKey, repoPathKey,
 		ws.ItemType, ws.ItemNumber, itemKey, ws.AssociatedPRNumber,
 		ws.GitHeadRef, ws.MRHeadRepo, ws.WorkspaceBranch,
@@ -5031,6 +4569,9 @@ func (d *DB) InsertWorkspace(
 	)
 	if err != nil {
 		return fmt.Errorf("insert workspace: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit insert workspace: %w", err)
 	}
 	ws.ItemKey = itemKey
 	return nil
@@ -5041,7 +4582,9 @@ func (d *DB) GetWorkspace(
 	ctx context.Context, id string,
 ) (*Workspace, error) {
 	ws, err := scanWorkspace(d.ro.QueryRowContext(ctx, `
-		SELECT id, platform, platform_host, repo_owner, repo_name,
+		SELECT id, repo_id, platform, platform_host, repo_owner, repo_name,
+		       COALESCE(legacy_clone_owner, ''),
+		       COALESCE(legacy_clone_name, ''),
 		       item_type, item_number, item_key, associated_pr_number,
 		       git_head_ref, mr_head_repo, workspace_branch,
 		       worktree_path, tmux_session, terminal_backend, status,
@@ -5087,15 +4630,21 @@ func (d *DB) getWorkspaceByMR(
 	provider = strings.ToLower(strings.TrimSpace(provider))
 	platformHost, owner, name = canonicalRepoLookupIdentifier(platformHost, owner, name)
 	ws, err := scanWorkspace(d.ro.QueryRowContext(ctx, `
-		SELECT id, platform, platform_host, repo_owner, repo_name,
-		       item_type, item_number, item_key, associated_pr_number,
-		       git_head_ref, mr_head_repo, workspace_branch,
-		       worktree_path, tmux_session, terminal_backend, status,
-		       error_message, created_at, kata_metadata
-			FROM forge_workspaces
-			WHERE platform_host = ? AND repo_owner_key = ?
-			  AND repo_name_key = ? AND item_type = ? AND item_number = ?
-			  AND (? = '' OR platform = ?)`,
+		SELECT w.id, w.repo_id, w.platform, w.platform_host,
+		       w.repo_owner, w.repo_name,
+		       COALESCE(w.legacy_clone_owner, ''),
+		       COALESCE(w.legacy_clone_name, ''),
+		       w.item_type, w.item_number, w.item_key,
+		       w.associated_pr_number,
+		       w.git_head_ref, w.mr_head_repo, w.workspace_branch,
+		       w.worktree_path, w.tmux_session, w.terminal_backend,
+		       w.status, w.error_message, w.created_at, w.kata_metadata
+		FROM forge_workspaces AS w
+		JOIN forge_repos AS r ON r.id = w.repo_id
+		WHERE r.platform_host = ? AND r.owner_key = ?
+		  AND r.name_key = ? AND w.item_type = ? AND w.item_number = ?
+		  AND r.retired_at IS NULL
+		  AND (? = '' OR r.platform = ?)`,
 		platformHost, owner, name, WorkspaceItemTypePullRequest, mrNumber,
 		provider, provider,
 	))
@@ -5138,15 +4687,21 @@ func (d *DB) getWorkspaceByIssue(
 	provider = strings.ToLower(strings.TrimSpace(provider))
 	platformHost, owner, name = canonicalRepoLookupIdentifier(platformHost, owner, name)
 	ws, err := scanWorkspace(d.ro.QueryRowContext(ctx, `
-		SELECT id, platform, platform_host, repo_owner, repo_name,
-		       item_type, item_number, item_key, associated_pr_number,
-		       git_head_ref, mr_head_repo, workspace_branch,
-		       worktree_path, tmux_session, terminal_backend, status,
-		       error_message, created_at, kata_metadata
-		FROM forge_workspaces
-		WHERE platform_host = ? AND repo_owner_key = ?
-		  AND repo_name_key = ? AND item_type = ? AND item_number = ?
-		  AND (? = '' OR platform = ?)`,
+		SELECT w.id, w.repo_id, w.platform, w.platform_host,
+		       w.repo_owner, w.repo_name,
+		       COALESCE(w.legacy_clone_owner, ''),
+		       COALESCE(w.legacy_clone_name, ''),
+		       w.item_type, w.item_number, w.item_key,
+		       w.associated_pr_number,
+		       w.git_head_ref, w.mr_head_repo, w.workspace_branch,
+		       w.worktree_path, w.tmux_session, w.terminal_backend,
+		       w.status, w.error_message, w.created_at, w.kata_metadata
+		FROM forge_workspaces AS w
+		JOIN forge_repos AS r ON r.id = w.repo_id
+		WHERE r.platform_host = ? AND r.owner_key = ?
+		  AND r.name_key = ? AND w.item_type = ? AND w.item_number = ?
+		  AND r.retired_at IS NULL
+		  AND (? = '' OR r.platform = ?)`,
 		platformHost, owner, name, WorkspaceItemTypeIssue, issueNumber,
 		provider, provider,
 	))
@@ -5171,15 +4726,21 @@ func (d *DB) GetWorkspaceByItemKeyForProvider(
 	}
 	platformHost, owner, name = canonicalRepoLookupIdentifier(platformHost, owner, name)
 	ws, err := scanWorkspace(d.ro.QueryRowContext(ctx, `
-		SELECT id, platform, platform_host, repo_owner, repo_name,
-		       item_type, item_number, item_key, associated_pr_number,
-		       git_head_ref, mr_head_repo, workspace_branch,
-		       worktree_path, tmux_session, terminal_backend, status,
-		       error_message, created_at, kata_metadata
-		FROM forge_workspaces
-		WHERE platform_host = ? AND repo_owner_key = ?
-		  AND repo_name_key = ? AND item_type = ? AND item_key = ?
-		  AND (? = '' OR platform = ?)`,
+		SELECT w.id, w.repo_id, w.platform, w.platform_host,
+		       w.repo_owner, w.repo_name,
+		       COALESCE(w.legacy_clone_owner, ''),
+		       COALESCE(w.legacy_clone_name, ''),
+		       w.item_type, w.item_number, w.item_key,
+		       w.associated_pr_number,
+		       w.git_head_ref, w.mr_head_repo, w.workspace_branch,
+		       w.worktree_path, w.tmux_session, w.terminal_backend,
+		       w.status, w.error_message, w.created_at, w.kata_metadata
+		FROM forge_workspaces AS w
+		JOIN forge_repos AS r ON r.id = w.repo_id
+		WHERE r.platform_host = ? AND r.owner_key = ?
+		  AND r.name_key = ? AND w.item_type = ? AND w.item_key = ?
+		  AND r.retired_at IS NULL
+		  AND (? = '' OR r.platform = ?)`,
 		platformHost, owner, name, itemType, itemKey, provider, provider,
 	))
 	if errors.Is(err, sql.ErrNoRows) {
@@ -5197,13 +4758,18 @@ func (d *DB) ListWorkspaces(
 	ctx context.Context,
 ) ([]Workspace, error) {
 	rows, err := d.ro.QueryContext(ctx, `
-		SELECT id, platform, platform_host, repo_owner, repo_name,
+		SELECT w.id, w.repo_id, w.platform, w.platform_host,
+		       w.repo_owner, w.repo_name,
+		       COALESCE(w.legacy_clone_owner, ''),
+		       COALESCE(w.legacy_clone_name, ''),
 		       item_type, item_number, item_key, associated_pr_number,
 		       git_head_ref, mr_head_repo, workspace_branch,
 		       worktree_path, tmux_session, terminal_backend, status,
-		       error_message, created_at, kata_metadata
-		FROM forge_workspaces
-		ORDER BY created_at DESC`,
+		       error_message, w.created_at, kata_metadata
+		FROM forge_workspaces AS w
+		LEFT JOIN forge_repos AS r ON r.id = w.repo_id
+		WHERE w.repo_id IS NULL OR r.retired_at IS NULL
+		ORDER BY w.created_at DESC`,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("list workspaces: %w", err)
@@ -5426,7 +4992,15 @@ func (d *DB) StartWorkspaceRetry(
 		UPDATE forge_workspaces
 		SET status = 'creating',
 		    error_message = NULL
-		WHERE id = ? AND status = 'error'`, id,
+		WHERE id = ? AND status = 'error'
+		  AND (
+		      repo_id IS NULL OR EXISTS (
+		          SELECT 1
+		          FROM forge_repos r
+		          WHERE r.id = forge_workspaces.repo_id
+		            AND r.retired_at IS NULL
+		      )
+		  )`, id,
 	)
 	if err != nil {
 		return false, fmt.Errorf("start workspace retry: %w", err)
@@ -5437,7 +5011,25 @@ func (d *DB) StartWorkspaceRetry(
 			"start workspace retry rows affected: %w", err,
 		)
 	}
-	return affected == 1, nil
+	if affected == 1 {
+		return true, nil
+	}
+	var retired bool
+	if err := d.ro.QueryRowContext(ctx, `
+		SELECT EXISTS (
+		    SELECT 1
+		    FROM forge_workspaces w
+		    JOIN forge_repos r ON r.id = w.repo_id
+		    WHERE w.id = ? AND r.retired_at IS NOT NULL
+		)`,
+		id,
+	).Scan(&retired); err != nil {
+		return false, fmt.Errorf("check workspace repository retirement: %w", err)
+	}
+	if retired {
+		return false, ErrRepositoryRetired
+	}
+	return false, nil
 }
 
 // SetWorkspaceAssociatedPRNumberIfNull stores a workspace's first detected
@@ -5751,7 +5343,8 @@ func (d *DB) DeleteWorkspace(
 // workspaceSummaryColumns is the SELECT list shared by
 // ListWorkspaceSummaries and GetWorkspaceSummary.
 const workspaceSummaryColumns = `
-	w.id, w.platform, w.platform_host, w.repo_owner, w.repo_name,
+	w.id, w.repo_id, w.platform, w.platform_host, w.repo_owner, w.repo_name,
+	COALESCE(w.legacy_clone_owner, ''), COALESCE(w.legacy_clone_name, ''),
 	w.item_type, w.item_number, w.item_key, w.associated_pr_number,
 	w.git_head_ref, w.mr_head_repo, w.workspace_branch,
 	w.worktree_path, w.tmux_session, w.terminal_backend, w.status,
@@ -5781,10 +5374,7 @@ const workspaceSummaryColumns = `
 const workspaceSummaryJoins = `
 	FROM forge_workspaces w
 	LEFT JOIN forge_repos r
-	    ON r.platform = w.platform
-	   AND r.platform_host = w.platform_host
-	   AND r.owner_key = w.repo_owner_key
-	   AND r.name_key = w.repo_name_key
+	    ON r.id = w.repo_id
 	LEFT JOIN forge_merge_requests m
 	    ON m.repo_id = r.id
 	   AND m.number = w.item_number
@@ -5801,7 +5391,9 @@ func scanWorkspaceSummary(
 	var kataMetadataJSON string
 	var itemLastActivityAt sql.NullString
 	err := scanner.Scan(
-		&s.ID, &s.Platform, &s.PlatformHost, &s.RepoOwner, &s.RepoName,
+		&s.ID, &s.RepoID,
+		&s.Platform, &s.PlatformHost, &s.RepoOwner, &s.RepoName,
+		&s.LegacyCloneOwner, &s.LegacyCloneName,
 		&s.ItemType, &s.ItemNumber, &s.ItemKey, &s.AssociatedPRNumber,
 		&s.GitHeadRef, &s.MRHeadRepo, &s.WorkspaceBranch,
 		&s.WorktreePath, &s.TmuxSession, &s.TerminalBackend, &s.Status,
@@ -5851,6 +5443,7 @@ func (d *DB) ListWorkspaceSummaries(
 ) ([]WorkspaceSummary, error) {
 	query := "SELECT " + workspaceSummaryColumns +
 		workspaceSummaryJoins +
+		"\nWHERE w.repo_id IS NULL OR r.retired_at IS NULL" +
 		"\nORDER BY w.created_at DESC"
 	rows, err := d.ro.QueryContext(ctx, query)
 	if err != nil {

--- a/internal/db/queries_activity.go
+++ b/internal/db/queries_activity.go
@@ -142,16 +142,14 @@ func (d *DB) ListActivity(
 			       COALESCE(mr.state, iss.state, '')
 			FROM forge_notification_items n
 			JOIN forge_repos r
-			       ON r.platform = n.platform
-			      AND r.platform_host = n.platform_host
-			      AND r.owner = n.repo_owner
-			      AND r.name = n.repo_name
+			       ON r.id = n.repo_id
 			LEFT JOIN forge_merge_requests mr
 			       ON n.item_type = 'pr' AND mr.repo_id = r.id AND mr.number = n.item_number
 			LEFT JOIN forge_issues iss
 			       ON n.item_type = 'issue' AND iss.repo_id = r.id AND iss.number = n.item_number
 			WHERE n.item_type IN ('pr', 'issue') AND n.item_number IS NOT NULL
-			      AND n.reason != 'author'` + notificationScope
+			      AND n.reason != 'author'
+			      AND r.retired_at IS NULL` + notificationScope
 	}
 
 	query := fmt.Sprintf(`
@@ -182,6 +180,7 @@ func (d *DB) ListActivity(
 			       '' AS subject_state
 			FROM forge_merge_requests p
 			JOIN forge_repos r ON p.repo_id = r.id
+			WHERE r.retired_at IS NULL
 			UNION ALL
 			SELECT 'new_issue', 'issue', i.id,
 			       r.platform, r.platform_host, r.owner, r.name, r.repo_path_key,
@@ -197,6 +196,7 @@ func (d *DB) ListActivity(
 			       ''
 			FROM forge_issues i
 			JOIN forge_repos r ON i.repo_id = r.id
+			WHERE r.retired_at IS NULL
 			UNION ALL
 			SELECT CASE e.event_type
 			           WHEN 'issue_comment' THEN 'comment'
@@ -219,6 +219,7 @@ func (d *DB) ListActivity(
 			JOIN forge_repos r ON p.repo_id = r.id
 			WHERE e.event_type IN (
 				'issue_comment', 'review', 'commit', 'force_push')
+			  AND r.retired_at IS NULL
 			UNION ALL
 			SELECT 'comment', 'ise', e.id,
 			       r.platform, r.platform_host, r.owner, r.name, r.repo_path_key,
@@ -236,6 +237,7 @@ func (d *DB) ListActivity(
 			JOIN forge_issues i ON e.issue_id = i.id
 			JOIN forge_repos r ON i.repo_id = r.id
 			WHERE e.event_type = 'issue_comment'
+			  AND r.retired_at IS NULL
 			UNION ALL
 			SELECT 'default_branch_commit', 'bc', bc.id,
 			       r.platform, r.platform_host, r.owner, r.name, r.repo_path_key,
@@ -253,6 +255,7 @@ func (d *DB) ListActivity(
 			       ''
 			FROM forge_branch_commits bc
 			JOIN forge_repos r ON bc.repo_id = r.id
+			WHERE r.retired_at IS NULL
 			UNION ALL
 			SELECT 'default_branch_force_push', 'bfp', bfp.id,
 			       r.platform, r.platform_host, r.owner, r.name, r.repo_path_key,
@@ -268,6 +271,7 @@ func (d *DB) ListActivity(
 			       ''
 			FROM forge_branch_force_pushes bfp
 			JOIN forge_repos r ON bfp.repo_id = r.id
+			WHERE r.retired_at IS NULL
 			%[3]s
 		) unified
 		%[2]s
@@ -388,7 +392,11 @@ func activityNotificationRepoFilterCondition(filters []NotificationRepoFilter, a
 		if platform == "" || owner == "" || name == "" {
 			continue
 		}
-		groups = append(groups, "(n.platform = ? AND n.platform_host = ? AND n.repo_owner = ? AND n.repo_name = ?)")
+		groups = append(
+			groups,
+			"(r.platform = ? AND r.platform_host = ? AND "+
+				"r.owner_key = ? AND r.name_key = ?)",
+		)
 		*args = append(*args, platform, host, owner, name)
 	}
 	if len(groups) == 0 {

--- a/internal/db/queries_activity_test.go
+++ b/internal/db/queries_activity_test.go
@@ -1272,3 +1272,84 @@ func TestListActivityNotificationRepoFiltersApplyBeforeUnionLimit(t *testing.T) 
 	require.NoError(err)
 	assert.Empty(none)
 }
+
+func TestActivityNotificationRepoFilterFollowsStableRepositoryRename(t *testing.T) {
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	now := baseTime()
+
+	repoID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repository-42",
+		Owner:          "acme",
+		Name:           "legacy-widget",
+	})
+	require.NoError(err)
+	item := notificationFixture("renamed-activity", "mention", now)
+	item.RepoID = &repoID
+	item.RepoName = "legacy-widget"
+	require.NoError(d.UpsertNotifications(ctx, []Notification{item}))
+
+	renamedID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repository-42",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	require.NoError(err)
+	require.Equal(repoID, renamedID)
+
+	items, err := d.ListActivity(ctx, ListActivityOpts{
+		Limit: 50,
+		Types: []string{"notification"},
+		NotificationRepoFilters: []NotificationRepoFilter{{
+			Platform:     "github",
+			PlatformHost: "github.com",
+			RepoOwner:    "acme",
+			RepoName:     "widget",
+		}},
+	})
+	require.NoError(err)
+	require.Len(items, 1)
+	require.Equal("Please review the widget", items[0].ItemTitle)
+}
+
+func TestListActivityHidesRetiredRepositoryIncarnations(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+
+	oldRepoID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repository-old",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	require.NoError(err)
+	insertTestMRWithOptions(t, d, testMR(
+		oldRepoID, 1, withMRTitle("Old repository activity"),
+	))
+
+	newRepoID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repository-new",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	require.NoError(err)
+	insertTestMRWithOptions(t, d, testMR(
+		newRepoID, 2, withMRTitle("New repository activity"),
+	))
+
+	items, err := d.ListActivity(ctx, ListActivityOpts{Limit: 50})
+	require.NoError(err)
+	require.Len(items, 1)
+	assert.Equal(2, items[0].ItemNumber)
+	assert.Equal("New repository activity", items[0].ItemTitle)
+}

--- a/internal/db/queries_archive.go
+++ b/internal/db/queries_archive.go
@@ -694,21 +694,25 @@ func listArchiveRepoStates(
 	repoIDs []int64,
 ) ([]ArchiveRepoState, error) {
 	query := `
-		SELECT repo_id, collection_mode, operator_state,
-			initial_started_at, initial_completed_at,
-			maintenance_watermark, maintenance_succeeded_at,
-			prompt_scan_started_at, prompt_since,
-			issues_coverage, merge_requests_coverage,
-			comments_coverage, reviews_coverage, inline_comments_coverage,
-			last_error_code, last_error_detail, next_retry_at,
-			created_at, updated_at
-		FROM forge_archive_repos`
+		SELECT ar.repo_id, ar.collection_mode, ar.operator_state,
+			ar.initial_started_at, ar.initial_completed_at,
+			ar.maintenance_watermark, ar.maintenance_succeeded_at,
+			ar.prompt_scan_started_at, ar.prompt_since,
+			ar.issues_coverage, ar.merge_requests_coverage,
+			ar.comments_coverage, ar.reviews_coverage,
+			ar.inline_comments_coverage,
+			ar.last_error_code, ar.last_error_detail, ar.next_retry_at,
+			ar.created_at, ar.updated_at
+		FROM forge_archive_repos ar`
 	var args []any
 	if len(repoIDs) > 0 {
-		query += " WHERE repo_id IN (" + sqlPlaceholders(len(repoIDs)) + ")"
+		query += " WHERE ar.repo_id IN (" + sqlPlaceholders(len(repoIDs)) + ")"
 		args = archiveRepoIDArgs(repoIDs)
+	} else {
+		query += ` JOIN forge_repos r ON r.id = ar.repo_id
+			WHERE r.retired_at IS NULL`
 	}
-	query += " ORDER BY repo_id"
+	query += " ORDER BY ar.repo_id"
 	rows, err := queryer.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list archive repo states: %w", err)

--- a/internal/db/queries_archive_report.go
+++ b/internal/db/queries_archive_report.go
@@ -110,7 +110,8 @@ func LoadArchiveReportRepositories(
 		return nil, err
 	}
 	rows, err := tx.QueryContext(ctx, fmt.Sprintf(`
-		SELECT id, platform, platform_host, owner, name, repo_path
+		SELECT id, platform, platform_host,
+			COALESCE(retired_owner, owner), COALESCE(retired_name, name), repo_path
 		FROM forge_repos
 		WHERE id IN (%s)
 		ORDER BY platform, platform_host, owner, name, id`, sqlPlaceholders(len(ids))),
@@ -270,7 +271,9 @@ func archiveReportActivityQuery(
 		WITH scope(repo_id) AS (VALUES %s),
 		bounds(start_at, end_at) AS (VALUES (?, ?)),
 		activity AS (
-			SELECT r.id AS repo_id, r.platform, r.platform_host, r.owner, r.name, r.repo_path,
+			SELECT r.id AS repo_id, r.platform, r.platform_host,
+				COALESCE(r.retired_owner, r.owner) AS owner,
+				COALESCE(r.retired_name, r.name) AS name, r.repo_path,
 				'issue' AS kind, i.number AS item_number,
 				COALESCE(NULLIF(i.platform_external_id, ''), 'issue:number:' || i.number) AS provider_external_id,
 				i.title, i.author, '' AS actor, i.created_at AS occurred_at, i.body, i.url,
@@ -283,7 +286,8 @@ func archiveReportActivityQuery(
 			CROSS JOIN bounds b
 			WHERE i.created_at >= b.start_at AND i.created_at < b.end_at
 			UNION ALL
-			SELECT r.id, r.platform, r.platform_host, r.owner, r.name, r.repo_path,
+			SELECT r.id, r.platform, r.platform_host,
+				COALESCE(r.retired_owner, r.owner), COALESCE(r.retired_name, r.name), r.repo_path,
 				'issue_closed', i.number,
 				COALESCE(NULLIF(i.platform_external_id, ''), 'issue:number:' || i.number),
 				i.title, i.author,
@@ -302,7 +306,8 @@ func archiveReportActivityQuery(
 			CROSS JOIN bounds b
 			WHERE i.closed_at >= b.start_at AND i.closed_at < b.end_at
 			UNION ALL
-			SELECT r.id, r.platform, r.platform_host, r.owner, r.name, r.repo_path,
+			SELECT r.id, r.platform, r.platform_host,
+				COALESCE(r.retired_owner, r.owner), COALESCE(r.retired_name, r.name), r.repo_path,
 				'merge_request', mr.number,
 				COALESCE(NULLIF(mr.platform_external_id, ''), 'merge_request:number:' || mr.number),
 				mr.title, mr.author, '', mr.created_at, mr.body, mr.url,
@@ -314,7 +319,8 @@ func archiveReportActivityQuery(
 			CROSS JOIN bounds b
 			WHERE mr.created_at >= b.start_at AND mr.created_at < b.end_at
 			UNION ALL
-			SELECT r.id, r.platform, r.platform_host, r.owner, r.name, r.repo_path,
+			SELECT r.id, r.platform, r.platform_host,
+				COALESCE(r.retired_owner, r.owner), COALESCE(r.retired_name, r.name), r.repo_path,
 				'merge_request_merged', mr.number,
 				COALESCE(NULLIF(mr.platform_external_id, ''), 'merge_request:number:' || mr.number),
 				mr.title, mr.author,
@@ -334,7 +340,8 @@ func archiveReportActivityQuery(
 			CROSS JOIN bounds b
 			WHERE mr.merged_at >= b.start_at AND mr.merged_at < b.end_at
 			UNION ALL
-			SELECT r.id, r.platform, r.platform_host, r.owner, r.name, r.repo_path,
+			SELECT r.id, r.platform, r.platform_host,
+				COALESCE(r.retired_owner, r.owner), COALESCE(r.retired_name, r.name), r.repo_path,
 				'ordinary_comment', i.number,
 				COALESCE(NULLIF(e.platform_external_id, ''), e.dedupe_key),
 				i.title, e.author, '', e.created_at, e.body,
@@ -349,7 +356,8 @@ func archiveReportActivityQuery(
 			WHERE e.event_type = 'issue_comment'
 			  AND e.created_at >= b.start_at AND e.created_at < b.end_at
 			UNION ALL
-			SELECT r.id, r.platform, r.platform_host, r.owner, r.name, r.repo_path,
+			SELECT r.id, r.platform, r.platform_host,
+				COALESCE(r.retired_owner, r.owner), COALESCE(r.retired_name, r.name), r.repo_path,
 				CASE e.event_type
 					WHEN 'issue_comment' THEN 'ordinary_comment'
 					WHEN 'review' THEN 'review'

--- a/internal/db/queries_branch_match.go
+++ b/internal/db/queries_branch_match.go
@@ -38,6 +38,7 @@ func (d *DB) ListWorktreesForBranchMatch(ctx context.Context) ([]WorktreeRepoRef
 		JOIN forge_projects p ON p.id = w.project_id
 		JOIN forge_repos r ON r.id = p.repo_id
 		WHERE w.branch != ''
+		  AND r.retired_at IS NULL
 		  AND w.branch != 'detached'
 		  AND w.branch NOT LIKE 'detached/%'
 		  AND w.is_stale = 0

--- a/internal/db/queries_branch_match_test.go
+++ b/internal/db/queries_branch_match_test.go
@@ -69,6 +69,42 @@ func TestListWorktreesForBranchMatch_ReturnsRepoLinkedWorktrees(t *testing.T) {
 	assert.Equal("widget", ref.Name)
 }
 
+func TestListWorktreesForBranchMatchExcludesRetiredRepository(t *testing.T) {
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	oldRepoID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repository-old",
+		Owner:          "acme",
+		Name:           "widget",
+		RepoPath:       "acme/widget",
+	})
+	require.NoError(err)
+	project := createLinkedProject(t, d, "linked", oldRepoID)
+	_, err = d.CreateProjectWorktree(ctx, CreateProjectWorktreeInput{
+		ProjectID: project.ID,
+		Branch:    "feature",
+		Path:      filepath.Join(t.TempDir(), "wt-feature"),
+	})
+	require.NoError(err)
+
+	_, err = d.UpsertRepoByProviderID(ctx, RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repository-replacement",
+		Owner:          "acme",
+		Name:           "widget",
+		RepoPath:       "acme/widget",
+	})
+	require.NoError(err)
+
+	refs, err := d.ListWorktreesForBranchMatch(ctx)
+	require.NoError(err)
+	assert.Empty(t, refs)
+}
+
 // TestListWorktreeLinkPRs_JoinsLinkedMergeRequestDisplayFields verifies the
 // snapshot-side read returns each worktree link joined to its merge request's
 // display fields, keyed by the worktree key the snapshot overlays onto

--- a/internal/db/queries_notifications.go
+++ b/internal/db/queries_notifications.go
@@ -860,8 +860,7 @@ func (d *DB) ReopenNotificationAckPropagation(ctx context.Context, id int64, que
 // NotificationRepoRef identifies one repository whose queued acknowledgements
 // share a credential.
 type NotificationRepoRef struct {
-	Owner string
-	Name  string
+	RepoID int64
 }
 
 // DeferQueuedNotificationAcksForRepos defers queued acknowledgements for the
@@ -889,8 +888,8 @@ func (d *DB) DeferQueuedNotificationAcksForRepos(
 	args := []any{errText, now, nextAttemptAt, nextAttemptAt, platform, host}
 	placeholders := make([]string, 0, len(repos))
 	for _, repo := range repos {
-		placeholders = append(placeholders, "(LOWER(?), LOWER(?))")
-		args = append(args, repo.Owner, repo.Name)
+		placeholders = append(placeholders, "?")
+		args = append(args, repo.RepoID)
 	}
 	_, err = d.rw.ExecContext(ctx, `UPDATE forge_notification_items
 		SET source_ack_error = ?, source_ack_last_attempt_at = ?,
@@ -903,7 +902,7 @@ func (d *DB) DeferQueuedNotificationAcksForRepos(
 		  AND source_ack_queued_at IS NOT NULL
 		  AND source_ack_synced_at IS NULL
 		  AND source_ack_error != 'max_attempts_exceeded'
-		  AND (LOWER(repo_owner), LOWER(repo_name)) IN (`+
+		  AND repo_id IN (`+
 		strings.Join(placeholders, ", ")+`)`, args...)
 	if err != nil {
 		return fmt.Errorf("defer queued notification acks for repos: %w", err)

--- a/internal/db/queries_notifications.go
+++ b/internal/db/queries_notifications.go
@@ -367,7 +367,11 @@ func lookupNotificationRepoIDTx(ctx context.Context, tx *sql.Tx, platform, host,
 	var id int64
 	err := tx.QueryRowContext(ctx, `
 		SELECT id FROM forge_repos
-		WHERE platform = ? AND platform_host = ? AND owner = ? AND name = ?`, platform, host, owner, name).Scan(&id)
+		WHERE platform = ? AND platform_host = ?
+		  AND owner_key = ? AND name_key = ?
+		  AND retired_at IS NULL`,
+		platform, host, owner, name,
+	).Scan(&id)
 	if err == nil {
 		return id, true, nil
 	}
@@ -378,7 +382,11 @@ func lookupNotificationRepoIDTx(ctx context.Context, tx *sql.Tx, platform, host,
 }
 
 func notificationWhere(opts ListNotificationsOpts) (string, []any, error) {
-	clauses := []string{}
+	clauses := []string{`EXISTS (
+		SELECT 1 FROM forge_repos active_repo
+		WHERE active_repo.id = n.repo_id
+		  AND active_repo.retired_at IS NULL
+	)`}
 	args := []any{}
 	if len(opts.Repos) > 0 {
 		repoClauses := make([]string, 0, len(opts.Repos))
@@ -397,7 +405,15 @@ func notificationWhere(opts ListNotificationsOpts) (string, []any, error) {
 				continue
 			}
 			seen[key] = struct{}{}
-			repoClauses = append(repoClauses, "(n.platform = ? AND n.platform_host = ? AND n.repo_owner = ? AND n.repo_name = ?)")
+			repoClauses = append(repoClauses, `n.repo_id IN (
+				SELECT filtered_repo.id
+				FROM forge_repos filtered_repo
+				WHERE filtered_repo.platform = ?
+				  AND filtered_repo.platform_host = ?
+				  AND filtered_repo.owner_key = ?
+				  AND filtered_repo.name_key = ?
+				  AND filtered_repo.retired_at IS NULL
+			)`)
 			args = append(args, platform, host, owner, name)
 		}
 		if len(repoClauses) == 0 {
@@ -405,14 +421,6 @@ func notificationWhere(opts ListNotificationsOpts) (string, []any, error) {
 		} else {
 			clauses = append(clauses, "("+strings.Join(repoClauses, " OR ")+")")
 		}
-	} else {
-		clauses = append(clauses, `EXISTS (
-			SELECT 1 FROM forge_repos r
-			WHERE r.platform = n.platform
-			  AND r.platform_host = n.platform_host
-			  AND r.owner = n.repo_owner
-			  AND r.name = n.repo_name
-		)`)
 	}
 	if opts.Platform != "" {
 		platform, err := canonicalizeRequiredNotificationPlatform(opts.Platform)
@@ -664,42 +672,25 @@ func scanReturnedNotificationIDs(rows *sql.Rows, action string) ([]int64, error)
 	return ids, nil
 }
 
-func canonicalizeNotificationRepo(owner, name string) (string, string, error) {
-	owner = strings.ToLower(strings.TrimSpace(owner))
-	name = strings.ToLower(strings.TrimSpace(name))
-	if owner == "" || name == "" {
-		return "", "", fmt.Errorf("notification sync watermark requires repository owner and name")
-	}
-	return owner, name, nil
-}
-
-func (d *DB) GetNotificationSyncWatermark(ctx context.Context, platform, host, owner, name string) (*NotificationSyncWatermark, error) {
-	var err error
-	platform, host, err = canonicalizeNotificationPlatformHost(platform, host)
-	if err != nil {
-		return nil, err
-	}
-	owner, name, err = canonicalizeNotificationRepo(owner, name)
-	if err != nil {
-		return nil, err
-	}
+func (d *DB) GetNotificationSyncWatermark(
+	ctx context.Context,
+	repoID int64,
+) (*NotificationSyncWatermark, error) {
 	var rawLastSuccessful string
 	var rawLastFull sql.NullString
-	err = d.ro.QueryRowContext(ctx, `
+	err := d.ro.QueryRowContext(ctx, `
 		SELECT last_successful_sync_at, last_full_sync_at
 		FROM forge_notification_sync_watermarks
-		WHERE platform = ? AND platform_host = ? AND repo_owner = ? AND repo_name = ?`,
-		platform, host, owner, name).Scan(&rawLastSuccessful, &rawLastFull)
+		WHERE repo_id = ?`,
+		repoID,
+	).Scan(&rawLastSuccessful, &rawLastFull)
 	if err == nil {
 		lastSuccessful, parseErr := parseDBTime(rawLastSuccessful)
 		if parseErr != nil {
 			return nil, fmt.Errorf("parse notification sync watermark: %w", parseErr)
 		}
 		state := NotificationSyncWatermark{
-			Platform:             platform,
-			PlatformHost:         host,
-			RepoOwner:            owner,
-			RepoName:             name,
+			RepoID:               repoID,
 			LastSuccessfulSyncAt: canonicalUTCTime(lastSuccessful),
 		}
 		if rawLastFull.Valid && rawLastFull.String != "" {
@@ -718,25 +709,23 @@ func (d *DB) GetNotificationSyncWatermark(ctx context.Context, platform, host, o
 	return nil, fmt.Errorf("get notification sync watermark: %w", err)
 }
 
-func (d *DB) UpdateNotificationSyncWatermark(ctx context.Context, platform, host, owner, name string, syncedAt time.Time, lastFullSyncedAt *time.Time) error {
-	var err error
-	platform, host, err = canonicalizeNotificationPlatformHost(platform, host)
-	if err != nil {
-		return err
-	}
-	owner, name, err = canonicalizeNotificationRepo(owner, name)
-	if err != nil {
-		return err
-	}
+func (d *DB) UpdateNotificationSyncWatermark(
+	ctx context.Context,
+	repoID int64,
+	syncedAt time.Time,
+	lastFullSyncedAt *time.Time,
+) error {
 	syncedAt = canonicalUTCTime(syncedAt)
 	lastFullValue := nullableNotificationTime(lastFullSyncedAt)
-	_, err = d.rw.ExecContext(ctx, `
-		INSERT INTO forge_notification_sync_watermarks (platform, platform_host, repo_owner, repo_name, last_successful_sync_at, last_full_sync_at)
-		VALUES (?, ?, ?, ?, ?, ?)
-		ON CONFLICT(platform, platform_host, repo_owner, repo_name) DO UPDATE SET
+	_, err := d.rw.ExecContext(ctx, `
+		INSERT INTO forge_notification_sync_watermarks (
+			repo_id, last_successful_sync_at, last_full_sync_at
+		)
+		VALUES (?, ?, ?)
+		ON CONFLICT(repo_id) DO UPDATE SET
 			last_successful_sync_at = excluded.last_successful_sync_at,
 			last_full_sync_at = excluded.last_full_sync_at`,
-		platform, host, owner, name, syncedAt, lastFullValue)
+		repoID, syncedAt, lastFullValue)
 	if err != nil {
 		return fmt.Errorf("update notification sync watermark: %w", err)
 	}
@@ -775,6 +764,7 @@ func (d *DB) ListQueuedNotificationAcks(ctx context.Context, platform, host stri
 	}
 	limit = normalizedNotificationLimit(limit)
 	rows, err := d.ro.QueryContext(ctx, fmt.Sprintf(`SELECT %s FROM forge_notification_items n
+		JOIN forge_repos r ON r.id = n.repo_id AND r.retired_at IS NULL
 		WHERE n.platform = ?
 		  AND n.platform_host = ?
 		  AND n.source_ack_queued_at IS NOT NULL
@@ -932,10 +922,8 @@ func (d *DB) MarkClosedLinkedNotificationsDone(ctx context.Context, now time.Tim
 		  AND EXISTS (
 		    SELECT 1 FROM forge_repos r
 		    JOIN forge_merge_requests mr ON mr.repo_id = r.id AND mr.number = forge_notification_items.item_number
-		    WHERE r.platform = forge_notification_items.platform
-		      AND r.platform_host = forge_notification_items.platform_host
-		      AND r.owner = forge_notification_items.repo_owner
-		      AND r.name = forge_notification_items.repo_name
+		    WHERE r.id = forge_notification_items.repo_id
+		      AND r.retired_at IS NULL
 		      AND (mr.state IN ('closed', 'merged') OR mr.merged_at IS NOT NULL OR mr.closed_at IS NOT NULL)
 		  )`, now)
 	if err != nil {
@@ -950,10 +938,8 @@ func (d *DB) MarkClosedLinkedNotificationsDone(ctx context.Context, now time.Tim
 		  AND EXISTS (
 		    SELECT 1 FROM forge_repos r
 		    JOIN forge_issues i ON i.repo_id = r.id AND i.number = forge_notification_items.item_number
-		    WHERE r.platform = forge_notification_items.platform
-		      AND r.platform_host = forge_notification_items.platform_host
-		      AND r.owner = forge_notification_items.repo_owner
-		      AND r.name = forge_notification_items.repo_name
+		    WHERE r.id = forge_notification_items.repo_id
+		      AND r.retired_at IS NULL
 		      AND (i.state = 'closed' OR i.closed_at IS NOT NULL)
 		  )`, now)
 	if err != nil {

--- a/internal/db/queries_notifications_test.go
+++ b/internal/db/queries_notifications_test.go
@@ -519,6 +519,80 @@ func TestNotificationsHideUnmonitoredRepos(t *testing.T) {
 	assert.Zero(summary.Unread)
 }
 
+func TestNotificationRepoFilterFollowsStableRepositoryRename(t *testing.T) {
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	now := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+
+	repoID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repository-42",
+		Owner:          "acme",
+		Name:           "legacy-widget",
+	})
+	require.NoError(err)
+	item := notificationFixture("renamed", "mention", now)
+	item.RepoID = &repoID
+	item.RepoName = "legacy-widget"
+	require.NoError(d.UpsertNotifications(ctx, []Notification{item}))
+
+	renamedID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repository-42",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	require.NoError(err)
+	require.Equal(repoID, renamedID)
+
+	items, err := d.ListNotifications(ctx, ListNotificationsOpts{
+		State: "all",
+		Repos: []NotificationRepoFilter{{
+			Platform:     "github",
+			PlatformHost: "github.com",
+			RepoOwner:    "acme",
+			RepoName:     "widget",
+		}},
+	})
+	require.NoError(err)
+	require.Len(items, 1)
+	require.Equal("renamed", items[0].PlatformNotificationID)
+
+	var owner string
+	var name string
+	require.NoError(d.ReadDB().QueryRowContext(ctx, `
+		SELECT repo_owner, repo_name
+		FROM forge_notification_items
+		WHERE repo_id = ?`,
+		repoID,
+	).Scan(&owner, &name))
+	require.Equal("acme", owner)
+	require.Equal("widget", name)
+
+	pullRequest := testMR(repoID, 7, withMRTitle("renamed pull request"))
+	pullRequest.State = MergeRequestStateClosed
+	pullRequest.ClosedAt = &now
+	_, err = d.UpsertMergeRequest(ctx, pullRequest)
+	require.NoError(err)
+	require.NoError(d.MarkClosedLinkedNotificationsDone(ctx, now))
+
+	items, err = d.ListNotifications(ctx, ListNotificationsOpts{
+		State: "all",
+		Repos: []NotificationRepoFilter{{
+			Platform:     "github",
+			PlatformHost: "github.com",
+			RepoOwner:    "acme",
+			RepoName:     "widget",
+		}},
+	})
+	require.NoError(err)
+	require.Len(items, 1)
+	require.NotNil(items[0].DoneAt)
+}
+
 func TestNotificationSummaryRepoFacetsIncludePlatformHost(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -640,19 +714,7 @@ func TestNotificationPlatformScopedOperationsRejectBlankPlatform(t *testing.T) {
 	d := openTestDB(t)
 	now := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
 
-	_, err := d.GetNotificationSyncWatermark(t.Context(), "", "github.com", "acme", "widget")
-	require.ErrorContains(err, "notification platform is required")
-
-	err = d.UpdateNotificationSyncWatermark(t.Context(), "", "github.com", "acme", "widget", now, nil)
-	require.ErrorContains(err, "notification platform is required")
-
-	_, err = d.GetNotificationSyncWatermark(t.Context(), "github", "github.com", "", "widget")
-	require.ErrorContains(err, "repository owner and name")
-
-	err = d.UpdateNotificationSyncWatermark(t.Context(), "github", "github.com", "acme", "", now, nil)
-	require.ErrorContains(err, "repository owner and name")
-
-	err = d.MarkNotificationsAcknowledged(t.Context(), "", "github.com", []string{"thread-1"}, now)
+	err := d.MarkNotificationsAcknowledged(t.Context(), "", "github.com", []string{"thread-1"}, now)
 	require.ErrorContains(err, "notification platform is required")
 
 	_, err = d.ListQueuedNotificationAcks(t.Context(), "", "github.com", 10, now)
@@ -668,35 +730,109 @@ func TestNotificationPlatformScopedOperationsRejectBlankPlatform(t *testing.T) {
 func TestNotificationSyncWatermarksAreScopedByRepoIdentity(t *testing.T) {
 	require := require.New(t)
 	d := openTestDB(t)
+	ctx := t.Context()
 	now := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
 	full := now.Add(-time.Hour)
 
-	require.NoError(d.UpdateNotificationSyncWatermark(t.Context(), "github", "code.example.com", "acme", "widget", now, &full))
-	require.NoError(d.UpdateNotificationSyncWatermark(t.Context(), "gitlab", "code.example.com", "acme", "widget", now.Add(time.Minute), nil))
-	require.NoError(d.UpdateNotificationSyncWatermark(t.Context(), "github", "code.example.com", "acme", "gadget", now.Add(2*time.Minute), nil))
+	githubID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "code.example.com",
+		PlatformRepoID: "github-widget",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	require.NoError(err)
+	gitlabID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
+		Platform:       "gitlab",
+		PlatformHost:   "code.example.com",
+		PlatformRepoID: "gitlab-widget",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	require.NoError(err)
+	siblingID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "code.example.com",
+		PlatformRepoID: "github-gadget",
+		Owner:          "acme",
+		Name:           "gadget",
+	})
+	require.NoError(err)
+	require.NoError(d.UpdateNotificationSyncWatermark(ctx, githubID, now, &full))
+	require.NoError(d.UpdateNotificationSyncWatermark(ctx, gitlabID, now.Add(time.Minute), nil))
+	require.NoError(d.UpdateNotificationSyncWatermark(ctx, siblingID, now.Add(2*time.Minute), nil))
 
-	githubWatermark, err := d.GetNotificationSyncWatermark(t.Context(), "github", "code.example.com", "Acme", "Widget")
+	githubWatermark, err := d.GetNotificationSyncWatermark(ctx, githubID)
 	require.NoError(err)
 	require.NotNil(githubWatermark)
-	require.Equal("github", githubWatermark.Platform)
-	require.Equal("acme", githubWatermark.RepoOwner)
+	require.Equal(githubID, githubWatermark.RepoID)
 	require.Equal(now, githubWatermark.LastSuccessfulSyncAt)
 	require.NotNil(githubWatermark.LastFullSyncAt)
 
-	gitlabWatermark, err := d.GetNotificationSyncWatermark(t.Context(), "gitlab", "code.example.com", "acme", "widget")
+	gitlabWatermark, err := d.GetNotificationSyncWatermark(ctx, gitlabID)
 	require.NoError(err)
 	require.NotNil(gitlabWatermark)
-	require.Equal("gitlab", gitlabWatermark.Platform)
+	require.Equal(gitlabID, gitlabWatermark.RepoID)
 	require.Equal(now.Add(time.Minute), gitlabWatermark.LastSuccessfulSyncAt)
 
-	siblingWatermark, err := d.GetNotificationSyncWatermark(t.Context(), "github", "code.example.com", "acme", "gadget")
+	siblingWatermark, err := d.GetNotificationSyncWatermark(ctx, siblingID)
 	require.NoError(err)
 	require.NotNil(siblingWatermark)
 	require.Equal(now.Add(2*time.Minute), siblingWatermark.LastSuccessfulSyncAt)
 
-	missing, err := d.GetNotificationSyncWatermark(t.Context(), "github", "code.example.com", "acme", "other")
+	missing, err := d.GetNotificationSyncWatermark(ctx, siblingID+1000)
 	require.NoError(err)
 	require.Nil(missing)
+}
+
+func TestRepositoryReplacementScopesNotificationWatermarkByInternalID(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	now := baseTime()
+
+	oldID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repo-old",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	require.NoError(err)
+	require.NoError(d.UpdateNotificationSyncWatermark(ctx, oldID, now, &now))
+	historicalNotification := notificationFixture("old-thread", "mention", now)
+	historicalNotification.RepoID = &oldID
+	require.NoError(d.UpsertNotifications(
+		ctx,
+		[]Notification{historicalNotification},
+	))
+
+	newID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repo-new",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	require.NoError(err)
+
+	newWatermark, err := d.GetNotificationSyncWatermark(ctx, newID)
+	require.NoError(err)
+	assert.Nil(newWatermark)
+
+	oldWatermark, err := d.GetNotificationSyncWatermark(ctx, oldID)
+	require.NoError(err)
+	require.NotNil(oldWatermark)
+	assert.Equal(oldID, oldWatermark.RepoID)
+	assert.Equal(now.UTC(), oldWatermark.LastSuccessfulSyncAt)
+
+	notifications, err := d.ListNotifications(
+		ctx,
+		ListNotificationsOpts{State: "all"},
+	)
+	require.NoError(err)
+	assert.Empty(notifications)
 }
 
 func TestQueuedNotificationAcksStayWithinPlatformAndHost(t *testing.T) {

--- a/internal/db/queries_notifications_test.go
+++ b/internal/db/queries_notifications_test.go
@@ -722,9 +722,70 @@ func TestNotificationPlatformScopedOperationsRejectBlankPlatform(t *testing.T) {
 
 	err = d.DeferQueuedNotificationAcksForRepos(
 		t.Context(), "", "github.com",
-		[]NotificationRepoRef{{Owner: "acme", Name: "widget"}}, now, "later",
+		[]NotificationRepoRef{{RepoID: 1}}, now, "later",
 	)
 	require.ErrorContains(err, "notification platform is required")
+}
+
+func TestDeferQueuedNotificationAcksFollowsRepositoryIdentityAcrossRouteReuse(
+	t *testing.T,
+) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	now := time.Date(2026, 7, 31, 10, 0, 0, 0, time.UTC)
+	originalID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "repository-original", Owner: "acme", Name: "widget",
+		RepoPath: "acme/widget",
+	})
+	require.NoError(err)
+	original := notificationFixture("original-thread", "mention", now)
+	original.RepoID = &originalID
+	require.NoError(d.UpsertNotifications(ctx, []Notification{original}))
+
+	_, err = d.UpsertRepoByProviderID(ctx, RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "repository-original", Owner: "acme", Name: "renamed-widget",
+		RepoPath: "acme/renamed-widget",
+	})
+	require.NoError(err)
+	replacementID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "repository-replacement", Owner: "acme", Name: "widget",
+		RepoPath: "acme/widget",
+	})
+	require.NoError(err)
+	replacement := notificationFixture("replacement-thread", "mention", now)
+	replacement.RepoID = &replacementID
+	require.NoError(d.UpsertNotifications(ctx, []Notification{replacement}))
+
+	items, err := d.ListNotifications(ctx, ListNotificationsOpts{State: "all"})
+	require.NoError(err)
+	require.Len(items, 2)
+	ids := make([]int64, 0, len(items))
+	for _, item := range items {
+		ids = append(ids, item.ID)
+	}
+	_, err = d.QueueNotificationIDsRead(ctx, ids, now.Add(time.Minute))
+	require.NoError(err)
+	nextAttemptAt := now.Add(time.Hour)
+	require.NoError(d.DeferQueuedNotificationAcksForRepos(
+		ctx, "github", "github.com",
+		[]NotificationRepoRef{{RepoID: originalID}},
+		nextAttemptAt, "rate_limited",
+	))
+
+	items, err = d.ListNotifications(ctx, ListNotificationsOpts{State: "all"})
+	require.NoError(err)
+	require.Len(items, 2)
+	byThread := make(map[string]Notification, len(items))
+	for _, item := range items {
+		byThread[item.PlatformNotificationID] = item
+	}
+	assert.Equal("rate_limited", byThread["original-thread"].SourceAckError)
+	assert.Empty(byThread["replacement-thread"].SourceAckError)
 }
 
 func TestNotificationSyncWatermarksAreScopedByRepoIdentity(t *testing.T) {

--- a/internal/db/queries_projects.go
+++ b/internal/db/queries_projects.go
@@ -131,7 +131,8 @@ const projectSelectColumns = `p.id, p.display_name, p.local_path,
         r.platform, r.platform_host, r.owner, r.name`
 
 const projectFromJoin = `FROM forge_projects p
-        LEFT JOIN forge_repos r ON r.id = p.repo_id`
+        LEFT JOIN forge_repos r ON r.id = p.repo_id
+                                  AND r.retired_at IS NULL`
 
 // GetProjectByID returns one project by its server-assigned id, joining the
 // linked forge_repos row to populate PlatformIdentity when present.

--- a/internal/db/queries_stacks.go
+++ b/internal/db/queries_stacks.go
@@ -115,7 +115,7 @@ func (d *DB) ReplaceStackMembers(ctx context.Context, stackID int64, members []S
 // ListStacksWithMembers returns stacks with repo info and their members.
 // Only stacks that have at least one open member are returned.
 func (d *DB) ListStacksWithMembers(ctx context.Context, repoFilter string) ([]StackWithRepo, map[int64][]StackMemberWithPR, error) {
-	var conds []string
+	conds := []string{"r.retired_at IS NULL"}
 	var args []any
 	if repoFilter != "" {
 		pathKey := canonicalRepoPathKey(repoFilter)
@@ -125,7 +125,9 @@ func (d *DB) ListStacksWithMembers(ctx context.Context, repoFilter string) ([]St
 		if strings.Count(pathKey, "/") > 1 {
 			var exists int
 			err := d.ro.QueryRowContext(ctx,
-				`SELECT 1 FROM forge_repos WHERE repo_path_key = ? LIMIT 1`,
+				`SELECT 1 FROM forge_repos
+				 WHERE repo_path_key = ? AND retired_at IS NULL
+				 LIMIT 1`,
 				pathKey,
 			).Scan(&exists)
 			if errors.Is(err, sql.ErrNoRows) {

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -17,6 +17,7 @@ func TestStartWorkspaceRetryTransitionsOnlyOneConcurrentCaller(t *testing.T) {
 
 	d := openTestDB(t)
 	ctx := t.Context()
+	insertTestRepo(t, d, "acme", "widget")
 	errMsg := "ensure clone failed"
 	ws := &Workspace{
 		ID:              "ws-retry-race",
@@ -111,6 +112,51 @@ func TestStartWorkspaceRetryPreservesBranchUntilCleanupSucceeds(t *testing.T) {
 	assert.Equal("kenn-forge/pr-42", got.WorkspaceBranch)
 }
 
+func TestStartWorkspaceRetryRejectsRetiredRepositoryIncarnation(t *testing.T) {
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+
+	oldRepoID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repository-old",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	require.NoError(err)
+	errMsg := "setup failed"
+	ws := &Workspace{
+		ID:           "retired-workspace-retry",
+		RepoID:       &oldRepoID,
+		Platform:     "github",
+		PlatformHost: "github.com",
+		RepoOwner:    "acme",
+		RepoName:     "widget",
+		ItemType:     WorkspaceItemTypePullRequest,
+		ItemNumber:   42,
+		GitHeadRef:   "feature/old",
+		WorktreePath: "/tmp/retired-workspace-retry",
+		TmuxSession:  "retired-workspace-retry",
+		Status:       "error",
+		ErrorMessage: &errMsg,
+	}
+	require.NoError(d.InsertWorkspace(ctx, ws))
+
+	_, err = d.UpsertRepoByProviderID(ctx, RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repository-new",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	require.NoError(err)
+
+	started, err := d.StartWorkspaceRetry(ctx, ws.ID)
+	require.ErrorIs(err, ErrRepositoryRetired)
+	require.False(started)
+}
+
 func insertTestRepo(t *testing.T, d *DB, owner, name string) int64 {
 	t.Helper()
 	id, err := d.UpsertRepo(t.Context(), GitHubRepoIdentity("github.com", owner, name))
@@ -142,6 +188,32 @@ func TestPurgeOtherHosts(t *testing.T) {
 	gheRepoID := insertTestRepoWithHost(
 		t, d, "corp", "internal", "ghes.company.com",
 	)
+
+	// Insert workspaces linked to both repository identities.
+	require.NoError(d.InsertWorkspace(ctx, &Workspace{
+		ID:           "ws-gh",
+		RepoID:       &ghRepoID,
+		Platform:     "github",
+		PlatformHost: "github.com",
+		RepoOwner:    "acme",
+		RepoName:     "widget",
+		ItemType:     WorkspaceItemTypePullRequest,
+		ItemNumber:   1,
+		WorktreePath: "/tmp/ws-gh",
+		Status:       "ready",
+	}))
+	require.NoError(d.InsertWorkspace(ctx, &Workspace{
+		ID:           "ws-ghe",
+		RepoID:       &gheRepoID,
+		Platform:     "github",
+		PlatformHost: "ghes.company.com",
+		RepoOwner:    "corp",
+		RepoName:     "internal",
+		ItemType:     WorkspaceItemTypePullRequest,
+		ItemNumber:   2,
+		WorktreePath: "/tmp/ws-ghe",
+		Status:       "ready",
+	}))
 
 	// Insert MRs for both hosts.
 	ghMRID := insertTestMR(
@@ -227,6 +299,13 @@ func TestPurgeOtherHosts(t *testing.T) {
 	require.NoError(err)
 	assert.True(starred)
 
+	// github.com workspace should remain.
+	ghWorkspace, err := d.GetWorkspace(ctx, "ws-gh")
+	require.NoError(err)
+	require.NotNil(ghWorkspace)
+	require.NotNil(ghWorkspace.RepoID)
+	assert.Equal(ghRepoID, *ghWorkspace.RepoID)
+
 	// ghes.company.com repo should be gone.
 	var gheCount int
 	err = d.ReadDB().QueryRowContext(ctx,
@@ -253,6 +332,11 @@ func TestPurgeOtherHosts(t *testing.T) {
 	).Scan(&gheEvtCount)
 	require.NoError(err)
 	assert.Equal(0, gheEvtCount)
+
+	// ghes.company.com workspace should be gone.
+	gheWorkspace, err := d.GetWorkspace(ctx, "ws-ghe")
+	require.NoError(err)
+	assert.Nil(gheWorkspace)
 
 	// github.com rate limits should remain.
 	ghRL, err := d.GetRateLimit("github.com", "user:1", "rest")
@@ -1021,9 +1105,95 @@ func TestUpdateRepoProviderMetadataPreservesIdentity(t *testing.T) {
 	assert.Equal("https://github.com/acme/widget.git", repo.CloneURL)
 	assert.Equal("main", repo.DefaultBranch)
 
+	err = d.UpdateRepoProviderMetadata(ctx, repoID, RepoProviderMetadata{
+		PlatformRepoID: "R_456",
+		WebURL:         "https://github.com/acme/replacement",
+		CloneURL:       "https://github.com/acme/replacement.git",
+		DefaultBranch:  "trunk",
+	})
+	require.Error(err)
+	var conflict *RepoIdentityConflictError
+	require.ErrorAs(err, &conflict)
+	assert.Equal(repoID, conflict.ExistingRepoID)
+
+	repo, err = d.GetRepoByID(ctx, repoID)
+	require.NoError(err)
+	require.NotNil(repo)
+	assert.Equal("R_123", repo.PlatformRepoID)
+	assert.Equal("https://github.com/acme/widget", repo.WebURL)
+	assert.Equal("https://github.com/acme/widget.git", repo.CloneURL)
+	assert.Equal("main", repo.DefaultBranch)
+
 	sameID, err := d.UpsertRepo(ctx, GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	assert.Equal(repoID, sameID)
+}
+
+func TestSaveRepoConfiguredRoutePreservesMultipleAliases(t *testing.T) {
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+
+	repoID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "R_stable", Owner: "acme", Name: "current",
+		RepoPath: "acme/current",
+	})
+	require.NoError(err)
+	for _, name := range []string{"legacy-one", "legacy-two"} {
+		require.NoError(d.SaveRepoConfiguredRoute(ctx, repoID, RepoIdentity{
+			Platform: "github", PlatformHost: "github.com",
+			Owner: "acme", Name: name, RepoPath: "acme/" + name,
+		}))
+	}
+
+	for _, name := range []string{"legacy-one", "legacy-two"} {
+		repo, err := d.GetRepoByConfiguredRoute(ctx, RepoIdentity{
+			Platform: "github", PlatformHost: "github.com",
+			Owner: "acme", Name: name, RepoPath: "acme/" + name,
+		})
+		require.NoError(err)
+		require.NotNil(repo)
+		require.Equal(repoID, repo.ID)
+	}
+}
+
+func TestReconcileRepoConfiguredRoutesRemovesStaleAliases(t *testing.T) {
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	repoID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "R_stable", Owner: "acme", Name: "current",
+		RepoPath: "acme/current",
+	})
+	require.NoError(err)
+	for _, name := range []string{"keep", "remove"} {
+		require.NoError(d.SaveRepoConfiguredRoute(ctx, repoID, RepoIdentity{
+			Platform: "github", PlatformHost: "github.com",
+			Owner: "acme", Name: name, RepoPath: "acme/" + name,
+		}))
+	}
+
+	require.NoError(d.ReconcileRepoConfiguredRoutes(ctx, []RepoConfiguredRouteBinding{{
+		RepoID: repoID,
+		Route: RepoIdentity{
+			Platform: "github", PlatformHost: "github.com",
+			Owner: "acme", Name: "keep", RepoPath: "acme/keep",
+		},
+	}}))
+	kept, err := d.GetRepoByConfiguredRoute(ctx, RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		Owner: "acme", Name: "keep", RepoPath: "acme/keep",
+	})
+	require.NoError(err)
+	require.NotNil(kept)
+	removed, err := d.GetRepoByConfiguredRoute(ctx, RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		Owner: "acme", Name: "remove", RepoPath: "acme/remove",
+	})
+	require.NoError(err)
+	require.Nil(removed)
 }
 
 func TestUpsertRepoByProviderIDUpdatesRenamedRepo(t *testing.T) {
@@ -1127,519 +1297,595 @@ func TestUpsertRepoByProviderIDUpdatesRenamedRepoWorkspaces(t *testing.T) {
 	assert.Equal("renamed PR", *summary.MRTitle)
 }
 
-func TestUpsertRepoByProviderIDMergesExistingDestinationPathRow(t *testing.T) {
+func TestUpsertRepoByProviderIDRetiresReplacedIncarnation(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+
+	repoID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repo-old",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	require.NoError(err)
+	insertTestMRWithOptions(t, d, testMR(repoID, 7, withMRTitle("old pull request")))
+	insertTestIssueWithOptions(t, d, testIssue(repoID, 8, withIssueTitle("old issue")))
+
+	replacementID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repo-new",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	require.NoError(err)
+	assert.NotEqual(repoID, replacementID)
+
+	repo, err := d.GetRepoByID(ctx, repoID)
+	require.NoError(err)
+	require.NotNil(repo)
+	assert.Equal("repo-old", repo.PlatformRepoID)
+	assert.Equal("acme/widget", repo.RepoPath)
+	require.NotNil(repo.RetiredAt)
+	require.NotNil(repo.RetiredReplacementID)
+	assert.Equal(replacementID, *repo.RetiredReplacementID)
+
+	replacement, err := d.GetRepoByID(ctx, replacementID)
+	require.NoError(err)
+	require.NotNil(replacement)
+	assert.Equal("repo-new", replacement.PlatformRepoID)
+	assert.Equal("acme/widget", replacement.RepoPath)
+
+	activeRepos, err := d.ListRepos(ctx)
+	require.NoError(err)
+	require.Len(activeRepos, 1)
+	assert.Equal(replacementID, activeRepos[0].ID)
+
+	activeByPath, err := d.GetRepoByIdentity(ctx, RepoIdentity{
+		Platform:     "github",
+		PlatformHost: "github.com",
+		Owner:        "acme",
+		Name:         "widget",
+	})
+	require.NoError(err)
+	require.NotNil(activeByPath)
+	assert.Equal(replacementID, activeByPath.ID)
+
+	var retiredAt sql.NullTime
+	var retiredReplacementID sql.NullInt64
+	require.NoError(d.ReadDB().QueryRowContext(ctx, `
+		SELECT retired_at, retired_replacement_id
+		FROM forge_repos
+		WHERE id = ?`,
+		repoID,
+	).Scan(&retiredAt, &retiredReplacementID))
+	assert.True(retiredAt.Valid)
+	assert.Equal(replacementID, retiredReplacementID.Int64)
+
+	mr, err := d.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
+	require.NoError(err)
+	require.NotNil(mr)
+	assert.Equal("old pull request", mr.Title)
+
+	issue, err := d.GetIssueByRepoIDAndNumber(ctx, repoID, 8)
+	require.NoError(err)
+	require.NotNil(issue)
+	assert.Equal("old issue", issue.Title)
+
+	replacementMR, err := d.GetMergeRequestByRepoIDAndNumber(ctx, replacementID, 7)
+	require.NoError(err)
+	assert.Nil(replacementMR)
+
+	replacementIssue, err := d.GetIssueByRepoIDAndNumber(ctx, replacementID, 8)
+	require.NoError(err)
+	assert.Nil(replacementIssue)
+}
+
+func TestRetiredRepositoryRejectsParentSnapshots(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+
+	retiredID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repo-old",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	require.NoError(err)
+	insertTestMRWithOptions(t, d, testMR(retiredID, 7, withMRTitle("old pull request")))
+	insertTestIssueWithOptions(t, d, testIssue(retiredID, 8, withIssueTitle("old issue")))
+
+	_, err = d.UpsertRepoByProviderID(ctx, RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repo-new",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	require.NoError(err)
+
+	updatedMR := testMR(retiredID, 7, withMRTitle("replacement pull request"))
+	updatedMR.UpdatedAt = updatedMR.UpdatedAt.Add(time.Minute)
+	_, _, _, err = d.UpsertMergeRequestSnapshotWithLabels(ctx, updatedMR)
+	require.ErrorIs(err, ErrRepositoryRetired)
+
+	updatedIssue := testIssue(retiredID, 8, withIssueTitle("replacement issue"))
+	updatedIssue.UpdatedAt = updatedIssue.UpdatedAt.Add(time.Minute)
+	_, _, _, err = d.UpsertIssueSnapshotWithLabels(ctx, updatedIssue)
+	require.ErrorIs(err, ErrRepositoryRetired)
+
+	storedMR, err := d.GetMergeRequestByRepoIDAndNumber(ctx, retiredID, 7)
+	require.NoError(err)
+	require.NotNil(storedMR)
+	assert.Equal("old pull request", storedMR.Title)
+
+	storedIssue, err := d.GetIssueByRepoIDAndNumber(ctx, retiredID, 8)
+	require.NoError(err)
+	require.NotNil(storedIssue)
+	assert.Equal("old issue", storedIssue.Title)
+}
+
+func TestRetiredRepositoryRejectsDirectParentUpserts(t *testing.T) {
+	require := require.New(t)
+	database := openTestDB(t)
+	ctx := t.Context()
+
+	retiredID, err := database.UpsertRepoByProviderID(ctx, RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repo-old",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	require.NoError(err)
+	mr := testMR(retiredID, 7, withMRTitle("old pull request"))
+	mrID, err := database.UpsertMergeRequest(ctx, mr)
+	require.NoError(err)
+	issue := testIssue(retiredID, 8, withIssueTitle("old issue"))
+	issueID, err := database.UpsertIssue(ctx, issue)
+	require.NoError(err)
+	_, err = database.UpsertRepoByProviderID(ctx, RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repo-new",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	require.NoError(err)
+
+	_, err = database.UpsertMergeRequest(
+		ctx,
+		testMR(retiredID, 7, withMRTitle("stale pull request")),
+	)
+	require.ErrorIs(err, ErrRepositoryRetired)
+	_, err = database.UpsertIssue(
+		ctx,
+		testIssue(retiredID, 8, withIssueTitle("stale issue")),
+	)
+	require.ErrorIs(err, ErrRepositoryRetired)
+
+	require.ErrorIs(
+		database.UpdateMergeRequestAssignees(
+			ctx, retiredID, mrID, []string{"alice"},
+		),
+		ErrRepositoryRetired,
+	)
+	require.ErrorIs(
+		database.UpdateMergeRequestReviewers(
+			ctx, retiredID, mrID, []string{"bob"},
+		),
+		ErrRepositoryRetired,
+	)
+	require.ErrorIs(
+		database.UpdateIssueAssignees(
+			ctx, retiredID, issueID, []string{"alice"},
+		),
+		ErrRepositoryRetired,
+	)
+	require.ErrorIs(
+		database.UpdateMRState(
+			ctx, retiredID, 7, "closed", nil, nil,
+		),
+		ErrRepositoryRetired,
+	)
+	require.ErrorIs(
+		database.UpdateIssueState(
+			ctx, retiredID, 8, "closed", nil,
+		),
+		ErrRepositoryRetired,
+	)
+	require.ErrorIs(
+		database.UpdateMRDraftState(ctx, retiredID, 7, true),
+		ErrRepositoryRetired,
+	)
+	require.ErrorIs(
+		database.ReplaceMergeRequestLabels(ctx, retiredID, mrID, nil),
+		ErrRepositoryRetired,
+	)
+	require.ErrorIs(
+		database.ReplaceIssueLabels(ctx, retiredID, issueID, nil),
+		ErrRepositoryRetired,
+	)
+	require.ErrorIs(
+		database.UpdateMRTitleBody(
+			ctx, retiredID, mrID, "stale", "stale", time.Now().UTC(),
+		),
+		ErrRepositoryRetired,
+	)
+	require.ErrorIs(
+		database.UpdateIssueTitleBody(
+			ctx, retiredID, issueID, "stale", "stale", time.Now().UTC(),
+		),
+		ErrRepositoryRetired,
+	)
+}
+
+func TestRepositoryReplacementScopesWorkspacesByInternalID(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+
+	oldID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repo-old",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	require.NoError(err)
+	require.NoError(d.InsertWorkspace(ctx, &Workspace{
+		ID:           "old-workspace",
+		Platform:     "github",
+		PlatformHost: "github.com",
+		RepoOwner:    "acme",
+		RepoName:     "widget",
+		ItemType:     WorkspaceItemTypePullRequest,
+		ItemNumber:   7,
+		GitHeadRef:   "old-branch",
+		WorktreePath: "/tmp/old-workspace",
+		TmuxSession:  "old-workspace",
+	}))
+
+	newID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repo-new",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	require.NoError(err)
+	require.NoError(d.InsertWorkspace(ctx, &Workspace{
+		ID:           "new-workspace",
+		Platform:     "github",
+		PlatformHost: "github.com",
+		RepoOwner:    "acme",
+		RepoName:     "widget",
+		ItemType:     WorkspaceItemTypePullRequest,
+		ItemNumber:   7,
+		GitHeadRef:   "new-branch",
+		WorktreePath: "/tmp/new-workspace",
+		TmuxSession:  "new-workspace",
+	}))
+
+	oldWorkspace, err := d.GetWorkspace(ctx, "old-workspace")
+	require.NoError(err)
+	require.NotNil(oldWorkspace)
+	require.NotNil(oldWorkspace.RepoID)
+	assert.Equal(oldID, *oldWorkspace.RepoID)
+
+	activeWorkspace, err := d.GetWorkspaceByMRForProvider(
+		ctx,
+		"github",
+		"github.com",
+		"acme",
+		"widget",
+		7,
+	)
+	require.NoError(err)
+	require.NotNil(activeWorkspace)
+	require.NotNil(activeWorkspace.RepoID)
+	assert.Equal(newID, *activeWorkspace.RepoID)
+	assert.Equal("new-workspace", activeWorkspace.ID)
+
+	workspaces, err := d.ListWorkspaces(ctx)
+	require.NoError(err)
+	require.Len(workspaces, 1)
+	assert.Equal("new-workspace", workspaces[0].ID)
+
+	summaries, err := d.ListWorkspaceSummaries(ctx)
+	require.NoError(err)
+	require.Len(summaries, 1)
+	assert.Equal("new-workspace", summaries[0].ID)
+	require.NotNil(summaries[0].RepoID)
+	assert.Equal(newID, *summaries[0].RepoID)
+}
+
+func TestInsertWorkspaceRejectsStaleRepositoryIncarnation(t *testing.T) {
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+
+	oldRepoID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repository-old",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	require.NoError(err)
+
+	newRepoID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repository-new",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	require.NoError(err)
+	require.NotEqual(oldRepoID, newRepoID)
+
+	ws := &Workspace{
+		ID:           "stale-incarnation-workspace",
+		RepoID:       &oldRepoID,
+		Platform:     "github",
+		PlatformHost: "github.com",
+		RepoOwner:    "acme",
+		RepoName:     "widget",
+		ItemType:     WorkspaceItemTypePullRequest,
+		ItemNumber:   42,
+		GitHeadRef:   "feature/stale",
+		WorktreePath: "/tmp/stale-incarnation-workspace",
+		TmuxSession:  "stale-incarnation-workspace",
+	}
+	err = d.InsertWorkspace(ctx, ws)
+	require.ErrorIs(err, ErrRepositoryRetired)
+
+	stored, err := d.GetWorkspace(ctx, ws.ID)
+	require.NoError(err)
+	require.Nil(stored)
+}
+
+func TestRepositoryReplacementScopesHTTPETagsByInternalID(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+
+	oldID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repo-old",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	require.NoError(err)
+	require.NoError(d.UpsertHTTPEtag(
+		ctx,
+		oldID,
+		"pull_request",
+		7,
+		"old-etag",
+	))
+
+	newID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repo-new",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	require.NoError(err)
+
+	newETag, err := d.GetHTTPEtag(ctx, newID, "pull_request", 7)
+	require.NoError(err)
+	assert.Empty(newETag)
+
+	oldETag, err := d.GetHTTPEtag(ctx, oldID, "pull_request", 7)
+	require.NoError(err)
+	assert.Equal("old-etag", oldETag)
+}
+
+func TestUpsertRepoRejectsConflictingStableProviderID(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+
+	repoID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repo-old",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	require.NoError(err)
+
+	_, err = d.UpsertRepo(ctx, RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repo-new",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	require.Error(err)
+	var conflict *RepoIdentityConflictError
+	require.ErrorAs(err, &conflict)
+	assert.Equal(repoID, conflict.ExistingRepoID)
+
+	repo, err := d.GetRepoByID(ctx, repoID)
+	require.NoError(err)
+	require.NotNil(repo)
+	assert.Equal("repo-old", repo.PlatformRepoID)
+}
+
+func TestUpsertRepoByProviderIDRetiresOccupiedRenameDestination(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	d := openTestDB(t)
 	ctx := t.Context()
 
 	sourceID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
-		Platform:       "gitlab",
-		PlatformHost:   "gitlab.com",
-		PlatformRepoID: "gid://gitlab/Project/42",
-		Owner:          "old-group",
-		Name:           "old-name",
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repo-moving",
+		Owner:          "acme",
+		Name:           "legacy-widget",
 	})
 	require.NoError(err)
-	insertTestMRWithOptions(t, d, testMR(sourceID, 7, withMRTitle("source PR")))
+	insertTestMRWithOptions(t, d, testMR(sourceID, 7, withMRTitle("source pull request")))
+	require.NoError(d.InsertWorkspace(ctx, &Workspace{
+		ID:           "source-workspace",
+		RepoID:       &sourceID,
+		Platform:     "github",
+		PlatformHost: "github.com",
+		RepoOwner:    "acme",
+		RepoName:     "legacy-widget",
+		ItemType:     WorkspaceItemTypePullRequest,
+		ItemNumber:   7,
+		GitHeadRef:   "feature/source",
+		WorktreePath: "/tmp/source-workspace",
+		TmuxSession:  "source-workspace",
+	}))
 
-	destinationID, err := d.UpsertRepo(ctx, RepoIdentity{
-		Platform:     "gitlab",
-		PlatformHost: "gitlab.com",
-		Owner:        "new-group",
-		Name:         "new-name",
+	destinationID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repo-occupied",
+		Owner:          "acme",
+		Name:           "widget",
 	})
 	require.NoError(err)
-	assert.NotEqual(sourceID, destinationID)
 	insertTestIssueWithOptions(t, d, testIssue(destinationID, 8, withIssueTitle("destination issue")))
+	require.NoError(d.InsertWorkspace(ctx, &Workspace{
+		ID:           "destination-workspace",
+		RepoID:       &destinationID,
+		Platform:     "github",
+		PlatformHost: "github.com",
+		RepoOwner:    "acme",
+		RepoName:     "widget",
+		ItemType:     WorkspaceItemTypePullRequest,
+		ItemNumber:   7,
+		GitHeadRef:   "feature/destination",
+		WorktreePath: "/tmp/destination-workspace",
+		TmuxSession:  "destination-workspace",
+	}))
 
-	gotID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
-		Platform:       "gitlab",
-		PlatformHost:   "gitlab.com",
-		PlatformRepoID: "gid://gitlab/Project/42",
-		Owner:          "new-group",
-		Name:           "new-name",
+	activeID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repo-moving",
+		Owner:          "acme",
+		Name:           "widget",
 	})
 	require.NoError(err)
-	assert.Equal(destinationID, gotID)
+	assert.Equal(sourceID, activeID)
 
 	repos, err := d.ListRepos(ctx)
 	require.NoError(err)
 	require.Len(repos, 1)
-	assert.Equal(destinationID, repos[0].ID)
-	assert.Equal("gid://gitlab/Project/42", repos[0].PlatformRepoID)
-	assert.Equal("new-group", repos[0].Owner)
-	assert.Equal("new-name", repos[0].Name)
-	assert.Equal("new-group/new-name", repos[0].RepoPath)
+	assert.Equal(sourceID, repos[0].ID)
+	assert.Equal("acme/widget", repos[0].RepoPath)
 
-	sourceAfterMerge, err := d.GetRepoByID(ctx, sourceID)
+	source, err := d.GetRepoByID(ctx, sourceID)
 	require.NoError(err)
-	assert.Nil(sourceAfterMerge)
+	require.NotNil(source)
+	assert.Equal("repo-moving", source.PlatformRepoID)
+	assert.Equal("acme/widget", source.RepoPath)
+	assert.Nil(source.RetiredAt)
 
-	var mergeRequestRepoID int64
-	err = d.ReadDB().QueryRowContext(ctx,
-		`SELECT repo_id FROM forge_merge_requests WHERE number = ?`,
-		7,
-	).Scan(&mergeRequestRepoID)
+	destination, err := d.GetRepoByID(ctx, destinationID)
 	require.NoError(err)
-	assert.Equal(destinationID, mergeRequestRepoID)
-
-	var issueRepoID int64
-	err = d.ReadDB().QueryRowContext(ctx,
-		`SELECT repo_id FROM forge_issues WHERE number = ?`,
-		8,
-	).Scan(&issueRepoID)
-	require.NoError(err)
-	assert.Equal(destinationID, issueRepoID)
-}
-
-func TestUpsertRepoByProviderIDPreservesNewerCollidingMergeRequest(t *testing.T) {
-	assert := assert.New(t)
-	require := require.New(t)
-	d := openTestDB(t)
-	ctx := t.Context()
-	now := baseTime()
-
-	sourceID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
-		Platform:       "gitlab",
-		PlatformHost:   "gitlab.com",
-		PlatformRepoID: "gid://gitlab/Project/42",
-		Owner:          "old-group",
-		Name:           "old-name",
-	})
-	require.NoError(err)
-	source := testMR(
-		sourceID,
-		7,
-		withMRTitle("new provider snapshot"),
-		withMRActivity(now.Add(time.Minute)),
-	)
-	source.PlatformID = 7007
-	source.PlatformExternalID = "gid://gitlab/MergeRequest/7007"
-	source.HeadRepoCloneURL = "https://gitlab.com/old-group/old-name.git"
-	insertTestMRWithOptions(t, d, source)
-
-	destinationID, err := d.UpsertRepo(ctx, RepoIdentity{
-		Platform:     "gitlab",
-		PlatformHost: "gitlab.com",
-		Owner:        "new-group",
-		Name:         "new-name",
-	})
-	require.NoError(err)
-	destination := testMR(
-		destinationID,
-		7,
-		withMRTitle("stale destination snapshot"),
-		withMRActivity(now),
-	)
-	destination.PlatformID = source.PlatformID
-	destination.PlatformExternalID = source.PlatformExternalID
-	destination.HeadRepoCloneURL = "https://gitlab.com/forker/old-name.git"
-	insertTestMRWithOptions(t, d, destination)
+	require.NotNil(destination)
+	assert.Equal("repo-occupied", destination.PlatformRepoID)
+	assert.Equal("acme/widget", destination.RepoPath)
+	require.NotNil(destination.RetiredAt)
+	require.NotNil(destination.RetiredReplacementID)
+	assert.Equal(sourceID, *destination.RetiredReplacementID)
 
 	sourceMR, err := d.GetMergeRequestByRepoIDAndNumber(ctx, sourceID, 7)
 	require.NoError(err)
 	require.NotNil(sourceMR)
-	destinationMR, err := d.GetMergeRequestByRepoIDAndNumber(ctx, destinationID, 7)
+	assert.Equal("source pull request", sourceMR.Title)
+
+	destinationIssue, err := d.GetIssueByRepoIDAndNumber(ctx, destinationID, 8)
 	require.NoError(err)
-	require.NotNil(destinationMR)
-
-	draft, err := d.GetOrCreateMRReviewDraft(ctx, destinationMR.ID)
-	require.NoError(err)
-	require.NotNil(draft)
-	_, err = d.rw.ExecContext(ctx, `
-		UPDATE forge_mr_review_drafts
-		SET body = 'destination draft'
-		WHERE id = ?`,
-		draft.ID,
-	)
-	require.NoError(err)
-
-	destinationThread := MRReviewThread{
-		MergeRequestID:   destinationMR.ID,
-		ProviderThreadID: "destination-thread",
-		Body:             "destination review thread",
-		Range:            testReviewLineRange(),
-		CreatedAt:        now,
-		UpdatedAt:        now,
-	}
-	require.NoError(d.UpsertMRReviewThreads(
-		ctx, destinationMR.ID, []MRReviewThread{destinationThread},
-	))
-	sourceThread := destinationThread
-	sourceThread.MergeRequestID = sourceMR.ID
-	sourceThread.ProviderThreadID = "source-thread"
-	sourceThread.Body = "source review thread"
-	require.NoError(d.UpsertMRReviewThreads(
-		ctx, sourceMR.ID, []MRReviewThread{sourceThread},
-	))
-
-	gotID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
-		Platform:       "gitlab",
-		PlatformHost:   "gitlab.com",
-		PlatformRepoID: "gid://gitlab/Project/42",
-		Owner:          "new-group",
-		Name:           "new-name",
-	})
-	require.NoError(err)
-	assert.Equal(destinationID, gotID)
-
-	merged, err := d.GetMergeRequestByRepoIDAndNumber(ctx, destinationID, 7)
-	require.NoError(err)
-	require.NotNil(merged)
-	assert.Equal(destinationMR.ID, merged.ID)
-	assert.Equal("new provider snapshot", merged.Title)
-	assert.Equal("https://gitlab.com/old-group/old-name.git", merged.HeadRepoCloneURL)
-	assert.Equal(now.Add(time.Minute), merged.UpdatedAt)
-	assert.True(merged.HeadRepoIdentityStale)
-	assert.Positive(merged.SnapshotRevision)
-
-	preservedDraft, err := d.GetMRReviewDraft(ctx, destinationMR.ID)
-	require.NoError(err)
-	require.NotNil(preservedDraft)
-	assert.Equal(draft.ID, preservedDraft.ID)
-	assert.Equal("destination draft", preservedDraft.Body)
-
-	preservedThreads, err := d.ListMRReviewThreads(ctx, destinationMR.ID)
-	require.NoError(err)
-	require.Len(preservedThreads, 2)
-	assert.ElementsMatch(
-		[]string{"destination-thread", "source-thread"},
-		[]string{
-			preservedThreads[0].ProviderThreadID,
-			preservedThreads[1].ProviderThreadID,
-		},
-	)
-}
-
-func TestUpsertRepoByProviderIDWaitsForMergeRequestSnapshotReconciliation(t *testing.T) {
-	assert := assert.New(t)
-	require := require.New(t)
-	d := openTestDB(t)
-	ctx := t.Context()
-
-	sourceID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
-		Platform:       "gitlab",
-		PlatformHost:   "gitlab.com",
-		PlatformRepoID: "gid://gitlab/Project/42",
-		Owner:          "old-group",
-		Name:           "old-name",
-	})
-	require.NoError(err)
-	insertTestMRWithOptions(t, d, testMR(sourceID, 7, withMRTitle("source PR")))
-
-	destinationID, err := d.UpsertRepo(ctx, RepoIdentity{
-		Platform:     "gitlab",
-		PlatformHost: "gitlab.com",
-		Owner:        "new-group",
-		Name:         "new-name",
-	})
-	require.NoError(err)
-
-	release, err := d.LockMergeRequestSnapshot(ctx, sourceID, 7)
-	require.NoError(err)
-
-	writeLockAttempted := make(chan struct{})
-	restoreWriteLockHook := d.SetBeforeRepositoryReconciliationWriteLockForTest(
-		func() { close(writeLockAttempted) },
-	)
-	defer restoreWriteLockHook()
-	done := make(chan error, 1)
-	go func() {
-		_, upsertErr := d.UpsertRepoByProviderID(ctx, RepoIdentity{
-			Platform:       "gitlab",
-			PlatformHost:   "gitlab.com",
-			PlatformRepoID: "gid://gitlab/Project/42",
-			Owner:          "new-group",
-			Name:           "new-name",
-		})
-		done <- upsertErr
-	}()
-
-	<-writeLockAttempted
-	select {
-	case upsertErr := <-done:
-		require.NoError(upsertErr)
-		require.Fail("repository reconciliation bypassed the active snapshot read barrier")
-	default:
-	}
-
-	release()
-	select {
-	case upsertErr := <-done:
-		require.NoError(upsertErr)
-	case <-time.After(5 * time.Second):
-		assert.Fail("repository reconciliation did not resume after snapshot read barrier released")
-	}
-
-	mr, err := d.GetMergeRequestByRepoIDAndNumber(ctx, destinationID, 7)
-	require.NoError(err)
-	require.NotNil(mr)
-	assert.Equal("source PR", mr.Title)
-}
-
-func TestUpsertRepoByProviderIDMergesExistingDestinationPathRowWorkspaces(t *testing.T) {
-	assert := assert.New(t)
-	require := require.New(t)
-	d := openTestDB(t)
-	ctx := t.Context()
-
-	sourceID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
-		Platform:       "gitlab",
-		PlatformHost:   "gitlab.com",
-		PlatformRepoID: "gid://gitlab/Project/42",
-		Owner:          "Old-Group",
-		Name:           "Old-Name",
-		RepoPath:       "Old-Group/Old-Name",
-	})
-	require.NoError(err)
-	insertTestMRWithOptions(t, d, testMR(sourceID, 7, withMRTitle("merged PR")))
-	require.NoError(d.InsertWorkspace(ctx, &Workspace{
-		ID:           "merged-workspace",
-		PlatformHost: "gitlab.com",
-		RepoOwner:    "Old-Group",
-		RepoName:     "Old-Name",
-		ItemType:     WorkspaceItemTypePullRequest,
-		ItemNumber:   7,
-		GitHeadRef:   "feature",
-		WorktreePath: "/tmp/merged-workspace",
-		TmuxSession:  "merged-workspace",
-	}))
-
-	destinationID, err := d.UpsertRepo(ctx, RepoIdentity{
-		Platform:     "gitlab",
-		PlatformHost: "gitlab.com",
-		Owner:        "New-Group/SubGroup",
-		Name:         "New-Name",
-		RepoPath:     "New-Group/SubGroup/New-Name",
-	})
-	require.NoError(err)
-	require.NotEqual(sourceID, destinationID)
-
-	gotID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
-		Platform:       "gitlab",
-		PlatformHost:   "gitlab.com",
-		PlatformRepoID: "gid://gitlab/Project/42",
-		Owner:          "New-Group/SubGroup",
-		Name:           "New-Name",
-		RepoPath:       "New-Group/SubGroup/New-Name",
-	})
-	require.NoError(err)
-	assert.Equal(destinationID, gotID)
-
-	workspace, err := d.GetWorkspaceByMR(ctx, "gitlab.com", "new-group/subgroup", "new-name", 7)
-	require.NoError(err)
-	require.NotNil(workspace)
-	assert.Equal("merged-workspace", workspace.ID)
-	assert.Equal("New-Group/SubGroup", workspace.RepoOwner)
-	assert.Equal("New-Name", workspace.RepoName)
-
-	summary, err := d.GetWorkspaceSummary(ctx, "merged-workspace")
-	require.NoError(err)
-	require.NotNil(summary)
-	require.NotNil(summary.MRTitle)
-	assert.Equal("merged PR", *summary.MRTitle)
-}
-
-func TestUpsertRepoByProviderIDMergesCollidingWorkspaceRows(t *testing.T) {
-	assert := assert.New(t)
-	require := require.New(t)
-	d := openTestDB(t)
-	ctx := t.Context()
-
-	sourceID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
-		Platform:       "gitlab",
-		PlatformHost:   "gitlab.com",
-		PlatformRepoID: "gid://gitlab/Project/42",
-		Owner:          "Old-Group",
-		Name:           "Old-Name",
-		RepoPath:       "Old-Group/Old-Name",
-	})
-	require.NoError(err)
-	insertTestMRWithOptions(t, d, testMR(sourceID, 7, withMRTitle("merged PR")))
-	require.NoError(d.InsertWorkspace(ctx, &Workspace{
-		ID:           "source-workspace",
-		PlatformHost: "gitlab.com",
-		RepoOwner:    "Old-Group",
-		RepoName:     "Old-Name",
-		ItemType:     WorkspaceItemTypePullRequest,
-		ItemNumber:   7,
-		GitHeadRef:   "feature",
-		WorktreePath: "/tmp/source-workspace",
-		TmuxSession:  "source-workspace",
-	}))
-	require.NoError(d.InsertWorkspaceSetupEvent(ctx, &WorkspaceSetupEvent{
-		WorkspaceID: "source-workspace",
-		Stage:       "clone",
-		Outcome:     "ok",
-		Message:     "source event",
-	}))
-	require.NoError(d.UpsertWorkspaceRuntimeSession(ctx, &WorkspaceRuntimeSession{
-		WorkspaceID: "source-workspace",
-		SessionKey:  "source-workspace_source",
-		TargetKey:   "source",
-		Label:       "source",
-		Kind:        "agent",
-		Scope:       "session",
-		TmuxSession: "source-session",
-	}))
-
-	destinationID, err := d.UpsertRepo(ctx, RepoIdentity{
-		Platform:     "gitlab",
-		PlatformHost: "gitlab.com",
-		Owner:        "New-Group/SubGroup",
-		Name:         "New-Name",
-		RepoPath:     "New-Group/SubGroup/New-Name",
-	})
-	require.NoError(err)
-	require.NotEqual(sourceID, destinationID)
-	require.NoError(d.InsertWorkspace(ctx, &Workspace{
-		ID:           "destination-workspace",
-		PlatformHost: "gitlab.com",
-		RepoOwner:    "New-Group/SubGroup",
-		RepoName:     "New-Name",
-		ItemType:     WorkspaceItemTypePullRequest,
-		ItemNumber:   7,
-		GitHeadRef:   "feature",
-		WorktreePath: "/tmp/destination-workspace",
-		TmuxSession:  "destination-workspace",
-	}))
-	require.NoError(d.InsertWorkspaceSetupEvent(ctx, &WorkspaceSetupEvent{
-		WorkspaceID: "destination-workspace",
-		Stage:       "deps",
-		Outcome:     "ok",
-		Message:     "destination event",
-	}))
-	require.NoError(d.UpsertWorkspaceRuntimeSession(ctx, &WorkspaceRuntimeSession{
-		WorkspaceID: "destination-workspace",
-		SessionKey:  "destination-workspace_destination",
-		TargetKey:   "destination",
-		Label:       "destination",
-		Kind:        "agent",
-		Scope:       "session",
-		TmuxSession: "destination-session",
-	}))
-
-	gotID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
-		Platform:       "gitlab",
-		PlatformHost:   "gitlab.com",
-		PlatformRepoID: "gid://gitlab/Project/42",
-		Owner:          "New-Group/SubGroup",
-		Name:           "New-Name",
-		RepoPath:       "New-Group/SubGroup/New-Name",
-	})
-	require.NoError(err)
-	assert.Equal(destinationID, gotID)
-
-	workspace, err := d.GetWorkspaceByMR(ctx, "gitlab.com", "new-group/subgroup", "new-name", 7)
-	require.NoError(err)
-	require.NotNil(workspace)
-	assert.Equal("destination-workspace", workspace.ID)
-	assert.Equal("New-Group/SubGroup", workspace.RepoOwner)
-	assert.Equal("New-Name", workspace.RepoName)
+	require.NotNil(destinationIssue)
+	assert.Equal("destination issue", destinationIssue.Title)
 
 	sourceWorkspace, err := d.GetWorkspace(ctx, "source-workspace")
 	require.NoError(err)
-	assert.Nil(sourceWorkspace)
+	require.NotNil(sourceWorkspace)
+	require.NotNil(sourceWorkspace.RepoID)
+	assert.Equal(sourceID, *sourceWorkspace.RepoID)
+	assert.Equal("widget", sourceWorkspace.RepoName)
 
-	events, err := d.ListWorkspaceSetupEvents(ctx, "destination-workspace")
+	destinationWorkspace, err := d.GetWorkspace(ctx, "destination-workspace")
 	require.NoError(err)
-	require.Len(events, 2)
-	assert.Equal("source event", events[0].Message)
-	assert.Equal("destination event", events[1].Message)
+	require.NotNil(destinationWorkspace)
+	require.NotNil(destinationWorkspace.RepoID)
+	assert.Equal(destinationID, *destinationWorkspace.RepoID)
+	assert.Equal("widget", destinationWorkspace.RepoName)
 
-	tmuxSessions, err := d.ListWorkspaceRuntimeTmuxSessions(ctx, "destination-workspace")
+	activeWorkspaces, err := d.ListWorkspaces(ctx)
 	require.NoError(err)
-	require.Len(tmuxSessions, 2)
-	assert.Equal("source-session", tmuxSessions[0].TmuxSession)
-	assert.Equal("destination-session", tmuxSessions[1].TmuxSession)
-
-	summary, err := d.GetWorkspaceSummary(ctx, "destination-workspace")
-	require.NoError(err)
-	require.NotNil(summary)
-	require.NotNil(summary.MRTitle)
-	assert.Equal("merged PR", *summary.MRTitle)
+	require.Len(activeWorkspaces, 1)
+	assert.Equal("source-workspace", activeWorkspaces[0].ID)
 }
 
-func TestUpsertRepoByProviderIDMergesMovedItemLabelLinksIntoDestinationLabels(t *testing.T) {
+func TestUpsertRepoByProviderIDReactivatesStableProviderID(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	d := openTestDB(t)
 	ctx := t.Context()
-	now := baseTime()
 
-	sourceID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
-		Platform:       "gitlab",
-		PlatformHost:   "gitlab.com",
-		PlatformRepoID: "gid://gitlab/Project/42",
-		Owner:          "old-group",
-		Name:           "old-name",
+	firstID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repo-first",
+		Owner:          "acme",
+		Name:           "widget",
 	})
 	require.NoError(err)
-	sourceMRID := insertTestMRWithOptions(t, d, testMR(sourceID, 7, withMRTitle("source PR")))
-	sourceIssueID := insertTestIssueWithOptions(t, d, testIssue(sourceID, 8, withIssueTitle("source issue")))
 
-	require.NoError(d.ReplaceMergeRequestLabels(ctx, sourceID, sourceMRID, []Label{{
-		PlatformID:  300,
-		Name:        "bug",
-		Description: "source label",
-		Color:       "d73a4a",
-		UpdatedAt:   now,
-	}}))
-	require.NoError(d.ReplaceIssueLabels(ctx, sourceID, sourceIssueID, []Label{{
-		PlatformID:  300,
-		Name:        "bug",
-		Description: "source label",
-		Color:       "d73a4a",
-		UpdatedAt:   now,
-	}}))
-
-	destinationID, err := d.UpsertRepo(ctx, RepoIdentity{
-		Platform:     "gitlab",
-		PlatformHost: "gitlab.com",
-		Owner:        "new-group",
-		Name:         "new-name",
+	secondID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repo-second",
+		Owner:          "acme",
+		Name:           "widget",
 	})
 	require.NoError(err)
-	require.NoError(d.UpsertLabels(ctx, destinationID, []Label{{
-		PlatformID:  300,
-		Name:        "bug",
-		Description: "destination label",
-		Color:       "b60205",
-		IsDefault:   true,
-		UpdatedAt:   now.Add(time.Minute),
-	}}))
+	assert.NotEqual(firstID, secondID)
 
-	var destinationLabelID int64
-	err = d.ReadDB().QueryRowContext(ctx,
-		`SELECT id FROM forge_labels WHERE repo_id = ? AND name = ?`,
-		destinationID, "bug",
-	).Scan(&destinationLabelID)
-	require.NoError(err)
-
-	gotID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
-		Platform:       "gitlab",
-		PlatformHost:   "gitlab.com",
-		PlatformRepoID: "gid://gitlab/Project/42",
-		Owner:          "new-group",
-		Name:           "new-name",
+	reactivatedID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repo-first",
+		Owner:          "acme",
+		Name:           "widget",
 	})
 	require.NoError(err)
-	assert.Equal(destinationID, gotID)
+	assert.Equal(firstID, reactivatedID)
 
-	mr, err := d.GetMergeRequestByRepoIDAndNumber(ctx, destinationID, 7)
+	first, err := d.GetRepoByID(ctx, firstID)
 	require.NoError(err)
-	require.NotNil(mr)
-	require.Len(mr.Labels, 1)
-	assert.Equal(destinationLabelID, mr.Labels[0].ID)
-	assert.Equal("bug", mr.Labels[0].Name)
+	require.NotNil(first)
+	assert.Nil(first.RetiredAt)
+	assert.Nil(first.RetiredReplacementID)
 
-	issue, err := d.GetIssueByRepoIDAndNumber(ctx, destinationID, 8)
+	second, err := d.GetRepoByID(ctx, secondID)
 	require.NoError(err)
-	require.NotNil(issue)
-	require.Len(issue.Labels, 1)
-	assert.Equal(destinationLabelID, issue.Labels[0].ID)
-	assert.Equal("bug", issue.Labels[0].Name)
+	require.NotNil(second)
+	require.NotNil(second.RetiredAt)
+	require.NotNil(second.RetiredReplacementID)
+	assert.Equal(firstID, *second.RetiredReplacementID)
 }
 
 func TestReplaceRepoLabelCatalogKeepsAssignedHistoricalLabels(t *testing.T) {
@@ -1720,61 +1966,6 @@ func TestLabelMergePreservesCatalogMembership(t *testing.T) {
 	assert.True(catalog[0].CatalogPresent)
 	require.NotNil(catalog[0].CatalogSeenAt)
 	assert.Equal(now, *catalog[0].CatalogSeenAt)
-}
-
-func TestRepoMergePreservesLabelCatalogFreshnessAndMembership(t *testing.T) {
-	assert := assert.New(t)
-	require := require.New(t)
-	d := openTestDB(t)
-	ctx := t.Context()
-	syncedAt := baseTime()
-
-	sourceID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
-		Platform:       "gitlab",
-		PlatformHost:   "gitlab.com",
-		PlatformRepoID: "gid://gitlab/Project/42",
-		Owner:          "old-group",
-		Name:           "old-name",
-	})
-	require.NoError(err)
-	require.NoError(d.ReplaceRepoLabelCatalog(ctx, sourceID, []Label{{
-		PlatformID: 300,
-		Name:       "bug",
-		Color:      "d73a4a",
-		UpdatedAt:  syncedAt,
-	}}, syncedAt))
-
-	destinationID, err := d.UpsertRepo(ctx, RepoIdentity{
-		Platform:     "gitlab",
-		PlatformHost: "gitlab.com",
-		Owner:        "new-group",
-		Name:         "new-name",
-	})
-	require.NoError(err)
-	require.NoError(d.UpsertLabels(ctx, destinationID, []Label{{
-		PlatformID: 300,
-		Name:       "bug",
-		Color:      "b60205",
-		UpdatedAt:  syncedAt.Add(time.Minute),
-	}}))
-
-	gotID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
-		Platform:       "gitlab",
-		PlatformHost:   "gitlab.com",
-		PlatformRepoID: "gid://gitlab/Project/42",
-		Owner:          "new-group",
-		Name:           "new-name",
-	})
-	require.NoError(err)
-	assert.Equal(destinationID, gotID)
-
-	catalog, freshness, err := d.ListRepoLabelCatalog(ctx, destinationID)
-	require.NoError(err)
-	require.Len(catalog, 1)
-	assert.Equal("bug", catalog[0].Name)
-	assert.True(catalog[0].CatalogPresent)
-	require.NotNil(freshness.SyncedAt)
-	assert.Equal(syncedAt, *freshness.SyncedAt)
 }
 
 func TestLabelMergeDoesNotLetItemRowOverwriteCatalogMetadata(t *testing.T) {
@@ -1885,282 +2076,6 @@ func TestLabelMergeKeepsFresherCatalogMetadata(t *testing.T) {
 	assert.Equal("bug", catalog[0].Name)
 	assert.Equal("fresh catalog", catalog[0].Description)
 	assert.Equal("0e8a16", catalog[0].Color)
-}
-
-func TestRepoMergeUsesNewerSourceLabelCatalogFreshness(t *testing.T) {
-	assert := assert.New(t)
-	require := require.New(t)
-	d := openTestDB(t)
-	ctx := t.Context()
-	oldCheck := baseTime()
-	newSync := oldCheck.Add(time.Hour)
-
-	sourceID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
-		Platform:       "gitlab",
-		PlatformHost:   "gitlab.com",
-		PlatformRepoID: "gid://gitlab/Project/42",
-		Owner:          "old-group",
-		Name:           "old-name",
-	})
-	require.NoError(err)
-	require.NoError(d.ReplaceRepoLabelCatalog(ctx, sourceID, []Label{{
-		PlatformID: 300,
-		Name:       "bug",
-		Color:      "d73a4a",
-		UpdatedAt:  newSync,
-	}}, newSync))
-
-	destinationID, err := d.UpsertRepo(ctx, RepoIdentity{
-		Platform:     "gitlab",
-		PlatformHost: "gitlab.com",
-		Owner:        "new-group",
-		Name:         "new-name",
-	})
-	require.NoError(err)
-	require.NoError(d.UpdateRepoLabelCatalogCheck(ctx, destinationID, oldCheck, "provider down"))
-
-	_, err = d.UpsertRepoByProviderID(ctx, RepoIdentity{
-		Platform:       "gitlab",
-		PlatformHost:   "gitlab.com",
-		PlatformRepoID: "gid://gitlab/Project/42",
-		Owner:          "new-group",
-		Name:           "new-name",
-	})
-	require.NoError(err)
-
-	_, freshness, err := d.ListRepoLabelCatalog(ctx, destinationID)
-	require.NoError(err)
-	require.NotNil(freshness.SyncedAt)
-	assert.Equal(newSync, *freshness.SyncedAt)
-	require.NotNil(freshness.CheckedAt)
-	assert.Equal(newSync, *freshness.CheckedAt)
-	assert.Empty(freshness.SyncError)
-}
-
-func TestRepoMergeUsesFresherSourceCatalogMembership(t *testing.T) {
-	assert := assert.New(t)
-	require := require.New(t)
-	d := openTestDB(t)
-	ctx := t.Context()
-	oldSync := baseTime()
-	newSync := oldSync.Add(time.Hour)
-
-	sourceID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
-		Platform:       "gitlab",
-		PlatformHost:   "gitlab.com",
-		PlatformRepoID: "gid://gitlab/Project/42",
-		Owner:          "old-group",
-		Name:           "old-name",
-	})
-	require.NoError(err)
-	require.NoError(d.ReplaceRepoLabelCatalog(ctx, sourceID, []Label{{Name: "bug", Color: "d73a4a", UpdatedAt: newSync}}, newSync))
-
-	destinationID, err := d.UpsertRepo(ctx, RepoIdentity{Platform: "gitlab", PlatformHost: "gitlab.com", Owner: "new-group", Name: "new-name"})
-	require.NoError(err)
-	require.NoError(d.ReplaceRepoLabelCatalog(ctx, destinationID, []Label{{Name: "old-destination", Color: "cccccc", UpdatedAt: oldSync}}, oldSync))
-
-	_, err = d.UpsertRepoByProviderID(ctx, RepoIdentity{
-		Platform:       "gitlab",
-		PlatformHost:   "gitlab.com",
-		PlatformRepoID: "gid://gitlab/Project/42",
-		Owner:          "new-group",
-		Name:           "new-name",
-	})
-	require.NoError(err)
-
-	catalog, _, err := d.ListRepoLabelCatalog(ctx, destinationID)
-	require.NoError(err)
-	require.Len(catalog, 1)
-	assert.Equal("bug", catalog[0].Name)
-}
-
-func TestRepoMergeUsesFresherDestinationCatalogMembership(t *testing.T) {
-	assert := assert.New(t)
-	require := require.New(t)
-	d := openTestDB(t)
-	ctx := t.Context()
-	oldSync := baseTime()
-	newSync := oldSync.Add(time.Hour)
-
-	sourceID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
-		Platform:       "gitlab",
-		PlatformHost:   "gitlab.com",
-		PlatformRepoID: "gid://gitlab/Project/42",
-		Owner:          "old-group",
-		Name:           "old-name",
-	})
-	require.NoError(err)
-	require.NoError(d.ReplaceRepoLabelCatalog(ctx, sourceID, []Label{{Name: "old-source", Color: "cccccc", UpdatedAt: oldSync}}, oldSync))
-
-	destinationID, err := d.UpsertRepo(ctx, RepoIdentity{Platform: "gitlab", PlatformHost: "gitlab.com", Owner: "new-group", Name: "new-name"})
-	require.NoError(err)
-	require.NoError(d.ReplaceRepoLabelCatalog(ctx, destinationID, []Label{{Name: "triage", Color: "fbca04", UpdatedAt: newSync}}, newSync))
-
-	_, err = d.UpsertRepoByProviderID(ctx, RepoIdentity{
-		Platform:       "gitlab",
-		PlatformHost:   "gitlab.com",
-		PlatformRepoID: "gid://gitlab/Project/42",
-		Owner:          "new-group",
-		Name:           "new-name",
-	})
-	require.NoError(err)
-
-	catalog, _, err := d.ListRepoLabelCatalog(ctx, destinationID)
-	require.NoError(err)
-	require.Len(catalog, 1)
-	assert.Equal("triage", catalog[0].Name)
-}
-
-func TestRepoMergeKeepsSuccessfulSyncWhenNewerCheckFailed(t *testing.T) {
-	assert := assert.New(t)
-	require := require.New(t)
-	d := openTestDB(t)
-	ctx := t.Context()
-	oldSync := baseTime()
-	newCheck := oldSync.Add(time.Hour)
-
-	sourceID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{
-		Platform:       "gitlab",
-		PlatformHost:   "gitlab.com",
-		PlatformRepoID: "gid://gitlab/Project/42",
-		Owner:          "old-group",
-		Name:           "old-name",
-	})
-	require.NoError(err)
-	require.NoError(d.UpdateRepoLabelCatalogCheck(ctx, sourceID, newCheck, "provider down"))
-
-	destinationID, err := d.UpsertRepo(ctx, RepoIdentity{Platform: "gitlab", PlatformHost: "gitlab.com", Owner: "new-group", Name: "new-name"})
-	require.NoError(err)
-	require.NoError(d.ReplaceRepoLabelCatalog(ctx, destinationID, []Label{{Name: "bug", Color: "d73a4a", UpdatedAt: oldSync}}, oldSync))
-
-	_, err = d.UpsertRepoByProviderID(ctx, RepoIdentity{
-		Platform:       "gitlab",
-		PlatformHost:   "gitlab.com",
-		PlatformRepoID: "gid://gitlab/Project/42",
-		Owner:          "new-group",
-		Name:           "new-name",
-	})
-	require.NoError(err)
-
-	_, freshness, err := d.ListRepoLabelCatalog(ctx, destinationID)
-	require.NoError(err)
-	require.NotNil(freshness.SyncedAt)
-	assert.Equal(oldSync, *freshness.SyncedAt)
-	require.NotNil(freshness.CheckedAt)
-	assert.Equal(newCheck, *freshness.CheckedAt)
-	assert.Equal("provider down", freshness.SyncError)
-}
-
-func TestRepoMergeCopiesFresherDuplicateLabelMetadata(t *testing.T) {
-	assert := assert.New(t)
-	require := require.New(t)
-	d := openTestDB(t)
-	ctx := t.Context()
-	oldSync := baseTime()
-	newSync := oldSync.Add(time.Hour)
-
-	sourceID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{Platform: "gitlab", PlatformHost: "gitlab.com", PlatformRepoID: "gid://gitlab/Project/42", Owner: "old-group", Name: "old-name"})
-	require.NoError(err)
-	require.NoError(d.ReplaceRepoLabelCatalog(ctx, sourceID, []Label{{PlatformID: 300, Name: "new-name", Description: "new", Color: "0e8a16", IsDefault: true, UpdatedAt: newSync}}, newSync))
-
-	destinationID, err := d.UpsertRepo(ctx, RepoIdentity{Platform: "gitlab", PlatformHost: "gitlab.com", Owner: "new-group", Name: "new-name"})
-	require.NoError(err)
-	require.NoError(d.ReplaceRepoLabelCatalog(ctx, destinationID, []Label{{PlatformID: 300, Name: "old-name", Description: "old", Color: "cccccc", UpdatedAt: oldSync}}, oldSync))
-
-	_, err = d.UpsertRepoByProviderID(ctx, RepoIdentity{Platform: "gitlab", PlatformHost: "gitlab.com", PlatformRepoID: "gid://gitlab/Project/42", Owner: "new-group", Name: "new-name"})
-	require.NoError(err)
-
-	catalog, _, err := d.ListRepoLabelCatalog(ctx, destinationID)
-	require.NoError(err)
-	require.Len(catalog, 1)
-	assert.Equal("new-name", catalog[0].Name)
-	assert.Equal("new", catalog[0].Description)
-	assert.Equal("0e8a16", catalog[0].Color)
-	assert.True(catalog[0].IsDefault)
-}
-
-func TestRepoMergeCoalescesPlatformExternalIDDuplicateLabels(t *testing.T) {
-	assert := assert.New(t)
-	require := require.New(t)
-	d := openTestDB(t)
-	ctx := t.Context()
-	oldSync := baseTime()
-	newSync := oldSync.Add(time.Hour)
-	externalID := "gid://gitlab/ProjectLabel/300"
-
-	sourceID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{Platform: "gitlab", PlatformHost: "gitlab.com", PlatformRepoID: "gid://gitlab/Project/42", Owner: "old-group", Name: "old-name"})
-	require.NoError(err)
-	require.NoError(d.ReplaceRepoLabelCatalog(ctx, sourceID, []Label{{PlatformExternalID: externalID, Name: "new-name", Description: "fresh", Color: "0e8a16", UpdatedAt: newSync}}, newSync))
-
-	destinationID, err := d.UpsertRepo(ctx, RepoIdentity{Platform: "gitlab", PlatformHost: "gitlab.com", Owner: "new-group", Name: "new-name"})
-	require.NoError(err)
-	require.NoError(d.ReplaceRepoLabelCatalog(ctx, destinationID, []Label{{PlatformExternalID: externalID, Name: "old-name", Description: "stale", Color: "cccccc", UpdatedAt: oldSync}}, oldSync))
-
-	_, err = d.UpsertRepoByProviderID(ctx, RepoIdentity{Platform: "gitlab", PlatformHost: "gitlab.com", PlatformRepoID: "gid://gitlab/Project/42", Owner: "new-group", Name: "new-name"})
-	require.NoError(err)
-
-	catalog, _, err := d.ListRepoLabelCatalog(ctx, destinationID)
-	require.NoError(err)
-	require.Len(catalog, 1)
-	assert.Equal("new-name", catalog[0].Name)
-	assert.Equal("fresh", catalog[0].Description)
-	assert.Equal("0e8a16", catalog[0].Color)
-}
-
-func TestRepoMergeCoalescesDestinationNameConflictBeforeCatalogRename(t *testing.T) {
-	assert := assert.New(t)
-	require := require.New(t)
-	d := openTestDB(t)
-	ctx := t.Context()
-	oldSync := baseTime()
-	newSync := oldSync.Add(time.Hour)
-
-	sourceID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{Platform: "gitlab", PlatformHost: "gitlab.com", PlatformRepoID: "gid://gitlab/Project/42", Owner: "old-group", Name: "old-name"})
-	require.NoError(err)
-	require.NoError(d.ReplaceRepoLabelCatalog(ctx, sourceID, []Label{{PlatformID: 300, Name: "new-name", Description: "fresh", Color: "0e8a16", UpdatedAt: newSync}}, newSync))
-
-	destinationID, err := d.UpsertRepo(ctx, RepoIdentity{Platform: "gitlab", PlatformHost: "gitlab.com", Owner: "new-group", Name: "new-name"})
-	require.NoError(err)
-	require.NoError(d.ReplaceRepoLabelCatalog(ctx, destinationID, []Label{{PlatformID: 300, Name: "old-name", Description: "stale", Color: "cccccc", UpdatedAt: oldSync}}, oldSync))
-	require.NoError(d.UpsertLabels(ctx, destinationID, []Label{{Name: "new-name", Description: "historical", Color: "d73a4a", UpdatedAt: oldSync}}))
-
-	_, err = d.UpsertRepoByProviderID(ctx, RepoIdentity{Platform: "gitlab", PlatformHost: "gitlab.com", PlatformRepoID: "gid://gitlab/Project/42", Owner: "new-group", Name: "new-name"})
-	require.NoError(err)
-
-	catalog, _, err := d.ListRepoLabelCatalog(ctx, destinationID)
-	require.NoError(err)
-	require.Len(catalog, 1)
-	assert.Equal("new-name", catalog[0].Name)
-	assert.Equal("fresh", catalog[0].Description)
-	assert.Equal("0e8a16", catalog[0].Color)
-}
-
-func TestRepoMergeCopiesFresherNameOnlyDuplicateLabelMetadata(t *testing.T) {
-	assert := assert.New(t)
-	require := require.New(t)
-	d := openTestDB(t)
-	ctx := t.Context()
-	oldSync := baseTime()
-	newSync := oldSync.Add(time.Hour)
-
-	sourceID, err := d.UpsertRepoByProviderID(ctx, RepoIdentity{Platform: "gitlab", PlatformHost: "gitlab.com", PlatformRepoID: "gid://gitlab/Project/42", Owner: "old-group", Name: "old-name"})
-	require.NoError(err)
-	require.NoError(d.ReplaceRepoLabelCatalog(ctx, sourceID, []Label{{Name: "triage", Description: "fresh", Color: "0e8a16", IsDefault: true, UpdatedAt: newSync}}, newSync))
-
-	destinationID, err := d.UpsertRepo(ctx, RepoIdentity{Platform: "gitlab", PlatformHost: "gitlab.com", Owner: "new-group", Name: "new-name"})
-	require.NoError(err)
-	require.NoError(d.ReplaceRepoLabelCatalog(ctx, destinationID, []Label{{Name: "triage", Description: "stale", Color: "cccccc", UpdatedAt: oldSync}}, oldSync))
-
-	_, err = d.UpsertRepoByProviderID(ctx, RepoIdentity{Platform: "gitlab", PlatformHost: "gitlab.com", PlatformRepoID: "gid://gitlab/Project/42", Owner: "new-group", Name: "new-name"})
-	require.NoError(err)
-
-	catalog, _, err := d.ListRepoLabelCatalog(ctx, destinationID)
-	require.NoError(err)
-	require.Len(catalog, 1)
-	assert.Equal("triage", catalog[0].Name)
-	assert.Equal("fresh", catalog[0].Description)
-	assert.Equal("0e8a16", catalog[0].Color)
-	assert.True(catalog[0].IsDefault)
 }
 
 func TestRepoLabelCatalogWritesIgnoreStaleResults(t *testing.T) {
@@ -4480,6 +4395,7 @@ func TestWorkspaceCRUD(t *testing.T) {
 	require := require.New(t)
 	d := openTestDB(t)
 	ctx := t.Context()
+	insertTestRepo(t, d, "acme", "widget")
 
 	ws := &Workspace{
 		ID:              "ws-abc-123",
@@ -4535,15 +4451,16 @@ func TestWorkspaceCRUD(t *testing.T) {
 
 	// List (ordered by created_at DESC).
 	// Force ws2 to have a later created_at.
+	gadgetRepoID := insertTestRepo(t, d, "acme", "gadget")
 	_, err = d.WriteDB().ExecContext(ctx, `
 		INSERT INTO forge_workspaces
-		    (id, platform_host, repo_owner, repo_name,
+		    (id, repo_id, platform_host, repo_owner, repo_name,
 		     item_type, item_number, item_key, git_head_ref,
 		     worktree_path, tmux_session, status,
 		     created_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
 		        datetime('now', '+1 minute'))`,
-		"ws-def-456", "github.com", "acme", "gadget",
+		"ws-def-456", gadgetRepoID, "github.com", "acme", "gadget",
 		WorkspaceItemTypePullRequest, 7, "7", "fix/bug",
 		"/tmp/ws-def-456", "ws-def-456", "ready",
 	)
@@ -4670,6 +4587,7 @@ func TestUpdateWorkspaceMRHeadRepo(t *testing.T) {
 	require := require.New(t)
 	d := openTestDB(t)
 	ctx := t.Context()
+	insertTestRepo(t, d, "acme", "widget")
 
 	ws := &Workspace{
 		ID:           "ws-head-repo",
@@ -4797,6 +4715,7 @@ func TestWorkspaceItemKeyDefaultsFromItemNumber(t *testing.T) {
 	require := require.New(t)
 	d := openTestDB(t)
 	ctx := t.Context()
+	insertTestRepo(t, d, "acme", "widget")
 
 	require.NoError(d.InsertWorkspace(ctx, &Workspace{
 		ID:              "ws-provider-issue",
@@ -5392,12 +5311,12 @@ func TestWorkspaceSummaries(t *testing.T) {
 	// PR workspace with matching PR (earlier created_at).
 	_, err = d.WriteDB().ExecContext(ctx, `
 		INSERT INTO forge_workspaces
-		    (id, platform_host, repo_owner, repo_name,
+		    (id, repo_id, platform_host, repo_owner, repo_name,
 		     item_type, item_number, item_key, git_head_ref,
 		     worktree_path, tmux_session, status,
 		     created_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		"ws-with-mr", "github.com", "acme", "widget",
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"ws-with-mr", repoID, "github.com", "acme", "widget",
 		WorkspaceItemTypePullRequest, 42, "42", "feat/workspace",
 		"/tmp/ws-with-mr", "ws-with-mr", "ready",
 		base,
@@ -5407,27 +5326,28 @@ func TestWorkspaceSummaries(t *testing.T) {
 	// Issue workspace with owner issue metadata and associated PR metadata.
 	_, err = d.WriteDB().ExecContext(ctx, `
 		INSERT INTO forge_workspaces
-		    (id, platform_host, repo_owner, repo_name,
+		    (id, repo_id, platform_host, repo_owner, repo_name,
 		     item_type, item_number, item_key, associated_pr_number, git_head_ref,
 		     worktree_path, tmux_session, status,
 		     created_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		"ws-issue-with-pr", "github.com", "acme", "widget",
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"ws-issue-with-pr", repoID, "github.com", "acme", "widget",
 		WorkspaceItemTypeIssue, 7, "7", 42, "feature/from-issue",
 		"/tmp/ws-issue-with-pr", "ws-issue-with-pr", "ready",
 		base.Add(30*time.Minute),
 	)
 	require.NoError(err)
 
-	// Workspace without matching PR (later created_at, no repo).
+	// Workspace without matching PR (later created_at).
+	gadgetRepoID := insertTestRepo(t, d, "acme", "gadget")
 	_, err = d.WriteDB().ExecContext(ctx, `
 		INSERT INTO forge_workspaces
-		    (id, platform_host, repo_owner, repo_name,
+		    (id, repo_id, platform_host, repo_owner, repo_name,
 		     item_type, item_number, item_key, git_head_ref,
 		     worktree_path, tmux_session, status,
 		     created_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		"ws-no-mr", "github.com", "acme", "gadget",
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"ws-no-mr", gadgetRepoID, "github.com", "acme", "gadget",
 		WorkspaceItemTypePullRequest, 99, "99", "fix/thing",
 		"/tmp/ws-no-mr", "ws-no-mr", "creating",
 		base.Add(time.Hour),
@@ -5582,7 +5502,9 @@ func TestUpdateMRTitleBody(t *testing.T) {
 	assert.NoError(err)
 
 	ghUpdatedAt := base.Add(10 * time.Minute)
-	assert.NoError(d.UpdateMRTitleBody(ctx, id, "new title", "new body", ghUpdatedAt))
+	assert.NoError(d.UpdateMRTitleBody(
+		ctx, repoID, id, "new title", "new body", ghUpdatedAt,
+	))
 
 	got, err := d.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 1)
 	assert.NoError(err)
@@ -5624,7 +5546,9 @@ func TestUpdateMRTitleBodyPreservesNewerActivity(t *testing.T) {
 
 	// updatedAt is 30 min, newer than base so the update applies.
 	updatedAt := base.Add(30 * time.Minute)
-	assert.NoError(d.UpdateMRTitleBody(ctx, id, "new title", "new body", updatedAt))
+	assert.NoError(d.UpdateMRTitleBody(
+		ctx, repoID, id, "new title", "new body", updatedAt,
+	))
 
 	got, err := d.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 2)
 	assert.NoError(err)
@@ -5663,7 +5587,9 @@ func TestUpdateMRTitleBodyIgnoresStaleUpdate(t *testing.T) {
 
 	// Stale update: updatedAt is older than existing row.
 	staleAt := base.Add(30 * time.Minute)
-	assert.NoError(d.UpdateMRTitleBody(ctx, id, "stale title", "stale body", staleAt))
+	assert.NoError(d.UpdateMRTitleBody(
+		ctx, repoID, id, "stale title", "stale body", staleAt,
+	))
 
 	got, err := d.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 3)
 	assert.NoError(err)
@@ -5677,32 +5603,28 @@ func TestHTTPEtagPersistence(t *testing.T) {
 	assert := require.New(t)
 	d := openTestDB(t)
 	ctx := t.Context()
+	repoID := insertTestRepo(t, d, "owner", "repo")
 
 	etag, err := d.GetHTTPEtag(
-		ctx, "github", "github.com", "OWNER", "Repo",
-		"pull_request", 7,
+		ctx, repoID, "pull_request", 7,
 	)
 	assert.NoError(err)
 	assert.Empty(etag)
 
 	assert.NoError(d.UpsertHTTPEtag(
-		ctx, "github", "github.com", "OWNER", "Repo",
-		"pull_request", 7, `"etag-v1"`,
+		ctx, repoID, "pull_request", 7, `"etag-v1"`,
 	))
 	etag, err = d.GetHTTPEtag(
-		ctx, "github", "github.com", "owner", "repo",
-		"pull_request", 7,
+		ctx, repoID, "pull_request", 7,
 	)
 	assert.NoError(err)
 	assert.Equal(`"etag-v1"`, etag)
 
 	assert.NoError(d.UpsertHTTPEtag(
-		ctx, "github", "github.com", "owner", "repo",
-		"pull_request", 7, `"etag-v2"`,
+		ctx, repoID, "pull_request", 7, `"etag-v2"`,
 	))
 	etag, err = d.GetHTTPEtag(
-		ctx, "github", "github.com", "OWNER", "Repo",
-		"pull_request", 7,
+		ctx, repoID, "pull_request", 7,
 	)
 	assert.NoError(err)
 	assert.Equal(`"etag-v2"`, etag)

--- a/internal/db/types.go
+++ b/internal/db/types.go
@@ -3,6 +3,7 @@ package db
 import (
 	"cmp"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -53,6 +54,8 @@ type Repo struct {
 	LabelCatalogSyncedAt  *time.Time
 	LabelCatalogCheckedAt *time.Time
 	LabelCatalogSyncError string
+	RetiredAt             *time.Time
+	RetiredReplacementID  *int64
 	CreatedAt             time.Time
 }
 
@@ -70,6 +73,27 @@ type RepoIdentity struct {
 	OwnerKey       string
 	NameKey        string
 	RepoPathKey    string
+}
+
+var ErrRepositoryRetired = errors.New("repository incarnation is retired")
+
+// RepoIdentityConflictError reports an attempted reconciliation into a path
+// already owned by a different stable provider repository.
+type RepoIdentityConflictError struct {
+	ExistingRepoID int64
+	Existing       RepoIdentity
+	Incoming       RepoIdentity
+}
+
+func (e *RepoIdentityConflictError) Error() string {
+	return fmt.Sprintf(
+		"repository identity conflict for %s|%s/%s: stored provider id %q, incoming provider id %q",
+		e.Incoming.Platform,
+		e.Incoming.PlatformHost,
+		e.Incoming.RepoPath,
+		e.Existing.PlatformRepoID,
+		e.Incoming.PlatformRepoID,
+	)
 }
 
 type RepoProviderMetadata struct {
@@ -1014,10 +1038,7 @@ type NotificationSummary struct {
 // identity so one unavailable credential route cannot block watermark
 // advancement for healthy repositories sharing the host.
 type NotificationSyncWatermark struct {
-	Platform             string
-	PlatformHost         string
-	RepoOwner            string
-	RepoName             string
+	RepoID               int64
 	LastSuccessfulSyncAt time.Time
 	LastFullSyncAt       *time.Time
 }
@@ -1208,10 +1229,13 @@ func kataWorkspaceItemKeyPart(value string) string {
 // pull request, provider issue, or external Kata task.
 type Workspace struct {
 	ID                 string
+	RepoID             *int64
 	Platform           string
 	PlatformHost       string
 	RepoOwner          string
 	RepoName           string
+	LegacyCloneOwner   string
+	LegacyCloneName    string
 	ItemType           string
 	ItemNumber         int
 	ItemKey            string

--- a/internal/gitclone/auth_test.go
+++ b/internal/gitclone/auth_test.go
@@ -45,6 +45,30 @@ func (r testRouteResolver) FallbackSource(host string) tokenauth.Source {
 	return r.fallback[host]
 }
 
+func TestRepositoryCredentialAliasKeepsRenamedCloneOnConfiguredRoute(
+	t *testing.T,
+) {
+	assert := assert.New(t)
+	configured := &mutableTestTokenSource{token: "configured-token"}
+	mgr := New(t.TempDir(), testRouteResolver{
+		repos: map[string]tokenauth.Source{
+			"github.com/acme/widget": configured,
+		},
+	})
+	mgr.ReplaceCredentialAliases([]CredentialAlias{{
+		Platform: "github", Host: "github.com",
+		Owner: "acme-tools", Name: "renamed-widget",
+		CredentialOwner: "acme", CredentialName: "widget",
+	}})
+
+	assert.Same(
+		configured,
+		mgr.sourceForRepo(
+			"github", "github.com", "acme-tools", "renamed-widget",
+		),
+	)
+}
+
 func TestGitOwnerRoutesSelectAndInvalidateOnlyTheirSource(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/gitclone/branch_activity.go
+++ b/internal/gitclone/branch_activity.go
@@ -20,7 +20,13 @@ func (m *Manager) ResolveDefaultBranch(
 	if err != nil {
 		return "", "", err
 	}
+	return m.resolveDefaultBranchInDir(ctx, dir, preferred)
+}
 
+func (m *Manager) resolveDefaultBranchInDir(
+	ctx context.Context,
+	dir, preferred string,
+) (branch string, ref string, err error) {
 	preferred = strings.TrimSpace(preferred)
 	if preferred != "" {
 		for _, candidate := range branchActivityRefCandidates(preferred) {
@@ -50,6 +56,18 @@ func (m *Manager) ResolveDefaultBranch(
 	return branch, sha, nil
 }
 
+// ResolveDefaultBranch resolves this repository incarnation's default branch.
+func (r RepositoryClone) ResolveDefaultBranch(
+	ctx context.Context,
+	preferred string,
+) (branch string, ref string, err error) {
+	dir, err := r.ClonePath()
+	if err != nil {
+		return "", "", err
+	}
+	return r.manager.resolveDefaultBranchInDir(ctx, dir, preferred)
+}
+
 func defaultBranchNameForResolvedCandidate(preferred, candidate string) string {
 	if branch, ok := strings.CutPrefix(preferred, "origin/"); ok &&
 		branch != "" &&
@@ -69,11 +87,30 @@ func (m *Manager) ResolveRef(
 	if err != nil {
 		return "", err
 	}
+	return m.resolveRefInClone(ctx, dir, ref)
+}
+
+func (m *Manager) resolveRefInClone(
+	ctx context.Context,
+	dir, ref string,
+) (string, error) {
 	refName, err := m.resolveBranchActivityRef(ctx, dir, ref)
 	if err != nil {
 		return "", err
 	}
 	return m.resolveRefInDir(ctx, dir, refName)
+}
+
+// ResolveRef resolves a branch, ref, or SHA in this repository incarnation.
+func (r RepositoryClone) ResolveRef(
+	ctx context.Context,
+	ref string,
+) (string, error) {
+	dir, err := r.ClonePath()
+	if err != nil {
+		return "", err
+	}
+	return r.manager.resolveRefInClone(ctx, dir, ref)
 }
 
 // ResolveCommit resolves objectID directly to a commit SHA without branch
@@ -89,6 +126,18 @@ func (m *Manager) ResolveCommit(
 	return m.resolveRefInDir(ctx, dir, objectID)
 }
 
+// ResolveCommit resolves an object directly in this repository incarnation.
+func (r RepositoryClone) ResolveCommit(
+	ctx context.Context,
+	objectID string,
+) (string, error) {
+	dir, err := r.ClonePath()
+	if err != nil {
+		return "", err
+	}
+	return r.manager.resolveRefInDir(ctx, dir, objectID)
+}
+
 // IsAncestor reports whether ancestor is reachable from descendant.
 func (m *Manager) IsAncestor(
 	ctx context.Context,
@@ -98,7 +147,14 @@ func (m *Manager) IsAncestor(
 	if err != nil {
 		return false, err
 	}
-	_, err = m.git(ctx, dir,
+	return m.isAncestorInDir(ctx, dir, ancestor, descendant)
+}
+
+func (m *Manager) isAncestorInDir(
+	ctx context.Context,
+	dir, ancestor, descendant string,
+) (bool, error) {
+	_, err := m.git(ctx, dir,
 		"merge-base", "--is-ancestor", ancestor, descendant,
 	)
 	if err == nil {
@@ -108,6 +164,18 @@ func (m *Manager) IsAncestor(
 		return false, nil
 	}
 	return false, fmt.Errorf("check ancestor %s..%s: %w", ancestor, descendant, err)
+}
+
+// IsAncestor reports ancestry inside this repository incarnation.
+func (r RepositoryClone) IsAncestor(
+	ctx context.Context,
+	ancestor, descendant string,
+) (bool, error) {
+	dir, err := r.ClonePath()
+	if err != nil {
+		return false, err
+	}
+	return r.manager.isAncestorInDir(ctx, dir, ancestor, descendant)
 }
 
 // ListBranchCommitsSince returns first-parent commits for a branch/ref newest
@@ -123,6 +191,23 @@ func (m *Manager) ListBranchCommitsSince(
 	if err != nil {
 		return nil, err
 	}
+	return m.listBranchCommitsSinceInDir(
+		ctx,
+		dir,
+		ref,
+		since,
+		afterSHA,
+		maxCount,
+	)
+}
+
+func (m *Manager) listBranchCommitsSinceInDir(
+	ctx context.Context,
+	dir, ref string,
+	since time.Time,
+	afterSHA string,
+	maxCount int,
+) ([]Commit, error) {
 	refName, err := m.resolveBranchActivityRef(ctx, dir, ref)
 	if err != nil {
 		return nil, err
@@ -142,6 +227,29 @@ func (m *Manager) ListBranchCommitsSince(
 		return nil, fmt.Errorf("list branch commits %s: %w", ref, err)
 	}
 	return parseCommitLog(out)
+}
+
+// ListBranchCommitsSince lists branch commits from this repository
+// incarnation.
+func (r RepositoryClone) ListBranchCommitsSince(
+	ctx context.Context,
+	ref string,
+	since time.Time,
+	afterSHA string,
+	maxCount int,
+) ([]Commit, error) {
+	dir, err := r.ClonePath()
+	if err != nil {
+		return nil, err
+	}
+	return r.manager.listBranchCommitsSinceInDir(
+		ctx,
+		dir,
+		ref,
+		since,
+		afterSHA,
+		maxCount,
+	)
 }
 
 func (m *Manager) resolveBranchActivityRef(

--- a/internal/gitclone/clone.go
+++ b/internal/gitclone/clone.go
@@ -30,6 +30,8 @@ import (
 // network connection inside one sync interval.
 const ensureCloneTimeout = 15 * time.Minute
 
+const repositoryIncarnationNamespace = "repository-incarnations"
+
 // ErrNotFound is returned when a git ref or object cannot be resolved.
 var ErrNotFound = errors.New("git object not found")
 
@@ -66,16 +68,61 @@ type Manager struct {
 	repoBrowserRefreshSF singleflight.Group
 	repoBrowserMu        sync.Mutex
 	repoBrowserRepos     map[string]RepoBrowserRepoRef
+	repoBrowserRefreshFn func(context.Context, RepoBrowserRepoRef) error
+	credentialAliasesMu  sync.RWMutex
+	credentialAliases    map[string]CredentialAlias
+	localReadTestMu      sync.RWMutex
+	beforeLocalReadTest  func()
+}
+
+// CredentialAlias selects configured credentials independently from the
+// current provider route used as the remote endpoint.
+type CredentialAlias struct {
+	Platform        string
+	Host            string
+	Owner           string
+	Name            string
+	CredentialOwner string
+	CredentialName  string
 }
 
 // New creates a Manager that stores bare clones under baseDir. A nil resolver
 // means all operations proceed without auth.
 func New(baseDir string, routes RouteResolver) *Manager {
 	return &Manager{
-		baseDir:          baseDir,
-		routes:           routes,
-		repoBrowserRepos: make(map[string]RepoBrowserRepoRef),
+		baseDir:           baseDir,
+		routes:            routes,
+		repoBrowserRepos:  make(map[string]RepoBrowserRepoRef),
+		credentialAliases: make(map[string]CredentialAlias),
 	}
+}
+
+// ReplaceCredentialAliases atomically replaces managed-Git credential
+// bindings for provider-side repository renames.
+func (m *Manager) ReplaceCredentialAliases(aliases []CredentialAlias) {
+	if m == nil {
+		return
+	}
+	next := make(map[string]CredentialAlias, len(aliases))
+	for _, alias := range aliases {
+		if strings.TrimSpace(alias.CredentialOwner) == "" ||
+			strings.TrimSpace(alias.CredentialName) == "" {
+			continue
+		}
+		next[credentialAliasKey(
+			alias.Platform, alias.Host, alias.Owner, alias.Name,
+		)] = alias
+	}
+	m.credentialAliasesMu.Lock()
+	m.credentialAliases = next
+	m.credentialAliasesMu.Unlock()
+}
+
+func credentialAliasKey(platform, host, owner, name string) string {
+	return strings.ToLower(strings.TrimSpace(platform)) + "\x00" +
+		strings.ToLower(strings.TrimSpace(host)) + "\x00" +
+		strings.ToLower(strings.TrimSpace(owner)) + "\x00" +
+		strings.ToLower(strings.TrimSpace(name))
 }
 
 // ClonePath returns the filesystem path for a repo's bare clone.
@@ -83,9 +130,131 @@ func New(baseDir string, routes RouteResolver) *Manager {
 func (m *Manager) ClonePath(
 	platform, host, owner, name string,
 ) (string, error) {
+	binding := cloneStorageBinding{
+		namespace: cloneNamespaceForPlatform(platform),
+		host:      host,
+		owner:     owner,
+		name:      name,
+	}
 	return m.ClonePathInNamespace(
-		cloneNamespaceForPlatform(platform), host, owner, name,
+		binding.namespace,
+		binding.host,
+		binding.owner,
+		binding.name,
 	)
+}
+
+type cloneStorageBinding struct {
+	namespace string
+	host      string
+	owner     string
+	name      string
+}
+
+// RepositoryClone is an immutable handle to one repository incarnation's
+// managed bare clone. Routing coordinates select credentials and the remote;
+// repositoryID alone selects local storage.
+type RepositoryClone struct {
+	manager      *Manager
+	repositoryID int64
+	platform     string
+	host         string
+	owner        string
+	name         string
+}
+
+// RepositoryClone returns an immutable clone handle for one internal
+// repository ID.
+func (m *Manager) RepositoryClone(
+	repositoryID int64,
+	platform, host, owner, name string,
+) RepositoryClone {
+	return RepositoryClone{
+		manager:      m,
+		repositoryID: repositoryID,
+		platform:     platform,
+		host:         host,
+		owner:        owner,
+		name:         name,
+	}
+}
+
+func (r RepositoryClone) storage() (cloneStorageBinding, error) {
+	if r.manager == nil {
+		return cloneStorageBinding{}, fmt.Errorf("repository clone manager is required")
+	}
+	if r.repositoryID <= 0 {
+		return cloneStorageBinding{}, fmt.Errorf("repository clone id must be positive")
+	}
+	return cloneStorageBinding{
+		namespace: repositoryIncarnationNamespace,
+		host:      "local",
+		owner:     "repositories",
+		name:      fmt.Sprintf("repo-%d", r.repositoryID),
+	}, nil
+}
+
+// ClonePath returns the incarnation-scoped bare clone path.
+func (r RepositoryClone) ClonePath() (string, error) {
+	storage, err := r.storage()
+	if err != nil {
+		return "", err
+	}
+	return r.manager.ClonePathInNamespace(
+		storage.namespace,
+		storage.host,
+		storage.owner,
+		storage.name,
+	)
+}
+
+// EnsureClone creates or refreshes this repository incarnation's bare clone.
+func (r RepositoryClone) EnsureClone(
+	ctx context.Context,
+	remoteURL string,
+) error {
+	if err := validateRemoteURLIdentity(
+		r.host, r.owner, r.name, remoteURL,
+	); err != nil {
+		return err
+	}
+	storage, err := r.storage()
+	if err != nil {
+		return err
+	}
+	return r.manager.ensureCloneInStorage(
+		ctx,
+		storage,
+		r.platform,
+		r.host,
+		r.owner,
+		r.name,
+		remoteURL,
+	)
+}
+
+// RevParse resolves a ref inside this repository incarnation.
+func (r RepositoryClone) RevParse(
+	ctx context.Context,
+	ref string,
+) (string, error) {
+	clonePath, err := r.ClonePath()
+	if err != nil {
+		return "", err
+	}
+	return r.manager.revParseInDir(ctx, clonePath, ref)
+}
+
+// MergeBase computes a merge base inside this repository incarnation.
+func (r RepositoryClone) MergeBase(
+	ctx context.Context,
+	sha1, sha2 string,
+) (string, error) {
+	clonePath, err := r.ClonePath()
+	if err != nil {
+		return "", err
+	}
+	return r.manager.mergeBaseInDir(ctx, clonePath, sha1, sha2)
 }
 
 func cloneNamespaceForPlatform(platform string) string {
@@ -166,9 +335,20 @@ func validateCloneNamespace(namespace string) error {
 func (m *Manager) EnsureClone(
 	ctx context.Context, platform, host, owner, name, remoteURL string,
 ) error {
-	return m.EnsureCloneInNamespace(
-		ctx, cloneNamespaceForPlatform(platform),
-		platform, host, owner, name, remoteURL,
+	binding := cloneStorageBinding{
+		namespace: cloneNamespaceForPlatform(platform),
+		host:      host,
+		owner:     owner,
+		name:      name,
+	}
+	return m.ensureCloneInStorage(
+		ctx,
+		binding,
+		platform,
+		host,
+		owner,
+		name,
+		remoteURL,
 	)
 }
 
@@ -177,7 +357,27 @@ func (m *Manager) EnsureClone(
 func (m *Manager) EnsureCloneInNamespace(
 	ctx context.Context, namespace, platform, host, owner, name, remoteURL string,
 ) error {
-	namespace = strings.TrimSpace(namespace)
+	return m.ensureCloneInStorage(
+		ctx,
+		cloneStorageBinding{
+			namespace: strings.TrimSpace(namespace),
+			host:      host,
+			owner:     owner,
+			name:      name,
+		},
+		platform,
+		host,
+		owner,
+		name,
+		remoteURL,
+	)
+}
+
+func (m *Manager) ensureCloneInStorage(
+	ctx context.Context,
+	storage cloneStorageBinding,
+	platform, host, owner, name, remoteURL string,
+) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -190,17 +390,33 @@ func (m *Manager) EnsureCloneInNamespace(
 	if err := validateRemoteURLIdentity(host, owner, name, remoteURL); err != nil {
 		return err
 	}
-	if _, err := m.ClonePathInNamespace(namespace, host, owner, name); err != nil {
+	if _, err := m.ClonePathInNamespace(
+		storage.namespace,
+		storage.host,
+		storage.owner,
+		storage.name,
+	); err != nil {
 		return err
 	}
-	key := ensureCloneKey(namespace, host, owner, name)
+	key := ensureCloneKey(
+		storage.namespace,
+		storage.host,
+		storage.owner,
+		storage.name,
+	)
 	ch := m.ensureSF.DoChan(key, func() (any, error) {
 		opCtx, cancel := context.WithTimeout(
 			context.WithoutCancel(ctx), ensureCloneTimeout,
 		)
 		defer cancel()
-		return nil, m.ensureCloneNowInNamespace(
-			opCtx, namespace, platform, host, owner, name, remoteURL,
+		return nil, m.ensureCloneNowInStorage(
+			opCtx,
+			storage,
+			platform,
+			host,
+			owner,
+			name,
+			remoteURL,
 		)
 	})
 	select {
@@ -219,10 +435,17 @@ func ensureCloneKey(namespace, host, owner, name string) string {
 // fresh bare clone or refresh an existing one. Always called from
 // inside the singleflight slot opened by EnsureClone, which has
 // already validated the caller's remoteURL.
-func (m *Manager) ensureCloneNowInNamespace(
-	ctx context.Context, namespace, platform, host, owner, name, remoteURL string,
+func (m *Manager) ensureCloneNowInStorage(
+	ctx context.Context,
+	storage cloneStorageBinding,
+	platform, host, owner, name, remoteURL string,
 ) error {
-	clonePath, err := m.ClonePathInNamespace(namespace, host, owner, name)
+	clonePath, err := m.ClonePathInNamespace(
+		storage.namespace,
+		storage.host,
+		storage.owner,
+		storage.name,
+	)
 	if err != nil {
 		return err
 	}
@@ -236,8 +459,28 @@ func (m *Manager) ensureCloneNowInNamespace(
 	// belongs to the expected host: catches a clone whose config
 	// was rewritten after creation.
 	if out, err := m.git(ctx, clonePath, "config", "--get", "remote.origin.url"); err == nil {
-		if err := validateRemoteURLIdentity(host, owner, name, strings.TrimSpace(string(out))); err != nil {
-			return err
+		storedOrigin := strings.TrimSpace(string(out))
+		if err := validateRemoteURLIdentity(host, owner, name, storedOrigin); err != nil {
+			// The repository-incarnation path is selected from the active
+			// repository's immutable internal ID. That binding authorizes an
+			// origin update after a provider-side rename even after restart,
+			// when the prior route is no longer present in memory.
+			if storage.namespace != repositoryIncarnationNamespace {
+				return err
+			}
+			if _, setErr := m.git(
+				ctx,
+				clonePath,
+				"remote",
+				"set-url",
+				"origin",
+				remoteURL,
+			); setErr != nil {
+				return fmt.Errorf(
+					"update managed clone origin after repository rename: %w",
+					setErr,
+				)
+			}
 		}
 	}
 	m.ensureRefspecs(ctx, clonePath)
@@ -404,6 +647,13 @@ func (m *Manager) RevParse(
 	if err != nil {
 		return "", err
 	}
+	return m.revParseInDir(ctx, clonePath, ref)
+}
+
+func (m *Manager) revParseInDir(
+	ctx context.Context,
+	clonePath, ref string,
+) (string, error) {
 	out, err := m.git(ctx, clonePath, "rev-parse", "--verify", ref)
 	if err != nil {
 		return "", fmt.Errorf("git rev-parse %s: %w", ref, err)
@@ -419,6 +669,13 @@ func (m *Manager) MergeBase(
 	if err != nil {
 		return "", err
 	}
+	return m.mergeBaseInDir(ctx, clonePath, sha1, sha2)
+}
+
+func (m *Manager) mergeBaseInDir(
+	ctx context.Context,
+	clonePath, sha1, sha2 string,
+) (string, error) {
 	out, err := m.git(ctx, clonePath, "merge-base", sha1, sha2)
 	if err != nil {
 		return "", fmt.Errorf("git merge-base %s %s: %w", sha1, sha2, err)
@@ -448,7 +705,27 @@ func validateRemoteURLIdentity(expectedHost, owner, name, remoteURL string) erro
 func (m *Manager) git(
 	ctx context.Context, dir string, args ...string,
 ) ([]byte, error) {
+	m.localReadTestMu.RLock()
+	hook := m.beforeLocalReadTest
+	m.localReadTestMu.RUnlock()
+	if hook != nil {
+		hook()
+	}
 	return m.gitWithInput(ctx, dir, nil, args...)
+}
+
+// SetBeforeLocalReadForTest installs a hook immediately before local Git
+// reads. It exists only to coordinate concurrency regression tests.
+func (m *Manager) SetBeforeLocalReadForTest(fn func()) func() {
+	m.localReadTestMu.Lock()
+	previous := m.beforeLocalReadTest
+	m.beforeLocalReadTest = fn
+	m.localReadTestMu.Unlock()
+	return func() {
+		m.localReadTestMu.Lock()
+		m.beforeLocalReadTest = previous
+		m.localReadTestMu.Unlock()
+	}
 }
 
 // RunGitForRepo runs a networked Git command with the repository route's
@@ -673,6 +950,14 @@ func (m *Manager) sourceForRepo(
 ) tokenauth.Source {
 	if m.routes == nil {
 		return nil
+	}
+	key := credentialAliasKey(platform, host, owner, name)
+	m.credentialAliasesMu.RLock()
+	alias, ok := m.credentialAliases[key]
+	m.credentialAliasesMu.RUnlock()
+	if ok {
+		owner = alias.CredentialOwner
+		name = alias.CredentialName
 	}
 	return m.routes.SourceForRepo(platform, host, owner, name)
 }

--- a/internal/gitclone/commits.go
+++ b/internal/gitclone/commits.go
@@ -42,7 +42,13 @@ func (m *Manager) ListCommits(
 	if err != nil {
 		return nil, err
 	}
+	return m.listCommitsInDir(ctx, dir, mergeBase, headSHA)
+}
 
+func (m *Manager) listCommitsInDir(
+	ctx context.Context,
+	dir, mergeBase, headSHA string,
+) ([]Commit, error) {
 	args := []string{"log", "--first-parent", "--format=" + commitLogFormat}
 	if mergeBase == emptyTreeSHA {
 		// Empty tree is not a commit — list all ancestors of head.
@@ -57,6 +63,18 @@ func (m *Manager) ListCommits(
 	}
 
 	return parseCommitLog(out)
+}
+
+// ListCommits returns commits from this repository incarnation.
+func (r RepositoryClone) ListCommits(
+	ctx context.Context,
+	mergeBase, headSHA string,
+) ([]Commit, error) {
+	dir, err := r.ClonePath()
+	if err != nil {
+		return nil, err
+	}
+	return r.manager.listCommitsInDir(ctx, dir, mergeBase, headSHA)
 }
 
 const (
@@ -134,6 +152,23 @@ func (m *Manager) CommitTimelineSinceTag(
 	if err != nil {
 		return 0, nil, err
 	}
+	return m.commitTimelineSinceTagInDir(
+		ctx,
+		dir,
+		platform,
+		host,
+		owner,
+		name,
+		tagName,
+		limit,
+	)
+}
+
+func (m *Manager) commitTimelineSinceTagInDir(
+	ctx context.Context,
+	dir, platform, host, owner, name, tagName string,
+	limit int,
+) (int, []CommitTimelinePoint, error) {
 	if err := m.fetchTimelineTag(
 		ctx, platform, host, owner, name, dir, tagName,
 	); err != nil {
@@ -189,6 +224,34 @@ func (m *Manager) CommitTimelineSinceTag(
 		return 0, nil, err
 	}
 	return count, points, nil
+}
+
+// CommitTimelineSinceTag returns a timeline from this repository incarnation.
+func (r RepositoryClone) CommitTimelineSinceTag(
+	ctx context.Context,
+	tagName string,
+	limit int,
+) (int, []CommitTimelinePoint, error) {
+	if tagName == "" {
+		return 0, nil, nil
+	}
+	if limit < 1 {
+		limit = 1
+	}
+	dir, err := r.ClonePath()
+	if err != nil {
+		return 0, nil, err
+	}
+	return r.manager.commitTimelineSinceTagInDir(
+		ctx,
+		dir,
+		r.platform,
+		r.host,
+		r.owner,
+		r.name,
+		tagName,
+		limit,
+	)
 }
 
 func (m *Manager) fetchTimelineTag(
@@ -257,6 +320,13 @@ func (m *Manager) ParentOf(
 	if err != nil {
 		return "", err
 	}
+	return m.parentOfInDir(ctx, dir, sha)
+}
+
+func (m *Manager) parentOfInDir(
+	ctx context.Context,
+	dir, sha string,
+) (string, error) {
 	out, err := m.git(ctx, dir,
 		"rev-list", "--parents", "-n", "1", "--end-of-options", sha,
 	)
@@ -272,4 +342,16 @@ func (m *Manager) ParentOf(
 		return emptyTreeSHA, nil
 	}
 	return fields[1], nil
+}
+
+// ParentOf returns a commit's first parent from this repository incarnation.
+func (r RepositoryClone) ParentOf(
+	ctx context.Context,
+	sha string,
+) (string, error) {
+	dir, err := r.ClonePath()
+	if err != nil {
+		return "", err
+	}
+	return r.manager.parentOfInDir(ctx, dir, sha)
 }

--- a/internal/gitclone/diff.go
+++ b/internal/gitclone/diff.go
@@ -24,6 +24,13 @@ func (m *Manager) DiffFiles(
 	if err != nil {
 		return nil, err
 	}
+	return m.diffFilesInDir(ctx, clonePath, mergeBase, headSHA)
+}
+
+func (m *Manager) diffFilesInDir(
+	ctx context.Context,
+	clonePath, mergeBase, headSHA string,
+) ([]DiffFile, error) {
 	rawOut, err := m.git(ctx, clonePath,
 		DiffArgs("--raw", "-z", "-M", "-C",
 			"--find-copies-harder", "--end-of-options", mergeBase, headSHA,
@@ -58,6 +65,18 @@ func (m *Manager) DiffFiles(
 	m.markGenerated(ctx, clonePath, headSHA, files)
 	SortDiffFiles(files)
 	return files, nil
+}
+
+// DiffFiles returns file metadata from this repository incarnation.
+func (r RepositoryClone) DiffFiles(
+	ctx context.Context,
+	mergeBase, headSHA string,
+) ([]DiffFile, error) {
+	clonePath, err := r.ClonePath()
+	if err != nil {
+		return nil, err
+	}
+	return r.manager.diffFilesInDir(ctx, clonePath, mergeBase, headSHA)
 }
 
 // SortDiffFiles orders files the same way Git path lists and the Pierre file
@@ -152,7 +171,14 @@ func (m *Manager) Diff(
 	if err != nil {
 		return nil, err
 	}
+	return m.diffInDir(ctx, clonePath, mergeBase, headSHA, hideWhitespace)
+}
 
+func (m *Manager) diffInDir(
+	ctx context.Context,
+	clonePath, mergeBase, headSHA string,
+	hideWhitespace bool,
+) (*DiffResult, error) {
 	// Step 1: Compute whitespace-only file count.
 	wsCount, err := m.computeWhitespaceOnlyCount(
 		ctx, clonePath, mergeBase, headSHA)
@@ -216,6 +242,25 @@ func (m *Manager) Diff(
 		WhitespaceOnlyCount: wsCount,
 		Files:               files,
 	}, nil
+}
+
+// Diff returns a structured diff from this repository incarnation.
+func (r RepositoryClone) Diff(
+	ctx context.Context,
+	mergeBase, headSHA string,
+	hideWhitespace bool,
+) (*DiffResult, error) {
+	clonePath, err := r.ClonePath()
+	if err != nil {
+		return nil, err
+	}
+	return r.manager.diffInDir(
+		ctx,
+		clonePath,
+		mergeBase,
+		headSHA,
+		hideWhitespace,
+	)
 }
 
 func (m *Manager) markGenerated(
@@ -344,6 +389,14 @@ func (m *Manager) FileContent(
 	if err != nil {
 		return nil, err
 	}
+	return m.fileContentInDir(ctx, clonePath, ref, filePath, maxBytes)
+}
+
+func (m *Manager) fileContentInDir(
+	ctx context.Context,
+	clonePath, ref, filePath string,
+	maxBytes int64,
+) (*FileContent, error) {
 	object := ref + ":" + filePath
 	sizeOut, err := m.git(ctx, clonePath, "cat-file", "-s", object)
 	if err != nil {
@@ -365,6 +418,25 @@ func (m *Manager) FileContent(
 		Data: data,
 		Size: size,
 	}, nil
+}
+
+// FileContent reads a blob from this repository incarnation.
+func (r RepositoryClone) FileContent(
+	ctx context.Context,
+	ref, filePath string,
+	maxBytes int64,
+) (*FileContent, error) {
+	clonePath, err := r.ClonePath()
+	if err != nil {
+		return nil, err
+	}
+	return r.manager.fileContentInDir(
+		ctx,
+		clonePath,
+		ref,
+		filePath,
+		maxBytes,
+	)
 }
 
 // parseRawZPaths extracts just the file paths from --raw -z output.

--- a/internal/gitclone/incarnation_test.go
+++ b/internal/gitclone/incarnation_test.go
@@ -1,0 +1,306 @@
+package gitclone
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	gitcmd "go.kenn.io/kit/git/cmd"
+)
+
+func TestRepositoryIncarnationPartitionsCloneStorage(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	baseDir := t.TempDir()
+	manager := New(baseDir, nil)
+
+	oldClone := manager.RepositoryClone(
+		41, "github", "github.com", "acme", "widget",
+	)
+	oldPath, err := oldClone.ClonePath()
+	require.NoError(err)
+
+	newClone := manager.RepositoryClone(
+		42, "github", "github.com", "acme", "widget",
+	)
+	newPath, err := newClone.ClonePath()
+	require.NoError(err)
+
+	assert.NotEqual(oldPath, newPath)
+	assert.Equal(
+		filepath.Join(
+			baseDir, "repository-incarnations", "local", "repositories",
+			"repo-41.git",
+		),
+		oldPath,
+	)
+	assert.Equal(
+		filepath.Join(
+			baseDir, "repository-incarnations", "local", "repositories",
+			"repo-42.git",
+		),
+		newPath,
+	)
+}
+
+func TestRepositoryCloneHandleKeepsImmutableIncarnation(t *testing.T) {
+	require := require.New(t)
+	manager := New(t.TempDir(), nil)
+
+	retired := manager.RepositoryClone(
+		41,
+		"github",
+		"github.com",
+		"acme",
+		"widget",
+	)
+	replacement := manager.RepositoryClone(
+		42,
+		"github",
+		"github.com",
+		"acme",
+		"widget",
+	)
+
+	retiredPath, err := retired.ClonePath()
+	require.NoError(err)
+	replacementPath, err := replacement.ClonePath()
+	require.NoError(err)
+	retiredPathAgain, err := retired.ClonePath()
+	require.NoError(err)
+
+	require.Equal(retiredPath, retiredPathAgain)
+	require.NotEqual(retiredPath, replacementPath)
+	require.Contains(retiredPath, "repo-41.git")
+	require.Contains(replacementPath, "repo-42.git")
+}
+
+func TestRepositoryRenameKeepsIncarnationCloneStorage(t *testing.T) {
+	require := require.New(t)
+	manager := New(t.TempDir(), nil)
+
+	beforeClone := manager.RepositoryClone(
+		42, "github", "github.com", "acme", "legacy-widget",
+	)
+	before, err := beforeClone.ClonePath()
+	require.NoError(err)
+
+	afterClone := manager.RepositoryClone(
+		42, "github", "github.com", "acme", "widget",
+	)
+	after, err := afterClone.ClonePath()
+	require.NoError(err)
+	require.Equal(before, after)
+}
+
+func TestRepositoryCloneDoesNotAdoptRouteMatchedLegacyClone(t *testing.T) {
+	require := require.New(t)
+	root := t.TempDir()
+	manager := New(filepath.Join(root, "clones"), nil)
+	legacyPath, _ := seedLegacyManagedClone(
+		t, root, manager, "acme", "widget",
+	)
+
+	repository := manager.RepositoryClone(
+		42, "github", "github.com", "acme", "widget",
+	)
+	_, err := repository.RevParse(t.Context(), "refs/heads/main")
+	require.Error(err)
+
+	incarnationPath, err := repository.ClonePath()
+	require.NoError(err)
+	require.NoDirExists(incarnationPath)
+	require.DirExists(legacyPath)
+}
+
+func TestRepositoryCloneDoesNotAdoptAliasedLegacyClone(t *testing.T) {
+	require := require.New(t)
+	root := t.TempDir()
+	manager := New(filepath.Join(root, "clones"), nil)
+	legacyPath, _ := seedLegacyManagedClone(
+		t, root, manager, "acme", "legacy-widget",
+	)
+	manager.ReplaceCredentialAliases([]CredentialAlias{{
+		Platform:        "github",
+		Host:            "github.com",
+		Owner:           "acme-tools",
+		Name:            "current-widget",
+		CredentialOwner: "acme",
+		CredentialName:  "legacy-widget",
+	}})
+
+	repository := manager.RepositoryClone(
+		42, "github", "github.com", "acme-tools", "current-widget",
+	)
+	_, err := repository.RevParse(t.Context(), "refs/heads/main")
+	require.Error(err)
+
+	incarnationPath, err := repository.ClonePath()
+	require.NoError(err)
+	require.NoDirExists(incarnationPath)
+	require.DirExists(legacyPath)
+}
+
+func TestRepositoryCloneLeavesMismatchedLegacyCloneUntouched(t *testing.T) {
+	require := require.New(t)
+	root := t.TempDir()
+	manager := New(filepath.Join(root, "clones"), nil)
+	legacyPath, err := manager.ClonePath(
+		"github", "github.com", "acme", "widget",
+	)
+	require.NoError(err)
+	runIncarnationGit(t, root, "init", "--bare", "--initial-branch=main", legacyPath)
+	runIncarnationGit(
+		t,
+		legacyPath,
+		"remote",
+		"add",
+		"origin",
+		"https://github.com/other/repository.git",
+	)
+
+	repository := manager.RepositoryClone(
+		42, "github", "github.com", "acme", "widget",
+	)
+	_, err = repository.RevParse(t.Context(), "refs/heads/main")
+	require.Error(err)
+	require.DirExists(legacyPath)
+	incarnationPath, err := repository.ClonePath()
+	require.NoError(err)
+	require.NoDirExists(incarnationPath)
+}
+
+func TestRepositoryRenameRepointsTrustedIncarnationOrigin(t *testing.T) {
+	require := require.New(t)
+	root := t.TempDir()
+	remote := filepath.Join(root, "remote.git")
+	runIncarnationGit(t, root, "init", "--bare", "--initial-branch=main", remote)
+
+	manager := New(filepath.Join(root, "clones"), nil)
+	legacyClone := manager.RepositoryClone(
+		42, "github", "github.com", "acme", "legacy-widget",
+	)
+	clonePath, err := legacyClone.ClonePath()
+	require.NoError(err)
+	require.NoError(os.MkdirAll(filepath.Dir(clonePath), 0o755))
+	runIncarnationGit(t, root, "clone", "--bare", remote, clonePath)
+
+	oldURL := "https://github.com/acme/legacy-widget.git"
+	newURL := "https://github.com/acme/widget.git"
+	runIncarnationGit(t, clonePath, "remote", "set-url", "origin", oldURL)
+	runIncarnationGit(
+		t,
+		clonePath,
+		"config",
+		"url."+remote+".insteadOf",
+		newURL,
+	)
+
+	renamedClone := manager.RepositoryClone(
+		42, "github", "github.com", "acme", "widget",
+	)
+	require.NoError(renamedClone.EnsureClone(
+		t.Context(),
+		newURL,
+	))
+
+	out, err := gitcmd.New().Output(
+		t.Context(),
+		clonePath,
+		"config",
+		"--get",
+		"remote.origin.url",
+	)
+	require.NoError(err)
+	require.Equal(newURL, strings.TrimSpace(string(out)))
+}
+
+func TestRepositoryRenameRepointsIncarnationOriginAfterRestart(t *testing.T) {
+	require := require.New(t)
+	root := t.TempDir()
+	remote := filepath.Join(root, "remote.git")
+	runIncarnationGit(t, root, "init", "--bare", "--initial-branch=main", remote)
+
+	baseDir := filepath.Join(root, "clones")
+	beforeRestart := New(baseDir, nil)
+	beforeClone := beforeRestart.RepositoryClone(
+		42, "github", "github.com", "acme", "legacy-widget",
+	)
+	clonePath, err := beforeClone.ClonePath()
+	require.NoError(err)
+	require.NoError(os.MkdirAll(filepath.Dir(clonePath), 0o755))
+	runIncarnationGit(t, root, "clone", "--bare", remote, clonePath)
+
+	oldURL := "https://github.com/acme/legacy-widget.git"
+	newURL := "https://github.com/acme/widget.git"
+	runIncarnationGit(t, clonePath, "remote", "set-url", "origin", oldURL)
+	runIncarnationGit(
+		t,
+		clonePath,
+		"config",
+		"url."+remote+".insteadOf",
+		newURL,
+	)
+
+	afterRestart := New(baseDir, nil)
+	afterClone := afterRestart.RepositoryClone(
+		42, "github", "github.com", "acme", "widget",
+	)
+	require.NoError(afterClone.EnsureClone(
+		t.Context(),
+		newURL,
+	))
+
+	out, err := gitcmd.New().Output(
+		t.Context(),
+		clonePath,
+		"config",
+		"--get",
+		"remote.origin.url",
+	)
+	require.NoError(err)
+	require.Equal(newURL, strings.TrimSpace(string(out)))
+}
+
+func runIncarnationGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	out, stderr, err := gitcmd.New().Run(t.Context(), dir, nil, args...)
+	require.NoError(t, err, "git %v failed: %s%s", args, out, stderr)
+}
+
+func seedLegacyManagedClone(
+	t *testing.T,
+	root string,
+	manager *Manager,
+	owner, name string,
+) (string, string) {
+	t.Helper()
+	require := require.New(t)
+	legacyPath, err := manager.ClonePath(
+		"github", "github.com", owner, name,
+	)
+	require.NoError(err)
+	work := filepath.Join(root, "work-"+name)
+	runIncarnationGit(t, root, "init", "--bare", "--initial-branch=main", legacyPath)
+	runIncarnationGit(t, root, "init", "--initial-branch=main", work)
+	runIncarnationGit(t, work, "config", "user.email", "test@example.com")
+	runIncarnationGit(t, work, "config", "user.name", "Test User")
+	require.NoError(os.WriteFile(filepath.Join(work, "README.md"), []byte("cached\n"), 0o644))
+	runIncarnationGit(t, work, "add", "README.md")
+	runIncarnationGit(t, work, "commit", "-m", "seed cache")
+	runIncarnationGit(t, work, "push", legacyPath, "main")
+	shaOut, err := gitcmd.New().Output(t.Context(), work, "rev-parse", "HEAD")
+	require.NoError(err)
+	runIncarnationGit(
+		t,
+		legacyPath,
+		"remote",
+		"add",
+		"origin",
+		"https://github.com/"+owner+"/"+name+".git",
+	)
+	return legacyPath, strings.TrimSpace(string(shaOut))
+}

--- a/internal/gitclone/repo_browser.go
+++ b/internal/gitclone/repo_browser.go
@@ -4,8 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -50,6 +48,7 @@ const (
 )
 
 type RepoBrowserRepoRef struct {
+	RepoID    int64
 	Provider  string
 	Host      string
 	Owner     string
@@ -57,6 +56,11 @@ type RepoBrowserRepoRef struct {
 	RepoPath  string
 	RemoteURL string
 }
+
+type RepoBrowserRefreshAuthorizer func(
+	context.Context,
+	RepoBrowserRepoRef,
+) (RepoBrowserRepoRef, func(), bool, error)
 
 type RepoBrowserRef struct {
 	Type         RepoBrowserRefType `json:"type" doc:"Selected ref type: branch, tag, or commit."`
@@ -754,7 +758,13 @@ func (m *Manager) resolveRepoBrowserRef(
 }
 
 func (m *Manager) repoBrowserClonePath(repo RepoBrowserRepoRef) (string, error) {
-	return m.ClonePathInNamespace(repoBrowserCloneNamespace(repo), repo.Host, repo.Owner, repo.Name)
+	storage, err := repoBrowserCloneStorage(repo)
+	if err != nil {
+		return "", err
+	}
+	return m.ClonePathInNamespace(
+		storage.namespace, storage.host, storage.owner, storage.name,
+	)
 }
 
 func (m *Manager) EnsureRepoBrowserClone(ctx context.Context, repo RepoBrowserRepoRef) error {
@@ -774,6 +784,7 @@ type repoBrowserRefreshWorkMode uint8
 const (
 	repoBrowserRefreshRespectCaller repoBrowserRefreshWorkMode = iota
 	repoBrowserRefreshDetachCaller
+	repoBrowserRefreshHoldAuthorization
 )
 
 func repoBrowserRefreshWorkParent(ctx context.Context, mode repoBrowserRefreshWorkMode) context.Context {
@@ -791,23 +802,36 @@ func (m *Manager) refreshRepoBrowserClone(
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	namespace := repoBrowserCloneNamespace(repo)
+	storage, err := repoBrowserCloneStorage(repo)
+	if err != nil {
+		return err
+	}
 	if err := validateRemoteURLIdentity(repo.Host, repo.Owner, repo.Name, repo.RemoteURL); err != nil {
 		return err
 	}
-	if _, err := m.ClonePathInNamespace(namespace, repo.Host, repo.Owner, repo.Name); err != nil {
+	if _, err := m.ClonePathInNamespace(
+		storage.namespace, storage.host, storage.owner, storage.name,
+	); err != nil {
 		return err
 	}
-	key := ensureCloneKey(namespace, repo.Host, repo.Owner, repo.Name)
+	key := ensureCloneKey(
+		repoBrowserCloneNamespace(repo),
+		storage.host,
+		storage.owner,
+		storage.name,
+	)
 	ch := m.repoBrowserRefreshSF.DoChan(key, func() (any, error) {
 		opCtx, cancel := context.WithTimeout(
 			repoBrowserRefreshWorkParent(ctx, mode),
 			ensureCloneTimeout,
 		)
 		defer cancel()
-		if err := m.ensureCloneNowInNamespace(
+		if m.repoBrowserRefreshFn != nil {
+			return nil, m.repoBrowserRefreshFn(opCtx, repo)
+		}
+		if err := m.ensureCloneNowInStorage(
 			opCtx,
-			namespace,
+			storage,
 			repo.Provider,
 			repo.Host,
 			repo.Owner,
@@ -830,25 +854,60 @@ func (m *Manager) refreshRepoBrowserClone(
 			return res.Err
 		}
 	case <-ctx.Done():
+		if mode == repoBrowserRefreshHoldAuthorization {
+			<-ch
+		}
 		return ctx.Err()
 	}
 	m.registerRepoBrowserRepo(repo)
 	return nil
 }
 
-func (m *Manager) RefreshRepoBrowserClones(ctx context.Context) {
+func (m *Manager) RefreshRepoBrowserClones(
+	ctx context.Context,
+	authorize RepoBrowserRefreshAuthorizer,
+) {
+	if authorize == nil {
+		return
+	}
 	for _, repo := range m.repoBrowserReposSnapshot() {
 		if err := ctx.Err(); err != nil {
 			return
 		}
-		if err := m.refreshRepoBrowserClone(ctx, repo, repoBrowserRefreshRespectCaller); err != nil {
+		authorized, release, active, err := authorize(ctx, repo)
+		if err != nil {
+			slog.Warn("repo browser clone refresh authorization failed",
+				"repository_id", repo.RepoID,
+				"err", err)
+			continue
+		}
+		if !active {
+			m.removeRepoBrowserRepo(repo)
+			continue
+		}
+		if release == nil {
+			release = func() {}
+		}
+		err = m.refreshRepoBrowserClone(
+			ctx,
+			authorized,
+			repoBrowserRefreshHoldAuthorization,
+		)
+		release()
+		if err != nil {
 			slog.Warn("repo browser clone refresh failed",
-				"provider", repo.Provider,
-				"host", repo.Host,
-				"repo", repo.RepoPath,
+				"provider", authorized.Provider,
+				"host", authorized.Host,
+				"repo", authorized.RepoPath,
 				"err", err)
 		}
 	}
+}
+
+func (m *Manager) removeRepoBrowserRepo(repo RepoBrowserRepoRef) {
+	m.repoBrowserMu.Lock()
+	defer m.repoBrowserMu.Unlock()
+	delete(m.repoBrowserRepos, repoBrowserCloneNamespace(repo))
 }
 
 func (m *Manager) RegisterExistingRepoBrowserClone(ctx context.Context, repo RepoBrowserRepoRef) (bool, error) {
@@ -869,7 +928,19 @@ func (m *Manager) RegisterExistingRepoBrowserClone(ctx context.Context, repo Rep
 	}
 	if out, err := m.git(ctx, dir, "config", "--get", "remote.origin.url"); err == nil {
 		if err := validateRemoteURLIdentity(repo.Host, repo.Owner, repo.Name, strings.TrimSpace(string(out))); err != nil {
-			return false, err
+			if _, setErr := m.git(
+				ctx,
+				dir,
+				"remote",
+				"set-url",
+				"origin",
+				repo.RemoteURL,
+			); setErr != nil {
+				return false, fmt.Errorf(
+					"update registered repo browser origin after repository rename: %w",
+					setErr,
+				)
+			}
 		}
 	}
 	m.ensureRefspecs(ctx, dir)
@@ -881,11 +952,10 @@ func (m *Manager) ensureRepoBrowserCloneLocal(ctx context.Context, repo RepoBrow
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	namespace := repoBrowserCloneNamespace(repo)
 	if err := validateRemoteURLIdentity(repo.Host, repo.Owner, repo.Name, repo.RemoteURL); err != nil {
 		return err
 	}
-	dir, err := m.ClonePathInNamespace(namespace, repo.Host, repo.Owner, repo.Name)
+	dir, err := m.repoBrowserClonePath(repo)
 	if err != nil {
 		return err
 	}
@@ -896,7 +966,11 @@ func (m *Manager) ensureRepoBrowserCloneLocal(ctx context.Context, repo RepoBrow
 	}
 	if out, err := m.git(ctx, dir, "config", "--get", "remote.origin.url"); err == nil {
 		if err := validateRemoteURLIdentity(repo.Host, repo.Owner, repo.Name, strings.TrimSpace(string(out))); err != nil {
-			return err
+			return m.refreshRepoBrowserClone(
+				ctx,
+				repo,
+				repoBrowserRefreshDetachCaller,
+			)
 		}
 	}
 	m.ensureRefspecs(ctx, dir)
@@ -938,13 +1012,26 @@ func (m *Manager) fetchRepoBrowserTags(
 }
 
 func repoBrowserCloneNamespace(repo RepoBrowserRepoRef) string {
-	identity := strings.Join([]string{
-		strings.TrimSpace(repo.Provider),
-		strings.TrimSpace(repo.Host),
-		strings.Trim(strings.TrimSpace(repo.RepoPath), "/"),
-	}, "\x00")
-	sum := sha256.Sum256([]byte(identity))
-	return "repo-browser-" + hex.EncodeToString(sum[:8])
+	if repo.RepoID <= 0 {
+		return ""
+	}
+	return "repo-browser-repository-" + strconv.FormatInt(repo.RepoID, 10)
+}
+
+func repoBrowserCloneStorage(
+	repo RepoBrowserRepoRef,
+) (cloneStorageBinding, error) {
+	if repo.RepoID <= 0 {
+		return cloneStorageBinding{}, errors.New(
+			"repo browser repository ID is required",
+		)
+	}
+	return cloneStorageBinding{
+		namespace: repositoryIncarnationNamespace,
+		host:      "local",
+		owner:     "repo-browser",
+		name:      "repo-" + strconv.FormatInt(repo.RepoID, 10),
+	}, nil
 }
 
 func (m *Manager) resolveRepoBrowserDefaultBranch(

--- a/internal/gitclone/repo_browser_test.go
+++ b/internal/gitclone/repo_browser_test.go
@@ -42,6 +42,84 @@ func TestRepoBrowserListRefsDisambiguatesBranchAndTag(t *testing.T) {
 	assert.Contains(refs, RepoBrowserRef{Type: RepoBrowserRefTag, Name: "release", SHA: mainSHA})
 }
 
+func TestRepoBrowserCloneNamespaceUsesRepositoryIncarnationID(t *testing.T) {
+	require := require.New(t)
+	base := RepoBrowserRepoRef{
+		Provider:  "github",
+		Host:      "github.com",
+		Owner:     "acme",
+		Name:      "widget",
+		RepoPath:  "acme/widget",
+		RemoteURL: "https://github.com/acme/widget.git",
+	}
+	first := base
+	second := base
+	first.RepoID = 41
+	second.RepoID = 42
+
+	require.NotEqual(
+		repoBrowserCloneNamespace(first),
+		repoBrowserCloneNamespace(second),
+	)
+	manager := New(t.TempDir(), nil)
+	firstPath, err := manager.repoBrowserClonePath(first)
+	require.NoError(err)
+	secondPath, err := manager.repoBrowserClonePath(second)
+	require.NoError(err)
+	require.NotEqual(firstPath, secondPath)
+
+	renamed := first
+	renamed.Owner = "acme-tools"
+	renamed.Name = "renamed-widget"
+	renamed.RepoPath = "acme-tools/renamed-widget"
+	renamedPath, err := manager.repoBrowserClonePath(renamed)
+	require.NoError(err)
+	require.Equal(firstPath, renamedPath)
+}
+
+func TestEnsureRepoBrowserCloneRepointsOriginAfterRename(t *testing.T) {
+	require := require.New(t)
+	mgr, repo, _ := setupRepoBrowserTestRepo(t)
+	clonePath, err := mgr.repoBrowserClonePath(repo)
+	require.NoError(err)
+	commitTestRun(t, clonePath, "git", "remote", "set-url", "origin",
+		"https://github.com/acme/widgets.git")
+
+	renamed := repo
+	renamed.Owner = "acme-tools"
+	renamed.Name = "renamed-widget"
+	renamed.RepoPath = "acme-tools/renamed-widget"
+
+	require.NoError(mgr.EnsureRepoBrowserClone(t.Context(), renamed))
+	out, err := mgr.git(t.Context(), clonePath, "config", "--get", "remote.origin.url")
+	require.NoError(err)
+	require.Equal(renamed.RemoteURL, strings.TrimSpace(string(out)))
+}
+
+func TestRegisterExistingRepoBrowserCloneRepointsOriginAfterRestartRename(t *testing.T) {
+	require := require.New(t)
+	mgr, repo, _ := setupRepoBrowserTestRepo(t)
+	clonePath, err := mgr.repoBrowserClonePath(repo)
+	require.NoError(err)
+	remoteURL := repo.RemoteURL
+	commitTestRun(t, clonePath, "git", "remote", "set-url", "origin",
+		"https://github.com/acme/widgets.git")
+	require.NoError(os.Rename(remoteURL, remoteURL+".offline"))
+
+	renamed := repo
+	renamed.Owner = "acme-tools"
+	renamed.Name = "renamed-widget"
+	renamed.RepoPath = "acme-tools/renamed-widget"
+	restarted := New(mgr.baseDir, nil)
+
+	registered, err := restarted.RegisterExistingRepoBrowserClone(t.Context(), renamed)
+	require.NoError(err)
+	require.True(registered)
+	out, err := restarted.git(t.Context(), clonePath, "config", "--get", "remote.origin.url")
+	require.NoError(err)
+	require.Equal(renamed.RemoteURL, strings.TrimSpace(string(out)))
+}
+
 func TestRepoBrowserListRefsCapsLargeRefSets(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -82,7 +160,33 @@ func TestRefreshRepoBrowserClonesRefreshesRegisteredRepos(t *testing.T) {
 
 	commitTestRun(t, work, "git", "tag", "v1.0.0", mainSHA)
 	commitTestRun(t, work, "git", "push", "origin", "refs/tags/v1.0.0")
-	mgr.RefreshRepoBrowserClones(t.Context())
+	releasedAfterRefresh := false
+	mgr.RefreshRepoBrowserClones(
+		t.Context(),
+		func(
+			_ context.Context,
+			registered RepoBrowserRepoRef,
+		) (RepoBrowserRepoRef, func(), bool, error) {
+			require.Equal(repo.RepoID, registered.RepoID)
+			return repo, func() {
+				refs, _, _, err := mgr.ListRepoBrowserRefs(
+					t.Context(),
+					repo,
+					"main",
+				)
+				require.NoError(err)
+				releasedAfterRefresh = assert.Contains(
+					refs,
+					RepoBrowserRef{
+						Type: RepoBrowserRefTag,
+						Name: "v1.0.0",
+						SHA:  mainSHA,
+					},
+				)
+			}, true, nil
+		},
+	)
+	require.True(releasedAfterRefresh)
 
 	refs, _, truncated, err := mgr.ListRepoBrowserRefs(t.Context(), repo, "main")
 	require.NoError(err)
@@ -105,7 +209,10 @@ func TestRefreshRepoBrowserClonesUsesSeededExistingClones(t *testing.T) {
 	registered, err := restarted.RegisterExistingRepoBrowserClone(t.Context(), repo)
 	require.NoError(err)
 	require.True(registered)
-	restarted.RefreshRepoBrowserClones(t.Context())
+	restarted.RefreshRepoBrowserClones(
+		t.Context(),
+		passthroughRepoBrowserRefreshAuthorizer,
+	)
 
 	resolved, err := restarted.ResolveRepoBrowserRef(t.Context(), repo, RepoBrowserRef{
 		Type: RepoBrowserRefBranch,
@@ -113,6 +220,13 @@ func TestRefreshRepoBrowserClonesUsesSeededExistingClones(t *testing.T) {
 	})
 	require.NoError(err)
 	assert.Equal(updatedSHA, resolved.SHA)
+}
+
+func passthroughRepoBrowserRefreshAuthorizer(
+	_ context.Context,
+	repo RepoBrowserRepoRef,
+) (RepoBrowserRepoRef, func(), bool, error) {
+	return repo, func() {}, true, nil
 }
 
 func TestEnsureRepoBrowserCloneDoesNotRefreshExistingClone(t *testing.T) {
@@ -149,6 +263,81 @@ func TestRepoBrowserScheduledRefreshContextStaysCancelable(t *testing.T) {
 	require.ErrorIs(err, context.Canceled)
 	repos := mgr.repoBrowserReposSnapshot()
 	assert.Empty(repos)
+}
+
+func TestRepoBrowserScheduledRefreshKeepsAuthorizationUntilJoinedWorkStops(
+	t *testing.T,
+) {
+	require := require.New(t)
+	assert := assert.New(t)
+	mgr, repo, _ := setupRepoBrowserTestRepo(t)
+	workStarted := make(chan struct{})
+	stopWork := make(chan struct{})
+	mgr.repoBrowserRefreshFn = func(
+		context.Context,
+		RepoBrowserRepoRef,
+	) error {
+		close(workStarted)
+		<-stopWork
+		return nil
+	}
+	detachedDone := make(chan error, 1)
+	go func() {
+		detachedDone <- mgr.refreshRepoBrowserClone(
+			context.Background(),
+			repo,
+			repoBrowserRefreshDetachCaller,
+		)
+	}()
+	<-workStarted
+
+	refreshCtx, cancelRefresh := context.WithCancel(t.Context())
+	authorized := make(chan struct{})
+	released := make(chan struct{})
+	refreshDone := make(chan struct{})
+	go func() {
+		defer close(refreshDone)
+		mgr.RefreshRepoBrowserClones(
+			refreshCtx,
+			func(
+				context.Context,
+				RepoBrowserRepoRef,
+			) (RepoBrowserRepoRef, func(), bool, error) {
+				close(authorized)
+				return repo, func() { close(released) }, true, nil
+			},
+		)
+	}()
+	<-authorized
+	cancelRefresh()
+
+	releasedBeforeWorkStopped := false
+	select {
+	case <-released:
+		releasedBeforeWorkStopped = true
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(stopWork)
+	select {
+	case <-detachedDone:
+	case <-time.After(2 * time.Second):
+		require.Fail("detached refresh did not stop")
+	}
+	select {
+	case <-refreshDone:
+	case <-time.After(2 * time.Second):
+		require.Fail("scheduled refresh did not stop")
+	}
+
+	assert.False(
+		releasedBeforeWorkStopped,
+		"authorization must remain held until joined singleflight work stops",
+	)
+	select {
+	case <-released:
+	default:
+		require.Fail("authorization was not released after refresh work stopped")
+	}
 }
 
 func TestRepoBrowserRequestRefreshWorkDetachesCallerCancellation(t *testing.T) {
@@ -618,6 +807,7 @@ func setupRepoBrowserTestRepo(t *testing.T) (*Manager, RepoBrowserRepoRef, strin
 
 	mgr := New(filepath.Join(dir, "clones"), nil)
 	repo := RepoBrowserRepoRef{
+		RepoID:    42,
 		Provider:  "github",
 		Host:      "github.com",
 		Owner:     "acme",

--- a/internal/github/archive_lifecycle_test.go
+++ b/internal/github/archive_lifecycle_test.go
@@ -1258,7 +1258,19 @@ func TestSyncRepoRegistersReadAndWriteIdentityProviderWork(t *testing.T) {
 		<-release
 		return nil, errors.New("stop after identity resolution")
 	}}
-	syncer := NewSyncer(map[string]Client{"github.com": mc}, database, nil, nil, time.Hour, nil, nil)
+	repo := RepoRef{
+		Platform: platform.KindGitHub, PlatformHost: "github.com",
+		Owner: "acme", Name: "widget",
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc},
+		database,
+		nil,
+		[]RepoRef{repo},
+		time.Hour,
+		nil,
+		nil,
+	)
 	t.Cleanup(syncer.Stop)
 	router, err := NewHostRouter("github.com", &Route{
 		Key:           RouteKey{Host: "github.com", Owner: "acme"},
@@ -1268,10 +1280,6 @@ func TestSyncRepoRegistersReadAndWriteIdentityProviderWork(t *testing.T) {
 	})
 	require.NoError(err)
 	syncer.SetGitHubRouters(map[string]*HostRouter{"github.com": router})
-	repo := RepoRef{
-		Platform: platform.KindGitHub, PlatformHost: "github.com",
-		Owner: "acme", Name: "widget",
-	}
 
 	done := make(chan error, 1)
 	go func() { done <- syncer.syncRepo(t.Context(), repo) }()

--- a/internal/github/auth_router.go
+++ b/internal/github/auth_router.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 
 	gh "github.com/google/go-github/v89/github"
 	"go.kenn.io/forge/internal/platform"
@@ -70,6 +71,17 @@ type HostRouter struct {
 	owners          map[string]*Route
 	repos           map[string]*Route
 	discoveryOwners map[string]Client
+	aliasesMu       sync.RWMutex
+	aliases         map[string]*Route
+}
+
+// CredentialAlias selects credentials through a configured repository route
+// while provider requests continue to address the repository's current route.
+type CredentialAlias struct {
+	Owner           string
+	Name            string
+	CredentialOwner string
+	CredentialName  string
 }
 
 func NewHostRouter(host string, routes ...*Route) (*HostRouter, error) {
@@ -78,6 +90,7 @@ func NewHostRouter(host string, routes ...*Route) (*HostRouter, error) {
 		owners:          make(map[string]*Route),
 		repos:           make(map[string]*Route),
 		discoveryOwners: make(map[string]Client),
+		aliases:         make(map[string]*Route),
 	}
 	for _, route := range routes {
 		if route == nil {
@@ -169,6 +182,12 @@ func (r *HostRouter) RouteForRepo(owner, name string) (*Route, error) {
 		if route := r.repos[repoRouteMapKey(owner, name)]; route != nil {
 			return route, nil
 		}
+		r.aliasesMu.RLock()
+		alias := r.aliases[repoRouteMapKey(owner, name)]
+		r.aliasesMu.RUnlock()
+		if alias != nil {
+			return alias, nil
+		}
 	}
 	route, err := r.RouteForOwner(owner)
 	if err != nil {
@@ -177,6 +196,45 @@ func (r *HostRouter) RouteForRepo(owner, name string) (*Route, error) {
 		}
 	}
 	return route, err
+}
+
+// ReplaceCredentialAliases atomically replaces the provider-route to
+// configured-credential-route bindings derived from the tracked repository
+// set. Directly configured exact routes always take precedence over aliases.
+func (r *HostRouter) ReplaceCredentialAliases(
+	aliases []CredentialAlias,
+) error {
+	if r == nil {
+		return nil
+	}
+	next := make(map[string]*Route, len(aliases))
+	for _, alias := range aliases {
+		if strings.TrimSpace(alias.Owner) == "" ||
+			strings.TrimSpace(alias.Name) == "" ||
+			strings.TrimSpace(alias.CredentialOwner) == "" ||
+			strings.TrimSpace(alias.CredentialName) == "" {
+			continue
+		}
+		route, err := r.configuredRouteForRepo(
+			alias.CredentialOwner,
+			alias.CredentialName,
+		)
+		if err != nil {
+			return err
+		}
+		next[repoRouteMapKey(alias.Owner, alias.Name)] = route
+	}
+	r.aliasesMu.Lock()
+	r.aliases = next
+	r.aliasesMu.Unlock()
+	return nil
+}
+
+func (r *HostRouter) configuredRouteForRepo(owner, name string) (*Route, error) {
+	if route := r.repos[repoRouteMapKey(owner, name)]; route != nil {
+		return route, nil
+	}
+	return r.RouteForOwner(owner)
 }
 
 func (r *HostRouter) ReadIdentityForRepo(owner, name string) (IdentityKey, error) {
@@ -600,7 +658,13 @@ func (c *RoutedClient) ListNotifications(ctx context.Context, opts NotificationL
 	var client Client
 	var err error
 	if opts.RepoOwner != "" && opts.RepoName != "" {
-		client, err = c.routeForRepo(opts.RepoOwner, opts.RepoName)
+		routeOwner := opts.RepoOwner
+		routeName := opts.RepoName
+		if opts.CredentialOwner != "" && opts.CredentialName != "" {
+			routeOwner = opts.CredentialOwner
+			routeName = opts.CredentialName
+		}
+		client, err = c.routeForRepo(routeOwner, routeName)
 	} else {
 		client, err = c.fallbackClient()
 	}

--- a/internal/github/auth_router_test.go
+++ b/internal/github/auth_router_test.go
@@ -19,14 +19,15 @@ import (
 
 type routeRecordingClient struct {
 	Client
-	marker         string
-	calls          []string
-	snapshot       *RateLimitSnapshot
-	snapshotErr    error
-	snapshotSource tokenauth.Source
-	snapshotToken  string
-	userSource     tokenauth.Source
-	userToken      string
+	marker           string
+	calls            []string
+	notificationOpts []NotificationListOptions
+	snapshot         *RateLimitSnapshot
+	snapshotErr      error
+	snapshotSource   tokenauth.Source
+	snapshotToken    string
+	userSource       tokenauth.Source
+	userToken        string
 }
 
 func (c *routeRecordingClient) GetRepository(
@@ -340,10 +341,44 @@ func (c *routeRecordingClient) bypassNotificationReadRateReserve() bool {
 }
 
 func (c *routeRecordingClient) ListNotifications(
-	_ context.Context, _ NotificationListOptions,
+	_ context.Context, opts NotificationListOptions,
 ) ([]NotificationThread, bool, error) {
 	c.calls = append(c.calls, "notifications")
+	c.notificationOpts = append(c.notificationOpts, opts)
 	return nil, false, nil
+}
+
+func TestRoutedClientListsRenamedRepoNotificationsWithConfiguredCredential(
+	t *testing.T,
+) {
+	require := require.New(t)
+	assert := assert.New(t)
+	exactClient := &routeRecordingClient{marker: "exact"}
+	router, err := NewHostRouter("github.com", &Route{
+		Key: RouteKey{
+			Host:  "github.com",
+			Owner: "acme",
+			Name:  "widget",
+		},
+		Client: exactClient,
+	})
+	require.NoError(err)
+	client, err := NewRoutedClient(router)
+	require.NoError(err)
+
+	_, _, err = client.ListNotifications(
+		t.Context(),
+		NotificationListOptions{
+			RepoOwner:       "acme-tools",
+			RepoName:        "renamed-widget",
+			CredentialOwner: "acme",
+			CredentialName:  "widget",
+		},
+	)
+	require.NoError(err)
+	require.Len(exactClient.notificationOpts, 1)
+	assert.Equal("acme-tools", exactClient.notificationOpts[0].RepoOwner)
+	assert.Equal("renamed-widget", exactClient.notificationOpts[0].RepoName)
 }
 
 func TestHostRouterSelectsExactOwnerAndFallbackRoutes(t *testing.T) {

--- a/internal/github/graphql_live_test.go
+++ b/internal/github/graphql_live_test.go
@@ -2,6 +2,8 @@ package github
 
 import (
 	"context"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -13,6 +15,7 @@ import (
 func TestLiveGraphQLQueriesValidateAgainstGitHub(t *testing.T) {
 	skipUnlessLiveGitHubTests(t)
 	token := requireLiveGitHubToken(t)
+	require := require.New(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
@@ -21,18 +24,26 @@ func TestLiveGraphQLQueriesValidateAgainstGitHub(t *testing.T) {
 		context.Background(),
 		oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token}),
 	))
+	repository := strings.TrimSpace(os.Getenv("GITHUB_REPOSITORY"))
+	if repository == "" {
+		repository = "kenn-io/middleman"
+	}
+	owner, name, ok := strings.Cut(repository, "/")
+	require.True(ok, "GITHUB_REPOSITORY must use owner/name form")
+	require.NotEmpty(owner, "GITHUB_REPOSITORY owner must not be empty")
+	require.NotEmpty(name, "GITHUB_REPOSITORY name must not be empty")
 
 	var prQuery gqlPRQuery[gqlPR]
 	vars := map[string]any{
-		"owner":    githubv4.String("kenn-io"),
-		"name":     githubv4.String("middleman"),
+		"owner":    githubv4.String(owner),
+		"name":     githubv4.String(name),
 		"pageSize": githubv4.Int(1),
 		"cursor":   (*githubv4.String)(nil),
 	}
 	err := client.Query(ctx, &prQuery, vars)
-	require.NoError(t, err, "bulk PR GraphQL query should validate against GitHub")
+	require.NoError(err, "bulk PR GraphQL query should validate against GitHub")
 
 	var issueQuery gqlIssueQuery
 	err = client.Query(ctx, &issueQuery, vars)
-	require.NoError(t, err, "bulk issue GraphQL query should validate against GitHub")
+	require.NoError(err, "bulk issue GraphQL query should validate against GitHub")
 }

--- a/internal/github/merged_diff_test.go
+++ b/internal/github/merged_diff_test.go
@@ -46,33 +46,70 @@ func initTestRepo(t *testing.T, dir string) {
 	gitRun(t, dir, "commit", "-m", "initial commit")
 }
 
-// setupBareClone creates a bare clone of sourceDir under clonesDir/owner/name.git,
-// adds the pull refspec, and fetches.
-func setupBareClone(t *testing.T, sourceDir, clonesDir, owner, name string) *gitclone.Manager {
+// setupBareClone creates a repository row and a bare clone of sourceDir in its
+// immutable repository-incarnation namespace, adds the pull refspec, and
+// fetches.
+func setupBareClone(
+	t *testing.T,
+	ctx context.Context,
+	sourceDir, clonesDir, owner, name string,
+	d *db.DB,
+) (*gitclone.Manager, int64) {
 	t.Helper()
+	repoID, err := d.UpsertRepo(
+		ctx, db.GitHubRepoIdentity("github.com", owner, name),
+	)
+	require.NoError(t, err)
 	mgr := gitclone.New(clonesDir, nil)
-	barePath, err := mgr.ClonePath("github", "github.com", owner, name)
+	barePath, err := mgr.RepositoryClone(
+		repoID, "github", "github.com", owner, name,
+	).ClonePath()
 	require.NoError(t, err)
 	gitRun(t, "", "clone", "--bare", sourceDir, barePath)
 	gitRun(t, barePath, "config", "--add", "remote.origin.fetch",
 		"+refs/pull/*/head:refs/pull/*/head")
 	gitRun(t, barePath, "remote", "set-url", "origin", sourceDir)
 	gitRun(t, barePath, "fetch", "--prune", "origin")
-	return mgr
+	return mgr, repoID
 }
 
 // setupSyncer creates a syncer with a real DB, bare clone manager, and mock client.
 // It runs one sync cycle to create the repo row, then returns the syncer and repo ID.
-func setupSyncer(t *testing.T, ctx context.Context, mgr *gitclone.Manager) (*Syncer, int64) {
+func setupSyncer(
+	t *testing.T,
+	ctx context.Context,
+	sourceDir, clonesDir string,
+) (*Syncer, int64) {
 	t.Helper()
 	d := openTestDB(t)
+	mgr, repoID := setupBareClone(
+		t, ctx, sourceDir, clonesDir, "owner", "repo", d,
+	)
 	mc := &mockClient{}
-	syncer := NewSyncer(map[string]Client{"github.com": mc}, d, mgr, []RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}}, time.Minute, nil, testBudget(500))
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc},
+		d,
+		mgr,
+		[]RepoRef{mergedDiffRepoRef(repoID)},
+		time.Minute,
+		nil,
+		testBudget(500),
+	)
 	syncer.RunOnce(ctx) // creates repo row
 	repoRow, err := d.GetRepoByIdentity(ctx, db.GitHubRepoIdentity("github.com", "owner", "repo"))
 	require.NoError(t, err)
 	require.NotNil(t, repoRow)
-	return syncer, repoRow.ID
+	require.Equal(t, repoID, repoRow.ID)
+	return syncer, repoID
+}
+
+func mergedDiffRepoRef(repoID int64) RepoRef {
+	return RepoRef{
+		RepoID:       repoID,
+		Owner:        "owner",
+		Name:         "repo",
+		PlatformHost: "github.com",
+	}
 }
 
 // insertMergedPR inserts a merged PR with empty diff SHAs into the DB.
@@ -121,11 +158,10 @@ func TestIntegrationComputeMergedPRDiffSHAs_MergeCommit(t *testing.T) {
 	// Create pull ref.
 	gitRun(t, sourceDir, "update-ref", "refs/pull/1/head", prHead)
 
-	mgr := setupBareClone(t, sourceDir, clonesDir, "owner", "repo")
-	syncer, repoID := setupSyncer(t, ctx, mgr)
+	syncer, repoID := setupSyncer(t, ctx, sourceDir, clonesDir)
 	mrID, revision := insertMergedPR(t, ctx, syncer.db, repoID, 1, prHead)
 
-	require.NoError(syncer.computeMergedMRDiffSHAs(ctx, RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}, repoID, mrID, revision, 1, prHead, "", mergeCommit, false))
+	require.NoError(syncer.computeMergedMRDiffSHAs(ctx, mergedDiffRepoRef(repoID), repoID, mrID, revision, 1, prHead, "", mergeCommit, false))
 
 	shas, err := syncer.db.GetDiffSHAs(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
@@ -159,21 +195,20 @@ func TestIntegrationComputeMergedPRDiffSHAs_ForceOverwritesIncorrectSHAs(t *test
 
 	gitRun(t, sourceDir, "update-ref", "refs/pull/1/head", prHead)
 
-	mgr := setupBareClone(t, sourceDir, clonesDir, "owner", "repo")
-	syncer, repoID := setupSyncer(t, ctx, mgr)
+	syncer, repoID := setupSyncer(t, ctx, sourceDir, clonesDir)
 	mrID, revision := insertMergedPR(t, ctx, syncer.db, repoID, 1, prHead)
 
 	// Seed incorrect diff SHAs (simulating prior SyncMR regression).
 	require.NoError(syncer.db.UpdateDiffSHAs(ctx, repoID, 1, "bad-head", "bad-base", "bad-merge-base"))
 
 	// Without force, the existing (incorrect) SHAs are preserved.
-	require.NoError(syncer.computeMergedMRDiffSHAs(ctx, RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}, repoID, mrID, revision, 1, prHead, "", mergeCommit, false))
+	require.NoError(syncer.computeMergedMRDiffSHAs(ctx, mergedDiffRepoRef(repoID), repoID, mrID, revision, 1, prHead, "", mergeCommit, false))
 	shas, err := syncer.db.GetDiffSHAs(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	assert.Equal("bad-head", shas.DiffHeadSHA, "force=false should not overwrite existing SHAs")
 
 	// With force, the incorrect SHAs are replaced with correct values.
-	require.NoError(syncer.computeMergedMRDiffSHAs(ctx, RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}, repoID, mrID, revision, 1, prHead, "", mergeCommit, true))
+	require.NoError(syncer.computeMergedMRDiffSHAs(ctx, mergedDiffRepoRef(repoID), repoID, mrID, revision, 1, prHead, "", mergeCommit, true))
 	shas, err = syncer.db.GetDiffSHAs(ctx, "github", "github.com", "owner", "repo", 1)
 	require.NoError(err)
 	require.NotNil(shas)
@@ -207,11 +242,10 @@ func TestIntegrationComputeMergedPRDiffSHAs_SquashMerge(t *testing.T) {
 
 	gitRun(t, sourceDir, "update-ref", "refs/pull/2/head", prHead)
 
-	mgr := setupBareClone(t, sourceDir, clonesDir, "owner", "repo")
-	syncer, repoID := setupSyncer(t, ctx, mgr)
+	syncer, repoID := setupSyncer(t, ctx, sourceDir, clonesDir)
 	mrID, revision := insertMergedPR(t, ctx, syncer.db, repoID, 2, prHead)
 
-	require.NoError(syncer.computeMergedMRDiffSHAs(ctx, RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}, repoID, mrID, revision, 2, prHead, "", squashCommit, false))
+	require.NoError(syncer.computeMergedMRDiffSHAs(ctx, mergedDiffRepoRef(repoID), repoID, mrID, revision, 2, prHead, "", squashCommit, false))
 
 	shas, err := syncer.db.GetDiffSHAs(ctx, "github", "github.com", "owner", "repo", 2)
 	require.NoError(err)
@@ -259,11 +293,10 @@ func TestIntegrationComputeMergedPRDiffSHAs_RebaseMerge(t *testing.T) {
 	// Pull ref points to original (pre-rebase) PR head.
 	gitRun(t, sourceDir, "update-ref", "refs/pull/3/head", prHead)
 
-	mgr := setupBareClone(t, sourceDir, clonesDir, "owner", "repo")
-	syncer, repoID := setupSyncer(t, ctx, mgr)
+	syncer, repoID := setupSyncer(t, ctx, sourceDir, clonesDir)
 	mrID, revision := insertMergedPR(t, ctx, syncer.db, repoID, 3, prHead)
 
-	require.NoError(syncer.computeMergedMRDiffSHAs(ctx, RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}, repoID, mrID, revision, 3, prHead, "", rebaseLastCommit, false))
+	require.NoError(syncer.computeMergedMRDiffSHAs(ctx, mergedDiffRepoRef(repoID), repoID, mrID, revision, 3, prHead, "", rebaseLastCommit, false))
 
 	shas, err := syncer.db.GetDiffSHAs(ctx, "github", "github.com", "owner", "repo", 3)
 	require.NoError(err)
@@ -306,7 +339,10 @@ func TestIntegrationSyncOpenToMergedTransition(t *testing.T) {
 	gitRun(t, sourceDir, "update-ref", "refs/pull/10/head", prHead)
 
 	// Set up bare clone BEFORE the merge -- reflects the pre-merge state.
-	mgr := setupBareClone(t, sourceDir, clonesDir, "owner", "repo")
+	d := openTestDB(t)
+	mgr, repoID := setupBareClone(
+		t, ctx, sourceDir, clonesDir, "owner", "repo", d,
+	)
 
 	now := time.Now().UTC()
 	number := 10
@@ -341,8 +377,15 @@ func TestIntegrationSyncOpenToMergedTransition(t *testing.T) {
 		openPRs: []*gh.PullRequest{openPR},
 	}
 
-	d := openTestDB(t)
-	syncer := NewSyncer(map[string]Client{"github.com": mc}, d, mgr, []RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}}, time.Minute, nil, testBudget(500))
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc},
+		d,
+		mgr,
+		[]RepoRef{mergedDiffRepoRef(repoID)},
+		time.Minute,
+		nil,
+		testBudget(500),
+	)
 	syncer.RunOnce(ctx)
 
 	pr, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", number)
@@ -364,7 +407,9 @@ func TestIntegrationSyncOpenToMergedTransition(t *testing.T) {
 	postmergeBaseSHA := gitRun(t, sourceDir, "rev-parse", "main")
 
 	// Re-fetch the bare clone to pick up the merge commit.
-	barePath, err := mgr.ClonePath("github", "github.com", "owner", "repo")
+	barePath, err := mgr.RepositoryClone(
+		repoID, "github", "github.com", "owner", "repo",
+	).ClonePath()
 	require.NoError(err)
 	gitRun(t, barePath, "fetch", "--prune", "origin")
 
@@ -475,7 +520,9 @@ func TestIntegrationSyncFirstSeenMergedPR(t *testing.T) {
 	postmergeBaseSHA := gitRun(t, sourceDir, "rev-parse", "main")
 
 	// Set up bare clone (post-merge state).
-	mgr := setupBareClone(t, sourceDir, clonesDir, "owner", "repo")
+	mgr, repoID := setupBareClone(
+		t, ctx, sourceDir, clonesDir, "owner", "repo", d,
+	)
 
 	closedState := "closed"
 	merged := true
@@ -500,7 +547,15 @@ func TestIntegrationSyncFirstSeenMergedPR(t *testing.T) {
 	// diff SHAs are empty.
 	mc.openPRs = nil
 	mc.singlePR = mergedPR
-	syncer2 := NewSyncer(map[string]Client{"github.com": mc}, d, mgr, []RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}}, time.Minute, nil, nil)
+	syncer2 := NewSyncer(
+		map[string]Client{"github.com": mc},
+		d,
+		mgr,
+		[]RepoRef{mergedDiffRepoRef(repoID)},
+		time.Minute,
+		nil,
+		nil,
+	)
 	syncer2.RunOnce(ctx)
 
 	shas, err := d.GetDiffSHAs(ctx, "github", "github.com", "owner", "repo", number)
@@ -539,7 +594,10 @@ func TestIntegrationSyncMRWrapsDiffFailureAsDiffSyncError(t *testing.T) {
 	prHead := gitRun(t, sourceDir, "rev-parse", "HEAD")
 	gitRun(t, sourceDir, "update-ref", "refs/pull/42/head", prHead)
 
-	mgr := setupBareClone(t, sourceDir, clonesDir, "owner", "repo")
+	d := openTestDB(t)
+	mgr, repoID := setupBareClone(
+		t, ctx, sourceDir, clonesDir, "owner", "repo", d,
+	)
 
 	// Now merge in the source repo *after* the bare clone has snapshotted,
 	// so the merge commit is unreachable from the clone.
@@ -552,7 +610,9 @@ func TestIntegrationSyncMRWrapsDiffFailureAsDiffSyncError(t *testing.T) {
 	// `git fetch` succeeds but the merge commit never enters the clone.
 	emptyRemote := t.TempDir()
 	initTestRepo(t, emptyRemote)
-	barePath, err := mgr.ClonePath("github", "github.com", "owner", "repo")
+	barePath, err := mgr.RepositoryClone(
+		repoID, "github", "github.com", "owner", "repo",
+	).ClonePath()
 	require.NoError(err)
 	gitRun(t, barePath, "remote", "set-url", "origin", emptyRemote)
 
@@ -582,9 +642,8 @@ func TestIntegrationSyncMRWrapsDiffFailureAsDiffSyncError(t *testing.T) {
 	}
 
 	mc := &mockClient{singlePR: mergedPR}
-	d := openTestDB(t)
 	syncer := NewSyncer(map[string]Client{"github.com": mc}, d, mgr,
-		[]RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}},
+		[]RepoRef{mergedDiffRepoRef(repoID)},
 		time.Minute, nil, nil)
 
 	err = syncer.SyncMR(ctx, "owner", "repo", number)
@@ -648,7 +707,10 @@ func TestIntegrationSyncItemByNumberReturnsTypeOnDiffSyncError(t *testing.T) {
 	prHead := gitRun(t, sourceDir, "rev-parse", "HEAD")
 	gitRun(t, sourceDir, "update-ref", "refs/pull/77/head", prHead)
 
-	mgr := setupBareClone(t, sourceDir, clonesDir, "owner", "repo")
+	d := openTestDB(t)
+	mgr, repoID := setupBareClone(
+		t, ctx, sourceDir, clonesDir, "owner", "repo", d,
+	)
 
 	gitRun(t, sourceDir, "checkout", "main")
 	gitRun(t, sourceDir, "merge", "--no-ff", "feature", "-m", "Merge feature")
@@ -659,7 +721,9 @@ func TestIntegrationSyncItemByNumberReturnsTypeOnDiffSyncError(t *testing.T) {
 	// reach it via fetch.
 	emptyRemote := t.TempDir()
 	initTestRepo(t, emptyRemote)
-	barePath, err := mgr.ClonePath("github", "github.com", "owner", "repo")
+	barePath, err := mgr.RepositoryClone(
+		repoID, "github", "github.com", "owner", "repo",
+	).ClonePath()
 	require.NoError(err)
 	gitRun(t, barePath, "remote", "set-url", "origin", emptyRemote)
 
@@ -697,9 +761,8 @@ func TestIntegrationSyncItemByNumberReturnsTypeOnDiffSyncError(t *testing.T) {
 			}, nil
 		},
 	}
-	d := openTestDB(t)
 	syncer := NewSyncer(map[string]Client{"github.com": mc}, d, mgr,
-		[]RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}},
+		[]RepoRef{mergedDiffRepoRef(repoID)},
 		time.Minute, nil, nil)
 
 	itemType, err := syncer.SyncItemByNumber(ctx, "owner", "repo", number)

--- a/internal/github/notifications_sync.go
+++ b/internal/github/notifications_sync.go
@@ -806,14 +806,17 @@ func (s *Syncer) ackRepoBuckets(
 	byNotification := make(map[int64]string, len(queued))
 	seen := make(map[string]struct{})
 	write := kind == platform.KindGitHub
-	add := func(bucket, owner, name string) {
-		key := bucket + "\x00" + strings.ToLower(owner) + "/" + strings.ToLower(name)
+	add := func(bucket string, repoID int64) {
+		if repoID <= 0 {
+			return
+		}
+		key := fmt.Sprintf("%s\x00%d", bucket, repoID)
 		if _, ok := seen[key]; ok {
 			return
 		}
 		seen[key] = struct{}{}
 		byBucket[bucket] = append(byBucket[bucket], db.NotificationRepoRef{
-			Owner: owner, Name: name,
+			RepoID: repoID,
 		})
 	}
 	for _, notification := range queued {
@@ -842,7 +845,7 @@ func (s *Syncer) ackRepoBuckets(
 			continue
 		}
 		byNotification[notification.ID] = bucket
-		add(bucket, repo.Owner, repo.Name)
+		add(bucket, repo.RepoID)
 	}
 	for _, repo := range s.TrackedRepos() {
 		if repoPlatform(repo) != kind || repoHost(repo) != host {
@@ -855,7 +858,7 @@ func (s *Syncer) ackRepoBuckets(
 		if _, relevant := byBucket[bucket]; !relevant {
 			continue
 		}
-		add(bucket, repo.Owner, repo.Name)
+		add(bucket, repo.RepoID)
 	}
 	return byBucket, byNotification
 }

--- a/internal/github/notifications_sync.go
+++ b/internal/github/notifications_sync.go
@@ -274,7 +274,7 @@ func (s *Syncer) syncNotificationsForHost(ctx context.Context, kind platform.Kin
 	var repoErrs []error
 	for _, repo := range trackedRepos {
 		if err := s.syncNotificationsForRepo(
-			ctx, kind, host, client, tracked, repo, startedAt,
+			ctx, kind, host, client, repo, startedAt,
 		); err != nil {
 			repoErrs = append(repoErrs, err)
 		}
@@ -287,13 +287,52 @@ func (s *Syncer) syncNotificationsForRepo(
 	kind platform.Kind,
 	host string,
 	client notificationClient,
-	tracked map[string]RepoRef,
 	repo RepoRef,
 	startedAt time.Time,
 ) error {
+	resolvedRepo, _, err := s.resolveActiveRepository(ctx, repo)
+	if err != nil {
+		return fmt.Errorf(
+			"resolve notification repository %s/%s on %s: %w",
+			repo.Owner,
+			repo.Name,
+			host,
+			err,
+		)
+	}
+	repo = resolvedRepo
+	releaseReconciliation, err := s.db.LockRepositoryReconciliationRead(ctx)
+	if err != nil {
+		return fmt.Errorf(
+			"lease notification repository %s/%s on %s: %w",
+			repo.Owner,
+			repo.Name,
+			host,
+			err,
+		)
+	}
+	defer releaseReconciliation()
+	stored, err := s.db.GetRepoByID(ctx, repo.RepoID)
+	if err != nil {
+		return fmt.Errorf(
+			"reauthorize notification repository %s/%s on %s: %w",
+			repo.Owner,
+			repo.Name,
+			host,
+			err,
+		)
+	}
+	if stored == nil || stored.RetiredAt != nil {
+		return fmt.Errorf(
+			"%w: repository %d",
+			db.ErrRepositoryRetired,
+			repo.RepoID,
+		)
+	}
+	repo = repoRefFromStoredRepository(repo, stored, nil)
 	platformName := string(kind)
 	watermark, err := s.db.GetNotificationSyncWatermark(
-		ctx, platformName, host, repo.Owner, repo.Name,
+		ctx, repo.RepoID,
 	)
 	if err != nil {
 		return fmt.Errorf(
@@ -318,11 +357,13 @@ func (s *Syncer) syncNotificationsForRepo(
 			return err
 		}
 		threads, hasNext, err := client.ListNotifications(ctx, NotificationListOptions{
-			All:       true,
-			Since:     since,
-			Page:      page,
-			RepoOwner: repo.Owner,
-			RepoName:  repo.Name,
+			All:             true,
+			Since:           since,
+			Page:            page,
+			RepoOwner:       repo.Owner,
+			RepoName:        repo.Name,
+			CredentialOwner: repo.CredentialOwner,
+			CredentialName:  repo.CredentialName,
 		})
 		if err != nil {
 			return fmt.Errorf(
@@ -343,8 +384,10 @@ func (s *Syncer) syncNotificationsForRepo(
 				thread.Participating = true
 			}
 			key := notificationRepoKey(platformName, host, thread.RepoOwner, thread.RepoName)
-			trackedRepo, ok := tracked[key]
-			if !ok {
+			resolvedKey := notificationRepoKey(
+				platformName, host, repo.Owner, repo.Name,
+			)
+			if key != resolvedKey {
 				continue
 			}
 			// Only notifications anchored to a PR or issue have an in-app
@@ -362,7 +405,7 @@ func (s *Syncer) syncNotificationsForRepo(
 			if thread.Reason == "author" {
 				continue
 			}
-			notification, err := s.notificationToDB(ctx, host, trackedRepo, thread, now)
+			notification, err := s.notificationToDB(ctx, host, repo, thread, now)
 			if err != nil {
 				return fmt.Errorf(
 					"normalize notification %s for %s/%s on %s page %d: %w",
@@ -380,7 +423,7 @@ func (s *Syncer) syncNotificationsForRepo(
 	}
 	lastFullSyncAt := watermarkLastFullSyncAt(watermark, startedAt, fullSync)
 	if err := s.db.UpdateNotificationSyncWatermark(
-		ctx, platformName, host, repo.Owner, repo.Name, startedAt, lastFullSyncAt,
+		ctx, repo.RepoID, startedAt, lastFullSyncAt,
 	); err != nil {
 		return fmt.Errorf(
 			"store notification sync watermark for %s/%s on %s: %w",
@@ -404,12 +447,14 @@ func (s *Syncer) listParticipatingNotificationIDs(
 				return nil, err
 			}
 			threads, hasNext, err := client.ListNotifications(ctx, NotificationListOptions{
-				All:           true,
-				Participating: true,
-				Since:         since,
-				Page:          page,
-				RepoOwner:     repo.Owner,
-				RepoName:      repo.Name,
+				All:             true,
+				Participating:   true,
+				Since:           since,
+				Page:            page,
+				RepoOwner:       repo.Owner,
+				RepoName:        repo.Name,
+				CredentialOwner: repo.CredentialOwner,
+				CredentialName:  repo.CredentialName,
 			})
 			if err != nil {
 				return nil, fmt.Errorf("list participating notifications for %s/%s on %s page %d: %w", repo.Owner, repo.Name, host, page, err)
@@ -598,7 +643,7 @@ func (s *Syncer) ProcessQueuedNotificationReads(ctx context.Context, kind platfo
 	// could overlap these requests. Rows whose repository no longer resolves
 	// to a route register nothing: their wire calls fail closed at routing
 	// without upstream I/O.
-	bucketRepos, ackBuckets := s.ackRepoBuckets(kind, host, queued)
+	bucketRepos, ackBuckets := s.ackRepoBuckets(ctx, kind, host, queued)
 	seenBuckets := make(map[string]struct{}, len(bucketRepos))
 	for _, notification := range queued {
 		bucket, ok := ackBuckets[notification.ID]
@@ -618,126 +663,129 @@ func (s *Syncer) ProcessQueuedNotificationReads(ctx context.Context, kind platfo
 	exhausted := make(map[string]struct{}, len(seenBuckets))
 	var rateLimitErr error
 	for _, notification := range queued {
-		bucket := ackBuckets[notification.ID]
+		bucket, ok := ackBuckets[notification.ID]
+		if !ok || notification.RepoID == nil {
+			continue
+		}
 		if _, stop := exhausted[bucket]; stop {
 			continue
 		}
-		// Each queued ack spends a refetch, the mark-read, and a
-		// reconciliation refetch on this row's credential. Stop before
-		// crossing that credential's reserve instead of discovering it as a
-		// per-row rate-limit error partway through the acknowledgement.
-		//
-		// Exhausting one credential's headroom stops only that bucket. Other
-		// credentials on this host keep propagating, matching how an actual
-		// rate-limit response is handled below.
-		if err := s.ensureNotificationBudget(RepoRef{
-			Platform: kind, PlatformHost: host,
-			Owner: notification.RepoOwner, Name: notification.RepoName,
-		}, client, notificationAckWorstCaseRequests); err != nil {
+		leaseCtx, repo, release, err := s.leaseActiveRepositoryByID(
+			ctx, *notification.RepoID,
+		)
+		if errors.Is(err, db.ErrRepositoryRetired) ||
+			errors.Is(err, errRepositoryResolutionSuperseded) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		notification.RepoOwner = repo.Owner
+		notification.RepoName = repo.Name
+		limited, limitedErr, processErr := s.processQueuedNotificationRead(
+			leaseCtx, kind, host, bucket, bucketRepos[bucket],
+			client, repo, notification,
+		)
+		release()
+		if processErr != nil {
+			return processErr
+		}
+		if limited {
 			exhausted[bucket] = struct{}{}
 			if rateLimitErr == nil {
-				rateLimitErr = err
+				rateLimitErr = limitedErr
 			}
-			continue
-		}
-		current, err := s.db.NotificationAckPropagationCurrent(ctx, notification.ID, notification.SourceAckQueuedAt, notification.SourceUpdatedAt)
-		if err != nil {
-			return err
-		}
-		if !current {
-			continue
-		}
-		remote, advanced, err := s.fetchAdvancedNotificationThread(ctx, host, client, notification)
-		if err != nil {
-			// The pre-ack refetch spends the same upstream budget as the
-			// mark-read call, so a rate limit here must defer the queued ack
-			// rather than retry the same due row every tick. Only this refetch
-			// API error routes through backoff; the persistence error below
-			// surfaces normally so a failed local refresh is not hidden.
-			limited, deferErr := s.deferQueuedNotificationAckOnError(
-				ctx, kind, host, bucket, bucketRepos[bucket], notification, err,
-			)
-			if deferErr != nil {
-				return deferErr
-			}
-			if limited {
-				exhausted[bucket] = struct{}{}
-				rateLimitErr = fmt.Errorf(
-					"notification read propagation rate limited for %s/%s on %s: %w",
-					notification.RepoOwner, notification.RepoName, host, err,
-				)
-			}
-			continue
-		}
-		if advanced {
-			// New activity arrived since the read was queued. Refresh local
-			// state from the upstream thread, preserving its read/unread flag
-			// so a thread the user already read upstream is not resurrected,
-			// and skip the mark-read so we never ack unseen activity.
-			if err := s.persistReopenedNotification(ctx, host, notification, remote, false); err != nil {
-				return err
-			}
-			continue
-		}
-		markRead := client.MarkNotificationThreadRead
-		if routed, ok := client.(routedNotificationReadMarker); ok {
-			markRead = func(ctx context.Context, threadID string) error {
-				return routed.MarkNotificationThreadReadForRepo(
-					ctx, notification.RepoOwner, notification.RepoName, threadID,
-				)
-			}
-		}
-		if err := markRead(ctx, notification.PlatformNotificationID); err != nil {
-			limited, deferErr := s.deferQueuedNotificationAckOnError(
-				ctx, kind, host, bucket, bucketRepos[bucket], notification, err,
-			)
-			if deferErr != nil {
-				return deferErr
-			}
-			if limited {
-				exhausted[bucket] = struct{}{}
-				rateLimitErr = fmt.Errorf(
-					"notification read propagation rate limited for %s/%s on %s: %w",
-					notification.RepoOwner, notification.RepoName, host, err,
-				)
-			}
-			continue
-		}
-		// Reconciliation refetch: if the thread advanced between the pre-ack
-		// refetch and the mark-read, our PATCH may have read newer activity
-		// the user never saw, so force it back to unread. Do not clear the
-		// queued ack until this refetch proves there was no newer activity.
-		remote, advanced, err = s.fetchAdvancedNotificationThread(ctx, host, client, notification)
-		if err != nil {
-			limited, deferErr := s.reopenNotificationAfterPostAckRefetchError(
-				ctx, kind, host, bucket, bucketRepos[bucket], notification, err,
-			)
-			if deferErr != nil {
-				return deferErr
-			}
-			if limited {
-				exhausted[bucket] = struct{}{}
-				rateLimitErr = fmt.Errorf(
-					"notification read propagation rate limited for %s/%s on %s: %w",
-					notification.RepoOwner, notification.RepoName, host, err,
-				)
-			}
-			continue
-		}
-		if advanced {
-			if err := s.persistReopenedNotification(ctx, host, notification, remote, true); err != nil {
-				return err
-			}
-			continue
-		}
-		syncedAt := time.Now().UTC()
-		if err := s.db.MarkNotificationAckPropagationResult(ctx, notification.ID, notification.SourceAckQueuedAt, notification.SourceUpdatedAt, &syncedAt, "", nil); err != nil {
-			return err
 		}
 	}
 	// Healthy credentials finished their rows; still report the rate limit so
 	// the caller records the host's sync error rather than claiming success.
 	return rateLimitErr
+}
+
+func (s *Syncer) processQueuedNotificationRead(
+	ctx context.Context,
+	kind platform.Kind,
+	host string,
+	bucket string,
+	bucketRepos []db.NotificationRepoRef,
+	client notificationClient,
+	repo RepoRef,
+	notification db.Notification,
+) (bool, error, error) {
+	if err := s.ensureNotificationBudget(
+		repo, client, notificationAckWorstCaseRequests,
+	); err != nil {
+		return true, err, nil
+	}
+	current, err := s.db.NotificationAckPropagationCurrent(
+		ctx, notification.ID, notification.SourceAckQueuedAt,
+		notification.SourceUpdatedAt,
+	)
+	if err != nil || !current {
+		return false, nil, err
+	}
+	remote, advanced, err := s.fetchAdvancedNotificationThread(
+		ctx, host, client, notification,
+	)
+	if err != nil {
+		limited, deferErr := s.deferQueuedNotificationAckOnError(
+			ctx, kind, host, bucket, bucketRepos, notification, err,
+		)
+		return limited, notificationAckRateLimitError(host, notification, err, limited), deferErr
+	}
+	if advanced {
+		return false, nil, s.persistReopenedNotification(
+			ctx, host, notification, remote, false,
+		)
+	}
+	markRead := client.MarkNotificationThreadRead
+	if routed, ok := client.(routedNotificationReadMarker); ok {
+		markRead = func(ctx context.Context, threadID string) error {
+			return routed.MarkNotificationThreadReadForRepo(
+				ctx, notification.RepoOwner, notification.RepoName, threadID,
+			)
+		}
+	}
+	if err := markRead(ctx, notification.PlatformNotificationID); err != nil {
+		limited, deferErr := s.deferQueuedNotificationAckOnError(
+			ctx, kind, host, bucket, bucketRepos, notification, err,
+		)
+		return limited, notificationAckRateLimitError(host, notification, err, limited), deferErr
+	}
+	remote, advanced, err = s.fetchAdvancedNotificationThread(
+		ctx, host, client, notification,
+	)
+	if err != nil {
+		limited, deferErr := s.reopenNotificationAfterPostAckRefetchError(
+			ctx, kind, host, bucket, bucketRepos, notification, err,
+		)
+		return limited, notificationAckRateLimitError(host, notification, err, limited), deferErr
+	}
+	if advanced {
+		return false, nil, s.persistReopenedNotification(
+			ctx, host, notification, remote, true,
+		)
+	}
+	syncedAt := time.Now().UTC()
+	return false, nil, s.db.MarkNotificationAckPropagationResult(
+		ctx, notification.ID, notification.SourceAckQueuedAt,
+		notification.SourceUpdatedAt, &syncedAt, "", nil,
+	)
+}
+
+func notificationAckRateLimitError(
+	host string,
+	notification db.Notification,
+	cause error,
+	limited bool,
+) error {
+	if !limited {
+		return nil
+	}
+	return fmt.Errorf(
+		"notification read propagation rate limited for %s/%s on %s: %w",
+		notification.RepoOwner, notification.RepoName, host, cause,
+	)
 }
 
 // ackRepoBuckets groups the repositories whose queued acknowledgements share a
@@ -749,7 +797,10 @@ func (s *Syncer) ProcessQueuedNotificationReads(ctx context.Context, kind platfo
 // always present, so deferral works even for a syncer with no tracked repos,
 // while the tracked list also reaches queued rows this batch did not include.
 func (s *Syncer) ackRepoBuckets(
-	kind platform.Kind, host string, queued []db.Notification,
+	ctx context.Context,
+	kind platform.Kind,
+	host string,
+	queued []db.Notification,
 ) (map[string][]db.NotificationRepoRef, map[int64]string) {
 	byBucket := make(map[string][]db.NotificationRepoRef)
 	byNotification := make(map[int64]string, len(queued))
@@ -766,15 +817,32 @@ func (s *Syncer) ackRepoBuckets(
 		})
 	}
 	for _, notification := range queued {
-		bucket, err := s.bucketKeyForRepo(RepoRef{
-			Platform: kind, PlatformHost: host,
-			Owner: notification.RepoOwner, Name: notification.RepoName,
-		}, write)
+		if notification.RepoID == nil {
+			continue
+		}
+		stored, err := s.db.GetRepoByID(ctx, *notification.RepoID)
+		if err != nil || stored == nil || stored.RetiredAt != nil {
+			continue
+		}
+		repo := RepoRef{
+			Platform: platform.Kind(stored.Platform), RepoID: stored.ID,
+			PlatformHost: stored.PlatformHost, Owner: stored.Owner, Name: stored.Name,
+			RepoPath: stored.RepoPath, PlatformExternalID: stored.PlatformRepoID,
+		}
+		if tracked, ok := s.trackedRepoForActiveRepository(repo); ok {
+			repo.CredentialOwner = tracked.CredentialOwner
+			repo.CredentialName = tracked.CredentialName
+			repo.PlatformRepoID = tracked.PlatformRepoID
+		}
+		if repoPlatform(repo) != kind || repoHost(repo) != host {
+			continue
+		}
+		bucket, err := s.bucketKeyForRepo(repo, write)
 		if err != nil {
 			continue
 		}
 		byNotification[notification.ID] = bucket
-		add(bucket, notification.RepoOwner, notification.RepoName)
+		add(bucket, repo.Owner, repo.Name)
 	}
 	for _, repo := range s.TrackedRepos() {
 		if repoPlatform(repo) != kind || repoHost(repo) != host {

--- a/internal/github/queue.go
+++ b/internal/github/queue.go
@@ -21,6 +21,7 @@ const (
 // item that may need a detail fetch.
 type QueueItem struct {
 	Type         QueueItemType
+	RepoID       int64
 	Platform     platform.Kind
 	RepoOwner    string
 	RepoName     string

--- a/internal/github/repo_config_resolver.go
+++ b/internal/github/repo_config_resolver.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"slices"
 	"strings"
 
 	"go.kenn.io/forge/internal/config"
@@ -32,8 +33,12 @@ func canonicalRepoRef(repo RepoRef) RepoRef {
 	kind := repoPlatform(repo)
 	out := RepoRef{
 		Platform:           kind,
+		RepoID:             repo.RepoID,
 		Owner:              strings.TrimSpace(repo.Owner),
 		Name:               strings.TrimSpace(repo.Name),
+		CredentialOwner:    strings.TrimSpace(repo.CredentialOwner),
+		CredentialName:     strings.TrimSpace(repo.CredentialName),
+		ConfiguredRoutes:   slices.Clone(repo.ConfiguredRoutes),
 		PlatformHost:       canonicalRepoHost(repo.PlatformHost),
 		RepoPath:           strings.TrimSpace(repo.RepoPath),
 		PlatformRepoID:     repo.PlatformRepoID,
@@ -76,6 +81,11 @@ type ResolveConfiguredReposResult struct {
 	Warnings   []error
 }
 
+type configuredRepoCandidateIndex struct {
+	index  int
+	isGlob bool
+}
+
 func FallbackConfiguredRepoRefs(
 	previous []RepoRef,
 	raw config.Repo,
@@ -84,6 +94,15 @@ func FallbackConfiguredRepoRefs(
 	host := raw.PlatformHostOrDefault()
 	repoPath := configuredRepoPath(raw)
 	if !raw.HasNameGlob() {
+		for _, repo := range previous {
+			credentialPath := strings.TrimSpace(repo.CredentialOwner) + "/" +
+				strings.TrimSpace(repo.CredentialName)
+			if repoPlatform(repo) == kind &&
+				sameConfiguredRepoHost(repoHost(repo), host) &&
+				strings.EqualFold(credentialPath, repoPath) {
+				return []RepoRef{repo}
+			}
+		}
 		for _, repo := range previous {
 			if repoPlatform(repo) == kind &&
 				sameConfiguredRepoHost(repoHost(repo), host) &&
@@ -153,7 +172,7 @@ func resolveConfiguredRepos(
 	registry *platform.Registry,
 	repos []config.Repo,
 ) ResolveConfiguredReposResult {
-	seen := make(map[string]struct{})
+	seen := make(map[string]configuredRepoCandidateIndex)
 	result := ResolveConfiguredReposResult{
 		Configured: make([]ConfiguredRepoStatus, 0, len(repos)),
 	}
@@ -168,7 +187,7 @@ func resolveConfiguredRepos(
 		}
 		result.Configured = append(result.Configured, status)
 		for _, repo := range expanded {
-			appendExpandedRepo(&result.Expanded, seen, repo)
+			appendExpandedRepo(&result.Expanded, seen, repo, raw.HasNameGlob())
 		}
 	}
 
@@ -189,6 +208,110 @@ func ResolveConfiguredRepoWithRegistry(
 	repo config.Repo,
 ) (ConfiguredRepoStatus, []RepoRef, error) {
 	return resolveConfiguredRepo(ctx, registry, repo)
+}
+
+// PreferConfiguredRepoCandidate reports whether candidate should replace an
+// existing configured reference that resolved to the same repository route.
+// Exact entries retain repository-scoped credential aliases when they overlap
+// globs. Among exact entries, a current direct route wins over a rename alias.
+func PreferConfiguredRepoCandidate(
+	existing RepoRef,
+	existingIsGlob bool,
+	candidate RepoRef,
+	candidateIsGlob bool,
+) bool {
+	if existingIsGlob != candidateIsGlob {
+		return !candidateIsGlob
+	}
+	if existingIsGlob {
+		return false
+	}
+	return repoUsesDirectCredentialRoute(candidate) &&
+		!repoUsesDirectCredentialRoute(existing)
+}
+
+// MergeConfiguredRepoCandidate combines two configured entries that resolve
+// to the same provider route. Exact entries outrank globs, and every distinct
+// exact route is retained for durable alias persistence.
+func MergeConfiguredRepoCandidate(
+	existing RepoRef,
+	existingIsGlob bool,
+	candidate RepoRef,
+	candidateIsGlob bool,
+) (RepoRef, bool) {
+	replace := PreferConfiguredRepoCandidate(
+		existing, existingIsGlob, candidate, candidateIsGlob,
+	)
+	winner := existing
+	winnerIsGlob := existingIsGlob
+	if replace {
+		winner = candidate
+		winnerIsGlob = candidateIsGlob
+	}
+	routes := configuredRoutesForCandidate(existing, existingIsGlob)
+	routes = appendUniqueConfiguredRoutes(
+		routes,
+		configuredRoutesForCandidate(candidate, candidateIsGlob)...,
+	)
+	if len(routes) > 1 {
+		winner.ConfiguredRoutes = routes
+	} else if len(winner.ConfiguredRoutes) > 0 {
+		winner.ConfiguredRoutes = routes
+	}
+	return winner, winnerIsGlob
+}
+
+func configuredRoutesForCandidate(repo RepoRef, isGlob bool) []ConfiguredRepoRoute {
+	routes := slices.Clone(repo.ConfiguredRoutes)
+	if isGlob {
+		return routes
+	}
+	owner := strings.TrimSpace(repo.CredentialOwner)
+	name := strings.TrimSpace(repo.CredentialName)
+	if owner == "" || name == "" {
+		owner = strings.TrimSpace(repo.Owner)
+		name = strings.TrimSpace(repo.Name)
+	}
+	return appendUniqueConfiguredRoutes(routes, ConfiguredRepoRoute{
+		Owner: owner, Name: name, RepoPath: owner + "/" + name,
+	})
+}
+
+func appendUniqueConfiguredRoutes(
+	routes []ConfiguredRepoRoute,
+	candidates ...ConfiguredRepoRoute,
+) []ConfiguredRepoRoute {
+	for _, candidate := range candidates {
+		key := strings.ToLower(strings.TrimSpace(candidate.RepoPath))
+		if key == "" {
+			key = strings.ToLower(strings.TrimSpace(candidate.Owner) + "/" + strings.TrimSpace(candidate.Name))
+			candidate.RepoPath = strings.TrimSpace(candidate.Owner) + "/" + strings.TrimSpace(candidate.Name)
+		}
+		found := false
+		for _, current := range routes {
+			currentKey := strings.ToLower(strings.TrimSpace(current.RepoPath))
+			if currentKey == "" {
+				currentKey = strings.ToLower(strings.TrimSpace(current.Owner) + "/" + strings.TrimSpace(current.Name))
+			}
+			if currentKey == key {
+				found = true
+				break
+			}
+		}
+		if !found {
+			routes = append(routes, candidate)
+		}
+	}
+	return routes
+}
+
+func repoUsesDirectCredentialRoute(repo RepoRef) bool {
+	if strings.TrimSpace(repo.CredentialOwner) == "" ||
+		strings.TrimSpace(repo.CredentialName) == "" {
+		return true
+	}
+	return strings.EqualFold(repo.CredentialOwner, repo.Owner) &&
+		strings.EqualFold(repo.CredentialName, repo.Name)
 }
 
 func resolveConfiguredRepo(
@@ -312,6 +435,12 @@ func repoRefFromRepository(
 		CloneURL:           repo.CloneURL,
 		DefaultBranch:      repo.DefaultBranch,
 	}
+	if !raw.HasNameGlob() &&
+		(!strings.EqualFold(ref.Owner, raw.Owner) ||
+			!strings.EqualFold(ref.Name, raw.Name)) {
+		ref.CredentialOwner = strings.TrimSpace(raw.Owner)
+		ref.CredentialName = strings.TrimSpace(raw.Name)
+	}
 	if ref.PlatformRepoID == 0 {
 		ref.PlatformRepoID = repo.Ref.PlatformID
 	}
@@ -340,15 +469,22 @@ func repoRefFromRepository(
 
 func appendExpandedRepo(
 	dst *[]RepoRef,
-	seen map[string]struct{},
+	seen map[string]configuredRepoCandidateIndex,
 	repo RepoRef,
+	isGlob bool,
 ) {
 	repo = canonicalRepoRef(repo)
 	key := string(repoPlatform(repo)) + "\x00" + repo.PlatformHost + "\x00" + repo.Owner + "\x00" + repo.Name
-	if _, ok := seen[key]; ok {
+	if current, ok := seen[key]; ok {
+		merged, mergedIsGlob := MergeConfiguredRepoCandidate(
+			(*dst)[current.index], current.isGlob, repo, isGlob,
+		)
+		(*dst)[current.index] = merged
+		current.isGlob = mergedIsGlob
+		seen[key] = current
 		return
 	}
-	seen[key] = struct{}{}
+	seen[key] = configuredRepoCandidateIndex{index: len(*dst), isGlob: isGlob}
 	*dst = append(*dst, repo)
 }
 

--- a/internal/github/repo_config_resolver.go
+++ b/internal/github/repo_config_resolver.go
@@ -39,6 +39,7 @@ func canonicalRepoRef(repo RepoRef) RepoRef {
 		CredentialOwner:    strings.TrimSpace(repo.CredentialOwner),
 		CredentialName:     strings.TrimSpace(repo.CredentialName),
 		ConfiguredRoutes:   slices.Clone(repo.ConfiguredRoutes),
+		ConfiguredGlobs:    slices.Clone(repo.ConfiguredGlobs),
 		PlatformHost:       canonicalRepoHost(repo.PlatformHost),
 		RepoPath:           strings.TrimSpace(repo.RepoPath),
 		PlatformRepoID:     repo.PlatformRepoID,
@@ -100,14 +101,14 @@ func FallbackConfiguredRepoRefs(
 			if repoPlatform(repo) == kind &&
 				sameConfiguredRepoHost(repoHost(repo), host) &&
 				strings.EqualFold(credentialPath, repoPath) {
-				return []RepoRef{repo}
+				return []RepoRef{exactFallbackRepoRef(repo, raw)}
 			}
 		}
 		for _, repo := range previous {
 			if repoPlatform(repo) == kind &&
 				sameConfiguredRepoHost(repoHost(repo), host) &&
 				strings.EqualFold(repoPathOrFullName(repo), repoPath) {
-				return []RepoRef{repo}
+				return []RepoRef{exactFallbackRepoRef(repo, raw)}
 			}
 		}
 		return []RepoRef{fallbackRepoRef(raw, kind, host)}
@@ -127,9 +128,34 @@ func FallbackConfiguredRepoRefs(
 		if err != nil || !matched {
 			continue
 		}
+		repo.CredentialOwner = ""
+		repo.CredentialName = ""
+		repo.ConfiguredRoutes = nil
+		repo.ConfiguredGlobs = []ConfiguredRepoGlob{{
+			Owner: strings.TrimSpace(raw.Owner),
+			Name:  strings.TrimSpace(raw.Name),
+		}}
 		fallback = append(fallback, repo)
 	}
 	return fallback
+}
+
+func exactFallbackRepoRef(repo RepoRef, raw config.Repo) RepoRef {
+	owner := strings.TrimSpace(raw.Owner)
+	name := strings.TrimSpace(raw.Name)
+	repo.ConfiguredGlobs = nil
+	repo.ConfiguredRoutes = []ConfiguredRepoRoute{{
+		Owner: owner, Name: name, RepoPath: owner + "/" + name,
+	}}
+	if !strings.EqualFold(repo.Owner, owner) ||
+		!strings.EqualFold(repo.Name, name) {
+		repo.CredentialOwner = owner
+		repo.CredentialName = name
+	} else {
+		repo.CredentialOwner = ""
+		repo.CredentialName = ""
+	}
+	return repo
 }
 
 func fallbackRepoRef(raw config.Repo, kind platform.Kind, host string) RepoRef {
@@ -253,11 +279,12 @@ func MergeConfiguredRepoCandidate(
 		routes,
 		configuredRoutesForCandidate(candidate, candidateIsGlob)...,
 	)
-	if len(routes) > 1 {
-		winner.ConfiguredRoutes = routes
-	} else if len(winner.ConfiguredRoutes) > 0 {
+	if len(routes) > 0 {
 		winner.ConfiguredRoutes = routes
 	}
+	winner.ConfiguredGlobs = appendUniqueConfiguredGlobs(
+		slices.Clone(existing.ConfiguredGlobs), candidate.ConfiguredGlobs...,
+	)
 	return winner, winnerIsGlob
 }
 
@@ -303,6 +330,22 @@ func appendUniqueConfiguredRoutes(
 		}
 	}
 	return routes
+}
+
+func appendUniqueConfiguredGlobs(
+	globs []ConfiguredRepoGlob,
+	candidates ...ConfiguredRepoGlob,
+) []ConfiguredRepoGlob {
+	for _, candidate := range candidates {
+		found := slices.ContainsFunc(globs, func(current ConfiguredRepoGlob) bool {
+			return strings.EqualFold(current.Owner, candidate.Owner) &&
+				strings.EqualFold(current.Name, candidate.Name)
+		})
+		if !found {
+			globs = append(globs, candidate)
+		}
+	}
+	return globs
 }
 
 func repoUsesDirectCredentialRoute(repo RepoRef) bool {
@@ -434,6 +477,12 @@ func repoRefFromRepository(
 		WebURL:             repo.WebURL,
 		CloneURL:           repo.CloneURL,
 		DefaultBranch:      repo.DefaultBranch,
+	}
+	if raw.HasNameGlob() {
+		ref.ConfiguredGlobs = []ConfiguredRepoGlob{{
+			Owner: strings.TrimSpace(raw.Owner),
+			Name:  strings.TrimSpace(raw.Name),
+		}}
 	}
 	if !raw.HasNameGlob() &&
 		(!strings.EqualFold(ref.Owner, raw.Owner) ||

--- a/internal/github/repo_config_resolver_test.go
+++ b/internal/github/repo_config_resolver_test.go
@@ -45,11 +45,12 @@ func TestResolveConfiguredRepos_ExpandsGlobAndSkipsArchived(t *testing.T) {
 	require.Len(t, result.Configured, 1)
 	assert.Equal(1, result.Configured[0].MatchedRepoCount)
 	assert.Equal([]RepoRef{{
-		Platform:     platform.KindGitHub,
-		Owner:        "acme",
-		Name:         "widgets-api",
-		PlatformHost: "github.com",
-		RepoPath:     "acme/widgets-api",
+		Platform:        platform.KindGitHub,
+		Owner:           "acme",
+		Name:            "widgets-api",
+		ConfiguredGlobs: []ConfiguredRepoGlob{{Owner: "acme", Name: "widgets-*"}},
+		PlatformHost:    "github.com",
+		RepoPath:        "acme/widgets-api",
 	}}, result.Expanded)
 }
 
@@ -92,8 +93,17 @@ func TestResolveConfiguredRepos_DeduplicatesExactAndGlobMatches(t *testing.T) {
 
 	assert.Len(result.Expanded, 2)
 	assert.ElementsMatch([]RepoRef{
-		{Platform: platform.KindGitHub, Owner: "acme", Name: "widgets", PlatformHost: "github.com", RepoPath: "acme/widgets"},
-		{Platform: platform.KindGitHub, Owner: "acme", Name: "widgets-api", PlatformHost: "github.com", RepoPath: "acme/widgets-api"},
+		{
+			Platform: platform.KindGitHub, Owner: "acme", Name: "widgets",
+			ConfiguredRoutes: []ConfiguredRepoRoute{{Owner: "acme", Name: "widgets", RepoPath: "acme/widgets"}},
+			ConfiguredGlobs:  []ConfiguredRepoGlob{{Owner: "acme", Name: "widgets*"}},
+			PlatformHost:     "github.com", RepoPath: "acme/widgets",
+		},
+		{
+			Platform: platform.KindGitHub, Owner: "acme", Name: "widgets-api",
+			ConfiguredGlobs: []ConfiguredRepoGlob{{Owner: "acme", Name: "widgets*"}},
+			PlatformHost:    "github.com", RepoPath: "acme/widgets-api",
+		},
 	}, result.Expanded)
 }
 
@@ -160,11 +170,13 @@ func TestResolveConfiguredRepos_DeduplicatesOwnerCase(t *testing.T) {
 	)
 
 	assert.Equal([]RepoRef{{
-		Platform:     platform.KindGitHub,
-		Owner:        "acme",
-		Name:         "widgets",
-		PlatformHost: "github.com",
-		RepoPath:     "acme/widgets",
+		Platform:         platform.KindGitHub,
+		Owner:            "acme",
+		Name:             "widgets",
+		ConfiguredRoutes: []ConfiguredRepoRoute{{Owner: "acme", Name: "widgets", RepoPath: "acme/widgets"}},
+		ConfiguredGlobs:  []ConfiguredRepoGlob{{Owner: "acme", Name: "widgets*"}},
+		PlatformHost:     "github.com",
+		RepoPath:         "acme/widgets",
 	}}, result.Expanded)
 }
 
@@ -243,11 +255,12 @@ func TestResolveConfiguredRepos_MatchesRepoNamesCaseInsensitively(t *testing.T) 
 	require.Len(t, result.Configured, 1)
 	assert.Equal(1, result.Configured[0].MatchedRepoCount)
 	assert.Equal([]RepoRef{{
-		Platform:     platform.KindGitHub,
-		Owner:        "acme",
-		Name:         "widget-api",
-		PlatformHost: "github.com",
-		RepoPath:     "acme/widget-api",
+		Platform:        platform.KindGitHub,
+		Owner:           "acme",
+		Name:            "widget-api",
+		ConfiguredGlobs: []ConfiguredRepoGlob{{Owner: "acme", Name: "widget-*"}},
+		PlatformHost:    "github.com",
+		RepoPath:        "acme/widget-api",
 	}}, result.Expanded)
 }
 
@@ -393,10 +406,11 @@ func TestFallbackConfiguredRepoRefsPreservesProviderIdentity(t *testing.T) {
 	})
 
 	assert.Equal([]RepoRef{{
-		Platform:     platform.KindGitLab,
-		PlatformHost: "code.example.com",
-		Owner:        "acme",
-		Name:         "widget",
+		Platform:         platform.KindGitLab,
+		PlatformHost:     "code.example.com",
+		Owner:            "acme",
+		Name:             "widget",
+		ConfiguredRoutes: []ConfiguredRepoRoute{{Owner: "acme", Name: "widget", RepoPath: "acme/widget"}},
 	}}, got)
 }
 
@@ -422,7 +436,11 @@ func TestFallbackConfiguredRepoRefsPreservesRenamedRepositoryByCredentialRoute(
 		Name:         "widget",
 	})
 
-	require.Equal(t, previous, got)
+	expected := previous
+	expected[0].ConfiguredRoutes = []ConfiguredRepoRoute{{
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+	}}
+	require.Equal(t, expected, got)
 }
 
 func TestFallbackConfiguredRepoRefsSynthesizesNonGitHubProvider(t *testing.T) {
@@ -468,10 +486,11 @@ func TestFallbackConfiguredRepoRefsGlobFiltersByProvider(t *testing.T) {
 	})
 
 	assert.Equal([]RepoRef{{
-		Platform:     platform.KindGitLab,
-		PlatformHost: "code.example.com",
-		Owner:        "acme",
-		Name:         "widget-api",
+		Platform:        platform.KindGitLab,
+		PlatformHost:    "code.example.com",
+		Owner:           "acme",
+		Name:            "widget-api",
+		ConfiguredGlobs: []ConfiguredRepoGlob{{Owner: "acme", Name: "widget-*"}},
 	}}, got)
 }
 

--- a/internal/github/repo_config_resolver_test.go
+++ b/internal/github/repo_config_resolver_test.go
@@ -97,6 +97,36 @@ func TestResolveConfiguredRepos_DeduplicatesExactAndGlobMatches(t *testing.T) {
 	}, result.Expanded)
 }
 
+func TestResolveConfiguredReposPreservesConvergedExactRoutes(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	client := &mockClient{getRepositoryFn: func(
+		_ context.Context, _, _ string,
+	) (*gh.Repository, error) {
+		return &gh.Repository{
+			ID: new(int64(42)), NodeID: new("R_stable"),
+			Name: new("current"), Owner: &gh.User{Login: new("acme")},
+			Archived: new(false),
+		}, nil
+	}}
+
+	result := ResolveConfiguredRepos(
+		t.Context(), map[string]Client{"github.com": client},
+		[]config.Repo{
+			{Owner: "acme", Name: "legacy"},
+			{Owner: "acme", Name: "current"},
+		},
+	)
+
+	require.Empty(result.Warnings)
+	require.Len(result.Expanded, 1)
+	assert.Equal([]ConfiguredRepoRoute{
+		{Owner: "acme", Name: "legacy", RepoPath: "acme/legacy"},
+		{Owner: "acme", Name: "current", RepoPath: "acme/current"},
+	}, result.Expanded[0].ConfiguredRoutes)
+	assert.Empty(result.Expanded[0].CredentialOwner)
+}
+
 func TestResolveConfiguredRepos_DeduplicatesOwnerCase(t *testing.T) {
 	assert := assert.New(t)
 	client := &mockClient{
@@ -368,6 +398,31 @@ func TestFallbackConfiguredRepoRefsPreservesProviderIdentity(t *testing.T) {
 		Owner:        "acme",
 		Name:         "widget",
 	}}, got)
+}
+
+func TestFallbackConfiguredRepoRefsPreservesRenamedRepositoryByCredentialRoute(
+	t *testing.T,
+) {
+	previous := []RepoRef{{
+		Platform:           platform.KindGitHub,
+		PlatformHost:       "github.com",
+		RepoID:             42,
+		Owner:              "acme-tools",
+		Name:               "renamed-widget",
+		RepoPath:           "acme-tools/renamed-widget",
+		CredentialOwner:    "acme",
+		CredentialName:     "widget",
+		PlatformExternalID: "R_stable",
+	}}
+
+	got := FallbackConfiguredRepoRefs(previous, config.Repo{
+		Platform:     "github",
+		PlatformHost: "github.com",
+		Owner:        "acme",
+		Name:         "widget",
+	})
+
+	require.Equal(t, previous, got)
 }
 
 func TestFallbackConfiguredRepoRefsSynthesizesNonGitHubProvider(t *testing.T) {

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 	"net/http"
 	"net/url"
+	"reflect"
 	"slices"
 	"strconv"
 	"strings"
@@ -230,10 +231,19 @@ func (e *DiffSyncError) UserMessage() string {
 
 // RepoRef identifies a repository on a configured provider.
 type RepoRef struct {
-	Platform           platform.Kind
-	RepoID             int64
-	Owner              string
-	Name               string
+	Platform platform.Kind
+	RepoID   int64
+	Owner    string
+	Name     string
+	// CredentialOwner and CredentialName retain the configured route used
+	// to select repository-scoped credentials when the provider reports a
+	// newer display path for the same stable repository ID.
+	CredentialOwner string
+	CredentialName  string
+	// ConfiguredRoutes retains every exact configuration route that resolved
+	// to this immutable repository identity. It is populated when configured
+	// entries converge so all aliases survive restart and reload.
+	ConfiguredRoutes   []ConfiguredRepoRoute
 	PlatformHost       string
 	RepoPath           string
 	PlatformRepoID     int64
@@ -241,6 +251,12 @@ type RepoRef struct {
 	WebURL             string
 	CloneURL           string
 	DefaultBranch      string
+}
+
+type ConfiguredRepoRoute struct {
+	Owner    string
+	Name     string
+	RepoPath string
 }
 
 // PartialSyncError reports a repo sync cycle whose index scan completed but
@@ -487,6 +503,8 @@ type Syncer struct {
 	rateLimitSnapshotRefresh map[string]time.Time
 	repos                    []RepoRef
 	reposMu                  sync.Mutex
+	repoPublicationMu        sync.Mutex
+	reposGeneration          uint64 // guarded by reposMu
 	interval                 time.Duration
 	watchInterval            time.Duration
 	watchedMRs               []WatchedMR
@@ -802,7 +820,7 @@ func NewSyncerWithRegistry(
 		clones:                   clones,
 		rateTrackers:             rateTrackers,
 		budgets:                  budgets,
-		repos:                    repos,
+		repos:                    slices.Clone(repos),
 		interval:                 interval,
 		rateLimitSnapshotRefresh: make(map[string]time.Time),
 		branchActivityRetention:  defaultBranchActivityRetention,
@@ -2936,6 +2954,42 @@ func (s *Syncer) SetClock(now func() time.Time) {
 // host fallback fetchers.
 func (s *Syncer) SetGitHubRouters(routers map[string]*HostRouter) {
 	s.routers = routers
+	if err := s.replaceRepositoryCredentialAliases(s.TrackedRepos()); err != nil {
+		slog.Warn("publish repository credential aliases", "err", err)
+	}
+}
+
+func (s *Syncer) replaceRepositoryCredentialAliases(repos []RepoRef) error {
+	httpAliases := make(map[string][]CredentialAlias)
+	cloneAliases := make([]gitclone.CredentialAlias, 0, len(repos))
+	for _, repo := range repos {
+		if repoPlatform(repo) != platform.KindGitHub ||
+			repo.CredentialOwner == "" || repo.CredentialName == "" ||
+			configuredRouteMatchesResolved(repo) {
+			continue
+		}
+		host := repoHost(repo)
+		httpAliases[host] = append(httpAliases[host], CredentialAlias{
+			Owner: repo.Owner, Name: repo.Name,
+			CredentialOwner: repo.CredentialOwner,
+			CredentialName:  repo.CredentialName,
+		})
+		cloneAliases = append(cloneAliases, gitclone.CredentialAlias{
+			Platform: string(platform.KindGitHub), Host: host,
+			Owner: repo.Owner, Name: repo.Name,
+			CredentialOwner: repo.CredentialOwner,
+			CredentialName:  repo.CredentialName,
+		})
+	}
+	for host, router := range s.routers {
+		if err := router.ReplaceCredentialAliases(httpAliases[host]); err != nil {
+			return fmt.Errorf("replace GitHub credential aliases for %s: %w", host, err)
+		}
+	}
+	if s.clones != nil {
+		s.clones.ReplaceCredentialAliases(cloneAliases)
+	}
+	return nil
 }
 
 // fetcherFor returns the GitHub GraphQL fetcher selected for a repository's
@@ -3038,10 +3092,16 @@ func (s *Syncer) identityForRepo(repo RepoRef, write bool) (IdentityKey, error) 
 	if router == nil {
 		return HostIdentity(host), nil
 	}
-	if write {
-		return router.WriteIdentityForRepo(repo.Owner, repo.Name)
+	owner := repo.Owner
+	name := repo.Name
+	if repo.CredentialOwner != "" && repo.CredentialName != "" {
+		owner = repo.CredentialOwner
+		name = repo.CredentialName
 	}
-	return router.ReadIdentityForRepo(repo.Owner, repo.Name)
+	if write {
+		return router.WriteIdentityForRepo(owner, name)
+	}
+	return router.ReadIdentityForRepo(owner, name)
 }
 
 func (s *Syncer) bucketKeyForRepo(repo RepoRef, write bool) (string, error) {
@@ -3226,6 +3286,16 @@ func cloneRemoteURL(repo RepoRef) string {
 		repoPath = strings.Trim(repo.Owner+"/"+repo.Name, "/")
 	}
 	return fmt.Sprintf("https://%s/%s.git", repoHost(repo), strings.Trim(repoPath, "/"))
+}
+
+func (s *Syncer) repositoryClone(repo RepoRef) gitclone.RepositoryClone {
+	return s.clones.RepositoryClone(
+		repo.RepoID,
+		string(repoPlatform(repo)),
+		repoHost(repo),
+		repo.Owner,
+		repo.Name,
+	)
 }
 
 func (s *Syncer) optionalGitHubClientFor(repo RepoRef) (Client, bool) {
@@ -3568,6 +3638,106 @@ func (s *Syncer) trackedRepoByIdentity(
 	return RepoRef{}, false
 }
 
+func (s *Syncer) trackedRepoByID(repoID int64) (RepoRef, bool) {
+	if repoID <= 0 {
+		return RepoRef{}, false
+	}
+	s.reposMu.Lock()
+	defer s.reposMu.Unlock()
+	for _, repo := range s.repos {
+		if repo.RepoID == repoID {
+			return repo, true
+		}
+	}
+	return RepoRef{}, false
+}
+
+func (s *Syncer) trackedRepoForActiveRepository(active RepoRef) (RepoRef, bool) {
+	if active.RepoID <= 0 {
+		return RepoRef{}, false
+	}
+	if tracked, ok := s.trackedRepoByID(active.RepoID); ok {
+		return tracked, true
+	}
+	// NewSyncer accepts unresolved references for tests and bootstrapping.
+	// They have no repository ID yet, so recognize one only by the active
+	// stored route. Once an ID is present, path equality must never override it.
+	s.reposMu.Lock()
+	defer s.reposMu.Unlock()
+	for _, tracked := range s.repos {
+		if tracked.RepoID != 0 ||
+			repoPlatform(tracked) != repoPlatform(active) ||
+			!strings.EqualFold(repoHost(tracked), repoHost(active)) ||
+			!strings.EqualFold(tracked.Owner, active.Owner) ||
+			!strings.EqualFold(tracked.Name, active.Name) {
+			continue
+		}
+		return tracked, true
+	}
+	return RepoRef{}, false
+}
+
+func (s *Syncer) leaseTrackedRepositoryByID(
+	ctx context.Context,
+	repoID int64,
+) (context.Context, RepoRef, func(), error) {
+	leaseCtx, active, release, err := s.leaseActiveRepositoryByID(ctx, repoID)
+	if err != nil {
+		return nil, RepoRef{}, nil, err
+	}
+	tracked, ok := s.trackedRepoForActiveRepository(active)
+	if !ok {
+		release()
+		return nil, RepoRef{}, nil, errRepositoryResolutionSuperseded
+	}
+	tracked.Owner = active.Owner
+	tracked.Name = active.Name
+	tracked.RepoPath = active.RepoPath
+	tracked.PlatformHost = active.PlatformHost
+	tracked.PlatformExternalID = active.PlatformExternalID
+	return leaseCtx, tracked, release, nil
+}
+
+func (s *Syncer) leaseActiveRepositoryByID(
+	ctx context.Context,
+	repoID int64,
+) (context.Context, RepoRef, func(), error) {
+	leaseCtx, release, err := s.db.LeaseRepositoryReconciliationRead(ctx)
+	if err != nil {
+		return nil, RepoRef{}, nil, err
+	}
+	stored, err := s.db.GetRepoByID(leaseCtx, repoID)
+	if err != nil {
+		release()
+		return nil, RepoRef{}, nil, err
+	}
+	if stored == nil || stored.RetiredAt != nil {
+		release()
+		return nil, RepoRef{}, nil, db.ErrRepositoryRetired
+	}
+	repo := RepoRef{
+		Platform:           platform.Kind(stored.Platform),
+		RepoID:             stored.ID,
+		Owner:              stored.Owner,
+		Name:               stored.Name,
+		PlatformHost:       stored.PlatformHost,
+		RepoPath:           stored.RepoPath,
+		PlatformExternalID: stored.PlatformRepoID,
+		WebURL:             stored.WebURL,
+		CloneURL:           stored.CloneURL,
+		DefaultBranch:      stored.DefaultBranch,
+	}
+	if tracked, ok := s.trackedRepoForActiveRepository(repo); ok {
+		repo.CredentialOwner = tracked.CredentialOwner
+		repo.CredentialName = tracked.CredentialName
+		repo.PlatformRepoID = tracked.PlatformRepoID
+		if repo.CloneURL == "" {
+			repo.CloneURL = tracked.CloneURL
+		}
+	}
+	return leaseCtx, repo, release, nil
+}
+
 func detailRepoKey(kind platform.Kind, host, owner, name string) string {
 	if kind == "" {
 		kind = platform.KindGitHub
@@ -3604,9 +3774,16 @@ func (s *Syncer) HostForRepo(owner, name string) string {
 func (s *Syncer) SetRepos(repos []RepoRef) {
 	if err := s.SetReposWithContext(context.Background(), repos, false); err != nil {
 		slog.Warn("update archive repositories", "err", err)
+		s.repoPublicationMu.Lock()
 		s.reposMu.Lock()
-		s.repos = slices.Clone(repos)
+		repos = compactTrackedRepositoriesByID(repos)
+		if aliasErr := s.replaceRepositoryCredentialAliases(repos); aliasErr != nil {
+			slog.Warn("publish repository credential aliases", "err", aliasErr)
+		}
+		s.repos = repos
+		s.reposGeneration++
 		s.reposMu.Unlock()
+		s.repoPublicationMu.Unlock()
 		s.WakeArchive()
 	}
 }
@@ -3615,6 +3792,10 @@ func (s *Syncer) SetRepos(repos []RepoRef) {
 // configured repository set to sync workers. Credential reloads may also make
 // authentication-blocked work eligible without resetting archive progress.
 func (s *Syncer) SetReposWithContext(ctx context.Context, repos []RepoRef, retryAuthentication bool) error {
+	s.repoPublicationMu.Lock()
+	defer s.repoPublicationMu.Unlock()
+
+	repos = slices.Clone(repos)
 	refs := make([]platform.RepoRef, 0, len(repos))
 	for _, repo := range repos {
 		refs = append(refs, platformRepoRef(repo))
@@ -3629,8 +3810,39 @@ func (s *Syncer) SetReposWithContext(ctx context.Context, repos []RepoRef, retry
 			}
 		}
 	}
+	for i := range repos {
+		if s.db == nil {
+			break
+		}
+		stored, err := s.db.GetRepoByIdentity(
+			ctx,
+			platform.DBRepoIdentity(platformRepoRef(repos[i])),
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"load configured repository %s: %w",
+				platformRepoRef(repos[i]).DisplayName(),
+				err,
+			)
+		}
+		if stored != nil {
+			repos[i] = repoRefFromStoredRepository(repos[i], stored, nil)
+		}
+	}
+	if s.db != nil {
+		bindings := configuredRouteBindings(repos)
+		if err := s.db.ReconcileRepoConfiguredRoutes(ctx, bindings); err != nil {
+			return fmt.Errorf("reconcile configured repository routes: %w", err)
+		}
+	}
 	s.reposMu.Lock()
-	s.repos = slices.Clone(repos)
+	repos = compactTrackedRepositoriesByID(repos)
+	if err := s.replaceRepositoryCredentialAliases(repos); err != nil {
+		s.reposMu.Unlock()
+		return err
+	}
+	s.repos = repos
+	s.reposGeneration++
 	s.reposMu.Unlock()
 	s.WakeArchive()
 	return nil
@@ -4667,6 +4879,10 @@ type runState struct {
 	// regardless of worker completion order. Each index is written
 	// by exactly one worker, so no mutex is needed.
 	results []RepoSyncResult
+	// resolvedRepos mirrors results and records the authoritative repository
+	// incarnation/path returned by the live identity lookup. Post-index detail
+	// drains must use this slice rather than the configured path snapshot.
+	resolvedRepos []RepoRef
 	// exhausted collects buckets that crossed their reserve while the pass
 	// was running. Eligibility is computed once before dispatch, so without
 	// this the detail and comment drains would keep spending a credential the
@@ -4755,7 +4971,10 @@ func (s *Syncer) runWorker(
 		slog.Info("syncing repo", "repo", repoName)
 		nativeResultKey := repoFailKey(repo)
 		s.nativeStackResults.Delete(nativeResultKey)
-		err := s.syncRepo(ctx, repo)
+		resolvedRepo, err := s.syncRepoResolved(ctx, repo)
+		if err == nil {
+			state.resolvedRepos[item.index] = resolvedRepo
+		}
 		if nativeResult, ok := s.nativeStackResults.LoadAndDelete(nativeResultKey); ok {
 			state.results[item.index].GitHubNativeStacks = nativeResult.(*GitHubNativeStackSyncResult)
 		}
@@ -4934,6 +5153,7 @@ func (s *Syncer) runOnce(
 
 	work := make(chan repoWork)
 	results := make([]RepoSyncResult, total)
+	resolvedRepos := slices.Clone(repos)
 	for i, r := range repos {
 		host := r.PlatformHost
 		if host == "" {
@@ -4967,14 +5187,15 @@ func (s *Syncer) runOnce(
 	)
 
 	state := &runState{
-		completed: &completed,
-		maxShown:  &maxShown,
-		errMu:     &errMu,
-		lastErr:   &lastErr,
-		canceled:  &canceled,
-		total:     total,
-		results:   results,
-		exhausted: &sync.Map{},
+		completed:     &completed,
+		maxShown:      &maxShown,
+		errMu:         &errMu,
+		lastErr:       &lastErr,
+		canceled:      &canceled,
+		total:         total,
+		results:       results,
+		resolvedRepos: resolvedRepos,
+		exhausted:     &sync.Map{},
 	}
 	for range workers {
 		wg.Go(func() {
@@ -5026,15 +5247,19 @@ dispatch:
 		// bucket rather than trusting only the workers' markers: the last
 		// repository on a credential can spend the headroom with no later
 		// repository left to observe it.
-		s.revokeExhaustedBuckets(eligibleBuckets, state, repos)
-		s.drainDetailQueue(ctx, eligibleBuckets, repos)
+		s.revokeExhaustedBuckets(eligibleBuckets, state, resolvedRepos)
+		s.drainDetailQueue(
+			ctx,
+			eligibleBuckets,
+			reposWithSuccessfulIndexSync(resolvedRepos, results),
+		)
 	}
 
 	if !canceled.Load() && ctx.Err() == nil {
 		// The detail drain spends the same credentials, so re-check again
 		// before the comment drain rather than reusing a map the drain that
 		// just ran may have invalidated.
-		s.revokeExhaustedBuckets(eligibleBuckets, state, repos)
+		s.revokeExhaustedBuckets(eligibleBuckets, state, resolvedRepos)
 		s.drainPendingCommentSyncs(ctx, eligibleBuckets)
 	}
 
@@ -5084,6 +5309,19 @@ dispatch:
 		LastRunAt: time.Now().UTC(),
 		LastError: lastErr,
 	})
+}
+
+func reposWithSuccessfulIndexSync(
+	repos []RepoRef,
+	results []RepoSyncResult,
+) []RepoRef {
+	successful := make([]RepoRef, 0, len(repos))
+	for i, repo := range repos {
+		if i < len(results) && results[i].Error == "" {
+			successful = append(successful, repo)
+		}
+	}
+	return successful
 }
 
 func prioritizeRepos(repos, priorityRepos []RepoRef) []RepoRef {
@@ -5156,25 +5394,417 @@ func repoPriorityKey(repo RepoRef) string {
 }
 
 func (s *Syncer) syncRepoIdentity(ctx context.Context, repo RepoRef) (db.RepoIdentity, *platform.Repository, error) {
-	identity := platform.DBRepoIdentity(platformRepoRef(repo))
-	if identity.PlatformRepoID != "" {
-		return identity, nil, nil
-	}
+	configured := platform.DBRepoIdentity(platformRepoRef(repo))
 	reader, err := s.clients.RepositoryReader(repoPlatform(repo), repoHost(repo))
 	if err != nil {
+		if errors.Is(err, platform.ErrUnsupportedCapability) {
+			if configured.PlatformRepoID == "" && s.db != nil {
+				stored, lookupErr := s.db.GetRepoByIdentity(ctx, configured)
+				if lookupErr != nil {
+					return db.RepoIdentity{}, nil, lookupErr
+				}
+				if stored != nil {
+					configured.PlatformRepoID = stored.PlatformRepoID
+				}
+			}
+			return configured, nil, nil
+		}
 		return db.RepoIdentity{}, nil, err
 	}
+	lookupRef := platformRepoRef(repo)
+	if repo.CredentialOwner != "" && repo.CredentialName != "" {
+		lookupRef.Owner = repo.CredentialOwner
+		lookupRef.Name = repo.CredentialName
+		lookupRef.RepoPath = strings.Trim(
+			repo.CredentialOwner+"/"+repo.CredentialName,
+			"/",
+		)
+	}
+	// Repository identity verification must resolve the configured route, not
+	// a cached stable ID. Resolving the old ID after a path takeover would
+	// faithfully return the old repository at its new route and fail to detect
+	// the replacement now occupying the configured path.
+	lookupRef.PlatformID = 0
+	lookupRef.PlatformExternalID = ""
 	// A refused identity resolve aborts the whole repo sync before the
 	// list fetches, so it shares their essential budget reserve.
-	resolved, err := reader.GetRepository(WithEssentialSyncBudget(ctx), platformRepoRef(repo))
+	resolved, err := reader.GetRepository(WithEssentialSyncBudget(ctx), lookupRef)
 	if err != nil {
 		return db.RepoIdentity{}, nil, err
 	}
-	identity = platform.DBRepositoryIdentity(resolved)
+	identity := platform.DBRepositoryIdentity(resolved)
 	if identity.PlatformRepoID == "" {
 		return db.RepoIdentity{}, nil, fmt.Errorf("provider returned no repo id")
 	}
 	return identity, &resolved, nil
+}
+
+func repoRefFromStoredRepository(
+	configured RepoRef,
+	stored *db.Repo,
+	resolved *platform.Repository,
+) RepoRef {
+	ref := RepoRef{
+		Platform:           platform.Kind(stored.Platform),
+		RepoID:             stored.ID,
+		Owner:              stored.Owner,
+		Name:               stored.Name,
+		CredentialOwner:    configured.CredentialOwner,
+		CredentialName:     configured.CredentialName,
+		ConfiguredRoutes:   slices.Clone(configured.ConfiguredRoutes),
+		PlatformHost:       stored.PlatformHost,
+		RepoPath:           stored.RepoPath,
+		PlatformRepoID:     configured.PlatformRepoID,
+		PlatformExternalID: stored.PlatformRepoID,
+		WebURL:             stored.WebURL,
+		CloneURL:           stored.CloneURL,
+		DefaultBranch:      stored.DefaultBranch,
+	}
+	if ref.WebURL == "" {
+		ref.WebURL = configured.WebURL
+	}
+	if ref.CloneURL == "" {
+		ref.CloneURL = configured.CloneURL
+	}
+	if ref.DefaultBranch == "" {
+		ref.DefaultBranch = configured.DefaultBranch
+	}
+	if (ref.CredentialOwner == "" || ref.CredentialName == "") &&
+		(!strings.EqualFold(configured.Owner, stored.Owner) ||
+			!strings.EqualFold(configured.Name, stored.Name)) {
+		ref.CredentialOwner = configured.Owner
+		ref.CredentialName = configured.Name
+	}
+	if resolved != nil {
+		if resolved.PlatformID != 0 {
+			ref.PlatformRepoID = resolved.PlatformID
+		} else if resolved.Ref.PlatformID != 0 {
+			ref.PlatformRepoID = resolved.Ref.PlatformID
+		}
+		if resolved.WebURL != "" {
+			ref.WebURL = resolved.WebURL
+		}
+		if resolved.CloneURL != "" {
+			ref.CloneURL = resolved.CloneURL
+		}
+		if resolved.DefaultBranch != "" {
+			ref.DefaultBranch = resolved.DefaultBranch
+		}
+	}
+	return canonicalRepoRef(ref)
+}
+
+func sameTrackedRepository(left, right RepoRef) bool {
+	if left.RepoID != 0 && right.RepoID != 0 {
+		return left.RepoID == right.RepoID
+	}
+	return repoPriorityKey(left) == repoPriorityKey(right)
+}
+
+var errRepositoryResolutionSuperseded = errors.New(
+	"repository identity resolution superseded by newer tracked state",
+)
+
+type repositoryResolution struct {
+	configured RepoRef
+	key        string
+	generation uint64
+}
+
+func configuredRepositoryKey(repo RepoRef) string {
+	if repo.CredentialOwner == "" || repo.CredentialName == "" {
+		return repoPriorityKey(repo)
+	}
+	configured := repo
+	configured.Owner = repo.CredentialOwner
+	configured.Name = repo.CredentialName
+	configured.RepoPath = repo.CredentialOwner + "/" + repo.CredentialName
+	return repoPriorityKey(configured)
+}
+
+func (s *Syncer) beginRepositoryResolution(
+	requested RepoRef,
+) (repositoryResolution, error) {
+	s.repoPublicationMu.Lock()
+	defer s.repoPublicationMu.Unlock()
+
+	s.reposMu.Lock()
+	defer s.reposMu.Unlock()
+	currentIndex := slices.IndexFunc(s.repos, func(current RepoRef) bool {
+		return repoRefsEqual(current, requested)
+	})
+	if currentIndex < 0 {
+		for i, current := range s.repos {
+			if sameTrackedRepository(current, requested) {
+				currentIndex = i
+				break
+			}
+		}
+	}
+	if currentIndex >= 0 {
+		current := s.repos[currentIndex]
+		key := configuredRepositoryKey(current)
+		return repositoryResolution{
+			configured: current,
+			key:        key,
+			generation: s.reposGeneration,
+		}, nil
+	}
+	return repositoryResolution{}, errRepositoryResolutionSuperseded
+}
+
+func compactTrackedRepositoriesByID(repos []RepoRef) []RepoRef {
+	compacted := make([]RepoRef, 0, len(repos))
+	seen := make(map[int64]int, len(repos))
+	for _, repo := range repos {
+		if repo.RepoID > 0 {
+			if existingIndex, ok := seen[repo.RepoID]; ok {
+				routes := appendUniqueConfiguredRoutes(
+					slices.Clone(compacted[existingIndex].ConfiguredRoutes),
+					repo.ConfiguredRoutes...,
+				)
+				if !configuredRouteMatchesResolved(compacted[existingIndex]) &&
+					configuredRouteMatchesResolved(repo) {
+					compacted[existingIndex] = repo
+				}
+				compacted[existingIndex].ConfiguredRoutes = routes
+				continue
+			}
+			seen[repo.RepoID] = len(compacted)
+		}
+		compacted = append(compacted, repo)
+	}
+	return compacted
+}
+
+func repoRefsEqual(left, right RepoRef) bool {
+	return reflect.DeepEqual(left, right)
+}
+
+func configuredRouteMatchesResolved(repo RepoRef) bool {
+	if repo.CredentialOwner == "" || repo.CredentialName == "" {
+		return true
+	}
+	return strings.EqualFold(repo.CredentialOwner, repo.Owner) &&
+		strings.EqualFold(repo.CredentialName, repo.Name)
+}
+
+func (s *Syncer) currentRepositoryForResolution(
+	resolution repositoryResolution,
+) (RepoRef, bool, bool) {
+	s.reposMu.Lock()
+	defer s.reposMu.Unlock()
+	for _, repo := range s.repos {
+		if configuredRepositoryKey(repo) == resolution.key {
+			return repo, true, s.reposGeneration == resolution.generation
+		}
+	}
+	return RepoRef{}, false, s.reposGeneration == resolution.generation
+}
+
+func repoRefMatchesResolvedIdentity(
+	repo RepoRef,
+	identity db.RepoIdentity,
+) bool {
+	current := platform.DBRepoIdentity(platformRepoRef(repo))
+	if repo.RepoID <= 0 ||
+		current.PlatformRepoID == "" ||
+		identity.PlatformRepoID == "" ||
+		current.PlatformRepoID != identity.PlatformRepoID {
+		return false
+	}
+	resolved := RepoRef{
+		Platform:           platform.Kind(identity.Platform),
+		PlatformHost:       identity.PlatformHost,
+		Owner:              identity.Owner,
+		Name:               identity.Name,
+		RepoPath:           identity.RepoPath,
+		PlatformExternalID: identity.PlatformRepoID,
+	}
+	return repoPriorityKey(repo) == repoPriorityKey(resolved)
+}
+
+func configuredRouteIdentity(repo RepoRef) db.RepoIdentity {
+	if repo.CredentialOwner == "" || repo.CredentialName == "" {
+		return platform.DBRepoIdentity(platformRepoRef(repo))
+	}
+	return platform.DBRepoIdentity(platform.RepoRef{
+		Platform: repo.Platform,
+		Host:     repo.PlatformHost,
+		Owner:    repo.CredentialOwner,
+		Name:     repo.CredentialName,
+		RepoPath: repo.CredentialOwner + "/" + repo.CredentialName,
+	})
+}
+
+func (s *Syncer) saveConfiguredRoutes(
+	ctx context.Context,
+	repoID int64,
+	repo RepoRef,
+) error {
+	routes := configuredRoutesForCandidate(repo, false)
+	if len(routes) == 0 {
+		return s.db.SaveRepoConfiguredRoute(
+			ctx, repoID, configuredRouteIdentity(repo),
+		)
+	}
+	for _, route := range routes {
+		if err := s.db.SaveRepoConfiguredRoute(ctx, repoID, db.RepoIdentity{
+			Platform:     string(repoPlatform(repo)),
+			PlatformHost: repoHost(repo),
+			Owner:        route.Owner,
+			Name:         route.Name,
+			RepoPath:     route.RepoPath,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func configuredRouteBindings(repos []RepoRef) []db.RepoConfiguredRouteBinding {
+	bindings := make([]db.RepoConfiguredRouteBinding, 0)
+	for _, repo := range repos {
+		if repo.RepoID <= 0 {
+			continue
+		}
+		for _, route := range configuredRoutesForCandidate(repo, false) {
+			bindings = append(bindings, db.RepoConfiguredRouteBinding{
+				RepoID: repo.RepoID,
+				Route: db.RepoIdentity{
+					Platform: string(repoPlatform(repo)), PlatformHost: repoHost(repo),
+					Owner: route.Owner, Name: route.Name, RepoPath: route.RepoPath,
+				},
+			})
+		}
+	}
+	return bindings
+}
+
+func (s *Syncer) publishResolvedRepositoryLocked(
+	ctx context.Context,
+	resolution repositoryResolution,
+	resolved RepoRef,
+) error {
+	s.reposMu.Lock()
+	repos := slices.Clone(s.repos)
+	for i := range repos {
+		if configuredRepositoryKey(repos[i]) != resolution.key {
+			continue
+		}
+		repos[i] = resolved
+		break
+	}
+	repos = compactTrackedRepositoriesByID(repos)
+	changed := !slices.EqualFunc(repos, s.repos, repoRefsEqual)
+	s.reposMu.Unlock()
+
+	if !changed {
+		return nil
+	}
+	if err := s.replaceRepositoryCredentialAliases(repos); err != nil {
+		return err
+	}
+	if s.archiveLifecycle != nil {
+		refs := make([]platform.RepoRef, 0, len(repos))
+		for _, repo := range repos {
+			refs = append(refs, platformRepoRef(repo))
+		}
+		if err := s.archiveLifecycle.EnsureConfigured(ctx, refs); err != nil {
+			return fmt.Errorf(
+				"reseed archive discovery after repository identity change: %w",
+				err,
+			)
+		}
+	}
+
+	s.reposMu.Lock()
+	s.repos = repos
+	s.reposGeneration++
+	s.reposMu.Unlock()
+	return nil
+}
+
+func (s *Syncer) resolveActiveRepository(
+	ctx context.Context,
+	configured RepoRef,
+) (RepoRef, *platform.Repository, error) {
+	resolution, err := s.beginRepositoryResolution(configured)
+	if err != nil {
+		return RepoRef{}, nil, err
+	}
+	identity, resolved, err := s.syncRepoIdentity(ctx, resolution.configured)
+	if err != nil {
+		return RepoRef{}, nil, err
+	}
+
+	s.repoPublicationMu.Lock()
+	defer s.repoPublicationMu.Unlock()
+	current, tracked, sameGeneration := s.currentRepositoryForResolution(
+		resolution,
+	)
+	if !tracked {
+		return RepoRef{}, nil, errRepositoryResolutionSuperseded
+	}
+	if repoRefMatchesResolvedIdentity(current, identity) {
+		_, active, release, leaseErr := s.leaseActiveRepositoryByID(
+			ctx,
+			current.RepoID,
+		)
+		if leaseErr != nil {
+			return RepoRef{}, nil, leaseErr
+		}
+		release()
+		if repoRefMatchesResolvedIdentity(active, identity) {
+			if err := s.saveConfiguredRoutes(
+				ctx, active.RepoID, resolution.configured,
+			); err != nil {
+				return RepoRef{}, nil, err
+			}
+			return active, resolved, nil
+		}
+	}
+	if !sameGeneration && !repoRefsEqual(current, resolution.configured) {
+		return RepoRef{}, nil, errRepositoryResolutionSuperseded
+	}
+
+	var repoID int64
+	if identity.PlatformRepoID == "" {
+		repoID, err = s.db.UpsertRepo(ctx, identity)
+	} else {
+		repoID, err = s.db.UpsertRepoByProviderID(ctx, identity)
+	}
+	if err != nil {
+		return RepoRef{}, nil, err
+	}
+	stored, err := s.db.GetRepoByID(ctx, repoID)
+	if err != nil {
+		return RepoRef{}, nil, err
+	}
+	if stored == nil || stored.RetiredAt != nil {
+		return RepoRef{}, nil, fmt.Errorf(
+			"repository incarnation %d is not active",
+			repoID,
+		)
+	}
+	authoritative := repoRefFromStoredRepository(
+		resolution.configured,
+		stored,
+		resolved,
+	)
+	if err := s.saveConfiguredRoutes(
+		ctx, repoID, resolution.configured,
+	); err != nil {
+		return RepoRef{}, nil, err
+	}
+	if err := s.publishResolvedRepositoryLocked(
+		ctx,
+		resolution,
+		authoritative,
+	); err != nil {
+		return RepoRef{}, nil, err
+	}
+	return authoritative, resolved, nil
 }
 
 // syncRepo syncs one repository: open PRs, timeline events, and stale closures.
@@ -5186,9 +5816,22 @@ func (s *Syncer) markClosedLinkedNotificationsDone(ctx context.Context) error {
 }
 
 func (s *Syncer) syncRepo(ctx context.Context, repo RepoRef) error {
+	_, err := s.syncRepoResolved(ctx, repo)
+	return err
+}
+
+func (s *Syncer) syncRepoResolved(
+	ctx context.Context,
+	repo RepoRef,
+) (RepoRef, error) {
 	bucket, err := s.bucketKeyForRepo(repo, false)
 	if err != nil {
-		return fmt.Errorf("resolve sync credential route for %s/%s: %w", repo.Owner, repo.Name, err)
+		return RepoRef{}, fmt.Errorf(
+			"resolve sync credential route for %s/%s: %w",
+			repo.Owner,
+			repo.Name,
+			err,
+		)
 	}
 	releaseProviderWork := s.beginProviderWork(bucket, archive.PriorityNormalIndex)
 	defer releaseProviderWork()
@@ -5205,23 +5848,38 @@ func (s *Syncer) syncRepo(ctx context.Context, repo RepoRef) error {
 		}
 	}
 
-	repoIdentity, resolvedRepo, err := s.syncRepoIdentity(ctx, repo)
+	resolvedRef, resolvedRepo, err := s.resolveActiveRepository(ctx, repo)
 	if err != nil {
-		return fmt.Errorf("resolve repo identity %s/%s: %w", repo.Owner, repo.Name, err)
+		return RepoRef{}, fmt.Errorf(
+			"resolve repo identity %s/%s: %w",
+			repo.Owner,
+			repo.Name,
+			err,
+		)
 	}
-	repoID, err := s.db.UpsertRepoByProviderID(ctx, repoIdentity)
+	leaseCtx, repo, releaseRepository, err := s.leaseTrackedRepositoryByID(
+		ctx,
+		resolvedRef.RepoID,
+	)
 	if err != nil {
-		return fmt.Errorf("upsert repo %s/%s by provider id: %w", repo.Owner, repo.Name, err)
+		return RepoRef{}, fmt.Errorf(
+			"lease resolved repo identity %s/%s: %w",
+			resolvedRef.Owner,
+			resolvedRef.Name,
+			err,
+		)
 	}
+	defer releaseRepository()
+	ctx = leaseCtx
+	repoID := repo.RepoID
 
 	s.refreshRepoSettings(ctx, repo, repoID, resolvedRepo)
 
 	if err := s.db.UpdateRepoSyncStarted(ctx, repoID, time.Now().UTC()); err != nil {
-		return fmt.Errorf("mark sync started for %s/%s: %w", repo.Owner, repo.Name, err)
+		return RepoRef{}, fmt.Errorf("mark sync started for %s/%s: %w", repo.Owner, repo.Name, err)
 	}
 
 	// Fetch bare clone before PR data so refs are available for merge-base.
-	host := repoHost(repo)
 	cloneFetchOK := false
 	defaultBranch := s.defaultBranchForActivity(ctx, repoID, repo)
 	var previousTip *db.BranchTip
@@ -5238,7 +5896,8 @@ func (s *Syncer) syncRepo(ctx context.Context, repo RepoRef) error {
 		}
 	}
 	if s.clones != nil {
-		if err := s.clones.EnsureClone(ctx, string(repoPlatform(repo)), host, repo.Owner, repo.Name, cloneRemoteURL(repo)); err != nil {
+		clone := s.repositoryClone(repo)
+		if err := clone.EnsureClone(ctx, cloneRemoteURL(repo)); err != nil {
 			slog.Warn("bare clone fetch failed",
 				"repo", repo.Owner+"/"+repo.Name, "err", err,
 			)
@@ -5274,7 +5933,7 @@ func (s *Syncer) syncRepo(ctx context.Context, repo RepoRef) error {
 		slog.Error("mark sync completed", "repo", repo.Owner+"/"+repo.Name, "err", err)
 	}
 
-	return syncErr
+	return repo, syncErr
 }
 
 func (s *Syncer) defaultBranchForActivity(ctx context.Context, repoID int64, repo RepoRef) string {
@@ -5302,14 +5961,8 @@ func (s *Syncer) syncDefaultBranchActivity(
 	if s.clones == nil {
 		return
 	}
-	host := repoHost(repo)
-	branch, currentTip, err := s.clones.ResolveDefaultBranch(
-		ctx,
-		string(repoPlatform(repo)), host,
-		repo.Owner,
-		repo.Name,
-		preferredBranch,
-	)
+	clone := s.repositoryClone(repo)
+	branch, currentTip, err := clone.ResolveDefaultBranch(ctx, preferredBranch)
 	if err != nil {
 		slog.Warn("resolve default branch activity ref failed",
 			"repo", repo.Owner+"/"+repo.Name,
@@ -5347,11 +6000,8 @@ func (s *Syncer) syncDefaultBranchActivity(
 		afterSHA = previousTip.TipSHA
 		beforeObservedAt = previousTip.ObservedAt
 		if previousTip.TipSHA != currentTip {
-			ancestor, err := s.clones.IsAncestor(
+			ancestor, err := clone.IsAncestor(
 				ctx,
-				string(repoPlatform(repo)), host,
-				repo.Owner,
-				repo.Name,
 				previousTip.TipSHA,
 				currentTip,
 			)
@@ -5367,11 +6017,8 @@ func (s *Syncer) syncDefaultBranchActivity(
 		}
 	}
 
-	gitCommits, err := s.clones.ListBranchCommitsSince(
+	gitCommits, err := clone.ListBranchCommitsSince(
 		ctx,
-		string(repoPlatform(repo)), host,
-		repo.Owner,
-		repo.Name,
 		branch,
 		retentionStart,
 		afterSHA,
@@ -5787,14 +6434,9 @@ func (s *Syncer) addRepoOverviewTimeline(
 	if len(tags) == 0 || s.clones == nil || !cloneFetchOK {
 		return
 	}
-	host := repo.PlatformHost
-	if host == "" {
-		host = "github.com"
-	}
 	latestTag := tags[0]
-	count, _, countErr := s.clones.CommitTimelineSinceTag(
-		ctx, string(repoPlatform(repo)), host, repo.Owner, repo.Name, latestTag, 1,
-	)
+	clone := s.repositoryClone(repo)
+	count, _, countErr := clone.CommitTimelineSinceTag(ctx, latestTag, 1)
 	if countErr != nil {
 		slog.Warn("count commits since latest version failed",
 			"repo", repo.Owner+"/"+repo.Name,
@@ -5805,9 +6447,8 @@ func (s *Syncer) addRepoOverviewTimeline(
 	}
 
 	timelineTag := tags[len(tags)-1]
-	_, points, err := s.clones.CommitTimelineSinceTag(
-		ctx, string(repoPlatform(repo)), host, repo.Owner, repo.Name,
-		timelineTag, repoOverviewTimelineLimit,
+	_, points, err := clone.CommitTimelineSinceTag(
+		ctx, timelineTag, repoOverviewTimelineLimit,
 	)
 	if err != nil {
 		slog.Warn("build repo commit timeline failed",
@@ -7389,17 +8030,12 @@ func (s *Syncer) syncOpenMRFromBulk(
 	}
 
 	// Diff SHAs.
-	repoHost := repo.PlatformHost
-	if repoHost == "" {
-		repoHost = "github.com"
-	}
 	if s.clones != nil && cloneFetchOK {
 		headSHA := normalized.PlatformHeadSHA
 		baseSHA := normalized.PlatformBaseSHA
 		if headSHA != "" && baseSHA != "" {
-			mb, mbErr := s.clones.MergeBase(
-				ctx, string(repoPlatform(repo)), repoHost, repo.Owner,
-				repo.Name, baseSHA, headSHA,
+			mb, mbErr := s.repositoryClone(repo).MergeBase(
+				ctx, baseSHA, headSHA,
 			)
 			if mbErr != nil {
 				slog.Warn("merge-base computation failed",
@@ -7649,7 +8285,7 @@ func (s *Syncer) fetchMRDetail(
 	}
 
 	fullPR, newETag, notModified, err := s.getPullRequestForDetail(
-		ctx, client, repo, number,
+		ctx, client, repo, repoID, number,
 	)
 	calls++
 	// Route fetch failures and detected transfers through the canonical
@@ -7708,17 +8344,12 @@ func (s *Syncer) fetchMRDetail(
 	}
 
 	// Diff SHAs if clone available.
-	cloneRepoHost := repo.PlatformHost
-	if cloneRepoHost == "" {
-		cloneRepoHost = "github.com"
-	}
 	if s.clones != nil && cloneFetchOK {
 		headSHA := normalized.PlatformHeadSHA
 		baseSHA := normalized.PlatformBaseSHA
 		if headSHA != "" && baseSHA != "" {
-			mb, mbErr := s.clones.MergeBase(
-				ctx, string(repoPlatform(repo)), cloneRepoHost, repo.Owner,
-				repo.Name, baseSHA, headSHA,
+			mb, mbErr := s.repositoryClone(repo).MergeBase(
+				ctx, baseSHA, headSHA,
 			)
 			if mbErr != nil {
 				slog.Warn("merge-base computation failed",
@@ -7827,8 +8458,7 @@ func (s *Syncer) fetchMRDetail(
 
 	if newETag != "" {
 		if err := s.db.UpsertHTTPEtag(
-			ctx, string(repoPlatform(repo)), repoHost(repo),
-			repo.Owner, repo.Name, "pull_request", number, newETag,
+			ctx, repoID, "pull_request", number, newETag,
 		); err != nil {
 			slog.Warn("persist pull request ETag failed",
 				"repo", repo.Owner+"/"+repo.Name,
@@ -7845,6 +8475,7 @@ func (s *Syncer) getPullRequestForDetail(
 	ctx context.Context,
 	client Client,
 	repo RepoRef,
+	repoID int64,
 	number int,
 ) (*gh.PullRequest, string, bool, error) {
 	conditional, ok := client.(conditionalPullRequestGetter)
@@ -7854,8 +8485,7 @@ func (s *Syncer) getPullRequestForDetail(
 	}
 
 	etag, err := s.db.GetHTTPEtag(
-		ctx, string(repoPlatform(repo)), repoHost(repo),
-		repo.Owner, repo.Name, "pull_request", number,
+		ctx, repoID, "pull_request", number,
 	)
 	if err != nil {
 		slog.Warn("load pull request ETag failed",
@@ -8182,7 +8812,7 @@ func (s *Syncer) fetchIssueDetail(
 	}
 
 	ghIssue, newETag, notModified, err := s.getIssueForDetail(
-		ctx, client, repo, number,
+		ctx, client, repo, repoID, number,
 	)
 	calls++
 	// Route fetch failures and detected transfers through the canonical
@@ -8257,8 +8887,7 @@ func (s *Syncer) fetchIssueDetail(
 
 	if newETag != "" {
 		if err := s.db.UpsertHTTPEtag(
-			ctx, string(repoPlatform(repo)), repoHost(repo),
-			repo.Owner, repo.Name, "issue", number, newETag,
+			ctx, repoID, "issue", number, newETag,
 		); err != nil {
 			slog.Warn("persist issue ETag failed",
 				"repo", repo.Owner+"/"+repo.Name,
@@ -8275,6 +8904,7 @@ func (s *Syncer) getIssueForDetail(
 	ctx context.Context,
 	client Client,
 	repo RepoRef,
+	repoID int64,
 	number int,
 ) (*gh.Issue, string, bool, error) {
 	if IsArchiveSyncBudgetContext(ctx) {
@@ -8288,8 +8918,7 @@ func (s *Syncer) getIssueForDetail(
 	}
 
 	etag, err := s.db.GetHTTPEtag(
-		ctx, string(repoPlatform(repo)), repoHost(repo),
-		repo.Owner, repo.Name, "issue", number,
+		ctx, repoID, "issue", number,
 	)
 	if err != nil {
 		slog.Warn("load issue ETag failed",
@@ -9640,6 +10269,14 @@ func (s *Syncer) drainDetailQueue(
 		return
 	}
 
+	s.drainDetailQueueItems(ctx, eligibleBuckets, items)
+}
+
+func (s *Syncer) drainDetailQueueItems(
+	ctx context.Context,
+	eligibleBuckets map[string]bool,
+	items []QueueItem,
+) {
 	queue := BuildQueue(items, time.Now())
 	if len(queue) == 0 {
 		return
@@ -9653,127 +10290,126 @@ func (s *Syncer) drainDetailQueue(
 			return
 		}
 		qi := &queue[i]
-		repo := RepoRef{
-			Owner: qi.RepoOwner, Name: qi.RepoName,
-			Platform: qi.Platform, PlatformHost: qi.PlatformHost,
-		}
-		host := repoHost(repo)
-		if tracked, ok := s.trackedRepoByIdentity(qi.Platform, qi.RepoOwner, qi.RepoName, host); ok {
-			repo = tracked
-			repo.Owner = qi.RepoOwner
-			repo.Name = qi.RepoName
-			repo.PlatformHost = host
-		}
-		// Resolve the credential bucket from the tracked repository. Routing
-		// keys off the owner and host that survive tracking, not the raw
-		// queue row, so this must follow the lookup above.
-		bucket, err := s.bucketKeyForRepo(repo, false)
-		if err != nil || !eligibleBuckets[bucket] {
+		leaseCtx, repo, release, err := s.leaseTrackedRepositoryByID(ctx, qi.RepoID)
+		if errors.Is(err, db.ErrRepositoryRetired) ||
+			errors.Is(err, errRepositoryResolutionSuperseded) {
 			continue
 		}
-		feature := platform.RepositoryFeatureIssues
-		if qi.Type == QueueItemPR {
-			feature = platform.RepositoryFeatureMergeRequests
-		}
-		probe, due := s.beginRepositoryFeatureProbe(ctx, repo, feature)
-		if !due {
-			continue
-		}
-		if exhausted[bucket] {
-			probe.abandon()
-			continue
-		}
-
-		budget := s.budgets[bucket]
-		if budget == nil {
-			probe.abandon()
-			continue
-		}
-
-		// Soft admission gate: check if the budget has nominal
-		// capacity for this item. The transport layer handles
-		// actual per-RoundTrip accounting; this prevents starting
-		// work we almost certainly can't afford.
-		worstCase := qi.WorstCaseCost()
-		if !budget.CanSpend(worstCase) {
-			probe.abandon()
-			exhausted[bucket] = true
-			continue
-		}
-		// The provider reserve is re-read per item alongside the local
-		// ceiling. A drain can be many items long, so a credential that had
-		// headroom when the drain started can reach its reserve partway
-		// through.
-		if s.backgroundReserveExhausted(repo, QuotaResourceREST, false) {
-			probe.abandon()
-			exhausted[bucket] = true
-			continue
-		}
-		// The provider reserve is re-read per item alongside the local
-		// ceiling. A drain can be many items long, so a credential that had
-		// headroom when the drain started can reach its reserve partway
-		// through.
-		repoID, err := s.db.UpsertRepo(ctx, platform.DBRepoIdentity(platformRepoRef(repo)))
 		if err != nil {
-			probe.abandon()
-			slog.Warn("detail drain: upsert repo failed",
-				"repo", qi.RepoOwner+"/"+qi.RepoName,
+			slog.Warn("detail drain: lease repository failed",
+				"repo_id", qi.RepoID,
 				"err", err,
 			)
 			continue
 		}
+		s.drainDetailQueueItem(leaseCtx, eligibleBuckets, exhausted, repo, qi)
+		release()
+	}
+}
 
-		// Compute diff SHAs if clone available.
-		cloneFetchOK := false
-		if s.clones != nil {
-			if cloneErr := s.clones.EnsureClone(
-				ctx, string(repoPlatform(repo)), host, qi.RepoOwner, qi.RepoName,
-				cloneRemoteURL(repo),
-			); cloneErr != nil {
-				slog.Warn("detail drain: bare clone failed",
-					"repo", qi.RepoOwner+"/"+qi.RepoName,
-					"err", cloneErr,
-				)
-			} else {
-				cloneFetchOK = true
-			}
-		}
-		providerCalls := 0
-		if qi.Type == QueueItemPR {
-			providerCalls, err = s.fetchMRDetail(
-				ctx, repo, repoID, qi.Number, cloneFetchOK,
+func (s *Syncer) drainDetailQueueItem(
+	ctx context.Context,
+	eligibleBuckets map[string]bool,
+	exhausted map[string]bool,
+	repo RepoRef,
+	qi *QueueItem,
+) {
+	// Resolve the credential bucket from the tracked repository. Routing
+	// uses the current endpoint together with the configured credential
+	// identity retained on the incarnation-bound repository reference.
+	bucket, err := s.bucketKeyForRepo(repo, false)
+	if err != nil || !eligibleBuckets[bucket] {
+		return
+	}
+	feature := platform.RepositoryFeatureIssues
+	if qi.Type == QueueItemPR {
+		feature = platform.RepositoryFeatureMergeRequests
+	}
+	probe, due := s.beginRepositoryFeatureProbe(ctx, repo, feature)
+	if !due {
+		return
+	}
+	if exhausted[bucket] {
+		probe.abandon()
+		return
+	}
+
+	budget := s.budgets[bucket]
+	if budget == nil {
+		probe.abandon()
+		return
+	}
+
+	// Soft admission gate: check if the budget has nominal
+	// capacity for this item. The transport layer handles
+	// actual per-RoundTrip accounting; this prevents starting
+	// work we almost certainly can't afford.
+	worstCase := qi.WorstCaseCost()
+	if !budget.CanSpend(worstCase) {
+		probe.abandon()
+		exhausted[bucket] = true
+		return
+	}
+	// The provider reserve is re-read per item alongside the local
+	// ceiling. A drain can be many items long, so a credential that had
+	// headroom when the drain started can reach its reserve partway
+	// through.
+	if s.backgroundReserveExhausted(repo, QuotaResourceREST, false) {
+		probe.abandon()
+		exhausted[bucket] = true
+		return
+	}
+
+	// Compute diff SHAs if clone available.
+	cloneFetchOK := false
+	if s.clones != nil {
+		if cloneErr := s.repositoryClone(repo).EnsureClone(
+			ctx,
+			cloneRemoteURL(repo),
+		); cloneErr != nil {
+			slog.Warn("detail drain: bare clone failed",
+				"repo", qi.RepoOwner+"/"+qi.RepoName,
+				"err", cloneErr,
 			)
 		} else {
-			providerCalls, err = s.fetchIssueDetail(
-				ctx, repo, repoID, qi.Number,
-			)
+			cloneFetchOK = true
 		}
+	}
+	providerCalls := 0
+	if qi.Type == QueueItemPR {
+		providerCalls, err = s.fetchMRDetail(
+			ctx, repo, qi.RepoID, qi.Number, cloneFetchOK,
+		)
+	} else {
+		providerCalls, err = s.fetchIssueDetail(
+			ctx, repo, qi.RepoID, qi.Number,
+		)
+	}
 
-		if err != nil {
-			disabledErr := repositoryFeatureDisabledError(repo, feature, err)
-			disabled := disabledErr != nil &&
-				s.recordRepositoryFeatureDisabled(repo, feature, disabledErr)
-			if providerCalls > 0 {
-				probe.release()
-			} else {
-				probe.abandon()
-			}
-			if disabled {
-				continue
-			}
-			slog.Warn("detail drain: fetch failed",
-				"repo", qi.RepoOwner+"/"+qi.RepoName,
-				"number", qi.Number,
-				"type", qi.Type,
-				"err", err,
-			)
-			continue
-		}
+	if err != nil {
+		disabledErr := repositoryFeatureDisabledError(repo, feature, err)
+		disabled := disabledErr != nil &&
+			s.recordRepositoryFeatureDisabled(repo, feature, disabledErr)
 		if providerCalls > 0 {
 			probe.release()
 		} else {
 			probe.abandon()
 		}
+		if disabled {
+			return
+		}
+		slog.Warn("detail drain: fetch failed",
+			"repo", qi.RepoOwner+"/"+qi.RepoName,
+			"number", qi.Number,
+			"type", qi.Type,
+			"err", err,
+		)
+		return
+	}
+	if providerCalls > 0 {
+		probe.release()
+	} else {
+		probe.abandon()
 	}
 }
 
@@ -9832,6 +10468,7 @@ func (s *Syncer) buildDetailQueueItems(
 		ciHadPending := pr.CIHadPending || ciHasPending(pr.CIChecksJSON)
 		items = append(items, QueueItem{
 			Type:            QueueItemPR,
+			RepoID:          pr.RepoID,
 			Platform:        platform.Kind(repo.Platform),
 			RepoOwner:       repo.Owner,
 			RepoName:        repo.Name,
@@ -9872,6 +10509,7 @@ func (s *Syncer) buildDetailQueueItems(
 		}
 		items = append(items, QueueItem{
 			Type:            QueueItemIssue,
+			RepoID:          issue.RepoID,
 			Platform:        platform.Kind(repo.Platform),
 			RepoOwner:       repo.Owner,
 			RepoName:        repo.Name,
@@ -10057,6 +10695,29 @@ func (s *Syncer) syncMRForRepo(
 		defer releaseProviderWork()
 	}
 
+	resolvedRepo, _, err := s.resolveActiveRepository(ctx, repo)
+	if err != nil {
+		return fmt.Errorf(
+			"resolve repo identity %s/%s: %w",
+			repo.Owner,
+			repo.Name,
+			err,
+		)
+	}
+	leaseCtx, repo, releaseRepository, err := s.leaseTrackedRepositoryByID(
+		ctx,
+		resolvedRepo.RepoID,
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"lease resolved repo identity %s/%s: %w",
+			resolvedRepo.Owner,
+			resolvedRepo.Name,
+			err,
+		)
+	}
+	defer releaseRepository()
+	ctx = leaseCtx
 	owner := repo.Owner
 	name := repo.Name
 	mrReader, err := s.mergeRequestReaderFor(repo)
@@ -10064,10 +10725,7 @@ func (s *Syncer) syncMRForRepo(
 		return fmt.Errorf("resolve merge request reader for %s/%s: %w", owner, name, err)
 	}
 
-	repoID, err := s.db.UpsertRepo(ctx, platform.DBRepoIdentity(platformRepoRef(repo)))
-	if err != nil {
-		return fmt.Errorf("upsert repo %s/%s: %w", owner, name, err)
-	}
+	repoID := repo.RepoID
 
 	// Preserve derived fields that provider detail doesn't populate. CI is
 	// refreshed later in this sync path; keeping the previous values here
@@ -10092,7 +10750,7 @@ func (s *Syncer) syncMRForRepo(
 				*providerAttempted = true
 			}
 			ghPR, newETag, notModified, err = s.getPullRequestForDetail(
-				ctx, client, repo, number,
+				ctx, client, repo, repoID, number,
 			)
 			// Same canonical lookup classification as the raw
 			// GetGitHubPullRequest branch below.
@@ -10326,8 +10984,7 @@ func (s *Syncer) syncMRForRepo(
 	}
 	if newETag != "" {
 		if err := s.db.UpsertHTTPEtag(
-			ctx, string(repoPlatform(repo)), repoHost(repo),
-			repo.Owner, repo.Name, "pull_request", number, newETag,
+			ctx, repoID, "pull_request", number, newETag,
 		); err != nil {
 			slog.Warn("persist pull request ETag failed",
 				"repo", repo.Owner+"/"+repo.Name,
@@ -10441,8 +11098,8 @@ func (s *Syncer) syncMRDiff(
 	if s.clones == nil {
 		return nil
 	}
-	host := repoHost(repo)
-	if err := s.clones.EnsureClone(ctx, string(repoPlatform(repo)), host, repo.Owner, repo.Name, cloneRemoteURL(repo)); err != nil {
+	clone := s.repositoryClone(repo)
+	if err := clone.EnsureClone(ctx, cloneRemoteURL(repo)); err != nil {
 		return &DiffSyncError{
 			Code: DiffSyncCodeCloneUnavailable,
 			Err:  fmt.Errorf("ensure bare clone for #%d: %w", number, err),
@@ -10462,7 +11119,11 @@ func (s *Syncer) syncMRDiff(
 	if normalized.PlatformHeadSHA == "" || normalized.PlatformBaseSHA == "" {
 		return nil
 	}
-	mb, err := s.clones.MergeBase(ctx, string(repoPlatform(repo)), host, repo.Owner, repo.Name, normalized.PlatformBaseSHA, normalized.PlatformHeadSHA)
+	mb, err := clone.MergeBase(
+		ctx,
+		normalized.PlatformBaseSHA,
+		normalized.PlatformHeadSHA,
+	)
 	if err != nil {
 		return &DiffSyncError{
 			Code: DiffSyncCodeMergeBaseFailed,
@@ -10506,20 +11167,24 @@ func (s *Syncer) syncProviderMRDiff(
 	if normalized.PlatformHeadSHA == "" || normalized.PlatformBaseSHA == "" {
 		return nil
 	}
-	host := repoHost(repo)
+	clone := s.repositoryClone(repo)
 	// List sync already fetched the repo clone once for this cycle;
 	// refetching per MR would turn one repo sync into N network
 	// round-trips. Per-MR detail syncs have no prior fetch and pass
 	// ensureClone.
 	if ensureClone {
-		if err := s.clones.EnsureClone(ctx, string(repoPlatform(repo)), host, repo.Owner, repo.Name, cloneRemoteURL(repo)); err != nil {
+		if err := clone.EnsureClone(ctx, cloneRemoteURL(repo)); err != nil {
 			return &DiffSyncError{
 				Code: DiffSyncCodeCloneUnavailable,
 				Err:  fmt.Errorf("ensure bare clone for #%d: %w", number, err),
 			}
 		}
 	}
-	mb, err := s.clones.MergeBase(ctx, string(repoPlatform(repo)), host, repo.Owner, repo.Name, normalized.PlatformBaseSHA, normalized.PlatformHeadSHA)
+	mb, err := clone.MergeBase(
+		ctx,
+		normalized.PlatformBaseSHA,
+		normalized.PlatformHeadSHA,
+	)
 	if err != nil {
 		return &DiffSyncError{
 			Code: DiffSyncCodeMergeBaseFailed,
@@ -10629,10 +11294,30 @@ func (s *Syncer) syncIssueForRepo(
 		defer releaseProviderWork()
 	}
 
-	repoID, err := s.db.UpsertRepo(ctx, platform.DBRepoIdentity(platformRepoRef(repo)))
+	resolvedRepo, _, err := s.resolveActiveRepository(ctx, repo)
 	if err != nil {
-		return fmt.Errorf("upsert repo %s/%s: %w", repo.Owner, repo.Name, err)
+		return fmt.Errorf(
+			"resolve repo identity %s/%s: %w",
+			repo.Owner,
+			repo.Name,
+			err,
+		)
 	}
+	leaseCtx, repo, releaseRepository, err := s.leaseTrackedRepositoryByID(
+		ctx,
+		resolvedRepo.RepoID,
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"lease resolved repo identity %s/%s: %w",
+			resolvedRepo.Owner,
+			resolvedRepo.Name,
+			err,
+		)
+	}
+	defer releaseRepository()
+	ctx = leaseCtx
+	repoID := repo.RepoID
 
 	providerCalls, err := s.fetchIssueDetail(ctx, repo, repoID, number)
 	if providerAttempted != nil && providerCalls > 0 {
@@ -10721,7 +11406,17 @@ func (s *Syncer) SyncItemByNumber(
 			owner, name, repoPlatform(repo), repo.PlatformHost,
 		)
 	}
-
+	repo, _, err = s.resolveActiveRepository(ctx, repo)
+	if err != nil {
+		return "", fmt.Errorf(
+			"resolve repo identity %s/%s: %w",
+			owner,
+			name,
+			err,
+		)
+	}
+	owner = repo.Owner
+	name = repo.Name
 	// GitHub's Issues API returns both issues and PRs. If the
 	// response has PullRequestLinks, it's a PR.
 	client, err := s.clientFor(repo)
@@ -10834,10 +11529,6 @@ func (s *Syncer) fetchAndUpdateClosed(ctx context.Context, repo RepoRef, repoID 
 	// is always a pre-merge commit on the base branch lineage, and the pull
 	// ref always points to the original PR head. We only do this when no diff
 	// SHAs exist yet; PRs synced while open already have valid diff SHAs.
-	closedHost := repo.PlatformHost
-	if closedHost == "" {
-		closedHost = "github.com"
-	}
 	if s.clones != nil && cloneFetchOK {
 		headSHA := ghPR.GetHead().GetSHA()
 		baseSHA := ghPR.GetBase().GetSHA()
@@ -10857,7 +11548,9 @@ func (s *Syncer) fetchAndUpdateClosed(ctx context.Context, repo RepoRef, repoID 
 				)
 			}
 		} else if headSHA != "" && baseSHA != "" {
-			mb, err := s.clones.MergeBase(ctx, string(repoPlatform(repo)), closedHost, repo.Owner, repo.Name, baseSHA, headSHA)
+			mb, err := s.repositoryClone(repo).MergeBase(
+				ctx, baseSHA, headSHA,
+			)
 			if err != nil {
 				slog.Warn("merge-base for closed PR failed",
 					"repo", repo.Owner+"/"+repo.Name,
@@ -11053,12 +11746,9 @@ func (s *Syncer) computeMergedMRDiffSHAs(
 	// Resolve the PR head from the pull ref. GitHub keeps these refs
 	// indefinitely, pointing to the original PR head commit regardless
 	// of merge strategy.
-	mergedHost := repo.PlatformHost
-	if mergedHost == "" {
-		mergedHost = "github.com"
-	}
 	pullRef := fmt.Sprintf("refs/pull/%d/head", number)
-	prHead, err := s.clones.RevParse(ctx, string(repoPlatform(repo)), mergedHost, repo.Owner, repo.Name, pullRef)
+	clone := s.repositoryClone(repo)
+	prHead, err := clone.RevParse(ctx, pullRef)
 	if err != nil {
 		return &DiffSyncError{
 			Code: DiffSyncCodeCommitUnreachable,
@@ -11069,7 +11759,7 @@ func (s *Syncer) computeMergedMRDiffSHAs(
 	// Use the merge commit's first parent as the base for merge-base.
 	// This avoids the post-merge ancestor problem where prHead is reachable
 	// from the current base branch tip (making merge-base return prHead).
-	preMergeBase, err := s.clones.RevParse(ctx, string(repoPlatform(repo)), mergedHost, repo.Owner, repo.Name, mergeCommitSHA+"^1")
+	preMergeBase, err := clone.RevParse(ctx, mergeCommitSHA+"^1")
 	if err != nil {
 		return &DiffSyncError{
 			Code: DiffSyncCodeCommitUnreachable,
@@ -11077,7 +11767,7 @@ func (s *Syncer) computeMergedMRDiffSHAs(
 		}
 	}
 
-	mb, err := s.clones.MergeBase(ctx, string(repoPlatform(repo)), mergedHost, repo.Owner, repo.Name, preMergeBase, prHead)
+	mb, err := clone.MergeBase(ctx, preMergeBase, prHead)
 	if err != nil {
 		return &DiffSyncError{
 			Code: DiffSyncCodeMergeBaseFailed,

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 	"net/http"
 	"net/url"
+	"path"
 	"reflect"
 	"slices"
 	"strconv"
@@ -243,7 +244,11 @@ type RepoRef struct {
 	// ConfiguredRoutes retains every exact configuration route that resolved
 	// to this immutable repository identity. It is populated when configured
 	// entries converge so all aliases survive restart and reload.
-	ConfiguredRoutes   []ConfiguredRepoRoute
+	ConfiguredRoutes []ConfiguredRepoRoute
+	// ConfiguredGlobs retains the glob entries that discovered this repository.
+	// Unlike exact routes, globs are membership constraints rather than aliases:
+	// a later provider rename must still match at least one active pattern.
+	ConfiguredGlobs    []ConfiguredRepoGlob
 	PlatformHost       string
 	RepoPath           string
 	PlatformRepoID     int64
@@ -257,6 +262,11 @@ type ConfiguredRepoRoute struct {
 	Owner    string
 	Name     string
 	RepoPath string
+}
+
+type ConfiguredRepoGlob struct {
+	Owner string
+	Name  string
 }
 
 // PartialSyncError reports a repo sync cycle whose index scan completed but
@@ -5452,6 +5462,7 @@ func repoRefFromStoredRepository(
 		CredentialOwner:    configured.CredentialOwner,
 		CredentialName:     configured.CredentialName,
 		ConfiguredRoutes:   slices.Clone(configured.ConfiguredRoutes),
+		ConfiguredGlobs:    slices.Clone(configured.ConfiguredGlobs),
 		PlatformHost:       stored.PlatformHost,
 		RepoPath:           stored.RepoPath,
 		PlatformRepoID:     configured.PlatformRepoID,
@@ -5568,6 +5579,10 @@ func compactTrackedRepositoriesByID(repos []RepoRef) []RepoRef {
 					compacted[existingIndex] = repo
 				}
 				compacted[existingIndex].ConfiguredRoutes = routes
+				compacted[existingIndex].ConfiguredGlobs = appendUniqueConfiguredGlobs(
+					slices.Clone(compacted[existingIndex].ConfiguredGlobs),
+					repo.ConfiguredGlobs...,
+				)
 				continue
 			}
 			seen[repo.RepoID] = len(compacted)
@@ -5642,7 +5657,10 @@ func (s *Syncer) saveConfiguredRoutes(
 	repoID int64,
 	repo RepoRef,
 ) error {
-	routes := configuredRoutesForCandidate(repo, false)
+	routes := exactConfiguredRoutes(repo)
+	if len(routes) == 0 && len(repo.ConfiguredGlobs) > 0 {
+		return nil
+	}
 	if len(routes) == 0 {
 		return s.db.SaveRepoConfiguredRoute(
 			ctx, repoID, configuredRouteIdentity(repo),
@@ -5668,7 +5686,7 @@ func configuredRouteBindings(repos []RepoRef) []db.RepoConfiguredRouteBinding {
 		if repo.RepoID <= 0 {
 			continue
 		}
-		for _, route := range configuredRoutesForCandidate(repo, false) {
+		for _, route := range exactConfiguredRoutes(repo) {
 			bindings = append(bindings, db.RepoConfiguredRouteBinding{
 				RepoID: repo.RepoID,
 				Route: db.RepoIdentity{
@@ -5679,6 +5697,63 @@ func configuredRouteBindings(repos []RepoRef) []db.RepoConfiguredRouteBinding {
 		}
 	}
 	return bindings
+}
+
+func exactConfiguredRoutes(repo RepoRef) []ConfiguredRepoRoute {
+	if len(repo.ConfiguredRoutes) > 0 {
+		return slices.Clone(repo.ConfiguredRoutes)
+	}
+	if len(repo.ConfiguredGlobs) > 0 {
+		return nil
+	}
+	return configuredRoutesForCandidate(repo, false)
+}
+
+func repoMatchesConfiguredGlobs(repo RepoRef, identity db.RepoIdentity) bool {
+	if len(repo.ConfiguredGlobs) == 0 || len(repo.ConfiguredRoutes) > 0 {
+		return true
+	}
+	for _, configured := range repo.ConfiguredGlobs {
+		if !strings.EqualFold(configured.Owner, identity.Owner) {
+			continue
+		}
+		matched, err := path.Match(
+			canonicalRepoPattern(configured.Name),
+			canonicalRepoName(identity.Name),
+		)
+		if err == nil && matched {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Syncer) removeTrackedRepositoryLocked(
+	ctx context.Context,
+	resolution repositoryResolution,
+) error {
+	s.reposMu.Lock()
+	repos := slices.DeleteFunc(slices.Clone(s.repos), func(repo RepoRef) bool {
+		return configuredRepositoryKey(repo) == resolution.key
+	})
+	s.reposMu.Unlock()
+	if err := s.replaceRepositoryCredentialAliases(repos); err != nil {
+		return err
+	}
+	if s.archiveLifecycle != nil {
+		refs := make([]platform.RepoRef, 0, len(repos))
+		for _, repo := range repos {
+			refs = append(refs, platformRepoRef(repo))
+		}
+		if err := s.archiveLifecycle.EnsureConfigured(ctx, refs); err != nil {
+			return fmt.Errorf("reconcile archive discovery after glob mismatch: %w", err)
+		}
+	}
+	s.reposMu.Lock()
+	s.repos = repos
+	s.reposGeneration++
+	s.reposMu.Unlock()
+	return nil
 }
 
 func (s *Syncer) publishResolvedRepositoryLocked(
@@ -5745,6 +5820,18 @@ func (s *Syncer) resolveActiveRepository(
 	)
 	if !tracked {
 		return RepoRef{}, nil, errRepositoryResolutionSuperseded
+	}
+	if !repoMatchesConfiguredGlobs(current, identity) {
+		if !sameGeneration || !repoRefsEqual(current, resolution.configured) {
+			return RepoRef{}, nil, errRepositoryResolutionSuperseded
+		}
+		if err := s.removeTrackedRepositoryLocked(ctx, resolution); err != nil {
+			return RepoRef{}, nil, err
+		}
+		return RepoRef{}, nil, fmt.Errorf(
+			"configured repository glob no longer matches %s/%s: %w",
+			identity.Owner, identity.Name, errRepositoryResolutionSuperseded,
+		)
 	}
 	if repoRefMatchesResolvedIdentity(current, identity) {
 		_, active, release, leaseErr := s.leaseActiveRepositoryByID(

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/shurcooL/githubv4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/config"
 	"go.kenn.io/forge/internal/db"
 	"go.kenn.io/forge/internal/gitclone"
 	"go.kenn.io/forge/internal/platform"
@@ -1050,6 +1051,7 @@ type syncTestReadProvider struct {
 type syncTestRepositoryReadProvider struct {
 	*syncTestReadProvider
 	repository         platform.Repository
+	repositories       []platform.Repository
 	repositoryErr      error
 	getRepositoryFn    func(context.Context, platform.RepoRef) (platform.Repository, error)
 	getRepositoryCalls atomic.Int32
@@ -1152,7 +1154,7 @@ func (p *syncTestRepositoryReadProvider) ListRepositories(
 	string,
 	platform.RepositoryListOptions,
 ) ([]platform.Repository, error) {
-	return nil, nil
+	return p.repositories, nil
 }
 
 func (p *syncTestReadProvider) ListOpenMergeRequests(
@@ -7165,6 +7167,116 @@ func TestResolveActiveRepositoryDiscardsSupersededGeneration(t *testing.T) {
 	require.Len(snapshots, 1)
 	require.Len(snapshots[0], 1)
 	require.Equal("newer-project", snapshots[0][0].Name)
+}
+
+func TestResolveActiveRepositoryDropsGlobMatchRenamedOutsidePattern(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	initial := platform.Repository{
+		Ref: platform.RepoRef{
+			Platform: platform.KindGitLab, Host: "gitlab.example.com",
+			Owner: "group", Name: "service-api", RepoPath: "group/service-api",
+			PlatformExternalID: "repository-42",
+		},
+		PlatformExternalID: "repository-42",
+	}
+	provider := &syncTestRepositoryReadProvider{
+		syncTestReadProvider: &syncTestReadProvider{
+			syncTestProvider: syncTestProvider{
+				kind: platform.KindGitLab, host: "gitlab.example.com",
+			},
+		},
+		repositories: []platform.Repository{initial},
+	}
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+	resolved := ResolveConfiguredReposWithRegistry(ctx, registry, []config.Repo{{
+		Platform: "gitlab", PlatformHost: "gitlab.example.com",
+		Owner: "group", Name: "service-*",
+	}})
+	require.Empty(resolved.Warnings)
+	require.Len(resolved.Expanded, 1)
+	configured := resolved.Expanded[0]
+	repoID, err := database.UpsertRepoByProviderID(
+		ctx, platform.DBRepositoryIdentity(initial),
+	)
+	require.NoError(err)
+	configured.RepoID = repoID
+	provider.repository = platform.Repository{
+		Ref: platform.RepoRef{
+			Platform: platform.KindGitLab, Host: "gitlab.example.com",
+			Owner: "group", Name: "utility", RepoPath: "group/utility",
+			PlatformExternalID: "repository-42",
+		},
+		PlatformExternalID: "repository-42",
+	}
+	syncer := NewSyncerWithRegistry(
+		registry, database, nil, []RepoRef{configured}, time.Minute, nil, nil,
+	)
+
+	_, _, err = syncer.resolveActiveRepository(ctx, configured)
+	require.Error(err)
+	require.Empty(syncer.TrackedRepos())
+}
+
+func TestResolveActiveRepositoryKeepsGlobMatchWithoutPersistingAlias(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	initial := platform.Repository{
+		Ref: platform.RepoRef{
+			Platform: platform.KindGitLab, Host: "gitlab.example.com",
+			Owner: "group", Name: "service-api", RepoPath: "group/service-api",
+			PlatformExternalID: "repository-42",
+		},
+		PlatformExternalID: "repository-42",
+	}
+	provider := &syncTestRepositoryReadProvider{
+		syncTestReadProvider: &syncTestReadProvider{
+			syncTestProvider: syncTestProvider{
+				kind: platform.KindGitLab, host: "gitlab.example.com",
+			},
+		},
+		repositories: []platform.Repository{initial},
+	}
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+	resolved := ResolveConfiguredReposWithRegistry(ctx, registry, []config.Repo{{
+		Platform: "gitlab", PlatformHost: "gitlab.example.com",
+		Owner: "group", Name: "service-*",
+	}})
+	require.Empty(resolved.Warnings)
+	require.Len(resolved.Expanded, 1)
+	configured := resolved.Expanded[0]
+	repoID, err := database.UpsertRepoByProviderID(
+		ctx, platform.DBRepositoryIdentity(initial),
+	)
+	require.NoError(err)
+	configured.RepoID = repoID
+	provider.repository = platform.Repository{
+		Ref: platform.RepoRef{
+			Platform: platform.KindGitLab, Host: "gitlab.example.com",
+			Owner: "group", Name: "service-worker", RepoPath: "group/service-worker",
+			PlatformExternalID: "repository-42",
+		},
+		PlatformExternalID: "repository-42",
+	}
+	syncer := NewSyncerWithRegistry(
+		registry, database, nil, []RepoRef{configured}, time.Minute, nil, nil,
+	)
+
+	active, _, err := syncer.resolveActiveRepository(ctx, configured)
+	require.NoError(err)
+	require.Equal("service-worker", active.Name)
+	require.Len(syncer.TrackedRepos(), 1)
+	var routeCount int
+	err = database.ReadDB().QueryRowContext(
+		ctx, `SELECT COUNT(*) FROM forge_repository_config_routes WHERE repo_id = ?`,
+		repoID,
+	).Scan(&routeCount)
+	require.NoError(err)
+	require.Zero(routeCount)
 }
 
 func TestResolveActiveRepositoryDeduplicatesConvergedConfiguredRoutes(t *testing.T) {
@@ -17637,6 +17749,122 @@ func TestProcessQueuedNotificationReadsDefersOnlyRateLimitedIdentity(t *testing.
 		"another owner's exhausted PAT must not defer this ack")
 	check.NotNil(byThread["healthy-thread"].SourceAckSyncedAt,
 		"the healthy owner's ack propagated in the same pass")
+}
+
+func TestNotificationRateLimitDeferralSurvivesRenameAndRouteReuse(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	originalID, err := database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "repository-original", Owner: "acme", Name: "widget",
+		RepoPath: "acme/widget",
+	})
+	require.NoError(err)
+	now := time.Date(2026, 7, 31, 10, 0, 0, 0, time.UTC)
+	queuedAt := now.Add(time.Minute)
+	number := 7
+	require.NoError(database.UpsertNotifications(ctx, []db.Notification{
+		{
+			Platform: "github", PlatformHost: "github.com",
+			PlatformNotificationID: "original-one", RepoID: &originalID,
+			RepoOwner: "acme", RepoName: "widget", SubjectType: "PullRequest",
+			SubjectTitle: "First", ItemNumber: &number, ItemType: "pr",
+			Reason: "mention", Unread: true, SourceUpdatedAt: now, SyncedAt: now,
+		},
+		{
+			Platform: "github", PlatformHost: "github.com",
+			PlatformNotificationID: "original-two", RepoID: &originalID,
+			RepoOwner: "acme", RepoName: "widget", SubjectType: "PullRequest",
+			SubjectTitle: "Second", ItemNumber: &number, ItemType: "pr",
+			Reason: "mention", Unread: true, SourceUpdatedAt: now, SyncedAt: now,
+		},
+	}))
+	items, err := database.ListNotifications(ctx, db.ListNotificationsOpts{State: "all"})
+	require.NoError(err)
+	require.Len(items, 2)
+	ids := []int64{items[0].ID, items[1].ID}
+	_, err = database.QueueNotificationIDsRead(ctx, ids, queuedAt)
+	require.NoError(err)
+	queued, err := database.ListQueuedNotificationAcks(
+		ctx, "github", "github.com", 10, queuedAt,
+	)
+	require.NoError(err)
+	require.Len(queued, 2)
+	syncer := NewSyncer(
+		map[string]Client{"github.com": &mockClient{}}, database, nil,
+		[]RepoRef{{
+			Platform: platform.KindGitHub, PlatformHost: "github.com",
+			RepoID: originalID, Owner: "acme", Name: "widget",
+			PlatformExternalID: "repository-original",
+		}},
+		time.Minute, nil, nil,
+	)
+	bucketRepos, notificationBuckets := syncer.ackRepoBuckets(
+		ctx, platform.KindGitHub, "github.com", queued,
+	)
+	bucket := notificationBuckets[queued[0].ID]
+	require.NotEmpty(bucket)
+	require.Equal([]db.NotificationRepoRef{{RepoID: originalID}}, bucketRepos[bucket])
+
+	_, err = database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "repository-original", Owner: "acme", Name: "renamed-widget",
+		RepoPath: "acme/renamed-widget",
+	})
+	require.NoError(err)
+	replacementID, err := database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "repository-replacement", Owner: "acme", Name: "widget",
+		RepoPath: "acme/widget",
+	})
+	require.NoError(err)
+	replacement := db.Notification{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformNotificationID: "replacement", RepoID: &replacementID,
+		RepoOwner: "acme", RepoName: "widget", SubjectType: "PullRequest",
+		SubjectTitle: "Replacement", ItemNumber: &number, ItemType: "pr",
+		Reason: "mention", Unread: true, SourceUpdatedAt: now, SyncedAt: now,
+	}
+	require.NoError(database.UpsertNotifications(ctx, []db.Notification{replacement}))
+	items, err = database.ListNotifications(ctx, db.ListNotificationsOpts{State: "all"})
+	require.NoError(err)
+	var replacementNotificationID int64
+	for _, item := range items {
+		if item.PlatformNotificationID == "replacement" {
+			replacementNotificationID = item.ID
+		}
+	}
+	require.Positive(replacementNotificationID)
+	_, err = database.QueueNotificationIDsRead(
+		ctx, []int64{replacementNotificationID}, queuedAt,
+	)
+	require.NoError(err)
+	resetAt := now.Add(time.Hour)
+	limited, err := syncer.deferQueuedNotificationAckOnError(
+		ctx, platform.KindGitHub, "github.com", bucket, bucketRepos[bucket],
+		queued[0], &gh.RateLimitError{
+			Rate: gh.Rate{Reset: gh.Timestamp{Time: resetAt}},
+			Response: &http.Response{
+				StatusCode: http.StatusForbidden,
+				Request:    httptest.NewRequest(http.MethodPatch, "https://api.github.com/notifications/threads/original-one", nil),
+			},
+			Message: "API rate limit exceeded",
+		},
+	)
+	require.NoError(err)
+	require.True(limited)
+
+	items, err = database.ListNotifications(ctx, db.ListNotificationsOpts{State: "all"})
+	require.NoError(err)
+	byThread := make(map[string]db.Notification, len(items))
+	for _, item := range items {
+		byThread[item.PlatformNotificationID] = item
+	}
+	assert.Equal("rate_limited", byThread["original-one"].SourceAckError)
+	assert.Equal("rate_limited", byThread["original-two"].SourceAckError)
+	assert.Empty(byThread["replacement"].SourceAckError)
 }
 
 // Deferral must be scoped even for queued rows this pass never reaches. With a

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -195,6 +195,7 @@ func TestSyncArchiveItemClassifiesOnlyConfirmedParentNotFound(t *testing.T) {
 	ref := platform.RepoRef{
 		Platform: platform.KindGitLab, Host: "gitlab.example.com",
 		Owner: "group", Name: "project", RepoPath: "group/project",
+		PlatformExternalID: "gid://gitlab/Project/42",
 	}
 	issue := platform.Issue{
 		Repo: ref, PlatformID: 7, PlatformExternalID: "issue-7", Number: 7,
@@ -211,16 +212,16 @@ func TestSyncArchiveItemClassifiesOnlyConfirmedParentNotFound(t *testing.T) {
 	}{
 		{
 			name: "accessible repository confirms missing parent", getIssueErr: platform.ErrNotFound,
-			wantNotPresent: true, wantRepoQueries: 1,
+			wantNotPresent: true, wantRepoQueries: 2,
 		},
 		{
 			name:           "provider metadata already confirms missing parent",
 			getIssueErr:    errors.Join(platform.ErrLookupNotPresent, platform.ErrNotFound),
-			wantNotPresent: true,
+			wantNotPresent: true, wantRepoQueries: 1,
 		},
 		{
 			name: "child event not found stays retryable", issues: []platform.Issue{issue},
-			listEventsErr: platform.ErrNotFound,
+			listEventsErr: platform.ErrNotFound, wantRepoQueries: 1,
 		},
 		{
 			name: "missing repository does not prove missing parent", getIssueErr: platform.ErrNotFound,
@@ -759,7 +760,15 @@ esac
 		PlatformHost: "github.com",
 		CloneURL:     "https://github.com/acme/widgets.git",
 	}
-	clonePath, err := clones.ClonePath("github", "github.com", repo.Owner, repo.Name)
+	repoID, err := database.UpsertRepo(
+		t.Context(),
+		db.GitHubRepoIdentity("github.com", repo.Owner, repo.Name),
+	)
+	require.NoError(err)
+	repo.RepoID = repoID
+	clonePath, err := clones.RepositoryClone(
+		repoID, "github", "github.com", repo.Owner, repo.Name,
+	).ClonePath()
 	require.NoError(err)
 	require.NoError(os.MkdirAll(clonePath, 0o755))
 	require.NoError(os.WriteFile(
@@ -767,11 +776,6 @@ esac
 		[]byte("ref: refs/heads/main\n"),
 		0o644,
 	))
-	repoID, err := database.UpsertRepo(
-		t.Context(),
-		db.GitHubRepoIdentity("github.com", repo.Owner, repo.Name),
-	)
-	require.NoError(err)
 	syncer := NewSyncer(
 		map[string]Client{"github.com": &mockClient{}},
 		database,
@@ -1047,6 +1051,7 @@ type syncTestRepositoryReadProvider struct {
 	*syncTestReadProvider
 	repository         platform.Repository
 	repositoryErr      error
+	getRepositoryFn    func(context.Context, platform.RepoRef) (platform.Repository, error)
 	getRepositoryCalls atomic.Int32
 }
 
@@ -1132,10 +1137,13 @@ func (p *syncTestReadProvider) Capabilities() platform.Capabilities {
 }
 
 func (p *syncTestRepositoryReadProvider) GetRepository(
-	context.Context,
-	platform.RepoRef,
+	ctx context.Context,
+	ref platform.RepoRef,
 ) (platform.Repository, error) {
 	p.getRepositoryCalls.Add(1)
+	if p.getRepositoryFn != nil {
+		return p.getRepositoryFn(ctx, ref)
+	}
 	return p.repository, p.repositoryErr
 }
 
@@ -2068,11 +2076,13 @@ func TestSyncNotificationsContinuesAfterRepoErrorOnSameHost(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	database := openTestDB(t)
+	repoIDs := make(map[string]int64)
 	for _, name := range []string{"broken", "widget"} {
-		_, err := database.UpsertRepo(
+		repoID, err := database.UpsertRepo(
 			t.Context(), db.GitHubRepoIdentity("github.com", "acme", name),
 		)
 		require.NoError(err)
+		repoIDs[name] = repoID
 	}
 	boom := errors.New("bad scoped credential")
 	number := 7
@@ -2115,12 +2125,12 @@ func TestSyncNotificationsContinuesAfterRepoErrorOnSameHost(t *testing.T) {
 	assert.Equal("thread-ok", items[0].PlatformNotificationID)
 
 	brokenWatermark, watermarkErr := database.GetNotificationSyncWatermark(
-		t.Context(), "github", "github.com", "acme", "broken",
+		t.Context(), repoIDs["broken"],
 	)
 	require.NoError(watermarkErr)
 	assert.Nil(brokenWatermark, "a failing repository must not advance its own watermark")
 	widgetWatermark, watermarkErr := database.GetNotificationSyncWatermark(
-		t.Context(), "github", "github.com", "acme", "widget",
+		t.Context(), repoIDs["widget"],
 	)
 	require.NoError(watermarkErr)
 	require.NotNil(widgetWatermark,
@@ -2128,16 +2138,178 @@ func TestSyncNotificationsContinuesAfterRepoErrorOnSameHost(t *testing.T) {
 	assert.False(widgetWatermark.LastSuccessfulSyncAt.IsZero())
 }
 
+func TestSyncNotificationsBlocksRepositoryReplacementThroughPersistence(
+	t *testing.T,
+) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	const (
+		oldProviderID = "R_old"
+		newProviderID = "R_new"
+	)
+	oldRepoID, err := database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: oldProviderID,
+		Owner:          "acme",
+		Name:           "widget",
+		RepoPath:       "acme/widget",
+	})
+	require.NoError(err)
+
+	fetchStarted := make(chan struct{})
+	continueFetch := make(chan struct{})
+	number := 7
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	client := &mockClient{
+		getRepositoryFn: func(
+			context.Context,
+			string,
+			string,
+		) (*gh.Repository, error) {
+			owner := "acme"
+			name := "widget"
+			nodeID := oldProviderID
+			return &gh.Repository{
+				NodeID: &nodeID,
+				Name:   &name,
+				Owner:  &gh.User{Login: &owner},
+			}, nil
+		},
+		listNotificationsFn: func(
+			_ context.Context,
+			opts NotificationListOptions,
+		) ([]NotificationThread, bool, error) {
+			if opts.Participating {
+				return nil, false, nil
+			}
+			close(fetchStarted)
+			<-continueFetch
+			return []NotificationThread{{
+				ID:           "thread-7",
+				RepoOwner:    "acme",
+				RepoName:     "widget",
+				SubjectType:  "PullRequest",
+				SubjectTitle: "Review requested",
+				WebURL:       "https://github.com/acme/widget/pull/7",
+				ItemNumber:   &number,
+				ItemType:     "pr",
+				Reason:       "mention",
+				Unread:       true,
+				UpdatedAt:    now,
+			}}, false, nil
+		},
+	}
+	configured := RepoRef{
+		Platform:           platform.KindGitHub,
+		PlatformHost:       "github.com",
+		Owner:              "acme",
+		Name:               "widget",
+		RepoPath:           "acme/widget",
+		RepoID:             oldRepoID,
+		PlatformExternalID: oldProviderID,
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client},
+		database,
+		nil,
+		[]RepoRef{configured},
+		time.Minute,
+		nil,
+		nil,
+	)
+	t.Cleanup(syncer.Stop)
+
+	syncDone := make(chan error, 1)
+	go func() {
+		syncDone <- syncer.syncNotificationsForRepo(
+			ctx,
+			platform.KindGitHub,
+			"github.com",
+			client,
+			configured,
+			now,
+		)
+	}()
+	<-fetchStarted
+
+	writeAttempted := make(chan struct{})
+	restoreWriteLockHook := database.SetBeforeRepositoryReconciliationWriteLockForTest(
+		func() { close(writeAttempted) },
+	)
+	defer restoreWriteLockHook()
+	replacementDone := make(chan error, 1)
+	go func() {
+		_, replacementErr := database.UpsertRepoByProviderID(
+			ctx,
+			db.RepoIdentity{
+				Platform:       "github",
+				PlatformHost:   "github.com",
+				PlatformRepoID: newProviderID,
+				Owner:          "acme",
+				Name:           "widget",
+				RepoPath:       "acme/widget",
+			},
+		)
+		replacementDone <- replacementErr
+	}()
+	<-writeAttempted
+
+	var (
+		replacementErr       error
+		replacementCompleted bool
+	)
+	select {
+	case replacementErr = <-replacementDone:
+		replacementCompleted = true
+	case <-time.After(250 * time.Millisecond):
+	}
+	close(continueFetch)
+	require.NoError(<-syncDone)
+	if !replacementCompleted {
+		replacementErr = <-replacementDone
+	}
+	require.NoError(replacementErr)
+	assert.False(
+		replacementCompleted,
+		"replacement must wait for notification persistence and watermark advancement",
+	)
+
+	active, err := database.GetRepoByIdentity(ctx, db.RepoIdentity{
+		Platform:     "github",
+		PlatformHost: "github.com",
+		Owner:        "acme",
+		Name:         "widget",
+	})
+	require.NoError(err)
+	require.NotNil(active)
+	assert.NotEqual(oldRepoID, active.ID)
+	assert.Equal(newProviderID, active.PlatformRepoID)
+	activeWatermark, err := database.GetNotificationSyncWatermark(
+		ctx,
+		active.ID,
+	)
+	require.NoError(err)
+	assert.Nil(
+		activeWatermark,
+		"the replacement incarnation must start with a fresh notification watermark",
+	)
+}
+
 func TestSyncNotificationsSkipsUnroutedRepoAndAdvancesRoutedSibling(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	database := openTestDB(t)
+	repoIDs := make(map[string]int64)
 	for _, identity := range []db.RepoIdentity{
 		db.GitHubRepoIdentity("github.com", "acme", "widget"),
 		db.GitHubRepoIdentity("github.com", "unrouted", "thing"),
 	} {
-		_, err := database.UpsertRepo(t.Context(), identity)
+		repoID, err := database.UpsertRepo(t.Context(), identity)
 		require.NoError(err)
+		repoIDs[identity.Name] = repoID
 	}
 	number := 7
 	client := &mockClient{
@@ -2175,13 +2347,13 @@ func TestSyncNotificationsSkipsUnroutedRepoAndAdvancesRoutedSibling(t *testing.T
 	err = syncer.SyncNotifications(t.Context())
 	require.Error(err, "the unrouted repository must surface its failure")
 	widgetWatermark, wmErr := database.GetNotificationSyncWatermark(
-		t.Context(), "github", "github.com", "acme", "widget",
+		t.Context(), repoIDs["widget"],
 	)
 	require.NoError(wmErr)
 	require.NotNil(widgetWatermark,
 		"a routed sibling must sync and advance despite an unroutable repository on the host")
 	unroutedWatermark, wmErr := database.GetNotificationSyncWatermark(
-		t.Context(), "github", "github.com", "unrouted", "thing",
+		t.Context(), repoIDs["thing"],
 	)
 	require.NoError(wmErr)
 	assert.Nil(unroutedWatermark)
@@ -3051,6 +3223,200 @@ func TestProcessQueuedNotificationReadsStopsRetryMetadataAtMaxAttempts(t *testin
 	assert.Empty(queued)
 }
 
+func TestProcessQueuedNotificationReadsUsesRenamedRepositoryCredentialAlias(
+	t *testing.T,
+) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	repoID, err := d.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "repo-stable", Owner: "acme", Name: "widget",
+		RepoPath: "acme/widget",
+	})
+	require.NoError(err)
+	_, err = d.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "repo-stable", Owner: "acme-tools", Name: "renamed-widget",
+		RepoPath: "acme-tools/renamed-widget",
+	})
+	require.NoError(err)
+	now := time.Date(2026, 7, 31, 10, 0, 0, 0, time.UTC)
+	number := 7
+	require.NoError(d.UpsertNotifications(ctx, []db.Notification{{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformNotificationID: "thread-renamed", RepoID: &repoID,
+		RepoOwner: "acme-tools", RepoName: "renamed-widget",
+		SubjectType: "PullRequest", SubjectTitle: "Review requested",
+		ItemNumber: &number, ItemType: "pr", Reason: "mention",
+		Unread: true, SourceUpdatedAt: now, SyncedAt: now,
+	}}))
+	items, err := d.ListNotifications(ctx, db.ListNotificationsOpts{State: "all"})
+	require.NoError(err)
+	require.Len(items, 1)
+	_, err = d.QueueNotificationIDsRead(ctx, []int64{items[0].ID}, now.Add(time.Minute))
+	require.NoError(err)
+
+	var fetched []string
+	var marked []string
+	provider := &mockClient{
+		getNotificationThreadFn: func(
+			_ context.Context, threadID string,
+		) (NotificationThread, error) {
+			fetched = append(fetched, threadID)
+			return NotificationThread{ID: threadID, UpdatedAt: now}, nil
+		},
+		markNotificationThreadReadFn: func(
+			_ context.Context, threadID string,
+		) error {
+			marked = append(marked, threadID)
+			return nil
+		},
+	}
+	router, err := NewHostRouter("github.com", &Route{
+		Key:           RouteKey{Host: "github.com", Owner: "acme", Name: "widget"},
+		Client:        provider,
+		ReadIdentity:  IdentityKey{Host: "github.com", Principal: "user:1"},
+		WriteIdentity: IdentityKey{Host: "github.com", Principal: "user:1"},
+	})
+	require.NoError(err)
+	routed, err := NewRoutedClient(router)
+	require.NoError(err)
+	syncer := NewSyncer(
+		map[string]Client{"github.com": routed}, d, nil,
+		[]RepoRef{{
+			Platform: platform.KindGitHub, PlatformHost: "github.com",
+			RepoID: repoID, Owner: "acme-tools", Name: "renamed-widget",
+			CredentialOwner: "acme", CredentialName: "widget",
+			PlatformExternalID: "repo-stable",
+		}},
+		time.Minute, nil, nil,
+	)
+	syncer.SetGitHubRouters(map[string]*HostRouter{"github.com": router})
+
+	require.NoError(syncer.ProcessQueuedNotificationReads(
+		ctx, platform.KindGitHub, "github.com", 10,
+	))
+	assert.Equal([]string{"thread-renamed", "thread-renamed"}, fetched)
+	assert.Equal([]string{"thread-renamed"}, marked)
+	queued, err := d.ListQueuedNotificationAcks(
+		ctx, "github", "github.com", 10, now.Add(time.Hour),
+	)
+	require.NoError(err)
+	assert.Empty(queued)
+}
+
+func TestProcessQueuedNotificationReadsLeasesRepositoryThroughPersistence(
+	t *testing.T,
+) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	repoID, err := d.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "repo-original", Owner: "acme", Name: "widget",
+		RepoPath: "acme/widget",
+	})
+	require.NoError(err)
+	now := time.Date(2026, 7, 31, 10, 0, 0, 0, time.UTC)
+	number := 7
+	require.NoError(d.UpsertNotifications(ctx, []db.Notification{{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformNotificationID: "thread-race", RepoID: &repoID,
+		RepoOwner: "acme", RepoName: "widget",
+		SubjectType: "PullRequest", SubjectTitle: "Review requested",
+		ItemNumber: &number, ItemType: "pr", Reason: "mention",
+		Unread: true, SourceUpdatedAt: now, SyncedAt: now,
+	}}))
+	items, err := d.ListNotifications(ctx, db.ListNotificationsOpts{State: "all"})
+	require.NoError(err)
+	require.Len(items, 1)
+	_, err = d.QueueNotificationIDsRead(ctx, []int64{items[0].ID}, now.Add(time.Minute))
+	require.NoError(err)
+
+	fetchStarted := make(chan struct{})
+	continueFetch := make(chan struct{})
+	var blockFirstFetch sync.Once
+	provider := &mockClient{
+		getNotificationThreadFn: func(
+			_ context.Context, threadID string,
+		) (NotificationThread, error) {
+			blockFirstFetch.Do(func() {
+				close(fetchStarted)
+				<-continueFetch
+			})
+			return NotificationThread{ID: threadID, UpdatedAt: now}, nil
+		},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": provider}, d, nil,
+		[]RepoRef{{
+			Platform: platform.KindGitHub, PlatformHost: "github.com",
+			RepoID: repoID, Owner: "acme", Name: "widget",
+			PlatformExternalID: "repo-original",
+		}},
+		time.Minute, nil, nil,
+	)
+	ackDone := make(chan error, 1)
+	go func() {
+		ackDone <- syncer.ProcessQueuedNotificationReads(
+			ctx, platform.KindGitHub, "github.com", 10,
+		)
+	}()
+	select {
+	case <-fetchStarted:
+	case <-time.After(2 * time.Second):
+		require.Fail("notification acknowledgement did not fetch")
+	}
+
+	writeLockAttempted := make(chan struct{})
+	d.SetBeforeRepositoryReconciliationWriteLockForTest(
+		func() { close(writeLockAttempted) },
+	)
+	replacementDone := make(chan error, 1)
+	go func() {
+		_, replaceErr := d.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+			Platform: "github", PlatformHost: "github.com",
+			PlatformRepoID: "repo-replacement", Owner: "acme", Name: "widget",
+			RepoPath: "acme/widget",
+		})
+		replacementDone <- replaceErr
+	}()
+	select {
+	case <-writeLockAttempted:
+	case <-time.After(2 * time.Second):
+		require.Fail("repository replacement did not queue")
+	}
+	replacedDuringFetch := false
+	select {
+	case err := <-replacementDone:
+		require.NoError(err)
+		replacedDuringFetch = true
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(continueFetch)
+	select {
+	case err := <-ackDone:
+		require.NoError(err)
+	case <-time.After(2 * time.Second):
+		require.Fail("notification acknowledgement did not finish")
+	}
+	if !replacedDuringFetch {
+		select {
+		case err := <-replacementDone:
+			require.NoError(err)
+		case <-time.After(2 * time.Second):
+			require.Fail("repository replacement did not resume")
+		}
+	}
+	assert.False(
+		replacedDuringFetch,
+		"repository replacement must wait for notification persistence",
+	)
+}
+
 func TestProcessQueuedNotificationReadsPausesOnRateLimitWithoutConsumingAttempts(t *testing.T) {
 	require := require.New(t)
 	check := assert.New(t)
@@ -3515,11 +3881,11 @@ func TestSyncNotificationsUsesPersistedSinceWatermark(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	d := openTestDB(t)
-	_, err := d.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
+	repoID, err := d.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	watermark := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
 	lastFullSyncAt := time.Now().UTC()
-	require.NoError(d.UpdateNotificationSyncWatermark(t.Context(), "github", "github.com", "acme", "widget", watermark, &lastFullSyncAt))
+	require.NoError(d.UpdateNotificationSyncWatermark(t.Context(), repoID, watermark, &lastFullSyncAt))
 	var seen []NotificationListOptions
 	syncer := NewSyncer(
 		map[string]Client{
@@ -3562,11 +3928,11 @@ func TestSyncNotificationsDoesPeriodicFullSyncForReadState(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 	d := openTestDB(t)
-	_, err := d.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
+	repoID, err := d.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	watermark := time.Now().UTC().Add(-2 * notificationFullSyncInterval)
 	lastFullSyncAt := watermark
-	require.NoError(d.UpdateNotificationSyncWatermark(t.Context(), "github", "github.com", "acme", "widget", watermark, &lastFullSyncAt))
+	require.NoError(d.UpdateNotificationSyncWatermark(t.Context(), repoID, watermark, &lastFullSyncAt))
 	var seen []NotificationListOptions
 	syncer := NewSyncer(
 		map[string]Client{
@@ -3605,13 +3971,13 @@ func TestSyncNotificationsNewRepoFullSyncsWithoutResettingSiblings(t *testing.T)
 	require := require.New(t)
 	assert := assert.New(t)
 	d := openTestDB(t)
-	_, err := d.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
+	repoID, err := d.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "widget"))
 	require.NoError(err)
 	_, err = d.UpsertRepo(t.Context(), db.GitHubRepoIdentity("github.com", "acme", "new-repo"))
 	require.NoError(err)
 	watermark := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
 	lastFullSyncAt := time.Now().UTC()
-	require.NoError(d.UpdateNotificationSyncWatermark(t.Context(), "github", "github.com", "acme", "widget", watermark, &lastFullSyncAt))
+	require.NoError(d.UpdateNotificationSyncWatermark(t.Context(), repoID, watermark, &lastFullSyncAt))
 	var seen []NotificationListOptions
 	syncer := NewSyncer(
 		map[string]Client{
@@ -5449,7 +5815,7 @@ func TestCommitMergeRequestParentSnapshotBlocksRepositoryReconciliationThroughRe
 		Name:           "old-name",
 	})
 	require.NoError(err)
-	destinationID, err := d.UpsertRepo(ctx, db.RepoIdentity{
+	_, err = d.UpsertRepo(ctx, db.RepoIdentity{
 		Platform:     "gitlab",
 		PlatformHost: "gitlab.com",
 		Owner:        "new-group",
@@ -5529,7 +5895,7 @@ func TestCommitMergeRequestParentSnapshotBlocksRepositoryReconciliationThroughRe
 	assert.Equal(forkURL, *reclassified.MRHeadRepo)
 
 	moved, err := d.GetMergeRequestByRepoIDAndNumber(
-		ctx, destinationID, stored.Number,
+		ctx, sourceID, stored.Number,
 	)
 	require.NoError(err)
 	require.NotNil(moved)
@@ -5612,7 +5978,7 @@ func TestReclassifyWorkspaceHeadRepoTrustBlocksRepositoryReconciliation(t *testi
 		Name:           "old-name",
 	})
 	require.NoError(err)
-	destinationID, err := d.UpsertRepo(ctx, db.RepoIdentity{
+	_, err = d.UpsertRepo(ctx, db.RepoIdentity{
 		Platform:     "gitlab",
 		PlatformHost: "gitlab.com",
 		Owner:        "new-group",
@@ -5716,7 +6082,7 @@ func TestReclassifyWorkspaceHeadRepoTrustBlocksRepositoryReconciliation(t *testi
 	assert.Equal(forkURL, *reclassified.MRHeadRepo)
 
 	moved, err := d.GetMergeRequestByRepoIDAndNumber(
-		ctx, destinationID, stored.Number,
+		ctx, sourceID, stored.Number,
 	)
 	require.NoError(err)
 	require.NotNil(moved)
@@ -6617,6 +6983,635 @@ func TestSyncRepoUsesProviderIDToPreserveRenamedRepo(t *testing.T) {
 	assert.Equal("new-group/new-project", repos[0].RepoPath)
 }
 
+func TestPublishResolvedRepositoryDoesNotMutateConfiguredInput(t *testing.T) {
+	require := require.New(t)
+
+	configured := RepoRef{
+		Platform:           platform.KindGitLab,
+		PlatformHost:       "gitlab.example.com",
+		Owner:              "old-group",
+		Name:               "old-project",
+		RepoPath:           "old-group/old-project",
+		PlatformExternalID: "gid://gitlab/Project/42",
+	}
+	repos := []RepoRef{configured}
+	syncer := NewSyncerWithRegistry(
+		nil, openTestDB(t), nil, repos, time.Minute, nil, nil,
+	)
+	resolved := configured
+	resolved.RepoID = 42
+	resolved.Owner = "new-group"
+	resolved.Name = "new-project"
+	resolved.RepoPath = "new-group/new-project"
+
+	resolution, err := syncer.beginRepositoryResolution(configured)
+	require.NoError(err)
+	syncer.repoPublicationMu.Lock()
+	require.NoError(syncer.publishResolvedRepositoryLocked(
+		t.Context(),
+		resolution,
+		resolved,
+	))
+	syncer.repoPublicationMu.Unlock()
+	require.Equal([]RepoRef{configured}, repos)
+	require.Equal([]RepoRef{resolved}, syncer.TrackedRepos())
+}
+
+func TestCompactTrackedRepositoriesPrefersCurrentConfiguredRouteAfterRename(
+	t *testing.T,
+) {
+	require := require.New(t)
+	alias := RepoRef{
+		Platform:           platform.KindGitHub,
+		PlatformHost:       "github.com",
+		RepoID:             42,
+		Owner:              "acme-tools",
+		Name:               "renamed-widget",
+		RepoPath:           "acme-tools/renamed-widget",
+		CredentialOwner:    "acme",
+		CredentialName:     "widget",
+		PlatformExternalID: "R_stable",
+	}
+	direct := alias
+	direct.CredentialOwner = ""
+	direct.CredentialName = ""
+
+	require.Equal(
+		[]RepoRef{direct},
+		compactTrackedRepositoriesByID([]RepoRef{alias, direct}),
+	)
+}
+
+type repositoryPublicationArchiveRecorder struct {
+	mu      sync.Mutex
+	ensured [][]platform.RepoRef
+}
+
+func (*repositoryPublicationArchiveRecorder) RunEligible(context.Context) error {
+	return nil
+}
+
+func (r *repositoryPublicationArchiveRecorder) EnsureConfigured(
+	_ context.Context,
+	refs []platform.RepoRef,
+) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.ensured = append(r.ensured, slices.Clone(refs))
+	return nil
+}
+
+func (*repositoryPublicationArchiveRecorder) RetryAuthentication(
+	context.Context,
+	[]platform.RepoRef,
+) error {
+	return nil
+}
+
+func (r *repositoryPublicationArchiveRecorder) snapshots() [][]platform.RepoRef {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([][]platform.RepoRef, len(r.ensured))
+	for i := range r.ensured {
+		out[i] = slices.Clone(r.ensured[i])
+	}
+	return out
+}
+
+func TestResolveActiveRepositoryDiscardsSupersededGeneration(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	configured := RepoRef{
+		Platform:     platform.KindGitLab,
+		PlatformHost: "gitlab.example.com",
+		Owner:        "group",
+		Name:         "configured-project",
+		RepoPath:     "group/configured-project",
+	}
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	var calls atomic.Int32
+	provider := &syncTestRepositoryReadProvider{
+		syncTestReadProvider: &syncTestReadProvider{
+			syncTestProvider: syncTestProvider{
+				kind: platform.KindGitLab,
+				host: "gitlab.example.com",
+			},
+		},
+		getRepositoryFn: func(
+			ctx context.Context,
+			_ platform.RepoRef,
+		) (platform.Repository, error) {
+			call := calls.Add(1)
+			name := "newer-project"
+			if call == 1 {
+				close(firstStarted)
+				select {
+				case <-releaseFirst:
+				case <-ctx.Done():
+					return platform.Repository{}, ctx.Err()
+				}
+				name = "older-project"
+			}
+			return platform.Repository{
+				Ref: platform.RepoRef{
+					Platform:           platform.KindGitLab,
+					Host:               "gitlab.example.com",
+					Owner:              "group",
+					Name:               name,
+					RepoPath:           "group/" + name,
+					PlatformExternalID: "repository-42",
+				},
+				PlatformExternalID: "repository-42",
+			}, nil
+		},
+	}
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+	syncer := NewSyncerWithRegistry(
+		registry,
+		database,
+		nil,
+		[]RepoRef{configured},
+		time.Minute,
+		nil,
+		nil,
+	)
+	archiveRecorder := &repositoryPublicationArchiveRecorder{}
+	syncer.archiveLifecycle = archiveRecorder
+
+	firstDone := make(chan error, 1)
+	go func() {
+		_, _, err := syncer.resolveActiveRepository(ctx, configured)
+		firstDone <- err
+	}()
+	<-firstStarted
+
+	_, _, err = syncer.resolveActiveRepository(ctx, configured)
+	require.NoError(err)
+	close(releaseFirst)
+	require.Error(<-firstDone)
+
+	tracked := syncer.TrackedRepos()
+	require.Len(tracked, 1)
+	require.Equal("newer-project", tracked[0].Name)
+	stored, err := database.GetRepoByID(ctx, tracked[0].RepoID)
+	require.NoError(err)
+	require.NotNil(stored)
+	require.Equal("newer-project", stored.Name)
+
+	snapshots := archiveRecorder.snapshots()
+	require.Len(snapshots, 1)
+	require.Len(snapshots[0], 1)
+	require.Equal("newer-project", snapshots[0][0].Name)
+}
+
+func TestResolveActiveRepositoryDeduplicatesConvergedConfiguredRoutes(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	configured := []RepoRef{
+		{
+			Platform:     platform.KindGitLab,
+			PlatformHost: "gitlab.example.com",
+			Owner:        "group",
+			Name:         "legacy-project",
+			RepoPath:     "group/legacy-project",
+		},
+		{
+			Platform:     platform.KindGitLab,
+			PlatformHost: "gitlab.example.com",
+			Owner:        "group",
+			Name:         "current-project",
+			RepoPath:     "group/current-project",
+		},
+	}
+	provider := &syncTestRepositoryReadProvider{
+		syncTestReadProvider: &syncTestReadProvider{
+			syncTestProvider: syncTestProvider{
+				kind: platform.KindGitLab,
+				host: "gitlab.example.com",
+			},
+		},
+		repository: platform.Repository{
+			Ref: platform.RepoRef{
+				Platform:           platform.KindGitLab,
+				Host:               "gitlab.example.com",
+				Owner:              "group",
+				Name:               "current-project",
+				RepoPath:           "group/current-project",
+				PlatformExternalID: "repository-42",
+			},
+			PlatformExternalID: "repository-42",
+		},
+	}
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+	syncer := NewSyncerWithRegistry(
+		registry,
+		database,
+		nil,
+		configured,
+		time.Minute,
+		nil,
+		nil,
+	)
+
+	_, _, err = syncer.resolveActiveRepository(ctx, configured[0])
+	require.NoError(err)
+	_, _, err = syncer.resolveActiveRepository(ctx, configured[1])
+	require.NoError(err)
+
+	tracked := syncer.TrackedRepos()
+	require.Len(tracked, 1)
+	require.Positive(tracked[0].RepoID)
+	require.Equal("current-project", tracked[0].Name)
+}
+
+func TestResolveActiveRepositoryPersistsConfiguredRouteAfterRename(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	configured := RepoRef{
+		Platform:     platform.KindGitLab,
+		PlatformHost: "gitlab.example.com",
+		Owner:        "group",
+		Name:         "legacy-project",
+		RepoPath:     "group/legacy-project",
+	}
+	provider := &syncTestRepositoryReadProvider{
+		syncTestReadProvider: &syncTestReadProvider{
+			syncTestProvider: syncTestProvider{
+				kind: platform.KindGitLab,
+				host: "gitlab.example.com",
+			},
+		},
+		repository: platform.Repository{
+			Ref: platform.RepoRef{
+				Platform:           platform.KindGitLab,
+				Host:               "gitlab.example.com",
+				Owner:              "group",
+				Name:               "current-project",
+				RepoPath:           "group/current-project",
+				PlatformExternalID: "repository-42",
+			},
+			PlatformExternalID: "repository-42",
+		},
+	}
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+	syncer := NewSyncerWithRegistry(
+		registry, database, nil, []RepoRef{configured}, time.Minute, nil, nil,
+	)
+
+	resolved, _, err := syncer.resolveActiveRepository(ctx, configured)
+	require.NoError(err)
+
+	var repoID int64
+	var owner, name string
+	err = database.ReadDB().QueryRowContext(ctx, `
+		SELECT repo_id, owner, name
+		FROM forge_repository_config_routes
+		WHERE platform = ? AND platform_host = ? AND repo_path_key = ?`,
+		"gitlab", "gitlab.example.com", "group/legacy-project",
+	).Scan(&repoID, &owner, &name)
+	require.NoError(err)
+	require.Equal(resolved.RepoID, repoID)
+	require.Equal("group", owner)
+	require.Equal("legacy-project", name)
+}
+
+func TestResolveActiveRepositoryBackfillsConfiguredRouteForStoredRename(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	repoID, err := database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform:       "gitlab",
+		PlatformHost:   "gitlab.example.com",
+		PlatformRepoID: "repository-42",
+		Owner:          "group",
+		Name:           "current-project",
+		RepoPath:       "group/current-project",
+	})
+	require.NoError(err)
+	configured := RepoRef{
+		Platform:           platform.KindGitLab,
+		RepoID:             repoID,
+		PlatformHost:       "gitlab.example.com",
+		Owner:              "group",
+		Name:               "current-project",
+		RepoPath:           "group/current-project",
+		CredentialOwner:    "group",
+		CredentialName:     "legacy-project",
+		PlatformExternalID: "repository-42",
+	}
+	provider := &syncTestRepositoryReadProvider{
+		syncTestReadProvider: &syncTestReadProvider{
+			syncTestProvider: syncTestProvider{
+				kind: platform.KindGitLab,
+				host: "gitlab.example.com",
+			},
+		},
+		repository: platform.Repository{
+			Ref: platform.RepoRef{
+				Platform:           platform.KindGitLab,
+				Host:               "gitlab.example.com",
+				Owner:              "group",
+				Name:               "current-project",
+				RepoPath:           "group/current-project",
+				PlatformExternalID: "repository-42",
+			},
+			PlatformExternalID: "repository-42",
+		},
+	}
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+	syncer := NewSyncerWithRegistry(
+		registry, database, nil, []RepoRef{configured}, time.Minute, nil, nil,
+	)
+
+	_, _, err = syncer.resolveActiveRepository(ctx, configured)
+	require.NoError(err)
+
+	var aliasedRepoID int64
+	err = database.ReadDB().QueryRowContext(ctx, `
+		SELECT repo_id
+		FROM forge_repository_config_routes
+		WHERE platform = ? AND platform_host = ? AND repo_path_key = ?`,
+		"gitlab", "gitlab.example.com", "group/legacy-project",
+	).Scan(&aliasedRepoID)
+	require.NoError(err)
+	require.Equal(repoID, aliasedRepoID)
+}
+
+func TestSetReposWithContextDoesNotMutateConfiguredInput(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	configured := RepoRef{
+		Platform:     platform.KindGitHub,
+		PlatformHost: "github.com",
+		Owner:        "acme",
+		Name:         "widget",
+		RepoPath:     "acme/widget",
+	}
+	repos := []RepoRef{configured}
+	repoID, err := database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repository-42",
+		Owner:          "acme",
+		Name:           "widget",
+		RepoPath:       "acme/widget",
+	})
+	require.NoError(err)
+	syncer := NewSyncerWithRegistry(
+		nil, database, nil, nil, time.Minute, nil, nil,
+	)
+
+	require.NoError(syncer.SetReposWithContext(ctx, repos, false))
+
+	require.Equal([]RepoRef{configured}, repos)
+	tracked := syncer.TrackedRepos()
+	require.Len(tracked, 1)
+	require.Equal(repoID, tracked[0].RepoID)
+	require.Equal("repository-42", tracked[0].PlatformExternalID)
+}
+
+func TestSetReposWithContextPersistsAllConvergedExactRoutes(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	repoID, err := database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "repository-42", Owner: "acme", Name: "current",
+		RepoPath: "acme/current",
+	})
+	require.NoError(err)
+	syncer := NewSyncerWithRegistry(nil, database, nil, nil, time.Minute, nil, nil)
+
+	require.NoError(syncer.SetReposWithContext(ctx, []RepoRef{{
+		Platform: platform.KindGitHub, PlatformHost: "github.com",
+		Owner: "acme", Name: "current", RepoPath: "acme/current",
+		PlatformExternalID: "repository-42",
+		ConfiguredRoutes: []ConfiguredRepoRoute{
+			{Owner: "acme", Name: "legacy", RepoPath: "acme/legacy"},
+			{Owner: "acme", Name: "current", RepoPath: "acme/current"},
+		},
+	}}, false))
+
+	legacy, err := database.GetRepoByConfiguredRoute(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		Owner: "acme", Name: "legacy", RepoPath: "acme/legacy",
+	})
+	require.NoError(err)
+	require.NotNil(legacy)
+	require.Equal(repoID, legacy.ID)
+}
+
+func TestSyncRepoReplacesPathWithNewRepositoryIncarnation(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+
+	oldID, err := d.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform:       "gitlab",
+		PlatformHost:   "gitlab.example.com",
+		PlatformRepoID: "gid://gitlab/Project/old",
+		Owner:          "group",
+		Name:           "project",
+		RepoPath:       "group/project",
+	})
+	require.NoError(err)
+	oldMR := &db.MergeRequest{
+		RepoID: oldID, PlatformID: 1001, PlatformExternalID: "old-mr",
+		Number: 7, Title: "old incarnation", State: db.MergeRequestStateOpen,
+		HeadBranch: "old-feature", BaseBranch: "main",
+		CreatedAt: now.Add(-time.Hour), UpdatedAt: now.Add(-time.Hour),
+		LastActivityAt: now.Add(-time.Hour),
+	}
+	_, err = d.UpsertMergeRequest(ctx, oldMR)
+	require.NoError(err)
+
+	ref := RepoRef{
+		Platform:           platform.KindGitLab,
+		PlatformHost:       "gitlab.example.com",
+		Owner:              "group",
+		Name:               "project",
+		RepoPath:           "group/project",
+		PlatformExternalID: "gid://gitlab/Project/old",
+	}
+	provider := &syncTestRepositoryReadProvider{
+		syncTestReadProvider: &syncTestReadProvider{
+			syncTestProvider: syncTestProvider{
+				kind: platform.KindGitLab,
+				host: "gitlab.example.com",
+			},
+			mergeRequests: []platform.MergeRequest{{
+				Repo: platform.RepoRef{
+					Platform: platform.KindGitLab,
+					Host:     "gitlab.example.com",
+					Owner:    "group",
+					Name:     "project",
+					RepoPath: "group/project",
+				},
+				PlatformID: 2001, PlatformExternalID: "new-mr",
+				Number: 7, Title: "new incarnation",
+				State:      string(db.MergeRequestStateOpen),
+				HeadBranch: "new-feature", BaseBranch: "main",
+				CreatedAt: now, UpdatedAt: now, LastActivityAt: now,
+			}},
+		},
+		repository: platform.Repository{
+			Ref: platform.RepoRef{
+				Platform:           platform.KindGitLab,
+				Host:               "gitlab.example.com",
+				Owner:              "group",
+				Name:               "project",
+				RepoPath:           "group/project",
+				PlatformExternalID: "gid://gitlab/Project/new",
+			},
+			PlatformExternalID: "gid://gitlab/Project/new",
+		},
+	}
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+	syncer := NewSyncerWithRegistry(
+		registry,
+		d,
+		nil,
+		[]RepoRef{ref},
+		time.Minute,
+		nil,
+		nil,
+	)
+
+	require.NoError(syncer.syncRepo(ctx, ref))
+
+	active, err := d.GetRepoByIdentity(ctx, db.RepoIdentity{
+		Platform:     "gitlab",
+		PlatformHost: "gitlab.example.com",
+		Owner:        "group",
+		Name:         "project",
+	})
+	require.NoError(err)
+	require.NotNil(active)
+	assert.NotEqual(oldID, active.ID)
+	assert.Equal("gid://gitlab/Project/new", active.PlatformRepoID)
+
+	retired, err := d.GetRepoByID(ctx, oldID)
+	require.NoError(err)
+	require.NotNil(retired)
+	require.NotNil(retired.RetiredAt)
+	require.NotNil(retired.RetiredReplacementID)
+	assert.Equal(active.ID, *retired.RetiredReplacementID)
+
+	oldStored, err := d.GetMergeRequestByRepoIDAndNumber(ctx, oldID, 7)
+	require.NoError(err)
+	require.NotNil(oldStored)
+	assert.Equal("old incarnation", oldStored.Title)
+
+	newStored, err := d.GetMergeRequestByRepoIDAndNumber(ctx, active.ID, 7)
+	require.NoError(err)
+	require.NotNil(newStored)
+	assert.Equal("new incarnation", newStored.Title)
+
+	listed, err := d.ListMergeRequests(ctx, db.ListMergeRequestsOpts{State: "all"})
+	require.NoError(err)
+	require.Len(listed, 1)
+	assert.Equal(active.ID, listed[0].RepoID)
+
+	tracked, ok := syncer.trackedRepoByIdentity(
+		platform.KindGitLab,
+		"group",
+		"project",
+		"gitlab.example.com",
+	)
+	require.True(ok)
+	assert.Equal(active.ID, tracked.RepoID)
+	assert.Equal("gid://gitlab/Project/new", tracked.PlatformExternalID)
+}
+
+func TestSyncRepoDetectsOriginalPathReuseAfterRename(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	configured := RepoRef{
+		Platform:     platform.KindGitLab,
+		PlatformHost: "gitlab.example.com",
+		Owner:        "group",
+		Name:         "legacy-project",
+		RepoPath:     "group/legacy-project",
+	}
+	original := platform.Repository{
+		Ref: platform.RepoRef{
+			Platform:           platform.KindGitLab,
+			Host:               "gitlab.example.com",
+			Owner:              "group",
+			Name:               "current-project",
+			RepoPath:           "group/current-project",
+			PlatformExternalID: "gid://gitlab/Project/42",
+		},
+		PlatformExternalID: "gid://gitlab/Project/42",
+	}
+	replacement := platform.Repository{
+		Ref: platform.RepoRef{
+			Platform:           platform.KindGitLab,
+			Host:               "gitlab.example.com",
+			Owner:              "group",
+			Name:               "legacy-project",
+			RepoPath:           "group/legacy-project",
+			PlatformExternalID: "gid://gitlab/Project/84",
+		},
+		PlatformExternalID: "gid://gitlab/Project/84",
+	}
+	current := original
+	provider := &syncTestRepositoryReadProvider{
+		syncTestReadProvider: &syncTestReadProvider{
+			syncTestProvider: syncTestProvider{
+				kind: platform.KindGitLab,
+				host: "gitlab.example.com",
+			},
+		},
+		getRepositoryFn: func(
+			_ context.Context,
+			ref platform.RepoRef,
+		) (platform.Repository, error) {
+			assert.Equal("group/legacy-project", ref.RepoPath)
+			return current, nil
+		},
+	}
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+	syncer := NewSyncerWithRegistry(
+		registry,
+		database,
+		nil,
+		[]RepoRef{configured},
+		time.Minute,
+		nil,
+		nil,
+	)
+
+	require.NoError(syncer.syncRepo(ctx, configured))
+	current = replacement
+	require.NoError(syncer.syncRepo(ctx, syncer.TrackedRepos()[0]))
+
+	repos, err := database.ListRepos(ctx)
+	require.NoError(err)
+	require.Len(repos, 2)
+	byProviderID := make(map[string]db.Repo, len(repos))
+	for _, repo := range repos {
+		byProviderID[repo.PlatformRepoID] = repo
+	}
+	assert.Equal("group/current-project", byProviderID["gid://gitlab/Project/42"].RepoPath)
+	assert.Equal("group/legacy-project", byProviderID["gid://gitlab/Project/84"].RepoPath)
+}
+
 func TestRepoReconciliationDefersTrustUntilPostRenameSnapshot(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -6683,9 +7678,9 @@ func TestRepoReconciliationDefersTrustUntilPostRenameSnapshot(t *testing.T) {
 		RepoPath:       "new-group/new-project",
 	})
 	require.NoError(err)
-	assert.Equal(destinationID, reconciledID)
+	assert.Equal(sourceID, reconciledID)
 
-	merged, err := d.GetMergeRequestByRepoIDAndNumber(ctx, destinationID, 7)
+	merged, err := d.GetMergeRequestByRepoIDAndNumber(ctx, sourceID, 7)
 	require.NoError(err)
 	require.NotNil(merged)
 	assert.Equal("newer old-identity snapshot", merged.Title)
@@ -6731,7 +7726,7 @@ func TestRepoReconciliationDefersTrustUntilPostRenameSnapshot(t *testing.T) {
 	require.True(accepted)
 	assert.Greater(revision, merged.SnapshotRevision)
 
-	merged, err = d.GetMergeRequestByRepoIDAndNumber(ctx, destinationID, 7)
+	merged, err = d.GetMergeRequestByRepoIDAndNumber(ctx, sourceID, 7)
 	require.NoError(err)
 	require.NotNil(merged)
 	assert.True(merged.HeadRepoIdentityStale)
@@ -6757,7 +7752,7 @@ func TestRepoReconciliationDefersTrustUntilPostRenameSnapshot(t *testing.T) {
 	require.True(accepted)
 	assert.Positive(revision)
 
-	merged, err = d.GetMergeRequestByRepoIDAndNumber(ctx, destinationID, 7)
+	merged, err = d.GetMergeRequestByRepoIDAndNumber(ctx, sourceID, 7)
 	require.NoError(err)
 	require.NotNil(merged)
 	assert.False(merged.HeadRepoIdentityStale)
@@ -6946,7 +7941,16 @@ func TestSyncRepoRefreshesProviderRepoSettingsWhenIdentityKnown(t *testing.T) {
 			},
 		},
 		repository: platform.Repository{
-			ViewerCanMerge: &viewerCanMerge,
+			Ref: platform.RepoRef{
+				Platform:           platform.KindGitLab,
+				Host:               "gitlab.example.com",
+				Owner:              "group",
+				Name:               "project",
+				RepoPath:           "group/project",
+				PlatformExternalID: "gid://gitlab/Project/42",
+			},
+			PlatformExternalID: "gid://gitlab/Project/42",
+			ViewerCanMerge:     &viewerCanMerge,
 		},
 	}
 	registry, err := platform.NewRegistry(provider)
@@ -6995,7 +7999,15 @@ func TestSyncRepoUsesProviderCloneURLForNestedGitLabRepo(t *testing.T) {
 	syncer := NewSyncerWithRegistry(registry, d, clones, []RepoRef{repo}, time.Minute, nil, nil)
 
 	require.NoError(syncer.syncRepo(ctx, repo))
-	clonePath, err := clones.ClonePath("gitlab", "gitlab.example.com", "group/subgroup", "project")
+	tracked := syncer.TrackedRepos()
+	require.Len(tracked, 1)
+	clonePath, err := clones.RepositoryClone(
+		tracked[0].RepoID,
+		"gitlab",
+		"gitlab.example.com",
+		"group/subgroup",
+		"project",
+	).ClonePath()
 	require.NoError(err)
 	require.FileExists(filepath.Join(clonePath, "HEAD"))
 }
@@ -7018,6 +8030,7 @@ func TestDetailDrainUsesProviderCloneURLForNestedGitLabRepo(t *testing.T) {
 	}
 	repoID, err := d.UpsertRepo(ctx, platform.DBRepoIdentity(platformRepoRef(repo)))
 	require.NoError(err)
+	repo.RepoID = repoID
 	_, err = d.UpsertMergeRequest(ctx, &db.MergeRequest{
 		RepoID:         repoID,
 		PlatformID:     1001,
@@ -7063,7 +8076,13 @@ func TestDetailDrainUsesProviderCloneURLForNestedGitLabRepo(t *testing.T) {
 	syncer.drainDetailQueue(ctx, map[string]bool{rateKey: true}, syncer.TrackedRepos())
 
 	assert.Equal(int32(1), provider.getMRCalls.Load())
-	clonePath, err := clones.ClonePath("gitlab", "gitlab.example.com", "group/subgroup", "project")
+	clonePath, err := clones.RepositoryClone(
+		repoID,
+		"gitlab",
+		"gitlab.example.com",
+		"group/subgroup",
+		"project",
+	).ClonePath()
 	require.NoError(err)
 	require.FileExists(filepath.Join(clonePath, "HEAD"))
 }
@@ -9957,8 +10976,7 @@ func TestFetchMRDetailUsesPersistedPullRequestETag(t *testing.T) {
 	})
 	require.NoError(err)
 	require.NoError(d.UpsertHTTPEtag(
-		ctx, "github", "github.com", "owner", "repo",
-		"pull_request", 1, `"etag-v1"`,
+		ctx, repoID, "pull_request", 1, `"etag-v1"`,
 	))
 
 	mc := &conditionalPRTrackingClient{notModified: true}
@@ -10014,8 +11032,7 @@ func TestFetchMRDetailDoesNotBackfillMergedActorOn304(t *testing.T) {
 	})
 	require.NoError(err)
 	require.NoError(d.UpsertHTTPEtag(
-		ctx, "github", "github.com", "owner", "repo",
-		"pull_request", 1, `"etag-v1"`,
+		ctx, repoID, "pull_request", 1, `"etag-v1"`,
 	))
 
 	mc := &conditionalPRTrackingClient{
@@ -10081,8 +11098,7 @@ func TestWatchedSyncMRUsesPersistedPullRequestETag(t *testing.T) {
 	})
 	require.NoError(err)
 	require.NoError(d.UpsertHTTPEtag(
-		ctx, "github", "github.com", "owner", "repo",
-		"pull_request", 1, `"etag-v1"`,
+		ctx, repoID, "pull_request", 1, `"etag-v1"`,
 	))
 
 	mc := &conditionalPRTrackingClient{notModified: true}
@@ -10140,8 +11156,7 @@ func TestWatchedSyncMRDoesNotBackfillMergedActorOn304(t *testing.T) {
 	})
 	require.NoError(err)
 	require.NoError(d.UpsertHTTPEtag(
-		ctx, "github", "github.com", "owner", "repo",
-		"pull_request", 1, `"etag-v1"`,
+		ctx, repoID, "pull_request", 1, `"etag-v1"`,
 	))
 
 	mc := &conditionalPRTrackingClient{
@@ -10205,8 +11220,7 @@ func TestSyncMRBypassesPersistedPullRequestETag(t *testing.T) {
 	})
 	require.NoError(err)
 	require.NoError(d.UpsertHTTPEtag(
-		ctx, "github", "github.com", "owner", "repo",
-		"pull_request", 1, `"etag-v1"`,
+		ctx, repoID, "pull_request", 1, `"etag-v1"`,
 	))
 
 	ciState := "success"
@@ -10257,8 +11271,7 @@ func TestFetchMRDetailPersistsPullRequestETag(t *testing.T) {
 	require.NoError(err)
 
 	etag, err := d.GetHTTPEtag(
-		ctx, "github", "github.com", "owner", "repo",
-		"pull_request", 1,
+		ctx, repoID, "pull_request", 1,
 	)
 	require.NoError(err)
 	assert.Equal(`"etag-v2"`, etag)
@@ -10274,8 +11287,7 @@ func TestFetchMRDetailDoesNotPersistPullRequestETagWhenDetailRefreshFails(t *tes
 	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", repo.Owner, repo.Name))
 	require.NoError(err)
 	require.NoError(d.UpsertHTTPEtag(
-		ctx, "github", "github.com", "owner", "repo",
-		"pull_request", 1, `"etag-v1"`,
+		ctx, repoID, "pull_request", 1, `"etag-v1"`,
 	))
 
 	updatedAt := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
@@ -10292,8 +11304,7 @@ func TestFetchMRDetailDoesNotPersistPullRequestETagWhenDetailRefreshFails(t *tes
 	require.Error(err)
 
 	etag, err := d.GetHTTPEtag(
-		ctx, "github", "github.com", "owner", "repo",
-		"pull_request", 1,
+		ctx, repoID, "pull_request", 1,
 	)
 	require.NoError(err)
 	assert.Equal(`"etag-v1"`, etag)
@@ -10325,8 +11336,7 @@ func TestFetchIssueDetailUsesPersistedIssueETag(t *testing.T) {
 	})
 	require.NoError(err)
 	require.NoError(d.UpsertHTTPEtag(
-		ctx, "github", "github.com", "owner", "repo",
-		"issue", 1, `"issue-etag-v1"`,
+		ctx, repoID, "issue", 1, `"issue-etag-v1"`,
 	))
 
 	mc := &conditionalIssueTrackingClient{notModified: true}
@@ -10366,8 +11376,7 @@ func TestSyncArchiveIssueBypassesPersistedETagForLifecycleBackfill(t *testing.T)
 	_, err = database.UpsertIssue(ctx, normalized)
 	require.NoError(err)
 	require.NoError(database.UpsertHTTPEtag(
-		ctx, "github", "github.com", "owner", "repo",
-		"issue", 7, `"legacy-etag"`,
+		ctx, repoID, "issue", 7, `"legacy-etag"`,
 	))
 
 	client := &conditionalIssueLifecycleClient{
@@ -10489,8 +11498,7 @@ func TestFetchIssueDetailPersistsIssueETag(t *testing.T) {
 	require.NoError(err)
 
 	etag, err := d.GetHTTPEtag(
-		ctx, "github", "github.com", "owner", "repo",
-		"issue", 1,
+		ctx, repoID, "issue", 1,
 	)
 	require.NoError(err)
 	assert.Equal(`"issue-etag-v2"`, etag)
@@ -10506,8 +11514,7 @@ func TestFetchIssueDetailDoesNotPersistIssueETagWhenDetailRefreshFails(t *testin
 	repoID, err := d.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", repo.Owner, repo.Name))
 	require.NoError(err)
 	require.NoError(d.UpsertHTTPEtag(
-		ctx, "github", "github.com", "owner", "repo",
-		"issue", 1, `"issue-etag-v1"`,
+		ctx, repoID, "issue", 1, `"issue-etag-v1"`,
 	))
 
 	updatedAt := time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC)
@@ -10540,8 +11547,7 @@ func TestFetchIssueDetailDoesNotPersistIssueETagWhenDetailRefreshFails(t *testin
 	require.Error(err)
 
 	etag, err := d.GetHTTPEtag(
-		ctx, "github", "github.com", "owner", "repo",
-		"issue", 1,
+		ctx, repoID, "issue", 1,
 	)
 	require.NoError(err)
 	assert.Equal(`"issue-etag-v1"`, etag)
@@ -11003,6 +12009,451 @@ func TestDetailQueueDerivesPendingCIFromCachedChecks(t *testing.T) {
 	queue := BuildQueue(items, now)
 	require.Len(queue, 1)
 	assert.Equal(1, queue[0].Number)
+}
+
+func TestDetailQueueBindsItemsToRepositoryIncarnation(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	repoID, err := database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "R_original",
+		Owner:          "acme",
+		Name:           "widget",
+		RepoPath:       "acme/widget",
+	})
+	require.NoError(err)
+	now := time.Now().UTC().Truncate(time.Second)
+	_, err = database.UpsertIssue(ctx, &db.Issue{
+		RepoID: repoID, PlatformID: 701, Number: 7,
+		Title: "queued detail", Author: "ada", State: "open",
+		CreatedAt: now, UpdatedAt: now, LastActivityAt: now,
+	})
+	require.NoError(err)
+	repo := RepoRef{
+		Platform: platform.KindGitHub, PlatformHost: "github.com",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+		RepoID: repoID, PlatformExternalID: "R_original",
+	}
+	syncer := NewSyncer(nil, database, nil, []RepoRef{repo}, time.Minute, nil, nil)
+
+	items := syncer.buildDetailQueueItems(ctx, syncer.TrackedRepos())
+
+	require.Len(items, 1)
+	require.Equal(repoID, items[0].RepoID)
+}
+
+func TestDetailQueueRejectsItemFromReplacedRepositoryIncarnation(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	repoID, err := database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "R_original",
+		Owner:          "acme",
+		Name:           "widget",
+		RepoPath:       "acme/widget",
+	})
+	require.NoError(err)
+	now := time.Now().UTC().Truncate(time.Second)
+	_, err = database.UpsertIssue(ctx, &db.Issue{
+		RepoID: repoID, PlatformID: 701, Number: 7,
+		Title: "queued detail", Author: "ada", State: "open",
+		CreatedAt: now, UpdatedAt: now, LastActivityAt: now,
+	})
+	require.NoError(err)
+	repo := RepoRef{
+		Platform: platform.KindGitHub, PlatformHost: "github.com",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+		RepoID: repoID, PlatformExternalID: "R_original",
+	}
+	var fetches atomic.Int32
+	client := &mockClient{getIssueFn: func(context.Context, string, string, int) (*gh.Issue, error) {
+		fetches.Add(1)
+		return nil, errors.New("must not fetch a replacement through a stale queue item")
+	}}
+	budgets := testBudget(100)
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client}, database, nil,
+		[]RepoRef{repo}, time.Minute, nil, budgets,
+	)
+	items := syncer.buildDetailQueueItems(ctx, syncer.TrackedRepos())
+	require.Len(items, 1)
+	_, err = database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "R_replacement",
+		Owner:          "acme",
+		Name:           "widget",
+		RepoPath:       "acme/widget",
+	})
+	require.NoError(err)
+
+	syncer.drainDetailQueueItems(ctx, map[string]bool{"github.com": true}, items)
+
+	assert.Zero(fetches.Load())
+	active, err := database.GetRepoByIdentity(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com", Owner: "acme", Name: "widget",
+	})
+	require.NoError(err)
+	require.NotNil(active)
+	assert.Equal("R_replacement", active.PlatformRepoID)
+}
+
+func TestDetailQueueFollowsSameIncarnationRenameWithConfiguredCredential(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	repoID, err := database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "R_stable",
+		Owner:          "acme",
+		Name:           "widget",
+		RepoPath:       "acme/widget",
+	})
+	require.NoError(err)
+	now := time.Now().UTC().Truncate(time.Second)
+	_, err = database.UpsertIssue(ctx, &db.Issue{
+		RepoID: repoID, PlatformID: 701, Number: 7,
+		Title: "queued detail", Author: "ada", State: "open",
+		CreatedAt: now, UpdatedAt: now, LastActivityAt: now,
+	})
+	require.NoError(err)
+	provider := &mockClient{getIssueFn: func(
+		_ context.Context, owner, name string, number int,
+	) (*gh.Issue, error) {
+		assert.Equal("acme-tools", owner)
+		assert.Equal("renamed-widget", name)
+		assert.Equal(7, number)
+		return buildOpenIssue(number, now), nil
+	}}
+	router, err := NewHostRouter("github.com", &Route{
+		Key:          RouteKey{Host: "github.com", Owner: "acme", Name: "widget"},
+		Client:       provider,
+		ReadIdentity: IdentityKey{Host: "github.com", Principal: "user:1"},
+	})
+	require.NoError(err)
+	routed, err := NewRoutedClient(router)
+	require.NoError(err)
+	budgets := testBudget(100)
+	rateBucket := RateBucketKey("github", "github.com", "user:1")
+	budgets[rateBucket] = budgets["github.com"]
+	syncer := NewSyncer(
+		map[string]Client{"github.com": routed}, database, nil,
+		[]RepoRef{{
+			Platform: platform.KindGitHub, PlatformHost: "github.com",
+			Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+			RepoID: repoID, PlatformExternalID: "R_stable",
+		}},
+		time.Minute, nil, budgets,
+	)
+	syncer.SetGitHubRouters(map[string]*HostRouter{"github.com": router})
+	items := syncer.buildDetailQueueItems(ctx, syncer.TrackedRepos())
+	require.Len(items, 1)
+	_, err = database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "R_stable",
+		Owner:          "acme-tools",
+		Name:           "renamed-widget",
+		RepoPath:       "acme-tools/renamed-widget",
+	})
+	require.NoError(err)
+	require.NoError(syncer.SetReposWithContext(ctx, []RepoRef{{
+		Platform: platform.KindGitHub, PlatformHost: "github.com",
+		Owner: "acme-tools", Name: "renamed-widget",
+		CredentialOwner: "acme", CredentialName: "widget",
+		RepoPath: "acme-tools/renamed-widget",
+	}}, false))
+
+	syncer.drainDetailQueueItems(ctx, map[string]bool{rateBucket: true}, items)
+
+	issue, err := database.GetIssueByRepoIDAndNumber(ctx, repoID, 7)
+	require.NoError(err)
+	require.NotNil(issue)
+	assert.NotNil(issue.DetailFetchedAt)
+}
+
+func TestDetailQueueLeasesRepositoryThroughProviderAndPersistence(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	repoID, err := database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "R_original",
+		Owner:          "acme",
+		Name:           "widget",
+		RepoPath:       "acme/widget",
+	})
+	require.NoError(err)
+	now := time.Now().UTC().Truncate(time.Second)
+	_, err = database.UpsertIssue(ctx, &db.Issue{
+		RepoID: repoID, PlatformID: 701, Number: 7,
+		Title: "queued detail", Author: "ada", State: "open",
+		CreatedAt: now, UpdatedAt: now, LastActivityAt: now,
+	})
+	require.NoError(err)
+	repo := RepoRef{
+		Platform: platform.KindGitHub, PlatformHost: "github.com",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+		RepoID: repoID, PlatformExternalID: "R_original",
+	}
+	fetchStarted := make(chan struct{})
+	continueFetch := make(chan struct{})
+	client := &mockClient{getIssueFn: func(context.Context, string, string, int) (*gh.Issue, error) {
+		close(fetchStarted)
+		<-continueFetch
+		return buildOpenIssue(7, now), nil
+	}}
+	budgets := testBudget(100)
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client}, database, nil,
+		[]RepoRef{repo}, time.Minute, nil, budgets,
+	)
+	items := syncer.buildDetailQueueItems(ctx, syncer.TrackedRepos())
+	require.Len(items, 1)
+	drainDone := make(chan struct{})
+	go func() {
+		syncer.drainDetailQueueItems(ctx, map[string]bool{"github.com": true}, items)
+		close(drainDone)
+	}()
+	<-fetchStarted
+
+	writeAttempted := make(chan struct{})
+	restoreWriteLockHook := database.SetBeforeRepositoryReconciliationWriteLockForTest(
+		func() { close(writeAttempted) },
+	)
+	defer restoreWriteLockHook()
+	replacementDone := make(chan error, 1)
+	go func() {
+		_, replacementErr := database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+			Platform:       "github",
+			PlatformHost:   "github.com",
+			PlatformRepoID: "R_replacement",
+			Owner:          "acme",
+			Name:           "widget",
+			RepoPath:       "acme/widget",
+		})
+		replacementDone <- replacementErr
+	}()
+	<-writeAttempted
+
+	var (
+		replacementErr       error
+		replacementCompleted bool
+	)
+	select {
+	case replacementErr = <-replacementDone:
+		replacementCompleted = true
+	case <-time.After(250 * time.Millisecond):
+	}
+	close(continueFetch)
+	<-drainDone
+	if !replacementCompleted {
+		replacementErr = <-replacementDone
+	}
+	require.NoError(replacementErr)
+	assert.False(
+		replacementCompleted,
+		"repository replacement must wait for detail fetch and persistence",
+	)
+}
+
+func TestFullSyncLeasesRepositoryThroughProviderAndPersistence(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	repoID, err := database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "R_original",
+		Owner:          "acme",
+		Name:           "widget",
+		RepoPath:       "acme/widget",
+	})
+	require.NoError(err)
+	repo := RepoRef{
+		Platform: platform.KindGitHub, PlatformHost: "github.com",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+		RepoID: repoID, PlatformExternalID: "R_original",
+	}
+	providerStarted := make(chan struct{})
+	continueProvider := make(chan struct{})
+	client := &mockClient{
+		getRepositoryFn: func(context.Context, string, string) (*gh.Repository, error) {
+			owner := "acme"
+			name := "widget"
+			nodeID := "R_original"
+			return &gh.Repository{
+				NodeID: &nodeID, Name: &name, Owner: &gh.User{Login: &owner},
+			}, nil
+		},
+		listOpenPRsFn: func(context.Context, string, string) ([]*gh.PullRequest, error) {
+			close(providerStarted)
+			<-continueProvider
+			return nil, nil
+		},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client}, database, nil,
+		[]RepoRef{repo}, time.Minute, nil, testBudget(100),
+	)
+
+	syncDone := make(chan error, 1)
+	go func() { syncDone <- syncer.syncRepo(ctx, repo) }()
+	<-providerStarted
+
+	writeAttempted := make(chan struct{})
+	restoreWriteLockHook := database.SetBeforeRepositoryReconciliationWriteLockForTest(
+		func() { close(writeAttempted) },
+	)
+	defer restoreWriteLockHook()
+	replacementDone := make(chan error, 1)
+	go func() {
+		_, replacementErr := database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+			Platform:       "github",
+			PlatformHost:   "github.com",
+			PlatformRepoID: "R_replacement",
+			Owner:          "acme",
+			Name:           "widget",
+			RepoPath:       "acme/widget",
+		})
+		replacementDone <- replacementErr
+	}()
+	<-writeAttempted
+
+	var (
+		replacementErr       error
+		replacementCompleted bool
+	)
+	select {
+	case replacementErr = <-replacementDone:
+		replacementCompleted = true
+	case <-time.After(250 * time.Millisecond):
+	}
+	close(continueProvider)
+	require.NoError(<-syncDone)
+	if !replacementCompleted {
+		replacementErr = <-replacementDone
+	}
+	require.NoError(replacementErr)
+	assert.False(
+		replacementCompleted,
+		"repository replacement must wait for the full sync",
+	)
+}
+
+func TestStandaloneItemSyncsLeaseRepositoryThroughProviderAndPersistence(
+	t *testing.T,
+) {
+	for _, itemType := range []string{"merge request", "issue"} {
+		t.Run(itemType, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			ctx := t.Context()
+			database := openTestDB(t)
+			repoID, err := database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+				Platform:       "github",
+				PlatformHost:   "github.com",
+				PlatformRepoID: "R_original",
+				Owner:          "acme",
+				Name:           "widget",
+				RepoPath:       "acme/widget",
+			})
+			require.NoError(err)
+			repo := RepoRef{
+				Platform: platform.KindGitHub, PlatformHost: "github.com",
+				Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+				RepoID: repoID, PlatformExternalID: "R_original",
+			}
+			providerStarted := make(chan struct{})
+			continueProvider := make(chan struct{})
+			now := time.Now().UTC().Truncate(time.Second)
+			client := &mockClient{
+				getRepositoryFn: func(context.Context, string, string) (*gh.Repository, error) {
+					owner := "acme"
+					name := "widget"
+					nodeID := "R_original"
+					return &gh.Repository{
+						NodeID: &nodeID, Name: &name, Owner: &gh.User{Login: &owner},
+					}, nil
+				},
+			}
+			var syncer *Syncer
+			var syncItem func() error
+			switch itemType {
+			case "merge request":
+				client.getPullRequestFn = func(context.Context, string, string, int) (*gh.PullRequest, error) {
+					close(providerStarted)
+					<-continueProvider
+					return buildOpenPR(7, now), nil
+				}
+				syncItem = func() error { return syncer.SyncMR(ctx, "acme", "widget", 7) }
+			case "issue":
+				client.getIssueFn = func(context.Context, string, string, int) (*gh.Issue, error) {
+					close(providerStarted)
+					<-continueProvider
+					return buildOpenIssue(7, now), nil
+				}
+				syncItem = func() error { return syncer.SyncIssue(ctx, "acme", "widget", 7) }
+			}
+			syncer = NewSyncer(
+				map[string]Client{"github.com": client}, database, nil,
+				[]RepoRef{repo}, time.Minute, nil, testBudget(100),
+			)
+
+			syncDone := make(chan error, 1)
+			go func() { syncDone <- syncItem() }()
+			<-providerStarted
+
+			writeAttempted := make(chan struct{})
+			restoreWriteLockHook := database.SetBeforeRepositoryReconciliationWriteLockForTest(
+				func() { close(writeAttempted) },
+			)
+			defer restoreWriteLockHook()
+			replacementDone := make(chan error, 1)
+			go func() {
+				_, replacementErr := database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+					Platform:       "github",
+					PlatformHost:   "github.com",
+					PlatformRepoID: "R_replacement",
+					Owner:          "acme",
+					Name:           "widget",
+					RepoPath:       "acme/widget",
+				})
+				replacementDone <- replacementErr
+			}()
+			<-writeAttempted
+
+			var (
+				replacementErr       error
+				replacementCompleted bool
+			)
+			select {
+			case replacementErr = <-replacementDone:
+				replacementCompleted = true
+			case <-time.After(250 * time.Millisecond):
+			}
+			close(continueProvider)
+			require.NoError(<-syncDone)
+			if !replacementCompleted {
+				replacementErr = <-replacementDone
+			}
+			require.NoError(replacementErr)
+			assert.False(
+				replacementCompleted,
+				"repository replacement must wait for item sync",
+			)
+		})
+	}
 }
 
 func TestDetailDrainRespectsBudget(t *testing.T) {

--- a/internal/github/syncertest/gitlab_sync_test.go
+++ b/internal/github/syncertest/gitlab_sync_test.go
@@ -287,6 +287,12 @@ func TestGitLabArchiveIssueLifecyclePersistsCloseActorInReport(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.EscapedPath() {
+		case "/api/v4/projects/group%2Fproject":
+			_, _ = w.Write([]byte(`{
+				"id": 42, "path": "project",
+				"path_with_namespace": "group/project",
+				"web_url": "https://gitlab.example.com/group/project"
+			}`))
 		case "/api/v4/projects/42/issues/7":
 			_, _ = w.Write([]byte(`{
 				"id": 2001, "iid": 7, "project_id": 42,

--- a/internal/github/syncertest/syncer_test.go
+++ b/internal/github/syncertest/syncer_test.go
@@ -300,12 +300,42 @@ func TestRunOnceSyncesReposInParallel(t *testing.T) {
 		saturated:        make(chan struct{}),
 		saturationTarget: parallelism,
 	}
+	mc.getRepositoryFn = func(
+		_ context.Context, owner, repo string,
+	) (*gh.Repository, error) {
+		var repoIndex int64
+		if _, err := fmt.Sscanf(repo, "r%d", &repoIndex); err != nil {
+			return nil, fmt.Errorf("parse synthetic repository ID: %w", err)
+		}
+		id := repoIndex + 1
+		nodeID := fmt.Sprintf("repo-%d", id)
+		return &gh.Repository{
+			ID:       &id,
+			NodeID:   &nodeID,
+			Name:     &repo,
+			Owner:    &gh.User{Login: &owner},
+			Archived: new(bool),
+		}, nil
+	}
 	repos := make([]ghclient.RepoRef, repoCount)
 	for i := range repos {
+		name := fmt.Sprintf("r%d", i)
+		providerID := fmt.Sprintf("repo-%d", i+1)
+		repoID, err := d.UpsertRepoByProviderID(t.Context(), db.RepoIdentity{
+			Platform:       "github",
+			PlatformHost:   "github.com",
+			PlatformRepoID: providerID,
+			Owner:          "o",
+			Name:           name,
+			RepoPath:       "o/" + name,
+		})
+		require.NoError(err)
 		repos[i] = ghclient.RepoRef{
-			Owner:        "o",
-			Name:         fmt.Sprintf("r%d", i),
-			PlatformHost: "github.com",
+			RepoID:             repoID,
+			Owner:              "o",
+			Name:               name,
+			PlatformHost:       "github.com",
+			PlatformExternalID: providerID,
 		}
 	}
 
@@ -323,7 +353,7 @@ func TestRunOnceSyncesReposInParallel(t *testing.T) {
 
 	select {
 	case <-mc.saturated:
-	case <-time.After(2 * time.Second):
+	case <-time.After(5 * time.Second):
 		require.Failf(
 			"expected worker pool to saturate",
 			"expected %d concurrent syncs, got %d",

--- a/internal/platform/github/adapter.go
+++ b/internal/platform/github/adapter.go
@@ -6,8 +6,9 @@ import (
 )
 
 var (
-	ErrNilPullRequest = errors.New("nil pull request")
-	ErrNilIssue       = errors.New("nil issue")
+	ErrNilPullRequest     = errors.New("nil pull request")
+	ErrNilIssue           = errors.New("nil issue")
+	ErrIssueIsPullRequest = errors.New("issue payload represents a pull request")
 )
 
 type ForcePushEvent struct {

--- a/internal/platform/github/normalize.go
+++ b/internal/platform/github/normalize.go
@@ -98,6 +98,9 @@ func NormalizeIssue(repo platform.RepoRef, ghIssue *gh.Issue) (platform.Issue, e
 	if ghIssue == nil {
 		return platform.Issue{}, ErrNilIssue
 	}
+	if ghIssue.PullRequestLinks != nil {
+		return platform.Issue{}, ErrIssueIsPullRequest
+	}
 
 	var assignees []string
 	for _, a := range ghIssue.Assignees {

--- a/internal/platform/github/normalize_test.go
+++ b/internal/platform/github/normalize_test.go
@@ -128,6 +128,15 @@ func TestNormalizeIssue_ExtractsAssignees(t *testing.T) {
 	require.Equal([]string{"alice", "bob"}, issue.Assignees)
 }
 
+func TestNormalizeIssueRejectsPullRequestPayload(t *testing.T) {
+	require := require.New(t)
+
+	_, err := NormalizeIssue(platform.RepoRef{}, &gh.Issue{
+		PullRequestLinks: &gh.PullRequestLinks{},
+	})
+	require.ErrorIs(err, ErrIssueIsPullRequest)
+}
+
 func TestNormalizeIssue_EmptyAssignees(t *testing.T) {
 	require := require.New(t)
 

--- a/internal/platform/types.go
+++ b/internal/platform/types.go
@@ -235,12 +235,14 @@ type Tag struct {
 }
 
 type NotificationListOptions struct {
-	Since         *time.Time
-	All           bool
-	Participating bool
-	Page          int
-	RepoOwner     string
-	RepoName      string
+	Since           *time.Time
+	All             bool
+	Participating   bool
+	Page            int
+	RepoOwner       string
+	RepoName        string
+	CredentialOwner string
+	CredentialName  string
 }
 
 type NotificationThread struct {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -28443,6 +28443,23 @@ func TestWorkspaceRuntimeSessionTerminalTmuxBackedWebSocketE2E(
 	assert.True(
 		isRuntimeTmuxSessionNameForWorkspace(ws.Id, stored[0].TmuxSession),
 	)
+	tmuxState := func() ([]byte, error) {
+		tmuxArgs := append(
+			slices.Clone(tmuxCommand[1:]),
+			"display-message", "-p", "-t", stored[0].TmuxSession,
+			"#{session_attached}:#{pane_dead}:#{pane_dead_status}",
+		)
+		return procutil.Command(tmuxCommand[0], tmuxArgs...).CombinedOutput()
+	}
+	var readyState []byte
+	var readyErr error
+	require.Eventuallyf(func() bool {
+		readyState, readyErr = tmuxState()
+		return readyErr == nil && strings.HasPrefix(string(readyState), "1:0:")
+	}, 5*time.Second, 10*time.Millisecond,
+		"runtime tmux client did not attach: state=%q err=%v",
+		readyState, readyErr,
+	)
 
 	ts := httptest.NewServer(srv)
 	t.Cleanup(ts.Close)
@@ -28454,29 +28471,55 @@ func TestWorkspaceRuntimeSessionTerminalTmuxBackedWebSocketE2E(
 	require.NoError(err)
 	defer conn.Close(websocket.StatusNormalClosure, "done")
 
-	writeResize := func() error {
-		t.Helper()
-		resize, err := json.Marshal(map[string]any{
-			"type": "resize",
-			"cols": 177,
-			"rows": 41,
-		})
-		require.NoError(err)
-		return conn.Write(ctx, websocket.MessageText, resize)
+	refresh, err := json.Marshal(map[string]any{
+		"type": "refresh",
+		"cols": 177,
+		"rows": 41,
+	})
+	require.NoError(err)
+	writeRefresh := func(writeCtx context.Context) error {
+		return conn.Write(writeCtx, websocket.MessageText, refresh)
 	}
-	probeSize := func() error {
-		if err := writeResize(); err != nil {
+	probeSize := func(writeCtx context.Context) error {
+		if err := writeRefresh(writeCtx); err != nil {
 			return err
 		}
-		return conn.Write(ctx, websocket.MessageBinary, []byte("probe\n"))
+		return conn.Write(writeCtx, websocket.MessageBinary, []byte("probe\n"))
 	}
-	require.NoError(probeSize())
+	probeCtx, stopProbes := context.WithCancel(ctx)
+	probeDone := make(chan struct{})
+	probeErr := make(chan error, 1)
+	go func() {
+		defer close(probeDone)
+		ticker := time.NewTicker(250 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			if err := probeSize(probeCtx); err != nil {
+				select {
+				case probeErr <- err:
+				default:
+				}
+				return
+			}
+			select {
+			case <-probeCtx.Done():
+				return
+			case <-ticker.C:
+			}
+		}
+	}()
+	defer func() {
+		stopProbes()
+		<-probeDone
+	}()
 	readCtx, cancel := context.WithTimeout(ctx, 8*time.Second)
 	defer cancel()
 	var got strings.Builder
+	var terminalReadErr error
 	for {
 		typ, data, readErr := conn.Read(readCtx)
 		if readErr != nil {
+			terminalReadErr = readErr
 			break
 		}
 		if typ != websocket.MessageBinary {
@@ -28489,11 +28532,26 @@ func TestWorkspaceRuntimeSessionTerminalTmuxBackedWebSocketE2E(
 		if strings.Contains(got.String(), "size:40:177:probe") {
 			return
 		}
-		if err := probeSize(); err != nil {
-			break
-		}
 	}
-	require.Contains(got.String(), "size:40:177:probe")
+	var terminalWriteErr error
+	select {
+	case terminalWriteErr = <-probeErr:
+	default:
+	}
+	finalTmuxState, tmuxErr := tmuxState()
+	if !strings.Contains(got.String(), "size:40:177:probe") {
+		terminalOutput := got.String()
+		if len(terminalOutput) > 4096 {
+			terminalOutput = terminalOutput[len(terminalOutput)-4096:]
+		}
+		require.FailNowf(
+			"terminal output did not contain resized probe",
+			"terminal output: %q; read ended: %v; probe write: %v; "+
+				"sessions: %#v; tmux state: %q (%v)",
+			terminalOutput, terminalReadErr, terminalWriteErr,
+			srv.runtime.ListSessions(ws.Id), finalTmuxState, tmuxErr,
+		)
+	}
 }
 
 func createReadyWorkspace(
@@ -29007,6 +29065,52 @@ func TestWorkspaceManualRefreshDiscoversAndSyncsAssociatedPR(t *testing.T) {
 	require.NotNil(pr)
 	assert.Equal(prTitleFromDetail, pr.Title)
 	assert.Equal(headSHA, pr.PlatformHeadSHA)
+}
+
+func TestWorkspaceManualRefreshRejectsRetiredRepositoryIncarnation(t *testing.T) {
+	t.Parallel()
+	acquireRootWorkspaceGitSlot(t)
+
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	fixture := setupWorkspaceServerFixtureWithMockHostAndOptions(
+		t, nil, &mockGH{}, "github.com",
+		ServerOptions{
+			PtyOwnerInProcess:                  true,
+			DisableWorkspaceBackgroundMonitors: true,
+		},
+	)
+	ws := createReadyWorkspace(t, ctx, fixture.client)
+	stored, err := fixture.database.GetWorkspace(ctx, ws.Id)
+	require.NoError(err)
+	require.NotNil(stored)
+	require.NotNil(stored.RepoID)
+	oldRepoID := *stored.RepoID
+
+	replacementID, err := fixture.database.UpsertRepoByProviderID(
+		ctx,
+		db.RepoIdentity{
+			Platform:       "github",
+			PlatformHost:   "github.com",
+			PlatformRepoID: "repo-replacement",
+			Owner:          "acme",
+			Name:           "widget",
+			RepoPath:       "acme/widget",
+		},
+	)
+	require.NoError(err)
+	require.NotEqual(oldRepoID, replacementID)
+
+	rr := doJSON(
+		t, fixture.server, http.MethodPost,
+		"/api/v1/workspaces/"+ws.Id+"/refresh", nil,
+	)
+	require.Equal(http.StatusConflict, rr.Code, rr.Body.String())
+	var problem rawProblemDetail
+	require.NoError(json.NewDecoder(rr.Body).Decode(&problem))
+	assert.Equal("conflict", problem.Code)
+	assert.Contains(problem.Detail, "repository incarnation is retired")
 }
 
 func TestKataWorkspaceManualRefreshDiscoversAndSyncsAssociatedPR(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -1719,6 +1719,101 @@ func TestAPIMergePRStoresUTCTimestamps(t *testing.T) {
 	assertTimePtrEqualsUTC(t, pr.ClosedAt, handlerNow)
 }
 
+func TestAPIMergePRHoldsRepositoryLeaseThroughProviderMutation(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	mergeStarted := make(chan struct{})
+	allowMerge := make(chan struct{})
+	mock := &mockGH{
+		mergePullRequestFn: func(
+			context.Context, string, string, int, string, string, string,
+		) (*gh.PullRequestMergeResult, error) {
+			close(mergeStarted)
+			<-allowMerge
+			return &gh.PullRequestMergeResult{
+				Merged: new(true),
+				SHA:    new("merged-sha"),
+			}, nil
+		},
+	}
+	srv, database := setupTestServerWithMock(t, mock)
+	expectedHeadSHA := "reviewed-sha"
+	seedPR(t, database, "acme", "widget", 1, withSeedPRHeadSHA(expectedHeadSHA))
+	oldRepoID, err := database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repository-old",
+		Owner:          "acme",
+		Name:           "widget",
+		RepoPath:       "acme/widget",
+	})
+	require.NoError(err)
+	client := setupTestClient(t, srv)
+
+	mergeDone := make(chan error, 1)
+	go func() {
+		resp, err := client.HTTP.MergePullWithResponse(
+			ctx, "gh", "acme", "widget", 1,
+			generated.MergePRInputBody{
+				Method:          "squash",
+				ExpectedHeadSha: &expectedHeadSHA,
+			},
+		)
+		if err == nil && resp.StatusCode() != http.StatusOK {
+			err = fmt.Errorf("merge status %d: %s", resp.StatusCode(), resp.Body)
+		}
+		mergeDone <- err
+	}()
+	<-mergeStarted
+
+	replacementStarted := make(chan struct{})
+	restore := database.SetBeforeRepositoryReconciliationWriteLockForTest(func() {
+		select {
+		case <-replacementStarted:
+		default:
+			close(replacementStarted)
+		}
+	})
+	t.Cleanup(restore)
+	replacementDone := make(chan error, 1)
+	go func() {
+		_, err := database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+			Platform:       "github",
+			PlatformHost:   "github.com",
+			PlatformRepoID: "repository-replacement",
+			Owner:          "acme",
+			Name:           "widget",
+			RepoPath:       "acme/widget",
+		})
+		replacementDone <- err
+	}()
+	<-replacementStarted
+
+	var earlyReplacementErr error
+	replacementCompletedEarly := false
+	select {
+	case earlyReplacementErr = <-replacementDone:
+		replacementCompletedEarly = true
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(allowMerge)
+	require.NoError(<-mergeDone)
+	if !replacementCompletedEarly {
+		require.NoError(<-replacementDone)
+	}
+	require.False(
+		replacementCompletedEarly,
+		"repository replacement completed during provider mutation: %v",
+		earlyReplacementErr,
+	)
+
+	oldRepo, err := database.GetRepoByID(ctx, oldRepoID)
+	require.NoError(err)
+	require.NotNil(oldRepo)
+	require.NotNil(oldRepo.RetiredAt)
+}
+
 func TestAPIClientConstruction(t *testing.T) {
 	srv, _ := setupTestServer(t)
 	client := setupTestClient(t, srv)
@@ -4614,6 +4709,15 @@ func TestAPIGitLabSyncReadsTokenFileAfterRotation(t *testing.T) {
 		tokens = append(tokens, r.Header.Get("Private-Token"))
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.EscapedPath() {
+		case "/api/v4/projects/group%2Fproject":
+			_, _ = fmt.Fprint(w, `{
+				"id": 42,
+				"path": "project",
+				"path_with_namespace": "group/project",
+				"web_url": "https://gitlab.example.com/group/project",
+				"http_url_to_repo": "https://gitlab.example.com/group/project.git",
+				"default_branch": "main"
+			}`)
 		case "/api/v4/projects/42/merge_requests/7":
 			_, _ = fmt.Fprint(w, `{
 				"id": 7001,
@@ -6111,7 +6215,18 @@ func TestAPIListRepoSummariesIncludesSyncedReleaseTimeline(t *testing.T) {
 	runGit(t, work, "push", "--tags", "origin", "main")
 
 	clones := gitclone.New(filepath.Join(dir, "clones"), nil)
-	clonePath, err := clones.ClonePath("github", "github.com", "acme", "widgets")
+	repoID, err := database.UpsertRepo(ctx, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repo-acme-widgets",
+		Owner:          "acme",
+		Name:           "widgets",
+		RepoPath:       "acme/widgets",
+	})
+	require.NoError(err)
+	clonePath, err := clones.RepositoryClone(
+		repoID, "github", "github.com", "acme", "widgets",
+	).ClonePath()
 	require.NoError(err)
 	require.NoError(os.MkdirAll(filepath.Dir(clonePath), 0o755))
 	runGit(t, dir, "clone", "--bare", remote, clonePath)
@@ -6443,6 +6558,103 @@ func TestAPICreateIssue(t *testing.T) {
 	require.Len(issue.Labels, 1)
 	assert.Equal("enhancement", issue.Labels[0].Name)
 	assert.Equal("a2eeef", issue.Labels[0].Color)
+}
+
+func TestAPICreateIssueHoldsRepositoryLeaseThroughProviderMutation(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	createStarted := make(chan struct{})
+	allowCreate := make(chan struct{})
+	mock := &mockGH{
+		createIssueFn: func(
+			context.Context, string, string, string, string,
+		) (*gh.Issue, error) {
+			close(createStarted)
+			<-allowCreate
+			number := 27
+			title := "New issue"
+			state := "open"
+			now := gh.Timestamp{Time: time.Now().UTC()}
+			return &gh.Issue{
+				Number:    &number,
+				Title:     &title,
+				State:     &state,
+				CreatedAt: &now,
+				UpdatedAt: &now,
+			}, nil
+		},
+	}
+	srv, database := setupTestServerWithMock(t, mock)
+	oldRepoID, err := database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repository-old",
+		Owner:          "acme",
+		Name:           "widget",
+		RepoPath:       "acme/widget",
+	})
+	require.NoError(err)
+	client := setupTestClient(t, srv)
+
+	createDone := make(chan error, 1)
+	go func() {
+		resp, err := client.HTTP.CreateIssueWithResponse(
+			ctx, "gh", "acme", "widget",
+			generated.CreateIssueJSONRequestBody{Title: "New issue"},
+		)
+		if err == nil && resp.StatusCode() != http.StatusCreated {
+			err = fmt.Errorf("create issue status %d: %s", resp.StatusCode(), resp.Body)
+		}
+		createDone <- err
+	}()
+	<-createStarted
+
+	replacementStarted := make(chan struct{})
+	restore := database.SetBeforeRepositoryReconciliationWriteLockForTest(func() {
+		select {
+		case <-replacementStarted:
+		default:
+			close(replacementStarted)
+		}
+	})
+	t.Cleanup(restore)
+	replacementDone := make(chan error, 1)
+	go func() {
+		_, err := database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+			Platform:       "github",
+			PlatformHost:   "github.com",
+			PlatformRepoID: "repository-replacement",
+			Owner:          "acme",
+			Name:           "widget",
+			RepoPath:       "acme/widget",
+		})
+		replacementDone <- err
+	}()
+	<-replacementStarted
+
+	var earlyReplacementErr error
+	replacementCompletedEarly := false
+	select {
+	case earlyReplacementErr = <-replacementDone:
+		replacementCompletedEarly = true
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(allowCreate)
+	require.NoError(<-createDone)
+	if !replacementCompletedEarly {
+		require.NoError(<-replacementDone)
+	}
+	require.False(
+		replacementCompletedEarly,
+		"repository replacement completed during provider mutation: %v",
+		earlyReplacementErr,
+	)
+
+	oldRepo, err := database.GetRepoByID(ctx, oldRepoID)
+	require.NoError(err)
+	require.NotNil(oldRepo)
+	require.NotNil(oldRepo.RetiredAt)
 }
 
 func TestAPICreateIssueRejectsNilProviderPayload(t *testing.T) {
@@ -7939,7 +8151,7 @@ func TestAPIGitLabDisabledIssueCooldownPersistsThroughHTTPAndSQLite(t *testing.T
 	providerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.EscapedPath() {
-		case "/api/v4/projects/42":
+		case "/api/v4/projects/42", "/api/v4/projects/group%2Fproject":
 			metadataCalls.Add(1)
 			_, _ = io.WriteString(w, `{
 				"id":42,"path":"project","path_with_namespace":"group/project",
@@ -8882,8 +9094,7 @@ func TestAPISyncPRBypassesPullRequestETagForCIRefresh(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(repo)
 	require.NoError(database.UpsertHTTPEtag(
-		t.Context(), "github", "github.com", "acme", "widget",
-		"pull_request", 1, `"etag-v1"`,
+		t.Context(), repo.ID, "pull_request", 1, `"etag-v1"`,
 	))
 
 	rr := doJSON(t, srv, http.MethodPost, "/api/v1/pulls/gh/acme/widget/1/sync", nil)
@@ -10865,8 +11076,7 @@ func TestE2ELargeRepoSkipsGraphQLAndUsesConditionalPRDetail(t *testing.T) {
 		require.NoError(err)
 	}
 	require.NoError(database.UpsertHTTPEtag(
-		ctx, "github", "github.com", "acme", "widget",
-		"pull_request", 1, `"etag-v1"`,
+		ctx, repoID, "pull_request", 1, `"etag-v1"`,
 	))
 
 	syncer := ghclient.NewSyncer(
@@ -10910,8 +11120,7 @@ func TestE2ELargeRepoSkipsGraphQLAndUsesConditionalPRDetail(t *testing.T) {
 	assert.Equal("detail comment", detailResp.Events[0].Body)
 
 	etag, err := database.GetHTTPEtag(
-		ctx, "github", "github.com", "acme", "widget",
-		"pull_request", 1,
+		ctx, repoID, "pull_request", 1,
 	)
 	require.NoError(err)
 	assert.Equal(`"etag-v2"`, etag)
@@ -11026,8 +11235,7 @@ func TestE2ELargeRepoSkipsGraphQLAndUsesConditionalIssueDetail(t *testing.T) {
 		require.NoError(err)
 	}
 	require.NoError(database.UpsertHTTPEtag(
-		ctx, "github", "github.com", "acme", "widget",
-		"issue", 1, `"issue-etag-v1"`,
+		ctx, repoID, "issue", 1, `"issue-etag-v1"`,
 	))
 
 	syncer := ghclient.NewSyncer(
@@ -11071,8 +11279,7 @@ func TestE2ELargeRepoSkipsGraphQLAndUsesConditionalIssueDetail(t *testing.T) {
 	assert.Equal("issue detail comment", detailResp.Events[0].Body)
 
 	etag, err := database.GetHTTPEtag(
-		ctx, "github", "github.com", "acme", "widget",
-		"issue", 1,
+		ctx, repoID, "issue", 1,
 	)
 	require.NoError(err)
 	assert.Equal(`"issue-etag-v2"`, etag)
@@ -13367,6 +13574,107 @@ func TestAPIClosePR422AlreadyClosed(t *testing.T) {
 
 	pr, _ := database.GetMergeRequest(t.Context(), "github", "github.com", "acme", "widget", 1)
 	require.Equal(db.MergeRequestStateClosed, pr.State)
+}
+
+func TestAPIClosePR422RecoveryDoesNotNestRepositoryLease(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	state := "closed"
+	var database *db.DB
+	writeLockAttempted := make(chan struct{})
+	reconciliationDone := make(chan error, 1)
+	var startReconciliation sync.Once
+	mock := &mockGH{
+		editPullRequestFn: func(
+			context.Context,
+			string,
+			string,
+			int,
+			ghclient.EditPullRequestOpts,
+		) (*gh.PullRequest, error) {
+			return nil, make422Error()
+		},
+		getPullRequestFn: func(
+			_ context.Context, _, _ string, _ int,
+		) (*gh.PullRequest, error) {
+			startReconciliation.Do(func() {
+				go func() {
+					_, err := database.UpsertRepoByProviderID(
+						ctx,
+						db.RepoIdentity{
+							Platform:       "github",
+							PlatformHost:   "github.com",
+							PlatformRepoID: "repo-stable",
+							Owner:          "acme-tools",
+							Name:           "renamed-widget",
+							RepoPath:       "acme-tools/renamed-widget",
+						},
+					)
+					reconciliationDone <- err
+				}()
+			})
+			select {
+			case <-writeLockAttempted:
+			case <-time.After(2 * time.Second):
+				require.Fail("repository reconciliation did not queue")
+			}
+			now := gh.Timestamp{Time: time.Now().UTC()}
+			return &gh.PullRequest{
+				ID: new(int64(1000)), Number: new(1), State: &state,
+				Title: new("PR"), HTMLURL: new("https://example.com/pull/1"),
+				User:      &gh.User{Login: new("user-a")},
+				Head:      &gh.PullRequestBranch{Ref: new("feature")},
+				Base:      &gh.PullRequestBranch{Ref: new("main")},
+				CreatedAt: &now, UpdatedAt: &now, ClosedAt: &now,
+			}, nil
+		},
+	}
+	srv, database := setupTestServerWithMock(t, mock)
+	seedPR(t, database, "acme", "widget", 1)
+	_, err := database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repo-stable",
+		Owner:          "acme",
+		Name:           "widget",
+		RepoPath:       "acme/widget",
+	})
+	require.NoError(err)
+	database.SetBeforeRepositoryReconciliationWriteLockForTest(
+		func() { close(writeLockAttempted) },
+	)
+
+	type result struct {
+		status int
+		err    error
+	}
+	responseDone := make(chan result, 1)
+	client := setupTestClient(t, srv)
+	go func() {
+		response, requestErr := client.HTTP.SetPrGithubStateWithResponse(
+			ctx, "gh", "acme", "widget", 1,
+			generated.SetPrGithubStateJSONRequestBody{State: "closed"},
+		)
+		status := 0
+		if response != nil {
+			status = response.StatusCode()
+		}
+		responseDone <- result{status: status, err: requestErr}
+	}()
+
+	select {
+	case got := <-responseDone:
+		require.NoError(got.err)
+		require.Equal(http.StatusOK, got.status)
+	case <-time.After(2 * time.Second):
+		require.Fail("422 recovery deadlocked behind its nested read lease")
+	}
+	select {
+	case err := <-reconciliationDone:
+		require.NoError(err)
+	case <-time.After(2 * time.Second):
+		require.Fail("repository reconciliation did not resume")
+	}
 }
 
 func TestAPIMarkPRDraftPersistsDraftFlag(t *testing.T) {
@@ -20427,7 +20735,16 @@ func TestAPIGetFilesAndDiffMarkGeneratedFilesE2E(t *testing.T) {
 	database := dbtest.Open(t)
 
 	bareDir := filepath.Join(dir, "clones")
-	bare := filepath.Join(bareDir, "github.com", "acme", "widget.git")
+	repoID, err := database.UpsertRepo(
+		ctx,
+		db.GitHubRepoIdentity("github.com", "acme", "widget"),
+	)
+	require.NoError(err)
+	clones := gitclone.New(bareDir, nil)
+	bare, err := clones.RepositoryClone(
+		repoID, "github", "github.com", "acme", "widget",
+	).ClonePath()
+	require.NoError(err)
 	require.NoError(os.MkdirAll(filepath.Dir(bare), 0o755))
 
 	work := filepath.Join(dir, "work")
@@ -20468,7 +20785,6 @@ func TestAPIGetFilesAndDiffMarkGeneratedFilesE2E(t *testing.T) {
 	runGit(t, work, "push", "origin", "feature")
 	headSHA := testGitSHA(t, work, "HEAD")
 
-	clones := gitclone.New(bareDir, nil)
 	syncer := ghclient.NewSyncer(
 		map[string]ghclient.Client{"github.com": &mockGH{}},
 		database, nil, defaultTestRepos, time.Minute, nil, nil,
@@ -20479,13 +20795,6 @@ func TestAPIGetFilesAndDiffMarkGeneratedFilesE2E(t *testing.T) {
 	client := setupTestClient(t, srv)
 
 	seedPR(t, database, "acme", "widget", 1)
-	repoID, err := database.UpsertRepo(ctx, db.RepoIdentity{
-		Platform:     "github",
-		PlatformHost: "github.com",
-		Owner:        "acme",
-		Name:         "widget",
-	})
-	require.NoError(err)
 	require.NoError(database.UpdateDiffSHAs(ctx, repoID, 1, headSHA, mergeBase, mergeBase))
 
 	filesResp, err := client.HTTP.GetPullFilesWithResponse(
@@ -20546,7 +20855,16 @@ func TestAPILocalReadEndpointsServeDuringTokenRotationE2E(t *testing.T) {
 	database := dbtest.Open(t)
 
 	bareDir := filepath.Join(dir, "clones")
-	bare := filepath.Join(bareDir, "github.com", "acme", "widget.git")
+	repoID, err := database.UpsertRepo(
+		ctx,
+		db.GitHubRepoIdentity("github.com", "acme", "widget"),
+	)
+	require.NoError(err)
+	clones := gitclone.New(bareDir, nil)
+	bare, err := clones.RepositoryClone(
+		repoID, "github", "github.com", "acme", "widget",
+	).ClonePath()
+	require.NoError(err)
 	require.NoError(os.MkdirAll(filepath.Dir(bare), 0o755))
 
 	work := filepath.Join(dir, "work")
@@ -20581,7 +20899,7 @@ func TestAPILocalReadEndpointsServeDuringTokenRotationE2E(t *testing.T) {
 		}, tokenauth.Options{}),
 	}
 
-	clones := gitclone.New(bareDir, gitclone.HostSources{"github.com": source})
+	clones = gitclone.New(bareDir, gitclone.HostSources{"github.com": source})
 	syncer := ghclient.NewSyncer(
 		map[string]ghclient.Client{"github.com": &mockGH{}},
 		database, nil, defaultTestRepos, time.Minute, nil, nil,
@@ -20592,8 +20910,6 @@ func TestAPILocalReadEndpointsServeDuringTokenRotationE2E(t *testing.T) {
 	client := setupTestClient(t, srv)
 
 	seedPR(t, database, "acme", "widget", 1)
-	repoID, err := database.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"))
-	require.NoError(err)
 	require.NoError(database.UpdateDiffSHAs(ctx, repoID, 1, headSHA, mergeBase, mergeBase))
 
 	// Rotation in progress: the token file is briefly empty. Any attempt to
@@ -21513,7 +21829,16 @@ func setupTestServerWithClonesAndServer(t *testing.T) (
 
 	bareDir := filepath.Join(dir, "clones")
 	require.NoError(t, os.MkdirAll(bareDir, 0o755))
-	bare := filepath.Join(bareDir, "github.com", "acme", "widget.git")
+	repoID, err := database.UpsertRepo(
+		t.Context(),
+		db.GitHubRepoIdentity("github.com", "acme", "widget"),
+	)
+	require.NoError(t, err)
+	clones := gitclone.New(bareDir, nil)
+	bare, err := clones.RepositoryClone(
+		repoID, "github", "github.com", "acme", "widget",
+	).ClonePath()
+	require.NoError(t, err)
 
 	tmpWork := filepath.Join(dir, "work")
 	runGit(t, dir, "init", "--bare", "--initial-branch=main", bare)
@@ -21545,7 +21870,6 @@ func setupTestServerWithClonesAndServer(t *testing.T) (
 		sha = testGitSHA(t, tmpWork, sha+"^1")
 	}
 
-	clones := gitclone.New(bareDir, nil)
 	mock := &mockGH{}
 	repos := []ghclient.RepoRef{{Platform: "github", Owner: "acme", Name: "widget", PlatformHost: "github.com"}}
 	syncer := ghclient.NewSyncer(map[string]ghclient.Client{"github.com": mock}, database, nil, repos, time.Minute, nil, nil)
@@ -21554,8 +21878,6 @@ func setupTestServerWithClonesAndServer(t *testing.T) (
 
 	seedPR(t, database, "acme", "widget", 1)
 	ctx := t.Context()
-	repoID, err := database.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "acme", "widget"))
-	require.NoError(t, err)
 	require.NoError(t, database.UpdateDiffSHAs(ctx, repoID, 1, headSHA, mergeBase, mergeBase))
 
 	client = setupTestClient(t, srv)
@@ -21645,11 +21967,135 @@ func TestAPIGetRepoCommitDiff(t *testing.T) {
 	assert.Equal("content 3", body.Files[0].Hunks[0].Lines[0].Content)
 }
 
+func TestAPIGetRepoCommitDiffHoldsRepositoryLeaseThroughCloneRead(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	_, database, _, _, commitSHAs, srv := setupTestServerWithClonesAndServer(t)
+	oldRepo, err := database.GetRepoByIdentity(
+		ctx,
+		db.GitHubRepoIdentity("github.com", "acme", "widget"),
+	)
+	require.NoError(err)
+	require.NotNil(oldRepo)
+	_, err = database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repository-old",
+		Owner:          "acme",
+		Name:           "widget",
+		RepoPath:       "acme/widget",
+	})
+	require.NoError(err)
+
+	readStarted := make(chan struct{})
+	allowRead := make(chan struct{})
+	var blockRead sync.Once
+	restoreReadHook := srv.clones.SetBeforeLocalReadForTest(func() {
+		blockRead.Do(func() {
+			close(readStarted)
+			<-allowRead
+		})
+	})
+	t.Cleanup(restoreReadHook)
+
+	responseDone := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		req := httptest.NewRequest(
+			http.MethodGet,
+			"/api/v1/repo/gh/acme/widget/commits/"+commitSHAs[2]+"/diff",
+			nil,
+		)
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+		responseDone <- rr
+	}()
+	<-readStarted
+
+	replacementStarted := make(chan struct{})
+	restoreWriteHook := database.SetBeforeRepositoryReconciliationWriteLockForTest(func() {
+		select {
+		case <-replacementStarted:
+		default:
+			close(replacementStarted)
+		}
+	})
+	t.Cleanup(restoreWriteHook)
+	replacementDone := make(chan error, 1)
+	go func() {
+		_, err := database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+			Platform:       "github",
+			PlatformHost:   "github.com",
+			PlatformRepoID: "repository-replacement",
+			Owner:          "acme",
+			Name:           "widget",
+			RepoPath:       "acme/widget",
+		})
+		replacementDone <- err
+	}()
+	<-replacementStarted
+
+	var earlyReplacementErr error
+	replacementCompletedEarly := false
+	select {
+	case earlyReplacementErr = <-replacementDone:
+		replacementCompletedEarly = true
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(allowRead)
+	rr := <-responseDone
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+	if !replacementCompletedEarly {
+		require.NoError(<-replacementDone)
+	}
+	require.False(
+		replacementCompletedEarly,
+		"repository replacement completed while the diff still read the old clone: %v",
+		earlyReplacementErr,
+	)
+}
+
+func TestAPIGetRepoCommitDiffDoesNotReuseRetiredIncarnationClone(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	_, database, _, _, commitSHAs, srv := setupTestServerWithClonesAndServer(t)
+	_, err := database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "repository-old", Owner: "acme", Name: "widget",
+		RepoPath: "acme/widget",
+	})
+	require.NoError(err)
+	_, err = database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "repository-replacement", Owner: "acme", Name: "widget",
+		RepoPath: "acme/widget",
+	})
+	require.NoError(err)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v1/repo/gh/acme/widget/commits/"+commitSHAs[2]+"/diff",
+		nil,
+	)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	require.NotEqual(http.StatusOK, rr.Code, rr.Body.String())
+}
+
 func TestAPIGetRepoCommitDiffRejectsOptionLikeSHA(t *testing.T) {
 	require := require.New(t)
 
-	_, _, _, _, _, srv := setupTestServerWithClonesAndServer(t)
-	clonePath, err := srv.clones.ClonePath("github", "github.com", "acme", "widget")
+	_, database, _, _, _, srv := setupTestServerWithClonesAndServer(t)
+	repo, err := database.GetRepoByIdentity(
+		t.Context(),
+		db.GitHubRepoIdentity("github.com", "acme", "widget"),
+	)
+	require.NoError(err)
+	require.NotNil(repo)
+	clonePath, err := srv.clones.RepositoryClone(
+		repo.ID, "github", "github.com", "acme", "widget",
+	).ClonePath()
 	require.NoError(err)
 	configPath := filepath.Join(clonePath, "config")
 	before, err := os.ReadFile(configPath)
@@ -21912,7 +22358,17 @@ func TestAPIGetDiff_RootCommit(t *testing.T) {
 
 	bareDir := filepath.Join(dir, "clones")
 	require.NoError(os.MkdirAll(bareDir, 0o755))
-	bare := filepath.Join(bareDir, "github.com", "acme", "rootrepo.git")
+	ctx := t.Context()
+	repoID, err := database.UpsertRepo(
+		ctx,
+		db.GitHubRepoIdentity("github.com", "acme", "rootrepo"),
+	)
+	require.NoError(err)
+	clones := gitclone.New(bareDir, nil)
+	bare, err := clones.RepositoryClone(
+		repoID, "github", "github.com", "acme", "rootrepo",
+	).ClonePath()
+	require.NoError(err)
 	tmpWork := filepath.Join(dir, "work")
 	runGit(t, dir, "init", "--bare", "--initial-branch=main", bare)
 	runGit(t, dir, "clone", bare, tmpWork)
@@ -21930,7 +22386,6 @@ func TestAPIGetDiff_RootCommit(t *testing.T) {
 	runGit(t, tmpWork, "push", "origin", "main")
 	headSHA := testGitSHA(t, tmpWork, "HEAD")
 
-	clones := gitclone.New(bareDir, nil)
 	mock := &mockGH{}
 	repos := []ghclient.RepoRef{{Owner: "acme", Name: "rootrepo", PlatformHost: "github.com"}}
 	syncer := ghclient.NewSyncer(map[string]ghclient.Client{"github.com": mock}, database, nil, repos, time.Minute, nil, nil)
@@ -21938,9 +22393,6 @@ func TestAPIGetDiff_RootCommit(t *testing.T) {
 	srv := New(database, syncer, nil, "/", nil, ServerOptions{Clones: clones})
 
 	seedPR(t, database, "acme", "rootrepo", 1)
-	ctx := t.Context()
-	repoID, err := database.UpsertRepo(ctx, db.GitHubRepoIdentity("github.com", "acme", "rootrepo"))
-	require.NoError(err)
 	require.NoError(database.UpdateDiffSHAs(ctx, repoID, 1, headSHA, "4b825dc642cb6eb9a060e54bf8d69288fbee4904", "4b825dc642cb6eb9a060e54bf8d69288fbee4904"))
 
 	client := setupTestClient(t, srv)
@@ -23674,13 +24126,26 @@ func setupWorkspaceServerFixtureWithMockHostAndOptions(
 
 	bareDir := filepath.Join(dir, "clones")
 	require.NoError(t, os.MkdirAll(bareDir, 0o755))
-	bare := filepath.Join(
-		bareDir, platformHost, "acme", "widget.git",
+	repoID, err := database.UpsertRepo(
+		t.Context(),
+		db.RepoIdentity{
+			Platform:       "github",
+			PlatformHost:   platformHost,
+			PlatformRepoID: "repo-acme-widget",
+			Owner:          "acme",
+			Name:           "widget",
+			RepoPath:       "acme/widget",
+		},
 	)
+	require.NoError(t, err)
+	clones := gitclone.New(bareDir, nil)
+	bare, err := clones.RepositoryClone(
+		repoID, "github", platformHost, "acme", "widget",
+	).ClonePath()
+	require.NoError(t, err)
 	runGit(t, dir, "clone", "--bare", remote, bare)
 	runGit(t, bare, "remote", "set-url", "origin", gitLocalRemoteURL(remote))
 
-	clones := gitclone.New(bareDir, nil)
 	worktreeDir := filepath.Join(dir, "worktrees")
 	repos := []ghclient.RepoRef{
 		{Owner: "acme", Name: "widget", PlatformHost: platformHost},
@@ -29160,9 +29625,22 @@ func TestWorkspaceCreateReusesExistingWorktreeThroughAPI(t *testing.T) {
 	}}}
 	fixture := setupWorkspaceServerFixture(t, cfg)
 	ctx := t.Context()
+	fixture.server.syncer.RunOnce(ctx)
+	seedPROnHost(
+		t, fixture.database,
+		platformHost, "acme", "widget", prNumber,
+		withSeedPRHeadRepoCloneURL("https://"+platformHost+"/acme/widget.git"),
+	)
+	activeRepo, err := fixture.database.GetRepoByIdentity(
+		ctx,
+		db.GitHubRepoIdentity(platformHost, "acme", "widget"),
+	)
+	require.NoError(err)
+	require.NotNil(activeRepo)
 	existingBranch := syntheticPRWorktreeBranchForTest(prNumber)
 	worktreePath := filepath.Join(
 		fixture.worktrees, "github", platformHost, "acme", "widget",
+		fmt.Sprintf("repo-%d", activeRepo.ID),
 		fmt.Sprintf("pr-%d", prNumber),
 	)
 	runGit(
@@ -29170,12 +29648,6 @@ func TestWorkspaceCreateReusesExistingWorktreeThroughAPI(t *testing.T) {
 		"worktree", "add", worktreePath, "-b", existingBranch, "main",
 	)
 	wantSHA := testGitSHA(t, worktreePath, "HEAD")
-	seedPROnHost(
-		t, fixture.database,
-		platformHost, "acme", "widget", prNumber,
-		withSeedPRHeadRepoCloneURL("https://"+platformHost+"/acme/widget.git"),
-	)
-
 	createResp, err := fixture.client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{
@@ -29222,8 +29694,21 @@ func TestWorkspaceRetryReusesExistingLocalHeadBranchThroughAPI(t *testing.T) {
 	}}}
 	fixture := setupWorkspaceServerFixture(t, cfg)
 	ctx := t.Context()
+	fixture.server.syncer.RunOnce(ctx)
+	seedPROnHost(
+		t, fixture.database,
+		platformHost, "acme", "widget", prNumber,
+		withSeedPRHeadRepoCloneURL("https://"+platformHost+"/acme/widget.git"),
+	)
+	activeRepo, err := fixture.database.GetRepoByIdentity(
+		ctx,
+		db.GitHubRepoIdentity(platformHost, "acme", "widget"),
+	)
+	require.NoError(err)
+	require.NotNil(activeRepo)
 	worktreePath := filepath.Join(
 		fixture.worktrees, "github", platformHost, "acme", "widget",
+		fmt.Sprintf("repo-%d", activeRepo.ID),
 		fmt.Sprintf("pr-%d", prNumber),
 	)
 	runGit(
@@ -29232,12 +29717,6 @@ func TestWorkspaceRetryReusesExistingLocalHeadBranchThroughAPI(t *testing.T) {
 		"-b", "feature", "refs/remotes/origin/feature",
 	)
 	wantSHA := testGitSHA(t, worktreePath, "HEAD")
-	seedPROnHost(
-		t, fixture.database,
-		platformHost, "acme", "widget", prNumber,
-		withSeedPRHeadRepoCloneURL("https://"+platformHost+"/acme/widget.git"),
-	)
-
 	createResp, err := fixture.client.HTTP.CreateWorkspaceWithResponse(
 		ctx,
 		generated.CreateWorkspaceInputBody{

--- a/internal/server/apitest/archive_test.go
+++ b/internal/server/apitest/archive_test.go
@@ -120,6 +120,8 @@ func TestAPIArchiveStartPauseStatusAndReport(t *testing.T) {
 	assert.Equal(int64(1), reportResponse.JSON200.Totals.MergeRequestsMerged)
 	require.NotNil(reportResponse.JSON200.Repositories)
 	require.Len(*reportResponse.JSON200.Repositories, 1)
+	require.NotNil((*reportResponse.JSON200.Repositories)[0].Repository.RepositoryId)
+	assert.Equal(repo.ID, *(*reportResponse.JSON200.Repositories)[0].Repository.RepositoryId)
 	assert.Equal(generated.ArchiveReportCoverageResponseIssuesSupported,
 		(*reportResponse.JSON200.Repositories)[0].Coverage.Issues)
 	assert.Equal(generated.ArchiveReportCoverageResponseMergeRequestsSupported,
@@ -153,6 +155,18 @@ func TestAPIArchiveStartPauseStatusAndReport(t *testing.T) {
 	require.NotNil(statusResponse.JSON200)
 	require.Len(*statusResponse.JSON200, 1)
 	assert.Equal("github", (*statusResponse.JSON200)[0].Repository.Provider)
+	require.NotNil((*statusResponse.JSON200)[0].Repository.RepositoryId)
+	assert.Equal(repo.ID, *(*statusResponse.JSON200)[0].Repository.RepositoryId)
+
+	repositoryIDs := []int64{repo.ID}
+	statusByID, err := client.HTTP.ListArchiveStatusWithResponse(
+		t.Context(), &generated.ListArchiveStatusParams{RepoId: &repositoryIDs},
+	)
+	require.NoError(err)
+	require.NotNil(statusByID.JSON200)
+	require.Len(*statusByID.JSON200, 1)
+	require.NotNil((*statusByID.JSON200)[0].Repository.RepositoryId)
+	assert.Equal(repo.ID, *(*statusByID.JSON200)[0].Repository.RepositoryId)
 
 	resetAt := time.Now().UTC().Add(time.Hour).Truncate(time.Second)
 	_, err = database.WriteDB().ExecContext(t.Context(), `

--- a/internal/server/archive_routes.go
+++ b/internal/server/archive_routes.go
@@ -17,6 +17,7 @@ import (
 )
 
 type archiveRepositoryRef struct {
+	RepositoryID int64  `json:"repository_id,omitempty" required:"false"`
 	Provider     string `json:"provider"`
 	PlatformHost string `json:"platform_host"`
 	Owner        string `json:"owner"`
@@ -32,14 +33,16 @@ type archiveMutationBody struct {
 type archiveMutationInput struct{ Body archiveMutationBody }
 
 type archiveStatusInput struct {
-	Repositories []string `query:"repo,explode" doc:"Repeated provider|platform_host/repo_path filters."`
+	Repositories  []string `query:"repo,explode" doc:"Repeated provider|platform_host/repo_path filters."`
+	RepositoryIDs []int64  `query:"repo_id,explode" doc:"Repeated immutable repository incarnation IDs."`
 }
 
 type archiveReportInput struct {
-	Start        string   `query:"start" required:"true" doc:"Inclusive UTC RFC3339 boundary."`
-	End          string   `query:"end" required:"true" doc:"Exclusive UTC RFC3339 boundary."`
-	Repositories []string `query:"repo,explode" doc:"Repeated provider|platform_host/repo_path filters."`
-	Verbose      bool     `query:"verbose"`
+	Start         string   `query:"start" required:"true" doc:"Inclusive UTC RFC3339 boundary."`
+	End           string   `query:"end" required:"true" doc:"Exclusive UTC RFC3339 boundary."`
+	Repositories  []string `query:"repo,explode" doc:"Repeated provider|platform_host/repo_path filters."`
+	RepositoryIDs []int64  `query:"repo_id,explode" doc:"Repeated immutable repository incarnation IDs."`
+	Verbose       bool     `query:"verbose"`
 }
 
 type archiveCoverageResponse struct {
@@ -240,11 +243,22 @@ func (s *Server) listArchiveStatus(
 	if s.archive == nil {
 		return nil, httpapi.ServiceUnavailable("archive service not configured")
 	}
+	if len(input.Repositories) > 0 && len(input.RepositoryIDs) > 0 {
+		return nil, httpapi.Validation("query.repo_id", "repo and repo_id are mutually exclusive")
+	}
+	if err := validateArchiveRepositoryIDs(input.RepositoryIDs); err != nil {
+		return nil, err
+	}
 	refs, err := archiveQueryRefs(input.Repositories)
 	if err != nil {
 		return nil, err
 	}
-	statuses, err := s.archive.Status(ctx, refs)
+	var statuses []archive.Status
+	if len(input.RepositoryIDs) > 0 {
+		statuses, err = s.archive.StatusByRepositoryIDs(ctx, input.RepositoryIDs)
+	} else {
+		statuses, err = s.archive.Status(ctx, refs)
+	}
 	if err != nil {
 		return nil, archiveOperationProblem(err)
 	}
@@ -269,17 +283,33 @@ func (s *Server) getArchiveReport(
 	if !start.Before(end) {
 		return nil, httpapi.Validation("query.end", "end must be after start")
 	}
+	if len(input.Repositories) > 0 && len(input.RepositoryIDs) > 0 {
+		return nil, httpapi.Validation("query.repo_id", "repo and repo_id are mutually exclusive")
+	}
+	if err := validateArchiveRepositoryIDs(input.RepositoryIDs); err != nil {
+		return nil, err
+	}
 	refs, err := archiveQueryRefs(input.Repositories)
 	if err != nil {
 		return nil, err
 	}
 	model, err := s.archive.Report(ctx, archive.ReportOptions{
-		Start: start, End: end, Repositories: refs, Detailed: input.Verbose,
+		Start: start, End: end, Repositories: refs,
+		RepositoryIDs: input.RepositoryIDs, Detailed: input.Verbose,
 	})
 	if err != nil {
 		return nil, archiveOperationProblem(err)
 	}
 	return &archiveReportOutput{Body: archiveReportModelResponse(model)}, nil
+}
+
+func validateArchiveRepositoryIDs(repoIDs []int64) error {
+	for _, repoID := range repoIDs {
+		if repoID <= 0 {
+			return httpapi.Validation("query.repo_id", "repository IDs must be positive")
+		}
+	}
+	return nil
 }
 
 func archiveMutationRefs(body archiveMutationBody) ([]platform.RepoRef, bool, error) {
@@ -349,7 +379,8 @@ func archiveStatusResponses(statuses []archive.Status) []archiveStatusResponse {
 		counts := status.Progress.Counts
 		responses[i] = archiveStatusResponse{
 			Repository: archiveRepositoryRef{
-				Provider: string(status.Repo.Platform), PlatformHost: status.Repo.Host,
+				RepositoryID: status.RepoID,
+				Provider:     string(status.Repo.Platform), PlatformHost: status.Repo.Host,
 				Owner: status.Repo.Owner, Name: status.Repo.Name, RepoPath: status.Repo.RepoPath,
 			},
 			CollectionMode: status.State.CollectionMode, OperatorState: status.State.OperatorState,
@@ -458,7 +489,8 @@ func archiveReportModelResponse(model report.Model) archiveReportResponse {
 
 func archiveReportRepository(ref report.RepositoryRef) archiveRepositoryRef {
 	return archiveRepositoryRef{
-		Provider: ref.Provider, PlatformHost: ref.PlatformHost, Owner: ref.Owner,
+		RepositoryID: ref.RepositoryID,
+		Provider:     ref.Provider, PlatformHost: ref.PlatformHost, Owner: ref.Owner,
 		Name: ref.Name, RepoPath: ref.RepoPath,
 	}
 }

--- a/internal/server/config_reload.go
+++ b/internal/server/config_reload.go
@@ -655,8 +655,12 @@ func (s *Server) resolveReposForReload(
 	if s.syncer == nil {
 		return nil, nil
 	}
+	type resolvedCandidate struct {
+		index  int
+		isGlob bool
+	}
 	resolved := make([]ghclient.RepoRef, 0, len(repos))
-	seen := make(map[string]struct{}, len(repos))
+	seen := make(map[string]resolvedCandidate, len(repos))
 	skipped := make([]string, 0)
 
 	for _, raw := range repos {
@@ -691,10 +695,22 @@ func (s *Server) resolveReposForReload(
 				strings.ToLower(canonicalReloadHost(repo)) + "\x00" +
 				strings.ToLower(repo.Owner) + "\x00" +
 				strings.ToLower(repo.Name)
-			if _, ok := seen[key]; ok {
+			if current, ok := seen[key]; ok {
+				merged, mergedIsGlob := ghclient.MergeConfiguredRepoCandidate(
+					resolved[current.index],
+					current.isGlob,
+					repo,
+					raw.HasNameGlob(),
+				)
+				resolved[current.index] = merged
+				current.isGlob = mergedIsGlob
+				seen[key] = current
 				continue
 			}
-			seen[key] = struct{}{}
+			seen[key] = resolvedCandidate{
+				index:  len(resolved),
+				isGlob: raw.HasNameGlob(),
+			}
 			resolved = append(resolved, repo)
 		}
 	}

--- a/internal/server/config_reload_test.go
+++ b/internal/server/config_reload_test.go
@@ -1794,11 +1794,17 @@ func TestResolveReposForReloadPrefersRenamedExactRouteOverGlob(t *testing.T) {
 
 			require.Empty(skipped)
 			require.Equal([]ghclient.RepoRef{{
-				Platform:           platform.KindGitHub,
-				Owner:              "acme-tools",
-				Name:               "current-widget",
-				CredentialOwner:    "acme",
-				CredentialName:     "legacy-widget",
+				Platform:        platform.KindGitHub,
+				Owner:           "acme-tools",
+				Name:            "current-widget",
+				CredentialOwner: "acme",
+				CredentialName:  "legacy-widget",
+				ConfiguredRoutes: []ghclient.ConfiguredRepoRoute{{
+					Owner: "acme", Name: "legacy-widget", RepoPath: "acme/legacy-widget",
+				}},
+				ConfiguredGlobs: []ghclient.ConfiguredRepoGlob{{
+					Owner: "acme-tools", Name: "*",
+				}},
 				PlatformHost:       "github.com",
 				RepoPath:           "acme-tools/current-widget",
 				PlatformExternalID: "R_42",

--- a/internal/server/config_reload_test.go
+++ b/internal/server/config_reload_test.go
@@ -1749,6 +1749,64 @@ func TestConfigReload_NewRepoEntersSyncerTrackedSet(t *testing.T) {
 	assert.Equal("globex/engine", archiveLifecycle.ensured[1].RepoPath)
 }
 
+func TestResolveReposForReloadPrefersRenamedExactRouteOverGlob(t *testing.T) {
+	canonical := &gh.Repository{
+		Name:     new("current-widget"),
+		NodeID:   new("R_42"),
+		Owner:    &gh.User{Login: new("acme-tools")},
+		FullName: new("acme-tools/current-widget"),
+		Archived: new(false),
+	}
+	mock := &mockGH{
+		getRepositoryFn: func(
+			context.Context, string, string,
+		) (*gh.Repository, error) {
+			return canonical, nil
+		},
+		listReposByOwnerFn: func(
+			context.Context, string,
+		) ([]*gh.Repository, error) {
+			return []*gh.Repository{canonical}, nil
+		},
+	}
+	srv, _, _ := setupTestServerWithConfigContent(
+		t, validReloadConfig, mock,
+	)
+	exact := config.Repo{
+		Owner:    "acme",
+		Name:     "legacy-widget",
+		TokenEnv: "EXACT_ROUTE_TOKEN",
+	}
+	glob := config.Repo{Owner: "acme-tools", Name: "*"}
+
+	for _, test := range []struct {
+		name  string
+		repos []config.Repo
+	}{
+		{name: "exact first", repos: []config.Repo{exact, glob}},
+		{name: "glob first", repos: []config.Repo{glob, exact}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			require := require.New(t)
+			resolved, skipped := srv.resolveReposForReload(
+				t.Context(), test.repos, nil,
+			)
+
+			require.Empty(skipped)
+			require.Equal([]ghclient.RepoRef{{
+				Platform:           platform.KindGitHub,
+				Owner:              "acme-tools",
+				Name:               "current-widget",
+				CredentialOwner:    "acme",
+				CredentialName:     "legacy-widget",
+				PlatformHost:       "github.com",
+				RepoPath:           "acme-tools/current-widget",
+				PlatformExternalID: "R_42",
+			}}, resolved)
+		})
+	}
+}
+
 func TestConfigReload_GlobFailureKeepsPreviouslyTrackedMatches(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/server/e2etest/fixtures_test.go
+++ b/internal/server/e2etest/fixtures_test.go
@@ -142,6 +142,8 @@ type mockGH struct {
 	getRateLimitSnapshotFn     func(context.Context) (*ghclient.RateLimitSnapshot, error)
 	getRepositoryFn            func(context.Context, string, string) (*gh.Repository, error)
 	getPullRequestFn           func(context.Context, string, string, int) (*gh.PullRequest, error)
+	getIssueFn                 func(context.Context, string, string, int) (*gh.Issue, error)
+	editIssueFn                func(context.Context, string, string, int, string) (*gh.Issue, error)
 	listOpenPullRequestsFn     func(context.Context, string, string) ([]*gh.PullRequest, error)
 	listReposByOwnerFn         func(context.Context, string) ([]*gh.Repository, error)
 	mergePullRequestFn         func(context.Context, string, string, int, string, string, string, string) (*gh.PullRequestMergeResult, error)
@@ -188,7 +190,15 @@ func (m *mockGH) ListTags(context.Context, string, string, int) ([]*gh.Repositor
 func (m *mockGH) ListOpenIssues(context.Context, string, string) ([]*gh.Issue, error) {
 	return nil, nil
 }
-func (m *mockGH) GetIssue(context.Context, string, string, int) (*gh.Issue, error) {
+func (m *mockGH) GetIssue(
+	ctx context.Context,
+	owner string,
+	repo string,
+	number int,
+) (*gh.Issue, error) {
+	if m.getIssueFn != nil {
+		return m.getIssueFn(ctx, owner, repo, number)
+	}
 	return nil, nil
 }
 func (m *mockGH) CreateIssue(context.Context, string, string, string, string) (*gh.Issue, error) {
@@ -319,7 +329,13 @@ func (m *mockGH) MergePullRequest(ctx context.Context, owner, repo string, numbe
 func (m *mockGH) EditPullRequest(context.Context, string, string, int, ghclient.EditPullRequestOpts) (*gh.PullRequest, error) {
 	return nil, nil
 }
-func (m *mockGH) EditIssue(context.Context, string, string, int, string) (*gh.Issue, error) {
+
+func (m *mockGH) EditIssue(
+	ctx context.Context, owner, repo string, number int, state string,
+) (*gh.Issue, error) {
+	if m.editIssueFn != nil {
+		return m.editIssueFn(ctx, owner, repo, number, state)
+	}
 	return nil, nil
 }
 func (m *mockGH) EditIssueContent(context.Context, string, string, int, *string, *string) (*gh.Issue, error) {

--- a/internal/server/e2etest/github_app_split_auth_test.go
+++ b/internal/server/e2etest/github_app_split_auth_test.go
@@ -70,6 +70,7 @@ func TestGitHubAppSplitAuthE2E(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = fmt.Fprint(w, `{
 				"id": 4242001,
+				"node_id": "4242001",
 				"name": "kenn-forge",
 				"full_name": "kenn-io/kenn-forge",
 				"owner": {"login": "kenn-io"},
@@ -674,6 +675,7 @@ func TestGitHubAppNoUserCredentialGatesWritesE2E(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = fmt.Fprint(w, `{
 				"id": 4242001,
+				"node_id": "4242001",
 				"name": "kenn-forge",
 				"full_name": "kenn-io/kenn-forge",
 				"owner": {"login": "kenn-io"},

--- a/internal/server/e2etest/github_issue_payload_boundary_test.go
+++ b/internal/server/e2etest/github_issue_payload_boundary_test.go
@@ -1,0 +1,124 @@
+package e2etest
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	gh "github.com/google/go-github/v89/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/apiclient"
+	ghclient "go.kenn.io/forge/internal/github"
+	"go.kenn.io/forge/internal/server"
+	"go.kenn.io/forge/internal/testutil/dbtest"
+)
+
+type pullRequestIssueMockGH struct {
+	*mockGH
+	issues []*gh.Issue
+}
+
+func (m *pullRequestIssueMockGH) ListOpenIssues(
+	context.Context, string, string,
+) ([]*gh.Issue, error) {
+	return m.issues, nil
+}
+
+func TestPullRequestShapedIssueIsNotPersistedOrExposed(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+
+	issueNumber := 41
+	issueID := int64(4100)
+	issueTitle := "issue returned by issues endpoint"
+	pullNumber := 42
+	pullID := int64(4200)
+	pullTitle := "pull request returned by issues endpoint"
+	state := "open"
+	issueURL := "https://github.com/acme/widget/issues/41"
+	pullURL := "https://github.com/acme/widget/pull/42"
+	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	mock := &pullRequestIssueMockGH{
+		mockGH: &mockGH{},
+		issues: []*gh.Issue{
+			{
+				ID:        &issueID,
+				Number:    &issueNumber,
+				Title:     &issueTitle,
+				State:     &state,
+				HTMLURL:   &issueURL,
+				CreatedAt: &gh.Timestamp{Time: now},
+				UpdatedAt: &gh.Timestamp{Time: now},
+			},
+			{
+				ID:               &pullID,
+				Number:           &pullNumber,
+				Title:            &pullTitle,
+				State:            &state,
+				HTMLURL:          &pullURL,
+				CreatedAt:        &gh.Timestamp{Time: now},
+				UpdatedAt:        &gh.Timestamp{Time: now},
+				PullRequestLinks: &gh.PullRequestLinks{},
+			},
+		},
+	}
+	database := dbtest.Open(t)
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": mock},
+		database, nil, []ghclient.RepoRef{{
+			Owner: "acme", Name: "widget", PlatformHost: "github.com",
+		}}, time.Minute, nil, nil,
+	)
+	t.Cleanup(syncer.Stop)
+	srv := server.New(database, syncer, nil, "/", nil, server.ServerOptions{
+		HostCheckAllowLoopbackAnyPort: true,
+	})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	client, err := apiclient.NewWithHTTPClient(ts.URL, ts.Client())
+	require.NoError(err)
+
+	syncer.RunOnce(ctx)
+
+	repos, err := database.ListRepos(ctx)
+	require.NoError(err)
+	require.Len(repos, 1)
+	storedIssue, err := database.GetIssueByRepoIDAndNumber(
+		ctx, repos[0].ID, issueNumber,
+	)
+	require.NoError(err)
+	require.NotNil(storedIssue)
+	assert.Equal(issueTitle, storedIssue.Title)
+
+	storedPull, err := database.GetIssueByRepoIDAndNumber(
+		ctx, repos[0].ID, pullNumber,
+	)
+	require.NoError(err)
+	assert.Nil(storedPull)
+
+	issueResponse, err := client.HTTP.GetIssueWithResponse(
+		ctx, "gh", "acme", "widget", int64(issueNumber),
+	)
+	require.NoError(err)
+	require.Equal(
+		http.StatusOK,
+		issueResponse.StatusCode(),
+		string(issueResponse.Body),
+	)
+	require.NotNil(issueResponse.JSON200)
+	assert.Equal(issueTitle, issueResponse.JSON200.Issue.Title)
+
+	pullResponse, err := client.HTTP.GetIssueWithResponse(
+		ctx, "gh", "acme", "widget", int64(pullNumber),
+	)
+	require.NoError(err)
+	assert.Equal(
+		http.StatusNotFound,
+		pullResponse.StatusCode(),
+		string(pullResponse.Body),
+	)
+}

--- a/internal/server/e2etest/gitlab_mutations_test.go
+++ b/internal/server/e2etest/gitlab_mutations_test.go
@@ -426,6 +426,18 @@ func assertNoGitLabRepoPathLookup(t *testing.T, recorder *gitlabAPIRecorder) {
 	assert.False(t, lookedUp, "GitLab mutations must use the stored project id without path lookup")
 }
 
+func assertGitLabRepoIdentityRevalidated(t *testing.T, recorder *gitlabAPIRecorder) {
+	t.Helper()
+	assert.True(
+		t,
+		recorder.findEventually(
+			http.MethodGet,
+			"/api/v4/projects/acme%2Fwidget",
+		),
+		"post-mutation sync must revalidate the configured repository route",
+	)
+}
+
 func TestGitLabMutationCommentPostAndEdit(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -650,7 +662,7 @@ func TestGitLabMutationApprove(t *testing.T) {
 	note, ok := recorder.find(http.MethodPost, "/api/v4/projects/4242/merge_requests/7/notes")
 	require.True(ok, "approval body was not posted as a note")
 	assert.Contains(note.Body, `"body":"ship it"`)
-	assertNoGitLabRepoPathLookup(t, recorder)
+	assertGitLabRepoIdentityRevalidated(t, recorder)
 
 	mr, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
 	require.NoError(err)

--- a/internal/server/e2etest/gitlab_sync_pin_test.go
+++ b/internal/server/e2etest/gitlab_sync_pin_test.go
@@ -9,6 +9,7 @@ package e2etest
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -85,12 +86,12 @@ func TestGitLabNormalSyncEnablesHeadBoundMutations(t *testing.T) {
 		path := r.URL.EscapedPath()
 		switch {
 		case path == "/api/v4/projects/acme%2Fwidget" && r.Method == http.MethodGet:
-			writeGitLabJSON(w, `{
+			writeGitLabJSON(w, fmt.Sprintf(`{
 				"id": 4242, "path": "widget", "path_with_namespace": "acme/widget",
 				"web_url": "https://gitlab.com/acme/widget",
-				"http_url_to_repo": "https://gitlab.com/acme/widget.git",
+				"http_url_to_repo": %q,
 				"default_branch": "main"
-			}`)
+			}`, cloneURL))
 		case path == "/api/v4/projects/4242/merge_requests" && r.Method == http.MethodGet:
 			writeGitLabJSON(w, `[`+mrJSON+`]`)
 		case path == "/api/v4/projects/4242/merge_requests/7" && r.Method == http.MethodGet:

--- a/internal/server/e2etest/repository_incarnation_test.go
+++ b/internal/server/e2etest/repository_incarnation_test.go
@@ -1,0 +1,667 @@
+package e2etest
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	gh "github.com/google/go-github/v89/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/apiclient"
+	"go.kenn.io/forge/internal/apiclient/generated"
+	"go.kenn.io/forge/internal/db"
+	ghclient "go.kenn.io/forge/internal/github"
+	"go.kenn.io/forge/internal/server"
+	"go.kenn.io/forge/internal/testutil/dbtest"
+)
+
+type repositoryIncarnationMockGH struct {
+	*mockGH
+	openIssues       []*gh.Issue
+	listOpenIssuesFn func(context.Context, string, string) ([]*gh.Issue, error)
+}
+
+func (m *repositoryIncarnationMockGH) ListOpenIssues(
+	ctx context.Context, owner, name string,
+) ([]*gh.Issue, error) {
+	if m.listOpenIssuesFn != nil {
+		return m.listOpenIssuesFn(ctx, owner, name)
+	}
+	return m.openIssues, nil
+}
+
+func TestRepositoryReplacementRetiresOldIncarnationAndHidesItsItems(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+
+	providerID := "repo-old"
+	mock := &repositoryIncarnationMockGH{
+		mockGH: &mockGH{
+			getRepositoryFn: func(
+				context.Context, string, string,
+			) (*gh.Repository, error) {
+				id := int64(1)
+				owner := "acme"
+				name := "widget"
+				return &gh.Repository{
+					ID:       &id,
+					NodeID:   &providerID,
+					Owner:    &gh.User{Login: &owner},
+					Name:     &name,
+					Archived: new(bool),
+				}, nil
+			},
+		},
+	}
+	database := dbtest.Open(t)
+	repos := []ghclient.RepoRef{{
+		Owner: "acme", Name: "widget", PlatformHost: "github.com",
+		PlatformExternalID: "repo-old",
+	}}
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": mock},
+		database, nil, repos, time.Minute, nil,
+		map[string]*ghclient.SyncBudget{
+			"github.com": ghclient.NewSyncBudget(1000),
+		},
+	)
+	t.Cleanup(syncer.Stop)
+	srv := server.New(database, syncer, nil, "/", nil, server.ServerOptions{
+		HostCheckAllowLoopbackAnyPort: true,
+	})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	client, err := apiclient.NewWithHTTPClient(ts.URL, ts.Client())
+	require.NoError(err)
+
+	syncer.RunOnce(ctx)
+	stored, err := database.GetRepoByIdentity(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		Owner: "acme", Name: "widget",
+	})
+	require.NoError(err)
+	require.NotNil(stored)
+	oldRepoID := stored.ID
+
+	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	mrID, err := database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID: oldRepoID, PlatformID: 6006, Number: 6,
+		URL:   "https://github.com/acme/widget/pull/6",
+		Title: "old stack member", Author: "octocat",
+		State:     db.MergeRequestStateOpen,
+		CreatedAt: now, UpdatedAt: now, LastActivityAt: now,
+	})
+	require.NoError(err)
+	stackID, err := database.UpsertStack(ctx, oldRepoID, 6, "old stack")
+	require.NoError(err)
+	require.NoError(database.ReplaceStackMembers(ctx, stackID, []db.StackMember{{
+		StackID: stackID, MergeRequestID: mrID, Position: 1,
+	}}))
+
+	issueID := int64(7007)
+	issueNumber := 7
+	oldTitle := "issue from original repository"
+	newTitle := "issue from replacement repository"
+	state := "open"
+	body := ""
+	url := "https://github.com/acme/widget/issues/7"
+	_, err = database.UpsertIssue(ctx, &db.Issue{
+		RepoID: stored.ID, PlatformID: issueID, Number: issueNumber,
+		URL: url, Title: oldTitle, State: state,
+		CreatedAt: now, UpdatedAt: now, LastActivityAt: now,
+	})
+	require.NoError(err)
+	replacementIssue := &gh.Issue{
+		ID:        &issueID,
+		Number:    &issueNumber,
+		Title:     &newTitle,
+		State:     &state,
+		Body:      &body,
+		HTMLURL:   &url,
+		CreatedAt: &gh.Timestamp{Time: now},
+		UpdatedAt: &gh.Timestamp{Time: now.Add(time.Hour)},
+	}
+	mock.openIssues = []*gh.Issue{replacementIssue}
+	mock.getIssueFn = func(
+		context.Context, string, string, int,
+	) (*gh.Issue, error) {
+		return replacementIssue, nil
+	}
+
+	providerID = "repo-new"
+	manualSync, err := client.HTTP.SyncIssueWithResponse(
+		ctx, "gh", "acme", "widget", int64(issueNumber),
+		generated.RequestEditorFn(func(_ context.Context, req *http.Request) error {
+			req.Header.Set("Content-Type", "application/json")
+			return nil
+		}),
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, manualSync.StatusCode(), string(manualSync.Body))
+	require.NotNil(manualSync.JSON200)
+	assert.Equal(newTitle, manualSync.JSON200.Issue.Title)
+
+	active, err := database.GetRepoByIdentity(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		Owner: "acme", Name: "widget",
+	})
+	require.NoError(err)
+	require.NotNil(active)
+	assert.NotEqual(oldRepoID, active.ID)
+	assert.Equal("repo-new", active.PlatformRepoID)
+
+	retired, err := database.GetRepoByID(ctx, oldRepoID)
+	require.NoError(err)
+	require.NotNil(retired)
+	require.NotNil(retired.RetiredAt)
+	require.NotNil(retired.RetiredReplacementID)
+	assert.Equal(active.ID, *retired.RetiredReplacementID)
+
+	historicalIssue, err := database.GetIssueByRepoIDAndNumber(
+		ctx, oldRepoID, issueNumber,
+	)
+	require.NoError(err)
+	require.NotNil(historicalIssue)
+	assert.Equal(oldTitle, historicalIssue.Title)
+
+	activeIssue, err := database.GetIssueByRepoIDAndNumber(
+		ctx, active.ID, issueNumber,
+	)
+	require.NoError(err)
+	require.NotNil(activeIssue)
+	assert.Equal(newTitle, activeIssue.Title)
+
+	response, err := client.HTTP.ListReposWithResponse(ctx)
+	require.NoError(err)
+	require.Equal(http.StatusOK, response.StatusCode(), string(response.Body))
+	require.NotNil(response.JSON200)
+	require.Len(*response.JSON200, 1)
+	repo := (*response.JSON200)[0]
+	assert.Equal("acme", repo.Owner)
+	assert.Equal("widget", repo.Name)
+	assert.Empty(repo.LastSyncError)
+
+	issueResponse, err := client.HTTP.GetIssueWithResponse(
+		ctx,
+		"gh",
+		"acme",
+		"widget",
+		int64(issueNumber),
+	)
+	require.NoError(err)
+	require.Equal(
+		http.StatusOK,
+		issueResponse.StatusCode(),
+		string(issueResponse.Body),
+	)
+	require.NotNil(issueResponse.JSON200)
+	assert.Equal(newTitle, issueResponse.JSON200.Issue.Title)
+
+	stackResponse, err := client.HTTP.ListStacksWithResponse(ctx, nil)
+	require.NoError(err)
+	require.Equal(
+		http.StatusOK,
+		stackResponse.StatusCode(),
+		string(stackResponse.Body),
+	)
+	require.NotNil(stackResponse.JSON200)
+	assert.Empty(*stackResponse.JSON200)
+
+	prNumber := 8
+	prID := int64(8008)
+	prTitle := "pull request from newest repository incarnation"
+	prURL := "https://github.com/acme/widget/pull/8"
+	headRef, baseRef := "feature", "main"
+	headSHA, baseSHA := "head-sha", "base-sha"
+	mock.getPullRequestFn = func(
+		context.Context, string, string, int,
+	) (*gh.PullRequest, error) {
+		return &gh.PullRequest{
+			ID: &prID, Number: &prNumber, Title: &prTitle, HTMLURL: &prURL,
+			State: &state, Body: &body, User: &gh.User{Login: new("author")},
+			CreatedAt: &gh.Timestamp{Time: now}, UpdatedAt: &gh.Timestamp{Time: now},
+			Head: &gh.PullRequestBranch{Ref: &headRef, SHA: &headSHA},
+			Base: &gh.PullRequestBranch{Ref: &baseRef, SHA: &baseSHA},
+		}, nil
+	}
+	providerID = "repo-newest"
+	manualPRSync, err := client.HTTP.SyncPullWithResponse(
+		ctx, "gh", "acme", "widget", int64(prNumber),
+		generated.RequestEditorFn(func(_ context.Context, req *http.Request) error {
+			req.Header.Set("Content-Type", "application/json")
+			return nil
+		}),
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, manualPRSync.StatusCode(), string(manualPRSync.Body))
+	require.NotNil(manualPRSync.JSON200)
+	assert.Equal(prTitle, manualPRSync.JSON200.MergeRequest.Title)
+	newest, err := database.GetRepoByIdentity(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com", Owner: "acme", Name: "widget",
+	})
+	require.NoError(err)
+	require.NotNil(newest)
+	assert.NotEqual(active.ID, newest.ID)
+	assert.Equal("repo-newest", newest.PlatformRepoID)
+}
+
+func TestRepositoryRenamePreservesIncarnationHistoryAndConfiguredLookup(
+	t *testing.T,
+) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	const providerID = "repo-stable"
+	currentOwner := "acme"
+	currentName := "widget"
+	var repositoryLookups []string
+	var issueLookups []string
+	var issueMutations []string
+	issueID := int64(7007)
+	issueNumber := 7
+	issueTitle := "preserved issue"
+	issueState := "open"
+	issueBody := ""
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	issueForRoute := func(owner string, name string) *gh.Issue {
+		url := "https://github.com/" + owner + "/" + name + "/issues/7"
+		return &gh.Issue{
+			ID:        &issueID,
+			Number:    &issueNumber,
+			Title:     &issueTitle,
+			State:     &issueState,
+			Body:      &issueBody,
+			HTMLURL:   &url,
+			CreatedAt: &gh.Timestamp{Time: now},
+			UpdatedAt: &gh.Timestamp{Time: now},
+		}
+	}
+
+	mock := &repositoryIncarnationMockGH{}
+	mock.mockGH = &mockGH{
+		getRepositoryFn: func(
+			_ context.Context,
+			owner string,
+			name string,
+		) (*gh.Repository, error) {
+			repositoryLookups = append(
+				repositoryLookups,
+				owner+"/"+name,
+			)
+			resolvedOwner := currentOwner
+			resolvedName := currentName
+			return &gh.Repository{
+				ID:       new(int64(1)),
+				NodeID:   new(providerID),
+				Owner:    &gh.User{Login: &resolvedOwner},
+				Name:     &resolvedName,
+				Archived: new(bool),
+			}, nil
+		},
+		getIssueFn: func(
+			_ context.Context,
+			owner string,
+			name string,
+			_ int,
+		) (*gh.Issue, error) {
+			return issueForRoute(owner, name), nil
+		},
+		editIssueFn: func(
+			_ context.Context,
+			owner string,
+			name string,
+			_ int,
+			state string,
+		) (*gh.Issue, error) {
+			issueMutations = append(
+				issueMutations,
+				owner+"/"+name+":"+state,
+			)
+			return issueForRoute(owner, name), nil
+		},
+	}
+	mock.listOpenIssuesFn = func(
+		_ context.Context,
+		owner string,
+		name string,
+	) ([]*gh.Issue, error) {
+		issueLookups = append(issueLookups, owner+"/"+name)
+		return []*gh.Issue{issueForRoute(owner, name)}, nil
+	}
+
+	database := dbtest.Open(t)
+	router, err := ghclient.NewHostRouter("github.com", &ghclient.Route{
+		Key: ghclient.RouteKey{
+			Host: "github.com", Owner: "acme", Name: "widget",
+		},
+		Client: mock,
+		ReadIdentity: ghclient.IdentityKey{
+			Host: "github.com", Principal: "user:1",
+		},
+		WriteIdentity: ghclient.IdentityKey{
+			Host: "github.com", Principal: "user:1",
+		},
+	})
+	require.NoError(err)
+	routed, err := ghclient.NewRoutedClient(router)
+	require.NoError(err)
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": routed},
+		database,
+		nil,
+		[]ghclient.RepoRef{{
+			Platform:           "github",
+			PlatformHost:       "github.com",
+			Owner:              "acme",
+			Name:               "widget",
+			RepoPath:           "acme/widget",
+			PlatformExternalID: providerID,
+		}},
+		time.Minute,
+		nil,
+		map[string]*ghclient.SyncBudget{
+			"github.com": ghclient.NewSyncBudget(1000),
+		},
+	)
+	syncer.SetGitHubRouters(map[string]*ghclient.HostRouter{
+		"github.com": router,
+	})
+	t.Cleanup(syncer.Stop)
+	srv := server.New(database, syncer, nil, "/", nil, server.ServerOptions{
+		HostCheckAllowLoopbackAnyPort: true,
+	})
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(
+			context.Background(),
+			5*time.Second,
+		)
+		defer cancel()
+		require.NoError(srv.Shutdown(shutdownCtx))
+	})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	client, err := apiclient.NewWithHTTPClient(ts.URL, ts.Client())
+	require.NoError(err)
+
+	triggerSync := func() {
+		t.Helper()
+		done := make(chan struct{}, 1)
+		syncer.SetOnStatusChange(func(status *ghclient.SyncStatus) {
+			if !status.Running {
+				select {
+				case done <- struct{}{}:
+				default:
+				}
+			}
+		})
+		response, syncErr := client.HTTP.TriggerSyncWithResponse(
+			ctx,
+			nil,
+			func(
+				_ context.Context,
+				request *http.Request,
+			) error {
+				request.Header.Set("Content-Type", "application/json")
+				return nil
+			},
+		)
+		require.NoError(syncErr)
+		require.Equal(
+			http.StatusAccepted,
+			response.StatusCode(),
+			string(response.Body),
+		)
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			require.Fail("repository sync did not complete")
+		}
+	}
+
+	triggerSync()
+	original, err := database.GetRepoByIdentity(
+		ctx,
+		db.RepoIdentity{
+			Platform: "github", PlatformHost: "github.com",
+			Owner: "acme", Name: "widget",
+		},
+	)
+	require.NoError(err)
+	require.NotNil(original)
+	originalIssue, err := database.GetIssueByRepoIDAndNumber(
+		ctx,
+		original.ID,
+		issueNumber,
+	)
+	require.NoError(err)
+	require.NotNil(originalIssue)
+
+	currentOwner = "acme-tools"
+	currentName = "renamed-widget"
+	triggerSync()
+
+	renamed, err := database.GetRepoByIdentity(
+		ctx,
+		db.RepoIdentity{
+			Platform: "github", PlatformHost: "github.com",
+			Owner: "acme-tools", Name: "renamed-widget",
+		},
+	)
+	require.NoError(err)
+	require.NotNil(renamed)
+	assert.Equal(original.ID, renamed.ID)
+	assert.Equal(providerID, renamed.PlatformRepoID)
+	renamedIssue, err := database.GetIssueByRepoIDAndNumber(
+		ctx,
+		renamed.ID,
+		issueNumber,
+	)
+	require.NoError(err)
+	require.NotNil(renamedIssue)
+	assert.Equal(originalIssue.ID, renamedIssue.ID)
+
+	tracked := syncer.TrackedRepos()
+	require.Len(tracked, 1)
+	assert.Equal("acme-tools", tracked[0].Owner)
+	assert.Equal("renamed-widget", tracked[0].Name)
+	assert.Equal("acme", tracked[0].CredentialOwner)
+	assert.Equal("widget", tracked[0].CredentialName)
+
+	triggerSync()
+	require.Len(repositoryLookups, 3)
+	assert.Equal(
+		[]string{"acme/widget", "acme/widget", "acme/widget"},
+		repositoryLookups,
+	)
+	require.Len(issueLookups, 3)
+	assert.Equal("acme/widget", issueLookups[0])
+	assert.Equal("acme-tools/renamed-widget", issueLookups[1])
+	assert.Equal("acme-tools/renamed-widget", issueLookups[2])
+
+	reposResponse, err := client.HTTP.ListReposWithResponse(ctx)
+	require.NoError(err)
+	require.Equal(
+		http.StatusOK,
+		reposResponse.StatusCode(),
+		string(reposResponse.Body),
+	)
+	require.NotNil(reposResponse.JSON200)
+	require.Len(*reposResponse.JSON200, 1)
+	assert.Equal("acme-tools", (*reposResponse.JSON200)[0].Owner)
+	assert.Equal("renamed-widget", (*reposResponse.JSON200)[0].Name)
+
+	issueResponse, err := client.HTTP.GetIssueWithResponse(
+		ctx,
+		"gh",
+		"acme-tools",
+		"renamed-widget",
+		int64(issueNumber),
+	)
+	require.NoError(err)
+	require.Equal(
+		http.StatusOK,
+		issueResponse.StatusCode(),
+		string(issueResponse.Body),
+	)
+	require.NotNil(issueResponse.JSON200)
+	assert.Equal(issueTitle, issueResponse.JSON200.Issue.Title)
+
+	mutationResponse, err := client.HTTP.SetIssueGithubStateWithResponse(
+		ctx,
+		"gh",
+		"acme-tools",
+		"renamed-widget",
+		int64(issueNumber),
+		generated.SetIssueGithubStateJSONRequestBody{State: "closed"},
+	)
+	require.NoError(err)
+	require.Equal(
+		http.StatusOK,
+		mutationResponse.StatusCode(),
+		string(mutationResponse.Body),
+	)
+	assert.Equal(
+		[]string{"acme-tools/renamed-widget:closed"},
+		issueMutations,
+	)
+}
+
+func TestRepositorySyncDiscardsPublicationSupersededDuringHTTPRun(
+	t *testing.T,
+) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	firstLookupStarted := make(chan struct{})
+	releaseFirstLookup := make(chan struct{})
+	provider := &repositoryIncarnationMockGH{
+		mockGH: &mockGH{
+			getRepositoryFn: func(
+				_ context.Context,
+				owner string,
+				name string,
+			) (*gh.Repository, error) {
+				if owner == "acme" && name == "first" {
+					close(firstLookupStarted)
+					<-releaseFirstLookup
+				}
+				nodeID := "repo-" + name
+				return &gh.Repository{
+					NodeID:   &nodeID,
+					Owner:    &gh.User{Login: &owner},
+					Name:     &name,
+					Archived: new(bool),
+				}, nil
+			},
+		},
+	}
+	database := dbtest.Open(t)
+	first := ghclient.RepoRef{
+		Platform: "github", PlatformHost: "github.com",
+		Owner: "acme", Name: "first", RepoPath: "acme/first",
+	}
+	second := ghclient.RepoRef{
+		Platform: "github", PlatformHost: "github.com",
+		Owner: "acme", Name: "second", RepoPath: "acme/second",
+	}
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": provider},
+		database,
+		nil,
+		[]ghclient.RepoRef{first},
+		time.Minute,
+		nil,
+		map[string]*ghclient.SyncBudget{
+			"github.com": ghclient.NewSyncBudget(1000),
+		},
+	)
+	t.Cleanup(syncer.Stop)
+	srv := server.New(
+		database,
+		syncer,
+		nil,
+		"/",
+		nil,
+		server.ServerOptions{HostCheckAllowLoopbackAnyPort: true},
+	)
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(
+			context.Background(),
+			5*time.Second,
+		)
+		defer cancel()
+		require.NoError(srv.Shutdown(shutdownCtx))
+	})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	client, err := apiclient.NewWithHTTPClient(ts.URL, ts.Client())
+	require.NoError(err)
+
+	triggerSync := func() <-chan struct{} {
+		t.Helper()
+		done := make(chan struct{}, 1)
+		syncer.SetOnStatusChange(func(status *ghclient.SyncStatus) {
+			if !status.Running {
+				select {
+				case done <- struct{}{}:
+				default:
+				}
+			}
+		})
+		response, syncErr := client.HTTP.TriggerSyncWithResponse(
+			ctx,
+			nil,
+			func(
+				_ context.Context,
+				request *http.Request,
+			) error {
+				request.Header.Set("Content-Type", "application/json")
+				return nil
+			},
+		)
+		require.NoError(syncErr)
+		require.Equal(
+			http.StatusAccepted,
+			response.StatusCode(),
+			string(response.Body),
+		)
+		return done
+	}
+
+	firstDone := triggerSync()
+	select {
+	case <-firstLookupStarted:
+	case <-time.After(2 * time.Second):
+		close(releaseFirstLookup)
+		require.Fail("first repository lookup did not start")
+	}
+	require.NoError(syncer.SetReposWithContext(
+		ctx,
+		[]ghclient.RepoRef{second},
+		false,
+	))
+	close(releaseFirstLookup)
+	select {
+	case <-firstDone:
+	case <-time.After(2 * time.Second):
+		require.Fail("superseded sync did not complete")
+	}
+	assert.Equal([]ghclient.RepoRef{second}, syncer.TrackedRepos())
+
+	secondDone := triggerSync()
+	select {
+	case <-secondDone:
+	case <-time.After(2 * time.Second):
+		require.Fail("replacement configured sync did not complete")
+	}
+	repos, err := database.ListRepos(ctx)
+	require.NoError(err)
+	require.Len(repos, 1)
+	assert.Equal("acme", repos[0].Owner)
+	assert.Equal("second", repos[0].Name)
+	assert.Equal("repo-second", repos[0].PlatformRepoID)
+}

--- a/internal/server/e2etest/token_rotation_test.go
+++ b/internal/server/e2etest/token_rotation_test.go
@@ -42,6 +42,13 @@ func TestTokenFileRotationE2EConfigStartupAndHTTPSync(t *testing.T) {
 		tokens = append(tokens, r.Header.Get("Private-Token"))
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.EscapedPath() {
+		case "/api/v4/projects/group%2Fproject":
+			_, _ = fmt.Fprint(w, `{
+				"id": 42,
+				"path": "project",
+				"path_with_namespace": "group/project",
+				"web_url": "https://gitlab.example.com/group/project"
+			}`)
 		case "/api/v4/projects/42/merge_requests/7":
 			_, _ = fmt.Fprint(w, `{
 				"id": 7001,
@@ -184,6 +191,13 @@ func TestInvalidReloadKeepsLiveTokenSourceE2E(t *testing.T) {
 		tokens = append(tokens, r.Header.Get("Private-Token"))
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.EscapedPath() {
+		case "/api/v4/projects/group%2Fproject":
+			_, _ = fmt.Fprint(w, `{
+				"id": 42,
+				"path": "project",
+				"path_with_namespace": "group/project",
+				"web_url": "https://gitlab.example.com/group/project"
+			}`)
 		case "/api/v4/projects/42/merge_requests/7":
 			_, _ = fmt.Fprint(w, `{
 				"id": 7001,

--- a/internal/server/httpapi/repository_resolver.go
+++ b/internal/server/httpapi/repository_resolver.go
@@ -50,6 +50,54 @@ func (r *RepositoryResolver) RequireRouteCapability(
 	return repo, nil
 }
 
+// LeaseRouteCapability resolves an active repository and prevents route
+// reconciliation from replacing it until release. Mutation handlers must hold
+// the returned lease through the provider call and local persistence.
+func (r *RepositoryResolver) LeaseRouteCapability(
+	ctx context.Context,
+	provider, platformHost, owner, name, capability string,
+) (*db.Repo, func(), error) {
+	repo, err := r.LookupRoute(ctx, provider, platformHost, owner, name)
+	if err != nil {
+		return nil, nil, ProviderRouteLookupError(err)
+	}
+	leased, release, err := r.LeaseActiveRepository(ctx, repo.ID)
+	if err != nil {
+		return nil, nil, ProviderRouteLookupError(err)
+	}
+	if leased == nil {
+		return nil, nil, ProviderRouteLookupError(ErrRepoNotFound)
+	}
+	if !CapabilityEnabled(r.Ref(*leased).Capabilities, capability) {
+		release()
+		return nil, nil, UnsupportedCapability(*leased, capability)
+	}
+	return leased, release, nil
+}
+
+// LeaseRouteContext resolves a repository route, revalidates the selected
+// incarnation under the reconciliation read lease, and returns a context that
+// nested repository-aware operations can reuse.
+func (r *RepositoryResolver) LeaseRouteContext(
+	ctx context.Context,
+	provider, platformHost, owner, name string,
+) (context.Context, *db.Repo, func(), error) {
+	repo, err := r.LookupRoute(ctx, provider, platformHost, owner, name)
+	if err != nil {
+		return ctx, nil, nil, err
+	}
+	leaseCtx, leased, release, err := r.LeaseActiveRepositoryContext(
+		ctx, repo.ID,
+	)
+	if err != nil {
+		return ctx, nil, nil, err
+	}
+	if leased == nil {
+		return ctx, nil, nil, ErrRepoNotFound
+	}
+	return leaseCtx, leased, release, nil
+}
+
 func ProviderRouteLookupError(err error) error {
 	if errors.Is(err, ErrRepoPathRequired) {
 		return BadRequest(CodeBadRequest, err.Error(), nil)
@@ -207,6 +255,42 @@ func (r *RepositoryResolver) List(ctx context.Context) ([]db.Repo, error) {
 		return nil, ErrRepositoryStoreUnavailable
 	}
 	return r.db.ListRepos(ctx)
+}
+
+// LeaseActiveRepository keeps one repository incarnation active until release.
+// Replacement reconciliation cannot retire or reuse its route while the lease
+// is held.
+func (r *RepositoryResolver) LeaseActiveRepository(
+	ctx context.Context,
+	repoID int64,
+) (*db.Repo, func(), error) {
+	_, repo, release, err := r.LeaseActiveRepositoryContext(ctx, repoID)
+	return repo, release, err
+}
+
+// LeaseActiveRepositoryContext returns a context that identifies the active
+// reconciliation lease to nested repository-aware persistence helpers.
+func (r *RepositoryResolver) LeaseActiveRepositoryContext(
+	ctx context.Context,
+	repoID int64,
+) (context.Context, *db.Repo, func(), error) {
+	if r == nil || r.db == nil {
+		return nil, nil, nil, ErrRepositoryStoreUnavailable
+	}
+	leaseCtx, release, err := r.db.LeaseRepositoryReconciliationRead(ctx)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	repo, err := r.db.GetRepoByID(leaseCtx, repoID)
+	if err != nil {
+		release()
+		return nil, nil, nil, err
+	}
+	if repo == nil || repo.RetiredAt != nil {
+		release()
+		return ctx, nil, nil, nil
+	}
+	return leaseCtx, repo, release, nil
 }
 
 func (r *RepositoryResolver) Ref(repo db.Repo) RepoRefResponse {

--- a/internal/server/httpapi/repository_resolver_test.go
+++ b/internal/server/httpapi/repository_resolver_test.go
@@ -20,6 +20,58 @@ func TestRepositoryResolverRejectsUnavailableStore(t *testing.T) {
 	require.ErrorIs(t, err, ErrRepositoryStoreUnavailable)
 }
 
+func TestRepositoryResolverActiveLeaseBlocksRepositoryReplacement(t *testing.T) {
+	require := require.New(t)
+	database := dbtest.Open(t)
+	oldID, err := database.UpsertRepoByProviderID(t.Context(), db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repository-old",
+		Owner:          "acme",
+		Name:           "widget",
+		RepoPath:       "acme/widget",
+	})
+	require.NoError(err)
+	resolver := NewRepositoryResolver(RepositoryResolverDeps{DB: database})
+
+	repo, release, err := resolver.LeaseActiveRepository(t.Context(), oldID)
+	require.NoError(err)
+	require.NotNil(repo)
+	require.NotNil(release)
+
+	writeStarted := make(chan struct{})
+	restore := database.SetBeforeRepositoryReconciliationWriteLockForTest(func() {
+		select {
+		case <-writeStarted:
+		default:
+			close(writeStarted)
+		}
+	})
+	t.Cleanup(restore)
+	replacementDone := make(chan error, 1)
+	go func() {
+		_, err := database.UpsertRepoByProviderID(t.Context(), db.RepoIdentity{
+			Platform:       "github",
+			PlatformHost:   "github.com",
+			PlatformRepoID: "repository-replacement",
+			Owner:          "acme",
+			Name:           "widget",
+			RepoPath:       "acme/widget",
+		})
+		replacementDone <- err
+	}()
+	<-writeStarted
+
+	select {
+	case err := <-replacementDone:
+		require.Fail("repository replacement completed while active lease was held", err)
+	default:
+	}
+
+	release()
+	require.NoError(<-replacementDone)
+}
+
 func TestRepositoryResolverOwnsCapabilityFallbackPolicy(t *testing.T) {
 	assert := assert.New(t)
 	resolver := NewRepositoryResolver(RepositoryResolverDeps{

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -459,19 +459,27 @@ func (s *Server) getRepoCommitDiff(
 		return nil, httpapi.ServiceUnavailable("diff view not available: clone manager not configured")
 	}
 
-	repo, err := s.repoResolver.LookupRoute(
+	leaseCtx, repo, release, err := s.repoResolver.LeaseRouteContext(
 		ctx, input.Provider, input.PlatformHost, input.Owner, input.Name,
 	)
 	if err != nil {
 		return nil, httpapi.ProviderRouteLookupError(err)
 	}
+	defer release()
+	ctx = leaseCtx
 
-	host := httpapi.ProviderHost(*repo)
 	if !isFullGitObjectID(input.SHA) {
 		return nil, httpapi.Validation("path.sha", "commit SHA must be a full object ID")
 	}
 
-	sha, err := s.clones.ResolveCommit(ctx, string(httpapi.ProviderKind(*repo)), host, repo.Owner, repo.Name, input.SHA)
+	clone := s.clones.RepositoryClone(
+		repo.ID,
+		string(httpapi.ProviderKind(*repo)),
+		httpapi.ProviderHost(*repo),
+		repo.Owner,
+		repo.Name,
+	)
+	sha, err := clone.ResolveCommit(ctx, input.SHA)
 	if err != nil {
 		if errors.Is(err, gitclone.ErrNotFound) {
 			return nil, httpapi.NotFound(httpapi.CodeNotFound, "diff not available: referenced commit not found", nil)
@@ -480,7 +488,7 @@ func (s *Server) getRepoCommitDiff(
 		return nil, httpapi.Upstream("failed to compute diff", "", "")
 	}
 
-	parent, err := s.clones.ParentOf(ctx, string(httpapi.ProviderKind(*repo)), host, repo.Owner, repo.Name, sha)
+	parent, err := clone.ParentOf(ctx, sha)
 	if err != nil {
 		if errors.Is(err, gitclone.ErrNotFound) {
 			return nil, httpapi.NotFound(httpapi.CodeNotFound, "diff not available: referenced commit not found", nil)
@@ -490,7 +498,7 @@ func (s *Server) getRepoCommitDiff(
 	}
 
 	hideWhitespace := input.Whitespace == "hide"
-	result, err := s.clones.Diff(ctx, string(httpapi.ProviderKind(*repo)), host, repo.Owner, repo.Name, parent, sha, hideWhitespace)
+	result, err := clone.Diff(ctx, parent, sha, hideWhitespace)
 	if err != nil {
 		if errors.Is(err, gitclone.ErrNotFound) {
 			return nil, httpapi.NotFound(httpapi.CodeNotFound, "diff not available: referenced commit not found", nil)
@@ -1076,6 +1084,14 @@ func (s *Server) syncPR(ctx context.Context, input *repoNumberInput) (*syncPROut
 			"sync PR: "+syncErr.Error(),
 		)
 	}
+	leaseCtx, repo, release, err := s.repoResolver.LeaseRouteContext(
+		ctx, input.Provider, input.PlatformHost, input.Owner, input.Name,
+	)
+	if err != nil {
+		return nil, httpapi.ProviderRouteLookupError(err)
+	}
+	defer release()
+	ctx = leaseCtx
 
 	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
 	if err != nil {
@@ -1158,6 +1174,14 @@ func (s *Server) syncIssue(ctx context.Context, input *issueRepoNumberInput) (*s
 			"sync issue: "+err.Error(),
 		)
 	}
+	leaseCtx, repo, release, err := s.repoResolver.LeaseRouteContext(
+		ctx, input.Provider, input.PlatformHost, input.Owner, input.Name,
+	)
+	if err != nil {
+		return nil, httpapi.ProviderRouteLookupError(err)
+	}
+	defer release()
+	ctx = leaseCtx
 
 	issue, err := s.db.GetIssueByRepoIDAndNumber(ctx, repo.ID, input.Number)
 	if err != nil {

--- a/internal/server/issueapi/mutation_handlers.go
+++ b/internal/server/issueapi/mutation_handlers.go
@@ -19,12 +19,13 @@ func (s *Handler) postIssueComment(ctx context.Context, input *postIssueCommentI
 	if strings.TrimSpace(input.Body.Body) == "" {
 		return nil, httpapi.Validation("body.body", "comment body must not be empty")
 	}
-	repo, err := s.resolver.RequireRouteCapability(
+	repo, release, err := s.resolver.LeaseRouteCapability(
 		ctx, input.Provider, input.PlatformHost, input.Owner, input.Name, capabilityCommentMutation,
 	)
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 	if err := s.requireSyncerCapability(*repo, capabilityCommentMutation); err != nil {
 		return nil, err
 	}
@@ -54,12 +55,13 @@ func (s *Handler) editIssueComment(ctx context.Context, input *editIssueCommentI
 	if strings.TrimSpace(input.Body.Body) == "" {
 		return nil, httpapi.Validation("body.body", "comment body must not be empty")
 	}
-	repo, err := s.resolver.RequireRouteCapability(
+	repo, release, err := s.resolver.LeaseRouteCapability(
 		ctx, input.Provider, input.PlatformHost, input.Owner, input.Name, capabilityCommentMutation,
 	)
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 	if err := s.requireSyncerCapability(*repo, capabilityCommentMutation); err != nil {
 		return nil, err
 	}
@@ -96,12 +98,13 @@ func (s *Handler) editIssueComment(ctx context.Context, input *editIssueCommentI
 }
 
 func (s *Handler) deleteIssueComment(ctx context.Context, input *deleteIssueCommentInput) (*deleteIssueCommentOutput, error) {
-	repo, err := s.resolver.RequireRouteCapability(
+	repo, release, err := s.resolver.LeaseRouteCapability(
 		ctx, input.Provider, input.PlatformHost, input.Owner, input.Name, capabilityCommentMutation,
 	)
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 	if err := s.requireSyncerCapability(*repo, capabilityCommentMutation); err != nil {
 		return nil, err
 	}
@@ -141,12 +144,13 @@ func (s *Handler) lookupIssueID(ctx context.Context, repo *db.Repo, number int) 
 }
 
 func (s *Handler) setIssueLabels(ctx context.Context, input *setIssueLabelsInput) (*setLabelsOutput, error) {
-	repo, names, err := s.resolveRequestedLabelNames(
+	repo, names, release, err := s.resolveRequestedLabelNames(
 		ctx, input.Provider, input.PlatformHost, input.Owner, input.Name, input.Body.LabelNames(),
 	)
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 	issue, err := s.db.GetIssueByRepoIDAndNumber(ctx, repo.ID, input.Number)
 	if err != nil {
 		return nil, httpapi.Internal("get issue failed")
@@ -182,30 +186,33 @@ func (s *Handler) resolveRequestedLabelNames(
 	ctx context.Context,
 	provider, platformHost, owner, name string,
 	names []string,
-) (*db.Repo, []string, error) {
-	repo, err := s.resolver.LookupRoute(ctx, provider, platformHost, owner, name)
+) (*db.Repo, []string, func(), error) {
+	repo, release, err := s.resolver.LeaseRouteCapability(
+		ctx, provider, platformHost, owner, name, capabilityReadLabels,
+	)
 	if err != nil {
-		return nil, nil, httpapi.ProviderRouteLookupError(err)
+		return nil, nil, nil, err
 	}
 	caps := s.resolver.CapabilitiesForRepo(*repo)
-	if !httpapi.CapabilityEnabled(caps, capabilityReadLabels) {
-		return nil, nil, httpapi.UnsupportedCapability(*repo, capabilityReadLabels)
-	}
 	if !httpapi.CapabilityEnabled(caps, capabilityLabelMutation) {
-		return nil, nil, httpapi.UnsupportedCapability(*repo, capabilityLabelMutation)
+		release()
+		return nil, nil, nil, httpapi.UnsupportedCapability(*repo, capabilityLabelMutation)
 	}
 	if names == nil {
-		return nil, nil, httpapi.Validation("body.labels", "labels must be an array")
+		release()
+		return nil, nil, nil, httpapi.Validation("body.labels", "labels must be an array")
 	}
 	catalog, freshness, err := s.db.ListRepoLabelCatalog(ctx, repo.ID)
 	if err != nil {
-		return nil, nil, httpapi.Internal("list repo labels failed")
+		release()
+		return nil, nil, nil, httpapi.Internal("list repo labels failed")
 	}
 	if labelCatalogStale(freshness, time.Now().UTC()) && s.syncer != nil {
 		_ = s.syncer.RefreshRepoLabelCatalog(ctx, *repo)
 		catalog, _, err = s.db.ListRepoLabelCatalog(ctx, repo.ID)
 		if err != nil {
-			return nil, nil, httpapi.Internal("list repo labels failed")
+			release()
+			return nil, nil, nil, httpapi.Internal("list repo labels failed")
 		}
 	}
 	catalogByName := make(map[string]struct{}, len(catalog))
@@ -217,13 +224,16 @@ func (s *Handler) resolveRequestedLabelNames(
 	for _, raw := range names {
 		label := strings.TrimSpace(raw)
 		if label == "" {
-			return nil, nil, httpapi.Validation("body.labels", "label names must not be empty")
+			release()
+			return nil, nil, nil, httpapi.Validation("body.labels", "label names must not be empty")
 		}
 		if _, ok := seen[label]; ok {
-			return nil, nil, httpapi.Validation("body.labels", fmt.Sprintf("duplicate label %q", label))
+			release()
+			return nil, nil, nil, httpapi.Validation("body.labels", fmt.Sprintf("duplicate label %q", label))
 		}
 		if _, ok := catalogByName[label]; !ok {
-			return nil, nil, httpapi.NewProblem(
+			release()
+			return nil, nil, nil, httpapi.NewProblem(
 				http.StatusBadRequest, httpapi.CodeValidationError,
 				fmt.Sprintf("label %q is not in the repository label catalog", label),
 				map[string]any{"field": "body.labels", "label": label},
@@ -232,16 +242,17 @@ func (s *Handler) resolveRequestedLabelNames(
 		seen[label] = struct{}{}
 		resolved = append(resolved, label)
 	}
-	return repo, resolved, nil
+	return repo, resolved, release, nil
 }
 
 func (s *Handler) setIssueAssignees(ctx context.Context, input *setIssueAssigneesInput) (*setAssigneesOutput, error) {
-	repo, names, err := s.resolveAssignees(
+	repo, names, release, err := s.resolveAssignees(
 		ctx, input.Provider, input.PlatformHost, input.Owner, input.Name, input.Body.Assignees,
 	)
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 	issue, err := s.db.GetIssueByRepoIDAndNumber(ctx, repo.ID, input.Number)
 	if err != nil {
 		return nil, httpapi.Internal("get issue failed")
@@ -269,46 +280,51 @@ func (s *Handler) resolveAssignees(
 	ctx context.Context,
 	provider, platformHost, owner, name string,
 	raw *[]string,
-) (*db.Repo, []string, error) {
-	repo, err := s.resolver.RequireRouteCapability(
+) (*db.Repo, []string, func(), error) {
+	repo, release, err := s.resolver.LeaseRouteCapability(
 		ctx, provider, platformHost, owner, name, capabilityAssigneeMutation,
 	)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	if s.syncer == nil {
-		return nil, nil, httpapi.UnsupportedCapability(*repo, capabilityAssigneeMutation)
+		release()
+		return nil, nil, nil, httpapi.UnsupportedCapability(*repo, capabilityAssigneeMutation)
 	}
 	if raw == nil {
-		return nil, nil, httpapi.Validation("body.assignees", "value must be an array of usernames")
+		release()
+		return nil, nil, nil, httpapi.Validation("body.assignees", "value must be an array of usernames")
 	}
 	seen := make(map[string]struct{}, len(*raw))
 	resolved := make([]string, 0, len(*raw))
 	for _, value := range *raw {
 		username := strings.TrimSpace(value)
 		if username == "" {
-			return nil, nil, httpapi.Validation("body.assignees", "usernames must not be empty")
+			release()
+			return nil, nil, nil, httpapi.Validation("body.assignees", "usernames must not be empty")
 		}
 		key := strings.ToLower(username)
 		if _, ok := seen[key]; ok {
-			return nil, nil, httpapi.Validation("body.assignees", fmt.Sprintf("duplicate username %q", username))
+			release()
+			return nil, nil, nil, httpapi.Validation("body.assignees", fmt.Sprintf("duplicate username %q", username))
 		}
 		seen[key] = struct{}{}
 		resolved = append(resolved, username)
 	}
-	return repo, resolved, nil
+	return repo, resolved, release, nil
 }
 
 func (s *Handler) setIssueGitHubState(ctx context.Context, input *githubStateInput) (*githubStateOutput, error) {
 	if input.Body.State != "open" && input.Body.State != "closed" {
 		return nil, httpapi.Validation("body.state", "state must be 'open' or 'closed'", "open", "closed")
 	}
-	repo, err := s.resolver.RequireRouteCapability(
+	repo, release, err := s.resolver.LeaseRouteCapability(
 		ctx, input.Provider, input.PlatformHost, input.Owner, input.Name, capabilityStateMutation,
 	)
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 	issue, err := s.db.GetIssueByRepoIDAndNumber(ctx, repo.ID, input.Number)
 	if err != nil {
 		return nil, httpapi.Internal("get issue: " + err.Error())

--- a/internal/server/issueapi/routes.go
+++ b/internal/server/issueapi/routes.go
@@ -59,12 +59,13 @@ func (s *Handler) createIssue(ctx context.Context, input *createIssueInput) (*cr
 	if title == "" {
 		return nil, httpapi.Validation("body.title", "issue title must not be empty")
 	}
-	repo, err := s.resolver.RequireRouteCapability(
+	repo, release, err := s.resolver.LeaseRouteCapability(
 		ctx, input.Provider, input.PlatformHost, input.Owner, input.Name, capabilityIssueMutation,
 	)
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 	if err := s.requireSyncerCapability(*repo, capabilityIssueMutation); err != nil {
 		return nil, err
 	}
@@ -176,12 +177,13 @@ func (s *Handler) editIssueContent(ctx context.Context, input *editIssueContentI
 	if input.Body.Title != nil && strings.TrimSpace(*input.Body.Title) == "" {
 		return nil, httpapi.Validation("body.title", "title must not be blank")
 	}
-	repo, err := s.resolver.RequireRouteCapability(
+	repo, release, err := s.resolver.LeaseRouteCapability(
 		ctx, input.Provider, input.PlatformHost, input.Owner, input.Name, capabilityStateMutation,
 	)
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 	if err := s.requireSyncerCapability(*repo, capabilityStateMutation); err != nil {
 		return nil, err
 	}
@@ -216,7 +218,9 @@ func (s *Handler) editIssueContent(ctx context.Context, input *editIssueContentI
 	if !updated.UpdatedAt.IsZero() {
 		updatedAt = updated.UpdatedAt.UTC()
 	}
-	if err := s.db.UpdateIssueTitleBody(ctx, issue.ID, newTitle, newBody, updatedAt); err != nil {
+	if err := s.db.UpdateIssueTitleBody(
+		ctx, repo.ID, issue.ID, newTitle, newBody, updatedAt,
+	); err != nil {
 		return nil, httpapi.Internal("update title/body failed")
 	}
 	issue, err = s.db.GetIssueByRepoIDAndNumber(ctx, repo.ID, input.Number)

--- a/internal/server/notifications_test.go
+++ b/internal/server/notifications_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	gh "github.com/google/go-github/v89/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/forge/internal/config"
@@ -423,6 +424,346 @@ func TestNotificationsAPIExposesBackgroundSyncStatus(t *testing.T) {
 		}
 		return !body.Sync.Running && strings.Contains(body.Sync.LastError, "notification API unavailable")
 	}, 2*time.Second, 20*time.Millisecond)
+}
+
+func TestNotificationsSyncAPIRoutesRenameThroughConfiguredCredential(
+	t *testing.T,
+) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	const providerID = "R_stable"
+	database := openTestDB(t)
+	repoID, err := database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: providerID,
+		Owner:          "acme",
+		Name:           "widget",
+		RepoPath:       "acme/widget",
+	})
+	require.NoError(err)
+	renamedID, err := database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: providerID,
+		Owner:          "acme-tools",
+		Name:           "renamed-widget",
+		RepoPath:       "acme-tools/renamed-widget",
+	})
+	require.NoError(err)
+	require.Equal(repoID, renamedID)
+
+	var repositoryLookups []string
+	var notificationOpts []ghclient.NotificationListOptions
+	number := 7
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	provider := &mockGH{
+		getRepositoryFn: func(
+			_ context.Context,
+			owner string,
+			name string,
+		) (*gh.Repository, error) {
+			repositoryLookups = append(repositoryLookups, owner+"/"+name)
+			resolvedOwner := "acme-tools"
+			resolvedName := "renamed-widget"
+			return &gh.Repository{
+				NodeID:   new(providerID),
+				Owner:    &gh.User{Login: &resolvedOwner},
+				Name:     &resolvedName,
+				Archived: new(bool),
+			}, nil
+		},
+		listNotificationsFn: func(
+			_ context.Context,
+			opts ghclient.NotificationListOptions,
+		) ([]ghclient.NotificationThread, bool, error) {
+			notificationOpts = append(notificationOpts, opts)
+			if opts.Participating {
+				return nil, false, nil
+			}
+			return []ghclient.NotificationThread{{
+				ID:           "thread-7",
+				RepoOwner:    "acme-tools",
+				RepoName:     "renamed-widget",
+				SubjectType:  "PullRequest",
+				SubjectTitle: "Review requested",
+				WebURL:       "https://github.com/acme-tools/renamed-widget/pull/7",
+				ItemNumber:   &number,
+				ItemType:     "pr",
+				Reason:       "mention",
+				Unread:       true,
+				UpdatedAt:    now,
+			}}, false, nil
+		},
+	}
+	router, err := ghclient.NewHostRouter("github.com", &ghclient.Route{
+		Key: ghclient.RouteKey{
+			Host:  "github.com",
+			Owner: "acme",
+			Name:  "widget",
+		},
+		Client: provider,
+		ReadIdentity: ghclient.IdentityKey{
+			Host: "github.com", Principal: "user:1",
+		},
+		WriteIdentity: ghclient.IdentityKey{
+			Host: "github.com", Principal: "user:1",
+		},
+	})
+	require.NoError(err)
+	routed, err := ghclient.NewRoutedClient(router)
+	require.NoError(err)
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": routed},
+		database,
+		nil,
+		[]ghclient.RepoRef{{
+			Platform:           "github",
+			PlatformHost:       "github.com",
+			RepoID:             repoID,
+			Owner:              "acme-tools",
+			Name:               "renamed-widget",
+			RepoPath:           "acme-tools/renamed-widget",
+			CredentialOwner:    "acme",
+			CredentialName:     "widget",
+			PlatformExternalID: providerID,
+		}},
+		time.Minute,
+		nil,
+		nil,
+	)
+	t.Cleanup(syncer.Stop)
+	syncer.SetGitHubRouters(map[string]*ghclient.HostRouter{
+		"github.com": router,
+	})
+	syncDone := make(chan struct{}, 1)
+	syncer.SetOnNotificationSyncComplete(func() {
+		select {
+		case syncDone <- struct{}{}:
+		default:
+		}
+	})
+	srv := New(
+		database,
+		syncer,
+		nil,
+		"/",
+		notificationsEnabledConfig(),
+		ServerOptions{},
+	)
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	response, err := http.Post(
+		ts.URL+"/api/v1/notifications/sync",
+		"application/json",
+		nil,
+	)
+	require.NoError(err)
+	defer response.Body.Close()
+	require.Equal(http.StatusAccepted, response.StatusCode)
+	select {
+	case <-syncDone:
+	case <-time.After(2 * time.Second):
+		require.Fail("notification sync did not complete")
+	}
+	assert.Empty(syncer.NotificationSyncStatus().LastError)
+	assert.Equal([]string{"acme/widget"}, repositoryLookups)
+	require.Len(notificationOpts, 2)
+	for _, opts := range notificationOpts {
+		assert.Equal("acme-tools", opts.RepoOwner)
+		assert.Equal("renamed-widget", opts.RepoName)
+		assert.Equal("acme", opts.CredentialOwner)
+		assert.Equal("widget", opts.CredentialName)
+	}
+	items, err := database.ListNotifications(
+		ctx,
+		db.ListNotificationsOpts{State: "all"},
+	)
+	require.NoError(err)
+	require.Len(items, 1)
+	require.NotNil(items[0].RepoID)
+	assert.Equal(repoID, *items[0].RepoID)
+	assert.Equal("acme-tools", items[0].RepoOwner)
+	assert.Equal("renamed-widget", items[0].RepoName)
+}
+
+func TestNotificationsSyncAPIHoldsRepositoryLeaseThroughProviderFetch(
+	t *testing.T,
+) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	const (
+		oldProviderID = "R_old"
+		newProviderID = "R_new"
+	)
+	database := openTestDB(t)
+	oldRepoID, err := database.UpsertRepoByProviderID(
+		ctx,
+		db.RepoIdentity{
+			Platform:       "github",
+			PlatformHost:   "github.com",
+			PlatformRepoID: oldProviderID,
+			Owner:          "acme",
+			Name:           "widget",
+			RepoPath:       "acme/widget",
+		},
+	)
+	require.NoError(err)
+	fetchStarted := make(chan struct{})
+	continueFetch := make(chan struct{})
+	number := 7
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	provider := &mockGH{
+		getRepositoryFn: func(
+			context.Context,
+			string,
+			string,
+		) (*gh.Repository, error) {
+			owner := "acme"
+			name := "widget"
+			return &gh.Repository{
+				NodeID:   new(oldProviderID),
+				Owner:    &gh.User{Login: &owner},
+				Name:     &name,
+				Archived: new(bool),
+			}, nil
+		},
+		listNotificationsFn: func(
+			_ context.Context,
+			opts ghclient.NotificationListOptions,
+		) ([]ghclient.NotificationThread, bool, error) {
+			if opts.Participating {
+				return nil, false, nil
+			}
+			close(fetchStarted)
+			<-continueFetch
+			return []ghclient.NotificationThread{{
+				ID:           "thread-7",
+				RepoOwner:    "acme",
+				RepoName:     "widget",
+				SubjectType:  "PullRequest",
+				SubjectTitle: "Review requested",
+				WebURL:       "https://github.com/acme/widget/pull/7",
+				ItemNumber:   &number,
+				ItemType:     "pr",
+				Reason:       "mention",
+				Unread:       true,
+				UpdatedAt:    now,
+			}}, false, nil
+		},
+	}
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": provider},
+		database,
+		nil,
+		[]ghclient.RepoRef{{
+			Platform:           "github",
+			PlatformHost:       "github.com",
+			RepoID:             oldRepoID,
+			Owner:              "acme",
+			Name:               "widget",
+			RepoPath:           "acme/widget",
+			PlatformExternalID: oldProviderID,
+		}},
+		time.Minute,
+		nil,
+		nil,
+	)
+	t.Cleanup(syncer.Stop)
+	syncDone := make(chan struct{}, 1)
+	syncer.SetOnNotificationSyncComplete(func() {
+		select {
+		case syncDone <- struct{}{}:
+		default:
+		}
+	})
+	srv := New(
+		database,
+		syncer,
+		nil,
+		"/",
+		notificationsEnabledConfig(),
+		ServerOptions{},
+	)
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	response, err := http.Post(
+		ts.URL+"/api/v1/notifications/sync",
+		"application/json",
+		nil,
+	)
+	require.NoError(err)
+	defer response.Body.Close()
+	require.Equal(http.StatusAccepted, response.StatusCode)
+	select {
+	case <-fetchStarted:
+	case <-time.After(2 * time.Second):
+		close(continueFetch)
+		require.Fail("notification sync did not reach the provider")
+	}
+
+	writeAttempted := make(chan struct{})
+	restore := database.SetBeforeRepositoryReconciliationWriteLockForTest(
+		func() { close(writeAttempted) },
+	)
+	defer restore()
+	replacementDone := make(chan error, 1)
+	go func() {
+		_, replacementErr := database.UpsertRepoByProviderID(
+			ctx,
+			db.RepoIdentity{
+				Platform:       "github",
+				PlatformHost:   "github.com",
+				PlatformRepoID: newProviderID,
+				Owner:          "acme",
+				Name:           "widget",
+				RepoPath:       "acme/widget",
+			},
+		)
+		replacementDone <- replacementErr
+	}()
+	<-writeAttempted
+
+	replacementCompletedEarly := false
+	select {
+	case replacementErr := <-replacementDone:
+		require.NoError(replacementErr)
+		replacementCompletedEarly = true
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(continueFetch)
+	select {
+	case <-syncDone:
+	case <-time.After(2 * time.Second):
+		require.Fail("notification sync did not complete")
+	}
+	if !replacementCompletedEarly {
+		require.NoError(<-replacementDone)
+	}
+	assert.False(
+		replacementCompletedEarly,
+		"replacement must wait for provider fetch and notification persistence",
+	)
+	active, err := database.GetRepoByIdentity(
+		ctx,
+		db.RepoIdentity{
+			Platform: "github", PlatformHost: "github.com",
+			Owner: "acme", Name: "widget",
+		},
+	)
+	require.NoError(err)
+	require.NotNil(active)
+	assert.NotEqual(oldRepoID, active.ID)
+	assert.Equal(newProviderID, active.PlatformRepoID)
+	watermark, err := database.GetNotificationSyncWatermark(ctx, active.ID)
+	require.NoError(err)
+	assert.Nil(watermark)
 }
 
 func TestGlobalSyncExposesNotificationSyncFailure(t *testing.T) {

--- a/internal/server/pullapi/assignee_reviewer_handlers.go
+++ b/internal/server/pullapi/assignee_reviewer_handlers.go
@@ -43,7 +43,7 @@ func (s *Handler) setPullAssignees(
 	ctx context.Context,
 	input *setPullAssigneesInput,
 ) (*setAssigneesOutput, error) {
-	repo, names, err := s.resolveUserMutationRequest(
+	repo, names, release, err := s.resolveUserMutationRequest(
 		ctx,
 		input.Provider, input.PlatformHost, input.Owner, input.Name,
 		capabilityAssigneeMutation, "body.assignees", input.Body.Assignees,
@@ -51,6 +51,7 @@ func (s *Handler) setPullAssignees(
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 
 	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
 	if err != nil {
@@ -85,7 +86,7 @@ func (s *Handler) setPullReviewers(
 	ctx context.Context,
 	input *setPullReviewersInput,
 ) (*setReviewersOutput, error) {
-	repo, names, err := s.resolveUserMutationRequest(
+	repo, names, release, err := s.resolveUserMutationRequest(
 		ctx,
 		input.Provider, input.PlatformHost, input.Owner, input.Name,
 		capabilityReviewerMutation, "body.reviewers", input.Body.Reviewers,
@@ -93,6 +94,7 @@ func (s *Handler) setPullReviewers(
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 
 	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
 	if err != nil {
@@ -167,19 +169,20 @@ func (s *Handler) resolveUserMutationRequest(
 	capability string,
 	field string,
 	raw *[]string,
-) (*db.Repo, []string, error) {
-	repo, err := s.lookupRepoByProviderRoute(ctx, provider, platformHost, owner, name)
+) (*db.Repo, []string, func(), error) {
+	repo, release, err := s.leaseRepoRouteCapability(
+		ctx, provider, platformHost, owner, name, capability,
+	)
 	if err != nil {
-		return nil, nil, providerRouteLookupError(err)
-	}
-	if !capabilityEnabled(s.capabilitiesForRepo(*repo), capability) {
-		return nil, nil, unsupportedCapabilityProblem(*repo, capability)
+		return nil, nil, nil, err
 	}
 	if s.syncer == nil {
-		return nil, nil, unsupportedCapabilityProblem(*repo, capability)
+		release()
+		return nil, nil, nil, unsupportedCapabilityProblem(*repo, capability)
 	}
 	if raw == nil {
-		return nil, nil, httpapi.Validation(field, "value must be an array of usernames")
+		release()
+		return nil, nil, nil, httpapi.Validation(field, "value must be an array of usernames")
 	}
 
 	seen := make(map[string]struct{}, len(*raw))
@@ -187,16 +190,18 @@ func (s *Handler) resolveUserMutationRequest(
 	for _, value := range *raw {
 		username := strings.TrimSpace(value)
 		if username == "" {
-			return nil, nil, httpapi.Validation(field, "usernames must not be empty")
+			release()
+			return nil, nil, nil, httpapi.Validation(field, "usernames must not be empty")
 		}
 		key := strings.ToLower(username)
 		if _, ok := seen[key]; ok {
-			return nil, nil, httpapi.Validation(field, fmt.Sprintf("duplicate username %q", username))
+			release()
+			return nil, nil, nil, httpapi.Validation(field, fmt.Sprintf("duplicate username %q", username))
 		}
 		seen[key] = struct{}{}
 		resolved = append(resolved, username)
 	}
-	return repo, resolved, nil
+	return repo, resolved, release, nil
 }
 
 // diffUserNames returns the entries of want that are absent from have,

--- a/internal/server/pullapi/deferred_merge.go
+++ b/internal/server/pullapi/deferred_merge.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strconv"
 	"strings"
@@ -103,7 +104,7 @@ func (s *Handler) enqueueDeferredMerge(
 	if maxWait <= 0 {
 		maxWait = defaultDeferredMergeMaxWait
 	}
-	repo, err := s.requireRepoRouteCapability(
+	repo, release, err := s.leaseRepoRouteCapability(
 		ctx,
 		provider, platformHost, owner, name,
 		capabilityMergeMutation,
@@ -111,6 +112,7 @@ func (s *Handler) enqueueDeferredMerge(
 	if err != nil {
 		return deferMergePRBody{}, err
 	}
+	defer release()
 	if err := s.requireSyncerCapability(*repo, capabilityMergeMutation); err != nil {
 		return deferMergePRBody{}, err
 	}
@@ -264,6 +266,20 @@ func (s *Handler) refreshDeferredMergeCI(
 	pendingKeys []deferredMergeCheckKey,
 	queuedTarget deferredMergeTargetSnapshot,
 ) (string, error) {
+	leaseCtx, activeRepo, release, err := s.resolver.LeaseActiveRepositoryContext(
+		ctx,
+		repo.ID,
+	)
+	if err != nil {
+		return "", fmt.Errorf("lease queued repository incarnation: %w", err)
+	}
+	if activeRepo == nil {
+		return "", errors.New("queued repository incarnation is no longer active")
+	}
+	defer release()
+	ctx = leaseCtx
+	repo = *activeRepo
+
 	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, number)
 	if err != nil {
 		return "", err
@@ -390,6 +406,22 @@ func (s *Handler) completeDeferredMerge(
 	queuedTarget deferredMergeTargetSnapshot,
 	handle *deferredMergeHandle,
 ) {
+	leaseCtx, activeRepo, release, err := s.resolver.LeaseActiveRepositoryContext(
+		ctx,
+		repo.ID,
+	)
+	if err != nil {
+		s.broadcastDeferredMergeFailure(repo, number, deferredMergeHeadSHA(body, queuedTarget.HeadSHA), "lease queued repository incarnation: "+err.Error(), handle)
+		return
+	}
+	if activeRepo == nil {
+		s.broadcastDeferredMergeFailure(repo, number, deferredMergeHeadSHA(body, queuedTarget.HeadSHA), "queued repository incarnation is no longer active", handle)
+		return
+	}
+	defer release()
+	ctx = leaseCtx
+	repo = *activeRepo
+
 	if err := s.ensureDeferredMergeTargetUnchanged(ctx, repo, number, queuedTarget); err != nil {
 		if errors.Is(err, errDeferredMergeTargetMerged) {
 			return
@@ -397,7 +429,7 @@ func (s *Handler) completeDeferredMerge(
 		s.broadcastDeferredMergeFailure(repo, number, deferredMergeHeadSHA(body, queuedTarget.HeadSHA), err.Error(), handle)
 		return
 	}
-	result, err := s.mergePRWithBody(ctx, string(repoProviderKind(repo)), repoProviderHost(repo), repo.Owner, repo.Name, number, body)
+	result, err := s.mergePRWithLeasedRepository(ctx, activeRepo, number, body)
 	if err != nil {
 		s.broadcastDeferredMergeFailure(repo, number, deferredMergeHeadSHA(body, queuedTarget.HeadSHA), err.Error(), handle)
 		return

--- a/internal/server/pullapi/deferred_merge_integration_test.go
+++ b/internal/server/pullapi/deferred_merge_integration_test.go
@@ -1533,6 +1533,101 @@ func TestDeferMergeEndpointRejectsClosedPullRequest(t *testing.T) {
 	}
 }
 
+func TestDeferredMergeLeasesQueuedRepositoryDuringProviderRefresh(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	ref := platform.RepoRef{
+		Platform:           platform.KindGitLab,
+		Host:               "gitlab.example.com",
+		Owner:              "group",
+		Name:               "project",
+		RepoPath:           "group/project",
+		PlatformID:         4242,
+		PlatformExternalID: "gid://gitlab/Project/4242",
+		DefaultBranch:      "main",
+	}
+	ciStarted := make(chan struct{})
+	ciRelease := make(chan struct{})
+	provider := &deferredMergeTestProvider{
+		deferredMergeProviderBase: deferredMergeProviderBase{
+			ref: ref,
+			ciChecks: map[string][]platform.CICheck{
+				"head-sha": {{
+					App: "GitLab", Name: "pipeline", Status: "completed", Conclusion: "success",
+				}},
+			},
+		},
+		mergeCh:   make(chan deferredMergeTestMergeCall, 1),
+		ciStarted: ciStarted,
+		ciRelease: ciRelease,
+	}
+	_, database, _, client := newDeferredMergeRouteServer(t, provider, ref, now, []db.CICheck{{
+		App: "GitLab", Name: "pipeline", Status: "in_progress",
+	}})
+
+	expectedHeadSHA := "head-sha"
+	resp, err := client.HTTP.DeferMergePullOnHostWithResponse(
+		ctx,
+		ref.Host,
+		"gitlab",
+		ref.Owner,
+		ref.Name,
+		7,
+		generated.MergePRInputBody{Method: "squash", ExpectedHeadSha: &expectedHeadSHA},
+	)
+	require.NoError(err)
+	require.Equal(202, resp.StatusCode(), string(resp.Body))
+	select {
+	case <-ciStarted:
+	case <-time.After(time.Second):
+		require.FailNow("timed out waiting for deferred CI refresh to start")
+	}
+
+	writeAttempted := make(chan struct{})
+	restoreWriteLockHook := database.SetBeforeRepositoryReconciliationWriteLockForTest(
+		func() { close(writeAttempted) },
+	)
+	defer restoreWriteLockHook()
+	replacementDone := make(chan error, 1)
+	go func() {
+		_, replacementErr := database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+			Platform:       "gitlab",
+			PlatformHost:   ref.Host,
+			PlatformRepoID: "gid://gitlab/Project/8484",
+			Owner:          ref.Owner,
+			Name:           ref.Name,
+			RepoPath:       ref.RepoPath,
+		})
+		replacementDone <- replacementErr
+	}()
+	<-writeAttempted
+
+	var (
+		replacementErr       error
+		replacementCompleted bool
+	)
+	select {
+	case replacementErr = <-replacementDone:
+		replacementCompleted = true
+	case <-time.After(250 * time.Millisecond):
+	}
+	close(ciRelease)
+	if !replacementCompleted {
+		replacementErr = <-replacementDone
+	}
+	require.NoError(replacementErr)
+	require.False(
+		replacementCompleted,
+		"repository replacement must wait for deferred CI refresh persistence",
+	)
+	select {
+	case call := <-provider.mergeCh:
+		require.Failf("unexpected merge", "merge call: %+v", call)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
 func TestDeferMergeEndpointBroadcastsFailureWhenTargetClosedWhileWaiting(t *testing.T) {
 	require := require.New(t)
 	ctx := t.Context()

--- a/internal/server/pullapi/diff_review_handlers.go
+++ b/internal/server/pullapi/diff_review_handlers.go
@@ -164,7 +164,7 @@ func (s *Handler) applyReviewSuggestions(
 	ctx context.Context,
 	input *applyReviewSuggestionInput,
 ) (*applyReviewSuggestionOutput, error) {
-	repo, err := s.requireRepoRouteCapability(
+	repo, release, err := s.leaseRepoRouteCapability(
 		ctx,
 		input.Provider, input.PlatformHost, input.Owner, input.Name,
 		capabilityReviewSuggestionApplication,
@@ -172,6 +172,7 @@ func (s *Handler) applyReviewSuggestions(
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 	if err := s.requireSyncerCapability(*repo, capabilityReviewSuggestionApplication); err != nil {
 		return nil, err
 	}
@@ -482,7 +483,7 @@ func (s *Handler) publishDiffReviewDraft(
 	ctx context.Context,
 	input *publishDiffReviewDraftInput,
 ) (*actionStatusOutput, error) {
-	repo, err := s.requireRepoRouteCapability(
+	repo, release, err := s.leaseRepoRouteCapability(
 		ctx,
 		input.Provider, input.PlatformHost, input.Owner, input.Name,
 		capabilityReviewDraftMutation,
@@ -490,6 +491,7 @@ func (s *Handler) publishDiffReviewDraft(
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("get pull request failed")
@@ -687,7 +689,7 @@ func (s *Handler) setDiffReviewThreadResolved(
 	if err != nil {
 		return nil, err
 	}
-	repo, err := s.requireRepoRouteCapability(
+	repo, release, err := s.leaseRepoRouteCapability(
 		ctx,
 		input.Provider, input.PlatformHost, input.Owner, input.Name,
 		capabilityReviewThreadResolution,
@@ -695,6 +697,7 @@ func (s *Handler) setDiffReviewThreadResolved(
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("get pull request failed")

--- a/internal/server/pullapi/label_handlers.go
+++ b/internal/server/pullapi/label_handlers.go
@@ -27,7 +27,7 @@ func (s *Handler) setPullLabels(
 	ctx context.Context,
 	input *setPullLabelsInput,
 ) (*setLabelsOutput, error) {
-	repo, names, err := s.resolveRequestedLabelNames(
+	repo, names, release, err := s.resolveRequestedLabelNames(
 		ctx,
 		input.Provider,
 		input.PlatformHost,
@@ -38,6 +38,7 @@ func (s *Handler) setPullLabels(
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 
 	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repo.ID, input.Number)
 	if err != nil {
@@ -85,31 +86,34 @@ func (s *Handler) resolveRequestedLabelNames(
 	owner string,
 	name string,
 	names []string,
-) (*db.Repo, []string, error) {
-	repo, err := s.lookupRepoByProviderRoute(ctx, provider, platformHost, owner, name)
+) (*db.Repo, []string, func(), error) {
+	repo, release, err := s.leaseRepoRouteCapability(
+		ctx, provider, platformHost, owner, name, capabilityReadLabels,
+	)
 	if err != nil {
-		return nil, nil, providerRouteLookupError(err)
+		return nil, nil, nil, err
 	}
 	caps := s.capabilitiesForRepo(*repo)
-	if !capabilityEnabled(caps, capabilityReadLabels) {
-		return nil, nil, unsupportedCapabilityProblem(*repo, capabilityReadLabels)
-	}
 	if !capabilityEnabled(caps, capabilityLabelMutation) {
-		return nil, nil, unsupportedCapabilityProblem(*repo, capabilityLabelMutation)
+		release()
+		return nil, nil, nil, unsupportedCapabilityProblem(*repo, capabilityLabelMutation)
 	}
 	if names == nil {
-		return nil, nil, httpapi.Validation("body.labels", "labels must be an array")
+		release()
+		return nil, nil, nil, httpapi.Validation("body.labels", "labels must be an array")
 	}
 
 	catalog, freshness, err := s.db.ListRepoLabelCatalog(ctx, repo.ID)
 	if err != nil {
-		return nil, nil, httpapi.Internal("list repo labels failed")
+		release()
+		return nil, nil, nil, httpapi.Internal("list repo labels failed")
 	}
 	if labelCatalogStale(freshness, time.Now().UTC()) && s.syncer != nil {
 		_ = s.syncer.RefreshRepoLabelCatalog(ctx, *repo)
 		catalog, _, err = s.db.ListRepoLabelCatalog(ctx, repo.ID)
 		if err != nil {
-			return nil, nil, httpapi.Internal("list repo labels failed")
+			release()
+			return nil, nil, nil, httpapi.Internal("list repo labels failed")
 		}
 	}
 	catalogByName := make(map[string]struct{}, len(catalog))
@@ -122,15 +126,18 @@ func (s *Handler) resolveRequestedLabelNames(
 	for _, raw := range names {
 		labelName := strings.TrimSpace(raw)
 		if labelName == "" {
-			return nil, nil, httpapi.Validation("body.labels", "label names must not be empty")
+			release()
+			return nil, nil, nil, httpapi.Validation("body.labels", "label names must not be empty")
 		}
 		if _, ok := seen[labelName]; ok {
-			return nil, nil, httpapi.Validation(
+			release()
+			return nil, nil, nil, httpapi.Validation(
 				"body.labels", fmt.Sprintf("duplicate label %q", labelName),
 			)
 		}
 		if _, ok := catalogByName[labelName]; !ok {
-			return nil, nil, httpapi.NewProblem(
+			release()
+			return nil, nil, nil, httpapi.NewProblem(
 				http.StatusBadRequest,
 				httpapi.CodeValidationError,
 				fmt.Sprintf("label %q is not in the repository label catalog", labelName),
@@ -140,7 +147,7 @@ func (s *Handler) resolveRequestedLabelNames(
 		seen[labelName] = struct{}{}
 		resolved = append(resolved, labelName)
 	}
-	return repo, resolved, nil
+	return repo, resolved, release, nil
 }
 
 func labelCatalogStale(freshness db.LabelCatalogFreshness, now time.Time) bool {

--- a/internal/server/pullapi/provider_helpers.go
+++ b/internal/server/pullapi/provider_helpers.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 	"go.kenn.io/forge/internal/db"
+	"go.kenn.io/forge/internal/gitclone"
 	"go.kenn.io/forge/internal/platform"
 	"go.kenn.io/forge/internal/server/httpapi"
 )
@@ -51,6 +52,15 @@ func (s *Handler) requireRepoRouteCapability(
 	)
 }
 
+func (s *Handler) leaseRepoRouteCapability(
+	ctx context.Context,
+	provider, platformHost, owner, name, capability string,
+) (*db.Repo, func(), error) {
+	return s.resolver.LeaseRouteCapability(
+		ctx, provider, platformHost, owner, name, capability,
+	)
+}
+
 func capabilityEnabled(
 	caps httpapi.ProviderCapabilitiesResponse,
 	capability string,
@@ -79,6 +89,29 @@ func repoProviderKind(repo db.Repo) platform.Kind {
 
 func repoProviderHost(repo db.Repo) string {
 	return httpapi.ProviderHost(repo)
+}
+
+func (s *Handler) repositoryClone(repo db.Repo) gitclone.RepositoryClone {
+	return s.clones.RepositoryClone(
+		repo.ID,
+		string(repoProviderKind(repo)),
+		repoProviderHost(repo),
+		repo.Owner,
+		repo.Name,
+	)
+}
+
+func (s *Handler) leaseRepoByProviderRoute(
+	ctx context.Context,
+	provider, platformHost, owner, name string,
+) (context.Context, *db.Repo, func(), error) {
+	leaseCtx, repo, release, err := s.resolver.LeaseRouteContext(
+		ctx, provider, platformHost, owner, name,
+	)
+	if err != nil {
+		return ctx, nil, nil, providerRouteLookupError(err)
+	}
+	return leaseCtx, repo, release, nil
 }
 
 func platformRepoRefFromDB(repo db.Repo) platform.RepoRef {

--- a/internal/server/pullapi/routes.go
+++ b/internal/server/pullapi/routes.go
@@ -804,7 +804,7 @@ func (s *Handler) editPRContent(
 		return nil, httpapi.Validation("body.title", "title must not be blank")
 	}
 
-	repo, err := s.requireRepoRouteCapability(
+	repo, release, err := s.leaseRepoRouteCapability(
 		ctx,
 		input.Provider, input.PlatformHost, input.Owner, input.Name,
 		capabilityStateMutation,
@@ -812,6 +812,7 @@ func (s *Handler) editPRContent(
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 	if err := s.requireSyncerCapability(*repo, capabilityStateMutation); err != nil {
 		return nil, err
 	}
@@ -859,7 +860,7 @@ func (s *Handler) editPRContent(
 		updatedAt = updatedMR.UpdatedAt.UTC()
 	}
 	if err := s.db.UpdateMRTitleBody(
-		ctx, mr.ID, newTitle, newBody, updatedAt,
+		ctx, repo.ID, mr.ID, newTitle, newBody, updatedAt,
 	); err != nil {
 		return nil, httpapi.Internal("update title/body failed")
 	}
@@ -882,7 +883,7 @@ func (s *Handler) postComment(ctx context.Context, input *postCommentInput) (*po
 		return nil, httpapi.Validation("body.body", "comment body must not be empty")
 	}
 
-	repo, err := s.requireRepoRouteCapability(
+	repo, release, err := s.leaseRepoRouteCapability(
 		ctx,
 		input.Provider, input.PlatformHost, input.Owner, input.Name,
 		capabilityCommentMutation,
@@ -890,6 +891,7 @@ func (s *Handler) postComment(ctx context.Context, input *postCommentInput) (*po
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 	if err := s.requireSyncerCapability(*repo, capabilityCommentMutation); err != nil {
 		return nil, err
 	}
@@ -937,7 +939,7 @@ func (s *Handler) editComment(ctx context.Context, input *editCommentInput) (*ed
 		return nil, httpapi.Validation("body.body", "comment body must not be empty")
 	}
 
-	repo, err := s.requireRepoRouteCapability(
+	repo, release, err := s.leaseRepoRouteCapability(
 		ctx,
 		input.Provider, input.PlatformHost, input.Owner, input.Name,
 		capabilityCommentMutation,
@@ -945,6 +947,7 @@ func (s *Handler) editComment(ctx context.Context, input *editCommentInput) (*ed
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 	if err := s.requireSyncerCapability(*repo, capabilityCommentMutation); err != nil {
 		return nil, err
 	}
@@ -997,7 +1000,7 @@ func (s *Handler) editComment(ctx context.Context, input *editCommentInput) (*ed
 }
 
 func (s *Handler) deleteComment(ctx context.Context, input *deleteCommentInput) (*deleteCommentOutput, error) {
-	repo, err := s.requireRepoRouteCapability(
+	repo, release, err := s.leaseRepoRouteCapability(
 		ctx,
 		input.Provider, input.PlatformHost, input.Owner, input.Name,
 		capabilityCommentMutation,
@@ -1005,6 +1008,7 @@ func (s *Handler) deleteComment(ctx context.Context, input *deleteCommentInput) 
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 	if err := s.requireSyncerCapability(*repo, capabilityCommentMutation); err != nil {
 		return nil, err
 	}
@@ -1043,7 +1047,7 @@ func (s *Handler) replyToDiscussion(ctx context.Context, input *replyToDiscussio
 		return nil, httpapi.Validation("body.body", "reply body must not be empty")
 	}
 
-	repo, err := s.requireRepoRouteCapability(
+	repo, release, err := s.leaseRepoRouteCapability(
 		ctx,
 		input.Provider, input.PlatformHost, input.Owner, input.Name,
 		capabilityThreadReply,
@@ -1051,6 +1055,7 @@ func (s *Handler) replyToDiscussion(ctx context.Context, input *replyToDiscussio
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 	if err := s.requireSyncerCapability(*repo, capabilityThreadReply); err != nil {
 		return nil, err
 	}
@@ -1147,7 +1152,7 @@ func (s *Handler) resolveDiscussion(ctx context.Context, input *resolveDiscussio
 		return nil, err
 	}
 
-	repo, err := s.requireRepoRouteCapability(
+	repo, release, err := s.leaseRepoRouteCapability(
 		ctx,
 		input.Provider, input.PlatformHost, input.Owner, input.Name,
 		capabilityThreadResolve,
@@ -1155,6 +1160,7 @@ func (s *Handler) resolveDiscussion(ctx context.Context, input *resolveDiscussio
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 	if err := s.requireSyncerCapability(*repo, capabilityThreadResolve); err != nil {
 		return nil, err
 	}
@@ -1205,7 +1211,7 @@ func (s *Handler) resolveDiscussion(ctx context.Context, input *resolveDiscussio
 }
 
 func (s *Handler) approvePR(ctx context.Context, input *approvePRInput) (*actionStatusOutput, error) {
-	repo, err := s.requireRepoRouteCapability(
+	repo, release, err := s.leaseRepoRouteCapability(
 		ctx,
 		input.Provider, input.PlatformHost, input.Owner, input.Name,
 		capabilityReviewMutation,
@@ -1213,6 +1219,7 @@ func (s *Handler) approvePR(ctx context.Context, input *approvePRInput) (*action
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 	if err := s.requireSyncerCapability(*repo, capabilityReviewMutation); err != nil {
 		return nil, err
 	}
@@ -1264,6 +1271,7 @@ func (s *Handler) approvePR(ctx context.Context, input *approvePRInput) (*action
 	event := platform.DBMREvent(mr.ID, platformEvent)
 	_ = s.db.UpsertMREvents(ctx, []db.MREvent{event})
 
+	release()
 	if syncErr := s.syncer.SyncMROnProvider(
 		ctx,
 		repoProviderKind(*repo), repoProviderHost(*repo),
@@ -1276,7 +1284,7 @@ func (s *Handler) approvePR(ctx context.Context, input *approvePRInput) (*action
 }
 
 func (s *Handler) requestChangesPR(ctx context.Context, input *requestChangesPRInput) (*actionStatusOutput, error) {
-	repo, err := s.requireRepoRouteCapability(
+	repo, release, err := s.leaseRepoRouteCapability(
 		ctx,
 		input.Provider, input.PlatformHost, input.Owner, input.Name,
 		capabilityReviewMutation,
@@ -1284,6 +1292,7 @@ func (s *Handler) requestChangesPR(ctx context.Context, input *requestChangesPRI
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 	if err := s.requireSyncerCapability(*repo, capabilityReviewMutation); err != nil {
 		return nil, err
 	}
@@ -1328,6 +1337,7 @@ func (s *Handler) requestChangesPR(ctx context.Context, input *requestChangesPRI
 		)
 	}
 
+	release()
 	if syncErr := s.syncer.SyncMROnProvider(
 		ctx,
 		repoProviderKind(*repo), repoProviderHost(*repo),
@@ -1364,7 +1374,7 @@ func approvalReviewHeadSHA(mr *db.MergeRequest, clientSHA string) string {
 }
 
 func (s *Handler) approveWorkflows(ctx context.Context, input *repoNumberInput) (*actionStatusOutput, error) {
-	repo, err := s.requireRepoRouteCapability(
+	repo, release, err := s.leaseRepoRouteCapability(
 		ctx,
 		input.Provider, input.PlatformHost, input.Owner, input.Name,
 		capabilityWorkflowApproval,
@@ -1372,6 +1382,7 @@ func (s *Handler) approveWorkflows(ctx context.Context, input *repoNumberInput) 
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 	if err := s.requireSyncerCapability(*repo, capabilityWorkflowApproval); err != nil {
 		return nil, err
 	}
@@ -1432,6 +1443,7 @@ func (s *Handler) approveWorkflows(ctx context.Context, input *repoNumberInput) 
 			ctx, platformRepoRefFromDB(*repo), strconv.FormatInt(run.GetID(), 10),
 		); err != nil {
 			if approvedCount > 0 {
+				release()
 				if syncErr := s.syncer.SyncMROnProvider(
 					context.WithoutCancel(ctx),
 					repoProviderKind(*repo), repoProviderHost(*repo),
@@ -1449,6 +1461,7 @@ func (s *Handler) approveWorkflows(ctx context.Context, input *repoNumberInput) 
 		approvedCount++
 	}
 
+	release()
 	if syncErr := s.syncer.SyncMROnProvider(
 		context.WithoutCancel(ctx),
 		repoProviderKind(*repo), repoProviderHost(*repo),
@@ -1473,7 +1486,7 @@ func (s *Handler) approveWorkflows(ctx context.Context, input *repoNumberInput) 
 }
 
 func (s *Handler) readyForReview(ctx context.Context, input *repoNumberInput) (*actionStatusOutput, error) {
-	repo, err := s.requireRepoRouteCapability(
+	repo, release, err := s.leaseRepoRouteCapability(
 		ctx,
 		input.Provider, input.PlatformHost, input.Owner, input.Name,
 		capabilityReadyForReview,
@@ -1481,6 +1494,7 @@ func (s *Handler) readyForReview(ctx context.Context, input *repoNumberInput) (*
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 	if err := s.requireSyncerCapability(*repo, capabilityReadyForReview); err != nil {
 		return nil, err
 	}
@@ -1504,6 +1518,7 @@ func (s *Handler) readyForReview(ctx context.Context, input *repoNumberInput) (*
 			staleState = errors.As(err, &ghErr) && ghErr != nil && ghErr.Response != nil && ghErr.Response.StatusCode == http.StatusNotFound
 		}
 		if staleState {
+			release()
 			if syncErr := s.syncer.SyncMROnProvider(
 				context.WithoutCancel(ctx),
 				repoProviderKind(*repo), repoProviderHost(*repo),
@@ -1540,6 +1555,7 @@ func (s *Handler) readyForReview(ctx context.Context, input *repoNumberInput) (*
 		)
 	}
 
+	release()
 	normalized := platform.DBMergeRequest(repo.ID, pr)
 	if mrID, _, accepted, upsertErr := s.syncer.CommitMergeRequestParentSnapshot(
 		ctx, mergeRequestRepoRef(*repo), normalized,
@@ -1567,7 +1583,7 @@ func (s *Handler) mergePRWithBody(
 	number int,
 	body mergePRInputBody,
 ) (mergePRBody, error) {
-	repo, err := s.requireRepoRouteCapability(
+	repo, release, err := s.leaseRepoRouteCapability(
 		ctx,
 		provider, platformHost, owner, name,
 		capabilityMergeMutation,
@@ -1575,6 +1591,18 @@ func (s *Handler) mergePRWithBody(
 	if err != nil {
 		return mergePRBody{}, err
 	}
+	defer release()
+	return s.mergePRWithLeasedRepository(ctx, repo, number, body)
+}
+
+// mergePRWithLeasedRepository performs the provider mutation and persistence
+// against the exact repository incarnation protected by the caller's lease.
+func (s *Handler) mergePRWithLeasedRepository(
+	ctx context.Context,
+	repo *db.Repo,
+	number int,
+	body mergePRInputBody,
+) (mergePRBody, error) {
 	if err := s.requireSyncerCapability(*repo, capabilityMergeMutation); err != nil {
 		return mergePRBody{}, err
 	}
@@ -1612,7 +1640,7 @@ func (s *Handler) mergePRWithBody(
 	if err != nil {
 		if status, message, ok := mergeHTTPErrorStatus(err); ok {
 			slog.Error("provider merge failed",
-				"owner", owner, "repo", name,
+				"owner", repo.Owner, "repo", repo.Name,
 				"number", number, "method", body.Method,
 				"status", status,
 				"message", message,
@@ -1654,7 +1682,7 @@ func (s *Handler) mergePRWithBody(
 			)
 		}
 		slog.Error("provider merge transport error",
-			"owner", owner, "repo", name,
+			"owner", repo.Owner, "repo", repo.Name,
 			"number", number, "method", body.Method,
 			"err", err)
 		return mergePRBody{}, httpapi.ProviderCallProblemWithDetail(
@@ -1923,7 +1951,7 @@ func (s *Handler) setPRGitHubState(
 	if input.Body.State == "draft" {
 		requiredCapability = capabilityDraftMutation
 	}
-	repo, err := s.requireRepoRouteCapability(
+	repo, release, err := s.leaseRepoRouteCapability(
 		ctx,
 		input.Provider, input.PlatformHost, input.Owner, input.Name,
 		requiredCapability,
@@ -1931,6 +1959,7 @@ func (s *Handler) setPRGitHubState(
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 	if err := s.requireSyncerCapability(*repo, requiredCapability); err != nil {
 		return nil, err
 	}
@@ -2010,6 +2039,11 @@ func (s *Handler) setPRGitHubState(
 							string(repoProviderKind(*repo)), repoProviderHost(*repo),
 						)
 					}
+					// CommitMergeRequestParentSnapshot owns its reconciliation
+					// read lease. Drop the mutation lease before entering it: a
+					// queued writer closes read admission, so recursively taking
+					// another read lease here would deadlock behind that writer.
+					release()
 					_, _, _, _ = s.syncer.CommitMergeRequestParentSnapshot(
 						ctx, mergeRequestRepoRef(*repo), normalized,
 					)
@@ -2066,12 +2100,14 @@ func (s *Handler) getCommits(ctx context.Context, input *repoNumberInput) (*getC
 		return nil, httpapi.ServiceUnavailable("commits not available: clone manager not configured")
 	}
 
-	repo, err := s.lookupRepoByProviderRoute(
+	leaseCtx, repo, release, err := s.leaseRepoByProviderRoute(
 		ctx, input.Provider, input.PlatformHost, input.Owner, input.Name,
 	)
 	if err != nil {
-		return nil, providerRouteLookupError(err)
+		return nil, err
 	}
+	defer release()
+	ctx = leaseCtx
 	shas, err := s.db.GetDiffSHAsByRepoID(ctx, repo.ID, input.Number)
 	if err != nil {
 		return nil, httpapi.Internal("failed to look up PR")
@@ -2083,10 +2119,8 @@ func (s *Handler) getCommits(ctx context.Context, input *repoNumberInput) (*getC
 		return nil, httpapi.NotFound(httpapi.CodeNotFound, "commits not available for this pull request", nil)
 	}
 
-	host := repoProviderHost(*repo)
-	commits, err := s.clones.ListCommits(
-		ctx, string(repoProviderKind(*repo)), host, repo.Owner, repo.Name,
-		shas.MergeBaseSHA, shas.DiffHeadSHA,
+	commits, err := s.repositoryClone(*repo).ListCommits(
+		ctx, shas.MergeBaseSHA, shas.DiffHeadSHA,
 	)
 	if err != nil {
 		if errors.Is(err, gitclone.ErrNotFound) {
@@ -2127,6 +2161,7 @@ type getDiffInput struct {
 type getDiffOutput = httpapi.BodyOutput[diffResponse]
 
 type resolvedDiffRange struct {
+	repoID   int64
 	platform string
 	host     string
 	owner    string
@@ -2139,13 +2174,8 @@ type resolvedDiffRange struct {
 func (s *Handler) resolveDiffRange(
 	ctx context.Context,
 	input *getDiffInput,
+	repo db.Repo,
 ) (*resolvedDiffRange, error) {
-	repo, err := s.lookupRepoByProviderRoute(
-		ctx, input.Provider, input.PlatformHost, input.Owner, input.Name,
-	)
-	if err != nil {
-		return nil, providerRouteLookupError(err)
-	}
 	shas, err := s.db.GetDiffSHAsByRepoID(ctx, repo.ID, input.Number)
 	if err != nil {
 		return nil, httpapi.Internal("failed to look up PR")
@@ -2157,7 +2187,7 @@ func (s *Handler) resolveDiffRange(
 		return nil, httpapi.NotFound(httpapi.CodeNotFound, "diff not available for this pull request", nil)
 	}
 
-	host := repoProviderHost(*repo)
+	host := repoProviderHost(repo)
 	diffFrom := shas.MergeBaseSHA
 	diffTo := shas.DiffHeadSHA
 
@@ -2171,13 +2201,11 @@ func (s *Handler) resolveDiffRange(
 
 	case hasCommit && !hasFrom && !hasTo:
 		if _, err := s.validateSHAs(
-			ctx, string(repoProviderKind(*repo)), host, input, shas, input.Commit,
+			ctx, repo, shas, input.Commit,
 		); err != nil {
 			return nil, err
 		}
-		parent, err := s.clones.ParentOf(
-			ctx, string(repoProviderKind(*repo)), host, repo.Owner, repo.Name, input.Commit,
-		)
+		parent, err := s.repositoryClone(repo).ParentOf(ctx, input.Commit)
 		if err != nil {
 			return nil, httpapi.Internal("failed to resolve parent: " + err.Error())
 		}
@@ -2186,7 +2214,7 @@ func (s *Handler) resolveDiffRange(
 
 	case !hasCommit && hasFrom && hasTo:
 		indexMap, err := s.validateSHAs(
-			ctx, string(repoProviderKind(*repo)), host, input, shas,
+			ctx, repo, shas,
 			input.From, input.To,
 		)
 		if err != nil {
@@ -2196,9 +2224,7 @@ func (s *Handler) resolveDiffRange(
 		if indexMap[input.From] <= indexMap[input.To] {
 			return nil, httpapi.Validation("query", "invalid range: 'from' must be older than 'to'")
 		}
-		parent, err := s.clones.ParentOf(
-			ctx, string(repoProviderKind(*repo)), host, repo.Owner, repo.Name, input.From,
-		)
+		parent, err := s.repositoryClone(repo).ParentOf(ctx, input.From)
 		if err != nil {
 			return nil, httpapi.Internal("failed to resolve parent: " + err.Error())
 		}
@@ -2210,7 +2236,8 @@ func (s *Handler) resolveDiffRange(
 	}
 
 	return &resolvedDiffRange{
-		platform: string(repoProviderKind(*repo)),
+		repoID:   repo.ID,
+		platform: string(repoProviderKind(repo)),
 		host:     host,
 		owner:    repo.Owner,
 		name:     repo.Name,
@@ -2224,15 +2251,29 @@ func (s *Handler) getDiff(ctx context.Context, input *getDiffInput) (*getDiffOut
 	if s.clones == nil {
 		return nil, httpapi.ServiceUnavailable("diff view not available: clone manager not configured")
 	}
+	leaseCtx, repo, release, err := s.leaseRepoByProviderRoute(
+		ctx, input.Provider, input.PlatformHost, input.Owner, input.Name,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+	ctx = leaseCtx
 
-	resolved, err := s.resolveDiffRange(ctx, input)
+	resolved, err := s.resolveDiffRange(ctx, input, *repo)
 	if err != nil {
 		return nil, err
 	}
 
 	hideWhitespace := input.Whitespace == "hide"
-	result, err := s.clones.Diff(
-		ctx, resolved.platform, resolved.host, resolved.owner, resolved.name,
+	result, err := s.clones.RepositoryClone(
+		resolved.repoID,
+		resolved.platform,
+		resolved.host,
+		resolved.owner,
+		resolved.name,
+	).Diff(
+		ctx,
 		resolved.fromSHA, resolved.toSHA, hideWhitespace,
 	)
 	if err != nil {
@@ -2281,6 +2322,14 @@ func (s *Handler) getFilePreview(ctx context.Context, input *getFilePreviewInput
 	if side != "" && side != "old" && side != "new" {
 		return nil, httpapi.Validation("query.side", "side must be old or new")
 	}
+	leaseCtx, repo, release, err := s.leaseRepoByProviderRoute(
+		ctx, input.Provider, input.PlatformHost, input.Owner, input.Name,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+	ctx = leaseCtx
 
 	resolved, err := s.resolveDiffRange(ctx, &getDiffInput{
 		Provider:     input.Provider,
@@ -2291,19 +2340,21 @@ func (s *Handler) getFilePreview(ctx context.Context, input *getFilePreviewInput
 		Commit:       input.Commit,
 		From:         input.From,
 		To:           input.To,
-	})
+	}, *repo)
 	if err != nil {
 		return nil, err
 	}
 
 	previewRef := resolved.toSHA
 	previewPath := input.Path
-	files, err := s.clones.DiffFiles(
-		ctx,
+	files, err := s.clones.RepositoryClone(
+		resolved.repoID,
 		resolved.platform,
 		resolved.host,
 		resolved.owner,
 		resolved.name,
+	).DiffFiles(
+		ctx,
 		resolved.fromSHA,
 		resolved.toSHA,
 	)
@@ -2348,12 +2399,14 @@ func (s *Handler) getFilePreview(ctx context.Context, input *getFilePreviewInput
 		return nil, httpapi.NotFound(httpapi.CodeNotFound, "file preview not available: file is not changed in this diff", nil)
 	}
 
-	content, err := s.clones.FileContent(
-		ctx,
+	content, err := s.clones.RepositoryClone(
+		resolved.repoID,
 		resolved.platform,
 		resolved.host,
 		resolved.owner,
 		resolved.name,
+	).FileContent(
+		ctx,
 		previewRef,
 		previewPath,
 		maxFilePreviewBytes,
@@ -2416,12 +2469,14 @@ func (s *Handler) getFiles(ctx context.Context, input *getFilesInput) (*getFiles
 		return nil, httpapi.ServiceUnavailable("files view not available: clone manager not configured")
 	}
 
-	repo, err := s.lookupRepoByProviderRoute(
+	leaseCtx, repo, release, err := s.leaseRepoByProviderRoute(
 		ctx, input.Provider, input.PlatformHost, input.Owner, input.Name,
 	)
 	if err != nil {
-		return nil, providerRouteLookupError(err)
+		return nil, err
 	}
+	defer release()
+	ctx = leaseCtx
 	shas, err := s.db.GetDiffSHAsByRepoID(ctx, repo.ID, input.Number)
 	if err != nil {
 		return nil, httpapi.Internal("failed to look up PR")
@@ -2433,9 +2488,8 @@ func (s *Handler) getFiles(ctx context.Context, input *getFilesInput) (*getFiles
 		return nil, httpapi.NotFound(httpapi.CodeNotFound, "file list not available for this pull request", nil)
 	}
 
-	host := repoProviderHost(*repo)
-	files, err := s.clones.DiffFiles(
-		ctx, string(repoProviderKind(*repo)), host, repo.Owner, repo.Name,
+	files, err := s.repositoryClone(*repo).DiffFiles(
+		ctx,
 		shas.MergeBaseSHA, shas.DiffHeadSHA,
 	)
 	if err != nil {
@@ -2456,13 +2510,12 @@ func (s *Handler) getFiles(ctx context.Context, input *getFilesInput) (*getFiles
 // Returns a SHA -> index map (newest-first order) so callers can check range ordering.
 func (s *Handler) validateSHAs(
 	ctx context.Context,
-	platformName, host string,
-	input *getDiffInput,
+	repo db.Repo,
 	shas *db.DiffSHAs,
 	userSHAs ...string,
 ) (map[string]int, error) {
-	commits, err := s.clones.ListCommits(
-		ctx, platformName, host, input.Owner, input.Name,
+	commits, err := s.repositoryClone(repo).ListCommits(
+		ctx,
 		shas.MergeBaseSHA, shas.DiffHeadSHA,
 	)
 	if err != nil {

--- a/internal/server/repo_import_handlers.go
+++ b/internal/server/repo_import_handlers.go
@@ -548,7 +548,12 @@ func (s *Server) applyBulkExactRepos(
 	resolved []resolvedBulkRepo,
 ) (settingsResponse, error) {
 	s.configReloadMu.Lock()
-	defer s.configReloadMu.Unlock()
+	configLocked := true
+	defer func() {
+		if configLocked {
+			s.configReloadMu.Unlock()
+		}
+	}()
 
 	s.cfgMu.Lock()
 	existing := exactConfiguredRepoSet(s.cfg.Repos)
@@ -588,14 +593,15 @@ func (s *Server) applyBulkExactRepos(
 			"save config: " + err.Error(),
 		)}
 	}
-	if err := s.persistResolvedRepos(ctx, addRefs); err != nil {
-		s.cfg.Repos = prev
-		s.cfgMu.Unlock()
-		return settingsResponse{}, &bulkApplyError{problem: httpapi.Internal(err.Error())}
-	}
-	s.mergeTrackedRepos(addRefs)
+	configured := slices.Clone(s.cfg.Repos)
 	s.applyWorkspaceConfigLocked()
 	s.cfgMu.Unlock()
+	s.configReloadMu.Unlock()
+	configLocked = false
+	previous := append(s.syncer.TrackedRepos(), addRefs...)
+	if err := s.replaceTrackedReposFromConfig(ctx, configured, previous); err != nil {
+		return settingsResponse{}, &bulkApplyError{problem: httpapi.Internal(err.Error())}
+	}
 
 	return s.buildLocalSettingsResponse(), nil
 }

--- a/internal/server/repo_import_handlers.go
+++ b/internal/server/repo_import_handlers.go
@@ -547,6 +547,9 @@ func (s *Server) applyBulkExactRepos(
 	ctx context.Context,
 	resolved []resolvedBulkRepo,
 ) (settingsResponse, error) {
+	s.configReloadMu.Lock()
+	defer s.configReloadMu.Unlock()
+
 	s.cfgMu.Lock()
 	existing := exactConfiguredRepoSet(s.cfg.Repos)
 	addConfigs := make([]config.Repo, 0, len(resolved))

--- a/internal/server/repobrowserapi/handler.go
+++ b/internal/server/repobrowserapi/handler.go
@@ -212,10 +212,11 @@ func (h *Handler) listRepoBrowserRefsFor(
 	ctx context.Context,
 	provider, platformHost, owner, name, repoPath string,
 ) (*httpapi.BodyOutput[RepoBrowserRefsResponse], error) {
-	repo, repoRef, err := h.ensureRepoBrowserClone(ctx, provider, platformHost, owner, name, repoPath)
+	repo, repoRef, release, err := h.ensureRepoBrowserClone(ctx, provider, platformHost, owner, name, repoPath)
 	if err != nil {
 		return nil, repoBrowserProblem(err)
 	}
+	defer release()
 	refs, defaultRef, truncated, err := h.clones.ListRepoBrowserRefs(ctx, repoRef, repo.DefaultBranch)
 	if err != nil {
 		return nil, repoBrowserProblem(err)
@@ -247,10 +248,11 @@ func (h *Handler) listRepoBrowserTreeFor(
 	provider, platformHost, owner, name, repoPath string,
 	ref gitclone.RepoBrowserRef,
 ) (*httpapi.BodyOutput[RepoBrowserTreeResponse], error) {
-	repo, repoRef, err := h.ensureRepoBrowserClone(ctx, provider, platformHost, owner, name, repoPath)
+	repo, repoRef, release, err := h.ensureRepoBrowserClone(ctx, provider, platformHost, owner, name, repoPath)
 	if err != nil {
 		return nil, repoBrowserProblem(err)
 	}
+	defer release()
 	resolvedRef, err := h.resolveRepoBrowserReadRef(ctx, repoRef, ref)
 	if err != nil {
 		return nil, repoBrowserProblem(err)
@@ -287,10 +289,11 @@ func (h *Handler) getRepoBrowserBlobFor(
 	ref gitclone.RepoBrowserRef,
 	path string,
 ) (*httpapi.BodyOutput[RepoBrowserBlobResponse], error) {
-	repo, repoRef, err := h.ensureRepoBrowserClone(ctx, provider, platformHost, owner, name, repoPath)
+	repo, repoRef, release, err := h.ensureRepoBrowserClone(ctx, provider, platformHost, owner, name, repoPath)
 	if err != nil {
 		return nil, repoBrowserProblem(err)
 	}
+	defer release()
 	resolvedRef, err := h.resolveRepoBrowserReadRef(ctx, repoRef, ref)
 	if err != nil {
 		return nil, repoBrowserProblem(err)
@@ -329,10 +332,11 @@ func (h *Handler) getRepoBrowserAssetFor(
 	if !repoBrowserAssetRefIsImmutable(ref) {
 		return nil, repoBrowserProblem(errRepoBrowserMutableAssetRef)
 	}
-	_, repoRef, err := h.ensureRepoBrowserClone(ctx, provider, platformHost, owner, name, repoPath)
+	_, repoRef, release, err := h.ensureRepoBrowserClone(ctx, provider, platformHost, owner, name, repoPath)
 	if err != nil {
 		return nil, repoBrowserProblem(err)
 	}
+	defer release()
 	resolvedRef, err := h.resolveRepoBrowserReadRef(ctx, repoRef, ref)
 	if err != nil {
 		return nil, repoBrowserProblem(err)
@@ -389,10 +393,11 @@ func (h *Handler) getRepoBrowserLastChangedFor(
 	ref gitclone.RepoBrowserRef,
 	paths []string,
 ) (*httpapi.BodyOutput[RepoBrowserLastChangedResponse], error) {
-	repo, repoRef, err := h.ensureRepoBrowserClone(ctx, provider, platformHost, owner, name, repoPath)
+	repo, repoRef, release, err := h.ensureRepoBrowserClone(ctx, provider, platformHost, owner, name, repoPath)
 	if err != nil {
 		return nil, repoBrowserProblem(err)
 	}
+	defer release()
 	resolvedRef, err := h.resolveRepoBrowserReadRef(ctx, repoRef, ref)
 	if err != nil {
 		return nil, repoBrowserProblem(err)
@@ -428,10 +433,11 @@ func (h *Handler) getRepoBrowserHistoryFor(
 	ref gitclone.RepoBrowserRef,
 	path string,
 ) (*httpapi.BodyOutput[RepoBrowserHistoryResponse], error) {
-	repo, repoRef, err := h.ensureRepoBrowserClone(ctx, provider, platformHost, owner, name, repoPath)
+	repo, repoRef, release, err := h.ensureRepoBrowserClone(ctx, provider, platformHost, owner, name, repoPath)
 	if err != nil {
 		return nil, repoBrowserProblem(err)
 	}
+	defer release()
 	resolvedRef, err := h.resolveRepoBrowserReadRef(ctx, repoRef, ref)
 	if err != nil {
 		return nil, repoBrowserProblem(err)
@@ -468,10 +474,11 @@ func (h *Handler) getRepoBrowserCommitFor(
 	ref gitclone.RepoBrowserRef,
 	path, sha string,
 ) (*httpapi.BodyOutput[RepoBrowserCommitResponse], error) {
-	repo, repoRef, err := h.ensureRepoBrowserClone(ctx, provider, platformHost, owner, name, repoPath)
+	repo, repoRef, release, err := h.ensureRepoBrowserClone(ctx, provider, platformHost, owner, name, repoPath)
 	if err != nil {
 		return nil, repoBrowserProblem(err)
 	}
+	defer release()
 	resolvedRef, err := h.resolveRepoBrowserReadRef(ctx, repoRef, ref)
 	if err != nil {
 		return nil, repoBrowserProblem(err)
@@ -491,22 +498,31 @@ func (h *Handler) getRepoBrowserCommitFor(
 func (h *Handler) ensureRepoBrowserClone(
 	ctx context.Context,
 	provider, platformHost, owner, name, repoPath string,
-) (*db.Repo, gitclone.RepoBrowserRepoRef, error) {
+) (*db.Repo, gitclone.RepoBrowserRepoRef, func(), error) {
 	if h.clones == nil {
-		return nil, gitclone.RepoBrowserRepoRef{}, errRepoBrowserCloneUnavailable
+		return nil, gitclone.RepoBrowserRepoRef{}, nil, errRepoBrowserCloneUnavailable
 	}
 	if h.resolver == nil {
-		return nil, gitclone.RepoBrowserRepoRef{}, httpapi.ErrRepositoryStoreUnavailable
+		return nil, gitclone.RepoBrowserRepoRef{}, nil, httpapi.ErrRepositoryStoreUnavailable
 	}
 	repoPath = canonicalRepoBrowserRepoPath(owner, name, repoPath)
 	repo, err := h.resolver.Lookup(ctx, provider, platformHost, repoPath)
 	if err != nil {
-		return nil, gitclone.RepoBrowserRepoRef{}, err
+		return nil, gitclone.RepoBrowserRepoRef{}, nil, err
+	}
+	repo, release, err := h.resolver.LeaseActiveRepository(ctx, repo.ID)
+	if err != nil {
+		return nil, gitclone.RepoBrowserRepoRef{}, nil, err
+	}
+	if repo == nil {
+		return nil, gitclone.RepoBrowserRepoRef{}, nil, httpapi.ErrRepoNotFound
 	}
 	if strings.TrimSpace(repo.CloneURL) == "" {
-		return nil, gitclone.RepoBrowserRepoRef{}, errRepoBrowserCloneUnavailable
+		release()
+		return nil, gitclone.RepoBrowserRepoRef{}, nil, errRepoBrowserCloneUnavailable
 	}
 	repoRef := gitclone.RepoBrowserRepoRef{
+		RepoID:    repo.ID,
 		Provider:  repo.Platform,
 		Host:      repo.PlatformHost,
 		Owner:     repo.Owner,
@@ -515,9 +531,10 @@ func (h *Handler) ensureRepoBrowserClone(
 		RemoteURL: repo.CloneURL,
 	}
 	if err := h.clones.EnsureRepoBrowserClone(ctx, repoRef); err != nil {
-		return nil, gitclone.RepoBrowserRepoRef{}, err
+		release()
+		return nil, gitclone.RepoBrowserRepoRef{}, nil, err
 	}
-	return repo, repoRef, nil
+	return repo, repoRef, release, nil
 }
 
 func (h *Handler) repoRefFromRepo(repo db.Repo) httpapi.RepoRefResponse {

--- a/internal/server/repobrowserapi/handler_test.go
+++ b/internal/server/repobrowserapi/handler_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/config"
 	"go.kenn.io/forge/internal/db"
 	"go.kenn.io/forge/internal/gitclone"
 	ghclient "go.kenn.io/forge/internal/github"
@@ -263,7 +264,15 @@ func TestRepoBrowserReadsStayPinnedAfterBranchAdvances(t *testing.T) {
 	)
 	advancedSHA := testGitSHA(t, work, "HEAD")
 	serverRepoBrowserGit(t, work, "push", "origin", "main")
-	clones.RefreshRepoBrowserClones(t.Context())
+	clones.RefreshRepoBrowserClones(
+		t.Context(),
+		func(
+			_ context.Context,
+			repo gitclone.RepoBrowserRepoRef,
+		) (gitclone.RepoBrowserRepoRef, func(), bool, error) {
+			return repo, func() {}, true, nil
+		},
+	)
 
 	branchBlob := repoBrowserRequest(t, srv, http.MethodGet,
 		"/api/v1/repo/github/acme/widgets/browser/blob?repo_path=acme%2Fwidgets&ref_type=branch&ref_name=main&path=README.md",
@@ -685,6 +694,169 @@ func TestRepoBrowserStartupRefreshSeedsExistingClone(t *testing.T) {
 	assert.Equal("# Updated\n", body.Blob.Content)
 }
 
+func TestRepoBrowserRefreshRouteReplacementKeepsRetiredClonePinnedThroughHTTP(
+	t *testing.T,
+) {
+	acquireRepoBrowserTestSlot(t)
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	database := dbtest.Open(t)
+	remote, oldWork := setupServerRepoBrowserGitRepo(t)
+	oldSHA := testGitSHA(t, oldWork, "main")
+	oldRepoID, err := database.UpsertRepoByProviderID(
+		ctx,
+		db.RepoIdentity{
+			Platform:       "github",
+			PlatformHost:   "github.com",
+			PlatformRepoID: "R_old",
+			Owner:          "acme",
+			Name:           "widgets",
+			RepoPath:       "acme/widgets",
+		},
+	)
+	require.NoError(err)
+	require.NoError(database.UpdateRepoProviderMetadata(
+		ctx,
+		oldRepoID,
+		db.RepoProviderMetadata{
+			WebURL:        "https://github.com/acme/widgets",
+			CloneURL:      remote,
+			DefaultBranch: "main",
+		},
+	))
+
+	clones := gitclone.New(filepath.Join(t.TempDir(), "clones"), nil)
+	syncer := ghclient.NewSyncer(
+		nil,
+		database,
+		nil,
+		nil,
+		time.Minute,
+		nil,
+		nil,
+	)
+	t.Cleanup(syncer.Stop)
+	srv := server.New(
+		database,
+		syncer,
+		nil,
+		"/",
+		&config.Config{SyncInterval: "20ms"},
+		server.ServerOptions{
+			Clones: clones,
+			HostCheck: server.HostCheckOptions{
+				Bind: config.HostKey{Host: "127.0.0.1", Port: "8091"},
+				Allowed: []config.HostKey{
+					{Host: "example.com"},
+				},
+			},
+		},
+	)
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(
+			context.Background(),
+			5*time.Second,
+		)
+		defer cancel()
+		require.NoError(srv.Shutdown(shutdownCtx))
+	})
+
+	oldResponse := repoBrowserRequest(
+		t,
+		srv,
+		http.MethodGet,
+		"/api/v1/repo/github/acme/widgets/browser/refs",
+	)
+	require.Equal(http.StatusOK, oldResponse.Code, oldResponse.Body.String())
+	var oldBody repobrowserapi.RepoBrowserRefsResponse
+	require.NoError(json.Unmarshal(oldResponse.Body.Bytes(), &oldBody))
+	require.Equal(oldSHA, oldBody.DefaultRef.SHA)
+
+	replacementRepoID, err := database.UpsertRepoByProviderID(
+		ctx,
+		db.RepoIdentity{
+			Platform:       "github",
+			PlatformHost:   "github.com",
+			PlatformRepoID: "R_new",
+			Owner:          "acme",
+			Name:           "widgets",
+			RepoPath:       "acme/widgets",
+		},
+	)
+	require.NoError(err)
+	require.NotEqual(oldRepoID, replacementRepoID)
+
+	replacementRemote, replacementWork := setupServerRepoBrowserGitRepo(t)
+	require.NoError(os.WriteFile(
+		filepath.Join(replacementWork, "README.md"),
+		[]byte("# Replacement\n"),
+		0o644,
+	))
+	serverRepoBrowserGit(t, replacementWork, "add", ".")
+	serverRepoBrowserGit(t, replacementWork, "commit", "-m", "replacement")
+	serverRepoBrowserGit(t, replacementWork, "push", "origin", "main")
+	replacementSHA := testGitSHA(t, replacementWork, "main")
+	require.NotEqual(oldSHA, replacementSHA)
+	require.NoError(os.Rename(remote, remote+".retired"))
+	require.NoError(os.Rename(replacementRemote, remote))
+	require.NoError(database.UpdateRepoProviderMetadata(
+		ctx,
+		replacementRepoID,
+		db.RepoProviderMetadata{
+			WebURL:        "https://github.com/acme/widgets",
+			CloneURL:      remote,
+			DefaultBranch: "main",
+		},
+	))
+
+	newResponse := repoBrowserRequest(
+		t,
+		srv,
+		http.MethodGet,
+		"/api/v1/repo/github/acme/widgets/browser/refs",
+	)
+	require.Equal(http.StatusOK, newResponse.Code, newResponse.Body.String())
+	var newBody repobrowserapi.RepoBrowserRefsResponse
+	require.NoError(json.Unmarshal(newResponse.Body.Bytes(), &newBody))
+	require.Equal(replacementSHA, newBody.DefaultRef.SHA)
+
+	oldRef := gitclone.RepoBrowserRepoRef{
+		RepoID:    oldRepoID,
+		Provider:  "github",
+		Host:      "github.com",
+		Owner:     "acme",
+		Name:      "widgets",
+		RepoPath:  "acme/widgets",
+		RemoteURL: remote,
+	}
+	require.Never(
+		func() bool {
+			resolved, resolveErr := clones.ResolveRepoBrowserRef(
+				ctx,
+				oldRef,
+				gitclone.RepoBrowserRef{
+					Type: gitclone.RepoBrowserRefBranch,
+					Name: "main",
+				},
+			)
+			return resolveErr == nil && resolved.SHA == replacementSHA
+		},
+		150*time.Millisecond,
+		10*time.Millisecond,
+	)
+	resolved, err := clones.ResolveRepoBrowserRef(
+		ctx,
+		oldRef,
+		gitclone.RepoBrowserRef{
+			Type: gitclone.RepoBrowserRefBranch,
+			Name: "main",
+		},
+	)
+	require.NoError(err)
+	assert.Equal(oldSHA, resolved.SHA)
+}
+
 func TestRepoBrowserStartupRefreshHonorsDisabledBackgroundMonitors(t *testing.T) {
 	acquireRepoBrowserTestSlot(t)
 	require := require.New(t)
@@ -732,6 +904,7 @@ func TestRepoBrowserStartupRefreshHonorsDisabledBackgroundMonitors(t *testing.T)
 
 	require.Never(func() bool {
 		resolved, err := disabledClones.ResolveRepoBrowserRef(t.Context(), gitclone.RepoBrowserRepoRef{
+			RepoID:    repoID,
 			Provider:  "github",
 			Host:      "github.com",
 			Owner:     "acme",

--- a/internal/server/repobrowserapi/refresh.go
+++ b/internal/server/repobrowserapi/refresh.go
@@ -48,45 +48,87 @@ func (h *Handler) SeedRefreshRepos(ctx context.Context) {
 	if h.clones == nil || h.resolver == nil {
 		return
 	}
-	repos, err := h.resolver.List(ctx)
+	repos, err := h.repoBrowserRefreshRepos(ctx)
 	if err != nil {
 		slog.Warn("failed to seed repo browser refresh repos", "err", err)
 		return
 	}
 	for _, repo := range repos {
-		if strings.TrimSpace(repo.CloneURL) == "" {
-			continue
-		}
-		repoRef := gitclone.RepoBrowserRepoRef{
-			Provider:  repo.Platform,
-			Host:      repo.PlatformHost,
-			Owner:     repo.Owner,
-			Name:      repo.Name,
-			RepoPath:  repo.RepoPath,
-			RemoteURL: repo.CloneURL,
-		}
-		registered, err := h.clones.RegisterExistingRepoBrowserClone(ctx, repoRef)
+		registered, err := h.clones.RegisterExistingRepoBrowserClone(ctx, repo)
 		if err != nil {
 			slog.Warn("failed to seed repo browser refresh repo",
-				"provider", repo.Platform,
-				"host", repo.PlatformHost,
+				"provider", repo.Provider,
+				"host", repo.Host,
 				"repo", repo.RepoPath,
 				"err", err)
 			continue
 		}
 		if registered {
 			slog.Debug("seeded repo browser refresh repo",
-				"provider", repo.Platform,
-				"host", repo.PlatformHost,
+				"provider", repo.Provider,
+				"host", repo.Host,
 				"repo", repo.RepoPath)
 		}
 	}
 }
 
 func (h *Handler) runRefreshPass(ctx context.Context) {
-	if h.clones == nil {
+	if h.clones == nil || h.resolver == nil {
 		return
 	}
 	slog.Debug("refreshing repo browser clones")
-	h.clones.RefreshRepoBrowserClones(ctx)
+	h.clones.RefreshRepoBrowserClones(ctx, h.authorizeRepoBrowserRefresh)
+}
+
+func (h *Handler) authorizeRepoBrowserRefresh(
+	ctx context.Context,
+	registered gitclone.RepoBrowserRepoRef,
+) (gitclone.RepoBrowserRepoRef, func(), bool, error) {
+	repo, release, err := h.resolver.LeaseActiveRepository(
+		ctx,
+		registered.RepoID,
+	)
+	if err != nil {
+		return gitclone.RepoBrowserRepoRef{}, nil, false, err
+	}
+	if repo == nil || strings.TrimSpace(repo.CloneURL) == "" {
+		if release != nil {
+			release()
+		}
+		return gitclone.RepoBrowserRepoRef{}, nil, false, nil
+	}
+	return gitclone.RepoBrowserRepoRef{
+		RepoID:    repo.ID,
+		Provider:  repo.Platform,
+		Host:      repo.PlatformHost,
+		Owner:     repo.Owner,
+		Name:      repo.Name,
+		RepoPath:  repo.RepoPath,
+		RemoteURL: repo.CloneURL,
+	}, release, true, nil
+}
+
+func (h *Handler) repoBrowserRefreshRepos(
+	ctx context.Context,
+) ([]gitclone.RepoBrowserRepoRef, error) {
+	repos, err := h.resolver.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	refs := make([]gitclone.RepoBrowserRepoRef, 0, len(repos))
+	for _, repo := range repos {
+		if strings.TrimSpace(repo.CloneURL) == "" {
+			continue
+		}
+		refs = append(refs, gitclone.RepoBrowserRepoRef{
+			RepoID:    repo.ID,
+			Provider:  repo.Platform,
+			Host:      repo.PlatformHost,
+			Owner:     repo.Owner,
+			Name:      repo.Name,
+			RepoPath:  repo.RepoPath,
+			RemoteURL: repo.CloneURL,
+		})
+	}
+	return refs, nil
 }

--- a/internal/server/repobrowserapi/refresh_internal_test.go
+++ b/internal/server/repobrowserapi/refresh_internal_test.go
@@ -1,0 +1,188 @@
+package repobrowserapi
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/db"
+	"go.kenn.io/forge/internal/gitclone"
+	"go.kenn.io/forge/internal/server/httpapi"
+	"go.kenn.io/forge/internal/testutil/dbtest"
+	gitcmd "go.kenn.io/kit/git/cmd"
+)
+
+func TestRepoBrowserRefreshDropsRetiredRouteBeforeFetch(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	database := dbtest.Open(t)
+	routeRoot := t.TempDir()
+	remote := filepath.Join(routeRoot, "remote.git")
+	oldWork := createRefreshTestRepository(t, remote, "old content\n")
+	oldSHA := refreshTestGitSHA(t, oldWork, "main")
+
+	identity := db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "stable-old",
+		Owner:          "acme",
+		Name:           "widgets",
+		RepoPath:       "acme/widgets",
+	}
+	oldID, err := database.UpsertRepoByProviderID(ctx, identity)
+	require.NoError(err)
+	require.NoError(database.UpdateRepoProviderMetadata(ctx, oldID, db.RepoProviderMetadata{
+		CloneURL:      remote,
+		DefaultBranch: "main",
+	}))
+
+	clones := gitclone.New(filepath.Join(t.TempDir(), "clones"), nil)
+	oldRef := gitclone.RepoBrowserRepoRef{
+		RepoID:    oldID,
+		Provider:  identity.Platform,
+		Host:      identity.PlatformHost,
+		Owner:     identity.Owner,
+		Name:      identity.Name,
+		RepoPath:  identity.RepoPath,
+		RemoteURL: remote,
+	}
+	require.NoError(clones.EnsureRepoBrowserClone(ctx, oldRef))
+
+	retiredRemote := filepath.Join(routeRoot, "retired.git")
+	require.NoError(os.Rename(remote, retiredRemote))
+	replacementWork := createRefreshTestRepository(t, remote, "replacement content\n")
+	replacementSHA := refreshTestGitSHA(t, replacementWork, "main")
+	require.NotEqual(oldSHA, replacementSHA)
+
+	identity.PlatformRepoID = "stable-replacement"
+	replacementID, err := database.UpsertRepoByProviderID(ctx, identity)
+	require.NoError(err)
+	require.NotEqual(oldID, replacementID)
+	require.NoError(database.UpdateRepoProviderMetadata(
+		ctx,
+		replacementID,
+		db.RepoProviderMetadata{
+			CloneURL:      remote,
+			DefaultBranch: "main",
+		},
+	))
+
+	handler := New(Deps{
+		Resolver: httpapi.NewRepositoryResolver(httpapi.RepositoryResolverDeps{
+			DB: database,
+		}),
+		Clones: clones,
+	})
+	handler.runRefreshPass(ctx)
+
+	resolved, err := clones.ResolveRepoBrowserRef(ctx, oldRef, gitclone.RepoBrowserRef{
+		Type: gitclone.RepoBrowserRefBranch,
+		Name: "main",
+	})
+	require.NoError(err)
+	require.Equal(oldSHA, resolved.SHA)
+}
+
+func TestRequestRepoBrowserLeaseBlocksRepositoryReplacement(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	database := dbtest.Open(t)
+	remote := filepath.Join(t.TempDir(), "remote.git")
+	createRefreshTestRepository(t, remote, "old content\n")
+	identity := db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "stable-old",
+		Owner:          "acme",
+		Name:           "widgets",
+		RepoPath:       "acme/widgets",
+	}
+	repoID, err := database.UpsertRepoByProviderID(ctx, identity)
+	require.NoError(err)
+	require.NoError(database.UpdateRepoProviderMetadata(
+		ctx,
+		repoID,
+		db.RepoProviderMetadata{CloneURL: remote, DefaultBranch: "main"},
+	))
+	handler := New(Deps{
+		Resolver: httpapi.NewRepositoryResolver(httpapi.RepositoryResolverDeps{
+			DB: database,
+		}),
+		Clones: gitclone.New(filepath.Join(t.TempDir(), "clones"), nil),
+	})
+
+	_, _, release, err := handler.ensureRepoBrowserClone(
+		ctx,
+		identity.Platform,
+		identity.PlatformHost,
+		identity.Owner,
+		identity.Name,
+		identity.RepoPath,
+	)
+	require.NoError(err)
+
+	writeAttempted := make(chan struct{})
+	restore := database.SetBeforeRepositoryReconciliationWriteLockForTest(
+		func() { close(writeAttempted) },
+	)
+	defer restore()
+	replacementDone := make(chan error, 1)
+	go func() {
+		identity.PlatformRepoID = "stable-replacement"
+		_, replacementErr := database.UpsertRepoByProviderID(ctx, identity)
+		replacementDone <- replacementErr
+	}()
+	select {
+	case <-writeAttempted:
+	case <-time.After(2 * time.Second):
+		require.Fail("repository replacement did not queue")
+	}
+	select {
+	case replacementErr := <-replacementDone:
+		require.NoError(replacementErr)
+		require.Fail("repository replacement bypassed request clone lease")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	release()
+	select {
+	case replacementErr := <-replacementDone:
+		require.NoError(replacementErr)
+	case <-time.After(2 * time.Second):
+		require.Fail("repository replacement did not resume")
+	}
+}
+
+func createRefreshTestRepository(t *testing.T, remote, content string) string {
+	t.Helper()
+	root := filepath.Dir(remote)
+	refreshTestGit(t, root, "init", "--bare", "--initial-branch=main", remote)
+	work, err := os.MkdirTemp(root, "work-*")
+	require.NoError(t, err)
+	require.NoError(t, os.Remove(work))
+	refreshTestGit(t, root, "clone", remote, work)
+	refreshTestGit(t, work, "config", "user.email", "alice@example.com")
+	refreshTestGit(t, work, "config", "user.name", "Alice")
+	require.NoError(t, os.WriteFile(filepath.Join(work, "README.md"), []byte(content), 0o644))
+	refreshTestGit(t, work, "add", ".")
+	refreshTestGit(t, work, "commit", "-m", "initial")
+	refreshTestGit(t, work, "push", "origin", "main")
+	return work
+}
+
+func refreshTestGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	runner := gitcmd.New().WithConfig("init.defaultBranch", "main")
+	out, stderr, err := runner.Run(t.Context(), dir, nil, args...)
+	require.NoError(t, err, "git %v failed: %s%s", args, out, stderr)
+}
+
+func refreshTestGitSHA(t *testing.T, dir, ref string) string {
+	t.Helper()
+	out, err := gitcmd.New().Output(t.Context(), dir, "rev-parse", ref)
+	require.NoError(t, err)
+	return strings.TrimSpace(string(out))
+}

--- a/internal/server/settings_handlers.go
+++ b/internal/server/settings_handlers.go
@@ -139,83 +139,6 @@ func matchedRepoCount(
 	return count
 }
 
-// mergeTrackedRepos adds repos to the syncer's tracked set,
-// deduplicating by host/owner/name.
-func (s *Server) mergeTrackedRepos(add []ghclient.RepoRef) {
-	current := s.syncer.TrackedRepos()
-	seen := make(map[string]struct{}, len(current))
-	for _, r := range current {
-		seen[trackedRepoKey(r)] = struct{}{}
-	}
-	for _, r := range add {
-		key := trackedRepoKey(r)
-		if _, ok := seen[key]; ok {
-			continue
-		}
-		seen[key] = struct{}{}
-		current = append(current, r)
-	}
-	s.syncer.SetRepos(current)
-}
-
-// replaceGlobRepos removes repos that only match the refreshed
-// glob entry, preserves repos still matched by other config
-// entries, then adds the newly resolved matches.
-func (s *Server) replaceGlobRepos(
-	raw config.Repo,
-	expanded []ghclient.RepoRef,
-	configured []config.Repo,
-) {
-	current := s.syncer.TrackedRepos()
-	kept := make([]ghclient.RepoRef, 0, len(current))
-	seen := make(map[string]struct{}, len(current)+len(expanded))
-	for _, repo := range current {
-		if repoMatchesConfig(repo, raw) &&
-			!repoMatchesOtherConfig(repo, raw, configured) {
-			continue
-		}
-		appendTrackedRepo(&kept, seen, repo)
-	}
-	for _, repo := range expanded {
-		appendTrackedRepo(&kept, seen, repo)
-	}
-	s.syncer.SetRepos(kept)
-}
-
-// removeConfigRepos keeps only tracked repos that match at
-// least one of the remaining config entries.
-func (s *Server) removeConfigRepos(
-	remaining []config.Repo,
-) {
-	current := s.syncer.TrackedRepos()
-	kept := make([]ghclient.RepoRef, 0, len(current))
-	for _, repo := range current {
-		for _, raw := range remaining {
-			if repoMatchesConfig(repo, raw) {
-				kept = append(kept, repo)
-				break
-			}
-		}
-	}
-	s.syncer.SetRepos(kept)
-}
-
-func repoMatchesOtherConfig(
-	repo ghclient.RepoRef,
-	target config.Repo,
-	configured []config.Repo,
-) bool {
-	for _, raw := range configured {
-		if sameConfiguredRepo(raw, target) {
-			continue
-		}
-		if repoMatchesConfig(repo, raw) {
-			return true
-		}
-	}
-	return false
-}
-
 func sameConfiguredRepo(left, right config.Repo) bool {
 	return strings.EqualFold(left.PlatformOrDefault(), right.PlatformOrDefault()) &&
 		samePlatformHost(
@@ -339,19 +262,6 @@ func trackedRepoPath(repo ghclient.RepoRef) string {
 	return repo.Owner + "/" + repo.Name
 }
 
-func appendTrackedRepo(
-	dst *[]ghclient.RepoRef,
-	seen map[string]struct{},
-	repo ghclient.RepoRef,
-) {
-	key := trackedRepoKey(repo)
-	if _, ok := seen[key]; ok {
-		return
-	}
-	seen[key] = struct{}{}
-	*dst = append(*dst, repo)
-}
-
 func repoProvider(repo ghclient.RepoRef) string {
 	provider := string(repo.Platform)
 	if provider == "" {
@@ -398,6 +308,43 @@ func (s *Server) persistResolvedRepos(
 		}
 	}
 	return nil
+}
+
+func (s *Server) replaceTrackedReposFromConfig(
+	ctx context.Context,
+	configured []config.Repo,
+	previous []ghclient.RepoRef,
+) error {
+	for {
+		resolved, skipped := s.resolveReposForReload(ctx, configured, previous)
+		if len(skipped) > 0 {
+			return fmt.Errorf(
+				"configured repository providers require a daemon restart: %s",
+				strings.Join(skipped, ", "),
+			)
+		}
+
+		s.configReloadMu.Lock()
+		s.cfgMu.Lock()
+		current := slices.Clone(s.cfg.Repos)
+		s.cfgMu.Unlock()
+		if !slices.Equal(current, configured) {
+			s.configReloadMu.Unlock()
+			configured = current
+			previous = append(s.syncer.TrackedRepos(), previous...)
+			continue
+		}
+		if err := s.persistResolvedRepos(ctx, resolved); err != nil {
+			s.configReloadMu.Unlock()
+			return err
+		}
+		if err := s.syncer.SetReposWithContext(ctx, resolved, false); err != nil {
+			s.configReloadMu.Unlock()
+			return fmt.Errorf("replace configured repositories: %w", err)
+		}
+		s.configReloadMu.Unlock()
+		return nil
+	}
 }
 
 func samePlatformHost(left, right string) bool {
@@ -664,13 +611,16 @@ func (s *Server) addConfiguredRepo(
 	if err != nil {
 		return nil, classifyResolveProblem(err)
 	}
+	previous := append(s.syncer.TrackedRepos(), expanded...)
 
 	// Re-acquire lock and apply the addition to current state
 	// so concurrent activity/settings changes are not lost.
+	s.configReloadMu.Lock()
 	s.cfgMu.Lock()
 	for _, rp := range s.cfg.Repos {
 		if sameConfiguredRepo(rp, newRepo) {
 			s.cfgMu.Unlock()
+			s.configReloadMu.Unlock()
 			return nil, httpapi.BadRequest(httpapi.CodeBadRequest,
 				input.Body.Owner+"/"+input.Body.Name+
 					" is already configured", nil)
@@ -680,16 +630,22 @@ func (s *Server) addConfiguredRepo(
 	if err := s.cfg.Validate(); err != nil {
 		s.cfg.Repos = s.cfg.Repos[:len(s.cfg.Repos)-1]
 		s.cfgMu.Unlock()
+		s.configReloadMu.Unlock()
 		return nil, httpapi.BadRequest(httpapi.CodeBadRequest, err.Error(), nil)
 	}
 	if err := s.cfg.Save(s.cfgPath); err != nil {
 		s.cfg.Repos = s.cfg.Repos[:len(s.cfg.Repos)-1]
 		s.cfgMu.Unlock()
+		s.configReloadMu.Unlock()
 		return nil, httpapi.Internal("save config: " + err.Error())
 	}
-	s.mergeTrackedRepos(expanded)
+	configured := slices.Clone(s.cfg.Repos)
 	s.applyWorkspaceConfigLocked()
 	s.cfgMu.Unlock()
+	s.configReloadMu.Unlock()
+	if err := s.replaceTrackedReposFromConfig(ctx, configured, previous); err != nil {
+		return nil, httpapi.Internal("apply configured repositories: " + err.Error())
+	}
 
 	s.syncer.TriggerRun(context.WithoutCancel(ctx))
 	return &settingsOutput{Body: s.buildLocalSettingsResponse()}, nil
@@ -701,7 +657,6 @@ func (s *Server) refreshConfiguredRepo(
 	if s.cfgPath == "" {
 		return nil, httpapi.NotFound(httpapi.CodeSettingsUnavailable, "settings not available", nil)
 	}
-
 	owner := input.Owner
 	name := input.Name
 	provider, err := normalizeRouteProvider(input.Provider)
@@ -744,6 +699,7 @@ func (s *Server) refreshConfiguredRepo(
 	if err != nil {
 		return nil, classifyResolveProblem(err)
 	}
+	previous := append(s.syncer.TrackedRepos(), expanded...)
 
 	// Re-acquire cfgMu and verify the target glob still exists
 	// in the config before applying the resolved matches.
@@ -767,12 +723,10 @@ func (s *Server) refreshConfiguredRepo(
 		return nil, httpapi.NotFound(httpapi.CodeRepoNotFound,
 			owner+"/"+name+" is no longer configured", nil)
 	}
-	if err := s.persistResolvedRepos(ctx, expanded); err != nil {
-		s.cfgMu.Unlock()
-		return nil, httpapi.Internal("persist resolved repos: " + err.Error())
-	}
-	s.replaceGlobRepos(*target, expanded, currentRepos)
 	s.cfgMu.Unlock()
+	if err := s.replaceTrackedReposFromConfig(ctx, currentRepos, previous); err != nil {
+		return nil, httpapi.Internal("apply configured repositories: " + err.Error())
+	}
 
 	s.syncer.TriggerRun(context.WithoutCancel(ctx))
 	return &settingsOutput{Body: s.buildLocalSettingsResponse()}, nil
@@ -881,12 +835,11 @@ func (s *Server) updateConfiguredRepoWorktreeBasePath(
 }
 
 func (s *Server) deleteConfiguredRepo(
-	_ context.Context, input *repoConfigInput,
+	ctx context.Context, input *repoConfigInput,
 ) (*struct{}, error) {
 	if s.cfgPath == "" {
 		return nil, httpapi.NotFound(httpapi.CodeSettingsUnavailable, "settings not available", nil)
 	}
-
 	owner := input.Owner
 	name := input.Name
 	provider, err := normalizeRouteProvider(input.Provider)
@@ -900,6 +853,7 @@ func (s *Server) deleteConfiguredRepo(
 		Name:         name,
 	}
 
+	s.configReloadMu.Lock()
 	s.cfgMu.Lock()
 	idx := -1
 	for i, rp := range s.cfg.Repos {
@@ -913,6 +867,7 @@ func (s *Server) deleteConfiguredRepo(
 	}
 	if idx == -1 {
 		s.cfgMu.Unlock()
+		s.configReloadMu.Unlock()
 		return nil, httpapi.NotFound(httpapi.CodeRepoNotFound,
 			owner+"/"+name+" is not configured", nil)
 	}
@@ -924,11 +879,18 @@ func (s *Server) deleteConfiguredRepo(
 	if err := s.cfg.Save(s.cfgPath); err != nil {
 		s.cfg.Repos = prevRepos
 		s.cfgMu.Unlock()
+		s.configReloadMu.Unlock()
 		return nil, httpapi.Internal("save config: " + err.Error())
 	}
-	s.removeConfigRepos(s.cfg.Repos)
+	configured := slices.Clone(s.cfg.Repos)
 	s.applyWorkspaceConfigLocked()
 	s.cfgMu.Unlock()
+	s.configReloadMu.Unlock()
+	if err := s.replaceTrackedReposFromConfig(
+		ctx, configured, s.syncer.TrackedRepos(),
+	); err != nil {
+		return nil, httpapi.Internal("apply configured repositories: " + err.Error())
+	}
 
 	return nil, nil
 }

--- a/internal/server/settings_handlers.go
+++ b/internal/server/settings_handlers.go
@@ -130,25 +130,9 @@ func (s *Server) buildLocalSettingsResponse() settingsResponse {
 func matchedRepoCount(
 	raw config.Repo, tracked []ghclient.RepoRef,
 ) int {
-	host := raw.PlatformHostOrDefault()
-	provider := raw.PlatformOrDefault()
 	count := 0
 	for _, repo := range tracked {
-		if !strings.EqualFold(repoProvider(repo), provider) ||
-			!samePlatformHost(repo.PlatformHost, host) ||
-			!strings.EqualFold(repo.Owner, raw.Owner) {
-			continue
-		}
-		if raw.HasNameGlob() {
-			matched, _ := path.Match(
-				strings.ToLower(raw.Name),
-				strings.ToLower(repo.Name),
-			)
-			if matched {
-				count++
-			}
-		} else if strings.EqualFold(trackedRepoPath(repo), configRepoPath(raw)) ||
-			strings.EqualFold(repo.Name, raw.Name) {
+		if repoMatchesConfig(repo, raw) {
 			count++
 		}
 	}
@@ -245,11 +229,20 @@ func (s *Server) worktreeBasePathForRepo(
 	ctx context.Context, provider, platformHost, owner, name string,
 ) (string, bool, error) {
 	if s.cfg != nil {
-		target := config.Repo{
-			Platform:     provider,
+		target := ghclient.RepoRef{
+			Platform:     platform.Kind(provider),
 			PlatformHost: platformHost,
 			Owner:        owner,
 			Name:         name,
+			RepoPath:     strings.Trim(owner+"/"+name, "/"),
+		}
+		if s.syncer != nil {
+			for _, tracked := range s.syncer.TrackedRepos() {
+				if sameTrackedRoute(tracked, target) {
+					target = tracked
+					break
+				}
+			}
 		}
 		configuredPath := func() string {
 			s.cfgMu.Lock()
@@ -258,7 +251,7 @@ func (s *Server) worktreeBasePathForRepo(
 				if repo.HasNameGlob() || strings.TrimSpace(repo.WorktreeBasePath) == "" {
 					continue
 				}
-				if sameConfiguredRepo(repo, target) {
+				if repoMatchesConfig(target, repo) {
 					return repo.WorktreeBasePath
 				}
 			}
@@ -301,19 +294,35 @@ func repoMatchesConfig(
 ) bool {
 	host := raw.PlatformHostOrDefault()
 	if !strings.EqualFold(repoProvider(repo), raw.PlatformOrDefault()) ||
-		!samePlatformHost(repo.PlatformHost, host) ||
-		!strings.EqualFold(repo.Owner, raw.Owner) {
+		!samePlatformHost(repo.PlatformHost, host) {
 		return false
 	}
 	if raw.HasNameGlob() {
+		if !strings.EqualFold(repo.Owner, raw.Owner) {
+			return false
+		}
 		matched, _ := path.Match(
 			strings.ToLower(raw.Name),
 			strings.ToLower(repo.Name),
 		)
 		return matched
 	}
+	if repo.CredentialOwner != "" && repo.CredentialName != "" {
+		configuredPath := strings.Trim(
+			repo.CredentialOwner+"/"+repo.CredentialName,
+			"/",
+		)
+		return strings.EqualFold(configuredPath, configRepoPath(raw))
+	}
 	return strings.EqualFold(trackedRepoPath(repo), configRepoPath(raw)) ||
-		strings.EqualFold(repo.Name, raw.Name)
+		(strings.EqualFold(repo.Owner, raw.Owner) &&
+			strings.EqualFold(repo.Name, raw.Name))
+}
+
+func sameTrackedRoute(left, right ghclient.RepoRef) bool {
+	return strings.EqualFold(repoProvider(left), repoProvider(right)) &&
+		samePlatformHost(left.PlatformHost, right.PlatformHost) &&
+		strings.EqualFold(trackedRepoPath(left), trackedRepoPath(right))
 }
 
 func configRepoPath(raw config.Repo) string {

--- a/internal/server/settings_test.go
+++ b/internal/server/settings_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -2187,6 +2188,66 @@ name = "widget"
 	assert.Equal("worker", cfg2.Repos[2].Name)
 }
 
+func TestBulkRepoImportSerializesWithConfigReload(t *testing.T) {
+	require := require.New(t)
+	srv, _, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "KENN_FORGE_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "widget"
+`, &mockGH{})
+
+	srv.configReloadMu.Lock()
+	srv.cfgMu.Lock()
+	staleReload := cloneReloadedConfig(srv.cfg)
+	srv.cfgMu.Unlock()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := srv.applyBulkExactRepos(t.Context(), []resolvedBulkRepo{{
+			Config: config.Repo{Owner: "acme", Name: "api"},
+			Ref: ghclient.RepoRef{
+				Platform:           platform.KindGitHub,
+				PlatformHost:       "github.com",
+				Owner:              "acme",
+				Name:               "api",
+				RepoPath:           "acme/api",
+				PlatformExternalID: "repo-42",
+			},
+		}})
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(err)
+		// Model the watcher publishing the snapshot it loaded before the
+		// import. Without serialization this discards the newer repo.
+		srv.cfgMu.Lock()
+		*srv.cfg = staleReload
+		srv.cfgMu.Unlock()
+		srv.configReloadMu.Unlock()
+	case <-time.After(100 * time.Millisecond):
+		// The import is correctly waiting for the reload to publish. Once
+		// released it must base its update on that published snapshot.
+		srv.cfgMu.Lock()
+		*srv.cfg = staleReload
+		srv.cfgMu.Unlock()
+		srv.configReloadMu.Unlock()
+		require.NoError(<-done)
+	}
+
+	srv.cfgMu.Lock()
+	repos := slices.Clone(srv.cfg.Repos)
+	srv.cfgMu.Unlock()
+	require.Len(repos, 2)
+	require.Equal("api", repos[1].Name)
+}
+
 func TestHandleBulkAddReposPersistsGitLabProviderIdentity(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -2287,6 +2348,75 @@ func TestWorktreeBasePathResolverMatchesProviderIdentity(t *testing.T) {
 	require.NoError(err)
 	require.True(ok)
 	assert.Equal("/tmp/gitlab-widget", got)
+}
+
+func TestRenamedExactRepoRetainsSettingsMatchAndWorktreeBasePath(t *testing.T) {
+	require := require.New(t)
+	renamed := ghclient.RepoRef{
+		Platform:        platform.KindGitHub,
+		PlatformHost:    "github.com",
+		Owner:           "acme-tools",
+		Name:            "current-widget",
+		RepoPath:        "acme-tools/current-widget",
+		CredentialOwner: "acme",
+		CredentialName:  "legacy-widget",
+	}
+	raw := config.Repo{
+		Owner:            "acme",
+		Name:             "legacy-widget",
+		WorktreeBasePath: "/tmp/acme-widget",
+	}
+	database := dbtest.Open(t)
+	syncer := ghclient.NewSyncer(
+		nil, database, nil, []ghclient.RepoRef{renamed}, time.Minute, nil, nil,
+	)
+	t.Cleanup(syncer.Stop)
+	srv := &Server{
+		cfg:    &config.Config{Repos: []config.Repo{raw}},
+		db:     database,
+		syncer: syncer,
+	}
+
+	require.Equal(1, matchedRepoCount(raw, syncer.TrackedRepos()))
+	got, ok, err := srv.worktreeBasePathForRepo(
+		t.Context(), "github", "github.com", "acme-tools", "current-widget",
+	)
+	require.NoError(err)
+	require.True(ok)
+	require.Equal("/tmp/acme-widget", got)
+}
+
+func TestRemovingOtherConfigKeepsRenamedExactRepoTracked(t *testing.T) {
+	require := require.New(t)
+	database := dbtest.Open(t)
+	renamed := ghclient.RepoRef{
+		Platform:        platform.KindGitHub,
+		PlatformHost:    "github.com",
+		Owner:           "acme-tools",
+		Name:            "current-widget",
+		RepoPath:        "acme-tools/current-widget",
+		CredentialOwner: "acme",
+		CredentialName:  "legacy-widget",
+	}
+	other := ghclient.RepoRef{
+		Platform:     platform.KindGitHub,
+		PlatformHost: "github.com",
+		Owner:        "acme",
+		Name:         "other",
+		RepoPath:     "acme/other",
+	}
+	syncer := ghclient.NewSyncer(
+		nil, database, nil, []ghclient.RepoRef{renamed, other}, time.Minute, nil, nil,
+	)
+	t.Cleanup(syncer.Stop)
+	srv := &Server{db: database, syncer: syncer}
+
+	srv.removeConfigRepos([]config.Repo{{
+		Owner: "acme",
+		Name:  "legacy-widget",
+	}})
+
+	require.Equal([]ghclient.RepoRef{renamed}, syncer.TrackedRepos())
 }
 
 func TestHandleBulkAddReposPersistsGiteaProviderIdentity(t *testing.T) {

--- a/internal/server/settings_test.go
+++ b/internal/server/settings_test.go
@@ -795,6 +795,51 @@ func TestHandleAddRepo(t *testing.T) {
 	require.Len(t, cfg2.Repos, 2)
 }
 
+func TestHandleAddExactRepoRebuildsOverlappingGlobProvenance(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	mock := &mockGH{
+		listReposByOwnerFn: func(
+			_ context.Context, owner string,
+		) ([]*gh.Repository, error) {
+			return []*gh.Repository{{
+				Name:     new("widget"),
+				NodeID:   new("repo-acme-widget"),
+				Owner:    &gh.User{Login: new(owner)},
+				Archived: new(false),
+			}}, nil
+		},
+	}
+	srv, _, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "KENN_FORGE_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "*"
+`, mock)
+	srv.syncer.Stop()
+
+	rr := doJSON(t, srv, http.MethodPost, "/api/v1/repos", map[string]string{
+		"provider": "github",
+		"host":     "github.com",
+		"owner":    "acme",
+		"name":     "widget",
+	})
+	require.Equal(http.StatusCreated, rr.Code, rr.Body.String())
+
+	tracked := srv.syncer.TrackedRepos()
+	require.Len(tracked, 1)
+	assert.Equal([]ghclient.ConfiguredRepoRoute{{
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+	}}, tracked[0].ConfiguredRoutes)
+	assert.Equal([]ghclient.ConfiguredRepoGlob{{
+		Owner: "acme", Name: "*",
+	}}, tracked[0].ConfiguredGlobs)
+}
+
 func TestHandleAddRepoTriggersImmediateSyncDuringCooldown(t *testing.T) {
 	require := require.New(t)
 
@@ -916,6 +961,69 @@ func TestHandleDeleteRepo(t *testing.T) {
 	require.NoError(err)
 	require.Len(cfg2.Repos, 1)
 	assert.Equal(t, "other-org", cfg2.Repos[0].Owner)
+}
+
+func TestHandleDeleteOverlappingRepoRebuildsConfigurationProvenance(
+	t *testing.T,
+) {
+	for _, tc := range []struct {
+		name       string
+		deletePath string
+		wantRoutes []ghclient.ConfiguredRepoRoute
+		wantGlobs  []ghclient.ConfiguredRepoGlob
+	}{
+		{
+			name:       "remove exact keeps glob only",
+			deletePath: "/api/v1/repo/gh/acme/widget",
+			wantGlobs: []ghclient.ConfiguredRepoGlob{{
+				Owner: "acme", Name: "*",
+			}},
+		},
+		{
+			name:       "remove glob keeps exact only",
+			deletePath: "/api/v1/repo/gh/acme/*",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			mock := &mockGH{
+				listReposByOwnerFn: func(
+					_ context.Context, owner string,
+				) ([]*gh.Repository, error) {
+					return []*gh.Repository{{
+						Name:     new("widget"),
+						NodeID:   new("repo-acme-widget"),
+						Owner:    &gh.User{Login: new(owner)},
+						Archived: new(false),
+					}}, nil
+				},
+			}
+			srv, _, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "KENN_FORGE_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "*"
+
+[[repos]]
+owner = "acme"
+name = "widget"
+`, mock)
+			srv.syncer.Stop()
+
+			rr := doJSON(t, srv, http.MethodDelete, tc.deletePath, nil)
+			require.Equal(http.StatusNoContent, rr.Code, rr.Body.String())
+
+			tracked := srv.syncer.TrackedRepos()
+			require.Len(tracked, 1)
+			assert.Equal(tc.wantRoutes, tracked[0].ConfiguredRoutes)
+			assert.Equal(tc.wantGlobs, tracked[0].ConfiguredGlobs)
+		})
+	}
 }
 
 func TestHandleDeleteRepoPreservesKataProjectMappings(t *testing.T) {
@@ -2386,37 +2494,55 @@ func TestRenamedExactRepoRetainsSettingsMatchAndWorktreeBasePath(t *testing.T) {
 	require.Equal("/tmp/acme-widget", got)
 }
 
-func TestRemovingOtherConfigKeepsRenamedExactRepoTracked(t *testing.T) {
+func TestHandleDeleteOtherRepoKeepsRenamedExactRepoTracked(t *testing.T) {
+	assert := assert.New(t)
 	require := require.New(t)
-	database := dbtest.Open(t)
-	renamed := ghclient.RepoRef{
-		Platform:        platform.KindGitHub,
-		PlatformHost:    "github.com",
-		Owner:           "acme-tools",
-		Name:            "current-widget",
-		RepoPath:        "acme-tools/current-widget",
-		CredentialOwner: "acme",
-		CredentialName:  "legacy-widget",
-	}
-	other := ghclient.RepoRef{
-		Platform:     platform.KindGitHub,
-		PlatformHost: "github.com",
-		Owner:        "acme",
-		Name:         "other",
-		RepoPath:     "acme/other",
-	}
-	syncer := ghclient.NewSyncer(
-		nil, database, nil, []ghclient.RepoRef{renamed, other}, time.Minute, nil, nil,
+	mock := &mockGH{getRepositoryFn: func(
+		_ context.Context, owner, repo string,
+	) (*gh.Repository, error) {
+		if owner == "acme" && repo == "legacy-widget" {
+			return &gh.Repository{
+				Name:     new("current-widget"),
+				NodeID:   new("repo-acme-widget"),
+				Owner:    &gh.User{Login: new("acme-tools")},
+				Archived: new(false),
+			}, nil
+		}
+		nodeID := "repo-" + owner + "-" + repo
+		return &gh.Repository{
+			Name:     new(repo),
+			NodeID:   &nodeID,
+			Owner:    &gh.User{Login: new(owner)},
+			Archived: new(false),
+		}, nil
+	}}
+	srv, _, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "KENN_FORGE_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "legacy-widget"
+
+[[repos]]
+owner = "acme"
+name = "other"
+`, mock)
+	srv.syncer.Stop()
+
+	rr := doJSON(
+		t, srv, http.MethodDelete, "/api/v1/repo/gh/acme/other", nil,
 	)
-	t.Cleanup(syncer.Stop)
-	srv := &Server{db: database, syncer: syncer}
+	require.Equal(http.StatusNoContent, rr.Code, rr.Body.String())
 
-	srv.removeConfigRepos([]config.Repo{{
-		Owner: "acme",
-		Name:  "legacy-widget",
-	}})
-
-	require.Equal([]ghclient.RepoRef{renamed}, syncer.TrackedRepos())
+	tracked := srv.syncer.TrackedRepos()
+	require.Len(tracked, 1)
+	assert.Equal("acme-tools", tracked[0].Owner)
+	assert.Equal("current-widget", tracked[0].Name)
+	assert.Equal("acme", tracked[0].CredentialOwner)
+	assert.Equal("legacy-widget", tracked[0].CredentialName)
 }
 
 func TestHandleBulkAddReposPersistsGiteaProviderIdentity(t *testing.T) {

--- a/internal/server/tmux_wrapper_test.go
+++ b/internal/server/tmux_wrapper_test.go
@@ -213,9 +213,16 @@ func setupWrapperServerWithScriptAndDBAndServer(
 
 	bareDir := filepath.Join(dir, "clones")
 	require.NoError(t, os.MkdirAll(bareDir, 0o755))
-	bare := filepath.Join(
-		bareDir, "github.com", "acme", "widget.git",
+	repoID, err := database.UpsertRepo(
+		t.Context(),
+		db.GitHubRepoIdentity("github.com", "acme", "widget"),
 	)
+	require.NoError(t, err)
+	clones := gitclone.New(bareDir, nil)
+	bare, err := clones.RepositoryClone(
+		repoID, "github", "github.com", "acme", "widget",
+	).ClonePath()
+	require.NoError(t, err)
 	tmpWork := filepath.Join(dir, "work")
 	runGit(t, dir, "init", "--bare", "--initial-branch=main", bare)
 	runGit(t, dir, "clone", bare, tmpWork)
@@ -240,7 +247,6 @@ func setupWrapperServerWithScriptAndDBAndServer(
 	// Point bare origin at itself so EnsureClone fetch works.
 	runGit(t, bare, "remote", "add", "origin", bare)
 
-	clones := gitclone.New(bareDir, nil)
 	worktreeDir := filepath.Join(dir, "worktrees")
 
 	repos := []ghclient.RepoRef{
@@ -727,7 +733,15 @@ func TestWorkspaceSetupFailureRollbackCleansWorktreeViaAPI(t *testing.T) {
 		t, script,
 	)
 	ctx := t.Context()
-	clonePath, err := srv.clones.ClonePath("github", "github.com", "acme", "widget")
+	repo, err := database.GetRepoByIdentity(
+		ctx,
+		db.GitHubRepoIdentity("github.com", "acme", "widget"),
+	)
+	require.NoError(err)
+	require.NotNil(repo)
+	clonePath, err := srv.clones.RepositoryClone(
+		repo.ID, "github", "github.com", "acme", "widget",
+	).ClonePath()
 	require.NoError(err)
 	featureSHA := testGitSHA(t, clonePath, "refs/heads/feature")
 

--- a/internal/server/workspaceapi/auto_assign.go
+++ b/internal/server/workspaceapi/auto_assign.go
@@ -19,6 +19,18 @@ func (s *Handler) autoAssignWorkspaceItem(
 	if !s.configSnapshot().AutoAssignOnCreate || s.syncer == nil {
 		return nil
 	}
+	if s.resolver == nil {
+		return fmt.Errorf("repository resolver unavailable")
+	}
+	activeRepo, release, err := s.resolver.LeaseActiveRepository(ctx, repo.ID)
+	if err != nil {
+		return fmt.Errorf("lease active repository: %w", err)
+	}
+	if activeRepo == nil {
+		return fmt.Errorf("repository is no longer active")
+	}
+	defer release()
+	repo = *activeRepo
 
 	kind := httpapi.ProviderKind(repo)
 	host := httpapi.ProviderHost(repo)

--- a/internal/server/workspaceapi/auto_assign_test.go
+++ b/internal/server/workspaceapi/auto_assign_test.go
@@ -11,6 +11,7 @@ import (
 	"go.kenn.io/forge/internal/db"
 	ghclient "go.kenn.io/forge/internal/github"
 	"go.kenn.io/forge/internal/platform"
+	"go.kenn.io/forge/internal/server/httpapi"
 	"go.kenn.io/forge/internal/testutil/dbtest"
 )
 
@@ -103,9 +104,10 @@ func TestAutoAssignWorkspaceItemPreservesExistingAssignees(t *testing.T) {
 	syncer := ghclient.NewSyncerWithRegistry(registry, database, nil, nil, time.Hour, nil, nil)
 	t.Cleanup(syncer.Stop)
 	handler := New(Deps{
-		DB:     database,
-		Syncer: syncer,
-		Config: ConfigSnapshot{AutoAssignOnCreate: true},
+		DB:       database,
+		Resolver: httpapi.NewRepositoryResolver(httpapi.RepositoryResolverDeps{DB: database}),
+		Syncer:   syncer,
+		Config:   ConfigSnapshot{AutoAssignOnCreate: true},
 	})
 	repo, err := database.GetRepoByIdentity(t.Context(), repoIdentity)
 	require.NoError(err)

--- a/internal/server/workspaceapi/routes_handlers.go
+++ b/internal/server/workspaceapi/routes_handlers.go
@@ -786,16 +786,37 @@ func (s *Handler) refreshWorkspace(
 	if s.workspaceDiffCache != nil {
 		s.workspaceDiffCache.RevalidateWorkspace(input.ID)
 	}
-
-	provider := strings.TrimSpace(summary.Platform)
-	if provider == "" {
-		provider = string(platform.KindGitHub)
+	if summary.RepoID == nil || *summary.RepoID <= 0 || s.resolver == nil {
+		return nil, httpapi.Conflict(
+			httpapi.CodeConflict,
+			"workspace repository incarnation is unavailable",
+			nil,
+		)
 	}
-	repo, err := s.lookupRepoByProviderRoute(
-		ctx, provider, summary.PlatformHost, summary.RepoOwner, summary.RepoName,
-	)
+	repoID := *summary.RepoID
+	activeRepo := func() (*db.Repo, error) {
+		_, repo, release, leaseErr := s.resolver.LeaseActiveRepositoryContext(
+			ctx, repoID,
+		)
+		if leaseErr != nil {
+			return nil, httpapi.Internal(
+				"lease workspace repository: " + leaseErr.Error(),
+			)
+		}
+		if repo == nil {
+			return nil, httpapi.Conflict(
+				httpapi.CodeConflict,
+				"workspace repository incarnation is retired",
+				nil,
+			)
+		}
+		snapshot := *repo
+		release()
+		return &snapshot, nil
+	}
+	repo, err := activeRepo()
 	if err != nil {
-		return nil, providerRouteLookupError(err)
+		return nil, err
 	}
 	kind := repoProviderKind(*repo)
 	host := repoProviderHost(*repo)
@@ -807,6 +828,12 @@ func (s *Handler) refreshWorkspace(
 		); err != nil {
 			return nil, err
 		}
+		repo, err = activeRepo()
+		if err != nil {
+			return nil, err
+		}
+		kind = repoProviderKind(*repo)
+		host = repoProviderHost(*repo)
 	case db.WorkspaceItemTypePullRequest:
 		// The PR detail sync runs after the repo index refresh below so the
 		// workspace response reflects the latest indexed PR row and diff.
@@ -825,6 +852,12 @@ func (s *Handler) refreshWorkspace(
 	); err != nil {
 		return nil, err
 	}
+	repo, err = activeRepo()
+	if err != nil {
+		return nil, err
+	}
+	kind = repoProviderKind(*repo)
+	host = repoProviderHost(*repo)
 
 	if s.workspacePRMonitor != nil {
 		update, changed, err := s.workspacePRMonitor.RefreshWorkspaceAssociation(
@@ -852,6 +885,9 @@ func (s *Handler) refreshWorkspace(
 		if err := s.refreshWorkspacePullRequest(
 			ctx, kind, host, repo.Owner, repo.Name, prNumber,
 		); err != nil {
+			return nil, err
+		}
+		if _, err := activeRepo(); err != nil {
 			return nil, err
 		}
 		refreshed, err = s.workspaces.GetSummary(ctx, input.ID)

--- a/internal/server/workspaceapi/workspace_branch_actions.go
+++ b/internal/server/workspaceapi/workspace_branch_actions.go
@@ -64,9 +64,31 @@ func (s *Handler) runWorkspaceBranchAction(
 	if err != nil {
 		return nil, err
 	}
+	if summary.RepoID == nil || *summary.RepoID <= 0 || s.resolver == nil {
+		return nil, httpapi.Conflict(
+			httpapi.CodeConflict,
+			"workspace repository incarnation is unavailable",
+			nil,
+		)
+	}
+	leaseCtx, repo, release, err := s.resolver.LeaseActiveRepositoryContext(
+		ctx, *summary.RepoID,
+	)
+	if err != nil {
+		return nil, httpapi.Internal("lease workspace repository: " + err.Error())
+	}
+	if repo == nil {
+		return nil, httpapi.Conflict(
+			httpapi.CodeConflict,
+			"workspace repository incarnation is retired",
+			nil,
+		)
+	}
+	defer release()
+	ctx = leaseCtx
 	if err := action(
-		ctx, summary.Platform, summary.PlatformHost,
-		summary.RepoOwner, summary.RepoName,
+		ctx, repo.Platform, repo.PlatformHost,
+		repo.Owner, repo.Name,
 		summary.WorktreePath,
 	); err != nil {
 		return nil, workspaceBranchActionProblem(err)

--- a/internal/server/workspaceapi/workspace_branch_actions_test.go
+++ b/internal/server/workspaceapi/workspace_branch_actions_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/forge/internal/db"
+	"go.kenn.io/forge/internal/server/httpapi"
 	"go.kenn.io/forge/internal/testutil/dbtest"
 	"go.kenn.io/forge/internal/workspace"
 )
@@ -35,4 +36,44 @@ func TestRevealWorkspaceOpensWorkspacePath(t *testing.T) {
 
 	require.NoError(err)
 	assert.Equal(path, opened)
+}
+
+func TestWorkspaceBranchActionRejectsRetiredRepositoryIncarnation(t *testing.T) {
+	require := require.New(t)
+	database := dbtest.Open(t)
+	ctx := t.Context()
+	repoID, err := database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "R_old", Owner: "acme", Name: "widget",
+		RepoPath: "acme/widget",
+	})
+	require.NoError(err)
+	manager := workspace.NewManager(database, t.TempDir())
+	require.NoError(database.InsertWorkspace(ctx, &db.Workspace{
+		ID: "ws-retired", RepoID: &repoID, Platform: "github",
+		PlatformHost: "github.com", RepoOwner: "acme", RepoName: "widget",
+		ItemType: db.WorkspaceItemTypePullRequest, ItemNumber: 1,
+		WorktreePath: t.TempDir(), Status: "ready",
+	}))
+	_, err = database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "R_new", Owner: "acme", Name: "widget",
+		RepoPath: "acme/widget",
+	})
+	require.NoError(err)
+	h := New(Deps{
+		DB: database, Workspaces: manager,
+		Resolver: httpapi.NewRepositoryResolver(httpapi.RepositoryResolverDeps{DB: database}),
+	})
+	called := false
+
+	_, err = h.runWorkspaceBranchAction(ctx, "ws-retired", func(
+		context.Context, string, string, string, string, string,
+	) error {
+		called = true
+		return nil
+	})
+
+	require.Error(err)
+	require.False(called)
 }

--- a/internal/server/workspacetest/fixtures_test.go
+++ b/internal/server/workspacetest/fixtures_test.go
@@ -29,6 +29,7 @@ type workspaceServerFixture struct {
 	server           *server.Server
 	client           *apiclient.Client
 	database         *db.DB
+	repoID           int64
 	bare             string
 	remote           string
 	agentActivityDir string
@@ -87,7 +88,16 @@ func setupWorkspaceServerFixture(
 
 	bareDir := filepath.Join(dir, "clones")
 	require.NoError(t, os.MkdirAll(bareDir, 0o755))
-	bare := filepath.Join(bareDir, "github.com", "acme", "widget.git")
+	repoID, err := database.UpsertRepo(
+		t.Context(),
+		db.GitHubRepoIdentity("github.com", "acme", "widget"),
+	)
+	require.NoError(t, err)
+	clones := gitclone.New(bareDir, nil)
+	bare, err := clones.RepositoryClone(
+		repoID, "github", "github.com", "acme", "widget",
+	).ClonePath()
+	require.NoError(t, err)
 	runGit(t, dir, "clone", "--bare", remote, bare)
 	runGit(
 		t, bare, "remote", "set-url", "origin",
@@ -98,7 +108,6 @@ func setupWorkspaceServerFixture(
 		"url."+remote+".insteadOf", "https://github.com/acme/widget.git",
 	)
 
-	clones := gitclone.New(bareDir, nil)
 	worktreeDir := filepath.Join(dir, "worktrees")
 	repos := []ghclient.RepoRef{
 		{Owner: "acme", Name: "widget", PlatformHost: "github.com"},
@@ -139,6 +148,7 @@ func setupWorkspaceServerFixture(
 		server:           srv,
 		client:           client,
 		database:         database,
+		repoID:           repoID,
 		bare:             bare,
 		remote:           remote,
 		agentActivityDir: filepath.Join(dir, "agent-activity"),

--- a/internal/server/workspacetest/issue_workspace_directory_recovery_test.go
+++ b/internal/server/workspacetest/issue_workspace_directory_recovery_test.go
@@ -1,6 +1,7 @@
 package workspacetest
 
 import (
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -23,7 +24,8 @@ func TestIssueWorkspaceRecoversExpectedDirectory(t *testing.T) {
 	branch := "kenn-forge/issue-7"
 	expectedPath := filepath.Join(
 		fixture.worktreeDir,
-		"github", "github.com", "acme", "widget", "issue-7",
+		"github", "github.com", "acme", "widget",
+		fmt.Sprintf("repo-%d", fixture.repoID), "issue-7",
 	)
 	runGit(
 		t, fixture.bare,
@@ -163,7 +165,8 @@ func TestIssueWorkspaceDirectoryRecoveryReasons(t *testing.T) {
 			seedIssue(t, fixture.database, "acme", "widget", 7, "open")
 			expectedPath := filepath.Join(
 				fixture.worktreeDir,
-				"github", "github.com", "acme", "widget", "issue-7",
+				"github", "github.com", "acme", "widget",
+				fmt.Sprintf("repo-%d", fixture.repoID), "issue-7",
 			)
 			tt.prepare(t, fixture, expectedPath)
 
@@ -209,7 +212,8 @@ func TestIssueWorkspaceConflictRejectsAlternateBranchForExistingDirectory(t *tes
 	branch := "kenn-forge/issue-7-original-title"
 	expectedPath := filepath.Join(
 		fixture.worktreeDir,
-		"github", "github.com", "acme", "widget", "issue-7",
+		"github", "github.com", "acme", "widget",
+		fmt.Sprintf("repo-%d", fixture.repoID), "issue-7",
 	)
 	runGit(t, fixture.bare, "worktree", "add", expectedPath, "-b", branch, "main")
 

--- a/internal/server/workspacetest/workspace_concurrent_e2e_test.go
+++ b/internal/server/workspacetest/workspace_concurrent_e2e_test.go
@@ -64,7 +64,7 @@ func TestWorkspaceConcurrentSameRepoOperationsE2E(t *testing.T) {
 			if resp.StatusCode() != http.StatusAccepted || resp.JSON202 == nil {
 				created <- createResult{
 					num: num,
-					err: assertableStatusErr(resp.StatusCode()),
+					err: assertableStatusErr(resp.StatusCode(), resp.Body),
 				}
 				return
 			}
@@ -119,7 +119,10 @@ func TestWorkspaceConcurrentSameRepoOperationsE2E(t *testing.T) {
 		case err != nil:
 			opOut <- opResult{op: "delete", err: err}
 		case resp.StatusCode() != http.StatusNoContent:
-			opOut <- opResult{op: "delete", err: assertableStatusErr(resp.StatusCode())}
+			opOut <- opResult{
+				op:  "delete",
+				err: assertableStatusErr(resp.StatusCode(), resp.Body),
+			}
 		default:
 			opOut <- opResult{op: "delete"}
 		}
@@ -130,7 +133,10 @@ func TestWorkspaceConcurrentSameRepoOperationsE2E(t *testing.T) {
 		case err != nil:
 			opOut <- opResult{op: "retry", err: err}
 		case resp.StatusCode() != http.StatusAccepted || resp.JSON202 == nil:
-			opOut <- opResult{op: "retry", err: assertableStatusErr(resp.StatusCode())}
+			opOut <- opResult{
+				op:  "retry",
+				err: assertableStatusErr(resp.StatusCode(), resp.Body),
+			}
 		default:
 			waitForWorkspaceReady(t, ctx, client, retryTarget.Id)
 			opOut <- opResult{op: "retry"}
@@ -164,16 +170,21 @@ func TestWorkspaceConcurrentSameRepoOperationsE2E(t *testing.T) {
 
 // assertableStatusErr lets the goroutines surface unexpected status
 // codes without calling t.Fatal off the test goroutine.
-func assertableStatusErr(status int) error {
-	return &unexpectedStatusError{status: status}
+func assertableStatusErr(status int, body []byte) error {
+	return &unexpectedStatusError{status: status, body: strings.TrimSpace(string(body))}
 }
 
 type unexpectedStatusError struct {
 	status int
+	body   string
 }
 
 func (e *unexpectedStatusError) Error() string {
-	return "unexpected HTTP status: " + strings.TrimSpace(http.StatusText(e.status))
+	message := "unexpected HTTP status: " + strings.TrimSpace(http.StatusText(e.status))
+	if e.body != "" {
+		message += ": " + e.body
+	}
+	return message
 }
 
 // listBareWorktrees counts entries in `git worktree list --porcelain`

--- a/internal/testutil/diff_repo.go
+++ b/internal/testutil/diff_repo.go
@@ -15,6 +15,7 @@ import (
 
 // DiffRepoResult holds the SHAs from the test repo for use in assertions.
 type DiffRepoResult struct {
+	RepositoryID int64
 	BaseSHA      string // merge-base / base branch tip
 	HeadSHA      string // PR head commit
 	AltHeadSHA   string // newer PR head commit used by E2E refresh tests
@@ -41,8 +42,6 @@ func SetupDiffRepo(
 ) (*DiffRepoResult, error) {
 	workDir := filepath.Join(tmpDir, "workrepo")
 	cloneBase := filepath.Join(tmpDir, "clones")
-	barePath := filepath.Join(
-		cloneBase, "github.com", "acme", "widgets.git")
 
 	if err := os.MkdirAll(workDir, 0o755); err != nil {
 		return nil, fmt.Errorf("mkdir work: %w", err)
@@ -158,6 +157,21 @@ func SetupDiffRepo(
 		return nil, fmt.Errorf("rev-parse alternate head: %w", err)
 	}
 
+	// Seed the repository before creating its managed clone so the fixture
+	// uses the same immutable repository-incarnation namespace as production.
+	repoID, err := d.UpsertRepo(
+		ctx, db.GitHubRepoIdentity("github.com", "acme", "widgets"))
+	if err != nil {
+		return nil, fmt.Errorf("upsert repo: %w", err)
+	}
+	mgr := gitclone.New(cloneBase, nil)
+	barePath, err := mgr.RepositoryClone(
+		repoID, "github", "github.com", "acme", "widgets",
+	).ClonePath()
+	if err != nil {
+		return nil, fmt.Errorf("resolve managed clone path: %w", err)
+	}
+
 	// Clone as bare to the path the clone manager expects.
 	if err := os.MkdirAll(
 		filepath.Dir(barePath), 0o755); err != nil {
@@ -169,11 +183,6 @@ func SetupDiffRepo(
 	}
 
 	// Seed database with the real SHAs for acme/widgets PR #1.
-	repoID, err := d.UpsertRepo(
-		ctx, db.GitHubRepoIdentity("github.com", "acme", "widgets"))
-	if err != nil {
-		return nil, fmt.Errorf("upsert repo: %w", err)
-	}
 	if err := d.UpdateDiffSHAs(
 		ctx, repoID, 1, headSHA, baseSHA, baseSHA); err != nil {
 		return nil, fmt.Errorf("update diff SHAs: %w", err)
@@ -195,9 +204,8 @@ func SetupDiffRepo(
 		return nil, fmt.Errorf("update repo provider metadata: %w", err)
 	}
 
-	mgr := gitclone.New(cloneBase, nil)
-
 	return &DiffRepoResult{
+		RepositoryID: repoID,
 		BaseSHA:      baseSHA,
 		HeadSHA:      headSHA,
 		AltHeadSHA:   altHeadSHA,

--- a/internal/testutil/diff_repo_test.go
+++ b/internal/testutil/diff_repo_test.go
@@ -1,11 +1,13 @@
 package testutil
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/db"
 	"go.kenn.io/forge/internal/testutil/dbtest"
 	gitcmd "go.kenn.io/kit/git/cmd"
 )
@@ -54,4 +56,38 @@ func TestSetupDiffRepoDoesNotLeakIntoHostGitDir(t *testing.T) {
 	r.Equal(string(before), string(after),
 		"SetupDiffRepo mutated the host .git/config via leaked GIT_DIR")
 	r.NoError(setupErr, "SetupDiffRepo should succeed under hook-simulated env")
+}
+
+func TestSetupDiffRepoUsesRepositoryIncarnationClonePath(t *testing.T) {
+	r := require.New(t)
+
+	fixtureDir := t.TempDir()
+	database := dbtest.OpenAt(t, filepath.Join(fixtureDir, "test.db"))
+
+	result, err := SetupDiffRepo(t.Context(), fixtureDir, database)
+	r.NoError(err)
+
+	repo, err := database.GetRepoByIdentity(
+		t.Context(),
+		db.GitHubRepoIdentity("github.com", "acme", "widgets"),
+	)
+	r.NoError(err)
+	r.NotNil(repo)
+
+	clonePath, err := result.Manager.RepositoryClone(
+		repo.ID, "github", "github.com", "acme", "widgets",
+	).ClonePath()
+	r.NoError(err)
+	r.Equal(
+		filepath.Join(
+			fixtureDir,
+			"clones",
+			"repository-incarnations",
+			"local",
+			"repositories",
+			fmt.Sprintf("repo-%d.git", repo.ID),
+		),
+		clonePath,
+	)
+	r.FileExists(filepath.Join(clonePath, "HEAD"))
 }

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -54,6 +54,7 @@ type Manager struct {
 	deletedSummaryIDs         map[string]bool
 	worktreeBaseResolver      WorktreeBasePathResolver
 	afterHeadRepoSnapshotRead func()
+	afterSetupHeadRepoRefresh func()
 }
 
 // WorktreeBasePathResolver resolves a tracked remote repository to a
@@ -342,6 +343,7 @@ func (m *Manager) Create(
 
 	ws := &Workspace{
 		ID:           id,
+		RepoID:       &repo.ID,
 		Platform:     repo.Platform,
 		PlatformHost: platformHost,
 		RepoOwner:    owner,
@@ -355,6 +357,7 @@ func (m *Manager) Create(
 		WorkspaceBranch: workspaceBranchUnknown,
 		WorktreePath: filepath.Join(
 			m.worktreeDir, repo.Platform, platformHost, owner, name,
+			fmt.Sprintf("repo-%d", repo.ID),
 			fmt.Sprintf("pr-%d", mrNumber),
 		),
 		TmuxSession:     "forge-" + id,
@@ -423,6 +426,7 @@ func (m *Manager) CreateIssue(
 
 	ws := &Workspace{
 		ID:              id,
+		RepoID:          &repo.ID,
 		Platform:        repo.Platform,
 		PlatformHost:    platformHost,
 		RepoOwner:       owner,
@@ -433,6 +437,7 @@ func (m *Manager) CreateIssue(
 		WorkspaceBranch: gitHeadRef,
 		WorktreePath: filepath.Join(
 			m.worktreeDir, repo.Platform, platformHost, owner, name,
+			fmt.Sprintf("repo-%d", repo.ID),
 			fmt.Sprintf("issue-%d", issueNumber),
 		),
 		TmuxSession:     "forge-" + id,
@@ -475,7 +480,7 @@ func (m *Manager) CreateIssue(
 
 	if !opts.ReuseExistingDirectory {
 		branchDir, ok, localBase, err := m.branchInspectionDir(
-			ctx, repo.Platform, platformHost, owner, name,
+			ctx, repo.ID, repo.Platform, platformHost, owner, name,
 			workspaceCloneRemoteURL(repo, platformHost, owner, name),
 		)
 		if err != nil {
@@ -616,6 +621,7 @@ func (m *Manager) CreateKataTask(
 
 	ws := &Workspace{
 		ID:              id,
+		RepoID:          &repo.ID,
 		Platform:        repo.Platform,
 		PlatformHost:    platformHost,
 		RepoOwner:       owner,
@@ -626,6 +632,7 @@ func (m *Manager) CreateKataTask(
 		WorkspaceBranch: gitHeadRef,
 		WorktreePath: filepath.Join(
 			m.worktreeDir, repo.Platform, platformHost, owner, name,
+			fmt.Sprintf("repo-%d", repo.ID),
 			"kata-"+branchID,
 		),
 		TmuxSession:     "forge-" + id,
@@ -680,7 +687,7 @@ func (m *Manager) CreateAdHoc(
 
 	workspaceBranch := gitHeadRef
 	branchDir, ok, localBase, err := m.branchInspectionDir(
-		ctx, repo.Platform, platformHost, owner, name,
+		ctx, repo.ID, repo.Platform, platformHost, owner, name,
 		workspaceCloneRemoteURL(repo, platformHost, owner, name),
 	)
 	if err != nil {
@@ -698,6 +705,7 @@ func (m *Manager) CreateAdHoc(
 
 	ws := &Workspace{
 		ID:              id,
+		RepoID:          &repo.ID,
 		Platform:        repo.Platform,
 		PlatformHost:    platformHost,
 		RepoOwner:       owner,
@@ -708,6 +716,7 @@ func (m *Manager) CreateAdHoc(
 		WorkspaceBranch: workspaceBranch,
 		WorktreePath: filepath.Join(
 			m.worktreeDir, repo.Platform, platformHost, owner, name,
+			fmt.Sprintf("repo-%d", repo.ID),
 			adHocWorktreeDirName(gitHeadRef),
 		),
 		TmuxSession:     "forge-" + id,
@@ -795,16 +804,16 @@ func newWorkspaceID() (string, error) {
 	return hex.EncodeToString(idBytes), nil
 }
 
-func workspaceCloneNamespace(platform string) string {
-	platform = strings.ToLower(strings.TrimSpace(platform))
-	if platform == "" || platform == "github" {
-		return ""
+func workspaceRepositoryID(ws *Workspace) (int64, error) {
+	if ws == nil || ws.RepoID == nil || *ws.RepoID <= 0 {
+		return 0, errors.New("workspace has no repository incarnation")
 	}
-	return platform
+	return *ws.RepoID, nil
 }
 
 func (m *Manager) branchInspectionDir(
-	ctx context.Context, platform, platformHost, owner, name, remoteURL string,
+	ctx context.Context, repoID int64,
+	platform, platformHost, owner, name, remoteURL string,
 ) (dir string, ok bool, localBase bool, err error) {
 	if baseDir, ok, err := m.localWorktreeBaseDir(ctx, platform, platformHost, owner, name); err != nil || ok {
 		return baseDir, ok, ok, err
@@ -813,16 +822,14 @@ func (m *Manager) branchInspectionDir(
 		return "", false, false, nil
 	}
 
-	if err := m.clones.EnsureCloneInNamespace(
-		ctx, workspaceCloneNamespace(platform), platform, platformHost,
-		owner, name, remoteURL,
-	); err != nil {
+	clone := m.clones.RepositoryClone(
+		repoID, platform, platformHost, owner, name,
+	)
+	if err := clone.EnsureClone(ctx, remoteURL); err != nil {
 		return "", false, false, fmt.Errorf("ensure clone: %w", err)
 	}
 
-	cloneDir, err := m.clones.ClonePathInNamespace(
-		workspaceCloneNamespace(platform), platformHost, owner, name,
-	)
+	cloneDir, err := clone.ClonePath()
 	if err != nil {
 		return "", false, false, err
 	}
@@ -921,17 +928,54 @@ func (m *Manager) Setup(
 func (m *Manager) SetupWithWorktreeBasePath(
 	ctx context.Context, ws *Workspace, worktreeBasePath string,
 ) error {
+	if ws == nil {
+		return ErrWorkspaceNotFound
+	}
 	recoveryPending := workspaceRequiresExistingDirectory(ws)
 	m.recordSetupEvent(
 		ctx,
 		ws.ID, workspaceSetupStageSetup, "started",
 		"starting workspace setup",
 	)
+	leaseCtx, releaseReconciliation, err :=
+		m.db.LeaseRepositoryReconciliationRead(ctx)
+	if err != nil {
+		return m.failSetup(
+			ctx, ws.ID, workspaceSetupStageSetup,
+			fmt.Errorf("lock repository reconciliation for setup: %w", err),
+		)
+	}
+	defer releaseReconciliation()
+	ctx = leaseCtx
+	repoID, err := workspaceRepositoryID(ws)
+	if err != nil {
+		return m.failSetup(
+			ctx, ws.ID, workspaceSetupStageSetup,
+			fmt.Errorf("resolve workspace repository incarnation: %w", err),
+		)
+	}
+	boundRepo, err := m.db.GetRepoByID(ctx, repoID)
+	if err != nil {
+		return m.failSetup(
+			ctx, ws.ID, workspaceSetupStageSetup,
+			fmt.Errorf("look up workspace repository incarnation: %w", err),
+		)
+	}
+	if boundRepo == nil || boundRepo.RetiredAt != nil {
+		return m.failSetup(
+			ctx, ws.ID, workspaceSetupStageSetup,
+			db.ErrRepositoryRetired,
+		)
+	}
+
 	if err := m.RefreshWorkspaceHeadRepo(ctx, ws); err != nil {
 		return m.failSetup(
 			ctx, ws.ID, workspaceSetupStageSetup,
 			fmt.Errorf("refresh workspace head repository: %w", err),
 		)
+	}
+	if m.afterSetupHeadRepoRefresh != nil {
+		m.afterSetupHeadRepoRefresh()
 	}
 	if recoveryPending {
 		if err := m.validateExistingWorkspaceDirectory(ctx, ws); err != nil {
@@ -1117,9 +1161,18 @@ func (m *Manager) RefreshWorkspaceHeadRepoSnapshot(
 		return nil, nil
 	}
 	for {
-		repo, err := m.workspaceRepo(
-			ctx, ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
-		)
+		var repo *db.Repo
+		var err error
+		if ws.RepoID != nil && *ws.RepoID > 0 {
+			repo, err = m.db.GetRepoByID(ctx, *ws.RepoID)
+			if repo != nil && repo.RetiredAt != nil {
+				return nil, db.ErrRepositoryRetired
+			}
+		} else {
+			repo, err = m.workspaceRepo(
+				ctx, ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
+			)
+		}
 		if err != nil {
 			return nil, fmt.Errorf("look up workspace repo: %w", err)
 		}
@@ -1301,6 +1354,9 @@ func (m *Manager) reuseExistingWorkspaceWorktree(
 //   - expected managed clone: reusable for synthetic PR branches, persisted
 //     workspace branches, issue branches, and detached/unknown heads that later
 //     pass branch validation;
+//   - pre-incarnation managed clone: reusable only when the workspace has a
+//     repository ID and the route-keyed Git directory still validates as the
+//     workspace repository;
 //   - current configured local base: reusable only for same-repo workspaces
 //     after validating the actual worktree config, hooks, refspecs, and origin;
 //   - fork PR/MR: reusable only from the managed clone, never from a local base;
@@ -1316,7 +1372,8 @@ func (m *Manager) existingWorkspaceWorktreeProvenance(
 	commonDir string,
 	ws *Workspace,
 ) (localBase bool, reusable bool, err error) {
-	if m.existingWorktreeUsesManagedClone(ctx, commonDir, ws) {
+	if m.existingWorktreeUsesManagedClone(ctx, commonDir, ws) ||
+		m.existingWorktreeUsesPreIncarnationManagedClone(ctx, commonDir, ws) {
 		return false, true, nil
 	}
 	if ws.MRHeadRepo != nil {
@@ -1342,9 +1399,55 @@ func (m *Manager) existingWorktreeUsesManagedClone(
 	if m.clones == nil {
 		return false
 	}
-	cloneDir, err := m.clones.ClonePathInNamespace(
-		workspaceCloneNamespace(ws.Platform),
-		ws.PlatformHost, ws.RepoOwner, ws.RepoName,
+	repoID, err := workspaceRepositoryID(ws)
+	if err != nil {
+		return false
+	}
+	cloneDir, err := m.clones.RepositoryClone(
+		repoID,
+		ws.Platform,
+		ws.PlatformHost,
+		ws.RepoOwner,
+		ws.RepoName,
+	).ClonePath()
+	if err != nil {
+		return false
+	}
+	ready, err := gitCloneDirReady(cloneDir)
+	if err != nil || !ready {
+		return false
+	}
+	actualDir, err := canonicalFilesystemPath(commonDir)
+	if err != nil {
+		return false
+	}
+	expectedDir, err := canonicalFilesystemPath(cloneDir)
+	if err != nil {
+		return false
+	}
+	return actualDir == expectedDir && gitDirMatchesWorkspaceRepo(ctx, commonDir, ws)
+}
+
+func (m *Manager) existingWorktreeUsesPreIncarnationManagedClone(
+	ctx context.Context,
+	commonDir string,
+	ws *Workspace,
+) bool {
+	if m.clones == nil {
+		return false
+	}
+	if _, err := workspaceRepositoryID(ws); err != nil {
+		return false
+	}
+	owner, name, ok := workspaceLegacyCloneCoordinates(ws)
+	if !ok {
+		return false
+	}
+	cloneDir, err := m.clones.ClonePath(
+		ws.Platform,
+		ws.PlatformHost,
+		owner,
+		name,
 	)
 	if err != nil {
 		return false
@@ -1521,24 +1624,29 @@ func (m *Manager) workspaceSetupGitDir(
 	if m.clones == nil {
 		return "", false, fmt.Errorf("clone manager not set")
 	}
+	repoID, err := workspaceRepositoryID(ws)
+	if err != nil {
+		return "", false, err
+	}
 
 	remoteURL, err := m.workspaceSetupRemoteURL(
-		ctx, ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
+		ctx, ws,
 	)
 	if err != nil {
 		return "", false, err
 	}
-	if err := m.clones.EnsureCloneInNamespace(
-		ctx, workspaceCloneNamespace(ws.Platform), ws.Platform, ws.PlatformHost,
-		ws.RepoOwner, ws.RepoName, remoteURL,
-	); err != nil {
+	clone := m.clones.RepositoryClone(
+		repoID,
+		ws.Platform,
+		ws.PlatformHost,
+		ws.RepoOwner,
+		ws.RepoName,
+	)
+	if err := clone.EnsureClone(ctx, remoteURL); err != nil {
 		return "", false, err
 	}
 
-	cloneDir, err := m.clones.ClonePathInNamespace(
-		workspaceCloneNamespace(ws.Platform),
-		ws.PlatformHost, ws.RepoOwner, ws.RepoName,
-	)
+	cloneDir, err := clone.ClonePath()
 	if err != nil {
 		return "", false, err
 	}
@@ -1546,18 +1654,22 @@ func (m *Manager) workspaceSetupGitDir(
 }
 
 func (m *Manager) workspaceSetupRemoteURL(
-	ctx context.Context, platform, platformHost, owner, name string,
+	ctx context.Context, ws *Workspace,
 ) (string, error) {
-	repo, err := m.db.GetRepoByIdentity(ctx, db.RepoIdentity{
-		Platform:     platform,
-		PlatformHost: platformHost,
-		Owner:        owner,
-		Name:         name,
-	})
+	repoID, err := workspaceRepositoryID(ws)
+	if err != nil {
+		return "", err
+	}
+	repo, err := m.db.GetRepoByID(ctx, repoID)
 	if err != nil {
 		return "", fmt.Errorf("look up repo clone URL: %w", err)
 	}
-	return workspaceCloneRemoteURL(repo, platformHost, owner, name), nil
+	if repo == nil || repo.RetiredAt != nil {
+		return "", db.ErrRepositoryRetired
+	}
+	return workspaceCloneRemoteURL(
+		repo, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
+	), nil
 }
 
 func (m *Manager) localWorktreeBaseDir(
@@ -2673,10 +2785,17 @@ func (m *Manager) workspaceCleanupGitDir(
 	}
 
 	if m.clones != nil {
-		cloneDir, err := m.clones.ClonePathInNamespace(
-			workspaceCloneNamespace(ws.Platform),
-			ws.PlatformHost, ws.RepoOwner, ws.RepoName,
-		)
+		repoID, err := workspaceRepositoryID(ws)
+		if err != nil {
+			return "", false, err
+		}
+		cloneDir, err := m.clones.RepositoryClone(
+			repoID,
+			ws.Platform,
+			ws.PlatformHost,
+			ws.RepoOwner,
+			ws.RepoName,
+		).ClonePath()
 		if err != nil {
 			return "", false, err
 		}
@@ -2693,6 +2812,25 @@ func (m *Manager) workspaceCleanupGitDir(
 			}
 			if owned {
 				return cloneDir, true, nil
+			}
+		}
+
+		owner, name, ok := workspaceLegacyCloneCoordinates(ws)
+		if ok {
+			legacyCloneDir, err := m.clones.ClonePath(
+				ws.Platform, ws.PlatformHost, owner, name,
+			)
+			if err != nil {
+				return "", false, err
+			}
+			ready, err := gitCloneDirReady(legacyCloneDir)
+			if err != nil {
+				return "", false, err
+			}
+			if ready && validateOriginRemoteURLs(
+				ctx, legacyCloneDir, ws.PlatformHost, owner, name,
+			) == nil {
+				return legacyCloneDir, true, nil
 			}
 		}
 	}
@@ -2779,9 +2917,24 @@ func pathContains(parent, child string) bool {
 func gitDirMatchesWorkspaceRepo(
 	ctx context.Context, dir string, ws *Workspace,
 ) bool {
-	return validateOriginRemoteURLs(
+	if validateOriginRemoteURLs(
 		ctx, dir, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
+	) == nil {
+		return true
+	}
+	owner, name, ok := workspaceLegacyCloneCoordinates(ws)
+	return ok && validateOriginRemoteURLs(
+		ctx, dir, ws.PlatformHost, owner, name,
 	) == nil
+}
+
+func workspaceLegacyCloneCoordinates(ws *Workspace) (string, string, bool) {
+	if ws == nil {
+		return "", "", false
+	}
+	owner := strings.TrimSpace(ws.LegacyCloneOwner)
+	name := strings.TrimSpace(ws.LegacyCloneName)
+	return owner, name, owner != "" && name != ""
 }
 
 func (m *Manager) cleanupTmuxSession(

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -582,6 +582,123 @@ func TestRefreshWorkspaceHeadRepoBlocksRepositoryReconciliation(t *testing.T) {
 	assert.Equal(forkURL, *stored.MRHeadRepo)
 }
 
+func TestSetupKeepsBoundRepositoryActiveThroughExternalSideEffects(
+	t *testing.T,
+) {
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	repoID, err := d.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repo-original",
+		Owner:          "acme",
+		Name:           "widget",
+		RepoPath:       "acme/widget",
+	})
+	require.NoError(err)
+	seedMR(t, d, repoID, 42, "feature/setup-fence")
+	mgr := NewManager(d, t.TempDir())
+	ws, err := mgr.Create(ctx, "github", "github.com", "acme", "widget", 42)
+	require.NoError(err)
+	require.NotNil(ws)
+
+	setupReachedExternalWork := make(chan struct{})
+	continueSetup := make(chan struct{})
+	mgr.afterSetupHeadRepoRefresh = func() {
+		close(setupReachedExternalWork)
+		<-continueSetup
+	}
+	setupDone := make(chan error, 1)
+	go func() { setupDone <- mgr.Setup(ctx, ws) }()
+	select {
+	case <-setupReachedExternalWork:
+	case <-time.After(2 * time.Second):
+		require.Fail("workspace setup did not reach external-work boundary")
+	}
+
+	writeLockAttempted := make(chan struct{})
+	d.SetBeforeRepositoryReconciliationWriteLockForTest(
+		func() { close(writeLockAttempted) },
+	)
+	replacementDone := make(chan error, 1)
+	go func() {
+		_, replaceErr := d.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+			Platform:       "github",
+			PlatformHost:   "github.com",
+			PlatformRepoID: "repo-replacement",
+			Owner:          "acme",
+			Name:           "widget",
+			RepoPath:       "acme/widget",
+		})
+		replacementDone <- replaceErr
+	}()
+	select {
+	case <-writeLockAttempted:
+	case <-time.After(2 * time.Second):
+		require.Fail("repository replacement did not queue")
+	}
+	select {
+	case err := <-replacementDone:
+		require.NoError(err)
+		require.Fail("repository replacement bypassed workspace setup")
+	default:
+	}
+
+	close(continueSetup)
+	select {
+	case err := <-setupDone:
+		require.Error(err, "setup has no clone manager and must fail after releasing its lease")
+	case <-time.After(2 * time.Second):
+		require.Fail("workspace setup did not finish")
+	}
+	select {
+	case err := <-replacementDone:
+		require.NoError(err)
+	case <-time.After(2 * time.Second):
+		require.Fail("repository replacement did not resume")
+	}
+}
+
+func TestSetupMarksWorkspaceFailedWhenBoundRepositoryWasReplaced(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	repoID, err := d.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repo-original",
+		Owner:          "acme",
+		Name:           "widget",
+		RepoPath:       "acme/widget",
+	})
+	require.NoError(err)
+	seedMR(t, d, repoID, 42, "feature/setup-fence")
+	mgr := NewManager(d, t.TempDir())
+	ws, err := mgr.Create(ctx, "github", "github.com", "acme", "widget", 42)
+	require.NoError(err)
+	require.NotNil(ws)
+
+	_, err = d.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repo-replacement",
+		Owner:          "acme",
+		Name:           "widget",
+		RepoPath:       "acme/widget",
+	})
+	require.NoError(err)
+
+	require.ErrorIs(mgr.Setup(ctx, ws), db.ErrRepositoryRetired)
+	stored, err := d.GetWorkspace(ctx, ws.ID)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.Equal("error", stored.Status)
+	require.NotNil(stored.ErrorMessage)
+	assert.Contains(*stored.ErrorMessage, db.ErrRepositoryRetired.Error())
+}
+
 func TestRefreshWorkspaceHeadRepoRetriesWhenMissingRepoAppears(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -822,7 +939,7 @@ func TestCreateKataTaskNormalizesRelativeWorktreeDir(t *testing.T) {
 
 	d := openTestDB(t)
 	ctx := t.Context()
-	seedRepo(t, d, "github.com", "acme", "widget")
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
 
 	mgr := NewManager(d, "relative-worktrees")
 	metadata := db.WorkspaceKataMetadata{
@@ -840,7 +957,8 @@ func TestCreateKataTaskNormalizesRelativeWorktreeDir(t *testing.T) {
 	assert.Equal(
 		filepath.Join(
 			cwd, "relative-worktrees", "github", "github.com",
-			"acme", "widget", "kata-"+kataTaskBranchID(metadata),
+			"acme", "widget", fmt.Sprintf("repo-%d", repoID),
+			"kata-"+kataTaskBranchID(metadata),
 		),
 		ws.WorktreePath,
 	)
@@ -931,7 +1049,8 @@ func TestCreateIssueRecoversExpectedExistingDirectory(t *testing.T) {
 
 	const branch = "kenn-forge/issue-7"
 	expectedPath := filepath.Join(
-		worktreeRoot, "github", platformHost, "acme", "widget", "issue-7",
+		worktreeRoot, "github", platformHost, "acme", "widget",
+		fmt.Sprintf("repo-%d", repoID), "issue-7",
 	)
 	runWorkspaceTestGit(
 		t, localRepo,
@@ -997,7 +1116,8 @@ func TestIssueWorkspaceBranchDoesNotCollideWithRecoveryState(t *testing.T) {
 
 			const branch = "__kenn_forge_recovery_pending__"
 			expectedPath := filepath.Join(
-				worktreeRoot, "github", platformHost, "acme", "widget", "issue-7",
+				worktreeRoot, "github", platformHost, "acme", "widget",
+				fmt.Sprintf("repo-%d", repoID), "issue-7",
 			)
 			if recoverExisting {
 				runWorkspaceTestGit(
@@ -1102,7 +1222,8 @@ func TestCreateIssueRecoveryRejectsInvalidExpectedDirectory(t *testing.T) {
 			seedIssue(t, d, repoID, 7, "")
 			const branch = "kenn-forge/issue-7"
 			expectedPath := filepath.Join(
-				worktreeRoot, "github", platformHost, "acme", "widget", "issue-7",
+				worktreeRoot, "github", platformHost, "acme", "widget",
+				fmt.Sprintf("repo-%d", repoID), "issue-7",
 			)
 			tt.prepare(t, localRepo, expectedPath, branch)
 
@@ -1147,7 +1268,9 @@ func TestCreateIssueRecoveryRejectsManagedCloneWithWrongOrigin(t *testing.T) {
 	seedIssue(t, d, repoID, 7, "")
 
 	clones := gitclone.New(t.TempDir(), nil)
-	cloneDir, err := clones.ClonePath("github", host, owner, name)
+	cloneDir, err := clones.RepositoryClone(
+		repoID, "github", host, owner, name,
+	).ClonePath()
 	require.NoError(err)
 	seedWorkspaceBareCloneAt(t, cloneDir)
 	runWorkspaceTestGit(
@@ -1155,7 +1278,8 @@ func TestCreateIssueRecoveryRejectsManagedCloneWithWrongOrigin(t *testing.T) {
 		"https://github.com/other/repository.git",
 	)
 	expectedPath := filepath.Join(
-		worktreeRoot, "github", host, owner, name, "issue-7",
+		worktreeRoot, "github", host, owner, name,
+		fmt.Sprintf("repo-%d", repoID), "issue-7",
 	)
 	runWorkspaceTestGit(
 		t, cloneDir,
@@ -1179,6 +1303,138 @@ func TestCreateIssueRecoveryRejectsManagedCloneWithWrongOrigin(t *testing.T) {
 	assert.Equal(WorkspaceDirectoryRepositoryMismatch, recoveryErr.Reason)
 }
 
+func TestSetupRecoveryAdoptsMigratedLegacyWorktreeAfterRepoRename(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	const (
+		host     = "github.com"
+		owner    = "acme"
+		name     = "widget"
+		newOwner = "example"
+		newName  = "renamed-widget"
+		branch   = "kenn-forge/issue-7"
+	)
+	repoID, err := d.UpsertRepoByProviderID(t.Context(), db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   host,
+		PlatformRepoID: "repository-stable-id",
+		Owner:          owner,
+		Name:           name,
+	})
+	require.NoError(err)
+	clones := gitclone.New(t.TempDir(), nil)
+	legacyCloneDir, err := clones.ClonePath("github", host, owner, name)
+	require.NoError(err)
+	seedWorkspaceBareCloneAt(t, legacyCloneDir)
+	remoteOutput := runWorkspaceTestGit(
+		t, legacyCloneDir, "config", "--get", "remote.origin.url",
+	)
+	remoteURL := strings.TrimSpace(string(remoteOutput))
+	require.NotEmpty(remoteURL)
+	providerURL := "https://github.com/acme/widget.git"
+	runWorkspaceTestGit(
+		t, legacyCloneDir, "remote", "set-url", "origin", providerURL,
+	)
+	runWorkspaceTestGit(
+		t, legacyCloneDir, "config", "--add",
+		"url."+remoteURL+".insteadOf", providerURL,
+	)
+	configureOriginHeadForIssueWorkspace(t, legacyCloneDir)
+
+	worktreeRoot := t.TempDir()
+	legacyWorktreePath := filepath.Join(
+		worktreeRoot, "github", host, owner, name, "issue-7",
+	)
+	runWorkspaceTestGit(
+		t, legacyCloneDir,
+		"worktree", "add", legacyWorktreePath,
+		"-b", branch, "origin/HEAD",
+	)
+	ws := &Workspace{
+		ID:              "ws-upgraded-legacy-layout",
+		RepoID:          &repoID,
+		Platform:        "github",
+		PlatformHost:    host,
+		RepoOwner:       owner,
+		RepoName:        name,
+		ItemType:        db.WorkspaceItemTypeIssue,
+		ItemNumber:      7,
+		GitHeadRef:      branch,
+		WorkspaceBranch: branch,
+		WorktreePath:    legacyWorktreePath,
+		TmuxSession:     "kenn-forge-ws-upgraded-legacy-layout",
+		Status:          "creating",
+	}
+	require.NoError(d.InsertWorkspace(t.Context(), ws))
+	_, err = d.WriteDB().ExecContext(t.Context(), `
+		UPDATE forge_workspaces
+		SET legacy_clone_owner = ?, legacy_clone_name = ?
+		WHERE id = ?`, owner, name, ws.ID)
+	require.NoError(err)
+	renamedRepoID, err := d.UpsertRepoByProviderID(t.Context(), db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   host,
+		PlatformRepoID: "repository-stable-id",
+		Owner:          newOwner,
+		Name:           newName,
+	})
+	require.NoError(err)
+	require.Equal(repoID, renamedRepoID)
+	ws, err = d.GetWorkspace(t.Context(), ws.ID)
+	require.NoError(err)
+	require.NotNil(ws)
+	assert.Equal(newOwner, ws.RepoOwner)
+	assert.Equal(newName, ws.RepoName)
+	assert.Equal(owner, ws.LegacyCloneOwner)
+	assert.Equal(name, ws.LegacyCloneName)
+
+	mgr := NewManager(d, worktreeRoot)
+	mgr.SetClones(clones)
+	tmuxScript, _ := writeRecorderScript(t)
+	mgr.SetTmuxCommand([]string{tmuxScript})
+
+	err = mgr.Setup(t.Context(), ws)
+
+	require.NoError(err)
+	stored, err := d.GetWorkspace(t.Context(), ws.ID)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.Equal("ready", stored.Status)
+	assert.Equal(branch, stored.WorkspaceBranch)
+	commonDir, err := worktreeCommonGitDir(t.Context(), stored.WorktreePath)
+	require.NoError(err)
+	expectedLegacyDir, err := canonicalFilesystemPath(legacyCloneDir)
+	require.NoError(err)
+	actualDir, err := canonicalFilesystemPath(commonDir)
+	require.NoError(err)
+	assert.Equal(expectedLegacyDir, actualDir)
+
+	runWorkspaceTestGit(
+		t, legacyCloneDir,
+		"worktree", "remove", "--force", legacyWorktreePath,
+	)
+	_, branchExists, err := gitRefSHA(
+		t.Context(), legacyCloneDir, "refs/heads/"+branch,
+	)
+	require.NoError(err)
+	require.True(branchExists)
+
+	dirty, err := mgr.Delete(t.Context(), ws.ID, true, nil)
+	require.NoError(err)
+	assert.Empty(dirty)
+	_, err = os.Stat(legacyWorktreePath)
+	require.ErrorIs(err, os.ErrNotExist)
+	stored, err = d.GetWorkspace(t.Context(), ws.ID)
+	require.NoError(err)
+	assert.Nil(stored)
+	_, branchExists, err = gitRefSHA(
+		t.Context(), legacyCloneDir, "refs/heads/"+branch,
+	)
+	require.NoError(err)
+	assert.False(branchExists)
+}
+
 func TestSetupRecoveryRejectsManagedCloneWhoseOriginChanged(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -1195,7 +1451,9 @@ func TestSetupRecoveryRejectsManagedCloneWhoseOriginChanged(t *testing.T) {
 	seedIssue(t, d, repoID, 7, "")
 
 	clones := gitclone.New(t.TempDir(), nil)
-	cloneDir, err := clones.ClonePath("github", host, owner, name)
+	cloneDir, err := clones.RepositoryClone(
+		repoID, "github", host, owner, name,
+	).ClonePath()
 	require.NoError(err)
 	seedWorkspaceBareCloneAt(t, cloneDir)
 	runWorkspaceTestGit(
@@ -1203,7 +1461,8 @@ func TestSetupRecoveryRejectsManagedCloneWhoseOriginChanged(t *testing.T) {
 		"https://github.com/acme/widget.git",
 	)
 	expectedPath := filepath.Join(
-		worktreeRoot, "github", host, owner, name, "issue-7",
+		worktreeRoot, "github", host, owner, name,
+		fmt.Sprintf("repo-%d", repoID), "issue-7",
 	)
 	runWorkspaceTestGit(
 		t, cloneDir,
@@ -1252,7 +1511,8 @@ func TestCreateIssueReportsRecoverableDirectoryBranch(t *testing.T) {
 
 	const existingBranch = "kenn-forge/issue-7-original-title"
 	expectedPath := filepath.Join(
-		worktreeRoot, "github", platformHost, "acme", "widget", "issue-7",
+		worktreeRoot, "github", platformHost, "acme", "widget",
+		fmt.Sprintf("repo-%d", repoID), "issue-7",
 	)
 	runWorkspaceTestGit(
 		t, localRepo,
@@ -1292,7 +1552,8 @@ func TestSetupDirectoryRecoveryNeverCreatesReplacement(t *testing.T) {
 
 	const branch = "kenn-forge/issue-7"
 	expectedPath := filepath.Join(
-		worktreeRoot, "github", platformHost, "acme", "widget", "issue-7",
+		worktreeRoot, "github", platformHost, "acme", "widget",
+		fmt.Sprintf("repo-%d", repoID), "issue-7",
 	)
 	runWorkspaceTestGit(
 		t, localRepo,
@@ -1345,7 +1606,8 @@ func TestRetryDirectoryRecoveryPreservesExistingWorktree(t *testing.T) {
 
 	const branch = "kenn-forge/issue-7"
 	expectedPath := filepath.Join(
-		worktreeRoot, "github", platformHost, "acme", "widget", "issue-7",
+		worktreeRoot, "github", platformHost, "acme", "widget",
+		fmt.Sprintf("repo-%d", repoID), "issue-7",
 	)
 	runWorkspaceTestGit(
 		t, localRepo,
@@ -1402,7 +1664,8 @@ func TestDeletePendingDirectoryRecoveryPreservesExistingWorktree(t *testing.T) {
 
 	const branch = "kenn-forge/issue-7"
 	expectedPath := filepath.Join(
-		worktreeRoot, "github", platformHost, "acme", "widget", "issue-7",
+		worktreeRoot, "github", platformHost, "acme", "widget",
+		fmt.Sprintf("repo-%d", repoID), "issue-7",
 	)
 	runWorkspaceTestGit(
 		t, localRepo,
@@ -1440,6 +1703,7 @@ func TestDeletePendingDirectoryRecoveryPreservesExistingWorktree(t *testing.T) {
 
 func TestCreateRepoNotTracked(t *testing.T) {
 	d := openTestDB(t)
+	seedRepo(t, d, "github.com", "acme", "widget")
 	mgr := NewManager(d, t.TempDir())
 
 	_, err := mgr.Create(
@@ -2290,9 +2554,9 @@ func TestCreateIssueUsesProviderCloneURLForNamespacedManagedClone(t *testing.T) 
 	require.NoError(err)
 	require.NotNil(ws)
 	assert.Equal("gitlab", ws.Platform)
-	cloneDir, err := clones.ClonePathInNamespace(
-		"gitlab", "gitlab.example.com", "group", "project",
-	)
+	cloneDir, err := clones.RepositoryClone(
+		repoID, "gitlab", "gitlab.example.com", "group", "project",
+	).ClonePath()
 	require.NoError(err)
 	assert.DirExists(cloneDir)
 	assert.Equal(
@@ -2337,10 +2601,59 @@ func TestCreateUsesProviderQualifiedRepo(t *testing.T) {
 	assert.Equal("feature/gitlab", ws.GitHeadRef)
 	assert.Equal(
 		filepath.Join(
-			worktreeDir, "gitlab", "forge.example.com", "acme", "widget", "pr-42",
+			worktreeDir, "gitlab", "forge.example.com", "acme", "widget",
+			fmt.Sprintf("repo-%d", gitlabRepoID), "pr-42",
 		),
 		ws.WorktreePath,
 	)
+}
+
+func TestCreateScopesWorkspaceFilesystemToRepositoryIncarnation(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	worktreeDir := t.TempDir()
+
+	oldRepoID, err := d.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repository-old",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	require.NoError(err)
+	seedMR(t, d, oldRepoID, 42, "feature/old")
+
+	mgr := NewManager(d, worktreeDir)
+	oldWorkspace, err := mgr.Create(
+		ctx, "github", "github.com", "acme", "widget", 42,
+	)
+	require.NoError(err)
+
+	newRepoID, err := d.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "repository-new",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	require.NoError(err)
+	require.NotEqual(oldRepoID, newRepoID)
+	seedMR(t, d, newRepoID, 42, "feature/new")
+
+	newWorkspace, err := mgr.Create(
+		ctx, "github", "github.com", "acme", "widget", 42,
+	)
+	require.NoError(err)
+
+	require.NotNil(oldWorkspace.RepoID)
+	require.NotNil(newWorkspace.RepoID)
+	assert.Equal(oldRepoID, *oldWorkspace.RepoID)
+	assert.Equal(newRepoID, *newWorkspace.RepoID)
+	assert.NotEqual(oldWorkspace.WorktreePath, newWorkspace.WorktreePath)
+	assert.Contains(oldWorkspace.WorktreePath, fmt.Sprintf("repo-%d", oldRepoID))
+	assert.Contains(newWorkspace.WorktreePath, fmt.Sprintf("repo-%d", newRepoID))
 }
 
 func TestSetupUsesManagedCloneForForkPRWithConfiguredWorktreeBasePath(t *testing.T) {
@@ -2367,7 +2680,9 @@ func TestSetupUsesManagedCloneForForkPRWithConfiguredWorktreeBasePath(t *testing
 		t, branch, prNumber,
 	)
 	clones := gitclone.New(cloneBaseDir, nil)
-	cloneDir, err := clones.ClonePath("github", host, owner, name)
+	cloneDir, err := clones.RepositoryClone(
+		repoID, "github", host, owner, name,
+	).ClonePath()
 	require.NoError(err)
 	require.NoError(os.MkdirAll(filepath.Dir(cloneDir), 0o755))
 	runWorkspaceTestGit(t, cloneBaseDir, "clone", "--bare", remote, cloneDir)
@@ -2784,9 +3099,12 @@ func TestCleanupFallsBackToManagedCloneWhenConfiguredBaseInvalid(t *testing.T) {
 	require := require.New(t)
 
 	const branch = "kenn-forge/pr-99"
+	var repoID int64 = 42
 	cloneBaseDir := t.TempDir()
 	clones := gitclone.New(cloneBaseDir, nil)
-	cloneDir, err := clones.ClonePath("github", "github.com", "acme", "widget")
+	cloneDir, err := clones.RepositoryClone(
+		repoID, "github", "github.com", "acme", "widget",
+	).ClonePath()
 	require.NoError(err)
 	require.NoError(os.MkdirAll(filepath.Dir(cloneDir), 0o755))
 	runWorkspaceTestGit(
@@ -2805,6 +3123,7 @@ func TestCleanupFallsBackToManagedCloneWhenConfiguredBaseInvalid(t *testing.T) {
 	mgr.SetWorktreeBasePathResolver(staticBaseResolver(filepath.Join(t.TempDir(), "missing")))
 	ws := &Workspace{
 		ID:              "ws-cleanup-managed-fallback",
+		RepoID:          &repoID,
 		Platform:        "github",
 		PlatformHost:    "github.com",
 		RepoOwner:       "acme",
@@ -2829,11 +3148,12 @@ func TestCleanupUsesProviderScopedManagedClone(t *testing.T) {
 
 	const branch = "kenn-forge/pr-99"
 	const host = "forge.example.com"
+	var repoID int64 = 42
 	cloneBaseDir := t.TempDir()
 	clones := gitclone.New(cloneBaseDir, nil)
-	cloneDir, err := clones.ClonePathInNamespace(
-		workspaceCloneNamespace("gitlab"), host, "acme", "widget",
-	)
+	cloneDir, err := clones.RepositoryClone(
+		repoID, "gitlab", host, "acme", "widget",
+	).ClonePath()
 	require.NoError(err)
 	require.NoError(os.MkdirAll(filepath.Dir(cloneDir), 0o755))
 	runWorkspaceTestGit(
@@ -2851,6 +3171,7 @@ func TestCleanupUsesProviderScopedManagedClone(t *testing.T) {
 	mgr.SetClones(clones)
 	ws := &Workspace{
 		ID:              "ws-cleanup-provider-scoped-managed",
+		RepoID:          &repoID,
 		Platform:        "gitlab",
 		PlatformHost:    host,
 		RepoOwner:       "acme",
@@ -4699,8 +5020,8 @@ func TestManagerReapOrphanTmuxSessionsKeepsStoredRuntimeSessions(
 		`printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"` + "\n" +
 		`for a in "$@"; do` + "\n" +
 		`  if [ "$a" = "list-sessions" ]; then` + "\n" +
-		`    printf 'middleman-0000000000000001:%s\n' "$KENN_FORGE_TMUX_OWNER"` + "\n" +
-		`    printf 'middleman-0000000000000001-57de4cf40144bdf7:%s\n' "$KENN_FORGE_TMUX_OWNER"` + "\n" +
+		`    printf 'kenn-forge-0000000000000001:%s\n' "$KENN_FORGE_TMUX_OWNER"` + "\n" +
+		`    printf 'kenn-forge-0000000000000001-57de4cf40144bdf7:%s\n' "$KENN_FORGE_TMUX_OWNER"` + "\n" +
 		`    printf 'forge-aaaaaaaaaaaaaaaa-c857d09db23e6822:%s\n' "$KENN_FORGE_TMUX_OWNER"` + "\n" +
 		`    exit 0` + "\n" +
 		`  fi` + "\n" +
@@ -4723,12 +5044,12 @@ func TestManagerReapOrphanTmuxSessionsKeepsStoredRuntimeSessions(
 		ItemNumber:   1,
 		GitHeadRef:   "feature/live",
 		WorktreePath: filepath.Join(t.TempDir(), "live"),
-		TmuxSession:  "middleman-0000000000000001",
+		TmuxSession:  "kenn-forge-0000000000000001",
 		Status:       "ready",
 	}))
 	recordRuntimeTmuxSessionForTest(
 		t, d, "0000000000000001", "0000000000000001_codex",
-		"codex", "middleman-0000000000000001-57de4cf40144bdf7",
+		"codex", "kenn-forge-0000000000000001-57de4cf40144bdf7",
 		time.Time{},
 	)
 
@@ -4741,7 +5062,7 @@ func TestManagerReapOrphanTmuxSessionsKeepsStoredRuntimeSessions(
 	})
 	assert.NotContains(argvs, []string{
 		"wrap", "kill-session", "-t",
-		"middleman-0000000000000001-57de4cf40144bdf7",
+		"kenn-forge-0000000000000001-57de4cf40144bdf7",
 	})
 }
 
@@ -4884,7 +5205,7 @@ func TestManagerTmuxSessionListSurvivesTmux36Sanitization(t *testing.T) {
 		`done` + "\n" +
 		`for a in "$@"; do` + "\n" +
 		`  if [ "$a" = "list-sessions" ]; then` + "\n" +
-		`    for name in middleman-0000000000000001 forge-aaaaaaaaaaaaaaaa; do` + "\n" +
+		`    for name in kenn-forge-0000000000000001 forge-aaaaaaaaaaaaaaaa; do` + "\n" +
 		`      printf '%s\n' "$fmt" \` + "\n" +
 		`        | sed -e "s|#{session_name}|$name|" \` + "\n" +
 		`              -e "s|#{@forge_owner}|$KENN_FORGE_TMUX_OWNER|" \` + "\n" +
@@ -4912,7 +5233,7 @@ func TestManagerTmuxSessionListSurvivesTmux36Sanitization(t *testing.T) {
 		ItemNumber:   1,
 		GitHeadRef:   "feature/live",
 		WorktreePath: filepath.Join(t.TempDir(), "live"),
-		TmuxSession:  "middleman-0000000000000001",
+		TmuxSession:  "kenn-forge-0000000000000001",
 		Status:       "ready",
 	}))
 
@@ -4930,7 +5251,7 @@ func TestManagerTmuxSessionListSurvivesTmux36Sanitization(t *testing.T) {
 		"wrap", "kill-session", "-t", "forge-aaaaaaaaaaaaaaaa",
 	})
 	assert.NotContains(argvs, []string{
-		"wrap", "kill-session", "-t", "middleman-0000000000000001",
+		"wrap", "kill-session", "-t", "kenn-forge-0000000000000001",
 	})
 }
 
@@ -5531,6 +5852,7 @@ func TestManagerRequestRetrySkipsGitCleanupWhenCloneMissing(t *testing.T) {
 	require.NoError(os.WriteFile(script, []byte(body), 0o755))
 
 	d := openTestDB(t)
+	repoID := seedRepo(t, d, "github.com", "acme", "widget")
 	mgr := NewManager(d, t.TempDir())
 	mgr.SetTmuxCommand([]string{script, "wrap"})
 	mgr.SetClones(gitclone.New(filepath.Join(dir, "clones"), nil))
@@ -5538,6 +5860,8 @@ func TestManagerRequestRetrySkipsGitCleanupWhenCloneMissing(t *testing.T) {
 	errMsg := "ensure clone failed"
 	ws := &Workspace{
 		ID:              "ws-retry-missing-clone",
+		RepoID:          &repoID,
+		Platform:        "github",
 		PlatformHost:    "github.com",
 		RepoOwner:       "acme",
 		RepoName:        "widget",
@@ -5573,10 +5897,14 @@ func TestIssueRetryCleansLeakedUnknownBranchAndUsesIssueBranch(t *testing.T) {
 
 	host, owner, name := "github.com", "acme", "widget"
 	baseDir := t.TempDir()
-	mgr := NewManager(openTestDB(t), t.TempDir())
+	d := openTestDB(t)
+	repoID := seedRepo(t, d, host, owner, name)
+	mgr := NewManager(d, t.TempDir())
 	mgr.SetClones(gitclone.New(baseDir, nil))
 
-	cloneDir, err := mgr.clones.ClonePath("github", host, owner, name)
+	cloneDir, err := mgr.clones.RepositoryClone(
+		repoID, "github", host, owner, name,
+	).ClonePath()
 	require.NoError(err)
 	seedWorkspaceBareCloneAt(t, cloneDir)
 	configureOriginHeadForIssueWorkspace(t, cloneDir)
@@ -5595,6 +5923,8 @@ func TestIssueRetryCleansLeakedUnknownBranchAndUsesIssueBranch(t *testing.T) {
 
 	ws := &Workspace{
 		ID:              "ws-issue-retry-unknown",
+		RepoID:          &repoID,
+		Platform:        "github",
 		PlatformHost:    host,
 		RepoOwner:       owner,
 		RepoName:        name,
@@ -6344,8 +6674,6 @@ func TestManagerCleanupForDeleteAcquiresRepoLock(t *testing.T) {
 
 	host, owner, name := "github.com", "acme", "widget"
 	baseDir := t.TempDir()
-	cloneDir := filepath.Join(baseDir, host, owner, name+".git")
-	require.NoError(os.MkdirAll(filepath.Dir(cloneDir), 0o755))
 	work := filepath.Join(t.TempDir(), "source")
 	runWorkspaceTestGit(t, baseDir, "init", "--initial-branch=main", work)
 	runWorkspaceTestGit(t, work, "config", "user.email", "test@test.com")
@@ -6355,12 +6683,19 @@ func TestManagerCleanupForDeleteAcquiresRepoLock(t *testing.T) {
 	))
 	runWorkspaceTestGit(t, work, "add", ".")
 	runWorkspaceTestGit(t, work, "commit", "-m", "base commit")
+
+	d := openTestDB(t)
+	repoID := seedRepo(t, d, host, owner, name)
+	mgr := NewManager(d, t.TempDir())
+	mgr.SetClones(gitclone.New(baseDir, nil))
+	cloneDir, err := mgr.clones.RepositoryClone(
+		repoID, "github", host, owner, name,
+	).ClonePath()
+	require.NoError(err)
+	require.NoError(os.MkdirAll(filepath.Dir(cloneDir), 0o755))
 	runWorkspaceTestGit(
 		t, baseDir, "clone", "--bare", work, cloneDir,
 	)
-
-	mgr := NewManager(openTestDB(t), t.TempDir())
-	mgr.SetClones(gitclone.New(baseDir, nil))
 	worktreePath := filepath.Join(t.TempDir(), "missing-wt")
 	runWorkspaceTestGit(
 		t, cloneDir, "worktree", "add", worktreePath, "HEAD",
@@ -6369,6 +6704,8 @@ func TestManagerCleanupForDeleteAcquiresRepoLock(t *testing.T) {
 
 	ws := &Workspace{
 		ID:           "ws-cleanup-lock",
+		RepoID:       &repoID,
+		Platform:     "github",
 		PlatformHost: host,
 		RepoOwner:    owner,
 		RepoName:     name,

--- a/internal/workspace/monitor.go
+++ b/internal/workspace/monitor.go
@@ -139,16 +139,14 @@ func (m *PRMonitor) detectAssociatedPR(
 	if currentBranch == "" {
 		return 0, false, nil
 	}
-	repo, err := m.db.GetRepoByIdentity(ctx, db.RepoIdentity{
-		Platform:     workspaceProvider(ws),
-		PlatformHost: ws.PlatformHost,
-		Owner:        ws.RepoOwner,
-		Name:         ws.RepoName,
-	})
+	if ws.RepoID == nil || *ws.RepoID <= 0 {
+		return 0, false, nil
+	}
+	repo, err := m.db.GetRepoByID(ctx, *ws.RepoID)
 	if err != nil {
 		return 0, false, fmt.Errorf("get repo: %w", err)
 	}
-	if repo == nil {
+	if repo == nil || repo.RetiredAt != nil {
 		return 0, false, nil
 	}
 	candidates, err := m.db.ListMergeRequests(ctx, db.ListMergeRequestsOpts{

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -4604,6 +4604,8 @@ export interface components {
             platform_host: string;
             provider: string;
             repo_path: string;
+            /** Format: int64 */
+            repository_id?: number;
         };
         ArchiveStatusResponse: {
             active_phases: ("issue_inventory" | "merge_request_inventory" | "hydration" | "prompt_maintenance")[] | null;
@@ -8027,6 +8029,8 @@ export interface operations {
                 end: string;
                 /** @description Repeated provider|platform_host/repo_path filters. */
                 repo?: string[] | null;
+                /** @description Repeated immutable repository incarnation IDs. */
+                repo_id?: number[] | null;
                 verbose?: boolean;
             };
             header?: never;
@@ -8093,6 +8097,8 @@ export interface operations {
             query?: {
                 /** @description Repeated provider|platform_host/repo_path filters. */
                 repo?: string[] | null;
+                /** @description Repeated immutable repository incarnation IDs. */
+                repo_id?: number[] | null;
             };
             header?: never;
             path?: never;


### PR DESCRIPTION
- Preserve repository history when a stable provider repository ID moves to a new path.
- Treat path reuse by a different provider ID as a separate repository incarnation.
- Scope repository-owned sync, archive, notification, workspace, and clone state to that incarnation.
- Preserve exact configuration routing and settings behavior across renames and offline restarts.