### PR TITLE
fix: restore workspace detail pane width

### DIFF
--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -222,9 +222,9 @@ Whenever a control persists, document and test:
 - where it persists
 - whether it is global, per-view, or per-item
 - what happens after navigating away and back
-- for layout dimensions, clamp stale values on restore, but keep temporary
-  container constraints separate from the saved preference so widening restores
-  user intent (`frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte::renderedRightSidebarWidth`)
+- for layout dimensions, clamp stale values on restore; temporary constraints
+  and resize input below a valid minimum must not replace the saved preference
+  (`frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte::renderedRightSidebarWidth`)
 
 ## Keyboard Scope Precedence
 

--- a/context/ui-interaction-contracts.md
+++ b/context/ui-interaction-contracts.md
@@ -222,9 +222,9 @@ Whenever a control persists, document and test:
 - where it persists
 - whether it is global, per-view, or per-item
 - what happens after navigating away and back
-- for layout dimensions, clamping on restore and whenever container bounds
-  change, with the normalized value re-persisted so stale geometry cannot return
-  (`frontend/src/lib/components/kata/KataResizableSash.svelte::clampSize`)
+- for layout dimensions, clamp stale values on restore, but keep temporary
+  container constraints separate from the saved preference so widening restores
+  user intent (`frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte::renderedRightSidebarWidth`)
 
 ## Keyboard Scope Precedence
 

--- a/docs/superpowers/plans/2026-08-04-workspace-detail-width-restoration.md
+++ b/docs/superpowers/plans/2026-08-04-workspace-detail-width-restoration.md
@@ -13,6 +13,7 @@
 - Preserve at least 300 pixels for the terminal whenever the container permits it.
 - Preserve the existing 280-pixel detail-pane minimum whenever the container permits it.
 - Persist only explicit user resize intent, never an automatic viewport constraint.
+- Disable resizing while the available detail-pane maximum is below 280 pixels.
 - Do not change API, database, provider, or terminal runtime behavior.
 
 ---
@@ -63,3 +64,37 @@ repository's focused frontend checks identified by package scripts.
 Review the complete diff, run context-sync commit mode and the public-data scrub,
 commit with rationale-focused history, push `pr-pane-collapsing`, and open a
 pull request against the repository default branch.
+
+---
+
+### Task 2: Reject Resizing During Exceptional Constraints
+
+**Files:**
+- Modify: `frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte:1258-1300,4020-4030`
+- Test: `frontend/tests/e2e/workspace-sidebar.spec.ts`
+
+**Interfaces:**
+- Consumes: `rightSidebarAriaMax`, `MIN_SIDEBAR_WIDTH`, `SplitResizeHandle.disabled`
+- Produces: `rightSidebarResizeDisabled`, which prevents constrained resize events from changing the preference
+
+- [ ] **Step 1: Extend the app-shell regression**
+
+After constraining the rendered pane below 280 pixels, drag the real sidebar
+resize handle before restoring the viewport. Assert that local storage remains
+`"400"` and that the rendered pane returns to 400 pixels.
+
+- [ ] **Step 2: Verify the regression fails**
+
+Run the focused Chromium Playwright test. Expected: local storage contains the
+temporary constrained width after the drag.
+
+- [ ] **Step 3: Disable and guard constrained resizing**
+
+Derive a disabled state when the current layout maximum is below 280 pixels,
+pass it to `SplitResizeHandle`, and return from `handleSidebarResize` while that
+state is active.
+
+- [ ] **Step 4: Verify the regression and affected frontend suites**
+
+Run the focused test, the complete workspace sidebar Chromium spec, both full
+Vitest projects, the Svelte analyzer, and the repository frontend checks.

