### PR TITLE
Open terminal hyperlinks safely

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,13 +20,14 @@
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/state": "^6.6.0",
         "@codemirror/view": "^6.43.0",
+        "@kenn-forge/ui": "workspace:*",
         "@kenn-io/kit-ui": "github:kenn-io/kit-ui#97be355ef25a02ce96de6da4f3627ed5b922c4c3",
         "@lucide/svelte": "1.23.0",
-        "@kenn-forge/ui": "workspace:*",
         "@pierre/diffs": "1.2.12",
         "@pierre/trees": "1.0.0-beta.5",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-ligatures": "^0.10.0",
+        "@xterm/addon-web-links": "^0.12.0",
         "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
         "@xyflow/svelte": "^1.6.1",
@@ -235,6 +236,10 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@kenn-forge/github-app-ui": ["@kenn-forge/github-app-ui@workspace:packages/github-app-ui"],
+
+    "@kenn-forge/ui": ["@kenn-forge/ui@workspace:packages/ui"],
+
     "@kenn-io/kit-ui": ["@kenn-io/kit-ui@github:kenn-io/kit-ui#97be355", { "peerDependencies": { "@lucide/svelte": ">=1.0.0", "dompurify": "^3.2.0", "marked": "^18.0.0", "mermaid": ">=11.15.0 <12", "shiki": "^4.0.0", "svelte": "^5.29.0" }, "optionalPeers": ["mermaid"], "bin": { "kit-ui-check": "./bin/kit-ui-check.mjs" } }, "kenn-io-kit-ui-97be355", "sha512-a439Xq53a+fp42MuXIVzO6MvS9XpyNjnbqiJPElIAIK5PYZZJMh0B13n94BY4XVJ5UlPh63IOSWFo/IdBW8+Wg=="],
 
     "@lezer/common": ["@lezer/common@1.5.2", "", {}, "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ=="],
@@ -256,10 +261,6 @@
     "@marijn/find-cluster-break": ["@marijn/find-cluster-break@1.0.2", "", {}, "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g=="],
 
     "@mermaid-js/parser": ["@mermaid-js/parser@1.2.0", "", { "dependencies": { "@chevrotain/types": "~11.1.2" } }, "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA=="],
-
-    "@kenn-forge/github-app-ui": ["@kenn-forge/github-app-ui@workspace:packages/github-app-ui"],
-
-    "@kenn-forge/ui": ["@kenn-forge/ui@workspace:packages/ui"],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
 
@@ -601,6 +602,8 @@
 
     "@xterm/addon-ligatures": ["@xterm/addon-ligatures@0.10.0", "", { "dependencies": { "font-finder": "^1.1.0", "font-ligatures": "^1.4.1" } }, "sha512-/Few8ZSHMib7sGjRJoc5l7bCtEB9XJfkNofvPpOcWADxKaUl8og8P172j67OoACSNJAXqeCLIuvj8WFCBkcTxg=="],
 
+    "@xterm/addon-web-links": ["@xterm/addon-web-links@0.12.0", "", {}, "sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw=="],
+
     "@xterm/addon-webgl": ["@xterm/addon-webgl@0.19.0", "", {}, "sha512-b3fMOsyLVuCeNJWxolACEUED0vm7qC0cy4wRvf3oURSzDTYVQiGPhTnhWZwIHdvC48Y+oLhvYXnY4XDXPoJo6A=="],
 
     "@xterm/xterm": ["@xterm/xterm@6.0.0", "", {}, "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg=="],
