### PR TITLE
Record merged actor for merges performed through forge

### DIFF
--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -105,6 +105,20 @@ For pull requests, that means:
 
 PR timeline storage is intentionally selective.
 
+- Merged-actor repair is independent of open-list freshness: run it after every successful
+  MR index cycle, preserve the provider-matched route, revalidate stored provider identity
+  before persistence, use parent timing, and cool down completed sweeps. (`internal/github/sync.go::reconcileMergedActorEvents`)
+- Keep one canonical merged lifecycle row across dedupe keys: authored rows dominate
+  actorless refreshes, and later authored snapshots update the retained row.
+  (`internal/db/queries.go::upsertMREventsTx`)
+- Actor repair uses transaction-current parent timing and rejects non-merged parents.
+  (`internal/db/queries.go::UpsertMergedActorEvent`)
+- Merged-actor provider reads are active-detail work and preempt archive leases.
+  (`internal/github/sync.go::BackfillMergedActorEventOnProvider`)
+- Successful immediate and scheduled actor repairs target `pr_detail_refreshed` with canonical
+  repository identity; broad `data_changed` does not refresh an open detail. (`internal/server/`)
+- Detail synthesis treats any authored merge as canonical regardless of timestamp, since
+  stored rows may predate parent-time realignment. (`internal/server/pullapi/routes.go::withSyntheticMRLifecycleEvents`)
 - Keep the existing event families stable: comments, reviews, commits, force
   pushes, and the currently supported PR system events.
 - Review comments are UI-aware but are not part of the stored sync model unless

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -1989,7 +1989,13 @@ func upsertMREventsTx(ctx context.Context, tx *sql.Tx, events []MREvent) error {
 			    platform_id   = excluded.platform_id,
 			    platform_external_id = excluded.platform_external_id,
 			    event_type    = excluded.event_type,
-			    author        = excluded.author,
+			    author        = CASE
+			        WHEN forge_mr_events.event_type = 'merged'
+			         AND excluded.event_type = 'merged'
+			         AND TRIM(excluded.author) = ''
+			        THEN forge_mr_events.author
+			        ELSE excluded.author
+			    END,
 			    summary       = excluded.summary,
 			    body          = excluded.body,
 			    metadata_json = excluded.metadata_json,
@@ -2014,14 +2020,156 @@ func upsertMREventsTx(ctx context.Context, tx *sql.Tx, events []MREvent) error {
 	for i := range events {
 		e := &events[i]
 		canonicalizeMREventTimestamps(e)
+		authoredMerge := e.EventType == "merged" && strings.TrimSpace(e.Author) != ""
+		if e.EventType == "merged" && !authoredMerge {
+			var authoredExists bool
+			if err := tx.QueryRowContext(ctx, `
+				SELECT EXISTS (
+					SELECT 1 FROM forge_mr_events
+					WHERE merge_request_id = ? AND event_type = 'merged'
+					  AND TRIM(author) != ''
+				)`, e.MergeRequestID).Scan(&authoredExists); err != nil {
+				return fmt.Errorf("check authored merged event: %w", err)
+			}
+			if authoredExists {
+				continue
+			}
+		}
+		if authoredMerge {
+			var canonicalDedupeKey string
+			err := tx.QueryRowContext(ctx, `
+				SELECT dedupe_key FROM forge_mr_events
+				WHERE merge_request_id = ? AND event_type = 'merged'
+				  AND TRIM(author) != ''
+				ORDER BY id LIMIT 1`, e.MergeRequestID).Scan(&canonicalDedupeKey)
+			switch {
+			case err == nil:
+				e.DedupeKey = canonicalDedupeKey
+			case !errors.Is(err, sql.ErrNoRows):
+				return fmt.Errorf("find canonical authored merged event: %w", err)
+			}
+		}
 		if _, err := stmt.ExecContext(ctx,
 			e.MergeRequestID, e.PlatformID, e.PlatformExternalID, e.EventType, e.Author, e.Summary, e.Body,
 			e.MetadataJSON, e.CreatedAt, e.DedupeKey, e.DirectURL, e.ThreadID, e.PositionJSON, e.Resolvable, e.Resolved,
 		); err != nil {
 			return fmt.Errorf("insert mr event (dedupe_key=%s): %w", e.DedupeKey, err)
 		}
+		if authoredMerge {
+			if _, err := tx.ExecContext(ctx, `
+				DELETE FROM forge_mr_events
+				WHERE merge_request_id = ? AND event_type = 'merged'
+				  AND id != (
+				      SELECT id FROM forge_mr_events
+				      WHERE merge_request_id = ? AND event_type = 'merged'
+				        AND TRIM(author) != ''
+				      ORDER BY id LIMIT 1
+				  )`, e.MergeRequestID, e.MergeRequestID); err != nil {
+				return fmt.Errorf("delete duplicate merged events: %w", err)
+			}
+		}
 	}
 	return nil
+}
+
+// UpsertMergedActorEvent atomically enriches an existing actorless merged
+// lifecycle event or inserts the authored event when no merged event exists.
+// Any extra actorless merged rows are removed so one merge transition remains.
+func (d *DB) UpsertMergedActorEvent(
+	ctx context.Context,
+	event MREvent,
+) (bool, error) {
+	event.Author = strings.TrimSpace(event.Author)
+	if event.MergeRequestID == 0 || event.EventType != "merged" || event.Author == "" {
+		return false, nil
+	}
+	canonicalizeMREventTimestamps(&event)
+	changed := false
+	err := d.Tx(ctx, func(tx *sql.Tx) error {
+		var parentState string
+		var parentMergedAt sql.NullString
+		err := tx.QueryRowContext(ctx, `
+			SELECT state, merged_at
+			FROM forge_merge_requests
+			WHERE id = ?`, event.MergeRequestID).Scan(&parentState, &parentMergedAt)
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("read merged-event parent state: %w", err)
+		}
+		if parentState != string(MergeRequestStateMerged) || !parentMergedAt.Valid {
+			return nil
+		}
+		currentMergedAt, err := parseDBTime(parentMergedAt.String)
+		if err != nil {
+			return fmt.Errorf("parse merged-event parent time: %w", err)
+		}
+		event.CreatedAt = currentMergedAt
+
+		var authoredID int64
+		err = tx.QueryRowContext(ctx, `
+			SELECT id FROM forge_mr_events
+			WHERE merge_request_id = ? AND event_type = 'merged'
+			  AND TRIM(author) != ''
+			ORDER BY id LIMIT 1`, event.MergeRequestID).Scan(&authoredID)
+		switch {
+		case err == nil:
+			if _, updateErr := tx.ExecContext(ctx, `
+				UPDATE forge_mr_events
+				SET author = ?,
+				    summary = CASE WHEN TRIM(summary) = '' THEN ? ELSE summary END,
+				    created_at = ?
+				WHERE id = ?`, event.Author, event.Summary, event.CreatedAt, authoredID); updateErr != nil {
+				return fmt.Errorf("align authored merged event: %w", updateErr)
+			}
+			if _, deleteErr := tx.ExecContext(ctx, `
+				DELETE FROM forge_mr_events
+				WHERE merge_request_id = ? AND event_type = 'merged'
+				  AND id != ?`, event.MergeRequestID, authoredID); deleteErr != nil {
+				return fmt.Errorf("delete duplicate merged events: %w", deleteErr)
+			}
+			changed = true
+			return nil
+		case !errors.Is(err, sql.ErrNoRows):
+			return fmt.Errorf("find authored merged event: %w", err)
+		}
+
+		var actorlessID int64
+		err = tx.QueryRowContext(ctx, `
+			SELECT id FROM forge_mr_events
+			WHERE merge_request_id = ? AND event_type = 'merged'
+			  AND TRIM(author) = ''
+			ORDER BY id LIMIT 1`, event.MergeRequestID).Scan(&actorlessID)
+		switch {
+		case err == nil:
+			if _, err := tx.ExecContext(ctx, `
+				UPDATE forge_mr_events
+				SET author = ?,
+				    summary = CASE WHEN TRIM(summary) = '' THEN ? ELSE summary END,
+				    created_at = ?
+				WHERE id = ?`, event.Author, event.Summary, event.CreatedAt, actorlessID); err != nil {
+				return fmt.Errorf("enrich actorless merged event: %w", err)
+			}
+			if _, err := tx.ExecContext(ctx, `
+				DELETE FROM forge_mr_events
+				WHERE merge_request_id = ? AND event_type = 'merged'
+				  AND id != ?`, event.MergeRequestID, actorlessID); err != nil {
+				return fmt.Errorf("delete duplicate merged events: %w", err)
+			}
+			changed = true
+			return nil
+		case !errors.Is(err, sql.ErrNoRows):
+			return fmt.Errorf("find actorless merged event: %w", err)
+		}
+
+		if err := upsertMREventsTx(ctx, tx, []MREvent{event}); err != nil {
+			return err
+		}
+		changed = true
+		return nil
+	})
+	return changed, err
 }
 
 func (d *DB) MRCommentEventExists(
@@ -2258,6 +2406,70 @@ func (d *DB) GetPreviouslyOpenMRNumbers(
 		}
 	}
 	return closed, rows.Err()
