### PR TITLE
Keep launcher closed during explicit agent startup

### DIFF
--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -90,12 +90,15 @@ Interactive surfaces must agree on which item is selected.
   begun controller-less must surface on an inline surface after a layout
   switch, where no recordCreated override ever ran
   (`frontend/src/lib/stores/workspace-host.svelte.ts::effectiveRef`).
-- An explicit create-and-launch intent must be published before presentation
-  liveness checks and remain reactive after a workspace is already ready; layout
-  churn or branch reuse must not silently discard the command
+- An explicit create-and-launch intent is keyed by `(workspaceHostKey, workspaceId)`
+  and must be published before presentation liveness checks; ID-only state collides
+  local and fleet workspaces, while layout churn must not discard the command
   (`packages/ui/src/components/workspace/WorkspaceCreateSplitButton.svelte::selectTarget`,
   `packages/ui/src/stores/workspace-create-pending.svelte.ts::queueWorkspaceLaunch`,
   `frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte::pendingWorkspaceLaunchTarget`).
+  Once claimed, the intent stays globally pending until its ownership token settles it:
+  sibling views suppress their empty fallback and may discard only unclaimed intents
+  (`packages/ui/src/stores/workspace-create-pending.svelte.ts::completeWorkspaceLaunch`).
 - Inline surface claims come only from live selection effects (the list
   views' claim effects, which react to recorded overrides); async responses
   record overrides and tombstones but never claim a surface themselves, and
@@ -114,9 +117,9 @@ Interactive surfaces must agree on which item is selected.
   surface immediately and reconcile the tombstone away — an ID-less tombstone
   would mask it forever, because the workspace-absent envelope it waits for
   never arrives once the item has a new workspace.
-- Automatic empty-pane launchers stay closed during inline workspace deletion:
-  runtime sessions disappear before the host is removed, and that teardown gap
-  is not a launchable empty workspace (`frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte::autoOpenLauncher`).
+- Automatic empty-pane launchers stay closed during inline workspace deletion
+  and explicit create-and-launch startup: teardown and pre-session gaps are not
+  launchable empty workspaces (`frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte::autoOpenLauncher`).
 - Catalog-backed routes must normalize missing selections even when the catalog
   is empty: select the first available item or `null`, and clear dependent route
   identity (`frontend/src/lib/components/docs/DocsWorkspace.svelte::loadFolders`).

--- a/frontend/src/lib/components/terminal/NewWorkspaceDialog.svelte
+++ b/frontend/src/lib/components/terminal/NewWorkspaceDialog.svelte
@@ -181,7 +181,7 @@
       }
       const workspaceId = data.id;
       if (launchTargetKey) {
-        queueWorkspaceLaunch(workspaceId, launchTargetKey);
+        queueWorkspaceLaunch(workspaceId, launchTargetKey, undefined);
       }
       // The workspace exists either way, so it stays the last-used repo; only
       // the navigation is abandoned when the user moved on.

--- a/frontend/src/lib/components/terminal/NewWorkspaceDialog.test.ts
+++ b/frontend/src/lib/components/terminal/NewWorkspaceDialog.test.ts
@@ -1,6 +1,6 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/svelte";
 import {
-  consumeWorkspaceLaunch,
+  discardWorkspaceLaunch,
   resetWorkspaceCreatePendingForTest,
 } from "@kenn-forge/ui/stores/workspace-create-pending";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
