### PR TITLE
Preserve settings across the Kenn Forge rename

### DIFF
--- a/context/server-runtime.md
+++ b/context/server-runtime.md
@@ -16,6 +16,10 @@ and the root event stream.
   credential (`internal/runtimelock/token.go::EnsureAuthToken`).
 - Config loading establishes the canonical `data_dir` identity used by startup
   and reload comparisons (`internal/config/config.go::load`).
+- Default-home upgrades copy the legacy config and its referenced credential
+  files before marking completion and relocating the database; explicit config
+  paths and `KENN_FORGE_HOME` never relocate config
+  (`internal/config/legacy_migration.go::migrateLegacyConfig`).
 
 ## Startup Lock
 

--- a/docs/superpowers/plans/2026-07-31-legacy-config-migration.md
+++ b/docs/superpowers/plans/2026-07-31-legacy-config-migration.md
@@ -1,0 +1,49 @@
+# Legacy Config Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan directly in the current agent, task-by-task. Never use subagent-driven development. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Copy the legacy config and credential files it references so Kenn Forge starts with the same repositories and authentication.
+
+**Approved spec/design:** `docs/superpowers/specs/2026-07-31-legacy-config-migration-design.md`
+
+**Architecture:** On default-home startup, read and validate the legacy config, update renamed values and old-home paths, copy referenced token files and GitHub App keys, publish the config, then relocate the database. Marker `v1` recovers the initially shipped config-only migration; `v2` means config and credentials are complete.
+
+**Tech Stack:** Go filesystem APIs, the existing TOML config loader, and `testify`.
+
+## Constraints
+
+- Leave legacy source files intact.
+- Never replace a conflicting Kenn Forge config or credential file.
+- Do not migrate custom config paths or `KENN_FORGE_HOME` installations.
+- Preserve repository settings, credential contents, and file permissions.
+
+### Task 1: Reproduce the Empty Settings Regression
+
+**Files:**
+- Test: `internal/config/legacy_migration_test.go`
+- Test: `internal/config/legacy_migration_integration_test.go`
+
+- [x] Add a failing `LoadOrCreate` test proving legacy `[[repos]]` entries replace the untouched generated config.
+- [x] Add destination-conflict, invalid-config, and repeated-start coverage.
+- [x] Extend the database integration test to combine nested `data_dir`, repository config, and schema migration.
+- [x] Run the focused tests with `-shuffle=on` and confirm RED.
+
+### Task 2: Copy Config and Credentials
+
+**Files:**
+- Create: `internal/config/legacy_config_migration.go`
+- Modify: `internal/config/config.go`
+- Modify: `internal/config/legacy_migration.go`
+
+- [x] Validate and transform the legacy config before publishing it.
+- [x] Copy referenced `token_file` and `private_key_path` files beneath the legacy home.
+- [x] Preserve an existing identical credential and reject conflicting bytes.
+- [x] Let marker `v1` finish credential copying and publish marker `v2` afterward.
+- [x] Rebase nested legacy `data_dir` paths when relocating the database.
+
+### Task 3: Verify and Commit
+
+- [x] Run focused migration tests, the full config package, and config-package lint.
+- [x] Update `context/server-runtime.md` with the startup migration order.
+- [x] Run context structural validation and `git diff --check`.
+- [x] Commit through repository hooks without bypasses.

--- a/docs/superpowers/specs/2026-07-31-legacy-config-migration-design.md
+++ b/docs/superpowers/specs/2026-07-31-legacy-config-migration-design.md
@@ -1,0 +1,46 @@
+# Legacy Config Migration Design
+
+## Goal
+
+Preserve repository tracking and other user settings when an existing Middleman installation first starts as Kenn Forge. The migration copies the legacy default config into the Kenn Forge default home and leaves the original file intact for recovery. This design supersedes the database-only compatibility boundary in the July 30 rename design.
+
+## Scope
+
+This is a bounded, one-time forward migration from `~/.config/middleman/config.toml` to `~/.kenn/forge/config.toml`. It runs only when using Kenn Forge's default config path without `KENN_FORGE_HOME`; explicitly selected config paths remain authoritative and are not relocated.
+
+The migration handles two destination states:
+
+- If the Kenn Forge config does not exist, publish the migrated copy.
+- If startup already created the exact generated Kenn Forge default, replace that untouched default with the migrated copy. This repairs installations that have already encountered the rename regression.
+
+Any other existing destination is user state. If it differs from the migrated legacy config, startup fails with a conflict instead of merging or overwriting it. After publication, write a migration marker in the Kenn Forge home. Later startups check the marker and do not reread the legacy config, so edits to the recoverable source cannot overwrite live Kenn Forge settings. A restart between config publication and marker creation recognizes the identical migrated destination and finishes the marker step idempotently.
+
+The migration boundary remains only while direct upgrades from a Middleman release to Kenn Forge are supported. When that upgrade path is removed from the support policy, remove the legacy config reader, marker handling, and their tests together.
+
+## Transformation and Publication
+
+Read the legacy config, update only product-rename values that Kenn Forge owns, and preserve unrelated user choices. Known built-in `MIDDLEMAN_*` token environment names become their `KENN_FORGE_*` equivalents. Absolute paths rooted beneath the old default home are rebased beneath the Kenn Forge home; external paths and custom environment-variable names stay unchanged.
+
+Write the transformed bytes to a temporary file in the destination directory, preserve the source file mode, and load the temporary config through the normal parser and validation path. Atomically rename the validated file into place. The source config is copied, never removed.
+
+Config migration must happen before database relocation so a legacy custom `data_dir` remains authoritative when `middleman.db` is renamed to `forge.db`. The existing legacy-daemon lock and database conflict checks remain in force.
+
+## User-Visible Data Flow
+
+After startup loads the migrated config, `cfg.Repos` contains the legacy `[[repos]]` entries. The existing Settings endpoint returns those configured entries, and the Svelte settings view renders them without a UI-specific fallback to database rows.
+
+## Errors
+
+Startup fails closed with paths identifying the source and destination when:
+
+- the destination contains a non-default, conflicting config;
+- the transformed legacy config does not parse or validate; or
+- the existing database migration detects an active Middleman daemon or conflicting database files.
+
+No partial destination config is published after validation or write failure.
+
+## Verification
+
+Table-driven config tests cover a missing destination, the already-created generated default, idempotent reruns, conflicting user config, product-owned value/path rewrites, preservation of custom values and file mode, and parse/validation failure. An integration test starts from a legacy config with tracked repositories and proves `LoadOrCreate` returns those repositories alongside the relocated database.
+
+The focused config package tests run first, followed by the repository's short Go suite. No Svelte change is required because the UI already renders the settings API correctly once startup loads the right config.

