### PR TITLE
Pace archive hydration off provider quota with a reserve floor

### DIFF
--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -270,16 +270,18 @@ fallback repository listing.
 - GitHub archive code owns historical identity inventory only; hydration must invoke ordinary item sync instead of adding archive-specific lookup, normalization, or persistence. (`internal/github/pages.go::ListIssuesPage`, `internal/github/sync.go::SyncArchiveItem`)
 - Archive item hydration bypasses persisted parent-detail ETags; an unchanged parent representation does not prove that legacy lifecycle timelines are complete. (`internal/github/sync.go::SyncArchiveItem`)
 - Archive issue hydration treats timeline failures as hard errors; ordinary issue refresh remains best-effort for that optional dataset. (`internal/github/sync.go::refreshIssueTimeline`)
-- GitHub archive hydration paces off provider quota alone: availability is
-  remaining minus the archive reserve (`max(limit/5, RateReserveBuffer)`),
-  enforced at admission and again at every wire attempt. Headerless Gitealike
-  hosts spend configured local hourly surplus above `archiveLiveFloor`.
-  Attempts covered by a registry reservation do not debit the local ceiling —
-  `sync_budget_per_hour` meters live sync only — and live work preempts the
-  archive lease.
+- GitHub archive admission with a known registry pacing window paces off
+  provider quota alone: availability is remaining minus the archive reserve
+  (`max(limit/5, RateReserveBuffer)`), enforced at admission and again at
+  every wire attempt, and attempts covered by a registry reservation do not
+  debit the local ceiling. Every other archive path — headerless Gitealike
+  hosts, the tracker fallback when the registry has no window, and any
+  attempt whose chain takes no reservation — spends configured local hourly
+  surplus above `archiveLiveFloor`. Live work preempts the archive lease.
   (`internal/github/budget.go::ArchiveProviderReserve`,
   `internal/github/budget.go::LocalArchiveSpendAvailable`,
-  `internal/github/sync.go::Admit`)
+  `internal/github/sync.go::Admit`,
+  `internal/github/budget_transport.go::archiveAttemptProviderReserved`)
 - A GitHub issue without `updated_at` uses `created_at` as both its freshness and initial activity boundary; zero timestamps must not bypass monotonic snapshot acceptance. (`internal/platform/github/normalize.go::NormalizeIssue`)
 
 ## Owner Routes And Identity Accounting
@@ -403,8 +405,8 @@ response never overwrites an App installation pool
   `sync_budget_per_hour` ceiling is separate and is reported apart from provider
   quota (`internal/github/sync.go::backgroundQuotaAvailability`).
 - List discovery (open PR/issue lists, repo identity resolve) spends the local
-  ceiling's essential reserve; optional spend (details, fast-sync, headerless
-  archive)
+  ceiling's essential reserve; optional spend (details, fast-sync, archive
+  attempts without a registry reservation)
   stops at limit minus reserve so it can never starve discovery
   (`internal/github/budget.go::TrySpendEssential`). Per-item enrichment nested
   inside an essential list fetch is demoted back to optional and degrades on

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -274,10 +274,13 @@ fallback repository listing.
   provider quota alone: availability is remaining minus the archive reserve
   (`max(limit/5, RateReserveBuffer)`), enforced at admission and again at
   every wire attempt, and attempts covered by a registry reservation do not
