### PR TITLE
Add a strict date order option to the PR timeline

### DIFF
--- a/context/ui-design-system.md
+++ b/context/ui-design-system.md
@@ -329,6 +329,13 @@ Intent:
 
 Do not add native `<select>` controls for visible app UI; use `SelectDropdown` instead. This is enforced by `frontend/src/no-native-select.test.ts`, which scans the component source trees and fails when a native `<select>` element is reintroduced. There is no allowlist or per-component exemption: if `SelectDropdown` cannot express a case, extend the primitive rather than reaching for a native `<select>`.
 
+### FilterDropdown menu rows
+
+A binary view mode in a `FilterDropdown` menu is one toggle row named for the
+non-default state ("Strict date order", "Hide bot activity"), checked when
+active. Do not add a row for the default state, an exclusive radio pair, or an
+opaque single-word label for default behavior.
+
 ### Overlays
 
 Use shared overlay primitives for dropdowns, popovers, menus, tooltips, and similar floating controls.

--- a/frontend/src/App.pr-timeline-filters.browser.svelte.ts
+++ b/frontend/src/App.pr-timeline-filters.browser.svelte.ts
@@ -453,6 +453,27 @@ describe("PR timeline filters", () => {
     expect(inDetail('[title="View and filter activity"]')[0]?.textContent ?? "").toContain("1");
   });
 
