### PR TITLE
Keep terminal text readable across pane redraws

### DIFF
--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -313,6 +313,9 @@ Keyboard handlers must have one clear owner for each key press.
   own, or one tmux session gets two sockets. A container mounts a session into
   the pool only while it actually renders it, since a parked terminal keeps its
   websocket (`frontend/src/lib/stores/session-host.svelte.ts`).
+- xterm WebGL texture atlases are shared across matching live panes; every explicit
+  atlas clear must refresh sibling renderers, or cached glyph coordinates display
+  repurposed characters (`frontend/src/lib/components/terminal/sharedTerminalTextureAtlas.ts::clearSharedTerminalTextureAtlas`).
 - A pooled terminal constructs immediately, even in parking, so every mounted
   session keeps its websocket; it opts out of renderer autofocus. After
   attachment the pool honors queued focus requests — explicit ones always, soft

--- a/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
@@ -25,6 +25,10 @@
     primaryTerminalFontFamily,
   } from "./terminalFontFamily.js";
   import { createInitialFocusIntent } from "./terminal-focus.js";
+  import {
+    clearSharedTerminalTextureAtlas,
+    registerTerminalTextureAtlasParticipant,
+  } from "./sharedTerminalTextureAtlas.js";
   import { createTmuxMouseDragAutoscroll } from "./tmuxMouseDragAutoscroll.js";
 
   interface TerminalPaneProps {
@@ -65,6 +69,7 @@
   let restartTimer: ReturnType<typeof setTimeout> | null = null;
   let reconnectDelay = 1000;
   let resizeObserver: ResizeObserver | null = null;
+  let unregisterTextureAtlasParticipant: (() => void) | null = null;
   let refreshFrame: number | null = null;
   let resizeFrame: number | null = null;
   // What the PTY was last told. Resends are skipped against this, so a
@@ -372,7 +377,7 @@
   function redrawTerminalTextureAtlas(): void {
     if (!terminal) return;
 
-    terminal.clearTextureAtlas();
+    clearSharedTerminalTextureAtlas(terminal);
     terminal.refresh(0, Math.max(0, terminal.rows - 1));
   }
 
@@ -664,6 +669,8 @@
     }
     containerEl?.removeEventListener("paste", handleTerminalPaste, true);
     if (terminal) {
+      unregisterTextureAtlasParticipant?.();
+      unregisterTextureAtlasParticipant = null;
       ligaturesAddon?.dispose();
       ligaturesAddon = null;
       webglAddon?.dispose();
@@ -757,6 +764,8 @@
         disableStdin: disabled,
       });
       terminal = term;
+      unregisterTextureAtlasParticipant =
+        registerTerminalTextureAtlasParticipant(terminal);
 
       term.open(containerEl);
       term.parser.registerOscHandler(52, handleOsc52Clipboard);
@@ -863,7 +872,7 @@
         if (!fontWaitTimedOut || lateFontRebuilt || disposed || !terminal) return;
 
         lateFontRebuilt = true;
-        terminal.clearTextureAtlas();
+        clearSharedTerminalTextureAtlas(terminal);
         // New metrics mean a new measurement; resizeVisibleTerminal re-fits,
         // repaints, and pushes the size only if the region now works out
         // differently.

--- a/frontend/src/lib/components/terminal/sharedTerminalTextureAtlas.test.ts
+++ b/frontend/src/lib/components/terminal/sharedTerminalTextureAtlas.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import {
+  clearSharedTerminalTextureAtlas,
+  registerTerminalTextureAtlasParticipant,
+} from "./sharedTerminalTextureAtlas.js";
+
+function terminal(rows = 24) {
+  return {
+    rows,
+    clearTextureAtlas: vi.fn(),
+    refresh: vi.fn(),
+  };
+}
+
+describe("shared terminal texture atlas", () => {
+  it("repaints sibling terminals after one clears the shared atlas", () => {
+    const source = terminal();
+    const sibling = terminal(30);
+    const unregisterSource = registerTerminalTextureAtlasParticipant(source);
+    const unregisterSibling = registerTerminalTextureAtlasParticipant(sibling);
+
+    clearSharedTerminalTextureAtlas(source);
+
+    expect(source.clearTextureAtlas).toHaveBeenCalledTimes(1);
+    expect(source.refresh).not.toHaveBeenCalled();
+    expect(sibling.refresh).toHaveBeenCalledWith(0, 29);
+    unregisterSource();
+    unregisterSibling();
+  });
+
+  it("does not repaint terminals after they unregister", () => {
+    const source = terminal();
+    const retired = terminal();
+    const unregisterSource = registerTerminalTextureAtlasParticipant(source);
+    const unregisterRetired = registerTerminalTextureAtlasParticipant(retired);
+    unregisterRetired();
+
+    clearSharedTerminalTextureAtlas(source);
+
+    expect(retired.refresh).not.toHaveBeenCalled();
+    unregisterSource();
+  });
+});

--- a/frontend/src/lib/components/terminal/sharedTerminalTextureAtlas.ts
+++ b/frontend/src/lib/components/terminal/sharedTerminalTextureAtlas.ts
@@ -1,0 +1,29 @@
+interface TerminalTextureAtlasParticipant {
+  readonly rows: number;
+  clearTextureAtlas(): void;
+  refresh(start: number, end: number): void;
+}
+
+const participants = new Set<TerminalTextureAtlasParticipant>();
+
+export function registerTerminalTextureAtlasParticipant(terminal: TerminalTextureAtlasParticipant): () => void {
+  participants.add(terminal);
+  return () => participants.delete(terminal);
+}
+
+/**
+ * Clear one terminal's atlas and repaint every other terminal that may share it.
+ *
+ * xterm's WebGL atlas is shared between terminals with matching render options.
+ * In xterm 0.19, clearing that atlas only invalidates the terminal that initiated
+ * the clear, leaving sibling render models pointing at repurposed glyph slots.
+ * The caller already repaints itself as part of its font-metric update, so only
+ * the sibling terminals need an explicit refresh here.
+ */
+export function clearSharedTerminalTextureAtlas(source: TerminalTextureAtlasParticipant): void {
+  source.clearTextureAtlas();
+  for (const terminal of participants) {
+    if (terminal === source) continue;
+    terminal.refresh(0, Math.max(0, terminal.rows - 1));
+  }
+}


### PR DESCRIPTION
- Keep long commands and interactive prompts readable after terminal font changes.
- Prevent sibling terminal panes from displaying characters from repurposed WebGL glyph slots.

<sup>generated by a clanker</sup>