### PR TITLE
fix: restore tmux input modes after workspace reconnect

### DIFF
--- a/cmd/kenn-forge/profiler_e2e_test.go
+++ b/cmd/kenn-forge/profiler_e2e_test.go
@@ -19,6 +19,8 @@ import (
 	"go.kenn.io/forge/internal/runtimelock"
 )
 
+const profilerE2EStartupTimeout = 30 * time.Second
+
 func TestServeStartsProfilerListenerE2E(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -55,11 +57,11 @@ func TestServeStartsProfilerListenerE2E(t *testing.T) {
 		}
 	})
 
-	waitForFile(t, runtimelock.MetadataPath(dataDir), 10*time.Second)
+	waitForFile(t, runtimelock.MetadataPath(dataDir), profilerE2EStartupTimeout)
 	healthBody := waitForHTTPBody(
 		t,
 		fmt.Sprintf("http://127.0.0.1:%d/healthz", appPort),
-		10*time.Second,
+		profilerE2EStartupTimeout,
 	)
 	profilerBody := waitForHTTPBody(
 		t,
@@ -67,7 +69,7 @@ func TestServeStartsProfilerListenerE2E(t *testing.T) {
 			"http://127.0.0.1:%d/debug/pprof/",
 			profilerPort,
 		),
-		10*time.Second,
+		profilerE2EStartupTimeout,
 	)
 
 	assert.Contains(healthBody, `"status":"ok"`)

--- a/context/testing.md
+++ b/context/testing.md
@@ -117,6 +117,9 @@ owner:
 - Use full-stack e2e or server/API tests when the disputed fact is produced by
   backend persistence, sync, capabilities, normalization, route middleware, or
   wire serialization.
+- Real-tmux Playwright tests observe user-visible state through the per-instance socket;
+  never replace global key bindings, which can leak into developer sessions and prove only event receipt
+  (`frontend/tests/e2e-full/00-inline-workspace-continuity.spec.ts::expectWheelScroll`).
 
 A UI regression can be sufficiently covered by a backend/server test for the
 real runtime path plus a component or Vitest browser test for presentation. Do

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -332,7 +332,9 @@ Keyboard handlers must have one clear owner for each key press.
   Ownership is revoked by any other element's focus claim, and by a park that
   settles with no destination (the pane closed) — a cross-flush transfer's
   transient no-destination park keeps it. A restore fires only into unclaimed
-  focus (`frontend/src/lib/components/terminal/PooledSessionTerminal.svelte`).
+  focus and after the attachment's `inert` removal commits, since browsers
+  silently ignore focus inside inert subtrees
+  (`frontend/src/lib/components/terminal/PooledSessionTerminal.svelte`).
 - A slot's `visible` means PAINTED, never FOCUSED. It gates INTERACTIVITY — an
   invisible slot's terminal is `inert`, dead to pointer and keyboard — so a
   container that reports only its focused session makes the other halves of a

--- a/context/workspace-runtime-lifecycle.md
+++ b/context/workspace-runtime-lifecycle.md
@@ -104,14 +104,18 @@ still exists.
   and ignored 1005/1015 encodings cannot re-enable modes or displace 1006/1016
   (`internal/workspace/localruntime/terminal_input_modes.go::terminalInputModeState.observe`).
 - Recognize C1 CSI only as decoded U+009B; valid non-C1 UTF-8 invalidates pending
-  controls, while standalone continuation bytes are decoder-discarded
+  controls, while invalid scalars, BOM, and standalone continuation bytes are
+  decoder-discarded without reaching the VT parser
   (`internal/workspace/localruntime/terminal_input_modes.go::terminalInputModeState.observe`).
 - Send reconnect cancellation to xterm as bytes, not text; only binary input
   clears its streaming UTF-8 decoder before replay
   (`frontend/src/lib/components/terminal/XtermTerminalPane.svelte::cancelPendingTerminalSequence`).
-- A same-renderer reconnect with unchanged geometry must omit initial size and
-  refresh controls; tmux redraw output can interrupt a retained VT/UTF-8 tail
-  (`frontend/src/lib/components/terminal/XtermTerminalPane.svelte::connect`).
+- Direct local-runtime sessions request a subscriber-only replay boundary and
+  withhold resize/refresh controls until xterm parses it; the backend queues the
+  boundary only after the retained VT/UTF-8 tail reaches ground. Fresh legacy
+  and Fleet attachments still receive dimensions on every connection
+  (`frontend/src/lib/components/terminal/XtermTerminalPane.svelte::connect`,
+  `internal/workspace/localruntime/manager.go::session.subscribeInternal`).
 - In xterm.js 6, DECSTR resets cursor keys, focus reporting, and bracketed paste,
   but leaves the mouse service's protocol and encoding unchanged
   (`internal/workspace/localruntime/terminal_input_modes.go::terminalInputModeState.softReset`).
@@ -248,9 +252,9 @@ behavior.
   runs clone/setup in a background goroutine; if the test returns first, that
   goroutine can keep writing into the test's `t.TempDir` clone path and race
   `RemoveAll` teardown, failing intermittently with "directory not empty".
-- Test fixtures must force-delete created workspaces before handler shutdown;
-  shutdown preserves durable base tmux sessions, so temp-dir cleanup alone leaks
-  sessions (`internal/server/kataapi/test_helpers_test.go::newKataTestServer`).
+- Kata API fixtures must use their package-private tmux server and force-delete
+  created workspaces; shutdown preserves durable base sessions, so temp-dir
+  cleanup alone leaks (`internal/server/kataapi/testmain_test.go::TestMain`).
 - Use tmux wrappers/fakes for missing-session and dead-server cases.
 - Add frontend or Playwright coverage when the regression is visible in tab
   selection, shell drawer state, or workspace navigation.

--- a/context/workspace-runtime-lifecycle.md
+++ b/context/workspace-runtime-lifecycle.md
@@ -94,6 +94,27 @@ still exists.
 - Every tmux client attach must force UTF-8; service launchers may omit locale
   variables, causing tmux to replace non-ASCII output before WebSocket transport
   (`internal/workspace/localruntime/tmux_launcher.go::tmuxAttachSessionCommand`).
+- Local-runtime reconnects restore browser-generated cursor-key, mouse, focus,
+  and paste DEC modes from session-wide PTY state, not bounded screen replay
+  (`internal/workspace/localruntime/manager.go::session.subscribe`).
+- Mode transitions precede one session-wide UTF-8-aware VT tail even in the
+  alternate screen; retain split-rune introducers and decoded C1 controls/ST
+  (`internal/workspace/localruntime/terminal_sequence_tail.go::trailingIncompleteTerminalDataLen`).
+- Mode replay must mirror xterm.js 6 effective semantics: DEC private save/restore
+  and ignored 1005/1015 encodings cannot re-enable modes or displace 1006/1016
+  (`internal/workspace/localruntime/terminal_input_modes.go::terminalInputModeState.observe`).
+- Recognize C1 CSI only as decoded U+009B; valid non-C1 UTF-8 invalidates pending
+  controls, while standalone continuation bytes are decoder-discarded
+  (`internal/workspace/localruntime/terminal_input_modes.go::terminalInputModeState.observe`).
+- Send reconnect cancellation to xterm as bytes, not text; only binary input
+  clears its streaming UTF-8 decoder before replay
+  (`frontend/src/lib/components/terminal/XtermTerminalPane.svelte::cancelPendingTerminalSequence`).
+- A same-renderer reconnect with unchanged geometry must omit initial size and
+  refresh controls; tmux redraw output can interrupt a retained VT/UTF-8 tail
+  (`frontend/src/lib/components/terminal/XtermTerminalPane.svelte::connect`).
+- In xterm.js 6, DECSTR resets cursor keys, focus reporting, and bracketed paste,
+  but leaves the mouse service's protocol and encoding unchanged
+  (`internal/workspace/localruntime/terminal_input_modes.go::terminalInputModeState.softReset`).
 
 ## UI Contract Rules
 
@@ -227,6 +248,9 @@ behavior.
   runs clone/setup in a background goroutine; if the test returns first, that
   goroutine can keep writing into the test's `t.TempDir` clone path and race
   `RemoveAll` teardown, failing intermittently with "directory not empty".
+- Test fixtures must force-delete created workspaces before handler shutdown;
+  shutdown preserves durable base tmux sessions, so temp-dir cleanup alone leaks
+  sessions (`internal/server/kataapi/test_helpers_test.go::newKataTestServer`).
 - Use tmux wrappers/fakes for missing-session and dead-server cases.
 - Add frontend or Playwright coverage when the regression is visible in tab
   selection, shell drawer state, or workspace navigation.

--- a/frontend/src/lib/components/terminal/PooledSessionTerminal.svelte
+++ b/frontend/src/lib/components/terminal/PooledSessionTerminal.svelte
@@ -106,8 +106,24 @@
       requested === "explicit" || (requested === "soft" && !focusIsSacred(document.activeElement));
     const unclaimed = document.activeElement === null || document.activeElement === document.body;
     if (!granted && !(ownsFocus && unclaimed)) return;
-    terminalPane?.focus();
-    if (!node.contains(document.activeElement)) node.focus();
+    const focusAtDecision = document.activeElement;
+    void (async () => {
+      // The active/attached state that admitted this effect also removes
+      // inert. Wait for that DOM update before asking xterm to focus; browsers
+      // silently ignore focus() inside an inert subtree.
+      await tick();
+      if (!attached || !active || wrapper !== node || node.inert) return;
+      if (
+        requested !== "explicit" &&
+        document.activeElement !== focusAtDecision &&
+        (focusIsSacred(document.activeElement) ||
+          (document.activeElement !== null && document.activeElement !== document.body))
+      ) {
+        return;
+      }
+      terminalPane?.focus();
+      if (!node.contains(document.activeElement)) node.focus();
+    })();
   });
 
   // The wrapper is reparented out of this component's own fragment, so Svelte

--- a/frontend/src/lib/components/terminal/TerminalPane.test.ts
+++ b/frontend/src/lib/components/terminal/TerminalPane.test.ts
@@ -815,6 +815,24 @@ describe("TerminalPane", () => {
     expect(mouseDragReset).toHaveBeenCalledTimes(1);
   });
 