--- a/docs/superpowers/specs/2026-07-31-legacy-config-migration-design.md
+++ b/docs/superpowers/specs/2026-07-31-legacy-config-migration-design.md
@@ -13,13 +13,15 @@ The migration handles two destination states:
 - If the Kenn Forge config does not exist, publish the migrated copy.
 - If startup already created the exact generated Kenn Forge default, replace that untouched default with the migrated copy. This repairs installations that have already encountered the rename regression.
 
-Any other existing destination is user state. If it differs from the migrated legacy config, startup fails with a conflict instead of merging or overwriting it. After publication, write a migration marker in the Kenn Forge home. Later startups check the marker and do not reread the legacy config, so edits to the recoverable source cannot overwrite live Kenn Forge settings. A restart between config publication and marker creation recognizes the identical migrated destination and finishes the marker step idempotently.
+Any other existing destination is user state. If it differs from the migrated legacy config, startup fails with a conflict instead of merging or overwriting it. After config and credential publication, write migration marker version `v2` in the Kenn Forge home. Later startups check the marker and do not reread the legacy config, so edits to the recoverable source cannot overwrite live Kenn Forge settings. Marker `v1` means the config was published by the incomplete migration but referenced credentials still need copying; completing those copies upgrades the marker to `v2`. A restart between publication and marker creation recognizes identical destinations and finishes idempotently.
 
 The migration boundary remains only while direct upgrades from a Middleman release to Kenn Forge are supported. When that upgrade path is removed from the support policy, remove the legacy config reader, marker handling, and their tests together.
 
 ## Transformation and Publication
 
-Read the legacy config, update only product-rename values that Kenn Forge owns, and preserve unrelated user choices. Known built-in `MIDDLEMAN_*` token environment names become their `KENN_FORGE_*` equivalents. Absolute paths rooted beneath the old default home are rebased beneath the Kenn Forge home; external paths and custom environment-variable names stay unchanged.
+Read the legacy config, update only product-rename values that Kenn Forge owns, and preserve user settings. Known built-in `MIDDLEMAN_*` token environment names become their `KENN_FORGE_*` equivalents. Paths rooted beneath the old default home are rebased beneath the Kenn Forge home; external paths and custom environment-variable names stay unchanged.
+
+Copy every referenced token file and GitHub App private key whose effective source is beneath the old default home. Relative credential paths resolve beneath the old and new config homes; absolute paths are rebased only when contained by the old home. Preserve file contents and permissions, leave each source intact, accept an identical destination, and fail rather than overwrite conflicting credential bytes.
 
 Write the transformed bytes to a temporary file in the destination directory, preserve the source file mode, and load the temporary config through the normal parser and validation path. Atomically rename the validated file into place. The source config is copied, never removed.
 
@@ -35,12 +37,13 @@ Startup fails closed with paths identifying the source and destination when:
 
 - the destination contains a non-default, conflicting config;
 - the transformed legacy config does not parse or validate; or
+- a referenced credential is missing or conflicts with its destination; or
 - the existing database migration detects an active Middleman daemon or conflicting database files.
 
 No partial destination config is published after validation or write failure.
 
 ## Verification
 
-Table-driven config tests cover a missing destination, the already-created generated default, idempotent reruns, conflicting user config, product-owned value/path rewrites, preservation of custom values and file mode, and parse/validation failure. An integration test starts from a legacy config with tracked repositories and proves `LoadOrCreate` returns those repositories alongside the relocated database.
+Table-driven config tests cover a missing destination, the already-created generated default, `v1` recovery, idempotent reruns, conflicting user config/credentials, product-owned value/path rewrites, preserved custom values and file modes, and parse/validation failure. An integration test starts from a legacy config with tracked repositories and proves `LoadOrCreate` returns those repositories alongside the relocated database.
 
 The focused config package tests run first, followed by the repository's short Go suite. No Svelte change is required because the UI already renders the settings API correctly once startup loads the right config.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -947,28 +947,7 @@ func homeDir() string {
 	return h
 }
 
