### PR TITLE
Prevent stale terminal writes from replacing PR copies

### DIFF
--- a/context/workspace-runtime-lifecycle.md
+++ b/context/workspace-runtime-lifecycle.md
@@ -110,9 +110,9 @@ stale tabs.
 - Keep OSC 52 validation synchronous and ahead of gesture consumption; replacing it with `@xterm/addon-clipboard`
   would require custom prefilters, nonblocking write separation, and handler-order coupling to preserve current
   rejection, parser-progress, and read-denial guarantees.
-- Pointer clipboard authority and keyboard authority created during it must remain timed and revocable through release
-  grace on capture, focus, or visibility loss; a watchdog bounds missing releases
-  (`frontend/src/lib/components/terminal/terminalClipboardWriter.ts::createTerminalClipboardWriter`).
+- Terminal keyboard clipboard authority is revoked when focus leaves the terminal; captured pointer drags retain authority
+  through release grace, while window focus or visibility loss revokes both and a watchdog bounds missing releases
+  (`frontend/src/lib/components/terminal/XtermTerminalPane.svelte::handleTerminalFocusOut`).
 - Host clipboard writes require a local browser; trusted loopback proxies must report exactly one client IP assigned
   to the host, because the proxy's loopback `RemoteAddr` alone does not establish browser locality
   (`internal/server/terminal_clipboard_access.go::isLocalTerminalClipboardRequest`).

--- a/context/workspace-runtime-lifecycle.md
+++ b/context/workspace-runtime-lifecycle.md
@@ -110,11 +110,11 @@ stale tabs.
 - Keep OSC 52 validation synchronous and ahead of gesture consumption; replacing it with `@xterm/addon-clipboard`
   would require custom prefilters, nonblocking write separation, and handler-order coupling to preserve current
   rejection, parser-progress, and read-denial guarantees.
-- Terminal clipboard authority is revoked on focus loss, pane inactivity/parking, disablement, or window focus/visibility
-  loss; revocation also stops in-flight browser-to-loopback fallback chains before their next stage
+- Terminal clipboard authority is revoked on concrete external focus transfer, pane inactivity/parking, disablement, or
+  window focus/visibility loss; revocation also stops in-flight browser-to-loopback fallback chains before their next stage
   (`frontend/src/lib/components/terminal/terminalClipboardWriter.ts::createTerminalClipboardWriter`).
-- Captured pointer drags retain authority only while the pane stays active; their watchdog also releases browser capture,
-  so a missing release cannot shield later focus loss
+- Captured pointer drags retain authority only through internal or destinationless focus movement while the pane stays
+  active; their watchdog also releases browser capture, so a missing release cannot shield later focus loss
   (`frontend/src/lib/components/terminal/XtermTerminalPane.svelte::cancelTerminalPointerGesture`).
 - Host clipboard writes require a local browser; trusted loopback proxies must report exactly one client IP assigned
   to the host, because the proxy's loopback `RemoteAddr` alone does not establish browser locality

--- a/context/workspace-runtime-lifecycle.md
+++ b/context/workspace-runtime-lifecycle.md
@@ -110,9 +110,9 @@ stale tabs.
 - Keep OSC 52 validation synchronous and ahead of gesture consumption; replacing it with `@xterm/addon-clipboard`
   would require custom prefilters, nonblocking write separation, and handler-order coupling to preserve current
   rejection, parser-progress, and read-denial guarantees.
-- Terminal keyboard clipboard authority is revoked when focus leaves the terminal; captured pointer drags retain authority
-  through release grace, while window focus or visibility loss revokes both and a watchdog bounds missing releases
-  (`frontend/src/lib/components/terminal/XtermTerminalPane.svelte::handleTerminalFocusOut`).
+- Terminal clipboard authority is revoked on focus loss, pane inactivity/parking, disablement, or window focus/visibility
+  loss; captured pointer drags retain authority only while the pane stays active, and a watchdog bounds missing releases
+  (`frontend/src/lib/components/terminal/XtermTerminalPane.svelte::cancelTerminalClipboardAuthorization`).
 - Host clipboard writes require a local browser; trusted loopback proxies must report exactly one client IP assigned
   to the host, because the proxy's loopback `RemoteAddr` alone does not establish browser locality
   (`internal/server/terminal_clipboard_access.go::isLocalTerminalClipboardRequest`).

--- a/context/workspace-runtime-lifecycle.md
+++ b/context/workspace-runtime-lifecycle.md
@@ -111,8 +111,11 @@ stale tabs.
   would require custom prefilters, nonblocking write separation, and handler-order coupling to preserve current
   rejection, parser-progress, and read-denial guarantees.
 - Terminal clipboard authority is revoked on focus loss, pane inactivity/parking, disablement, or window focus/visibility
