### PR TITLE
Prepare Kenn Forge documentation for general use

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ only routes to them.
   reloadable config; derive required request metadata from the runtime record or
   send it safely when the middleware ignores it (`cmd/kenn-forge/daemon_client.go::discoverDaemonHTTP`).
 - User-facing workflow screenshots are generated into a staged docs tree by the docs build and must not be tracked in Git; the Playwright captures in `docs/screenshots/` use the real seeded e2e backend, not mocked API fixtures or a developer daemon.
+- Stage Zensical input from an explicit public allowlist; internal plans, specs, ADRs, reports, and screenshot tooling must never enter the staged tree or rendered `site/` output.
 - Verify Zensical screenshot asset-path findings against rendered `site/` output; raw HTML source paths can be rewritten when `use_directory_urls` is enabled.
 - Zensical resolves `docs_dir`/`site_dir` relative to the config file's directory, so `uvx zensical build` cannot run in place against the checked-in `docs/zensical.toml`; stage a scratch project root containing a copy of the config beside a copy of `docs/`, then build there.
 - Tests, docs, fixtures, commit messages, and PR text should use generic synthetic examples unless the user explicitly asks to preserve exact private project names, paths, prose, or domain details.

--- a/README.md
+++ b/README.md
@@ -39,11 +39,10 @@ Build the current source when no release is published:
 ```sh
 git clone https://github.com/kenn-io/middleman.git kenn-forge
 cd kenn-forge
-make build
+make install
 ```
 