+  it("orders the timeline strictly by date when strict date order is selected", async () => {
+    await mountTimeline("/pulls/github/acme/widgets/1");
+    await vi.waitFor(() => expect(detailText(".kit-timeline")).toContain("Same timestamp reviewer note"), WAIT);
+
+    // Grouped default: the follow-up force push pulls its rebase commit above
+    // the reviewer note that was written before the push.
+    expect(detailText(".kit-timeline").indexOf("fix: finish cache rebase after follow-up force push")).toBeLessThan(
+      detailText(".kit-timeline").indexOf("Same timestamp reviewer note"),
+    );
+
+    await openViewMenu();
+    await toggleBucket("Strict date order");
+
+    await vi.waitFor(() => {
+      expect(detailText(".kit-timeline").indexOf("Same timestamp reviewer note")).toBeLessThan(
+        detailText(".kit-timeline").indexOf("fix: finish cache rebase after follow-up force push"),
+      );
+    }, WAIT);
+    expect(localStorage.getItem("kenn-forge-detail-timeline-order")).toBe("chronological");
+  });
+
   it("keeps commit rows when other event buckets are hidden", async () => {
     await mountTimeline("/pulls/github/acme/widgets/1");
     await vi.waitFor(() => expect(detailText(".kit-timeline")).toContain("feat: add cache store"), WAIT);

--- a/packages/ui/src/components/detail/DetailActivityViewMenu.svelte
+++ b/packages/ui/src/components/detail/DetailActivityViewMenu.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import { FilterDropdown } from "@kenn-io/kit-ui";
-  import type { DetailActivityViewMode } from "../../stores/detail-activity-view.svelte.js";
+  import type {
+    DetailActivityViewMode,
+    DetailTimelineOrder,
+  } from "../../stores/detail-activity-view.svelte.js";
   import {
     activePRTimelineFilterCount,
     DEFAULT_PR_TIMELINE_FILTER,
@@ -10,11 +13,13 @@
   interface Props {
     viewMode: DetailActivityViewMode;
     onViewChange: (mode: DetailActivityViewMode) => void;
+    timelineOrder?: DetailTimelineOrder;
+    onOrderChange?: (order: DetailTimelineOrder) => void;
     filter?: PRTimelineFilterState;
     onFilterChange?: (filter: PRTimelineFilterState) => void;
   }
 
-  let { viewMode, onViewChange, filter, onFilterChange }: Props = $props();
+  let { viewMode, onViewChange, timelineOrder, onOrderChange, filter, onFilterChange }: Props = $props();
 
   const activeFilterCount = $derived(
     filter ? activePRTimelineFilterCount(filter) : 0,
@@ -24,6 +29,9 @@
   );
   const hasPRFilters = $derived(
     filter !== undefined && onFilterChange !== undefined,
+  );
+  const hasOrderControls = $derived(
+    timelineOrder !== undefined && onOrderChange !== undefined,
   );
 
   function updateFilter(patch: Partial<PRTimelineFilterState>): void {
@@ -55,6 +63,29 @@
         },
       ],
     },
+    ...(hasOrderControls
+      ? [
+          {
+            title: "Order",
+            items: [
+              {
+                id: "order-grouped",
+                label: "Grouped",
+                active: timelineOrder === "grouped",
+                closeOnSelect: true,
+                onSelect: () => onOrderChange?.("grouped"),
+              },
+              {
+                id: "order-chronological",
+                label: "Strict date order",
+                active: timelineOrder === "chronological",
+                closeOnSelect: true,
+                onSelect: () => onOrderChange?.("chronological"),
+              },
+            ],
+          },
+        ]
+      : []),
     ...(hasPRFilters && filter
       ? [
           {
@@ -125,7 +156,7 @@
 <FilterDropdown
   label="View"
   detail={currentViewDetail}
-  active={viewMode === "compact" || activeFilterCount > 0}
+  active={viewMode === "compact" || timelineOrder === "chronological" || activeFilterCount > 0}
   badgeCount={activeFilterCount}
   title={hasPRFilters
     ? "View and filter activity"

--- a/packages/ui/src/components/detail/DetailActivityViewMenu.svelte
+++ b/packages/ui/src/components/detail/DetailActivityViewMenu.svelte
@@ -69,18 +69,13 @@
             title: "Order",
             items: [
               {
-                id: "order-grouped",
-                label: "Grouped",
-                active: timelineOrder === "grouped",
-                closeOnSelect: true,
-                onSelect: () => onOrderChange?.("grouped"),
-              },
-              {
                 id: "order-chronological",
                 label: "Strict date order",
                 active: timelineOrder === "chronological",
-                closeOnSelect: true,
-                onSelect: () => onOrderChange?.("chronological"),
+                onSelect: () =>
+                  onOrderChange?.(
+                    timelineOrder === "chronological" ? "grouped" : "chronological",
+                  ),
               },
             ],
           },

--- a/packages/ui/src/components/detail/EventTimeline.svelte
+++ b/packages/ui/src/components/detail/EventTimeline.svelte
@@ -201,6 +201,7 @@
     threadID?: string | undefined;
     reviewThread?: TimelineReviewThread | undefined;
     replies: Array<PREvent | IssueEvent>;
+    obsoleteCommits?: Array<PREvent | IssueEvent> | undefined;
   };
 
   type TimelineReviewThread = {
@@ -600,6 +601,53 @@
     return orderEventsForForcePushBoundaries(sourceEvents, orderingSourceEvents);
   }
 
+  // A commit is obsolete once a later force push replaced the lineage it
+  // belongs to; the cutoff is the newest commit any force-push generation
+  // starts after. Grouped mode already communicates this by sorting those
+  // commits below their force-push row, so the cutoff only drives the
+  // collapsed runs in strict date order.
+  function obsoleteCommitCutoff(orderingSourceEvents: Array<PREvent | IssueEvent>): number {
+    const generations = buildForcePushGenerations(buildForcePushBoundaries(orderingSourceEvents));
+    return generations.reduce(
+      (cutoff, generation) => Math.max(cutoff, generation.effectiveStartAfterCommitID),
+      0,
+    );
+  }
+
+  function collapseObsoleteCommitEntries(
+    entries: TimelineEntry[],
+    orderingSourceEvents: Array<PREvent | IssueEvent>,
+    keyPrefix: string,
+  ): TimelineEntry[] {
+    const cutoff = obsoleteCommitCutoff(orderingSourceEvents);
+    if (cutoff <= 0) return entries;
+
+    const collapsed: TimelineEntry[] = [];
+    let run: Array<PREvent | IssueEvent> = [];
+    const flushRun = (): void => {
+      const [newest] = run;
+      if (newest === undefined) return;
+      collapsed.push({
+        key: `${keyPrefix}obsolete-${newest.ID}`,
+        event: newest,
+        obsoleteCommits: run,
+        replies: [],
+      });
+      run = [];
+    };
+
+    for (const entry of entries) {
+      if (entry.event.EventType === "commit" && commitOrder(entry.event) <= cutoff) {
+        run = [...run, entry.event];
+        continue;
+      }
+      flushRun();
+      collapsed.push(entry);
+    }
+    flushRun();
+    return collapsed;
+  }
+
   function buildTimelineEntries(
     sourceEvents: Array<PREvent | IssueEvent>,
     orderingSourceEvents: Array<PREvent | IssueEvent>,
@@ -661,7 +709,9 @@
       });
     }
 
-    return entries;
+    return timelineOrder === "chronological"
+      ? collapseObsoleteCommitEntries(entries, orderingSourceEvents, "")
+      : entries;
   }
 
   const displayEvents = $derived(collapseLifecycleTransitions(events));
