### PR TITLE
fix: keep new-PR discovery alive when the local sync ceiling exhausts

### DIFF
--- a/cmd/e2e-server/main.go
+++ b/cmd/e2e-server/main.go
@@ -1249,7 +1249,7 @@ func buildAppState(
 		Reset:     time.Now().Add(40 * time.Minute),
 	})
 
-	budget := ghclient.NewSyncBudget(500)
+	budget := ghclient.NewSyncBudgetWithEssentialReserve(500)
 	budget.Spend(75)
 
 	gitLabIssue, gitLabIssueEvents := gitLabReadOnlyIssueFixture(

--- a/cmd/kenn-forge/provider_startup.go
+++ b/cmd/kenn-forge/provider_startup.go
@@ -333,7 +333,7 @@ func buildProviderStartup(
 			}
 			if budgetPerHour > 0 {
 				if _, ok := startup.budgets[rateKey]; !ok {
-					startup.budgets[rateKey] = github.NewSyncBudget(budgetPerHour)
+					startup.budgets[rateKey] = github.NewSyncBudgetWithEssentialReserve(budgetPerHour)
 				}
 			}
 		}
@@ -808,7 +808,7 @@ func ensureGitHubIdentityRuntime(
 		),
 	}
 	if budgetPerHour > 0 {
-		runtime.budget = github.NewSyncBudget(budgetPerHour)
+		runtime.budget = github.NewSyncBudgetWithEssentialReserve(budgetPerHour)
 		runtime.rest.SetOnWindowReset(runtime.budget.Reset)
 	}
 	startup.githubIdentities[key] = runtime

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -376,7 +376,10 @@ response never overwrites an App installation pool
 - List discovery (open PR/issue lists, repo identity resolve) spends the local
   ceiling's essential reserve; optional spend (details, fast-sync, archive)
   stops at limit minus reserve so it can never starve discovery
-  (`internal/github/budget.go::TrySpendEssential`).
+  (`internal/github/budget.go::TrySpendEssential`). Per-item enrichment nested
+  inside an essential list fetch is demoted back to optional and degrades on
+  refusal instead of failing the list
+  (`internal/github/budget_transport.go::WithoutEssentialSyncBudget`).
 - A list fetch refused by the local ceiling must not evict list ETags: nothing
   reached the wire, so eviction would only turn recovery cycles into
   unconditional refetches that deepen the exhaustion

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -234,6 +234,12 @@ fallback repository listing.
 - Updated issue scans query one second before the durable watermark while keeping cursor identity bound to the original boundary. Updated pull-request scans run newest-first across the same overlap. (`internal/github/pages.go::ListIssuesPage`, `internal/github/pages.go::ListMergeRequestsPage`)
 - Durable pull-request inventory bypasses the process-local list ETag cache. Archive cursors require response bodies, so a bodyless `304 Not Modified` must not turn an unchanged maintenance scan into a retryable failure. (`internal/github/pages.go::liveClient.ListInventoryPullRequestsPage`)
 - Repository probes classify only authentication/access/not-found responses; transient probe failures remain retryable and non-destructive. Issue and pull-request lookups compare the response repository with the requested source identity so transfers become moved outcomes instead of source-owned snapshots. (`internal/github/pages.go::archiveRepositoryProbeError`, `internal/github/pages.go::githubArchiveDestination`)
+- A previously-open issue whose GitHub-classified lookup is a true removal
+  (not_found, no destination) is tombstoned closed locally; otherwise it would
+  fail every cycle forever. Transfers and provider-neutral bare 404s (GitLab
+  hides inaccessible items behind 404) keep failing the cycle so maintainers
+  see them in repo sync health
+  (`internal/github/sync.go::tombstoneRemovedIssue`).
 - Archive REST and GraphQL failures must preserve typed authentication and reset-aware rate-limit errors so scheduling defers rather than hot-looping generic retries. (`internal/github/pages.go::archiveTransportError`)
 - GitHub archive code owns historical identity inventory only; hydration must invoke ordinary item sync instead of adding archive-specific lookup, normalization, or persistence. (`internal/github/pages.go::ListIssuesPage`, `internal/github/sync.go::SyncArchiveItem`)
 - Archive item hydration bypasses persisted parent-detail ETags; an unchanged parent representation does not prove that legacy lifecycle timelines are complete. (`internal/github/sync.go::SyncArchiveItem`)
@@ -367,6 +373,14 @@ response never overwrites an App installation pool
 - Background admission gates on the routed credential's own reserve; the local
   `sync_budget_per_hour` ceiling is separate and is reported apart from provider
   quota (`internal/github/sync.go::backgroundQuotaAvailability`).
+- List discovery (open PR/issue lists, repo identity resolve) spends the local
+  ceiling's essential reserve; optional spend (details, fast-sync, archive)
+  stops at limit minus reserve so it can never starve discovery
+  (`internal/github/budget.go::TrySpendEssential`).
+- A list fetch refused by the local ceiling must not evict list ETags: nothing
+  reached the wire, so eviction would only turn recovery cycles into
+  unconditional refetches that deepen the exhaustion
+  (`internal/github/sync.go::indexSyncRepo`).
 - Archive pacing uses the smaller of the local hourly surplus, the routed
   credential's paced required-resource quota, and its current remaining
   headroom after the provider reserve; a high local ceiling must not enlarge

--- a/internal/github/budget.go
+++ b/internal/github/budget.go
@@ -40,8 +40,15 @@ func detailWorstCaseAttemptCost(kind platform.Kind, itemType QueueItemType) int 
 // counted requests before any wire attempt, so no provider response — and
 // therefore no provider-driven reset — can arrive to release it.
 type SyncBudget struct {
-	mu                   sync.Mutex
-	limit                int
+	mu    sync.Mutex
+	limit int
+	// reserve is the slice of limit held back for essential spend (the
+	// list fetches that discover new and closed items). Optional
+	// background work — detail refreshes, fast-sync, archive — refuses
+	// beyond limit-reserve so it can never starve discovery within the
+	// configured ceiling. Zero unless constructed with
+	// NewSyncBudgetWithEssentialReserve.
+	reserve              int
 	spent                int
 	archiveSpent         int
 	providerArchiveSpent map[providerArchiveWindow]int
@@ -69,6 +76,41 @@ func NewSyncBudget(limit int) *SyncBudget {
 	}
 }
 