@@ -901,6 +904,8 @@
 
     "katex": ["katex@0.16.47", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg=="],
 
+    "kenn-forge-frontend": ["kenn-forge-frontend@workspace:frontend"],
+
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
     "khroma": ["khroma@2.1.0", "", {}, "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="],
@@ -966,8 +971,6 @@
     "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
 
     "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
-
-    "kenn-forge-frontend": ["kenn-forge-frontend@workspace:frontend"],
 
     "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
     "@pierre/trees": "1.0.0-beta.5",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-ligatures": "^0.10.0",
+    "@xterm/addon-web-links": "^0.12.0",
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
     "@xyflow/svelte": "^1.6.1",

--- a/frontend/src/lib/components/terminal/TerminalPane.test.ts
+++ b/frontend/src/lib/components/terminal/TerminalPane.test.ts
@@ -15,6 +15,7 @@ const {
   mouseDragObserveTerminalData,
   mouseDragReset,
   resizeObserverCallbacks,
+  webLinksAddonCtor,
   xtermFitAddons,
   xtermInstances,
   xtermOnDataHandlers,
@@ -34,6 +35,7 @@ const {
   mouseDragObserveTerminalData: vi.fn(),
   mouseDragReset: vi.fn(),
   resizeObserverCallbacks: [] as ResizeObserverCallback[],
+  webLinksAddonCtor: vi.fn(),
   xtermFitAddons: [] as Array<{ fit: ReturnType<typeof vi.fn>; proposeDimensions: ReturnType<typeof vi.fn> }>,
   xtermInstances: [] as Array<{
     clearTextureAtlas: ReturnType<typeof vi.fn>;
@@ -201,6 +203,13 @@ vi.mock("@xterm/addon-ligatures/lib/addon-ligatures.mjs", () => ({
   }),
 }));
 
+vi.mock("@xterm/addon-web-links", () => ({
+  WebLinksAddon: vi.fn().mockImplementation(function (handler, options) {
+    webLinksAddonCtor(handler, options);
+    return { dispose: vi.fn() };
+  }),
+}));
+
 vi.mock("@xterm/addon-webgl", () => ({
   WebglAddon: vi.fn().mockImplementation(function (options) {
     mockWebglCtor(options);
@@ -242,6 +251,7 @@ describe("TerminalPane", () => {
     mouseDragObserveTerminalData.mockReset();
     mouseDragReset.mockReset();
     resizeObserverCallbacks.length = 0;
+    webLinksAddonCtor.mockReset();
     xtermFitAddons.length = 0;
     xtermInstances.length = 0;
     xtermTerminalCtor.mockReset();
@@ -276,6 +286,7 @@ describe("TerminalPane", () => {
 
   afterEach(() => {
     cleanup();
+    vi.restoreAllMocks();
     vi.useRealTimers();
     vi.unstubAllGlobals();
     if (originalDocumentFonts) {
@@ -294,6 +305,46 @@ describe("TerminalPane", () => {
     render(TerminalPane, { props: { workspaceId: "ws-123" } });
 
     await waitFor(() => expect(xtermTerminalCtor).toHaveBeenCalled());
+  });
+
+  it("uses the same safe opener for detected URLs and OSC 8 links", async () => {
+    render(TerminalPane, { props: { workspaceId: "ws-123" } });
+    await waitFor(() => expect(xtermTerminalCtor).toHaveBeenCalled());
+
+    const linkHandler = xtermTerminalCtor.mock.calls[0]![0].linkHandler;
+
+    expect(webLinksAddonCtor.mock.calls[0]![0]).toBe(linkHandler.activate);
+    expect(webLinksAddonCtor.mock.calls[0]![1]).toEqual({
+      hover: linkHandler.hover,
+      leave: linkHandler.leave,
+    });
+  });
+
+  it("discloses a hovered link target and its activation modifier", async () => {
+    const view = render(TerminalPane, { props: { workspaceId: "ws-123" } });
+    await waitFor(() => expect(xtermTerminalCtor).toHaveBeenCalled());
+    const linkHandler = xtermTerminalCtor.mock.calls[0]![0].linkHandler;
+
+    linkHandler.hover(new MouseEvent("mouseover"), "https://example.com/hidden");
+    await tick();
+
+    expect(view.getByText("https://example.com/hidden")).toBeTruthy();
+    expect(view.getByText(`${/Mac/.test(navigator.platform) ? "Cmd" : "Ctrl"}+Click to open link`)).toBeTruthy();
+  });
+
+  it("opens only modified HTTP links in a new isolated tab", async () => {
+    const open = vi.spyOn(window, "open").mockImplementation(() => null);
+    render(TerminalPane, { props: { workspaceId: "ws-123" } });
+    await waitFor(() => expect(xtermTerminalCtor).toHaveBeenCalled());
+    const activate = xtermTerminalCtor.mock.calls[0]![0].linkHandler.activate;
+    const modifier = /Mac/.test(navigator.platform) ? { metaKey: true } : { ctrlKey: true };
+
+    activate(new MouseEvent("click"), "https://example.com/no-modifier");
+    activate(new MouseEvent("click", modifier), "javascript:alert(document.domain)");
+    activate(new MouseEvent("click", modifier), "https://example.com/docs");
+
+    expect(open).toHaveBeenCalledTimes(1);
+    expect(open).toHaveBeenCalledWith("https://example.com/docs", "_blank", "noopener,noreferrer");
   });
 
   it("forwards accepted tmux OSC 52 text to the authorized clipboard writer", async () => {

--- a/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
@@ -158,10 +158,7 @@
   }
 
   function openTerminalLink(event: MouseEvent, uri: string): void {
-    const modifierPressed = terminalLinkUsesMetaKey
-      ? event.metaKey
-      : event.ctrlKey;
-    if (!modifierPressed) return;
+    if (!terminalLinkModifierPressed(event)) return;
 
     let url: URL;
     try {
@@ -172,6 +169,10 @@
     if (url.protocol !== "http:" && url.protocol !== "https:") return;
 
     window.open(url.href, "_blank", "noopener,noreferrer");
+  }
+
+  function terminalLinkModifierPressed(event: MouseEvent): boolean {
+    return terminalLinkUsesMetaKey ? event.metaKey : event.ctrlKey;
   }
 
   function showTerminalLink(_event: MouseEvent, uri: string): void {
@@ -193,6 +194,9 @@
     if (activePointerId !== null) {
       cancelTerminalPointerGesture();
     }
+    // Pointer capture retargets mouseup to the container, preventing xterm's
+    // linkifier from seeing the matching release and activating the link.
+    if (terminalLinkModifierPressed(event)) return;
     activePointerId = event.pointerId;
     clipboardWriter.beginPointerGesture();
     try {

--- a/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
@@ -3,8 +3,10 @@
   import { getStores } from "@kenn-forge/ui";
   import { showFlash } from "@kenn-forge/ui/stores/flash";
   import { Terminal } from "@xterm/xterm";
+  import type { ILinkHandler } from "@xterm/xterm";
   import { FitAddon } from "@xterm/addon-fit";
   import { LigaturesAddon } from "@xterm/addon-ligatures/lib/addon-ligatures.mjs";
+  import { WebLinksAddon } from "@xterm/addon-web-links";
   import { WebglAddon } from "@xterm/addon-webgl";
   import "@xterm/xterm/css/xterm.css";
   import { workspaceTmuxWebSocketPath } from "../../api/workspace-runtime.js";
@@ -58,9 +60,12 @@
   const { settings: settingsStore } = getStores();
 
   const basePath = (window.__BASE_PATH__ ?? "/").replace(/\/$/, "");
+  const terminalLinkUsesMetaKey = /Mac/.test(navigator.platform);
+  const terminalLinkModifierLabel = terminalLinkUsesMetaKey ? "Cmd" : "Ctrl";
 
   let containerEl: HTMLDivElement;
   let terminal: Terminal | null = $state(null);
+  let hoveredTerminalLink: string | null = $state(null);
   let fitAddon: FitAddon | null = null;
   let ligaturesAddon: LigaturesAddon | null = null;
   let webglAddon: WebglAddon | null = null;
@@ -151,6 +156,37 @@
     });
     return true;
   }
+
+  function openTerminalLink(event: MouseEvent, uri: string): void {
+    const modifierPressed = terminalLinkUsesMetaKey
+      ? event.metaKey
+      : event.ctrlKey;
+    if (!modifierPressed) return;
+
+    let url: URL;
+    try {
+      url = new URL(uri);
+    } catch {
+      return;
+    }
+    if (url.protocol !== "http:" && url.protocol !== "https:") return;
+
+    window.open(url.href, "_blank", "noopener,noreferrer");
+  }
+
+  function showTerminalLink(_event: MouseEvent, uri: string): void {
+    hoveredTerminalLink = uri;
+  }
+
+  function hideTerminalLink(): void {
+    hoveredTerminalLink = null;
+  }
+
+  const terminalLinkHandler: ILinkHandler = {
+    activate: openTerminalLink,
+    hover: showTerminalLink,
+    leave: hideTerminalLink,
+  };
 
   function handleTerminalPointerDown(event: PointerEvent): void {
     if (disposed || disabled || event.button !== 0 || !event.isTrusted) return;
@@ -806,6 +842,7 @@
         scrollback: terminalScrollback,
         letterSpacing: terminalLetterSpacing,
         lineHeight: terminalLineHeight,
+        linkHandler: terminalLinkHandler,
         minimumContrastRatio: TERMINAL_MINIMUM_CONTRAST_RATIO,
         rescaleOverlappingGlyphs: true,
         scrollOnEraseInDisplay: true,
@@ -824,6 +861,12 @@
       const fit = new FitAddon();
       fitAddon = fit;
       term.loadAddon(fit);
+      term.loadAddon(
+        new WebLinksAddon(openTerminalLink, {
+          hover: showTerminalLink,
+          leave: hideTerminalLink,
+        }),
+      );
 
       if (terminalFontLigatures) {
         ligaturesAddon = new LigaturesAddon();
@@ -960,13 +1003,54 @@
   onlostpointercapture={handleTerminalLostPointerCapture}
   onkeydowncapture={handleTerminalKeyDown}
   onfocusout={handleTerminalFocusOut}
-></div>
+>
+  {#if hoveredTerminalLink}
+    <div class="terminal-link-tooltip">
+      <span>{hoveredTerminalLink}</span>
+      <small>{terminalLinkModifierLabel}+Click to open link</small>
+    </div>
+    {/if}
+</div>
 
 <style>
   .terminal-container {
+    position: relative;
     width: 100%;
     height: 100%;
     background: var(--terminal-bg);
+  }
+
+  .terminal-link-tooltip {
+    position: absolute;
+    z-index: 5;
+    bottom: var(--space-4);
+    left: var(--space-4);
+    display: flex;
+    max-width: calc(100% - (2 * var(--space-4)));
+    flex-direction: column;
+    gap: var(--space-1);
+    padding: var(--space-2) var(--space-3);
+    overflow: hidden;
+    color: var(--text-primary);
+    font-family: var(--font-sans);
+    font-size: var(--font-size-sm);
+    line-height: 1.25;
+    pointer-events: none;
+    background: var(--bg-surface);
+    border: var(--border-width) solid var(--border-default);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-md);
+  }
+
+  .terminal-link-tooltip span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .terminal-link-tooltip small {
+    color: var(--text-muted);
+    font-size: inherit;
   }
 
   .terminal-container :global(.xterm),

--- a/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
@@ -194,9 +194,10 @@
     if (activePointerId !== null) {
       cancelTerminalPointerGesture();
     }
-    // Pointer capture retargets mouseup to the container, preventing xterm's
-    // linkifier from seeing the matching release and activating the link.
-    if (terminalLinkModifierPressed(event)) return;
+    // Over an active link, pointer capture retargets mouseup to the container
+    // and prevents xterm's linkifier from activating it. Modified non-link
+    // gestures still need the normal clipboard and drag lifecycle below.
+    if (hoveredTerminalLink !== null && terminalLinkModifierPressed(event)) return;
     activePointerId = event.pointerId;
     clipboardWriter.beginPointerGesture();
     try {

--- a/frontend/tests/e2e-full/00-tmux-browser-clipboard.spec.ts
+++ b/frontend/tests/e2e-full/00-tmux-browser-clipboard.spec.ts
@@ -23,6 +23,12 @@ type TerminalDimensions = {
   rows: number;
 };
 
+type TerminalLinkOpen = {
+  url: string;
+  target: string | undefined;
+  features: string | undefined;
+};
+
 let clipboardProbeSequence = 0;
 const TERMINAL_OUTPUT_TIMEOUT_MS = 15_000;
 
@@ -183,6 +189,74 @@ function observeTerminalOutput(page: Page): {
 
 function shellOctal(text: string): string {
   return Array.from(new TextEncoder().encode(text), (byte) => `\\${byte.toString(8).padStart(3, "0")}`).join("");
+}
+
+function tmuxPassthroughSequence(payload: string): string {
+  return `\x1bPtmux;${payload.replaceAll("\x1b", "\x1b\x1b")}\x1b\\`;
+}
+
+async function interceptTerminalLinkOpens(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const testWindow = window as Window & { __terminalLinkOpens?: TerminalLinkOpen[] };
+    testWindow.__terminalLinkOpens = [];
+    window.open = ((url?: string | URL, target?: string, features?: string) => {
+      testWindow.__terminalLinkOpens!.push({
+        url: String(url ?? ""),
+        target,
+        features,
+      });
+      return null;
+    }) as typeof window.open;
+  });
+}
+
+async function terminalLinkOpens(page: Page): Promise<TerminalLinkOpen[]> {
+  return await page.evaluate(() => {
+    const testWindow = window as Window & { __terminalLinkOpens?: TerminalLinkOpen[] };
+    return testWindow.__terminalLinkOpens ?? [];
+  });
+}
+
+async function renderTerminalLink(
+  page: Page,
+  container: Locator,
+  output: ReturnType<typeof observeTerminalOutput>,
+  renderedText: string,
+  marker: string,
+): Promise<TerminalDimensions> {
+  await container.locator(".xterm-helper-textarea").focus();
+  await page.keyboard.type(`clear; printf '${shellOctal(`${renderedText}\n${marker}\n`)}'`);
+  await page.keyboard.press("Enter");
+  await expect.poll(() => output.includes(marker), { timeout: TERMINAL_OUTPUT_TIMEOUT_MS }).toBe(true);
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      }),
+  );
+  const dimensions = output.dimensionsForLatestInput();
+  if (!dimensions) throw new Error(`terminal dimensions unavailable for link marker ${marker}`);
+  return dimensions;
+}
+
+async function terminalCellCenter(
+  container: Locator,
+  dimensions: TerminalDimensions,
+  column: number,
+  row: number,
+): Promise<{ x: number; y: number }> {
+  return await container.evaluate(
+    (element, { columns, rows, columnIndex, rowIndex }) => {
+      const screen = element.querySelector<HTMLElement>(".xterm-screen");
+      if (!screen) throw new Error("xterm screen geometry unavailable");
+      const bounds = screen.getBoundingClientRect();
+      return {
+        x: bounds.left + (bounds.width / columns) * (columnIndex + 0.5),
+        y: bounds.top + (bounds.height / rows) * (rowIndex + 0.5),
+      };
+    },
+    { columns: dimensions.columns, rows: dimensions.rows, columnIndex: column, rowIndex: row },
+  );
 }
 
 async function emitApplicationOsc52(
@@ -454,6 +528,83 @@ async function dragTerminalPastTop(page: Page, container: Locator, dimensions: T
 }
 
 test.describe.configure({ mode: "serial", timeout: 120_000 });
+
+test("real xterm links disclose destinations and require a modified click", async ({ page }) => {
+  test.skip(!hasCommand("git") || !hasCommand("tmux", ["-V"]), "git and tmux are required for the real workspace flow");
+
+  let isolatedServer: IsolatedE2EServer | null = null;
+  let api: APIRequestContext | null = null;
+  try {
+    await interceptTerminalLinkOpens(page);
+    isolatedServer = await startIsolatedWorkspaceE2EServer();
+    api = await playwrightRequest.newContext({ baseURL: isolatedServer.info.base_url });
+    const workspace = await createIssueWorkspace(api, 10);
+    const output = observeTerminalOutput(page);
+
+    await page.goto(`${isolatedServer.info.base_url}/terminal/${workspace.id}`);
+    const terminal = await openTerminalPanel(page);
+    await terminal.locator(".xterm-helper-textarea").focus();
+    await runAttachedTmuxCommand(page, "set-option -p allow-passthrough on");
+    const usesMetaKey = await page.evaluate(() => /Mac/.test(navigator.platform));
+    const modifier = usesMetaKey ? "Meta" : "Control";
+    const modifierLabel = usesMetaKey ? "Cmd" : "Ctrl";
+    const links = [
+      {
+        destination: "https://example.com/detected-link",
+        renderedText: "https://example.com/detected-link",
+        marker: "detected-link-ready",
+      },
+      {
+        destination: "https://example.org/osc8-destination",
+        renderedText: tmuxPassthroughSequence(
+          "\x1b]8;;https://example.org/osc8-destination\x07Open release notes\x1b]8;;\x07",
+        ),
+        marker: "osc8-link-ready",
+      },
+    ];
+
+    for (const link of links) {
+      await page.mouse.move(1, 1);
+      await expect(terminal.locator(".terminal-link-tooltip")).toHaveCount(0);
+      const dimensions = await renderTerminalLink(page, terminal, output, link.renderedText, link.marker);
+      expect(output.includes(link.destination)).toBe(true);
+      const point = await terminalCellCenter(terminal, dimensions, 4, 0);
+      const resetPoint = await terminalCellCenter(terminal, dimensions, 4, 2);
+
+      await page.mouse.move(resetPoint.x, resetPoint.y);
+      await page.mouse.move(point.x, point.y);
+      const tooltip = terminal.locator(".terminal-link-tooltip");
+      await expect(tooltip).toContainText(link.destination);
+      await expect(tooltip).toContainText(`${modifierLabel}+Click to open link`);
+
+      const opensBeforeClick = await terminalLinkOpens(page);
+      await page.mouse.click(point.x, point.y);
+      expect(await terminalLinkOpens(page)).toEqual(opensBeforeClick);
+
+      await page.mouse.move(resetPoint.x, resetPoint.y);
+      await expect(tooltip).toHaveCount(0);
+      await page.mouse.move(point.x, point.y);
+      await expect(tooltip).toContainText(link.destination);
+      await page.keyboard.down(modifier);
+      await page.mouse.click(point.x, point.y);
+      await page.keyboard.up(modifier);
+      await expect.poll(() => terminalLinkOpens(page)).toHaveLength(opensBeforeClick.length + 1);
+    }
+
+    await expect
+      .poll(() => terminalLinkOpens(page))
+      .toEqual(
+        links.map((link) => ({
+          url: link.destination,
+          target: "_blank",
+          features: "noopener,noreferrer",
+        })),
+      );
+  } finally {
+    await api?.dispose();
+    await isolatedServer?.stop();
+  }
+});
 
 test("tmux blocks application OSC 52 while keyboard copy reaches the clipboard", async ({ page, browserName }) => {
   test.skip(!hasCommand("git") || !hasCommand("tmux", ["-V"]), "git and tmux are required for the real workspace flow");

--- a/frontend/tests/e2e-full/00-tmux-browser-clipboard.spec.ts
+++ b/frontend/tests/e2e-full/00-tmux-browser-clipboard.spec.ts
@@ -1,6 +1,8 @@
 import { execFileSync } from "node:child_process";
+import { closeSync, constants, openSync, readFileSync, writeSync } from "node:fs";
 import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { load as loadToml } from "js-toml";
 import {
   expect,
   request as playwrightRequest,
@@ -27,6 +29,23 @@ type TerminalLinkOpen = {
   url: string;
   target: string | undefined;
   features: string | undefined;
+};
+
+type E2ETmuxConfig = {
+  tmux?: {
+    command?: string[];
+  };
+};
+
+type RuntimeSessionResponse = {
+  sessions: Array<{
+    key: string;
+    status: string;
+  }> | null;
+};
+
+type RuntimeAttachSpecResponse = {
+  tmux_session: string;
 };
 
 let clipboardProbeSequence = 0;
@@ -70,6 +89,19 @@ async function launchDockedShell(api: APIRequestContext, workspaceId: string): P
     },
   });
   expect(response.status(), await response.text()).toBe(200);
+}
+
+async function runningRuntimeTmuxSession(api: APIRequestContext, workspaceId: string): Promise<string> {
+  const response = await api.get(`/api/v1/workspaces/${workspaceId}/runtime`);
+  expect(response.ok()).toBe(true);
+  const runtime = (await response.json()) as RuntimeSessionResponse;
+  const running = runtime.sessions?.filter((session) => session.status === "running") ?? [];
+  expect(running).toHaveLength(1);
+  const attachResponse = await api.get(
+    `/api/v1/workspaces/${workspaceId}/runtime/sessions/${encodeURIComponent(running[0]!.key)}/attach-spec`,
+  );
+  expect(attachResponse.ok()).toBe(true);
+  return ((await attachResponse.json()) as RuntimeAttachSpecResponse).tmux_session;
 }
 
 async function openTerminalPanel(page: Page): Promise<Locator> {
@@ -191,8 +223,21 @@ function shellOctal(text: string): string {
   return Array.from(new TextEncoder().encode(text), (byte) => `\\${byte.toString(8).padStart(3, "0")}`).join("");
 }
 
-function tmuxPassthroughSequence(payload: string): string {
-  return `\x1bPtmux;${payload.replaceAll("\x1b", "\x1b\x1b")}\x1b\\`;
+function runE2ETmuxCommand(server: IsolatedE2EServer, args: string[]): string {
+  const config = loadToml(readFileSync(server.info.config_path, "utf8")) as E2ETmuxConfig;
+  const [command, ...prefix] = config.tmux?.command ?? [];
+  if (!command) throw new Error("e2e tmux command is unavailable");
+  return execFileSync(command, [...prefix, ...args], { encoding: "utf8" }).trim();
+}
+
+function writeTmuxClientTTY(server: IsolatedE2EServer, tmuxSession: string, data: Uint8Array): void {
+  const clientTTY = runE2ETmuxCommand(server, ["list-clients", "-t", tmuxSession, "-F", "#{client_tty}"]);
+  const fd = openSync(clientTTY, constants.O_WRONLY | constants.O_NOCTTY);
+  try {
+    writeSync(fd, data);
+  } finally {
+    closeSync(fd);
+  }
 }
 
 async function interceptTerminalLinkOpens(page: Page): Promise<void> {
@@ -227,6 +272,27 @@ async function renderTerminalLink(
   await container.locator(".xterm-helper-textarea").focus();
   await page.keyboard.type(`clear; printf '${shellOctal(`${renderedText}\n${marker}\n`)}'`);
   await page.keyboard.press("Enter");
+  await expect.poll(() => output.includes(marker), { timeout: TERMINAL_OUTPUT_TIMEOUT_MS }).toBe(true);
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      }),
+  );
+  const dimensions = output.dimensionsForLatestInput();
+  if (!dimensions) throw new Error(`terminal dimensions unavailable for link marker ${marker}`);
+  return dimensions;
+}
+
+async function renderRawTerminalLink(
+  page: Page,
+  output: ReturnType<typeof observeTerminalOutput>,
+  server: IsolatedE2EServer,
+  tmuxSession: string,
+  renderedText: string,
+  marker: string,
+): Promise<TerminalDimensions> {
+  writeTmuxClientTTY(server, tmuxSession, new TextEncoder().encode(`\x1b[2J\x1b[H${renderedText}\r\n${marker}\r\n`));
   await expect.poll(() => output.includes(marker), { timeout: TERMINAL_OUTPUT_TIMEOUT_MS }).toBe(true);
   await page.evaluate(
     () =>
@@ -543,8 +609,7 @@ test("real xterm links disclose destinations and require a modified click", asyn
 
     await page.goto(`${isolatedServer.info.base_url}/terminal/${workspace.id}`);
     const terminal = await openTerminalPanel(page);
-    await terminal.locator(".xterm-helper-textarea").focus();
-    await runAttachedTmuxCommand(page, "set-option -p allow-passthrough on");
+    const tmuxSession = await runningRuntimeTmuxSession(api, workspace.id);
     const usesMetaKey = await page.evaluate(() => /Mac/.test(navigator.platform));
     const modifier = usesMetaKey ? "Meta" : "Control";
     const modifierLabel = usesMetaKey ? "Cmd" : "Ctrl";
@@ -553,21 +618,25 @@ test("real xterm links disclose destinations and require a modified click", asyn
         destination: "https://example.com/detected-link",
         renderedText: "https://example.com/detected-link",
         marker: "detected-link-ready",
+        raw: false,
       },
       {
         destination: "https://example.org/osc8-destination",
-        renderedText: tmuxPassthroughSequence(
-          "\x1b]8;;https://example.org/osc8-destination\x07Open release notes\x1b]8;;\x07",
-        ),
+        renderedText: "\x1b]8;;https://example.org/osc8-destination\x07Open release notes\x1b]8;;\x07",
         marker: "osc8-link-ready",
+        raw: true,
       },
     ];
 
     for (const link of links) {
       await page.mouse.move(1, 1);
       await expect(terminal.locator(".terminal-link-tooltip")).toHaveCount(0);
-      const dimensions = await renderTerminalLink(page, terminal, output, link.renderedText, link.marker);
-      expect(output.includes(link.destination)).toBe(true);
+      const dimensions = link.raw
+        ? await renderRawTerminalLink(page, output, isolatedServer, tmuxSession, link.renderedText, link.marker)
+        : await renderTerminalLink(page, terminal, output, link.renderedText, link.marker);
+      expect(output.includes(link.destination), `${link.marker} destination did not reach the terminal stream`).toBe(
+        true,
+      );
       const point = await terminalCellCenter(terminal, dimensions, 4, 0);
       const resetPoint = await terminalCellCenter(terminal, dimensions, 4, 2);
 
@@ -601,6 +670,50 @@ test("real xterm links disclose destinations and require a modified click", asyn
         })),
       );
   } finally {
+    await api?.dispose();
+    await isolatedServer?.stop();
+  }
+});
+
+test("modified non-link terminal drags retain pointer capture through outside release", async ({ page }) => {
+  test.skip(!hasCommand("git") || !hasCommand("tmux", ["-V"]), "git and tmux are required for the real workspace flow");
+
+  let isolatedServer: IsolatedE2EServer | null = null;
+  let api: APIRequestContext | null = null;
+  let modifierDown = false;
+  let pointerDown = false;
+  let modifier: "Meta" | "Control" | null = null;
+  try {
+    isolatedServer = await startIsolatedWorkspaceE2EServer();
+    api = await playwrightRequest.newContext({ baseURL: isolatedServer.info.base_url });
+    const workspace = await createIssueWorkspace(api, 10);
+
+    await page.goto(`${isolatedServer.info.base_url}/terminal/${workspace.id}`);
+    const terminal = await openTerminalPanel(page);
+    const screen = await terminal.locator(".xterm-screen").boundingBox();
+    if (!screen) throw new Error("xterm screen geometry unavailable");
+    modifier = (await page.evaluate(() => /Mac/.test(navigator.platform))) ? "Meta" : "Control";
+
+    await page.mouse.move(screen.x + screen.width / 2, screen.y + screen.height / 2);
+    await page.keyboard.down(modifier);
+    modifierDown = true;
+    pointerDown = true;
+    await beginCapturedPointerGesture(page, terminal);
+
+    await page.mouse.move(screen.x - 20, screen.y - 20, { steps: 5 });
+    await page.mouse.up();
+    pointerDown = false;
+    await expect
+      .poll(() =>
+        terminal.evaluate((element) => {
+          const target = element as HTMLElement;
+          return target.hasPointerCapture(Number(target.dataset.playwrightPointerId));
+        }),
+      )
+      .toBe(false);
+  } finally {
+    if (pointerDown) await page.mouse.up();
+    if (modifierDown && modifier) await page.keyboard.up(modifier);
     await api?.dispose();
     await isolatedServer?.stop();
   }


### PR DESCRIPTION
- Detect web URLs and OSC 8 hyperlinks in terminal output.
- Show the destination on hover and require Cmd/Ctrl+Click before opening it.
- Restrict navigation to HTTP(S) links opened in an isolated tab.

<sup>generated by a clanker</sup>