### PR TITLE
Publish generated long-lived transport inventory

### DIFF
--- a/cmd/kenn-forge-transport-inventory/main.go
+++ b/cmd/kenn-forge-transport-inventory/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"go.kenn.io/forge/internal/server"
+)
+
+func main() {
+	inventory, err := server.NewTransportInventory()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "generate transport inventory: %v\n", err)
+		os.Exit(1)
+	}
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(inventory); err != nil {
+		fmt.Fprintf(os.Stderr, "encode transport inventory: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/context/server-runtime.md
+++ b/context/server-runtime.md
@@ -81,3 +81,9 @@ and the root event stream.
 - A cursor older than the ring or ahead of the current process head emits
   `reconnect.stale`; the client must discard incremental assumptions and perform
   an authoritative refetch (`internal/server/server.go::Server.handleSSE`).
+
+## Long-Lived Transport Inventory
+
+- Long-lived HTTP and WebSocket contracts derive from the Huma registrations;
+  catch-all proxies declare finite streaming variants on their operation, and
+  tracing consumes the same inventory (`internal/server/transport_inventory.go::NewTransportInventory`).

--- a/context/server-runtime.md
+++ b/context/server-runtime.md
@@ -87,3 +87,5 @@ and the root event stream.
 - Long-lived HTTP and WebSocket contracts derive from the Huma registrations;
   catch-all proxies declare finite streaming variants on their operation, and
   tracing consumes the same inventory (`internal/server/transport_inventory.go::NewTransportInventory`).
+- An annotated proxy stream is served only when the request explicitly accepts
+  its declared media type (`internal/server/httpapi/transport.go::ValidateTransportAccept`).

--- a/context/testing.md
+++ b/context/testing.md
@@ -297,6 +297,16 @@ make api-generate
 Then review generated Go and TypeScript client diffs for operation-name
 renames and update checked-in callers that use generated method/type names.
 
+For long-lived transport registration changes, run:
+
+```sh
+go test ./internal/server -run 'TestTransportInventory|TestOTelTraceable' -shuffle=on
+go run ./cmd/kenn-forge-transport-inventory
+```
+
+The generated inventory must come from Huma registration metadata; do not add
+a hand-maintained route snapshot.
+
 Do not duplicate full-stack e2e tests across default-host and
 `/host/{platform_host}` route forms when the host route is only a generic
 wrapper. Add host-specific e2e coverage only for custom host logic, route

--- a/docs/superpowers/specs/2026-08-03-huma-transport-inventory-design.md
+++ b/docs/superpowers/specs/2026-08-03-huma-transport-inventory-design.md
@@ -70,9 +70,13 @@ The schema is versioned:
 
 Routes are sorted by method, path, transport, and media type before encoding.
 The optional `query` object identifies values that select a streaming mode on
-an otherwise ordinary endpoint.
+an otherwise ordinary endpoint; every listed string key/value must match.
+Consumers ignore unknown additive fields. A new required field, changed matching
+semantics, or new transport kind increments `schema_version`.
 Duplicate entries, malformed absolute paths, unknown metadata shapes, and
 unsupported transport values are generation errors.
+Annotated proxy streams require a matching explicit `Accept` media type at
+runtime and return HTTP 406 before proxying when it is absent or rejected.
 
 ### Developer and CI command
 
@@ -99,4 +103,5 @@ Focused Forge tests will prove that:
 - Exposing live connection counts or request details at runtime.
 - Defining how a particular embedding host implements its transport.
 - Maintaining a Markdown or hand-written JSON route list.
-- Changing terminal, stream replay, proxy, or authorization semantics.
+- Changing terminal, stream replay, or authorization semantics beyond the
+  declared proxy-stream content negotiation.

--- a/docs/superpowers/specs/2026-08-03-huma-transport-inventory-design.md
+++ b/docs/superpowers/specs/2026-08-03-huma-transport-inventory-design.md
@@ -1,0 +1,100 @@
+# Huma Transport Inventory Design
+
+## Goal
+
+Generate a deterministic, machine-readable inventory of Kenn Forge's
+long-lived HTTP and WebSocket routes from the Huma operations that register
+them. Embedding hosts and transport proxies can use the inventory in contract
+tests without maintaining a second route list.
+
+## Problem
+
+The public OpenAPI document describes ordinary REST operations and
+first-party server-sent event responses, but it intentionally excludes hidden
+terminal WebSocket operations. Generic proxy operations also hide the finite
+downstream paths and query modes that return long-lived streams. A consumer
+that needs different handling for ordinary HTTP, streaming HTTP, and
+WebSockets must currently rediscover those cases from implementation details.
+
+A hand-written Markdown or JSON inventory would drift as routes change. The
+inventory must instead observe the same Huma operations used by the running
+server, with explicit registration metadata only where a proxy boundary makes
+automatic inference impossible.
+
+## Selected design
+
+### Record registered operations
+
+Forge will add a recording adapter around its Huma adapter. The recorder
+observes each `huma.Operation` handed to the adapter, including hidden
+operations registered directly through `Adapter().Handle`. Inventory
+generation will assemble the same REST, terminal-WebSocket, and proxy Huma
+route sets used by the server.
+
+The recorder will retain only transport-contract fields. It will not retain
+handlers, schemas, credentials, runtime state, or request data.
+
+### Derive transport entries
+
+The inventory generator will classify operations as follows:
+
+- a response content entry of `text/event-stream` produces an `http-stream`
+  route with that request media type;
+- operations registered on the terminal Huma API produce `websocket` routes;
+- a proxy operation may declare finite long-lived downstream variants in Huma
+  operation metadata when its catch-all path prevents response inference.
+
+Proxy annotations live at the Huma registration boundary. There is no
+separate production inventory file.
+
+The schema is versioned:
+
+```json
+{
+  "schema_version": 1,
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/api/v1/events",
+      "transport": "http-stream",
+      "accept": "text/event-stream"
+    },
+    {
+      "method": "GET",
+      "path": "/ws/v1/workspaces/{id}/terminal",
+      "transport": "websocket"
+    }
+  ]
+}
+```
+
+Routes are sorted by method, path, transport, and media type before encoding.
+Duplicate entries, malformed absolute paths, unknown metadata shapes, and
+unsupported transport values are generation errors.
+
+### Developer and CI command
+
+A developer command parallel to `cmd/kenn-forge-openapi` will write the JSON
+inventory to standard output. It will construct route registrations without
+starting listeners, opening the database, or launching background workers.
+The command is tooling, not a public runtime subcommand or HTTP endpoint.
+
+## Verification
+
+Focused Forge tests will prove that:
+
+- visible SSE operations are discovered from Huma response metadata;
+- hidden local, runtime-session, and Fleet terminal operations are discovered;
+- annotated proxy stream variants are included;
+- output ordering and JSON encoding are deterministic;
+- malformed or duplicate metadata fails generation;
+- the generated inventory contains every long-lived route mode that Forge's
+  request tracing excludes from ordinary bounded spans.
+
+## Non-goals
+
+- Publishing Forge's internal HTTP API as a supported public contract.
+- Exposing live connection counts or request details at runtime.
+- Defining how a particular embedding host implements its transport.
+- Maintaining a Markdown or hand-written JSON route list.
+- Changing terminal, stream replay, proxy, or authorization semantics.

--- a/docs/superpowers/specs/2026-08-03-huma-transport-inventory-design.md
+++ b/docs/superpowers/specs/2026-08-03-huma-transport-inventory-design.md
@@ -69,6 +69,8 @@ The schema is versioned:
 ```
 
 Routes are sorted by method, path, transport, and media type before encoding.
+The optional `query` object identifies values that select a streaming mode on
+an otherwise ordinary endpoint.
 Duplicate entries, malformed absolute paths, unknown metadata shapes, and
 unsupported transport values are generation errors.
 

--- a/frontend/src/lib/stores/roborev-log.test.ts
+++ b/frontend/src/lib/stores/roborev-log.test.ts
@@ -61,6 +61,7 @@ describe("createLogStore", () => {
     await store.startStreaming(77);
 
     expect(fetchMock).toHaveBeenCalledWith("http://roborev.test/api/job/output?job_id=77&stream=1", {
+      headers: { Accept: "application/x-ndjson" },
       signal: expect.any(AbortSignal),
     });
     expect(store.getLines()).toEqual([

--- a/internal/server/httpapi/transport.go
+++ b/internal/server/httpapi/transport.go
@@ -1,0 +1,57 @@
+package httpapi
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+
+	"github.com/danielgtaylor/huma/v2"
+)
+
+// TransportKind identifies a long-lived HTTP or upgraded transport.
+type TransportKind string
+
+const (
+	TransportHTTPStream TransportKind = "http-stream"
+	TransportWebSocket  TransportKind = "websocket"
+)
+
+// TransportRoute is the machine-readable contract for one long-lived route.
+type TransportRoute struct {
+	Method    string            `json:"method"`
+	Path      string            `json:"path"`
+	Transport TransportKind     `json:"transport"`
+	Accept    string            `json:"accept,omitempty"`
+	Query     map[string]string `json:"query,omitempty"`
+}
+
+const transportRoutesMetadataKey = "_forge_transport_routes"
+
+// AddTransportRoutes attaches proxy-only route variants to the Huma operation
+// that registers their catch-all handler.
+func AddTransportRoutes(op *huma.Operation, routes ...TransportRoute) {
+	if op.Metadata == nil {
+		op.Metadata = map[string]any{}
+	}
+	op.Metadata[transportRoutesMetadataKey] = slices.Clone(routes)
+}
+
+// TransportRoutes returns an isolated copy of routes attached to op.
+func TransportRoutes(op *huma.Operation) ([]TransportRoute, error) {
+	if op.Metadata == nil {
+		return nil, nil
+	}
+	raw, ok := op.Metadata[transportRoutesMetadataKey]
+	if !ok {
+		return nil, nil
+	}
+	routes, ok := raw.([]TransportRoute)
+	if !ok {
+		return nil, fmt.Errorf("transport metadata has type %T", raw)
+	}
+	cloned := slices.Clone(routes)
+	for i := range cloned {
+		cloned[i].Query = maps.Clone(cloned[i].Query)
+	}
+	return cloned, nil
+}

--- a/internal/server/httpapi/transport.go
+++ b/internal/server/httpapi/transport.go
@@ -3,7 +3,10 @@ package httpapi
 import (
 	"fmt"
 	"maps"
+	"net/http"
 	"slices"
+	"strconv"
+	"strings"
 
 	"github.com/danielgtaylor/huma/v2"
 )
@@ -54,4 +57,54 @@ func TransportRoutes(op *huma.Operation) ([]TransportRoute, error) {
 		cloned[i].Query = maps.Clone(cloned[i].Query)
 	}
 	return cloned, nil
+}
+
+// ValidateTransportAccept reports whether a request satisfies the media type
+// declared by a matching proxy-only stream variant.
+func ValidateTransportAccept(op *huma.Operation, request *http.Request) (bool, error) {
+	routes, err := TransportRoutes(op)
+	if err != nil {
+		return false, err
+	}
+	for _, route := range routes {
+		if route.Transport != TransportHTTPStream ||
+			route.Method != request.Method || route.Path != request.URL.Path {
+			continue
+		}
+		matches := true
+		for key, value := range route.Query {
+			if request.URL.Query().Get(key) != value {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return acceptsMediaType(request.Header.Get("Accept"), route.Accept), nil
+		}
+	}
+	return true, nil
+}
+
+func acceptsMediaType(header string, required string) bool {
+	for mediaRange := range strings.SplitSeq(header, ",") {
+		parts := strings.Split(mediaRange, ";")
+		if !strings.EqualFold(strings.TrimSpace(parts[0]), required) {
+			continue
+		}
+		accepted := true
+		for _, parameter := range parts[1:] {
+			name, value, ok := strings.Cut(parameter, "=")
+			if !ok || !strings.EqualFold(strings.TrimSpace(name), "q") {
+				continue
+			}
+			quality, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
+			if err != nil || quality <= 0 {
+				accepted = false
+			}
+		}
+		if accepted {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/server/httpapi/transport_test.go
+++ b/internal/server/httpapi/transport_test.go
@@ -1,0 +1,55 @@
+package httpapi
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateTransportAccept(t *testing.T) {
+	op := &huma.Operation{}
+	AddTransportRoutes(op,
+		TransportRoute{
+			Method: http.MethodGet, Path: "/api/events",
+			Transport: TransportHTTPStream, Accept: "application/x-ndjson",
+		},
+		TransportRoute{
+			Method: http.MethodGet, Path: "/api/output",
+			Transport: TransportHTTPStream, Accept: "application/x-ndjson",
+			Query: map[string]string{"stream": "1"},
+		},
+	)
+
+	tests := []struct {
+		name   string
+		target string
+		accept string
+		want   bool
+	}{
+		{name: "declared stream", target: "/api/events", accept: "application/x-ndjson", want: true},
+		{name: "declared stream with parameters", target: "/api/events", accept: "application/json, application/x-ndjson; charset=utf-8", want: true},
+		{name: "missing accept", target: "/api/events", want: false},
+		{name: "rejected accept", target: "/api/events", accept: "application/x-ndjson; q=0", want: false},
+		{name: "query stream", target: "/api/output?stream=1", accept: "application/x-ndjson", want: true},
+		{name: "query stream missing accept", target: "/api/output?stream=1", want: false},
+		{name: "ordinary query variant", target: "/api/output", want: true},
+		{name: "unrelated route", target: "/api/jobs", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, tt.target, nil)
+			require.NoError(t, err)
+			if tt.accept != "" {
+				req.Header.Set("Accept", tt.accept)
+			}
+
+			accepted, err := ValidateTransportAccept(op, req)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, accepted)
+		})
+	}
+}

--- a/internal/server/kataapi/proxy_routes.go
+++ b/internal/server/kataapi/proxy_routes.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humago"
+
+	"go.kenn.io/forge/internal/server/httpapi"
 )
 
 func (h *Handler) registerKataProxyAPI(api huma.API) {
@@ -24,6 +26,14 @@ func (h *Handler) registerKataProxyAPI(api huma.API) {
 			Method:      method,
 			Path:        "/kata/proxy/",
 			Hidden:      true,
+		}
+		if method == http.MethodGet {
+			httpapi.AddTransportRoutes(op, httpapi.TransportRoute{
+				Method:    http.MethodGet,
+				Path:      "/api/v1/kata/proxy/api/v1/events/stream",
+				Transport: httpapi.TransportHTTPStream,
+				Accept:    "text/event-stream",
+			})
 		}
 		api.Adapter().Handle(op, func(ctx huma.Context) {
 			r, w := humago.Unwrap(ctx)

--- a/internal/server/kataapi/proxy_routes.go
+++ b/internal/server/kataapi/proxy_routes.go
@@ -37,6 +37,15 @@ func (h *Handler) registerKataProxyAPI(api huma.API) {
 		}
 		api.Adapter().Handle(op, func(ctx huma.Context) {
 			r, w := humago.Unwrap(ctx)
+			accepted, err := httpapi.ValidateTransportAccept(op, r)
+			if err != nil {
+				http.Error(w, "invalid transport metadata", http.StatusInternalServerError)
+				return
+			}
+			if !accepted {
+				http.Error(w, "streaming route requires an explicit Accept header", http.StatusNotAcceptable)
+				return
+			}
 			proxy.ServeHTTP(w, r)
 		})
 	}

--- a/internal/server/otel_middleware.go
+++ b/internal/server/otel_middleware.go
@@ -16,6 +16,10 @@ import (
 // terminal attach gets its own bounded span instead (internal/tracing).
 func otelTraceable(basePath string) func(*http.Request) bool {
 	prefix := strings.TrimSuffix(basePath, "/")
+	inventory, err := NewTransportInventory()
+	if err != nil {
+		panic("build transport inventory: " + err.Error())
+	}
 	return func(r *http.Request) bool {
 		if strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
 			return false
@@ -24,21 +28,12 @@ func otelTraceable(basePath string) func(*http.Request) bool {
 		if prefix != "" && strings.HasPrefix(path, prefix+"/") {
 			path = strings.TrimPrefix(path, prefix)
 		}
-		if r.Method == http.MethodGet {
-			switch path {
-			case "/api/v1/events":
-				return false
-			case "/api/v1/kata/proxy/api/v1/events/stream":
-				return false
-			case "/api/roborev/api/stream/events":
-				return false
-			case "/api/roborev/api/job/output":
-				return r.URL.Query().Get("stream") != "1"
-			}
+		if path != r.URL.Path {
+			cloned := r.Clone(r.Context())
+			cloned.URL.Path = path
+			r = cloned
 		}
-		return r.Method != http.MethodPost ||
-			path != "/api/roborev/api/sync/now" ||
-			r.URL.Query().Get("stream") != "1"
+		return !inventory.matchesHTTPStream(r)
 	}
 }
 

--- a/internal/server/roborev_proxy_routes.go
+++ b/internal/server/roborev_proxy_routes.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humago"
+
+	"go.kenn.io/forge/internal/server/httpapi"
 )
 
 func roborevProxyAPIConfig() huma.Config {
@@ -34,6 +36,32 @@ func (s *Server) registerRoborevProxyAPI(api huma.API) {
 			Method:      method,
 			Path:        "/roborev/",
 			Hidden:      true,
+		}
+		switch method {
+		case http.MethodGet:
+			httpapi.AddTransportRoutes(op,
+				httpapi.TransportRoute{
+					Method:    http.MethodGet,
+					Path:      "/api/roborev/api/stream/events",
+					Transport: httpapi.TransportHTTPStream,
+					Accept:    "application/x-ndjson",
+				},
+				httpapi.TransportRoute{
+					Method:    http.MethodGet,
+					Path:      "/api/roborev/api/job/output",
+					Transport: httpapi.TransportHTTPStream,
+					Accept:    "application/x-ndjson",
+					Query:     map[string]string{"stream": "1"},
+				},
+			)
+		case http.MethodPost:
+			httpapi.AddTransportRoutes(op, httpapi.TransportRoute{
+				Method:    http.MethodPost,
+				Path:      "/api/roborev/api/sync/now",
+				Transport: httpapi.TransportHTTPStream,
+				Accept:    "application/x-ndjson",
+				Query:     map[string]string{"stream": "1"},
+			})
 		}
 		api.Adapter().Handle(op, func(ctx huma.Context) {
 			r, w := humago.Unwrap(ctx)

--- a/internal/server/roborev_proxy_routes.go
+++ b/internal/server/roborev_proxy_routes.go
@@ -65,6 +65,15 @@ func (s *Server) registerRoborevProxyAPI(api huma.API) {
 		}
 		api.Adapter().Handle(op, func(ctx huma.Context) {
 			r, w := humago.Unwrap(ctx)
+			accepted, err := httpapi.ValidateTransportAccept(op, r)
+			if err != nil {
+				http.Error(w, "invalid transport metadata", http.StatusInternalServerError)
+				return
+			}
+			if !accepted {
+				http.Error(w, "streaming route requires an explicit Accept header", http.StatusNotAcceptable)
+				return
+			}
 			proxy.ServeHTTP(w, r)
 		})
 	}

--- a/internal/server/roborev_proxy_test.go
+++ b/internal/server/roborev_proxy_test.go
@@ -98,6 +98,29 @@ func TestRoborevProxyForwarding(t *testing.T) {
 	assert.JSONEq(`{"jobs":[{"id":1}]}`, rr.Body.String())
 }
 
+func TestRoborevProxyRejectsDeclaredStreamsWithoutAccept(t *testing.T) {
+	var upstreamRequests atomic.Int64
+	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamRequests.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer daemon.Close()
+
+	srv := setupTestServerWithRoborev(t, daemon.URL)
+	for _, target := range []string{
+		"/api/roborev/api/stream/events",
+		"/api/roborev/api/job/output?job_id=7&stream=1",
+	} {
+		t.Run(target, func(t *testing.T) {
+			rr := doJSON(t, srv, http.MethodGet, target, nil)
+
+			assert.Equal(t, http.StatusNotAcceptable, rr.Code)
+			assert.Contains(t, rr.Body.String(), "requires an explicit Accept header")
+		})
+	}
+	assert.Zero(t, upstreamRequests.Load())
+}
+
 func TestRoborevProxyE2EForwardsSubpathAndNonGETMethod(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -311,6 +334,7 @@ func TestRoborevProxyCancelsIdleUpstreamBeforeReconnect(t *testing.T) {
 			nil,
 		)
 		require.NoError(err)
+		req.Header.Set("Accept", "application/x-ndjson")
 		done := make(chan error, 1)
 		go func() {
 			resp, requestErr := http.DefaultClient.Do(req)

--- a/internal/server/transport_inventory.go
+++ b/internal/server/transport_inventory.go
@@ -1,0 +1,227 @@
+package server
+
+import (
+	"fmt"
+	"maps"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/adapters/humago"
+
+	"go.kenn.io/forge/internal/config"
+	"go.kenn.io/forge/internal/server/httpapi"
+	"go.kenn.io/forge/internal/server/workspaceapi"
+)
+
+const TransportInventorySchemaVersion = 1
+
+type TransportRoute = httpapi.TransportRoute
+type TransportKind = httpapi.TransportKind
+
+const (
+	TransportHTTPStream = httpapi.TransportHTTPStream
+	TransportWebSocket  = httpapi.TransportWebSocket
+)
+
+// TransportInventory describes every registered long-lived route.
+type TransportInventory struct {
+	SchemaVersion int              `json:"schema_version"`
+	Routes        []TransportRoute `json:"routes"`
+}
+
+type transportRecorder struct {
+	routes []TransportRoute
+	errs   []error
+}
+
+type recordingAdapter struct {
+	huma.Adapter
+	prefix           string
+	defaultTransport TransportKind
+	recorder         *transportRecorder
+}
+
+func (a *recordingAdapter) Handle(
+	op *huma.Operation,
+	handler func(huma.Context),
+) {
+	a.recorder.record(a.prefix, a.defaultTransport, op)
+	a.Adapter.Handle(op, handler)
+}
+
+func (r *transportRecorder) record(
+	prefix string,
+	defaultTransport TransportKind,
+	op *huma.Operation,
+) {
+	if defaultTransport != "" {
+		r.routes = append(r.routes, TransportRoute{
+			Method: op.Method, Path: prefix + op.Path,
+			Transport: defaultTransport,
+		})
+	}
+	for status, response := range op.Responses {
+		if !strings.HasPrefix(status, "2") || response == nil {
+			continue
+		}
+		for mediaType := range response.Content {
+			if !isLongLivedMediaType(mediaType) {
+				continue
+			}
+			r.routes = append(r.routes, TransportRoute{
+				Method: op.Method, Path: prefix + op.Path,
+				Transport: TransportHTTPStream, Accept: mediaType,
+			})
+		}
+	}
+	annotated, err := httpapi.TransportRoutes(op)
+	if err != nil {
+		r.errs = append(r.errs, fmt.Errorf("%s %s: %w", op.Method, prefix+op.Path, err))
+		return
+	}
+	r.routes = append(r.routes, annotated...)
+}
+
+func isLongLivedMediaType(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(strings.SplitN(value, ";", 2)[0])) {
+	case "text/event-stream", "application/x-ndjson":
+		return true
+	default:
+		return false
+	}
+}
+
+func newRecordingAPI(
+	mux *http.ServeMux,
+	prefix string,
+	config huma.Config,
+	recorder *transportRecorder,
+	defaultTransport TransportKind,
+) huma.API {
+	adapter := &recordingAdapter{
+		Adapter: humago.NewAdapter(mux, prefix),
+		prefix:  prefix, defaultTransport: defaultTransport, recorder: recorder,
+	}
+	return huma.NewAPI(config, adapter)
+}
+
+// NewTransportInventory builds the long-lived transport contract from the
+// same Huma route registrations used by the server.
+func NewTransportInventory() (TransportInventory, error) {
+	mux := http.NewServeMux()
+	recorder := &transportRecorder{}
+	s := &Server{cfg: &config.Config{}}
+
+	api := newRecordingAPI(mux, "/api/v1", apiConfig("/"), recorder, "")
+	s.registerAPI(api)
+	restAdapter := api.Adapter().(*recordingAdapter)
+	restAdapter.defaultTransport = TransportWebSocket
+	s.fleetAPI.RegisterTerminal(api)
+	workspaceapi.RegisterTerminalInventory(api)
+	restAdapter.defaultTransport = ""
+
+	wsAPI := newRecordingAPI(
+		mux, "/ws/v1", terminalAPIConfig(), recorder, TransportWebSocket,
+	)
+	s.fleetAPI.RegisterTerminal(wsAPI)
+	workspaceapi.RegisterTerminalInventory(wsAPI)
+
+	roborevAPI := newRecordingAPI(
+		mux, "/api", roborevProxyAPIConfig(), recorder, "",
+	)
+	s.registerRoborevProxyAPI(roborevAPI)
+
+	if len(recorder.errs) > 0 {
+		return TransportInventory{}, recorder.errs[0]
+	}
+	routes, err := normalizeTransportRoutes(recorder.routes)
+	if err != nil {
+		return TransportInventory{}, err
+	}
+	return TransportInventory{
+		SchemaVersion: TransportInventorySchemaVersion,
+		Routes:        routes,
+	}, nil
+}
+
+func normalizeTransportRoutes(routes []TransportRoute) ([]TransportRoute, error) {
+	normalized := make([]TransportRoute, 0, len(routes))
+	seen := map[string]struct{}{}
+	for _, route := range routes {
+		route.Method = strings.ToUpper(strings.TrimSpace(route.Method))
+		route.Path = strings.TrimSpace(route.Path)
+		route.Accept = strings.ToLower(strings.TrimSpace(route.Accept))
+		route.Query = maps.Clone(route.Query)
+		if route.Method == "" {
+			return nil, fmt.Errorf("transport route has empty method")
+		}
+		if !strings.HasPrefix(route.Path, "/") || strings.HasPrefix(route.Path, "//") {
+			return nil, fmt.Errorf("%s %s: route requires an absolute path", route.Method, route.Path)
+		}
+		if strings.ContainsAny(route.Path, "\\\x00#") || strings.Contains(route.Path, "://") {
+			return nil, fmt.Errorf("%s %s: invalid transport path", route.Method, route.Path)
+		}
+		switch route.Transport {
+		case TransportHTTPStream:
+			if route.Accept == "" {
+				return nil, fmt.Errorf("%s %s: HTTP stream requires accept", route.Method, route.Path)
+			}
+		case TransportWebSocket:
+			if route.Accept != "" {
+				return nil, fmt.Errorf("%s %s: WebSocket must not declare accept", route.Method, route.Path)
+			}
+		default:
+			return nil, fmt.Errorf("%s %s: unsupported transport %q", route.Method, route.Path, route.Transport)
+		}
+		for key, value := range route.Query {
+			if strings.TrimSpace(key) == "" || strings.TrimSpace(value) == "" {
+				return nil, fmt.Errorf("%s %s: transport query requires non-empty keys and values", route.Method, route.Path)
+			}
+		}
+		identity := transportRouteIdentity(route)
+		if _, ok := seen[identity]; ok {
+			return nil, fmt.Errorf("duplicate transport route: %s %s", route.Method, route.Path)
+		}
+		seen[identity] = struct{}{}
+		normalized = append(normalized, route)
+	}
+	sort.Slice(normalized, func(i, j int) bool {
+		return transportRouteIdentity(normalized[i]) <
+			transportRouteIdentity(normalized[j])
+	})
+	return normalized, nil
+}
+
+func transportRouteIdentity(route TransportRoute) string {
+	query := make([]string, 0, len(route.Query))
+	for key, value := range route.Query {
+		query = append(query, key+"="+value)
+	}
+	sort.Strings(query)
+	return strings.Join([]string{
+		route.Method, route.Path, string(route.Transport), route.Accept,
+		strings.Join(query, "&"),
+	}, "\x00")
+}
+
+func (inventory TransportInventory) matchesHTTPStream(request *http.Request) bool {
+	for _, route := range inventory.Routes {
+		if route.Transport != TransportHTTPStream ||
+			route.Method != request.Method || route.Path != request.URL.Path {
+			continue
+		}
+		matches := true
+		for key, value := range route.Query {
+			if request.URL.Query().Get(key) != value {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/server/transport_inventory_test.go
+++ b/internal/server/transport_inventory_test.go
@@ -1,0 +1,141 @@
+package server
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransportInventoryIncludesRegisteredLongLivedRoutes(t *testing.T) {
+	inventory, err := NewTransportInventory()
+	require.NoError(t, err)
+
+	assert := assert.New(t)
+	assert.Equal(1, inventory.SchemaVersion)
+	for _, expected := range []TransportRoute{
+		{
+			Method: http.MethodGet, Path: "/api/v1/events",
+			Transport: TransportHTTPStream, Accept: "text/event-stream",
+		},
+		{
+			Method: http.MethodGet, Path: "/api/v1/kata/tasks/events",
+			Transport: TransportHTTPStream, Accept: "text/event-stream",
+		},
+		{
+			Method:    http.MethodGet,
+			Path:      "/api/v1/kata/proxy/api/v1/events/stream",
+			Transport: TransportHTTPStream,
+			Accept:    "text/event-stream",
+		},
+		{
+			Method: http.MethodGet, Path: "/api/roborev/api/stream/events",
+			Transport: TransportHTTPStream, Accept: "application/x-ndjson",
+		},
+		{
+			Method: http.MethodGet, Path: "/api/roborev/api/job/output",
+			Transport: TransportHTTPStream, Accept: "application/x-ndjson",
+			Query: map[string]string{"stream": "1"},
+		},
+		{
+			Method: http.MethodPost, Path: "/api/roborev/api/sync/now",
+			Transport: TransportHTTPStream, Accept: "application/x-ndjson",
+			Query: map[string]string{"stream": "1"},
+		},
+		{
+			Method:    http.MethodGet,
+			Path:      "/api/v1/workspaces/{id}/terminal",
+			Transport: TransportWebSocket,
+		},
+		{
+			Method:    http.MethodGet,
+			Path:      "/ws/v1/workspaces/{id}/terminal",
+			Transport: TransportWebSocket,
+		},
+		{
+			Method:    http.MethodGet,
+			Path:      "/ws/v1/workspaces/{id}/runtime/sessions/{session_key}/terminal",
+			Transport: TransportWebSocket,
+		},
+		{
+			Method:    http.MethodGet,
+			Path:      "/ws/v1/fleet/hosts/{host_key}/workspaces/{id}/terminal",
+			Transport: TransportWebSocket,
+		},
+		{
+			Method:    http.MethodGet,
+			Path:      "/ws/v1/fleet/hosts/{host_key}/workspaces/{id}/runtime/sessions/{session_key}/terminal",
+			Transport: TransportWebSocket,
+		},
+	} {
+		assert.Contains(inventory.Routes, expected)
+	}
+}
+
+func TestNormalizeTransportRoutesRejectsInvalidContracts(t *testing.T) {
+	tests := []struct {
+		name   string
+		routes []TransportRoute
+		match  string
+	}{
+		{
+			name: "relative path",
+			routes: []TransportRoute{{
+				Method: http.MethodGet, Path: "api/events",
+				Transport: TransportHTTPStream, Accept: "text/event-stream",
+			}},
+			match: "absolute path",
+		},
+		{
+			name: "unknown transport",
+			routes: []TransportRoute{{
+				Method: http.MethodGet, Path: "/api/events",
+				Transport: "carrier-pigeon", Accept: "text/plain",
+			}},
+			match: "unsupported transport",
+		},
+		{
+			name: "websocket with accept",
+			routes: []TransportRoute{{
+				Method: http.MethodGet, Path: "/ws/terminal",
+				Transport: TransportWebSocket, Accept: "text/event-stream",
+			}},
+			match: "must not declare accept",
+		},
+		{
+			name: "duplicate",
+			routes: []TransportRoute{
+				{Method: http.MethodGet, Path: "/ws/terminal", Transport: TransportWebSocket},
+				{Method: http.MethodGet, Path: "/ws/terminal", Transport: TransportWebSocket},
+			},
+			match: "duplicate transport route",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := normalizeTransportRoutes(tt.routes)
+			require.ErrorContains(t, err, tt.match)
+		})
+	}
+}
+
+func TestNormalizeTransportRoutesSortsDeterministically(t *testing.T) {
+	routes, err := normalizeTransportRoutes([]TransportRoute{
+		{Method: http.MethodPost, Path: "/z", Transport: TransportHTTPStream, Accept: "text/event-stream"},
+		{Method: http.MethodGet, Path: "/b", Transport: TransportWebSocket},
+		{Method: http.MethodGet, Path: "/a", Transport: TransportWebSocket},
+		{Method: http.MethodGet, Path: "/q", Transport: TransportHTTPStream, Accept: "application/x-ndjson", Query: map[string]string{"stream": "2"}},
+		{Method: http.MethodGet, Path: "/q", Transport: TransportHTTPStream, Accept: "application/x-ndjson", Query: map[string]string{"stream": "1"}},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, []TransportRoute{
+		{Method: http.MethodGet, Path: "/a", Transport: TransportWebSocket},
+		{Method: http.MethodGet, Path: "/b", Transport: TransportWebSocket},
+		{Method: http.MethodGet, Path: "/q", Transport: TransportHTTPStream, Accept: "application/x-ndjson", Query: map[string]string{"stream": "1"}},
+		{Method: http.MethodGet, Path: "/q", Transport: TransportHTTPStream, Accept: "application/x-ndjson", Query: map[string]string{"stream": "2"}},
+		{Method: http.MethodPost, Path: "/z", Transport: TransportHTTPStream, Accept: "text/event-stream"},
+	}, routes)
+}

--- a/internal/server/workspaceapi/terminal_routes.go
+++ b/internal/server/workspaceapi/terminal_routes.go
@@ -12,9 +12,22 @@ import (
 // RegisterTerminal registers workspace terminal websocket routes on either
 // the REST or websocket-prefixed Huma API.
 func (h *Handler) RegisterTerminal(api huma.API) {
-	handler := &terminal.Handler{
-		Workspaces:  h.workspaces,
-		TmuxCommand: slices.Clone(h.tmuxCmd),
+	h.registerTerminal(api, h != nil && h.runtime != nil)
+}
+
+// RegisterTerminalInventory registers every terminal operation against a
+// tooling-only API that records route contracts and never serves requests.
+func RegisterTerminalInventory(api huma.API) {
+	(*Handler)(nil).registerTerminal(api, true)
+}
+
+func (h *Handler) registerTerminal(api huma.API, includeRuntime bool) {
+	var handler *terminal.Handler
+	if h != nil {
+		handler = &terminal.Handler{
+			Workspaces:  h.workspaces,
+			TmuxCommand: slices.Clone(h.tmuxCmd),
+		}
 	}
 	op := &huma.Operation{
 		OperationID: "connect-workspace-terminal",
@@ -23,11 +36,14 @@ func (h *Handler) RegisterTerminal(api huma.API) {
 		Hidden:      true,
 	}
 	api.Adapter().Handle(op, func(ctx huma.Context) {
+		if handler == nil {
+			panic("workspace terminal inventory handler cannot serve requests")
+		}
 		r, w := humago.Unwrap(ctx)
 		handler.ServeHTTP(w, r)
 	})
 
-	if h.runtime == nil {
+	if !includeRuntime {
 		return
 	}
 	sessionOp := &huma.Operation{
@@ -37,6 +53,9 @@ func (h *Handler) RegisterTerminal(api huma.API) {
 		Hidden:      true,
 	}
 	api.Adapter().Handle(sessionOp, func(ctx huma.Context) {
+		if h == nil {
+			panic("runtime terminal inventory handler cannot serve requests")
+		}
 		r, w := humago.Unwrap(ctx)
 		h.handleWorkspaceRuntimeSessionTerminal(w, r)
 	})

--- a/packages/ui/src/stores/roborev/log.svelte.ts
+++ b/packages/ui/src/stores/roborev/log.svelte.ts
@@ -50,6 +50,7 @@ export function createLogStore(opts: LogStoreOptions) {
 
     try {
       const resp = await fetch(url, {
+        headers: { Accept: "application/x-ndjson" },
         signal: abortController.signal,
       });
       if (!resp.ok || !resp.body) {


### PR DESCRIPTION
## Why

Long-lived HTTP and WebSocket routes are not fully represented by the public OpenAPI document. Hidden terminal operations and finite modes behind catch-all proxies otherwise force tooling to reconstruct transport behavior from individual handlers, which can drift from the registrations that actually serve requests.

This establishes Huma registration as the source for a deterministic schema-v1 inventory without adding a runtime endpoint or expanding the supported HTTP API. Annotated proxy streams also require their declared `Accept` media type before proxying, so the published request contract is enforced rather than advisory.

The inventory and tracing exclusions now share the same route classification, and the streaming job-output client explicitly negotiates NDJSON. Future route additions can therefore be checked mechanically instead of extending a hand-maintained snapshot.

## Verification note

The HTTP API, Kata proxy, transport inventory, and frontend log-store suites pass. The post-rebase full server run encountered one unrelated tmux cleanup timeout; that exact test passed immediately in isolation, and the complete server suite passed before the clean rebase.

<sup>generated by a clanker</sup>