### PR TITLE
chore: align Kata project with Forge

### DIFF
--- a/.kata.toml
+++ b/.kata.toml
@@ -1,4 +1,5 @@
 version = 1
 
 [project]
+identity = "github.com/kenn-io/forge"
 name = "forge"

--- a/.kata.toml
+++ b/.kata.toml
@@ -1,5 +1,4 @@
 version = 1
 
 [project]
-identity = "github.com/kenn-io/middleman"
-name = "kenn-forge"
+name = "forge"


### PR DESCRIPTION
The workspace still pointed Kata at the repository's pre-rename project identity, which could route future issue activity under the old name.

- Bind this workspace to the `forge` Kata project.
- Preserve the existing Kata project and issue history under project ID 7.

<sup>generated by a clanker</sup>