### PR TITLE
fix: merge GitHub stacks through the async API

### DIFF
--- a/context/github-sync-invariants.md
+++ b/context/github-sync-invariants.md
@@ -166,6 +166,12 @@ fallback repository listing.
 
 ## Native Stack Rules
 
+- GitHub.com merges are versioned asynchronous direct operations polled to terminal
+  `merged`; `pending`/`enqueued` never count as merged. GHES stays synchronous with no
+  probe fallback. (`internal/github/merge_async.go::liveClient.MergePullRequest`)
+- Preserve required-rebase failures verbatim; do not substitute private website routes
+  or local force-pushes until GitHub exposes a token-authenticated stack-rebase API.
+  (`internal/github/merge_async.go::mergeAsyncTerminalResult`)
 - Confirmed native stacks claim and order their PRs first; branch inference always
   runs afterward on every unclaimed PR, including when the preview is disabled,
   incomplete, or failing. (`internal/stacks/detect.go::RunDetectionWithNativeStacks`)

--- a/docs/superpowers/specs/2026-08-03-github-asynchronous-merge-design.md
+++ b/docs/superpowers/specs/2026-08-03-github-asynchronous-merge-design.md
@@ -1,0 +1,123 @@
+# GitHub Asynchronous Merge Design
+
+**Date:** 2026-08-03
+**Status:** Approved for implementation
+
+## Goal
+
+Merge GitHub pull requests through GitHub's supported asynchronous merge API so
+GitHub-native stacked pull requests can be merged from Kenn Forge without
+weakening the existing reviewed-head guarantee.
+
+## Background
+
+Kenn Forge currently sends GitHub merges through
+`PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge`. GitHub rejects native
+stack members at that endpoint and requires
+`PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge-async`, introduced in API
+version `2026-03-10`.
+
+The asynchronous endpoint supports both stacked and unstacked pull requests.
+For a stack member, GitHub atomically merges every unmerged pull request from
+the bottom of the stack through the requested member. This remains subject to
+Kenn Forge's existing mid-stack merge policy.
+
+GitHub also offers a server-side cascading **Rebase stack** action on its
+website. That action is not exposed through the documented token-authenticated
+REST or GraphQL APIs. GitHub's website uses private, browser-session-bound
+`page_data/stack_rebase` endpoints. Kenn Forge will not depend on those private
+endpoints or introduce browser-cookie authentication into the daemon.
+
+## Provider Behavior
+
+All GitHub merges will use the asynchronous endpoint, regardless of whether
+Kenn Forge currently recognizes the pull request as a native stack member.
+Using one path avoids a stale stack-membership check and matches GitHub's
+documented support for ordinary pull requests at the same endpoint.
+
+The request will:
+
+- send `X-GitHub-Api-Version: 2026-03-10` for this operation;
+- pass the selected `merge`, `squash`, or `rebase` merge method;
+- pass the current commit title and message;
+- pass the reviewed head as `sha` so GitHub cancels the operation if the head
+  moves before execution; and
+- request `direct_merge` to preserve Kenn Forge's existing immediate-merge
+  semantics rather than silently enqueueing a merge queue operation.
+
+The provider will keep the existing synchronous Kenn Forge merge contract by
+polling `GET /repos/{owner}/{repo}/pulls/{pull_number}/merge-async/{uuid}` after
+a `202 pending` response. Polling will honor request cancellation, use a bounded
+backoff, and stop at GitHub's terminal `merged`, `enqueued`, or `failed` state.
+
+A terminal `merged` result returns the merge commit SHA and message through the
+existing `platform.MergeResult`. A `failed` result becomes a provider error
+whose detail preserves GitHub's message. An unexpected `enqueued` result is not
+reported as merged because Kenn Forge requested a direct merge and does not yet
+model merge-queue completion.
+
+GitHub returns `409` when another asynchronous merge request already exists for
+the pull request. Kenn Forge will surface that as a conflict rather than adopt
+the UUID: the existing request may have a different merge method, commit
+message, or reviewed head, and the response does not contain enough information
+to prove that its options match the user's request.
+
+## Stack Rebase Boundary
+
+Kenn Forge will not automatically rebase a non-linear native stack in this
+change. When GitHub rejects an asynchronous merge because the stack must be
+rebased, Kenn Forge will preserve GitHub's exact failure message so the user can
+run GitHub's **Rebase stack** action or rebase and push with `gh stack`.
+
+Kenn Forge will not:
+
+- call GitHub's undocumented website endpoints;
+- acquire or persist GitHub browser cookies or CSRF state;
+- run a local cascading rebase and force-push as a substitute for the native
+  server action; or
+- fall back to the synchronous merge endpoint after an asynchronous failure.
+
+If GitHub publishes a token-authenticated server-side stack-rebase endpoint, it
+can be designed as a separate provider capability with its own reviewed-head,
+conflict, polling, and UI contracts.
+
+## Deferred Merge Integration
+
+The existing deferred **merge after CI** worker already completes through the
+same provider merge method as immediate merges. It will therefore use the
+asynchronous GitHub path automatically once pending checks pass. Its queueing,
+cancellation, supersession, and event-ordering contracts remain unchanged.
+
+## Error Handling
+
+HTTP failures and asynchronous terminal failures must continue through Kenn
+Forge's provider error classification. In particular:
+
+- a moved reviewed head remains `stale_state`;
+- an already-running asynchronous request is a conflict;
+- GitHub validation, permission, branch-protection, and required-rebase
+  messages remain visible to the user;
+- transport failures remain provider-call failures; and
+- cancellation or polling exhaustion must never be recorded locally as a
+  successful merge.
+
+The server must update the local pull request to merged only after the provider
+returns a terminal `merged` result.
+
+## Testing
+
+Focused GitHub client tests will cover:
+
+- the `merge-async` route, API-version header, request body, merge action, and
+  reviewed-head binding;
+- an immediate `merged` response;
+- `pending` followed by `merged` polling;
+- a terminal failure, including a stack-rebase-required message;
+- stale-head classification;
+- a `409` existing asynchronous operation;
+- cancellation while polling; and
+- an unexpected merge-queue result that must not be recorded as merged.
+
+Existing provider and pull API tests remain the regression suite for server
+error mapping, local state updates, mid-stack safeguards, and deferred merges.
+No public Kenn Forge route or frontend response shape changes are required.