--- a/docs/superpowers/plans/2026-08-04-workspace-detail-width-restoration.md
+++ b/docs/superpowers/plans/2026-08-04-workspace-detail-width-restoration.md
@@ -1,0 +1,65 @@
+# Workspace Detail Width Restoration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore the Workspaces detail pane to the user's preferred width after temporary layout constraints.
+
+**Architecture:** `WorkspaceTerminalView.svelte` will retain one persisted preferred width and derive a separate rendered width from the current container geometry. Resize input changes the preference; automatic layout reconciliation changes only the rendered projection.
+
+**Tech Stack:** Svelte 5, TypeScript, Vitest Browser Mode
+
+## Global Constraints
+
+- Preserve at least 300 pixels for the terminal whenever the container permits it.
+- Preserve the existing 280-pixel detail-pane minimum whenever the container permits it.
+- Persist only explicit user resize intent, never an automatic viewport constraint.
+- Do not change API, database, provider, or terminal runtime behavior.
+
+---
+
+### Task 1: Separate Preferred and Rendered Workspace Detail Width
+
+**Files:**
+- Modify: `frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte:462-483,1150-1161,1249-1334,4052-4065`
+- Test: `frontend/src/lib/components/terminal/WorkspaceTerminalView.host-visible.browser.svelte.ts`
+
+**Interfaces:**
+- Consumes: `containerEl.clientWidth`, `MIN_SIDEBAR_WIDTH`, `MIN_TERMINAL_WIDTH`, `SplitResizeEvent`
+- Produces: persisted user-preferred `sidebarWidth` and layout-constrained `renderedSidebarWidth`
+
+- [ ] **Step 1: Write the failing browser regression**
+
+Mount the real `WorkspaceTerminalView` with the right pane open and a 400-pixel
+stored preference. Change its available width to force a sub-280-pixel rendered
+pane, dispatch the resize path, then restore the available width. Assert the DOM
+width returns to 400 pixels and `kenn-forge-workspace-sidebar-width` remains
+`"400"` throughout.
+
+- [ ] **Step 2: Run the regression and verify the expected failure**
+
+Run:
+
+```bash
+cd frontend && bun run test:browser -- WorkspaceTerminalView.host-visible.browser.svelte.ts
+```
+
+Expected: the final rendered width remains at the temporary constrained width,
+or local storage contains that constrained value.
+
+- [ ] **Step 3: Implement the minimal state separation**
+
+Derive the rendered width from the preferred width and current maximum. Remove
+automatic writes to the preferred width. Make the splitter ARIA value and pane
+style consume the rendered width, while pointer and keyboard resizing continue
+to update the preferred width using the rendered starting point.
+
+- [ ] **Step 4: Run focused verification**
+
+Run the browser regression again, then run the affected Svelte analyzer and the
+repository's focused frontend checks identified by package scripts.
+
+- [ ] **Step 5: Review and publish**
+
+Review the complete diff, run context-sync commit mode and the public-data scrub,
+commit with rationale-focused history, push `pr-pane-collapsing`, and open a
+pull request against the repository default branch.

--- a/docs/superpowers/specs/2026-08-04-workspace-detail-width-restoration-design.md
+++ b/docs/superpowers/specs/2026-08-04-workspace-detail-width-restoration-design.md
@@ -1,0 +1,35 @@
+# Workspace Detail Width Restoration Design
+
+## Problem
+
+The Workspaces right detail pane uses one `sidebarWidth` value as both the
+user's preferred width and the width currently permitted by the layout. When
+the terminal/detail row narrows, the layout clamps that value to preserve 300
+pixels for the terminal. The persistence effect then records the constrained
+value as the preference. Widening the row does not restore the old preference,
+so the pane can remain only a few pixels wide even though it is still open.
+
+## Design
+
+Keep the persisted preferred width separate from the rendered width. Pointer
+and keyboard resizing update the preferred width. Container reconciliation
+derives the rendered width by constraining that preference to the current
+maximum, without overwriting or persisting the temporary result. When space
+returns, the rendered width therefore returns to the preference automatically.
+
+The existing 280-pixel minimum remains the floor whenever the container can
+support it. If the container cannot support both that floor and the 300-pixel
+terminal minimum, the rendered pane may temporarily become narrower. This
+preserves the existing terminal usability contract without converting a
+transient constraint into durable state.
+
+## Verification
+
+Add a real-browser regression that opens the Workspaces detail pane with a
+saved preferred width, narrows the available row until the rendered pane is
+below its minimum, and then widens it again. Assert that the rendered pane
+returns to the saved preference and that local storage never changes during
+the temporary constraint.
+
+Retain the existing pointer-resize persistence and left-sidebar reclamping
+coverage. No API, database, provider, or terminal runtime behavior changes.

--- a/docs/superpowers/specs/2026-08-04-workspace-detail-width-restoration-design.md
+++ b/docs/superpowers/specs/2026-08-04-workspace-detail-width-restoration-design.md
@@ -23,13 +23,18 @@ terminal minimum, the rendered pane may temporarily become narrower. This
 preserves the existing terminal usability contract without converting a
 transient constraint into durable state.
 
