### PR TITLE
Fix terminal click jitter overwriting the clipboard

### DIFF
--- a/context/workspace-runtime-lifecycle.md
+++ b/context/workspace-runtime-lifecycle.md
@@ -139,9 +139,9 @@ stale tabs.
   or window focus/visibility loss; pointerdown capture closes the race before a competing browser copy starts, and
   revocation also stops in-flight browser-to-loopback fallback chains before their next stage
   (`frontend/src/lib/components/terminal/XtermTerminalPane.svelte::handleDocumentPointerDown`).
-- Terminal pointerdown only prepares clipboard access; selection intent requires movement of roughly one rendered
-  terminal cell rather than a fixed CSS-pixel threshold, so physical focus-click jitter expires without reaching
-  browser or loopback clipboard fallbacks.
+- Terminal pointerdown only prepares clipboard access; selection intent requires both a four-CSS-pixel dead zone and
+  movement of roughly one rendered terminal cell, so physical focus-click jitter expires without reaching browser or
+  loopback clipboard fallbacks even at the smallest supported terminal geometry.
   Confirmed captured drags retain authority only through internal or destinationless focus movement while the pane stays
   active; their watchdog also releases browser capture, so a missing release cannot shield later focus loss
   (`frontend/src/lib/components/terminal/XtermTerminalPane.svelte::hasPointerSelectionIntent`).

--- a/context/workspace-runtime-lifecycle.md
+++ b/context/workspace-runtime-lifecycle.md
@@ -141,7 +141,7 @@ stale tabs.
   (`frontend/src/lib/components/terminal/XtermTerminalPane.svelte::handleDocumentPointerDown`).
 - Terminal pointerdown only prepares clipboard access; selection intent requires both a four-CSS-pixel dead zone and
   movement of roughly one rendered terminal cell, so physical focus-click jitter expires without reaching browser or
-  loopback clipboard fallbacks even at the smallest supported terminal geometry.
+  loopback clipboard fallbacks at readable terminal geometry without suppressing deliberate drags.
   Confirmed captured drags retain authority only through internal or destinationless focus movement while the pane stays
   active; their watchdog also releases browser capture, so a missing release cannot shield later focus loss
   (`frontend/src/lib/components/terminal/XtermTerminalPane.svelte::hasPointerSelectionIntent`).

--- a/context/workspace-runtime-lifecycle.md
+++ b/context/workspace-runtime-lifecycle.md
@@ -139,11 +139,12 @@ stale tabs.
   or window focus/visibility loss; pointerdown capture closes the race before a competing browser copy starts, and
   revocation also stops in-flight browser-to-loopback fallback chains before their next stage
   (`frontend/src/lib/components/terminal/XtermTerminalPane.svelte::handleDocumentPointerDown`).
-- Terminal pointerdown only prepares clipboard access; movement of at least four CSS pixels confirms selection intent,
-  while a zero-motion or sub-threshold focus click expires without reaching browser or loopback clipboard fallbacks.
+- Terminal pointerdown only prepares clipboard access; selection intent requires movement of roughly one rendered
+  terminal cell rather than a fixed CSS-pixel threshold, so physical focus-click jitter expires without reaching
+  browser or loopback clipboard fallbacks.
   Confirmed captured drags retain authority only through internal or destinationless focus movement while the pane stays
   active; their watchdog also releases browser capture, so a missing release cannot shield later focus loss
-  (`frontend/src/lib/components/terminal/terminalClipboardWriter.ts::confirmPointerSelection`).
+  (`frontend/src/lib/components/terminal/XtermTerminalPane.svelte::hasPointerSelectionIntent`).
 - Host clipboard writes require a local browser; trusted loopback proxies must report exactly one client IP assigned
   to the host, because the proxy's loopback `RemoteAddr` alone does not establish browser locality
   (`internal/server/terminal_clipboard_access.go::isLocalTerminalClipboardRequest`).

--- a/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
@@ -129,7 +129,6 @@
   const TERMINAL_MINIMUM_CONTRAST_RATIO = 4.5;
   const TERMINAL_FONT_WAIT_MS = 300;
   const TERMINAL_FONT_LOAD_GLYPHS = "0MWim@#";
-  const POINTER_SELECTION_INTENT_PX = 4;
   const TERMINAL_SEQUENCE_CANCEL = new Uint8Array([0x18]);
 
   function isAttachableInitialStatus(status: string | undefined): boolean {
@@ -293,15 +292,21 @@
     clipboardWriter.authorizeKeyboardGesture();
   }
 