-  loss; captured pointer drags retain authority only while the pane stays active, and a watchdog bounds missing releases
-  (`frontend/src/lib/components/terminal/XtermTerminalPane.svelte::cancelTerminalClipboardAuthorization`).
+  loss; revocation also stops in-flight browser-to-loopback fallback chains before their next stage
+  (`frontend/src/lib/components/terminal/terminalClipboardWriter.ts::createTerminalClipboardWriter`).
+- Captured pointer drags retain authority only while the pane stays active; their watchdog also releases browser capture,
+  so a missing release cannot shield later focus loss
+  (`frontend/src/lib/components/terminal/XtermTerminalPane.svelte::cancelTerminalPointerGesture`).
 - Host clipboard writes require a local browser; trusted loopback proxies must report exactly one client IP assigned
   to the host, because the proxy's loopback `RemoteAddr` alone does not establish browser locality
   (`internal/server/terminal_clipboard_access.go::isLocalTerminalClipboardRequest`).

--- a/frontend/src/lib/components/terminal/TerminalPane.test.ts
+++ b/frontend/src/lib/components/terminal/TerminalPane.test.ts
@@ -865,6 +865,18 @@ describe("TerminalPane", () => {
     visibilityState.mockRestore();
   });
 
+  it("revokes pending terminal clipboard writes when focus leaves the terminal", async () => {
+    const { container } = render(TerminalPane, { props: { workspaceId: "ws-123" } });
+    await waitFor(() => expect(xtermTerminalCtor).toHaveBeenCalled());
+    const terminalContainer = container.querySelector<HTMLElement>(".terminal-container");
+    const outsideButton = document.createElement("button");
+    container.append(outsideButton);
+
+    terminalContainer!.dispatchEvent(new FocusEvent("focusout", { bubbles: true, relatedTarget: outsideButton }));
+
+    expect(clipboardWriterCancelAuthorization).toHaveBeenCalledTimes(1);
+  });
+
   it("does not attach xterm sessions with unavailable initial status", async () => {
     render(TerminalPane, {
       props: {

--- a/frontend/src/lib/components/terminal/TerminalPane.test.ts
+++ b/frontend/src/lib/components/terminal/TerminalPane.test.ts
@@ -865,18 +865,6 @@ describe("TerminalPane", () => {
     visibilityState.mockRestore();
   });
 
-  it("revokes pending terminal clipboard writes when focus leaves the terminal", async () => {
-    const { container } = render(TerminalPane, { props: { workspaceId: "ws-123" } });
-    await waitFor(() => expect(xtermTerminalCtor).toHaveBeenCalled());
-    const terminalContainer = container.querySelector<HTMLElement>(".terminal-container");
-    const outsideButton = document.createElement("button");
-    container.append(outsideButton);
-
-    terminalContainer!.dispatchEvent(new FocusEvent("focusout", { bubbles: true, relatedTarget: outsideButton }));
-
-    expect(clipboardWriterCancelAuthorization).toHaveBeenCalledTimes(1);
-  });
-
   it("does not attach xterm sessions with unavailable initial status", async () => {
     render(TerminalPane, {
       props: {

--- a/frontend/src/lib/components/terminal/TerminalPane.test.ts
+++ b/frontend/src/lib/components/terminal/TerminalPane.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test"
 
 const {
   clipboardWriteText,
+  clipboardWriterCancelAuthorization,
   clipboardWriterCancelPointerGesture,
   clipboardWriterDispose,
   clipboardWriterWrite,
@@ -22,6 +23,7 @@ const {
   xtermOpen,
 } = vi.hoisted(() => ({
   clipboardWriteText: vi.fn(),
+  clipboardWriterCancelAuthorization: vi.fn(),
   clipboardWriterCancelPointerGesture: vi.fn(),
   clipboardWriterDispose: vi.fn(),
   clipboardWriterWrite: vi.fn(),
@@ -129,6 +131,7 @@ vi.mock("./terminalClipboardWriter.js", () => ({
   createBrowserTerminalClipboardPort: vi.fn(() => ({})),
   createTerminalClipboardWriter: vi.fn(() => ({
     beginPointerGesture: vi.fn(),
+    cancelAuthorization: clipboardWriterCancelAuthorization,
     cancelPointerGesture: clipboardWriterCancelPointerGesture,
     endPointerGesture: vi.fn(),
     authorizeKeyboardGesture: vi.fn(),
@@ -227,6 +230,7 @@ describe("TerminalPane", () => {
     fitDimensions = { cols: 80, rows: 24 };
     ligaturesAddonCtor.mockReset();
     clipboardWriteText.mockReset();
+    clipboardWriterCancelAuthorization.mockReset();
     clipboardWriterCancelPointerGesture.mockReset();
     clipboardWriterDispose.mockReset();
     clipboardWriterWrite.mockReset().mockResolvedValue("unauthorized");
@@ -859,6 +863,18 @@ describe("TerminalPane", () => {
 
     expect(clipboardWriterCancelPointerGesture).toHaveBeenCalledTimes(1);
     visibilityState.mockRestore();
+  });
+
+  it("revokes pending terminal clipboard writes when focus leaves the terminal", async () => {
+    const { container } = render(TerminalPane, { props: { workspaceId: "ws-123" } });
+    await waitFor(() => expect(xtermTerminalCtor).toHaveBeenCalled());
+    const terminalContainer = container.querySelector<HTMLElement>(".terminal-container");
+    const outsideButton = document.createElement("button");
+    container.append(outsideButton);
+
+    terminalContainer!.dispatchEvent(new FocusEvent("focusout", { bubbles: true, relatedTarget: outsideButton }));
+
+    expect(clipboardWriterCancelAuthorization).toHaveBeenCalledTimes(1);
   });
 
   it("does not attach xterm sessions with unavailable initial status", async () => {

--- a/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
@@ -204,13 +204,27 @@
     mouseDragAutoscroll.endPointerGesture();
   }
 
-  function handleWindowBlur(): void {
+  function cancelTerminalClipboardAuthorization(): void {
     cancelTerminalPointerGesture();
+    clipboardWriter.cancelAuthorization();
+  }
+
+  function handleTerminalFocusOut(event: FocusEvent): void {
+    // Pointer capture owns an active drag even when focus moves outside the
+    // terminal bounds. Its release/grace path revokes the authorization.
+    if (activePointerId !== null) return;
+    const nextTarget = event.relatedTarget;
+    if (nextTarget instanceof Node && containerEl.contains(nextTarget)) return;
+    cancelTerminalClipboardAuthorization();
+  }
+
+  function handleWindowBlur(): void {
+    cancelTerminalClipboardAuthorization();
   }
 
   function handleDocumentVisibilityChange(): void {
     if (document.visibilityState !== "visible") {
-      cancelTerminalPointerGesture();
+      cancelTerminalClipboardAuthorization();
     }
   }
 
@@ -910,6 +924,7 @@
   onpointerdowncapture={handleTerminalPointerDown}
   onlostpointercapture={handleTerminalLostPointerCapture}
   onkeydowncapture={handleTerminalKeyDown}
+  onfocusout={handleTerminalFocusOut}
 ></div>
 
 <style>

--- a/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
@@ -93,6 +93,7 @@
   const encoder = new TextEncoder();
   const clipboardWriter = createTerminalClipboardWriter(
     createBrowserTerminalClipboardPort(),
+    { onPointerGestureTimeout: cancelTerminalPointerGesture },
   );
   const mouseDragAutoscroll = createTmuxMouseDragAutoscroll({
     send(data) {

--- a/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
@@ -211,11 +211,11 @@
   }
 
   function handleTerminalFocusOut(event: FocusEvent): void {
-    // Pointer capture owns an active drag even when focus moves outside the
-    // terminal bounds. Its release/grace path revokes the authorization.
-    if (activePointerId !== null) return;
     const nextTarget = event.relatedTarget;
     if (nextTarget instanceof Node && containerEl.contains(nextTarget)) return;
+    // Pointer capture can briefly produce a focusout without a destination.
+    // A concrete external target is an actual focus transfer and must revoke.
+    if (nextTarget === null && activePointerId !== null) return;
     cancelTerminalClipboardAuthorization();
   }
 

--- a/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
@@ -228,6 +228,11 @@
     }
   }
 
+  $effect(() => {
+    if (active && !disabled) return;
+    cancelTerminalClipboardAuthorization();
+  });
+
   function handleTerminalKeyDown(event: KeyboardEvent): void {
     if (disposed || disabled || event.isComposing || !event.isTrusted) return;
     clipboardWriter.authorizeKeyboardGesture();

--- a/frontend/src/lib/components/terminal/terminalClipboardWriter.test.ts
+++ b/frontend/src/lib/components/terminal/terminalClipboardWriter.test.ts
@@ -198,6 +198,19 @@ describe("terminal clipboard writer", () => {
     expect(writeLocalText).not.toHaveBeenCalled();
   });
 
+  it("revokes keyboard authorization when terminal focus is lost", async () => {
+    const { port, deferredWrites, writeLocalText, writeText } = createPort();
+    const writer = createTerminalClipboardWriter(port);
+
+    writer.authorizeKeyboardGesture();
+    writer.cancelAuthorization();
+
+    await expect(writer.write("late terminal write")).resolves.toBe("unauthorized");
+    await expect(deferredWrites[0]).rejects.toMatchObject({ name: "AbortError" });
+    expect(writeText).not.toHaveBeenCalled();
+    expect(writeLocalText).not.toHaveBeenCalled();
+  });
+
   it("does not shorten keyboard authorization for an unrelated pointer release", async () => {
     vi.useFakeTimers();
     const { port, deferredWrites, writeLocalText, writeText } = createPort();

--- a/frontend/src/lib/components/terminal/terminalClipboardWriter.test.ts
+++ b/frontend/src/lib/components/terminal/terminalClipboardWriter.test.ts
@@ -150,15 +150,20 @@ describe("terminal clipboard writer", () => {
   it("revokes a pointer authorization when its watchdog expires", async () => {
     vi.useFakeTimers();
     const { port, deferredWrites, writeLocalText, writeText } = createPort();
-    const writer = createTerminalClipboardWriter(port);
+    const onPointerGestureTimeout = vi.fn();
+    const writer = createTerminalClipboardWriter(port, { onPointerGestureTimeout });
 
     writer.beginPointerGesture();
     await vi.advanceTimersByTimeAsync(60_001);
 
+    expect(onPointerGestureTimeout).toHaveBeenCalledTimes(1);
     await expect(writer.write("late write")).resolves.toBe("unauthorized");
     await expect(deferredWrites[0]).rejects.toMatchObject({ name: "AbortError" });
     expect(writeText).not.toHaveBeenCalled();
     expect(writeLocalText).not.toHaveBeenCalled();
+
+    writer.authorizeKeyboardGesture();
+    await expect(writer.write("later keyboard write")).resolves.toBe("written");
   });
 
   it("clears a rejected authorization so a later gesture can retry", async () => {
@@ -247,6 +252,53 @@ describe("terminal clipboard writer", () => {
     await expect(writer.write("late write")).resolves.toBe("unauthorized");
     expect(writeText).not.toHaveBeenCalled();
     pending.resolve();
+  });
+
+  it("does not start a direct fallback after focus loss during a deferred write", async () => {
+    const deferredWrite = deferred<void>();
+    const deferredWrites: Array<Promise<string>> = [];
+    const writeText = vi.fn(async () => undefined);
+    const writeLocalText = vi.fn(async () => undefined);
+    const writer = createTerminalClipboardWriter({
+      beginDeferredWrite(text) {
+        deferredWrites.push(text);
+        return deferredWrite.promise;
+      },
+      writeLocalText,
+      writeText,
+    });
+
+    writer.authorizeKeyboardGesture();
+    const copied = writer.write("stale terminal write");
+    await expect(deferredWrites[0]).resolves.toBe("stale terminal write");
+    writer.cancelAuthorization();
+    deferredWrite.reject(new DOMException("denied", "NotAllowedError"));
+
+    await expect(copied).resolves.toBe("unauthorized");
+    expect(writeText).not.toHaveBeenCalled();
+    expect(writeLocalText).not.toHaveBeenCalled();
+  });
+
+  it("does not start a loopback fallback after focus loss during a direct write", async () => {
+    const directWrite = deferred<void>();
+    const writeText = vi.fn(() => directWrite.promise);
+    const writeLocalText = vi.fn(async () => undefined);
+    const writer = createTerminalClipboardWriter({
+      beginDeferredWrite() {
+        throw new DOMException("unsupported", "NotSupportedError");
+      },
+      writeLocalText,
+      writeText,
+    });
+
+    writer.authorizeKeyboardGesture();
+    const copied = writer.write("stale terminal write");
+    await vi.waitFor(() => expect(writeText).toHaveBeenCalledWith("stale terminal write"));
+    writer.cancelAuthorization();
+    directWrite.reject(new DOMException("denied", "NotAllowedError"));
+
+    await expect(copied).resolves.toBe("unauthorized");
+    expect(writeLocalText).not.toHaveBeenCalled();
   });
 
   it("falls back to writeText when deferred clipboard setup is unavailable", async () => {

--- a/frontend/src/lib/components/terminal/terminalClipboardWriter.ts
+++ b/frontend/src/lib/components/terminal/terminalClipboardWriter.ts
@@ -12,6 +12,7 @@ export interface TerminalClipboardPort {
 
 export interface TerminalClipboardWriter {
   beginPointerGesture(): void;
+  cancelAuthorization(): void;
   cancelPointerGesture(): void;
   endPointerGesture(): void;
   authorizeKeyboardGesture(): void;
@@ -152,6 +153,12 @@ export function createTerminalClipboardWriter(port: TerminalClipboardPort): Term
       arm();
       pointerAuthorizationPending = pending !== null;
       pointerGestureTimer = setTimeout(cancelPointerGesture, POINTER_GESTURE_WATCHDOG_MS);
+    },
+    cancelAuthorization() {
+      clearPointerGestureTimer();
+      pointerGestureActive = false;
+      pointerGestureAuthorizationConsumed = false;
+      expirePending();
     },
     cancelPointerGesture,
     endPointerGesture() {

--- a/frontend/src/lib/components/terminal/terminalClipboardWriter.ts
+++ b/frontend/src/lib/components/terminal/terminalClipboardWriter.ts
@@ -20,6 +20,10 @@ export interface TerminalClipboardWriter {
   dispose(): void;
 }
 
+export interface TerminalClipboardWriterOptions {
+  onPointerGestureTimeout?: () => void;
+}
+
 export type TerminalClipboardWriteResult = "written" | "unauthorized" | "blocked";
 
 interface PendingClipboardWrite {
@@ -55,7 +59,10 @@ export function createBrowserTerminalClipboardPort(): TerminalClipboardPort {
   };
 }
 
-export function createTerminalClipboardWriter(port: TerminalClipboardPort): TerminalClipboardWriter {
+export function createTerminalClipboardWriter(
+  port: TerminalClipboardPort,
+  options: TerminalClipboardWriterOptions = {},
+): TerminalClipboardWriter {
   let pending: PendingClipboardWrite | null = null;
   let expirationTimer: ReturnType<typeof setTimeout> | null = null;
   let pointerGestureTimer: ReturnType<typeof setTimeout> | null = null;
@@ -63,6 +70,7 @@ export function createTerminalClipboardWriter(port: TerminalClipboardPort): Term
   let pointerAuthorizationPending = false;
   let pointerGestureAuthorizationConsumed = false;
   let disposed = false;
+  let revocationGeneration = 0;
 
   function clearExpiration(): void {
     if (expirationTimer === null) return;
@@ -137,10 +145,16 @@ export function createTerminalClipboardWriter(port: TerminalClipboardPort): Term
 
   function cancelPointerGesture(): void {
     if (!pointerGestureActive && !pointerAuthorizationPending) return;
+    revocationGeneration += 1;
     clearPointerGestureTimer();
     pointerGestureActive = false;
     pointerGestureAuthorizationConsumed = false;
     if (pointerAuthorizationPending) expirePending();
+  }
+
+  function timeoutPointerGesture(): void {
+    cancelPointerGesture();
+    options.onPointerGestureTimeout?.();
   }
 
   return {
@@ -152,9 +166,10 @@ export function createTerminalClipboardWriter(port: TerminalClipboardPort): Term
       clearExpiration();
       arm();
       pointerAuthorizationPending = pending !== null;
-      pointerGestureTimer = setTimeout(cancelPointerGesture, POINTER_GESTURE_WATCHDOG_MS);
+      pointerGestureTimer = setTimeout(timeoutPointerGesture, POINTER_GESTURE_WATCHDOG_MS);
     },
     cancelAuthorization() {
+      revocationGeneration += 1;
       clearPointerGestureTimer();
       pointerGestureActive = false;
       pointerGestureAuthorizationConsumed = false;
@@ -187,19 +202,27 @@ export function createTerminalClipboardWriter(port: TerminalClipboardPort): Term
       const authorized = pending;
       pending = null;
       if (!authorized) return "unauthorized";
+      const writeGeneration = revocationGeneration;
       if (pointerGestureActive && pointerAuthorizationPending) {
         pointerGestureAuthorizationConsumed = true;
       }
       pointerAuthorizationPending = false;
 
       authorized.resolve(text);
-      if (await authorized.outcome) return "written";
-      if (await writeDirect(text)) return "written";
-      return (await writeLocal(text)) ? "written" : "blocked";
+      const deferredWritten = await authorized.outcome;
+      if (disposed || writeGeneration !== revocationGeneration) return "unauthorized";
+      if (deferredWritten) return "written";
+      const directWritten = await writeDirect(text);
+      if (disposed || writeGeneration !== revocationGeneration) return "unauthorized";
+      if (directWritten) return "written";
+      const localWritten = await writeLocal(text);
+      if (disposed || writeGeneration !== revocationGeneration) return "unauthorized";
+      return localWritten ? "written" : "blocked";
     },
     dispose() {
       if (disposed) return;
       disposed = true;
+      revocationGeneration += 1;
       clearPointerGestureTimer();
       pointerGestureActive = false;
       pointerAuthorizationPending = false;

--- a/frontend/tests/e2e-full/00-tmux-browser-clipboard.spec.ts
+++ b/frontend/tests/e2e-full/00-tmux-browser-clipboard.spec.ts
@@ -1,4 +1,6 @@
 import { execFileSync } from "node:child_process";
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
 import {
   expect,
   request as playwrightRequest,
@@ -12,6 +14,7 @@ import { startIsolatedWorkspaceE2EServer, type IsolatedE2EServer } from "./suppo
 type WorkspaceStatusResponse = {
   id: string;
   status: string;
+  worktree_path: string;
   error_message?: string | null;
 };
 
@@ -53,6 +56,16 @@ async function createIssueWorkspace(api: APIRequestContext, issueNumber: number)
   return waitForWorkspaceReady(api, workspace.id);
 }
 
+async function launchDockedShell(api: APIRequestContext, workspaceId: string): Promise<void> {
+  const response = await api.post(`/api/v1/workspaces/${workspaceId}/runtime/sessions`, {
+    data: {
+      target_key: "plain_shell",
+      display_region: "terminal",
+    },
+  });
+  expect(response.status(), await response.text()).toBe(200);
+}
+
 async function openTerminalPanel(page: Page): Promise<Locator> {
   await page.getByRole("button", { name: "Open terminal panel" }).click();
   const container = page.locator(".terminal-panel.open .terminal-container");
@@ -62,14 +75,20 @@ async function openTerminalPanel(page: Page): Promise<Locator> {
 }
 
 async function selectTopBarTab(page: Page, label: string): Promise<void> {
-  await page.locator(".kit-top-bar__tabs .kit-top-bar__tab", { hasText: label }).click();
+  const tab = page.locator(".kit-top-bar__tabs .kit-top-bar__tab", { hasText: label });
+  if (await tab.isVisible()) {
+    await tab.click();
+    return;
+  }
+  await page.locator(".kit-top-bar__nav-select .kit-select-dropdown__trigger").click();
+  await page.getByRole("option", { name: label, exact: true }).click();
 }
 
 async function selectIssueByTitle(page: Page, title: string): Promise<void> {
   await selectTopBarTab(page, "Issues");
   const issue = page.locator(".issue-item").filter({ hasText: title }).first();
   await issue.click();
-  await issue.click();
+  await expect(page.locator(".issue-detail")).toBeVisible();
 }
 
 function observeTerminalOutput(page: Page): {
@@ -177,6 +196,18 @@ async function emitApplicationOsc52(
   await page.keyboard.type(`printf '${shellOctal(`\x1b]52;c;${payload}\x07${marker}\n`)}'`);
   await page.keyboard.press("Enter");
   await expect.poll(() => output.includes(marker), { timeout: TERMINAL_OUTPUT_TIMEOUT_MS }).toBe(true);
+}
+
+async function scheduleApplicationOsc52(page: Page, container: Locator): Promise<string> {
+  const marker = "late parked osc52 complete";
+  const value = "late parked terminal write";
+  const payload = Buffer.from(value).toString("base64");
+  await container.click({ position: { x: 10, y: 10 } });
+  await page.keyboard.type(
+    `while [ ! -f .clipboard-osc52-gate ]; do sleep 0.05; done; printf '${shellOctal(`\x1b]52;c;${payload}\x07${marker}\n`)}'`,
+  );
+  await page.keyboard.press("Enter");
+  return marker;
 }
 
 async function runAttachedTmuxCommand(page: Page, command: string): Promise<void> {
@@ -459,6 +490,65 @@ test("tmux blocks application OSC 52 while keyboard copy reaches the clipboard",
       await copyMarkerWithTmuxKeys(page, tabTerminal, output, keyboardMarker);
       await expect.poll(() => readBrowserClipboard(page), { timeout: 15_000 }).toBe(keyboardMarker);
     }
+  } finally {
+    await api?.dispose();
+    await isolatedServer?.stop();
+  }
+});
+
+test("a parked pooled terminal cannot overwrite a newer detail clipboard copy", async ({ page, browserName }) => {
+  test.skip(browserName !== "chromium", "Clipboard ordering assertions require Chromium permissions");
+  test.skip(!hasCommand("git") || !hasCommand("tmux", ["-V"]), "git and tmux are required for the real workspace flow");
+  await page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
+
+  let isolatedServer: IsolatedE2EServer | null = null;
+  let api: APIRequestContext | null = null;
+  try {
+    isolatedServer = await startIsolatedWorkspaceE2EServer();
+    api = await playwrightRequest.newContext({
+      baseURL: isolatedServer.info.base_url,
+    });
+    const workspace = await createIssueWorkspace(api, 10);
+    await launchDockedShell(api, workspace.id);
+    await launchDockedShell(api, workspace.id);
+    const output = observeTerminalOutput(page);
+
+    await page.setViewportSize({ width: 1800, height: 900 });
+    await page.goto(`${isolatedServer.info.base_url}/issues/github/acme/widgets/10`);
+    await expect(page.locator(".detail-pane-workspace-slot .workspace-host-wrapper")).toBeVisible();
+    await openTerminalPanel(page);
+    const chosenLeaf = page
+      .locator('.terminal-panel.open .terminal-leaf:has(button[aria-label$=" to a pane"])')
+      .first();
+    const dockedTerminal = chosenLeaf.locator(".terminal-container");
+    await expect(dockedTerminal).toBeVisible();
+    const promote = chosenLeaf.getByRole("button", { name: /^Move .+ to a pane$/ });
+    await expect(promote).toBeVisible();
+    await dockedTerminal.evaluate((element) => element.setAttribute("data-clipboard-park-witness", "live-terminal"));
+    await promote.click();
+
+    const terminal = page.locator('.session-terminal-slot [data-clipboard-park-witness="live-terminal"]');
+    await expect(terminal).toBeVisible();
+
+    const lateWriteMarker = await scheduleApplicationOsc52(page, terminal);
+    await expect.poll(() => output.activeSocketCount()).toBeGreaterThan(0);
+    const activeSocketsBeforePark = output.activeSocketCount();
+    const promotedLeaf = page.locator(".tabbed-panel-leaf").filter({ has: terminal });
+    await promotedLeaf
+      .locator('[data-testid^="pane-hide-session:"]')
+      .evaluate((element) => (element as HTMLElement).click());
+    await expect(page.locator('.session-pool-parking [data-clipboard-park-witness="live-terminal"]')).toHaveCount(1);
+    await expect.poll(() => output.activeSocketCount()).toBe(activeSocketsBeforePark);
+
+    const copyButton = page.getByRole("button", { name: "Copy issue #10 link" });
+    await copyButton.click();
+    await expect(copyButton).toHaveAttribute("title", "Copied!");
+    await expect.poll(() => readBrowserClipboard(page)).toBe("https://github.com/acme/widgets/issues/10");
+
+    await writeFile(join(workspace.worktree_path, ".clipboard-osc52-gate"), "go", { mode: 0o600 });
+    await expect.poll(() => output.includes(lateWriteMarker), { timeout: TERMINAL_OUTPUT_TIMEOUT_MS }).toBe(true);
+    await page.waitForTimeout(250);
+    expect(await readBrowserClipboard(page)).toBe("https://github.com/acme/widgets/issues/10");
   } finally {
     await api?.dispose();
     await isolatedServer?.stop();

--- a/frontend/tests/e2e-full/00-tmux-browser-clipboard.spec.ts
+++ b/frontend/tests/e2e-full/00-tmux-browser-clipboard.spec.ts
@@ -574,6 +574,69 @@ test("visible terminal focus loss revokes keyboard authorization after a missed 
   }
 });
 
+test("visible detail copy wins when focus leaves a pointer-captured terminal", async ({ page, browserName }) => {
+  test.skip(browserName !== "chromium", "Clipboard ordering assertions require Chromium permissions");
+  test.skip(!hasCommand("git") || !hasCommand("tmux", ["-V"]), "git and tmux are required for the real workspace flow");
+  await page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
+
+  let isolatedServer: IsolatedE2EServer | null = null;
+  let api: APIRequestContext | null = null;
+  let pointerIsDown = false;
+  try {
+    isolatedServer = await startIsolatedWorkspaceE2EServer();
+    api = await playwrightRequest.newContext({ baseURL: isolatedServer.info.base_url });
+    const workspace = await createIssueWorkspace(api, 10);
+    await launchDockedShell(api, workspace.id);
+    await launchDockedShell(api, workspace.id);
+    const output = observeTerminalOutput(page);
+
+    await page.setViewportSize({ width: 1800, height: 900 });
+    await page.goto(`${isolatedServer.info.base_url}/issues/github/acme/widgets/10`);
+    await expect(page.locator(".detail-pane-workspace-slot .workspace-host-wrapper")).toBeVisible();
+    await openTerminalPanel(page);
+    const chosenLeaf = page
+      .locator('.terminal-panel.open .terminal-leaf:has(button[aria-label$=" to a pane"])')
+      .first();
+    const dockedTerminal = chosenLeaf.locator(".terminal-container");
+    await expect(dockedTerminal).toBeVisible();
+    await chosenLeaf.getByRole("button", { name: /^Move .+ to a pane$/ }).click();
+    const terminal = page.locator(".session-terminal-slot .terminal-container");
+    await expect(terminal).toBeVisible();
+
+    const lateWriteMarker = await scheduleApplicationOsc52(page, terminal);
+    const bounds = await terminal.boundingBox();
+    if (!bounds) throw new Error("promoted terminal has no pointer bounds");
+    await page.mouse.move(bounds.x + 10, bounds.y + 10);
+    await beginCapturedPointerGesture(page, terminal);
+    pointerIsDown = true;
+
+    const copyButton = page.getByRole("button", { name: "Copy issue #10 link" });
+    await copyButton.evaluate((element) => (element as HTMLElement).focus());
+    await expect.poll(() => copyButton.evaluate((element) => document.activeElement === element)).toBe(true);
+    await expect
+      .poll(() =>
+        terminal.evaluate((element) => {
+          const target = element as HTMLElement;
+          return target.hasPointerCapture(Number(target.dataset.playwrightPointerId));
+        }),
+      )
+      .toBe(false);
+    await page.keyboard.press("Enter");
+    await expect(copyButton).toHaveAttribute("title", "Copied!");
+
+    await writeFile(join(workspace.worktree_path, ".clipboard-osc52-gate"), "go", { mode: 0o600 });
+    await expect.poll(() => output.includes(lateWriteMarker), { timeout: TERMINAL_OUTPUT_TIMEOUT_MS }).toBe(true);
+    await page.waitForTimeout(250);
+    await page.mouse.up();
+    pointerIsDown = false;
+    expect(await readBrowserClipboard(page)).toBe("https://github.com/acme/widgets/issues/10");
+  } finally {
+    if (pointerIsDown) await page.mouse.up();
+    await api?.dispose();
+    await isolatedServer?.stop();
+  }
+});
+
 test("a parked pooled terminal cannot overwrite a newer detail clipboard copy", async ({ page, browserName }) => {
   test.skip(browserName !== "chromium", "Clipboard ordering assertions require Chromium permissions");
   test.skip(!hasCommand("git") || !hasCommand("tmux", ["-V"]), "git and tmux are required for the real workspace flow");

--- a/frontend/tests/e2e-full/00-tmux-browser-clipboard.spec.ts
+++ b/frontend/tests/e2e-full/00-tmux-browser-clipboard.spec.ts
@@ -199,10 +199,14 @@ async function emitApplicationOsc52(
 }
 
 async function scheduleApplicationOsc52(page: Page, container: Locator): Promise<string> {
-  const marker = "late parked osc52 complete";
-  const value = "late parked terminal write";
-  const payload = Buffer.from(value).toString("base64");
   await container.click({ position: { x: 10, y: 10 } });
+  return typeScheduledApplicationOsc52(page);
+}
+
+async function typeScheduledApplicationOsc52(page: Page): Promise<string> {
+  const marker = "late terminal osc52 complete";
+  const value = "late terminal write";
+  const payload = Buffer.from(value).toString("base64");
   await page.keyboard.type(
     `while [ ! -f .clipboard-osc52-gate ]; do sleep 0.05; done; printf '${shellOctal(`\x1b]52;c;${payload}\x07${marker}\n`)}'`,
   );
@@ -490,6 +494,80 @@ test("tmux blocks application OSC 52 while keyboard copy reaches the clipboard",
       await copyMarkerWithTmuxKeys(page, tabTerminal, output, keyboardMarker);
       await expect.poll(() => readBrowserClipboard(page), { timeout: 15_000 }).toBe(keyboardMarker);
     }
+  } finally {
+    await api?.dispose();
+    await isolatedServer?.stop();
+  }
+});
+
+test("visible terminal focus loss revokes keyboard authorization after a missed pointer release", async ({
+  page,
+  browserName,
+}) => {
+  test.skip(browserName !== "chromium", "Clipboard ordering assertions require Chromium permissions");
+  test.skip(!hasCommand("git") || !hasCommand("tmux", ["-V"]), "git and tmux are required for the real workspace flow");
+  await page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
+
+  let isolatedServer: IsolatedE2EServer | null = null;
+  let api: APIRequestContext | null = null;
+  try {
+    isolatedServer = await startIsolatedWorkspaceE2EServer();
+    api = await playwrightRequest.newContext({ baseURL: isolatedServer.info.base_url });
+    const workspace = await createIssueWorkspace(api, 10);
+    await launchDockedShell(api, workspace.id);
+    await launchDockedShell(api, workspace.id);
+    const output = observeTerminalOutput(page);
+
+    await page.setViewportSize({ width: 1800, height: 900 });
+    await page.goto(`${isolatedServer.info.base_url}/issues/github/acme/widgets/10`);
+    await expect(page.locator(".detail-pane-workspace-slot .workspace-host-wrapper")).toBeVisible();
+    await openTerminalPanel(page);
+    const chosenLeaf = page
+      .locator('.terminal-panel.open .terminal-leaf:has(button[aria-label$=" to a pane"])')
+      .first();
+    const dockedTerminal = chosenLeaf.locator(".terminal-container");
+    await expect(dockedTerminal).toBeVisible();
+    await chosenLeaf.getByRole("button", { name: /^Move .+ to a pane$/ }).click();
+    const terminal = page.locator(".session-terminal-slot .terminal-container");
+    await expect(terminal).toBeVisible();
+
+    const bounds = await terminal.boundingBox();
+    if (!bounds) throw new Error("promoted terminal has no pointer bounds");
+    await page.mouse.move(bounds.x + 10, bounds.y + 10);
+    await page.evaluate(() => {
+      const nativeSetTimeout = window.setTimeout.bind(window);
+      const testWindow = window as Window & { __restoreNativeSetTimeout?: () => void };
+      testWindow.__restoreNativeSetTimeout = () => {
+        window.setTimeout = nativeSetTimeout;
+      };
+      window.setTimeout = ((handler: TimerHandler, timeout?: number, ...args: unknown[]) =>
+        nativeSetTimeout(handler, timeout === 60_000 ? 500 : timeout, ...args)) as typeof window.setTimeout;
+    });
+    await beginCapturedPointerGesture(page, terminal);
+    await page.evaluate(() => {
+      (window as Window & { __restoreNativeSetTimeout?: () => void }).__restoreNativeSetTimeout?.();
+    });
+    await page.waitForTimeout(750);
+    await expect
+      .poll(() =>
+        terminal.evaluate((element) => {
+          const target = element as HTMLElement;
+          return target.hasPointerCapture(Number(target.dataset.playwrightPointerId));
+        }),
+      )
+      .toBe(false);
+    await page.mouse.up();
+
+    const lateWriteMarker = await typeScheduledApplicationOsc52(page);
+    const copyButton = page.getByRole("button", { name: "Copy issue #10 link" });
+    await copyButton.click();
+    await expect(copyButton).toHaveAttribute("title", "Copied!");
+    await expect.poll(() => readBrowserClipboard(page)).toBe("https://github.com/acme/widgets/issues/10");
+
+    await writeFile(join(workspace.worktree_path, ".clipboard-osc52-gate"), "go", { mode: 0o600 });
+    await expect.poll(() => output.includes(lateWriteMarker), { timeout: TERMINAL_OUTPUT_TIMEOUT_MS }).toBe(true);
+    await page.waitForTimeout(250);
+    expect(await readBrowserClipboard(page)).toBe("https://github.com/acme/widgets/issues/10");
   } finally {
     await api?.dispose();
     await isolatedServer?.stop();

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -39,6 +39,7 @@ const uiStoreDetailActivityView = path.resolve(
   "../packages/ui/src/stores/detail-activity-view.svelte.ts",
 );
 const uiStoreSettings = path.resolve(process.cwd(), "../packages/ui/src/stores/settings.svelte.ts");
+const uiModalStack = path.resolve(process.cwd(), "../packages/ui/src/stores/keyboard/modal-stack.svelte.ts");
 
 function devApiUrlPlugin(url: string): Plugin {
   return {
@@ -315,6 +316,10 @@ const config = {
       {
         find: /^@kenn-forge\/ui\/stores\/settings$/,
         replacement: uiStoreSettings,
+      },
+      {
+        find: /^@kenn-forge\/ui\/stores\/keyboard\/modal-stack$/,
+        replacement: uiModalStack,
       },
     ],
   },


### PR DESCRIPTION
A terminal clipboard request could remain pending after the user moved into PR details. The PR copy button would show success, but delayed terminal output could overwrite the copied description with a short terminal fragment.

- Keep successful PR and issue copy actions authoritative after leaving the terminal.
- Preserve terminal keyboard and drag-copy behavior.