### PR TITLE
fix: sync issues from GitHub repos that have pull requests disabled

### DIFF
--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -193,6 +193,11 @@ fallback repository listing.
   requests off still enters the cooldown.
   (`internal/github/native_stacks.go::decodeNativeStackHint`,
   `internal/github/sync.go::ListOpenMergeRequestsWithNativeStackHints`)
+- GitHub repositories can have pull requests disabled (issues-only trackers):
+  the pulls API 404s for every credential. A pulls-list 404 classifies as
+  merge-requests feature disabled only when the repository probe reads back
+  `has_pull_requests=false`; a bare 404 stays a transient failure
+  (`internal/github/sync.go::mergeRequestsDisabledByRepository`).
 - Preview-only GraphQL fields must be absent from disabled query shapes;
   `@include(false)` does not bypass schema validation on servers without those
   fields. Schema rejection drops the fields for that host instead of abandoning

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -1623,6 +1623,31 @@ func (p *gitHubClientProvider) ListRepositories(
 	return out, nil
 }
 
+// mergeRequestsDisabledByRepository classifies a pulls-list 404 against the
+// repository record. GitHub issues-only repositories report
+// has_pull_requests=false and return a bare 404 from the pulls API for every
+// credential, so without this probe the sync retries the repo as a hard
+// failure every cycle and never reaches its issue phase. A repository that
+// cannot be read, or that does not report the field, keeps the original
+// error: only an explicit has_pull_requests=false is proof.
+func (p *gitHubClientProvider) mergeRequestsDisabledByRepository(
+	ctx context.Context,
+	ref platform.RepoRef,
+	err error,
+) error {
+	if githubStatusCode(err) != http.StatusNotFound {
+		return nil
+	}
+	repo, repoErr := p.client.GetRepository(ctx, ref.Owner, ref.Name)
+	if repoErr != nil || repo == nil || repo.HasPullRequests == nil ||
+		repo.GetHasPullRequests() {
+		return nil
+	}
+	return platform.RepositoryFeatureDisabled(
+		platform.KindGitHub, p.host, platform.RepositoryFeatureMergeRequests, err,
+	)
+}
+
 func (p *gitHubClientProvider) ListOpenMergeRequests(
 	ctx context.Context,
 	ref platform.RepoRef,
@@ -1632,6 +1657,9 @@ func (p *gitHubClientProvider) ListOpenMergeRequests(
 		if disabledErr := githubRepositoryFeatureDisabled(
 			p.host, platform.RepositoryFeatureMergeRequests, err,
 		); disabledErr != nil {
+			return nil, disabledErr
+		}
+		if disabledErr := p.mergeRequestsDisabledByRepository(ctx, ref, err); disabledErr != nil {
 			return nil, disabledErr
 		}
 		return nil, err
@@ -1666,6 +1694,9 @@ func (p *gitHubClientProvider) ListOpenMergeRequestsWithNativeStackHints(
 		if disabledErr := githubRepositoryFeatureDisabled(
 			p.host, platform.RepositoryFeatureMergeRequests, err,
 		); disabledErr != nil {
+			return nil, nil, disabledErr
+		}
+		if disabledErr := p.mergeRequestsDisabledByRepository(ctx, ref, err); disabledErr != nil {
 			return nil, nil, disabledErr
 		}
 		return nil, nil, err

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -12734,6 +12734,89 @@ func TestSyncerMRListFailureMarksRepoFailed(t *testing.T) {
 	assert.False(flagged, "failedRepos must be cleared after successful retry")
 }
 
+// TestSyncerIssuesOnlyRepoDisablesMergeRequestFeature verifies that a
+// repository with pull requests disabled (GitHub issues-only repositories
+// report has_pull_requests=false and 404 on the pulls API) enters the
+// merge-request feature cooldown instead of hard-failing every cycle, and
+// that its issues still sync in the same cycle. Without the classification
+// the pulls 404 aborts the repo sync before the issue phase, so an
+// issues-only tracker never syncs the one thing it exists for.
+func TestSyncerIssuesOnlyRepoDisablesMergeRequestFeature(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	now := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	repos := []RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}}
+
+	issueNumber := 7
+	issueTitle := "product issue"
+	issueState := "open"
+	issueURL := "https://github.com/owner/repo/issues/7"
+	issueBody := ""
+	issueID := int64(777)
+	openIssue := &gh.Issue{
+		ID:        &issueID,
+		Number:    &issueNumber,
+		Title:     &issueTitle,
+		State:     &issueState,
+		HTMLURL:   &issueURL,
+		Body:      &issueBody,
+		CreatedAt: makeTimestamp(now),
+		UpdatedAt: makeTimestamp(now),
+	}
+
+	var prListCalls atomic.Int32
+	mc := &partialFailureMock{}
+	mc.listOpenPRsFn = func(context.Context, string, string) ([]*gh.PullRequest, error) {
+		prListCalls.Add(1)
+		return nil, &gh.ErrorResponse{
+			Response: &http.Response{StatusCode: http.StatusNotFound},
+			Message:  "Not Found",
+		}
+	}
+	mc.getRepositoryFn = func(_ context.Context, owner, repo string) (*gh.Repository, error) {
+		id := int64(1)
+		nodeID := "repo-" + owner + "-" + repo
+		prsDisabled := false
+		return &gh.Repository{
+			ID:              &id,
+			NodeID:          &nodeID,
+			Name:            &repo,
+			Owner:           &gh.User{Login: &owner},
+			HasPullRequests: &prsDisabled,
+		}, nil
+	}
+	mc.openIssues = []*gh.Issue{openIssue}
+	mc.comments = []*gh.IssueComment{}
+
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc},
+		d, nil, repos, time.Minute, nil, nil,
+	)
+
+	// Cycle 1: pulls 404 classifies as feature-disabled; issues still sync.
+	syncer.RunOnce(ctx)
+
+	issue, err := d.GetIssue(ctx, "github", "github.com", "owner", "repo", issueNumber)
+	require.NoError(err)
+	require.NotNil(issue,
+		"issues must sync even though the pulls API is unavailable")
+	assert.Equal("open", issue.State)
+
+	assert.Empty(syncer.Status().LastError,
+		"an issues-only repository is not a sync failure")
+	_, flagged := syncer.failedRepos.Load(repoFailKey(repos[0]))
+	assert.False(flagged, "feature-disabled must not mark the repo failed")
+	callsAfterFirstCycle := prListCalls.Load()
+
+	// Cycle 2: the merge-request feature cooldown skips the pulls list.
+	syncer.RunOnce(ctx)
+	assert.Equal(callsAfterFirstCycle, prListCalls.Load(),
+		"deferred merge-request feature must not re-probe next cycle")
+}
+
 // TestSyncerRemovedIssueTombstonedInsteadOfFailing verifies that an issue
 // deleted upstream (open in a previous cycle, absent from the open list,
 // direct lookup classified not_found) is closed locally instead of failing


### PR DESCRIPTION
GitHub now supports issues-only repositories (`has_pull_requests: false`); their pulls API returns a bare 404 for every credential, including app installation tokens with full repository access. The GitHub provider assumed pull requests could never be disabled, so it treated that 404 as transient: the repo hard-failed every sync cycle, kept a permanent error pinned in sync status, and — because the merge-request failure aborts the repo cycle before the issue phase — never synced the repo's issues, the one thing an issues-only tracker exists for.

- A pulls-list 404 now probes the repository record and classifies as a merge-requests feature disable only when the repo is readable and explicitly reports `has_pull_requests: false`, entering the existing feature-probe cooldown; issues sync normally in the same cycle.
- A bare 404 without that proof stays transient, so deleted or inaccessible repositories keep their retry semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)