@@ -676,12 +726,15 @@
     sourceEvents: Array<PREvent | IssueEvent>,
     orderingSourceEvents: Array<PREvent | IssueEvent>,
   ): TimelineEntry[] {
-    return orderEventsForDisplay(sourceEvents, orderingSourceEvents).map((event) => ({
+    const entries = orderEventsForDisplay(sourceEvents, orderingSourceEvents).map((event) => ({
       key: `compact-event-${event.ID}`,
       event,
       reviewThread: reviewThreadFor(event) ?? undefined,
       replies: [],
     }));
+    return timelineOrder === "chronological"
+      ? collapseObsoleteCommitEntries(entries, orderingSourceEvents, "compact-")
+      : entries;
   }
 
   function isCompactEvent(eventType: string): boolean {
@@ -939,6 +992,7 @@
   let deleteError = $state<string | null>(null);
   let collapsedThreads = $state<string[]>([]);
   let expandedCompactRows = $state<string[]>([]);
+  let expandedObsoleteGroups = $state<string[]>([]);
   let replyingThreadID = $state<string | null>(null);
   let replyingEntryKey = $state<string | null>(null);
   let replyDraft = $state("");
@@ -1074,6 +1128,22 @@
     collapsedThreads = collapsedThreads.includes(id)
       ? collapsedThreads.filter((item) => item !== id)
       : [...collapsedThreads, id];
+  }
+
+  function isObsoleteGroupExpanded(entry: TimelineEntry): boolean {
+    return expandedObsoleteGroups.includes(entry.key);
+  }
+
+  function toggleObsoleteGroup(entry: TimelineEntry): void {
+    expandedObsoleteGroups = expandedObsoleteGroups.includes(entry.key)
+      ? expandedObsoleteGroups.filter((item) => item !== entry.key)
+      : [...expandedObsoleteGroups, entry.key];
+  }
+
+  function obsoleteGroupSummary(commits: Array<PREvent | IssueEvent>): string {
+    return commits.length === 1
+      ? "1 commit replaced by a later force push"
+      : `${commits.length} commits replaced by a later force push`;
   }
 
   function compactEntryCanExpand(entry: TimelineEntry): boolean {
@@ -1689,6 +1759,45 @@
       {@const event = entry.event}
       {@const targetID = replyTargetID(entry)}
       {@const hasReplyOnlyAction = entry.replies.length === 0 && canReplyToThread(entry)}
+      {#if entry.obsoleteCommits}
+        {@const obsoleteExpanded = isObsoleteGroupExpanded(entry)}
+        <TimelineItem tone="muted" class="event--compact">
+          <Card level="default" padding="sm" class="event-card--compact event-card--obsolete-group">
+            <button
+              class="obsolete-group-row compact-event-toggle"
+              type="button"
+              onclick={() => toggleObsoleteGroup(entry)}
+              aria-expanded={obsoleteExpanded}
+              title={obsoleteExpanded ? "Collapse obsolete commits" : "Expand obsolete commits"}
+            >
+              <span class="compact-event-expander" aria-hidden="true">
+                {#if obsoleteExpanded}
+                  <ChevronDownIcon size={14} />
+                {:else}
+                  <ChevronRightIcon size={14} />
+                {/if}
+              </span>
+              <span class="event-type obsolete-group-type">Obsolete</span>
+              <span class="compact-event-summary">{obsoleteGroupSummary(entry.obsoleteCommits)}</span>
+              <span class="event-time compact-event-time">{formatRelativeTime(event.CreatedAt)}</span>
+            </button>
+            {#if obsoleteExpanded}
+              <div class="obsolete-commit-list">
+                {#each entry.obsoleteCommits as commit (commit.ID)}
+                  <div class="obsolete-commit-row">
+                    {#if commit.Author}
+                      <span class="event-author">{commit.Author}</span>
+                    {/if}
+                    <span class="commit-sha">{shortCommit(commit.Summary)}</span>
+                    <span class="commit-title">{commitTitle(commit.Body)}</span>
+                    <span class="event-time">{formatRelativeTime(commit.CreatedAt)}</span>
+                  </div>
+                {/each}
+              </div>
+            {/if}
+          </Card>
+        </TimelineItem>
+      {:else}
       <TimelineItem
         tone={eventTimelineTone(event.EventType)}
         class={activityViewMode === "compact" || isCompactEvent(event.EventType) ? "event--compact" : ""}
@@ -1940,6 +2049,7 @@
           </CommentCard>
         {/if}
       </TimelineItem>
+      {/if}
       {/each}
     </Timeline>
   </div>
@@ -2181,6 +2291,38 @@
   .commit-body-details {
     margin-top: var(--focus-detail-space-xs, 7px);
     padding-right: var(--focus-detail-space-sm, 10px);
+  }
+
+  .obsolete-group-row {
+    display: grid;
+    grid-template-columns: 15px max-content minmax(0, 1fr) max-content;
+    align-items: center;
+    gap: var(--focus-detail-space-xs, 6px);
+    min-width: 0;
+  }
+
+  .obsolete-group-type {
+    color: var(--text-muted);
+  }
+
+  .obsolete-commit-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--focus-detail-space-xs, 4px);
+    margin-top: var(--focus-detail-space-sm, 8px);
+    padding-top: var(--focus-detail-space-sm, 8px);
+    border-top: 1px solid var(--border-muted);
+  }
+
+  .obsolete-commit-row {
+    display: flex;
+    align-items: center;
+    gap: var(--focus-detail-space-sm, 8px);
+    min-width: 0;
+  }
+
+  .obsolete-commit-row .commit-title {
+    color: var(--text-secondary);
   }
 
   .system-event-summary,

--- a/packages/ui/src/components/detail/EventTimeline.svelte
+++ b/packages/ui/src/components/detail/EventTimeline.svelte
@@ -11,7 +11,10 @@
   import { untrack } from "svelte";
   import { slide } from "svelte/transition";
   import type { IssueEvent, PREvent } from "../../api/types.js";
-  import type { DetailActivityViewMode } from "../../stores/detail-activity-view.svelte.js";
+  import type {
+    DetailActivityViewMode,
+    DetailTimelineOrder,
+  } from "../../stores/detail-activity-view.svelte.js";
   import { pushModalFrame } from "../../stores/keyboard/modal-stack.svelte.js";
   import type { StoreInstances } from "../../types.js";
   import { renderMarkdown, renderMarkdownSync } from "../../utils/markdown.js";
@@ -61,6 +64,7 @@
     filtered?: boolean;
     showCommitDetails?: boolean;
     activityViewMode?: DetailActivityViewMode;
+    timelineOrder?: DetailTimelineOrder;
     onEditComment?: ((event: PREvent | IssueEvent, body: string) => Promise<boolean>) | undefined;
     onDeleteComment?: ((event: PREvent | IssueEvent) => Promise<string | null>) | undefined;
     onApplySuggestion?: ((input: ApplySuggestionRequest) => Promise<boolean | SuggestionApplyResult>) | undefined;
@@ -87,6 +91,7 @@
     filtered = false,
     showCommitDetails = true,
     activityViewMode = "normal",
+    timelineOrder = "grouped",
     onEditComment,
     onDeleteComment,
     onApplySuggestion,
@@ -582,11 +587,24 @@
     });
   }
 
+  function orderEventsForDisplay(
+    sourceEvents: Array<PREvent | IssueEvent>,
+    orderingSourceEvents: Array<PREvent | IssueEvent>,
+  ): Array<PREvent | IssueEvent> {
+    // Strict date order keeps events at their own timestamps instead of
+    // clamping re-pushed commits into force-push generations, so recent
+    // comments stay above older commit batches.
+    if (timelineOrder === "chronological") {
+      return [...sourceEvents].sort(compareEventsDescending);
+    }
+    return orderEventsForForcePushBoundaries(sourceEvents, orderingSourceEvents);
+  }
+
   function buildTimelineEntries(
     sourceEvents: Array<PREvent | IssueEvent>,
     orderingSourceEvents: Array<PREvent | IssueEvent>,
   ): TimelineEntry[] {
-    const orderedEvents = orderEventsForForcePushBoundaries(sourceEvents, orderingSourceEvents);
+    const orderedEvents = orderEventsForDisplay(sourceEvents, orderingSourceEvents);
     const threads: Array<{ id: string; events: Array<PREvent | IssueEvent> }> = [];
 
     for (const event of orderedEvents) {
@@ -658,7 +676,7 @@
     sourceEvents: Array<PREvent | IssueEvent>,
     orderingSourceEvents: Array<PREvent | IssueEvent>,
   ): TimelineEntry[] {
-    return orderEventsForForcePushBoundaries(sourceEvents, orderingSourceEvents).map((event) => ({
+    return orderEventsForDisplay(sourceEvents, orderingSourceEvents).map((event) => ({
       key: `compact-event-${event.ID}`,
       event,
       reviewThread: reviewThreadFor(event) ?? undefined,

--- a/packages/ui/src/components/detail/EventTimeline.test.ts
+++ b/packages/ui/src/components/detail/EventTimeline.test.ts
@@ -1739,6 +1739,13 @@ describe("EventTimeline", () => {
         Body: "old C3 before rebase",
         CreatedAt: "2024-06-01T10:02:00Z",
       }),
+      makeEvent({
+        ID: 2,
+        EventType: "commit",
+        Summary: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        Body: "old C2 before rebase",
+        CreatedAt: "2024-06-01T10:01:00Z",
+      }),
     ];
 
     const grouped = render(EventTimeline, { props: { events } });
@@ -1746,6 +1753,7 @@ describe("EventTimeline", () => {
     expect(groupedText.indexOf("new C3 after rebase")).toBeLessThan(
       groupedText.indexOf("comment between commits and push"),
     );
+    expect(groupedText).toContain("old C3 before rebase");
     cleanup();
 
     const chronological = render(EventTimeline, {
@@ -1754,7 +1762,65 @@ describe("EventTimeline", () => {
     const text = chronological.container.textContent ?? "";
     expect(text.indexOf("ccccccc -> fffffff")).toBeLessThan(text.indexOf("comment between commits and push"));
     expect(text.indexOf("comment between commits and push")).toBeLessThan(text.indexOf("new C3 after rebase"));
-    expect(text.indexOf("new C3 after rebase")).toBeLessThan(text.indexOf("old C3 before rebase"));
+    expect(text).toContain("2 commits replaced by a later force push");
+    expect(text).not.toContain("old C3 before rebase");
+    expect(text).not.toContain("old C2 before rebase");
+  });
+
+  it("expands collapsed obsolete commits on demand in strict date order", async () => {
+    const oldHead = "cccccccccccccccccccccccccccccccccccccccc";
+    const newHead = "ffffffffffffffffffffffffffffffffffffffff";
+    const { container } = render(EventTimeline, {
+      props: {
+        events: [
+          makeEvent({
+            ID: 7,
+            EventType: "force_push",
+            Author: "alice",
+            Summary: "ccccccc -> fffffff",
+            CreatedAt: "2024-06-01T12:00:00Z",
+            MetadataJSON: JSON.stringify({
+              before_sha: oldHead,
+              after_sha: newHead,
+            }),
+          }),
+          makeEvent({
+            ID: 6,
+            EventType: "commit",
+            Summary: newHead,
+            Body: "new C3 after rebase",
+            CreatedAt: "2024-06-01T10:03:00Z",
+          }),
+          makeEvent({
+            ID: 3,
+            EventType: "commit",
+            Summary: oldHead,
+            Body: "old C3 before rebase",
+            CreatedAt: "2024-06-01T10:02:00Z",
+          }),
+          makeEvent({
+            ID: 2,
+            EventType: "commit",
+            Summary: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            Body: "old C2 before rebase",
+            CreatedAt: "2024-06-01T10:01:00Z",
+          }),
+        ],
+        timelineOrder: "chronological",
+      },
+    });
+
+    const toggle = screen.getByRole("button", { name: /obsolete/i });
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+
+    await fireEvent.click(toggle);
+
+    const text = container.textContent ?? "";
+    expect(text.indexOf("old C3 before rebase")).toBeLessThan(text.indexOf("old C2 before rebase"));
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+
+    await fireEvent.click(toggle);
+    expect(container.textContent ?? "").not.toContain("old C3 before rebase");
   });
 
   it("keeps strictly chronological order in compact view when timelineOrder is chronological", () => {
@@ -1788,6 +1854,13 @@ describe("EventTimeline", () => {
             Body: "new C3 after rebase",
             CreatedAt: "2024-06-01T10:03:00Z",
           }),
+          makeEvent({
+            ID: 3,
+            EventType: "commit",
+            Summary: oldHead,
+            Body: "old C3 before rebase",
+            CreatedAt: "2024-06-01T10:02:00Z",
+          }),
         ],
         activityViewMode: "compact",
         timelineOrder: "chronological",
@@ -1797,6 +1870,8 @@ describe("EventTimeline", () => {
     const text = container.textContent ?? "";
     expect(text.indexOf("ccccccc -> fffffff")).toBeLessThan(text.indexOf("comment between commits and push"));
     expect(text.indexOf("comment between commits and push")).toBeLessThan(text.indexOf("new C3 after rebase"));
+    expect(text).toContain("1 commit replaced by a later force push");
+    expect(text).not.toContain("old C3 before rebase");
   });
 
   it("orders force-push generations from commit ancestry even when database IDs are not generation order", () => {

--- a/packages/ui/src/components/detail/EventTimeline.test.ts
+++ b/packages/ui/src/components/detail/EventTimeline.test.ts
@@ -1703,6 +1703,102 @@ describe("EventTimeline", () => {
     expect(text.indexOf("ccccccc -> fffffff")).toBeLessThan(text.indexOf("old C2 before rebase"));
   });
 
+  it("keeps strictly chronological order when timelineOrder is chronological", () => {
+    const oldHead = "cccccccccccccccccccccccccccccccccccccccc";
+    const newHead = "ffffffffffffffffffffffffffffffffffffffff";
+    const events = [
+      makeEvent({
+        ID: 7,
+        EventType: "force_push",
+        Author: "alice",
+        Summary: "ccccccc -> fffffff",
+        CreatedAt: "2024-06-01T12:00:00Z",
+        MetadataJSON: JSON.stringify({
+          before_sha: oldHead,
+          after_sha: newHead,
+        }),
+      }),
+      makeEvent({
+        ID: 4,
+        EventType: "issue_comment",
+        Author: "bob",
+        Body: "comment between commits and push",
+        CreatedAt: "2024-06-01T11:00:00Z",
+      }),
+      makeEvent({
+        ID: 6,
+        EventType: "commit",
+        Summary: newHead,
+        Body: "new C3 after rebase",
+        CreatedAt: "2024-06-01T10:03:00Z",
+      }),
+      makeEvent({
+        ID: 3,
+        EventType: "commit",
+        Summary: oldHead,
+        Body: "old C3 before rebase",
+        CreatedAt: "2024-06-01T10:02:00Z",
+      }),
+    ];
+
+    const grouped = render(EventTimeline, { props: { events } });
+    const groupedText = grouped.container.textContent ?? "";
+    expect(groupedText.indexOf("new C3 after rebase")).toBeLessThan(
+      groupedText.indexOf("comment between commits and push"),
+    );
+    cleanup();
+
+    const chronological = render(EventTimeline, {
+      props: { events, timelineOrder: "chronological" },
+    });
+    const text = chronological.container.textContent ?? "";
+    expect(text.indexOf("ccccccc -> fffffff")).toBeLessThan(text.indexOf("comment between commits and push"));
+    expect(text.indexOf("comment between commits and push")).toBeLessThan(text.indexOf("new C3 after rebase"));
+    expect(text.indexOf("new C3 after rebase")).toBeLessThan(text.indexOf("old C3 before rebase"));
+  });
+
+  it("keeps strictly chronological order in compact view when timelineOrder is chronological", () => {
+    const oldHead = "cccccccccccccccccccccccccccccccccccccccc";
+    const newHead = "ffffffffffffffffffffffffffffffffffffffff";
+    const { container } = render(EventTimeline, {
+      props: {
+        events: [
+          makeEvent({
+            ID: 7,
+            EventType: "force_push",
+            Author: "alice",
+            Summary: "ccccccc -> fffffff",
+            CreatedAt: "2024-06-01T12:00:00Z",
+            MetadataJSON: JSON.stringify({
+              before_sha: oldHead,
+              after_sha: newHead,
+            }),
+          }),
+          makeEvent({
+            ID: 4,
+            EventType: "issue_comment",
+            Author: "bob",
+            Body: "comment between commits and push",
+            CreatedAt: "2024-06-01T11:00:00Z",
+          }),
+          makeEvent({
+            ID: 6,
+            EventType: "commit",
+            Summary: newHead,
+            Body: "new C3 after rebase",
+            CreatedAt: "2024-06-01T10:03:00Z",
+          }),
+        ],
+        activityViewMode: "compact",
+        timelineOrder: "chronological",
+      },
+    });
+
+    const text = container.textContent ?? "";
+    expect(text.indexOf("ccccccc -> fffffff")).toBeLessThan(text.indexOf("comment between commits and push"));
+    expect(text.indexOf("comment between commits and push")).toBeLessThan(text.indexOf("new C3 after rebase"));
+  });
+
   it("orders force-push generations from commit ancestry even when database IDs are not generation order", () => {
     const oldHead = "cccccccccccccccccccccccccccccccccccccccc";
     const newHead = "ffffffffffffffffffffffffffffffffffffffff";

--- a/packages/ui/src/components/detail/PullDetail.svelte
+++ b/packages/ui/src/components/detail/PullDetail.svelte
@@ -2831,6 +2831,8 @@
           <DetailActivityViewMenu
             viewMode={detailActivityView.getMode()}
             onViewChange={(mode) => detailActivityView.setMode(mode)}
+            timelineOrder={detailActivityView.getOrder()}
+            onOrderChange={(order) => detailActivityView.setOrder(order)}
             filter={timelineFilter}
             onFilterChange={updateTimelineFilter}
           />
@@ -2851,6 +2853,7 @@
             filtered={hasActiveTimelineFilters}
             showCommitDetails={timelineFilter.showCommitDetails}
             activityViewMode={detailActivityView.getMode()}
+            timelineOrder={detailActivityView.getOrder()}
             onEditComment={capabilities.comment_mutation && !stalePR && !editCommentGate.unavailable
               ? editTimelineComment
               : undefined}

--- a/packages/ui/src/components/detail/prTimelineFilter.test.ts
+++ b/packages/ui/src/components/detail/prTimelineFilter.test.ts
@@ -359,7 +359,7 @@ describe("DetailActivityViewMenu", () => {
     expect(screen.getByRole("button", { name: /hide bot activity/i })).toBeTruthy();
   });
 
-  it("offers timeline order options when order state is provided", async () => {
+  it("toggles strict date order on from a single order row", async () => {
     const onOrderChange = vi.fn();
     render(DetailActivityViewMenu, {
       props: {
@@ -376,10 +376,10 @@ describe("DetailActivityViewMenu", () => {
     await fireEvent.click(screen.getByRole("button", { name: /strict date order/i }));
 
     expect(onOrderChange).toHaveBeenCalledWith("chronological");
-    expect(document.querySelector(".kit-filter-dropdown__panel")).toBeNull();
+    expect(document.querySelector(".kit-filter-dropdown__panel")).toBeTruthy();
   });
 
-  it("switches back to grouped order from the order section", async () => {
+  it("toggles strict date order back off from the same row", async () => {
     const onOrderChange = vi.fn();
     render(DetailActivityViewMenu, {
       props: {
@@ -393,12 +393,15 @@ describe("DetailActivityViewMenu", () => {
     });
 
     await fireEvent.click(screen.getByRole("button", { name: /view/i }));
-    await fireEvent.click(screen.getByRole("button", { name: /grouped/i }));
+
+    const orderButtons = screen.getAllByRole("button", { name: /strict date order/i });
+    expect(orderButtons.length).toBe(1);
+    await fireEvent.click(orderButtons[0]!);
 
     expect(onOrderChange).toHaveBeenCalledWith("grouped");
   });
 
-  it("omits timeline order options when order state is not provided", async () => {
+  it("omits the timeline order toggle when order state is not provided", async () => {
     render(DetailActivityViewMenu, {
       props: {
         viewMode: "normal",
@@ -409,6 +412,5 @@ describe("DetailActivityViewMenu", () => {
     await fireEvent.click(screen.getByRole("button", { name: /view/i }));
 
     expect(screen.queryByRole("button", { name: /strict date order/i })).toBeNull();
-    expect(screen.queryByRole("button", { name: /grouped/i })).toBeNull();
   });
 });

--- a/packages/ui/src/components/detail/prTimelineFilter.test.ts
+++ b/packages/ui/src/components/detail/prTimelineFilter.test.ts
@@ -358,4 +358,57 @@ describe("DetailActivityViewMenu", () => {
     expect(screen.getByRole("button", { name: /force pushes/i })).toBeTruthy();
     expect(screen.getByRole("button", { name: /hide bot activity/i })).toBeTruthy();
   });
+
+  it("offers timeline order options when order state is provided", async () => {
+    const onOrderChange = vi.fn();
+    render(DetailActivityViewMenu, {
+      props: {
+        viewMode: "normal",
+        onViewChange: vi.fn(),
+        filter: DEFAULT_PR_TIMELINE_FILTER,
+        onFilterChange: vi.fn(),
+        timelineOrder: "grouped",
+        onOrderChange,
+      },
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: /view/i }));
+    await fireEvent.click(screen.getByRole("button", { name: /strict date order/i }));
+
+    expect(onOrderChange).toHaveBeenCalledWith("chronological");
+    expect(document.querySelector(".kit-filter-dropdown__panel")).toBeNull();
+  });
+
+  it("switches back to grouped order from the order section", async () => {
+    const onOrderChange = vi.fn();
+    render(DetailActivityViewMenu, {
+      props: {
+        viewMode: "normal",
+        onViewChange: vi.fn(),
+        filter: DEFAULT_PR_TIMELINE_FILTER,
+        onFilterChange: vi.fn(),
+        timelineOrder: "chronological",
+        onOrderChange,
+      },
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: /view/i }));
+    await fireEvent.click(screen.getByRole("button", { name: /grouped/i }));
+
+    expect(onOrderChange).toHaveBeenCalledWith("grouped");
+  });
+
+  it("omits timeline order options when order state is not provided", async () => {
+    render(DetailActivityViewMenu, {
+      props: {
+        viewMode: "normal",
+        onViewChange: vi.fn(),
+      },
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: /view/i }));
+
+    expect(screen.queryByRole("button", { name: /strict date order/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /grouped/i })).toBeNull();
+  });
 });

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -99,7 +99,7 @@ export type { RepoBrowserStoreOptions } from "./stores/repo-browser.svelte.js";
 export { createDiffReviewDraftStore } from "./stores/diff-review-draft.svelte.js";
 export { createGroupingStore } from "./stores/grouping.svelte.js";
 export { createDetailActivityViewStore } from "./stores/detail-activity-view.svelte.js";
-export type { DetailActivityViewMode } from "./stores/detail-activity-view.svelte.js";
+export type { DetailActivityViewMode, DetailTimelineOrder } from "./stores/detail-activity-view.svelte.js";
 export { classifyPR, groupByWorkflow, workflowGroupOrder, workflowGroupLabels } from "./stores/workflow.svelte.js";
 export type { WorkflowGroup, WorkflowGroupEntry } from "./stores/workflow.svelte.js";
 export { createCollapsedReposStore } from "./stores/collapsedRepos.svelte.js";

--- a/packages/ui/src/stores/detail-activity-view.svelte.test.ts
+++ b/packages/ui/src/stores/detail-activity-view.svelte.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test"
 import { createDetailActivityViewStore } from "./detail-activity-view.svelte.js";
 
 const STORAGE_KEY = "kenn-forge-detail-activity-view";
+const ORDER_STORAGE_KEY = "kenn-forge-detail-timeline-order";
 
 beforeEach(() => {
   localStorage.clear();
@@ -63,5 +64,46 @@ describe("createDetailActivityViewStore", () => {
     const store = createDetailActivityViewStore();
 
     expect(store.getMode()).toBe("normal");
+  });
+
+  it("defaults to grouped timeline order", () => {
+    const store = createDetailActivityViewStore();
+    expect(store.getOrder()).toBe("grouped");
+  });
+
+  it("loads chronological order from localStorage", () => {
+    localStorage.setItem(ORDER_STORAGE_KEY, "chronological");
+
+    const store = createDetailActivityViewStore();
+
+    expect(store.getOrder()).toBe("chronological");
+  });
+
+  it("falls back to grouped for invalid persisted orders", () => {
+    localStorage.setItem(ORDER_STORAGE_KEY, "reverse");
+
+    const store = createDetailActivityViewStore();
+
+    expect(store.getOrder()).toBe("grouped");
+  });
+
+  it("persists valid order changes", () => {
+    const store = createDetailActivityViewStore();
+
+    store.setOrder("chronological");
+
+    expect(store.getOrder()).toBe("chronological");
+    expect(localStorage.getItem(ORDER_STORAGE_KEY)).toBe("chronological");
+  });
+
+  it("keeps in-memory order updates when localStorage writes fail", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("storage unavailable");
+    });
+    const store = createDetailActivityViewStore();
+
+    expect(() => store.setOrder("chronological")).not.toThrow();
+
+    expect(store.getOrder()).toBe("chronological");
   });
 });

--- a/packages/ui/src/stores/detail-activity-view.svelte.ts
+++ b/packages/ui/src/stores/detail-activity-view.svelte.ts
@@ -1,6 +1,8 @@
 export type DetailActivityViewMode = "normal" | "compact";
+export type DetailTimelineOrder = "grouped" | "chronological";
 
 const STORAGE_KEY = "kenn-forge-detail-activity-view";
+const ORDER_STORAGE_KEY = "kenn-forge-detail-timeline-order";
 
 function readFromStorage(): DetailActivityViewMode {
   try {
@@ -11,8 +13,18 @@ function readFromStorage(): DetailActivityViewMode {
   }
 }
 
+function readOrderFromStorage(): DetailTimelineOrder {
+  try {
+    const raw = localStorage.getItem(ORDER_STORAGE_KEY);
+    return raw === "chronological" ? "chronological" : "grouped";
+  } catch {
+    return "grouped";
+  }
+}
+
 export function createDetailActivityViewStore() {
   let mode = $state<DetailActivityViewMode>(readFromStorage());
+  let order = $state<DetailTimelineOrder>(readOrderFromStorage());
 
   function getMode(): DetailActivityViewMode {
     return mode;
@@ -27,9 +39,24 @@ export function createDetailActivityViewStore() {
     }
   }
 
+  function getOrder(): DetailTimelineOrder {
+    return order;
+  }
+
+  function setOrder(value: DetailTimelineOrder): void {
+    order = value;
+    try {
+      localStorage.setItem(ORDER_STORAGE_KEY, value);
+    } catch {
+      // localStorage unavailable.
+    }
+  }
+
   return {
     getMode,
     setMode,
+    getOrder,
+    setOrder,
   };
 }
 


### PR DESCRIPTION
Force pushes group re-pushed commits under their push row in the PR timeline, which can drag a large batch of commits above comments written just before the push and bury the conversation below the fold.

- The Activity View menu gains an Order section with a single **Strict date order** toggle that keeps every event at its own timestamp; the preference persists like the layout mode.
- In strict date order, runs of commits replaced by a later force push collapse into one muted "N commits replaced by a later force push" row, expandable on demand, so restoring chronology does not reintroduce the commit walls.
- Grouped ordering stays the default and is unchanged; the issue timeline is unaffected.

![strict-order-menu.png](https://github.com/user-attachments/assets/17224e5b-7751-4c32-bc25-466a1375e034)

Strict date order with an obsolete run collapsed, then expanded:

![strict-order-timeline.png](https://github.com/user-attachments/assets/d1df8bf8-d418-4c0b-bb2d-9c83fa32eaa6)

![strict-order-expanded.png](https://github.com/user-attachments/assets/622814b3-4ff1-478e-9ebc-3d22614d4363)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sup>generated by a clanker</sup>