+// essentialReserveDenominator sizes the essential reserve as a fraction of
+// the configured hourly limit: limit/10. With steady-state list fetches
+// riding warm ETags (304s are refunded), a tenth of the ceiling comfortably
+// covers the lists that actually changed plus transient in-flight spend.
+const essentialReserveDenominator = 10
+
+// NewSyncBudgetWithEssentialReserve returns a budget that holds back a
+// slice of the hourly limit for essential spend (list discovery). Optional
+// background work refuses beyond limit minus the reserve; TrySpendEssential
+// may spend up to the full limit.
+func NewSyncBudgetWithEssentialReserve(limit int) *SyncBudget {
+	b := NewSyncBudget(limit)
+	b.reserve = limit / essentialReserveDenominator
+	return b
+}
+
+// TrySpendEssential is TrySpend for essential requests: it may consume the
+// reserved headroom that optional spend cannot touch.
+func (b *SyncBudget) TrySpendEssential(n int) (BudgetWindow, bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.rollLocked()
+	if n < 0 || b.spent+n > b.limit {
+		return 0, false
+	}
+	b.spent += n
+	return b.window, true
+}
+
+// optionalLimitLocked is the ceiling for non-essential spend. Must be
+// called with mu held.
+func (b *SyncBudget) optionalLimitLocked() int {
+	return b.limit - b.reserve
+}
+
 // rollLocked clears spend once the local hourly window has elapsed.
 // Must be called with mu held.
 func (b *SyncBudget) rollLocked() {
@@ -86,7 +128,7 @@ func (b *SyncBudget) CanSpend(n int) bool {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.rollLocked()
-	return b.spent+n <= b.limit
+	return b.spent+n <= b.optionalLimitLocked()
 }
 
 // TrySpend atomically checks and increments the budget. It reports whether the
@@ -96,7 +138,7 @@ func (b *SyncBudget) TrySpend(n int) (BudgetWindow, bool) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.rollLocked()
-	if n < 0 || b.spent+n > b.limit {
+	if n < 0 || b.spent+n > b.optionalLimitLocked() {
 		return 0, false
 	}
 	b.spent += n
@@ -180,7 +222,7 @@ func (b *SyncBudget) ProviderArchiveSpendAvailable(
 	ceilingRemaining := b.providerArchiveSpendCeiling(
 		now, &window.ResetAt, localLiveFloor, window.Limit, providerReserve,
 	) - providerArchiveSpent
-	localRemaining := b.limit - max(localLiveFloor, 0) - b.spent
+	localRemaining := b.optionalLimitLocked() - max(localLiveFloor, 0) - b.spent
 	providerHeadroom := window.Remaining - max(providerReserve, 0)
 	return max(min(ceilingRemaining, localRemaining, providerHeadroom), 0)
 }
@@ -220,7 +262,7 @@ func (b *SyncBudget) providerArchiveSpendCeiling(
 		return 0
 	}
 	elapsedFraction := 1 - float64(remaining)/float64(time.Hour)
-	localSurplus := b.limit - max(localLiveFloor, 0)
+	localSurplus := b.optionalLimitLocked() - max(localLiveFloor, 0)
 	providerSurplus := providerLimit - max(providerReserve, 0)
 	surplus := min(localSurplus, providerSurplus)
 	if surplus <= 0 {
@@ -249,7 +291,7 @@ func (b *SyncBudget) ArchiveSpendAvailable(now time.Time, resetAt *time.Time, li
 func (b *SyncBudget) LocalArchiveSpendAvailable(liveFloor int) int {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	return max(b.limit-max(liveFloor, 0)-b.spent, 0)
+	return max(b.optionalLimitLocked()-max(liveFloor, 0)-b.spent, 0)
 }
 
 func (b *SyncBudget) SpendArchive(n int) {
@@ -260,7 +302,7 @@ func (b *SyncBudget) TrySpendArchive(n int) (BudgetWindow, bool) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.rollLocked()
-	if n < 0 || b.spent+n > b.limit {
+	if n < 0 || b.spent+n > b.optionalLimitLocked() {
 		return 0, false
 	}
 	b.spent += n
@@ -309,7 +351,7 @@ func (b *SyncBudget) ArchiveSpent() int {
 }
 
 func (b *SyncBudget) archiveSpendCeiling(now time.Time, resetAt *time.Time, liveFloor int) int {
-	if resetAt == nil || liveFloor >= b.limit {
+	if resetAt == nil || liveFloor >= b.optionalLimitLocked() {
 		return 0
 	}
 	remaining := resetAt.Sub(now)
@@ -317,12 +359,12 @@ func (b *SyncBudget) archiveSpendCeiling(now time.Time, resetAt *time.Time, live
 		return 0
 	}
 	elapsedFraction := 1 - float64(remaining)/float64(time.Hour)
-	surplus := b.limit - max(liveFloor, 0)
+	surplus := b.optionalLimitLocked() - max(liveFloor, 0)
 	return int(math.Floor(float64(surplus) * elapsedFraction * elapsedFraction))
 }
 
 func (b *SyncBudget) archiveSpendAvailable(now time.Time, resetAt *time.Time, liveFloor int) int {
 	ceilingRemaining := b.archiveSpendCeiling(now, resetAt, liveFloor) - b.archiveSpent
-	liveRemaining := b.limit - max(liveFloor, 0) - b.spent
+	liveRemaining := b.optionalLimitLocked() - max(liveFloor, 0) - b.spent
 	return max(min(ceilingRemaining, liveRemaining), 0)
 }

--- a/internal/github/budget_test.go
+++ b/internal/github/budget_test.go
@@ -40,6 +40,40 @@ func TestSyncBudgetWorstCase(t *testing.T) {
 	assert.True(t, b.CanSpend(IssueDetailWorstCase)) // 2 <= 5 remaining
 }
 
+func TestSyncBudgetEssentialReserve(t *testing.T) {
+	assert := assert.New(t)
+
+	// A tenth of the limit is held back for essential spend.
+	b := NewSyncBudgetWithEssentialReserve(100)
+	_, ok := b.TrySpend(90)
+	assert.True(ok, "optional spend may use the limit minus the reserve")
+	_, ok = b.TrySpend(1)
+	assert.False(ok, "optional spend must stop at the essential reserve")
+
+	_, ok = b.TrySpendEssential(10)
+	assert.True(ok, "essential spend may consume the reserved headroom")
+	_, ok = b.TrySpendEssential(1)
+	assert.False(ok, "essential spend must stop at the full limit")
+}
+
+func TestSyncBudgetEssentialReserveBoundsArchiveSpend(t *testing.T) {
+	assert := assert.New(t)
+
+	b := NewSyncBudgetWithEssentialReserve(100)
+	_, ok := b.TrySpendArchive(91)
+	assert.False(ok, "archive spend must not consume the essential reserve")
+	_, ok = b.TrySpendArchive(90)
+	assert.True(ok)
+}
+
+func TestSyncBudgetDefaultConstructorHasNoReserve(t *testing.T) {
+	assert := assert.New(t)
+
+	b := NewSyncBudget(100)
+	_, ok := b.TrySpend(100)
+	assert.True(ok, "budgets without an essential reserve keep full-limit spend")
+}
+
 func TestArchiveLiveFloorReservesWorstCaseWireAttempts(t *testing.T) {
 	assert := assert.New(t)
 	assert.Equal(24, archiveLiveFloor(platform.KindGitHub))

--- a/internal/github/budget_transport.go
+++ b/internal/github/budget_transport.go
@@ -215,9 +215,16 @@ func WithEssentialSyncBudget(ctx context.Context) context.Context {
 	return context.WithValue(ctx, essentialSyncBudgetKey{}, true)
 }
 
+// WithoutEssentialSyncBudget demotes a context back to optional spend. List
+// implementations use it for per-item enrichment lookups nested inside an
+// essential list fetch, so enrichment cannot drain the discovery reserve.
+func WithoutEssentialSyncBudget(ctx context.Context) context.Context {
+	return context.WithValue(ctx, essentialSyncBudgetKey{}, false)
+}
+
 func IsEssentialSyncBudgetContext(ctx context.Context) bool {
-	_, ok := ctx.Value(essentialSyncBudgetKey{}).(bool)
-	return ok
+	essential, ok := ctx.Value(essentialSyncBudgetKey{}).(bool)
+	return ok && essential
 }
 
 func WithArchiveSyncBudget(ctx context.Context) context.Context {

--- a/internal/github/budget_transport.go
+++ b/internal/github/budget_transport.go
@@ -204,6 +204,22 @@ func IsSyncBudgetContext(ctx context.Context) bool {
 	return ok
 }
 
+type essentialSyncBudgetKey struct{}
+
+// WithEssentialSyncBudget marks a context whose counted requests may spend
+// the budget's essential reserve. Only the list fetches that discover new
+// and closed items use it: they are the sync's source of truth, and optional
+// work (detail refreshes, fast-sync, archive) must not be able to starve
+// them within the configured ceiling.
+func WithEssentialSyncBudget(ctx context.Context) context.Context {
+	return context.WithValue(ctx, essentialSyncBudgetKey{}, true)
+}
+
+func IsEssentialSyncBudgetContext(ctx context.Context) bool {
+	_, ok := ctx.Value(essentialSyncBudgetKey{}).(bool)
+	return ok
+}
+
 func WithArchiveSyncBudget(ctx context.Context) context.Context {
 	return context.WithValue(WithSyncBudget(ctx), archiveSyncBudgetKey{}, true)
 }
@@ -245,9 +261,12 @@ func (t *budgetTransport) RoundTrip(
 	var window BudgetWindow
 	if counted {
 		var reserved bool
-		if archive {
+		switch {
+		case archive:
 			window, reserved = t.budget.TrySpendArchive(1)
-		} else {
+		case IsEssentialSyncBudgetContext(req.Context()):
+			window, reserved = t.budget.TrySpendEssential(1)
+		default:
 			window, reserved = t.budget.TrySpend(1)
 		}
 		if !reserved {

--- a/internal/github/budget_transport_test.go
+++ b/internal/github/budget_transport_test.go
@@ -137,6 +137,45 @@ func TestBudgetTransport_CountsArchiveContextSeparately(t *testing.T) {
 	assert.True(IsArchiveSyncBudgetContext(req.Context()))
 }
 
+func TestBudgetTransportEssentialContextSpendsReserve(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	budget := NewSyncBudgetWithEssentialReserve(10) // reserve 1
+	bt := WrapSyncBudgetTransport(roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       http.NoBody,
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	}), budget)
+
+	send := func(ctx context.Context) error {
+		req, err := http.NewRequestWithContext(
+			ctx, http.MethodGet,
+			"https://api.github.com/repos/acme/widget/pulls", nil,
+		)
+		require.NoError(err)
+		_, err = bt.RoundTrip(req)
+		return err
+	}
+
+	// Optional counted requests exhaust the optional ceiling (limit-reserve).
+	optionalCtx := WithSyncBudget(t.Context())
+	for range 9 {
+		require.NoError(send(optionalCtx))
+	}
+	require.ErrorIs(send(optionalCtx), platform.ErrSyncBudgetExhausted)
+
+	// An essential list fetch still goes through on the reserve.
+	essentialCtx := WithEssentialSyncBudget(optionalCtx)
+	require.NoError(send(essentialCtx))
+
+	// The full limit still bounds essential spend.
+	assert.ErrorIs(send(essentialCtx), platform.ErrSyncBudgetExhausted)
+}
+
 func TestBudgetTransport_SkipsNotModifiedResponses(t *testing.T) {
 	assert := assert.New(t)
 

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -5164,7 +5164,9 @@ func (s *Syncer) syncRepoIdentity(ctx context.Context, repo RepoRef) (db.RepoIde
 	if err != nil {
 		return db.RepoIdentity{}, nil, err
 	}
-	resolved, err := reader.GetRepository(ctx, platformRepoRef(repo))
+	// A refused identity resolve aborts the whole repo sync before the
+	// list fetches, so it shares their essential budget reserve.
+	resolved, err := reader.GetRepository(WithEssentialSyncBudget(ctx), platformRepoRef(repo))
 	if err != nil {
 		return db.RepoIdentity{}, nil, err
 	}
@@ -5996,6 +5998,12 @@ func (s *Syncer) indexSyncRepo(
 	var attemptedScope failScope
 	var failedScope failScope
 	var disabledScope failScope
+	// Failures caused by the local budget refusing a list fetch before
+	// any wire attempt. They fail the cycle but must not evict list
+	// ETags: nothing upstream was touched, so the cached validators are
+	// still correct and eviction would only add unconditional-refetch
+	// spend to an already-exhausted window.
+	var budgetRefusedScope failScope
 
 	preferNativeStacks := s.preferGitHubNativeStacks.Load() &&
 		repoPlatform(repo) == platform.KindGitHub
@@ -6025,14 +6033,17 @@ func (s *Syncer) indexSyncRepo(
 		}
 		mrProviderAttempted = true
 		var openMRs []platform.MergeRequest
+		// Discovery of new and closed PRs rides the essential budget
+		// reserve so optional background spend cannot starve it.
+		listCtx := WithEssentialSyncBudget(ctx)
 		if nativeReader, ok := mrReader.(interface {
 			ListOpenMergeRequestsWithNativeStackHints(
 				context.Context, platform.RepoRef,
 			) ([]platform.MergeRequest, map[int]*NativeStackHint, error)
 		}); preferNativeStacks && ok {
-			openMRs, nativeStackHints, err = nativeReader.ListOpenMergeRequestsWithNativeStackHints(ctx, platformRef)
+			openMRs, nativeStackHints, err = nativeReader.ListOpenMergeRequestsWithNativeStackHints(listCtx, platformRef)
 		} else {
-			openMRs, err = mrReader.ListOpenMergeRequests(ctx, platformRef)
+			openMRs, err = mrReader.ListOpenMergeRequests(listCtx, platformRef)
 		}
 		mrListBlocked := false
 		if err != nil {
@@ -6043,6 +6054,13 @@ func (s *Syncer) indexSyncRepo(
 			// produced the cached etag.
 			if IsNotModified(err) {
 				prListUnchanged = true
+			} else if errors.Is(err, platform.ErrSyncBudgetExhausted) {
+				// The local budget refused the request before any wire
+				// attempt, so the cached list validators are still
+				// correct. Marking the repo failed would evict them and
+				// force an unconditional refetch next cycle — extra
+				// spend exactly when the budget is already exhausted.
+				return fmt.Errorf("list open PRs: %w", err)
 			} else if s.recordRepositoryFeatureDisabled(
 				repo, platform.RepositoryFeatureMergeRequests, err,
 			) {
@@ -6175,20 +6193,25 @@ func (s *Syncer) indexSyncRepo(
 			ListOpenGitHubIssues(context.Context, platform.RepoRef) ([]*gh.Issue, error)
 		})
 		var issueListErr error
+		// Same essential-reserve treatment as the open-PR list.
+		issueListCtx := WithEssentialSyncBudget(ctx)
 		if rawIssueReader, ok := issueReader.(interface {
 			ListOpenGitHubIssues(context.Context, platform.RepoRef) ([]*gh.Issue, error)
 		}); ok && hasGitHubClient {
 			// Keep GitHub's ETag-gated bulk path so index sync retains the
 			// provider-only fields used by per-item detail refreshes. The raw
 			// reader performs the same contract checks before persistence.
-			ghIssues, issueListErr = rawIssueReader.ListOpenGitHubIssues(ctx, platformRef)
+			ghIssues, issueListErr = rawIssueReader.ListOpenGitHubIssues(issueListCtx, platformRef)
 		} else {
-			openIssues, issueListErr = issueReader.ListOpenIssues(ctx, platformRef)
+			openIssues, issueListErr = issueReader.ListOpenIssues(issueListCtx, platformRef)
 		}
 		if issueListErr != nil {
 			if IsNotModified(issueListErr) {
 				// 304: open issue list unchanged, skip.
 				issueListUnchanged = true
+			} else if errors.Is(issueListErr, platform.ErrSyncBudgetExhausted) {
+				failedScope |= failIssues
+				budgetRefusedScope |= failIssues
 			} else if s.recordRepositoryFeatureDisabled(
 				repo, platform.RepositoryFeatureIssues, issueListErr,
 			) {
@@ -6286,11 +6309,12 @@ func (s *Syncer) indexSyncRepo(
 		mrProbe.clear()
 	}
 
-	if failedScope != 0 {
+	if evictScope := failedScope &^ budgetRefusedScope; evictScope != 0 {
 		// One or more per-item steps failed. Record which paths
 		// failed so the next cycle forces an unconditional refetch
-		// only for the affected list endpoints.
-		s.markRepoFailed(repo, failedScope)
+		// only for the affected list endpoints. Budget-refused list
+		// fetches are excluded: their cached validators are intact.
+		s.markRepoFailed(repo, evictScope)
 	}
 	succeededScope := attemptedScope &^ failedScope &^ disabledScope
 	if succeededScope != 0 {
@@ -9486,6 +9510,14 @@ func (s *Syncer) fetchAndUpdateClosedIssue(
 	// lookup classification so removed, inaccessible, and moved items
 	// surface typed outcomes instead of generic upstream failures.
 	if outcomeErr := s.issueFetchOutcomeError(ctx, repo, number, ghIssue, err); outcomeErr != nil {
+		// A not_found without a destination is a true removal and gets a
+		// terminal local state. A transfer carries the destination and
+		// keeps failing the cycle so the maintainer sees the moved item
+		// in repo sync health instead of it silently closing here.
+		if errors.Is(outcomeErr, platform.ErrNotFound) &&
+			lookupDestination(outcomeErr) == nil {
+			return s.tombstoneRemovedIssue(ctx, repo, repoID, number)
+		}
 		return fmt.Errorf("get closed issue #%d: %w", number, outcomeErr)
 	}
 	if err != nil {
@@ -9514,6 +9546,53 @@ func (s *Syncer) fetchAndUpdateClosedIssue(
 	return s.markClosedLinkedNotificationsDone(ctx)
 }
 
+// lookupDestination extracts the transfer destination from a typed lookup
+// error, or nil when the error carries none (a true removal).
+func lookupDestination(err error) *platform.RepoRef {
+	var pErr *platform.Error
+	if errors.As(err, &pErr) && pErr != nil {
+		return pErr.Destination
+	}
+	return nil
+}
+
+// tombstoneRemovedIssue closes the local copy of a previously-open issue
+// whose provider lookup is explicitly classified as not present (deleted or
+// transferred upstream). Without a terminal state the number stays
+// "previously open" forever: every cycle re-fetches it, fails the repo's
+// issue sync, and spends a lookup plus repository probe on an item that can
+// never resolve.
+func (s *Syncer) tombstoneRemovedIssue(
+	ctx context.Context, repo RepoRef, repoID int64, number int,
+) error {
+	existing, err := s.db.GetIssueByRepoIDAndNumber(ctx, repoID, number)
+	if err != nil {
+		return fmt.Errorf("get removed issue #%d: %w", number, err)
+	}
+	if existing == nil || existing.State != "open" {
+		return nil
+	}
+	now := time.Now().UTC()
+	tombstone := *existing
+	tombstone.State = "closed"
+	if tombstone.ClosedAt == nil {
+		tombstone.ClosedAt = &now
+	}
+	// Upstream is gone; there is no detail left to fetch, so keep the
+	// detail drain from retrying the lookup.
+	if tombstone.DetailFetchedAt == nil {
+		tombstone.DetailFetchedAt = &now
+	}
+	if _, _, _, err := s.commitIssueParentSnapshot(ctx, repo, &tombstone); err != nil {
+		return fmt.Errorf("tombstone removed issue #%d: %w", number, err)
+	}
+	slog.Info("issue removed upstream; closed local copy",
+		"repo", repo.Owner+"/"+repo.Name,
+		"number", number,
+	)
+	return nil
+}
+
 func (s *Syncer) fetchAndUpdateClosedPlatformIssue(
 	ctx context.Context,
 	repo RepoRef,
@@ -9526,6 +9605,10 @@ func (s *Syncer) fetchAndUpdateClosedPlatformIssue(
 	}
 	issue, err := issueReader.GetIssue(ctx, platformRepoRef(repo), number)
 	if err != nil {
+		// No tombstone here: a bare provider 404 is ambiguous on the
+		// neutral path (GitLab hides inaccessible items behind 404), so
+		// the row is retained and the failure surfaces as partial. Only
+		// GitHub's classified lookup can distinguish a true removal.
 		return fmt.Errorf("get closed issue #%d: %w", number, err)
 	}
 	normalized := platform.DBIssue(repoID, issue)

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -12192,13 +12192,19 @@ type partialFailureMock struct {
 	issuesCached         bool
 	prsCached            bool
 	listOpenIssuesFn     func(context.Context, string, string) ([]*gh.Issue, error)
+	listOpenPRsFn        func(context.Context, string, string) ([]*gh.PullRequest, error)
+	listIssueCommentsFn  func(context.Context, string, string, int) ([]*gh.IssueComment, error)
+	listReviewsFn        func(context.Context, string, string, int) ([]*gh.PullRequestReview, error)
 	listOpenPRsErr       error // injected error for ListOpenPullRequests
 	listIssueCommentsErr error // injected error for ListIssueComments
 	listReviewsErr       error // injected error for ListReviews (MR timeline)
 	getIssueErr          error // injected error for GetIssue (closure path)
 }
 
-func (m *partialFailureMock) ListOpenPullRequests(_ context.Context, _, _ string) ([]*gh.PullRequest, error) {
+func (m *partialFailureMock) ListOpenPullRequests(ctx context.Context, owner, repo string) ([]*gh.PullRequest, error) {
+	if m.listOpenPRsFn != nil {
+		return m.listOpenPRsFn(ctx, owner, repo)
+	}
 	if m.listOpenPRsErr != nil {
 		return nil, m.listOpenPRsErr
 	}
@@ -12223,7 +12229,10 @@ func (m *partialFailureMock) ListOpenIssues(ctx context.Context, owner, repo str
 	return m.openIssues, nil
 }
 
-func (m *partialFailureMock) ListIssueComments(_ context.Context, _, _ string, _ int) ([]*gh.IssueComment, error) {
+func (m *partialFailureMock) ListIssueComments(ctx context.Context, owner, repo string, number int) ([]*gh.IssueComment, error) {
+	if m.listIssueCommentsFn != nil {
+		return m.listIssueCommentsFn(ctx, owner, repo, number)
+	}
 	if m.listIssueCommentsErr != nil {
 		return nil, m.listIssueCommentsErr
 	}
@@ -12242,7 +12251,10 @@ func (m *partialFailureMock) ListIssueCommentsIfChanged(
 	return m.ListIssueComments(ctx, owner, repo, number)
 }
 
-func (m *partialFailureMock) ListReviews(_ context.Context, _, _ string, _ int) ([]*gh.PullRequestReview, error) {
+func (m *partialFailureMock) ListReviews(ctx context.Context, owner, repo string, number int) ([]*gh.PullRequestReview, error) {
+	if m.listReviewsFn != nil {
+		return m.listReviewsFn(ctx, owner, repo, number)
+	}
 	if m.listReviewsErr != nil {
 		return nil, m.listReviewsErr
 	}
@@ -12720,6 +12732,244 @@ func TestSyncerMRListFailureMarksRepoFailed(t *testing.T) {
 
 	_, flagged = syncer.failedRepos.Load(repoFailKey(repos[0]))
 	assert.False(flagged, "failedRepos must be cleared after successful retry")
+}
+
+// TestSyncerRemovedIssueTombstonedInsteadOfFailing verifies that an issue
+// deleted upstream (open in a previous cycle, absent from the open list,
+// direct lookup classified not_found) is closed locally instead of failing
+// the repo's issue sync. Without the tombstone the number stays "previously
+// open" forever: every cycle re-fetches it, fails the repo, and spends a
+// lookup plus repository probe on an item that can never resolve.
+func TestSyncerRemovedIssueTombstonedInsteadOfFailing(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	now := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	repos := []RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}}
+
+	issueNumber := 7
+	issueTitle := "will be deleted upstream"
+	issueState := "open"
+	issueURL := "https://github.com/owner/repo/issues/7"
+	issueBody := ""
+	issueID := int64(777)
+	openIssue := &gh.Issue{
+		ID:        &issueID,
+		Number:    &issueNumber,
+		Title:     &issueTitle,
+		State:     &issueState,
+		HTMLURL:   &issueURL,
+		Body:      &issueBody,
+		CreatedAt: makeTimestamp(now),
+		UpdatedAt: makeTimestamp(now),
+	}
+
+	var getIssueCalls atomic.Int32
+	mc := &partialFailureMock{}
+	mc.openPRs = []*gh.PullRequest{}
+	mc.openIssues = []*gh.Issue{openIssue}
+	mc.comments = []*gh.IssueComment{}
+	mc.getIssueFn = func(context.Context, string, string, int) (*gh.Issue, error) {
+		getIssueCalls.Add(1)
+		return nil, &gh.ErrorResponse{
+			Response: &http.Response{StatusCode: http.StatusNotFound},
+			Message:  "Not Found",
+		}
+	}
+
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc},
+		d, nil, repos, time.Minute, nil, nil,
+	)
+
+	// Cycle 1: issue is open and synced.
+	syncer.RunOnce(ctx)
+	issue, err := d.GetIssue(ctx, "github", "github.com", "owner", "repo", issueNumber)
+	require.NoError(err)
+	require.NotNil(issue)
+	require.Equal("open", issue.State)
+
+	// Cycle 2: issue vanished from the open list; direct lookup 404s.
+	mc.openIssues = []*gh.Issue{}
+	mc.issuesCached = false
+	syncer.RunOnce(ctx)
+
+	_, flagged := syncer.failedRepos.Load(repoFailKey(repos[0]))
+	assert.False(flagged,
+		"removed issue must not mark the repo failed")
+	issue, err = d.GetIssue(ctx, "github", "github.com", "owner", "repo", issueNumber)
+	require.NoError(err)
+	require.NotNil(issue, "local copy should remain as a tombstone")
+	assert.Equal("closed", issue.State,
+		"removed issue must be closed locally")
+	callsAfterTombstone := getIssueCalls.Load()
+
+	// Cycle 3: closure detection no longer retries the removed issue.
+	mc.issuesCached = false
+	syncer.RunOnce(ctx)
+	assert.Equal(callsAfterTombstone, getIssueCalls.Load(),
+		"tombstoned issue must not be re-fetched")
+}
+
+// TestSyncerBudgetRefusedPRListSkipsETagEviction verifies that when the
+// open-PR list fetch is refused by the local sync budget ceiling, the repo
+// is not marked for ETag eviction: the refusal happened before any wire
+// attempt, so the cached list validators are still correct and the next
+// cycle must reuse them instead of forcing an unconditional refetch that
+// spends budget the refusal just proved is unavailable.
+func TestSyncerBudgetRefusedPRListSkipsETagEviction(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	now := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	repos := []RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}}
+
+	mc := &partialFailureMock{}
+	mc.openPRs = []*gh.PullRequest{buildOpenPR(1, now)}
+	mc.comments = []*gh.IssueComment{}
+	mc.reviews = []*gh.PullRequestReview{}
+	mc.commits = []*gh.RepositoryCommit{}
+
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc},
+		d, nil, repos, time.Minute, nil, nil,
+	)
+
+	// Cycle 1: clean sync warms the list caches.
+	syncer.RunOnce(ctx)
+	require.True(mc.prsCached, "first cycle should warm the PR list cache")
+	_, flagged := syncer.failedRepos.Load(repoFailKey(repos[0]))
+	require.False(flagged, "clean cycle must not flag the repo")
+
+	// Cycle 2: the budget transport refuses the PR list before any I/O.
+	mc.listOpenPRsErr = fmt.Errorf(
+		"Get %q: %w",
+		"https://api.github.com/repos/owner/repo/pulls",
+		platform.ErrSyncBudgetExhausted,
+	)
+	syncer.RunOnce(ctx)
+
+	_, flagged = syncer.failedRepos.Load(repoFailKey(repos[0]))
+	assert.False(flagged,
+		"budget refusal must not mark the repo for ETag eviction")
+	assert.Contains(syncer.Status().LastError, "list open PRs",
+		"budget refusal must still surface as a sync error")
+
+	// Cycle 3: budget available again. The list must go through the
+	// conditional path (warm cache → 304), not an eviction-forced refetch.
+	mc.listOpenPRsErr = nil
+	invalidateBefore := mc.invalidateCalls.Load()
+	syncer.RunOnce(ctx)
+
+	assert.Equal(invalidateBefore, mc.invalidateCalls.Load(),
+		"recovery cycle must not invalidate list ETags")
+	assert.True(mc.prsCached, "cached PR list validator must stay warm")
+}
+
+// TestSyncerBudgetRefusedIssueListSkipsETagEviction verifies the same
+// no-eviction rule for the open-issue list: a budget refusal fails the
+// cycle but leaves the issue list validators warm for the next cycle.
+func TestSyncerBudgetRefusedIssueListSkipsETagEviction(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	now := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	repos := []RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}}
+
+	mc := &partialFailureMock{}
+	mc.openPRs = []*gh.PullRequest{buildOpenPR(1, now)}
+	mc.comments = []*gh.IssueComment{}
+	mc.reviews = []*gh.PullRequestReview{}
+	mc.commits = []*gh.RepositoryCommit{}
+
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc},
+		d, nil, repos, time.Minute, nil, nil,
+	)
+
+	// Cycle 1: clean sync warms both list caches.
+	syncer.RunOnce(ctx)
+	require.True(mc.issuesCached, "first cycle should warm the issue list cache")
+
+	// Cycle 2: budget refuses the issue list; the PR list stays warm (304).
+	mc.listOpenIssuesErr = fmt.Errorf(
+		"Get %q: %w",
+		"https://api.github.com/repos/owner/repo/issues",
+		platform.ErrSyncBudgetExhausted,
+	)
+	syncer.RunOnce(ctx)
+
+	_, flagged := syncer.failedRepos.Load(repoFailKey(repos[0]))
+	assert.False(flagged,
+		"budget refusal must not mark the repo for ETag eviction")
+
+	// Cycle 3: budget available again — no eviction-forced refetch.
+	mc.listOpenIssuesErr = nil
+	invalidateBefore := mc.invalidateCalls.Load()
+	syncer.RunOnce(ctx)
+
+	assert.Equal(invalidateBefore, mc.invalidateCalls.Load(),
+		"recovery cycle must not invalidate list ETags")
+	assert.True(mc.issuesCached, "cached issue list validator must stay warm")
+}
+
+// TestSyncerListFetchesUseEssentialBudgetContext verifies that the open-PR
+// and open-issue list fetches — the calls that discover new and closed items
+// — run under the essential sync-budget context so they can spend the
+// reserved headroom, while per-item detail fetches stay optional.
+func TestSyncerListFetchesUseEssentialBudgetContext(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	now := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	repos := []RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}}
+
+	var prListEssential, issueListEssential atomic.Bool
+	var reviewsCalled, reviewsEssential atomic.Bool
+
+	mc := &partialFailureMock{}
+	// openPRs also backs the mock's GetPullRequest for the detail drain.
+	mc.openPRs = []*gh.PullRequest{buildOpenPR(1, now)}
+	mc.listOpenPRsFn = func(fnCtx context.Context, _, _ string) ([]*gh.PullRequest, error) {
+		prListEssential.Store(IsEssentialSyncBudgetContext(fnCtx))
+		return mc.openPRs, nil
+	}
+	mc.listOpenIssuesFn = func(fnCtx context.Context, _, _ string) ([]*gh.Issue, error) {
+		issueListEssential.Store(IsEssentialSyncBudgetContext(fnCtx))
+		return nil, nil
+	}
+	mc.listReviewsFn = func(fnCtx context.Context, _, _ string, _ int) ([]*gh.PullRequestReview, error) {
+		reviewsCalled.Store(true)
+		reviewsEssential.Store(IsEssentialSyncBudgetContext(fnCtx))
+		return []*gh.PullRequestReview{}, nil
+	}
+	mc.comments = []*gh.IssueComment{}
+	mc.commits = []*gh.RepositoryCommit{}
+	ciState := "success"
+	mc.ciStatus = &gh.CombinedStatus{State: &ciState}
+
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc},
+		d, nil, repos, time.Minute, nil, testBudget(10000),
+	)
+	syncer.RunOnce(ctx)
+
+	assert.True(prListEssential.Load(),
+		"open-PR list fetch must run under the essential budget context")
+	assert.True(issueListEssential.Load(),
+		"open-issue list fetch must run under the essential budget context")
+	require.True(reviewsCalled.Load(),
+		"PR timeline reviews fetch should have run")
+	assert.False(reviewsEssential.Load(),
+		"detail fetches must stay on the optional budget")
 }
 
 // TestSyncerMRDetailFailureRetries verifies that when fetchMRDetail

--- a/internal/github/syncertest/budget_reserve_sync_test.go
+++ b/internal/github/syncertest/budget_reserve_sync_test.go
@@ -1,0 +1,139 @@
+package syncertest
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	ghclient "go.kenn.io/forge/internal/github"
+	"go.kenn.io/forge/internal/platform"
+	"go.kenn.io/forge/internal/platform/gitlab"
+)
+
+// TestEssentialReserveKeepsDiscoveryAliveAfterOptionalExhaustion proves the
+// discovery guarantee end to end over a real provider HTTP fixture, the real
+// budget transport, and SQLite: after optional background spend has consumed
+// the hourly ceiling, a newly opened merge request must still be discovered
+// and persisted on the next sync cycle.
+//
+// The control variant runs the identical scenario on a budget without an
+// essential reserve and must NOT discover the new merge request — proving
+// the test discriminates the reserve behavior rather than passing vacuously.
+func TestEssentialReserveKeepsDiscoveryAliveAfterOptionalExhaustion(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	run := func(t *testing.T, budget *ghclient.SyncBudget) *string {
+		t.Helper()
+		ctx := t.Context()
+		d := openTestDB(t)
+
+		var newMRVisible atomic.Bool
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch r.URL.EscapedPath() {
+			case "/api/v4/projects/group%2Fproject", "/api/v4/projects/42":
+				_, _ = w.Write([]byte(`{
+					"id": 42,
+					"path": "project",
+					"path_with_namespace": "group/project",
+					"name": "Project",
+					"default_branch": "main",
+					"web_url": "https://gitlab.example.com/group/project",
+					"http_url_to_repo": "https://gitlab.example.com/group/project.git",
+					"created_at": "2026-01-01T00:00:00Z",
+					"updated_at": "2026-01-02T00:00:00Z"
+				}`))
+			case "/api/v4/projects/42/merge_requests":
+				seeded := `{
+					"id": 1001, "iid": 8, "project_id": 42, "source_project_id": 42,
+					"title": "seeded MR", "state": "opened",
+					"author": {"username": "lin"},
+					"source_branch": "feature", "target_branch": "main", "sha": "abc123",
+					"web_url": "https://gitlab.example.com/group/project/-/merge_requests/8",
+					"created_at": "2026-06-01T00:00:00Z", "updated_at": "2026-06-02T00:00:00Z"
+				}`
+				if newMRVisible.Load() {
+					_, _ = w.Write([]byte(`[` + seeded + `,{
+						"id": 1002, "iid": 9, "project_id": 42, "source_project_id": 42,
+						"title": "newly opened MR", "state": "opened",
+						"author": {"username": "kai"},
+						"source_branch": "feature-2", "target_branch": "main", "sha": "def456",
+						"web_url": "https://gitlab.example.com/group/project/-/merge_requests/9",
+						"created_at": "2026-06-03T00:00:00Z", "updated_at": "2026-06-03T00:00:00Z"
+					}]`))
+					return
+				}
+				_, _ = w.Write([]byte(`[` + seeded + `]`))
+			default:
+				_, _ = w.Write([]byte(`[]`))
+			}
+		}))
+		t.Cleanup(server.Close)
+
+		client, err := gitlab.NewClient(
+			"gitlab.example.com", staticGitLabToken("token"),
+			gitlab.WithBaseURLForTesting(server.URL+"/api/v4"),
+			gitlab.WithoutRetriesForTesting(),
+			gitlab.WithSyncBudget(budget),
+		)
+		require.NoError(err)
+		registry, err := ghclient.NewProviderRegistry(nil, client)
+		require.NoError(err)
+		repo := ghclient.RepoRef{
+			Platform: platform.KindGitLab, PlatformHost: "gitlab.example.com",
+			Owner: "group", Name: "project", RepoPath: "group/project",
+		}
+		syncer := ghclient.NewSyncerWithRegistry(
+			registry, d, nil, []ghclient.RepoRef{repo}, time.Minute, nil,
+			map[string]*ghclient.SyncBudget{
+				ghclient.RateBucketKey("gitlab", "gitlab.example.com", "host"): budget,
+			},
+		)
+		t.Cleanup(syncer.Stop)
+
+		// Seed cycle with budget available: MR 8 lands.
+		syncer.RunOnce(ctx)
+		seededMR, err := d.GetMergeRequest(
+			ctx, "gitlab", "gitlab.example.com", "group", "project", 8,
+		)
+		require.NoError(err)
+		require.NotNil(seededMR, "seed cycle must persist the existing MR")
+
+		// A new MR opens upstream while optional spend exhausts the ceiling.
+		newMRVisible.Store(true)
+		for budget.CanSpend(1) {
+			budget.Spend(1)
+		}
+
+		syncer.RunOnce(ctx)
+
+		newMR, err := d.GetMergeRequest(
+			ctx, "gitlab", "gitlab.example.com", "group", "project", 9,
+		)
+		require.NoError(err)
+		if newMR == nil {
+			return nil
+		}
+		return &newMR.Title
+	}
+
+	t.Run("control without reserve stays starved", func(t *testing.T) {
+		title := run(t, ghclient.NewSyncBudget(200))
+		assert.Nil(title,
+			"without a reserve the exhausted ceiling must block discovery — "+
+				"a non-nil result means this test no longer discriminates")
+	})
+
+	t.Run("essential reserve discovers the new MR", func(t *testing.T) {
+		title := run(t, ghclient.NewSyncBudgetWithEssentialReserve(200))
+		require.NotNil(title,
+			"discovery must survive optional budget exhaustion")
+		assert.Equal("newly opened MR", *title)
+	})
+}

--- a/internal/platform/gitlab/client.go
+++ b/internal/platform/gitlab/client.go
@@ -456,6 +456,11 @@ func (c *Client) ListOpenMergeRequests(
 		ListOptions: gitlab.ListOptions{Page: 1, PerPage: defaultPageSize},
 	}
 	var out []platform.MergeRequest
+	// Fork-source clone URL lookups are enrichment, not discovery: they run
+	// on the optional budget so they cannot drain the essential reserve, and
+	// a budget-refused lookup degrades to an unknown head repo instead of
+	// discarding the fetched list.
+	enrichCtx := ghsync.WithoutEssentialSyncBudget(ctx)
 	for {
 		mrs, resp, err := c.api.MergeRequests.ListProjectMergeRequests(pid, opt, gitlab.WithContext(ctx))
 		if err != nil {
@@ -467,9 +472,14 @@ func (c *Client) ListOpenMergeRequests(
 		for _, mr := range mrs {
 			normalized := NormalizeMergeRequest(normalizedRef, mr, nil)
 			normalized.HeadRepoCloneURL, normalized.HeadRepoCloneURLUnknown, err =
-				c.optionalHeadRepoCloneURL(ctx, normalizedRef, mr.ProjectID, mr.SourceProjectID)
+				c.optionalHeadRepoCloneURL(enrichCtx, normalizedRef, mr.ProjectID, mr.SourceProjectID)
 			if err != nil {
-				return nil, err
+				if errors.Is(err, platform.ErrSyncBudgetExhausted) {
+					normalized.HeadRepoCloneURL = ""
+					normalized.HeadRepoCloneURLUnknown = true
+				} else {
+					return nil, err
+				}
 			}
 			out = append(out, normalized)
 		}

--- a/internal/platform/gitlab/client.go
+++ b/internal/platform/gitlab/client.go
@@ -164,9 +164,12 @@ func (t *syncBudgetTransport) RoundTrip(req *http.Request) (*http.Response, erro
 	var window ghsync.BudgetWindow
 	if counted {
 		var reserved bool
-		if archive {
+		switch {
+		case archive:
 			window, reserved = t.budget.TrySpendArchive(1)
-		} else {
+		case ghsync.IsEssentialSyncBudgetContext(req.Context()):
+			window, reserved = t.budget.TrySpendEssential(1)
+		default:
 			window, reserved = t.budget.TrySpend(1)
 		}
 		if !reserved {

--- a/internal/platform/gitlab/client_test.go
+++ b/internal/platform/gitlab/client_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -155,6 +156,61 @@ func TestClientListOpenMergeRequestsPopulatesForkHeadRepoCloneURL(t *testing.T) 
 		"/api/v4/projects/42/merge_requests",
 		"/api/v4/projects/77",
 	}, paths)
+}
+
+// TestClientListOpenMergeRequestsEnrichmentStaysOptional verifies that the
+// per-MR source-project clone URL lookups inside the open-MR list run on the
+// optional budget, not the essential reserve, and that a budget-refused
+// lookup degrades to an unknown head repo instead of discarding the fetched
+// list. Otherwise a repository with many uncached fork MRs could drain the
+// discovery reserve on enrichment or lose the whole list to one refusal.
+func TestClientListOpenMergeRequestsEnrichmentStaysOptional(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	var forkLookups atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.EscapedPath() {
+		case "/api/v4/projects/42/merge_requests":
+			writeJSON(w, `[
+				{"id": 1001, "iid": 7, "project_id": 42, "source_project_id": 77, "target_project_id": 42, "source_branch": "feature/auth", "target_branch": "main", "title": "Fork MR", "state": "opened"}
+			]`)
+		case "/api/v4/projects/77":
+			forkLookups.Add(1)
+			writeJSON(w, `{
+				"id": 77,
+				"path": "project",
+				"path_with_namespace": "fork/project",
+				"http_url_to_repo": "https://gitlab.example.com/fork/project.git"
+			}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	// Reserve of 3: enough that a wrongly-essential enrichment lookup would
+	// succeed on the reserve; the optional ceiling is fully spent.
+	budget := ghsync.NewSyncBudgetWithEssentialReserve(30)
+	budget.Spend(27)
+	client := newTestClient(t, server.URL, WithSyncBudget(budget))
+	ref := platform.RepoRef{
+		Platform:   platform.KindGitLab,
+		Host:       "gitlab.example.com",
+		RepoPath:   "group/project",
+		PlatformID: 42,
+		CloneURL:   "https://gitlab.example.com/group/project.git",
+	}
+
+	ctx := ghsync.WithEssentialSyncBudget(ghsync.WithSyncBudget(context.Background()))
+	mrs, err := client.ListOpenMergeRequests(ctx, ref)
+	require.NoError(err,
+		"a budget-refused enrichment must not discard the fetched list")
+	require.Len(mrs, 1)
+	assert.True(mrs[0].HeadRepoCloneURLUnknown,
+		"refused enrichment must degrade to an unknown head repo")
+	assert.Empty(mrs[0].HeadRepoCloneURL)
+	assert.Zero(forkLookups.Load(),
+		"enrichment must not spend the essential reserve")
 }
 
 func TestClientListOpenMergeRequestsContinuesWhenForkHeadRepoLookupFails(t *testing.T) {


### PR DESCRIPTION
Newly opened PRs intermittently never appeared in the dashboard. Live diagnosis showed the per-credential `sync_budget_per_hour` ceiling (which gates all background sync wire calls, not just archive) exhausting within minutes of process start while the provider still had ~15k requests of headroom — after which every 5-minute cycle's open-PR list fetch was refused for the rest of the hour. Three mechanisms fed the outage and each gets a fix:

- A budget-refused list fetch marked the repo failed, so the next cycle evicted its list ETags and refetched unconditionally. The refusal never reached the wire, so the cached validators were still valid; the eviction converted free refunded 304s into paid 200s exactly when the budget was already gone, re-exhausting the window every cycle. Refusals now skip eviction while still surfacing as sync errors.
- Optional background spend (fast-sync of active PRs, detail drain, archive) could consume the entire ceiling. The budget now holds back a tenth of the limit as an essential reserve that only list discovery (open PR/issue lists, repo identity resolve) may spend, on both the GitHub and GitLab budget transports.
- An issue deleted upstream stayed "previously open" forever, failing the repo's issue sync and spending a lookup plus repository probe every cycle. A GitHub-classified true removal (not_found, no transfer destination) now tombstones the local copy closed. Transfers and provider-neutral bare 404s keep failing visibly: GitLab hides inaccessible items behind 404, so only GitHub's classified lookup can safely distinguish a real deletion.

Reviewers should note the essential reserve changes `TrySpend`/`TrySpendArchive` semantics only for budgets built with `NewSyncBudgetWithEssentialReserve` (the production constructor sites); plain `NewSyncBudget` keeps full-limit spend, so existing boundary behavior elsewhere is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)