+}
+
+// MergedMRMissingActorCursor is the exclusive upper bound for one page of
+// merged MRs missing an actor. MergeRequestID breaks ties between rows with
+// the same merged timestamp.
+type MergedMRMissingActorCursor struct {
+	MergedAt       time.Time
+	MergeRequestID int64
+}
+
+// MergedMRMissingActor is one merged MR whose events lack an authored
+// "merged" lifecycle event. Its timestamp and stable row ID form the cursor
+// for the next page.
+type MergedMRMissingActor struct {
+	MergeRequestID int64
+	Number         int
+	MergedAt       time.Time
+}
+
+// GetMergedMRNumbersMissingMergedActor returns merged MRs (merged at or after
+// mergedSince and before the composite cursor) whose events lack an authored
+// "merged" lifecycle event, newest merged first, capped at limit. Merges
+// performed through forge itself mark the MR merged eagerly, which suppresses
+// the sync-side open->closed transition that records the acting user — these
+// MRs are the gap this query finds so sync can backfill the actor from the
+// provider. The mergedBefore bound lets the caller sweep the whole window
+// across cycles: candidates whose provider permanently reports no actor would
+// otherwise occupy every newest-first batch and starve older candidates.
+func (d *DB) GetMergedMRNumbersMissingMergedActor(
+	ctx context.Context,
+	repoID int64,
+	mergedSince time.Time,
+	before MergedMRMissingActorCursor,
+	limit int,
+) ([]MergedMRMissingActor, error) {
+	rows, err := d.ro.QueryContext(ctx,
+		`SELECT mr.id, mr.number, mr.merged_at FROM forge_merge_requests mr
+		 WHERE mr.repo_id = ? AND mr.state = 'merged'
+		   AND mr.merged_at >= ?
+		   AND (mr.merged_at < ? OR (mr.merged_at = ? AND mr.id < ?))
+		   AND NOT EXISTS (
+		     SELECT 1 FROM forge_mr_events e
+		     WHERE e.merge_request_id = mr.id
+		       AND e.event_type = 'merged' AND TRIM(e.author) != ''
+		   )
+		 ORDER BY mr.merged_at DESC, mr.id DESC LIMIT ?`,
+		repoID, mergedSince, before.MergedAt, before.MergedAt,
+		before.MergeRequestID, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get merged mrs missing merged actor: %w", err)
+	}
+	defer rows.Close()
+
+	var missing []MergedMRMissingActor
+	for rows.Next() {
+		var row MergedMRMissingActor
+		if err := rows.Scan(&row.MergeRequestID, &row.Number, &row.MergedAt); err != nil {
+			return nil, fmt.Errorf("scan merged mr missing actor: %w", err)
+		}
+		row.MergedAt = row.MergedAt.UTC()
+		missing = append(missing, row)
+	}
+	return missing, rows.Err()
 }
 
 func (d *DB) CountOpenMergeRequestsForRepo(ctx context.Context, repoID int64) (int, error) {

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -393,6 +393,148 @@ func TestUpsertMREventsUpdatesExistingEventBody(t *testing.T) {
 	assert.Equal("edited body", events[0].Body)
 }
 
+func TestUpsertMREventsPreservesEnrichedMergedActor(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	repoID := insertTestRepo(t, d, "acme", "widget")
+	mrID := insertTestMR(t, d, repoID, 1, "pr", baseTime())
+
+	event := MREvent{
+		MergeRequestID: mrID,
+		EventType:      "merged",
+		Author:         "merge-admin",
+		Summary:        "merged this",
+		CreatedAt:      baseTime(),
+		DedupeKey:      "provider-merged-event",
+	}
+	require.NoError(d.UpsertMREvents(ctx, []MREvent{event}))
+	event.Author = ""
+	require.NoError(d.UpsertMREvents(ctx, []MREvent{event}))
+
+	events, err := d.ListMREvents(ctx, mrID)
+	require.NoError(err)
+	require.Len(events, 1)
+	require.Equal("merge-admin", events[0].Author)
+}
+
+func TestUpsertMREventsRejectsDistinctActorlessMergeAfterAuthoredMerge(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	repoID := insertTestRepo(t, d, "acme", "widget")
+	mrID := insertTestMR(t, d, repoID, 1, "pr", baseTime())
+
+	require.NoError(d.UpsertMREvents(ctx, []MREvent{{
+		MergeRequestID: mrID,
+		EventType:      "merged",
+		Author:         "merge-admin",
+		Summary:        "merged this",
+		CreatedAt:      baseTime(),
+		DedupeKey:      "authored-merge",
+	}}))
+	require.NoError(d.UpsertMREvents(ctx, []MREvent{{
+		MergeRequestID: mrID,
+		EventType:      "merged",
+		Summary:        "merged this",
+		CreatedAt:      baseTime().Add(time.Minute),
+		DedupeKey:      "actorless-provider-refresh",
+	}}))
+
+	events, err := d.ListMREvents(ctx, mrID)
+	require.NoError(err)
+	require.Len(events, 1)
+	require.Equal("authored-merge", events[0].DedupeKey)
+	require.Equal("merge-admin", events[0].Author)
+}
+
+func TestUpsertMREventsDeduplicatesDistinctAuthoredMergeEvents(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	repoID := insertTestRepo(t, d, "acme", "widget")
+	mrID := insertTestMR(t, d, repoID, 1, "pr", baseTime())
+
+	require.NoError(d.UpsertMREvents(ctx, []MREvent{
+		{
+			MergeRequestID: mrID,
+			EventType:      "merged",
+			Author:         "first-admin",
+			Summary:        "merged this",
+			CreatedAt:      baseTime(),
+			DedupeKey:      "first-authored-merge",
+		},
+		{
+			MergeRequestID: mrID,
+			EventType:      "merged",
+			Author:         "second-admin",
+			Summary:        "merged this",
+			CreatedAt:      baseTime().Add(time.Minute),
+			DedupeKey:      "second-authored-merge",
+		},
+	}))
+
+	events, err := d.ListMREvents(ctx, mrID)
+	require.NoError(err)
+	require.Len(events, 1)
+	require.Equal("first-authored-merge", events[0].DedupeKey)
+	require.Equal("second-admin", events[0].Author)
+	require.Equal(baseTime().Add(time.Minute), events[0].CreatedAt)
+}
+
+func TestUpsertMergedActorEventUsesCurrentParentMergedAt(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	repoID := insertTestRepo(t, d, "acme", "widget")
+	initialMergedAt := baseTime()
+	mrID := insertTestMRWithOptions(t, d, testMR(repoID, 1, func(mr *MergeRequest) {
+		mr.State = MergeRequestStateMerged
+		mr.MergedAt = &initialMergedAt
+	}))
+	currentMergedAt := initialMergedAt.Add(time.Hour)
+	require.NoError(d.UpdateMRState(
+		ctx, repoID, 1, "merged", &currentMergedAt, &currentMergedAt,
+	))
+
+	changed, err := d.UpsertMergedActorEvent(ctx, MREvent{
+		MergeRequestID: mrID,
+		EventType:      "merged",
+		Author:         "merge-admin",
+		Summary:        "merged this",
+		CreatedAt:      initialMergedAt,
+		DedupeKey:      "stale-provider-event",
+	})
+	require.NoError(err)
+	require.True(changed)
+	events, err := d.ListMREvents(ctx, mrID)
+	require.NoError(err)
+	require.Len(events, 1)
+	require.Equal(currentMergedAt, events[0].CreatedAt)
+}
+
+func TestUpsertMergedActorEventRejectsNonMergedParent(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	repoID := insertTestRepo(t, d, "acme", "widget")
+	mrID := insertTestMR(t, d, repoID, 1, "pr", baseTime())
+
+	changed, err := d.UpsertMergedActorEvent(ctx, MREvent{
+		MergeRequestID: mrID,
+		EventType:      "merged",
+		Author:         "merge-admin",
+		Summary:        "merged this",
+		CreatedAt:      baseTime(),
+		DedupeKey:      "stale-provider-event",
+	})
+	require.NoError(err)
+	require.False(changed)
+	events, err := d.ListMREvents(ctx, mrID)
+	require.NoError(err)
+	require.Empty(events)
+}
+
 func TestUpsertMREventsUpdatesExistingReviewState(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -5170,4 +5312,108 @@ func TestUpsertIssue_NormalizesEmptyAssigneesJSON(t *testing.T) {
 	issues, err := d.ListIssues(ctx, ListIssuesOpts{Assignee: "anyone", State: "all"})
 	require.NoError(err)
 	assert.Empty(issues)
+}
+
+func TestGetMergedMRNumbersMissingMergedActor(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	repoID := insertTestRepo(t, d, "acme", "widget")
+	base := baseTime()
+	mergedOpt := func(at time.Time) testMROpt {
+		return func(mr *MergeRequest) {
+			mr.State = MergeRequestStateMerged
+			mr.MergedAt = &at
+		}
+	}
+
+	// #1: merged through forge — state merged, no events at all.
+	insertTestMRWithOptions(t, d, testMR(repoID, 1, mergedOpt(base.Add(time.Hour))))
+	// #2: merged with the actor already recorded.
+	id2 := insertTestMRWithOptions(t, d, testMR(repoID, 2, mergedOpt(base.Add(2*time.Hour))))
+	require.NoError(d.UpsertMREvents(ctx, []MREvent{{
+		MergeRequestID: id2,
+		EventType:      "merged",
+		Author:         "merge-admin",
+		Summary:        "merged this",
+		CreatedAt:      base.Add(2 * time.Hour),
+		DedupeKey:      "evt-2",
+	}}))
+	// #3: still open.
+	insertTestMR(t, d, repoID, 3, "open", base)
+	// #4: merged with an actor-less merged event — still needs the actor.
+	id4 := insertTestMRWithOptions(t, d, testMR(repoID, 4, mergedOpt(base.Add(3*time.Hour))))
+	require.NoError(d.UpsertMREvents(ctx, []MREvent{{
+		MergeRequestID: id4,
+		EventType:      "merged",
+		Summary:        "merged this",
+		CreatedAt:      base.Add(3 * time.Hour),
+		DedupeKey:      "evt-4",
+	}}))
+	// #5: merged before the cutoff — out of scope.
+	insertTestMRWithOptions(t, d, testMR(repoID, 5, mergedOpt(base.Add(-time.Hour))))
+
+	horizon := base.Add(100 * time.Hour)
+	rows, err := d.GetMergedMRNumbersMissingMergedActor(ctx, repoID, base,
+		MergedMRMissingActorCursor{MergedAt: horizon, MergeRequestID: 1<<63 - 1}, 10)
+	require.NoError(err)
+	require.Len(rows, 2)
+	assert.Equal(4, rows[0].Number)
+	assert.Equal(base.Add(3*time.Hour), rows[0].MergedAt)
+	assert.Equal(1, rows[1].Number)
+	assert.Equal(base.Add(time.Hour), rows[1].MergedAt)
+
+	limited, err := d.GetMergedMRNumbersMissingMergedActor(ctx, repoID, base,
+		MergedMRMissingActorCursor{MergedAt: horizon, MergeRequestID: 1<<63 - 1}, 1)
+	require.NoError(err)
+	require.Len(limited, 1)
+	assert.Equal(4, limited[0].Number)
+
+	// The mergedBefore bound is the sweep cursor: excluding the newest
+	// candidate's merged_at must surface the older candidate it was hiding.
+	older, err := d.GetMergedMRNumbersMissingMergedActor(
+		ctx, repoID, base,
+		MergedMRMissingActorCursor{
+			MergedAt:       rows[0].MergedAt,
+			MergeRequestID: rows[0].MergeRequestID,
+		}, 10,
+	)
+	require.NoError(err)
+	require.Len(older, 1)
+	assert.Equal(1, older[0].Number)
+}
+
+func TestGetMergedMRNumbersMissingMergedActorPaginatesTiedTimestamps(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	repoID := insertTestRepo(t, d, "acme", "widget")
+	mergedAt := baseTime().Add(time.Hour)
+	for number := 1; number <= 12; number++ {
+		insertTestMRWithOptions(t, d, testMR(repoID, number, func(mr *MergeRequest) {
+			mr.State = MergeRequestStateMerged
+			mr.MergedAt = &mergedAt
+		}))
+	}
+
+	first, err := d.GetMergedMRNumbersMissingMergedActor(
+		ctx, repoID, baseTime(), MergedMRMissingActorCursor{
+			MergedAt: mergedAt.Add(time.Hour), MergeRequestID: 1<<63 - 1,
+		}, 10,
+	)
+	require.NoError(err)
+	require.Len(first, 10)
+
+	second, err := d.GetMergedMRNumbersMissingMergedActor(
+		ctx, repoID, baseTime(), MergedMRMissingActorCursor{
+			MergedAt:       first[len(first)-1].MergedAt,
+			MergeRequestID: first[len(first)-1].MergeRequestID,
+		}, 10,
+	)
+	require.NoError(err)
+	require.Len(second, 2,
+		"the next page must retain rows tied with the previous page's timestamp")
 }

--- a/internal/github/archive_lifecycle_test.go
+++ b/internal/github/archive_lifecycle_test.go
@@ -1353,6 +1353,78 @@ func TestLiveProviderWorkCancelsAndWaitsForArchiveRequest(t *testing.T) {
 	}
 }
 
+func TestBackfillMergedActorCancelsAndWaitsForArchiveRequest(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	database := dbtest.Open(t)
+	now := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	ref := platform.RepoRef{
+		Platform: platform.KindGitLab, Host: "gitlab.test",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+	}
+	provider := &blockingPriorityProvider{
+		syncTestProvider: syncTestProvider{kind: ref.Platform, host: ref.Host},
+		ref:              ref, operation: priorityWorkMR,
+		started: make(chan struct{}), release: make(chan struct{}),
+	}
+	releaseProvider := sync.OnceFunc(func() { close(provider.release) })
+	t.Cleanup(releaseProvider)
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+	repoID, err := database.UpsertRepo(ctx, db.RepoIdentity{
+		Platform: string(ref.Platform), PlatformHost: ref.Host,
+		PlatformRepoID: "repo-1", Owner: ref.Owner, Name: ref.Name, RepoPath: ref.RepoPath,
+	})
+	require.NoError(err)
+	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID: repoID, PlatformID: 7, PlatformExternalID: "mr-7", Number: 7,
+		Title: "Synthetic MR", State: db.MergeRequestStateMerged,
+		CreatedAt: now, UpdatedAt: now, LastActivityAt: now, MergedAt: &now,
+	})
+	require.NoError(err)
+	key := RateBucketKey(string(ref.Platform), ref.Host, "host")
+	syncer := NewSyncerWithRegistry(
+		registry, database, nil, []RepoRef{{
+			Platform: ref.Platform, PlatformHost: ref.Host, PlatformExternalID: "repo-1",
+			Owner: ref.Owner, Name: ref.Name, RepoPath: ref.RepoPath,
+		}}, time.Hour, nil, map[string]*SyncBudget{key: NewSyncBudget(10)},
+	)
+	t.Cleanup(syncer.Stop)
+
+	archiveCtx, releaseArchive, allowed := syncer.tryBeginArchiveProviderRequest(ctx, key)
+	require.True(allowed)
+	done := make(chan error, 1)
+	go func() {
+		_, backfillErr := syncer.BackfillMergedActorEventOnProvider(ctx, repoID, 7)
+		done <- backfillErr
+	}()
+
+	select {
+	case <-archiveCtx.Done():
+	case <-provider.started:
+		releaseProvider()
+		releaseArchive()
+		require.NoError(<-done)
+		require.Fail("merged-actor backfill overlapped an active archive request")
+	case <-time.After(time.Second):
+		releaseArchive()
+		require.Fail("merged-actor backfill did not cancel the active archive request")
+	}
+	select {
+	case <-provider.started:
+		require.Fail("merged-actor backfill started before the archive lease released")
+	case <-time.After(25 * time.Millisecond):
+	}
+	releaseArchive()
+	select {
+	case <-provider.started:
+	case <-time.After(time.Second):
+		require.Fail("merged-actor backfill did not proceed after the archive lease released")
+	}
+	releaseProvider()
+	require.NoError(<-done)
+}
+
 func TestArchiveAdmissionDefersToForegroundSyncEntryPoints(t *testing.T) {
 	for _, tc := range []struct {
 		name      string

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -486,6 +486,8 @@ type Syncer struct {
 	rateLimitSnapshotRefresh map[string]time.Time
 	repos                    []RepoRef
 	reposMu                  sync.Mutex
+	mergedActorCursorMu      sync.Mutex
+	mergedActorCursors       map[int64]mergedActorSweepState
 	interval                 time.Duration
 	watchInterval            time.Duration
 	watchedMRs               []WatchedMR
@@ -527,7 +529,10 @@ type Syncer struct {
 	// onWatchedMRSyncCompleted fires once after a watched-MR fast-sync
 	// pass refreshes at least one MR.
 	onWatchedMRSyncCompleted func()
-	onStatusChange           func(status *SyncStatus)
+	// onMergedActorRepaired fires after scheduled reconciliation persists an
+	// authored merge event so consumers can refresh the affected detail.
+	onMergedActorRepaired func(context.Context, int64, int)
+	onStatusChange        func(status *SyncStatus)
 	// onNotificationSyncComplete fires after each notification sync run
 	// (periodic, manual, or sidecar) so the server can broadcast the same
 	// data-change signal the normal sync uses. Notification sync can insert
@@ -2979,6 +2984,16 @@ func (s *Syncer) SetOnWatchedMRSyncCompleted(fn func()) {
 	s.onWatchedMRSyncCompleted = fn
 }
 
+// SetOnMergedActorRepaired registers a callback invoked after scheduled
+// reconciliation persists an authored merged event. RunOnce can process
+// repositories in parallel, so the callback must be concurrency-safe.
+// Register it before Start or RunOnce.
+func (s *Syncer) SetOnMergedActorRepaired(
+	fn func(context.Context, int64, int),
+) {
+	s.onMergedActorRepaired = fn
+}
+
 // SetParallelism sets the maximum number of repos synced
 // concurrently in RunOnce. Values <= 0 are clamped to 1
 // (sequential).
@@ -3699,6 +3714,30 @@ func (s *Syncer) trackedRepoByIdentity(
 			strings.EqualFold(r.Name, name) &&
 			strings.EqualFold(rHost, host) {
 			return r, true
+		}
+	}
+	return RepoRef{}, false
+}
+
+func (s *Syncer) trackedRepoByProviderID(
+	kind platform.Kind,
+	host, providerID string,
+) (RepoRef, bool) {
+	if kind == "" {
+		kind = platform.KindGitHub
+	}
+	host = repoHost(RepoRef{Platform: kind, PlatformHost: host})
+	providerID = strings.TrimSpace(providerID)
+	if providerID == "" {
+		return RepoRef{}, false
+	}
+	s.reposMu.Lock()
+	defer s.reposMu.Unlock()
+	for _, repo := range s.repos {
+		if repoPlatform(repo) == kind &&
+			strings.EqualFold(repoHost(repo), host) &&
+			strings.TrimSpace(repo.PlatformExternalID) == providerID {
+			return repo, true
 		}
 	}
 	return RepoRef{}, false
@@ -6423,8 +6462,11 @@ func (s *Syncer) indexSyncRepo(
 		}
 
 		if prListUnchanged {
-			// 304 — nothing to do. The detail drain handles CI
-			// updates for PRs with pending checks via priority scoring.
+			// The open list is unchanged, but repair work is independent
+			// of that ETag and must continue advancing on every healthy MR
+			// sync cycle. The detail drain handles CI updates for PRs with
+			// pending checks via priority scoring.
+			s.reconcileMergedActorEvents(ctx, repo, repoID)
 		} else if !mrListBlocked {
 			// GraphQL path: if fetcher available and not rate-limited,
 			// do a bulk fetch that replaces both index upsert and
@@ -6749,10 +6791,290 @@ func (s *Syncer) syncMergeRequestsFromList(
 		}
 	}
 
+	s.reconcileMergedActorEvents(ctx, repo, repoID)
+
 	if hadItemFailure {
 		return fmt.Errorf("one or more merge request sync items failed")
 	}
 	progress.done()
+	return nil
+}
+
+// mergedActorBackfillPerSync caps how many merged MRs are re-fetched per
+// sync cycle to backfill a missing merged actor; mergedActorBackfillWindow
+// bounds how far back the backfill looks so a provider that never reports
+// the actor cannot cause an unbounded refetch loop.
+const (
+	mergedActorBackfillPerSync       = 10
+	mergedActorBackfillWindow        = 90 * 24 * time.Hour
+	mergedActorBackfillSweepInterval = time.Hour
+)
+
+type mergedActorSweepState struct {
+	Cursor    db.MergedMRMissingActorCursor
+	RestartAt time.Time
+}
+
+// reconcileMergedActorEvents backfills authored merged events for MRs that
+// were marked merged without one. Merges performed through forge itself
+// eagerly write state=merged, which suppresses the open->closed transition
+// in syncMergeRequestsFromList — the only sync path that fetches the MR
+// with its merged_by actor. Failures are logged, not propagated: this is a
+// repair pass and must not fail an otherwise healthy sync cycle.
+//
+// Each cycle takes the next batch below the per-repo sweep cursor instead
+// of a fixed newest-first batch: candidates whose provider permanently
+// reports no actor (e.g. the merging account was deleted) would otherwise
+// occupy every batch and starve older candidates. An exhausted sweep retains
+// a bounded cooldown, so persistent candidates are retried once per interval,
+// not once per sync cycle.
+func (s *Syncer) reconcileMergedActorEvents(
+	ctx context.Context,
+	repo RepoRef,
+	repoID int64,
+) {
+	now := s.nowUTC()
+	since := now.Add(-mergedActorBackfillWindow)
+	cursor, ready := s.mergedActorSweepCursor(repoID, now)
+	if !ready {
+		return
+	}
+	missing, err := s.db.GetMergedMRNumbersMissingMergedActor(
+		ctx, repoID, since, cursor,
+		mergedActorBackfillPerSync,
+	)
+	if err != nil {
+		slog.Error("list merged MRs missing merged actor",
+			"repo", repo.Owner+"/"+repo.Name, "err", err)
+		return
+	}
+	if len(missing) < mergedActorBackfillPerSync {
+		s.setMergedActorSweepState(repoID, mergedActorSweepState{
+			RestartAt: now.Add(mergedActorBackfillSweepInterval),
+		})
+	} else {
+		last := missing[len(missing)-1]
+		s.setMergedActorSweepState(repoID, mergedActorSweepState{
+			Cursor: db.MergedMRMissingActorCursor{
+				MergedAt:       last.MergedAt,
+				MergeRequestID: last.MergeRequestID,
+			},
+		})
+	}
+	for _, candidate := range missing {
+		changed, err := s.backfillMergedActorEvent(ctx, repo, repoID, candidate.Number)
+		if err != nil {
+			slog.Warn("backfill merged actor failed",
+				"repo", repo.Owner+"/"+repo.Name,
+				"number", candidate.Number,
+				"err", err)
+			continue
+		}
+		if changed && s.onMergedActorRepaired != nil {
+			s.onMergedActorRepaired(ctx, repoID, candidate.Number)
+		}
+	}
+}
+
+// mergedActorSweepCursor returns the exclusive composite upper bound for the
+// repo's next backfill batch. Exhausted sweeps retain a cooldown before a new
+// sweep starts from the top of the window; the initial timestamp sits ahead of
+// now so a merge stamped by a marginally faster clock is still swept.
+func (s *Syncer) mergedActorSweepCursor(
+	repoID int64,
+	now time.Time,
+) (db.MergedMRMissingActorCursor, bool) {
+	s.mergedActorCursorMu.Lock()
+	defer s.mergedActorCursorMu.Unlock()
+	state, ok := s.mergedActorCursors[repoID]
+	if ok && !state.RestartAt.IsZero() {
+		if now.Before(state.RestartAt) {
+			return db.MergedMRMissingActorCursor{}, false
+		}
+		delete(s.mergedActorCursors, repoID)
+		ok = false
+	}
+	if !ok {
+		return db.MergedMRMissingActorCursor{
+			MergedAt:       now.Add(time.Hour),
+			MergeRequestID: 1<<63 - 1,
+		}, true
+	}
+	return state.Cursor, true
+}
+
+func (s *Syncer) setMergedActorSweepState(
+	repoID int64,
+	state mergedActorSweepState,
+) {
+	s.mergedActorCursorMu.Lock()
+	defer s.mergedActorCursorMu.Unlock()
+	if s.mergedActorCursors == nil {
+		s.mergedActorCursors = make(map[int64]mergedActorSweepState)
+	}
+	s.mergedActorCursors[repoID] = state
+}
+
+// BackfillMergedActorEventOnProvider records the authored merged lifecycle
+// event for one MR by re-fetching it from the provider, reporting whether an
+// event was inserted. The merge mutation calls this in the background after
+// a successful merge: its eager state=merged write both suppresses the
+// sync-side closed transition and advances updated_at past the provider's,
+// so a full snapshot resync would be rejected as stale and never persist the
+// actor. The provider target is resolved from the stable repository row for
+// repoID so a configuration rename between the mutation and this background
+// pass cannot fetch from a different repository than the row being updated.
+func (s *Syncer) BackfillMergedActorEventOnProvider(
+	ctx context.Context,
+	repoID int64,
+	number int,
+) (bool, error) {
+	stored, err := s.db.GetRepoByID(ctx, repoID)
+	if err != nil {
+		return false, fmt.Errorf("get repo %d for merged-actor backfill: %w", repoID, err)
+	}
+	if stored == nil {
+		return false, fmt.Errorf("repo %d is not known for merged-actor backfill", repoID)
+	}
+	kind := platform.Kind(stored.Platform)
+	providerID := strings.TrimSpace(stored.PlatformRepoID)
+	if providerID == "" {
+		return false, fmt.Errorf(
+			"repo %d has no stable provider ID for merged-actor backfill", repoID,
+		)
+	}
+	repo, ok := s.trackedRepoByProviderID(kind, stored.PlatformHost, providerID)
+	if !ok {
+		routed, routeOK := s.trackedRepoByIdentity(
+			kind, stored.Owner, stored.Name, stored.PlatformHost,
+		)
+		if !routeOK {
+			return false, fmt.Errorf(
+				"repo %s/%s on %s/%s with provider ID %q is not tracked",
+				stored.Owner, stored.Name, stored.Platform, stored.PlatformHost, providerID,
+			)
+		}
+		if routedID := strings.TrimSpace(routed.PlatformExternalID); routedID != "" {
+			return false, fmt.Errorf(
+				"tracked repo %s/%s provider ID %q does not match stored provider ID %q",
+				stored.Owner, stored.Name, routedID, providerID,
+			)
+		}
+		repo = routed
+	}
+	repo = repoRefForMergedActorBackfill(repo, *stored)
+	bucket, err := s.bucketKeyForRepo(repo, false)
+	if err != nil {
+		return false, fmt.Errorf(
+			"resolve merged-actor credential route for %s/%s: %w",
+			repo.Owner, repo.Name, err,
+		)
+	}
+	releaseProviderWork := s.beginProviderWork(bucket, archive.PriorityActiveDetail)
+	defer releaseProviderWork()
+	return s.backfillMergedActorEvent(ctx, repo, repoID, number)
+}
+
+// repoRefForMergedActorBackfill preserves the current provider-verified route
+// while attaching stable identity and non-routing metadata from persistence.
+func repoRefForMergedActorBackfill(tracked RepoRef, stored db.Repo) RepoRef {
+	repo := tracked
+	repo.Platform = platform.Kind(stored.Platform)
+	repo.PlatformHost = stored.PlatformHost
+	repo.RepoID = stored.ID
+	repo.PlatformExternalID = stored.PlatformRepoID
+	if repo.WebURL == "" {
+		repo.WebURL = stored.WebURL
+	}
+	if repo.CloneURL == "" {
+		repo.CloneURL = stored.CloneURL
+	}
+	if repo.DefaultBranch == "" {
+		repo.DefaultBranch = stored.DefaultBranch
+	}
+	return repo
+}
+
+// backfillMergedActorEvent persists the authored merged event from a fresh
+// provider fetch, bypassing the parent-snapshot staleness gate — the event
+// is keyed to the MR row and does not depend on snapshot acceptance. It
+// reports whether an event was inserted.
+func (s *Syncer) backfillMergedActorEvent(
+	ctx context.Context,
+	repo RepoRef,
+	repoID int64,
+	number int,
+) (bool, error) {
+	stored, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repoID, number)
+	if err != nil {
+		return false, fmt.Errorf("get MR #%d for merged-actor backfill: %w", number, err)
+	}
+	if stored == nil {
+		return false, nil
+	}
+	mrReader, err := s.mergeRequestReaderFor(repo)
+	if err != nil {
+		return false, fmt.Errorf(
+			"resolve merge request reader for %s/%s: %w", repo.Owner, repo.Name, err,
+		)
+	}
+	mr, err := mrReader.GetMergeRequest(ctx, platformRepoRef(repo), number)
+	if err != nil {
+		return false, fmt.Errorf("get MR #%d for merged-actor backfill: %w", number, err)
+	}
+	storedRepo, err := s.db.GetRepoByID(ctx, repoID)
+	if err != nil {
+		return false, fmt.Errorf("get repo %d for merged-actor identity check: %w", repoID, err)
+	}
+	if storedRepo == nil {
+		return false, fmt.Errorf("repo %d disappeared during merged-actor backfill", repoID)
+	}
+	if err := s.verifyMergedActorBackfillIdentity(
+		ctx, repo, strings.TrimSpace(storedRepo.PlatformRepoID),
+	); err != nil {
+		return false, err
+	}
+	inserted, err := s.persistMergedActorEvent(
+		ctx, stored.ID, 0, mr.MergedBy, stored.MergedAt,
+	)
+	if err != nil {
+		return false, fmt.Errorf(
+			"persist merged lifecycle event for MR #%d: %w", number, err,
+		)
+	}
+	return inserted, nil
+}
+
+func (s *Syncer) verifyMergedActorBackfillIdentity(
+	ctx context.Context,
+	repo RepoRef,
+	expectedProviderID string,
+) error {
+	if expectedProviderID == "" {
+		return errors.New("merged-actor backfill requires a stable provider ID")
+	}
+	reader, err := s.clients.RepositoryReader(repoPlatform(repo), repoHost(repo))
+	if err != nil {
+		return fmt.Errorf("resolve repository reader for merged-actor identity check: %w", err)
+	}
+	observed, err := reader.GetRepository(ctx, platformRepoRef(repo))
+	if err != nil {
+		return fmt.Errorf(
+			"verify repository identity before merged-actor persistence: %w", err,
+		)
+	}
+	observedProviderID := strings.TrimSpace(
+		platform.DBRepositoryIdentity(observed).PlatformRepoID,
+	)
+	if observedProviderID == "" {
+		return errors.New("provider returned no repository ID during merged-actor identity check")
+	}
+	if observedProviderID != expectedProviderID {
+		return fmt.Errorf(
+			"repository route %s/%s changed provider ID from %q to %q during merged-actor backfill",
+			repo.Owner, repo.Name, expectedProviderID, observedProviderID,
+		)
+	}
 	return nil
 }
 
@@ -7433,6 +7755,8 @@ func (s *Syncer) doSyncRepoGraphQL(
 			failedScope |= failMR
 		}
 	}
+
+	s.reconcileMergedActorEvents(ctx, repo, repoID)
 
 	if failedScope != 0 {
 		return fmt.Errorf("GraphQL sync had partial failures")
@@ -11285,17 +11609,6 @@ func (s *Syncer) filterDuplicateMergedLifecycleEvents(
 	return out, nil
 }
 
-func (s *Syncer) authoredMergedLifecycleEventExists(
-	ctx context.Context,
-	mrID int64,
-) (bool, error) {
-	events, err := s.db.ListMREvents(ctx, mrID)
-	if err != nil {
-		return false, err
-	}
-	return authoredMergedLifecycleEventExists(events), nil
-}
-
 func authoredMergedLifecycleEventExists(events []db.MREvent) bool {
 	return slices.ContainsFunc(events, isAuthoredMergedLifecycleEvent)
 }
@@ -11336,13 +11649,6 @@ func (s *Syncer) persistMergedActorEvent(
 	if actor == "" {
 		return false, nil
 	}
-	exists, err := s.authoredMergedLifecycleEventExists(ctx, mrID)
-	if err != nil {
-		return false, err
-	}
-	if exists {
-		return false, nil
-	}
 	event := NormalizeTimelineEvent(mrID, PullRequestTimelineEvent{
 		EventType: "merged",
 		Actor:     actor,
@@ -11351,10 +11657,7 @@ func (s *Syncer) persistMergedActorEvent(
 	if event == nil {
 		return false, nil
 	}
-	if err := s.db.UpsertMREvents(ctx, []db.MREvent{*event}); err != nil {
-		return false, err
-	}
-	return true, nil
+	return s.db.UpsertMergedActorEvent(ctx, *event)
 }
 
 func (s *Syncer) fetchAndUpdateClosedMergeRequest(

--- a/internal/github/sync_test.go
+++ b/internal/github/sync_test.go
@@ -8456,7 +8456,8 @@ func TestSyncOpenMRFromBulkSkipsMergedActorFallbackWhenAuthoredMergedEventExists
 	assert.Equal("merged", events[0].EventType)
 	assert.Equal("merge-admin", events[0].Author)
 	assert.Equal("timeline-existing", events[0].DedupeKey)
-	assert.True(events[0].CreatedAt.Equal(existingMergedAt))
+	assert.True(events[0].CreatedAt.Equal(incomingMergedAt),
+		"the authored event must follow an accepted merged_at correction")
 }
 
 func TestFetchProviderMRDetailSyncsReviewThreads(t *testing.T) {
@@ -12246,6 +12247,57 @@ func TestSyncerHandles304OnPRList(t *testing.T) {
 	require.Len(results, 1)
 	assert.Empty(results[0].Error,
 		"304 on open-PR list must not surface as a sync error")
+}
+
+func TestSyncerReconcilesMergedActorOnPRList304(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	now := time.Date(2024, 6, 5, 12, 0, 0, 0, time.UTC)
+
+	repoID, err := d.UpsertRepo(
+		ctx, verifiedGitHubRepoIdentity("github.com", "owner", "repo"),
+	)
+	require.NoError(err)
+	pr := buildOpenPR(7, now)
+	normalizedPR, err := NormalizePR(repoID, pr)
+	require.NoError(err)
+	_, err = d.UpsertMergeRequest(ctx, normalizedPR)
+	require.NoError(err)
+	mergedAt := now.Add(time.Minute)
+	require.NoError(d.UpdateMRState(ctx, repoID, 7, "merged", &mergedAt, &mergedAt))
+
+	merged := true
+	actor := "merge-admin"
+	pr.State = new("closed")
+	pr.Merged = &merged
+	pr.MergedAt = makeTimestamp(mergedAt)
+	pr.ClosedAt = makeTimestamp(mergedAt)
+	pr.UpdatedAt = makeTimestamp(mergedAt)
+	pr.MergedBy = &gh.User{Login: &actor}
+	mc := &mockClient{listOpenPRsErr: notModifiedErr(), singlePR: pr}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc}, d, nil,
+		[]RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}},
+		time.Minute, nil, nil,
+	)
+	syncer.SetClock(func() time.Time { return now.Add(time.Hour) })
+
+	syncer.RunOnce(ctx)
+
+	stored, err := d.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
+	require.NoError(err)
+	require.NotNil(stored)
+	events, err := d.ListMREvents(ctx, stored.ID)
+	require.NoError(err)
+	require.Condition(func() bool {
+		for _, event := range events {
+			if event.EventType == "merged" && event.Author == actor {
+				return true
+			}
+		}
+		return false
+	}, "a successful 304 sync must still reconcile missing merged actors")
 }
 
 // TestSyncerHandles304OnIssueList verifies the same short-circuit
@@ -18061,4 +18113,430 @@ func TestCommitMergeRequestDatasetsBindsToParentID(t *testing.T) {
 	require.NoError(err)
 	require.Empty(newEvents,
 		"the replacement repository's MR must not receive the stale datasets")
+}
+
+func TestReconcileMergedActorEventsBackfillsForgeMergedMR(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	repoID, err := d.UpsertRepo(ctx, verifiedGitHubRepoIdentity("github.com", "owner", "repo"))
+	require.NoError(err)
+	now := time.Date(2024, 6, 5, 12, 0, 0, 0, time.UTC)
+
+	// Simulate a merge performed through forge: the mutation eagerly marks
+	// the MR merged, so the sync's open->closed transition never fires and
+	// no authored merged event is ever written.
+	pr := buildOpenPR(7, now)
+	normalizedPR, err := NormalizePR(repoID, pr)
+	require.NoError(err)
+	_, err = d.UpsertMergeRequest(ctx, normalizedPR)
+	require.NoError(err)
+	mergedAt := now.Add(time.Minute)
+	require.NoError(d.UpdateMRState(ctx, repoID, 7, "merged", &mergedAt, &mergedAt))
+
+	merged := true
+	mergedBy := "merge-admin"
+	pr.State = new("closed")
+	pr.Merged = &merged
+	pr.MergedAt = makeTimestamp(mergedAt)
+	pr.ClosedAt = makeTimestamp(mergedAt)
+	pr.UpdatedAt = makeTimestamp(mergedAt)
+	pr.MergedBy = &gh.User{Login: &mergedBy}
+	mc := &mockClient{singlePR: pr}
+	syncer := NewSyncer(map[string]Client{"github.com": mc}, d, nil, []RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}}, time.Minute, nil, nil)
+	syncer.SetClock(func() time.Time { return now.Add(time.Hour) })
+
+	repo := RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}
+	syncer.reconcileMergedActorEvents(ctx, repo, repoID)
+
+	stored, err := d.GetMergeRequest(ctx, "github", "github.com", "owner", "repo", 7)
+	require.NoError(err)
+	events, err := d.ListMREvents(ctx, stored.ID)
+	require.NoError(err)
+	require.NotEmpty(events)
+	found := false
+	for _, event := range events {
+		if event.EventType == "merged" && event.Author == "merge-admin" {
+			found = true
+		}
+	}
+	assert.True(found, "authored merged event must be backfilled")
+}
+
+func TestReconcileMergedActorEventsEnrichesActorlessMergedEvent(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	now := time.Date(2024, 6, 5, 12, 0, 0, 0, time.UTC)
+
+	repoID, err := d.UpsertRepo(
+		ctx, verifiedGitHubRepoIdentity("github.com", "owner", "repo"),
+	)
+	require.NoError(err)
+	pr := buildOpenPR(7, now)
+	normalizedPR, err := NormalizePR(repoID, pr)
+	require.NoError(err)
+	_, err = d.UpsertMergeRequest(ctx, normalizedPR)
+	require.NoError(err)
+	mergedAt := now.Add(time.Minute)
+	require.NoError(d.UpdateMRState(ctx, repoID, 7, "merged", &mergedAt, &mergedAt))
+	stored, err := d.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
+	require.NoError(err)
+	require.NoError(d.UpsertMREvents(ctx, []db.MREvent{{
+		MergeRequestID: stored.ID,
+		EventType:      "merged",
+		Summary:        "merged this",
+		CreatedAt:      mergedAt.Add(time.Minute),
+		DedupeKey:      "provider-merged-event",
+	}}))
+
+	merged := true
+	actor := "merge-admin"
+	pr.State = new("closed")
+	pr.Merged = &merged
+	pr.MergedAt = makeTimestamp(mergedAt)
+	pr.MergedBy = &gh.User{Login: &actor}
+	mc := &mockClient{singlePR: pr}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc}, d, nil,
+		[]RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}},
+		time.Minute, nil, nil,
+	)
+	syncer.SetClock(func() time.Time { return now.Add(time.Hour) })
+
+	syncer.reconcileMergedActorEvents(
+		ctx, RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}, repoID,
+	)
+
+	events, err := d.ListMREvents(ctx, stored.ID)
+	require.NoError(err)
+	mergedEvents := make([]db.MREvent, 0, 1)
+	for _, event := range events {
+		if event.EventType == "merged" {
+			mergedEvents = append(mergedEvents, event)
+		}
+	}
+	require.Len(mergedEvents, 1)
+	require.Equal("provider-merged-event", mergedEvents[0].DedupeKey)
+	require.Equal("merge-admin", mergedEvents[0].Author)
+	require.Equal(mergedAt, mergedEvents[0].CreatedAt)
+}
+
+func TestBackfillMergedActorRejectsReusedRepositoryRoute(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	now := time.Date(2024, 6, 5, 12, 0, 0, 0, time.UTC)
+	displacedID := seedDisplacedRepository(t, d)
+
+	pr := buildOpenPR(7, now)
+	normalizedPR, err := NormalizePR(displacedID, pr)
+	require.NoError(err)
+	_, err = d.UpsertMergeRequest(ctx, normalizedPR)
+	require.NoError(err)
+	mergedAt := now.Add(time.Minute)
+	require.NoError(d.UpdateMRState(ctx, displacedID, 7, "merged", &mergedAt, &mergedAt))
+
+	providerCalls := 0
+	mc := &mockClient{getPullRequestFn: func(
+		_ context.Context, _, _ string, _ int,
+	) (*gh.PullRequest, error) {
+		providerCalls++
+		merged := true
+		actor := "replacement-admin"
+		pr.State = new("closed")
+		pr.Merged = &merged
+		pr.MergedAt = makeTimestamp(mergedAt)
+		pr.MergedBy = &gh.User{Login: &actor}
+		return pr, nil
+	}}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc}, d, nil,
+		[]RepoRef{{
+			Platform: platform.KindGitHub, PlatformHost: "github.com",
+			PlatformExternalID: "repo-new",
+			Owner:              "acme", Name: "widget", RepoPath: "acme/widget",
+		}},
+		time.Minute, nil, nil,
+	)
+
+	inserted, err := syncer.BackfillMergedActorEventOnProvider(ctx, displacedID, 7)
+	require.ErrorContains(err, "provider ID")
+	require.False(inserted)
+	require.Zero(providerCalls,
+		"a route replacement must be rejected before fetching its pull request")
+}
+
+func TestBackfillMergedActorUsesProviderMatchedRouteAfterRename(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	now := time.Date(2024, 6, 5, 12, 0, 0, 0, time.UTC)
+	providerID := "repo-stable"
+
+	repoID, err := d.UpsertRepo(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com", PlatformRepoID: providerID,
+		Owner: "acme", Name: "old-name", RepoPath: "acme/old-name",
+	})
+	require.NoError(err)
+	pr := buildOpenPR(7, now)
+	normalizedPR, err := NormalizePR(repoID, pr)
+	require.NoError(err)
+	_, err = d.UpsertMergeRequest(ctx, normalizedPR)
+	require.NoError(err)
+	mergedAt := now.Add(time.Minute)
+	require.NoError(d.UpdateMRState(ctx, repoID, 7, "merged", &mergedAt, &mergedAt))
+
+	merged := true
+	actor := "merge-admin"
+	pr.State = new("closed")
+	pr.Merged = &merged
+	pr.MergedAt = makeTimestamp(mergedAt)
+	pr.MergedBy = &gh.User{Login: &actor}
+	mc := &mockClient{
+		getPullRequestFn: func(_ context.Context, owner, name string, _ int) (*gh.PullRequest, error) {
+			if owner != "acme" || name != "new-name" {
+				return nil, fmt.Errorf("backfill used stale route %s/%s", owner, name)
+			}
+			return pr, nil
+		},
+		getRepositoryFn: func(_ context.Context, owner, name string) (*gh.Repository, error) {
+			if owner != "acme" || name != "new-name" {
+				return nil, fmt.Errorf("identity check used stale route %s/%s", owner, name)
+			}
+			id := int64(42)
+			return &gh.Repository{
+				ID: &id, NodeID: &providerID, Name: &name,
+				Owner: &gh.User{Login: &owner},
+			}, nil
+		},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc}, d, nil,
+		[]RepoRef{{
+			Platform: platform.KindGitHub, PlatformHost: "github.com",
+			PlatformExternalID: providerID,
+			Owner:              "acme", Name: "new-name", RepoPath: "acme/new-name",
+		}},
+		time.Minute, nil, nil,
+	)
+
+	inserted, err := syncer.BackfillMergedActorEventOnProvider(ctx, repoID, 7)
+	require.NoError(err)
+	require.True(inserted)
+}
+
+func TestBackfillMergedActorRevalidatesProviderIdentityBeforePersisting(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	now := time.Date(2024, 6, 5, 12, 0, 0, 0, time.UTC)
+	providerID := "repo-old"
+
+	repoID, err := d.UpsertRepo(ctx, db.RepoIdentity{
+		Platform: "github", PlatformHost: "github.com", PlatformRepoID: providerID,
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+	})
+	require.NoError(err)
+	pr := buildOpenPR(7, now)
+	normalizedPR, err := NormalizePR(repoID, pr)
+	require.NoError(err)
+	_, err = d.UpsertMergeRequest(ctx, normalizedPR)
+	require.NoError(err)
+	mergedAt := now.Add(time.Minute)
+	require.NoError(d.UpdateMRState(ctx, repoID, 7, "merged", &mergedAt, &mergedAt))
+
+	merged := true
+	actor := "replacement-admin"
+	pr.State = new("closed")
+	pr.Merged = &merged
+	pr.MergedAt = makeTimestamp(mergedAt)
+	pr.MergedBy = &gh.User{Login: &actor}
+	replacementID := "repo-new"
+	mc := &mockClient{
+		getPullRequestFn: func(context.Context, string, string, int) (*gh.PullRequest, error) {
+			return pr, nil
+		},
+		getRepositoryFn: func(_ context.Context, owner, name string) (*gh.Repository, error) {
+			id := int64(43)
+			return &gh.Repository{
+				ID: &id, NodeID: &replacementID, Name: &name,
+				Owner: &gh.User{Login: &owner},
+			}, nil
+		},
+	}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc}, d, nil,
+		[]RepoRef{{
+			Platform: platform.KindGitHub, PlatformHost: "github.com",
+			PlatformExternalID: providerID,
+			Owner:              "acme", Name: "widget", RepoPath: "acme/widget",
+		}},
+		time.Minute, nil, nil,
+	)
+
+	inserted, err := syncer.BackfillMergedActorEventOnProvider(ctx, repoID, 7)
+	require.ErrorContains(err, "provider ID")
+	require.False(inserted)
+	stored, err := d.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
+	require.NoError(err)
+	events, err := d.ListMREvents(ctx, stored.ID)
+	require.NoError(err)
+	require.Empty(events, "replacement repository actor must not be persisted")
+}
+
+func TestBackfillMergedActorVerifiesRouteWhenTrackedProviderIDMissing(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	now := time.Date(2024, 6, 5, 12, 0, 0, 0, time.UTC)
+
+	repoID, err := d.UpsertRepo(
+		ctx, verifiedGitHubRepoIdentity("github.com", "owner", "repo"),
+	)
+	require.NoError(err)
+	pr := buildOpenPR(7, now)
+	normalizedPR, err := NormalizePR(repoID, pr)
+	require.NoError(err)
+	_, err = d.UpsertMergeRequest(ctx, normalizedPR)
+	require.NoError(err)
+	mergedAt := now.Add(time.Minute)
+	require.NoError(d.UpdateMRState(ctx, repoID, 7, "merged", &mergedAt, &mergedAt))
+
+	merged := true
+	actor := "merge-admin"
+	pr.State = new("closed")
+	pr.Merged = &merged
+	pr.MergedAt = makeTimestamp(mergedAt)
+	pr.MergedBy = &gh.User{Login: &actor}
+	mc := &mockClient{singlePR: pr}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc}, d, nil,
+		[]RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}},
+		time.Minute, nil, nil,
+	)
+
+	inserted, err := syncer.BackfillMergedActorEventOnProvider(ctx, repoID, 7)
+	require.NoError(err)
+	require.True(inserted)
+}
+
+func TestReconcileMergedActorEventsSweepsPastPersistentlyMissingActors(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+
+	repoID, err := d.UpsertRepo(ctx, verifiedGitHubRepoIdentity("github.com", "owner", "repo"))
+	require.NoError(err)
+	now := time.Date(2024, 6, 5, 12, 0, 0, 0, time.UTC)
+
+	// Twelve forge-merged MRs missing the actor. The provider permanently
+	// reports no merged_by for the ten newest (e.g. the merging account was
+	// deleted), so a fixed newest-first batch would retry them every cycle
+	// and never reach the two oldest.
+	actorless := map[int]bool{}
+	for number := 3; number <= 12; number++ {
+		actorless[number] = true
+	}
+	for number := 1; number <= 12; number++ {
+		pr := buildOpenPR(number, now)
+		normalizedPR, err := NormalizePR(repoID, pr)
+		require.NoError(err)
+		_, err = d.UpsertMergeRequest(ctx, normalizedPR)
+		require.NoError(err)
+		mergedAt := now.Add(time.Duration(number) * time.Minute)
+		require.NoError(d.UpdateMRState(ctx, repoID, number, "merged", &mergedAt, &mergedAt))
+	}
+
+	mc := &mockClient{
+		getPullRequestFn: func(_ context.Context, _, _ string, number int) (*gh.PullRequest, error) {
+			pr := buildOpenPR(number, now)
+			merged := true
+			mergedAt := now.Add(time.Duration(number) * time.Minute)
+			pr.State = new("closed")
+			pr.Merged = &merged
+			pr.MergedAt = makeTimestamp(mergedAt)
+			pr.ClosedAt = makeTimestamp(mergedAt)
+			pr.UpdatedAt = makeTimestamp(mergedAt)
+			if !actorless[number] {
+				actor := "merge-admin"
+				pr.MergedBy = &gh.User{Login: &actor}
+			}
+			return pr, nil
+		},
+	}
+	syncer := NewSyncer(map[string]Client{"github.com": mc}, d, nil, []RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}}, time.Minute, nil, nil)
+	syncer.SetClock(func() time.Time { return now.Add(time.Hour) })
+
+	repo := RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}
+	syncer.reconcileMergedActorEvents(ctx, repo, repoID)
+	syncer.reconcileMergedActorEvents(ctx, repo, repoID)
+
+	for _, number := range []int{1, 2} {
+		stored, err := d.GetMergeRequestByRepoIDAndNumber(ctx, repoID, number)
+		require.NoError(err)
+		require.NotNil(stored)
+		events, err := d.ListMREvents(ctx, stored.ID)
+		require.NoError(err)
+		found := false
+		for _, event := range events {
+			if event.EventType == "merged" && event.Author == "merge-admin" {
+				found = true
+			}
+		}
+		assert.True(found,
+			"MR #%d must receive its merged actor even while newer candidates stay unresolved", number)
+	}
+}
+
+func TestReconcileMergedActorEventsCoolsDownAfterSweepExhaustion(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	d := openTestDB(t)
+	now := time.Date(2024, 6, 5, 12, 0, 0, 0, time.UTC)
+	clock := now.Add(time.Hour)
+
+	repoID, err := d.UpsertRepo(
+		ctx, verifiedGitHubRepoIdentity("github.com", "owner", "repo"),
+	)
+	require.NoError(err)
+	pr := buildOpenPR(7, now)
+	normalizedPR, err := NormalizePR(repoID, pr)
+	require.NoError(err)
+	_, err = d.UpsertMergeRequest(ctx, normalizedPR)
+	require.NoError(err)
+	mergedAt := now.Add(time.Minute)
+	require.NoError(d.UpdateMRState(ctx, repoID, 7, "merged", &mergedAt, &mergedAt))
+
+	providerCalls := 0
+	mc := &mockClient{getPullRequestFn: func(
+		_ context.Context, _, _ string, _ int,
+	) (*gh.PullRequest, error) {
+		providerCalls++
+		merged := true
+		pr.State = new("closed")
+		pr.Merged = &merged
+		pr.MergedAt = makeTimestamp(mergedAt)
+		pr.MergedBy = nil
+		return pr, nil
+	}}
+	syncer := NewSyncer(
+		map[string]Client{"github.com": mc}, d, nil,
+		[]RepoRef{{Owner: "owner", Name: "repo", PlatformHost: "github.com"}},
+		time.Minute, nil, nil,
+	)
+	syncer.SetClock(func() time.Time { return clock })
+	repo := RepoRef{Owner: "owner", Name: "repo", PlatformHost: "github.com"}
+
+	syncer.reconcileMergedActorEvents(ctx, repo, repoID)
+	require.Equal(1, providerCalls)
+	clock = clock.Add(59 * time.Minute)
+	syncer.reconcileMergedActorEvents(ctx, repo, repoID)
+	require.Equal(1, providerCalls, "an exhausted sweep must retain its cooldown")
+	clock = clock.Add(time.Minute)
+	syncer.reconcileMergedActorEvents(ctx, repo, repoID)
+	require.Equal(2, providerCalls, "a new sweep must start after the bounded cooldown")
 }

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -4571,6 +4571,153 @@ func TestAPIGitLabClosedSyncPersistsMergedActorForImmediateDetail(t *testing.T) 
 	assert.True(event.CreatedAt.Equal(mergedAt))
 }
 
