### PR TITLE
fix: stabilize hosted Go CI fallbacks

### DIFF
--- a/context/testing.md
+++ b/context/testing.md
@@ -385,6 +385,7 @@ migration state, dirty database handling, or other internal invariants.
 - Prove pause by blocking provider I/O, pausing, then releasing and asserting no cursor or dataset commit. (`internal/archive/service_test.go::TestArchiveServicePauseRejectsInFlightInventoryCommit`)
 - Prove worker readiness, wake, and shutdown through the owning loop rather than direct service calls. (`internal/github/archive_lifecycle_test.go::TestArchiveWorkerAdvancesRealServiceAfterStart`)
 - Prove cross-ingestion child replacement with a newer dataset followed by an older complete replacement; parent-only races do not cover destructive child deletes. (`internal/github/sync_test.go::TestNormalSyncRejectsChildrenAfterArchivePublishesNewerSnapshot`)
+- Prove lock ownership with a `TryLock` probe while the owner is provably parked inside the guarded section; an event emitted before a blocking `Lock` call proves nothing, because the goroutine can be descheduled before acquiring. (`internal/workspace/localruntime/manager.go::CommandSessionStartLockHeldForTest`)
 
 ### Boundary-value contracts
 

--- a/context/workspace-runtime-lifecycle.md
+++ b/context/workspace-runtime-lifecycle.md
@@ -90,17 +90,19 @@ still exists.
   cleanup.
 - Removal of a created runtime backend is attempted when launch or persistence
   fails; it is best-effort, not retried, and a backend that survives a failed
-  compensation is unrecorded until startup reaping. Caller-keyed command ensure
-  uses one manager transaction, and per-worktree shell discovery uses one handler
-  transaction, through persistence and compensation so rollback authority cannot race adoption (`internal/workspace/localruntime/command_session.go::EnsureCommandSessionAndPersist`, `internal/server/workspaceapi/projects_handlers.go::Handler.ensureProjectWorktreeRuntimeShell`).
+  compensation is unrecorded until startup reaping. Reaping must protect stored
+  workspace, host, and project-worktree sessions while recognizing every owned
+  scope-derived tmux name (`internal/workspace/manager.go::ReapOrphanTmuxSessions`).
+  Caller-keyed command ensure uses one manager transaction, and per-worktree shell
+  discovery uses one handler transaction, through persistence and compensation so rollback authority cannot race adoption (`internal/workspace/localruntime/command_session.go::EnsureCommandSessionAndPersist`, `internal/server/workspaceapi/projects_handlers.go::Handler.ensureProjectWorktreeRuntimeShell`).
 - Persistence failures stay client-visible; compensation failures are logged.
   Ptyowner rollback needs a live owned entry, and tmux fallback cleanup must
   match the launch marker, which adoption rewrites so a stale creator rollback
   cannot kill an adopted backend (`internal/workspace/localruntime/manager.go::RollbackLaunch`).
-- A command can exit while its metadata write is still in flight, so command
-  launch handlers must reconcile after persistence: live means both key and
+- A runtime can exit while its metadata write is still in flight, so every
+  launch path must reconcile after persistence: live means both key and
   `CreatedAt` match, and a replacement must not suppress deletion of the exited
-  generation's row (`internal/server/host_runtime_handlers.go::forgetHostRuntimeCommandSessionIfExited`).
+  generation's row (`internal/server/host_runtime_handlers.go::Server.forgetHostRuntimeCommandSessionIfExited`, `internal/server/workspaceapi/projects_handlers.go::Handler.forgetProjectWorktreeRuntimeSessionIfExited`).
 - During kenn-forge shutdown, detach/restart behavior is different: do not treat
   normal server shutdown as a natural user exit that should erase recoverable
   base runtime state.

--- a/context/workspace-runtime-lifecycle.md
+++ b/context/workspace-runtime-lifecycle.md
@@ -88,6 +88,19 @@ still exists.
   gone state to be cleaned up, not as a reason to preserve stale runtime rows.
 - During explicit delete or stop flows, forgetting the persisted row is part of
   cleanup.
+- Removal of a created runtime backend is attempted when launch or persistence
+  fails; it is best-effort, not retried, and a backend that survives a failed
+  compensation is unrecorded until startup reaping. Caller-keyed command ensure
+  uses one manager transaction, and per-worktree shell discovery uses one handler
+  transaction, through persistence and compensation so rollback authority cannot race adoption (`internal/workspace/localruntime/command_session.go::EnsureCommandSessionAndPersist`, `internal/server/workspaceapi/projects_handlers.go::Handler.ensureProjectWorktreeRuntimeShell`).
+- Persistence failures stay client-visible; compensation failures are logged.
+  Ptyowner rollback needs a live owned entry, and tmux fallback cleanup must
+  match the launch marker, which adoption rewrites so a stale creator rollback
+  cannot kill an adopted backend (`internal/workspace/localruntime/manager.go::RollbackLaunch`).
+- A command can exit while its metadata write is still in flight, so command
+  launch handlers must reconcile after persistence: live means both key and
+  `CreatedAt` match, and a replacement must not suppress deletion of the exited
+  generation's row (`internal/server/host_runtime_handlers.go::forgetHostRuntimeCommandSessionIfExited`).
 - During kenn-forge shutdown, detach/restart behavior is different: do not treat
   normal server shutdown as a natural user exit that should erase recoverable
   base runtime state.

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -25060,6 +25060,62 @@ func TestWorkspaceRuntimePlainShellUsesPtyOwnerWhenTmuxUnavailableE2E(t *testing
 	)
 }
 