--- a/docs/superpowers/specs/2026-08-03-github-asynchronous-merge-design.md
+++ b/docs/superpowers/specs/2026-08-03-github-asynchronous-merge-design.md
@@ -5,9 +5,10 @@
 
 ## Goal
 
-Merge GitHub pull requests through GitHub's supported asynchronous merge API so
-GitHub-native stacked pull requests can be merged from Kenn Forge without
-weakening the existing reviewed-head guarantee.
+Merge GitHub.com pull requests through GitHub's supported asynchronous merge
+API so GitHub-native stacked pull requests can be merged from Kenn Forge
+without weakening the existing reviewed-head guarantee or regressing GitHub
+Enterprise Server hosts.
 
 ## Background
 
@@ -30,10 +31,18 @@ endpoints or introduce browser-cookie authentication into the daemon.
 
 ## Provider Behavior
 
-All GitHub merges will use the asynchronous endpoint, regardless of whether
-Kenn Forge currently recognizes the pull request as a native stack member.
-Using one path avoids a stale stack-membership check and matches GitHub's
-documented support for ordinary pull requests at the same endpoint.
+All GitHub.com merges will use the asynchronous endpoint, regardless of
+whether Kenn Forge currently recognizes the pull request as a native stack
+member. Using one path on that host avoids a stale stack-membership check and
+matches GitHub's documented support for ordinary pull requests at the same
+endpoint.
+
+GitHub Enterprise Server hosts will continue using the existing synchronous
+merge endpoint. Their deployed versions may not expose `merge-async` or accept
+API version `2026-03-10`, and GitHub does not advertise this operation through
+the provider capability data Kenn Forge currently reads. The implementation
+will select the asynchronous path only for the normalized `github.com` host; it
+will not probe and retry through a second mutation endpoint after a failure.
 
 The request will:
 
@@ -110,6 +119,8 @@ Focused GitHub client tests will cover:
 
 - the `merge-async` route, API-version header, request body, merge action, and
   reviewed-head binding;
+- preservation of the synchronous merge route for a custom GitHub Enterprise
+  host;
 - an immediate `merged` response;
 - `pending` followed by `merged` polling;
 - a terminal failure, including a stack-rebase-required message;
@@ -118,6 +129,12 @@ Focused GitHub client tests will cover:
 - cancellation while polling; and
 - an unexpected merge-queue result that must not be recorded as merged.
 
+Full-stack HTTP-and-SQLite tests with a fake GitHub upstream will exercise the
+Kenn Forge merge route through terminal success and terminal failure, asserting
+that only success persists merged state. Deferred merge coverage will drive the
+same asynchronous provider path after CI passes and assert terminal persistence
+and completion behavior.
+
 Existing provider and pull API tests remain the regression suite for server
-error mapping, local state updates, mid-stack safeguards, and deferred merges.
-No public Kenn Forge route or frontend response shape changes are required.
+error mapping, mid-stack safeguards, and other deferred-merge invariants. No
+public Kenn Forge route or frontend response shape changes are required.

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -3367,29 +3367,6 @@ func (c *liveClient) ConvertPullRequestToDraft(
 	}, nil
 }
 
