### PR TITLE
Keep large diffs responsive while preparing context

### DIFF
--- a/cmd/e2e-server/main.go
+++ b/cmd/e2e-server/main.go
@@ -2105,6 +2105,41 @@ func buildAppState(
 			return
 		}
 		if r.Method == http.MethodPost &&
+			r.URL.Path == "/__e2e/pr-diff-context/large-head" {
+			repo, err := database.GetRepoByIdentity(
+				r.Context(), db.GitHubRepoIdentity("github.com", "acme", "widgets"),
+			)
+			if err != nil || repo == nil {
+				http.Error(w, "repo not found", http.StatusNotFound)
+				return
+			}
+			if err := database.UpdateDiffSHAs(
+				r.Context(), repo.ID, 1,
+				diffRepo.ContextHeadSHA, diffRepo.BaseSHA, diffRepo.BaseSHA,
+			); err != nil {
+				http.Error(w, "update diff shas", http.StatusInternalServerError)
+				return
+			}
+			if err := database.UpdatePlatformSHAs(
+				r.Context(), repo.ID, 1,
+				diffRepo.ContextHeadSHA, diffRepo.BaseSHA,
+			); err != nil {
+				http.Error(w, "update platform shas", http.StatusInternalServerError)
+				return
+			}
+			patchFixturePRSHAs(
+				fc, "acme", "widgets", 1,
+				diffRepo.ContextHeadSHA, diffRepo.BaseSHA,
+			)
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(map[string]string{
+				"head_sha": diffRepo.ContextHeadSHA,
+			}); err != nil {
+				slog.Warn("write e2e response", "err", err)
+			}
+			return
+		}
+		if r.Method == http.MethodPost &&
 			r.URL.Path == "/__e2e/pr-review-thread-regroup/add-reply" {
 			repo, err := database.GetRepoByIdentity(
 				r.Context(), db.GitHubRepoIdentity("github.com", "acme", "widgets"),

--- a/docs/superpowers/plans/2026-07-31-bounded-diff-context-prefetch.md
+++ b/docs/superpowers/plans/2026-07-31-bounded-diff-context-prefetch.md
@@ -1,0 +1,164 @@
+# Bounded Diff Context Prefetch Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan directly in the current agent, task-by-task. Never use subagent-driven development. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Proactively load syntax context for all eligible diff files with visible-file priority and at most four concurrent file loads.
+
+**Approved spec/design:** `docs/superpowers/specs/2026-07-31-bounded-diff-context-prefetch-design.md`
+
+**Architecture:** A plain TypeScript scheduler owns queue ordering, idle dispatch, concurrency, and cancellation. `DiffView` scopes one scheduler to the current diff, while `DiffFile` forwards it and `PierreFileDiff` registers only syntax-context work.
+
+**Tech Stack:** TypeScript, Svelte 5 runes, Vitest through Vite+, `IntersectionObserver`, `requestIdleCallback` with a delayed timer fallback.
+
+## Global Constraints
+
+- Run at most four full-context file tasks concurrently.
+- Foreground files inside the existing 600px observer margin outrank queued background files.
+- Background work starts only from a deferred background callback.
+- Reset and teardown cancel queued work and fence stale active completions.
+- Manual context expansion remains immediate.
+- Preserve standalone `PierreFileDiff` behavior when no scheduler is supplied.
+
+---
+
+### Task 1: Context prefetch scheduler
+
+**Files:**
+
+- Create: `packages/ui/src/components/diff/diff-context-prefetch.ts`
+- Create: `packages/ui/src/components/diff/diff-context-prefetch.test.ts`
+
+**Interfaces:**
+
+- Produces: `createDiffContextPrefetchScheduler({ concurrency, scheduleDeferred? })`
+- Produces: `DiffContextPrefetchScheduler.schedule(id, priority, run)` returning a handle with `setPriority(priority)` and `cancel()`
+- Produces: `DiffContextPrefetchScheduler.reset()` and `dispose()`
+- Priority values are `"foreground" | "background"`; task callbacks receive an `AbortSignal`
+
+- [x] **Step 1: Write failing scheduler tests**
+
+  Add focused tests whose task promises are controlled by the test. Assert that
+  four tasks start, a fifth waits, the fifth starts after one settles,
+  foreground work runs before queued background work, `setPriority()` promotes
+  and immediately starts queued work, background registration waits for the
+  injected deferred callback, reset aborts active signals while removing queued
+  work, and stale completion from the prior generation does not consume slots
+  in the new generation.
+
+- [x] **Step 2: Run the scheduler test and verify RED**
+
+  Run from `frontend/`: `node ../node_modules/vite-plus/bin/vp test run --project unit ../packages/ui/src/components/diff/diff-context-prefetch.test.ts`
+
+  Expected: FAIL because `diff-context-prefetch.ts` does not exist.
+
+- [x] **Step 3: Implement the minimal scheduler**
+
+  Use two ordered queues, one active-task map, one scheduled-idle cancellation
+  function, and a monotonically increasing generation. Foreground scheduling
+  drains synchronously. Background scheduling requests one idle drain. Task
+  settlement releases a slot only when its generation is current, then drains
+  foreground work before arranging the next idle drain.
+
+- [x] **Step 4: Run the scheduler test and verify GREEN**
+
+  Run from `frontend/`: `node ../node_modules/vite-plus/bin/vp test run --project unit ../packages/ui/src/components/diff/diff-context-prefetch.test.ts`
+
+  Expected: PASS with no warnings.
+
+### Task 2: Svelte integration
+
+**Files:**
+
+- Modify: `packages/ui/src/components/diff/DiffView.svelte`
+- Modify: `packages/ui/src/components/diff/DiffFile.svelte`
+- Modify: `packages/ui/src/components/diff/PierreFileDiff.svelte`
+- Modify: `packages/ui/src/components/diff/PierreFileDiff.test.ts`
+
+**Interfaces:**
+
+- Consumes: `DiffContextPrefetchScheduler` from Task 1
+- `DiffFile` accepts optional `contextPrefetchScheduler`
+- `PierreFileDiff` accepts optional `contextPrefetchScheduler`
+- The registered task calls the existing syntax-context loader and uses the current `active` value to set foreground/background priority
+
+- [x] **Step 1: Write the failing component test**
+
+  Render an inactive sparse `PierreFileDiff` with a fake scheduler that captures
+  the registered task. Assert no preview call happens at registration, invoke
+  the captured task, and assert both old/new preview loads occur. Add focused
+  cases proving component cleanup calls the handle's `cancel()`, an aborted
+  controlled preview completion does not render or write an error, and manual
+  expansion loads immediately even while the proactive task remains queued.
+  This catches removal of proactive registration while retaining the existing
+  offscreen no-eager-load guarantee.
+
+- [x] **Step 2: Run the component test and verify RED**
+
+  Run from `frontend/`: `node ../node_modules/vite-plus/bin/vp test run --project unit ../packages/ui/src/components/diff/PierreFileDiff.test.ts`
+
+  Expected: FAIL because `PierreFileDiff` does not accept or use the scheduler.
+
+- [x] **Step 3: Integrate the scheduler**
+
+  Create one four-worker scheduler in `DiffView`. Define its identity as
+  provider, platform host, repository path, item number, and
+  `diffStore.getFilePreviewGeneration()`, reset when that identity changes,
+  dispose it on unmount, and pass it through `DiffFile`.
+  `PierreFileDiff` registers only when full syntax context is needed, promotes
+  the handle when `active` changes, and cancels on dependency cleanup. Thread
+  the task signal through the syntax loader and check it before every state
+  write, full-context render, and error update; do not pass it into the shared
+  preview-cache request. Keep the existing direct visible-load branch when no
+  scheduler is present.
+
+  Mock the scheduler factory in `DiffView.test.ts`, change the store's reactive
+  file-preview generation through a real `createDiffStore`, and assert that the
+  existing scheduler resets. This proves the complete reset wiring rather than
+  only the pure scheduler method.
+
+- [x] **Step 4: Run component and scheduler tests and verify GREEN**
+
+  Run from `frontend/`: `node ../node_modules/vite-plus/bin/vp test run --project unit ../packages/ui/src/components/diff/diff-context-prefetch.test.ts ../packages/ui/src/components/diff/PierreFileDiff.test.ts ../packages/ui/src/components/diff/DiffFile.test.ts ../packages/ui/src/components/diff/DiffView.test.ts`
+
+  Expected: PASS with no warnings.
+
+### Task 3: Verification and commit
+
+**Files:**
+
+- Verify all files modified by Tasks 1 and 2.
+
+**Interfaces:**
+
+- Consumes the completed scheduler and Svelte integration.
+- Produces a committed, locally verified change.
+
+- [x] **Step 1: Run Svelte analysis and package checks**
+
+  Run from the repository root:
+
+  - `node node_modules/vite-plus/bin/vp exec -- svelte-mcp svelte-autofixer packages/ui/src/components/diff/DiffView.svelte`
+  - `node node_modules/vite-plus/bin/vp exec -- svelte-mcp svelte-autofixer packages/ui/src/components/diff/DiffFile.svelte`
+  - `node node_modules/vite-plus/bin/vp exec -- svelte-mcp svelte-autofixer packages/ui/src/components/diff/PierreFileDiff.svelte`
+  - `node node_modules/vite-plus/bin/vp run ui-package-check`
+  - `node node_modules/vite-plus/bin/vp fmt --check packages/ui/src/components/diff docs/superpowers/specs/2026-07-31-bounded-diff-context-prefetch-design.md docs/superpowers/plans/2026-07-31-bounded-diff-context-prefetch.md --no-error-on-unmatched-pattern --threads=1`
+  - `node node_modules/vite-plus/bin/vp lint packages/ui/src/components/diff --no-error-on-unmatched-pattern`
+
+- [x] **Step 2: Run the full frontend unit suite**
+
+  Run from `frontend/`: `node ../node_modules/vite-plus/bin/vp test run --project unit`
+
+  Expected: all tests pass.
+
+- [x] **Step 3: Run the affected browser suite**
+
+  Run from the repository root:
+  `node node_modules/vite-plus/bin/vp run kenn-forge-frontend#test:e2e --project=chromium tests/e2e-full/diff-view.spec.ts`
+
+  Expected: all diff-view tests pass.
+
+- [x] **Step 4: Synchronize context and commit**
+
+  Run the repository-local context synchronization workflow with `--commit`,
+  review the staged diff, then create a conventional commit through the
+  hook-enforced commit workflow. Do not amend or bypass hooks.

--- a/docs/superpowers/plans/2026-07-31-bounded-diff-context-prefetch.md
+++ b/docs/superpowers/plans/2026-07-31-bounded-diff-context-prefetch.md
@@ -15,7 +15,9 @@
 - Run at most four full-context file tasks concurrently.
 - Foreground files inside the existing 600px observer margin outrank queued background files.
 - Background work starts only from a deferred background callback.
-- Reset and teardown cancel queued work and fence stale active completions.
+- Reset and teardown cancel queued work and fence stale active completions while
+  retaining their slots until the shared requests settle.
+- A failed speculative request retries only after the file becomes foreground.
 - Manual context expansion remains immediate.
 - Preserve standalone `PierreFileDiff` behavior when no scheduler is supplied.
 
@@ -32,7 +34,7 @@
 
 - Produces: `createDiffContextPrefetchScheduler({ concurrency, scheduleDeferred? })`
 - Produces: `DiffContextPrefetchScheduler.schedule(id, priority, run)` returning a handle with `setPriority(priority)` and `cancel()`
-- Produces: `DiffContextPrefetchScheduler.reset()` and `dispose()`
+- Produces: `DiffContextPrefetchScheduler.reset()`, `setGeneration(identity)`, and `dispose()`
 - Priority values are `"foreground" | "background"`; task callbacks receive an `AbortSignal`
 
 - [x] **Step 1: Write failing scheduler tests**
@@ -42,8 +44,8 @@
   foreground work runs before queued background work, `setPriority()` promotes
   and immediately starts queued work, background registration waits for the
   injected deferred callback, reset aborts active signals while removing queued
-  work, and stale completion from the prior generation does not consume slots
-  in the new generation.
+  work, and stale completion from the prior generation retains its slot until
+  settlement without mutating the new generation.
 
 - [x] **Step 2: Run the scheduler test and verify RED**
 
@@ -56,8 +58,9 @@
   Use two ordered queues, one active-task map, one scheduled-idle cancellation
   function, and a monotonically increasing generation. Foreground scheduling
   drains synchronously. Background scheduling requests one idle drain. Task
-  settlement releases a slot only when its generation is current, then drains
-  foreground work before arranging the next idle drain.
+  settlement always releases its global slot, while only current-generation
+  queues remain eligible to drain. `setGeneration()` is idempotent so both the
+  view and mounted components can align before scheduling.
 
 - [x] **Step 4: Run the scheduler test and verify GREEN**
 
@@ -102,19 +105,20 @@
 
   Create one four-worker scheduler in `DiffView`. Define its identity as
   provider, platform host, repository path, item number, and
-  `diffStore.getFilePreviewGeneration()`, reset when that identity changes,
-  dispose it on unmount, and pass it through `DiffFile`.
+  `diffStore.getFilePreviewGeneration()`, align when that identity changes,
+  dispose it on unmount, and pass the scheduler and identity through `DiffFile`.
   `PierreFileDiff` registers only when full syntax context is needed, promotes
   the handle when `active` changes, and cancels on dependency cleanup. Thread
   the task signal through the syntax loader and check it before every state
   write, full-context render, and error update; do not pass it into the shared
   preview-cache request. Keep the existing direct visible-load branch when no
-  scheduler is present.
+  scheduler is present. Treat a background failure as speculative and register
+  one foreground retry before using the existing terminal failure latch.
 
   Mock the scheduler factory in `DiffView.test.ts`, change the store's reactive
   file-preview generation through a real `createDiffStore`, and assert that the
-  existing scheduler resets. This proves the complete reset wiring rather than
-  only the pure scheduler method.
+  existing scheduler aligns. This proves the complete generation wiring rather
+  than only the pure scheduler method.
 
 - [x] **Step 4: Run component and scheduler tests and verify GREEN**
 
@@ -122,7 +126,29 @@
 
   Expected: PASS with no warnings.
 
-### Task 3: Verification and commit
+### Task 3: Full-stack context-prefetch regression
+
+**Files:**
+
+- Modify: `internal/testutil/diff_repo.go`
+- Modify: `cmd/e2e-server/main.go`
+- Modify: `frontend/tests/e2e-full/diff-view.spec.ts`
+
+- [x] **Step 1: Add a real syntax-gap fixture revision**
+
+  Keep the default and alternate fixture heads unchanged. Add a third revision
+  with eight modified TypeScript files whose separated hunks carry syntax state,
+  plus an isolated E2E endpoint that selects that revision.
+
+- [x] **Step 2: Prove the workflow through the real HTTP API**
+
+  Hold real file-preview responses, trigger a whitespace refresh, and assert
+  unresolved work never exceeds four file tasks/eight side requests across the
+  generation boundary. Release the responses, verify a distant file's two sides
+  were proactively requested, then scroll to it and assert no loading placeholder
+  remains.
+
+### Task 4: Verification and commit
 
 **Files:**
 

--- a/docs/superpowers/specs/2026-07-31-bounded-diff-context-prefetch-design.md
+++ b/docs/superpowers/specs/2026-07-31-bounded-diff-context-prefetch-design.md
@@ -12,7 +12,7 @@ Each `DiffView` owns one context-prefetch scheduler with a concurrency limit of
 four files. `PierreFileDiff` registers only when its sparse patch can distort
 syntax highlighting and complete old/new contents are available. A registered
 task owns both side requests, so the limit is four files rather than four HTTP
-requests.
+requests. At most eight side requests may therefore be unresolved at once.
 
 Files inside the existing 600px intersection margin are foreground work. Their
 tasks are promoted and dispatched immediately. Other registered files remain in
@@ -25,11 +25,23 @@ The scheduler is scoped to the rendered diff identity: provider, host,
 repository path, item number, and the diff store's file-preview generation. The
 store increments that generation whenever workspace identity, base, commit/range
 scope, whitespace mode, or snapshot changes clear the preview cache. Component
-teardown cancels its queued task. Diff identity changes and view teardown reset
-the scheduler, cancel all queued tasks, abort active task signals, and ignore
-stale completion callbacks. The file-preview cache continues to deduplicate
-requests; the task abort signal is checked before every component state write,
-render, or error update rather than aborting the cache's shared request.
+teardown cancels its queued task. Both the view and each registering component
+align the scheduler to the current identity, making generation changes safe
+regardless of Svelte parent/child effect order. Identity changes and view
+teardown cancel all queued tasks, abort active task signals, and ignore stale
+completion callbacks. Because the file-preview cache's shared requests are not
+aborted, stale active tasks retain their scheduler slots until they settle; the
+four-file ceiling therefore applies across generations. Cache generations drop
+references to old results, and stale component state is never retained.
+
+A failed background attempt is speculative: it does not show an error or latch
+the file as permanently failed. The file is registered again when it enters the
+foreground. Failure of that foreground attempt keeps the existing sparse render
+and displays the context error without an automatic retry loop.
+
+Collapsed files do not mount `PierreFileDiff` and therefore do not register
+prefetch work. Background dispatch uses a 500ms idle timeout, so work still
+progresses when the tab or browser does not grant an ordinary idle period.
 
 Without a scheduler, `PierreFileDiff` retains its existing standalone behavior:
 visible files may load syntax context and offscreen files do not preload it.
@@ -40,13 +52,26 @@ background queue.
 
 - Pure scheduler tests prove the four-file ceiling, foreground priority over
   queued background work, deferred background dispatch, priority promotion,
-  slot reuse, generation-safe reset, and cancellation.
+  slot reuse, generation-safe reset, cross-generation slot accounting, and
+  cancellation.
 - A `PierreFileDiff` component test proves an offscreen sparse diff registers
   proactive work and loads only after the scheduler starts it.
 - Component tests prove teardown cancels registration, aborted completion does
-  not write stale state, and manual context expansion bypasses the queue.
-- A `DiffView` test proves a file-preview generation change resets the scheduler.
+  not write stale state, a failed speculative attempt retries in the foreground,
+  and manual context expansion bypasses the queue.
+- A `DiffView` test proves a file-preview generation change aligns the scheduler.
+- A Playwright test uses the real seeded git repository, HTTP API, and preview
+  cache to hold one generation's requests across a whitespace refresh. It proves
+  the process never exceeds four file tasks/eight side requests and that a
+  distant file is prepared before scrolling reaches it.
 - Existing diff component tests continue to cover viewport rendering and manual
   context expansion.
 - The full frontend unit suite and the Chromium diff-view Playwright suite cover
   integration regressions.
+
+The measurable acceptance boundary is four unresolved file tasks (eight side
+requests), including stale generations, with no visible loading placeholder
+when the tested distant file is reached after its proactive requests complete.
+The existing large-diff fast-scroll Playwright case remains the interaction
+latency guard; this scheduler does not introduce a hardware-specific frame-time
+budget.

--- a/docs/superpowers/specs/2026-07-31-bounded-diff-context-prefetch-design.md
+++ b/docs/superpowers/specs/2026-07-31-bounded-diff-context-prefetch-design.md
@@ -1,0 +1,52 @@
+# Bounded diff context prefetch
+
+## Goal
+
+Let large diffs progressively prepare syntax-correct full-file context without
+waiting for every file to approach the viewport, while ensuring that background
+work cannot recreate the eager-load stall.
+
+## Design
+
+Each `DiffView` owns one context-prefetch scheduler with a concurrency limit of
+four files. `PierreFileDiff` registers only when its sparse patch can distort
+syntax highlighting and complete old/new contents are available. A registered
+task owns both side requests, so the limit is four files rather than four HTTP
+requests.
+
+Files inside the existing 600px intersection margin are foreground work. Their
+tasks are promoted and dispatched immediately. Other registered files remain in
+document order and begin from deferred background turns: `requestIdleCallback`
+where available and a delayed timer fallback elsewhere. When a slot opens,
+queued foreground work always wins over background work. Already-started work
+is not preempted merely because another file becomes visible.
+
+The scheduler is scoped to the rendered diff identity: provider, host,
+repository path, item number, and the diff store's file-preview generation. The
+store increments that generation whenever workspace identity, base, commit/range
+scope, whitespace mode, or snapshot changes clear the preview cache. Component
+teardown cancels its queued task. Diff identity changes and view teardown reset
+the scheduler, cancel all queued tasks, abort active task signals, and ignore
+stale completion callbacks. The file-preview cache continues to deduplicate
+requests; the task abort signal is checked before every component state write,
+render, or error update rather than aborting the cache's shared request.
+
+Without a scheduler, `PierreFileDiff` retains its existing standalone behavior:
+visible files may load syntax context and offscreen files do not preload it.
+Demand-driven context expansion remains immediate and does not wait for the
+background queue.
+
+## Testing
+
+- Pure scheduler tests prove the four-file ceiling, foreground priority over
+  queued background work, deferred background dispatch, priority promotion,
+  slot reuse, generation-safe reset, and cancellation.
+- A `PierreFileDiff` component test proves an offscreen sparse diff registers
+  proactive work and loads only after the scheduler starts it.
+- Component tests prove teardown cancels registration, aborted completion does
+  not write stale state, and manual context expansion bypasses the queue.
+- A `DiffView` test proves a file-preview generation change resets the scheduler.
+- Existing diff component tests continue to cover viewport rendering and manual
+  context expansion.
+- The full frontend unit suite and the Chromium diff-view Playwright suite cover
+  integration regressions.

--- a/frontend/tests/e2e-full/00-inline-workspace-continuity.spec.ts
+++ b/frontend/tests/e2e-full/00-inline-workspace-continuity.spec.ts
@@ -307,9 +307,7 @@ function tmuxClientTTY(server: IsolatedE2EServer, tmuxSession: string): string {
 }
 
 function tmuxClientPtyGeometries(server: IsolatedE2EServer): Array<{ rows: number; cols: number }> {
-  const clientTTYs = runE2ETmuxCommand(server, ["list-clients", "-F", "#{client_tty}"])
-    .split("\n")
-    .filter(Boolean);
+  const clientTTYs = runE2ETmuxCommand(server, ["list-clients", "-F", "#{client_tty}"]).split("\n").filter(Boolean);
   return clientTTYs.map((clientTTY) => {
     const fd = openSync(clientTTY, constants.O_RDONLY | constants.O_NOCTTY);
     try {
@@ -473,8 +471,7 @@ async function crossTerminalCellBoundary(container: Locator): Promise<void> {
         get(styleDeclaration, property) {
           if (property === "height") return previousHeight;
           if (property === "getPropertyValue") {
-            return (name: string) =>
-              name === "height" ? previousHeight : styleDeclaration.getPropertyValue(name);
+            return (name: string) => (name === "height" ? previousHeight : styleDeclaration.getPropertyValue(name));
           }
           const value = Reflect.get(styleDeclaration, property, styleDeclaration);
           return typeof value === "function" ? value.bind(styleDeclaration) : value;

--- a/frontend/tests/e2e-full/diff-view.spec.ts
+++ b/frontend/tests/e2e-full/diff-view.spec.ts
@@ -4072,6 +4072,78 @@ test.describe("diff view (git-backed)", () => {
     await expect(treeFileItems(page)).toHaveCount(4);
   });
 
+  test("bounds proactive syntax context across refreshes and prepares distant files", async ({ page }) => {
+    const server = await startIsolatedE2EServer();
+    let releasePreviewRequests = (): void => {};
+    const previewGate = new Promise<void>((resolve) => {
+      releasePreviewRequests = resolve;
+    });
+    let activePreviewRequests = 0;
+    let maxActivePreviewRequests = 0;
+    const previewRequests: Array<{ path: string; side: string }> = [];
+    const previewPattern = "**/api/v1/pulls/github/acme/widgets/1/file-preview**";
+
+    try {
+      const seeded = await page.request.post(`${server.info.base_url}/__e2e/pr-diff-context/large-head`);
+      expect(seeded.ok()).toBe(true);
+
+      await page.route(previewPattern, async (route) => {
+        const url = new URL(route.request().url());
+        previewRequests.push({
+          path: url.searchParams.get("path") ?? "",
+          side: url.searchParams.get("side") ?? "",
+        });
+        activePreviewRequests += 1;
+        maxActivePreviewRequests = Math.max(maxActivePreviewRequests, activePreviewRequests);
+        try {
+          await previewGate;
+          const response = await route.fetch();
+          await route.fulfill({ response });
+        } finally {
+          activePreviewRequests -= 1;
+        }
+      });
+
+      await page.goto(`${server.info.base_url}/pulls/github/acme/widgets/1/files`);
+      await waitForDiffLoaded(page);
+      await expect.poll(() => activePreviewRequests, { timeout: 15_000 }).toBe(8);
+
+      const refreshed = page.waitForRequest((request) => {
+        const url = new URL(request.url());
+        return url.pathname.endsWith("/diff") && url.searchParams.get("whitespace") === "hide";
+      });
+      await openDiffFilterMenu(page);
+      await page.getByRole("switch", { name: "Hide whitespace changes" }).click();
+      await refreshed;
+      await page.waitForTimeout(750);
+
+      expect(previewRequests).toHaveLength(8);
+      expect(maxActivePreviewRequests).toBe(8);
+
+      releasePreviewRequests();
+      const distantPath = "src/context/file_07.ts";
+      await expect
+        .poll(
+          () =>
+            new Set(previewRequests.filter((request) => request.path === distantPath).map((request) => request.side))
+              .size,
+          { timeout: 15_000 },
+        )
+        .toBe(2);
+
+      const distantFile = page.locator(`[data-file-path="${distantPath}"]`);
+      await distantFile.scrollIntoViewIfNeeded();
+      await expect(distantFile.locator(".pierre-diff-loading")).toHaveCount(0);
+      await expect.poll(() => previewRequests.length, { timeout: 15_000 }).toBe(24);
+      await expect.poll(() => activePreviewRequests, { timeout: 15_000 }).toBe(0);
+      expect(maxActivePreviewRequests).toBeLessThanOrEqual(8);
+    } finally {
+      releasePreviewRequests();
+      await page.unrouteAll({ behavior: "ignoreErrors" });
+      await server.stop();
+    }
+  });
+
   test("category filter counts and filtering come from the real diff API", async ({ page }) => {
     const server = await startIsolatedE2EServer();
     try {

--- a/internal/testutil/diff_repo.go
+++ b/internal/testutil/diff_repo.go
@@ -15,13 +15,14 @@ import (
 
 // DiffRepoResult holds the SHAs from the test repo for use in assertions.
 type DiffRepoResult struct {
-	BaseSHA      string // merge-base / base branch tip
-	HeadSHA      string // PR head commit
-	AltHeadSHA   string // newer PR head commit used by E2E refresh tests
-	Manager      *gitclone.Manager
-	FileCount    int // number of changed files (excluding whitespace-only when hidden)
-	AddedFiles   []string
-	DeletedFiles []string
+	BaseSHA        string // merge-base / base branch tip
+	HeadSHA        string // PR head commit
+	AltHeadSHA     string // newer PR head commit used by E2E refresh tests
+	ContextHeadSHA string // large syntax-gap revision used by diff context E2E tests
+	Manager        *gitclone.Manager
+	FileCount      int // number of changed files (excluding whitespace-only when hidden)
+	AddedFiles     []string
+	DeletedFiles   []string
 }
 
 // SetupDiffRepo creates a git repository with known commits and wires
@@ -81,6 +82,15 @@ func SetupDiffRepo(
 	if err := writeFile(workDir,
 		"docs/guide.md", guideMarkdownContent()); err != nil {
 		return nil, err
+	}
+	for i := range 8 {
+		if err := writeFile(
+			workDir,
+			fmt.Sprintf("src/context/file_%02d.ts", i),
+			diffContextFileContent(i, false),
+		); err != nil {
+			return nil, err
+		}
 	}
 
 	if err := git(ctx, workDir, "add", "-A"); err != nil {
@@ -158,6 +168,28 @@ func SetupDiffRepo(
 		return nil, fmt.Errorf("rev-parse alternate head: %w", err)
 	}
 
+	for i := range 8 {
+		if err := writeFile(
+			workDir,
+			fmt.Sprintf("src/context/file_%02d.ts", i),
+			diffContextFileContent(i, true),
+		); err != nil {
+			return nil, err
+		}
+	}
+	if err := git(ctx, workDir, "add", "-A"); err != nil {
+		return nil, err
+	}
+	if err := git(ctx, workDir,
+		"commit", "-m", "test: add sparse syntax context fixtures"); err != nil {
+		return nil, err
+	}
+
+	contextHeadSHA, err := revParse(ctx, workDir, "HEAD")
+	if err != nil {
+		return nil, fmt.Errorf("rev-parse context head: %w", err)
+	}
+
 	// Clone as bare to the path the clone manager expects.
 	if err := os.MkdirAll(
 		filepath.Dir(barePath), 0o755); err != nil {
@@ -198,14 +230,42 @@ func SetupDiffRepo(
 	mgr := gitclone.New(cloneBase, nil)
 
 	return &DiffRepoResult{
-		BaseSHA:      baseSHA,
-		HeadSHA:      headSHA,
-		AltHeadSHA:   altHeadSHA,
-		Manager:      mgr,
-		FileCount:    4,
-		AddedFiles:   []string{"internal/cache.go"},
-		DeletedFiles: []string{"config.yaml"},
+		BaseSHA:        baseSHA,
+		HeadSHA:        headSHA,
+		AltHeadSHA:     altHeadSHA,
+		ContextHeadSHA: contextHeadSHA,
+		Manager:        mgr,
+		FileCount:      4,
+		AddedFiles:     []string{"internal/cache.go"},
+		DeletedFiles:   []string{"config.yaml"},
 	}, nil
+}
+
+func diffContextFileContent(index int, changed bool) string {
+	marker := "old"
+	if changed {
+		marker = "new"
+	}
+	lines := []string{
+		fmt.Sprintf("export function renderFile%02d() {", index),
+		"  const html = `",
+		"    <section>",
+		fmt.Sprintf("      <p>%s context %02d</p>", marker, index),
+	}
+	for line := range 16 {
+		lines = append(lines, fmt.Sprintf("      <span>stable %02d</span>", line))
+	}
+	lines = append(lines,
+		"    </section>",
+		"  `;",
+		"  return html;",
+		"}",
+	)
+	for line := range 24 {
+		lines = append(lines, fmt.Sprintf("// stable filler %02d", line))
+	}
+	lines = append(lines, fmt.Sprintf("export const tail%02d = %q;", index, marker))
+	return strings.Join(lines, "\n") + "\n"
 }
 
 func git(ctx context.Context, dir string, args ...string) error {

--- a/packages/ui/src/components/diff/DiffFile.svelte
+++ b/packages/ui/src/components/diff/DiffFile.svelte
@@ -16,6 +16,7 @@
     type ReviewThread,
   } from "./review-thread-context.js";
   import PierreFileDiff from "./PierreFileDiff.svelte";
+  import type { DiffContextPrefetchScheduler } from "./diff-context-prefetch.js";
 
   const stores = getStores();
   const diffStore = stores.diff;
@@ -23,6 +24,7 @@
 
   interface Props {
     file: DiffFileType;
+    contextPrefetchScheduler?: DiffContextPrefetchScheduler | undefined;
     provider: string;
     platformHost?: string | undefined;
     owner: string;
@@ -41,6 +43,7 @@
 
   const {
     file,
+    contextPrefetchScheduler,
     provider,
     platformHost,
     owner,
@@ -586,6 +589,7 @@
             <PierreFileDiff
               {file}
               active={inViewport}
+              {contextPrefetchScheduler}
               {viewMode}
               {wordWrap}
               {tabWidth}

--- a/packages/ui/src/components/diff/DiffFile.svelte
+++ b/packages/ui/src/components/diff/DiffFile.svelte
@@ -24,6 +24,7 @@
 
   interface Props {
     file: DiffFileType;
+    contextPrefetchIdentity?: string | undefined;
     contextPrefetchScheduler?: DiffContextPrefetchScheduler | undefined;
     provider: string;
     platformHost?: string | undefined;
@@ -43,6 +44,7 @@
 
   const {
     file,
+    contextPrefetchIdentity = "",
     contextPrefetchScheduler,
     provider,
     platformHost,
@@ -589,6 +591,7 @@
             <PierreFileDiff
               {file}
               active={inViewport}
+              {contextPrefetchIdentity}
               {contextPrefetchScheduler}
               {viewMode}
               {wordWrap}

--- a/packages/ui/src/components/diff/DiffView.svelte
+++ b/packages/ui/src/components/diff/DiffView.svelte
@@ -12,6 +12,7 @@
   const diffReviewDraft = stores.diffReviewDraft;
   import { ScrollBox } from "@kenn-io/kit-ui";
   import DiffFileComponent from "./DiffFile.svelte";
+  import { createDiffContextPrefetchScheduler } from "./diff-context-prefetch.js";
   import DiffReviewDraftTray from "./DiffReviewDraftTray.svelte";
 
   interface Props {
@@ -72,6 +73,8 @@
   let scrollRestoreRaf = 0;
   let scrollTargetRaf = 0;
   let virtualizerWakeRaf = 0;
+  const contextPrefetchScheduler = createDiffContextPrefetchScheduler({ concurrency: 4 });
+  let contextPrefetchIdentity = "";
   let scrollTargetRun = 0;
   let scrollingToTarget: DiffScrollTarget | null = null;
   let restoredScrollScope = "";
@@ -96,6 +99,7 @@
       cancelAnimationFrame(scrollRestoreRaf);
       cancelAnimationFrame(scrollTargetRaf);
       cancelAnimationFrame(virtualizerWakeRaf);
+      contextPrefetchScheduler.dispose();
       diffStore.clearDiff();
       diffReviewDraft?.clear();
     };
@@ -111,6 +115,7 @@
   const reviewWarning = $derived(diffReviewDraft?.getWarning() ?? null);
   const tabWidth = $derived(diffStore.getTabWidth());
   const wordWrap = $derived(diffStore.getWordWrap());
+  const filePreviewGeneration = $derived(diffStore.getFilePreviewGeneration());
   const scopeKind = $derived(
     "getScope" in diffStore ? diffStore.getScope().kind : "head",
   );
@@ -125,6 +130,19 @@
   const diffScrollScopeKey = $derived(
     `${provider}\0${platformHost ?? ""}\0${repoPath}\0${number}\0${diffHeadSHA ?? ""}`,
   );
+  const nextContextPrefetchIdentity = $derived(
+    `${provider}\0${platformHost ?? ""}\0${repoPath}\0${number}\0${filePreviewGeneration}`,
+  );
+
+  $effect(() => {
+    const nextIdentity = nextContextPrefetchIdentity;
+    if (!contextPrefetchIdentity) {
+      contextPrefetchIdentity = nextIdentity;
+    } else if (contextPrefetchIdentity !== nextIdentity) {
+      contextPrefetchIdentity = nextIdentity;
+      contextPrefetchScheduler.reset();
+    }
+  });
 
   $effect(() => {
     const nextRef = { provider, platformHost, owner, name, repoPath };
@@ -616,6 +634,7 @@
             {#each visibleFiles as file (file.path)}
               <DiffFileComponent
                 {file}
+                {contextPrefetchScheduler}
                 {provider}
                 {platformHost}
                 {owner}

--- a/packages/ui/src/components/diff/DiffView.svelte
+++ b/packages/ui/src/components/diff/DiffView.svelte
@@ -74,7 +74,6 @@
   let scrollTargetRaf = 0;
   let virtualizerWakeRaf = 0;
   const contextPrefetchScheduler = createDiffContextPrefetchScheduler({ concurrency: 4 });
-  let contextPrefetchIdentity = "";
   let scrollTargetRun = 0;
   let scrollingToTarget: DiffScrollTarget | null = null;
   let restoredScrollScope = "";
@@ -135,13 +134,7 @@
   );
 
   $effect(() => {
-    const nextIdentity = nextContextPrefetchIdentity;
-    if (!contextPrefetchIdentity) {
-      contextPrefetchIdentity = nextIdentity;
-    } else if (contextPrefetchIdentity !== nextIdentity) {
-      contextPrefetchIdentity = nextIdentity;
-      contextPrefetchScheduler.reset();
-    }
+    contextPrefetchScheduler.setGeneration(nextContextPrefetchIdentity);
   });
 
   $effect(() => {
@@ -635,6 +628,7 @@
               <DiffFileComponent
                 {file}
                 {contextPrefetchScheduler}
+                contextPrefetchIdentity={nextContextPrefetchIdentity}
                 {provider}
                 {platformHost}
                 {owner}

--- a/packages/ui/src/components/diff/DiffView.test.ts
+++ b/packages/ui/src/components/diff/DiffView.test.ts
@@ -9,6 +9,16 @@ import {
   type DiffStoreOptions,
 } from "../../stores/diff.svelte.js";
 
+const prefetchScheduler = vi.hoisted(() => ({
+  dispose: vi.fn(),
+  reset: vi.fn(),
+  schedule: vi.fn(),
+}));
+
+vi.mock("./diff-context-prefetch.js", () => ({
+  createDiffContextPrefetchScheduler: () => prefetchScheduler,
+}));
+
 vi.mock("./DiffFile.svelte", async () => ({
   default: (await import("./DiffViewTestFile.svelte")).default,
 }));
@@ -122,6 +132,27 @@ describe("DiffView", () => {
   afterEach(() => {
     vi.useRealTimers();
     cleanup();
+    prefetchScheduler.dispose.mockReset();
+    prefetchScheduler.reset.mockReset();
+    prefetchScheduler.schedule.mockReset();
+  });
+
+  it("resets context prefetch when the file-preview generation changes", async () => {
+    const diff = createDiffStore();
+    renderDiffView(diff);
+    expect(prefetchScheduler.reset).not.toHaveBeenCalled();
+
+    diff.resetToHead();
+
+    await waitFor(() => expect(prefetchScheduler.reset).toHaveBeenCalledOnce());
+  });
+
+  it("disposes context prefetch when the diff view unmounts", () => {
+    const result = renderDiffView(createDiffStore());
+
+    result.unmount();
+
+    expect(prefetchScheduler.dispose).toHaveBeenCalledOnce();
   });
 
   it("uses the workspace file list for keyboard navigation", async () => {

--- a/packages/ui/src/components/diff/DiffView.test.ts
+++ b/packages/ui/src/components/diff/DiffView.test.ts
@@ -13,6 +13,7 @@ const prefetchScheduler = vi.hoisted(() => ({
   dispose: vi.fn(),
   reset: vi.fn(),
   schedule: vi.fn(),
+  setGeneration: vi.fn(),
 }));
 
 vi.mock("./diff-context-prefetch.js", () => ({
@@ -135,16 +136,20 @@ describe("DiffView", () => {
     prefetchScheduler.dispose.mockReset();
     prefetchScheduler.reset.mockReset();
     prefetchScheduler.schedule.mockReset();
+    prefetchScheduler.setGeneration.mockReset();
   });
 
-  it("resets context prefetch when the file-preview generation changes", async () => {
+  it("aligns context prefetch when the file-preview generation changes", async () => {
     const diff = createDiffStore();
     renderDiffView(diff);
-    expect(prefetchScheduler.reset).not.toHaveBeenCalled();
+    await waitFor(() => expect(prefetchScheduler.setGeneration).toHaveBeenCalledOnce());
 
     diff.resetToHead();
 
-    await waitFor(() => expect(prefetchScheduler.reset).toHaveBeenCalledOnce());
+    await waitFor(() => expect(prefetchScheduler.setGeneration).toHaveBeenCalledTimes(2));
+    expect(prefetchScheduler.setGeneration).toHaveBeenLastCalledWith(
+      ["github", "github.com", "acme/widgets", "1", "1"].join("\0"),
+    );
   });
 
   it("disposes context prefetch when the diff view unmounts", () => {

--- a/packages/ui/src/components/diff/PierreFileDiff.svelte
+++ b/packages/ui/src/components/diff/PierreFileDiff.svelte
@@ -384,7 +384,6 @@
       pierreDiff.setVisibility(true);
     }
     if (
-      !contextPrefetchScheduler &&
       active &&
       needsFullContextForSyntax &&
       !fullContext &&
@@ -392,7 +391,7 @@
     ) {
       rendered = false;
       clearRenderedDomState();
-      void loadFullContextForSyntax(fileKey);
+      if (!contextPrefetchScheduler) void loadFullContextForSyntax(fileKey);
       return;
     }
     const nextRenderAttemptKey = [
@@ -1071,10 +1070,14 @@
       path: renderFile.path,
       status: renderFile.status,
     });
-    const [oldContents, newContents] = await Promise.all([
+    const [oldResult, newResult] = await Promise.allSettled([
       renderFile.status === "added" ? Promise.resolve("") : loadFileText("old"),
       renderFile.status === "deleted" ? Promise.resolve("") : loadFileText("new"),
     ]);
+    if (oldResult.status === "rejected") throw oldResult.reason;
+    if (newResult.status === "rejected") throw newResult.reason;
+    const oldContents = oldResult.value;
+    const newContents = newResult.value;
     const context = {
       oldFile: pierreFileContents(renderFile.old_path || renderFile.path, oldContents, "full-old"),
       newFile: pierreFileContents(renderFile.path, newContents, "full-new"),

--- a/packages/ui/src/components/diff/PierreFileDiff.svelte
+++ b/packages/ui/src/components/diff/PierreFileDiff.svelte
@@ -30,6 +30,7 @@
   } from "./pierre-dom.js";
   import { diffTokenizeMaxLineLength, getPierreDiffWorkerPool } from "./pierre-worker-pool.js";
   import type {
+    DiffContextPrefetchPriority,
     DiffContextPrefetchScheduler,
     DiffContextPrefetchTaskHandle,
   } from "./diff-context-prefetch.js";
@@ -38,6 +39,7 @@
   interface Props {
     file: DiffFile | null | undefined;
     active?: boolean;
+    contextPrefetchIdentity?: string | undefined;
     contextPrefetchScheduler?: DiffContextPrefetchScheduler | undefined;
     viewMode?: "unified" | "split";
     wordWrap?: boolean;
@@ -91,6 +93,7 @@
   const {
     file = null,
     active = true,
+    contextPrefetchIdentity = "",
     contextPrefetchScheduler = undefined,
     viewMode = "unified",
     wordWrap = false,
@@ -117,6 +120,7 @@
   let contextLoadPromise: Promise<{ oldFile: FileContents; newFile: FileContents }> | undefined;
   let contextPrefetchHandle: DiffContextPrefetchTaskHandle | undefined;
   let contextError: string | null = $state(null);
+  let syntaxContextPrefetchFailedFileKey = $state("");
   let syntaxContextLoadFailedFileKey = $state("");
   let themeType = $state<ThemeTypes>(appThemeType());
   let rendered = $state(false);
@@ -139,7 +143,9 @@
   const maxImmediateRenderRetries = 5;
 
   const renderFile = $derived(file ? diffFileWithPatch(file) : emptyFile);
-  const fileKey = $derived(`${renderFile.path}\0${renderFile.old_path}\0${renderFile.patch}`);
+  const fileKey = $derived(
+    `${renderFile.path}\0${renderFile.old_path}\0${renderFile.patch}\0${contextPrefetchIdentity}`,
+  );
   const fileHunks = $derived(renderFile.hunks ?? []);
   const pierreFile = $derived.by<FileDiffMetadata | undefined>(() => {
     return parsePierreFileDiff(renderFile, {
@@ -305,6 +311,7 @@
     cleanUpPierreDiff();
     contextLoadPromise = undefined;
     contextError = null;
+    syntaxContextPrefetchFailedFileKey = "";
     syntaxContextLoadFailedFileKey = "";
     fullContext = undefined;
     fullContextFileDiff = undefined;
@@ -330,16 +337,23 @@
   $effect(() => {
     const scheduler = contextPrefetchScheduler;
     const requestFileKey = fileKey;
+    scheduler?.setGeneration(contextPrefetchIdentity);
+    const retryForeground = syntaxContextPrefetchFailedFileKey === requestFileKey;
     if (
       !scheduler ||
       !needsFullContextForSyntax ||
       fullContext ||
-      syntaxContextLoadFailedFileKey === requestFileKey
+      syntaxContextLoadFailedFileKey === requestFileKey ||
+      (retryForeground && !active)
     ) return;
     const handle = scheduler.schedule(
       requestFileKey,
-      untrack(() => active) ? "foreground" : "background",
-      (signal) => loadFullContextForSyntax(requestFileKey, signal),
+      retryForeground || untrack(() => active) ? "foreground" : "background",
+      (signal) => loadFullContextForSyntax(
+        requestFileKey,
+        signal,
+        untrack(() => active) ? "foreground" : "background",
+      ),
     );
     contextPrefetchHandle = handle;
     return () => {
@@ -1026,6 +1040,7 @@
   async function loadFullContextForSyntax(
     requestFileKey: string,
     signal?: AbortSignal,
+    priority: DiffContextPrefetchPriority = "foreground",
   ): Promise<void> {
     try {
       const context = await loadFullContext(requestFileKey, signal);
@@ -1035,6 +1050,10 @@
       renderFullContext(context);
     } catch (err) {
       if (signal?.aborted || fileKey !== requestFileKey) return;
+      if (priority === "background") {
+        syntaxContextPrefetchFailedFileKey = requestFileKey;
+        return;
+      }
       syntaxContextLoadFailedFileKey = requestFileKey;
       contextError = err instanceof Error ? err.message : "unknown error";
     }

--- a/packages/ui/src/components/diff/PierreFileDiff.svelte
+++ b/packages/ui/src/components/diff/PierreFileDiff.svelte
@@ -12,7 +12,7 @@
     ThemeTypes,
     Virtualizer,
   } from "@pierre/diffs";
-  import { onMount, tick } from "svelte";
+  import { onMount, tick, untrack } from "svelte";
   import type { DiffFile } from "../../api/types.js";
   import {
     appThemeType,
@@ -29,11 +29,16 @@
     renderedCodeSide as renderedPierreCodeSide,
   } from "./pierre-dom.js";
   import { diffTokenizeMaxLineLength, getPierreDiffWorkerPool } from "./pierre-worker-pool.js";
+  import type {
+    DiffContextPrefetchScheduler,
+    DiffContextPrefetchTaskHandle,
+  } from "./diff-context-prefetch.js";
   import type { WorkerPoolManager } from "@pierre/diffs/worker";
 
   interface Props {
     file: DiffFile | null | undefined;
     active?: boolean;
+    contextPrefetchScheduler?: DiffContextPrefetchScheduler | undefined;
     viewMode?: "unified" | "split";
     wordWrap?: boolean;
     tabWidth?: number;
@@ -86,6 +91,7 @@
   const {
     file = null,
     active = true,
+    contextPrefetchScheduler = undefined,
     viewMode = "unified",
     wordWrap = false,
     tabWidth = 4,
@@ -109,6 +115,7 @@
   let fullContextFileDiff: FileDiffMetadata | undefined;
   let fullContextRendered = false;
   let contextLoadPromise: Promise<{ oldFile: FileContents; newFile: FileContents }> | undefined;
+  let contextPrefetchHandle: DiffContextPrefetchTaskHandle | undefined;
   let contextError: string | null = $state(null);
   let syntaxContextLoadFailedFileKey = $state("");
   let themeType = $state<ThemeTypes>(appThemeType());
@@ -321,6 +328,31 @@
   });
 
   $effect(() => {
+    const scheduler = contextPrefetchScheduler;
+    const requestFileKey = fileKey;
+    if (
+      !scheduler ||
+      !needsFullContextForSyntax ||
+      fullContext ||
+      syntaxContextLoadFailedFileKey === requestFileKey
+    ) return;
+    const handle = scheduler.schedule(
+      requestFileKey,
+      untrack(() => active) ? "foreground" : "background",
+      (signal) => loadFullContextForSyntax(requestFileKey, signal),
+    );
+    contextPrefetchHandle = handle;
+    return () => {
+      if (contextPrefetchHandle === handle) contextPrefetchHandle = undefined;
+      handle.cancel();
+    };
+  });
+
+  $effect(() => {
+    contextPrefetchHandle?.setPriority(active ? "foreground" : "background");
+  });
+
+  $effect(() => {
     const currentRenderRetryTick = renderRetryTick;
     if (currentRenderRetryTick < 0) return;
     if (emptyTextualDiff) {
@@ -337,7 +369,13 @@
     if (pierreDiff instanceof VirtualizedFileDiff && isHostInScrollViewport()) {
       pierreDiff.setVisibility(true);
     }
-    if (active && needsFullContextForSyntax && !fullContext && syntaxContextLoadFailedFileKey !== fileKey) {
+    if (
+      !contextPrefetchScheduler &&
+      active &&
+      needsFullContextForSyntax &&
+      !fullContext &&
+      syntaxContextLoadFailedFileKey !== fileKey
+    ) {
       rendered = false;
       clearRenderedDomState();
       void loadFullContextForSyntax(fileKey);
@@ -963,41 +1001,52 @@
 
   async function loadFullContext(
     requestFileKey: string,
+    signal?: AbortSignal,
   ): Promise<{ oldFile: FileContents; newFile: FileContents } | undefined> {
     if (fullContext) return fullContext;
-    const promise = contextLoadPromise ??= fetchFullContext();
+    const promise = contextLoadPromise ??= fetchFullContext(signal);
     try {
       const context = await promise;
-      if (fileKey !== requestFileKey || contextLoadPromise !== promise) return undefined;
+      if (
+        signal?.aborted ||
+        fileKey !== requestFileKey ||
+        contextLoadPromise !== promise
+      ) return undefined;
       fullContext = context;
     } catch (err) {
       if (contextLoadPromise === promise) {
         contextLoadPromise = undefined;
       }
-      if (fileKey !== requestFileKey) return undefined;
+      if (signal?.aborted || fileKey !== requestFileKey) return undefined;
       throw err;
     }
     return fullContext;
   }
 
-  async function loadFullContextForSyntax(requestFileKey: string): Promise<void> {
+  async function loadFullContextForSyntax(
+    requestFileKey: string,
+    signal?: AbortSignal,
+  ): Promise<void> {
     try {
-      const context = await loadFullContext(requestFileKey);
-      if (!context || fileKey !== requestFileKey) return;
+      const context = await loadFullContext(requestFileKey, signal);
+      if (!context || signal?.aborted || fileKey !== requestFileKey) return;
       await tick();
-      if (fileKey !== requestFileKey || fullContextRendered) return;
+      if (signal?.aborted || fileKey !== requestFileKey || fullContextRendered) return;
       renderFullContext(context);
     } catch (err) {
-      if (fileKey !== requestFileKey) return;
+      if (signal?.aborted || fileKey !== requestFileKey) return;
       syntaxContextLoadFailedFileKey = requestFileKey;
       contextError = err instanceof Error ? err.message : "unknown error";
     }
   }
 
-  async function fetchFullContext(): Promise<{ oldFile: FileContents; newFile: FileContents }> {
+  async function fetchFullContext(
+    signal?: AbortSignal,
+  ): Promise<{ oldFile: FileContents; newFile: FileContents }> {
     if (!loadFileText) {
       throw new Error("Context loading is unavailable");
     }
+    if (signal?.aborted) throw signal.reason;
     contextError = null;
     debugPierreDiff("fetch full context start", {
       path: renderFile.path,

--- a/packages/ui/src/components/diff/PierreFileDiff.svelte
+++ b/packages/ui/src/components/diff/PierreFileDiff.svelte
@@ -337,7 +337,7 @@
     if (pierreDiff instanceof VirtualizedFileDiff && isHostInScrollViewport()) {
       pierreDiff.setVisibility(true);
     }
-    if (needsFullContextForSyntax && !fullContext && syntaxContextLoadFailedFileKey !== fileKey) {
+    if (active && needsFullContextForSyntax && !fullContext && syntaxContextLoadFailedFileKey !== fileKey) {
       rendered = false;
       clearRenderedDomState();
       void loadFullContextForSyntax(fileKey);

--- a/packages/ui/src/components/diff/PierreFileDiff.test.ts
+++ b/packages/ui/src/components/diff/PierreFileDiff.test.ts
@@ -2,7 +2,11 @@ import { cleanup, fireEvent, render, waitFor } from "@testing-library/svelte";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
 import type { DiffLineAnnotation, FileDiffOptions, Virtualizer } from "@pierre/diffs";
 import type { DiffFile } from "../../api/types.js";
-import type { DiffContextPrefetchScheduler, DiffContextPrefetchTaskHandle } from "./diff-context-prefetch.js";
+import {
+  createDiffContextPrefetchScheduler,
+  type DiffContextPrefetchScheduler,
+  type DiffContextPrefetchTaskHandle,
+} from "./diff-context-prefetch.js";
 
 type GlobalWithCSSStyleSheet = {
   CSSStyleSheet?: {
@@ -452,6 +456,78 @@ describe("PierreFileDiff", () => {
 
     await run(new AbortController().signal);
     expect(loadFileText).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps an active syntax-gap diff hidden while scheduled context is pending", async () => {
+    const { default: PierreFileDiff } = await import("./PierreFileDiff.svelte");
+    const prefetch = capturingPrefetchScheduler();
+    const releases: Array<(value: string) => void> = [];
+    const loadFileText = vi.fn(() => new Promise<string>((resolve) => releases.push(resolve)));
+
+    render(PierreFileDiff, {
+      props: {
+        file: makeSyntaxStateGapFile(),
+        active: true,
+        contextPrefetchScheduler: prefetch.scheduler,
+        loadFileText,
+      },
+    });
+
+    const run = await waitFor(() => {
+      expect(prefetch.run()).toBeTypeOf("function");
+      return prefetch.run()!;
+    });
+    const task = run(new AbortController().signal);
+    await waitFor(() => expect(loadFileText).toHaveBeenCalledTimes(2));
+
+    expect(pierre.renderCount()).toBe(0);
+    expect(document.querySelector(".pierre-diff-loading")).not.toBeNull();
+
+    releases.forEach((release) => release("full file text"));
+    await task;
+
+    await waitFor(() => {
+      expect(pierre.renderCount()).toBe(1);
+      expect(document.querySelector(".pierre-diff-loading")).toBeNull();
+    });
+  });
+
+  it("keeps the scheduler slot until both paired previews settle", async () => {
+    const { default: PierreFileDiff } = await import("./PierreFileDiff.svelte");
+    const scheduler = createDiffContextPrefetchScheduler({ concurrency: 1 });
+    let releaseNewPreview = (_value: string): void => {};
+    const loadFileText = vi.fn((side: "old" | "new") => {
+      if (side === "old") return Promise.reject(new Error("old preview failed"));
+      return new Promise<string>((resolve) => {
+        releaseNewPreview = resolve;
+      });
+    });
+
+    render(PierreFileDiff, {
+      props: {
+        file: makeSyntaxStateGapFile(),
+        active: true,
+        contextPrefetchScheduler: scheduler,
+        loadFileText,
+      },
+    });
+
+    await waitFor(() => expect(loadFileText).toHaveBeenCalledTimes(2));
+    let queuedTaskStarted = false;
+    scheduler.schedule("queued", "foreground", async () => {
+      queuedTaskStarted = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(queuedTaskStarted).toBe(false);
+
+    releaseNewPreview("full file text");
+
+    await waitFor(() => {
+      expect(queuedTaskStarted).toBe(true);
+      expect(document.querySelector(".context-error")?.textContent).toContain("old preview failed");
+      expect(pierre.renderCount()).toBe(1);
+    });
   });
 
   it("retries a failed speculative prefetch after the file becomes active", async () => {

--- a/packages/ui/src/components/diff/PierreFileDiff.test.ts
+++ b/packages/ui/src/components/diff/PierreFileDiff.test.ts
@@ -1,6 +1,6 @@
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/svelte";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
-import type { DiffLineAnnotation, FileDiffOptions } from "@pierre/diffs";
+import type { DiffLineAnnotation, FileDiffOptions, Virtualizer } from "@pierre/diffs";
 import type { DiffFile } from "../../api/types.js";
 
 type GlobalWithCSSStyleSheet = {
@@ -379,6 +379,23 @@ describe("PierreFileDiff", () => {
       expect(document.querySelector(".context-error")?.textContent).toContain("preview failed");
       expect(pierre.renderCount()).toBe(1);
     });
+  });
+
+  it("does not preload syntax context for an offscreen virtualized diff", async () => {
+    const { default: PierreFileDiff } = await import("./PierreFileDiff.svelte");
+    const loadFileText = vi.fn(async () => "full file text");
+
+    render(PierreFileDiff, {
+      props: {
+        file: makeSyntaxStateGapFile(),
+        active: false,
+        loadFileText,
+        virtualizer: {} as Virtualizer,
+      },
+    });
+
+    await Promise.resolve();
+    expect(loadFileText).not.toHaveBeenCalled();
   });
 
   it("shows the empty textual state for metadata-only patches", async () => {

--- a/packages/ui/src/components/diff/PierreFileDiff.test.ts
+++ b/packages/ui/src/components/diff/PierreFileDiff.test.ts
@@ -2,6 +2,7 @@ import { cleanup, fireEvent, render, waitFor } from "@testing-library/svelte";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vite-plus/test";
 import type { DiffLineAnnotation, FileDiffOptions, Virtualizer } from "@pierre/diffs";
 import type { DiffFile } from "../../api/types.js";
+import type { DiffContextPrefetchScheduler, DiffContextPrefetchTaskHandle } from "./diff-context-prefetch.js";
 
 type GlobalWithCSSStyleSheet = {
   CSSStyleSheet?: {
@@ -103,6 +104,7 @@ const pierre = (() => {
     setOptions = (options?: FileDiffOptions<unknown>) => {
       lastOptions = options;
     };
+    setMetrics = () => {};
     setSelectedLines = () => {};
     setThemeType = () => {};
   }
@@ -310,6 +312,31 @@ function makeSyntaxStateGapFile(): DiffFile {
   };
 }
 
+function capturingPrefetchScheduler(): {
+  cancel: ReturnType<typeof vi.fn>;
+  run: () => ((signal: AbortSignal) => Promise<void>) | undefined;
+  scheduler: DiffContextPrefetchScheduler;
+  setPriority: ReturnType<typeof vi.fn>;
+} {
+  let capturedRun: ((signal: AbortSignal) => Promise<void>) | undefined;
+  const cancel = vi.fn();
+  const setPriority = vi.fn();
+  const handle: DiffContextPrefetchTaskHandle = { cancel, setPriority };
+  return {
+    cancel,
+    run: () => capturedRun,
+    scheduler: {
+      dispose: vi.fn(),
+      reset: vi.fn(),
+      schedule: vi.fn((_id, _priority, run) => {
+        capturedRun = run;
+        return handle;
+      }),
+    },
+    setPriority,
+  };
+}
+
 describe("PierreFileDiff", () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -396,6 +423,107 @@ describe("PierreFileDiff", () => {
 
     await Promise.resolve();
     expect(loadFileText).not.toHaveBeenCalled();
+  });
+
+  it("registers offscreen syntax context for proactive prefetch", async () => {
+    const { default: PierreFileDiff } = await import("./PierreFileDiff.svelte");
+    const prefetch = capturingPrefetchScheduler();
+    const loadFileText = vi.fn(async () => "full file text");
+
+    render(PierreFileDiff, {
+      props: {
+        file: makeSyntaxStateGapFile(),
+        active: false,
+        contextPrefetchScheduler: prefetch.scheduler,
+        loadFileText,
+        virtualizer: {} as Virtualizer,
+      },
+    });
+
+    const run = await waitFor(() => {
+      expect(prefetch.run()).toBeTypeOf("function");
+      return prefetch.run()!;
+    });
+    expect(loadFileText).not.toHaveBeenCalled();
+
+    await run(new AbortController().signal);
+    expect(loadFileText).toHaveBeenCalledTimes(2);
+  });
+
+  it("cancels proactive prefetch registration on cleanup", async () => {
+    const { default: PierreFileDiff } = await import("./PierreFileDiff.svelte");
+    const prefetch = capturingPrefetchScheduler();
+    const result = render(PierreFileDiff, {
+      props: {
+        file: makeSyntaxStateGapFile(),
+        active: false,
+        contextPrefetchScheduler: prefetch.scheduler,
+        loadFileText: async () => "full file text",
+        virtualizer: {} as Virtualizer,
+      },
+    });
+    await waitFor(() => expect(prefetch.run()).toBeTypeOf("function"));
+
+    result.unmount();
+
+    expect(prefetch.cancel).toHaveBeenCalledOnce();
+  });
+
+  it("does not apply syntax context after proactive prefetch is aborted", async () => {
+    const { default: PierreFileDiff } = await import("./PierreFileDiff.svelte");
+    const prefetch = capturingPrefetchScheduler();
+    const releases: Array<(value: string) => void> = [];
+    const loadFileText = vi.fn(() => new Promise<string>((resolve) => releases.push(resolve)));
+    render(PierreFileDiff, {
+      props: {
+        file: makeSyntaxStateGapFile(),
+        active: false,
+        contextPrefetchScheduler: prefetch.scheduler,
+        loadFileText,
+        virtualizer: {} as Virtualizer,
+      },
+    });
+    const run = await waitFor(() => {
+      expect(prefetch.run()).toBeTypeOf("function");
+      return prefetch.run()!;
+    });
+    const controller = new AbortController();
+    const task = run(controller.signal);
+    await waitFor(() => expect(loadFileText).toHaveBeenCalledTimes(2));
+    const sparseRenderCount = pierre.renderCount();
+
+    controller.abort();
+    releases.forEach((release) => release("full file text"));
+    await task;
+
+    expect(pierre.renderCount()).toBe(sparseRenderCount);
+    expect(document.querySelector(".context-error")).toBeNull();
+  });
+
+  it("loads manual context expansion without waiting for proactive prefetch", async () => {
+    const { default: PierreFileDiff } = await import("./PierreFileDiff.svelte");
+    const prefetch = capturingPrefetchScheduler();
+    const loadFileText = vi.fn(async () => "full file text");
+    render(PierreFileDiff, {
+      props: {
+        file: makeSyntaxStateGapFile(),
+        active: false,
+        contextPrefetchScheduler: prefetch.scheduler,
+        loadFileText,
+        virtualizer: {} as Virtualizer,
+      },
+    });
+
+    const expandButton = await waitFor(() => {
+      const button = document
+        .querySelector(".pierre-diff")
+        ?.shadowRoot?.querySelector<HTMLElement>("[data-expand-button]");
+      expect(button).toBeTruthy();
+      return button!;
+    });
+    await fireEvent.click(expandButton);
+
+    await waitFor(() => expect(loadFileText).toHaveBeenCalledTimes(2));
   });
 
   it("shows the empty textual state for metadata-only patches", async () => {

--- a/packages/ui/src/components/diff/PierreFileDiff.test.ts
+++ b/packages/ui/src/components/diff/PierreFileDiff.test.ts
@@ -315,23 +315,27 @@ function makeSyntaxStateGapFile(): DiffFile {
 function capturingPrefetchScheduler(): {
   cancel: ReturnType<typeof vi.fn>;
   run: () => ((signal: AbortSignal) => Promise<void>) | undefined;
+  schedule: ReturnType<typeof vi.fn>;
   scheduler: DiffContextPrefetchScheduler;
   setPriority: ReturnType<typeof vi.fn>;
 } {
   let capturedRun: ((signal: AbortSignal) => Promise<void>) | undefined;
   const cancel = vi.fn();
   const setPriority = vi.fn();
+  const schedule = vi.fn((_id, _priority, run) => {
+    capturedRun = run;
+    return handle;
+  });
   const handle: DiffContextPrefetchTaskHandle = { cancel, setPriority };
   return {
     cancel,
     run: () => capturedRun,
+    schedule,
     scheduler: {
       dispose: vi.fn(),
       reset: vi.fn(),
-      schedule: vi.fn((_id, _priority, run) => {
-        capturedRun = run;
-        return handle;
-      }),
+      schedule,
+      setGeneration: vi.fn(),
     },
     setPriority,
   };
@@ -448,6 +452,42 @@ describe("PierreFileDiff", () => {
 
     await run(new AbortController().signal);
     expect(loadFileText).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries a failed speculative prefetch after the file becomes active", async () => {
+    const { default: PierreFileDiff } = await import("./PierreFileDiff.svelte");
+    const prefetch = capturingPrefetchScheduler();
+    const loadFileText = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("temporary preview failure"))
+      .mockRejectedValueOnce(new Error("temporary preview failure"))
+      .mockResolvedValue("full file text");
+    const view = render(PierreFileDiff, {
+      props: {
+        file: makeSyntaxStateGapFile(),
+        active: false,
+        contextPrefetchScheduler: prefetch.scheduler,
+        loadFileText,
+        virtualizer: {} as Virtualizer,
+      },
+    });
+
+    const backgroundRun = await waitFor(() => {
+      expect(prefetch.run()).toBeTypeOf("function");
+      return prefetch.run()!;
+    });
+    await backgroundRun(new AbortController().signal);
+
+    expect(document.querySelector(".context-error")).toBeNull();
+    await view.rerender({ active: true });
+    const foregroundRun = await waitFor(() => {
+      expect(prefetch.schedule).toHaveBeenCalledTimes(2);
+      return prefetch.run()!;
+    });
+    await foregroundRun(new AbortController().signal);
+
+    expect(loadFileText).toHaveBeenCalledTimes(4);
+    expect(document.querySelector(".context-error")).toBeNull();
   });
 
   it("cancels proactive prefetch registration on cleanup", async () => {

--- a/packages/ui/src/components/diff/diff-context-prefetch.test.ts
+++ b/packages/ui/src/components/diff/diff-context-prefetch.test.ts
@@ -130,6 +130,8 @@ describe("diff context prefetch scheduler", () => {
     scheduler.schedule("current", "foreground", currentTask.run);
     scheduler.schedule("waiting", "foreground", waitingTask.run);
 
+    expect(starts).toEqual(["old"]);
+
     oldTask.resolve();
     await Promise.resolve();
     await Promise.resolve();
@@ -139,6 +141,51 @@ describe("diff context prefetch scheduler", () => {
     await Promise.resolve();
     await Promise.resolve();
     expect(starts).toEqual(["old", "current", "waiting"]);
+  });
+
+  it("keeps unresolved work inside the concurrency ceiling across repeated resets", async () => {
+    const starts: string[] = [];
+    const oldTasks = [controlledTask(starts, "old-1"), controlledTask(starts, "old-2")];
+    const abandonedTasks = [controlledTask(starts, "abandoned-1"), controlledTask(starts, "abandoned-2")];
+    const currentTasks = [controlledTask(starts, "current-1"), controlledTask(starts, "current-2")];
+    const scheduler = createDiffContextPrefetchScheduler({ concurrency: 2 });
+
+    oldTasks.forEach((task, index) => scheduler.schedule(`old-${index}`, "foreground", task.run));
+    scheduler.reset();
+    abandonedTasks.forEach((task, index) => scheduler.schedule(`abandoned-${index}`, "foreground", task.run));
+    scheduler.reset();
+    currentTasks.forEach((task, index) => scheduler.schedule(`current-${index}`, "foreground", task.run));
+
+    expect(starts).toEqual(["old-1", "old-2"]);
+
+    oldTasks[0]!.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(starts).toEqual(["old-1", "old-2", "current-1"]);
+
+    oldTasks[1]!.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(starts).toEqual(["old-1", "old-2", "current-1", "current-2"]);
+  });
+
+  it("aligns mounted task registration with the latest diff generation", async () => {
+    const starts: string[] = [];
+    const oldTask = controlledTask(starts, "old");
+    const currentTask = controlledTask(starts, "current");
+    const scheduler = createDiffContextPrefetchScheduler({ concurrency: 1 });
+
+    scheduler.setGeneration("old-diff");
+    scheduler.schedule("old", "foreground", oldTask.run);
+    scheduler.setGeneration("current-diff");
+    scheduler.schedule("current", "foreground", currentTask.run);
+    scheduler.setGeneration("current-diff");
+
+    expect(starts).toEqual(["old"]);
+    oldTask.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(starts).toEqual(["old", "current"]);
   });
 
   it("cancels an individual queued task", () => {

--- a/packages/ui/src/components/diff/diff-context-prefetch.test.ts
+++ b/packages/ui/src/components/diff/diff-context-prefetch.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vite-plus/test";
+import { createDiffContextPrefetchScheduler } from "./diff-context-prefetch.js";
+
+function controlledTask(
+  starts: string[],
+  id: string,
+): {
+  resolve: () => void;
+  run: (signal: AbortSignal) => Promise<void>;
+  signal: () => AbortSignal | undefined;
+} {
+  let resolve = (): void => {};
+  let capturedSignal: AbortSignal | undefined;
+  return {
+    resolve: () => resolve(),
+    run: (signal) => {
+      starts.push(id);
+      capturedSignal = signal;
+      return new Promise<void>((done) => {
+        resolve = done;
+      });
+    },
+    signal: () => capturedSignal,
+  };
+}
+
+function deferredCallbacks(): {
+  runNext: () => void;
+  scheduleDeferred: (callback: () => void) => () => void;
+} {
+  const callbacks: Array<{ callback: () => void; cancelled: boolean }> = [];
+  return {
+    runNext: () => {
+      const next = callbacks.shift();
+      if (next && !next.cancelled) next.callback();
+    },
+    scheduleDeferred: (callback) => {
+      const entry = { callback, cancelled: false };
+      callbacks.push(entry);
+      return () => {
+        entry.cancelled = true;
+      };
+    },
+  };
+}
+
+describe("diff context prefetch scheduler", () => {
+  it("runs at most four file tasks and reuses a released slot", async () => {
+    const starts: string[] = [];
+    const tasks = Array.from({ length: 5 }, (_, index) => controlledTask(starts, String(index + 1)));
+    const scheduler = createDiffContextPrefetchScheduler({ concurrency: 4 });
+
+    tasks.forEach((task, index) => scheduler.schedule(String(index), "foreground", task.run));
+
+    expect(starts).toEqual(["1", "2", "3", "4"]);
+    tasks[0]!.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(starts).toEqual(["1", "2", "3", "4", "5"]);
+  });
+
+  it("waits for a deferred turn before starting background work", () => {
+    const starts: string[] = [];
+    const deferred = deferredCallbacks();
+    const task = controlledTask(starts, "background");
+    const scheduler = createDiffContextPrefetchScheduler({
+      concurrency: 4,
+      scheduleDeferred: deferred.scheduleDeferred,
+    });
+
+    scheduler.schedule("background", "background", task.run);
+    expect(starts).toEqual([]);
+
+    deferred.runNext();
+    expect(starts).toEqual(["background"]);
+  });
+
+  it("promotes queued background work ahead of the background queue", async () => {
+    const starts: string[] = [];
+    const deferred = deferredCallbacks();
+    const blocker = controlledTask(starts, "blocker");
+    const firstBackground = controlledTask(starts, "first-background");
+    const promoted = controlledTask(starts, "promoted");
+    const scheduler = createDiffContextPrefetchScheduler({
+      concurrency: 1,
+      scheduleDeferred: deferred.scheduleDeferred,
+    });
+
+    scheduler.schedule("blocker", "foreground", blocker.run);
+    scheduler.schedule("first-background", "background", firstBackground.run);
+    const promotedHandle = scheduler.schedule("promoted", "background", promoted.run);
+    promotedHandle.setPriority("foreground");
+
+    blocker.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(starts).toEqual(["blocker", "promoted"]);
+
+    promoted.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(starts).toEqual(["blocker", "promoted"]);
+    deferred.runNext();
+    expect(starts).toEqual(["blocker", "promoted", "first-background"]);
+  });
+
+  it("cancels queued work and aborts active work on reset", () => {
+    const starts: string[] = [];
+    const active = controlledTask(starts, "active");
+    const queued = controlledTask(starts, "queued");
+    const scheduler = createDiffContextPrefetchScheduler({ concurrency: 1 });
+
+    scheduler.schedule("active", "foreground", active.run);
+    scheduler.schedule("queued", "foreground", queued.run);
+    scheduler.reset();
+
+    expect(active.signal()?.aborted).toBe(true);
+    expect(starts).toEqual(["active"]);
+  });
+
+  it("ignores stale completion from a prior generation", async () => {
+    const starts: string[] = [];
+    const oldTask = controlledTask(starts, "old");
+    const currentTask = controlledTask(starts, "current");
+    const waitingTask = controlledTask(starts, "waiting");
+    const scheduler = createDiffContextPrefetchScheduler({ concurrency: 1 });
+
+    scheduler.schedule("old", "foreground", oldTask.run);
+    scheduler.reset();
+    scheduler.schedule("current", "foreground", currentTask.run);
+    scheduler.schedule("waiting", "foreground", waitingTask.run);
+
+    oldTask.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(starts).toEqual(["old", "current"]);
+
+    currentTask.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(starts).toEqual(["old", "current", "waiting"]);
+  });
+
+  it("cancels an individual queued task", () => {
+    const starts: string[] = [];
+    const deferred = deferredCallbacks();
+    const queued = controlledTask(starts, "queued");
+    const scheduler = createDiffContextPrefetchScheduler({
+      concurrency: 1,
+      scheduleDeferred: deferred.scheduleDeferred,
+    });
+    const handle = scheduler.schedule("queued", "background", queued.run);
+
+    handle.cancel();
+    deferred.runNext();
+
+    expect(starts).toEqual([]);
+  });
+
+  it("aborts an individually cancelled active task", () => {
+    const starts: string[] = [];
+    const active = controlledTask(starts, "active");
+    const scheduler = createDiffContextPrefetchScheduler({ concurrency: 1 });
+    const handle = scheduler.schedule("active", "foreground", active.run);
+
+    handle.cancel();
+
+    expect(active.signal()?.aborted).toBe(true);
+  });
+
+  it("does not accept new work after disposal", () => {
+    const starts: string[] = [];
+    const scheduler = createDiffContextPrefetchScheduler({ concurrency: 1 });
+    scheduler.dispose();
+
+    scheduler.schedule("late", "foreground", controlledTask(starts, "late").run);
+
+    expect(starts).toEqual([]);
+  });
+});

--- a/packages/ui/src/components/diff/diff-context-prefetch.ts
+++ b/packages/ui/src/components/diff/diff-context-prefetch.ts
@@ -1,0 +1,161 @@
+export type DiffContextPrefetchPriority = "foreground" | "background";
+
+export interface DiffContextPrefetchTaskHandle {
+  cancel(): void;
+  setPriority(priority: DiffContextPrefetchPriority): void;
+}
+
+export interface DiffContextPrefetchScheduler {
+  dispose(): void;
+  reset(): void;
+  schedule(
+    id: string,
+    priority: DiffContextPrefetchPriority,
+    run: (signal: AbortSignal) => Promise<void>,
+  ): DiffContextPrefetchTaskHandle;
+}
+
+interface SchedulerOptions {
+  concurrency?: number;
+  scheduleDeferred?: (callback: () => void) => () => void;
+}
+
+interface PrefetchTask {
+  controller: AbortController;
+  generation: number;
+  id: string;
+  priority: DiffContextPrefetchPriority;
+  run: (signal: AbortSignal) => Promise<void>;
+  state: "queued" | "active" | "cancelled" | "settled";
+}
+
+export function createDiffContextPrefetchScheduler(options: SchedulerOptions = {}): DiffContextPrefetchScheduler {
+  const concurrency = options.concurrency ?? 4;
+  if (!Number.isInteger(concurrency) || concurrency < 1) {
+    throw new RangeError("Diff context prefetch concurrency must be a positive integer");
+  }
+
+  const scheduleDeferred = options.scheduleDeferred ?? scheduleBrowserBackgroundTurn;
+  let generation = 0;
+  let disposed = false;
+  let cancelDeferred: (() => void) | undefined;
+  const foregroundQueue: PrefetchTask[] = [];
+  const backgroundQueue: PrefetchTask[] = [];
+  const active = new Set<PrefetchTask>();
+
+  function removeQueuedTask(task: PrefetchTask): void {
+    const queue = task.priority === "foreground" ? foregroundQueue : backgroundQueue;
+    const index = queue.indexOf(task);
+    if (index >= 0) queue.splice(index, 1);
+  }
+
+  function start(task: PrefetchTask): void {
+    if (task.state !== "queued" || task.generation !== generation || disposed) return;
+    task.state = "active";
+    active.add(task);
+    let result: Promise<void>;
+    try {
+      result = task.run(task.controller.signal);
+    } catch (error) {
+      result = Promise.reject(error);
+    }
+    void result.catch(() => undefined).finally(() => settle(task));
+  }
+
+  function settle(task: PrefetchTask): void {
+    task.state = "settled";
+    if (disposed || task.generation !== generation || !active.delete(task)) return;
+    drainForeground();
+    scheduleBackground();
+  }
+
+  function drainForeground(): void {
+    while (active.size < concurrency && foregroundQueue.length > 0) {
+      const task = foregroundQueue.shift()!;
+      start(task);
+    }
+  }
+
+  function drainBackgroundTurn(): void {
+    cancelDeferred = undefined;
+    drainForeground();
+    while (active.size < concurrency && backgroundQueue.length > 0) {
+      const task = backgroundQueue.shift()!;
+      start(task);
+    }
+  }
+
+  function scheduleBackground(): void {
+    if (disposed || cancelDeferred || active.size >= concurrency || backgroundQueue.length === 0) return;
+    cancelDeferred = scheduleDeferred(drainBackgroundTurn);
+  }
+
+  function cancelTask(task: PrefetchTask): void {
+    if (task.state === "cancelled" || task.state === "settled") return;
+    if (task.state === "queued") removeQueuedTask(task);
+    task.state = "cancelled";
+    task.controller.abort();
+    // Active work retains its slot until the task settles because file previews
+    // use a shared cache request that cancellation deliberately does not abort.
+  }
+
+  function resetTasks(): void {
+    generation += 1;
+    cancelDeferred?.();
+    cancelDeferred = undefined;
+    while (foregroundQueue.length > 0) cancelTask(foregroundQueue[0]!);
+    while (backgroundQueue.length > 0) cancelTask(backgroundQueue[0]!);
+    for (const task of active) cancelTask(task);
+    foregroundQueue.length = 0;
+    backgroundQueue.length = 0;
+    active.clear();
+  }
+
+  return {
+    dispose(): void {
+      if (disposed) return;
+      resetTasks();
+      disposed = true;
+    },
+    reset(): void {
+      if (!disposed) resetTasks();
+    },
+    schedule(id, priority, run): DiffContextPrefetchTaskHandle {
+      if (disposed) {
+        return { cancel: () => {}, setPriority: () => {} };
+      }
+      const task: PrefetchTask = {
+        controller: new AbortController(),
+        generation,
+        id,
+        priority,
+        run,
+        state: "queued",
+      };
+      (priority === "foreground" ? foregroundQueue : backgroundQueue).push(task);
+      if (priority === "foreground") drainForeground();
+      else scheduleBackground();
+
+      return {
+        cancel: () => cancelTask(task),
+        setPriority(nextPriority): void {
+          if (task.state !== "queued" || task.priority === nextPriority) return;
+          removeQueuedTask(task);
+          task.priority = nextPriority;
+          (nextPriority === "foreground" ? foregroundQueue : backgroundQueue).push(task);
+          if (nextPriority === "foreground") drainForeground();
+          else scheduleBackground();
+        },
+      };
+    },
+  };
+}
+
+function scheduleBrowserBackgroundTurn(callback: () => void): () => void {
+  if (typeof globalThis.requestIdleCallback === "function") {
+    const id = globalThis.requestIdleCallback(callback, { timeout: 500 });
+    return () => globalThis.cancelIdleCallback(id);
+  }
+  const id = globalThis.setTimeout(callback, 50);
+  return () => globalThis.clearTimeout(id);
+}

--- a/packages/ui/src/components/diff/diff-context-prefetch.ts
+++ b/packages/ui/src/components/diff/diff-context-prefetch.ts
@@ -8,6 +8,7 @@ export interface DiffContextPrefetchTaskHandle {
 export interface DiffContextPrefetchScheduler {
   dispose(): void;
   reset(): void;
+  setGeneration(identity: string): void;
   schedule(
     id: string,
     priority: DiffContextPrefetchPriority,
@@ -37,6 +38,7 @@ export function createDiffContextPrefetchScheduler(options: SchedulerOptions = {
 
   const scheduleDeferred = options.scheduleDeferred ?? scheduleBrowserBackgroundTurn;
   let generation = 0;
+  let sourceGeneration: string | undefined;
   let disposed = false;
   let cancelDeferred: (() => void) | undefined;
   const foregroundQueue: PrefetchTask[] = [];
@@ -64,7 +66,7 @@ export function createDiffContextPrefetchScheduler(options: SchedulerOptions = {
 
   function settle(task: PrefetchTask): void {
     task.state = "settled";
-    if (disposed || task.generation !== generation || !active.delete(task)) return;
+    if (!active.delete(task) || disposed) return;
     drainForeground();
     scheduleBackground();
   }
@@ -108,7 +110,6 @@ export function createDiffContextPrefetchScheduler(options: SchedulerOptions = {
     for (const task of active) cancelTask(task);
     foregroundQueue.length = 0;
     backgroundQueue.length = 0;
-    active.clear();
   }
 
   return {
@@ -119,6 +120,11 @@ export function createDiffContextPrefetchScheduler(options: SchedulerOptions = {
     },
     reset(): void {
       if (!disposed) resetTasks();
+    },
+    setGeneration(identity): void {
+      if (disposed || sourceGeneration === identity) return;
+      sourceGeneration = identity;
+      resetTasks();
     },
     schedule(id, priority, run): DiffContextPrefetchTaskHandle {
       if (disposed) {


### PR DESCRIPTION
- Keep large diffs responsive by limiting eager full-context rendering to nearby files.
- Prepare remaining syntax context in the background with visible files taking priority.
- Bound context loading to four files and discard stale queued work when the diff changes.

<sup>generated by a clanker</sup>