### PR TITLE
Keep launcher closed during inline workspace deletion

### DIFF
--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -114,6 +114,9 @@ Interactive surfaces must agree on which item is selected.
   surface immediately and reconcile the tombstone away — an ID-less tombstone
   would mask it forever, because the workspace-absent envelope it waits for
   never arrives once the item has a new workspace.
+- Automatic empty-pane launchers stay closed during inline workspace deletion:
+  runtime sessions disappear before the host is removed, and that teardown gap
+  is not a launchable empty workspace (`frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte::autoOpenLauncher`).
 - Catalog-backed routes must normalize missing selections even when the catalog
   is empty: select the first available item or `null`, and clear dependent route
   identity (`frontend/src/lib/components/docs/DocsWorkspace.svelte::loadFolders`).

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -685,6 +685,9 @@
     // state message, and the Retry and Delete beside it, with an invitation to start
     // an agent inside something that cannot run one.
     if (workspace?.status !== "ready") return;
+    // Runtime teardown can reach any of the automatic fallback paths before the
+    // deleted inline host is removed. It is not an empty workspace to relaunch.
+    if (deletingSelectedWorkspace || forceDeleting) return;
     if (launcherAutoOpenedFor.includes(viewWorkspaceKey)) return;
     launcherAutoOpenedFor = [...launcherAutoOpenedFor, viewWorkspaceKey];
     launcherState = { workspaceKey: viewWorkspaceKey, auto: true };
@@ -760,6 +763,7 @@
     const anySession = runtimeSessions.length > 0;
     const openState = launcherState;
     const autoOpened = launcherAutoOpenedFor.includes(workspaceKey);