+func TestAPIScheduledMergedActorRepairRefreshesOpenDetail(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	ctx := t.Context()
+	now := time.Now().UTC().Truncate(time.Second)
+	mergedAt := now.Add(-time.Minute)
+
+	database := dbtest.Open(t)
+	ref := platform.RepoRef{
+		Platform:           platform.KindGitLab,
+		Host:               "gitlab.example.com",
+		Owner:              "group",
+		Name:               "project",
+		RepoPath:           "group/project",
+		PlatformID:         4242,
+		PlatformExternalID: "gid://gitlab/Project/4242",
+		WebURL:             "https://gitlab.example.com/group/project",
+		CloneURL:           "https://gitlab.example.com/group/project.git",
+		DefaultBranch:      "main",
+	}
+	repoID, err := database.UpsertRepo(ctx, platform.DBRepoIdentity(ref))
+	require.NoError(err)
+	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:             repoID,
+		PlatformID:         7001,
+		PlatformExternalID: "gid://gitlab/MergeRequest/7001",
+		Number:             7,
+		URL:                "https://gitlab.example.com/group/project/-/merge_requests/7",
+		Title:              "Delayed merged actor",
+		Author:             "ada",
+		State:              db.MergeRequestStateMerged,
+		HeadBranch:         "feature/gitlab",
+		BaseBranch:         "main",
+		PlatformHeadSHA:    "abc123",
+		CreatedAt:          now.Add(-time.Hour),
+		UpdatedAt:          mergedAt,
+		LastActivityAt:     mergedAt,
+		MergedAt:           &mergedAt,
+		ClosedAt:           &mergedAt,
+	})
+	require.NoError(err)
+	providerMR := platform.MergeRequest{
+		Repo:               ref,
+		PlatformID:         7001,
+		PlatformExternalID: "gid://gitlab/MergeRequest/7001",
+		Number:             7,
+		URL:                "https://gitlab.example.com/group/project/-/merge_requests/7",
+		Title:              "Delayed merged actor",
+		Author:             "ada",
+		State:              "merged",
+		HeadBranch:         "feature/gitlab",
+		BaseBranch:         "main",
+		HeadSHA:            "abc123",
+		CreatedAt:          now.Add(-time.Hour),
+		UpdatedAt:          mergedAt,
+		LastActivityAt:     mergedAt,
+		MergedAt:           &mergedAt,
+		ClosedAt:           &mergedAt,
+	}
+	provider := &apiTestGitLabProvider{
+		ref:                ref,
+		mergeRequestDetail: map[int]platform.MergeRequest{7: providerMR},
+	}
+	registry, err := platform.NewRegistry(provider)
+	require.NoError(err)
+	repo := ghclient.RepoRef{
+		Platform:           platform.KindGitLab,
+		Owner:              ref.Owner,
+		Name:               ref.Name,
+		PlatformHost:       ref.Host,
+		RepoPath:           ref.RepoPath,
+		PlatformRepoID:     ref.PlatformID,
+		PlatformExternalID: ref.PlatformExternalID,
+		WebURL:             ref.WebURL,
+		CloneURL:           ref.CloneURL,
+		DefaultBranch:      ref.DefaultBranch,
+	}
+	syncer := ghclient.NewSyncerWithRegistry(
+		registry, database, nil, []ghclient.RepoRef{repo}, time.Minute, nil, nil,
+	)
+	t.Cleanup(syncer.Stop)
+	srv := New(database, syncer, nil, "/", nil, ServerOptions{})
+	srv.now = func() time.Time { return now }
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	client := setupTestClient(t, srv)
+
+	changed, err := syncer.BackfillMergedActorEventOnProvider(ctx, repoID, 7)
+	require.NoError(err)
+	require.False(changed, "the initial provider response has no merged actor")
+	before, err := client.HTTP.GetPullOnHostWithResponse(
+		ctx, ref.Host, "gitlab", ref.Owner, ref.Name, 7,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, before.StatusCode(), string(before.Body))
+	require.NotNil(before.JSON200)
+	require.NotNil(before.JSON200.Events)
+	require.Len(*before.JSON200.Events, 1)
+	assert.Empty((*before.JSON200.Events)[0].Author)
+
+	events, _ := srv.Hub().Subscribe(ctx, false)
+	provider.mu.Lock()
+	providerMR.MergedBy = "merge-admin"
+	provider.mergeRequestDetail[7] = providerMR
+	provider.mu.Unlock()
+	syncer.RunOnce(ctx)
+
+	var refreshPayload struct {
+		Provider     string   `json:"provider"`
+		PlatformHost string   `json:"platform_host"`
+		RepoPath     string   `json:"repo_path"`
+		Owner        string   `json:"owner"`
+		Name         string   `json:"name"`
+		Number       int      `json:"number"`
+		HeadSHA      string   `json:"head_sha"`
+		SyncedAt     string   `json:"synced_at"`
+		Warnings     []string `json:"warnings"`
+	}
+	select {
+	case event := <-events:
+		require.Equal("pr_detail_refreshed", event.Event.Type)
+		raw, marshalErr := json.Marshal(event.Event.Data)
+		require.NoError(marshalErr)
+		require.NoError(json.Unmarshal(raw, &refreshPayload))
+	default:
+		require.Fail("scheduled merged-actor repair did not refresh the open detail")
+	}
+	assert.Equal("gitlab", refreshPayload.Provider)
+	assert.Equal(ref.Host, refreshPayload.PlatformHost)
+	assert.Equal(ref.RepoPath, refreshPayload.RepoPath)
+	assert.Equal(ref.Owner, refreshPayload.Owner)
+	assert.Equal(ref.Name, refreshPayload.Name)
+	assert.Equal(7, refreshPayload.Number)
+	assert.Equal("abc123", refreshPayload.HeadSHA)
+	assert.Equal(now.Format(time.RFC3339), refreshPayload.SyncedAt)
+	assert.Empty(refreshPayload.Warnings)
+
+	after, err := client.HTTP.GetPullOnHostWithResponse(
+		ctx, ref.Host, "gitlab", ref.Owner, ref.Name, 7,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, after.StatusCode(), string(after.Body))
+	require.NotNil(after.JSON200)
+	require.NotNil(after.JSON200.Events)
+	require.Len(*after.JSON200.Events, 1)
+	assert.Equal("merge-admin", (*after.JSON200.Events)[0].Author)
+}
+
 func TestAPIGitLabDirectSyncPersistsMergedActorForImmediateDetail(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)

