### PR TITLE
Identify linked items in reference events

### DIFF
--- a/packages/ui/src/components/detail/EventTimeline.svelte
+++ b/packages/ui/src/components/detail/EventTimeline.svelte
@@ -890,7 +890,7 @@
       return commitTitle(event.Body) || event.Summary;
     }
     if (event.EventType === "cross_referenced") {
-      return metadataString(parseMetadata(event), "source_title") ?? event.Summary;
+      return crossReferenceLabel(parseMetadata(event), event.Summary);
     }
     if (isLifecycleTransitionEvent(event.EventType)) {
       return "";
@@ -920,6 +920,17 @@
     if (typeof value !== "string") return null;
     const parsed = parseInt(value, 10);
     return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+  }
+
+  function crossReferenceLabel(metadata: Record<string, unknown>, fallback: string): string {
+    const title = metadataString(metadata, "source_title");
+    const owner = metadataString(metadata, "source_owner");
+    const name = metadataString(metadata, "source_repo");
+    const number = metadataNumber(metadata, "source_number");
+    const reference = owner && name && number !== null ? `${owner}/${name}#${number}` : null;
+
+    if (title && reference) return `${title} ${reference}`;
+    return title ?? fallback;
   }
 
   type CrossReferenceLink = {
@@ -1931,7 +1942,7 @@
             </Card>
           {:else if event.EventType === "cross_referenced"}
             {@const sourceUrl = metadataString(metadata, "source_url")}
-            {@const sourceTitle = metadataString(metadata, "source_title") ?? event.Summary}
+            {@const sourceLabel = crossReferenceLabel(metadata, event.Summary)}
             {@const sourceLink = crossReferenceLink(metadata, sourceUrl)}
             <CommentCard
               class="event-card--compact"
@@ -1948,10 +1959,10 @@
                   rel={sourceLink.internal ? undefined : "noopener noreferrer"}
                   {...(sourceLink.dataAttributes ?? {})}
                 >
-                  {sourceTitle}
+                  {sourceLabel}
                 </a>
               {:else}
-                <span class="system-event-summary">{sourceTitle}</span>
+                <span class="system-event-summary">{sourceLabel}</span>
               {/if}
             </CommentCard>
           {:else}

--- a/packages/ui/src/components/detail/EventTimeline.test.ts
+++ b/packages/ui/src/components/detail/EventTimeline.test.ts
@@ -2487,7 +2487,7 @@ describe("EventTimeline", () => {
     expect(screen.getByText("Title changed")).toBeTruthy();
     expect(screen.getByText("Base changed")).toBeTruthy();
     expect(screen.getByText("Referenced")).toBeTruthy();
-    expect(screen.getByText("Related bug")).toBeTruthy();
+    expect(screen.getByText("Related bug other/repo#77")).toBeTruthy();
     expect(screen.queryByText("Assigned")).toBeNull();
     expect(screen.getByText("self-assigned this")).toBeTruthy();
     expect(document.querySelectorAll(".event--compact").length).toBe(5);
@@ -2524,7 +2524,7 @@ describe("EventTimeline", () => {
     });
 
     const link = screen.getByRole("link", {
-      name: "Add shared git tooling packages",
+      name: "Add shared git tooling packages kenn-io/kit#1",
     });
     const assert = expect.soft;
     assert(link.getAttribute("href")).toBe("/pulls/github/kenn-io/kit/1");
@@ -2569,7 +2569,7 @@ describe("EventTimeline", () => {
     });
 
     const link = screen.getByRole("link", {
-      name: "Add shared git tooling packages",
+      name: "Add shared git tooling packages kenn-io/kit#1",
     });
     const assert = expect.soft;
     assert(link.closest(".event-card--compact-row")).toBeTruthy();


### PR DESCRIPTION
Cross-reference timeline rows currently show only the source title, making similarly named pull requests and issues ambiguous until a maintainer opens the link.

This adds the repository-qualified item number to linked labels in both standard and compact timelines while preserving internal navigation and incomplete-metadata fallbacks. Maintainers can identify the referenced item before leaving the timeline.

<sup>generated by a clanker</sup>