### PR TITLE
Keep tmux aligned with fitted terminal dimensions

### DIFF
--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -354,7 +354,9 @@ Keyboard handlers must have one clear owner for each key press.
   only once the socket carried it, or a resize computed before the socket opened
   is suppressed forever and the PTY keeps its launch default. Synchronize
   authority on every measurement because geometry changes independently of
-  painted state; reclaiming authority must push even an unchanged size
+  painted state; reclaiming authority must push even an unchanged size. The
+  preflight measurement establishes authority only: send xterm's dimensions
+  after `fit()`, which measures again and may cross a cell boundary
   (`frontend/src/lib/components/terminal/TerminalSplitTree.svelte::terminal-leaf-body`,
   `frontend/src/lib/components/terminal/XtermTerminalPane.svelte::resizeVisibleTerminal`).
 - A promoted session is recorded ONCE, in the detail surface's stored pane tree.

--- a/frontend/src/lib/components/terminal/TerminalPane.test.ts
+++ b/frontend/src/lib/components/terminal/TerminalPane.test.ts
@@ -159,7 +159,10 @@ vi.mock("./tmuxMouseDragAutoscroll.js", () => ({
 vi.mock("@xterm/xterm", () => ({
   Terminal: vi.fn().mockImplementation(function (options) {
     xtermTerminalCtor(options);
-    const terminal = {
+    // The real xterm Terminal is a class instance, which Svelte leaves opaque.
+    // Keep the double equally opaque so fit updates the same object the pane reads.
+    class MockTerminal {}
+    const terminal = Object.assign(new MockTerminal(), {
       cols: initialTerminalDimensions.cols,
       rows: initialTerminalDimensions.rows,
       modes: { bracketedPasteMode: false },
@@ -182,7 +185,7 @@ vi.mock("@xterm/xterm", () => ({
       },
       refresh: vi.fn(),
       write: vi.fn(),
-    };
+    });
     xtermInstances.push(terminal);
     return terminal;
   }),
@@ -193,7 +196,16 @@ vi.mock("@xterm/addon-fit", () => ({
     // proposeDimensions is the pane's measurement of its own region: the real
     // addon returns undefined, or a zero, for a container with no content box
     // (a parked terminal), and the pane only pushes a size when it gets one.
-    const addon = { fit: vi.fn(), proposeDimensions: vi.fn(() => fitDimensions) };
+    const terminal = xtermInstances.at(-1);
+    const addon = {
+      fit: vi.fn(() => {
+        const fitted = addon.proposeDimensions();
+        if (!terminal || !fitted) return;
+        terminal.cols = fitted.cols;
+        terminal.rows = fitted.rows;
+      }),
+      proposeDimensions: vi.fn(() => fitDimensions),
+    };
     xtermFitAddons.push(addon);
     return addon;
   }),
@@ -764,6 +776,28 @@ describe("TerminalPane", () => {
     expect(resizeFramesOf(mockSockets[0]!)).toEqual([JSON.stringify({ type: "resize", cols: 120, rows: 50 })]);
   });
 
+  it("reports the dimensions that fit actually applies when the region changes between measurements", async () => {
+    render(TerminalPane, { props: { workspaceId: "ws-123" } });
+
+    await waitFor(() => expect(resizeObserverCallbacks).toHaveLength(1));
+    const terminal = xtermInstances[0]!;
+    const fitAddon = xtermFitAddons[0]!;
+    mockSockets[0]!.onopen?.();
+    mockSockets[0]!.sent = [];
+    fitDimensions = undefined;
+    resizeObserverCallbacks[0]!([], {} as ResizeObserver);
+    fitAddon.proposeDimensions.mockReturnValueOnce({ cols: 80, rows: 24 }).mockReturnValue({ cols: 80, rows: 25 });
+
+    resizeObserverCallbacks[0]!([], {} as ResizeObserver);
+
+    expect(terminal.rows).toBe(25);
+    expect(mockSockets[0]!.sent.map(String)).toEqual([
+      JSON.stringify({ type: "resize_active", active: false }),
+      JSON.stringify({ type: "resize_active", active: true }),
+      JSON.stringify({ type: "resize", cols: 80, rows: 25 }),
+    ]);
+  });
+
   it("sends a size measured before socket open once the connection opens", async () => {
     // The first measurement lands before the socket opens. Recording it as sent
     // anyway would let the dedupe suppress it forever, leaving the PTY at the
@@ -938,6 +972,32 @@ describe("TerminalPane", () => {
     expect(reconnectURL.searchParams.get("replay_boundary")).toBe("1");
     expect(reconnectURL.searchParams.has("cols")).toBe(false);
     expect(reconnectURL.searchParams.has("rows")).toBe(false);
+  });
+
+  it("refreshes tmux with the dimensions fit applies after replay", async () => {
+    initialTerminalDimensions = { cols: 177, rows: 41 };
+    fitDimensions = initialTerminalDimensions;
+    render(TerminalPane, {
+      props: {
+        websocketPath: "/ws/v1/workspaces/ws-123/runtime/sessions/ws-123%3Ashell/terminal",
+        active: true,
+      },
+    });
+
+    await waitFor(() => expect(mockSockets).toHaveLength(1));
+    const terminal = xtermInstances[0]!;
+    const fitAddon = xtermFitAddons[0]!;
+    const socket = mockSockets[0]!;
+    socket.onopen?.();
+    socket.sent = [];
+    fitAddon.proposeDimensions.mockReturnValueOnce({ cols: 177, rows: 41 }).mockReturnValue({ cols: 177, rows: 42 });
+
+    socket.onmessage?.(new MessageEvent("message", { data: JSON.stringify({ type: "replay_ready" }) }));
+    const boundaryCallback = terminal.write.mock.calls.at(-1)?.[1] as (() => void) | undefined;
+    boundaryCallback?.();
+
+    expect(terminal.rows).toBe(42);
+    expect(socket.sent.map(String)).toContain(JSON.stringify({ type: "refresh", cols: 177, rows: 42 }));
   });
 
   it("aborts a partial OSC sequence before writing output from a reconnected socket", async () => {

--- a/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
@@ -464,12 +464,13 @@
     if (!size || !terminal) return;
 
     fitAddon?.fit();
-    terminal.refresh(0, Math.max(0, size.rows - 1));
+    const fittedSize = { cols: terminal.cols, rows: terminal.rows };
+    terminal.refresh(0, Math.max(0, fittedSize.rows - 1));
     // The server resizes on a refresh's dimensions too, so a delivered refresh
     // counts as the size the PTY now has.
-    if (sendRefresh(size.cols, size.rows)) {
-      sentCols = size.cols;
-      sentRows = size.rows;
+    if (sendRefresh(fittedSize.cols, fittedSize.rows)) {
+      sentCols = fittedSize.cols;
+      sentRows = fittedSize.rows;
     }
   }
 
@@ -578,17 +579,19 @@
     if (!resizeActive || !size || !terminal) return;
 
     fitAddon?.fit();
-    terminal.refresh(0, Math.max(0, size.rows - 1));
-    // Compare the MEASUREMENT, not a read-back of terminal.cols: fit() applies
-    // these same numbers, and the measurement is what the size should be.
+    const fittedSize = { cols: terminal.cols, rows: terminal.rows };
+    terminal.refresh(0, Math.max(0, fittedSize.rows - 1));
+    // Report the dimensions fit() actually applied. It takes its own fresh
+    // measurement, so the region can cross a row or column boundary after the
+    // authority preflight above but before xterm is resized.
     // Re-send unchanged dimensions when reclaiming authority because another
     // attachment may have resized the PTY while this region had no geometry.
-    if (!authorityChanged && size.cols === sentCols && size.rows === sentRows) return;
+    if (!authorityChanged && fittedSize.cols === sentCols && fittedSize.rows === sentRows) return;
     // Recorded only once the socket carried it — a resize computed before the
     // socket opened would otherwise be suppressed forever as already sent.
-    if (sendResize(size.cols, size.rows)) {
-      sentCols = size.cols;
-      sentRows = size.rows;
+    if (sendResize(fittedSize.cols, fittedSize.rows)) {
+      sentCols = fittedSize.cols;
+      sentRows = fittedSize.rows;
     }
   }
 

--- a/frontend/tests/e2e-full/00-inline-workspace-continuity.spec.ts
+++ b/frontend/tests/e2e-full/00-inline-workspace-continuity.spec.ts
@@ -306,6 +306,27 @@ function tmuxClientTTY(server: IsolatedE2EServer, tmuxSession: string): string {
   return runE2ETmuxCommand(server, ["list-clients", "-t", tmuxSession, "-F", "#{client_tty}"]);
 }
 
+function tmuxClientPtyGeometries(server: IsolatedE2EServer): Array<{ rows: number; cols: number }> {
+  const clientTTYs = runE2ETmuxCommand(server, ["list-clients", "-F", "#{client_tty}"])
+    .split("\n")
+    .filter(Boolean);
+  return clientTTYs.map((clientTTY) => {
+    const fd = openSync(clientTTY, constants.O_RDONLY | constants.O_NOCTTY);
+    try {
+      const [rows, cols] = execFileSync("stty", ["size"], {
+        encoding: "utf8",
+        stdio: [fd, "pipe", "pipe"],
+      })
+        .trim()
+        .split(/\s+/)
+        .map(Number);
+      return { rows: rows!, cols: cols! };
+    } finally {
+      closeSync(fd);
+    }
+  });
+}
+
 function writeTTY(clientTTY: string, data: Uint8Array): void {
   const fd = openSync(clientTTY, constants.O_WRONLY | constants.O_NOCTTY);
   try {
@@ -418,6 +439,49 @@ async function readPtyGeometry(
   expect(rows).toBeGreaterThan(0);
   expect(cols).toBeGreaterThan(0);
   return { rows: rows!, cols: cols! };
+}
+
+async function readTerminalScreenSize(container: Locator): Promise<{ width: number; height: number }> {
+  return container.evaluate((element) => {
+    const screen = element.querySelector<HTMLElement>(".xterm-screen");
+    if (!screen) throw new Error("xterm screen geometry unavailable");
+    const bounds = screen.getBoundingClientRect();
+    if (bounds.width <= 0 || bounds.height <= 0) throw new Error("xterm screen geometry is empty");
+    return { width: bounds.width, height: bounds.height };
+  });
+}
+
+async function crossTerminalCellBoundary(container: Locator): Promise<void> {
+  await container.evaluate((element) => {
+    const terminalContainer = element as HTMLElement;
+    const originalGetComputedStyle = window.getComputedStyle;
+    const previousHeight = originalGetComputedStyle.call(window, terminalContainer).height;
+    const resizeHandle = document.querySelector<HTMLElement>(
+      '.terminal-panel.open [role="separator"][aria-label="Resize terminal panel"]',
+    );
+    if (!resizeHandle) throw new Error("terminal resize handle unavailable");
+
+    resizeHandle.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "ArrowUp" }));
+
+    window.getComputedStyle = ((target: Element, pseudoElement?: string | null) => {
+      const style = originalGetComputedStyle.call(window, target, pseudoElement);
+      if (target !== terminalContainer) return style;
+
+      window.getComputedStyle = originalGetComputedStyle;
+      terminalContainer.dataset.fitBoundaryCrossed = "true";
+      return new Proxy(style, {
+        get(styleDeclaration, property) {
+          if (property === "height") return previousHeight;
+          if (property === "getPropertyValue") {
+            return (name: string) =>
+              name === "height" ? previousHeight : styleDeclaration.getPropertyValue(name);
+          }
+          const value = Reflect.get(styleDeclaration, property, styleDeclaration);
+          return typeof value === "function" ? value.bind(styleDeclaration) : value;
+        },
+      });
+    }) as typeof window.getComputedStyle;
+  });
 }
 
 async function waitForPtyColumnsBelow(
@@ -534,6 +598,66 @@ test.describe("inline workspace pane continuity", () => {
         );
         expect(afterPty.rows).toBeGreaterThan(beforePtys[index]!.rows);
       }
+    } finally {
+      await api?.dispose();
+      await isolatedServer?.stop();
+    }
+  });
+
+  test("a fitted resize frame and the PTY agree after crossing a cell boundary", async ({ page }) => {
+    test.skip(
+      !hasCommand("git") || !hasCommand("tmux", ["-V"]),
+      "git and tmux are required for the real workspace flow",
+    );
+    await page.setViewportSize({ width: 1440, height: 900 });
+
+    let isolatedServer: IsolatedE2EServer | null = null;
+    let api: APIRequestContext | null = null;
+    try {
+      const controlFrames = observeTerminalControlFrames(page);
+      isolatedServer = await startIsolatedWorkspaceE2EServer();
+      api = await playwrightRequest.newContext({ baseURL: isolatedServer.info.base_url });
+      const workspace = await createIssueWorkspace(api, 10);
+      for (let index = 0; index < 2; index += 1) {
+        const launch = await api.post(`/api/v1/workspaces/${workspace.id}/runtime/sessions`, {
+          data: { target_key: "plain_shell", display_region: "terminal" },
+        });
+        expect(launch.status(), await launch.text()).toBe(200);
+      }
+
+      await page.goto(`${isolatedServer.info.base_url}/issues/github/acme/widgets/10`);
+      const terminal = await openTerminalPanel(page);
+      await expect
+        .poll(() => controlFrames.filter((frame) => frame.type === "resize" || frame.type === "refresh").length)
+        .toBeGreaterThan(0);
+      const initialFrame = controlFrames.filter((frame) => frame.type === "resize" || frame.type === "refresh").at(-1)!;
+      expect(initialFrame.cols).toBeGreaterThan(0);
+      expect(initialFrame.rows).toBeGreaterThan(0);
+      const before = await readTerminalScreenSize(terminal);
+      const cellWidth = before.width / initialFrame.cols!;
+      const cellHeight = before.height / initialFrame.rows!;
+      const resizeFramesBeforeBoundary = controlFrames.filter((frame) => frame.type === "resize").length;
+
+      // Reproduce the real race deterministically: the preflight sees the old
+      // container height while FitAddon.fit() sees the new height after it has
+      // crossed at least one cell boundary.
+      await crossTerminalCellBoundary(terminal);
+      await expect(terminal).toHaveAttribute("data-fit-boundary-crossed", "true");
+      await expect
+        .poll(() => controlFrames.filter((frame) => frame.type === "resize").length)
+        .toBeGreaterThan(resizeFramesBeforeBoundary);
+
+      const after = await readTerminalScreenSize(terminal);
+      const renderedRows = Math.round(after.height / cellHeight);
+      const renderedCols = Math.round(after.width / cellWidth);
+      const fittedFrame = controlFrames.filter((frame) => frame.type === "resize")[resizeFramesBeforeBoundary]!;
+
+      expect(renderedRows).toBeGreaterThan(initialFrame.rows!);
+      expect(renderedCols).toBe(initialFrame.cols);
+      expect(fittedFrame).toMatchObject({ cols: renderedCols, rows: renderedRows });
+      await expect
+        .poll(() => tmuxClientPtyGeometries(isolatedServer!))
+        .toContainEqual({ cols: renderedCols, rows: renderedRows });
     } finally {
       await api?.dispose();
       await isolatedServer?.stop();


### PR DESCRIPTION
Bottom terminals could occasionally show tmux's status line one row above the panel edge. The browser used a fit preflight size even though xterm measures again while applying fit; a panel settling across a cell boundary could therefore leave xterm and the PTY disagreeing about row count.

This makes the preflight measurement authority-only and reports post-fit dimensions for both normal resizes and replay reconciliation. The regression tests model a row-boundary change in both paths.

Verification note: the full frontend unit suite passes with reduced concurrency. The default-concurrency run hit four unrelated host-load timeouts, and each affected test passed independently.