--- a/internal/server/merged_actor_refresh.go
+++ b/internal/server/merged_actor_refresh.go
@@ -1,0 +1,41 @@
+package server
+
+import (
+	"context"
+	"log/slog"
+
+	"go.kenn.io/forge/internal/server/workspaceapi"
+)
+
+func (s *Server) broadcastMergedActorDetailRefresh(
+	ctx context.Context,
+	repoID int64,
+	number int,
+) {
+	repo, err := s.db.GetRepoByID(ctx, repoID)
+	if err != nil || repo == nil {
+		slog.Warn("load repository for scheduled merged-actor detail refresh",
+			"repo_id", repoID, "number", number, "err", err)
+		return
+	}
+	mr, err := s.db.GetMergeRequestByRepoIDAndNumber(ctx, repoID, number)
+	if err != nil || mr == nil {
+		slog.Warn("load pull request for scheduled merged-actor detail refresh",
+			"repo_id", repoID, "number", number, "err", err)
+		return
+	}
+	s.hub.Broadcast(Event{
+		Type: "pr_detail_refreshed",
+		Data: workspaceapi.PRDetailRefreshedPayload{
+			Provider:     repo.Platform,
+			PlatformHost: repo.PlatformHost,
+			RepoPath:     repo.RepoPath,
+			Owner:        repo.Owner,
+			Name:         repo.Name,
+			Number:       number,
+			HeadSHA:      mr.PlatformHeadSHA,
+			SyncedAt:     formatUTCRFC3339(s.now().UTC()),
+			Warnings:     []string{},
+		},
+	})
+}

