### PR TITLE
docs(terminal): record snapshot accelerator no-go

### DIFF
--- a/context/workspace-runtime-lifecycle.md
+++ b/context/workspace-runtime-lifecycle.md
@@ -23,7 +23,9 @@ Kenn Forge manages three related but different things:
 
 Rules:
 
-- The base workspace `tmux` tab is part of the durable workspace experience.
+- The base workspace tmux session remains durable backend state, but production
+  workspace terminal panes are pooled runtime sessions; do not treat the primary
+  terminal endpoint as a mounted SPA workflow (`frontend/src/lib/components/terminal/PooledSessionTerminal.svelte`).
 - Launched agent sessions and shell sessions are not durable after natural exit.
 - The shell drawer is a singleton per workspace, but a tmux-backed shell should
   survive kenn-forge server restarts until the shell exits or the workspace is

--- a/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
+++ b/frontend/src/lib/components/terminal/XtermTerminalPane.svelte
@@ -27,6 +27,7 @@
     primaryTerminalFontFamily,
   } from "./terminalFontFamily.js";
   import { createInitialFocusIntent } from "./terminal-focus.js";
+  import { supportsReplayBoundary } from "./terminalReplayBoundary.js";
   import {
     clearSharedTerminalTextureAtlas,
     registerTerminalTextureAtlasParticipant,
@@ -399,19 +400,6 @@
     return `${proto}://${location.host}${withBasePath(withConnectionParams)}`;
   }
 
-  function supportsReplayBoundary(): boolean {
-    if (!websocketPath) return false;
-    try {
-      const pathname = new URL(websocketPath, window.location.href).pathname;
-      return (
-        !pathname.includes("/fleet/hosts/") &&
-        /\/workspaces\/[^/]+\/runtime\/sessions\/[^/]+\/terminal$/.test(pathname)
-      );
-    } catch {
-      return false;
-    }
-  }
-
   function withBasePath(path: string): string {
     const normalizedPath = path.startsWith("/") ? path : `/${path}`;
     if (!basePath) return normalizedPath;
@@ -639,7 +627,7 @@
     mouseDragAutoscroll.reset();
     const cols = terminal.cols;
     const rows = terminal.rows;
-    const replayBoundary = supportsReplayBoundary();
+    const replayBoundary = supportsReplayBoundary(websocketPath);
     const url = buildWsUrl(replayBoundary ? null : { cols, rows }, replayBoundary);
     if (!url) return;
     const socket = new WebSocket(url);

--- a/frontend/src/lib/components/terminal/terminalReplayBoundary.test.ts
+++ b/frontend/src/lib/components/terminal/terminalReplayBoundary.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { supportsReplayBoundary } from "./terminalReplayBoundary.js";
+
+describe("supportsReplayBoundary", () => {
+  it.each([
+    [false, "/ws/v1/workspaces/ws-1/terminal"],
+    [false, "/api/v1/workspaces/ws-1/terminal?cols=80"],
+    [true, "/ws/v1/workspaces/ws-1/runtime/sessions/shell/terminal"],
+    [false, "/ws/v1/fleet/hosts/peer/workspaces/ws-1/terminal"],
+    [false, "/ws/v1/fleet/hosts/peer/workspaces/ws-1/runtime/sessions/shell/terminal"],
+    [false, "/ws/v1/workspaces/ws-1/files"],
+  ] as const)("returns %s for %s", (expected, path) => {
+    expect(supportsReplayBoundary(path)).toBe(expected);
+  });
+
+  it("returns false for a missing or malformed path", () => {
+    expect(supportsReplayBoundary(undefined)).toBe(false);
+    expect(supportsReplayBoundary(null)).toBe(false);
+    expect(supportsReplayBoundary("http://[invalid")).toBe(false);
+  });
+});

--- a/frontend/src/lib/components/terminal/terminalReplayBoundary.ts
+++ b/frontend/src/lib/components/terminal/terminalReplayBoundary.ts
@@ -1,0 +1,11 @@
+export function supportsReplayBoundary(websocketPath: string | null | undefined): boolean {
+  if (!websocketPath) return false;
+  try {
+    const pathname = new URL(websocketPath, window.location.href).pathname;
+    return (
+      !pathname.includes("/fleet/hosts/") && /\/workspaces\/[^/]+\/runtime\/sessions\/[^/]+\/terminal$/.test(pathname)
+    );
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
- Record the production-path finding: workspace switching reparents pooled runtime-session terminals rather than opening the primary terminal endpoint.
- Keep runtime replay-boundary eligibility explicit while primary and Fleet terminals retain raw attachment behavior.
- Remove the unused snapshot/handover prototype and its rejected implementation spec; the concise lifecycle invariant and PR discussion preserve the actionable lesson.