-func (c *liveClient) MergePullRequest(
-	ctx context.Context, owner, repo string, number int,
-	commitTitle, commitMessage, method, expectedHeadSHA string,
-) (*gh.PullRequestMergeResult, error) {
-	opts := &gh.PullRequestOptions{
-		CommitTitle: commitTitle,
-		MergeMethod: method,
-		// When set, GitHub rejects the merge with 405 "Head branch was
-		// modified" if the PR head moved past the reviewed commit.
-		SHA: expectedHeadSHA,
-	}
-	result, resp, err := c.writeGH().PullRequests.Merge(
-		ctx, owner, repo, number, commitMessage, opts,
-	)
-	c.trackWriteRate(resp)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"merging %s/%s#%d: %w", owner, repo, number, err,
-		)
-	}
-	return result, nil
-}
-
 func (c *liveClient) EditPullRequest(
 	ctx context.Context, owner, repo string, number int, opts EditPullRequestOpts,
 ) (*gh.PullRequest, error) {

--- a/internal/github/merge_async.go
+++ b/internal/github/merge_async.go
@@ -1,0 +1,250 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	gh "github.com/google/go-github/v89/github"
+)
+
+const (
+	githubAsyncMergeAPIVersion = "2026-03-10"
+	mergeAsyncInitialPollDelay = 100 * time.Millisecond
+	mergeAsyncMaxPollDelay     = 2 * time.Second
+	mergeAsyncMaxPolls         = 120
+)
+
+type mergeAsyncRequest struct {
+	CommitTitle   string `json:"commit_title,omitempty"`
+	CommitMessage string `json:"commit_message,omitempty"`
+	SHA           string `json:"sha,omitempty"`
+	MergeMethod   string `json:"merge_method,omitempty"`
+	MergeAction   string `json:"merge_action"`
+}
+
+type mergeAsyncResponse struct {
+	Status  string            `json:"status"`
+	Details mergeAsyncDetails `json:"details"`
+}
+
+type mergeAsyncDetails struct {
+	Message         string `json:"message"`
+	UUID            string `json:"uuid"`
+	SHA             string `json:"sha"`
+	MergeMethod     string `json:"merge_method"`
+	MergeAction     string `json:"merge_action"`
+	ExpectedHeadSHA string `json:"expected_head_sha"`
+}
+
+func (c *liveClient) MergePullRequest(
+	ctx context.Context, owner, repo string, number int,
+	commitTitle, commitMessage, method, expectedHeadSHA string,
+) (*gh.PullRequestMergeResult, error) {
+	if canonicalRepoHost(c.platformHost) != "github.com" {
+		return c.mergePullRequestSync(
+			ctx, owner, repo, number,
+			commitTitle, commitMessage, method, expectedHeadSHA,
+		)
+	}
+	return c.mergePullRequestAsync(
+		ctx, owner, repo, number,
+		commitTitle, commitMessage, method, expectedHeadSHA,
+	)
+}
+
+func (c *liveClient) mergePullRequestSync(
+	ctx context.Context, owner, repo string, number int,
+	commitTitle, commitMessage, method, expectedHeadSHA string,
+) (*gh.PullRequestMergeResult, error) {
+	opts := &gh.PullRequestOptions{
+		CommitTitle: commitTitle,
+		MergeMethod: method,
+		// When set, GitHub rejects the merge if the PR head moved past the
+		// reviewed commit.
+		SHA: expectedHeadSHA,
+	}
+	result, resp, err := c.writeGH().PullRequests.Merge(
+		ctx, owner, repo, number, commitMessage, opts,
+	)
+	c.trackWriteRate(resp)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"merging %s/%s#%d: %w", owner, repo, number, err,
+		)
+	}
+	return result, nil
+}
+
+func (c *liveClient) mergePullRequestAsync(
+	ctx context.Context, owner, repo string, number int,
+	commitTitle, commitMessage, method, expectedHeadSHA string,
+) (*gh.PullRequestMergeResult, error) {
+	requestPath := fmt.Sprintf(
+		"repos/%s/%s/pulls/%d/merge-async", owner, repo, number,
+	)
+	body := mergeAsyncRequest{
+		CommitTitle:   commitTitle,
+		CommitMessage: commitMessage,
+		SHA:           expectedHeadSHA,
+		MergeMethod:   method,
+		MergeAction:   "direct_merge",
+	}
+	result, resp, err := c.doMergeAsyncRequest(
+		ctx, http.MethodPut, requestPath, body,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("merging %s/%s#%d: %w", owner, repo, number, err)
+	}
+	if terminal, err := mergeAsyncTerminalResult(resp, result); terminal {
+		if err != nil {
+			return nil, fmt.Errorf("merging %s/%s#%d: %w", owner, repo, number, err)
+		}
+		return result.pullRequestMergeResult(), nil
+	}
+	if resp == nil || resp.StatusCode != http.StatusAccepted {
+		return nil, fmt.Errorf(
+			"merging %s/%s#%d: GitHub returned pending without accepting an asynchronous merge",
+			owner, repo, number,
+		)
+	}
+	if result.Details.UUID == "" {
+		return nil, fmt.Errorf(
+			"merging %s/%s#%d: GitHub accepted an asynchronous merge without an operation UUID",
+			owner, repo, number,
+		)
+	}
+
+	pollPath := requestPath + "/" + result.Details.UUID
+	for poll := range mergeAsyncMaxPolls {
+		if err := waitForMergeAsyncPoll(ctx, poll); err != nil {
+			return nil, fmt.Errorf("merging %s/%s#%d: %w", owner, repo, number, err)
+		}
+		result, resp, err = c.doMergeAsyncRequest(ctx, http.MethodGet, pollPath, nil)
+		if err != nil {
+			return nil, fmt.Errorf("merging %s/%s#%d: %w", owner, repo, number, err)
+		}
+		if terminal, err := mergeAsyncTerminalResult(resp, result); terminal {
+			if err != nil {
+				return nil, fmt.Errorf("merging %s/%s#%d: %w", owner, repo, number, err)
+			}
+			return result.pullRequestMergeResult(), nil
+		}
+	}
+
+	return nil, fmt.Errorf(
+		"merging %s/%s#%d: GitHub asynchronous merge did not complete after %d polls",
+		owner, repo, number, mergeAsyncMaxPolls,
+	)
+}
+
+func (c *liveClient) doMergeAsyncRequest(
+	ctx context.Context,
+	method string,
+	requestPath string,
+	body any,
+) (mergeAsyncResponse, *gh.Response, error) {
+	var result mergeAsyncResponse
+	req, err := c.writeGH().NewRequest(
+		ctx, method, requestPath, body, gh.WithVersion(githubAsyncMergeAPIVersion),
+	)
+	if err != nil {
+		return result, nil, err
+	}
+	resp, requestErr := c.writeGH().BareDo(req)
+	c.trackWriteRate(resp)
+	if resp == nil {
+		return result, nil, requestErr
+	}
+	if requestErr != nil {
+		var accepted *gh.AcceptedError
+		if errors.As(requestErr, &accepted) && resp.StatusCode == http.StatusAccepted {
+			if err := json.Unmarshal(accepted.Raw, &result); err != nil {
+				return result, resp, err
+			}
+			return result, resp, nil
+		}
+		var githubError *gh.ErrorResponse
+		if errors.As(requestErr, &githubError) &&
+			resp.StatusCode == http.StatusConflict &&
+			githubError.Message == "" {
+			githubError.Message = "an asynchronous merge request is already in progress"
+		}
+		return result, resp, requestErr
+	}
+	defer resp.Body.Close()
+	decodeErr := json.NewDecoder(resp.Body).Decode(&result)
+	if decodeErr != nil {
+		return result, resp, decodeErr
+	}
+	return result, resp, nil
+}
+
+func mergeAsyncTerminalResult(
+	resp *gh.Response,
+	result mergeAsyncResponse,
+) (bool, error) {
+	switch result.Status {
+	case "pending":
+		return false, nil
+	case "merged":
+		return true, nil
+	case "failed", "enqueued":
+		message := result.Details.Message
+		if message == "" {
+			message = "GitHub asynchronous merge ended in state " + result.Status
+		}
+		return true, &gh.ErrorResponse{
+			Response: mergeAsyncConflictResponse(resp),
+			Message:  message,
+		}
+	default:
+		return true, fmt.Errorf(
+			"GitHub asynchronous merge returned unknown status %q", result.Status,
+		)
+	}
+}
+
+func mergeAsyncConflictResponse(resp *gh.Response) *http.Response {
+	conflict := &http.Response{
+		StatusCode: http.StatusConflict,
+		Status:     http.StatusText(http.StatusConflict),
+		Header:     make(http.Header),
+	}
+	if resp == nil || resp.Response == nil {
+		return conflict
+	}
+	conflict.Request = resp.Request
+	conflict.Header = resp.Header.Clone()
+	return conflict
+}
+
+func (r mergeAsyncResponse) pullRequestMergeResult() *gh.PullRequestMergeResult {
+	merged := true
+	return &gh.PullRequestMergeResult{
+		Merged:  &merged,
+		SHA:     &r.Details.SHA,
+		Message: &r.Details.Message,
+	}
+}
+
+func waitForMergeAsyncPoll(ctx context.Context, poll int) error {
+	delay := mergeAsyncInitialPollDelay
+	for i := 0; i < poll && delay < mergeAsyncMaxPollDelay; i++ {
+		delay *= 2
+		if delay > mergeAsyncMaxPollDelay {
+			delay = mergeAsyncMaxPollDelay
+		}
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/internal/github/merge_async_test.go
+++ b/internal/github/merge_async_test.go
@@ -1,0 +1,295 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	gh "github.com/google/go-github/v89/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGitHubComMergeUsesAsyncAPI(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(http.MethodPut, r.Method)
+		assert.Equal("/api/v3/repos/acme/widget/pulls/7/merge-async", r.URL.Path)
+		assert.Equal("2026-03-10", r.Header.Get("X-GitHub-Api-Version"))
+		var body map[string]string
+		assert.NoError(json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(map[string]string{
+			"commit_title":   "Merge feature",
+			"commit_message": "Reviewed and ready",
+			"sha":            "reviewed-head",
+			"merge_method":   "squash",
+			"merge_action":   "direct_merge",
+		}, body)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"status":"merged",
+			"details":{"message":"Pull request merged.","sha":"merge-sha"}
+		}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewClient(
+		testTokenSource("token"), "github.com", nil, nil,
+		WithBaseURLForTesting(server.URL),
+	)
+	require.NoError(err)
+
+	result, err := client.MergePullRequest(
+		t.Context(), "acme", "widget", 7,
+		"Merge feature", "Reviewed and ready", "squash", "reviewed-head",
+	)
+	require.NoError(err)
+	require.NotNil(result)
+	assert.True(result.GetMerged())
+	assert.Equal("merge-sha", result.GetSHA())
+	assert.Equal("Pull request merged.", result.GetMessage())
+}
+
+func TestGitHubComMergePollsPendingOperation(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call := calls.Add(1)
+		assert.Equal("2026-03-10", r.Header.Get("X-GitHub-Api-Version"))
+		w.Header().Set("Content-Type", "application/json")
+		switch call {
+		case 1:
+			assert.Equal(http.MethodPut, r.Method)
+			assert.Equal("/api/v3/repos/acme/widget/pulls/7/merge-async", r.URL.Path)
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = w.Write([]byte(`{
+				"status":"pending",
+				"details":{"message":"Merge request is in progress.","uuid":"operation-id"}
+			}`))
+		case 2:
+			assert.Equal(http.MethodGet, r.Method)
+			assert.Equal("/api/v3/repos/acme/widget/pulls/7/merge-async/operation-id", r.URL.Path)
+			_, _ = w.Write([]byte(`{
+				"status":"merged",
+				"details":{"message":"Pull request merged.","sha":"merge-sha"}
+			}`))
+		default:
+			assert.Fail("unexpected request", "call %d", call)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewClient(
+		testTokenSource("token"), "github.com", nil, nil,
+		WithBaseURLForTesting(server.URL),
+	)
+	require.NoError(err)
+
+	result, err := client.MergePullRequest(
+		t.Context(), "acme", "widget", 7, "title", "message", "merge", "head",
+	)
+	require.NoError(err)
+	require.NotNil(result)
+	assert.True(result.GetMerged())
+	assert.Equal("merge-sha", result.GetSHA())
+	assert.Equal(int32(2), calls.Load())
+}
+
+func TestGitHubComMergePreservesTerminalFailure(t *testing.T) {
+	require := require.New(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"status":"failed",
+			"details":{"message":"The stack must be rebased before it can be merged."}
+		}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewClient(
+		testTokenSource("token"), "github.com", nil, nil,
+		WithBaseURLForTesting(server.URL),
+	)
+	require.NoError(err)
+
+	result, err := client.MergePullRequest(
+		t.Context(), "acme", "widget", 7, "title", "message", "merge", "head",
+	)
+	require.Nil(result)
+	require.Error(err)
+	assert.Contains(t, err.Error(), "The stack must be rebased before it can be merged.")
+	var githubError *gh.ErrorResponse
+	require.ErrorAs(err, &githubError)
+	require.NotNil(githubError.Response)
+	assert.Equal(t, http.StatusConflict, githubError.Response.StatusCode)
+}
+
+func TestGitHubComMergeHeadMoveIsConflict(t *testing.T) {
+	require := require.New(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"status":"failed",
+			"details":{"message":"Head branch was modified. Review and try the merge again."}
+		}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewClient(
+		testTokenSource("token"), "github.com", nil, nil,
+		WithBaseURLForTesting(server.URL),
+	)
+	require.NoError(err)
+
+	_, err = client.MergePullRequest(
+		t.Context(), "acme", "widget", 7, "title", "message", "merge", "head",
+	)
+	require.Error(err)
+	var githubError *gh.ErrorResponse
+	require.ErrorAs(err, &githubError)
+	require.NotNil(githubError.Response)
+	assert.Equal(t, http.StatusConflict, githubError.Response.StatusCode)
+	assert.Equal(t, "Head branch was modified. Review and try the merge again.", githubError.Message)
+	assert.True(t, isGitHubHeadModified(err))
+}
+
+func TestGitHubComMergeDoesNotAdoptExistingOperation(t *testing.T) {
+	require := require.New(t)
+	var calls atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{
+			"status":"pending",
+			"details":{"message":"An asynchronous merge is already in progress.","uuid":"other-options"}
+		}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewClient(
+		testTokenSource("token"), "github.com", nil, nil,
+		WithBaseURLForTesting(server.URL),
+	)
+	require.NoError(err)
+
+	result, err := client.MergePullRequest(
+		t.Context(), "acme", "widget", 7, "title", "message", "merge", "head",
+	)
+	require.Nil(result)
+	require.Error(err)
+	var githubError *gh.ErrorResponse
+	require.ErrorAs(err, &githubError)
+	require.NotNil(githubError.Response)
+	assert.Equal(t, http.StatusConflict, githubError.Response.StatusCode)
+	assert.Equal(t, "an asynchronous merge request is already in progress", githubError.Message)
+	assert.Equal(t, int32(1), calls.Load(), "must not poll the existing operation")
+}
+
+func TestGitHubComMergeHonorsCancellationWhilePolling(t *testing.T) {
+	require := require.New(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	var calls atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{
+			"status":"pending",
+			"details":{"message":"Merge request is in progress.","uuid":"operation-id"}
+		}`))
+		cancel()
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewClient(
+		testTokenSource("token"), "github.com", nil, nil,
+		WithBaseURLForTesting(server.URL),
+	)
+	require.NoError(err)
+
+	result, err := client.MergePullRequest(
+		ctx, "acme", "widget", 7, "title", "message", "merge", "head",
+	)
+	require.Nil(result)
+	require.Error(err)
+	require.ErrorIs(err, context.Canceled)
+	assert.Equal(t, int32(1), calls.Load())
+}
+
+func TestGitHubComMergeDoesNotTreatEnqueuedAsMerged(t *testing.T) {
+	require := require.New(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"status":"enqueued",
+			"details":{"message":"Pull request was added to the merge queue."}
+		}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewClient(
+		testTokenSource("token"), "github.com", nil, nil,
+		WithBaseURLForTesting(server.URL),
+	)
+	require.NoError(err)
+
+	result, err := client.MergePullRequest(
+		t.Context(), "acme", "widget", 7, "title", "message", "merge", "head",
+	)
+	require.Nil(result)
+	require.Error(err)
+	assert.Contains(t, err.Error(), "Pull request was added to the merge queue.")
+}
+
+func TestGitHubEnterpriseMergeKeepsSynchronousAPI(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(http.MethodPut, r.Method)
+		assert.Equal("/api/v3/repos/acme/widget/pulls/7/merge", r.URL.Path)
+		var body map[string]string
+		assert.NoError(json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal("reviewed-head", body["sha"])
+		assert.Equal("squash", body["merge_method"])
+		assert.Equal("Merge feature", body["commit_title"])
+		assert.Equal("Reviewed and ready", body["commit_message"])
+		assert.NotContains(body, "merge_action")
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"merged":true,"sha":"merge-sha","message":"Pull request merged."
+		}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewClient(
+		testTokenSource("token"), "github.example.com", nil, nil,
+		WithBaseURLForTesting(server.URL),
+	)
+	require.NoError(err)
+
+	result, err := client.MergePullRequest(
+		t.Context(), "acme", "widget", 7,
+		"Merge feature", "Reviewed and ready", "squash", "reviewed-head",
+	)
+	require.NoError(err)
+	require.NotNil(result)
+	assert.True(result.GetMerged())
+	assert.Equal("merge-sha", result.GetSHA())
+}

--- a/internal/github/mutation_auth_test.go
+++ b/internal/github/mutation_auth_test.go
@@ -36,7 +36,7 @@ func newSplitAuthTestClient(
 			registries[0], splitAuthReadIdentity, splitAuthWriteIdentity,
 		))
 	}
-	client, err := NewClient(source, "github.example.com", nil, nil, options...)
+	client, err := NewClient(source, "github.com", nil, nil, options...)
 	require.NoError(t, err)
 	live, ok := client.(*liveClient)
 	require.True(t, ok)
@@ -93,11 +93,14 @@ func TestMutationsUseUserPATWhileReadsUseAppToken(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"id":1,"name":"widgets","permissions":{"push":false}}`))
 		})