--- a/internal/server/pullapi/deferred_merge_integration_test.go
+++ b/internal/server/pullapi/deferred_merge_integration_test.go
@@ -42,9 +42,34 @@ func (p *deferredMergeProviderBase) Host() string {
 
 func (p *deferredMergeProviderBase) Capabilities() platform.Capabilities {
 	return platform.Capabilities{
+		ReadRepositories:  true,
 		ReadMergeRequests: true,
 		ReadCI:            true,
 	}
+}
+
+func (p *deferredMergeProviderBase) GetRepository(
+	context.Context,
+	platform.RepoRef,
+) (platform.Repository, error) {
+	return platform.Repository{
+		Ref:                p.ref,
+		PlatformID:         p.ref.PlatformID,
+		PlatformExternalID: p.ref.PlatformExternalID,
+		DefaultBranch:      p.ref.DefaultBranch,
+	}, nil
+}
+
+func (p *deferredMergeProviderBase) ListRepositories(
+	ctx context.Context,
+	_ string,
+	_ platform.RepositoryListOptions,
+) ([]platform.Repository, error) {
+	repo, err := p.GetRepository(ctx, p.ref)
+	if err != nil {
+		return nil, err
+	}
+	return []platform.Repository{repo}, nil
 }
 
 func (p *deferredMergeProviderBase) ListOpenMergeRequests(
@@ -270,11 +295,13 @@ func newDeferredMergeRouteServer(
 		database,
 		nil,
 		[]ghclient.RepoRef{{
-			Platform:     platform.KindGitLab,
-			PlatformHost: ref.Host,
-			Owner:        ref.Owner,
-			Name:         ref.Name,
-			RepoPath:     ref.RepoPath,
+			Platform:           platform.KindGitLab,
+			PlatformHost:       ref.Host,
+			Owner:              ref.Owner,
+			Name:               ref.Name,
+			RepoPath:           ref.RepoPath,
+			PlatformRepoID:     ref.PlatformID,
+			PlatformExternalID: ref.PlatformExternalID,
 		}},
 		time.Minute,
 		nil,
@@ -1848,4 +1875,170 @@ func mustDeferredMergeChecksJSON(t *testing.T, checks []db.CICheck) string {
 	raw, err := json.Marshal(checks)
 	require.NoError(t, err)
 	return string(raw)
+}
+
+func TestImmediateMergeRecordsMergedActor(t *testing.T) {
+	require := require.New(t)
+	ctx := t.Context()
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	ref := platform.RepoRef{
+		Platform:           platform.KindGitLab,
+		Host:               "gitlab.example.com",
+		Owner:              "group",
+		Name:               "project",
+		RepoPath:           "group/project",
+		PlatformID:         4242,
+		PlatformExternalID: "gid://gitlab/Project/4242",
+		DefaultBranch:      "main",
+	}
+	mergedAt := now.Add(time.Minute)
+	provider := &deferredMergeTestProvider{
+		deferredMergeProviderBase: deferredMergeProviderBase{
+			ref: ref,
+			// The provider view after the merge lands: merged, with the
+			// acting user. The post-merge background resync must persist
+			// this actor as an authored merged event — the eager local
+			// state write otherwise suppresses the sync-side transition
+			// that records it.
+			mergeRequests: []platform.MergeRequest{{
+				Repo:           ref,
+				PlatformID:     7001,
+				Number:         7,
+				URL:            "https://gitlab.example.com/group/project/-/merge_requests/7",
+				Title:          "Merge me",
+				Author:         "ada",
+				State:          "merged",
+				MergedAt:       &mergedAt,
+				MergedBy:       "merge-admin",
+				HeadBranch:     "feature",
+				BaseBranch:     "main",
+				HeadSHA:        "head-sha",
+				BaseSHA:        "base-sha",
+				CreatedAt:      now,
+				UpdatedAt:      mergedAt,
+				LastActivityAt: mergedAt,
+			}},
+		},
+		mergeCh: make(chan deferredMergeTestMergeCall, 1),
+	}
+	srv, database, repoID, client := newDeferredMergeRouteServer(
+		t,
+		provider,
+		ref,
+		now,
+		[]db.CICheck{{App: "GitLab", Name: "pipeline", Status: "completed", Conclusion: "success"}},
+	)
+	events, _ := srv.Hub().Subscribe(ctx, false)
+
+	expectedHeadSHA := "head-sha"
+	mergeResp, err := client.HTTP.MergePullOnHostWithResponse(
+		ctx,
+		ref.Host,
+		"gitlab",
+		ref.Owner,
+		ref.Name,
+		7,
+		generated.MergePRInputBody{Method: "squash", ExpectedHeadSha: &expectedHeadSHA},
+	)
+	require.NoError(err)
+	require.Equal(200, mergeResp.StatusCode(), string(mergeResp.Body))
+
+	stored, err := database.GetMergeRequestByRepoIDAndNumber(ctx, repoID, 7)
+	require.NoError(err)
+	require.NotNil(stored)
+
+	require.Eventually(func() bool {
+		events, err := database.ListMREvents(ctx, stored.ID)
+		require.NoError(err)
+		for _, event := range events {
+			if event.EventType == "merged" && event.Author == "merge-admin" {
+				return true
+			}
+		}
+		return false
+	}, 3*time.Second, 50*time.Millisecond,
+		"no authored merged event recorded after immediate merge")
+
+	detailResp, err := client.HTTP.GetPullOnHostWithResponse(
+		ctx, ref.Host, "gitlab", ref.Owner, ref.Name, 7,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, detailResp.StatusCode(), string(detailResp.Body))
+	require.NotNil(detailResp.JSON200)
+	require.NotNil(detailResp.JSON200.Events)
+	mergedEvents := make([]generated.MergeRequestEventResponse, 0, 1)
+	for _, event := range *detailResp.JSON200.Events {
+		if event.EventType == "merged" {
+			mergedEvents = append(mergedEvents, event)
+		}
+	}
+	require.Len(mergedEvents, 1,
+		"detail must not combine an authored event with a synthetic merge event")
+	require.Equal("merge-admin", mergedEvents[0].Author)
+	require.True(mergedEvents[0].CreatedAt.Equal(now))
+	require.NotNil(detailResp.JSON200.MergeRequest.MergedAt)
+	require.True(detailResp.JSON200.MergeRequest.MergedAt.Equal(mergedEvents[0].CreatedAt))
+
+	// Simulate a later accepted provider snapshot replacing the eager local
+	// merge timestamp. Existing databases may briefly contain an authored
+	// event at the old time; the detail response must still show one merge.
+	require.NoError(database.UpdateMRState(
+		ctx, repoID, 7, "merged", &mergedAt, &mergedAt,
+	))
+	detailResp, err = client.HTTP.GetPullOnHostWithResponse(
+		ctx, ref.Host, "gitlab", ref.Owner, ref.Name, 7,
+	)
+	require.NoError(err)
+	require.Equal(http.StatusOK, detailResp.StatusCode(), string(detailResp.Body))
+	require.NotNil(detailResp.JSON200)
+	require.NotNil(detailResp.JSON200.Events)
+	mergedEvents = mergedEvents[:0]
+	for _, event := range *detailResp.JSON200.Events {
+		if event.EventType == "merged" {
+			mergedEvents = append(mergedEvents, event)
+		}
+	}
+	require.Len(mergedEvents, 1,
+		"detail must not synthesize a second merge beside an authored event")
+	require.Equal("merge-admin", mergedEvents[0].Author)
+
+	// The merge response returns before the background backfill lands, so
+	// clients that reload immediately still hold the synthetic actorless
+	// event. The successful backfill must target the canonical detail identity.
+	var refreshPayload struct {
+		Provider     string   `json:"provider"`
+		PlatformHost string   `json:"platform_host"`
+		RepoPath     string   `json:"repo_path"`
+		Owner        string   `json:"owner"`
+		Name         string   `json:"name"`
+		Number       int      `json:"number"`
+		HeadSHA      string   `json:"head_sha"`
+		SyncedAt     string   `json:"synced_at"`
+		Warnings     []string `json:"warnings"`
+	}
+	require.Eventually(func() bool {
+		select {
+		case event := <-events:
+			if event.Event.Type != "pr_detail_refreshed" {
+				return false
+			}
+			raw, err := json.Marshal(event.Event.Data)
+			if err != nil {
+				return false
+			}
+			return json.Unmarshal(raw, &refreshPayload) == nil
+		default:
+			return false
+		}
+	}, 3*time.Second, 50*time.Millisecond,
+		"merged-actor backfill must target the open detail view")
+	require.Equal("gitlab", refreshPayload.Provider)
+	require.Equal(ref.Host, refreshPayload.PlatformHost)
+	require.Equal(ref.RepoPath, refreshPayload.RepoPath)
+	require.Equal(ref.Owner, refreshPayload.Owner)
+	require.Equal(ref.Name, refreshPayload.Name)
+	require.Equal(7, refreshPayload.Number)
+	require.Equal("head-sha", refreshPayload.HeadSHA)
+	require.Equal(now.Format(time.RFC3339), refreshPayload.SyncedAt)
+	require.Empty(refreshPayload.Warnings)
 }

--- a/internal/server/pullapi/routes.go
+++ b/internal/server/pullapi/routes.go
@@ -613,7 +613,11 @@ func withSyntheticMRLifecycleEvents(mr db.MergeRequest, events []db.MREvent) []d
 	hasLifecycleEvent := func(eventType string, createdAt time.Time) bool {
 		createdAt = createdAt.UTC()
 		for _, event := range events {
-			if event.EventType == eventType && event.CreatedAt.UTC().Equal(createdAt) {
+			if event.EventType != eventType {
+				continue
+			}
+			if event.CreatedAt.UTC().Equal(createdAt) ||
+				(eventType == "merged" && strings.TrimSpace(event.Author) != "") {
 				return true
 			}
 		}
@@ -1680,6 +1684,52 @@ func (s *Handler) mergePRWithBody(
 	// (A deferred worker completing through this same path supersedes its
 	// own handle, which is a no-op by the time it broadcasts completion.)
 	s.supersedeDeferredMerge(deferredMergeKey(*repo, number))
+
+	// The eager state write above suppresses the sync-side open->closed
+	// transition — the path that records who merged. Backfill the authored
+	// merged event from the provider so the actor is not lost, and target the
+	// affected detail once it lands: the merge response returns before this
+	// completes, so an already-open detail would otherwise keep showing the
+	// synthetic actorless merge event.
+	repoID := repo.ID
+	s.runBackground(func(bgCtx context.Context) {
+		changed, err := s.syncer.BackfillMergedActorEventOnProvider(bgCtx, repoID, number)
+		if err != nil {
+			slog.Warn("record merged actor after merge",
+				"owner", repo.Owner, "repo", repo.Name,
+				"number", number, "err", err)
+			return
+		}
+		if !changed {
+			return
+		}
+		currentRepo, err := s.db.GetRepoByID(bgCtx, repoID)
+		if err != nil || currentRepo == nil {
+			slog.Warn("load repository for merged-actor detail refresh",
+				"repo_id", repoID, "number", number, "err", err)
+			return
+		}
+		currentMR, err := s.db.GetMergeRequestByRepoIDAndNumber(bgCtx, repoID, number)
+		if err != nil || currentMR == nil {
+			slog.Warn("load pull request for merged-actor detail refresh",
+				"repo_id", repoID, "number", number, "err", err)
+			return
+		}
+		s.publish(Event{
+			Type: "pr_detail_refreshed",
+			Data: workspaceapi.PRDetailRefreshedPayload{
+				Provider:     currentRepo.Platform,
+				PlatformHost: currentRepo.PlatformHost,
+				RepoPath:     currentRepo.RepoPath,
+				Owner:        currentRepo.Owner,
+				Name:         currentRepo.Name,
+				Number:       number,
+				HeadSHA:      currentMR.PlatformHeadSHA,
+				SyncedAt:     formatUTCRFC3339(s.now().UTC()),
+				Warnings:     []string{},
+			},
+		})
+	})
 
 	return mergePRBody{
 		Merged:  result.Merged,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -785,6 +785,9 @@ func newServer(
 		roborevConfig.RoborevEndpoint(),
 		workspaceConfigSnapshot(cfg, nil).KnownPlatformHosts,
 	)
+	if syncer != nil {
+		syncer.SetOnMergedActorRepaired(s.broadcastMergedActorDetailRefresh)
+	}
 	s.workspaceDependentsCtx, s.workspaceDependentsCancel = context.WithCancel(s.bgCtx)
 	s.workspaceLifecycleCtx, s.workspaceLifecycleCancel = context.WithCancel(context.Background())
 	s.kataLifecycleCtx, s.kataLifecycleCancel = context.WithCancel(context.Background())

--- a/internal/server/workspaceapi/workspace_pushed_head.go
+++ b/internal/server/workspaceapi/workspace_pushed_head.go
@@ -65,6 +65,9 @@ type prDetailRefreshedPayload struct {
 	Warnings     []string `json:"warnings"`
 }
 
+// PRDetailRefreshedPayload is shared with pull-request event producers.
+type PRDetailRefreshedPayload = prDetailRefreshedPayload
+
 type prCIRefreshQueuedPayload struct {
 	Provider     string `json:"provider"`
 	PlatformHost string `json:"platform_host"`


### PR DESCRIPTION
Merges performed through forge call \`UpdateMRState(..., "merged", ...)\` directly and never persist a \`merged\` event with an author. The read API papers over this with synthetic actor-less lifecycle events, and the sync path that would fetch \`merged_by\` from the provider (\`fetchAndUpdateClosedMergeRequest\`) only runs for MRs still recorded as open — which forge's own eager state write prevents. Net effect: every forge-performed merge has no recorded merger.

Fixes:

- **Record the actor at merge time.** After a successful merge mutation, a background task fetches the MR from the provider and persists an authored \`merged\` event via \`persistMergedActorEvent\`. The event is written directly rather than through the snapshot upsert because the mutation's wall-clock \`updated_at\` exceeds the provider's, so the snapshot staleness gate would reject the refetch. The provider target is resolved from the stable repository row for \`repoID\`, so a configuration rename between the mutation and the background pass cannot fetch from a different repository than the row being updated. On success the task broadcasts \`data_changed\` — the merge response returns before the backfill lands, and clients that reload immediately would otherwise keep the synthetic actorless event until a manual refresh.
- **Reconcile historical rows during sync.** Each repo sync cycle (both the GraphQL and REST list paths) backfills merged MRs from the last 90 days that lack an authored \`merged\` event, 10 per repo per cycle. The batch follows a per-repo sweep cursor rather than a fixed newest-first window: candidates whose provider permanently reports no \`merged_by\` (e.g. a deleted account) would otherwise occupy every batch and starve older candidates. When a sweep exhausts the window the cursor resets, so persistent candidates get one attempt per sweep. Errors are logged and never fail the sync.

New query \`GetMergedMRNumbersMissingMergedActor\` selects merged MRs with no authored \`merged\` event within a \`[since, before)\` window for the sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)