+    const deletionPending = deletingSelectedWorkspace || forceDeleting;
     untrack(() => {
       if (tabs.length > 0 && activeMissing) selectWorkspaceTab(tabs[0]!.key);
       // A docked terminal is not a workflow tab but is very much on screen, so an
@@ -772,6 +776,9 @@
         if (openState?.workspaceKey === workspaceKey && openState.auto) closeLauncher();
         return;
       }
+      // Deletion tears down the runtime before the inline host disappears. That
+      // sessionless gap is not an empty workspace asking what to launch next.
+      if (deletionPending) return;
       // Once per workspace: reopening a launcher the user dismissed would trap them
       // in it, while a different session-less workspace still gets one.
       if (openState?.workspaceKey === workspaceKey || autoOpened) return;

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -2899,6 +2899,50 @@ describe("WorkspaceTerminalView", () => {
     await waitFor(() => expect(launch.hasAttribute("disabled")).toBe(true));
   });
 
+  it("does not auto-open the session launcher while workspace deletion empties the runtime", async () => {
+    const deleteRequest = deferred<Response>();
+    const eventListeners: Record<string, () => void> = {};
+    vi.stubGlobal(
+      "EventSource",
+      class {
+        addEventListener(type: string, callback: () => void): void {
+          eventListeners[type] = callback;
+        }
+        close(): void {}
+      },
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((input: Request | URL | string, init?: RequestInit) => {
+        const method = init?.method ?? (input instanceof Request ? input.method : "GET");
+        const { pathname } = new URL(input instanceof Request ? input.url : String(input), "http://localhost");
+        if (method === "DELETE" && pathname.endsWith("/workspaces/ws-1")) return deleteRequest.promise;
+        if (pathname.endsWith("/workspaces/ws-1")) {
+          return Promise.resolve(Response.json(workspaceResponse));
+        }
+        if (pathname.endsWith("/api/v1/workspaces")) {
+          return Promise.resolve(Response.json({ workspaces: [workspaceResponse] }));
+        }
+        return Promise.resolve(Response.json({}));
+      }),
+    );
+    claimForPrs();
+
+    render(WorkspaceTerminalView, {
+      props: { workspaceId: "ws-1", paneSurface: "prs" as const },
+    });
+    await waitFor(() => expect(hostedWorkspaceControls()).not.toBeNull());
+    render(WorkspacePaneControls);
+    await screen.findByRole("button", { name: "Launch session" });
+
+    await clickDeleteAndConfirm(screen.getByRole("button", { name: /^Delete workspace / }));
+    mocks.getWorkspaceRuntime.mockResolvedValue(runtimeWithLaunchTargetsOnly());
+    eventListeners["reconnect.stale"]?.();
+
+    await waitFor(() => expect(mocks.getWorkspaceRuntime).toHaveBeenCalledTimes(2));
+    expect(screen.queryByRole("dialog", { name: "Launch a session" })).toBeNull();
+  });
+
   it("leaves workspace strip actions off a broken workspace, whose error panel owns delete", async () => {
     // The strip actions only apply while the workspace is ready. A failed setup
     // cannot launch a session and renders its own Delete beside the Retry the user

--- a/frontend/tests/e2e-full/00-inline-workspace-continuity.spec.ts
+++ b/frontend/tests/e2e-full/00-inline-workspace-continuity.spec.ts
@@ -511,6 +511,90 @@ test.describe("inline workspace pane continuity", () => {
     }
   });
 
+  test("deleting a running inline workspace never reveals the launcher during teardown", async ({ page }) => {
+    test.skip(
+      !hasCommand("git") || !hasCommand("tmux", ["-V"]),
+      "git and tmux are required for the real workspace flow",
+    );
+
+    let isolatedServer: IsolatedE2EServer | null = null;
+    let api: APIRequestContext | null = null;
+    try {
+      isolatedServer = await startIsolatedWorkspaceE2EServer();
+      api = await playwrightRequest.newContext({ baseURL: isolatedServer.info.base_url });
+      const workspace = await createIssueWorkspace(api, 10);
+      const launch = await api.post(`/api/v1/workspaces/${workspace.id}/runtime/sessions`, {
+        data: { target_key: "plain_shell", display_region: "workflow" },
+      });
+      expect(launch.status(), await launch.text()).toBe(200);
+
+      await page.goto(`${isolatedServer.info.base_url}/issues/github/acme/widgets/10`);
+      await expect(page.locator(".detail-pane-workspace-slot .terminal-container")).toBeVisible();
+      const launcher = page.getByRole("dialog", { name: "Launch a session" });
+      await expect(launcher).toHaveCount(0);
+
+      let resolveDeleteProxy!: () => void;
+      const deleteProxyCompleted = new Promise<void>((resolve) => {
+        resolveDeleteProxy = resolve;
+      });
+      // Let the real DELETE stop tmux and remove the workspace, but hold its
+      // response briefly so runtime teardown can render while the inline host is
+      // still present. A mocked runtime response would miss the server ordering
+      // this regression is meant to protect.
+      await page.route(`**/api/v1/workspaces/${workspace.id}`, async (route) => {
+        if (route.request().method() !== "DELETE") {
+          await route.continue();
+          return;
+        }
+        try {
+          const response = await route.fetch();
+          await new Promise((resolve) => setTimeout(resolve, 1_000));
+          await route.fulfill({ response });
+        } finally {
+          resolveDeleteProxy();
+        }
+      });
+
+      // An end-state absence assertion can miss a dialog that mounts for one
+      // render and disappears with the host. Record every added dialog node so
+      // even that transient launch surface fails the test.
+      await page.evaluate(() => {
+        const selector = '[role="dialog"][aria-label="Launch a session"]';
+        const state = { appeared: document.querySelector(selector) !== null };
+        Reflect.set(window, "__middlemanDeleteLauncherProbe", state);
+        new MutationObserver((records) => {
+          for (const record of records) {
+            for (const node of record.addedNodes) {
+              if (node instanceof Element && (node.matches(selector) || node.querySelector(selector) !== null)) {
+                state.appeared = true;
+              }
+            }
+          }
+        }).observe(document.body, { childList: true, subtree: true });
+      });
+
+      await page.getByRole("button", { name: /^Delete workspace / }).click();
+      await page
+        .getByRole("dialog", { name: "Delete workspace?" })
+        .getByRole("button", { name: "Delete workspace" })
+        .click();
+
+      await expect(page.locator(".detail-pane-workspace-slot")).toHaveCount(0, { timeout: 10_000 });
+      await deleteProxyCompleted;
+      const launcherAppeared = await page.evaluate(
+        () =>
+          (Reflect.get(window, "__middlemanDeleteLauncherProbe") as { appeared?: boolean } | undefined)?.appeared ??
+          false,
+      );
+      expect(launcherAppeared).toBe(false);
+      await expect.poll(async () => (await api!.get(`/api/v1/workspaces/${workspace.id}`)).status()).toBe(404);
+    } finally {
+      await page.unrouteAll({ behavior: "ignoreErrors" });
+      await api?.dispose();
+      await isolatedServer?.stop();
+    }
+  });
+
   test("the pane's own maximize and close controls keep the live terminal", async ({ page }) => {
     // The frame-geometry side of maximizing is covered above. This is the same pair
     // of pane-native controls driven for a different question: that the single hosted


### PR DESCRIPTION
Deleting an inline workspace could briefly show the Launch Session dialog while it was being removed.

- Keep the launcher closed throughout normal and force-delete flows.
- Preserve automatic launch prompts for genuinely empty ready workspaces.

[Inline workspace deletion video](https://github.com/user-attachments/assets/e6a1a228-fbc3-4c75-880e-1fc956eba576)