### PR TITLE
fix: recover cleanly from orphaned workspace directories

### DIFF
--- a/cmd/kenn-forge/api_verb_e2e_test.go
+++ b/cmd/kenn-forge/api_verb_e2e_test.go
@@ -64,7 +64,7 @@ func TestAPIVerbE2E(t *testing.T) {
 		}
 		defer resp.Body.Close()
 		return resp.StatusCode == http.StatusUnauthorized
-	}, 10*time.Second, 100*time.Millisecond,
+	}, 30*time.Second, 100*time.Millisecond,
 		"credential-less API request must 401")
 
 	run := func(args ...string) (string, string, int) {

--- a/cmd/kenn-forge/provider_startup_identity_test.go
+++ b/cmd/kenn-forge/provider_startup_identity_test.go
@@ -934,7 +934,7 @@ func TestProductionStartupRoutesTwoOwnersThroughSyncAndMutationAPI(t *testing.T)
 			}
 		}
 		return true
-	}, 5*time.Second, 20*time.Millisecond)
+	}, 30*time.Second, 20*time.Millisecond)
 
 	for _, repo := range repos {
 		url := fmt.Sprintf(

--- a/context/testing.md
+++ b/context/testing.md
@@ -8,6 +8,10 @@ as `assert := assert.New(t)` when a test has more than three assertions.
 Aliasing the `assert` package, including `Assert`, is not allowed and is
 enforced by golangci-lint's `importas` rule.
 
+Test server constructors that create a Workspace manager must apply their
+isolated test tmux command; they must never fall back to the host tmux server
+(`internal/server/kataapi/test_helpers_test.go::newKataTestServer`).
+
 ## Live GraphQL validation
 
 GraphQL query shape changes must be validated against GitHub's live GraphQL API before they are merged. The local test suite includes a gated live test:

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -137,6 +137,22 @@ embedder protocol for arbitrary host state.
   (`packages/ui/src/stores/detail.svelte.ts::applyRefreshedDetail`).
 - `DELETE /workspaces/{id}`: tear down a kenn-forge-managed workspace and its
   local resources.
+  - Setup rejects occupied destinations before clone/fetch and again under the
+    repo lock before `git worktree add`; failed adds delete only branches absent
+    before the command because Git may create `-b` first (`internal/workspace/manager.go::Manager.addWorktree`).
+  - Destructive worktree removal requires a matching persisted workspace-ID marker;
+    repo, origin, branch, path, and self-registration are not ownership. Preserve
+    unmarked or mismatched roots (`internal/workspace/manager.go::Manager.workspaceCleanupGitDir`).
+  - An unmarked live registration is ambiguous after upgrade: delete and retry return
+    conflict and retain the workspace row; only registrations without a live worktree
+    may be cleared as stale (`internal/workspace/manager.go::gitDirOwnsCleanupWorktree`).
+  - Symlinked Git roots are live but never owned; they conflict instead of entering
+    stale-registration cleanup (`internal/workspace/manager.go::gitDirHasLiveWorktree`).
+  - Pre-lock cleanup resolution is advisory. Revalidate marker identity and current
+    live/stale state as the first locked action (`internal/workspace/manager.go::currentWorkspaceCleanupState`).
+  - A force delete retains the workspace row when Git cannot remove a live owned
+    worktree; only errors proving the worktree is already absent or corrupt may
+    continue to branch and row cleanup (`internal/workspace/manager.go::Manager.cleanupWorkspaceArtifactsForDeleteLocked`).
 
 ## Data Model Intent
 

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -138,14 +138,16 @@ embedder protocol for arbitrary host state.
 - `DELETE /workspaces/{id}`: tear down a kenn-forge-managed workspace and its
   local resources.
   - Setup rejects occupied destinations before clone/fetch and again under the
-    repo lock before `git worktree add`; failed adds delete only branches absent
-    before the command because Git may create `-b` first (`internal/workspace/manager.go::Manager.addWorktree`).
+    repo lock before mutation. Branch creation and failed-add cleanup use ref
+    compare-and-swap so changed branches survive (`internal/workspace/manager.go::createBranchAndAddWorktree`).
+  - New registrations receive their workspace-ID marker before fallible post-add
+    configuration (`internal/workspace/manager.go::Manager.runOwnedGitWorktreeAdd`).
   - Existing-worktree reuse accepts only a non-symlink worktree root and revalidates
     its repository and provenance under the repo lock before refresh or ownership
     marking (`internal/workspace/manager.go::Manager.reuseExistingWorkspaceWorktree`).
-  - Destructive worktree removal requires a matching persisted workspace-ID marker;
-    repo, origin, branch, path, and self-registration are not ownership. Preserve
-    unmarked or mismatched roots (`internal/workspace/manager.go::Manager.workspaceCleanupGitDir`).
+  - Destructive worktree removal, including setup rollback, requires a matching
+    persisted workspace-ID marker under the repo lock; preserve unmarked or mismatched
+    roots (`internal/workspace/manager.go::Manager.rollbackWorktree`).
   - An unmarked live registration is ambiguous after upgrade: delete and retry return
     conflict and retain the workspace row; only registrations without a live worktree
     may be cleared as stale (`internal/workspace/manager.go::gitDirOwnsCleanupWorktree`).

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -140,6 +140,9 @@ embedder protocol for arbitrary host state.
   - Setup rejects occupied destinations before clone/fetch and again under the
     repo lock before `git worktree add`; failed adds delete only branches absent
     before the command because Git may create `-b` first (`internal/workspace/manager.go::Manager.addWorktree`).
+  - Existing-worktree reuse accepts only a non-symlink worktree root and revalidates
+    its repository and provenance under the repo lock before refresh or ownership
+    marking (`internal/workspace/manager.go::Manager.reuseExistingWorkspaceWorktree`).
   - Destructive worktree removal requires a matching persisted workspace-ID marker;
     repo, origin, branch, path, and self-registration are not ownership. Preserve
     unmarked or mismatched roots (`internal/workspace/manager.go::Manager.workspaceCleanupGitDir`).

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -137,8 +137,8 @@ embedder protocol for arbitrary host state.
   (`packages/ui/src/stores/detail.svelte.ts::applyRefreshedDetail`).
 - `DELETE /workspaces/{id}`: tear down a kenn-forge-managed workspace and its
   local resources.
-  - Force-delete joins any registered setup worker before filesystem and row
-    cleanup, so accepted creation cannot materialize resources after deletion
+  - Force-delete blocks new setup generations before joining the current worker,
+    so creation or retry cannot materialize resources after cleanup and row removal
     (`internal/server/workspaceapi/routes_handlers.go::Handler.deleteWorkspace`).
   - Setup rejects occupied destinations before clone/fetch and again under the
     repo lock before mutation. Branch creation and failed-add cleanup use ref

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -137,6 +137,9 @@ embedder protocol for arbitrary host state.
   (`packages/ui/src/stores/detail.svelte.ts::applyRefreshedDetail`).
 - `DELETE /workspaces/{id}`: tear down a kenn-forge-managed workspace and its
   local resources.
+  - Force-delete joins any registered setup worker before filesystem and row
+    cleanup, so accepted creation cannot materialize resources after deletion
+    (`internal/server/workspaceapi/routes_handlers.go::Handler.deleteWorkspace`).
   - Setup rejects occupied destinations before clone/fetch and again under the
     repo lock before mutation. Branch creation and failed-add cleanup use ref
     compare-and-swap so changed branches survive (`internal/workspace/manager.go::createBranchAndAddWorktree`).

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -138,7 +138,11 @@ embedder protocol for arbitrary host state.
 - `DELETE /workspaces/{id}`: tear down a kenn-forge-managed workspace and its
   local resources.
   - Force-delete blocks new setup generations before joining the current worker,
-    so creation or retry cannot materialize resources after cleanup and row removal
+    so creation or retry cannot materialize resources after cleanup and row removal.
+    Deletions are reference-counted per workspace ID; setup dispatched during
+    deletion queues and replays only if every concurrent deletion fails — one
+    success closes admission permanently, and a dropped replay would strand an
+    accepted retry in "creating"
     (`internal/server/workspaceapi/routes_handlers.go::Handler.deleteWorkspace`).
   - Setup rejects occupied destinations before clone/fetch and again under the
     repo lock before mutation. Branch creation and failed-add cleanup use ref

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -141,7 +141,8 @@ embedder protocol for arbitrary host state.
     repo lock before mutation. Branch creation and failed-add cleanup use ref
     compare-and-swap so changed branches survive (`internal/workspace/manager.go::createBranchAndAddWorktree`).
   - New registrations receive their workspace-ID marker before fallible post-add
-    configuration (`internal/workspace/manager.go::Manager.runOwnedGitWorktreeAdd`).
+    configuration; marker failure rolls back the exact registration and any unchanged
+    created branch under the repo lock (`internal/workspace/manager.go::Manager.runOwnedGitWorktreeAdd`).
   - Existing-worktree reuse accepts only a non-symlink worktree root and revalidates
     its repository and provenance under the repo lock before refresh or ownership
     marking (`internal/workspace/manager.go::Manager.reuseExistingWorkspaceWorktree`).

--- a/context/workspace-apis.md
+++ b/context/workspace-apis.md
@@ -151,8 +151,9 @@ embedder protocol for arbitrary host state.
   - An unmarked live registration is ambiguous after upgrade: delete and retry return
     conflict and retain the workspace row; only registrations without a live worktree
     may be cleared as stale (`internal/workspace/manager.go::gitDirOwnsCleanupWorktree`).
-  - Symlinked Git roots are live but never owned; they conflict instead of entering
-    stale-registration cleanup (`internal/workspace/manager.go::gitDirHasLiveWorktree`).
+  - Only exact Git roots whose `.git` matches their registration are live; symlinked
+    roots may be live but are never owned, so they conflict instead of entering stale
+    cleanup (`internal/workspace/manager.go::gitDirHasLiveWorktree`).
   - Pre-lock cleanup resolution is advisory. Revalidate marker identity and current
     live/stale state as the first locked action (`internal/workspace/manager.go::currentWorkspaceCleanupState`).
   - A force delete retains the workspace row when Git cannot remove a live owned

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -5246,7 +5246,7 @@ func (d *DB) UpdateWorkspaceStatus(
 func (d *DB) UpdateWorkspaceBranch(
 	ctx context.Context, id, branch string,
 ) error {
-	_, err := d.rw.ExecContext(ctx, `
+	result, err := d.rw.ExecContext(ctx, `
 		UPDATE forge_workspaces
 		SET workspace_branch = ?
 		WHERE id = ?`,
@@ -5254,6 +5254,13 @@ func (d *DB) UpdateWorkspaceBranch(
 	)
 	if err != nil {
 		return fmt.Errorf("update workspace branch: %w", err)
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("read workspace branch update result: %w", err)
+	}
+	if rowsAffected == 0 {
+		return fmt.Errorf("workspace %q not found", id)
 	}
 	return nil
 }

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -4665,6 +4665,16 @@ func TestWorkspaceCRUD(t *testing.T) {
 	assert.Nil(noSuch)
 }
 
+func TestUpdateWorkspaceBranchRejectsMissingWorkspace(t *testing.T) {
+	d := openTestDB(t)
+
+	err := d.UpdateWorkspaceBranch(
+		t.Context(), "missing-workspace", "feature/example",
+	)
+
+	require.Error(t, err)
+}
+
 func TestUpdateWorkspaceMRHeadRepo(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -9185,7 +9185,7 @@ func TestSetWatchedMRsReplacesList(t *testing.T) {
 		mu.Lock()
 		defer mu.Unlock()
 		return syncedNumbers[1] >= 1
-	}, 2*time.Second, 20*time.Millisecond)
+	}, 10*time.Second, 20*time.Millisecond)
 
 	// Replace with PR #2 only.
 	mu.Lock()
@@ -9201,7 +9201,7 @@ func TestSetWatchedMRsReplacesList(t *testing.T) {
 		mu.Lock()
 		defer mu.Unlock()
 		return syncedNumbers[2] >= 1
-	}, 2*time.Second, 20*time.Millisecond)
+	}, 10*time.Second, 20*time.Millisecond)
 
 	// PR #1 should not accumulate many more syncs after replacement.
 	// Allow at most 1 extra (for an in-flight tick at replacement time).

--- a/internal/server/workspaceapi/handler.go
+++ b/internal/server/workspaceapi/handler.go
@@ -136,7 +136,7 @@ type Handler struct {
 	workspaceEnrichmentDisabled    bool
 	workspaceSetupMu               sync.Mutex
 	workspaceSetupDone             map[string]chan struct{}
-	workspaceDeleting              map[string]bool
+	workspaceDeleting              map[string]*workspaceDeletion
 	workspaceTmuxPrunedAt          time.Time
 	workspaceTmuxPrunePending      bool
 	workspaceTmuxPruneInFlight     bool
@@ -183,7 +183,7 @@ func New(deps Deps) *Handler {
 		workspaceEnrichmentSlots:       make(chan struct{}, tmuxProbeMaxConcurrency),
 		workspaceEnrichmentDisabled:    deps.EnrichmentDisabled,
 		workspaceSetupDone:             make(map[string]chan struct{}),
-		workspaceDeleting:              make(map[string]bool),
+		workspaceDeleting:              make(map[string]*workspaceDeletion),
 		tmuxActivity:                   newTmuxActivityTracker(now),
 		lifecycleCtx:                   lifecycleCtx,
 		lifecycleCancel:                lifecycleCancel,

--- a/internal/server/workspaceapi/handler.go
+++ b/internal/server/workspaceapi/handler.go
@@ -136,6 +136,7 @@ type Handler struct {
 	workspaceEnrichmentDisabled    bool
 	workspaceSetupMu               sync.Mutex
 	workspaceSetupDone             map[string]chan struct{}
+	workspaceDeleting              map[string]bool
 	workspaceTmuxPrunedAt          time.Time
 	workspaceTmuxPrunePending      bool
 	workspaceTmuxPruneInFlight     bool
@@ -182,6 +183,7 @@ func New(deps Deps) *Handler {
 		workspaceEnrichmentSlots:       make(chan struct{}, tmuxProbeMaxConcurrency),
 		workspaceEnrichmentDisabled:    deps.EnrichmentDisabled,
 		workspaceSetupDone:             make(map[string]chan struct{}),
+		workspaceDeleting:              make(map[string]bool),
 		tmuxActivity:                   newTmuxActivityTracker(now),
 		lifecycleCtx:                   lifecycleCtx,
 		lifecycleCancel:                lifecycleCancel,

--- a/internal/server/workspaceapi/handler.go
+++ b/internal/server/workspaceapi/handler.go
@@ -134,6 +134,8 @@ type Handler struct {
 	workspaceEnrichmentWorkers     int
 	workspaceEnrichmentSlots       chan struct{}
 	workspaceEnrichmentDisabled    bool
+	workspaceSetupMu               sync.Mutex
+	workspaceSetupDone             map[string]chan struct{}
 	workspaceTmuxPrunedAt          time.Time
 	workspaceTmuxPrunePending      bool
 	workspaceTmuxPruneInFlight     bool
@@ -179,6 +181,7 @@ func New(deps Deps) *Handler {
 		workspaceEnrichmentPending:     make(map[string]workspaceEnrichmentJob),
 		workspaceEnrichmentSlots:       make(chan struct{}, tmuxProbeMaxConcurrency),
 		workspaceEnrichmentDisabled:    deps.EnrichmentDisabled,
+		workspaceSetupDone:             make(map[string]chan struct{}),
 		tmuxActivity:                   newTmuxActivityTracker(now),
 		lifecycleCtx:                   lifecycleCtx,
 		lifecycleCancel:                lifecycleCancel,

--- a/internal/server/workspaceapi/routes_handlers.go
+++ b/internal/server/workspaceapi/routes_handlers.go
@@ -1526,6 +1526,9 @@ func (s *Handler) retryWorkspace(
 		if errors.Is(err, workspace.ErrWorkspaceInvalidState) {
 			return nil, httpapi.Conflict(httpapi.CodeConflict, err.Error(), nil)
 		}
+		if errors.Is(err, workspace.ErrWorkspaceOwnershipUnproven) {
+			return nil, httpapi.Conflict(httpapi.CodeConflict, err.Error(), nil)
+		}
 		return nil, httpapi.Internal("retry workspace: " + err.Error())
 	}
 	s.invalidateWorkspaceEnrichment(ws.ID)
@@ -2374,6 +2377,9 @@ func (s *Handler) deleteWorkspace(
 	if err != nil {
 		if errors.Is(err, workspace.ErrWorkspaceNotFound) {
 			return nil, httpapi.NotFound(httpapi.CodeWorkspaceNotFound, err.Error(), nil)
+		}
+		if errors.Is(err, workspace.ErrWorkspaceOwnershipUnproven) {
+			return nil, httpapi.Conflict(httpapi.CodeConflict, err.Error(), nil)
 		}
 		return nil, httpapi.Internal("delete workspace: " + err.Error())
 	}

--- a/internal/server/workspaceapi/routes_handlers.go
+++ b/internal/server/workspaceapi/routes_handlers.go
@@ -387,11 +387,25 @@ func (s *Handler) runWorkspaceSetupWithBasePath(ws *workspace.Workspace, basePat
 	}
 }
 
+// workspaceDeletion tracks concurrent DELETE requests for one workspace ID.
+// Setup admission stays closed while any deletion is active and permanently
+// once one succeeds; done is closed when the last active deletion finishes so
+// setup dispatchers queued behind a failed deletion can replay.
+type workspaceDeletion struct {
+	active    int
+	succeeded bool
+	closed    bool
+	done      chan struct{}
+}
+
 func (s *Handler) beginWorkspaceSetup(workspaceID string) (chan struct{}, bool) {
 	s.workspaceSetupMu.Lock()
 	defer s.workspaceSetupMu.Unlock()
-	if s.workspaceDeleting[workspaceID] {
-		return nil, false
+	if deletion := s.workspaceDeleting[workspaceID]; deletion != nil {
+		if deletion.succeeded {
+			return nil, false
+		}
+		return deletion.done, false
 	}
 	if done, ok := s.workspaceSetupDone[workspaceID]; ok {
 		return done, false
@@ -412,16 +426,37 @@ func (s *Handler) finishWorkspaceSetup(workspaceID string, done chan struct{}) {
 
 func (s *Handler) markWorkspaceDeleting(workspaceID string) <-chan struct{} {
 	s.workspaceSetupMu.Lock()
-	s.workspaceDeleting[workspaceID] = true
-	done := s.workspaceSetupDone[workspaceID]
-	s.workspaceSetupMu.Unlock()
-	return done
+	defer s.workspaceSetupMu.Unlock()
+	deletion := s.workspaceDeleting[workspaceID]
+	if deletion == nil {
+		deletion = &workspaceDeletion{done: make(chan struct{})}
+		s.workspaceDeleting[workspaceID] = deletion
+	}
+	deletion.active++
+	return s.workspaceSetupDone[workspaceID]
 }
 
-func (s *Handler) unmarkWorkspaceDeleting(workspaceID string) {
+func (s *Handler) finishWorkspaceDeleting(workspaceID string, succeeded bool) {
 	s.workspaceSetupMu.Lock()
-	delete(s.workspaceDeleting, workspaceID)
-	s.workspaceSetupMu.Unlock()
+	defer s.workspaceSetupMu.Unlock()
+	deletion := s.workspaceDeleting[workspaceID]
+	if deletion == nil {
+		return
+	}
+	deletion.active--
+	if succeeded {
+		deletion.succeeded = true
+	}
+	if deletion.active > 0 {
+		return
+	}
+	if !deletion.closed {
+		close(deletion.done)
+		deletion.closed = true
+	}
+	if !deletion.succeeded {
+		delete(s.workspaceDeleting, workspaceID)
+	}
 }
 
 func waitForWorkspaceSetup(ctx context.Context, done <-chan struct{}) error {
@@ -2420,13 +2455,10 @@ func (s *Handler) deleteWorkspace(
 
 	setupDone := s.markWorkspaceDeleting(input.ID)
 	deleted := false
-	defer func() {
-		// Keep successful deletions marked so setup dispatchers already queued on
-		// the old generation cannot reopen admission after the row is gone.
-		if !deleted {
-			s.unmarkWorkspaceDeleting(input.ID)
-		}
-	}()
+	// A successful deletion keeps admission closed permanently so queued setup
+	// dispatchers cannot recreate resources for the removed row; a failed one
+	// reopens admission only after every concurrent deletion has finished.
+	defer func() { s.finishWorkspaceDeleting(input.ID, deleted) }()
 
 	if s.runtime != nil {
 		// Block new launches before the dirty preflight; existing

--- a/internal/server/workspaceapi/routes_handlers.go
+++ b/internal/server/workspaceapi/routes_handlers.go
@@ -295,6 +295,9 @@ func (s *Handler) runWorkspaceSetup(ws *workspace.Workspace) {
 
 func (s *Handler) runWorkspaceSetupWithBasePath(ws *workspace.Workspace, basePath string) {
 	done, start := s.beginWorkspaceSetup(ws.ID)
+	if done == nil {
+		return
+	}
 	if !start {
 		s.runBackground(func(ctx context.Context) {
 			select {
@@ -387,6 +390,9 @@ func (s *Handler) runWorkspaceSetupWithBasePath(ws *workspace.Workspace, basePat
 func (s *Handler) beginWorkspaceSetup(workspaceID string) (chan struct{}, bool) {
 	s.workspaceSetupMu.Lock()
 	defer s.workspaceSetupMu.Unlock()
+	if s.workspaceDeleting[workspaceID] {
+		return nil, false
+	}
 	if done, ok := s.workspaceSetupDone[workspaceID]; ok {
 		return done, false
 	}
@@ -404,12 +410,21 @@ func (s *Handler) finishWorkspaceSetup(workspaceID string, done chan struct{}) {
 	s.workspaceSetupMu.Unlock()
 }
 
-func (s *Handler) waitForWorkspaceSetup(
-	ctx context.Context, workspaceID string,
-) error {
+func (s *Handler) markWorkspaceDeleting(workspaceID string) <-chan struct{} {
 	s.workspaceSetupMu.Lock()
+	s.workspaceDeleting[workspaceID] = true
 	done := s.workspaceSetupDone[workspaceID]
 	s.workspaceSetupMu.Unlock()
+	return done
+}
+
+func (s *Handler) unmarkWorkspaceDeleting(workspaceID string) {
+	s.workspaceSetupMu.Lock()
+	delete(s.workspaceDeleting, workspaceID)
+	s.workspaceSetupMu.Unlock()
+}
+
+func waitForWorkspaceSetup(ctx context.Context, done <-chan struct{}) error {
 	if done == nil {
 		return nil
 	}
@@ -2403,6 +2418,16 @@ func (s *Handler) deleteWorkspace(
 		return nil, httpapi.ServiceUnavailable("workspace manager not configured")
 	}
 
+	setupDone := s.markWorkspaceDeleting(input.ID)
+	deleted := false
+	defer func() {
+		// Keep successful deletions marked so setup dispatchers already queued on
+		// the old generation cannot reopen admission after the row is gone.
+		if !deleted {
+			s.unmarkWorkspaceDeleting(input.ID)
+		}
+	}()
+
 	if s.runtime != nil {
 		// Block new launches before the dirty preflight; existing
 		// sessions are stopped only after the preflight passes.
@@ -2413,7 +2438,7 @@ func (s *Handler) deleteWorkspace(
 			s.runtime.EndStopping(input.ID)
 		}
 	}()
-	if err := s.waitForWorkspaceSetup(ctx, input.ID); err != nil {
+	if err := waitForWorkspaceSetup(ctx, setupDone); err != nil {
 		return nil, httpapi.Internal("wait for workspace setup: " + err.Error())
 	}
 	dirty, err := s.workspaces.Delete(
@@ -2442,5 +2467,6 @@ func (s *Handler) deleteWorkspace(
 			"workspace has uncommitted changes: "+strings.Join(dirty, ", "), nil)
 	}
 
+	deleted = true
 	return nil, nil
 }

--- a/internal/server/workspaceapi/routes_handlers.go
+++ b/internal/server/workspaceapi/routes_handlers.go
@@ -294,7 +294,19 @@ func (s *Handler) runWorkspaceSetup(ws *workspace.Workspace) {
 }
 
 func (s *Handler) runWorkspaceSetupWithBasePath(ws *workspace.Workspace, basePath string) {
-	s.runBackground(func(bgCtx context.Context) {
+	done, start := s.beginWorkspaceSetup(ws.ID)
+	if !start {
+		s.runBackground(func(ctx context.Context) {
+			select {
+			case <-done:
+				s.runWorkspaceSetupWithBasePath(ws, basePath)
+			case <-ctx.Done():
+			}
+		})
+		return
+	}
+	if !s.runBackground(func(bgCtx context.Context) {
+		defer s.finishWorkspaceSetup(ws.ID, done)
 		for {
 			setupErr := s.workspaces.SetupWithWorktreeBasePath(bgCtx, ws, basePath)
 			summary, getErr := s.workspaces.GetSummary(
@@ -367,7 +379,46 @@ func (s *Handler) runWorkspaceSetupWithBasePath(ws *workspace.Workspace, basePat
 				Data: s.toWorkspaceResponse(bgCtx, summary),
 			})
 		}
-	})
+	}) {
+		s.finishWorkspaceSetup(ws.ID, done)
+	}
+}
+
+func (s *Handler) beginWorkspaceSetup(workspaceID string) (chan struct{}, bool) {
+	s.workspaceSetupMu.Lock()
+	defer s.workspaceSetupMu.Unlock()
+	if done, ok := s.workspaceSetupDone[workspaceID]; ok {
+		return done, false
+	}
+	done := make(chan struct{})
+	s.workspaceSetupDone[workspaceID] = done
+	return done, true
+}
+
+func (s *Handler) finishWorkspaceSetup(workspaceID string, done chan struct{}) {
+	s.workspaceSetupMu.Lock()
+	if s.workspaceSetupDone[workspaceID] == done {
+		delete(s.workspaceSetupDone, workspaceID)
+		close(done)
+	}
+	s.workspaceSetupMu.Unlock()
+}
+
+func (s *Handler) waitForWorkspaceSetup(
+	ctx context.Context, workspaceID string,
+) error {
+	s.workspaceSetupMu.Lock()
+	done := s.workspaceSetupDone[workspaceID]
+	s.workspaceSetupMu.Unlock()
+	if done == nil {
+		return nil
+	}
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // RunWorkspaceSetupWithBasePath starts asynchronous materialization for a
@@ -2362,6 +2413,9 @@ func (s *Handler) deleteWorkspace(
 			s.runtime.EndStopping(input.ID)
 		}
 	}()
+	if err := s.waitForWorkspaceSetup(ctx, input.ID); err != nil {
+		return nil, httpapi.Internal("wait for workspace setup: " + err.Error())
+	}
 	dirty, err := s.workspaces.Delete(
 		ctx, input.ID, input.Force,
 		func(stopCtx context.Context) {

--- a/internal/server/workspacetest/workspace_clone_safety_test.go
+++ b/internal/server/workspacetest/workspace_clone_safety_test.go
@@ -685,6 +685,50 @@ func TestWorkspaceRetryRejectsPreMarkerWorkspaceAfterUpgradeE2E(
 	)
 }
 
+func TestWorkspaceRetryCleansStalePreMarkerRegistrationE2E(t *testing.T) {
+	t.Parallel()
+	acquireWorkspaceGitSlot(t)
+
+	require := require.New(t)
+	assert := assert.New(t)
+	fixture := setupWorkspaceServerFixture(t, nil)
+	ctx := t.Context()
+
+	ws := createReadyWorkspace(t, ctx, fixture.client)
+	branch := workspaceGitOutput(t, ws.WorktreePath, "branch", "--show-current")
+	metadataDir := workspaceGitOutput(
+		t, ws.WorktreePath,
+		"rev-parse", "--path-format=absolute", "--git-dir",
+	)
+	require.NoError(os.Remove(filepath.Join(metadataDir, "kenn-forge-workspace-id")))
+	require.NoError(os.RemoveAll(ws.WorktreePath))
+	errorMessage := "simulate missing worktree after upgrade"
+	require.NoError(fixture.database.UpdateWorkspaceStatus(
+		ctx, ws.Id, "error", &errorMessage,
+	))
+
+	retryResp, err := fixture.client.HTTP.RetryWorkspaceWithResponse(ctx, ws.Id)
+	require.NoError(err)
+	require.Equal(
+		http.StatusAccepted, retryResp.StatusCode(), string(retryResp.Body),
+	)
+
+	ready := waitForWorkspaceReady(t, ctx, fixture.client, ws.Id)
+	assert.Equal(branch, workspaceGitOutput(
+		t, ready.WorktreePath, "branch", "--show-current",
+	))
+	require.FileExists(filepath.Join(ready.WorktreePath, ".git"))
+	newMetadataDir := workspaceGitOutput(
+		t, ready.WorktreePath,
+		"rev-parse", "--path-format=absolute", "--git-dir",
+	)
+	marker, err := os.ReadFile(filepath.Join(
+		newMetadataDir, "kenn-forge-workspace-id",
+	))
+	require.NoError(err)
+	assert.Equal(ws.Id+"\n", string(marker))
+}
+
 func TestWorkspaceCreateOccupiedPathCreatesNoBranchesE2E(t *testing.T) {
 	t.Parallel()
 	acquireWorkspaceGitSlot(t)

--- a/internal/server/workspacetest/workspace_clone_safety_test.go
+++ b/internal/server/workspacetest/workspace_clone_safety_test.go
@@ -554,6 +554,69 @@ func TestWorkspaceForceDeleteRejectsSymlinkToSameRepoWorktreeE2E(
 	)
 }
 
+func TestWorkspaceCreateRejectsSymlinkedReusableWorktreeE2E(t *testing.T) {
+	t.Parallel()
+	acquireWorkspaceGitSlot(t)
+
+	require := require.New(t)
+	assert := assert.New(t)
+	fixture := setupWorkspaceServerFixture(t, nil)
+	ctx := t.Context()
+
+	worktreePath := filepath.Join(
+		fixture.worktreeDir, "github", "github.com", "acme", "widget", "pr-1",
+	)
+	targetPath := filepath.Join(t.TempDir(), "linked-worktree")
+	runGit(t, fixture.bare, "worktree", "add", targetPath, "feature")
+	require.NoError(os.MkdirAll(filepath.Dir(worktreePath), 0o755))
+	require.NoError(os.Symlink(targetPath, worktreePath))
+	wantHead := testGitSHA(t, targetPath, "HEAD")
+
+	createResp, err := fixture.client.HTTP.CreateWorkspaceWithResponse(
+		ctx,
+		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
+			PlatformHost: "github.com",
+			Owner:        "acme",
+			Name:         "widget",
+			MrNumber:     1,
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusAccepted, createResp.StatusCode())
+	require.NotNil(createResp.JSON202)
+
+	var terminal *generated.WorkspaceResponse
+	require.Eventually(func() bool {
+		getResp, getErr := fixture.client.HTTP.GetWorkspaceWithResponse(
+			ctx, createResp.JSON202.Id,
+		)
+		if getErr != nil || getResp.JSON200 == nil ||
+			getResp.JSON200.Status == "creating" {
+			return false
+		}
+		terminal = getResp.JSON200
+		return true
+	}, 10*time.Second, 25*time.Millisecond)
+	require.NotNil(terminal)
+	assert.Equal("error", terminal.Status)
+
+	pathInfo, err := os.Lstat(worktreePath)
+	require.NoError(err)
+	assert.NotZero(pathInfo.Mode() & os.ModeSymlink)
+	assert.Equal(wantHead, testGitSHA(t, targetPath, "HEAD"))
+	assert.Contains(
+		workspaceGitOutput(t, fixture.bare, "worktree", "list", "--porcelain"),
+		targetPath,
+	)
+	metadataDir := workspaceGitOutput(
+		t, targetPath,
+		"rev-parse", "--path-format=absolute", "--git-dir",
+	)
+	_, err = os.Lstat(filepath.Join(metadataDir, "kenn-forge-workspace-id"))
+	assert.ErrorIs(err, os.ErrNotExist)
+}
+
 func TestWorkspaceRetryRejectsPreMarkerWorkspaceAfterUpgradeE2E(
 	t *testing.T,
 ) {

--- a/internal/server/workspacetest/workspace_clone_safety_test.go
+++ b/internal/server/workspacetest/workspace_clone_safety_test.go
@@ -25,6 +25,33 @@ func setupLifecycleWorkspaceServer(t *testing.T) (*apiclient.Client, *db.DB, str
 	return fixture.client, fixture.database, fixture.bare, fixture.remote
 }
 
+func TestWorkspaceForceDeleteToleratesCorruptWorktreeGitfileE2E(t *testing.T) {
+	t.Parallel()
+	acquireWorkspaceGitSlot(t)
+
+	require := require.New(t)
+	assert := assert.New(t)
+	client, database, _, _ := setupLifecycleWorkspaceServer(t)
+	ctx := t.Context()
+	ws := createReadyWorkspace(t, ctx, client)
+
+	gitfile := filepath.Join(ws.WorktreePath, ".git")
+	require.FileExists(gitfile)
+	require.NoError(os.Truncate(gitfile, 0))
+
+	force := true
+	deleteResp, err := client.HTTP.DeleteWorkspaceWithResponse(
+		ctx, ws.Id, &generated.DeleteWorkspaceParams{Force: &force},
+	)
+	require.NoError(err)
+	require.Equal(
+		http.StatusNoContent, deleteResp.StatusCode(), string(deleteResp.Body),
+	)
+	stored, err := database.GetWorkspace(ctx, ws.Id)
+	require.NoError(err)
+	assert.Nil(stored)
+}
+
 // TestWorkspaceForceDeleteQuarantinesReplacedWorktreeAndAllowsRecreateE2E
 // covers the user-visible recovery path when a workspace directory no longer
 // contains the linked worktree registered by its managed clone.

--- a/internal/server/workspacetest/workspace_clone_safety_test.go
+++ b/internal/server/workspacetest/workspace_clone_safety_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -24,14 +25,12 @@ func setupLifecycleWorkspaceServer(t *testing.T) (*apiclient.Client, *db.DB, str
 	return fixture.client, fixture.database, fixture.bare, fixture.remote
 }
 
-// TestWorkspaceForceDeleteToleratesCorruptWorktreeGitfileE2E verifies a
-// workspace whose worktree .git gitfile was left empty by an
-// interrupted "git worktree add" (the daemon canceling background
-// setup at shutdown) can still be force-deleted through the API. Git
-// rejects such a worktree with "invalid gitfile format", which the
-// delete path's worktree-ownership probe surfaced as a 500 before the
-// fix — leaving the workspace permanently undeletable.
-func TestWorkspaceForceDeleteToleratesCorruptWorktreeGitfileE2E(t *testing.T) {
+// TestWorkspaceForceDeleteQuarantinesReplacedWorktreeAndAllowsRecreateE2E
+// covers the user-visible recovery path when a workspace directory no longer
+// contains the linked worktree registered by its managed clone.
+func TestWorkspaceForceDeleteQuarantinesReplacedWorktreeAndAllowsRecreateE2E(
+	t *testing.T,
+) {
 	t.Parallel()
 	acquireWorkspaceGitSlot(t)
 
@@ -39,14 +38,17 @@ func TestWorkspaceForceDeleteToleratesCorruptWorktreeGitfileE2E(t *testing.T) {
 	assert := assert.New(t)
 
 	client, database, _, _ := setupLifecycleWorkspaceServer(t)
-	ctx := context.Background()
+	ctx := t.Context()
 	ws := createReadyWorkspace(t, ctx, client)
+	worktreePath := ws.WorktreePath
 
-	gitfile := filepath.Join(ws.WorktreePath, ".git")
-	require.FileExists(gitfile)
-	// Truncate the worktree's .git gitfile to reproduce the corrupt
-	// state an interrupted "git worktree add" leaves behind.
-	require.NoError(os.Truncate(gitfile, 0))
+	require.NoError(os.RemoveAll(worktreePath))
+	require.NoError(os.MkdirAll(worktreePath, 0o755))
+	require.NoError(os.WriteFile(
+		filepath.Join(worktreePath, "recover.txt"),
+		[]byte("preserve me\n"),
+		0o644,
+	))
 
 	force := true
 	delResp, err := client.HTTP.DeleteWorkspaceWithResponse(
@@ -60,6 +62,612 @@ func TestWorkspaceForceDeleteToleratesCorruptWorktreeGitfileE2E(t *testing.T) {
 	got, err := database.GetWorkspace(ctx, ws.Id)
 	require.NoError(err)
 	assert.Nil(got)
+	_, err = os.Lstat(worktreePath)
+	require.ErrorIs(err, os.ErrNotExist)
+	recoveryPaths, err := filepath.Glob(worktreePath + ".orphaned-*")
+	require.NoError(err)
+	require.Len(recoveryPaths, 1)
+	contents, err := os.ReadFile(filepath.Join(recoveryPaths[0], "recover.txt"))
+	require.NoError(err)
+	assert.Equal("preserve me\n", string(contents))
+
+	recreateCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	recreated := createReadyWorkspace(t, recreateCtx, client)
+	assert.NotEqual(ws.Id, recreated.Id)
+	assert.Equal(worktreePath, recreated.WorktreePath)
+	require.FileExists(filepath.Join(recreated.WorktreePath, ".git"))
+}
+
+func TestWorkspaceForceDeleteQuarantinesReplacementFileAndAllowsRecreateE2E(
+	t *testing.T,
+) {
+	t.Parallel()
+	acquireWorkspaceGitSlot(t)
+
+	require := require.New(t)
+	assert := assert.New(t)
+
+	client, database, _, _ := setupLifecycleWorkspaceServer(t)
+	ctx := t.Context()
+	ws := createReadyWorkspace(t, ctx, client)
+	worktreePath := ws.WorktreePath
+
+	require.NoError(os.RemoveAll(worktreePath))
+	require.NoError(os.WriteFile(
+		worktreePath, []byte("preserve replacement file\n"), 0o644,
+	))
+
+	force := true
+	deleteResp, err := client.HTTP.DeleteWorkspaceWithResponse(
+		ctx, ws.Id, &generated.DeleteWorkspaceParams{Force: &force},
+	)
+	require.NoError(err)
+	require.Equal(
+		http.StatusNoContent, deleteResp.StatusCode(), string(deleteResp.Body),
+	)
+
+	stored, err := database.GetWorkspace(ctx, ws.Id)
+	require.NoError(err)
+	assert.Nil(stored)
+	_, err = os.Lstat(worktreePath)
+	require.ErrorIs(err, os.ErrNotExist)
+	recoveryPaths, err := filepath.Glob(worktreePath + ".orphaned-*")
+	require.NoError(err)
+	require.Len(recoveryPaths, 1)
+	contents, err := os.ReadFile(recoveryPaths[0])
+	require.NoError(err)
+	assert.Equal("preserve replacement file\n", string(contents))
+
+	recreated := createReadyWorkspace(t, ctx, client)
+	assert.NotEqual(ws.Id, recreated.Id)
+	assert.Equal(worktreePath, recreated.WorktreePath)
+	require.FileExists(filepath.Join(recreated.WorktreePath, ".git"))
+}
+
+func TestWorkspaceForceDeleteReplacementCloneClearsManagedRegistrationE2E(
+	t *testing.T,
+) {
+	t.Parallel()
+	acquireWorkspaceGitSlot(t)
+
+	require := require.New(t)
+	assert := assert.New(t)
+	fixture := setupWorkspaceServerFixture(t, nil)
+	ctx := t.Context()
+
+	// Force setup onto the managed fallback branch so deletion has both a
+	// linked-worktree registration and a Kenn Forge branch to clear.
+	runGit(t, fixture.bare, "update-ref", "refs/heads/feature", "refs/heads/main")
+	ws := createReadyWorkspace(t, ctx, fixture.client)
+	worktreePath := ws.WorktreePath
+	assert.Equal(
+		"kenn-forge/pr-1",
+		workspaceGitOutput(t, worktreePath, "branch", "--show-current"),
+	)
+
+	require.NoError(os.RemoveAll(worktreePath))
+	runGit(t, filepath.Dir(worktreePath), "clone", fixture.remote, worktreePath)
+	runGit(
+		t, worktreePath, "remote", "set-url", "origin",
+		"https://github.com/acme/widget.git",
+	)
+	require.NoError(os.WriteFile(
+		filepath.Join(worktreePath, "foreign.txt"), []byte("preserve me\n"), 0o644,
+	))
+	foreignHead := testGitSHA(t, worktreePath, "HEAD")
+
+	force := true
+	deleteResp, err := fixture.client.HTTP.DeleteWorkspaceWithResponse(
+		ctx, ws.Id, &generated.DeleteWorkspaceParams{Force: &force},
+	)
+	require.NoError(err)
+	require.Equal(
+		http.StatusNoContent, deleteResp.StatusCode(), string(deleteResp.Body),
+	)
+
+	stored, err := fixture.database.GetWorkspace(ctx, ws.Id)
+	require.NoError(err)
+	assert.Nil(stored)
+	assert.Equal(foreignHead, testGitSHA(t, worktreePath, "HEAD"))
+	contents, err := os.ReadFile(filepath.Join(worktreePath, "foreign.txt"))
+	require.NoError(err)
+	assert.Equal("preserve me\n", string(contents))
+	assert.NotContains(
+		workspaceGitOutput(t, fixture.bare, "worktree", "list", "--porcelain"),
+		worktreePath,
+	)
+	requireGitRefMissing(t, fixture.bare, "refs/heads/kenn-forge/pr-1")
+
+	require.NoError(os.RemoveAll(worktreePath))
+	recreated := createReadyWorkspace(t, ctx, fixture.client)
+	assert.Equal(worktreePath, recreated.WorktreePath)
+	assert.Equal(
+		"kenn-forge/pr-1",
+		workspaceGitOutput(t, worktreePath, "branch", "--show-current"),
+	)
+}
+
+func TestWorkspaceForceDeletePreservesSameOriginForeignLinkedWorktreeE2E(
+	t *testing.T,
+) {
+	t.Parallel()
+	acquireWorkspaceGitSlot(t)
+
+	require := require.New(t)
+	assert := assert.New(t)
+	fixture := setupWorkspaceServerFixture(t, nil)
+	ctx := t.Context()
+
+	runGit(t, fixture.bare, "update-ref", "refs/heads/feature", "refs/heads/main")
+	ws := createReadyWorkspace(t, ctx, fixture.client)
+	worktreePath := ws.WorktreePath
+	assert.Equal(
+		"kenn-forge/pr-1",
+		workspaceGitOutput(t, worktreePath, "branch", "--show-current"),
+	)
+
+	require.NoError(os.RemoveAll(worktreePath))
+	foreignGitDir := filepath.Join(t.TempDir(), "foreign.git")
+	runGit(t, filepath.Dir(foreignGitDir), "clone", "--bare", fixture.remote, foreignGitDir)
+	runGit(
+		t, foreignGitDir, "remote", "set-url", "origin",
+		"https://github.com/acme/widget.git",
+	)
+	runGit(
+		t, foreignGitDir, "worktree", "add", worktreePath,
+		"-b", "foreign/scratch", "HEAD",
+	)
+	require.NoError(os.WriteFile(
+		filepath.Join(worktreePath, "base.txt"), []byte("foreign dirty data\n"), 0o644,
+	))
+	foreignHead := testGitSHA(t, worktreePath, "HEAD")
+
+	force := true
+	deleteResp, err := fixture.client.HTTP.DeleteWorkspaceWithResponse(
+		ctx, ws.Id, &generated.DeleteWorkspaceParams{Force: &force},
+	)
+	require.NoError(err)
+	require.Equal(
+		http.StatusNoContent, deleteResp.StatusCode(), string(deleteResp.Body),
+	)
+
+	stored, err := fixture.database.GetWorkspace(ctx, ws.Id)
+	require.NoError(err)
+	assert.Nil(stored)
+	require.FileExists(filepath.Join(worktreePath, ".git"))
+	contents, err := os.ReadFile(filepath.Join(worktreePath, "base.txt"))
+	require.NoError(err)
+	assert.Equal("foreign dirty data\n", string(contents))
+	assert.Equal(foreignHead, testGitSHA(t, worktreePath, "HEAD"))
+	assert.Contains(
+		workspaceGitOutput(t, worktreePath, "status", "--porcelain"),
+		"M base.txt",
+	)
+	assert.Contains(
+		workspaceGitOutput(t, foreignGitDir, "worktree", "list", "--porcelain"),
+		worktreePath,
+	)
+	assert.NotContains(
+		workspaceGitOutput(t, fixture.bare, "worktree", "list", "--porcelain"),
+		worktreePath,
+	)
+	requireGitRefMissing(t, fixture.bare, "refs/heads/kenn-forge/pr-1")
+
+	runGit(t, foreignGitDir, "worktree", "remove", "--force", worktreePath)
+	recreated := createReadyWorkspace(t, ctx, fixture.client)
+	assert.Equal(worktreePath, recreated.WorktreePath)
+	assert.Equal(
+		"kenn-forge/pr-1",
+		workspaceGitOutput(t, worktreePath, "branch", "--show-current"),
+	)
+}
+
+func TestWorkspaceForceDeletePreservesForeignLinkedWorktreeAfterManagedPruneE2E(
+	t *testing.T,
+) {
+	t.Parallel()
+	acquireWorkspaceGitSlot(t)
+
+	require := require.New(t)
+	assert := assert.New(t)
+	fixture := setupWorkspaceServerFixture(t, nil)
+	ctx := t.Context()
+
+	runGit(t, fixture.bare, "update-ref", "refs/heads/feature", "refs/heads/main")
+	ws := createReadyWorkspace(t, ctx, fixture.client)
+	worktreePath := ws.WorktreePath
+	assert.Equal(
+		"kenn-forge/pr-1",
+		workspaceGitOutput(t, worktreePath, "branch", "--show-current"),
+	)
+
+	require.NoError(os.RemoveAll(worktreePath))
+	runGit(t, fixture.bare, "worktree", "prune")
+	assert.NotContains(
+		workspaceGitOutput(t, fixture.bare, "worktree", "list", "--porcelain"),
+		worktreePath,
+	)
+
+	foreignGitDir := filepath.Join(t.TempDir(), "foreign.git")
+	runGit(t, filepath.Dir(foreignGitDir), "clone", "--bare", fixture.remote, foreignGitDir)
+	runGit(
+		t, foreignGitDir, "remote", "set-url", "origin",
+		"https://github.com/acme/widget.git",
+	)
+	runGit(
+		t, foreignGitDir, "worktree", "add", worktreePath,
+		"-b", "foreign/scratch", "HEAD",
+	)
+	require.NoError(os.WriteFile(
+		filepath.Join(worktreePath, "base.txt"), []byte("foreign dirty data\n"), 0o644,
+	))
+	foreignHead := testGitSHA(t, worktreePath, "HEAD")
+
+	force := true
+	deleteResp, err := fixture.client.HTTP.DeleteWorkspaceWithResponse(
+		ctx, ws.Id, &generated.DeleteWorkspaceParams{Force: &force},
+	)
+	require.NoError(err)
+	require.Equal(
+		http.StatusNoContent, deleteResp.StatusCode(), string(deleteResp.Body),
+	)
+
+	stored, err := fixture.database.GetWorkspace(ctx, ws.Id)
+	require.NoError(err)
+	assert.Nil(stored)
+	require.FileExists(filepath.Join(worktreePath, ".git"))
+	contents, err := os.ReadFile(filepath.Join(worktreePath, "base.txt"))
+	require.NoError(err)
+	assert.Equal("foreign dirty data\n", string(contents))
+	assert.Equal(foreignHead, testGitSHA(t, worktreePath, "HEAD"))
+	assert.Contains(
+		workspaceGitOutput(t, worktreePath, "status", "--porcelain"),
+		"M base.txt",
+	)
+	assert.Contains(
+		workspaceGitOutput(t, foreignGitDir, "worktree", "list", "--porcelain"),
+		worktreePath,
+	)
+}
+
+func TestWorkspaceForceDeleteRejectsSameRepoReplacementAfterManagedPruneE2E(
+	t *testing.T,
+) {
+	t.Parallel()
+	acquireWorkspaceGitSlot(t)
+
+	require := require.New(t)
+	assert := assert.New(t)
+	fixture := setupWorkspaceServerFixture(t, nil)
+	ctx := t.Context()
+
+	runGit(t, fixture.bare, "update-ref", "refs/heads/feature", "refs/heads/main")
+	ws := createReadyWorkspace(t, ctx, fixture.client)
+	worktreePath := ws.WorktreePath
+	assert.Equal(
+		"kenn-forge/pr-1",
+		workspaceGitOutput(t, worktreePath, "branch", "--show-current"),
+	)
+
+	require.NoError(os.RemoveAll(worktreePath))
+	runGit(t, fixture.bare, "worktree", "prune")
+	runGit(
+		t, fixture.bare, "worktree", "add", worktreePath,
+		"-b", "foreign/scratch", "HEAD",
+	)
+	require.NoError(os.WriteFile(
+		filepath.Join(worktreePath, "base.txt"), []byte("foreign dirty data\n"), 0o644,
+	))
+	foreignHead := testGitSHA(t, worktreePath, "HEAD")
+
+	force := true
+	deleteResp, err := fixture.client.HTTP.DeleteWorkspaceWithResponse(
+		ctx, ws.Id, &generated.DeleteWorkspaceParams{Force: &force},
+	)
+	require.NoError(err)
+	require.Equal(
+		http.StatusConflict, deleteResp.StatusCode(), string(deleteResp.Body),
+	)
+
+	stored, err := fixture.database.GetWorkspace(ctx, ws.Id)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.Equal(ws.Id, stored.ID)
+	require.FileExists(filepath.Join(worktreePath, ".git"))
+	contents, err := os.ReadFile(filepath.Join(worktreePath, "base.txt"))
+	require.NoError(err)
+	assert.Equal("foreign dirty data\n", string(contents))
+	assert.Equal(foreignHead, testGitSHA(t, worktreePath, "HEAD"))
+	assert.Contains(
+		workspaceGitOutput(t, worktreePath, "status", "--porcelain"),
+		"M base.txt",
+	)
+	assert.Contains(
+		workspaceGitOutput(t, fixture.bare, "worktree", "list", "--porcelain"),
+		worktreePath,
+	)
+	assert.Equal(
+		foreignHead,
+		testGitSHA(t, fixture.bare, "refs/heads/foreign/scratch"),
+	)
+}
+
+func TestWorkspaceForceDeleteRejectsPreMarkerWorkspaceAfterUpgradeE2E(
+	t *testing.T,
+) {
+	t.Parallel()
+	acquireWorkspaceGitSlot(t)
+
+	require := require.New(t)
+	assert := assert.New(t)
+	fixture := setupWorkspaceServerFixture(t, nil)
+	ctx := t.Context()
+
+	runGit(t, fixture.bare, "update-ref", "refs/heads/feature", "refs/heads/main")
+	ws := createReadyWorkspace(t, ctx, fixture.client)
+	worktreePath := ws.WorktreePath
+	assert.Equal(
+		"kenn-forge/pr-1",
+		workspaceGitOutput(t, worktreePath, "branch", "--show-current"),
+	)
+	metadataDir := workspaceGitOutput(
+		t, worktreePath,
+		"rev-parse", "--path-format=absolute", "--git-dir",
+	)
+	require.NoError(os.Remove(filepath.Join(metadataDir, "kenn-forge-workspace-id")))
+
+	force := true
+	deleteResp, err := fixture.client.HTTP.DeleteWorkspaceWithResponse(
+		ctx, ws.Id, &generated.DeleteWorkspaceParams{Force: &force},
+	)
+	require.NoError(err)
+	require.Equal(
+		http.StatusConflict, deleteResp.StatusCode(), string(deleteResp.Body),
+	)
+
+	stored, err := fixture.database.GetWorkspace(ctx, ws.Id)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.Equal(ws.Id, stored.ID)
+	require.FileExists(filepath.Join(worktreePath, ".git"))
+	assert.Equal(
+		"kenn-forge/pr-1",
+		workspaceGitOutput(t, worktreePath, "branch", "--show-current"),
+	)
+	assert.Contains(
+		workspaceGitOutput(t, fixture.bare, "worktree", "list", "--porcelain"),
+		worktreePath,
+	)
+	assert.Equal(
+		testGitSHA(t, worktreePath, "HEAD"),
+		testGitSHA(t, fixture.bare, "refs/heads/kenn-forge/pr-1"),
+	)
+}
+
+func TestWorkspaceForceDeleteRetainsLockedWorktreeE2E(t *testing.T) {
+	t.Parallel()
+	acquireWorkspaceGitSlot(t)
+
+	require := require.New(t)
+	assert := assert.New(t)
+	fixture := setupWorkspaceServerFixture(t, nil)
+	ctx := t.Context()
+
+	ws := createReadyWorkspace(t, ctx, fixture.client)
+	runGit(
+		t, fixture.bare, "worktree", "lock", "--reason", "test lock",
+		ws.WorktreePath,
+	)
+
+	force := true
+	deleteResp, err := fixture.client.HTTP.DeleteWorkspaceWithResponse(
+		ctx, ws.Id, &generated.DeleteWorkspaceParams{Force: &force},
+	)
+	require.NoError(err)
+	require.Equal(
+		http.StatusInternalServerError,
+		deleteResp.StatusCode(),
+		string(deleteResp.Body),
+	)
+
+	stored, err := fixture.database.GetWorkspace(ctx, ws.Id)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.Equal(ws.Id, stored.ID)
+	require.FileExists(filepath.Join(ws.WorktreePath, ".git"))
+	assert.Contains(
+		workspaceGitOutput(t, fixture.bare, "worktree", "list", "--porcelain"),
+		ws.WorktreePath,
+	)
+	metadataDir := workspaceGitOutput(
+		t, ws.WorktreePath,
+		"rev-parse", "--path-format=absolute", "--git-dir",
+	)
+	marker, err := os.ReadFile(filepath.Join(metadataDir, "kenn-forge-workspace-id"))
+	require.NoError(err)
+	assert.Equal(ws.Id+"\n", string(marker))
+
+	runGit(t, fixture.bare, "worktree", "unlock", ws.WorktreePath)
+	deleteResp, err = fixture.client.HTTP.DeleteWorkspaceWithResponse(
+		ctx, ws.Id, &generated.DeleteWorkspaceParams{Force: &force},
+	)
+	require.NoError(err)
+	require.Equal(
+		http.StatusNoContent, deleteResp.StatusCode(), string(deleteResp.Body),
+	)
+	stored, err = fixture.database.GetWorkspace(ctx, ws.Id)
+	require.NoError(err)
+	assert.Nil(stored)
+}
+
+func TestWorkspaceForceDeleteRejectsSymlinkToSameRepoWorktreeE2E(
+	t *testing.T,
+) {
+	t.Parallel()
+	acquireWorkspaceGitSlot(t)
+
+	require := require.New(t)
+	assert := assert.New(t)
+	fixture := setupWorkspaceServerFixture(t, nil)
+	ctx := t.Context()
+
+	ws := createReadyWorkspace(t, ctx, fixture.client)
+	worktreePath := ws.WorktreePath
+	require.NoError(os.RemoveAll(worktreePath))
+	runGit(t, fixture.bare, "worktree", "prune")
+
+	targetPath := filepath.Join(t.TempDir(), "replacement-worktree")
+	runGit(
+		t, fixture.bare, "worktree", "add", targetPath,
+		"-b", "foreign/symlink-target", "HEAD",
+	)
+	require.NoError(os.WriteFile(
+		filepath.Join(targetPath, "base.txt"), []byte("foreign dirty data\n"), 0o644,
+	))
+	require.NoError(os.Symlink(targetPath, worktreePath))
+	foreignHead := testGitSHA(t, targetPath, "HEAD")
+
+	force := true
+	deleteResp, err := fixture.client.HTTP.DeleteWorkspaceWithResponse(
+		ctx, ws.Id, &generated.DeleteWorkspaceParams{Force: &force},
+	)
+	require.NoError(err)
+	require.Equal(
+		http.StatusConflict, deleteResp.StatusCode(), string(deleteResp.Body),
+	)
+
+	stored, err := fixture.database.GetWorkspace(ctx, ws.Id)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.Equal(ws.Id, stored.ID)
+	pathInfo, err := os.Lstat(worktreePath)
+	require.NoError(err)
+	assert.NotZero(pathInfo.Mode() & os.ModeSymlink)
+	contents, err := os.ReadFile(filepath.Join(targetPath, "base.txt"))
+	require.NoError(err)
+	assert.Equal("foreign dirty data\n", string(contents))
+	assert.Equal(foreignHead, testGitSHA(t, targetPath, "HEAD"))
+	assert.Contains(
+		workspaceGitOutput(t, fixture.bare, "worktree", "list", "--porcelain"),
+		targetPath,
+	)
+}
+
+func TestWorkspaceRetryRejectsPreMarkerWorkspaceAfterUpgradeE2E(
+	t *testing.T,
+) {
+	t.Parallel()
+	acquireWorkspaceGitSlot(t)
+
+	require := require.New(t)
+	assert := assert.New(t)
+	fixture := setupWorkspaceServerFixture(t, nil)
+	ctx := t.Context()
+
+	ws := createReadyWorkspace(t, ctx, fixture.client)
+	metadataDir := workspaceGitOutput(
+		t, ws.WorktreePath,
+		"rev-parse", "--path-format=absolute", "--git-dir",
+	)
+	require.NoError(os.Remove(filepath.Join(metadataDir, "kenn-forge-workspace-id")))
+	errorMessage := "simulate setup failure before upgrade"
+	require.NoError(fixture.database.UpdateWorkspaceStatus(
+		ctx, ws.Id, "error", &errorMessage,
+	))
+
+	retryResp, err := fixture.client.HTTP.RetryWorkspaceWithResponse(ctx, ws.Id)
+	require.NoError(err)
+	require.Equal(
+		http.StatusConflict, retryResp.StatusCode(), string(retryResp.Body),
+	)
+
+	stored, err := fixture.database.GetWorkspace(ctx, ws.Id)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.Equal("error", stored.Status)
+	require.NotNil(stored.ErrorMessage)
+	assert.NotEmpty(*stored.ErrorMessage)
+	require.FileExists(filepath.Join(ws.WorktreePath, ".git"))
+	assert.Contains(
+		workspaceGitOutput(t, fixture.bare, "worktree", "list", "--porcelain"),
+		ws.WorktreePath,
+	)
+}
+
+func TestWorkspaceCreateOccupiedPathCreatesNoBranchesE2E(t *testing.T) {
+	t.Parallel()
+	acquireWorkspaceGitSlot(t)
+
+	require := require.New(t)
+	assert := assert.New(t)
+	fixture := setupWorkspaceServerFixture(t, nil)
+	ctx := t.Context()
+
+	const (
+		mrNumber        = 2
+		preferredBranch = "topic/occupied-path"
+		fallbackBranch  = "kenn-forge/pr-2"
+	)
+	seedPRWithHeadRepo(
+		t, fixture.database, "github.com", "acme", "widget", mrNumber,
+		"https://github.com/contributor/widget.git",
+	)
+	headSHA := testGitSHA(t, fixture.remote, "refs/heads/feature")
+	runGit(t, fixture.remote, "update-ref", "refs/pull/2/head", headSHA)
+	_, err := fixture.database.WriteDB().ExecContext(
+		ctx,
+		`UPDATE forge_merge_requests SET head_branch = ? WHERE number = ?`,
+		preferredBranch, mrNumber,
+	)
+	require.NoError(err)
+
+	worktreePath := filepath.Join(
+		fixture.worktreeDir, "github", "github.com", "acme", "widget", "pr-2",
+	)
+	require.NoError(os.MkdirAll(worktreePath, 0o755))
+	require.NoError(os.WriteFile(
+		filepath.Join(worktreePath, "keep.txt"), []byte("preserve me\n"), 0o644,
+	))
+
+	createResp, err := fixture.client.HTTP.CreateWorkspaceWithResponse(
+		ctx,
+		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
+			PlatformHost: "github.com",
+			Owner:        "acme",
+			Name:         "widget",
+			MrNumber:     mrNumber,
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusAccepted, createResp.StatusCode())
+	require.NotNil(createResp.JSON202)
+
+	var errored *generated.WorkspaceResponse
+	require.Eventually(func() bool {
+		getResp, getErr := fixture.client.HTTP.GetWorkspaceWithResponse(
+			ctx, createResp.JSON202.Id,
+		)
+		if getErr != nil || getResp.JSON200 == nil ||
+			getResp.JSON200.Status != "error" {
+			return false
+		}
+		errored = getResp.JSON200
+		return true
+	}, 10*time.Second, 25*time.Millisecond)
+	require.NotNil(errored.ErrorMessage)
+	assert.NotEmpty(*errored.ErrorMessage)
+
+	stored, err := fixture.database.GetWorkspace(ctx, createResp.JSON202.Id)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.Equal("error", stored.Status)
+	contents, err := os.ReadFile(filepath.Join(worktreePath, "keep.txt"))
+	require.NoError(err)
+	assert.Equal("preserve me\n", string(contents))
+	requireGitRefMissing(t, fixture.bare, "refs/heads/"+preferredBranch)
+	requireGitRefMissing(t, fixture.bare, "refs/heads/"+fallbackBranch)
 }
 
 func TestWorkspaceCreateSameRepoHeadCloneURLTracksOriginBranchE2E(t *testing.T) {
@@ -115,6 +723,19 @@ func TestWorkspaceCreateSameRepoHeadCloneURLTracksOriginBranchE2E(t *testing.T) 
 			"config", "--get", "branch.feature.merge",
 		),
 	)
+}
+
+func requireGitRefMissing(t *testing.T, dir, ref string) {
+	t.Helper()
+
+	_, stderr, err := gitcmd.New().Run(
+		t.Context(), dir, nil, "show-ref", "--verify", "--quiet", ref,
+	)
+	var exitErr *exec.ExitError
+	require.ErrorAs(
+		t, err, &exitErr, "git ref %q unexpectedly exists: %s", ref, stderr,
+	)
+	require.Equal(t, 1, exitErr.ExitCode(), "git show-ref failed: %s", stderr)
 }
 
 func TestWorkspaceRetryLegacyUnknownHeadRepoLeavesBranchUntrackedE2E(t *testing.T) {

--- a/internal/server/workspacetest/workspace_concurrent_e2e_test.go
+++ b/internal/server/workspacetest/workspace_concurrent_e2e_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/forge/internal/apiclient/generated"
+	"go.kenn.io/forge/internal/config"
 	"go.kenn.io/forge/internal/workspace"
 	gitcmd "go.kenn.io/kit/git/cmd"
 )
@@ -83,6 +84,120 @@ func TestWorkspaceForceDeleteWaitsForInFlightSetupE2E(t *testing.T) {
 	case result = <-deleteDone:
 	case <-time.After(10 * time.Second):
 		require.FailNow("force-delete did not finish after workspace setup resumed")
+	}
+	require.NoError(result.err)
+	assert.Equal(http.StatusNoContent, result.status)
+
+	stored, err := fixture.database.GetWorkspace(ctx, ws.Id)
+	require.NoError(err)
+	assert.Nil(stored)
+	_, err = os.Lstat(ws.WorktreePath)
+	require.ErrorIs(err, os.ErrNotExist)
+	assert.Equal(1, listBareWorktrees(t, fixture.bare))
+}
+
+func TestWorkspaceForceDeleteRejectsConcurrentRetrySetupE2E(t *testing.T) {
+	t.Parallel()
+	acquireWorkspaceGitSlot(t)
+
+	require := require.New(t)
+	assert := assert.New(t)
+	if len(workspaceTestTmuxCommand) == 0 {
+		t.Skip("tmux not available")
+	}
+
+	dir := t.TempDir()
+	started := dir + "/delete-started"
+	release := dir + "/delete-release"
+	claim := dir + "/delete-claim"
+	wrapper := dir + "/tmux-wrapper.sh"
+	require.NoError(os.WriteFile(wrapper, []byte(`#!/bin/sh
+started=$1
+release=$2
+claim=$3
+shift 3
+is_kill=false
+for arg in "$@"; do
+  if [ "$arg" = "kill-session" ]; then
+    is_kill=true
+  fi
+done
+if [ "$is_kill" = true ] && mkdir "$claim" 2>/dev/null; then
+  : > "$started"
+  while [ ! -e "$release" ]; do
+    sleep 0.01
+  done
+fi
+exec "$@"
+`), 0o700))
+	defer func() {
+		_ = os.WriteFile(release, []byte("release\n"), 0o600)
+	}()
+
+	tmuxCommand := []string{wrapper, started, release, claim}
+	tmuxCommand = append(tmuxCommand, workspaceTestTmuxCommand...)
+	cfg := &config.Config{}
+	cfg.Tmux.Command = tmuxCommand
+	fixture := setupWorkspaceServerFixture(t, cfg)
+	ctx := t.Context()
+
+	createResp, err := fixture.client.HTTP.CreateWorkspaceWithResponse(
+		ctx,
+		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
+			PlatformHost: "github.com",
+			Owner:        "acme",
+			Name:         "widget",
+			MrNumber:     1,
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusAccepted, createResp.StatusCode())
+	require.NotNil(createResp.JSON202)
+	ws := waitForWorkspaceReady(t, ctx, fixture.client, createResp.JSON202.Id)
+
+	msg := "forced error for delete and retry overlap"
+	require.NoError(fixture.database.UpdateWorkspaceStatus(
+		ctx, ws.Id, "error", &msg,
+	))
+
+	type deleteResult struct {
+		status int
+		err    error
+	}
+	deleteDone := make(chan deleteResult, 1)
+	go func() {
+		force := true
+		resp, deleteErr := fixture.client.HTTP.DeleteWorkspaceWithResponse(
+			ctx, ws.Id, &generated.DeleteWorkspaceParams{Force: &force},
+		)
+		if deleteErr != nil {
+			deleteDone <- deleteResult{err: deleteErr}
+			return
+		}
+		deleteDone <- deleteResult{status: resp.StatusCode()}
+	}()
+
+	require.Eventually(func() bool {
+		_, statErr := os.Stat(started)
+		return statErr == nil
+	}, 5*time.Second, 10*time.Millisecond)
+
+	retryResp, err := fixture.client.HTTP.RetryWorkspaceWithResponse(ctx, ws.Id)
+	require.NoError(err)
+	require.Equal(http.StatusAccepted, retryResp.StatusCode())
+	require.Never(func() bool {
+		_, statErr := os.Lstat(ws.WorktreePath)
+		return statErr == nil
+	}, time.Second, 10*time.Millisecond,
+		"retry recreated the worktree while deletion was paused")
+
+	require.NoError(os.WriteFile(release, []byte("release\n"), 0o600))
+	var result deleteResult
+	select {
+	case result = <-deleteDone:
+	case <-time.After(10 * time.Second):
+		require.FailNow("force-delete did not finish after terminal cleanup resumed")
 	}
 	require.NoError(result.err)
 	assert.Equal(http.StatusNoContent, result.status)

--- a/internal/server/workspacetest/workspace_concurrent_e2e_test.go
+++ b/internal/server/workspacetest/workspace_concurrent_e2e_test.go
@@ -3,16 +3,97 @@ package workspacetest
 import (
 	"context"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/forge/internal/apiclient/generated"
+	"go.kenn.io/forge/internal/workspace"
 	gitcmd "go.kenn.io/kit/git/cmd"
 )
+
+func TestWorkspaceForceDeleteWaitsForInFlightSetupE2E(t *testing.T) {
+	t.Parallel()
+	acquireWorkspaceGitSlot(t)
+
+	require := require.New(t)
+	assert := assert.New(t)
+	fixture := setupWorkspaceServerFixture(t, nil)
+	ctx := t.Context()
+
+	lockManager := workspace.NewFileLockManager()
+	held, err := lockManager.Acquire(ctx, fixture.bare)
+	require.NoError(err)
+	unlocked := false
+	defer func() {
+		if !unlocked {
+			_ = held.Unlock()
+		}
+	}()
+
+	createResp, err := fixture.client.HTTP.CreateWorkspaceWithResponse(
+		ctx,
+		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
+			PlatformHost: "github.com",
+			Owner:        "acme",
+			Name:         "widget",
+			MrNumber:     1,
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusAccepted, createResp.StatusCode())
+	require.NotNil(createResp.JSON202)
+	ws := createResp.JSON202
+
+	type deleteResult struct {
+		status int
+		err    error
+	}
+	deleteDone := make(chan deleteResult, 1)
+	go func() {
+		force := true
+		resp, deleteErr := fixture.client.HTTP.DeleteWorkspaceWithResponse(
+			ctx, ws.Id, &generated.DeleteWorkspaceParams{Force: &force},
+		)
+		if deleteErr != nil {
+			deleteDone <- deleteResult{err: deleteErr}
+			return
+		}
+		deleteDone <- deleteResult{status: resp.StatusCode()}
+	}()
+
+	select {
+	case result := <-deleteDone:
+		require.NoError(result.err)
+		require.FailNow("force-delete returned while workspace setup was paused")
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	require.NoError(held.Unlock())
+	unlocked = true
+
+	var result deleteResult
+	select {
+	case result = <-deleteDone:
+	case <-time.After(10 * time.Second):
+		require.FailNow("force-delete did not finish after workspace setup resumed")
+	}
+	require.NoError(result.err)
+	assert.Equal(http.StatusNoContent, result.status)
+
+	stored, err := fixture.database.GetWorkspace(ctx, ws.Id)
+	require.NoError(err)
+	assert.Nil(stored)
+	_, err = os.Lstat(ws.WorktreePath)
+	require.ErrorIs(err, os.ErrNotExist)
+	assert.Equal(1, listBareWorktrees(t, fixture.bare))
+}
 
 // TestWorkspaceConcurrentSameRepoOperationsE2E exercises the per-repo
 // worktree lock through the public API and SQLite. Two PRs in the same

--- a/internal/server/workspacetest/workspace_concurrent_e2e_test.go
+++ b/internal/server/workspacetest/workspace_concurrent_e2e_test.go
@@ -210,6 +210,262 @@ exec "$@"
 	assert.Equal(1, listBareWorktrees(t, fixture.bare))
 }
 
+// TestWorkspaceRetryDuringFailedDeleteReplaysSetupE2E covers a retry accepted
+// while a DELETE is in flight and the DELETE then fails. The retry has already
+// moved the row to "creating", so its queued setup must replay once deletion
+// admission reopens; dropping it would leave the workspace stuck in
+// "creating" with no worker attached.
+func TestWorkspaceRetryDuringFailedDeleteReplaysSetupE2E(t *testing.T) {
+	t.Parallel()
+	acquireWorkspaceGitSlot(t)
+
+	require := require.New(t)
+	assert := assert.New(t)
+	if len(workspaceTestTmuxCommand) == 0 {
+		t.Skip("tmux not available")
+	}
+
+	dir := t.TempDir()
+	started := dir + "/delete-started"
+	release := dir + "/delete-release"
+	claim := dir + "/delete-claim"
+	wrapper := dir + "/tmux-wrapper.sh"
+	// The first kill-session pauses until released and then fails, so the
+	// DELETE reaches destructive cleanup and errors out of it.
+	require.NoError(os.WriteFile(wrapper, []byte(`#!/bin/sh
+started=$1
+release=$2
+claim=$3
+shift 3
+is_kill=false
+for arg in "$@"; do
+  if [ "$arg" = "kill-session" ]; then
+    is_kill=true
+  fi
+done
+if [ "$is_kill" = true ] && mkdir "$claim" 2>/dev/null; then
+  : > "$started"
+  while [ ! -e "$release" ]; do
+    sleep 0.01
+  done
+  echo "forced kill-session failure" >&2
+  exit 1
+fi
+exec "$@"
+`), 0o700))
+	defer func() {
+		_ = os.WriteFile(release, []byte("release\n"), 0o600)
+	}()
+
+	tmuxCommand := []string{wrapper, started, release, claim}
+	tmuxCommand = append(tmuxCommand, workspaceTestTmuxCommand...)
+	cfg := &config.Config{}
+	cfg.Tmux.Command = tmuxCommand
+	fixture := setupWorkspaceServerFixture(t, cfg)
+	ctx := t.Context()
+
+	createResp, err := fixture.client.HTTP.CreateWorkspaceWithResponse(
+		ctx,
+		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
+			PlatformHost: "github.com",
+			Owner:        "acme",
+			Name:         "widget",
+			MrNumber:     1,
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusAccepted, createResp.StatusCode())
+	require.NotNil(createResp.JSON202)
+	ws := waitForWorkspaceReady(t, ctx, fixture.client, createResp.JSON202.Id)
+
+	msg := "forced error for retry during failed delete"
+	require.NoError(fixture.database.UpdateWorkspaceStatus(
+		ctx, ws.Id, "error", &msg,
+	))
+
+	type deleteResult struct {
+		status int
+		err    error
+	}
+	deleteDone := make(chan deleteResult, 1)
+	go func() {
+		force := true
+		resp, deleteErr := fixture.client.HTTP.DeleteWorkspaceWithResponse(
+			ctx, ws.Id, &generated.DeleteWorkspaceParams{Force: &force},
+		)
+		if deleteErr != nil {
+			deleteDone <- deleteResult{err: deleteErr}
+			return
+		}
+		deleteDone <- deleteResult{status: resp.StatusCode()}
+	}()
+
+	require.Eventually(func() bool {
+		_, statErr := os.Stat(started)
+		return statErr == nil
+	}, 5*time.Second, 10*time.Millisecond)
+
+	retryResp, err := fixture.client.HTTP.RetryWorkspaceWithResponse(ctx, ws.Id)
+	require.NoError(err)
+	require.Equal(http.StatusAccepted, retryResp.StatusCode())
+	require.Never(func() bool {
+		_, statErr := os.Lstat(ws.WorktreePath)
+		return statErr == nil
+	}, time.Second, 10*time.Millisecond,
+		"retry recreated the worktree while deletion was in flight")
+
+	require.NoError(os.WriteFile(release, []byte("release\n"), 0o600))
+	var result deleteResult
+	select {
+	case result = <-deleteDone:
+	case <-time.After(10 * time.Second):
+		require.FailNow("delete did not finish after terminal cleanup resumed")
+	}
+	require.NoError(result.err)
+	require.Equal(http.StatusInternalServerError, result.status)
+
+	recovered := waitForWorkspaceReady(t, ctx, fixture.client, ws.Id)
+	assert.Equal("ready", recovered.Status)
+	_, err = os.Lstat(recovered.WorktreePath)
+	require.NoError(err)
+	assert.Equal(2, listBareWorktrees(t, fixture.bare))
+}
+
+// TestWorkspaceFailedConcurrentDeleteKeepsSetupBlockedE2E covers two DELETEs
+// racing on one workspace: one fails fast on the dirty preflight while the
+// other is still inside destructive cleanup. The failed request must not
+// reopen setup admission, so a retry accepted during the overlap cannot
+// materialize a worktree for the row the surviving DELETE removes.
+func TestWorkspaceFailedConcurrentDeleteKeepsSetupBlockedE2E(t *testing.T) {
+	t.Parallel()
+	acquireWorkspaceGitSlot(t)
+
+	require := require.New(t)
+	assert := assert.New(t)
+	if len(workspaceTestTmuxCommand) == 0 {
+		t.Skip("tmux not available")
+	}
+
+	dir := t.TempDir()
+	started := dir + "/delete-started"
+	release := dir + "/delete-release"
+	claim := dir + "/delete-claim"
+	wrapper := dir + "/tmux-wrapper.sh"
+	require.NoError(os.WriteFile(wrapper, []byte(`#!/bin/sh
+started=$1
+release=$2
+claim=$3
+shift 3
+is_kill=false
+for arg in "$@"; do
+  if [ "$arg" = "kill-session" ]; then
+    is_kill=true
+  fi
+done
+if [ "$is_kill" = true ] && mkdir "$claim" 2>/dev/null; then
+  : > "$started"
+  while [ ! -e "$release" ]; do
+    sleep 0.01
+  done
+fi
+exec "$@"
+`), 0o700))
+	defer func() {
+		_ = os.WriteFile(release, []byte("release\n"), 0o600)
+	}()
+
+	tmuxCommand := []string{wrapper, started, release, claim}
+	tmuxCommand = append(tmuxCommand, workspaceTestTmuxCommand...)
+	cfg := &config.Config{}
+	cfg.Tmux.Command = tmuxCommand
+	fixture := setupWorkspaceServerFixture(t, cfg)
+	ctx := t.Context()
+
+	createResp, err := fixture.client.HTTP.CreateWorkspaceWithResponse(
+		ctx,
+		generated.CreateWorkspaceInputBody{
+			Provider:     "github",
+			PlatformHost: "github.com",
+			Owner:        "acme",
+			Name:         "widget",
+			MrNumber:     1,
+		},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusAccepted, createResp.StatusCode())
+	require.NotNil(createResp.JSON202)
+	ws := waitForWorkspaceReady(t, ctx, fixture.client, createResp.JSON202.Id)
+
+	msg := "forced error for concurrent delete overlap"
+	require.NoError(fixture.database.UpdateWorkspaceStatus(
+		ctx, ws.Id, "error", &msg,
+	))
+	// An untracked file makes the second, non-force DELETE fail its dirty
+	// preflight while the first DELETE is paused in destructive cleanup.
+	require.NoError(os.WriteFile(
+		ws.WorktreePath+"/untracked.txt", []byte("dirty\n"), 0o600,
+	))
+
+	type deleteResult struct {
+		status int
+		err    error
+	}
+	deleteDone := make(chan deleteResult, 1)
+	go func() {
+		force := true
+		resp, deleteErr := fixture.client.HTTP.DeleteWorkspaceWithResponse(
+			ctx, ws.Id, &generated.DeleteWorkspaceParams{Force: &force},
+		)
+		if deleteErr != nil {
+			deleteDone <- deleteResult{err: deleteErr}
+			return
+		}
+		deleteDone <- deleteResult{status: resp.StatusCode()}
+	}()
+
+	require.Eventually(func() bool {
+		_, statErr := os.Stat(started)
+		return statErr == nil
+	}, 5*time.Second, 10*time.Millisecond)
+
+	noForce := false
+	dirtyResp, err := fixture.client.HTTP.DeleteWorkspaceWithResponse(
+		ctx, ws.Id, &generated.DeleteWorkspaceParams{Force: &noForce},
+	)
+	require.NoError(err)
+	require.Equal(http.StatusConflict, dirtyResp.StatusCode())
+
+	retryResp, err := fixture.client.HTTP.RetryWorkspaceWithResponse(ctx, ws.Id)
+	require.NoError(err)
+	require.Equal(http.StatusAccepted, retryResp.StatusCode())
+	require.Never(func() bool {
+		_, statErr := os.Lstat(ws.WorktreePath)
+		return statErr == nil
+	}, time.Second, 10*time.Millisecond,
+		"retry recreated the worktree after the failed delete unblocked setup")
+
+	require.NoError(os.WriteFile(release, []byte("release\n"), 0o600))
+	var result deleteResult
+	select {
+	case result = <-deleteDone:
+	case <-time.After(10 * time.Second):
+		require.FailNow("force-delete did not finish after terminal cleanup resumed")
+	}
+	require.NoError(result.err)
+	require.Equal(http.StatusNoContent, result.status)
+
+	require.Never(func() bool {
+		_, statErr := os.Lstat(ws.WorktreePath)
+		return statErr == nil
+	}, time.Second, 10*time.Millisecond,
+		"queued setup resurrected the worktree after successful deletion")
+	stored, err := fixture.database.GetWorkspace(ctx, ws.Id)
+	require.NoError(err)
+	assert.Nil(stored)
+	assert.Equal(1, listBareWorktrees(t, fixture.bare))
+}
+
 // TestWorkspaceConcurrentSameRepoOperationsE2E exercises the per-repo
 // worktree lock through the public API and SQLite. Two PRs in the same
 // repo are created concurrently, then one is retried while the other is

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -1232,14 +1232,14 @@ func (m *Manager) RefreshWorkspaceHeadRepoSnapshot(
 func (m *Manager) reuseExistingWorkspaceWorktree(
 	ctx context.Context, ws *Workspace,
 ) (string, bool, error) {
-	info, err := os.Stat(ws.WorktreePath)
+	info, err := os.Lstat(ws.WorktreePath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return "", false, nil
 		}
 		return "", false, fmt.Errorf("stat existing worktree: %w", err)
 	}
-	if !info.IsDir() {
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
 		return "", false, nil
 	}
 	commonDir, err := worktreeCommonGitDir(ctx, ws.WorktreePath)
@@ -1270,6 +1270,11 @@ func (m *Manager) reuseExistingWorkspaceWorktree(
 	}
 	var branch string
 	if err := m.withRepoLockForGitDir(ctx, commonDir, func() error {
+		if err := m.revalidateExistingWorkspaceWorktree(
+			ctx, commonDir, localBase, ws,
+		); err != nil {
+			return err
+		}
 		useMergeRequestHeadRef, refreshErr := m.refreshExistingWorkspaceWorktree(
 			ctx, commonDir, ws,
 		)
@@ -1301,6 +1306,71 @@ func (m *Manager) reuseExistingWorkspaceWorktree(
 		return "", false, err
 	}
 	return branch, true, nil
+}
+
+func (m *Manager) revalidateExistingWorkspaceWorktree(
+	ctx context.Context,
+	expectedCommonDir string,
+	expectedLocalBase bool,
+	ws *Workspace,
+) error {
+	info, err := os.Lstat(ws.WorktreePath)
+	if errors.Is(err, os.ErrNotExist) {
+		return &WorkspaceDirectoryRecoveryError{
+			Reason: WorkspaceDirectoryMissing,
+		}
+	}
+	if err != nil {
+		return fmt.Errorf("stat existing worktree under repository lock: %w", err)
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return &WorkspaceDirectoryRecoveryError{
+			Reason: WorkspaceDirectoryNotLinkedWorktree,
+		}
+	}
+	currentCommonDir, err := worktreeCommonGitDir(ctx, ws.WorktreePath)
+	if err != nil {
+		if isGitWorktreeAbsent(err) {
+			return &WorkspaceDirectoryRecoveryError{
+				Reason: WorkspaceDirectoryNotLinkedWorktree,
+			}
+		}
+		return fmt.Errorf("inspect existing worktree under repository lock: %w", err)
+	}
+	current, err := canonicalFilesystemPath(currentCommonDir)
+	if err != nil {
+		return fmt.Errorf("resolve existing worktree repository: %w", err)
+	}
+	expected, err := canonicalFilesystemPath(expectedCommonDir)
+	if err != nil {
+		return fmt.Errorf("resolve expected worktree repository: %w", err)
+	}
+	if current != expected {
+		return &WorkspaceDirectoryRecoveryError{
+			Reason: WorkspaceDirectoryRepositoryMismatch,
+		}
+	}
+	owned, err := gitDirOwnsLinkedWorktree(ctx, currentCommonDir, ws.WorktreePath)
+	if err != nil {
+		return fmt.Errorf("revalidate existing linked worktree: %w", err)
+	}
+	if !owned {
+		return &WorkspaceDirectoryRecoveryError{
+			Reason: WorkspaceDirectoryNotLinkedWorktree,
+		}
+	}
+	localBase, reusable, err := m.existingWorkspaceWorktreeProvenance(
+		ctx, currentCommonDir, ws,
+	)
+	if err != nil {
+		return fmt.Errorf("revalidate existing worktree provenance: %w", err)
+	}
+	if !reusable || localBase != expectedLocalBase {
+		return &WorkspaceDirectoryRecoveryError{
+			Reason: WorkspaceDirectoryRepositoryMismatch,
+		}
+	}
+	return nil
 }
 
 func (m *Manager) ensureWorkspacePathAvailable(

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -3251,6 +3251,16 @@ func gitDirHasLiveWorktree(
 	if !isDirectory {
 		return false, nil
 	}
+	isRoot, err := worktreePathIsRoot(ctx, worktreePath)
+	if err != nil {
+		if isGitWorktreeAbsent(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("inspect workspace worktree root: %w", err)
+	}
+	if !isRoot {
+		return false, nil
+	}
 	commonDir, err := worktreeCommonGitDir(ctx, worktreePath)
 	if err != nil {
 		if isGitWorktreeAbsent(err) {
@@ -3273,7 +3283,28 @@ func gitDirHasLiveWorktree(
 	if current != candidate {
 		return false, nil
 	}
-	return gitDirOwnsLinkedWorktree(ctx, candidateCommonDir, worktreePath)
+	metadataDir, ok, err := worktreeRegistrationMetadataDir(
+		ctx, candidateCommonDir, worktreePath,
+	)
+	if err != nil || !ok {
+		return false, err
+	}
+	currentGitDir, err := worktreeGitDir(ctx, worktreePath)
+	if err != nil {
+		if isGitWorktreeAbsent(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("inspect workspace git dir: %w", err)
+	}
+	currentRegistration, err := canonicalFilesystemPath(currentGitDir)
+	if err != nil {
+		return false, fmt.Errorf("resolve workspace git dir: %w", err)
+	}
+	expectedRegistration, err := canonicalFilesystemPath(metadataDir)
+	if err != nil {
+		return false, fmt.Errorf("resolve workspace registration: %w", err)
+	}
+	return currentRegistration == expectedRegistration, nil
 }
 
 func worktreeGitDir(ctx context.Context, worktreePath string) (string, error) {

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -141,6 +141,7 @@ const (
 	workspaceSetupStageTmuxSession = "tmux_session"
 	workspaceBranchUnknown         = "__kenn_forge_unknown__"
 	workspaceBranchRecoveryPending = "__kenn_forge_recovery_pending__..state"
+	workspaceOwnershipMarkerFile   = "kenn-forge-workspace-id"
 	tmuxCaptureScrollbackLines     = 160
 )
 
@@ -148,10 +149,11 @@ var workspacePersistTimeout = 5 * time.Second
 var workspaceCleanupTimeout = 5 * time.Second
 
 var (
-	ErrWorkspaceNotFound     = errors.New("workspace not found")
-	ErrWorkspaceNotSynced    = errors.New("workspace merge request not synced")
-	ErrWorkspaceDuplicate    = errors.New("workspace already exists")
-	ErrWorkspaceInvalidState = errors.New("workspace invalid state")
+	ErrWorkspaceNotFound          = errors.New("workspace not found")
+	ErrWorkspaceNotSynced         = errors.New("workspace merge request not synced")
+	ErrWorkspaceDuplicate         = errors.New("workspace already exists")
+	ErrWorkspaceInvalidState      = errors.New("workspace invalid state")
+	ErrWorkspaceOwnershipUnproven = errors.New("workspace worktree ownership cannot be verified")
 	// ErrInvalidBranchName lets HTTP handlers map a rejected branch to a
 	// validation response with errors.Is instead of matching on the git
 	// message this error carries.
@@ -961,6 +963,9 @@ func (m *Manager) SetupWithWorktreeBasePath(
 		)
 	}
 	if !reusedWorktree {
+		if err := m.ensureWorkspacePathAvailable(ctx, ws); err != nil {
+			return m.failSetup(ctx, ws.ID, workspaceSetupStageWorktree, err)
+		}
 		var refreshBeforeAdd bool
 		gitDir, refreshBeforeAdd, err = m.workspaceSetupGitDir(ctx, ws, worktreeBasePath)
 		if err != nil {
@@ -1288,11 +1293,32 @@ func (m *Manager) reuseExistingWorkspaceWorktree(
 				currentBranch, ws.ItemType, ws.ItemNumber,
 			)
 		}
+		if err := writeWorkspaceOwnershipMarker(ctx, commonDir, ws); err != nil {
+			return fmt.Errorf("record workspace ownership: %w", err)
+		}
 		return nil
 	}); err != nil {
 		return "", false, err
 	}
 	return branch, true, nil
+}
+
+func (m *Manager) ensureWorkspacePathAvailable(
+	ctx context.Context, ws *Workspace,
+) error {
+	_, err := os.Lstat(ws.WorktreePath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("stat workspace destination: %w", err)
+	}
+	if _, err := m.inspectExistingWorkspaceDirectory(ctx, ws); err != nil {
+		return err
+	}
+	return &WorkspaceDirectoryRecoveryError{
+		Reason: WorkspaceDirectoryNotLinkedWorktree,
+	}
 }
 
 // existingWorkspaceWorktreeProvenance decides whether the path already
@@ -1901,9 +1927,21 @@ func (m *Manager) addWorktree(
 				return err
 			}
 		}
+		if err := m.ensureWorkspacePathAvailable(ctx, ws); err != nil {
+			return err
+		}
 		var addErr error
 		branch, addErr = m.addWorktreeLocked(ctx, cloneDir, refreshBeforeAdd, ws)
-		return addErr
+		if addErr != nil {
+			return addErr
+		}
+		if err := writeWorkspaceOwnershipMarker(ctx, cloneDir, ws); err != nil {
+			cleanupWorktreeAddOnUpstreamFailure(
+				ctx, cloneDir, ws.WorktreePath, branch,
+			)
+			return fmt.Errorf("record workspace ownership: %w", err)
+		}
+		return nil
 	})
 	return branch, err
 }
@@ -2021,8 +2059,8 @@ func (m *Manager) addFallbackBranchWorktree(
 	ws *Workspace,
 	branch, startRef string,
 ) (string, error) {
-	if err := runGitWorktreeAdd(
-		ctx, cloneDir, ws.WorktreePath, "-b", branch, startRef,
+	if err := runGitWorktreeAddCreatingBranch(
+		ctx, cloneDir, ws.WorktreePath, branch, startRef,
 	); err != nil {
 		return "", err
 	}
@@ -2053,9 +2091,8 @@ func (m *Manager) addIssueWorktree(
 		return "", nil
 	}
 	startRef := workspaceStartRef(ws)
-	if err := runGitWorktreeAdd(
-		ctx, cloneDir, ws.WorktreePath,
-		"-b", workspaceBranch, startRef,
+	if err := runGitWorktreeAddCreatingBranch(
+		ctx, cloneDir, ws.WorktreePath, workspaceBranch, startRef,
 	); err != nil {
 		return "", err
 	}
@@ -2072,9 +2109,9 @@ func (m *Manager) addPreferredWorktree(
 	}
 
 	if ws.MRHeadRepo != nil {
-		err := runGitWorktreeAdd(
+		err := runGitWorktreeAddCreatingBranch(
 			ctx, cloneDir, ws.WorktreePath,
-			"-b", ws.GitHeadRef, workspaceStartRef(ws),
+			ws.GitHeadRef, workspaceStartRef(ws),
 		)
 		if err != nil {
 			return "", err
@@ -2097,9 +2134,8 @@ func (m *Manager) addPreferredWorktree(
 		return "", err
 	}
 	if !exists {
-		if err := runGitWorktreeAdd(
-			ctx, cloneDir, ws.WorktreePath,
-			"-b", ws.GitHeadRef, startRef,
+		if err := runGitWorktreeAddCreatingBranch(
+			ctx, cloneDir, ws.WorktreePath, ws.GitHeadRef, startRef,
 		); err != nil {
 			return "", err
 		}
@@ -2578,29 +2614,48 @@ func (m *Manager) cleanupWorkspaceArtifactsForRetry(
 	}
 
 	return m.withRepoLockForGitDir(ctx, gitDir, func() error {
+		return m.cleanupWorkspaceArtifactsForRetryLocked(ctx, gitDir, ws)
+	})
+}
+
+func (m *Manager) cleanupWorkspaceArtifactsForRetryLocked(
+	ctx context.Context, gitDir string, ws *Workspace,
+) error {
+	state, err := currentWorkspaceCleanupState(ctx, gitDir, ws)
+	if err != nil {
+		return err
+	}
+	switch state {
+	case workspaceCleanupOwned:
 		if err := runGitWithoutHooks(
 			ctx, gitDir,
 			"worktree", "remove", "--force", ws.WorktreePath,
 		); err != nil && !isGitWorktreeAbsent(err) {
 			return fmt.Errorf("remove git worktree: %w", err)
 		}
-		if ws.WorkspaceBranch == workspaceBranchUnknown {
-			if err := deleteWorkspaceBranchStrict(
-				ctx, gitDir, workspaceBranchUnknown,
-			); err != nil {
-				return err
-			}
-		}
-		if err := m.deleteWorkspaceBranchesStrict(
-			ctx, gitDir, ws, ws.WorkspaceBranch,
+	case workspaceCleanupStaleRegistration:
+		if err := removeStaleWorktreeRegistrationMetadata(
+			ctx, gitDir, ws.WorktreePath,
 		); err != nil {
 			return err
 		}
-		if err := runGitWithoutHooks(ctx, gitDir, "worktree", "prune"); err != nil {
-			return fmt.Errorf("prune git worktrees: %w", err)
+	}
+	if ws.WorkspaceBranch == workspaceBranchUnknown {
+		if err := deleteWorkspaceBranchStrict(
+			ctx, gitDir, workspaceBranchUnknown,
+		); err != nil {
+			return err
 		}
-		return nil
-	})
+	}
+	if err := m.deleteWorkspaceBranchesStrict(
+		ctx, gitDir, ws, ws.WorkspaceBranch,
+	); err != nil {
+		return err
+	}
+	if err := runGitWithoutHooks(ctx, gitDir, "worktree", "prune"); err != nil {
+		return fmt.Errorf("prune git worktrees: %w", err)
+	}
+	return nil
 }
 
 func (m *Manager) cleanupWorkspaceArtifactsForDelete(
@@ -2618,38 +2673,162 @@ func (m *Manager) cleanupWorkspaceArtifactsForDelete(
 		return err
 	}
 	if !ok {
-		return nil
+		if err := quarantineOrphanedWorkspacePath(ctx, ws.WorktreePath); err != nil {
+			return err
+		}
+		gitDir, ok, err = m.workspaceCleanupGitDir(ctx, ws)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			gitDir, ok, err = m.workspaceRegisteredCleanupGitDir(ctx, ws)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return nil
+			}
+		}
 	}
 
 	return m.withRepoLockForGitDir(ctx, gitDir, func() error {
-		_ = runGitWithoutHooks(
+		return m.cleanupWorkspaceArtifactsForDeleteLocked(ctx, gitDir, ws)
+	})
+}
+
+func (m *Manager) cleanupWorkspaceArtifactsForDeleteLocked(
+	ctx context.Context, gitDir string, ws *Workspace,
+) error {
+	state, err := currentWorkspaceCleanupState(ctx, gitDir, ws)
+	if err != nil {
+		return err
+	}
+	switch state {
+	case workspaceCleanupOwned:
+		if err := runGitWithoutHooks(
 			ctx, gitDir,
 			"worktree", "remove", "--force", ws.WorktreePath,
-		)
-		m.deleteWorkspaceBranches(ctx, gitDir, ws, ws.WorkspaceBranch)
-		_ = runGitWithoutHooks(ctx, gitDir, "worktree", "prune")
+		); err != nil && !isGitWorktreeAbsent(err) {
+			return fmt.Errorf("remove git worktree: %w", err)
+		}
+	case workspaceCleanupStaleRegistration:
+		if err := removeStaleWorktreeRegistrationMetadata(
+			ctx, gitDir, ws.WorktreePath,
+		); err != nil {
+			return err
+		}
+	}
+	m.deleteWorkspaceBranches(ctx, gitDir, ws, ws.WorkspaceBranch)
+	_ = runGitWithoutHooks(ctx, gitDir, "worktree", "prune")
+	return nil
+}
+
+type workspaceCleanupState uint8
+
+const (
+	workspaceCleanupNone workspaceCleanupState = iota
+	workspaceCleanupOwned
+	workspaceCleanupStaleRegistration
+)
+
+func currentWorkspaceCleanupState(
+	ctx context.Context, gitDir string, ws *Workspace,
+) (workspaceCleanupState, error) {
+	owned, err := gitDirOwnsCleanupWorktree(
+		ctx, gitDir, ws.WorktreePath, ws.ID,
+	)
+	if err != nil {
+		return workspaceCleanupNone, err
+	}
+	if owned {
+		return workspaceCleanupOwned, nil
+	}
+	stale, err := gitDirHasStaleWorktreeRegistration(
+		ctx, gitDir, ws.WorktreePath,
+	)
+	if err != nil {
+		return workspaceCleanupNone, err
+	}
+	if stale {
+		return workspaceCleanupStaleRegistration, nil
+	}
+	return workspaceCleanupNone, nil
+}
+
+func quarantineOrphanedWorkspacePath(
+	ctx context.Context, worktreePath string,
+) error {
+	pathInfo, err := os.Lstat(worktreePath)
+	if errors.Is(err, os.ErrNotExist) {
 		return nil
-	})
+	}
+	if err != nil {
+		return fmt.Errorf("stat orphaned workspace path: %w", err)
+	}
+
+	inspectAsDirectory := pathInfo.IsDir()
+	if pathInfo.Mode()&os.ModeSymlink != 0 {
+		targetInfo, statErr := os.Stat(worktreePath)
+		if statErr == nil {
+			inspectAsDirectory = targetInfo.IsDir()
+		} else if errors.Is(statErr, os.ErrNotExist) {
+			inspectAsDirectory = false
+		} else {
+			return fmt.Errorf("stat orphaned workspace symlink target: %w", statErr)
+		}
+	}
+
+	if inspectAsDirectory {
+		if _, err := worktreeCommonGitDir(ctx, worktreePath); err == nil {
+			isRoot, err := worktreePathIsRoot(ctx, worktreePath)
+			if err != nil {
+				return fmt.Errorf("inspect orphaned workspace root: %w", err)
+			}
+			if isRoot {
+				return nil
+			}
+		} else if !isGitWorktreeAbsent(err) {
+			return fmt.Errorf("inspect orphaned workspace path: %w", err)
+		}
+	}
+
+	recoveryPath, err := nextWorkspaceRecoveryPath(worktreePath, time.Now())
+	if err != nil {
+		return err
+	}
+	if err := os.Rename(worktreePath, recoveryPath); err != nil {
+		return fmt.Errorf("preserve orphaned workspace path: %w", err)
+	}
+	slog.Warn(
+		"preserved orphaned workspace path",
+		"path", worktreePath,
+		"recovery_path", recoveryPath,
+	)
+	return nil
+}
+
+func nextWorkspaceRecoveryPath(
+	worktreePath string, now time.Time,
+) (string, error) {
+	base := worktreePath + ".orphaned-" + now.UTC().Format("20060102T150405Z")
+	for suffix := 1; ; suffix++ {
+		candidate := base
+		if suffix > 1 {
+			candidate = fmt.Sprintf("%s-%d", base, suffix)
+		}
+		_, err := os.Lstat(candidate)
+		if errors.Is(err, os.ErrNotExist) {
+			return candidate, nil
+		}
+		if err != nil {
+			return "", fmt.Errorf("stat workspace recovery path: %w", err)
+		}
+	}
 }
 
 func (m *Manager) workspaceCleanupGitDir(
 	ctx context.Context, ws *Workspace,
 ) (string, bool, error) {
-	commonDir, err := worktreeCommonGitDir(ctx, ws.WorktreePath)
-	if err == nil {
-		if gitDirMatchesWorkspaceRepo(ctx, commonDir, ws) {
-			owned, err := gitDirOwnsLinkedWorktree(
-				ctx, commonDir, ws.WorktreePath,
-			)
-			if err != nil {
-				return "", false, err
-			}
-			if owned {
-				return commonDir, true, nil
-			}
-		}
-	}
-
 	if baseDir, ok, err := m.localWorktreeBaseDir(
 		ctx, ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
 	); err != nil || ok {
@@ -2661,7 +2840,7 @@ func (m *Manager) workspaceCleanupGitDir(
 		}
 		if ok {
 			owned, err := gitDirOwnsCleanupWorktree(
-				ctx, baseDir, ws.WorktreePath,
+				ctx, baseDir, ws.WorktreePath, ws.ID,
 			)
 			if err != nil {
 				return "", false, err
@@ -2686,7 +2865,7 @@ func (m *Manager) workspaceCleanupGitDir(
 		}
 		if ready {
 			owned, err := gitDirOwnsCleanupWorktree(
-				ctx, cloneDir, ws.WorktreePath,
+				ctx, cloneDir, ws.WorktreePath, ws.ID,
 			)
 			if err != nil {
 				return "", false, err
@@ -2700,23 +2879,279 @@ func (m *Manager) workspaceCleanupGitDir(
 	return "", false, nil
 }
 
-func gitDirOwnsCleanupWorktree(
-	ctx context.Context, gitDir, worktreePath string,
-) (bool, error) {
-	if strings.TrimSpace(worktreePath) == "" {
-		return false, nil
-	}
-	info, err := os.Stat(worktreePath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return gitDirTracksWorktreePath(ctx, gitDir, worktreePath)
+func (m *Manager) workspaceRegisteredCleanupGitDir(
+	ctx context.Context, ws *Workspace,
+) (string, bool, error) {
+	if baseDir, ok, err := m.localWorktreeBaseDir(
+		ctx, ws.Platform, ws.PlatformHost, ws.RepoOwner, ws.RepoName,
+	); err == nil && ok {
+		stale, err := gitDirHasStaleWorktreeRegistration(
+			ctx, baseDir, ws.WorktreePath,
+		)
+		if err != nil {
+			return "", false, err
 		}
-		return false, fmt.Errorf("stat workspace path: %w", err)
-	}
-	if !info.IsDir() {
-		return false, nil
+		if stale {
+			return baseDir, true, nil
+		}
 	}
 
+	if m.clones == nil {
+		return "", false, nil
+	}
+	cloneDir, err := m.clones.ClonePathInNamespace(
+		workspaceCloneNamespace(ws.Platform),
+		ws.PlatformHost, ws.RepoOwner, ws.RepoName,
+	)
+	if err != nil {
+		return "", false, err
+	}
+	ready, err := gitCloneDirReady(cloneDir)
+	if err != nil || !ready {
+		return "", false, err
+	}
+	stale, err := gitDirHasStaleWorktreeRegistration(
+		ctx, cloneDir, ws.WorktreePath,
+	)
+	if err != nil {
+		return "", false, err
+	}
+	return cloneDir, stale, nil
+}
+
+// removeStaleWorktreeRegistrationMetadata clears only the linked-worktree
+// administration entry whose gitdir names worktreePath. Git refuses
+// `worktree remove` when a foreign repository now occupies that path, while
+// `worktree prune` keeps the stale entry because the directory still exists.
+// Callers hold the repository worktree lock and have already established that
+// the checkout at worktreePath is not owned by gitDir.
+func removeStaleWorktreeRegistrationMetadata(
+	ctx context.Context, gitDir, worktreePath string,
+) error {
+	tracked, err := gitDirTracksWorktreePath(ctx, gitDir, worktreePath)
+	if err != nil {
+		return err
+	}
+	if !tracked {
+		return nil
+	}
+
+	metadataDir, ok, err := worktreeRegistrationMetadataDir(
+		ctx, gitDir, worktreePath,
+	)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return errors.New("remove stale worktree registration: metadata not found")
+	}
+	if err := os.RemoveAll(metadataDir); err != nil {
+		return fmt.Errorf("remove stale worktree registration: %w", err)
+	}
+	return nil
+}
+
+func writeWorkspaceOwnershipMarker(
+	ctx context.Context, gitDir string, ws *Workspace,
+) error {
+	if ws == nil || strings.TrimSpace(ws.ID) == "" {
+		return errors.New("workspace ID is required")
+	}
+	metadataDir, ok, err := worktreeRegistrationMetadataDir(
+		ctx, gitDir, ws.WorktreePath,
+	)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return errors.New("workspace worktree registration metadata not found")
+	}
+	markerPath := filepath.Join(metadataDir, workspaceOwnershipMarkerFile)
+	marker, exists, err := readWorkspaceOwnershipMarker(markerPath)
+	if err != nil {
+		return err
+	}
+	if exists {
+		if marker != ws.ID {
+			return errors.New("workspace ownership marker belongs to another workspace")
+		}
+		return nil
+	}
+	file, err := os.OpenFile(
+		markerPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600,
+	)
+	if err != nil {
+		return fmt.Errorf("create workspace ownership marker: %w", err)
+	}
+	_, writeErr := file.WriteString(ws.ID + "\n")
+	closeErr := file.Close()
+	if err := errors.Join(writeErr, closeErr); err != nil {
+		_ = os.Remove(markerPath)
+		return fmt.Errorf("write workspace ownership marker: %w", err)
+	}
+	return nil
+}
+
+func workspaceRegistrationMatches(
+	ctx context.Context, gitDir, worktreePath, workspaceID string,
+) (bool, error) {
+	workspaceID = strings.TrimSpace(workspaceID)
+	if strings.TrimSpace(worktreePath) == "" || workspaceID == "" {
+		return false, nil
+	}
+	metadataDir, ok, err := worktreeRegistrationMetadataDir(
+		ctx, gitDir, worktreePath,
+	)
+	if err != nil || !ok {
+		return false, err
+	}
+	marker, exists, err := readWorkspaceOwnershipMarker(
+		filepath.Join(metadataDir, workspaceOwnershipMarkerFile),
+	)
+	if err != nil || !exists || marker != workspaceID {
+		return false, err
+	}
+
+	info, err := os.Lstat(worktreePath)
+	if errors.Is(err, os.ErrNotExist) {
+		return true, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("stat workspace path: %w", err)
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return false, nil
+	}
+	currentGitDir, err := worktreeGitDir(ctx, worktreePath)
+	if err != nil {
+		if isGitWorktreeAbsent(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("inspect workspace git dir: %w", err)
+	}
+	current, err := canonicalFilesystemPath(currentGitDir)
+	if err != nil {
+		return false, fmt.Errorf("resolve workspace git dir: %w", err)
+	}
+	want, err := canonicalFilesystemPath(metadataDir)
+	if err != nil {
+		return false, fmt.Errorf("resolve workspace registration: %w", err)
+	}
+	return current == want, nil
+}
+
+func readWorkspaceOwnershipMarker(markerPath string) (string, bool, error) {
+	info, err := os.Lstat(markerPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("stat workspace ownership marker: %w", err)
+	}
+	if !info.Mode().IsRegular() || info.Size() > 256 {
+		return "", true, nil
+	}
+	contents, err := os.ReadFile(markerPath)
+	if err != nil {
+		return "", false, fmt.Errorf("read workspace ownership marker: %w", err)
+	}
+	return strings.TrimSpace(string(contents)), true, nil
+}
+
+func worktreeRegistrationMetadataDir(
+	ctx context.Context, gitDir, worktreePath string,
+) (string, bool, error) {
+	out, err := gitCombinedOutput(
+		ctx, gitDir,
+		"rev-parse", "--path-format=absolute", "--git-path", "worktrees",
+	)
+	if err != nil {
+		return "", false, fmt.Errorf("resolve git worktree metadata: %w", err)
+	}
+	metadataRoot := strings.TrimSpace(out)
+	entries, err := os.ReadDir(metadataRoot)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("read git worktree metadata: %w", err)
+	}
+	wantGitFile, err := canonicalWorktreeListPath(
+		filepath.Join(worktreePath, ".git"),
+	)
+	if err != nil {
+		return "", false, fmt.Errorf("resolve worktree gitfile: %w", err)
+	}
+	var found string
+	for _, entry := range entries {
+		if !entry.IsDir() || entry.Type()&os.ModeSymlink != 0 {
+			continue
+		}
+		metadataDir := filepath.Join(metadataRoot, entry.Name())
+		gitFile, err := os.ReadFile(filepath.Join(metadataDir, "gitdir"))
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return "", false, fmt.Errorf("read worktree registration: %w", err)
+		}
+		registeredGitFile := strings.TrimSpace(string(gitFile))
+		if !filepath.IsAbs(registeredGitFile) {
+			registeredGitFile = filepath.Join(metadataDir, registeredGitFile)
+		}
+		gotGitFile, err := canonicalWorktreeListPath(registeredGitFile)
+		if err != nil {
+			return "", false, fmt.Errorf("resolve registered worktree gitfile: %w", err)
+		}
+		if gotGitFile != wantGitFile {
+			continue
+		}
+		if found != "" {
+			return "", false, errors.New("multiple worktree registrations match path")
+		}
+		found = metadataDir
+	}
+	return found, found != "", nil
+}
+
+func gitDirHasStaleWorktreeRegistration(
+	ctx context.Context, gitDir, worktreePath string,
+) (bool, error) {
+	tracked, err := gitDirTracksWorktreePath(ctx, gitDir, worktreePath)
+	if err != nil || !tracked {
+		return false, err
+	}
+	live, err := gitDirHasLiveWorktree(ctx, gitDir, worktreePath)
+	if err != nil {
+		return false, err
+	}
+	return !live, nil
+}
+
+func gitDirHasLiveWorktree(
+	ctx context.Context, gitDir, worktreePath string,
+) (bool, error) {
+	info, err := os.Lstat(worktreePath)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("stat workspace path: %w", err)
+	}
+	isDirectory := info.IsDir()
+	if info.Mode()&os.ModeSymlink != 0 {
+		targetInfo, targetErr := os.Stat(worktreePath)
+		if errors.Is(targetErr, os.ErrNotExist) {
+			return false, nil
+		}
+		if targetErr != nil {
+			return false, fmt.Errorf("stat workspace symlink target: %w", targetErr)
+		}
+		isDirectory = targetInfo.IsDir()
+	}
+	if !isDirectory {
+		return false, nil
+	}
 	commonDir, err := worktreeCommonGitDir(ctx, worktreePath)
 	if err != nil {
 		if isGitWorktreeAbsent(err) {
@@ -2724,18 +3159,51 @@ func gitDirOwnsCleanupWorktree(
 		}
 		return false, err
 	}
-	candidateDir, err := canonicalFilesystemPath(gitDir)
+	candidateCommonDir, err := worktreeCommonGitDir(ctx, gitDir)
 	if err != nil {
-		return false, fmt.Errorf("resolve git dir: %w", err)
+		return false, fmt.Errorf("inspect cleanup git dir: %w", err)
 	}
-	actualDir, err := canonicalFilesystemPath(commonDir)
+	candidate, err := canonicalFilesystemPath(candidateCommonDir)
+	if err != nil {
+		return false, fmt.Errorf("resolve cleanup git dir: %w", err)
+	}
+	current, err := canonicalFilesystemPath(commonDir)
 	if err != nil {
 		return false, fmt.Errorf("resolve workspace git common dir: %w", err)
 	}
-	if actualDir != candidateDir {
+	if current != candidate {
 		return false, nil
 	}
-	return gitDirOwnsLinkedWorktree(ctx, gitDir, worktreePath)
+	return gitDirOwnsLinkedWorktree(ctx, candidateCommonDir, worktreePath)
+}
+
+func worktreeGitDir(ctx context.Context, worktreePath string) (string, error) {
+	out, err := gitCombinedOutput(
+		ctx, worktreePath,
+		"rev-parse", "--path-format=absolute", "--git-dir",
+	)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
+}
+
+func gitDirOwnsCleanupWorktree(
+	ctx context.Context, gitDir, worktreePath, workspaceID string,
+) (bool, error) {
+	owned, err := workspaceRegistrationMatches(
+		ctx, gitDir, worktreePath, workspaceID,
+	)
+	if err != nil || owned {
+		return owned, err
+	}
+	live, err := gitDirHasLiveWorktree(ctx, gitDir, worktreePath)
+	if err != nil || !live {
+		return false, err
+	}
+	return false, fmt.Errorf(
+		"%w: %s", ErrWorkspaceOwnershipUnproven, worktreePath,
+	)
 }
 
 func gitDirOwnsLinkedWorktree(
@@ -3943,6 +4411,30 @@ func runGitWorktreeAdd(
 	return runGitWithoutHooks(ctx, dir, gitArgs...)
 }
 
+func runGitWorktreeAddCreatingBranch(
+	ctx context.Context, dir, worktreePath, branch, startRef string,
+) error {
+	existed, err := localBranchExists(ctx, dir, branch)
+	if err != nil {
+		return fmt.Errorf("inspect worktree branch %q: %w", branch, err)
+	}
+	addErr := runGitWorktreeAdd(
+		ctx, dir, worktreePath, "-b", branch, startRef,
+	)
+	if addErr == nil || existed {
+		return addErr
+	}
+	if cleanupErr := deleteWorkspaceBranchStrict(
+		ctx, dir, branch,
+	); cleanupErr != nil {
+		return errors.Join(
+			addErr,
+			fmt.Errorf("clean up failed worktree branch: %w", cleanupErr),
+		)
+	}
+	return addErr
+}
+
 // runBuiltCmd runs a pre-built exec.Cmd and wraps any failure with
 // the combined output. Used for tmux invocations whose *exec.Cmd is
 // assembled by tmuxExec so argv[0] access stays inside that helper.
@@ -4333,6 +4825,36 @@ func worktreeCommonGitDir(
 	return strings.TrimSpace(out), nil
 }
 
+func worktreePathIsRoot(
+	ctx context.Context, worktreePath string,
+) (bool, error) {
+	insideWorktree, err := gitCombinedOutput(
+		ctx, worktreePath, "rev-parse", "--is-inside-work-tree",
+	)
+	if err != nil {
+		return false, err
+	}
+	if strings.TrimSpace(insideWorktree) != "true" {
+		return false, nil
+	}
+	out, err := gitCombinedOutput(
+		ctx, worktreePath,
+		"rev-parse", "--path-format=absolute", "--show-toplevel",
+	)
+	if err != nil {
+		return false, err
+	}
+	root, err := canonicalFilesystemPath(strings.TrimSpace(out))
+	if err != nil {
+		return false, err
+	}
+	candidate, err := canonicalFilesystemPath(worktreePath)
+	if err != nil {
+		return false, err
+	}
+	return root == candidate, nil
+}
+
 func gitDirTracksWorktreePath(
 	ctx context.Context, gitDir, worktreePath string,
 ) (bool, error) {
@@ -4370,15 +4892,19 @@ func canonicalWorktreeListPath(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if evaluated, err := filepath.EvalSymlinks(abs); err == nil {
-		return evaluated, nil
+	current := abs
+	var suffix []string
+	for {
+		if evaluated, err := filepath.EvalSymlinks(current); err == nil {
+			return filepath.Join(append([]string{evaluated}, suffix...)...), nil
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return abs, nil
+		}
+		suffix = append([]string{filepath.Base(current)}, suffix...)
+		current = parent
 	}
-	parent := filepath.Dir(abs)
-	evaluatedParent, err := filepath.EvalSymlinks(parent)
-	if err != nil {
-		return abs, nil
-	}
-	return filepath.Join(evaluatedParent, filepath.Base(abs)), nil
 }
 
 func gitIsBareRepository(ctx context.Context, dir string) (bool, error) {

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -2328,6 +2328,65 @@ func isSyntheticPRWorktreeBranch(mrNumber int, branch string) bool {
 	return err == nil
 }
 
+// cleanupUnmarkedWorktreeAdd rolls back a worktree whose ownership marker
+// could not be published. Callers hold the repository lock. The exact live
+// registration must still be present and unmarked before it can be removed.
+func cleanupUnmarkedWorktreeAdd(
+	ctx context.Context,
+	cloneDir string,
+	ws *Workspace,
+	branch, branchSHA string,
+) error {
+	cleanupCtx, cancel := cleanupContext(ctx)
+	defer cancel()
+	live, err := gitDirHasLiveWorktree(
+		cleanupCtx, cloneDir, ws.WorktreePath,
+	)
+	if err != nil {
+		return fmt.Errorf("verify failed worktree registration: %w", err)
+	}
+	if !live {
+		return fmt.Errorf(
+			"%w: %s", ErrWorkspaceOwnershipUnproven, ws.WorktreePath,
+		)
+	}
+	metadataDir, ok, err := worktreeRegistrationMetadataDir(
+		cleanupCtx, cloneDir, ws.WorktreePath,
+	)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return errors.New("failed worktree registration metadata not found")
+	}
+	_, marked, err := readWorkspaceOwnershipMarker(
+		filepath.Join(metadataDir, workspaceOwnershipMarkerFile),
+	)
+	if err != nil {
+		return err
+	}
+	if marked {
+		return fmt.Errorf(
+			"%w: %s", ErrWorkspaceOwnershipUnproven, ws.WorktreePath,
+		)
+	}
+	if err := runGitWithoutHooks(
+		cleanupCtx, cloneDir,
+		"worktree", "remove", "--force", ws.WorktreePath,
+	); err != nil {
+		return fmt.Errorf("remove failed worktree: %w", err)
+	}
+	if branch == "" {
+		return nil
+	}
+	if err := deleteWorkspaceBranchIfMatches(
+		cleanupCtx, cloneDir, branch, branchSHA,
+	); err != nil {
+		return fmt.Errorf("remove failed worktree branch: %w", err)
+	}
+	return nil
+}
+
 // cleanupOwnedWorktreeAddOnUpstreamFailure rolls back a marked worktree after
 // post-add configuration fails. Callers hold the repository lock. An empty
 // branch leaves a pre-existing user-owned branch in place.
@@ -2709,7 +2768,13 @@ func (m *Manager) cleanupWorkspaceArtifactsForRetry(
 		return err
 	}
 	if !ok {
-		return nil
+		gitDir, ok, err = m.workspaceRegisteredCleanupGitDir(ctx, ws)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return nil
+		}
 	}
 
 	return m.withRepoLockForGitDir(ctx, gitDir, func() error {
@@ -4548,7 +4613,15 @@ func (m *Manager) runOwnedGitWorktreeAdd(
 		return err
 	}
 	if err := writeWorkspaceOwnershipMarker(ctx, dir, ws); err != nil {
-		return fmt.Errorf("%w: %w", errWorkspaceOwnershipMarker, err)
+		markerErr := fmt.Errorf("%w: %w", errWorkspaceOwnershipMarker, err)
+		cleanupErr := cleanupUnmarkedWorktreeAdd(ctx, dir, ws, "", "")
+		if cleanupErr != nil {
+			return errors.Join(
+				markerErr,
+				fmt.Errorf("roll back unmarked worktree: %w", cleanupErr),
+			)
+		}
+		return markerErr
 	}
 	return nil
 }
@@ -4575,7 +4648,17 @@ func (m *Manager) runOwnedGitWorktreeAddCreatingBranch(
 		return "", err
 	}
 	if err := writeWorkspaceOwnershipMarker(ctx, dir, ws); err != nil {
-		return "", fmt.Errorf("%w: %w", errWorkspaceOwnershipMarker, err)
+		markerErr := fmt.Errorf("%w: %w", errWorkspaceOwnershipMarker, err)
+		cleanupErr := cleanupUnmarkedWorktreeAdd(
+			ctx, dir, ws, branch, branchSHA,
+		)
+		if cleanupErr != nil {
+			return "", errors.Join(
+				markerErr,
+				fmt.Errorf("roll back unmarked worktree: %w", cleanupErr),
+			)
+		}
+		return "", markerErr
 	}
 	return branchSHA, nil
 }

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -154,6 +154,7 @@ var (
 	ErrWorkspaceDuplicate         = errors.New("workspace already exists")
 	ErrWorkspaceInvalidState      = errors.New("workspace invalid state")
 	ErrWorkspaceOwnershipUnproven = errors.New("workspace worktree ownership cannot be verified")
+	errWorkspaceOwnershipMarker   = errors.New("workspace ownership marker failed")
 	// ErrInvalidBranchName lets HTTP handlers map a rejected branch to a
 	// validation response with errors.Is instead of matching on the git
 	// message this error carries.
@@ -2005,12 +2006,6 @@ func (m *Manager) addWorktree(
 		if addErr != nil {
 			return addErr
 		}
-		if err := writeWorkspaceOwnershipMarker(ctx, cloneDir, ws); err != nil {
-			cleanupWorktreeAddOnUpstreamFailure(
-				ctx, cloneDir, ws.WorktreePath, branch,
-			)
-			return fmt.Errorf("record workspace ownership: %w", err)
-		}
 		return nil
 	})
 	return branch, err
@@ -2034,6 +2029,9 @@ func (m *Manager) addWorktreeLocked(
 	branch, err := m.addPreferredWorktree(ctx, cloneDir, localBase, ws)
 	if err == nil {
 		return branch, nil
+	}
+	if errors.Is(err, errWorkspaceOwnershipMarker) {
+		return "", err
 	}
 	fallbackBranch := syntheticPRWorktreeBranch(ws.ItemNumber)
 	// Providers may not retain a synthetic MR head ref. Try to populate the
@@ -2094,6 +2092,9 @@ func (m *Manager) addFallbackWorktree(
 		return branch, nil
 	}
 	fallbackErr := err
+	if errors.Is(err, errWorkspaceOwnershipMarker) {
+		return "", err
+	}
 
 	// Uniquifying leaves the colliding branch untouched: it may be a live
 	// workspace's checkout or a user branch kenn-forge never created.
@@ -2106,10 +2107,13 @@ func (m *Manager) addFallbackWorktree(
 		if err == nil {
 			return branch, nil
 		}
+		if errors.Is(err, errWorkspaceOwnershipMarker) {
+			return "", err
+		}
 	}
 
-	if detachErr := runGitWorktreeAdd(
-		ctx, cloneDir, ws.WorktreePath, "--detach", startRef,
+	if detachErr := m.runOwnedGitWorktreeAdd(
+		ctx, cloneDir, ws, "--detach", startRef,
 	); detachErr != nil {
 		return "", fmt.Errorf(
 			"%w; detached checkout failed: %w", fallbackErr, detachErr,
@@ -2129,18 +2133,21 @@ func (m *Manager) addFallbackBranchWorktree(
 	ws *Workspace,
 	branch, startRef string,
 ) (string, error) {
-	if err := runGitWorktreeAddCreatingBranch(
-		ctx, cloneDir, ws.WorktreePath, branch, startRef,
-	); err != nil {
+	branchSHA, err := m.runOwnedGitWorktreeAddCreatingBranch(
+		ctx, cloneDir, ws, branch, startRef,
+	)
+	if err != nil {
 		return "", err
 	}
 	if err := configureFallbackBranchUpstream(
 		ctx, cloneDir, ws, branch,
 	); err != nil {
-		cleanupWorktreeAddOnUpstreamFailure(
-			ctx, cloneDir, ws.WorktreePath, branch,
+		cleanupErr := cleanupOwnedWorktreeAddOnUpstreamFailure(
+			ctx, cloneDir, ws, branch, branchSHA,
 		)
-		return "", fmt.Errorf("configure branch upstream: %w", err)
+		return "", errors.Join(
+			fmt.Errorf("configure branch upstream: %w", err), cleanupErr,
+		)
 	}
 	return branch, nil
 }
@@ -2153,16 +2160,16 @@ func (m *Manager) addIssueWorktree(
 		workspaceBranch = ws.GitHeadRef
 	}
 	if workspaceBranch == "" {
-		if err := runGitWorktreeAdd(
-			ctx, cloneDir, ws.WorktreePath, ws.GitHeadRef,
+		if err := m.runOwnedGitWorktreeAdd(
+			ctx, cloneDir, ws, ws.GitHeadRef,
 		); err != nil {
 			return "", err
 		}
 		return "", nil
 	}
 	startRef := workspaceStartRef(ws)
-	if err := runGitWorktreeAddCreatingBranch(
-		ctx, cloneDir, ws.WorktreePath, workspaceBranch, startRef,
+	if _, err := m.runOwnedGitWorktreeAddCreatingBranch(
+		ctx, cloneDir, ws, workspaceBranch, startRef,
 	); err != nil {
 		return "", err
 	}
@@ -2179,8 +2186,8 @@ func (m *Manager) addPreferredWorktree(
 	}
 
 	if ws.MRHeadRepo != nil {
-		err := runGitWorktreeAddCreatingBranch(
-			ctx, cloneDir, ws.WorktreePath,
+		_, err := m.runOwnedGitWorktreeAddCreatingBranch(
+			ctx, cloneDir, ws,
 			ws.GitHeadRef, workspaceStartRef(ws),
 		)
 		if err != nil {
@@ -2204,19 +2211,22 @@ func (m *Manager) addPreferredWorktree(
 		return "", err
 	}
 	if !exists {
-		if err := runGitWorktreeAddCreatingBranch(
-			ctx, cloneDir, ws.WorktreePath, ws.GitHeadRef, startRef,
-		); err != nil {
+		branchSHA, err := m.runOwnedGitWorktreeAddCreatingBranch(
+			ctx, cloneDir, ws, ws.GitHeadRef, startRef,
+		)
+		if err != nil {
 			return "", err
 		}
 		if err := setBranchUpstream(
 			ctx, ws.WorktreePath, ws.GitHeadRef,
 			"origin", "refs/heads/"+ws.GitHeadRef,
 		); err != nil {
-			cleanupWorktreeAddOnUpstreamFailure(
-				ctx, cloneDir, ws.WorktreePath, ws.GitHeadRef,
+			cleanupErr := cleanupOwnedWorktreeAddOnUpstreamFailure(
+				ctx, cloneDir, ws, ws.GitHeadRef, branchSHA,
 			)
-			return "", fmt.Errorf("configure branch upstream: %w", err)
+			return "", errors.Join(
+				fmt.Errorf("configure branch upstream: %w", err), cleanupErr,
+			)
 		}
 		return ws.GitHeadRef, nil
 	}
@@ -2239,8 +2249,8 @@ func (m *Manager) addPreferredWorktree(
 		}
 	}
 
-	if err := runGitWorktreeAdd(
-		ctx, cloneDir, ws.WorktreePath, ws.GitHeadRef,
+	if err := m.runOwnedGitWorktreeAdd(
+		ctx, cloneDir, ws, ws.GitHeadRef,
 	); err != nil {
 		return "", err
 	}
@@ -2252,10 +2262,12 @@ func (m *Manager) addPreferredWorktree(
 		); err != nil {
 			// Empty branch: the branch pre-existed this workspace and
 			// stays in place; only the worktree is rolled back.
-			cleanupWorktreeAddOnUpstreamFailure(
-				ctx, cloneDir, ws.WorktreePath, "",
+			cleanupErr := cleanupOwnedWorktreeAddOnUpstreamFailure(
+				ctx, cloneDir, ws, "", "",
 			)
-			return "", fmt.Errorf("configure branch upstream: %w", err)
+			return "", errors.Join(
+				fmt.Errorf("configure branch upstream: %w", err), cleanupErr,
+			)
 		}
 	}
 
@@ -2316,26 +2328,43 @@ func isSyntheticPRWorktreeBranch(mrNumber int, branch string) bool {
 	return err == nil
 }
 
-// cleanupWorktreeAddOnUpstreamFailure rolls back a just-added worktree (and,
-// when kenn-forge created it, its branch) after configuring the branch
-// upstream failed. Callers must already hold the per-repo lock for cloneDir.
-// An empty branch leaves a pre-existing user-owned branch in place.
-func cleanupWorktreeAddOnUpstreamFailure(
-	ctx context.Context, cloneDir, worktreePath, branch string,
-) {
+// cleanupOwnedWorktreeAddOnUpstreamFailure rolls back a marked worktree after
+// post-add configuration fails. Callers hold the repository lock. An empty
+// branch leaves a pre-existing user-owned branch in place.
+func cleanupOwnedWorktreeAddOnUpstreamFailure(
+	ctx context.Context,
+	cloneDir string,
+	ws *Workspace,
+	branch, branchSHA string,
+) error {
 	cleanupCtx, cancel := cleanupContext(ctx)
 	defer cancel()
-	_ = runGitWithoutHooks(
-		cleanupCtx, cloneDir,
-		"worktree", "remove", "--force", worktreePath,
+	owned, err := workspaceRegistrationMatches(
+		cleanupCtx, cloneDir, ws.WorktreePath, ws.ID,
 	)
-	if branch == "" {
-		return
+	if err != nil {
+		return fmt.Errorf("verify failed worktree ownership: %w", err)
 	}
-	_ = runGitWithoutHooks(
+	if !owned {
+		return fmt.Errorf(
+			"%w: %s", ErrWorkspaceOwnershipUnproven, ws.WorktreePath,
+		)
+	}
+	if err := runGitWithoutHooks(
 		cleanupCtx, cloneDir,
-		"branch", "-D", "--", branch,
-	)
+		"worktree", "remove", "--force", ws.WorktreePath,
+	); err != nil {
+		return fmt.Errorf("remove failed worktree: %w", err)
+	}
+	if branch == "" {
+		return nil
+	}
+	if err := deleteWorkspaceBranchIfMatches(
+		cleanupCtx, cloneDir, branch, branchSHA,
+	); err != nil {
+		return fmt.Errorf("remove failed worktree branch: %w", err)
+	}
+	return nil
 }
 
 // configureFallbackBranchUpstream points the synthetic PR fallback branch at
@@ -4481,28 +4510,98 @@ func runGitWorktreeAdd(
 	return runGitWithoutHooks(ctx, dir, gitArgs...)
 }
 
+func (m *Manager) runOwnedGitWorktreeAdd(
+	ctx context.Context, dir string, ws *Workspace, args ...string,
+) error {
+	if err := runGitWorktreeAdd(ctx, dir, ws.WorktreePath, args...); err != nil {
+		return err
+	}
+	if err := writeWorkspaceOwnershipMarker(ctx, dir, ws); err != nil {
+		return fmt.Errorf("%w: %w", errWorkspaceOwnershipMarker, err)
+	}
+	return nil
+}
+
 func runGitWorktreeAddCreatingBranch(
 	ctx context.Context, dir, worktreePath, branch, startRef string,
 ) error {
-	existed, err := localBranchExists(ctx, dir, branch)
+	_, err := createBranchAndAddWorktree(
+		ctx, dir, worktreePath, branch, startRef,
+	)
+	return err
+}
+
+func (m *Manager) runOwnedGitWorktreeAddCreatingBranch(
+	ctx context.Context,
+	dir string,
+	ws *Workspace,
+	branch, startRef string,
+) (string, error) {
+	branchSHA, err := createBranchAndAddWorktree(
+		ctx, dir, ws.WorktreePath, branch, startRef,
+	)
 	if err != nil {
-		return fmt.Errorf("inspect worktree branch %q: %w", branch, err)
+		return "", err
+	}
+	if err := writeWorkspaceOwnershipMarker(ctx, dir, ws); err != nil {
+		return "", fmt.Errorf("%w: %w", errWorkspaceOwnershipMarker, err)
+	}
+	return branchSHA, nil
+}
+
+func createBranchAndAddWorktree(
+	ctx context.Context, dir, worktreePath, branch, startRef string,
+) (string, error) {
+	if err := validateLocalBranchName(ctx, dir, branch); err != nil {
+		return "", err
+	}
+	startSHA, ok, err := gitRefSHA(ctx, dir, startRef)
+	if err != nil {
+		return "", fmt.Errorf("resolve worktree start ref %q: %w", startRef, err)
+	}
+	if !ok {
+		return "", fmt.Errorf("worktree start ref %q not found", startRef)
+	}
+	branchRef := "refs/heads/" + branch
+	zeroOID := strings.Repeat("0", len(startSHA))
+	if err := runGitWithoutHooks(
+		ctx, dir, "update-ref", branchRef, startSHA, zeroOID,
+	); err != nil {
+		return "", fmt.Errorf("create worktree branch %q: %w", branch, err)
 	}
 	addErr := runGitWorktreeAdd(
-		ctx, dir, worktreePath, "-b", branch, startRef,
+		ctx, dir, worktreePath, branch,
 	)
-	if addErr == nil || existed {
-		return addErr
+	if addErr == nil {
+		return startSHA, nil
 	}
-	if cleanupErr := deleteWorkspaceBranchStrict(
-		ctx, dir, branch,
+	if cleanupErr := deleteWorkspaceBranchIfMatches(
+		ctx, dir, branch, startSHA,
 	); cleanupErr != nil {
-		return errors.Join(
+		return "", errors.Join(
 			addErr,
 			fmt.Errorf("clean up failed worktree branch: %w", cleanupErr),
 		)
 	}
-	return addErr
+	return "", addErr
+}
+
+func deleteWorkspaceBranchIfMatches(
+	ctx context.Context, dir, branch, expectedSHA string,
+) error {
+	if strings.TrimSpace(expectedSHA) == "" {
+		return errors.New("expected branch SHA is required")
+	}
+	if err := validateLocalBranchName(ctx, dir, branch); err != nil {
+		return err
+	}
+	if err := runGitWithoutHooks(
+		ctx, dir,
+		"update-ref", "-d", "refs/heads/"+branch, expectedSHA,
+	); err != nil {
+		return fmt.Errorf("delete git branch %q if unchanged: %w", branch, err)
+	}
+	return nil
 }
 
 // runBuiltCmd runs a pre-built exec.Cmd and wraps any failure with
@@ -4658,12 +4757,32 @@ func (m *Manager) rollbackWorktree(
 	cleanupCtx, cancel := cleanupContext(ctx)
 	defer cancel()
 	err := m.withRepoLockForGitDir(cleanupCtx, cloneDir, func() error {
+		owned, err := workspaceRegistrationMatches(
+			cleanupCtx, cloneDir, ws.WorktreePath, ws.ID,
+		)
+		if err != nil {
+			return fmt.Errorf("verify rollback worktree ownership: %w", err)
+		}
+		if !owned {
+			slog.Warn("rollback: preserved worktree without matching ownership marker",
+				"workspace_id", ws.ID, "path", ws.WorktreePath)
+			return nil
+		}
 		if err := runGitWithoutHooks(
 			cleanupCtx, cloneDir,
 			"worktree", "remove", "--force", ws.WorktreePath,
 		); err != nil {
+			if isGitWorktreeAbsent(err) {
+				if staleErr := removeStaleWorktreeRegistrationMetadata(
+					cleanupCtx, cloneDir, ws.WorktreePath,
+				); staleErr == nil {
+					m.deleteWorkspaceBranches(cleanupCtx, cloneDir, ws, branch)
+					return nil
+				}
+			}
 			slog.Warn("rollback: worktree remove failed",
 				"path", ws.WorktreePath, "err", err)
+			return nil
 		}
 		m.deleteWorkspaceBranches(cleanupCtx, cloneDir, ws, branch)
 		return nil

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -3057,6 +3057,11 @@ func TestCleanupQuarantinesPlainWorkspaceNestedInRepository(t *testing.T) {
 
 	parentRepo := setupLocalWorktreeBaseForWorkspaceGitTest(t, "feature/thing")
 	worktreePath := filepath.Join(parentRepo, "managed", "workspace")
+	runWorkspaceTestGit(
+		t, parentRepo,
+		"worktree", "add", worktreePath, "-b", "topic/stale-nested", "HEAD",
+	)
+	require.NoError(os.RemoveAll(worktreePath))
 	require.NoError(os.MkdirAll(worktreePath, 0o755))
 	require.NoError(os.WriteFile(
 		filepath.Join(worktreePath, "leftover.txt"), []byte("preserve me\n"), 0o644,

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -3321,6 +3321,7 @@ func TestAddPreferredWorktreeRejectsUnsafeBranchName(t *testing.T) {
 	cloneDir := setupBareCloneForWorkspaceGitTest(t)
 	mgr := NewManager(openTestDB(t), t.TempDir())
 	ws := &Workspace{
+		ID:           "ws-unsafe-branch",
 		ItemType:     db.WorkspaceItemTypePullRequest,
 		ItemNumber:   42,
 		GitHeadRef:   "-unsafe",
@@ -3377,6 +3378,7 @@ func TestAddWorktreeUsesFallbackWhenLocalBasePreferredBranchCheckedOut(t *testin
 	)
 	mgr := NewManager(openTestDB(t), t.TempDir())
 	ws := &Workspace{
+		ID:           "ws-local-base-fallback",
 		ItemType:     db.WorkspaceItemTypePullRequest,
 		ItemNumber:   42,
 		GitHeadRef:   branch,
@@ -3462,6 +3464,37 @@ func TestAddWorktreeFallbackBranchTracksPRHeadBranch(t *testing.T) {
 	require.True(ok, "divergence probe must resolve @{upstream}")
 	assert.Equal(0, div.Ahead)
 	assert.Equal(0, div.Behind)
+}
+
+func TestAddWorktreeLockedRecordsOwnershipBeforeReturning(t *testing.T) {
+	require := require.New(t)
+	cloneDir := setupBareCloneForWorkspaceGitTest(t)
+	const (
+		prNumber   = 45
+		headBranch = "feature/owned-registration"
+	)
+	configureSameRepoPRRefs(t, cloneDir, headBranch, prNumber)
+	ws := &Workspace{
+		ID:              "ws-owned-registration",
+		Platform:        "github",
+		PlatformHost:    "github.com",
+		RepoOwner:       "acme",
+		RepoName:        "widget",
+		ItemType:        db.WorkspaceItemTypePullRequest,
+		ItemNumber:      prNumber,
+		GitHeadRef:      headBranch,
+		WorkspaceBranch: workspaceBranchUnknown,
+		WorktreePath:    filepath.Join(t.TempDir(), "worktree"),
+	}
+	mgr := NewManager(openTestDB(t), t.TempDir())
+
+	_, err := mgr.addWorktreeLocked(t.Context(), cloneDir, false, ws)
+	require.NoError(err)
+	owned, err := workspaceRegistrationMatches(
+		t.Context(), cloneDir, ws.WorktreePath, ws.ID,
+	)
+	require.NoError(err)
+	require.True(owned, "the registration must be marked before addWorktreeLocked returns")
 }
 
 // divergentCommitForWorkspaceGitTest creates a commit that is not the PR head so
@@ -4128,16 +4161,17 @@ func TestRollbackWorktreeDeletesBranchWhenContextCanceled(t *testing.T) {
 
 	cloneDir := setupBareCloneForWorkspaceGitTest(t)
 	branch := syntheticPRWorktreeBranch(42)
-	require.NoError(runGitWithoutHooks(
-		t.Context(), cloneDir,
-		"branch", branch, "main",
-	))
-
 	ws := &Workspace{
+		ID:           "ws-canceled-rollback",
 		ItemType:     db.WorkspaceItemTypePullRequest,
 		ItemNumber:   42,
-		WorktreePath: filepath.Join(t.TempDir(), "missing-worktree"),
+		WorktreePath: filepath.Join(t.TempDir(), "worktree"),
 	}
+	runWorkspaceTestGit(
+		t, cloneDir,
+		"worktree", "add", ws.WorktreePath, "-b", branch, "main",
+	)
+	require.NoError(writeWorkspaceOwnershipMarker(t.Context(), cloneDir, ws))
 	mgr := NewManager(openTestDB(t), t.TempDir())
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -4150,6 +4184,46 @@ func TestRollbackWorktreeDeletesBranchWhenContextCanceled(t *testing.T) {
 	)
 	require.NoError(err)
 	assert.False(exists)
+}
+
+func TestRollbackWorktreePreservesReplacementWithoutOwnershipMarker(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	cloneDir := setupBareCloneForWorkspaceGitTest(t)
+	branch := syntheticPRWorktreeBranch(43)
+	ws := &Workspace{
+		ID:           "ws-replaced-before-rollback",
+		ItemType:     db.WorkspaceItemTypePullRequest,
+		ItemNumber:   43,
+		WorktreePath: filepath.Join(t.TempDir(), "worktree"),
+	}
+	runWorkspaceTestGit(
+		t, cloneDir,
+		"worktree", "add", ws.WorktreePath, "-b", branch, "main",
+	)
+	require.NoError(writeWorkspaceOwnershipMarker(t.Context(), cloneDir, ws))
+	runWorkspaceTestGit(
+		t, cloneDir, "worktree", "remove", "--force", ws.WorktreePath,
+	)
+	runWorkspaceTestGit(t, cloneDir, "worktree", "add", ws.WorktreePath, branch)
+	require.NoError(os.WriteFile(
+		filepath.Join(ws.WorktreePath, "replacement.txt"),
+		[]byte("uncommitted replacement\n"), 0o644,
+	))
+
+	mgr := NewManager(openTestDB(t), t.TempDir())
+	mgr.rollbackWorktree(t.Context(), cloneDir, ws, branch)
+
+	contents, err := os.ReadFile(filepath.Join(ws.WorktreePath, "replacement.txt"))
+	require.NoError(err)
+	assert.Equal("uncommitted replacement\n", string(contents))
+	branchSHA, exists, err := gitRefSHA(
+		t.Context(), cloneDir, "refs/heads/"+branch,
+	)
+	require.NoError(err)
+	assert.True(exists)
+	assert.NotEmpty(branchSHA)
 }
 
 func TestLocalBranchExistsIgnoresInheritedGitEnv(t *testing.T) {
@@ -6759,6 +6833,48 @@ func TestAddPreferredWorktreeRemovesBranchCreatedByFailedAdd(t *testing.T) {
 	exists, err := localBranchExists(t.Context(), cloneDir, preferredBranch)
 	require.NoError(err)
 	assert.False(exists, "a failed add must remove only the branch it created")
+}
+
+func TestFailedWorktreeAddPreservesConcurrentlyChangedBranch(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	cloneDir := setupBareCloneForWorkspaceGitTest(t)
+	const branch = "feature/concurrent-owner"
+	divergentSHA := divergentCommitForWorkspaceGitTest(
+		t, cloneDir,
+		strings.TrimSpace(string(runWorkspaceTestGit(t, cloneDir, "rev-parse", "main"))),
+	)
+	realGit, err := exec.LookPath("git")
+	require.NoError(err)
+	fakeDir := t.TempDir()
+	fakeGit := filepath.Join(fakeDir, "git")
+	require.NoError(os.WriteFile(fakeGit, []byte(`#!/bin/sh
+set -eu
+case " $* " in
+  *" worktree add "*)
+    "$KENN_FORGE_TEST_REAL_GIT" --git-dir="$KENN_FORGE_TEST_GIT_DIR" \
+      update-ref "$KENN_FORGE_TEST_BRANCH_REF" "$KENN_FORGE_TEST_BRANCH_SHA"
+    exit 128
+    ;;
+esac
+exec "$KENN_FORGE_TEST_REAL_GIT" "$@"
+`), 0o755))
+	t.Setenv("KENN_FORGE_TEST_REAL_GIT", realGit)
+	t.Setenv("KENN_FORGE_TEST_GIT_DIR", cloneDir)
+	t.Setenv("KENN_FORGE_TEST_BRANCH_REF", "refs/heads/"+branch)
+	t.Setenv("KENN_FORGE_TEST_BRANCH_SHA", divergentSHA)
+	t.Setenv("PATH", fakeDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	err = runGitWorktreeAddCreatingBranch(
+		t.Context(), cloneDir, filepath.Join(t.TempDir(), "worktree"), branch, "main",
+	)
+	require.Error(err)
+	branchSHA, exists, err := gitRefSHA(
+		t.Context(), cloneDir, "refs/heads/"+branch,
+	)
+	require.NoError(err)
+	assert.True(exists)
+	assert.Equal(divergentSHA, branchSHA)
 }
 
 func TestManagerCleanupForDeleteAcquiresRepoLock(t *testing.T) {

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -1689,8 +1689,9 @@ func TestSetupDoesNotReuseUnconfiguredMatchingOriginWorktree(t *testing.T) {
 
 	err = mgr.Setup(t.Context(), ws)
 
-	require.Error(err)
-	assert.Contains(err.Error(), "clone manager not set")
+	var recoveryErr *WorkspaceDirectoryRecoveryError
+	require.ErrorAs(err, &recoveryErr)
+	assert.Equal(WorkspaceDirectoryRepositoryMismatch, recoveryErr.Reason)
 	got, getErr := d.GetWorkspace(t.Context(), ws.ID)
 	require.NoError(getErr)
 	require.NotNil(got)
@@ -1838,6 +1839,51 @@ func TestSetupReusesExistingLocalBasePRHeadBranchWithoutManagingIt(t *testing.T)
 	exists, err := localBranchExists(t.Context(), localRepo, "feature/thing")
 	require.NoError(err)
 	assert.True(exists)
+}
+
+func TestSetupRejectsOrphanedWorkspacePathBeforeCreatingBranches(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	wtDir := t.TempDir()
+
+	localRepo, _, platformHost := setupHTTPWorktreeBaseForWorkspaceGitTest(
+		t, "feature/thing",
+	)
+	repoID := seedRepo(t, d, platformHost, "acme", "widget")
+	seedMR(t, d, repoID, 42, "feature/thing")
+
+	mgr := NewManager(d, wtDir)
+	mgr.SetWorktreeBasePathResolver(staticBaseResolver(localRepo))
+	ws, err := mgr.Create(
+		t.Context(), "github", platformHost, "acme", "widget", 42,
+	)
+	require.NoError(err)
+	require.NoError(os.MkdirAll(ws.WorktreePath, 0o755))
+	staleGitDir := filepath.Join(t.TempDir(), "removed", "worktrees", "pr-42")
+	require.NoError(os.WriteFile(
+		filepath.Join(ws.WorktreePath, ".git"),
+		[]byte("gitdir: "+staleGitDir+"\n"),
+		0o644,
+	))
+	require.NoError(os.WriteFile(
+		filepath.Join(ws.WorktreePath, "keep.txt"), []byte("preserve me\n"), 0o644,
+	))
+
+	err = mgr.Setup(t.Context(), ws)
+
+	var recoveryErr *WorkspaceDirectoryRecoveryError
+	if assert.ErrorAs(err, &recoveryErr) {
+		assert.Equal(WorkspaceDirectoryNotLinkedWorktree, recoveryErr.Reason)
+	}
+	contents, readErr := os.ReadFile(filepath.Join(ws.WorktreePath, "keep.txt"))
+	require.NoError(readErr)
+	assert.Equal("preserve me\n", string(contents))
+	for _, branch := range []string{ws.GitHeadRef, syntheticPRWorktreeBranch(42)} {
+		exists, branchErr := localBranchExists(t.Context(), localRepo, branch)
+		require.NoError(branchErr)
+		assert.False(exists, "setup must not create branch %q", branch)
+	}
 }
 
 func TestSetupRejectsExistingPRWorktreeOnUnexpectedBranch(t *testing.T) {
@@ -2576,7 +2622,7 @@ func TestFetchWorkspaceBaseDisablesGitHooks(t *testing.T) {
 	assert.Contains(calls[1], "set-head")
 }
 
-func TestCleanupUsesExistingWorktreeGitDirWhenConfiguredBaseChanges(t *testing.T) {
+func TestCleanupPreservesExistingWorktreeWhenConfiguredBaseChanges(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -2606,11 +2652,10 @@ func TestCleanupUsesExistingWorktreeGitDirWhenConfiguredBaseChanges(t *testing.T
 
 	require.NoError(mgr.cleanupWorkspaceArtifactsForDelete(t.Context(), ws))
 
-	_, err := os.Stat(worktreePath)
-	assert.True(os.IsNotExist(err), "cleanup should remove original worktree")
+	assert.DirExists(worktreePath)
 	actualExists, err := localBranchExists(t.Context(), actualRepo, branch)
 	require.NoError(err)
-	assert.False(actualExists)
+	assert.True(actualExists, "cleanup must preserve the unconfigured worktree")
 	wrongExists, err := localBranchExists(t.Context(), wrongRepo, branch)
 	require.NoError(err)
 	assert.True(wrongExists, "cleanup must not delete branch from current settings repo")
@@ -2702,6 +2747,75 @@ func TestCleanupDoesNotTrustStaleLocalBaseRegistrationForReplacementClone(t *tes
 	require.NoError(err)
 }
 
+func TestCleanupDeleteLockedRevalidatesOwnershipAfterPlanRace(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	const branch = "kenn-forge/pr-42"
+	localRepo, _ := setupLocalWorktreeBaseWithRemoteForWorkspaceGitTest(
+		t, "feature/thing",
+	)
+	worktreePath := filepath.Join(t.TempDir(), "workspace")
+	runWorkspaceTestGit(
+		t, localRepo,
+		"worktree", "add", worktreePath, "-b", branch, "HEAD",
+	)
+
+	mgr := NewManager(openTestDB(t), t.TempDir())
+	mgr.SetWorktreeBasePathResolver(staticBaseResolver(localRepo))
+	ws := &Workspace{
+		ID:              "ws-delete-lock-race",
+		Platform:        "github",
+		PlatformHost:    "github.com",
+		RepoOwner:       "acme",
+		RepoName:        "widget",
+		ItemType:        db.WorkspaceItemTypePullRequest,
+		ItemNumber:      42,
+		GitHeadRef:      "feature/thing",
+		WorkspaceBranch: branch,
+		WorktreePath:    worktreePath,
+	}
+	require.NoError(writeWorkspaceOwnershipMarker(t.Context(), localRepo, ws))
+	gitDir, owned, err := mgr.workspaceCleanupGitDir(t.Context(), ws)
+	require.NoError(err)
+	require.True(owned)
+	require.NotEmpty(gitDir)
+
+	require.NoError(os.RemoveAll(worktreePath))
+	runWorkspaceTestGit(t, localRepo, "worktree", "prune")
+	runWorkspaceTestGit(
+		t, localRepo,
+		"worktree", "add", worktreePath,
+		"-b", "foreign/race-replacement", "HEAD",
+	)
+	require.NoError(os.WriteFile(
+		filepath.Join(worktreePath, "foreign.txt"), []byte("keep me\n"), 0o644,
+	))
+	foreignHead := strings.TrimSpace(string(
+		runWorkspaceTestGit(t, worktreePath, "rev-parse", "HEAD"),
+	))
+
+	err = mgr.cleanupWorkspaceArtifactsForDeleteLocked(
+		t.Context(), gitDir, ws,
+	)
+
+	require.ErrorIs(err, ErrWorkspaceOwnershipUnproven)
+	require.FileExists(filepath.Join(worktreePath, ".git"))
+	contents, err := os.ReadFile(filepath.Join(worktreePath, "foreign.txt"))
+	require.NoError(err)
+	assert.Equal("keep me\n", string(contents))
+	assert.Equal(
+		foreignHead,
+		strings.TrimSpace(string(
+			runWorkspaceTestGit(t, worktreePath, "rev-parse", "HEAD"),
+		)),
+	)
+	assert.Contains(
+		string(runWorkspaceTestGit(t, localRepo, "worktree", "list", "--porcelain")),
+		worktreePath,
+	)
+}
+
 func TestCleanupIgnoresInvalidConfiguredBaseWhenWorktreeAbsent(t *testing.T) {
 	require := require.New(t)
 
@@ -2752,6 +2866,7 @@ func TestCleanupSucceedsWhenWorkspacePathReplacedByNonGitDirectory(t *testing.T)
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
 			require := require.New(t)
 
 			localRepo := setupLocalWorktreeBaseForWorkspaceGitTest(t, "feature/thing")
@@ -2775,8 +2890,158 @@ func TestCleanupSucceedsWhenWorkspacePathReplacedByNonGitDirectory(t *testing.T)
 			}
 
 			require.NoError(mgr.cleanupWorkspaceArtifactsForDelete(t.Context(), ws))
+			_, err := os.Lstat(worktreePath)
+			require.ErrorIs(err, os.ErrNotExist)
+			recoveryPaths, err := filepath.Glob(worktreePath + ".orphaned-*")
+			require.NoError(err)
+			require.Len(recoveryPaths, 1)
+			if tt.name == "plain directory" {
+				contents, err := os.ReadFile(filepath.Join(recoveryPaths[0], "leftover.txt"))
+				require.NoError(err)
+				assert.Equal("not a repo", string(contents))
+			} else {
+				contents, err := os.ReadFile(filepath.Join(recoveryPaths[0], ".git"))
+				require.NoError(err)
+				assert.Contains(string(contents), "gitdir:")
+			}
 		})
 	}
+}
+
+func TestQuarantineOrphanedWorkspacePathPreservesSymlinkToFile(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	parent := t.TempDir()
+	targetPath := filepath.Join(parent, "replacement-target")
+	worktreePath := filepath.Join(parent, "workspace")
+	require.NoError(os.WriteFile(
+		targetPath, []byte("preserve target\n"), 0o644,
+	))
+	require.NoError(os.Symlink(targetPath, worktreePath))
+
+	require.NoError(quarantineOrphanedWorkspacePath(t.Context(), worktreePath))
+	_, err := os.Lstat(worktreePath)
+	require.ErrorIs(err, os.ErrNotExist)
+	recoveryPaths, err := filepath.Glob(worktreePath + ".orphaned-*")
+	require.NoError(err)
+	require.Len(recoveryPaths, 1)
+	recoveryInfo, err := os.Lstat(recoveryPaths[0])
+	require.NoError(err)
+	assert.NotZero(recoveryInfo.Mode() & os.ModeSymlink)
+	contents, err := os.ReadFile(targetPath)
+	require.NoError(err)
+	assert.Equal("preserve target\n", string(contents))
+}
+
+func TestQuarantineOrphanedWorkspacePathPreservesBareRepository(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	worktreePath := filepath.Join(t.TempDir(), "workspace.git")
+	runWorkspaceTestGit(t, filepath.Dir(worktreePath), "init", "--bare", worktreePath)
+
+	require.NoError(quarantineOrphanedWorkspacePath(t.Context(), worktreePath))
+	_, err := os.Lstat(worktreePath)
+	require.ErrorIs(err, os.ErrNotExist)
+	recoveryPaths, err := filepath.Glob(worktreePath + ".orphaned-*")
+	require.NoError(err)
+	require.Len(recoveryPaths, 1)
+	bare, err := gitIsBareRepository(t.Context(), recoveryPaths[0])
+	require.NoError(err)
+	assert.True(bare)
+}
+
+func TestRemoveStaleWorktreeRegistrationMetadataResolvesRelativeGitdir(
+	t *testing.T,
+) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	cloneDir := setupBareCloneForWorkspaceGitTest(t)
+	runWorkspaceTestGit(t, cloneDir, "config", "worktree.useRelativePaths", "true")
+	worktreeRoot, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(err)
+	worktreePath := filepath.Join(worktreeRoot, "workspace")
+	runWorkspaceTestGit(
+		t, cloneDir, "worktree", "add", worktreePath, "-b", "topic/relative", "HEAD",
+	)
+	metadataRoot := strings.TrimSpace(string(runWorkspaceTestGit(
+		t, cloneDir,
+		"rev-parse", "--path-format=absolute", "--git-path", "worktrees",
+	)))
+	entries, err := os.ReadDir(metadataRoot)
+	require.NoError(err)
+	require.Len(entries, 1)
+	metadataDir := filepath.Join(metadataRoot, entries[0].Name())
+	gitFile, err := os.ReadFile(filepath.Join(metadataDir, "gitdir"))
+	require.NoError(err)
+	assert.False(filepath.IsAbs(strings.TrimSpace(string(gitFile))))
+	require.NoError(os.RemoveAll(worktreePath))
+
+	require.NoError(removeStaleWorktreeRegistrationMetadata(
+		t.Context(), cloneDir, worktreePath,
+	))
+	_, err = os.Lstat(metadataDir)
+	require.ErrorIs(err, os.ErrNotExist)
+	tracked, err := gitDirTracksWorktreePath(t.Context(), cloneDir, worktreePath)
+	require.NoError(err)
+	assert.False(tracked)
+}
+
+func TestCleanupQuarantinesPlainWorkspaceNestedInRepository(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	parentRepo := setupLocalWorktreeBaseForWorkspaceGitTest(t, "feature/thing")
+	worktreePath := filepath.Join(parentRepo, "managed", "workspace")
+	require.NoError(os.MkdirAll(worktreePath, 0o755))
+	require.NoError(os.WriteFile(
+		filepath.Join(worktreePath, "leftover.txt"), []byte("preserve me\n"), 0o644,
+	))
+
+	mgr := NewManager(openTestDB(t), filepath.Join(parentRepo, "managed"))
+	mgr.SetWorktreeBasePathResolver(staticBaseResolver(parentRepo))
+	ws := &Workspace{
+		ID:              "ws-cleanup-nested-plain-dir",
+		Platform:        "github",
+		PlatformHost:    "github.com",
+		RepoOwner:       "acme",
+		RepoName:        "widget",
+		ItemType:        db.WorkspaceItemTypePullRequest,
+		ItemNumber:      99,
+		GitHeadRef:      "feature/thing",
+		WorkspaceBranch: "kenn-forge/pr-99",
+		WorktreePath:    worktreePath,
+	}
+
+	require.NoError(mgr.cleanupWorkspaceArtifactsForDelete(t.Context(), ws))
+	_, err := os.Lstat(worktreePath)
+	require.ErrorIs(err, os.ErrNotExist)
+	recoveryPaths, err := filepath.Glob(worktreePath + ".orphaned-*")
+	require.NoError(err)
+	require.Len(recoveryPaths, 1)
+	contents, err := os.ReadFile(filepath.Join(recoveryPaths[0], "leftover.txt"))
+	require.NoError(err)
+	assert.Equal("preserve me\n", string(contents))
+}
+
+func TestNextWorkspaceRecoveryPathAvoidsCollisions(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	worktreePath := filepath.Join(t.TempDir(), "workspace")
+	now := time.Date(2026, time.July, 31, 17, 15, 30, 0, time.UTC)
+	want := worktreePath + ".orphaned-20260731T171530Z"
+
+	got, err := nextWorkspaceRecoveryPath(worktreePath, now)
+	require.NoError(err)
+	assert.Equal(want, got)
+	require.NoError(os.WriteFile(want, []byte("occupied"), 0o600))
+
+	got, err = nextWorkspaceRecoveryPath(worktreePath, now)
+	require.NoError(err)
+	assert.Equal(want+"-2", got)
 }
 
 func TestCleanupFallsBackToManagedCloneWhenConfiguredBaseInvalid(t *testing.T) {
@@ -3359,6 +3624,7 @@ func TestAddWorktreeLocalBaseFetchesPullRefWhenHeadBranchDeleted(t *testing.T) {
 
 	mgr := NewManager(openTestDB(t), t.TempDir())
 	ws := &Workspace{
+		ID:           "ws-add-fetches-pull-ref",
 		Platform:     "github",
 		PlatformHost: platformHost,
 		ItemType:     db.WorkspaceItemTypePullRequest,
@@ -3407,6 +3673,7 @@ func TestAddWorktreeLocalBaseIgnoresStalePullRefWhenFetchFails(t *testing.T) {
 	)
 	mgr := NewManager(openTestDB(t), t.TempDir())
 	ws := &Workspace{
+		ID:           "ws-add-ignores-stale-pull-ref",
 		Platform:     "github",
 		PlatformHost: "127.0.0.1",
 		ItemType:     db.WorkspaceItemTypePullRequest,
@@ -5605,6 +5872,7 @@ func TestIssueRetryCleansLeakedUnknownBranchAndUsesIssueBranch(t *testing.T) {
 		WorktreePath:    staleWorktree,
 		Status:          "error",
 	}
+	require.NoError(writeWorkspaceOwnershipMarker(t.Context(), cloneDir, ws))
 	require.NoError(mgr.cleanupWorkspaceArtifactsForRetry(t.Context(), ws))
 
 	exists, err = localBranchExists(
@@ -6313,6 +6581,7 @@ func TestManagerAddWorktreeAcquiresRepoLock(t *testing.T) {
 	require.NoError(err)
 
 	ws := &Workspace{
+		ID:           "ws-add-worktree-lock",
 		ItemType:     db.WorkspaceItemTypePullRequest,
 		ItemNumber:   7,
 		GitHeadRef:   "feature/lock-probe",
@@ -6337,6 +6606,97 @@ func TestManagerAddWorktreeAcquiresRepoLock(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		require.FailNow("addWorktree did not finish after lock release")
 	}
+}
+
+func TestManagerAddWorktreeRechecksOccupiedPathAfterWaitingForLock(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	cloneDir := setupBareCloneForWorkspaceGitTest(t)
+	const (
+		preferredBranch = "feature/occupied-after-preflight"
+		prNumber        = 73
+	)
+	configureSameRepoPRRefs(t, cloneDir, preferredBranch, prNumber)
+	mgr := NewManager(openTestDB(t), t.TempDir())
+	ws := &Workspace{
+		ID:           "ws-add-worktree-occupied-after-preflight",
+		ItemType:     db.WorkspaceItemTypePullRequest,
+		ItemNumber:   prNumber,
+		GitHeadRef:   preferredBranch,
+		WorktreePath: filepath.Join(t.TempDir(), "wt"),
+	}
+
+	held, err := mgr.locks.Acquire(t.Context(), cloneDir)
+	require.NoError(err)
+	done := make(chan error, 1)
+	go func() {
+		_, err := mgr.addWorktree(t.Context(), cloneDir, false, ws)
+		done <- err
+	}()
+
+	select {
+	case <-done:
+		require.FailNow("addWorktree completed while the per-repo lock was held")
+	case <-time.After(80 * time.Millisecond):
+	}
+	require.NoError(os.MkdirAll(ws.WorktreePath, 0o755))
+	require.NoError(os.WriteFile(
+		filepath.Join(ws.WorktreePath, "keep.txt"), []byte("preserve me\n"), 0o644,
+	))
+	require.NoError(held.Unlock())
+
+	select {
+	case err := <-done:
+		require.Error(err)
+	case <-time.After(5 * time.Second):
+		require.FailNow("addWorktree did not finish after lock release")
+	}
+	contents, err := os.ReadFile(filepath.Join(ws.WorktreePath, "keep.txt"))
+	require.NoError(err)
+	assert.Equal("preserve me\n", string(contents))
+	for _, branch := range []string{
+		preferredBranch, syntheticPRWorktreeBranch(prNumber),
+	} {
+		exists, branchErr := localBranchExists(t.Context(), cloneDir, branch)
+		require.NoError(branchErr)
+		assert.False(exists, "addWorktree must not leak branch %q", branch)
+	}
+}
+
+func TestAddPreferredWorktreeRemovesBranchCreatedByFailedAdd(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	cloneDir := setupBareCloneForWorkspaceGitTest(t)
+	const (
+		preferredBranch = "contributor/occupied-path"
+		prNumber        = 74
+	)
+	configureForkPRRefs(t, cloneDir, preferredBranch, prNumber)
+	headRepo := "https://github.com/contributor/widget.git"
+	ws := &Workspace{
+		ID:           "ws-failed-preferred-add",
+		Platform:     "github",
+		ItemType:     db.WorkspaceItemTypePullRequest,
+		ItemNumber:   prNumber,
+		GitHeadRef:   preferredBranch,
+		MRHeadRepo:   &headRepo,
+		WorktreePath: filepath.Join(t.TempDir(), "occupied"),
+	}
+	require.NoError(os.MkdirAll(ws.WorktreePath, 0o755))
+	require.NoError(os.WriteFile(
+		filepath.Join(ws.WorktreePath, "keep.txt"), []byte("preserve me\n"), 0o644,
+	))
+	mgr := NewManager(openTestDB(t), t.TempDir())
+
+	_, err := mgr.addPreferredWorktree(t.Context(), cloneDir, false, ws)
+
+	require.Error(err)
+	contents, err := os.ReadFile(filepath.Join(ws.WorktreePath, "keep.txt"))
+	require.NoError(err)
+	assert.Equal("preserve me\n", string(contents))
+	exists, err := localBranchExists(t.Context(), cloneDir, preferredBranch)
+	require.NoError(err)
+	assert.False(exists, "a failed add must remove only the branch it created")
 }
 
 func TestManagerCleanupForDeleteAcquiresRepoLock(t *testing.T) {

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -3502,6 +3502,37 @@ func TestAddWorktreeLockedRecordsOwnershipBeforeReturning(t *testing.T) {
 	require.True(owned, "the registration must be marked before addWorktreeLocked returns")
 }
 
+func TestOwnedWorktreeAddRollsBackWhenOwnershipMarkerFails(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	cloneDir := setupBareCloneForWorkspaceGitTest(t)
+	branch := syntheticPRWorktreeBranch(46)
+	ws := &Workspace{
+		ItemType:     db.WorkspaceItemTypePullRequest,
+		ItemNumber:   46,
+		WorktreePath: filepath.Join(t.TempDir(), "worktree"),
+	}
+	mgr := NewManager(openTestDB(t), t.TempDir())
+
+	_, err := mgr.runOwnedGitWorktreeAddCreatingBranch(
+		t.Context(), cloneDir, ws, branch, "main",
+	)
+	require.Error(err)
+	require.ErrorIs(err, errWorkspaceOwnershipMarker)
+	_, statErr := os.Lstat(ws.WorktreePath)
+	require.ErrorIs(statErr, os.ErrNotExist)
+	tracked, trackErr := gitDirTracksWorktreePath(
+		t.Context(), cloneDir, ws.WorktreePath,
+	)
+	require.NoError(trackErr)
+	assert.False(tracked)
+	_, exists, refErr := gitRefSHA(
+		t.Context(), cloneDir, "refs/heads/"+branch,
+	)
+	require.NoError(refErr)
+	assert.False(exists)
+}
+
 // divergentCommitForWorkspaceGitTest creates a commit that is not the PR head so
 // a branch pointing at it makes addPreferredWorktree reject the preferred name.
 func divergentCommitForWorkspaceGitTest(

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -1624,6 +1624,68 @@ func TestSetupReusesExistingWorkspaceWorktree(t *testing.T) {
 	assert.Contains(argvs[0], ws.WorktreePath)
 }
 
+func TestReuseExistingWorkspaceWorktreeRechecksSymlinkAfterLock(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	wtDir := t.TempDir()
+
+	localRepo, _, platformHost := setupHTTPWorktreeBaseForWorkspaceGitTest(
+		t, "feature/thing",
+	)
+	repoID := seedRepo(t, d, platformHost, "acme", "widget")
+	seedMR(t, d, repoID, 42, "feature/thing")
+
+	mgr := NewManager(d, wtDir)
+	mgr.SetWorktreeBasePathResolver(staticBaseResolver(localRepo))
+	ws, err := mgr.Create(t.Context(), "github", platformHost, "acme", "widget", 42)
+	require.NoError(err)
+	existingBranch := syntheticPRWorktreeBranch(42)
+	runWorkspaceTestGit(
+		t, localRepo,
+		"worktree", "add", ws.WorktreePath, "-b", existingBranch, "HEAD",
+	)
+	metadataDir, err := worktreeGitDir(t.Context(), ws.WorktreePath)
+	require.NoError(err)
+
+	lockRoot := mgr.localWorktreeBaseLockRoot(localRepo)
+	require.NoError(os.MkdirAll(lockRoot, 0o755))
+	held, err := mgr.locks.Acquire(t.Context(), lockRoot)
+	require.NoError(err)
+	type reuseResult struct {
+		reused bool
+		err    error
+	}
+	done := make(chan reuseResult, 1)
+	go func() {
+		_, reused, reuseErr := mgr.reuseExistingWorkspaceWorktree(t.Context(), ws)
+		done <- reuseResult{reused: reused, err: reuseErr}
+	}()
+
+	select {
+	case <-done:
+		require.FailNow("worktree reuse completed while the repository lock was held")
+	case <-time.After(80 * time.Millisecond):
+	}
+	targetPath := filepath.Join(wtDir, "replacement-target")
+	require.NoError(os.Rename(ws.WorktreePath, targetPath))
+	require.NoError(os.Symlink(targetPath, ws.WorktreePath))
+	require.NoError(held.Unlock())
+
+	select {
+	case result := <-done:
+		require.Error(result.err)
+		assert.False(result.reused)
+	case <-time.After(5 * time.Second):
+		require.FailNow("worktree reuse did not finish after lock release")
+	}
+	pathInfo, err := os.Lstat(ws.WorktreePath)
+	require.NoError(err)
+	assert.NotZero(pathInfo.Mode() & os.ModeSymlink)
+	_, err = os.Lstat(filepath.Join(metadataDir, workspaceOwnershipMarkerFile))
+	assert.ErrorIs(err, os.ErrNotExist)
+}
+
 // A retried setup must recognize the uniquified synthetic branch as its own,
 // otherwise the workspace whose first attempt hit a name collision can never be
 // set up again.


### PR DESCRIPTION
Deleting or relocating a repository checkout could leave a workspace path occupied by stale worktree metadata. Retrying then leaked branch names or could not recreate the workspace.\n\n- Stop setup before Git can create branches for an occupied orphan path.\n- Quarantine ordinary orphan contents while preserving valid replacement checkouts.\n- Clear stale managed worktree registrations and branches so deleted workspaces can be recreated.\n- Keep workspace tests isolated from the host tmux server.