### PR TITLE
Keep workspace detail tabs workspace-local

### DIFF
--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -178,6 +178,9 @@ Persisted controls must state their scope clearly.
 
 - Browser-local preferences belong in `localStorage` only when the behavior is
   intentionally per-browser and not worth server settings.
+- The workspace details tab is keyed by host-aware workspace identity; an unsupported
+  tab may fall back only for the current live workspace, never rewrite another
+  workspace's choice (`frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte::sidebarTabStorageKey`).
 - URL query state belongs in the route only when deep-linking or back/forward
   navigation is part of the feature contract.
 - Server-backed settings belong in the API only when the preference should

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -346,7 +346,7 @@
     total: number;
   }>({ status: "loading", total: 0 });
 
-  const SIDEBAR_TAB_KEY = "kenn-forge-workspace-sidebar-tab";
+  const SIDEBAR_TAB_KEY_PREFIX = "kenn-forge-workspace-sidebar-tab:";
   const SIDEBAR_OPEN_KEY = "kenn-forge-workspace-sidebar-open";
   const SIDEBAR_WIDTH_KEY = "kenn-forge-workspace-sidebar-width";
   const WORKSPACE_LIST_WIDTH_KEY =
@@ -438,12 +438,17 @@
       : DEFAULT_WORKSPACE_LIST_WIDTH;
   }
 
-  function loadSidebarTab(): SidebarTab {
-    const v = readLocalStorage(SIDEBAR_TAB_KEY);
+  function sidebarTabStorageKey(storageId: string): string {
+    return `${SIDEBAR_TAB_KEY_PREFIX}${storageId}`;
+  }
+
+  function loadSidebarTab(storageId: string): SidebarTab {
+    const v = readLocalStorage(sidebarTabStorageKey(storageId));
     if (v === "diff") return "diff";
     if (v === "pr") return "pr";
     if (v === "issue") return "issue";
     if (v === "reviews") return "reviews";
+    if (v === "kata_task") return "kata_task";
     return "diff";
   }
 
@@ -466,7 +471,11 @@
       : DEFAULT_SIDEBAR_WIDTH;
   }
 
-  let sidebarTab = $state<SidebarTab>(loadSidebarTab());
+  let selectedSidebarTabs = $state.raw<Record<string, SidebarTab>>({});
+  const sidebarTab = $derived.by(() => {
+    const storageId = workspaceStorageId(workspaceId, workspaceHostKey);
+    return selectedSidebarTabs[storageId] ?? loadSidebarTab(storageId);
+  });
   let sidebarOpen = $state(loadSidebarOpen());
   let sidebarWidth = $state(loadSidebarWidth());
   let workspaceListWidth = $state(loadWorkspaceListWidth());