-// EnsureDefault creates a default config file at path if it does not exist.
-// The file contains sensible defaults. Repos can be added later through the
-// settings UI.
-//
-// Writes to a temp file first, then hard-links into place so the target
-// path is never left empty or partially written.
-func EnsureDefault(path string) error {
-	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return fmt.Errorf("creating config directory: %w", err)
-	}
-
-	tmp, err := os.CreateTemp(dir, ".config-*.tmp")
-	if err != nil {
-		if _, statErr := os.Stat(path); statErr == nil {
-			return nil
-		}
-		return fmt.Errorf("creating temp config: %w", err)
-	}
-	tmpPath := tmp.Name()
-	defer os.Remove(tmpPath)
-
+func defaultConfigContents() string {
 	const defaultConfig = `# kenn-forge configuration
 # See https://github.com/wesm/kenn-forge for documentation.
 
@@ -1038,7 +1017,32 @@ batch_size = 25
 [tmux]
 agent_sessions = true
 `
-	if _, err := tmp.WriteString(defaultConfig); err != nil {
+	return defaultConfig
+}
+
+// EnsureDefault creates a default config file at path if it does not exist.
+// The file contains sensible defaults. Repos can be added later through the
+// settings UI.
+//
+// Writes to a temp file first, then hard-links into place so the target
+// path is never left empty or partially written.
+func EnsureDefault(path string) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("creating config directory: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(dir, ".config-*.tmp")
+	if err != nil {
+		if _, statErr := os.Stat(path); statErr == nil {
+			return nil
+		}
+		return fmt.Errorf("creating temp config: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+
+	if _, err := tmp.WriteString(defaultConfigContents()); err != nil {
 		tmp.Close()
 		return fmt.Errorf("writing default config: %w", err)
 	}

--- a/internal/config/legacy_config_migration.go
+++ b/internal/config/legacy_config_migration.go
@@ -1,0 +1,213 @@
+package config
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const legacyConfigMigrationMarker = ".legacy-config-migrated"
+
+var legacyConfigValueReplacements = [][2]string{
+	{"MIDDLEMAN_GITHUB_TOKEN", "KENN_FORGE_GITHUB_TOKEN"},
+	{"MIDDLEMAN_GITLAB_TOKEN", "KENN_FORGE_GITLAB_TOKEN"},
+	{"MIDDLEMAN_FORGEJO_TOKEN", "KENN_FORGE_FORGEJO_TOKEN"},
+	{"MIDDLEMAN_GITEA_TOKEN", "KENN_FORGE_GITEA_TOKEN"},
+}
+
+func migrateLegacyConfig(configPath string) error {
+	if os.Getenv("KENN_FORGE_HOME") != "" ||
+		filepath.Clean(configPath) != filepath.Clean(DefaultConfigPath()) {
+		return nil
+	}
+
+	oldHome := legacyDefaultHome()
+	newHome := DefaultDataDir()
+	markerPath := filepath.Join(newHome, legacyConfigMigrationMarker)
+	markerVersion, err := readLegacyConfigMigrationMarker(markerPath)
+	if err != nil {
+		return err
+	}
+	if markerVersion == "v2\n" {
+		return nil
+	}
+
+	sourcePath := filepath.Join(oldHome, "config.toml")
+	source, err := os.ReadFile(sourcePath)
+	if errors.Is(err, os.ErrNotExist) {
+		if markerVersion == "v1\n" {
+			return fmt.Errorf("complete legacy config migration from %s: source config is missing", sourcePath)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read legacy config %s: %w", sourcePath, err)
+	}
+	sourceInfo, err := os.Stat(sourcePath)
+	if err != nil {
+		return fmt.Errorf("inspect legacy config %s: %w", sourcePath, err)
+	}
+	legacyConfig, err := Load(sourcePath)
+	if err != nil {
+		return fmt.Errorf("load legacy config %s for migration to %s: %w", sourcePath, configPath, err)
+	}
+	transformed, err := transformLegacyConfig(source, oldHome, newHome)
+	if err != nil {
+		return fmt.Errorf("transform legacy config %s: %w", sourcePath, err)
+	}
+
+	if err := os.MkdirAll(newHome, 0o700); err != nil {
+		return fmt.Errorf("create Kenn Forge config directory %s: %w", newHome, err)
+	}
+	tmp, err := os.CreateTemp(newHome, ".legacy-config-*.toml")
+	if err != nil {
+		return fmt.Errorf("create migrated config beside %s: %w", configPath, err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if err := tmp.Chmod(sourceInfo.Mode().Perm()); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("preserve legacy config mode from %s: %w", sourcePath, err)
+	}
+	if _, err := tmp.Write(transformed); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write migrated config for %s: %w", configPath, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close migrated config for %s: %w", configPath, err)
+	}
+	if _, err := Load(tmpPath); err != nil {
+		return fmt.Errorf("validate legacy config migration from %s to %s: %w", sourcePath, configPath, err)
+	}
+
+	if err := copyLegacyCredentialPaths(legacyConfig, oldHome, newHome); err != nil {
+		return err
+	}
+
+	destination, err := os.ReadFile(configPath)
+	switch {
+	case markerVersion == "v1\n":
+		if err != nil {
+			return fmt.Errorf("complete legacy config migration to %s: %w", configPath, err)
+		}
+	case errors.Is(err, os.ErrNotExist):
+		if err := os.Rename(tmpPath, configPath); err != nil {
+			return fmt.Errorf("publish migrated config %s: %w", configPath, err)
+		}
+	case err != nil:
+		return fmt.Errorf("inspect Kenn Forge config %s: %w", configPath, err)
+	case bytes.Equal(destination, transformed):
+	case bytes.Equal(destination, []byte(defaultConfigContents())):
+		if err := os.Rename(tmpPath, configPath); err != nil {
+			return fmt.Errorf("replace generated config %s: %w", configPath, err)
+		}
+	default:
+		return fmt.Errorf("legacy config %s conflicts with existing Kenn Forge config %s", sourcePath, configPath)
+	}
+
+	return writeLegacyConfigMigrationMarker(markerPath)
+}
+
+func transformLegacyConfig(body []byte, oldHome, newHome string) ([]byte, error) {
+	out := bytes.Clone(body)
+	for _, replacement := range legacyConfigValueReplacements {
+		out = bytes.ReplaceAll(out, []byte(`"`+replacement[0]+`"`), []byte(`"`+replacement[1]+`"`))
+		out = bytes.ReplaceAll(out, []byte(`'`+replacement[0]+`'`), []byte(`'`+replacement[1]+`'`))
+	}
+	out = bytes.ReplaceAll(out, []byte(filepath.Clean(oldHome)), []byte(filepath.Clean(newHome)))
+	return out, nil
+}
+
+func copyLegacyCredentialPaths(cfg *Config, oldHome, newHome string) error {
+	var paths []string
+	for _, repo := range cfg.Repos {
+		paths = append(paths, repo.TokenFile)
+	}
+	for _, platform := range cfg.Platforms {
+		paths = append(paths, platform.TokenFile)
+	}
+	for _, owner := range cfg.GitHubOwnerTokens {
+		paths = append(paths, owner.TokenFile)
+	}
+	for _, app := range cfg.GitHubApps {
+		paths = append(paths, app.PrivateKeyPath)
+	}
+
+	seen := make(map[string]struct{})
+	for _, sourcePath := range paths {
+		destinationPath, contained := rebaseLegacyPath(sourcePath, oldHome, newHome)
+		if sourcePath == "" || !contained {
+			continue
+		}
+		if _, ok := seen[destinationPath]; ok {
+			continue
+		}
+		seen[destinationPath] = struct{}{}
+		if err := copyLegacyCredential(sourcePath, destinationPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func rebaseLegacyPath(sourcePath, oldHome, newHome string) (string, bool) {
+	relative, err := filepath.Rel(filepath.Clean(oldHome), filepath.Clean(sourcePath))
+	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	return filepath.Join(newHome, relative), true
+}
+
+func copyLegacyCredential(sourcePath, destinationPath string) error {
+	body, err := os.ReadFile(sourcePath)
+	if err != nil {
+		return fmt.Errorf("read legacy credential %s for %s: %w", sourcePath, destinationPath, err)
+	}
+	info, err := os.Stat(sourcePath)
+	if err != nil {
+		return fmt.Errorf("inspect legacy credential %s for %s: %w", sourcePath, destinationPath, err)
+	}
+	if destination, err := os.ReadFile(destinationPath); err == nil {
+		if bytes.Equal(destination, body) {
+			return nil
+		}
+		return fmt.Errorf("legacy credential %s conflicts with existing destination %s", sourcePath, destinationPath)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("inspect credential destination %s: %w", destinationPath, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(destinationPath), 0o700); err != nil {
+		return fmt.Errorf("create credential directory for %s: %w", destinationPath, err)
+	}
+	if err := os.WriteFile(destinationPath, body, info.Mode().Perm()); err != nil {
+		return fmt.Errorf("copy legacy credential %s to %s: %w", sourcePath, destinationPath, err)
+	}
+	return nil
+}
+
+func readLegacyConfigMigrationMarker(markerPath string) (string, error) {
+	body, err := os.ReadFile(markerPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("read legacy config migration marker %s: %w", markerPath, err)
+	}
+	if string(body) != "v1\n" && string(body) != "v2\n" {
+		return "", fmt.Errorf("legacy config migration marker %s has unknown contents", markerPath)
+	}
+	return string(body), nil
+}
+
+func writeLegacyConfigMigrationMarker(markerPath string) error {
+	if err := os.WriteFile(markerPath, []byte("v2\n"), 0o600); err != nil {
+		return fmt.Errorf("write legacy config migration marker %s: %w", markerPath, err)
+	}
+	return nil
+}
+
+func legacyDefaultHome() string {
+	return filepath.Join(homeDir(), ".config", "middleman")
+}

--- a/internal/config/legacy_migration.go
+++ b/internal/config/legacy_migration.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/BurntSushi/toml"
 	"github.com/gofrs/flock"
@@ -16,8 +17,11 @@ const (
 	forgeDatabaseFile  = "forge.db"
 )
 
-// LoadOrCreate relocates a legacy database before creating or loading config.
+// LoadOrCreate relocates legacy config and database state before loading it.
 func LoadOrCreate(path string) (*Config, error) {
+	if err := migrateLegacyConfig(path); err != nil {
+		return nil, err
+	}
 	if err := migrateLegacyDatabase(path); err != nil {
 		return nil, err
 	}
@@ -88,10 +92,17 @@ func legacyDatabaseDirectories(configPath string) (string, string, error) {
 			return "", "", err
 		}
 		if os.Getenv("KENN_FORGE_HOME") == "" && filepath.Clean(configPath) == filepath.Clean(DefaultConfigPath()) {
-			oldDefault := filepath.Join(homeDir(), ".config", "middleman")
 			exists, err := legacyDatabaseExists(dataDir)
 			if err != nil || exists {
 				return dataDir, dataDir, err
+			}
+			oldDefault := legacyDefaultHome()
+			legacyDataDir, mapped := legacyDataDirectory(dataDir, oldDefault)
+			if mapped && filepath.Clean(legacyDataDir) != filepath.Clean(dataDir) {
+				exists, err = legacyDatabaseExists(legacyDataDir)
+				if err != nil || exists {
+					return legacyDataDir, dataDir, err
+				}
 			}
 			exists, err = legacyDatabaseExists(oldDefault)
 			if err != nil || exists {
@@ -105,7 +116,18 @@ func legacyDatabaseDirectories(configPath string) (string, string, error) {
 	if os.Getenv("KENN_FORGE_HOME") != "" || filepath.Clean(configPath) != filepath.Clean(DefaultConfigPath()) {
 		return "", "", nil
 	}
-	return filepath.Join(homeDir(), ".config", "middleman"), DefaultDataDir(), nil
+	return legacyDefaultHome(), DefaultDataDir(), nil
+}
+
+func legacyDataDirectory(dataDir, oldDefault string) (string, bool) {
+	relative, err := filepath.Rel(DefaultDataDir(), dataDir)
+	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	if relative == "." {
+		return oldDefault, true
+	}
+	return filepath.Join(oldDefault, relative), true
 }
 
 func legacyDatabaseExists(dataDir string) (bool, error) {

--- a/internal/config/legacy_migration_integration_test.go
+++ b/internal/config/legacy_migration_integration_test.go
@@ -2,6 +2,7 @@ package config_test
 
 import (
 	"database/sql"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -22,8 +23,16 @@ func TestLegacyDatabaseRelocationAppliesSchemaIdentityMigration(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("KENN_FORGE_HOME", "")
-	legacyPath := filepath.Join(home, ".config", "middleman", "middleman.db")
+	legacyHome := filepath.Join(home, ".config", "middleman")
+	legacyDataDir := filepath.Join(legacyHome, "state")
+	forgeDataDir := filepath.Join(home, ".kenn", "forge", "state")
+	legacyPath := filepath.Join(legacyDataDir, "middleman.db")
 	require.NoError(os.MkdirAll(filepath.Dir(legacyPath), 0o700))
+	legacyConfig := fmt.Sprintf(
+		"data_dir = %q\n[[repos]]\nowner = \"acme\"\nname = \"widget\"\n",
+		legacyDataDir,
+	)
+	require.NoError(os.WriteFile(filepath.Join(legacyHome, "config.toml"), []byte(legacyConfig), 0o600))
 
 	database := dbtest.OpenAt(t, legacyPath)
 	_, err := database.WriteDB().Exec(`
@@ -54,6 +63,12 @@ func TestLegacyDatabaseRelocationAppliesSchemaIdentityMigration(t *testing.T) {
 
 	cfg, err := config.LoadOrCreate(config.DefaultConfigPath())
 	require.NoError(err)
+	canonicalForgeDataDir, err := filepath.EvalSymlinks(forgeDataDir)
+	require.NoError(err)
+	require.Len(cfg.Repos, 1)
+	assert.Equal("acme", cfg.Repos[0].Owner)
+	assert.Equal("widget", cfg.Repos[0].Name)
+	assert.Equal(canonicalForgeDataDir, cfg.DataDir)
 	forgePath := filepath.Join(cfg.DataDir, "forge.db")
 	database = dbtest.OpenWithMigrationsAt(t, forgePath)
 

--- a/internal/config/legacy_migration_test.go
+++ b/internal/config/legacy_migration_test.go
@@ -3,12 +3,342 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gofrs/flock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestLoadOrCreateCopiesLegacyDefaultConfig(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("KENN_FORGE_HOME", "")
+	oldHome := filepath.Join(home, ".config", "middleman")
+	require.NoError(os.MkdirAll(oldHome, 0o700))
+	legacy := "github_token_env = \"MIDDLEMAN_GITHUB_TOKEN\"\n" +
+		"[[repos]]\nowner = \"acme\"\nname = \"widgets\"\n"
+	source := filepath.Join(oldHome, "config.toml")
+	require.NoError(os.WriteFile(source, []byte(legacy), 0o640))
+
+	cfg, err := LoadOrCreate(DefaultConfigPath())
+	require.NoError(err)
+
+	require.Len(cfg.Repos, 1)
+	assert.Equal("acme", cfg.Repos[0].Owner)
+	assert.Equal("widgets", cfg.Repos[0].Name)
+	assert.Equal("KENN_FORGE_GITHUB_TOKEN", cfg.GitHubTokenEnv)
+	assert.FileExists(source)
+	assert.FileExists(filepath.Join(DefaultDataDir(), ".legacy-config-migrated"))
+	info, err := os.Stat(DefaultConfigPath())
+	require.NoError(err)
+	assert.Equal(os.FileMode(0o640), info.Mode().Perm())
+	dirInfo, err := os.Stat(DefaultDataDir())
+	require.NoError(err)
+	assert.Equal(os.FileMode(0o700), dirInfo.Mode().Perm())
+}
+
+func TestLoadOrCreateLegacyConfigDestinationStates(t *testing.T) {
+	tests := []struct {
+		name               string
+		prepareDestination func(t *testing.T, destination, migrated string)
+		wantError          bool
+	}{
+		{name: "missing destination"},
+		{
+			name: "generated default",
+			prepareDestination: func(t *testing.T, destination, _ string) {
+				require.NoError(t, EnsureDefault(destination))
+			},
+		},
+		{
+			name: "identical migration without marker",
+			prepareDestination: func(t *testing.T, destination, migrated string) {
+				require.NoError(t, os.MkdirAll(filepath.Dir(destination), 0o700))
+				require.NoError(t, os.WriteFile(destination, []byte(migrated), 0o600))
+			},
+		},
+		{
+			name: "conflicting destination",
+			prepareDestination: func(t *testing.T, destination, _ string) {
+				require.NoError(t, os.MkdirAll(filepath.Dir(destination), 0o700))
+				require.NoError(t, os.WriteFile(destination, []byte("[[repos]]\nowner = \"other\"\nname = \"repo\"\n"), 0o600))
+			},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("KENN_FORGE_HOME", "")
+			oldHome := filepath.Join(home, ".config", "middleman")
+			newHome := filepath.Join(home, ".kenn", "forge")
+			require.NoError(os.MkdirAll(oldHome, 0o700))
+			legacy := "[[repos]]\nowner = \"acme\"\nname = \"widgets\"\n"
+			source := filepath.Join(oldHome, "config.toml")
+			destination := filepath.Join(newHome, "config.toml")
+			require.NoError(os.WriteFile(source, []byte(legacy), 0o600))
+			if tt.prepareDestination != nil {
+				tt.prepareDestination(t, destination, legacy)
+			}
+			before, beforeErr := os.ReadFile(destination)
+
+			cfg, err := LoadOrCreate(destination)
+			if tt.wantError {
+				require.Error(err)
+				assert.Contains(err.Error(), source)
+				assert.Contains(err.Error(), destination)
+				after, readErr := os.ReadFile(destination)
+				require.NoError(readErr)
+				assert.Equal(before, after)
+				assert.NoFileExists(filepath.Join(newHome, ".legacy-config-migrated"))
+				return
+			}
+
+			require.NoError(err)
+			require.Len(cfg.Repos, 1)
+			assert.Equal("acme", cfg.Repos[0].Owner)
+			assert.Equal("widgets", cfg.Repos[0].Name)
+			assert.FileExists(filepath.Join(newHome, ".legacy-config-migrated"))
+			if beforeErr != nil {
+				assert.ErrorIs(beforeErr, os.ErrNotExist)
+			}
+		})
+	}
+}
+
+func TestLoadOrCreateLegacyConfigMarkerStopsFutureLegacyReads(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("KENN_FORGE_HOME", "")
+	oldHome := filepath.Join(home, ".config", "middleman")
+	require.NoError(os.MkdirAll(oldHome, 0o700))
+	source := filepath.Join(oldHome, "config.toml")
+	require.NoError(os.WriteFile(source, []byte("[[repos]]\nowner = \"acme\"\nname = \"widgets\"\n"), 0o600))
+	_, err := LoadOrCreate(DefaultConfigPath())
+	require.NoError(err)
+	live, err := os.ReadFile(DefaultConfigPath())
+	require.NoError(err)
+	live = append(live, []byte("\n# live Kenn Forge edit\n")...)
+	require.NoError(os.WriteFile(DefaultConfigPath(), live, 0o600))
+	require.NoError(os.WriteFile(source, []byte("[[repos]]\nowner ="), 0o600))
+
+	cfg, err := LoadOrCreate(DefaultConfigPath())
+	require.NoError(err)
+
+	require.Len(cfg.Repos, 1)
+	assert.Equal("acme", cfg.Repos[0].Owner)
+	after, err := os.ReadFile(DefaultConfigPath())
+	require.NoError(err)
+	assert.Contains(string(after), "live Kenn Forge edit")
+}
+
+func TestLoadOrCreateTransformsOnlyProductOwnedLegacyValues(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("KENN_FORGE_HOME", "")
+	oldHome := filepath.Join(home, ".config", "middleman")
+	newHome := filepath.Join(home, ".kenn", "forge")
+	require.NoError(os.MkdirAll(oldHome, 0o700))
+	require.NoError(os.MkdirAll(filepath.Join(oldHome, "tokens"), 0o700))
+	require.NoError(os.WriteFile(filepath.Join(oldHome, "tokens", "repo"), []byte("repo-token\n"), 0o600))
+	legacy := strings.Join([]string{
+		"github_token_env = 'MIDDLEMAN_GITHUB_TOKEN' # keep token comment",
+		"data_dir = '" + oldHome + "'",
+		"[[repos]]",
+		"owner = 'acme'",
+		"name = 'widgets'",
+		"token_env = \"MIDDLEMAN_GITHUB_TOKEN_ORG_A\"",
+		"token_file = '" + filepath.Join(oldHome, "tokens", "repo") + "'",
+		"worktree_base_path = '/opt/worktrees'",
+		"[[platforms]]",
+		"type = 'gitlab'",
+		"host = 'gitlab.example'",
+		"token_env = 'MIDDLEMAN_GITLAB_TOKEN'",
+		"",
+	}, "\n")
+	require.NoError(os.WriteFile(filepath.Join(oldHome, "config.toml"), []byte(legacy), 0o600))
+
+	_, err := LoadOrCreate(DefaultConfigPath())
+	require.NoError(err)
+	body, err := os.ReadFile(DefaultConfigPath())
+	require.NoError(err)
+	migrated := string(body)
+
+	assert.Contains(migrated, "github_token_env = 'KENN_FORGE_GITHUB_TOKEN' # keep token comment")
+	assert.Contains(migrated, "token_env = 'KENN_FORGE_GITLAB_TOKEN'")
+	assert.Contains(migrated, "token_env = \"MIDDLEMAN_GITHUB_TOKEN_ORG_A\"")
+	assert.Contains(migrated, "data_dir = '"+newHome+"'")
+	assert.Contains(migrated, "token_file = '"+filepath.Join(newHome, "tokens", "repo")+"'")
+	assert.Contains(migrated, "worktree_base_path = '/opt/worktrees'")
+}
+
+func TestLoadOrCreateRejectsInvalidLegacyConfigBeforePublishing(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("KENN_FORGE_HOME", "")
+	oldHome := filepath.Join(home, ".config", "middleman")
+	newHome := filepath.Join(home, ".kenn", "forge")
+	require.NoError(os.MkdirAll(oldHome, 0o700))
+	source := filepath.Join(oldHome, "config.toml")
+	legacy := []byte("[[repos]]\nowner =")
+	require.NoError(os.WriteFile(source, legacy, 0o600))
+
+	_, err := LoadOrCreate(DefaultConfigPath())
+	require.Error(err)
+
+	assert.Contains(err.Error(), source)
+	assert.Contains(err.Error(), DefaultConfigPath())
+	assert.NoFileExists(DefaultConfigPath())
+	assert.NoFileExists(filepath.Join(newHome, ".legacy-config-migrated"))
+	after, err := os.ReadFile(source)
+	require.NoError(err)
+	assert.Equal(legacy, after)
+}
+
+func TestLoadOrCreateCopiesLegacyCredentialFiles(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("KENN_FORGE_HOME", "")
+	oldHome := filepath.Join(home, ".config", "middleman")
+	newHome := filepath.Join(home, ".kenn", "forge")
+	oldToken := filepath.Join(oldHome, "tokens", "repo.token")
+	oldKey := filepath.Join(oldHome, "github-app.pem")
+	require.NoError(os.MkdirAll(filepath.Dir(oldToken), 0o700))
+	tokenBody := []byte("repo-token\n")
+	keyBody := []byte("private-key\n")
+	require.NoError(os.WriteFile(oldToken, tokenBody, 0o640))
+	require.NoError(os.WriteFile(oldKey, keyBody, 0o600))
+	legacy := strings.Join([]string{
+		"[[repos]]",
+		"owner = 'acme'",
+		"name = 'widgets'",
+		"token_file = 'tokens/repo.token'",
+		"[[github_apps]]",
+		"host = 'github.com'",
+		"app_id = 42",
+		"private_key_path = '" + oldKey + "'",
+		"",
+	}, "\n")
+	require.NoError(os.WriteFile(filepath.Join(oldHome, "config.toml"), []byte(legacy), 0o600))
+
+	cfg, err := LoadOrCreate(DefaultConfigPath())
+	require.NoError(err)
+
+	require.Len(cfg.Repos, 1)
+	require.Len(cfg.GitHubApps, 1)
+	newToken := filepath.Join(newHome, "tokens", "repo.token")
+	newKey := filepath.Join(newHome, "github-app.pem")
+	assert.Equal(newToken, cfg.Repos[0].TokenFile)
+	assert.Equal(newKey, cfg.GitHubApps[0].PrivateKeyPath)
+	copiedToken, err := os.ReadFile(newToken)
+	require.NoError(err)
+	copiedKey, err := os.ReadFile(newKey)
+	require.NoError(err)
+	assert.Equal(tokenBody, copiedToken)
+	assert.Equal(keyBody, copiedKey)
+	tokenInfo, err := os.Stat(newToken)
+	require.NoError(err)
+	keyInfo, err := os.Stat(newKey)
+	require.NoError(err)
+	assert.Equal(os.FileMode(0o640), tokenInfo.Mode().Perm())
+	assert.Equal(os.FileMode(0o600), keyInfo.Mode().Perm())
+	marker, err := os.ReadFile(filepath.Join(newHome, legacyConfigMigrationMarker))
+	require.NoError(err)
+	assert.Equal("v2\n", string(marker))
+	oldTokenAfter, err := os.ReadFile(oldToken)
+	require.NoError(err)
+	oldKeyAfter, err := os.ReadFile(oldKey)
+	require.NoError(err)
+	assert.Equal(tokenBody, oldTokenAfter)
+	assert.Equal(keyBody, oldKeyAfter)
+}
+
+func TestLoadOrCreateCompletesV1CredentialMigration(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("KENN_FORGE_HOME", "")
+	oldHome := filepath.Join(home, ".config", "middleman")
+	newHome := filepath.Join(home, ".kenn", "forge")
+	oldKey := filepath.Join(oldHome, "github-app.pem")
+	newKey := filepath.Join(newHome, "github-app.pem")
+	require.NoError(os.MkdirAll(oldHome, 0o700))
+	require.NoError(os.MkdirAll(newHome, 0o700))
+	keyBody := []byte("private-key\n")
+	require.NoError(os.WriteFile(oldKey, keyBody, 0o600))
+	legacy := "[[github_apps]]\nhost = 'github.com'\napp_id = 42\nprivate_key_path = '" + oldKey + "'\n"
+	require.NoError(os.WriteFile(filepath.Join(oldHome, "config.toml"), []byte(legacy), 0o600))
+	migrated, err := transformLegacyConfig([]byte(legacy), oldHome, newHome)
+	require.NoError(err)
+	require.NoError(os.WriteFile(DefaultConfigPath(), migrated, 0o600))
+	markerPath := filepath.Join(newHome, legacyConfigMigrationMarker)
+	require.NoError(os.WriteFile(markerPath, []byte("v1\n"), 0o600))
+
+	cfg, err := LoadOrCreate(DefaultConfigPath())
+	require.NoError(err)
+
+	require.Len(cfg.GitHubApps, 1)
+	assert.Equal(newKey, cfg.GitHubApps[0].PrivateKeyPath)
+	copied, err := os.ReadFile(newKey)
+	require.NoError(err)
+	assert.Equal(keyBody, copied)
+	marker, err := os.ReadFile(markerPath)
+	require.NoError(err)
+	assert.Equal("v2\n", string(marker))
+}
+
+func TestLoadOrCreateRejectsConflictingCredentialFile(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("KENN_FORGE_HOME", "")
+	oldHome := filepath.Join(home, ".config", "middleman")
+	newHome := filepath.Join(home, ".kenn", "forge")
+	oldKey := filepath.Join(oldHome, "github-app.pem")
+	newKey := filepath.Join(newHome, "github-app.pem")
+	require.NoError(os.MkdirAll(oldHome, 0o700))
+	require.NoError(os.MkdirAll(newHome, 0o700))
+	require.NoError(os.WriteFile(oldKey, []byte("legacy-key\n"), 0o600))
+	legacy := "[[github_apps]]\nhost = 'github.com'\napp_id = 42\nprivate_key_path = '" + oldKey + "'\n"
+	require.NoError(os.WriteFile(filepath.Join(oldHome, "config.toml"), []byte(legacy), 0o600))
+	migrated, err := transformLegacyConfig([]byte(legacy), oldHome, newHome)
+	require.NoError(err)
+	require.NoError(os.WriteFile(DefaultConfigPath(), migrated, 0o600))
+	markerPath := filepath.Join(newHome, legacyConfigMigrationMarker)
+	require.NoError(os.WriteFile(markerPath, []byte("v1\n"), 0o600))
+	conflict := []byte("different-key\n")
+	require.NoError(os.WriteFile(newKey, conflict, 0o600))
+
+	_, err = LoadOrCreate(DefaultConfigPath())
+	require.Error(err)
+
+	assert.Contains(err.Error(), oldKey)
+	assert.Contains(err.Error(), newKey)
+	after, err := os.ReadFile(newKey)
+	require.NoError(err)
+	assert.Equal(conflict, after)
+	marker, err := os.ReadFile(markerPath)
+	require.NoError(err)
+	assert.Equal("v1\n", string(marker))
+}
 
 func TestLoadOrCreateMovesLegacyDefaultDatabase(t *testing.T) {
 	require := require.New(t)

--- a/internal/github/graphql_live_test.go
+++ b/internal/github/graphql_live_test.go
@@ -24,8 +24,8 @@ func TestLiveGraphQLQueriesValidateAgainstGitHub(t *testing.T) {
 
 	var prQuery gqlPRQuery[gqlPR]
 	vars := map[string]any{
-		"owner":    githubv4.String("wesm"),
-		"name":     githubv4.String("kenn-forge"),
+		"owner":    githubv4.String("kenn-io"),
+		"name":     githubv4.String("middleman"),
 		"pageSize": githubv4.Int(1),
 		"cursor":   (*githubv4.String)(nil),
 	}


### PR DESCRIPTION
Kenn Forge moved the database but left existing repository configuration and credential files in the Middleman home, causing Settings to appear empty and GitHub App startup to fail.

- Carry tracked repositories and other config into the default Kenn Forge home
- Carry referenced token files and GitHub App keys while preserving source files
- Recover installs that completed the config-only migration

<sup>generated by a clanker</sup>