-Source builds require Go 1.26+ and [Bun](https://bun.sh/). Run `make install`
-to install an optimized build.
+Source builds require Go 1.26+ and [Bun](https://bun.sh/).
 
 ## Start
 
@@ -55,12 +54,15 @@ kenn-forge
 ```
 
 Open `http://127.0.0.1:8091`. First-run setup connects a code forge, adds
-repositories, runs the first sync, opens a pull request, and can create a local
-workspace.
+repositories, runs the first sync, and opens a pull request.
 
-GitLab, Forgejo, Gitea, self-hosted providers, and explicit token setup use the
-Repositories panel in Settings. Kenn Forge stores its config and data under
-`~/.kenn/forge/` by default.
+The Repositories panel selects provider hosts and repository patterns. Configure
+non-GitHub and explicit credentials through environment variables or
+`~/.kenn/forge/config.toml`; see [Configuration](docs/configuration.md).
+
+Local workspaces require Git and tmux on a Unix-like host. The Windows release
+supports the dashboard and provider actions. Use WSL or a remote Unix-like Kenn
+Forge host when you need workspace sessions.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -1,102 +1,40 @@
 # kenn-forge
 
-A local-first maintainer console. The original core syncs PRs and issues from your repos into SQLite, serves a fast Svelte 5 frontend from a single binary, and keeps you out of provider notification inboxes.
+Kenn Forge is a local maintainer console for pull requests, issues, reviews,
+activity, and local workspaces. It syncs the repositories you maintain into a
+local SQLite database and serves the UI from one binary.
 
-Kenn Forge runs entirely on your machine -- no hosted service, no account to create. One binary, one config file, and you're up.
+Start with the [user guide](docs/index.md) for setup and workflows.
 
-For user-facing setup and workflow docs, start with
-[docs/index.md](docs/index.md).
+## What you can do
 
-This workstream expands kenn-forge beyond provider PR/MR triage with first-class
-modes for external Kata task daemons and local markdown docs. Those domains
-stay owned by their source systems: Kata task data remains in Kata daemons and
-docs remain on disk.
+- Triage activity across repositories and provider hosts.
+- Review pull requests and merge requests with discussion, diffs, and CI context.
+- Work with issues without leaving the console.
+- Create local workspaces for hands-on review or implementation.
+- Connect optional Kata task daemons and local Markdown folders.
+- View and operate remote Kenn Forge daemons through a federated fleet.
 
-## Features
+Provider capabilities vary. Kenn Forge shows unsupported actions as unavailable.
 
-### Activity feed
+## Install a release
 
-A unified timeline of comments, reviews, and commits across all your repos. Switch between flat and threaded views. Threaded view groups events by PR/issue and collapses long commit runs for readability.
+Download the archive for your system from
+[GitHub Releases](https://github.com/kenn-io/middleman/releases). Releases
+include a `SHA256SUMS` file.
 
-Filter by time range (24h / 7d / 30d / 90d), event type, repo, item type (PRs vs issues), or free-text search. Hide closed items and bot noise with a toggle.
+| System | Architecture | Archive |
+| --- | --- | --- |
+| Linux | x86-64 | `forge_<version>_linux_amd64.tar.gz` |
+| Linux | ARM64 | `forge_<version>_linux_arm64.tar.gz` |
+| macOS | Intel | `forge_<version>_darwin_amd64.tar.gz` |
+| macOS | Apple silicon | `forge_<version>_darwin_arm64.tar.gz` |
+| Windows | x86-64 | `forge_<version>_windows_amd64.zip` |
 
-### Pull request management
+Extract the archive and move `kenn-forge` or `kenn-forge.exe` to a directory on
+your `PATH`.
 
-Browse, search, and filter PRs across repos. Group by repo or show a flat list. From the detail view you can:
-
-- **Comment** directly on a PR
-- **Approve** a PR
-- **Merge** with your choice of merge commit, squash, or rebase
-- **Mark draft PRs as ready** for review
-- **Close and reopen** PRs
-- **Star** items for quick filtering
-
-Review decisions, diff stats (additions/deletions), CI status, merge conflict indicators, and branch info are visible at a glance.
-
-### Diff view
-
-Inline diffs with a collapsible file tree sidebar. Files are grouped by directory and show status badges (modified, added, deleted, renamed) with per-file addition/deletion counts. Syntax highlighting via Shiki with light/dark theme support.
-
-Filter the file tree by name, toggle whitespace visibility, and adjust tab width. Navigate between files with `j`/`k`. Each file section is independently collapsible.
-
-### Issue tracking
-
-Same filtering, search, and detail view as PRs. Post comments, close/reopen, and
-star issues without context-switching to the provider.
-
-### CI checks
-
-Expandable check run section on each PR shows success, failure, pending, skipped,
-and neutral results with direct links to provider runs when available.
-
-### Sync engine
-
-- Runs immediately on startup, then on a configurable interval (default 5 minutes)
-- Opening a PR or issue triggers an immediate sync for that item
-- The active detail view polls every 60 seconds for new comments
-- Progress is visible in the status bar; errors surface clearly
-
-### Keyboard navigation
-
-| Key | Action |
-|-----|--------|
-| `j` / `k` | Move through the list (or between files in diff view) |
-| `1` | Open the pull request list |
-| `Escape` | Close detail view / clear selection |
-
-### Other
-
-- **Dark mode** -- auto-detects system preference, with a manual toggle
-- **GitHub Enterprise, GitLab, Forgejo, and Gitea** -- set
-  `platform`/`platform_host` per repo to connect to other provider hosts
-- **Copy to clipboard** -- one-click copy of PR/issue bodies and comments
-- **Settings UI** -- add/remove repos and configure activity feed defaults from the browser
-- **Reverse proxy support** -- deploy behind a proxy with the `base_path` config
-- **Version info** -- `kenn-forge version` prints build metadata, with `--json` for integrations
-
-### Additional modes in this integration branch
-
-- **Kata** -- talk to external Kata daemons discovered from Kata's own
-  `$KATA_HOME/config.toml` and runtime records.
-- **Docs** -- browse, view, edit, search, and publish configured markdown
-  folders.
-- **Federated fleet** -- one daemon (the hub) merges snapshots from remote
-  kenn-forge daemons, proxies mutations to the host that owns the resource,
-  and hands out native tmux attach commands fleet-wide. Peers are reached
-  over HTTP or SSH (no exposed remote listener required). See
-  [docs/federated-fleet.md](docs/federated-fleet.md).
-
-## Quickstart
-
-### Requirements
-
-- Go 1.26+
-- [Bun](https://bun.sh/) (or install via [mise](https://mise.jdx.dev/))
-- A provider token with read access to the configured repos. GitHub can use a
-  classic or fine-grained token; GitLab, Forgejo, and Gitea use host-scoped
-  tokens from config.
-
-### Build and run
+Build the current source when no release is published:
 
 ```sh
 git clone https://github.com/kenn-io/middleman.git kenn-forge
@@ -104,355 +42,32 @@ cd kenn-forge
 make build
 ```
 
-Set your token and start kenn-forge:
+Source builds require Go 1.26+ and [Bun](https://bun.sh/). Run `make install`
+to install an optimized build.
+
+## Start
+
+GitHub users can reuse an authenticated GitHub CLI session:
 
 ```sh
-export KENN_FORGE_GITHUB_TOKEN=ghp_your_token_here
-./kenn-forge
+gh auth login
+kenn-forge
 ```
 
-If you use the [GitHub CLI](https://cli.github.com/), kenn-forge will use
-`gh auth token --hostname HOST` automatically. The unscoped fallback applies
-only to `github.com`.
-
-For token rotation without restarting kenn-forge, configure `token_file` on a
-repo, provider, or GitHub owner entry and replace that file atomically when the
-token changes. Kenn Forge reads token files on demand and trims surrounding
-whitespace. Restart after rotating an owner route to a PAT issued by a different
-GitHub user.
-
-On first run, kenn-forge creates a default config at `~/.kenn/forge/config.toml` and serves the UI at **http://localhost:8091**. Add repositories from the Settings page, or edit the config file directly:
-
-```toml
-[[repos]]
-owner = "your-org"
-name = "your-repo"
-
-[[repos]]
-owner = "your-org"
-name = "another-repo"
-```
-
-To expose Go profiler endpoints for local diagnostics, start a separate listener:
-
-```sh
-KENN_FORGE_PPROF_ADDR=127.0.0.1:6060 ./kenn-forge
-# or
-./kenn-forge serve -pprof-addr 127.0.0.1:6060
-```
-
-The listener is disabled when the address is empty and serves the standard `/debug/pprof/` endpoints.
-
-### Install to PATH
-
-```sh
-make install   # installs to ~/.local/bin
-```
-
-## Configuration
-
-All fields are optional. Repos can be added in the config file or through the Settings UI.
-
-| Field | Default | Description |
-|-------|---------|-------------|
-| `sync_interval` | `"5m"` | How often to pull from configured providers |
-| `github_token_env` | `"KENN_FORGE_GITHUB_TOKEN"` | Env var holding the default GitHub token |
-| `default_platform_host` | `"github.com"` | Host treated as implicit in repository UI labels |
-| `host` | `"127.0.0.1"` | Listen address |
-| `port` | `8091` | Listen port, from 1 to 65535 |
-| `base_path` | `"/"` | URL prefix for reverse proxy deployments |
-| `data_dir` | `"~/.kenn/forge"` | Directory for the SQLite database |
-| `activity.view_mode` | `"threaded"` | `"flat"` or `"threaded"` |
-| `activity.time_range` | `"7d"` | `"24h"`, `"7d"`, `"30d"`, or `"90d"` |
-| `activity.hide_closed` | `false` | Hide closed/merged items in the feed |
-| `activity.hide_bots` | `false` | Hide bot activity |
-| `activity.default_branch_retention_days` | `90` | Days of default-branch commits to keep for Activity |
-| `activity.default_branch_max_commits` | `5000` | Maximum default-branch commit rows kept per repo branch |
-
-The integration branch also adds docs-folder configuration. Kata
-daemon definitions are intentionally not stored in kenn-forge config; kenn-forge
-reads the Kata daemon catalog from `$KATA_HOME/config.toml`, defaulting to
-`~/.kata/config.toml`.
-
-### Provider Hosts
-
-Add `platform_host` and optionally `token_env` or `token_file` to repos hosted
-on a GitHub Enterprise instance:
-
-```toml
-[[repos]]
-owner = "team"
-name = "internal-app"
-platform_host = "github.corp.example.com"
-token_env = "GHE_TOKEN"
-```
-
-Tokens can come from `token_file`, `token_env`, exact public-host defaults, or
-the GitHub CLI fallback. Use `token_file` when you need rotation without
-restarting Kenn Forge: write the new token to a temporary file, then atomically
-rename it over the configured path. Kenn Forge reads token files on demand and
-trims surrounding whitespace.
-
-For a repo or platform entry, `token_file` is checked before `token_env`; empty
-token files and empty env vars are treated as absent so the next configured
-fallback can supply a token. Public-host defaults are:
-
-- GitHub `github.com`: `github_token_env`, defaulting to
-  `KENN_FORGE_GITHUB_TOKEN`, then GitHub CLI fallback.
-- GitLab `gitlab.com`: no implicit default env var; configure `token_env` or
-  `token_file`.
-- Forgejo `codeberg.org`: `KENN_FORGE_FORGEJO_TOKEN`.
-- Gitea `gitea.com`: `KENN_FORGE_GITEA_TOKEN`.
-
-Provider fallback tokens are looked up by `(provider, host)`. GitHub may also
-route exact repositories or owners to dedicated PATs; see
-[configuration](docs/configuration.md#github-tokens-by-owner). Each distinct
-provider host can use a separate fallback source, so `github.com`, a GitHub Enterprise host,
-`gitlab.com`, `codeberg.org`, and a private Gitea host do not share API
-credentials unless you explicitly point them at the same source. Repos without
-`platform_host` default to that provider's public host: `github.com`,
-`gitlab.com`, `codeberg.org`, or `gitea.com`. Set `default_platform_host` when
-you want another host to be hidden as the implied repository host in the UI.
-
-Managed Git credentials are selected by full provider and repository identity.
-GitHub exact-repository and owner routes use their user PAT chain, never an App
-installation token. Non-GitHub providers continue to use their host fallback;
-clone storage is partitioned by provider when provider kinds share a hostname.
-
-Example provider-level token file:
-
-```toml
-[[platforms]]
-type = "gitlab"
-host = "gitlab.com"
-token_file = "~/.kenn/forge/tokens/gitlab.com"
-```
-
-Minimum read access is enough for sync: repository metadata, pull or merge
-requests, issues, comments, commits, tags, releases, and CI/status data. Enable
-write access only if you want kenn-forge to post comments, edit titles/bodies,
-change issue or PR state, approve reviews, or merge.
-
-GitLab hosts are configured through `[[platforms]]`, then referenced by repos:
-
-```toml
-[[platforms]]
-type = "gitlab"
-host = "gitlab.com"
-token_env = "KENN_FORGE_GITLAB_TOKEN"
-
-[[repos]]
-platform = "gitlab"
-platform_host = "gitlab.com"
-owner = "my-group/subgroup"
-name = "my-project"
-repo_path = "my-group/subgroup/my-project"
-```
-
-GitLab nested namespaces are preserved in `owner` and `repo_path`. Mutating
-actions are exposed only when the provider reports support for that capability;
-unsupported provider actions return a typed capability error instead of trying a
-GitHub-only route.
-
-Forgejo and Gitea use the same provider-host shape. Public Forgejo defaults to
-Codeberg, and public Gitea defaults to gitea.com:
-
-```toml
-[[repos]]
-platform = "forgejo"
-platform_host = "codeberg.org"
-owner = "forgejo"
-name = "forgejo"
-
-[[repos]]
-platform = "gitea"
-platform_host = "gitea.com"
-owner = "gitea"
-name = "tea"
-```
-
-Self-hosted Forgejo and Gitea instances should be declared in `[[platforms]]`
-with their own token env var, then referenced from repos:
-
-```toml
-[[platforms]]
-type = "forgejo"
-host = "forgejo.internal.example"
-token_env = "FORGEJO_INTERNAL_TOKEN"
-
-[[platforms]]
-type = "gitea"
-host = "gitea.internal.example"
-token_env = "GITEA_INTERNAL_TOKEN"
-
-[[repos]]
-platform = "forgejo"
-platform_host = "forgejo.internal.example"
-owner = "team"
-name = "service"
-
-[[repos]]
-platform = "gitea"
-platform_host = "gitea.internal.example"
-owner = "team"
-name = "ops"
-```
-
-Forgejo and Gitea preserve owner and repo casing as returned by the server.
-Unlike GitLab, nested owners are not supported for these providers; `repo_path`
-is normally the same as `owner/name` and is most useful when kenn-forge parsed a
-repository URL or needs to preserve provider-canonical casing.
-
-## Telemetry
-
-Kenn Forge sends limited anonymous telemetry to PostHog: `daemon_active` with repo count and `app_loaded` with view name, plus version, commit, OS/arch, `application: "kenn-forge"`, and an anonymous install ID.
-It disables PostHog person profile processing and IP geolocation for every capture. It does not send repo names, PR/issue content, provider tokens, usernames, hostnames, or paths; set `TELEMETRY_ENABLED=0` to disable it.
-
-## Thin clients
-
-Kenn Forge runs as a standalone daemon. Native apps and scripts reach
-it without out-of-band configuration: probe the flock on
-`<data_dir>/kenn-forge.lock`, read `kenn-forge.run.json` for the listen
-address and base path, authenticate with the bearer token minted at
-`<data_dir>/auth_token`, and use `/api/v1` plus the SSE event stream
-(Last-Event-ID replay supported). The `kenn-forge api` CLI verb wraps
-this discovery + auth for one-shot calls; webview hosts can load SPA
-routes directly and read daemon-side UI state from the served
-`window.__kenn_forge_config`. See `docs/federated-fleet.md` for the
-fleet and daemon contract details.
-
-## Architecture
-
-Kenn Forge is a single Go binary with the Svelte frontend embedded at build time.
-The provider dashboard stores synced provider state in SQLite. Additional modes
-may talk to local external services such as Kata daemons.
-
-```
-kenn-forge binary
-  |- Config loader (TOML)
-  |- Sync engine -> provider registry (GitHub/GitLab/Forgejo/Gitea readers)
-  |- Mode adapters -> Kata daemons, markdown folders
-  |- SQLite database (WAL mode, pure Go driver)
-  +- HTTP server (Huma) -> REST API + embedded SPA
-```
-
-- **No CGO required** -- uses [modernc.org/sqlite](https://pkg.go.dev/modernc.org/sqlite), a pure Go SQLite implementation
-- **Loopback only** -- binds to 127.0.0.1 by default; this is a personal tool, not a shared service
-- **Graceful shutdown** -- handles SIGINT/SIGTERM cleanly
-
-## Database
-
-Kenn Forge uses SQLite with embedded SQL migrations in `internal/db/migrations/`, applied on startup via `github.com/golang-migrate/migrate/v4`.
-
-On startup:
-
-- **Fresh database**: all embedded migrations are applied.
-- **Legacy database without `schema_migrations`**: kenn-forge assumes the pre-migration schema is baseline version 1 and migrates forward.
-- **Dirty or failed migration state**: startup fails and instructs you to delete the database file and let kenn-forge recreate it.
-- **Newer database** (migration version > binary): startup fails and instructs you to upgrade kenn-forge.
-
-If a migration cannot be applied cleanly, delete `~/.kenn/forge/forge.db` and let kenn-forge recreate it. Sync data will be repopulated from GitHub on the next run; local-only state (PR workflow statuses, stars, and worktree links) is lost.
-
-## Development
-
-Run the Go backend and Vite dev server in parallel:
-
-```sh
-make air-install    # one-time: install air for live reload
-make dev            # Go server on :8091 with live reload
-make frontend-dev   # Vite on :5174, proxies /api to Go
-```
-
-### Docker Compose dev stack
-
-Use the `mise` tasks to manage compose stack with a token fetched from host GitHub CLI:
-
-```sh
-mise run dev-compose       # docker compose up
-mise run dev-compose-logs  # docker compose logs -f
-mise run dev-compose-down  # docker compose down
-```
-
-Compose behavior:
-- Uses repo-local `docker/dev-config.toml` so compose config stays isolated from native runs
-- Stores SQLite state in Docker volume as `/data/forge.db` via `data_dir = "/data"`
-- Exposes backend on `http://127.0.0.1:18090` and frontend dev server on `http://127.0.0.1:15173`
-
-### Custom config file
-
-Use custom config file for both processes with shared env override:
-
-```sh
-KENN_FORGE_CONFIG=/path/to/config.toml make dev
-KENN_FORGE_CONFIG=/path/to/config.toml make frontend-dev
-```
-
-### Ephemeral dev stack
-
-Run backend and frontend together on two free loopback ports with an isolated
-copy of your configured SQLite state:
-
-```sh
-make dev-ephemeral
-```
-
-The command writes a generated config, database directory, logs, and typed
-status JSON into `tmp/dev-ephemeral`. By default it snapshots the source SQLite
-database into the generated data directory. The status file sits next to the
-generated config as `dev-ephemeral.json` and records the launcher PID, backend
-PID, frontend PID, selected ports, URLs, config path, and data directory. If the
-default stack is already running, another `make dev-ephemeral` prints the
-existing status instead of starting a second stack. Stale status files are
-removed and replaced.
-
-Pass `ARGS` to control the generated run:
-
-```sh
-make dev-ephemeral ARGS="-work-dir tmp/my-run"
-make dev-ephemeral ARGS="-backend-port 19091 -frontend-port 15174"
-make dev-ephemeral ARGS="-fresh-db"
-```
-
-Use `-work-dir` when you intentionally want a separate concurrent stack.
-The ephemeral launcher is currently supported on Unix-like development
-environments only.
-
-Other targets:
-
-```sh
-make build          # Debug build with embedded frontend
-make build-release  # Optimized, stripped release binary
-make test           # All Go tests
-make test-short     # Fast tests only
-make lint           # golangci-lint
-make frontend-check # Vite+ formatting, lint, type, and Svelte checks
-make api-generate   # Regenerate OpenAPI spec and clients
-make clean          # Remove build artifacts
-```
-
-### Pre-commit hooks
-
-Managed with [prek](https://github.com/j178/prek):
-
-```sh
-brew install prek
-prek install
-```
-
-## License
-
-Kenn Forge is source-available software, licensed under the
-[Elastic License 2.0](LICENSE) (ELv2).
-
-You can use, copy, modify, and redistribute it for free. The main restriction is
-that you may not provide Kenn Forge to third parties as a hosted or managed
-service that gives users access to a substantial set of its features. You also
-may not remove the project's licensing or copyright notices. The
-[LICENSE](LICENSE) file is the authoritative text; this paragraph is a
-non-binding summary.
-
-Contributions made before the relicense remain available under the MIT License;
-see the [NOTICE](NOTICE) file.
-
-A commercial license is available for uses not permitted by ELv2. For commercial
-licensing, contact [Kenn Software](https://kenn.io) at info@kenn.io.
+Open `http://127.0.0.1:8091`. First-run setup connects a code forge, adds
+repositories, runs the first sync, opens a pull request, and can create a local
+workspace.
+
+GitLab, Forgejo, Gitea, self-hosted providers, and explicit token setup use the
+Repositories panel in Settings. Kenn Forge stores its config and data under
+`~/.kenn/forge/` by default.
+
+## Documentation
+
+- [Quick Start](docs/quickstart.md)
+- [Workflows](docs/workflows.md)
+- [Configuration](docs/configuration.md)
+- [Commands](docs/commands.md)
+- [Troubleshooting](docs/troubleshooting.md)
+
+Kenn Forge is licensed under the [Elastic License 2.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Provider capabilities vary. Kenn Forge shows unsupported actions as unavailable.
 ## Install a release
 
 Download the archive for your system from
-[GitHub Releases](https://github.com/kenn-io/middleman/releases). Releases
+[GitHub Releases](https://github.com/kenn-io/forge/releases). Releases
 include a `SHA256SUMS` file.
 
 | System | Architecture | Archive |
@@ -37,7 +37,7 @@ your `PATH`.
 Build the current source when no release is published:
 
 ```sh
-git clone https://github.com/kenn-io/middleman.git kenn-forge
+git clone https://github.com/kenn-io/forge.git kenn-forge
 cd kenn-forge
 make install
 ```

--- a/README.md
+++ b/README.md
@@ -70,4 +70,7 @@ Repositories panel in Settings. Kenn Forge stores its config and data under
 - [Commands](docs/commands.md)
 - [Troubleshooting](docs/troubleshooting.md)
 
-Kenn Forge is licensed under the [Elastic License 2.0](LICENSE).
+Kenn Forge is licensed under the [Elastic License 2.0](LICENSE). Contributions
+made before the relicense remain available under the MIT License; see
+[NOTICE](NOTICE). Contact [Kenn Software](https://kenn.io) at info@kenn.io for
+commercial licensing.

--- a/docs/archive.md
+++ b/docs/archive.md
@@ -1,46 +1,84 @@
 # Historical activity archive
 
-Kenn Forge can backfill historical provider activity into its local SQLite database and keep it fresh under the normal sync budget. Reports read only local data, so they remain deterministic and do not spend provider requests.
+Kenn Forge can backfill provider activity into its local SQLite database.
+Archive work uses spare provider capacity, so normal sync stays ahead of
+historical requests.
 
-For command syntax, see [Commands](commands.md#historical-activity-archive).
+Reports read only local data. They do not spend provider requests.
 
-## What is archived
+## Coverage
 
-A full archive inventories supported historical issues and pull or merge requests, then schedules each item through the same detail-sync path used by normal sync. Comments, reviews, inline threads, and other supported detail are therefore normalized and persisted by one canonical implementation.
+Full archival covers supported historical issues, pull requests or merge
+requests, comments, reviews, and inline threads.
 
-The archive mirrors current provider truth. It does not retain deleted content, previous edit versions, commits, CI history, releases, labels, assignments, or other lifecycle events.
+The archive mirrors current provider state. It does not retain deleted
+content, previous edits, commits, CI history, releases, labels, assignments,
+or unrelated lifecycle events.
 
-Provider capabilities determine coverage. Unsupported historical inventory is reported explicitly as partial coverage. For example, GitLab historical merge-request inventory is currently unsupported because its offset pagination cannot guarantee a complete traversal across equal timestamps; GitLab issue history and updated-item maintenance remain available.
+Provider capabilities determine coverage. Unsupported inventory appears as
+partial coverage. GitLab merge-request history is currently partial because
+its pagination cannot guarantee a complete traversal across equal timestamps.
+GitLab issue history and updated-item maintenance remain available.
 
-## Workflow
+## Start
 
-Every configured repository begins in discovery mode. Discovery inventories supported historical item identities without hydrating each item.
+Every configured repository starts in discovery mode. Discovery records item
+identities without loading every detail.
 
-Use `kenn-forge archive start` to promote selected repositories, or all configured repositories, to full archival. Use `kenn-forge archive pause` to stop new archive work without deleting data or progress. Start and pause are idempotent.
+Promote one repository or all repositories to full archival:
 
-Archive work is incremental and resumable across daemon restarts. Inventory pages record item identities and durable cursors; admitted item work then invokes normal sync and records the archive outcome. A failed or interrupted operation is retried from durable progress while unrelated repositories continue independently.
+```sh
+kenn-forge archive start --repo 'github|github.com/owner/repo'
+kenn-forge archive start --all
+```
 
-There is no manual cursor-reset command. Invalid cursors, provider page limits, repository access loss, and contract violations block only the affected scope and remain visible in status rather than silently restarting potentially unbounded work.
+Progress survives daemon restarts. Repositories advance independently.
 
-## Status and coverage
+## Monitor
 
-`kenn-forge archive status` reports repository-scoped progress using the full provider identity. Common states are:
+```sh
+kenn-forge archive status --json
+```
 
-- **current** — supported inventory and item hydration are complete;
-- **partial** — one or more inventory scopes or items are unsupported or terminally blocked;
-- **running** — archive work is eligible or in progress;
-- **waiting_for_budget** — live-work reserves or provider limits currently prevent archive requests;
-- **paused** — the operator or configuration has paused archive work;
-- **blocked** — a scoped provider, cursor, access, or contract error requires attention.
+Common states:
 
-Error details are sanitized. Removing a repository from configuration pauses its archive state while keeping archived content and reports; re-adding the same provider and host identity resumes it.
+- **current**: supported inventory and item details are complete.
+- **partial**: some scopes or items are unsupported or blocked.
+- **running**: archive work is ready or in progress.
+- **waiting_for_budget**: live work or provider limits consume the safe budget.
+- **paused**: configuration or an operator paused new work.
+- **blocked**: a provider, cursor, access, or contract error needs attention.
 
-## Reports
+Errors identify the affected scope without exposing credentials. Removing a
+repository pauses its archive state but keeps data and progress. Adding the
+same provider and host identity resumes it.
 
-`kenn-forge archive report` reads SQLite for a UTC time range and optional repository filters. Summary output aggregates activity and contributors. Verbose output includes individual records. JSON output is available for automation.
+## Pause and resume
 
-Reports reflect supported coverage. Check archive status before treating a report as complete.
+```sh
+kenn-forge archive pause --all
+kenn-forge archive pause --repo 'github|github.com/owner/repo'
+```
 
-## Scheduling and provider budget
+Pause stops new archive work without deleting data. Start and pause are
+idempotent. Starting the same scope resumes durable progress.
 
-Live maintainer workflows always outrank archive traffic. Archive work uses bounded requests, releases provider admission before database work, and spends only surplus capacity above the live reserve. If safe surplus is unavailable, archive work waits while normal sync continues.
+There is no manual cursor reset. Invalid cursors, page limits, access loss,
+and contract errors block only the affected scope.
+
+## Report
+
+```sh
+kenn-forge archive report --days 7
+kenn-forge archive report --start 2026-07-01 --end 2026-07-07 --verbose
+```
+
+Reports use UTC. `--days` selects rolling 24-hour periods. Date-only ranges
+include both dates. RFC3339 ranges use an inclusive start and exclusive end.
+
+Markdown is the default. Use `--format json`, `--output PATH`, and repeated
+`--repo` filters for automation. Check status before treating a report as
+complete.
+
+See [Commands](commands.md#manage-historical-archives) for the short syntax
+reference.

--- a/docs/archive.md
+++ b/docs/archive.md
@@ -43,11 +43,12 @@ kenn-forge archive status --json
 Common states:
 
 - **current**: supported inventory and item details are complete.
-- **partial**: some scopes or items are unsupported or blocked.
+- **partial**: completed archival has unsupported or inaccessible coverage.
 - **running**: archive work is ready or in progress.
 - **waiting_for_budget**: live work or provider limits consume the safe budget.
 - **paused**: configuration or an operator paused new work.
-- **blocked**: a provider, cursor, access, or contract error needs attention.
+- **blocked**: work cannot advance until a provider, cursor, access, or contract
+  error receives attention.
 
 Errors identify the affected scope without exposing credentials. Removing a
 repository pauses its archive state but keeps data and progress. Adding the

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,74 +1,62 @@
 # Commands
 
-## Serve the app
+Run `kenn-forge --help` for the complete command tree. Most commands accept
+`--config`, `--server`, and `--timeout` where they apply.
+
+## Start and inspect the daemon
 
 ```sh
 kenn-forge
 kenn-forge serve
-kenn-forge serve -config /path/to/config.toml
-```
-
-Without a subcommand, `kenn-forge` starts the daemon and web UI.
-
-Use the idempotent background lifecycle when a caller needs to ensure the app
-is available without treating an existing compatible process as an error:
-
-```sh
+kenn-forge serve --config /path/to/config.toml
 kenn-forge start --background
-kenn-forge start --background --config /path/to/config.toml
+kenn-forge status
+kenn-forge status --json
 ```
 
-The command waits for the ready daemon identity before returning. Direct
-foreground starts retain their duplicate-process error behavior. Background
-startup requires a loopback listener. It verifies the recorded endpoint with a
-credential-free challenge before reusing the process, including when general
-API authentication is disabled.
+`kenn-forge` and `kenn-forge serve` run in the foreground. Background start
+returns after the daemon publishes its ready identity. It requires a loopback
+listener and safely reuses a compatible running process.
 
-## Version
+Direct foreground starts still reject a second process using the same data
+directory.
+
+## Check build information
 
 ```sh
 kenn-forge version
 kenn-forge version --json
 ```
 
-Prints the version, commit, and build date. Use `--json` for fleet inventory
-and other integrations. The JSON contract is a single object written to stdout:
+The JSON object contains `name`, `version`, `commit`, and `buildDate`.
+`buildDate` is a UTC RFC3339 timestamp or `unknown` for an uninjected build.
+This command does not read config or connect to a daemon.
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `name` | string | Canonical tool name, always `kenn-forge` |
-| `version` | string | Semantic version for a release build; development identifier otherwise |
-| `commit` | string | Build commit identifier |
-| `buildDate` | string | UTC RFC3339 timestamp for a release build; `unknown` when not injected |
+## Query and sync data
 
-The command does not read configuration, connect to a daemon, or require a
-workspace.
-
-## Status
+The CLI includes commands for `activity`, `issues`, `pulls`, `repos`,
+`repo-summaries`, `stacks`, `workspaces`, `rate-limits`, and `sync`. Use the
+command help before scripting an output shape:
 
 ```sh
-kenn-forge status
-kenn-forge status -json
-kenn-forge status -config /path/to/config.toml
+kenn-forge pulls --help
+kenn-forge sync --help
 ```
 
-Reports whether a kenn-forge daemon is running.
-
-## API relay
+## Relay an API request
 
 ```sh
-kenn-forge api GET /api/v1/pulls
-kenn-forge api POST /api/v1/sync
+kenn-forge api list
 kenn-forge api GET /api/v1/version
+kenn-forge api POST /api/v1/sync
+kenn-forge api -i GET /api/v1/pulls
 ```
 
-`kenn-forge api` discovers the running daemon from the selected config and
-relays one request. Use `-i` to include the HTTP status line, `--timeout` to
-bound the request, and `--config` when the daemon uses another config file.
-Non-2xx responses return a distinct failure exit code while preserving the
-response body.
+`kenn-forge api` discovers the selected daemon and supplies its local
+credential. Use `--data @-` to read a request body from stdin. Exit status 0
+means 2xx, 1 means another HTTP status, and 2 means no request was made.
 
-## Historical activity archive
+## Manage historical archives
 
 ```sh
 kenn-forge archive start --all
@@ -79,33 +67,21 @@ kenn-forge archive report --days 7
 kenn-forge archive report --start 2026-07-01 --end 2026-07-07 --verbose
 ```
 
-Archive collection runs in the background within each provider host's normal
-sync budget. Status reports `current`, `partial`, or blocked work honestly; a
-provider that cannot supply a required dataset remains partial rather than
-being treated as complete.
+Use repeated `--repo` flags for multiple repositories. Reports default to
+Markdown. Add `--format json` or `--output PATH` when needed.
 
-Reports use only kenn-forge's local archive, so they make no provider requests,
-but the kenn-forge daemon must be running. `--days` uses rolling 24-hour UTC
-periods. Date-only ranges include both named dates; RFC3339 ranges use an
-inclusive start and exclusive end. Reports default to Markdown; use
-`--format json`, `--output PATH`, and repeated fully qualified `--repo` filters
-as needed.
+See [Historical activity archive](archive.md) for coverage and status rules.
 
-Starting from an existing kenn-forge database discovers historical issues, pull
-or merge requests, comments, and supported review activity. No import from an
-older standalone archive is required.
-
-## Config
+## Read configuration
 
 ```sh
 kenn-forge config read port
-kenn-forge config read -config /path/to/config.toml port
+kenn-forge config read --config /path/to/config.toml port
 ```
 
-The current CLI exposes a small read surface. Use the Settings UI or edit the
-TOML file for normal configuration changes.
+Use Settings or edit TOML for normal configuration changes.
 
-## Docs folders
+## Manage Docs folders
 
 ```sh
 kenn-forge docs list-folders
@@ -114,9 +90,9 @@ kenn-forge docs add-folder --id project --daemon kata-main ~/project-docs
 kenn-forge docs remove-folder project
 ```
 
-These commands manage `[[doc_folders]]` in the config file.
+These commands manage `[[doc_folders]]` in the selected config file.
 
-## Agent activity hooks
+## Install agent activity hooks
 
 ```sh
 kenn-forge agent-hook install
@@ -125,11 +101,11 @@ kenn-forge agent-hook uninstall
 kenn-forge agent-hook uninstall --agent codex
 ```
 
-With no `--agent`, install or remove every supported integration. Installed
-hooks forward lifecycle activity to the running daemon; Codex asks for one
-manual review of the installed commands through `/hooks`.
+Without `--agent`, install or remove every supported integration. Installed
+hooks send lifecycle activity to the running daemon. Codex asks you to review
+the installed commands through `/hooks` once.
 
-## GitHub App credentials
+## Manage GitHub App credentials
 
 ```sh
 kenn-forge-github-app create
@@ -140,5 +116,6 @@ kenn-forge-github-app delete
 kenn-forge-github-app open
 ```
 
-Use this companion CLI when you want kenn-forge sync reads to use GitHub App
-installation tokens instead of your personal access token rate limit.
+Use this companion CLI when sync reads should use GitHub App installation
+tokens. Comments, reviews, state changes, and merges still use the user PAT
+chain.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,111 +1,86 @@
 # Configuration
 
-kenn-forge reads TOML from:
+Kenn Forge reads `~/.kenn/forge/config.toml`. Set `KENN_FORGE_HOME` to move
+both config and app data. Most users only need repositories, credentials, and
+optional modes.
 
-```text
-~/.kenn/forge/config.toml
-```
-
-Set `KENN_FORGE_HOME` to use a different config and data directory. Most users
-only need repositories, tokens, and optional modes.
-
-## Basic server settings
-
-```toml
-sync_interval = "5m"
-host = "127.0.0.1"
-port = 8091
-base_path = "/"
-```
-
-- `sync_interval`: how often provider data is refreshed.
-- `host` and `port`: where the local daemon listens.
-- `base_path`: URL prefix when serving behind a reverse proxy.
-- `data_dir`: local database and app state location. Leave unset for the
-  default; set `KENN_FORGE_HOME` to relocate both config and data, or use an
-  absolute `data_dir` path to move only app state.
-
-For a trusted reverse proxy or a larger SSE replay window, use:
-
-```toml
-allowed_hosts = ["kenn-forge.example.com", "proxy.example.com:8091"]
-trust_reverse_proxy = true
-sse_buffer_size = 256
-```
-
-`allowed_hosts` accepts exact host-and-port values beyond the listener's
-loopback names. With `trust_reverse_proxy`, both the direct request host and
-the forwarded public host must be accepted. `sse_buffer_size` defaults to 256
-events and accepts 16 through 16384. Restart kenn-forge after changing these
-startup settings.
+Use Settings for routine changes. Edit TOML for provider hosts and advanced
+options. Restart Kenn Forge after changing startup settings.
 
 ## Repositories
 
-GitHub repositories can use the default provider settings:
+A GitHub repository on `github.com` needs only its owner and name:
 
 ```toml
 [[repos]]
-owner = "kenn-io"
-name = "kenn-forge"
+owner = "team"
+name = "service"
 ```
 
-You can also paste a repository URL into `owner` or `name`; kenn-forge normalizes
-common HTTPS and SSH forms.
+You can paste a common HTTPS or SSH repository URL into `owner` or `name`.
+Kenn Forge normalizes it.
 
-For providers or hosts outside the default GitHub host, set `platform` and
-`platform_host`:
+Set the provider and host for other services or self-hosted instances:
 
 ```toml
+[[platforms]]
+type = "gitlab"
+host = "gitlab.example.com"
+token_env = "GITLAB_EXAMPLE_TOKEN"
+
 [[repos]]
 platform = "gitlab"
-platform_host = "gitlab.com"
+platform_host = "gitlab.example.com"
 owner = "group/subgroup"
 name = "project"
 repo_path = "group/subgroup/project"
 ```
 
-For self-hosted providers, declare the host once:
+Repository identity includes `platform`, `platform_host`, `owner`, and `name`.
+Keep `repo_path` when the provider uses nested namespaces or canonical casing.
 
-```toml
-[[platforms]]
-type = "forgejo"
-host = "forgejo.internal.example"
-token_env = "FORGEJO_INTERNAL_TOKEN"
+## Credentials
 
-[[repos]]
-platform = "forgejo"
-platform_host = "forgejo.internal.example"
-owner = "team"
-name = "service"
-```
-
-## Tokens
-
-Token lookup is scoped by provider and host. Use one of these sources:
+Credentials are scoped by provider and host:
 
 ```toml
 github_token_env = "KENN_FORGE_GITHUB_TOKEN"
 
 [[platforms]]
-type = "gitlab"
-host = "gitlab.com"
-token_env = "KENN_FORGE_GITLAB_TOKEN"
+type = "forgejo"
+host = "forge.example.com"
+token_env = "FORGE_EXAMPLE_TOKEN"
 
 [[repos]]
 owner = "team"
-name = "private-repo"
-token_file = "~/.kenn/forge/tokens/private-repo"
+name = "private-service"
+token_file = "~/.kenn/forge/tokens/private-service"
 ```
 
-For GitHub, kenn-forge can also fall back to
-`gh auth token --hostname HOST`. The unscoped `gh auth token` fallback applies
-only to `github.com`; authenticate another host with
-`gh auth login --hostname HOST`.
+An exact repository `token_file` or `token_env` takes priority over broader
+credentials. Empty files and variables are skipped. Token files are read on
+each request, so replacing a file atomically rotates that credential.
 
-### GitHub tokens by owner
+For GitHub, Kenn Forge can run `gh auth token --hostname HOST`. The unscoped
+fallback applies only to `github.com`. Authenticate another host with:
 
-Fine-grained PATs can expand access across owners without giving one token every
-repository. This advanced feature is configured in TOML only:
+```sh
+gh auth login --hostname HOST
+```
+
+Public-host defaults are:
+
+- GitHub `github.com`: `KENN_FORGE_GITHUB_TOKEN`, then the GitHub CLI.
+- GitLab `gitlab.com`: no implicit variable. Configure a token source.
+- Forgejo `codeberg.org`: `KENN_FORGE_FORGEJO_TOKEN`.
+- Gitea `gitea.com`: `KENN_FORGE_GITEA_TOKEN`.
+
+Grant read access for monitoring. Add write access only for comments, reviews,
+state changes, edits, or merges.
+
+### GitHub credentials by owner
+
+Map fine-grained PATs to owners when one token cannot read every repository:
 
 ```toml
 [[github_owner_tokens]]
@@ -117,53 +92,33 @@ owner = "org-b"
 token_file = "~/.kenn/forge/tokens/org-b"
 ```
 
-Authorization is selected by GitHub host and repository owner. An exact
-repository `token_env` or `token_file` wins; a covered GitHub App installation
-handles reads; the owner PAT handles uncovered reads and user-attributed writes;
-then the host fallback and GitHub CLI are tried.
+Owner mappings are configured in TOML only.
 
-For an App installed on only selected repositories, `selected_repos` is a
-startup routing snapshot. After changing repository access on GitHub, rerun
-`kenn-forge-github-app install` and restart kenn-forge. Until then, newly granted
-repositories continue on their PAT route, while revoked App access can surface
-as a repository 404. Kenn Forge does not retry a PAT after that 404 because the
-same response can also mean that the repository is absent or private.
+GitHub selects credentials by host and owner. Exact repository credentials win.
+A covered GitHub App handles reads. Owner PATs handle uncovered reads and
+user-attributed writes. Host credentials and the GitHub CLI follow.
 
-Rate limits and sync budgets are accounted by authenticated identity, not by
-configuration entry. PATs issued to the same GitHub user share that user's
-budget and rate state. Different users and App installations have separate
-host-and-identity budgets. Owner mappings are not editable in the UI.
+PATs for the same GitHub user share one rate limit and sync budget. Different
+users and App installations have separate budgets. Restart after routing an
+owner to a PAT from a different GitHub user.
 
-Replacing a PAT with another token for the same GitHub user can be applied from
-a token file. Restart kenn-forge after changing a route to a different GitHub
-user so identity-scoped budgets, mutation availability, and snapshots are
-rebuilt safely.
+### GitHub App reads
 
-Use read access for monitoring. Add write access only when you want kenn-forge to
-comment, approve, close, reopen, edit, or merge.
-
-For GitHub rate-limit isolation, use the companion CLI:
+Use the companion CLI to keep sync reads off your personal rate limit:
 
 ```sh
 kenn-forge-github-app create
+kenn-forge-github-app install
 kenn-forge-github-app list
 ```
 
-The app credentials are written to `[[github_apps]]` in the same config file.
+The CLI writes `[[github_apps]]` entries. Mutations still use a user PAT.
+After changing selected repository access on GitHub, run
+`kenn-forge-github-app install` again and restart Kenn Forge.
 
-### Pull request stacks
-
-```toml
-[pull_requests]
-prefer_github_native_stacks = true
-allow_mid_stack_merges = false
-```
-
-The native-stack option opts into GitHub's read-only stack preview data when it
-is complete and usable; kenn-forge keeps branch-based detection as the fallback.
-It does not create, reorder, or mutate GitHub stacks. Mid-stack merging stays
-blocked by default because merging a later branch first can invalidate earlier
-stack members.
+Selected repository access is a startup routing snapshot. New grants use the
+PAT route until refresh. Revoked App access can return 404, and Kenn Forge does
+not retry that response with a PAT because 404 can also mean missing or private.
 
 ## Activity defaults
 
@@ -178,10 +133,9 @@ default_branch_retention_days = 90
 default_branch_max_commits = 5000
 ```
 
-These settings control the initial Activity feed state and how much
-default-branch commit activity is retained locally.
+These values set the initial Activity view and local default-branch retention.
 
-## Modes
+## App modes
 
 ```toml
 [modes]
@@ -195,14 +149,12 @@ reviews = true
 workspaces = true
 ```
 
-Set a mode to `false` to hide it from the app. Kata and Docs default to hidden
-because they depend on external or local sources.
+Set a mode to `false` to hide it. Kata and Docs start hidden because they need
+external or local sources.
 
 ## Workspace agents
 
-Workspace launch cards include the built-in agents (Codex, Claude, Gemini,
-opencode, aider) that are found on `PATH`. Add custom agents or override a
-built-in command with `[[agents]]` entries:
+Kenn Forge detects built-in agents on `PATH`. Add or override an agent with:
 
 ```toml
 [[agents]]
@@ -211,11 +163,11 @@ label = "Review Agent"
 command = ["review-agent", "--fast"]
 ```
 
-Custom agents are also editable in the app under Settings → Agents.
+You can also edit agents under **Settings → Agents**.
 
 ## Docs folders
 
-Register markdown folders from the CLI:
+Register local Markdown folders from the CLI:
 
 ```sh
 kenn-forge docs add-folder --name Notes ~/notes
@@ -223,7 +175,7 @@ kenn-forge docs list-folders
 kenn-forge docs remove-folder notes
 ```
 
-This writes `[[doc_folders]]` entries:
+The equivalent config is:
 
 ```toml
 [[doc_folders]]
@@ -233,15 +185,52 @@ path = "/Users/you/notes"
 daemon = "kata-main"
 ```
 
-`daemon` is optional. Set it when task references in that folder must always
-open against one Kata daemon instead of the currently selected daemon.
+`daemon` is optional. Set it when task links in this folder always belong to
+one Kata daemon.
+
+## Server and storage
+
+```toml
+sync_interval = "5m"
+host = "127.0.0.1"
+port = 8091
+base_path = "/"
+```
+
+- `sync_interval` controls provider refreshes.
+- `host` and `port` set the listener.
+- `base_path` adds a URL prefix behind a reverse proxy.
+- `data_dir` moves app data while leaving config under `KENN_FORGE_HOME`.
+
+For a trusted reverse proxy or a larger SSE replay window:
+
+```toml
+allowed_hosts = ["forge.example.com", "proxy.example.com:8091"]
+trust_reverse_proxy = true
+sse_buffer_size = 256
+```
+
+`allowed_hosts` accepts exact host and port values. A trusted proxy must
+present accepted direct and forwarded hosts. `sse_buffer_size` defaults to 256
+and accepts 16 through 16384.
+
+## Pull request stacks
+
+```toml
+[pull_requests]
+prefer_github_native_stacks = true
+allow_mid_stack_merges = false
+```
+
+Native GitHub stack data improves read-only detection when complete. Branch
+relationships remain the fallback. Kenn Forge does not create or reorder
+stacks. Mid-stack merges stay blocked by default.
 
 ## Telemetry
 
-kenn-forge sends limited anonymous telemetry by default: daemon activity, app
-load view names, version, commit, OS/arch, and an anonymous install ID.
-
-It does not send repo names, PR or issue content, tokens, usernames, hostnames,
+Kenn Forge sends limited anonymous telemetry by default: daemon activity, app
+view names, version, commit, OS and architecture, and an anonymous install ID.
+It does not send repository names, item content, tokens, usernames, hostnames,
 or paths.
 
 Disable telemetry with:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,6 +52,8 @@ host = "forge.example.com"
 token_env = "FORGE_EXAMPLE_TOKEN"
 
 [[repos]]
+platform = "forgejo"
+platform_host = "forge.example.com"
 owner = "team"
 name = "private-service"
 token_file = "~/.kenn/forge/tokens/private-service"

--- a/docs/federated-fleet.md
+++ b/docs/federated-fleet.md
@@ -79,6 +79,22 @@ directory.
 
 Restart the hub after changing API authentication or SSH peer entries.
 
+## Open an authenticated hub
+
+When `require_auth = true`, read the hub token from
+`<data_dir>/auth_token`. The default path is
+`~/.kenn/forge/auth_token`.
+
+Open the hub once with the token in the query string:
+
+```text
+http://127.0.0.1:8091/?auth_token=<token>
+```
+
+Kenn Forge exchanges the token for an HttpOnly browser cookie, then redirects
+to the clean URL. The cookie also authenticates terminal WebSocket requests.
+Do not share the tokenized URL.
+
 ## Use the fleet
 
 Open the hub UI. Fleet-aware views show the host that owns each resource.

--- a/docs/federated-fleet.md
+++ b/docs/federated-fleet.md
@@ -1,300 +1,142 @@
 # Federated fleet
 
-Kenn Forge daemons federate into a fleet: one daemon (the **hub**) merges
-its own state with the state of remote daemons (**peers**) into a single
-snapshot, proxies mutations to the peer that owns the resource, and tells
-clients how to attach native terminals to sessions anywhere in the fleet.
-Every daemon runs the same binary; hub vs. peer is purely a matter of
-which daemon a client talks to and which peers its config lists.
+A fleet combines several Kenn Forge daemons in one UI. The daemon you open is
+the **hub**. Remote daemons are **peers**.
 
-This document is the single reference for the fleet's scope, wire
-contracts, and transports. It supersedes the per-slice design documents
-that previously lived under `docs/superpowers/`.
+The hub shows repositories, worktrees, sessions, hosts, and live tmux state.
+Supported actions route back to the peer that owns the resource. Every machine
+runs the same `kenn-forge` binary.
 
-## Scope
+Fleet links are one hop from hub to peer. Peers do not discover or relay
+through other peers.
 
-What the fleet does today:
+## Choose a transport
 
-- **Read plane**: the hub fans out to every configured peer, fetches
-  each peer's raw snapshot, and merges them into one enriched snapshot
-  (projects, worktrees, sessions, hosts, live tmux state).
-- **Write plane**: mutations against a remote host's resources
-  (workspace create/delete, runtime session launch/stop, registered-
-  worktree runtime, filesystem probes) ride hub-keyed proxy routes.
-- **Terminal plane**: attach-spec reads return the native command
-  vector for a tmux-backed session; WebSocket terminal routes proxy
-  interactive sessions through the hub.
-- **Transports**: peers are reached over plain HTTP or over SSH
-  (the hub holds a ControlMaster per SSH peer and relays API calls by
-  executing the peer's own CLI remotely, so the peer's HTTP listener
-  never leaves its host).
-- **Daemon contract**: runtime discovery via the lock file and
-  published metadata, a minted bearer token, and the `kenn-forge api`
-  CLI verb give thin clients and relays one uniform way to reach a
-  daemon.
+| Transport | Use it when | Required boundary |
+| --- | --- | --- |
+| HTTP | The peer listener is reachable from the hub | Loopback, tailnet, or another trusted VPN |
+| SSH | The peer should not expose a listener or requires authentication | Working non-interactive SSH access |
 
-Out of scope: remote binary provisioning/bootstrap
-(peers are expected to have `kenn-forge` installed), cross-fleet
-identity beyond config keys, and peer-to-peer topology. Fan-out is always
-hub → peer, one hop.
+HTTP fleet requests do not carry a bearer token. The hub also strips the
+caller's authorization and cookies. An HTTP peer must leave
+`[api].require_auth` disabled.
 
-## Configuration
+Use SSH for any peer that requires API authentication. The hub owns one SSH
+ControlMaster per peer and runs the remote Kenn Forge CLI through it.
+
+## Prepare each machine
+
+1. Install `kenn-forge` on the hub and every peer.
+2. Give each daemon a unique fleet key.
+3. Start each peer with its own repositories and workspaces configured.
+4. Confirm the hub can reach the HTTP listener or SSH destination.
+
+Remote binary installation is not automatic. SSH peers can start an installed
+daemon when needed, but they cannot install or upgrade it.
+
+## Configure the hub
 
 ```toml
 [fleet]
-# Fleet federation is opt-in. Set this on hubs that should fetch and
-# proxy remote peers; leaving it false keeps remote hosts unavailable.
 enabled = true
-# This daemon's identity in the fleet. Required to be unique across
-# the fleet; empty means "anonymous member" (can be a peer, cannot
-# meaningfully host).
 key = "studio"
-# Per-peer snapshot fetch budget (default "2s"). A peer that does not
-# answer in time degrades (reachable=false) instead of stalling the
-# snapshot.
 peer_timeout = "2s"
 
 [fleet.sessions]
-# Unmanaged tmux sessions are redacted to summary-only (name + window
-# count) unless the operator opts in to full window details.
 include_unmanaged_details = false
 
-# HTTP peer: the hub fetches http://mini.tail:8091/api/v1/snapshot/raw
-# and proxies writes to the same base URL. HTTP peers are credential-free
-# from the hub: the hub sends no token and never forwards the caller's
-# Authorization/cookie (those authenticate the hub, not the peer). So the
-# peer daemon must NOT set [api].require_auth, and base_url must ride a
-# trusted transport boundary (loopback, tailnet, or a VPN). Use an SSH
-# peer when the target needs authentication or has no exposed listener.
 [[fleet.peers]]
-key = "mini"
-name = "Mac mini"
-base_url = "http://mini.tail:8091"
+key = "desktop"
+name = "Desktop"
+base_url = "http://desktop.internal.example:8091"
 
-# SSH peer: no exposed listener. The hub opens a ControlMaster to the
-# destination and relays API calls by executing the remote CLI.
 [[fleet.ssh_peers]]
-key = "epyc"
-name = "EPYC box"
-destination = "wes@epyc.tail"
-# platform = "linux"
-# remote_command = "kenn-forge"   # bare executable, no flags
+key = "build"
+name = "Build host"
+destination = "maintainer@build.internal.example"
+remote_command = "kenn-forge"
 
 [api]
-# Gate this daemon's own HTTP API and terminal WebSocket routes behind
-# the minted bearer token (see "Daemon contract"). Recommended whenever
-# browsers or SSH-relay peers reach this daemon. Do not enable it on a
-# daemon that other hubs reach as an HTTP peer: HTTP peer fetches are
-# credential-free and would be rejected.
 require_auth = true
 ```
 
-Validation rules (`internal/config/config.go`): peer keys must be
-non-empty and unique across `fleet.key`, `[[fleet.peers]]`, and
-`[[fleet.ssh_peers]]`; SSH `destination` is required (it is passed to
-ssh(1) as a single positional argument, never through a shell);
-`remote_command` must be a bare executable name or path. The relay
-embeds it unquoted in a remote shell fragment and the CLI only
-dispatches subcommands in `argv[0]` position, so flags or metacharacters
-would change meaning. A custom remote config location is set via
-`KENN_FORGE_HOME` in the remote login profile (the relay runs
-`sh -lc`). Editing `[api].require_auth` or the SSH peer set while the
-daemon runs reports `restart_required` on the `config.changed` event.
-Both are wired at startup.
+`fleet.enabled` turns on remote federation. `fleet.key` identifies this host.
+An empty host key creates an anonymous member that cannot meaningfully host.
+Peer keys must be non-empty and unique across all fleet entries.
+`fleet.peer_timeout` defaults to `2s`.
 
-## Read plane: snapshots
+`include_unmanaged_details = false` limits unregistered tmux sessions to names
+and window counts. Enable it only when the hub may show full unmanaged session
+details.
 
-Two snapshot endpoints with distinct roles:
+The hub may protect its own API with `require_auth = true`. An HTTP peer may
+not. The HTTP peer must travel over a trusted private network.
 
-- `GET /api/v1/snapshot/raw`: this host only, never fans out. The
-  schema-versioned wire shape (`fleet.RawSnapshot`, `schemaVersion: 2`,
-  `internal/fleet/types.go`) carries the host record (hostname, platform,
-  version, live tmux inventory), projects, worktrees, and sessions,
-  each tagged with a `scopedKey` that is unique fleet-wide.
-- `GET /api/v1/snapshot?include_peers=true`: the merged, enriched
-  view. The hub fetches every configured peer's `/snapshot/raw`
-  concurrently (`fleet_hub.go`), bounded per peer by
-  `fleet.peer_timeout`, and merges results (`fleet.Merge`,
-  `fleet.BuildEnriched`). Without `include_peers` the hub answers from
-  local state alone.
+For SSH peers, `destination` is passed directly to `ssh`. `remote_command` must
+be a bare executable name or path without flags or shell syntax. Set
+`KENN_FORGE_HOME` in the remote login profile when the peer uses another config
+directory.
 
-The enriched entity types (`WorktreeSummary`, `HostSummary`,
-`SessionSummary`, `ProjectSummary`) are a hand-maintained projection of
-the raw wire types, not a structural copy: `BuildEnriched`'s `build*`
-helpers copy fields one by one and stamp UUIDs. A field added to a raw
-type (e.g. `RawWorktree`) therefore reaches `/snapshot` clients only
-after it is also added to the matching enriched summary and copied in
-its builder (e.g. `buildWorktree`). Skip that second half and the field
-travels the hub<->peer wire but is silently dropped before the client,
-with no compile error to flag it — so a snapshot-path test must assert
-on the enriched `/snapshot` shape, not just the raw inventory.
+Restart the hub after changing API authentication or SSH peer entries.
 
-Peer failures degrade rather than break the merge: an unreachable or
-slow peer appears in `hosts[]` with `reachable: false` and a
-diagnostic `error`, while the rest of the snapshot stays intact. For
-SSH peers a cold connection returns a "connection warming" degraded
-result while the fetch continues in the background (single-flighted
-per peer), so the next read benefits.
+## Use the fleet
 
-Enrichment (`internal/fleet/enrich.go`) computes two per-host layers:
+Open the hub UI. Fleet-aware views show the host that owns each resource.
+Create or delete workspaces, launch or stop sessions, and open terminals from
+the same controls used for local resources.
 
-- **Diagnostics**: informational warnings (tmux missing, platform
-  auth absent, probe errors) surfaced to the UI.
-- **Operation availability**: a binary gate per operation. The hub
-  applies a routability policy (`fleet_hub.go`): operations it cannot
-  route to a host are suppressed with an explanatory reason. HTTP and
-  SSH peers are routable (proxy routes exist), so their workspace and
-  session operations stay available; repo/project-registry mutations
-  remain local to each host.
+Remote operations preserve the peer's response. If the hub cannot route an
+operation, the UI disables it and explains why.
 
-A background monitor (`fleet_platform_auth.go`) keeps the local host's
-platform-authentication signal fresh (resolving a token can shell out
-to `gh auth token`, so it never runs on the snapshot read path).
+An unreachable peer does not break the fleet view. Its host remains visible
+with `reachable: false` and an error. Other hosts continue to load.
 
-## Live tmux monitoring
+The first request to a cold SSH peer may report **connection warming**. The
+hub continues opening the shared connection in the background. Retry after the
+host state changes to connected.
 
-Each daemon monitors its own tmux server and reports the result in its
-raw snapshot (`fleet_tmux_monitor.go`, `fleet_tmux_reconcile.go`):
+## Work with sessions
 
-- **Inventory probe** every 4s (`tmux list-sessions` /
-  `list-windows`, 750ms timeout): names, windows, created-at.
-- **Metrics probe** every 15s, best-effort: per-session CPU, RSS,
-  process count.
-- **Reconciliation** joins live sessions against DB ownership rows
-  (workspace sessions and registered-worktree sessions). A live owned
-  session is `managed: true` and carries its `sessionScopedKey` join
-  key; a live unowned session is `managed: false` and redacted to
-  summary unless `include_unmanaged_details` is set. An owned session
-  absent from two consecutive samples (both newer than the ownership
-  row) is marked exited. The two-sample debounce absorbs the race with
-  session creation.
-- Probe failures surface as `tmuxProbeError` / `tmuxMetricsError` on
-  the host record with `tmuxLastPolledAt` for staleness.
+Each daemon reports its own tmux sessions. Registered workspace sessions are
+marked as managed. Unregistered sessions stay redacted unless
+`include_unmanaged_details` is enabled.
 
-## Write plane: fleet proxy routes
+An attach action returns the native tmux command for a local session. For an
+SSH peer, the hub wraps that command through the existing SSH ControlMaster.
+Clients do not need to create their own SSH master.
 
-Hub-keyed routes under `/api/v1/fleet/hosts/{host_key}/...`
-(`fleet_proxy.go`, `fleet_project_proxy.go`) cover:
+SSH masters use keepalives and close after 30 minutes without activity. A
+socket left by a previous hub process is reused when it is still alive.
 
-- workspace create (including from an issue) and delete
-- workspace runtime sessions: launch, stop, attach-spec
-- host-level runtime sessions: launch, stop, attach-spec
-- registered-worktree runtime: info, ensure-shell, launch/stop
-  session, attach-spec
-- filesystem completion and repo validation (for create-workspace UIs)
+## Troubleshoot a peer
 
-Resolution order for `{host_key}`: the local host serves itself; an
-HTTP peer gets a reverse proxy to its base URL; an SSH peer gets the
-CLI relay below. The request body rides verbatim. The remote's exact
-status code and body come back, and error bodies are RFC 9457 problem
-documents the caller wants.
+### HTTP peer is unreachable
 
-WebSocket terminal routes (`/ws/v1/fleet/hosts/{host_key}/...`) proxy
-interactive terminals through the hub for workspace, runtime-shell,
-and runtime-session targets.
+Check `base_url` from the hub machine. Confirm the route stays on a trusted
+network and the peer does not require API authentication. A slow peer must
+answer within `fleet.peer_timeout`.
 
-## Terminal plane: attach-specs
+### SSH peer does not connect
 
-`GET .../attach-spec` returns the native command vector for a
-tmux-backed session:
+Test the exact destination from the hub:
 
-```json
-{
-  "version": 1,
-  "kind": "tmux",
-  "session_key": "...",
-  "target_key": "...",
-  "tmux_session": "mm-...",
-  "command": ["tmux", "attach-session", "-t", "mm-..."],
-  "requires_local_host": true
-}
+```sh
+ssh -o BatchMode=yes maintainer@build.internal.example true
 ```
 
-The session must exist both as a DB ownership row and in live tmux;
-non-tmux sessions are not attachable. When the fleet proxy serves an
-attach-spec for an **SSH peer**, it wraps the command so it runs from
-the hub's host through the peer's ControlMaster:
-`ssh -o ControlPath=<socket> -o ControlMaster=no -t <destination>
-tmux attach-session ...`. It also flips `requires_local_host` to false
-(`fleet_ssh.go: wrapAttachSpecForSSH`). Clients consume the socket
-path and connection state; they never spawn their own masters.
+Confirm `kenn-forge` is on the remote login `PATH`. If the peer uses another
+home directory, set `KENN_FORGE_HOME` in that login profile.
 
-## SSH transport
+When the relay finds no running daemon, it checks remote status and starts
+`kenn-forge serve`. It waits for runtime metadata, then retries once.
 
-`internal/sshfleet` owns the SSH side; the hub is the single owner of
-the ControlMaster lifecycle.
+### Remote action is unavailable
 
-- **ConnectionManager** (`connection.go`): one master per peer
-  (`-MNf`, `ServerAliveInterval=15`, `BatchMode=yes`,
-  `ConnectTimeout=10`), deterministic socket path under
-  `<data_dir>/ssh-sockets` (short hash of the host key). Sockets that
-  survive a daemon restart are adopted when still alive; per-host
-  connect coalescing prevents racing spawns; an idle monitor reaps
-  masters after 30 minutes without activity. State transitions
-  (connecting / connected / probe_failed / disconnected / error)
-  broadcast on the event hub as `fleet_host_state` and map onto the
-  snapshot's `connectionState`.
-- **Runner** (`runner.go`): relays one HTTP exchange by executing
-  the remote CLI through the master:
-  `ssh -o ControlPath=<socket> -o ControlMaster=no <destination>
-  sh -lc '<PATH=...>; kenn-forge api -i [-d @-] METHOD PATH'`. The
-  `-i` framing (status line, blank line, body) lets the hub recover
-  the exact remote status. Exit codes are the transport contract:
-  0/1 → parse framed response, 2 → typed
-  `ErrRemoteDaemonUnavailable`.
-- **Daemon auto-start** (`ensure.go`): when a relay hits exit 2, the
-  hub probes `status --json` on the peer, starts a detached daemon
-  (`nohup kenn-forge serve`) if none runs, polls until the probe
-  reports running **with published runtime metadata** (the api verb
-  needs the listen address, which trails the lock early in startup),
-  then retries the relay once. Double-starts are harmless: the loser
-  exits on the remote runtime lock.
+Check the host diagnostic in the UI. Repository registry changes remain local
+to each host. Workspace and session actions require a reachable HTTP or SSH
+route.
 
-## Daemon contract for thin clients
+### Attach is unavailable
 
-Everything a local client (or the SSH relay acting as one) needs to
-reach a daemon, with no out-of-band configuration:
-
-- **Runtime discovery** (`internal/runtimelock`): the daemon is
-  running iff the flock on `<data_dir>/kenn-forge.lock` is held; only
-  then is `<data_dir>/kenn-forge.run.json` authoritative. The metadata
-  publishes pid, `listen_addr` (from the actual bound listener),
-  `base_path` (canonical, no trailing slash; clients join API paths
-  onto it), `token_path`, and `require_auth`.
-- **Auth token**: minted at startup (32-byte hex, 0600, reused
-  across restarts) at `<data_dir>/auth_token`. The file mode is the
-  authorization boundary. With `[api] require_auth`, both the `/api/`
-  routes and the `/ws/` terminal WebSocket routes demand
-  `Authorization: Bearer <token>` or the session cookie that browsers
-  bootstrap once via the tokenized URL (`/?auth_token=...` → HttpOnly
-  cookie + redirect; browsers carry the cookie on the WebSocket
-  upgrade). `/healthz` and `/livez` stay exempt so supervisors can poll
-  before reading the token file. The hub never forwards a caller's
-  token or cookie to an HTTP peer. A require_auth daemon must be reached
-  as an SSH peer instead.
-- **`kenn-forge api` verb** (`cmd/kenn-forge/api_verb.go`): the
-  thin-client primitive: discovers the daemon through the runtime
-  metadata, authenticates with the token, relays one request.
-  Response bytes go to stdout verbatim; `-i` prefixes the exact
-  status line; exit 0 on 2xx, 1 on other HTTP statuses, 2 when no
-  request was made. The running daemon's published `base_path` is
-  authoritative for the URL prefix (a config edit awaiting restart
-  must not repoint the verb).
-- **Host validation**: the TCP listener validates the `Host` header
-  against the bind address and `allowed_hosts` (DNS-rebinding
-  defense). An ephemeral bind (port 0 listeners passed to `Serve`)
-  repoints the accept-set at the kernel-assigned port.
-
-## Testing
-
-- Wire-level tests per route (`internal/server/fleet_*_test.go`),
-  including degraded-peer, cold-SSH-peer single-flight, attach-spec
-  wrapping, and auto-start contracts against a faked ssh exec seam.
-- `internal/sshfleet` unit tests pin the ControlMaster lifecycle,
-  relay framing, and ensure-daemon polling.
-- `cmd/kenn-forge` e2e tests build the kenn-forge binary and pin the api
-  verb's auth, framing, exit-code, and base-path behavior.
-- Container e2e (`fleet_container_e2e_test.go`,
-  `scripts/e2e/fleet/`) runs a real hub + member over Docker
-  networking and validates the read plane and availability policy
-  end to end.
+The session must exist in Kenn Forge and in tmux. Non-tmux sessions do not
+provide native attach commands.

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,12 @@ Use Kenn Forge to answer four daily questions:
 - What can I review, update, or merge now?
 - Which branch or task should I open locally?
 
+<figure class="workflow-shot">
+  <img class="workflow-shot__image workflow-shot__image--light" src="assets/generated/maintainer-overview-light.svg" alt="Kenn Forge Activity feed with recent repository changes in light mode">
+  <img class="workflow-shot__image workflow-shot__image--dark" src="assets/generated/maintainer-overview-dark.svg" alt="Kenn Forge Activity feed with recent repository changes in dark mode">
+  <figcaption>Activity turns recent repository changes into one maintainer queue.</figcaption>
+</figure>
+
 ## Start here
 
 New users should follow the [Quick Start](quickstart.md). It covers

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,51 +1,48 @@
-# kenn-forge user docs
+# Kenn Forge
 
-kenn-forge is a local-first maintainer console for repositories you watch every
-day. It syncs pull requests, merge requests, issues, reviews, comments, CI
-signals, releases, and activity into SQLite, then gives you one browser UI for
-triage and action.
+Kenn Forge gives maintainers one local console for repository activity, pull
+requests, issues, reviews, and working sessions. It syncs provider data into
+SQLite and serves the UI from a single binary.
 
-Use it when you already know your forge and want one place to answer: what
-changed, what needs me, what can be merged, and what local work should I open
-next?
+Use Kenn Forge to answer four daily questions:
+
+- What changed across the repositories I maintain?
+- Which pull requests and issues need attention?
+- What can I review, update, or merge now?
+- Which branch or task should I open locally?
 
 ## Start here
 
-- [Quick start](quickstart.md): build, run, add repositories, and open the UI.
-- [Configuration](configuration.md): repositories, provider hosts, tokens, modes,
-  docs folders, and telemetry.
-- [Workflows](workflows.md): common ways to use Activity, PRs, issues, reviews,
-  workspaces, Kata, Docs, and fleet views.
-- [Commands](commands.md): CLI commands for serving, status, historical
-  archives, docs folders, and GitHub App credentials.
-- [Troubleshooting](troubleshooting.md): startup, auth, sync, config, database,
-  and mode issues.
+New users should follow the [Quick Start](quickstart.md). It covers
+installation, provider setup, repository selection, the first sync, and
+workspace creation.
 
-## What kenn-forge can do
+Returning users can jump to a task:
 
-- Show a cross-repository Activity feed with comment, review, commit, PR, and
-  issue activity.
-- Build and report on a resumable local archive of historical issues, pull or
-  merge requests, comments, and supported review activity.
-- Browse PRs/MRs and issues with filters, keyboard navigation, details, comments,
-  review actions, state changes, and merge actions where the provider supports
-  them.
-- Move with the command palette and view-specific keyboard shortcuts.
-- Inspect diffs, changed files, CI status, branch metadata, review state, labels,
-  and release signals without leaving the console.
-- Track local PR workflow status without mutating provider labels or projects.
-- Launch and attach to local workspace sessions for repository work.
-- Browse repository source, branches, and files from the UI.
-- Use optional modes for Kata task daemons and local markdown docs.
-- Federate kenn-forge daemons so one machine can view and act on items owned by
-  another machine.
-- Run as one local daemon with an embedded web app, local SQLite storage, and a
-  single TOML config file.
+- [Triage an issue](workflows/issue-triager.md)
+- [Review a pull request](workflows/code-reviewer.md)
+- [Run daily maintainer workflows](workflows.md)
+- [Change repositories, tokens, or modes](configuration.md)
+- [Fix startup, authentication, or sync problems](troubleshooting.md)
 
-## What kenn-forge is not
+## Main views
 
-- It is not a hosted service.
-- It is not a replacement data source for your forge, Kata, or local docs.
-  Those systems remain the source of truth.
-- It is not a general multi-user server by default. It binds to loopback unless
-  you configure otherwise.
+**Activity** collects recent comments, reviews, commits, and state changes.
+Filter by time, repository, item type, event type, or text.
+
+**Pulls** and **Issues** combine lists, details, discussion, provider actions,
+and workspace creation. Unsupported provider actions remain visible but
+unavailable.
+
+**Workspaces** opens local shells and configured agents against repository
+worktrees. **Repos** browses configured source. Optional **Kata** and **Docs**
+modes connect external task daemons and local Markdown folders.
+
+## Advanced use
+
+- [Command reference](commands.md)
+- [Historical activity archives](archive.md)
+- [Federated fleets](federated-fleet.md)
+
+Kenn Forge runs on your machine. Your provider, Kata daemons, and local files
+remain the source of truth.

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% block extrahead %}
+  <script>
+    (function () {
+      var stored = __md_get("__palette");
+      var color = stored && stored.color;
+      if (!color || color.media === "(prefers-color-scheme)") {
+        var light = matchMedia("(prefers-color-scheme: light)").matches;
+        color = {
+          media: "(prefers-color-scheme)",
+          scheme: light ? "default" : "slate",
+          primary: "custom",
+          accent: "custom",
+        };
+      }
+
+      new MutationObserver(function (_, observer) {
+        if (!document.body) return;
+        for (var key in color) document.body.setAttribute("data-md-color-" + key, color[key]);
+        observer.disconnect();
+      }).observe(document.documentElement, { childList: true });
+    })();
+  </script>
+{% endblock %}

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -81,7 +81,7 @@ In PowerShell:
 
 ```powershell
 $env:KENN_FORGE_GITHUB_TOKEN = 'ghp_your_token_here'
-.\kenn-forge.exe
+kenn-forge.exe
 ```
 
 For another provider or host, set its token environment variable before

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -98,6 +98,12 @@ Open `http://127.0.0.1:8091`. Kenn Forge creates
 The setup flow leads to a synced pull request and, on a host with Git and tmux,
 a working local workspace:
 
+<figure class="workflow-shot">
+  <img class="workflow-shot__image workflow-shot__image--light" src="assets/generated/first-run-light.svg" alt="Kenn Forge code forge readiness step in light mode">
+  <img class="workflow-shot__image workflow-shot__image--dark" src="assets/generated/first-run-dark.svg" alt="Kenn Forge code forge readiness step in dark mode">
+  <figcaption>First run checks the GitHub CLI and routes other providers through repository setup.</figcaption>
+</figure>
+
 1. **Connect a code forge.** Continue with an authenticated GitHub CLI, or
    open Settings for another provider or host.
 2. **Choose repositories.** GitHub users can select discovered repositories.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,12 +1,29 @@
-# Quick start
+# Quick Start
 
-## Requirements
+Install Kenn Forge, connect a code forge, and open your first workspace.
 
-- Go 1.26+
-- Bun for frontend dependencies and builds
-- A provider token, or `gh auth token` for GitHub
+## Install a release
 
-## Build
+Download the archive for your system from
+[GitHub Releases](https://github.com/kenn-io/middleman/releases). Each release
+also includes `SHA256SUMS`.
+
+| System | Architecture | Archive |
+| --- | --- | --- |
+| Linux | x86-64 | `forge_<version>_linux_amd64.tar.gz` |
+| Linux | ARM64 | `forge_<version>_linux_arm64.tar.gz` |
+| macOS | Intel | `forge_<version>_darwin_amd64.tar.gz` |
+| macOS | Apple silicon | `forge_<version>_darwin_arm64.tar.gz` |
+| Windows | x86-64 | `forge_<version>_windows_amd64.zip` |
+
+Extract the archive. Move `kenn-forge` or `kenn-forge.exe` to a directory on
+your `PATH`.
+
+If the Releases page has no published version, build from source.
+
+## Build from source
+
+Source builds require Go 1.26+ and [Bun](https://bun.sh/).
 
 ```sh
 git clone https://github.com/kenn-io/middleman.git kenn-forge
@@ -14,68 +31,62 @@ cd kenn-forge
 make build
 ```
 
-This builds a `kenn-forge` binary with the frontend embedded.
+The build embeds the frontend in `./kenn-forge`. Run `make install` to install
+an optimized binary.
 
-## Start kenn-forge
+## Start Kenn Forge
 
-For GitHub, either authenticate with the GitHub CLI:
+GitHub users get the shortest setup path with an authenticated GitHub CLI:
 
 ```sh
 gh auth login
-./kenn-forge
+kenn-forge
 ```
 
-or set a token explicitly:
+You can also provide a GitHub token directly:
 
 ```sh
 export KENN_FORGE_GITHUB_TOKEN=ghp_your_token_here
-./kenn-forge
+kenn-forge
 ```
 
-On first run, kenn-forge creates `~/.kenn/forge/config.toml` and starts the
-UI at:
+Open `http://127.0.0.1:8091`. Kenn Forge creates
+`~/.kenn/forge/config.toml` on first run.
 
-```text
-http://127.0.0.1:8091
-```
+## Complete first-run setup
 
-Install the binary to your path when you want to run it normally:
+The setup flow leads to a working pull-request workspace:
 
-```sh
-make install
-```
+1. **Connect a code forge.** Continue with an authenticated GitHub CLI, or
+   open Settings for another provider or host.
+2. **Choose repositories.** GitHub users can select discovered repositories.
+   Other providers use the Repositories panel in Settings.
+3. **Run the first sync.** Kenn Forge loads pull requests, issues, and activity
+   for the configured repositories.
+4. **Open a pull request.** Choose an open item from the synced list.
+5. **Start a workspace.** Create a local worktree and open its working session.
 
-## Add repositories
+You can leave setup and return later. Kenn Forge resumes unfinished setup after
+you return to a provider view.
 
-Use Settings in the UI, or edit `~/.kenn/forge/config.toml`:
+If repository discovery cannot find what you need, open **Settings →
+Repositories**. Settings also handles self-hosted providers, explicit tokens,
+and manual repository URLs.
 
-```toml
-[[repos]]
-owner = "your-org"
-name = "your-repo"
+## Use the main views
 
-[[repos]]
-owner = "your-org"
-name = "another-repo"
-```
+- **Activity**: scan recent cross-repository changes.
+- **Pulls**: review discussion, diffs, CI, and merge state.
+- **Issues**: triage, comment, change state, or create a workspace.
+- **Repos**: browse configured source and branches.
+- **Workspaces**: open local shells and configured agents.
+- **Settings**: manage repositories, agents, and app preferences.
 
-Restart kenn-forge after editing the config file. The first sync starts on
-startup and then repeats on the configured interval.
+Press `?` to see shortcuts for the current view.
 
-## Open the main views
+## Enable optional modes
 
-- **Activity**: recent cross-repo changes and discussion.
-- **Pulls**: PR/MR triage, review, CI, diff, and merge workflows.
-- **Issues**: issue triage, comments, state changes, and workspace launch.
-- **Reviews**: review jobs and review-oriented activity.
-- **Workspaces**: local working sessions tied to repos and tasks.
-- **Settings**: repository and app configuration.
-
-Press `?` in the UI for the current keyboard shortcuts.
-
-## Optional modes
-
-Kata and Docs are hidden by default. Enable them in config:
+Kata and Docs are hidden by default:
 
 ```toml
 [modes]
@@ -83,5 +94,8 @@ kata = true
 docs = true
 ```
 
-- Kata reads daemon definitions from Kata's own config.
-- Docs uses folders you register with `kenn-forge docs add-folder`.
+Kata reads daemon definitions from Kata's config. Docs uses folders registered
+with `kenn-forge docs add-folder`.
+
+Continue with [daily workflows](workflows.md) or the
+[configuration reference](configuration.md).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -16,6 +16,30 @@ also includes `SHA256SUMS`.
 | macOS | Apple silicon | `forge_<version>_darwin_arm64.tar.gz` |
 | Windows | x86-64 | `forge_<version>_windows_amd64.zip` |
 
+Verify the downloaded archive against `SHA256SUMS`.
+
+Linux:
+
+```sh
+sha256sum -c SHA256SUMS --ignore-missing
+```
+
+macOS:
+
+```sh
+shasum -a 256 forge_<version>_darwin_<arch>.tar.gz
+grep 'forge_<version>_darwin_<arch>.tar.gz' SHA256SUMS
+```
+
+Windows PowerShell:
+
+```powershell
+Get-FileHash .\forge_<version>_windows_amd64.zip -Algorithm SHA256
+Select-String -Path .\SHA256SUMS -Pattern 'forge_<version>_windows_amd64.zip'
+```
+
+Compare the printed SHA-256 values before extracting the archive.
+
 Extract the archive. Move `kenn-forge` or `kenn-forge.exe` to a directory on
 your `PATH`.
 
@@ -36,6 +60,9 @@ an optimized binary.
 
 ## Start Kenn Forge
 
+The commands below assume `kenn-forge` is on `PATH`. After `make build`, use
+`./kenn-forge` instead or run `make install`.
+
 GitHub users get the shortest setup path with an authenticated GitHub CLI:
 
 ```sh
@@ -50,12 +77,26 @@ export KENN_FORGE_GITHUB_TOKEN=ghp_your_token_here
 kenn-forge
 ```
 
+In PowerShell:
+
+```powershell
+$env:KENN_FORGE_GITHUB_TOKEN = 'ghp_your_token_here'
+.\kenn-forge.exe
+```
+
+For another provider or host, set its token environment variable before
+starting. To use `token_env` or `token_file`, start once to create
+`~/.kenn/forge/config.toml`, edit it, then restart. Settings chooses provider
+hosts and repository patterns, but it does not store credentials. See
+[Configuration](configuration.md#credentials).
+
 Open `http://127.0.0.1:8091`. Kenn Forge creates
 `~/.kenn/forge/config.toml` on first run.
 
 ## Complete first-run setup
 
-The setup flow leads to a working pull-request workspace:
+The setup flow leads to a synced pull request and, on a host with Git and tmux,
+a working local workspace:
 
 1. **Connect a code forge.** Continue with an authenticated GitHub CLI, or
    open Settings for another provider or host.
@@ -69,9 +110,13 @@ The setup flow leads to a working pull-request workspace:
 You can leave setup and return later. Kenn Forge resumes unfinished setup after
 you return to a provider view.
 
-If repository discovery cannot find what you need, open **Settings →
-Repositories**. Settings also handles self-hosted providers, explicit tokens,
-and manual repository URLs.
+If GitHub discovery cannot find what you need, open **Settings → Repositories**.
+For another provider, choose its host and repository pattern there after its
+credential is available to the daemon.
+
+The Windows release supports the dashboard and provider actions. Local
+workspace sessions require Git and tmux on a Unix-like host. Use WSL or a remote
+Unix-like Kenn Forge host for that step.
 
 ## Use the main views
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -5,7 +5,7 @@ Install Kenn Forge, connect a code forge, and open your first workspace.
 ## Install a release
 
 Download the archive for your system from
-[GitHub Releases](https://github.com/kenn-io/middleman/releases). Each release
+[GitHub Releases](https://github.com/kenn-io/forge/releases). Each release
 also includes `SHA256SUMS`.
 
 | System | Architecture | Archive |
@@ -50,7 +50,7 @@ If the Releases page has no published version, build from source.
 Source builds require Go 1.26+ and [Bun](https://bun.sh/).
 
 ```sh
-git clone https://github.com/kenn-io/middleman.git kenn-forge
+git clone https://github.com/kenn-io/forge.git kenn-forge
 cd kenn-forge
 make build
 ```

--- a/docs/screenshots/README.md
+++ b/docs/screenshots/README.md
@@ -25,10 +25,17 @@ must not embed PNG, JPEG, or other raster screenshot payloads:
 - `maintainer-overview-dark.svg`
 - `first-run-light.svg`
 - `first-run-dark.svg`
+- `code-reviewer-agent-launch-light.svg`
+- `code-reviewer-agent-launch-dark.svg`
+- `workspace-codex-session-light.svg`
+- `workspace-codex-session-dark.svg`
 
 Workflow captures use a configured seeded server. First-run captures use a
 second isolated server with its repositories removed and a synthetic tooling
 response. Neither path reads a developer config, database, or running daemon.
+The workspace cases configure a synthetic Codex target backed by an isolated
+long-running shell. They never start the installed Codex binary or read agent
+credentials.
 
 Dark captures must render as dark when opened as standalone SVG files. The
 capture task preserves the live root theme class and computed CSS custom

--- a/docs/screenshots/README.md
+++ b/docs/screenshots/README.md
@@ -7,7 +7,7 @@ used by the user workflow docs. They use the real seeded e2e backend from
 Run from the repository root:
 
 ```sh
-node node_modules/vite-plus/bin/vp run docs:build
+node scripts/build-docs.mjs
 ```
 
 The build stages the docs in a temporary directory, writes the generated SVGs
@@ -21,6 +21,14 @@ must not embed PNG, JPEG, or other raster screenshot payloads:
 - `issue-triager-dark.svg`
 - `code-reviewer-light.svg`
 - `code-reviewer-dark.svg`
+- `maintainer-overview-light.svg`
+- `maintainer-overview-dark.svg`
+- `first-run-light.svg`
+- `first-run-dark.svg`
+
+Workflow captures use a configured seeded server. First-run captures use a
+second isolated server with its repositories removed and a synthetic tooling
+response. Neither path reads a developer config, database, or running daemon.
 
 Dark captures must render as dark when opened as standalone SVG files. The
 capture task preserves the live root theme class and computed CSS custom

--- a/docs/screenshots/docs-screenshots.spec.ts
+++ b/docs/screenshots/docs-screenshots.spec.ts
@@ -179,6 +179,7 @@ const firstRunCases: CaptureCase[] = [
     readySelector: ".onboarding",
     readyText: "Connect a code forge",
     requiredSelector: ".provider-readiness",
+    requiredButtonName: "Continue with GitHub",
     description:
       "First-run code forge readiness with an authenticated synthetic GitHub account and other provider paths.",
   },
@@ -189,6 +190,7 @@ const firstRunCases: CaptureCase[] = [
     readySelector: ".onboarding",
     readyText: "Connect a code forge",
     requiredSelector: ".provider-readiness",
+    requiredButtonName: "Continue with GitHub",
     description:
       "First-run code forge readiness in dark mode with an authenticated synthetic GitHub account and other provider paths.",
   },

--- a/docs/screenshots/docs-screenshots.spec.ts
+++ b/docs/screenshots/docs-screenshots.spec.ts
@@ -12,7 +12,13 @@ const outputDir = process.env.KENN_FORGE_DOCS_SCREENSHOT_DIR;
 type ThemeName = "light" | "dark";
 
 type CaptureCase = {
-  name: "maintainer-overview" | "issue-triager" | "code-reviewer" | "first-run";
+  name:
+    | "maintainer-overview"
+    | "issue-triager"
+    | "code-reviewer"
+    | "code-reviewer-agent-launch"
+    | "workspace-codex-session"
+    | "first-run";
   theme: ThemeName;
   path: string;
   readySelector: string;
@@ -21,8 +27,30 @@ type CaptureCase = {
   requiredButtonName?: string;
   loadingText?: RegExp;
   waitForSync?: boolean;
+  prepare?: (page: Page, baseURL: string) => Promise<void>;
+  afterReady?: (page: Page) => Promise<void>;
   description: string;
 };
+
+async function openCodexLaunchMenu(page: Page): Promise<void> {
+  await page.getByRole("button", { name: "Create Workspace options" }).click();
+  await expect(page.getByRole("menuitem", { name: "Codex" })).toBeVisible();
+}
+
+async function showCodexWorkspace(page: Page): Promise<void> {
+  const row = page.locator(".workspace-list-sidebar .ws-row", { hasText: "Add widget caching layer" });
+  await row.click();
+  await expect(row).toHaveClass(/\bselected\b/);
+  await expect(page.getByRole("region", { name: "Workflow panes" }).getByRole("tab", { name: "Codex" })).toBeVisible();
+
+  const syntheticPath = "/worktrees/github/github.com/acme/widgets/pr-1";
+  await page.locator(".meta-chip.mono.path").evaluate((element, replacement) => {
+    const pathText = Array.from(element.childNodes).find((node) => node.nodeType === Node.TEXT_NODE);
+    if (!pathText) throw new Error("workspace path text node was not found");
+    pathText.textContent = replacement;
+    element.setAttribute("title", replacement);
+  }, syntheticPath);
+}
 
 const cases: CaptureCase[] = [
   {
@@ -93,6 +121,54 @@ const cases: CaptureCase[] = [
     description:
       "Code review view in dark mode with recent PR activity, review state, CI context, and workspace creation in one pane.",
   },
+  {
+    name: "code-reviewer-agent-launch",
+    theme: "light",
+    path: "/pulls/github/acme/widgets/1",
+    readySelector: ".pull-detail .detail-title",
+    readyText: "Add widget caching layer",
+    loadingText: /Loading discussion/i,
+    waitForSync: true,
+    prepare: configureSyntheticCodexAgent,
+    afterReady: openCodexLaunchMenu,
+    description: "Code review view with the Create Workspace menu open to launch a configured Codex agent.",
+  },
+  {
+    name: "code-reviewer-agent-launch",
+    theme: "dark",
+    path: "/pulls/github/acme/widgets/1",
+    readySelector: ".pull-detail .detail-title",
+    readyText: "Add widget caching layer",
+    loadingText: /Loading discussion/i,
+    waitForSync: true,
+    prepare: configureSyntheticCodexAgent,
+    afterReady: openCodexLaunchMenu,
+    description:
+      "Code review view in dark mode with the Create Workspace menu open to launch a configured Codex agent.",
+  },
+  {
+    name: "workspace-codex-session",
+    theme: "light",
+    path: "/workspaces",
+    readySelector: ".workspace-list-sidebar",
+    readyText: "Add widget caching layer",
+    waitForSync: true,
+    prepare: ensureSyntheticCodexWorkspace,
+    afterReady: showCodexWorkspace,
+    description: "Workspaces view with the pull request worktree selected and its Codex session available.",
+  },
+  {
+    name: "workspace-codex-session",
+    theme: "dark",
+    path: "/workspaces",
+    readySelector: ".workspace-list-sidebar",
+    readyText: "Add widget caching layer",
+    waitForSync: true,
+    prepare: ensureSyntheticCodexWorkspace,
+    afterReady: showCodexWorkspace,
+    description:
+      "Workspaces view in dark mode with the pull request worktree selected and its Codex session available.",
+  },
 ];
 
 const firstRunCases: CaptureCase[] = [
@@ -141,6 +217,140 @@ async function stabilizePage(page: Page): Promise<void> {
 async function waitForIdleSync(page: Page): Promise<void> {
   await expect(page.getByRole("button", { name: "Sync", exact: true })).toBeEnabled();
   await expect(page.getByText(/syncing/i)).toHaveCount(0);
+}
+
+async function configureSyntheticCodexAgent(page: Page, baseURL: string): Promise<void> {
+  const desiredAgent = {
+    key: "codex",
+    label: "Codex",
+    command: ["/bin/sh", "-lc", "while :; do sleep 3600; done"],
+    enabled: true,
+  };
+  const currentResponse = await page.request.get(`${baseURL}/api/v1/settings`);
+  if (currentResponse.status() !== 200) {
+    throw new Error(`GET settings returned ${currentResponse.status()}: ${await currentResponse.text()}`);
+  }
+  const currentSettings = (await currentResponse.json()) as {
+    agents: Array<typeof desiredAgent>;
+    launch_targets: Array<{ key: string; available: boolean }>;
+  };
+  const currentAgent = currentSettings.agents.find((agent) => agent.key === desiredAgent.key);
+  if (
+    currentAgent?.label === desiredAgent.label &&
+    currentAgent.enabled === desiredAgent.enabled &&
+    JSON.stringify(currentAgent.command) === JSON.stringify(desiredAgent.command)
+  ) {
+    expect(currentSettings.launch_targets).toEqual(
+      expect.arrayContaining([expect.objectContaining({ key: "codex", available: true })]),
+    );
+    return;
+  }
+
+  const response = await page.request.put(`${baseURL}/api/v1/settings`, {
+    data: { agents: [desiredAgent] },
+  });
+  if (response.status() !== 200) {
+    throw new Error(`PUT settings returned ${response.status()}: ${await response.text()}`);
+  }
+  const settings = (await response.json()) as {
+    launch_targets: Array<{ key: string; available: boolean }>;
+  };
+  expect(settings.launch_targets).toEqual(
+    expect.arrayContaining([expect.objectContaining({ key: "codex", available: true })]),
+  );
+}
+
+async function waitForBackendIdleSync(page: Page, baseURL: string): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        const response = await page.request.get(`${baseURL}/api/v1/sync/status`);
+        if (response.status() !== 200) {
+          throw new Error(`GET sync status returned ${response.status()}: ${await response.text()}`);
+        }
+        return ((await response.json()) as { running: boolean }).running;
+      },
+      { timeout: 60_000 },
+    )
+    .toBe(false);
+}
+
+type WorkspaceResponse = {
+  id: string;
+  status: string;
+  error_message?: string | null;
+  item_type?: string;
+  item_number?: number;
+  repo?: {
+    provider: string;
+    platform_host: string;
+    owner: string;
+    name: string;
+  };
+};
+
+async function ensureSyntheticCodexWorkspace(page: Page, baseURL: string): Promise<void> {
+  await configureSyntheticCodexAgent(page, baseURL);
+  const listResponse = await page.request.get(`${baseURL}/api/v1/workspaces`);
+  if (listResponse.status() !== 200) {
+    throw new Error(`GET workspaces returned ${listResponse.status()}: ${await listResponse.text()}`);
+  }
+  const listed = (await listResponse.json()) as { workspaces: WorkspaceResponse[] };
+  let workspace = listed.workspaces.find(
+    (candidate) =>
+      candidate.repo?.provider === "github" &&
+      candidate.repo.platform_host === "github.com" &&
+      candidate.repo.owner === "acme" &&
+      candidate.repo.name === "widgets" &&
+      candidate.item_type === "pull_request" &&
+      candidate.item_number === 1,
+  );
+
+  if (!workspace) {
+    const createResponse = await page.request.post(`${baseURL}/api/v1/workspaces`, {
+      data: {
+        provider: "github",
+        platform_host: "github.com",
+        owner: "acme",
+        name: "widgets",
+        mr_number: 1,
+      },
+    });
+    if (createResponse.status() !== 202) {
+      throw new Error(`POST workspace returned ${createResponse.status()}: ${await createResponse.text()}`);
+    }
+    workspace = (await createResponse.json()) as WorkspaceResponse;
+  }
+
+  for (let attempt = 0; attempt < 100 && workspace.status !== "ready"; attempt += 1) {
+    const statusResponse = await page.request.get(`${baseURL}/api/v1/workspaces/${workspace.id}`);
+    if (statusResponse.status() !== 200) {
+      throw new Error(`GET workspace returned ${statusResponse.status()}: ${await statusResponse.text()}`);
+    }
+    workspace = (await statusResponse.json()) as WorkspaceResponse;
+    if (workspace.status === "error") {
+      throw new Error(workspace.error_message ?? `workspace ${workspace.id} failed to become ready`);
+    }
+    if (workspace.status !== "ready") {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+  }
+  expect(workspace.status).toBe("ready");
+
+  const runtimeResponse = await page.request.get(`${baseURL}/api/v1/workspaces/${workspace.id}/runtime`);
+  if (runtimeResponse.status() !== 200) {
+    throw new Error(`GET workspace runtime returned ${runtimeResponse.status()}: ${await runtimeResponse.text()}`);
+  }
+  const runtime = (await runtimeResponse.json()) as { sessions?: Array<{ target_key: string }> };
+  if (!(runtime.sessions ?? []).some((session) => session.target_key === "codex")) {
+    const launchResponse = await page.request.post(
+      `${baseURL}/api/v1/workspaces/${workspace.id}/runtime/sessions`,
+      { data: { target_key: "codex" } },
+    );
+    if (launchResponse.status() !== 200) {
+      throw new Error(`POST runtime session returned ${launchResponse.status()}: ${await launchResponse.text()}`);
+    }
+  }
 }
 
 async function removeConfiguredRepositories(page: Page, baseURL: string): Promise<void> {
@@ -329,6 +539,10 @@ body {
 
 async function captureCase(page: Page, baseURL: string, capture: CaptureCase): Promise<void> {
   await preparePage(page, capture.theme);
+  await capture.prepare?.(page, baseURL);
+  if (capture.waitForSync) {
+    await waitForBackendIdleSync(page, baseURL);
+  }
   await page.goto(`${baseURL}${capture.path}`);
   await stabilizePage(page);
   await expect(page.locator(capture.readySelector)).toContainText(capture.readyText);
@@ -344,6 +558,7 @@ async function captureCase(page: Page, baseURL: string, capture: CaptureCase): P
   if (capture.waitForSync) {
     await waitForIdleSync(page);
   }
+  await capture.afterReady?.(page);
   await expect
     .poll(() => page.evaluate(() => document.documentElement.classList.contains("dark")))
     .toBe(capture.theme === "dark");
@@ -364,6 +579,7 @@ async function captureCase(page: Page, baseURL: string, capture: CaptureCase): P
   expect(svg).not.toMatch(/\b(?:aria-label|title)="Syncing"/);
   expect(svg).not.toMatch(/<img[^>]+src="(?:https?:|\/)/i);
   expect(svg).not.toMatch(/data:image\/(?:avif|gif|jpe?g|png|webp)/i);
+  expect(svg).not.toMatch(/\/var\/folders|kenn-forge-e2e-\d+/i);
   await writeFile(path.join(outputDir!, `${capture.name}-${capture.theme}.svg`), svg);
 }
 

--- a/docs/screenshots/docs-screenshots.spec.ts
+++ b/docs/screenshots/docs-screenshots.spec.ts
@@ -218,7 +218,7 @@ async function stabilizePage(page: Page): Promise<void> {
 
 async function waitForIdleSync(page: Page): Promise<void> {
   await expect(page.getByRole("button", { name: "Sync", exact: true })).toBeEnabled();
-  await expect(page.getByText(/syncing/i)).toHaveCount(0);
+  await expect(page.getByText(/syncing/i)).toHaveCount(0, { timeout: 15_000 });
 }
 
 async function configureSyntheticCodexAgent(page: Page, baseURL: string): Promise<void> {

--- a/docs/screenshots/docs-screenshots.spec.ts
+++ b/docs/screenshots/docs-screenshots.spec.ts
@@ -2,32 +2,59 @@ import { expect, test, type Page } from "@playwright/test";
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 
-import { startIsolatedWorkspaceE2EServer } from "../../frontend/tests/e2e-full/support/e2eServer";
+import {
+  startIsolatedE2EServerWithOptions,
+  startIsolatedWorkspaceE2EServer,
+} from "../../frontend/tests/e2e-full/support/e2eServer";
 
 const outputDir = process.env.KENN_FORGE_DOCS_SCREENSHOT_DIR;
 
 type ThemeName = "light" | "dark";
 
 type CaptureCase = {
-  name: "issue-triager" | "code-reviewer";
+  name: "maintainer-overview" | "issue-triager" | "code-reviewer" | "first-run";
   theme: ThemeName;
   path: string;
   readySelector: string;
   readyText: string;
-  workspaceSelector: string;
-  loadingText: RegExp;
+  requiredSelector?: string;
+  requiredButtonName?: string;
+  loadingText?: RegExp;
+  waitForSync?: boolean;
   description: string;
 };
 
 const cases: CaptureCase[] = [
+  {
+    name: "maintainer-overview",
+    theme: "light",
+    path: "/",
+    readySelector: ".activity-feed",
+    readyText: "Add widget caching layer",
+    loadingText: /Loading activity/i,
+    waitForSync: true,
+    description: "Activity overview with recent pull request and issue context across seeded repositories.",
+  },
+  {
+    name: "maintainer-overview",
+    theme: "dark",
+    path: "/",
+    readySelector: ".activity-feed",
+    readyText: "Add widget caching layer",
+    loadingText: /Loading activity/i,
+    waitForSync: true,
+    description:
+      "Activity overview in dark mode with recent pull request and issue context across seeded repositories.",
+  },
   {
     name: "issue-triager",
     theme: "light",
     path: "/issues/github/acme/widgets/10",
     readySelector: ".issue-detail .detail-title",
     readyText: "Widget rendering broken on Safari",
-    workspaceSelector: ".issue-detail .btn--workspace",
+    requiredButtonName: "Create Workspace",
     loadingText: /Loading comments/i,
+    waitForSync: true,
     description: "Issue triage view with the newest issue context first and a workspace action in the detail pane.",
   },
   {
@@ -36,8 +63,9 @@ const cases: CaptureCase[] = [
     path: "/issues/github/acme/widgets/10",
     readySelector: ".issue-detail .detail-title",
     readyText: "Widget rendering broken on Safari",
-    workspaceSelector: ".issue-detail .btn--workspace",
+    requiredButtonName: "Create Workspace",
     loadingText: /Loading comments/i,
+    waitForSync: true,
     description:
       "Issue triage view in dark mode with the newest issue context first and a workspace action in the detail pane.",
   },
@@ -47,8 +75,9 @@ const cases: CaptureCase[] = [
     path: "/pulls/github/acme/widgets/1",
     readySelector: ".pull-detail .detail-title",
     readyText: "Add widget caching layer",
-    workspaceSelector: ".pull-detail .btn--workspace",
+    requiredButtonName: "Create Workspace",
     loadingText: /Loading discussion/i,
+    waitForSync: true,
     description:
       "Code review view with recent PR activity, review state, CI context, and workspace creation in one pane.",
   },
@@ -58,10 +87,34 @@ const cases: CaptureCase[] = [
     path: "/pulls/github/acme/widgets/1",
     readySelector: ".pull-detail .detail-title",
     readyText: "Add widget caching layer",
-    workspaceSelector: ".pull-detail .btn--workspace",
+    requiredButtonName: "Create Workspace",
     loadingText: /Loading discussion/i,
+    waitForSync: true,
     description:
       "Code review view in dark mode with recent PR activity, review state, CI context, and workspace creation in one pane.",
+  },
+];
+
+const firstRunCases: CaptureCase[] = [
+  {
+    name: "first-run",
+    theme: "light",
+    path: "/",
+    readySelector: ".onboarding",
+    readyText: "Connect a code forge",
+    requiredSelector: ".provider-readiness",
+    description:
+      "First-run code forge readiness with an authenticated synthetic GitHub account and other provider paths.",
+  },
+  {
+    name: "first-run",
+    theme: "dark",
+    path: "/",
+    readySelector: ".onboarding",
+    readyText: "Connect a code forge",
+    requiredSelector: ".provider-readiness",
+    description:
+      "First-run code forge readiness in dark mode with an authenticated synthetic GitHub account and other provider paths.",
   },
 ];
 
@@ -90,6 +143,45 @@ async function waitForIdleSync(page: Page): Promise<void> {
   await expect(page.getByText(/syncing/i)).toHaveCount(0);
 }
 
+async function removeConfiguredRepositories(page: Page, baseURL: string): Promise<void> {
+  const response = await page.request.get(`${baseURL}/api/v1/settings`);
+  expect(response.ok()).toBe(true);
+  const settings = (await response.json()) as {
+    repos: Array<{
+      provider: string;
+      platform_host: string;
+      owner: string;
+      name: string;
+    }>;
+  };
+  for (const repo of settings.repos) {
+    const removed = await page.request.delete(
+      `${baseURL}/api/v1/host/${encodeURIComponent(repo.platform_host)}` +
+        `/repo/${encodeURIComponent(repo.provider)}/${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.name)}`,
+      { headers: { "content-type": "application/json" } },
+    );
+    expect(removed.ok()).toBe(true);
+  }
+}
+
+async function prepareFirstRunPage(page: Page, baseURL: string): Promise<void> {
+  await removeConfiguredRepositories(page, baseURL);
+  await page.addInitScript(() => {
+    localStorage.removeItem("kenn-forge:first-run-onboarding");
+    sessionStorage.removeItem("kenn-forge:first-run-onboarding");
+  });
+  await page.route("**/api/v1/tooling-status", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        git: { available: true, version: "2.50" },
+        gh: { available: true, authenticated: true, host: "github.com", user: "maintainer" },
+        glab: { available: false, authenticated: false, host: "gitlab.com" },
+      }),
+    });
+  });
+}
+
 async function svgDOMSnapshot(
   page: Page,
   input: {
@@ -99,7 +191,7 @@ async function svgDOMSnapshot(
     height: number;
   },
 ): Promise<string> {
-  return page.evaluate(({ title, description, width, height }) => {
+  return page.evaluate(async ({ title, description, width, height }) => {
     const svgNS = "http://www.w3.org/2000/svg";
     const xhtmlNS = "http://www.w3.org/1999/xhtml";
 
@@ -208,6 +300,24 @@ body {
     for (const script of Array.from(body.querySelectorAll("script"))) {
       script.remove();
     }
+
+    const liveImages = Array.from(document.body.querySelectorAll("img"));
+    const clonedImages = Array.from(body.querySelectorAll("img"));
+    await Promise.all(
+      liveImages.map(async (liveImage, index) => {
+        const clonedImage = clonedImages[index];
+        const source = liveImage.currentSrc || liveImage.src;
+        if (!clonedImage || !source || source.startsWith("data:")) return;
+
+        const sourceURL = new URL(source, document.baseURI);
+        if (!sourceURL.pathname.toLowerCase().endsWith(".svg")) return;
+
+        const response = await fetch(sourceURL);
+        const svgImage = await response.text();
+        clonedImage.setAttribute("src", `data:image/svg+xml,${encodeURIComponent(svgImage)}`);
+        clonedImage.removeAttribute("srcset");
+      }),
+    );
     html.appendChild(body);
 
     foreignObject.appendChild(svgDoc.importNode(html, true));
@@ -215,6 +325,46 @@ body {
 
     return `${new XMLSerializer().serializeToString(svg).replace(/[ \t]+$/gm, "")}\n`;
   }, input);
+}
+
+async function captureCase(page: Page, baseURL: string, capture: CaptureCase): Promise<void> {
+  await preparePage(page, capture.theme);
+  await page.goto(`${baseURL}${capture.path}`);
+  await stabilizePage(page);
+  await expect(page.locator(capture.readySelector)).toContainText(capture.readyText);
+  if (capture.requiredSelector) {
+    await expect(page.locator(`${capture.requiredSelector}:visible`).first()).toBeVisible();
+  }
+  if (capture.requiredButtonName) {
+    await expect(page.getByRole("button", { name: capture.requiredButtonName, exact: true }).first()).toBeVisible();
+  }
+  if (capture.loadingText) {
+    await expect(page.getByText(capture.loadingText)).toHaveCount(0);
+  }
+  if (capture.waitForSync) {
+    await waitForIdleSync(page);
+  }
+  await expect
+    .poll(() => page.evaluate(() => document.documentElement.classList.contains("dark")))
+    .toBe(capture.theme === "dark");
+
+  const svg = await svgDOMSnapshot(page, {
+    title: `${capture.name} ${capture.theme}`,
+    description: capture.description,
+    width: page.viewportSize()?.width ?? 1280,
+    height: page.viewportSize()?.height ?? 820,
+  });
+  if (capture.theme === "dark") {
+    expect(svg).toMatch(/<html[^>]*class="[^"]*\bdark\b[^"]*"/);
+  } else {
+    expect(svg).not.toMatch(/<html[^>]*class="[^"]*\bdark\b[^"]*"/);
+  }
+  expect(svg).not.toMatch(/>\s*Syncing(?:\.\.\.)?\s*</i);
+  expect(svg).not.toMatch(/>\s*syncing(?:\u2026|\s*\([^<]*\))?\s*</i);
+  expect(svg).not.toMatch(/\b(?:aria-label|title)="Syncing"/);
+  expect(svg).not.toMatch(/<img[^>]+src="(?:https?:|\/)/i);
+  expect(svg).not.toMatch(/data:image\/(?:avif|gif|jpe?g|png|webp)/i);
+  await writeFile(path.join(outputDir!, `${capture.name}-${capture.theme}.svg`), svg);
 }
 
 test.describe("docs workflow screenshots", () => {
@@ -235,33 +385,31 @@ test.describe("docs workflow screenshots", () => {
   for (const capture of cases) {
     test(`${capture.name} ${capture.theme}`, async ({ page }) => {
       if (!server) throw new Error("e2e server was not started");
+      await captureCase(page, server.info.base_url, capture);
+    });
+  }
+});
 
-      await preparePage(page, capture.theme);
-      await page.goto(`${server.info.base_url}${capture.path}`);
-      await stabilizePage(page);
-      await expect(page.locator(capture.readySelector)).toContainText(capture.readyText);
-      await expect(page.locator(`${capture.workspaceSelector}:visible`).first()).toBeVisible();
-      await expect(page.getByText(capture.loadingText)).toHaveCount(0);
-      await waitForIdleSync(page);
-      await expect
-        .poll(() => page.evaluate(() => document.documentElement.classList.contains("dark")))
-        .toBe(capture.theme === "dark");
+test.describe("docs first-run screenshots", () => {
+  let server: Awaited<ReturnType<typeof startIsolatedE2EServerWithOptions>> | null = null;
 
-      const svg = await svgDOMSnapshot(page, {
-        title: `${capture.name} ${capture.theme}`,
-        description: capture.description,
-        width: page.viewportSize()?.width ?? 1280,
-        height: page.viewportSize()?.height ?? 820,
-      });
-      if (capture.theme === "dark") {
-        expect(svg).toMatch(/<html[^>]*class="[^"]*\bdark\b[^"]*"/);
-      } else {
-        expect(svg).not.toMatch(/<html[^>]*class="[^"]*\bdark\b[^"]*"/);
-      }
-      expect(svg).not.toMatch(/>\s*Syncing(?:\.\.\.)?\s*</i);
-      expect(svg).not.toMatch(/>\s*syncing(?:\u2026|\s*\([^<]*\))?\s*</i);
-      expect(svg).not.toMatch(/\b(?:aria-label|title)="Syncing"/);
-      await writeFile(path.join(outputDir!, `${capture.name}-${capture.theme}.svg`), svg);
+  test.beforeAll(async () => {
+    if (!outputDir) {
+      throw new Error("KENN_FORGE_DOCS_SCREENSHOT_DIR must point to the staged docs asset directory");
+    }
+    server = await startIsolatedE2EServerWithOptions();
+    await mkdir(outputDir, { recursive: true });
+  });
+
+  test.afterAll(async () => {
+    await server?.stop();
+  });
+
+  for (const capture of firstRunCases) {
+    test(`${capture.name} ${capture.theme}`, async ({ page }) => {
+      if (!server) throw new Error("e2e server was not started");
+      await prepareFirstRunPage(page, server.info.base_url);
+      await captureCase(page, server.info.base_url, capture);
     });
   }
 });

--- a/docs/site/docs-site.spec.ts
+++ b/docs/site/docs-site.spec.ts
@@ -57,3 +57,22 @@ test("links to the canonical Forge repository and releases", async ({ page }) =>
     "https://github.com/kenn-io/forge/releases",
   );
 });
+
+test("places Fleet under advanced and experimental navigation", async ({ page }) => {
+  await page.goto("/");
+
+  const primaryNav = page.locator(".md-sidebar--primary nav[data-md-level='0']");
+  const advancedLabel = primaryNav.locator("label.md-nav__link", {
+    hasText: "Advanced / experimental",
+  });
+  await expect(advancedLabel).toBeVisible();
+
+  const advancedItem = advancedLabel.locator("xpath=ancestor::li[1]");
+  await expect(advancedItem.getByRole("link", { name: "Fleet" })).toHaveAttribute(
+    "href",
+    /federated-fleet\/$/,
+  );
+  await expect(
+    primaryNav.locator(":scope > ul > li > a.md-nav__link", { hasText: "Fleet" }),
+  ).toHaveCount(0);
+});

--- a/docs/site/docs-site.spec.ts
+++ b/docs/site/docs-site.spec.ts
@@ -6,6 +6,10 @@ type HeaderStyle = {
   transform: string;
 };
 
+type FirstFrameWindow = Window & {
+  __firstFrameScheme?: Promise<string | null>;
+};
+
 test("keeps the site brand stable while scrolling", async ({ page }) => {
   for (const viewport of [
     { width: 1280, height: 800 },
@@ -75,4 +79,58 @@ test("places Fleet under advanced and experimental navigation", async ({ page })
   await expect(
     primaryNav.locator(":scope > ul > li > a.md-nav__link", { hasText: "Fleet" }),
   ).toHaveCount(0);
+});
+
+test("applies the browser theme before the runtime bundle", async ({ browser }) => {
+  for (const preference of [
+    { colorScheme: "light" as const, expected: "default" },
+    { colorScheme: "dark" as const, expected: "slate" },
+  ]) {
+    const context = await browser.newContext({ colorScheme: preference.colorScheme });
+    await context.addInitScript(() => {
+      const target = window as FirstFrameWindow;
+      target.__firstFrameScheme = new Promise((resolve) => {
+        requestAnimationFrame(() => {
+          resolve(document.body?.getAttribute("data-md-color-scheme") ?? null);
+        });
+      });
+    });
+    const page = await context.newPage();
+    await page.route("**/assets/javascripts/bundle.*.min.js", (route) => route.abort());
+
+    await page.goto("/");
+    const firstFrameScheme = await page.evaluate(() =>
+      (window as FirstFrameWindow).__firstFrameScheme,
+    );
+    expect(firstFrameScheme).toBe(preference.expected);
+    await context.close();
+  }
+});
+
+test("keeps following system theme changes until the reader chooses", async ({ browser }) => {
+  const context = await browser.newContext({ colorScheme: "dark" });
+  const page = await context.newPage();
+  await page.goto("/");
+  await expect(page.locator("body")).toHaveAttribute("data-md-color-scheme", "slate");
+
+  await page.emulateMedia({ colorScheme: "light" });
+  await expect(page.locator("body")).toHaveAttribute("data-md-color-scheme", "default");
+
+  await page.reload();
+  await expect(page.locator("body")).toHaveAttribute("data-md-color-scheme", "default");
+  await context.close();
+});
+
+test("persists an explicit light override on a dark system", async ({ browser }) => {
+  const context = await browser.newContext({ colorScheme: "dark" });
+  const page = await context.newPage();
+  await page.goto("/");
+  await expect(page.locator("body")).toHaveAttribute("data-md-color-scheme", "slate");
+
+  await page.locator('label[title="Switch to light mode"]').click();
+  await expect(page.locator("body")).toHaveAttribute("data-md-color-scheme", "default");
+
+  await page.reload();
+  await expect(page.locator("body")).toHaveAttribute("data-md-color-scheme", "default");
+  await context.close();
 });

--- a/docs/site/docs-site.spec.ts
+++ b/docs/site/docs-site.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "@playwright/test";
+
+type HeaderStyle = {
+  fontFamily: string;
+  fontWeight: string;
+  transform: string;
+};
+
+test("keeps the site brand stable while scrolling", async ({ page }) => {
+  for (const viewport of [
+    { width: 1280, height: 800 },
+    { width: 390, height: 844 },
+  ]) {
+    await page.setViewportSize(viewport);
+    await page.goto("/");
+
+    const topics = page.locator(".md-header__topic");
+    const brand = topics.first();
+    const pageTitle = topics.nth(1);
+    const before = await brand.evaluate<HeaderStyle>((element) => {
+      const style = getComputedStyle(element);
+      return {
+        fontFamily: style.fontFamily,
+        fontWeight: style.fontWeight,
+        transform: style.transform,
+      };
+    });
+
+    await page.evaluate(() => scrollTo(0, 500));
+    await page.waitForTimeout(450);
+
+    const after = await brand.evaluate<HeaderStyle>((element) => {
+      const style = getComputedStyle(element);
+      return {
+        fontFamily: style.fontFamily,
+        fontWeight: style.fontWeight,
+        transform: style.transform,
+      };
+    });
+    await expect(brand).toHaveText("kenn-forge");
+    await expect(brand).toBeVisible();
+    await expect(pageTitle).toBeHidden();
+    expect(after.fontFamily).toBe(before.fontFamily);
+    expect(after.fontWeight).toBe(before.fontWeight);
+    expect(after.transform).toBe("none");
+    await expect(brand).toBeInViewport();
+  }
+});
+
+test("links to the canonical Forge repository and releases", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.locator('a[href="https://github.com/kenn-io/forge"]').first()).toBeVisible();
+
+  await page.goto("/quickstart/");
+  await expect(page.getByRole("link", { name: "GitHub Releases" })).toHaveAttribute(
+    "href",
+    "https://github.com/kenn-io/forge/releases",
+  );
+});

--- a/docs/site/playwright.config.ts
+++ b/docs/site/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from "@playwright/test";
+import path from "node:path";
+
+const siteDirInput = process.env.KENN_FORGE_DOCS_SITE_DIR;
+
+if (!siteDirInput) {
+  throw new Error("KENN_FORGE_DOCS_SITE_DIR must point to rendered site output");
+}
+const siteDir = path.resolve(siteDirInput);
+
+export default defineConfig({
+  testDir: ".",
+  testMatch: "docs-site.spec.ts",
+  workers: 1,
+  use: {
+    baseURL: "http://127.0.0.1:4178",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 1280, height: 800 },
+      },
+    },
+  ],
+  webServer: {
+    command: "python3 -m http.server 4178 --bind 127.0.0.1",
+    cwd: siteDir,
+    url: "http://127.0.0.1:4178",
+    reuseExistingServer: false,
+  },
+});

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -38,3 +38,14 @@
 [data-md-color-scheme="slate"] .workflow-shot__image--dark {
   display: block !important;
 }
+
+.md-header__topic:first-child {
+  opacity: 1;
+  pointer-events: auto;
+  transform: none;
+  z-index: 0;
+}
+
+.md-header__topic + .md-header__topic {
+  display: none;
+}

--- a/docs/superpowers/plans/2026-08-02-public-documentation-readiness.md
+++ b/docs/superpowers/plans/2026-08-02-public-documentation-readiness.md
@@ -512,9 +512,10 @@ Expected before the URL edit: FAIL because both links still target
 Record the original constraints and banned-pattern result before editing:
 
 ```bash
+: "${UNSLOP_SKILL_DIR:?set UNSLOP_SKILL_DIR to the installed unslop skill directory}"
 for docs_file in README.md docs/quickstart.md; do
-  python3 /Users/mariusvniekerk/.agents/skills/unslop/scripts/extract_constraints.py "$docs_file"
-  python3 /Users/mariusvniekerk/.agents/skills/unslop/scripts/banned_phrase_scan.py "$docs_file"
+  python3 "$UNSLOP_SKILL_DIR/scripts/extract_constraints.py" "$docs_file"
+  python3 "$UNSLOP_SKILL_DIR/scripts/banned_phrase_scan.py" "$docs_file"
 done
 ```
 
@@ -663,10 +664,11 @@ Markdown pages. For `README.md`, `docs/quickstart.md`, and
 baseline:
 
 ```bash
+: "${UNSLOP_SKILL_DIR:?set UNSLOP_SKILL_DIR to the installed unslop skill directory}"
 for docs_file in README.md docs/quickstart.md docs/workflows/code-reviewer.md; do
-  python3 /Users/mariusvniekerk/.agents/skills/unslop/scripts/diff_check.py \
+  python3 "$UNSLOP_SKILL_DIR/scripts/diff_check.py" \
     <(git show HEAD:"$docs_file") "$docs_file"
-  python3 /Users/mariusvniekerk/.agents/skills/unslop/scripts/validate_preservation.py \
+  python3 "$UNSLOP_SKILL_DIR/scripts/validate_preservation.py" \
     <(git show HEAD:"$docs_file") "$docs_file"
 done
 ```

--- a/docs/superpowers/plans/2026-08-02-public-documentation-readiness.md
+++ b/docs/superpowers/plans/2026-08-02-public-documentation-readiness.md
@@ -98,7 +98,10 @@ git diff --check
 node node_modules/vite-plus/bin/vp exec -- node --test scripts/build-docs.test.mjs scripts/docs-screenshots-command.test.mjs
 \`\`\`
 
-Run \`scripts/context-sync --check\`, inspect the intended diff, then commit only the four Task 1 files with a conventional \`docs:\` subject and a rationale-focused body.
+Invoke the repository-local `context-sync` skill with `--commit`. Run the
+structural `scripts/context-sync --check` first, then perform the semantic
+commit review. Include any required context updates and commit the Task 1
+files with a conventional `docs:` subject and a rationale-focused body.
 
 ---
 
@@ -209,7 +212,9 @@ git diff --check
 node node_modules/vite-plus/bin/vp exec -- node --test scripts/build-docs.test.mjs scripts/docs-screenshots-command.test.mjs
 \`\`\`
 
-Run \`scripts/context-sync --check\`, inspect the intended diff, then commit only the eight Task 2 files with a conventional \`docs:\` subject and a rationale-focused body.
+Invoke the repository-local `context-sync` skill with `--commit`. Include any
+required context updates, then commit the Task 2 files with a conventional
+`docs:` subject and a rationale-focused body.
 
 ---
 
@@ -268,7 +273,8 @@ Run:
 
 \`\`\`bash
 node node_modules/vite-plus/bin/vp exec -- node --test scripts/build-docs.test.mjs scripts/docs-screenshots-command.test.mjs
-node node_modules/vite-plus/bin/vp exec -- playwright test --config docs/screenshots/playwright.config.ts --project=chromium
+mkdir -p tmp/docs-screenshots
+env KENN_FORGE_DOCS_SCREENSHOT_DIR=tmp/docs-screenshots node node_modules/vite-plus/bin/vp exec -- playwright test --config docs/screenshots/playwright.config.ts --project=chromium
 node scripts/build-docs.mjs
 \`\`\`
 
@@ -294,7 +300,10 @@ Use \`superpowers:verification-before-completion\` before reporting success.
 
 - [ ] **Step 8: Commit the visuals and final corrections**
 
-Run \`scripts/context-sync --check\`, inspect the intended diff, and commit the screenshot generator, screenshot guidance, styles, and final page corrections with a conventional \`docs:\` subject and a rationale-focused body.
+Invoke the repository-local `context-sync` skill with `--commit`. Include any
+required context updates, then commit the screenshot generator, screenshot
+guidance, styles, and final page corrections with a conventional `docs:`
+subject and a rationale-focused body.
 
 ---
 

--- a/docs/superpowers/plans/2026-08-02-public-documentation-readiness.md
+++ b/docs/superpowers/plans/2026-08-02-public-documentation-readiness.md
@@ -568,9 +568,11 @@ an available target with `key: "codex"` before continuing.
 Add `ensureSyntheticCodexWorkspace(page, baseURL)` that:
 
 1. Configures the synthetic agent.
-2. Reuses the `acme/widgets#1` workspace when present, or posts
-   `{ provider: "github", platform_host: "github.com", owner: "acme",
-   name: "widgets", mr_number: 1 }` to `POST /api/v1/workspaces`.
+2. Reuses a workspace only when `(provider, platform_host, owner, name,
+   item_type, item_number)` matches `(github, github.com, acme, widgets,
+   pull_request, 1)`. Otherwise, it posts `{ provider: "github",
+   platform_host: "github.com", owner: "acme", name: "widgets",
+   mr_number: 1 }` to `POST /api/v1/workspaces`.
 3. Polls `GET /api/v1/workspaces/{id}` until status is `ready`, failing on
    `error`.
 4. Reads `GET /api/v1/workspaces/{id}/runtime` and posts

--- a/docs/superpowers/plans/2026-08-02-public-documentation-readiness.md
+++ b/docs/superpowers/plans/2026-08-02-public-documentation-readiness.md
@@ -10,12 +10,17 @@
 
 **Tech Stack:** Markdown, Zensical, TypeScript, Playwright, Node.js, Vite+, Python-based \`unslop\` validation
 
+**Execution status:** Tasks 1 through 3 are complete in commits through
+`7d0a3cd87`. Resume at Task 4; do not repeat the earlier rewrites or eight
+existing captures.
+
 ## Global Constraints
 
 - Apply the \`unslop\` crisp preset to every public Markdown page.
 - Preserve commands, paths, provider names, defaults, limits, URLs, and security boundaries exactly unless repository evidence proves they are stale.
 - Keep paragraphs short, lead with actions or facts, and describe user outcomes instead of implementation details.
-- Keep ADRs, plans, specs, reports, and \`context/\` documents out of the public navigation.
+- Keep ADRs, plans, specs, reports, \`context/\`, and build tooling out of
+  both the staged Zensical input and rendered public site.
 - Generate screenshots only from isolated seeded servers. Never use a live developer app or private data.
 - Keep generated SVG files untracked. Commit only their Playwright cases, page references, styles, and build guidance.
 - Do not change production onboarding behavior or add product features.
@@ -307,30 +312,422 @@ subject and a rationale-focused body.
 
 ---
 
-### Task 4: Publish the stacked pull request
+### Task 4: Close public-site and reviewer-workspace gaps
+
+**Files:**
+- Modify: `scripts/build-docs.mjs`
+- Modify: `scripts/build-docs.test.mjs`
+- Modify: `docs/zensical.toml`
+- Modify: `docs/stylesheets/extra.css`
+- Modify: `README.md`
+- Modify: `docs/quickstart.md`
+- Modify: `docs/workflows/code-reviewer.md`
+- Modify: `docs/screenshots/docs-screenshots.spec.ts`
+- Modify: `docs/screenshots/README.md`
+- Create: `docs/site/docs-site.spec.ts`
+- Create: `docs/site/playwright.config.ts`
+
+**Interfaces:**
+- Consumes: `stageDocsSource(sourceDir, destinationDir)`,
+  `startIsolatedWorkspaceE2EServer()`, the seeded `acme/widgets#1` pull
+  request, and the existing `captureCase()` SVG serializer
+- Produces: a public-only staged docs tree and four additional generated SVGs:
+  `code-reviewer-agent-launch-{light,dark}.svg` and
+  `workspace-codex-session-{light,dark}.svg`
+
+- [ ] **Step 1: Prove internal docs leak through staging**
+
+Extend `scripts/build-docs.test.mjs` so its fixture contains public inputs and
+internal inputs:
+
+```js
+await mkdir(path.join(source, "stylesheets"), { recursive: true });
+await mkdir(path.join(source, "workflows"), { recursive: true });
+await mkdir(path.join(source, "superpowers", "plans"), { recursive: true });
+await mkdir(path.join(source, "adr"), { recursive: true });
+await mkdir(path.join(source, "reports"), { recursive: true });
+await mkdir(path.join(source, "screenshots"), { recursive: true });
+await writeFile(path.join(source, "index.md"), "# Docs\n");
+await writeFile(path.join(source, "workflows", "code-reviewer.md"), "# Reviewer\n");
+await writeFile(path.join(source, "stylesheets", "extra.css"), ":root {}\n");
+await writeFile(path.join(source, "superpowers", "plans", "private.md"), "# Private\n");
+await writeFile(path.join(source, "adr", "0001-private.md"), "# Private\n");
+await writeFile(path.join(source, "reports", "private.md"), "# Private\n");
+await writeFile(path.join(source, "screenshots", "README.md"), "# Build only\n");
+await writeFile(path.join(source, "workflows", "internal.md"), "# Private\n");
+await writeFile(path.join(source, "stylesheets", "internal.css"), ":root {}\n");
+```
+
+After `stageDocsSource()`, assert that `index.md`, the workflow page, and the
+stylesheet exist. Assert `ENOENT` for every internal fixture path and for a
+stale `assets/generated/stale.svg`. The rejected fixtures must include
+`workflows/internal.md` and `stylesheets/internal.css`, proving that allowed
+directories are traversal paths rather than recursive publication roots.
+
+- [ ] **Step 2: Run the staging test and verify the leak is detected**
+
+Run:
+
+```bash
+node node_modules/vite-plus/bin/vp exec -- node --test scripts/build-docs.test.mjs
+```
+
+Expected: FAIL because the current recursive copy stages
+`superpowers/plans/private.md`.
+
+- [ ] **Step 3: Stage only explicit public inputs**
+
+In `scripts/build-docs.mjs`, replace the generated-asset-only filter with:
+
+```js
+const publishedFiles = new Set([
+  "archive.md",
+  "commands.md",
+  "configuration.md",
+  "federated-fleet.md",
+  "index.md",
+  "quickstart.md",
+  "stylesheets/extra.css",
+  "troubleshooting.md",
+  "workflows/code-reviewer.md",
+  "workflows/issue-triager.md",
+  "workflows.md",
+]);
+const publishedDirectoryEntries = new Set(["stylesheets", "workflows"]);
+
+function isPublishedDocsInput(sourceDir, candidate) {
+  const relative = path.relative(sourceDir, candidate);
+  if (relative === "") return true;
+  return publishedFiles.has(relative) || publishedDirectoryEntries.has(relative);
+}
+```
+
+Use `isPublishedDocsInput` as the `cp` filter. Continue copying
+`zensical.toml` separately and generating `assets/generated/` only in the
+staged tree. The two directory entries allow `cp` to traverse to explicitly
+listed files; they do not publish unlisted descendants.
+
+- [ ] **Step 4: Verify the public staging boundary**
+
+Run the test from Step 2 again.
+
+Expected: PASS with public pages and styles preserved and every internal input
+absent.
+
+- [ ] **Step 5: Add a rendered-site header regression test**
+
+Create `docs/site/playwright.config.ts` with one Chromium project and a local
+static server:
+
+```ts
+import { defineConfig, devices } from "@playwright/test";
+
+const siteDir = process.env.KENN_FORGE_DOCS_SITE_DIR;
+if (!siteDir) throw new Error("KENN_FORGE_DOCS_SITE_DIR must point to rendered site output");
+
+export default defineConfig({
+  testDir: ".",
+  testMatch: "docs-site.spec.ts",
+  workers: 1,
+  use: {
+    baseURL: "http://127.0.0.1:4178",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"], viewport: { width: 1280, height: 800 } },
+    },
+  ],
+  webServer: {
+    command: "python3 -m http.server 4178 --bind 127.0.0.1",
+    cwd: siteDir,
+    url: "http://127.0.0.1:4178",
+    reuseExistingServer: false,
+  },
+});
+```
+
+Create `docs/site/docs-site.spec.ts` with a test that opens `/`, records the
+visible first `.md-header__topic` text, `fontFamily`, `fontWeight`, and
+`transform`, scrolls to 500px, waits for the 400ms Zensical transition, and
+asserts the following at both `{ width: 1280, height: 800 }` and
+`{ width: 390, height: 844 }`:
+
+```ts
+await expect(brand).toHaveText("kenn-forge");
+await expect(brand).toBeVisible();
+await expect(pageTitle).toBeHidden();
+expect(after.fontFamily).toBe(before.fontFamily);
+expect(after.fontWeight).toBe(before.fontWeight);
+expect(after.transform).toBe("none");
+```
+
+Run against the current rendered `site/`:
+
+```bash
+env KENN_FORGE_DOCS_SITE_DIR=site \
+  node node_modules/vite-plus/bin/vp exec -- playwright test \
+  --config docs/site/playwright.config.ts --project=chromium
+```
+
+Expected: FAIL because Zensical hides `kenn-forge` and shows the regular-weight
+`Kenn Forge` page topic after scrolling.
+
+- [ ] **Step 6: Keep header branding stable**
+
+Append this minimal override to `docs/stylesheets/extra.css`:
+
+```css
+.md-header__topic:first-child {
+  opacity: 1;
+  pointer-events: auto;
+  transform: none;
+  z-index: 0;
+}
+
+.md-header__topic + .md-header__topic {
+  display: none;
+}
+```
+
+Rebuild with `node scripts/build-docs.mjs`, then rerun the rendered-site test
+from Step 5 at 1280px and at 390px. Both viewports must keep the same visible,
+unclipped `kenn-forge` brand.
+
+After `uvx zensical build` in `scripts/build-docs.mjs`, invoke this
+rendered-site Playwright project with
+`KENN_FORGE_DOCS_SITE_DIR=path.join(stagingRoot, "site")`. The docs build must
+fail if the rendered-site test fails.
+
+- [ ] **Step 7: Correct public repository and release links**
+
+Add a second test to `docs/site/docs-site.spec.ts` that requires the rendered
+home repository link to target `https://github.com/kenn-io/forge` and the
+Quick Start `GitHub Releases` link to target
+`https://github.com/kenn-io/forge/releases`. Run the rendered-site project.
+
+Expected before the URL edit: FAIL because both links still target
+`kenn-io/middleman`.
+
+Record the original constraints and banned-pattern result before editing:
+
+```bash
+for docs_file in README.md docs/quickstart.md; do
+  python3 /Users/mariusvniekerk/.agents/skills/unslop/scripts/extract_constraints.py "$docs_file"
+  python3 /Users/mariusvniekerk/.agents/skills/unslop/scripts/banned_phrase_scan.py "$docs_file"
+done
+```
+
+Replace public `kenn-io/middleman` URLs with `kenn-io/forge` in
+`README.md`, `docs/quickstart.md`, and `docs/zensical.toml`. This includes
+release URLs, source clone commands, `repo_url`, and `repo_name`. Do not
+rewrite historical internal plans or specs.
+
+Run:
+
+```bash
+if rg -n 'github\.com/kenn-io/middleman|repo_name = "kenn-io/middleman"' \
+  README.md docs/index.md docs/quickstart.md docs/configuration.md \
+  docs/commands.md docs/workflows.md docs/workflows docs/archive.md \
+  docs/federated-fleet.md docs/troubleshooting.md docs/zensical.toml; then
+  exit 1
+fi
+```
+
+Expected: no matches and exit 0. Rebuild the site and rerun the rendered-site
+project. Both canonical-link assertions must pass.
+
+- [ ] **Step 8: Add synthetic Codex workspace preparation**
+
+In `docs/screenshots/docs-screenshots.spec.ts`, extend `CaptureCase.name`
+with `code-reviewer-agent-launch` and `workspace-codex-session`. Add optional
+`prepare(page, baseURL)` and `afterReady(page)` callbacks. Call `prepare`
+before navigation and `afterReady` after stable selectors and loading checks,
+but before SVG serialization.
+
+Add `configureSyntheticCodexAgent(page, baseURL)` that writes this agent
+through `PUT /api/v1/settings`:
+
+```ts
+{
+  agents: [
+    {
+      key: "codex",
+      label: "Codex",
+      command: ["/bin/sh", "-lc", "while :; do sleep 3600; done"],
+      enabled: true,
+    },
+  ],
+}
+```
+
+Assert the update returns status 200 and its `launch_targets` array contains
+an available target with `key: "codex"` before continuing.
+
+Add `ensureSyntheticCodexWorkspace(page, baseURL)` that:
+
+1. Configures the synthetic agent.
+2. Reuses the `acme/widgets#1` workspace when present, or posts
+   `{ provider: "github", platform_host: "github.com", owner: "acme",
+   name: "widgets", mr_number: 1 }` to `POST /api/v1/workspaces`.
+3. Polls `GET /api/v1/workspaces/{id}` until status is `ready`, failing on
+   `error`.
+4. Reads `GET /api/v1/workspaces/{id}/runtime` and posts
+   `{ target_key: "codex" }` to
+   `POST /api/v1/workspaces/{id}/runtime/sessions` only when needed.
+5. Returns the workspace ID.
+
+The command is a synthetic long-running shell. It must never invoke the
+installed `codex` binary or read developer configuration or credentials.
+
+- [ ] **Step 9: Add the reviewer-to-Codex captures**
+
+Add light and dark `code-reviewer-agent-launch` cases at
+`/pulls/github/acme/widgets/1`. Their `prepare` callback configures the
+synthetic agent. Their `afterReady` callback clicks the accessible
+`Create Workspace options` button and waits for the `Codex` menu item.
+
+Add light and dark `workspace-codex-session` cases at `/workspaces`. Their
+`prepare` callback calls `ensureSyntheticCodexWorkspace`. Their
+`readySelector` is `.workspace-list-sidebar` with ready text
+`Add widget caching layer`. Their `afterReady` callback selects that row and
+waits for both `.workspace-list-sidebar .ws-row.selected` and the `Codex` tab
+inside the `Workflow panes` region.
+
+Update `docs/screenshots/README.md` with the four filenames and the rule that
+the Codex process is synthetic.
+
+- [ ] **Step 10: Expand the code-reviewer workflow**
+
+Before editing, run constraint extraction and the banned-pattern scan on
+`docs/workflows/code-reviewer.md`.
+
+In `docs/workflows/code-reviewer.md`, replace the short local-verification
+paragraph with:
+
+```markdown
+## Move from review into a coding agent
+
+Open **Create Workspace** and choose a configured agent such as Codex. Kenn
+Forge automatically creates and tracks a Git worktree for the pull-request
+branch, then launches the agent in that worktree. You do not need to run
+`git worktree add` or manage a separate checkout.
+```
+
+Place the `code-reviewer-agent-launch` light/dark figure after that paragraph.
+Follow it with a short paragraph explaining that Workspaces keeps the branch,
+session, and review context together, then place the
+`workspace-codex-session` light/dark figure. Use specific alt text and
+one-sentence captions.
+
+- [ ] **Step 11: Verify all captures and rendered output**
+
+Run:
+
+```bash
+env KENN_FORGE_DOCS_SCREENSHOT_DIR=tmp/docs-screenshots \
+  node node_modules/vite-plus/bin/vp exec -- playwright test \
+  --config docs/screenshots/playwright.config.ts --project=chromium
+node scripts/build-docs.mjs
+```
+
+Expected: 12 screenshot cases pass and Zensical builds the public site. Inspect
+all four new SVGs in light and dark mode. Confirm the menu shows Codex, the
+Workspaces capture shows the selected PR worktree and Codex session, no terminal
+content or private data appears, and every app icon renders standalone.
+
+Serve `site/` and inspect `/workflows/code-reviewer/` at 1280px and 390px.
+Verify both new figures load, their alt text and captions match the workflow,
+theme switching selects the correct light/dark assets, navigation contains only
+public pages, and scrolling keeps `kenn-forge` unchanged. Inspect the rendered
+home and Quick Start links and confirm their resolved `href` values target
+`kenn-io/forge`.
+
+Confirm these paths do not exist:
+
+```bash
+test ! -e site/superpowers
+test ! -e site/adr
+test ! -e site/reports
+test ! -e site/screenshots
+```
+
+Also request `/superpowers/`, `/adr/`, `/reports/`, and `/screenshots/`
+from the served site and confirm each returns 404.
+
+- [ ] **Step 12: Run final prose and repository verification**
+
+Run the `unslop` banned-pattern and readability checks over all 11 public
+Markdown pages. For `README.md`, `docs/quickstart.md`, and
+`docs/workflows/code-reviewer.md`, compare the final file with its Task 4
+baseline:
+
+```bash
+for docs_file in README.md docs/quickstart.md docs/workflows/code-reviewer.md; do
+  python3 /Users/mariusvniekerk/.agents/skills/unslop/scripts/diff_check.py \
+    <(git show HEAD:"$docs_file") "$docs_file"
+  python3 /Users/mariusvniekerk/.agents/skills/unslop/scripts/validate_preservation.py \
+    <(git show HEAD:"$docs_file") "$docs_file"
+done
+```
+
+Review every reported URL change against the canonical `kenn-io/forge`
+decision. No unrelated command, path, provider fact, or workflow claim may be
+lost. Then run:
+
+```bash
+git diff --check
+node node_modules/vite-plus/bin/vp exec -- node --test scripts/*.test.mjs scripts/*.test.ts
+git status --short
+```
+
+Use `superpowers:verification-before-completion`. Invoke the repository-local
+`context-sync --commit` workflow, then commit Task 4 with a conventional
+subject and rationale-focused body.
+
+---
+
+### Task 5: Publish the stacked pull request
 
 **Files:**
 - No repository file changes expected
 
 **Interfaces:**
-- Consumes: the verified commits from Tasks 1 through 3 and onboarding PR #816
+- Consumes: the verified commits from Tasks 1 through 4 and onboarding PR #816
 - Produces: a pushed branch and a pull request whose base is \`t3code/design-onboarding-mockups\`
 
 - [ ] **Step 1: Scrub public metadata and the complete diff**
 
 The repository references a \`scrub-private-data\` skill that is not installed in this session. Perform the fallback manually with \`git diff origin/t3code/design-onboarding-mockups...HEAD\`, \`git log\`, and targeted searches for home paths, private hosts, credentials, runner topology, and private project names. Generic seeded names such as \`acme/widgets\` are allowed.
 
-- [ ] **Step 2: Push and link the stack**
+- [ ] **Step 2: Push and create the attributed pull request**
 
-Push \`t3code/refine-onboarding-documentation\` to \`origin\`. Use non-interactive \`gh stack link --base main --open 816 t3code/refine-onboarding-documentation\` so the new PR is based on \`t3code/design-onboarding-mockups\` and linked above PR #816.
+Push `t3code/refine-onboarding-documentation` to `origin`. Create the pull
+request with `gh pr create`, base `t3code/design-onboarding-mockups`, a concise
+title, and only this style of user-visible summary:
 
-- [ ] **Step 3: Set concise public PR metadata**
+```markdown
+- Adds a release-first setup path and provider-aware onboarding guidance
+- Organizes daily maintainer, archive, fleet, and recovery workflows
+- Adds current first-run, review, workspace, and activity visuals
 
-Use \`gh pr edit\` to set a concise title and a body containing only a bulleted summary of user-visible documentation changes. Do not include a test plan, checklist, implementation detail, or marketing language. End any GitHub-authored text with:
-
-\`\`\`html
 <sup>generated by a clanker</sup>
-\`\`\`
+```
+
+Supply `--base`, `--head`, `--title`, and `--body` so the command cannot prompt.
+Capture the returned PR number. The attribution footer must be present at
+creation time; do not create the PR through `gh stack link`.
+
+- [ ] **Step 3: Link the existing pull requests**
+
+Run:
+
+```bash
+gh stack link --base main --open --remote origin 816 "$pr_number"
+```
+
+Both arguments are existing PRs in bottom-to-top order. This links the new PR
+above #816 without generating or replacing its title or body.
 
 - [ ] **Step 4: Verify the remote stack**
 

--- a/docs/superpowers/plans/2026-08-02-public-documentation-readiness.md
+++ b/docs/superpowers/plans/2026-08-02-public-documentation-readiness.md
@@ -1,0 +1,328 @@
+# Public Documentation Readiness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan directly in the current agent, task-by-task. Never use subagent-driven development. Steps use checkbox (\`- [ ]\`) syntax for tracking.
+
+**Goal:** Publish a concise, accurate public guide with current generated visuals for onboarding and the main maintainer workflows.
+
+**Approved spec/design:** \`docs/superpowers/specs/2026-08-02-public-documentation-readiness-design.md\`
+
+**Architecture:** Treat the public Markdown files as one documentation product with a short repository landing page, a task-first guide, and separate advanced references. Generate all UI images from isolated seeded servers during the existing staged Zensical build, then inspect the rendered \`site/\` output instead of tracking generated assets.
+
+**Tech Stack:** Markdown, Zensical, TypeScript, Playwright, Node.js, Vite+, Python-based \`unslop\` validation
+
+## Global Constraints
+
+- Apply the \`unslop\` crisp preset to every public Markdown page.
+- Preserve commands, paths, provider names, defaults, limits, URLs, and security boundaries exactly unless repository evidence proves they are stale.
+- Keep paragraphs short, lead with actions or facts, and describe user outcomes instead of implementation details.
+- Keep ADRs, plans, specs, reports, and \`context/\` documents out of the public navigation.
+- Generate screenshots only from isolated seeded servers. Never use a live developer app or private data.
+- Keep generated SVG files untracked. Commit only their Playwright cases, page references, styles, and build guidance.
+- Do not change production onboarding behavior or add product features.
+- Keep the pull request based on \`t3code/design-onboarding-mockups\`.
+
+---
+
+### Task 1: Rewrite the public entry path
+
+**Files:**
+- Modify: \`README.md\`
+- Modify: \`docs/index.md\`
+- Modify: \`docs/quickstart.md\`
+- Modify: \`docs/zensical.toml\`
+
+**Interfaces:**
+- Consumes: the first-run provider flow from PR #816, release artifact names from \`.github/workflows/release.yml\`, and the public page boundaries in the approved spec
+- Produces: a short repository landing page, a release-first Quick Start, and task-first site navigation used by every later documentation page
+
+- [ ] **Step 1: Record the original prose constraints and AI-pattern scan**
+
+Run:
+
+\`\`\`bash
+for docs_file in README.md docs/index.md docs/quickstart.md; do
+  python3 ~/.agents/skills/unslop/scripts/extract_constraints.py "$docs_file"
+  python3 ~/.agents/skills/unslop/scripts/banned_phrase_scan.py "$docs_file"
+done
+\`\`\`
+
+Expected: each command returns JSON. Record any hard or soft violations before editing.
+
+- [ ] **Step 2: Rewrite the repository landing page**
+
+Use \`apply_patch\` to make \`README.md\` contain these sections in order:
+
+1. One short product description and a link to the public guide.
+2. A compact list of maintainer outcomes: triage, review, local workspaces, optional Kata and Docs modes, and fleet access.
+3. Installation from the GitHub Releases page, including the existing Linux, macOS, and Windows archives.
+4. A source-build alternative requiring Go 1.26+ and Bun.
+5. The shortest start command and \`http://127.0.0.1:8091\`.
+6. Links to Quick Start, Configuration, Workflows, and Troubleshooting.
+
+Remove duplicated configuration tables, provider token routing detail, profiler instructions, and feature walkthroughs that belong in the public guide.
+
+- [ ] **Step 3: Rewrite the docs home and Quick Start**
+
+Use \`apply_patch\` to:
+
+- make \`docs/index.md\` explain the product, identify the first useful tasks, and route readers to Quick Start or a role-based workflow;
+- make \`docs/quickstart.md\` lead with release installation, retain source builds as an alternative, start the daemon, and describe the provider-aware onboarding path from code-forge readiness through repository selection, sync, PR selection, and workspace creation;
+- keep Settings and TOML as recovery or advanced configuration paths;
+- retain optional Kata and Docs mode activation without expanding their setup on this page.
+
+- [ ] **Step 4: Tighten the Zensical navigation**
+
+Use \`apply_patch\` to keep task-first labels and ensure the public home is reachable. Preserve the existing advanced Archive and Fleet pages without exposing internal docs.
+
+- [ ] **Step 5: Validate the rewritten entry path**
+
+Run:
+
+\`\`\`bash
+for docs_file in README.md docs/index.md docs/quickstart.md; do
+  python3 ~/.agents/skills/unslop/scripts/banned_phrase_scan.py "$docs_file"
+  python3 ~/.agents/skills/unslop/scripts/readability_metrics.py "$docs_file"
+  python3 ~/.agents/skills/unslop/scripts/diff_check.py <(git show 8d5a5c191:"$docs_file") "$docs_file"
+  python3 ~/.agents/skills/unslop/scripts/validate_preservation.py <(git show 8d5a5c191:"$docs_file") "$docs_file"
+done
+\`\`\`
+
+Expected: zero hard banned-pattern violations. Review every reported missing constraint against the approved information architecture; keep the fact on the most relevant public page when it was intentionally removed from \`README.md\`.
+
+- [ ] **Step 6: Verify and commit the entry path**
+
+Run:
+
+\`\`\`bash
+git diff --check
+node node_modules/vite-plus/bin/vp exec -- node --test scripts/build-docs.test.mjs scripts/docs-screenshots-command.test.mjs
+\`\`\`
+
+Run \`scripts/context-sync --check\`, inspect the intended diff, then commit only the four Task 1 files with a conventional \`docs:\` subject and a rationale-focused body.
+
+---
+
+### Task 2: Rewrite workflow and advanced references
+
+**Files:**
+- Modify: \`docs/configuration.md\`
+- Modify: \`docs/commands.md\`
+- Modify: \`docs/workflows.md\`
+- Modify: \`docs/workflows/issue-triager.md\`
+- Modify: \`docs/workflows/code-reviewer.md\`
+- Modify: \`docs/archive.md\`
+- Modify: \`docs/federated-fleet.md\`
+- Modify: \`docs/troubleshooting.md\`
+
+**Interfaces:**
+- Consumes: the navigation and terminology established in Task 1, current CLI help, config types, provider capabilities, and the approved public page boundaries
+- Produces: concise task guides and accurate references linked from the repository landing page and docs home
+
+- [ ] **Step 1: Audit facts against product-owned sources**
+
+Before editing, run:
+
+\`\`\`bash
+for docs_file in \
+  docs/configuration.md \
+  docs/commands.md \
+  docs/workflows.md \
+  docs/workflows/issue-triager.md \
+  docs/workflows/code-reviewer.md \
+  docs/archive.md \
+  docs/federated-fleet.md \
+  docs/troubleshooting.md; do
+  python3 ~/.agents/skills/unslop/scripts/extract_constraints.py "$docs_file"
+  python3 ~/.agents/skills/unslop/scripts/banned_phrase_scan.py "$docs_file"
+done
+\`\`\`
+
+Check claims against:
+
+\`\`\`bash
+./kenn-forge --help
+./kenn-forge serve --help
+./kenn-forge start --help
+./kenn-forge archive --help
+./kenn-forge docs --help
+./kenn-forge agent-hook --help
+./kenn-forge status --help
+\`\`\`
+
+If the binary is absent, build it with \`make build\` before running the help checks. Use \`internal/config/config.go\`, \`.github/workflows/release.yml\`, and the relevant command definitions only to settle claims that the CLI cannot show.
+
+- [ ] **Step 2: Rewrite the routine workflow guides**
+
+Use \`apply_patch\` to make \`docs/workflows.md\` task-first and remove repeated feature inventory. Keep daily triage, navigation, reviews, issues, repository browsing, workspaces, optional modes, and fleet handoff as separate short workflows.
+
+Tighten the two role guides around observable decisions:
+
+- Issue triager: scan recent context, decide the next action, then create a workspace.
+- Code reviewer: check recent context and CI, inspect the diff, act on the review, then open a workspace when local verification is needed.
+
+Keep capability differences explicit without repeating the supported-provider list.
+
+- [ ] **Step 3: Rewrite Configuration and Commands as references**
+
+Use \`apply_patch\` to keep exact examples and defaults while shortening explanations. Put common repository, token, mode, agent, docs-folder, and telemetry settings before advanced GitHub App, owner-token, stack, reverse-proxy, and SSE settings. Group commands by the user task they perform and preserve all supported flags shown by CLI help.
+
+- [ ] **Step 4: Rewrite Archive, Fleet, and Troubleshooting around operations**
+
+Use \`apply_patch\` to:
+
+- organize Archive by start, monitor, pause, report, and resume;
+- organize Fleet by topology, peer setup, operation, and failure recovery;
+- organize Troubleshooting by symptom, direct check, and recovery command;
+- remove internal rationale and repeated architecture detail unless it changes safe operation.
+
+- [ ] **Step 5: Validate facts and prose across the full public corpus**
+
+Run:
+
+\`\`\`bash
+for docs_file in \
+  docs/configuration.md \
+  docs/commands.md \
+  docs/workflows.md \
+  docs/workflows/issue-triager.md \
+  docs/workflows/code-reviewer.md \
+  docs/archive.md \
+  docs/federated-fleet.md \
+  docs/troubleshooting.md; do
+  python3 ~/.agents/skills/unslop/scripts/banned_phrase_scan.py "$docs_file"
+  python3 ~/.agents/skills/unslop/scripts/readability_metrics.py "$docs_file"
+  python3 ~/.agents/skills/unslop/scripts/diff_check.py <(git show 8d5a5c191:"$docs_file") "$docs_file"
+  python3 ~/.agents/skills/unslop/scripts/validate_preservation.py <(git show 8d5a5c191:"$docs_file") "$docs_file"
+done
+\`\`\`
+
+Review intentional fact movement across the complete public corpus. No command, default, limit, provider boundary, or security constraint may disappear from all public pages.
+
+Expected: zero hard banned-pattern violations and no unexplained missing constraints.
+
+- [ ] **Step 6: Verify and commit the reference rewrite**
+
+Run:
+
+\`\`\`bash
+git diff --check
+node node_modules/vite-plus/bin/vp exec -- node --test scripts/build-docs.test.mjs scripts/docs-screenshots-command.test.mjs
+\`\`\`
+
+Run \`scripts/context-sync --check\`, inspect the intended diff, then commit only the eight Task 2 files with a conventional \`docs:\` subject and a rationale-focused body.
+
+---
+
+### Task 3: Refresh and expand generated documentation visuals
+
+**Files:**
+- Modify: \`docs/screenshots/docs-screenshots.spec.ts\`
+- Modify: \`docs/screenshots/README.md\`
+- Modify: \`docs/stylesheets/extra.css\`
+- Modify: \`docs/index.md\`
+- Modify: \`docs/quickstart.md\`
+- Modify: \`docs/workflows/issue-triager.md\`
+- Modify: \`docs/workflows/code-reviewer.md\`
+
+**Interfaces:**
+- Consumes: \`startIsolatedWorkspaceE2EServer()\`, \`startIsolatedE2EServerWithOptions()\`, the seeded \`acme/widgets\` fixtures, onboarding storage keys, and \`KENN_FORGE_DOCS_SCREENSHOT_DIR\`
+- Produces: generated \`first-run-{light,dark}.svg\`, \`maintainer-overview-{light,dark}.svg\`, \`issue-triager-{light,dark}.svg\`, and \`code-reviewer-{light,dark}.svg\` in the staged docs asset directory
+
+- [ ] **Step 1: Apply the repository test-scope guidance**
+
+Read \`kenn-test-scope-discipline:test-scope-discipline\` before changing the Playwright generator. Keep assertions focused on stable visible state, theme selection, settled loading, and privacy-safe fixture data.
+
+- [ ] **Step 2: Generalize the capture cases without changing production code**
+
+Use \`apply_patch\` to extend \`CaptureCase.name\` with \`maintainer-overview\` and add light and dark overview cases at \`/\`. Use \`.activity-feed\` as the ready selector and a seeded item title as the ready text. Keep issue and code-review cases on their current provider-aware routes.
+
+Extract one capture helper that:
+
+- prepares the selected theme;
+- opens the case route;
+- disables transitions and animation;
+- waits for the case's stable visible selector and text;
+- waits for sync and loading indicators to settle when that case has sync controls;
+- serializes the current DOM into the existing accessible SVG wrapper;
+- writes the file under \`KENN_FORGE_DOCS_SCREENSHOT_DIR\`.
+
+- [ ] **Step 3: Add an isolated first-run capture**
+
+Start a second server with \`startIsolatedE2EServerWithOptions()\`. Remove its configured repositories through the public settings API, clear \`kenn-forge:first-run-onboarding\` in local and session storage, and route \`/api/v1/tooling-status\` to the synthetic authenticated \`github.com\` maintainer used by the onboarding e2e test.
+
+Capture light and dark \`first-run\` SVGs only after the \`Connect a code forge\` heading and provider readiness list are visible. Stop this server in teardown. Do not reuse or mutate the configured workflow server.
+
+- [ ] **Step 4: Place each visual next to the task it explains**
+
+Use \`apply_patch\` to add theme-aware \`<figure>\` blocks:
+
+- first-run on \`docs/quickstart.md\`;
+- maintainer overview on \`docs/index.md\`;
+- refreshed issue triage and code review on their existing role guides.
+
+Write specific alt text and one-sentence captions. Extend \`docs/stylesheets/extra.css\` only if the new placements reveal a real rendering issue. Update \`docs/screenshots/README.md\` with all eight generated names and the isolated-data rule.
+
+- [ ] **Step 5: Run the screenshot and build tests**
+
+Run:
+
+\`\`\`bash
+node node_modules/vite-plus/bin/vp exec -- node --test scripts/build-docs.test.mjs scripts/docs-screenshots-command.test.mjs
+node node_modules/vite-plus/bin/vp exec -- playwright test --config docs/screenshots/playwright.config.ts --project=chromium
+node scripts/build-docs.mjs
+\`\`\`
+
+Expected: all screenshot cases pass, all eight SVGs appear in staged build output, and Zensical writes the rendered site to \`site/\`.
+
+- [ ] **Step 6: Inspect generated artifacts and rendered pages**
+
+Use the local image viewer for each generated light and dark SVG. Check current UI, stable synthetic data, clipping, loading states, and private information. Serve \`site/\` locally, then use the T3 preview browser to inspect the docs home, Quick Start, both role guides, navigation, links, theme switching, and a 390px-wide viewport.
+
+Confirm raw source paths that look suspicious against the rendered \`site/\` output. Confirm \`git status --short\` does not list \`docs/assets/generated/\` or generated SVGs.
+
+- [ ] **Step 7: Run final prose and repository verification**
+
+Run banned-pattern, readability, and preservation checks over every public Markdown page. Then run:
+
+\`\`\`bash
+git diff --check
+node node_modules/vite-plus/bin/vp exec -- node --test scripts/*.test.mjs scripts/*.test.ts
+git status --short
+\`\`\`
+
+Use \`superpowers:verification-before-completion\` before reporting success.
+
+- [ ] **Step 8: Commit the visuals and final corrections**
+
+Run \`scripts/context-sync --check\`, inspect the intended diff, and commit the screenshot generator, screenshot guidance, styles, and final page corrections with a conventional \`docs:\` subject and a rationale-focused body.
+
+---
+
+### Task 4: Publish the stacked pull request
+
+**Files:**
+- No repository file changes expected
+
+**Interfaces:**
+- Consumes: the verified commits from Tasks 1 through 3 and onboarding PR #816
+- Produces: a pushed branch and a pull request whose base is \`t3code/design-onboarding-mockups\`
+
+- [ ] **Step 1: Scrub public metadata and the complete diff**
+
+The repository references a \`scrub-private-data\` skill that is not installed in this session. Perform the fallback manually with \`git diff origin/t3code/design-onboarding-mockups...HEAD\`, \`git log\`, and targeted searches for home paths, private hosts, credentials, runner topology, and private project names. Generic seeded names such as \`acme/widgets\` are allowed.
+
+- [ ] **Step 2: Push and link the stack**
+
+Push \`t3code/refine-onboarding-documentation\` to \`origin\`. Use non-interactive \`gh stack link --base main --open 816 t3code/refine-onboarding-documentation\` so the new PR is based on \`t3code/design-onboarding-mockups\` and linked above PR #816.
+
+- [ ] **Step 3: Set concise public PR metadata**
+
+Use \`gh pr edit\` to set a concise title and a body containing only a bulleted summary of user-visible documentation changes. Do not include a test plan, checklist, implementation detail, or marketing language. End any GitHub-authored text with:
+
+\`\`\`html
+<sup>generated by a clanker</sup>
+\`\`\`
+
+- [ ] **Step 4: Verify the remote stack**
+
+Run \`gh stack view --json\` and \`gh pr view\` for the new PR. Confirm the new PR is open, its base is \`t3code/design-onboarding-mockups\`, and PR #816 remains the lower stack layer. Do not poll CI.

--- a/docs/superpowers/plans/2026-08-03-docs-navigation-system-theme.md
+++ b/docs/superpowers/plans/2026-08-03-docs-navigation-system-theme.md
@@ -1,0 +1,386 @@
+# Documentation Navigation and System Theme Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan directly in the current agent, task-by-task. Never use subagent-driven development. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move Fleet under an advanced/experimental navigation group and make the rendered documentation follow the browser color scheme before first paint while preserving explicit user overrides.
+
+**Approved spec/design:** `docs/superpowers/specs/2026-08-02-public-documentation-readiness-design.md`
+
+**Architecture:** Keep Fleet's page and URL unchanged; only the Zensical navigation hierarchy changes. Use media-qualified light and dark palette entries, plus a small staged Zensical `main.html` override that applies the matching or stored palette from the document head. Until the reader interacts with the palette control, the override prevents Zensical's runtime from turning an automatic match into a persisted manual choice.
+
+**Tech Stack:** Zensical TOML and Jinja templates, Node.js staging script/tests, Playwright rendered-site tests.
+
+## Global Constraints
+
+- Fleet appears under **Advanced / experimental**, not beside the main setup and workflow pages.
+- Existing Fleet URLs and Markdown cross-links remain unchanged.
+- A first visit follows `prefers-color-scheme: light` or `prefers-color-scheme: dark` before the runtime bundle loads.
+- Automatic selection keeps following later browser preference changes until the reader uses the palette control.
+- An explicit light or dark choice persists and overrides the browser preference.
+- Internal plans, specs, ADRs, reports, and screenshot tooling remain excluded from staged and rendered output.
+- Generated SVG screenshots remain untracked.
+
+---
+
+### Task 0: Commit the reviewed plan
+
+**Files:**
+- Create: `docs/superpowers/plans/2026-08-03-docs-navigation-system-theme.md`
+
+- [ ] **Step 1: Apply the read-only plan review**
+
+Resolve every supported finding from RoboRev task `9469`. Run:
+
+```bash
+git diff --check
+```
+
+- [ ] **Step 2: Commit the plan**
+
+Invoke repository-local `context-sync --commit`, then invoke the mandatory
+commit skill. Stage only this plan and use the subject
+`docs: plan final public site corrections`, with a rationale body and Codex
+attribution. Do not run a separate subject-only commit command.
+
+---
+
+### Task 1: Nest Fleet under advanced navigation
+
+**Files:**
+- Modify: `docs/site/docs-site.spec.ts`
+- Modify: `docs/zensical.toml`
+
+**Interfaces:**
+- Consumes: the rendered primary navigation under `.md-sidebar--primary`
+- Produces: an **Advanced / experimental** navigation section whose nested Fleet link still resolves to `/federated-fleet/`
+
+- [ ] **Step 1: Add the failing rendered-navigation test**
+
+Append this test to `docs/site/docs-site.spec.ts`:
+
+```ts
+test("places Fleet under advanced and experimental navigation", async ({ page }) => {
+  await page.goto("/");
+
+  const primaryNav = page.locator(".md-sidebar--primary nav[data-md-level='0']");
+  const advancedLabel = primaryNav.locator("label.md-nav__link", {
+    hasText: "Advanced / experimental",
+  });
+  await expect(advancedLabel).toBeVisible();
+
+  const advancedItem = advancedLabel.locator("xpath=ancestor::li[1]");
+  await expect(advancedItem.getByRole("link", { name: "Fleet" })).toHaveAttribute(
+    "href",
+    /federated-fleet\/$/,
+  );
+  await expect(
+    primaryNav.locator(":scope > ul > li > a.md-nav__link", { hasText: "Fleet" }),
+  ).toHaveCount(0);
+});
+```
+
+- [ ] **Step 2: Run the docs build and verify the navigation test fails**
+
+Run:
+
+```bash
+node scripts/build-docs.mjs
+```
+
+Expected: the screenshot cases and Zensical build pass, then the rendered-site project fails because **Advanced / experimental** does not exist.
+
+- [ ] **Step 3: Move Fleet into the nested navigation group**
+
+Replace the top-level Fleet entry in `docs/zensical.toml` with:
+
+```toml
+  {"Advanced / experimental" = [
+    {"Fleet" = "federated-fleet.md"},
+  ]},
+```
+
+Keep Archive and Commands at their existing top-level positions.
+
+- [ ] **Step 4: Rebuild and verify the navigation test passes**
+
+Run:
+
+```bash
+node scripts/build-docs.mjs
+```
+
+Expected: 12 screenshot tests, Zensical, and all rendered-site tests pass. Inspect `site/index.html` and confirm Fleet appears only inside the nested section.
+
+- [ ] **Step 5: Commit the navigation change**
+
+Invoke repository-local `context-sync --commit`, then invoke the mandatory
+commit skill. Stage only `docs/site/docs-site.spec.ts` and `docs/zensical.toml`.
+Use the subject `docs: classify Fleet as advanced functionality`, with a
+rationale body and Codex attribution. Do not run a separate subject-only commit
+command or amend earlier commits.
+
+---
+
+### Task 2: Apply system theme before the runtime bundle
+
+**Files:**
+- Create: `docs/overrides/main.html`
+- Modify: `docs/site/docs-site.spec.ts`
+- Modify: `docs/zensical.toml`
+- Modify: `scripts/build-docs.mjs`
+- Modify: `scripts/build-docs.test.mjs`
+
+**Interfaces:**
+- Consumes: Zensical's `__md_get("__palette")` and `__md_set`, palette change events, and browser `matchMedia`
+- Produces: a head-level bootstrap that sets body `data-md-color-*` attributes before the first animation frame, follows system changes while no stored choice exists, and leaves explicit user choices to Zensical's normal persistence path
+
+- [ ] **Step 1: Add failing system-theme and persistence tests**
+
+Add this type near the top of `docs/site/docs-site.spec.ts`:
+
+```ts
+type FirstFrameWindow = Window & {
+  __firstFrameScheme?: Promise<string | null>;
+};
+```
+
+Append these tests:
+
+```ts
+test("applies the browser theme before the runtime bundle", async ({ browser }) => {
+  for (const preference of [
+    { colorScheme: "light" as const, expected: "default" },
+    { colorScheme: "dark" as const, expected: "slate" },
+  ]) {
+    const context = await browser.newContext({ colorScheme: preference.colorScheme });
+    await context.addInitScript(() => {
+      const target = window as FirstFrameWindow;
+      target.__firstFrameScheme = new Promise((resolve) => {
+        requestAnimationFrame(() => {
+          resolve(document.body?.getAttribute("data-md-color-scheme") ?? null);
+        });
+      });
+    });
+    const page = await context.newPage();
+    await page.route("**/assets/javascripts/bundle.*.min.js", (route) => route.abort());
+
+    await page.goto("/");
+    const firstFrameScheme = await page.evaluate(() =>
+      (window as FirstFrameWindow).__firstFrameScheme,
+    );
+    expect(firstFrameScheme).toBe(preference.expected);
+    await context.close();
+  }
+});
+
+test("keeps following system theme changes until the reader chooses", async ({ browser }) => {
+  const context = await browser.newContext({ colorScheme: "dark" });
+  const page = await context.newPage();
+  await page.goto("/");
+  await expect(page.locator("body")).toHaveAttribute("data-md-color-scheme", "slate");
+
+  await page.emulateMedia({ colorScheme: "light" });
+  await expect(page.locator("body")).toHaveAttribute("data-md-color-scheme", "default");
+
+  await page.reload();
+  await expect(page.locator("body")).toHaveAttribute("data-md-color-scheme", "default");
+  await context.close();
+});
+
+test("persists an explicit light override on a dark system", async ({ browser }) => {
+  const context = await browser.newContext({ colorScheme: "dark" });
+  const page = await context.newPage();
+  await page.goto("/");
+  await expect(page.locator("body")).toHaveAttribute("data-md-color-scheme", "slate");
+
+  await page.locator('label[title="Switch to light mode"]').click();
+  await expect(page.locator("body")).toHaveAttribute("data-md-color-scheme", "default");
+
+  await page.reload();
+  await expect(page.locator("body")).toHaveAttribute("data-md-color-scheme", "default");
+  await context.close();
+});
+```
+
+- [ ] **Step 2: Run the docs build and verify the dark-preference assertions fail**
+
+Run:
+
+```bash
+node scripts/build-docs.mjs
+```
+
+Expected: the first-frame dark case and initial dark assertions fail because both current palette entries use `media = "none"` and the body starts with `data-md-color-scheme="default"`.
+
+- [ ] **Step 3: Add the palette override to the staged-source contract test**
+
+In `scripts/build-docs.test.mjs`, create
+`overrides/main.html` in the synthetic source, write
+`<script>palette</script>\n`, and assert that exact content is staged. Also
+write `overrides/internal.html` and include it in the existing rejection list.
+
+Run:
+
+```bash
+node node_modules/vite-plus/bin/vp exec -- node --test scripts/build-docs.test.mjs
+```
+
+Expected: FAIL because the current public staging allowlist excludes the override tree.
+
+- [ ] **Step 4: Allowlist only the palette override**
+
+In `scripts/build-docs.mjs`, add this exact file to `publishedFiles`:
+
+```js
+path.join("overrides", "main.html")
+```
+
+Add only the required parent directory to `publishedDirectoryEntries`:
+
+```js
+"overrides",
+```
+
+Rerun the focused script test. Expected: PASS, while `overrides/internal.html`
+remains excluded.
+
+- [ ] **Step 5: Configure media-qualified palettes and the custom template directory**
+
+In `docs/zensical.toml`, add:
+
+```toml
+[project.theme]
+custom_dir = "docs/overrides"
+```
+
+Keep the existing `variant` and `features` entries in the same table. Add
+`media = "(prefers-color-scheme: light)"` to the `default` palette and
+`media = "(prefers-color-scheme: dark)"` to the `slate` palette. Keep the
+existing toggle icons and names.
+
+- [ ] **Step 6: Add the synchronous palette bootstrap override**
+
+Create `docs/overrides/main.html` with:
+
+```html
+{% extends "base.html" %}
+{% block extrahead %}
+  <script>
+    (function () {
+      var stored = __md_get("__palette");
+      var color = stored && stored.color;
+      if (!color) {
+        var light = matchMedia("(prefers-color-scheme: light)").matches;
+        color = {
+          media: light ? "(prefers-color-scheme: light)" : "(prefers-color-scheme: dark)",
+          scheme: light ? "default" : "slate",
+          primary: "custom",
+          accent: "custom",
+        };
+
+        var persist = __md_set;
+        var readerSelected = false;
+        document.addEventListener("change", function (event) {
+          if (event.target && event.target.name === "__palette") readerSelected = true;
+        }, true);
+        __md_set = function (key, value, storage, scope) {
+          if (key === "__palette" && !readerSelected) return;
+          persist(key, value, storage, scope);
+        };
+      }
+
+      new MutationObserver(function (_, observer) {
+        if (!document.body) return;
+        for (var key in color) document.body.setAttribute("data-md-color-" + key, color[key]);
+        observer.disconnect();
+      }).observe(document.documentElement, { childList: true });
+    })();
+  </script>
+{% endblock %}
+```
+
+Keep the override self-contained and dependency-free. It must not write a
+palette choice. It may suppress Zensical's automatic palette write only while
+there is no stored choice and no palette change event from the reader.
+
+- [ ] **Step 7: Rebuild and verify theme selection and persistence**
+
+Run:
+
+```bash
+node scripts/build-docs.mjs
+```
+
+Expected: 12 screenshot tests, Zensical, and all rendered-site tests pass. The
+bundle-blocked dark context must report `slate` at its first animation frame.
+Changing an untouched page from dark to light must survive reload without
+creating a manual override.
+
+- [ ] **Step 8: Inspect both browser preferences in the embedded browser**
+
+Keep the existing validated server on `127.0.0.1:4177`. In the embedded browser,
+open `/workflows/code-reviewer/` at desktop and phone widths. Confirm the page
+and matching workflow SVG use the active appearance, Fleet is reachable only
+inside **Advanced / experimental**, and a manual palette choice survives a
+reload. Use the rendered-site Playwright cases for deterministic light and dark
+emulation.
+
+- [ ] **Step 9: Commit the theme change**
+
+Invoke repository-local `context-sync --commit`, then invoke the mandatory
+commit skill. Stage only `docs/overrides/main.html`,
+`docs/site/docs-site.spec.ts`, `docs/zensical.toml`, `scripts/build-docs.mjs`,
+and `scripts/build-docs.test.mjs`. Use the subject
+`fix: respect the browser theme in public docs`, with a rationale body and
+Codex attribution. Do not run a separate subject-only commit command or amend
+earlier commits.
+
+---
+
+### Task 3: Verify and publish the correction
+
+**Files:**
+- No repository file changes expected
+
+**Interfaces:**
+- Consumes: the committed navigation and theme behavior
+- Produces: a clean pushed branch updating PR #821
+
+- [ ] **Step 1: Run final verification**
+
+Run:
+
+```bash
+base=$(git merge-base HEAD origin/t3code/design-onboarding-mockups)
+git diff --check "$base"...HEAD
+node node_modules/vite-plus/bin/vp exec -- node --test scripts/*.test.mjs scripts/*.test.ts
+node scripts/build-docs.mjs
+test -z "$(git ls-files 'site/**' 'docs/assets/generated/**')"
+if find site -type f \( -path '*/superpowers/*' -o -path '*/adr/*' -o -path '*/reports/*' -o -path '*/screenshots/*' \) -print -quit | grep -q .; then exit 1; fi
+git status --short
+```
+
+Expected: script tests pass, the docs build reports 12 screenshot cases and all
+rendered-site cases passing, internal trees remain absent from `site/`, and
+generated SVGs remain untracked. Inspect every generated light/dark SVG for
+clipping, loading state, and synthetic content. Use the embedded browser to
+visit every primary navigation page at 1280x800 and 390x844; check headings,
+code blocks, internal links, image paths, alt text, and theme switching.
+
+- [ ] **Step 2: Scrub and push**
+
+Inspect the complete diff and new commit messages for contributor home paths,
+private hosts, credentials, runner details, and non-synthetic project names.
+Push `t3code/refine-onboarding-documentation` to `origin` without polling CI.
+
+- [ ] **Step 3: Verify the running preview and PR**
+
+Confirm the embedded browser is visible on the live rendered site, the serving
+process still listens on port `4177`, and run:
+
+```bash
+gh pr view 821 --json baseRefName,headRefName,url
+```
+
+Confirm the base is `t3code/design-onboarding-mockups` and the head is
+`t3code/refine-onboarding-documentation`.

--- a/docs/superpowers/specs/2026-08-02-public-documentation-readiness-design.md
+++ b/docs/superpowers/specs/2026-08-02-public-documentation-readiness-design.md
@@ -1,0 +1,131 @@
+# Public Documentation Readiness Design
+
+## Goal
+
+Prepare Kenn Forge's public documentation for people encountering the product
+for the first time. The finished site should explain what Kenn Forge does, get
+a new user into the app, and support the main maintainer workflows without
+requiring them to read internal design or implementation notes.
+
+## Audience
+
+The primary reader maintains repositories and is comfortable with a terminal,
+but does not know Kenn Forge's architecture or configuration model. Advanced
+operators still need accurate references for provider hosts, archives, fleet
+operation, and troubleshooting.
+
+## Scope
+
+Audit and revise the complete public documentation surface:
+
+- `README.md`
+- `docs/index.md`
+- `docs/quickstart.md`
+- `docs/configuration.md`
+- `docs/commands.md`
+- `docs/workflows.md`
+- `docs/workflows/issue-triager.md`
+- `docs/workflows/code-reviewer.md`
+- `docs/archive.md`
+- `docs/federated-fleet.md`
+- `docs/troubleshooting.md`
+- the Zensical navigation, styles, screenshot cases, and screenshot guidance
+
+ADRs, implementation plans, design specs, reports, and `context/` documents
+remain internal. This work may update their links only when a public page would
+otherwise point readers into internal material.
+
+## Information Architecture
+
+`README.md` becomes a short repository landing page. It explains the product,
+links to releases and the documentation site, shows the shortest supported
+start path, and sends detailed questions to the public guide. It must not
+duplicate the configuration or workflow reference.
+
+The documentation home answers three questions in order: what the product is,
+how to start, and where to find a task-specific guide. Quick Start takes a new
+user from installation through the first-run flow introduced by PR #816. It
+leads with release binaries for Linux, macOS, and Windows, then offers a source
+build for contributors and unreleased builds.
+
+The remaining pages keep their current subject boundaries:
+
+- Workflows describes routine use of the product.
+- Configuration documents durable settings and credentials.
+- Commands documents the supported CLI surface.
+- Archive and Fleet cover their advanced operating models.
+- Troubleshooting starts with observable symptoms and gives direct recovery
+  steps.
+
+Navigation labels should use the terms shown in the UI. Cross-links should
+move readers to the next useful task without repeating the destination page.
+
+## Content Rules
+
+Public prose uses the `unslop` crisp preset. Pages lead with the action or fact,
+use active voice, and keep paragraphs short. Feature lists describe user
+outcomes instead of implementation details. Commands, paths, provider names,
+defaults, limits, and security boundaries must remain exact.
+
+Every public page goes through the two-pass `unslop` workflow:
+
+1. Extract facts and scan the existing prose for banned patterns.
+2. Rewrite for clarity, then validate fact preservation, banned patterns,
+   readability, and change size.
+
+Large reductions are acceptable when they remove duplicated or internal prose.
+The final review still checks every removed fact against the product and the
+remaining reference pages.
+
+## Visual Documentation
+
+Screenshots remain generated build artifacts. The repository tracks the
+Playwright cases and page references, not the generated SVG files.
+
+The screenshot suite uses the isolated seeded backend. It must never capture a
+developer's running app or private data. Each capture records a stable, useful
+state after sync and loading indicators settle. Light and dark variants must
+render from the same case.
+
+The visual inventory should cover distinct user questions, not every mode:
+
+- first-run provider readiness or repository selection in Quick Start
+- the main Activity or pull-request workflow on the docs home or workflow
+  overview
+- issue triage
+- code review
+
+Existing issue-triage and code-review captures must be regenerated from the
+current UI. Add or replace the first-run and overview captures only when they
+improve the surrounding instructions. Each image needs specific alt text and a
+caption that explains what the reader should notice.
+
+## Implementation Boundaries
+
+This work updates public documentation, its build pipeline, and isolated
+screenshot fixtures. It does not change production onboarding behavior or add
+new product features. If a documentation audit finds a product defect, record
+it separately instead of widening this PR.
+
+The branch is stacked directly above onboarding PR #816. Its pull request base
+must remain `t3code/design-onboarding-mockups` so reviewers see only the public
+documentation layer.
+
+## Verification
+
+Verification covers source text, generated artifacts, and the rendered site:
+
+- Run every public Markdown file through the `unslop` validation scripts.
+- Run the docs build and its screenshot Playwright cases against the isolated
+  seeded backend.
+- Run the docs build script tests.
+- Inspect every generated SVG in light and dark mode for current UI, stable
+  data, clipped content, loading states, and private information.
+- Inspect the rendered Zensical site at desktop and phone widths.
+- Check navigation, internal links, code blocks, headings, image paths, alt
+  text, and theme switching in rendered output.
+- Confirm generated screenshot assets remain untracked.
+
+The work is complete when a new user can install Kenn Forge, finish onboarding,
+understand the main workflows, and reach accurate advanced references without
+encountering stale UI or internal project language.

--- a/docs/superpowers/specs/2026-08-02-public-documentation-readiness-design.md
+++ b/docs/superpowers/specs/2026-08-02-public-documentation-readiness-design.md
@@ -32,8 +32,10 @@ Audit and revise the complete public documentation surface:
 - the Zensical navigation, styles, screenshot cases, and screenshot guidance
 
 ADRs, implementation plans, design specs, reports, and `context/` documents
-remain internal. This work may update their links only when a public page would
-otherwise point readers into internal material.
+remain internal. The docs build must not copy them into its staged source or
+emit them under `site/`. Build-only screenshot specs and guidance also stay out
+of the published site. This work may update internal links only when a public
+page would otherwise point readers into internal material.
 
 ## Information Architecture
 
@@ -41,6 +43,11 @@ otherwise point readers into internal material.
 links to releases and the documentation site, shows the shortest supported
 start path, and sends detailed questions to the public guide. It must not
 duplicate the configuration or workflow reference.
+
+Public repository, source, and release links use the canonical
+`https://github.com/kenn-io/forge` repository. The Zensical header keeps the
+`kenn-forge` brand text and typography while the reader scrolls. It must not
+replace the brand with the current page title.
 
 The documentation home answers three questions in order: what the product is,
 how to start, and where to find a task-specific guide. Quick Start takes a new
@@ -51,6 +58,9 @@ build for contributors and unreleased builds.
 The remaining pages keep their current subject boundaries:
 
 - Workflows describes routine use of the product.
+- The code-reviewer guide shows the handoff from review to a configured coding
+  agent such as Codex. Kenn Forge automatically creates and tracks the Git
+  worktree for the pull-request branch.
 - Configuration documents durable settings and credentials.
 - Commands documents the supported CLI surface.
 - Archive and Fleet cover their advanced operating models.
@@ -94,11 +104,21 @@ The visual inventory should cover distinct user questions, not every mode:
   overview
 - issue triage
 - code review
+- the code-reviewer's **Create Workspace** menu with a configured Codex launch
+  target
+- the resulting Workspaces view with the pull-request worktree selected and
+  its Codex session available
 
 Existing issue-triage and code-review captures must be regenerated from the
 current UI. Add or replace the first-run and overview captures only when they
 improve the surrounding instructions. Each image needs specific alt text and a
 caption that explains what the reader should notice.
+
+Workspace captures use a synthetic Codex agent on the isolated seeded server.
+They must not start a live Codex process, read agent credentials, or capture a
+developer terminal. The reviewer guide keeps the review overview, then shows
+the direct agent launch and the managed-worktree result as two light/dark
+figures. It does not add a terminal-content screenshot.
 
 ## Implementation Boundaries
 
@@ -119,11 +139,16 @@ Verification covers source text, generated artifacts, and the rendered site:
 - Run the docs build and its screenshot Playwright cases against the isolated
   seeded backend.
 - Run the docs build script tests.
+- Confirm the staged source and rendered site contain only the public Markdown
+  pages, public styles, and generated workflow images. In particular,
+  `superpowers/`, `adr/`, `reports/`, and `screenshots/` must not be published.
 - Inspect every generated SVG in light and dark mode for current UI, stable
   data, clipped content, loading states, and private information.
 - Inspect the rendered Zensical site at desktop and phone widths.
 - Check navigation, internal links, code blocks, headings, image paths, alt
   text, and theme switching in rendered output.
+- Confirm scrolling does not change the Zensical header brand or font.
+- Confirm public repository and release links target `kenn-io/forge`.
 - Confirm generated screenshot assets remain untracked.
 
 The work is complete when a new user can install Kenn Forge, finish onboarding,

--- a/docs/superpowers/specs/2026-08-02-public-documentation-readiness-design.md
+++ b/docs/superpowers/specs/2026-08-02-public-documentation-readiness-design.md
@@ -69,6 +69,14 @@ The remaining pages keep their current subject boundaries:
 
 Navigation labels should use the terms shown in the UI. Cross-links should
 move readers to the next useful task without repeating the destination page.
+Fleet belongs under an **Advanced / experimental** navigation group rather
+than beside the main setup and workflow pages. Its URL and existing links stay
+unchanged.
+
+On first load, Zensical should follow the browser's `prefers-color-scheme`
+value. A reader's explicit light or dark selection overrides that default and
+persists across visits. The initial page paint must use the selected scheme so
+dark-mode readers do not see a light flash.
 
 ## Content Rules
 
@@ -147,6 +155,10 @@ Verification covers source text, generated artifacts, and the rendered site:
 - Inspect the rendered Zensical site at desktop and phone widths.
 - Check navigation, internal links, code blocks, headings, image paths, alt
   text, and theme switching in rendered output.
+- Confirm Fleet renders under **Advanced / experimental**, not as a primary
+  navigation item.
+- Confirm first paint follows light and dark browser preferences, then confirm
+  an explicit theme choice persists and takes priority.
 - Confirm scrolling does not change the Zensical header brand or font.
 - Confirm public repository and release links target `kenn-io/forge`.
 - Confirm generated screenshot assets remain untracked.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,7 +8,7 @@ Check the daemon:
 kenn-forge status
 ```
 
-If another kenn-forge is already running on the same `data_dir`, the startup
+If another Kenn Forge process uses the same `data_dir`, the startup
 banner shows the existing daemon. Use the reported URL instead of starting a
 second daemon with the same data directory.
 
@@ -23,13 +23,12 @@ port = 8092
 or start with another config:
 
 ```sh
-kenn-forge serve -config /path/to/config.toml
+kenn-forge serve --config /path/to/config.toml
 ```
 
 ## Config edits are not showing up
 
-Most config is read at startup. Restart the daemon after editing
-`config.toml`.
+Most config loads at startup. Restart the daemon after editing `config.toml`.
 
 If you need isolated state for a test run, set `KENN_FORGE_HOME` before starting
 kenn-forge.
@@ -57,7 +56,7 @@ without exposing token material.
 
 Actions such as approve, merge, close, reopen, or comment require both provider
 support and token permission. If the provider does not support an action,
-kenn-forge reports an unsupported capability instead of trying a GitHub-specific
+Kenn Forge reports an unsupported capability instead of trying a GitHub-specific
 fallback.
 
 ## GitHub sync hits rate limits
@@ -83,16 +82,16 @@ read-only until startup establishes a stable write identity.
 ## A repository feature stays unavailable
 
 When a provider definitively reports that issues or pull requests are disabled,
-kenn-forge cools that repository feature down for 24 hours instead of retrying a
+Kenn Forge cools that repository feature down for 24 hours instead of retrying a
 permanent failure every sync. Other repository data continues syncing. Use an
 explicit repository sync after re-enabling the feature to bypass the cooldown
 and clear it on success.
 
 ## An issue workspace directory already exists
 
-If an issue workspace row was lost but its expected kenn-forge worktree is still
+If an issue workspace row was lost but its expected Kenn Forge worktree is still
 on disk, choose **Use Existing Directory** in the branch-conflict dialog. This
-only re-registers the deterministic kenn-forge-managed directory after verifying
+only re-registers the deterministic Kenn Forge-managed directory after verifying
 its repository and branch. It does not reset the branch, clean files, or remove
 untracked work. Use **Use Existing Branch** only when the branch is not already
 checked out in that directory.
@@ -114,7 +113,7 @@ docs = true
 
 ## Kata mode has no daemons
 
-kenn-forge does not store Kata daemon definitions. Check Kata's own config:
+Kenn Forge does not store Kata daemon definitions. Check Kata's own config:
 
 ```text
 ~/.kata/config.toml
@@ -124,7 +123,7 @@ or set `KATA_HOME` before starting kenn-forge.
 
 ## The database will not migrate
 
-kenn-forge stores synced data in:
+Kenn Forge stores synced data in:
 
 ```text
 ~/.kenn/forge/forge.db
@@ -136,8 +135,8 @@ sidecars out of the data directory before starting again. Provider data will
 sync again from a fresh database, but local-only state such as stars, PR
 workflow statuses, and workspace links is only available in the saved copy.
 
-If startup reports that the database is newer than the binary, upgrade
-kenn-forge.
+If startup reports that the database is newer than the binary, upgrade Kenn
+Forge.
 
 ## Need more logs
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,161 +1,114 @@
 # Workflows
 
-## Daily triage
+## Scan recent activity
 
-Open **Activity** first. Use it to scan comments, reviews, commits, PRs, and
-issues across your configured repositories.
+Open **Activity** for the daily queue. Filter by time, event type, repository,
+item type, text, closed state, or bot activity.
 
-Useful filters:
+Threaded mode groups events by pull request or issue. Flat mode keeps exact
+event order. Select a row to open its detail without leaving the queue.
 
-- Time range: 24h, 7d, 30d, or 90d.
-- Event type: comments, reviews, commits, and state changes.
-- Repository and item type.
-- Hide closed items.
-- Hide bot activity.
-- Free-text search.
+Use **Sync current repository** when one repository needs fresh data. This
+avoids scheduling a global refresh.
 
-Threaded mode groups events by PR or issue. Flat mode is better when exact event
-order matters.
+## Follow a role-based guide
 
-## Role-based walkthroughs
+- [Triage an issue](workflows/issue-triager.md)
+- [Review a pull request](workflows/code-reviewer.md)
 
-- [I am an issue triager](workflows/issue-triager.md): start with the newest
-  issue activity, decide what needs attention, and create a workspace when work
-  is ready.
-- [I am a code reviewer](workflows/code-reviewer.md): start with the newest PR
-  review context, check CI and discussion, and open a local worktree when review
-  needs hands-on verification.
+## Move quickly
 
-## Move around the UI
+Use the sidebar for modes and the repository selector for scope. Open the
+command palette with `Cmd/Ctrl+K` or `Cmd/Ctrl+P`. Use `Cmd/Ctrl+Shift+K`
+while a terminal has focus.
 
-Use the sidebar to switch between modes. Open the command palette with
-`Cmd/Ctrl+K` or `Cmd/Ctrl+P` when you know the action or destination but do not
-want to hunt through the page. Use `Cmd/Ctrl+Shift+K` while a terminal has
-focus. Prefix a search with `>` for commands, `pr:` for pull requests, or
-`issue:` for issues. Press `?` to see the shortcuts available in the current
-view.
+Palette prefixes narrow results:
 
-The UI supports repeated keyboard triage. List movement, detail panes, drawer
-closing, mode switching, and search stay inside the console flow.
+- `>` for commands
+- `pr:` for pull requests
+- `issue:` for issues
 
-The repository selector filters every provider-qualified repository in the
-current mode. Use **Sync current repository** when you need fresh data for the
-selected item without scheduling a global refresh.
+Press `?` for shortcuts in the current view.
 
 ## Review and merge
 
-Open **Pulls** to work through PRs and MRs.
+Open **Pulls**, then select an item. The detail view combines description,
+discussion, CI, branch state, review state, changed files, and provider
+actions.
 
-From the detail view you can:
+Use the **View** menu to filter the timeline or compact rows. Open the file
+tree for line-by-line review. Comment, approve, mark ready, close, reopen, or
+merge when the provider and credential allow it.
 
-- Read the description and discussion.
-- Inspect changed files and inline diffs.
-- Use the shared **View** menu to filter the timeline or switch compact rows,
-  and copy provider links for individual comments.
-- Edit or delete your own comments where the provider supports it.
-- Check CI and branch status.
-- Comment.
-- Approve where supported.
-- Mark drafts ready where supported.
-- Close, reopen, or merge where supported.
-- Star items for quick follow-up.
+Unsupported actions remain visible but unavailable.
 
-Provider-specific differences are shown as disabled or unavailable actions
-rather than hidden GitHub-only behavior.
+Detected stacks show member order. Mid-stack merges stay blocked by default
+until earlier members land.
 
-When kenn-forge detects a stacked PR series, the detail view shows its members
-and ordering. GitHub native stack data can improve detection when enabled, but
-the same UI and branch-based fallback remain authoritative. Merging a middle
-member is blocked by default until earlier members land.
+The conversation, files, and workspace can share a pane layout. Reorder,
+split, resize, hide, or maximize panes as the task changes.
 
-Conversation, files, and an open workspace share a rearrangeable pane layout.
-Drag tabs to reorder or split them, resize the resulting panes, hide or maximize
-panes, and reopen them from the tab strip or command palette. Long PR and issue
-descriptions start expanded and can be collapsed when they crowd the working
-area.
+## Track local pull-request state
 
-## Track local PR state
+Set a workflow status from the pull-request detail and filter the list by one
+or more statuses. This status stays in Kenn Forge. It does not change provider
+labels, milestones, projects, or fields.
 
-Set a PR's workflow status from its detail view, and filter the PR list by one
-or more statuses. Workflow status is stored in kenn-forge and does not write
-provider labels, milestones, projects, or fields.
+## Work with issues
 
-## Work issues
+Open **Issues** to search, filter, comment, star, close, or reopen issues.
+Create a workspace when an issue is ready for implementation.
 
-Open **Issues** to search, filter, comment, close, reopen, and star issues.
+## Browse repository source
 
-When workspaces are configured, an issue can become a local work session. You
-can move from triage to implementation without hunting for the repository.
-
-## Inspect repository source
-
-Use **Repos** to browse configured repositories, inspect summary metadata,
-switch branches, search paths, open source files, and follow references back to
-provider items. This is useful when a review or issue references code and you
-need quick context without opening the forge.
+Open **Repos** to inspect repository summaries, switch branches, search paths,
+and read source files. Provider links return to the original item when needed.
 
 ## Work in local sessions
 
-Use **Workspaces** to launch and attach to shell or agent sessions tied to local
-repositories. tmux-backed sessions let kenn-forge keep a durable attach point for
-ongoing work. The primary **Create Workspace** action creates only; choose an
-agent from its dropdown to create and launch immediately without another modal.
-The choice is per-creation, session-scoped intent, not a persistent default.
+Create a workspace from a pull request, issue, Kata task, or the **New
+workspace** action. A workspace creates a worktree. Choose an agent from the
+action menu to create and launch in one step.
 
-Once a workspace is ready, launch another session from its header. A session can
-stay in the workspace controls or be promoted into the detail pane layout and
-moved beside the conversation or files without opening a second terminal
-connection.
+New workspaces can start from any tracked repository. Choose a branch name or
+let Kenn Forge create one from the default branch.
 
-New work does not need an existing pull request, issue, or Kata task. Use **New
-workspace** in the Workspaces sidebar, or the same command in the palette
-(Cmd/Ctrl+K), to pick a tracked repository and start a fresh worktree. The
-picker preselects the repository you last started work in. Name the
-branch or leave it empty and kenn-forge generates one; either way the worktree
-branches from the repository's default branch.
+Workspaces use tmux-backed sessions for durable attachment. Launch more shells
+or agents from the workspace header. Promote a session into the detail layout
+when you want it beside discussion or files.
 
-Run or rerun `kenn-forge agent-hook install` to show activity from Claude Code,
-Codex, GitHub Copilot CLI, Cursor, Factory Droid, Gemini CLI, Hermes Agent, and
-Qwen Code in workspace rows. The command installs all supported integrations by
-default; pass `--agent NAME` to install only one. The rows distinguish active
-work, approval requests, and user input, refreshing within five seconds while
-the sidebar is open. Reports expire after 30 minutes without another hook event
-and then fall back to tmux activity. Installed hooks forward lifecycle events
-to the running kenn-forge daemon. Claude sessions also receive a workspace
-summary regenerated from persisted workspace metadata at session start;
-`CLAUDE.local.md` is never read for it. Codex asks you to review the installed
-command through `/hooks` once.
+Install lifecycle hooks to show agent activity in workspace rows:
+
+```sh
+kenn-forge agent-hook install
+```
+
+Use `--agent NAME` to limit installation. Active work, approval requests, and
+input requests update while the sidebar is open. Hook reports expire after 30
+minutes without another event, then fall back to tmux activity.
 
 ## Use Kata tasks
 
-Enable Kata mode when your work is tracked in Kata. kenn-forge discovers Kata
-daemons from Kata's own config and runtime records. You can browse tasks, open
-details, update task state, and cross-link task references from Docs when the
-source contains them.
+Enable Kata mode to work with daemons listed in Kata's own config and runtime
+records. Filter tasks by project, status, text, columns, and links. Open the
+dependency graph or create a workspace when a task resolves to one registered
+repository.
 
-Use project scope, the **Open**, **Ready**, **Closed**, and **All** status
-filters, text search, optional columns, and link filters to narrow the task
-tree. Parent and child tasks stay together while you expand the hierarchy. Open
-the reachable-task graph when dependencies matter, or create a workspace when a
-task resolves to exactly one registered repository. Configure project-to-repo
-mappings when Kata cannot infer that repository unambiguously. Kata task data
-stays in Kata; kenn-forge is the console.
+Kata remains the source of truth for task data.
 
-## Browse and edit docs
+## Browse and edit Docs
 
-Enable Docs mode and register markdown folders. Use it to browse, search, read,
-edit, pull, and publish local docs from the same console you use for code review.
-Folder trees show markdown changes, and task references can open the matching
-Kata task using the folder's configured daemon binding.
+Enable Docs mode and register Markdown folders. Browse, search, read, edit,
+pull, and publish files from the console. Task references can open a Kata task
+through the folder's daemon binding.
 
-Docs files stay on disk. kenn-forge only operates inside the configured folders.
+Files remain on disk inside the configured folders.
 
 ## Use a fleet
 
-Fleet mode lets one kenn-forge daemon view snapshots from other kenn-forge
-daemons. The hub can route supported mutations back to the machine that owns the
-resource and can expose attach commands for remote sessions.
+A hub can combine snapshots from other Kenn Forge daemons. Supported actions
+route back to the machine that owns the resource. Sessions expose local or
+remote attach commands.
 
-Use HTTP peers for reachable daemons or SSH peers when the remote listener
-should stay private. See [Federated fleet](federated-fleet.md) for the full
-fleet shape.
+Use HTTP on a trusted private network. Use SSH when the peer should not expose
+its listener. See [Federated fleet](federated-fleet.md).

--- a/docs/workflows/code-reviewer.md
+++ b/docs/workflows/code-reviewer.md
@@ -26,8 +26,24 @@ Select an item to open its description, timeline, actions, and diff.
 
 Unsupported actions remain visible but unavailable.
 
-## Verify locally
+## Move from review into a coding agent
 
-Choose **Create Workspace** when the review needs local verification or
-follow-up changes. Kenn Forge creates a worktree for the pull-request head.
-Run a shell or configured agent, then return to the review.
+Open **Create Workspace** and choose a configured agent such as Codex. Kenn
+Forge automatically creates and tracks a Git worktree for the pull-request
+branch, then launches the agent there. You do not need to run
+`git worktree add` or manage a separate checkout.
+
+<figure class="workflow-shot">
+  <img class="workflow-shot__image workflow-shot__image--light" src="../assets/generated/code-reviewer-agent-launch-light.svg" alt="Kenn Forge pull-request detail with the Create Workspace menu open to Codex in light mode">
+  <img class="workflow-shot__image workflow-shot__image--dark" src="../assets/generated/code-reviewer-agent-launch-dark.svg" alt="Kenn Forge pull-request detail with the Create Workspace menu open to Codex in dark mode">
+  <figcaption>Create the review worktree and launch Codex from the pull-request view.</figcaption>
+</figure>
+
+**Workspaces** keeps the branch, session, and review links together. Return to
+the pull request after local verification or follow-up changes.
+
+<figure class="workflow-shot">
+  <img class="workflow-shot__image workflow-shot__image--light" src="../assets/generated/workspace-codex-session-light.svg" alt="Kenn Forge Workspaces view with a pull-request worktree and running Codex session in light mode">
+  <img class="workflow-shot__image workflow-shot__image--dark" src="../assets/generated/workspace-codex-session-dark.svg" alt="Kenn Forge Workspaces view with a pull-request worktree and running Codex session in dark mode">
+  <figcaption>Workspaces tracks the pull-request branch and its running Codex session.</figcaption>
+</figure>

--- a/docs/workflows/code-reviewer.md
+++ b/docs/workflows/code-reviewer.md
@@ -1,43 +1,33 @@
 # I am a code reviewer
 
-Use kenn-forge to review the newest PR context, check whether the branch is
-ready, and move into local follow-up work when needed.
+Review the newest pull-request context, decide whether the branch is ready,
+and open local follow-up work when needed.
 
 <figure class="workflow-shot">
-  <img class="workflow-shot__image workflow-shot__image--light" src="../assets/generated/code-reviewer-light.svg" alt="kenn-forge code review view in light mode">
-  <img class="workflow-shot__image workflow-shot__image--dark" src="../assets/generated/code-reviewer-dark.svg" alt="kenn-forge code review view in dark mode">
-  <figcaption>PR detail brings together review status, CI context, discussion, files, and workspace creation.</figcaption>
+  <img class="workflow-shot__image workflow-shot__image--light" src="../assets/generated/code-reviewer-light.svg" alt="Kenn Forge pull-request detail in light mode">
+  <img class="workflow-shot__image workflow-shot__image--dark" src="../assets/generated/code-reviewer-dark.svg" alt="Kenn Forge pull-request detail in dark mode">
+  <figcaption>Review status, CI, discussion, files, and workspace actions share one view.</figcaption>
 </figure>
 
-## Review from newest context
+## Scan the queue
 
-Start in **Activity**. The newest PR comments, reviews, and state changes appear
-first, so changed reviews surface quickly.
+Start in **Activity** to find new comments, reviews, and state changes. Open
+**Pulls** for the review queue.
 
-Switch to **Pulls** for the review queue. The list keeps PR state, review
-decision, CI signal, branch information, and repository context visible. The
-detail pane holds the description, timeline, actions, and diff entry points.
+The list shows review state, CI, branch information, and repository context.
+Select an item to open its description, timeline, actions, and diff.
 
 ## Work the review
 
-For each PR:
-
-- Open the most recently active item first.
-- Check review state and CI before spending time in the diff.
+- Check review state and CI.
 - Read the description and latest discussion.
-- Use the diff and file tree for line-by-line review.
-- Comment, approve, mark ready, close, reopen, or merge when the provider and
-  token support that action.
+- Inspect the diff and file tree.
+- Comment, approve, mark ready, close, reopen, or merge when supported.
 
-Unsupported provider actions are shown as unavailable instead of pretending every
-forge behaves like GitHub.
+Unsupported actions remain visible but unavailable.
 
-## Drop into a workspace
+## Verify locally
 
-When a review needs local verification or follow-up changes, use **Create
-Workspace** from the PR detail pane. kenn-forge creates a worktree for the PR head
-and opens the workspace surface. You can run a shell or configured agent without
-finding the repo, branch, or clone path by hand.
-
-Read the newest context, inspect the branch, open a workspace, then return to
-the PR action surface.
+Choose **Create Workspace** when the review needs local verification or
+follow-up changes. Kenn Forge creates a worktree for the pull-request head.
+Run a shell or configured agent, then return to the review.

--- a/docs/workflows/issue-triager.md
+++ b/docs/workflows/issue-triager.md
@@ -1,39 +1,32 @@
 # I am an issue triager
 
-Use kenn-forge to decide which issue needs attention next. You do not need to
-read every issue in arrival order.
+Find the issue that needs attention now. Recent activity matters more than
+arrival order.
 
 <figure class="workflow-shot">
-  <img class="workflow-shot__image workflow-shot__image--light" src="../assets/generated/issue-triager-light.svg" alt="kenn-forge issue triage view in light mode">
-  <img class="workflow-shot__image workflow-shot__image--dark" src="../assets/generated/issue-triager-dark.svg" alt="kenn-forge issue triage view in dark mode">
-  <figcaption>Issue detail, discussion, state, labels, and workspace creation stay in one view.</figcaption>
+  <img class="workflow-shot__image workflow-shot__image--light" src="../assets/generated/issue-triager-light.svg" alt="Kenn Forge issue detail in light mode">
+  <img class="workflow-shot__image workflow-shot__image--dark" src="../assets/generated/issue-triager-dark.svg" alt="Kenn Forge issue detail in dark mode">
+  <figcaption>Review issue context, state, labels, and workspace actions in one view.</figcaption>
 </figure>
 
-## Triage from newest context
+## Scan the queue
 
-Start in **Activity** for the broad queue. The newest comments, reviews, and
-state changes appear first, so recent movement comes before older background.
-Filter to **Issues** when you only want issue work. Hide closed items or bot
-activity as needed.
+Start in **Activity**. Filter to issues, then hide closed items or bot activity
+when they add noise.
 
-Switch to **Issues** for a focused list. Open an issue to review its title,
-body, labels, assignees, comments, and state without leaving the console.
+Open **Issues** for a focused list. Select an issue to read its title, body,
+labels, assignees, comments, and state.
 
 ## Decide the next action
 
-For each issue:
-
-- Read the newest activity before older context.
+- Read the newest activity first.
 - Check labels and assignees.
 - Comment when you need more information.
-- Close or reopen when the provider supports it and your token allows it.
-- Star issues that need a second pass.
+- Close or reopen when the provider and credential allow it.
+- Star work that needs another pass.
 
-## Drop into a workspace
+## Start implementation
 
-When an issue is ready for implementation, use **Create Workspace** from the
-issue detail pane. kenn-forge creates a local worktree for the issue branch and
-sends you to **Workspaces**, where you can launch shells or configured agents on
-that branch.
-
-Triage the issue, create the workspace, and start work from the same console.
+Choose **Create Workspace** from the issue detail. Kenn Forge creates a local
+worktree and opens **Workspaces**. Start a shell or configured agent on that
+branch.

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -30,6 +30,7 @@ nav = [
 homepage = "/"
 
 [project.theme]
+custom_dir = "docs/overrides"
 variant = "modern"
 features = [
   "navigation.instant",
@@ -41,16 +42,25 @@ features = [
 ]
 
 [[project.theme.palette]]
+media = "(prefers-color-scheme)"
+scheme = "default"
+primary = "custom"
+accent = "custom"
+toggle = { icon = "material/brightness-auto", name = "Switch to light mode" }
+
+[[project.theme.palette]]
+media = "(prefers-color-scheme: light)"
 scheme = "default"
 primary = "custom"
 accent = "custom"
 toggle = { icon = "material/weather-night", name = "Switch to dark mode" }
 
 [[project.theme.palette]]
+media = "(prefers-color-scheme: dark)"
 scheme = "slate"
 primary = "custom"
 accent = "custom"
-toggle = { icon = "material/weather-sunny", name = "Switch to light mode" }
+toggle = { icon = "material/brightness-auto", name = "Use system theme" }
 
 [project.theme.icon]
 repo = "fontawesome/brands/github"

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -5,8 +5,8 @@ site_author = "Kenn Software LLC"
 copyright = 'Copyright &copy; 2026 <a href="https://kenn.io">Kenn Software LLC</a>. Elastic License 2.0.'
 docs_dir = "docs"
 site_dir = "site"
-repo_url = "https://github.com/kenn-io/middleman"
-repo_name = "kenn-io/middleman"
+repo_url = "https://github.com/kenn-io/forge"
+repo_name = "kenn-io/forge"
 extra_css = ["stylesheets/extra.css"]
 use_directory_urls = true
 nav = [

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -19,7 +19,9 @@ nav = [
   ]},
   {"Configuration" = "configuration.md"},
   {"Commands" = "commands.md"},
-  {"Fleet" = "federated-fleet.md"},
+  {"Advanced / experimental" = [
+    {"Fleet" = "federated-fleet.md"},
+  ]},
   {"Archive" = "archive.md"},
   {"Troubleshooting" = "troubleshooting.md"},
 ]

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -10,6 +10,7 @@ repo_name = "kenn-io/middleman"
 extra_css = ["stylesheets/extra.css"]
 use_directory_urls = true
 nav = [
+  {"Overview" = "index.md"},
   {"Quick Start" = "quickstart.md"},
   {"Workflows" = [
     {"Overview" = "workflows.md"},

--- a/scripts/build-docs.mjs
+++ b/scripts/build-docs.mjs
@@ -14,13 +14,14 @@ const publishedFiles = new Set([
   "federated-fleet.md",
   "index.md",
   "quickstart.md",
+  path.join("overrides", "main.html"),
   path.join("stylesheets", "extra.css"),
   "troubleshooting.md",
   path.join("workflows", "code-reviewer.md"),
   path.join("workflows", "issue-triager.md"),
   "workflows.md",
 ]);
-const publishedDirectoryEntries = new Set(["stylesheets", "workflows"]);
+const publishedDirectoryEntries = new Set(["overrides", "stylesheets", "workflows"]);
 
 function isPublishedDocsInput(sourceDir, candidate) {
   const relative = path.relative(sourceDir, candidate);

--- a/scripts/build-docs.mjs
+++ b/scripts/build-docs.mjs
@@ -7,16 +7,31 @@ import { fileURLToPath } from "node:url";
 const scriptPath = fileURLToPath(import.meta.url);
 const repoRoot = path.resolve(path.dirname(scriptPath), "..");
 
-function isGeneratedAsset(sourceDir, candidate) {
+const publishedFiles = new Set([
+  "archive.md",
+  "commands.md",
+  "configuration.md",
+  "federated-fleet.md",
+  "index.md",
+  "quickstart.md",
+  path.join("stylesheets", "extra.css"),
+  "troubleshooting.md",
+  path.join("workflows", "code-reviewer.md"),
+  path.join("workflows", "issue-triager.md"),
+  "workflows.md",
+]);
+const publishedDirectoryEntries = new Set(["stylesheets", "workflows"]);
+
+function isPublishedDocsInput(sourceDir, candidate) {
   const relative = path.relative(sourceDir, candidate);
-  const generatedDir = path.join("assets", "generated");
-  return relative === generatedDir || relative.startsWith(`${generatedDir}${path.sep}`);
+  if (relative === "") return true;
+  return publishedFiles.has(relative) || publishedDirectoryEntries.has(relative);
 }
 
 export async function stageDocsSource(sourceDir, destinationDir) {
   await cp(sourceDir, destinationDir, {
     recursive: true,
-    filter: (candidate) => !isGeneratedAsset(sourceDir, candidate) && path.basename(candidate) !== "zensical.toml",
+    filter: (candidate) => isPublishedDocsInput(sourceDir, candidate),
   });
 }
 
@@ -71,6 +86,28 @@ export async function buildDocs() {
     );
 
     await run("uvx", ["zensical", "build"], { cwd: stagingRoot, env: process.env });
+    await run(
+      process.execPath,
+      [
+        path.join(repoRoot, "node_modules", "vite-plus", "bin", "vp"),
+        "exec",
+        "--",
+        "playwright",
+        "test",
+        "--config",
+        path.join(repoRoot, "docs", "site", "playwright.config.ts"),
+        "--project=chromium",
+        "--output",
+        path.join(stagingRoot, "site-test-results"),
+      ],
+      {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          KENN_FORGE_DOCS_SITE_DIR: path.join(stagingRoot, "site"),
+        },
+      },
+    );
 
     await rm(siteDir, { recursive: true, force: true });
     await cp(path.join(stagingRoot, "site"), siteDir, { recursive: true });

--- a/scripts/build-docs.test.mjs
+++ b/scripts/build-docs.test.mjs
@@ -6,20 +6,45 @@ import { test } from "node:test";
 
 import { stageDocsSource } from "./build-docs.mjs";
 
-test("docs staging excludes previously generated screenshots", async (t) => {
+test("docs staging includes only public site inputs", async (t) => {
   const root = await mkdtemp(path.join(os.tmpdir(), "kenn-forge-docs-build-test-"));
   t.after(() => rm(root, { recursive: true, force: true }));
 
   const source = path.join(root, "source");
   const staged = path.join(root, "staged");
+  await mkdir(path.join(source, "stylesheets"), { recursive: true });
+  await mkdir(path.join(source, "workflows"), { recursive: true });
   await mkdir(path.join(source, "assets", "generated"), { recursive: true });
+  await mkdir(path.join(source, "superpowers", "plans"), { recursive: true });
+  await mkdir(path.join(source, "adr"), { recursive: true });
+  await mkdir(path.join(source, "reports"), { recursive: true });
+  await mkdir(path.join(source, "screenshots"), { recursive: true });
   await writeFile(path.join(source, "index.md"), "# Docs\n");
+  await writeFile(path.join(source, "workflows", "code-reviewer.md"), "# Reviewer\n");
+  await writeFile(path.join(source, "stylesheets", "extra.css"), ":root {}\n");
   await writeFile(path.join(source, "assets", "generated", "stale.svg"), "<svg />\n");
+  await writeFile(path.join(source, "superpowers", "plans", "private.md"), "# Private\n");
+  await writeFile(path.join(source, "adr", "0001-private.md"), "# Private\n");
+  await writeFile(path.join(source, "reports", "private.md"), "# Private\n");
+  await writeFile(path.join(source, "screenshots", "README.md"), "# Build only\n");
+  await writeFile(path.join(source, "workflows", "internal.md"), "# Private\n");
+  await writeFile(path.join(source, "stylesheets", "internal.css"), ":root {}\n");
 
   await stageDocsSource(source, staged);
 
   assert.equal(await readFile(path.join(staged, "index.md"), "utf8"), "# Docs\n");
-  await assert.rejects(readFile(path.join(staged, "assets", "generated", "stale.svg"), "utf8"), {
-    code: "ENOENT",
-  });
+  assert.equal(await readFile(path.join(staged, "workflows", "code-reviewer.md"), "utf8"), "# Reviewer\n");
+  assert.equal(await readFile(path.join(staged, "stylesheets", "extra.css"), "utf8"), ":root {}\n");
+
+  for (const internalPath of [
+    "assets/generated/stale.svg",
+    "superpowers/plans/private.md",
+    "adr/0001-private.md",
+    "reports/private.md",
+    "screenshots/README.md",
+    "workflows/internal.md",
+    "stylesheets/internal.css",
+  ]) {
+    await assert.rejects(readFile(path.join(staged, internalPath), "utf8"), { code: "ENOENT" });
+  }
 });

--- a/scripts/build-docs.test.mjs
+++ b/scripts/build-docs.test.mjs
@@ -14,6 +14,7 @@ test("docs staging includes only public site inputs", async (t) => {
   const staged = path.join(root, "staged");
   await mkdir(path.join(source, "stylesheets"), { recursive: true });
   await mkdir(path.join(source, "workflows"), { recursive: true });
+  await mkdir(path.join(source, "overrides"), { recursive: true });
   await mkdir(path.join(source, "assets", "generated"), { recursive: true });
   await mkdir(path.join(source, "superpowers", "plans"), { recursive: true });
   await mkdir(path.join(source, "adr"), { recursive: true });
@@ -22,6 +23,8 @@ test("docs staging includes only public site inputs", async (t) => {
   await writeFile(path.join(source, "index.md"), "# Docs\n");
   await writeFile(path.join(source, "workflows", "code-reviewer.md"), "# Reviewer\n");
   await writeFile(path.join(source, "stylesheets", "extra.css"), ":root {}\n");
+  await writeFile(path.join(source, "overrides", "main.html"), "<script>palette</script>\n");
+  await writeFile(path.join(source, "overrides", "internal.html"), "<script>private</script>\n");
   await writeFile(path.join(source, "assets", "generated", "stale.svg"), "<svg />\n");
   await writeFile(path.join(source, "superpowers", "plans", "private.md"), "# Private\n");
   await writeFile(path.join(source, "adr", "0001-private.md"), "# Private\n");
@@ -35,6 +38,10 @@ test("docs staging includes only public site inputs", async (t) => {
   assert.equal(await readFile(path.join(staged, "index.md"), "utf8"), "# Docs\n");
   assert.equal(await readFile(path.join(staged, "workflows", "code-reviewer.md"), "utf8"), "# Reviewer\n");
   assert.equal(await readFile(path.join(staged, "stylesheets", "extra.css"), "utf8"), ":root {}\n");
+  assert.equal(
+    await readFile(path.join(staged, "overrides", "main.html"), "utf8"),
+    "<script>palette</script>\n",
+  );
 
   for (const internalPath of [
     "assets/generated/stale.svg",
@@ -44,6 +51,7 @@ test("docs staging includes only public site inputs", async (t) => {
     "screenshots/README.md",
     "workflows/internal.md",
     "stylesheets/internal.css",
+    "overrides/internal.html",
   ]) {
     await assert.rejects(readFile(path.join(staged, internalPath), "utf8"), { code: "ENOENT" });
   }


### PR DESCRIPTION
Stacked on #816.

- Reworks the public guide around setup and maintainer workflows, including a direct reviewer handoff into Codex and automatically managed Git worktrees.
- Regenerates workflow SVGs from isolated synthetic data and adds reviewer launch and workspace session views.
- Keeps internal plans, specs, ADRs, reports, and screenshot tooling out of Zensical while checking stable branding and canonical Forge links.

<sup>generated by a clanker</sup>