@@ -1121,9 +1130,6 @@
   );
 
   $effect(() => {
-    writeLocalStorage(SIDEBAR_TAB_KEY, sidebarTab);
-  });
-  $effect(() => {
     writeLocalStorage(
       SIDEBAR_OPEN_KEY,
       String(sidebarOpen),
@@ -1160,9 +1166,22 @@
     if (sidebarOpen && sidebarTab === tab) {
       sidebarOpen = false;
     } else {
-      sidebarTab = tab;
+      setSidebarTab(tab);
       sidebarOpen = true;
     }
+  }
+
+  function setSidebarTab(
+    tab: SidebarTab,
+    targetId: string | undefined = undefined,
+    targetHostKey?: string,
+  ): void {
+    const storageId = workspaceStorageId(
+      targetId ?? workspaceId,
+      targetId === undefined ? workspaceHostKey : targetHostKey,
+    );
+    selectedSidebarTabs = { ...selectedSidebarTabs, [storageId]: tab };
+    writeLocalStorage(sidebarTabStorageKey(storageId), tab);
   }
 
   function openItemSidebar(
@@ -1176,7 +1195,7 @@
       targetId !== workspaceId ||
       (targetHostKey ?? undefined) !== workspaceHostKey
     ) {
-      sidebarTab = tab;
+      setSidebarTab(tab, targetId, targetHostKey);
       sidebarOpen = true;
       if (targetHostKey) {
         navigate(
@@ -1493,7 +1512,7 @@
 
   function workspaceStorageId(
     id: string,
-    hostKey: string | undefined = workspaceHostKey,
+    hostKey: string | undefined,
   ): string {
     return hostKey ? `fleet:${encodeURIComponent(hostKey)}:${id}` : id;
   }
@@ -1691,7 +1710,7 @@
   function rememberActiveTab(key: WorkflowTabKey): void {
     if (!workspaceId) return;
     writeLocalStorage(
-      `${ACTIVE_WORKSPACE_TAB_KEY_PREFIX}${workspaceStorageId(workspaceId)}`,
+      `${ACTIVE_WORKSPACE_TAB_KEY_PREFIX}${workspaceStorageId(workspaceId, workspaceHostKey)}`,
       key,
     );
   }
@@ -1751,7 +1770,7 @@
 
   function syncSidebarTabForWorkspace(ws: Workspace): void {
     if (!isSidebarTabSupported(ws, sidebarTab)) {
-      sidebarTab = defaultSidebarTab();
+      setSidebarTab(defaultSidebarTab());
     }
   }
 
@@ -3301,9 +3320,9 @@
   });
 
   $effect(() => {
-    if (!workspace) return;
+    if (!workspaceLive || !workspace) return;
     if (!isSidebarTabSupported(workspace, sidebarTab)) {
-      sidebarTab = defaultSidebarTab();
+      setSidebarTab(defaultSidebarTab());
     }
   });
 

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.test.ts
@@ -160,6 +160,10 @@ vi.mock("@kenn-forge/ui/stores/flash", () => ({
   showFlash: mocks.showFlash,
 }));
 
+vi.mock("../../../../../packages/ui/src/components/detail/PullDetail.svelte", async () => ({
+  default: (await import("../../../../../packages/ui/src/views/PRListViewTestPullDetail.svelte")).default,
+}));
+
 // The harness pairs the view with the session terminal pool, which WorkspaceHost
 // mounts in the app. Terminals live in the pool now, so the view on its own
 // renders portal slots and no terminal would ever appear.
@@ -1167,7 +1171,7 @@ describe("WorkspaceTerminalView", () => {
   it("prewarms a selected fleet diff and reloads it when the remote watch advances", async () => {
     window.__BASE_PATH__ = window.location.origin;
     localStorage.setItem("kenn-forge-workspace-sidebar-open", "true");
-    localStorage.setItem("kenn-forge-workspace-sidebar-tab", "diff");
+    localStorage.setItem("kenn-forge-workspace-sidebar-tab:fleet:member:ws-1", "diff");
     const changed = deferred<Response>();
     let watchCalls = 0;
     const fetchMock = vi.fn().mockImplementation((input: Request | URL | string) => {
@@ -1215,7 +1219,7 @@ describe("WorkspaceTerminalView", () => {
   it("retries a fleet diff watch while the workspace transitions from creating to ready", async () => {
     window.__BASE_PATH__ = window.location.origin;
     localStorage.setItem("kenn-forge-workspace-sidebar-open", "true");
-    localStorage.setItem("kenn-forge-workspace-sidebar-tab", "diff");
+    localStorage.setItem("kenn-forge-workspace-sidebar-tab:fleet:member:ws-1", "diff");
     vi.spyOn(Math, "random").mockReturnValue(0);
     let watchCalls = 0;
     const fetchMock = vi.fn().mockImplementation((input: Request | URL | string) => {
@@ -1267,7 +1271,7 @@ describe("WorkspaceTerminalView", () => {
   it("removes the old sidebar and waits for matching runtime before loading the new diff", async () => {
     window.__BASE_PATH__ = window.location.origin;
     localStorage.setItem("kenn-forge-workspace-sidebar-open", "true");
-    localStorage.setItem("kenn-forge-workspace-sidebar-tab", "diff");
+    localStorage.setItem("kenn-forge-workspace-sidebar-tab:ws-1", "diff");
     const workspaceB = { ...workspaceResponse, id: "ws-2", git_head_ref: "feature/two" };
     const workspaceBGate = deferred<typeof workspaceB>();
     const runtimeBGate = deferred<ReturnType<typeof runtimeWithStaleSession>>();
@@ -1341,7 +1345,7 @@ describe("WorkspaceTerminalView", () => {
   it("renders matching workspace details when runtime loading fails", async () => {
     window.__BASE_PATH__ = window.location.origin;
     localStorage.setItem("kenn-forge-workspace-sidebar-open", "true");
-    localStorage.setItem("kenn-forge-workspace-sidebar-tab", "diff");
+    localStorage.setItem("kenn-forge-workspace-sidebar-tab:ws-1", "diff");
     const loadWorkspaceDiff = vi.spyOn(mocks.diffStore, "loadWorkspaceDiff").mockResolvedValue();
 
     vi.stubGlobal(
@@ -2101,6 +2105,62 @@ describe("WorkspaceTerminalView", () => {
     await fireEvent.click(collapseButton);
 
     expect(onToggleSidebar).toHaveBeenCalledTimes(1);
+  });
+
+  it("remembers the selected details tab for each workspace", async () => {
+    window.__BASE_PATH__ = window.location.origin;
+    const adhocWorkspace = {
+      ...workspaceResponse,
+      id: "ws-2",
+      item_type: "adhoc",
+      item_number: 0,
+      associated_pr_number: null,
+      git_head_ref: "feature/adhoc",
+      tmux_session: "kenn-forge-ws-2",
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((input: Request | URL | string) => {
+        const url = input instanceof Request ? input.url : String(input);
+        const { pathname } = new URL(url, "http://localhost");
+        if (pathname.endsWith("/workspaces/ws-1")) {
+          return Promise.resolve(Response.json(workspaceResponse));
+        }
+        if (pathname.endsWith("/workspaces/ws-2")) {
+          return Promise.resolve(Response.json(adhocWorkspace));
+        }
+        if (pathname.endsWith("/api/v1/workspaces")) {
+          return Promise.resolve(Response.json({ workspaces: [workspaceResponse, adhocWorkspace] }));
+        }
+        return Promise.resolve(Response.json({}));
+      }),
+    );
+
+    const view = render(WorkspaceTerminalView, {
+      props: { workspaceId: "ws-1" },
+      context: new Map([
+        [
+          STORES_KEY,
+          {
+            diff: mocks.diffStore,
+            roborevDaemon: { isAvailable: () => false },
+          },
+        ],
+      ]),
+    });
+
+    const prButton = await screen.findByRole("button", { name: "PR" });
+    await fireEvent.click(prButton);
+    expect(prButton.classList.contains("active")).toBe(true);
+
+    await view.rerender({ workspaceId: "ws-2" });
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "PR" })).toBeNull();
+      expect(screen.getByRole("button", { name: "Diff" }).classList.contains("active")).toBe(true);
+    });
+
+    await view.rerender({ workspaceId: "ws-1" });
+    await waitFor(() => expect(screen.getByRole("button", { name: "PR" }).classList.contains("active")).toBe(true));
   });
 
   it("disables middle-pane workspace controls while the selected workspace is deleting", async () => {

--- a/frontend/tests/e2e-full/00-workspace-tab-persistence.spec.ts
+++ b/frontend/tests/e2e-full/00-workspace-tab-persistence.spec.ts
@@ -64,6 +64,22 @@ async function createIssueWorkspace(api: APIRequestContext, issueNumber: number)
   return createdWorkspace;
 }
 
+async function createPullWorkspace(api: APIRequestContext, pullNumber: number): Promise<WorkspaceStatusResponse> {
+  const createResponse = await api.post("/api/v1/workspaces", {
+    data: {
+      provider: "github",
+      platform_host: "github.com",
+      owner: "acme",
+      name: "widgets",
+      mr_number: pullNumber,
+    },
+  });
+  expect(createResponse.status()).toBe(202);
+  const createdWorkspace = (await createResponse.json()) as WorkspaceStatusResponse;
+  await waitForWorkspaceReady(api, createdWorkspace.id);
+  return createdWorkspace;
+}
+
 async function clickPierreExpander(file: Locator, separatorIndex: number): Promise<void> {
   const expander = file
     .locator(".pierre-diff [data-separator][data-expand-index]")
@@ -214,6 +230,45 @@ test.describe("workspace tab persistence", () => {
 
       await page.goto(`${isolatedServer.info.base_url}/terminal/${firstWorkspace.id}`);
       await expect(terminalTab).toHaveAttribute("aria-selected", "true");
+    } finally {
+      await api?.dispose();
+      await isolatedServer?.stop();
+    }
+  });
+
+  test("restores each workspace's selected details tab after navigation", async ({ page }) => {
+    test.skip(
+      !hasCommand("git") || !hasCommand("tmux", ["-V"]),
+      "git and tmux are required for the real workspace flow",
+    );
+
+    let isolatedServer: IsolatedE2EServer | null = null;
+    let api: APIRequestContext | null = null;
+    try {
+      isolatedServer = await startIsolatedWorkspaceE2EServer();
+      api = await playwrightRequest.newContext({ baseURL: isolatedServer.info.base_url });
+
+      const pullWorkspace = await createPullWorkspace(api, 1);
+      const issueWorkspace = await createIssueWorkspace(api, 11);
+      const detailsToggle = (label: "Diff" | "Issue" | "PR") =>
+        page.locator(".terminal-view .panel-toggle-group .panel-toggle-btn", { hasText: label });
+
+      await page.goto(`${isolatedServer.info.base_url}/terminal/${pullWorkspace.id}`);
+      await detailsToggle("PR").click();
+      await expect(detailsToggle("PR")).toHaveClass(/active/);
+
+      await page.locator(".workspace-list-sidebar .ws-row", { hasText: "Add dark mode support" }).click();
+      await expect(page).toHaveURL(new RegExp(`/terminal/${issueWorkspace.id}$`));
+      await detailsToggle("Issue").click();
+      await expect(detailsToggle("Issue")).toHaveClass(/active/);
+
+      await page.locator(".workspace-list-sidebar .ws-row", { hasText: "Add widget caching layer" }).click();
+      await expect(page).toHaveURL(new RegExp(`/terminal/${pullWorkspace.id}$`));
+      await expect(detailsToggle("PR")).toHaveClass(/active/);
+
+      await page.locator(".workspace-list-sidebar .ws-row", { hasText: "Add dark mode support" }).click();
+      await expect(page).toHaveURL(new RegExp(`/terminal/${issueWorkspace.id}$`));
+      await expect(detailsToggle("Issue")).toHaveClass(/active/);
     } finally {
       await api?.dispose();
       await isolatedServer?.stop();

--- a/frontend/tests/e2e/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar.spec.ts
@@ -2,6 +2,12 @@ import { expect, test } from "@playwright/test";
 
 import { mockApi } from "./support/mockApi";
 
+function clearWorkspaceSidebarTabStorage(): void {
+  for (const key of Object.keys(localStorage)) {
+    if (key.startsWith("kenn-forge-workspace-sidebar-tab:")) localStorage.removeItem(key);
+  }
+}
+
 function workspaceRepoRef(owner = "acme", name = "widgets", host = "github.com", provider = "github") {
   return {
     provider,
@@ -861,8 +867,8 @@ test("provider-aware detail mocks enforce provider and host identity", async ({ 
 
 test.describe("terminal state icons", () => {
   test.beforeEach(async ({ page }) => {
+    await page.addInitScript(clearWorkspaceSidebarTabStorage);
     await page.addInitScript(() => {
-      localStorage.removeItem("kenn-forge-workspace-sidebar-tab");
       localStorage.removeItem("kenn-forge-workspace-sidebar-open");
       localStorage.removeItem("kenn-forge-workspace-sidebar-width");
     });
@@ -1481,9 +1487,9 @@ test.describe("terminal state icons", () => {
 
 test.describe("workspace launch home", () => {
   test.beforeEach(async ({ page }) => {
+    await page.addInitScript(clearWorkspaceSidebarTabStorage);
     await page.addInitScript(() => {
       localStorage.removeItem("kenn-forge-workspace-list-sidebar-width");
-      localStorage.removeItem("kenn-forge-workspace-sidebar-tab");
       localStorage.removeItem("kenn-forge-workspace-sidebar-open");
       localStorage.removeItem("kenn-forge-workspace-sidebar-width");
     });
@@ -2569,9 +2575,9 @@ test.describe("workspace launch home", () => {
 test.describe("sidebar toggle behavior", () => {
   test.beforeEach(async ({ page }) => {
     // Clear any persisted sidebar state before each test.
+    await page.addInitScript(clearWorkspaceSidebarTabStorage);
     await page.addInitScript(() => {
       localStorage.removeItem("kenn-forge-workspace-list-sidebar-width");
-      localStorage.removeItem("kenn-forge-workspace-sidebar-tab");
       localStorage.removeItem("kenn-forge-workspace-sidebar-open");
       localStorage.removeItem("kenn-forge-workspace-sidebar-width");
     });
@@ -2869,9 +2875,9 @@ test.describe("sidebar toggle behavior", () => {
 
 test.describe("workspace list fleet inventory", () => {
   test.beforeEach(async ({ page }) => {
+    await page.addInitScript(clearWorkspaceSidebarTabStorage);
     await page.addInitScript(() => {
       localStorage.removeItem("kenn-forge-workspace-list-sidebar-width");
-      localStorage.removeItem("kenn-forge-workspace-sidebar-tab");
       localStorage.removeItem("kenn-forge-workspace-sidebar-open");
       localStorage.removeItem("kenn-forge-workspace-sidebar-width");
     });
@@ -3137,8 +3143,8 @@ test.describe("sidebar persistence", () => {
   });
 
   async function clearSidebarStorage(page: import("@playwright/test").Page): Promise<void> {
+    await page.evaluate(clearWorkspaceSidebarTabStorage);
     await page.evaluate(() => {
-      localStorage.removeItem("kenn-forge-workspace-sidebar-tab");
       localStorage.removeItem("kenn-forge-workspace-sidebar-open");
       localStorage.removeItem("kenn-forge-workspace-sidebar-width");
     });
@@ -3176,7 +3182,7 @@ test.describe("sidebar persistence", () => {
     await expect(reviewsBtn).toHaveClass(/active/);
 
     // Verify localStorage
-    const tab = await page.evaluate(() => localStorage.getItem("kenn-forge-workspace-sidebar-tab"));
+    const tab = await page.evaluate(() => localStorage.getItem("kenn-forge-workspace-sidebar-tab:ws-123"));
     expect(tab).toBe("reviews");
 
     // Reload
@@ -3230,8 +3236,8 @@ test.describe("sidebar persistence", () => {
 
 test.describe("sidebar PR tab", () => {
   test.beforeEach(async ({ page }) => {
+    await page.addInitScript(clearWorkspaceSidebarTabStorage);
     await page.addInitScript(() => {
-      localStorage.removeItem("kenn-forge-workspace-sidebar-tab");
       localStorage.removeItem("kenn-forge-workspace-sidebar-open");
       localStorage.removeItem("kenn-forge-workspace-sidebar-width");
     });
@@ -3270,8 +3276,8 @@ test.describe("sidebar PR tab", () => {
 
 test.describe("workspace list bubble opens right sidebar", () => {
   test.beforeEach(async ({ page }) => {
+    await page.addInitScript(clearWorkspaceSidebarTabStorage);
     await page.addInitScript(() => {
-      localStorage.removeItem("kenn-forge-workspace-sidebar-tab");
       localStorage.removeItem("kenn-forge-workspace-sidebar-open");
       localStorage.removeItem("kenn-forge-workspace-sidebar-width");
     });
@@ -3835,8 +3841,8 @@ test.describe("workspace list sorting", () => {
 
 test.describe("delayed-response navigation", () => {
   test.beforeEach(async ({ page }) => {
+    await page.addInitScript(clearWorkspaceSidebarTabStorage);
     await page.addInitScript(() => {
-      localStorage.removeItem("kenn-forge-workspace-sidebar-tab");
       localStorage.removeItem("kenn-forge-workspace-sidebar-open");
       localStorage.removeItem("kenn-forge-workspace-sidebar-width");
     });
@@ -4447,8 +4453,8 @@ test.describe("delayed-response navigation", () => {
 
 test.describe("issue workspace sidebar", () => {
   test.beforeEach(async ({ page }) => {
+    await page.addInitScript(clearWorkspaceSidebarTabStorage);
     await page.addInitScript(() => {
-      localStorage.removeItem("kenn-forge-workspace-sidebar-tab");
       localStorage.removeItem("kenn-forge-workspace-sidebar-open");
       localStorage.removeItem("kenn-forge-workspace-sidebar-width");
     });
@@ -4603,7 +4609,7 @@ test.describe("issue workspace sidebar", () => {
 
     await page.addInitScript(() => {
       localStorage.setItem("kenn-forge-workspace-sidebar-open", "true");
-      localStorage.setItem("kenn-forge-workspace-sidebar-tab", "issue");
+      localStorage.setItem("kenn-forge-workspace-sidebar-tab:ws-issue-7", "issue");
 
       const instances: Array<{
         listeners: Map<string, Set<(event: MessageEvent) => void>>;
@@ -4708,8 +4714,8 @@ test.describe("issue workspace sidebar", () => {
 
 test.describe("sidebar Reviews tab", () => {
   test.beforeEach(async ({ page }) => {
+    await page.addInitScript(clearWorkspaceSidebarTabStorage);
     await page.addInitScript(() => {
-      localStorage.removeItem("kenn-forge-workspace-sidebar-tab");
       localStorage.removeItem("kenn-forge-workspace-sidebar-open");
       localStorage.removeItem("kenn-forge-workspace-sidebar-width");
     });


### PR DESCRIPTION
Workspace detail tabs were remembered globally, so visiting a workspace without a linked PR forced every workspace back to Diff.

This keeps the selected details tab with the host-aware workspace identity. Unsupported tabs fall back only for the current live workspace, while sidebar visibility and width remain shared.