### PR TITLE
Preserve provider snapshots when reconciling renamed repositories

### DIFF
--- a/cmd/e2e-server/main.go
+++ b/cmd/e2e-server/main.go
@@ -1496,25 +1496,35 @@ func buildAppState(
 	rootHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost &&
 			r.URL.Path == "/__e2e/issue-workspace/reused-branch" {
-			clonePath, err := diffRepo.Manager.ClonePath(
+			identityClonePath, err := diffRepo.Manager.ClonePathForContext(
+				gitclone.WithRepositoryIdentity(r.Context(), diffRepo.PlatformRepoID),
 				"github", "github.com", "acme", "widgets",
 			)
 			if err != nil {
 				http.Error(w, "resolve fixture clone", http.StatusInternalServerError)
 				return
 			}
-			const branch = "kenn-forge/issue-10-widget-rendering-broken-on-safari"
-			_, stderr, err := gitcmd.New().Run(
-				r.Context(), clonePath, nil,
-				"update-ref", "refs/heads/"+branch, diffRepo.BaseSHA,
+			workspaceClonePath, err := diffRepo.Manager.ClonePath(
+				"github", "github.com", "acme", "widgets",
 			)
 			if err != nil {
-				http.Error(
-					w,
-					"create reused issue branch: "+string(stderr),
-					http.StatusInternalServerError,
-				)
+				http.Error(w, "resolve workspace fixture clone", http.StatusInternalServerError)
 				return
+			}
+			const branch = "kenn-forge/issue-10-widget-rendering-broken-on-safari"
+			for _, clonePath := range []string{identityClonePath, workspaceClonePath} {
+				_, stderr, err := gitcmd.New().Run(
+					r.Context(), clonePath, nil,
+					"update-ref", "refs/heads/"+branch, diffRepo.BaseSHA,
+				)
+				if err != nil {
+					http.Error(
+						w,
+						"create reused issue branch: "+string(stderr),
+						http.StatusInternalServerError,
+					)
+					return
+				}
 			}
 			w.WriteHeader(http.StatusNoContent)
 			return
@@ -1535,7 +1545,8 @@ func buildAppState(
 			forkSnapshot := *mr
 			forkSnapshot.HeadRepoCloneURL = "https://github.com/forker/widgets.git"
 			forkSnapshot.UpdatedAt = time.Now().UTC()
-			clonePath, err := diffRepo.Manager.ClonePath(
+			clonePath, err := diffRepo.Manager.ClonePathForContext(
+				gitclone.WithRepositoryIdentity(r.Context(), diffRepo.PlatformRepoID),
 				"github", "github.com", "acme", "widgets",
 			)
 			if err != nil {

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -162,6 +162,9 @@ Some PR-derived state is only valid for one head commit.
   (`internal/github/sync.go::computeCommitLiveness`,
   `internal/db/queries.go::UpsertMergeRequestSnapshotWithLabelsUnderRepositoryReconciliationRead`,
   `internal/gitclone/reachability.go::CommitsReachableFrom`).
+- Mutation-triggered closed-MR refetches capture the route generation before
+  provider I/O, carry stable clone identity, and fence all snapshot/diff writes
+  (`internal/github/sync.go::SyncClosedMROnProvider`).
 - Workflow-approval decisions must be tied to the correct PR identity, not just
   the head SHA. Shared SHAs across forks or sibling PRs must not leak approval
   state between items.
@@ -548,8 +551,15 @@ Managed Git uses exact-repository or owner PAT routes with mutation context and
 must never expose an App installation token to smart HTTP. Thread full provider,
 host, owner, and repository identity through clone/fetch and local reads, passing
 the normalized platform (`repoPlatform(repo)`) so an unqualified GitHub ref still
-picks its credential route instead of none;
-partition non-GitHub clone storage by provider on shared hosts. Before injecting
+picks its credential route instead of none. Partition sync, diff, and repository
+browser clone storage by stable provider repository identity
+(`internal/gitclone/repo_browser.go::repoBrowserCloneNamespace`). Only the shared fetch's starter discards
+a clone when its captured route generation no longer owns the path; later
+callers re-validate their own fences as pure gates so a stale caller never
+deletes a clone current-route callers are reading, and a follower rejected only
+by the starter's stale route retries with its own validated fetch. Workspace clones remain
+path-scoped, so shared full-stack fixtures must seed both namespaces
+(`internal/testutil/diff_repo.go::SetupDiffRepo`). Before injecting
 a PAT into workspace fetch or push, require the branch upstream to be `origin`,
 reject repository-local URL rewrites, and validate every origin fetch/push URL.
 

--- a/context/notifications-in-activity.md
+++ b/context/notifications-in-activity.md
@@ -39,6 +39,7 @@ Rules:
 - Persist notification item identity as `(platform, platform_host, platform_notification_id)`.
 - Route-facing notification filters and summaries resolve through the repository's current `(platform, platform_host, repo_owner, repo_name)` route.
 - For subject joins, a non-null `repo_id` is authoritative across renames and route reuse; only legacy null IDs fall back through the current route (`internal/db/queries_notifications.go::DB.LatestOpenPRNotificationActivity`).
+- Queued-ack deferral matches linked rows by `repo_id` across renames; route owner/name matching is restricted to null-ID legacy rows (`internal/db/queries_notifications.go::DB.DeferQueuedNotificationAcksForRepos`).
 - `platform` is required. Blank provider/platform values are errors, not implicit GitHub defaults.
 - Show notifications only for current monitored repo set from config/syncer repo refs.
 - Historical notifications for removed repos may stay in SQLite but must not appear in `unread`, `active`, `read`, `done`, or `all` unless future explicit `include_unmonitored` contract exists.
@@ -111,6 +112,15 @@ Rules:
 - The sync engine intentionally requires BOTH `ReadNotifications` and `NotificationMutation` to select a provider: listing and read-ack propagation are treated as one feature today. A future read-only provider (list without upstream mark-read) would split this — select listing on `ReadNotifications` and propagation on `NotificationMutation` separately. Until such a provider exists the coupling keeps the path simple.
 - Propagation workers must revalidate queued generation before calling provider.
 - Stale queued work must not mark newer provider activity read.
+- Advanced-activity refreshes resolve legacy unlinked rows to the active route and
+  commit under its fence; rejection reopens the acknowledgement and provider-unread
+  activity clears local completion (`internal/github/notifications_sync.go::Syncer.ProcessQueuedNotificationReads`).
+- Queued acknowledgements outlive route renames, including changes during
+  propagation: linked rows stay queued on fence rejection, and the next pass
+  resolves current owner/name by `repo_id` (`internal/github/notifications_sync.go::Syncer.ProcessQueuedNotificationReads`,
+  `internal/db/queries_notifications.go::DB.ListQueuedNotificationAcks`). Linked rows
+  without a current route remain queued for future reactivation but are excluded before
+  the bounded propagation batch limit so they cannot starve routable acknowledgements.
 - After successful propagation, stale GitHub sync payloads with `unread=true` and `source_updated_at <= source_ack_generation_at` must preserve local read state.
 - Newer unread GitHub activity clears queued/synced/error propagation fields and reactivates row.
 - Failure updates must be guarded by queued generation just like success updates.
@@ -128,11 +138,17 @@ Rules:
 - These two filters are enforced at sync (new rows) and in the Activity union (existing rows). The notification list/summary APIs (`GET /notifications`, summaries) are not UI-surfaced today and intentionally still return any rows already in `forge_notification_items`; the Activity feed is the only filtered surface. If those APIs gain a UI, apply the same `item_type IN ('pr','issue') AND item_number IS NOT NULL AND reason != 'author'` filter there.
 - Notification sync should process each configured provider host independently; one provider-host failure must not block others.
 - Notification sync failures should update notification sync status so UI can surface them.
+- Every notification listing attempt must provider-verify the stable repository ID and persist
+  its metadata/settings only while that observation remains current; an occupied route is not
+  identity proof. Rejected observations and route- or observation-fenced commits retry before listing
+  (`internal/github/notifications_sync.go::Syncer.syncNotificationsForRepoAttempt`).
+- Quota admission precedes identity verification against its read identity and any distinct
+  write-permission overlay; a shared identity is checked once (`internal/github/notifications_sync.go::Syncer.ensureNotificationIdentityBudget`).
 - Top-level manual sync also triggers notification sync.
 - `/notifications/sync` triggers only notification sync and returns `202` once accepted.
 - Sync watermark identity is per repository: `(platform, platform_host, repo_owner, repo_name)`, with owner/name lowercased to match `notificationRepoKey`. One repository's failing or unroutable credential route must not hold back watermark advancement for healthy repositories on the same host.
 - A repository with no watermark yet full-syncs (GitHub `All: true`) without resetting siblings; later syncs use its persisted watermark/overlap to avoid full backlog scans.
-- GitHub notification pagination must run until the provider reports no next page; do not use a fixed page cap for either the primary repo notification list or the participating-only annotation scan. A fixed cap can pin the watermark forever on large backlogs. The guardrail is the shared sync budget/rate reserve (`internal/github/notifications_sync.go::ensureNotificationPageBudget`), which should stop sync explicitly when upstream budget is exhausted (`internal/github/sync_test.go::TestSyncNotificationsReadsAllRepositoryNotificationPages`, `internal/github/sync_test.go::TestSyncNotificationsReadsAllParticipatingNotificationPages`).
+- GitHub notification pagination must run until the provider reports no next page; do not use a fixed page cap for either the primary repo notification list or the participating-only annotation scan. A fixed cap can pin the watermark forever on large backlogs. The guardrail is the shared sync budget/rate reserve (`internal/github/notifications_sync.go::Syncer.ensureNotificationBudget`), which should stop sync explicitly when upstream budget is exhausted (`internal/github/sync_test.go::TestSyncNotificationsReadsAllRepositoryNotificationPages`, `internal/github/sync_test.go::TestSyncNotificationsReadsAllParticipatingNotificationPages`).
 - Notification sync and read propagation should stop with server lifecycle before shared services are torn down.
 - Closed/merged linked notification completion must run after repo/detail/list paths that persist closed PR or issue state, not only after notification sync.
 

--- a/context/platform-sync-invariants.md
+++ b/context/platform-sync-invariants.md
@@ -25,6 +25,35 @@ combining repository-owned history
 - Timestamp provider observations before the identity lookup starts; a delayed
   response must not supersede a newer route observation
   (`internal/github/sync.go::Syncer.syncRepoIdentity`).
+- Asynchronous provider responses fetched through a mutable route must fence the
+  exact ownership generation before snapshot, notification, or cache commits;
+  same-identity freshness observations do not advance that generation
+  (`internal/db/repository_catalog.go::RepositoryRouteFence`).
+- Repository provider metadata and merge settings have a single sync-path
+  writer: commits go through the observation watermark so a delayed snapshot
+  never overwrites a newer same-route observation, and reconciled direct item
+  syncs persist their verified snapshot so a replacement repository row never
+  serves permissive schema defaults. Snapshot fields a provider omits must not
+  erase stored metadata — clone URLs seeded outside the provider resolve
+  clones — and a failed settings write stops the item sync instead of
+  populating a row that still advertises default merge availability
+  (`internal/db/repository_catalog.go::UpdateRepoProviderObservation`).
+  Newly verified or legacy-adopted rows fail closed when viewer merge permission
+  is omitted; only an already verified row may preserve its stored permission
+  (`internal/db/repository_catalog.go::ReconcileRepositoryObservation`).
+  Concurrent identity-only observations (the archive lifecycle re-reconciles
+  tracked repositories during route changes and first encounters) advance the
+  watermark without writing settings, so a direct sync whose snapshot loses
+  the watermark must re-resolve rather than proceed unsettled
+  (`internal/github/sync.go::Syncer.reconcileRepoForDirectSync`). Periodic
+  repository sync holds the same line: an uncommitted settings refresh aborts
+  the sync before item indexing and records the aborted attempt on the
+  repository row's sync health; only a provider that cannot report settings
+  is a silent skip (`internal/github/sync.go::Syncer.refreshRepoSettings`,
+  `internal/github/sync.go::Syncer.recordAbortedRepoSync`).
+- Assigning a historically occupied route to another verified repository clears
+  route-scoped state even without an active occupant; migration 47 applies the same
+  cleanup to preexisting reuse, while legacy adoption remains in-place (`internal/db/repository_catalog.go::ReconcileRepositoryObservation`, `internal/db/migrations/000047_repository_route_generation.up.sql:1`).
 
 GitLab nested namespaces make `repo_path` mandatory for reliable addressing:
 `group/subgroup/project` has owner `group/subgroup` and name `project`.
@@ -94,9 +123,17 @@ Managed Git authorization is selected by full `(platform, platform_host, owner,
 name)` identity. GitHub smart HTTP uses mutation/user candidates and never an
 App installation token. Exact repository routes beat owner routes, which beat
 the unscoped host fallback. Non-GitHub providers use their provider-host
-fallback. Clone storage and singleflight keys must partition providers sharing a
-host, and authenticated workspace operations must validate the effective origin
-fetch and push destinations before resolving a credential.
+fallback. Clone storage and clone-coordination keys must partition providers sharing a host and
+distinct stable repository IDs sharing mutable routes
+(`internal/gitclone/clone.go::WithRepositoryIdentity`). Authenticated workspace operations
+must validate the effective origin fetch and push destinations before resolving a credential.
+Pre-stable-ID clone adoption stays offline and requires a catalog-verified stable owner with
+no other route history plus a matching stored origin (`internal/db/repository_catalog.go::DB.AdoptLegacyClonesIfSafe`).
+Stable main storage is an independent copy while the workspace path-scoped main clone remains
+(`internal/gitclone/repo_browser.go::Manager.AdoptLegacyClones`).
+Repository-browser refreshes fetch only into unpublished same-filesystem staging and publish with a
+route-generation guard plus reader-exclusive rename swap; failures retain the prior clone. Current
+waiters retry only after stale staging cleanup (`internal/gitclone/repo_browser.go::refreshRepoBrowserClone`).
 
 Minimum read scope should cover repository metadata, merge requests or pull
 requests, issues, comments, commits, tags, releases, and CI/status data. Write
@@ -218,7 +255,8 @@ registry helpers return typed errors for missing providers or capabilities.
   `closed_at`. (`internal/db/queries_archive.go::RequeueArchiveLifecycleDetails`)
 - Successful canonical hydration durably marks lifecycle details checked even when a provider omits them, preventing repeated backfill reads. (`internal/db/queries_dataset_progress.go::CommitArchiveItemSync`)
 - Authentication and repository-blocked errors defer every archive work class, including already-pending hydration, until an explicit retry clears the repository error. (`internal/archive/scheduler.go::archiveRepoDeferred`)
-- Archive admission is provider-host scoped. Normal index, notification, and active-detail work outrank archive requests; live work registers first, cancels the active archive request context, and waits for that request lease to release before provider I/O. Archive leases are released before SQLite commits. Register repo index and item detail work inside their shared execution functions so periodic, watched, manual, API, and item-number entry points cannot bypass admission. (`internal/github/sync.go::beginProviderWork`, `internal/github/sync.go::tryBeginArchiveProviderRequest`, `internal/github/sync.go::Admit`, `internal/archive/scheduler.go::admit`)
+- Archive admission is provider-host scoped. Normal index, notification, and active-detail work outrank archive requests; live work registers first, cancels the active archive request context, and waits for that request lease to release before provider I/O. Archive leases are released before SQLite commits. (`internal/github/sync.go::beginProviderWork`, `internal/github/sync.go::tryBeginArchiveProviderRequest`, `internal/github/sync.go::Admit`, `internal/archive/scheduler.go::admit`)
+- Split-auth live work holds every read/write credential identity it may spend, including identities selected after route reconciliation. Register work inside shared execution functions so no entry point bypasses admission. (`internal/github/notifications_sync.go::notificationProviderWork`)
 - Archive admission requires the declared minimum cost and normally bounds wire attempts above the live floor. Gitealike merge-request reads remain preemptible but may exceed the estimate to complete their atomic dataset. (`internal/github/budget.go::LocalArchiveSpendAvailable`,
   `internal/archive/scheduler.go::archiveFeatureReadAttemptCost`, `internal/github/sync.go::Admit`)
 - Detailed reports use schema `kenn-forge-archive-report/1` and half-open UTC windows. They expose opened items, current close/merge lifecycle projections, comments, reviews, and inline comments; a reopened issue has no close row. Issue close actors must match the current `closed_at`; merge metrics come from the normalized merge-request row. Daemon CLI JSON must reject any other schema before conversion and round-trip every recognized report kind and field. (`internal/db/queries_archive_report.go::archiveReportActivityQuery`, `cmd/kenn-forge/archive_cli.go::archiveReportFromAPI`)

--- a/context/retries-and-backoffs.md
+++ b/context/retries-and-backoffs.md
@@ -100,27 +100,33 @@ Hydration excludes the cooled repository feature only while selecting work in th
 pass, so unaffected due items remain eligible and restart or manual recovery can resume
 immediately. (`internal/archive/scheduler.go::runNextHydrationWork`)
 
-## Single-flight: `Manager.EnsureClone`
+## Shared clone slot: `Manager.EnsureClone`
 
-[`clone.go`](../internal/gitclone/clone.go). `EnsureClone` opens a
-`singleflight` slot keyed on `(host, owner, name)` so concurrent
-callers (periodic syncer, per-PR detail syncs, workspace setup) share
-one underlying clone/fetch instead of stampeding GitHub.
+[`clone.go`](../internal/gitclone/clone.go). `EnsureClone` opens a shared slot
+keyed on storage namespace plus `(host, owner, name)` so concurrent callers
+share one clone/fetch instead of stampeding GitHub. The slot remains occupied
+until every joined caller completes its own route validation gate.
 
 Invariants to preserve:
 
 - **Pre-check `ctx.Err()`**. A caller whose ctx is already canceled
   must not enter the slot, or the runner does work for nobody.
-- **Key shape** `host \x00 owner \x00 name`. The null separator
+- **Key shape** `namespace \x00 host \x00 owner \x00 name`. The null separator
   prevents `foo/barbaz` colliding with `foobar/baz`.
 - **Detached, bounded runner ctx**. The slot runs with
   `context.WithTimeout(context.WithoutCancel(ctx), ensureCloneTimeout)`.
   Detached so one canceled waiter cannot abort work for others;
   bounded so a stuck git subprocess cannot hold the slot forever.
-- **`DoChan`, not `Do`**, so each caller still observes its own
-  `ctx.Done()` via the outer `select`.
+- **Only the slot starter deletes**. The starter's validation runs inside the
+  slot after the fetch and spans the whole fetch window; its failure attempts
+  to remove the clone before releasing waiters. Callers preflight before joining
+  and remain registered through their final route gate; completed flights stay
+  joinable until all gates finish. Followers retry only after successful
+  quarantine and full drain; cleanup failure is terminal. Invalid clones are
+  renamed aside so external readers never observe partial deletion
+  (`internal/gitclone/clone.go::ensureCloneInNamespaceValidated`).
 
-Reach for a singleflight slot whenever multiple in-process call sites
+Reach for a shared slot whenever multiple in-process call sites
 hit the same upstream resource. Prefer dedup over retry — it removes
 the cause, retry just absorbs the effect.
 
@@ -133,7 +139,5 @@ cancelable by each waiter (`internal/server/roborev_repositories.go::roborevRepo
 
 Test the policy decisions, not the library. For retry that means the
 matcher, the `backoff.Permanent` wrap, and the budget constant. For
-dedup that means the key shape and the integration paths that
-exercise the real cloneBare/fetch. Skip tests that assert "the library
-loops" or "DoChan delivers to every waiter" — those are upstream's
-contract.
+dedup that means the key shape, per-caller validation, and integration paths
+that exercise the real cloneBare/fetch.

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -30,6 +31,22 @@ type mergeRequestSnapshotLockKey struct {
 type mergeRequestSnapshotLock struct {
 	token chan struct{}
 	refs  int
+}
+
+var ErrRepositoryRouteFenceChanged = errors.New("repository route fence changed")
+
+type repositoryRouteGuardContextKey struct{}
+
+type repositoryRouteLeaseContextKey struct{}
+
+type repositoryRouteGuard struct {
+	db       *DB
+	identity RepoIdentity
+	fence    RepositoryRouteFence
+}
+
+type repositoryRouteLease struct {
+	guard *repositoryRouteGuard
 }
 
 // Open opens (or creates) a SQLite database at path, enables WAL mode, and
@@ -123,6 +140,92 @@ func (d *DB) LockRepositoryReconciliationRead(
 	return func() {
 		once.Do(d.mrReconcileMu.RUnlock)
 	}, nil
+}
+
+// WithRepositoryRouteFence binds subsequent database writes to one observed
+// repository route generation. Reads are unaffected; each write validates the
+// fence while holding the reconciliation read lock through commit.
+func (d *DB) WithRepositoryRouteFence(
+	ctx context.Context,
+	identity RepoIdentity,
+	fence RepositoryRouteFence,
+) context.Context {
+	return context.WithValue(ctx, repositoryRouteGuardContextKey{}, &repositoryRouteGuard{
+		db: d, identity: canonicalRepoIdentity(identity), fence: fence,
+	})
+}
+
+func (d *DB) repositoryRouteGuard(ctx context.Context) *repositoryRouteGuard {
+	guard, _ := ctx.Value(repositoryRouteGuardContextKey{}).(*repositoryRouteGuard)
+	if guard == nil || guard.db != d {
+		return nil
+	}
+	return guard
+}
+
+// lockRepositoryRouteWrite validates an optional context route guard and keeps
+// repository reconciliation from interleaving until release. The returned
+// context makes nested guarded writes re-entrant for the same short critical
+// section.
+func (d *DB) lockRepositoryRouteWrite(
+	ctx context.Context,
+) (context.Context, func(), error) {
+	guard := d.repositoryRouteGuard(ctx)
+	if guard == nil {
+		return ctx, func() {}, nil
+	}
+	if lease, _ := ctx.Value(repositoryRouteLeaseContextKey{}).(*repositoryRouteLease); lease != nil && lease.guard == guard {
+		return ctx, func() {}, nil
+	}
+
+	release, err := d.LockRepositoryReconciliationRead(ctx)
+	if err != nil {
+		return ctx, nil, err
+	}
+	matches, err := d.RepositoryRouteFenceMatchesUnderRepositoryReconciliationRead(
+		ctx, guard.identity, guard.fence,
+	)
+	if err != nil {
+		release()
+		return ctx, nil, err
+	}
+	if !matches {
+		release()
+		return ctx, nil, fmt.Errorf(
+			"%w for %s/%s", ErrRepositoryRouteFenceChanged,
+			guard.identity.PlatformHost, guard.identity.RepoPath,
+		)
+	}
+	locked := context.WithValue(
+		ctx, repositoryRouteLeaseContextKey{}, &repositoryRouteLease{guard: guard},
+	)
+	return locked, release, nil
+}
+
+// LockRepositoryReconciliationReadForWrite holds repository identity stable
+// for a compound write. When ctx carries a route fence, it validates that
+// fence and returns a context that makes nested guarded DB writes re-entrant.
+func (d *DB) LockRepositoryReconciliationReadForWrite(
+	ctx context.Context,
+) (context.Context, func(), error) {
+	if d.repositoryRouteGuard(ctx) != nil {
+		return d.lockRepositoryRouteWrite(ctx)
+	}
+	release, err := d.LockRepositoryReconciliationRead(ctx)
+	return ctx, release, err
+}
+
+func (d *DB) execContext(
+	ctx context.Context,
+	query string,
+	args ...any,
+) (sql.Result, error) {
+	lockedCtx, release, err := d.lockRepositoryRouteWrite(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+	return d.rw.ExecContext(lockedCtx, query, args...)
 }
 
 func (d *DB) lockRepositoryReconciliationWrite() func() {
@@ -232,7 +335,12 @@ func (d *DB) releaseMergeRequestSnapshotLockRef(
 
 // Tx runs fn inside a transaction, rolling back on error.
 func (d *DB) Tx(ctx context.Context, fn func(tx *sql.Tx) error) error {
-	tx, err := d.rw.BeginTx(ctx, nil)
+	lockedCtx, release, err := d.lockRepositoryRouteWrite(ctx)
+	if err != nil {
+		return err
+	}
+	defer release()
+	tx, err := d.rw.BeginTx(lockedCtx, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -778,6 +778,136 @@ func TestRepositoryCatalogMigrationPreservesDataAndIndexes(t *testing.T) {
 	assertDatabaseIntegrityForTest(t, database.ReadDB())
 }
 
+func TestRepositoryRouteGenerationMigrationClearsHistoricallyReusedRouteState(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	dbPath := filepath.Join(t.TempDir(), "repository-route-generation-v46.db")
+
+	openAtVersionForTest(t, dbPath, 46, func(raw *sql.DB) {
+		_, err := raw.Exec(`
+			INSERT INTO forge_repos (
+				id, platform, platform_host, platform_repo_id,
+				owner, name, repo_path, owner_key, name_key, repo_path_key,
+				lifecycle_state
+			) VALUES
+				(1, 'github', 'github.com', 'provider-old',
+				 'acme', 'renamed', 'acme/renamed',
+				 'acme', 'renamed', 'acme/renamed', 'active'),
+				(2, 'github', 'github.com', 'provider-current',
+				 'acme', 'widget', 'acme/widget',
+				 'acme', 'widget', 'acme/widget', 'active');
+
+			INSERT INTO forge_repo_routes (
+				repo_id, platform, platform_host,
+				owner, name, repo_path, owner_key, name_key, repo_path_key,
+				is_current, first_seen_at, last_seen_at
+			) VALUES
+				(1, 'github', 'github.com',
+				 'acme', 'widget', 'acme/widget', 'acme', 'widget', 'acme/widget',
+				 0, '2026-01-01T00:00:00Z', '2026-01-02T00:00:00Z'),
+				(1, 'github', 'github.com',
+				 'acme', 'renamed', 'acme/renamed', 'acme', 'renamed', 'acme/renamed',
+				 1, '2026-01-02T00:00:00Z', '2026-01-02T00:00:00Z'),
+				(2, 'github', 'github.com',
+				 'acme', 'widget', 'acme/widget', 'acme', 'widget', 'acme/widget',
+				 1, '2026-01-03T00:00:00Z', '2026-01-03T00:00:00Z');
+
+			INSERT INTO forge_notification_sync_watermarks (
+				platform, platform_host, repo_owner, repo_name,
+				last_successful_sync_at
+			) VALUES
+				('github', 'github.com', 'acme', 'widget', '2026-01-03T00:00:00Z'),
+				('github', 'github.com', 'acme', 'safe', '2026-01-03T00:00:00Z');
+
+			INSERT INTO forge_http_etags (
+				platform, platform_host, owner_key, name_key,
+				resource_type, resource_number, etag
+			) VALUES
+				('github', 'github.com', 'acme', 'widget', 'pull_request', 7, 'stale'),
+				('github', 'github.com', 'acme', 'safe', 'pull_request', 8, 'keep');
+
+			INSERT INTO forge_notification_items (
+				platform, platform_host, platform_notification_id, repo_id,
+				repo_owner, repo_name, subject_type, subject_title,
+				reason, source_updated_at, synced_at
+			) VALUES
+				('github', 'github.com', 'reused-unlinked', NULL,
+				 'acme', 'widget', 'PullRequest', 'stale',
+				 'mention', '2026-01-03T00:00:00Z', '2026-01-03T00:00:00Z'),
+				('github', 'github.com', 'reused-linked', 2,
+				 'acme', 'widget', 'PullRequest', 'keep linked',
+				 'mention', '2026-01-03T00:00:00Z', '2026-01-03T00:00:00Z'),
+				('github', 'github.com', 'safe-unlinked', NULL,
+				 'acme', 'safe', 'PullRequest', 'keep safe',
+				 'mention', '2026-01-03T00:00:00Z', '2026-01-03T00:00:00Z');
+		`)
+		require.NoError(err)
+	})
+
+	database, err := Open(dbPath)
+	require.NoError(err)
+	t.Cleanup(func() { require.NoError(database.Close()) })
+
+	entry, accepted, err := database.ReconcileRepositoryObservation(
+		t.Context(), RepoIdentity{
+			Platform: "github", PlatformHost: "github.com",
+			PlatformRepoID: "provider-current",
+			Owner:          "acme", Name: "widget", RepoPath: "acme/widget",
+		},
+		time.Date(2026, 1, 4, 0, 0, 0, 0, time.UTC),
+	)
+	require.NoError(err)
+	require.True(accepted)
+	assert.Equal(int64(2), entry.Repository.ID)
+
+	var reusedWatermarks, safeWatermarks int
+	require.NoError(database.ReadDB().QueryRow(`
+		SELECT COUNT(*) FROM forge_notification_sync_watermarks
+		WHERE repo_owner = 'acme' AND repo_name = 'widget'
+	`).Scan(&reusedWatermarks))
+	require.NoError(database.ReadDB().QueryRow(`
+		SELECT COUNT(*) FROM forge_notification_sync_watermarks
+		WHERE repo_owner = 'acme' AND repo_name = 'safe'
+	`).Scan(&safeWatermarks))
+	assert.Zero(reusedWatermarks)
+	assert.Equal(1, safeWatermarks)
+
+	var reusedETags, safeETags int
+	require.NoError(database.ReadDB().QueryRow(`
+		SELECT COUNT(*) FROM forge_http_etags
+		WHERE owner_key = 'acme' AND name_key = 'widget'
+	`).Scan(&reusedETags))
+	require.NoError(database.ReadDB().QueryRow(`
+		SELECT COUNT(*) FROM forge_http_etags
+		WHERE owner_key = 'acme' AND name_key = 'safe'
+	`).Scan(&safeETags))
+	assert.Zero(reusedETags)
+	assert.Equal(1, safeETags)
+
+	rows, err := database.ReadDB().Query(`
+		SELECT platform_notification_id
+		FROM forge_notification_items
+		ORDER BY platform_notification_id
+	`)
+	require.NoError(err)
+	defer rows.Close()
+	var notificationIDs []string
+	for rows.Next() {
+		var id string
+		require.NoError(rows.Scan(&id))
+		notificationIDs = append(notificationIDs, id)
+	}
+	require.NoError(rows.Err())
+	assert.Equal([]string{"reused-linked", "safe-unlinked"}, notificationIDs)
+
+	var minimumGeneration int64
+	require.NoError(database.ReadDB().QueryRow(`
+		SELECT MIN(generation) FROM forge_repo_routes
+	`).Scan(&minimumGeneration))
+	assert.Equal(int64(1), minimumGeneration)
+	assertDatabaseIntegrityForTest(t, database.ReadDB())
+}
+
 func TestRepositoryCatalogMigrationDownRestoresRouteIdentity(t *testing.T) {
 	require := require.New(t)
 	dbPath := filepath.Join(t.TempDir(), "repository-catalog-v45.db")

--- a/internal/db/migrations/000047_repository_route_generation.down.sql
+++ b/internal/db/migrations/000047_repository_route_generation.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE forge_repo_routes DROP COLUMN generation;

--- a/internal/db/migrations/000047_repository_route_generation.up.sql
+++ b/internal/db/migrations/000047_repository_route_generation.up.sql
@@ -1,0 +1,57 @@
+ALTER TABLE forge_repo_routes
+ADD COLUMN generation INTEGER NOT NULL DEFAULT 1;
+
+-- Schema 45 could record a route's old and current owners without clearing
+-- route-scoped state. Clean every currently published route with a historical
+-- owner before normal reconciliation can take its same-owner fast path.
+DELETE FROM forge_notification_items
+WHERE repo_id IS NULL
+  AND EXISTS (
+      SELECT 1
+      FROM forge_repo_routes AS current_route
+      JOIN forge_repo_routes AS historical_route
+        ON historical_route.platform = current_route.platform
+       AND historical_route.platform_host = current_route.platform_host
+       AND historical_route.repo_path_key = current_route.repo_path_key
+       AND historical_route.repo_id <> current_route.repo_id
+      WHERE current_route.is_current = 1
+        AND historical_route.is_current = 0
+        AND current_route.platform = forge_notification_items.platform
+        AND current_route.platform_host = forge_notification_items.platform_host
+        AND current_route.owner_key = forge_notification_items.repo_owner
+        AND current_route.name_key = forge_notification_items.repo_name
+  );
+
+DELETE FROM forge_http_etags
+WHERE EXISTS (
+    SELECT 1
+    FROM forge_repo_routes AS current_route
+    JOIN forge_repo_routes AS historical_route
+      ON historical_route.platform = current_route.platform
+     AND historical_route.platform_host = current_route.platform_host
+     AND historical_route.repo_path_key = current_route.repo_path_key
+     AND historical_route.repo_id <> current_route.repo_id
+    WHERE current_route.is_current = 1
+      AND historical_route.is_current = 0
+      AND current_route.platform = forge_http_etags.platform
+      AND current_route.platform_host = forge_http_etags.platform_host
+      AND current_route.owner_key = forge_http_etags.owner_key
+      AND current_route.name_key = forge_http_etags.name_key
+);
+
+DELETE FROM forge_notification_sync_watermarks
+WHERE EXISTS (
+    SELECT 1
+    FROM forge_repo_routes AS current_route
+    JOIN forge_repo_routes AS historical_route
+      ON historical_route.platform = current_route.platform
+     AND historical_route.platform_host = current_route.platform_host
+     AND historical_route.repo_path_key = current_route.repo_path_key
+     AND historical_route.repo_id <> current_route.repo_id
+    WHERE current_route.is_current = 1
+      AND historical_route.is_current = 0
+      AND current_route.platform = forge_notification_sync_watermarks.platform
+      AND current_route.platform_host = forge_notification_sync_watermarks.platform_host
+      AND current_route.owner_key = forge_notification_sync_watermarks.repo_owner
+      AND current_route.name_key = forge_notification_sync_watermarks.repo_name
+);

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -789,7 +789,7 @@ func (d *DB) GetRepoLabelCatalogFreshness(ctx context.Context, repoID int64) (La
 
 func (d *DB) UpdateRepoLabelCatalogCheck(ctx context.Context, repoID int64, checkedAt time.Time, syncErr string) error {
 	checkedAt = canonicalUTCTime(checkedAt)
-	_, err := d.rw.ExecContext(ctx, `
+	_, err := d.execContext(ctx, `
 		UPDATE forge_repos
 		SET label_catalog_checked_at = ?, label_catalog_sync_error = ?
 		WHERE id = ?
@@ -804,7 +804,7 @@ func (d *DB) UpdateRepoLabelCatalogCheck(ctx context.Context, repoID int64, chec
 
 func (d *DB) MarkRepoLabelCatalogSynced(ctx context.Context, repoID int64, syncedAt time.Time) error {
 	syncedAt = canonicalUTCTime(syncedAt)
-	_, err := d.rw.ExecContext(ctx, `
+	_, err := d.execContext(ctx, `
 		UPDATE forge_repos
 		SET label_catalog_synced_at = CASE
 		        WHEN ? >= COALESCE(label_catalog_synced_at, '') THEN ?
@@ -1153,7 +1153,7 @@ func (d *DB) ListRepos(ctx context.Context) ([]Repo, error) {
 // UpdateRepoSyncStarted records the time a sync began.
 func (d *DB) UpdateRepoSyncStarted(ctx context.Context, id int64, t time.Time) error {
 	t = canonicalUTCTime(t)
-	_, err := d.rw.ExecContext(ctx,
+	_, err := d.execContext(ctx,
 		`UPDATE forge_repos SET last_sync_started_at = ? WHERE id = ?`, t, id,
 	)
 	if err != nil {
@@ -1165,7 +1165,7 @@ func (d *DB) UpdateRepoSyncStarted(ctx context.Context, id int64, t time.Time) e
 // UpdateRepoSyncCompleted records the time and optional error a sync finished.
 func (d *DB) UpdateRepoSyncCompleted(ctx context.Context, id int64, t time.Time, syncErr string) error {
 	t = canonicalUTCTime(t)
-	_, err := d.rw.ExecContext(ctx,
+	_, err := d.execContext(ctx,
 		`UPDATE forge_repos SET last_sync_completed_at = ?, last_sync_error = ? WHERE id = ?`,
 		t, syncErr, id,
 	)
@@ -1186,7 +1186,27 @@ func (d *DB) UpdateRepoProviderMetadata(
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	err := d.Tx(ctx, func(tx *sql.Tx) error {
+	tx, err := d.rw.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("update repo provider metadata: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if guard := d.repositoryRouteGuard(ctx); guard != nil {
+		matches, err := repositoryRouteFenceMatchesTx(
+			ctx, tx, guard.identity, guard.fence,
+		)
+		if err != nil {
+			return fmt.Errorf("update repo provider metadata: %w", err)
+		}
+		if !matches {
+			return fmt.Errorf(
+				"update repo provider metadata: %w for %s/%s",
+				ErrRepositoryRouteFenceChanged,
+				guard.identity.PlatformHost, guard.identity.RepoPath,
+			)
+		}
+	}
+	err = func(tx *sql.Tx) error {
 		identity, err := lookupRepoIdentityByIDTx(ctx, tx, repoID)
 		if err != nil {
 			return err
@@ -1254,9 +1274,12 @@ func (d *DB) UpdateRepoProviderMetadata(
 			repoID,
 		)
 		return err
-	})
+	}(tx)
 	if err != nil {
 		return fmt.Errorf("update repo provider metadata: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("update repo provider metadata: commit: %w", err)
 	}
 	return nil
 }
@@ -1356,7 +1379,7 @@ func (d *DB) UpdateRepoSettings(
 	id int64,
 	allowSquash, allowMerge, allowRebase, viewerCanMerge bool,
 ) error {
-	_, err := d.rw.ExecContext(ctx,
+	_, err := d.execContext(ctx,
 		`UPDATE forge_repos SET allow_squash_merge = ?, allow_merge_commit = ?, allow_rebase_merge = ?, viewer_can_merge = ? WHERE id = ?`,
 		allowSquash, allowMerge, allowRebase, viewerCanMerge, id,
 	)
@@ -1369,7 +1392,7 @@ func (d *DB) UpdateRepoMergeSettings(
 	id int64,
 	allowSquash, allowMerge, allowRebase bool,
 ) error {
-	_, err := d.rw.ExecContext(ctx,
+	_, err := d.execContext(ctx,
 		`UPDATE forge_repos SET allow_squash_merge = ?, allow_merge_commit = ?, allow_rebase_merge = ? WHERE id = ?`,
 		allowSquash, allowMerge, allowRebase, id,
 	)
@@ -1378,7 +1401,7 @@ func (d *DB) UpdateRepoMergeSettings(
 
 // UpdateRepoViewerCanMerge updates the current user's merge permission for a repo without changing merge method settings.
 func (d *DB) UpdateRepoViewerCanMerge(ctx context.Context, id int64, viewerCanMerge bool) error {
-	_, err := d.rw.ExecContext(ctx,
+	_, err := d.execContext(ctx,
 		`UPDATE forge_repos SET viewer_can_merge = ? WHERE id = ?`,
 		viewerCanMerge, id,
 	)
@@ -1423,7 +1446,7 @@ func marshalUserNamesJSON(names []string) string {
 // UpdateMergeRequestAssignees persists a provider-confirmed assignee set
 // after a mutation so the next sync does not revert the edit.
 func (d *DB) UpdateMergeRequestAssignees(ctx context.Context, repoID, mrID int64, assignees []string) error {
-	_, err := d.rw.ExecContext(ctx,
+	_, err := d.execContext(ctx,
 		`UPDATE forge_merge_requests SET assignees_json = ? WHERE id = ? AND repo_id = ?`,
 		marshalUserNamesJSON(assignees), mrID, repoID,
 	)
@@ -1436,7 +1459,7 @@ func (d *DB) UpdateMergeRequestAssignees(ctx context.Context, repoID, mrID int64
 // UpdateMergeRequestReviewers persists a provider-confirmed
 // requested-reviewer set after a mutation.
 func (d *DB) UpdateMergeRequestReviewers(ctx context.Context, repoID, mrID int64, reviewers []string) error {
-	_, err := d.rw.ExecContext(ctx,
+	_, err := d.execContext(ctx,
 		`UPDATE forge_merge_requests SET reviewers_json = ? WHERE id = ? AND repo_id = ?`,
 		marshalUserNamesJSON(reviewers), mrID, repoID,
 	)
@@ -1449,7 +1472,7 @@ func (d *DB) UpdateMergeRequestReviewers(ctx context.Context, repoID, mrID int64
 // UpdateIssueAssignees persists a provider-confirmed assignee set on an
 // issue after a mutation.
 func (d *DB) UpdateIssueAssignees(ctx context.Context, repoID, issueID int64, assignees []string) error {
-	_, err := d.rw.ExecContext(ctx,
+	_, err := d.execContext(ctx,
 		`UPDATE forge_issues SET assignees_json = ? WHERE id = ? AND repo_id = ?`,
 		marshalUserNamesJSON(assignees), issueID, repoID,
 	)
@@ -2390,7 +2413,7 @@ func listMREvents(ctx context.Context, q mrEventQueryer, mrID int64) ([]MREvent,
 // UpdateThreadResolved updates the resolved state for all events matching the
 // given merge request and thread ID.
 func (d *DB) UpdateThreadResolved(ctx context.Context, mrID int64, threadID string, resolved bool) error {
-	_, err := d.rw.ExecContext(ctx, `
+	_, err := d.execContext(ctx, `
 		UPDATE forge_mr_events
 		SET resolved = ?
 		WHERE merge_request_id = ? AND thread_id = ?`,
@@ -2592,7 +2615,7 @@ func (d *DB) UpdateMRTitleBody(
 	title, body string,
 	updatedAt time.Time,
 ) error {
-	_, err := d.rw.ExecContext(ctx, `
+	_, err := d.execContext(ctx, `
 		UPDATE forge_merge_requests
 		SET title = ?, body = ?, updated_at = ?,
 		    last_activity_at = MAX(last_activity_at, ?)
@@ -2614,7 +2637,7 @@ func (d *DB) UpdateIssueTitleBody(
 	title, body string,
 	updatedAt time.Time,
 ) error {
-	_, err := d.rw.ExecContext(ctx, `
+	_, err := d.execContext(ctx, `
 		UPDATE forge_issues
 		SET title = ?, body = ?, updated_at = ?,
 		    last_activity_at = MAX(last_activity_at, ?)
@@ -2634,7 +2657,7 @@ func (d *DB) UpdateMRDerivedFields(
 	number int,
 	fields MRDerivedFields,
 ) error {
-	_, err := d.rw.ExecContext(ctx, `
+	_, err := d.execContext(ctx, `
 		UPDATE forge_merge_requests
 		SET review_decision = ?, comment_count = ?, last_activity_at = ?
 		WHERE repo_id = ? AND number = ?`,
@@ -2655,7 +2678,7 @@ func (d *DB) UpdateMRReviewActivity(
 	reviewDecision string,
 	lastActivityAt time.Time,
 ) error {
-	_, err := d.rw.ExecContext(ctx, `
+	_, err := d.execContext(ctx, `
 		UPDATE forge_merge_requests
 		SET review_decision = ?, last_activity_at = ?
 		WHERE id = ?`, reviewDecision, lastActivityAt, mrID)
@@ -2672,7 +2695,7 @@ func (d *DB) UpdateIssueDerivedFields(
 	number int,
 	fields IssueDerivedFields,
 ) error {
-	_, err := d.rw.ExecContext(ctx, `
+	_, err := d.execContext(ctx, `
 		UPDATE forge_issues
 		SET comment_count = ?, last_activity_at = ?
 		WHERE repo_id = ? AND number = ?`,
@@ -2692,7 +2715,7 @@ func (d *DB) UpdateIssueActivity(
 	issueID int64,
 	lastActivityAt time.Time,
 ) error {
-	_, err := d.rw.ExecContext(ctx, `
+	_, err := d.execContext(ctx, `
 		UPDATE forge_issues
 		SET last_activity_at = ?
 		WHERE id = ?`, lastActivityAt, issueID)
@@ -2710,7 +2733,7 @@ func (d *DB) UpdateMRCIStatus(
 	ciStatus string,
 	ciChecksJSON string,
 ) error {
-	_, err := d.rw.ExecContext(ctx, `
+	_, err := d.execContext(ctx, `
 		UPDATE forge_merge_requests
 		SET ci_status = ?, ci_checks_json = ?
 		WHERE repo_id = ? AND number = ?`,
@@ -2734,7 +2757,7 @@ func (d *DB) UpdateMRCIStatusForHead(
 	ciChecksJSON string,
 	ciHadPending bool,
 ) error {
-	_, err := d.rw.ExecContext(ctx, `
+	_, err := d.execContext(ctx, `
 		UPDATE forge_merge_requests
 		SET ci_status = ?, ci_checks_json = ?, ci_had_pending = ci_had_pending OR ?
 		WHERE repo_id = ? AND number = ? AND platform_head_sha = ?`,
@@ -2759,7 +2782,7 @@ func (d *DB) UpdateClosedMRState(
 	mergedAt, closedAt *time.Time,
 	platformHeadSHA, platformBaseSHA string,
 ) error {
-	_, err := d.rw.ExecContext(ctx, `
+	_, err := d.execContext(ctx, `
 		UPDATE forge_merge_requests
 		SET state = ?, merged_at = ?, closed_at = ?,
 		    updated_at = ?, last_activity_at = ?,
@@ -2777,7 +2800,7 @@ func (d *DB) UpdateClosedMRState(
 // UpdateDiffSHAs stores the locally-verified diff SHAs for a merge request.
 // Called after a successful bare clone fetch and merge-base computation.
 func (d *DB) UpdateDiffSHAs(ctx context.Context, repoID int64, number int, diffHead, diffBase, mergeBase string) error {
-	_, err := d.rw.ExecContext(ctx, `
+	_, err := d.execContext(ctx, `
 		UPDATE forge_merge_requests
 		 SET diff_head_sha = ?, diff_base_sha = ?, merge_base_sha = ?
 		 WHERE repo_id = ? AND number = ?`,
@@ -2796,7 +2819,7 @@ func (d *DB) UpdatePlatformSHAs(
 	repoID int64, number int,
 	platformHead, platformBase string,
 ) error {
-	_, err := d.rw.ExecContext(ctx, `
+	_, err := d.execContext(ctx, `
 		UPDATE forge_merge_requests
 		 SET platform_head_sha = ?, platform_base_sha = ?
 		 WHERE repo_id = ? AND number = ?`,
@@ -2885,7 +2908,7 @@ func (d *DB) UpdateMRState(
 	mergedAt, closedAt *time.Time,
 ) error {
 	now := time.Now().UTC()
-	_, err := d.rw.ExecContext(ctx, `
+	_, err := d.execContext(ctx, `
 		UPDATE forge_merge_requests
 		SET state = ?, merged_at = ?, closed_at = ?,
 		    updated_at = ?, last_activity_at = ?
@@ -3328,7 +3351,7 @@ func (d *DB) UpdateIssueState(
 	closedAt *time.Time,
 ) error {
 	now := time.Now().UTC()
-	_, err := d.rw.ExecContext(ctx, `
+	_, err := d.execContext(ctx, `
 		UPDATE forge_issues SET state = ?, closed_at = ?,
 		    updated_at = ?, last_activity_at = ?
 		WHERE repo_id = ? AND number = ?`,
@@ -3419,7 +3442,51 @@ func (d *DB) UpsertHTTPEtag(
 		return nil
 	}
 	platformHost, owner, name = canonicalRepoLookupIdentifier(platformHost, owner, name)
-	_, err := d.rw.ExecContext(ctx,
+	return d.Tx(ctx, func(tx *sql.Tx) error {
+		return upsertHTTPEtagTx(
+			ctx, tx, platform, platformHost, owner, name,
+			resourceType, resourceNumber, etag,
+		)
+	})
+}
+
+func (d *DB) UpsertHTTPEtagIfRouteFence(
+	ctx context.Context,
+	identity RepoIdentity,
+	fence RepositoryRouteFence,
+	resourceType string,
+	resourceNumber int,
+	etag string,
+) (bool, error) {
+	if etag == "" {
+		return true, nil
+	}
+	identity = canonicalRepoIdentity(identity)
+	guarded := d.WithRepositoryRouteFence(ctx, identity, fence)
+	err := d.Tx(guarded, func(tx *sql.Tx) error {
+		return upsertHTTPEtagTx(
+			guarded, tx, identity.Platform, identity.PlatformHost,
+			identity.OwnerKey, identity.NameKey,
+			resourceType, resourceNumber, etag,
+		)
+	})
+	if errors.Is(err, ErrRepositoryRouteFenceChanged) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("conditionally upsert http etag: %w", err)
+	}
+	return true, nil
+}
+
+func upsertHTTPEtagTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	platform, platformHost, owner, name, resourceType string,
+	resourceNumber int,
+	etag string,
+) error {
+	_, err := tx.ExecContext(ctx,
 		`INSERT INTO forge_http_etags (
 			platform, platform_host, owner_key, name_key,
 			resource_type, resource_number, etag, fetched_at
@@ -3452,7 +3519,7 @@ func (d *DB) UpdateMRDetailFetched(
 	platformHost, repoOwner, repoName = canonicalRepoLookupIdentifier(
 		platformHost, repoOwner, repoName,
 	)
-	_, err := d.rw.ExecContext(ctx, `
+	_, err := d.execContext(ctx, `
 		UPDATE forge_merge_requests
 		SET detail_fetched_at = datetime('now'),
 		    ci_had_pending = ?
@@ -3477,7 +3544,7 @@ func (d *DB) UpdateMRDetailFetchedByRepoID(
 	number int,
 	ciHadPending bool,
 ) error {
-	_, err := d.rw.ExecContext(ctx, `
+	_, err := d.execContext(ctx, `
 		UPDATE forge_merge_requests
 		SET detail_fetched_at = datetime('now'),
 		    ci_had_pending = ?
@@ -3504,7 +3571,7 @@ func (d *DB) UpdateMRWorkflowApproval(
 	required bool,
 	count int,
 ) error {
-	_, err := d.rw.ExecContext(ctx, `
+	_, err := d.execContext(ctx, `
 		UPDATE forge_merge_requests
 		SET workflow_approval_checked_at = ?,
 		    workflow_approval_head_sha   = ?,
@@ -3529,7 +3596,7 @@ func (d *DB) UpdateIssueDetailFetched(
 	platformHost, repoOwner, repoName = canonicalRepoLookupIdentifier(
 		platformHost, repoOwner, repoName,
 	)
-	_, err := d.rw.ExecContext(ctx, `
+	_, err := d.execContext(ctx, `
 		UPDATE forge_issues
 		SET detail_fetched_at = datetime('now')
 		WHERE repo_id = (
@@ -3859,7 +3926,7 @@ func (d *DB) ListCommentAutocompleteReferences(
 func (d *DB) SetStarred(
 	ctx context.Context, itemType string, repoID int64, number int,
 ) error {
-	_, err := d.rw.ExecContext(ctx, `
+	_, err := d.execContext(ctx, `
 		INSERT INTO forge_starred_items (item_type, repo_id, number)
 		VALUES (?, ?, ?)
 		ON CONFLICT(item_type, repo_id, number) DO NOTHING`,
@@ -3875,7 +3942,7 @@ func (d *DB) SetStarred(
 func (d *DB) UnsetStarred(
 	ctx context.Context, itemType string, repoID int64, number int,
 ) error {
-	_, err := d.rw.ExecContext(ctx, `
+	_, err := d.execContext(ctx, `
 		DELETE FROM forge_starred_items
 		WHERE item_type = ? AND repo_id = ? AND number = ?`,
 		itemType, repoID, number,
@@ -4334,7 +4401,7 @@ func (d *DB) InsertWorkspace(
 	if err != nil {
 		return fmt.Errorf("encode workspace kata metadata: %w", err)
 	}
-	_, err = d.rw.ExecContext(ctx, `
+	_, err = d.execContext(ctx, `
 		INSERT INTO forge_workspaces
 		    (id, platform, platform_host, repo_owner, repo_name,
 		     repo_owner_key, repo_name_key, repo_path_key,
@@ -4637,7 +4704,7 @@ func (d *DB) UpdateWorkspaceStatus(
 	id, status string,
 	errMsg *string,
 ) error {
-	_, err := d.rw.ExecContext(ctx, `
+	_, err := d.execContext(ctx, `
 		UPDATE forge_workspaces
 		SET status = ?, error_message = ?
 		WHERE id = ?`,
@@ -4655,7 +4722,7 @@ func (d *DB) UpdateWorkspaceStatus(
 func (d *DB) UpdateWorkspaceBranch(
 	ctx context.Context, id, branch string,
 ) error {
-	result, err := d.rw.ExecContext(ctx, `
+	result, err := d.execContext(ctx, `
 		UPDATE forge_workspaces
 		SET workspace_branch = ?
 		WHERE id = ?`,
@@ -4680,7 +4747,7 @@ func (d *DB) UpdateWorkspaceBranch(
 func (d *DB) CompleteRecoveredWorkspaceSetup(
 	ctx context.Context, id, branch string,
 ) error {
-	_, err := d.rw.ExecContext(ctx, `
+	_, err := d.execContext(ctx, `
 		UPDATE forge_workspaces
 		SET workspace_branch = ?,
 		    status = 'ready',
@@ -4701,7 +4768,7 @@ func (d *DB) CompleteRecoveredWorkspaceSetup(
 func (d *DB) UpdateWorkspaceMRHeadRepo(
 	ctx context.Context, id string, mrHeadRepo *string,
 ) error {
-	_, err := d.rw.ExecContext(ctx, `
+	_, err := d.execContext(ctx, `
 		UPDATE forge_workspaces
 		SET mr_head_repo = ?
 		WHERE id = ?`,
@@ -4724,7 +4791,7 @@ func (d *DB) UpdateWorkspaceMRHeadRepoForMissingRepo(
 	mrHeadRepo *string,
 ) (bool, error) {
 	identity = canonicalRepoIdentity(identity)
-	result, err := d.rw.ExecContext(ctx, `
+	result, err := d.execContext(ctx, `
 		UPDATE forge_workspaces
 		SET mr_head_repo = ?
 		WHERE id = ?
@@ -4786,7 +4853,7 @@ func (d *DB) UpdateWorkspaceMRHeadRepoForSnapshot(
 	expectedRevision int64,
 	mrHeadRepo *string,
 ) (bool, error) {
-	result, err := d.rw.ExecContext(ctx, `
+	result, err := d.execContext(ctx, `
 		UPDATE forge_workspaces
 		SET mr_head_repo = ?
 		WHERE id = ?
@@ -4839,7 +4906,7 @@ func (d *DB) UpdateWorkspaceMRHeadRepoForSnapshot(
 func (d *DB) StartWorkspaceRetry(
 	ctx context.Context, id string,
 ) (bool, error) {
-	res, err := d.rw.ExecContext(ctx, `
+	res, err := d.execContext(ctx, `
 		UPDATE forge_workspaces
 		SET status = 'creating',
 		    error_message = NULL
@@ -4862,7 +4929,7 @@ func (d *DB) StartWorkspaceRetry(
 func (d *DB) SetWorkspaceAssociatedPRNumberIfNull(
 	ctx context.Context, id string, prNumber int,
 ) (bool, error) {
-	res, err := d.rw.ExecContext(ctx, `
+	res, err := d.execContext(ctx, `
 		UPDATE forge_workspaces
 		SET associated_pr_number = ?
 		WHERE id = ? AND associated_pr_number IS NULL`,
@@ -4887,7 +4954,7 @@ func (d *DB) SetWorkspaceAssociatedPRNumberIfNull(
 func (d *DB) InsertWorkspaceSetupEvent(
 	ctx context.Context, event *WorkspaceSetupEvent,
 ) error {
-	_, err := d.rw.ExecContext(ctx, `
+	_, err := d.execContext(ctx, `
 		INSERT INTO forge_workspace_setup_events
 		    (workspace_id, stage, outcome, message)
 		VALUES (?, ?, ?, ?)`,
@@ -4948,7 +5015,7 @@ func (d *DB) UpsertWorkspaceRuntimeSession(
 	if createdAt.IsZero() {
 		createdAt = time.Now().UTC()
 	}
-	_, err := d.rw.ExecContext(ctx, `
+	_, err := d.execContext(ctx, `
 		INSERT INTO forge_workspace_runtime_sessions
 		    (workspace_id, session_key, target_key, label, kind, display_region, scope,
 		     tmux_session, created_at)
@@ -5060,7 +5127,7 @@ func (d *DB) UpdateWorkspaceRuntimeSessionLabel(
 	sessionKey string,
 	label string,
 ) (bool, error) {
-	res, err := d.rw.ExecContext(ctx, `
+	res, err := d.execContext(ctx, `
 		UPDATE forge_workspace_runtime_sessions
 		SET label = ?
 		WHERE workspace_id = ? AND session_key = ?`,
@@ -5102,7 +5169,7 @@ func (d *DB) DeleteWorkspaceRuntimeSession(
 	workspaceID string,
 	sessionKey string,
 ) error {
-	_, err := d.rw.ExecContext(ctx, `
+	_, err := d.execContext(ctx, `
 		DELETE FROM forge_workspace_runtime_sessions
 		WHERE workspace_id = ? AND session_key = ?`,
 		workspaceID, sessionKey,
@@ -5121,7 +5188,7 @@ func (d *DB) DeleteWorkspaceRuntimeSessionCreatedAt(
 	sessionKey string,
 	createdAt time.Time,
 ) (bool, error) {
-	result, err := d.rw.ExecContext(ctx, `
+	result, err := d.execContext(ctx, `
 		DELETE FROM forge_workspace_runtime_sessions
 		WHERE workspace_id = ? AND session_key = ? AND created_at = ?`,
 		workspaceID, sessionKey, canonicalUTCTime(createdAt),
@@ -5142,7 +5209,7 @@ func (d *DB) DeleteWorkspaceRuntimeSessions(
 	ctx context.Context,
 	workspaceID string,
 ) error {
-	_, err := d.rw.ExecContext(ctx, `
+	_, err := d.execContext(ctx, `
 		DELETE FROM forge_workspace_runtime_sessions
 		WHERE workspace_id = ?`, workspaceID,
 	)
@@ -5156,7 +5223,7 @@ func (d *DB) DeleteWorkspaceRuntimeSessions(
 func (d *DB) DeleteWorkspace(
 	ctx context.Context, id string,
 ) error {
-	_, err := d.rw.ExecContext(ctx,
+	_, err := d.execContext(ctx,
 		`DELETE FROM forge_workspaces WHERE id = ?`, id,
 	)
 	if err != nil {

--- a/internal/db/queries_archive.go
+++ b/internal/db/queries_archive.go
@@ -344,7 +344,7 @@ func (d *DB) RequeueArchiveLifecycleDetails(
 	args := []any{archiveLifecycleDetailsGeneration, formatDatasetProgressTime(now)}
 	args = append(args, archiveRepoIDArgs(repoIDs)...)
 	args = append(args, archiveLifecycleDetailsGeneration)
-	_, err := d.rw.ExecContext(ctx, fmt.Sprintf(`
+	_, err := d.execContext(ctx, fmt.Sprintf(`
 		UPDATE forge_archive_dataset_progress
 		SET scan_generation = ?,
 			next_cursor = NULL, last_input_cursor = NULL,
@@ -403,7 +403,7 @@ func (d *DB) RequeueArchiveLifecycleDetails(
 // DeferArchiveRepository records provider-host admission waits without
 // incrementing item attempts. A later successful request clears this state.
 func (d *DB) DeferArchiveRepository(ctx context.Context, repoID int64, retryAt time.Time, detail string, now time.Time) error {
-	result, err := d.rw.ExecContext(ctx, `
+	result, err := d.execContext(ctx, `
 		UPDATE forge_archive_repos
 		SET last_error_code = ?, last_error_detail = ?, next_retry_at = ?, updated_at = ?
 		WHERE repo_id = ?`, ArchiveErrorCodeBudgetExhausted,
@@ -422,7 +422,7 @@ func (d *DB) DeferArchiveRepository(ctx context.Context, repoID int64, retryAt t
 }
 
 func (d *DB) ClearArchiveRepositoryError(ctx context.Context, repoID int64, now time.Time) error {
-	_, err := d.rw.ExecContext(ctx, `
+	_, err := d.execContext(ctx, `
 		UPDATE forge_archive_repos
 		SET last_error_code = CASE WHEN last_error_code = ? THEN NULL ELSE last_error_code END,
 			last_error_detail = CASE WHEN last_error_code = ? THEN NULL ELSE last_error_detail END,
@@ -445,7 +445,7 @@ func (d *DB) RetryArchiveAuthentication(ctx context.Context, repoIDs []int64, no
 		return nil
 	}
 	args := append([]any{now.UTC()}, archiveRepoIDArgs(repoIDs)...)
-	_, err := d.rw.ExecContext(ctx, fmt.Sprintf(`
+	_, err := d.execContext(ctx, fmt.Sprintf(`
 		UPDATE forge_archive_repos
 		SET last_error_code = NULL, last_error_detail = NULL,
 			next_retry_at = NULL, updated_at = MAX(updated_at, ?)

--- a/internal/db/queries_archive_scans.go
+++ b/internal/db/queries_archive_scans.go
@@ -249,7 +249,7 @@ func (d *DB) BlockArchiveRepoScan(
 	code string,
 	detail string,
 ) error {
-	_, err := d.rw.ExecContext(ctx, `
+	_, err := d.execContext(ctx, `
 		UPDATE forge_archive_repo_scans
 		SET status = 'blocked', last_error_code = ?, last_error_detail = ?, updated_at = ?
 		WHERE repo_id = ? AND scan = ?

--- a/internal/db/queries_branch_activity.go
+++ b/internal/db/queries_branch_activity.go
@@ -129,7 +129,7 @@ func (d *DB) GetBranchTip(
 
 func (d *DB) UpsertBranchTip(ctx context.Context, tip BranchTip) error {
 	canonicalizeBranchTipTimestamps(&tip)
-	_, err := d.rw.ExecContext(ctx, `
+	_, err := d.execContext(ctx, `
 		INSERT INTO forge_branch_tips (
 		    repo_id, branch_name, tip_sha, observed_at
 		)
@@ -159,7 +159,7 @@ func (d *DB) InsertBranchForcePush(
 	fp BranchForcePush,
 ) error {
 	canonicalizeBranchForcePushTimestamps(&fp)
-	_, err := d.rw.ExecContext(ctx, `
+	_, err := d.execContext(ctx, `
 		INSERT INTO forge_branch_force_pushes (
 		    repo_id, branch_name, before_sha, after_sha, before_observed_at,
 		    detected_at

--- a/internal/db/queries_github_native_stacks.go
+++ b/internal/db/queries_github_native_stacks.go
@@ -136,7 +136,7 @@ func (d *DB) DeleteGitHubNativeStacks(ctx context.Context, repoID int64, numbers
 	for _, number := range numbers {
 		args = append(args, number)
 	}
-	if _, err := d.rw.ExecContext(ctx,
+	if _, err := d.execContext(ctx,
 		`DELETE FROM github_native_stacks WHERE repo_id = ? AND stack_number IN (`+
 			sqlPlaceholders(len(numbers))+`)`, args...,
 	); err != nil {

--- a/internal/db/queries_host_runtime.go
+++ b/internal/db/queries_host_runtime.go
@@ -27,7 +27,7 @@ func (d *DB) UpsertHostRuntimeTmuxSession(
 	if createdAt.IsZero() {
 		createdAt = time.Now().UTC()
 	}
-	_, err := d.rw.ExecContext(ctx, `
+	_, err := d.execContext(ctx, `
 		INSERT INTO forge_host_runtime_sessions
 		    (session_key, runtime_backend, backend_session_key, label, cwd,
 		     created_at)
@@ -88,7 +88,7 @@ func (d *DB) DeleteHostRuntimeTmuxSession(
 	ctx context.Context,
 	sessionKey string,
 ) error {
-	_, err := d.rw.ExecContext(ctx, `
+	_, err := d.execContext(ctx, `
 		DELETE FROM forge_host_runtime_sessions
 		WHERE session_key = ? AND runtime_backend = 'tmux'`, sessionKey,
 	)
@@ -108,7 +108,7 @@ func (d *DB) DeleteHostRuntimeTmuxSessionCreatedAt(
 	sessionKey string,
 	createdAt time.Time,
 ) (bool, error) {
-	result, err := d.rw.ExecContext(ctx, `
+	result, err := d.execContext(ctx, `
 		DELETE FROM forge_host_runtime_sessions
 		WHERE session_key = ?
 		  AND runtime_backend = 'tmux'

--- a/internal/db/queries_notifications.go
+++ b/internal/db/queries_notifications.go
@@ -185,24 +185,29 @@ func (d *DB) UpsertNotifications(ctx context.Context, notifications []Notificati
 		return nil
 	}
 	return d.Tx(ctx, func(tx *sql.Tx) error {
-		for i := range notifications {
-			n := notifications[i]
-			if err := canonicalizeNotification(&n); err != nil {
-				return err
-			}
-			if n.SyncedAt.IsZero() {
-				n.SyncedAt = time.Now().UTC()
-			}
-			var repoID *int64
-			if n.RepoID != nil {
-				repoID = n.RepoID
-			} else if id, found, err := lookupNotificationRepoIDTx(ctx, tx, n.Platform, n.PlatformHost, n.RepoOwner, n.RepoName); err != nil {
-				return err
-			} else if found {
-				repoID = &id
-			}
+		return upsertNotificationsTx(ctx, tx, notifications)
+	})
+}
 
-			_, err := tx.ExecContext(ctx, `
+func upsertNotificationsTx(ctx context.Context, tx *sql.Tx, notifications []Notification) error {
+	for i := range notifications {
+		n := notifications[i]
+		if err := canonicalizeNotification(&n); err != nil {
+			return err
+		}
+		if n.SyncedAt.IsZero() {
+			n.SyncedAt = time.Now().UTC()
+		}
+		var repoID *int64
+		if n.RepoID != nil {
+			repoID = n.RepoID
+		} else if id, found, err := lookupNotificationRepoIDTx(ctx, tx, n.Platform, n.PlatformHost, n.RepoOwner, n.RepoName); err != nil {
+			return err
+		} else if found {
+			repoID = &id
+		}
+
+		_, err := tx.ExecContext(ctx, `
 				INSERT INTO forge_notification_items (
 					platform, platform_host, platform_notification_id, repo_id, repo_owner, repo_name,
 					subject_type, subject_title, subject_url, subject_latest_comment_url, web_url,
@@ -330,19 +335,54 @@ func (d *DB) UpsertNotifications(ctx context.Context, notifications []Notificati
 						ELSE forge_notification_items.source_ack_generation_at
 					END
 				WHERE excluded.source_updated_at >= forge_notification_items.source_updated_at`,
-				n.Platform, n.PlatformHost, n.PlatformNotificationID, nullableInt64(repoID), n.RepoOwner, n.RepoName,
-				n.SubjectType, n.SubjectTitle, n.SubjectURL, n.SubjectLatestCommentURL, n.WebURL,
-				nullableInt(n.ItemNumber), n.ItemType, n.ItemAuthor, n.Reason, boolInt(n.Unread), boolInt(n.Participating),
-				n.SourceUpdatedAt, nullableNotificationTime(n.SourceLastAcknowledgedAt), n.SyncedAt, nullableNotificationTime(n.DoneAt), n.DoneReason,
-				nullableNotificationTime(n.SourceAckQueuedAt), nullableNotificationTime(n.SourceAckSyncedAt), nullableNotificationTime(n.SourceAckGenerationAt), n.SourceAckError, n.SourceAckAttempts,
-				nullableNotificationTime(n.SourceAckLastAttemptAt), nullableNotificationTime(n.SourceAckNextAttemptAt),
-			)
-			if err != nil {
-				return fmt.Errorf("upsert notification %s: %w", n.PlatformNotificationID, err)
-			}
+			n.Platform, n.PlatformHost, n.PlatformNotificationID, nullableInt64(repoID), n.RepoOwner, n.RepoName,
+			n.SubjectType, n.SubjectTitle, n.SubjectURL, n.SubjectLatestCommentURL, n.WebURL,
+			nullableInt(n.ItemNumber), n.ItemType, n.ItemAuthor, n.Reason, boolInt(n.Unread), boolInt(n.Participating),
+			n.SourceUpdatedAt, nullableNotificationTime(n.SourceLastAcknowledgedAt), n.SyncedAt, nullableNotificationTime(n.DoneAt), n.DoneReason,
+			nullableNotificationTime(n.SourceAckQueuedAt), nullableNotificationTime(n.SourceAckSyncedAt), nullableNotificationTime(n.SourceAckGenerationAt), n.SourceAckError, n.SourceAckAttempts,
+			nullableNotificationTime(n.SourceAckLastAttemptAt), nullableNotificationTime(n.SourceAckNextAttemptAt),
+		)
+		if err != nil {
+			return fmt.Errorf("upsert notification %s: %w", n.PlatformNotificationID, err)
 		}
+	}
+	return nil
+}
+
+func (d *DB) UpsertNotificationsIfRouteFence(
+	ctx context.Context,
+	notifications []Notification,
+	identity RepoIdentity,
+	fence RepositoryRouteFence,
+) (bool, error) {
+	identity = canonicalRepoIdentity(identity)
+	release, err := d.LockRepositoryReconciliationRead(ctx)
+	if err != nil {
+		return false, err
+	}
+	defer release()
+
+	committed := false
+	err = d.Tx(ctx, func(tx *sql.Tx) error {
+		matches, err := repositoryRouteFenceMatchesTx(
+			ctx, tx, identity, fence,
+		)
+		if err != nil {
+			return err
+		}
+		if !matches {
+			return nil
+		}
+		if err := upsertNotificationsTx(ctx, tx, notifications); err != nil {
+			return err
+		}
+		committed = true
 		return nil
 	})
+	if err != nil {
+		return false, fmt.Errorf("conditionally upsert notifications: %w", err)
+	}
+	return committed, nil
 }
 
 // LatestOpenPRNotificationActivity returns the newest notification timestamp
@@ -838,7 +878,7 @@ func (d *DB) UpdateNotificationSyncWatermark(ctx context.Context, platform, host
 	}
 	syncedAt = canonicalUTCTime(syncedAt)
 	lastFullValue := nullableNotificationTime(lastFullSyncedAt)
-	_, err = d.rw.ExecContext(ctx, `
+	_, err = d.execContext(ctx, `
 		INSERT INTO forge_notification_sync_watermarks (platform, platform_host, repo_owner, repo_name, last_successful_sync_at, last_full_sync_at)
 		VALUES (?, ?, ?, ?, ?, ?)
 		ON CONFLICT(platform, platform_host, repo_owner, repo_name) DO UPDATE SET
@@ -849,6 +889,67 @@ func (d *DB) UpdateNotificationSyncWatermark(ctx context.Context, platform, host
 		return fmt.Errorf("update notification sync watermark: %w", err)
 	}
 	return nil
+}
+
+func (d *DB) UpdateNotificationSyncWatermarkIfRouteFence(
+	ctx context.Context,
+	platform, host, owner, name string,
+	fence RepositoryRouteFence,
+	syncedAt time.Time,
+	lastFullSyncedAt *time.Time,
+) (bool, error) {
+	var err error
+	platform, host, err = canonicalizeNotificationPlatformHost(platform, host)
+	if err != nil {
+		return false, err
+	}
+	owner, name, err = canonicalizeNotificationRepo(owner, name)
+	if err != nil {
+		return false, err
+	}
+	syncedAt = canonicalUTCTime(syncedAt)
+	lastFullValue := nullableNotificationTime(lastFullSyncedAt)
+	identity := canonicalRepoIdentity(RepoIdentity{
+		Platform: platform, PlatformHost: host, Owner: owner, Name: name,
+	})
+	release, err := d.LockRepositoryReconciliationRead(ctx)
+	if err != nil {
+		return false, err
+	}
+	defer release()
+
+	committed := false
+	err = d.Tx(ctx, func(tx *sql.Tx) error {
+		matches, err := repositoryRouteFenceMatchesTx(
+			ctx, tx, identity, fence,
+		)
+		if err != nil {
+			return err
+		}
+		if !matches {
+			return nil
+		}
+		_, err = tx.ExecContext(ctx, `
+		INSERT INTO forge_notification_sync_watermarks (
+			platform, platform_host, repo_owner, repo_name,
+			last_successful_sync_at, last_full_sync_at
+		)
+		VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(platform, platform_host, repo_owner, repo_name) DO UPDATE SET
+			last_successful_sync_at = excluded.last_successful_sync_at,
+			last_full_sync_at = excluded.last_full_sync_at`,
+			platform, host, owner, name, syncedAt, lastFullValue,
+		)
+		if err != nil {
+			return err
+		}
+		committed = true
+		return nil
+	})
+	if err != nil {
+		return false, fmt.Errorf("conditionally update notification sync watermark: %w", err)
+	}
+	return committed, nil
 }
 
 func (d *DB) MarkNotificationsAcknowledged(ctx context.Context, platform, host string, notificationIDs []string, acknowledgedAt time.Time) error {
@@ -865,7 +966,7 @@ func (d *DB) MarkNotificationsAcknowledged(ctx context.Context, platform, host s
 	for _, id := range notificationIDs {
 		args = append(args, id)
 	}
-	_, err = d.rw.ExecContext(ctx, fmt.Sprintf(`UPDATE forge_notification_items
+	_, err = d.execContext(ctx, fmt.Sprintf(`UPDATE forge_notification_items
 		SET unread = 0, source_last_acknowledged_at = ?, source_ack_synced_at = ?, source_ack_queued_at = NULL, source_ack_generation_at = NULL,
 		    source_ack_error = '', source_ack_attempts = 0, source_ack_last_attempt_at = NULL, source_ack_next_attempt_at = NULL
 		WHERE platform = ? AND platform_host = ? AND platform_notification_id IN (%s)`, sqlPlaceholders(len(notificationIDs))), args...)
@@ -889,6 +990,17 @@ func (d *DB) ListQueuedNotificationAcks(ctx context.Context, platform, host stri
 		  AND n.source_ack_synced_at IS NULL
 		  AND n.source_ack_error != 'max_attempts_exceeded'
 		  AND COALESCE(n.source_ack_next_attempt_at, n.source_ack_queued_at) <= ?
+		  AND (
+		      n.repo_id IS NULL
+		      OR EXISTS (
+		          SELECT 1
+		          FROM forge_repo_routes route
+		          WHERE route.repo_id = n.repo_id
+		            AND route.platform = n.platform
+		            AND route.platform_host = n.platform_host
+		            AND route.is_current = 1
+		      )
+		  )
 		ORDER BY n.source_ack_queued_at ASC, n.id ASC LIMIT ?`, notificationSelectColumns), platform, host, canonicalUTCTime(now), limit)
 	if err != nil {
 		return nil, fmt.Errorf("list queued notification acks: %w", err)
@@ -902,7 +1014,38 @@ func (d *DB) ListQueuedNotificationAcks(ctx context.Context, platform, host stri
 		}
 		notifications = append(notifications, n)
 	}
-	return notifications, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	// Queued acknowledgements outlive route renames: a row resolved to a
+	// stable repository carries that repository's current owner/name, so
+	// propagation fences, credential selection, and routed mark-read calls
+	// follow the live route instead of failing against the cached
+	// historical one and dropping the acknowledgement.
+	repoRoutes := map[int64]*Repo{}
+	for i := range notifications {
+		repoID := notifications[i].RepoID
+		if repoID == nil {
+			continue
+		}
+		repo, seen := repoRoutes[*repoID]
+		if !seen {
+			repo, err = d.GetRepoByID(ctx, *repoID)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"resolve queued notification ack repository: %w", err,
+				)
+			}
+			repoRoutes[*repoID] = repo
+		}
+		if repo == nil || repo.Platform != platform || repo.PlatformHost != host ||
+			repo.Owner == "" || repo.Name == "" {
+			continue
+		}
+		notifications[i].RepoOwner = repo.Owner
+		notifications[i].RepoName = repo.Name
+	}
+	return notifications, nil
 }
 
 func (d *DB) NotificationAckPropagationCurrent(ctx context.Context, id int64, queuedAt *time.Time, sourceUpdatedAt time.Time) (bool, error) {
@@ -927,7 +1070,7 @@ func (d *DB) MarkNotificationAckPropagationResult(ctx context.Context, id int64,
 		synced := canonicalUTCTime(*syncedAt)
 		queuedAtValue := nullableNotificationTime(queuedAt)
 		sourceUpdatedAt = canonicalUTCTime(sourceUpdatedAt)
-		_, err := d.rw.ExecContext(ctx, `UPDATE forge_notification_items
+		_, err := d.execContext(ctx, `UPDATE forge_notification_items
 			SET unread = 0,
 			    source_last_acknowledged_at = ?,
 			    source_ack_synced_at = ?,
@@ -945,7 +1088,7 @@ func (d *DB) MarkNotificationAckPropagationResult(ctx context.Context, id int64,
 		return nil
 	}
 	now := time.Now().UTC()
-	_, err := d.rw.ExecContext(ctx, `UPDATE forge_notification_items
+	_, err := d.execContext(ctx, `UPDATE forge_notification_items
 		SET source_ack_error = ?, source_ack_attempts = source_ack_attempts + 1,
 		    source_ack_last_attempt_at = ?, source_ack_next_attempt_at = ?
 		WHERE id = ? AND source_ack_queued_at = ? AND source_updated_at = ?`, errText, now, nullableNotificationTime(nextAttemptAt), id, nullableNotificationTime(queuedAt), canonicalUTCTime(sourceUpdatedAt))
@@ -958,7 +1101,7 @@ func (d *DB) MarkNotificationAckPropagationResult(ctx context.Context, id int64,
 // ReopenNotificationAckPropagation restores a locally read notification to
 // unread when a successful upstream read ack cannot be reconciled safely.
 func (d *DB) ReopenNotificationAckPropagation(ctx context.Context, id int64, queuedAt *time.Time, sourceUpdatedAt time.Time) error {
-	_, err := d.rw.ExecContext(ctx, `UPDATE forge_notification_items
+	_, err := d.execContext(ctx, `UPDATE forge_notification_items
 		SET unread = 1,
 		    source_ack_queued_at = NULL,
 		    source_ack_synced_at = NULL,
@@ -975,11 +1118,35 @@ func (d *DB) ReopenNotificationAckPropagation(ctx context.Context, id int64, que
 	return nil
 }
 
+// ReactivateNotificationAckPropagation reopens a guarded acknowledgement and
+// clears local completion after confirmed newer unread provider activity.
+func (d *DB) ReactivateNotificationAckPropagation(ctx context.Context, id int64, queuedAt *time.Time, sourceUpdatedAt time.Time) error {
+	_, err := d.execContext(ctx, `UPDATE forge_notification_items
+		SET unread = 1,
+		    done_at = NULL,
+		    done_reason = '',
+		    source_ack_queued_at = NULL,
+		    source_ack_synced_at = NULL,
+		    source_ack_generation_at = NULL,
+		    source_ack_error = '',
+		    source_ack_attempts = 0,
+		    source_ack_last_attempt_at = NULL,
+		    source_ack_next_attempt_at = NULL
+		WHERE id = ? AND source_ack_queued_at = ? AND source_updated_at = ?`,
+		id, nullableNotificationTime(queuedAt), canonicalUTCTime(sourceUpdatedAt))
+	if err != nil {
+		return fmt.Errorf("reactivate notification ack propagation: %w", err)
+	}
+	return nil
+}
+
 // NotificationRepoRef identifies one repository whose queued acknowledgements
-// share a credential.
+// share a credential. RepoID fences linked rows across route renames; Owner and
+// Name remain necessary for unlinked legacy rows.
 type NotificationRepoRef struct {
-	Owner string
-	Name  string
+	RepoID int64
+	Owner  string
+	Name   string
 }
 
 // DeferQueuedNotificationAcksForRepos defers queued acknowledgements for the
@@ -1005,12 +1172,27 @@ func (d *DB) DeferQueuedNotificationAcksForRepos(
 	now := time.Now().UTC()
 	nextAttemptAt = canonicalUTCTime(nextAttemptAt)
 	args := []any{errText, now, nextAttemptAt, nextAttemptAt, platform, host}
-	placeholders := make([]string, 0, len(repos))
+	repoIDPlaceholders := make([]string, 0, len(repos))
+	routePlaceholders := make([]string, 0, len(repos))
+	repoIDArgs := make([]any, 0, len(repos))
+	routeArgs := make([]any, 0, len(repos)*2)
 	for _, repo := range repos {
-		placeholders = append(placeholders, "(LOWER(?), LOWER(?))")
-		args = append(args, repo.Owner, repo.Name)
+		if repo.RepoID > 0 {
+			repoIDPlaceholders = append(repoIDPlaceholders, "?")
+			repoIDArgs = append(repoIDArgs, repo.RepoID)
+		}
+		routePlaceholders = append(routePlaceholders, "(LOWER(?), LOWER(?))")
+		routeArgs = append(routeArgs, repo.Owner, repo.Name)
 	}
-	_, err = d.rw.ExecContext(ctx, `UPDATE forge_notification_items
+	match := make([]string, 0, 2)
+	if len(repoIDPlaceholders) > 0 {
+		match = append(match, "repo_id IN ("+strings.Join(repoIDPlaceholders, ", ")+")")
+		args = append(args, repoIDArgs...)
+	}
+	match = append(match, "(repo_id IS NULL AND (LOWER(repo_owner), LOWER(repo_name)) IN ("+
+		strings.Join(routePlaceholders, ", ")+"))")
+	args = append(args, routeArgs...)
+	_, err = d.execContext(ctx, `UPDATE forge_notification_items
 		SET source_ack_error = ?, source_ack_last_attempt_at = ?,
 		    source_ack_next_attempt_at = CASE
 			    WHEN source_ack_next_attempt_at IS NULL OR source_ack_next_attempt_at < ? THEN ?
@@ -1021,8 +1203,7 @@ func (d *DB) DeferQueuedNotificationAcksForRepos(
 		  AND source_ack_queued_at IS NOT NULL
 		  AND source_ack_synced_at IS NULL
 		  AND source_ack_error != 'max_attempts_exceeded'
-		  AND (LOWER(repo_owner), LOWER(repo_name)) IN (`+
-		strings.Join(placeholders, ", ")+`)`, args...)
+		  AND (`+strings.Join(match, " OR ")+`)`, args...)
 	if err != nil {
 		return fmt.Errorf("defer queued notification acks for repos: %w", err)
 	}
@@ -1031,7 +1212,7 @@ func (d *DB) DeferQueuedNotificationAcksForRepos(
 
 func (d *DB) MarkClosedLinkedNotificationsDone(ctx context.Context, now time.Time) error {
 	now = canonicalUTCTime(now)
-	_, err := d.rw.ExecContext(ctx, `
+	_, err := d.execContext(ctx, `
 		UPDATE forge_notification_items
 		SET done_at = COALESCE(done_at, ?), done_reason = 'closed'
 		WHERE done_at IS NULL
@@ -1054,7 +1235,7 @@ func (d *DB) MarkClosedLinkedNotificationsDone(ctx context.Context, now time.Tim
 	if err != nil {
 		return fmt.Errorf("mark closed pr notifications done: %w", err)
 	}
-	_, err = d.rw.ExecContext(ctx, `
+	_, err = d.execContext(ctx, `
 		UPDATE forge_notification_items
 		SET done_at = COALESCE(done_at, ?), done_reason = 'closed'
 		WHERE done_at IS NULL

--- a/internal/db/queries_notifications_test.go
+++ b/internal/db/queries_notifications_test.go
@@ -870,6 +870,63 @@ func TestNotificationSyncWatermarksAreScopedByRepoIdentity(t *testing.T) {
 	require.Nil(missing)
 }
 
+func TestConditionalNotificationWritesRejectABARouteReuse(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	observedAt := time.Now().UTC()
+	originalIdentity := RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "original-repo", Owner: "acme", Name: "alpha",
+		RepoPath: "acme/alpha",
+	}
+	original, _, err := database.ReconcileRepositoryObservation(
+		ctx, originalIdentity, observedAt,
+	)
+	require.NoError(err)
+	fence, found, err := database.CurrentRepositoryRouteFence(
+		ctx, originalIdentity, original.Repository.ID,
+	)
+	require.NoError(err)
+	require.True(found)
+
+	_, _, err = database.ReconcileRepositoryObservation(ctx, RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "original-repo", Owner: "acme", Name: "beta",
+		RepoPath: "acme/beta",
+	}, observedAt.Add(time.Minute))
+	require.NoError(err)
+	_, _, err = database.ReconcileRepositoryObservation(ctx, RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "replacement-repo", Owner: "acme", Name: "alpha",
+		RepoPath: "acme/alpha",
+	}, observedAt.Add(2*time.Minute))
+	require.NoError(err)
+	_, _, err = database.ReconcileRepositoryObservation(ctx, RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "replacement-repo", Owner: "acme", Name: "gamma",
+		RepoPath: "acme/gamma",
+	}, observedAt.Add(3*time.Minute))
+	require.NoError(err)
+	_, _, err = database.ReconcileRepositoryObservation(
+		ctx, originalIdentity, observedAt.Add(4*time.Minute),
+	)
+	require.NoError(err)
+
+	committed, err := database.UpsertNotificationsIfRouteFence(
+		ctx, nil, originalIdentity, fence,
+	)
+	require.NoError(err)
+	require.False(committed)
+
+	committed, err = database.UpdateNotificationSyncWatermarkIfRouteFence(
+		ctx, "github", "github.com", "acme", "alpha",
+		fence, observedAt.Add(5*time.Minute), nil,
+	)
+	require.NoError(err)
+	require.False(committed)
+}
+
 func TestQueuedNotificationAcksStayWithinPlatformAndHost(t *testing.T) {
 	require := require.New(t)
 	d := openTestDB(t)
@@ -1065,4 +1122,201 @@ func TestNotificationSummaryGroupsByCurrentRoute(t *testing.T) {
 	assert.Equal(1, summary.ByRepo["github.com/acme/gadget"],
 		"summary must group linked rows by the current route")
 	assert.NotContains(summary.ByRepo, "github.com/acme/widget")
+}
+
+// TestListQueuedNotificationAcksFollowsRenamedRepositoryRoute pins the queued
+// acknowledgement listing to the repository's current route: rows resolved to
+// a stable repository must carry its live owner/name after a rename so
+// propagation fences and routed mark-read calls do not fail against the
+// cached historical route.
+func TestListQueuedNotificationAcksFollowsRenamedRepositoryRoute(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	now := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	entry, accepted, err := d.ReconcileRepositoryObservation(ctx, RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "R_widget", Owner: "acme", Name: "widget",
+	}, now)
+	require.NoError(err)
+	require.True(accepted)
+	repoID := entry.Repository.ID
+	number := 7
+	require.NoError(d.UpsertNotifications(ctx, []Notification{{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformNotificationID: "thread-1",
+		RepoID:                 &repoID, RepoOwner: "acme", RepoName: "widget",
+		SubjectType: "PullRequest", SubjectTitle: "Please review",
+		WebURL:     "https://github.com/acme/widget/pull/7",
+		ItemNumber: &number, ItemType: "pr", Reason: "mention",
+		Unread: true, SourceUpdatedAt: now, SyncedAt: now,
+	}}))
+	items, err := d.ListNotifications(ctx, ListNotificationsOpts{State: "unread"})
+	require.NoError(err)
+	require.Len(items, 1)
+	_, err = d.MarkNotificationsDone(ctx, []int64{items[0].ID}, now.Add(time.Minute), true)
+	require.NoError(err)
+
+	_, accepted, err = d.ReconcileRepositoryObservation(ctx, RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "R_widget", Owner: "acme", Name: "renamed",
+	}, now.Add(2*time.Minute))
+	require.NoError(err)
+	require.True(accepted)
+
+	queued, err := d.ListQueuedNotificationAcks(
+		ctx, "github", "github.com", 10, now.Add(3*time.Minute),
+	)
+	require.NoError(err)
+	require.Len(queued, 1)
+	assert.Equal("acme", queued[0].RepoOwner)
+	assert.Equal("renamed", queued[0].RepoName)
+}
+
+func TestListQueuedNotificationAcksDoesNotLetUnroutableLinkedRowsConsumeLimit(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	now := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+
+	stale, accepted, err := d.ReconcileRepositoryObservation(ctx, RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "R_stale", Owner: "acme", Name: "widget",
+	}, now)
+	require.NoError(err)
+	require.True(accepted)
+	staleNotification := notificationFixture("stale-thread", "mention", now)
+	staleNotification.RepoID = &stale.Repository.ID
+	require.NoError(d.UpsertNotifications(ctx, []Notification{staleNotification}))
+	var staleNotificationID int64
+	require.NoError(d.ReadDB().QueryRowContext(ctx, `
+		SELECT id FROM forge_notification_items
+		WHERE platform_notification_id = 'stale-thread'
+	`).Scan(&staleNotificationID))
+	_, err = d.MarkNotificationsDone(
+		ctx, []int64{staleNotificationID}, now.Add(time.Minute), true,
+	)
+	require.NoError(err)
+
+	// Reusing the route leaves the original repository and its queued
+	// acknowledgement linked by stable ID, but without a current route.
+	_, accepted, err = d.ReconcileRepositoryObservation(ctx, RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "R_replacement", Owner: "acme", Name: "widget",
+	}, now.Add(2*time.Minute))
+	require.NoError(err)
+	require.True(accepted)
+
+	current, accepted, err := d.ReconcileRepositoryObservation(ctx, RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "R_current", Owner: "acme", Name: "gadget",
+	}, now.Add(3*time.Minute))
+	require.NoError(err)
+	require.True(accepted)
+	currentNotification := notificationFixture(
+		"current-thread", "mention", now.Add(3*time.Minute),
+	)
+	currentNotification.RepoID = &current.Repository.ID
+	currentNotification.RepoName = "gadget"
+	require.NoError(d.UpsertNotifications(ctx, []Notification{currentNotification}))
+	var currentNotificationID int64
+	require.NoError(d.ReadDB().QueryRowContext(ctx, `
+		SELECT id FROM forge_notification_items
+		WHERE platform_notification_id = 'current-thread'
+	`).Scan(&currentNotificationID))
+	_, err = d.MarkNotificationsDone(
+		ctx, []int64{currentNotificationID}, now.Add(4*time.Minute), true,
+	)
+	require.NoError(err)
+
+	queued, err := d.ListQueuedNotificationAcks(
+		ctx, "github", "github.com", 1, now.Add(5*time.Minute),
+	)
+	require.NoError(err)
+	require.Len(queued, 1)
+	assert.Equal("current-thread", queued[0].PlatformNotificationID)
+
+	var staleStillQueued int
+	require.NoError(d.ReadDB().QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM forge_notification_items
+		WHERE platform_notification_id = 'stale-thread'
+		  AND source_ack_queued_at IS NOT NULL
+		  AND source_ack_synced_at IS NULL
+	`).Scan(&staleStillQueued))
+	assert.Equal(1, staleStillQueued)
+}
+
+func TestDeferQueuedNotificationAcksUsesStableRepoIDAfterRename(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	now := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	entry, accepted, err := d.ReconcileRepositoryObservation(ctx, RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "R_widget", Owner: "acme", Name: "widget",
+	}, now)
+	require.NoError(err)
+	require.True(accepted)
+	repoID := entry.Repository.ID
+	number := 7
+	require.NoError(d.UpsertNotifications(ctx, []Notification{{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformNotificationID: "linked-old-route",
+		RepoID:                 &repoID, RepoOwner: "acme", RepoName: "widget",
+		SubjectType: "PullRequest", SubjectTitle: "linked",
+		ItemNumber: &number, ItemType: "pr", Reason: "mention",
+		Unread: true, SourceUpdatedAt: now, SyncedAt: now,
+	}}))
+
+	_, accepted, err = d.ReconcileRepositoryObservation(ctx, RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "R_widget", Owner: "acme", Name: "renamed",
+	}, now.Add(time.Minute))
+	require.NoError(err)
+	require.True(accepted)
+	require.NoError(d.UpsertNotifications(ctx, []Notification{{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformNotificationID: "legacy-current-route",
+		RepoOwner:              "acme", RepoName: "renamed",
+		SubjectType: "PullRequest", SubjectTitle: "legacy current",
+		ItemNumber: &number, ItemType: "pr", Reason: "mention",
+		Unread: true, SourceUpdatedAt: now.Add(time.Minute), SyncedAt: now.Add(time.Minute),
+	}}))
+	_, err = d.WriteDB().ExecContext(ctx, `
+		UPDATE forge_notification_items SET repo_id = NULL
+		WHERE platform_notification_id = 'legacy-current-route'
+	`)
+	require.NoError(err)
+
+	items, err := d.ListNotifications(ctx, ListNotificationsOpts{State: "all"})
+	require.NoError(err)
+	require.Len(items, 2)
+	ids := make([]int64, 0, len(items))
+	for _, item := range items {
+		ids = append(ids, item.ID)
+	}
+	_, err = d.QueueNotificationIDsRead(ctx, ids, now.Add(2*time.Minute))
+	require.NoError(err)
+	nextAttemptAt := now.Add(time.Hour)
+	require.NoError(d.DeferQueuedNotificationAcksForRepos(
+		ctx, "github", "github.com",
+		[]NotificationRepoRef{{RepoID: repoID, Owner: "acme", Name: "renamed"}},
+		nextAttemptAt, "rate_limited",
+	))
+
+	items, err = d.ListNotifications(ctx, ListNotificationsOpts{State: "all"})
+	require.NoError(err)
+	byThread := make(map[string]Notification, len(items))
+	for _, item := range items {
+		byThread[item.PlatformNotificationID] = item
+	}
+	for _, thread := range []string{"linked-old-route", "legacy-current-route"} {
+		assert.Equal("rate_limited", byThread[thread].SourceAckError)
+		if assert.NotNil(byThread[thread].SourceAckNextAttemptAt) {
+			assert.Equal(nextAttemptAt, *byThread[thread].SourceAckNextAttemptAt)
+		}
+	}
 }

--- a/internal/db/queries_projects.go
+++ b/internal/db/queries_projects.go
@@ -109,7 +109,7 @@ func (d *DB) CreateProject(ctx context.Context, in CreateProjectInput) (*Project
 
 	defaultBranch := strings.TrimSpace(in.DefaultBranch)
 
-	_, err = d.rw.ExecContext(ctx,
+	_, err = d.execContext(ctx,
 		`INSERT INTO forge_projects (
 		    id, display_name, local_path, repo_id, default_branch
 		 ) VALUES (?, ?, ?, ?, ?)`,
@@ -185,7 +185,7 @@ func (d *DB) ListProjects(ctx context.Context) ([]Project, error) {
 // when no project matches the id so the caller can map the result to a 404
 // rather than a misleading success.
 func (d *DB) DeleteProject(ctx context.Context, id string) error {
-	res, err := d.rw.ExecContext(ctx,
+	res, err := d.execContext(ctx,
 		`DELETE FROM forge_projects WHERE id = ?`, id,
 	)
 	if err != nil {
@@ -208,7 +208,7 @@ func (d *DB) DeleteProject(ctx context.Context, id string) error {
 // worktree exists, so a host write-through can surface a 404 instead of a
 // misleading 204.
 func (d *DB) DeleteProjectWorktree(ctx context.Context, projectID, worktreeID string) error {
-	res, err := d.rw.ExecContext(ctx,
+	res, err := d.execContext(ctx,
 		`DELETE FROM forge_project_worktrees WHERE id = ? AND project_id = ?`,
 		worktreeID, projectID,
 	)
@@ -258,7 +258,7 @@ func (d *DB) CreateProjectWorktree(ctx context.Context, in CreateProjectWorktree
 		return nil, err
 	}
 
-	_, err = d.rw.ExecContext(ctx,
+	_, err = d.execContext(ctx,
 		`INSERT INTO forge_project_worktrees (
 		    id, project_id, branch, path
 		 ) VALUES (?, ?, ?, ?)`,
@@ -292,7 +292,7 @@ func (d *DB) adoptProjectWorktreeByPath(
 	if owner != projectID {
 		return nil, ErrWorktreePathTaken
 	}
-	if _, err := d.rw.ExecContext(ctx,
+	if _, err := d.execContext(ctx,
 		`UPDATE forge_project_worktrees
 		 SET branch = ?, is_stale = 0, updated_at = (datetime('now'))
 		 WHERE id = ?`,
@@ -373,7 +373,7 @@ func (d *DB) SetProjectWorktreeHidden(
 	if hidden {
 		hiddenInt = 1
 	}
-	res, err := d.rw.ExecContext(ctx, `
+	res, err := d.execContext(ctx, `
 		UPDATE forge_project_worktrees
 		SET is_hidden = ?, updated_at = ?
 		WHERE id = ? AND project_id = ?`,
@@ -406,7 +406,7 @@ func (d *DB) SetProjectWorktreeSessionBackend(
 	if ts.IsZero() {
 		ts = time.Now().UTC()
 	}
-	res, err := d.rw.ExecContext(ctx, `
+	res, err := d.execContext(ctx, `
 		UPDATE forge_project_worktrees
 		SET session_backend = ?, updated_at = ?
 		WHERE id = ? AND project_id = ?`,
@@ -537,7 +537,7 @@ func (d *DB) MarkProjectStale(
 	if ts.IsZero() {
 		ts = time.Now().UTC()
 	}
-	if _, err := d.rw.ExecContext(ctx, `
+	if _, err := d.execContext(ctx, `
 		UPDATE forge_projects
 		SET is_stale = 1, updated_at = ?
 		WHERE id = ?`, ts, projectID,
@@ -558,7 +558,7 @@ func (d *DB) UpsertProjectWorktreeTmuxSession(
 	if createdAt.IsZero() {
 		createdAt = time.Now().UTC()
 	}
-	_, err := d.rw.ExecContext(ctx, `
+	_, err := d.execContext(ctx, `
 		INSERT INTO forge_project_worktree_runtime_sessions
 		    (worktree_id, session_key, target_key, label, runtime_backend,
 		     backend_session_key,
@@ -654,7 +654,7 @@ func (d *DB) DeleteProjectWorktreeTmuxSession(
 	worktreeID string,
 	sessionKey string,
 ) error {
-	_, err := d.rw.ExecContext(ctx, `
+	_, err := d.execContext(ctx, `
 		DELETE FROM forge_project_worktree_runtime_sessions
 		WHERE worktree_id = ?
 		  AND session_key = ?
@@ -677,7 +677,7 @@ func (d *DB) DeleteProjectWorktreeTmuxSessionCreatedAt(
 	sessionKey string,
 	createdAt time.Time,
 ) (bool, error) {
-	result, err := d.rw.ExecContext(ctx, `
+	result, err := d.execContext(ctx, `
 		DELETE FROM forge_project_worktree_runtime_sessions
 		WHERE worktree_id = ?
 		  AND session_key = ?
@@ -848,7 +848,7 @@ func (d *DB) SetProjectWorktreeLinkedIssues(
 	if err != nil {
 		return nil, fmt.Errorf("marshal linked issue numbers: %w", err)
 	}
-	res, err := d.rw.ExecContext(ctx, `
+	res, err := d.execContext(ctx, `
 		UPDATE forge_project_worktrees
 		SET linked_issue_numbers = ?, updated_at = ?
 		WHERE id = ? AND project_id = ?`,

--- a/internal/db/queries_repo_summaries.go
+++ b/internal/db/queries_repo_summaries.go
@@ -194,7 +194,7 @@ func (d *DB) UpsertRepoOverview(
 		publishedAt = overview.LatestRelease.PublishedAt
 	}
 
-	_, err = d.rw.ExecContext(ctx, `
+	_, err = d.execContext(ctx, `
 		INSERT INTO forge_repo_overviews
 		    (repo_id, latest_release_tag, latest_release_name,
 		     latest_release_url, latest_release_target,

--- a/internal/db/queries_review.go
+++ b/internal/db/queries_review.go
@@ -47,7 +47,7 @@ func parseNullableTime(v sql.NullString) (*time.Time, error) {
 
 func (d *DB) GetOrCreateMRReviewDraft(ctx context.Context, mrID int64) (*MRReviewDraft, error) {
 	now := time.Now().UTC().Format(time.RFC3339)
-	if _, err := d.rw.ExecContext(ctx, `
+	if _, err := d.execContext(ctx, `
 		INSERT INTO forge_mr_review_drafts (merge_request_id, created_at, updated_at)
 		VALUES (?, ?, ?)
 		ON CONFLICT(merge_request_id) DO NOTHING`,
@@ -125,7 +125,7 @@ func (d *DB) CreateMRReviewDraftComment(
 	input MRReviewDraftCommentInput,
 ) (*MRReviewDraftComment, error) {
 	now := time.Now().UTC().Format(time.RFC3339)
-	res, err := d.rw.ExecContext(ctx, `
+	res, err := d.execContext(ctx, `
 		INSERT INTO forge_mr_review_draft_comments (
 			draft_id, body, path, old_path, side, start_side, start_line,
 			line, old_line, new_line, line_type, diff_head_sha, commit_sha,
@@ -144,7 +144,7 @@ func (d *DB) CreateMRReviewDraftComment(
 	if err != nil {
 		return nil, fmt.Errorf("get mr review draft comment id: %w", err)
 	}
-	if _, err := d.rw.ExecContext(ctx,
+	if _, err := d.execContext(ctx,
 		`UPDATE forge_mr_review_drafts SET updated_at = ? WHERE id = ?`,
 		now, draftID,
 	); err != nil {
@@ -159,7 +159,7 @@ func (d *DB) UpdateMRReviewDraftComment(
 	input MRReviewDraftCommentInput,
 ) (*MRReviewDraftComment, error) {
 	now := time.Now().UTC().Format(time.RFC3339)
-	res, err := d.rw.ExecContext(ctx, `
+	res, err := d.execContext(ctx, `
 		UPDATE forge_mr_review_draft_comments
 		SET body = ?, path = ?, old_path = ?, side = ?, start_side = ?,
 			start_line = ?, line = ?, old_line = ?, new_line = ?,
@@ -179,7 +179,7 @@ func (d *DB) UpdateMRReviewDraftComment(
 	} else if n == 0 {
 		return nil, sql.ErrNoRows
 	}
-	if _, err := d.rw.ExecContext(ctx,
+	if _, err := d.execContext(ctx,
 		`UPDATE forge_mr_review_drafts SET updated_at = ? WHERE id = ?`,
 		now, draftID,
 	); err != nil {
@@ -189,7 +189,7 @@ func (d *DB) UpdateMRReviewDraftComment(
 }
 
 func (d *DB) DeleteMRReviewDraftComment(ctx context.Context, draftID, commentID int64) error {
-	res, err := d.rw.ExecContext(ctx,
+	res, err := d.execContext(ctx,
 		`DELETE FROM forge_mr_review_draft_comments WHERE draft_id = ? AND id = ?`,
 		draftID, commentID,
 	)
@@ -202,7 +202,7 @@ func (d *DB) DeleteMRReviewDraftComment(ctx context.Context, draftID, commentID 
 		return sql.ErrNoRows
 	}
 	now := time.Now().UTC().Format(time.RFC3339)
-	if _, err := d.rw.ExecContext(ctx,
+	if _, err := d.execContext(ctx,
 		`UPDATE forge_mr_review_drafts SET updated_at = ? WHERE id = ?`,
 		now, draftID,
 	); err != nil {
@@ -212,7 +212,7 @@ func (d *DB) DeleteMRReviewDraftComment(ctx context.Context, draftID, commentID 
 }
 
 func (d *DB) DeleteMRReviewDraft(ctx context.Context, mrID int64) error {
-	if _, err := d.rw.ExecContext(ctx,
+	if _, err := d.execContext(ctx,
 		`DELETE FROM forge_mr_review_drafts WHERE merge_request_id = ?`,
 		mrID,
 	); err != nil {
@@ -440,7 +440,7 @@ func (d *DB) SetMRReviewThreadResolved(
 	resolved bool,
 	resolvedAt *time.Time,
 ) error {
-	res, err := d.rw.ExecContext(ctx, `
+	res, err := d.execContext(ctx, `
 		UPDATE forge_mr_review_threads
 		SET resolved = ?, resolved_at = ?, updated_at = ?
 		WHERE merge_request_id = ? AND id = ?`,

--- a/internal/db/queries_snapshot_children.go
+++ b/internal/db/queries_snapshot_children.go
@@ -168,7 +168,7 @@ func (d *DB) updateApplied(
 	query string,
 	args ...any,
 ) (bool, error) {
-	result, err := d.rw.ExecContext(ctx, query, args...)
+	result, err := d.execContext(ctx, query, args...)
 	if err != nil {
 		return false, fmt.Errorf("%s: %w", action, err)
 	}

--- a/internal/db/queries_stacks.go
+++ b/internal/db/queries_stacks.go
@@ -52,7 +52,7 @@ func (d *DB) listPRsForStacks(ctx context.Context, repoID int64, stateFilter str
 
 // UpsertStack inserts or updates a stack keyed by (repo_id, base_number).
 func (d *DB) UpsertStack(ctx context.Context, repoID int64, baseNumber int, name string) (int64, error) {
-	_, err := d.rw.ExecContext(ctx, `
+	_, err := d.execContext(ctx, `
 		INSERT INTO forge_stacks (repo_id, base_number, name)
 		VALUES (?, ?, ?)
 		ON CONFLICT(repo_id, base_number) DO UPDATE SET
@@ -219,7 +219,7 @@ func (d *DB) ListStacksWithMembers(ctx context.Context, repoFilter string) ([]St
 // DeleteStaleStacks removes stacks for a repo that are not in the active set.
 func (d *DB) DeleteStaleStacks(ctx context.Context, repoID int64, activeStackIDs []int64) error {
 	if len(activeStackIDs) == 0 {
-		_, err := d.rw.ExecContext(ctx,
+		_, err := d.execContext(ctx,
 			`DELETE FROM forge_stacks WHERE repo_id = ?`, repoID)
 		if err != nil {
 			return fmt.Errorf("delete all stacks for repo: %w", err)
@@ -231,7 +231,7 @@ func (d *DB) DeleteStaleStacks(ctx context.Context, repoID int64, activeStackIDs
 	for _, id := range activeStackIDs {
 		args = append(args, id)
 	}
-	_, err := d.rw.ExecContext(ctx,
+	_, err := d.execContext(ctx,
 		`DELETE FROM forge_stacks WHERE repo_id = ? AND id NOT IN (`+
 			sqlPlaceholders(len(activeStackIDs))+`)`,
 		args...,

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -5115,6 +5115,73 @@ func TestHTTPEtagPersistence(t *testing.T) {
 	assert.Equal(`"etag-v2"`, etag)
 }
 
+func TestUpsertHTTPEtagIfRouteFenceRejectsConcurrentPathReuse(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	observedAt := time.Now().UTC()
+	originalIdentity := RepoIdentity{
+		Platform: "github", PlatformHost: "github.com", PlatformRepoID: "original-repo",
+		Owner: "acme", Name: "alpha", RepoPath: "acme/alpha",
+	}
+	original, _, err := database.ReconcileRepositoryObservation(
+		ctx, originalIdentity, observedAt,
+	)
+	require.NoError(err)
+	fence, found, err := database.CurrentRepositoryRouteFence(
+		ctx, originalIdentity, original.Repository.ID,
+	)
+	require.NoError(err)
+	require.True(found)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	type result struct {
+		committed bool
+		err       error
+	}
+	done := make(chan result, 1)
+	go func() {
+		close(started)
+		<-release
+		committed, upsertErr := database.UpsertHTTPEtagIfRouteFence(
+			ctx, originalIdentity, fence,
+			"pull_request", 7, `"stale-etag"`,
+		)
+		done <- result{committed: committed, err: upsertErr}
+	}()
+	<-started
+	_, _, err = database.ReconcileRepositoryObservation(ctx, RepoIdentity{
+		Platform: "github", PlatformHost: "github.com", PlatformRepoID: "original-repo",
+		Owner: "acme", Name: "beta", RepoPath: "acme/beta",
+	}, observedAt.Add(time.Minute))
+	require.NoError(err)
+	_, _, err = database.ReconcileRepositoryObservation(ctx, RepoIdentity{
+		Platform: "github", PlatformHost: "github.com", PlatformRepoID: "replacement-repo",
+		Owner: "acme", Name: "alpha", RepoPath: "acme/alpha",
+	}, observedAt.Add(2*time.Minute))
+	require.NoError(err)
+	_, _, err = database.ReconcileRepositoryObservation(ctx, RepoIdentity{
+		Platform: "github", PlatformHost: "github.com", PlatformRepoID: "replacement-repo",
+		Owner: "acme", Name: "gamma", RepoPath: "acme/gamma",
+	}, observedAt.Add(3*time.Minute))
+	require.NoError(err)
+	_, _, err = database.ReconcileRepositoryObservation(ctx, originalIdentity,
+		observedAt.Add(4*time.Minute))
+	require.NoError(err)
+	close(release)
+	got := <-done
+	require.NoError(got.err)
+	assert.False(got.committed)
+
+	etag, err := database.GetHTTPEtag(
+		ctx, "github", "github.com", "acme", "alpha", "pull_request", 7,
+	)
+	require.NoError(err)
+	assert.Empty(etag)
+}
+
 func TestUpsertIssue_StoresAssignees(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/db/queries_workflow.go
+++ b/internal/db/queries_workflow.go
@@ -77,7 +77,7 @@ func (d *DB) EnsureItemWorkflowState(
 	if err := validateItemWorkflowType(itemType); err != nil {
 		return err
 	}
-	_, err := d.rw.ExecContext(ctx,
+	_, err := d.execContext(ctx,
 		`INSERT INTO forge_item_workflow_state (repo_id, item_type, item_number, status)
 		 VALUES (?, ?, ?, 'new')
 		 ON CONFLICT(repo_id, item_type, item_number) DO NOTHING`,

--- a/internal/db/queries_worktree_stats.go
+++ b/internal/db/queries_worktree_stats.go
@@ -56,7 +56,7 @@ func (d *DB) UpsertWorktreeStats(
 		changed = !worktreeStatsCountsEqual(prev, stats)
 	}
 
-	if _, err = d.rw.ExecContext(ctx, `
+	if _, err = d.execContext(ctx, `
 		INSERT INTO forge_worktree_stats
 		    (path, diff_added, diff_removed, sync_ahead, sync_behind, sampled_at)
 		VALUES (?, ?, ?, ?, ?, ?)
@@ -123,7 +123,7 @@ func (d *DB) ListWorktreeStats(
 // snapshot's worktree set. An empty keep set clears the table.
 func (d *DB) PruneWorktreeStats(ctx context.Context, keepPaths []string) error {
 	if len(keepPaths) == 0 {
-		if _, err := d.rw.ExecContext(
+		if _, err := d.execContext(
 			ctx, `DELETE FROM forge_worktree_stats`,
 		); err != nil {
 			return fmt.Errorf("prune worktree stats: %w", err)
@@ -135,7 +135,7 @@ func (d *DB) PruneWorktreeStats(ctx context.Context, keepPaths []string) error {
 	for _, p := range keepPaths {
 		args = append(args, p)
 	}
-	if _, err := d.rw.ExecContext(ctx,
+	if _, err := d.execContext(ctx,
 		`DELETE FROM forge_worktree_stats WHERE path NOT IN (`+placeholders+`)`,
 		args...,
 	); err != nil {

--- a/internal/db/repository_catalog.go
+++ b/internal/db/repository_catalog.go
@@ -32,6 +32,16 @@ type RepositoryRoute struct {
 	LastSeenAt   time.Time
 }
 
+// RepositoryRouteFence identifies one ownership generation of an active route.
+// Route rows are reused when a repository returns to a historical path, so the
+// generation prevents A -> B -> A changes from looking unchanged without
+// invalidating in-flight work when the same owner merely refreshes last_seen_at.
+type RepositoryRouteFence struct {
+	RouteID    int64
+	RepoID     int64
+	Generation int64
+}
+
 type RepositoryCatalogEntry struct {
 	Repository Repo
 	Lifecycle  RepositoryLifecycleState
@@ -137,6 +147,60 @@ func (d *DB) ResolveActiveRepositoryRoute(
 	}
 	defer release()
 	return d.resolveActiveRepositoryRoute(ctx, identity)
+}
+
+// CurrentRepositoryRouteFence captures the active route generation when it is
+// still owned by repoID.
+func (d *DB) CurrentRepositoryRouteFence(
+	ctx context.Context,
+	identity RepoIdentity,
+	repoID int64,
+) (RepositoryRouteFence, bool, error) {
+	fence, found, err := d.ResolveCurrentRepositoryRouteFence(ctx, identity)
+	if err != nil {
+		return RepositoryRouteFence{}, false, err
+	}
+	if !found || fence.RepoID != repoID {
+		return RepositoryRouteFence{}, false, nil
+	}
+	return fence, true, nil
+}
+
+// ResolveCurrentRepositoryRouteFence captures the active generation of a
+// route, including for legacy callers that do not yet carry a repository ID.
+func (d *DB) ResolveCurrentRepositoryRouteFence(
+	ctx context.Context,
+	identity RepoIdentity,
+) (RepositoryRouteFence, bool, error) {
+	identity = canonicalRepoIdentity(identity)
+	release, err := d.LockRepositoryReconciliationRead(ctx)
+	if err != nil {
+		return RepositoryRouteFence{}, false, err
+	}
+	defer release()
+
+	fence, found, err := currentRepositoryRouteFence(
+		ctx, d.ro, identity,
+	)
+	if err != nil {
+		return RepositoryRouteFence{}, false, err
+	}
+	return fence, found, nil
+}
+
+// RepositoryRouteFenceMatchesUnderRepositoryReconciliationRead verifies a
+// fence for a caller that already holds the reconciliation read lock.
+func (d *DB) RepositoryRouteFenceMatchesUnderRepositoryReconciliationRead(
+	ctx context.Context,
+	identity RepoIdentity,
+	fence RepositoryRouteFence,
+) (bool, error) {
+	identity = canonicalRepoIdentity(identity)
+	current, found, err := currentRepositoryRouteFence(ctx, d.ro, identity)
+	if err != nil || !found {
+		return false, err
+	}
+	return repositoryRouteFencesEqual(current, fence), nil
 }
 
 // resolveActiveRepositoryRoute is ResolveActiveRepositoryRoute without the
@@ -376,7 +440,7 @@ func (d *DB) ReconcileRepositoryObservation(
 			repoID = legacyID
 			if _, err := tx.ExecContext(ctx, `
 				UPDATE forge_repos
-				SET platform_repo_id = ?, lifecycle_state = 'active'
+				SET platform_repo_id = ?, lifecycle_state = 'active', viewer_can_merge = 0
 				WHERE id = ?`,
 				identity.PlatformRepoID, repoID,
 			); err != nil {
@@ -388,8 +452,8 @@ func (d *DB) ReconcileRepositoryObservation(
 					platform, platform_host, platform_repo_id,
 					owner, name, repo_path,
 					owner_key, name_key, repo_path_key,
-					lifecycle_state
-				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'active')`,
+					lifecycle_state, viewer_can_merge
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', 0)`,
 				identity.Platform, identity.PlatformHost,
 				identity.PlatformRepoID,
 				identity.Owner, identity.Name, identity.RepoPath,
@@ -409,6 +473,20 @@ func (d *DB) ReconcileRepositoryObservation(
 				ctx, tx, targetID, observedAt,
 			); err != nil {
 				return err
+			}
+		} else if !targetFound {
+			reused, err := historicalRouteHasOtherRepositoryTx(
+				ctx, tx, identity, repoID,
+			)
+			if err != nil {
+				return err
+			}
+			if reused {
+				if err := deleteRepositoryRouteScopedStateTx(
+					ctx, tx, identity,
+				); err != nil {
+					return err
+				}
 			}
 		}
 		if err := activateRepositoryRouteTx(
@@ -434,6 +512,187 @@ func (d *DB) ReconcileRepositoryObservation(
 		return nil, false, errors.New("reconciled repository is missing")
 	}
 	return entry, accepted, nil
+}
+
+// UpdateRepoProviderObservation atomically persists provider metadata and
+// merge settings only while observedAt is still the repository's newest
+// accepted identity observation. Route generations intentionally do not
+// advance for same-route refreshes, so the observation watermark is the
+// freshness fence for provider snapshots captured on that route.
+func (d *DB) UpdateRepoProviderObservation(
+	ctx context.Context,
+	repoID int64,
+	observedAt time.Time,
+	metadata RepoProviderMetadata,
+	mergeSettings *RepoMergeSettings,
+	viewerCanMerge *bool,
+) (bool, error) {
+	metadata.PlatformRepoID = strings.TrimSpace(metadata.PlatformRepoID)
+	observedAt = canonicalUTCTime(observedAt)
+	release := d.lockRepositoryReconciliationWrite()
+	defer release()
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	tx, err := d.rw.BeginTx(ctx, nil)
+	if err != nil {
+		return false, fmt.Errorf("update repository provider observation: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if guard := d.repositoryRouteGuard(ctx); guard != nil {
+		matches, err := repositoryRouteFenceMatchesTx(ctx, tx, guard.identity, guard.fence)
+		if err != nil {
+			return false, fmt.Errorf("update repository provider observation: %w", err)
+		}
+		if !matches {
+			return false, fmt.Errorf(
+				"update repository provider observation: %w for %s/%s",
+				ErrRepositoryRouteFenceChanged,
+				guard.identity.PlatformHost, guard.identity.RepoPath,
+			)
+		}
+	}
+	watermark, found, err := repositoryObservationWatermarkTx(ctx, tx, repoID)
+	if err != nil {
+		return false, fmt.Errorf("update repository provider observation: %w", err)
+	}
+	if !found || !watermark.Equal(observedAt) {
+		return false, nil
+	}
+	identity, err := lookupRepoIdentityByIDTx(ctx, tx, repoID)
+	if err != nil {
+		return false, fmt.Errorf("update repository provider observation: %w", err)
+	}
+	if current := strings.TrimSpace(identity.PlatformRepoID); current != metadata.PlatformRepoID {
+		return false, fmt.Errorf(
+			"update repository provider observation: stable provider id for repository %d is %q, not %q",
+			repoID, current, metadata.PlatformRepoID,
+		)
+	}
+
+	// Snapshots may omit URLs or the default branch (minimal payloads, list
+	// responses). Known stored metadata must survive an omitted field, or a
+	// settings-only snapshot would erase the clone URL other flows resolve
+	// clones through.
+	query := `UPDATE forge_repos
+		SET web_url = CASE WHEN ? <> '' THEN ? ELSE web_url END,
+		    clone_url = CASE WHEN ? <> '' THEN ? ELSE clone_url END,
+		    default_branch = CASE WHEN ? <> '' THEN ? ELSE default_branch END`
+	args := []any{
+		metadata.WebURL, metadata.WebURL,
+		metadata.CloneURL, metadata.CloneURL,
+		metadata.DefaultBranch, metadata.DefaultBranch,
+	}
+	if mergeSettings != nil {
+		query += `, allow_squash_merge = ?, allow_merge_commit = ?, allow_rebase_merge = ?`
+		args = append(args,
+			mergeSettings.AllowSquashMerge,
+			mergeSettings.AllowMergeCommit,
+			mergeSettings.AllowRebaseMerge,
+		)
+	}
+	if viewerCanMerge != nil {
+		query += `, viewer_can_merge = ?`
+		args = append(args, *viewerCanMerge)
+	}
+	query += ` WHERE id = ?`
+	args = append(args, repoID)
+	if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+		return false, fmt.Errorf("update repository provider observation: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return false, fmt.Errorf("update repository provider observation: commit: %w", err)
+	}
+	return true, nil
+}
+
+func historicalRouteHasOtherRepositoryTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	identity RepoIdentity,
+	repoID int64,
+) (bool, error) {
+	var reused bool
+	err := tx.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM forge_repo_routes AS route
+			WHERE route.platform = ?
+			  AND route.platform_host = ?
+			  AND route.repo_path_key = ?
+			  AND route.repo_id <> ?
+		)`,
+		identity.Platform, identity.PlatformHost, identity.RepoPathKey, repoID,
+	).Scan(&reused)
+	if err != nil {
+		return false, fmt.Errorf("check historical repository route reuse: %w", err)
+	}
+	return reused, nil
+}
+
+// AdoptLegacyClonesIfSafe runs adopt while repoID remains the verified current
+// owner of an unambiguous route. Pre-stable-ID clones were path-scoped, so a
+// route with any other catalog owner must not adopt them.
+func (d *DB) AdoptLegacyClonesIfSafe(
+	ctx context.Context,
+	identity RepoIdentity,
+	repoID int64,
+	adopt func() error,
+) (bool, error) {
+	if err := validateRepositoryObservation(identity); err != nil {
+		return false, err
+	}
+	if adopt == nil {
+		return false, errors.New("legacy clone adoption callback is required")
+	}
+	identity.PlatformRepoID = strings.TrimSpace(identity.PlatformRepoID)
+	identity = canonicalRepoIdentity(identity)
+	release, err := d.LockRepositoryReconciliationRead(ctx)
+	if err != nil {
+		return false, err
+	}
+	defer release()
+
+	var allowed bool
+	err = d.ro.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM forge_repo_routes AS current
+			JOIN forge_repos AS repo ON repo.id = current.repo_id
+			WHERE current.repo_id = ?
+			  AND current.is_current = 1
+			  AND current.platform = ?
+			  AND current.platform_host = ?
+			  AND current.repo_path_key = ?
+			  AND repo.lifecycle_state = 'active'
+			  AND repo.platform = current.platform
+			  AND repo.platform_host = current.platform_host
+			  AND repo.platform_repo_id = ?
+			  AND NOT EXISTS (
+				SELECT 1
+				FROM forge_repo_routes AS historical
+				WHERE historical.platform = current.platform
+				  AND historical.platform_host = current.platform_host
+				  AND historical.repo_path_key = current.repo_path_key
+				  AND historical.repo_id <> current.repo_id
+			  )
+		)`,
+		repoID,
+		identity.Platform,
+		identity.PlatformHost,
+		identity.RepoPathKey,
+		identity.PlatformRepoID,
+	).Scan(&allowed)
+	if err != nil {
+		return false, fmt.Errorf("check legacy clone adoption: %w", err)
+	}
+	if !allowed {
+		return false, nil
+	}
+	if err := adopt(); err != nil {
+		return true, fmt.Errorf("adopt legacy clones: %w", err)
+	}
+	return true, nil
 }
 
 // DeactivateRepositoryObservation records an authoritative provider absence.
@@ -556,6 +815,53 @@ func currentRepositoryIDByRouteTx(
 	return repoID, true, nil
 }
 
+func currentRepositoryRouteFence(
+	ctx context.Context,
+	queryer repositoryCatalogQueryer,
+	identity RepoIdentity,
+) (RepositoryRouteFence, bool, error) {
+	var fence RepositoryRouteFence
+	err := queryer.QueryRowContext(ctx, `
+		SELECT id, repo_id, generation
+		FROM forge_repo_routes
+		WHERE platform = ?
+		  AND platform_host = ?
+		  AND repo_path_key = ?
+		  AND is_current = 1`,
+		identity.Platform,
+		identity.PlatformHost,
+		identity.RepoPathKey,
+	).Scan(&fence.RouteID, &fence.RepoID, &fence.Generation)
+	if errors.Is(err, sql.ErrNoRows) {
+		return RepositoryRouteFence{}, false, nil
+	}
+	if err != nil {
+		return RepositoryRouteFence{}, false, fmt.Errorf(
+			"lookup current repository route fence: %w", err,
+		)
+	}
+	return fence, true, nil
+}
+
+func repositoryRouteFenceMatchesTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	identity RepoIdentity,
+	fence RepositoryRouteFence,
+) (bool, error) {
+	current, found, err := currentRepositoryRouteFence(ctx, tx, identity)
+	if err != nil || !found {
+		return false, err
+	}
+	return repositoryRouteFencesEqual(current, fence), nil
+}
+
+func repositoryRouteFencesEqual(a, b RepositoryRouteFence) bool {
+	return a.RouteID == b.RouteID &&
+		a.RepoID == b.RepoID &&
+		a.Generation == b.Generation
+}
+
 // repositoryObservationWatermarkTx returns the newest observation recorded
 // across all of a repository's routes, current or historical. Deactivations
 // stamp last_seen_at, so the watermark also advances when a route is
@@ -614,6 +920,26 @@ func deactivateCurrentRepositoryRouteTx(
 	repoID int64,
 	observedAt time.Time,
 ) error {
+	var route RepoIdentity
+	err := tx.QueryRowContext(ctx, `
+		SELECT platform, platform_host, owner, name, repo_path,
+		       owner_key, name_key, repo_path_key
+		FROM forge_repo_routes
+		WHERE repo_id = ? AND is_current = 1`, repoID,
+	).Scan(
+		&route.Platform, &route.PlatformHost,
+		&route.Owner, &route.Name, &route.RepoPath,
+		&route.OwnerKey, &route.NameKey, &route.RepoPathKey,
+	)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("load repository route before historicalizing: %w", err)
+	}
+	if err == nil {
+		if err := deleteRepositoryRouteScopedStateTx(ctx, tx, route); err != nil {
+			return err
+		}
+	}
+
 	result, err := tx.ExecContext(ctx, `
 		UPDATE forge_repo_routes
 		SET is_current = 0, last_seen_at = ?
@@ -650,6 +976,62 @@ func deactivateCurrentRepositoryRouteTx(
 		repoID,
 	); err != nil {
 		return fmt.Errorf("deactivate repository: %w", err)
+	}
+	return nil
+}
+
+func deleteRepositoryRouteScopedStateTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	identity RepoIdentity,
+) error {
+	steps := []struct {
+		name string
+		sql  string
+		args []any
+	}{
+		{
+			name: "delete unlinked route notifications",
+			sql: `DELETE FROM forge_notification_items
+			      WHERE repo_id IS NULL
+			        AND platform = ?
+			        AND platform_host = ?
+			        AND repo_owner = ?
+			        AND repo_name = ?`,
+			args: []any{
+				identity.Platform, identity.PlatformHost,
+				identity.OwnerKey, identity.NameKey,
+			},
+		},
+		{
+			name: "delete route HTTP ETags",
+			sql: `DELETE FROM forge_http_etags
+			      WHERE platform = ?
+			        AND platform_host = ?
+			        AND owner_key = ?
+			        AND name_key = ?`,
+			args: []any{
+				identity.Platform, identity.PlatformHost,
+				identity.OwnerKey, identity.NameKey,
+			},
+		},
+		{
+			name: "delete route notification watermark",
+			sql: `DELETE FROM forge_notification_sync_watermarks
+			      WHERE platform = ?
+			        AND platform_host = ?
+			        AND repo_owner = ?
+			        AND repo_name = ?`,
+			args: []any{
+				identity.Platform, identity.PlatformHost,
+				identity.OwnerKey, identity.NameKey,
+			},
+		},
+	}
+	for _, step := range steps {
+		if _, err := tx.ExecContext(ctx, step.sql, step.args...); err != nil {
+			return fmt.Errorf("%s: %w", step.name, err)
+		}
 	}
 	return nil
 }
@@ -705,6 +1087,11 @@ func activateRepositoryRouteTx(
 			owner_key = excluded.owner_key,
 			name_key = excluded.name_key,
 			is_current = 1,
+			generation = CASE
+				WHEN forge_repo_routes.is_current = 0
+				THEN forge_repo_routes.generation + 1
+				ELSE forge_repo_routes.generation
+			END,
 			last_seen_at = excluded.last_seen_at`,
 		repoID,
 		identity.Platform,

--- a/internal/db/repository_catalog_test.go
+++ b/internal/db/repository_catalog_test.go
@@ -1095,6 +1095,218 @@ func TestUpdateRepoProviderMetadataRejectsStableIDChange(t *testing.T) {
 	require.NotNil(entry)
 }
 
+func TestUpdateRepoProviderObservationRejectsOlderSameRouteSettings(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	identity := RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "repo-a", Owner: "acme", Name: "widget",
+	}
+	older := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	newer := older.Add(time.Second)
+	entry, accepted, err := d.ReconcileRepositoryObservation(ctx, identity, older)
+	require.NoError(err)
+	require.True(accepted)
+	require.NotNil(entry)
+	_, accepted, err = d.ReconcileRepositoryObservation(ctx, identity, newer)
+	require.NoError(err)
+	require.True(accepted)
+
+	applied, err := d.UpdateRepoProviderObservation(
+		ctx,
+		entry.Repository.ID,
+		newer,
+		RepoProviderMetadata{
+			PlatformRepoID: "repo-a",
+			WebURL:         "https://github.com/acme/widget",
+			CloneURL:       "https://github.com/acme/widget.git",
+			DefaultBranch:  "main",
+		},
+		&RepoMergeSettings{AllowSquashMerge: false, AllowMergeCommit: true},
+		new(true),
+	)
+	require.NoError(err)
+	require.True(applied)
+
+	applied, err = d.UpdateRepoProviderObservation(
+		ctx,
+		entry.Repository.ID,
+		older,
+		RepoProviderMetadata{
+			PlatformRepoID: "repo-a",
+			WebURL:         "https://stale.example/acme/widget",
+			CloneURL:       "https://stale.example/acme/widget.git",
+			DefaultBranch:  "stale",
+		},
+		&RepoMergeSettings{AllowSquashMerge: true},
+		new(false),
+	)
+	require.NoError(err)
+	require.False(applied)
+
+	stored, err := d.GetRepoByID(ctx, entry.Repository.ID)
+	require.NoError(err)
+	require.NotNil(stored)
+	require.Equal("https://github.com/acme/widget", stored.WebURL)
+	require.Equal("main", stored.DefaultBranch)
+	require.False(stored.AllowSquashMerge)
+	require.True(stored.AllowMergeCommit)
+	require.True(stored.ViewerCanMerge)
+}
+
+// TestUpdateRepoProviderObservationPersistsViewerOnlySnapshot covers
+// providers that report the viewer's merge permission without repository
+// merge-method settings (for example a GitLab snapshot). The permission must
+// persist on its own; the merge methods keep their stored values.
+func TestUpdateRepoProviderObservationPersistsViewerOnlySnapshot(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	identity := RepoIdentity{
+		Platform: "gitlab", PlatformHost: "gitlab.example.com",
+		PlatformRepoID: "gid://gitlab/Project/42",
+		Owner:          "group", Name: "project", RepoPath: "group/project",
+	}
+	when := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	entry, accepted, err := d.ReconcileRepositoryObservation(ctx, identity, when)
+	require.NoError(err)
+	require.True(accepted)
+	require.NoError(d.UpdateRepoMergeSettings(
+		ctx, entry.Repository.ID, true, false, true,
+	))
+
+	applied, err := d.UpdateRepoProviderObservation(
+		ctx,
+		entry.Repository.ID,
+		when,
+		RepoProviderMetadata{
+			PlatformRepoID: "gid://gitlab/Project/42",
+			DefaultBranch:  "main",
+		},
+		nil,
+		new(false),
+	)
+	require.NoError(err)
+	require.True(applied)
+
+	stored, err := d.GetRepoByID(ctx, entry.Repository.ID)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.False(stored.ViewerCanMerge)
+	assert.True(stored.AllowSquashMerge)
+	assert.False(stored.AllowMergeCommit)
+	assert.True(stored.AllowRebaseMerge)
+}
+
+// TestUpdateRepoProviderObservationPreservesMetadataOnEmptyFields covers
+// provider snapshots that omit URLs or the default branch (minimal REST
+// payloads and test fixtures): known stored metadata must survive, while the
+// snapshot's merge settings still commit.
+func TestUpdateRepoProviderObservationPreservesMetadataOnEmptyFields(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	identity := RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "repo-a", Owner: "acme", Name: "widget",
+		RepoPath: "acme/widget",
+	}
+	when := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	entry, accepted, err := d.ReconcileRepositoryObservation(ctx, identity, when)
+	require.NoError(err)
+	require.True(accepted)
+	require.NoError(d.UpdateRepoProviderMetadata(
+		ctx, entry.Repository.ID, RepoProviderMetadata{
+			PlatformRepoID: "repo-a",
+			WebURL:         "https://github.com/acme/widget",
+			CloneURL:       "/fixtures/acme/widget.git",
+			DefaultBranch:  "main",
+		},
+	))
+
+	applied, err := d.UpdateRepoProviderObservation(
+		ctx,
+		entry.Repository.ID,
+		when,
+		RepoProviderMetadata{PlatformRepoID: "repo-a"},
+		&RepoMergeSettings{AllowSquashMerge: true},
+		new(false),
+	)
+	require.NoError(err)
+	require.True(applied)
+
+	stored, err := d.GetRepoByID(ctx, entry.Repository.ID)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.Equal("https://github.com/acme/widget", stored.WebURL)
+	assert.Equal("/fixtures/acme/widget.git", stored.CloneURL)
+	assert.Equal("main", stored.DefaultBranch)
+	assert.True(stored.AllowSquashMerge)
+	assert.False(stored.AllowMergeCommit)
+	assert.False(stored.ViewerCanMerge)
+}
+
+func TestUpdateRepoProviderObservationFailsClosedForReplacementOnReusedRoute(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	observedAt := baseTime()
+
+	reconcileCatalogRepository(t, d, "provider-original", "acme", "widget", observedAt)
+	reconcileCatalogRepository(
+		t, d, "provider-original", "acme", "renamed", observedAt.Add(time.Minute),
+	)
+	replacementObservedAt := observedAt.Add(2 * time.Minute)
+	replacement := reconcileCatalogRepository(
+		t, d, "provider-replacement", "acme", "widget", replacementObservedAt,
+	)
+
+	applied, err := d.UpdateRepoProviderObservation(
+		ctx,
+		replacement.Repository.ID,
+		replacementObservedAt,
+		RepoProviderMetadata{PlatformRepoID: "provider-replacement"},
+		nil,
+		nil,
+	)
+	require.NoError(err)
+	require.True(applied)
+
+	stored, err := d.GetRepoByID(ctx, replacement.Repository.ID)
+	require.NoError(err)
+	require.NotNil(stored)
+	require.False(stored.ViewerCanMerge,
+		"a replacement must not inherit the permissive schema default")
+}
+
+func TestUpdateRepoProviderObservationPreservesKnownViewerPermissionWhenOmitted(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	observedAt := baseTime()
+	entry := reconcileCatalogRepository(t, d, "provider-1", "acme", "widget", observedAt)
+	require.NoError(d.UpdateRepoViewerCanMerge(ctx, entry.Repository.ID, true))
+
+	applied, err := d.UpdateRepoProviderObservation(
+		ctx,
+		entry.Repository.ID,
+		observedAt,
+		RepoProviderMetadata{PlatformRepoID: "provider-1"},
+		nil,
+		nil,
+	)
+	require.NoError(err)
+	require.True(applied)
+
+	stored, err := d.GetRepoByID(ctx, entry.Repository.ID)
+	require.NoError(err)
+	require.NotNil(stored)
+	require.True(stored.ViewerCanMerge)
+}
+
 // TestUpsertRepoCachedIdentityDoesNotReclaimReusedRoute covers a delayed
 // cached write: it carries no provider verification, so it must resolve by
 // stable ID without stealing back a route another repository now holds.
@@ -1230,4 +1442,386 @@ func TestReconcileRepositoryObservationAdoptsLegacyRouteOnlyRepository(t *testin
 	require.NoError(err)
 	assert.False(collision,
 		"an adopted route has a single owner and must stay unambiguous")
+}
+
+func TestReconcileRepositoryObservationFailsClosedWhenAdoptingLegacyRepository(t *testing.T) {
+	require := require.New(t)
+	d := openTestDB(t)
+	legacyID, err := d.UpsertRepo(t.Context(), RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		Owner: "org-a", Name: "project-a",
+	})
+	require.NoError(err)
+	require.NoError(d.UpdateRepoViewerCanMerge(t.Context(), legacyID, true))
+
+	entry := reconcileCatalogRepository(
+		t, d, "provider-1", "org-a", "project-a", baseTime(),
+	)
+	require.Equal(legacyID, entry.Repository.ID)
+
+	stored, err := d.GetRepoByID(t.Context(), legacyID)
+	require.NoError(err)
+	require.NotNil(stored)
+	require.False(stored.ViewerCanMerge,
+		"first provider verification must reset a legacy path-only permission")
+}
+
+func TestAdoptLegacyClonesIfSafeRequiresUnreusedVerifiedRoute(t *testing.T) {
+	t.Run("verified route with one owner", func(t *testing.T) {
+		d := openTestDB(t)
+		entry := reconcileCatalogRepository(
+			t, d, "provider-1", "acme", "widget", baseTime(),
+		)
+		called := false
+
+		adopted, err := d.AdoptLegacyClonesIfSafe(
+			t.Context(), RepoIdentity{
+				Platform: "github", PlatformHost: "github.com",
+				PlatformRepoID: "provider-1",
+				Owner:          "acme", Name: "widget", RepoPath: "acme/widget",
+			}, entry.Repository.ID,
+			func() error { called = true; return nil },
+		)
+		require.NoError(t, err)
+		assert.True(t, adopted)
+		assert.True(t, called)
+	})
+
+	t.Run("route with a different legacy owner", func(t *testing.T) {
+		d := openTestDB(t)
+		_, err := d.UpsertRepo(t.Context(), RepoIdentity{
+			Platform: "github", PlatformHost: "github.com",
+			Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+		})
+		require.NoError(t, err)
+		entry := reconcileCatalogRepository(
+			t, d, "provider-1", "acme", "renamed", baseTime(),
+		)
+		moved, _, err := d.ReconcileRepositoryObservation(t.Context(), RepoIdentity{
+			Platform: "github", PlatformHost: "github.com",
+			PlatformRepoID: "provider-1",
+			Owner:          "acme", Name: "widget", RepoPath: "acme/widget",
+		}, baseTime().Add(time.Minute))
+		require.NoError(t, err)
+		require.Equal(t, entry.Repository.ID, moved.Repository.ID)
+
+		called := false
+		adopted, err := d.AdoptLegacyClonesIfSafe(
+			t.Context(), RepoIdentity{
+				Platform: "github", PlatformHost: "github.com",
+				PlatformRepoID: "provider-1",
+				Owner:          "acme", Name: "widget", RepoPath: "acme/widget",
+			}, moved.Repository.ID,
+			func() error { called = true; return nil },
+		)
+		require.NoError(t, err)
+		assert.False(t, adopted)
+		assert.False(t, called)
+	})
+
+	t.Run("stale route snapshot after reuse", func(t *testing.T) {
+		d := openTestDB(t)
+		original := reconcileCatalogRepository(
+			t, d, "provider-original", "acme", "widget", baseTime(),
+		)
+		_, _, err := d.ReconcileRepositoryObservation(t.Context(), RepoIdentity{
+			Platform: "github", PlatformHost: "github.com",
+			PlatformRepoID: "provider-original",
+			Owner:          "acme", Name: "renamed", RepoPath: "acme/renamed",
+		}, baseTime().Add(time.Minute))
+		require.NoError(t, err)
+		reconcileCatalogRepository(
+			t, d, "provider-replacement", "acme", "widget",
+			baseTime().Add(2*time.Minute),
+		)
+		called := false
+
+		adopted, err := d.AdoptLegacyClonesIfSafe(
+			t.Context(), RepoIdentity{
+				Platform: "github", PlatformHost: "github.com",
+				PlatformRepoID: "provider-original",
+				Owner:          "acme", Name: "widget", RepoPath: "acme/widget",
+			}, original.Repository.ID,
+			func() error { called = true; return nil },
+		)
+		require.NoError(t, err)
+		assert.False(t, adopted)
+		assert.False(t, called)
+	})
+}
+
+func TestAdoptLegacyClonesIfSafeHoldsRouteGuardThroughAdoption(t *testing.T) {
+	require := require.New(t)
+	d := openTestDB(t)
+	entry := reconcileCatalogRepository(
+		t, d, "provider-1", "acme", "widget", baseTime(),
+	)
+	identity := RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "provider-1",
+		Owner:          "acme", Name: "widget", RepoPath: "acme/widget",
+	}
+	adoptionStarted := make(chan struct{})
+	releaseAdoption := make(chan struct{})
+	adoptionDone := make(chan error, 1)
+	go func() {
+		_, err := d.AdoptLegacyClonesIfSafe(
+			t.Context(), identity, entry.Repository.ID,
+			func() error {
+				close(adoptionStarted)
+				<-releaseAdoption
+				return nil
+			},
+		)
+		adoptionDone <- err
+	}()
+	<-adoptionStarted
+
+	writerWaiting := make(chan struct{})
+	restoreHook := d.SetBeforeRepositoryReconciliationWriteLockForTest(func() {
+		close(writerWaiting)
+	})
+	t.Cleanup(restoreHook)
+	renameDone := make(chan error, 1)
+	go func() {
+		_, _, err := d.ReconcileRepositoryObservation(t.Context(), RepoIdentity{
+			Platform: "github", PlatformHost: "github.com",
+			PlatformRepoID: "provider-1",
+			Owner:          "acme", Name: "renamed", RepoPath: "acme/renamed",
+		}, baseTime().Add(time.Minute))
+		renameDone <- err
+	}()
+	<-writerWaiting
+	select {
+	case err := <-renameDone:
+		require.Fail("route changed during clone adoption", "unexpected error: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(releaseAdoption)
+	require.NoError(<-adoptionDone)
+	require.NoError(<-renameDone)
+}
+
+func TestReconcileRepositoryObservationClearsVacatedRouteSyncState(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	observedAt := baseTime()
+	number := 7
+
+	original := reconcileCatalogRepository(
+		t, d, "provider-original", "acme", "alpha", observedAt,
+	)
+	require.NoError(d.UpdateNotificationSyncWatermark(
+		ctx, "github", "github.com", "acme", "alpha", observedAt, &observedAt,
+	))
+	require.NoError(d.UpsertHTTPEtag(
+		ctx, "github", "github.com", "acme", "alpha", "pull_request", number, `"old"`,
+	))
+	require.NoError(d.UpsertNotifications(ctx, []Notification{
+		{
+			Platform: "github", PlatformHost: "github.com",
+			PlatformNotificationID: "linked", RepoOwner: "acme", RepoName: "alpha",
+			SubjectType: "PullRequest", SubjectTitle: "linked", ItemNumber: &number,
+			ItemType: ItemTypePR, Reason: "mention", Unread: true,
+			SourceUpdatedAt: observedAt, SyncedAt: observedAt,
+		},
+		{
+			Platform: "github", PlatformHost: "github.com",
+			PlatformNotificationID: "path-only", RepoOwner: "acme", RepoName: "alpha",
+			SubjectType: "PullRequest", SubjectTitle: "path only", ItemNumber: &number,
+			ItemType: ItemTypePR, Reason: "mention", Unread: true,
+			SourceUpdatedAt: observedAt, SyncedAt: observedAt,
+		},
+	}))
+	_, err := d.WriteDB().ExecContext(ctx,
+		`UPDATE forge_notification_items SET repo_id = NULL
+		 WHERE platform_notification_id = 'path-only'`,
+	)
+	require.NoError(err)
+
+	renamed, _, err := d.ReconcileRepositoryObservation(ctx, RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "provider-original",
+		Owner:          "acme", Name: "beta", RepoPath: "acme/beta",
+	}, observedAt.Add(time.Minute))
+	require.NoError(err)
+	assert.Equal(original.Repository.ID, renamed.Repository.ID)
+
+	watermark, err := d.GetNotificationSyncWatermark(
+		ctx, "github", "github.com", "acme", "alpha",
+	)
+	require.NoError(err)
+	assert.Nil(watermark)
+	etag, err := d.GetHTTPEtag(
+		ctx, "github", "github.com", "acme", "alpha", "pull_request", number,
+	)
+	require.NoError(err)
+	assert.Empty(etag)
+	notifications, err := d.ListNotifications(ctx, ListNotificationsOpts{State: "all"})
+	require.NoError(err)
+	require.Len(notifications, 1)
+	assert.Equal("linked", notifications[0].PlatformNotificationID)
+	require.NotNil(notifications[0].RepoID)
+	assert.Equal(original.Repository.ID, *notifications[0].RepoID)
+}
+
+func TestReconcileRepositoryObservationClearsHistoricalRouteStateBeforeReuse(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	observedAt := baseTime()
+	number := 7
+
+	reconcileCatalogRepository(t, d, "provider-original", "acme", "alpha", observedAt)
+	_, _, err := d.ReconcileRepositoryObservation(ctx, RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "provider-original",
+		Owner:          "acme", Name: "beta", RepoPath: "acme/beta",
+	}, observedAt.Add(time.Minute))
+	require.NoError(err)
+
+	require.NoError(d.UpdateNotificationSyncWatermark(
+		ctx, "github", "github.com", "acme", "alpha", observedAt, &observedAt,
+	))
+	require.NoError(d.UpsertHTTPEtag(
+		ctx, "github", "github.com", "acme", "alpha", "pull_request", number, `"stale"`,
+	))
+	require.NoError(d.UpsertNotifications(ctx, []Notification{{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformNotificationID: "path-only", RepoOwner: "acme", RepoName: "alpha",
+		SubjectType: "PullRequest", SubjectTitle: "stale", ItemNumber: &number,
+		ItemType: ItemTypePR, Reason: "mention", Unread: true,
+		SourceUpdatedAt: observedAt, SyncedAt: observedAt,
+	}}))
+
+	replacement, _, err := d.ReconcileRepositoryObservation(ctx, RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "provider-replacement",
+		Owner:          "acme", Name: "alpha", RepoPath: "acme/alpha",
+	}, observedAt.Add(2*time.Minute))
+	require.NoError(err)
+	assert.Equal("provider-replacement", replacement.Repository.PlatformRepoID)
+
+	watermark, err := d.GetNotificationSyncWatermark(
+		ctx, "github", "github.com", "acme", "alpha",
+	)
+	require.NoError(err)
+	assert.Nil(watermark)
+	etag, err := d.GetHTTPEtag(
+		ctx, "github", "github.com", "acme", "alpha", "pull_request", number,
+	)
+	require.NoError(err)
+	assert.Empty(etag)
+	notifications, err := d.ListNotifications(ctx, ListNotificationsOpts{State: "all"})
+	require.NoError(err)
+	assert.Empty(notifications)
+}
+
+func TestReconcileRepositoryObservationClearsLegacyHistoricalRouteStateBeforeReuse(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	observedAt := baseTime()
+	number := 7
+
+	legacyID, err := d.UpsertRepo(ctx, RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		Owner: "acme", Name: "alpha", RepoPath: "acme/alpha",
+	})
+	require.NoError(err)
+	replacement := reconcileCatalogRepository(
+		t, d, "provider-replacement", "acme", "beta", observedAt,
+	)
+	require.NotEqual(legacyID, replacement.Repository.ID)
+
+	require.NoError(d.UpdateNotificationSyncWatermark(
+		ctx, "github", "github.com", "acme", "alpha", observedAt, &observedAt,
+	))
+	require.NoError(d.UpsertHTTPEtag(
+		ctx, "github", "github.com", "acme", "alpha", "pull_request", number, `"stale"`,
+	))
+	require.NoError(d.UpsertNotifications(ctx, []Notification{{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformNotificationID: "path-only", RepoOwner: "acme", RepoName: "alpha",
+		SubjectType: "PullRequest", SubjectTitle: "stale", ItemNumber: &number,
+		ItemType: ItemTypePR, Reason: "mention", Unread: true,
+		SourceUpdatedAt: observedAt, SyncedAt: observedAt,
+	}}))
+
+	moved, _, err := d.ReconcileRepositoryObservation(ctx, RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "provider-replacement",
+		Owner:          "acme", Name: "alpha", RepoPath: "acme/alpha",
+	}, observedAt.Add(time.Minute))
+	require.NoError(err)
+	assert.Equal(replacement.Repository.ID, moved.Repository.ID)
+
+	watermark, err := d.GetNotificationSyncWatermark(
+		ctx, "github", "github.com", "acme", "alpha",
+	)
+	require.NoError(err)
+	assert.Nil(watermark)
+	etag, err := d.GetHTTPEtag(
+		ctx, "github", "github.com", "acme", "alpha", "pull_request", number,
+	)
+	require.NoError(err)
+	assert.Empty(etag)
+	notifications, err := d.ListNotifications(ctx, ListNotificationsOpts{State: "all"})
+	require.NoError(err)
+	assert.Empty(notifications)
+}
+
+func TestRepositoryRouteGuardRejectsWriteAfterABAReuse(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	observedAt := baseTime()
+	identity := RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "provider-original",
+		Owner:          "acme", Name: "widget", RepoPath: "acme/widget",
+	}
+	original, _, err := d.ReconcileRepositoryObservation(ctx, identity, observedAt)
+	require.NoError(err)
+	require.NoError(d.UpdateRepoMergeSettings(
+		ctx, original.Repository.ID, false, false, false,
+	))
+	fence, found, err := d.CurrentRepositoryRouteFence(
+		ctx, identity, original.Repository.ID,
+	)
+	require.NoError(err)
+	require.True(found)
+	guarded := d.WithRepositoryRouteFence(ctx, identity, fence)
+
+	_, _, err = d.ReconcileRepositoryObservation(ctx, RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "provider-original",
+		Owner:          "acme", Name: "renamed", RepoPath: "acme/renamed",
+	}, observedAt.Add(time.Minute))
+	require.NoError(err)
+	_, _, err = d.ReconcileRepositoryObservation(ctx, RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "provider-replacement",
+		Owner:          "acme", Name: "widget", RepoPath: "acme/widget",
+	}, observedAt.Add(2*time.Minute))
+	require.NoError(err)
+	_, _, err = d.ReconcileRepositoryObservation(ctx, RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "provider-replacement",
+		Owner:          "acme", Name: "elsewhere", RepoPath: "acme/elsewhere",
+	}, observedAt.Add(3*time.Minute))
+	require.NoError(err)
+	_, _, err = d.ReconcileRepositoryObservation(ctx, identity, observedAt.Add(4*time.Minute))
+	require.NoError(err)
+
+	err = d.UpdateRepoMergeSettings(guarded, original.Repository.ID, true, false, false)
+	require.ErrorIs(err, ErrRepositoryRouteFenceChanged)
+	repo, err := d.GetRepoByID(ctx, original.Repository.ID)
+	require.NoError(err)
+	require.NotNil(repo)
+	require.False(repo.AllowSquashMerge)
 }

--- a/internal/db/types.go
+++ b/internal/db/types.go
@@ -79,6 +79,12 @@ type RepoProviderMetadata struct {
 	DefaultBranch  string
 }
 
+type RepoMergeSettings struct {
+	AllowSquashMerge bool
+	AllowMergeCommit bool
+	AllowRebaseMerge bool
+}
+
 type ArchiveCollectionMode string
 
 const (

--- a/internal/gitclone/branch_activity.go
+++ b/internal/gitclone/branch_activity.go
@@ -16,7 +16,7 @@ func (m *Manager) ResolveDefaultBranch(
 	ctx context.Context,
 	platform, host, owner, name, preferred string,
 ) (branch string, ref string, err error) {
-	dir, err := m.ClonePath(platform, host, owner, name)
+	dir, err := m.clonePathForContext(ctx, platform, host, owner, name)
 	if err != nil {
 		return "", "", err
 	}
@@ -65,7 +65,7 @@ func (m *Manager) ResolveRef(
 	ctx context.Context,
 	platform, host, owner, name, ref string,
 ) (string, error) {
-	dir, err := m.ClonePath(platform, host, owner, name)
+	dir, err := m.clonePathForContext(ctx, platform, host, owner, name)
 	if err != nil {
 		return "", err
 	}
@@ -82,7 +82,7 @@ func (m *Manager) ResolveCommit(
 	ctx context.Context,
 	platform, host, owner, name, objectID string,
 ) (string, error) {
-	dir, err := m.ClonePath(platform, host, owner, name)
+	dir, err := m.clonePathForContext(ctx, platform, host, owner, name)
 	if err != nil {
 		return "", err
 	}
@@ -94,7 +94,7 @@ func (m *Manager) IsAncestor(
 	ctx context.Context,
 	platform, host, owner, name, ancestor, descendant string,
 ) (bool, error) {
-	dir, err := m.ClonePath(platform, host, owner, name)
+	dir, err := m.clonePathForContext(ctx, platform, host, owner, name)
 	if err != nil {
 		return false, err
 	}
@@ -119,7 +119,7 @@ func (m *Manager) ListBranchCommitsSince(
 	afterSHA string,
 	maxCount int,
 ) ([]Commit, error) {
-	dir, err := m.ClonePath(platform, host, owner, name)
+	dir, err := m.clonePathForContext(ctx, platform, host, owner, name)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gitclone/clone.go
+++ b/internal/gitclone/clone.go
@@ -3,9 +3,11 @@ package gitclone
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -56,12 +58,11 @@ type Manager struct {
 	baseDir string
 	routes  RouteResolver
 
-	// ensureSF deduplicates concurrent EnsureClone calls for the same
-	// (host, owner, name). Without it, callers like the periodic syncer,
-	// per-PR detail syncs, and workspace setup race each other on the
-	// same bare clone and trigger a stampede of identical git fetches,
-	// which GitHub's smart-HTTP edge throttles with sporadic 5xx.
-	ensureSF singleflight.Group
+	// ensureFlights deduplicates concurrent EnsureClone calls for the same
+	// storage namespace and repository while retaining the slot until every
+	// caller has run its own route validation.
+	ensureMu      sync.Mutex
+	ensureFlights map[string]*ensureCloneFlight
 
 	repoBrowserRefreshSF singleflight.Group
 	repoBrowserMu        sync.Mutex
@@ -69,16 +70,62 @@ type Manager struct {
 
 	// ancestryVisitBudget overrides maxAncestryVisits when positive; tests
 	// use it to exercise the budget without building enormous histories.
-	ancestryVisitBudget int
+	ancestryVisitBudget  int
+	repoBrowserBarrierMu sync.Mutex
+	repoBrowserBarriers  map[string]*repoBrowserBarrier
+
+	// Deterministic synchronization and failure-injection hooks for
+	// repository-browser concurrency tests and clone cleanup tests. Tests set
+	// these before starting goroutines.
+	repoBrowserReadWaitingForTest      func(string)
+	repoBrowserAfterReadLockForTest    func(string)
+	repoBrowserAfterRefreshJoinForTest func(RepoBrowserRouteFence)
+	repoBrowserFetchErrorForTest       func(RepoBrowserRouteFence) error
+	removeRepoBrowserStagingForTest    func(string) error
+	publishRepoBrowserStagingForTest   func(string, string) error
+	removeCloneAsideForTest            func(string) error
+}
+
+type ensureCloneFlight struct {
+	done     chan struct{}
+	released chan struct{}
+	err      error
+	complete bool
+	waiters  int
+}
+
+// cloneValidationError marks a slot whose fetch succeeded but whose
+// starter's route validation failed, removing the fetched clone. Followers
+// distinguish it from a fetch failure so a caller whose own route still owns
+// the path can retry with a fresh, self-validated fetch. Unwrap keeps
+// errors.Is checks (for example db.ErrRepositoryRouteFenceChanged) working
+// through the marker.
+type cloneValidationError struct{ err error }
+
+func (e *cloneValidationError) Error() string { return e.err.Error() }
+
+func (e *cloneValidationError) Unwrap() error { return e.err }
+
+type repositoryIdentityContextKey struct{}
+
+// WithRepositoryIdentity partitions clone-backed work by the provider's
+// stable repository identity. Callers should set this after reconciling a
+// mutable owner/name route so route reuse cannot share clone state or an
+// in-flight fetch between distinct repositories.
+func WithRepositoryIdentity(ctx context.Context, providerRepoID string) context.Context {
+	providerRepoID = strings.TrimSpace(providerRepoID)
+	return context.WithValue(ctx, repositoryIdentityContextKey{}, providerRepoID)
 }
 
 // New creates a Manager that stores bare clones under baseDir. A nil resolver
 // means all operations proceed without auth.
 func New(baseDir string, routes RouteResolver) *Manager {
 	return &Manager{
-		baseDir:          baseDir,
-		routes:           routes,
-		repoBrowserRepos: make(map[string]RepoBrowserRepoRef),
+		baseDir:             baseDir,
+		routes:              routes,
+		ensureFlights:       make(map[string]*ensureCloneFlight),
+		repoBrowserRepos:    make(map[string]RepoBrowserRepoRef),
+		repoBrowserBarriers: make(map[string]*repoBrowserBarrier),
 	}
 }
 
@@ -98,6 +145,37 @@ func cloneNamespaceForPlatform(platform string) string {
 		return ""
 	}
 	return platform
+}
+
+func cloneNamespaceForContext(ctx context.Context, platform string) string {
+	namespace := cloneNamespaceForPlatform(platform)
+	providerRepoID, _ := ctx.Value(repositoryIdentityContextKey{}).(string)
+	providerRepoID = strings.TrimSpace(providerRepoID)
+	if providerRepoID == "" {
+		return namespace
+	}
+	digest := sha256.Sum256([]byte(providerRepoID))
+	identityNamespace := fmt.Sprintf("repo-%x", digest[:16])
+	if namespace == "" {
+		return identityNamespace
+	}
+	return namespace + "-" + identityNamespace
+}
+
+// ClonePathForContext returns the clone path selected for ctx. Contexts
+// carrying a provider repository identity use identity-partitioned storage.
+func (m *Manager) ClonePathForContext(
+	ctx context.Context, platform, host, owner, name string,
+) (string, error) {
+	return m.ClonePathInNamespace(
+		cloneNamespaceForContext(ctx, platform), host, owner, name,
+	)
+}
+
+func (m *Manager) clonePathForContext(
+	ctx context.Context, platform, host, owner, name string,
+) (string, error) {
+	return m.ClonePathForContext(ctx, platform, host, owner, name)
 }
 
 // ClonePathInNamespace returns the filesystem path for a repo's bare clone
@@ -156,8 +234,8 @@ func validateCloneNamespace(namespace string) error {
 // remoteURL is the HTTPS clone URL (e.g., https://github.com/owner/name.git).
 // On first call, clones the repo. On subsequent calls, fetches updates.
 //
-// Concurrent callers for the same (host, owner, name) share a single
-// underlying clone/fetch via singleflight so PR detail syncs, the
+// Concurrent callers for the same storage namespace and (host, owner, name)
+// share a single underlying clone/fetch slot so PR detail syncs, the
 // periodic syncer, and workspace setup do not stampede the same bare
 // clone with duplicate git operations.
 //
@@ -171,8 +249,27 @@ func (m *Manager) EnsureClone(
 	ctx context.Context, platform, host, owner, name, remoteURL string,
 ) error {
 	return m.EnsureCloneInNamespace(
-		ctx, cloneNamespaceForPlatform(platform),
+		ctx, cloneNamespaceForContext(ctx, platform),
 		platform, host, owner, name, remoteURL,
+	)
+}
+
+// EnsureCloneValidated creates or fetches a clone with route validation.
+// When this caller starts the shared fetch, validate runs inside the slot
+// after the fetch and before any waiter is released; a failure there removes
+// the fetched clone, so data fetched across an A -> B -> A ownership change
+// is never retained. Every caller additionally runs validate as a pure gate
+// before joining and again before leaving the slot; a stale caller is
+// rejected without touching the shared clone, and joined validation remains
+// serialized against later clone work.
+func (m *Manager) EnsureCloneValidated(
+	ctx context.Context,
+	platform, host, owner, name, remoteURL string,
+	validate func(context.Context) error,
+) error {
+	return m.ensureCloneInNamespaceValidated(
+		ctx, cloneNamespaceForContext(ctx, platform),
+		platform, host, owner, name, remoteURL, validate,
 	)
 }
 
@@ -181,11 +278,21 @@ func (m *Manager) EnsureClone(
 func (m *Manager) EnsureCloneInNamespace(
 	ctx context.Context, namespace, platform, host, owner, name, remoteURL string,
 ) error {
+	return m.ensureCloneInNamespaceValidated(
+		ctx, namespace, platform, host, owner, name, remoteURL, nil,
+	)
+}
+
+func (m *Manager) ensureCloneInNamespaceValidated(
+	ctx context.Context,
+	namespace, platform, host, owner, name, remoteURL string,
+	validate func(context.Context) error,
+) error {
 	namespace = strings.TrimSpace(namespace)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	// Validate per-caller inputs before entering the singleflight
+	// Validate per-caller inputs before entering the shared clone
 	// slot. remoteURL is not part of the slot key (we dedup by
 	// repo identity, not URL spelling), so without an up-front
 	// check a follower with a malformed URL could inherit the
@@ -194,22 +301,184 @@ func (m *Manager) EnsureCloneInNamespace(
 	if err := validateRemoteURLIdentity(host, owner, name, remoteURL); err != nil {
 		return err
 	}
-	if _, err := m.ClonePathInNamespace(namespace, host, owner, name); err != nil {
+	clonePath, err := m.ClonePathInNamespace(namespace, host, owner, name)
+	if err != nil {
 		return err
 	}
 	key := ensureCloneKey(namespace, host, owner, name)
-	ch := m.ensureSF.DoChan(key, func() (any, error) {
+	if err := validateEnsureCloneCaller(ctx, validate); err != nil {
+		return err
+	}
+	run := func() error {
 		opCtx, cancel := context.WithTimeout(
 			context.WithoutCancel(ctx), ensureCloneTimeout,
 		)
 		defer cancel()
-		return nil, m.ensureCloneNowInNamespace(
+		if err := m.ensureCloneNowInNamespace(
 			opCtx, namespace, platform, host, owner, name, remoteURL,
-		)
-	})
+		); err != nil {
+			return err
+		}
+		if validate == nil {
+			return nil
+		}
+		// The slot starter's validation spans the whole fetch window, so a
+		// route that changed ownership during the fetch fails here and the
+		// possibly cross-repository clone is removed before any waiter can
+		// observe it.
+		if err := validate(opCtx); err != nil {
+			if cleanupErr := m.removeCloneAside(clonePath); cleanupErr != nil {
+				return errors.Join(err, fmt.Errorf(
+					"remove clone after failed validation: %w", cleanupErr,
+				))
+			}
+			return &cloneValidationError{err: err}
+		}
+		return nil
+	}
+	started, flight, err := m.awaitEnsureCloneFlight(ctx, key, run, validate)
+	if err != nil {
+		var invalidated *cloneValidationError
+		if started || !errors.As(err, &invalidated) {
+			return err
+		}
+		// The starter's route lost ownership and its failed validation
+		// removed the fetched clone, but this caller's route may still own
+		// the path. Wait for every joined caller to finish validation, then
+		// retry once with a fresh fetch this caller validates.
+		if err := waitEnsureCloneFlightReleased(ctx, flight); err != nil {
+			return err
+		}
+		if err := validateEnsureCloneCaller(ctx, validate); err != nil {
+			return err
+		}
+		if _, _, err := m.awaitEnsureCloneFlight(ctx, key, run, validate); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateEnsureCloneCaller(
+	ctx context.Context, validate func(context.Context) error,
+) error {
+	if validate == nil {
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	validationCtx, cancel := context.WithTimeout(
+		context.WithoutCancel(ctx), ensureCloneTimeout,
+	)
+	defer cancel()
+	return validate(validationCtx)
+}
+
+// removeCloneAside renames an invalidated clone out of its published path
+// before deleting it. Readers outside the clone flight (diff, commit, and
+// file reads resolve the path directly) either finish on their already-open
+// handles or fail cleanly on a vanished path; they never observe a
+// half-deleted tree mid-RemoveAll.
+func removeCloneAside(clonePath string) error {
+	aside := clonePath + ".removing"
+	if err := os.RemoveAll(aside); err != nil {
+		return err
+	}
+	if err := os.Rename(clonePath, aside); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	return os.RemoveAll(aside)
+}
+
+func (m *Manager) removeCloneAside(clonePath string) error {
+	if remove := m.removeCloneAsideForTest; remove != nil {
+		return remove(clonePath)
+	}
+	return removeCloneAside(clonePath)
+}
+
+// awaitEnsureCloneFlight joins (or starts) the shared clone flight for key,
+// waits for it, and reports whether this caller started it alongside the
+// flight and its result. Per-caller validation runs before leaving the
+// flight, keeping the slot serialized until every joined route check ends.
+func (m *Manager) awaitEnsureCloneFlight(
+	ctx context.Context, key string, run func() error,
+	validate func(context.Context) error,
+) (bool, *ensureCloneFlight, error) {
+	flight, started := m.joinEnsureCloneFlight(key, run)
+	defer m.leaveEnsureCloneFlight(key, flight)
 	select {
-	case res := <-ch:
-		return res.Err
+	case <-flight.done:
+	case <-ctx.Done():
+		return started, flight, ctx.Err()
+	}
+	err := flight.err
+	if err == nil {
+		err = validateEnsureCloneCaller(ctx, validate)
+	}
+	return started, flight, err
+}
+
+func (m *Manager) joinEnsureCloneFlight(
+	key string,
+	run func() error,
+) (*ensureCloneFlight, bool) {
+	m.ensureMu.Lock()
+	if m.ensureFlights == nil {
+		m.ensureFlights = make(map[string]*ensureCloneFlight)
+	}
+	// Completed work remains joinable until every registered caller finishes
+	// its own route validation. A second flight must not mutate or remove the
+	// clone while callers from the first flight are still checking ownership.
+	if flight := m.ensureFlights[key]; flight != nil {
+		flight.waiters++
+		m.ensureMu.Unlock()
+		return flight, false
+	}
+	flight := &ensureCloneFlight{
+		done: make(chan struct{}), released: make(chan struct{}), waiters: 1,
+	}
+	m.ensureFlights[key] = flight
+	m.ensureMu.Unlock()
+
+	go func() {
+		err := run()
+		m.ensureMu.Lock()
+		flight.err = err
+		flight.complete = true
+		close(flight.done)
+		if flight.waiters == 0 && m.ensureFlights[key] == flight {
+			delete(m.ensureFlights, key)
+			close(flight.released)
+		}
+		m.ensureMu.Unlock()
+	}()
+	return flight, true
+}
+
+func (m *Manager) leaveEnsureCloneFlight(key string, flight *ensureCloneFlight) {
+	m.ensureMu.Lock()
+	flight.waiters--
+	if flight.complete && flight.waiters == 0 && m.ensureFlights[key] == flight {
+		delete(m.ensureFlights, key)
+		close(flight.released)
+	}
+	m.ensureMu.Unlock()
+}
+
+func waitEnsureCloneFlightReleased(
+	ctx context.Context, flight *ensureCloneFlight,
+) error {
+	if flight == nil {
+		return errors.New("wait for clone flight release: missing flight")
+	}
+	select {
+	case <-flight.released:
+		return nil
 	case <-ctx.Done():
 		return ctx.Err()
 	}
@@ -221,7 +490,7 @@ func ensureCloneKey(namespace, host, owner, name string) string {
 
 // ensureCloneNow is the unshared inner: it decides whether to create a
 // fresh bare clone or refresh an existing one. Always called from
-// inside the singleflight slot opened by EnsureClone, which has
+// inside the shared clone slot opened by EnsureClone, which has
 // already validated the caller's remoteURL.
 func (m *Manager) ensureCloneNowInNamespace(
 	ctx context.Context, namespace, platform, host, owner, name, remoteURL string,
@@ -404,7 +673,7 @@ func (m *Manager) fetch(
 func (m *Manager) RevParse(
 	ctx context.Context, platform, host, owner, name, ref string,
 ) (string, error) {
-	clonePath, err := m.ClonePath(platform, host, owner, name)
+	clonePath, err := m.clonePathForContext(ctx, platform, host, owner, name)
 	if err != nil {
 		return "", err
 	}
@@ -419,7 +688,7 @@ func (m *Manager) RevParse(
 func (m *Manager) MergeBase(
 	ctx context.Context, platform, host, owner, name, sha1, sha2 string,
 ) (string, error) {
-	clonePath, err := m.ClonePath(platform, host, owner, name)
+	clonePath, err := m.clonePathForContext(ctx, platform, host, owner, name)
 	if err != nil {
 		return "", err
 	}

--- a/internal/gitclone/clone_test.go
+++ b/internal/gitclone/clone_test.go
@@ -3,16 +3,38 @@
 package gitclone
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/tokenauth"
 	gitcmd "go.kenn.io/kit/git/cmd"
 )
+
+type blockingRouteResolver struct {
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (r *blockingRouteResolver) SourceForRepo(_, _, _, _ string) tokenauth.Source {
+	r.once.Do(func() {
+		close(r.started)
+		<-r.release
+	})
+	return nil
+}
+
+func (*blockingRouteResolver) FallbackSource(string) tokenauth.Source { return nil }
 
 // setupTestRepo creates a bare "remote" repo with one commit and returns
 // both the remote path and the working clone path (for follow-up pushes).
@@ -91,6 +113,406 @@ func TestIntegrationEnsureCloneInNamespacePartitionsStorage(t *testing.T) {
 		clonesDir, "github.com", "testowner", "testrepo.git",
 	)
 	assert.NoDirExists(t, defaultPath)
+}
+
+func TestIntegrationEnsureClonePartitionsConcurrentRouteReuseByProviderIdentity(t *testing.T) {
+	remoteA, workA := setupTestRepo(t)
+	remoteB, workB := setupTestRepo(t)
+	shaABytes, err := gitcmd.New().Output(t.Context(), workA, "rev-parse", "HEAD")
+	require.NoError(t, err)
+	shaA := strings.TrimSpace(string(shaABytes))
+	shaB := commitAndPush(t, workB, "replacement.go", "package replacement\n", "replacement")
+
+	mgr := New(t.TempDir(), nil)
+	ctxA := WithRepositoryIdentity(t.Context(), "provider-repo-a")
+	ctxB := WithRepositoryIdentity(t.Context(), "provider-repo-b")
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	var ready sync.WaitGroup
+	ready.Add(2)
+	for _, clone := range []struct {
+		ctx    context.Context
+		remote string
+	}{{ctxA, remoteA}, {ctxB, remoteB}} {
+		go func() {
+			ready.Done()
+			<-start
+			errs <- mgr.EnsureClone(
+				clone.ctx, "github", "github.com", "acme", "widget", clone.remote,
+			)
+		}()
+	}
+	ready.Wait()
+	close(start)
+	require.NoError(t, <-errs)
+	require.NoError(t, <-errs)
+
+	gotA, err := mgr.RevParse(ctxA, "github", "github.com", "acme", "widget", "HEAD")
+	require.NoError(t, err)
+	gotB, err := mgr.RevParse(ctxB, "github", "github.com", "acme", "widget", "HEAD")
+	require.NoError(t, err)
+	assert.Equal(t, shaA, gotA)
+	assert.Equal(t, shaB, gotB)
+}
+
+func TestIntegrationEnsureCloneValidatedRemovesCloneAfterRouteChange(t *testing.T) {
+	remote, _ := setupTestRepo(t)
+	mgr := New(t.TempDir(), nil)
+	ctx := WithRepositoryIdentity(t.Context(), "provider-repo-a")
+	validationErr := errors.New("repository route changed")
+	var validations atomic.Int64
+
+	err := mgr.EnsureCloneValidated(
+		ctx, "github", "github.com", "acme", "widget", remote,
+		func(context.Context) error {
+			if validations.Add(1) == 1 {
+				return nil
+			}
+			return validationErr
+		},
+	)
+	require.ErrorIs(t, err, validationErr)
+	assert.Equal(t, int64(2), validations.Load())
+	clonePath, pathErr := mgr.ClonePathForContext(
+		ctx, "github", "github.com", "acme", "widget",
+	)
+	require.NoError(t, pathErr)
+	assert.NoDirExists(t, clonePath)
+	assert.NoDirExists(t, clonePath+".removing",
+		"invalidation must not leave a renamed-aside clone behind")
+}
+
+func TestIntegrationEnsureCloneValidatedRejectsStaleCallerBeforeUnvalidatedFetch(t *testing.T) {
+	remote, _ := setupTestRepo(t)
+	routes := &blockingRouteResolver{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	mgr := New(t.TempDir(), routes)
+	ctx := WithRepositoryIdentity(t.Context(), "provider-repo-a")
+	leaderDone := make(chan error, 1)
+	go func() {
+		leaderDone <- mgr.EnsureClone(
+			ctx, "github", "github.com", "acme", "widget", remote,
+		)
+	}()
+	<-routes.started
+
+	validationErr := errors.New("repository route changed")
+	validatedDone := make(chan error, 1)
+	go func() {
+		validatedDone <- mgr.EnsureCloneValidated(
+			ctx, "github", "github.com", "acme", "widget", remote,
+			func(context.Context) error { return validationErr },
+		)
+	}()
+	select {
+	case err := <-validatedDone:
+		require.ErrorIs(t, err, validationErr)
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "stale caller was not rejected before joining clone work")
+	}
+	close(routes.release)
+
+	require.NoError(t, <-leaderDone)
+	// The stale caller never joins or mutates the unvalidated leader's flight.
+	clonePath, err := mgr.ClonePathForContext(
+		ctx, "github", "github.com", "acme", "widget",
+	)
+	require.NoError(t, err)
+	assert.DirExists(t, clonePath)
+}
+
+func TestIntegrationEnsureCloneValidatedStaleFollowerKeepsValidatedClone(t *testing.T) {
+	remote, _ := setupTestRepo(t)
+	mgr := New(t.TempDir(), nil)
+	ctx := WithRepositoryIdentity(t.Context(), "provider-repo-a")
+
+	leaderValidationStarted := make(chan struct{})
+	releaseLeaderValidation := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseLeader := func() {
+		releaseOnce.Do(func() { close(releaseLeaderValidation) })
+	}
+	t.Cleanup(releaseLeader)
+	var leaderValidations atomic.Int64
+	leaderDone := make(chan error, 1)
+	go func() {
+		leaderDone <- mgr.EnsureCloneValidated(
+			ctx, "github", "github.com", "acme", "widget", remote,
+			func(context.Context) error {
+				if leaderValidations.Add(1) == 2 {
+					close(leaderValidationStarted)
+					<-releaseLeaderValidation
+				}
+				return nil
+			},
+		)
+	}()
+	select {
+	case <-leaderValidationStarted:
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "leader did not reach post-fetch validation")
+	}
+	key := ensureCloneKey(
+		cloneNamespaceForContext(ctx, "github"), "github.com", "acme", "widget",
+	)
+
+	staleErr := errors.New("repository route changed")
+	followerDone := make(chan error, 1)
+	go func() {
+		followerDone <- mgr.EnsureCloneValidated(
+			ctx, "github", "github.com", "acme", "widget", remote,
+			func(context.Context) error { return staleErr },
+		)
+	}()
+	select {
+	case err := <-followerDone:
+		require.ErrorIs(t, err, staleErr)
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "stale follower was not rejected before joining")
+	}
+	mgr.ensureMu.Lock()
+	flight := mgr.ensureFlights[key]
+	waiters := 0
+	if flight != nil {
+		waiters = flight.waiters
+	}
+	mgr.ensureMu.Unlock()
+	assert.Equal(t, 1, waiters, "stale follower must not join the current flight")
+	releaseLeader()
+
+	require.NoError(t, <-leaderDone,
+		"the caller whose route still owns the clone must keep using it")
+	clonePath, err := mgr.ClonePathForContext(
+		ctx, "github", "github.com", "acme", "widget",
+	)
+	require.NoError(t, err)
+	assert.DirExists(t, clonePath,
+		"a stale follower must not remove a clone the current route still owns")
+	require.Eventually(t, func() bool {
+		mgr.ensureMu.Lock()
+		defer mgr.ensureMu.Unlock()
+		return mgr.ensureFlights[key] == nil
+	}, 5*time.Second, time.Millisecond)
+}
+
+func TestIntegrationEnsureCloneValidatedRejectsStaleCallerWhileCurrentCallerValidates(t *testing.T) {
+	remote, _ := setupTestRepo(t)
+	mgr := New(t.TempDir(), nil)
+	ctx := WithRepositoryIdentity(t.Context(), "provider-repo-a")
+	require.NoError(t, mgr.EnsureClone(
+		ctx, "github", "github.com", "acme", "widget", remote,
+	))
+	key := ensureCloneKey(
+		cloneNamespaceForContext(ctx, "github"), "github.com", "acme", "widget",
+	)
+	clonePath, err := mgr.ClonePathForContext(
+		ctx, "github", "github.com", "acme", "widget",
+	)
+	require.NoError(t, err)
+
+	currentValidationStarted := make(chan struct{})
+	releaseCurrentValidation := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseCurrent := func() {
+		releaseOnce.Do(func() { close(releaseCurrentValidation) })
+	}
+	t.Cleanup(releaseCurrent)
+	currentDone := make(chan error, 1)
+	go func() {
+		currentDone <- mgr.EnsureCloneValidated(
+			ctx, "github", "github.com", "acme", "widget", remote,
+			func(context.Context) error {
+				mgr.ensureMu.Lock()
+				flight := mgr.ensureFlights[key]
+				validatingJoinedCaller := flight != nil && flight.complete
+				mgr.ensureMu.Unlock()
+				if validatingJoinedCaller {
+					close(currentValidationStarted)
+					<-releaseCurrentValidation
+				}
+				return nil
+			},
+		)
+	}()
+
+	select {
+	case <-currentValidationStarted:
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "current caller validation ran after its flight was released")
+	}
+
+	staleErr := errors.New("repository route changed")
+	var staleValidations atomic.Int64
+	staleDone := make(chan error, 1)
+	go func() {
+		staleDone <- mgr.EnsureCloneValidated(
+			ctx, "github", "github.com", "acme", "widget", remote,
+			func(context.Context) error {
+				staleValidations.Add(1)
+				return staleErr
+			},
+		)
+	}()
+	select {
+	case err := <-staleDone:
+		require.ErrorIs(t, err, staleErr)
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "stale caller was not rejected before joining clone work")
+	}
+	assert.Equal(t, int64(1), staleValidations.Load())
+	assert.DirExists(t, clonePath,
+		"a stale caller must not remove the current caller's validated clone")
+	select {
+	case err := <-currentDone:
+		require.Fail(t, "current caller returned before validation was released", "%v", err)
+	default:
+	}
+
+	releaseCurrent()
+	require.NoError(t, <-currentDone)
+}
+
+func TestIntegrationEnsureCloneValidatedFollowerRetriesAfterStarterInvalidation(t *testing.T) {
+	remote, _ := setupTestRepo(t)
+	mgr := New(t.TempDir(), nil)
+	ctx := WithRepositoryIdentity(t.Context(), "provider-repo-a")
+
+	followerJoined := make(chan struct{})
+	staleErr := errors.New("repository route changed")
+	var starterValidations atomic.Int64
+	starterDone := make(chan error, 1)
+	go func() {
+		starterDone <- mgr.EnsureCloneValidated(
+			ctx, "github", "github.com", "acme", "widget", remote,
+			func(context.Context) error {
+				if starterValidations.Add(1) == 2 {
+					<-followerJoined
+					return staleErr
+				}
+				return nil
+			},
+		)
+	}()
+	key := ensureCloneKey(
+		cloneNamespaceForContext(ctx, "github"), "github.com", "acme", "widget",
+	)
+	require.Eventually(t, func() bool {
+		mgr.ensureMu.Lock()
+		defer mgr.ensureMu.Unlock()
+		return mgr.ensureFlights[key] != nil
+	}, 5*time.Second, time.Millisecond)
+
+	var followerValidations atomic.Int64
+	followerDone := make(chan error, 1)
+	go func() {
+		followerDone <- mgr.EnsureCloneValidated(
+			ctx, "github", "github.com", "acme", "widget", remote,
+			func(context.Context) error {
+				followerValidations.Add(1)
+				return nil
+			},
+		)
+	}()
+	require.Eventually(t, func() bool {
+		mgr.ensureMu.Lock()
+		defer mgr.ensureMu.Unlock()
+		flight := mgr.ensureFlights[key]
+		return flight != nil && flight.waiters == 2
+	}, 5*time.Second, time.Millisecond)
+	close(followerJoined)
+
+	require.ErrorIs(t, <-starterDone, staleErr)
+	// A follower whose own route still owns the path must not be rejected
+	// because the starter's route lost ownership: it refetches the clone the
+	// starter's failed validation removed.
+	require.NoError(t, <-followerDone)
+	assert.Greater(t, followerValidations.Load(), int64(1),
+		"a follower retries and validates the freshly fetched clone")
+	clonePath, err := mgr.ClonePathForContext(
+		ctx, "github", "github.com", "acme", "widget",
+	)
+	require.NoError(t, err)
+	assert.DirExists(t, clonePath)
+}
+
+func TestIntegrationEnsureCloneValidatedCleanupFailureIsNotRetryable(t *testing.T) {
+	remote, _ := setupTestRepo(t)
+	mgr := New(t.TempDir(), nil)
+	ctx := WithRepositoryIdentity(t.Context(), "provider-repo-a")
+
+	cleanupErr := errors.New("remove invalidated clone failed")
+	var cleanupCalls atomic.Int64
+	mgr.removeCloneAsideForTest = func(string) error {
+		cleanupCalls.Add(1)
+		return cleanupErr
+	}
+
+	followerJoined := make(chan struct{})
+	staleErr := errors.New("repository route changed")
+	var starterValidations atomic.Int64
+	starterDone := make(chan error, 1)
+	go func() {
+		starterDone <- mgr.EnsureCloneValidated(
+			ctx, "github", "github.com", "acme", "widget", remote,
+			func(context.Context) error {
+				if starterValidations.Add(1) == 2 {
+					<-followerJoined
+					return staleErr
+				}
+				return nil
+			},
+		)
+	}()
+	key := ensureCloneKey(
+		cloneNamespaceForContext(ctx, "github"), "github.com", "acme", "widget",
+	)
+	require.Eventually(t, func() bool {
+		mgr.ensureMu.Lock()
+		defer mgr.ensureMu.Unlock()
+		return mgr.ensureFlights[key] != nil
+	}, 5*time.Second, time.Millisecond)
+
+	var followerValidations atomic.Int64
+	followerDone := make(chan error, 1)
+	go func() {
+		followerDone <- mgr.EnsureCloneValidated(
+			ctx, "github", "github.com", "acme", "widget", remote,
+			func(context.Context) error {
+				followerValidations.Add(1)
+				return nil
+			},
+		)
+	}()
+	require.Eventually(t, func() bool {
+		mgr.ensureMu.Lock()
+		defer mgr.ensureMu.Unlock()
+		flight := mgr.ensureFlights[key]
+		return flight != nil && flight.waiters == 2
+	}, 5*time.Second, time.Millisecond)
+	close(followerJoined)
+
+	for _, err := range []error{<-starterDone, <-followerDone} {
+		require.ErrorIs(t, err, staleErr)
+		require.ErrorIs(t, err, cleanupErr)
+		var invalidated *cloneValidationError
+		require.NotErrorAs(t, err, &invalidated)
+	}
+	assert.Equal(t, int64(1), cleanupCalls.Load())
+	assert.Equal(t, int64(1), followerValidations.Load(),
+		"a follower must preflight once but not retry after failed quarantine")
+	clonePath, err := mgr.ClonePathForContext(
+		ctx, "github", "github.com", "acme", "widget",
+	)
+	require.NoError(t, err)
+	assert.DirExists(t, clonePath,
+		"a failed cleanup leaves the possibly contaminated clone in place")
+}
+
+func TestWaitEnsureCloneFlightReleasedRejectsMissingFlight(t *testing.T) {
+	err := waitEnsureCloneFlightReleased(t.Context(), nil)
+	require.EqualError(t, err, "wait for clone flight release: missing flight")
 }
 
 // TestEnsureCloneShortCircuitsCanceledContext verifies that a caller
@@ -547,4 +969,326 @@ func TestIntegrationMergeBase(t *testing.T) {
 		ctx, "github", "github.com", "testowner", "testrepo", headSHA, headSHA)
 	require.NoError(err)
 	assert.Equal(headSHA, mb)
+}
+
+func TestIntegrationRepoBrowserClonePartitionsRouteReuseByProviderIdentity(t *testing.T) {
+	remoteA, workA := setupTestRepo(t)
+	remoteB, workB := setupTestRepo(t)
+	shaABytes, err := gitcmd.New().Output(t.Context(), workA, "rev-parse", "HEAD")
+	require.NoError(t, err)
+	shaA := strings.TrimSpace(string(shaABytes))
+	shaB := commitAndPush(t, workB, "replacement.go", "package replacement\n", "replacement")
+
+	mgr := New(t.TempDir(), nil)
+	refA := RepoBrowserRepoRef{
+		Provider: "github", Host: "github.com",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+		ProviderRepoID: "provider-repo-a", RemoteURL: remoteA,
+	}
+	refB := RepoBrowserRepoRef{
+		Provider: "github", Host: "github.com",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+		ProviderRepoID: "provider-repo-b", RemoteURL: remoteB,
+	}
+	require.NoError(t, mgr.EnsureRepoBrowserClone(t.Context(), refA))
+	require.NoError(t, mgr.EnsureRepoBrowserClone(t.Context(), refB))
+
+	pathA, err := mgr.repoBrowserClonePath(refA)
+	require.NoError(t, err)
+	pathB, err := mgr.repoBrowserClonePath(refB)
+	require.NoError(t, err)
+	require.NotEqual(t, pathA, pathB,
+		"distinct repository identities sharing a path must not share browser clone storage")
+	gotA, err := gitcmd.New().Output(t.Context(), pathA, "rev-parse", "HEAD")
+	require.NoError(t, err)
+	gotB, err := gitcmd.New().Output(t.Context(), pathB, "rev-parse", "HEAD")
+	require.NoError(t, err)
+	assert.Equal(t, shaA, strings.TrimSpace(string(gotA)))
+	assert.Equal(t, shaB, strings.TrimSpace(string(gotB)))
+}
+
+func TestAdoptLegacyClonesKeepsMainAndBrowserCachesAvailableOffline(t *testing.T) {
+	remote, work := setupTestRepo(t)
+	shaBytes, err := gitcmd.New().Output(t.Context(), work, "rev-parse", "HEAD")
+	require.NoError(t, err)
+	wantSHA := strings.TrimSpace(string(shaBytes))
+	mgr := New(t.TempDir(), nil)
+	legacyRepo := RepoBrowserRepoRef{
+		Provider: "github", Host: "github.com",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+		RemoteURL: remote,
+	}
+
+	require.NoError(t, mgr.EnsureClone(
+		t.Context(), "github", "github.com", "acme", "widget", remote,
+	))
+	require.NoError(t, mgr.EnsureRepoBrowserClone(t.Context(), legacyRepo))
+	legacyMainPath, err := mgr.ClonePath(
+		"github", "github.com", "acme", "widget",
+	)
+	require.NoError(t, err)
+	legacyBrowserPath, err := mgr.repoBrowserClonePath(legacyRepo)
+	require.NoError(t, err)
+	require.NoError(t, os.Rename(remote, remote+".offline"))
+
+	stableRepo := legacyRepo
+	stableRepo.ProviderRepoID = "provider-repo-1"
+	require.NoError(t, mgr.AdoptLegacyClones(t.Context(), stableRepo))
+
+	legacyMainSHA, err := mgr.RevParse(
+		t.Context(), "github", "github.com", "acme", "widget", "HEAD",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, wantSHA, legacyMainSHA)
+	stableCtx := WithRepositoryIdentity(t.Context(), stableRepo.ProviderRepoID)
+	gotMainSHA, err := mgr.RevParse(
+		stableCtx, "github", "github.com", "acme", "widget", "HEAD",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, wantSHA, gotMainSHA)
+	stableMainPath, err := mgr.ClonePathForContext(
+		stableCtx, "github", "github.com", "acme", "widget",
+	)
+	require.NoError(t, err)
+	stableOrigin, err := gitcmd.New().Output(
+		t.Context(), stableMainPath, "config", "--get", "remote.origin.url",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, remote, strings.TrimSpace(string(stableOrigin)))
+	stableFetch, err := gitcmd.New().Output(
+		t.Context(), stableMainPath, "config", "--get-all", "remote.origin.fetch",
+	)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, defaultRefspecs(), strings.Fields(string(stableFetch)))
+	_, err = gitcmd.New().Output(
+		t.Context(), stableMainPath, "config", "--get", "remote.origin.mirror",
+	)
+	assert.Error(t, err)
+	resolved, err := mgr.ResolveRepoBrowserRef(
+		t.Context(), stableRepo,
+		RepoBrowserRef{Type: RepoBrowserRefBranch, Name: "main"},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, wantSHA, resolved.SHA)
+	assert.DirExists(t, legacyMainPath)
+	assert.NoDirExists(t, legacyBrowserPath)
+}
+
+func TestAdoptLegacyClonesCopiesMainWithoutSharedRefsOrObjects(t *testing.T) {
+	remote, _ := setupTestRepo(t)
+	mgr := New(t.TempDir(), nil)
+	legacyRepo := RepoBrowserRepoRef{
+		Provider: "github", Host: "github.com",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+		RemoteURL: remote,
+	}
+	require.NoError(t, mgr.EnsureClone(
+		t.Context(), "github", "github.com", "acme", "widget", remote,
+	))
+	legacyMainPath, err := mgr.ClonePath(
+		"github", "github.com", "acme", "widget",
+	)
+	require.NoError(t, err)
+	objectContent := []byte("independent legacy object\n")
+	objectOut, stderr, err := gitcmd.New().Run(
+		t.Context(), legacyMainPath, bytes.NewReader(objectContent),
+		"hash-object", "-w", "--stdin",
+	)
+	require.NoError(t, err, string(stderr))
+	objectSHA := strings.TrimSpace(string(objectOut))
+	run(t, legacyMainPath, "git", "update-ref", "refs/test/independent", objectSHA)
+
+	stableRepo := legacyRepo
+	stableRepo.ProviderRepoID = "provider-repo-1"
+	require.NoError(t, mgr.AdoptLegacyClones(t.Context(), stableRepo))
+	stableMainPath, err := mgr.ClonePathForContext(
+		WithRepositoryIdentity(t.Context(), stableRepo.ProviderRepoID),
+		"github", "github.com", "acme", "widget",
+	)
+	require.NoError(t, err)
+	stableRef, err := mgr.RevParse(
+		WithRepositoryIdentity(t.Context(), stableRepo.ProviderRepoID),
+		"github", "github.com", "acme", "widget", "refs/test/independent",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, objectSHA, stableRef)
+	stableObjectPath := filepath.Join(
+		stableMainPath, "objects", objectSHA[:2], objectSHA[2:],
+	)
+	legacyObjectPath := filepath.Join(
+		legacyMainPath, "objects", objectSHA[:2], objectSHA[2:],
+	)
+	require.FileExists(t, stableObjectPath)
+	stableObjectInfo, err := os.Stat(stableObjectPath)
+	require.NoError(t, err)
+	legacyObjectInfo, err := os.Stat(legacyObjectPath)
+	require.NoError(t, err)
+	assert.False(t, os.SameFile(stableObjectInfo, legacyObjectInfo))
+	assert.NoFileExists(t, filepath.Join(stableMainPath, "objects", "info", "alternates"))
+	require.NoError(t, os.WriteFile(stableObjectPath, []byte("corrupt"), 0o444))
+	run(t, stableMainPath, "git", "update-ref", "-d", "refs/test/independent")
+
+	legacyRef, err := mgr.RevParse(
+		t.Context(), "github", "github.com", "acme", "widget",
+		"refs/test/independent",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, objectSHA, legacyRef)
+	legacyObject, err := gitcmd.New().Output(
+		t.Context(), legacyMainPath, "cat-file", "blob", objectSHA,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, objectContent, legacyObject)
+}
+
+func TestAdoptLegacyClonesCopyFailureDoesNotPublishPartialStableMain(t *testing.T) {
+	remote, _ := setupTestRepo(t)
+	mgr := New(t.TempDir(), nil)
+	legacyRepo := RepoBrowserRepoRef{
+		Provider: "github", Host: "github.com",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+		RemoteURL: remote,
+	}
+	require.NoError(t, mgr.EnsureClone(
+		t.Context(), "github", "github.com", "acme", "widget", remote,
+	))
+	legacyMainPath, err := mgr.ClonePath(
+		"github", "github.com", "acme", "widget",
+	)
+	require.NoError(t, err)
+	brokenRefPath := filepath.Join(legacyMainPath, "refs", "test", "broken")
+	require.NoError(t, os.MkdirAll(filepath.Dir(brokenRefPath), 0o755))
+	require.NoError(t, os.WriteFile(
+		brokenRefPath, []byte(strings.Repeat("f", 40)+"\n"), 0o644,
+	))
+
+	stableRepo := legacyRepo
+	stableRepo.ProviderRepoID = "provider-repo-1"
+	err = mgr.AdoptLegacyClones(t.Context(), stableRepo)
+	require.Error(t, err)
+	stableMainPath, pathErr := mgr.ClonePathForContext(
+		WithRepositoryIdentity(t.Context(), stableRepo.ProviderRepoID),
+		"github", "github.com", "acme", "widget",
+	)
+	require.NoError(t, pathErr)
+	assert.NoDirExists(t, stableMainPath)
+	legacySHA, revErr := mgr.RevParse(
+		t.Context(), "github", "github.com", "acme", "widget", "HEAD",
+	)
+	require.NoError(t, revErr)
+	assert.NotEmpty(t, legacySHA)
+	staging, globErr := filepath.Glob(filepath.Join(
+		filepath.Dir(stableMainPath), "."+filepath.Base(stableMainPath)+".adopting-*",
+	))
+	require.NoError(t, globErr)
+	assert.Empty(t, staging)
+}
+
+func TestAdoptLegacyClonesRejectsIncompleteStableMain(t *testing.T) {
+	remote, _ := setupTestRepo(t)
+	mgr := New(t.TempDir(), nil)
+	legacyRepo := RepoBrowserRepoRef{
+		Provider: "github", Host: "github.com",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+		RemoteURL: remote,
+	}
+	require.NoError(t, mgr.EnsureClone(
+		t.Context(), "github", "github.com", "acme", "widget", remote,
+	))
+	stableRepo := legacyRepo
+	stableRepo.ProviderRepoID = "provider-repo-1"
+	stableMainPath, err := mgr.ClonePathForContext(
+		WithRepositoryIdentity(t.Context(), stableRepo.ProviderRepoID),
+		"github", "github.com", "acme", "widget",
+	)
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(stableMainPath, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(stableMainPath, "HEAD"), []byte("ref: refs/heads/main\n"), 0o644,
+	))
+
+	err = mgr.AdoptLegacyClones(t.Context(), stableRepo)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "incomplete")
+	legacySHA, revErr := mgr.RevParse(
+		t.Context(), "github", "github.com", "acme", "widget", "HEAD",
+	)
+	require.NoError(t, revErr)
+	assert.NotEmpty(t, legacySHA)
+}
+
+func TestAdoptLegacyClonesHandlesConcurrentStableMainPublication(t *testing.T) {
+	remote, _ := setupTestRepo(t)
+	cloneBase := t.TempDir()
+	seedManager := New(cloneBase, nil)
+	require.NoError(t, seedManager.EnsureClone(
+		t.Context(), "github", "github.com", "acme", "widget", remote,
+	))
+	stableRepo := RepoBrowserRepoRef{
+		Provider: "github", Host: "github.com",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+		ProviderRepoID: "provider-repo-1", RemoteURL: remote,
+	}
+
+	ctx := t.Context()
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	var ready sync.WaitGroup
+	ready.Add(2)
+	for range 2 {
+		mgr := New(cloneBase, nil)
+		go func() {
+			ready.Done()
+			<-start
+			errs <- mgr.AdoptLegacyClones(ctx, stableRepo)
+		}()
+	}
+	ready.Wait()
+	close(start)
+	require.NoError(t, <-errs)
+	require.NoError(t, <-errs)
+
+	legacySHA, err := seedManager.RevParse(
+		t.Context(), "github", "github.com", "acme", "widget", "HEAD",
+	)
+	require.NoError(t, err)
+	stableSHA, err := seedManager.RevParse(
+		WithRepositoryIdentity(t.Context(), stableRepo.ProviderRepoID),
+		"github", "github.com", "acme", "widget", "HEAD",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, legacySHA, stableSHA)
+}
+
+func TestAdoptLegacyClonesRejectsMismatchedStoredOrigin(t *testing.T) {
+	remote, _ := setupTestRepo(t)
+	mgr := New(t.TempDir(), nil)
+	legacyRepo := RepoBrowserRepoRef{
+		Provider: "github", Host: "github.com",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+		RemoteURL: remote,
+	}
+	require.NoError(t, mgr.EnsureClone(
+		t.Context(), "github", "github.com", "acme", "widget", remote,
+	))
+	require.NoError(t, mgr.EnsureRepoBrowserClone(t.Context(), legacyRepo))
+	legacyMainPath, err := mgr.ClonePath(
+		"github", "github.com", "acme", "widget",
+	)
+	require.NoError(t, err)
+	run(t, legacyMainPath, "git", "config", "remote.origin.url",
+		"https://github.com/other/repository.git")
+
+	stableRepo := legacyRepo
+	stableRepo.ProviderRepoID = "provider-repo-1"
+	err = mgr.AdoptLegacyClones(t.Context(), stableRepo)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "does not match configured repo")
+	assert.DirExists(t, legacyMainPath)
+	stableMainPath, pathErr := mgr.ClonePathForContext(
+		WithRepositoryIdentity(t.Context(), stableRepo.ProviderRepoID),
+		"github", "github.com", "acme", "widget",
+	)
+	require.NoError(t, pathErr)
+	assert.NoDirExists(t, stableMainPath)
 }

--- a/internal/gitclone/commits.go
+++ b/internal/gitclone/commits.go
@@ -38,7 +38,7 @@ func (m *Manager) ListCommits(
 	ctx context.Context,
 	platform, host, owner, name, mergeBase, headSHA string,
 ) ([]Commit, error) {
-	dir, err := m.ClonePath(platform, host, owner, name)
+	dir, err := m.clonePathForContext(ctx, platform, host, owner, name)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +130,7 @@ func (m *Manager) CommitTimelineSinceTag(
 		limit = 1
 	}
 
-	dir, err := m.ClonePath(platform, host, owner, name)
+	dir, err := m.clonePathForContext(ctx, platform, host, owner, name)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -253,7 +253,7 @@ func (m *Manager) ParentOf(
 	ctx context.Context,
 	platform, host, owner, name, sha string,
 ) (string, error) {
-	dir, err := m.ClonePath(platform, host, owner, name)
+	dir, err := m.clonePathForContext(ctx, platform, host, owner, name)
 	if err != nil {
 		return "", err
 	}

--- a/internal/gitclone/diff.go
+++ b/internal/gitclone/diff.go
@@ -20,7 +20,7 @@ func (m *Manager) DiffFiles(
 	ctx context.Context,
 	platform, host, owner, name, mergeBase, headSHA string,
 ) ([]DiffFile, error) {
-	clonePath, err := m.ClonePath(platform, host, owner, name)
+	clonePath, err := m.clonePathForContext(ctx, platform, host, owner, name)
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +148,7 @@ func (m *Manager) Diff(
 	platform, host, owner, name, mergeBase, headSHA string,
 	hideWhitespace bool,
 ) (*DiffResult, error) {
-	clonePath, err := m.ClonePath(platform, host, owner, name)
+	clonePath, err := m.clonePathForContext(ctx, platform, host, owner, name)
 	if err != nil {
 		return nil, err
 	}
@@ -340,7 +340,7 @@ func (m *Manager) FileContent(
 	platform, host, owner, name, ref, filePath string,
 	maxBytes int64,
 ) (*FileContent, error) {
-	clonePath, err := m.ClonePath(platform, host, owner, name)
+	clonePath, err := m.clonePathForContext(ctx, platform, host, owner, name)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gitclone/reachability.go
+++ b/internal/gitclone/reachability.go
@@ -65,7 +65,7 @@ func (m *Manager) CommitsReachableFrom(
 	platform, host, owner, name, headSHA string,
 	candidateSHAs []string,
 ) (CommitReachability, error) {
-	clonePath, err := m.ClonePath(platform, host, owner, name)
+	clonePath, err := m.clonePathForContext(ctx, platform, host, owner, name)
 	if err != nil {
 		return CommitReachability{}, err
 	}

--- a/internal/gitclone/reachability_test.go
+++ b/internal/gitclone/reachability_test.go
@@ -32,6 +32,30 @@ func TestCommitsReachableFrom(t *testing.T) {
 	assert.False(evaluated, "unrepresentable candidates are omitted, not judged")
 }
 
+func TestCommitsReachableFromUsesRepositoryIdentityNamespace(t *testing.T) {
+	mgr, shas := setupAncestryClone(t)
+	ctx := WithRepositoryIdentity(context.Background(), "provider-repo-1")
+	legacyPath, err := mgr.ClonePath(
+		"github", "example.com", "acme", "widgets",
+	)
+	require.NoError(t, err)
+	identityPath, err := mgr.ClonePathForContext(
+		ctx, "github", "example.com", "acme", "widgets",
+	)
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(identityPath), 0o755))
+	require.NoError(t, os.Rename(legacyPath, identityPath))
+
+	result, err := mgr.CommitsReachableFrom(
+		ctx, "github", "example.com", "acme", "widgets", shas["c2"],
+		[]string{shas["c1"], shas["c3"]},
+	)
+	require.NoError(t, err)
+	assert.True(t, result.HeadVerified)
+	assert.True(t, result.Live[shas["c1"]])
+	assert.False(t, result.Live[shas["c3"]])
+}
+
 func TestCommitsReachableFromMissingHead(t *testing.T) {
 	ctx := context.Background()
 	mgr, shas := setupAncestryClone(t)

--- a/internal/gitclone/repo_browser.go
+++ b/internal/gitclone/repo_browser.go
@@ -18,10 +18,14 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 	"unicode/utf8"
 
+	"github.com/gofrs/flock"
 	"go.kenn.io/forge/internal/procutil"
+	"golang.org/x/sync/semaphore"
+	"golang.org/x/sync/singleflight"
 )
 
 const (
@@ -34,12 +38,96 @@ const (
 )
 
 var (
-	ErrUnsafePath       = errors.New("unsafe repo browser path")
-	ErrTooManyPaths     = errors.New("too many repo browser paths")
-	ErrTooLargeAsset    = errors.New("repo browser asset too large")
-	ErrUnsupportedAsset = errors.New("unsupported repo browser asset type")
-	ErrCommitOutOfScope = errors.New("repo browser commit outside selected file history")
+	ErrUnsafePath                   = errors.New("unsafe repo browser path")
+	ErrTooManyPaths                 = errors.New("too many repo browser paths")
+	ErrTooLargeAsset                = errors.New("repo browser asset too large")
+	ErrUnsupportedAsset             = errors.New("unsupported repo browser asset type")
+	ErrCommitOutOfScope             = errors.New("repo browser commit outside selected file history")
+	ErrRepoBrowserRouteFenceChanged = errors.New("repo browser repository route changed")
 )
+
+// RepoBrowserRouteFence is an opaque, comparable route-ownership token.
+// Server callers create one from their catalog generation without exposing
+// the database representation to gitclone.
+type RepoBrowserRouteFence struct {
+	parts [3]int64
+}
+
+func NewRepoBrowserRouteFence(part1, part2, part3 int64) RepoBrowserRouteFence {
+	return RepoBrowserRouteFence{parts: [3]int64{part1, part2, part3}}
+}
+
+type RepoBrowserRouteFenceValidator func(
+	context.Context, RepoBrowserRouteFence,
+) (bool, error)
+
+type RepoBrowserRouteFencePublishGuard func(
+	context.Context,
+	RepoBrowserRouteFence,
+	func() error,
+) (bool, error)
+
+type repoBrowserCloneValidationError struct{ err error }
+
+func (e *repoBrowserCloneValidationError) Error() string { return e.err.Error() }
+func (e *repoBrowserCloneValidationError) Unwrap() error { return e.err }
+
+const repoBrowserBarrierCapacity int64 = 1 << 30
+
+// repoBrowserBarrier gives publications preference once queued so a steady
+// stream of browser reads cannot starve a validated clone swap. The weighted
+// semaphore also lets callers abandon admission when their context is canceled.
+type repoBrowserBarrier struct {
+	semaphore      *semaphore.Weighted
+	mu             sync.Mutex
+	waitingWriters int
+	writer         bool
+}
+
+func newRepoBrowserBarrier() *repoBrowserBarrier {
+	return &repoBrowserBarrier{semaphore: semaphore.NewWeighted(repoBrowserBarrierCapacity)}
+}
+
+func (b *repoBrowserBarrier) lockRead(ctx context.Context, waiting func()) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	b.mu.Lock()
+	queuedBehindWriter := b.writer || b.waitingWriters > 0
+	b.mu.Unlock()
+	if queuedBehindWriter && waiting != nil {
+		waiting()
+	}
+	return b.semaphore.Acquire(ctx, 1)
+}
+
+func (b *repoBrowserBarrier) unlockRead() {
+	b.semaphore.Release(1)
+}
+
+func (b *repoBrowserBarrier) lockWrite(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	b.mu.Lock()
+	b.waitingWriters++
+	b.mu.Unlock()
+	err := b.semaphore.Acquire(ctx, repoBrowserBarrierCapacity)
+	b.mu.Lock()
+	b.waitingWriters--
+	if err == nil {
+		b.writer = true
+	}
+	b.mu.Unlock()
+	return err
+}
+
+func (b *repoBrowserBarrier) unlockWrite() {
+	b.mu.Lock()
+	b.writer = false
+	b.mu.Unlock()
+	b.semaphore.Release(repoBrowserBarrierCapacity)
+}
 
 type RepoBrowserRefType string
 
@@ -50,12 +138,27 @@ const (
 )
 
 type RepoBrowserRepoRef struct {
-	Provider  string
-	Host      string
-	Owner     string
-	Name      string
-	RepoPath  string
-	RemoteURL string
+	Provider string
+	Host     string
+	Owner    string
+	Name     string
+	RepoPath string
+	// ProviderRepoID is the provider's stable repository identity. Browser
+	// clone storage partitions on it so a reused owner/name path never
+	// serves the displaced repository's cached refs or objects. Empty for
+	// repositories without a verified identity, which keep path-scoped
+	// storage.
+	ProviderRepoID string
+	RemoteURL      string
+
+	// The route-fence callbacks bind server-created browser work to the catalog
+	// generation that supplied RemoteURL. Standalone callers may leave all
+	// three unset for legacy unfenced behavior.
+	RouteFence         RepoBrowserRouteFence
+	ValidateRouteFence RepoBrowserRouteFenceValidator
+	// PublishIfRouteFenceMatches must hold route ownership stable while it
+	// invokes the supplied filesystem publication callback.
+	PublishIfRouteFenceMatches RepoBrowserRouteFencePublishGuard
 }
 
 type RepoBrowserRef struct {
@@ -97,6 +200,11 @@ func (m *Manager) ListRepoBrowserRefs(
 	repo RepoBrowserRepoRef,
 	defaultBranch string,
 ) ([]RepoBrowserRef, RepoBrowserRef, bool, error) {
+	unlock, err := m.lockRepoBrowserRead(ctx, repo)
+	if err != nil {
+		return nil, RepoBrowserRef{}, false, err
+	}
+	defer unlock()
 	dir, err := m.repoBrowserClonePath(repo)
 	if err != nil {
 		return nil, RepoBrowserRef{}, false, err
@@ -172,6 +280,11 @@ func (m *Manager) ListRepoBrowserTree(
 	repo RepoBrowserRepoRef,
 	ref RepoBrowserRef,
 ) ([]RepoBrowserTreeEntry, bool, error) {
+	unlock, err := m.lockRepoBrowserRead(ctx, repo)
+	if err != nil {
+		return nil, false, err
+	}
+	defer unlock()
 	dir, sha, _, err := m.resolveRepoBrowserRef(ctx, repo, ref)
 	if err != nil {
 		return nil, false, err
@@ -280,6 +393,11 @@ func (m *Manager) ReadRepoBrowserBlob(
 	ref RepoBrowserRef,
 	pathName string,
 ) (RepoBrowserBlob, error) {
+	unlock, err := m.lockRepoBrowserRead(ctx, repo)
+	if err != nil {
+		return RepoBrowserBlob{}, err
+	}
+	defer unlock()
 	return m.readRepoBrowserBlob(ctx, repo, ref, pathName, false)
 }
 
@@ -289,6 +407,11 @@ func (m *Manager) ReadRepoBrowserAsset(
 	ref RepoBrowserRef,
 	pathName string,
 ) (RepoBrowserBlob, error) {
+	unlock, err := m.lockRepoBrowserRead(ctx, repo)
+	if err != nil {
+		return RepoBrowserBlob{}, err
+	}
+	defer unlock()
 	blob, err := m.readRepoBrowserBlob(ctx, repo, ref, pathName, true)
 	if err != nil {
 		return RepoBrowserBlob{}, err
@@ -399,6 +522,11 @@ func (m *Manager) RepoBrowserLastChanged(
 	ref RepoBrowserRef,
 	paths []string,
 ) (map[string]RepoBrowserCommit, error) {
+	unlock, err := m.lockRepoBrowserRead(ctx, repo)
+	if err != nil {
+		return nil, err
+	}
+	defer unlock()
 	if len(paths) > RepoBrowserLastChangedBatchMax {
 		return nil, ErrTooManyPaths
 	}
@@ -525,6 +653,11 @@ func (m *Manager) RepoBrowserFileHistory(
 	ref RepoBrowserRef,
 	pathName string,
 ) ([]RepoBrowserCommit, error) {
+	unlock, err := m.lockRepoBrowserRead(ctx, repo)
+	if err != nil {
+		return nil, err
+	}
+	defer unlock()
 	cleanPath, err := cleanRepoBrowserPath(pathName)
 	if err != nil {
 		return nil, err
@@ -562,6 +695,11 @@ func (m *Manager) RepoBrowserCommitDetail(
 	pathName string,
 	sha string,
 ) (RepoBrowserCommit, error) {
+	unlock, err := m.lockRepoBrowserRead(ctx, repo)
+	if err != nil {
+		return RepoBrowserCommit{}, err
+	}
+	defer unlock()
 	cleanPath, err := cleanRepoBrowserPath(pathName)
 	if err != nil {
 		return RepoBrowserCommit{}, err
@@ -641,6 +779,11 @@ func (m *Manager) ResolveRepoBrowserRef(
 	repo RepoBrowserRepoRef,
 	ref RepoBrowserRef,
 ) (RepoBrowserRef, error) {
+	unlock, err := m.lockRepoBrowserRead(ctx, repo)
+	if err != nil {
+		return RepoBrowserRef{}, err
+	}
+	defer unlock()
 	_, sha, stale, err := m.resolveRepoBrowserRef(ctx, repo, ref)
 	if err != nil {
 		return RepoBrowserRef{}, err
@@ -757,6 +900,280 @@ func (m *Manager) repoBrowserClonePath(repo RepoBrowserRepoRef) (string, error) 
 	return m.ClonePathInNamespace(repoBrowserCloneNamespace(repo), repo.Host, repo.Owner, repo.Name)
 }
 
+func (m *Manager) repoBrowserCloneBarrier(repo RepoBrowserRepoRef) *repoBrowserBarrier {
+	namespace := repoBrowserCloneNamespace(repo)
+	m.repoBrowserBarrierMu.Lock()
+	defer m.repoBrowserBarrierMu.Unlock()
+	if m.repoBrowserBarriers == nil {
+		m.repoBrowserBarriers = make(map[string]*repoBrowserBarrier)
+	}
+	barrier := m.repoBrowserBarriers[namespace]
+	if barrier == nil {
+		barrier = newRepoBrowserBarrier()
+		m.repoBrowserBarriers[namespace] = barrier
+	}
+	return barrier
+}
+
+func (m *Manager) lockRepoBrowserRead(
+	ctx context.Context, repo RepoBrowserRepoRef,
+) (func(), error) {
+	namespace := repoBrowserCloneNamespace(repo)
+	barrier := m.repoBrowserCloneBarrier(repo)
+	if err := barrier.lockRead(ctx, func() {
+		if hook := m.repoBrowserReadWaitingForTest; hook != nil {
+			hook(namespace)
+		}
+	}); err != nil {
+		return nil, err
+	}
+	if hook := m.repoBrowserAfterReadLockForTest; hook != nil {
+		hook(namespace)
+	}
+	return barrier.unlockRead, nil
+}
+
+// AdoptLegacyClones copies the pre-stable-ID main clone and moves the legacy
+// repository-browser clone into identity-partitioned storage without
+// contacting the provider. The path-scoped main clone remains in place for
+// workspace flows that intentionally continue to use it. Callers must invoke
+// this only after the repository catalog has verified that the current route
+// has no other historical owner.
+func (m *Manager) AdoptLegacyClones(ctx context.Context, repo RepoBrowserRepoRef) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(repo.ProviderRepoID) == "" {
+		return errors.New("adopt legacy clones requires a stable provider repository id")
+	}
+	if err := validateRemoteURLIdentity(repo.Host, repo.Owner, repo.Name, repo.RemoteURL); err != nil {
+		return err
+	}
+
+	legacyMain, err := m.ClonePath(repo.Provider, repo.Host, repo.Owner, repo.Name)
+	if err != nil {
+		return err
+	}
+	stableMain, err := m.ClonePathForContext(
+		WithRepositoryIdentity(ctx, repo.ProviderRepoID),
+		repo.Provider, repo.Host, repo.Owner, repo.Name,
+	)
+	if err != nil {
+		return err
+	}
+	legacyBrowserRepo := repo
+	legacyBrowserRepo.ProviderRepoID = ""
+	legacyBrowser, err := m.repoBrowserClonePath(legacyBrowserRepo)
+	if err != nil {
+		return err
+	}
+	stableBrowser, err := m.repoBrowserClonePath(repo)
+	if err != nil {
+		return err
+	}
+
+	if err := m.copyLegacyMainClone(
+		ctx, legacyMain, stableMain, repo.Host, repo.Owner, repo.Name, repo.RemoteURL,
+	); err != nil {
+		return fmt.Errorf("adopt legacy main clone: %w", err)
+	}
+	if err := m.adoptLegacyClone(
+		ctx, legacyBrowser, stableBrowser, repo.Host, repo.Owner, repo.Name,
+	); err != nil {
+		return fmt.Errorf("adopt legacy repository browser clone: %w", err)
+	}
+	return nil
+}
+
+func (m *Manager) copyLegacyMainClone(
+	ctx context.Context,
+	legacyPath, stablePath, host, owner, name, remoteURL string,
+) error {
+	if legacyPath == stablePath {
+		return nil
+	}
+	stableExists, err := m.validateStableClone(ctx, stablePath)
+	if err != nil || stableExists {
+		return err
+	}
+	legacyExists, err := m.validateLegacyClone(
+		ctx, legacyPath, host, owner, name,
+	)
+	if err != nil || !legacyExists {
+		return err
+	}
+
+	stableParent := filepath.Dir(stablePath)
+	if err := os.MkdirAll(stableParent, 0o755); err != nil {
+		return err
+	}
+	// Keep the lock file after unlock: removing a flock path can let a third
+	// process lock a new inode while another adopter still holds the old one.
+	adoptionLock := flock.New(stablePath + ".adopt.lock")
+	locked, err := adoptionLock.TryLockContext(ctx, 10*time.Millisecond)
+	if err != nil {
+		return fmt.Errorf("acquire stable clone adoption lock: %w", err)
+	}
+	if !locked {
+		return errors.New("stable clone adoption lock not acquired")
+	}
+	defer func() {
+		_ = adoptionLock.Unlock()
+		_ = adoptionLock.Close()
+	}()
+
+	stableExists, err = m.validateStableClone(ctx, stablePath)
+	if err != nil || stableExists {
+		return err
+	}
+	staging, err := os.MkdirTemp(
+		stableParent, "."+filepath.Base(stablePath)+".adopting-",
+	)
+	if err != nil {
+		return fmt.Errorf("create stable clone staging path: %w", err)
+	}
+	if err := os.Remove(staging); err != nil {
+		return fmt.Errorf("prepare stable clone staging path: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(staging) }()
+
+	if _, err := m.git(
+		ctx, stableParent,
+		"clone", "--mirror", "--no-hardlinks", legacyPath, staging,
+	); err != nil {
+		return fmt.Errorf("copy legacy main clone: %w", err)
+	}
+	if _, err := m.git(
+		ctx, staging, "config", "remote.origin.url", remoteURL,
+	); err != nil {
+		return fmt.Errorf("set copied main clone origin: %w", err)
+	}
+	if _, err := m.git(
+		ctx, staging, "config", "--unset-all", "remote.origin.fetch",
+	); err != nil {
+		return fmt.Errorf("reset copied main clone refspecs: %w", err)
+	}
+	if _, err := m.git(
+		ctx, staging, "config", "--unset", "remote.origin.mirror",
+	); err != nil {
+		return fmt.Errorf("reset copied main clone mirror mode: %w", err)
+	}
+	for _, refspec := range defaultRefspecs() {
+		if _, err := m.git(
+			ctx, staging, "config", "--add", "remote.origin.fetch", refspec,
+		); err != nil {
+			return fmt.Errorf("add copied main clone refspec %q: %w", refspec, err)
+		}
+	}
+	if complete, err := m.validateStableClone(ctx, staging); err != nil {
+		return fmt.Errorf("validate copied main clone: %w", err)
+	} else if !complete {
+		return errors.New("validate copied main clone: staging clone is missing")
+	}
+
+	stableExists, err = m.validateStableClone(ctx, stablePath)
+	if err != nil {
+		return err
+	}
+	if stableExists {
+		return nil
+	}
+	if err := os.Rename(staging, stablePath); err != nil {
+		if exists, validationErr := m.validateStableClone(ctx, stablePath); exists && validationErr == nil {
+			return nil
+		} else if validationErr != nil {
+			return errors.Join(err, validationErr)
+		}
+		return err
+	}
+	return nil
+}
+
+func (m *Manager) validateStableClone(
+	ctx context.Context, stablePath string,
+) (bool, error) {
+	info, err := os.Lstat(stablePath)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return false, errors.New("stable clone path is not a directory")
+	}
+	headInfo, err := os.Lstat(filepath.Join(stablePath, "HEAD"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, errors.New("stable clone path is incomplete: missing HEAD")
+		}
+		return false, err
+	}
+	if !headInfo.Mode().IsRegular() {
+		return false, errors.New("stable clone path is incomplete: HEAD is not a regular file")
+	}
+	out, err := m.git(ctx, stablePath, "rev-parse", "--is-bare-repository")
+	if err != nil || strings.TrimSpace(string(out)) != "true" {
+		if err == nil {
+			err = errors.New("repository is not bare")
+		}
+		return false, fmt.Errorf("stable clone path is incomplete: %w", err)
+	}
+	return true, nil
+}
+
+func (m *Manager) validateLegacyClone(
+	ctx context.Context, legacyPath, host, owner, name string,
+) (bool, error) {
+	info, err := os.Lstat(legacyPath)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return false, errors.New("legacy clone path is not a directory")
+	}
+	if _, err := os.Stat(filepath.Join(legacyPath, "HEAD")); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	if err := m.validateOriginIdentity(ctx, legacyPath, host, owner, name); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (m *Manager) adoptLegacyClone(
+	ctx context.Context,
+	legacyPath, stablePath, host, owner, name string,
+) error {
+	if legacyPath == stablePath {
+		return nil
+	}
+	stableExists, err := m.validateStableClone(ctx, stablePath)
+	if err != nil || stableExists {
+		return err
+	}
+	legacyExists, err := m.validateLegacyClone(ctx, legacyPath, host, owner, name)
+	if err != nil || !legacyExists {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(stablePath), 0o755); err != nil {
+		return err
+	}
+	if err := os.Rename(legacyPath, stablePath); err != nil {
+		if _, statErr := os.Stat(filepath.Join(stablePath, "HEAD")); statErr == nil {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
 func (m *Manager) EnsureRepoBrowserClone(ctx context.Context, repo RepoBrowserRepoRef) error {
 	if err := m.ensureRepoBrowserCloneLocal(ctx, repo); err != nil {
 		return err
@@ -791,49 +1208,300 @@ func (m *Manager) refreshRepoBrowserClone(
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+	if err := m.validateRepoBrowserRouteFence(ctx, repo); err != nil {
+		m.evictStaleRepoBrowserRegistration(repo, err)
+		return err
+	}
+	if repo.ValidateRouteFence != nil && repo.PublishIfRouteFenceMatches == nil {
+		return errors.New("repo browser fenced refresh requires guarded publication")
+	}
 	namespace := repoBrowserCloneNamespace(repo)
 	if err := validateRemoteURLIdentity(repo.Host, repo.Owner, repo.Name, repo.RemoteURL); err != nil {
 		return err
 	}
-	if _, err := m.ClonePathInNamespace(namespace, repo.Host, repo.Owner, repo.Name); err != nil {
+	dir, err := m.ClonePathInNamespace(namespace, repo.Host, repo.Owner, repo.Name)
+	if err != nil {
 		return err
 	}
 	key := ensureCloneKey(namespace, repo.Host, repo.Owner, repo.Name)
-	ch := m.repoBrowserRefreshSF.DoChan(key, func() (any, error) {
+	run := func() (any, error) {
 		opCtx, cancel := context.WithTimeout(
 			repoBrowserRefreshWorkParent(ctx, mode),
 			ensureCloneTimeout,
 		)
 		defer cancel()
-		if err := m.ensureCloneNowInNamespace(
-			opCtx,
-			namespace,
-			repo.Provider,
-			repo.Host,
-			repo.Owner,
-			repo.Name,
-			repo.RemoteURL,
-		); err != nil {
-			return nil, err
-		}
-		dir, err := m.repoBrowserClonePath(repo)
+		staging, seeded, err := m.prepareRepoBrowserStaging(opCtx, repo, dir)
 		if err != nil {
 			return nil, err
 		}
-		return nil, m.fetchRepoBrowserTags(
-			opCtx, repo.Provider, repo.Host, repo.Owner, repo.Name, dir,
-		)
-	})
-	select {
-	case res := <-ch:
+		if !seeded {
+			err = m.cloneBare(
+				opCtx, repo.Provider, repo.Host, repo.Owner, repo.Name,
+				staging, repo.RemoteURL,
+			)
+		} else {
+			if inject := m.repoBrowserFetchErrorForTest; inject != nil {
+				err = inject(repo.RouteFence)
+			}
+			if err == nil {
+				err = m.fetch(
+					opCtx, repo.Provider, repo.Host, repo.Owner, repo.Name, staging,
+				)
+			}
+		}
+		if err != nil {
+			return nil, m.finishRepoBrowserStagingFailure(opCtx, repo, staging, err)
+		}
+		if err := m.fetchRepoBrowserTags(
+			opCtx, repo.Provider, repo.Host, repo.Owner, repo.Name, staging,
+		); err != nil {
+			return nil, m.finishRepoBrowserStagingFailure(opCtx, repo, staging, err)
+		}
+		if err := m.validateRepoBrowserRouteFence(opCtx, repo); err != nil {
+			return nil, m.discardRepoBrowserStaging(
+				staging, err, errors.Is(err, ErrRepoBrowserRouteFenceChanged),
+			)
+		}
+		moved, err := m.publishRepoBrowserStagingGuarded(opCtx, repo, staging, dir)
+		if err != nil {
+			if moved {
+				return nil, err
+			}
+			return nil, m.discardRepoBrowserStaging(
+				staging, err, errors.Is(err, ErrRepoBrowserRouteFenceChanged),
+			)
+		}
+		return nil, nil
+	}
+	start := func() <-chan singleflight.Result {
+		ch := m.repoBrowserRefreshSF.DoChan(key, run)
+		if hook := m.repoBrowserAfterRefreshJoinForTest; hook != nil {
+			hook(repo.RouteFence)
+		}
+		return ch
+	}
+	wait := func(ch <-chan singleflight.Result) (singleflight.Result, error) {
+		select {
+		case res := <-ch:
+			return res, nil
+		case <-ctx.Done():
+			return singleflight.Result{}, ctx.Err()
+		}
+	}
+	res, err := wait(start())
+	if err != nil {
+		return err
+	}
+	if res.Err != nil {
+		var invalidated *repoBrowserCloneValidationError
+		if !errors.As(res.Err, &invalidated) {
+			if errors.Is(res.Err, ErrRepoBrowserRouteFenceChanged) {
+				if ownErr := m.validateRepoBrowserRouteFence(ctx, repo); ownErr != nil {
+					m.evictStaleRepoBrowserRegistration(repo, ownErr)
+				}
+			}
+			return res.Err
+		}
+		if ownErr := m.validateRepoBrowserRouteFence(ctx, repo); ownErr != nil {
+			m.evictStaleRepoBrowserRegistration(repo, ownErr)
+			return ownErr
+		}
+		res, err = wait(start())
+		if err != nil {
+			return err
+		}
 		if res.Err != nil {
 			return res.Err
 		}
-	case <-ctx.Done():
-		return ctx.Err()
+	}
+	if err := m.validateRepoBrowserRouteFence(ctx, repo); err != nil {
+		m.evictStaleRepoBrowserRegistration(repo, err)
+		return err
 	}
 	m.registerRepoBrowserRepo(repo)
 	return nil
+}
+
+func (m *Manager) finishRepoBrowserStagingFailure(
+	ctx context.Context,
+	repo RepoBrowserRepoRef,
+	staging string,
+	mutationErr error,
+) error {
+	validationErr := m.validateRepoBrowserRouteFence(ctx, repo)
+	reason := errors.Join(mutationErr, validationErr)
+	return m.discardRepoBrowserStaging(
+		staging,
+		reason,
+		errors.Is(validationErr, ErrRepoBrowserRouteFenceChanged),
+	)
+}
+
+func (m *Manager) prepareRepoBrowserStaging(
+	ctx context.Context,
+	repo RepoBrowserRepoRef,
+	published string,
+) (string, bool, error) {
+	if err := os.MkdirAll(filepath.Dir(published), 0o755); err != nil {
+		return "", false, fmt.Errorf("mkdir repo browser staging parent: %w", err)
+	}
+	staging, err := os.MkdirTemp(
+		filepath.Dir(published), "."+filepath.Base(published)+".staging-",
+	)
+	if err != nil {
+		return "", false, fmt.Errorf("create repo browser staging path: %w", err)
+	}
+	if err := os.Remove(staging); err != nil {
+		return "", false, fmt.Errorf("prepare repo browser staging path: %w", err)
+	}
+	fail := func(reason error) (string, bool, error) {
+		if cleanupErr := m.removeRepoBrowserStaging(staging); cleanupErr != nil {
+			return "", false, errors.Join(
+				reason,
+				fmt.Errorf("remove unpublished repo browser staging clone: %w", cleanupErr),
+			)
+		}
+		return "", false, reason
+	}
+
+	unlock, err := m.lockRepoBrowserRead(ctx, repo)
+	if err != nil {
+		return fail(err)
+	}
+	defer unlock()
+	if _, err := os.Stat(filepath.Join(published, "HEAD")); err != nil {
+		if os.IsNotExist(err) {
+			return staging, false, nil
+		}
+		return fail(err)
+	}
+	if out, err := m.git(ctx, published, "config", "--get", "remote.origin.url"); err == nil {
+		if err := validateRemoteURLIdentity(
+			repo.Host, repo.Owner, repo.Name, strings.TrimSpace(string(out)),
+		); err != nil {
+			return fail(err)
+		}
+	}
+	if _, err := m.git(
+		ctx, filepath.Dir(published),
+		"clone", "--mirror", "--no-hardlinks", published, staging,
+	); err != nil {
+		return fail(fmt.Errorf("seed repo browser staging clone: %w", err))
+	}
+	if _, err := m.git(ctx, staging, "config", "remote.origin.url", repo.RemoteURL); err != nil {
+		return fail(fmt.Errorf("set repo browser staging origin: %w", err))
+	}
+	_, _ = m.git(ctx, staging, "config", "--unset-all", "remote.origin.fetch")
+	_, _ = m.git(ctx, staging, "config", "--unset", "remote.origin.mirror")
+	for _, refspec := range defaultRefspecs() {
+		if _, err := m.git(
+			ctx, staging, "config", "--add", "remote.origin.fetch", refspec,
+		); err != nil {
+			return fail(fmt.Errorf("add repo browser staging refspec %q: %w", refspec, err))
+		}
+	}
+	return staging, true, nil
+}
+
+func (m *Manager) discardRepoBrowserStaging(
+	staging string,
+	reason error,
+	retryCurrentFence bool,
+) error {
+	if cleanupErr := m.removeRepoBrowserStaging(staging); cleanupErr != nil {
+		return errors.Join(
+			reason,
+			fmt.Errorf("remove unpublished repo browser staging clone: %w", cleanupErr),
+		)
+	}
+	if retryCurrentFence {
+		return &repoBrowserCloneValidationError{err: reason}
+	}
+	return reason
+}
+
+func (m *Manager) removeRepoBrowserStaging(path string) error {
+	if remove := m.removeRepoBrowserStagingForTest; remove != nil {
+		return remove(path)
+	}
+	return os.RemoveAll(path)
+}
+
+func (m *Manager) publishRepoBrowserStagingGuarded(
+	ctx context.Context,
+	repo RepoBrowserRepoRef,
+	staging string,
+	published string,
+) (bool, error) {
+	moved := false
+	publish := func() error {
+		var err error
+		moved, err = m.publishRepoBrowserStaging(ctx, repo, staging, published)
+		return err
+	}
+	if repo.PublishIfRouteFenceMatches == nil {
+		return moved, publish()
+	}
+	matches, err := repo.PublishIfRouteFenceMatches(ctx, repo.RouteFence, publish)
+	if err != nil {
+		return moved, err
+	}
+	if !matches {
+		return moved, ErrRepoBrowserRouteFenceChanged
+	}
+	return moved, nil
+}
+
+func (m *Manager) publishRepoBrowserStaging(
+	ctx context.Context,
+	repo RepoBrowserRepoRef,
+	staging string,
+	published string,
+) (bool, error) {
+	barrier := m.repoBrowserCloneBarrier(repo)
+	if err := barrier.lockWrite(ctx); err != nil {
+		return false, err
+	}
+	previous := staging + ".previous"
+	hadPrevious := false
+	if err := os.Rename(published, previous); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			barrier.unlockWrite()
+			return false, fmt.Errorf("move published repo browser clone aside: %w", err)
+		}
+	} else {
+		hadPrevious = true
+	}
+	publish := os.Rename
+	if injected := m.publishRepoBrowserStagingForTest; injected != nil {
+		publish = injected
+	}
+	if err := publish(staging, published); err != nil {
+		var restoreErr error
+		if hadPrevious {
+			restoreErr = os.Rename(previous, published)
+		}
+		barrier.unlockWrite()
+		return false, errors.Join(
+			fmt.Errorf("publish repo browser staging clone: %w", err),
+			wrapOptionalError("restore published repo browser clone", restoreErr),
+		)
+	}
+	barrier.unlockWrite()
+	if !hadPrevious {
+		return true, nil
+	}
+	if err := os.RemoveAll(previous); err != nil {
+		return true, fmt.Errorf("remove previous repo browser clone: %w", err)
+	}
+	return true, nil
+}
+
+func wrapOptionalError(message string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%s: %w", message, err)
 }
 
 func (m *Manager) RefreshRepoBrowserClones(ctx context.Context) {
@@ -855,6 +1523,10 @@ func (m *Manager) RegisterExistingRepoBrowserClone(ctx context.Context, repo Rep
 	if err := ctx.Err(); err != nil {
 		return false, err
 	}
+	if err := m.validateRepoBrowserRouteFence(ctx, repo); err != nil {
+		m.evictStaleRepoBrowserRegistration(repo, err)
+		return false, err
+	}
 	if err := validateRemoteURLIdentity(repo.Host, repo.Owner, repo.Name, repo.RemoteURL); err != nil {
 		return false, err
 	}
@@ -862,6 +1534,11 @@ func (m *Manager) RegisterExistingRepoBrowserClone(ctx context.Context, repo Rep
 	if err != nil {
 		return false, err
 	}
+	unlock, err := m.lockRepoBrowserRead(ctx, repo)
+	if err != nil {
+		return false, err
+	}
+	defer unlock()
 	if _, err := os.Stat(filepath.Join(dir, "HEAD")); os.IsNotExist(err) {
 		return false, nil
 	} else if err != nil {
@@ -881,6 +1558,10 @@ func (m *Manager) ensureRepoBrowserCloneLocal(ctx context.Context, repo RepoBrow
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+	if err := m.validateRepoBrowserRouteFence(ctx, repo); err != nil {
+		m.evictStaleRepoBrowserRegistration(repo, err)
+		return err
+	}
 	namespace := repoBrowserCloneNamespace(repo)
 	if err := validateRemoteURLIdentity(repo.Host, repo.Owner, repo.Name, repo.RemoteURL); err != nil {
 		return err
@@ -889,17 +1570,32 @@ func (m *Manager) ensureRepoBrowserCloneLocal(ctx context.Context, repo RepoBrow
 	if err != nil {
 		return err
 	}
+	unlock, err := m.lockRepoBrowserRead(ctx, repo)
+	if err != nil {
+		return err
+	}
 	if _, err := os.Stat(filepath.Join(dir, "HEAD")); os.IsNotExist(err) {
+		unlock()
 		return m.refreshRepoBrowserClone(ctx, repo, repoBrowserRefreshDetachCaller)
 	} else if err != nil {
+		unlock()
 		return err
 	}
 	if out, err := m.git(ctx, dir, "config", "--get", "remote.origin.url"); err == nil {
 		if err := validateRemoteURLIdentity(repo.Host, repo.Owner, repo.Name, strings.TrimSpace(string(out))); err != nil {
+			unlock()
 			return err
 		}
 	}
 	m.ensureRefspecs(ctx, dir)
+	// Route reconciliation may queue behind guarded publication. Release the
+	// clone read barrier before re-entering that DB guard so publication never
+	// waits on a reader that is itself waiting on reconciliation.
+	unlock()
+	if err := m.validateRepoBrowserRouteFence(ctx, repo); err != nil {
+		m.evictStaleRepoBrowserRegistration(repo, err)
+		return err
+	}
 	return nil
 }
 
@@ -907,6 +1603,37 @@ func (m *Manager) registerRepoBrowserRepo(repo RepoBrowserRepoRef) {
 	m.repoBrowserMu.Lock()
 	defer m.repoBrowserMu.Unlock()
 	m.repoBrowserRepos[repoBrowserCloneNamespace(repo)] = repo
+}
+
+func (m *Manager) validateRepoBrowserRouteFence(
+	ctx context.Context, repo RepoBrowserRepoRef,
+) error {
+	if repo.ValidateRouteFence == nil {
+		return nil
+	}
+	matches, err := repo.ValidateRouteFence(ctx, repo.RouteFence)
+	if err != nil {
+		return err
+	}
+	if !matches {
+		return ErrRepoBrowserRouteFenceChanged
+	}
+	return nil
+}
+
+func (m *Manager) evictStaleRepoBrowserRegistration(
+	repo RepoBrowserRepoRef, err error,
+) {
+	if !errors.Is(err, ErrRepoBrowserRouteFenceChanged) {
+		return
+	}
+	namespace := repoBrowserCloneNamespace(repo)
+	m.repoBrowserMu.Lock()
+	defer m.repoBrowserMu.Unlock()
+	current, ok := m.repoBrowserRepos[namespace]
+	if ok && current.RouteFence == repo.RouteFence {
+		delete(m.repoBrowserRepos, namespace)
+	}
 }
 
 func (m *Manager) repoBrowserReposSnapshot() []RepoBrowserRepoRef {
@@ -938,12 +1665,19 @@ func (m *Manager) fetchRepoBrowserTags(
 }
 
 func repoBrowserCloneNamespace(repo RepoBrowserRepoRef) string {
-	identity := strings.Join([]string{
+	parts := []string{
 		strings.TrimSpace(repo.Provider),
 		strings.TrimSpace(repo.Host),
 		strings.Trim(strings.TrimSpace(repo.RepoPath), "/"),
-	}, "\x00")
-	sum := sha256.Sum256([]byte(identity))
+	}
+	// The stable provider identity partitions browser storage across route
+	// reuse: a replacement repository on a reused path must not serve the
+	// displaced repository's cached refs or SHA-addressable objects.
+	// Repositories without a verified identity keep path-scoped storage.
+	if id := strings.TrimSpace(repo.ProviderRepoID); id != "" {
+		parts = append(parts, id)
+	}
+	sum := sha256.Sum256([]byte(strings.Join(parts, "\x00")))
 	return "repo-browser-" + hex.EncodeToString(sum[:8])
 }
 

--- a/internal/gitclone/repo_browser_test.go
+++ b/internal/gitclone/repo_browser_test.go
@@ -2,17 +2,64 @@ package gitclone
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/tokenauth"
 )
+
+type countingRepoBrowserRouteResolver struct {
+	calls atomic.Int64
+}
+
+func (r *countingRepoBrowserRouteResolver) SourceForRepo(_, _, _, _ string) tokenauth.Source {
+	r.calls.Add(1)
+	return nil
+}
+
+func (*countingRepoBrowserRouteResolver) FallbackSource(string) tokenauth.Source { return nil }
+
+type blockingRepoBrowserRouteResolver struct {
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (r *blockingRepoBrowserRouteResolver) SourceForRepo(_, _, _, _ string) tokenauth.Source {
+	r.once.Do(func() {
+		close(r.started)
+		<-r.release
+	})
+	return nil
+}
+
+func (*blockingRepoBrowserRouteResolver) FallbackSource(string) tokenauth.Source { return nil }
+
+type callbackRepoBrowserRouteResolver struct {
+	calls  atomic.Int64
+	onCall func(int64)
+}
+
+func (r *callbackRepoBrowserRouteResolver) SourceForRepo(_, _, _, _ string) tokenauth.Source {
+	call := r.calls.Add(1)
+	if r.onCall != nil {
+		r.onCall(call)
+	}
+	return nil
+}
+
+func (*callbackRepoBrowserRouteResolver) FallbackSource(string) tokenauth.Source { return nil }
 
 func TestRepoBrowserListRefsDisambiguatesBranchAndTag(t *testing.T) {
 	require := require.New(t)
@@ -115,6 +162,589 @@ func TestRefreshRepoBrowserClonesUsesSeededExistingClones(t *testing.T) {
 	assert.Equal(updatedSHA, resolved.SHA)
 }
 
+func TestRefreshRepoBrowserClonesEvictsStaleRegistrationBeforeFetch(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	mgr, repo, _ := setupRepoBrowserTestRepo(t)
+	routes := &countingRepoBrowserRouteResolver{}
+	restarted := New(mgr.baseDir, routes)
+	valid := true
+	repo.RouteFence = NewRepoBrowserRouteFence(1, 2, 3)
+	repo.ValidateRouteFence = func(context.Context, RepoBrowserRouteFence) (bool, error) {
+		return valid, nil
+	}
+	repo.PublishIfRouteFenceMatches = repoBrowserTestPublishGuard(repo.ValidateRouteFence)
+
+	registered, err := restarted.RegisterExistingRepoBrowserClone(t.Context(), repo)
+	require.NoError(err)
+	require.True(registered)
+	valid = false
+
+	restarted.RefreshRepoBrowserClones(t.Context())
+
+	assert.Zero(routes.calls.Load(), "a stale registration must not resolve credentials or fetch")
+	assert.Empty(restarted.repoBrowserReposSnapshot())
+}
+
+func TestRefreshRepoBrowserCloneKeepsPublishedCloneWhenStagingIsInvalidated(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	mgr, repo, work := setupRepoBrowserTestRepo(t)
+	routes := &blockingRepoBrowserRouteResolver{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	restarted := New(mgr.baseDir, routes)
+	var valid atomic.Bool
+	valid.Store(true)
+	repo.RouteFence = NewRepoBrowserRouteFence(1, 2, 3)
+	repo.ValidateRouteFence = func(context.Context, RepoBrowserRouteFence) (bool, error) {
+		return valid.Load(), nil
+	}
+	repo.PublishIfRouteFenceMatches = repoBrowserTestPublishGuard(repo.ValidateRouteFence)
+	registered, err := restarted.RegisterExistingRepoBrowserClone(t.Context(), repo)
+	require.NoError(err)
+	require.True(registered)
+	clonePath, err := restarted.repoBrowserClonePath(repo)
+	require.NoError(err)
+	before := repoBrowserCloneSnapshot(t, clonePath)
+
+	require.NoError(os.WriteFile(filepath.Join(work, "README.md"), []byte("# Updated\n"), 0o644))
+	commitTestRun(t, work, "git", "add", ".")
+	commitTestRun(t, work, "git", "commit", "-m", "update readme")
+	commitTestRun(t, work, "git", "push", "origin", "main")
+
+	done := make(chan error, 1)
+	go func() {
+		done <- restarted.RefreshRepoBrowserClone(t.Context(), repo)
+	}()
+	<-routes.started
+	valid.Store(false)
+	close(routes.release)
+
+	require.ErrorIs(<-done, ErrRepoBrowserRouteFenceChanged)
+	assert.Equal(before, repoBrowserCloneSnapshot(t, clonePath))
+	blob, err := restarted.ReadRepoBrowserBlob(
+		t.Context(), repo,
+		RepoBrowserRef{Type: RepoBrowserRefBranch, Name: "main"},
+		"README.md",
+	)
+	require.NoError(err)
+	assert.Equal("# Widgets\n", blob.Content)
+	assert.Empty(restarted.repoBrowserReposSnapshot())
+}
+
+func TestEnsureRepoBrowserCloneRemovesCloneInvalidatedDuringInitialFetch(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	_, repo, _ := setupRepoBrowserTestRepo(t)
+	routes := &blockingRepoBrowserRouteResolver{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	mgr := New(filepath.Join(t.TempDir(), "clones"), routes)
+	var valid atomic.Bool
+	valid.Store(true)
+	repo.RouteFence = NewRepoBrowserRouteFence(1, 2, 3)
+	repo.ValidateRouteFence = func(context.Context, RepoBrowserRouteFence) (bool, error) {
+		return valid.Load(), nil
+	}
+	repo.PublishIfRouteFenceMatches = repoBrowserTestPublishGuard(repo.ValidateRouteFence)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- mgr.EnsureRepoBrowserClone(t.Context(), repo)
+	}()
+	<-routes.started
+	valid.Store(false)
+	close(routes.release)
+
+	require.ErrorIs(<-done, ErrRepoBrowserRouteFenceChanged)
+	clonePath, err := mgr.repoBrowserClonePath(repo)
+	require.NoError(err)
+	assert.NoDirExists(clonePath)
+	assert.Empty(mgr.repoBrowserReposSnapshot())
+}
+
+func TestRepoBrowserReadContinuesWhileStaleStageAwaitsValidation(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	mgr, staleRepo, currentRepo, _, _ := setupRepoBrowserRouteReuseRefreshTest(t)
+	postFetchValidation := make(chan struct{})
+	releaseValidation := make(chan struct{})
+	var validations atomic.Int64
+	var postFetchOnce sync.Once
+	staleRepo.ValidateRouteFence = func(context.Context, RepoBrowserRouteFence) (bool, error) {
+		if validations.Add(1) == 1 {
+			return true, nil
+		}
+		postFetchOnce.Do(func() { close(postFetchValidation) })
+		<-releaseValidation
+		return false, nil
+	}
+	staleRepo.PublishIfRouteFenceMatches = repoBrowserTestPublishGuard(staleRepo.ValidateRouteFence)
+
+	refreshDone := make(chan error, 1)
+	go func() {
+		refreshDone <- mgr.RefreshRepoBrowserClone(t.Context(), staleRepo)
+	}()
+	<-postFetchValidation
+
+	readWaiting := make(chan struct{})
+	var waitingOnce sync.Once
+	mgr.repoBrowserReadWaitingForTest = func(string) {
+		waitingOnce.Do(func() { close(readWaiting) })
+	}
+	type readResult struct {
+		blob RepoBrowserBlob
+		err  error
+	}
+	readDone := make(chan readResult, 1)
+	go func() {
+		blob, err := mgr.ReadRepoBrowserBlob(
+			t.Context(), currentRepo,
+			RepoBrowserRef{Type: RepoBrowserRefBranch, Name: "main"},
+			"README.md",
+		)
+		readDone <- readResult{blob: blob, err: err}
+	}()
+	select {
+	case result := <-readDone:
+		require.NoError(result.err)
+		assert.Equal("# Widgets\n", result.blob.Content)
+	case <-readWaiting:
+		require.Fail("read waited for unpublished staging refresh")
+	}
+	_, err := mgr.ReadRepoBrowserBlob(
+		t.Context(), currentRepo,
+		RepoBrowserRef{Type: RepoBrowserRefBranch, Name: "main"},
+		"ONLY_B.md",
+	)
+	require.ErrorIs(err, ErrNotFound)
+
+	close(releaseValidation)
+	require.ErrorIs(<-refreshDone, ErrRepoBrowserRouteFenceChanged)
+}
+
+func TestRepoBrowserPublicationWaitsForAdmittedReader(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	mgr, repo, work := setupRepoBrowserTestRepo(t)
+	repo.RouteFence = NewRepoBrowserRouteFence(1, 2, 3)
+	repo.ValidateRouteFence = func(context.Context, RepoBrowserRouteFence) (bool, error) {
+		return true, nil
+	}
+	publishReady := make(chan struct{})
+	releasePublish := make(chan struct{})
+	repo.PublishIfRouteFenceMatches = func(
+		_ context.Context,
+		_ RepoBrowserRouteFence,
+		publish func() error,
+	) (bool, error) {
+		close(publishReady)
+		<-releasePublish
+		return true, publish()
+	}
+
+	require.NoError(os.WriteFile(filepath.Join(work, "README.md"), []byte("# Updated\n"), 0o644))
+	commitTestRun(t, work, "git", "add", ".")
+	commitTestRun(t, work, "git", "commit", "-m", "update readme")
+	commitTestRun(t, work, "git", "push", "origin", "main")
+
+	refreshDone := make(chan error, 1)
+	go func() {
+		refreshDone <- mgr.RefreshRepoBrowserClone(t.Context(), repo)
+	}()
+	<-publishReady
+
+	readAdmitted := make(chan struct{})
+	releaseRead := make(chan struct{})
+	var admittedOnce sync.Once
+	mgr.repoBrowserAfterReadLockForTest = func(string) {
+		admittedOnce.Do(func() {
+			close(readAdmitted)
+			<-releaseRead
+		})
+	}
+	type readResult struct {
+		blob RepoBrowserBlob
+		err  error
+	}
+	readDone := make(chan readResult, 1)
+	go func() {
+		blob, err := mgr.ReadRepoBrowserBlob(
+			t.Context(), repo,
+			RepoBrowserRef{Type: RepoBrowserRefBranch, Name: "main"},
+			"README.md",
+		)
+		readDone <- readResult{blob: blob, err: err}
+	}()
+	<-readAdmitted
+	close(releasePublish)
+	close(releaseRead)
+
+	oldRead := <-readDone
+	require.NoError(oldRead.err)
+	assert.Equal("# Widgets\n", oldRead.blob.Content)
+	require.NoError(<-refreshDone)
+
+	newRead, err := mgr.ReadRepoBrowserBlob(
+		t.Context(), repo,
+		RepoBrowserRef{Type: RepoBrowserRefBranch, Name: "main"},
+		"README.md",
+	)
+	require.NoError(err)
+	assert.Equal("# Updated\n", newRead.Content)
+}
+
+func TestRepoBrowserRefreshValidFollowerRetriesStaleLeader(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	mgr, staleRepo, currentRepo, initialSHA, work := setupRepoBrowserRouteReuseRefreshTest(t)
+	postFetchValidation := make(chan struct{})
+	releaseValidation := make(chan struct{})
+	var staleValidations atomic.Int64
+	var postFetchOnce sync.Once
+	staleRepo.ValidateRouteFence = func(context.Context, RepoBrowserRouteFence) (bool, error) {
+		if staleValidations.Add(1) == 1 {
+			return true, nil
+		}
+		postFetchOnce.Do(func() { close(postFetchValidation) })
+		<-releaseValidation
+		return false, nil
+	}
+	staleRepo.PublishIfRouteFenceMatches = repoBrowserTestPublishGuard(staleRepo.ValidateRouteFence)
+	var currentValidations atomic.Int64
+	currentRepo.ValidateRouteFence = func(context.Context, RepoBrowserRouteFence) (bool, error) {
+		currentValidations.Add(1)
+		return true, nil
+	}
+	currentRepo.PublishIfRouteFenceMatches = repoBrowserTestPublishGuard(currentRepo.ValidateRouteFence)
+	followerJoined := make(chan struct{})
+	var joinedOnce sync.Once
+	mgr.repoBrowserAfterRefreshJoinForTest = func(fence RepoBrowserRouteFence) {
+		if fence == currentRepo.RouteFence {
+			joinedOnce.Do(func() { close(followerJoined) })
+		}
+	}
+
+	staleDone := make(chan error, 1)
+	go func() {
+		staleDone <- mgr.RefreshRepoBrowserClone(t.Context(), staleRepo)
+	}()
+	<-postFetchValidation
+	commitTestRun(t, work, "git", "push", "--force", "origin", initialSHA+":refs/heads/main")
+	currentDone := make(chan error, 1)
+	go func() {
+		currentDone <- mgr.RefreshRepoBrowserClone(t.Context(), currentRepo)
+	}()
+	<-followerJoined
+	close(releaseValidation)
+
+	require.ErrorIs(<-staleDone, ErrRepoBrowserRouteFenceChanged)
+	require.NoError(<-currentDone)
+	resolved, err := mgr.ResolveRepoBrowserRef(t.Context(), currentRepo, RepoBrowserRef{
+		Type: RepoBrowserRefBranch,
+		Name: "main",
+	})
+	require.NoError(err)
+	assert.Equal(initialSHA, resolved.SHA)
+	assert.Greater(currentValidations.Load(), int64(1),
+		"the valid follower must validate and run its own retry")
+}
+
+func TestRepoBrowserRefreshValidFollowerRetriesStaleLeaderFetchFailure(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	mgr, staleRepo, currentRepo, initialSHA, work := setupRepoBrowserRouteReuseRefreshTest(t)
+	var staleCurrent atomic.Bool
+	staleCurrent.Store(true)
+	staleRepo.ValidateRouteFence = func(context.Context, RepoBrowserRouteFence) (bool, error) {
+		return staleCurrent.Load(), nil
+	}
+	staleRepo.PublishIfRouteFenceMatches = repoBrowserTestPublishGuard(staleRepo.ValidateRouteFence)
+	var currentValidations atomic.Int64
+	currentRepo.ValidateRouteFence = func(context.Context, RepoBrowserRouteFence) (bool, error) {
+		currentValidations.Add(1)
+		return true, nil
+	}
+	currentRepo.PublishIfRouteFenceMatches = repoBrowserTestPublishGuard(currentRepo.ValidateRouteFence)
+
+	fetchStarted := make(chan struct{})
+	releaseFetch := make(chan struct{})
+	fetchErr := errors.New("stale staging fetch failed")
+	mgr.repoBrowserFetchErrorForTest = func(fence RepoBrowserRouteFence) error {
+		if fence != staleRepo.RouteFence {
+			return nil
+		}
+		close(fetchStarted)
+		<-releaseFetch
+		return fetchErr
+	}
+	followerJoined := make(chan struct{})
+	var joinedOnce sync.Once
+	mgr.repoBrowserAfterRefreshJoinForTest = func(fence RepoBrowserRouteFence) {
+		if fence == currentRepo.RouteFence {
+			joinedOnce.Do(func() { close(followerJoined) })
+		}
+	}
+
+	staleDone := make(chan error, 1)
+	go func() {
+		staleDone <- mgr.RefreshRepoBrowserClone(t.Context(), staleRepo)
+	}()
+	<-fetchStarted
+	currentDone := make(chan error, 1)
+	go func() {
+		currentDone <- mgr.RefreshRepoBrowserClone(t.Context(), currentRepo)
+	}()
+	<-followerJoined
+	staleCurrent.Store(false)
+	commitTestRun(t, work, "git", "push", "--force", "origin", initialSHA+":refs/heads/main")
+	close(releaseFetch)
+
+	staleErr := <-staleDone
+	require.ErrorIs(staleErr, ErrRepoBrowserRouteFenceChanged)
+	require.NoError(<-currentDone)
+	resolved, err := mgr.ResolveRepoBrowserRef(t.Context(), currentRepo, RepoBrowserRef{
+		Type: RepoBrowserRefBranch,
+		Name: "main",
+	})
+	require.NoError(err)
+	assert.Equal(initialSHA, resolved.SHA)
+	assert.Greater(currentValidations.Load(), int64(1),
+		"the valid follower must validate and run its own retry")
+}
+
+func TestRepoBrowserStagingCleanupFailureIsNotRetryable(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	mgr, staleRepo, currentRepo, initialSHA, _ := setupRepoBrowserRouteReuseRefreshTest(t)
+	postFetchValidation := make(chan struct{})
+	releaseValidation := make(chan struct{})
+	var staleValidations atomic.Int64
+	var postFetchOnce sync.Once
+	staleRepo.ValidateRouteFence = func(context.Context, RepoBrowserRouteFence) (bool, error) {
+		if staleValidations.Add(1) == 1 {
+			return true, nil
+		}
+		postFetchOnce.Do(func() { close(postFetchValidation) })
+		<-releaseValidation
+		return false, nil
+	}
+	staleRepo.PublishIfRouteFenceMatches = repoBrowserTestPublishGuard(staleRepo.ValidateRouteFence)
+	var currentValidations atomic.Int64
+	currentRepo.ValidateRouteFence = func(context.Context, RepoBrowserRouteFence) (bool, error) {
+		currentValidations.Add(1)
+		return true, nil
+	}
+	currentRepo.PublishIfRouteFenceMatches = repoBrowserTestPublishGuard(currentRepo.ValidateRouteFence)
+	cleanupErr := errors.New("staging cleanup failed")
+	mgr.removeRepoBrowserStagingForTest = func(string) error { return cleanupErr }
+	followerJoined := make(chan struct{})
+	var joinedOnce sync.Once
+	var currentJoins atomic.Int64
+	mgr.repoBrowserAfterRefreshJoinForTest = func(fence RepoBrowserRouteFence) {
+		if fence == currentRepo.RouteFence {
+			currentJoins.Add(1)
+			joinedOnce.Do(func() { close(followerJoined) })
+		}
+	}
+
+	staleDone := make(chan error, 1)
+	go func() {
+		staleDone <- mgr.RefreshRepoBrowserClone(t.Context(), staleRepo)
+	}()
+	<-postFetchValidation
+	currentDone := make(chan error, 1)
+	go func() {
+		currentDone <- mgr.RefreshRepoBrowserClone(t.Context(), currentRepo)
+	}()
+	<-followerJoined
+	close(releaseValidation)
+
+	require.ErrorIs(<-staleDone, cleanupErr)
+	require.ErrorIs(<-currentDone, cleanupErr)
+	assert.Equal(int64(1), currentJoins.Load(),
+		"a follower must not retry when the stale clone could not be quarantined")
+	assert.Positive(currentValidations.Load())
+
+	blob, err := mgr.ReadRepoBrowserBlob(
+		t.Context(), currentRepo,
+		RepoBrowserRef{Type: RepoBrowserRefBranch, Name: "main"},
+		"README.md",
+	)
+	require.NoError(err)
+	assert.Equal("# Widgets\n", blob.Content)
+	_, err = mgr.ReadRepoBrowserBlob(
+		t.Context(), currentRepo,
+		RepoBrowserRef{Type: RepoBrowserRefBranch, Name: "main"},
+		"ONLY_B.md",
+	)
+	require.ErrorIs(err, ErrNotFound)
+
+	restarted := New(mgr.baseDir, nil)
+	registered, err := restarted.RegisterExistingRepoBrowserClone(t.Context(), currentRepo)
+	require.NoError(err)
+	require.True(registered)
+	resolved, err := restarted.ResolveRepoBrowserRef(t.Context(), currentRepo, RepoBrowserRef{
+		Type: RepoBrowserRefBranch,
+		Name: "main",
+	})
+	require.NoError(err)
+	assert.Equal(initialSHA, resolved.SHA)
+}
+
+func TestRepoBrowserFetchErrorsLeavePublishedCloneUnchanged(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		offlineCall int64
+	}{
+		{name: "branch fetch", offlineCall: 1},
+		{name: "tag fetch", offlineCall: 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+			assert := assert.New(t)
+			mgr, repo, work := setupRepoBrowserTestRepo(t)
+			repo.ProviderRepoID = "provider-repository-a"
+			require.NoError(mgr.EnsureRepoBrowserClone(t.Context(), repo))
+			clonePath, err := mgr.repoBrowserClonePath(repo)
+			require.NoError(err)
+			before := repoBrowserCloneSnapshot(t, clonePath)
+
+			require.NoError(os.WriteFile(filepath.Join(work, "ONLY_B.md"), []byte("only repository B\n"), 0o644))
+			commitTestRun(t, work, "git", "add", ".")
+			commitTestRun(t, work, "git", "commit", "-m", "replace route with repository B")
+			commitTestRun(t, work, "git", "push", "origin", "main")
+
+			remoteOffline := repo.RemoteURL + ".offline"
+			var offlineOnce sync.Once
+			routes := &callbackRepoBrowserRouteResolver{onCall: func(call int64) {
+				if call == tc.offlineCall {
+					offlineOnce.Do(func() {
+						require.NoError(os.Rename(repo.RemoteURL, remoteOffline))
+					})
+				}
+			}}
+			restarted := New(mgr.baseDir, routes)
+			repo.RouteFence = NewRepoBrowserRouteFence(1, 2, 1)
+			repo.ValidateRouteFence = func(context.Context, RepoBrowserRouteFence) (bool, error) {
+				return true, nil
+			}
+			repo.PublishIfRouteFenceMatches = repoBrowserTestPublishGuard(repo.ValidateRouteFence)
+
+			require.Error(restarted.RefreshRepoBrowserClone(t.Context(), repo))
+			assert.Equal(before, repoBrowserCloneSnapshot(t, clonePath))
+			blob, err := restarted.ReadRepoBrowserBlob(
+				t.Context(), repo,
+				RepoBrowserRef{Type: RepoBrowserRefBranch, Name: "main"},
+				"README.md",
+			)
+			require.NoError(err)
+			assert.Equal("# Widgets\n", blob.Content)
+			_, err = restarted.ReadRepoBrowserBlob(
+				t.Context(), repo,
+				RepoBrowserRef{Type: RepoBrowserRefBranch, Name: "main"},
+				"ONLY_B.md",
+			)
+			require.ErrorIs(err, ErrNotFound)
+		})
+	}
+}
+
+func TestRepoBrowserPublicationFailureRestoresPublishedClone(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	mgr, _, repo, initialSHA, _ := setupRepoBrowserRouteReuseRefreshTest(t)
+	repo.ValidateRouteFence = func(context.Context, RepoBrowserRouteFence) (bool, error) {
+		return true, nil
+	}
+	repo.PublishIfRouteFenceMatches = func(
+		_ context.Context,
+		_ RepoBrowserRouteFence,
+		publish func() error,
+	) (bool, error) {
+		return true, publish()
+	}
+	clonePath, err := mgr.repoBrowserClonePath(repo)
+	require.NoError(err)
+	before := repoBrowserCloneSnapshot(t, clonePath)
+	publishErr := errors.New("publish staging failed")
+	mgr.publishRepoBrowserStagingForTest = func(string, string) error { return publishErr }
+
+	require.ErrorIs(mgr.RefreshRepoBrowserClone(t.Context(), repo), publishErr)
+	assert.Equal(before, repoBrowserCloneSnapshot(t, clonePath))
+	resolved, err := mgr.ResolveRepoBrowserRef(t.Context(), repo, RepoBrowserRef{
+		Type: RepoBrowserRefBranch,
+		Name: "main",
+	})
+	require.NoError(err)
+	assert.Equal(initialSHA, resolved.SHA)
+}
+
+func TestRepoBrowserGuardedPublicationRefusesRouteChangeAfterValidation(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	mgr, _, repo, initialSHA, _ := setupRepoBrowserRouteReuseRefreshTest(t)
+	var validations atomic.Int64
+	var routeCurrent atomic.Bool
+	routeCurrent.Store(true)
+	repo.ValidateRouteFence = func(context.Context, RepoBrowserRouteFence) (bool, error) {
+		validations.Add(1)
+		return routeCurrent.Load(), nil
+	}
+	guardCalled := make(chan struct{})
+	repo.PublishIfRouteFenceMatches = func(
+		_ context.Context,
+		_ RepoBrowserRouteFence,
+		_ func() error,
+	) (bool, error) {
+		routeCurrent.Store(false)
+		close(guardCalled)
+		return false, nil
+	}
+	clonePath, err := mgr.repoBrowserClonePath(repo)
+	require.NoError(err)
+	before := repoBrowserCloneSnapshot(t, clonePath)
+
+	require.ErrorIs(mgr.RefreshRepoBrowserClone(t.Context(), repo), ErrRepoBrowserRouteFenceChanged)
+	<-guardCalled
+	assert.GreaterOrEqual(validations.Load(), int64(2))
+	assert.Equal(before, repoBrowserCloneSnapshot(t, clonePath))
+	resolved, err := mgr.ResolveRepoBrowserRef(t.Context(), repo, RepoBrowserRef{
+		Type: RepoBrowserRefBranch,
+		Name: "main",
+	})
+	require.NoError(err)
+	assert.Equal(initialSHA, resolved.SHA)
+}
+
+func TestRepoBrowserBarrierReadAdmissionHonorsContextCancellation(t *testing.T) {
+	barrier := newRepoBrowserBarrier()
+	require.NoError(t, barrier.lockWrite(t.Context()))
+	t.Cleanup(barrier.unlockWrite)
+	ctx, cancel := context.WithCancel(t.Context())
+	waiting := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		err := barrier.lockRead(ctx, func() { close(waiting) })
+		if err == nil {
+			barrier.unlockRead()
+		}
+		done <- err
+	}()
+	<-waiting
+	cancel()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, "repo browser read did not abandon blocked barrier admission")
+	}
+}
+
 func TestEnsureRepoBrowserCloneDoesNotRefreshExistingClone(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -134,6 +764,29 @@ func TestEnsureRepoBrowserCloneDoesNotRefreshExistingClone(t *testing.T) {
 	require.NoError(mgr.RefreshRepoBrowserClone(t.Context(), repo))
 	refreshed := repoBrowserMainRef(t, mgr, repo)
 	assert.Equal(updatedSHA, refreshed.SHA)
+}
+
+func TestEnsureRepoBrowserCloneReleasesReadBarrierBeforeFinalFenceValidation(t *testing.T) {
+	require := require.New(t)
+	mgr, repo, _ := setupRepoBrowserTestRepo(t)
+	repo.RouteFence = NewRepoBrowserRouteFence(1, 2, 3)
+	barrierHeld := errors.New("repo browser read barrier held during final fence validation")
+	var validations atomic.Int64
+	repo.ValidateRouteFence = func(context.Context, RepoBrowserRouteFence) (bool, error) {
+		if validations.Add(1) == 1 {
+			return true, nil
+		}
+		barrier := mgr.repoBrowserCloneBarrier(repo)
+		if !barrier.semaphore.TryAcquire(repoBrowserBarrierCapacity) {
+			return false, barrierHeld
+		}
+		barrier.semaphore.Release(repoBrowserBarrierCapacity)
+		return true, nil
+	}
+	repo.PublishIfRouteFenceMatches = repoBrowserTestPublishGuard(repo.ValidateRouteFence)
+
+	require.NoError(mgr.EnsureRepoBrowserClone(t.Context(), repo))
+	require.Equal(int64(2), validations.Load())
 }
 
 func TestRepoBrowserScheduledRefreshContextStaysCancelable(t *testing.T) {
@@ -629,9 +1282,86 @@ func setupRepoBrowserTestRepo(t *testing.T) (*Manager, RepoBrowserRepoRef, strin
 	return mgr, repo, work
 }
 
+func setupRepoBrowserRouteReuseRefreshTest(
+	t *testing.T,
+) (*Manager, RepoBrowserRepoRef, RepoBrowserRepoRef, string, string) {
+	t.Helper()
+	mgr, repo, work := setupRepoBrowserTestRepo(t)
+	repo.ProviderRepoID = "provider-repository-a"
+	require.NoError(t, mgr.EnsureRepoBrowserClone(t.Context(), repo))
+	initialSHA := gitSHA(t, work, "main")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(work, "README.md"), []byte("repository B\n"), 0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(work, "ONLY_B.md"), []byte("only repository B\n"), 0o644,
+	))
+	commitTestRun(t, work, "git", "add", ".")
+	commitTestRun(t, work, "git", "commit", "-m", "replace route with repository B")
+	commitTestRun(t, work, "git", "push", "origin", "main")
+
+	staleRepo := repo
+	staleRepo.RouteFence = NewRepoBrowserRouteFence(1, 2, 1)
+	currentRepo := staleRepo
+	currentRepo.RouteFence = NewRepoBrowserRouteFence(1, 2, 3)
+	return mgr, staleRepo, currentRepo, initialSHA, work
+}
+
 func repoBrowserMainRef(t *testing.T, mgr *Manager, repo RepoBrowserRepoRef) RepoBrowserRef {
 	t.Helper()
 	_, ref, err := mgr.resolveRepoBrowserDefaultBranch(t.Context(), repo, "main")
 	require.NoError(t, err)
 	return RepoBrowserRef{Type: RepoBrowserRefBranch, Name: "main", SHA: ref}
+}
+
+func repoBrowserCloneSnapshot(t *testing.T, root string) map[string]string {
+	t.Helper()
+	snapshot := make(map[string]string)
+	require.NoError(t, filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		switch {
+		case entry.IsDir():
+			snapshot[rel] = "dir:" + info.Mode().String()
+		case info.Mode()&os.ModeSymlink != 0:
+			target, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			snapshot[rel] = "link:" + target
+		default:
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			snapshot[rel] = fmt.Sprintf("file:%s:%x", info.Mode(), sha256.Sum256(data))
+		}
+		return nil
+	}))
+	return snapshot
+}
+
+func repoBrowserTestPublishGuard(
+	validate RepoBrowserRouteFenceValidator,
+) RepoBrowserRouteFencePublishGuard {
+	return func(
+		ctx context.Context,
+		fence RepoBrowserRouteFence,
+		publish func() error,
+	) (bool, error) {
+		matches, err := validate(ctx, fence)
+		if err != nil || !matches {
+			return false, err
+		}
+		return true, publish()
+	}
 }

--- a/internal/github/archive_lifecycle_test.go
+++ b/internal/github/archive_lifecycle_test.go
@@ -1734,6 +1734,134 @@ func TestSyncRepoRegistersReadAndWriteIdentityProviderWork(t *testing.T) {
 	assert.False(syncer.higherPriorityProviderWorkActive(writeBucket, archive.PriorityFullArchive))
 }
 
+func TestSyncNotificationsPreemptsArchivesForSplitAndReconciledIdentities(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	database := dbtest.Open(t)
+	getRepoStarted := make(chan struct{})
+	listStarted := make(chan struct{})
+	releaseList := make(chan struct{})
+	var getRepoOnce sync.Once
+	var listOnce sync.Once
+	mc := &mockClient{
+		getRepositoryFn: func(context.Context, string, string) (*gh.Repository, error) {
+			getRepoOnce.Do(func() { close(getRepoStarted) })
+			owner := "acme"
+			name := "widget"
+			nodeID := "repo-new"
+			id := int64(1)
+			return &gh.Repository{
+				ID: &id, NodeID: &nodeID, Owner: &gh.User{Login: &owner}, Name: &name,
+			}, nil
+		},
+		listNotificationsFn: func(
+			context.Context, NotificationListOptions,
+		) ([]NotificationThread, bool, error) {
+			listOnce.Do(func() { close(listStarted) })
+			<-releaseList
+			return nil, false, nil
+		},
+	}
+	repo := RepoRef{
+		Platform: platform.KindGitHub, PlatformHost: "github.com",
+		Owner: "acme", Name: "widget",
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc}, database, nil,
+		[]RepoRef{repo}, time.Hour, nil, nil,
+	)
+	t.Cleanup(syncer.Stop)
+	router, err := NewHostRouter(
+		"github.com",
+		&Route{
+			Key: RouteKey{Host: "github.com", Owner: "acme"}, Client: mc,
+			ReadIdentity:  IdentityKey{Host: "github.com", Principal: "installation:22"},
+			WriteIdentity: IdentityKey{Host: "github.com", Principal: "user:8"},
+		},
+		&Route{
+			Key: RouteKey{Host: "github.com", Owner: "legacy"}, Client: mc,
+			ReadIdentity:  IdentityKey{Host: "github.com", Principal: "installation:11"},
+			WriteIdentity: IdentityKey{Host: "github.com", Principal: "user:9"},
+		},
+	)
+	require.NoError(err)
+	router.RegisterRepoCredentialAlias("acme", "widget", RouteKey{
+		Host: "github.com", Owner: "legacy",
+	}, "repo-old")
+	syncer.SetGitHubRouters(map[string]*HostRouter{"github.com": router})
+
+	oldReadBucket := RateBucketKey("github", "github.com", "installation:11")
+	oldWriteBucket := RateBucketKey("github", "github.com", "user:9")
+	newReadBucket := RateBucketKey("github", "github.com", "installation:22")
+	newWriteBucket := RateBucketKey("github", "github.com", "user:8")
+	oldArchiveCtx, releaseOldArchive, allowed := syncer.tryBeginArchiveProviderRequest(
+		t.Context(), oldReadBucket,
+	)
+	require.True(allowed)
+	t.Cleanup(releaseOldArchive)
+	newArchiveCtx, releaseNewArchive, allowed := syncer.tryBeginArchiveProviderRequest(
+		t.Context(), newReadBucket,
+	)
+	require.True(allowed)
+	t.Cleanup(releaseNewArchive)
+	t.Cleanup(func() {
+		select {
+		case <-releaseList:
+		default:
+			close(releaseList)
+		}
+	})
+
+	done := make(chan error, 1)
+	go func() { done <- syncer.SyncNotifications(t.Context()) }()
+	select {
+	case <-oldArchiveCtx.Done():
+	case <-time.After(time.Second):
+		require.Fail("notification sync did not preempt the initial read identity archive")
+	}
+	select {
+	case <-getRepoStarted:
+		require.Fail("repository verification started before the initial read archive released")
+	case <-time.After(25 * time.Millisecond):
+	}
+	releaseOldArchive()
+	select {
+	case <-getRepoStarted:
+	case <-time.After(time.Second):
+		require.Fail("notification sync did not begin repository verification")
+	}
+	select {
+	case <-newArchiveCtx.Done():
+	case <-time.After(time.Second):
+		require.Fail("notification sync did not preempt the reconciled read identity archive")
+	}
+	select {
+	case <-listStarted:
+		require.Fail("notification listing started before the reconciled read archive released")
+	case <-time.After(25 * time.Millisecond):
+	}
+	releaseNewArchive()
+	select {
+	case <-listStarted:
+	case <-time.After(time.Second):
+		require.Fail("notification sync did not begin listing notifications")
+	}
+	for bucket, label := range map[string]string{
+		oldReadBucket: "initial read", oldWriteBucket: "initial write",
+		newReadBucket: "reconciled read", newWriteBucket: "reconciled write",
+	} {
+		assert.True(
+			syncer.higherPriorityProviderWorkActive(bucket, archive.PriorityFullArchive),
+			label+" identity work must preempt archives during notification sync",
+		)
+	}
+	close(releaseList)
+	require.NoError(<-done)
+	for _, bucket := range []string{oldReadBucket, oldWriteBucket, newReadBucket, newWriteBucket} {
+		assert.False(syncer.higherPriorityProviderWorkActive(bucket, archive.PriorityFullArchive))
+	}
+}
+
 func TestProcessQueuedNotificationReadsHoldsWriteIdentityProviderWork(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/github/auth_router_test.go
+++ b/internal/github/auth_router_test.go
@@ -920,6 +920,78 @@ func TestSyncerNotificationAdmissionUsesRepositoryWriteIdentity(t *testing.T) {
 	require.ErrorContains(err, "rate reserve exhausted")
 }
 
+func TestSyncerNotificationIdentityAdmissionUsesSplitCredentials(t *testing.T) {
+	require := require.New(t)
+	database := openTestDB(t)
+	readIdentity := IdentityKey{
+		Host: "github.com", Principal: "installation:789",
+	}
+	writeIdentity := IdentityKey{Host: "github.com", Principal: "user:123"}
+	router, err := NewHostRouter("github.com", &Route{
+		Key:          RouteKey{Host: "github.com", Owner: "org-a"},
+		ReadIdentity: readIdentity, WriteIdentity: writeIdentity,
+	})
+	require.NoError(err)
+	readBudget := NewSyncBudget(0)
+	writeBudget := NewSyncBudget(10)
+	syncer := &Syncer{
+		routers: map[string]*HostRouter{"github.com": router},
+		budgets: map[string]*SyncBudget{
+			RateBucketKey("github", "github.com", "installation:789"): readBudget,
+			RateBucketKey("github", "github.com", "user:123"):         writeBudget,
+		},
+	}
+	repo := RepoRef{Owner: "org-a", Name: "one", PlatformHost: "github.com"}
+
+	err = syncer.ensureNotificationIdentityBudget(
+		repo, &routeRecordingClient{},
+	)
+	require.ErrorContains(err, "sync budget exhausted")
+
+	readBudget = NewSyncBudget(10)
+	writeBudget = NewSyncBudget(0)
+	syncer.budgets = map[string]*SyncBudget{
+		RateBucketKey("github", "github.com", "installation:789"): readBudget,
+		RateBucketKey("github", "github.com", "user:123"):         writeBudget,
+	}
+	err = syncer.ensureNotificationIdentityBudget(
+		repo, &routeRecordingClient{},
+	)
+	require.ErrorContains(err, "sync budget exhausted")
+
+	readBudget = NewSyncBudget(10)
+	writeBudget = NewSyncBudget(10)
+	syncer.budgets = map[string]*SyncBudget{
+		RateBucketKey("github", "github.com", "installation:789"): readBudget,
+		RateBucketKey("github", "github.com", "user:123"):         writeBudget,
+	}
+	readTracker := NewRateTracker(
+		database, "github.com", "installation:789", "rest",
+	)
+	readTracker.UpdateFromRate(Rate{
+		Limit: 5000, Remaining: 0, Reset: time.Now().Add(time.Hour),
+	})
+	syncer.rateTrackers = map[string]*RateTracker{
+		RateBucketKey("github", "github.com", "installation:789"): readTracker,
+	}
+	err = syncer.ensureNotificationIdentityBudget(
+		repo, &routeRecordingClient{},
+	)
+	require.ErrorContains(err, "rate reserve exhausted")
+
+	syncer.rateTrackers = nil
+	registry := NewQuotaRegistry()
+	registry.UpdateSnapshot(readIdentity, QuotaResourceREST, Rate{
+		Limit: 5000, Remaining: RateReserveBuffer,
+		Reset: time.Now().Add(time.Hour),
+	})
+	syncer.SetQuotaRegistry(registry)
+	err = syncer.ensureNotificationIdentityBudget(
+		repo, &routeRecordingClient{},
+	)
+	require.ErrorContains(err, "read rate reserve exhausted")
+}
+
 func TestSyncerRefreshesRateSnapshotsPerIdentityRoute(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/github/commit_liveness_test.go
+++ b/internal/github/commit_liveness_test.go
@@ -881,11 +881,16 @@ func TestCommitLivenessRepairsThroughUnchangedDetail(t *testing.T) {
 	livenessTestGit(t, h.sourceDir, "commit", "-m", "repair head")
 	repairHead := livenessTestGit(t, h.sourceDir, "rev-parse", "HEAD")
 	existing := setLivenessFixtureHead(t, fixture, repairHead)
+	routeFence, found, err := fixture.database.CurrentRepositoryRouteFence(
+		t.Context(), platform.DBRepoIdentity(platformRepoRef(fixture.repo)), fixture.repoID,
+	)
+	require.NoError(t, err)
+	require.True(t, found)
 
 	// The clone does not yet contain the head, so the unchanged-detail round
 	// marks detail fetched without touching liveness metadata.
-	_, err := fixture.syncer.markUnchangedMRDetailFetched(
-		t.Context(), fixture.repo, fixture.repoID, 1, existing, 1,
+	_, err = fixture.syncer.markUnchangedMRDetailFetched(
+		t.Context(), fixture.repo, fixture.repoID, 1, existing, routeFence, 1,
 	)
 	require.NoError(t, err)
 	assertLivenessCommitFlags(t, fixture, map[string]bool{h.a1: false})
@@ -899,7 +904,7 @@ func TestCommitLivenessRepairsThroughUnchangedDetail(t *testing.T) {
 	// Once the clone has the head, the next unchanged-detail round carries the
 	// liveness updates with its marker under the same revision guard.
 	_, err = fixture.syncer.markUnchangedMRDetailFetched(
-		t.Context(), fixture.repo, fixture.repoID, 1, existing, 1,
+		t.Context(), fixture.repo, fixture.repoID, 1, existing, routeFence, 1,
 	)
 	require.NoError(t, err)
 	assertLivenessCommitFlags(t, fixture, map[string]bool{h.a1: true})
@@ -927,6 +932,11 @@ func TestCommitLivenessViaFetchProviderMRDetail(t *testing.T) {
 		t.Context(), verifiedDBRepoIdentity(platformRepoRef(providerRepo)),
 	)
 	require.NoError(t, err)
+	routeFence, found, err := fixture.database.CurrentRepositoryRouteFence(
+		t.Context(), platform.DBRepoIdentity(platformRepoRef(providerRepo)), providerRepoID,
+	)
+	require.NoError(t, err)
+	require.True(t, found)
 	now := time.Date(2026, 8, 5, 12, 1, 0, 0, time.UTC)
 	providerMRID, err := fixture.database.UpsertMergeRequest(t.Context(), &db.MergeRequest{
 		RepoID:             providerRepoID,
@@ -1005,7 +1015,7 @@ func TestCommitLivenessViaFetchProviderMRDetail(t *testing.T) {
 	t.Cleanup(syncer.Stop)
 
 	_, err = syncer.fetchProviderMRDetail(
-		t.Context(), provider, providerRepo, providerRepoID, 1,
+		t.Context(), provider, providerRepo, providerRepoID, 1, routeFence,
 	)
 	require.NoError(t, err)
 	assertLivenessCommitFlags(t, providerFixture, map[string]bool{
@@ -1035,7 +1045,8 @@ func TestCommitLivenessFinalizedByPeriodicCloseDetection(t *testing.T) {
 		RepoPath:           "owner/repo",
 		CloneURL:           h.sourceDir,
 	}
-	barePath, err := h.manager.ClonePath(
+	barePath, err := h.manager.ClonePathForContext(
+		gitclone.WithRepositoryIdentity(t.Context(), providerRepo.PlatformExternalID),
 		string(platform.KindForgejo), platform.DefaultForgejoHost, "owner", "repo",
 	)
 	require.NoError(t, err)

--- a/internal/github/feature_cooldown_test.go
+++ b/internal/github/feature_cooldown_test.go
@@ -721,20 +721,20 @@ func TestCommentRefreshWithoutProviderAttemptAbandonsExpiredFeatureProbeReservat
 	tests := []struct {
 		name    string
 		feature string
-		run     func(context.Context, *Syncer, RepoRef)
+		run     func(context.Context, *Syncer, RepoRef, int64)
 	}{
 		{
 			name:    "pending merge request missing detail",
 			feature: platform.RepositoryFeatureMergeRequests,
-			run: func(ctx context.Context, syncer *Syncer, repo RepoRef) {
-				syncer.queuePRCommentSync(repo, 7)
+			run: func(ctx context.Context, syncer *Syncer, repo RepoRef, repoID int64) {
+				syncer.queuePRCommentSync(repo, repoID, 7)
 				syncer.drainPendingCommentSyncs(ctx, map[string]bool{"github.com": true})
 			},
 		},
 		{
 			name:    "repository issue list empty",
 			feature: platform.RepositoryFeatureIssues,
-			run: func(ctx context.Context, syncer *Syncer, repo RepoRef) {
+			run: func(ctx context.Context, syncer *Syncer, repo RepoRef, _ int64) {
 				syncer.refreshRepoIssueComments(ctx, repo)
 			},
 		},
@@ -776,7 +776,7 @@ func TestCommentRefreshWithoutProviderAttemptAbandonsExpiredFeatureProbeReservat
 			))
 			now = now.Add(repositoryFeatureProbeInterval)
 
-			tc.run(ctx, syncer, repo)
+			tc.run(ctx, syncer, repo, repoID)
 
 			first, due := syncer.beginRepositoryFeatureProbe(ctx, repo, tc.feature)
 			require.True(due)
@@ -949,7 +949,7 @@ func TestDisabledIssueCooldownSkipsQueuedComments(t *testing.T) {
 			errors.New("repository issues disabled"),
 		),
 	))
-	syncer.queueIssueCommentSync(repo, 1)
+	syncer.queueIssueCommentSync(repo, repoID, 1)
 
 	syncer.drainPendingCommentSyncs(ctx, map[string]bool{"github.com": true})
 
@@ -1002,9 +1002,9 @@ func TestExpiredIssueCommentProbeRenewsDisabledCooldown(t *testing.T) {
 	))
 	now = now.Add(repositoryFeatureProbeInterval)
 
-	syncer.queueIssueCommentSync(repo, 1)
+	syncer.queueIssueCommentSync(repo, repoID, 1)
 	syncer.drainPendingCommentSyncs(ctx, map[string]bool{"github.com": true})
-	syncer.queueIssueCommentSync(repo, 1)
+	syncer.queueIssueCommentSync(repo, repoID, 1)
 	syncer.drainPendingCommentSyncs(ctx, map[string]bool{"github.com": true})
 
 	assert.Equal(int32(1), commentCalls.Load())

--- a/internal/github/merged_diff_test.go
+++ b/internal/github/merged_diff_test.go
@@ -51,14 +51,31 @@ func initTestRepo(t *testing.T, dir string) {
 func setupBareClone(t *testing.T, sourceDir, clonesDir, owner, name string) *gitclone.Manager {
 	t.Helper()
 	mgr := gitclone.New(clonesDir, nil)
-	barePath, err := mgr.ClonePath("github", "github.com", owner, name)
+	legacyPath, err := mgr.ClonePath("github", "github.com", owner, name)
 	require.NoError(t, err)
-	gitRun(t, "", "clone", "--bare", sourceDir, barePath)
-	gitRun(t, barePath, "config", "--add", "remote.origin.fetch",
-		"+refs/pull/*/head:refs/pull/*/head")
-	gitRun(t, barePath, "remote", "set-url", "origin", sourceDir)
-	gitRun(t, barePath, "fetch", "--prune", "origin")
+	identityPath := syncTestClonePath(t, mgr, owner, name)
+	for _, barePath := range []string{legacyPath, identityPath} {
+		gitRun(t, "", "clone", "--bare", sourceDir, barePath)
+		gitRun(t, barePath, "config", "--add", "remote.origin.fetch",
+			"+refs/pull/*/head:refs/pull/*/head")
+		gitRun(t, barePath, "remote", "set-url", "origin", sourceDir)
+		gitRun(t, barePath, "fetch", "--prune", "origin")
+	}
 	return mgr
+}
+
+func syncTestClonePath(
+	t *testing.T, mgr *gitclone.Manager, owner, name string,
+) string {
+	t.Helper()
+	path, err := mgr.ClonePathForContext(
+		gitclone.WithRepositoryIdentity(
+			t.Context(), "repo-"+strings.ToLower(owner+"-"+name),
+		),
+		"github", "github.com", owner, name,
+	)
+	require.NoError(t, err)
+	return path
 }
 
 // setupSyncer creates a syncer with a real DB, bare clone manager, and mock client.
@@ -364,8 +381,7 @@ func TestIntegrationSyncOpenToMergedTransition(t *testing.T) {
 	postmergeBaseSHA := gitRun(t, sourceDir, "rev-parse", "main")
 
 	// Re-fetch the bare clone to pick up the merge commit.
-	barePath, err := mgr.ClonePath("github", "github.com", "owner", "repo")
-	require.NoError(err)
+	barePath := syncTestClonePath(t, mgr, "owner", "repo")
 	gitRun(t, barePath, "fetch", "--prune", "origin")
 
 	closedState := "closed"
@@ -513,6 +529,84 @@ func TestIntegrationSyncFirstSeenMergedPR(t *testing.T) {
 	assert.NotEqual(prHead, shas.MergeBaseSHA, "diff should not be empty")
 }
 
+func TestIntegrationSyncClosedMROnProviderRepairsDiffFromStableIdentityClone(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	sourceDir := t.TempDir()
+	clonesDir := t.TempDir()
+
+	initTestRepo(t, sourceDir)
+	forkPoint := gitRun(t, sourceDir, "rev-parse", "HEAD")
+	gitRun(t, sourceDir, "checkout", "-b", "feature")
+	require.NoError(os.WriteFile(
+		filepath.Join(sourceDir, "feature.txt"), []byte("feature\n"), 0o644,
+	))
+	gitRun(t, sourceDir, "add", ".")
+	gitRun(t, sourceDir, "commit", "-m", "add feature")
+	prHead := gitRun(t, sourceDir, "rev-parse", "HEAD")
+	gitRun(t, sourceDir, "update-ref", "refs/pull/91/head", prHead)
+	gitRun(t, sourceDir, "checkout", "main")
+	gitRun(t, sourceDir, "merge", "--no-ff", "feature", "-m", "Merge feature")
+	mergeCommit := gitRun(t, sourceDir, "rev-parse", "HEAD")
+
+	mgr := gitclone.New(clonesDir, nil)
+	stablePath := syncTestClonePath(t, mgr, "owner", "repo")
+	gitRun(t, "", "clone", "--bare", sourceDir, stablePath)
+	gitRun(t, stablePath, "config", "--add", "remote.origin.fetch",
+		"+refs/pull/*/head:refs/pull/*/head")
+	gitRun(t, stablePath, "remote", "set-url", "origin", sourceDir)
+	gitRun(t, stablePath, "fetch", "--prune", "origin")
+	legacyPath, err := mgr.ClonePath("github", "github.com", "owner", "repo")
+	require.NoError(err)
+	assert.NoDirExists(legacyPath,
+		"the mutation resync must not depend on a legacy route clone")
+
+	database := openTestDB(t)
+	repoID, err := database.UpsertRepo(
+		ctx, verifiedGitHubRepoIdentity("github.com", "owner", "repo"),
+	)
+	require.NoError(err)
+	now := time.Now().UTC()
+	openPR := buildOpenPR(91, now)
+	openPR.Head.SHA = &prHead
+	openPR.Base.SHA = &forkPoint
+	normalized, err := NormalizePR(repoID, openPR)
+	require.NoError(err)
+	_, err = database.UpsertMergeRequest(ctx, normalized)
+	require.NoError(err)
+
+	closedState := "closed"
+	merged := true
+	mergedAt := now.Add(time.Minute)
+	mergedPR := buildOpenPR(91, mergedAt)
+	mergedPR.State = &closedState
+	mergedPR.Merged = &merged
+	mergedPR.MergedAt = makeTimestamp(mergedAt)
+	mergedPR.ClosedAt = makeTimestamp(mergedAt)
+	mergedPR.MergeCommitSHA = &mergeCommit
+	mergedPR.Head.SHA = &prHead
+	mergedPR.Base.SHA = &mergeCommit
+	client := &mockClient{singlePR: mergedPR}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client}, database, mgr,
+		[]RepoRef{{
+			Platform: platform.KindGitHub, PlatformHost: "github.com",
+			PlatformExternalID: "repo-owner-repo",
+			Owner:              "owner", Name: "repo", RepoPath: "owner/repo",
+		}},
+		time.Minute, nil, testBudget(100),
+	)
+
+	require.NoError(syncer.SyncClosedMROnProvider(ctx, repoID, 91))
+	shas, err := database.GetDiffSHAsByRepoID(ctx, repoID, 91)
+	require.NoError(err)
+	require.NotNil(shas)
+	assert.Equal(prHead, shas.DiffHeadSHA)
+	assert.Equal(forkPoint, shas.DiffBaseSHA)
+	assert.Equal(forkPoint, shas.MergeBaseSHA)
+}
+
 // TestSyncMRWrapsDiffFailureAsDiffSyncError verifies that when SyncMR cannot
 // compute diff SHAs for a merged PR (here: the bare clone is missing the
 // merge commit), it still upserts the PR row, refreshes the timeline, and
@@ -552,8 +646,7 @@ func TestIntegrationSyncMRWrapsDiffFailureAsDiffSyncError(t *testing.T) {
 	// `git fetch` succeeds but the merge commit never enters the clone.
 	emptyRemote := t.TempDir()
 	initTestRepo(t, emptyRemote)
-	barePath, err := mgr.ClonePath("github", "github.com", "owner", "repo")
-	require.NoError(err)
+	barePath := syncTestClonePath(t, mgr, "owner", "repo")
 	gitRun(t, barePath, "remote", "set-url", "origin", emptyRemote)
 
 	number := 42
@@ -587,7 +680,7 @@ func TestIntegrationSyncMRWrapsDiffFailureAsDiffSyncError(t *testing.T) {
 		[]RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}},
 		time.Minute, nil, nil)
 
-	err = syncer.SyncMR(ctx, "owner", "repo", number)
+	err := syncer.SyncMR(ctx, "owner", "repo", number)
 	require.Error(err)
 	var diffErr *DiffSyncError
 	require.ErrorAs(err, &diffErr)
@@ -659,8 +752,7 @@ func TestIntegrationSyncItemByNumberReturnsTypeOnDiffSyncError(t *testing.T) {
 	// reach it via fetch.
 	emptyRemote := t.TempDir()
 	initTestRepo(t, emptyRemote)
-	barePath, err := mgr.ClonePath("github", "github.com", "owner", "repo")
-	require.NoError(err)
+	barePath := syncTestClonePath(t, mgr, "owner", "repo")
 	gitRun(t, barePath, "remote", "set-url", "origin", emptyRemote)
 
 	number := 77

--- a/internal/github/notifications_sync.go
+++ b/internal/github/notifications_sync.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -159,11 +160,13 @@ func (s *Syncer) SyncNotifications(ctx context.Context) error {
 	clients := s.notificationClients()
 	var errs []error
 	for _, entry := range clients {
-		releaseProviderWork := s.beginNotificationProviderWork(
+		providerWork := s.beginNotificationProviderWork(
 			entry.platform, entry.host, tracked,
 		)
-		err := s.syncNotificationsForHost(ctx, entry.platform, entry.host, entry.client, tracked)
-		releaseProviderWork()
+		err := s.syncNotificationsForHost(
+			ctx, entry.platform, entry.host, entry.client, tracked, providerWork,
+		)
+		providerWork.release()
 		if err != nil {
 			errs = append(errs, err)
 		}
@@ -178,32 +181,51 @@ func (s *Syncer) beginNotificationProviderWork(
 	kind platform.Kind,
 	host string,
 	tracked map[string]RepoRef,
-) func() {
-	seen := make(map[string]struct{})
-	releases := make([]func(), 0)
+) *notificationProviderWork {
+	work := &notificationProviderWork{
+		syncer: s,
+		seen:   make(map[string]struct{}),
+	}
 	// A repository whose credential route cannot resolve registers nothing:
 	// its own wire calls fail closed at routing without upstream I/O and its
 	// per-repository sync reports the error. Aborting the whole host here
 	// would block healthy siblings from syncing and advancing their
 	// watermarks — the exact coupling per-repository watermarks remove.
 	for _, repo := range notificationTrackedRepos(string(kind), host, tracked) {
-		useWriteIdentity := repoPlatform(repo) == platform.KindGitHub
-		bucket, err := s.bucketKeyForRepo(repo, useWriteIdentity)
+		work.addRepo(repo)
+	}
+	return work
+}
+
+type notificationProviderWork struct {
+	syncer   *Syncer
+	seen     map[string]struct{}
+	releases []func()
+}
+
+func (w *notificationProviderWork) addRepo(repo RepoRef) {
+	identityRoutes := []bool{false}
+	if repoPlatform(repo) == platform.KindGitHub {
+		identityRoutes = append(identityRoutes, true)
+	}
+	for _, useWriteIdentity := range identityRoutes {
+		bucket, err := w.syncer.bucketKeyForRepo(repo, useWriteIdentity)
 		if err != nil {
 			continue
 		}
-		if _, ok := seen[bucket]; ok {
+		if _, ok := w.seen[bucket]; ok {
 			continue
 		}
-		seen[bucket] = struct{}{}
-		releases = append(releases, s.beginProviderWork(
+		w.seen[bucket] = struct{}{}
+		w.releases = append(w.releases, w.syncer.beginProviderWork(
 			bucket, archive.PriorityNotificationRefresh,
 		))
 	}
-	return func() {
-		for i := len(releases) - 1; i >= 0; i-- {
-			releases[i]()
-		}
+}
+
+func (w *notificationProviderWork) release() {
+	for i := len(w.releases) - 1; i >= 0; i-- {
+		w.releases[i]()
 	}
 }
 
@@ -262,7 +284,14 @@ func (s *Syncer) notificationClientForHost(kind platform.Kind, host string) (not
 	return client, true
 }
 
-func (s *Syncer) syncNotificationsForHost(ctx context.Context, kind platform.Kind, host string, client notificationClient, tracked map[string]RepoRef) error {
+func (s *Syncer) syncNotificationsForHost(
+	ctx context.Context,
+	kind platform.Kind,
+	host string,
+	client notificationClient,
+	tracked map[string]RepoRef,
+	providerWork *notificationProviderWork,
+) error {
 	startedAt := time.Now().UTC()
 	trackedRepos := notificationTrackedRepos(string(kind), host, tracked)
 	if len(trackedRepos) == 0 {
@@ -274,7 +303,7 @@ func (s *Syncer) syncNotificationsForHost(ctx context.Context, kind platform.Kin
 	var repoErrs []error
 	for _, repo := range trackedRepos {
 		if err := s.syncNotificationsForRepo(
-			ctx, kind, host, client, tracked, repo, startedAt,
+			ctx, kind, host, client, tracked, repo, startedAt, providerWork,
 		); err != nil {
 			repoErrs = append(repoErrs, err)
 		}
@@ -290,13 +319,94 @@ func (s *Syncer) syncNotificationsForRepo(
 	tracked map[string]RepoRef,
 	repo RepoRef,
 	startedAt time.Time,
+	providerWork *notificationProviderWork,
 ) error {
+	for range 2 {
+		retry, err := s.syncNotificationsForRepoAttempt(
+			ctx, kind, host, client, tracked, repo, startedAt, providerWork,
+		)
+		if err != nil || !retry {
+			return err
+		}
+	}
+	return fmt.Errorf(
+		"repository route changed repeatedly during notification sync of %s/%s on %s",
+		repo.Owner, repo.Name, host,
+	)
+}
+
+func (s *Syncer) syncNotificationsForRepoAttempt(
+	ctx context.Context,
+	kind platform.Kind,
+	host string,
+	client notificationClient,
+	tracked map[string]RepoRef,
+	repo RepoRef,
+	startedAt time.Time,
+	providerWork *notificationProviderWork,
+) (bool, error) {
 	platformName := string(kind)
+	if err := s.ensureNotificationIdentityBudget(repo, client); err != nil {
+		return false, err
+	}
+	resolved, observedRepoID, providerRepo, observedAt, accepted, err :=
+		s.reconcileRepoIdentityObservation(ctx, repo)
+	if err != nil {
+		return false, fmt.Errorf(
+			"verify repository identity before notification sync of %s/%s on %s: %w",
+			repo.Owner, repo.Name, host, err,
+		)
+	}
+	if !accepted {
+		return true, nil
+	}
+	repo = resolved
+	observedIdentity := platform.DBRepoIdentity(platformRepoRef(repo))
+	routeFence, found, err := s.db.CurrentRepositoryRouteFence(
+		ctx, observedIdentity, observedRepoID,
+	)
+	if err != nil {
+		return false, fmt.Errorf(
+			"capture repository route before notification sync of %s/%s on %s: %w",
+			repo.Owner, repo.Name, host, err,
+		)
+	}
+	if !found {
+		return true, nil
+	}
+	providerWork.addRepo(repo)
+	if s.afterNotificationRepoIdentityReconciled != nil {
+		s.afterNotificationRepoIdentityReconciled()
+	}
+	if providerRepo != nil {
+		applied, err := s.updateRepoSettingsFromProviderObservation(
+			s.db.WithRepositoryRouteFence(ctx, observedIdentity, routeFence),
+			observedRepoID, observedAt, *providerRepo,
+		)
+		if err != nil {
+			if errors.Is(err, db.ErrRepositoryRouteFenceChanged) {
+				return true, nil
+			}
+			return false, fmt.Errorf(
+				"persist repository settings before notification sync of %s/%s on %s: %w",
+				repo.Owner, repo.Name, host, err,
+			)
+		}
+		if !applied {
+			return true, nil
+		}
+	}
+	if err := s.ensureNotificationBudget(repo, client, 1); err != nil {
+		return false, err
+	}
+	trackedRepo := repo
+	trackedRepo.RepoID = observedRepoID
+	tracked[notificationRepoKey(platformName, host, repo.Owner, repo.Name)] = trackedRepo
 	watermark, err := s.db.GetNotificationSyncWatermark(
 		ctx, platformName, host, repo.Owner, repo.Name,
 	)
 	if err != nil {
-		return fmt.Errorf(
+		return false, fmt.Errorf(
 			"load notification sync watermark for %s/%s on %s: %w",
 			repo.Owner, repo.Name, host, err,
 		)
@@ -311,11 +421,11 @@ func (s *Syncer) syncNotificationsForRepo(
 		ctx, host, client, []RepoRef{repo}, since,
 	)
 	if err != nil {
-		return err
+		return false, err
 	}
 	for page := 1; ; page++ {
 		if err := s.ensureNotificationBudget(repo, client, 1); err != nil {
-			return err
+			return false, err
 		}
 		threads, hasNext, err := client.ListNotifications(ctx, NotificationListOptions{
 			All:       true,
@@ -325,7 +435,7 @@ func (s *Syncer) syncNotificationsForRepo(
 			RepoName:  repo.Name,
 		})
 		if err != nil {
-			return fmt.Errorf(
+			return false, fmt.Errorf(
 				"list notifications for %s/%s on %s page %d: %w",
 				repo.Owner, repo.Name, host, page, err,
 			)
@@ -347,6 +457,7 @@ func (s *Syncer) syncNotificationsForRepo(
 			if !ok {
 				continue
 			}
+			trackedRepo.RepoID = observedRepoID
 			// Only notifications anchored to a PR or issue have an in-app
 			// destination and meaningful triage. CI/check-suite, discussion,
 			// release, and other subjects are worthless in kenn-forge, so do
@@ -364,30 +475,38 @@ func (s *Syncer) syncNotificationsForRepo(
 			}
 			notification, err := s.notificationToDB(ctx, host, trackedRepo, thread, now)
 			if err != nil {
-				return fmt.Errorf(
+				return false, fmt.Errorf(
 					"normalize notification %s for %s/%s on %s page %d: %w",
 					thread.ID, repo.Owner, repo.Name, host, page, err,
 				)
 			}
 			notifications = append(notifications, notification)
 		}
-		if err := s.db.UpsertNotifications(ctx, notifications); err != nil {
-			return fmt.Errorf("upsert notifications for %s/%s on %s page %d: %w", repo.Owner, repo.Name, host, page, err)
+		committed, err := s.db.UpsertNotificationsIfRouteFence(
+			ctx, notifications, observedIdentity, routeFence,
+		)
+		if err != nil {
+			return false, fmt.Errorf("upsert notifications for %s/%s on %s page %d: %w", repo.Owner, repo.Name, host, page, err)
+		}
+		if !committed {
+			return true, nil
 		}
 		if !hasNext {
 			break
 		}
 	}
 	lastFullSyncAt := watermarkLastFullSyncAt(watermark, startedAt, fullSync)
-	if err := s.db.UpdateNotificationSyncWatermark(
-		ctx, platformName, host, repo.Owner, repo.Name, startedAt, lastFullSyncAt,
-	); err != nil {
-		return fmt.Errorf(
+	committed, err := s.db.UpdateNotificationSyncWatermarkIfRouteFence(
+		ctx, platformName, host, repo.Owner, repo.Name,
+		routeFence, startedAt, lastFullSyncAt,
+	)
+	if err != nil {
+		return false, fmt.Errorf(
 			"store notification sync watermark for %s/%s on %s: %w",
 			repo.Owner, repo.Name, host, err,
 		)
 	}
-	return nil
+	return !committed, nil
 }
 
 func (s *Syncer) listParticipatingNotificationIDs(
@@ -437,8 +556,50 @@ func (s *Syncer) listParticipatingNotificationIDs(
 func (s *Syncer) ensureNotificationBudget(
 	repo RepoRef, client notificationClient, cost int,
 ) error {
+	return s.ensureNotificationBudgetForIdentity(
+		repo, client, cost, repoPlatform(repo) == platform.KindGitHub,
+	)
+}
+
+// ensureNotificationIdentityBudget admits the repository read and, when split
+// authentication adds a permissions overlay, the distinct write credential.
+// Matching identities are checked once because GetRepository then spends one
+// request from one REST pool.
+func (s *Syncer) ensureNotificationIdentityBudget(
+	repo RepoRef, client notificationClient,
+) error {
+	readIdentity, err := s.identityForRepo(repo, false)
+	if err != nil {
+		return err
+	}
+	if err := s.ensureNotificationBudgetForIdentity(
+		repo, client, 1, false,
+	); err != nil {
+		return err
+	}
+	if repoPlatform(repo) != platform.KindGitHub {
+		return nil
+	}
+	writeIdentity, err := s.identityForRepo(repo, true)
+	if err != nil {
+		return fmt.Errorf(
+			"notification sync paused for %s: no startup-resolved write identity",
+			repoHost(repo),
+		)
+	}
+	if writeIdentity == readIdentity {
+		return nil
+	}
+	return s.ensureNotificationBudgetForIdentity(repo, client, 1, true)
+}
+
+func (s *Syncer) ensureNotificationBudgetForIdentity(
+	repo RepoRef,
+	client notificationClient,
+	cost int,
+	writeIdentity bool,
+) error {
 	host := repoHost(repo)
-	writeIdentity := repoPlatform(repo) == platform.KindGitHub
 	if writeIdentity && s.routers[host] != nil {
 		if _, ok := s.WriteIdentityForRepo(repo); !ok {
 			return fmt.Errorf(
@@ -464,8 +625,18 @@ func (s *Syncer) ensureNotificationBudget(
 	// credential -- through the same cadence-cached reserve check every other
 	// background path uses.
 	if s.backgroundReserveExhausted(repo, QuotaResourceREST, writeIdentity) {
+		identityKind := "user"
+		if !writeIdentity {
+			identity, identityErr := s.identityForRepo(repo, false)
+			if identityErr == nil && strings.HasPrefix(
+				identity.Principal, "installation:",
+			) {
+				identityKind = "read"
+			}
+		}
 		return fmt.Errorf(
-			"notification sync paused for %s: user rate reserve exhausted", host,
+			"notification sync paused for %s: %s rate reserve exhausted",
+			host, identityKind,
 		)
 	}
 	bypassReserve := notificationBypassesReadRateReserve(client)
@@ -647,6 +818,35 @@ func (s *Syncer) ProcessQueuedNotificationReads(ctx context.Context, kind platfo
 		if !current {
 			continue
 		}
+		identity := db.RepoIdentity{
+			Platform: notification.Platform, PlatformHost: host,
+			Owner: notification.RepoOwner, Name: notification.RepoName,
+		}
+		var routeFence db.RepositoryRouteFence
+		var routeFound bool
+		if notification.RepoID == nil {
+			routeFence, routeFound, err = s.db.ResolveCurrentRepositoryRouteFence(
+				ctx, identity,
+			)
+		} else {
+			routeFence, routeFound, err = s.db.CurrentRepositoryRouteFence(
+				ctx, identity, *notification.RepoID,
+			)
+		}
+		if err != nil {
+			return fmt.Errorf(
+				"capture repository route before refreshing notification %s: %w",
+				notification.PlatformNotificationID, err,
+			)
+		}
+		if !routeFound {
+			if err := s.reopenLegacyNotificationAckAfterRouteChange(
+				ctx, notification,
+			); err != nil {
+				return err
+			}
+			continue
+		}
 		remote, advanced, err := s.fetchAdvancedNotificationThread(ctx, host, client, notification)
 		if err != nil {
 			// The pre-ack refetch spends the same upstream budget as the
@@ -674,7 +874,9 @@ func (s *Syncer) ProcessQueuedNotificationReads(ctx context.Context, kind platfo
 			// state from the upstream thread, preserving its read/unread flag
 			// so a thread the user already read upstream is not resurrected,
 			// and skip the mark-read so we never ack unseen activity.
-			if err := s.persistReopenedNotification(ctx, host, notification, remote, false); err != nil {
+			if err := s.persistOrReopenNotificationAck(
+				ctx, host, notification, remote, routeFence, false,
+			); err != nil {
 				return err
 			}
 			continue
@@ -687,9 +889,31 @@ func (s *Syncer) ProcessQueuedNotificationReads(ctx context.Context, kind platfo
 				)
 			}
 		}
-		if err := markRead(ctx, notification.PlatformNotificationID); err != nil {
+		releaseRoute, err := s.db.LockRepositoryReconciliationRead(ctx)
+		if err != nil {
+			return err
+		}
+		routeMatches, err := s.db.RepositoryRouteFenceMatchesUnderRepositoryReconciliationRead(
+			ctx, identity, routeFence,
+		)
+		if err != nil {
+			releaseRoute()
+			return err
+		}
+		if !routeMatches {
+			releaseRoute()
+			if err := s.reopenLegacyNotificationAckAfterRouteChange(
+				ctx, notification,
+			); err != nil {
+				return err
+			}
+			continue
+		}
+		markErr := markRead(ctx, notification.PlatformNotificationID)
+		releaseRoute()
+		if markErr != nil {
 			limited, deferErr := s.deferQueuedNotificationAckOnError(
-				ctx, kind, host, bucket, bucketRepos[bucket], notification, err,
+				ctx, kind, host, bucket, bucketRepos[bucket], notification, markErr,
 			)
 			if deferErr != nil {
 				return deferErr
@@ -698,7 +922,7 @@ func (s *Syncer) ProcessQueuedNotificationReads(ctx context.Context, kind platfo
 				exhausted[bucket] = struct{}{}
 				rateLimitErr = fmt.Errorf(
 					"notification read propagation rate limited for %s/%s on %s: %w",
-					notification.RepoOwner, notification.RepoName, host, err,
+					notification.RepoOwner, notification.RepoName, host, markErr,
 				)
 			}
 			continue
@@ -725,7 +949,9 @@ func (s *Syncer) ProcessQueuedNotificationReads(ctx context.Context, kind platfo
 			continue
 		}
 		if advanced {
-			if err := s.persistReopenedNotification(ctx, host, notification, remote, true); err != nil {
+			if err := s.persistOrReopenNotificationAck(
+				ctx, host, notification, remote, routeFence, true,
+			); err != nil {
 				return err
 			}
 			continue
@@ -755,14 +981,15 @@ func (s *Syncer) ackRepoBuckets(
 	byNotification := make(map[int64]string, len(queued))
 	seen := make(map[string]struct{})
 	write := kind == platform.KindGitHub
-	add := func(bucket, owner, name string) {
-		key := bucket + "\x00" + strings.ToLower(owner) + "/" + strings.ToLower(name)
+	add := func(bucket string, repoID int64, owner, name string) {
+		key := bucket + "\x00" + strconv.FormatInt(repoID, 10) + "\x00" +
+			strings.ToLower(owner) + "/" + strings.ToLower(name)
 		if _, ok := seen[key]; ok {
 			return
 		}
 		seen[key] = struct{}{}
 		byBucket[bucket] = append(byBucket[bucket], db.NotificationRepoRef{
-			Owner: owner, Name: name,
+			RepoID: repoID, Owner: owner, Name: name,
 		})
 	}
 	for _, notification := range queued {
@@ -774,7 +1001,11 @@ func (s *Syncer) ackRepoBuckets(
 			continue
 		}
 		byNotification[notification.ID] = bucket
-		add(bucket, notification.RepoOwner, notification.RepoName)
+		var repoID int64
+		if notification.RepoID != nil {
+			repoID = *notification.RepoID
+		}
+		add(bucket, repoID, notification.RepoOwner, notification.RepoName)
 	}
 	// Archived repos stay in the grouping: their queued acknowledgements
 	// (from before archiving) must still be covered by credential-wide
@@ -790,7 +1021,7 @@ func (s *Syncer) ackRepoBuckets(
 		if _, relevant := byBucket[bucket]; !relevant {
 			continue
 		}
-		add(bucket, repo.Owner, repo.Name)
+		add(bucket, repo.RepoID, repo.Owner, repo.Name)
 	}
 	return byBucket, byNotification
 }
@@ -923,8 +1154,19 @@ func (s *Syncer) persistReopenedNotification(
 	host string,
 	notification db.Notification,
 	remote NotificationThread,
+	routeFence db.RepositoryRouteFence,
 	forceUnread bool,
-) error {
+) (bool, error) {
+	if routeFence.RepoID == 0 {
+		return false, nil
+	}
+	observedIdentity := db.RepoIdentity{
+		Platform:     notification.Platform,
+		PlatformHost: host,
+		Owner:        notification.RepoOwner,
+		Name:         notification.RepoName,
+	}
+	observedRepoID := routeFence.RepoID
 	if remote.ID == "" {
 		remote.ID = notification.PlatformNotificationID
 	}
@@ -946,17 +1188,65 @@ func (s *Syncer) persistReopenedNotification(
 		Name:         remote.RepoName,
 		PlatformHost: host,
 	}
-	if notification.RepoID != nil {
-		repo.RepoID = *notification.RepoID
-	}
+	repo.RepoID = observedRepoID
 	refreshed, err := s.notificationToDB(ctx, host, repo, remote, time.Now().UTC())
 	if err != nil {
-		return fmt.Errorf("normalize refreshed notification %s for %s: %w", notification.PlatformNotificationID, host, err)
+		return false, fmt.Errorf("normalize refreshed notification %s for %s: %w", notification.PlatformNotificationID, host, err)
 	}
-	if err := s.db.UpsertNotifications(ctx, []db.Notification{refreshed}); err != nil {
-		return fmt.Errorf("upsert refreshed notification %s for %s: %w", notification.PlatformNotificationID, host, err)
+	committed, err := s.db.UpsertNotificationsIfRouteFence(
+		ctx, []db.Notification{refreshed}, observedIdentity, routeFence,
+	)
+	if err != nil {
+		return false, fmt.Errorf("upsert refreshed notification %s for %s: %w", notification.PlatformNotificationID, host, err)
 	}
-	return nil
+	return committed, nil
+}
+
+func (s *Syncer) persistOrReopenNotificationAck(
+	ctx context.Context,
+	host string,
+	notification db.Notification,
+	remote NotificationThread,
+	routeFence db.RepositoryRouteFence,
+	forceUnread bool,
+) error {
+	committed, err := s.persistReopenedNotification(
+		ctx, host, notification, remote, routeFence, forceUnread,
+	)
+	if err != nil || committed {
+		return err
+	}
+	if notification.RepoID != nil {
+		// A linked repository can be renamed while this provider request is
+		// in flight. Keep its stable-ID acknowledgement queued so the next
+		// pass resolves the repository's current route and retries there.
+		return nil
+	}
+	if forceUnread || remote.Unread {
+		return s.db.ReactivateNotificationAckPropagation(
+			ctx, notification.ID, notification.SourceAckQueuedAt,
+			notification.SourceUpdatedAt,
+		)
+	}
+	return s.db.ReopenNotificationAckPropagation(
+		ctx, notification.ID, notification.SourceAckQueuedAt,
+		notification.SourceUpdatedAt,
+	)
+}
+
+func (s *Syncer) reopenLegacyNotificationAckAfterRouteChange(
+	ctx context.Context,
+	notification db.Notification,
+) error {
+	if notification.RepoID != nil {
+		// ListQueuedNotificationAcks resolves linked rows by repo_id on every
+		// pass, so retaining the queue is sufficient to retry a rename safely.
+		return nil
+	}
+	return s.db.ReopenNotificationAckPropagation(
+		ctx, notification.ID, notification.SourceAckQueuedAt,
+		notification.SourceUpdatedAt,
+	)
 }
 
 func notificationReadRateLimitNextAttempt(err error, now time.Time) (time.Time, bool) {

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -903,8 +903,10 @@ type Syncer struct {
 	pendingPRCommentSyncs    []queuedPRCommentSync
 	pendingIssueCommentSyncs []queuedIssueCommentSync
 
-	afterMergeRequestParentSnapshotCommit func()
-	afterHeadRepoSnapshotRead             func()
+	afterMergeRequestParentSnapshotCommit   func()
+	afterHeadRepoSnapshotRead               func()
+	afterNotificationRepoIdentityReconciled func()
+	beforeCloneRouteValidation              func()
 }
 
 type archiveProviderRequest struct {
@@ -923,11 +925,13 @@ type archiveRepositoryLifecycle interface {
 
 type queuedPRCommentSync struct {
 	repo   RepoRef
+	repoID int64
 	number int
 }
 
 type queuedIssueCommentSync struct {
 	repo   RepoRef
+	repoID int64
 	number int
 }
 
@@ -1533,11 +1537,41 @@ func (s *Syncer) commitIssueParentSnapshot(
 	repo RepoRef,
 	issue *db.Issue,
 ) (int64, int64, bool, error) {
-	releaseReconciliation, err := s.db.LockRepositoryReconciliationRead(ctx)
+	return s.commitIssueParentSnapshotWithRouteFence(ctx, repo, issue, nil)
+}
+
+func (s *Syncer) commitIssueParentSnapshotIfRouteFence(
+	ctx context.Context,
+	repo RepoRef,
+	issue *db.Issue,
+	fence db.RepositoryRouteFence,
+) (int64, int64, bool, error) {
+	return s.commitIssueParentSnapshotWithRouteFence(
+		ctx, repo, issue, &fence,
+	)
+}
+
+func (s *Syncer) commitIssueParentSnapshotWithRouteFence(
+	ctx context.Context,
+	repo RepoRef,
+	issue *db.Issue,
+	fence *db.RepositoryRouteFence,
+) (int64, int64, bool, error) {
+	if fence != nil {
+		ctx = s.db.WithRepositoryRouteFence(
+			ctx, platform.DBRepoIdentity(platformRepoRef(repo)), *fence,
+		)
+	}
+	lockedCtx, releaseReconciliation, err :=
+		s.db.LockRepositoryReconciliationReadForWrite(ctx)
 	if err != nil {
+		if errors.Is(err, db.ErrRepositoryRouteFenceChanged) {
+			return 0, 0, false, nil
+		}
 		return 0, 0, false, err
 	}
 	defer releaseReconciliation()
+	ctx = lockedCtx
 	if err := s.verifyRepoRouteOwnershipUnderReconciliationRead(
 		ctx, repo, issue.RepoID,
 	); err != nil {
@@ -1563,11 +1597,42 @@ func (s *Syncer) CommitMergeRequestParentSnapshot(
 	repo RepoRef,
 	mr *db.MergeRequest,
 ) (int64, int64, bool, error) {
-	releaseReconciliation, err := s.db.LockRepositoryReconciliationRead(ctx)
+	return s.commitMergeRequestParentSnapshotWithRouteFence(ctx, repo, mr, nil)
+}
+
+func (s *Syncer) commitMergeRequestParentSnapshotIfRouteFence(
+	ctx context.Context,
+	repo RepoRef,
+	mr *db.MergeRequest,
+	fence db.RepositoryRouteFence,
+) (int64, int64, bool, error) {
+	return s.commitMergeRequestParentSnapshotWithRouteFence(
+		ctx, repo, mr, &fence,
+	)
+}
+
+func (s *Syncer) commitMergeRequestParentSnapshotWithRouteFence(
+	ctx context.Context,
+	repo RepoRef,
+	mr *db.MergeRequest,
+	fence *db.RepositoryRouteFence,
+) (int64, int64, bool, error) {
+	ctx = withCloneRepositoryIdentity(ctx, repo)
+	if fence != nil {
+		ctx = s.db.WithRepositoryRouteFence(
+			ctx, platform.DBRepoIdentity(platformRepoRef(repo)), *fence,
+		)
+	}
+	lockedCtx, releaseReconciliation, err :=
+		s.db.LockRepositoryReconciliationReadForWrite(ctx)
 	if err != nil {
+		if errors.Is(err, db.ErrRepositoryRouteFenceChanged) {
+			return 0, 0, false, nil
+		}
 		return 0, 0, false, err
 	}
 	defer releaseReconciliation()
+	ctx = lockedCtx
 
 	if err := s.verifyRepoRouteOwnershipUnderReconciliationRead(
 		ctx, repo, mr.RepoID,
@@ -1588,6 +1653,57 @@ func (s *Syncer) CommitMergeRequestParentSnapshot(
 		ctx, repo, mr.RepoID, mr.Number,
 	)
 	return mrID, revision, accepted, err
+}
+
+func (s *Syncer) repositoryRouteFenceMatches(
+	ctx context.Context,
+	repo RepoRef,
+	fence db.RepositoryRouteFence,
+) (bool, error) {
+	releaseReconciliation, err := s.db.LockRepositoryReconciliationRead(ctx)
+	if err != nil {
+		return false, err
+	}
+	defer releaseReconciliation()
+	return s.db.RepositoryRouteFenceMatchesUnderRepositoryReconciliationRead(
+		ctx, platform.DBRepoIdentity(platformRepoRef(repo)), fence,
+	)
+}
+
+func (s *Syncer) markMergeRequestDetailFetchedIfRouteFence(
+	ctx context.Context,
+	repo RepoRef,
+	fence db.RepositoryRouteFence,
+	mrID, revision int64,
+	pending bool,
+	eventMetadataUpdates map[string]string,
+) (bool, error) {
+	ctx = s.db.WithRepositoryRouteFence(
+		ctx, platform.DBRepoIdentity(platformRepoRef(repo)), fence,
+	)
+	applied, err := s.db.MarkMergeRequestDetailFetchedSnapshot(
+		ctx, mrID, revision, pending, eventMetadataUpdates,
+	)
+	if errors.Is(err, db.ErrRepositoryRouteFenceChanged) {
+		return false, nil
+	}
+	return applied, err
+}
+
+func (s *Syncer) markIssueDetailFetchedIfRouteFence(
+	ctx context.Context,
+	repo RepoRef,
+	fence db.RepositoryRouteFence,
+	issueID, revision int64,
+) (bool, error) {
+	ctx = s.db.WithRepositoryRouteFence(
+		ctx, platform.DBRepoIdentity(platformRepoRef(repo)), fence,
+	)
+	applied, err := s.db.MarkIssueDetailFetchedSnapshot(ctx, issueID, revision)
+	if errors.Is(err, db.ErrRepositoryRouteFenceChanged) {
+		return false, nil
+	}
+	return applied, err
 }
 
 // commitIssueCommentsSnapshot binds the child snapshot to the parent issue ID
@@ -1992,7 +2108,16 @@ func (p *gitHubClientProvider) GetRepository(
 	if err != nil {
 		return platform.Repository{}, err
 	}
-	owner := ref.Owner
+	return gitHubPlatformRepository(p.host, ref.Owner, repo), nil
+}
+
+// gitHubPlatformRepository converts a GitHub REST repository into the
+// provider-neutral snapshot, preferring the canonical owner the provider
+// reports over the requested route owner.
+func gitHubPlatformRepository(
+	host, requestedOwner string, repo *gh.Repository,
+) platform.Repository {
+	owner := requestedOwner
 	if repo.GetOwner().GetLogin() != "" {
 		owner = repo.GetOwner().GetLogin()
 	}
@@ -2000,7 +2125,7 @@ func (p *gitHubClientProvider) GetRepository(
 	return platform.Repository{
 		Ref: platform.RepoRef{
 			Platform:           platform.KindGitHub,
-			Host:               p.host,
+			Host:               host,
 			Owner:              canonicalRepoOwner(owner),
 			Name:               canonicalRepoName(repo.GetName()),
 			RepoPath:           canonicalRepoOwner(owner) + "/" + canonicalRepoName(repo.GetName()),
@@ -2024,7 +2149,7 @@ func (p *gitHubClientProvider) GetRepository(
 		DefaultBranch:  repo.GetDefaultBranch(),
 		WebURL:         repo.GetHTMLURL(),
 		CloneURL:       repo.GetCloneURL(),
-	}, nil
+	}
 }
 
 func gitHubViewerCanMerge(repo *gh.Repository) *bool {
@@ -3751,6 +3876,42 @@ func cloneRemoteURL(repo RepoRef) string {
 		repoPath = strings.Trim(repo.Owner+"/"+repo.Name, "/")
 	}
 	return fmt.Sprintf("https://%s/%s.git", repoHost(repo), strings.Trim(repoPath, "/"))
+}
+
+func withCloneRepositoryIdentity(ctx context.Context, repo RepoRef) context.Context {
+	return gitclone.WithRepositoryIdentity(ctx, repo.PlatformExternalID)
+}
+
+func (s *Syncer) ensureCloneForRoute(
+	ctx context.Context,
+	repo RepoRef,
+	repoID int64,
+	routeFence db.RepositoryRouteFence,
+) error {
+	identity := platform.DBRepoIdentity(platformRepoRef(repo))
+	return s.clones.EnsureCloneValidated(
+		ctx,
+		string(repoPlatform(repo)),
+		repoHost(repo),
+		repo.Owner,
+		repo.Name,
+		cloneRemoteURL(repo),
+		func(validationCtx context.Context) error {
+			if s.beforeCloneRouteValidation != nil {
+				s.beforeCloneRouteValidation()
+			}
+			current, found, err := s.db.CurrentRepositoryRouteFence(
+				validationCtx, identity, repoID,
+			)
+			if err != nil {
+				return err
+			}
+			if !found || current != routeFence {
+				return db.ErrRepositoryRouteFenceChanged
+			}
+			return nil
+		},
+	)
 }
 
 func (s *Syncer) optionalGitHubClientFor(repo RepoRef) (Client, bool) {
@@ -5776,7 +5937,7 @@ func (s *Syncer) reconcileArchivedRepos(
 		// same credential is preempted instead of overlapping the
 		// refresh, matching the coordination live repo syncs get.
 		release := s.beginProviderWork(bucket, archive.PriorityNormalIndex)
-		resolved, _, _, err := s.reconcileRepoIdentity(ctx, repo)
+		resolved, _, _, _, _, err := s.reconcileRepoIdentityObservation(ctx, repo)
 		release()
 		if err != nil {
 			slog.Debug("archived repo metadata refresh failed",
@@ -5874,27 +6035,27 @@ func (s *Syncer) syncRepoIdentity(
 	return identity, &resolved, observedAt, nil
 }
 
-func (s *Syncer) reconcileRepoIdentity(
+func (s *Syncer) reconcileRepoIdentityObservation(
 	ctx context.Context,
 	repo RepoRef,
-) (RepoRef, int64, *platform.Repository, error) {
+) (RepoRef, int64, *platform.Repository, time.Time, bool, error) {
 	previousID := int64(0)
 	previous, err := s.db.ResolveActiveRepositoryRoute(
 		ctx, platform.DBRepoIdentity(platformRepoRef(repo)),
 	)
 	if err != nil {
-		return RepoRef{}, 0, nil, err
+		return RepoRef{}, 0, nil, time.Time{}, false, err
 	}
 	if previous != nil {
 		previousID = previous.Repository.ID
 	}
 	identity, resolved, observedAt, err := s.syncRepoIdentity(ctx, repo)
 	if err != nil {
-		return RepoRef{}, 0, nil, err
+		return RepoRef{}, 0, nil, time.Time{}, false, err
 	}
 	entry, accepted, err := s.db.ReconcileRepositoryObservation(ctx, identity, observedAt)
 	if err != nil {
-		return RepoRef{}, 0, nil, err
+		return RepoRef{}, 0, nil, time.Time{}, false, err
 	}
 	if !accepted {
 		// The catalog holds a newer observation, so this snapshot's
@@ -5905,7 +6066,7 @@ func (s *Syncer) reconcileRepoIdentity(
 			// The stale observation resolved to a repository a route
 			// replacement has displaced. Syncing would fetch the reused
 			// route's content into the preserved repository's history.
-			return RepoRef{}, 0, nil, fmt.Errorf(
+			return RepoRef{}, 0, nil, time.Time{}, false, fmt.Errorf(
 				"repository identity observation for %s/%s is stale and "+
 					"resolves to %s catalog entry %d; awaiting revalidation",
 				repo.Owner, repo.Name, entry.Lifecycle, entry.Repository.ID,
@@ -5924,9 +6085,9 @@ func (s *Syncer) reconcileRepoIdentity(
 	if err := s.reconcileArchiveRepositoryIfNeeded(
 		ctx, previousID, entry.Repository.ID,
 	); err != nil {
-		return RepoRef{}, 0, nil, err
+		return RepoRef{}, 0, nil, time.Time{}, false, err
 	}
-	return authoritative, entry.Repository.ID, resolved, nil
+	return authoritative, entry.Repository.ID, resolved, observedAt, accepted, nil
 }
 
 func (s *Syncer) reconcileArchiveRepositoryIfNeeded(
@@ -6177,7 +6338,8 @@ func (s *Syncer) syncRepo(ctx context.Context, repo RepoRef) error {
 		}
 	}
 
-	resolvedRef, repoID, resolvedRepo, err := s.reconcileRepoIdentity(ctx, repo)
+	resolvedRef, repoID, resolvedRepo, observedAt, _, err :=
+		s.reconcileRepoIdentityObservation(ctx, repo)
 	if err != nil {
 		return fmt.Errorf("resolve repo identity %s/%s: %w", repo.Owner, repo.Name, err)
 	}
@@ -6191,15 +6353,51 @@ func (s *Syncer) syncRepo(ctx context.Context, repo RepoRef) error {
 		)
 		return nil
 	}
+	ctx = withCloneRepositoryIdentity(ctx, repo)
+	routeFence, found, err := s.db.CurrentRepositoryRouteFence(
+		ctx, platform.DBRepoIdentity(platformRepoRef(repo)), repoID,
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"capture repository route for %s/%s: %w", repo.Owner, repo.Name, err,
+		)
+	}
+	if !found {
+		return nil
+	}
 
-	s.refreshRepoSettings(ctx, repo, repoID, resolvedRepo)
+	// Settings refresh runs before the route guard is attached: its refetch
+	// branches record fresh identity observations, and reconciliation takes
+	// the reconciliation write lock that a guarded context's transactions
+	// would deadlock against. Its writes carry the fence explicitly. A
+	// failed settings commit aborts the sync: a route-reuse replacement row
+	// must not have items indexed under it while it still advertises the
+	// permissive schema defaults.
+	if err := s.refreshRepoSettings(
+		ctx, repo, repoID, resolvedRepo, observedAt, routeFence,
+	); err != nil {
+		if errors.Is(err, db.ErrRepositoryRouteFenceChanged) {
+			return nil
+		}
+		err = fmt.Errorf(
+			"refresh repo settings for %s/%s: %w", repo.Owner, repo.Name, err,
+		)
+		s.recordAbortedRepoSync(ctx, repo, repoID, routeFence, err)
+		return err
+	}
+
+	ctx = s.db.WithRepositoryRouteFence(
+		ctx, platform.DBRepoIdentity(platformRepoRef(repo)), routeFence,
+	)
 
 	if err := s.db.UpdateRepoSyncStarted(ctx, repoID, time.Now().UTC()); err != nil {
+		if errors.Is(err, db.ErrRepositoryRouteFenceChanged) {
+			return nil
+		}
 		return fmt.Errorf("mark sync started for %s/%s: %w", repo.Owner, repo.Name, err)
 	}
 
 	// Fetch bare clone before PR data so refs are available for merge-base.
-	host := repoHost(repo)
 	cloneFetchOK := false
 	defaultBranch := s.defaultBranchForActivity(ctx, repoID, repo)
 	var previousTip *db.BranchTip
@@ -6216,7 +6414,7 @@ func (s *Syncer) syncRepo(ctx context.Context, repo RepoRef) error {
 		}
 	}
 	if s.clones != nil {
-		if err := s.clones.EnsureClone(ctx, string(repoPlatform(repo)), host, repo.Owner, repo.Name, cloneRemoteURL(repo)); err != nil {
+		if err := s.ensureCloneForRoute(ctx, repo, repoID, routeFence); err != nil {
 			slog.Warn("bare clone fetch failed",
 				"repo", repo.Owner+"/"+repo.Name, "err", err,
 			)
@@ -6235,7 +6433,13 @@ func (s *Syncer) syncRepo(ctx context.Context, repo RepoRef) error {
 	s.syncRepoLabelCatalog(ctx, repo, repoID)
 
 	syncErr := s.indexSyncRepo(ctx, repo, repoID, cloneFetchOK)
+	if errors.Is(syncErr, db.ErrRepositoryRouteFenceChanged) {
+		return nil
+	}
 	if err := s.markClosedLinkedNotificationsDone(ctx); err != nil {
+		if errors.Is(err, db.ErrRepositoryRouteFenceChanged) {
+			return nil
+		}
 		markErr := err
 		if syncErr == nil {
 			syncErr = markErr
@@ -6253,6 +6457,39 @@ func (s *Syncer) syncRepo(ctx context.Context, repo RepoRef) error {
 	}
 
 	return syncErr
+}
+
+// recordAbortedRepoSync surfaces a sync that stopped before item indexing on
+// the repository row's sync health, so the UI reports the failed attempt
+// instead of presenting the previous outcome as current. Best effort under
+// the route fence: a route that changed owners no longer reports this
+// repository's health.
+func (s *Syncer) recordAbortedRepoSync(
+	ctx context.Context,
+	repo RepoRef,
+	repoID int64,
+	routeFence db.RepositoryRouteFence,
+	syncErr error,
+) {
+	statusCtx := s.db.WithRepositoryRouteFence(
+		ctx, platform.DBRepoIdentity(platformRepoRef(repo)), routeFence,
+	)
+	now := time.Now().UTC()
+	if err := s.db.UpdateRepoSyncStarted(statusCtx, repoID, now); err != nil {
+		if !errors.Is(err, db.ErrRepositoryRouteFenceChanged) {
+			slog.Warn("record aborted sync start failed",
+				"repo", repo.Owner+"/"+repo.Name, "err", err,
+			)
+		}
+		return
+	}
+	if err := s.db.UpdateRepoSyncCompleted(
+		statusCtx, repoID, now, syncErr.Error(),
+	); err != nil && !errors.Is(err, db.ErrRepositoryRouteFenceChanged) {
+		slog.Warn("record aborted sync completion failed",
+			"repo", repo.Owner+"/"+repo.Name, "err", err,
+		)
+	}
 }
 
 func (s *Syncer) defaultBranchForActivity(ctx context.Context, repoID int64, repo RepoRef) string {
@@ -6436,113 +6673,227 @@ func dbBranchCommits(
 	return out
 }
 
+// refreshRepoSettings persists provider metadata and merge settings for a
+// reconciled repository. ctx must not carry a repository route guard:
+// refetch branches record fresh identity observations through the
+// reconciliation write lock. All writes go through the observation
+// watermark, so a snapshot that lost to a newer observation is refetched
+// once and then dropped rather than overwriting fresher settings. A nil
+// return means the settings are committed or the provider cannot report
+// them; any other outcome is an error so callers do not index items
+// against unverified merge availability.
 func (s *Syncer) refreshRepoSettings(
 	ctx context.Context,
 	repo RepoRef,
 	repoID int64,
 	resolvedRepo *platform.Repository,
-) {
+	observedAt time.Time,
+	routeFence db.RepositoryRouteFence,
+) error {
 	if resolvedRepo != nil {
-		s.updateRepoSettingsFromProviderRepo(ctx, repoID, *resolvedRepo)
-		return
+		applied, err := s.persistRepoSettingsObservation(
+			ctx, repo, repoID, observedAt, *resolvedRepo, routeFence,
+		)
+		if err != nil {
+			return err
+		}
+		if applied {
+			return nil
+		}
+		// The snapshot lost to a newer observation between capture and
+		// commit; fall through and fetch fresh settings.
 	}
 
 	if client, ok := s.optionalGitHubClientFor(repo); ok {
+		observedAt := time.Now().UTC()
 		ghRepo, err := client.GetRepository(ctx, repo.Owner, repo.Name)
 		if err != nil {
-			slog.Warn("get repo settings failed",
-				"repo", repo.Owner+"/"+repo.Name, "err", err,
-			)
-			return
+			return fmt.Errorf("get repo settings: %w", err)
 		}
-		// This branch is the only settings refresh most GitHub repos ever
-		// take (resolution pre-fills the platform repo id, so resolvedRepo
-		// is nil), so it must persist provider metadata too — otherwise a
-		// newly discovered repo keeps an empty default branch and the
-		// worktree diff sampler degrades to a bare HEAD diff.
-		if err := s.db.UpdateRepoProviderMetadata(ctx, repoID, db.RepoProviderMetadata{
-			PlatformRepoID: ghRepo.GetNodeID(),
-			WebURL:         ghRepo.GetHTMLURL(),
-			CloneURL:       ghRepo.GetCloneURL(),
-			DefaultBranch:  ghRepo.GetDefaultBranch(),
-		}); err != nil {
-			slog.Warn("update repo provider metadata failed",
-				"repo", repo.Owner+"/"+repo.Name, "err", err,
-			)
-		}
-		if canMerge := gitHubViewerCanMerge(ghRepo); canMerge != nil {
-			_ = s.db.UpdateRepoSettings(ctx, repoID,
-				ghRepo.GetAllowSquashMerge(),
-				ghRepo.GetAllowMergeCommit(),
-				ghRepo.GetAllowRebaseMerge(),
-				*canMerge,
-			)
-			return
-		}
-		_ = s.db.UpdateRepoMergeSettings(ctx, repoID,
-			ghRepo.GetAllowSquashMerge(),
-			ghRepo.GetAllowMergeCommit(),
-			ghRepo.GetAllowRebaseMerge(),
+		return s.persistRefetchedRepoSettings(
+			ctx, repo, repoID, observedAt,
+			gitHubPlatformRepository(repoHost(repo), repo.Owner, ghRepo),
+			routeFence,
 		)
-		return
 	}
 
 	reader, err := s.clients.RepositoryReader(repoPlatform(repo), repoHost(repo))
 	if err != nil {
 		if errors.Is(err, platform.ErrUnsupportedCapability) || errors.Is(err, platform.ErrProviderNotConfigured) {
-			return
+			return nil
 		}
-		slog.Warn("get repo settings reader failed",
-			"repo", repo.Owner+"/"+repo.Name, "err", err,
-		)
-		return
+		return fmt.Errorf("resolve repo settings reader: %w", err)
 	}
+	observedAt = time.Now().UTC()
 	providerRepo, err := reader.GetRepository(ctx, platformRepoRef(repo))
 	if err != nil {
-		slog.Warn("get repo settings failed",
-			"repo", repo.Owner+"/"+repo.Name, "err", err,
-		)
-		return
+		return fmt.Errorf("get repo settings: %w", err)
 	}
-	s.updateRepoSettingsFromProviderRepo(ctx, repoID, providerRepo)
+	return s.persistRefetchedRepoSettings(
+		ctx, repo, repoID, observedAt, providerRepo, routeFence,
+	)
 }
 
-func (s *Syncer) updateRepoSettingsFromProviderRepo(
+// reconcileRepoForDirectSync resolves repository identity for a direct item
+// sync and persists the verified provider snapshot under the current route
+// fence. The archive lifecycle records its own identity observations between
+// reconciliation and this write (route changes, first encounters), which
+// advances the observation watermark and rejects the held snapshot as stale;
+// re-resolving fetches a fresh snapshot with a fresh timestamp so settings
+// still commit instead of leaving a replacement row on permissive schema
+// defaults. found=false reports a vanished route; callers skip the sync unit.
+func (s *Syncer) reconcileRepoForDirectSync(
+	ctx context.Context,
+	repo RepoRef,
+) (RepoRef, int64, db.RepositoryRouteFence, bool, error) {
+	var zero db.RepositoryRouteFence
+	for range 2 {
+		resolvedRef, repoID, providerRepo, observedAt, accepted, err :=
+			s.reconcileRepoIdentityObservation(ctx, repo)
+		if err != nil {
+			return RepoRef{}, 0, zero, false, fmt.Errorf(
+				"resolve repo identity %s/%s: %w", repo.Owner, repo.Name, err,
+			)
+		}
+		if !accepted {
+			// The catalog rejected this observation for a newer one, so the
+			// provider snapshot was discarded and the row's settings are
+			// unverified. This is not the same as a provider without
+			// repository reading: retry rather than sync the item against
+			// possibly default merge availability.
+			repo = resolvedRef
+			continue
+		}
+		routeFence, found, err := s.db.CurrentRepositoryRouteFence(
+			ctx, platform.DBRepoIdentity(platformRepoRef(resolvedRef)), repoID,
+		)
+		if err != nil {
+			return RepoRef{}, 0, zero, false, fmt.Errorf(
+				"capture repository route for %s/%s: %w",
+				resolvedRef.Owner, resolvedRef.Name, err,
+			)
+		}
+		if !found {
+			return resolvedRef, repoID, zero, false, nil
+		}
+		if providerRepo == nil {
+			return resolvedRef, repoID, routeFence, true, nil
+		}
+		applied, err := s.persistRepoSettingsObservation(
+			ctx, resolvedRef, repoID, observedAt, *providerRepo, routeFence,
+		)
+		if err != nil {
+			if errors.Is(err, db.ErrRepositoryRouteFenceChanged) {
+				return RepoRef{}, 0, zero, false, err
+			}
+			return RepoRef{}, 0, zero, false, fmt.Errorf(
+				"persist repository settings for %s/%s: %w",
+				resolvedRef.Owner, resolvedRef.Name, err,
+			)
+		}
+		if applied {
+			return resolvedRef, repoID, routeFence, true, nil
+		}
+		repo = resolvedRef
+	}
+	return RepoRef{}, 0, zero, false, fmt.Errorf(
+		"repository settings observation for %s/%s kept losing to newer observations",
+		repo.Owner, repo.Name,
+	)
+}
+
+// persistRepoSettingsObservation commits a provider repository snapshot under
+// both the observation watermark and the captured route fence. applied=false
+// with a nil error means the snapshot lost to a newer observation, whose
+// writer carries fresher data. Errors — including
+// db.ErrRepositoryRouteFenceChanged — surface to the caller: a failed write
+// can leave a just-reconciled replacement row on its permissive schema
+// defaults, so item syncs must not continue as if settings were committed.
+func (s *Syncer) persistRepoSettingsObservation(
+	ctx context.Context,
+	repo RepoRef,
+	repoID int64,
+	observedAt time.Time,
+	providerRepo platform.Repository,
+	routeFence db.RepositoryRouteFence,
+) (bool, error) {
+	fencedCtx := s.db.WithRepositoryRouteFence(
+		ctx, platform.DBRepoIdentity(platformRepoRef(repo)), routeFence,
+	)
+	return s.updateRepoSettingsFromProviderObservation(
+		fencedCtx, repoID, observedAt, providerRepo,
+	)
+}
+
+// persistRefetchedRepoSettings records a freshly fetched repository snapshot
+// as its own identity observation so its settings commit under the
+// observation watermark. A snapshot whose identity no longer resolves to
+// repoID reports a changed route fence; one that keeps losing the watermark
+// is an error, because the repository's settings remain unverified.
+func (s *Syncer) persistRefetchedRepoSettings(
+	ctx context.Context,
+	repo RepoRef,
+	repoID int64,
+	observedAt time.Time,
+	providerRepo platform.Repository,
+	routeFence db.RepositoryRouteFence,
+) error {
+	entry, accepted, err := s.db.ReconcileRepositoryObservation(
+		ctx, platform.DBRepositoryIdentity(providerRepo), observedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("record repo settings observation: %w", err)
+	}
+	if entry.Repository.ID != repoID {
+		return fmt.Errorf(
+			"repo settings observation: %w for %s/%s",
+			db.ErrRepositoryRouteFenceChanged, repo.Owner, repo.Name,
+		)
+	}
+	if accepted {
+		applied, err := s.persistRepoSettingsObservation(
+			ctx, repo, repoID, observedAt, providerRepo, routeFence,
+		)
+		if err != nil {
+			return err
+		}
+		if applied {
+			return nil
+		}
+	}
+	return fmt.Errorf(
+		"repository settings observation for %s/%s kept losing to newer observations",
+		repo.Owner, repo.Name,
+	)
+}
+
+func (s *Syncer) updateRepoSettingsFromProviderObservation(
 	ctx context.Context,
 	repoID int64,
+	observedAt time.Time,
 	repo platform.Repository,
-) {
-	if err := s.db.UpdateRepoProviderMetadata(ctx, repoID, db.RepoProviderMetadata{
-		PlatformRepoID: repo.PlatformExternalID,
-		WebURL:         repo.WebURL,
-		CloneURL:       repo.CloneURL,
-		DefaultBranch:  repo.DefaultBranch,
-	}); err != nil {
-		slog.Warn("update repo provider metadata failed",
-			"repo", repo.Ref.DisplayName(), "err", err,
-		)
-	}
+) (bool, error) {
+	var settings *db.RepoMergeSettings
 	if repo.MergeSettings != nil {
-		settings := repo.MergeSettings
-		if repo.ViewerCanMerge == nil {
-			_ = s.db.UpdateRepoMergeSettings(ctx, repoID,
-				settings.AllowSquashMerge,
-				settings.AllowMergeCommit,
-				settings.AllowRebaseMerge,
-			)
-			return
+		settings = &db.RepoMergeSettings{
+			AllowSquashMerge: repo.MergeSettings.AllowSquashMerge,
+			AllowMergeCommit: repo.MergeSettings.AllowMergeCommit,
+			AllowRebaseMerge: repo.MergeSettings.AllowRebaseMerge,
 		}
-		_ = s.db.UpdateRepoSettings(ctx, repoID,
-			settings.AllowSquashMerge,
-			settings.AllowMergeCommit,
-			settings.AllowRebaseMerge,
-			*repo.ViewerCanMerge,
-		)
-		return
 	}
-	if repo.ViewerCanMerge != nil {
-		_ = s.db.UpdateRepoViewerCanMerge(ctx, repoID, *repo.ViewerCanMerge)
-	}
+	return s.db.UpdateRepoProviderObservation(
+		ctx,
+		repoID,
+		observedAt,
+		db.RepoProviderMetadata{
+			PlatformRepoID: repo.PlatformExternalID,
+			WebURL:         repo.WebURL,
+			CloneURL:       repo.CloneURL,
+			DefaultBranch:  repo.DefaultBranch,
+		},
+		settings,
+		repo.ViewerCanMerge,
+	)
 }
 
 func (s *Syncer) syncRepoLabelCatalog(ctx context.Context, repo RepoRef, repoID int64) {
@@ -6584,21 +6935,48 @@ func (s *Syncer) RefreshRepoLabelCatalog(ctx context.Context, repo db.Repo) erro
 		WebURL:             repo.WebURL,
 		DefaultBranch:      repo.DefaultBranch,
 	}
+	identity := platform.DBRepoIdentity(platformRepoRef(ref))
+	routeFence, found, err := s.db.CurrentRepositoryRouteFence(ctx, identity, repo.ID)
+	if err != nil {
+		return fmt.Errorf("capture repository route for label catalog: %w", err)
+	}
+	if !found {
+		return nil
+	}
+	ctx = s.db.WithRepositoryRouteFence(ctx, identity, routeFence)
 	checkedAt := time.Now().UTC()
 	reader, err := s.labelReaderFor(ref)
 	if err != nil {
-		_ = s.db.UpdateRepoLabelCatalogCheck(ctx, repo.ID, checkedAt, err.Error())
+		if updateErr := s.db.UpdateRepoLabelCatalogCheck(ctx, repo.ID, checkedAt, err.Error()); updateErr != nil {
+			if errors.Is(updateErr, db.ErrRepositoryRouteFenceChanged) {
+				return nil
+			}
+			return errors.Join(err, updateErr)
+		}
 		return err
 	}
 	catalog, err := reader.ListLabels(ctx, platformRepoRef(ref))
 	if err != nil {
-		_ = s.db.UpdateRepoLabelCatalogCheck(ctx, repo.ID, checkedAt, err.Error())
+		if updateErr := s.db.UpdateRepoLabelCatalogCheck(ctx, repo.ID, checkedAt, err.Error()); updateErr != nil {
+			if errors.Is(updateErr, db.ErrRepositoryRouteFenceChanged) {
+				return nil
+			}
+			return errors.Join(err, updateErr)
+		}
 		return err
 	}
 	if catalog.NotModified {
-		return s.db.MarkRepoLabelCatalogSynced(ctx, repo.ID, checkedAt)
+		err := s.db.MarkRepoLabelCatalogSynced(ctx, repo.ID, checkedAt)
+		if errors.Is(err, db.ErrRepositoryRouteFenceChanged) {
+			return nil
+		}
+		return err
 	}
-	return s.db.ReplaceRepoLabelCatalog(ctx, repo.ID, platform.DBLabels(catalog.Labels, checkedAt), checkedAt)
+	err = s.db.ReplaceRepoLabelCatalog(ctx, repo.ID, platform.DBLabels(catalog.Labels, checkedAt), checkedAt)
+	if errors.Is(err, db.ErrRepositoryRouteFenceChanged) {
+		return nil
+	}
+	return err
 }
 
 const repoOverviewTimelineLimit = 30
@@ -7815,7 +8193,10 @@ func (s *Syncer) indexUpsertMergeRequest(
 		existing.DiffBaseSHA == normalized.PlatformBaseSHA &&
 		existing.MergeBaseSHA != ""
 	if s.clones != nil && cloneFetchOK && !snapshotCurrent {
-		if err := s.syncProviderMRDiff(ctx, repo, mrID, revision, mr.Number, normalized, false); err != nil {
+		if err := s.syncProviderMRDiff(
+			ctx, repo, repoID, mrID, revision, mr.Number,
+			normalized, false, db.RepositoryRouteFence{},
+		); err != nil {
 			if errors.Is(err, errParentSnapshotAdvanced) {
 				return nil
 			}
@@ -7829,7 +8210,7 @@ func (s *Syncer) indexUpsertMergeRequest(
 	if existing != nil &&
 		existing.DetailFetchedAt != nil &&
 		existing.UpdatedAt.Equal(normalized.UpdatedAt) {
-		s.queuePRCommentSync(repo, existing.Number)
+		s.queuePRCommentSync(repo, existing.RepoID, existing.Number)
 	}
 
 	return nil
@@ -8023,7 +8404,7 @@ func (s *Syncer) indexUpsertMR(
 	if existing != nil &&
 		existing.DetailFetchedAt != nil &&
 		existing.UpdatedAt.Equal(normalized.UpdatedAt) {
-		s.queuePRCommentSync(repo, existing.Number)
+		s.queuePRCommentSync(repo, existing.RepoID, existing.Number)
 	}
 
 	return nil
@@ -8139,22 +8520,35 @@ func (s *Syncer) resetPendingCommentSyncs() {
 	s.pendingIssueCommentSyncs = nil
 }
 
-func (s *Syncer) queuePRCommentSync(repo RepoRef, number int) {
+func (s *Syncer) queuePRCommentSync(repo RepoRef, repoID int64, number int) {
 	s.commentRefreshMu.Lock()
 	defer s.commentRefreshMu.Unlock()
 	s.pendingPRCommentSyncs = append(s.pendingPRCommentSyncs, queuedPRCommentSync{
-		repo:   repo,
+		repo: repo, repoID: repoID,
 		number: number,
 	})
 }
 
-func (s *Syncer) queueIssueCommentSync(repo RepoRef, number int) {
+func (s *Syncer) queueIssueCommentSync(repo RepoRef, repoID int64, number int) {
 	s.commentRefreshMu.Lock()
 	defer s.commentRefreshMu.Unlock()
 	s.pendingIssueCommentSyncs = append(s.pendingIssueCommentSyncs, queuedIssueCommentSync{
-		repo:   repo,
+		repo: repo, repoID: repoID,
 		number: number,
 	})
+}
+
+func (s *Syncer) commentRefreshRouteContext(
+	ctx context.Context,
+	repo RepoRef,
+	repoID int64,
+) (context.Context, bool, error) {
+	identity := platform.DBRepoIdentity(platformRepoRef(repo))
+	fence, found, err := s.db.CurrentRepositoryRouteFence(ctx, identity, repoID)
+	if err != nil || !found {
+		return ctx, found, err
+	}
+	return s.db.WithRepositoryRouteFence(ctx, identity, fence), true, nil
 }
 
 func (s *Syncer) drainPendingCommentSyncs(
@@ -8183,6 +8577,20 @@ func (s *Syncer) drainPendingCommentSyncs(
 			eligibleHosts[bucket] = false
 			continue
 		}
+		refreshCtx, found, err := s.commentRefreshRouteContext(
+			ctx, item.repo, item.repoID,
+		)
+		if err != nil {
+			slog.Warn("comment refresh: capture PR repo route failed",
+				"repo", item.repo.Owner+"/"+item.repo.Name,
+				"number", item.number,
+				"err", err,
+			)
+			continue
+		}
+		if !found {
+			continue
+		}
 		client, err := s.clientFor(item.repo)
 		if err != nil {
 			slog.Warn("comment refresh: resolve client failed",
@@ -8192,19 +8600,8 @@ func (s *Syncer) drainPendingCommentSyncs(
 			)
 			continue
 		}
-		repoRow, err := s.db.GetRepoByIdentity(
-			ctx, platform.DBRepoIdentity(platformRepoRef(item.repo)),
-		)
-		if err != nil || repoRow == nil {
-			slog.Warn("comment refresh: get PR repo failed",
-				"repo", item.repo.Owner+"/"+item.repo.Name,
-				"number", item.number,
-				"err", err,
-			)
-			continue
-		}
 		pr, err := s.db.GetMergeRequestByRepoIDAndNumber(
-			ctx, repoRow.ID, item.number,
+			refreshCtx, item.repoID, item.number,
 		)
 		if err != nil {
 			slog.Warn("comment refresh: get PR failed",
@@ -8215,12 +8612,14 @@ func (s *Syncer) drainPendingCommentSyncs(
 			continue
 		}
 		probe, due := s.beginRepositoryFeatureProbe(
-			ctx, item.repo, platform.RepositoryFeatureMergeRequests,
+			refreshCtx, item.repo, platform.RepositoryFeatureMergeRequests,
 		)
 		if !due {
 			continue
 		}
-		providerAttempted, _ := s.refreshPRCommentsForItem(ctx, client, item.repo, pr)
+		providerAttempted, _ := s.refreshPRCommentsForItem(
+			refreshCtx, client, item.repo, pr,
+		)
 		if providerAttempted {
 			probe.release()
 		} else {
@@ -8243,6 +8642,20 @@ func (s *Syncer) drainPendingCommentSyncs(
 			eligibleHosts[bucket] = false
 			continue
 		}
+		refreshCtx, found, err := s.commentRefreshRouteContext(
+			ctx, item.repo, item.repoID,
+		)
+		if err != nil {
+			slog.Warn("comment refresh: capture issue repo route failed",
+				"repo", item.repo.Owner+"/"+item.repo.Name,
+				"number", item.number,
+				"err", err,
+			)
+			continue
+		}
+		if !found {
+			continue
+		}
 		client, err := s.clientFor(item.repo)
 		if err != nil {
 			slog.Warn("comment refresh: resolve client failed",
@@ -8252,19 +8665,8 @@ func (s *Syncer) drainPendingCommentSyncs(
 			)
 			continue
 		}
-		repoRow, err := s.db.GetRepoByIdentity(
-			ctx, platform.DBRepoIdentity(platformRepoRef(item.repo)),
-		)
-		if err != nil || repoRow == nil {
-			slog.Warn("comment refresh: get issue repo failed",
-				"repo", item.repo.Owner+"/"+item.repo.Name,
-				"number", item.number,
-				"err", err,
-			)
-			continue
-		}
 		issue, err := s.db.GetIssueByRepoIDAndNumber(
-			ctx, repoRow.ID, item.number,
+			refreshCtx, item.repoID, item.number,
 		)
 		if err != nil {
 			slog.Warn("comment refresh: get issue failed",
@@ -8275,12 +8677,14 @@ func (s *Syncer) drainPendingCommentSyncs(
 			continue
 		}
 		probe, due := s.beginRepositoryFeatureProbe(
-			ctx, item.repo, platform.RepositoryFeatureIssues,
+			refreshCtx, item.repo, platform.RepositoryFeatureIssues,
 		)
 		if !due {
 			continue
 		}
-		providerAttempted, _ := s.refreshIssueCommentsForItem(ctx, client, item.repo, issue)
+		providerAttempted, _ := s.refreshIssueCommentsForItem(
+			refreshCtx, client, item.repo, issue,
+		)
 		if providerAttempted {
 			probe.release()
 		} else {
@@ -8887,22 +9291,46 @@ func (s *Syncer) fetchMRDetail(
 	number int,
 	cloneFetchOK bool,
 ) (int, error) {
+	calls, err := s.fetchMRDetailWithRouteFence(
+		ctx, repo, repoID, number, cloneFetchOK,
+	)
+	if errors.Is(err, db.ErrRepositoryRouteFenceChanged) {
+		return calls, nil
+	}
+	return calls, err
+}
+
+func (s *Syncer) fetchMRDetailWithRouteFence(
+	ctx context.Context,
+	repo RepoRef,
+	repoID int64,
+	number int,
+	cloneFetchOK bool,
+) (int, error) {
+	ctx = withCloneRepositoryIdentity(ctx, repo)
 	calls := 0
 	mrReader, err := s.mergeRequestReaderFor(repo)
 	if err != nil {
 		return calls, fmt.Errorf("resolve merge request reader for %s/%s: %w", repo.Owner, repo.Name, err)
 	}
+	routeFence, _, err := s.db.CurrentRepositoryRouteFence(
+		ctx, platform.DBRepoIdentity(platformRepoRef(repo)), repoID,
+	)
+	if err != nil {
+		return calls, fmt.Errorf("capture repository route for %s/%s: %w", repo.Owner, repo.Name, err)
+	}
 	if _, ok := mrReader.(interface {
 		GetGitHubPullRequest(context.Context, platform.RepoRef, int) (*gh.PullRequest, platform.MergeRequest, error)
 	}); !ok {
-		return s.fetchProviderMRDetail(ctx, mrReader, repo, repoID, number)
+		return s.fetchProviderMRDetail(
+			ctx, mrReader, repo, repoID, number, routeFence,
+		)
 	}
 
 	client, err := s.clientFor(repo)
 	if err != nil {
 		return calls, fmt.Errorf("resolve client for %s/%s: %w", repo.Owner, repo.Name, err)
 	}
-
 	existing, err := s.db.GetMergeRequestByRepoIDAndNumber(
 		ctx, repoID, number,
 	)
@@ -8929,7 +9357,7 @@ func (s *Syncer) fetchMRDetail(
 	if err == nil && fullPR == nil {
 		if notModified && existing != nil {
 			return s.markUnchangedMRDetailFetched(
-				ctx, repo, repoID, number, existing, calls,
+				ctx, repo, repoID, number, existing, routeFence, calls,
 			)
 		}
 		err = fmt.Errorf("client returned nil pull request")
@@ -8955,7 +9383,9 @@ func (s *Syncer) fetchMRDetail(
 		calls++ // GetUser
 	}
 
-	mrID, revision, accepted, err := s.CommitMergeRequestParentSnapshot(ctx, repo, normalized)
+	mrID, revision, accepted, err := s.commitMergeRequestParentSnapshotIfRouteFence(
+		ctx, repo, normalized, routeFence,
+	)
 	if err != nil {
 		return calls, fmt.Errorf(
 			"upsert MR #%d: %w", number, err,
@@ -8964,8 +9394,14 @@ func (s *Syncer) fetchMRDetail(
 	if !accepted {
 		return calls, nil
 	}
+	ctx = s.db.WithRepositoryRouteFence(
+		ctx, platform.DBRepoIdentity(platformRepoRef(repo)), routeFence,
+	)
 
 	if err := s.db.EnsureKanbanState(ctx, mrID); err != nil {
+		if errors.Is(err, db.ErrRepositoryRouteFenceChanged) {
+			return calls, nil
+		}
 		return calls, fmt.Errorf(
 			"ensure kanban state for MR #%d: %w", number, err,
 		)
@@ -9065,7 +9501,9 @@ func (s *Syncer) fetchMRDetail(
 		pending = ciHasPending(freshMR.CIChecksJSON)
 	}
 
-	detailApplied, err := s.db.MarkMergeRequestDetailFetchedSnapshot(ctx, mrID, revision, pending, nil)
+	detailApplied, err := s.markMergeRequestDetailFetchedIfRouteFence(
+		ctx, repo, routeFence, mrID, revision, pending, nil,
+	)
 	if err != nil {
 		return calls, fmt.Errorf(
 			"mark detail fetched for MR #%d: %w", number, err,
@@ -9091,9 +9529,9 @@ func (s *Syncer) fetchMRDetail(
 	}
 
 	if newETag != "" {
-		if err := s.db.UpsertHTTPEtag(
-			ctx, string(repoPlatform(repo)), repoHost(repo),
-			repo.Owner, repo.Name, "pull_request", number, newETag,
+		if _, err := s.db.UpsertHTTPEtagIfRouteFence(
+			ctx, platform.DBRepoIdentity(platformRepoRef(repo)), routeFence,
+			"pull_request", number, newETag,
 		); err != nil {
 			slog.Warn("persist pull request ETag failed",
 				"repo", repo.Owner+"/"+repo.Name,
@@ -9142,8 +9580,19 @@ func (s *Syncer) markUnchangedMRDetailFetched(
 	repoID int64,
 	number int,
 	existing *db.MergeRequest,
+	routeFence db.RepositoryRouteFence,
 	calls int,
 ) (int, error) {
+	matches, err := s.repositoryRouteFenceMatches(ctx, repo, routeFence)
+	if err != nil {
+		return calls, err
+	}
+	if !matches {
+		return calls, nil
+	}
+	ctx = s.db.WithRepositoryRouteFence(
+		ctx, platform.DBRepoIdentity(platformRepoRef(repo)), routeFence,
+	)
 	pending := existing.CIHadPending
 	if existing.CIHadPending && existing.PlatformHeadSHA != "" {
 		ciApplied, err := s.refreshCIStatusSnapshot(
@@ -9170,8 +9619,9 @@ func (s *Syncer) markUnchangedMRDetailFetched(
 	metadataUpdates := s.computeCommitLiveness(
 		ctx, repo, existing.ID, livenessHeadForRound(existing, existing), nil,
 	)
-	detailApplied, err := s.db.MarkMergeRequestDetailFetchedSnapshot(
-		ctx, existing.ID, existing.SnapshotRevision, pending, metadataUpdates,
+	detailApplied, err := s.markMergeRequestDetailFetchedIfRouteFence(
+		ctx, repo, routeFence, existing.ID, existing.SnapshotRevision, pending,
+		metadataUpdates,
 	)
 	if err != nil {
 		return calls, fmt.Errorf("mark unchanged detail fetched for MR #%d: %w", number, err)
@@ -9199,6 +9649,7 @@ func (s *Syncer) fetchProviderMRDetail(
 	repo RepoRef,
 	repoID int64,
 	number int,
+	routeFence db.RepositoryRouteFence,
 ) (int, error) {
 	calls := 0
 	mrReader, err := s.mergeRequestReaderFor(repo)
@@ -9225,7 +9676,9 @@ func (s *Syncer) fetchProviderMRDetail(
 	}
 	preserveMergeableStateIfOmitted(normalized, existing)
 
-	mrID, revision, accepted, err := s.CommitMergeRequestParentSnapshot(ctx, repo, normalized)
+	mrID, revision, accepted, err := s.commitMergeRequestParentSnapshotIfRouteFence(
+		ctx, repo, normalized, routeFence,
+	)
 	if err != nil {
 		return calls, fmt.Errorf(
 			"upsert MR #%d: %w", number, err,
@@ -9234,7 +9687,13 @@ func (s *Syncer) fetchProviderMRDetail(
 	if !accepted {
 		return calls, nil
 	}
+	ctx = s.db.WithRepositoryRouteFence(
+		ctx, platform.DBRepoIdentity(platformRepoRef(repo)), routeFence,
+	)
 	if err := s.db.EnsureKanbanState(ctx, mrID); err != nil {
+		if errors.Is(err, db.ErrRepositoryRouteFenceChanged) {
+			return calls, nil
+		}
 		return calls, fmt.Errorf(
 			"ensure kanban state for MR #%d: %w", number, err,
 		)
@@ -9255,7 +9714,9 @@ func (s *Syncer) fetchProviderMRDetail(
 		return calls, fmt.Errorf("persist merged lifecycle event for MR #%d: %w", number, err)
 	}
 
-	detailApplied, err := s.db.MarkMergeRequestDetailFetchedSnapshot(ctx, mrID, revision, pending, nil)
+	detailApplied, err := s.markMergeRequestDetailFetchedIfRouteFence(
+		ctx, repo, routeFence, mrID, revision, pending, nil,
+	)
 	if err != nil {
 		return calls, fmt.Errorf("mark detail fetched for MR #%d: %w", number, err)
 	}
@@ -9440,10 +9901,18 @@ func (s *Syncer) fetchIssueDetail(
 	if err != nil {
 		return calls, fmt.Errorf("resolve issue reader for %s/%s: %w", repo.Owner, repo.Name, err)
 	}
+	routeFence, _, err := s.db.CurrentRepositoryRouteFence(
+		ctx, platform.DBRepoIdentity(platformRepoRef(repo)), repoID,
+	)
+	if err != nil {
+		return calls, fmt.Errorf("capture repository route for %s/%s: %w", repo.Owner, repo.Name, err)
+	}
 	if _, ok := issueReader.(interface {
 		GetGitHubIssue(context.Context, platform.RepoRef, int) (*gh.Issue, error)
 	}); !ok {
-		return s.fetchProviderIssueDetail(ctx, issueReader, repo, repoID, number)
+		return s.fetchProviderIssueDetail(
+			ctx, issueReader, repo, repoID, number, routeFence,
+		)
 	}
 
 	client, err := s.clientFor(repo)
@@ -9479,8 +9948,8 @@ func (s *Syncer) fetchIssueDetail(
 			if existing == nil {
 				return calls, fmt.Errorf("mark unchanged detail fetched for issue #%d: issue is missing", number)
 			}
-			detailApplied, markErr := s.db.MarkIssueDetailFetchedSnapshot(
-				ctx, existing.ID, existing.SnapshotRevision,
+			detailApplied, markErr := s.markIssueDetailFetchedIfRouteFence(
+				ctx, repo, routeFence, existing.ID, existing.SnapshotRevision,
 			)
 			if markErr != nil {
 				return calls, fmt.Errorf(
@@ -9503,7 +9972,9 @@ func (s *Syncer) fetchIssueDetail(
 	if err != nil {
 		return calls, fmt.Errorf("normalize issue #%d: %w", number, err)
 	}
-	issueID, revision, accepted, err := s.commitIssueParentSnapshot(ctx, repo, normalized)
+	issueID, revision, accepted, err := s.commitIssueParentSnapshotIfRouteFence(
+		ctx, repo, normalized, routeFence,
+	)
 	if err != nil {
 		return calls, fmt.Errorf(
 			"upsert issue #%d: %w", number, err,
@@ -9512,6 +9983,9 @@ func (s *Syncer) fetchIssueDetail(
 	if !accepted {
 		return calls, nil
 	}
+	ctx = s.db.WithRepositoryRouteFence(
+		ctx, platform.DBRepoIdentity(platformRepoRef(repo)), routeFence,
+	)
 
 	if err := s.refreshIssueTimeline(
 		ctx, repo, issueID, revision, ghIssue,
@@ -9520,11 +9994,16 @@ func (s *Syncer) fetchIssueDetail(
 		if errors.Is(err, errParentSnapshotAdvanced) {
 			return calls, nil
 		}
+		if errors.Is(err, db.ErrRepositoryRouteFenceChanged) {
+			return calls, nil
+		}
 		return calls, err
 	}
 	calls++ // comments
 
-	detailApplied, err := s.db.MarkIssueDetailFetchedSnapshot(ctx, issueID, revision)
+	detailApplied, err := s.markIssueDetailFetchedIfRouteFence(
+		ctx, repo, routeFence, issueID, revision,
+	)
 	if err != nil {
 		return calls, fmt.Errorf(
 			"mark detail fetched for issue #%d: %w", number, err,
@@ -9535,9 +10014,9 @@ func (s *Syncer) fetchIssueDetail(
 	}
 
 	if newETag != "" {
-		if err := s.db.UpsertHTTPEtag(
-			ctx, string(repoPlatform(repo)), repoHost(repo),
-			repo.Owner, repo.Name, "issue", number, newETag,
+		if _, err := s.db.UpsertHTTPEtagIfRouteFence(
+			ctx, platform.DBRepoIdentity(platformRepoRef(repo)), routeFence,
+			"issue", number, newETag,
 		); err != nil {
 			slog.Warn("persist issue ETag failed",
 				"repo", repo.Owner+"/"+repo.Name,
@@ -9590,6 +10069,7 @@ func (s *Syncer) fetchProviderIssueDetail(
 	repo RepoRef,
 	repoID int64,
 	number int,
+	routeFence db.RepositoryRouteFence,
 ) (int, error) {
 	calls := 0
 	issueReader, err := s.issueReaderFor(repo)
@@ -9613,7 +10093,9 @@ func (s *Syncer) fetchProviderIssueDetail(
 	if existing != nil {
 		normalized.CommentCount = existing.CommentCount
 	}
-	issueID, revision, accepted, err := s.commitIssueParentSnapshot(ctx, repo, normalized)
+	issueID, revision, accepted, err := s.commitIssueParentSnapshotIfRouteFence(
+		ctx, repo, normalized, routeFence,
+	)
 	if err != nil {
 		return calls, fmt.Errorf(
 			"upsert issue #%d: %w", number, err,
@@ -9622,6 +10104,9 @@ func (s *Syncer) fetchProviderIssueDetail(
 	if !accepted {
 		return calls, nil
 	}
+	ctx = s.db.WithRepositoryRouteFence(
+		ctx, platform.DBRepoIdentity(platformRepoRef(repo)), routeFence,
+	)
 	events, eventsErr := reader.ListIssueEvents(ctx, platformRepoRef(repo), number)
 	calls++
 	if eventsErr != nil && !errors.Is(eventsErr, platform.ErrUnsupportedCapability) {
@@ -9640,6 +10125,9 @@ func (s *Syncer) fetchProviderIssueDetail(
 		}
 		applied, commitErr := s.commitIssueCommentsSnapshot(ctx, repo, issueID, number, revision, comments, dbEvents, nil)
 		if commitErr != nil {
+			if errors.Is(commitErr, db.ErrRepositoryRouteFenceChanged) {
+				return calls, nil
+			}
 			return calls, fmt.Errorf("replace provider issue comments for #%d: %w", number, commitErr)
 		}
 		if !applied {
@@ -9647,7 +10135,9 @@ func (s *Syncer) fetchProviderIssueDetail(
 		}
 	}
 
-	detailApplied, err := s.db.MarkIssueDetailFetchedSnapshot(ctx, issueID, revision)
+	detailApplied, err := s.markIssueDetailFetchedIfRouteFence(
+		ctx, repo, routeFence, issueID, revision,
+	)
 	if err != nil {
 		return calls, fmt.Errorf(
 			"mark detail fetched for issue #%d: %w", number, err,
@@ -9904,9 +10394,13 @@ func (s *Syncer) refreshCIStatusSnapshot(
 	if !result.Updated {
 		return true, nil
 	}
-	return s.db.UpdateMergeRequestCISnapshot(
+	applied, err := s.db.UpdateMergeRequestCISnapshot(
 		ctx, mrID, expectedRevision, result.Status, result.ChecksJSON,
 	)
+	if errors.Is(err, db.ErrRepositoryRouteFenceChanged) {
+		return false, nil
+	}
+	return applied, err
 }
 
 const ciRefreshWarning = "Could not refresh CI checks; showing last known status."
@@ -10441,7 +10935,7 @@ func (s *Syncer) syncOpenPlatformIssue(
 
 	if !needsTimeline {
 		if existing != nil && existing.DetailFetchedAt != nil {
-			s.queueIssueCommentSync(repo, existing.Number)
+			s.queueIssueCommentSync(repo, existing.RepoID, existing.Number)
 		}
 		return nil
 	}
@@ -10510,7 +11004,7 @@ func (s *Syncer) syncOpenIssue(
 
 	if !needsTimeline {
 		if existing != nil && existing.DetailFetchedAt != nil {
-			s.queueIssueCommentSync(repo, existing.Number)
+			s.queueIssueCommentSync(repo, existing.RepoID, existing.Number)
 		}
 		return nil
 	}
@@ -10929,6 +11423,7 @@ func (s *Syncer) drainDetailQueue(
 	exhausted := make(map[string]bool)
 	verifiedRepos := make(map[string]RepoRef)
 	verifiedRepoIDs := make(map[string]int64)
+	verifiedRouteFences := make(map[string]db.RepositoryRouteFence)
 	rejectedRepos := make(map[string]bool)
 
 	for i := range queue {
@@ -11005,23 +11500,28 @@ func (s *Syncer) drainDetailQueue(
 			continue
 		}
 		repoID, verified := verifiedRepoIDs[repoKey]
+		routeFence := verifiedRouteFences[repoKey]
 		if verified {
 			repo = verifiedRepos[repoKey]
 		} else {
-			resolvedRepo, resolvedRepoID, _, resolveErr := s.reconcileRepoIdentity(ctx, repo)
-			if resolveErr != nil {
+			resolvedRepo, resolvedRepoID, resolvedFence, found, resolveErr :=
+				s.reconcileRepoForDirectSync(ctx, repo)
+			if resolveErr != nil || !found {
 				probe.abandon()
 				rejectedRepos[repoKey] = true
 				slog.Warn("detail drain: verify repo identity failed",
 					"repo", qi.RepoOwner+"/"+qi.RepoName,
+					"found", found,
 					"err", resolveErr,
 				)
 				continue
 			}
 			repo = resolvedRepo
 			repoID = resolvedRepoID
+			routeFence = resolvedFence
 			verifiedRepos[repoKey] = repo
 			verifiedRepoIDs[repoKey] = repoID
+			verifiedRouteFences[repoKey] = routeFence
 		}
 		if repo.Archived {
 			// Identity verification just discovered the archived flip;
@@ -11038,13 +11538,13 @@ func (s *Syncer) drainDetailQueue(
 			)
 			continue
 		}
+		itemCtx := withCloneRepositoryIdentity(ctx, repo)
 
 		// Compute diff SHAs if clone available.
 		cloneFetchOK := false
 		if s.clones != nil {
-			if cloneErr := s.clones.EnsureClone(
-				ctx, string(repoPlatform(repo)), host, qi.RepoOwner, qi.RepoName,
-				cloneRemoteURL(repo),
+			if cloneErr := s.ensureCloneForRoute(
+				itemCtx, repo, repoID, routeFence,
 			); cloneErr != nil {
 				slog.Warn("detail drain: bare clone failed",
 					"repo", qi.RepoOwner+"/"+qi.RepoName,
@@ -11057,11 +11557,11 @@ func (s *Syncer) drainDetailQueue(
 		providerCalls := 0
 		if qi.Type == QueueItemPR {
 			providerCalls, err = s.fetchMRDetail(
-				ctx, repo, repoID, qi.Number, cloneFetchOK,
+				itemCtx, repo, repoID, qi.Number, cloneFetchOK,
 			)
 		} else {
 			providerCalls, err = s.fetchIssueDetail(
-				ctx, repo, repoID, qi.Number,
+				itemCtx, repo, repoID, qi.Number,
 			)
 		}
 
@@ -11319,6 +11819,21 @@ func (s *Syncer) SyncClosedMROnProvider(
 		repo = routed
 	}
 	repo = repoRefFromStoredIdentity(repo, *stored)
+	identity := platform.DBRepoIdentity(platformRepoRef(repo))
+	routeFence, found, err := s.db.CurrentRepositoryRouteFence(
+		ctx, identity, repoID,
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"capture repository route for closed-MR resync %s/%s: %w",
+			repo.Owner, repo.Name, err,
+		)
+	}
+	if !found {
+		return nil
+	}
+	ctx = withCloneRepositoryIdentity(ctx, repo)
+	ctx = s.db.WithRepositoryRouteFence(ctx, identity, routeFence)
 	reader, err := s.mergeRequestReaderFor(repo)
 	if err != nil {
 		return fmt.Errorf(
@@ -11436,9 +11951,15 @@ func (s *Syncer) syncMRForRepo(
 		return fmt.Errorf("resolve merge request reader for %s/%s: %w", owner, name, err)
 	}
 
-	resolvedRef, repoID, _, err := s.reconcileRepoIdentity(ctx, repo)
+	resolvedRef, repoID, routeFence, found, err := s.reconcileRepoForDirectSync(ctx, repo)
 	if err != nil {
-		return fmt.Errorf("resolve repo identity %s/%s: %w", owner, name, err)
+		if errors.Is(err, db.ErrRepositoryRouteFenceChanged) {
+			return nil
+		}
+		return err
+	}
+	if !found {
+		return nil
 	}
 	repo = resolvedRef
 	if repo.Archived && !IsArchiveSyncBudgetContext(ctx) {
@@ -11449,6 +11970,7 @@ func (s *Syncer) syncMRForRepo(
 		)
 		return nil
 	}
+	ctx = withCloneRepositoryIdentity(ctx, repo)
 
 	// Preserve derived fields that provider detail doesn't populate. CI is
 	// refreshed later in this sync path; keeping the previous values here
@@ -11487,7 +12009,7 @@ func (s *Syncer) syncMRForRepo(
 			if err == nil && ghPR == nil {
 				if notModified && existing != nil {
 					_, err := s.markUnchangedMRDetailFetched(
-						ctx, repo, repoID, number, existing, 1,
+						ctx, repo, repoID, number, existing, routeFence, 1,
 					)
 					return err
 				}
@@ -11559,14 +12081,22 @@ func (s *Syncer) syncMRForRepo(
 		}
 	}
 
-	mrID, revision, accepted, err := s.CommitMergeRequestParentSnapshot(ctx, repo, normalized)
+	mrID, revision, accepted, err := s.commitMergeRequestParentSnapshotIfRouteFence(
+		ctx, repo, normalized, routeFence,
+	)
 	if err != nil {
 		return fmt.Errorf("upsert MR #%d: %w", number, err)
 	}
 	if !accepted {
 		return nil
 	}
+	ctx = s.db.WithRepositoryRouteFence(
+		ctx, platform.DBRepoIdentity(platformRepoRef(repo)), routeFence,
+	)
 	if err := s.markClosedLinkedNotificationsDone(ctx); err != nil {
+		if errors.Is(err, db.ErrRepositoryRouteFenceChanged) {
+			return nil
+		}
 		return err
 	}
 	// UpsertMergeRequest preserves ci_had_pending across upserts. Clear
@@ -11592,7 +12122,10 @@ func (s *Syncer) syncMRForRepo(
 		// Run the diff sync, but don't let its failure abort the rest of SyncMR:
 		// timeline and CI status are independent and the user still wants them
 		// fresh. Capture the error and surface it via DiffSyncError at the end.
-		diffErr = s.syncMRDiff(ctx, repo, repoID, mrID, revision, number, ghPR, normalized)
+		diffErr = s.syncMRDiff(
+			ctx, repo, repoID, mrID, revision, number,
+			ghPR, normalized, routeFence,
+		)
 		if errors.Is(diffErr, errParentSnapshotAdvanced) {
 			return nil
 		}
@@ -11641,8 +12174,8 @@ func (s *Syncer) syncMRForRepo(
 		fresh, freshErr := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repoID, number)
 		if freshErr == nil && fresh != nil {
 			pending := ciHasPending(fresh.CIChecksJSON)
-			detailApplied, detailErr := s.db.MarkMergeRequestDetailFetchedSnapshot(
-				ctx, mrID, revision, pending, nil,
+			detailApplied, detailErr := s.markMergeRequestDetailFetchedIfRouteFence(
+				ctx, repo, routeFence, mrID, revision, pending, nil,
 			)
 			if detailErr != nil {
 				return fmt.Errorf("mark detail fetched for MR #%d: %w", number, detailErr)
@@ -11657,7 +12190,10 @@ func (s *Syncer) syncMRForRepo(
 		// DiffHeadSHA matches the platform head, so a sync that never
 		// writes it would leave head-bound actions permanently
 		// disabled with 409 head_unknown.
-		diffErr = s.syncProviderMRDiff(ctx, repo, mrID, revision, number, normalized, true)
+		diffErr = s.syncProviderMRDiff(
+			ctx, repo, repoID, mrID, revision, number,
+			normalized, true, routeFence,
+		)
 		if errors.Is(diffErr, errParentSnapshotAdvanced) {
 			return nil
 		}
@@ -11676,8 +12212,8 @@ func (s *Syncer) syncMRForRepo(
 		if _, err := s.persistMergedActorEvent(ctx, mrID, revision, platformMR.MergedBy, normalized.MergedAt); err != nil {
 			return fmt.Errorf("persist merged lifecycle event for MR #%d: %w", number, err)
 		}
-		detailApplied, err := s.db.MarkMergeRequestDetailFetchedSnapshot(
-			ctx, mrID, revision, pending, nil,
+		detailApplied, err := s.markMergeRequestDetailFetchedIfRouteFence(
+			ctx, repo, routeFence, mrID, revision, pending, nil,
 		)
 		if err != nil {
 			return fmt.Errorf("mark detail fetched for MR #%d: %w", number, err)
@@ -11710,9 +12246,9 @@ func (s *Syncer) syncMRForRepo(
 		return diffErr
 	}
 	if newETag != "" {
-		if err := s.db.UpsertHTTPEtag(
-			ctx, string(repoPlatform(repo)), repoHost(repo),
-			repo.Owner, repo.Name, "pull_request", number, newETag,
+		if _, err := s.db.UpsertHTTPEtagIfRouteFence(
+			ctx, platform.DBRepoIdentity(platformRepoRef(repo)), routeFence,
+			"pull_request", number, newETag,
 		); err != nil {
 			slog.Warn("persist pull request ETag failed",
 				"repo", repo.Owner+"/"+repo.Name,
@@ -11822,12 +12358,14 @@ func preserveCIStateIfOmitted(
 func (s *Syncer) syncMRDiff(
 	ctx context.Context, repo RepoRef, repoID, mrID, expectedRevision int64, number int,
 	ghPR *gh.PullRequest, normalized *db.MergeRequest,
+	routeFence db.RepositoryRouteFence,
 ) error {
+	ctx = withCloneRepositoryIdentity(ctx, repo)
 	if s.clones == nil {
 		return nil
 	}
 	host := repoHost(repo)
-	if err := s.clones.EnsureClone(ctx, string(repoPlatform(repo)), host, repo.Owner, repo.Name, cloneRemoteURL(repo)); err != nil {
+	if err := s.ensureCloneForRoute(ctx, repo, repoID, routeFence); err != nil {
 		return &DiffSyncError{
 			Code: DiffSyncCodeCloneUnavailable,
 			Err:  fmt.Errorf("ensure bare clone for #%d: %w", number, err),
@@ -11879,9 +12417,11 @@ func (s *Syncer) syncMRDiff(
 // meaningless once merged/closed, and the merged-MR merge-base repair
 // logic is GitHub-specific.
 func (s *Syncer) syncProviderMRDiff(
-	ctx context.Context, repo RepoRef, mrID, expectedRevision int64, number int,
+	ctx context.Context, repo RepoRef, repoID, mrID, expectedRevision int64, number int,
 	normalized *db.MergeRequest, ensureClone bool,
+	routeFence db.RepositoryRouteFence,
 ) error {
+	ctx = withCloneRepositoryIdentity(ctx, repo)
 	if s.clones == nil {
 		return nil
 	}
@@ -11897,7 +12437,7 @@ func (s *Syncer) syncProviderMRDiff(
 	// round-trips. Per-MR detail syncs have no prior fetch and pass
 	// ensureClone.
 	if ensureClone {
-		if err := s.clones.EnsureClone(ctx, string(repoPlatform(repo)), host, repo.Owner, repo.Name, cloneRemoteURL(repo)); err != nil {
+		if err := s.ensureCloneForRoute(ctx, repo, repoID, routeFence); err != nil {
 			return &DiffSyncError{
 				Code: DiffSyncCodeCloneUnavailable,
 				Err:  fmt.Errorf("ensure bare clone for #%d: %w", number, err),
@@ -12014,11 +12554,15 @@ func (s *Syncer) syncIssueForRepo(
 		defer releaseProviderWork()
 	}
 
-	resolvedRef, repoID, _, err := s.reconcileRepoIdentity(ctx, repo)
+	resolvedRef, repoID, _, found, err := s.reconcileRepoForDirectSync(ctx, repo)
 	if err != nil {
-		return fmt.Errorf(
-			"resolve repo identity %s/%s: %w", repo.Owner, repo.Name, err,
-		)
+		if errors.Is(err, db.ErrRepositoryRouteFenceChanged) {
+			return nil
+		}
+		return err
+	}
+	if !found {
+		return nil
 	}
 	repo = resolvedRef
 	if repo.Archived && !IsArchiveSyncBudgetContext(ctx) {

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -795,6 +795,11 @@ esac
 		verifiedGitHubRepoIdentity("github.com", repo.Owner, repo.Name),
 	)
 	require.NoError(err)
+	routeFence, found, err := database.CurrentRepositoryRouteFence(
+		t.Context(), platform.DBRepoIdentity(platformRepoRef(repo)), repoID,
+	)
+	require.NoError(err)
+	require.True(found)
 	syncer := NewSyncer(
 		map[string]Client{"github.com": &mockClient{}},
 		database,
@@ -834,6 +839,7 @@ esac
 			PlatformHeadSHA: "head-sha",
 			PlatformBaseSHA: "base-sha",
 		},
+		routeFence,
 	)
 
 	require.Error(err)
@@ -928,6 +934,7 @@ type mockClient struct {
 	ciStatusErr                     error
 	checkRuns                       []*gh.CheckRun
 	checkRunsErr                    error
+	listCheckRunsForRefFn           func(context.Context, string, string, string) ([]*gh.CheckRun, error)
 	workflowRuns                    []*gh.WorkflowRun
 	listWorkflowRunsFn              func(context.Context, string, string, string) ([]*gh.WorkflowRun, error)
 	approveWorkflowRunFn            func(context.Context, string, string, int64) error
@@ -1006,14 +1013,18 @@ func (m *rateLimitSnapshotMockClient) GetRateLimitSnapshot(ctx context.Context) 
 
 type labelCatalogTestClient struct {
 	*mockClient
-	labels []*gh.Label
-	calls  atomic.Int32
+	labels           []*gh.Label
+	listRepoLabelsFn func(context.Context, string, string) ([]*gh.Label, error)
+	calls            atomic.Int32
 }
 
 func (c *labelCatalogTestClient) ListRepoLabels(
-	_ context.Context, _, _ string,
+	ctx context.Context, owner, repo string,
 ) ([]*gh.Label, error) {
 	c.calls.Add(1)
+	if c.listRepoLabelsFn != nil {
+		return c.listRepoLabelsFn(ctx, owner, repo)
+	}
 	return append([]*gh.Label(nil), c.labels...), nil
 }
 
@@ -1461,8 +1472,11 @@ func (m *mockClient) GetCombinedStatus(_ context.Context, _, _, _ string) (*gh.C
 	return m.ciStatus, nil
 }
 
-func (m *mockClient) ListCheckRunsForRef(_ context.Context, _, _, _ string) ([]*gh.CheckRun, error) {
+func (m *mockClient) ListCheckRunsForRef(ctx context.Context, owner, repo, ref string) ([]*gh.CheckRun, error) {
 	m.trackCall()
+	if m.listCheckRunsForRefFn != nil {
+		return m.listCheckRunsForRefFn(ctx, owner, repo, ref)
+	}
 	if m.checkRunsErr != nil {
 		return nil, m.checkRunsErr
 	}
@@ -2226,13 +2240,14 @@ func TestAckRepoBucketsIncludesArchivedTrackedRepos(t *testing.T) {
 	syncer := NewSyncer(
 		map[string]Client{"github.com": &mockClient{}}, database, nil,
 		[]RepoRef{
-			{Owner: "acme", Name: "frozen", PlatformHost: "github.com", Archived: true},
-			{Owner: "acme", Name: "widget", PlatformHost: "github.com"},
+			{RepoID: 41, Owner: "acme", Name: "frozen", PlatformHost: "github.com", Archived: true},
+			{RepoID: 42, Owner: "acme", Name: "widget", PlatformHost: "github.com"},
 		},
 		time.Minute, nil, nil,
 	)
+	queuedRepoID := int64(42)
 	queued := []db.Notification{{
-		ID: 1, RepoOwner: "acme", RepoName: "widget",
+		ID: 1, RepoID: &queuedRepoID, RepoOwner: "acme", RepoName: "widget",
 	}}
 
 	byBucket, byNotification := syncer.ackRepoBuckets(
@@ -2242,12 +2257,16 @@ func TestAckRepoBucketsIncludesArchivedTrackedRepos(t *testing.T) {
 	bucket, ok := byNotification[1]
 	require.True(ok)
 	names := make([]string, 0, len(byBucket[bucket]))
+	repoIDs := make([]int64, 0, len(byBucket[bucket]))
 	for _, repo := range byBucket[bucket] {
 		names = append(names, repo.Name)
+		repoIDs = append(repoIDs, repo.RepoID)
 	}
 	assert.Contains(names, "frozen",
 		"archived repos must stay in ack deferral buckets: their queued "+
 			"acknowledgements share the credential's rate limit")
+	assert.ElementsMatch([]int64{41, 42}, repoIDs,
+		"credential buckets must retain stable repository IDs across renames")
 }
 
 func TestSyncNotificationsSkipsUnroutedRepoAndAdvancesRoutedSibling(t *testing.T) {
@@ -2382,10 +2401,18 @@ func TestSyncNotificationsStopsBeforeListingWhenSharedReadRateReserveExhausted(t
 		Remaining: RateReserveBuffer,
 		Reset:     time.Now().UTC().Add(time.Hour),
 	})
+	var identityCalls atomic.Int32
 	var calls atomic.Int32
 	syncer := NewSyncer(
 		map[string]Client{
 			"github.com": &mockClient{
+				getRepositoryFn: func(_ context.Context, owner, name string) (*gh.Repository, error) {
+					identityCalls.Add(1)
+					return &gh.Repository{
+						ID: new(int64(1)), NodeID: new("repo-acme-widget"), Name: &name,
+						Owner: &gh.User{Login: &owner},
+					}, nil
+				},
 				listNotificationsFn: func(context.Context, NotificationListOptions) ([]NotificationThread, bool, error) {
 					calls.Add(1)
 					return nil, false, nil
@@ -2404,6 +2431,7 @@ func TestSyncNotificationsStopsBeforeListingWhenSharedReadRateReserveExhausted(t
 
 	require.Error(syncErr)
 	require.ErrorContains(syncErr, "rate reserve exhausted")
+	assert.Equal(int32(0), identityCalls.Load())
 	assert.Equal(int32(0), calls.Load())
 }
 
@@ -2436,6 +2464,44 @@ func TestSyncNotificationsStopsBeforeListingWhenSyncBudgetExhausted(t *testing.T
 	require.Error(syncErr)
 	require.ErrorContains(syncErr, "sync budget exhausted")
 	assert.Equal(int32(0), calls.Load())
+}
+
+func TestSyncNotificationsDeduplicatesSharedIdentityLookupBudget(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	d := openTestDB(t)
+	_, err := d.UpsertRepo(t.Context(), verifiedGitHubRepoIdentity("github.com", "acme", "widget"))
+	require.NoError(err)
+	budget := NewSyncBudget(1)
+	var identityCalls atomic.Int32
+	var notificationCalls atomic.Int32
+	client := &mockClient{
+		budget: budget,
+		getRepositoryFn: func(_ context.Context, owner, name string) (*gh.Repository, error) {
+			identityCalls.Add(1)
+			return &gh.Repository{
+				ID: new(int64(1)), NodeID: new("repo-acme-widget"), Name: &name,
+				Owner: &gh.User{Login: &owner},
+			}, nil
+		},
+		listNotificationsFn: func(context.Context, NotificationListOptions) ([]NotificationThread, bool, error) {
+			notificationCalls.Add(1)
+			return nil, false, nil
+		},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client}, d, nil,
+		[]RepoRef{{Owner: "acme", Name: "widget", PlatformHost: "github.com"}},
+		time.Minute, nil, map[string]*SyncBudget{"github.com": budget},
+	)
+
+	syncErr := syncer.SyncNotifications(t.Context())
+
+	require.Error(syncErr)
+	require.ErrorContains(syncErr, "sync budget exhausted")
+	assert.Equal(int32(1), identityCalls.Load())
+	assert.Equal(int32(0), notificationCalls.Load())
+	assert.Equal(1, budget.Spent())
 }
 
 func TestSyncNotificationsReadsAllRepositoryNotificationPages(t *testing.T) {
@@ -2954,6 +3020,12 @@ func TestSyncNotificationsEnrichesItemAuthorFromProviderScopedRepo(t *testing.T)
 	syncer := NewSyncer(
 		map[string]Client{
 			"code.example.com": &mockClient{
+				getRepositoryFn: func(_ context.Context, owner, name string) (*gh.Repository, error) {
+					return &gh.Repository{
+						ID: new(int64(1)), NodeID: new("github-acme-widget"), Name: &name,
+						Owner: &gh.User{Login: &owner},
+					}, nil
+				},
 				listNotificationsFn: func(_ context.Context, opts NotificationListOptions) ([]NotificationThread, bool, error) {
 					if opts.Participating {
 						return nil, false, nil
@@ -3220,6 +3292,13 @@ func TestProcessQueuedNotificationReadsPausesOnRateLimitWithoutConsumingAttempts
 	queuedAt := now.Add(time.Minute)
 	_, err = d.QueueNotificationIDsRead(t.Context(), []int64{items[0].ID, items[1].ID}, queuedAt)
 	require.NoError(err)
+	renamedIdentity := verifiedGitHubRepoIdentity("github.com", "acme", "renamed")
+	renamedIdentity.PlatformRepoID = "repo-acme-widget"
+	_, accepted, err := d.ReconcileRepositoryObservation(
+		t.Context(), renamedIdentity, time.Now().UTC().Add(time.Minute),
+	)
+	require.NoError(err)
+	require.True(accepted)
 	resetAt := time.Now().UTC().Add(time.Hour).Round(0)
 	var markedThreads []string
 	mc := &mockClient{markNotificationThreadReadFn: func(_ context.Context, threadID string) error {
@@ -3421,6 +3500,189 @@ func TestProcessQueuedNotificationReadsPreservesUpstreamReadOnPreAckRefetch(t *t
 	unread, err := d.ListNotifications(t.Context(), db.ListNotificationsOpts{State: "unread"})
 	require.NoError(err)
 	check.Empty(unread)
+}
+
+func TestQueuedNotificationRefreshPreservesDoneAckAfterRouteChange(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	repoID, err := database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com", PlatformRepoID: "original-repo",
+		Owner: "acme", Name: "alpha",
+	})
+	require.NoError(err)
+	number := 7
+	originalUpdatedAt := time.Date(2026, 8, 3, 9, 0, 0, 0, time.UTC)
+	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID: repoID, PlatformID: 7007, Number: number,
+		URL: "https://github.com/acme/alpha/pull/7", Title: "Pull request",
+		State: db.MergeRequestStateOpen, CreatedAt: originalUpdatedAt,
+		UpdatedAt: originalUpdatedAt, LastActivityAt: originalUpdatedAt,
+	})
+	require.NoError(err)
+	require.NoError(database.UpsertNotifications(ctx, []db.Notification{{
+		Platform: "github", PlatformHost: "github.com", PlatformNotificationID: "thread-1",
+		RepoID: &repoID, RepoOwner: "acme", RepoName: "alpha",
+		SubjectType: "PullRequest", SubjectTitle: "Please review",
+		WebURL: "https://github.com/acme/alpha/pull/7", ItemNumber: &number, ItemType: "pr",
+		Reason: "mention", Unread: true, SourceUpdatedAt: originalUpdatedAt, SyncedAt: originalUpdatedAt,
+	}}))
+	items, err := database.ListNotifications(ctx, db.ListNotificationsOpts{State: "all"})
+	require.NoError(err)
+	require.Len(items, 1)
+	queuedAt := originalUpdatedAt.Add(time.Minute)
+	_, err = database.MarkNotificationsDone(ctx, []int64{items[0].ID}, queuedAt, true)
+	require.NoError(err)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var fetches atomic.Int32
+	var marked atomic.Int32
+	client := &mockClient{
+		getNotificationThreadFn: func(context.Context, string) (NotificationThread, error) {
+			if fetches.Add(1) == 1 {
+				close(started)
+				<-release
+			}
+			return NotificationThread{
+				ID: "thread-1", RepoOwner: "acme", RepoName: "beta",
+				SubjectType: "PullRequest", SubjectTitle: "Please review",
+				WebURL: "https://github.com/acme/beta/pull/7", ItemNumber: &number, ItemType: "pr",
+				Reason: "mention", Unread: false, UpdatedAt: originalUpdatedAt,
+			}, nil
+		},
+		markNotificationThreadReadFn: func(context.Context, string) error {
+			marked.Add(1)
+			return nil
+		},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client}, database, nil,
+		[]RepoRef{{
+			Platform: platform.KindGitHub, PlatformHost: "github.com",
+			Owner: "acme", Name: "alpha", PlatformExternalID: "original-repo",
+		}},
+		time.Minute, nil, testBudget(100),
+	)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- syncer.ProcessQueuedNotificationReads(ctx, platform.KindGitHub, "github.com", 10)
+	}()
+	<-started
+	_, _, err = database.ReconcileRepositoryObservation(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com", PlatformRepoID: "original-repo",
+		Owner: "acme", Name: "beta", RepoPath: "acme/beta",
+	}, time.Now().UTC().Add(time.Hour))
+	require.NoError(err)
+	close(release)
+	require.NoError(<-done)
+
+	// The route changed after this pass captured alpha. The stable linked
+	// acknowledgement must remain queued so the next pass can resolve repoID
+	// to beta instead of discarding the upstream read intent.
+	items, err = database.ListNotifications(ctx, db.ListNotificationsOpts{State: "all"})
+	require.NoError(err)
+	require.Len(items, 1)
+	assert.Equal("acme", items[0].RepoOwner)
+	assert.Equal("alpha", items[0].RepoName)
+	assert.Equal("Please review", items[0].SubjectTitle)
+	assert.Equal(originalUpdatedAt, items[0].SourceUpdatedAt)
+	assert.False(items[0].Unread)
+	assert.NotNil(items[0].DoneAt)
+	assert.NotEmpty(items[0].DoneReason)
+	assert.NotNil(items[0].SourceAckQueuedAt)
+	assert.Nil(items[0].SourceAckSyncedAt)
+	require.NotNil(items[0].RepoID)
+	assert.Equal(repoID, *items[0].RepoID)
+	assert.Zero(marked.Load())
+	queued, err := database.ListQueuedNotificationAcks(
+		ctx, "github", "github.com", 10, time.Now().UTC().Add(2*time.Hour),
+	)
+	require.NoError(err)
+	require.Len(queued, 1)
+	assert.Equal("acme", queued[0].RepoOwner)
+	assert.Equal("beta", queued[0].RepoName)
+
+	require.NoError(syncer.ProcessQueuedNotificationReads(
+		ctx, platform.KindGitHub, "github.com", 10,
+	))
+	assert.Equal(int32(1), marked.Load())
+	items, err = database.ListNotifications(ctx, db.ListNotificationsOpts{State: "all"})
+	require.NoError(err)
+	require.Len(items, 1)
+	assert.False(items[0].Unread)
+	assert.NotNil(items[0].DoneAt)
+	assert.Nil(items[0].SourceAckQueuedAt)
+	assert.NotNil(items[0].SourceAckSyncedAt)
+}
+
+func TestQueuedNotificationRefreshLinksLegacyUnownedRow(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	number := 7
+	originalUpdatedAt := time.Date(2026, 8, 3, 9, 0, 0, 0, time.UTC)
+	require.NoError(database.UpsertNotifications(ctx, []db.Notification{{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformNotificationID: "legacy-thread",
+		RepoOwner:              "acme", RepoName: "widget",
+		SubjectType: "PullRequest", SubjectTitle: "Please review",
+		WebURL:     "https://github.com/acme/widget/pull/7",
+		ItemNumber: &number, ItemType: "pr", Reason: "mention", Unread: true,
+		SourceUpdatedAt: originalUpdatedAt, SyncedAt: originalUpdatedAt,
+	}}))
+	repoID, err := database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "repo-widget", Owner: "acme", Name: "widget",
+	})
+	require.NoError(err)
+	items, err := database.ListNotifications(
+		ctx, db.ListNotificationsOpts{State: "all"},
+	)
+	require.NoError(err)
+	require.Len(items, 1)
+	require.Nil(items[0].RepoID)
+	queuedAt := originalUpdatedAt.Add(time.Minute)
+	_, err = database.MarkNotificationsDone(
+		ctx, []int64{items[0].ID}, queuedAt, true,
+	)
+	require.NoError(err)
+
+	newer := originalUpdatedAt.Add(2 * time.Minute)
+	client := &mockClient{getNotificationThreadFn: func(
+		context.Context, string,
+	) (NotificationThread, error) {
+		return NotificationThread{
+			ID: "legacy-thread", RepoOwner: "acme", RepoName: "widget",
+			SubjectType: "PullRequest", SubjectTitle: "New activity",
+			WebURL:     "https://github.com/acme/widget/pull/7",
+			ItemNumber: &number, ItemType: "pr", Reason: "mention",
+			Unread: true, UpdatedAt: newer,
+		}, nil
+	}}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client}, database, nil, nil,
+		time.Minute, nil, nil,
+	)
+	require.NoError(syncer.ProcessQueuedNotificationReads(
+		ctx, platform.KindGitHub, "github.com", 10,
+	))
+
+	items, err = database.ListNotifications(
+		ctx, db.ListNotificationsOpts{State: "all"},
+	)
+	require.NoError(err)
+	require.Len(items, 1)
+	require.NotNil(items[0].RepoID)
+	assert.Equal(repoID, *items[0].RepoID)
+	assert.Equal(newer, items[0].SourceUpdatedAt)
+	assert.Equal("New activity", items[0].SubjectTitle)
+	assert.True(items[0].Unread)
+	assert.Nil(items[0].DoneAt)
+	assert.Nil(items[0].SourceAckQueuedAt)
 }
 
 func TestProcessQueuedNotificationReadsBacksOffRowAndContinuesOnRefetchError(t *testing.T) {
@@ -3651,6 +3913,443 @@ func TestSyncNotificationsSkipsHostsWithoutTrackedRepos(t *testing.T) {
 	require.Equal(int32(0), calls.Load())
 }
 
+func TestSyncNotificationsCatalogsRepoBeforeFetching(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	d := openTestDB(t)
+	number := 7
+	now := time.Date(2026, 8, 3, 10, 0, 0, 0, time.UTC)
+	client := &mockClient{
+		listNotificationsFn: func(_ context.Context, opts NotificationListOptions) ([]NotificationThread, bool, error) {
+			if opts.Participating {
+				return nil, false, nil
+			}
+			return []NotificationThread{{
+				ID: "thread-1", RepoOwner: "acme", RepoName: "widget",
+				SubjectType: "PullRequest", SubjectTitle: "Please review",
+				WebURL: "https://github.com/acme/widget/pull/7", ItemNumber: &number,
+				ItemType: "pr", Reason: "mention", Unread: true, UpdatedAt: now,
+			}}, false, nil
+		},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client}, d, nil,
+		[]RepoRef{{
+			Platform: platform.KindGitHub, PlatformHost: "github.com",
+			Owner: "acme", Name: "widget",
+		}},
+		time.Minute, nil, nil,
+	)
+
+	require.NoError(syncer.SyncNotifications(t.Context()))
+	repo, err := d.GetRepoByIdentity(t.Context(), db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com", Owner: "acme", Name: "widget",
+	})
+	require.NoError(err)
+	require.NotNil(repo)
+	items, err := d.ListNotifications(t.Context(), db.ListNotificationsOpts{State: "all"})
+	require.NoError(err)
+	require.Len(items, 1)
+	require.NotNil(items[0].RepoID)
+	assert.Equal(repo.ID, *items[0].RepoID)
+}
+
+func TestSyncNotificationsReconcilesOccupiedRouteBeforeFetching(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	oldRepoID, err := d.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "R_old",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	require.NoError(err)
+	number := 7
+	now := time.Date(2026, 8, 3, 10, 0, 0, 0, time.UTC)
+	client := &mockClient{
+		getRepositoryFn: func(_ context.Context, owner, name string) (*gh.Repository, error) {
+			return &gh.Repository{
+				ID: new(int64(2)), NodeID: new("R_new"), Name: &name,
+				Owner: &gh.User{Login: &owner}, Archived: new(bool),
+			}, nil
+		},
+		listNotificationsFn: func(_ context.Context, opts NotificationListOptions) ([]NotificationThread, bool, error) {
+			if opts.Participating {
+				return nil, false, nil
+			}
+			return []NotificationThread{{
+				ID: "replacement-thread", RepoOwner: "acme", RepoName: "widget",
+				SubjectType: "PullRequest", SubjectTitle: "Replacement repository",
+				WebURL: "https://github.com/acme/widget/pull/7", ItemNumber: &number,
+				ItemType: "pr", Reason: "mention", Unread: true, UpdatedAt: now,
+			}}, false, nil
+		},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client}, d, nil,
+		[]RepoRef{{
+			Platform: platform.KindGitHub, PlatformHost: "github.com",
+			Owner: "acme", Name: "widget",
+		}},
+		time.Minute, nil, nil,
+	)
+
+	require.NoError(syncer.SyncNotifications(ctx))
+	active, err := d.GetRepoByIdentity(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com", Owner: "acme", Name: "widget",
+	})
+	require.NoError(err)
+	require.NotNil(active)
+	assert.Equal("R_new", active.PlatformRepoID)
+	assert.NotEqual(oldRepoID, active.ID)
+	items, err := d.ListNotifications(ctx, db.ListNotificationsOpts{State: "all"})
+	require.NoError(err)
+	require.Len(items, 1)
+	require.NotNil(items[0].RepoID)
+	assert.Equal(active.ID, *items[0].RepoID)
+}
+
+func TestSyncNotificationsReportsReconciledRepoSettingsPersistenceFailure(t *testing.T) {
+	require := require.New(t)
+	database := openTestDB(t)
+	ctx := t.Context()
+	_, err := database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com", PlatformRepoID: "R_old",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+	})
+	require.NoError(err)
+	_, err = database.WriteDB().ExecContext(ctx, `
+		CREATE TRIGGER reject_notification_repo_settings
+		BEFORE UPDATE OF allow_squash_merge ON forge_repos
+		BEGIN SELECT RAISE(ABORT, 'reject settings'); END`)
+	require.NoError(err)
+
+	var listCalls atomic.Int32
+	client := &mockClient{
+		getRepositoryFn: func(_ context.Context, owner, name string) (*gh.Repository, error) {
+			return &gh.Repository{
+				NodeID: new("R_new"), Name: &name, Owner: &gh.User{Login: &owner},
+				DefaultBranch: new("main"), AllowSquashMerge: new(true),
+			}, nil
+		},
+		listNotificationsFn: func(context.Context, NotificationListOptions) ([]NotificationThread, bool, error) {
+			listCalls.Add(1)
+			return nil, false, nil
+		},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client}, database, nil,
+		[]RepoRef{{Platform: platform.KindGitHub, PlatformHost: "github.com", Owner: "acme", Name: "widget"}},
+		time.Minute, nil, nil,
+	)
+
+	err = syncer.SyncNotifications(ctx)
+	require.ErrorContains(err, "reject settings")
+	require.Zero(listCalls.Load(), "notification listing must not run with stale repository settings")
+}
+
+func TestSyncNotificationsRetriesSettingsAfterABARouteReuse(t *testing.T) {
+	require := require.New(t)
+	database := openTestDB(t)
+	ctx := t.Context()
+	observedAt := time.Now().UTC()
+	original, _, err := database.ReconcileRepositoryObservation(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com", PlatformRepoID: "repo-a",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+	}, observedAt)
+	require.NoError(err)
+	require.NoError(database.UpdateRepoMergeSettings(
+		ctx, original.Repository.ID, false, false, false,
+	))
+
+	var repositoryCalls atomic.Int32
+	client := &mockClient{
+		getRepositoryFn: func(_ context.Context, owner, name string) (*gh.Repository, error) {
+			allowSquash := repositoryCalls.Add(1) == 1
+			return &gh.Repository{
+				NodeID: new("repo-a"), Name: &name, Owner: &gh.User{Login: &owner},
+				AllowSquashMerge: &allowSquash, AllowMergeCommit: new(false),
+				AllowRebaseMerge: new(false),
+			}, nil
+		},
+		listNotificationsFn: func(context.Context, NotificationListOptions) ([]NotificationThread, bool, error) {
+			return nil, false, nil
+		},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client}, database, nil,
+		[]RepoRef{{
+			Platform: platform.KindGitHub, PlatformHost: "github.com",
+			Owner: "acme", Name: "widget", PlatformExternalID: "repo-a",
+		}},
+		time.Minute, nil, nil,
+	)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var blockOnce sync.Once
+	syncer.afterNotificationRepoIdentityReconciled = func() {
+		blockOnce.Do(func() {
+			close(started)
+			<-release
+		})
+	}
+	done := make(chan error, 1)
+	go func() { done <- syncer.SyncNotifications(ctx) }()
+	<-started
+	require.NoError(reconcileRepositoryRouteABA(
+		ctx, database, observedAt, "repo-a", "repo-b", "acme", "widget",
+	))
+	require.NoError(database.UpdateRepoMergeSettings(
+		ctx, original.Repository.ID, false, false, false,
+	))
+	close(release)
+	require.NoError(<-done)
+
+	stored, err := database.GetRepoByID(ctx, original.Repository.ID)
+	require.NoError(err)
+	require.NotNil(stored)
+	require.False(stored.AllowSquashMerge)
+	require.Equal(int32(2), repositoryCalls.Load(), "stale settings must trigger one retry")
+}
+
+func TestEnsureCloneForRouteRemovesFetchedCloneAfterABARouteReuse(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	observedAt := time.Now().UTC()
+	identity := db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com", PlatformRepoID: "repo-a",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+	}
+	entry, _, err := database.ReconcileRepositoryObservation(ctx, identity, observedAt)
+	require.NoError(err)
+	routeFence, found, err := database.CurrentRepositoryRouteFence(
+		ctx, identity, entry.Repository.ID,
+	)
+	require.NoError(err)
+	require.True(found)
+
+	clones := gitclone.New(t.TempDir(), nil)
+	repo := RepoRef{
+		Platform: platform.KindGitHub, PlatformHost: "github.com",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+		PlatformExternalID: "repo-a", CloneURL: setupBareRemoteForSyncTest(t),
+	}
+	syncer := &Syncer{db: database, clones: clones}
+	cloneFetched := make(chan struct{})
+	releaseValidation := make(chan struct{})
+	syncer.beforeCloneRouteValidation = func() {
+		close(cloneFetched)
+		<-releaseValidation
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- syncer.ensureCloneForRoute(ctx, repo, entry.Repository.ID, routeFence)
+	}()
+	<-cloneFetched
+	require.NoError(reconcileRepositoryRouteABA(
+		ctx, database, observedAt, "repo-a", "repo-b", "acme", "widget",
+	))
+	close(releaseValidation)
+	require.ErrorIs(<-done, db.ErrRepositoryRouteFenceChanged)
+
+	clonePath, err := clones.ClonePathForContext(
+		withCloneRepositoryIdentity(ctx, repo),
+		"github", "github.com", "acme", "widget",
+	)
+	require.NoError(err)
+	assert.NoDirExists(clonePath)
+}
+
+func TestSyncMRDiffRejectsCloneFetchedAcrossABARouteReuse(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	observedAt := time.Now().UTC()
+	identity := db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com", PlatformRepoID: "repo-a",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+	}
+	entry, _, err := database.ReconcileRepositoryObservation(ctx, identity, observedAt)
+	require.NoError(err)
+	routeFence, found, err := database.CurrentRepositoryRouteFence(
+		ctx, identity, entry.Repository.ID,
+	)
+	require.NoError(err)
+	require.True(found)
+
+	clones := gitclone.New(t.TempDir(), nil)
+	repo := RepoRef{
+		Platform: platform.KindGitHub, PlatformHost: "github.com",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+		PlatformExternalID: "repo-a", CloneURL: setupBareRemoteForSyncTest(t),
+	}
+	syncer := &Syncer{db: database, clones: clones}
+	cloneFetched := make(chan struct{})
+	releaseValidation := make(chan struct{})
+	syncer.beforeCloneRouteValidation = func() {
+		close(cloneFetched)
+		<-releaseValidation
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- syncer.syncMRDiff(
+			ctx, repo, entry.Repository.ID, 0, 0, 1,
+			&gh.PullRequest{}, &db.MergeRequest{}, routeFence,
+		)
+	}()
+	<-cloneFetched
+	require.NoError(reconcileRepositoryRouteABA(
+		ctx, database, observedAt, "repo-a", "repo-b", "acme", "widget",
+	))
+	close(releaseValidation)
+	err = <-done
+	require.ErrorIs(err, db.ErrRepositoryRouteFenceChanged)
+	var diffErr *DiffSyncError
+	require.ErrorAs(err, &diffErr)
+	assert.Equal(DiffSyncCodeCloneUnavailable, diffErr.Code)
+
+	clonePath, err := clones.ClonePathForContext(
+		withCloneRepositoryIdentity(ctx, repo),
+		"github", "github.com", "acme", "widget",
+	)
+	require.NoError(err)
+	assert.NoDirExists(clonePath)
+}
+
+func TestSyncNotificationsRetriesSettingsAfterNewerSameRouteObservation(t *testing.T) {
+	require := require.New(t)
+	database := openTestDB(t)
+	ctx := t.Context()
+	identity := db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com", PlatformRepoID: "repo-a",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+	}
+	original, _, err := database.ReconcileRepositoryObservation(
+		ctx, identity, time.Now().UTC(),
+	)
+	require.NoError(err)
+	require.NoError(database.UpdateRepoMergeSettings(
+		ctx, original.Repository.ID, false, false, false,
+	))
+
+	var repositoryCalls atomic.Int32
+	client := &mockClient{
+		getRepositoryFn: func(_ context.Context, owner, name string) (*gh.Repository, error) {
+			allowSquash := repositoryCalls.Add(1) == 1
+			return &gh.Repository{
+				NodeID: new("repo-a"), Name: &name, Owner: &gh.User{Login: &owner},
+				AllowSquashMerge: &allowSquash, AllowMergeCommit: new(false),
+				AllowRebaseMerge: new(false),
+			}, nil
+		},
+		listNotificationsFn: func(context.Context, NotificationListOptions) ([]NotificationThread, bool, error) {
+			return nil, false, nil
+		},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client}, database, nil,
+		[]RepoRef{{
+			Platform: platform.KindGitHub, PlatformHost: "github.com",
+			Owner: "acme", Name: "widget", PlatformExternalID: "repo-a",
+		}},
+		time.Minute, nil, nil,
+	)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var blockOnce sync.Once
+	syncer.afterNotificationRepoIdentityReconciled = func() {
+		blockOnce.Do(func() {
+			close(started)
+			<-release
+		})
+	}
+	done := make(chan error, 1)
+	go func() { done <- syncer.SyncNotifications(ctx) }()
+	<-started
+	_, accepted, err := database.ReconcileRepositoryObservation(
+		ctx, identity, time.Now().UTC(),
+	)
+	require.NoError(err)
+	require.True(accepted)
+	require.NoError(database.UpdateRepoMergeSettings(
+		ctx, original.Repository.ID, false, false, false,
+	))
+	close(release)
+	require.NoError(<-done)
+
+	stored, err := database.GetRepoByID(ctx, original.Repository.ID)
+	require.NoError(err)
+	require.NotNil(stored)
+	require.False(stored.AllowSquashMerge)
+	require.Equal(int32(2), repositoryCalls.Load(), "stale settings must trigger one retry")
+}
+
+func TestSyncNotificationsRetriesBeforeListingWhenRepositoryObservationIsStale(t *testing.T) {
+	require := require.New(t)
+	database := openTestDB(t)
+	ctx := t.Context()
+	identity := db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com", PlatformRepoID: "repo-a",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+	}
+	original, _, err := database.ReconcileRepositoryObservation(
+		ctx, identity, time.Now().UTC(),
+	)
+	require.NoError(err)
+	require.NoError(database.UpdateRepoMergeSettings(
+		ctx, original.Repository.ID, false, false, false,
+	))
+
+	var repositoryCalls atomic.Int32
+	var listCalls atomic.Int32
+	client := &mockClient{
+		getRepositoryFn: func(_ context.Context, owner, name string) (*gh.Repository, error) {
+			call := repositoryCalls.Add(1)
+			if call == 1 {
+				// This observation lands after syncRepoIdentity captured its
+				// timestamp but before that snapshot is reconciled.
+				_, accepted, reconcileErr := database.ReconcileRepositoryObservation(
+					ctx, identity, time.Now().UTC(),
+				)
+				require.NoError(reconcileErr)
+				require.True(accepted)
+			}
+			allowSquash := call == 1
+			return &gh.Repository{
+				NodeID: new("repo-a"), Name: &name, Owner: &gh.User{Login: &owner},
+				AllowSquashMerge: &allowSquash, AllowMergeCommit: new(false),
+				AllowRebaseMerge: new(false),
+			}, nil
+		},
+		listNotificationsFn: func(context.Context, NotificationListOptions) ([]NotificationThread, bool, error) {
+			listCalls.Add(1)
+			return nil, false, nil
+		},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client}, database, nil,
+		[]RepoRef{{
+			Platform: platform.KindGitHub, PlatformHost: "github.com",
+			Owner: "acme", Name: "widget", PlatformExternalID: "repo-a",
+		}},
+		time.Minute, nil, nil,
+	)
+
+	require.NoError(syncer.SyncNotifications(ctx))
+	stored, err := database.GetRepoByID(ctx, original.Repository.ID)
+	require.NoError(err)
+	require.NotNil(stored)
+	require.False(stored.AllowSquashMerge)
+	require.Equal(int32(2), repositoryCalls.Load(), "stale identity must retry")
+	require.Equal(int32(2), listCalls.Load(), "only the successful attempt may list")
+}
+
 func TestSyncNotificationsUsesPersistedSinceWatermark(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
@@ -3696,6 +4395,154 @@ func TestSyncNotificationsUsesPersistedSinceWatermark(t *testing.T) {
 	if assert.NotNil(seen[1].Since) {
 		assert.True(watermark.Add(-notificationSyncSinceOverlap).Equal(*seen[1].Since))
 	}
+}
+
+func TestSyncNotificationsFullSyncsAfterConflictingProviderIDAtPath(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	d := openTestDB(t)
+	_, err := d.UpsertRepoByProviderID(t.Context(), db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "R_displaced",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	require.NoError(err)
+	watermark := time.Now().UTC().Add(-time.Minute)
+	lastFullSyncAt := watermark
+	require.NoError(d.UpdateNotificationSyncWatermark(
+		t.Context(), "github", "github.com", "acme", "widget", watermark, &lastFullSyncAt,
+	))
+	_, err = d.UpsertRepoByProviderID(t.Context(), db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "R_incoming",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	require.NoError(err)
+
+	var seen []NotificationListOptions
+	syncer := NewSyncer(
+		map[string]Client{
+			"github.com": &mockClient{
+				listNotificationsFn: func(_ context.Context, opts NotificationListOptions) ([]NotificationThread, bool, error) {
+					seen = append(seen, opts)
+					return nil, false, nil
+				},
+			},
+		},
+		d,
+		nil,
+		[]RepoRef{{Owner: "acme", Name: "widget", PlatformHost: "github.com"}},
+		time.Minute,
+		nil,
+		nil,
+	)
+
+	require.NoError(syncer.SyncNotifications(t.Context()))
+	require.Len(seen, 2)
+	assert.Nil(seen[0].Since)
+	assert.Nil(seen[1].Since)
+}
+
+func TestSyncNotificationsRetriesAfterRepositoryReplacement(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	d := openTestDB(t)
+	ctx := t.Context()
+	_, err := d.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "R_original",
+		Owner:          "acme",
+		Name:           "alpha",
+	})
+	require.NoError(err)
+	watermark := time.Now().UTC().Add(-time.Minute)
+	require.NoError(d.UpdateNotificationSyncWatermark(
+		ctx, "github", "github.com", "acme", "alpha", watermark, &watermark,
+	))
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	number := 7
+	var calls atomic.Int32
+	var providerRepoID atomic.Value
+	providerRepoID.Store("R_original")
+	syncer := NewSyncer(
+		map[string]Client{
+			"github.com": &mockClient{
+				getRepositoryFn: func(_ context.Context, owner, name string) (*gh.Repository, error) {
+					return &gh.Repository{
+						ID: new(int64(1)), NodeID: new(providerRepoID.Load().(string)), Name: &name,
+						Owner: &gh.User{Login: &owner},
+					}, nil
+				},
+				listNotificationsFn: func(_ context.Context, _ NotificationListOptions) ([]NotificationThread, bool, error) {
+					call := calls.Add(1)
+					if call == 1 {
+						close(started)
+						<-release
+						return nil, false, nil
+					}
+					if call > 2 {
+						return nil, false, nil
+					}
+					return []NotificationThread{{
+						ID: "stale-thread", RepoOwner: "acme", RepoName: "alpha",
+						SubjectType: "PullRequest", SubjectTitle: "stale notification",
+						WebURL:     "https://github.com/acme/alpha/pull/7",
+						ItemNumber: &number, ItemType: "pr", Reason: "mention",
+						Unread: true, UpdatedAt: watermark,
+					}}, false, nil
+				},
+			},
+		},
+		d,
+		nil,
+		[]RepoRef{{Owner: "acme", Name: "alpha", PlatformHost: "github.com"}},
+		time.Minute,
+		nil,
+		nil,
+	)
+
+	done := make(chan error, 1)
+	go func() { done <- syncer.SyncNotifications(ctx) }()
+	<-started
+	observedAt := time.Now().UTC()
+	_, _, err = d.ReconcileRepositoryObservation(ctx, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "R_original",
+		Owner:          "acme",
+		Name:           "beta",
+		RepoPath:       "acme/beta",
+	}, observedAt)
+	require.NoError(err)
+	_, _, err = d.ReconcileRepositoryObservation(ctx, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "R_replacement",
+		Owner:          "acme",
+		Name:           "alpha",
+		RepoPath:       "acme/alpha",
+	}, observedAt.Add(time.Nanosecond))
+	require.NoError(err)
+	providerRepoID.Store("R_replacement")
+	close(release)
+	require.NoError(<-done)
+
+	restored, err := d.GetNotificationSyncWatermark(
+		ctx, "github", "github.com", "acme", "alpha",
+	)
+	require.NoError(err)
+	assert.NotNil(restored)
+	assert.Equal(int32(4), calls.Load())
+	notifications, err := d.ListNotifications(ctx, db.ListNotificationsOpts{State: "all"})
+	require.NoError(err)
+	assert.Empty(notifications)
 }
 
 func TestSyncNotificationsDoesPeriodicFullSyncForReadState(t *testing.T) {
@@ -4741,6 +5588,47 @@ func TestSyncRefreshesRepoLabelCatalog(t *testing.T) {
 	require.Equal(int32(1), client.calls.Load())
 }
 
+func TestRefreshRepoLabelCatalogRejectsABARoutePayload(t *testing.T) {
+	require := require.New(t)
+	database := openTestDB(t)
+	ctx := t.Context()
+	observedAt := time.Now().UTC()
+	original, _, err := database.ReconcileRepositoryObservation(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com", PlatformRepoID: "repo-a",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+	}, observedAt)
+	require.NoError(err)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	client := &labelCatalogTestClient{
+		mockClient: &mockClient{},
+		listRepoLabelsFn: func(context.Context, string, string) ([]*gh.Label, error) {
+			close(started)
+			<-release
+			return []*gh.Label{buildGitHubLabel(901, "replacement", "", "fbca04", false)}, nil
+		},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client}, database, nil, nil,
+		time.Minute, nil, nil,
+	)
+	done := make(chan error, 1)
+	go func() {
+		done <- syncer.RefreshRepoLabelCatalog(ctx, original.Repository)
+	}()
+	<-started
+	require.NoError(reconcileRepositoryRouteABA(
+		ctx, database, observedAt, "repo-a", "repo-b", "acme", "widget",
+	))
+	close(release)
+	require.NoError(<-done)
+
+	labels, _, err := database.ListRepoLabelCatalog(ctx, original.Repository.ID)
+	require.NoError(err)
+	require.Empty(labels)
+}
+
 func TestSyncMRReplacesLabelsOnResync(t *testing.T) {
 	require := require.New(t)
 	ctx := t.Context()
@@ -5122,8 +6010,10 @@ func TestReconcileRepoIdentityDiscardsStaleSameRouteMetadata(t *testing.T) {
 		d, nil, []RepoRef{repo}, time.Minute, nil, nil,
 	)
 
-	authoritative, repoID, resolved, err := syncer.reconcileRepoIdentity(ctx, repo)
+	authoritative, repoID, resolved, _, accepted, err :=
+		syncer.reconcileRepoIdentityObservation(ctx, repo)
 	require.NoError(err)
+	require.False(accepted)
 
 	assert.Equal(entry.Repository.ID, repoID)
 	assert.Nil(resolved,
@@ -7171,22 +8061,30 @@ func TestSyncRepoUpdatesViewerCanMergeWithoutMergeSettings(t *testing.T) {
 	require := require.New(t)
 	ctx := t.Context()
 	d := openTestDB(t)
-	repoID, err := d.UpsertRepo(ctx, db.RepoIdentity{
+	when := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	entry, accepted, err := d.ReconcileRepositoryObservation(ctx, db.RepoIdentity{
 		Platform:       "gitlab",
 		PlatformHost:   "gitlab.example.com",
 		PlatformRepoID: "gitlab-project",
 		Owner:          "group",
 		Name:           "project",
 		RepoPath:       "group/project",
-	})
+	}, when)
 	require.NoError(err)
+	require.True(accepted)
+	repoID := entry.Repository.ID
 	require.NoError(d.UpdateRepoSettings(ctx, repoID, true, false, true, true))
 	syncer := &Syncer{db: d}
 	viewerCanMerge := false
 
-	syncer.updateRepoSettingsFromProviderRepo(ctx, repoID, platform.Repository{
-		ViewerCanMerge: &viewerCanMerge,
-	})
+	applied, err := syncer.updateRepoSettingsFromProviderObservation(
+		ctx, repoID, when, platform.Repository{
+			PlatformExternalID: "gitlab-project",
+			ViewerCanMerge:     &viewerCanMerge,
+		},
+	)
+	require.NoError(err)
+	require.True(applied)
 
 	repos, err := d.ListRepos(ctx)
 	require.NoError(err)
@@ -7248,15 +8146,19 @@ func TestRefreshRepoSettingsPreservesViewerCanMergeWhenGitHubOmitsPermissions(t 
 	require := require.New(t)
 	ctx := t.Context()
 	d := openTestDB(t)
-	repoID, err := d.UpsertRepo(ctx, db.RepoIdentity{
+	identity := db.RepoIdentity{
 		Platform:       "github",
 		PlatformHost:   "github.com",
 		PlatformRepoID: "repo-acme-widgets",
 		Owner:          "acme",
 		Name:           "widgets",
 		RepoPath:       "acme/widgets",
-	})
+	}
+	observedAt := time.Now().UTC().Add(-time.Minute)
+	entry, accepted, err := d.ReconcileRepositoryObservation(ctx, identity, observedAt)
 	require.NoError(err)
+	require.True(accepted)
+	repoID := entry.Repository.ID
 	require.NoError(d.UpdateRepoSettings(ctx, repoID, true, true, true, false))
 	client := &mockClient{getRepositoryFn: func(
 		context.Context,
@@ -7265,6 +8167,7 @@ func TestRefreshRepoSettingsPreservesViewerCanMergeWhenGitHubOmitsPermissions(t 
 	) (*gh.Repository, error) {
 		return &gh.Repository{
 			Name:             new("widgets"),
+			NodeID:           new("repo-acme-widgets"),
 			AllowSquashMerge: new(false),
 			AllowMergeCommit: new(true),
 			AllowRebaseMerge: new(false),
@@ -7277,8 +8180,15 @@ func TestRefreshRepoSettingsPreservesViewerCanMergeWhenGitHubOmitsPermissions(t 
 		Name:         "widgets",
 		RepoPath:     "acme/widgets",
 	}}, time.Minute, nil, nil)
+	routeFence, found, err := d.CurrentRepositoryRouteFence(
+		ctx, identity, repoID,
+	)
+	require.NoError(err)
+	require.True(found)
 
-	syncer.refreshRepoSettings(ctx, syncer.repos[0], repoID, nil)
+	require.NoError(syncer.refreshRepoSettings(
+		ctx, syncer.repos[0], repoID, nil, observedAt, routeFence,
+	))
 
 	repos, err := d.ListRepos(ctx)
 	require.NoError(err)
@@ -7294,25 +8204,33 @@ func TestSyncRepoPreservesViewerCanMergeWhenMergeSettingsOmitPermission(t *testi
 	require := require.New(t)
 	ctx := t.Context()
 	d := openTestDB(t)
-	repoID, err := d.UpsertRepo(ctx, db.RepoIdentity{
+	when := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	entry, accepted, err := d.ReconcileRepositoryObservation(ctx, db.RepoIdentity{
 		Platform:       "gitlab",
 		PlatformHost:   "gitlab.example.com",
 		PlatformRepoID: "gitlab-project",
 		Owner:          "group",
 		Name:           "project",
 		RepoPath:       "group/project",
-	})
+	}, when)
 	require.NoError(err)
+	require.True(accepted)
+	repoID := entry.Repository.ID
 	require.NoError(d.UpdateRepoSettings(ctx, repoID, true, true, true, false))
 	syncer := &Syncer{db: d}
 
-	syncer.updateRepoSettingsFromProviderRepo(ctx, repoID, platform.Repository{
-		MergeSettings: &platform.RepositoryMergeSettings{
-			AllowSquashMerge: false,
-			AllowMergeCommit: true,
-			AllowRebaseMerge: false,
+	applied, err := syncer.updateRepoSettingsFromProviderObservation(
+		ctx, repoID, when, platform.Repository{
+			PlatformExternalID: "gitlab-project",
+			MergeSettings: &platform.RepositoryMergeSettings{
+				AllowSquashMerge: false,
+				AllowMergeCommit: true,
+				AllowRebaseMerge: false,
+			},
 		},
-	})
+	)
+	require.NoError(err)
+	require.True(applied)
 
 	repos, err := d.ListRepos(ctx)
 	require.NoError(err)
@@ -7401,7 +8319,10 @@ func TestSyncRepoUsesProviderCloneURLForNestedGitLabRepo(t *testing.T) {
 	syncer := NewSyncerWithRegistry(registry, d, clones, []RepoRef{repo}, time.Minute, nil, nil)
 
 	require.NoError(syncer.syncRepo(ctx, repo))
-	clonePath, err := clones.ClonePath("gitlab", "gitlab.example.com", "group/subgroup", "project")
+	clonePath, err := clones.ClonePathForContext(
+		gitclone.WithRepositoryIdentity(ctx, repo.PlatformExternalID),
+		"gitlab", "gitlab.example.com", "group/subgroup", "project",
+	)
 	require.NoError(err)
 	require.FileExists(filepath.Join(clonePath, "HEAD"))
 }
@@ -7476,7 +8397,12 @@ func TestDetailDrainUsesProviderCloneURLForNestedGitLabRepo(t *testing.T) {
 
 	assert.Equal(int32(1), provider.getRepositoryCalls.Load())
 	assert.Equal(int32(1), provider.getMRCalls.Load())
-	clonePath, err := clones.ClonePath("gitlab", "gitlab.example.com", "group/subgroup", "project")
+	clonePath, err := clones.ClonePathForContext(
+		gitclone.WithRepositoryIdentity(
+			ctx, verifiedDBRepoIdentity(platformRepoRef(repo)).PlatformRepoID,
+		),
+		"gitlab", "gitlab.example.com", "group/subgroup", "project",
+	)
 	require.NoError(err)
 	require.FileExists(filepath.Join(clonePath, "HEAD"))
 }
@@ -8599,8 +9525,15 @@ func TestFetchProviderMRDetailSyncsReviewThreads(t *testing.T) {
 	registry, err := platform.NewRegistry(provider)
 	require.NoError(err)
 	syncer := NewSyncerWithRegistry(registry, d, nil, []RepoRef{repo}, time.Minute, nil, nil)
+	routeFence, found, err := d.CurrentRepositoryRouteFence(
+		ctx, platform.DBRepoIdentity(ref), repoID,
+	)
+	require.NoError(err)
+	require.True(found)
 
-	calls, err := syncer.fetchProviderMRDetail(ctx, provider, repo, repoID, 42)
+	calls, err := syncer.fetchProviderMRDetail(
+		ctx, provider, repo, repoID, 42, routeFence,
+	)
 	require.NoError(err)
 	assert.Equal(3, calls)
 	assert.Equal(int32(1), provider.listReviewThreads.Load())
@@ -8624,7 +9557,9 @@ func TestFetchProviderMRDetailSyncsReviewThreads(t *testing.T) {
 	assert.Equal("thread-42", *events[0].ThreadID)
 
 	provider.reviewThreads = nil
-	calls, err = syncer.fetchProviderMRDetail(ctx, provider, repo, repoID, 42)
+	calls, err = syncer.fetchProviderMRDetail(
+		ctx, provider, repo, repoID, 42, routeFence,
+	)
 	require.NoError(err)
 	assert.Equal(3, calls)
 
@@ -9226,6 +10161,100 @@ func TestSyncIssueUsesProviderIssueReader(t *testing.T) {
 	events, err = d.ListIssueEvents(t.Context(), issue.ID)
 	require.NoError(err)
 	assert.Empty(events)
+}
+
+func TestDirectMRSyncReplacesConflictingPathOccupant(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	displacedID, err := database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform: "gitlab", PlatformHost: "gitlab.com", PlatformRepoID: "old-repo",
+		Owner: "acme", Name: "widget",
+	})
+	require.NoError(err)
+	require.NoError(database.UpdateRepoSettings(ctx, displacedID, false, false, false, false))
+
+	now := time.Date(2026, 8, 3, 9, 0, 0, 0, time.UTC)
+	repo := RepoRef{
+		Platform: platform.KindGitLab, PlatformHost: "gitlab.com",
+		Owner: "acme", Name: "widget", PlatformExternalID: "incoming-repo",
+	}
+	provider := &syncTestReadProvider{
+		syncTestProvider: syncTestProvider{kind: platform.KindGitLab, host: "gitlab.com"},
+		mergeRequests: []platform.MergeRequest{{
+			Repo: platformRepoRef(repo), PlatformID: 7007, Number: 7,
+			Title: "incoming merge request", State: "open",
+			CreatedAt: now, UpdatedAt: now, LastActivityAt: now,
+		}},
+	}
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+	syncer := NewSyncerWithRegistry(
+		registry, database, nil, []RepoRef{repo}, time.Minute, nil, nil,
+	)
+
+	require.NoError(syncer.SyncMROnProvider(
+		ctx, platform.KindGitLab, "gitlab.com", "acme", "widget", 7,
+	))
+
+	stored, err := database.GetRepoByIdentity(ctx, db.RepoIdentity{
+		Platform: "gitlab", PlatformHost: "gitlab.com", Owner: "acme", Name: "widget",
+	})
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.NotEqual(displacedID, stored.ID)
+	assert.Equal("incoming-repo", stored.PlatformRepoID)
+	assert.True(stored.AllowSquashMerge)
+	assert.False(stored.ViewerCanMerge,
+		"replacement must fail closed when the provider omits viewer permission")
+}
+
+func TestDirectIssueSyncReplacesConflictingPathOccupant(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	displacedID, err := database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform: "gitlab", PlatformHost: "gitlab.com", PlatformRepoID: "old-repo",
+		Owner: "acme", Name: "widget",
+	})
+	require.NoError(err)
+	require.NoError(database.UpdateRepoSettings(ctx, displacedID, false, false, false, false))
+
+	now := time.Date(2026, 8, 3, 9, 0, 0, 0, time.UTC)
+	repo := RepoRef{
+		Platform: platform.KindGitLab, PlatformHost: "gitlab.com",
+		Owner: "acme", Name: "widget", PlatformExternalID: "incoming-repo",
+	}
+	provider := &syncTestReadProvider{
+		syncTestProvider: syncTestProvider{kind: platform.KindGitLab, host: "gitlab.com"},
+		issues: []platform.Issue{{
+			Repo: platformRepoRef(repo), PlatformID: 8011, Number: 11,
+			Title: "incoming issue", State: "open",
+			CreatedAt: now, UpdatedAt: now, LastActivityAt: now,
+		}},
+	}
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+	syncer := NewSyncerWithRegistry(
+		registry, database, nil, []RepoRef{repo}, time.Minute, nil, nil,
+	)
+
+	require.NoError(syncer.SyncIssueOnProvider(
+		ctx, platform.KindGitLab, "gitlab.com", "acme", "widget", 11,
+	))
+
+	stored, err := database.GetRepoByIdentity(ctx, db.RepoIdentity{
+		Platform: "gitlab", PlatformHost: "gitlab.com", Owner: "acme", Name: "widget",
+	})
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.NotEqual(displacedID, stored.ID)
+	assert.Equal("incoming-repo", stored.PlatformRepoID)
+	assert.True(stored.AllowMergeCommit)
+	assert.False(stored.ViewerCanMerge,
+		"replacement must fail closed when the provider omits viewer permission")
 }
 
 func TestSyncIssueProviderCommentReplacementRollsBack(t *testing.T) {
@@ -10485,7 +11514,7 @@ func TestRunOnceRegistersProviderWorkForArchivedRefresh(t *testing.T) {
 			"admitted archive lease on the credential is preempted")
 }
 
-func TestReconcileRepoIdentityReturnsMidflightArchivedFlip(t *testing.T) {
+func TestReconcileRepoIdentityObservationReturnsMidflightArchivedFlip(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	d := openTestDB(t)
@@ -10508,7 +11537,9 @@ func TestReconcileRepoIdentityReturnsMidflightArchivedFlip(t *testing.T) {
 	)
 
 	snapshot := RepoRef{Owner: "acme", Name: "widget", PlatformHost: "github.com"}
-	authoritative, _, _, err := syncer.reconcileRepoIdentity(t.Context(), snapshot)
+	authoritative, _, _, _, _, err := syncer.reconcileRepoIdentityObservation(
+		t.Context(), snapshot,
+	)
 	require.NoError(err)
 
 	assert.True(authoritative.Archived,
@@ -11192,6 +12223,7 @@ type conditionalPRTrackingClient struct {
 	conditionalCalls atomic.Int32
 	notModified      bool
 	nextETag         string
+	beforeReturn     func()
 }
 
 func (c *conditionalPRTrackingClient) GetPullRequestIfChanged(
@@ -11202,6 +12234,9 @@ func (c *conditionalPRTrackingClient) GetPullRequestIfChanged(
 ) (*gh.PullRequest, string, bool, error) {
 	c.conditionalCalls.Add(1)
 	c.receivedETag = etag
+	if c.beforeReturn != nil {
+		c.beforeReturn()
+	}
 	if c.notModified {
 		return nil, etag, true, nil
 	}
@@ -11216,6 +12251,7 @@ type conditionalIssueTrackingClient struct {
 	conditionalCalls atomic.Int32
 	notModified      bool
 	nextETag         string
+	beforeReturn     func()
 }
 
 type conditionalIssueLifecycleClient struct {
@@ -11249,6 +12285,9 @@ func (c *conditionalIssueTrackingClient) GetIssueIfChanged(
 ) (*gh.Issue, string, bool, error) {
 	c.conditionalCalls.Add(1)
 	c.receivedETag = etag
+	if c.beforeReturn != nil {
+		c.beforeReturn()
+	}
 	if c.notModified {
 		return nil, etag, true, nil
 	}
@@ -15058,6 +16097,724 @@ func TestFetchIssueDetailRemovesDeletedCommentDuringFullRefresh(t *testing.T) {
 	assert.Empty(events)
 }
 
+func TestFetchMRDetailRejectsABARoutePayload(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	observedAt := time.Now().UTC()
+	repo := RepoRef{
+		Platform: platform.KindGitHub, PlatformHost: "github.com",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+	}
+	original, _, err := database.ReconcileRepositoryObservation(
+		ctx, db.RepoIdentity{
+			Platform: "github", PlatformHost: "github.com",
+			PlatformRepoID: "repo-a", Owner: "acme", Name: "widget",
+			RepoPath: "acme/widget",
+		}, observedAt,
+	)
+	require.NoError(err)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	client := &mockClient{getPullRequestFn: func(
+		context.Context, string, string, int,
+	) (*gh.PullRequest, error) {
+		close(started)
+		<-release
+		pr := buildOpenPR(7, observedAt.Add(time.Hour))
+		pr.Title = new("replacement payload")
+		return pr, nil
+	}}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client}, database, nil,
+		[]RepoRef{repo}, time.Minute, nil, nil,
+	)
+	done := make(chan error, 1)
+	go func() {
+		_, fetchErr := syncer.fetchMRDetail(
+			ctx, repo, original.Repository.ID, 7, false,
+		)
+		done <- fetchErr
+	}()
+	<-started
+	require.NoError(reconcileRepositoryRouteABA(
+		ctx, database, observedAt, "repo-a", "repo-b", "acme", "widget",
+	))
+	close(release)
+	require.NoError(<-done)
+
+	mr, err := database.GetMergeRequestByRepoIDAndNumber(
+		ctx, original.Repository.ID, 7,
+	)
+	require.NoError(err)
+	require.Nil(mr)
+}
+
+func TestFetchMRDetailRejectsChildSnapshotAfterABARouteReuse(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	observedAt := time.Now().UTC()
+	repo := RepoRef{
+		Platform: platform.KindGitHub, PlatformHost: "github.com",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+	}
+	original, _, err := database.ReconcileRepositoryObservation(
+		ctx, db.RepoIdentity{
+			Platform: "github", PlatformHost: "github.com",
+			PlatformRepoID: "repo-a", Owner: "acme", Name: "widget",
+			RepoPath: "acme/widget",
+		}, observedAt,
+	)
+	require.NoError(err)
+	aboutToWriteChild := make(chan struct{})
+	abaDone := make(chan struct{})
+	abaErr := make(chan error, 1)
+	commentID := int64(91)
+	commentBody := "replacement repository comment"
+	client := &mockClient{
+		getPullRequestFn: func(
+			context.Context, string, string, int,
+		) (*gh.PullRequest, error) {
+			return buildOpenPR(7, observedAt.Add(time.Hour)), nil
+		},
+		listIssueCommentsFn: func(
+			context.Context, string, string, int,
+		) ([]*gh.IssueComment, error) {
+			close(aboutToWriteChild)
+			<-abaDone
+			return []*gh.IssueComment{{
+				ID: &commentID, Body: &commentBody,
+				CreatedAt: makeTimestamp(observedAt.Add(time.Hour)),
+				UpdatedAt: makeTimestamp(observedAt.Add(time.Hour)),
+			}}, nil
+		},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client}, database, nil,
+		[]RepoRef{repo}, time.Minute, nil, nil,
+	)
+	syncer.afterMergeRequestParentSnapshotCommit = func() {
+		go func() {
+			abaErr <- reconcileRepositoryRouteABA(
+				ctx, database, observedAt, "repo-a", "repo-b", "acme", "widget",
+			)
+			close(abaDone)
+		}()
+	}
+
+	_, err = syncer.fetchMRDetail(ctx, repo, original.Repository.ID, 7, false)
+	require.NoError(err)
+	select {
+	case <-aboutToWriteChild:
+	default:
+	}
+	<-abaDone
+	require.NoError(<-abaErr)
+
+	mr, err := database.GetMergeRequestByRepoIDAndNumber(
+		ctx, original.Repository.ID, 7,
+	)
+	require.NoError(err)
+	require.NotNil(mr)
+	events, err := database.ListMREvents(ctx, mr.ID)
+	require.NoError(err)
+	require.Empty(events)
+}
+
+func TestFetchIssueDetailRejectsABARoutePayload(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	observedAt := time.Now().UTC()
+	repo := RepoRef{
+		Platform: platform.KindGitHub, PlatformHost: "github.com",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+	}
+	original, _, err := database.ReconcileRepositoryObservation(
+		ctx, db.RepoIdentity{
+			Platform: "github", PlatformHost: "github.com",
+			PlatformRepoID: "repo-a", Owner: "acme", Name: "widget",
+			RepoPath: "acme/widget",
+		}, observedAt,
+	)
+	require.NoError(err)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	client := &mockClient{getIssueFn: func(
+		context.Context, string, string, int,
+	) (*gh.Issue, error) {
+		close(started)
+		<-release
+		issue := buildOpenIssue(7, observedAt.Add(time.Hour))
+		issue.Title = new("replacement payload")
+		return issue, nil
+	}}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client}, database, nil,
+		[]RepoRef{repo}, time.Minute, nil, nil,
+	)
+	done := make(chan error, 1)
+	go func() {
+		_, fetchErr := syncer.fetchIssueDetail(
+			ctx, repo, original.Repository.ID, 7,
+		)
+		done <- fetchErr
+	}()
+	<-started
+	require.NoError(reconcileRepositoryRouteABA(
+		ctx, database, observedAt, "repo-a", "repo-b", "acme", "widget",
+	))
+	close(release)
+	require.NoError(<-done)
+
+	issue, err := database.GetIssueByRepoIDAndNumber(
+		ctx, original.Repository.ID, 7,
+	)
+	require.NoError(err)
+	require.Nil(issue)
+}
+
+func TestFetchIssueDetailRejectsChildSnapshotAfterABARouteReuse(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	observedAt := time.Now().UTC()
+	repo := RepoRef{
+		Platform: platform.KindGitHub, PlatformHost: "github.com",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+	}
+	original, _, err := database.ReconcileRepositoryObservation(
+		ctx, db.RepoIdentity{
+			Platform: "github", PlatformHost: "github.com",
+			PlatformRepoID: "repo-a", Owner: "acme", Name: "widget",
+			RepoPath: "acme/widget",
+		}, observedAt,
+	)
+	require.NoError(err)
+	childFetchStarted := make(chan struct{})
+	releaseChildFetch := make(chan struct{})
+	commentID := int64(92)
+	commentBody := "replacement repository issue comment"
+	client := &mockClient{
+		getIssueFn: func(
+			context.Context, string, string, int,
+		) (*gh.Issue, error) {
+			return buildOpenIssue(7, observedAt.Add(time.Hour)), nil
+		},
+		listIssueCommentsFn: func(
+			context.Context, string, string, int,
+		) ([]*gh.IssueComment, error) {
+			close(childFetchStarted)
+			<-releaseChildFetch
+			return []*gh.IssueComment{{
+				ID: &commentID, Body: &commentBody,
+				CreatedAt: makeTimestamp(observedAt.Add(time.Hour)),
+				UpdatedAt: makeTimestamp(observedAt.Add(time.Hour)),
+			}}, nil
+		},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client}, database, nil,
+		[]RepoRef{repo}, time.Minute, nil, nil,
+	)
+	done := make(chan error, 1)
+	go func() {
+		_, fetchErr := syncer.fetchIssueDetail(
+			ctx, repo, original.Repository.ID, 7,
+		)
+		done <- fetchErr
+	}()
+	<-childFetchStarted
+	require.NoError(reconcileRepositoryRouteABA(
+		ctx, database, observedAt, "repo-a", "repo-b", "acme", "widget",
+	))
+	close(releaseChildFetch)
+	require.NoError(<-done)
+
+	issue, err := database.GetIssueByRepoIDAndNumber(
+		ctx, original.Repository.ID, 7,
+	)
+	require.NoError(err)
+	require.NotNil(issue)
+	events, err := database.ListIssueEvents(ctx, issue.ID)
+	require.NoError(err)
+	require.Empty(events)
+}
+
+func TestDeferredCommentRefreshRejectsABARoutePayload(t *testing.T) {
+	t.Run("pull request", func(t *testing.T) {
+		require := require.New(t)
+		database := openTestDB(t)
+		ctx := t.Context()
+		observedAt := time.Now().UTC()
+		repo := RepoRef{
+			Platform: platform.KindGitHub, PlatformHost: "github.com",
+			Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+			PlatformExternalID: "repo-a",
+		}
+		original, _, err := database.ReconcileRepositoryObservation(ctx, db.RepoIdentity{
+			Platform: "github", PlatformHost: "github.com", PlatformRepoID: "repo-a",
+			Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+		}, observedAt)
+		require.NoError(err)
+		detailFetchedAt := observedAt
+		_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+			RepoID: original.Repository.ID, PlatformID: 7007, Number: 7,
+			URL: "https://github.com/acme/widget/pull/7", Title: "original",
+			State: db.MergeRequestStateOpen, CreatedAt: observedAt,
+			UpdatedAt: observedAt, LastActivityAt: observedAt,
+			DetailFetchedAt: &detailFetchedAt,
+		})
+		require.NoError(err)
+
+		started := make(chan struct{})
+		release := make(chan struct{})
+		commentID, body, login := int64(91), "replacement comment", "reviewer"
+		client := &mockClient{listIssueCommentsIfChangedFn: func(
+			context.Context, string, string, int,
+		) ([]*gh.IssueComment, error) {
+			close(started)
+			<-release
+			return []*gh.IssueComment{{
+				ID: &commentID, Body: &body, User: &gh.User{Login: &login},
+				CreatedAt: makeTimestamp(observedAt.Add(time.Hour)),
+				UpdatedAt: makeTimestamp(observedAt.Add(time.Hour)),
+			}}, nil
+		}}
+		syncer := NewSyncer(
+			map[string]Client{"github.com": client}, database, nil,
+			[]RepoRef{repo}, time.Minute, nil, nil,
+		)
+		syncer.queuePRCommentSync(repo, original.Repository.ID, 7)
+		done := make(chan struct{})
+		go func() {
+			syncer.drainPendingCommentSyncs(ctx, map[string]bool{"github.com": true})
+			close(done)
+		}()
+		<-started
+		require.NoError(reconcileRepositoryRouteABA(
+			ctx, database, observedAt, "repo-a", "repo-b", "acme", "widget",
+		))
+		close(release)
+		<-done
+
+		stored, err := database.GetMergeRequestByRepoIDAndNumber(ctx, original.Repository.ID, 7)
+		require.NoError(err)
+		require.NotNil(stored)
+		events, err := database.ListMREvents(ctx, stored.ID)
+		require.NoError(err)
+		require.Empty(events)
+	})
+
+	t.Run("issue", func(t *testing.T) {
+		require := require.New(t)
+		database := openTestDB(t)
+		ctx := t.Context()
+		observedAt := time.Now().UTC()
+		repo := RepoRef{
+			Platform: platform.KindGitHub, PlatformHost: "github.com",
+			Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+			PlatformExternalID: "repo-a",
+		}
+		original, _, err := database.ReconcileRepositoryObservation(ctx, db.RepoIdentity{
+			Platform: "github", PlatformHost: "github.com", PlatformRepoID: "repo-a",
+			Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+		}, observedAt)
+		require.NoError(err)
+		detailFetchedAt := observedAt
+		_, err = database.UpsertIssue(ctx, &db.Issue{
+			RepoID: original.Repository.ID, PlatformID: 8007, Number: 7,
+			URL: "https://github.com/acme/widget/issues/7", Title: "original",
+			State: "open", CreatedAt: observedAt, UpdatedAt: observedAt,
+			LastActivityAt: observedAt, DetailFetchedAt: &detailFetchedAt,
+		})
+		require.NoError(err)
+
+		started := make(chan struct{})
+		release := make(chan struct{})
+		commentID, body, login := int64(92), "replacement comment", "reviewer"
+		client := &mockClient{listIssueCommentsIfChangedFn: func(
+			context.Context, string, string, int,
+		) ([]*gh.IssueComment, error) {
+			close(started)
+			<-release
+			return []*gh.IssueComment{{
+				ID: &commentID, Body: &body, User: &gh.User{Login: &login},
+				CreatedAt: makeTimestamp(observedAt.Add(time.Hour)),
+				UpdatedAt: makeTimestamp(observedAt.Add(time.Hour)),
+			}}, nil
+		}}
+		syncer := NewSyncer(
+			map[string]Client{"github.com": client}, database, nil,
+			[]RepoRef{repo}, time.Minute, nil, nil,
+		)
+		syncer.queueIssueCommentSync(repo, original.Repository.ID, 7)
+		done := make(chan struct{})
+		go func() {
+			syncer.drainPendingCommentSyncs(ctx, map[string]bool{"github.com": true})
+			close(done)
+		}()
+		<-started
+		require.NoError(reconcileRepositoryRouteABA(
+			ctx, database, observedAt, "repo-a", "repo-b", "acme", "widget",
+		))
+		close(release)
+		<-done
+
+		stored, err := database.GetIssueByRepoIDAndNumber(ctx, original.Repository.ID, 7)
+		require.NoError(err)
+		require.NotNil(stored)
+		events, err := database.ListIssueEvents(ctx, stored.ID)
+		require.NoError(err)
+		require.Empty(events)
+	})
+}
+
+func TestFetchMRDetailRejectsABAOnNotModified(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	observedAt := time.Now().UTC()
+	repo := RepoRef{
+		Platform: platform.KindGitHub, PlatformHost: "github.com",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+	}
+	original, _, err := database.ReconcileRepositoryObservation(
+		ctx, db.RepoIdentity{
+			Platform: "github", PlatformHost: "github.com",
+			PlatformRepoID: "repo-a", Owner: "acme", Name: "widget",
+			RepoPath: "acme/widget",
+		}, observedAt,
+	)
+	require.NoError(err)
+	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID: original.Repository.ID, PlatformID: 7007, Number: 7,
+		URL: "https://github.com/acme/widget/pull/7", Title: "original",
+		State: db.MergeRequestStateOpen, CreatedAt: observedAt,
+		UpdatedAt: observedAt, LastActivityAt: observedAt,
+	})
+	require.NoError(err)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	client := &conditionalPRTrackingClient{notModified: true}
+	client.beforeReturn = func() {
+		close(started)
+		<-release
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client}, database, nil,
+		[]RepoRef{repo}, time.Minute, nil, nil,
+	)
+	done := make(chan error, 1)
+	go func() {
+		_, fetchErr := syncer.fetchMRDetail(
+			ctx, repo, original.Repository.ID, 7, false,
+		)
+		done <- fetchErr
+	}()
+	<-started
+	require.NoError(reconcileRepositoryRouteABA(
+		ctx, database, observedAt, "repo-a", "repo-b", "acme", "widget",
+	))
+	close(release)
+	require.NoError(<-done)
+
+	mr, err := database.GetMergeRequestByRepoIDAndNumber(
+		ctx, original.Repository.ID, 7,
+	)
+	require.NoError(err)
+	require.NotNil(mr)
+	require.Nil(mr.DetailFetchedAt)
+}
+
+func TestFetchMRDetailRejectsCIFromABAOnNotModified(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	observedAt := time.Now().UTC()
+	repo := RepoRef{
+		Platform: platform.KindGitHub, PlatformHost: "github.com",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+	}
+	original, _, err := database.ReconcileRepositoryObservation(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com", PlatformRepoID: "repo-a",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+	}, observedAt)
+	require.NoError(err)
+	const oldChecks = `[{"name":"old","status":"in_progress"}]`
+	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID: original.Repository.ID, PlatformID: 7007, Number: 7,
+		URL: "https://github.com/acme/widget/pull/7", Title: "original",
+		State: db.MergeRequestStateOpen, PlatformHeadSHA: "head-a",
+		CIStatus: "pending", CIChecksJSON: oldChecks, CIHadPending: true,
+		CreatedAt: observedAt, UpdatedAt: observedAt, LastActivityAt: observedAt,
+	})
+	require.NoError(err)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	client := &conditionalPRTrackingClient{notModified: true}
+	client.ciStatus = &gh.CombinedStatus{State: new("success")}
+	client.listCheckRunsForRefFn = func(
+		context.Context, string, string, string,
+	) ([]*gh.CheckRun, error) {
+		close(started)
+		<-release
+		return []*gh.CheckRun{{
+			Name: new("replacement"), Status: new("completed"), Conclusion: new("success"),
+		}}, nil
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client}, database, nil,
+		[]RepoRef{repo}, time.Minute, nil, nil,
+	)
+	done := make(chan error, 1)
+	go func() {
+		_, fetchErr := syncer.fetchMRDetail(
+			ctx, repo, original.Repository.ID, 7, false,
+		)
+		done <- fetchErr
+	}()
+	<-started
+	require.NoError(reconcileRepositoryRouteABA(
+		ctx, database, observedAt, "repo-a", "repo-b", "acme", "widget",
+	))
+	close(release)
+	require.NoError(<-done)
+
+	mr, err := database.GetMergeRequestByRepoIDAndNumber(ctx, original.Repository.ID, 7)
+	require.NoError(err)
+	require.NotNil(mr)
+	require.Equal("pending", mr.CIStatus)
+	require.JSONEq(oldChecks, mr.CIChecksJSON)
+	require.Nil(mr.DetailFetchedAt)
+}
+
+func TestFetchIssueDetailRejectsABAOnNotModified(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	observedAt := time.Now().UTC()
+	repo := RepoRef{
+		Platform: platform.KindGitHub, PlatformHost: "github.com",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+	}
+	original, _, err := database.ReconcileRepositoryObservation(
+		ctx, db.RepoIdentity{
+			Platform: "github", PlatformHost: "github.com",
+			PlatformRepoID: "repo-a", Owner: "acme", Name: "widget",
+			RepoPath: "acme/widget",
+		}, observedAt,
+	)
+	require.NoError(err)
+	_, err = database.UpsertIssue(ctx, &db.Issue{
+		RepoID: original.Repository.ID, PlatformID: 8007, Number: 7,
+		URL: "https://github.com/acme/widget/issues/7", Title: "original",
+		State: "open", CreatedAt: observedAt,
+		UpdatedAt: observedAt, LastActivityAt: observedAt,
+	})
+	require.NoError(err)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	client := &conditionalIssueTrackingClient{notModified: true}
+	client.beforeReturn = func() {
+		close(started)
+		<-release
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client}, database, nil,
+		[]RepoRef{repo}, time.Minute, nil, nil,
+	)
+	done := make(chan error, 1)
+	go func() {
+		_, fetchErr := syncer.fetchIssueDetail(
+			ctx, repo, original.Repository.ID, 7,
+		)
+		done <- fetchErr
+	}()
+	<-started
+	require.NoError(reconcileRepositoryRouteABA(
+		ctx, database, observedAt, "repo-a", "repo-b", "acme", "widget",
+	))
+	close(release)
+	require.NoError(<-done)
+
+	issue, err := database.GetIssueByRepoIDAndNumber(
+		ctx, original.Repository.ID, 7,
+	)
+	require.NoError(err)
+	require.NotNil(issue)
+	require.Nil(issue.DetailFetchedAt)
+}
+
+func TestSyncRepoRejectsListSnapshotAfterABARouteReuse(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	observedAt := time.Now().UTC()
+	repo := RepoRef{
+		Platform: platform.KindGitHub, PlatformHost: "github.com",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+	}
+	original, _, err := database.ReconcileRepositoryObservation(
+		ctx, db.RepoIdentity{
+			Platform: "github", PlatformHost: "github.com",
+			PlatformRepoID: "repo-a", Owner: "acme", Name: "widget",
+			RepoPath: "acme/widget",
+		}, observedAt,
+	)
+	require.NoError(err)
+	listStarted := make(chan struct{})
+	releaseList := make(chan struct{})
+	client := &mockClient{
+		getRepositoryFn: func(
+			context.Context, string, string,
+		) (*gh.Repository, error) {
+			return &gh.Repository{
+				ID: new(int64(1)), NodeID: new("repo-a"),
+				Owner: &gh.User{Login: new("acme")}, Name: new("widget"),
+				Archived: new(false),
+			}, nil
+		},
+		listOpenPRsFn: func(
+			context.Context, string, string,
+		) ([]*gh.PullRequest, error) {
+			close(listStarted)
+			<-releaseList
+			pr := buildOpenPR(7, observedAt.Add(time.Hour))
+			pr.Title = new("replacement repository PR")
+			return []*gh.PullRequest{pr}, nil
+		},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client}, database, nil,
+		[]RepoRef{repo}, time.Minute, nil, nil,
+	)
+	done := make(chan error, 1)
+	go func() { done <- syncer.syncRepo(ctx, repo) }()
+	<-listStarted
+	require.NoError(reconcileRepositoryRouteABA(
+		ctx, database, observedAt, "repo-a", "repo-b", "acme", "widget",
+	))
+	close(releaseList)
+	require.NoError(<-done)
+
+	mr, err := database.GetMergeRequestByRepoIDAndNumber(
+		ctx, original.Repository.ID, 7,
+	)
+	require.NoError(err)
+	require.Nil(mr)
+}
+
+func reconcileRepositoryRouteABA(
+	ctx context.Context,
+	database *db.DB,
+	observedAt time.Time,
+	originalProviderID, replacementProviderID, owner, name string,
+) error {
+	if now := time.Now().UTC(); now.After(observedAt) {
+		observedAt = now
+	}
+	_, _, err := database.ReconcileRepositoryObservation(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: originalProviderID, Owner: owner, Name: "renamed",
+		RepoPath: owner + "/renamed",
+	}, observedAt.Add(time.Nanosecond))
+	if err != nil {
+		return err
+	}
+	_, _, err = database.ReconcileRepositoryObservation(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: replacementProviderID, Owner: owner, Name: name,
+		RepoPath: owner + "/" + name,
+	}, observedAt.Add(2*time.Nanosecond))
+	if err != nil {
+		return err
+	}
+	_, _, err = database.ReconcileRepositoryObservation(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: replacementProviderID, Owner: owner, Name: "elsewhere",
+		RepoPath: owner + "/elsewhere",
+	}, observedAt.Add(3*time.Nanosecond))
+	if err != nil {
+		return err
+	}
+	_, _, err = database.ReconcileRepositoryObservation(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: originalProviderID, Owner: owner, Name: name,
+		RepoPath: owner + "/" + name,
+	}, observedAt.Add(4*time.Nanosecond))
+	return err
+}
+
+func TestSyncClosedMROnProviderDropsSnapshotAcrossABARouteReuse(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	database := openTestDB(t)
+	observedAt := time.Now().UTC()
+	identity := db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "repo-a", Owner: "acme", Name: "widget",
+		RepoPath: "acme/widget",
+	}
+	entry, _, err := database.ReconcileRepositoryObservation(
+		ctx, identity, observedAt,
+	)
+	require.NoError(err)
+	now := observedAt.Add(-time.Hour)
+	original := buildOpenPR(7, now)
+	original.Title = new("repository A")
+	normalized, err := NormalizePR(entry.Repository.ID, original)
+	require.NoError(err)
+	_, err = database.UpsertMergeRequest(ctx, normalized)
+	require.NoError(err)
+
+	fetchStarted := make(chan struct{})
+	releaseFetch := make(chan struct{})
+	client := &mockClient{getPullRequestFn: func(
+		context.Context, string, string, int,
+	) (*gh.PullRequest, error) {
+		close(fetchStarted)
+		<-releaseFetch
+		stale := buildOpenPR(7, observedAt.Add(time.Hour))
+		stale.Title = new("repository B")
+		stale.State = new("closed")
+		stale.ClosedAt = makeTimestamp(observedAt.Add(time.Hour))
+		return stale, nil
+	}}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": client}, database, nil,
+		[]RepoRef{{
+			Platform: platform.KindGitHub, PlatformHost: "github.com",
+			PlatformExternalID: "repo-a", Owner: "acme", Name: "widget",
+			RepoPath: "acme/widget",
+		}},
+		time.Minute, nil, testBudget(100),
+	)
+	done := make(chan error, 1)
+	go func() {
+		done <- syncer.SyncClosedMROnProvider(
+			ctx, entry.Repository.ID, 7,
+		)
+	}()
+	<-fetchStarted
+	require.NoError(reconcileRepositoryRouteABA(
+		ctx, database, observedAt, "repo-a", "repo-b", "acme", "widget",
+	))
+	close(releaseFetch)
+	require.NoError(<-done)
+
+	stored, err := database.GetMergeRequestByRepoIDAndNumber(
+		ctx, entry.Repository.ID, 7,
+	)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.Equal("repository A", stored.Title)
+	assert.Equal(db.MergeRequestStateOpen, stored.State)
+}
+
 func TestSyncOpenMRFromBulkRemovesDeletedCommentsWhenCommentsAreComplete(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -16895,8 +18652,8 @@ func TestDrainPendingCommentSyncsReadsQueuedItemsByProviderIdentity(t *testing.T
 		[]RepoRef{codeRepo, githubRepo},
 		time.Minute, nil, nil,
 	)
-	syncer.queuePRCommentSync(codeRepo, 7)
-	syncer.queueIssueCommentSync(codeRepo, 8)
+	syncer.queuePRCommentSync(codeRepo, codeRepoID, 7)
+	syncer.queueIssueCommentSync(codeRepo, codeRepoID, 8)
 
 	syncer.drainPendingCommentSyncs(ctx, map[string]bool{"code.example.com": true})
 
@@ -17140,7 +18897,7 @@ func TestDeferredCommentRefreshYieldsBudgetToDetailDrain(t *testing.T) {
 		time.Minute, nil, budget,
 	)
 
-	syncer.queuePRCommentSync(repo, 1)
+	syncer.queuePRCommentSync(repo, repoID, 1)
 	budget["github.com"].Spend(3)
 	syncer.drainDetailQueue(ctx, map[string]bool{"github.com": true}, syncer.TrackedRepos())
 	syncer.drainPendingCommentSyncs(ctx, map[string]bool{"github.com": true})
@@ -18631,7 +20388,7 @@ func TestCommentDrainStopsIssueRefreshesAtTheReserve(t *testing.T) {
 	require.NoError(err)
 	syncer.SetGitHubRouters(map[string]*HostRouter{"github.com": router})
 	syncer.SetQuotaRegistry(registry)
-	syncer.queueIssueCommentSync(repo, 11)
+	syncer.queueIssueCommentSync(repo, repoID, 11)
 
 	bucket := RateBucketKey("github", "github.com", "user:7")
 	eligible := map[string]bool{bucket: true}
@@ -18816,7 +20573,7 @@ func TestReconcileRepoIdentityAbortsWhenRejectedObservationIsInactive(t *testing
 		d, nil, []RepoRef{repo}, time.Minute, nil, nil,
 	)
 
-	_, _, _, err = syncer.reconcileRepoIdentity(ctx, repo)
+	_, _, _, _, _, err = syncer.reconcileRepoIdentityObservation(ctx, repo)
 	require.ErrorContains(err, "stale")
 }
 
@@ -19469,4 +21226,559 @@ func TestWithObsoleteMetadata(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestSyncRepoDropsStaleSettingsSnapshotBehindNewerObservation simulates a
+// notification sync committing fresher repository settings between this
+// sync's provider snapshot capture and its settings write. The delayed full
+// sync must drop its stale snapshot instead of overwriting the newer
+// settings; the route generation cannot catch this because same-route
+// observations do not advance it.
+func TestSyncRepoDropsStaleSettingsSnapshotBehindNewerObservation(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	identity := db.RepoIdentity{
+		Platform: "gitlab", PlatformHost: "gitlab.example.com",
+		PlatformRepoID: "gid://gitlab/Project/42",
+		Owner:          "group", Name: "project", RepoPath: "group/project",
+	}
+	seeded, accepted, err := d.ReconcileRepositoryObservation(
+		ctx, identity, time.Now().UTC().Add(-time.Hour),
+	)
+	require.NoError(err)
+	require.True(accepted)
+	repoID := seeded.Repository.ID
+
+	injectNewerObservation := func() {
+		// Stamp strictly after any timestamp the sync captured before this
+		// provider call: wall-clock reads can collide at microsecond
+		// granularity, and an equal-timestamp observation ties instead of
+		// winning the watermark comparison.
+		observedAt := time.Now().UTC().Add(time.Millisecond)
+		_, accepted, err := d.ReconcileRepositoryObservation(ctx, identity, observedAt)
+		require.NoError(err)
+		require.True(accepted)
+		applied, err := d.UpdateRepoProviderObservation(
+			ctx, repoID, observedAt,
+			db.RepoProviderMetadata{
+				PlatformRepoID: "gid://gitlab/Project/42",
+				WebURL:         "https://gitlab.example.com/group/project",
+				CloneURL:       "https://gitlab.example.com/group/project.git",
+				DefaultBranch:  "newer-main",
+			},
+			&db.RepoMergeSettings{},
+			new(false),
+		)
+		require.NoError(err)
+		require.True(applied)
+	}
+	provider := &syncTestRepositoryReadProvider{
+		syncTestReadProvider: &syncTestReadProvider{
+			syncTestProvider: syncTestProvider{
+				kind: platform.KindGitLab, host: "gitlab.example.com",
+			},
+		},
+		getRepositoryFn: func(context.Context, platform.RepoRef) (platform.Repository, error) {
+			injectNewerObservation()
+			return platform.Repository{
+				Ref: platform.RepoRef{
+					Platform: platform.KindGitLab, Host: "gitlab.example.com",
+					Owner: "group", Name: "project", RepoPath: "group/project",
+				},
+				PlatformExternalID: "gid://gitlab/Project/42",
+				DefaultBranch:      "stale-main",
+				WebURL:             "https://gitlab.example.com/group/project-stale",
+				CloneURL:           "https://gitlab.example.com/group/project-stale.git",
+				MergeSettings: &platform.RepositoryMergeSettings{
+					AllowSquashMerge: true, AllowMergeCommit: true, AllowRebaseMerge: true,
+				},
+				ViewerCanMerge: new(true),
+			}, nil
+		},
+	}
+	syncer := NewSyncerWithRegistry(
+		mustRegistry(t, provider), d, nil, []RepoRef{{
+			Platform:           platform.KindGitLab,
+			PlatformHost:       "gitlab.example.com",
+			Owner:              "group",
+			Name:               "project",
+			RepoPath:           "group/project",
+			PlatformExternalID: "gid://gitlab/Project/42",
+		}}, time.Minute, nil, nil,
+	)
+
+	// Both the reconciled snapshot and the refetch lose to the injected
+	// newer observations, so the sync aborts rather than indexing against
+	// unverified settings — and the newer settings survive untouched.
+	require.ErrorContains(syncer.syncRepo(ctx, syncer.repos[0]), "kept losing")
+
+	stored, err := d.GetRepoByID(ctx, repoID)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.False(stored.AllowSquashMerge)
+	assert.False(stored.AllowMergeCommit)
+	assert.False(stored.AllowRebaseMerge)
+	assert.False(stored.ViewerCanMerge)
+	assert.Equal("newer-main", stored.DefaultBranch)
+	assert.Equal("https://gitlab.example.com/group/project", stored.WebURL)
+	assert.Equal(int32(2), provider.getRepositoryCalls.Load())
+}
+
+// TestSyncMRForRepoPersistsSettingsForReplacementRepository covers a reused
+// route: the tracked path now belongs to a different provider repository.
+// Direct MR sync creates the replacement catalog row; it must persist the
+// verified provider snapshot so the row does not advertise the permissive
+// schema defaults (all merge methods allowed, viewer can merge).
+func TestSyncMRForRepoPersistsSettingsForReplacementRepository(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	_, accepted, err := d.ReconcileRepositoryObservation(ctx, db.RepoIdentity{
+		Platform: "gitlab", PlatformHost: "gitlab.example.com",
+		PlatformRepoID: "gid://gitlab/Project/42",
+		Owner:          "group", Name: "project", RepoPath: "group/project",
+	}, now.Add(-time.Hour))
+	require.NoError(err)
+	require.True(accepted)
+
+	repo := RepoRef{
+		Platform:     platform.KindGitLab,
+		PlatformHost: "gitlab.example.com",
+		Owner:        "group",
+		Name:         "project",
+		RepoPath:     "group/project",
+	}
+	provider := &syncTestRepositoryReadProvider{
+		syncTestReadProvider: &syncTestReadProvider{
+			syncTestProvider: syncTestProvider{
+				kind: platform.KindGitLab, host: "gitlab.example.com",
+			},
+			mergeRequests: []platform.MergeRequest{{
+				Repo:           platformRepoRef(repo),
+				PlatformID:     1001,
+				Number:         7,
+				URL:            "https://gitlab.example.com/group/project/-/merge_requests/7",
+				Title:          "replacement MR",
+				Author:         "ada",
+				State:          "open",
+				HeadBranch:     "feature",
+				BaseBranch:     "main",
+				CreatedAt:      now,
+				UpdatedAt:      now,
+				LastActivityAt: now,
+			}},
+		},
+		repository: platform.Repository{
+			Ref:                platformRepoRef(repo),
+			PlatformExternalID: "gid://gitlab/Project/99",
+			DefaultBranch:      "main",
+			WebURL:             "https://gitlab.example.com/group/project",
+			CloneURL:           "https://gitlab.example.com/group/project.git",
+			MergeSettings: &platform.RepositoryMergeSettings{
+				AllowSquashMerge: true,
+			},
+			ViewerCanMerge: new(false),
+		},
+	}
+	syncer := NewSyncerWithRegistry(
+		mustRegistry(t, provider), d, nil, []RepoRef{repo}, time.Minute, nil, nil,
+	)
+
+	require.NoError(syncer.syncMRForRepo(ctx, repo, 7, false, nil))
+
+	entry, err := d.GetRepositoryByProviderID(
+		ctx, "gitlab", "gitlab.example.com", "gid://gitlab/Project/99",
+	)
+	require.NoError(err)
+	require.NotNil(entry, "direct sync must catalog the replacement repository")
+	stored, err := d.GetRepoByID(ctx, entry.Repository.ID)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.True(stored.AllowSquashMerge)
+	assert.False(stored.AllowMergeCommit)
+	assert.False(stored.AllowRebaseMerge)
+	assert.False(stored.ViewerCanMerge)
+	assert.Equal("main", stored.DefaultBranch)
+}
+
+// TestSyncIssueForRepoPersistsSettingsForReplacementRepository is the issue
+// analog of the direct MR sync case: the replacement repository row created
+// during a direct issue sync must carry the provider's verified settings.
+func TestSyncIssueForRepoPersistsSettingsForReplacementRepository(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	_, accepted, err := d.ReconcileRepositoryObservation(ctx, db.RepoIdentity{
+		Platform: "gitlab", PlatformHost: "gitlab.example.com",
+		PlatformRepoID: "gid://gitlab/Project/42",
+		Owner:          "group", Name: "project", RepoPath: "group/project",
+	}, now.Add(-time.Hour))
+	require.NoError(err)
+	require.True(accepted)
+
+	repo := RepoRef{
+		Platform:     platform.KindGitLab,
+		PlatformHost: "gitlab.example.com",
+		Owner:        "group",
+		Name:         "project",
+		RepoPath:     "group/project",
+	}
+	provider := &syncTestRepositoryReadProvider{
+		syncTestReadProvider: &syncTestReadProvider{
+			syncTestProvider: syncTestProvider{
+				kind: platform.KindGitLab, host: "gitlab.example.com",
+			},
+			issues: []platform.Issue{{
+				Repo:           platformRepoRef(repo),
+				PlatformID:     2001,
+				Number:         11,
+				URL:            "https://gitlab.example.com/group/project/-/issues/11",
+				Title:          "replacement issue",
+				Author:         "grace",
+				State:          "open",
+				CreatedAt:      now,
+				UpdatedAt:      now,
+				LastActivityAt: now,
+			}},
+		},
+		repository: platform.Repository{
+			Ref:                platformRepoRef(repo),
+			PlatformExternalID: "gid://gitlab/Project/99",
+			DefaultBranch:      "main",
+			WebURL:             "https://gitlab.example.com/group/project",
+			CloneURL:           "https://gitlab.example.com/group/project.git",
+			MergeSettings: &platform.RepositoryMergeSettings{
+				AllowSquashMerge: true,
+			},
+			ViewerCanMerge: new(false),
+		},
+	}
+	syncer := NewSyncerWithRegistry(
+		mustRegistry(t, provider), d, nil, []RepoRef{repo}, time.Minute, nil, nil,
+	)
+
+	require.NoError(syncer.syncIssueForRepo(ctx, repo, 11, nil))
+
+	entry, err := d.GetRepositoryByProviderID(
+		ctx, "gitlab", "gitlab.example.com", "gid://gitlab/Project/99",
+	)
+	require.NoError(err)
+	require.NotNil(entry, "direct sync must catalog the replacement repository")
+	stored, err := d.GetRepoByID(ctx, entry.Repository.ID)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.True(stored.AllowSquashMerge)
+	assert.False(stored.AllowMergeCommit)
+	assert.False(stored.AllowRebaseMerge)
+	assert.False(stored.ViewerCanMerge)
+	assert.Equal("main", stored.DefaultBranch)
+}
+
+// TestPersistRepoSettingsObservationDistinguishesFenceErrorFromStale pins the
+// helper's contract: a route fence mismatch surfaces as an error callers can
+// stop on, while a snapshot that merely lost to a newer observation reports
+// applied=false with no error so syncs continue on the fresher data.
+func TestPersistRepoSettingsObservationDistinguishesFenceErrorFromStale(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	identity := db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "repo-old", Owner: "acme", Name: "widget",
+		RepoPath: "acme/widget",
+	}
+	entry, accepted, err := d.ReconcileRepositoryObservation(ctx, identity, now)
+	require.NoError(err)
+	require.True(accepted)
+	repoID := entry.Repository.ID
+	fence, found, err := d.CurrentRepositoryRouteFence(ctx, identity, repoID)
+	require.NoError(err)
+	require.True(found)
+	syncer := &Syncer{db: d}
+	repo := RepoRef{
+		Platform: platform.KindGitHub, PlatformHost: "github.com",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+	}
+	snapshot := platform.Repository{
+		Ref: platform.RepoRef{
+			Platform: platform.KindGitHub, Host: "github.com",
+			Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+		},
+		PlatformExternalID: "repo-old",
+		MergeSettings:      &platform.RepositoryMergeSettings{AllowSquashMerge: true},
+	}
+
+	// A newer same-route observation makes the captured snapshot stale:
+	// no error, not applied.
+	_, accepted, err = d.ReconcileRepositoryObservation(ctx, identity, now.Add(time.Second))
+	require.NoError(err)
+	require.True(accepted)
+	applied, err := syncer.persistRepoSettingsObservation(
+		ctx, repo, repoID, now, snapshot, fence,
+	)
+	require.NoError(err)
+	assert.False(applied)
+
+	// A different repository claiming the route invalidates the captured
+	// fence: the mismatch is an error, not a silent skip.
+	_, accepted, err = d.ReconcileRepositoryObservation(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "repo-new", Owner: "acme", Name: "widget",
+		RepoPath: "acme/widget",
+	}, now.Add(2*time.Second))
+	require.NoError(err)
+	require.True(accepted)
+	_, err = syncer.persistRepoSettingsObservation(
+		ctx, repo, repoID, now, snapshot, fence,
+	)
+	require.ErrorIs(err, db.ErrRepositoryRouteFenceChanged)
+}
+
+// watermarkAdvancingArchiveLifecycle mimics the real archive service: route
+// changes and first encounters make reconcileArchiveRepositoryIfNeeded call
+// EnsureConfigured, which records its own identity observation for tracked
+// repositories and thereby advances the observation watermark past the
+// snapshot the surrounding sync is still holding.
+type watermarkAdvancingArchiveLifecycle struct {
+	db *db.DB
+}
+
+func (l watermarkAdvancingArchiveLifecycle) EnsureConfigured(
+	ctx context.Context, refs []platform.RepoRef,
+) ([]platform.RepoRef, error) {
+	for _, ref := range refs {
+		identity := platform.DBRepoIdentity(ref)
+		if identity.PlatformRepoID == "" {
+			continue
+		}
+		entry, _, err := l.db.ReconcileRepositoryObservation(
+			ctx, identity, time.Now().UTC(),
+		)
+		if err != nil {
+			return nil, err
+		}
+		if err := l.db.ReconcileDiscoveryArchives(
+			ctx, []int64{entry.Repository.ID}, time.Now().UTC(),
+		); err != nil {
+			return nil, err
+		}
+	}
+	return refs, nil
+}
+
+func (watermarkAdvancingArchiveLifecycle) RetryAuthentication(
+	context.Context, []platform.RepoRef,
+) error {
+	return nil
+}
+
+// TestSyncMRForRepoPersistsSettingsDespiteArchiveWatermarkAdvance covers the
+// production wiring the plain replacement test misses: the archive lifecycle
+// runs between identity reconciliation and the settings write and advances
+// the watermark, so the sync's first settings commit is rejected as stale.
+// The sync must re-resolve and persist instead of populating the replacement
+// row while it still advertises the permissive schema defaults.
+func TestSyncMRForRepoPersistsSettingsDespiteArchiveWatermarkAdvance(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	_, accepted, err := d.ReconcileRepositoryObservation(ctx, db.RepoIdentity{
+		Platform: "gitlab", PlatformHost: "gitlab.example.com",
+		PlatformRepoID: "gid://gitlab/Project/42",
+		Owner:          "group", Name: "project", RepoPath: "group/project",
+	}, now.Add(-time.Hour))
+	require.NoError(err)
+	require.True(accepted)
+
+	repo := RepoRef{
+		Platform:     platform.KindGitLab,
+		PlatformHost: "gitlab.example.com",
+		Owner:        "group",
+		Name:         "project",
+		RepoPath:     "group/project",
+	}
+	provider := &syncTestRepositoryReadProvider{
+		syncTestReadProvider: &syncTestReadProvider{
+			syncTestProvider: syncTestProvider{
+				kind: platform.KindGitLab, host: "gitlab.example.com",
+			},
+			mergeRequests: []platform.MergeRequest{{
+				Repo:           platformRepoRef(repo),
+				PlatformID:     1001,
+				Number:         7,
+				URL:            "https://gitlab.example.com/group/project/-/merge_requests/7",
+				Title:          "replacement MR",
+				Author:         "ada",
+				State:          "open",
+				HeadBranch:     "feature",
+				BaseBranch:     "main",
+				CreatedAt:      now,
+				UpdatedAt:      now,
+				LastActivityAt: now,
+			}},
+		},
+		repository: platform.Repository{
+			Ref:                platformRepoRef(repo),
+			PlatformExternalID: "gid://gitlab/Project/99",
+			DefaultBranch:      "main",
+			WebURL:             "https://gitlab.example.com/group/project",
+			CloneURL:           "https://gitlab.example.com/group/project.git",
+			MergeSettings: &platform.RepositoryMergeSettings{
+				AllowSquashMerge: true,
+			},
+			ViewerCanMerge: new(false),
+		},
+	}
+	syncer := NewSyncerWithRegistry(
+		mustRegistry(t, provider), d, nil, []RepoRef{repo}, time.Minute, nil, nil,
+	)
+	syncer.archiveLifecycle = watermarkAdvancingArchiveLifecycle{db: d}
+
+	require.NoError(syncer.syncMRForRepo(ctx, repo, 7, false, nil))
+
+	entry, err := d.GetRepositoryByProviderID(
+		ctx, "gitlab", "gitlab.example.com", "gid://gitlab/Project/99",
+	)
+	require.NoError(err)
+	require.NotNil(entry, "direct sync must catalog the replacement repository")
+	stored, err := d.GetRepoByID(ctx, entry.Repository.ID)
+	require.NoError(err)
+	require.NotNil(stored)
+	assert.True(stored.AllowSquashMerge)
+	assert.False(stored.AllowMergeCommit)
+	assert.False(stored.AllowRebaseMerge)
+	assert.False(stored.ViewerCanMerge)
+}
+
+// TestSyncMRForRepoErrsWhenSettingsObservationKeepsLosing covers the rejected
+// observation branch of direct sync: when the catalog holds a newer
+// observation than every attempt this sync makes, the provider snapshot is
+// discarded and the repository row's merge settings remain unverified. The
+// sync must fail — a nil snapshot from a rejected observation is not the same
+// as a provider without repository reading — instead of syncing the item
+// against potentially default merge availability.
+func TestSyncMRForRepoErrsWhenSettingsObservationKeepsLosing(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	_, accepted, err := d.ReconcileRepositoryObservation(ctx, db.RepoIdentity{
+		Platform: "gitlab", PlatformHost: "gitlab.example.com",
+		PlatformRepoID: "gid://gitlab/Project/42",
+		Owner:          "group", Name: "project", RepoPath: "group/project",
+	}, time.Now().UTC().Add(time.Hour))
+	require.NoError(err)
+	require.True(accepted)
+
+	repo := RepoRef{
+		Platform:     platform.KindGitLab,
+		PlatformHost: "gitlab.example.com",
+		Owner:        "group",
+		Name:         "project",
+		RepoPath:     "group/project",
+	}
+	provider := &syncTestRepositoryReadProvider{
+		syncTestReadProvider: &syncTestReadProvider{
+			syncTestProvider: syncTestProvider{
+				kind: platform.KindGitLab, host: "gitlab.example.com",
+			},
+			mergeRequests: []platform.MergeRequest{{
+				Repo:           platformRepoRef(repo),
+				PlatformID:     1001,
+				Number:         7,
+				URL:            "https://gitlab.example.com/group/project/-/merge_requests/7",
+				Title:          "stale observation MR",
+				Author:         "ada",
+				State:          "open",
+				HeadBranch:     "feature",
+				BaseBranch:     "main",
+				CreatedAt:      now,
+				UpdatedAt:      now,
+				LastActivityAt: now,
+			}},
+		},
+		repository: platform.Repository{
+			Ref:                platformRepoRef(repo),
+			PlatformExternalID: "gid://gitlab/Project/42",
+			DefaultBranch:      "main",
+			MergeSettings: &platform.RepositoryMergeSettings{
+				AllowSquashMerge: true,
+			},
+			ViewerCanMerge: new(false),
+		},
+	}
+	syncer := NewSyncerWithRegistry(
+		mustRegistry(t, provider), d, nil, []RepoRef{repo}, time.Minute, nil, nil,
+	)
+
+	err = syncer.syncMRForRepo(ctx, repo, 7, false, nil)
+	require.ErrorContains(err, "kept losing")
+}
+
+// TestSyncRepoErrsWhenSettingsObservationKeepsLosing pins periodic sync to
+// the same contract as direct item sync: when every settings observation this
+// sync makes loses to a newer catalog observation, the repository's merge
+// settings remain unverified and indexing must not proceed as if they were
+// committed.
+func TestSyncRepoErrsWhenSettingsObservationKeepsLosing(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	_, accepted, err := d.ReconcileRepositoryObservation(ctx, db.RepoIdentity{
+		Platform: "gitlab", PlatformHost: "gitlab.example.com",
+		PlatformRepoID: "gid://gitlab/Project/42",
+		Owner:          "group", Name: "project", RepoPath: "group/project",
+	}, time.Now().UTC().Add(time.Hour))
+	require.NoError(err)
+	require.True(accepted)
+
+	provider := &syncTestRepositoryReadProvider{
+		syncTestReadProvider: &syncTestReadProvider{
+			syncTestProvider: syncTestProvider{
+				kind: platform.KindGitLab, host: "gitlab.example.com",
+			},
+		},
+		repository: platform.Repository{
+			Ref: platform.RepoRef{
+				Platform: platform.KindGitLab, Host: "gitlab.example.com",
+				Owner: "group", Name: "project", RepoPath: "group/project",
+			},
+			PlatformExternalID: "gid://gitlab/Project/42",
+			DefaultBranch:      "main",
+			MergeSettings: &platform.RepositoryMergeSettings{
+				AllowSquashMerge: true,
+			},
+			ViewerCanMerge: new(false),
+		},
+	}
+	syncer := NewSyncerWithRegistry(
+		mustRegistry(t, provider), d, nil, []RepoRef{{
+			Platform:     platform.KindGitLab,
+			PlatformHost: "gitlab.example.com",
+			Owner:        "group",
+			Name:         "project",
+			RepoPath:     "group/project",
+		}}, time.Minute, nil, nil,
+	)
+
+	err = syncer.syncRepo(ctx, syncer.repos[0])
+	require.ErrorContains(err, "kept losing")
+
+	// The aborted attempt must reach the repository row's sync health, or
+	// the UI keeps reporting the previous outcome as current.
+	repos, err := d.ListRepos(ctx)
+	require.NoError(err)
+	require.Len(repos, 1)
+	require.Contains(repos[0].LastSyncError, "kept losing")
+	require.NotNil(repos[0].LastSyncStartedAt)
 }

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -3025,7 +3025,7 @@ func TestAPIEnqueuePRSyncQueuesOneRerun(t *testing.T) {
 		default:
 			return false
 		}
-	}, time.Second, time.Millisecond)
+	}, 10*time.Second, time.Millisecond)
 
 	for range 3 {
 		resp, err = client.HTTP.EnqueuePrSyncWithResponse(
@@ -3036,6 +3036,8 @@ func TestAPIEnqueuePRSyncQueuesOneRerun(t *testing.T) {
 	}
 	close(releaseFirst)
 
+	// The rerun re-verifies repository identity and persists the settings
+	// observation before its PR fetch; give the loaded CI runner headroom.
 	require.Eventually(func() bool {
 		select {
 		case <-secondDone:
@@ -3043,7 +3045,7 @@ func TestAPIEnqueuePRSyncQueuesOneRerun(t *testing.T) {
 		default:
 			return false
 		}
-	}, time.Second, time.Millisecond)
+	}, 10*time.Second, time.Millisecond)
 	assert.Equal(int64(2), calls.Load())
 	assert.Never(
 		func() bool { return calls.Load() > 2 },
@@ -6511,7 +6513,10 @@ func TestAPIListRepoSummariesIncludesSyncedReleaseTimeline(t *testing.T) {
 	runGit(t, work, "push", "--tags", "origin", "main")
 
 	clones := gitclone.New(filepath.Join(dir, "clones"), nil)
-	clonePath, err := clones.ClonePath("github", "github.com", "acme", "widgets")
+	clonePath, err := clones.ClonePathForContext(
+		gitclone.WithRepositoryIdentity(ctx, "repo-acme-widgets"),
+		"github", "github.com", "acme", "widgets",
+	)
 	require.NoError(err)
 	require.NoError(os.MkdirAll(filepath.Dir(clonePath), 0o755))
 	runGit(t, dir, "clone", "--bare", remote, clonePath)
@@ -20893,7 +20898,12 @@ func TestAPIGetFilesAndDiffMarkGeneratedFilesE2E(t *testing.T) {
 	database := dbtest.Open(t)
 
 	bareDir := filepath.Join(dir, "clones")
-	bare := filepath.Join(bareDir, "github.com", "acme", "widget.git")
+	clones := gitclone.New(bareDir, nil)
+	bare, err := clones.ClonePathForContext(
+		gitclone.WithRepositoryIdentity(ctx, "repo-acme-widget"),
+		"github", "github.com", "acme", "widget",
+	)
+	require.NoError(err)
 	require.NoError(os.MkdirAll(filepath.Dir(bare), 0o755))
 
 	work := filepath.Join(dir, "work")
@@ -20934,7 +20944,6 @@ func TestAPIGetFilesAndDiffMarkGeneratedFilesE2E(t *testing.T) {
 	runGit(t, work, "push", "origin", "feature")
 	headSHA := testGitSHA(t, work, "HEAD")
 
-	clones := gitclone.New(bareDir, nil)
 	syncer := ghclient.NewSyncer(
 		map[string]ghclient.Client{"github.com": &mockGH{}},
 		database, nil, defaultTestRepos, time.Minute, nil, nil,
@@ -21012,7 +21021,11 @@ func TestAPILocalReadEndpointsServeDuringTokenRotationE2E(t *testing.T) {
 	database := dbtest.Open(t)
 
 	bareDir := filepath.Join(dir, "clones")
-	bare := filepath.Join(bareDir, "github.com", "acme", "widget.git")
+	bare, err := gitclone.New(bareDir, nil).ClonePathForContext(
+		gitclone.WithRepositoryIdentity(ctx, "repo-acme-widget"),
+		"github", "github.com", "acme", "widget",
+	)
+	require.NoError(err)
 	require.NoError(os.MkdirAll(filepath.Dir(bare), 0o755))
 
 	work := filepath.Join(dir, "work")
@@ -22059,7 +22072,12 @@ func setupTestServerWithClonesAndServer(t *testing.T) (
 
 	bareDir := filepath.Join(dir, "clones")
 	require.NoError(t, os.MkdirAll(bareDir, 0o755))
-	bare := filepath.Join(bareDir, "github.com", "acme", "widget.git")
+	clones := gitclone.New(bareDir, nil)
+	bare, err := clones.ClonePathForContext(
+		gitclone.WithRepositoryIdentity(t.Context(), "repo-acme-widget"),
+		"github", "github.com", "acme", "widget",
+	)
+	require.NoError(t, err)
 
 	tmpWork := filepath.Join(dir, "work")
 	runGit(t, dir, "init", "--bare", "--initial-branch=main", bare)
@@ -22091,7 +22109,6 @@ func setupTestServerWithClonesAndServer(t *testing.T) (
 		sha = testGitSHA(t, tmpWork, sha+"^1")
 	}
 
-	clones := gitclone.New(bareDir, nil)
 	mock := &mockGH{}
 	repos := []ghclient.RepoRef{{Platform: "github", Owner: "acme", Name: "widget", PlatformHost: "github.com"}}
 	syncer := ghclient.NewSyncer(map[string]ghclient.Client{"github.com": mock}, database, nil, repos, time.Minute, nil, nil)
@@ -22195,7 +22212,10 @@ func TestAPIGetRepoCommitDiffRejectsOptionLikeSHA(t *testing.T) {
 	require := require.New(t)
 
 	_, _, _, _, _, srv := setupTestServerWithClonesAndServer(t)
-	clonePath, err := srv.clones.ClonePath("github", "github.com", "acme", "widget")
+	clonePath, err := srv.clones.ClonePathForContext(
+		gitclone.WithRepositoryIdentity(t.Context(), "repo-acme-widget"),
+		"github", "github.com", "acme", "widget",
+	)
 	require.NoError(err)
 	configPath := filepath.Join(clonePath, "config")
 	before, err := os.ReadFile(configPath)
@@ -22458,7 +22478,12 @@ func TestAPIGetDiff_RootCommit(t *testing.T) {
 
 	bareDir := filepath.Join(dir, "clones")
 	require.NoError(os.MkdirAll(bareDir, 0o755))
-	bare := filepath.Join(bareDir, "github.com", "acme", "rootrepo.git")
+	clones := gitclone.New(bareDir, nil)
+	bare, err := clones.ClonePathForContext(
+		gitclone.WithRepositoryIdentity(t.Context(), "repo-acme-rootrepo"),
+		"github", "github.com", "acme", "rootrepo",
+	)
+	require.NoError(err)
 	tmpWork := filepath.Join(dir, "work")
 	runGit(t, dir, "init", "--bare", "--initial-branch=main", bare)
 	runGit(t, dir, "clone", bare, tmpWork)
@@ -22476,7 +22501,6 @@ func TestAPIGetDiff_RootCommit(t *testing.T) {
 	runGit(t, tmpWork, "push", "origin", "main")
 	headSHA := testGitSHA(t, tmpWork, "HEAD")
 
-	clones := gitclone.New(bareDir, nil)
 	mock := &mockGH{}
 	repos := []ghclient.RepoRef{{Owner: "acme", Name: "rootrepo", PlatformHost: "github.com"}}
 	syncer := ghclient.NewSyncer(map[string]ghclient.Client{"github.com": mock}, database, nil, repos, time.Minute, nil, nil)

--- a/internal/server/e2etest/fixtures_test.go
+++ b/internal/server/e2etest/fixtures_test.go
@@ -147,6 +147,7 @@ type mockGH struct {
 	mergePullRequestFn         func(context.Context, string, string, int, string, string, string, string) (*gh.PullRequestMergeResult, error)
 	createReviewWithCommentsFn func(context.Context, string, string, int, string, string, string, []*gh.DraftReviewComment) (*gh.PullRequestReview, error)
 	dismissReviewFn            func(context.Context, string, string, int, int64, string) (*gh.PullRequestReview, error)
+	listNotificationsFn        func(context.Context, ghclient.NotificationListOptions) ([]ghclient.NotificationThread, bool, error)
 	getNotificationThreadFn    func(context.Context, string) (ghclient.NotificationThread, error)
 	markNotificationReadFn     func(context.Context, string) error
 }
@@ -241,7 +242,10 @@ func (m *mockGH) CreatePullRequestReviewCommentReply(
 ) (*gh.PullRequestComment, error) {
 	return nil, nil
 }
-func (m *mockGH) ListNotifications(context.Context, ghclient.NotificationListOptions) ([]ghclient.NotificationThread, bool, error) {
+func (m *mockGH) ListNotifications(ctx context.Context, opts ghclient.NotificationListOptions) ([]ghclient.NotificationThread, bool, error) {
+	if m.listNotificationsFn != nil {
+		return m.listNotificationsFn(ctx, opts)
+	}
 	return nil, false, nil
 }
 func (m *mockGH) GetNotificationThread(ctx context.Context, threadID string) (ghclient.NotificationThread, error) {

--- a/internal/server/e2etest/notifications_test.go
+++ b/internal/server/e2etest/notifications_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -167,6 +169,442 @@ name = "tools"
 	}
 }
 
+func TestNotificationSyncReconcilesReusedRouteE2E(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	number := 7
+	firstActivityAt := time.Date(2026, 8, 3, 10, 0, 0, 0, time.UTC)
+	var activityAt atomic.Int64
+	activityAt.Store(firstActivityAt.UnixNano())
+	var listCalls atomic.Int32
+	mock := &mockGH{
+		getRepositoryFn: func(_ context.Context, owner, name string) (*gh.Repository, error) {
+			return &gh.Repository{
+				ID: new(int64(2)), NodeID: new("R_replacement"), Name: &name,
+				Owner: &gh.User{Login: &owner}, Archived: new(bool),
+				AllowSquashMerge: new(true), AllowMergeCommit: new(false),
+				AllowRebaseMerge: new(false),
+				Permissions:      &gh.RepositoryPermissions{Push: new(false)},
+			}, nil
+		},
+		listNotificationsFn: func(_ context.Context, opts github.NotificationListOptions) ([]github.NotificationThread, bool, error) {
+			listCalls.Add(1)
+			if opts.Participating {
+				return nil, false, nil
+			}
+			return []github.NotificationThread{{
+				ID: "replacement-thread", RepoOwner: "acme", RepoName: "widget",
+				SubjectType: "PullRequest", SubjectTitle: "Replacement notification",
+				WebURL: "https://github.com/acme/widget/pull/7", ItemNumber: &number,
+				ItemType: "pr", Reason: "review_requested", Unread: true,
+				UpdatedAt: time.Unix(0, activityAt.Load()).UTC(),
+			}}, false, nil
+		},
+	}
+	srv, database, _ := setupTestServerWithConfigContent(t, `
+sync_interval = "5m"
+github_token_env = "KENN_FORGE_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[notifications]
+enabled = true
+sync_interval = "2m"
+propagation_interval = "1m"
+batch_size = 25
+
+[[repos]]
+owner = "acme"
+name = "widget"
+`, mock)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	client, err := apiclient.NewWithHTTPClient(ts.URL, ts.Client())
+	require.NoError(err)
+	withJSON := func(_ context.Context, req *http.Request) error {
+		req.Header.Set("Content-Type", "application/json")
+		return nil
+	}
+
+	oldRepoID, err := database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com", PlatformRepoID: "R_old",
+		Owner: "acme", Name: "widget",
+	})
+	require.NoError(err)
+	syncResp, err := client.HTTP.SyncNotificationsWithResponse(ctx, withJSON)
+	require.NoError(err)
+	assert.Equal(http.StatusAccepted, syncResp.StatusCode())
+	var firstSyncAt time.Time
+	require.Eventually(func() bool {
+		watermark, watermarkErr := database.GetNotificationSyncWatermark(
+			ctx, "github", "github.com", "acme", "widget",
+		)
+		if watermarkErr != nil || watermark == nil || listCalls.Load() < 2 {
+			return false
+		}
+		resp, callErr := client.HTTP.ListNotificationsWithResponse(
+			ctx, &generated.ListNotificationsParams{State: new("unread")},
+		)
+		if callErr != nil || resp.JSON200 == nil || resp.JSON200.Sync.Running {
+			return false
+		}
+		firstSyncAt = watermark.LastSuccessfulSyncAt
+		return true
+	}, 10*time.Second, 10*time.Millisecond)
+
+	active, err := database.GetRepoByIdentity(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com", Owner: "acme", Name: "widget",
+	})
+	require.NoError(err)
+	require.NotNil(active)
+	assert.Equal("R_replacement", active.PlatformRepoID)
+	assert.NotEqual(oldRepoID, active.ID)
+	repoResp, err := client.HTTP.GetRepoWithResponse(ctx, "github", "acme", "widget")
+	require.NoError(err)
+	require.Equal(http.StatusOK, repoResp.StatusCode(), string(repoResp.Body))
+	require.NotNil(repoResp.JSON200)
+	assert.True(repoResp.JSON200.AllowSquashMerge)
+	assert.False(repoResp.JSON200.AllowMergeCommit)
+	assert.False(repoResp.JSON200.AllowRebaseMerge)
+	assert.False(repoResp.JSON200.ViewerCanMerge)
+	assert.False(repoResp.JSON200.Operations.MergePr.Available)
+	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID: active.ID, PlatformID: 7, Number: number,
+		URL: "https://github.com/acme/widget/pull/7", Title: "Replacement pull request",
+		Author: "octocat", State: db.MergeRequestStateOpen,
+		CreatedAt: firstActivityAt.Add(-time.Hour), UpdatedAt: firstActivityAt,
+		LastActivityAt: firstActivityAt,
+	})
+	require.NoError(err)
+
+	var notificationID int64
+	require.Eventually(func() bool {
+		resp, callErr := client.HTTP.ListNotificationsWithResponse(ctx, &generated.ListNotificationsParams{State: new("unread")})
+		if callErr != nil || resp.JSON200 == nil || resp.JSON200.Items == nil || len(*resp.JSON200.Items) != 1 {
+			return false
+		}
+		item := (*resp.JSON200.Items)[0]
+		notificationID = item.Id
+		return item.PlatformThreadId == "replacement-thread" && item.RepoOwner == "acme" && item.RepoName == "widget"
+	}, 3*time.Second, 10*time.Millisecond)
+
+	activityResp, err := client.HTTP.ListActivityWithResponse(ctx, &generated.ListActivityParams{
+		Types: &[]string{"notification"},
+	})
+	require.NoError(err)
+	require.NotNil(activityResp.JSON200)
+	require.NotNil(activityResp.JSON200.Items)
+	require.Len(*activityResp.JSON200.Items, 1)
+	activity := (*activityResp.JSON200.Items)[0]
+	assert.Equal("notification", activity.ActivityType)
+	assert.Equal(int64(number), activity.ItemNumber)
+	assert.Equal("acme", activity.RepoOwner)
+	assert.Equal("widget", activity.RepoName)
+
+	doneResp, err := client.HTTP.MarkNotificationsDoneWithResponse(
+		ctx, generated.MarkNotificationsDoneJSONRequestBody{Ids: &[]int64{notificationID}},
+	)
+	require.NoError(err)
+	require.NotNil(doneResp.JSON200)
+	require.ElementsMatch([]int64{notificationID}, *doneResp.JSON200.Succeeded)
+	require.ElementsMatch([]int64{notificationID}, *doneResp.JSON200.Queued)
+
+	activityAt.Store(firstActivityAt.Add(time.Hour).UnixNano())
+	syncResp, err = client.HTTP.SyncNotificationsWithResponse(ctx, withJSON)
+	require.NoError(err)
+	assert.Equal(http.StatusAccepted, syncResp.StatusCode())
+	require.Eventually(func() bool {
+		watermark, watermarkErr := database.GetNotificationSyncWatermark(
+			ctx, "github", "github.com", "acme", "widget",
+		)
+		if watermarkErr != nil || watermark == nil ||
+			!watermark.LastSuccessfulSyncAt.After(firstSyncAt) || listCalls.Load() < 4 {
+			return false
+		}
+		resp, callErr := client.HTTP.ListNotificationsWithResponse(ctx, &generated.ListNotificationsParams{State: new("unread")})
+		if callErr != nil || resp.JSON200 == nil || resp.JSON200.Sync.Running ||
+			resp.JSON200.Items == nil || len(*resp.JSON200.Items) != 1 {
+			return false
+		}
+		item := (*resp.JSON200.Items)[0]
+		return item.Id == notificationID && item.DoneAt == nil && item.GithubReadQueuedAt == nil
+	}, 10*time.Second, 10*time.Millisecond)
+}
+
+func TestNotificationAckRouteFenceReactivatesThroughAPIE2E(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	number := 7
+	providerID := "R_original"
+	sourceUpdatedAt := time.Date(2026, 8, 3, 10, 0, 0, 0, time.UTC)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var renamed atomic.Bool
+	var firstFetch sync.Once
+	mock := &mockGH{
+		getRepositoryFn: func(_ context.Context, owner, name string) (*gh.Repository, error) {
+			if renamed.Load() {
+				name = "beta"
+			}
+			return &gh.Repository{
+				ID: new(int64(1)), NodeID: &providerID, Name: &name,
+				Owner: &gh.User{Login: &owner}, Archived: new(bool),
+			}, nil
+		},
+		getNotificationThreadFn: func(_ context.Context, threadID string) (github.NotificationThread, error) {
+			firstFetch.Do(func() {
+				close(started)
+				<-release
+			})
+			repoName := "alpha"
+			if renamed.Load() {
+				repoName = "beta"
+			}
+			return github.NotificationThread{
+				ID: threadID, RepoOwner: "acme", RepoName: repoName,
+				SubjectType: "PullRequest", SubjectTitle: "New activity",
+				WebURL: "https://github.com/acme/" + repoName + "/pull/7", ItemNumber: &number,
+				ItemType: "pr", Reason: "mention", Unread: true,
+				UpdatedAt: sourceUpdatedAt.Add(time.Hour),
+			}, nil
+		},
+	}
+	srv, database, _, syncer := setupTestServerWithConfigContentAndSyncer(t, `
+sync_interval = "5m"
+github_token_env = "KENN_FORGE_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[notifications]
+enabled = true
+sync_interval = "2m"
+propagation_interval = "1m"
+batch_size = 25
+
+[[repos]]
+owner = "acme"
+name = "alpha"
+`, mock)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	client, err := apiclient.NewWithHTTPClient(ts.URL, ts.Client())
+	require.NoError(err)
+
+	repoID, err := database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com", PlatformRepoID: providerID,
+		Owner: "acme", Name: "alpha",
+	})
+	require.NoError(err)
+	require.NoError(database.UpsertNotifications(ctx, []db.Notification{{
+		Platform: "github", PlatformHost: "github.com", PlatformNotificationID: "thread-1",
+		RepoID: &repoID, RepoOwner: "acme", RepoName: "alpha",
+		SubjectType: "PullRequest", SubjectTitle: "Please review",
+		WebURL: "https://github.com/acme/alpha/pull/7", ItemNumber: &number, ItemType: "pr",
+		Reason: "mention", Unread: true, SourceUpdatedAt: sourceUpdatedAt, SyncedAt: sourceUpdatedAt,
+	}}))
+
+	unreadResp, err := client.HTTP.ListNotificationsWithResponse(ctx, &generated.ListNotificationsParams{State: new("unread")})
+	require.NoError(err)
+	require.NotNil(unreadResp.JSON200)
+	require.NotNil(unreadResp.JSON200.Items)
+	require.Len(*unreadResp.JSON200.Items, 1)
+	notificationID := (*unreadResp.JSON200.Items)[0].Id
+	doneResp, err := client.HTTP.MarkNotificationsDoneWithResponse(
+		ctx, generated.MarkNotificationsDoneJSONRequestBody{Ids: &[]int64{notificationID}},
+	)
+	require.NoError(err)
+	require.NotNil(doneResp.JSON200)
+	require.ElementsMatch([]int64{notificationID}, *doneResp.JSON200.Succeeded)
+	require.ElementsMatch([]int64{notificationID}, *doneResp.JSON200.Queued)
+
+	propagationDone := make(chan error, 1)
+	go func() {
+		propagationDone <- syncer.ProcessQueuedNotificationReads(
+			ctx, platform.KindGitHub, "github.com", 10,
+		)
+	}()
+	<-started
+	renamed.Store(true)
+	require.NoError(syncer.SyncNotifications(ctx))
+	close(release)
+	require.NoError(<-propagationDone)
+
+	doneStateResp, err := client.HTTP.ListNotificationsWithResponse(ctx, &generated.ListNotificationsParams{State: new("done")})
+	require.NoError(err)
+	require.NotNil(doneStateResp.JSON200)
+	require.NotNil(doneStateResp.JSON200.Items)
+	require.Len(*doneStateResp.JSON200.Items, 1)
+	item := (*doneStateResp.JSON200.Items)[0]
+	assert.Equal(notificationID, item.Id)
+	assert.Equal("beta", item.RepoName)
+	assert.False(item.Unread)
+	assert.NotNil(item.DoneAt)
+	assert.NotNil(item.GithubReadQueuedAt)
+	assert.Nil(item.GithubReadSyncedAt)
+	assert.Empty(item.GithubReadError)
+
+	require.NoError(syncer.ProcessQueuedNotificationReads(
+		ctx, platform.KindGitHub, "github.com", 10,
+	))
+	activeResp, err := client.HTTP.ListNotificationsWithResponse(
+		ctx, &generated.ListNotificationsParams{State: new("active")},
+	)
+	require.NoError(err)
+	require.NotNil(activeResp.JSON200)
+	require.NotNil(activeResp.JSON200.Items)
+	require.Len(*activeResp.JSON200.Items, 1)
+	item = (*activeResp.JSON200.Items)[0]
+	assert.Equal(notificationID, item.Id)
+	assert.Equal("beta", item.RepoName)
+	assert.True(item.Unread)
+	assert.Nil(item.DoneAt)
+	assert.Nil(item.GithubReadQueuedAt)
+	assert.Nil(item.GithubReadSyncedAt)
+}
+
+func TestNotificationAckSkipsMarkReadAfterABARouteReuseE2E(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	number := 7
+	providerID := "R_original"
+	observedAt := time.Date(2026, 8, 3, 10, 0, 0, 0, time.UTC)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var firstFetch sync.Once
+	var marked atomic.Int32
+	mock := &mockGH{
+		getNotificationThreadFn: func(_ context.Context, threadID string) (github.NotificationThread, error) {
+			firstFetch.Do(func() {
+				close(started)
+				<-release
+			})
+			return github.NotificationThread{
+				ID: threadID, RepoOwner: "acme", RepoName: "widget",
+				SubjectType: "PullRequest", SubjectTitle: "Please review",
+				WebURL: "https://github.com/acme/widget/pull/7", ItemNumber: &number,
+				ItemType: "pr", Reason: "mention", Unread: false,
+				UpdatedAt: observedAt,
+			}, nil
+		},
+		markNotificationReadFn: func(context.Context, string) error {
+			marked.Add(1)
+			return nil
+		},
+	}
+	srv, database, _, syncer := setupTestServerWithConfigContentAndSyncer(t, `
+sync_interval = "5m"
+github_token_env = "KENN_FORGE_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[notifications]
+enabled = true
+sync_interval = "2m"
+propagation_interval = "1m"
+batch_size = 25
+
+[[repos]]
+owner = "acme"
+name = "widget"
+`, mock)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	client, err := apiclient.NewWithHTTPClient(ts.URL, ts.Client())
+	require.NoError(err)
+
+	repoID, err := database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com", PlatformRepoID: providerID,
+		Owner: "acme", Name: "widget",
+	})
+	require.NoError(err)
+	require.NoError(database.UpsertNotifications(ctx, []db.Notification{{
+		Platform: "github", PlatformHost: "github.com", PlatformNotificationID: "thread-1",
+		RepoID: &repoID, RepoOwner: "acme", RepoName: "widget",
+		SubjectType: "PullRequest", SubjectTitle: "Please review",
+		WebURL: "https://github.com/acme/widget/pull/7", ItemNumber: &number, ItemType: "pr",
+		Reason: "mention", Unread: true, SourceUpdatedAt: observedAt, SyncedAt: observedAt,
+	}}))
+	unreadResp, err := client.HTTP.ListNotificationsWithResponse(
+		ctx, &generated.ListNotificationsParams{State: new("unread")},
+	)
+	require.NoError(err)
+	require.NotNil(unreadResp.JSON200)
+	require.NotNil(unreadResp.JSON200.Items)
+	require.Len(*unreadResp.JSON200.Items, 1)
+	notificationID := (*unreadResp.JSON200.Items)[0].Id
+	doneResp, err := client.HTTP.MarkNotificationsDoneWithResponse(
+		ctx, generated.MarkNotificationsDoneJSONRequestBody{Ids: &[]int64{notificationID}},
+	)
+	require.NoError(err)
+	require.NotNil(doneResp.JSON200)
+
+	propagationDone := make(chan error, 1)
+	go func() {
+		propagationDone <- syncer.ProcessQueuedNotificationReads(
+			ctx, platform.KindGitHub, "github.com", 10,
+		)
+	}()
+	<-started
+	routeChangedAt := time.Now().UTC().Add(time.Hour)
+	_, _, err = database.ReconcileRepositoryObservation(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com", PlatformRepoID: providerID,
+		Owner: "acme", Name: "renamed",
+	}, routeChangedAt)
+	require.NoError(err)
+	_, _, err = database.ReconcileRepositoryObservation(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com", PlatformRepoID: "R_replacement",
+		Owner: "acme", Name: "widget",
+	}, routeChangedAt.Add(time.Minute))
+	require.NoError(err)
+	_, _, err = database.ReconcileRepositoryObservation(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com", PlatformRepoID: "R_replacement",
+		Owner: "acme", Name: "elsewhere",
+	}, routeChangedAt.Add(2*time.Minute))
+	require.NoError(err)
+	_, _, err = database.ReconcileRepositoryObservation(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com", PlatformRepoID: providerID,
+		Owner: "acme", Name: "widget",
+	}, routeChangedAt.Add(3*time.Minute))
+	require.NoError(err)
+	close(release)
+	require.NoError(<-propagationDone)
+	assert.Zero(marked.Load())
+
+	allResp, err := client.HTTP.ListNotificationsWithResponse(
+		ctx, &generated.ListNotificationsParams{State: new("all")},
+	)
+	require.NoError(err)
+	require.NotNil(allResp.JSON200)
+	require.NotNil(allResp.JSON200.Items)
+	require.Len(*allResp.JSON200.Items, 1)
+	item := (*allResp.JSON200.Items)[0]
+	assert.Equal(notificationID, item.Id)
+	assert.False(item.Unread)
+	assert.NotNil(item.DoneAt)
+	assert.NotNil(item.GithubReadQueuedAt)
+	assert.Nil(item.GithubReadSyncedAt)
+
+	require.NoError(syncer.ProcessQueuedNotificationReads(
+		ctx, platform.KindGitHub, "github.com", 10,
+	))
+	assert.Equal(int32(1), marked.Load())
+	allResp, err = client.HTTP.ListNotificationsWithResponse(
+		ctx, &generated.ListNotificationsParams{State: new("all")},
+	)
+	require.NoError(err)
+	require.NotNil(allResp.JSON200)
+	require.NotNil(allResp.JSON200.Items)
+	require.Len(*allResp.JSON200.Items, 1)
+	item = (*allResp.JSON200.Items)[0]
+	assert.False(item.Unread)
+	assert.NotNil(item.DoneAt)
+	assert.Nil(item.GithubReadQueuedAt)
+	assert.NotNil(item.GithubReadSyncedAt)
+}
+
 func TestNotificationReadPropagationDefersQueuedAcksOnRefetchRateLimitE2E(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -298,4 +736,112 @@ name = "widget"
 		}
 		assert.NotNil(queuedByThread[threadID], threadID)
 	}
+}
+
+// TestNotificationAckPropagatesAfterRepositoryRenameE2E queues a read
+// acknowledgement, completes a repository rename with no intervening
+// notification refresh, then propagates. The notification still caches the
+// historical owner/name; the acknowledgement must follow the stable
+// repository identity to its current route instead of being dropped with the
+// upstream thread left unread.
+func TestNotificationAckPropagatesAfterRepositoryRenameE2E(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	number := 7
+	providerID := "R_original"
+	sourceUpdatedAt := time.Date(2026, 8, 3, 10, 0, 0, 0, time.UTC)
+	var markedThreads []string
+	mock := &mockGH{
+		getNotificationThreadFn: func(_ context.Context, threadID string) (github.NotificationThread, error) {
+			return github.NotificationThread{
+				ID: threadID, RepoOwner: "acme", RepoName: "renamed",
+				SubjectType: "PullRequest", SubjectTitle: "Please review",
+				WebURL: "https://github.com/acme/renamed/pull/7", ItemNumber: &number,
+				ItemType: "pr", Reason: "mention", Unread: false,
+				UpdatedAt: sourceUpdatedAt,
+			}, nil
+		},
+		markNotificationReadFn: func(_ context.Context, threadID string) error {
+			markedThreads = append(markedThreads, threadID)
+			return nil
+		},
+	}
+	srv, database, _, syncer := setupTestServerWithConfigContentAndSyncer(t, `
+sync_interval = "5m"
+github_token_env = "KENN_FORGE_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[notifications]
+enabled = true
+sync_interval = "2m"
+propagation_interval = "1m"
+batch_size = 25
+
+[[repos]]
+owner = "acme"
+name = "widget"
+`, mock)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	client, err := apiclient.NewWithHTTPClient(ts.URL, ts.Client())
+	require.NoError(err)
+
+	entry, accepted, err := database.ReconcileRepositoryObservation(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com", PlatformRepoID: providerID,
+		Owner: "acme", Name: "widget",
+	}, time.Now().UTC().Add(-time.Hour))
+	require.NoError(err)
+	require.True(accepted)
+	repoID := entry.Repository.ID
+	require.NoError(database.UpsertNotifications(ctx, []db.Notification{{
+		Platform: "github", PlatformHost: "github.com", PlatformNotificationID: "thread-1",
+		RepoID: &repoID, RepoOwner: "acme", RepoName: "widget",
+		SubjectType: "PullRequest", SubjectTitle: "Please review",
+		WebURL: "https://github.com/acme/widget/pull/7", ItemNumber: &number, ItemType: "pr",
+		Reason: "mention", Unread: true, SourceUpdatedAt: sourceUpdatedAt, SyncedAt: sourceUpdatedAt,
+	}}))
+
+	unreadResp, err := client.HTTP.ListNotificationsWithResponse(
+		ctx, &generated.ListNotificationsParams{State: new("unread")},
+	)
+	require.NoError(err)
+	require.NotNil(unreadResp.JSON200)
+	require.NotNil(unreadResp.JSON200.Items)
+	require.Len(*unreadResp.JSON200.Items, 1)
+	notificationID := (*unreadResp.JSON200.Items)[0].Id
+	doneResp, err := client.HTTP.MarkNotificationsDoneWithResponse(
+		ctx, generated.MarkNotificationsDoneJSONRequestBody{Ids: &[]int64{notificationID}},
+	)
+	require.NoError(err)
+	require.NotNil(doneResp.JSON200)
+	require.ElementsMatch([]int64{notificationID}, *doneResp.JSON200.Queued)
+
+	_, accepted, err = database.ReconcileRepositoryObservation(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com", PlatformRepoID: providerID,
+		Owner: "acme", Name: "renamed",
+	}, time.Now().UTC())
+	require.NoError(err)
+	require.True(accepted)
+
+	require.NoError(syncer.ProcessQueuedNotificationReads(
+		ctx, platform.KindGitHub, "github.com", 10,
+	))
+
+	assert.Equal([]string{"thread-1"}, markedThreads,
+		"the queued acknowledgement must reach the upstream thread")
+	// Verified at the database layer: the API listing scopes by the
+	// configured route, which stops matching after a rename until a sync
+	// republishes the tracked repository — separate behavior from ack
+	// propagation.
+	items, err := database.ListNotifications(ctx, db.ListNotificationsOpts{State: "all"})
+	require.NoError(err)
+	require.Len(items, 1)
+	assert.Equal(notificationID, items[0].ID)
+	assert.False(items[0].Unread)
+	assert.NotNil(items[0].DoneAt)
+	assert.NotNil(items[0].SourceAckSyncedAt)
+	assert.Empty(items[0].SourceAckError)
+	assert.Nil(items[0].SourceAckQueuedAt)
 }

--- a/internal/server/e2etest/operation_availability_test.go
+++ b/internal/server/e2etest/operation_availability_test.go
@@ -1,20 +1,299 @@
 package e2etest
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	gh "github.com/google/go-github/v89/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/forge/internal/apiclient"
 	"go.kenn.io/forge/internal/db"
 	ghclient "go.kenn.io/forge/internal/github"
+	"go.kenn.io/forge/internal/platform"
 	"go.kenn.io/forge/internal/server"
 	"go.kenn.io/forge/internal/testutil/dbtest"
 	"go.kenn.io/forge/internal/testutil/servertest"
 )
+
+func TestRepoRenameSyncPreservesMergeAvailabilityE2E(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	database := dbtest.Open(t)
+	providerID := "R_renamed_repo"
+	previousSyncStartedAt := time.Now().UTC().Add(-time.Hour)
+	previousSyncCompletedAt := previousSyncStartedAt.Add(time.Minute)
+
+	sourceID, err := database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: providerID,
+		Owner:          "acme",
+		Name:           "old-widget",
+	})
+	require.NoError(err)
+	require.NoError(database.UpdateRepoSettings(ctx, sourceID, true, false, false, true))
+	require.NoError(database.UpdateRepoSyncStarted(ctx, sourceID, previousSyncStartedAt))
+	require.NoError(database.UpdateRepoSyncCompleted(ctx, sourceID, previousSyncCompletedAt, ""))
+	sourceMRID, err := database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:             sourceID,
+		PlatformID:         7001,
+		PlatformExternalID: "PR_source",
+		Number:             7,
+		URL:                "https://github.com/acme/old-widget/pull/7",
+		Title:              "source PR snapshot",
+		Author:             "ada",
+		State:              db.MergeRequestStateOpen,
+		CreatedAt:          previousSyncStartedAt.Add(-time.Hour),
+		UpdatedAt:          previousSyncStartedAt,
+		LastActivityAt:     previousSyncStartedAt,
+	})
+	require.NoError(err)
+	require.NoError(database.SetStarred(ctx, db.ItemTypePR, sourceID, 7))
+	_, err = database.SetItemWorkflowState(ctx, db.SetItemWorkflowStateParams{
+		RepoID:     sourceID,
+		ItemType:   db.ItemTypePR,
+		ItemNumber: 7,
+		Status:     string(db.KanbanStatusReviewing),
+		Source:     "user",
+	})
+	require.NoError(err)
+
+	destinationID, err := database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "R_obsolete_repo",
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	require.NoError(err)
+	require.NotEqual(sourceID, destinationID)
+	// Keep every destination field distinct from the authoritative source
+	// snapshot so the HTTP response proves reconciliation preserved all four.
+	require.NoError(database.UpdateRepoSettings(ctx, destinationID, false, true, true, false))
+	destinationSnapshotAt := previousSyncCompletedAt.Add(time.Hour)
+	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:             destinationID,
+		PlatformID:         9001,
+		PlatformExternalID: "PR_destination",
+		Number:             7,
+		URL:                "https://github.com/acme/widget/pull/7",
+		Title:              "destination PR snapshot",
+		Author:             "grace",
+		State:              db.MergeRequestStateOpen,
+		CreatedAt:          destinationSnapshotAt.Add(-time.Hour),
+		UpdatedAt:          destinationSnapshotAt,
+		LastActivityAt:     destinationSnapshotAt,
+	})
+	require.NoError(err)
+	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:             destinationID,
+		PlatformID:         9002,
+		PlatformExternalID: "PR_destination_only",
+		Number:             8,
+		URL:                "https://github.com/acme/widget/pull/8",
+		Title:              "destination-only PR snapshot",
+		Author:             "grace",
+		State:              db.MergeRequestStateOpen,
+		CreatedAt:          destinationSnapshotAt.Add(-time.Hour),
+		UpdatedAt:          destinationSnapshotAt,
+		LastActivityAt:     destinationSnapshotAt,
+	})
+	require.NoError(err)
+	_, err = database.SetItemWorkflowState(ctx, db.SetItemWorkflowStateParams{
+		RepoID:     destinationID,
+		ItemType:   db.ItemTypePR,
+		ItemNumber: 7,
+		Status:     string(db.KanbanStatusWaiting),
+		Source:     "user",
+	})
+	require.NoError(err)
+
+	mock := &mockGH{
+		getRepositoryFn: func(context.Context, string, string) (*gh.Repository, error) {
+			return &gh.Repository{
+				ID: new(int64(7001)), NodeID: &providerID,
+				Owner: &gh.User{Login: new("acme")}, Name: new("widget"),
+				AllowSquashMerge: new(true), AllowMergeCommit: new(false),
+				AllowRebaseMerge: new(false),
+				Permissions:      &gh.RepositoryPermissions{Push: new(true)},
+			}, nil
+		},
+	}
+	ref := ghclient.RepoRef{
+		Platform:           platform.KindGitHub,
+		PlatformHost:       "github.com",
+		PlatformExternalID: providerID,
+		Owner:              "acme",
+		Name:               "widget",
+		RepoPath:           "acme/widget",
+	}
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": mock},
+		database, nil, []ghclient.RepoRef{ref}, time.Minute, nil, nil,
+	)
+	t.Cleanup(syncer.Stop)
+	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{
+		HostCheckAllowLoopbackAnyPort: true,
+	})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	forge := httptest.NewServer(srv)
+	t.Cleanup(forge.Close)
+
+	status, body := postJSON(t, forge.Client(), forge.URL+"/api/v1/sync", nil)
+	require.Equal(http.StatusAccepted, status, body)
+	waitForRepoSynced(t, database, "acme", "widget", &previousSyncCompletedAt)
+
+	client, err := apiclient.NewWithHTTPClient(forge.URL, forge.Client())
+	require.NoError(err)
+	response, err := client.HTTP.GetRepoWithResponse(ctx, "github", "acme", "widget")
+	require.NoError(err)
+	require.Equal(http.StatusOK, response.StatusCode(), string(response.Body))
+	require.NotNil(response.JSON200)
+
+	repo := response.JSON200
+	assert.True(repo.AllowSquashMerge)
+	assert.False(repo.AllowMergeCommit)
+	assert.False(repo.AllowRebaseMerge)
+	assert.True(repo.ViewerCanMerge)
+	assert.True(repo.Operations.MergePr.Available)
+
+	pull, err := client.HTTP.GetPullWithResponse(ctx, "github", "acme", "widget", 7)
+	require.NoError(err)
+	require.Equal(http.StatusOK, pull.StatusCode(), string(pull.Body))
+	require.NotNil(pull.JSON200)
+	assert.Equal(sourceMRID, pull.JSON200.MergeRequest.ID)
+	assert.Equal(sourceID, pull.JSON200.MergeRequest.RepoID)
+	assert.Equal("source PR snapshot", pull.JSON200.MergeRequest.Title)
+	assert.True(pull.JSON200.MergeRequest.Starred)
+	assert.Equal("reviewing", string(pull.JSON200.MergeRequest.KanbanStatus))
+
+	discarded, err := client.HTTP.GetPullWithResponse(ctx, "github", "acme", "widget", 8)
+	require.NoError(err)
+	assert.Equal(http.StatusNotFound, discarded.StatusCode(), string(discarded.Body))
+}
+
+func TestRepoPathReuseSyncDropsPreviousProviderSnapshotE2E(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	database := dbtest.Open(t)
+	displacedProviderID := "R_displaced_repo"
+	incomingProviderID := "R_incoming_repo"
+	previousSyncStartedAt := time.Now().UTC().Add(-time.Hour)
+	previousSyncCompletedAt := previousSyncStartedAt.Add(time.Minute)
+
+	displacedID, err := database.UpsertRepoByProviderID(ctx, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: displacedProviderID,
+		Owner:          "acme",
+		Name:           "widget",
+	})
+	require.NoError(err)
+	require.NoError(database.UpdateRepoProviderMetadata(ctx, displacedID, db.RepoProviderMetadata{
+		PlatformRepoID: displacedProviderID,
+		WebURL:         "https://github.com/acme/obsolete-widget",
+		CloneURL:       "https://github.com/acme/obsolete-widget.git",
+		DefaultBranch:  "obsolete-main",
+	}))
+	require.NoError(database.UpdateRepoSettings(ctx, displacedID, false, false, false, false))
+	require.NoError(database.UpdateRepoSyncStarted(ctx, displacedID, previousSyncStartedAt))
+	require.NoError(database.UpdateRepoSyncCompleted(ctx, displacedID, previousSyncCompletedAt, ""))
+	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:             displacedID,
+		PlatformID:         7001,
+		PlatformExternalID: "PR_displaced",
+		Number:             7,
+		URL:                "https://github.com/acme/obsolete-widget/pull/7",
+		Title:              "displaced PR snapshot",
+		Author:             "ada",
+		State:              db.MergeRequestStateOpen,
+		CreatedAt:          previousSyncStartedAt.Add(-time.Hour),
+		UpdatedAt:          previousSyncStartedAt,
+		LastActivityAt:     previousSyncStartedAt,
+	})
+	require.NoError(err)
+	_, err = database.UpsertIssue(ctx, &db.Issue{
+		RepoID:             displacedID,
+		PlatformID:         8001,
+		PlatformExternalID: "I_displaced",
+		Number:             8,
+		URL:                "https://github.com/acme/obsolete-widget/issues/8",
+		Title:              "displaced issue snapshot",
+		Author:             "ada",
+		State:              "open",
+		CreatedAt:          previousSyncStartedAt.Add(-time.Hour),
+		UpdatedAt:          previousSyncStartedAt,
+		LastActivityAt:     previousSyncStartedAt,
+	})
+	require.NoError(err)
+
+	mock := &mockGH{
+		getRepositoryFn: func(context.Context, string, string) (*gh.Repository, error) {
+			return &gh.Repository{
+				ID: new(int64(8001)), NodeID: &incomingProviderID,
+				Owner: &gh.User{Login: new("acme")}, Name: new("widget"),
+				AllowSquashMerge: new(true), AllowMergeCommit: new(true),
+				AllowRebaseMerge: new(true),
+				Permissions:      &gh.RepositoryPermissions{Push: new(true)},
+			}, nil
+		},
+	}
+	ref := ghclient.RepoRef{
+		Platform:           platform.KindGitHub,
+		PlatformHost:       "github.com",
+		PlatformExternalID: incomingProviderID,
+		Owner:              "acme",
+		Name:               "widget",
+		RepoPath:           "acme/widget",
+	}
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": mock},
+		database, nil, []ghclient.RepoRef{ref}, time.Minute, nil, nil,
+	)
+	t.Cleanup(syncer.Stop)
+	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{
+		HostCheckAllowLoopbackAnyPort: true,
+	})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	forge := httptest.NewServer(srv)
+	t.Cleanup(forge.Close)
+
+	status, body := postJSON(t, forge.Client(), forge.URL+"/api/v1/sync", nil)
+	require.Equal(http.StatusAccepted, status, body)
+	newRepo := waitForRepoSynced(t, database, "acme", "widget", &previousSyncCompletedAt)
+	assert.NotEqual(displacedID, newRepo.ID)
+	assert.Equal(incomingProviderID, newRepo.PlatformRepoID)
+	assert.Empty(newRepo.WebURL)
+	assert.Empty(newRepo.CloneURL)
+	assert.Empty(newRepo.DefaultBranch)
+
+	client, err := apiclient.NewWithHTTPClient(forge.URL, forge.Client())
+	require.NoError(err)
+	response, err := client.HTTP.GetRepoWithResponse(ctx, "github", "acme", "widget")
+	require.NoError(err)
+	require.Equal(http.StatusOK, response.StatusCode(), string(response.Body))
+	require.NotNil(response.JSON200)
+	assert.True(response.JSON200.AllowSquashMerge)
+	assert.True(response.JSON200.AllowMergeCommit)
+	assert.True(response.JSON200.AllowRebaseMerge)
+	assert.True(response.JSON200.ViewerCanMerge)
+	assert.True(response.JSON200.Operations.MergePr.Available)
+
+	pull, err := client.HTTP.GetPullWithResponse(ctx, "github", "acme", "widget", 7)
+	require.NoError(err)
+	assert.Equal(http.StatusNotFound, pull.StatusCode(), string(pull.Body))
+	issue, err := client.HTTP.GetIssueWithResponse(ctx, "github", "acme", "widget", 8)
+	require.NoError(err)
+	assert.Equal(http.StatusNotFound, issue.StatusCode(), string(issue.Body))
+}
 
 func TestPullDetailReportsPausedRateTrackerE2E(t *testing.T) {
 	assert := assert.New(t)
@@ -37,6 +316,9 @@ func TestPullDetailReportsPausedRateTrackerE2E(t *testing.T) {
 	identity.PlatformRepoID = "repo-acme-widget"
 	repoID, err := database.UpsertRepo(t.Context(), identity)
 	require.NoError(err)
+	// Keep merge permission available so this fixture isolates the rate-limit
+	// gate instead of the fail-closed viewer permission gate.
+	require.NoError(database.UpdateRepoViewerCanMerge(t.Context(), repoID, true))
 	_, err = database.UpsertMergeRequest(t.Context(), &db.MergeRequest{
 		RepoID:         repoID,
 		PlatformID:     7001,
@@ -76,4 +358,81 @@ func TestPullDetailReportsPausedRateTrackerE2E(t *testing.T) {
 	assert.Equal("github.com rate-limited", *merge.UnavailableReason)
 	require.NotNil(merge.RetryAt)
 	assert.Equal(resetAt.Format(time.RFC3339), *merge.RetryAt)
+}
+
+// TestRepoSyncHealthReportsSettingsFailureE2E drives the real sync entry
+// point over HTTP against SQLite. A catalog observation newer than anything
+// the sync can produce makes every settings commit lose the watermark, so the
+// sync aborts before item indexing; the repository API must expose that
+// failure instead of reporting the repository as healthy.
+func TestRepoSyncHealthReportsSettingsFailureE2E(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	database := dbtest.Open(t)
+	providerID := "R_health_repo"
+	previousSyncStartedAt := time.Now().UTC().Add(-time.Hour)
+	previousSyncCompletedAt := previousSyncStartedAt.Add(time.Minute)
+
+	entry, accepted, err := database.ReconcileRepositoryObservation(ctx, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: providerID,
+		Owner:          "acme",
+		Name:           "widget",
+		RepoPath:       "acme/widget",
+	}, time.Now().UTC().Add(time.Hour))
+	require.NoError(err)
+	require.True(accepted)
+	require.NoError(database.UpdateRepoSyncStarted(
+		ctx, entry.Repository.ID, previousSyncStartedAt,
+	))
+	require.NoError(database.UpdateRepoSyncCompleted(
+		ctx, entry.Repository.ID, previousSyncCompletedAt, "",
+	))
+
+	mock := &mockGH{
+		getRepositoryFn: func(context.Context, string, string) (*gh.Repository, error) {
+			return &gh.Repository{
+				ID: new(int64(9001)), NodeID: &providerID,
+				Owner: &gh.User{Login: new("acme")}, Name: new("widget"),
+				AllowSquashMerge: new(true), AllowMergeCommit: new(true),
+				AllowRebaseMerge: new(true),
+				Permissions:      &gh.RepositoryPermissions{Push: new(true)},
+			}, nil
+		},
+	}
+	ref := ghclient.RepoRef{
+		Platform:           platform.KindGitHub,
+		PlatformHost:       "github.com",
+		PlatformExternalID: providerID,
+		Owner:              "acme",
+		Name:               "widget",
+		RepoPath:           "acme/widget",
+	}
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": mock},
+		database, nil, []ghclient.RepoRef{ref}, time.Minute, nil, nil,
+	)
+	t.Cleanup(syncer.Stop)
+	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{
+		HostCheckAllowLoopbackAnyPort: true,
+	})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	forge := httptest.NewServer(srv)
+	t.Cleanup(forge.Close)
+
+	status, body := postJSON(t, forge.Client(), forge.URL+"/api/v1/sync", nil)
+	require.Equal(http.StatusAccepted, status, body)
+	repo := waitForRepoSynced(t, database, "acme", "widget", &previousSyncCompletedAt)
+	require.Contains(repo.LastSyncError, "kept losing")
+
+	client, err := apiclient.NewWithHTTPClient(forge.URL, forge.Client())
+	require.NoError(err)
+	response, err := client.HTTP.GetRepoWithResponse(ctx, "github", "acme", "widget")
+	require.NoError(err)
+	require.Equal(http.StatusOK, response.StatusCode(), string(response.Body))
+	require.NotNil(response.JSON200)
+	assert.Contains(response.JSON200.LastSyncError, "kept losing")
 }

--- a/internal/server/httpapi/repository_resolver.go
+++ b/internal/server/httpapi/repository_resolver.go
@@ -209,6 +209,75 @@ func (r *RepositoryResolver) List(ctx context.Context) ([]db.Repo, error) {
 	return r.db.ListRepos(ctx)
 }
 
+func (r *RepositoryResolver) CaptureRepositoryRouteFence(
+	ctx context.Context, repo db.Repo,
+) (db.RepositoryRouteFence, bool, error) {
+	if r == nil || r.db == nil {
+		return db.RepositoryRouteFence{}, false, ErrRepositoryStoreUnavailable
+	}
+	return r.db.CurrentRepositoryRouteFence(ctx, repositoryRouteIdentity(repo), repo.ID)
+}
+
+func (r *RepositoryResolver) RepositoryRouteFenceMatches(
+	ctx context.Context, repo db.Repo, fence db.RepositoryRouteFence,
+) (bool, error) {
+	current, found, err := r.CaptureRepositoryRouteFence(ctx, repo)
+	if err != nil || !found {
+		return false, err
+	}
+	return current == fence, nil
+}
+
+// GuardRepositoryRouteFence holds repository reconciliation stable while a
+// caller publishes work derived from the exact captured route generation.
+func (r *RepositoryResolver) GuardRepositoryRouteFence(
+	ctx context.Context,
+	repo db.Repo,
+	fence db.RepositoryRouteFence,
+	publish func() error,
+) (bool, error) {
+	if r == nil || r.db == nil {
+		return false, ErrRepositoryStoreUnavailable
+	}
+	release, err := r.db.LockRepositoryReconciliationRead(ctx)
+	if err != nil {
+		return false, err
+	}
+	defer release()
+	matches, err := r.db.RepositoryRouteFenceMatchesUnderRepositoryReconciliationRead(
+		ctx, repositoryRouteIdentity(repo), fence,
+	)
+	if err != nil || !matches {
+		return false, err
+	}
+	if err := publish(); err != nil {
+		return true, err
+	}
+	return true, nil
+}
+
+func repositoryRouteIdentity(repo db.Repo) db.RepoIdentity {
+	return db.RepoIdentity{
+		Platform:       repo.Platform,
+		PlatformHost:   repo.PlatformHost,
+		PlatformRepoID: repo.PlatformRepoID,
+		Owner:          repo.Owner,
+		Name:           repo.Name,
+		RepoPath:       repo.RepoPath,
+	}
+}
+
+func (r *RepositoryResolver) AdoptLegacyClonesIfSafe(
+	ctx context.Context, repo db.Repo, adopt func() error,
+) (bool, error) {
+	if r == nil || r.db == nil {
+		return false, ErrRepositoryStoreUnavailable
+	}
+	return r.db.AdoptLegacyClonesIfSafe(
+		ctx, repositoryRouteIdentity(repo), repo.ID, adopt,
+	)
+}
+
 func (r *RepositoryResolver) Ref(repo db.Repo) RepoRefResponse {
 	provider := strings.TrimSpace(repo.Platform)
 	if provider == "" {

--- a/internal/server/httpapi/repository_resolver_test.go
+++ b/internal/server/httpapi/repository_resolver_test.go
@@ -1,8 +1,10 @@
 package httpapi
 
 import (
+	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -68,6 +70,91 @@ func TestRepositoryResolverBuildsCanonicalRef(t *testing.T) {
 	assert.Equal("gitlab.example.com", ref.PlatformHost)
 	assert.Equal("group/subgroup/widget", ref.RepoPath)
 	assert.True(ref.Capabilities.ReadRepositories)
+}
+
+func TestRepositoryResolverGuardRepositoryRouteFenceBlocksReconciliation(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	database := dbtest.Open(t)
+	repoID, err := database.UpsertRepo(t.Context(), db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "provider-old",
+		Owner:          "acme",
+		Name:           "widget",
+		RepoPath:       "acme/widget",
+	})
+	require.NoError(err)
+	repo, err := database.GetRepoByID(t.Context(), repoID)
+	require.NoError(err)
+	resolver := NewRepositoryResolver(RepositoryResolverDeps{DB: database})
+	fence, found, err := resolver.CaptureRepositoryRouteFence(t.Context(), *repo)
+	require.NoError(err)
+	require.True(found)
+
+	publishStarted := make(chan struct{})
+	releasePublish := make(chan struct{})
+	type guardResult struct {
+		matches bool
+		err     error
+	}
+	guardDone := make(chan guardResult, 1)
+	go func() {
+		matches, guardErr := resolver.GuardRepositoryRouteFence(
+			context.Background(), *repo, fence, func() error {
+				close(publishStarted)
+				<-releasePublish
+				return nil
+			},
+		)
+		guardDone <- guardResult{matches: matches, err: guardErr}
+	}()
+	<-publishStarted
+
+	writerWaiting := make(chan struct{})
+	restoreHook := database.SetBeforeRepositoryReconciliationWriteLockForTest(func() {
+		close(writerWaiting)
+	})
+	t.Cleanup(restoreHook)
+	writerDone := make(chan error, 1)
+	go func() {
+		_, _, reconcileErr := database.ReconcileRepositoryObservation(
+			context.Background(),
+			db.RepoIdentity{
+				Platform:       "github",
+				PlatformHost:   "github.com",
+				PlatformRepoID: "provider-new",
+				Owner:          "acme",
+				Name:           "widget",
+				RepoPath:       "acme/widget",
+			},
+			time.Now().UTC().Add(time.Hour),
+		)
+		writerDone <- reconcileErr
+	}()
+	<-writerWaiting
+	select {
+	case writerErr := <-writerDone:
+		require.Fail("reconciliation completed while publication guard was held", writerErr)
+	default:
+	}
+
+	close(releasePublish)
+	guarded := <-guardDone
+	require.NoError(guarded.err)
+	assert.True(guarded.matches)
+	require.NoError(<-writerDone)
+
+	stalePublishCalled := false
+	matches, err := resolver.GuardRepositoryRouteFence(
+		t.Context(), *repo, fence, func() error {
+			stalePublishCalled = true
+			return nil
+		},
+	)
+	require.NoError(err)
+	assert.False(matches)
+	assert.False(stalePublishCalled)
 }
 
 func TestPlatformRepoRefRestoresProviderIdentityAndNumericID(t *testing.T) {

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -477,6 +477,7 @@ func (s *Server) getRepoCommitDiff(
 	}
 
 	host := httpapi.ProviderHost(*repo)
+	ctx = gitclone.WithRepositoryIdentity(ctx, repo.PlatformRepoID)
 	if !isFullGitObjectID(input.SHA) {
 		return nil, httpapi.Validation("path.sha", "commit SHA must be a full object ID")
 	}

--- a/internal/server/operation_availability_test.go
+++ b/internal/server/operation_availability_test.go
@@ -352,12 +352,12 @@ func TestAPIRepoResponseIncludesOperationsHealthy(t *testing.T) {
 	assert := assert.New(t)
 
 	srv, database, _ := newServerWithRateTracker(t)
-	_, err := database.UpsertRepo(
+	repoID, err := database.UpsertRepo(
 		t.Context(), verifiedGitHubRepoIdentity("github.com", "acme", "widget"),
 	)
 	require.NoError(err)
-	// Schema default is viewer_can_merge=1, so no extra update is
-	// needed; the fresh row already satisfies the merge permission.
+	// Keep merge available so this fixture isolates the healthy path.
+	require.NoError(database.UpdateRepoViewerCanMerge(t.Context(), repoID, true))
 
 	rr := doJSON(t, srv, http.MethodGet, "/api/v1/repo/github/acme/widget", nil)
 	require.Equal(http.StatusOK, rr.Code)
@@ -376,11 +376,12 @@ func TestAPIRepoResponseIncludesOperationsRateLimited(t *testing.T) {
 	assert := assert.New(t)
 
 	srv, database, rt := newServerWithRateTracker(t)
-	_, err := database.UpsertRepo(
+	repoID, err := database.UpsertRepo(
 		t.Context(), verifiedGitHubRepoIdentity("github.com", "acme", "widget"),
 	)
 	require.NoError(err)
-	// Schema default already grants viewer merge permission.
+	// Keep merge available so this fixture isolates rate limiting.
+	require.NoError(database.UpdateRepoViewerCanMerge(t.Context(), repoID, true))
 
 	resetAt := time.Now().UTC().Add(30 * time.Minute)
 	rt.UpdateFromRate(ratelimit.Rate{Limit: 5000, Remaining: 0, Reset: resetAt})
@@ -426,10 +427,12 @@ func TestAPIRepoResponseIncludesOperationsGraphQLPauseDoesNotBlockREST(t *testin
 	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
 	t.Cleanup(func() { gracefulShutdown(t, srv) })
 
-	_, err := database.UpsertRepo(
+	repoID, err := database.UpsertRepo(
 		t.Context(), verifiedGitHubRepoIdentity("github.com", "acme", "widget"),
 	)
 	require.NoError(err)
+	// Keep merge available so this fixture isolates GraphQL tracker state.
+	require.NoError(database.UpdateRepoViewerCanMerge(t.Context(), repoID, true))
 
 	// Pause GraphQL by reporting zero remaining requests with a
 	// future reset; leave REST untouched.
@@ -655,10 +658,12 @@ func TestAPIRepoResponseOperationsGateOnWriteTrackerWhenSplit(t *testing.T) {
 	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
 	t.Cleanup(func() { gracefulShutdown(t, srv) })
 
-	_, err := database.UpsertRepo(
+	repoID, err := database.UpsertRepo(
 		t.Context(), verifiedGitHubRepoIdentity("github.com", "acme", "widget"),
 	)
 	require.NoError(err)
+	// Keep merge available so this fixture isolates write tracker state.
+	require.NoError(database.UpdateRepoViewerCanMerge(t.Context(), repoID, true))
 
 	// App (sync) budget exhausted, PAT healthy: writes stay available.
 	resetAt := time.Now().UTC().Add(30 * time.Minute)
@@ -961,6 +966,13 @@ func TestAPIPullDetailOperationsDisableSelfApproval(t *testing.T) {
 	}
 	srv, database := setupTestServerWithMock(t, mock)
 	seedPR(t, database, "acme", "widget", 1, withSeedPRAuthor("marius"))
+	repo, err := database.GetRepoByIdentity(
+		t.Context(), verifiedGitHubRepoIdentity("github.com", "acme", "widget"),
+	)
+	require.NoError(err)
+	require.NotNil(repo)
+	// Keep merge available so this fixture isolates the self-approval gate.
+	require.NoError(database.UpdateRepoViewerCanMerge(t.Context(), repo.ID, true))
 
 	rr := doJSON(t, srv, http.MethodGet, "/api/v1/pulls/github/acme/widget/1", nil)
 	require.Equal(http.StatusOK, rr.Code)

--- a/internal/server/pullapi/routes.go
+++ b/internal/server/pullapi/routes.go
@@ -2136,6 +2136,7 @@ func (s *Handler) getCommits(ctx context.Context, input *repoNumberInput) (*getC
 	}
 
 	host := repoProviderHost(*repo)
+	ctx = gitclone.WithRepositoryIdentity(ctx, repo.PlatformRepoID)
 	commits, err := s.clones.ListCommits(
 		ctx, string(repoProviderKind(*repo)), host, repo.Owner, repo.Name,
 		shas.MergeBaseSHA, shas.DiffHeadSHA,
@@ -2179,13 +2180,14 @@ type getDiffInput struct {
 type getDiffOutput = httpapi.BodyOutput[diffResponse]
 
 type resolvedDiffRange struct {
-	platform string
-	host     string
-	owner    string
-	name     string
-	fromSHA  string
-	toSHA    string
-	diffSHAs *db.DiffSHAs
+	platform       string
+	host           string
+	owner          string
+	name           string
+	providerRepoID string
+	fromSHA        string
+	toSHA          string
+	diffSHAs       *db.DiffSHAs
 }
 
 func (s *Handler) resolveDiffRange(
@@ -2210,6 +2212,7 @@ func (s *Handler) resolveDiffRange(
 	}
 
 	host := repoProviderHost(*repo)
+	ctx = gitclone.WithRepositoryIdentity(ctx, repo.PlatformRepoID)
 	diffFrom := shas.MergeBaseSHA
 	diffTo := shas.DiffHeadSHA
 
@@ -2262,13 +2265,14 @@ func (s *Handler) resolveDiffRange(
 	}
 
 	return &resolvedDiffRange{
-		platform: string(repoProviderKind(*repo)),
-		host:     host,
-		owner:    repo.Owner,
-		name:     repo.Name,
-		fromSHA:  diffFrom,
-		toSHA:    diffTo,
-		diffSHAs: shas,
+		platform:       string(repoProviderKind(*repo)),
+		host:           host,
+		owner:          repo.Owner,
+		name:           repo.Name,
+		providerRepoID: repo.PlatformRepoID,
+		fromSHA:        diffFrom,
+		toSHA:          diffTo,
+		diffSHAs:       shas,
 	}, nil
 }
 
@@ -2281,6 +2285,7 @@ func (s *Handler) getDiff(ctx context.Context, input *getDiffInput) (*getDiffOut
 	if err != nil {
 		return nil, err
 	}
+	ctx = gitclone.WithRepositoryIdentity(ctx, resolved.providerRepoID)
 
 	hideWhitespace := input.Whitespace == "hide"
 	result, err := s.clones.Diff(
@@ -2347,6 +2352,7 @@ func (s *Handler) getFilePreview(ctx context.Context, input *getFilePreviewInput
 	if err != nil {
 		return nil, err
 	}
+	ctx = gitclone.WithRepositoryIdentity(ctx, resolved.providerRepoID)
 
 	previewRef := resolved.toSHA
 	previewPath := input.Path
@@ -2486,6 +2492,7 @@ func (s *Handler) getFiles(ctx context.Context, input *getFilesInput) (*getFiles
 	}
 
 	host := repoProviderHost(*repo)
+	ctx = gitclone.WithRepositoryIdentity(ctx, repo.PlatformRepoID)
 	files, err := s.clones.DiffFiles(
 		ctx, string(repoProviderKind(*repo)), host, repo.Owner, repo.Name,
 		shas.MergeBaseSHA, shas.DiffHeadSHA,

--- a/internal/server/repobrowserapi/handler.go
+++ b/internal/server/repobrowserapi/handler.go
@@ -506,18 +506,62 @@ func (h *Handler) ensureRepoBrowserClone(
 	if strings.TrimSpace(repo.CloneURL) == "" {
 		return nil, gitclone.RepoBrowserRepoRef{}, errRepoBrowserCloneUnavailable
 	}
-	repoRef := gitclone.RepoBrowserRepoRef{
-		Provider:  repo.Platform,
-		Host:      repo.PlatformHost,
-		Owner:     repo.Owner,
-		Name:      repo.Name,
-		RepoPath:  repo.RepoPath,
-		RemoteURL: repo.CloneURL,
+	repoRef, err := h.repoBrowserRepoRef(ctx, *repo)
+	if err != nil {
+		return nil, gitclone.RepoBrowserRepoRef{}, err
 	}
 	if err := h.clones.EnsureRepoBrowserClone(ctx, repoRef); err != nil {
 		return nil, gitclone.RepoBrowserRepoRef{}, err
 	}
 	return repo, repoRef, nil
+}
+
+func (h *Handler) repoBrowserRepoRef(
+	ctx context.Context, repo db.Repo,
+) (gitclone.RepoBrowserRepoRef, error) {
+	fence, found, err := h.resolver.CaptureRepositoryRouteFence(ctx, repo)
+	if err != nil {
+		return gitclone.RepoBrowserRepoRef{}, err
+	}
+	if !found {
+		return gitclone.RepoBrowserRepoRef{}, db.ErrRepositoryRouteFenceChanged
+	}
+	token := gitclone.NewRepoBrowserRouteFence(
+		fence.RouteID, fence.RepoID, fence.Generation,
+	)
+	return gitclone.RepoBrowserRepoRef{
+		Provider:       repo.Platform,
+		Host:           repo.PlatformHost,
+		Owner:          repo.Owner,
+		Name:           repo.Name,
+		RepoPath:       repo.RepoPath,
+		ProviderRepoID: repo.PlatformRepoID,
+		RemoteURL:      repo.CloneURL,
+		RouteFence:     token,
+		ValidateRouteFence: func(
+			validationCtx context.Context,
+			got gitclone.RepoBrowserRouteFence,
+		) (bool, error) {
+			if got != token {
+				return false, nil
+			}
+			return h.resolver.RepositoryRouteFenceMatches(
+				validationCtx, repo, fence,
+			)
+		},
+		PublishIfRouteFenceMatches: func(
+			publishCtx context.Context,
+			got gitclone.RepoBrowserRouteFence,
+			publish func() error,
+		) (bool, error) {
+			if got != token {
+				return false, nil
+			}
+			return h.resolver.GuardRepositoryRouteFence(
+				publishCtx, repo, fence, publish,
+			)
+		},
+	}, nil
 }
 
 func (h *Handler) repoRefFromRepo(repo db.Repo) httpapi.RepoRefResponse {
@@ -576,6 +620,10 @@ func repoBrowserProblem(err error) error {
 	}
 	if errors.Is(err, httpapi.ErrRepoNotFound) {
 		return httpapi.NotFound(httpapi.CodeRepoNotFound, "repo not found", map[string]any{"reason": "repo_not_found"})
+	}
+	if errors.Is(err, db.ErrRepositoryRouteFenceChanged) ||
+		errors.Is(err, gitclone.ErrRepoBrowserRouteFenceChanged) {
+		return httpapi.NotFound(httpapi.CodeRepoNotFound, "repo route changed", map[string]any{"reason": "repo_not_found"})
 	}
 	if errors.Is(err, errRepoBrowserCloneUnavailable) {
 		return httpapi.NotFound(httpapi.CodeNotFound, "repo browser clone unavailable", map[string]any{"reason": "clone_unavailable"})

--- a/internal/server/repobrowserapi/handler_test.go
+++ b/internal/server/repobrowserapi/handler_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -22,11 +23,41 @@ import (
 	"go.kenn.io/forge/internal/server/httpapi"
 	"go.kenn.io/forge/internal/server/repobrowserapi"
 	"go.kenn.io/forge/internal/testutil/dbtest"
+	"go.kenn.io/forge/internal/tokenauth"
 	gitcmd "go.kenn.io/kit/git/cmd"
 	"golang.org/x/sync/semaphore"
 )
 
 var repoBrowserTestSlots = semaphore.NewWeighted(2)
+
+type blockingRepoBrowserRefreshRoutes struct {
+	mu      sync.Mutex
+	block   bool
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (r *blockingRepoBrowserRefreshRoutes) SourceForRepo(_, _, _, _ string) tokenauth.Source {
+	r.mu.Lock()
+	block := r.block
+	r.mu.Unlock()
+	if block {
+		r.once.Do(func() {
+			close(r.started)
+			<-r.release
+		})
+	}
+	return nil
+}
+
+func (*blockingRepoBrowserRefreshRoutes) FallbackSource(string) tokenauth.Source { return nil }
+
+func (r *blockingRepoBrowserRefreshRoutes) enable() {
+	r.mu.Lock()
+	r.block = true
+	r.mu.Unlock()
+}
 
 func acquireRepoBrowserTestSlot(t *testing.T) {
 	t.Helper()
@@ -173,6 +204,120 @@ func TestRepoBrowserCloneCacheSeparatesProvidersWithSameHostAndPath(t *testing.T
 	var gitlabBody repobrowserapi.RepoBrowserBlobResponse
 	require.NoError(json.Unmarshal(gitlabBlob.Body.Bytes(), &gitlabBody))
 	assert.Equal("gitlab repo\n", gitlabBody.Blob.Content)
+}
+
+func TestRepoBrowserRefreshDoesNotContaminateReturnedRouteAfterABAReuse(t *testing.T) {
+	acquireRepoBrowserTestSlot(t)
+	require := require.New(t)
+	assert := assert.New(t)
+	database := dbtest.Open(t)
+	routeRemote, workA := setupServerRepoBrowserGitRepo(t)
+	_, workB := setupServerRepoBrowserGitRepo(t)
+
+	require.NoError(os.WriteFile(filepath.Join(workA, "README.md"), []byte("repository A\n"), 0o644))
+	serverRepoBrowserGit(t, workA, "add", ".")
+	serverRepoBrowserGit(t, workA, "commit", "-m", "identify repository A")
+	serverRepoBrowserGit(t, workA, "push", "origin", "main")
+	require.NoError(os.WriteFile(filepath.Join(workB, "README.md"), []byte("repository B\n"), 0o644))
+	require.NoError(os.WriteFile(filepath.Join(workB, "ONLY_B.md"), []byte("only repository B\n"), 0o644))
+	serverRepoBrowserGit(t, workB, "add", ".")
+	serverRepoBrowserGit(t, workB, "commit", "-m", "identify repository B")
+
+	observedAt := time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC)
+	repoA := db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "provider-repository-a",
+		Owner:          "acme", Name: "widgets", RepoPath: "acme/widgets",
+	}
+	entryA, applied, err := database.ReconcileRepositoryObservation(t.Context(), repoA, observedAt)
+	require.NoError(err)
+	require.True(applied)
+	require.NoError(database.UpdateRepoProviderMetadata(
+		t.Context(), entryA.Repository.ID, db.RepoProviderMetadata{
+			WebURL:        "https://github.com/acme/widgets",
+			CloneURL:      routeRemote,
+			DefaultBranch: "main",
+		},
+	))
+
+	routes := &blockingRepoBrowserRefreshRoutes{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	clones := gitclone.New(filepath.Join(t.TempDir(), "clones"), routes)
+	syncer := ghclient.NewSyncer(nil, database, nil, nil, time.Minute, nil, nil)
+	t.Cleanup(syncer.Stop)
+	srv := server.New(database, syncer, nil, "/", nil, server.ServerOptions{
+		Clones:                             clones,
+		DisableWorkspaceBackgroundMonitors: true,
+	})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+
+	initial := repoBrowserRequest(t, srv, http.MethodGet,
+		"/api/v1/repo/github/acme/widgets/browser/blob?ref_type=branch&ref_name=main&path=README.md",
+	)
+	require.Equal(http.StatusOK, initial.Code, initial.Body.String())
+	var initialBody repobrowserapi.RepoBrowserBlobResponse
+	require.NoError(json.Unmarshal(initial.Body.Bytes(), &initialBody))
+	require.Equal("repository A\n", initialBody.Blob.Content)
+
+	serverRepoBrowserGit(t, workB, "push", "--force", routeRemote, "main:main")
+	routes.enable()
+	refreshDone := make(chan struct{})
+	go func() {
+		clones.RefreshRepoBrowserClones(t.Context())
+		close(refreshDone)
+	}()
+	<-routes.started
+
+	_, _, err = database.ReconcileRepositoryObservation(t.Context(), db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "provider-repository-a",
+		Owner:          "acme", Name: "widgets-renamed", RepoPath: "acme/widgets-renamed",
+	}, observedAt.Add(time.Minute))
+	require.NoError(err)
+	entryB, applied, err := database.ReconcileRepositoryObservation(t.Context(), db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "provider-repository-b",
+		Owner:          "acme", Name: "widgets", RepoPath: "acme/widgets",
+	}, observedAt.Add(2*time.Minute))
+	require.NoError(err)
+	require.True(applied)
+	require.NoError(database.UpdateRepoProviderMetadata(
+		t.Context(), entryB.Repository.ID, db.RepoProviderMetadata{
+			WebURL:        "https://github.com/acme/widgets",
+			CloneURL:      routeRemote,
+			DefaultBranch: "main",
+		},
+	))
+	close(routes.release)
+	<-refreshDone
+
+	_, _, err = database.ReconcileRepositoryObservation(t.Context(), db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com",
+		PlatformRepoID: "provider-repository-b",
+		Owner:          "acme", Name: "widgets-elsewhere", RepoPath: "acme/widgets-elsewhere",
+	}, observedAt.Add(3*time.Minute))
+	require.NoError(err)
+	_, applied, err = database.ReconcileRepositoryObservation(
+		t.Context(), repoA, observedAt.Add(4*time.Minute),
+	)
+	require.NoError(err)
+	require.True(applied)
+	serverRepoBrowserGit(t, workA, "push", "--force", routeRemote, "main:main")
+
+	returned := repoBrowserRequest(t, srv, http.MethodGet,
+		"/api/v1/repo/github/acme/widgets/browser/blob?ref_type=branch&ref_name=main&path=README.md",
+	)
+	require.Equal(http.StatusOK, returned.Code, returned.Body.String())
+	var returnedBody repobrowserapi.RepoBrowserBlobResponse
+	require.NoError(json.Unmarshal(returned.Body.Bytes(), &returnedBody))
+	assert.Equal("repository A\n", returnedBody.Blob.Content)
+
+	bOnly := repoBrowserRequest(t, srv, http.MethodGet,
+		"/api/v1/repo/github/acme/widgets/browser/blob?ref_type=branch&ref_name=main&path=ONLY_B.md",
+	)
+	assert.Equal(http.StatusNotFound, bOnly.Code, bOnly.Body.String())
 }
 
 func TestRepoBrowserBlobReturnsTypedLargeAndBinaryStates(t *testing.T) {
@@ -748,6 +893,69 @@ func TestRepoBrowserStartupRefreshHonorsDisabledBackgroundMonitors(t *testing.T)
 		}
 		return resolved.SHA == updatedSHA
 	}, 250*time.Millisecond, 25*time.Millisecond)
+}
+
+func TestRepoBrowserStartupAdoptsLegacyClonesWithoutProviderAccess(t *testing.T) {
+	acquireRepoBrowserTestSlot(t)
+	require := require.New(t)
+	assert := assert.New(t)
+	database := dbtest.Open(t)
+	remote, work := setupServerRepoBrowserGitRepo(t)
+	wantSHA := testGitSHA(t, work, "main")
+	repoID, err := database.UpsertRepo(
+		t.Context(), verifiedGitHubRepoIdentity("github.com", "acme", "widgets"),
+	)
+	require.NoError(err)
+	require.NoError(database.UpdateRepoProviderMetadata(
+		t.Context(), repoID, db.RepoProviderMetadata{
+			WebURL:        "https://github.com/acme/widgets",
+			CloneURL:      remote,
+			DefaultBranch: "main",
+		},
+	))
+
+	cloneBase := filepath.Join(t.TempDir(), "clones")
+	legacyClones := gitclone.New(cloneBase, nil)
+	require.NoError(legacyClones.EnsureClone(
+		t.Context(), "github", "github.com", "acme", "widgets", remote,
+	))
+	legacyRepo := gitclone.RepoBrowserRepoRef{
+		Provider: "github", Host: "github.com",
+		Owner: "acme", Name: "widgets", RepoPath: "acme/widgets",
+		RemoteURL: remote,
+	}
+	require.NoError(legacyClones.EnsureRepoBrowserClone(t.Context(), legacyRepo))
+	require.NoError(os.Rename(remote, remote+".offline"))
+
+	restartedClones := gitclone.New(cloneBase, nil)
+	restartedSyncer := ghclient.NewSyncer(nil, database, nil, nil, time.Minute, nil, nil)
+	t.Cleanup(restartedSyncer.Stop)
+	restartedServer := server.New(database, restartedSyncer, nil, "/", nil, server.ServerOptions{
+		Clones:                             restartedClones,
+		DisableWorkspaceBackgroundMonitors: true,
+	})
+	t.Cleanup(func() { gracefulShutdown(t, restartedServer) })
+
+	stableCtx := gitclone.WithRepositoryIdentity(t.Context(), "repo-acme-widgets")
+	legacyMainSHA, err := restartedClones.RevParse(
+		t.Context(), "github", "github.com", "acme", "widgets", "HEAD",
+	)
+	require.NoError(err)
+	assert.Equal(wantSHA, legacyMainSHA,
+		"workspace path-scoped clone must remain available after adoption")
+	mainSHA, err := restartedClones.RevParse(
+		stableCtx, "github", "github.com", "acme", "widgets", "HEAD",
+	)
+	require.NoError(err)
+	assert.Equal(wantSHA, mainSHA)
+	stableRepo := legacyRepo
+	stableRepo.ProviderRepoID = "repo-acme-widgets"
+	resolved, err := restartedClones.ResolveRepoBrowserRef(
+		t.Context(), stableRepo,
+		gitclone.RepoBrowserRef{Type: gitclone.RepoBrowserRefBranch, Name: "main"},
+	)
+	require.NoError(err)
+	assert.Equal(wantSHA, resolved.SHA)
 }
 
 func TestRepoBrowserRejectsUnsafePath(t *testing.T) {

--- a/internal/server/repobrowserapi/refresh.go
+++ b/internal/server/repobrowserapi/refresh.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"go.kenn.io/forge/internal/config"
-	"go.kenn.io/forge/internal/gitclone"
 )
 
 const defaultRepoBrowserRefreshInterval = 5 * time.Minute
@@ -57,13 +56,24 @@ func (h *Handler) SeedRefreshRepos(ctx context.Context) {
 		if strings.TrimSpace(repo.CloneURL) == "" {
 			continue
 		}
-		repoRef := gitclone.RepoBrowserRepoRef{
-			Provider:  repo.Platform,
-			Host:      repo.PlatformHost,
-			Owner:     repo.Owner,
-			Name:      repo.Name,
-			RepoPath:  repo.RepoPath,
-			RemoteURL: repo.CloneURL,
+		repoRef, err := h.repoBrowserRepoRef(ctx, repo)
+		if err != nil {
+			slog.Warn("failed to fence repo browser refresh repo",
+				"provider", repo.Platform,
+				"host", repo.PlatformHost,
+				"repo", repo.RepoPath,
+				"err", err)
+			continue
+		}
+		_, err = h.resolver.AdoptLegacyClonesIfSafe(ctx, repo, func() error {
+			return h.clones.AdoptLegacyClones(ctx, repoRef)
+		})
+		if err != nil {
+			slog.Warn("failed to adopt legacy repository clones",
+				"provider", repo.Platform,
+				"host", repo.PlatformHost,
+				"repo", repo.RepoPath,
+				"err", err)
 		}
 		registered, err := h.clones.RegisterExistingRepoBrowserClone(ctx, repoRef)
 		if err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1080,9 +1080,13 @@ func newServer(
 		tmuxAvailable && s.workspaces != nil,
 		options.DisableWorkspaceBackgroundMonitors,
 	)
-	if clones != nil && !options.DisableWorkspaceBackgroundMonitors {
+	if clones != nil {
+		// Seed even when background refresh is disabled: startup also adopts
+		// safe pre-stable-ID clone paths so cached reads survive an upgrade.
 		s.repoBrowserAPI.SeedRefreshRepos(context.Background())
-		s.runWorkspaceDependent(s.repoBrowserAPI.RunRefreshLoop)
+		if !options.DisableWorkspaceBackgroundMonitors {
+			s.runWorkspaceDependent(s.repoBrowserAPI.RunRefreshLoop)
+		}
 	}
 
 	// The syncer's native-stack preference is the transition authority for

--- a/internal/testutil/diff_repo.go
+++ b/internal/testutil/diff_repo.go
@@ -15,6 +15,7 @@ import (
 
 // DiffRepoResult holds the SHAs from the test repo for use in assertions.
 type DiffRepoResult struct {
+	PlatformRepoID string
 	BaseSHA        string // merge-base / base branch tip
 	HeadSHA        string // PR head commit
 	AltHeadSHA     string // newer PR head commit used by E2E refresh tests
@@ -42,8 +43,16 @@ func SetupDiffRepo(
 ) (*DiffRepoResult, error) {
 	workDir := filepath.Join(tmpDir, "workrepo")
 	cloneBase := filepath.Join(tmpDir, "clones")
-	barePath := filepath.Join(
-		cloneBase, "github.com", "acme", "widgets.git")
+	repoIdentity := db.GitHubRepoIdentity("github.com", "acme", "widgets")
+	repoIdentity.PlatformRepoID = "repo-acme-widgets"
+	mgr := gitclone.New(cloneBase, nil)
+	barePath, err := mgr.ClonePathForContext(
+		gitclone.WithRepositoryIdentity(ctx, repoIdentity.PlatformRepoID),
+		"github", "github.com", "acme", "widgets",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("resolve bare clone path: %w", err)
+	}
 
 	if err := os.MkdirAll(workDir, 0o755); err != nil {
 		return nil, fmt.Errorf("mkdir work: %w", err)
@@ -199,10 +208,28 @@ func SetupDiffRepo(
 		"clone", "--bare", workDir, barePath); err != nil {
 		return nil, fmt.Errorf("bare clone: %w", err)
 	}
+	// Workspace setup still uses the platform/path namespace because a
+	// workspace can outlive catalog route changes. Seed that independent clone
+	// as well as the stable-identity clone used by sync and diff endpoints.
+	workspaceBarePath, err := mgr.ClonePath(
+		"github", "github.com", "acme", "widgets",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("resolve workspace bare clone path: %w", err)
+	}
+	// git clone creates missing destination parents itself; this mirrors the
+	// identity-namespace clone above so the two seeding sites stay uniform.
+	if err := os.MkdirAll(
+		filepath.Dir(workspaceBarePath), 0o755); err != nil {
+		return nil, err
+	}
+	if err := git(ctx, "",
+		"clone", "--bare", workDir, workspaceBarePath); err != nil {
+		return nil, fmt.Errorf("workspace bare clone: %w", err)
+	}
 
 	// Seed database with the real SHAs for acme/widgets PR #1.
-	repoID, err := d.UpsertRepo(
-		ctx, db.GitHubRepoIdentity("github.com", "acme", "widgets"))
+	repoID, err := d.UpsertRepo(ctx, repoIdentity)
 	if err != nil {
 		return nil, fmt.Errorf("upsert repo: %w", err)
 	}
@@ -227,9 +254,8 @@ func SetupDiffRepo(
 		return nil, fmt.Errorf("update repo provider metadata: %w", err)
 	}
 
-	mgr := gitclone.New(cloneBase, nil)
-
 	return &DiffRepoResult{
+		PlatformRepoID: repoIdentity.PlatformRepoID,
 		BaseSHA:        baseSHA,
 		HeadSHA:        headSHA,
 		AltHeadSHA:     altHeadSHA,

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -31,9 +31,15 @@ func SeedFixtures(ctx context.Context, d *db.DB) (*SeedResult, error) {
 	if err != nil {
 		return nil, fmt.Errorf("upsert acme/widgets: %w", err)
 	}
+	if err := d.UpdateRepoViewerCanMerge(ctx, widgetsID, true); err != nil {
+		return nil, fmt.Errorf("grant fixture merge permission for acme/widgets: %w", err)
+	}
 	toolsID, err := d.UpsertRepo(ctx, fixtureRepoIdentity("acme", "tools"))
 	if err != nil {
 		return nil, fmt.Errorf("upsert acme/tools: %w", err)
+	}
+	if err := d.UpdateRepoViewerCanMerge(ctx, toolsID, true); err != nil {
+		return nil, fmt.Errorf("grant fixture merge permission for acme/tools: %w", err)
 	}
 	const toolsCloneURL = "https://github.com/acme/tools.git"
 	if err := d.UpdateRepoProviderMetadata(ctx, toolsID, db.RepoProviderMetadata{

--- a/internal/testutil/fixtures_test.go
+++ b/internal/testutil/fixtures_test.go
@@ -18,12 +18,16 @@ func TestSeedFixtures_Repos(t *testing.T) {
 	assert.Len(repos, 3)
 
 	names := make([]string, len(repos))
+	mergePermission := make(map[string]bool, len(repos))
 	for i, r := range repos {
 		names[i] = r.FullName()
+		mergePermission[r.FullName()] = r.ViewerCanMerge
 	}
 	assert.Contains(names, "acme/widgets")
 	assert.Contains(names, "acme/tools")
 	assert.Contains(names, "acme/archived")
+	assert.True(mergePermission["acme/widgets"])
+	assert.True(mergePermission["acme/tools"])
 }
 
 func TestSeedFixtures_PRCounts(t *testing.T) {


### PR DESCRIPTION
A repository's owner/name is a mutable route: renames move it, and a vacated path can be reused by a different repository. Because sync keyed repository data by path, a rename could lose merge settings, and a reused path could mix items, notifications, and cached state from two different repositories.

This PR keys repository-owned data by the provider's stable repository ID and checks route ownership before committing async provider data:

- **Route fences.** Routes carry a generation that increments when a path changes owners. Provider-derived writes (item snapshots, notifications, watermarks, ETags, deferred comment refreshes, queued read acknowledgements) commit only while the fence captured at sync start still holds.
- **Settings.** All sync paths persist repository metadata and merge settings through one watermark-gated writer. Stale snapshots are dropped instead of overwriting newer ones, provider-omitted fields don't erase stored values, and direct PR/issue syncs persist verified settings so a repository row created for a reused path never advertises the default (all-allowed) merge availability.
- **Clones.** Sync and diff clones are stored per stable repository ID, so repositories that ever share a path never share git data. The shared fetch validates route ownership before releasing waiters; workspace clones stay path-scoped.
- **Notifications.** Sync verifies repository identity before listing, and a vacated path drops its notifications, ETags, and sync watermarks so the next occupant starts clean.

Most of the added lines are tests; the context docs record the new invariants.