-  debit the local ceiling. Every other archive path — headerless Gitealike
-  hosts, the tracker fallback when the registry has no window, and any
-  attempt whose chain takes no reservation — spends configured local hourly
-  surplus above `archiveLiveFloor`. Live work preempts the archive lease.
+  debit the local ceiling. An active registry whose combined window is
+  incomplete or expired defers admission as provider-quota-unknown; it never
+  falls through to local pacing. Every other archive path — headerless
+  Gitealike hosts, GitHub without registry-based pacing (nil registry or
+  unresolved identity), and any attempt whose chain takes no reservation —
+  spends configured local hourly surplus above `archiveLiveFloor`. Live work
+  preempts the archive lease.
   (`internal/github/budget.go::ArchiveProviderReserve`,
   `internal/github/budget.go::LocalArchiveSpendAvailable`,
   `internal/github/sync.go::Admit`,

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -271,10 +271,12 @@ fallback repository listing.
 - Archive item hydration bypasses persisted parent-detail ETags; an unchanged parent representation does not prove that legacy lifecycle timelines are complete. (`internal/github/sync.go::SyncArchiveItem`)
 - Archive issue hydration treats timeline failures as hard errors; ordinary issue refresh remains best-effort for that optional dataset. (`internal/github/sync.go::refreshIssueTimeline`)
 - GitHub archive admission with a known registry pacing window paces off
-  provider quota alone: availability is remaining minus the archive reserve
-  (`max(limit/5, RateReserveBuffer)`), enforced at admission and again at
-  every wire attempt, and attempts covered by a registry reservation do not
-  debit the local ceiling. An active registry whose combined window is
+  provider quota alone: availability is the minimum across required resources
+  of remaining minus that pool's own archive reserve
+  (`max(limit/5, RateReserveBuffer)` of that pool's limit), enforced at
+  admission and again at every wire attempt. Reserves are per pool — the
+  smallest pool's reserve must not be applied to a larger pool. Attempts
+  covered by a registry reservation do not debit the local ceiling. An active registry whose combined window is
   incomplete or expired defers admission as provider-quota-unknown; it never
   falls through to local pacing. Every other archive path — headerless
   Gitealike hosts, GitHub without registry-based pacing (nil registry or
@@ -419,8 +421,8 @@ response never overwrites an App installation pool
   reached the wire, so eviction would only turn recovery cycles into
   unconditional refetches that deepen the exhaustion
   (`internal/github/sync.go::indexSyncRepo`).
-- Archive pacing on the provider path is the routed credential's remaining
-  required-resource headroom above the archive reserve; the local ceiling
+- Archive pacing on the provider path is the routed credential's minimum
+  per-pool headroom above each resource's own archive reserve; the local ceiling
   neither enlarges nor shrinks the provider envelope. Each archive attempt
   atomically reserves live headroom; an unobserved reservation remains
   deducted until a current header accounts for it or that resource window

--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -270,11 +270,14 @@ fallback repository listing.
 - GitHub archive code owns historical identity inventory only; hydration must invoke ordinary item sync instead of adding archive-specific lookup, normalization, or persistence. (`internal/github/pages.go::ListIssuesPage`, `internal/github/sync.go::SyncArchiveItem`)
 - Archive item hydration bypasses persisted parent-detail ETags; an unchanged parent representation does not prove that legacy lifecycle timelines are complete. (`internal/github/sync.go::SyncArchiveItem`)
 - Archive issue hydration treats timeline failures as hard errors; ordinary issue refresh remains best-effort for that optional dataset. (`internal/github/sync.go::refreshIssueTimeline`)
-- Archive requests use shared sync budgets above `archiveLiveFloor`: GitHub uses
-  the credential-aware provider pacing below, while headerless Gitealike hosts
-  use configured local hourly surplus. The transport attributes every attempt,
-  and live work preempts the archive lease.
-  (`internal/github/budget.go::ProviderArchiveSpendAvailable`,
+- GitHub archive hydration paces off provider quota alone: availability is
+  remaining minus the archive reserve (`max(limit/5, RateReserveBuffer)`),
+  enforced at admission and again at every wire attempt. Headerless Gitealike
+  hosts spend configured local hourly surplus above `archiveLiveFloor`.
+  Attempts covered by a registry reservation do not debit the local ceiling —
+  `sync_budget_per_hour` meters live sync only — and live work preempts the
+  archive lease.
+  (`internal/github/budget.go::ArchiveProviderReserve`,
   `internal/github/budget.go::LocalArchiveSpendAvailable`,
   `internal/github/sync.go::Admit`)
 - A GitHub issue without `updated_at` uses `created_at` as both its freshness and initial activity boundary; zero timestamps must not bypass monotonic snapshot acceptance. (`internal/platform/github/normalize.go::NormalizeIssue`)
@@ -400,7 +403,8 @@ response never overwrites an App installation pool
   `sync_budget_per_hour` ceiling is separate and is reported apart from provider
   quota (`internal/github/sync.go::backgroundQuotaAvailability`).
 - List discovery (open PR/issue lists, repo identity resolve) spends the local
-  ceiling's essential reserve; optional spend (details, fast-sync, archive)
+  ceiling's essential reserve; optional spend (details, fast-sync, headerless
+  archive)
   stops at limit minus reserve so it can never starve discovery
   (`internal/github/budget.go::TrySpendEssential`). Per-item enrichment nested
   inside an essential list fetch is demoted back to optional and degrades on
@@ -410,14 +414,13 @@ response never overwrites an App installation pool
   reached the wire, so eviction would only turn recovery cycles into
   unconditional refetches that deepen the exhaustion
   (`internal/github/sync.go::indexSyncRepo`).
-- Archive pacing uses the smaller of the local hourly surplus, the routed
-  credential's paced required-resource quota, and its current remaining
-  headroom after the provider reserve; a high local ceiling must not enlarge
-  the provider envelope. Each archive attempt atomically reserves live headroom;
-  an unobserved reservation remains deducted until a current header accounts
-  for it or that resource window rolls. The first header in a newer window uses
-  total reported usage as its conservative request-cost bound. Persistent spend
-  is keyed by resource and reset window, so staggered resets cannot erase charges
+- Archive pacing on the provider path is the routed credential's remaining
+  required-resource headroom above the archive reserve; the local ceiling
+  neither enlarges nor shrinks the provider envelope. Each archive attempt
+  atomically reserves live headroom; an unobserved reservation remains
+  deducted until a current header accounts for it or that resource window
+  rolls. The first header in a newer window uses total reported usage as its
+  conservative request-cost bound
   (`internal/github/sync.go::Admit`,
   `internal/github/quota.go::quotaTransport`).
 - Outside the archive attempt guard above, there is one background reserve

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -417,6 +417,8 @@ components:
         available:
           format: int64
           type: integer
+        known:
+          type: boolean
         limit:
           format: int64
           type: integer
@@ -444,6 +446,7 @@ components:
         - platform_host
         - principal
         - source
+        - known
         - limit
         - remaining
         - reserve

--- a/frontend/openapi/openapi.yaml
+++ b/frontend/openapi/openapi.yaml
@@ -411,6 +411,44 @@ components:
       required:
         - all
       type: object
+    ArchivePacingStatusResponse:
+      additionalProperties: false
+      properties:
+        available:
+          format: int64
+          type: integer
+        limit:
+          format: int64
+          type: integer
+        platform_host:
+          type: string
+        principal:
+          type: string
+        provider:
+          type: string
+        remaining:
+          format: int64
+          type: integer
+        reserve:
+          format: int64
+          type: integer
+        reset_at:
+          format: date-time
+          type: string
+        source:
+          enum:
+            - provider
+          type: string
+      required:
+        - provider
+        - platform_host
+        - principal
+        - source
+        - limit
+        - remaining
+        - reserve
+        - available
+      type: object
     ArchiveProgressCountsResponse:
       additionalProperties: false
       properties:
@@ -8178,6 +8216,29 @@ paths:
       summary: Receive agent lifecycle hook
       tags:
         - Activity
+  /archive/pacing:
+    get:
+      operationId: list-archive-pacing
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: "#/components/schemas/ArchivePacingStatusResponse"
+                type:
+                  - array
+                  - "null"
+          description: OK
+        default:
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemError"
+          description: Error
+      summary: List archive hydration pacing per provider credential
+      tags:
+        - Archive
   /archive/pause:
     post:
       operationId: pause-archives

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -1203,6 +1203,7 @@ type ArchiveMutationBody struct {
 // ArchivePacingStatusResponse defines model for ArchivePacingStatusResponse.
 type ArchivePacingStatusResponse struct {
 	Available    int64                             `json:"available"`
+	Known        bool                              `json:"known"`
 	Limit        int64                             `json:"limit"`
 	PlatformHost string                            `json:"platform_host"`
 	Principal    string                            `json:"principal"`

--- a/internal/apiclient/generated/client.gen.go
+++ b/internal/apiclient/generated/client.gen.go
@@ -164,6 +164,21 @@ func (e ArchiveCoverageResponseReviews) Valid() bool {
 	}
 }
 
+// Defines values for ArchivePacingStatusResponseSource.
+const (
+	Provider ArchivePacingStatusResponseSource = "provider"
+)
+
+// Valid indicates whether the value is a known member of the ArchivePacingStatusResponseSource enum.
+func (e ArchivePacingStatusResponseSource) Valid() bool {
+	switch e {
+	case Provider:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for ArchiveReportActivityResponseKind.
 const (
 	ArchiveReportActivityResponseKindInlineReviewComment ArchiveReportActivityResponseKind = "inline_review_comment"
@@ -1184,6 +1199,22 @@ type ArchiveMutationBody struct {
 	All          bool                    `json:"all"`
 	Repositories *[]ArchiveRepositoryRef `json:"repositories,omitempty"`
 }
+
+// ArchivePacingStatusResponse defines model for ArchivePacingStatusResponse.
+type ArchivePacingStatusResponse struct {
+	Available    int64                             `json:"available"`
+	Limit        int64                             `json:"limit"`
+	PlatformHost string                            `json:"platform_host"`
+	Principal    string                            `json:"principal"`
+	Provider     string                            `json:"provider"`
+	Remaining    int64                             `json:"remaining"`
+	Reserve      int64                             `json:"reserve"`
+	ResetAt      *time.Time                        `json:"reset_at,omitempty"`
+	Source       ArchivePacingStatusResponseSource `json:"source"`
+}
+
+// ArchivePacingStatusResponseSource defines model for ArchivePacingStatusResponse.Source.
+type ArchivePacingStatusResponseSource string
 
 // ArchiveProgressCountsResponse defines model for ArchiveProgressCountsResponse.
 type ArchiveProgressCountsResponse struct {
@@ -5501,6 +5532,9 @@ type ClientInterface interface {
 
 	ReceiveAgentHook(ctx context.Context, agent string, params *ReceiveAgentHookParams, body ReceiveAgentHookJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ListArchivePacing request
+	ListArchivePacing(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// PauseArchivesWithBody request with any body
 	PauseArchivesWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -6595,6 +6629,18 @@ func (c *Client) ReceiveAgentHookWithBody(ctx context.Context, agent string, par
 
 func (c *Client) ReceiveAgentHook(ctx context.Context, agent string, params *ReceiveAgentHookParams, body ReceiveAgentHookJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewReceiveAgentHookRequest(c.Server, agent, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListArchivePacing(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListArchivePacingRequest(c.Server)
 	if err != nil {
 		return nil, err
 	}
@@ -11468,6 +11514,33 @@ func NewReceiveAgentHookRequestWithBody(server string, agent string, params *Rec
 			req.Header.Set("X-Kenn-Forge-Runtime-Session-Key", headerParam0)
 		}
 
+	}
+
+	return req, nil
+}
+
+// NewListArchivePacingRequest generates requests for ListArchivePacing
+func NewListArchivePacingRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/archive/pacing")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
 	}
 
 	return req, nil
@@ -29052,6 +29125,9 @@ type ClientWithResponsesInterface interface {
 
 	ReceiveAgentHookWithResponse(ctx context.Context, agent string, params *ReceiveAgentHookParams, body ReceiveAgentHookJSONRequestBody, reqEditors ...RequestEditorFn) (*ReceiveAgentHookResponse, error)
 
+	// ListArchivePacingWithResponse request
+	ListArchivePacingWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListArchivePacingResponse, error)
+
 	// PauseArchivesWithBodyWithResponse request with any body
 	PauseArchivesWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PauseArchivesResponse, error)
 
@@ -30154,6 +30230,29 @@ func (r ReceiveAgentHookResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r ReceiveAgentHookResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListArchivePacingResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *[]ArchivePacingStatusResponse
+	ApplicationproblemJSONDefault *ProblemError
+}
+
+// Status returns HTTPResponse.Status
+func (r ListArchivePacingResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListArchivePacingResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -36653,6 +36752,15 @@ func (c *ClientWithResponses) ReceiveAgentHookWithResponse(ctx context.Context, 
 	return ParseReceiveAgentHookResponse(rsp)
 }
 
+// ListArchivePacingWithResponse request returning *ListArchivePacingResponse
+func (c *ClientWithResponses) ListArchivePacingWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListArchivePacingResponse, error) {
+	rsp, err := c.ListArchivePacing(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListArchivePacingResponse(rsp)
+}
+
 // PauseArchivesWithBodyWithResponse request with arbitrary body returning *PauseArchivesResponse
 func (c *ClientWithResponses) PauseArchivesWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PauseArchivesResponse, error) {
 	rsp, err := c.PauseArchivesWithBody(ctx, contentType, body, reqEditors...)
@@ -40097,6 +40205,39 @@ func ParseReceiveAgentHookResponse(rsp *http.Response) (*ReceiveAgentHookRespons
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest AgentHookResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ProblemError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListArchivePacingResponse parses an HTTP response from a ListArchivePacingWithResponse call
+func ParseListArchivePacingResponse(rsp *http.Response) (*ListArchivePacingResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListArchivePacingResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []ArchivePacingStatusResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/internal/github/archive_attempt_allowance_test.go
+++ b/internal/github/archive_attempt_allowance_test.go
@@ -140,7 +140,6 @@ func TestArchiveProviderAttemptAllowanceUsesObservedQuotaCost(t *testing.T) {
 		identity,
 		[]QuotaResource{QuotaResourceREST, QuotaResourceGraphQL},
 		RateReserveBuffer,
-		budget,
 	)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.test/repos/o/r", nil)
@@ -155,7 +154,7 @@ func TestArchiveProviderAttemptAllowanceUsesObservedQuotaCost(t *testing.T) {
 	require.ErrorIs(err, platform.ErrArchiveAttemptBudget)
 
 	assert.Equal(int32(1), calls.Load())
-	assert.Equal(1, budget.ArchiveSpent())
+	assert.Zero(budget.ArchiveSpent())
 	pool, ok := registry.Get(identity, QuotaResourceREST)
 	require.True(ok)
 	assert.Equal(201, pool.Remaining)
@@ -184,9 +183,7 @@ func TestArchiveProviderQuotaCostPersistsAcrossAdmissions(t *testing.T) {
 	window, ok := registry.PacingWindow(identity, resources)
 	require.True(ok)
 	budget := NewSyncBudget(100000)
-	assert.Equal(1200, budget.ProviderArchiveSpendAvailable(
-		now, window, 24, RateReserveBuffer,
-	))
+	assert.Equal(5000, window.Remaining)
 
 	var calls atomic.Int32
 	base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
@@ -211,7 +208,6 @@ func TestArchiveProviderQuotaCostPersistsAcrossAdmissions(t *testing.T) {
 		identity,
 		resources,
 		RateReserveBuffer,
-		budget,
 	)
 	req, err := http.NewRequestWithContext(
 		ctx, http.MethodGet, "https://api.github.test/repos/o/r", nil,
@@ -222,9 +218,7 @@ func TestArchiveProviderQuotaCostPersistsAcrossAdmissions(t *testing.T) {
 
 	window, ok = registry.PacingWindow(identity, resources)
 	require.True(ok)
-	assert.Equal(1198, budget.ProviderArchiveSpendAvailable(
-		now, window, 24, RateReserveBuffer,
-	))
+	assert.Equal(4998, window.Remaining)
 
 	// A later admission reserves the learned two-unit cost. Even if its
 	// response omits quota headers, that reserved cost must persist beyond the
@@ -235,7 +229,6 @@ func TestArchiveProviderQuotaCostPersistsAcrossAdmissions(t *testing.T) {
 		identity,
 		resources,
 		RateReserveBuffer,
-		budget,
 	)
 	req, err = http.NewRequestWithContext(
 		ctx, http.MethodGet, "https://api.github.test/repos/o/r", nil,
@@ -246,9 +239,7 @@ func TestArchiveProviderQuotaCostPersistsAcrossAdmissions(t *testing.T) {
 
 	window, ok = registry.PacingWindow(identity, resources)
 	require.True(ok)
-	assert.Equal(1196, budget.ProviderArchiveSpendAvailable(
-		now, window, 24, RateReserveBuffer,
-	))
+	assert.Equal(4996, window.Remaining)
 }
 
 func TestArchiveProviderHeaderlessReservationsProtectReserveAcrossAdmissions(t *testing.T) {
@@ -268,9 +259,7 @@ func TestArchiveProviderHeaderlessReservationsProtectReserveAcrossAdmissions(t *
 	window, ok := registry.PacingWindow(identity, resources)
 	require.True(ok)
 	budget := NewSyncBudget(100000)
-	assert.Equal(1, budget.ProviderArchiveSpendAvailable(
-		now, window, 24, RateReserveBuffer,
-	))
+	assert.Equal(RateReserveBuffer+1, window.Remaining)
 
 	var calls atomic.Int32
 	base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
@@ -293,7 +282,6 @@ func TestArchiveProviderHeaderlessReservationsProtectReserveAcrossAdmissions(t *
 			identity,
 			resources,
 			RateReserveBuffer,
-			budget,
 		)
 		req, err := http.NewRequestWithContext(
 			ctx, http.MethodGet, "https://api.github.test/repos/o/r", nil,
@@ -306,9 +294,7 @@ func TestArchiveProviderHeaderlessReservationsProtectReserveAcrossAdmissions(t *
 	require.NoError(request())
 	window, ok = registry.PacingWindow(identity, resources)
 	require.True(ok)
-	assert.Zero(budget.ProviderArchiveSpendAvailable(
-		now, window, 24, RateReserveBuffer,
-	))
+	assert.Equal(RateReserveBuffer, window.Remaining)
 	require.ErrorIs(request(), platform.ErrArchiveAttemptBudget)
 	assert.Equal(int32(1), calls.Load())
 }
@@ -348,7 +334,6 @@ func TestArchiveProviderAttemptAllowanceResetsObservedCostWithQuotaWindow(t *tes
 		identity,
 		[]QuotaResource{QuotaResourceREST, QuotaResourceGraphQL},
 		RateReserveBuffer,
-		budget,
 	)
 	request := func() error {
 		req, err := http.NewRequestWithContext(
@@ -421,7 +406,6 @@ func TestArchiveProviderAttemptAllowanceSeedsCostAcrossQuotaWindowReset(t *testi
 			identity,
 			resources,
 			RateReserveBuffer,
-			budget,
 		)
 		req, err := http.NewRequestWithContext(
 			ctx, http.MethodPost, "https://api.github.test/graphql", nil,
@@ -473,7 +457,6 @@ func TestArchiveProviderAttemptAllowanceRechecksEveryRequiredPool(t *testing.T) 
 		identity,
 		[]QuotaResource{QuotaResourceREST, QuotaResourceGraphQL},
 		RateReserveBuffer,
-		budget,
 	)
 
 	// Concurrent GraphQL work reaches the reserve after admission but before

--- a/internal/github/archive_attempt_allowance_test.go
+++ b/internal/github/archive_attempt_allowance_test.go
@@ -116,7 +116,7 @@ func TestArchiveProviderAttemptAllowanceUsesObservedQuotaCost(t *testing.T) {
 	reset := time.Now().UTC().Add(time.Hour).Truncate(time.Second)
 	for _, resource := range []QuotaResource{QuotaResourceREST, QuotaResourceGraphQL} {
 		registry.UpdateSnapshot(identity, resource, Rate{
-			Limit: 5000, Remaining: 203, Reset: reset,
+			Limit: 5000, Remaining: 1003, Reset: reset,
 		})
 	}
 	var calls atomic.Int32
@@ -125,7 +125,7 @@ func TestArchiveProviderAttemptAllowanceUsesObservedQuotaCost(t *testing.T) {
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Body:       io.NopCloser(strings.NewReader("{}")),
-			Header:     quotaTestHeaders(5000, 201, reset),
+			Header:     quotaTestHeaders(5000, 1001, reset),
 			Request:    req,
 		}, nil
 	})
@@ -139,7 +139,6 @@ func TestArchiveProviderAttemptAllowanceUsesObservedQuotaCost(t *testing.T) {
 		3,
 		identity,
 		[]QuotaResource{QuotaResourceREST, QuotaResourceGraphQL},
-		RateReserveBuffer,
 	)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.test/repos/o/r", nil)
@@ -157,13 +156,13 @@ func TestArchiveProviderAttemptAllowanceUsesObservedQuotaCost(t *testing.T) {
 	assert.Zero(budget.ArchiveSpent())
 	pool, ok := registry.Get(identity, QuotaResourceREST)
 	require.True(ok)
-	assert.Equal(201, pool.Remaining)
+	assert.Equal(1001, pool.Remaining)
 	assert.Equal(2, pool.AttemptCost)
 	window, ok := registry.PacingWindow(
 		identity, []QuotaResource{QuotaResourceREST, QuotaResourceGraphQL},
 	)
 	require.True(ok)
-	assert.Equal(201, window.Remaining)
+	assert.Equal(1001, window.Remaining)
 }
 
 func TestArchiveProviderQuotaCostPersistsAcrossAdmissions(t *testing.T) {
@@ -207,7 +206,6 @@ func TestArchiveProviderQuotaCostPersistsAcrossAdmissions(t *testing.T) {
 		1200,
 		identity,
 		resources,
-		RateReserveBuffer,
 	)
 	req, err := http.NewRequestWithContext(
 		ctx, http.MethodGet, "https://api.github.test/repos/o/r", nil,
@@ -228,7 +226,6 @@ func TestArchiveProviderQuotaCostPersistsAcrossAdmissions(t *testing.T) {
 		1198,
 		identity,
 		resources,
-		RateReserveBuffer,
 	)
 	req, err = http.NewRequestWithContext(
 		ctx, http.MethodGet, "https://api.github.test/repos/o/r", nil,
@@ -253,13 +250,13 @@ func TestArchiveProviderHeaderlessReservationsProtectReserveAcrossAdmissions(t *
 	resources := []QuotaResource{QuotaResourceREST, QuotaResourceGraphQL}
 	for _, resource := range resources {
 		registry.UpdateSnapshot(identity, resource, Rate{
-			Limit: 5000, Remaining: RateReserveBuffer + 1, Reset: reset,
+			Limit: 5000, Remaining: ArchiveProviderReserve(5000) + 1, Reset: reset,
 		})
 	}
 	window, ok := registry.PacingWindow(identity, resources)
 	require.True(ok)
 	budget := NewSyncBudget(100000)
-	assert.Equal(RateReserveBuffer+1, window.Remaining)
+	assert.Equal(ArchiveProviderReserve(5000)+1, window.Remaining)
 
 	var calls atomic.Int32
 	base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
@@ -281,7 +278,6 @@ func TestArchiveProviderHeaderlessReservationsProtectReserveAcrossAdmissions(t *
 			1,
 			identity,
 			resources,
-			RateReserveBuffer,
 		)
 		req, err := http.NewRequestWithContext(
 			ctx, http.MethodGet, "https://api.github.test/repos/o/r", nil,
@@ -294,7 +290,7 @@ func TestArchiveProviderHeaderlessReservationsProtectReserveAcrossAdmissions(t *
 	require.NoError(request())
 	window, ok = registry.PacingWindow(identity, resources)
 	require.True(ok)
-	assert.Equal(RateReserveBuffer, window.Remaining)
+	assert.Equal(ArchiveProviderReserve(5000), window.Remaining)
 	require.ErrorIs(request(), platform.ErrArchiveAttemptBudget)
 	assert.Equal(int32(1), calls.Load())
 }
@@ -308,11 +304,11 @@ func TestArchiveProviderAttemptAllowanceResetsObservedCostWithQuotaWindow(t *tes
 	nextReset := firstReset.Add(time.Hour)
 	for _, resource := range []QuotaResource{QuotaResourceREST, QuotaResourceGraphQL} {
 		registry.UpdateSnapshot(identity, resource, Rate{
-			Limit: 5000, Remaining: 210, Reset: firstReset,
+			Limit: 5000, Remaining: 1010, Reset: firstReset,
 		})
 	}
 	currentReset := firstReset
-	currentRemaining := 208
+	currentRemaining := 1008
 	var calls atomic.Int32
 	base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		calls.Add(1)
@@ -333,7 +329,6 @@ func TestArchiveProviderAttemptAllowanceResetsObservedCostWithQuotaWindow(t *tes
 		3,
 		identity,
 		[]QuotaResource{QuotaResourceREST, QuotaResourceGraphQL},
-		RateReserveBuffer,
 	)
 	request := func() error {
 		req, err := http.NewRequestWithContext(
@@ -352,10 +347,10 @@ func TestArchiveProviderAttemptAllowanceResetsObservedCostWithQuotaWindow(t *tes
 	assert.Equal(2, pool.AttemptCost)
 
 	registry.UpdateSnapshot(identity, QuotaResourceREST, Rate{
-		Limit: 5000, Remaining: 210, Reset: nextReset,
+		Limit: 5000, Remaining: 1010, Reset: nextReset,
 	})
 	currentReset = nextReset
-	currentRemaining = 209
+	currentRemaining = 1009
 	require.NoError(request())
 
 	pool, ok = registry.Get(identity, QuotaResourceREST)
@@ -405,7 +400,6 @@ func TestArchiveProviderAttemptAllowanceSeedsCostAcrossQuotaWindowReset(t *testi
 			10,
 			identity,
 			resources,
-			RateReserveBuffer,
 		)
 		req, err := http.NewRequestWithContext(
 			ctx, http.MethodPost, "https://api.github.test/graphql", nil,
@@ -456,7 +450,6 @@ func TestArchiveProviderAttemptAllowanceRechecksEveryRequiredPool(t *testing.T) 
 		10,
 		identity,
 		[]QuotaResource{QuotaResourceREST, QuotaResourceGraphQL},
-		RateReserveBuffer,
 	)
 
 	// Concurrent GraphQL work reaches the reserve after admission but before

--- a/internal/github/archive_lifecycle_test.go
+++ b/internal/github/archive_lifecycle_test.go
@@ -1815,3 +1815,31 @@ func TestGitHubArchiveAdmissionHonorsEachPoolsOwnReserve(t *testing.T) {
 	require.NotNil(denied.RetryAt)
 	assert.Equal(reset, *denied.RetryAt)
 }
+
+// When admission defers on the archive reserve, the retry time comes from the
+// pools that actually lack headroom. Waiting for the latest reset across all
+// pools would leave archives paused after the exhausted pool has reset.
+func TestGitHubArchiveAdmissionRetriesWhenDeficientPoolResets(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	now := time.Date(2026, 7, 28, 18, 30, 0, 0, time.UTC)
+	restReset := now.Add(10 * time.Minute)
+	graphQLReset := now.Add(30 * time.Minute)
+	syncer, registry, ref := newProviderQuotaAdmissionSyncer(
+		t, now, NewSyncBudget(100000),
+	)
+	identity := IdentityKey{Host: "github.test", Principal: "user:7"}
+	// REST sits at its own reserve and resets first; GraphQL has headroom
+	// and resets later.
+	registry.UpdateSnapshot(identity, QuotaResourceREST,
+		Rate{Limit: 15000, Remaining: 3000, Reset: restReset})
+	registry.UpdateSnapshot(identity, QuotaResourceGraphQL,
+		Rate{Limit: 5000, Remaining: 4800, Reset: graphQLReset})
+
+	denied, err := syncer.Admit(t.Context(), ref, db.ArchiveItemTypeIssue, 1)
+	require.NoError(err)
+	assert.False(denied.Allowed)
+	assert.Contains(denied.Detail, "provider rate reserve")
+	require.NotNil(denied.RetryAt)
+	assert.Equal(restReset, *denied.RetryAt)
+}

--- a/internal/github/archive_lifecycle_test.go
+++ b/internal/github/archive_lifecycle_test.go
@@ -1016,7 +1016,8 @@ func TestGitHubArchiveAdmissionCapsAttemptAllowanceByProviderQuota(t *testing.T)
 	require.NoError(err)
 	require.True(admission.Allowed)
 	t.Cleanup(func() { admission.Complete(nil, false) })
-	for range 1200 {
+	// remaining 4500 minus the limit/5 archive reserve (1000).
+	for range 3500 {
 		assert.True(ConsumeArchiveAttemptAllowance(admission.Context))
 	}
 	assert.False(ConsumeArchiveAttemptAllowance(admission.Context))
@@ -1678,4 +1679,114 @@ func TestConfiguredRepositoriesCarryStableProviderIdentity(t *testing.T) {
 	require.Len(refs, 1)
 	require.Equal("R_1", refs[0].PlatformExternalID,
 		"archive scheduling needs the stable provider identity for cooldown keys")
+}
+
+func newProviderQuotaAdmissionSyncer(
+	t *testing.T, now time.Time, budget *SyncBudget,
+) (*Syncer, *QuotaRegistry, platform.RepoRef) {
+	t.Helper()
+	database := dbtest.Open(t)
+	registry := NewQuotaRegistry()
+	registry.now = func() time.Time { return now }
+	client := &credentialRateLimitSnapshotMockClient{mockClient: &mockClient{}}
+	identity := IdentityKey{Host: "github.test", Principal: "user:7"}
+	bucket := RateBucketKey("github", "github.test", "user:7")
+	syncer := NewSyncer(
+		map[string]Client{"github.test": client},
+		database, nil,
+		[]RepoRef{{
+			Platform: platform.KindGitHub, PlatformHost: "github.test",
+			Owner: "acme", Name: "widget",
+		}},
+		time.Hour, nil,
+		map[string]*SyncBudget{bucket: budget},
+	)
+	router, err := NewHostRouter("github.test", &Route{
+		Key: RouteKey{Host: "github.test", Owner: "acme"}, Client: client,
+		ReadIdentity: identity, WriteIdentity: identity,
+	})
+	require.NoError(t, err)
+	syncer.SetGitHubRouters(map[string]*HostRouter{"github.test": router})
+	syncer.SetQuotaRegistry(registry)
+	syncer.now = func() time.Time { return now }
+	ref := platform.RepoRef{
+		Platform: platform.KindGitHub, Host: "github.test",
+		Owner: "acme", Name: "widget",
+	}
+	return syncer, registry, ref
+}
+
+// A fresh provider window grants the full surplus above the archive reserve
+// immediately: archive availability is a floor on remaining quota, not a ramp
+// across the window.
+func TestGitHubArchiveAdmissionGrantsFullSurplusAtWindowStart(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	now := time.Date(2026, 7, 28, 18, 30, 0, 0, time.UTC)
+	reset := now.Add(59 * time.Minute)
+	syncer, registry, ref := newProviderQuotaAdmissionSyncer(
+		t, now, NewSyncBudget(100000),
+	)
+	identity := IdentityKey{Host: "github.test", Principal: "user:7"}
+	registry.UpdateSnapshot(identity, QuotaResourceREST,
+		Rate{Limit: 5000, Remaining: 4500, Reset: reset})
+	registry.UpdateSnapshot(identity, QuotaResourceGraphQL,
+		Rate{Limit: 5000, Remaining: 4500, Reset: reset})
+
+	admission, err := syncer.Admit(t.Context(), ref, db.ArchiveItemTypeIssue, 2)
+	require.NoError(err)
+	require.True(admission.Allowed)
+	t.Cleanup(func() { admission.Complete(nil, false) })
+	// remaining 4500 minus the limit/5 reserve (1000) is fully consumable.
+	for range 3500 {
+		assert.True(ConsumeArchiveAttemptAllowance(admission.Context))
+	}
+	assert.False(ConsumeArchiveAttemptAllowance(admission.Context))
+}
+
+// The local sync budget meters live sync only; provider-paced archive
+// admission must not defer because live sync spent the configured hourly
+// ceiling while provider quota still has surplus above the archive reserve.
+func TestGitHubArchiveAdmissionIgnoresLocalSyncBudget(t *testing.T) {
+	require := require.New(t)
+	now := time.Date(2026, 7, 28, 18, 30, 0, 0, time.UTC)
+	reset := now.Add(30 * time.Minute)
+	budget := NewSyncBudget(100)
+	budget.Spend(100)
+	syncer, registry, ref := newProviderQuotaAdmissionSyncer(t, now, budget)
+	identity := IdentityKey{Host: "github.test", Principal: "user:7"}
+	registry.UpdateSnapshot(identity, QuotaResourceREST,
+		Rate{Limit: 5000, Remaining: 4500, Reset: reset})
+	registry.UpdateSnapshot(identity, QuotaResourceGraphQL,
+		Rate{Limit: 5000, Remaining: 4500, Reset: reset})
+
+	admission, err := syncer.Admit(t.Context(), ref, db.ArchiveItemTypeIssue, 1)
+	require.NoError(err)
+	require.True(admission.Allowed)
+	t.Cleanup(func() { admission.Complete(nil, false) })
+}
+
+// Remaining quota at or below the archive reserve defers admission until the
+// provider window resets, even though the global rate reserve buffer still
+// has headroom.
+func TestGitHubArchiveAdmissionDefersAtArchiveReserve(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	now := time.Date(2026, 7, 28, 18, 30, 0, 0, time.UTC)
+	reset := now.Add(30 * time.Minute)
+	syncer, registry, ref := newProviderQuotaAdmissionSyncer(
+		t, now, NewSyncBudget(100000),
+	)
+	identity := IdentityKey{Host: "github.test", Principal: "user:7"}
+	registry.UpdateSnapshot(identity, QuotaResourceREST,
+		Rate{Limit: 5000, Remaining: 1000, Reset: reset})
+	registry.UpdateSnapshot(identity, QuotaResourceGraphQL,
+		Rate{Limit: 5000, Remaining: 4500, Reset: reset})
+
+	denied, err := syncer.Admit(t.Context(), ref, db.ArchiveItemTypeIssue, 1)
+	require.NoError(err)
+	assert.False(denied.Allowed)
+	assert.Contains(denied.Detail, "provider rate reserve")
+	require.NotNil(denied.RetryAt)
+	assert.Equal(reset, *denied.RetryAt)
 }

--- a/internal/github/archive_lifecycle_test.go
+++ b/internal/github/archive_lifecycle_test.go
@@ -1790,3 +1790,28 @@ func TestGitHubArchiveAdmissionDefersAtArchiveReserve(t *testing.T) {
 	require.NotNil(denied.RetryAt)
 	assert.Equal(reset, *denied.RetryAt)
 }
+
+// A pool sitting at its own limit/5 reserve blocks admission even when the
+// smallest-limit pool still has headroom: reserves are per pool, and the
+// min-limit pool's reserve must not be applied to a larger pool.
+func TestGitHubArchiveAdmissionHonorsEachPoolsOwnReserve(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	now := time.Date(2026, 7, 28, 18, 30, 0, 0, time.UTC)
+	reset := now.Add(30 * time.Minute)
+	syncer, registry, ref := newProviderQuotaAdmissionSyncer(
+		t, now, NewSyncBudget(100000),
+	)
+	identity := IdentityKey{Host: "github.test", Principal: "user:7"}
+	registry.UpdateSnapshot(identity, QuotaResourceREST,
+		Rate{Limit: 15000, Remaining: 3000, Reset: reset})
+	registry.UpdateSnapshot(identity, QuotaResourceGraphQL,
+		Rate{Limit: 5000, Remaining: 4800, Reset: reset})
+
+	denied, err := syncer.Admit(t.Context(), ref, db.ArchiveItemTypeIssue, 1)
+	require.NoError(err)
+	assert.False(denied.Allowed)
+	assert.Contains(denied.Detail, "provider rate reserve")
+	require.NotNil(denied.RetryAt)
+	assert.Equal(reset, *denied.RetryAt)
+}

--- a/internal/github/budget.go
+++ b/internal/github/budget.go
@@ -48,18 +48,12 @@ type SyncBudget struct {
 	// beyond limit-reserve so it can never starve discovery within the
 	// configured ceiling. Zero unless constructed with
 	// NewSyncBudgetWithEssentialReserve.
-	reserve              int
-	spent                int
-	archiveSpent         int
-	providerArchiveSpent map[providerArchiveWindow]int
-	windowStart          time.Time
-	window               BudgetWindow
-	now                  func() time.Time
-}
-
-type providerArchiveWindow struct {
-	resource QuotaResource
-	resetAt  time.Time
+	reserve      int
+	spent        int
+	archiveSpent int
+	windowStart  time.Time
+	window       BudgetWindow
+	now          func() time.Time
 }
 
 // BudgetWindow identifies the hourly window a reservation was made in. Refunds
@@ -74,6 +68,20 @@ func NewSyncBudget(limit int) *SyncBudget {
 		windowStart: time.Now().UTC(),
 		now:         time.Now,
 	}
+}
+
+// archiveProviderReserveDenominator sizes the slice of a provider quota
+// window held back from archive hydration: limit/5. Live and essential sync
+// always keep at least that headroom; archive availability is whatever
+// remains above it.
+const archiveProviderReserveDenominator = 5
+
+// archiveProviderReserve returns the provider quota archive hydration must
+// leave untouched. It never drops below the global rate reserve buffer, so
+// small or unknown limits still keep the hard floor that pauses all
+// background work.
+func archiveProviderReserve(limit int) int {
+	return max(limit/archiveProviderReserveDenominator, RateReserveBuffer)
 }
 
 // essentialReserveDenominator sizes the essential reserve as a fraction of
@@ -194,83 +202,6 @@ func (b *SyncBudget) ArchiveSpendCeiling(now time.Time, resetAt *time.Time, live
 	return b.archiveSpendCeiling(now, resetAt, liveFloor)
 }
 
-func (b *SyncBudget) ProviderArchiveSpendCeiling(
-	now time.Time,
-	resetAt *time.Time,
-	localLiveFloor int,
-	providerLimit int,
-	providerReserve int,
-) int {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	b.rollLocked()
-	return b.providerArchiveSpendCeiling(
-		now, resetAt, localLiveFloor, providerLimit, providerReserve,
-	)
-}
-
-func (b *SyncBudget) ProviderArchiveSpendAvailable(
-	now time.Time,
-	window QuotaPacingWindow,
-	localLiveFloor int,
-	providerReserve int,
-) int {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	b.rollLocked()
-	providerArchiveSpent := b.providerArchiveSpendLocked(window.ResourceResets)
-	ceilingRemaining := b.providerArchiveSpendCeiling(
-		now, &window.ResetAt, localLiveFloor, window.Limit, providerReserve,
-	) - providerArchiveSpent
-	localRemaining := b.optionalLimitLocked() - max(localLiveFloor, 0) - b.spent
-	providerHeadroom := window.Remaining - max(providerReserve, 0)
-	return max(min(ceilingRemaining, localRemaining, providerHeadroom), 0)
-}
-
-// providerArchiveSpendLocked returns provider quota-unit spend belonging to
-// each resource's current window. Staggered resets expire only the spend for
-// the resource that advanced, preserving charges already made in another
-// resource's newer window.
-func (b *SyncBudget) providerArchiveSpendLocked(
-	resourceResets map[QuotaResource]time.Time,
-) int {
-	spent := 0
-	for window, amount := range b.providerArchiveSpent {
-		currentReset, current := resourceResets[window.resource]
-		switch {
-		case current && currentReset.Equal(window.resetAt):
-			spent += amount
-		case current && currentReset.After(window.resetAt):
-			delete(b.providerArchiveSpent, window)
-		}
-	}
-	return spent
-}
-
-func (b *SyncBudget) providerArchiveSpendCeiling(
-	now time.Time,
-	resetAt *time.Time,
-	localLiveFloor int,
-	providerLimit int,
-	providerReserve int,
-) int {
-	if resetAt == nil || providerLimit <= providerReserve {
-		return 0
-	}
-	remaining := resetAt.Sub(now)
-	if remaining < 0 || remaining > time.Hour {
-		return 0
-	}
-	elapsedFraction := 1 - float64(remaining)/float64(time.Hour)
-	localSurplus := b.optionalLimitLocked() - max(localLiveFloor, 0)
-	providerSurplus := providerLimit - max(providerReserve, 0)
-	surplus := min(localSurplus, providerSurplus)
-	if surplus <= 0 {
-		return 0
-	}
-	return int(math.Floor(float64(surplus) * elapsedFraction * elapsedFraction))
-}
-
 func (b *SyncBudget) CanSpendArchive(n int, now time.Time, resetAt *time.Time, liveFloor int) bool {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -310,26 +241,6 @@ func (b *SyncBudget) TrySpendArchive(n int) (BudgetWindow, bool) {
 	return b.window, true
 }
 
-// addProviderArchiveSpend records provider quota units independently from the
-// local wire-call ceiling and keys them to the resource window that incurred
-// them so staggered resets cannot clear newer-window spend.
-func (b *SyncBudget) addProviderArchiveSpend(
-	resource QuotaResource,
-	resetAt time.Time,
-	n int,
-) {
-	if resource == "" || resetAt.IsZero() || n <= 0 {
-		return
-	}
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	if b.providerArchiveSpent == nil {
-		b.providerArchiveSpent = make(map[providerArchiveWindow]int)
-	}
-	window := providerArchiveWindow{resource: resource, resetAt: resetAt.UTC()}
-	b.providerArchiveSpent[window] += n
-}
-
 func (b *SyncBudget) RefundArchive(window BudgetWindow, n int) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -338,9 +249,6 @@ func (b *SyncBudget) RefundArchive(window BudgetWindow, n int) {
 	}
 	b.spent = max(b.spent-n, 0)
 	b.archiveSpent = max(b.archiveSpent-n, 0)
-	// Provider pacing counts wire attempts, including conditional requests.
-	// Do not return this spend: a late response may belong to an older provider
-	// window even when it still belongs to the current local budget window.
 }
 
 func (b *SyncBudget) ArchiveSpent() int {

--- a/internal/github/budget.go
+++ b/internal/github/budget.go
@@ -76,11 +76,11 @@ func NewSyncBudget(limit int) *SyncBudget {
 // remains above it.
 const archiveProviderReserveDenominator = 5
 
-// archiveProviderReserve returns the provider quota archive hydration must
+// ArchiveProviderReserve returns the provider quota archive hydration must
 // leave untouched. It never drops below the global rate reserve buffer, so
 // small or unknown limits still keep the hard floor that pauses all
 // background work.
-func archiveProviderReserve(limit int) int {
+func ArchiveProviderReserve(limit int) int {
 	return max(limit/archiveProviderReserveDenominator, RateReserveBuffer)
 }
 

--- a/internal/github/budget_test.go
+++ b/internal/github/budget_test.go
@@ -278,9 +278,9 @@ func TestSyncBudgetResetDropsInFlightRefund(t *testing.T) {
 // essential work, never dropping below the global rate reserve buffer.
 func TestArchiveProviderReserveHoldsBackFifthOfLimit(t *testing.T) {
 	assert := assert.New(t)
-	assert.Equal(1000, archiveProviderReserve(5000))
-	assert.Equal(300, archiveProviderReserve(1500))
-	assert.Equal(RateReserveBuffer, archiveProviderReserve(500))
-	assert.Equal(RateReserveBuffer, archiveProviderReserve(0))
-	assert.Equal(RateReserveBuffer, archiveProviderReserve(-100))
+	assert.Equal(1000, ArchiveProviderReserve(5000))
+	assert.Equal(300, ArchiveProviderReserve(1500))
+	assert.Equal(RateReserveBuffer, ArchiveProviderReserve(500))
+	assert.Equal(RateReserveBuffer, ArchiveProviderReserve(0))
+	assert.Equal(RateReserveBuffer, ArchiveProviderReserve(-100))
 }

--- a/internal/github/budget_test.go
+++ b/internal/github/budget_test.go
@@ -1,14 +1,10 @@
 package github
 
 import (
-	"io"
-	"net/http"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"go.kenn.io/forge/internal/platform"
 )
 
@@ -125,278 +121,6 @@ func TestSyncBudgetArchiveAdmissionRampsTowardReset(t *testing.T) {
 	}
 	assert.Equal(80, budget.ArchiveSpent())
 	assert.Equal(20, budget.Remaining())
-}
-
-func TestSyncBudgetProviderArchivePacingUsesConservativeEnvelope(t *testing.T) {
-	reset := time.Date(2026, 7, 28, 19, 0, 0, 0, time.UTC)
-	now := reset.Add(-30 * time.Minute)
-
-	tests := []struct {
-		name            string
-		localLimit      int
-		localFloor      int
-		providerLimit   int
-		providerReserve int
-		want            int
-	}{
-		{
-			name:       "provider quota caps high local guard",
-			localLimit: 100000, localFloor: 24,
-			providerLimit: 5000, providerReserve: 200,
-			want: 1200,
-		},
-		{
-			name:       "lower local guard remains authoritative",
-			localLimit: 3000, localFloor: 24,
-			providerLimit: 5000, providerReserve: 200,
-			want: 744,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			budget := NewSyncBudget(test.localLimit)
-			assert.Equal(t, test.want, budget.ProviderArchiveSpendCeiling(
-				now, &reset, test.localFloor, test.providerLimit, test.providerReserve,
-			))
-		})
-	}
-}
-
-func providerPacingWindowForTest(
-	limit int,
-	remaining int,
-	reset time.Time,
-) QuotaPacingWindow {
-	return QuotaPacingWindow{
-		Limit: limit, Remaining: remaining, ResetAt: reset,
-		ResourceResets: map[QuotaResource]time.Time{
-			QuotaResourceREST: reset, QuotaResourceGraphQL: reset,
-		},
-	}
-}
-
-func TestSyncBudgetProviderArchiveAvailabilityPreservesCurrentProviderReserve(t *testing.T) {
-	reset := time.Date(2026, 7, 28, 19, 0, 0, 0, time.UTC)
-	now := reset.Add(-30 * time.Minute)
-	budget := NewSyncBudget(100000)
-
-	assert.Equal(t, 1, budget.ProviderArchiveSpendAvailable(
-		now, providerPacingWindowForTest(5000, 201, reset), 24, 200,
-	))
-}
-
-func TestSyncBudgetProviderArchivePacingSurvivesLocalRollover(t *testing.T) {
-	reset := time.Date(2026, 7, 28, 19, 0, 0, 0, time.UTC)
-	clock := reset.Add(-30 * time.Minute)
-	budget := NewSyncBudget(100000)
-	budget.now = func() time.Time { return clock }
-	budget.windowStart = clock.Add(-55 * time.Minute)
-
-	assert.Equal(t, 1200, budget.ProviderArchiveSpendAvailable(
-		clock, providerPacingWindowForTest(5000, 5000, reset), 24, 200,
-	))
-	budget.addProviderArchiveSpend(QuotaResourceREST, reset, 100)
-
-	// The local hour rolls before the provider's conservative pacing window.
-	// That replenishes the local ceiling but must not forget provider attempts
-	// already made against the still-active provider window.
-	clock = clock.Add(5 * time.Minute)
-	assert.Equal(t, 1533, budget.ProviderArchiveSpendAvailable(
-		clock, providerPacingWindowForTest(5000, 5000, reset), 24, 200,
-	))
-}
-
-func TestSyncBudgetProviderArchivePacingSurvivesEarlierPoolReset(t *testing.T) {
-	assert := assert.New(t)
-	require := require.New(t)
-	now := time.Date(2026, 7, 28, 18, 30, 0, 0, time.UTC)
-	restReset := now.Add(5 * time.Minute)
-	graphQLReset := now.Add(30 * time.Minute)
-	registry := NewQuotaRegistry()
-	registry.now = func() time.Time { return now }
-	registry.UpdateSnapshot(quotaTestUser, QuotaResourceREST, Rate{
-		Limit: 5000, Remaining: 5000, Reset: restReset,
-	})
-	registry.UpdateSnapshot(quotaTestUser, QuotaResourceGraphQL, Rate{
-		Limit: 5000, Remaining: 5000, Reset: graphQLReset,
-	})
-	window, ok := registry.PacingWindow(
-		quotaTestUser, []QuotaResource{QuotaResourceREST, QuotaResourceGraphQL},
-	)
-	require.True(ok)
-	require.Equal(graphQLReset, window.ResetAt)
-
-	budget := NewSyncBudget(100000)
-	assert.Equal(1200, budget.ProviderArchiveSpendAvailable(
-		now, window, 24, 200,
-	))
-	budget.addProviderArchiveSpend(QuotaResourceGraphQL, graphQLReset, 100)
-
-	// A tracker for the earlier REST window invokes Reset while the selected
-	// GraphQL pacing window is unchanged. The 100 provider attempts still
-	// belong to that selected window.
-	budget.Reset()
-	window, ok = registry.PacingWindow(
-		quotaTestUser, []QuotaResource{QuotaResourceREST, QuotaResourceGraphQL},
-	)
-	require.True(ok)
-	assert.Equal(1100, budget.ProviderArchiveSpendAvailable(
-		now, window, 24, 200,
-	))
-
-	// Once the selected provider window itself advances, its paced spend starts
-	// fresh independently of the local budget window.
-	nextNow := graphQLReset
-	nextReset := nextNow.Add(30 * time.Minute)
-	assert.Equal(1200, budget.ProviderArchiveSpendAvailable(
-		nextNow,
-		providerPacingWindowForTest(window.Limit, window.Remaining, nextReset),
-		24,
-		200,
-	))
-}
-
-func TestSyncBudgetProviderArchivePacingWaitsForEveryPoolReset(t *testing.T) {
-	require := require.New(t)
-	assert := assert.New(t)
-	now := time.Date(2026, 7, 28, 18, 30, 0, 0, time.UTC)
-	registry := NewQuotaRegistry()
-	registry.now = func() time.Time { return now }
-	restReset := now.Add(5 * time.Minute)
-	graphQLReset := now.Add(30 * time.Minute)
-	registry.UpdateSnapshot(quotaTestUser, QuotaResourceREST, Rate{
-		Limit: 5000, Remaining: 5000, Reset: restReset,
-	})
-	registry.UpdateSnapshot(quotaTestUser, QuotaResourceGraphQL, Rate{
-		Limit: 5000, Remaining: 5000, Reset: graphQLReset,
-	})
-	window, ok := registry.PacingWindow(
-		quotaTestUser, []QuotaResource{QuotaResourceREST, QuotaResourceGraphQL},
-	)
-	require.True(ok)
-
-	budget := NewSyncBudget(100000)
-	assert.Equal(1200, budget.ProviderArchiveSpendAvailable(
-		now, window, 24, 200,
-	))
-	budget.addProviderArchiveSpend(QuotaResourceGraphQL, graphQLReset, 100)
-
-	// Only REST advances. The combined latest reset changes, but GraphQL still
-	// represents the original pacing epoch, so its existing spend must remain.
-	registry.UpdateSnapshot(quotaTestUser, QuotaResourceREST, Rate{
-		Limit: 5000, Remaining: 5000, Reset: now.Add(31 * time.Minute),
-	})
-	window, ok = registry.PacingWindow(
-		quotaTestUser, []QuotaResource{QuotaResourceREST, QuotaResourceGraphQL},
-	)
-	require.True(ok)
-	ceiling := budget.ProviderArchiveSpendCeiling(
-		now, &window.ResetAt, 24, window.Limit, 200,
-	)
-	assert.Equal(ceiling-100, budget.ProviderArchiveSpendAvailable(
-		now, window, 24, 200,
-	))
-
-	// Once GraphQL advances too, every constituent window in the original
-	// epoch has rolled and the provider-paced spend starts fresh.
-	registry.UpdateSnapshot(quotaTestUser, QuotaResourceGraphQL, Rate{
-		Limit: 5000, Remaining: 5000, Reset: now.Add(32 * time.Minute),
-	})
-	window, ok = registry.PacingWindow(
-		quotaTestUser, []QuotaResource{QuotaResourceREST, QuotaResourceGraphQL},
-	)
-	require.True(ok)
-	ceiling = budget.ProviderArchiveSpendCeiling(
-		now, &window.ResetAt, 24, window.Limit, 200,
-	)
-	assert.Equal(ceiling, budget.ProviderArchiveSpendAvailable(
-		now, window, 24, 200,
-	))
-}
-
-func TestSyncBudgetProviderArchivePacingRetainsSpendFromNewerResourceWindow(t *testing.T) {
-	require := require.New(t)
-	assert := assert.New(t)
-	now := time.Date(2026, 7, 28, 18, 30, 0, 0, time.UTC)
-	registry := NewQuotaRegistry()
-	registry.now = func() time.Time { return now }
-	identity := IdentityKey{Host: "github.com", Principal: "user:7"}
-	resources := []QuotaResource{QuotaResourceREST, QuotaResourceGraphQL}
-	restReset := now.Add(5 * time.Minute)
-	graphQLReset := now.Add(30 * time.Minute)
-	registry.UpdateSnapshot(identity, QuotaResourceREST, Rate{
-		Limit: 5000, Remaining: 5000, Reset: restReset,
-	})
-	registry.UpdateSnapshot(identity, QuotaResourceGraphQL, Rate{
-		Limit: 5000, Remaining: 5000, Reset: graphQLReset,
-	})
-	window, ok := registry.PacingWindow(identity, resources)
-	require.True(ok)
-	budget := NewSyncBudget(100000)
-	assert.Equal(1200, budget.ProviderArchiveSpendAvailable(
-		now, window, 24, RateReserveBuffer,
-	))
-
-	transportFor := func(
-		resource QuotaResource,
-		remaining int,
-		reset time.Time,
-	) http.RoundTripper {
-		base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(strings.NewReader("{}")),
-				Header:     quotaTestHeaders(5000, remaining, reset),
-				Request:    req,
-			}, nil
-		})
-		return &quotaTransport{
-			base: WrapSyncBudgetTransport(base, budget), registry: registry,
-			identity: identity, resource: resource,
-		}
-	}
-	request := func(transport http.RoundTripper) {
-		ctx := WithArchiveProviderAttemptAllowance(
-			WithArchiveSyncBudget(t.Context()),
-			1000,
-			identity,
-			resources,
-			RateReserveBuffer,
-			budget,
-		)
-		req, err := http.NewRequestWithContext(
-			ctx, http.MethodGet, "https://api.github.test/repos/o/r", nil,
-		)
-		require.NoError(err)
-		_, err = transport.RoundTrip(req)
-		require.NoError(err)
-	}
-
-	// Spend 100 GraphQL units in the original epoch.
-	request(transportFor(QuotaResourceGraphQL, 4900, graphQLReset))
-
-	// REST rolls first, then spends 25 units in its new window while GraphQL
-	// still belongs to the original epoch.
-	nextRESTReset := now.Add(31 * time.Minute)
-	registry.UpdateSnapshot(identity, QuotaResourceREST, Rate{
-		Limit: 5000, Remaining: 5000, Reset: nextRESTReset,
-	})
-	request(transportFor(QuotaResourceREST, 4975, nextRESTReset))
-
-	// GraphQL rolls afterward. Its old 100-unit spend expires, but the 25 REST
-	// units belong to the current REST window and must remain paced.
-	registry.UpdateSnapshot(identity, QuotaResourceGraphQL, Rate{
-		Limit: 5000, Remaining: 5000, Reset: now.Add(32 * time.Minute),
-	})
-	window, ok = registry.PacingWindow(identity, resources)
-	require.True(ok)
-	ceiling := budget.ProviderArchiveSpendCeiling(
-		now, &window.ResetAt, 24, window.Limit, RateReserveBuffer,
-	)
-	assert.Equal(ceiling-25, budget.ProviderArchiveSpendAvailable(
-		now, window, 24, RateReserveBuffer,
-	))
 }
 
 func TestSyncBudgetArchiveAdmissionPreservesLiveFloor(t *testing.T) {
@@ -548,4 +272,15 @@ func TestSyncBudgetResetDropsInFlightRefund(t *testing.T) {
 
 	budget.Refund(stale, 1)
 	assert.Equal(2, budget.Spent())
+}
+
+// The archive reserve holds back a fifth of the provider limit for live and
+// essential work, never dropping below the global rate reserve buffer.
+func TestArchiveProviderReserveHoldsBackFifthOfLimit(t *testing.T) {
+	assert := assert.New(t)
+	assert.Equal(1000, archiveProviderReserve(5000))
+	assert.Equal(300, archiveProviderReserve(1500))
+	assert.Equal(RateReserveBuffer, archiveProviderReserve(500))
+	assert.Equal(RateReserveBuffer, archiveProviderReserve(0))
+	assert.Equal(RateReserveBuffer, archiveProviderReserve(-100))
 }

--- a/internal/github/budget_transport.go
+++ b/internal/github/budget_transport.go
@@ -27,7 +27,6 @@ type archiveAttemptAllowance struct {
 type archiveProviderAttemptConfig struct {
 	identity  IdentityKey
 	resources []QuotaResource
-	reserve   int
 }
 
 type archiveProviderAttemptReservation struct {
@@ -55,11 +54,10 @@ func WithArchiveProviderAttemptAllowance(
 	attempts int,
 	identity IdentityKey,
 	resources []QuotaResource,
-	reserve int,
 ) context.Context {
 	allowance := &archiveAttemptAllowance{
 		provider: &archiveProviderAttemptConfig{
-			identity: identity, resources: slices.Clone(resources), reserve: max(reserve, 0),
+			identity: identity, resources: slices.Clone(resources),
 		},
 	}
 	allowance.remaining.Store(int64(attempts))
@@ -123,7 +121,7 @@ func reserveArchiveProviderAttempt(
 		resources = config.resources
 	}
 	quota, allowed := registry.reserveArchiveAttempt(
-		identity, resources, resource, config.reserve,
+		identity, resources, resource,
 	)
 	if !allowed {
 		return req, archiveProviderAttemptReservation{}, false

--- a/internal/github/budget_transport.go
+++ b/internal/github/budget_transport.go
@@ -28,7 +28,6 @@ type archiveProviderAttemptConfig struct {
 	identity  IdentityKey
 	resources []QuotaResource
 	reserve   int
-	budget    *SyncBudget
 }
 
 type archiveProviderAttemptReservation struct {
@@ -57,12 +56,10 @@ func WithArchiveProviderAttemptAllowance(
 	identity IdentityKey,
 	resources []QuotaResource,
 	reserve int,
-	budget *SyncBudget,
 ) context.Context {
 	allowance := &archiveAttemptAllowance{
 		provider: &archiveProviderAttemptConfig{
 			identity: identity, resources: slices.Clone(resources), reserve: max(reserve, 0),
-			budget: budget,
 		},
 	}
 	allowance.remaining.Store(int64(attempts))
@@ -148,14 +145,12 @@ func reserveArchiveProviderAttempt(
 func reconcileArchiveProviderAttempt(
 	reservation archiveProviderAttemptReservation,
 	registry *QuotaRegistry,
-	resource QuotaResource,
 	header http.Header,
 ) {
 	if reservation.allowance == nil {
 		return
 	}
 	actualCost := reservation.cost
-	spendReset := reservation.before.ResetAt
 	if observed, ok := rateFromQuotaHeaders(header); ok {
 		observedReset := observed.Reset.UTC()
 		if observedReset.After(reservation.before.ResetAt) ||
@@ -171,7 +166,6 @@ func reconcileArchiveProviderAttempt(
 				reservation.before.Remaining-observed.Remaining,
 			)
 		case observedReset.After(reservation.before.ResetAt):
-			spendReset = observedReset
 			actualCost = max(
 				actualCost,
 				observed.Limit-observed.Remaining,
@@ -182,9 +176,6 @@ func reconcileArchiveProviderAttempt(
 				actualCost,
 			)
 		}
-	}
-	if budget := reservation.allowance.provider.budget; budget != nil {
-		budget.addProviderArchiveSpend(resource, spendReset, actualCost)
 	}
 	if actualCost > reservation.cost {
 		reservation.allowance.debit(actualCost - reservation.cost)
@@ -257,6 +248,20 @@ func WrapSyncBudgetTransport(base http.RoundTripper, budget *SyncBudget) http.Ro
 	return &budgetTransport{base: base, budget: budget}
 }
 
+// archiveAttemptProviderReserved reports whether the attempt in ctx is
+// covered by a provider quota reservation. Reserved attempts are metered by
+// the quota registry; the local sync budget meters live sync only and must
+// not double-count them. Attempts whose chain took no reservation (no quota
+// transport for the identity) stay on the local-debit fallback.
+func archiveAttemptProviderReserved(ctx context.Context) bool {
+	allowance, ok := ctx.Value(archiveAttemptAllowanceKey{}).(*archiveAttemptAllowance)
+	if !ok {
+		return false
+	}
+	reserved, _ := ctx.Value(archiveProviderAttemptReservationKey{}).(*archiveAttemptAllowance)
+	return reserved == allowance
+}
+
 func (t *budgetTransport) RoundTrip(
 	req *http.Request,
 ) (*http.Response, error) {
@@ -265,6 +270,9 @@ func (t *budgetTransport) RoundTrip(
 	}
 	counted := IsSyncBudgetContext(req.Context())
 	archive := IsArchiveSyncBudgetContext(req.Context())
+	if archive && archiveAttemptProviderReserved(req.Context()) {
+		counted = false
+	}
 	var window BudgetWindow
 	if counted {
 		var reserved bool

--- a/internal/github/budget_transport_test.go
+++ b/internal/github/budget_transport_test.go
@@ -340,7 +340,7 @@ func TestBudgetTransportSkipsLocalDebitForProviderReservedAttempts(t *testing.T)
 	ctx := WithArchiveProviderAttemptAllowance(
 		WithArchiveSyncBudget(t.Context()), 10,
 		IdentityKey{Host: "github.test", Principal: "user:7"},
-		[]QuotaResource{QuotaResourceREST}, 1000,
+		[]QuotaResource{QuotaResourceREST},
 	)
 	allowance, ok := ctx.Value(archiveAttemptAllowanceKey{}).(*archiveAttemptAllowance)
 	require.True(ok)

--- a/internal/github/budget_transport_test.go
+++ b/internal/github/budget_transport_test.go
@@ -321,3 +321,50 @@ func TestBudgetTransportRecoversAfterWindowWithoutProviderResponse(t *testing.T)
 	require.NoError(send())
 	assert.Equal(int32(2), providerCalls.Load())
 }
+
+// An archive attempt covered by a provider quota reservation is metered by
+// the quota registry alone: the local sync budget keeps metering live sync
+// and must not debit for it.
+func TestBudgetTransportSkipsLocalDebitForProviderReservedAttempts(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	budget := NewSyncBudget(100)
+	transport := WrapSyncBudgetTransport(roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       http.NoBody,
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	}), budget)
+	ctx := WithArchiveProviderAttemptAllowance(
+		WithArchiveSyncBudget(t.Context()), 10,
+		IdentityKey{Host: "github.test", Principal: "user:7"},
+		[]QuotaResource{QuotaResourceREST}, 1000,
+	)
+	allowance, ok := ctx.Value(archiveAttemptAllowanceKey{}).(*archiveAttemptAllowance)
+	require.True(ok)
+	reserved := context.WithValue(ctx, archiveProviderAttemptReservationKey{}, allowance)
+
+	req, err := http.NewRequestWithContext(
+		reserved, http.MethodGet,
+		"https://api.github.com/repos/acme/widget/issues/1", nil,
+	)
+	require.NoError(err)
+	_, err = transport.RoundTrip(req)
+	require.NoError(err)
+	assert.Zero(budget.Spent())
+	assert.Zero(budget.ArchiveSpent())
+
+	// Without the reservation marker — a chain that has no quota transport —
+	// the same provider-configured context stays on the local-debit fallback.
+	unreserved, err := http.NewRequestWithContext(
+		ctx, http.MethodGet,
+		"https://api.github.com/repos/acme/widget/issues/2", nil,
+	)
+	require.NoError(err)
+	_, err = transport.RoundTrip(unreserved)
+	require.NoError(err)
+	assert.Equal(1, budget.Spent())
+	assert.Equal(1, budget.ArchiveSpent())
+}

--- a/internal/github/quota.go
+++ b/internal/github/quota.go
@@ -204,6 +204,17 @@ type QuotaAvailability struct {
 	ResetAt   *time.Time
 }
 
+// QuotaPacingResource is one resource pool's view inside a pacing window.
+type QuotaPacingResource struct {
+	Limit     int
+	Remaining int
+	// Headroom is remaining minus this pool's own archive reserve
+	// (`ArchiveProviderReserve` of this pool's limit). Negative when the
+	// pool sits below its reserve.
+	Headroom int
+	ResetAt  time.Time
+}
+
 type QuotaPacingWindow struct {
 	Limit     int
 	Remaining int
@@ -214,7 +225,39 @@ type QuotaPacingWindow struct {
 	// floor. Negative when the binding pool sits below its reserve.
 	ArchiveHeadroom int
 	ResetAt         time.Time
-	ResourceResets  map[QuotaResource]time.Time
+	Resources       map[QuotaResource]QuotaPacingResource
+}
+
+// ArchiveRetryAt returns the latest reset among pools whose headroom is below
+// cost: the earliest time every deficient pool can have recovered. Waiting for
+// the window-wide latest reset would leave archives paused after the exhausted
+// pool has already reset. Zero when no pool is deficient.
+func (w QuotaPacingWindow) ArchiveRetryAt(cost int) time.Time {
+	var retry time.Time
+	for _, resource := range w.Resources {
+		if resource.Headroom < cost && resource.ResetAt.After(retry) {
+			retry = resource.ResetAt
+		}
+	}
+	return retry
+}
+
+// ArchiveBindingResource returns the pool with the least archive headroom —
+// the constraint that currently limits archive admission — with a
+// lexicographic tie-break for determinism.
+func (w QuotaPacingWindow) ArchiveBindingResource() (QuotaResource, QuotaPacingResource) {
+	var bindingName QuotaResource
+	var binding QuotaPacingResource
+	first := true
+	for name, resource := range w.Resources {
+		if first || resource.Headroom < binding.Headroom ||
+			(resource.Headroom == binding.Headroom && name < bindingName) {
+			bindingName = name
+			binding = resource
+			first = false
+		}
+	}
+	return bindingName, binding
 }
 
 func (r *QuotaRegistry) PacingWindow(
@@ -228,7 +271,7 @@ func (r *QuotaRegistry) PacingWindow(
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	window := QuotaPacingWindow{
-		ResourceResets: make(map[QuotaResource]time.Time, len(resources)),
+		Resources: make(map[QuotaResource]QuotaPacingResource, len(resources)),
 	}
 	for index, resource := range resources {
 		key := newQuotaKey(identity, resource)
@@ -251,7 +294,12 @@ func (r *QuotaRegistry) PacingWindow(
 		if pool.ResetAt.After(window.ResetAt) {
 			window.ResetAt = pool.ResetAt
 		}
-		window.ResourceResets[resource] = pool.ResetAt
+		window.Resources[resource] = QuotaPacingResource{
+			Limit:     pool.Limit,
+			Remaining: remaining,
+			Headroom:  headroom,
+			ResetAt:   pool.ResetAt,
+		}
 	}
 	return window, true
 }

--- a/internal/github/quota.go
+++ b/internal/github/quota.go
@@ -483,7 +483,7 @@ func (t *quotaTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 	var header http.Header
 	if resp == nil || t.registry == nil || t.identity.Principal == "" {
-		reconcileArchiveProviderAttempt(reservation, t.registry, resource, header)
+		reconcileArchiveProviderAttempt(reservation, t.registry, header)
 		return resp, err
 	}
 	header = resp.Header
@@ -492,6 +492,6 @@ func (t *quotaTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		resource,
 		header,
 	)
-	reconcileArchiveProviderAttempt(reservation, t.registry, resource, header)
+	reconcileArchiveProviderAttempt(reservation, t.registry, header)
 	return resp, err
 }

--- a/internal/github/quota.go
+++ b/internal/github/quota.go
@@ -205,10 +205,16 @@ type QuotaAvailability struct {
 }
 
 type QuotaPacingWindow struct {
-	Limit          int
-	Remaining      int
-	ResetAt        time.Time
-	ResourceResets map[QuotaResource]time.Time
+	Limit     int
+	Remaining int
+	// ArchiveHeadroom is the archive spend this credential may admit: the
+	// minimum across required resources of remaining minus that pool's own
+	// archive reserve. Reserves are per pool — applying the smallest pool's
+	// reserve to a larger pool would admit spend below the larger pool's
+	// floor. Negative when the binding pool sits below its reserve.
+	ArchiveHeadroom int
+	ResetAt         time.Time
+	ResourceResets  map[QuotaResource]time.Time
 }
 
 func (r *QuotaRegistry) PacingWindow(
@@ -237,6 +243,10 @@ func (r *QuotaRegistry) PacingWindow(
 		remaining := r.effectiveRemainingLocked(key, pool)
 		if index == 0 || remaining < window.Remaining {
 			window.Remaining = remaining
+		}
+		headroom := remaining - ArchiveProviderReserve(pool.Limit)
+		if index == 0 || headroom < window.ArchiveHeadroom {
+			window.ArchiveHeadroom = headroom
 		}
 		if pool.ResetAt.After(window.ResetAt) {
 			window.ResetAt = pool.ResetAt
@@ -284,11 +294,14 @@ func (r *QuotaRegistry) CheckReserve(
 	return availability
 }
 
+// reserveArchiveAttempt reserves one wire attempt's cost against the target
+// resource pool. Every required pool must stay above its own archive reserve
+// (`ArchiveProviderReserve` of that pool's limit) — reserves are per pool, so
+// a larger pool keeps its proportionally larger floor.
 func (r *QuotaRegistry) reserveArchiveAttempt(
 	identity IdentityKey,
 	resources []QuotaResource,
 	resource QuotaResource,
-	reserve int,
 ) (quotaReservation, bool) {
 	if r == nil || identity.Principal == "" {
 		return quotaReservation{}, false
@@ -311,7 +324,7 @@ func (r *QuotaRegistry) reserveArchiveAttempt(
 			target = pool
 			continue
 		}
-		if remaining <= reserve {
+		if remaining <= ArchiveProviderReserve(pool.Limit) {
 			return quotaReservation{}, false
 		}
 	}
@@ -319,7 +332,7 @@ func (r *QuotaRegistry) reserveArchiveAttempt(
 		return quotaReservation{}, false
 	}
 	cost := max(target.AttemptCost, 1)
-	if r.effectiveRemainingLocked(targetKey, target)-cost < reserve {
+	if r.effectiveRemainingLocked(targetKey, target)-cost < ArchiveProviderReserve(target.Limit) {
 		return quotaReservation{}, false
 	}
 	key := quotaReservationKey{quotaKey: targetKey, resetAt: target.ResetAt.UTC()}

--- a/internal/github/quota_test.go
+++ b/internal/github/quota_test.go
@@ -543,3 +543,40 @@ func TestSnapshotRefreshDropsTheCachedReserveVerdict(t *testing.T) {
 		syncer.backgroundReserveExhausted(repo, QuotaResourceREST, false),
 		"a fresh snapshot must take effect without waiting out the window")
 }
+
+// Archive headroom is computed per pool — remaining minus that pool's own
+// reserve — and the window carries the minimum. Taking min(limit) and
+// min(remaining) from different pools would understate a larger pool's
+// reserve and admit spend below its floor.
+func TestQuotaRegistryPacingWindowArchiveHeadroomIsPerPool(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	now := time.Date(2026, 7, 28, 18, 0, 0, 0, time.UTC)
+	registry := NewQuotaRegistry()
+	registry.now = func() time.Time { return now }
+	reset := now.Add(30 * time.Minute)
+	// REST sits exactly at its own limit/5 reserve (3000); GraphQL has plenty.
+	registry.UpdateSnapshot(quotaTestUser, QuotaResourceREST, Rate{
+		Limit: 15000, Remaining: 3000, Reset: reset,
+	})
+	registry.UpdateSnapshot(quotaTestUser, QuotaResourceGraphQL, Rate{
+		Limit: 5000, Remaining: 4800, Reset: reset,
+	})
+
+	window, ok := registry.PacingWindow(
+		quotaTestUser, []QuotaResource{QuotaResourceREST, QuotaResourceGraphQL},
+	)
+
+	require.True(ok)
+	assert.Zero(window.ArchiveHeadroom)
+
+	// With REST above its reserve, GraphQL's headroom (4800-1000) binds.
+	registry.UpdateSnapshot(quotaTestUser, QuotaResourceREST, Rate{
+		Limit: 15000, Remaining: 8000, Reset: reset,
+	})
+	window, ok = registry.PacingWindow(
+		quotaTestUser, []QuotaResource{QuotaResourceREST, QuotaResourceGraphQL},
+	)
+	require.True(ok)
+	assert.Equal(3800, window.ArchiveHeadroom)
+}

--- a/internal/github/quota_test.go
+++ b/internal/github/quota_test.go
@@ -157,8 +157,8 @@ func TestQuotaRegistryPacingWindowTracksStaggeredResourceResets(t *testing.T) {
 		quotaTestUser, []QuotaResource{QuotaResourceREST, QuotaResourceGraphQL},
 	)
 	require.True(ok)
-	assert.Equal(restReset, window.ResourceResets[QuotaResourceREST])
-	assert.Equal(graphQLReset, window.ResourceResets[QuotaResourceGraphQL])
+	assert.Equal(restReset, window.Resources[QuotaResourceREST].ResetAt)
+	assert.Equal(graphQLReset, window.Resources[QuotaResourceGraphQL].ResetAt)
 
 	// Advancing only the earlier REST pool changes the combined maximum while
 	// GraphQL still belongs to its original window.
@@ -171,8 +171,8 @@ func TestQuotaRegistryPacingWindowTracksStaggeredResourceResets(t *testing.T) {
 	)
 	require.True(ok)
 	assert.Equal(nextRESTReset, window.ResetAt)
-	assert.Equal(nextRESTReset, window.ResourceResets[QuotaResourceREST])
-	assert.Equal(graphQLReset, window.ResourceResets[QuotaResourceGraphQL])
+	assert.Equal(nextRESTReset, window.Resources[QuotaResourceREST].ResetAt)
+	assert.Equal(graphQLReset, window.Resources[QuotaResourceGraphQL].ResetAt)
 }
 
 func TestQuotaRegistryPacingWindowRequiresEveryCurrentPool(t *testing.T) {
@@ -579,4 +579,39 @@ func TestQuotaRegistryPacingWindowArchiveHeadroomIsPerPool(t *testing.T) {
 	)
 	require.True(ok)
 	assert.Equal(3800, window.ArchiveHeadroom)
+}
+
+// The pacing window carries each pool's own limit, remaining, headroom, and
+// reset so callers can attribute the binding constraint and the recovery time
+// to the pool that owns them.
+func TestQuotaRegistryPacingWindowExposesPerResourcePools(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+	now := time.Date(2026, 7, 28, 18, 0, 0, 0, time.UTC)
+	registry := NewQuotaRegistry()
+	registry.now = func() time.Time { return now }
+	restReset := now.Add(10 * time.Minute)
+	graphQLReset := now.Add(30 * time.Minute)
+	registry.UpdateSnapshot(quotaTestUser, QuotaResourceREST, Rate{
+		Limit: 15000, Remaining: 3000, Reset: restReset,
+	})
+	registry.UpdateSnapshot(quotaTestUser, QuotaResourceGraphQL, Rate{
+		Limit: 5000, Remaining: 4800, Reset: graphQLReset,
+	})
+
+	window, ok := registry.PacingWindow(
+		quotaTestUser, []QuotaResource{QuotaResourceREST, QuotaResourceGraphQL},
+	)
+
+	require.True(ok)
+	rest := window.Resources[QuotaResourceREST]
+	assert.Equal(15000, rest.Limit)
+	assert.Equal(3000, rest.Remaining)
+	assert.Zero(rest.Headroom)
+	assert.Equal(restReset, rest.ResetAt)
+	graphQL := window.Resources[QuotaResourceGraphQL]
+	assert.Equal(5000, graphQL.Limit)
+	assert.Equal(4800, graphQL.Remaining)
+	assert.Equal(3800, graphQL.Headroom)
+	assert.Equal(graphQLReset, graphQL.ResetAt)
 }

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -941,13 +941,15 @@ func (s *Syncer) Admit(
 	var providerResetAt *time.Time
 	var providerPacingWindow *QuotaPacingWindow
 	var providerResources []QuotaResource
+	providerReserve := 0
 	identity, identityErr := s.identityForRepo(repo, false)
 	if ref.Platform == platform.KindGitHub && s.quotaRegistry != nil && identityErr == nil {
 		providerResources = []QuotaResource{QuotaResourceREST, QuotaResourceGraphQL}
-		availability := s.quotaRegistry.CheckReserve(
-			identity, providerResources, cost, RateReserveBuffer,
-		)
 		pacingWindow, pacingKnown := s.quotaRegistry.PacingWindow(identity, providerResources)
+		providerReserve = archiveProviderReserve(pacingWindow.Limit)
+		availability := s.quotaRegistry.CheckReserve(
+			identity, providerResources, cost, providerReserve,
+		)
 		if !availability.Allowed || !pacingKnown {
 			probe.abandon()
 			retryAt := now.Add(time.Minute)
@@ -976,16 +978,13 @@ func (s *Syncer) Admit(
 		resetAt = archiveBudgetResetAt(tracker)
 	}
 	available := 0
-	if budget != nil {
+	if providerPacingWindow != nil {
+		// Provider quota is authoritative: archive may spend everything above
+		// the archive reserve, and the local sync budget meters live sync only.
+		available = max(providerPacingWindow.Remaining-providerReserve, 0)
+	} else if budget != nil {
 		liveFloor := archiveLiveFloor(ref.Platform)
-		if providerPacingWindow != nil {
-			available = budget.ProviderArchiveSpendAvailable(
-				now,
-				*providerPacingWindow,
-				liveFloor,
-				RateReserveBuffer,
-			)
-		} else if resetAt == nil &&
+		if resetAt == nil &&
 			(ref.Platform == platform.KindGitea || ref.Platform == platform.KindForgejo) {
 			available = budget.LocalArchiveSpendAvailable(liveFloor)
 		} else {
@@ -1012,7 +1011,7 @@ func (s *Syncer) Admit(
 	if !completeGitealikeMR {
 		if providerPacingWindow != nil {
 			requestCtx = WithArchiveProviderAttemptAllowance(
-				requestCtx, available, identity, providerResources, RateReserveBuffer, budget,
+				requestCtx, available, identity, providerResources, providerReserve,
 			)
 		} else {
 			requestCtx = WithArchiveAttemptAllowance(requestCtx, available)

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -951,8 +951,8 @@ func (s *Syncer) Admit(
 			detail := "provider rate reserve reached"
 			if !pacingKnown {
 				detail = "provider quota unknown"
-			} else if pacingWindow.ResetAt.After(now) {
-				retryAt = pacingWindow.ResetAt.UTC()
+			} else if reset := pacingWindow.ArchiveRetryAt(cost); reset.After(now) {
+				retryAt = reset.UTC()
 			}
 			return archive.AdmissionResult{RetryAt: &retryAt, Detail: detail}, nil
 		}

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -941,23 +941,18 @@ func (s *Syncer) Admit(
 	var providerResetAt *time.Time
 	var providerPacingWindow *QuotaPacingWindow
 	var providerResources []QuotaResource
-	providerReserve := 0
 	identity, identityErr := s.identityForRepo(repo, false)
 	if ref.Platform == platform.KindGitHub && s.quotaRegistry != nil && identityErr == nil {
 		providerResources = []QuotaResource{QuotaResourceREST, QuotaResourceGraphQL}
 		pacingWindow, pacingKnown := s.quotaRegistry.PacingWindow(identity, providerResources)
-		providerReserve = ArchiveProviderReserve(pacingWindow.Limit)
-		availability := s.quotaRegistry.CheckReserve(
-			identity, providerResources, cost, providerReserve,
-		)
-		if !availability.Allowed || !pacingKnown {
+		if !pacingKnown || pacingWindow.ArchiveHeadroom < cost {
 			probe.abandon()
 			retryAt := now.Add(time.Minute)
 			detail := "provider rate reserve reached"
-			if !availability.Known || !pacingKnown {
+			if !pacingKnown {
 				detail = "provider quota unknown"
-			} else if availability.ResetAt != nil && availability.ResetAt.After(now) {
-				retryAt = availability.ResetAt.UTC()
+			} else if pacingWindow.ResetAt.After(now) {
+				retryAt = pacingWindow.ResetAt.UTC()
 			}
 			return archive.AdmissionResult{RetryAt: &retryAt, Detail: detail}, nil
 		}
@@ -980,8 +975,9 @@ func (s *Syncer) Admit(
 	available := 0
 	if providerPacingWindow != nil {
 		// Provider quota is authoritative: archive may spend everything above
-		// the archive reserve, and the local sync budget meters live sync only.
-		available = max(providerPacingWindow.Remaining-providerReserve, 0)
+		// each pool's own archive reserve, and the local sync budget meters
+		// live sync only.
+		available = max(providerPacingWindow.ArchiveHeadroom, 0)
 	} else if budget != nil {
 		liveFloor := archiveLiveFloor(ref.Platform)
 		if resetAt == nil &&
@@ -1011,7 +1007,7 @@ func (s *Syncer) Admit(
 	if !completeGitealikeMR {
 		if providerPacingWindow != nil {
 			requestCtx = WithArchiveProviderAttemptAllowance(
-				requestCtx, available, identity, providerResources, providerReserve,
+				requestCtx, available, identity, providerResources,
 			)
 		} else {
 			requestCtx = WithArchiveAttemptAllowance(requestCtx, available)

--- a/internal/github/sync.go
+++ b/internal/github/sync.go
@@ -946,7 +946,7 @@ func (s *Syncer) Admit(
 	if ref.Platform == platform.KindGitHub && s.quotaRegistry != nil && identityErr == nil {
 		providerResources = []QuotaResource{QuotaResourceREST, QuotaResourceGraphQL}
 		pacingWindow, pacingKnown := s.quotaRegistry.PacingWindow(identity, providerResources)
-		providerReserve = archiveProviderReserve(pacingWindow.Limit)
+		providerReserve = ArchiveProviderReserve(pacingWindow.Limit)
 		availability := s.quotaRegistry.CheckReserve(
 			identity, providerResources, cost, providerReserve,
 		)

--- a/internal/server/apitest/archive_test.go
+++ b/internal/server/apitest/archive_test.go
@@ -573,10 +573,10 @@ func TestAPIArchivePacingUsesPerPoolReserves(t *testing.T) {
 	require.Len(rows, 1)
 	row := rows[0]
 	assert.True(row.Known)
-	assert.Equal(5000, row.Limit)
+	// The binding pool is REST (least headroom): every reported number comes
+	// from that one pool so limit, remaining, and reserve are consistent.
+	assert.Equal(15000, row.Limit)
 	assert.Equal(3000, row.Remaining)
-	// REST (15000-limit) sits at its 3000 reserve, so nothing is available;
-	// the reported reserve is the quota held back at that binding pool.
 	assert.Equal(3000, row.Reserve)
 	assert.Zero(row.Available)
 }

--- a/internal/server/apitest/archive_test.go
+++ b/internal/server/apitest/archive_test.go
@@ -532,3 +532,51 @@ func TestAPIArchivePacingReportsPartiallyKnownCredentials(t *testing.T) {
 	assert.Zero(rows[0].Available)
 	assert.Empty(rows[0].ResetAt)
 }
+
+// With unequal pool limits, the reported reserve and availability come from
+// per-pool headroom: a large pool at its own limit/5 floor zeroes archive
+// availability even though the smallest pool still has headroom.
+func TestAPIArchivePacingUsesPerPoolReserves(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	database := dbtest.Open(t)
+	syncer := ghclient.NewSyncer(nil, database, nil, nil, time.Minute, nil, nil)
+	t.Cleanup(syncer.Stop)
+	registry := ghclient.NewQuotaRegistry()
+	identity := ghclient.IdentityKey{Host: "github.test", Principal: "user:7"}
+	reset := time.Now().UTC().Add(30 * time.Minute).Truncate(time.Second)
+	registry.UpdateSnapshot(identity, ghclient.QuotaResourceREST,
+		ghclient.Rate{Limit: 15000, Remaining: 3000, Reset: reset})
+	registry.UpdateSnapshot(identity, ghclient.QuotaResourceGraphQL,
+		ghclient.Rate{Limit: 5000, Remaining: 4800, Reset: reset})
+	syncer.SetQuotaRegistry(registry)
+	srv := server.New(database, syncer, nil, "/", nil, server.ServerOptions{})
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		require.NoError(srv.Shutdown(ctx))
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/archive/pacing", http.NoBody)
+	req.Host = "forge.test"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+	var rows []struct {
+		Known     bool `json:"known"`
+		Limit     int  `json:"limit"`
+		Remaining int  `json:"remaining"`
+		Reserve   int  `json:"reserve"`
+		Available int  `json:"available"`
+	}
+	require.NoError(json.Unmarshal(rr.Body.Bytes(), &rows))
+	require.Len(rows, 1)
+	row := rows[0]
+	assert.True(row.Known)
+	assert.Equal(5000, row.Limit)
+	assert.Equal(3000, row.Remaining)
+	// REST (15000-limit) sits at its 3000 reserve, so nothing is available;
+	// the reported reserve is the quota held back at that binding pool.
+	assert.Equal(3000, row.Reserve)
+	assert.Zero(row.Available)
+}

--- a/internal/server/apitest/archive_test.go
+++ b/internal/server/apitest/archive_test.go
@@ -445,6 +445,7 @@ func TestAPIArchivePacingReportsProviderHeadroom(t *testing.T) {
 		PlatformHost string `json:"platform_host"`
 		Principal    string `json:"principal"`
 		Source       string `json:"source"`
+		Known        bool   `json:"known"`
 		Limit        int    `json:"limit"`
 		Remaining    int    `json:"remaining"`
 		Reserve      int    `json:"reserve"`
@@ -458,6 +459,7 @@ func TestAPIArchivePacingReportsProviderHeadroom(t *testing.T) {
 	assert.Equal("github.test", row.PlatformHost)
 	assert.Equal("user:7", row.Principal)
 	assert.Equal("provider", row.Source)
+	assert.True(row.Known)
 	// Limit and remaining are the min across REST and GraphQL, matching what
 	// archive admission consumes.
 	assert.Equal(5000, row.Limit)
@@ -487,4 +489,46 @@ func TestAPIArchivePacingEmptyWithoutKnownPools(t *testing.T) {
 	var rows []map[string]any
 	require.NoError(json.Unmarshal(rr.Body.Bytes(), &rows))
 	require.Empty(rows)
+}
+
+// A credential whose pacing window cannot be combined (a pool missing,
+// expired, or never observed) must still appear, marked unknown: those are
+// exactly the identities archive admission defers as "provider quota
+// unknown", and omitting them would hide why hydration is blocked.
+func TestAPIArchivePacingReportsPartiallyKnownCredentials(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	database := dbtest.Open(t)
+	syncer := ghclient.NewSyncer(nil, database, nil, nil, time.Minute, nil, nil)
+	t.Cleanup(syncer.Stop)
+	registry := ghclient.NewQuotaRegistry()
+	identity := ghclient.IdentityKey{Host: "github.test", Principal: "user:7"}
+	reset := time.Now().UTC().Add(30 * time.Minute).Truncate(time.Second)
+	registry.UpdateSnapshot(identity, ghclient.QuotaResourceREST,
+		ghclient.Rate{Limit: 5000, Remaining: 4500, Reset: reset})
+	syncer.SetQuotaRegistry(registry)
+	srv := server.New(database, syncer, nil, "/", nil, server.ServerOptions{})
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		require.NoError(srv.Shutdown(ctx))
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/archive/pacing", http.NoBody)
+	req.Host = "forge.test"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+	var rows []struct {
+		Principal string `json:"principal"`
+		Known     bool   `json:"known"`
+		Available int    `json:"available"`
+		ResetAt   string `json:"reset_at"`
+	}
+	require.NoError(json.Unmarshal(rr.Body.Bytes(), &rows))
+	require.Len(rows, 1)
+	assert.Equal("user:7", rows[0].Principal)
+	assert.False(rows[0].Known)
+	assert.Zero(rows[0].Available)
+	assert.Empty(rows[0].ResetAt)
 }

--- a/internal/server/apitest/archive_test.go
+++ b/internal/server/apitest/archive_test.go
@@ -413,3 +413,78 @@ func archiveGeneratedRef(ref platform.RepoRef) generated.ArchiveRepositoryRef {
 		Name: ref.Name, RepoPath: ref.RepoPath,
 	}
 }
+
+func TestAPIArchivePacingReportsProviderHeadroom(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	database := dbtest.Open(t)
+	syncer := ghclient.NewSyncer(nil, database, nil, nil, time.Minute, nil, nil)
+	t.Cleanup(syncer.Stop)
+	registry := ghclient.NewQuotaRegistry()
+	identity := ghclient.IdentityKey{Host: "github.test", Principal: "user:7"}
+	reset := time.Now().UTC().Add(30 * time.Minute).Truncate(time.Second)
+	registry.UpdateSnapshot(identity, ghclient.QuotaResourceREST,
+		ghclient.Rate{Limit: 5000, Remaining: 4500, Reset: reset})
+	registry.UpdateSnapshot(identity, ghclient.QuotaResourceGraphQL,
+		ghclient.Rate{Limit: 5000, Remaining: 4200, Reset: reset})
+	syncer.SetQuotaRegistry(registry)
+	srv := server.New(database, syncer, nil, "/", nil, server.ServerOptions{})
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		require.NoError(srv.Shutdown(ctx))
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/archive/pacing", http.NoBody)
+	req.Host = "forge.test"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+	var rows []struct {
+		Provider     string `json:"provider"`
+		PlatformHost string `json:"platform_host"`
+		Principal    string `json:"principal"`
+		Source       string `json:"source"`
+		Limit        int    `json:"limit"`
+		Remaining    int    `json:"remaining"`
+		Reserve      int    `json:"reserve"`
+		Available    int    `json:"available"`
+		ResetAt      string `json:"reset_at"`
+	}
+	require.NoError(json.Unmarshal(rr.Body.Bytes(), &rows))
+	require.Len(rows, 1)
+	row := rows[0]
+	assert.Equal("github", row.Provider)
+	assert.Equal("github.test", row.PlatformHost)
+	assert.Equal("user:7", row.Principal)
+	assert.Equal("provider", row.Source)
+	// Limit and remaining are the min across REST and GraphQL, matching what
+	// archive admission consumes.
+	assert.Equal(5000, row.Limit)
+	assert.Equal(4200, row.Remaining)
+	assert.Equal(1000, row.Reserve)
+	assert.Equal(3200, row.Available)
+	assert.Equal(reset.Format(time.RFC3339), row.ResetAt)
+}
+
+func TestAPIArchivePacingEmptyWithoutKnownPools(t *testing.T) {
+	require := require.New(t)
+	database := dbtest.Open(t)
+	syncer := ghclient.NewSyncer(nil, database, nil, nil, time.Minute, nil, nil)
+	t.Cleanup(syncer.Stop)
+	srv := server.New(database, syncer, nil, "/", nil, server.ServerOptions{})
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		require.NoError(srv.Shutdown(ctx))
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/archive/pacing", http.NoBody)
+	req.Host = "forge.test"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+	var rows []map[string]any
+	require.NoError(json.Unmarshal(rr.Body.Bytes(), &rows))
+	require.Empty(rows)
+}

--- a/internal/server/archive_routes.go
+++ b/internal/server/archive_routes.go
@@ -238,12 +238,14 @@ func (s *Server) listArchivePacing(
 			Source:       "provider",
 		}
 		if window, ok := registry.PacingWindow(pool.Identity, resources); ok {
-			reserve := ghclient.ArchiveProviderReserve(window.Limit)
 			status.Known = true
 			status.Limit = window.Limit
 			status.Remaining = window.Remaining
-			status.Reserve = reserve
-			status.Available = max(window.Remaining-reserve, 0)
+			// Headroom is per pool (remaining minus that pool's limit/5
+			// reserve); the reported reserve is the quota held back at the
+			// binding pool.
+			status.Reserve = window.Remaining - window.ArchiveHeadroom
+			status.Available = max(window.ArchiveHeadroom, 0)
 			status.ResetAt = formatUTCRFC3339(window.ResetAt)
 		}
 		statuses = append(statuses, status)

--- a/internal/server/archive_routes.go
+++ b/internal/server/archive_routes.go
@@ -12,6 +12,7 @@ import (
 	"go.kenn.io/forge/internal/archive"
 	"go.kenn.io/forge/internal/archive/report"
 	"go.kenn.io/forge/internal/db"
+	ghclient "go.kenn.io/forge/internal/github"
 	"go.kenn.io/forge/internal/platform"
 	"go.kenn.io/forge/internal/server/httpapi"
 )
@@ -185,6 +186,65 @@ func (s *Server) registerArchiveAPI(api huma.API) {
 		OperationID: "get-archive-report", Method: http.MethodGet, Path: "/archive/report",
 		DefaultStatus: http.StatusOK, Summary: "Get historical archive activity report", Tags: []string{"Archive"},
 	}, s.getArchiveReport)
+	huma.Register(api, huma.Operation{
+		OperationID: "list-archive-pacing", Method: http.MethodGet, Path: "/archive/pacing",
+		DefaultStatus: http.StatusOK, Summary: "List archive hydration pacing per provider credential", Tags: []string{"Archive"},
+	}, s.listArchivePacing)
+}
+
+// archivePacingStatusResponse reports one provider credential's archive
+// hydration headroom: the quota window admission consumes (limit and
+// remaining are the min across REST and GraphQL), the reserve held back for
+// live sync, and the spend archive work may currently admit.
+type archivePacingStatusResponse struct {
+	Provider     string `json:"provider"`
+	PlatformHost string `json:"platform_host"`
+	Principal    string `json:"principal"`
+	Source       string `json:"source" enum:"provider"`
+	Limit        int    `json:"limit"`
+	Remaining    int    `json:"remaining"`
+	Reserve      int    `json:"reserve"`
+	Available    int    `json:"available"`
+	ResetAt      string `json:"reset_at,omitempty" format:"date-time"`
+}
+
+type archivePacingOutput = httpapi.BodyOutput[[]archivePacingStatusResponse]
+
+func (s *Server) listArchivePacing(
+	_ context.Context, _ *struct{},
+) (*archivePacingOutput, error) {
+	statuses := []archivePacingStatusResponse{}
+	if s.syncer == nil {
+		return &archivePacingOutput{Body: statuses}, nil
+	}
+	registry := s.syncer.QuotaRegistry()
+	resources := []ghclient.QuotaResource{
+		ghclient.QuotaResourceREST, ghclient.QuotaResourceGraphQL,
+	}
+	seen := map[ghclient.IdentityKey]bool{}
+	for _, pool := range registry.Snapshot() {
+		if seen[pool.Identity] {
+			continue
+		}
+		seen[pool.Identity] = true
+		window, ok := registry.PacingWindow(pool.Identity, resources)
+		if !ok {
+			continue
+		}
+		reserve := ghclient.ArchiveProviderReserve(window.Limit)
+		statuses = append(statuses, archivePacingStatusResponse{
+			Provider:     string(platform.KindGitHub),
+			PlatformHost: pool.Identity.Host,
+			Principal:    pool.Identity.Principal,
+			Source:       "provider",
+			Limit:        window.Limit,
+			Remaining:    window.Remaining,
+			Reserve:      reserve,
+			Available:    max(window.Remaining-reserve, 0),
+			ResetAt:      formatUTCRFC3339(window.ResetAt),
+		})
+	}
+	return &archivePacingOutput{Body: statuses}, nil
 }
 
 func (s *Server) startArchives(

--- a/internal/server/archive_routes.go
+++ b/internal/server/archive_routes.go
@@ -193,12 +193,13 @@ func (s *Server) registerArchiveAPI(api huma.API) {
 }
 
 // archivePacingStatusResponse reports one provider credential's archive
-// hydration headroom: the quota window admission consumes (limit and
-// remaining are the min across REST and GraphQL), the reserve held back for
-// live sync, and the spend archive work may currently admit. Known is false
-// when the combined window is unavailable (a required pool missing, expired,
-// or never observed) — the state archive admission defers as "provider quota
-// unknown" — and the pacing numbers are zero.
+// hydration headroom. Limit, remaining, reserve, and reset all describe the
+// binding pool — the resource with the least headroom, the constraint that
+// currently limits admission — so the numbers are mutually consistent.
+// Available is that pool's remaining above its own limit/5 reserve. Known is
+// false when the combined window is unavailable (a required pool missing,
+// expired, or never observed) — the state archive admission defers as
+// "provider quota unknown" — and the pacing numbers are zero.
 type archivePacingStatusResponse struct {
 	Provider     string `json:"provider"`
 	PlatformHost string `json:"platform_host"`
@@ -238,15 +239,13 @@ func (s *Server) listArchivePacing(
 			Source:       "provider",
 		}
 		if window, ok := registry.PacingWindow(pool.Identity, resources); ok {
+			_, binding := window.ArchiveBindingResource()
 			status.Known = true
-			status.Limit = window.Limit
-			status.Remaining = window.Remaining
-			// Headroom is per pool (remaining minus that pool's limit/5
-			// reserve); the reported reserve is the quota held back at the
-			// binding pool.
-			status.Reserve = window.Remaining - window.ArchiveHeadroom
-			status.Available = max(window.ArchiveHeadroom, 0)
-			status.ResetAt = formatUTCRFC3339(window.ResetAt)
+			status.Limit = binding.Limit
+			status.Remaining = binding.Remaining
+			status.Reserve = binding.Remaining - binding.Headroom
+			status.Available = max(binding.Headroom, 0)
+			status.ResetAt = formatUTCRFC3339(binding.ResetAt)
 		}
 		statuses = append(statuses, status)
 	}

--- a/internal/server/archive_routes.go
+++ b/internal/server/archive_routes.go
@@ -195,12 +195,16 @@ func (s *Server) registerArchiveAPI(api huma.API) {
 // archivePacingStatusResponse reports one provider credential's archive
 // hydration headroom: the quota window admission consumes (limit and
 // remaining are the min across REST and GraphQL), the reserve held back for
-// live sync, and the spend archive work may currently admit.
+// live sync, and the spend archive work may currently admit. Known is false
+// when the combined window is unavailable (a required pool missing, expired,
+// or never observed) — the state archive admission defers as "provider quota
+// unknown" — and the pacing numbers are zero.
 type archivePacingStatusResponse struct {
 	Provider     string `json:"provider"`
 	PlatformHost string `json:"platform_host"`
 	Principal    string `json:"principal"`
 	Source       string `json:"source" enum:"provider"`
+	Known        bool   `json:"known"`
 	Limit        int    `json:"limit"`
 	Remaining    int    `json:"remaining"`
 	Reserve      int    `json:"reserve"`
@@ -227,22 +231,22 @@ func (s *Server) listArchivePacing(
 			continue
 		}
 		seen[pool.Identity] = true
-		window, ok := registry.PacingWindow(pool.Identity, resources)
-		if !ok {
-			continue
-		}
-		reserve := ghclient.ArchiveProviderReserve(window.Limit)
-		statuses = append(statuses, archivePacingStatusResponse{
+		status := archivePacingStatusResponse{
 			Provider:     string(platform.KindGitHub),
 			PlatformHost: pool.Identity.Host,
 			Principal:    pool.Identity.Principal,
 			Source:       "provider",
-			Limit:        window.Limit,
-			Remaining:    window.Remaining,
-			Reserve:      reserve,
-			Available:    max(window.Remaining-reserve, 0),
-			ResetAt:      formatUTCRFC3339(window.ResetAt),
-		})
+		}
+		if window, ok := registry.PacingWindow(pool.Identity, resources); ok {
+			reserve := ghclient.ArchiveProviderReserve(window.Limit)
+			status.Known = true
+			status.Limit = window.Limit
+			status.Remaining = window.Remaining
+			status.Reserve = reserve
+			status.Available = max(window.Remaining-reserve, 0)
+			status.ResetAt = formatUTCRFC3339(window.ResetAt)
+		}
+		statuses = append(statuses, status)
 	}
 	return &archivePacingOutput{Body: statuses}, nil
 }

--- a/internal/server/e2etest/archive_quota_test.go
+++ b/internal/server/e2etest/archive_quota_test.go
@@ -58,7 +58,7 @@ func TestArchiveAPIStopsProviderBurstAtObservedQuotaHeadroomE2E(t *testing.T) {
 	reset := now.Add(30 * time.Minute).Truncate(time.Second)
 	var upstreamCalls atomic.Int32
 	var upstreamRemaining atomic.Int32
-	upstreamRemaining.Store(203)
+	upstreamRemaining.Store(1003)
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		call := upstreamCalls.Add(1)
 		remaining := upstreamRemaining.Add(-2)
@@ -128,10 +128,10 @@ func TestArchiveAPIStopsProviderBurstAtObservedQuotaHeadroomE2E(t *testing.T) {
 	syncer.SetGitHubRouters(map[string]*ghclient.HostRouter{"github.com": router})
 	syncer.SetQuotaRegistry(quotaRegistry)
 	quotaRegistry.UpdateSnapshot(identity, ghclient.QuotaResourceREST, ghclient.Rate{
-		Limit: 5000, Remaining: 203, Reset: reset,
+		Limit: 5000, Remaining: 1003, Reset: reset,
 	})
 	quotaRegistry.UpdateSnapshot(identity, ghclient.QuotaResourceGraphQL, ghclient.Rate{
-		Limit: 5000, Remaining: 203, Reset: reset,
+		Limit: 5000, Remaining: 1003, Reset: reset,
 	})
 
 	source := archiveQuotaBurstSource{refs: []platform.RepoRef{ref}, client: client}
@@ -185,10 +185,12 @@ func TestArchiveAPIStopsProviderBurstAtObservedQuotaHeadroomE2E(t *testing.T) {
 	runErr := archiveService.RunEligible(t.Context())
 	require.ErrorIs(runErr, platform.ErrArchiveAttemptBudget)
 	assert.Equal(int32(1), upstreamCalls.Load())
-	assert.Equal(1, budget.ArchiveSpent())
+	// Provider-reserved attempts are metered by the quota registry, not the
+	// local sync budget.
+	assert.Zero(budget.ArchiveSpent())
 	pool, ok := quotaRegistry.Get(identity, ghclient.QuotaResourceREST)
 	require.True(ok)
-	assert.Equal(201, pool.Remaining)
+	assert.Equal(1001, pool.Remaining)
 	progress, err := database.GetDatasetProgress(
 		t.Context(), repo.ID, db.ArchiveItemTypeIssue, 1, db.ArchiveDatasetLookup,
 	)

--- a/internal/server/e2etest/archive_quota_test.go
+++ b/internal/server/e2etest/archive_quota_test.go
@@ -197,3 +197,142 @@ func TestArchiveAPIStopsProviderBurstAtObservedQuotaHeadroomE2E(t *testing.T) {
 	require.NoError(err)
 	assert.Equal(db.ArchiveDatasetProgressFailed, progress.Status)
 }
+
+// A large pool sitting at its own limit/5 reserve must stop hydration end to
+// end — through the HTTP API, scheduler, SQLite state, and provider
+// transport — even though the smallest pool still has headroom, and the
+// persisted deferral must retry when that deficient pool resets.
+func TestArchiveAPIDefersHydrationAtLargerPoolReserveE2E(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	now := time.Now().UTC()
+	restReset := now.Add(10 * time.Minute).Truncate(time.Second)
+	graphQLReset := now.Add(30 * time.Minute).Truncate(time.Second)
+	var upstreamCalls atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{}`)
+	}))
+	t.Cleanup(upstream.Close)
+
+	database := dbtest.Open(t)
+	quotaRegistry := ghclient.NewQuotaRegistry()
+	identity := ghclient.IdentityKey{Host: "github.com", Principal: "user:7"}
+	bucket := ghclient.RateBucketKey("github", "github.com", "user:7")
+	budget := ghclient.NewSyncBudget(100000)
+	client, err := ghclient.NewClient(
+		staticTokenSource("archive-token"),
+		"github.com",
+		nil,
+		budget,
+		ghclient.WithBaseURLForTesting(upstream.URL),
+		ghclient.WithQuotaAccounting(quotaRegistry, identity, identity),
+	)
+	require.NoError(err)
+	registry, err := ghclient.NewProviderRegistry(map[string]ghclient.Client{
+		"github.com": client,
+	})
+	require.NoError(err)
+	syncRef := ghclient.RepoRef{
+		Platform: platform.KindGitHub, PlatformHost: "github.com",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+		PlatformExternalID: "repo-acme-widget",
+	}
+	ref := platform.RepoRef{
+		Platform: platform.KindGitHub, Host: "github.com",
+		Owner: "acme", Name: "widget", RepoPath: "acme/widget",
+		PlatformExternalID: "repo-acme-widget",
+	}
+	syncer := ghclient.NewSyncerWithRegistry(
+		registry,
+		database,
+		nil,
+		[]ghclient.RepoRef{syncRef},
+		time.Hour,
+		nil,
+		map[string]*ghclient.SyncBudget{bucket: budget},
+	)
+	t.Cleanup(syncer.Stop)
+	router, err := ghclient.NewHostRouter("github.com", &ghclient.Route{
+		Key:           ghclient.RouteKey{Host: "github.com", Owner: "acme"},
+		Client:        client,
+		ReadIdentity:  identity,
+		WriteIdentity: identity,
+	})
+	require.NoError(err)
+	syncer.SetGitHubRouters(map[string]*ghclient.HostRouter{"github.com": router})
+	syncer.SetQuotaRegistry(quotaRegistry)
+	// REST sits exactly at its own limit/5 reserve (3000) and resets first;
+	// GraphQL has plenty of headroom and resets later.
+	quotaRegistry.UpdateSnapshot(identity, ghclient.QuotaResourceREST, ghclient.Rate{
+		Limit: 15000, Remaining: 3000, Reset: restReset,
+	})
+	quotaRegistry.UpdateSnapshot(identity, ghclient.QuotaResourceGraphQL, ghclient.Rate{
+		Limit: 5000, Remaining: 4800, Reset: graphQLReset,
+	})
+
+	source := archiveQuotaBurstSource{refs: []platform.RepoRef{ref}, client: client}
+	archiveService, err := archive.NewService(
+		database, registry, syncer, source, nil, nil,
+	)
+	require.NoError(err)
+	require.NoError(archiveService.EnsureConfigured(t.Context(), []platform.RepoRef{ref}))
+	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{
+		Archive:                       archiveService,
+		HostCheckAllowLoopbackAnyPort: true,
+	})
+	t.Cleanup(func() { gracefulShutdown(t, srv) })
+	forge := httptest.NewServer(srv)
+	t.Cleanup(forge.Close)
+
+	status, body := postJSON(
+		t,
+		forge.Client(),
+		forge.URL+"/api/v1/archive/start",
+		map[string]any{"all": false, "repositories": []map[string]string{{
+			"provider": "github", "platform_host": "github.com",
+			"owner": "acme", "name": "widget", "repo_path": "acme/widget",
+		}}},
+	)
+	require.Equal(http.StatusOK, status, body)
+
+	repo, err := database.GetRepoByIdentity(t.Context(), platform.DBRepoIdentity(ref))
+	require.NoError(err)
+	require.NotNil(repo)
+	states, err := database.ListArchiveRepoStates(t.Context(), []int64{repo.ID})
+	require.NoError(err)
+	require.Len(states, 1)
+	require.NoError(database.CommitArchiveInventoryPage(t.Context(), db.ArchiveInventoryCommit{
+		RepoID: repo.ID, ItemType: db.ArchiveItemTypeIssue,
+		RefreshReason: db.ArchiveRefreshReasonInitial,
+		Items: []db.ArchiveInventoryItem{{
+			Number: 1, ProviderItemID: "issue-1",
+			ProviderCreatedAt: now.Add(-time.Hour), ProviderUpdatedAt: now,
+		}},
+		ScanGeneration: states[0].IssueInventory.Generation,
+		Exhausted:      true, Coverage: db.ArchiveCoverageSupported, Now: now,
+	}))
+	require.NoError(database.CommitArchiveInventoryPage(t.Context(), db.ArchiveInventoryCommit{
+		RepoID: repo.ID, ItemType: db.ArchiveItemTypeMergeRequest,
+		RefreshReason:  db.ArchiveRefreshReasonInitial,
+		ScanGeneration: states[0].MergeRequestInventory.Generation,
+		Exhausted:      true, Coverage: db.ArchiveCoverageSupported, Now: now,
+	}))
+
+	require.NoError(archiveService.RunEligible(t.Context()))
+	assert.Zero(upstreamCalls.Load(), "no upstream hydration below the larger pool's reserve")
+
+	states, err = database.ListArchiveRepoStates(t.Context(), []int64{repo.ID})
+	require.NoError(err)
+	require.Len(states, 1)
+	require.NotNil(states[0].LastErrorCode)
+	assert.Equal(string(db.ArchiveErrorCodeBudgetExhausted), *states[0].LastErrorCode)
+	require.NotNil(states[0].NextRetryAt)
+	assert.Equal(restReset, states[0].NextRetryAt.UTC())
+	progress, err := database.GetDatasetProgress(
+		t.Context(), repo.ID, db.ArchiveItemTypeIssue, 1, db.ArchiveDatasetLookup,
+	)
+	require.NoError(err)
+	assert.Equal(db.ArchiveDatasetProgressPending, progress.Status)
+}

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -38,6 +38,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/archive/pacing": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List archive hydration pacing per provider credential */
+        get: operations["list-archive-pacing"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/archive/pause": {
         parameters: {
             query?: never;
@@ -4502,6 +4519,23 @@ export interface components {
             all: boolean;
             repositories?: components["schemas"]["ArchiveRepositoryRef"][] | null;
         };
+        ArchivePacingStatusResponse: {
+            /** Format: int64 */
+            available: number;
+            /** Format: int64 */
+            limit: number;
+            platform_host: string;
+            principal: string;
+            provider: string;
+            /** Format: int64 */
+            remaining: number;
+            /** Format: int64 */
+            reserve: number;
+            /** Format: date-time */
+            reset_at?: string;
+            /** @enum {string} */
+            source: "provider";
+        };
         ArchiveProgressCountsResponse: {
             /** Format: int64 */
             complete_items: number;
@@ -8006,6 +8040,35 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AgentHookResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemError"];
+                };
+            };
+        };
+    };
+    "list-archive-pacing": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ArchivePacingStatusResponse"][] | null;
                 };
             };
             /** @description Error */
@@ -17787,6 +17850,7 @@ export const archiveCoverageResponseInline_commentsValues: ReadonlyArray<Flatten
 export const archiveCoverageResponseIssuesValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["ArchiveCoverageResponse"]["issues"]> = ["unknown", "supported", "unsupported"];
 export const archiveCoverageResponseMerge_requestsValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["ArchiveCoverageResponse"]["merge_requests"]> = ["unknown", "supported", "unsupported"];
 export const archiveCoverageResponseReviewsValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["ArchiveCoverageResponse"]["reviews"]> = ["unknown", "supported", "unsupported"];
+export const archivePacingStatusResponseSourceValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["ArchivePacingStatusResponse"]["source"]> = ["provider"];
 export const archiveReportActivityResponseKindValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["ArchiveReportActivityResponse"]["kind"]> = ["issue", "issue_closed", "merge_request", "merge_request_merged", "ordinary_comment", "review", "inline_review_comment"];
 export const archiveReportCoverageResponseCollection_modeValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["ArchiveReportCoverageResponse"]["collection_mode"]> = ["discovery", "full"];
 export const archiveReportCoverageResponseCommentsValues: ReadonlyArray<FlattenedDeepRequired<components>["schemas"]["ArchiveReportCoverageResponse"]["comments"]> = ["unknown", "supported", "unsupported"];

--- a/packages/ui/src/api/generated/schema.ts
+++ b/packages/ui/src/api/generated/schema.ts
@@ -4522,6 +4522,7 @@ export interface components {
         ArchivePacingStatusResponse: {
             /** Format: int64 */
             available: number;
+            known: boolean;
             /** Format: int64 */
             limit: number;
             platform_host: string;


### PR DESCRIPTION
Archive hydration was throttled by two mechanisms that duplicate the live rate-limit enforcement forge already has. Both regularly blocked hydration while GitHub reported thousands of requests remaining.

## What changed

- When a credential's REST and GraphQL pools are known, archive admission uses provider quota directly: available spend is remaining minus a reserve, where **each pool keeps its own reserve of max(limit/5, 200)** for live sync.
- The quadratic pacing curve is gone. A fresh quota window grants full archive throughput immediately instead of ramping up over the hour.
- Reserves are enforced per pool, at admission and on every wire attempt, so a 15,000-limit pool keeps a 3,000 floor even when a 5,000-limit pool is the smallest.
- When admission defers on the reserve, it retries when the deficient pool resets, not the latest reset across all pools.
- Archive attempts covered by a quota reservation no longer count against `sync_budget_per_hour` — that knob meters live sync only. Providers without rate-limit headers (Gitea/Forgejo) and requests without a reservation keep the existing local-budget pacing.
- New endpoint `GET /archive/pacing` reports each credential's binding pool: limit, remaining, reserve, available, and reset. Credentials with incomplete quota data appear with `known: false` instead of being omitted.

## Why

- The old curve (`surplus × elapsedFraction²`) allowed almost no archive spend early in each quota window. Observed on a live drain: 35-minute stalls with 3,520/5,000 core remaining, averaging ~24 items/hour.
- The local budget made archive and live sync compete for one knob. The default (500/hour) starves hydration entirely; draining a backlog meant repeatedly raising it and restarting the daemon.

## Operator notes

- `sync_budget_per_hour` values raised to work around the old pacing can return to the default.
- The rate-limits budget meter no longer moves with GitHub archive traffic; archive spend is visible in provider quota and `/archive/pacing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)