### PR TITLE
Stop detached worktrees from raising probe warnings

### DIFF
--- a/docs/superpowers/plans/2026-08-03-detached-head-divergence.md
+++ b/docs/superpowers/plans/2026-08-03-detached-head-divergence.md
@@ -1,0 +1,111 @@
+# Detached HEAD Divergence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan directly in the current agent, task-by-task. Never use subagent-driven development. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop routine upstream probes from reporting detached managed worktrees as unexpected Git failures.
+
+**Approved spec/design:** `docs/superpowers/specs/2026-08-03-detached-head-divergence-design.md`
+
+**Architecture:** Keep upstream availability classification inside the shared workspace Git probe boundary. Extend the existing stderr classifier with Git's exact detached-`HEAD` response so both divergence and unpushed-commit callers return their established unavailable result without adding subprocesses or sampler-specific behavior.
+
+**Tech Stack:** Go, Git CLI, Testify
+
+## Global Constraints
+
+- Detached `HEAD` returns zero data, `ok=false`, and no error from both upstream probes.
+- Other `git rev-list` failures remain errors.
+- Do not add a routine Git subprocess.
+
+---
+
+### Task 1: Classify detached upstream probes as unavailable
+
+**Files:**
+- Modify: `internal/workspace/divergence_test.go`
+- Modify: `internal/workspace/divergence.go`
+
+**Interfaces:**
+- Consumes: `WorktreeDivergence(context.Context, string) (Divergence, bool, error)` and `WorktreeUnpushedSHAs(context.Context, string) (map[string]struct{}, bool, error)`.
+- Produces: The existing `isNoUpstreamMessage(string) bool` classifier recognizes Git's detached-`HEAD` response for both callers.
+
+- [ ] **Step 1: Add real-Git detached-HEAD regression tests**
+
+Add these focused tests beside the existing no-upstream cases in `internal/workspace/divergence_test.go`:
+
+```go
+func TestWorktreeDivergenceDetachedHead(t *testing.T) {
+	work := setupDivergenceWorktree(t)
+	runWorkspaceTestGit(t, work, "checkout", "--detach")
+
+	div, ok, err := WorktreeDivergence(t.Context(), work)
+	require.NoError(t, err)
+	assert.False(t, ok, "expected ok=false for detached HEAD")
+	assert.Equal(t, Divergence{}, div)
+}
+
+func TestWorktreeUnpushedSHAsDetachedHead(t *testing.T) {
+	work := setupDivergenceWorktree(t)
+	runWorkspaceTestGit(t, work, "checkout", "--detach")
+
+	unpushed, ok, err := WorktreeUnpushedSHAs(t.Context(), work)
+	require.NoError(t, err)
+	assert.False(t, ok, "expected ok=false for detached HEAD")
+	assert.Nil(t, unpushed)
+}
+```
+
+These tests catch removal or omission of detached-`HEAD` classification by exercising the actual Git failure through both public probe functions.
+
+- [ ] **Step 2: Run the tests and verify the regression is red**
+
+Run:
+
+```bash
+go test -shuffle=on ./internal/workspace -run 'TestWorktree(Divergence|UnpushedSHAs)DetachedHead'
+```
+
+Expected: FAIL because each probe returns `git rev-list: exit status 128: fatal: HEAD does not point to a branch`.
+
+- [ ] **Step 3: Add the minimal shared classification**
+
+Extend `isNoUpstreamMessage` in `internal/workspace/divergence.go` without changing its callers:
+
+```go
+return strings.Contains(s, "no upstream configured") ||
+	strings.Contains(s, "unknown revision") ||
+	strings.Contains(s, "no such ref") ||
+	strings.Contains(s, "ambiguous argument") ||
+	strings.Contains(s, "head does not point to a branch")
+```
+
+- [ ] **Step 4: Verify focused and package behavior is green**
+
+Run:
+
+```bash
+go test -shuffle=on ./internal/workspace -run 'TestWorktree(Divergence|UnpushedSHAs)'
+go test -shuffle=on ./internal/workspace
+```
+
+Expected: PASS with no probe warnings or errors.
+
+- [ ] **Step 5: Run repository short verification**
+
+Run:
+
+```bash
+make test-short
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the implementation**
+
+Run the repository-local `context-sync --commit` workflow, then the mandatory commit skill. Stage only:
+
+```bash
+git add internal/workspace/divergence.go internal/workspace/divergence_test.go docs/superpowers/plans/2026-08-03-detached-head-divergence.md
+git commit -m "fix: stop detached worktrees from raising probe warnings"
+```
+
+The commit body should explain that detached worktrees are intentional last-resort states and therefore have no meaningful upstream divergence.

--- a/docs/superpowers/specs/2026-08-03-detached-head-divergence-design.md
+++ b/docs/superpowers/specs/2026-08-03-detached-head-divergence-design.md
@@ -1,0 +1,28 @@
+# Detached HEAD Divergence Design
+
+## Problem
+
+Kenn Forge intentionally permits a detached `HEAD` as the last-resort state
+for a managed worktree. Git reports `fatal: HEAD does not point to a branch`
+when the divergence and unpushed-commit probes ask that worktree for its
+upstream. Kenn Forge currently treats that expected result as an unexpected
+probe failure, producing recurring fleet warnings and workspace debug errors.
+
+## Design
+
+Extend the existing no-upstream error classification in
+`internal/workspace/divergence.go` to recognize Git's exact detached-`HEAD`
+message. Both `WorktreeDivergence` and `WorktreeUnpushedSHAs` already share this
+classification and will return their documented unavailable result: zero data,
+`ok=false`, and no error.
+
+This keeps detached worktrees eligible for diff sampling, adds no routine Git
+subprocess, and leaves all other `rev-list` failures visible. It also avoids a
+sampler-specific exception that would leave workspace enrichment noisy.
+
+## Verification
+
+Add real-Git regression coverage that detaches an existing test worktree and
+asserts that both upstream probes report unavailable data without error. Run
+the focused workspace package tests, followed by the repository's applicable
+short verification before committing the implementation.

--- a/internal/server/e2etest/fleet_snapshot_diff_stats_test.go
+++ b/internal/server/e2etest/fleet_snapshot_diff_stats_test.go
@@ -52,14 +52,14 @@ func runGit(t *testing.T, dir string, args ...string) {
 	require.NoError(t, err, "git %v failed: %s%s", args, out, stderr)
 }
 
-// TestFleetSnapshotBranchDiffForSyncedRepoE2E covers the full chain behind the
-// workspace sidebar's +/- chips: a GitHub sync with a pre-resolved repo
-// identity persists the provider default branch, the worktree stats sampler
-// resolves an orphan workspace's diff base from that synced row, and the
-// snapshot API reports the branch-relative diff counts. A regression anywhere
-// in that wiring reproduces the user-visible failure where committed work
-// sampled 0/0 because the repo row had no default branch.
-func TestFleetSnapshotBranchDiffForSyncedRepoE2E(t *testing.T) {
+// TestFleetSnapshotDetachedWorktreeDiffForSyncedRepoE2E covers the full chain
+// behind the workspace sidebar's +/- chips: a GitHub sync with a pre-resolved
+// repo identity persists the provider default branch, the worktree stats
+// sampler resolves an orphan workspace's diff base from that synced row, and
+// the snapshot API reports the diff even when HEAD is detached. A regression
+// anywhere in that wiring either loses the sample on the expected unavailable-
+// upstream result or measures committed work against the wrong base.
+func TestFleetSnapshotDetachedWorktreeDiffForSyncedRepoE2E(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}
@@ -83,6 +83,7 @@ func TestFleetSnapshotBranchDiffForSyncedRepoE2E(t *testing.T) {
 	))
 	runGit(t, featDir, "add", ".")
 	runGit(t, featDir, "commit", "-m", "feature work")
+	runGit(t, featDir, "checkout", "--detach")
 
 	database := dbtest.Open(t)
 	// The pre-filled external id reproduces the modern resolution shape:

--- a/internal/workspace/divergence.go
+++ b/internal/workspace/divergence.go
@@ -22,10 +22,10 @@ type Divergence struct {
 // WorktreeDivergence computes ahead/behind counts between the
 // worktree at dir and its `@{upstream}` tracking branch.
 //
-// The second return value is false when the branch has no upstream
-// configured — that is a normal state for fresh issue branches and
-// not an error. The error return is reserved for unexpected git
-// failures (missing worktree, command crashed, parse failure).
+// The second return value is false when upstream data is unavailable — either
+// HEAD is detached or the branch has no upstream configured. Those are normal
+// states, not errors. The error return is reserved for unexpected git failures
+// (missing worktree, command crashed, parse failure).
 func WorktreeDivergence(
 	ctx context.Context, dir string,
 ) (Divergence, bool, error) {
@@ -97,10 +97,11 @@ func WorktreeDivergence(
 // worktree's HEAD but not from its `@{upstream}` tracking branch — the commits
 // that have not been pushed yet.
 //
-// The second return value is false when the branch has no upstream configured.
-// Callers cannot infer push status in that case: a fresh branch has pushed
-// nothing, but a fork PR head also has no upstream while already existing on a
-// remote. The error return is reserved for unexpected git failures.
+// The second return value is false when upstream data is unavailable because
+// HEAD is detached or the branch has no upstream configured. Callers cannot
+// infer push status in that case: a fresh branch has pushed nothing, but a fork
+// PR head also has no upstream while already existing on a remote. The error
+// return is reserved for unexpected git failures.
 func WorktreeUnpushedSHAs(
 	ctx context.Context, dir string,
 ) (map[string]struct{}, bool, error) {

--- a/internal/workspace/divergence.go
+++ b/internal/workspace/divergence.go
@@ -156,5 +156,6 @@ func isNoUpstreamMessage(stderr string) bool {
 	return strings.Contains(s, "no upstream configured") ||
 		strings.Contains(s, "unknown revision") ||
 		strings.Contains(s, "no such ref") ||
-		strings.Contains(s, "ambiguous argument")
+		strings.Contains(s, "ambiguous argument") ||
+		strings.Contains(s, "head does not point to a branch")
 }

--- a/internal/workspace/divergence_test.go
+++ b/internal/workspace/divergence_test.go
@@ -126,6 +126,16 @@ func TestWorktreeDivergenceWithoutUpstream(t *testing.T) {
 	assert.New(t).Equal(Divergence{}, div)
 }
 
+func TestWorktreeDivergenceDetachedHead(t *testing.T) {
+	work := setupDivergenceWorktree(t)
+	runWorkspaceTestGit(t, work, "checkout", "--detach")
+
+	div, ok, err := WorktreeDivergence(t.Context(), work)
+	require.NoError(t, err)
+	assert.False(t, ok, "expected ok=false for detached HEAD")
+	assert.Equal(t, Divergence{}, div)
+}
+
 func TestWorktreeUnpushedSHAsInSync(t *testing.T) {
 	work := setupDivergenceWorktree(t)
 
@@ -183,6 +193,16 @@ func TestWorktreeUnpushedSHAsWithoutUpstream(t *testing.T) {
 	require.NoError(err)
 	assert.New(t).False(ok, "expected ok=false for branch without upstream")
 	assert.New(t).Nil(unpushed)
+}
+
+func TestWorktreeUnpushedSHAsDetachedHead(t *testing.T) {
+	work := setupDivergenceWorktree(t)
+	runWorkspaceTestGit(t, work, "checkout", "--detach")
+
+	unpushed, ok, err := WorktreeUnpushedSHAs(t.Context(), work)
+	require.NoError(t, err)
+	assert.False(t, ok, "expected ok=false for detached HEAD")
+	assert.Nil(t, unpushed)
 }
 
 func revParseTestSHA(t *testing.T, dir, ref string) string {


### PR DESCRIPTION
Detached managed worktrees are an intentional fallback, but Git's branch-oriented upstream probes reported them as failures every polling cycle. That made routine, non-actionable state look fatal in operator logs.

- Treat Git's detached-HEAD response as the same unavailable-upstream outcome used by other untracked worktrees.
- Cover divergence and unpushed-commit probes with real detached-worktree regressions.

<sup>generated by a clanker</sup>