+func TestWorkspaceRuntimePtyOwnerPersistenceFailureRollsBackSessionE2E(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test fixture uses /bin/sh")
+	}
+	runParallelPTYE2E(t)
+
+	require := require.New(t)
+	assert := assert.New(t)
+	fixture, _, ptyOwnerDir := setupPtyOwnerWorkspaceFixture(t)
+	ctx := context.Background()
+	ws := createReadyWorkspace(t, ctx, fixture.client)
+	cleanupPtyOwnerWorkspace(t, ptyOwnerDir, ws.TmuxSession)
+
+	transaction := occupyRuntimeWriter(t, fixture.database)
+	baseline := fixture.database.WriteDB().Stats().WaitCount
+	requestCtx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	responses := serveRuntimeRequestAsync(
+		fixture.server,
+		requestCtx,
+		http.MethodPost,
+		"/api/v1/workspaces/"+ws.Id+"/runtime/sessions",
+		mustMarshal(t, map[string]any{
+			"target_key": string(localruntime.LaunchTargetPlainShell),
+		}),
+	)
+
+	var launched localruntime.SessionInfo
+	require.Eventually(func() bool {
+		sessions := fixture.server.workspaceAPI.RuntimeSnapshot(ws.Id)
+		if len(sessions) != 1 || sessions[0].TmuxSession != "" {
+			return false
+		}
+		launched = sessions[0]
+		return true
+	}, 2*time.Second, 20*time.Millisecond)
+	cleanupPtyOwnerWorkspace(t, ptyOwnerDir, launched.Key)
+	paths, err := ptyowner.NewSessionPaths(ptyOwnerDir, launched.Key)
+	require.NoError(err)
+	require.FileExists(paths.StatePath)
+	waitForRuntimeWriterWait(t, fixture.database, baseline)
+
+	cancel()
+	recorder := awaitRuntimeResponse(t, responses)
+	require.NoError(transaction.Rollback())
+
+	assert.Equal(http.StatusInternalServerError, recorder.Code)
+	assert.Contains(recorder.Body.String(), "record runtime session")
+	assert.Contains(recorder.Body.String(), "context canceled")
+	assert.NoFileExists(paths.StatePath)
+	assert.Empty(fixture.server.workspaceAPI.RuntimeSnapshot(ws.Id))
+	runtimeRows, err := fixture.database.ListWorkspaceRuntimeSessions(ctx, ws.Id)
+	require.NoError(err)
+	assert.Empty(runtimeRows)
+}
+
 func TestWorkspaceRuntimePtyOwnerShellReattachesAfterServerRestartE2E(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test fixture uses /bin/sh")
@@ -25551,6 +25607,9 @@ func buildRustPtyManagerForTest(t *testing.T) string {
 	cargo, err := exec.LookPath("cargo")
 	if err != nil {
 		t.Skip("cargo not available")
+	}
+	if err := procutil.Command(cargo, "--version").Run(); err != nil {
+		t.Skipf("cargo not usable: %v", err)
 	}
 	root := repoRootForTest(t)
 	cmd := procutil.Command(cargo, "build", "-p", "kenn-forge-pty-manager")
@@ -27461,6 +27520,10 @@ func TestWorkspaceRuntimePlainShellRecordFailureCleansCreatedTmuxShellE2E(t *tes
 	require := require.New(t)
 
 	tmuxPath := writeFakeWorkspaceRuntimeTmux(t)
+	attachGate := filepath.Join(t.TempDir(), "attach-gate")
+	require.NoError(os.WriteFile(attachGate, []byte("wait"), 0o600))
+	t.Setenv("KENN_FORGE_FAKE_TMUX_ATTACH_GATE", attachGate)
+	t.Setenv("KENN_FORGE_FAKE_TMUX_ATTACH_EXIT", "1")
 	cfg := &config.Config{
 		Tmux: config.Tmux{Command: []string{tmuxPath}},
 		Shell: config.Shell{
@@ -27481,16 +27544,42 @@ func TestWorkspaceRuntimePlainShellRecordFailureCleansCreatedTmuxShellE2E(t *tes
 	tx, err := fixture.database.WriteDB().BeginTx(ctx, &sql.TxOptions{})
 	require.NoError(err)
 	defer func() { _ = tx.Rollback() }()
-	recordCtx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	recordCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	failedResp, err := fixture.client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
-		recordCtx, ws.Id,
-		generated.LaunchWorkspaceRuntimeSessionInputBody{
-			TargetKey: string(localruntime.LaunchTargetPlainShell),
-		},
-	)
-	require.NoError(err)
-	require.Equal(http.StatusInternalServerError, failedResp.StatusCode())
+	type launchResult struct {
+		response *generated.LaunchWorkspaceRuntimeSessionResponse
+		err      error
+	}
+	launchDone := make(chan launchResult, 1)
+	go func() {
+		response, launchErr := fixture.client.HTTP.LaunchWorkspaceRuntimeSessionWithResponse(
+			recordCtx, ws.Id,
+			generated.LaunchWorkspaceRuntimeSessionInputBody{
+				TargetKey: string(localruntime.LaunchTargetPlainShell),
+			},
+		)
+		launchDone <- launchResult{response: response, err: launchErr}
+	}()
+	require.Eventually(func() bool {
+		entries, readErr := os.ReadDir(stateDir)
+		return readErr == nil && len(entries) > len(initialState)
+	}, 2*time.Second, 20*time.Millisecond)
+	require.Eventually(func() bool {
+		return len(fixture.server.runtime.ListSessions(ws.Id)) > 0
+	}, 2*time.Second, 20*time.Millisecond)
+	require.NoError(os.Remove(attachGate))
+	require.Eventually(func() bool {
+		return len(fixture.server.runtime.ListSessions(ws.Id)) == 0
+	}, 2*time.Second, 20*time.Millisecond)
+	cancel()
+	var result launchResult
+	select {
+	case result = <-launchDone:
+	case <-time.After(5 * time.Second):
+		require.FailNow("runtime launch request did not complete within 5 seconds")
+	}
+	require.NoError(result.err)
+	require.Equal(http.StatusInternalServerError, result.response.StatusCode())
 	require.NoError(tx.Rollback())
 
 	require.Eventually(func() bool {
@@ -28519,17 +28608,19 @@ session_arg() {
   done
   printf '%s' "$session"
 }
-owner_arg() {
-  owner=""
+option_arg() {
+  option="$1"
+  shift
+  value=""
   while [ "$#" -gt 0 ]; do
-    if [ "$1" = "@forge_owner" ]; then
+    if [ "$1" = "$option" ]; then
       shift
-      owner="${1:-}"
+      value="${1:-}"
       break
     fi
     [ "$#" -gt 0 ] && shift || true
   done
-  printf '%s' "$owner"
+  printf '%s' "$value"
 }
 cmd="${1:-}"
 [ "$#" -gt 0 ] && shift || true
@@ -28541,6 +28632,9 @@ case "$cmd" in
   list-sessions)
     for session in "$state_dir"/*; do
       [ -e "$session" ] || continue
+      case "$session" in
+        *.owner|*.launch) continue ;;
+      esac
       basename "$session"
     done
     ;;
@@ -28555,23 +28649,37 @@ case "$cmd" in
   new-session)
     session="$(session_arg "$@")"
     [ -n "$session" ] && : > "$state_dir/$session"
-    owner="$(owner_arg "$@")"
+    owner="$(option_arg @forge_owner "$@")"
     if [ -n "$session" ] && [ -n "$owner" ]; then
       printf '%s\n' "$owner" > "$state_dir/$session.owner"
+    fi
+    launch="$(option_arg @forge_launch "$@")"
+    if [ -n "$session" ] && [ -n "$launch" ]; then
+      printf '%s\n' "$launch" > "$state_dir/$session.launch"
     fi
     ;;
   set-option)
     session="$(session_arg "$@")"
-    owner="$(owner_arg "$@")"
+    owner="$(option_arg @forge_owner "$@")"
     if [ -n "$session" ] && [ -n "$owner" ]; then
       printf '%s\n' "$owner" > "$state_dir/$session.owner"
+    fi
+    launch="$(option_arg @forge_launch "$@")"
+    if [ -n "$session" ] && [ -n "$launch" ]; then
+      printf '%s\n' "$launch" > "$state_dir/$session.launch"
     fi
     ;;
   show-option)
     ;;
   show-options)
     session="$(session_arg "$@")"
-    if [ -n "$session" ] && [ -e "$state_dir/$session.owner" ]; then
+    requested=""
+    for arg in "$@"; do requested="$arg"; done
+    if [ "$requested" = "@forge_launch" ]; then
+      if [ -n "$session" ] && [ -e "$state_dir/$session.launch" ]; then
+        cat "$state_dir/$session.launch"
+      fi
+    elif [ -n "$session" ] && [ -e "$state_dir/$session.owner" ]; then
       cat "$state_dir/$session.owner"
     else
       printf '%s\n' "${KENN_FORGE_FAKE_TMUX_OWNER:-kenn-forge:test-owner}"
@@ -28584,6 +28692,14 @@ case "$cmd" in
       exit 1
     fi
     printf 'attached:%s\n' "$session"
+    if [ -n "${KENN_FORGE_FAKE_TMUX_ATTACH_GATE:-}" ]; then
+      while [ -e "$KENN_FORGE_FAKE_TMUX_ATTACH_GATE" ]; do
+        sleep 0.01
+      done
+    fi
+    if [ "${KENN_FORGE_FAKE_TMUX_ATTACH_EXIT:-}" = "1" ]; then
+      exit 0
+    fi
     while [ -e "$state_dir/$session" ]; do
       if IFS= read -r line; then
         printf 'fake-tmux:%s\n' "$line"
@@ -28596,6 +28712,7 @@ case "$cmd" in
     session="$(session_arg "$@")"
     [ -n "$session" ] && rm -f "$state_dir/$session"
     [ -n "$session" ] && rm -f "$state_dir/$session.owner"
+    [ -n "$session" ] && rm -f "$state_dir/$session.launch"
     ;;
   capture-pane|list-clients|refresh-client|wait-for)
     ;;

--- a/internal/server/host_runtime_handlers.go
+++ b/internal/server/host_runtime_handlers.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -112,7 +113,7 @@ func (s *Server) launchHostRuntimeSession(
 	}
 
 	sessionKey := strings.TrimSpace(input.Body.SessionKey)
-	session, err := s.runtime.EnsureCommandSession(
+	session, err := s.runtime.EnsureCommandSessionAndPersist(
 		ctx, hostRuntimeScope, localruntime.CommandLaunchSpec{
 			SessionKey: sessionKey,
 			Command:    input.Body.Command,
@@ -120,38 +121,69 @@ func (s *Server) launchHostRuntimeSession(
 			Label:      input.Body.Label,
 			CWD:        cwd,
 		},
+		func(ctx context.Context, session localruntime.SessionInfo) error {
+			// Always upsert with the returned live generation: ensure semantics
+			// can reuse a session, and stale async exit cleanup is generation-safe.
+			return s.db.UpsertHostRuntimeTmuxSession(
+				ctx, &db.HostRuntimeTmuxSession{
+					SessionKey:  session.Key,
+					SessionName: session.TmuxSession,
+					Label:       session.Label,
+					CWD:         cwd,
+					CreatedAt:   session.CreatedAt,
+				},
+			)
+		},
 	)
 	if err != nil {
-		return nil, workspaceapi.RuntimeLaunchError(err)
-	}
-	// Always upsert with the returned session's generation: ensure semantics
-	// can return a live reused session or a brand-new one, and the stored
-	// row must carry the live created_at so a stale generation's async exit
-	// cleanup cannot delete it.
-	if session.TmuxSession != "" {
-		if err := s.db.UpsertHostRuntimeTmuxSession(
-			ctx, &db.HostRuntimeTmuxSession{
-				SessionKey:  session.Key,
-				SessionName: session.TmuxSession,
-				Label:       session.Label,
-				CWD:         cwd,
-				CreatedAt:   session.CreatedAt,
-			},
-		); err != nil {
-			// Only roll back a session this request launched: stopping
-			// a reused live session would kill someone else's work
-			// over a bookkeeping failure.
-			if !session.Reused {
-				_ = s.runtime.Stop(ctx, hostRuntimeScope, session.Key)
+		var persistenceErr *localruntime.CommandSessionPersistenceError
+		if errors.As(err, &persistenceErr) {
+			if persistenceErr.RollbackErr != nil {
+				slog.Warn(
+					"roll back unrecorded host runtime session",
+					"session_key", session.Key,
+					"tmux_session", session.TmuxSession,
+					"err", persistenceErr.RollbackErr,
+				)
 			}
 			return nil, httpapi.Internal(
-				"record host runtime tmux session: " + err.Error(),
+				"record host runtime tmux session: " + persistenceErr.Error(),
 			)
 		}
+		return nil, workspaceapi.RuntimeLaunchError(err)
 	}
+	s.forgetHostRuntimeCommandSessionIfExited(ctx, session)
 	return &hostRuntimeSessionOutput{
 		Body: hostRuntimeSessionFromRuntime(session),
 	}, nil
+}
+
+// forgetHostRuntimeCommandSessionIfExited reconciles a command that exited
+// while its metadata write was still in flight: the async exit handler's
+// generation-qualified delete can run before the row exists, so a short-lived
+// command could otherwise leave a durable row for a dead session.
+func (s *Server) forgetHostRuntimeCommandSessionIfExited(
+	ctx context.Context, session localruntime.SessionInfo,
+) {
+	for _, live := range s.runtime.ListSessions(hostRuntimeScope) {
+		if live.SameGeneration(session) {
+			return
+		}
+	}
+	cleanupCtx, cancel := context.WithTimeout(
+		context.WithoutCancel(ctx), runtimeSessionCleanupTimeout,
+	)
+	defer cancel()
+	if _, err := s.db.DeleteHostRuntimeTmuxSessionCreatedAt(
+		cleanupCtx, session.Key, session.CreatedAt,
+	); err != nil {
+		slog.Warn(
+			"forget host runtime tmux session recorded after exit",
+			"session_key", session.Key,
+			"tmux_session", session.TmuxSession,
+			"err", err,
+		)
+	}
 }
 
 func (s *Server) listHostRuntimeSessions(

--- a/internal/server/runtime_launch_rollback_test.go
+++ b/internal/server/runtime_launch_rollback_test.go
@@ -964,20 +964,27 @@ func TestProjectWorktreeRuntimeLaunchPersistenceFailureLogsRollbackFailureAndPre
 	assert.FileExists(fixture.tmux.statePath)
 }
 
-func TestCommandSessionExitDuringPersistenceLeavesNoDurableRow(t *testing.T) {
+func TestRuntimeSessionExitDuringPersistenceLeavesNoDurableRow(t *testing.T) {
 	requirePTYAvailable(t)
 	tests := []struct {
-		name       string
-		sessionKey string
-		path       func(runtimeLaunchRollbackFixture) string
-		scope      func(runtimeLaunchRollbackFixture) string
-		countRows  func(*testing.T, runtimeLaunchRollbackFixture) int
+		name      string
+		path      func(runtimeLaunchRollbackFixture) string
+		body      func(*testing.T) []byte
+		scope     func(runtimeLaunchRollbackFixture) string
+		countRows func(*testing.T, runtimeLaunchRollbackFixture) int
 	}{
 		{
-			name:       "host_command",
-			sessionKey: "surface:exit-race:host",
+			name: "host_command",
 			path: func(runtimeLaunchRollbackFixture) string {
 				return "/api/v1/runtime/sessions"
+			},
+			body: func(t *testing.T) []byte {
+				return mustMarshal(t, map[string]any{
+					"session_key": "surface:exit-race:host",
+					"command":     []string{"/bin/sh", "-lc", "exec sleep 60"},
+					"label":       "Exit-race command",
+					"cwd":         t.TempDir(),
+				})
 			},
 			scope: func(runtimeLaunchRollbackFixture) string {
 				return hostRuntimeScope
@@ -991,11 +998,56 @@ func TestCommandSessionExitDuringPersistenceLeavesNoDurableRow(t *testing.T) {
 			},
 		},
 		{
-			name:       "project_command",
-			sessionKey: "surface:exit-race:project",
+			name: "project_shell",
+			path: func(fixture runtimeLaunchRollbackFixture) string {
+				return "/api/v1/projects/" + fixture.projectID +
+					"/worktrees/" + fixture.worktreeID + "/runtime/shell"
+			},
+			body: func(*testing.T) []byte { return nil },
+			scope: func(fixture runtimeLaunchRollbackFixture) string {
+				return workspaceapi.ProjectWorktreeRuntimeScope(fixture.worktreeID)
+			},
+			countRows: func(t *testing.T, fixture runtimeLaunchRollbackFixture) int {
+				rows, err := fixture.server.db.ListProjectWorktreeTmuxSessions(
+					context.Background(), fixture.worktreeID,
+				)
+				require.NoError(t, err)
+				return len(rows)
+			},
+		},
+		{
+			name: "project_configured_target",
 			path: func(fixture runtimeLaunchRollbackFixture) string {
 				return "/api/v1/projects/" + fixture.projectID +
 					"/worktrees/" + fixture.worktreeID + "/runtime/sessions"
+			},
+			body: func(t *testing.T) []byte {
+				return mustMarshal(t, map[string]any{"target_key": "helper"})
+			},
+			scope: func(fixture runtimeLaunchRollbackFixture) string {
+				return workspaceapi.ProjectWorktreeRuntimeScope(fixture.worktreeID)
+			},
+			countRows: func(t *testing.T, fixture runtimeLaunchRollbackFixture) int {
+				rows, err := fixture.server.db.ListProjectWorktreeTmuxSessions(
+					context.Background(), fixture.worktreeID,
+				)
+				require.NoError(t, err)
+				return len(rows)
+			},
+		},
+		{
+			name: "project_command",
+			path: func(fixture runtimeLaunchRollbackFixture) string {
+				return "/api/v1/projects/" + fixture.projectID +
+					"/worktrees/" + fixture.worktreeID + "/runtime/sessions"
+			},
+			body: func(t *testing.T) []byte {
+				return mustMarshal(t, map[string]any{
+					"session_key": "surface:exit-race:project",
+					"command":     []string{"/bin/sh", "-lc", "exec sleep 60"},
+					"label":       "Exit-race command",
+					"cwd":         t.TempDir(),
+				})
 			},
 			scope: func(fixture runtimeLaunchRollbackFixture) string {
 				return workspaceapi.ProjectWorktreeRuntimeScope(fixture.worktreeID)
@@ -1016,17 +1068,12 @@ func TestCommandSessionExitDuringPersistenceLeavesNoDurableRow(t *testing.T) {
 			require := require.New(t)
 			fixture := setupRuntimeLaunchRollbackFixture(t, false)
 			scope := test.scope(fixture)
-			body := mustMarshal(t, map[string]any{
-				"session_key": test.sessionKey,
-				"command":     []string{"/bin/sh", "-lc", "exec sleep 60"},
-				"label":       "Exit-race command",
-				"cwd":         t.TempDir(),
-			})
 			transaction := occupyRuntimeWriter(t, fixture.server.db)
 			baseline := fixture.server.db.WriteDB().Stats().WaitCount
 
 			responses := serveRuntimeRequestAsync(
-				fixture.server, t.Context(), http.MethodPost, test.path(fixture), body,
+				fixture.server, t.Context(), http.MethodPost, test.path(fixture),
+				test.body(t),
 			)
 			require.Eventually(func() bool {
 				return len(fixture.server.runtime.ListSessions(scope)) == 1
@@ -1046,7 +1093,7 @@ func TestCommandSessionExitDuringPersistenceLeavesNoDurableRow(t *testing.T) {
 
 			assert.Equal(http.StatusOK, recorder.Code)
 			assert.Zero(test.countRows(t, fixture),
-				"a command that exited before its metadata write completed"+
+				"a session that exited before its metadata write completed"+
 					" must not leave a durable row")
 		})
 	}

--- a/internal/server/runtime_launch_rollback_test.go
+++ b/internal/server/runtime_launch_rollback_test.go
@@ -1,0 +1,1136 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	shellquote "github.com/kballard/go-shellquote"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/forge/internal/config"
+	"go.kenn.io/forge/internal/db"
+	ghclient "go.kenn.io/forge/internal/github"
+	"go.kenn.io/forge/internal/server/workspaceapi"
+	"go.kenn.io/forge/internal/testutil/dbtest"
+	"go.kenn.io/forge/internal/workspace/localruntime"
+)
+
+type runtimeRollbackFakeTmux struct {
+	command            []string
+	recordPath         string
+	statePath          string
+	attachStartedPath  string
+	exitAttachPath     string
+	killFailurePath    string
+	launchPath         string
+	launchHistoryPath  string
+	killedLaunchesPath string
+}
+
+type runtimeLaunchRollbackFixture struct {
+	server     *Server
+	projectID  string
+	worktreeID string
+	tmux       runtimeRollbackFakeTmux
+}
+
+func setupRuntimeLaunchRollbackFixture(
+	t *testing.T,
+	failKill bool,
+) runtimeLaunchRollbackFixture {
+	t.Helper()
+	dir := t.TempDir()
+	tmux := runtimeRollbackFakeTmux{
+		recordPath:         filepath.Join(dir, "tmux-record"),
+		statePath:          filepath.Join(dir, "tmux-session-exists"),
+		attachStartedPath:  filepath.Join(dir, "tmux-attach-started"),
+		exitAttachPath:     filepath.Join(dir, "tmux-exit-attach"),
+		killFailurePath:    filepath.Join(dir, "tmux-kill-failure"),
+		launchPath:         filepath.Join(dir, "tmux-launch-id"),
+		launchHistoryPath:  filepath.Join(dir, "tmux-launch-history"),
+		killedLaunchesPath: filepath.Join(dir, "tmux-killed-launches"),
+	}
+	if failKill {
+		require.NoError(t, os.WriteFile(tmux.killFailurePath, nil, 0o600))
+	}
+	ownerPath := filepath.Join(dir, "tmux-owner-marker")
+	tmuxPath := filepath.Join(dir, "fake-tmux")
+	script := fmt.Sprintf(`#!/bin/sh
+printf '%%s\0' "$#" "$@" >> %[1]s
+if [ "$1" = "-u" ]; then shift; fi
+case "$1" in
+  has-session)
+    if [ -f %[2]s ]; then exit 0; fi
+    echo "can't find session: $3" >&2
+    exit 1
+    ;;
+  new-session)
+    : > %[2]s
+    marker=""
+    for arg in "$@"; do
+      if [ "$marker" = "owner" ]; then
+        printf '%%s\n' "$arg" > %[3]s
+        marker="done"
+      elif [ "$marker" = "launch" ]; then
+        printf '%%s\n' "$arg" > %[7]s
+        printf '%%s\n' "$arg" >> %[8]s
+        marker="done"
+      elif [ "$arg" = "@forge_owner" ]; then
+        marker="owner"
+      elif [ "$arg" = "@forge_launch" ]; then
+        marker="launch"
+      fi
+    done
+    exit 0
+    ;;
+  show-options)
+    option=""
+    for arg in "$@"; do option="$arg"; done
+    if [ "$option" = "@forge_launch" ]; then
+      if [ -f %[7]s ]; then cat %[7]s; fi
+    elif [ -f %[3]s ]; then
+      cat %[3]s
+    fi
+    exit 0
+    ;;
+  set-option)
+    exit 0
+    ;;
+  attach-session)
+    : > %[4]s
+    while [ ! -f %[5]s ]; do sleep 0.01; done
+    exit 0
+    ;;
+  kill-session)
+    if [ -f %[7]s ]; then cat %[7]s >> %[9]s; fi
+    if [ -f %[6]s ]; then
+      echo "forced kill-session failure" >&2
+      exit 1
+    fi
+    rm -f %[2]s %[7]s
+    exit 0
+    ;;
+esac
+exit 0
+`,
+		shellquote.Join(tmux.recordPath),
+		shellquote.Join(tmux.statePath),
+		shellquote.Join(ownerPath),
+		shellquote.Join(tmux.attachStartedPath),
+		shellquote.Join(tmux.exitAttachPath),
+		shellquote.Join(tmux.killFailurePath),
+		shellquote.Join(tmux.launchPath),
+		shellquote.Join(tmux.launchHistoryPath),
+		shellquote.Join(tmux.killedLaunchesPath),
+	)
+	require.NoError(t, os.WriteFile(tmuxPath, []byte(script), 0o755))
+	tmux.command = []string{tmuxPath}
+
+	cfgPath := filepath.Join(dir, "config.toml")
+	cfgContent := `
+sync_interval = "5m"
+github_token_env = "KENN_FORGE_GITHUB_TOKEN"
+host = "127.0.0.1"
+port = 8091
+
+[[repos]]
+owner = "acme"
+name = "widget"
+
+[[agents]]
+key = "helper"
+label = "Helper"
+command = ["/bin/sh", "-lc", "exec sleep 60"]
+
+[tmux]
+agent_sessions = true
+`
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfgContent), 0o644))
+	cfg, err := config.Load(cfgPath)
+	require.NoError(t, err)
+	cfg.Tmux.Command = tmux.command
+	database := dbtest.Open(t)
+	mock := &mockGH{}
+	clients := map[string]ghclient.Client{"github.com": mock}
+	resolved := ghclient.ResolveConfiguredRepos(t.Context(), clients, cfg.Repos)
+	syncer := ghclient.NewSyncer(
+		clients, database, nil, resolved.Expanded, time.Minute, nil, nil,
+	)
+	t.Cleanup(syncer.Stop)
+	srv := NewWithConfig(
+		database, syncer, nil, nil, cfg, cfgPath,
+		ServerOptions{
+			WorktreeDir:                   filepath.Join(dir, "managed-worktrees"),
+			PtyOwnerInProcess:             true,
+			HostCheckAllowLoopbackAnyPort: true,
+		},
+	)
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	project := createRuntimeTestProject(t, database, t.TempDir())
+	worktree, err := database.CreateProjectWorktree(
+		context.Background(), db.CreateProjectWorktreeInput{
+			ProjectID: project.ID,
+			Branch:    "runtime",
+			Path:      t.TempDir(),
+		},
+	)
+	require.NoError(t, err)
+	return runtimeLaunchRollbackFixture{
+		server:     srv,
+		projectID:  project.ID,
+		worktreeID: worktree.ID,
+		tmux:       tmux,
+	}
+}
+
+func occupyRuntimeWriter(t *testing.T, database *db.DB) *sql.Tx {
+	t.Helper()
+	tx, err := database.WriteDB().BeginTx(t.Context(), nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tx.Rollback() })
+	return tx
+}
+
+func serveRuntimeRequestAsync(
+	srv *Server,
+	ctx context.Context,
+	method string,
+	path string,
+	body []byte,
+) <-chan *httptest.ResponseRecorder {
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(method, path, bytes.NewReader(body)).WithContext(ctx)
+	request.Host = "127.0.0.1:8091"
+	if method == http.MethodPost {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	responses := make(chan *httptest.ResponseRecorder, 1)
+	go func() {
+		srv.ServeHTTP(recorder, request)
+		responses <- recorder
+	}()
+	return responses
+}
+
+func waitForRuntimeWriterWait(t *testing.T, database *db.DB, baseline int64) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		return database.WriteDB().Stats().WaitCount > baseline
+	}, time.Second, 10*time.Millisecond)
+}
+
+func runtimeLaunchRequestBody(t *testing.T, sessionKey string) []byte {
+	t.Helper()
+	return mustMarshal(t, map[string]any{
+		"session_key": sessionKey,
+		"command":     []string{"/bin/sh", "-lc", "exec sleep 60"},
+		"label":       "Rollback shell",
+		"cwd":         t.TempDir(),
+	})
+}
+
+func awaitRuntimeResponse(
+	t *testing.T,
+	responses <-chan *httptest.ResponseRecorder,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	select {
+	case recorder := <-responses:
+		return recorder
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, "runtime request did not complete within 5 seconds")
+		return nil
+	}
+}
+
+func readRuntimeLaunchIDs(t *testing.T, path string) []string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return strings.Fields(string(data))
+}
+
+func TestCommandSameKeyPersistenceOwnership(t *testing.T) {
+	requirePTYAvailable(t)
+	tests := []struct {
+		name             string
+		sessionKey       string
+		label            string
+		path             func(runtimeLaunchRollbackFixture) string
+		scope            func(runtimeLaunchRollbackFixture) string
+		persistenceError string
+		assertDurable    func(
+			*testing.T,
+			runtimeLaunchRollbackFixture,
+			localruntime.SessionInfo,
+			string,
+		)
+	}{
+		{
+			name:       "host_command",
+			sessionKey: "surface:same-key:host",
+			label:      "Same-key host command",
+			path: func(runtimeLaunchRollbackFixture) string {
+				return "/api/v1/runtime/sessions"
+			},
+			scope: func(runtimeLaunchRollbackFixture) string {
+				return hostRuntimeScope
+			},
+			persistenceError: "record host runtime tmux session",
+			assertDurable: func(
+				t *testing.T,
+				fixture runtimeLaunchRollbackFixture,
+				session localruntime.SessionInfo,
+				cwd string,
+			) {
+				rows, err := fixture.server.db.ListHostRuntimeTmuxSessions(t.Context())
+				require.NoError(t, err)
+				require.Len(t, rows, 1)
+				assert.Equal(t, session.Key, rows[0].SessionKey)
+				assert.Equal(t, session.TmuxSession, rows[0].SessionName)
+				assert.Equal(t, session.Label, rows[0].Label)
+				assert.Equal(t, cwd, rows[0].CWD)
+				assert.Equal(t, session.CreatedAt, rows[0].CreatedAt)
+			},
+		},
+		{
+			name:       "project_command",
+			sessionKey: "surface:same-key:project",
+			label:      "Same-key project command",
+			path: func(fixture runtimeLaunchRollbackFixture) string {
+				return "/api/v1/projects/" + fixture.projectID +
+					"/worktrees/" + fixture.worktreeID + "/runtime/sessions"
+			},
+			scope: func(fixture runtimeLaunchRollbackFixture) string {
+				return workspaceapi.ProjectWorktreeRuntimeScope(fixture.worktreeID)
+			},
+			persistenceError: "record project worktree runtime tmux session",
+			assertDurable: func(
+				t *testing.T,
+				fixture runtimeLaunchRollbackFixture,
+				session localruntime.SessionInfo,
+				_ string,
+			) {
+				rows, err := fixture.server.db.ListProjectWorktreeTmuxSessions(
+					t.Context(), fixture.worktreeID,
+				)
+				require.NoError(t, err)
+				require.Len(t, rows, 1)
+				assert.Equal(t, fixture.projectID, rows[0].ProjectID)
+				assert.Equal(t, fixture.worktreeID, rows[0].WorktreeID)
+				assert.Equal(t, session.Key, rows[0].SessionKey)
+				assert.Equal(t, session.TmuxSession, rows[0].SessionName)
+				assert.Equal(t, session.Label, rows[0].Label)
+				assert.Empty(t, rows[0].TargetKey)
+				assert.Equal(t, session.CreatedAt, rows[0].CreatedAt)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			fixture := setupRuntimeLaunchRollbackFixture(t, false)
+			scope := test.scope(fixture)
+			cwd := t.TempDir()
+			body := mustMarshal(t, map[string]any{
+				"session_key": test.sessionKey,
+				"command":     []string{"/bin/sh", "-lc", "exec sleep 60"},
+				"label":       test.label,
+				"cwd":         cwd,
+			})
+			transaction := occupyRuntimeWriter(t, fixture.server.db)
+			baseline := fixture.server.db.WriteDB().Stats().WaitCount
+			ctxA, cancelA := context.WithCancel(t.Context())
+			t.Cleanup(cancelA)
+
+			aResponses := serveRuntimeRequestAsync(
+				fixture.server, ctxA, http.MethodPost, test.path(fixture), body,
+			)
+			require.Eventually(func() bool {
+				return len(fixture.server.runtime.ListSessions(scope)) == 1
+			}, time.Second, 10*time.Millisecond)
+			waitForRuntimeWriterWait(t, fixture.server.db, baseline)
+			generationOne := fixture.server.runtime.ListSessions(scope)[0]
+			assert.True(
+				fixture.server.runtime.CommandSessionStartLockHeldForTest(test.sessionKey),
+				"A must hold the keyed transaction lock while its metadata write is blocked",
+			)
+
+			bResponses := serveRuntimeRequestAsync(
+				fixture.server, t.Context(), http.MethodPost, test.path(fixture), body,
+			)
+			require.Never(func() bool {
+				return fixture.server.db.WriteDB().Stats().WaitCount > baseline+1
+			}, 150*time.Millisecond, 10*time.Millisecond,
+				"request B must not reach persistence while A owns rollback authority",
+			)
+
+			cancelA()
+			aRecorder := awaitRuntimeResponse(t, aResponses)
+			waitForRuntimeWriterWait(t, fixture.server.db, baseline+1)
+			require.Eventually(func() bool {
+				launches, err := os.ReadFile(fixture.tmux.launchHistoryPath)
+				return err == nil && len(strings.Fields(string(launches))) == 2
+			}, time.Second, 10*time.Millisecond)
+			require.NoError(transaction.Rollback())
+			bRecorder := awaitRuntimeResponse(t, bResponses)
+
+			assert.Equal(http.StatusInternalServerError, aRecorder.Code)
+			assert.Contains(aRecorder.Body.String(), test.persistenceError)
+			assert.Contains(aRecorder.Body.String(), "context canceled")
+			assert.Equal(http.StatusOK, bRecorder.Code)
+
+			sessions := fixture.server.runtime.ListSessions(scope)
+			require.Len(sessions, 1)
+			generationTwo := sessions[0]
+			assert.Equal(generationOne.Key, generationTwo.Key)
+			assert.NotEqual(generationOne.CreatedAt, generationTwo.CreatedAt)
+			assert.Equal(localruntime.SessionStatusRunning, generationTwo.Status)
+			assert.FileExists(fixture.tmux.statePath)
+			currentLaunch, err := os.ReadFile(fixture.tmux.launchPath)
+			require.NoError(err)
+			launches := readRuntimeLaunchIDs(t, fixture.tmux.launchHistoryPath)
+			require.Len(launches, 2)
+			assert.NotEqual(launches[0], launches[1])
+			assert.Equal(launches[1], strings.TrimSpace(string(currentLaunch)))
+			for _, killed := range readRuntimeLaunchIDs(
+				t, fixture.tmux.killedLaunchesPath,
+			) {
+				assert.Equal(launches[0], killed)
+				assert.NotEqual(launches[1], killed)
+			}
+			test.assertDurable(t, fixture, generationTwo, cwd)
+		})
+	}
+}
+
+func TestProjectWorktreeShellPersistenceOwnership(t *testing.T) {
+	requirePTYAvailable(t)
+	assert := assert.New(t)
+	require := require.New(t)
+	fixture := setupRuntimeLaunchRollbackFixture(t, false)
+	scope := workspaceapi.ProjectWorktreeRuntimeScope(fixture.worktreeID)
+	path := "/api/v1/projects/" + fixture.projectID +
+		"/worktrees/" + fixture.worktreeID + "/runtime/shell"
+	transaction := occupyRuntimeWriter(t, fixture.server.db)
+	baseline := fixture.server.db.WriteDB().Stats().WaitCount
+	ctxA, cancelA := context.WithCancel(t.Context())
+	t.Cleanup(cancelA)
+
+	aResponses := serveRuntimeRequestAsync(
+		fixture.server, ctxA, http.MethodPost, path, nil,
+	)
+	require.Eventually(func() bool {
+		return len(fixture.server.runtime.ListSessions(scope)) == 1
+	}, time.Second, 10*time.Millisecond)
+	waitForRuntimeWriterWait(t, fixture.server.db, baseline)
+	generationOne := fixture.server.runtime.ListSessions(scope)[0]
+
+	bResponses := serveRuntimeRequestAsync(
+		fixture.server, t.Context(), http.MethodPost, path, nil,
+	)
+	require.Never(func() bool {
+		return fixture.server.db.WriteDB().Stats().WaitCount > baseline+1
+	}, 150*time.Millisecond, 10*time.Millisecond,
+		"the follower must not persist while the creator owns rollback authority",
+	)
+
+	cancelA()
+	aRecorder := awaitRuntimeResponse(t, aResponses)
+	waitForRuntimeWriterWait(t, fixture.server.db, baseline+1)
+	require.Eventually(func() bool {
+		launches, err := os.ReadFile(fixture.tmux.launchHistoryPath)
+		return err == nil && len(strings.Fields(string(launches))) == 2
+	}, time.Second, 10*time.Millisecond)
+	require.NoError(transaction.Rollback())
+	bRecorder := awaitRuntimeResponse(t, bResponses)
+
+	assert.Equal(http.StatusInternalServerError, aRecorder.Code)
+	assert.Contains(aRecorder.Body.String(), "record project worktree runtime tmux session")
+	assert.Contains(aRecorder.Body.String(), "context canceled")
+	assert.Equal(http.StatusOK, bRecorder.Code)
+
+	sessions := fixture.server.runtime.ListSessions(scope)
+	require.Len(sessions, 1)
+	generationTwo := sessions[0]
+	assert.NotEqual(generationOne.Key, generationTwo.Key)
+	assert.NotEqual(generationOne.CreatedAt, generationTwo.CreatedAt)
+	assert.Equal(localruntime.SessionStatusRunning, generationTwo.Status)
+	assert.FileExists(fixture.tmux.statePath)
+	currentLaunch, err := os.ReadFile(fixture.tmux.launchPath)
+	require.NoError(err)
+	launches := readRuntimeLaunchIDs(t, fixture.tmux.launchHistoryPath)
+	require.Len(launches, 2)
+	assert.NotEqual(launches[0], launches[1])
+	assert.Equal(launches[1], strings.TrimSpace(string(currentLaunch)))
+	for _, killed := range readRuntimeLaunchIDs(t, fixture.tmux.killedLaunchesPath) {
+		assert.Equal(launches[0], killed)
+		assert.NotEqual(launches[1], killed)
+	}
+	rows, err := fixture.server.db.ListProjectWorktreeTmuxSessions(
+		context.Background(), fixture.worktreeID,
+	)
+	require.NoError(err)
+	require.Len(rows, 1)
+	assert.Equal(generationTwo.Key, rows[0].SessionKey)
+	assert.Equal(generationTwo.TmuxSession, rows[0].SessionName)
+	assert.Equal(generationTwo.CreatedAt, rows[0].CreatedAt)
+}
+
+func TestHostRuntimeLaunchPersistenceFailureRollsBackNewTmuxSession(
+	t *testing.T,
+) {
+	requirePTYAvailable(t)
+	assert := assert.New(t)
+	require := require.New(t)
+	fixture := setupRuntimeLaunchRollbackFixture(t, false)
+	transaction := occupyRuntimeWriter(t, fixture.server.db)
+	baseline := fixture.server.db.WriteDB().Stats().WaitCount
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	responses := serveRuntimeRequestAsync(
+		fixture.server, ctx, http.MethodPost, "/api/v1/runtime/sessions",
+		runtimeLaunchRequestBody(t, "surface:host:console:rollback-new"),
+	)
+	require.Eventually(func() bool {
+		_, err := os.Stat(fixture.tmux.attachStartedPath)
+		return err == nil
+	}, time.Second, 10*time.Millisecond)
+	require.Eventually(func() bool {
+		return len(fixture.server.runtime.ListSessions(hostRuntimeScope)) == 1
+	}, time.Second, 10*time.Millisecond)
+	waitForRuntimeWriterWait(t, fixture.server.db, baseline)
+	launched := fixture.server.runtime.ListSessions(hostRuntimeScope)[0]
+
+	require.NoError(os.WriteFile(fixture.tmux.exitAttachPath, nil, 0o600))
+	require.Eventually(func() bool {
+		return len(fixture.server.runtime.ListSessions(hostRuntimeScope)) == 0
+	}, time.Second, 10*time.Millisecond)
+	cancel()
+	recorder := awaitRuntimeResponse(t, responses)
+	require.NoError(transaction.Rollback())
+
+	assert.Equal(http.StatusInternalServerError, recorder.Code)
+	assert.Contains(recorder.Body.String(), "record host runtime tmux session")
+	assert.Contains(recorder.Body.String(), "context canceled")
+	assert.NoFileExists(fixture.tmux.statePath)
+	assertFakeTmuxKilledSession(t, fixture.tmux.recordPath, launched.TmuxSession)
+	assert.Empty(fixture.server.runtime.ListSessions(hostRuntimeScope))
+	rows, err := fixture.server.db.ListHostRuntimeTmuxSessions(context.Background())
+	require.NoError(err)
+	assert.Empty(rows)
+}
+
+func TestHostRuntimeLaunchPersistenceFailurePreservesReusedTmuxSession(
+	t *testing.T,
+) {
+	requirePTYAvailable(t)
+	assert := assert.New(t)
+	require := require.New(t)
+	fixture := setupRuntimeLaunchRollbackFixture(t, false)
+	body := runtimeLaunchRequestBody(t, "surface:host:console:rollback-reused")
+	initial := serveRuntimeRequestAsync(
+		fixture.server, t.Context(), http.MethodPost, "/api/v1/runtime/sessions", body,
+	)
+	require.Equal(http.StatusOK, awaitRuntimeResponse(t, initial).Code)
+	sessions := fixture.server.runtime.ListSessions(hostRuntimeScope)
+	require.Len(sessions, 1)
+	original := sessions[0]
+
+	transaction := occupyRuntimeWriter(t, fixture.server.db)
+	baseline := fixture.server.db.WriteDB().Stats().WaitCount
+	ctx, cancel := context.WithCancel(t.Context())
+	responses := serveRuntimeRequestAsync(
+		fixture.server, ctx, http.MethodPost, "/api/v1/runtime/sessions", body,
+	)
+	waitForRuntimeWriterWait(t, fixture.server.db, baseline)
+	cancel()
+	recorder := awaitRuntimeResponse(t, responses)
+	require.NoError(transaction.Rollback())
+
+	assert.Equal(http.StatusInternalServerError, recorder.Code)
+	assert.FileExists(fixture.tmux.statePath)
+	sessions = fixture.server.runtime.ListSessions(hostRuntimeScope)
+	require.Len(sessions, 1)
+	assert.Equal(original.Key, sessions[0].Key)
+	assert.Equal(original.TmuxSession, sessions[0].TmuxSession)
+	record, err := os.ReadFile(fixture.tmux.recordPath)
+	require.NoError(err)
+	assert.NotContains(
+		string(record), "kill-session\x00-t\x00"+original.TmuxSession,
+	)
+	rows, err := fixture.server.db.ListHostRuntimeTmuxSessions(context.Background())
+	require.NoError(err)
+	require.Len(rows, 1)
+	assert.Equal(original.Key, rows[0].SessionKey)
+	assert.Equal(original.TmuxSession, rows[0].SessionName)
+}
+
+func TestHostRuntimeLaunchPersistenceFailurePreservesReattachedTmuxBackend(
+	t *testing.T,
+) {
+	requirePTYAvailable(t)
+	assert := assert.New(t)
+	require := require.New(t)
+	fixture := setupRuntimeLaunchRollbackFixture(t, false)
+	body := runtimeLaunchRequestBody(t, "surface:host:console:rollback-reattached")
+	initial := serveRuntimeRequestAsync(
+		fixture.server, t.Context(), http.MethodPost, "/api/v1/runtime/sessions", body,
+	)
+	require.Equal(http.StatusOK, awaitRuntimeResponse(t, initial).Code)
+	sessions := fixture.server.runtime.ListSessions(hostRuntimeScope)
+	require.Len(sessions, 1)
+	original := sessions[0]
+	require.NoError(fixture.server.runtime.Detach(hostRuntimeScope, original.Key))
+	require.Empty(fixture.server.runtime.ListSessions(hostRuntimeScope))
+
+	transaction := occupyRuntimeWriter(t, fixture.server.db)
+	baseline := fixture.server.db.WriteDB().Stats().WaitCount
+	ctx, cancel := context.WithCancel(t.Context())
+	responses := serveRuntimeRequestAsync(
+		fixture.server, ctx, http.MethodPost, "/api/v1/runtime/sessions", body,
+	)
+	waitForRuntimeWriterWait(t, fixture.server.db, baseline)
+	cancel()
+	recorder := awaitRuntimeResponse(t, responses)
+	require.NoError(transaction.Rollback())
+
+	assert.Equal(http.StatusInternalServerError, recorder.Code)
+	assert.Contains(recorder.Body.String(), "record host runtime tmux session")
+	assert.Contains(recorder.Body.String(), "context canceled")
+	assert.FileExists(fixture.tmux.statePath)
+	sessions = fixture.server.runtime.ListSessions(hostRuntimeScope)
+	require.Len(sessions, 1)
+	assert.Equal(original.Key, sessions[0].Key)
+	assert.Equal(original.TmuxSession, sessions[0].TmuxSession)
+	record, err := os.ReadFile(fixture.tmux.recordPath)
+	require.NoError(err)
+	assert.NotContains(
+		string(record), "kill-session\x00-t\x00"+original.TmuxSession,
+	)
+	rows, err := fixture.server.db.ListHostRuntimeTmuxSessions(context.Background())
+	require.NoError(err)
+	require.Len(rows, 1)
+	assert.Equal(original.Key, rows[0].SessionKey)
+	assert.Equal(original.TmuxSession, rows[0].SessionName)
+}
+
+func TestHostRuntimeLaunchPersistenceFailureLogsRollbackFailureAndPreservesPersistenceError(
+	t *testing.T,
+) {
+	requirePTYAvailable(t)
+	assert := assert.New(t)
+	require := require.New(t)
+	fixture := setupRuntimeLaunchRollbackFixture(t, true)
+	var logs bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, nil)))
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
+	transaction := occupyRuntimeWriter(t, fixture.server.db)
+	baseline := fixture.server.db.WriteDB().Stats().WaitCount
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	responses := serveRuntimeRequestAsync(
+		fixture.server, ctx, http.MethodPost, "/api/v1/runtime/sessions",
+		runtimeLaunchRequestBody(t, "surface:host:console:rollback-failure"),
+	)
+	require.Eventually(func() bool {
+		_, err := os.Stat(fixture.tmux.attachStartedPath)
+		return err == nil
+	}, time.Second, 10*time.Millisecond)
+	waitForRuntimeWriterWait(t, fixture.server.db, baseline)
+	launched := fixture.server.runtime.ListSessions(hostRuntimeScope)[0]
+	require.NoError(os.WriteFile(fixture.tmux.exitAttachPath, nil, 0o600))
+	require.Eventually(func() bool {
+		return len(fixture.server.runtime.ListSessions(hostRuntimeScope)) == 0
+	}, time.Second, 10*time.Millisecond)
+	cancel()
+	recorder := awaitRuntimeResponse(t, responses)
+	require.NoError(transaction.Rollback())
+
+	assert.Equal(http.StatusInternalServerError, recorder.Code)
+	assert.Contains(recorder.Body.String(), "record host runtime tmux session")
+	assert.Contains(recorder.Body.String(), "context canceled")
+	assert.NotContains(recorder.Body.String(), "forced kill-session failure")
+	assert.Contains(logs.String(), "roll back unrecorded host runtime session")
+	assert.Contains(logs.String(), launched.Key)
+	assert.Contains(logs.String(), launched.TmuxSession)
+	assert.Contains(logs.String(), "forced kill-session failure")
+	assert.FileExists(fixture.tmux.statePath)
+}
+
+func TestProjectWorktreeRuntimeLaunchPersistenceFailureRollsBackNewTmuxSession(
+	t *testing.T,
+) {
+	requirePTYAvailable(t)
+	tests := []struct {
+		name string
+		path func(projectID, worktreeID string) string
+		body func(t *testing.T) []byte
+	}{
+		{
+			name: "shell",
+			path: func(projectID, worktreeID string) string {
+				return "/api/v1/projects/" + projectID +
+					"/worktrees/" + worktreeID + "/runtime/shell"
+			},
+			body: func(*testing.T) []byte { return nil },
+		},
+		{
+			name: "configured_target",
+			path: func(projectID, worktreeID string) string {
+				return "/api/v1/projects/" + projectID +
+					"/worktrees/" + worktreeID + "/runtime/sessions"
+			},
+			body: func(t *testing.T) []byte {
+				return mustMarshal(t, map[string]any{"target_key": "helper"})
+			},
+		},
+		{
+			name: "command",
+			path: func(projectID, worktreeID string) string {
+				return "/api/v1/projects/" + projectID +
+					"/worktrees/" + worktreeID + "/runtime/sessions"
+			},
+			body: func(t *testing.T) []byte {
+				return mustMarshal(t, map[string]any{
+					"session_key": "surface:project:rollback:command",
+					"command":     []string{"/bin/sh", "-lc", "exec sleep 60"},
+					"label":       "Rollback Command",
+				})
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			fixture := setupRuntimeLaunchRollbackFixture(t, false)
+			scope := workspaceapi.ProjectWorktreeRuntimeScope(fixture.worktreeID)
+			transaction := occupyRuntimeWriter(t, fixture.server.db)
+			baseline := fixture.server.db.WriteDB().Stats().WaitCount
+			ctx, cancel := context.WithCancel(t.Context())
+			t.Cleanup(cancel)
+
+			responses := serveRuntimeRequestAsync(
+				fixture.server, ctx, http.MethodPost,
+				test.path(fixture.projectID, fixture.worktreeID), test.body(t),
+			)
+			require.Eventually(func() bool {
+				_, err := os.Stat(fixture.tmux.attachStartedPath)
+				return err == nil
+			}, time.Second, 10*time.Millisecond)
+			require.Eventually(func() bool {
+				return len(fixture.server.runtime.ListSessions(scope)) == 1
+			}, time.Second, 10*time.Millisecond)
+			waitForRuntimeWriterWait(t, fixture.server.db, baseline)
+			launched := fixture.server.runtime.ListSessions(scope)[0]
+
+			require.NoError(os.WriteFile(fixture.tmux.exitAttachPath, nil, 0o600))
+			require.Eventually(func() bool {
+				return len(fixture.server.runtime.ListSessions(scope)) == 0
+			}, time.Second, 10*time.Millisecond)
+			cancel()
+			recorder := awaitRuntimeResponse(t, responses)
+			require.NoError(transaction.Rollback())
+
+			assert.Equal(http.StatusInternalServerError, recorder.Code)
+			assert.Contains(recorder.Body.String(), "record project worktree runtime tmux session")
+			assert.Contains(recorder.Body.String(), "context canceled")
+			assert.NoFileExists(fixture.tmux.statePath)
+			assertFakeTmuxKilledSession(t, fixture.tmux.recordPath, launched.TmuxSession)
+			assert.Empty(fixture.server.runtime.ListSessions(scope))
+			rows, err := fixture.server.db.ListProjectWorktreeTmuxSessions(
+				context.Background(), fixture.worktreeID,
+			)
+			require.NoError(err)
+			assert.Empty(rows)
+		})
+	}
+}
+
+func TestProjectWorktreeRuntimeLaunchPersistenceFailurePreservesReusedTmuxSession(
+	t *testing.T,
+) {
+	requirePTYAvailable(t)
+	tests := []struct {
+		name string
+		path func(projectID, worktreeID string) string
+		body func(t *testing.T) []byte
+	}{
+		{
+			name: "shell",
+			path: func(projectID, worktreeID string) string {
+				return "/api/v1/projects/" + projectID +
+					"/worktrees/" + worktreeID + "/runtime/shell"
+			},
+			body: func(*testing.T) []byte { return nil },
+		},
+		{
+			name: "command",
+			path: func(projectID, worktreeID string) string {
+				return "/api/v1/projects/" + projectID +
+					"/worktrees/" + worktreeID + "/runtime/sessions"
+			},
+			body: func(t *testing.T) []byte {
+				return mustMarshal(t, map[string]any{
+					"session_key": "surface:project:rollback:reused",
+					"command":     []string{"/bin/sh", "-lc", "exec sleep 60"},
+					"label":       "Rollback Reused Command",
+				})
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			fixture := setupRuntimeLaunchRollbackFixture(t, false)
+			scope := workspaceapi.ProjectWorktreeRuntimeScope(fixture.worktreeID)
+			path := test.path(fixture.projectID, fixture.worktreeID)
+			body := test.body(t)
+
+			initial := serveRuntimeRequestAsync(
+				fixture.server, t.Context(), http.MethodPost, path, body,
+			)
+			require.Equal(http.StatusOK, awaitRuntimeResponse(t, initial).Code)
+			sessions := fixture.server.runtime.ListSessions(scope)
+			require.Len(sessions, 1)
+			original := sessions[0]
+
+			transaction := occupyRuntimeWriter(t, fixture.server.db)
+			baseline := fixture.server.db.WriteDB().Stats().WaitCount
+			ctx, cancel := context.WithCancel(t.Context())
+			responses := serveRuntimeRequestAsync(
+				fixture.server, ctx, http.MethodPost, path, body,
+			)
+			waitForRuntimeWriterWait(t, fixture.server.db, baseline)
+			cancel()
+			recorder := awaitRuntimeResponse(t, responses)
+			require.NoError(transaction.Rollback())
+
+			assert.Equal(http.StatusInternalServerError, recorder.Code)
+			assert.Contains(recorder.Body.String(), "record project worktree runtime tmux session")
+			assert.Contains(recorder.Body.String(), "context canceled")
+			assert.FileExists(fixture.tmux.statePath)
+			sessions = fixture.server.runtime.ListSessions(scope)
+			require.Len(sessions, 1)
+			assert.Equal(original.Key, sessions[0].Key)
+			assert.Equal(original.TmuxSession, sessions[0].TmuxSession)
+			record, err := os.ReadFile(fixture.tmux.recordPath)
+			require.NoError(err)
+			assert.NotContains(
+				string(record), "kill-session\x00-t\x00"+original.TmuxSession,
+			)
+			rows, err := fixture.server.db.ListProjectWorktreeTmuxSessions(
+				context.Background(), fixture.worktreeID,
+			)
+			require.NoError(err)
+			require.Len(rows, 1)
+			assert.Equal(original.Key, rows[0].SessionKey)
+			assert.Equal(original.TmuxSession, rows[0].SessionName)
+		})
+	}
+}
+
+func TestProjectWorktreeRuntimeLaunchPersistenceFailurePreservesReattachedCommandBackend(
+	t *testing.T,
+) {
+	requirePTYAvailable(t)
+	assert := assert.New(t)
+	require := require.New(t)
+	fixture := setupRuntimeLaunchRollbackFixture(t, false)
+	scope := workspaceapi.ProjectWorktreeRuntimeScope(fixture.worktreeID)
+	path := "/api/v1/projects/" + fixture.projectID + "/worktrees/" +
+		fixture.worktreeID + "/runtime/sessions"
+	body := mustMarshal(t, map[string]any{
+		"session_key": "surface:project:rollback:reattached",
+		"command":     []string{"/bin/sh", "-lc", "exec sleep 60"},
+		"label":       "Rollback Reattached Command",
+	})
+	initial := serveRuntimeRequestAsync(
+		fixture.server, t.Context(), http.MethodPost, path, body,
+	)
+	require.Equal(http.StatusOK, awaitRuntimeResponse(t, initial).Code)
+	sessions := fixture.server.runtime.ListSessions(scope)
+	require.Len(sessions, 1)
+	original := sessions[0]
+	require.NoError(fixture.server.runtime.Detach(scope, original.Key))
+	require.Empty(fixture.server.runtime.ListSessions(scope))
+
+	transaction := occupyRuntimeWriter(t, fixture.server.db)
+	baseline := fixture.server.db.WriteDB().Stats().WaitCount
+	ctx, cancel := context.WithCancel(t.Context())
+	responses := serveRuntimeRequestAsync(
+		fixture.server, ctx, http.MethodPost, path, body,
+	)
+	waitForRuntimeWriterWait(t, fixture.server.db, baseline)
+	cancel()
+	recorder := awaitRuntimeResponse(t, responses)
+	require.NoError(transaction.Rollback())
+
+	assert.Equal(http.StatusInternalServerError, recorder.Code)
+	assert.Contains(
+		recorder.Body.String(), "record project worktree runtime tmux session",
+	)
+	assert.Contains(recorder.Body.String(), "context canceled")
+	assert.FileExists(fixture.tmux.statePath)
+	sessions = fixture.server.runtime.ListSessions(scope)
+	require.Len(sessions, 1)
+	assert.Equal(original.Key, sessions[0].Key)
+	assert.Equal(original.TmuxSession, sessions[0].TmuxSession)
+	record, err := os.ReadFile(fixture.tmux.recordPath)
+	require.NoError(err)
+	assert.NotContains(
+		string(record), "kill-session\x00-t\x00"+original.TmuxSession,
+	)
+	rows, err := fixture.server.db.ListProjectWorktreeTmuxSessions(
+		context.Background(), fixture.worktreeID,
+	)
+	require.NoError(err)
+	require.Len(rows, 1)
+	assert.Equal(original.Key, rows[0].SessionKey)
+	assert.Equal(original.TmuxSession, rows[0].SessionName)
+}
+
+func TestProjectWorktreeRuntimeLaunchPersistenceFailureLogsRollbackFailureAndPreservesPersistenceError(
+	t *testing.T,
+) {
+	requirePTYAvailable(t)
+	assert := assert.New(t)
+	require := require.New(t)
+	fixture := setupRuntimeLaunchRollbackFixture(t, true)
+	scope := workspaceapi.ProjectWorktreeRuntimeScope(fixture.worktreeID)
+	var logs bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, nil)))
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
+	transaction := occupyRuntimeWriter(t, fixture.server.db)
+	baseline := fixture.server.db.WriteDB().Stats().WaitCount
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	responses := serveRuntimeRequestAsync(
+		fixture.server, ctx, http.MethodPost,
+		"/api/v1/projects/"+fixture.projectID+"/worktrees/"+fixture.worktreeID+
+			"/runtime/sessions",
+		mustMarshal(t, map[string]any{
+			"session_key": "surface:project:rollback:failure",
+			"command":     []string{"/bin/sh", "-lc", "exec sleep 60"},
+			"label":       "Rollback Failure Command",
+		}),
+	)
+	require.Eventually(func() bool {
+		_, err := os.Stat(fixture.tmux.attachStartedPath)
+		return err == nil
+	}, time.Second, 10*time.Millisecond)
+	waitForRuntimeWriterWait(t, fixture.server.db, baseline)
+	launched := fixture.server.runtime.ListSessions(scope)[0]
+	require.NoError(os.WriteFile(fixture.tmux.exitAttachPath, nil, 0o600))
+	require.Eventually(func() bool {
+		return len(fixture.server.runtime.ListSessions(scope)) == 0
+	}, time.Second, 10*time.Millisecond)
+	cancel()
+	recorder := awaitRuntimeResponse(t, responses)
+	require.NoError(transaction.Rollback())
+
+	assert.Equal(http.StatusInternalServerError, recorder.Code)
+	assert.Contains(recorder.Body.String(), "record project worktree runtime tmux session")
+	assert.Contains(recorder.Body.String(), "context canceled")
+	assert.NotContains(recorder.Body.String(), "forced kill-session failure")
+	assert.Contains(logs.String(), "roll back unrecorded project worktree runtime session")
+	assert.Contains(logs.String(), fixture.projectID)
+	assert.Contains(logs.String(), fixture.worktreeID)
+	assert.Contains(logs.String(), launched.Key)
+	assert.Contains(logs.String(), launched.TmuxSession)
+	assert.Contains(logs.String(), "forced kill-session failure")
+	assert.FileExists(fixture.tmux.statePath)
+}
+
+func TestCommandSessionExitDuringPersistenceLeavesNoDurableRow(t *testing.T) {
+	requirePTYAvailable(t)
+	tests := []struct {
+		name       string
+		sessionKey string
+		path       func(runtimeLaunchRollbackFixture) string
+		scope      func(runtimeLaunchRollbackFixture) string
+		countRows  func(*testing.T, runtimeLaunchRollbackFixture) int
+	}{
+		{
+			name:       "host_command",
+			sessionKey: "surface:exit-race:host",
+			path: func(runtimeLaunchRollbackFixture) string {
+				return "/api/v1/runtime/sessions"
+			},
+			scope: func(runtimeLaunchRollbackFixture) string {
+				return hostRuntimeScope
+			},
+			countRows: func(t *testing.T, fixture runtimeLaunchRollbackFixture) int {
+				rows, err := fixture.server.db.ListHostRuntimeTmuxSessions(
+					context.Background(),
+				)
+				require.NoError(t, err)
+				return len(rows)
+			},
+		},
+		{
+			name:       "project_command",
+			sessionKey: "surface:exit-race:project",
+			path: func(fixture runtimeLaunchRollbackFixture) string {
+				return "/api/v1/projects/" + fixture.projectID +
+					"/worktrees/" + fixture.worktreeID + "/runtime/sessions"
+			},
+			scope: func(fixture runtimeLaunchRollbackFixture) string {
+				return workspaceapi.ProjectWorktreeRuntimeScope(fixture.worktreeID)
+			},
+			countRows: func(t *testing.T, fixture runtimeLaunchRollbackFixture) int {
+				rows, err := fixture.server.db.ListProjectWorktreeTmuxSessions(
+					context.Background(), fixture.worktreeID,
+				)
+				require.NoError(t, err)
+				return len(rows)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+			fixture := setupRuntimeLaunchRollbackFixture(t, false)
+			scope := test.scope(fixture)
+			body := mustMarshal(t, map[string]any{
+				"session_key": test.sessionKey,
+				"command":     []string{"/bin/sh", "-lc", "exec sleep 60"},
+				"label":       "Exit-race command",
+				"cwd":         t.TempDir(),
+			})
+			transaction := occupyRuntimeWriter(t, fixture.server.db)
+			baseline := fixture.server.db.WriteDB().Stats().WaitCount
+
+			responses := serveRuntimeRequestAsync(
+				fixture.server, t.Context(), http.MethodPost, test.path(fixture), body,
+			)
+			require.Eventually(func() bool {
+				return len(fixture.server.runtime.ListSessions(scope)) == 1
+			}, time.Second, 10*time.Millisecond)
+			waitForRuntimeWriterWait(t, fixture.server.db, baseline)
+
+			// The command exits while its metadata write is still blocked, so
+			// the async exit cleanup can observe zero rows before the write
+			// lands.
+			require.NoError(os.WriteFile(fixture.tmux.exitAttachPath, nil, 0o600))
+			require.Eventually(func() bool {
+				return len(fixture.server.runtime.ListSessions(scope)) == 0
+			}, time.Second, 10*time.Millisecond)
+
+			require.NoError(transaction.Rollback())
+			recorder := awaitRuntimeResponse(t, responses)
+
+			assert.Equal(http.StatusOK, recorder.Code)
+			assert.Zero(test.countRows(t, fixture),
+				"a command that exited before its metadata write completed"+
+					" must not leave a durable row")
+		})
+	}
+}
+
+func TestForgetHostRuntimeCommandSessionIfExitedKeepsLiveAndNewerRows(
+	t *testing.T,
+) {
+	requirePTYAvailable(t)
+	assert := assert.New(t)
+	require := require.New(t)
+	fixture := setupRuntimeLaunchRollbackFixture(t, false)
+	ctx := context.Background()
+
+	responses := serveRuntimeRequestAsync(
+		fixture.server, t.Context(), http.MethodPost, "/api/v1/runtime/sessions",
+		runtimeLaunchRequestBody(t, "surface:exit-race:live"),
+	)
+	recorder := awaitRuntimeResponse(t, responses)
+	require.Equal(http.StatusOK, recorder.Code)
+	live := fixture.server.runtime.ListSessions(hostRuntimeScope)[0]
+
+	// A live session must keep its durable row.
+	fixture.server.forgetHostRuntimeCommandSessionIfExited(ctx, live)
+	rows, err := fixture.server.db.ListHostRuntimeTmuxSessions(ctx)
+	require.NoError(err)
+	require.Len(rows, 1)
+
+	// Reconciling a dead older generation must not delete a newer
+	// generation's row recorded under the same reusable key.
+	stale := live
+	stale.Key = "surface:exit-race:stale"
+	stale.CreatedAt = live.CreatedAt.Add(-time.Minute)
+	require.NoError(fixture.server.db.UpsertHostRuntimeTmuxSession(
+		ctx, &db.HostRuntimeTmuxSession{
+			SessionKey:  stale.Key,
+			SessionName: "newer-generation",
+			Label:       "Newer generation",
+			CWD:         t.TempDir(),
+			CreatedAt:   live.CreatedAt,
+		},
+	))
+	fixture.server.forgetHostRuntimeCommandSessionIfExited(ctx, stale)
+	rows, err = fixture.server.db.ListHostRuntimeTmuxSessions(ctx)
+	require.NoError(err)
+	assert.Len(rows, 2, "an older dead generation must not delete a newer row")
+
+	// The exact dead generation is deleted once no newer row replaced it.
+	stale.CreatedAt = live.CreatedAt
+	fixture.server.forgetHostRuntimeCommandSessionIfExited(ctx, stale)
+	rows, err = fixture.server.db.ListHostRuntimeTmuxSessions(ctx)
+	require.NoError(err)
+	assert.Len(rows, 1)
+	assert.Equal(live.Key, rows[0].SessionKey)
+
+	// A live replacement with the same reusable key must not be mistaken for
+	// the exited generation. If its persistence later fails and rolls back,
+	// the exited generation's durable row must already be gone.
+	require.NoError(fixture.server.runtime.Detach(hostRuntimeScope, live.Key))
+	replacement, err := fixture.server.runtime.EnsureCommandSessionAndPersist(
+		ctx,
+		hostRuntimeScope,
+		localruntime.CommandLaunchSpec{
+			SessionKey: live.Key,
+			Command:    []string{"/bin/sh", "-lc", "exec sleep 60"},
+			Label:      "Replacement generation",
+			CWD:        t.TempDir(),
+		},
+		func(context.Context, localruntime.SessionInfo) error { return nil },
+	)
+	require.NoError(err)
+	require.NotEqual(live.CreatedAt, replacement.CreatedAt)
+	require.NoError(fixture.server.db.UpsertHostRuntimeTmuxSession(
+		ctx, &db.HostRuntimeTmuxSession{
+			SessionKey:  live.Key,
+			SessionName: live.TmuxSession,
+			Label:       live.Label,
+			CWD:         t.TempDir(),
+			CreatedAt:   live.CreatedAt,
+		},
+	))
+
+	fixture.server.forgetHostRuntimeCommandSessionIfExited(ctx, live)
+	rows, err = fixture.server.db.ListHostRuntimeTmuxSessions(ctx)
+	require.NoError(err)
+	assert.Empty(rows)
+}

--- a/internal/server/workspaceapi/handler.go
+++ b/internal/server/workspaceapi/handler.go
@@ -137,6 +137,7 @@ type Handler struct {
 	workspaceSetupMu               sync.Mutex
 	workspaceSetupDone             map[string]chan struct{}
 	workspaceDeleting              map[string]*workspaceDeletion
+	worktreeShellTransactions      sync.Map
 	workspaceTmuxPrunedAt          time.Time
 	workspaceTmuxPrunePending      bool
 	workspaceTmuxPruneInFlight     bool

--- a/internal/server/workspaceapi/projects_handlers.go
+++ b/internal/server/workspaceapi/projects_handlers.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/exec"
@@ -1237,6 +1238,30 @@ func (s *Handler) getProjectWorktreeRuntime(
 	return &getProjectWorktreeRuntimeOutput{Body: out}, nil
 }
 
+func (s *Handler) rollbackProjectWorktreeRuntimeLaunch(
+	ctx context.Context,
+	projectID string,
+	worktreeID string,
+	session localruntime.SessionInfo,
+) {
+	cleanupCtx, cancel := context.WithTimeout(
+		context.WithoutCancel(ctx),
+		5*time.Second,
+	)
+	defer cancel()
+
+	if err := s.runtime.RollbackLaunch(cleanupCtx, session); err != nil {
+		slog.Warn(
+			"roll back unrecorded project worktree runtime session",
+			"project_id", projectID,
+			"worktree_id", worktreeID,
+			"session_key", session.Key,
+			"tmux_session", session.TmuxSession,
+			"err", err,
+		)
+	}
+}
+
 func (s *Handler) ensureProjectWorktreeRuntimeShell(
 	ctx context.Context,
 	input *projectWorktreeIDInput,
@@ -1245,6 +1270,10 @@ func (s *Handler) ensureProjectWorktreeRuntimeShell(
 	if err != nil {
 		return nil, err
 	}
+	transaction := s.projectWorktreeShellTransaction(worktree.ID)
+	transaction.Lock()
+	defer transaction.Unlock()
+
 	scope := projectWorktreeRuntimeScope(worktree.ID)
 	var session localruntime.SessionInfo
 	if shell := projectWorktreeShellSession(s.runtime.ListSessions(scope)); shell != nil {
@@ -1276,7 +1305,12 @@ func (s *Handler) ensureProjectWorktreeRuntimeShell(
 			// a reused live shell would kill someone else's work over
 			// a bookkeeping failure.
 			if !session.Reused {
-				_ = s.runtime.Stop(ctx, scope, session.Key)
+				s.rollbackProjectWorktreeRuntimeLaunch(
+					ctx,
+					input.ProjectID,
+					worktree.ID,
+					session,
+				)
 			}
 			return nil, httpapi.Internal(
 				"record project worktree runtime tmux session: " + err.Error(),
@@ -1347,7 +1381,12 @@ func (s *Handler) launchProjectWorktreeRuntimeSession(
 				CreatedAt:   session.CreatedAt,
 			},
 		); err != nil {
-			_ = s.runtime.Stop(ctx, scope, session.Key)
+			s.rollbackProjectWorktreeRuntimeLaunch(
+				ctx,
+				input.ProjectID,
+				worktree.ID,
+				session,
+			)
 			return nil, httpapi.Internal(
 				"record project worktree runtime tmux session: " + err.Error(),
 			)
@@ -1381,7 +1420,7 @@ func (s *Handler) launchProjectWorktreeRuntimeCommandSession(
 	if cwd == "" {
 		cwd = worktree.Path
 	}
-	session, err := s.runtime.EnsureCommandSession(
+	session, err := s.runtime.EnsureCommandSessionAndPersist(
 		ctx, scope, localruntime.CommandLaunchSpec{
 			SessionKey: sessionKey,
 			Command:    input.Body.Command,
@@ -1389,39 +1428,77 @@ func (s *Handler) launchProjectWorktreeRuntimeCommandSession(
 			Label:      input.Body.Label,
 			CWD:        cwd,
 		},
+		func(ctx context.Context, session localruntime.SessionInfo) error {
+			// Always upsert with the returned live generation: ensure semantics
+			// can reuse a session, and stale async exit cleanup is generation-safe.
+			return s.db.UpsertProjectWorktreeTmuxSession(
+				ctx, &db.ProjectWorktreeTmuxSession{
+					WorktreeID:  worktree.ID,
+					SessionKey:  session.Key,
+					SessionName: session.TmuxSession,
+					Label:       session.Label,
+					CreatedAt:   session.CreatedAt,
+				},
+			)
+		},
 	)
 	if err != nil {
-		return nil, projectWorktreeRuntimeLaunchError(err)
-	}
-	// Always upsert with the returned session's generation: ensure semantics
-	// can return a live reused session or a brand-new one, and the stored
-	// row must carry the live created_at so a stale generation's async exit
-	// cleanup cannot delete it.
-	if session.TmuxSession != "" {
-		if err := s.db.UpsertProjectWorktreeTmuxSession(
-			ctx, &db.ProjectWorktreeTmuxSession{
-				WorktreeID:  worktree.ID,
-				SessionKey:  session.Key,
-				SessionName: session.TmuxSession,
-				Label:       session.Label,
-				CreatedAt:   session.CreatedAt,
-			},
-		); err != nil {
-			// Only roll back a session this request launched (see the
-			// shell ensure above).
-			if !session.Reused {
-				_ = s.runtime.Stop(ctx, scope, session.Key)
+		var persistenceErr *localruntime.CommandSessionPersistenceError
+		if errors.As(err, &persistenceErr) {
+			if persistenceErr.RollbackErr != nil {
+				slog.Warn(
+					"roll back unrecorded project worktree runtime session",
+					"project_id", input.ProjectID,
+					"worktree_id", worktree.ID,
+					"session_key", session.Key,
+					"tmux_session", session.TmuxSession,
+					"err", persistenceErr.RollbackErr,
+				)
 			}
 			return nil, httpapi.Internal(
-				"record project worktree runtime tmux session: " + err.Error(),
+				"record project worktree runtime tmux session: " + persistenceErr.Error(),
 			)
 		}
+		return nil, projectWorktreeRuntimeLaunchError(err)
 	}
+	s.forgetProjectWorktreeCommandSessionIfExited(ctx, scope, worktree.ID, session)
 	return &projectWorktreeRuntimeSessionOutput{
 		Body: projectWorktreeRuntimeSessionFromRuntime(
 			session, input.ProjectID, worktree.ID,
 		),
 	}, nil
+}
+
+// forgetProjectWorktreeCommandSessionIfExited reconciles a command that exited
+// while its metadata write was still in flight: the async exit handler's
+// generation-qualified delete can run before the row exists, so a short-lived
+// command could otherwise leave a durable row for a dead session.
+func (s *Handler) forgetProjectWorktreeCommandSessionIfExited(
+	ctx context.Context,
+	scope string,
+	worktreeID string,
+	session localruntime.SessionInfo,
+) {
+	for _, live := range s.runtime.ListSessions(scope) {
+		if live.SameGeneration(session) {
+			return
+		}
+	}
+	cleanupCtx, cancel := context.WithTimeout(
+		context.WithoutCancel(ctx), runtimeSessionCleanupTimeout,
+	)
+	defer cancel()
+	if _, err := s.db.DeleteProjectWorktreeTmuxSessionCreatedAt(
+		cleanupCtx, worktreeID, session.Key, session.CreatedAt,
+	); err != nil {
+		slog.Warn(
+			"forget project worktree runtime tmux session recorded after exit",
+			"worktree_id", worktreeID,
+			"session_key", session.Key,
+			"tmux_session", session.TmuxSession,
+			"err", err,
+		)
+	}
 }
 
 func (s *Handler) stopProjectWorktreeRuntimeSession(
@@ -1641,6 +1718,13 @@ func (s *Handler) readyRuntimeProjectWorktree(
 
 func projectWorktreeRuntimeScope(worktreeID string) string {
 	return "project-worktree:" + worktreeID
+}
+
+func (s *Handler) projectWorktreeShellTransaction(worktreeID string) *sync.Mutex {
+	transaction, _ := s.worktreeShellTransactions.LoadOrStore(
+		worktreeID, &sync.Mutex{},
+	)
+	return transaction.(*sync.Mutex)
 }
 
 // ProjectWorktreeRuntimeScope returns the runtime-manager scope for a

--- a/internal/server/workspaceapi/projects_handlers.go
+++ b/internal/server/workspaceapi/projects_handlers.go
@@ -1316,6 +1316,9 @@ func (s *Handler) ensureProjectWorktreeRuntimeShell(
 				"record project worktree runtime tmux session: " + err.Error(),
 			)
 		}
+		s.forgetProjectWorktreeRuntimeSessionIfExited(
+			ctx, scope, worktree.ID, session,
+		)
 	}
 	return &projectWorktreeRuntimeSessionOutput{
 		Body: projectWorktreeRuntimeSessionFromRuntime(session, input.ProjectID, worktree.ID),
@@ -1391,6 +1394,9 @@ func (s *Handler) launchProjectWorktreeRuntimeSession(
 				"record project worktree runtime tmux session: " + err.Error(),
 			)
 		}
+		s.forgetProjectWorktreeRuntimeSessionIfExited(
+			ctx, scope, worktree.ID, session,
+		)
 	}
 	return &projectWorktreeRuntimeSessionOutput{
 		Body: projectWorktreeRuntimeSessionFromRuntime(session, input.ProjectID, worktree.ID),
@@ -1461,7 +1467,7 @@ func (s *Handler) launchProjectWorktreeRuntimeCommandSession(
 		}
 		return nil, projectWorktreeRuntimeLaunchError(err)
 	}
-	s.forgetProjectWorktreeCommandSessionIfExited(ctx, scope, worktree.ID, session)
+	s.forgetProjectWorktreeRuntimeSessionIfExited(ctx, scope, worktree.ID, session)
 	return &projectWorktreeRuntimeSessionOutput{
 		Body: projectWorktreeRuntimeSessionFromRuntime(
 			session, input.ProjectID, worktree.ID,
@@ -1469,11 +1475,11 @@ func (s *Handler) launchProjectWorktreeRuntimeCommandSession(
 	}, nil
 }
 
-// forgetProjectWorktreeCommandSessionIfExited reconciles a command that exited
+// forgetProjectWorktreeRuntimeSessionIfExited reconciles a session that exited
 // while its metadata write was still in flight: the async exit handler's
 // generation-qualified delete can run before the row exists, so a short-lived
-// command could otherwise leave a durable row for a dead session.
-func (s *Handler) forgetProjectWorktreeCommandSessionIfExited(
+// launch could otherwise leave a durable row for a dead session.
+func (s *Handler) forgetProjectWorktreeRuntimeSessionIfExited(
 	ctx context.Context,
 	scope string,
 	worktreeID string,

--- a/internal/server/workspaceapi/routes_handlers.go
+++ b/internal/server/workspaceapi/routes_handlers.go
@@ -2105,7 +2105,15 @@ func (s *Handler) launchWorkspaceRuntimeSession(
 			context.WithoutCancel(ctx), 5*time.Second,
 		)
 		defer cancel()
-		_ = s.runtime.Stop(cleanupCtx, summary.ID, session.Key)
+		if cleanupErr := s.runtime.RollbackLaunch(cleanupCtx, session); cleanupErr != nil {
+			slog.Warn(
+				"roll back unrecorded runtime session",
+				"workspace_id", summary.ID,
+				"session_key", session.Key,
+				"tmux_session", session.TmuxSession,
+				"err", cleanupErr,
+			)
+		}
 		return nil, err
 	}
 	s.invalidateWorkspaceEnrichment(summary.ID)

--- a/internal/server/workspacetest/pty_owner_e2e_test.go
+++ b/internal/server/workspacetest/pty_owner_e2e_test.go
@@ -206,6 +206,9 @@ func buildRustPtyManagerForTest(t *testing.T) string {
 	if err != nil {
 		t.Skip("cargo not available")
 	}
+	if err := procutil.Command(cargo, "--version").Run(); err != nil {
+		t.Skipf("cargo not usable: %v", err)
+	}
 	rustPtyManagerBuild.once.Do(func() {
 		root := repoRootForPtyOwnerTest(t)
 		cmd := procutil.Command(cargo, "build", "-p", "kenn-forge-pty-manager")

--- a/internal/workspace/localruntime/command_session.go
+++ b/internal/workspace/localruntime/command_session.go
@@ -21,9 +21,9 @@ var ErrSessionKeyConflict = errors.New("session key conflict")
 type CommandLaunchSpec struct {
 	// SessionKey optionally names the session with a caller-owned durable
 	// key. When a live command session with the same key already exists in
-	// the same scope, EnsureCommandSession returns it instead of launching
-	// again; a key owned by a different session kind (agent, shell) is a
-	// conflict. Empty means a random session key is generated.
+	// the same scope, EnsureCommandSessionAndPersist returns it instead of
+	// launching again; a key owned by a different session kind (agent, shell)
+	// is a conflict. Empty means a random session key is generated.
 	SessionKey string
 	// Command is the argv to run inside the tmux pane. Required.
 	Command []string
@@ -37,15 +37,38 @@ type CommandLaunchSpec struct {
 	CWD string
 }
 
-// EnsureCommandSession launches spec.Command in a tmux session owned by this
-// manager, or returns the existing live session when spec.SessionKey names
-// one in the same scope. The tmux session name is derived deterministically
-// from (workspaceID, key), so re-ensuring after a manager restart reattaches
-// to a surviving tmux session instead of launching a duplicate.
-func (m *Manager) EnsureCommandSession(
+// CommandSessionPersistenceError reports that a command session generation
+// could not be recorded durably. PersistenceErr remains the caller-visible
+// cause; RollbackErr is diagnostic only.
+type CommandSessionPersistenceError struct {
+	PersistenceErr error
+	RollbackErr    error
+}
+
+func (e *CommandSessionPersistenceError) Error() string {
+	if e == nil || e.PersistenceErr == nil {
+		return "command session persistence failed"
+	}
+	return e.PersistenceErr.Error()
+}
+
+func (e *CommandSessionPersistenceError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.PersistenceErr
+}
+
+// EnsureCommandSessionAndPersist launches spec.Command in a tmux session owned
+// by this manager, or returns the existing live session when spec.SessionKey
+// names one in the same scope. Same-key ensure, persistence, and compensation
+// share one manager-owned transaction, so no request can reuse a generation
+// while another request still owns rollback authority over it.
+func (m *Manager) EnsureCommandSessionAndPersist(
 	ctx context.Context,
 	workspaceID string,
 	spec CommandLaunchSpec,
+	persist func(context.Context, SessionInfo) error,
 ) (SessionInfo, error) {
 	if err := ctx.Err(); err != nil {
 		return SessionInfo{}, err
@@ -69,6 +92,69 @@ func (m *Manager) EnsureCommandSession(
 		startMu := m.startLock(key)
 		startMu.Lock()
 		defer startMu.Unlock()
+		return m.ensureCommandSessionAndPersistLocked(
+			ctx, workspaceID, spec, key, persist,
+		)
+	}
+
+	session, err := m.ensureCommandSessionLocked(ctx, workspaceID, spec, "")
+	if err != nil {
+		return SessionInfo{}, err
+	}
+	startMu := m.startLock(session.Key)
+	startMu.Lock()
+	defer startMu.Unlock()
+	return m.persistCommandSessionLocked(ctx, session, persist)
+}
+
+func (m *Manager) ensureCommandSessionAndPersistLocked(
+	ctx context.Context,
+	workspaceID string,
+	spec CommandLaunchSpec,
+	key string,
+	persist func(context.Context, SessionInfo) error,
+) (SessionInfo, error) {
+	session, err := m.ensureCommandSessionLocked(ctx, workspaceID, spec, key)
+	if err != nil {
+		return SessionInfo{}, err
+	}
+	return m.persistCommandSessionLocked(ctx, session, persist)
+}
+
+func (m *Manager) persistCommandSessionLocked(
+	ctx context.Context,
+	session SessionInfo,
+	persist func(context.Context, SessionInfo) error,
+) (SessionInfo, error) {
+	persistenceErr := persist(ctx, session)
+	if persistenceErr == nil {
+		return session, nil
+	}
+
+	var rollbackErr error
+	if !session.Reused {
+		cleanupCtx, cancel := context.WithTimeout(
+			context.WithoutCancel(ctx), 5*time.Second,
+		)
+		rollbackErr = m.rollbackLaunchLocked(cleanupCtx, session)
+		cancel()
+	}
+	return session, &CommandSessionPersistenceError{
+		PersistenceErr: persistenceErr,
+		RollbackErr:    rollbackErr,
+	}
+}
+
+// ensureCommandSessionLocked assumes the caller owns startLock(key) when key is
+// non-empty. Empty keys are generated here and locked by the caller before
+// persistence or compensation.
+func (m *Manager) ensureCommandSessionLocked(
+	ctx context.Context,
+	workspaceID string,
+	spec CommandLaunchSpec,
+	key string,
+) (SessionInfo, error) {
+	if key != "" {
 		if existing := m.runningSession(m.sessions, key); existing != nil {
 			info := existing.snapshot()
 			if info.WorkspaceID != workspaceID {
@@ -126,17 +212,23 @@ func (m *Manager) EnsureCommandSession(
 	}
 
 	started, err := m.startOwnedSession(ctx, SessionInfo{
-		Key:         key,
-		WorkspaceID: workspaceID,
-		Label:       label,
-		Kind:        LaunchTargetCommand,
-		Status:      SessionStatusStarting,
-		CreatedAt:   time.Now().UTC(),
-		TmuxSession: launch.TmuxSession,
+		Key:          key,
+		WorkspaceID:  workspaceID,
+		Label:        label,
+		Kind:         LaunchTargetCommand,
+		Status:       SessionStatusStarting,
+		CreatedAt:    time.Now().UTC(),
+		TmuxSession:  launch.TmuxSession,
+		tmuxLaunchID: launch.TmuxLaunchID,
+		Reused:       !launch.TmuxCreated,
 	}, launch.Command, spec.CWD, stripEnvVars)
 	if err != nil {
 		if launch.TmuxCreated {
-			_ = m.killTmuxSession(ctx, launch.TmuxSession)
+			cleanupCtx, cancel := context.WithTimeout(
+				context.WithoutCancel(ctx), 5*time.Second,
+			)
+			_ = m.killTmuxSession(cleanupCtx, launch.TmuxSession)
+			cancel()
 		}
 		return SessionInfo{}, err
 	}
@@ -185,6 +277,10 @@ func (m *Manager) commandSessionLaunch(
 	command[0] = resolvedPath
 
 	tmuxSession := tmuxSessionName(workspaceID, key)
+	launchID, err := newTmuxLaunchID()
+	if err != nil {
+		return launchCommand{}, err
+	}
 	paneEnv := tmuxAgentEnvPolicy.paneEnvironmentWithExtra(
 		os.Environ(), command, stripEnvVars, spec.Env,
 	)
@@ -194,14 +290,19 @@ func (m *Manager) commandSessionLaunch(
 		CWD:         spec.CWD,
 		Pane:        paneEnv,
 		OwnerMarker: m.tmuxOwnerMarker,
+		LaunchID:    launchID,
 		HideStatus:  m.currentHideTmuxStatus(),
 	}.prepare(ctx)
 	if err != nil {
 		return launchCommand{}, err
 	}
-	return launchCommand{
+	result := launchCommand{
 		Command:     prepared.AttachCommand,
 		TmuxSession: tmuxSession,
 		TmuxCreated: prepared.Created,
-	}, nil
+	}
+	if prepared.Created {
+		result.TmuxLaunchID = launchID
+	}
+	return result, nil
 }

--- a/internal/workspace/localruntime/command_session_test.go
+++ b/internal/workspace/localruntime/command_session_test.go
@@ -2,6 +2,7 @@ package localruntime
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -25,6 +26,8 @@ func writeCommandSessionFakeTmux(
 	dir := t.TempDir()
 	recordPath = filepath.Join(dir, "tmux-record")
 	statePath = filepath.Join(dir, "tmux-session-exists")
+	launchPath := filepath.Join(dir, "tmux-launch-id")
+	killFailurePath := filepath.Join(dir, "tmux-kill-failure")
 	tmuxPath = filepath.Join(dir, "tmux")
 	script := fmt.Sprintf(`#!/bin/sh
 printf '%%s\0' "$#" "$@" >> %s
@@ -37,14 +40,47 @@ case "$1" in
     ;;
   new-session)
     touch %s
+    marker=""
+    for arg in "$@"; do
+      if [ "$marker" = "next" ]; then
+        printf '%%s\n' "$arg" > %s
+        marker="done"
+      fi
+      if [ "$arg" = "@forge_launch" ]; then marker="next"; fi
+    done
+    exit 0
+    ;;
+  set-option)
+    marker=""
+    for arg in "$@"; do
+      if [ "$marker" = "next" ]; then
+        printf '%%s\n' "$arg" > %s
+        marker="done"
+      fi
+      if [ "$arg" = "@forge_launch" ]; then marker="next"; fi
+    done
     exit 0
     ;;
   show-options)
-    printf '%%s\n' %s
+    option=""
+    for arg in "$@"; do option="$arg"; done
+    if [ "$option" = "@forge_launch" ]; then
+      if [ -f %s ]; then cat %s; fi
+    else
+      printf '%%s\n' %s
+    fi
     exit 0
     ;;
   attach-session)
     exec sleep 60
+    ;;
+  kill-session)
+    if [ -f %s ]; then
+      echo "forced kill-session failure" >&2
+      exit 1
+    fi
+    rm -f %s
+    exit 0
     ;;
 esac
 exit 0
@@ -52,7 +88,13 @@ exit 0
 		shellquote.Join(recordPath),
 		shellquote.Join(statePath),
 		shellquote.Join(statePath),
+		shellquote.Join(launchPath),
+		shellquote.Join(launchPath),
+		shellquote.Join(launchPath),
+		shellquote.Join(launchPath),
 		shellquote.Join(ownerMarker),
+		shellquote.Join(killFailurePath),
+		shellquote.Join(statePath),
 	)
 	require.NoError(t, os.WriteFile(tmuxPath, []byte(script), 0o755))
 	return tmuxPath, recordPath, statePath
@@ -68,7 +110,11 @@ func commandSessionTestSpec(key string, cwd string) CommandLaunchSpec {
 	}
 }
 
-func TestEnsureCommandSessionLaunchesTmuxBackedCommand(t *testing.T) {
+func persistCommandSessionNoop(context.Context, SessionInfo) error {
+	return nil
+}
+
+func TestEnsureCommandSessionAndPersistLaunchesTmuxBackedCommand(t *testing.T) {
 	requirePTYAvailable(t)
 	require := require.New(t)
 	assert := assert.New(t)
@@ -82,9 +128,10 @@ func TestEnsureCommandSessionLaunchesTmuxBackedCommand(t *testing.T) {
 	t.Cleanup(mgr.Shutdown)
 
 	cwd := t.TempDir()
-	info, err := mgr.EnsureCommandSession(
+	info, err := mgr.EnsureCommandSessionAndPersist(
 		context.Background(), "scope-1",
 		commandSessionTestSpec("client:key one", cwd),
+		persistCommandSessionNoop,
 	)
 	require.NoError(err)
 
@@ -116,7 +163,7 @@ func TestEnsureCommandSessionLaunchesTmuxBackedCommand(t *testing.T) {
 	assert.Equal("client:key one", sessions[0].Key)
 }
 
-func TestEnsureCommandSessionReturnsExistingLiveSession(t *testing.T) {
+func TestEnsureCommandSessionAndPersistReturnsExistingLiveSession(t *testing.T) {
 	requirePTYAvailable(t)
 	require := require.New(t)
 	assert := assert.New(t)
@@ -131,8 +178,9 @@ func TestEnsureCommandSessionReturnsExistingLiveSession(t *testing.T) {
 
 	ctx := context.Background()
 	cwd := t.TempDir()
-	first, err := mgr.EnsureCommandSession(
+	first, err := mgr.EnsureCommandSessionAndPersist(
 		ctx, "scope-1", commandSessionTestSpec("client:key one", cwd),
+		persistCommandSessionNoop,
 	)
 	require.NoError(err)
 	require.Eventually(func() bool {
@@ -144,8 +192,9 @@ func TestEnsureCommandSessionReturnsExistingLiveSession(t *testing.T) {
 	}, 2*time.Second, 20*time.Millisecond)
 	callsAfterFirst := len(readNullArgvRecord(t, recordPath))
 
-	second, err := mgr.EnsureCommandSession(
+	second, err := mgr.EnsureCommandSessionAndPersist(
 		ctx, "scope-1", commandSessionTestSpec("client:key one", cwd),
+		persistCommandSessionNoop,
 	)
 	require.NoError(err)
 
@@ -159,7 +208,7 @@ func TestEnsureCommandSessionReturnsExistingLiveSession(t *testing.T) {
 	assert.Len(mgr.ListSessions("scope-1"), 1)
 }
 
-func TestEnsureCommandSessionRejectsKeyOwnedByAnotherScope(t *testing.T) {
+func TestEnsureCommandSessionAndPersistRejectsKeyOwnedByAnotherScope(t *testing.T) {
 	requirePTYAvailable(t)
 	require := require.New(t)
 	tmuxPath, _, _ := writeCommandSessionFakeTmux(t, "kenn-forge:test-owner")
@@ -170,32 +219,35 @@ func TestEnsureCommandSessionRejectsKeyOwnedByAnotherScope(t *testing.T) {
 	t.Cleanup(mgr.Shutdown)
 
 	ctx := context.Background()
-	_, err := mgr.EnsureCommandSession(
+	_, err := mgr.EnsureCommandSessionAndPersist(
 		ctx, "scope-1", commandSessionTestSpec("client:key one", t.TempDir()),
+		persistCommandSessionNoop,
 	)
 	require.NoError(err)
 
-	_, err = mgr.EnsureCommandSession(
+	_, err = mgr.EnsureCommandSessionAndPersist(
 		ctx, "scope-2", commandSessionTestSpec("client:key one", t.TempDir()),
+		persistCommandSessionNoop,
 	)
 	require.Error(err)
 	require.Contains(err.Error(), "another scope")
 }
 
-func TestEnsureCommandSessionRequiresCommand(t *testing.T) {
+func TestEnsureCommandSessionAndPersistRequiresCommand(t *testing.T) {
 	tmuxPath, _, _ := writeCommandSessionFakeTmux(t, "kenn-forge:test-owner")
 	mgr := NewManager(Options{TmuxCommand: []string{tmuxPath}})
 	t.Cleanup(mgr.Shutdown)
 
-	_, err := mgr.EnsureCommandSession(
+	_, err := mgr.EnsureCommandSessionAndPersist(
 		context.Background(), "scope-1",
 		CommandLaunchSpec{SessionKey: "client:key one"},
+		persistCommandSessionNoop,
 	)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "command is required")
 }
 
-func TestEnsureCommandSessionReattachesToSurvivingTmuxSession(t *testing.T) {
+func TestEnsureCommandSessionAndPersistReattachesToSurvivingTmuxSession(t *testing.T) {
 	requirePTYAvailable(t)
 	require := require.New(t)
 	assert := assert.New(t)
@@ -210,14 +262,17 @@ func TestEnsureCommandSessionReattachesToSurvivingTmuxSession(t *testing.T) {
 	})
 	t.Cleanup(mgr.Shutdown)
 
-	info, err := mgr.EnsureCommandSession(
+	info, err := mgr.EnsureCommandSessionAndPersist(
 		context.Background(), "scope-1",
 		commandSessionTestSpec("client:key one", t.TempDir()),
+		persistCommandSessionNoop,
 	)
 	require.NoError(err)
 
 	sessionName := tmuxSessionName("scope-1", "client:key one")
 	assert.Equal(sessionName, info.TmuxSession)
+	assert.True(info.Reused,
+		"reattaching to a surviving backend must not claim launch ownership")
 	for _, record := range readNullArgvRecord(t, recordPath) {
 		if len(record) > 0 {
 			assert.NotEqual("new-session", record[0])
@@ -225,7 +280,245 @@ func TestEnsureCommandSessionReattachesToSurvivingTmuxSession(t *testing.T) {
 	}
 }
 
-func TestEnsureCommandSessionRejectsForeignTmuxSessionOwner(t *testing.T) {
+func TestRollbackLaunchPreservesNewerCommandSessionGeneration(t *testing.T) {
+	requirePTYAvailable(t)
+	require := require.New(t)
+	assert := assert.New(t)
+	tmuxPath, recordPath, statePath := writeCommandSessionFakeTmux(
+		t, "kenn-forge:test-owner",
+	)
+	mgr := NewManager(Options{
+		TmuxCommand:     []string{tmuxPath},
+		TmuxOwnerMarker: "kenn-forge:test-owner",
+	})
+	t.Cleanup(mgr.Shutdown)
+
+	ctx := context.Background()
+	cwd := t.TempDir()
+	original, err := mgr.EnsureCommandSessionAndPersist(
+		ctx, "scope-1", commandSessionTestSpec("client:key one", cwd),
+		persistCommandSessionNoop,
+	)
+	require.NoError(err)
+	require.NoError(mgr.Detach(original.WorkspaceID, original.Key))
+	require.NoError(os.Remove(statePath))
+
+	replacement, err := mgr.EnsureCommandSessionAndPersist(
+		ctx, "scope-1", commandSessionTestSpec("client:key one", cwd),
+		persistCommandSessionNoop,
+	)
+	require.NoError(err)
+	require.NotEqual(original.CreatedAt, replacement.CreatedAt)
+	require.NoError(mgr.Detach(replacement.WorkspaceID, replacement.Key))
+	require.Empty(mgr.ListSessions("scope-1"))
+
+	require.NoError(mgr.RollbackLaunch(ctx, original))
+
+	assert.FileExists(statePath)
+	record, err := os.ReadFile(recordPath)
+	require.NoError(err)
+	assert.NotContains(
+		string(record), "kill-session\x00-t\x00"+replacement.TmuxSession,
+	)
+}
+
+func TestRollbackLaunchPreservesAdoptedCommandSessionBackend(t *testing.T) {
+	requirePTYAvailable(t)
+	require := require.New(t)
+	assert := assert.New(t)
+	tmuxPath, recordPath, statePath := writeCommandSessionFakeTmux(
+		t, "kenn-forge:test-owner",
+	)
+	mgr := NewManager(Options{
+		TmuxCommand:     []string{tmuxPath},
+		TmuxOwnerMarker: "kenn-forge:test-owner",
+	})
+	t.Cleanup(mgr.Shutdown)
+
+	ctx := context.Background()
+	cwd := t.TempDir()
+	original, err := mgr.EnsureCommandSessionAndPersist(
+		ctx, "scope-1", commandSessionTestSpec("client:key one", cwd),
+		persistCommandSessionNoop,
+	)
+	require.NoError(err)
+	require.False(original.Reused)
+	require.NoError(mgr.Detach(original.WorkspaceID, original.Key))
+
+	// The backend survived the detach, so the next ensure adopts it instead
+	// of creating a new generation.
+	adopted, err := mgr.EnsureCommandSessionAndPersist(
+		ctx, "scope-1", commandSessionTestSpec("client:key one", cwd),
+		persistCommandSessionNoop,
+	)
+	require.NoError(err)
+	require.True(adopted.Reused,
+		"a surviving backend must be adopted, not recreated")
+	require.NoError(mgr.Detach(adopted.WorkspaceID, adopted.Key))
+	require.Empty(mgr.ListSessions("scope-1"))
+
+	require.NoError(mgr.RollbackLaunch(ctx, original))
+
+	assert.FileExists(statePath,
+		"a stale creator rollback must not kill an adopted backend")
+	record, err := os.ReadFile(recordPath)
+	require.NoError(err)
+	assert.NotContains(string(record), "kill-session")
+}
+
+func TestEnsureCommandSessionAndPersistSerializesSameKeyOwnership(t *testing.T) {
+	requirePTYAvailable(t)
+	require := require.New(t)
+	assert := assert.New(t)
+	tmuxPath, recordPath, statePath := writeCommandSessionFakeTmux(
+		t, "kenn-forge:test-owner",
+	)
+	mgr := NewManager(Options{
+		TmuxCommand:     []string{tmuxPath},
+		TmuxOwnerMarker: "kenn-forge:test-owner",
+	})
+	t.Cleanup(mgr.Shutdown)
+
+	type ensureResult struct {
+		info SessionInfo
+		err  error
+	}
+	ctx := context.Background()
+	spec := commandSessionTestSpec("surface:shared", t.TempDir())
+	aPersistEntered := make(chan struct{})
+	failAPersist := make(chan struct{})
+	aResults := make(chan ensureResult, 1)
+	persistenceErr := errors.New("metadata write failed")
+	go func() {
+		info, err := mgr.EnsureCommandSessionAndPersist(
+			ctx, "scope-1", spec,
+			func(_ context.Context, persisted SessionInfo) error {
+				assert.Equal("surface:shared", persisted.Key)
+				close(aPersistEntered)
+				<-failAPersist
+				return persistenceErr
+			},
+		)
+		aResults <- ensureResult{info: info, err: err}
+	}()
+	<-aPersistEntered
+	assert.True(
+		mgr.CommandSessionStartLockHeldForTest(spec.SessionKey),
+		"A must hold the keyed transaction lock during persistence",
+	)
+
+	bPersistEntered := make(chan struct{})
+	finishBPersist := make(chan struct{})
+	bResults := make(chan ensureResult, 1)
+	go func() {
+		info, err := mgr.EnsureCommandSessionAndPersist(
+			ctx, "scope-1", spec,
+			func(_ context.Context, persisted SessionInfo) error {
+				assert.Equal("surface:shared", persisted.Key)
+				close(bPersistEntered)
+				<-finishBPersist
+				return nil
+			},
+		)
+		bResults <- ensureResult{info: info, err: err}
+	}()
+	require.Never(func() bool {
+		select {
+		case <-bPersistEntered:
+			return true
+		default:
+			return false
+		}
+	}, 100*time.Millisecond, 10*time.Millisecond)
+
+	close(failAPersist)
+	require.Eventually(func() bool {
+		select {
+		case <-bPersistEntered:
+			return true
+		default:
+			return false
+		}
+	}, 2*time.Second, 10*time.Millisecond)
+	require.Eventually(func() bool { return len(aResults) == 1 }, time.Second, 10*time.Millisecond)
+	aResult := <-aResults
+	require.Error(aResult.err)
+	require.ErrorIs(aResult.err, persistenceErr)
+	assert.False(aResult.info.Reused)
+
+	records := readNullArgvRecord(t, recordPath)
+	var newSessionIndexes []int
+	var killSessionIndexes []int
+	for index, record := range records {
+		if len(record) == 0 {
+			continue
+		}
+		switch record[0] {
+		case "new-session":
+			newSessionIndexes = append(newSessionIndexes, index)
+		case "kill-session":
+			killSessionIndexes = append(killSessionIndexes, index)
+		}
+	}
+	require.Len(newSessionIndexes, 2)
+	require.NotEmpty(killSessionIndexes)
+	for _, index := range killSessionIndexes {
+		assert.Less(index, newSessionIndexes[1],
+			"A's compensation must finish before B creates its generation")
+	}
+	assert.FileExists(statePath)
+
+	close(finishBPersist)
+	require.Eventually(func() bool { return len(bResults) == 1 }, time.Second, 10*time.Millisecond)
+	bResult := <-bResults
+	require.NoError(bResult.err)
+	assert.False(bResult.info.Reused)
+	assert.NotEqual(aResult.info.tmuxLaunchID, bResult.info.tmuxLaunchID)
+	sessions := mgr.ListSessions("scope-1")
+	require.Len(sessions, 1)
+	assert.Equal(bResult.info.Key, sessions[0].Key)
+	assert.Equal(bResult.info.CreatedAt, sessions[0].CreatedAt)
+	assert.Equal(bResult.info.TmuxSession, sessions[0].TmuxSession)
+	assert.FileExists(statePath)
+}
+
+func TestEnsureCommandSessionAndPersistPreservesPersistenceCauseAndRollbackDiagnostics(
+	t *testing.T,
+) {
+	requirePTYAvailable(t)
+	require := require.New(t)
+	assert := assert.New(t)
+	tmuxPath, _, statePath := writeCommandSessionFakeTmux(
+		t, "kenn-forge:test-owner",
+	)
+	require.NoError(os.WriteFile(
+		filepath.Join(filepath.Dir(statePath), "tmux-kill-failure"), nil, 0o600,
+	))
+	mgr := NewManager(Options{
+		TmuxCommand:     []string{tmuxPath},
+		TmuxOwnerMarker: "kenn-forge:test-owner",
+	})
+	t.Cleanup(mgr.Shutdown)
+	persistenceErr := errors.New("metadata write failed")
+
+	_, err := mgr.EnsureCommandSessionAndPersist(
+		context.Background(), "scope-1",
+		commandSessionTestSpec("surface:typed-error", t.TempDir()),
+		func(context.Context, SessionInfo) error { return persistenceErr },
+	)
+	require.Error(err)
+	var transactionErr *CommandSessionPersistenceError
+	require.ErrorAs(err, &transactionErr)
+	assert.Same(persistenceErr, transactionErr.PersistenceErr)
+	require.Error(transactionErr.RollbackErr)
+	assert.Contains(transactionErr.RollbackErr.Error(), "forced kill-session failure")
+	require.ErrorIs(err, persistenceErr)
+	require.NotErrorIs(err, transactionErr.RollbackErr)
+	assert.Equal(persistenceErr.Error(), err.Error())
+	assert.NotContains(err.Error(), "forced kill-session failure")
+}
+
+func TestEnsureCommandSessionAndPersistRejectsForeignTmuxSessionOwner(t *testing.T) {
 	requirePTYAvailable(t)
 	require := require.New(t)
 	tmuxPath, _, statePath := writeCommandSessionFakeTmux(
@@ -238,9 +531,10 @@ func TestEnsureCommandSessionRejectsForeignTmuxSessionOwner(t *testing.T) {
 	})
 	t.Cleanup(mgr.Shutdown)
 
-	_, err := mgr.EnsureCommandSession(
+	_, err := mgr.EnsureCommandSessionAndPersist(
 		context.Background(), "scope-1",
 		commandSessionTestSpec("client:key one", t.TempDir()),
+		persistCommandSessionNoop,
 	)
 	require.Error(err)
 	require.Contains(err.Error(), "not owned")

--- a/internal/workspace/localruntime/manager.go
+++ b/internal/workspace/localruntime/manager.go
@@ -58,14 +58,25 @@ type SessionInfo struct {
 	ExitedAt      *time.Time       `json:"exited_at,omitempty"`
 	ExitCode      *int             `json:"exit_code,omitempty"`
 	TmuxSession   string           `json:"-"`
-	// Reused reports that ensure semantics returned an already-live
-	// session instead of launching one. Callers whose post-launch
-	// bookkeeping fails must not stop a session they did not start.
+	// tmuxLaunchID identifies the concrete tmux backend generation created for
+	// this launch. It is empty when the manager reattached to a pre-existing
+	// backend instead of creating one.
+	tmuxLaunchID string
+	// Reused reports that ensure semantics returned an already-live attachment
+	// or reattached to a pre-existing backend. Callers whose post-launch
+	// bookkeeping fails must not stop a session they did not create.
 	Reused bool `json:"-"`
 }
 
 func (s SessionInfo) Compare(other SessionInfo) int {
 	return s.CreatedAt.Compare(other.CreatedAt)
+}
+
+// SameGeneration reports whether two snapshots identify the same reusable
+// session generation. Keys can be reused after an exit, so the key alone is
+// not a generation identity.
+func (s SessionInfo) SameGeneration(other SessionInfo) bool {
+	return s.Key == other.Key && s.CreatedAt.Equal(other.CreatedAt)
 }
 
 type RestoredRuntimeSession struct {
@@ -370,18 +381,24 @@ func (m *Manager) Launch(
 	)
 
 	started, err := m.startOwnedSession(ctx, SessionInfo{
-		Key:         key,
-		WorkspaceID: workspaceID,
-		TargetKey:   targetKey,
-		Label:       label,
-		Kind:        target.Kind,
-		Status:      SessionStatusStarting,
-		CreatedAt:   time.Now().UTC(),
-		TmuxSession: launch.TmuxSession,
+		Key:          key,
+		WorkspaceID:  workspaceID,
+		TargetKey:    targetKey,
+		Label:        label,
+		Kind:         target.Kind,
+		Status:       SessionStatusStarting,
+		CreatedAt:    time.Now().UTC(),
+		TmuxSession:  launch.TmuxSession,
+		tmuxLaunchID: launch.TmuxLaunchID,
+		Reused:       launch.TmuxSession != "" && !launch.TmuxCreated,
 	}, launch.Command, cwd, m.currentStripEnvVars())
 	if err != nil {
 		if launch.TmuxCreated {
-			_ = m.killTmuxSession(ctx, launch.TmuxSession)
+			cleanupCtx, cancel := context.WithTimeout(
+				context.WithoutCancel(ctx), 5*time.Second,
+			)
+			_ = m.killTmuxSession(cleanupCtx, launch.TmuxSession)
+			cancel()
 		}
 		slog.Debug(
 			"runtime launch start failed",
@@ -771,6 +788,53 @@ func (m *Manager) Stop(
 	}
 }
 
+// RollbackLaunch stops the owned backend created by a launch whose caller
+// failed to persist its metadata. A non-tmux backend can be stopped only while
+// its live manager entry proves ownership. A short-lived tmux attachment can
+// disappear from the manager before persistence returns, so tmux rollback falls
+// back to the generation marker retained in the launch result.
+func (m *Manager) RollbackLaunch(ctx context.Context, info SessionInfo) error {
+	if info.Reused {
+		return nil
+	}
+	startMu := m.startLock(info.Key)
+	startMu.Lock()
+	defer startMu.Unlock()
+	return m.rollbackLaunchLocked(ctx, info)
+}
+
+// rollbackLaunchLocked requires the caller to own startLock(info.Key) and the
+// launch result to represent a newly owned backend.
+func (m *Manager) rollbackLaunchLocked(ctx context.Context, info SessionInfo) error {
+	if info.TmuxSession == "" {
+		stopErr := m.Stop(ctx, info.WorkspaceID, info.Key)
+		if errors.Is(stopErr, ErrSessionNotFound) {
+			return nil
+		}
+		return stopErr
+	}
+	if info.tmuxLaunchID == "" {
+		return nil
+	}
+
+	if current, ok := m.session(info.WorkspaceID, info.Key); ok &&
+		current.snapshot().tmuxLaunchID != info.tmuxLaunchID {
+		return nil
+	}
+
+	stopErr := m.Stop(ctx, info.WorkspaceID, info.Key)
+	if errors.Is(stopErr, ErrSessionNotFound) {
+		stopErr = nil
+	}
+	// Stop normally removes the tmux backend itself. Repeat cleanup only when
+	// the retained launch marker still identifies this concrete generation, so
+	// an older rollback cannot kill a newer replacement using the same name.
+	tmuxErr := m.killTmuxSessionIfLaunchID(
+		ctx, info.TmuxSession, info.tmuxLaunchID,
+	)
+	return errors.Join(stopErr, tmuxErr)
+}
+
 // Detach removes an in-memory runtime session attachment without stopping the
 // owned backend.
 func (m *Manager) Detach(workspaceID string, sessionKey string) error {
@@ -908,6 +972,62 @@ func (m *Manager) knownPtyOwnerSessionKeys(workspaceID string) []string {
 	}
 	slices.Sort(keys)
 	return slices.Compact(keys)
+}
+
+func (m *Manager) killTmuxSessionIfLaunchID(
+	ctx context.Context,
+	session string,
+	launchID string,
+) error {
+	actual, exists, err := m.tmuxSessionLaunchID(ctx, session)
+	if err != nil {
+		return err
+	}
+	if !exists || actual != launchID {
+		return nil
+	}
+	return m.killTmuxSession(ctx, session)
+}
+
+func (m *Manager) tmuxSessionLaunchID(
+	ctx context.Context,
+	session string,
+) (string, bool, error) {
+	if session == "" {
+		return "", false, nil
+	}
+	command := slices.Clone(m.tmuxCommand)
+	if len(command) == 0 {
+		command = []string{"tmux"}
+	}
+	if len(command) == 0 || command[0] == "" {
+		return "", false, nil
+	}
+	var err error
+	command, err = resolveTmuxCommand(command)
+	if err != nil {
+		return "", false, err
+	}
+	args := append(
+		command[1:], "show-options", "-qv", "-t", session, "@forge_launch",
+	)
+	cmd := procutil.CommandContext(ctx, command[0], args...)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err = procutil.Run(ctx, cmd, "tmux subprocess capacity")
+	if err == nil {
+		return strings.TrimSpace(stdout.String()), true, nil
+	}
+	if isTmuxSessionAbsent(stderr.Bytes(), err) {
+		return "", false, nil
+	}
+	msg := strings.TrimSpace(stderr.String())
+	if msg == "" {
+		return "", false, err
+	}
+	return "", false, fmt.Errorf("%w: %s", err, msg)
 }
 
 func (m *Manager) killTmuxSession(
@@ -1319,6 +1439,10 @@ func (m *Manager) shellLaunchCommand(
 	resolvedCommand[0] = resolvedPath
 
 	tmuxSession := tmuxSessionName(workspaceID, sessionKey)
+	launchID, err := newTmuxLaunchID()
+	if err != nil {
+		return launchCommand{}, err
+	}
 	paneEnv := tmuxShellEnvPolicy.paneEnvironment(
 		os.Environ(), resolvedCommand, m.currentStripEnvVars(),
 	)
@@ -1328,16 +1452,21 @@ func (m *Manager) shellLaunchCommand(
 		CWD:         cwd,
 		Pane:        paneEnv,
 		OwnerMarker: m.tmuxOwnerMarker,
+		LaunchID:    launchID,
 		HideStatus:  m.currentHideTmuxStatus(),
 	}.prepare(ctx)
 	if err != nil {
 		return launchCommand{}, err
 	}
-	return launchCommand{
+	result := launchCommand{
 		Command:     prepared.AttachCommand,
 		TmuxSession: tmuxSession,
 		TmuxCreated: prepared.Created,
-	}, nil
+	}
+	if prepared.Created {
+		result.TmuxLaunchID = launchID
+	}
+	return result, nil
 }
 
 func (m *Manager) Shutdown() {
@@ -1391,6 +1520,18 @@ func (m *Manager) startLock(key string) *sync.Mutex {
 	return startMu
 }
 
+// CommandSessionStartLockHeldForTest reports whether the keyed command-session
+// transaction lock is held. It releases the lock immediately when probing finds
+// it available.
+func (m *Manager) CommandSessionStartLockHeldForTest(key string) bool {
+	startMu := m.startLock(key)
+	if startMu.TryLock() {
+		startMu.Unlock()
+		return false
+	}
+	return true
+}
+
 func (m *Manager) beginStart() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -1417,9 +1558,10 @@ func (m *Manager) target(key string) (LaunchTarget, error) {
 }
 
 type launchCommand struct {
-	Command     []string
-	TmuxSession string
-	TmuxCreated bool
+	Command      []string
+	TmuxSession  string
+	TmuxLaunchID string
+	TmuxCreated  bool
 }
 
 func (m *Manager) launchCommand(
@@ -1472,6 +1614,10 @@ func (m *Manager) launchCommand(
 	resolvedAgentCommand[0] = resolvedPath
 
 	tmuxSession := tmuxSessionName(workspaceID, sessionKey)
+	launchID, err := newTmuxLaunchID()
+	if err != nil {
+		return launchCommand{}, err
+	}
 
 	paneEnv := tmuxAgentEnvPolicy.paneEnvironmentWithExtra(
 		os.Environ(), resolvedAgentCommand, m.currentStripEnvVars(), map[string]string{
@@ -1484,16 +1630,21 @@ func (m *Manager) launchCommand(
 		CWD:         cwd,
 		Pane:        paneEnv,
 		OwnerMarker: m.tmuxOwnerMarker,
+		LaunchID:    launchID,
 		HideStatus:  m.currentHideTmuxStatus(),
 	}.prepare(ctx)
 	if err != nil {
 		return launchCommand{}, err
 	}
-	return launchCommand{
+	result := launchCommand{
 		Command:     prepared.AttachCommand,
 		TmuxSession: tmuxSession,
 		TmuxCreated: prepared.Created,
-	}, nil
+	}
+	if prepared.Created {
+		result.TmuxLaunchID = launchID
+	}
+	return result, nil
 }
 
 func tmuxSessionName(workspaceID string, targetKey string) string {
@@ -2212,6 +2363,14 @@ func NewSessionKey(workspaceID string) (string, error) {
 		return "", fmt.Errorf("generate runtime session id: %w", err)
 	}
 	return workspaceID + "_" + hex.EncodeToString(data[:]), nil
+}
+
+func newTmuxLaunchID() (string, error) {
+	var data [16]byte
+	if _, err := cryptorand.Read(data[:]); err != nil {
+		return "", fmt.Errorf("generate tmux launch id: %w", err)
+	}
+	return hex.EncodeToString(data[:]), nil
 }
 
 // resolveExecutable returns an absolute path for name. Names that

--- a/internal/workspace/localruntime/manager_test.go
+++ b/internal/workspace/localruntime/manager_test.go
@@ -184,6 +184,24 @@ func TestNewSessionKeyUsesWorkspacePrefixAndRandomSuffix(t *testing.T) {
 	assert.Len(strings.TrimPrefix(first, "ws-1_"), 16)
 }
 
+func TestSessionInfoSameGenerationRequiresKeyAndCreatedAt(t *testing.T) {
+	createdAt := time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC)
+	session := SessionInfo{Key: "surface:console", CreatedAt: createdAt}
+
+	assert.True(t, session.SameGeneration(SessionInfo{
+		Key:       session.Key,
+		CreatedAt: createdAt,
+	}))
+	assert.False(t, session.SameGeneration(SessionInfo{
+		Key:       session.Key,
+		CreatedAt: createdAt.Add(time.Second),
+	}))
+	assert.False(t, session.SameGeneration(SessionInfo{
+		Key:       "surface:replacement",
+		CreatedAt: createdAt,
+	}))
+}
+
 func TestManagerLaunchUnavailableTarget(t *testing.T) {
 	ctx := context.Background()
 	mgr := NewManager(Options{Targets: []LaunchTarget{{
@@ -1488,6 +1506,52 @@ func TestManagerStopKeepsPtyOwnerSessionRetryableAfterStopFailure(t *testing.T) 
 	_, ok = mgr.session("ws-1", info.Key)
 	assert.False(ok)
 	assert.Equal([]string{info.Key, info.Key}, owner.stoppedSessions)
+}
+
+func TestRollbackLaunchStopsOwnedNonTmuxSession(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	owner := newFakeRuntimePtyOwner()
+	mgr := NewManager(Options{
+		PtyOwnerRuntime: owner,
+		ShellCommand:    []string{"/bin/sh"},
+		Targets:         []LaunchTarget{plainShellTarget()},
+	})
+	t.Cleanup(mgr.Shutdown)
+
+	info, err := mgr.Launch(
+		context.Background(), "ws-1", t.TempDir(), string(LaunchTargetPlainShell),
+	)
+	require.NoError(err)
+	require.Empty(info.TmuxSession)
+
+	require.NoError(mgr.RollbackLaunch(context.Background(), info))
+	assert.Equal([]string{info.Key}, owner.stoppedSessions)
+	assert.Empty(mgr.ListSessions("ws-1"))
+}
+
+func TestRollbackLaunchPreservesReusedNonTmuxSession(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	owner := newFakeRuntimePtyOwner()
+	mgr := NewManager(Options{
+		PtyOwnerRuntime: owner,
+		ShellCommand:    []string{"/bin/sh"},
+		Targets:         []LaunchTarget{plainShellTarget()},
+	})
+	t.Cleanup(mgr.Shutdown)
+
+	info, err := mgr.Launch(
+		context.Background(), "ws-1", t.TempDir(), string(LaunchTargetPlainShell),
+	)
+	require.NoError(err)
+	info.Reused = true
+
+	require.NoError(mgr.RollbackLaunch(context.Background(), info))
+	assert.Empty(owner.stoppedSessions)
+	assert.Len(mgr.ListSessions("ws-1"), 1)
 }
 
 func TestManagerStopRemovesSession(t *testing.T) {

--- a/internal/workspace/localruntime/tmux_launcher.go
+++ b/internal/workspace/localruntime/tmux_launcher.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"slices"
 	"strings"
+	"time"
 
 	shellquote "github.com/kballard/go-shellquote"
 	"go.kenn.io/forge/internal/procutil"
@@ -132,6 +133,7 @@ type tmuxLauncher struct {
 	CWD         string
 	Pane        tmuxPaneEnvironment
 	OwnerMarker string
+	LaunchID    string
 	HideStatus  bool
 }
 
@@ -152,6 +154,9 @@ func (l tmuxLauncher) prepare(ctx context.Context) (tmuxLaunchResult, error) {
 		if err := l.validateOwner(ctx); err != nil {
 			return tmuxLaunchResult{}, err
 		}
+		if err := l.replaceLaunchMarker(ctx); err != nil {
+			return tmuxLaunchResult{}, err
+		}
 		return tmuxLaunchResult{AttachCommand: l.attachSessionCommand()}, nil
 	}
 
@@ -167,13 +172,22 @@ func (l tmuxLauncher) prepare(ctx context.Context) (tmuxLaunchResult, error) {
 	}()
 	if err := l.run(ctx, l.newSessionCommand(paneCommand)); err != nil {
 		if retryErr := l.validateExistingAfterCreateRace(ctx); retryErr == nil {
+			if markerErr := l.replaceLaunchMarker(ctx); markerErr != nil {
+				return tmuxLaunchResult{}, markerErr
+			}
 			return tmuxLaunchResult{AttachCommand: l.attachSessionCommand()}, nil
 		}
 		return tmuxLaunchResult{}, fmt.Errorf("tmux new-session: %w", err)
 	}
 	if l.HideStatus {
 		if err := l.run(ctx, l.hideStatusCommand()); err != nil {
-			if killErr := l.run(ctx, l.killSessionCommand()); killErr != nil {
+			cleanupCtx, cancel := context.WithTimeout(
+				context.WithoutCancel(ctx),
+				5*time.Second,
+			)
+			killErr := l.run(cleanupCtx, l.killSessionCommand())
+			cancel()
+			if killErr != nil {
 				return tmuxLaunchResult{}, fmt.Errorf(
 					"hide tmux status: %w; cleanup new tmux session: %v",
 					err, killErr,
@@ -187,6 +201,25 @@ func (l tmuxLauncher) prepare(ctx context.Context) (tmuxLaunchResult, error) {
 		AttachCommand: l.attachSessionCommand(),
 		Created:       true,
 	}, nil
+}
+
+// replaceLaunchMarker rewrites @forge_launch when this launch adopts an
+// already-existing backend. The creator's rollback kills by launch marker as a
+// fallback when no live manager entry remains, so an adopted backend must stop
+// matching the creator's generation or a stale rollback after the adopting
+// attachment detaches would kill work the adopter durably recorded.
+func (l tmuxLauncher) replaceLaunchMarker(ctx context.Context) error {
+	if l.LaunchID == "" {
+		return nil
+	}
+	command := append(
+		slices.Clone(l.TmuxCommand),
+		"set-option", "-q", "-t", l.Session, "@forge_launch", l.LaunchID,
+	)
+	if err := l.run(ctx, command); err != nil {
+		return fmt.Errorf("replace tmux launch marker: %w", err)
+	}
+	return nil
 }
 
 func (l tmuxLauncher) validateExistingAfterCreateRace(
@@ -409,6 +442,13 @@ func (l tmuxLauncher) newSessionCommand(paneCommand string) []string {
 			command,
 			";", "set-option", "-q", "-t", l.Session,
 			"@forge_owner", l.OwnerMarker,
+		)
+	}
+	if l.LaunchID != "" {
+		command = append(
+			command,
+			";", "set-option", "-q", "-t", l.Session,
+			"@forge_launch", l.LaunchID,
 		)
 	}
 	return command

--- a/internal/workspace/localruntime/tmux_launcher_test.go
+++ b/internal/workspace/localruntime/tmux_launcher_test.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	shellquote "github.com/kballard/go-shellquote"
 	"github.com/stretchr/testify/assert"
@@ -201,6 +202,139 @@ exit 0
 		"-u", "attach-session", "-t", "kenn-forge-test",
 	})
 	assert.NoFileExists(created)
+}
+
+func TestTmuxLauncherCleansUpCreatedSessionAfterLaunchContextCancellation(
+	t *testing.T,
+) {
+	require := require.New(t)
+	assert := assert.New(t)
+	dir := t.TempDir()
+	record := filepath.Join(dir, "tmux-record")
+	createdSessionState := filepath.Join(dir, "created-session")
+	statusStarted := filepath.Join(dir, "status-started")
+	tmuxPath := filepath.Join(dir, "tmux")
+	require.NoError(os.WriteFile(tmuxPath, []byte(`#!/bin/sh
+printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"
+case "$1" in
+  has-session)
+    if [ -f "$TMUX_CREATED" ]; then exit 0; fi
+    echo "can't find session: $3" >&2
+    exit 1
+    ;;
+  new-session)
+    : > "$TMUX_CREATED"
+    exit 0
+    ;;
+  set-option)
+    if [ "$5" = "status" ] && [ "$6" = "off" ]; then
+      : > "$TMUX_STATUS_STARTED"
+      while [ ! -f "$TMUX_STATUS_RELEASE" ]; do
+        sleep 0.01
+      done
+    fi
+    exit 0
+    ;;
+  kill-session)
+    rm -f "$TMUX_CREATED"
+    exit 0
+    ;;
+esac
+exit 0
+`), 0o755))
+
+	launcher := tmuxLauncher{
+		TmuxCommand: []string{tmuxPath},
+		Session:     "kenn-forge-test",
+		Pane: tmuxPaneEnvironment{
+			paneCommand: "exec /bin/sh",
+			keys:        []string{"PATH", "TERM"},
+			commandEnv: []string{
+				"PATH=" + os.Getenv("PATH"),
+				"TERM=xterm-256color",
+				"TMUX_RECORD=" + record,
+				"TMUX_CREATED=" + createdSessionState,
+				"TMUX_STATUS_STARTED=" + statusStarted,
+				"TMUX_STATUS_RELEASE=" + filepath.Join(dir, "status-release"),
+			},
+		},
+		HideStatus: true,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := launcher.prepare(ctx)
+		errCh <- err
+	}()
+
+	require.Eventually(func() bool {
+		_, err := os.Stat(statusStarted)
+		return err == nil
+	}, time.Second, 10*time.Millisecond)
+
+	cancel()
+
+	var err error
+	select {
+	case err = <-errCh:
+	case <-time.After(5 * time.Second):
+		require.FailNow("tmux launcher did not return after cancellation")
+	}
+
+	require.Error(err)
+	assert.Contains(err.Error(), "hide tmux status")
+	assert.NoFileExists(createdSessionState)
+	assert.Contains(readNullArgvRecord(t, record), []string{
+		"kill-session", "-t", launcher.Session,
+	})
+}
+
+func TestTmuxLauncherDoesNotKillSessionAfterNewSessionError(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	dir := t.TempDir()
+	record := filepath.Join(dir, "tmux-record")
+	tmuxPath := filepath.Join(dir, "tmux")
+	require.NoError(os.WriteFile(tmuxPath, []byte(`#!/bin/sh
+printf '%s\0' "$#" "$@" >> "$TMUX_RECORD"
+case "$1" in
+  has-session)
+    echo "can't find session: $3" >&2
+    exit 1
+    ;;
+  new-session)
+    echo "new session failed" >&2
+    exit 1
+    ;;
+  kill-session)
+    exit 0
+    ;;
+esac
+exit 0
+`), 0o755))
+
+	launcher := tmuxLauncher{
+		TmuxCommand: []string{tmuxPath},
+		Session:     "kenn-forge-test",
+		Pane: tmuxPaneEnvironment{
+			paneCommand: "exec /bin/sh",
+			keys:        []string{"PATH", "TERM"},
+			commandEnv: []string{
+				"PATH=" + os.Getenv("PATH"),
+				"TERM=xterm-256color",
+				"TMUX_RECORD=" + record,
+			},
+		},
+	}
+
+	_, err := launcher.prepare(context.Background())
+
+	require.Error(err)
+	assert.Contains(err.Error(), "tmux new-session")
+	assert.NotContains(readNullArgvRecord(t, record), []string{
+		"kill-session", "-t", launcher.Session,
+	})
 }
 
 func TestTmuxLauncherShellPolicyPreservesCustomEnvByKey(t *testing.T) {

--- a/internal/workspace/localruntime/types.go
+++ b/internal/workspace/localruntime/types.go
@@ -6,8 +6,8 @@ const (
 	LaunchTargetAgent      LaunchTargetKind = "agent"
 	LaunchTargetShell      LaunchTargetKind = "shell"
 	LaunchTargetPlainShell LaunchTargetKind = "plain_shell"
-	// LaunchTargetCommand marks sessions launched from a caller-supplied
-	// command line via EnsureCommandSession rather than a configured target.
+	// LaunchTargetCommand marks sessions launched from a caller-supplied command
+	// line via EnsureCommandSessionAndPersist rather than a configured target.
 	LaunchTargetCommand LaunchTargetKind = "command"
 )
 

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -54,6 +54,10 @@ type Manager struct {
 	deletedSummaryIDs         map[string]bool
 	worktreeBaseResolver      WorktreeBasePathResolver
 	afterHeadRepoSnapshotRead func()
+	// beforeExistingWorktreeRepoLock runs after reuse pre-validation and right
+	// before acquiring the repository lock; tests use it to coordinate a path
+	// replacement while lock acquisition is blocked.
+	beforeExistingWorktreeRepoLock func()
 	// beforeSetupRouteRevalidation runs right before setup's final route
 	// re-validation; tests use it to interleave a route replacement.
 	beforeSetupRouteRevalidation func()
@@ -1332,6 +1336,9 @@ func (m *Manager) reuseExistingWorkspaceWorktree(
 	}
 	if !reusable {
 		return "", false, nil
+	}
+	if m.beforeExistingWorktreeRepoLock != nil {
+		m.beforeExistingWorktreeRepoLock()
 	}
 	var branch string
 	if err := m.withRepoLockForGitDir(ctx, commonDir, func() error {

--- a/internal/workspace/manager.go
+++ b/internal/workspace/manager.go
@@ -3755,8 +3755,9 @@ func filterDeletedWorkspaceSummaries(
 }
 
 // ReapOrphanTmuxSessions kills kenn-forge-managed tmux sessions that no longer
-// correspond to any workspace row. This is a conservative startup cleanup for
-// stale sessions left behind by crashes or previous bugs.
+// correspond to any durable workspace, host, or project-worktree row. This is
+// a conservative startup cleanup for stale sessions left behind by crashes or
+// previous bugs.
 func (m *Manager) ReapOrphanTmuxSessions(ctx context.Context) error {
 	workspaces, err := m.db.ListWorkspaces(ctx)
 	if err != nil {
@@ -3778,6 +3779,24 @@ func (m *Manager) ReapOrphanTmuxSessions(ctx context.Context) error {
 			live[stored.TmuxSession] = true
 		}
 	}
+	hostSessions, err := m.db.ListHostRuntimeTmuxSessions(ctx)
+	if err != nil {
+		return err
+	}
+	for _, stored := range hostSessions {
+		if stored.SessionName != "" {
+			live[stored.SessionName] = true
+		}
+	}
+	projectSessions, err := m.db.ListAllProjectWorktreeTmuxSessions(ctx)
+	if err != nil {
+		return err
+	}
+	for _, stored := range projectSessions {
+		if stored.SessionName != "" {
+			live[stored.SessionName] = true
+		}
+	}
 
 	sessions, err := m.listTmuxSessionInfos(ctx)
 	if err != nil {
@@ -3787,7 +3806,7 @@ func (m *Manager) ReapOrphanTmuxSessions(ctx context.Context) error {
 		return err
 	}
 	for _, session := range sessions {
-		if !isForgeWorkspaceTmuxSessionName(session.name) {
+		if !isForgeOwnedTmuxSessionName(session.name) {
 			continue
 		}
 		if live[session.name] {
@@ -3892,16 +3911,18 @@ func isWorkspaceTmuxSessionName(session string) bool {
 	return false
 }
 
-func isForgeWorkspaceTmuxSessionName(session string) bool {
+func isForgeOwnedTmuxSessionName(session string) bool {
 	if isWorkspaceTmuxSessionName(session) {
 		return true
 	}
 	for _, prefix := range []string{"forge-", "middleman-"} {
-		if len(session) == len(prefix)+16+1+16 &&
-			strings.HasPrefix(session, prefix) &&
-			session[len(prefix)+16] == '-' &&
-			isLowerHex(session[len(prefix):len(prefix)+16]) &&
-			isLowerHex(session[len(prefix)+17:]) {
+		if !strings.HasPrefix(session, prefix) {
+			continue
+		}
+		scopeAndKey := session[len(prefix):]
+		separator := len(scopeAndKey) - 17
+		if separator > 0 && scopeAndKey[separator] == '-' &&
+			isLowerHex(scopeAndKey[separator+1:]) {
 			return true
 		}
 	}

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -5158,6 +5158,10 @@ func TestManagerReapOrphanTmuxSessionsKeepsStoredRuntimeSessions(
 		`  if [ "$a" = "list-sessions" ]; then` + "\n" +
 		`    printf 'middleman-0000000000000001:%s\n' "$KENN_FORGE_TMUX_OWNER"` + "\n" +
 		`    printf 'middleman-0000000000000001-57de4cf40144bdf7:%s\n' "$KENN_FORGE_TMUX_OWNER"` + "\n" +
+		`    printf '%s:%s\n' "$STORED_HOST_SESSION" "$KENN_FORGE_TMUX_OWNER"` + "\n" +
+		`    printf '%s:%s\n' "$STORED_PROJECT_SESSION" "$KENN_FORGE_TMUX_OWNER"` + "\n" +
+		`    printf '%s:%s\n' "$ORPHAN_HOST_SESSION" "$KENN_FORGE_TMUX_OWNER"` + "\n" +
+		`    printf '%s:%s\n' "$ORPHAN_PROJECT_SESSION" "$KENN_FORGE_TMUX_OWNER"` + "\n" +
 		`    printf 'forge-aaaaaaaaaaaaaaaa-c857d09db23e6822:%s\n' "$KENN_FORGE_TMUX_OWNER"` + "\n" +
 		`    exit 0` + "\n" +
 		`  fi` + "\n" +
@@ -5170,6 +5174,10 @@ func TestManagerReapOrphanTmuxSessionsKeepsStoredRuntimeSessions(
 	mgr := NewManager(d, t.TempDir())
 	mgr.SetTmuxCommand([]string{script, "wrap"})
 	t.Setenv("KENN_FORGE_TMUX_OWNER", mgr.tmuxOwnerMarker())
+	storedHostSession := "forge-host-1111111111111111"
+	orphanHostSession := "forge-host-2222222222222222"
+	t.Setenv("STORED_HOST_SESSION", storedHostSession)
+	t.Setenv("ORPHAN_HOST_SESSION", orphanHostSession)
 
 	require.NoError(d.InsertWorkspace(context.Background(), &Workspace{
 		ID:           "0000000000000001",
@@ -5188,6 +5196,37 @@ func TestManagerReapOrphanTmuxSessionsKeepsStoredRuntimeSessions(
 		"codex", "middleman-0000000000000001-57de4cf40144bdf7",
 		time.Time{},
 	)
+	require.NoError(d.UpsertHostRuntimeTmuxSession(
+		context.Background(), &db.HostRuntimeTmuxSession{
+			SessionKey:  "host-live",
+			SessionName: storedHostSession,
+		},
+	))
+	project, err := d.CreateProject(context.Background(), db.CreateProjectInput{
+		DisplayName: "runtime-project",
+		LocalPath:   filepath.Join(t.TempDir(), "project"),
+	})
+	require.NoError(err)
+	worktree, err := d.CreateProjectWorktree(
+		context.Background(), db.CreateProjectWorktreeInput{
+			ProjectID: project.ID,
+			Branch:    "feature/runtime",
+			Path:      filepath.Join(t.TempDir(), "worktree"),
+		},
+	)
+	require.NoError(err)
+	storedProjectSession := "forge-project-worktree-" + worktree.ID +
+		"-3333333333333333"
+	orphanProjectSession := "forge-project-worktree-unrecorded-4444444444444444"
+	t.Setenv("STORED_PROJECT_SESSION", storedProjectSession)
+	t.Setenv("ORPHAN_PROJECT_SESSION", orphanProjectSession)
+	require.NoError(d.UpsertProjectWorktreeTmuxSession(
+		context.Background(), &db.ProjectWorktreeTmuxSession{
+			WorktreeID:  worktree.ID,
+			SessionKey:  "project-live",
+			SessionName: storedProjectSession,
+		},
+	))
 
 	require.NoError(mgr.ReapOrphanTmuxSessions(context.Background()))
 
@@ -5196,9 +5235,21 @@ func TestManagerReapOrphanTmuxSessionsKeepsStoredRuntimeSessions(
 		"wrap", "kill-session", "-t",
 		"forge-aaaaaaaaaaaaaaaa-c857d09db23e6822",
 	})
+	assert.Contains(argvs, []string{
+		"wrap", "kill-session", "-t", orphanHostSession,
+	})
+	assert.Contains(argvs, []string{
+		"wrap", "kill-session", "-t", orphanProjectSession,
+	})
 	assert.NotContains(argvs, []string{
 		"wrap", "kill-session", "-t",
 		"middleman-0000000000000001-57de4cf40144bdf7",
+	})
+	assert.NotContains(argvs, []string{
+		"wrap", "kill-session", "-t", storedHostSession,
+	})
+	assert.NotContains(argvs, []string{
+		"wrap", "kill-session", "-t", storedProjectSession,
 	})
 }
 

--- a/internal/workspace/manager_test.go
+++ b/internal/workspace/manager_test.go
@@ -1628,6 +1628,77 @@ func TestSetupReusesExistingWorkspaceWorktree(t *testing.T) {
 	assert.Contains(argvs[0], ws.WorktreePath)
 }
 
+func TestReuseExistingWorkspaceWorktreeRechecksSymlinkAfterLock(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	d := openTestDB(t)
+	wtDir := t.TempDir()
+
+	localRepo, _, platformHost := setupHTTPWorktreeBaseForWorkspaceGitTest(
+		t, "feature/thing",
+	)
+	repoID := seedRepo(t, d, platformHost, "acme", "widget")
+	seedMR(t, d, repoID, 42, "feature/thing")
+
+	mgr := NewManager(d, wtDir)
+	mgr.SetWorktreeBasePathResolver(staticBaseResolver(localRepo))
+	readyForRepoLock := make(chan struct{})
+	mgr.beforeExistingWorktreeRepoLock = func() {
+		close(readyForRepoLock)
+	}
+	ws, err := mgr.Create(t.Context(), "github", platformHost, "acme", "widget", 42)
+	require.NoError(err)
+	existingBranch := syntheticPRWorktreeBranch(42)
+	runWorkspaceTestGit(
+		t, localRepo,
+		"worktree", "add", ws.WorktreePath, "-b", existingBranch, "HEAD",
+	)
+	metadataDir, err := worktreeGitDir(t.Context(), ws.WorktreePath)
+	require.NoError(err)
+
+	lockRoot := mgr.localWorktreeBaseLockRoot(localRepo)
+	require.NoError(os.MkdirAll(lockRoot, 0o755))
+	held, err := mgr.locks.Acquire(t.Context(), lockRoot)
+	require.NoError(err)
+	type reuseResult struct {
+		reused bool
+		err    error
+	}
+	done := make(chan reuseResult, 1)
+	go func() {
+		_, reused, reuseErr := mgr.reuseExistingWorkspaceWorktree(t.Context(), ws)
+		done <- reuseResult{reused: reused, err: reuseErr}
+	}()
+
+	select {
+	case <-readyForRepoLock:
+	case result := <-done:
+		require.FailNowf(
+			"worktree reuse completed before repository lock acquisition",
+			"reused=%t err=%v", result.reused, result.err,
+		)
+	case <-time.After(5 * time.Second):
+		require.FailNow("worktree reuse did not reach repository lock acquisition")
+	}
+	targetPath := filepath.Join(wtDir, "replacement-target")
+	require.NoError(os.Rename(ws.WorktreePath, targetPath))
+	require.NoError(os.Symlink(targetPath, ws.WorktreePath))
+	require.NoError(held.Unlock())
+
+	select {
+	case result := <-done:
+		require.Error(result.err)
+		assert.False(result.reused)
+	case <-time.After(5 * time.Second):
+		require.FailNow("worktree reuse did not finish after lock release")
+	}
+	pathInfo, err := os.Lstat(ws.WorktreePath)
+	require.NoError(err)
+	assert.NotZero(pathInfo.Mode() & os.ModeSymlink)
+	_, err = os.Lstat(filepath.Join(metadataDir, workspaceOwnershipMarkerFile))
+	assert.ErrorIs(err, os.ErrNotExist)
+}
+
 // A retried setup must recognize the uniquified synthetic branch as its own,
 // otherwise the workspace whose first attempt hit a name collision can never be
 // set up again.


### PR DESCRIPTION
## Why

PR #823 restored Forge's managed-runner routing, but pull-request dispatch intentionally invokes the reusable workflow from `main`. Until a repair reaches `main`, PR checks therefore bootstrap on the hosted lane. Those runners can expose a rustup `cargo` shim without an installed toolchain, and the lower worker profile made two timing-based test assumptions unreliable.

The investigation also exposed a real cleanup race: a newly created tmux backend could outlive a failed metadata write if request cancellation or natural attachment exit removed the in-memory session first.

## What changed

- Require `cargo --version` to succeed before running Rust-backed Go E2Es.
- Synchronize the existing-worktree replacement test at the exact repository-lock boundary instead of sleeping for 80 ms.
- Make launch rollback cancellation-independent and clean the tmux backend by the launch result even if the in-memory session has already exited.
- Document the runtime cleanup invariant.

## Verification

- All commit and push hooks passed, including Go short tests, golangci-lint, nilaway, and repository guardrails.
- `scripts/context-sync --check` and branch diff integrity passed.
- The worktree lock regression passed 10 repeated race-instrumented runs.
- The Rust manager and rollback server regressions passed five repeated race-instrumented runs.
- Both Rust workspace E2Es passed.

During broader diagnosis, a complete `internal/server -race` run also surfaced one unrelated pre-existing failure in `TestWorkspaceRefreshProceedsThroughIssueScopePartialSyncFailure`; the regressions changed here pass independently and repeatedly.

Origin: Buzz channel `23c2f26c-fce2-5341-b4c1-f149e7cbbfea`, thread `674b32e20376aa7f86aafd2e4069328e03c8a198f1d6b7b5f622b58c66362d19`.

<sup>generated by a clanker</sup>