@@ -129,7 +129,7 @@ describe("NewWorkspaceDialog", () => {
     await waitFor(() => expect(repoPicker().textContent).toContain("acme/widget"));
     await fireEvent.click(screen.getByRole("button", { name: "Create workspace" }));
     await waitFor(() => expect(mockPost).toHaveBeenCalled());
-    expect(consumeWorkspaceLaunch("ws-new")).toBeNull();
+    expect(discardWorkspaceLaunch("ws-new", undefined)).toBeNull();
   });
 
   it("retains an agent choice through suggested-branch retry", async () => {
@@ -159,7 +159,7 @@ describe("NewWorkspaceDialog", () => {
     );
     await fireEvent.click(screen.getByRole("button", { name: "Create workspace" }));
     await waitFor(() => expect(mockPost).toHaveBeenCalledTimes(2));
-    expect(consumeWorkspaceLaunch("ws-second")).toBe("codex");
+    expect(discardWorkspaceLaunch("ws-second", undefined)).toBe("codex");
   });
 
   it("sends the typed branch name", async () => {
@@ -330,11 +330,11 @@ describe("NewWorkspaceDialog", () => {
 
     expect(mockNavigate).not.toHaveBeenCalled();
     expect(onCreated).not.toHaveBeenCalled();
-    expect(consumeWorkspaceLaunch("ws-stale")).toBe("codex");
+    expect(discardWorkspaceLaunch("ws-stale", undefined)).toBe("codex");
 
     await fireEvent.click(screen.getByRole("button", { name: "Create workspace" }));
     await waitFor(() => expect(onCreated).toHaveBeenCalledWith("ws-new"));
-    expect(consumeWorkspaceLaunch("ws-new")).toBeNull();
+    expect(discardWorkspaceLaunch("ws-new", undefined)).toBeNull();
   });
 
   it("keeps the form locked when a stale create resolves under a newer one", async () => {

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -130,7 +130,10 @@
   import type { KataWorkspaceMetadata } from "../../api/kata/workspaces.js";
   import { showFlash } from "@kenn-forge/ui/stores/flash";
   import {
-    consumeWorkspaceLaunch,
+    claimWorkspaceLaunch,
+    completeWorkspaceLaunch,
+    discardWorkspaceLaunch,
+    isWorkspaceCreatePending,
     pendingWorkspaceLaunchTarget,
   } from "@kenn-forge/ui/stores/workspace-create-pending";
   import { createTerminalZoomController } from "./terminalZoom";
@@ -677,6 +680,15 @@
     launcherState = { workspaceKey: viewWorkspaceKey, auto: false };
   }
 
+  function createOrLaunchPending(): boolean {
+    const identity = workspaceIdentitySnapshot(workspaceId);
+    return (
+      (identity !== undefined && isWorkspaceCreatePending(identity)) ||
+      pendingWorkspaceLaunchTarget(workspaceId, workspaceHostKey) !== null ||
+      launchingKey !== null
+    );
+  }
+
   /**
    * The view's own fallback when a pane has nothing left to render.
    *
@@ -697,6 +709,11 @@
     // Runtime teardown can reach any of the automatic fallback paths before the
     // deleted inline host is removed. It is not an empty workspace to relaunch.
     if (deletingSelectedWorkspace || forceDeleting) return;
+    // A split-button selection already chose what to launch. Creation can publish
+    // the ready workspace before its POST response hands the choice to the
+    // workspace-ID launch queue, and the runtime stays empty until that launch
+    // produces its first session.
+    if (createOrLaunchPending()) return;
     if (launcherAutoOpenedFor.includes(viewWorkspaceKey)) return;
     launcherAutoOpenedFor = [...launcherAutoOpenedFor, viewWorkspaceKey];
     launcherState = { workspaceKey: viewWorkspaceKey, auto: true };
@@ -773,6 +790,7 @@
     const openState = launcherState;
     const autoOpened = launcherAutoOpenedFor.includes(workspaceKey);
     const deletionPending = deletingSelectedWorkspace || forceDeleting;
+    const createOrLaunchIsPending = createOrLaunchPending();
     untrack(() => {
       if (tabs.length > 0 && activeMissing) selectWorkspaceTab(tabs[0]!.key);
       // A docked terminal is not a workflow tab but is very much on screen, so an
@@ -787,7 +805,7 @@
       }
       // Deletion tears down the runtime before the inline host disappears. That
       // sessionless gap is not an empty workspace asking what to launch next.
-      if (deletionPending) return;
+      if (deletionPending || createOrLaunchIsPending) return;
       // Once per workspace: reopening a launcher the user dismissed would trap them
       // in it, while a different session-less workspace still gets one.
       if (openState?.workspaceKey === workspaceKey || autoOpened) return;
@@ -3548,17 +3566,17 @@
   $effect(() => {
     if (!workspaceId || !runtimeLive || workspace?.status !== "ready") return;
     if (actionsBlocked || launchingKey !== null) return;
-    const targetKey = pendingWorkspaceLaunchTarget(workspaceId);
+    const targetKey = pendingWorkspaceLaunchTarget(workspaceId, workspaceHostKey);
     if (targetKey === null) return;
     if (runtimeSessions.length > 0) {
-      consumeWorkspaceLaunch(workspaceId);
+      discardWorkspaceLaunch(workspaceId, workspaceHostKey);
       return;
     }
     const target = launchTargets.find(
       (candidate) => candidate.key === targetKey,
     );
     if (!target || target.kind !== "agent" || !target.available) {
-      consumeWorkspaceLaunch(workspaceId);
+      if (discardWorkspaceLaunch(workspaceId, workspaceHostKey) === null) return;
       const reason =
         target?.disabled_reason ?? "is not available in this workspace";
       showFlash(`Agent "${targetKey}" could not launch: ${reason}`, {
@@ -3566,8 +3584,9 @@
       });
       return;
     }
-    if (consumeWorkspaceLaunch(workspaceId) === null) return;
-    void handleLaunch(targetKey);
+    const claim = claimWorkspaceLaunch(workspaceId, workspaceHostKey);
+    if (claim === null) return;
+    void handleLaunch(claim.targetKey).finally(() => completeWorkspaceLaunch(claim));
   });
 </script>
 

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -9,7 +9,8 @@ import {
   startTabbedPanelTabDrag,
 } from "@kenn-forge/ui";
 import {
-  consumeWorkspaceLaunch,
+  discardWorkspaceLaunch,
+  pendingWorkspaceLaunchTarget,
   queueWorkspaceLaunch,
   resetWorkspaceCreatePendingForTest,
 } from "@kenn-forge/ui/stores/workspace-create-pending";
@@ -2577,7 +2578,7 @@ describe("WorkspaceTerminalView", () => {
     await waitFor(() => expect(window.location.pathname).toBe("/workspaces"));
   });
   it("launches an explicitly queued target without a confirmation modal", async () => {
-    queueWorkspaceLaunch("ws-1", "codex");
+    queueWorkspaceLaunch("ws-1", "codex", undefined);
     mocks.getWorkspaceRuntime
       .mockResolvedValueOnce(runtimeWithCodexTarget())
       .mockResolvedValue(runtimeWithCodexTarget(true, [runningSession]));
@@ -2598,13 +2599,85 @@ describe("WorkspaceTerminalView", () => {
     ).toBeNull();
   });
 
+  it("keeps the empty-workspace launcher closed while an explicit launch starts", async () => {
+    const launchRequest = deferred<typeof runningSession>();
+    queueWorkspaceLaunch("ws-1", "codex", undefined);
+    mocks.getWorkspaceRuntime.mockResolvedValue(runtimeWithCodexTarget());
+    mocks.launchWorkspaceSession.mockReturnValue(launchRequest.promise);
+    claimForPrs();
+
+    render(WorkspaceTerminalView, {
+      props: { workspaceId: "ws-1", paneSurface: "prs" as const },
+    });
+
+    await waitFor(() => expect(mocks.launchWorkspaceSession).toHaveBeenCalledTimes(1));
+    expect(screen.queryByRole("dialog", { name: "Launch a session" })).toBeNull();
+  });
+
+  it("does not apply a local launch intent to a same-ID fleet workspace", async () => {
+    queueWorkspaceLaunch("ws-1", "codex", undefined);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((input: Request | URL | string) => {
+        const path = fetchPath(input);
+        if (path.endsWith("/fleet/hosts/member/workspaces/ws-1")) {
+          return Promise.resolve(Response.json({ ...workspaceResponse, fleet_host_key: "member" }));
+        }
+        if (path.endsWith("/api/v1/workspaces")) {
+          return Promise.resolve(Response.json({ workspaces: [] }));
+        }
+        return Promise.resolve(Response.json({}));
+      }),
+    );
+    mocks.getWorkspaceRuntime.mockResolvedValue(runtimeWithCodexTarget());
+
+    render(WorkspaceTerminalView, {
+      props: { workspaceId: "ws-1", workspaceHostKey: "member", paneSurface: "prs" as const },
+    });
+
+    expect(await screen.findByRole("dialog", { name: "Launch a session" })).toBeTruthy();
+    expect(mocks.launchWorkspaceSession).not.toHaveBeenCalled();
+    expect(pendingWorkspaceLaunchTarget("ws-1", undefined)).toBe("codex");
+  });
+
+  it("settles only the claimed workspace intent after navigating during launch", async () => {
+    const launchRequest = deferred<typeof runningSession>();
+    const workspaceB = { ...workspaceResponse, id: "ws-2", status: "provisioning" };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((input: Request | URL | string) => {
+        const path = fetchPath(input);
+        if (path.endsWith("/workspaces/ws-1")) return Promise.resolve(Response.json(workspaceResponse));
+        if (path.endsWith("/workspaces/ws-2")) return Promise.resolve(Response.json(workspaceB));
+        if (path.endsWith("/api/v1/workspaces")) {
+          return Promise.resolve(Response.json({ workspaces: [workspaceResponse, workspaceB] }));
+        }
+        return Promise.resolve(Response.json({}));
+      }),
+    );
+    queueWorkspaceLaunch("ws-1", "codex", undefined);
+    mocks.getWorkspaceRuntime.mockResolvedValue(runtimeWithCodexTarget());
+    mocks.launchWorkspaceSession.mockReturnValue(launchRequest.promise);
+
+    const view = render(WorkspaceTerminalView, { props: { workspaceId: "ws-1" } });
+    await waitFor(() => expect(mocks.launchWorkspaceSession).toHaveBeenCalledWith("ws-1", "codex", expect.anything()));
+
+    await view.rerender({ workspaceId: "ws-2" });
+    await screen.findByText("Setting up workspace...");
+    queueWorkspaceLaunch("ws-2", "codex", undefined);
+    launchRequest.resolve(runningSession);
+
+    await waitFor(() => expect(pendingWorkspaceLaunchTarget("ws-1", undefined)).toBeNull());
+    expect(pendingWorkspaceLaunchTarget("ws-2", undefined)).toBe("codex");
+  });
+
   it("reacts when intent is queued after an already-ready workspace renders", async () => {
     mocks.getWorkspaceRuntime.mockResolvedValue(runtimeWithCodexTarget());
     mocks.launchWorkspaceSession.mockResolvedValue(runningSession);
     render(WorkspaceTerminalView, { props: { workspaceId: "ws-1" } });
     await screen.findByRole("tab", { name: "Home" });
 
-    queueWorkspaceLaunch("ws-1", "codex");
+    queueWorkspaceLaunch("ws-1", "codex", undefined);
 
     await waitFor(() => {
       expect(mocks.launchWorkspaceSession).toHaveBeenCalledTimes(1);
@@ -2612,7 +2685,7 @@ describe("WorkspaceTerminalView", () => {
   });
 
   it("allows an explicit fork-workspace launch", async () => {
-    queueWorkspaceLaunch("ws-1", "codex");
+    queueWorkspaceLaunch("ws-1", "codex", undefined);
     mocks.getWorkspaceRuntime.mockResolvedValue(runtimeWithCodexTarget());
     mocks.launchWorkspaceSession.mockResolvedValue(runningSession);
     const forkWorkspaceResponse = { ...workspaceResponse, mr_head_repo_kind: "fork" };
@@ -2669,7 +2742,7 @@ describe("WorkspaceTerminalView", () => {
   });
 
   it("consumes unavailable explicit intent and flashes its reason", async () => {
-    queueWorkspaceLaunch("ws-1", "codex");
+    queueWorkspaceLaunch("ws-1", "codex", undefined);
     mocks.getWorkspaceRuntime.mockResolvedValue(runtimeWithCodexTarget(false));
     render(WorkspaceTerminalView, { props: { workspaceId: "ws-1" } });
     await screen.findByRole("tab", { name: "Home" });
@@ -2677,11 +2750,11 @@ describe("WorkspaceTerminalView", () => {
     expect(mocks.showFlash).toHaveBeenCalledWith(expect.stringContaining("Codex is not configured"), {
       tone: "danger",
     });
-    expect(consumeWorkspaceLaunch("ws-1")).toBeNull();
+    expect(discardWorkspaceLaunch("ws-1", undefined)).toBeNull();
   });
 
   it("consumes missing explicit intent and flashes a generic reason", async () => {
-    queueWorkspaceLaunch("ws-1", "missing");
+    queueWorkspaceLaunch("ws-1", "missing", undefined);
     mocks.getWorkspaceRuntime.mockResolvedValue({ launch_targets: [], sessions: [] });
     render(WorkspaceTerminalView, { props: { workspaceId: "ws-1" } });
     await screen.findByRole("tab", { name: "Home" });
@@ -2689,17 +2762,17 @@ describe("WorkspaceTerminalView", () => {
     expect(mocks.showFlash).toHaveBeenCalledWith(expect.stringContaining("is not available in this workspace"), {
       tone: "danger",
     });
-    expect(consumeWorkspaceLaunch("ws-1")).toBeNull();
+    expect(discardWorkspaceLaunch("ws-1", undefined)).toBeNull();
   });
 
   it("consumes explicit intent without launching when a session exists", async () => {
-    queueWorkspaceLaunch("ws-1", "codex");
+    queueWorkspaceLaunch("ws-1", "codex", undefined);
     mocks.getWorkspaceRuntime.mockResolvedValue(runtimeWithCodexTarget(true, [runningSession]));
     render(WorkspaceTerminalView, { props: { workspaceId: "ws-1" } });
     await screen.findByRole("tab", { name: /Helper/ });
     expect(mocks.launchWorkspaceSession).not.toHaveBeenCalled();
     expect(mocks.showFlash).not.toHaveBeenCalled();
-    expect(consumeWorkspaceLaunch("ws-1")).toBeNull();
+    expect(discardWorkspaceLaunch("ws-1", undefined)).toBeNull();
   });
 
   it("publishes the session the pane is showing, so a keyboard command can promote it", async () => {

--- a/frontend/src/lib/features/kata/KataWorkspace.svelte
+++ b/frontend/src/lib/features/kata/KataWorkspace.svelte
@@ -1621,7 +1621,7 @@
         ),
       );
       if (launchTargetKey) {
-        queueWorkspaceLaunch(created.id, launchTargetKey);
+        queueWorkspaceLaunch(created.id, launchTargetKey, undefined);
       }
       openWorkspace(created.id);
     } catch (err) {

--- a/frontend/src/lib/features/kata/KataWorkspace.test.ts
+++ b/frontend/src/lib/features/kata/KataWorkspace.test.ts
@@ -3,7 +3,7 @@ import { tick } from "svelte";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import {
-  consumeWorkspaceLaunch,
+  discardWorkspaceLaunch,
   resetWorkspaceCreatePendingForTest,
 } from "@kenn-forge/ui/stores/workspace-create-pending";
 import type { KataTaskLink } from "../../api/kata/taskTypes.js";
@@ -206,7 +206,7 @@ describe("KataWorkspace snapshot authority", () => {
     await fireEvent.click(screen.getByRole("menuitem", { name: "Codex" }));
 
     await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/terminal/workspace-1"));
-    expect(consumeWorkspaceLaunch("workspace-1")).toBe("codex");
+    expect(discardWorkspaceLaunch("workspace-1", undefined)).toBe("codex");
   });
 
   it("does not queue a launch for the standard create action", async () => {
@@ -241,7 +241,7 @@ describe("KataWorkspace snapshot authority", () => {
     await fireEvent.click(await screen.findByRole("button", { name: "Create workspace" }));
 
     await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/terminal/workspace-existing"));
-    expect(consumeWorkspaceLaunch("workspace-existing")).toBeNull();
+    expect(discardWorkspaceLaunch("workspace-existing", undefined)).toBeNull();
   });
 
   it("renders canonical catalog identity when selected detail protocol omits summary-only fields", async () => {

--- a/frontend/tests/e2e-full/00-workspace-create-and-launch.spec.ts
+++ b/frontend/tests/e2e-full/00-workspace-create-and-launch.spec.ts
@@ -25,6 +25,26 @@ const workspaceTestTimeoutMs = 120_000;
 const agentKey = "e2e-agent";
 const agentLabel = "E2E Agent";
 
+type LaunchDialogProbe = {
+  phase?: string;
+  firstAppearancePhase?: string | null;
+};
+
+async function launchDialogFirstAppearance(page: Page): Promise<string | null> {
+  return page.evaluate(
+    () =>
+      (Reflect.get(window, "__middlemanCreateLaunchDialogProbe") as LaunchDialogProbe | undefined)
+        ?.firstAppearancePhase ?? null,
+  );
+}
+
+async function setLaunchDialogProbePhase(page: Page, phase: string): Promise<void> {
+  await page.evaluate((nextPhase) => {
+    const probe = Reflect.get(window, "__middlemanCreateLaunchDialogProbe") as LaunchDialogProbe | undefined;
+    if (probe) probe.phase = nextPhase;
+  }, phase);
+}
+
 function hasCommand(command: string, args: string[] = ["--version"]): boolean {
   try {
     execFileSync(command, args, { stdio: "ignore" });
@@ -162,7 +182,7 @@ test.describe("workspace create-and-launch full stack", () => {
     }
   });
 
-  test("explicit PR agent selection launches and persists without a dialog in the narrow drawer", async ({ page }) => {
+  test("explicit PR agent selection never opens a transient dialog and fits the narrow drawer", async ({ page }) => {
     test.skip(
       !hasCommand("git") || !hasCommand("tmux", ["-V"]) || !hasCommand("sh", ["-c", ":"]),
       "git, tmux, and sh are required for the real workspace runtime flow",
@@ -170,12 +190,50 @@ test.describe("workspace create-and-launch full stack", () => {
 
     let server: IsolatedE2EServer | null = null;
     let api: APIRequestContext | null = null;
+    const createResponseGate: { release: (() => void) | null } = { release: null };
+    const launchResponseGate: { release: (() => void) | null } = { release: null };
     try {
       server = await startIsolatedWorkspaceE2EServer();
       api = await playwrightRequest.newContext({
         baseURL: server.info.base_url,
       });
       await configureAgent(page, server.info.base_url);
+
+      const createResponseRelease = new Promise<void>((resolve) => {
+        createResponseGate.release = resolve;
+      });
+      let markCreateResponseHeld!: () => void;
+      const createResponseHeld = new Promise<void>((resolve) => {
+        markCreateResponseHeld = resolve;
+      });
+      await page.route("**/api/v1/workspaces", async (route) => {
+        if (route.request().method() !== "POST") {
+          await route.continue();
+          return;
+        }
+        const response = await route.fetch();
+        markCreateResponseHeld();
+        await createResponseRelease;
+        await route.fulfill({ response });
+      });
+
+      const launchResponseRelease = new Promise<void>((resolve) => {
+        launchResponseGate.release = resolve;
+      });
+      let markLaunchRequestHeld!: () => void;
+      const launchRequestHeld = new Promise<void>((resolve) => {
+        markLaunchRequestHeld = resolve;
+      });
+      await page.route("**/api/v1/workspaces/*/runtime/sessions", async (route) => {
+        if (route.request().method() !== "POST") {
+          await route.continue();
+          return;
+        }
+        markLaunchRequestHeld();
+        await launchResponseRelease;
+        const response = await route.fetch();
+        await route.fulfill({ response });
+      });
 
       const launchResponsePromise = page.waitForResponse(
         (response) =>
@@ -198,6 +256,31 @@ test.describe("workspace create-and-launch full stack", () => {
       await expect(create.locator("..")).toHaveCSS("max-width", "100%");
       await expect(create.locator("span")).toHaveCSS("text-overflow", "ellipsis");
       await expect(options).toHaveCSS("flex-shrink", "0");
+      await page.setViewportSize({ width: 1280, height: 800 });
+      await page.reload();
+      await expect(page.locator(".pull-detail")).toBeVisible();
+
+      // An end-state absence assertion can miss a dialog that mounts for one
+      // render and closes when either startup response arrives. Record every
+      // added launcher node so the transient startup state remains observable.
+      await page.evaluate(() => {
+        const selector = '[role="dialog"][aria-label="Launch a session"]';
+        const initiallyPresent = document.querySelector(selector) !== null;
+        const state = {
+          phase: "create-pending",
+          firstAppearancePhase: initiallyPresent ? "initial" : null,
+        };
+        Reflect.set(window, "__middlemanCreateLaunchDialogProbe", state);
+        new MutationObserver((records) => {
+          for (const record of records) {
+            for (const node of record.addedNodes) {
+              if (node instanceof Element && (node.matches(selector) || node.querySelector(selector) !== null)) {
+                state.firstAppearancePhase ??= state.phase;
+              }
+            }
+          }
+        }).observe(document.body, { childList: true, subtree: true });
+      });
 
       const createResponsePromise = page.waitForResponse(
         (response) => response.request().method() === "POST" && response.url().endsWith("/api/v1/workspaces"),
@@ -205,12 +288,44 @@ test.describe("workspace create-and-launch full stack", () => {
       await options.click();
       await expect(page.getByRole("menuitem", { name: agentLabel })).toBeVisible();
       await page.getByRole("menuitem", { name: agentLabel }).click();
+
+      await createResponseHeld;
+      await expect(page.locator(".detail-pane-workspace-slot")).toBeVisible();
+      await expect(page.getByRole("button", { name: "Launch session" })).toBeVisible();
+      await page.evaluate(
+        () =>
+          new Promise<void>((resolve) => {
+            requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+          }),
+      );
+      const launcherAppearedBeforeCreateResponse = await launchDialogFirstAppearance(page);
+      expect(launcherAppearedBeforeCreateResponse).toBeNull();
+      await setLaunchDialogProbePhase(page, "create-response-released");
+      createResponseGate.release?.();
+      createResponseGate.release = null;
+
       const createResponse = await createResponsePromise;
       expect(createResponse.status(), await createResponse.text()).toBe(202);
       const created = (await createResponse.json()) as WorkspaceResponse;
       expect(created.created).toBe(true);
       expect(created.mr_head_repo_kind).toBe("same_repo");
       await waitForWorkspaceReady(api, created.id);
+      await expect(page.locator(".detail-pane-workspace-slot")).toBeVisible();
+      await expect(page.getByRole("button", { name: "Launch session" })).toBeVisible();
+
+      await launchRequestHeld;
+      await setLaunchDialogProbePhase(page, "launch-request-held");
+      await page.evaluate(
+        () =>
+          new Promise<void>((resolve) => {
+            requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+          }),
+      );
+      const launcherAppearedWhilePending = await launchDialogFirstAppearance(page);
+      expect(launcherAppearedWhilePending).toBeNull();
+      await setLaunchDialogProbePhase(page, "launch-response-released");
+      launchResponseGate.release?.();
+      launchResponseGate.release = null;
 
       const launchResponse = await launchResponsePromise;
       expect(launchResponse.status(), await launchResponse.text()).toBe(200);
@@ -220,7 +335,12 @@ test.describe("workspace create-and-launch full stack", () => {
       await expect
         .poll(() => page.evaluate(() => document.activeElement?.closest(".terminal-container") !== null))
         .toBe(true);
+      const launcherEverAppeared = await launchDialogFirstAppearance(page);
+      expect(launcherEverAppeared).toBeNull();
     } finally {
+      createResponseGate.release?.();
+      launchResponseGate.release?.();
+      await page.unrouteAll({ behavior: "ignoreErrors" });
       await api?.dispose();
       await server?.stop();
     }

--- a/packages/ui/src/components/detail/IssueDetail.svelte
+++ b/packages/ui/src/components/detail/IssueDetail.svelte
@@ -801,7 +801,7 @@
         };
         recordWorkspaceCreated(requestIdentity, createdRef);
         if (launchTargetKey) {
-          queueWorkspaceLaunch(createdRef.id, launchTargetKey);
+          queueWorkspaceLaunch(createdRef.id, launchTargetKey, undefined);
         }
         inlineWorkspace?.recordCreated(requestIdentity, createdRef);
       }

--- a/packages/ui/src/components/detail/IssueDetail.test.ts
+++ b/packages/ui/src/components/detail/IssueDetail.test.ts
@@ -5,7 +5,7 @@ import { ACTIONS_KEY, API_CLIENT_KEY, NAVIGATE_KEY, STORES_KEY, UI_CONFIG_KEY } 
 import { createDetailActivityViewStore } from "../../stores/detail-activity-view.svelte.js";
 import { dismissFlash, getFlashes } from "../../stores/flash.svelte.js";
 import {
-  consumeWorkspaceLaunch,
+  discardWorkspaceLaunch,
   markWorkspaceIdDeleted,
   nextWorkspaceLifecycleTick,
   recordWorkspaceCreated,
@@ -560,7 +560,7 @@ describe("IssueDetail inline workspace handoff", () => {
     resolvePost({ data: { id: "ws-new", status: "creating", created: true } });
 
     await waitFor(() => expect(controller.recordCreated).toHaveBeenCalled());
-    expect(consumeWorkspaceLaunch("ws-new")).toBeNull();
+    expect(discardWorkspaceLaunch("ws-new", undefined)).toBeNull();
   });
 
   it("queues the agent selected from Create Workspace options", async () => {
@@ -578,7 +578,7 @@ describe("IssueDetail inline workspace handoff", () => {
     resolvePost({ data: { id: "ws-new", status: "creating" } });
 
     await waitFor(() => expect(controller.recordCreated).toHaveBeenCalled());
-    expect(consumeWorkspaceLaunch("ws-new")).toBe("codex");
+    expect(discardWorkspaceLaunch("ws-new", undefined)).toBe("codex");
   });
 
   it("retains the selected agent when reusing an existing branch", async () => {
@@ -605,7 +605,7 @@ describe("IssueDetail inline workspace handoff", () => {
     );
     await waitFor(() => expect(apiClient.POST).toHaveBeenCalledTimes(2));
     await waitFor(() => expect(controller.recordCreated).toHaveBeenCalled());
-    expect(consumeWorkspaceLaunch("ws-existing")).toBe("codex");
+    expect(discardWorkspaceLaunch("ws-existing", undefined)).toBe("codex");
   });
 
   it("publishes a confirmed creation even after the selection changed", async () => {

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -1466,7 +1466,7 @@
         };
         recordWorkspaceCreated(requestIdentity, createdRef);
         if (launchTargetKey) {
-          queueWorkspaceLaunch(createdRef.id, launchTargetKey);
+          queueWorkspaceLaunch(createdRef.id, launchTargetKey, undefined);
         }
         inlineWorkspace?.recordCreated(requestIdentity, createdRef);
       }

--- a/packages/ui/src/components/detail/PullDetail.test.ts
+++ b/packages/ui/src/components/detail/PullDetail.test.ts
@@ -6,7 +6,7 @@ import { createDetailActivityViewStore } from "../../stores/detail-activity-view
 import { createDetailStore } from "../../stores/detail.svelte.js";
 import { dismissFlash, getFlashes } from "../../stores/flash.svelte.js";
 import {
-  consumeWorkspaceLaunch,
+  discardWorkspaceLaunch,
   markWorkspaceIdDeleted,
   nextWorkspaceLifecycleTick,
   recordWorkspaceCreated,
@@ -1580,7 +1580,7 @@ describe("PullDetail inline workspace handoff", () => {
     resolvePost({ data: { id: "ws-new", status: "creating", created: true } });
 
     await waitFor(() => expect(navigate).toHaveBeenCalledWith("/terminal/ws-new"));
-    expect(consumeWorkspaceLaunch("ws-new")).toBeNull();
+    expect(discardWorkspaceLaunch("ws-new", undefined)).toBeNull();
   });
 
   it("queues the agent selected from Create Workspace options", async () => {
@@ -1599,7 +1599,7 @@ describe("PullDetail inline workspace handoff", () => {
     resolvePost({ data: { id: "ws-new", status: "creating" } });
 
     await waitFor(() => expect(navigate).toHaveBeenCalledWith("/terminal/ws-new"));
-    expect(consumeWorkspaceLaunch("ws-new")).toBe("codex");
+    expect(discardWorkspaceLaunch("ws-new", undefined)).toBe("codex");
   });
 
   it("publishes a confirmed creation even after the selection changed", async () => {

--- a/packages/ui/src/components/diff/DiffFile.test.ts
+++ b/packages/ui/src/components/diff/DiffFile.test.ts
@@ -1933,6 +1933,12 @@ describe("DiffFile", () => {
   it("renders unmatched review threads at the file header", () => {
     renderDiffFile(
       makeFile({
+        patch: `diff --git a/src/foo.ts b/src/foo.ts
+--- a/src/foo.ts
++++ b/src/foo.ts
+@@ -60,1 +60,1 @@
+ visible context
+`,
         hunks: [
           {
             old_start: 60,

--- a/packages/ui/src/stores/workspace-create-pending.svelte.ts
+++ b/packages/ui/src/stores/workspace-create-pending.svelte.ts
@@ -39,8 +39,17 @@ let deletedIds = $state<ReadonlySet<string>>(new Set());
 
 type PendingWorkspaceLaunch = {
   workspaceId: string;
+  workspaceHostKey: string | undefined;
   targetKey: string;
+  claimToken: symbol | null;
 };
+
+export type WorkspaceLaunchClaim = Readonly<{
+  workspaceId: string;
+  workspaceHostKey: string | undefined;
+  targetKey: string;
+  token: symbol;
+}>;
 
 let pendingWorkspaceLaunches = $state<PendingWorkspaceLaunch[]>([]);
 
@@ -55,24 +64,74 @@ export function isWorkspaceIdDeleted(workspaceId: string): boolean {
   return deletedIds.has(workspaceId);
 }
 
-export function queueWorkspaceLaunch(workspaceId: string, targetKey: string): void {
+function workspaceLaunchMatches(
+  entry: PendingWorkspaceLaunch,
+  workspaceId: string,
+  workspaceHostKey: string | undefined,
+): boolean {
+  return entry.workspaceId === workspaceId && entry.workspaceHostKey === workspaceHostKey;
+}
+
+export function queueWorkspaceLaunch(
+  workspaceId: string,
+  targetKey: string,
+  workspaceHostKey: string | undefined,
+): void {
   const normalized = targetKey.trim();
   if (!workspaceId || !normalized) return;
   pendingWorkspaceLaunches = [
-    ...pendingWorkspaceLaunches.filter((entry) => entry.workspaceId !== workspaceId),
-    { workspaceId, targetKey: normalized },
+    ...pendingWorkspaceLaunches.filter((entry) => !workspaceLaunchMatches(entry, workspaceId, workspaceHostKey)),
+    { workspaceId, workspaceHostKey, targetKey: normalized, claimToken: null },
   ];
 }
 
-export function pendingWorkspaceLaunchTarget(workspaceId: string): string | null {
-  return pendingWorkspaceLaunches.find((entry) => entry.workspaceId === workspaceId)?.targetKey ?? null;
+export function pendingWorkspaceLaunchTarget(workspaceId: string, workspaceHostKey: string | undefined): string | null {
+  return (
+    pendingWorkspaceLaunches.find((entry) => workspaceLaunchMatches(entry, workspaceId, workspaceHostKey))?.targetKey ??
+    null
+  );
 }
 
-export function consumeWorkspaceLaunch(workspaceId: string): string | null {
-  const targetKey = pendingWorkspaceLaunchTarget(workspaceId);
-  if (targetKey === null) return null;
-  pendingWorkspaceLaunches = pendingWorkspaceLaunches.filter((entry) => entry.workspaceId !== workspaceId);
-  return targetKey;
+export function claimWorkspaceLaunch(
+  workspaceId: string,
+  workspaceHostKey: string | undefined,
+): WorkspaceLaunchClaim | null {
+  const entry = pendingWorkspaceLaunches.find((candidate) =>
+    workspaceLaunchMatches(candidate, workspaceId, workspaceHostKey),
+  );
+  if (!entry || entry.claimToken !== null) return null;
+  // Keep the entry visible while one view owns the request. A second live view
+  // for the same workspace must suppress its empty-state launcher without
+  // starting a duplicate session.
+  const token = Symbol("workspace-launch-claim");
+  pendingWorkspaceLaunches = pendingWorkspaceLaunches.map((candidate) =>
+    workspaceLaunchMatches(candidate, workspaceId, workspaceHostKey) ? { ...candidate, claimToken: token } : candidate,
+  );
+  return { workspaceId, workspaceHostKey, targetKey: entry.targetKey, token };
+}
+
+export function discardWorkspaceLaunch(workspaceId: string, workspaceHostKey: string | undefined): string | null {
+  const entry = pendingWorkspaceLaunches.find((candidate) =>
+    workspaceLaunchMatches(candidate, workspaceId, workspaceHostKey),
+  );
+  if (!entry || entry.claimToken !== null) return null;
+  pendingWorkspaceLaunches = pendingWorkspaceLaunches.filter(
+    (entry) => !workspaceLaunchMatches(entry, workspaceId, workspaceHostKey),
+  );
+  return entry.targetKey;
+}
+
+export function completeWorkspaceLaunch(claim: WorkspaceLaunchClaim): boolean {
+  const owned = pendingWorkspaceLaunches.some(
+    (entry) =>
+      workspaceLaunchMatches(entry, claim.workspaceId, claim.workspaceHostKey) && entry.claimToken === claim.token,
+  );
+  if (!owned) return false;
+  pendingWorkspaceLaunches = pendingWorkspaceLaunches.filter(
+    (entry) =>
+      !workspaceLaunchMatches(entry, claim.workspaceId, claim.workspaceHostKey) || entry.claimToken !== claim.token,
+  );
+  return true;
 }
 
 export function beginWorkspaceCreate(identity: WorkspaceItemIdentity): void {

--- a/packages/ui/src/stores/workspace-create-pending.test.ts
+++ b/packages/ui/src/stores/workspace-create-pending.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import {
+  claimWorkspaceLaunch,
+  completeWorkspaceLaunch,
+  discardWorkspaceLaunch,
   queueWorkspaceLaunch,
   pendingWorkspaceLaunchTarget,
-  consumeWorkspaceLaunch,
   resetWorkspaceCreatePendingForTest,
 } from "./workspace-create-pending.svelte.js";
 
@@ -11,25 +13,60 @@ describe("workspace-create-pending launch intent", () => {
     resetWorkspaceCreatePendingForTest();
   });
 
-  it("queues and consumes a target key exactly once per workspace", () => {
-    queueWorkspaceLaunch("ws-1", "codex");
-    queueWorkspaceLaunch("ws-2", "claude");
+  it("queues and discards an unclaimed target key exactly once per workspace", () => {
+    queueWorkspaceLaunch("ws-1", "codex", undefined);
+    queueWorkspaceLaunch("ws-2", "claude", undefined);
 
-    expect(pendingWorkspaceLaunchTarget("ws-1")).toBe("codex");
-    expect(consumeWorkspaceLaunch("ws-1")).toBe("codex");
-    expect(consumeWorkspaceLaunch("ws-1")).toBeNull();
-    expect(pendingWorkspaceLaunchTarget("ws-2")).toBe("claude");
+    expect(pendingWorkspaceLaunchTarget("ws-1", undefined)).toBe("codex");
+    expect(discardWorkspaceLaunch("ws-1", undefined)).toBe("codex");
+    expect(discardWorkspaceLaunch("ws-1", undefined)).toBeNull();
+    expect(pendingWorkspaceLaunchTarget("ws-2", undefined)).toBe("claude");
   });
 
   it("replaces an earlier target when the user makes a newer explicit choice", () => {
-    queueWorkspaceLaunch("ws-1", "codex");
-    queueWorkspaceLaunch("ws-1", "claude");
-    expect(consumeWorkspaceLaunch("ws-1")).toBe("claude");
+    queueWorkspaceLaunch("ws-1", "codex", undefined);
+    queueWorkspaceLaunch("ws-1", "claude", undefined);
+    expect(discardWorkspaceLaunch("ws-1", undefined)).toBe("claude");
+  });
+
+  it("keeps launch intents independent across hosts sharing a workspace ID", () => {
+    queueWorkspaceLaunch("ws-1", "codex", undefined);
+    queueWorkspaceLaunch("ws-1", "claude", "member");
+
+    expect(pendingWorkspaceLaunchTarget("ws-1", undefined)).toBe("codex");
+    expect(pendingWorkspaceLaunchTarget("ws-1", "member")).toBe("claude");
+    expect(discardWorkspaceLaunch("ws-1", undefined)).toBe("codex");
+    expect(pendingWorkspaceLaunchTarget("ws-1", "member")).toBe("claude");
+  });
+
+  it("keeps a claimed target pending while preventing a second launcher from claiming it", () => {
+    queueWorkspaceLaunch("ws-1", "codex", undefined);
+
+    const claim = claimWorkspaceLaunch("ws-1", undefined);
+    expect(claim).toMatchObject({ workspaceId: "ws-1", targetKey: "codex" });
+    expect(pendingWorkspaceLaunchTarget("ws-1", undefined)).toBe("codex");
+    expect(claimWorkspaceLaunch("ws-1", undefined)).toBeNull();
+    expect(discardWorkspaceLaunch("ws-1", undefined)).toBeNull();
+    expect(pendingWorkspaceLaunchTarget("ws-1", undefined)).toBe("codex");
+    expect(completeWorkspaceLaunch(claim!)).toBe(true);
+    expect(pendingWorkspaceLaunchTarget("ws-1", undefined)).toBeNull();
+    expect(completeWorkspaceLaunch(claim!)).toBe(false);
+  });
+
+  it("does not let an old claim complete a newer intent for the same workspace", () => {
+    queueWorkspaceLaunch("ws-1", "codex", undefined);
+    const claim = claimWorkspaceLaunch("ws-1", undefined);
+    expect(claim).not.toBeNull();
+
+    queueWorkspaceLaunch("ws-1", "claude", undefined);
+
+    expect(completeWorkspaceLaunch(claim!)).toBe(false);
+    expect(pendingWorkspaceLaunchTarget("ws-1", undefined)).toBe("claude");
   });
 
   it("clears explicit launch intent in the shared test reset", () => {
-    queueWorkspaceLaunch("ws-1", "codex");
+    queueWorkspaceLaunch("ws-1", "codex", undefined);
     resetWorkspaceCreatePendingForTest();
-    expect(pendingWorkspaceLaunchTarget("ws-1")).toBeNull();
+    expect(pendingWorkspaceLaunchTarget("ws-1", undefined)).toBeNull();
   });
 });


### PR DESCRIPTION
Selecting an agent from the **Create Workspace** split menu is already a complete launch decision. During startup, a newly ready workspace can temporarily report zero runtime sessions; the empty-pane fallback treated that transient state as genuinely empty and briefly displayed **Launch a session**, suggesting that a second choice was required.

This keeps the automatic fallback suppressed while the explicit intent is queued or its agent launch is in flight. If launch fails and the workspace remains empty, the normal launcher becomes available again. Regression coverage holds the launch request open to protect this transient state, and the UI interaction context now records the broader invariant.