-	mux.HandleFunc("PUT /api/v3/repos/acme/widgets/pulls/5/merge",
+	mux.HandleFunc("PUT /api/v3/repos/acme/widgets/pulls/5/merge-async",
 		func(w http.ResponseWriter, r *http.Request) {
 			record("write:merge", r)
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"merged":true}`))
+			_, _ = w.Write([]byte(`{
+				"status":"merged",
+				"details":{"message":"Pull request merged.","sha":"merge-sha"}
+			}`))
 		})
 	mux.HandleFunc("PUT /api/v3/repos/acme/widgets/pulls/5/reviews/77/dismissals",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -134,7 +137,7 @@ func TestMutationsUseUserPATWhileReadsUseAppToken(t *testing.T) {
 
 	var mints atomic.Int64
 	source := tokenauth.NewManagedSource(tokenauth.Descriptor{
-		Key: tokenauth.Key{Platform: "github", Host: "github.example.com"},
+		Key: tokenauth.Key{Platform: "github", Host: "github.com"},
 		Candidates: []tokenauth.Candidate{
 			{
 				Kind:           tokenauth.SourceKindGitHubApp,

--- a/internal/server/e2etest/github_merge_async_test.go
+++ b/internal/server/e2etest/github_merge_async_test.go
@@ -1,0 +1,334 @@
+package e2etest
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/forge/internal/db"
+	ghclient "go.kenn.io/forge/internal/github"
+	"go.kenn.io/forge/internal/platform"
+	"go.kenn.io/forge/internal/server"
+	"go.kenn.io/forge/internal/server/pullapi"
+	"go.kenn.io/forge/internal/testutil/dbtest"
+	"go.kenn.io/forge/internal/testutil/servertest"
+)
+
+type githubAsyncMergeUpstream struct {
+	mu            sync.Mutex
+	mergeResults  []string
+	mergeRequests []recordedGitHubAsyncMergeRequest
+	checkRunReads int
+	statusReads   int
+	pullReads     int
+	pollStarted   chan struct{}
+	pollRelease   chan struct{}
+	pollStartOnce sync.Once
+}
+
+type recordedGitHubAsyncMergeRequest struct {
+	Method     string
+	Path       string
+	APIVersion string
+	Body       string
+}
+
+func (u *githubAsyncMergeUpstream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	switch {
+	case r.URL.Path == "/api/v3/repos/acme/widget/pulls/7/merge-async" && r.Method == http.MethodPut:
+		u.writeMergeResult(w, r)
+	case strings.HasPrefix(r.URL.Path, "/api/v3/repos/acme/widget/pulls/7/merge-async/") && r.Method == http.MethodGet:
+		u.writeMergeResult(w, r)
+	case r.URL.Path == "/api/v3/repos/acme/widget/commits/reviewed-sha/check-runs" && r.Method == http.MethodGet:
+		u.mu.Lock()
+		u.checkRunReads++
+		u.mu.Unlock()
+		_, _ = io.WriteString(w, `{
+			"total_count":1,
+			"check_runs":[{
+				"id":1,"name":"build","status":"completed","conclusion":"success",
+				"html_url":"https://github.com/acme/widget/actions/runs/1",
+				"app":{"name":"GitHub Actions"}
+			}]
+		}`)
+	case r.URL.Path == "/api/v3/repos/acme/widget/commits/reviewed-sha/status" && r.Method == http.MethodGet:
+		u.mu.Lock()
+		u.statusReads++
+		u.mu.Unlock()
+		_, _ = io.WriteString(w, `{"state":"success","total_count":0,"statuses":[]}`)
+	case r.URL.Path == "/api/v3/repos/acme/widget/pulls/7" && r.Method == http.MethodGet:
+		u.mu.Lock()
+		u.pullReads++
+		u.mu.Unlock()
+		_, _ = io.WriteString(w, `{
+			"id":7001,"number":7,"state":"open","title":"Test PR",
+			"html_url":"https://github.com/acme/widget/pull/7",
+			"user":{"login":"author"},
+			"created_at":"2026-08-01T10:00:00Z",
+			"updated_at":"2026-08-01T10:00:00Z",
+			"head":{"ref":"feature","sha":"reviewed-sha","repo":{"id":1,"full_name":"acme/widget"}},
+			"base":{"ref":"main","sha":"base-sha","repo":{"id":1,"full_name":"acme/widget"}}
+		}`)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (u *githubAsyncMergeUpstream) writeMergeResult(w http.ResponseWriter, r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+	u.mu.Lock()
+	index := len(u.mergeRequests)
+	u.mergeRequests = append(u.mergeRequests, recordedGitHubAsyncMergeRequest{
+		Method:     r.Method,
+		Path:       r.URL.Path,
+		APIVersion: r.Header.Get("X-GitHub-Api-Version"),
+		Body:       string(body),
+	})
+	result := u.mergeResults[len(u.mergeResults)-1]
+	if index < len(u.mergeResults) {
+		result = u.mergeResults[index]
+	}
+	u.mu.Unlock()
+	if r.Method == http.MethodGet && u.pollStarted != nil {
+		u.pollStartOnce.Do(func() { close(u.pollStarted) })
+		<-u.pollRelease
+	}
+	if strings.Contains(result, `"status":"pending"`) {
+		w.WriteHeader(http.StatusAccepted)
+	}
+	_, _ = io.WriteString(w, result)
+}
+
+func (u *githubAsyncMergeUpstream) requests() []recordedGitHubAsyncMergeRequest {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return append([]recordedGitHubAsyncMergeRequest(nil), u.mergeRequests...)
+}
+
+func setupGitHubAsyncMergeE2E(
+	t *testing.T,
+	mergeResults ...string,
+) (*server.Server, *db.DB, int64, *githubAsyncMergeUpstream) {
+	t.Helper()
+	require := require.New(t)
+	ctx := t.Context()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	upstream := &githubAsyncMergeUpstream{mergeResults: mergeResults}
+	githubAPI := httptest.NewServer(upstream)
+	t.Cleanup(githubAPI.Close)
+
+	client, err := ghclient.NewClient(
+		staticTokenSource("token"), "github.com", nil, nil,
+		ghclient.WithBaseURLForTesting(githubAPI.URL),
+	)
+	require.NoError(err)
+
+	database := dbtest.Open(t)
+	repoID, err := database.UpsertRepo(ctx, db.RepoIdentity{
+		Platform:       "github",
+		PlatformHost:   "github.com",
+		PlatformRepoID: "1",
+		Owner:          "acme",
+		Name:           "widget",
+		RepoPath:       "acme/widget",
+	})
+	require.NoError(err)
+	_, err = database.UpsertMergeRequest(ctx, &db.MergeRequest{
+		RepoID:          repoID,
+		PlatformID:      7001,
+		Number:          7,
+		URL:             "https://github.com/acme/widget/pull/7",
+		Title:           "Test PR",
+		Author:          "author",
+		State:           "open",
+		HeadBranch:      "feature",
+		BaseBranch:      "main",
+		PlatformHeadSHA: "reviewed-sha",
+		PlatformBaseSHA: "base-sha",
+		CIStatus:        "pending",
+		CIChecksJSON:    `[{"name":"build","status":"in_progress","conclusion":"","url":"","app":"GitHub Actions"}]`,
+		CIHadPending:    true,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+		LastActivityAt:  now,
+	})
+	require.NoError(err)
+	require.NoError(database.UpdateDiffSHAs(
+		ctx, repoID, 7, "reviewed-sha", "base-sha", "merge-base",
+	))
+
+	repo := ghclient.RepoRef{
+		Platform:     platform.KindGitHub,
+		Owner:        "acme",
+		Name:         "widget",
+		PlatformHost: "github.com",
+		RepoPath:     "acme/widget",
+	}
+	syncer := ghclient.NewSyncer(
+		map[string]ghclient.Client{"github.com": client},
+		database, nil, []ghclient.RepoRef{repo}, time.Minute, nil, nil,
+	)
+	t.Cleanup(syncer.Stop)
+
+	srv := servertest.New(t, database, syncer, nil, "/", nil, server.ServerOptions{})
+	return srv, database, repoID, upstream
+}
+
+func TestGitHubAsyncMergePersistsOnlyAfterTerminalSuccess(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	srv, database, repoID, upstream := setupGitHubAsyncMergeE2E(
+		t,
+		`{"status":"pending","details":{"message":"Merge request is in progress.","uuid":"operation-id"}}`,
+		`{"status":"merged","details":{"message":"Pull request merged.","sha":"merge-sha"}}`,
+	)
+	upstream.pollStarted = make(chan struct{})
+	upstream.pollRelease = make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-upstream.pollRelease:
+		default:
+			close(upstream.pollRelease)
+		}
+	})
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/pulls/github/acme/widget/7/merge",
+		strings.NewReader(`{"method":"squash","commit_title":"Merge title","commit_message":"Merge body","expected_head_sha":"reviewed-sha"}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	requestDone := make(chan struct{})
+	go func() {
+		srv.ServeHTTP(rr, req)
+		close(requestDone)
+	}()
+
+	select {
+	case <-upstream.pollStarted:
+	case <-time.After(3 * time.Second):
+		require.FailNow("timed out waiting for asynchronous merge poll")
+	}
+	pending, err := database.GetMergeRequestByRepoIDAndNumber(t.Context(), repoID, 7)
+	require.NoError(err)
+	require.NotNil(pending)
+	assert.Equal(db.MergeRequestStateOpen, pending.State,
+		"a pending GitHub operation must not be persisted as merged")
+	close(upstream.pollRelease)
+	select {
+	case <-requestDone:
+	case <-time.After(3 * time.Second):
+		require.FailNow("timed out waiting for asynchronous merge completion")
+	}
+
+	require.Equal(http.StatusOK, rr.Code, rr.Body.String())
+	var result struct {
+		Merged bool   `json:"merged"`
+		SHA    string `json:"sha"`
+	}
+	require.NoError(json.NewDecoder(rr.Body).Decode(&result))
+	assert.True(result.Merged)
+	assert.Equal("merge-sha", result.SHA)
+
+	requests := upstream.requests()
+	require.Len(requests, 2)
+	assert.Equal(http.MethodPut, requests[0].Method)
+	assert.Equal(http.MethodGet, requests[1].Method)
+	assert.Equal("2026-03-10", requests[0].APIVersion)
+	assert.Contains(requests[0].Body, `"merge_action":"direct_merge"`)
+	assert.Contains(requests[0].Body, `"sha":"reviewed-sha"`)
+
+	mr, err := database.GetMergeRequestByRepoIDAndNumber(t.Context(), repoID, 7)
+	require.NoError(err)
+	require.NotNil(mr)
+	assert.Equal(db.MergeRequestStateMerged, mr.State)
+}
+
+func TestGitHubAsyncMergeFailureLeavesPullRequestOpen(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	srv, database, repoID, _ := setupGitHubAsyncMergeE2E(
+		t,
+		`{"status":"failed","details":{"message":"The stack must be rebased before it can be merged."}}`,
+	)
+
+	rr := doJSONRequest(t, srv, http.MethodPost,
+		"/api/v1/pulls/github/acme/widget/7/merge",
+		json.RawMessage(`{"method":"merge","commit_title":"Merge title","commit_message":"Merge body","expected_head_sha":"reviewed-sha"}`),
+	)
+	require.Equal(http.StatusConflict, rr.Code, rr.Body.String())
+	var problem conflictProblemBody
+	require.NoError(json.NewDecoder(rr.Body).Decode(&problem))
+	assert.Equal("conflict", problem.Code)
+	assert.Equal("The stack must be rebased before it can be merged.", problem.Detail)
+	assert.Equal("conflict", problem.Details["reason"])
+
+	mr, err := database.GetMergeRequestByRepoIDAndNumber(t.Context(), repoID, 7)
+	require.NoError(err)
+	require.NotNil(mr)
+	assert.Equal(db.MergeRequestStateOpen, mr.State)
+}
+
+func TestGitHubDeferredMergeUsesAsyncAPIAndPersistsTerminalSuccess(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	srv, database, repoID, upstream := setupGitHubAsyncMergeE2E(
+		t,
+		`{"status":"pending","details":{"message":"Merge request is in progress.","uuid":"operation-id"}}`,
+		`{"status":"merged","details":{"message":"Pull request merged.","sha":"merge-sha"}}`,
+	)
+	eventCtx, cancelEvents := context.WithCancel(t.Context())
+	t.Cleanup(cancelEvents)
+	events, _ := srv.Hub().Subscribe(eventCtx, false)
+
+	rr := doJSONRequest(t, srv, http.MethodPost,
+		"/api/v1/pulls/github/acme/widget/7/merge/deferred",
+		json.RawMessage(`{"method":"squash","commit_title":"Merge title","commit_message":"Merge body","expected_head_sha":"reviewed-sha"}`),
+	)
+	require.Equal(http.StatusAccepted, rr.Code, rr.Body.String())
+
+	var completed pullapi.DeferredMergeCompletedPayload
+	deadline := time.After(3 * time.Second)
+	for completed.Status == "" {
+		select {
+		case event := <-events:
+			if event.Event.Type != "deferred_merge_completed" {
+				continue
+			}
+			payload, ok := event.Event.Data.(pullapi.DeferredMergeCompletedPayload)
+			require.True(ok)
+			completed = payload
+		case <-deadline:
+			require.FailNow("timed out waiting for deferred merge completion")
+		}
+	}
+	assert.Equal("merged", completed.Status)
+	assert.True(completed.Merged)
+	assert.Equal("merge-sha", completed.SHA)
+
+	mr, err := database.GetMergeRequestByRepoIDAndNumber(t.Context(), repoID, 7)
+	require.NoError(err)
+	require.NotNil(mr)
+	assert.Equal(db.MergeRequestStateMerged, mr.State)
+
+	requests := upstream.requests()
+	require.Len(requests, 2)
+	assert.Equal(http.MethodPut, requests[0].Method)
+	assert.Equal(http.MethodGet, requests[1].Method)
+	upstream.mu.Lock()
+	assert.Equal(1, upstream.checkRunReads)
+	assert.Equal(1, upstream.statusReads)
+	assert.Positive(upstream.pullReads)
+	upstream.mu.Unlock()
+}


### PR DESCRIPTION
## Why

GitHub rejects the legacy synchronous merge endpoint for native stack members. Kenn Forge therefore could not land those pull requests, while treating an accepted background operation as complete would risk recording a merge before GitHub actually finished it.

## What changes

- Use GitHub.com's supported asynchronous direct-merge API and wait for terminal success before updating local state.
- Preserve reviewed-head binding and surface terminal conflicts, including required stack rebases, without private browser APIs or local force-pushes.
- Keep GitHub Enterprise hosts on their supported synchronous merge endpoint without probe-and-retry fallback.

<sup>generated by a clanker</sup>