+  function hasPointerSelectionIntent(event: PointerEvent): boolean {
+    if (pointerOrigin === null) return false;
+    const cell = containerEl.querySelector<HTMLElement>(".xterm-helper-textarea")?.getBoundingClientRect();
+    if (!cell || cell.width <= 0 || cell.height <= 0) return false;
+
+    const columnsMoved = (event.clientX - pointerOrigin.clientX) / cell.width;
+    const rowsMoved = (event.clientY - pointerOrigin.clientY) / cell.height;
+    return columnsMoved * columnsMoved + rowsMoved * rowsMoved >= 1;
+  }
+
   function handleWindowPointerMove(event: PointerEvent): void {
     if (disposed || disabled || !terminal) return;
-    if (activePointerId === event.pointerId && pointerOrigin !== null) {
-      const deltaX = event.clientX - pointerOrigin.clientX;
-      const deltaY = event.clientY - pointerOrigin.clientY;
-      if (deltaX * deltaX + deltaY * deltaY >= POINTER_SELECTION_INTENT_PX ** 2) {
-        clipboardWriter.confirmPointerSelection();
-        pointerOrigin = null;
-      }
+    if (activePointerId === event.pointerId && hasPointerSelectionIntent(event)) {
+      clipboardWriter.confirmPointerSelection();
+      pointerOrigin = null;
     }
     const screen = containerEl.querySelector<HTMLElement>(".xterm-screen");
     const bounds = (screen ?? containerEl).getBoundingClientRect();

--- a/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
@@ -130,6 +130,7 @@
   const TERMINAL_FONT_WAIT_MS = 300;
   const TERMINAL_FONT_LOAD_GLYPHS = "0MWim@#";
   const TERMINAL_SEQUENCE_CANCEL = new Uint8Array([0x18]);
+  const POINTER_SELECTION_INTENT_MIN_PX = 4;
 
   function isAttachableInitialStatus(status: string | undefined): boolean {
     return status === undefined || status === "running" || status === "starting";
@@ -297,9 +298,15 @@
     const cell = containerEl.querySelector<HTMLElement>(".xterm-helper-textarea")?.getBoundingClientRect();
     if (!cell || cell.width <= 0 || cell.height <= 0) return false;
 
-    const columnsMoved = (event.clientX - pointerOrigin.clientX) / cell.width;
-    const rowsMoved = (event.clientY - pointerOrigin.clientY) / cell.height;
-    return columnsMoved * columnsMoved + rowsMoved * rowsMoved >= 1;
+    const deltaX = event.clientX - pointerOrigin.clientX;
+    const deltaY = event.clientY - pointerOrigin.clientY;
+    const pixelsMovedSquared = deltaX * deltaX + deltaY * deltaY;
+    const columnsMoved = deltaX / cell.width;
+    const rowsMoved = deltaY / cell.height;
+    return (
+      pixelsMovedSquared >= POINTER_SELECTION_INTENT_MIN_PX ** 2 &&
+      columnsMoved * columnsMoved + rowsMoved * rowsMoved >= 1
+    );
   }
 
   function handleWindowPointerMove(event: PointerEvent): void {

--- a/frontend/tests/e2e-full/00-inline-workspace-continuity.spec.ts
+++ b/frontend/tests/e2e-full/00-inline-workspace-continuity.spec.ts
@@ -307,9 +307,7 @@ function tmuxClientTTY(server: IsolatedE2EServer, tmuxSession: string): string {
 }
 
 function tmuxClientPtyGeometries(server: IsolatedE2EServer): Array<{ rows: number; cols: number }> {
-  const clientTTYs = runE2ETmuxCommand(server, ["list-clients", "-F", "#{client_tty}"])
-    .split("\n")
-    .filter(Boolean);
+  const clientTTYs = runE2ETmuxCommand(server, ["list-clients", "-F", "#{client_tty}"]).split("\n").filter(Boolean);
   return clientTTYs.map((clientTTY) => {
     const fd = openSync(clientTTY, constants.O_RDONLY | constants.O_NOCTTY);
     try {
@@ -473,8 +471,7 @@ async function crossTerminalCellBoundary(container: Locator): Promise<void> {
         get(styleDeclaration, property) {
           if (property === "height") return previousHeight;
           if (property === "getPropertyValue") {
-            return (name: string) =>
-              name === "height" ? previousHeight : styleDeclaration.getPropertyValue(name);
+            return (name: string) => (name === "height" ? previousHeight : styleDeclaration.getPropertyValue(name));
           }
           const value = Reflect.get(styleDeclaration, property, styleDeclaration);
           return typeof value === "function" ? value.bind(styleDeclaration) : value;

--- a/frontend/tests/e2e-full/00-tmux-browser-clipboard.spec.ts
+++ b/frontend/tests/e2e-full/00-tmux-browser-clipboard.spec.ts
@@ -988,10 +988,7 @@ test("visible detail copy wins when focus leaves a pointer-captured terminal", a
   }
 });
 
-test("PR comment copy survives terminal focus jitter at the smallest supported cell geometry", async ({
-  page,
-  browserName,
-}) => {
+test("PR comment copy survives 5px terminal focus jitter at default geometry", async ({ page, browserName }) => {
   test.skip(!hasCommand("git") || !hasCommand("tmux", ["-V"]), "git and tmux are required for the real workspace flow");
   let fallbackWrites: string[] = [];
   if (browserName === "chromium") {
@@ -1005,21 +1002,6 @@ test("PR comment copy survives terminal focus jitter at the smallest supported c
   try {
     isolatedServer = await startIsolatedWorkspaceE2EServer();
     api = await playwrightRequest.newContext({ baseURL: isolatedServer.info.base_url });
-    const settingsResponse = await api.get("/api/v1/settings");
-    expect(settingsResponse.ok()).toBe(true);
-    const settings = (await settingsResponse.json()) as {
-      terminal: Record<string, unknown>;
-    };
-    const saveSettingsResponse = await api.put("/api/v1/settings", {
-      data: {
-        terminal: {
-          ...settings.terminal,
-          font_size: 8,
-          letter_spacing: -2,
-        },
-      },
-    });
-    expect(saveSettingsResponse.ok()).toBe(true);
     const { output, terminal } = await openPullDetailWithPromotedTerminal(page, api, isolatedServer.info.base_url);
 
     await enableTmuxMouseAndRenderMarker(page, terminal, output, "focus click marker");
@@ -1042,9 +1024,8 @@ test("PR comment copy survives terminal focus jitter at the smallest supported c
     const cellWidth = await terminal
       .locator(".xterm-helper-textarea")
       .evaluate((element) => element.getBoundingClientRect().width);
-    const subFourPixelJitter = 3;
-    expect(cellWidth).toBeLessThan(subFourPixelJitter);
-    await clickTerminalWithPointerJitter(page, terminal, subFourPixelJitter);
+    expect(cellWidth).toBeGreaterThan(5);
+    await clickTerminalWithPointerJitter(page, terminal);
     await expect
       .poll(() => output.count("\x1b]52;"), { timeout: TERMINAL_OUTPUT_TIMEOUT_MS })
       .toBeGreaterThan(osc52Count);

--- a/frontend/tests/e2e-full/00-tmux-browser-clipboard.spec.ts
+++ b/frontend/tests/e2e-full/00-tmux-browser-clipboard.spec.ts
@@ -584,7 +584,7 @@ async function dragTerminalCells(page: Page, container: Locator, cellCount: numb
   await page.mouse.up();
 }
 
-async function jitterFirstTerminalCell(page: Page, container: Locator): Promise<void> {
+async function clickTerminalWithPointerJitter(page: Page, container: Locator): Promise<void> {
   const start = await container.evaluate((element) => {
     const screen = element.querySelector<HTMLElement>(".xterm-screen");
     const textarea = element.querySelector<HTMLElement>(".xterm-helper-textarea");
@@ -602,7 +602,8 @@ async function jitterFirstTerminalCell(page: Page, container: Locator): Promise<
 
   await page.mouse.move(start.x, start.y);
   await beginCapturedPointerGesture(page, container);
-  await page.mouse.move(start.x + 1, start.y);
+  // A physical focus click can slip a few pixels while the button is down.
+  await page.mouse.move(start.x + 5, start.y);
   await page.mouse.up();
 }
 
@@ -1020,7 +1021,7 @@ test("PR comment copy survives a terminal focus click", async ({ page, browserNa
     if (browserName === "firefox") await denyCurrentPageBrowserClipboardWrites(page);
 
     const osc52Count = output.count("\x1b]52;");
-    await jitterFirstTerminalCell(page, terminal);
+    await clickTerminalWithPointerJitter(page, terminal);
     await expect
       .poll(() => output.count("\x1b]52;"), { timeout: TERMINAL_OUTPUT_TIMEOUT_MS })
       .toBeGreaterThan(osc52Count);

--- a/frontend/tests/e2e-full/00-tmux-browser-clipboard.spec.ts
+++ b/frontend/tests/e2e-full/00-tmux-browser-clipboard.spec.ts
@@ -584,7 +584,7 @@ async function dragTerminalCells(page: Page, container: Locator, cellCount: numb
   await page.mouse.up();
 }
 
-async function clickTerminalWithPointerJitter(page: Page, container: Locator): Promise<void> {
+async function clickTerminalWithPointerJitter(page: Page, container: Locator, horizontalJitter = 5): Promise<void> {
   const start = await container.evaluate((element) => {
     const screen = element.querySelector<HTMLElement>(".xterm-screen");
     const textarea = element.querySelector<HTMLElement>(".xterm-helper-textarea");
@@ -603,7 +603,7 @@ async function clickTerminalWithPointerJitter(page: Page, container: Locator): P
   await page.mouse.move(start.x, start.y);
   await beginCapturedPointerGesture(page, container);
   // A physical focus click can slip a few pixels while the button is down.
-  await page.mouse.move(start.x + 5, start.y);
+  await page.mouse.move(start.x + horizontalJitter, start.y);
   await page.mouse.up();
 }
 
@@ -988,7 +988,10 @@ test("visible detail copy wins when focus leaves a pointer-captured terminal", a
   }
 });
 
-test("PR comment copy survives a terminal focus click", async ({ page, browserName }) => {
+test("PR comment copy survives terminal focus jitter at the smallest supported cell geometry", async ({
+  page,
+  browserName,
+}) => {
   test.skip(!hasCommand("git") || !hasCommand("tmux", ["-V"]), "git and tmux are required for the real workspace flow");
   let fallbackWrites: string[] = [];
   if (browserName === "chromium") {
@@ -1002,6 +1005,21 @@ test("PR comment copy survives a terminal focus click", async ({ page, browserNa
   try {
     isolatedServer = await startIsolatedWorkspaceE2EServer();
     api = await playwrightRequest.newContext({ baseURL: isolatedServer.info.base_url });
+    const settingsResponse = await api.get("/api/v1/settings");
+    expect(settingsResponse.ok()).toBe(true);
+    const settings = (await settingsResponse.json()) as {
+      terminal: Record<string, unknown>;
+    };
+    const saveSettingsResponse = await api.put("/api/v1/settings", {
+      data: {
+        terminal: {
+          ...settings.terminal,
+          font_size: 8,
+          letter_spacing: -2,
+        },
+      },
+    });
+    expect(saveSettingsResponse.ok()).toBe(true);
     const { output, terminal } = await openPullDetailWithPromotedTerminal(page, api, isolatedServer.info.base_url);
 
     await enableTmuxMouseAndRenderMarker(page, terminal, output, "focus click marker");
@@ -1021,7 +1039,12 @@ test("PR comment copy survives a terminal focus click", async ({ page, browserNa
     if (browserName === "firefox") await denyCurrentPageBrowserClipboardWrites(page);
 
     const osc52Count = output.count("\x1b]52;");
-    await clickTerminalWithPointerJitter(page, terminal);
+    const cellWidth = await terminal
+      .locator(".xterm-helper-textarea")
+      .evaluate((element) => element.getBoundingClientRect().width);
+    const subFourPixelJitter = 3;
+    expect(cellWidth).toBeLessThan(subFourPixelJitter);
+    await clickTerminalWithPointerJitter(page, terminal, subFourPixelJitter);
     await expect
       .poll(() => output.count("\x1b]52;"), { timeout: TERMINAL_OUTPUT_TIMEOUT_MS })
       .toBeGreaterThan(osc52Count);


### PR DESCRIPTION
Ordinary terminal focus clicks can slip five pixels. The previous four-pixel absolute threshold could treat that motion as a tmux selection and replace clipboard text copied from PR details.

Selection authorization now follows readable rendered cell geometry while preserving the four-pixel floor, so realistic focus jitter remains unauthorized and deliberate drag-copy still works.