### PR TITLE
fix: cap race-job fan-out so e2e servers start before their deadline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,6 +349,12 @@ jobs:
   race:
     name: go test -race
     runs-on: ${{ github.repository == 'kenn-io/forge' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
+    # Cap package fan-out like test_go, but lower: the race detector multiplies
+    # CPU and memory per package, and unbounded fan-out starves servers that
+    # tests boot with their own startup deadlines.
+    env:
+      GOMAXPROCS: ${{ github.repository == 'kenn-io/forge' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && '4' || '2' }}
+      GOFLAGS: ${{ github.repository == 'kenn-io/forge' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && '-p=4' || '-p=2' }}
     needs: detect_changes
     if: needs.detect_changes.outputs.backend == 'true'
     steps:


### PR DESCRIPTION
The race-detector job intermittently misses the 30-second deadline while `cmd/e2e-server` waits for its server-info file. Repeated failures at the same deadline are consistent with runner contention, so this change limits the race job's fan-out instead of weakening the test timeout.

- Set `GOMAXPROCS=4` and `GOFLAGS=-p=4` on the managed runner. This follows the regular Go test job's resource policy, with lower package concurrency for the added cost of `-race`.
- Use `GOMAXPROCS=2` and `GOFLAGS=-p=2` on the hosted-runner fallback, matching the regular test job there.
- Limit only CI scheduling. The tests and application behavior are unchanged, and the 30-second startup deadline remains available to catch a genuinely slow or broken server.
- The recurring examples are [30781313857](https://github.com/kenn-io/forge/actions/runs/30781313857), [30775706089](https://github.com/kenn-io/forge/actions/runs/30775706089), and [30744831652](https://github.com/kenn-io/forge/actions/runs/30744831652).