+While the available maximum is below 280 pixels, the resize handle is disabled
+and the resize handler rejects any event already in flight. A temporarily
+constrained width is not a valid user preference and must never be persisted.
+
 ## Verification
 
 Add a real-browser regression that opens the Workspaces detail pane with a
 saved preferred width, narrows the available row until the rendered pane is
 below its minimum, and then widens it again. Assert that the rendered pane
 returns to the saved preference and that local storage never changes during
-the temporary constraint.
+the temporary constraint, including after attempting to drag the constrained
+resize handle.
 
 Retain the existing pointer-resize persistence and left-sidebar reclamping
 coverage. No API, database, provider, or terminal runtime behavior changes.

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.host-visible.browser.svelte.ts
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.host-visible.browser.svelte.ts
@@ -251,6 +251,71 @@ describe("WorkspaceTerminalView hostVisible", () => {
     }
   });
 
+  it("restores the preferred sidebar width after a temporary visible constraint", async () => {
+    const api = createMockApiFetch([workspaceRoutes()]);
+    const originalFetch = globalThis.fetch;
+    const originalEventSource = globalThis.EventSource;
+    globalThis.fetch = api.fetch;
+    globalThis.EventSource = NoopEventSource as unknown as typeof EventSource;
+
+    const settingsStore = {
+      getTerminalFontSize: () => DEFAULT_TERMINAL_SETTINGS.font_size,
+      getTerminalSettings: () => DEFAULT_TERMINAL_SETTINGS,
+    };
+    const diffStore = createDiffStore();
+
+    localStorage.removeItem("kenn-forge-workspace-sidebar-open");
+    localStorage.setItem("kenn-forge-workspace-sidebar-width", "400");
+
+    const target = document.createElement("div");
+    target.style.width = "804px";
+    target.style.height = "600px";
+    document.body.appendChild(target);
+
+    const instance = mount(WorkspaceTerminalView, {
+      target,
+      props: {
+        workspaceId: "ws-1",
+        hideWorkspaceList: true,
+        hideRightSidebar: false,
+      },
+      context: new Map([[STORES_KEY, { settings: settingsStore, diff: diffStore }]]),
+    });
+
+    const resizeWindow = () => {
+      window.dispatchEvent(new Event("resize"));
+      flushSync();
+    };
+
+    try {
+      await vi.waitFor(() => {
+        expect(document.querySelector(".header-btn.danger")).not.toBeNull();
+      }, WAIT);
+
+      await page.getByRole("button", { name: "Diff", exact: true }).click();
+      const sidebar = document.querySelector<HTMLElement>(".right-sidebar");
+      expect(sidebar).not.toBeNull();
+      expect(sidebar!.style.width).toBe("400px");
+
+      target.style.width = "404px";
+      resizeWindow();
+      await vi.waitFor(() => expect(sidebar!.style.width).toBe("100px"), WAIT);
+      expect(localStorage.getItem("kenn-forge-workspace-sidebar-width")).toBe("400");
+
+      target.style.width = "804px";
+      resizeWindow();
+      await vi.waitFor(() => expect(sidebar!.style.width).toBe("400px"), WAIT);
+      expect(localStorage.getItem("kenn-forge-workspace-sidebar-width")).toBe("400");
+    } finally {
+      flushSync(() => unmount(instance));
+      target.remove();
+      localStorage.removeItem("kenn-forge-workspace-sidebar-open");
+      localStorage.removeItem("kenn-forge-workspace-sidebar-width");
+      globalThis.fetch = originalFetch;
+      globalThis.EventSource = originalEventSource;
+    }
+  });
+
   it("parking closes toolbar menus and their nested modal instead of leaving an invisible stack", async () => {
     const api = createMockApiFetch([workspaceRoutes()]);
     const originalFetch = globalThis.fetch;

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -1263,6 +1263,9 @@
   const rightSidebarAriaMin = $derived(
     Math.min(MIN_SIDEBAR_WIDTH, rightSidebarAriaMax),
   );
+  const rightSidebarResizeDisabled = $derived(
+    rightSidebarAriaMax < MIN_SIDEBAR_WIDTH,
+  );
   // The saved width records user intent. A narrow window or a wider workspace
   // list may temporarily leave less room, but that layout constraint must not
   // replace the preference and strand the pane at its constrained width after
@@ -1289,6 +1292,7 @@
   }
 
   function handleSidebarResize(event: SplitResizeEvent): void {
+    if (rightSidebarResizeDisabled) return;
     preferredRightSidebarWidth = Math.max(
       sidebarResizeMinWidth,
       Math.min(
@@ -4022,6 +4026,7 @@
               ariaValueMin={rightSidebarAriaMin}
               ariaValueMax={rightSidebarAriaMax}
               ariaValueNow={renderedRightSidebarWidth}
+              disabled={rightSidebarResizeDisabled}
               onResizeStart={handleSidebarResizeStart}
               onResize={handleSidebarResize}
             />

--- a/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
+++ b/frontend/src/lib/components/terminal/WorkspaceTerminalView.svelte
@@ -480,7 +480,7 @@
     return selectedSidebarTabs[storageId] ?? loadSidebarTab(storageId);
   });
   let sidebarOpen = $state(loadSidebarOpen());
-  let sidebarWidth = $state(loadSidebarWidth());
+  let preferredRightSidebarWidth = $state(loadSidebarWidth());
   let workspaceListWidth = $state(loadWorkspaceListWidth());
   const currentWorkspaceListWidth = $derived(
     clampWorkspaceListWidth(
@@ -1156,7 +1156,7 @@
   $effect(() => {
     writeLocalStorage(
       SIDEBAR_WIDTH_KEY,
-      String(sidebarWidth),
+      String(preferredRightSidebarWidth),
     );
   });
   $effect(() => {
@@ -1239,11 +1239,6 @@
     } else {
       workspaceListWidth = clamped;
     }
-    requestAnimationFrame(() => {
-      if (containerEl) {
-        clampRightSidebarWidth(containerEl.clientWidth);
-      }
-    });
   }
 
   let containerEl = $state<HTMLElement | null>(null);
@@ -1263,57 +1258,27 @@
   const rightSidebarAriaMax = $derived(
     containerWidth > 0
       ? maxRightSidebarWidth(containerWidth)
-      : Math.max(MIN_SIDEBAR_WIDTH, sidebarWidth),
+      : Math.max(MIN_SIDEBAR_WIDTH, preferredRightSidebarWidth),
   );
   const rightSidebarAriaMin = $derived(
     Math.min(MIN_SIDEBAR_WIDTH, rightSidebarAriaMax),
   );
-
-  function clampRightSidebarWidth(
-    containerWidth: number,
-  ): void {
-    const maxW = maxRightSidebarWidth(containerWidth);
-    if (sidebarWidth > maxW) {
-      sidebarWidth = maxW;
-    }
-  }
-
-  // Keep the terminal usable when the main layout
-  // shrinks, including when the left workspace list
-  // is resized after the right sidebar is already open.
-  // Gated on hostVisible: a parked host sits in a display:none parking
-  // node where clientWidth is 0, and clamping against that zero would
-  // collapse (and persist) the sidebar width. hostVisible flipping back
-  // on reruns the clamp against real geometry.
-  $effect(() => {
-    if (!hostVisible || hideRightSidebar) return;
-    if (!containerEl || !sidebarOpen) return;
-
-    clampRightSidebarWidth(containerEl.clientWidth);
-  });
-
-  $effect(() => {
-    if (!hostVisible || hideRightSidebar) return;
-    if (!sidebarOpen) return;
-
-    function onResize(): void {
-      if (containerEl) {
-        clampRightSidebarWidth(containerEl.clientWidth);
-      }
-    }
-
-    window.addEventListener("resize", onResize);
-    return () => {
-      window.removeEventListener("resize", onResize);
-    };
-  });
+  // The saved width records user intent. A narrow window or a wider workspace
+  // list may temporarily leave less room, but that layout constraint must not
+  // replace the preference and strand the pane at its constrained width after
+  // space returns.
+  const renderedRightSidebarWidth = $derived(
+    containerWidth > 0
+      ? Math.min(preferredRightSidebarWidth, maxRightSidebarWidth(containerWidth))
+      : preferredRightSidebarWidth,
+  );
 
   let sidebarResizeStartWidth = 0;
   let sidebarResizeMinWidth = MIN_SIDEBAR_WIDTH;
   let sidebarResizeMaxWidth = 9999;
 
   function handleSidebarResizeStart(): void {
-    sidebarResizeStartWidth = sidebarWidth;
+    sidebarResizeStartWidth = renderedRightSidebarWidth;
     sidebarResizeMaxWidth = containerEl
       ? maxRightSidebarWidth(containerEl.clientWidth)
       : 9999;
@@ -1324,7 +1289,7 @@
   }
 
   function handleSidebarResize(event: SplitResizeEvent): void {
-    sidebarWidth = Math.max(
+    preferredRightSidebarWidth = Math.max(
       sidebarResizeMinWidth,
       Math.min(
         sidebarResizeMaxWidth,
@@ -4056,13 +4021,13 @@
               orientation="horizontal"
               ariaValueMin={rightSidebarAriaMin}
               ariaValueMax={rightSidebarAriaMax}
-              ariaValueNow={sidebarWidth}
+              ariaValueNow={renderedRightSidebarWidth}
               onResizeStart={handleSidebarResizeStart}
               onResize={handleSidebarResize}
             />
             <div
               class="right-sidebar"
-              style="width: {sidebarWidth}px"
+              style="width: {renderedRightSidebarWidth}px"
             >
               {#if workspaceDetailsReady && workspace}
                 {#snippet kataTaskPanel()}

--- a/frontend/tests/e2e/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar.spec.ts
@@ -3273,6 +3273,32 @@ test.describe("sidebar persistence", () => {
     expect(actualWidth).toBeGreaterThanOrEqual(savedWidth - 2);
     expect(actualWidth).toBeLessThanOrEqual(savedWidth + 2);
   });
+
+  test("temporary layout constraints preserve and restore the preferred sidebar width", async ({ page }) => {
+    await page.setViewportSize({ width: 1080, height: 720 });
+    await page.addInitScript(() => {
+      localStorage.setItem("kenn-forge-workspace-list-sidebar-width", "260");
+      localStorage.setItem("kenn-forge-workspace-sidebar-open", "true");
+      localStorage.setItem("kenn-forge-workspace-sidebar-width", "400");
+    });
+    await page.goto("/terminal/ws-123");
+
+    const rightSidebar = page.locator(".right-sidebar");
+    await expect(rightSidebar).toBeVisible();
+    await expect.poll(() => rightSidebar.evaluate((el) => el.offsetWidth)).toBe(400);
+
+    await page.setViewportSize({ width: 900, height: 720 });
+    await expect.poll(() => rightSidebar.evaluate((el) => el.offsetWidth)).toBeLessThan(280);
+    await expect
+      .poll(() => page.evaluate(() => localStorage.getItem("kenn-forge-workspace-sidebar-width")))
+      .toBe("400");
+
+    await page.setViewportSize({ width: 1080, height: 720 });
+    await expect.poll(() => rightSidebar.evaluate((el) => el.offsetWidth)).toBe(400);
+    await expect
+      .poll(() => page.evaluate(() => localStorage.getItem("kenn-forge-workspace-sidebar-width")))
+      .toBe("400");
+  });
 });
 
 // -------------------------------------------------------

--- a/frontend/tests/e2e/workspace-sidebar.spec.ts
+++ b/frontend/tests/e2e/workspace-sidebar.spec.ts
@@ -3289,6 +3289,17 @@ test.describe("sidebar persistence", () => {
 
     await page.setViewportSize({ width: 900, height: 720 });
     await expect.poll(() => rightSidebar.evaluate((el) => el.offsetWidth)).toBeLessThan(280);
+
+    const handle = page.locator(".sidebar-resize-handle");
+    const box = await handle.boundingBox();
+    expect(box).toBeTruthy();
+    if (box) {
+      await page.mouse.move(box.x + 2, box.y + box.height / 2);
+      await page.mouse.down();
+      await page.mouse.move(box.x - 40, box.y + box.height / 2);
+      await page.mouse.up();
+    }
+
     await expect
       .poll(() => page.evaluate(() => localStorage.getItem("kenn-forge-workspace-sidebar-width")))
       .toBe("400");


### PR DESCRIPTION
## Why

The Workspaces detail pane could become effectively inaccessible after a temporary narrow layout because its constrained rendered width replaced the saved preference. The pane remained logically open, so clicking its tab could not recover it.

## What changed

The preferred width is now kept separate from the width the current layout can render. Temporary constraints still preserve space for the terminal, while widening restores the preferred pane width automatically.

Component-browser and app-shell Playwright regressions cover narrowing below the normal pane minimum, preserving local storage, and restoring the width when space returns.

## Verification

- Frontend unit project: 3,488 passed, 2 skipped
- Frontend browser project: 222 passed
- Workspace sidebar Chromium spec: 80 passed, 1 skipped
- Frontend formatting, lint, type, and Svelte checks