+  it("does not redraw tmux when a same-size renderer reconnects", async () => {
+    render(TerminalPane, { props: { workspaceId: "ws-123", active: true } });
+
+    await waitFor(() => expect(mockSockets).toHaveLength(1));
+    const firstSocket = mockSockets[0]!;
+    firstSocket.onopen?.();
+    vi.useFakeTimers();
+
+    firstSocket.onclose?.();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(mockSockets).toHaveLength(2);
+    const reconnectedSocket = mockSockets[1]!;
+
+    expect(reconnectedSocket.url).not.toMatch(/[?&](?:cols|rows)=/);
+    reconnectedSocket.onopen?.();
+    expect(reconnectedSocket.sent.map(String)).not.toContainEqual(expect.stringContaining('"type":"refresh"'));
+  });
+
   it("aborts a partial OSC sequence before writing output from a reconnected socket", async () => {
     render(TerminalPane, { props: { workspaceId: "ws-123" } });
 
@@ -841,6 +859,39 @@ describe("TerminalPane", () => {
       typeof data === "string" ? data : new TextDecoder().decode(data),
     );
     expect(writtenChunks).toEqual(["\x1b]52;c;cGFydGlhbA==", "\x18", "fresh session output"]);
+    expect(terminal.write.mock.calls[1]![0]).toEqual(new Uint8Array([0x18]));
+  });
+
+  it("clears an incomplete UTF-8 byte before replaying it into the same terminal", async () => {
+    render(TerminalPane, { props: { workspaceId: "ws-123" } });
+
+    await waitFor(() => expect(mockSockets).toHaveLength(1));
+    const terminal = xtermInstances[0]!;
+    const firstSocket = mockSockets[0]!;
+    terminal.write.mockClear();
+    vi.useFakeTimers();
+    const binaryMessage = (bytes: number[]): MessageEvent => {
+      const data = new Uint8Array(new window.ArrayBuffer(bytes.length));
+      data.set(bytes);
+      return new MessageEvent("message", { data: data.buffer });
+    };
+
+    firstSocket.onmessage?.(binaryMessage([0xe2]));
+    firstSocket.onclose?.();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(mockSockets).toHaveLength(2);
+
+    // The new subscriber replays the prefix before live output completes the
+    // rune. The byte CAN between them must clear xterm's streaming decoder.
+    mockSockets[1]!.onmessage?.(binaryMessage([0xe2]));
+    mockSockets[1]!.onmessage?.(binaryMessage([0x98, 0x83]));
+
+    expect(terminal.write.mock.calls.map(([data]) => Array.from(data as Uint8Array))).toEqual([
+      [0xe2],
+      [0x18],
+      [0xe2],
+      [0x98, 0x83],
+    ]);
   });
 
   it("revokes pointer clipboard authorization when the window loses focus", async () => {

--- a/frontend/src/lib/components/terminal/TerminalPane.test.ts
+++ b/frontend/src/lib/components/terminal/TerminalPane.test.ts
@@ -58,6 +58,7 @@ let configuredLetterSpacing = 0;
 let configuredCursorBlink = true;
 let configuredFontLigatures = false;
 let mockSockets: MockWebSocket[] = [];
+let initialTerminalDimensions = { cols: 80, rows: 24 };
 // What the fit addon measures the region as. undefined models a container with
 // no content box (a parked terminal), for which the real addon proposes nothing.
 let fitDimensions: { cols: number; rows: number } | undefined = { cols: 80, rows: 24 };
@@ -154,8 +155,8 @@ vi.mock("@xterm/xterm", () => ({
   Terminal: vi.fn().mockImplementation(function (options) {
     xtermTerminalCtor(options);
     const terminal = {
-      cols: 80,
-      rows: 24,
+      cols: initialTerminalDimensions.cols,
+      rows: initialTerminalDimensions.rows,
       modes: { bracketedPasteMode: false },
       options: { ...options },
       clearTextureAtlas: vi.fn(),
@@ -227,6 +228,7 @@ describe("TerminalPane", () => {
     configuredLetterSpacing = 0;
     configuredCursorBlink = true;
     configuredFontLigatures = false;
+    initialTerminalDimensions = { cols: 80, rows: 24 };
     fitDimensions = { cols: 80, rows: 24 };
     ligaturesAddonCtor.mockReset();
     clipboardWriteText.mockReset();
@@ -815,8 +817,22 @@ describe("TerminalPane", () => {
     expect(mouseDragReset).toHaveBeenCalledTimes(1);
   });
 
-  it("does not redraw tmux when a same-size renderer reconnects", async () => {
-    render(TerminalPane, { props: { workspaceId: "ws-123", active: true } });
+  it.each([
+    {
+      name: "legacy workspace terminal",
+      props: { workspaceId: "ws-123", active: true },
+    },
+    {
+      name: "Fleet session",
+      props: {
+        websocketPath: "/ws/v1/fleet/hosts/peer/workspaces/ws-123/runtime/sessions/ws-123%3Ashell/terminal",
+        active: true,
+      },
+    },
+  ])("resends dimensions without a client refresh when a $name reconnects", async ({ props }) => {
+    initialTerminalDimensions = { cols: 177, rows: 41 };
+    fitDimensions = initialTerminalDimensions;
+    render(TerminalPane, { props });
 
     await waitFor(() => expect(mockSockets).toHaveLength(1));
     const firstSocket = mockSockets[0]!;
@@ -828,9 +844,45 @@ describe("TerminalPane", () => {
     expect(mockSockets).toHaveLength(2);
     const reconnectedSocket = mockSockets[1]!;
 
-    expect(reconnectedSocket.url).not.toMatch(/[?&](?:cols|rows)=/);
+    const reconnectURL = new URL(reconnectedSocket.url);
+    expect(reconnectURL.searchParams.get("cols")).toBe("177");
+    expect(reconnectURL.searchParams.get("rows")).toBe("41");
     reconnectedSocket.onopen?.();
     expect(reconnectedSocket.sent.map(String)).not.toContainEqual(expect.stringContaining('"type":"refresh"'));
+  });
+
+  it("waits for replay parsing before resizing a reconnected local runtime session", async () => {
+    initialTerminalDimensions = { cols: 177, rows: 41 };
+    fitDimensions = initialTerminalDimensions;
+    render(TerminalPane, {
+      props: {
+        websocketPath: "/ws/v1/workspaces/ws-123/runtime/sessions/ws-123%3Ashell/terminal",
+        active: true,
+      },
+    });
+
+    await waitFor(() => expect(mockSockets).toHaveLength(1));
+    const firstSocket = mockSockets[0]!;
+    expect(new URL(firstSocket.url).searchParams.get("replay_boundary")).toBe("1");
+    expect(new URL(firstSocket.url).searchParams.has("cols")).toBe(false);
+    firstSocket.onopen?.();
+    expect(firstSocket.sent.map(String)).not.toContainEqual(expect.stringContaining('"type":"refresh"'));
+
+    firstSocket.onmessage?.(new MessageEvent("message", { data: JSON.stringify({ type: "replay_ready" }) }));
+    const firstBoundaryCallback = xtermInstances[0]!.write.mock.calls.at(-1)?.[1] as (() => void) | undefined;
+    expect(firstBoundaryCallback).toBeTypeOf("function");
+    firstBoundaryCallback?.();
+    expect(firstSocket.sent.map(String)).toContain(JSON.stringify({ type: "refresh", cols: 177, rows: 41 }));
+
+    vi.useFakeTimers();
+    firstSocket.onclose?.();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(mockSockets).toHaveLength(2);
+    const reconnectedSocket = mockSockets[1]!;
+    const reconnectURL = new URL(reconnectedSocket.url);
+    expect(reconnectURL.searchParams.get("replay_boundary")).toBe("1");
+    expect(reconnectURL.searchParams.has("cols")).toBe(false);
+    expect(reconnectURL.searchParams.has("rows")).toBe(false);
   });
 
   it("aborts a partial OSC sequence before writing output from a reconnected socket", async () => {

--- a/frontend/src/lib/components/terminal/XtermTerminalPane.replay.browser.svelte.ts
+++ b/frontend/src/lib/components/terminal/XtermTerminalPane.replay.browser.svelte.ts
@@ -1,0 +1,185 @@
+import { Terminal } from "@xterm/xterm";
+import { describe, expect, it } from "vite-plus/test";
+
+function writeParsed(terminal: Terminal, data: string | Uint8Array): Promise<void> {
+  return new Promise((resolve) => {
+    terminal.write(data, resolve);
+  });
+}
+
+describe("xterm terminal replay", () => {
+  it("clears the decoder before replaying a split UTF-8 rune into the same renderer", async () => {
+    const target = document.createElement("div");
+    target.style.width = "600px";
+    target.style.height = "400px";
+    document.body.appendChild(target);
+    const terminal = new Terminal();
+    terminal.open(target);
+
+    try {
+      // The old socket leaves a prefix in xterm's decoder. Disconnect writes
+      // binary CAN, then the new subscriber replays that prefix before live
+      // output supplies the continuation bytes.
+      await writeParsed(terminal, new Uint8Array([0xe2]));
+      await writeParsed(terminal, new Uint8Array([0x18]));
+      await writeParsed(terminal, new Uint8Array([0xe2]));
+      await writeParsed(terminal, new Uint8Array([0x98, 0x83, 0x41]));
+
+      expect(terminal.buffer.active.getLine(0)?.translateToString(true)).toBe("☃A");
+    } finally {
+      terminal.dispose();
+      target.remove();
+    }
+  });
+
+  it("parses a live DECSET continuation after replay transitions", async () => {
+    const target = document.createElement("div");
+    target.style.width = "600px";
+    target.style.height = "400px";
+    document.body.appendChild(target);
+    const terminal = new Terminal();
+    terminal.open(target);
+
+    try {
+      await writeParsed(terminal, "screen\x1b[?2004h\x1b[?1000");
+      expect(terminal.modes.bracketedPasteMode).toBe(true);
+      expect(terminal.modes.mouseTrackingMode).toBe("none");
+
+      await writeParsed(terminal, "h");
+      expect(terminal.modes.mouseTrackingMode).toBe("vt200");
+    } finally {
+      terminal.dispose();
+      target.remove();
+    }
+  });
+
+  it("drops raw C1 bytes but parses their valid UTF-8 encoding", async () => {
+    const target = document.createElement("div");
+    target.style.width = "600px";
+    target.style.height = "400px";
+    document.body.appendChild(target);
+    const terminal = new Terminal();
+    terminal.open(target);
+
+    try {
+      await writeParsed(terminal, new Uint8Array([0x9b, 0x3f, 0x32, 0x30, 0x30, 0x34, 0x68]));
+      expect(terminal.modes.bracketedPasteMode).toBe(false);
+
+      await writeParsed(terminal, new Uint8Array([0xc2, 0x9b, 0x3f, 0x32, 0x30, 0x30, 0x34, 0x68]));
+      expect(terminal.modes.bracketedPasteMode).toBe(true);
+    } finally {
+      terminal.dispose();
+      target.remove();
+    }
+  });
+
+  it("ignores DEC private-mode save and restore finals", async () => {
+    const target = document.createElement("div");
+    target.style.width = "600px";
+    target.style.height = "400px";
+    document.body.appendChild(target);
+    const terminal = new Terminal();
+    terminal.open(target);
+
+    try {
+      await writeParsed(terminal, "\x1b[?1;1000;1004;2004h");
+      expect(terminal.modes.applicationCursorKeysMode).toBe(true);
+      expect(terminal.modes.mouseTrackingMode).toBe("vt200");
+      expect(terminal.modes.sendFocusMode).toBe(true);
+      expect(terminal.modes.bracketedPasteMode).toBe(true);
+
+      await writeParsed(terminal, "\x1b[?1;1000;1004;2004s\x1b[?1;1000;1004;2004l\x1b[?1;1000;1004;2004r");
+      expect(terminal.modes.applicationCursorKeysMode).toBe(false);
+      expect(terminal.modes.mouseTrackingMode).toBe("none");
+      expect(terminal.modes.sendFocusMode).toBe(false);
+      expect(terminal.modes.bracketedPasteMode).toBe(false);
+    } finally {
+      terminal.dispose();
+      target.remove();
+    }
+  });
+
+  it("resets core modes but preserves the mouse service on DECSTR", async () => {
+    const target = document.createElement("div");
+    target.style.width = "600px";
+    target.style.height = "400px";
+    document.body.appendChild(target);
+    const terminal = new Terminal();
+    terminal.open(target);
+    const reports: string[] = [];
+    const dataSubscription = terminal.onData((data) => reports.push(data));
+
+    try {
+      await writeParsed(terminal, "\x1b[?1;1000;1004;1006;2004h");
+      expect(terminal.modes.applicationCursorKeysMode).toBe(true);
+      expect(terminal.modes.mouseTrackingMode).toBe("vt200");
+      expect(terminal.modes.sendFocusMode).toBe(true);
+      expect(terminal.modes.bracketedPasteMode).toBe(true);
+
+      await writeParsed(terminal, "\x1b[!p");
+      expect(terminal.modes.applicationCursorKeysMode).toBe(false);
+      expect(terminal.modes.mouseTrackingMode).toBe("vt200");
+      expect(terminal.modes.sendFocusMode).toBe(false);
+      expect(terminal.modes.bracketedPasteMode).toBe(false);
+
+      reports.length = 0;
+      const screen = target.querySelector<HTMLElement>(".xterm-screen");
+      expect(screen).not.toBeNull();
+      const bounds = screen!.getBoundingClientRect();
+      terminal.element!.dispatchEvent(
+        new MouseEvent("mousedown", {
+          bubbles: true,
+          cancelable: true,
+          button: 0,
+          buttons: 1,
+          clientX: bounds.left + 10,
+          clientY: bounds.top + 10,
+        }),
+      );
+      expect(reports.join("")).toMatch(/^\x1b\[<0;\d+;\d+M$/);
+    } finally {
+      dataSubscription.dispose();
+      terminal.dispose();
+      target.remove();
+    }
+  });
+
+  it.each([
+    ["ignored urxvt encoding after SGR", "\x1b[?1000;1006;1015h"],
+    ["ignored urxvt encoding before SGR", "\x1b[?1000;1015;1006h"],
+    ["ignored UTF-8 encoding after SGR pixels", "\x1b[?1000;1016;1005h"],
+    ["ignored UTF-8 encoding before SGR pixels", "\x1b[?1000;1005;1016h"],
+  ])("keeps %s", async (_name, sequence) => {
+    const target = document.createElement("div");
+    target.style.width = "600px";
+    target.style.height = "400px";
+    document.body.appendChild(target);
+    const terminal = new Terminal();
+    terminal.open(target);
+    const reports: string[] = [];
+    const dataSubscription = terminal.onData((data) => reports.push(data));
+
+    try {
+      await writeParsed(terminal, sequence);
+      const screen = target.querySelector<HTMLElement>(".xterm-screen");
+      expect(screen).not.toBeNull();
+      const bounds = screen!.getBoundingClientRect();
+      terminal.element!.dispatchEvent(
+        new MouseEvent("mousedown", {
+          bubbles: true,
+          cancelable: true,
+          button: 0,
+          buttons: 1,
+          clientX: bounds.left + 10,
+          clientY: bounds.top + 10,
+        }),
+      );
+
+      expect(reports.join("")).toMatch(/^\x1b\[<0;\d+;\d+M$/);
+    } finally {
+      dataSubscription.dispose();
+      terminal.dispose();
+      target.remove();
+    }
+  });
+});

--- a/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
@@ -77,6 +77,7 @@
   let sentCols = 0;
   let sentRows = 0;
   let sentResizeActive: boolean | null = null;
+  let resizeReady = true;
   let appliedTerminalFontFamily = "";
   let appliedFontSize = 0;
   let appliedScrollback = 0;
@@ -136,8 +137,8 @@
     });
   }
 
-  function cancelPendingTerminalSequence(): void {
-    terminal?.write(TERMINAL_SEQUENCE_CANCEL);
+  function cancelPendingTerminalSequence(callback?: () => void): void {
+    terminal?.write(TERMINAL_SEQUENCE_CANCEL, callback);
   }
 
   function handleOsc52Clipboard(data: string): boolean {
@@ -292,6 +293,7 @@
   function appendConnectionParams(
     url: string,
     size: { cols: number; rows: number } | null,
+    replayBoundary: boolean,
   ): string {
     const sep = url.includes("?") ? "&" : "?";
     const resizeActive = resizeAuthorityRegionSize() !== null ? "1" : "0";
@@ -299,18 +301,20 @@
     const sizeParams = size
       ? `cols=${size.cols}&rows=${size.rows}&`
       : "";
-    let result = `${url}${sep}${sizeParams}resize_active=${resizeActive}&traceparent=${encodeURIComponent(traceparent)}`;
+    const replayBoundaryParam = replayBoundary ? "replay_boundary=1&" : "";
+    let result = `${url}${sep}${sizeParams}${replayBoundaryParam}resize_active=${resizeActive}&traceparent=${encodeURIComponent(traceparent)}`;
     if (baggage !== null) result += `&baggage=${encodeURIComponent(baggage)}`;
     return result;
   }
 
   function buildWsUrl(
     size: { cols: number; rows: number } | null,
+    replayBoundary: boolean,
   ): string | null {
     const path = websocketPath ?? defaultWebsocketPath();
     if (!path) return null;
 
-    const withConnectionParams = appendConnectionParams(path, size);
+    const withConnectionParams = appendConnectionParams(path, size, replayBoundary);
     if (/^wss?:\/\//.test(withConnectionParams)) {
       return withConnectionParams;
     }
@@ -320,6 +324,19 @@
     if (devUrl) return devUrl;
     const proto = location.protocol === "https:" ? "wss" : "ws";
     return `${proto}://${location.host}${withBasePath(withConnectionParams)}`;
+  }
+
+  function supportsReplayBoundary(): boolean {
+    if (!websocketPath) return false;
+    try {
+      const pathname = new URL(websocketPath, window.location.href).pathname;
+      return (
+        !pathname.includes("/fleet/hosts/") &&
+        /\/workspaces\/[^/]+\/runtime\/sessions\/[^/]+\/terminal$/.test(pathname)
+      );
+    } catch {
+      return false;
+    }
   }
 
   function withBasePath(path: string): string {
@@ -376,7 +393,7 @@
     cols: number,
     rows: number,
   ): boolean {
-    if (ws?.readyState !== WebSocket.OPEN) return false;
+    if (!resizeReady || ws?.readyState !== WebSocket.OPEN) return false;
     ws.send(JSON.stringify({ type, cols, rows }));
     return true;
   }
@@ -546,12 +563,13 @@
     mouseDragAutoscroll.reset();
     const cols = terminal.cols;
     const rows = terminal.rows;
-    const sizeAlreadySent = cols === sentCols && rows === sentRows;
-    const url = buildWsUrl(sizeAlreadySent ? null : { cols, rows });
+    const replayBoundary = supportsReplayBoundary();
+    const url = buildWsUrl(replayBoundary ? null : { cols, rows }, replayBoundary);
     if (!url) return;
     const socket = new WebSocket(url);
     socket.binaryType = "arraybuffer";
     sentResizeActive = null;
+    resizeReady = !replayBoundary;
     ws = socket;
 
     socket.onopen = () => {
@@ -559,7 +577,7 @@
       reconnectDelay = 1000;
       sendResizeActive(resizeAuthorityRegionSize() !== null);
       const size = resizeAuthorityRegionSize();
-      if (size && (size.cols !== sentCols || size.rows !== sentRows)) {
+      if (resizeReady && size && (size.cols !== sentCols || size.rows !== sentRows)) {
         scheduleTerminalRefresh();
       }
     };
@@ -595,7 +613,13 @@
             type: string;
             code?: number;
           };
-          if (msg.type === "exited") {
+          if (msg.type === "replay_ready" && replayBoundary) {
+            cancelPendingTerminalSequence(() => {
+              if (disposed || ws !== socket) return;
+              resizeReady = true;
+              scheduleTerminalRefresh();
+            });
+          } else if (msg.type === "exited") {
             cancelPendingTerminalSequence();
             onExit?.(msg.code ?? 0);
             exited = true;

--- a/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
@@ -122,7 +122,7 @@
   const TERMINAL_MINIMUM_CONTRAST_RATIO = 4.5;
   const TERMINAL_FONT_WAIT_MS = 300;
   const TERMINAL_FONT_LOAD_GLYPHS = "0MWim@#";
-  const TERMINAL_SEQUENCE_CANCEL = "\x18";
+  const TERMINAL_SEQUENCE_CANCEL = new Uint8Array([0x18]);
 
   function isAttachableInitialStatus(status: string | undefined): boolean {
     return status === undefined || status === "running" || status === "starting";
@@ -289,36 +289,37 @@
     return workspaceTmuxWebSocketPath(workspaceId);
   }
 
-  function appendSizeParams(
+  function appendConnectionParams(
     url: string,
-    cols: number,
-    rows: number,
+    size: { cols: number; rows: number } | null,
   ): string {
     const sep = url.includes("?") ? "&" : "?";
     const resizeActive = resizeAuthorityRegionSize() !== null ? "1" : "0";
     const { traceparent, baggage } = traceHeadersForRequest();
-    let result = `${url}${sep}cols=${cols}&rows=${rows}&resize_active=${resizeActive}&traceparent=${encodeURIComponent(traceparent)}`;
+    const sizeParams = size
+      ? `cols=${size.cols}&rows=${size.rows}&`
+      : "";
+    let result = `${url}${sep}${sizeParams}resize_active=${resizeActive}&traceparent=${encodeURIComponent(traceparent)}`;
     if (baggage !== null) result += `&baggage=${encodeURIComponent(baggage)}`;
     return result;
   }
 
   function buildWsUrl(
-    cols: number,
-    rows: number,
+    size: { cols: number; rows: number } | null,
   ): string | null {
     const path = websocketPath ?? defaultWebsocketPath();
     if (!path) return null;
 
-    const withSize = appendSizeParams(path, cols, rows);
-    if (/^wss?:\/\//.test(withSize)) {
-      return withSize;
+    const withConnectionParams = appendConnectionParams(path, size);
+    if (/^wss?:\/\//.test(withConnectionParams)) {
+      return withConnectionParams;
     }
-    const embeddedUrl = embeddedWebSocketUrl(withBasePath(withSize));
+    const embeddedUrl = embeddedWebSocketUrl(withBasePath(withConnectionParams));
     if (embeddedUrl) return embeddedUrl;
-    const devUrl = buildDevApiWsUrl(withSize);
+    const devUrl = buildDevApiWsUrl(withConnectionParams);
     if (devUrl) return devUrl;
     const proto = location.protocol === "https:" ? "wss" : "ws";
-    return `${proto}://${location.host}${withBasePath(withSize)}`;
+    return `${proto}://${location.host}${withBasePath(withConnectionParams)}`;
   }
 
   function withBasePath(path: string): string {
@@ -545,7 +546,8 @@
     mouseDragAutoscroll.reset();
     const cols = terminal.cols;
     const rows = terminal.rows;
-    const url = buildWsUrl(cols, rows);
+    const sizeAlreadySent = cols === sentCols && rows === sentRows;
+    const url = buildWsUrl(sizeAlreadySent ? null : { cols, rows });
     if (!url) return;
     const socket = new WebSocket(url);
     socket.binaryType = "arraybuffer";
@@ -556,7 +558,10 @@
       switchTimer.record("socket-open");
       reconnectDelay = 1000;
       sendResizeActive(resizeAuthorityRegionSize() !== null);
-      if (active) scheduleTerminalRefresh();
+      const size = resizeAuthorityRegionSize();
+      if (size && (size.cols !== sentCols || size.rows !== sentRows)) {
+        scheduleTerminalRefresh();
+      }
     };
 
     socket.onmessage = (ev: MessageEvent) => {

--- a/frontend/tests/e2e-full/00-inline-workspace-continuity.spec.ts
+++ b/frontend/tests/e2e-full/00-inline-workspace-continuity.spec.ts
@@ -17,9 +17,10 @@
 // input is broken (and canvas readback is unavailable anyway: xterm.js's
 // WebGL renderer owns the canvas GL context).
 
-import { existsSync, readFileSync } from "node:fs";
+import { closeSync, constants, existsSync, openSync, readFileSync, writeFileSync, writeSync } from "node:fs";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
+import { load as loadToml } from "js-toml";
 import {
   expect,
   request as playwrightRequest,
@@ -38,6 +39,23 @@ type WorkspaceStatusResponse = {
   error_message?: string | null;
 };
 
+type E2ETmuxConfig = {
+  tmux?: {
+    command?: string[];
+  };
+};
+
+type RuntimeSessionResponse = {
+  sessions: Array<{
+    key: string;
+    status: string;
+  }> | null;
+};
+
+type RuntimeAttachSpecResponse = {
+  tmux_session: string;
+};
+
 type TerminalControlFrame = {
   active: boolean | undefined;
   cols: number | undefined;
@@ -45,10 +63,21 @@ type TerminalControlFrame = {
   type: "refresh" | "resize" | "resize_active";
 };
 
+type TerminalOutputObserver = {
+  cursorReports: () => string[];
+  inputIncludes: (text: string) => boolean;
+  inputOccurrences: (text: string) => number;
+  reconnectedSessionModes: (workspaceId: string) => string[];
+  sessionOutputIncludes: (workspaceId: string, text: string) => boolean;
+};
+
 const lockedWorkspaceTestTimeoutMs = 120_000;
 const ZOOMED_TERMINAL_FONT_SIZE = 16;
 const SAFARI_ISSUE_TITLE = "Widget rendering broken on Safari";
 const DARK_MODE_ISSUE_TITLE = "Add dark mode support";
+const ESCAPE = "\u001b";
+const cursorReportPattern = new RegExp(`${ESCAPE}\\[\\??[0-9]+;[0-9]+R`, "g");
+const privateModePattern = new RegExp(`${ESCAPE}\\[\\?[0-9;]*[hl]`, "g");
 
 function hasCommand(command: string, args: string[] = ["--version"]): boolean {
   try {
@@ -86,6 +115,83 @@ function observeTerminalControlFrames(page: Page): TerminalControlFrame[] {
   return frames;
 }
 
+function observeTerminalOutput(page: Page): TerminalOutputObserver {
+  const streams: Array<{ url: string; output: string; input: string }> = [];
+  const isWorkspaceSessionStream = (url: string, workspaceId: string) => {
+    const pathname = new URL(url).pathname;
+    return (
+      pathname.includes(`/workspaces/${encodeURIComponent(workspaceId)}/runtime/sessions/`) &&
+      pathname.endsWith("/terminal")
+    );
+  };
+  page.on("websocket", (socket) => {
+    const stream = { url: socket.url(), output: "", input: "" };
+    streams.push(stream);
+    const decoder = new TextDecoder();
+    socket.on("framereceived", ({ payload }) => {
+      const chunk = typeof payload === "string" ? payload : decoder.decode(payload, { stream: true });
+      stream.output = (stream.output + chunk).slice(-128 * 1024);
+    });
+    socket.on("framesent", ({ payload }) => {
+      if (typeof payload === "string") {
+        try {
+          const control = JSON.parse(payload) as { type?: string };
+          if (control.type) return;
+        } catch {
+          // Raw string terminal input is not a JSON control.
+        }
+      }
+      const chunk = typeof payload === "string" ? payload : new TextDecoder().decode(payload);
+      stream.input = (stream.input + chunk).slice(-128 * 1024);
+    });
+  });
+  return {
+    cursorReports: () =>
+      streams.flatMap((stream) => Array.from(stream.input.matchAll(cursorReportPattern), ([report]) => report)),
+    inputIncludes: (text: string) => streams.some((stream) => stream.input.includes(text)),
+    inputOccurrences: (text: string) =>
+      streams.reduce((total, stream) => total + stream.input.split(text).length - 1, 0),
+    reconnectedSessionModes: (workspaceId: string) =>
+      streams
+        .filter((stream) => isWorkspaceSessionStream(stream.url, workspaceId))
+        .slice(1)
+        .flatMap((stream) => Array.from(stream.output.matchAll(privateModePattern), ([mode]) => mode)),
+    sessionOutputIncludes: (workspaceId: string, text: string) =>
+      streams.some((stream) => isWorkspaceSessionStream(stream.url, workspaceId) && stream.output.includes(text)),
+  };
+}
+
+async function readWebSocketUntil(url: string, expectedText: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const socket = new WebSocket(url);
+    socket.binaryType = "arraybuffer";
+    let output = "";
+    const timeout = setTimeout(() => {
+      socket.close();
+      reject(new Error(`timed out waiting for replay from ${new URL(url).pathname}`));
+    }, 15_000);
+    socket.addEventListener("message", async (event) => {
+      let chunk: string;
+      if (typeof event.data === "string") {
+        chunk = event.data;
+      } else if (event.data instanceof ArrayBuffer) {
+        chunk = new TextDecoder().decode(event.data);
+      } else {
+        chunk = new TextDecoder().decode(await event.data.arrayBuffer());
+      }
+      output += chunk;
+      if (!output.includes(expectedText)) return;
+      clearTimeout(timeout);
+      socket.close();
+      resolve(output);
+    });
+    socket.addEventListener("error", () => {
+      clearTimeout(timeout);
+      reject(new Error(`failed to read replay from ${new URL(url).pathname}`));
+    });
+  });
+}
+
 async function waitForWorkspaceReady(api: APIRequestContext, workspaceId: string): Promise<WorkspaceStatusResponse> {
   for (let attempt = 0; attempt < 100; attempt += 1) {
     const response = await api.get(`/api/v1/workspaces/${workspaceId}`);
@@ -109,6 +215,19 @@ async function createIssueWorkspace(api: APIRequestContext, issueNumber: number)
   // Return the ready-state GET body: the 202 payload predates worktree
   // provisioning, so only the polled response carries worktree_path.
   return waitForWorkspaceReady(api, workspace.id);
+}
+
+async function runningRuntimeTmuxSession(api: APIRequestContext, workspaceId: string): Promise<string> {
+  const response = await api.get(`/api/v1/workspaces/${workspaceId}/runtime`);
+  expect(response.ok()).toBe(true);
+  const runtime = (await response.json()) as RuntimeSessionResponse;
+  const running = runtime.sessions?.filter((session) => session.status === "running") ?? [];
+  expect(running).toHaveLength(1);
+  const attachResponse = await api.get(
+    `/api/v1/workspaces/${workspaceId}/runtime/sessions/${encodeURIComponent(running[0]!.key)}/attach-spec`,
+  );
+  expect(attachResponse.ok()).toBe(true);
+  return ((await attachResponse.json()) as RuntimeAttachSpecResponse).tmux_session;
 }
 
 /**
@@ -143,6 +262,21 @@ async function openTerminalPanel(page: Page): Promise<Locator> {
   return container;
 }
 
+async function ensureTerminalPanelOpen(page: Page): Promise<Locator> {
+  const container = page
+    .locator(".terminal-panel.open .terminal-container, .sole-embedded-session .terminal-container")
+    .first();
+  const openButton = page.getByRole("button", { name: "Open terminal panel" });
+  const closeButton = page.getByRole("button", { name: "Close terminal panel" }).first();
+  await expect.poll(async () => (await openButton.isVisible()) || (await closeButton.isVisible())).toBe(true);
+  if (await openButton.isVisible()) {
+    await openButton.click();
+  }
+  await expect(container).toBeVisible();
+  await expect(container.locator("canvas, .xterm-screen").first()).toBeVisible();
+  return container;
+}
+
 /**
  * Put the whole workspace away.
  *
@@ -159,6 +293,91 @@ async function typeIntoTerminal(page: Page, container: Locator, command: string)
   await container.click({ position: { x: 10, y: 10 } });
   await page.keyboard.type(command);
   await page.keyboard.press("Enter");
+}
+
+async function runAttachedTmuxCommand(page: Page, command: string): Promise<void> {
+  await page.keyboard.press("Control+b");
+  await page.keyboard.press(":");
+  await page.keyboard.type(command);
+  await page.keyboard.press("Enter");
+}
+
+function runE2ETmuxCommand(server: IsolatedE2EServer, args: string[]): string {
+  const config = loadToml(readFileSync(server.info.config_path, "utf8")) as E2ETmuxConfig;
+  const [command, ...prefix] = config.tmux?.command ?? [];
+  if (!command) throw new Error("e2e tmux command is unavailable");
+  return execFileSync(command, [...prefix, ...args], { encoding: "utf8" }).trim();
+}
+
+function writeTmuxClientTTY(server: IsolatedE2EServer, tmuxSession: string, data: Uint8Array): void {
+  const clientTTY = runE2ETmuxCommand(server, ["list-clients", "-t", tmuxSession, "-F", "#{client_tty}"]);
+  const fd = openSync(clientTTY, constants.O_WRONLY | constants.O_NOCTTY);
+  try {
+    writeSync(fd, data);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function tmuxPassthroughFormat(payloadFormat: string): string {
+  return `\\033Ptmux;${payloadFormat}\\033\\\\`;
+}
+
+async function expectWheelScroll(
+  page: Page,
+  container: Locator,
+  server: IsolatedE2EServer,
+  tmuxSession: string,
+): Promise<void> {
+  await expect(container.locator(".xterm.enable-mouse-events")).toBeVisible();
+  const screen = container.locator(".xterm-screen");
+  const box = await screen.boundingBox();
+  expect(box).not.toBeNull();
+  await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+  await page.mouse.wheel(0, -120);
+  await expect
+    .poll(
+      () =>
+        runE2ETmuxCommand(server, [
+          "display-message",
+          "-p",
+          "-t",
+          tmuxSession,
+          "#{pane_in_mode}:#{scroll_position}:#{alternate_on}:#{mouse_any_flag}",
+        ]),
+      { timeout: 15_000 },
+    )
+    .toMatch(/^1:0:0:0$/);
+  await page.mouse.wheel(0, -120);
+  await expect
+    .poll(
+      () =>
+        runE2ETmuxCommand(server, [
+          "display-message",
+          "-p",
+          "-t",
+          tmuxSession,
+          "#{pane_in_mode}:#{scroll_position}:#{alternate_on}:#{mouse_any_flag}",
+        ]),
+      { timeout: 15_000 },
+    )
+    .toMatch(/^1:[1-9]\d*:0:0$/);
+}
+
+function exitTmuxCopyMode(server: IsolatedE2EServer, tmuxSession: string): void {
+  runE2ETmuxCommand(server, ["send-keys", "-t", tmuxSession, "-X", "cancel"]);
+}
+
+async function dispatchTerminalPaste(container: Locator, text: string): Promise<void> {
+  await container.locator(".xterm-helper-textarea").evaluate((textarea, pastedText) => {
+    const paste = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(paste, "clipboardData", {
+      value: {
+        getData: (format: string) => (format === "text/plain" ? pastedText : ""),
+      },
+    });
+    textarea.dispatchEvent(paste);
+  }, text);
 }
 
 // Types a command that creates a marker file in the workspace worktree and
@@ -942,7 +1161,7 @@ test.describe("inline workspace pane continuity", () => {
       const workspace = await createIssueWorkspace(api, 10);
 
       await page.goto(`${isolatedServer.info.base_url}/workspaces/embed/terminal/${workspace.id}`);
-      const dockContainer = await openTerminalPanel(page);
+      await openTerminalPanel(page);
       await page.getByRole("button", { name: "New terminal" }).click();
       const moveSession = page.getByRole("button", { name: /^Move (?!terminal panel).+ to workflow$/ }).first();
       await expect(moveSession).toBeVisible();
@@ -1297,6 +1516,667 @@ test.describe("inline workspace pane continuity", () => {
       await expect(page.locator('[data-continuity="witness-a"]')).toHaveCount(0);
       await expect(page.locator(".workspace-list-sidebar .ws-row.selected")).toContainText(DARK_MODE_ISSUE_TITLE);
     } finally {
+      await api?.dispose();
+      await isolatedServer?.stop();
+    }
+  });
+
+  test("tmux wheel scrolling survives local workspace renderer replacement", async ({ page }) => {
+    test.skip(
+      !hasCommand("git") || !hasCommand("tmux", ["-V"]),
+      "git and tmux are required for the real workspace flow",
+    );
+
+    let isolatedServer: IsolatedE2EServer | null = null;
+    let api: APIRequestContext | null = null;
+    try {
+      const output = observeTerminalOutput(page);
+      isolatedServer = await startIsolatedWorkspaceE2EServer();
+      api = await playwrightRequest.newContext({ baseURL: isolatedServer.info.base_url });
+      const workspaceA = await createIssueWorkspace(api, 10);
+      const workspaceB = await createIssueWorkspace(api, 11);
+
+      await page.goto(`${isolatedServer.info.base_url}/terminal/${workspaceA.id}`);
+      const initialA = await openTerminalPanel(page);
+      const runtimeTmuxSessionA = await runningRuntimeTmuxSession(api, workspaceA.id);
+      await initialA.click({ position: { x: 10, y: 10 } });
+      await runAttachedTmuxCommand(page, "set-option -g mouse off");
+      await runAttachedTmuxCommand(page, "set-option -g mouse on");
+      await expect(initialA.locator(".xterm.enable-mouse-events")).toBeVisible();
+
+      const replaySentinel = "mode-replay-output-complete";
+      await typeIntoTerminal(
+        page,
+        initialA,
+        `printf '\\033[?2004h'; yes '0123456789abcdef0123456789abcdef' | head -n 5000; printf '\\nmode-replay-output-%s\\n' complete; while IFS= read -r _; do :; done`,
+      );
+      await expect
+        .poll(() => output.sessionOutputIncludes(workspaceA.id, replaySentinel), { timeout: 15_000 })
+        .toBe(true);
+
+      await expectWheelScroll(page, initialA, isolatedServer, runtimeTmuxSessionA);
+      exitTmuxCopyMode(isolatedServer, runtimeTmuxSessionA);
+      await initialA.evaluate((element) => {
+        element.setAttribute("data-continuity", "mouse-before-standalone-switch");
+      });
+
+      await page.locator(".workspace-list-sidebar .ws-row", { hasText: DARK_MODE_ISSUE_TITLE }).click();
+      await expect(page).toHaveURL(new RegExp(`/terminal/${workspaceB.id}$`));
+      const containerB = await openTerminalPanel(page);
+      await typeMarkerCommand(page, containerB, workspaceB.worktree_path, "mouse-replay-switch-b");
+
+      await page.locator(".workspace-list-sidebar .ws-row", { hasText: SAFARI_ISSUE_TITLE }).click();
+      await expect(page).toHaveURL(new RegExp(`/terminal/${workspaceA.id}$`));
+      const returnedA = page.locator(".terminal-panel.open .terminal-container").first();
+      await expect(returnedA).toBeVisible();
+      await expect(page.locator('[data-continuity="mouse-before-standalone-switch"]')).toHaveCount(0);
+      await expectWheelScroll(page, returnedA, isolatedServer, runtimeTmuxSessionA);
+      exitTmuxCopyMode(isolatedServer, runtimeTmuxSessionA);
+      const standalonePaste = "standalone-bracketed-paste";
+      await dispatchTerminalPaste(returnedA, standalonePaste);
+      await expect
+        .poll(() => output.inputIncludes(`\x1b[200~${standalonePaste}\x1b[201~`), { timeout: 15_000 })
+        .toBe(true);
+
+      await returnedA.evaluate((element) => {
+        element.setAttribute("data-continuity", "mouse-before-inline-switch");
+      });
+      await selectIssueByTitle(page, DARK_MODE_ISSUE_TITLE);
+      await expect(page.locator(".detail-pane-workspace-slot .terminal-container")).toBeVisible();
+      await selectIssueByTitle(page, SAFARI_ISSUE_TITLE);
+
+      const inlineA = page.locator(".detail-pane-workspace-slot .terminal-container").first();
+      await expect(inlineA).toBeVisible();
+      await expect(page.locator('[data-continuity="mouse-before-inline-switch"]')).toHaveCount(0);
+      await expectWheelScroll(page, inlineA, isolatedServer, runtimeTmuxSessionA);
+      exitTmuxCopyMode(isolatedServer, runtimeTmuxSessionA);
+      const inlinePaste = "inline-bracketed-paste";
+      await dispatchTerminalPaste(inlineA, inlinePaste);
+      await expect.poll(() => output.inputIncludes(`\x1b[200~${inlinePaste}\x1b[201~`), { timeout: 15_000 }).toBe(true);
+      await page.keyboard.press("Control+c");
+    } finally {
+      await api?.dispose();
+      await isolatedServer?.stop();
+    }
+  });
+
+  test("terminal replay preserves split data through a real tmux websocket boundary", async ({ page }) => {
+    test.skip(
+      !hasCommand("git") || !hasCommand("tmux", ["-V"]),
+      "git and tmux are required for the real workspace flow",
+    );
+
+    const cases = [
+      {
+        name: "partial-utf8",
+        candidateFormat: "replay-partial-utf8:\\033\\033[He\\314",
+        continuationFormat: "\\201\\033\\033[6n",
+        pasteText: null,
+        entersAlternateScreen: false,
+        evictsCandidateFromReplay: false,
+        expectsBracketedPaste: false,
+        expectsCursorReport: true,
+      },
+      {
+        name: "incomplete-csi",
+        candidateFormat: "replay-incomplete-csi:\\033\\033[?2004",
+        continuationFormat: "h",
+        pasteText: "incomplete-csi-bracketed-paste",
+        entersAlternateScreen: false,
+        evictsCandidateFromReplay: false,
+        expectsBracketedPaste: true,
+        expectsCursorReport: false,
+      },
+      {
+        name: "unicode-interrupted-csi",
+        candidateFormat: "replay-unicode-interrupted-csi:\\033\\033[?2004\\342\\230\\203h",
+        continuationFormat: "\\033\\033[6n",
+        pasteText: "unicode-interrupted-csi-paste",
+        entersAlternateScreen: true,
+        evictsCandidateFromReplay: true,
+        expectsBracketedPaste: false,
+        expectsCursorReport: true,
+      },
+      {
+        name: "alternate-screen-incomplete-csi",
+        candidateFormat: "",
+        continuationFormat: "",
+        directPrecondition: "\x1b[?1000l;1002l;1003l",
+        directCandidate: "\x1b[?1049h\rsame-renderer-alt-csi:\x1b[?1003h\x1b[5",
+        directContinuation: "C\x1b[6n",
+        pasteText: null,
+        entersAlternateScreen: false,
+        evictsCandidateFromReplay: false,
+        expectsBracketedPaste: false,
+        expectsCursorReport: true,
+        expectedCursorColumn: "28",
+      },
+      {
+        name: "osc-split-st",
+        candidateFormat: "\\033\\033]0;replay-osc-split-st\\033\\033",
+        continuationFormat: "\\\\\\033\\033[6n",
+        pasteText: null,
+        entersAlternateScreen: false,
+        evictsCandidateFromReplay: false,
+        expectsBracketedPaste: false,
+        expectsCursorReport: true,
+      },
+      {
+        name: "dcs-split-st",
+        candidateFormat: "replay-dcs-split-st:\\033\\033P$qm\\033\\033",
+        continuationFormat: "\\\\\\033\\033[6n",
+        pasteText: null,
+        entersAlternateScreen: false,
+        evictsCandidateFromReplay: false,
+        expectsBracketedPaste: false,
+        expectsCursorReport: true,
+      },
+    ] as const;
+
+    await page.addInitScript(() => {
+      const refreshSuppressedFor = new Set<string>();
+      const runtimeSockets: Array<{ url: string; socket: WebSocket; receivedFrames: number }> = [];
+      (
+        window as unknown as {
+          __suppressRuntimeRefresh: (workspaceId: string) => void;
+        }
+      ).__suppressRuntimeRefresh = (workspaceId: string) => {
+        refreshSuppressedFor.add(workspaceId);
+      };
+      (
+        window as unknown as {
+          __disconnectRuntime: (workspaceId: string) => number;
+          __runtimeReconnectReady: (workspaceId: string, previousCount: number) => boolean;
+        }
+      ).__disconnectRuntime = (workspaceId: string) => {
+        const matching = runtimeSockets.filter(({ url }) => url.includes(`/workspaces/${workspaceId}/`));
+        matching.at(-1)?.socket.close();
+        return matching.length;
+      };
+      (
+        window as unknown as {
+          __runtimeReconnectReady: (workspaceId: string, previousCount: number) => boolean;
+        }
+      ).__runtimeReconnectReady = (workspaceId: string, previousCount: number) => {
+        const matching = runtimeSockets.filter(({ url }) => url.includes(`/workspaces/${workspaceId}/`));
+        const latest = matching.at(-1);
+        return (
+          matching.length > previousCount && latest?.socket.readyState === WebSocket.OPEN && latest.receivedFrames > 0
+        );
+      };
+      const Native = window.WebSocket;
+      class RefreshSuppressingWebSocket extends Native {
+        readonly suppressRefresh: boolean;
+
+        constructor(url: string | URL, protocols?: string | string[]) {
+          const rewritten = new URL(String(url));
+          const suppressRefresh = [...refreshSuppressedFor].some((id) =>
+            rewritten.pathname.includes(`/workspaces/${id}/`),
+          );
+          if (suppressRefresh) {
+            rewritten.searchParams.delete("cols");
+            rewritten.searchParams.delete("rows");
+          }
+          super(rewritten, protocols);
+          this.suppressRefresh = suppressRefresh;
+          if (rewritten.pathname.includes("/runtime/sessions/")) {
+            const entry = { url: rewritten.toString(), socket: this as WebSocket, receivedFrames: 0 };
+            runtimeSockets.push(entry);
+            this.addEventListener("message", () => {
+              entry.receivedFrames += 1;
+            });
+          }
+        }
+
+        override send(data: string | ArrayBufferLike | Blob | ArrayBufferView): void {
+          if (this.suppressRefresh && typeof data === "string") {
+            try {
+              if ((JSON.parse(data) as { type?: string }).type === "refresh") return;
+            } catch {
+              // Forward non-JSON terminal input unchanged.
+            }
+          }
+          Native.prototype.send.call(this, data);
+        }
+      }
+      window.WebSocket = RefreshSuppressingWebSocket as unknown as typeof WebSocket;
+    });
+
+    for (const boundary of cases) {
+      let isolatedServer: IsolatedE2EServer | null = null;
+      let api: APIRequestContext | null = null;
+      let helperFinishPath: string | null = null;
+      try {
+        const output = observeTerminalOutput(page);
+        isolatedServer = await startIsolatedWorkspaceE2EServer();
+        api = await playwrightRequest.newContext({ baseURL: isolatedServer.info.base_url });
+        const workspaceA = await createIssueWorkspace(api, 10);
+        const workspaceB = await createIssueWorkspace(api, 11);
+
+        await page.goto(`${isolatedServer.info.base_url}/terminal/${workspaceA.id}`);
+        let containerA = await openTerminalPanel(page);
+        const tmuxSessionA = await runningRuntimeTmuxSession(api, workspaceA.id);
+        runE2ETmuxCommand(isolatedServer, ["set-option", "-p", "-t", tmuxSessionA, "allow-passthrough", "on"]);
+        runE2ETmuxCommand(isolatedServer, ["set-option", "-t", tmuxSessionA, "status", "off"]);
+        await page.evaluate((workspaceId) => {
+          (
+            window as unknown as {
+              __suppressRuntimeRefresh?: (id: string) => void;
+            }
+          ).__suppressRuntimeRefresh?.(workspaceId);
+        }, workspaceA.id);
+
+        runE2ETmuxCommand(isolatedServer, ["set-option", "-g", "-t", tmuxSessionA, "mouse", "off"]);
+        runE2ETmuxCommand(isolatedServer, ["set-option", "-g", "-t", tmuxSessionA, "mouse", "on"]);
+        await expect(containerA.locator(".xterm.enable-mouse-events")).toBeVisible();
+
+        const readyPath = path.join(workspaceA.worktree_path, `${boundary.name}-ready`);
+        const continuePath = path.join(workspaceA.worktree_path, `${boundary.name}-continue`);
+        const donePath = path.join(workspaceA.worktree_path, `${boundary.name}-done`);
+        helperFinishPath = path.join(workspaceA.worktree_path, `${boundary.name}-finish`);
+        const helperPath = path.join(workspaceA.worktree_path, `${boundary.name}-helper.sh`);
+        const completionMarker = `${boundary.name}-complete`;
+        const command = [
+          "i=0",
+          `while [ "$i" -lt 2500 ]; do printf '${tmuxPassthroughFormat("0123456789abcdef0123456789abcdef\\r\\n")}'; i=$((i+1)); done`,
+          ...(boundary.entersAlternateScreen ? [`printf '${tmuxPassthroughFormat("\\033\\033[?1049h")}'`] : []),
+          ...(boundary.evictsCandidateFromReplay ? [`printf '${tmuxPassthroughFormat("\\033\\033[?2004l")}'`] : []),
+          ...("directCandidate" in boundary ? [] : [`printf '${tmuxPassthroughFormat(boundary.candidateFormat)}'`]),
+          ...(boundary.evictsCandidateFromReplay
+            ? [
+                "i=0",
+                `while [ "$i" -lt 2500 ]; do printf '${tmuxPassthroughFormat("fedcba9876543210fedcba9876543210\\r\\n")}'; i=$((i+1)); done`,
+              ]
+            : []),
+          `touch '${readyPath}'`,
+          `while [ ! -f '${continuePath}' ]; do sleep 0.05; done`,
+          `printf '${tmuxPassthroughFormat(boundary.continuationFormat)}'`,
+          `printf '\\r\\n${completionMarker}\\r\\n'`,
+          `touch '${donePath}'`,
+          `while [ ! -f '${helperFinishPath}' ]; do sleep 0.05; done`,
+        ].join("\n");
+        writeFileSync(helperPath, `${command}\n`, "utf8");
+
+        await typeIntoTerminal(page, containerA, `sh '${helperPath}'`);
+        await expect.poll(() => existsSync(readyPath), { timeout: 15_000 }).toBe(true);
+        if ("directCandidate" in boundary) {
+          writeTmuxClientTTY(isolatedServer, tmuxSessionA, new TextEncoder().encode(boundary.directPrecondition));
+          await expect(containerA.locator(".xterm.enable-mouse-events")).toHaveCount(0);
+          writeTmuxClientTTY(isolatedServer, tmuxSessionA, new TextEncoder().encode(boundary.directCandidate));
+          await expect
+            .poll(() => output.sessionOutputIncludes(workspaceA.id, "same-renderer-alt-csi:"), { timeout: 15_000 })
+            .toBe(true);
+          await expect(containerA.locator(".xterm.enable-mouse-events")).toBeVisible();
+        } else if (!boundary.evictsCandidateFromReplay) {
+          await expect
+            .poll(() => output.sessionOutputIncludes(workspaceA.id, `replay-${boundary.name}`), { timeout: 15_000 })
+            .toBe(true);
+        }
+        await containerA.evaluate((element, name) => {
+          element.setAttribute("data-replay-boundary", name);
+        }, boundary.name);
+
+        if ("directCandidate" in boundary) {
+          const previousConnectionCount = await page.evaluate((workspaceId) => {
+            return (
+              window as unknown as {
+                __disconnectRuntime: (id: string) => number;
+              }
+            ).__disconnectRuntime(workspaceId);
+          }, workspaceA.id);
+          await expect
+            .poll(() =>
+              page.evaluate(
+                ({ workspaceId, previousConnectionCount }) =>
+                  (
+                    window as unknown as {
+                      __runtimeReconnectReady: (id: string, count: number) => boolean;
+                    }
+                  ).__runtimeReconnectReady(workspaceId, previousConnectionCount),
+                { workspaceId: workspaceA.id, previousConnectionCount },
+              ),
+            )
+            .toBe(true);
+        } else {
+          await page.locator(".workspace-list-sidebar .ws-row", { hasText: DARK_MODE_ISSUE_TITLE }).click();
+          await expect(page).toHaveURL(new RegExp(`/terminal/${workspaceB.id}$`));
+          await ensureTerminalPanelOpen(page);
+          await page.locator(".workspace-list-sidebar .ws-row", { hasText: SAFARI_ISSUE_TITLE }).click();
+          await expect(page).toHaveURL(new RegExp(`/terminal/${workspaceA.id}$`));
+        }
+
+        containerA = await ensureTerminalPanelOpen(page);
+        await expect(page.locator(`[data-replay-boundary="${boundary.name}"]`)).toHaveCount(
+          "directCandidate" in boundary ? 1 : 0,
+        );
+        await expect(containerA.locator(".xterm.enable-mouse-events")).toBeVisible();
+        await containerA.locator(".xterm-helper-textarea").focus();
+        const bracketedPaste = boundary.pasteText === null ? null : `\x1b[200~${boundary.pasteText}\x1b[201~`;
+        const bracketedPasteOccurrencesBeforeContinuation =
+          bracketedPaste === null ? 0 : output.inputOccurrences(bracketedPaste);
+        const pasteTextOccurrencesBeforeContinuation =
+          boundary.pasteText === null ? 0 : output.inputOccurrences(boundary.pasteText);
+        const cursorReportsBeforeContinuation = output.cursorReports().length;
+
+        if ("directContinuation" in boundary) {
+          writeTmuxClientTTY(isolatedServer, tmuxSessionA, new TextEncoder().encode(boundary.directContinuation));
+        }
+        writeFileSync(continuePath, "continue\n", "utf8");
+        await expect.poll(() => existsSync(donePath), { timeout: 15_000 }).toBe(true);
+        await expect
+          .poll(() => output.sessionOutputIncludes(workspaceA.id, completionMarker), { timeout: 15_000 })
+          .toBe(true);
+        if (boundary.pasteText !== null && bracketedPaste !== null) {
+          await dispatchTerminalPaste(containerA, boundary.pasteText);
+          await expect
+            .poll(() => output.inputOccurrences(boundary.pasteText))
+            .toBeGreaterThan(pasteTextOccurrencesBeforeContinuation);
+          if (boundary.expectsBracketedPaste) {
+            await expect
+              .poll(() => output.inputOccurrences(bracketedPaste))
+              .toBeGreaterThan(bracketedPasteOccurrencesBeforeContinuation);
+          } else {
+            expect(output.inputOccurrences(bracketedPaste)).toBe(bracketedPasteOccurrencesBeforeContinuation);
+          }
+        }
+        if (boundary.expectsCursorReport) {
+          await expect.poll(() => output.cursorReports().length).toBeGreaterThan(cursorReportsBeforeContinuation);
+          if ("expectedCursorColumn" in boundary) {
+            const cursorColumn = /^\x1b\[\??\d+;(\d+)R$/.exec(output.cursorReports().at(-1) ?? "")?.[1];
+            expect(cursorColumn).toBe(boundary.expectedCursorColumn);
+          }
+        }
+        writeFileSync(helperFinishPath, "finish\n", "utf8");
+        helperFinishPath = null;
+      } finally {
+        if (helperFinishPath !== null) {
+          writeFileSync(helperFinishPath, "finish\n", "utf8");
+        }
+        await api?.dispose();
+        await isolatedServer?.stop();
+      }
+    }
+  });
+
+  test("same renderer reconnect applies mouse mode disabled while offline", async ({ page }) => {
+    test.skip(
+      !hasCommand("git") || !hasCommand("tmux", ["-V"]),
+      "git and tmux are required for the real workspace flow",
+    );
+
+    let isolatedServer: IsolatedE2EServer | null = null;
+    let api: APIRequestContext | null = null;
+    let helperFinishPath: string | null = null;
+    try {
+      await page.addInitScript(() => {
+        const log: Array<{ url: string; closed: boolean; socket: WebSocket; sent: string[] }> = [];
+        (window as unknown as { __reconnectWsLog: typeof log }).__reconnectWsLog = log;
+        const Native = window.WebSocket;
+        class TrackedWebSocket extends Native {
+          constructor(url: string | URL, protocols?: string | string[]) {
+            super(url, protocols);
+            const entry = { url: String(url), closed: false, socket: this, sent: [] };
+            log.push(entry);
+            this.addEventListener("close", () => {
+              entry.closed = true;
+            });
+          }
+
+          override send(data: string | ArrayBufferLike | Blob | ArrayBufferView): void {
+            const entry = log.find((candidate) => candidate.socket === this);
+            if (entry && typeof data === "string") entry.sent.push(data);
+            super.send(data);
+          }
+        }
+        window.WebSocket = TrackedWebSocket as unknown as typeof WebSocket;
+        (
+          window as unknown as {
+            __closeRuntimeSockets: (workspaceId: string) => void;
+          }
+        ).__closeRuntimeSockets = (workspaceId: string) => {
+          for (const entry of log) {
+            if (entry.url.includes(`/workspaces/${workspaceId}/runtime/sessions/`)) {
+              entry.socket.close();
+            }
+          }
+        };
+      });
+
+      isolatedServer = await startIsolatedWorkspaceE2EServer();
+      api = await playwrightRequest.newContext({ baseURL: isolatedServer.info.base_url });
+      const workspace = await createIssueWorkspace(api, 10);
+      const output = observeTerminalOutput(page);
+
+      const runtimeSockets = () =>
+        page.evaluate((workspaceId) => {
+          const log =
+            (
+              window as unknown as {
+                __reconnectWsLog?: Array<{ url: string; closed: boolean; sent: string[] }>;
+              }
+            ).__reconnectWsLog ?? [];
+          return log
+            .filter((entry) => entry.url.includes(`/workspaces/${workspaceId}/runtime/sessions/`))
+            .map(({ url, closed, sent }) => ({ url, closed, sent }));
+        }, workspace.id);
+
+      await page.goto(`${isolatedServer.info.base_url}/terminal/${workspace.id}`);
+      const container = await openTerminalPanel(page);
+      const disableSignal = path.join(workspace.worktree_path, "same-renderer-disable-signal");
+      const replayReady = path.join(workspace.worktree_path, "same-renderer-replay-ready");
+      const helperDone = path.join(workspace.worktree_path, "same-renderer-helper-done");
+      helperFinishPath = path.join(workspace.worktree_path, "same-renderer-helper-finish");
+      const helperPath = path.join(workspace.worktree_path, "same-renderer-helper.sh");
+      const offlineOutputMarker = "same-renderer-offline-output-complete";
+      const canonicalReconnectReset = new RegExp(`${ESCAPE}\\[\\?1;1000;(?:[0-9]+;)*1006l`);
+      writeFileSync(
+        helperPath,
+        `${[
+          `printf '${tmuxPassthroughFormat("\\033\\033[?1h")}'`,
+          `while [ ! -f '${disableSignal}' ]; do sleep 0.05; done`,
+          `printf '${tmuxPassthroughFormat("\\033\\033[?1l")}'`,
+          "yes '0123456789abcdef0123456789abcdef' | head -n 2500",
+          `printf '\\r\\n${offlineOutputMarker}\\r\\n'`,
+          `touch '${replayReady}'`,
+          `while [ ! -f '${helperFinishPath}' ]; do sleep 0.05; done`,
+          `touch '${helperDone}'`,
+        ].join("\n")}\n`,
+        "utf8",
+      );
+      const tmuxSession = await runningRuntimeTmuxSession(api, workspace.id);
+      runE2ETmuxCommand(isolatedServer, ["set-option", "-p", "-t", tmuxSession, "allow-passthrough", "on"]);
+      await typeIntoTerminal(page, container, `sh '${helperPath}'`);
+      runE2ETmuxCommand(isolatedServer, ["set-option", "-g", "-t", tmuxSession, "mouse", "on"]);
+      await expect(container.locator(".xterm.enable-mouse-events")).toBeVisible();
+      const applicationCursorUp = "\x1bOA";
+      const normalCursorUp = "\x1b[A";
+      const applicationCursorUpBefore = output.inputOccurrences(applicationCursorUp);
+      await container.locator(".xterm-helper-textarea").focus();
+      await page.keyboard.press("ArrowUp");
+      await expect.poll(() => output.inputOccurrences(applicationCursorUp)).toBeGreaterThan(applicationCursorUpBefore);
+      await container.evaluate((element) => {
+        element.setAttribute("data-same-renderer-reconnect", "witness");
+      });
+      await expect.poll(async () => (await runtimeSockets()).length).toBe(1);
+      const runtimeSocketURL = (await runtimeSockets())[0]!.url;
+
+      await page.context().setOffline(true);
+      await page.evaluate((workspaceId) => {
+        (
+          window as unknown as {
+            __closeRuntimeSockets?: (id: string) => void;
+          }
+        ).__closeRuntimeSockets?.(workspaceId);
+      }, workspace.id);
+      await expect.poll(async () => (await runtimeSockets())[0]?.closed).toBe(true);
+
+      runE2ETmuxCommand(isolatedServer, ["set-option", "-g", "-t", tmuxSession, "mouse", "off"]);
+      writeFileSync(disableSignal, "disable\n", "utf8");
+      await expect.poll(() => existsSync(replayReady), { timeout: 15_000 }).toBe(true);
+      const replay = await readWebSocketUntil(runtimeSocketURL, offlineOutputMarker);
+      expect(replay).toContain(offlineOutputMarker);
+      expect(replay).toMatch(canonicalReconnectReset);
+
+      await page.context().setOffline(false);
+      await expect.poll(async () => (await runtimeSockets()).length, { timeout: 15_000 }).toBeGreaterThan(1);
+      await expect
+        .poll(() => output.reconnectedSessionModes(workspace.id).some((mode) => canonicalReconnectReset.test(mode)), {
+          timeout: 15_000,
+        })
+        .toBe(true);
+      const reconnectSocket = (await runtimeSockets()).at(-1);
+      expect(reconnectSocket).toBeDefined();
+      expect(new URL(reconnectSocket!.url).searchParams.has("cols")).toBe(false);
+      expect(new URL(reconnectSocket!.url).searchParams.has("rows")).toBe(false);
+      expect(reconnectSocket!.sent.filter((frame) => frame.includes('"type":"refresh"'))).toEqual([]);
+      await expect(page.locator('[data-same-renderer-reconnect="witness"]')).toBeVisible();
+      await expect(container.locator(".xterm.enable-mouse-events")).toHaveCount(0);
+      const normalCursorUpBefore = output.inputOccurrences(normalCursorUp);
+      await container.locator(".xterm-helper-textarea").focus();
+      await page.keyboard.press("ArrowUp");
+      await expect.poll(() => output.inputOccurrences(normalCursorUp)).toBeGreaterThan(normalCursorUpBefore);
+      writeFileSync(helperFinishPath, "finish\n", "utf8");
+      await expect.poll(() => existsSync(helperDone), { timeout: 15_000 }).toBe(true);
+      await page.keyboard.press("Control+c");
+      await typeMarkerCommand(page, container, workspace.worktree_path, "same-renderer-reconnect-input");
+    } finally {
+      await page.context().setOffline(false);
+      if (helperFinishPath !== null) {
+        writeFileSync(helperFinishPath, "finish\n", "utf8");
+      }
+      await api?.dispose();
+      await isolatedServer?.stop();
+    }
+  });
+
+  test("same renderer reconnect completes replayed UTF-8 before later output", async ({ page }) => {
+    test.skip(
+      !hasCommand("git") || !hasCommand("tmux", ["-V"]),
+      "git and tmux are required for the real workspace flow",
+    );
+
+    await page.addInitScript(() => {
+      const runtimeConnections = new Map<string, number>();
+      const sockets: Array<{ url: string; closed: boolean; socket: WebSocket }> = [];
+      (
+        window as unknown as {
+          __splitReplaySockets: typeof sockets;
+        }
+      ).__splitReplaySockets = sockets;
+      const Native = window.WebSocket;
+      class SplitReplayWebSocket extends Native {
+        constructor(url: string | URL, protocols?: string | string[]) {
+          super(url, protocols);
+          const socketURL = String(url);
+          if (!socketURL.includes("/runtime/sessions/")) return;
+
+          const connectionNumber = runtimeConnections.get(socketURL.split("?")[0]!) ?? 0;
+          runtimeConnections.set(socketURL.split("?")[0]!, connectionNumber + 1);
+          const entry = { url: socketURL, closed: false, socket: this };
+          sockets.push(entry);
+          this.addEventListener("close", () => {
+            entry.closed = true;
+          });
+          if (connectionNumber === 0) return;
+
+          let replayPrefixDelivered = false;
+          let continuationDelivered = false;
+          let fallbackTimer: number | null = null;
+          const deliver = (bytes: Uint8Array) => {
+            this.onmessage?.(new MessageEvent("message", { data: bytes.buffer }));
+          };
+          const deliverContinuation = () => {
+            if (continuationDelivered) return;
+            continuationDelivered = true;
+            if (fallbackTimer !== null) window.clearTimeout(fallbackTimer);
+            deliver(new Uint8Array([0x98, 0x83, 0x41, 0x1b, 0x5b, 0x36, 0x6e]));
+          };
+          this.addEventListener("message", (event) => {
+            if (!(event.data instanceof ArrayBuffer)) return;
+            if (!replayPrefixDelivered) {
+              event.stopImmediatePropagation();
+              replayPrefixDelivered = true;
+              const text = new TextEncoder().encode("\x1b[?1049h\r\x1b[2Ksame-renderer-split-utf8:");
+              const prefix = new Uint8Array(text.length + 1);
+              prefix.set(text);
+              prefix[text.length] = 0xe2;
+              deliver(prefix);
+              fallbackTimer = window.setTimeout(deliverContinuation, 500);
+              return;
+            }
+            if (!continuationDelivered) queueMicrotask(deliverContinuation);
+          });
+        }
+      }
+      window.WebSocket = SplitReplayWebSocket as unknown as typeof WebSocket;
+      (
+        window as unknown as {
+          __closeSplitReplaySockets: (workspaceId: string) => void;
+        }
+      ).__closeSplitReplaySockets = (workspaceId: string) => {
+        for (const entry of sockets) {
+          if (entry.url.includes(`/workspaces/${workspaceId}/runtime/sessions/`)) {
+            entry.socket.close();
+          }
+        }
+      };
+    });
+
+    let isolatedServer: IsolatedE2EServer | null = null;
+    let api: APIRequestContext | null = null;
+    try {
+      isolatedServer = await startIsolatedWorkspaceE2EServer();
+      api = await playwrightRequest.newContext({ baseURL: isolatedServer.info.base_url });
+      const workspace = await createIssueWorkspace(api, 10);
+      const output = observeTerminalOutput(page);
+      const runtimeSockets = () =>
+        page.evaluate((workspaceId) => {
+          const sockets =
+            (
+              window as unknown as {
+                __splitReplaySockets?: Array<{ url: string; closed: boolean; socket: WebSocket }>;
+              }
+            ).__splitReplaySockets ?? [];
+          return sockets
+            .filter((entry) => entry.url.includes(`/workspaces/${workspaceId}/runtime/sessions/`))
+            .map(({ url, closed, socket }) => ({ url, closed, readyState: socket.readyState }));
+        }, workspace.id);
+
+      await page.goto(`${isolatedServer.info.base_url}/terminal/${workspace.id}`);
+      const container = await openTerminalPanel(page);
+      await expect.poll(async () => (await runtimeSockets()).length).toBe(1);
+      await container.evaluate((element) => {
+        element.setAttribute("data-split-replay-renderer", "witness");
+      });
+      const cursorReportsBefore = output.cursorReports().length;
+
+      await page.context().setOffline(true);
+      await page.evaluate((workspaceId) => {
+        (
+          window as unknown as {
+            __closeSplitReplaySockets?: (id: string) => void;
+          }
+        ).__closeSplitReplaySockets?.(workspaceId);
+      }, workspace.id);
+      await expect.poll(async () => (await runtimeSockets())[0]?.closed).toBe(true);
+
+      await page.context().setOffline(false);
+      await expect
+        .poll(async () => (await runtimeSockets()).filter((socket) => socket.readyState === WebSocket.OPEN).length, {
+          timeout: 15_000,
+        })
+        .toBe(1);
+      await expect(page.locator('[data-split-replay-renderer="witness"]')).toBeVisible();
+      const reconnectedSocket = (await runtimeSockets()).at(-1);
+      expect(reconnectedSocket).toBeDefined();
+
+      await expect.poll(() => output.cursorReports().length, { timeout: 15_000 }).toBeGreaterThan(cursorReportsBefore);
+      const cursorColumn = /^\x1b\[\??\d+;(\d+)R$/.exec(output.cursorReports().at(-1) ?? "")?.[1];
+      expect(cursorColumn).toBe("28");
+      expect(new URL(reconnectedSocket!.url).searchParams.has("cols")).toBe(false);
+      expect(new URL(reconnectedSocket!.url).searchParams.has("rows")).toBe(false);
+    } finally {
+      await page.context().setOffline(false);
       await api?.dispose();
       await isolatedServer?.stop();
     }

--- a/frontend/tests/e2e-full/00-inline-workspace-continuity.spec.ts
+++ b/frontend/tests/e2e-full/00-inline-workspace-continuity.spec.ts
@@ -295,13 +295,6 @@ async function typeIntoTerminal(page: Page, container: Locator, command: string)
   await page.keyboard.press("Enter");
 }
 
-async function runAttachedTmuxCommand(page: Page, command: string): Promise<void> {
-  await page.keyboard.press("Control+b");
-  await page.keyboard.press(":");
-  await page.keyboard.type(command);
-  await page.keyboard.press("Enter");
-}
-
 function runE2ETmuxCommand(server: IsolatedE2EServer, args: string[]): string {
   const config = loadToml(readFileSync(server.info.config_path, "utf8")) as E2ETmuxConfig;
   const [command, ...prefix] = config.tmux?.command ?? [];
@@ -1540,8 +1533,8 @@ test.describe("inline workspace pane continuity", () => {
       const initialA = await openTerminalPanel(page);
       const runtimeTmuxSessionA = await runningRuntimeTmuxSession(api, workspaceA.id);
       await initialA.click({ position: { x: 10, y: 10 } });
-      await runAttachedTmuxCommand(page, "set-option -g mouse off");
-      await runAttachedTmuxCommand(page, "set-option -g mouse on");
+      runE2ETmuxCommand(isolatedServer, ["set-option", "-g", "-t", runtimeTmuxSessionA, "mouse", "off"]);
+      runE2ETmuxCommand(isolatedServer, ["set-option", "-g", "-t", runtimeTmuxSessionA, "mouse", "on"]);
       await expect(initialA.locator(".xterm.enable-mouse-events")).toBeVisible();
 
       const replaySentinel = "mode-replay-output-complete";
@@ -1909,16 +1902,30 @@ test.describe("inline workspace pane continuity", () => {
     let helperFinishPath: string | null = null;
     try {
       await page.addInitScript(() => {
-        const log: Array<{ url: string; closed: boolean; socket: WebSocket; sent: string[] }> = [];
+        const log: Array<{
+          url: string;
+          closed: boolean;
+          replayReady: boolean;
+          socket: WebSocket;
+          sent: string[];
+        }> = [];
         (window as unknown as { __reconnectWsLog: typeof log }).__reconnectWsLog = log;
         const Native = window.WebSocket;
         class TrackedWebSocket extends Native {
           constructor(url: string | URL, protocols?: string | string[]) {
             super(url, protocols);
-            const entry = { url: String(url), closed: false, socket: this, sent: [] };
+            const entry = { url: String(url), closed: false, replayReady: false, socket: this, sent: [] };
             log.push(entry);
             this.addEventListener("close", () => {
               entry.closed = true;
+            });
+            this.addEventListener("message", (event) => {
+              if (typeof event.data !== "string") return;
+              try {
+                entry.replayReady = (JSON.parse(event.data) as { type?: string }).type === "replay_ready";
+              } catch {
+                // Non-JSON text frame; the renderer ignores it too.
+              }
             });
           }
 
@@ -1952,12 +1959,17 @@ test.describe("inline workspace pane continuity", () => {
           const log =
             (
               window as unknown as {
-                __reconnectWsLog?: Array<{ url: string; closed: boolean; sent: string[] }>;
+                __reconnectWsLog?: Array<{
+                  url: string;
+                  closed: boolean;
+                  replayReady: boolean;
+                  sent: string[];
+                }>;
               }
             ).__reconnectWsLog ?? [];
           return log
             .filter((entry) => entry.url.includes(`/workspaces/${workspaceId}/runtime/sessions/`))
-            .map(({ url, closed, sent }) => ({ url, closed, sent }));
+            .map(({ url, closed, replayReady, sent }) => ({ url, closed, replayReady, sent }));
         }, workspace.id);
 
       await page.goto(`${isolatedServer.info.base_url}/terminal/${workspace.id}`);
@@ -2026,9 +2038,21 @@ test.describe("inline workspace pane continuity", () => {
         .toBe(true);
       const reconnectSocket = (await runtimeSockets()).at(-1);
       expect(reconnectSocket).toBeDefined();
+      expect(new URL(reconnectSocket!.url).searchParams.get("replay_boundary")).toBe("1");
       expect(new URL(reconnectSocket!.url).searchParams.has("cols")).toBe(false);
       expect(new URL(reconnectSocket!.url).searchParams.has("rows")).toBe(false);
-      expect(reconnectSocket!.sent.filter((frame) => frame.includes('"type":"refresh"'))).toEqual([]);
+      await expect.poll(async () => (await runtimeSockets()).at(-1)?.replayReady).toBe(true);
+      await expect
+        .poll(
+          async () =>
+            (await runtimeSockets()).at(-1)?.sent.filter((frame) => frame.includes('"type":"refresh"')).length,
+        )
+        .toBe(1);
+      const refresh = JSON.parse(
+        (await runtimeSockets()).at(-1)!.sent.find((frame) => frame.includes('"type":"refresh"'))!,
+      ) as TerminalControlFrame;
+      expect(refresh.cols).toBeGreaterThan(0);
+      expect(refresh.rows).toBeGreaterThan(0);
       await expect(page.locator('[data-same-renderer-reconnect="witness"]')).toBeVisible();
       await expect(container.locator(".xterm.enable-mouse-events")).toHaveCount(0);
       const normalCursorUpBefore = output.inputOccurrences(normalCursorUp);
@@ -2092,6 +2116,18 @@ test.describe("inline workspace pane continuity", () => {
             deliver(new Uint8Array([0x98, 0x83, 0x41, 0x1b, 0x5b, 0x36, 0x6e]));
           };
           this.addEventListener("message", (event) => {
+            if (typeof event.data === "string") {
+              try {
+                if ((JSON.parse(event.data) as { type?: string }).type !== "replay_ready") return;
+              } catch {
+                return;
+              }
+              if (continuationDelivered) return;
+              event.stopImmediatePropagation();
+              deliverContinuation();
+              this.onmessage?.(new MessageEvent("message", { data: event.data }));
+              return;
+            }
             if (!(event.data instanceof ArrayBuffer)) return;
             if (!replayPrefixDelivered) {
               event.stopImmediatePropagation();
@@ -2173,6 +2209,7 @@ test.describe("inline workspace pane continuity", () => {
       await expect.poll(() => output.cursorReports().length, { timeout: 15_000 }).toBeGreaterThan(cursorReportsBefore);
       const cursorColumn = /^\x1b\[\??\d+;(\d+)R$/.exec(output.cursorReports().at(-1) ?? "")?.[1];
       expect(cursorColumn).toBe("28");
+      expect(new URL(reconnectedSocket!.url).searchParams.get("replay_boundary")).toBe("1");
       expect(new URL(reconnectedSocket!.url).searchParams.has("cols")).toBe(false);
       expect(new URL(reconnectedSocket!.url).searchParams.has("rows")).toBe(false);
     } finally {

--- a/frontend/tests/e2e/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar.spec.ts
@@ -1951,6 +1951,7 @@ test.describe("workspace launch home", () => {
     test.setTimeout(60_000);
     await page.addInitScript(() => {
       type RecordedSocket = {
+        receiveReplayReady: () => void;
         sent: unknown[];
         url: string;
       };
@@ -1983,7 +1984,17 @@ test.describe("workspace launch home", () => {
           if (!this.url.includes("/ws/v1/workspaces/")) {
             return new NativeWebSocket(url, protocols);
           }
-          this.record = { url: this.url, sent: [] };
+          this.record = {
+            receiveReplayReady: () => {
+              const replayReady = new MessageEvent("message", {
+                data: JSON.stringify({ type: "replay_ready" }),
+              });
+              this.dispatchEvent(replayReady);
+              this.onmessage?.(replayReady);
+            },
+            url: this.url,
+            sent: [],
+          };
           recordedSockets.push(this.record);
           queueMicrotask(() => {
             const event = new Event("open");
@@ -2020,6 +2031,40 @@ test.describe("workspace launch home", () => {
     await launchTarget.click();
 
     await expect(page.locator(".terminal-container .xterm")).toBeVisible();
+    await page.evaluate(() => {
+      for (const socket of (
+        window as unknown as {
+          __kenn_forgeRecordedTerminalSockets: Array<{
+            receiveReplayReady: () => void;
+            sent: unknown[];
+          }>;
+        }
+      ).__kenn_forgeRecordedTerminalSockets) {
+        socket.receiveReplayReady();
+      }
+    });
+    await expect
+      .poll(async () =>
+        page.evaluate(() =>
+          (
+            window as unknown as {
+              __kenn_forgeRecordedTerminalSockets: Array<{
+                sent: unknown[];
+              }>;
+            }
+          ).__kenn_forgeRecordedTerminalSockets.some((socket) =>
+            socket.sent.some((frame) => {
+              if (typeof frame !== "string") return false;
+              try {
+                return JSON.parse(frame).type === "refresh";
+              } catch {
+                return false;
+              }
+            }),
+          ),
+        ),
+      )
+      .toBe(true);
     await page.evaluate(() => {
       for (const socket of (
         window as unknown as {

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -9097,7 +9097,7 @@ func TestWatchedMRsSyncedOnFastInterval(t *testing.T) {
 		mu.Lock()
 		defer mu.Unlock()
 		return len(hookCalls) >= 1
-	}, 2*time.Second, 20*time.Millisecond)
+	}, 10*time.Second, 20*time.Millisecond)
 
 	// Verify the MR was persisted.
 	mr, err := d.GetMergeRequest(ctx, "github", "github.com", "acme", "app", 7)

--- a/internal/github/syncertest/syncer_test.go
+++ b/internal/github/syncertest/syncer_test.go
@@ -645,6 +645,7 @@ func TestSyncerTriggerRunRunsRunOnce(t *testing.T) {
 func TestSyncerTriggerRunWithPrioritySyncsSelectedReposFirst(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
+	const completionTimeout = 30 * time.Second
 
 	var mu sync.Mutex
 	var calls []string
@@ -707,8 +708,12 @@ func TestSyncerTriggerRunWithPrioritySyncsSelectedReposFirst(t *testing.T) {
 
 	select {
 	case <-done:
-	case <-time.After(5 * time.Second):
-		require.FailNow("priority TriggerRun did not complete within 5s")
+	case <-time.After(completionTimeout):
+		require.FailNowf(
+			"priority TriggerRun did not complete",
+			"timeout=%s",
+			completionTimeout,
+		)
 	}
 	s.Stop()
 
@@ -843,7 +848,7 @@ func TestSyncerStopCancelsTriggerRun(t *testing.T) {
 
 	select {
 	case <-entered:
-	case <-time.After(time.Second):
+	case <-time.After(5 * time.Second):
 		require.FailNow("TriggerRun did not start ListOpenPullRequests")
 	}
 
@@ -855,7 +860,7 @@ func TestSyncerStopCancelsTriggerRun(t *testing.T) {
 
 	select {
 	case <-stopped:
-	case <-time.After(2 * time.Second):
+	case <-time.After(5 * time.Second):
 		close(release)
 		require.FailNow("Stop did not return after ctx cancellation")
 	}

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -27057,18 +27057,11 @@ func TestWorkspaceRuntimePlainShellRecordFailureCleansCreatedTmuxShellE2E(t *tes
 	}, 2*time.Second, 20*time.Millisecond)
 	require.Eventually(func() bool {
 		entries, readErr := os.ReadDir(stateDir)
-		if readErr != nil {
+		if readErr != nil || len(entries) != len(initialState) {
 			return false
 		}
-		currentState := make(map[string]bool, len(entries))
 		for _, entry := range entries {
-			currentState[entry.Name()] = true
-		}
-		if len(currentState) != len(initialState) {
-			return false
-		}
-		for name := range initialState {
-			if !currentState[name] {
+			if !initialState[entry.Name()] {
 				return false
 			}
 		}

--- a/internal/server/kataapi/test_helpers_test.go
+++ b/internal/server/kataapi/test_helpers_test.go
@@ -42,8 +42,33 @@ type Server struct {
 	workspaceAPI *workspaceapi.Handler
 }
 
+func TestKataTestServerCleanupStopsWorkspaceSetupBeforeDeleting(t *testing.T) {
+	var steps []string
+	runKataTestServerCleanup(
+		func() { steps = append(steps, "stop workspace setup") },
+		func() { steps = append(steps, "delete workspaces") },
+		func() { steps = append(steps, "stop Kata handler") },
+	)
+
+	assert.Equal(t, []string{
+		"stop workspace setup",
+		"delete workspaces",
+		"stop Kata handler",
+	}, steps)
+}
+
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	s.http.ServeHTTP(w, r)
+}
+
+func runKataTestServerCleanup(
+	stopWorkspaceSetup func(),
+	deleteWorkspaces func(),
+	stopKataHandler func(),
+) {
+	stopWorkspaceSetup()
+	deleteWorkspaces()
+	stopKataHandler()
 }
 
 func setupTestServer(t *testing.T) (*Server, *db.DB) {
@@ -126,17 +151,26 @@ func newKataTestServer(
 	handler.Start(t.Context())
 	t.Cleanup(func() {
 		assert := assert.New(t)
-		if workspaces != nil {
-			stored, err := database.ListWorkspaces(context.Background())
-			if assert.NoError(err) {
-				for _, ws := range stored {
-					_, err := workspaces.Delete(context.Background(), ws.ID, true, nil)
-					assert.NoError(err)
+		runKataTestServerCleanup(
+			func() {
+				assert.NoError(workspaceHandler.Shutdown(context.Background()))
+			},
+			func() {
+				if workspaces == nil {
+					return
 				}
-			}
-		}
-		assert.NoError(handler.Shutdown(context.Background()))
-		assert.NoError(workspaceHandler.Shutdown(context.Background()))
+				stored, err := database.ListWorkspaces(context.Background())
+				if assert.NoError(err) {
+					for _, ws := range stored {
+						_, err := workspaces.Delete(context.Background(), ws.ID, true, nil)
+						assert.NoError(err)
+					}
+				}
+			},
+			func() {
+				assert.NoError(handler.Shutdown(context.Background()))
+			},
+		)
 	})
 	return server
 }

--- a/internal/server/kataapi/test_helpers_test.go
+++ b/internal/server/kataapi/test_helpers_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humago"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/forge/internal/config"
 	"go.kenn.io/forge/internal/db"
@@ -123,8 +124,18 @@ func newKataTestServer(
 	server := &Server{Handler: handler, http: mux, workspaceAPI: workspaceHandler}
 	handler.Start(t.Context())
 	t.Cleanup(func() {
-		require.NoError(t, handler.Shutdown(context.Background()))
-		require.NoError(t, workspaceHandler.Shutdown(context.Background()))
+		assert := assert.New(t)
+		if workspaces != nil {
+			stored, err := database.ListWorkspaces(context.Background())
+			if assert.NoError(err) {
+				for _, ws := range stored {
+					_, err := workspaces.Delete(context.Background(), ws.ID, true, nil)
+					assert.NoError(err)
+				}
+			}
+		}
+		assert.NoError(handler.Shutdown(context.Background()))
+		assert.NoError(workspaceHandler.Shutdown(context.Background()))
 	})
 	return server
 }

--- a/internal/server/kataapi/test_helpers_test.go
+++ b/internal/server/kataapi/test_helpers_test.go
@@ -101,6 +101,7 @@ func newKataTestServer(
 	var workspaces *workspace.Manager
 	if options.WorktreeDir != "" {
 		workspaces = workspace.NewManager(database, options.WorktreeDir)
+		workspaces.SetTmuxCommand(kataAPITestTmuxCommand)
 	}
 	workspaceHandler := workspaceapi.New(workspaceapi.Deps{
 		DB: database, Resolver: resolver, Workspaces: workspaces,

--- a/internal/server/kataapi/testmain_test.go
+++ b/internal/server/kataapi/testmain_test.go
@@ -1,0 +1,90 @@
+package kataapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"go.kenn.io/forge/internal/procutil"
+	"go.kenn.io/forge/internal/testutil/gitsafe"
+)
+
+var kataAPITestTmuxCommand []string
+
+func TestMain(m *testing.M) {
+	cleanupTmux, err := configureKataAPITestTmux()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "configure isolated Kata API test tmux: %v\n", err)
+		os.Exit(1)
+	}
+	code := gitsafe.RunIsolatedMain(m)
+	if err := cleanupTmux(); err != nil {
+		fmt.Fprintf(os.Stderr, "cleanup isolated Kata API test tmux: %v\n", err)
+		if code == 0 {
+			code = 1
+		}
+	}
+	os.Exit(code)
+}
+
+func configureKataAPITestTmux() (func() error, error) {
+	tmuxPath, err := exec.LookPath("tmux")
+	if errors.Is(err, exec.ErrNotFound) {
+		return func() error { return nil }, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("find tmux: %w", err)
+	}
+
+	tmuxDir, err := os.MkdirTemp("/tmp", "forge-kataapi-test-tmux-*")
+	if err != nil {
+		return nil, fmt.Errorf("create tmux socket directory: %w", err)
+	}
+	socket := filepath.Join(tmuxDir, "tmux.sock")
+	kataAPITestTmuxCommand = []string{
+		tmuxPath, "-f", "/dev/null", "-S", socket,
+	}
+
+	return func() error {
+		var errs []error
+		if _, statErr := os.Stat(socket); statErr == nil {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			out, killErr := procutil.CombinedOutput(
+				ctx,
+				procutil.CommandContext(
+					ctx, tmuxPath, "-f", "/dev/null", "-S", socket,
+					"kill-server",
+				),
+				"Kata API test tmux cleanup",
+			)
+			cancel()
+			msg := strings.TrimSpace(string(out))
+			if killErr != nil && !kataAPITestTmuxServerAbsent(msg) {
+				errs = append(errs, fmt.Errorf(
+					"kill private tmux server: %w: %s",
+					killErr, msg,
+				))
+			}
+		} else if !errors.Is(statErr, os.ErrNotExist) {
+			errs = append(errs, fmt.Errorf("inspect tmux socket: %w", statErr))
+		}
+		if removeErr := os.RemoveAll(tmuxDir); removeErr != nil {
+			errs = append(errs, fmt.Errorf(
+				"remove tmux socket directory: %w", removeErr,
+			))
+		}
+		return errors.Join(errs...)
+	}, nil
+}
+
+func kataAPITestTmuxServerAbsent(msg string) bool {
+	return strings.Contains(msg, "no server running") ||
+		(strings.Contains(msg, "error connecting to") &&
+			strings.Contains(msg, "No such file or directory"))
+}

--- a/internal/server/kataapi/workspace_test.go
+++ b/internal/server/kataapi/workspace_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/forge/internal/db"
+	"go.kenn.io/forge/internal/procutil"
 	"go.kenn.io/forge/internal/server/workspaceapi"
 )
 
@@ -443,6 +444,16 @@ command = ["sh", "-c", "exit 0"]
 		stored, err = database.GetWorkspace(t.Context(), created.ID)
 		return err == nil && stored != nil && stored.Status == "ready"
 	}, 10*time.Second, 25*time.Millisecond)
+	privateTmuxArgs := append(
+		append([]string{}, kataAPITestTmuxCommand[1:]...),
+		"has-session", "-t", stored.TmuxSession,
+	)
+	require.NoError(procutil.CommandContext(
+		t.Context(), kataAPITestTmuxCommand[0], privateTmuxArgs...,
+	).Run())
+	require.Error(procutil.CommandContext(
+		t.Context(), "tmux", "has-session", "-t", stored.TmuxSession,
+	).Run())
 	commonDir := strings.TrimSpace(gitOutput(t, stored.WorktreePath, "rev-parse", "--git-common-dir"))
 	if !filepath.IsAbs(commonDir) {
 		commonDir = filepath.Join(stored.WorktreePath, commonDir)

--- a/internal/server/workspaceapi/workspace_runtime_terminal.go
+++ b/internal/server/workspaceapi/workspace_runtime_terminal.go
@@ -67,6 +67,7 @@ func (s *Handler) handleWorkspaceRuntimeSessionTerminal(
 		localruntime.AttachSessionOptions{
 			ResizePriority: runtimeTerminalResizePriority(r),
 			ResizeActive:   parseRuntimeTerminalResizeActive(r),
+			ReplayBoundary: parseRuntimeTerminalReplayBoundary(r),
 		},
 	)
 	if err != nil {
@@ -101,6 +102,11 @@ func ParseRuntimeTerminalResizeActive(r *http.Request) bool {
 	return parseRuntimeTerminalResizeActive(r)
 }
 
+func parseRuntimeTerminalReplayBoundary(r *http.Request) bool {
+	raw := r.URL.Query().Get("replay_boundary")
+	return raw == "1" || raw == "true"
+}
+
 func (s *Handler) serveRuntimeTerminal(
 	w http.ResponseWriter,
 	r *http.Request,
@@ -124,7 +130,8 @@ func (s *Handler) serveRuntimeTerminal(
 		"session_key", info.Key,
 		"target_key", info.TargetKey,
 	)
-	if cols, rows, ok := parseRuntimeTerminalSize(r); ok {
+	if cols, rows, ok := parseRuntimeTerminalSize(r); ok &&
+		!parseRuntimeTerminalReplayBoundary(r) {
 		logWebsocketDebug(
 			"runtime terminal initial resize",
 			"workspace_id", info.WorkspaceID,
@@ -325,8 +332,13 @@ func bridgeRuntimeAttachment(
 				if !ok {
 					return
 				}
+				messageType := websocket.MessageBinary
+				if data == nil {
+					messageType = websocket.MessageText
+					data = []byte(`{"type":"replay_ready"}`)
+				}
 				if err := conn.Write(
-					ctx, websocket.MessageBinary, data,
+					ctx, messageType, data,
 				); err != nil {
 					logWebsocketDebug(
 						"runtime terminal websocket write ended",

--- a/internal/server/workspaceapi/workspace_runtime_terminal_test.go
+++ b/internal/server/workspaceapi/workspace_runtime_terminal_test.go
@@ -112,6 +112,71 @@ func TestForwardAvailableRuntimeOutputBoundsBlockedWrite(t *testing.T) {
 	require.ErrorIs(err, context.DeadlineExceeded)
 }
 
+func TestServeRuntimeTerminalTranslatesReplayBoundary(t *testing.T) {
+	require := require.New(t)
+	output := make(chan []byte, 1)
+	output <- nil
+	attachment := localruntime.NewAttachmentForTesting(
+		localruntime.AttachmentForTestingOptions{
+			Output: output,
+			Done:   make(chan struct{}),
+		},
+	)
+	wsURL, _ := runtimeTerminalTestServer(t, attachment)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	require.NoError(err)
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+
+	typ, data, err := conn.Read(ctx)
+	require.NoError(err)
+	require.Equal(websocket.MessageText, typ)
+	var msg struct {
+		Type string `json:"type"`
+	}
+	require.NoError(json.Unmarshal(data, &msg))
+	require.Equal("replay_ready", msg.Type)
+}
+
+func TestServeRuntimeTerminalReplayBoundaryDefersInitialResize(t *testing.T) {
+	require := require.New(t)
+	output := make(chan []byte, 1)
+	output <- nil
+	resizeCalled := make(chan struct{}, 1)
+	attachment := localruntime.NewAttachmentForTesting(
+		localruntime.AttachmentForTestingOptions{
+			Output: output,
+			Done:   make(chan struct{}),
+			Resize: func(_, _ int) error {
+				resizeCalled <- struct{}{}
+				return nil
+			},
+		},
+	)
+	wsURL, _ := runtimeTerminalTestServer(t, attachment)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	conn, _, err := websocket.Dial(
+		ctx,
+		wsURL+"?cols=177&rows=41&replay_boundary=1",
+		nil,
+	)
+	require.NoError(err)
+	defer conn.Close(websocket.StatusNormalClosure, "done")
+
+	typ, _, err := conn.Read(ctx)
+	require.NoError(err)
+	require.Equal(websocket.MessageText, typ)
+	select {
+	case <-resizeCalled:
+		require.Fail("initial resize ran before the replay boundary")
+	default:
+	}
+}
+
 func TestServeRuntimeTerminalClosedOutputStillReportsSessionExit(t *testing.T) {
 	require := require.New(t)
 	output := make(chan []byte)

--- a/internal/workspace/localruntime/manager.go
+++ b/internal/workspace/localruntime/manager.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/creack/pty/v2"
 
@@ -177,6 +178,8 @@ type session struct {
 	outputClosed          bool
 	alternateScreenActive bool
 	alternateScreenTail   []byte
+	terminalSequenceTail  []byte
+	inputModes            terminalInputModeState
 	lifecycleMu           sync.Mutex
 	lifecycleClosed       bool
 	stopRequested         bool
@@ -1770,6 +1773,7 @@ func (s *session) broadcast(data []byte) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	s.inputModes.observe(chunk)
 	s.appendReplayOutputLocked(chunk)
 
 	for ch := range s.subscribers {
@@ -1789,6 +1793,8 @@ type alternateScreenEvent struct {
 }
 
 func (s *session) appendReplayOutputLocked(chunk []byte) {
+	s.updateTerminalSequenceTailLocked(chunk)
+
 	// Alternate-screen TUIs are stateful. Replaying a suffix of their
 	// screen history into a fresh terminal can corrupt the attach, so
 	// keep only normal-screen output for future subscribers.
@@ -1821,11 +1827,42 @@ func (s *session) appendReplayOutputLocked(chunk []byte) {
 	s.alternateScreenTail = trailingBytes(scan, maxAlternateScreenSequenceLen-1)
 }
 
+func (s *session) updateTerminalSequenceTailLocked(chunk []byte) {
+	scan := append(slices.Clone(s.terminalSequenceTail), chunk...)
+	tailLen := trailingIncompleteTerminalDataLen(scan)
+	if tailLen == 0 || tailLen > maxSessionOutputReplay {
+		s.terminalSequenceTail = nil
+		return
+	}
+	s.terminalSequenceTail = slices.Clone(scan[len(scan)-tailLen:])
+}
+
 func (s *session) appendOutputBufferLocked(chunk []byte) {
 	s.outputBuffer = append(s.outputBuffer, chunk...)
 	if extra := len(s.outputBuffer) - maxSessionOutputReplay; extra > 0 {
-		s.outputBuffer = slices.Clone(s.outputBuffer[extra:])
+		start := replaySuffixStart(s.outputBuffer, extra)
+		s.outputBuffer = slices.Clone(s.outputBuffer[start:])
 	}
+}
+
+// replaySuffixStart advances a size-based cutoff only when it demonstrably
+// splits a valid UTF-8 rune. Invalid continuation bytes are preserved because
+// terminals may use them as raw C1 controls.
+func replaySuffixStart(data []byte, start int) int {
+	if start <= 0 || start >= len(data) || utf8.RuneStart(data[start]) {
+		return start
+	}
+	for candidate := start - 1; candidate >= max(0, start-utf8.UTFMax+1); candidate-- {
+		if !utf8.RuneStart(data[candidate]) {
+			continue
+		}
+		_, size := utf8.DecodeRune(data[candidate:])
+		if size > 1 && candidate+size > start {
+			return candidate + size
+		}
+		return start
+	}
+	return start
 }
 
 func alternateScreenEvents(data []byte) []alternateScreenEvent {
@@ -1874,8 +1911,25 @@ func (s *session) subscribe() (<-chan []byte, func()) {
 
 	s.mu.Lock()
 	info := s.info
-	if len(s.outputBuffer) > 0 && !s.alternateScreenActive {
-		replay := slices.Clone(s.outputBuffer)
+	replay := make([]byte, 0)
+	if !s.alternateScreenActive {
+		replay = append(replay, s.outputBuffer...)
+	}
+	var replayModes terminalInputModeState
+	replayModes.observe(replay)
+	if pendingLen := trailingIncompleteTerminalDataLen(replay); pendingLen > 0 {
+		stableLen := len(replay) - pendingLen
+		pending := slices.Clone(replay[stableLen:])
+		replay = slices.Clone(replay[:stableLen])
+		replay = s.inputModes.appendTransitions(replay, replayModes)
+		replay = append(replay, pending...)
+	} else {
+		replay = s.inputModes.appendTransitions(replay, replayModes)
+	}
+	if s.alternateScreenActive {
+		replay = append(replay, s.terminalSequenceTail...)
+	}
+	if len(replay) > 0 {
 		ch <- replay
 		slog.Debug(
 			"runtime terminal replay queued",

--- a/internal/workspace/localruntime/manager.go
+++ b/internal/workspace/localruntime/manager.go
@@ -164,29 +164,30 @@ var (
 )
 
 type session struct {
-	mu                    sync.Mutex
-	info                  SessionInfo
-	cmd                   *exec.Cmd
-	ptmx                  *os.File
-	pty                   ptyownerruntime.PTY
-	lifecycle             sessionLifecycle
-	tmuxSession           string
-	done                  chan struct{}
-	outputDone            chan struct{}
-	subscribers           map[chan []byte]struct{}
-	outputBuffer          []byte
-	outputClosed          bool
-	alternateScreenActive bool
-	alternateScreenTail   []byte
-	terminalSequenceTail  []byte
-	inputModes            terminalInputModeState
-	lifecycleMu           sync.Mutex
-	lifecycleClosed       bool
-	stopRequested         bool
-	nextAttachmentID      uint64
-	resizeOwnerID         uint64
-	resizeOwnerPriority   ResizePriority
-	resizeAttachments     map[uint64]resizeAttachment
+	mu                        sync.Mutex
+	info                      SessionInfo
+	cmd                       *exec.Cmd
+	ptmx                      *os.File
+	pty                       ptyownerruntime.PTY
+	lifecycle                 sessionLifecycle
+	tmuxSession               string
+	done                      chan struct{}
+	outputDone                chan struct{}
+	subscribers               map[chan []byte]struct{}
+	outputBuffer              []byte
+	outputClosed              bool
+	alternateScreenActive     bool
+	alternateScreenTail       []byte
+	terminalSequenceTail      []byte
+	inputModes                terminalInputModeState
+	lifecycleMu               sync.Mutex
+	lifecycleClosed           bool
+	stopRequested             bool
+	nextAttachmentID          uint64
+	resizeOwnerID             uint64
+	resizeOwnerPriority       ResizePriority
+	resizeAttachments         map[uint64]resizeAttachment
+	replayBoundarySubscribers map[chan []byte]struct{}
 }
 
 type ResizePriority int
@@ -199,6 +200,7 @@ const (
 type AttachSessionOptions struct {
 	ResizePriority ResizePriority
 	ResizeActive   bool
+	ReplayBoundary bool
 }
 
 type resizeAttachment struct {
@@ -1775,12 +1777,29 @@ func (s *session) broadcast(data []byte) {
 
 	s.inputModes.observe(chunk)
 	s.appendReplayOutputLocked(chunk)
+	replayReady := len(s.terminalSequenceTail) == 0
 
 	for ch := range s.subscribers {
 		select {
 		case ch <- chunk:
 		default:
 			delete(s.subscribers, ch)
+			delete(s.replayBoundarySubscribers, ch)
+			close(ch)
+			continue
+		}
+		if !replayReady {
+			continue
+		}
+		if _, pending := s.replayBoundarySubscribers[ch]; !pending {
+			continue
+		}
+		select {
+		case ch <- nil:
+			delete(s.replayBoundarySubscribers, ch)
+		default:
+			delete(s.subscribers, ch)
+			delete(s.replayBoundarySubscribers, ch)
 			close(ch)
 		}
 	}
@@ -1907,6 +1926,14 @@ func trailingBytes(data []byte, maxLen int) []byte {
 }
 
 func (s *session) subscribe() (<-chan []byte, func()) {
+	return s.subscribeInternal(false)
+}
+
+func (s *session) subscribeWithReplayBoundary() (<-chan []byte, func()) {
+	return s.subscribeInternal(true)
+}
+
+func (s *session) subscribeInternal(replayBoundary bool) (<-chan []byte, func()) {
 	ch := make(chan []byte, 64)
 
 	s.mu.Lock()
@@ -1938,6 +1965,16 @@ func (s *session) subscribe() (<-chan []byte, func()) {
 			"bytes", len(replay),
 		)
 	}
+	if replayBoundary {
+		if s.outputClosed || len(s.terminalSequenceTail) == 0 {
+			ch <- nil
+		} else {
+			if s.replayBoundarySubscribers == nil {
+				s.replayBoundarySubscribers = make(map[chan []byte]struct{})
+			}
+			s.replayBoundarySubscribers[ch] = struct{}{}
+		}
+	}
 	if s.outputClosed {
 		close(ch)
 		s.mu.Unlock()
@@ -1958,6 +1995,7 @@ func (s *session) subscribe() (<-chan []byte, func()) {
 		info := s.info
 		if _, ok := s.subscribers[ch]; ok {
 			delete(s.subscribers, ch)
+			delete(s.replayBoundarySubscribers, ch)
 			close(ch)
 		}
 		subscriberCount := len(s.subscribers)
@@ -2079,6 +2117,13 @@ func (s *session) closeSubscribers() {
 	}
 	s.outputClosed = true
 	for ch := range s.subscribers {
+		if _, pending := s.replayBoundarySubscribers[ch]; pending {
+			select {
+			case ch <- nil:
+			default:
+			}
+			delete(s.replayBoundarySubscribers, ch)
+		}
 		delete(s.subscribers, ch)
 		close(ch)
 	}
@@ -2317,7 +2362,13 @@ func attachToSession(
 		return nil, fmt.Errorf("session %q is not running", key)
 	}
 
-	output, unsubscribe := s.subscribe()
+	var output <-chan []byte
+	var unsubscribe func()
+	if options.ReplayBoundary {
+		output, unsubscribe = s.subscribeWithReplayBoundary()
+	} else {
+		output, unsubscribe = s.subscribe()
+	}
 	resizeAttachmentID := s.registerResizeAttachment(
 		options.ResizePriority,
 		options.ResizeActive,

--- a/internal/workspace/localruntime/manager_test.go
+++ b/internal/workspace/localruntime/manager_test.go
@@ -1,6 +1,7 @@
 package localruntime
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -2263,6 +2264,494 @@ func TestSessionSubscribeReplaysBufferedOutput(t *testing.T) {
 	case <-time.After(100 * time.Millisecond):
 		assert.Fail("subscriber did not receive new output after replay")
 	}
+}
+
+func TestSessionSubscribeReplayTruncationPreservesUTF8Boundary(t *testing.T) {
+	s := &session{subscribers: make(map[chan []byte]struct{})}
+	// U+201B ends in 0x9b. If truncation retains only that continuation byte,
+	// the replay scanner mistakes it for a raw C1 CSI and treats the following
+	// text as a bracketed-paste mode change.
+	prefix := []byte("\xe2\x80\x9b?2004h")
+	output := append(prefix, bytes.Repeat([]byte("x"), maxSessionOutputReplay+2-len(prefix))...)
+	s.broadcast(output)
+
+	ch, cancel := s.subscribe()
+	t.Cleanup(cancel)
+
+	select {
+	case data := <-ch:
+		assert := assert.New(t)
+		assert.Equal(byte('?'), data[0])
+		assert.NotContains(string(data), "\x1b[?2004l")
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail(t, "subscriber did not receive replay")
+	}
+}
+
+func TestSessionSubscribeReplayTruncationPreservesRawC1(t *testing.T) {
+	s := &session{subscribers: make(map[chan []byte]struct{})}
+	prefix := []byte("xx\x9b?2004h")
+	output := append(prefix, bytes.Repeat([]byte("x"), maxSessionOutputReplay+2-len(prefix))...)
+	s.broadcast(output)
+
+	ch, cancel := s.subscribe()
+	t.Cleanup(cancel)
+
+	select {
+	case data := <-ch:
+		assert.Equal(t, byte(0x9b), data[0])
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail(t, "subscriber did not receive replay")
+	}
+}
+
+func TestSessionSubscribeRestoresInputModesAfterReplayTruncation(t *testing.T) {
+	s := &session{subscribers: make(map[chan []byte]struct{})}
+	modeSequence := "\x1b[?1000;1006;2004h"
+	s.broadcast([]byte(modeSequence))
+	s.broadcast(bytes.Repeat([]byte("x"), maxSessionOutputReplay+1))
+
+	ch, cancel := s.subscribe()
+	t.Cleanup(cancel)
+
+	select {
+	case data := <-ch:
+		assert := assert.New(t)
+		assert.Len(data, maxSessionOutputReplay+len(modeSequence))
+		assert.Equal(modeSequence, string(data[maxSessionOutputReplay:]))
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail(t, "subscriber did not receive replay")
+	}
+}
+
+func TestSessionSubscribeRestoresDisabledInputModesAfterReplayTruncation(t *testing.T) {
+	s := &session{subscribers: make(map[chan []byte]struct{})}
+	s.broadcast([]byte("\x1b[?1003;1004;1016;2004h"))
+	s.broadcast([]byte("\x1b[?1000;1004;1006;2004l"))
+	s.broadcast(bytes.Repeat([]byte("x"), maxSessionOutputReplay+1))
+
+	ch, cancel := s.subscribe()
+	t.Cleanup(cancel)
+
+	select {
+	case data := <-ch:
+		resetSequence := "\x1b[?1000;1004;1006;2004l"
+		assert := assert.New(t)
+		assert.Len(data, maxSessionOutputReplay+len(resetSequence))
+		assert.Equal(resetSequence, string(data[maxSessionOutputReplay:]))
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail(t, "subscriber did not receive replay")
+	}
+}
+
+func TestSessionSubscribeOverridesStaleReplayInputModes(t *testing.T) {
+	s := &session{subscribers: make(map[chan []byte]struct{})}
+	s.broadcast([]byte("\x1b[?1000l"))
+	s.mu.Lock()
+	s.outputBuffer = []byte("screen\x1b[?1000h")
+	s.mu.Unlock()
+
+	ch, cancel := s.subscribe()
+	t.Cleanup(cancel)
+
+	select {
+	case data := <-ch:
+		assert.Equal(t, "screen\x1b[?1000h\x1b[?1000l", string(data))
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail(t, "subscriber did not receive replay")
+	}
+}
+
+func TestSessionSubscribeDoesNotSynthesizeDuplicateRetainedFocusMode(t *testing.T) {
+	s := &session{subscribers: make(map[chan []byte]struct{})}
+	s.broadcast([]byte("screen\x1b[?1004h\x1b[?1004h"))
+
+	ch, cancel := s.subscribe()
+	t.Cleanup(cancel)
+
+	select {
+	case data := <-ch:
+		assert.Equal(t, 2, bytes.Count(data, []byte("\x1b[?1004h")))
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail(t, "subscriber did not receive replay")
+	}
+}
+
+func TestSessionSubscribePreservesSplitTerminalData(t *testing.T) {
+	tests := []struct {
+		name         string
+		candidate    string
+		continuation string
+	}{
+		{
+			name:         "tracked private mode CSI",
+			candidate:    "\x1b[?1004",
+			continuation: "h",
+		},
+		{
+			name:         "ordinary CSI",
+			candidate:    "\x1b[31",
+			continuation: "m",
+		},
+		{
+			name:         "ordinary CSI with executable C0",
+			candidate:    "\x1b[31\x07",
+			continuation: "m",
+		},
+		{
+			name:         "ordinary CSI with DEL",
+			candidate:    "\x1b[31\x7f",
+			continuation: "m",
+		},
+		{
+			name:         "Unicode split inside CSI",
+			candidate:    "\x1b[?2004\xe2",
+			continuation: "\x98\x83h",
+		},
+		{
+			name:         "OSC",
+			candidate:    "\x1b]0;partial title",
+			continuation: "\x07",
+		},
+		{
+			name:         "OSC terminated by ST",
+			candidate:    "\x1b]0;partial title",
+			continuation: "\x1b\\",
+		},
+		{
+			name:         "OSC split inside ST",
+			candidate:    "\x1b]0;partial title\x1b",
+			continuation: "\\",
+		},
+		{
+			name:         "DCS",
+			candidate:    "\x1bP1;2|partial data",
+			continuation: "\x1b\\",
+		},
+		{
+			name:         "DCS split inside ST",
+			candidate:    "\x1bP1;2|partial data\x1b",
+			continuation: "\\",
+		},
+		{
+			name:         "ESC with intermediate",
+			candidate:    "\x1b(",
+			continuation: "B",
+		},
+		{
+			name:         "UTF-8 C1 CSI",
+			candidate:    "\xc2\x9b31",
+			continuation: "m",
+		},
+		{
+			name:         "UTF-8 C1 OSC",
+			candidate:    "\xc2\x9d0;partial title",
+			continuation: "\xc2\x9c",
+		},
+		{
+			name:         "UTF-8 C1 DCS",
+			candidate:    "\xc2\x901;2|partial data",
+			continuation: "\xc2\x9c",
+		},
+		{
+			name:         "UTF-8 code point",
+			candidate:    "\xe2\x82",
+			continuation: "\xac",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &session{subscribers: make(map[chan []byte]struct{})}
+			s.broadcast([]byte("\x1b[?1000h"))
+			s.broadcast(bytes.Repeat([]byte("x"), maxSessionOutputReplay+1))
+			s.broadcast([]byte(tt.candidate))
+
+			ch, cancel := s.subscribe()
+			t.Cleanup(cancel)
+
+			assert := assert.New(t)
+			select {
+			case data := <-ch:
+				assert.True(bytes.HasSuffix(data, []byte("\x1b[?1000h"+tt.candidate)))
+			case <-time.After(100 * time.Millisecond):
+				assert.Fail("subscriber did not receive replay")
+			}
+
+			s.broadcast([]byte(tt.continuation))
+			select {
+			case data := <-ch:
+				assert.Equal(tt.continuation, string(data))
+			case <-time.After(100 * time.Millisecond):
+				assert.Fail("subscriber did not receive split sequence continuation")
+			}
+		})
+	}
+}
+
+func TestSessionSubscribePlacesTransitionsAfterCompleteOrDiscardedC1Data(t *testing.T) {
+	tests := []struct {
+		name          string
+		controlString string
+	}{
+		{
+			name:          "UTF-8 C1 controls",
+			controlString: "\xc2\x9d0;complete title\xc2\x9c",
+		},
+		{
+			name:          "raw C1 controls",
+			controlString: "\x9d0;complete title\x9c",
+		},
+		{
+			name:          "raw C1 CSI prefix",
+			controlString: "\x9b31",
+		},
+		{
+			name:          "raw C1 OSC prefix",
+			controlString: "\x9d0;partial title",
+		},
+		{
+			name:          "raw C1 DCS prefix",
+			controlString: "\x901;2|partial data",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &session{subscribers: make(map[chan []byte]struct{})}
+			s.broadcast([]byte("\x1b[?1000h"))
+			s.broadcast(bytes.Repeat([]byte("x"), maxSessionOutputReplay+1))
+			s.broadcast([]byte(tt.controlString))
+
+			ch, cancel := s.subscribe()
+			t.Cleanup(cancel)
+
+			select {
+			case data := <-ch:
+				assert.True(t, bytes.HasSuffix(data, []byte(tt.controlString+"\x1b[?1000h")))
+			case <-time.After(100 * time.Millisecond):
+				assert.Fail(t, "subscriber did not receive replay")
+			}
+		})
+	}
+}
+
+func TestSessionSubscribeRestoresInputModesWhileAlternateScreenActive(t *testing.T) {
+	s := &session{subscribers: make(map[chan []byte]struct{})}
+	s.broadcast([]byte("\x1b[?1000;1006h"))
+	s.broadcast([]byte("\x1b[?1049h\x1b[Hcodex screen"))
+
+	ch, cancel := s.subscribe()
+	t.Cleanup(cancel)
+
+	select {
+	case data := <-ch:
+		assert.Equal(t, "\x1b[?1000;1006h", string(data))
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail(t, "subscriber did not receive input mode replay")
+	}
+}
+
+func TestSessionSubscribeIgnoresUTF8ContinuationWhileAlternateScreenActive(t *testing.T) {
+	s := &session{subscribers: make(map[chan []byte]struct{})}
+	s.broadcast([]byte("\x1b[?1049h"))
+	s.broadcast([]byte("\xd8"))
+	s.broadcast([]byte("\x9b"))
+
+	ch, cancel := s.subscribe()
+	t.Cleanup(cancel)
+
+	select {
+	case data := <-ch:
+		assert.Failf(
+			t,
+			"subscriber received a phantom C1 sequence",
+			"unexpected replay: %q",
+			string(data),
+		)
+	case <-time.After(25 * time.Millisecond):
+	}
+}
+
+func TestSessionSubscribePreservesSplitUTF8C1WhileAlternateScreenActive(t *testing.T) {
+	s := &session{subscribers: make(map[chan []byte]struct{})}
+	s.broadcast([]byte("\x1b[?1049h"))
+	s.broadcast([]byte("\xc2"))
+
+	ch, cancel := s.subscribe()
+	t.Cleanup(cancel)
+
+	select {
+	case data := <-ch:
+		assert.Equal(t, "\xc2", string(data))
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail(t, "subscriber did not receive split UTF-8 C1 prefix")
+	}
+}
+
+func TestSessionSubscribePreservesSplitTerminalDataWhileAlternateScreenActive(t *testing.T) {
+	tests := []struct {
+		name         string
+		candidate    string
+		continuation string
+	}{
+		{
+			name:         "tracked input mode",
+			candidate:    "\x1b[?2004",
+			continuation: "h",
+		},
+		{
+			name:         "ordinary CSI",
+			candidate:    "\x1b[31",
+			continuation: "m",
+		},
+		{
+			name:         "Unicode split inside CSI",
+			candidate:    "\x1b[?2004\xe2",
+			continuation: "\x98\x83h",
+		},
+		{
+			name:         "OSC",
+			candidate:    "\x1b]0;partial title",
+			continuation: "\x07",
+		},
+		{
+			name:         "OSC terminated by ST",
+			candidate:    "\x1b]0;partial title",
+			continuation: "\x1b\\",
+		},
+		{
+			name:         "DCS",
+			candidate:    "\x1bP1;2|partial data",
+			continuation: "\x1b\\",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &session{subscribers: make(map[chan []byte]struct{})}
+			s.broadcast([]byte("\x1b[?1000h"))
+			s.broadcast([]byte("\x1b[?1049h"))
+			s.broadcast([]byte(tt.candidate))
+
+			ch, cancel := s.subscribe()
+			t.Cleanup(cancel)
+
+			assert := assert.New(t)
+			select {
+			case data := <-ch:
+				assert.Equal("\x1b[?1000h"+tt.candidate, string(data))
+			case <-time.After(100 * time.Millisecond):
+				assert.Fail("subscriber did not receive terminal replay")
+			}
+
+			s.broadcast([]byte(tt.continuation))
+			select {
+			case data := <-ch:
+				assert.Equal(tt.continuation, string(data))
+			case <-time.After(100 * time.Millisecond):
+				assert.Fail("subscriber did not receive split sequence continuation")
+			}
+		})
+	}
+}
+
+func TestSessionSubscribeDropsRawC1TailWhileAlternateScreenActive(t *testing.T) {
+	tests := []struct {
+		name      string
+		candidate string
+	}{
+		{name: "CSI", candidate: "\x9b31"},
+		{name: "OSC", candidate: "\x9d0;partial title"},
+		{name: "DCS", candidate: "\x901;2|partial data"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &session{subscribers: make(map[chan []byte]struct{})}
+			s.broadcast([]byte("\x1b[?1000h"))
+			s.broadcast([]byte("\x1b[?1049h"))
+			s.broadcast([]byte(tt.candidate))
+
+			ch, cancel := s.subscribe()
+			t.Cleanup(cancel)
+
+			select {
+			case data := <-ch:
+				assert.Equal(t, "\x1b[?1000h", string(data))
+			case <-time.After(100 * time.Millisecond):
+				assert.Fail(t, "subscriber did not receive terminal replay")
+			}
+		})
+	}
+}
+
+func TestSessionSubscribeAfterCloseCombinesReplayAndInputModes(t *testing.T) {
+	s := &session{subscribers: make(map[chan []byte]struct{})}
+	modeSequence := "\x1b[?1000;1006h"
+	s.broadcast([]byte(modeSequence))
+	s.broadcast(bytes.Repeat([]byte("x"), maxSessionOutputReplay+1))
+	s.closeSubscribers()
+
+	ch, cancel := s.subscribe()
+	t.Cleanup(cancel)
+
+	assert := assert.New(t)
+	select {
+	case data, ok := <-ch:
+		assert.True(ok)
+		assert.Len(data, maxSessionOutputReplay+len(modeSequence))
+		assert.Equal(modeSequence, string(data[maxSessionOutputReplay:]))
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail("expected replay before channel close")
+	}
+	select {
+	case _, ok := <-ch:
+		assert.False(ok)
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail("expected channel to close after replay")
+	}
+}
+
+func TestSessionSubscribeWithoutInputModesPreservesReplay(t *testing.T) {
+	s := &session{subscribers: make(map[chan []byte]struct{})}
+	s.broadcast([]byte("startup-banner\r\n$ "))
+
+	ch, cancel := s.subscribe()
+	t.Cleanup(cancel)
+
+	select {
+	case data := <-ch:
+		assert.Equal(t, "startup-banner\r\n$ ", string(data))
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail(t, "subscriber did not receive replay")
+	}
+}
+
+func TestSessionInputModeReplayIsSubscriberOnly(t *testing.T) {
+	s := &session{subscribers: make(map[chan []byte]struct{})}
+	ch, cancel := s.subscribe()
+	t.Cleanup(cancel)
+	raw := []byte("screen\x1b[?1000;1006h")
+
+	s.broadcast(raw)
+
+	assert := assert.New(t)
+	select {
+	case data := <-ch:
+		assert.Equal(raw, data)
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail("subscriber did not receive live output")
+	}
+	select {
+	case data := <-ch:
+		assert.Failf("subscriber received synthesized live output", "output: %q", data)
+	case <-time.After(25 * time.Millisecond):
+	}
+	s.mu.Lock()
+	replay := bytes.Clone(s.outputBuffer)
+	s.mu.Unlock()
+	assert.Equal(raw, replay)
 }
 
 func TestSessionSubscribeSkipsReplayWhileAlternateScreenActive(t *testing.T) {

--- a/internal/workspace/localruntime/manager_test.go
+++ b/internal/workspace/localruntime/manager_test.go
@@ -2409,6 +2409,16 @@ func TestSessionSubscribePreservesSplitTerminalData(t *testing.T) {
 			continuation: "\x98\x83h",
 		},
 		{
+			name:         "discarded BOM inside CSI",
+			candidate:    "\x1b[?2004\xef\xbb\xbf",
+			continuation: "h",
+		},
+		{
+			name:         "discarded invalid scalar inside CSI",
+			candidate:    "\x1b[?2004\xed\xa0\x80",
+			continuation: "h",
+		},
+		{
 			name:         "OSC",
 			candidate:    "\x1b]0;partial title",
 			continuation: "\x07",
@@ -2467,7 +2477,7 @@ func TestSessionSubscribePreservesSplitTerminalData(t *testing.T) {
 			s.broadcast(bytes.Repeat([]byte("x"), maxSessionOutputReplay+1))
 			s.broadcast([]byte(tt.candidate))
 
-			ch, cancel := s.subscribe()
+			ch, cancel := s.subscribeWithReplayBoundary()
 			t.Cleanup(cancel)
 
 			assert := assert.New(t)
@@ -2485,7 +2495,35 @@ func TestSessionSubscribePreservesSplitTerminalData(t *testing.T) {
 			case <-time.After(100 * time.Millisecond):
 				assert.Fail("subscriber did not receive split sequence continuation")
 			}
+			select {
+			case data := <-ch:
+				assert.Nil(data)
+			case <-time.After(100 * time.Millisecond):
+				assert.Fail("subscriber did not receive replay boundary")
+			}
 		})
+	}
+}
+
+func TestSessionSubscribeReplayBoundaryReadyWithoutPendingTail(t *testing.T) {
+	s := &session{subscribers: make(map[chan []byte]struct{})}
+	s.broadcast([]byte("complete replay"))
+
+	ch, cancel := s.subscribeWithReplayBoundary()
+	t.Cleanup(cancel)
+
+	assert := assert.New(t)
+	select {
+	case data := <-ch:
+		assert.Equal("complete replay", string(data))
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail("subscriber did not receive replay")
+	}
+	select {
+	case data := <-ch:
+		assert.Nil(data)
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail("subscriber did not receive replay boundary")
 	}
 }
 
@@ -2574,18 +2612,32 @@ func TestSessionSubscribeIgnoresUTF8ContinuationWhileAlternateScreenActive(t *te
 }
 
 func TestSessionSubscribePreservesSplitUTF8C1WhileAlternateScreenActive(t *testing.T) {
+	assert := assert.New(t)
 	s := &session{subscribers: make(map[chan []byte]struct{})}
 	s.broadcast([]byte("\x1b[?1049h"))
 	s.broadcast([]byte("\xc2"))
 
-	ch, cancel := s.subscribe()
+	ch, cancel := s.subscribeWithReplayBoundary()
 	t.Cleanup(cancel)
 
 	select {
 	case data := <-ch:
-		assert.Equal(t, "\xc2", string(data))
+		assert.Equal("\xc2", string(data))
 	case <-time.After(100 * time.Millisecond):
-		assert.Fail(t, "subscriber did not receive split UTF-8 C1 prefix")
+		assert.Fail("subscriber did not receive split UTF-8 C1 prefix")
+	}
+	s.broadcast([]byte("\x9b?1h"))
+	select {
+	case data := <-ch:
+		assert.Equal("\x9b?1h", string(data))
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail("subscriber did not receive split UTF-8 C1 continuation")
+	}
+	select {
+	case data := <-ch:
+		assert.Nil(data)
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail("subscriber did not receive replay boundary")
 	}
 }
 
@@ -2611,6 +2663,16 @@ func TestSessionSubscribePreservesSplitTerminalDataWhileAlternateScreenActive(t 
 			continuation: "\x98\x83h",
 		},
 		{
+			name:         "discarded BOM inside CSI",
+			candidate:    "\x1b[?2004\xef\xbb\xbf",
+			continuation: "h",
+		},
+		{
+			name:         "discarded invalid scalar inside CSI",
+			candidate:    "\x1b[?2004\xed\xa0\x80",
+			continuation: "h",
+		},
+		{
 			name:         "OSC",
 			candidate:    "\x1b]0;partial title",
 			continuation: "\x07",
@@ -2634,7 +2696,7 @@ func TestSessionSubscribePreservesSplitTerminalDataWhileAlternateScreenActive(t 
 			s.broadcast([]byte("\x1b[?1049h"))
 			s.broadcast([]byte(tt.candidate))
 
-			ch, cancel := s.subscribe()
+			ch, cancel := s.subscribeWithReplayBoundary()
 			t.Cleanup(cancel)
 
 			assert := assert.New(t)
@@ -2651,6 +2713,12 @@ func TestSessionSubscribePreservesSplitTerminalDataWhileAlternateScreenActive(t 
 				assert.Equal(tt.continuation, string(data))
 			case <-time.After(100 * time.Millisecond):
 				assert.Fail("subscriber did not receive split sequence continuation")
+			}
+			select {
+			case data := <-ch:
+				assert.Nil(data)
+			case <-time.After(100 * time.Millisecond):
+				assert.Fail("subscriber did not receive replay boundary")
 			}
 		})
 	}

--- a/internal/workspace/localruntime/terminal_input_modes.go
+++ b/internal/workspace/localruntime/terminal_input_modes.go
@@ -67,11 +67,11 @@ func (s *terminalInputModeState) consumeUTF8Byte(current byte) bool {
 			s.utf8Pending[s.utf8PendingLen] = current
 			s.utf8PendingLen++
 			if s.utf8PendingLen == s.utf8ExpectedLen {
-				decoded, _ := utf8.DecodeRune(s.pendingUTF8())
+				decoded, size := utf8.DecodeRune(s.pendingUTF8())
 				s.clearUTF8()
 				if decoded == '\u009b' {
 					s.observeControlByte('\x9b')
-				} else {
+				} else if !isXtermDiscardedUTF8(decoded, size) {
 					s.pending = nil
 				}
 			}
@@ -95,6 +95,10 @@ func (s *terminalInputModeState) consumeUTF8Byte(current byte) bool {
 		// bytes and invalid leading bytes before VT parsing.
 		return current >= utf8.RuneSelf
 	}
+}
+
+func isXtermDiscardedUTF8(decoded rune, size int) bool {
+	return decoded == '\ufeff' || decoded == utf8.RuneError && size == 1
 }
 
 func (s *terminalInputModeState) startUTF8(current byte, expectedLen uint8) {

--- a/internal/workspace/localruntime/terminal_input_modes.go
+++ b/internal/workspace/localruntime/terminal_input_modes.go
@@ -1,0 +1,374 @@
+package localruntime
+
+import (
+	"strconv"
+	"unicode/utf8"
+)
+
+const maxTerminalInputModeSequence = 128
+
+const (
+	terminalMouseProtocolResetMode = 1000
+	terminalMouseEncodingResetMode = 1006
+)
+
+var trackedTerminalInputModes = [...]int{
+	1,
+	9,
+	1000,
+	1002,
+	1003,
+	1004,
+	1005,
+	1006,
+	1015,
+	1016,
+	2004,
+}
+
+var trackedTerminalInputModeSet = map[int]struct{}{
+	1:    {},
+	9:    {},
+	1000: {},
+	1002: {},
+	1003: {},
+	1004: {},
+	1005: {},
+	1006: {},
+	1015: {},
+	1016: {},
+	2004: {},
+}
+
+type terminalInputModeState struct {
+	observed              map[int]bool
+	mouseProtocol         int
+	mouseProtocolObserved bool
+	mouseEncoding         int
+	mouseEncodingObserved bool
+	pending               []byte
+	utf8Pending           [utf8.UTFMax]byte
+	utf8PendingLen        uint8
+	utf8ExpectedLen       uint8
+}
+
+func (s *terminalInputModeState) observe(data []byte) {
+	for _, current := range data {
+		if s.consumeUTF8Byte(current) {
+			continue
+		}
+		s.observeControlByte(current)
+	}
+}
+
+func (s *terminalInputModeState) consumeUTF8Byte(current byte) bool {
+	if s.utf8PendingLen > 0 {
+		if current&0xc0 == 0x80 {
+			s.utf8Pending[s.utf8PendingLen] = current
+			s.utf8PendingLen++
+			if s.utf8PendingLen == s.utf8ExpectedLen {
+				decoded, _ := utf8.DecodeRune(s.pendingUTF8())
+				s.clearUTF8()
+				if decoded == '\u009b' {
+					s.observeControlByte('\x9b')
+				} else {
+					s.pending = nil
+				}
+			}
+			return true
+		}
+		s.clearUTF8()
+	}
+
+	switch {
+	case current >= 0xc2 && current <= 0xdf:
+		s.startUTF8(current, 2)
+		return true
+	case current >= 0xe0 && current <= 0xef:
+		s.startUTF8(current, 3)
+		return true
+	case current >= 0xf0 && current <= 0xf4:
+		s.startUTF8(current, 4)
+		return true
+	default:
+		// xterm's binary UTF-8 decoder discards standalone continuation
+		// bytes and invalid leading bytes before VT parsing.
+		return current >= utf8.RuneSelf
+	}
+}
+
+func (s *terminalInputModeState) startUTF8(current byte, expectedLen uint8) {
+	// Keep a byte-oriented candidate until the rune is complete. If the lead
+	// byte is followed by invalid UTF-8, xterm drops it and parses the next
+	// byte as the candidate's continuation.
+	s.utf8Pending[0] = current
+	s.utf8PendingLen = 1
+	s.utf8ExpectedLen = expectedLen
+}
+
+func (s *terminalInputModeState) pendingUTF8() []byte {
+	return s.utf8Pending[:s.utf8PendingLen]
+}
+
+func (s *terminalInputModeState) clearUTF8() {
+	s.utf8PendingLen = 0
+	s.utf8ExpectedLen = 0
+}
+
+func (s *terminalInputModeState) observeControlByte(current byte) {
+	if len(s.pending) == 0 {
+		s.startCandidate(current)
+		return
+	}
+	if current == '\x18' || current == '\x1a' {
+		s.pending = nil
+		return
+	}
+	if isTerminalExecutableC0(current) || current == '\x7f' {
+		return
+	}
+	if current == '\x9b' {
+		s.pending = append(s.pending[:0], '\x1b', '[')
+		return
+	}
+
+	switch len(s.pending) {
+	case 1:
+		if current == 'c' {
+			s.fullReset()
+			s.pending = nil
+			return
+		}
+		if current != '[' {
+			s.resetCandidate(current)
+			return
+		}
+	case 2:
+		if current != '?' && current != '!' {
+			s.resetCandidate(current)
+			return
+		}
+	default:
+		if s.pending[2] == '!' {
+			if len(s.pending) == 3 && current == 'p' {
+				s.softReset()
+				s.pending = nil
+				return
+			}
+			s.resetCandidate(current)
+			return
+		}
+		// xterm.js 6 does not implement DEC private-mode save/restore
+		// (CSI ? Pm s/r), so only set/reset finals change effective state.
+		switch {
+		case current == 'h' || current == 'l':
+			s.recordCandidate(current == 'h')
+			s.pending = nil
+			return
+		case current < '0' || current > '9':
+			if current != ';' {
+				s.resetCandidate(current)
+				return
+			}
+		}
+	}
+
+	s.pending = append(s.pending, current)
+	if len(s.pending) >= maxTerminalInputModeSequence {
+		s.pending = nil
+	}
+}
+
+func (s *terminalInputModeState) startCandidate(current byte) {
+	switch current {
+	case '\x1b':
+		s.pending = append(s.pending, current)
+	case '\x9b':
+		s.pending = append(s.pending, '\x1b', '[')
+	}
+}
+
+func (s *terminalInputModeState) resetCandidate(current byte) {
+	s.pending = nil
+	s.startCandidate(current)
+}
+
+func (s *terminalInputModeState) recordCandidate(enabled bool) {
+	parameters := s.pending[3:]
+	start := 0
+	for end := 0; end <= len(parameters); end++ {
+		if end < len(parameters) && parameters[end] != ';' {
+			continue
+		}
+		if end > start {
+			mode, err := strconv.Atoi(string(parameters[start:end]))
+			if err == nil {
+				if _, tracked := trackedTerminalInputModeSet[mode]; tracked {
+					s.recordMode(mode, enabled)
+				}
+			}
+		}
+		start = end + 1
+	}
+}
+
+func (s *terminalInputModeState) recordMode(mode int, enabled bool) {
+	switch {
+	case isTerminalMouseProtocol(mode):
+		s.mouseProtocolObserved = true
+		if enabled {
+			s.mouseProtocol = mode
+		} else {
+			s.mouseProtocol = 0
+		}
+	case isSupportedTerminalMouseEncoding(mode):
+		s.mouseEncodingObserved = true
+		if enabled {
+			s.mouseEncoding = mode
+		} else {
+			s.mouseEncoding = 0
+		}
+	default:
+		if s.observed == nil {
+			s.observed = make(map[int]bool)
+		}
+		s.observed[mode] = enabled
+	}
+}
+
+func (s *terminalInputModeState) fullReset() {
+	s.mouseProtocol = 0
+	s.mouseProtocolObserved = true
+	s.mouseEncoding = 0
+	s.mouseEncodingObserved = true
+	if s.observed == nil {
+		s.observed = make(map[int]bool)
+	}
+	for _, mode := range trackedTerminalInputModes {
+		if !isTerminalMouseProtocol(mode) &&
+			!isSupportedTerminalMouseEncoding(mode) {
+			s.observed[mode] = false
+		}
+	}
+}
+
+func (s *terminalInputModeState) softReset() {
+	if s.observed == nil {
+		s.observed = make(map[int]bool)
+	}
+	// xterm DECSTR resets CoreService modes, but does not reset
+	// CoreMouseService's active protocol or encoding.
+	s.observed[1] = false
+	s.observed[1004] = false
+	s.observed[2004] = false
+}
+
+func (s *terminalInputModeState) appendTransitions(
+	dst []byte,
+	baseline terminalInputModeState,
+) []byte {
+	resetModes := make(map[int]bool)
+	setModes := make(map[int]bool)
+	for _, mode := range trackedTerminalInputModes {
+		if isTerminalMouseProtocol(mode) ||
+			isSupportedTerminalMouseEncoding(mode) {
+			continue
+		}
+		current, observed := s.observed[mode]
+		baselineCurrent, baselineObserved := baseline.observed[mode]
+		if !observed || (baselineObserved && baselineCurrent == current) {
+			continue
+		}
+		if current {
+			setModes[mode] = true
+		} else {
+			resetModes[mode] = true
+		}
+	}
+	appendGroupedTransition(
+		resetModes,
+		setModes,
+		s.mouseProtocolObserved,
+		s.mouseProtocol,
+		baseline.mouseProtocolObserved,
+		baseline.mouseProtocol,
+		terminalMouseProtocolResetMode,
+	)
+	appendGroupedTransition(
+		resetModes,
+		setModes,
+		s.mouseEncodingObserved,
+		s.mouseEncoding,
+		baseline.mouseEncodingObserved,
+		baseline.mouseEncoding,
+		terminalMouseEncodingResetMode,
+	)
+
+	resets := make([]int, 0, len(resetModes))
+	sets := make([]int, 0, len(setModes))
+	for _, mode := range trackedTerminalInputModes {
+		if resetModes[mode] {
+			resets = append(resets, mode)
+		}
+		if setModes[mode] {
+			sets = append(sets, mode)
+		}
+	}
+	dst = appendTerminalInputModeSequence(dst, resets, 'l')
+	return appendTerminalInputModeSequence(dst, sets, 'h')
+}
+
+func appendGroupedTransition(
+	resetModes map[int]bool,
+	setModes map[int]bool,
+	currentObserved bool,
+	current int,
+	baselineObserved bool,
+	baseline int,
+	canonicalReset int,
+) {
+	if !currentObserved {
+		return
+	}
+	if !baselineObserved {
+		if current == 0 {
+			resetModes[canonicalReset] = true
+		} else {
+			setModes[current] = true
+		}
+		return
+	}
+	if current == baseline {
+		return
+	}
+	if baseline != 0 {
+		resetModes[baseline] = true
+	}
+	if current != 0 {
+		setModes[current] = true
+	}
+}
+
+func isTerminalMouseProtocol(mode int) bool {
+	return mode == 9 || mode == 1000 || mode == 1002 || mode == 1003
+}
+
+func isSupportedTerminalMouseEncoding(mode int) bool {
+	// xterm.js 6 ignores 1005 and 1015. Keeping them outside this group
+	// preserves an active SGR encoding when either ignored mode follows it.
+	return mode == 1006 || mode == 1016
+}
+
+func appendTerminalInputModeSequence(dst []byte, modes []int, final byte) []byte {
+	if len(modes) == 0 {
+		return dst
+	}
+	dst = append(dst, "\x1b[?"...)
+	for index, mode := range modes {
+		if index > 0 {
+			dst = append(dst, ';')
+		}
+		dst = strconv.AppendInt(dst, int64(mode), 10)
+	}
+	return append(dst, final)
+}

--- a/internal/workspace/localruntime/terminal_input_modes_test.go
+++ b/internal/workspace/localruntime/terminal_input_modes_test.go
@@ -1,0 +1,255 @@
+package localruntime
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTerminalInputModeStateObserve(t *testing.T) {
+	tests := []struct {
+		name           string
+		baselineChunks []string
+		currentChunks  []string
+		want           string
+	}{
+		{
+			name:          "tracks effective input modes",
+			currentChunks: []string{"\x1b[?1;9;1000;1002;1003;1004;1005;1006;1015;1016;2004h"},
+			want:          "\x1b[?1;1003;1004;1005;1015;1016;2004h",
+		},
+		{
+			name:           "emits resets before sets",
+			baselineChunks: []string{"\x1b[?1003;1016h"},
+			currentChunks:  []string{"\x1b[?1000;1006h"},
+			want:           "\x1b[?1003;1016l\x1b[?1000;1006h",
+		},
+		{
+			name:           "latest observation wins",
+			baselineChunks: []string{"\x1b[?2004h"},
+			currentChunks:  []string{"\x1b[?2004h", "\x1b[?2004l"},
+			want:           "\x1b[?2004l",
+		},
+		{
+			name:          "observed disabled modes reset an unobserved baseline",
+			currentChunks: []string{"\x1b[?1004;2004h", "\x1b[?1004;2004l"},
+			want:          "\x1b[?1004;2004l",
+		},
+		{
+			name:          "observed disabled mouse groups use canonical resets",
+			currentChunks: []string{"\x1b[?1003;1016h", "\x1b[?1000;1006l"},
+			want:          "\x1b[?1000;1006l",
+		},
+		{
+			name:          "ignores unrelated and alternate screen modes",
+			currentChunks: []string{"\x1b[?25;1049h"},
+			want:          "",
+		},
+		{
+			name:          "extracts tracked modes from a mixed sequence",
+			currentChunks: []string{"\x1b[?1049;1000;1006h"},
+			want:          "\x1b[?1000;1006h",
+		},
+		{
+			name:           "does not duplicate retained focus mode",
+			baselineChunks: []string{"\x1b[?1004h"},
+			currentChunks:  []string{"\x1b[?1004h"},
+			want:           "",
+		},
+		{
+			name:          "last mouse protocol set wins",
+			currentChunks: []string{"\x1b[?1003h", "\x1b[?1000h"},
+			want:          "\x1b[?1000h",
+		},
+		{
+			name:           "resetting an inactive mouse protocol disables tracking",
+			baselineChunks: []string{"\x1b[?1002h"},
+			currentChunks:  []string{"\x1b[?1002h", "\x1b[?1000l"},
+			want:           "\x1b[?1002l",
+		},
+		{
+			name:          "last supported mouse encoding set wins",
+			currentChunks: []string{"\x1b[?1016h", "\x1b[?1006h"},
+			want:          "\x1b[?1006h",
+		},
+		{
+			name:          "ignored urxvt encoding after SGR preserves both observations",
+			currentChunks: []string{"\x1b[?1006h", "\x1b[?1015h"},
+			want:          "\x1b[?1006;1015h",
+		},
+		{
+			name:          "ignored UTF-8 encoding before SGR pixels preserves both observations",
+			currentChunks: []string{"\x1b[?1005h", "\x1b[?1016h"},
+			want:          "\x1b[?1005;1016h",
+		},
+		{
+			name:           "truncated replay restores SGR after ignored urxvt encoding",
+			baselineChunks: []string{"\x1b[?1015h"},
+			currentChunks:  []string{"\x1b[?1006h", "\x1b[?1015h"},
+			want:           "\x1b[?1006h",
+		},
+		{
+			name:           "truncated replay preserves SGR before ignored urxvt encoding",
+			baselineChunks: []string{"\x1b[?1006h"},
+			currentChunks:  []string{"\x1b[?1006h", "\x1b[?1015h"},
+			want:           "\x1b[?1015h",
+		},
+		{
+			name:           "truncated replay restores SGR pixels after ignored UTF-8 encoding",
+			baselineChunks: []string{"\x1b[?1005h"},
+			currentChunks:  []string{"\x1b[?1016h", "\x1b[?1005h"},
+			want:           "\x1b[?1016h",
+		},
+		{
+			name: "private mode save and restore remain ignored",
+			currentChunks: []string{
+				"\x1b[?1;1000;1004;2004h",
+				"\x1b[?1;1000;1004;2004s",
+				"\x1b[?1;1000;1004;2004l",
+				"\x1b[?1;1000;1004;2004r",
+			},
+			want: "\x1b[?1;1000;1004;2004l",
+		},
+		{
+			name:           "full reset clears all effective input modes",
+			baselineChunks: []string{"\x1b[?1;1003;1004;1005;1015;1016;2004h"},
+			currentChunks:  []string{"\x1b[?1;1003;1004;1005;1015;1016;2004h", "\x1bc"},
+			want:           "\x1b[?1;1003;1004;1005;1015;1016;2004l",
+		},
+		{
+			name:           "soft reset clears core input modes only",
+			baselineChunks: []string{"\x1b[?1;1000;1004;1006;2004h"},
+			currentChunks:  []string{"\x1b[?1;1000;1004;1006;2004h", "\x1b[!p"},
+			want:           "\x1b[?1;1004;2004l",
+		},
+		{
+			name:          "accepts UTF-8 encoded C1 CSI split across chunks",
+			currentChunks: []string{"\xc2", "\x9b?1h"},
+			want:          "\x1b[?1h",
+		},
+		{
+			name:          "ignores raw C1 CSI",
+			currentChunks: []string{"\x9b?1h"},
+			want:          "",
+		},
+		{
+			name:          "raw C1 byte does not interrupt pending CSI",
+			currentChunks: []string{"\x1b[?2004", "\x9b", "h"},
+			want:          "\x1b[?2004h",
+		},
+		{
+			name:          "ignores C1-valued continuation in Unicode output",
+			currentChunks: []string{"\xd8\x9b?1004h"},
+			want:          "",
+		},
+		{
+			name:          "ignores split C1-valued continuation in Unicode output",
+			currentChunks: []string{"\xe2\x80", "\x9b?2004h"},
+			want:          "",
+		},
+		{
+			name:          "split Unicode interrupts escape candidate",
+			currentChunks: []string{"\x1b", "\xe2", "\x98", "\x83", "c"},
+			want:          "",
+		},
+		{
+			name:          "split Unicode interrupts CSI candidate",
+			currentChunks: []string{"\x1b[?2004", "\xe2", "\x98", "\x83", "h"},
+			want:          "",
+		},
+		{
+			name:          "ignores executable controls inside CSI",
+			currentChunks: []string{"\x1b[?\x001\x7fh"},
+			want:          "\x1b[?1h",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var baseline, current terminalInputModeState
+			for _, chunk := range tt.baselineChunks {
+				baseline.observe([]byte(chunk))
+			}
+			for _, chunk := range tt.currentChunks {
+				current.observe([]byte(chunk))
+			}
+			assert.Equal(t, tt.want, string(current.appendTransitions(nil, baseline)))
+		})
+	}
+}
+
+func TestTerminalInputModeStateAppendTransitionsPreservesPrefix(t *testing.T) {
+	var state terminalInputModeState
+	state.observe([]byte("\x1b[?1000h"))
+	prefix := []byte("screen")
+	original := append([]byte(nil), prefix...)
+
+	got := state.appendTransitions(prefix, terminalInputModeState{})
+
+	assert := assert.New(t)
+	assert.Equal("screen\x1b[?1000h", string(got))
+	assert.Equal(original, prefix)
+}
+
+func TestTerminalInputModeStateHandlesEverySplit(t *testing.T) {
+	sequence := "\x1b[?1;1000;1002;1004;1006;2004h"
+	want := "\x1b[?1;1002;1004;1006;2004h"
+	for split := 1; split < len(sequence); split++ {
+		t.Run(strconv.Itoa(split), func(t *testing.T) {
+			var state terminalInputModeState
+			state.observe([]byte(sequence[:split]))
+			state.observe([]byte(sequence[split:]))
+			assert.Equal(
+				t,
+				want,
+				string(state.appendTransitions(nil, terminalInputModeState{})),
+			)
+		})
+	}
+}
+
+func TestTerminalInputModeStateRecoversAfterOverlongSequence(t *testing.T) {
+	var state terminalInputModeState
+	state.observe([]byte("\x1b[?" + strings.Repeat("1", maxTerminalInputModeSequence)))
+	state.observe([]byte("\x1b[?2004h"))
+
+	assert.Equal(
+		t,
+		"\x1b[?2004h",
+		string(state.appendTransitions(nil, terminalInputModeState{})),
+	)
+}
+
+func TestTerminalInputModeStateHandlesSplitResetSequences(t *testing.T) {
+	tests := []struct {
+		name     string
+		sequence string
+		want     string
+	}{
+		{
+			name:     "full reset",
+			sequence: "\x1bc",
+			want:     "\x1b[?1;1000;1004;1005;1006;1015;2004l",
+		},
+		{
+			name:     "soft reset",
+			sequence: "\x1b[!p",
+			want:     "\x1b[?1;1004;2004l",
+		},
+	}
+
+	for _, tt := range tests {
+		for split := 1; split < len(tt.sequence); split++ {
+			t.Run(tt.name+"/"+strconv.Itoa(split), func(t *testing.T) {
+				var baseline, current terminalInputModeState
+				baseline.observe([]byte("\x1b[?1;1000;1004;1006;2004h"))
+				current.observe([]byte("\x1b[?1;1000;1004;1006;2004h"))
+				current.observe([]byte(tt.sequence[:split]))
+				current.observe([]byte(tt.sequence[split:]))
+				assert.Equal(t, tt.want, string(current.appendTransitions(nil, baseline)))
+			})
+		}
+	}
+}

--- a/internal/workspace/localruntime/terminal_input_modes_test.go
+++ b/internal/workspace/localruntime/terminal_input_modes_test.go
@@ -160,6 +160,26 @@ func TestTerminalInputModeStateObserve(t *testing.T) {
 			want:          "",
 		},
 		{
+			name:          "discarded BOM preserves CSI candidate",
+			currentChunks: []string{"\x1b[?2004", "\xef", "\xbb", "\xbf", "h"},
+			want:          "\x1b[?2004h",
+		},
+		{
+			name:          "discarded overlong scalar preserves CSI candidate",
+			currentChunks: []string{"\x1b[?2004", "\xe0", "\x80", "\x80", "h"},
+			want:          "\x1b[?2004h",
+		},
+		{
+			name:          "discarded surrogate preserves CSI candidate",
+			currentChunks: []string{"\x1b[?2004", "\xed", "\xa0", "\x80", "h"},
+			want:          "\x1b[?2004h",
+		},
+		{
+			name:          "discarded out of range scalar preserves CSI candidate",
+			currentChunks: []string{"\x1b[?2004", "\xf4", "\x90", "\x80", "\x80", "h"},
+			want:          "\x1b[?2004h",
+		},
+		{
 			name:          "ignores executable controls inside CSI",
 			currentChunks: []string{"\x1b[?\x001\x7fh"},
 			want:          "\x1b[?1h",

--- a/internal/workspace/localruntime/terminal_sequence_tail.go
+++ b/internal/workspace/localruntime/terminal_sequence_tail.go
@@ -93,10 +93,13 @@ func trailingIncompleteTerminalDataLen(data []byte) int {
 				return len(data) - start
 			}
 			decoded, size := utf8.DecodeRune(data[index:])
-			if decoded == utf8.RuneError && size == 1 {
-				// xterm discards invalid standalone bytes in binary writes;
-				// they neither start nor interrupt a VT control sequence.
+			if isXtermDiscardedUTF8(decoded, size) {
+				// Xterm's binary decoder drops invalid scalars and BOM before
+				// VT parsing, so they neither start nor interrupt a control.
 				index++
+				if size > 1 {
+					index += size - 1
+				}
 				continue
 			}
 			if decoded >= '\u0080' && decoded <= '\u009f' {

--- a/internal/workspace/localruntime/terminal_sequence_tail.go
+++ b/internal/workspace/localruntime/terminal_sequence_tail.go
@@ -1,0 +1,188 @@
+package localruntime
+
+import "unicode/utf8"
+
+type terminalSequenceState uint8
+
+const (
+	terminalSequenceGround terminalSequenceState = iota
+	terminalSequenceEscape
+	terminalSequenceEscapeIntermediate
+	terminalSequenceCSI
+	terminalSequenceOSC
+	terminalSequenceString
+	terminalSequenceOSCSTPending
+	terminalSequenceStringSTPending
+)
+
+// trailingIncompleteTerminalDataLen returns the number of trailing bytes that
+// must remain adjacent to the next PTY chunk. Subscriber-only mode transitions
+// must precede that suffix so they cannot split a VT control sequence or a
+// multibyte UTF-8 code point.
+func trailingIncompleteTerminalDataLen(data []byte) int {
+	state := terminalSequenceGround
+	start := -1
+	stEscapeStart := -1
+
+	startEscape := func(index int) {
+		start = index
+		state = terminalSequenceEscape
+	}
+	advanceC1 := func(current byte, index int) {
+		if current == 0x9c {
+			start = -1
+			state = terminalSequenceGround
+			return
+		}
+		start = index
+		switch current {
+		case 0x90, 0x98, 0x9e, 0x9f:
+			state = terminalSequenceString
+		case 0x9b:
+			state = terminalSequenceCSI
+		case 0x9d:
+			state = terminalSequenceOSC
+		default:
+			start = -1
+			state = terminalSequenceGround
+		}
+	}
+	advanceEscape := func(current byte, index int) {
+		switch current {
+		case '[':
+			state = terminalSequenceCSI
+		case ']':
+			state = terminalSequenceOSC
+		case 'P', 'X', '^', '_':
+			state = terminalSequenceString
+		case '\x1b':
+			startEscape(index)
+		default:
+			switch {
+			case isTerminalExecutableC0(current), current == '\x7f':
+			case current >= 0x20 && current <= 0x2f:
+				state = terminalSequenceEscapeIntermediate
+			case current >= 0x30 && current <= 0x7e:
+				start = -1
+				state = terminalSequenceGround
+			default:
+				start = -1
+				state = terminalSequenceGround
+			}
+		}
+	}
+	advanceNonASCII := func() {
+		switch state {
+		case terminalSequenceEscape,
+			terminalSequenceEscapeIntermediate,
+			terminalSequenceCSI,
+			terminalSequenceOSCSTPending,
+			terminalSequenceStringSTPending:
+			start = -1
+			state = terminalSequenceGround
+		}
+	}
+
+	for index := 0; index < len(data); {
+		current := data[index]
+		if current >= utf8.RuneSelf {
+			if !utf8.FullRune(data[index:]) {
+				if start < 0 {
+					start = index
+				}
+				return len(data) - start
+			}
+			decoded, size := utf8.DecodeRune(data[index:])
+			if decoded == utf8.RuneError && size == 1 {
+				// xterm discards invalid standalone bytes in binary writes;
+				// they neither start nor interrupt a VT control sequence.
+				index++
+				continue
+			}
+			if decoded >= '\u0080' && decoded <= '\u009f' {
+				advanceC1(byte(decoded), index)
+			} else {
+				advanceNonASCII()
+			}
+			index += size
+			continue
+		}
+
+		switch current {
+		case '\x18', '\x1a':
+			start = -1
+			state = terminalSequenceGround
+			index++
+			continue
+		case '\x1b':
+			switch state {
+			case terminalSequenceOSC, terminalSequenceOSCSTPending:
+				stEscapeStart = index
+				state = terminalSequenceOSCSTPending
+			case terminalSequenceString, terminalSequenceStringSTPending:
+				stEscapeStart = index
+				state = terminalSequenceStringSTPending
+			default:
+				startEscape(index)
+			}
+			index++
+			continue
+		}
+
+		switch state {
+		case terminalSequenceGround:
+		case terminalSequenceEscape:
+			advanceEscape(current, index)
+		case terminalSequenceEscapeIntermediate:
+			switch {
+			case isTerminalExecutableC0(current), current == '\x7f':
+			case current >= 0x20 && current <= 0x2f:
+			case current >= 0x30 && current <= 0x7e:
+				start = -1
+				state = terminalSequenceGround
+			default:
+				start = -1
+				state = terminalSequenceGround
+			}
+		case terminalSequenceCSI:
+			switch {
+			case isTerminalExecutableC0(current), current == '\x7f':
+			case current >= 0x20 && current <= 0x3f:
+			case current >= 0x40 && current <= 0x7e:
+				start = -1
+				state = terminalSequenceGround
+			default:
+				start = -1
+				state = terminalSequenceGround
+			}
+		case terminalSequenceOSC:
+			if current == '\x07' {
+				start = -1
+				state = terminalSequenceGround
+			}
+		case terminalSequenceString:
+		case terminalSequenceOSCSTPending, terminalSequenceStringSTPending:
+			if current == '\\' {
+				start = -1
+				state = terminalSequenceGround
+				index++
+				continue
+			}
+			start = stEscapeStart
+			state = terminalSequenceEscape
+			advanceEscape(current, index)
+		}
+		index++
+	}
+
+	if state == terminalSequenceGround || start < 0 {
+		return 0
+	}
+	return len(data) - start
+}
+
+func isTerminalExecutableC0(current byte) bool {
+	return current <= 0x17 ||
+		current == 0x19 ||
+		current >= 0x1c && current <= 0x1f
+}


### PR DESCRIPTION
Workspace terminals could accept keyboard input after switching away and back while tmux mouse scrolling and bracketed paste remained disabled until the pane was resized. The tmux client outlives its browser renderer, but bounded screen replay may no longer contain the mode sequences a replacement terminal needs.

- Restore effective mouse, focus, and bracketed-paste modes for each local-runtime attachment.
- Preserve screen replay and live terminal output semantics while repairing only the new subscriber.
- Cover standalone and inline renderer replacement against a real tmux session.