### PR TITLE
Suppress expected clipboard expiry errors

### DIFF
--- a/frontend/src/lib/components/terminal/terminalClipboardWriter.test.ts
+++ b/frontend/src/lib/components/terminal/terminalClipboardWriter.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
-import { createTerminalClipboardWriter, type TerminalClipboardPort } from "./terminalClipboardWriter";
+import {
+  createBrowserTerminalClipboardPort,
+  createTerminalClipboardWriter,
+  type TerminalClipboardPort,
+} from "./terminalClipboardWriter";
 
 function deferred<T>(): {
   promise: Promise<T>;
@@ -42,6 +46,28 @@ function createPort(): {
 
 afterEach(() => {
   vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("browser terminal clipboard port", () => {
+  it("handles an expired deferred payload without leaking an unhandled rejection", async () => {
+    const payload = deferred<string>();
+    const write = vi.fn(async () => undefined);
+
+    vi.stubGlobal("navigator", { clipboard: { write } });
+    vi.stubGlobal(
+      "ClipboardItem",
+      class {
+        constructor(_items: Record<string, Promise<Blob>>) {}
+      },
+    );
+
+    await createBrowserTerminalClipboardPort().beginDeferredWrite(payload.promise);
+    payload.reject(new DOMException("Terminal clipboard authorization expired", "AbortError"));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(write).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("terminal clipboard writer", () => {

--- a/frontend/src/lib/components/terminal/terminalClipboardWriter.ts
+++ b/frontend/src/lib/components/terminal/terminalClipboardWriter.ts
@@ -34,9 +34,11 @@ export function createBrowserTerminalClipboardPort(): TerminalClipboardPort {
       if (!navigator.clipboard?.write || typeof ClipboardItem === "undefined") {
         throw new DOMException("Deferred clipboard writes are unavailable", "NotSupportedError");
       }
-      const item = new ClipboardItem({
-        "text/plain": text.then((value) => new Blob([value], { type: "text/plain" })),
-      });
+      const payload = text.then((value) => new Blob([value], { type: "text/plain" }));
+      // ClipboardItem does not consistently observe a rejected deferred payload.
+      // Keep the rejection intact so the write is canceled, but mark it handled.
+      void payload.catch(() => undefined);
+      const item = new ClipboardItem({ "text/plain": payload });
       return navigator.clipboard.write([item]);
     },
     writeLocalText(text) {


### PR DESCRIPTION
- Prevent expired terminal clipboard authorizations from surfacing as unhandled `AbortError`s.
- Preserve rejection semantics so expired writes still cancel without changing clipboard contents.
- Cover the browser clipboard adapter with a regression test.

<sup>generated by a clanker</sup>